### PR TITLE
Research: cube-root-3-irrational-oq-02-oq-03 — prove even base case n=2 of Vahlen–Capelli

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
@@ -39,6 +39,7 @@ counterpart in the odd theory.
 | `vahlen_capelli_odd` — full `iff` for odd `n` (wraps Mathlib) | **proved** |
 | `not_irreducible_of_proper_dvd` — proper divisor ⟹ reducible (over a field) | **proved** |
 | `vahlen_capelli_necessity` — necessity for **all** `n` (both parities) | **proved** |
+| `vahlen_capelli` (even `n = 2` base case) — sufficiency via prime Kummer | **proved** |
 
 The two obstruction lemmas assemble into `vahlen_capelli_necessity`: their contrapositive
 shows that if either condition fails, the binomial acquires a proper divisor (degree
@@ -48,9 +49,13 @@ field for **every** `n`.
 ## The remaining gap (the genuine open part)
 
 The `even sufficiency` direction — "conditions (1),(2) hold ⟹ `X^n − C a` irreducible"
-for `4 ∣ n` — is the hard Capelli theorem and is **not** in Mathlib. With necessity now
-fully discharged (all `n`) and the odd `iff` complete, `vahlen_capelli` isolates this single
-`even sufficiency` step as the **sole** remaining `sorry`, with a proof sketch.
+for even `n` — is the hard Capelli theorem and is **not** in Mathlib. With necessity now
+fully discharged (all `n`), the odd `iff` complete, and the **even base case `n = 2` now
+proved** (via Mathlib's prime-exponent criterion `X_pow_sub_C_irreducible_iff_of_prime`,
+whose `4 ∤ 2` makes the `−4·K⁴` obstruction vacuous), `vahlen_capelli` isolates the sole
+remaining `sorry` to **even `n ≥ 4`** — the 2-power / `4 ∣ n` regime where the Sophie-Germain
+obstruction is essential and Mathlib's prime-power criterion
+`X_pow_sub_C_irreducible_iff_of_prime_pow` is restricted to *odd* primes.
 
 ## Mathematical heart: the Sophie Germain identity
 
@@ -292,8 +297,19 @@ theorem vahlen_capelli {K : Type*} [Field K] {n : ℕ} (hn : 1 ≤ n) {a : K} :
   · exact vahlen_capelli_necessity hn
   · intro hcond
     rcases Nat.even_or_odd n with _he | ho
-    · -- even sufficiency: the genuine open gap (Lang VI §9 / Mathlib TODO)
-      sorry
+    · -- even sufficiency
+      by_cases h2 : n = 2
+      · -- base case n = 2 (prime exponent): the 4·K⁴ obstruction cannot occur since 4 ∤ 2,
+        -- so the criterion collapses to condition (1) at p = 2, i.e. `a` is not a square.
+        -- This is Mathlib's prime-exponent Kummer criterion `X_pow_sub_C_irreducible_iff_of_prime`.
+        subst h2
+        have hp2 : Nat.Prime 2 := Nat.prime_two
+        exact (X_pow_sub_C_irreducible_iff_of_prime hp2).mpr (hcond.1 2 hp2 (dvd_refl 2))
+      · -- even `n ≥ 4`: the genuine open gap (Lang VI §9 / Mathlib TODO — 2-power exponents,
+        -- where the `−4·K⁴` Sophie-Germain obstruction is the essential extra content and
+        -- Mathlib's prime-power criterion `X_pow_sub_C_irreducible_iff_of_prime_pow` is
+        -- restricted to odd primes).
+        sorry
     · exact (vahlen_capelli_odd ho).mpr hcond
 
 end CubeRoot3IrrationalOQ02OQ03

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
@@ -22,8 +22,8 @@
     "sorries": 1,
     "dateAdded": "2026-07-04",
     "axiomCount": 0,
-    "assumptions": "Builds cleanly (verified via Docker, 0 axioms). One sorry remains: the even-sufficiency direction of the criterion (conditions (1),(2) ⟹ irreducible for 4 | n), which is an explicit open TODO in Mathlib/FieldTheory/KummerExtension.lean citing Lang, Algebra, VI §9. Everything else is machine-checked: the Sophie Germain identity, both necessity factorizations, the full necessity direction for ALL n (both parities, via vahlen_capelli_necessity), and the complete odd-case iff.",
-    "lineCount": 202,
+    "assumptions": "Builds cleanly (verified via Docker, 0 axioms). One sorry remains: the even-sufficiency direction for even n ≥ 4 (the 2-power / 4|n regime), an explicit open TODO in Mathlib/FieldTheory/KummerExtension.lean citing Lang, Algebra, VI §9. Everything else is machine-checked: the Sophie Germain identity, both necessity factorizations, the full necessity direction for ALL n (both parities), the complete odd-case iff, AND the even base case n=2 (sufficiency via Mathlib's prime-exponent criterion X_pow_sub_C_irreducible_iff_of_prime, whose 4∤2 makes the −4·K⁴ obstruction vacuous).",
+    "lineCount": 315,
     "theoremCount": 7,
     "definitionCount": 1,
     "originalContributions": [


### PR DESCRIPTION
## Summary

Narrows the sole remaining `sorry` in the Vahlen–Capelli formalization (`Proofs/CubeRoot3IrrationalOQ02OQ03.lean`) from **"all even n"** down to **"even n ≥ 4"**, by machine-verifying the even base case `n = 2`.

Since `4 ∤ 2`, the `−4·K⁴` Sophie-Germain obstruction (condition (2)) is vacuous at `n = 2`, so the criterion collapses to condition (1) at `p = 2` — "`a` is not a square" — which is exactly Mathlib's prime-exponent Kummer lemma `X_pow_sub_C_irreducible_iff_of_prime` (valid for `p = 2`). Wired into `vahlen_capelli` via a `by_cases n = 2` split:

```lean
· subst h2
  have hp2 : Nat.Prime 2 := Nat.prime_two
  exact (X_pow_sub_C_irreducible_iff_of_prime hp2).mpr (hcond.1 2 hp2 (dvd_refl 2))
```

## Remaining gap

The residual `sorry` is now scoped to **even `n ≥ 4`** — the genuine 2-power / `4 ∣ n` regime where the Sophie-Germain obstruction is essential and Mathlib's prime-power criterion `X_pow_sub_C_irreducible_iff_of_prime_pow` is **restricted to odd primes** (confirmed this session: its signature requires `p ≠ 2`). This remains the open Mathlib TODO (Lang, *Algebra*, VI §9).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ02OQ03` → **Build succeeded** (3061 jobs, 3.2s)
- Comment-stripped scan: `sorry: 1` (even n ≥ 4), `axiom: 0`, `native_decide: 0`
- Gallery meta `assumptions` updated to reflect the narrowed scope; status stays `formalized`/`wip` (1 sorry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)