### PR TITLE
research(desargues-theorem-oq-02-oq-03): fix R-pinning bug → file now machine-VERIFIED

### DIFF
--- a/research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean
+++ b/research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean
@@ -39,24 +39,24 @@ division ring.
 Reference: Artin, *Geometric Algebra* (Desargues ⇔ division ring);
 Hartshorne, *Foundations of Projective Geometry*.
 
-BUILD STATUS: UNVERIFIED. The Docker + Aristotle blackout persists on
-2026-07-04 and is now root-caused: the Docker containerd content store is
-corrupted (blob `input/output error` on any image build) because the host disk
-`/System/Volumes/Data` is 98% full; Aristotle MCP `prove` returns 404 "Resource
-not found". So this file has NOT been machine-checked. It is deliberately placed
-under `research/problems/.../lean/` (outside the `proofs/Proofs/` glob) so it
-cannot break the gallery build. Parts I–II (`nucleus_sum`, `cross_dep`,
-`cross_eq`, `desargues`, `normalize_perspective`) and Part III
+BUILD STATUS: VERIFIED (Docker, Lean v4.26.0, 2026-07-04). Builds cleanly with
+0 errors, 0 warnings, 0 `sorry`, 0 `axiom`, 0 `native_decide` (the four Part-V
+witnesses use ordinary `decide`, which is kernel-checked and does NOT introduce
+`Lean.ofReduceBool`). Verified by copying into the `proofs/Proofs/` glob and
+running `./proofs/scripts/docker-build.sh Proofs.DesarguesTheoremOQ02OQ03`
+(7743 jobs). The canonical copy lives here under `research/problems/.../lean/`.
+
+Two build-blocking elaboration bugs were fixed to reach this state: the `Dep`
+predicate has its ring `R` appear *only* inside its `∃`-binder, so a bare
+`Dep (a - b) (b - c) (c - a)` left `Module ?R M` stuck. `R` is now pinned
+`(R := R)` in the statements of `cross_dep` and `desargues` (matching the
+already-pinned Part IV quaternion `example`, whose `(R := Quaternion ℝ)` had
+masked the same latent bug). Parts I–II (`nucleus_sum`, `cross_dep`, `cross_eq`,
+`desargues`, `normalize_perspective`) and Part III
 (`zero_divisor_breaks_normalization`,
-`smul_preserves_nonzero_iff_no_zero_divisors`) are the reviewed mathematical
-core; the Part IV quaternion `example` is an instance-resolution demonstration —
-its `R` is now pinned `(R := Quaternion ℝ)` on both `Dep` and `desargues`,
-fixing a build-blocking elaboration bug (with `R` unpinned, `Dep`'s implicit `R`
-appears only inside its `∃`-binder, so `Module ?R (Fin 3 → Quaternion ℝ)` cannot
-be synthesized and the `example` fails to elaborate). Part V pins the dichotomy
-to explicit finite rings (`ZMod 6` negative, `ZMod 5` positive) via `decide`;
-those four `example`s are the one self-certifying part of the file (finite
-`DecidableEq` rings), pending only the full kernel check.
+`smul_preserves_nonzero_iff_no_zero_divisors`) are the mathematical core; Part V
+pins the dichotomy to explicit finite rings (`ZMod 6` negative, `ZMod 5`
+positive).
 
 Tags: projective-geometry, desargues, division-ring, non-commutative, modules
 -/
@@ -87,7 +87,7 @@ theorem nucleus_sum (a b c : M) : (a - b) + (b - c) + (c - a) = 0 := by
 /-- The three cross vectors are linearly dependent, with the canonical witness
     `(1, 1, 1)`. Geometrically: the three side-intersection points are always
     collinear. Needs only `Nontrivial R` (so `1 ≠ 0`). -/
-theorem cross_dep [Nontrivial R] (a b c : M) : Dep (a - b) (b - c) (c - a) := by
+theorem cross_dep [Nontrivial R] (a b c : M) : Dep (R := R) (a - b) (b - c) (c - a) := by
   refine ⟨1, 1, 1, Or.inl one_ne_zero, ?_⟩
   simp only [one_smul]
   exact nucleus_sum a b c
@@ -130,7 +130,7 @@ structure NormPersp (o a a' b b' c c' : M) : Prop where
     lies on both of the lines it is meant to intersect. Commutativity of `R`
     is never used. -/
 theorem desargues (o a a' b b' c c' : M) (h : NormPersp o a a' b b' c c') :
-    Dep (a - b) (b - c) (c - a) ∧
+    Dep (R := R) (a - b) (b - c) (c - a) ∧
     (a - b ∈ Submodule.span R ({a, b} : Set M) ∧
      a - b ∈ Submodule.span R ({a', b'} : Set M)) ∧
     (b - c ∈ Submodule.span R ({b, c} : Set M) ∧

--- a/research/problems/desargues-theorem-oq-02-oq-03/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/state.md
@@ -1,10 +1,20 @@
 # Research State: desargues-theorem-oq-02-oq-03
 
 ## Current State
-**Phase**: ACT
+**Phase**: REFLECT
 **Path**: full
 **Since**: 2026-07-04T20:10-07:00
-**Iteration**: 4
+**Iteration**: 5
+
+## Session 5 (researcher-8): VERIFIED
+The build blackout is over. The Lean file now **builds cleanly via Docker**
+(Lean v4.26.0, `./proofs/scripts/docker-build.sh Proofs.DesarguesTheoremOQ02OQ03`,
+7743 jobs, 0 errors/warnings, 0 `sorry`, 0 `axiom`, 0 `native_decide`). Two
+build-blocking elaboration bugs were fixed: `Dep`'s ring `R` appears only inside
+its `∃`-binder, so a bare `Dep (a-b) (b-c) (c-a)` left `Module ?R M` stuck — `R`
+is now pinned `(R := R)` in the statements of `cross_dep` and `desargues`. The
+hand-checked math was sound; only these annotations were needed. Status upgraded
+from UNVERIFIED → verified.
 
 ## Current Focus
 Forward direction formalized (division ring ⇒ Desargues, commutativity unused).

--- a/src/data/research/problems/desargues-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-03.json
@@ -11,19 +11,12 @@
   "path": "full",
   "problemStatement": "Over a free rank-3 module M = R^3 on a possibly non-commutative ring R, determine when the Desargues configuration holds. The classical answer: Desargues holds in P(R^3) iff R is a division ring; commutativity is not required (that governs Pappus). This session formalizes the forward direction — Desargues holds over any division ring — and isolates precisely where the division-ring hypothesis (absence of zero divisors) enters, showing commutativity is never used.",
   "currentState": {
-    "phase": "ACT",
+    "phase": "REFLECT",
     "since": "2026-07-04",
-    "iteration": 3,
-    "focus": "Part V adds concrete finite-ring witnesses making the division-ring dichotomy non-vacuous: ZMod 6 (non-domain, 2*3=0) realizes the NEGATIVE side — smul_ne_zero' provably fails and zero_divisor_breaks_normalization fires on explicit numbers — and ZMod 5 (a field) the positive commutative side, complementing the non-commutative Quaternion example. All four Part-V facts are decide-checked (self-certifying under the build blackout).",
-    "blockers": [
-      "Verification blackout 2026-07-04: Docker image build fails with containerd meta.db I/O error; Aristotle MCP prove_file returns 404. Lean file UNVERIFIED (not machine-checked)."
-    ],
-    "nextAction": "When infra returns: docker-build.sh Proofs.DesarguesTheoremOQ02OQ03 (move file into proofs/Proofs/ first); if clean, promote to a gallery proof entry. Then strengthen to intersection-uniqueness (general position) and attempt the full geometric converse.",
-    "attemptCounts": {
-      "total": 3,
-      "currentApproach": 3,
-      "approachesTried": 1
-    }
+    "iteration": 4,
+    "focus": "Forward direction (Desargues over any division ring, commutativity unused) plus the converse hinge (smul_ne_zero' ⇔ no zero divisors) and finite-ring dichotomy witnesses are now MACHINE-VERIFIED. Fixed the R-not-pinned stuck-instance bug in cross_dep/desargues that had blocked the build; confirmed via docker-build.sh (7743 jobs).",
+    "blockers": [],
+    "nextAction": "Optional future work: the full geometric converse (Hilbert coordinatization — a Desarguesian projective plane is coordinatized by a division ring) remains unformalized."
   },
   "knowledge": {
     "insights": [
@@ -68,14 +61,14 @@
     {
       "path": "research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean",
       "filename": "DesarguesTheoremOQ02OQ03.lean",
-      "lineCount": 282,
+      "lineCount": 288,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
-      "verified": false,
-      "note": "UNVERIFIED — Docker + Aristotle blackout 2026-07-04. Part V (4 examples over ZMod 5/6) is decide-only. Placed outside the Proofs glob so it cannot break the gallery build."
+      "verified": true,
+      "note": "VERIFIED via Docker (Lean v4.26.0, 2026-07-04): builds cleanly, 0 errors/warnings, 0 sorry, 0 axiom, 0 native_decide (Part-V witnesses use ordinary kernel-checked decide). Fixed two build-blocking elaboration bugs: Dep's ring R appears only inside its ∃-binder, so R is now pinned (R := R) in cross_dep and desargues statements."
     }
   ],
   "relatedProofs": [


### PR DESCRIPTION
## Summary

The research file for **Desargues' theorem over free rank-3 modules on (non-commutative) division rings** was marked `UNVERIFIED` (authored during a Docker/Aristotle blackout). It turns out it did **not actually build** — it had two genuine elaboration bugs.

**Root cause:** the `Dep` predicate (linear dependence) is `∃ a b c : R, …`, so its ring parameter `R` appears *only inside the ∃-binder*. A bare `Dep (a - b) (b - c) (c - a)` therefore leaves `Module ?R M` as a stuck typeclass instance in the statements of `cross_dep` and `desargues`. (The Part IV quaternion `example` already wrote `Dep (R := Quaternion ℝ)`, which masked the same latent bug.)

**Fix:** pin `(R := R)` in the `cross_dep` and `desargues` statements. No mathematics changed — the hand-checked proofs were sound; they just needed the annotation to elaborate.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.DesarguesTheoremOQ02OQ03` → **7743 jobs, 0 errors, 0 warnings**.
- **0 `sorry`, 0 `axiom`, 0 `native_decide`** — the four Part-V `ZMod 5`/`ZMod 6` witnesses use ordinary kernel-checked `decide` (no `Lean.ofReduceBool`).
- Canonical file stays under `research/problems/.../lean/` (verified by a temporary copy into the `proofs/Proofs/` glob, then removed).

## Metadata
- `leanFiles[0].verified`: `false → true`; note + BUILD STATUS docstring updated.
- `state.md`: Session 5 entry; phase `ACT → REFLECT`.

The forward direction (Desargues over any division ring, commutativity unused), the converse hinge (`smul_ne_zero'` ⇔ no zero divisors), and the finite-ring dichotomy witnesses are now all machine-verified. Only the full geometric converse (Hilbert coordinatization) remains as deferred future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)