### PR TITLE
research(roth-theorem-k3-oq-01-wip-01): axiomatize the 4 deep quantitative Roth bounds

### DIFF
--- a/proofs/Proofs/RothTheoremQuantitative.lean
+++ b/proofs/Proofs/RothTheoremQuantitative.lean
@@ -333,8 +333,16 @@ theorem two_mul_rothNumber_le {N : ℕ} [NeZero N] (h : Nat.Coprime 3 N) :
   rwa [rothNumber_three] at hmul
 
 -- ═══════════════════════════════════════════════════════════════════
--- PART III: QUANTITATIVE BOUNDS (STATEMENTS)
+-- PART III: QUANTITATIVE BOUNDS (AXIOMATIZED EXTERNAL RESULTS)
 -- ═══════════════════════════════════════════════════════════════════
+--
+-- The four deep quantitative Roth bounds below (Roth 1953, Behrend 1946,
+-- Bloom–Sisask 2020, Kelley–Meka 2023) are published results whose full Lean
+-- formalization is out of scope. They were previously stated as `theorem ... := by
+-- sorry`, which misleadingly presents them as provable here. They are now recorded
+-- as `axiom` declarations — honest, disclosed assumptions in the sense of the
+-- project's Axiom Integrity Policy — so the file is sorry-free and its assumption
+-- count (4) is explicit. Parts I–II above remain fully proved and axiom-free.
 
 /-- **Roth's quantitative bound** (1953): r₃(N) ≤ C·N/log(log N).
 
@@ -343,10 +351,9 @@ theorem two_mul_rothNumber_le {N : ℕ} [NeZero N] (h : Nat.Coprime 3 N) :
     reaches O(1), so density must have reached 1. This forces
     ⌊100/δ²⌋ ≥ ⌊log₂(log N)⌋, giving δ ≤ C/√(log log N).
     Roth's more careful analysis (tracking M ≥ N^{2/3}) gives C/log(log N). -/
-theorem roth_quantitative_upper_bound :
+axiom roth_quantitative_upper_bound :
     ∃ (C : ℝ), C > 0 ∧ ∀ N : ℕ, 3 ≤ N →
-      (rothNumber N : ℝ) ≤ C * N / Real.log (Real.log N) := by
-  sorry
+      (rothNumber N : ℝ) ≤ C * N / Real.log (Real.log N)
 
 /-- **Behrend's lower bound** (1946): r₃(N) ≥ N·exp(-c·√(log N)).
 
@@ -357,20 +364,18 @@ theorem roth_quantitative_upper_bound :
     sphere forces a = c, hence a = b = c).
 
     This lower bound has remained essentially optimal for 80 years. -/
-theorem behrend_lower_bound :
+axiom behrend_lower_bound :
     ∃ (c : ℝ), c > 0 ∧ ∀ N : ℕ, 3 ≤ N →
-      (rothNumber N : ℝ) ≥ N * Real.exp (-c * Real.sqrt (Real.log N)) := by
-  sorry
+      (rothNumber N : ℝ) ≥ N * Real.exp (-c * Real.sqrt (Real.log N))
 
 /-- **Bloom-Sisask bound** (2020): r₃(N) ≤ N/(log N)^{1+c}.
 
     Broke the long-standing "logarithmic barrier" in Roth's theorem.
     Previous bounds (Bourgain 1999, 2008; Sanders 2011) could not
     surpass N/(log N)^{1-ε}. -/
-theorem bloom_sisask_bound :
+axiom bloom_sisask_bound :
     ∃ (c : ℝ), c > 0 ∧ ∀ N : ℕ, 3 ≤ N →
-      (rothNumber N : ℝ) ≤ N / (Real.log N) ^ (1 + c) := by
-  sorry
+      (rothNumber N : ℝ) ≤ N / (Real.log N) ^ (1 + c)
 
 /-- **Kelley-Meka bound** (2023): r₃(N) ≤ N·exp(-c·(log N)^{1/12}).
 
@@ -379,10 +384,9 @@ theorem bloom_sisask_bound :
 
     Gap remaining: Behrend gives exp(-c√(log N)), Kelley-Meka gives
     exp(-c(log N)^{1/12}). Closing this gap is a major open problem. -/
-theorem kelley_meka_upper_bound :
+axiom kelley_meka_upper_bound :
     ∃ (c : ℝ), c > 0 ∧ ∀ N : ℕ, 3 ≤ N →
-      (rothNumber N : ℝ) ≤ N * Real.exp (-c * (Real.log N) ^ (1/12 : ℝ)) := by
-  sorry
+      (rothNumber N : ℝ) ≤ N * Real.exp (-c * (Real.log N) ^ (1/12 : ℝ))
 
 -- NOTE: The previously stated crude_sqrt_bound (r₃(N) ≤ 10√N) was FALSE.
 -- Behrend's lower bound gives r₃(N) ≥ N·exp(-c√(log N)) >> √N for large N.

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Roth (1953), Behrend (1946), Bloom-Sisask (2020), Kelley-Meka (2023)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Roth%27s_theorem_on_arithmetic_progressions",
     "date": "1953",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/RothTheoremQuantitative.lean",
     "tags": [
       "additive-combinatorics",
@@ -16,10 +16,10 @@
       "quantitative-bounds",
       "roth-number"
     ],
-    "badge": "wip",
-    "sorries": 4,
-    "axiomCount": 0,
-    "assumptions": "0 axioms. 4 sorries: roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound. (density_upper_bound_from_iteration was removed — the claim r₃(N) ≤ 10√N is false for large N.)",
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 4,
+    "assumptions": "4 axioms (0 sorries): the four landmark quantitative Roth bounds are recorded as disclosed `axiom` declarations — roth_quantitative_upper_bound (Roth 1953), behrend_lower_bound (Behrend 1946), bloom_sisask_bound (Bloom–Sisask 2020), kelley_meka_upper_bound (Kelley–Meka 2023). Their full Lean proofs are out of scope; Parts I–II (definition of r₃(N), basic bounds, the density-increment iteration count, and the qualitative asymptotic r₃(N)/N → 0) are fully proved and axiom-free. Previously these four were `theorem ... := by sorry`; converting them to axioms makes the assumption count explicit per the Axiom Integrity Policy.",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {
@@ -51,8 +51,8 @@
       "Proof of rothNumber_div_tendsto_zero: the qualitative Roth asymptotic r₃(N)/N → 0, reduced to the parent RothTheorem via Mathlib's corners / triangle-removal chain",
       "Formal statements of 4 quantitative bounds: Roth, Behrend, Bloom-Sisask, Kelley-Meka"
     ],
-    "lineCount": 306,
-    "theoremCount": 20,
+    "lineCount": 393,
+    "theoremCount": 19,
     "definitionCount": 2,
     "additionalFiles": [
       "Proofs/RothTheoremQuantitativeAristotle.lean"
@@ -63,10 +63,10 @@
     "historicalContext": "The quantitative study of $r_3(N)$ — the maximum size of a 3-AP-free subset of $\\{1, \\ldots, N\\}$ — has been one of the most celebrated and active problems in combinatorics for nearly 80 years.\n\nThe story begins with **Felix Behrend** in 1946, who constructed large AP-free sets by exploiting the geometry of high-dimensional spheres: lattice points on a sphere of dimension $d \\approx \\sqrt{\\log N}$ project injectively into $[N]$ while remaining AP-free (since $\\|a\\|^2 + \\|c\\|^2 = 2\\|b\\|^2$ and equal norms force $a = b = c$ in any AP). This gives $r_3(N) \\geq N \\cdot \\exp(-c\\sqrt{\\log N})$, a bound that remained essentially optimal for 80 years.\n\n**Klaus Roth** (1953) then proved the first non-trivial upper bound $r_3(N) = O(N/\\log\\log N)$ via the density increment method: any AP-free set of density $\\delta$ contains a substructure with density $\\delta + \\delta^2/100$; iterating and using exponential sum estimates to control the modulus decay yields the bound. This was the first proof that sets with positive density must contain a 3-AP — later generalized by Szemerédi (1975) to $k$-term APs for all $k$.\n\nFor 50 years, improvements were incremental: Bourgain (1999, 2008) used Bohr sets to sharpen the logarithm, Sanders (2011) reached $N \\log\\log N / \\log N$. Then in 2020, **Bloom and Sisask** broke the 'logarithmic barrier', achieving $N/(\\log N)^{1+c}$ — the first time any power greater than 1 appeared. Their key innovation was a quantitative Bogolyubov lemma on structured Bohr sets.\n\nThe current best upper bound comes from **Kelley and Meka** (2023): $r_3(N) \\leq N \\cdot \\exp(-c(\\log N)^{1/12})$, a dramatic improvement that nearly matches Behrend's lower bound. The gap between exponents $1/12$ (upper) and $1/2$ (lower) remains one of the most tantalizing open problems in additive combinatorics.",
     "problemStatement": "Define the Roth number r₃(N) = max{|A| : A ⊆ [N], A contains no 3-term AP} and formalize the known quantitative bounds.",
     "text": "Formalizes the Roth number and states the progression of quantitative bounds from Roth (1953) to Kelley-Meka (2023).",
-    "proofStrategy": "1. Define r₃(N) as the maximum cardinality of AP-free subsets of ZMod N using Finset.sup.\n2. Prove basic properties: r₃(N) ≤ N (trivial), r₃(N) ≥ 1 (singleton witness), and the qualitative asymptotic r₃(N)/N → 0 (via the parent RothTheorem).\n3. Prove the density increment iteration-count bound: if δ + kδ²/100 ≤ 1 then k ≤ 100/δ² (iterations_before_contradiction).\n4. State four quantitative bounds — Roth, Behrend, Bloom-Sisask, Kelley-Meka — with precise mathematical formulations (all sorried).",
+    "proofStrategy": "1. Define r₃(N) as the maximum cardinality of AP-free subsets of ZMod N using Finset.sup.\n2. Prove basic properties: r₃(N) ≤ N (trivial), r₃(N) ≥ 1 (singleton witness), and the qualitative asymptotic r₃(N)/N → 0 (via the parent RothTheorem).\n3. Prove the density increment iteration-count bound: if δ + kδ²/100 ≤ 1 then k ≤ 100/δ² (iterations_before_contradiction).\n4. State four quantitative bounds — Roth, Behrend, Bloom-Sisask, Kelley-Meka — with precise mathematical formulations, recorded as disclosed axioms (Axiom Integrity Policy).",
     "keyInsights": [
       "**Roth Number as a Supremum**: The definition $r_3(N) = \\texttt{Finset.sup}(\\{A \\subseteq \\mathbb{Z}/N\\mathbb{Z} : \\text{APFree}\\,A\\}, |\\cdot|)$ is `noncomputable` in Lean — it is logically definable but not algorithmically extractable. The proof that the supremum is achieved (rothNumber_achieved) uses `Finset.exists_max_image`, a finite analogue of the extreme value theorem.",
-      "**Modulus Decay Is the Key Obstacle**: All quantitative upper bounds fundamentally differ in how fast they can guarantee the modulus $N$ decreases across density increment iterations. Roth's original analysis gives $M \\geq N^{2/3}$ at each step, yielding $O(\\log\\log N)$ iterations. The formalization isolates this precisely: iterations_before_contradiction bounds the iteration count $k \\leq 100/\\delta^2$, but the missing modulus-decay rate ($M \\geq N^c$) is exactly why the four Part III bounds remain sorried. An earlier density_upper_bound_from_iteration was removed because, without that rate, its $r_3(N) \\leq 10\\sqrt{N}$ conclusion is false for large $N$.",
+      "**Modulus Decay Is the Key Obstacle**: All quantitative upper bounds fundamentally differ in how fast they can guarantee the modulus $N$ decreases across density increment iterations. Roth's original analysis gives $M \\geq N^{2/3}$ at each step, yielding $O(\\log\\log N)$ iterations. The formalization isolates this precisely: iterations_before_contradiction bounds the iteration count $k \\leq 100/\\delta^2$, but the missing modulus-decay rate ($M \\geq N^c$) is exactly why the four Part III bounds are recorded as axioms rather than proved. An earlier density_upper_bound_from_iteration was removed because, without that rate, its $r_3(N) \\leq 10\\sqrt{N}$ conclusion is false for large $N$.",
       "**Behrend's Geometric Miracle**: That the lower bound $r_3(N) \\geq N \\cdot \\exp(-c\\sqrt{\\log N})$ has remained essentially optimal for 80 years is remarkable. It comes from sphere geometry in high dimensions — a completely different world from the Fourier-analytic upper bounds. The two methods speak different mathematical languages, making the gap between them hard to close.",
       "**Kelley-Meka's Polynomial Exponent**: The jump from Bloom-Sisask's $1/(\\log N)^{1+c}$ to Kelley-Meka's $\\exp(-(\\log N)^{1/12})$ represents a qualitative change — exponential improvement rather than polynomial. Their proof introduces polynomial methods and higher-order Fourier analysis into the density increment framework, inspired by the cap set problem techniques of Croot-Lev-Pach and Ellenberg-Gijswijt (2016).",
       "**ZMod N vs Integer Intervals**: Working in $\\mathbb{Z}/N\\mathbb{Z}$ (cyclic group) rather than $\\{1, \\ldots, N\\}$ (integers) simplifies the algebra at the cost of wraparound effects. All major results transfer between the two settings, but the cyclic group formulation integrates cleanly with Lean's Mathlib ZMod API and enables direct use of Fourier/spectral tools on finite abelian groups.",
@@ -124,10 +124,10 @@
     },
     {
       "id": "quantitative-bounds",
-      "title": "Part III: Four Quantitative Bound Statements (All Sorried)",
+      "title": "Part III: Four Quantitative Bound Statements (Axiomatized External Results)",
       "startLine": 248,
       "endLine": 306,
-      "summary": "States four landmark bounds: roth_quantitative_upper_bound (1953, O(N/log log N)), behrend_lower_bound (1946, Ω(N·exp(-c√log N))), bloom_sisask_bound (2020, O(N/(log N)^{1+c})), kelley_meka_upper_bound (2023, O(N·exp(-c(log N)^{1/12}))). All 4 carry sorries.",
+      "summary": "States four landmark bounds: roth_quantitative_upper_bound (1953, O(N/log log N)), behrend_lower_bound (1946, Ω(N·exp(-c√log N))), bloom_sisask_bound (2020, O(N/(log N)^{1+c})), kelley_meka_upper_bound (2023, O(N·exp(-c(log N)^{1/12}))). All 4 are recorded as disclosed axioms (previously sorries).",
       "mathContext": "Historical progression: Roth $N/\\log\\log N$ → Bourgain $N/(\\log N)^{1-\\varepsilon}$ → Sanders $N\\log\\log N/\\log N$ → Bloom-Sisask $N/(\\log N)^{1+c}$ → Kelley-Meka $N\\exp(-(\\log N)^{1/12})$. Lower bound: Behrend $N\\exp(-c\\sqrt{\\log N})$ (1946). Gap: exponent $1/12$ vs $1/2$ is open."
     }
   ],
@@ -174,10 +174,10 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization defines the Roth number $r_3(N)$, proves its basic properties (bounds, achievability, small cases), formalizes the density increment iteration framework, and states the four landmark quantitative bounds — Roth (1953), Behrend (1946), Bloom-Sisask (2020), and Kelley-Meka (2023). The density-increment iteration-count bound (iterations_before_contradiction) and the qualitative asymptotic r₃(N)/N → 0 are proved completely; the four main quantitative bounds remain as precise mathematical statements awaiting proof infrastructure.",
-    "implications": "This formalization provides:\n\n1. **Canonical formal definition of $r_3(N)$** using ZMod N and Finset.sup — a reusable foundation for all future quantitative additive combinatorics in Lean.\n2. **Precise Lean statements of the four key bounds**, giving future researchers a clear target for formalization efforts and ensuring the mathematical content is correctly transcribed.\n3. **Isolation of the core obstacle**: the proved iterations_before_contradiction bound, together with the four sorried Part III bounds, precisely identifies that modulus decay (M ≥ N^c) is the missing ingredient for completing Roth's proof — guiding where future formalization effort should focus. (An earlier density_upper_bound_from_iteration was removed because its r₃(N) ≤ 10√N conclusion is false without such a rate.)\n4. **Infrastructure for comparison**: by placing Roth, Behrend, Bloom-Sisask, and Kelley-Meka side by side with matching types, the formalization enables machine-checkable comparisons between bounds and their hypotheses.\n\n**The cap set problem and polynomial methods**: The cap set problem asks for the maximum size of a set in $(\\mathbb{Z}/3\\mathbb{Z})^n$ with no 3-term AP. In 2016, Croot-Lev-Pach and Ellenberg-Gijswijt proved the cap set conjecture: the maximum is $O(2.756^n)$ (exponentially small), using the polynomial method — functions on the set are bounded-degree polynomials, and a dimension argument gives the bound. This is the finite-field analog of Roth's theorem. The polynomial method from the cap set proof was a key inspiration for Kelley-Meka, who adapted it to the integer setting using a 'slice rank' analog.\n\n**The Bogolyubov lemma and Bohr sets**: All modern upper bounds for $r_3(N)$ use the Bogolyubov-Ruzsa lemma: if $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ has $|A| \\ge \\delta N$, then $A+A-A-A$ contains a Bohr set of dimension $\\ge \\delta^2 N/4$ and radius $\\ge 1/(8\\pi)$. Bohr sets are the approximate subgroups of $\\mathbb{Z}/N\\mathbb{Z}$; they arise because sets with large additive energy have structured sumsets. Formalizing the Bogolyubov lemma in Lean would be a significant contribution toward completing the density increment step.\n\n**Szemerédi's theorem and beyond**: Roth's theorem is the $k=3$ case of Szemerédi's theorem: every subset of positive density in the integers contains $k$-term APs for all $k$. The quantitative bounds for $k \\ge 4$ are dramatically weaker: the best known for $k=4$ is tower-type (Gowers 2001). The polynomial method and Kelley-Meka's techniques are specific to $k=3$; generalizing to $k=4$ is a major open problem.",
+    "summary": "This formalization defines the Roth number $r_3(N)$, proves its basic properties (bounds, achievability, small cases), formalizes the density increment iteration framework, and states the four landmark quantitative bounds — Roth (1953), Behrend (1946), Bloom-Sisask (2020), and Kelley-Meka (2023). The density-increment iteration-count bound (iterations_before_contradiction) and the qualitative asymptotic r₃(N)/N → 0 are proved completely; the four main quantitative bounds are recorded as disclosed axioms (external published results) awaiting full Lean formalization.",
+    "implications": "This formalization provides:\n\n1. **Canonical formal definition of $r_3(N)$** using ZMod N and Finset.sup — a reusable foundation for all future quantitative additive combinatorics in Lean.\n2. **Precise Lean statements of the four key bounds**, giving future researchers a clear target for formalization efforts and ensuring the mathematical content is correctly transcribed.\n3. **Isolation of the core obstacle**: the proved iterations_before_contradiction bound, together with the four axiomatized Part III bounds, precisely identifies that modulus decay (M ≥ N^c) is the missing ingredient for completing Roth's proof — guiding where future formalization effort should focus. (An earlier density_upper_bound_from_iteration was removed because its r₃(N) ≤ 10√N conclusion is false without such a rate.)\n4. **Infrastructure for comparison**: by placing Roth, Behrend, Bloom-Sisask, and Kelley-Meka side by side with matching types, the formalization enables machine-checkable comparisons between bounds and their hypotheses.\n\n**The cap set problem and polynomial methods**: The cap set problem asks for the maximum size of a set in $(\\mathbb{Z}/3\\mathbb{Z})^n$ with no 3-term AP. In 2016, Croot-Lev-Pach and Ellenberg-Gijswijt proved the cap set conjecture: the maximum is $O(2.756^n)$ (exponentially small), using the polynomial method — functions on the set are bounded-degree polynomials, and a dimension argument gives the bound. This is the finite-field analog of Roth's theorem. The polynomial method from the cap set proof was a key inspiration for Kelley-Meka, who adapted it to the integer setting using a 'slice rank' analog.\n\n**The Bogolyubov lemma and Bohr sets**: All modern upper bounds for $r_3(N)$ use the Bogolyubov-Ruzsa lemma: if $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ has $|A| \\ge \\delta N$, then $A+A-A-A$ contains a Bohr set of dimension $\\ge \\delta^2 N/4$ and radius $\\ge 1/(8\\pi)$. Bohr sets are the approximate subgroups of $\\mathbb{Z}/N\\mathbb{Z}$; they arise because sets with large additive energy have structured sumsets. Formalizing the Bogolyubov lemma in Lean would be a significant contribution toward completing the density increment step.\n\n**Szemerédi's theorem and beyond**: Roth's theorem is the $k=3$ case of Szemerédi's theorem: every subset of positive density in the integers contains $k$-term APs for all $k$. The quantitative bounds for $k \\ge 4$ are dramatically weaker: the best known for $k=4$ is tower-type (Gowers 2001). The polynomial method and Kelley-Meka's techniques are specific to $k=3$; generalizing to $k=4$ is a major open problem.",
     "openQuestions": [
-      "Can the modulus decay bound $M \\geq N^{2/3}$ in Roth's density increment be formalized in Mathlib, supplying the missing ingredient to discharge the sorry in roth_quantitative_upper_bound?",
+      "Can the modulus decay bound $M \\geq N^{2/3}$ in Roth's density increment be formalized in Mathlib, supplying the missing ingredient to replace the axiom roth_quantitative_upper_bound with a proof?",
       "Can Behrend's sphere-projection construction be formalized in Lean 4 to prove the lower bound $r_3(N) \\geq N \\cdot \\exp(-c\\sqrt{\\log N})$?",
       "What is the true asymptotic for $r_3(N)$: does the correct exponent lie closer to $\\sqrt{\\log N}$ (Behrend) or $(\\log N)^{1/12}$ (Kelley-Meka), or is there a completely different barrier?",
       "Can the Kelley-Meka proof strategy (polynomial methods + Bohr set density increment) be formalized, and does the formalization reveal any hidden gaps in the argument?"
@@ -218,15 +218,15 @@
       "Finset"
     ],
     "namespace": "Szemeredi.Roth.Quantitative",
-    "lineCount": 306,
-    "axiomCount": 0,
-    "theoremCount": 20,
+    "lineCount": 393,
+    "axiomCount": 4,
+    "theoremCount": 19,
     "definitionCount": 2,
     "path": "Proofs/RothTheoremQuantitative.lean",
-    "sorries": 4,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/RothTheoremQuantitativeAristotle.lean"
     ]
   },
-  "sorries": 4
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Completes the WIP entry `roth-theorem-k3-oq-01` (`RothTheoremQuantitative.lean`) by converting its four **sorry'd** Part III theorems — the landmark quantitative Roth bounds — into properly-disclosed **axioms**:

| Axiom | Result |
|---|---|
| `roth_quantitative_upper_bound` | Roth 1953: $r_3(N) \le C\,N/\log\log N$ |
| `behrend_lower_bound` | Behrend 1946: $r_3(N) \ge N e^{-c\sqrt{\log N}}$ |
| `bloom_sisask_bound` | Bloom–Sisask 2020: $r_3(N) \le N/(\log N)^{1+c}$ |
| `kelley_meka_upper_bound` | Kelley–Meka 2023: $r_3(N) \le N e^{-c(\log N)^{1/12}}$ |

These are published external results whose full Lean formalization is out of scope. A `theorem ... := by sorry` **misleadingly presents them as provable here**; recording them as `axiom` declarations is the honest form under the project's **Axiom Integrity Policy** and makes the assumption count explicit. This mirrors how the sibling `RothTheoremOQ02` axiomatizes Bloom–Sisask.

**Safety:** no code consumes these as theorems — `RothTheoremOQ02` only cites them in prose, and `Erdos139Problem` has its own independent axioms of the same name. Parts I–II (definition of $r_3(N)$, basic bounds, the density-increment iteration count, and the qualitative $r_3(N)/N \to 0$) remain **fully proved and axiom-free**.

## Verification
- Build-verified via `./proofs/scripts/docker-build.sh Proofs.RothTheoremQuantitative`: **0 code sorries**, 4 axiom declarations.
- Meta updated: `status` formalized → **axiomatized**, `badge` wip → **axiom**, `sorries` 4 → **0**, `axiomCount` 0 → **4**, `assumptions` disclosed; prose de-referenced from 'sorried' to 'axiomatized'.

This is an integrity/honesty improvement (sorry → disclosed assumption), not a claim of new proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)