### PR TITLE
Research: Binary Error-and-Erasure Channel (BEEC) capacity VERIFIED — unifies BEC + BSC

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingBECOQ04.lean
+++ b/proofs/Proofs/ShannonChannelCodingBECOQ04.lean
@@ -1,0 +1,431 @@
+/-
+  Binary Error-and-Erasure Channel (BEEC) Capacity
+
+  Open question (shannon-channel-coding-bec OQ-04): extend the binary erasure
+  channel to a channel with **both erasures and errors** — the binary
+  error-and-erasure channel BEEC(ε, q).
+
+  Model.  Input `Bool`, output `Option Bool` (`none` = erasure). Each symbol is
+  erased with probability `ε`; if it is *not* erased (probability `1 - ε`) it is
+  transmitted through a binary symmetric channel with crossover probability `q`
+  (flipped with probability `q`, correct with probability `1 - q`):
+
+      W x none        = ε
+      W x (some x)    = (1 - ε)·(1 - q)          -- delivered, correct
+      W x (some ¬x)   = (1 - ε)·q                -- delivered, flipped
+
+  This is the natural common generalisation of the two channels already in the
+  gallery:
+
+    * `q = 0` (no errors)     →  BEEC = BEC,  capacity `(1 - ε)·log 2`
+      (`ShannonChannelCodingBEC.bec_capacity`).
+    * `ε = 0` (no erasures)   →  BEEC = BSC,  capacity `log 2 - h(q)`
+      (`ShannonChannelCodingOQ02.bsc_capacity_proved`).
+
+  **Main result** (`beec_capacity`, 0 axioms, 0 sorries):
+
+      C(BEEC(ε, q)) = (1 - ε)·(log 2 - h(q))   nats.
+
+  Proof engine, following the BSC development:
+  1.  `H(Y|X) = h(ε) + (1 - ε)·h(q)` for *every* input distribution
+      (`beec_conditional_output_entropy`): the per-input output law
+      `(ε, (1-ε)(1-q), (1-ε)q)` is the same for both inputs.
+  2.  Chain rule `I(X;Y) = H(Y) - H(Y|X)` (`mi_eq_hY_sub_hYgivenX`).
+  3.  Achievability: the uniform input gives `H(Y) = h(ε) + (1-ε)·log 2`, hence
+      `I = (1-ε)(log 2 - h(q))` (`beec_uniform_mi`).
+  4.  Converse: for *any* input the output marginal has a fixed erasure mass `ε`,
+      so `H(Y) = h(ε) + (1-ε)·H₂(·) ≤ h(ε) + (1-ε)·log 2`
+      (`beec_ymarg_entropy_le`, via the grouping bound `mul_log_pair_ge`).
+
+  Both degenerations `q → 0` and `ε → 0` of the capacity formula are recorded as
+  `beec_capacity_eq_bec_formula` / `beec_capacity_eq_bsc_formula`.
+
+  Claude Shannon (1948).
+
+  Axioms: 0
+  Sorries: 0
+-/
+import Mathlib
+import Proofs.ShannonChannelCoding
+import Proofs.ShannonChannelCodingOQ02
+import Proofs.ShannonChannelCodingOQ04
+import Proofs.ShannonChannelCodingBEC
+
+open Real Finset InformationTheory InformationTheory.ChannelCoding
+open InformationTheory.BinaryEntropy
+
+namespace InformationTheory.ChannelCoding.BEEC
+
+/-! ## An elementary two-point log inequality (grouping bound engine)
+
+For positive `a, b`, the "pooled" term `(a+b)·log((a+b)/2)` is a lower bound for
+`a·log a + b·log b`. Equivalently, the binary entropy of the split `(a, b)` is at
+most `log 2`. This is the only inequality needed for the converse. -/
+
+/-- **Two-point log bound.** For `a, b > 0`,
+`(a + b)·log((a+b)/2) ≤ a·log a + b·log b`.
+Rearranged, this says the binary entropy `H₂(a/(a+b)) ≤ log 2`. -/
+lemma mul_log_pair_ge {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
+    (a + b) * Real.log ((a + b) / 2) ≤ a * Real.log a + b * Real.log b := by
+  have hs : (0 : ℝ) < a + b := by linarith
+  have hne : a + b ≠ 0 := hs.ne'
+  have hu0 : 0 < a / (a + b) := div_pos ha hs
+  have hu1 : a / (a + b) < 1 := (div_lt_one hs).mpr (by linarith)
+  have h1u : 1 - a / (a + b) = b / (a + b) := by
+    rw [← div_self hne, div_sub_div_same]; congr 1; ring
+  have hh : InformationTheory.BinaryEntropy.h (a / (a + b)) ≤ Real.log 2 :=
+    InformationTheory.BinaryEntropy.h_le_log_two hu0.le hu1.le
+  have hlu : Real.log (a / (a + b)) = Real.log a - Real.log (a + b) :=
+    Real.log_div ha.ne' hne
+  have hl1u : Real.log (b / (a + b)) = Real.log b - Real.log (a + b) :=
+    Real.log_div hb.ne' hne
+  -- Recast `a log a + b log b` through the binary entropy of the split.
+  have key : a * Real.log a + b * Real.log b
+      = (a + b) * Real.log (a + b)
+        - (a + b) * InformationTheory.BinaryEntropy.h (a / (a + b)) := by
+    rw [InformationTheory.BinaryEntropy.h, h1u, hlu, hl1u]
+    field_simp
+    ring
+  have hls2 : Real.log ((a + b) / 2) = Real.log (a + b) - Real.log 2 :=
+    Real.log_div hne (by norm_num)
+  rw [key, hls2]
+  nlinarith [mul_le_mul_of_nonneg_left hh hs.le]
+
+/-! ## The binary error-and-erasure channel -/
+
+/-- The binary error-and-erasure channel `BEEC(ε, q)`: input `Bool`, output
+    `Option Bool` (`none` = erasure). Erased with probability `ε`; otherwise
+    passed through a BSC with crossover probability `q`. -/
+noncomputable def beec (ε q : ℝ) (hε0 : 0 ≤ ε) (hε1 : ε ≤ 1)
+    (hq0 : 0 ≤ q) (hq1 : q ≤ 1) : DMChannel Bool (Option Bool) where
+  W := fun x o =>
+    match o with
+    | none => ε
+    | some y => if x = y then (1 - ε) * (1 - q) else (1 - ε) * q
+  nonneg := fun x o => by
+    cases o with
+    | none => exact hε0
+    | some y =>
+        dsimp only
+        split_ifs <;> exact mul_nonneg (by linarith) (by linarith)
+  sum_one := fun x => by
+    rw [Fintype.sum_option, Fintype.sum_bool]
+    cases x <;> · dsimp only; simp only [reduceIte, reduceCtorEq]; ring
+
+@[simp] lemma beec_W_none {ε q : ℝ} (hε0 : 0 ≤ ε) (hε1 : ε ≤ 1)
+    (hq0 : 0 ≤ q) (hq1 : q ≤ 1) (x : Bool) :
+    (beec ε q hε0 hε1 hq0 hq1).W x none = ε := rfl
+
+@[simp] lemma beec_W_some {ε q : ℝ} (hε0 : 0 ≤ ε) (hε1 : ε ≤ 1)
+    (hq0 : 0 ≤ q) (hq1 : q ≤ 1) (x y : Bool) :
+    (beec ε q hε0 hε1 hq0 hq1).W x (some y)
+      = if x = y then (1 - ε) * (1 - q) else (1 - ε) * q := rfl
+
+/-- Every transition probability is strictly positive for `0 < ε < 1`,
+    `0 < q < 1`. -/
+lemma beec_W_pos {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1) (hq0 : 0 < q) (hq1 : q < 1)
+    (x : Bool) (o : Option Bool) :
+    0 < (beec ε q hε0.le hε1.le hq0.le hq1.le).W x o := by
+  cases o with
+  | none => exact hε0
+  | some y =>
+      simp only [beec_W_some]
+      split_ifs <;> exact mul_pos (by linarith) (by linarith)
+
+/-! ## Output marginals -/
+
+/-- The erasure (`none`) output marginal is `ε` for every input distribution. -/
+lemma beec_ymarg_none {ε q : ℝ} (hε0 : 0 ≤ ε) (hε1 : ε ≤ 1)
+    (hq0 : 0 ≤ q) (hq1 : q ≤ 1) (inp : InputDist Bool) :
+    (∑ x' : Bool, jointDist (beec ε q hε0 hε1 hq0 hq1) inp (x', none)) = ε := by
+  simp only [jointDist, beec_W_none]
+  rw [← Finset.sum_mul, inp.sum_one, one_mul]
+
+/-- The un-erased marginal `P(Y = some y) = (1 - ε)·(p(y)(1-q) + p(¬y) q)`. -/
+lemma beec_ymarg_some {ε q : ℝ} (hε0 : 0 ≤ ε) (hε1 : ε ≤ 1)
+    (hq0 : 0 ≤ q) (hq1 : q ≤ 1) (inp : InputDist Bool) (y : Bool) :
+    (∑ x' : Bool, jointDist (beec ε q hε0 hε1 hq0 hq1) inp (x', some y))
+      = (1 - ε) * (inp.p y * (1 - q) + inp.p (!y) * q) := by
+  simp only [jointDist, beec_W_some]
+  rw [Fintype.sum_bool]
+  cases y <;> · simp <;> ring
+
+/-! ## Conditional output entropy `H(Y|X) = h(ε) + (1-ε)·h(q)` -/
+
+/-- The per-input output "energy" `∑_o W(x,o)·log W(x,o)` is the same for both
+    inputs and equals `ε·log ε + (1-ε)(1-q)·log((1-ε)(1-q)) + (1-ε)q·log((1-ε)q)`. -/
+lemma beec_output_entropy_per_input {ε q : ℝ} (hε0 : 0 ≤ ε) (hε1 : ε ≤ 1)
+    (hq0 : 0 ≤ q) (hq1 : q ≤ 1) (x : Bool) :
+    ∑ o : Option Bool, (beec ε q hε0 hε1 hq0 hq1).W x o *
+        Real.log ((beec ε q hε0 hε1 hq0 hq1).W x o)
+      = ε * Real.log ε
+        + (1 - ε) * (1 - q) * Real.log ((1 - ε) * (1 - q))
+        + (1 - ε) * q * Real.log ((1 - ε) * q) := by
+  rw [Fintype.sum_option, Fintype.sum_bool]
+  simp only [beec_W_none, beec_W_some]
+  cases x <;> · simp only [if_true, if_false, Bool.true_eq_false, Bool.false_eq_true,
+    reduceCtorEq]; ring
+
+/-- The negated per-input energy is exactly `h(ε) + (1-ε)·h(q)`. -/
+lemma neg_output_energy_eq {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1)
+    (hq0 : 0 < q) (hq1 : q < 1) :
+    -(ε * Real.log ε
+        + (1 - ε) * (1 - q) * Real.log ((1 - ε) * (1 - q))
+        + (1 - ε) * q * Real.log ((1 - ε) * q))
+      = InformationTheory.BinaryEntropy.h ε
+        + (1 - ε) * InformationTheory.BinaryEntropy.h q := by
+  have h1e : (0 : ℝ) < 1 - ε := by linarith
+  have h1q : (0 : ℝ) < 1 - q := by linarith
+  rw [Real.log_mul h1e.ne' h1q.ne', Real.log_mul h1e.ne' hq0.ne']
+  simp only [InformationTheory.BinaryEntropy.h]
+  ring
+
+/-- **H(Y|X) = h(ε) + (1-ε)·h(q)** for any positive input distribution.
+    Mirrors `bsc_conditional_output_entropy`. -/
+theorem beec_conditional_output_entropy {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1)
+    (hq0 : 0 < q) (hq1 : q < 1)
+    (inp : InputDist Bool) (hinp : ∀ b, 0 < inp.p b) :
+    conditionalEntropy
+        (transposeJoint (jointDist (beec ε q hε0.le hε1.le hq0.le hq1.le) inp))
+      = InformationTheory.BinaryEntropy.h ε
+        + (1 - ε) * InformationTheory.BinaryEntropy.h q := by
+  set ch := beec ε q hε0.le hε1.le hq0.le hq1.le with hch_def
+  unfold conditionalEntropy transposeJoint jointDist
+  dsimp only
+  have hne : ∀ (b : Bool) (a : Option Bool), inp.p b * ch.W b a ≠ 0 :=
+    fun b a => ne_of_gt (mul_pos (hinp b) (beec_W_pos hε0 hε1 hq0 hq1 b a))
+  have hden : ∀ b : Bool, ∑ a' : Option Bool, inp.p b * ch.W b a' = inp.p b :=
+    fun b => by rw [← Finset.mul_sum, ch.sum_one, mul_one]
+  have hterm : ∀ (a : Option Bool) (b : Bool),
+      (if inp.p b * ch.W b a = 0 then (0 : ℝ)
+       else inp.p b * ch.W b a *
+         Real.log (inp.p b * ch.W b a / (∑ a' : Option Bool, inp.p b * ch.W b a'))) =
+      inp.p b * (ch.W b a * Real.log (ch.W b a)) := by
+    intro a b
+    rw [if_neg (hne b a), hden b, mul_div_cancel_left₀ _ (ne_of_gt (hinp b))]
+    ring
+  simp_rw [hterm]
+  rw [Finset.sum_comm]
+  simp_rw [← Finset.mul_sum]
+  simp_rw [hch_def, beec_output_entropy_per_input hε0.le hε1.le hq0.le hq1.le]
+  rw [← Finset.sum_mul, inp.sum_one, one_mul]
+  exact neg_output_energy_eq hε0 hε1 hq0 hq1
+
+/-! ## Mutual information -/
+
+/-- **Achievability.** The uniform input yields
+    `I(X;Y) = (1 - ε)·(log 2 - h(q))`. -/
+theorem beec_uniform_mi {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1)
+    (hq0 : 0 < q) (hq1 : q < 1) :
+    channelMI (beec ε q hε0.le hε1.le hq0.le hq1.le) BSCCapacity.uniformBool
+      = (1 - ε) * (Real.log 2 - InformationTheory.BinaryEntropy.h q) := by
+  set ch := beec ε q hε0.le hε1.le hq0.le hq1.le with hch_def
+  unfold channelMI
+  have hjoint_nn : ∀ xy, 0 ≤ jointDist ch BSCCapacity.uniformBool xy :=
+    fun xy => le_of_lt (mul_pos (BSCCapacity.uniformBool_pos xy.1)
+      (beec_W_pos hε0 hε1 hq0 hq1 xy.1 xy.2))
+  have hjoint_sum := jointDist_sum_one ch BSCCapacity.uniformBool
+  rw [BSCCapacity.mi_eq_hY_sub_hYgivenX hjoint_nn hjoint_sum,
+      beec_conditional_output_entropy hε0 hε1 hq0 hq1 BSCCapacity.uniformBool
+        BSCCapacity.uniformBool_pos]
+  have h1e : (0 : ℝ) < 1 - ε := by linarith
+  have hhalf : (1 - ε) / 2 ≠ 0 := by positivity
+  have huni : BSCCapacity.uniformBool.p = fun _ => (1 : ℝ) / 2 := rfl
+  have e_none : (∑ x : Bool, jointDist ch BSCCapacity.uniformBool (x, none)) = ε :=
+    beec_ymarg_none hε0.le hε1.le hq0.le hq1.le BSCCapacity.uniformBool
+  have e_false : (∑ x : Bool, jointDist ch BSCCapacity.uniformBool (x, some false)) = (1 - ε) / 2 := by
+    rw [beec_ymarg_some hε0.le hε1.le hq0.le hq1.le BSCCapacity.uniformBool false, huni]; ring
+  have e_true : (∑ x : Bool, jointDist ch BSCCapacity.uniformBool (x, some true)) = (1 - ε) / 2 := by
+    rw [beec_ymarg_some hε0.le hε1.le hq0.le hq1.le BSCCapacity.uniformBool true, huni]; ring
+  have hls2 : Real.log ((1 - ε) / 2) = Real.log (1 - ε) - Real.log 2 :=
+    Real.log_div h1e.ne' (by norm_num)
+  -- Compute `H(Y) = h(ε) + (1-ε)·log 2` for the uniform marginal.
+  have hHY : shannonEntropy (fun o => ∑ x : Bool, jointDist ch BSCCapacity.uniformBool (x, o))
+      = InformationTheory.BinaryEntropy.h ε + (1 - ε) * Real.log 2 := by
+    unfold shannonEntropy
+    rw [Fintype.sum_option, Fintype.sum_bool]
+    dsimp only
+    rw [e_none, e_false, e_true, if_neg hε0.ne', if_neg hhalf, hls2]
+    simp only [InformationTheory.BinaryEntropy.h]
+    ring
+  rw [hHY]
+  ring
+
+/-- **Converse (positive input).** For any input with full support,
+    `I(X;Y) ≤ (1 - ε)·(log 2 - h(q))`. -/
+theorem beec_mi_le {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1) (hq0 : 0 < q) (hq1 : q < 1)
+    (inp : InputDist Bool) (hinp : ∀ b, 0 < inp.p b) :
+    channelMI (beec ε q hε0.le hε1.le hq0.le hq1.le) inp
+      ≤ (1 - ε) * (Real.log 2 - InformationTheory.BinaryEntropy.h q) := by
+  set ch := beec ε q hε0.le hε1.le hq0.le hq1.le with hch_def
+  unfold channelMI
+  have hjoint_nn : ∀ xy, 0 ≤ jointDist ch inp xy :=
+    fun xy => le_of_lt (mul_pos (hinp xy.1) (beec_W_pos hε0 hε1 hq0 hq1 xy.1 xy.2))
+  have hjoint_sum := jointDist_sum_one ch inp
+  rw [BSCCapacity.mi_eq_hY_sub_hYgivenX hjoint_nn hjoint_sum,
+      beec_conditional_output_entropy hε0 hε1 hq0 hq1 inp hinp]
+  have h1e : (0 : ℝ) < 1 - ε := by linarith
+  have h1q : (0 : ℝ) < 1 - q := by linarith
+  -- Abbreviations for the un-erased marginals.
+  set a := (1 - ε) * (inp.p true * (1 - q) + inp.p false * q) with ha_def
+  set b := (1 - ε) * (inp.p false * (1 - q) + inp.p true * q) with hb_def
+  have hapos : 0 < a := by
+    rw [ha_def]; exact mul_pos h1e (by nlinarith [hinp true, hinp false])
+  have hbpos : 0 < b := by
+    rw [hb_def]; exact mul_pos h1e (by nlinarith [hinp true, hinp false])
+  have e_none : (∑ x : Bool, jointDist ch inp (x, none)) = ε :=
+    beec_ymarg_none hε0.le hε1.le hq0.le hq1.le inp
+  have e_false : (∑ x : Bool, jointDist ch inp (x, some false)) = b := by
+    rw [beec_ymarg_some hε0.le hε1.le hq0.le hq1.le inp false, hb_def]; simp
+  have e_true : (∑ x : Bool, jointDist ch inp (x, some true)) = a := by
+    rw [beec_ymarg_some hε0.le hε1.le hq0.le hq1.le inp true, ha_def]; simp
+  -- Total mass: `ε + a + b = 1`, hence `a + b = 1 - ε`.
+  have hsum : a + b = 1 - ε := by
+    have h := inp.sum_one
+    rw [Fintype.sum_bool] at h
+    rw [ha_def, hb_def]; nlinarith [h]
+  -- `H(Y) = -(ε log ε + b log b + a log a)`.
+  have hHY : shannonEntropy (fun o => ∑ x : Bool, jointDist ch inp (x, o))
+      = -(ε * Real.log ε + (b * Real.log b + a * Real.log a)) := by
+    unfold shannonEntropy
+    rw [Fintype.sum_option, Fintype.sum_bool]
+    dsimp only
+    rw [e_none, e_false, e_true, if_neg hε0.ne', if_neg hbpos.ne', if_neg hapos.ne']
+    ring
+  -- Converse bound `H(Y) ≤ h(ε) + (1-ε) log 2` via the grouping inequality.
+  have hHY_le : shannonEntropy (fun o => ∑ x : Bool, jointDist ch inp (x, o))
+      ≤ InformationTheory.BinaryEntropy.h ε + (1 - ε) * Real.log 2 := by
+    rw [hHY]
+    have hgroup := mul_log_pair_ge hapos hbpos
+    rw [hsum] at hgroup
+    have hls2 : Real.log ((1 - ε) / 2) = Real.log (1 - ε) - Real.log 2 :=
+      Real.log_div h1e.ne' (by norm_num)
+    rw [hls2] at hgroup
+    simp only [InformationTheory.BinaryEntropy.h]
+    nlinarith [hgroup]
+  rw [show (1 - ε) * (Real.log 2 - InformationTheory.BinaryEntropy.h q)
+        = (1 - ε) * Real.log 2 - (1 - ε) * InformationTheory.BinaryEntropy.h q from by ring]
+  linarith [hHY_le]
+
+/-- **Converse (all inputs).** `I(X;Y) ≤ (1 - ε)·(log 2 - h(q))` for every input
+    distribution, including degenerate (point-mass) ones. -/
+theorem beec_mi_le_general {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1)
+    (hq0 : 0 < q) (hq1 : q < 1) (inp : InputDist Bool) :
+    channelMI (beec ε q hε0.le hε1.le hq0.le hq1.le) inp
+      ≤ (1 - ε) * (Real.log 2 - InformationTheory.BinaryEntropy.h q) := by
+  by_cases h : ∀ b, 0 < inp.p b
+  · exact beec_mi_le hε0 hε1 hq0 hq1 inp h
+  · push_neg at h
+    obtain ⟨b₀, hb₀⟩ := h
+    have hb₀_eq : inp.p b₀ = 0 := le_antisymm hb₀ (inp.nonneg b₀)
+    set ch := beec ε q hε0.le hε1.le hq0.le hq1.le
+    have hjoint_nn : ∀ xy, 0 ≤ jointDist ch inp xy :=
+      fun xy => mul_nonneg (inp.nonneg xy.1) (ch.nonneg xy.1 xy.2)
+    have hjoint_sum := jointDist_sum_one ch inp
+    -- MI ≤ H(X) by the chain rule, and H(X) = 0 for a point mass.
+    have hMI_le_HX : mutualInformation (jointDist ch inp) ≤
+        shannonEntropy (fun x => ∑ y : Option Bool, jointDist ch inp (x, y)) := by
+      have hchain := chain_rule hjoint_nn hjoint_sum
+      have hcond := conditionalEntropy_nonneg hjoint_nn hjoint_sum
+      linarith
+    have hxmarg : (fun x => ∑ y : Option Bool, jointDist ch inp (x, y)) = inp.p := by
+      ext x
+      simp only [jointDist, ← Finset.mul_sum, ch.sum_one, mul_one]
+    rw [hxmarg] at hMI_le_HX
+    have hpoint : ∀ x : Bool, x ≠ !b₀ → inp.p x = 0 := by
+      intro x hx; cases b₀ <;> cases x <;> simp_all
+    have hent_zero : shannonEntropy inp.p = 0 :=
+      entropy_point_mass inp.nonneg inp.sum_one hpoint
+    rw [hent_zero] at hMI_le_HX
+    unfold channelMI
+    have hqle : InformationTheory.BinaryEntropy.h q ≤ Real.log 2 :=
+      InformationTheory.BinaryEntropy.h_le_log_two hq0.le hq1.le
+    have h1e : (0 : ℝ) ≤ 1 - ε := by linarith
+    nlinarith [hMI_le_HX, mul_nonneg h1e (sub_nonneg.mpr hqle)]
+
+/-! ## Capacity -/
+
+/-- **BEEC capacity = (1 - ε)·(log 2 - h(q)).**
+    The binary error-and-erasure channel `BEEC(ε, q)` has capacity
+    `(1 - ε)·(log 2 - h(q))` nats, proven from first principles with no axioms.
+    Every input gives `I ≤ (1-ε)(log 2 - h(q))`, and the uniform input attains
+    the bound. -/
+theorem beec_capacity {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1) (hq0 : 0 < q) (hq1 : q < 1) :
+    channelCapacity (beec ε q hε0.le hε1.le hq0.le hq1.le)
+      = (1 - ε) * (Real.log 2 - InformationTheory.BinaryEntropy.h q) := by
+  unfold channelCapacity
+  apply le_antisymm
+  · apply csSup_le
+    · exact ⟨_, BSCCapacity.uniformBool, rfl⟩
+    · rintro r ⟨inp, rfl⟩; exact beec_mi_le_general hε0 hε1 hq0 hq1 inp
+  · apply le_csSup
+    · exact ⟨Real.log (Fintype.card (Option Bool)),
+        fun _ ⟨inp, hr⟩ => hr ▸ channelMI_le_log_card _ _⟩
+    · exact ⟨BSCCapacity.uniformBool, beec_uniform_mi hε0 hε1 hq0 hq1⟩
+
+/-- BEEC capacity in bits: `C₂(BEEC(ε, q)) = (1 - ε)·(1 - h₂(q))`. -/
+theorem beec_capacity_bits {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1) (hq0 : 0 < q) (hq1 : q < 1) :
+    channelCapacity (beec ε q hε0.le hε1.le hq0.le hq1.le) / Real.log 2
+      = (1 - ε) * (1 - InformationTheory.BinaryEntropy.h q / Real.log 2) := by
+  rw [beec_capacity hε0 hε1 hq0 hq1]
+  have hlog2 : Real.log 2 ≠ 0 := (Real.log_pos (by norm_num)).ne'
+  rw [mul_div_assoc]
+  congr 1
+  rw [sub_div, div_self hlog2]
+
+/-- BEEC capacity is non-negative. -/
+theorem beec_capacity_nonneg {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1)
+    (hq0 : 0 < q) (hq1 : q < 1) :
+    0 ≤ channelCapacity (beec ε q hε0.le hε1.le hq0.le hq1.le) := by
+  rw [beec_capacity hε0 hε1 hq0 hq1]
+  have hqle : InformationTheory.BinaryEntropy.h q ≤ Real.log 2 :=
+    InformationTheory.BinaryEntropy.h_le_log_two hq0.le hq1.le
+  have h1e : (0 : ℝ) ≤ 1 - ε := by linarith
+  exact mul_nonneg h1e (by linarith)
+
+/-- BEEC capacity is at most `(1 - ε)·log 2` (the BEC capacity): adding errors
+    can only reduce capacity relative to pure erasures. -/
+theorem beec_capacity_le_bec {ε q : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1)
+    (hq0 : 0 < q) (hq1 : q < 1) :
+    channelCapacity (beec ε q hε0.le hε1.le hq0.le hq1.le) ≤ (1 - ε) * Real.log 2 := by
+  rw [beec_capacity hε0 hε1 hq0 hq1]
+  have hqnn : 0 ≤ InformationTheory.BinaryEntropy.h q :=
+    InformationTheory.BinaryEntropy.h_nonneg hq0.le hq1.le
+  have h1e : (0 : ℝ) ≤ 1 - ε := by linarith
+  nlinarith [mul_nonneg h1e hqnn]
+
+/-! ## Unification with the BEC and BSC capacities
+
+The capacity formula degenerates to the two channels already in the gallery.
+These are the *formula-level* limits (the channels `beec ε 0 _` and `beec 0 q _`
+lie on the boundary of the strict-parameter regime, so we record the algebraic
+identity of the capacity expressions). -/
+
+/-- **No-error limit `q → 0`:** the BEEC capacity formula becomes the BEC formula
+    `(1 - ε)·log 2` (cf. `ShannonChannelCodingBEC.bec_capacity`). -/
+theorem beec_capacity_eq_bec_formula (ε : ℝ) :
+    (1 - ε) * (Real.log 2 - InformationTheory.BinaryEntropy.h 0) = (1 - ε) * Real.log 2 := by
+  rw [InformationTheory.BinaryEntropy.h_zero]; ring
+
+/-- **No-erasure limit `ε → 0`:** the BEEC capacity formula becomes the BSC
+    formula `log 2 - h(q)` (cf. `ShannonChannelCodingOQ02.bsc_capacity_proved`). -/
+theorem beec_capacity_eq_bsc_formula (q : ℝ) :
+    (1 - 0) * (Real.log 2 - InformationTheory.BinaryEntropy.h q)
+      = Real.log 2 - InformationTheory.BinaryEntropy.h q := by
+  ring
+
+/-- **Useless-BSC limit `q → 1/2`:** when the un-erased sub-channel is a fair coin
+    the whole channel carries no information: capacity `= 0`. -/
+theorem beec_capacity_eq_zero_at_half (ε : ℝ) :
+    (1 - ε) * (Real.log 2 - InformationTheory.BinaryEntropy.h (1 / 2)) = 0 := by
+  rw [InformationTheory.BinaryEntropy.h_half]; ring
+
+-- Axiom audit: the BEEC capacity result is proved from first principles.
+-- (The parent `ShannonChannelCoding` import carries `channel_coding_achievability`
+-- and `channel_coding_converse` in scope, but the capacity value below does not
+-- invoke them.)
+#print axioms beec_capacity
+#print axioms beec_uniform_mi
+#print axioms beec_mi_le_general
+
+end InformationTheory.ChannelCoding.BEEC

--- a/src/data/proofs/shannon-channel-coding-bec-oq-04/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-beec-grouping",
+    "proofId": "shannon-channel-coding-bec-oq-04",
+    "range": { "startLine": 60, "endLine": 91 },
+    "type": "technique",
+    "title": "The Two-Point Log Inequality",
+    "content": "mul_log_pair_ge proves (a+b)·log((a+b)/2) ≤ a·log a + b·log b for a, b > 0. Setting u = a/(a+b), it recasts a·log a + b·log b = (a+b)·log(a+b) - (a+b)·H₂(u) and invokes the binary entropy bound H₂(u) ≤ log 2. This is the single inequality the converse of the capacity theorem depends on; everything else is an identity.",
+    "mathContext": "$(a+b)\\log\\tfrac{a+b}{2} \\le a\\log a + b\\log b \\iff H_2\\!\\left(\\tfrac{a}{a+b}\\right) \\le \\log 2$",
+    "significance": "supporting",
+    "relatedConcepts": ["binary entropy", "Jensen inequality", "log-sum inequality", "concavity of entropy"],
+    "prerequisites": ["binary entropy function h(p)", "h ≤ log 2"]
+  },
+  {
+    "id": "ann-beec-channel",
+    "proofId": "shannon-channel-coding-bec-oq-04",
+    "range": { "startLine": 93, "endLine": 135 },
+    "type": "definition",
+    "title": "The Binary Error-and-Erasure Channel BEEC(ε, q)",
+    "content": "beec : DMChannel Bool (Option Bool) erases each symbol with probability ε (W x none = ε) and otherwise passes it through a BSC with crossover q: W x (some y) = (1-ε)(1-q) when x = y (delivered correctly) and (1-ε)q when x ≠ y (delivered flipped). The rows sum to ε + (1-ε)(1-q) + (1-ε)q = ε + (1-ε) = 1. Setting q = 0 recovers the BEC; setting ε = 0 recovers the BSC.",
+    "mathContext": "$W(?\\mid x)=\\varepsilon,\\ W(x\\mid x)=(1-\\varepsilon)(1-q),\\ W(\\bar x\\mid x)=(1-\\varepsilon)q$",
+    "significance": "supporting",
+    "relatedConcepts": ["discrete memoryless channel", "erasure channel", "binary symmetric channel", "packet loss with noise"],
+    "prerequisites": ["DMChannel structure", "binary erasure channel", "binary symmetric channel"]
+  },
+  {
+    "id": "ann-beec-conditional-entropy",
+    "proofId": "shannon-channel-coding-bec-oq-04",
+    "range": { "startLine": 153, "endLine": 211 },
+    "type": "key-step",
+    "title": "Constant Conditional Output Entropy H(Y|X) = h(ε) + (1-ε)·h(q)",
+    "content": "Because the per-input output law (ε, (1-ε)(1-q), (1-ε)q) is identical for both inputs, the conditional output entropy is a constant independent of the input distribution. Expanding the log-products log((1-ε)(1-q)) = log(1-ε)+log(1-q) etc. collects the terms into h(ε) + (1-ε)·h(q): the entropy of the erasure coin plus the surviving fraction times the BSC noise entropy.",
+    "mathContext": "$H(Y\\mid X) = h(\\varepsilon) + (1-\\varepsilon)\\,h(q)$",
+    "significance": "critical",
+    "relatedConcepts": ["conditional entropy", "symmetric channel", "chain rule for mutual information"],
+    "prerequisites": ["conditional entropy on the transposed joint distribution", "binary entropy function"]
+  },
+  {
+    "id": "ann-beec-capacity",
+    "proofId": "shannon-channel-coding-bec-oq-04",
+    "range": { "startLine": 352, "endLine": 401 },
+    "type": "theorem",
+    "title": "BEEC Capacity = (1-ε)·(log 2 - h(q))",
+    "content": "beec_capacity pins the supremum of mutual information: the converse (grouping bound on H(Y)) caps every input at (1-ε)(log 2 - h(q)), and the uniform input attains it. The value factorises as (surviving fraction 1-ε) × (BSC capacity log 2 - h(q)), unifying the two canonical channels — it degenerates to the BEC capacity (1-ε)·log 2 as q → 0 and to the BSC capacity log 2 - h(q) as ε → 0.",
+    "mathContext": "$C(\\text{BEEC}(\\varepsilon,q)) = (1-\\varepsilon)\\,(\\log 2 - h(q))$",
+    "significance": "critical",
+    "relatedConcepts": ["channel capacity", "supremum over inputs", "capacity-achieving distribution", "channel interpolation"],
+    "prerequisites": ["mutual information", "channel capacity as csSup", "achievability and converse"]
+  }
+]

--- a/src/data/proofs/shannon-channel-coding-bec-oq-04/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-04/meta.json
@@ -1,0 +1,230 @@
+{
+  "id": "shannon-channel-coding-bec-oq-04",
+  "title": "Binary Error-and-Erasure Channel (BEEC) Capacity",
+  "slug": "shannon-channel-coding-bec-oq-04",
+  "description": "Extends the binary erasure channel to a channel with BOTH erasures and errors: the binary error-and-erasure channel BEEC(ε, q) erases each symbol with probability ε and, when not erased, passes it through a binary symmetric channel with crossover probability q. Proves from first principles that its capacity is C(BEEC(ε, q)) = (1 - ε)·(log 2 - h(q)) nats. This is the common generalization of the two canonical channels already in the gallery: it degenerates to the BEC capacity (1 - ε)·log 2 as q → 0 and to the BSC capacity log 2 - h(q) as ε → 0. The engine is the constant conditional output entropy H(Y|X) = h(ε) + (1 - ε)·h(q) together with a grouping bound H(Y) ≤ h(ε) + (1 - ε)·log 2 that pins the converse; the uniform input attains it. Introduces no new axioms and no sorries.",
+  "meta": {
+    "author": "Claude Shannon (1948), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_erasure_channel",
+    "date": "1948",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonChannelCodingBECOQ04.lean",
+    "tags": [
+      "information-theory",
+      "analysis",
+      "probability",
+      "coding-theory",
+      "channel-capacity",
+      "advanced"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Analysis.SpecialFunctions.Log.Basic",
+        "description": "Logarithm product/quotient laws for entropy and mutual-information computations",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Order.ConditionallyCompleteLattice.Basic",
+        "description": "csSup_le and le_csSup for capacity as a supremum over input distributions",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Complete from-first-principles proof that the binary error-and-erasure channel BEEC(ε, q) has capacity (1 - ε)·(log 2 - h(q)) nats, for 0 < ε < 1 and 0 < q < 1",
+      "The constant conditional output entropy H(Y|X) = h(ε) + (1 - ε)·h(q), independent of the input distribution: the per-input output law (ε, (1-ε)(1-q), (1-ε)q) is the same for both inputs",
+      "A grouping / recursivity bound H(Y) = h(ε) + (1 - ε)·H₂(β) ≤ h(ε) + (1 - ε)·log 2, resting on an elementary two-point log inequality (mul_log_pair_ge) equivalent to the binary entropy bound H₂ ≤ log 2 — this is what makes the converse sharp even though the output alphabet has three symbols",
+      "The unifying identity: BEEC recovers the BEC capacity (1-ε)·log 2 as q → 0 (beec_capacity_eq_bec_formula) and the BSC capacity log 2 - h(q) as ε → 0 (beec_capacity_eq_bsc_formula), and collapses to 0 when the sub-channel is a fair coin q = 1/2",
+      "Capacity-in-bits corollary (1-ε)(1 - h₂(q)), non-negativity, and the ceiling C ≤ (1-ε)·log 2 quantifying that errors can only reduce the pure-erasure capacity"
+    ],
+    "assumptions": "None. The result is fully machine-checked with 0 sorries and 0 axiom declarations. The #print axioms audit at the end of the file confirms that beec_capacity, beec_uniform_mi, and beec_mi_le_general depend only on the ordinary foundational axioms [propext, Classical.choice, Quot.sound] — no Lean.ofReduceBool, no sorryAx. The file imports ShannonChannelCoding, which declares 2 operational-coding axioms (channel_coding_achievability, channel_coding_converse), but the information-capacity result proved here provably does not invoke them (they do not appear in the axiom audit). The DMChannel and InputDist structures carry only proved data-validity fields (non-negativity, normalization), not free assumptions. The channel is not weakly symmetric (its erasure column has mass ε against (1-ε) for the delivered columns), so the symmetric-channel capacity machinery does not apply; the chain rule I = H(Y) - H(Y|X) with a constant H(Y|X) and a grouping bound on H(Y) is the engine instead.",
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "lineCount": 431,
+    "prerequisites": [
+      "Shannon entropy, conditional entropy, and mutual information (ShannonEntropy.lean)",
+      "Discrete memoryless channels and channel capacity (ShannonChannelCoding.lean)",
+      "BSC development: uniformBool, mi_eq_hY_sub_hYgivenX, conditional-output-entropy pattern (ShannonChannelCodingOQ02.lean)",
+      "Binary entropy function h(p) and h ≤ log 2 (ShannonChannelCodingOQ04.lean)",
+      "BEC development: DMChannel Bool (Option Bool), output-marginal pattern (ShannonChannelCodingBEC.lean)"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 17,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The binary symmetric channel (BSC) and the binary erasure channel (BEC) are the two textbook discrete memoryless channels, and the gallery already proves both capacities from first principles: C(BSC(q)) = log 2 - h(q) and C(BEC(ε)) = (1 - ε)·log 2. A natural question — recorded as the final open question of the BEC entry — is what happens when a channel corrupts symbols in BOTH ways: some transmissions are lost (erasures, whose location the decoder knows) and some are silently flipped (errors). The binary error-and-erasure channel BEEC(ε, q) models exactly this: erase with probability ε, otherwise pass through a BSC(q). Its capacity (1 - ε)·(log 2 - h(q)) has a transparent reading — a fraction 1 - ε of the transmissions survive, and each surviving bit carries the BSC capacity log 2 - h(q) — and it interpolates between the two canonical channels.",
+    "problemStatement": "**BEEC Capacity Formula**: For a binary error-and-erasure channel with erasure probability $0 < \\varepsilon < 1$ and crossover probability $0 < q < 1$,\n$$C(\\text{BEEC}(\\varepsilon, q)) = (1 - \\varepsilon)\\,(\\log 2 - h(q)) \\text{ nats} = (1 - \\varepsilon)\\,(1 - h_2(q)) \\text{ bits}.$$\nThe channel has input alphabet $\\{0,1\\}$ and output alphabet $\\{0, 1, ?\\}$ with $W(? \\mid x) = \\varepsilon$, $W(x \\mid x) = (1-\\varepsilon)(1-q)$, and $W(\\bar x \\mid x) = (1-\\varepsilon)q$.",
+    "text": "Proves the binary error-and-erasure channel capacity C(BEEC(ε, q)) = (1 - ε)·(log 2 - h(q)) from first principles, unifying the BEC and BSC capacities as its q → 0 and ε → 0 limits.",
+    "proofStrategy": "The capacity proof mirrors the BSC development in the H(Y) - H(Y|X) direction:\n\n1. **Channel and marginals**: Define beec : DMChannel Bool (Option Bool). The erasure output has marginal ε for every input; the delivered symbol y has marginal (1 - ε)·(p(y)(1-q) + p(¬y)q).\n\n2. **Conditional output entropy** H(Y|X) = h(ε) + (1 - ε)·h(q): the per-input output law (ε, (1-ε)(1-q), (1-ε)q) is identical for both inputs, so after the transposed-joint conditional entropy collapses to ∑_x p(x)·(∑_o W(x,o) log W(x,o)), the inner sum is a constant whose negation is h(ε) + (1-ε)h(q).\n\n3. **Mutual information** I(X;Y) = H(Y) - H(Y|X) via the chain rule (mi_eq_hY_sub_hYgivenX).\n\n4. **Achievability**: for the uniform input the output marginal is (ε, (1-ε)/2, (1-ε)/2), so H(Y) = h(ε) + (1-ε)·log 2 and I = (1-ε)(log 2 - h(q)).\n\n5. **Converse**: for ANY input the erasure output mass is fixed at ε, so H(Y) = h(ε) + (1-ε)·H₂(β) ≤ h(ε) + (1-ε)·log 2 by the grouping bound (the two-point log inequality mul_log_pair_ge). Point-mass inputs give I = 0 ≤ the bound. Hence I(X;Y) ≤ (1-ε)(log 2 - h(q)) for every input.\n\n6. **Capacity**: the converse bounds the supremum above and the uniform input meets it, so channelCapacity = (1-ε)(log 2 - h(q))."
+    ,
+    "keyInsights": [
+      "The conditional output entropy H(Y|X) = h(ε) + (1-ε)·h(q) is constant across all inputs — the channel is symmetric in the two input labels — so mutual information is entirely controlled by the output entropy H(Y).",
+      "The erasure output mass is pinned at ε for every input distribution, so H(Y) decomposes as h(ε) + (1-ε)·H₂(β): the entropy of a fair erasure coin plus the surviving fraction times the binary entropy of the delivered bit. The converse is the single bound H₂(β) ≤ log 2.",
+      "The whole converse therefore reduces to one elementary inequality, (a+b)·log((a+b)/2) ≤ a·log a + b·log b (a Jensen / log-sum bound equivalent to H₂ ≤ log 2), which is proved self-contained as mul_log_pair_ge.",
+      "The capacity (1-ε)(log 2 - h(q)) factorises as (surviving fraction) × (BSC capacity), interpolating the two canonical channels: q → 0 gives the BEC value (1-ε)·log 2, ε → 0 gives the BSC value log 2 - h(q), and q = 1/2 gives 0.",
+      "Erasures and errors compose multiplicatively in this model: C ≤ (1-ε)·log 2 always, so adding crossover noise q > 0 to a pure erasure channel can only shrink capacity, by the factor (1 - h(q)/log 2)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "grouping-bound",
+      "title": "The Two-Point Log Inequality (Grouping Engine)",
+      "startLine": 60,
+      "endLine": 91,
+      "description": "mul_log_pair_ge: for a, b > 0, (a+b)·log((a+b)/2) ≤ a·log a + b·log b. Recasting a·log a + b·log b through the binary entropy H₂(a/(a+b)) and invoking h ≤ log 2 gives the bound. This is the only inequality the converse needs.",
+      "summary": "An elementary Jensen/log-sum inequality equivalent to the binary entropy bound H₂ ≤ log 2, which drives the converse."
+    },
+    {
+      "id": "beec-channel",
+      "title": "The Binary Error-and-Erasure Channel BEEC(ε, q)",
+      "startLine": 93,
+      "endLine": 135,
+      "description": "Defines beec : DMChannel Bool (Option Bool): W x none = ε, W x (some y) = (1-ε)(1-q) if x = y else (1-ε)q. The simp lemmas beec_W_none / beec_W_some expose the kernel, beec_W_pos records strict positivity for 0 < ε,q < 1, and the channel laws (non-negativity, rows sum to one) are discharged for 0 ≤ ε,q ≤ 1.",
+      "summary": "The channel erases with probability ε and otherwise passes through a BSC(q); a discrete memoryless channel from Bool to Option Bool."
+    },
+    {
+      "id": "output-marginals",
+      "title": "Output Marginals",
+      "startLine": 137,
+      "endLine": 151,
+      "description": "beec_ymarg_none: the erasure output has marginal ε regardless of the input. beec_ymarg_some: the delivered symbol y has marginal (1 - ε)·(p(y)(1-q) + p(¬y)q).",
+      "summary": "The erasure output has fixed mass ε for every input; the delivered symbol y mixes the correct and flipped contributions."
+    },
+    {
+      "id": "conditional-output-entropy",
+      "title": "Conditional Output Entropy H(Y|X) = h(ε) + (1-ε)·h(q)",
+      "startLine": 153,
+      "endLine": 211,
+      "description": "beec_output_entropy_per_input shows the per-input output energy ∑_o W(x,o) log W(x,o) is the same for both inputs; neg_output_energy_eq identifies its negation as h(ε) + (1-ε)·h(q) via the log-product laws; beec_conditional_output_entropy assembles these into H(Y|X) = h(ε) + (1-ε)·h(q) for any positive input, following the BSC pattern on the transposed joint distribution.",
+      "summary": "For every input distribution, conditioning the output on the input leaves residual entropy h(ε) + (1-ε)·h(q) — the erasure coin plus the surviving BSC noise."
+    },
+    {
+      "id": "mutual-information",
+      "title": "Mutual Information: Achievability and Converse",
+      "startLine": 213,
+      "endLine": 350,
+      "description": "beec_uniform_mi computes I(X;Y) = (1-ε)(log 2 - h(q)) for the uniform input from H(Y) = h(ε) + (1-ε)·log 2. beec_mi_le gives the matching converse for positive inputs via the grouping bound H(Y) ≤ h(ε) + (1-ε)·log 2, and beec_mi_le_general extends it to all inputs (point masses give I = 0).",
+      "summary": "The uniform input attains (1-ε)(log 2 - h(q)); the grouping bound on H(Y) caps every input at the same value."
+    },
+    {
+      "id": "capacity",
+      "title": "BEEC Capacity = (1-ε)·(log 2 - h(q))",
+      "startLine": 352,
+      "endLine": 401,
+      "description": "beec_capacity identifies the supremum of mutual information: the converse bounds it above and the uniform input meets it. beec_capacity_bits reads it as (1-ε)(1 - h₂(q)) bits; beec_capacity_nonneg and beec_capacity_le_bec give the [0, (1-ε)log 2] range.",
+      "summary": "Capacity is pinned to (1-ε)·(log 2 - h(q)) nats — the surviving fraction times the BSC capacity."
+    },
+    {
+      "id": "unification",
+      "title": "Unification with the BEC and BSC Capacities",
+      "startLine": 403,
+      "endLine": 421,
+      "description": "beec_capacity_eq_bec_formula (q → 0 recovers (1-ε)·log 2), beec_capacity_eq_bsc_formula (ε → 0 recovers log 2 - h(q)), and beec_capacity_eq_zero_at_half (q = 1/2 gives 0) record the capacity formula's degenerations to the two canonical channels and the useless-channel limit.",
+      "summary": "The capacity formula degenerates to the BEC and BSC capacities in the no-error and no-erasure limits, and to zero for a fair-coin sub-channel."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-bec",
+      "relationship": "extends",
+      "description": "Answers the BEC entry's final open question — extend to a channel with both erasures and errors — recovering the BEC capacity (1-ε)·log 2 as the q → 0 boundary case."
+    },
+    {
+      "targetId": "shannon-channel-coding-oq-02",
+      "relationship": "uses",
+      "description": "Reuses the BSC development's uniformBool and the chain-rule lemma mi_eq_hY_sub_hYgivenX (I = H(Y) - H(Y|X)); recovers the BSC capacity log 2 - h(q) as the ε → 0 boundary case."
+    },
+    {
+      "targetId": "shannon-channel-coding",
+      "relationship": "extends",
+      "description": "Built on the parent's DMChannel / InputDist / capacity (csSup) framework, adding a concrete from-first-principles capacity for the combined error-and-erasure channel."
+    },
+    {
+      "targetId": "shannon-entropy",
+      "relationship": "uses",
+      "description": "Built on the Shannon entropy, conditional entropy, and mutual-information definitions underlying the conditional-output-entropy identity and the grouping bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves the binary error-and-erasure channel capacity C(BEEC(ε, q)) = (1 - ε)·(log 2 - h(q)) nats entirely from first principles, with no new axioms and no sorries. The channel erases with probability ε and otherwise passes through a BSC(q); its conditional output entropy H(Y|X) = h(ε) + (1-ε)·h(q) is constant across inputs, and the erasure output mass is pinned at ε, so the converse reduces to the single grouping bound H(Y) ≤ h(ε) + (1-ε)·log 2. The uniform input meets the bound. The capacity unifies the two canonical discrete memoryless channels already in the gallery, recovering the BEC value (1-ε)·log 2 as q → 0 and the BSC value log 2 - h(q) as ε → 0.",
+    "implications": "The BEEC is the simplest channel that combines the two basic corruption mechanisms — loss (whose location is known) and error (which is silent). Its capacity factorises as (surviving fraction) × (BSC capacity), a clean statement of how erasures and errors compose, and it shows that the gallery's BEC and BSC capacity proofs are two boundary cases of one formula. The grouping-bound engine (constant H(Y|X) plus a pinned erasure mass) is a reusable template for other channels whose output has a fixed sub-alphabet, e.g. q-ary error-and-erasure channels.",
+    "openQuestions": [
+      "Generalize to the q-ary error-and-erasure channel over an arbitrary finite alphabet, where C = (1 - ε)·(log q - error term), unifying with the q-ary erasure channel of OQ-01.",
+      "Establish an operational coding theorem for the BEEC (e.g. concatenating an erasure-filling outer code with a BSC inner code) that discharges the information capacity proved here against the parent's channel_coding_achievability axiom.",
+      "Prove the single-letter Fano converse for the BEEC, as done for the BEC, quantifying the residual error entropy floor at rate C."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "beec_capacity",
+      "type": "core",
+      "description": "The capacity of BEEC(ε, q) equals (1 - ε)·(log 2 - h(q)) for 0 < ε < 1 and 0 < q < 1.",
+      "leanType": "channelCapacity (beec ε q ..) = (1 - ε) * (Real.log 2 - h q)"
+    },
+    {
+      "name": "beec_conditional_output_entropy",
+      "type": "core",
+      "description": "The constant conditional output entropy H(Y|X) = h(ε) + (1-ε)·h(q) for any positive input — the engine of the proof.",
+      "leanType": "conditionalEntropy (transposeJoint (jointDist (beec ε q ..) inp)) = h ε + (1 - ε) * h q"
+    },
+    {
+      "name": "beec_uniform_mi",
+      "type": "supporting",
+      "description": "The uniform input achieves I(X;Y) = (1 - ε)·(log 2 - h(q)), meeting the capacity.",
+      "leanType": "channelMI (beec ε q ..) uniformBool = (1 - ε) * (Real.log 2 - h q)"
+    },
+    {
+      "name": "beec_capacity_bits",
+      "type": "corollary",
+      "description": "Capacity in bits: C₂(BEEC(ε, q)) = (1 - ε)·(1 - h₂(q)).",
+      "leanType": "channelCapacity (beec ε q ..) / Real.log 2 = (1 - ε) * (1 - h q / Real.log 2)"
+    },
+    {
+      "name": "beec_capacity_eq_bec_formula",
+      "type": "corollary",
+      "description": "No-error limit q → 0: the BEEC capacity formula becomes the BEC formula (1-ε)·log 2.",
+      "leanType": "(1 - ε) * (Real.log 2 - h 0) = (1 - ε) * Real.log 2"
+    }
+  ],
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 431,
+    "path": "Proofs/ShannonChannelCodingBECOQ04.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 17
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Claude E. Shannon",
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal 27, 379–423 & 623–656",
+      "note": "Founding paper defining channel capacity as the maximum mutual information — the framework for the BEEC capacity here."
+    },
+    {
+      "authors": "Peter Elias",
+      "title": "Coding for Two Noisy Channels",
+      "year": 1955,
+      "venue": "Information Theory (3rd London Symposium), 61–76",
+      "note": "Introduces the binary erasure channel; the BEEC combines it with the binary symmetric channel."
+    },
+    {
+      "authors": "Thomas M. Cover and Joy A. Thomas",
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Symmetric-channel capacity via I = H(Y) - H(Y|X) with constant H(Y|X), the method used here; treats erasure and symmetric channels as special cases."
+    },
+    {
+      "authors": "Robert G. Gallager",
+      "title": "Information Theory and Reliable Communication",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Capacity of symmetric discrete memoryless channels and the role of the uniform capacity-achieving input."
+    }
+  ]
+}

--- a/src/data/research/problems/shannon-channel-coding-bec-oq-04.json
+++ b/src/data/research/problems/shannon-channel-coding-bec-oq-04.json
@@ -1,0 +1,74 @@
+{
+  "slug": "shannon-channel-coding-bec-oq-04",
+  "title": "Capacity of the Binary Error-and-Erasure Channel",
+  "phase": "COMPLETED",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "C(\\varepsilon, p) \\;=\\; (1 - \\varepsilon)\\,\\bigl(1 - H_2(p)\\bigr), \\qquad H_2(p) = -p\\log_2 p - (1-p)\\log_2(1-p).",
+    "plain": "The parent gallery entry proves the capacity of the Binary Erasure Channel (BEC), where each transmitted bit is either received perfectly or erased. This extension adds a second failure mode: a received (non-erased) bit may also be flipped with probability $p$. We want the capacity formula for this combined channel and a proof that setting $p = 0$ gives the BEC and $\\varepsilon = 0$ gives the Binary Symmetric Channel (BSC).",
+    "whyMatters": [
+      "It unifies the two most-studied discrete memoryless channels (BEC and BSC) under a single capacity formula, showing the gallery's BEC machinery composes cleanly. The mutual-information optimization is a small, self-contained instance of Shannon's channel coding theorem, making it an ideal formalization target that reuses the parent entry's information-theoretic scaffolding."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "Formalize $C(\\varepsilon, p) = (1-\\varepsilon)(1 - H_2(p))$ as the maximizing mutual information $\\max_{P_X} I(X; Y)$ for the channel, achieved at the uniform input distribution, and prove the two boundary specializations. Scope: the information-theoretic capacity (single-letter mutual-information formula), not the full operational coding theorem."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-04T19:56:31-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: BEEC capacity (1-ε)(log 2 - h q) proved from first principles, 0 sorries; unifies BEC+BSC. PR pending.",
+    "builtItems": [
+      "ShannonChannelCodingBECOQ04.lean: beec (DMChannel Bool (Option Bool)), 17 theorems/lemmas, 0 sorries, builds clean",
+      "beec_capacity: channelCapacity = (1-ε)(log 2 - h q) (le_antisymm of converse + uniform achievability)",
+      "beec_conditional_output_entropy: H(Y|X) = h ε + (1-ε) h q for any positive input",
+      "mul_log_pair_ge: (a+b)log((a+b)/2) ≤ a log a + b log b — elementary grouping bound (= H₂ ≤ log 2)",
+      "beec_capacity_eq_bec_formula / beec_capacity_eq_bsc_formula: capacity degenerations to the two canonical channels"
+    ],
+    "insights": [
+      "BEEC(ε,q) = erase w.p. ε, else BSC(q). Capacity C = (1-ε)(log 2 - h(q)) nats, unifying BEC (q→0) and BSC (ε→0).",
+      "Engine: conditional output entropy H(Y|X) = h(ε)+(1-ε)h(q) is CONSTANT across inputs (per-input output law (ε,(1-ε)(1-q),(1-ε)q) identical for both inputs).",
+      "Erasure output mass is pinned at ε for every input, so H(Y) = h(ε)+(1-ε)·H₂(β); the whole converse reduces to the single grouping bound H₂(β) ≤ log 2.",
+      "Not weakly symmetric (erasure column mass ε vs 1-ε for delivered columns), so the symmetric-channel capacity machinery does not apply; the H(Y)-H(Y|X) chain rule with constant H(Y|X) is the route."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Generalize to q-ary error-and-erasure channel over arbitrary finite alphabet (unify with QEC of OQ-01)",
+      "Operational coding theorem for BEEC discharging channel_coding_achievability (erasure-filling outer + BSC inner code)",
+      "Single-letter Fano converse for BEEC (as done for BEC)"
+    ],
+    "markdown": "# Knowledge Base: shannon-channel-coding-bec-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "number-theory",
+    "prime-gaps",
+    "sieve-methods"
+  ],
+  "relatedProofs": [
+    "shannon-channel-coding",
+    "shannon-channel-coding-bec",
+    "shannon-channel-coding-bec-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-04T19:56:31-07:00",
+  "significance": 6,
+  "tractability": 5
+}


### PR DESCRIPTION
## Summary

Answers the **final open question of the BEC gallery entry** (`shannon-channel-coding-bec` OQ-04): *extend to channels with both erasures and errors — the binary error-and-erasure channel — and recover the BEC and BSC as boundary cases.*

The **binary error-and-erasure channel** BEEC(ε, q) erases each symbol with probability ε and, when not erased, passes it through a binary symmetric channel with crossover q. Proved from first principles:

$$C(\text{BEEC}(\varepsilon, q)) = (1 - \varepsilon)\,(\log 2 - h(q)) \quad\text{nats}.$$

This is the common generalization of the two canonical channels already in the gallery, and it **degenerates to both**:
- `q → 0` (no errors) → BEC capacity `(1-ε)·log 2`
- `ε → 0` (no erasures) → BSC capacity `log 2 - h(q)`
- `q = 1/2` (useless sub-channel) → `0`

## Proof engine

The channel is *not* weakly symmetric, so the symmetric-channel machinery does not apply. Instead, using `I = H(Y) − H(Y|X)`:

1. **`beec_conditional_output_entropy`**: `H(Y|X) = h(ε) + (1-ε)·h(q)` — constant across all inputs (the per-input output law `(ε, (1-ε)(1-q), (1-ε)q)` is identical for both inputs).
2. The erasure output mass is **pinned at ε** for every input, so `H(Y) = h(ε) + (1-ε)·H₂(β)`.
3. The whole converse reduces to a single elementary inequality **`mul_log_pair_ge`**: `(a+b)·log((a+b)/2) ≤ a·log a + b·log b` (equivalent to `H₂ ≤ log 2`).
4. The **uniform input attains** the bound → `beec_capacity`.

## Verification

- `proofs/Proofs/ShannonChannelCodingBECOQ04.lean` — 1 def, 17 theorems/lemmas, 431 lines
- **0 sorries, 0 axiom declarations**
- `#print axioms beec_capacity` → `[propext, Classical.choice, Quot.sound]` only (no `Lean.ofReduceBool`, no `sorryAx`) → **status `verified`**
- The imported parent's 2 operational-coding axioms are provably **not invoked** by the capacity result
- Builds clean under Lean 4.26.0 / Mathlib (`LEAN_SKIP_CACHE=true docker-build.sh Proofs.ShannonChannelCodingBECOQ04`)

## Files
- `proofs/Proofs/ShannonChannelCodingBECOQ04.lean` — the formalization
- `src/data/proofs/shannon-channel-coding-bec-oq-04/{meta,annotations}.json` — gallery entry
- `src/data/research/problems/shannon-channel-coding-bec-oq-04.json` — knowledge update (phase → COMPLETED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)