### PR TITLE
Enrich Weighted Product-Sum Identities for Lucas and Gibonacci: add annotations

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-05-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-gib-setup",
+    "proofId": "fibonacci-identities-oq-05-oq-01-oq-02",
+    "range": { "startLine": 41, "endLine": 45 },
+    "type": "definition",
+    "title": "Gibonacci abstraction: recurrence as a hypothesis",
+    "content": "The `Gibonacci` section fixes an arbitrary integer sequence `G : ℕ → ℤ` together with a hypothesis `hrec : ∀ n, G (n+2) = G n + G (n+1)` (the only structure used). Abstracting the recurrence this way — rather than hard-coding Fibonacci — is the key move: Fibonacci and Lucas then become the *same* theorem evaluated at different sequences, and the discriminant D = G₁² − G₁G₀ − G₀² is the sole invariant that survives.",
+    "mathContext": "$G_{n+2} = G_n + G_{n+1},\\qquad D := G_1^2 - G_1 G_0 - G_0^2$",
+    "significance": "supporting",
+    "relatedConcepts": ["Gibonacci sequence", "linear recurrence", "generalization by hypothesis", "Cassini discriminant"],
+    "prerequisites": ["recurrence relations", "generalized Fibonacci sequences"]
+  },
+  {
+    "id": "ann-gib-cassini",
+    "proofId": "fibonacci-identities-oq-05-oq-01-oq-02",
+    "range": { "startLine": 47, "endLine": 59 },
+    "type": "insight",
+    "title": "Cassini's identity with a discriminant",
+    "content": "`gib_cassini` proves Gₙ₊₁² − Gₙ₊₁Gₙ − Gₙ² = (−1)ⁿ·D, the Gibonacci generalization of the classical Fibonacci Cassini identity (the D = 1 case). Induction on n: the base case is `simp`; the step rewrites (−1)^(n+1) = −(−1)ⁿ (`hsign`) and the recurrence `G(n+2) = G n + G(n+1)` (`hr`), then closes with `linear_combination -ih` — the induction hypothesis, negated, is exactly the polynomial certificate. The alternating sign is what makes the correction term flip with parity downstream.",
+    "mathContext": "$G_{n+1}^2 - G_{n+1}G_n - G_n^2 = (-1)^n D$",
+    "significance": "key",
+    "relatedConcepts": ["Cassini's identity", "induction", "linear_combination", "sign alternation", "discriminant"],
+    "prerequisites": ["Cassini's identity", "induction over ℕ", "polynomial arithmetic"]
+  },
+  {
+    "id": "ann-gib-weighted",
+    "proofId": "fibonacci-identities-oq-05-oq-01-oq-02",
+    "range": { "startLine": 61, "endLine": 93 },
+    "type": "insight",
+    "title": "The general weighted product-sum closed form",
+    "content": "`gib_weighted_prod_sum` is the headline result: 2·∑_{k≤n} k GₖGₖ₊₁ equals 2n Gₙ₊₁² − 2 Gₙ Gₙ₊₁ + 2 G₀ G₁ + D·(if n even then −n else n+1). Induction peels the top term with `Finset.sum_range_succ` and applies the IH; the crux is a parity case split (`Nat.even_or_odd n`). In each branch, `gib_cassini` is specialized to a signed form `hcass1` and the goal closes with `linear_combination 2·(n+1)·hcass1` — Cassini supplies exactly the D-scaled increment of the correction term as n advances. The parent's ±1 correction is now visibly ±D, plus the seed constant 2 G₀ G₁.",
+    "mathContext": "$2\\sum_{k\\le n} k\\,G_k G_{k+1} = 2n G_{n+1}^2 - 2 G_n G_{n+1} + 2G_0 G_1 + D\\cdot(\\text{if } 2\\mid n \\text{ then } -n \\text{ else } n{+}1)$",
+    "significance": "key",
+    "relatedConcepts": ["weighted summation identity", "Finset.sum_range_succ", "parity case analysis", "linear_combination", "telescoping via Cassini"],
+    "prerequisites": ["finite sums by induction", "parity case analysis"]
+  },
+  {
+    "id": "ann-fib-recovery",
+    "proofId": "fibonacci-identities-oq-05-oq-01-oq-02",
+    "range": { "startLine": 97, "endLine": 113 },
+    "type": "concept",
+    "title": "Fibonacci recovery (D = 1, seed 0)",
+    "content": "`fib_weighted_prod_sum` recovers the parent's Fibonacci identity by instantiating the general theorem at the integer-cast Fibonacci sequence. `fib_hrec` supplies the recurrence hypothesis via `Nat.fib_add_two` cast to ℤ. Substituting F₀ = 0, F₁ = 1 collapses the discriminant D = 1 and the seed 2F₀F₁ = 0, leaving the correction as the bare ±1 (`if Even n then −n else n+1`) — confirming the generalization is faithful, since the special case reproduces the parent verbatim.",
+    "mathContext": "$F_0 = 0,\\ F_1 = 1 \\Rightarrow D = 1,\\ 2F_0 F_1 = 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci numbers", "Nat.fib_add_two", "instantiation", "faithful specialization"],
+    "prerequisites": ["Fibonacci numbers", "Nat-to-Int casting"]
+  },
+  {
+    "id": "ann-lucas",
+    "proofId": "fibonacci-identities-oq-05-oq-01-oq-02",
+    "range": { "startLine": 115, "endLine": 147 },
+    "type": "insight",
+    "title": "Lucas numbers (D = −5, seed 4) — the '5' of Binet's formula",
+    "content": "Defines the Lucas sequence Luc (L₀ = 2, L₁ = 1, Lₙ₊₂ = Lₙ + Lₙ₊₁) with recurrence `Luc_rec`, then specializes the general results. `lucas_cassini` gives Lₙ₊₁² − Lₙ₊₁Lₙ − Lₙ² = (−1)ⁿ·(−5): the discriminant is D = 1 − 2 − 4 = −5, precisely the '5' under the √5 of Binet's formula for both Fibonacci and Lucas. `lucas_weighted_prod_sum` then reads 2·∑ k LₖLₖ₊₁ = 2n Lₙ₊₁² − 2 Lₙ Lₙ₊₁ + 4 − 5·(parity term), with seed constant 2L₀L₁ = 4. Both proofs are a single `linear_combination` against the general theorem after substituting the seed values.",
+    "mathContext": "$L_0 = 2,\\ L_1 = 1 \\Rightarrow D = -5,\\ 2L_0 L_1 = 4;\\quad L_{n+1}^2 - L_{n+1}L_n - L_n^2 = -5(-1)^n$",
+    "significance": "key",
+    "relatedConcepts": ["Lucas numbers", "Binet's formula", "discriminant −5", "recursive definition", "linear_combination"],
+    "prerequisites": ["Lucas numbers", "Binet's formula"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for **fibonacci-identities-oq-05-oq-01-oq-02** (Weighted Product-Sum Identities for Lucas and Gibonacci Sequences), quality 41, passes 0.

meta.json was already rich (overview, sections, mainTheorems, conclusion, crossReferences, references). The gap was **no annotations.json**.

## Added
- **annotations.json** (5 annotations) — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering:
  - the Gibonacci abstraction (recurrence as a hypothesis; discriminant D = G₁² − G₁G₀ − G₀²)
  - `gib_cassini` (Cassini with discriminant, via induction + `linear_combination -ih`)
  - `gib_weighted_prod_sum` (the general closed form; parity split closed by `2(n+1)·Cassini`)
  - `fib_weighted_prod_sum` (Fibonacci recovery, D=1, seed 0)
  - the Lucas block (D=−5 = the '5' of Binet's formula, seed 4)

## Integrity
- No meta.json change. `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` preserved and accurate (no native_decide).

_Shipped via git plumbing off `origin/main`._
