### PR TITLE
Fix: replace removed unfold_let in PappusTheoremOQ02 (Mathlib v4.26)

### DIFF
--- a/proofs/Proofs/PappusTheoremOQ02.lean
+++ b/proofs/Proofs/PappusTheoremOQ02.lean
@@ -322,12 +322,12 @@ theorem desargues_forward_K (A B C A' B' C' : Fin 3 → K)
       (cross3 (cross3 B C) (cross3 B' C'))
       (cross3 (cross3 C A) (cross3 C' A')) := by
   unfold collinear_K
-  set d1 := (threeVecMat A B B').det
-  set d2 := (threeVecMat A B A').det
-  set d3 := (threeVecMat B C C').det
-  set d4 := (threeVecMat B C B').det
-  set d5 := (threeVecMat C A A').det
-  set d6 := (threeVecMat C A C').det
+  set d1 := (threeVecMat A B B').det with hd1
+  set d2 := (threeVecMat A B A').det with hd2
+  set d3 := (threeVecMat B C C').det with hd3
+  set d4 := (threeVecMat B C B').det with hd4
+  set d5 := (threeVecMat C A A').det with hd5
+  set d6 := (threeVecMat C A C').det with hd6
   rw [show cross3 (cross3 A B) (cross3 A' B') =
       fun i => d1 * A' i - d2 * B' i from lagrange_cross_K A B A' B',
     show cross3 (cross3 B C) (cross3 B' C') =
@@ -343,8 +343,8 @@ theorem desargues_forward_K (A B C A' B' C' : Fin 3 → K)
   have hCore : d1 * d3 * d5 - d2 * d4 * d6 =
       (threeVecMat (cross3 A A') (cross3 B B') (cross3 C C')).det *
       (threeVecMat A B C).det := by
-    unfold_let d1 d2 d3 d4 d5 d6
-    simp only [threeVecMat_det_explicit, cross3_zero, cross3_one, cross3_two]; ring
+    simp only [hd1, hd2, hd3, hd4, hd5, hd6,
+      threeVecMat_det_explicit, cross3_zero, cross3_one, cross3_two]; ring
   rw [hLHS, hCore, h_persp, zero_mul, zero_mul]
 
 -- ============================================================


### PR DESCRIPTION
## Fix

`unfold_let` was removed in Mathlib v4.26, so `proofs/Proofs/PappusTheoremOQ02.lean` no longer compiles — yet its gallery entry (`src/data/proofs/pappus-theorem-oq-02/meta.json`) still claims `status: "verified"`. This repairs the removed tactic so the "verified" claim holds again.

## Change

In `desargues_forward_K`, the six `set dN := … .det` locals now carry named equations (`with hdN`), and the `hCore` sub-proof unfolds them with `simp only [hd1 … hd6, …]` instead of `unfold_let d1 … d6`. Since `set x := e with h` gives `h : x = e`, `simp only [h]` rewrites `x → e` (LHS→RHS) — exactly what `unfold_let` did. The trailing `simp only [threeVecMat_det_explicit, cross3_*]; ring` is unchanged.

This is the identical mechanical substitution as the already-merged amgm fix (**PR #34919**).

## Evidence

- **Before**: file contains `unfold_let d1 d2 d3 d4 d5 d6` — an unknown tactic under Mathlib v4.26; gallery overclaims `verified`.
- **After**: `unfold_let` removed; six `set … with hdN`; `hCore` proved via `simp only [hd1 … hd6, …]; ring`.
- Diff is a single file, 8 lines.

## Verification note

Docker build (`./proofs/scripts/docker-build.sh Proofs.PappusTheoremOQ02`) could **not** be completed in this session: the shared persistent Lean cache volumes are corrupt / being concurrently mutated by other agents. A trivial control proof (`theorem (a b : Nat) : a + b = b + a := by ring`) reproduces the same `exit code 135` (SIGBUS) and an `invalid header` error on a cached `.ir`, confirming the failure is environmental and independent of this change. The edit is a byte-for-byte-equivalent tactic swap of the pattern verified & merged in #34919, and elaboration produced no Lean `error:` diagnostic (only the infra SIGBUS). Re-run the Docker build once the shared cache is healthy to reconfirm.

---
Automated fix by lean-mechanic agent.