### PR TITLE
Fix: restore compilation of AmgmInequalityOQ02OQ02 (unfold_let removed in Mathlib v4.26)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02.lean
@@ -442,12 +442,12 @@ theorem newton_cleared_denom_inductive_step (m k : ℕ) (hk : 2 ≤ k) (hm_eq : 
   set AD := (b + a) * (d + c) with hAD_def
   set B2 := (c + b) ^ 2 with hB2_def
   have hAD_nn : 0 ≤ AD := by
-    unfold_let AD; nlinarith [mul_nonneg ha_nn hd_nn, mul_nonneg hb_nn hc_nn]
+    simp only [hAD_def]; nlinarith [mul_nonneg ha_nn hd_nn, mul_nonneg hb_nn hc_nn]
   -- binom_ineq ↔ c²·AD ≥ bd·B2
   have h_c2AD_ge_bdB2 : c ^ 2 * AD ≥ b * d * B2 := by nlinarith [h_binom]
   -- Algebraic identity gives dual: b²·AD ≥ ac·B2
   have h_binom_symm : (c ^ 2 - b ^ 2) * AD = (b * d - a * c) * B2 := by
-    unfold_let AD B2; ring
+    simp only [hAD_def, hB2_def]; ring
   have h_b2AD_ge_acB2 : b ^ 2 * AD ≥ a * c * B2 := by
     nlinarith [h_c2AD_ge_bdB2, h_binom_symm]
   -- Positivity of binomial coefficients
@@ -465,7 +465,7 @@ theorem newton_cleared_denom_inductive_step (m k : ℕ) (hk : 2 ≤ k) (hm_eq : 
       mul_nonneg (mul_nonneg hekm1_nn hekp1_nn) (by nlinarith [h_c2AD_ge_bdB2])
     have h_sum : (ek ^ 2 * (b * d) - ekm1 * ekp1 * c ^ 2) * AD +
         ekm1 * ekp1 * (c ^ 2 * AD - b * d * B2) =
-        b * d * (ek ^ 2 * AD - ekm1 * ekp1 * B2) := by unfold_let AD B2; ring
+        b * d * (ek ^ 2 * AD - ekm1 * ekp1 * B2) := by simp only [hAD_def, hB2_def]; ring
     by_contra h_neg; push_neg at h_neg
     linarith [mul_neg_of_pos_of_neg (mul_pos hb_pos hd_pos) (by linarith :
       ek ^ 2 * AD - ekm1 * ekp1 * B2 < 0)]
@@ -478,7 +478,7 @@ theorem newton_cleared_denom_inductive_step (m k : ℕ) (hk : 2 ≤ k) (hm_eq : 
       mul_nonneg (mul_nonneg hekm2_nn hek_nn) (by nlinarith [h_b2AD_ge_acB2])
     have h_sum : (ekm1 ^ 2 * (a * c) - ekm2 * ek * b ^ 2) * AD +
         ekm2 * ek * (b ^ 2 * AD - a * c * B2) =
-        a * c * (ekm1 ^ 2 * AD - ekm2 * ek * B2) := by unfold_let AD B2; ring
+        a * c * (ekm1 ^ 2 * AD - ekm2 * ek * B2) := by simp only [hAD_def, hB2_def]; ring
     by_contra h_neg; push_neg at h_neg
     linarith [mul_neg_of_pos_of_neg (mul_pos ha_pos hc_pos) (by linarith :
       ekm1 ^ 2 * AD - ekm2 * ek * B2 < 0)]


### PR DESCRIPTION
## Fix

The gallery entry **`amgm-inequality-oq-02-oq-02`** declares `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` for `proofs/Proofs/AmgmInequalityOQ02OQ02.lean` — but the Lean file **no longer compiles** against pinned Mathlib v4.26.0. The `unfold_let` tactic was removed from Mathlib, so the file failed with `unknown tactic` at line 445 plus cascading unsolved goals (444, 408). A "verified" entry whose source does not compile is a live integrity overclaim.

This replaces all **4** `unfold_let X` calls with `simp only [hX_def]`, reusing the `set X := e with hX_def` hypotheses already in scope. `set … with h` gives `h : X = e`, so `simp only [h]` unfolds the set-variable to its definition — a faithful, minimal, one-for-one replacement.

## Evidence

**Before**: `error: Proofs/AmgmInequalityOQ02OQ02.lean:445:5: unknown tactic` (deterministic compile failure against Mathlib v4.26.0).

**After**: the target file elaborates to completion — a full 20s elaboration pass with **zero errors** (only pre-existing Mathlib deprecation warnings, e.g. `Finset.toSet`). No `unfold_let`, unsolved-goal, or tactic errors remain.

> Docker build note: the local build harness could not write the final `.olean` — repeated `exit 135` (SIGBUS) and a corrupted shared package cache (`aesop/.../Types.ir: invalid header`) on a host at 90% disk. These failures are infra-level (corrupted Docker cache volume, a known blackout condition) and affect every target regardless of this diff; they are unrelated to the code change, which the elaborator accepts cleanly. A build in a clean cache environment (deployer/CI) will confirm.

## Scope

Also unblocks the `AmgmInequalityOQ02OQ03*` dependency chain (relevant to the missing-`.lean` entries tracked in #34905), though this PR is scoped solely to the parent build fix.

---
Automated fix by lean-mechanic agent.