### PR TITLE
Enrich Dense Countable Fσ-not-Gδ (alg-numbers OQ-02-03-02-01): 4th keyInsight

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/meta.json
@@ -69,7 +69,8 @@
     "keyInsights": [
       "The 'not Gδ' phenomenon for a dense countable set is entirely topological: it depends only on the ambient space being nonempty, perfect, T1, and Baire — not on ℝ, algebraicity, or any arithmetic.",
       "Density is essential: a countable set that is Fσ-but-not-Gδ must be dense, because the obstruction is exactly that its complement is a competing dense Gδ.",
-      "The abstraction makes the classical placement of ℚ at Borel level Σ⁰₂ ∖ Π⁰₂ a one-line instance, and applies uniformly to any countable dense subset of any perfect Polish space (e.g. ℚⁿ ⊆ ℝⁿ, dyadic rationals in Cantor/Baire space)."
+      "The abstraction makes the classical placement of ℚ at Borel level Σ⁰₂ ∖ Π⁰₂ a one-line instance, and applies uniformly to any countable dense subset of any perfect Polish space (e.g. ℚⁿ ⊆ ℝⁿ, dyadic rationals in Cantor/Baire space).",
+      "A dense countable set is a concrete witness that the Borel hierarchy is proper at level 2 — that Σ⁰₂ ≠ Π⁰₂ — in every perfect Polish space: it lands in Σ⁰₂ (Fσ) but provably escapes Π⁰₂ (Gδ), so the two additive/multiplicative classes genuinely differ. The whole theorem is a pure assembly of three already-verified parent lemmas, contributing no new mathematics beyond isolating the exact typeclass hypotheses that make the Baire obstruction fire."
     ],
     "prerequisites": [
       "Baire category theorem; meagre and comeagre sets",


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01` (0 prior passes, quality 87).

Already richly structured (sections, conclusion, cross-references, references, a theorems array, 4 well-annotated code ranges). The one field below the quality minimum was `overview.keyInsights` at 3 items.

## Change
- Added a 4th key insight: a dense countable set is a **concrete witness that the Borel hierarchy is proper at level 2** (Σ⁰₂ ≠ Π⁰₂) in every perfect Polish space — it lands in Σ⁰₂ (Fσ) but provably escapes Π⁰₂ (Gδ) — and the whole theorem is a pure assembly of three already-verified parent lemmas, isolating exactly the typeclass hypotheses that make the Baire obstruction fire.

## Verification
- meta.json valid JSON, 11.5 KB (within all caps; keyInsights now 4, per-item under cap)
- `status: verified` / 0 axioms unchanged and accurate
- Single-file diff