### PR TITLE
Enrich Coprime Companion Blocks (CH OQ-01-02-05): add setup annotation

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["companion matrices", "minimal and characteristic polynomials"]
   },
   {
+    "id": "ann-setup-generic-field",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
+    "range": { "startLine": 47, "endLine": 53 },
+    "type": "definition",
+    "title": "Setup: reuse of the parent scaffold over an arbitrary field",
+    "content": "The file opens the two parent namespaces `CayleyHamiltonReductionOQ02OQ01` and `...WIP01`, which supply the sorry-free block-matrix facts `charpoly_companion_block` (= p·q) and `minpoly_companion_block` (= lcm p q) used verbatim below. The single ambient assumption is `variable {F : Type*} [Field F]` — the entire coprime-merge argument is generic over *any* field, not just ℝ or ℚ, because it rests only on the GCD-monoid arithmetic of F[X]. The one instance the individual lemmas add locally is `[DecidableEq F]`, which is exactly what upgrades `F[X]` to a `GCDMonoid` so that `lcm` (and hence `lcm p q`) is available; supplying it is the sole fix that turned the originally build-pending draft into a machine-checked proof.",
+    "mathContext": "$F$ an arbitrary field $\\Rightarrow$ $F[X]$ is a PID and (with $\\mathrm{DecidableEq}\\,F$) a $\\mathrm{GCDMonoid}$, so $\\mathrm{lcm}$, $\\gcd$, and coprimality are all available.",
+    "significance": "supporting",
+    "relatedConcepts": ["field genericity", "GCDMonoid instance", "DecidableEq", "namespace reuse", "PID structure of F[X]"],
+    "prerequisites": ["fields and polynomial rings", "typeclass instances in Lean"]
+  },
+  {
     "id": "ann-lcm-eq-mul",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
     "range": { "startLine": 55, "endLine": 71 },


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05` (0 prior passes, quality 86).

This entry was already richly structured (sections, conclusion, cross-references, references, 4 key insights). The one remaining gap was annotation coverage: 4 annotations, below the 5-annotation minimum, with the file's setup block (lines 47–53) uncovered.

## Change
- Added **`ann-setup-generic-field`** covering the namespace/`variable` block: it explains the reuse of the parent scaffold's sorry-free lemmas (`charpoly_companion_block`, `minpoly_companion_block`) via `open`, the genericity of the whole argument over an arbitrary field `F`, and the role of `[DecidableEq F]` in unlocking the `GCDMonoid F[X]` `lcm` used by the merge.

## Verification
- annotations.json valid JSON, 5 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`
- meta.json unchanged, within all caps; `status: verified` / 0 axioms left accurate
- Single-file diff