### PR TITLE
Enrich Solution of the Cubic: Closed-Form vs Iterative Complexity: add annotations

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-04/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-04/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-bisection-width",
+    "proofId": "solution-of-cubic-oq-04",
+    "range": { "startLine": 47, "endLine": 66 },
+    "type": "definition",
+    "title": "The bisection width recurrence",
+    "content": "`bisectionWidth W n = W / 2^n` models the width of the bracketing interval after n bisection steps from an initial bracket of width W. `bisectionWidth_succ` proves each step halves the interval (via `pow_succ` + `ring`), and `bisectionWidth_pos` gives positivity by `positivity`. This is the sole geometric fact the whole complexity analysis rests on: convergence is exactly the geometric sequence W/2^n.",
+    "mathContext": "$w_n = W/2^n,\\qquad w_{n+1} = w_n/2$",
+    "significance": "supporting",
+    "relatedConcepts": ["bisection method", "geometric convergence", "interval halving"],
+    "prerequisites": ["bisection root-finding", "geometric sequences"]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "solution-of-cubic-oq-04",
+    "range": { "startLine": 68, "endLine": 95 },
+    "type": "insight",
+    "title": "Iterative lower bound: steps grow like log₂(W/ε)",
+    "content": "`bisection_steps_lower` shows that if n steps reach accuracy ε (W/2^n ≤ ε), then 2^n ≥ W/ε — i.e. n ≥ log₂(W/ε). The proof is pure order algebra: clear the positive denominators with `div_le_iff₀` on both sides. `bisection_achievable` supplies the matching upper bound: `exists_nat_gt (W/ε)` picks N > W/ε, and the Archimedean estimate `Nat.lt_two_pow_self` (N < 2^N) forces width ≤ ε in N steps. Together the two bounds make bisection genuinely Θ(log(1/ε)), not merely Ω.",
+    "mathContext": "$w_n \\le \\varepsilon \\Rightarrow 2^n \\ge W/\\varepsilon,\\ \\text{i.e. } n \\ge \\log_2(W/\\varepsilon)$",
+    "significance": "key",
+    "relatedConcepts": ["logarithmic lower bound", "div_le_iff₀", "Archimedean property", "two-sided bound"],
+    "prerequisites": ["order arithmetic in ordered fields", "Archimedean property"]
+  },
+  {
+    "id": "ann-unbounded",
+    "proofId": "solution-of-cubic-oq-04",
+    "range": { "startLine": 97, "endLine": 114 },
+    "type": "insight",
+    "title": "Unboundedness: the axiom-free form of 'grows like log(1/ε)'",
+    "content": "`bisection_steps_unbounded` is the crux of the separation, stated without ever manipulating `log`: for every target N, the witness accuracy ε = W/2^N forces at least N steps. The proof clears denominators by multiplying the hypothesis W/2^n ≤ W/2^N by 2^n·2^N > 0 (`field_simp` on both product forms), cancels the positive W (`le_of_mul_le_mul_left`), and turns 2^N ≤ 2^n into N ≤ n via `pow_le_pow_iff_right₀` (valid since base 2 > 1). Quantifying over N yields a step count with no ε-uniform bound.",
+    "mathContext": "$\\forall N,\\ \\exists \\varepsilon = W/2^N > 0:\\ w_n \\le \\varepsilon \\Rightarrow N \\le n$",
+    "significance": "key",
+    "relatedConcepts": ["unbounded step count", "pow_le_pow_iff_right₀", "field_simp", "witness accuracy", "monotonicity of 2^x"],
+    "prerequisites": ["monotonicity of exponentials", "quantifier reasoning"]
+  },
+  {
+    "id": "ann-cardano-cost",
+    "proofId": "solution-of-cubic-oq-04",
+    "range": { "startLine": 116, "endLine": 142 },
+    "type": "concept",
+    "title": "The closed-form cost is accuracy-independent",
+    "content": "The Cardano side models the operation count as a fixed constant `cardanoOpCount` (value 14, immaterial), with `cardanoCost ε := cardanoOpCount` independent of ε: `cardanoCost_const` (equal for any two accuracies, by `rfl`) and `cardanoCost_le`. The justification is `cardano_zero_residual`, a re-export of the parent's `SolutionOfCubic.cardano_formula`: Cardano's root u + v (with u³ + v³ = −q, uv = −p/3) has residual exactly 0. Because the root is exact, there is no error to drive below ε, so the same fixed evaluation serves every tolerance.",
+    "mathContext": "$T_{\\text{Cardano}}(\\varepsilon) = \\text{const};\\qquad (x^3+px+q)\\big|_{x=u+v} = 0$",
+    "significance": "key",
+    "relatedConcepts": ["Cardano's formula", "exact root", "closed-form cost", "residual", "depressed cubic"],
+    "prerequisites": ["Cardano's formula", "operation counting models"]
+  },
+  {
+    "id": "ann-separation",
+    "proofId": "solution-of-cubic-oq-04",
+    "range": { "startLine": 144, "endLine": 172 },
+    "type": "insight",
+    "title": "The complexity separation, assembled",
+    "content": "`cardano_beats_iterative` pairs the two sides: the closed-form cost is bounded by `cardanoOpCount` for all ε (left conjunct), while for every N some ε forces ≥ N bisection steps (right conjunct). `no_uniform_iterative_bound` sharpens this to a clean impossibility: no constant C bounds the bisection steps across all ε > 0. Its proof is a two-line contradiction — instantiate unboundedness at C+1 to get an ε forcing ≥ C+1 steps, use achievability to actually reach that ε in some n, and `omega` on C+1 ≤ n ≤ C. This is the rigorous statement of T_Cardano = O(1) vs T_iterative = Θ(log(1/ε)).",
+    "mathContext": "$\\neg\\,\\exists C,\\ \\forall \\varepsilon>0,\\ \\forall n,\\ w_n \\le \\varepsilon \\Rightarrow n \\le C$",
+    "significance": "key",
+    "relatedConcepts": ["complexity separation", "O(1) vs Θ(log)", "proof by contradiction", "omega"],
+    "prerequisites": ["asymptotic complexity", "proof by contradiction"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for **solution-of-cubic-oq-04** (Solution of the Cubic: Closed-Form vs. Iterative Complexity), quality 43, passes 0.

meta.json was already rich (overview with 5 keyInsights, sections with mathContext, mainTheorems, conclusion, crossReferences, references). The gap was **no annotations.json**.

## Added
- **annotations.json** (5 annotations) — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering:
  - the bisection width recurrence `W/2^n`
  - the log₂(W/ε) lower bound + Archimedean achievability (two-sided ⟹ Θ)
  - the unboundedness result (axiom-free form of "grows like log(1/ε)")
  - the accuracy-independent Cardano cost, grounded in the exact-root theorem (`cardano_zero_residual`)
  - the assembled separation `cardano_beats_iterative` / `no_uniform_iterative_bound` (O(1) vs Θ(log))

## Integrity
- No meta.json change. `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` preserved and accurate (no native_decide). `cardanoOpCount` is a modeling constant; the separation depends only on it being fixed.

_Shipped via git plumbing off `origin/main`._
