### PR TITLE
Research(ramsey-r4k-oq-04): VERIFIED multicolour Ramsey theorem — extends RamseyProp to c colours, discharges a gallery axiom (0 sorry, 0 axiom)

### DIFF
--- a/proofs/Proofs/RamseyR4kOQ04.lean
+++ b/proofs/Proofs/RamseyR4kOQ04.lean
@@ -1,0 +1,348 @@
+import Proofs.RamseyR4k
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Tactic
+
+/-
+# Multicolor Ramsey: extending `RamseyProp` from 2 colors to `c` colors (OQ-04)
+
+## What This Proves
+
+The gallery's `RamseyR4k.RamseyProp n r s` encodes the *two-colour* Ramsey
+property: every red/blue edge-colouring of the complete graph `K_n` contains a
+red `r`-clique or a blue `s`-clique.  The open question ramsey-r4k-oq-04 asks to
+extend this framework to **multicolourings** (`c` colours) and to hypergraphs.
+
+This file settles the **multicolouring** half completely and machine-verified:
+
+* `RamseyMulti n c t` — the `c`-colour Ramsey property: every colouring
+  `f : Fin n → Fin n → Fin c` of the edges of `K_n` with `c` colours contains,
+  for some colour `i`, a clique of size `≥ t i` monochromatic in colour `i`.
+
+* `ramseyProp_exists` — the classical **two-colour Ramsey theorem**
+  `∀ r s, ∃ n, RamseyProp n r s`, obtained from the gallery's recursive bound
+  `ramsey_recursion` (`R(r,s) ≤ R(r-1,s) + R(r,s-1)`) by strong induction on
+  `r + s`.  (The gallery had the recursion but not the packaged existence.)
+
+* `ramseyMulti_transfer` — a subset-transfer lemma: if `K_m` has the `c`-colour
+  property then so does every `m`-element vertex subset of a larger graph.
+
+* `ramseyMulti_succ` — the **colour-merging reduction**, the heart of the
+  multicolour theorem: collapsing colour `0` against "all other colours" turns a
+  `(c+1)`-colouring into a 2-colouring; a `RamseyProp` clique in the merged
+  colour then carries a `c`-colouring on which the `c`-colour property recurses.
+
+* `ramseyMulti_exists` — the **multicolour Ramsey theorem**
+  `∀ c ≥ 1, ∀ t, ∃ N, RamseyMulti N c t`, by induction on the number of colours,
+  each step peeling one colour via `ramseyMulti_succ` and `ramseyProp_exists`.
+
+* `ramseyMulti_two_iff_ramseyProp` — the bridge back to the existing gallery:
+  the 2-colour instance of `RamseyMulti` is *equivalent* to `RamseyProp`.
+
+Everything is fully verified: 0 sorries, 0 `axiom` declarations, no
+`native_decide`.  Colours live in `Fin c`; the edge-colouring's diagonal is
+irrelevant (cliques only constrain distinct pairs), so unlike `RamseyProp` we do
+not carry an irreflexivity hypothesis.
+
+The **hypergraph** half of OQ-04 is genuinely harder: the gallery's own
+`RamseyHypergraph.ramsey_existence` still carries a `sorry` on the recursive
+uniformity-induction case, so it is left open here.
+
+Tags: combinatorics, ramsey-theory, multicolouring
+-/
+
+namespace RamseyR4kOQ04
+
+open Finset RamseyR4k
+
+/-!
+## Part I: the multicolour Ramsey property
+-/
+
+/-- The **`c`-colour Ramsey property** on `K_n`.  Every edge-colouring
+`f : Fin n → Fin n → Fin c` (symmetric on the edges) contains a clique of size
+`≥ t i` monochromatic in some colour `i`.
+
+The diagonal `f x x` is unconstrained: a clique only looks at distinct pairs. -/
+def RamseyMulti (n c : ℕ) (t : Fin c → ℕ) : Prop :=
+  ∀ (f : Fin n → Fin n → Fin c), (∀ x y, f x y = f y x) →
+    ∃ (i : Fin c) (S : Finset (Fin n)),
+      S.card ≥ t i ∧ ∀ x y, x ∈ S → y ∈ S → x ≠ y → f x y = i
+
+/-- `RamseyMulti` is monotone in the vertex count `n`. -/
+theorem ramseyMulti_mono_n {n m c : ℕ} (t : Fin c → ℕ) (h : n ≤ m)
+    (hR : RamseyMulti n c t) : RamseyMulti m c t := by
+  intro f hfsym
+  let embed : Fin n → Fin m := fun i => ⟨i.val, by omega⟩
+  have embed_inj : Function.Injective embed := by
+    intro a b hab; exact Fin.ext (Fin.mk.inj hab)
+  let f' : Fin n → Fin n → Fin c := fun i j => f (embed i) (embed j)
+  obtain ⟨i, S, hS_card, hS_mono⟩ := hR f' (fun x y => hfsym _ _)
+  refine ⟨i, S.map ⟨embed, embed_inj⟩, ?_, ?_⟩
+  · rw [card_map]; exact hS_card
+  · intro x y hx hy hxy
+    simp only [mem_map, Function.Embedding.coeFn_mk] at hx hy
+    obtain ⟨a, ha, rfl⟩ := hx
+    obtain ⟨b, hb, rfl⟩ := hy
+    exact hS_mono a b ha hb (fun h => hxy (congrArg embed h))
+
+/-!
+## Part II: the two-colour Ramsey theorem (existence)
+
+The gallery has the recursive bound `ramsey_recursion` and the base cases, but
+not the packaged existence statement `∀ r s, ∃ n, RamseyProp n r s`.  We supply
+it by strong induction on `r + s`.
+-/
+
+/-- `RamseyProp n 0 s` holds for every `n`: the empty set is a red `0`-clique. -/
+private theorem ramseyProp_zero_left (n s : ℕ) : RamseyProp n 0 s := by
+  intro f _ _; exact Or.inl ⟨∅, by simp, by simp⟩
+
+/-- `RamseyProp n r 0` holds for every `n`: the empty set is a blue `0`-clique. -/
+private theorem ramseyProp_zero_right (n r : ℕ) : RamseyProp n r 0 := by
+  intro f _ _; exact Or.inr ⟨∅, by simp, by simp⟩
+
+/-- **Two-colour Ramsey theorem.** For all target sizes `r, s` there is a finite
+`n` with `RamseyProp n r s`.  Proved by strong induction on `r + s`: the base
+cases `r ≤ 1` or `s ≤ 1` are the gallery's `ramseyProp_*`, and the inductive
+step is the gallery's recursive bound `R(r,s) ≤ R(r-1,s) + R(r,s-1)`. -/
+theorem ramseyProp_exists : ∀ r s : ℕ, ∃ n, RamseyProp n r s := by
+  -- strong induction on the sum r + s
+  have key : ∀ N r s : ℕ, r + s ≤ N → ∃ n, RamseyProp n r s := by
+    intro N
+    induction N with
+    | zero =>
+      intro r s hrs
+      have hr : r = 0 := by omega
+      exact ⟨0, hr ▸ ramseyProp_zero_left 0 s⟩
+    | succ N ih =>
+      intro r s hrs
+      match r, s with
+      | 0, s => exact ⟨0, ramseyProp_zero_left 0 s⟩
+      | r, 0 => exact ⟨0, ramseyProp_zero_right 0 r⟩
+      | 1, (s+1) => exact ⟨1, ramseyProp_one_left 1 (s+1) le_rfl⟩
+      | (r+1), 1 => exact ⟨1, ramseyProp_one_right 1 (r+1) le_rfl⟩
+      | (r+2), (s+2) =>
+        obtain ⟨n1, hn1⟩ := ih (r + 1) (s + 2) (by omega)
+        obtain ⟨n2, hn2⟩ := ih (r + 2) (s + 1) (by omega)
+        refine ⟨n1 + n2, ?_⟩
+        have := ramsey_recursion n1 n2 (r+2) (s+2) (by omega) (by omega)
+          (by simpa using hn1) (by simpa using hn2)
+        exact this
+  intro r s
+  exact key (r + s) r s le_rfl
+
+/-!
+## Part III: subset transfer for the multicolour property
+
+If `K_m` has the `c`-colour property, then every `m`-element subset `W` of the
+vertex set of a larger graph does too.  This mirrors the `orderIsoOfFin`
+extraction already used in the gallery's `ramsey_recursion`.
+-/
+
+/-- **Subset transfer.** Given `RamseyMulti m c t` and a vertex subset
+`W : Finset (Fin N)` with `W.card ≥ m`, every symmetric `c`-colouring of `K_N`
+has a monochromatic clique of colour `i` and size `≥ t i` *inside* `W`. -/
+theorem ramseyMulti_transfer {N m c : ℕ} (t : Fin c → ℕ)
+    (hR : RamseyMulti m c t) (W : Finset (Fin N)) (hW : W.card ≥ m)
+    (f : Fin N → Fin N → Fin c) (hsym : ∀ x y, f x y = f y x) :
+    ∃ (i : Fin c) (S : Finset (Fin N)),
+      S ⊆ W ∧ S.card ≥ t i ∧ ∀ x y, x ∈ S → y ∈ S → x ≠ y → f x y = i := by
+  -- extract an exactly-`m`-element subset `W₀ ⊆ W` and identify it with `Fin m`
+  obtain ⟨W₀, hW₀sub, hW₀card⟩ := Finset.exists_subset_card_eq hW
+  have hequiv := W₀.orderIsoOfFin hW₀card
+  let embed : Fin m → Fin N := fun i => (hequiv i).val
+  have embed_inj : Function.Injective embed :=
+    fun a b hab => hequiv.injective (Subtype.val_injective hab)
+  have embed_mem : ∀ i, embed i ∈ W := fun i => hW₀sub (hequiv i).prop
+  -- pull the colouring back to `Fin m`
+  let g : Fin m → Fin m → Fin c := fun a b => f (embed a) (embed b)
+  obtain ⟨i, T, hT_card, hT_mono⟩ := hR g (fun x y => hsym _ _)
+  refine ⟨i, T.map ⟨embed, embed_inj⟩, ?_, ?_, ?_⟩
+  · intro x hx
+    simp only [mem_map, Function.Embedding.coeFn_mk] at hx
+    obtain ⟨a, _, rfl⟩ := hx
+    exact embed_mem a
+  · rw [card_map]; exact hT_card
+  · intro x y hx hy hxy
+    simp only [mem_map, Function.Embedding.coeFn_mk] at hx hy
+    obtain ⟨a, ha, rfl⟩ := hx
+    obtain ⟨b, hb, rfl⟩ := hy
+    exact hT_mono a b ha hb (fun h => hxy (congrArg embed h))
+
+/-!
+## Part IV: the colour-merging reduction
+
+The inductive engine.  Merge colour `0` against the union of all other colours to
+form a 2-colouring; a `RamseyProp` clique in the "colour 0" class is a
+monochromatic `0`-clique, while a clique in the "other" class carries a genuine
+`c`-colouring (the colours `1, …, c` relabelled to `0, …, c-1`) on which the
+`c`-colour property recurses.
+-/
+
+/-- **Colour-merging reduction.** If `K_N` has the two-colour Ramsey property for
+`(t 0, M)` and `K_M` has the `c`-colour property for the tail targets
+`fun j => t j.succ`, then `K_N` has the `(c+1)`-colour property for `t`. -/
+theorem ramseyMulti_succ {N M c : ℕ} (t : Fin (c+1) → ℕ) (hc : 1 ≤ c)
+    (hbase : RamseyProp N (t 0) M)
+    (hrec : RamseyMulti M c (fun j => t j.succ)) :
+    RamseyMulti N (c+1) t := by
+  intro f hfsym
+  -- merged 2-colouring: `true` = colour 0, `false` = "some colour ≠ 0"
+  let g : Fin N → Fin N → Bool :=
+    fun x y => if x = y then false else decide ((f x y).val = 0)
+  have hgsym : ∀ x y, g x y = g y x := by
+    intro x y; simp only [g]
+    by_cases h : x = y
+    · subst h; rfl
+    · rw [if_neg h, if_neg (Ne.symm h), hfsym]
+  have hgirr : ∀ x, g x x = false := by intro x; simp [g]
+  rcases hbase g hgsym hgirr with ⟨S, hS_card, hS_red⟩ | ⟨W, hW_card, hW_blue⟩
+  · -- red clique in `g` ⇒ every edge is colour `0`
+    refine ⟨0, S, by simpa using hS_card, ?_⟩
+    intro x y hx hy hxy
+    have := hS_red x y hx hy hxy
+    simp only [g, if_neg hxy, decide_eq_true_eq] at this
+    exact Fin.ext this
+  · -- blue clique `W`: every edge inside `W` has colour `≠ 0`
+    have hW_ne : ∀ x y, x ∈ W → y ∈ W → x ≠ y → (f x y).val ≠ 0 := by
+      intro x y hx hy hxy
+      have := hW_blue x y hx hy hxy
+      simp only [g, if_neg hxy, decide_eq_false_iff_not] at this
+      exact this
+    -- relabel colours `1,…,c` to `0,…,c-1` by subtracting one
+    let f' : Fin N → Fin N → Fin c :=
+      fun x y => ⟨(f x y).val - 1, by have := (f x y).isLt; omega⟩
+    have hf'sym : ∀ x y, f' x y = f' y x := by
+      intro x y; simp only [f']; rw [Fin.mk.injEq]; rw [hfsym]
+    -- recurse on `W` via subset transfer
+    obtain ⟨i, T, hTsub, hT_card, hT_mono⟩ :=
+      ramseyMulti_transfer (fun j => t j.succ) hrec W hW_card f' hf'sym
+    refine ⟨i.succ, T, by simpa using hT_card, ?_⟩
+    intro x y hx hy hxy
+    have hxW := hTsub hx
+    have hyW := hTsub hy
+    have hne : (f x y).val ≠ 0 := hW_ne x y hxW hyW hxy
+    have hf' : f' x y = i := hT_mono x y hx hy hxy
+    -- decode: `f' x y = i` and `f x y ≠ 0` force `f x y = i.succ`
+    have hval : (f x y).val - 1 = i.val := congrArg Fin.val hf'
+    have : (f x y).val = i.val + 1 := by omega
+    exact Fin.ext (by simpa [Fin.val_succ] using this)
+
+/-!
+## Part V: the multicolour Ramsey theorem
+-/
+
+/-- With a single colour every graph is monochromatic. -/
+private theorem ramseyMulti_one (t : Fin 1 → ℕ) : RamseyMulti (t 0) 1 t := by
+  intro f _
+  refine ⟨0, Finset.univ, ?_, ?_⟩
+  · simp [Finset.card_univ]
+  · intro x y _ _ _; exact Subsingleton.elim _ _
+
+/-- **Multicolour Ramsey theorem.** For every colour count `c ≥ 1` and every
+tuple of target sizes `t : Fin c → ℕ`, there is a finite `N` such that every
+`c`-colouring of `K_N` contains a monochromatic clique of colour `i` and size
+`≥ t i` for some `i`.
+
+Proof: induction on `c`.  The base `c = 1` is trivial; the step peels colour `0`
+using the two-colour theorem `ramseyProp_exists` and the reduction
+`ramseyMulti_succ`, recursing on the remaining `c` colours. -/
+theorem ramseyMulti_exists :
+    ∀ (c : ℕ), 1 ≤ c → ∀ (t : Fin c → ℕ), ∃ N, RamseyMulti N c t := by
+  intro c
+  induction c with
+  | zero => intro h; omega
+  | succ c ih =>
+    intro _ t
+    rcases Nat.eq_zero_or_pos c with hc0 | hcpos
+    · subst hc0
+      exact ⟨t 0, ramseyMulti_one t⟩
+    · obtain ⟨M, hM⟩ := ih hcpos (fun j => t j.succ)
+      obtain ⟨N, hN⟩ := ramseyProp_exists (t 0) M
+      exact ⟨N, ramseyMulti_succ t hcpos hN hM⟩
+
+/-- **Diagonal multicolour Ramsey.** Specialising all targets to a common size
+`k` recovers the exact statement the gallery currently *axiomatises* as
+`RamseysTheorem.multicolor_ramsey_exists` (see `RamseysTheorem.lean`, where it is
+introduced with the note "The full formalization requires multicolor edge
+colorings and lifting lemmas. We axiomatize the result").  Here it is a
+**theorem**, discharged from the fully verified `ramseyMulti_exists`. -/
+theorem multicolor_ramsey_exists_proved (c k : ℕ) (hc : c ≥ 1) (_hk : k ≥ 1) :
+    ∃ n : ℕ, n ≥ 1 ∧ ∀ (color : Fin n → Fin n → Fin c),
+      (∀ x y, color x y = color y x) →
+      ∃ (clique : Finset (Fin n)) (col : Fin c),
+        clique.card ≥ k ∧
+          ∀ x y, x ∈ clique → y ∈ clique → x ≠ y → color x y = col := by
+  obtain ⟨N, hN⟩ := ramseyMulti_exists c hc (fun _ => k)
+  refine ⟨N + 1, Nat.succ_pos N, ?_⟩
+  intro color hsym
+  obtain ⟨i, S, hcard, hmono⟩ :=
+    ramseyMulti_mono_n (fun _ => k) (Nat.le_succ N) hN color hsym
+  exact ⟨S, i, hcard, hmono⟩
+
+/-!
+## Part VI: bridge back to `RamseyProp`
+
+The two-colour instance of `RamseyMulti` is exactly `RamseyProp`, so the new
+framework is a conservative extension of the gallery's.
+-/
+
+/-- Colour code for the bridge: red (`true`) ↦ colour `0` (target `r`),
+blue (`false`) ↦ colour `1` (target `s`), matching `![r, s]`. -/
+private def b2 (b : Bool) : Fin 2 := if b then 0 else 1
+
+private lemma b2_eq_zero (b : Bool) : b2 b = 0 ↔ b = true := by cases b <;> decide
+private lemma b2_eq_one (b : Bool) : b2 b = 1 ↔ b = false := by cases b <;> decide
+
+/-- Colour `0` of a 2-colouring corresponds to `RamseyProp`'s red clique (target
+`r`) and colour `1` to the blue clique (target `s`).  Hence `RamseyMulti n 2
+![r, s]` and `RamseyProp n r s` are equivalent. -/
+theorem ramseyMulti_two_iff_ramseyProp (n r s : ℕ) :
+    RamseyMulti n 2 ![r, s] ↔ RamseyProp n r s := by
+  constructor
+  · -- multicolour ⇒ two-colour
+    intro hM f hfsym _
+    -- encode: red (`true`) ↦ colour 0, blue (`false`) ↦ colour 1
+    let f' : Fin n → Fin n → Fin 2 := fun x y => b2 (f x y)
+    have hf'sym : ∀ x y, f' x y = f' y x := by
+      intro x y; simp only [f', hfsym]
+    obtain ⟨i, S, hS_card, hS_mono⟩ := hM f' hf'sym
+    fin_cases i
+    · -- colour 0 ⇒ red clique (`f = true`), target `![r,s] 0 = r`
+      left
+      refine ⟨S, by simpa using hS_card, ?_⟩
+      intro x y hx hy hxy
+      exact (b2_eq_zero (f x y)).mp (hS_mono x y hx hy hxy)
+    · -- colour 1 ⇒ blue clique (`f = false`), target `![r,s] 1 = s`
+      right
+      refine ⟨S, by simpa using hS_card, ?_⟩
+      intro x y hx hy hxy
+      exact (b2_eq_one (f x y)).mp (hS_mono x y hx hy hxy)
+  · -- two-colour ⇒ multicolour
+    intro hR f hfsym
+    -- decode: colour 0 ↦ red (`true`), colour 1 ↦ blue (`false`); `false` diagonal
+    let g : Fin n → Fin n → Bool :=
+      fun x y => if x = y then false else decide ((f x y).val = 0)
+    have hgsym : ∀ x y, g x y = g y x := by
+      intro x y; simp only [g]
+      by_cases h : x = y
+      · subst h; rfl
+      · rw [if_neg h, if_neg (Ne.symm h), hfsym]
+    have hgirr : ∀ x, g x x = false := by intro x; simp [g]
+    rcases hR g hgsym hgirr with ⟨S, hS_card, hS_red⟩ | ⟨S, hS_card, hS_blue⟩
+    · -- red (`g = true`) ⇒ colour 0, target `![r,s] 0 = r`
+      refine ⟨0, S, by simpa using hS_card, ?_⟩
+      intro x y hx hy hxy
+      have := hS_red x y hx hy hxy
+      simp only [g, if_neg hxy, decide_eq_true_eq] at this
+      exact Fin.ext (by simpa using this)
+    · -- blue (`g = false`) ⇒ colour 1 (the only other `Fin 2` value), target `s`
+      refine ⟨1, S, by simpa using hS_card, ?_⟩
+      intro x y hx hy hxy
+      have := hS_blue x y hx hy hxy
+      simp only [g, if_neg hxy, decide_eq_false_iff_not] at this
+      -- `(f x y).val ≠ 0` and `f x y : Fin 2` force `f x y = 1`
+      have hlt := (f x y).isLt
+      exact Fin.ext (by simp only [Fin.val_one]; omega)
+
+end RamseyR4kOQ04

--- a/src/data/proofs/ramsey-r4k-oq-04/annotations.json
+++ b/src/data/proofs/ramsey-r4k-oq-04/annotations.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "ann-r4k-oq04-ramseymulti-def",
+    "proofId": "ramsey-r4k-oq-04",
+    "range": {
+      "startLine": 60,
+      "endLine": 87
+    },
+    "type": "definition",
+    "title": "RamseyMulti: the c-colour Ramsey property",
+    "content": "RamseyMulti n c t quantifies over all symmetric edge-colourings f : Fin n -> Fin n -> Fin c and asserts that some colour i admits a clique S with S.card >= t i that is monochromatic in colour i (f x y = i for all distinct x, y in S). Unlike the gallery's two-colour RamseyProp, there is no irreflexivity hypothesis on f: a clique constrains only distinct pairs, so the diagonal colour f x x is irrelevant. The targets are per-colour (t : Fin c -> ℕ), strictly more general than a common diagonal target.",
+    "mathContext": "This is the finite pigeonhole statement underlying multicolour Ramsey: with c colours on the edges of $K_n$, one colour class must contain a large clique. The two-colour case $c = 2$, $t = (r, s)$ is exactly Ramsey's original red/blue property, recovered by the bridge lemma.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multicolour Ramsey property",
+      "monochromatic clique",
+      "edge colouring Fin n -> Fin n -> Fin c",
+      "RamseyProp (two-colour)"
+    ],
+    "prerequisites": [
+      "Finset (Fin n) and cardinality",
+      "Fin c as a colour palette",
+      "clique / monochromatic subset"
+    ]
+  },
+  {
+    "id": "ann-r4k-oq04-two-colour-existence",
+    "proofId": "ramsey-r4k-oq-04",
+    "range": {
+      "startLine": 108,
+      "endLine": 133
+    },
+    "type": "technique",
+    "title": "Two-colour existence by strong induction on r + s",
+    "content": "ramseyProp_exists packages the classical Ramsey existence theorem for RamseyProp: for all r, s there is n with RamseyProp n r s. The gallery already had the recursive bound ramsey_recursion (R(r,s) <= R(r-1,s) + R(r,s-1)) and the base cases, but not the packaged existence. The proof uses a helper 'key : forall N r s, r + s <= N -> exists n, RamseyProp n r s' proved by induction on the bound N; base cases r <= 1 or s <= 1 discharge via ramseyProp_zero_left/right and ramseyProp_one_left/right, and the r >= 2, s >= 2 case combines two induction-hypothesis witnesses through ramsey_recursion.",
+    "mathContext": "Strong induction on $r + s$ is the standard route to Ramsey existence: the recursion $R(r,s) \\le R(r-1,s) + R(r,s-1)$ strictly decreases $r + s$, and the boundary $\\min(r,s) \\le 1$ is trivial. Bounding the recursion depth by an explicit parameter $N$ avoids well-founded-recursion boilerplate.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Erdos-Szekeres recursion",
+      "strong induction on r + s",
+      "ramsey_recursion (gallery)",
+      "Ramsey number upper bound"
+    ],
+    "prerequisites": [
+      "RamseyProp definition",
+      "induction on a numeric bound",
+      "the recursive Ramsey inequality"
+    ]
+  },
+  {
+    "id": "ann-r4k-oq04-transfer",
+    "proofId": "ramsey-r4k-oq-04",
+    "range": {
+      "startLine": 145,
+      "endLine": 171
+    },
+    "type": "technique",
+    "title": "Subset transfer via orderIsoOfFin",
+    "content": "ramseyMulti_transfer lets the c-colour property on K_m be applied to any m-element vertex subset W of a larger K_N. It extracts an exactly-m-element W0 subset of W (Finset.exists_subset_card_eq), identifies W0 with Fin m through W0.orderIsoOfFin, pulls the colouring back to a g : Fin m -> Fin m -> Fin c, applies RamseyMulti m, and pushes the resulting clique forward along the (injective) embedding, preserving both cardinality (Finset.card_map) and monochromaticity. This mirrors the embed_from_finset helper the gallery already uses inside ramsey_recursion.",
+    "mathContext": "Ramsey properties are really about the isomorphism type of the induced complete graph, so a large subset behaves like a smaller complete graph. The order isomorphism $W_0 \\cong \\mathrm{Fin}\\,m$ makes this precise and lets the abstract $\\mathrm{Fin}\\,m$ statement act on a concrete subset - the crucial plumbing that lets the multicolour induction recurse inside a monochromatic clique.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.orderIsoOfFin",
+      "Finset.exists_subset_card_eq",
+      "Finset.card_map",
+      "induced subgraph transfer"
+    ],
+    "prerequisites": [
+      "Finset embeddings and maps",
+      "order isomorphism of a finset with Fin",
+      "cardinality under injective maps"
+    ]
+  },
+  {
+    "id": "ann-r4k-oq04-colour-merge",
+    "proofId": "ramsey-r4k-oq-04",
+    "range": {
+      "startLine": 185,
+      "endLine": 230
+    },
+    "type": "proof-step",
+    "title": "The colour-merging reduction (inductive engine)",
+    "content": "ramseyMulti_succ reduces a (c+1)-colouring to a 2-colouring by merging: g x y = true iff colour 0 (off the diagonal). Applying RamseyProp N (t 0) M yields either a red clique - directly a monochromatic colour-0 clique of size >= t 0 - or a blue clique W of size >= M, where every internal edge has colour /= 0. On W the colours 1..c are relabelled to 0..c-1 by decrementing the Fin value (f' x y = (f x y).val - 1, total but only used where f x y /= 0), the c-colour property is applied via subset transfer, and the returned clique of colour i lifts back to colour i.succ since f x y = i.succ exactly when f' x y = i.",
+    "mathContext": "This is the classical grouping argument behind $R(t_0, \\dots, t_c) \\le R(t_0, R(t_1, \\dots, t_c))$: split the palette into 'colour 0' versus 'the rest', let two-colour Ramsey find either a colour-0 clique or a large sub-clique using only the remaining $c$ colours, and recurse on the latter. The decrement bijection $\\{1,\\dots,c\\} \\to \\{0,\\dots,c-1\\}$ is what makes 'the rest' a genuine $c$-colour instance.",
+    "significance": "key",
+    "relatedConcepts": [
+      "colour grouping / merging",
+      "R(t0,...,tc) <= R(t0, R(t1,...,tc))",
+      "two-colour reduction",
+      "Fin index decrement bijection"
+    ],
+    "prerequisites": [
+      "RamseyProp red/blue dichotomy",
+      "subset transfer (ramseyMulti_transfer)",
+      "Fin.succ / Fin.val arithmetic"
+    ]
+  },
+  {
+    "id": "ann-r4k-oq04-axiom-discharged",
+    "proofId": "ramsey-r4k-oq-04",
+    "range": {
+      "startLine": 250,
+      "endLine": 288
+    },
+    "type": "concept",
+    "title": "Multicolour existence and discharging a gallery axiom",
+    "content": "ramseyMulti_exists proves, by induction on the colour count c, that for every c >= 1 and every target tuple t there is N with RamseyMulti N c t: the base c = 1 is trivial (a single colour makes every graph monochromatic) and the step peels colour 0 via ramseyProp_exists (two-colour existence) and ramseyMulti_succ (the merging reduction). Specialising all targets to a common k, multicolor_ramsey_exists_proved reproduces verbatim the statement that RamseysTheorem.lean introduces as the AXIOM multicolor_ramsey_exists - deferred there with the note 'the full formalization requires multicolor edge colorings and lifting lemmas; we axiomatize the result'. It is now a fully verified theorem (0 axioms).",
+    "mathContext": "The induction on colour count is the multicolour Ramsey theorem proper. Discharging the gallery's axiom demonstrates the practical payoff: downstream results (e.g. Schur's theorem) that consumed multicolor_ramsey_exists as an assumption can instead depend on a proved statement, and #print axioms on the result shows only propext, Classical.choice, Quot.sound.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multicolour Ramsey theorem",
+      "induction on colour count",
+      "RamseysTheorem.multicolor_ramsey_exists (axiom)",
+      "axiom elimination"
+    ],
+    "prerequisites": [
+      "two-colour existence (ramseyProp_exists)",
+      "colour-merging reduction (ramseyMulti_succ)",
+      "vertex-count monotonicity"
+    ]
+  },
+  {
+    "id": "ann-r4k-oq04-bridge",
+    "proofId": "ramsey-r4k-oq-04",
+    "range": {
+      "startLine": 300,
+      "endLine": 347
+    },
+    "type": "concept",
+    "title": "Bridge: two-colour RamseyMulti equals RamseyProp",
+    "content": "ramseyMulti_two_iff_ramseyProp proves RamseyMulti n 2 ![r,s] <-> RamseyProp n r s. A small colour code b2 : Bool -> Fin 2 (red/true -> colour 0 with target r, blue/false -> colour 1 with target s) mediates both directions, decoded by the decide lemmas b2_eq_zero and b2_eq_one. This certifies the multicolour framework is a conservative extension of the gallery's two-colour theory: nothing about RamseyProp is changed, it is exactly the c = 2 instance.",
+    "mathContext": "Colour $0$ carries the first target $r$ (the red clique) and colour $1$ the second target $s$ (the blue clique), matching the vector $![r, s]$. The equivalence anchors the new definition to the established one so the extension cannot silently diverge from classical Ramsey theory.",
+    "significance": "important",
+    "relatedConcepts": [
+      "conservative extension",
+      "Bool <-> Fin 2 colour code",
+      "RamseyProp red/blue targets",
+      "Matrix.cons vector ![r,s]"
+    ],
+    "prerequisites": [
+      "RamseyProp definition",
+      "decide on Fin 2 equalities",
+      "vector notation ![r, s]"
+    ]
+  }
+]

--- a/src/data/proofs/ramsey-r4k-oq-04/meta.json
+++ b/src/data/proofs/ramsey-r4k-oq-04/meta.json
@@ -1,0 +1,154 @@
+{
+  "id": "ramsey-r4k-oq-04",
+  "title": "Multicolour Ramsey: extending RamseyProp from 2 colours to c colours (verified)",
+  "slug": "ramsey-r4k-oq-04",
+  "description": "Extends the gallery's two-colour Ramsey property RamseyProp (from ramsey-r4k) to the multicolour setting and proves the full multicolour Ramsey theorem with zero axioms and zero sorries. Defines RamseyMulti n c t (every c-colouring of the edges of K_n contains a clique of size >= t i monochromatic in some colour i), packages the classical two-colour Ramsey existence theorem from the gallery's recursive bound, proves a subset-transfer lemma and the colour-merging reduction, and concludes multicolour existence by induction on the number of colours. The diagonal specialisation is exactly the statement RamseysTheorem.multicolor_ramsey_exists, which the gallery currently only AXIOMATIZES; here it becomes a fully verified theorem. A bridge lemma proves the two-colour instance is equivalent to RamseyProp, so the framework is a conservative extension. 10 theorems, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RamseyR4kOQ04.lean",
+    "tags": [
+      "combinatorics",
+      "ramsey-theory",
+      "multicolouring",
+      "pigeonhole",
+      "induction"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 348,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "assumptions": "None. All results are fully machine-checked; #print axioms reports only the standard foundational axioms propext, Classical.choice, Quot.sound for every theorem. No axiom declarations, no structure-encoded assumptions, no native_decide (so no Lean.ofReduceBool).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.exists_subset_card_eq",
+        "description": "Extracts an exactly-m-element subset from a finset of card >= m, used in the subset-transfer lemma",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.orderIsoOfFin",
+        "description": "Identifies a finset of cardinality m with Fin m, giving the injective embedding used to pull colourings back to Fin m",
+        "module": "Mathlib.Order.Fin.Basic"
+      },
+      {
+        "theorem": "Finset.card_map",
+        "description": "Cardinality is preserved when mapping a finset along an embedding; used to transport clique sizes",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "RamseyMulti n c t: a per-colour-target multicolour Ramsey property extending the gallery's two-colour RamseyProp (from ramsey-r4k) with an unconstrained diagonal (cliques only see distinct pairs, so no irreflexivity hypothesis)",
+      "ramseyProp_exists: packages the classical two-colour Ramsey theorem exists n, RamseyProp n r s from the gallery's recursive bound ramsey_recursion by strong induction on r + s (the gallery had the recursion but not the packaged existence for RamseyProp)",
+      "ramseyMulti_succ: the colour-merging reduction (merge colour 0 vs all other colours to a 2-colouring, apply RamseyProp, recurse on the resulting c-colouring inside the blue clique) - the inductive engine of the multicolour theorem",
+      "ramseyMulti_exists: the full multicolour Ramsey theorem, for all c >= 1 and all targets t there is N with RamseyMulti N c t, proved with 0 axioms",
+      "multicolor_ramsey_exists_proved: derives the EXACT statement that RamseysTheorem.lean currently declares as the axiom multicolor_ramsey_exists (deferred there with the note 'we axiomatize the result'), turning a gallery axiom into a verified theorem",
+      "ramseyMulti_two_iff_ramseyProp: the two-colour instance RamseyMulti n 2 ![r,s] is equivalent to RamseyProp n r s, so the new framework is a conservative extension"
+    ],
+    "dateAdded": "2026-07-04",
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "Two-colour Ramsey property RamseyProp and the recursive bound (ramsey-r4k gallery entry)",
+      "Finite pigeonhole / clique extraction on Finset (Fin n)",
+      "Induction on the number of colours"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Ramsey's theorem in its classical two-colour form guarantees that for any target sizes r, s there is an n such that every red/blue edge-colouring of the complete graph K_n contains a red r-clique or a blue s-clique. The multicolour generalisation (Ramsey 1930) replaces the two colours by c colours: for target sizes t_0, ..., t_{c-1} there is an N such that every c-colouring of K_N contains, for some colour i, a t_i-clique monochromatic in colour i. The standard proof reduces c colours to two by merging colour 0 against the union of the remaining colours and recursing, giving the tower-type bound R(t_0, ..., t_{c-1}) <= R(t_0, R(t_1, ..., t_{c-1})). The gallery already formalised the two-colour theory (RamseyProp, the recursive bound R(r,s) <= R(r-1,s) + R(r,s-1), and off-diagonal R(4,k) work) but only AXIOMATIZED the multicolour existence result (RamseysTheorem.multicolor_ramsey_exists), noting that a full proof requires multicolour edge-colourings and lifting lemmas.",
+    "problemStatement": "Open question ramsey-r4k-oq-04 asks to extend the gallery's RamseyProp framework to hypergraphs and to multicolourings. This entry settles the MULTICOLOURING half completely and machine-verified. It defines RamseyMulti n c t, proves the full multicolour Ramsey existence theorem with zero axioms, and connects it back to the existing two-colour RamseyProp. The hypergraph half is left open: the gallery's own RamseyHypergraph.ramsey_existence still carries a sorry on the recursive uniformity-induction case, so k-uniform multicolour Ramsey is genuinely harder and out of scope here.",
+    "proofStrategy": "Six layers. (I) Define RamseyMulti n c t over colourings f : Fin n -> Fin n -> Fin c, symmetric on edges, with per-colour clique targets; prove monotonicity in the vertex count. (II) Package two-colour existence exists n, RamseyProp n r s by strong induction on r + s: base cases r <= 1 or s <= 1 are the gallery's ramseyProp_* lemmas, the inductive step is the gallery's ramsey_recursion. (III) Prove a subset-transfer lemma: if K_m has the c-colour property then every m-element vertex subset W of a larger K_N does, by extracting an exactly-m subset, identifying it with Fin m via orderIsoOfFin, pulling the colouring back and pushing the clique forward (the same embedding pattern the gallery uses inside ramsey_recursion). (IV) Prove the colour-merging reduction ramseyMulti_succ: given RamseyProp N (t 0) M and RamseyMulti M c (tail t), form the 2-colouring 'colour 0 vs the rest'; a RamseyProp red clique is a monochromatic colour-0 clique, while a blue clique of size >= M carries a genuine c-colouring (colours 1..c relabelled by subtracting one) on which the c-colour property recurses via subset transfer. (V) Conclude ramseyMulti_exists by induction on c: base c = 1 is trivial (one colour makes everything monochromatic), the step peels colour 0 using ramseyProp_exists and ramseyMulti_succ; specialise to a common target to discharge the gallery's multicolor_ramsey_exists axiom. (VI) Prove the two-colour instance equivalent to RamseyProp via an explicit Bool <-> Fin 2 colour code.",
+    "keyInsights": [
+      "The colour-merging reduction is the whole engine: collapsing colour 0 against 'every other colour' is exactly a 2-colouring, so the gallery's existing RamseyProp does the pigeonhole work; the blue clique it returns is a smaller complete graph carrying only c colours, on which the induction hypothesis applies.",
+      "The relabelling of colours 1..c to 0..c-1 by subtracting one from the Fin index is total (out-of-clique edges map arbitrarily) and only needs to be correct inside the blue clique, where every edge has colour /= 0 so the decrement is invertible: f x y = i.succ exactly when f'(x,y) = i.",
+      "Subset transfer via orderIsoOfFin is the one non-trivial piece of plumbing shared with the gallery's ramsey_recursion; isolating it as ramseyMulti_transfer keeps the reduction and the induction clean and reusable.",
+      "The gallery only needed to axiomatize multicolour Ramsey because it lacked a multicolour clique predicate and the lifting lemmas; supplying RamseyMulti plus transfer turns multicolor_ramsey_exists into a one-line corollary (multicolor_ramsey_exists_proved), converting an axiom into a theorem.",
+      "The bridge lemma ramseyMulti_two_iff_ramseyProp certifies the extension is conservative: colour 0 corresponds to RamseyProp's red target r and colour 1 to the blue target s, matching ![r,s], so nothing about the two-colour theory is lost or silently changed."
+    ],
+    "prerequisites": [
+      "Two-colour Ramsey property and recursive bound (ramsey-r4k)",
+      "Finset cardinality, embeddings, and orderIsoOfFin in Lean 4 Mathlib",
+      "Induction on colour count and on r + s"
+    ]
+  },
+  "sections": [
+    {
+      "id": "multicolour-property",
+      "title": "The Multicolour Ramsey Property",
+      "startLine": 58,
+      "endLine": 87,
+      "summary": "Defines RamseyMulti n c t: every symmetric c-colouring of the edges of K_n has a clique of size >= t i monochromatic in some colour i. The diagonal is unconstrained (cliques only see distinct pairs). Proves ramseyMulti_mono_n, monotonicity in the vertex count."
+    },
+    {
+      "id": "two-colour-existence",
+      "title": "Two-Colour Ramsey Existence",
+      "startLine": 89,
+      "endLine": 133,
+      "summary": "ramseyProp_exists: for all r, s there is n with RamseyProp n r s, by strong induction on r + s. Base cases r <= 1 or s <= 1 use the gallery's ramseyProp_zero_*/ramseyProp_one_* lemmas; the inductive step is the gallery's recursive bound ramsey_recursion."
+    },
+    {
+      "id": "subset-transfer",
+      "title": "Subset Transfer",
+      "startLine": 135,
+      "endLine": 171,
+      "summary": "ramseyMulti_transfer: if K_m has the c-colour property, every m-element vertex subset W of a larger K_N has a monochromatic clique inside W, via Finset.exists_subset_card_eq and orderIsoOfFin (the embedding pattern reused from the gallery's ramsey_recursion)."
+    },
+    {
+      "id": "colour-merging-reduction",
+      "title": "The Colour-Merging Reduction",
+      "startLine": 173,
+      "endLine": 230,
+      "summary": "ramseyMulti_succ: merges colour 0 against all other colours to a 2-colouring; a RamseyProp red clique is a colour-0 clique, a blue clique carries a relabelled c-colouring on which the c-colour property recurses via subset transfer. The inductive engine of the multicolour theorem."
+    },
+    {
+      "id": "multicolour-theorem",
+      "title": "The Multicolour Ramsey Theorem",
+      "startLine": 232,
+      "endLine": 283,
+      "summary": "ramseyMulti_exists: for all c >= 1 and all targets t there is N with RamseyMulti N c t, by induction on c peeling colour 0 via ramseyProp_exists and ramseyMulti_succ. multicolor_ramsey_exists_proved specialises to a common target, discharging the gallery's previously-axiomatized RamseysTheorem.multicolor_ramsey_exists."
+    },
+    {
+      "id": "ramseyprop-bridge",
+      "title": "Bridge Back to RamseyProp",
+      "startLine": 284,
+      "endLine": 348,
+      "summary": "ramseyMulti_two_iff_ramseyProp: the two-colour instance RamseyMulti n 2 ![r,s] is equivalent to RamseyProp n r s (colour 0 = red target r, colour 1 = blue target s), certifying the extension is conservative."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry extends the gallery's two-colour RamseyProp to arbitrarily many colours and proves the full multicolour Ramsey theorem with zero axioms and zero sorries. The colour-merging reduction turns c-colour existence into an induction over the gallery's existing two-colour infrastructure, and the diagonal specialisation discharges the statement RamseysTheorem.multicolor_ramsey_exists, which the gallery previously only axiomatized. The bridge lemma confirms the two-colour instance coincides with RamseyProp, so the framework is a conservative, machine-checked extension.",
+    "implications": "Multicolour Ramsey is the natural next layer above the two-colour theory and is the standard input to results such as Schur's theorem and multicolour Ramsey number bounds. Providing a verified RamseyMulti predicate together with subset transfer and the colour-merging reduction gives downstream formalizations a proved foundation rather than an axiom. The remaining half of the open question - multicolour Ramsey for k-uniform hypergraphs - stays open, gated by the gallery's incomplete RamseyHypergraph.ramsey_existence (recursive uniformity induction still a sorry).",
+    "openQuestions": [
+      "Can the hypergraph half of ramsey-r4k-oq-04 be settled, i.e. multicolour Ramsey for k-uniform hypergraphs, once RamseyHypergraph.ramsey_existence is completed?",
+      "Can RamseysTheorem.lean be refactored to import this file and replace its multicolor_ramsey_exists axiom with multicolor_ramsey_exists_proved, reducing the gallery's total axiom count?",
+      "What explicit multicolour Ramsey number upper bounds (e.g. the tower bound R_c(k) <= c^{c(k-1)}) can be extracted constructively from ramseyMulti_succ?",
+      "Does the per-colour-target formulation admit a matching lower-bound framework (multicolour analogues of the probabilistic method) within the gallery?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "ramsey-r4k",
+      "relationship": "parent",
+      "description": "Defines RamseyProp, the recursive bound ramsey_recursion, and the base-case lemmas ramseyProp_one_left/right that this file imports and builds on"
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Contains the axiom multicolor_ramsey_exists; this file proves the exact same statement as the theorem multicolor_ramsey_exists_proved, discharged from a fully verified multicolour existence theorem"
+    },
+    {
+      "targetId": "ramsey-r4k-extensions",
+      "relationship": "related",
+      "description": "Sibling extension of the two-colour R(4,k) theory; this file extends the same RamseyProp in the orthogonal direction of colour count"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/RamseyR4kOQ04.lean",
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "lineCount": 348,
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Settles the **multicolouring** half of open question `ramsey-r4k-oq-04` ("Extending `RamseyProp` to hypergraphs and multicolourings"). Extends the gallery's two-colour `RamseyProp` (from `ramsey-r4k`) to arbitrarily many colours and proves the **full multicolour Ramsey theorem** with **0 sorries and 0 axioms**.

The gallery previously only *axiomatized* multicolour Ramsey (`RamseysTheorem.multicolor_ramsey_exists`, introduced with the note "the full formalization requires multicolor edge colorings and lifting lemmas; we axiomatize the result"). This PR provides that formalization and derives the axiom's exact statement as a theorem.

## New verified content — `proofs/Proofs/RamseyR4kOQ04.lean` (348 lines, 10 theorems, 2 defs)

| Result | What it gives |
|---|---|
| `RamseyMulti n c t` | Per-colour-target multicolour Ramsey property (colours in `Fin c`; unconstrained diagonal) |
| `ramseyProp_exists` | Two-colour existence `∀ r s, ∃ n, RamseyProp n r s` — packaged from the gallery's `ramsey_recursion` by strong induction on `r + s` |
| `ramseyMulti_transfer` | Subset transfer via `orderIsoOfFin` (the embedding pattern already used inside `ramsey_recursion`) |
| `ramseyMulti_succ` | **Colour-merging reduction** — the inductive engine: merge colour 0 vs the rest → 2-colouring → recurse on the blue clique |
| `ramseyMulti_exists` | **Multicolour Ramsey theorem** `∀ c ≥ 1, ∀ t, ∃ N, RamseyMulti N c t`, 0 axioms |
| `multicolor_ramsey_exists_proved` | Derives the **exact** statement of the gallery axiom `RamseysTheorem.multicolor_ramsey_exists` — axiom → theorem |
| `ramseyMulti_two_iff_ramseyProp` | Conservative-extension bridge: `RamseyMulti n 2 ![r,s] ↔ RamseyProp n r s` |

## Verification

- Builds clean: `LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh Proofs.RamseyR4kOQ04` ✔ (no warnings from this file)
- `#print axioms` on `ramseyMulti_exists`, `ramseyProp_exists`, `ramseyMulti_succ`, `multicolor_ramsey_exists_proved`, `ramseyMulti_two_iff_ramseyProp`: **only** `propext, Classical.choice, Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`.
- No `native_decide`, no `axiom` declarations, no structure-encoded assumptions.

## Scope / honesty

- **Multicolouring half: DONE and verified.**
- **Hypergraph half: left open.** The gallery's own `RamseyHypergraph.ramsey_existence` still carries a `sorry` on the recursive uniformity-induction case, so `k`-uniform multicolour Ramsey is genuinely harder and out of scope here.
- This PR does **not** edit `RamseysTheorem.lean`; it proves the same statement in a self-contained file. A follow-up could refactor `RamseysTheorem` to import this and replace its axiom, reducing the gallery's axiom count.

## Gallery integration

- `src/data/proofs/ramsey-r4k-oq-04/meta.json` (status `verified`, badge `original`, `axiomCount: 0`)
- `src/data/proofs/ramsey-r4k-oq-04/annotations.json` (6 annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)