### PR TITLE
Research(strong-goldbach-symmetric-oq-03): VERIFIED — the minimal symmetric offset (innermost Goldbach partition), 0 sorry 0 axiom

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetricOffset.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetricOffset.lean
@@ -1,0 +1,289 @@
+/-
+# Strong Goldbach — the Minimal Symmetric Offset (Innermost Goldbach Partition)
+
+This file is a follow-up to `Proofs.StrongGoldbachSymmetric`, which reformulates the
+open **Strong (Binary) Goldbach Conjecture** in terms of prime pairs symmetric about
+the midpoint `m`: a Goldbach partition of `2 * m` is a pair `(m - k, m + k)` of primes
+with offset `k < m`. That file develops the *comet count* `symmetricPairCount m` — the
+number of such offsets — and gives a battery of upper bounds on it (parity ceiling,
+single-prime sieve, Euler-totient ceiling, half-totient at odd midpoints).
+
+Here we study a complementary object that the count bounds do **not** see: the
+**minimal offset**
+
+    minimalSymmetricOffset m  =  least k with `m - k` and `m + k` both prime,
+
+i.e. the *innermost* Goldbach partition of `2 * m` — the one whose two primes sit
+closest to the midpoint. Where the comet count measures *how many* partitions exist,
+the minimal offset measures *where the first one is*.
+
+What we prove, with **zero axioms and zero `sorry`** (kernel `decide` only, no
+`native_decide`):
+
+* **Characterization** — the minimal offset is a genuine symmetric offset and is
+  `≤` every other one (`minimalSymmetricOffset_le`), and it lies in range
+  (`< m`) exactly when a Goldbach partition exists
+  (`minimalSymmetricOffset_lt_iff`, tied to the parent's comet count).
+* **Diagonal law** — `minimalSymmetricOffset m = 0 ↔ m` is prime
+  (`minimalSymmetricOffset_eq_zero_iff`): the innermost partition is the diagonal
+  `2 * m = m + m` precisely at prime midpoints.
+* **Prime-gap connection** — the larger summand `m + minimalSymmetricOffset m` is the
+  *smallest* prime `j ≥ m` whose reflection `2 * m - j` is also prime
+  (`add_minimalSymmetricOffset_le`); dually the smaller summand is the *largest* prime
+  `≤ m` with prime complement (`le_sub_minimalSymmetricOffset`). A large minimal offset
+  therefore encodes a long run of primes near `m` whose Goldbach complements are all
+  composite — this is the sense in which the minimal offset "relates to prime gaps".
+* **Inherited structure** — at composite `m` the minimal offset is a nonzero
+  **totative** of `m` (`minimalSymmetricOffset_coprime_of_not_prime`) and, for `m > 2`,
+  of opposite parity to `m` (`minimalSymmetricOffset_parity`), by specializing the
+  parent's coprimality and parity constraints to the innermost pair.
+* **A new reformulation of Strong Goldbach** — the conjecture is *equivalent* to the
+  statement that the minimal offset is always well-defined (in range) for every
+  `m ≥ 2` (`symmetricGoldbach_iff_minimalSymmetricOffset_lt`), the minimal-offset analogue
+  of the parent's comet-positivity reformulation `symmetricGoldbach_iff_count`.
+
+**Status.** All results here are fully verified. The Strong Goldbach Conjecture itself
+remains **open**; nothing here proves it. A general *upper* bound on the minimal offset
+(that it is `< m` for every `m ≥ 2`) is by `symmetricGoldbach_iff_minimalSymmetricOffset_lt`
+logically equivalent to the conjecture, and whether the minimal offset is unbounded (a
+midpoint whose only partition is far off-diagonal) is an open sparsity question about
+Goldbach partitions.
+
+**References**:
+- Goldbach's letter to Euler (1742); the "Goldbach comet" picture.
+- `Proofs.StrongGoldbachSymmetric` (the parent reformulation and comet-count bounds).
+-/
+
+import Proofs.StrongGoldbachSymmetric
+import Mathlib.Tactic
+
+namespace StrongGoldbach
+
+/-! ## Definition of the Minimal Symmetric Offset
+
+We define `minimalSymmetricOffset m` as the least offset `k` for which both `m - k`
+and `m + k` are prime, using `Nat.find` on the (decidable) symmetric-pair predicate.
+When `m` has no Goldbach partition at all we return the sentinel value `m` (which lies
+*outside* the valid range `[0, m)`, so `minimalSymmetricOffset m < m` cleanly detects
+existence — see `minimalSymmetricOffset_lt_iff`).
+
+The parent file provides `decidableHasSymmetricPrimePair`, making the `if h : …`
+computable, so concrete values remain machine-checkable by kernel `decide`. -/
+
+/-- The **minimal symmetric offset** at midpoint `m`: the least `k` with both `m - k`
+and `m + k` prime — the offset of the *innermost* Goldbach partition of `2 * m`.
+Returns the out-of-range sentinel `m` when `2 * m` has no Goldbach partition. -/
+def minimalSymmetricOffset (m : ℕ) : ℕ :=
+  if h : HasSymmetricPrimePair m then Nat.find h else m
+
+/-- Unfolding lemma: when a symmetric prime pair exists, the minimal offset is the
+`Nat.find` of the pair predicate. -/
+theorem minimalSymmetricOffset_of_hasPair {m : ℕ} (h : HasSymmetricPrimePair m) :
+    minimalSymmetricOffset m = Nat.find h := by
+  simp only [minimalSymmetricOffset, dif_pos h]
+
+/-! ## Characterization: it is a symmetric offset, and the least one -/
+
+/-- The minimal offset is in range when a Goldbach partition exists. -/
+theorem minimalSymmetricOffset_lt {m : ℕ} (h : HasSymmetricPrimePair m) :
+    minimalSymmetricOffset m < m := by
+  rw [minimalSymmetricOffset_of_hasPair h]; exact (Nat.find_spec h).1
+
+/-- The smaller summand `m - minimalSymmetricOffset m` is prime. -/
+theorem prime_sub_minimalSymmetricOffset {m : ℕ} (h : HasSymmetricPrimePair m) :
+    Nat.Prime (m - minimalSymmetricOffset m) := by
+  rw [minimalSymmetricOffset_of_hasPair h]; exact (Nat.find_spec h).2.1
+
+/-- The larger summand `m + minimalSymmetricOffset m` is prime. -/
+theorem prime_add_minimalSymmetricOffset {m : ℕ} (h : HasSymmetricPrimePair m) :
+    Nat.Prime (m + minimalSymmetricOffset m) := by
+  rw [minimalSymmetricOffset_of_hasPair h]; exact (Nat.find_spec h).2.2
+
+/-- The two summands recover `2 * m`: `(m - off) + (m + off) = 2 * m`. -/
+theorem sub_add_add_minimalSymmetricOffset {m : ℕ} (h : HasSymmetricPrimePair m) :
+    (m - minimalSymmetricOffset m) + (m + minimalSymmetricOffset m) = 2 * m := by
+  have := minimalSymmetricOffset_lt h; omega
+
+/-- **Minimality.** Every symmetric offset `k` (both `m - k` and `m + k` prime) is at
+least the minimal one. -/
+theorem minimalSymmetricOffset_le {m k : ℕ} (h : HasSymmetricPrimePair m)
+    (h1 : Nat.Prime (m - k)) (h2 : Nat.Prime (m + k)) :
+    minimalSymmetricOffset m ≤ k := by
+  rw [minimalSymmetricOffset_of_hasPair h]
+  have hk : k < m := by have := h1.two_le; omega
+  exact Nat.find_min' h ⟨hk, h1, h2⟩
+
+/-! ## In-range ⟺ existence ⟺ positive comet count -/
+
+/-- The minimal offset is in range (`< m`) **iff** `2 * m` has a Goldbach partition.
+The sentinel value `m` for the empty case makes `< m` a clean existence test. -/
+theorem minimalSymmetricOffset_lt_iff (m : ℕ) :
+    minimalSymmetricOffset m < m ↔ HasSymmetricPrimePair m := by
+  constructor
+  · intro hlt
+    by_contra h
+    rw [minimalSymmetricOffset, dif_neg h] at hlt
+    exact absurd hlt (lt_irrefl m)
+  · exact minimalSymmetricOffset_lt
+
+/-- Tie to the parent's Goldbach comet count: the minimal offset is in range iff the
+comet height is positive. -/
+theorem minimalSymmetricOffset_lt_iff_count_pos (m : ℕ) :
+    minimalSymmetricOffset m < m ↔ 0 < symmetricPairCount m := by
+  rw [minimalSymmetricOffset_lt_iff, hasSymmetricPrimePair_iff_count_pos]
+
+/-! ## Diagonal law: minimal offset `0 ⟺ m` prime -/
+
+/-- If the midpoint `m` is prime, the innermost Goldbach partition is the diagonal
+`2 * m = m + m`, i.e. the minimal offset is `0`. -/
+theorem minimalSymmetricOffset_eq_zero_of_prime {m : ℕ} (hm : Nat.Prime m) :
+    minimalSymmetricOffset m = 0 := by
+  have h : HasSymmetricPrimePair m := hasSymmetricPrimePair_of_prime hm
+  rw [minimalSymmetricOffset_of_hasPair h, Nat.find_eq_zero]
+  exact ⟨hm.pos, by simpa using hm, by simpa using hm⟩
+
+/-- **Diagonal law.** When a Goldbach partition exists, its innermost offset is `0`
+exactly when the midpoint is prime. -/
+theorem minimalSymmetricOffset_eq_zero_iff {m : ℕ} (h : HasSymmetricPrimePair m) :
+    minimalSymmetricOffset m = 0 ↔ Nat.Prime m := by
+  rw [minimalSymmetricOffset_of_hasPair h, Nat.find_eq_zero]
+  constructor
+  · rintro ⟨_, hp, _⟩; simpa using hp
+  · intro hm; exact ⟨hm.pos, by simpa using hm, by simpa using hm⟩
+
+/-- At a composite midpoint (that still has some partition) the minimal offset is
+strictly positive: the innermost pair is genuinely off-diagonal. -/
+theorem minimalSymmetricOffset_pos_of_not_prime {m : ℕ}
+    (h : HasSymmetricPrimePair m) (hm : ¬ Nat.Prime m) :
+    0 < minimalSymmetricOffset m :=
+  Nat.pos_of_ne_zero fun h0 => hm ((minimalSymmetricOffset_eq_zero_iff h).mp h0)
+
+/-! ## Prime-gap connection: the summands are the extreme Goldbach primes
+
+The minimality of the offset transports to the summands. Since `k ↦ m + k` is
+increasing, the least offset gives the **smallest** larger prime `j = m + k` in the
+upper arm `[m, 2 * m)` whose reflection `2 * m - j` is prime; dually the **largest**
+smaller prime `p = m - k` in the lower arm `(0, m]` with prime complement. A large
+minimal offset therefore means every prime `j` just above `m` has a *composite*
+Goldbach complement `2 * m - j` — a structural link between the innermost partition
+and the distribution (gaps) of primes near `m`. -/
+
+/-- **The larger summand is the least Goldbach prime `≥ m`.** For any prime `j ≥ m`
+whose reflection `2 * m - j` is also prime, the innermost larger summand does not
+exceed `j`: `m + minimalSymmetricOffset m ≤ j`. -/
+theorem add_minimalSymmetricOffset_le {m j : ℕ} (h : HasSymmetricPrimePair m)
+    (hjm : m ≤ j) (hj : Nat.Prime j) (hcj : Nat.Prime (2 * m - j)) :
+    m + minimalSymmetricOffset m ≤ j := by
+  have hk : minimalSymmetricOffset m ≤ j - m := by
+    apply minimalSymmetricOffset_le h
+    · have e : m - (j - m) = 2 * m - j := by omega
+      rw [e]; exact hcj
+    · have e : m + (j - m) = j := by omega
+      rw [e]; exact hj
+  omega
+
+/-- **The smaller summand is the greatest Goldbach prime `≤ m`.** For any prime `p ≤ m`
+(with `p ≤ 2 * m`) whose complement `2 * m - p` is also prime, the innermost smaller
+summand is at least `p`: `p ≤ m - minimalSymmetricOffset m`. -/
+theorem le_sub_minimalSymmetricOffset {m p : ℕ} (h : HasSymmetricPrimePair m)
+    (hpm : p ≤ m) (hp : Nat.Prime p) (hcp : Nat.Prime (2 * m - p)) :
+    p ≤ m - minimalSymmetricOffset m := by
+  have hk : minimalSymmetricOffset m ≤ m - p := by
+    apply minimalSymmetricOffset_le h
+    · have e : m - (m - p) = p := by omega
+      rw [e]; exact hp
+    · have e : m + (m - p) = 2 * m - p := by omega
+      rw [e]; exact hcp
+  omega
+
+/-! ## Inherited structure at composite midpoints
+
+Specializing the parent's structural constraints (`symmetric_pair_offset_coprime`,
+`symmetric_pair_offset_parity`) to the innermost pair. -/
+
+/-- At a composite midpoint the minimal offset is **coprime** to `m`: the innermost
+off-diagonal offset shares no prime factor with the midpoint. -/
+theorem minimalSymmetricOffset_coprime_of_not_prime {m : ℕ}
+    (h : HasSymmetricPrimePair m) (hm : ¬ Nat.Prime m) :
+    Nat.Coprime (minimalSymmetricOffset m) m :=
+  symmetric_pair_offset_coprime
+    (minimalSymmetricOffset_pos_of_not_prime h hm)
+    (prime_sub_minimalSymmetricOffset h)
+    (prime_add_minimalSymmetricOffset h)
+
+/-- For `m > 2` the minimal offset has **opposite parity** to `m` (both summands odd). -/
+theorem minimalSymmetricOffset_parity {m : ℕ} (hm : 2 < m)
+    (h : HasSymmetricPrimePair m) :
+    m % 2 ≠ minimalSymmetricOffset m % 2 :=
+  symmetric_pair_offset_parity hm (minimalSymmetricOffset_lt h)
+    (prime_sub_minimalSymmetricOffset h) (prime_add_minimalSymmetricOffset h)
+
+/-! ## A new reformulation of Strong Goldbach via the minimal offset
+
+The parent recast Strong Goldbach as positivity of the comet count
+(`symmetricGoldbach_iff_count`). The minimal offset gives an equally clean equivalent
+form: the conjecture holds iff the innermost offset is always well-defined (in range)
+for every `m ≥ 2`. -/
+
+/-- Under Strong Goldbach the minimal offset is well-defined (in range) at every
+`m ≥ 2`. -/
+theorem minimalSymmetricOffset_lt_of_symmetricGoldbach
+    (H : SymmetricGoldbachConjecture) {m : ℕ} (hm : 2 ≤ m) :
+    minimalSymmetricOffset m < m :=
+  minimalSymmetricOffset_lt (H m hm)
+
+/-- **Strong Goldbach as minimal-offset well-definedness.** The Symmetric (hence Strong)
+Goldbach Conjecture is equivalent to: for every `m ≥ 2` the minimal symmetric offset is
+in range (`< m`). The minimal-offset analogue of `symmetricGoldbach_iff_count`. -/
+theorem symmetricGoldbach_iff_minimalSymmetricOffset_lt :
+    SymmetricGoldbachConjecture ↔ ∀ m : ℕ, 2 ≤ m → minimalSymmetricOffset m < m := by
+  constructor
+  · intro H m hm; exact minimalSymmetricOffset_lt (H m hm)
+  · intro H m hm; exact (minimalSymmetricOffset_lt_iff m).mp (H m hm)
+
+/-! ## Verified concrete values (kernel `decide`, axiom-free)
+
+Exact minimal offsets, pinned via `Nat.find_eq_iff` so the checks reduce to small
+concrete primality facts (no heavy `Nat.find` kernel reduction). -/
+
+-- `m = 5` is prime, so the innermost partition of `10` is the diagonal `5 + 5`.
+example : minimalSymmetricOffset 5 = 0 := minimalSymmetricOffset_eq_zero_of_prime (by norm_num)
+
+-- `m = 4` (composite): `8 = 3 + 5`, offset `1`; the diagonal `4 + 4` fails (`4` composite).
+example : minimalSymmetricOffset 4 = 1 := by
+  have h : HasSymmetricPrimePair 4 := ⟨1, by norm_num, by decide, by decide⟩
+  rw [minimalSymmetricOffset_of_hasPair h, Nat.find_eq_iff]
+  refine ⟨⟨by norm_num, by decide, by decide⟩, ?_⟩
+  intro n hn; interval_cases n; decide
+
+-- `m = 6` (composite): `12 = 5 + 7`, offset `1`.
+example : minimalSymmetricOffset 6 = 1 := by
+  have h : HasSymmetricPrimePair 6 := ⟨1, by norm_num, by decide, by decide⟩
+  rw [minimalSymmetricOffset_of_hasPair h, Nat.find_eq_iff]
+  refine ⟨⟨by norm_num, by decide, by decide⟩, ?_⟩
+  intro n hn; interval_cases n; decide
+
+-- `m = 9 = 3²` (odd composite): innermost partition `18 = 7 + 11`, offset `2`.
+-- Illustrates the inherited structure — the offset `2` is even (opposite parity to the
+-- odd `m`) and coprime to `9`.
+example : minimalSymmetricOffset 9 = 2 := by
+  have h : HasSymmetricPrimePair 9 := ⟨2, by norm_num, by decide, by decide⟩
+  rw [minimalSymmetricOffset_of_hasPair h, Nat.find_eq_iff]
+  refine ⟨⟨by norm_num, by decide, by decide⟩, ?_⟩
+  intro n hn; interval_cases n <;> decide
+
+-- A larger off-diagonal offset: `m = 34`, innermost partition `68 = 31 + 37`, offset `3`.
+-- The nearer reflections fail — `33, 35` (offset 1) and `32, 36` (offset 2) are all
+-- composite — so the smallest Goldbach prime above `34` with prime complement is `37`.
+example : minimalSymmetricOffset 34 = 3 := by
+  have h : HasSymmetricPrimePair 34 := ⟨3, by norm_num, by decide, by decide⟩
+  rw [minimalSymmetricOffset_of_hasPair h, Nat.find_eq_iff]
+  refine ⟨⟨by norm_num, by decide, by decide⟩, ?_⟩
+  intro n hn; interval_cases n <;> decide
+
+-- The minimal offset detects existence: `m = 1` (i.e. `2`) has no Goldbach partition,
+-- so the sentinel makes it *not* in range.
+example : ¬ minimalSymmetricOffset 1 < 1 := by
+  rw [minimalSymmetricOffset_lt_iff]; decide
+
+end StrongGoldbach

--- a/src/data/proofs/strong-goldbach-symmetric-oq-03/annotations.json
+++ b/src/data/proofs/strong-goldbach-symmetric-oq-03/annotations.json
@@ -1,0 +1,136 @@
+[
+  {
+    "id": "ann-definition",
+    "proofId": "strong-goldbach-symmetric-oq-03",
+    "range": {
+      "startLine": 62,
+      "endLine": 84
+    },
+    "type": "definition",
+    "title": "The Minimal Symmetric Offset via Nat.find",
+    "content": "`minimalSymmetricOffset m` is the least offset $k$ for which both $m-k$ and $m+k$ are prime — the offset of the *innermost* Goldbach partition of $2m$, the one whose two primes sit closest to the midpoint $m$. It is defined by `Nat.find` on the parent file's decidable symmetric-pair predicate, returning the out-of-range sentinel $m$ when $2m$ has no Goldbach partition. The unfolding lemma `minimalSymmetricOffset_of_hasPair` exposes it as `Nat.find h` whenever a pair exists, which is the entry point for every property below.",
+    "mathContext": "$\\text{minimalSymmetricOffset}(m) = \\min\\{k : \\mathbb{P}(m-k)\\wedge\\mathbb{P}(m+k)\\}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.find",
+      "least element",
+      "Goldbach comet",
+      "innermost partition"
+    ],
+    "prerequisites": [
+      "Nat.find and Nat.find_spec",
+      "decidable predicates",
+      "dependent if (dite)"
+    ]
+  },
+  {
+    "id": "ann-minimality",
+    "proofId": "strong-goldbach-symmetric-oq-03",
+    "range": {
+      "startLine": 109,
+      "endLine": 134
+    },
+    "type": "theorem",
+    "title": "Minimality and the Existence Test",
+    "content": "`minimalSymmetricOffset_le` records that every symmetric offset (any $k$ with $m-k$ and $m+k$ prime) is at least the minimal one, via `Nat.find_min'`; the hypothesis $k<m$ is derived automatically from $m-k$ being prime (hence $\\geq 2$). `minimalSymmetricOffset_lt_iff` then shows the minimal offset lies in range $(<m)$ exactly when $2m$ has a Goldbach partition, the sentinel value $m$ turning `< m` into a clean existence detector. `minimalSymmetricOffset_lt_iff_count_pos` ties this to the parent's Goldbach comet count being positive.",
+    "mathContext": "$\\text{minimalSymmetricOffset}(m) < m \\iff \\text{HasSymmetricPrimePair}(m) \\iff \\text{symmetricPairCount}(m) > 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "least element",
+      "existence detection",
+      "Goldbach comet count"
+    ],
+    "prerequisites": [
+      "Nat.find_min'",
+      "the parent's symmetricPairCount"
+    ]
+  },
+  {
+    "id": "ann-diagonal",
+    "proofId": "strong-goldbach-symmetric-oq-03",
+    "range": {
+      "startLine": 135,
+      "endLine": 159
+    },
+    "type": "theorem",
+    "title": "Diagonal Law: Offset 0 ⟺ Prime Midpoint",
+    "content": "The innermost partition is the diagonal $2m = m + m$ precisely when the midpoint $m$ is prime: `minimalSymmetricOffset_eq_zero_iff` proves `minimalSymmetricOffset m = 0 ↔ Nat.Prime m` (given some partition exists), and `minimalSymmetricOffset_eq_zero_of_prime` gives the unconditional forward direction. Consequently, at composite midpoints the innermost partition is genuinely off-diagonal (`minimalSymmetricOffset_pos_of_not_prime`). This explains the diagonal ray of the Goldbach comet: prime abscissae always carry the trivial closest pair.",
+    "mathContext": "$\\text{minimalSymmetricOffset}(m) = 0 \\iff \\mathbb{P}(m)$",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.find_eq_zero",
+      "diagonal partition",
+      "prime midpoint"
+    ],
+    "prerequisites": [
+      "Nat.find_eq_zero",
+      "hasSymmetricPrimePair_of_prime"
+    ]
+  },
+  {
+    "id": "ann-prime-gap",
+    "proofId": "strong-goldbach-symmetric-oq-03",
+    "range": {
+      "startLine": 161,
+      "endLine": 197
+    },
+    "type": "theorem",
+    "title": "Prime-Gap Connection: The Extreme Goldbach Primes",
+    "content": "Because $k \\mapsto m+k$ is increasing, the least offset produces the *smallest* prime $j \\geq m$ in the upper arm whose reflection $2m-j$ is also prime (`add_minimalSymmetricOffset_le`), and dually the *largest* prime $p \\leq m$ with prime complement $2m-p$ (`le_sub_minimalSymmetricOffset`). A large minimal offset therefore certifies a whole run of primes just above $m$ every one of whose Goldbach complements $2m-j$ is composite — the precise sense in which the innermost-partition offset 'relates to prime gaps', the theme of this follow-up question.",
+    "mathContext": "$m + \\text{minimalSymmetricOffset}(m) = \\min\\{\\,j \\geq m : \\mathbb{P}(j)\\wedge\\mathbb{P}(2m-j)\\,\\}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "prime gaps",
+      "Goldbach partition",
+      "monotone offset map"
+    ],
+    "prerequisites": [
+      "minimality of the offset",
+      "natural-number subtraction identities"
+    ]
+  },
+  {
+    "id": "ann-reformulation",
+    "proofId": "strong-goldbach-symmetric-oq-03",
+    "range": {
+      "startLine": 221,
+      "endLine": 242
+    },
+    "type": "theorem",
+    "title": "A New Reformulation of Strong Goldbach",
+    "content": "`symmetricGoldbach_iff_minimalSymmetricOffset_lt` proves that the Symmetric (hence Strong) Goldbach Conjecture is equivalent to the minimal offset being well-defined — in range $(<m)$ — for every $m \\geq 2$. This is the minimal-offset analogue of the parent's comet-positivity reformulation `symmetricGoldbach_iff_count`: the conjecture becomes the single statement that the innermost Goldbach partition always exists. A general upper bound on the minimal offset is thus equivalent to Strong Goldbach and remains open.",
+    "mathContext": "$\\text{SymmetricGoldbach} \\iff \\forall m \\geq 2,\\ \\text{minimalSymmetricOffset}(m) < m$",
+    "significance": "key",
+    "relatedConcepts": [
+      "conjecture reformulation",
+      "well-definedness",
+      "open problem"
+    ],
+    "prerequisites": [
+      "the existence test minimalSymmetricOffset_lt_iff",
+      "SymmetricGoldbachConjecture"
+    ]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "strong-goldbach-symmetric-oq-03",
+    "range": {
+      "startLine": 244,
+      "endLine": 289
+    },
+    "type": "technique",
+    "title": "Pinning Exact Values with Nat.find_eq_iff",
+    "content": "Concrete minimal offsets are verified by kernel `decide` (not `native_decide`, keeping the file axiom-free). Rather than reducing `Nat.find` in the kernel — which is heavy — each exact value is pinned via `Nat.find_eq_iff`, splitting the claim into 'the predicate holds at the target offset' plus 'it fails at every smaller one', both of which are small concrete primality checks dispatched by `decide` after `interval_cases`. Verified values: 0 at the prime midpoint 5; 1 at 4 and 6; 2 at 9; and 3 at 34, where the nearer reflections $33,35$ and $32,36$ are all composite.",
+    "mathContext": "$\\text{minimalSymmetricOffset}(34) = 3 \\quad (68 = 31 + 37,\\ \\text{with } 33,35,32,36 \\text{ composite})$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.find_eq_iff",
+      "kernel decide",
+      "interval_cases"
+    ],
+    "prerequisites": [
+      "Nat.find_eq_iff",
+      "Decidable instances for Nat.Prime"
+    ]
+  }
+]

--- a/src/data/proofs/strong-goldbach-symmetric-oq-03/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric-oq-03/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "strong-goldbach-symmetric-oq-03",
+  "slug": "strong-goldbach-symmetric-oq-03",
+  "title": "Strong Goldbach: The Minimal Symmetric Offset (Innermost Partition)",
+  "description": "A fully verified, axiom-free study of the MINIMAL symmetric offset for the Strong/Binary Goldbach reformulation — the offset k of the innermost Goldbach partition (m−k, m+k) of 2m, whose two primes sit closest to the midpoint m. This complements the parent entry, which bounds the NUMBER of Goldbach partitions (the comet count); here the object is WHERE the first one sits. Defines minimalSymmetricOffset via Nat.find on the parent's decidable symmetric-pair predicate (with an out-of-range sentinel m when 2m has no partition), and proves: (1) it is a genuine symmetric offset and the least one (minimalSymmetricOffset_le); (2) it is in range (< m) iff a Goldbach partition exists, tied to the parent's comet count being positive; (3) the diagonal law minimalSymmetricOffset m = 0 ↔ m prime — the innermost partition is the diagonal 2m = m+m exactly at prime midpoints; (4) the prime-gap connection: the larger summand m + off is the SMALLEST prime j ≥ m whose reflection 2m−j is also prime, and dually the smaller summand is the GREATEST prime ≤ m with prime complement (add_minimalSymmetricOffset_le / le_sub_minimalSymmetricOffset), so a large minimal offset encodes a run of primes near m all of whose Goldbach complements are composite; (5) inherited structure — at composite m the offset is a nonzero totative of m and, for m > 2, of opposite parity to m; and (6) a NEW reformulation of Strong Goldbach: the conjecture is EQUIVALENT to the minimal offset being well-defined (< m) for every m ≥ 2 (symmetricGoldbach_iff_minimalSymmetricOffset_lt), the minimal-offset analogue of the parent's comet-positivity form. Concrete minimal offsets verified by kernel `decide` (0=prime midpoint 5; 1 at 4,6; 2 at 9; 3 at 34). The Strong Goldbach Conjecture itself is NOT proved — a general upper bound on the minimal offset is equivalent to the conjecture and remains open. 17 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "sorries": 0,
+  "leanFile": {
+    "namespace": "StrongGoldbach",
+    "lineCount": 289,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "definitionCount": 1,
+    "path": "Proofs/StrongGoldbachSymmetricOffset.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StrongGoldbachSymmetricOffset.lean",
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "lineCount": 289,
+    "theoremCount": 17,
+    "definitionCount": 1,
+    "assumptions": "None. The file is axiom-free: `#print axioms` on the headline results (symmetricGoldbach_iff_minimalSymmetricOffset_lt, add_minimalSymmetricOffset_le, minimalSymmetricOffset_eq_zero_iff) shows only the ordinary foundational axioms propext / Classical.choice / Quot.sound — no `sorryAx`, no `Lean.ofReduceBool`. All concrete values use kernel `decide` (pinned via Nat.find_eq_iff so only small primality facts are reduced), not `native_decide`. This file does NOT prove the Strong Goldbach Conjecture, which remains open; it studies the minimal-offset object and proves an equivalent reformulation of the conjecture in terms of it.",
+    "tags": [
+      "number-theory",
+      "goldbach",
+      "prime-sums",
+      "prime-gaps",
+      "open-problem",
+      "reformulation",
+      "follow-up"
+    ],
+    "originalContributions": [
+      "minimalSymmetricOffset: the least offset k with m−k and m+k both prime — the innermost Goldbach partition of 2m — defined by Nat.find on the parent's decidable symmetric-pair predicate, with the out-of-range sentinel m marking the no-partition case",
+      "minimalSymmetricOffset_le: minimality — every symmetric offset (both m−k, m+k prime) is at least the minimal one",
+      "minimalSymmetricOffset_lt_iff / minimalSymmetricOffset_lt_iff_count_pos: the minimal offset is in range (< m) iff 2m has a Goldbach partition iff the parent's comet count symmetricPairCount m is positive — the sentinel makes `< m` a clean existence test",
+      "minimalSymmetricOffset_eq_zero_iff: the diagonal law — when a partition exists, the innermost offset is 0 exactly when the midpoint m is prime (the trivial pair 2m = m+m); minimalSymmetricOffset_eq_zero_of_prime gives the unconditional forward direction",
+      "add_minimalSymmetricOffset_le: prime-gap connection — the larger summand m + minimalSymmetricOffset m is the SMALLEST prime j ≥ m whose reflection 2m−j is also prime",
+      "le_sub_minimalSymmetricOffset: dual — the smaller summand m − minimalSymmetricOffset m is the GREATEST prime p ≤ m whose complement 2m−p is also prime; together these say a large minimal offset means a run of primes near m all with composite Goldbach complement",
+      "minimalSymmetricOffset_coprime_of_not_prime: at composite m the minimal offset is a nonzero totative of m (coprime), by specializing the parent's symmetric_pair_offset_coprime to the innermost pair",
+      "minimalSymmetricOffset_parity: for m > 2 the minimal offset has opposite parity to m (both summands odd), specializing the parent's symmetric_pair_offset_parity",
+      "symmetricGoldbach_iff_minimalSymmetricOffset_lt: a new reformulation — the Symmetric (hence Strong) Goldbach Conjecture is equivalent to the minimal offset being well-defined (< m) for every m ≥ 2; the minimal-offset analogue of the parent's symmetricGoldbach_iff_count",
+      "minimalSymmetricOffset_lt_of_symmetricGoldbach: under the conjecture, the minimal offset is in range at every m ≥ 2",
+      "sub_add_add_minimalSymmetricOffset: the two summands recover 2m",
+      "prime_sub_minimalSymmetricOffset / prime_add_minimalSymmetricOffset: the summands at the minimal offset are prime",
+      "minimalSymmetricOffset_pos_of_not_prime: at composite midpoints the innermost partition is genuinely off-diagonal (offset > 0)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "strong-goldbach-symmetric",
+      "relationship": "extends",
+      "description": "Parent entry: the symmetric-prime-pair reformulation of Strong Goldbach and the comet counting function symmetricPairCount with its upper bounds (parity, single-prime sieve, Euler-totient). This follow-up imports that file and studies the complementary minimal-offset object — where the innermost partition sits rather than how many partitions exist — reusing the parent's decidable instance, coprimality (symmetric_pair_offset_coprime) and parity (symmetric_pair_offset_parity) lemmas, and comet count."
+    },
+    {
+      "targetId": "weak-goldbach",
+      "relationship": "related",
+      "description": "The Weak (Ternary) Goldbach entry defines IsSumOfTwoPrimes and the Binary Goldbach statement reformulated here; the minimal offset gives a further equivalent form of that same conjecture."
+    }
+  ],
+  "references": [
+    {
+      "title": "Goldbach's letter to Euler (1742)",
+      "note": "Origin of the conjecture that every even number > 2 is a sum of two primes."
+    },
+    {
+      "title": "The Goldbach comet",
+      "note": "The plot of the number of Goldbach partitions of 2m against 2m; the minimal offset studied here is the innermost (closest-to-midpoint) partition contributing to each comet abscissa."
+    }
+  ],
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Definition of the Minimal Symmetric Offset",
+      "startLine": 51,
+      "endLine": 78,
+      "summary": "Defines minimalSymmetricOffset m as Nat.find on the (decidable) symmetric-pair predicate, returning the out-of-range sentinel m when 2m has no Goldbach partition, with the unfolding lemma minimalSymmetricOffset_of_hasPair."
+    },
+    {
+      "id": "characterization",
+      "title": "Characterization: a symmetric offset, and the least one",
+      "startLine": 80,
+      "endLine": 118,
+      "summary": "The minimal offset is in range, its summands are prime and recover 2m, and it is ≤ every other symmetric offset (minimality via Nat.find_min')."
+    },
+    {
+      "id": "existence",
+      "title": "In-range ⟺ existence ⟺ positive comet count",
+      "startLine": 120,
+      "endLine": 138,
+      "summary": "minimalSymmetricOffset m < m iff a Goldbach partition exists iff the parent's comet count is positive; the sentinel makes < m a clean existence detector."
+    },
+    {
+      "id": "diagonal",
+      "title": "Diagonal law: minimal offset 0 ⟺ m prime",
+      "startLine": 140,
+      "endLine": 176,
+      "summary": "The innermost partition is the diagonal 2m = m+m exactly at prime midpoints; at composite midpoints it is genuinely off-diagonal (offset > 0)."
+    },
+    {
+      "id": "prime-gap",
+      "title": "Prime-gap connection: the summands are the extreme Goldbach primes",
+      "startLine": 178,
+      "endLine": 217,
+      "summary": "The larger summand is the smallest prime ≥ m with prime reflection, the smaller is the greatest prime ≤ m with prime complement; a large minimal offset encodes a run of primes near m with composite Goldbach complements."
+    },
+    {
+      "id": "inherited-structure",
+      "title": "Inherited structure at composite midpoints",
+      "startLine": 219,
+      "endLine": 240,
+      "summary": "Specializes the parent's coprimality and parity constraints to the innermost pair: at composite m the offset is a nonzero totative of m and, for m > 2, of opposite parity."
+    },
+    {
+      "id": "reformulation",
+      "title": "A new reformulation of Strong Goldbach via the minimal offset",
+      "startLine": 242,
+      "endLine": 268,
+      "summary": "Strong Goldbach is equivalent to the minimal offset being well-defined (< m) for every m ≥ 2 — the minimal-offset analogue of the parent's comet-positivity reformulation."
+    },
+    {
+      "id": "examples",
+      "title": "Verified concrete values",
+      "startLine": 270,
+      "endLine": 289,
+      "summary": "Exact minimal offsets by kernel decide, pinned via Nat.find_eq_iff: 0 at prime midpoint 5, 1 at 4 and 6, 2 at 9, 3 at 34 (with nearer reflections composite); and the m=1 existence non-detection."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to **strong-goldbach-symmetric**, answering its 3rd open question — *"minimal symmetric-prime offset bounds for the strong Goldbach reformulation ... bounds on the minimal offset relate to prime gaps."*

The parent bounds **how many** Goldbach partitions `2m` has (the comet count). This entry studies **where the innermost one sits**: `minimalSymmetricOffset m`, the least offset `k` with both `m − k` and `m + k` prime.

New file `Proofs/StrongGoldbachSymmetricOffset.lean` (imports the parent). **0 sorries, 0 axioms** — `#print axioms` on the headline results shows only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`); all concrete values use **kernel `decide`**, not `native_decide`.

## Results (17 theorems, 1 definition)

- **Definition & characterization** — `minimalSymmetricOffset` via `Nat.find` on the parent's decidable predicate (out-of-range sentinel `m` for the no-partition case); it is a genuine symmetric offset and the least one (`minimalSymmetricOffset_le`).
- **Existence test** — `minimalSymmetricOffset m < m ↔ HasSymmetricPrimePair m ↔ symmetricPairCount m > 0` (tied to the parent's comet count).
- **Diagonal law** — `minimalSymmetricOffset m = 0 ↔ Nat.Prime m`: the innermost partition is the diagonal `2m = m + m` exactly at prime midpoints.
- **Prime-gap connection** — the larger summand `m + off` is the *smallest* prime `j ≥ m` with prime reflection `2m − j` (`add_minimalSymmetricOffset_le`); dually the smaller summand is the *greatest* prime `≤ m` with prime complement. A large minimal offset ⟺ a run of primes near `m` all with composite Goldbach complement.
- **Inherited structure** — at composite `m` the offset is a nonzero totative of `m`, and for `m > 2` has opposite parity to `m` (reusing the parent's `symmetric_pair_offset_coprime` / `symmetric_pair_offset_parity`).
- **A new reformulation of Strong Goldbach** — `SymmetricGoldbachConjecture ↔ ∀ m ≥ 2, minimalSymmetricOffset m < m` (`symmetricGoldbach_iff_minimalSymmetricOffset_lt`), the minimal-offset analogue of the parent's comet-positivity form.
- **Verified values** — `0` at prime midpoint `5`; `1` at `4, 6`; `2` at `9`; `3` at `34` (nearer reflections composite), pinned via `Nat.find_eq_iff`.

## Honesty

Does **not** prove the Strong Goldbach Conjecture, which remains open. A general upper bound on the minimal offset (that it is `< m` for all `m ≥ 2`) is by the reformulation logically *equivalent* to the conjecture; whether the minimal offset is unbounded is an open sparsity question.

## Build

`LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh Proofs.StrongGoldbachSymmetricOffset` — succeeds, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)