### PR TITLE
research(erdos-3-incomplete-01): health-check + fix deprecated indicator lemma

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -445,7 +445,7 @@ theorem summable_of_strongBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 
     by_cases hmem : i ∈ A
     · rw [Set.indicator_of_mem hmem, hF]
       exact one_div_le_one_div_of_le (by positivity) h2j
-    · rw [Set.indicator_of_not_mem hmem]; positivity
+    · rw [Set.indicator_of_notMem hmem]; positivity
   -- Crude bound: every block has mass ≤ 1.
   have hcrude : ∀ j, block j ≤ 1 := by
     intro j


### PR DESCRIPTION
## Summary

Iteration on Erdős Problem #3 (`erdos-3-incomplete-01`, APs in large sets — famously **open**, \$5,000).

**Finding:** the elementary formalization surface of `Erdos3Problem.lean` is **fully exhausted** by 4 prior iterations — monotonicity (`containsAP_of_le`, `isAPFree_of_le`, `rothNumber_mono`), boundary regimes (`hasDivergentSum_containsAP_le_two` proves Erdős #3 unconditionally for `k ≤ 2`), Roth bracketing (`rothNumber_ge_min`), the strong-threshold reduction (`strong_required_bound_implies_conjecture`, fully proved), and `requiredBound_iff_sublogarithmicGrowth` are all present and machine-checked. The single remaining `sorry` (`required_bound_implies_conjecture`) is the **genuine open crux**: the weak `o(N/log N)` hypothesis is provably insufficient (the sufficient threshold is `O(N/(log N)^{1+δ})`, already handled by the strong version). No new tractable elementary content remains — fabricating a redundant lemma would be padding.

**Verification:** build health-check confirms the claimed state is accurate — `docker-build.sh Proofs.Erdos3Problem` → 7743 jobs, clean, **exactly 1 sorry**, **0 axioms**.

**Change:** the one non-`sorry` warning was a deprecated Mathlib lemma — `Set.indicator_of_not_mem` → `Set.indicator_of_notMem`. Fixed, future-proofing the file against the deprecation becoming a hard error. No mathematics changed; still builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)