### PR TITLE
Enrich Coprime Companion Blocks are Nonderogatory: add annotations

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-crt-context",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
+    "range": { "startLine": 4, "endLine": 45 },
+    "type": "context",
+    "title": "The CRT merge of companion blocks",
+    "content": "The parent file supplies, sorry-free, the two facts about the block sum C(p) ⊕ C(q) = fromBlocks C(p) 0 0 C(q): its characteristic polynomial is the product p·q and its minimal polynomial is lcm p q. In general lcm p q divides p·q strictly, so the block sum is *derogatory* (minpoly ≠ charpoly). This file isolates the case that removes the gap — p, q coprime — where lcm p q = p·q, the two polynomials coincide, and the block sum becomes nonderogatory (cyclic), hence similar to the single companion matrix C(p·q). This is the matrix incarnation of the Chinese Remainder Theorem K[X]/(p·q) ≅ K[X]/(p) × K[X]/(q).",
+    "mathContext": "$\\operatorname{charpoly}(C(p)\\oplus C(q)) = pq,\\quad \\operatorname{minpoly}(C(p)\\oplus C(q)) = \\operatorname{lcm}(p,q)$",
+    "significance": "context",
+    "relatedConcepts": ["rational canonical form", "companion matrix", "Chinese Remainder Theorem", "invariant factors", "derogatory matrix"],
+    "prerequisites": ["companion matrices", "minimal and characteristic polynomials"]
+  },
+  {
+    "id": "ann-lcm-eq-mul",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
+    "range": { "startLine": 55, "endLine": 71 },
+    "type": "technique",
+    "title": "lcm = product for coprime monic polynomials",
+    "content": "`lcm_eq_mul_of_isCoprime_monic` proves the purely arithmetic heart of the merge: for coprime monic p, q over a field, lcm p q = p·q. The proof is mutual divisibility of monics. One direction, lcm p q ∣ p·q, is always true (`lcm_dvd`). The other, p·q ∣ lcm p q, uses `IsCoprime.mul_dvd`: since p and q are coprime and each divides lcm p q, their product does too. Both lcm p q and p·q are monic (the lcm via `normalize_lcm`, the product via `Monic.mul`), so `eq_of_monic_of_associated` upgrades the resulting associatedness to genuine equality. The `[DecidableEq F]` instance is required only to obtain the `GCDMonoid F[X]` structure that gives `lcm`.",
+    "mathContext": "$\\gcd(p,q)=1,\\ p,q \\text{ monic} \\ \\Longrightarrow\\ \\operatorname{lcm}(p,q) = pq$",
+    "significance": "key",
+    "relatedConcepts": ["GCD monoid", "IsCoprime.mul_dvd", "monic polynomials", "associated elements", "normalize"],
+    "prerequisites": ["divisibility in polynomial rings", "lcm and gcd", "coprimality"]
+  },
+  {
+    "id": "ann-minpoly-eq-charpoly",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
+    "range": { "startLine": 73, "endLine": 87 },
+    "type": "insight",
+    "title": "Minpoly = charpoly = p·q for coprime blocks",
+    "content": "`companion_block_coprime_minpoly_eq_charpoly` reads off the polynomial identities. The characteristic polynomial is `charpoly_companion_block` (= p·q) directly from the parent. For the minimal polynomial, rewrite `minpoly_companion_block` (= lcm p q) with the coprime lcm lemma to get p·q. So both minimal and characteristic polynomial equal p·q — the equality that makes the block cyclic. The `NeZero dp`/`NeZero dq` instances record that each block has positive size (the companion matrices are indexed by Fin dp, Fin dq with dp = deg p, dq = deg q).",
+    "mathContext": "$\\operatorname{minpoly} = \\operatorname{charpoly} = pq \\quad (\\gcd(p,q)=1)$",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "characteristic polynomial", "block-diagonal matrices", "companion matrix degree"],
+    "prerequisites": ["minimal polynomial", "block matrices"]
+  },
+  {
+    "id": "ann-nonderogatory",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
+    "range": { "startLine": 89, "endLine": 104 },
+    "type": "insight",
+    "title": "Coprime companion blocks are nonderogatory (cyclic)",
+    "content": "`companion_block_coprime_nonderogatory` states the headline: minpoly (C(p) ⊕ C(q)) = charpoly, the defining condition for a matrix to be nonderogatory — equivalently, to admit a cyclic vector. It follows immediately from the previous lemma by rewriting both sides to p·q. Nonderogatory means the block sum is similar to the single companion matrix C(p·q), i.e. two coprime invariant factors collapse into one — the CRT decomposition realized at the level of matrices. The explicit change of basis is deferred (it needs the companionMatrix-flavoured restatement of the cyclic-vector bridge).",
+    "mathContext": "$\\operatorname{minpoly}(C(p)\\oplus C(q)) = \\operatorname{charpoly} \\ \\Longleftrightarrow\\ C(p)\\oplus C(q) \\sim C(pq)$",
+    "significance": "key",
+    "relatedConcepts": ["nonderogatory matrix", "cyclic vector", "matrix similarity", "rational canonical form", "invariant factors"],
+    "prerequisites": ["nonderogatory matrices", "cyclic vectors", "matrix similarity"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for **cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05** (Coprime Companion Blocks are Nonderogatory / Matrix CRT), quality 36, passes 0.

meta.json was already complete (overview, sections, conclusion, crossReferences, references). The one gap was **no annotations.json**.

## Added
- **annotations.json** (4 annotations) — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering:
  - the CRT-merge context (parent's charpoly = p·q, minpoly = lcm; coprimality closes the gap)
  - `lcm_eq_mul_of_isCoprime_monic` (lcm = product via mutual divisibility of monics + `IsCoprime.mul_dvd`)
  - `companion_block_coprime_minpoly_eq_charpoly` (minpoly = charpoly = p·q)
  - `companion_block_coprime_nonderogatory` (the cyclic criterion; similarity to C(p·q))

## Integrity
- No meta.json change. `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` preserved and accurate.

_Shipped via git plumbing off `origin/main` (concurrent processes were rewriting the shared working tree this session)._
