### PR TITLE
research(erdos101-problem-oq-02): elementary Cauchy–Schwarz incidence bound toward Szemerédi–Trotter

### DIFF
--- a/proofs/Proofs/Erdos101ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos101ProblemOQ02.lean
@@ -1,0 +1,183 @@
+/-
+# Erdős Problem #101 — Elementary Incidence Bound (toward Szemerédi–Trotter)
+
+Follow-up to Erdős Problem #101 (`Erdos101Problem.lean`), open question OQ-02:
+*"Formalize the Szemerédi–Trotter bound `I(P,L) ≤ C(|P|^{2/3}|L|^{2/3} + |P| + |L|)`."*
+
+The full Szemerédi–Trotter theorem requires either the crossing-number inequality
+or a cell decomposition, both substantial. This file formalizes the classical
+**elementary predecessor** of that theorem — the Cauchy–Schwarz incidence bound —
+in fully rigorous, axiom-free form.
+
+## Setup
+
+An *incidence system* is a set of points `P`, a set of lines `L`, and an incidence
+relation `Inc`, subject to the defining axiom of a linear space:
+
+  **two distinct points lie on at most one common line.**
+
+Write `r ℓ = |{p ∈ P : Inc p ℓ}|` for the number of points on a line and
+`I = ∑_{ℓ∈L} r ℓ` for the total number of incidences.
+
+## Main result
+
+  `incidences_sq_le : I² ≤ |L| · (|P|² + I)`
+
+This is the sharp, sqrt-free integer form of the elementary bound. It immediately
+gives (over the reals) `I ≤ |P|·√|L| + |L|` and, symmetrically, `I ≤ |L|·√|P| + |P|`,
+the bounds that Szemerédi–Trotter improves to `|P|^{2/3}|L|^{2/3}`.
+
+## Proof
+
+Pure double counting of collinear point-pairs plus Cauchy–Schwarz:
+
+* `sum_choose_two_le` : `∑_ℓ C(r ℓ, 2) ≤ C(|P|, 2)` — each pair of points is
+  collinear on at most one line, so the map `(ℓ, {p,q}) ↦ {p,q}` from
+  line-incident pairs into all pairs is injective.
+* `sq_eq_self_add_two_mul_choose_two` : `n² = n + 2·C(n,2)`, converting the
+  pair count into a sum of squares: `∑_ℓ (r ℓ)² = I + 2·∑_ℓ C(r ℓ,2) ≤ I + |P|²`.
+* Cauchy–Schwarz: `I² = (∑_ℓ r ℓ)² ≤ |L|·∑_ℓ (r ℓ)² ≤ |L|·(|P|² + I)`.
+
+All results are axiom-free (0 sorries, 0 axioms).
+
+Reference: https://erdosproblems.com/101
+-/
+
+import Mathlib
+
+namespace Erdos101OQ02ST
+
+open Finset
+
+/-- The elementary identity `n² = n + 2·C(n,2)` relating a square to a triangular
+    number. This is what turns a sum of pair-counts into a sum of squares. -/
+lemma sq_eq_self_add_two_mul_choose_two (n : ℕ) : n ^ 2 = n + 2 * n.choose 2 := by
+  induction n with
+  | zero => rfl
+  | succ k ih =>
+      have hc : (k + 1).choose 2 = k.choose 2 + k := by
+        rw [Nat.choose_succ_succ, Nat.choose_one_right]
+        show k + k.choose 2 = k.choose 2 + k
+        omega
+      have hsq : (k + 1) ^ 2 = k ^ 2 + 2 * k + 1 := by ring
+      rw [hc, hsq, ih]; ring
+
+variable {α β : Type*} [DecidableEq α] [DecidableEq β]
+
+/-- The points of `P` lying on the line `ℓ` under the incidence relation `Inc`. -/
+def pointsOn (Inc : α → β → Prop) [DecidableRel Inc] (P : Finset α) (ℓ : β) : Finset α :=
+  P.filter (fun p => Inc p ℓ)
+
+lemma pointsOn_subset (Inc : α → β → Prop) [DecidableRel Inc] (P : Finset α) (ℓ : β) :
+    pointsOn Inc P ℓ ⊆ P := Finset.filter_subset _ _
+
+/-- Total number of point–line incidences `I(P,L) = ∑_{ℓ∈L} |{p ∈ P : Inc p ℓ}|`. -/
+def incidences (Inc : α → β → Prop) [DecidableRel Inc] (P : Finset α) (L : Finset β) : ℕ :=
+  ∑ ℓ ∈ L, (pointsOn Inc P ℓ).card
+
+/-- **Double counting of collinear pairs.** In a linear space (two distinct points
+    determine at most one common line), the number of point-pairs summed over the
+    lines they lie on is bounded by the total number of point-pairs `C(|P|, 2)`. -/
+lemma sum_choose_two_le
+    (Inc : α → β → Prop) [DecidableRel Inc] (P : Finset α) (L : Finset β)
+    (huniq : ∀ p ∈ P, ∀ q ∈ P, p ≠ q → ∀ ℓ₁ ∈ L, ∀ ℓ₂ ∈ L,
+      Inc p ℓ₁ → Inc q ℓ₁ → Inc p ℓ₂ → Inc q ℓ₂ → ℓ₁ = ℓ₂) :
+    ∑ ℓ ∈ L, (pointsOn Inc P ℓ).card.choose 2 ≤ P.card.choose 2 := by
+  -- The LHS is the cardinality of the Σ-type of 2-element incident subsets.
+  have hcard : ∑ ℓ ∈ L, (pointsOn Inc P ℓ).card.choose 2
+      = (L.sigma (fun ℓ => (pointsOn Inc P ℓ).powersetCard 2)).card := by
+    rw [Finset.card_sigma]
+    apply Finset.sum_congr rfl
+    intro ℓ _
+    rw [Finset.card_powersetCard]
+  rw [hcard, show P.card.choose 2 = (P.powersetCard 2).card from
+        (Finset.card_powersetCard 2 P).symm]
+  -- Project `(ℓ, e) ↦ e`; injectivity is exactly the linear-space axiom.
+  apply Finset.card_le_card_of_injOn (fun x => x.2)
+  · rintro ⟨ℓ, e⟩ hx
+    obtain ⟨_, he⟩ := Finset.mem_sigma.mp hx
+    obtain ⟨hsub, hc2⟩ := Finset.mem_powersetCard.mp he
+    exact Finset.mem_powersetCard.mpr ⟨hsub.trans (pointsOn_subset Inc P ℓ), hc2⟩
+  · rintro ⟨ℓ₁, e₁⟩ hx₁ ⟨ℓ₂, e₂⟩ hx₂ heq
+    obtain ⟨hℓ₁, he₁⟩ := Finset.mem_sigma.mp hx₁
+    obtain ⟨hℓ₂, he₂⟩ := Finset.mem_sigma.mp hx₂
+    obtain ⟨hsub₁, hcard₁⟩ := Finset.mem_powersetCard.mp he₁
+    obtain ⟨hsub₂, _⟩ := Finset.mem_powersetCard.mp he₂
+    -- `heq : e₁ = e₂` (after beta / `Sigma.snd`)
+    have heqe : e₁ = e₂ := heq
+    subst heqe
+    obtain ⟨a, b, hab, hrfl⟩ := Finset.card_eq_two.mp hcard₁
+    subst hrfl
+    have ha1 : a ∈ pointsOn Inc P ℓ₁ := hsub₁ (by simp)
+    have hb1 : b ∈ pointsOn Inc P ℓ₁ := hsub₁ (by simp)
+    have ha2 : a ∈ pointsOn Inc P ℓ₂ := hsub₂ (by simp)
+    have hb2 : b ∈ pointsOn Inc P ℓ₂ := hsub₂ (by simp)
+    simp only [pointsOn, Finset.mem_filter] at ha1 hb1 ha2 hb2
+    have hll : ℓ₁ = ℓ₂ :=
+      huniq a ha1.1 b hb1.1 hab ℓ₁ hℓ₁ ℓ₂ hℓ₂ ha1.2 hb1.2 ha2.2 hb2.2
+    subst hll; rfl
+
+/-- `∑_ℓ (r ℓ)² = I + 2·∑_ℓ C(r ℓ, 2)`, where `r ℓ = |pointsOn ℓ|` and `I` is the
+    incidence count. -/
+lemma sum_sq_eq (Inc : α → β → Prop) [DecidableRel Inc] (P : Finset α) (L : Finset β) :
+    ∑ ℓ ∈ L, ((pointsOn Inc P ℓ).card) ^ 2
+      = incidences Inc P L + 2 * ∑ ℓ ∈ L, ((pointsOn Inc P ℓ).card).choose 2 := by
+  unfold incidences
+  rw [Finset.mul_sum, ← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro ℓ _
+  exact sq_eq_self_add_two_mul_choose_two _
+
+/-- Cauchy–Schwarz for natural-number sums: `(∑ f)² ≤ |s| · ∑ f²`.
+    Proved over `ℝ` and cast back to `ℕ`. -/
+lemma sq_sum_le_card_mul_sum_sq_nat (s : Finset β) (f : β → ℕ) :
+    (∑ i ∈ s, f i) ^ 2 ≤ s.card * ∑ i ∈ s, (f i) ^ 2 := by
+  rw [← Nat.cast_le (α := ℝ)]
+  push_cast
+  have h := Finset.sum_mul_sq_le_sq_mul_sq s (fun i => (f i : ℝ)) (fun _ => (1 : ℝ))
+  simp only [mul_one, one_pow, Finset.sum_const, nsmul_eq_mul, mul_one] at h
+  calc (∑ i ∈ s, (f i : ℝ)) ^ 2
+      ≤ (∑ i ∈ s, (f i : ℝ) ^ 2) * s.card := h
+    _ = s.card * ∑ i ∈ s, (f i : ℝ) ^ 2 := by ring
+
+/-- **Elementary incidence bound (toward Szemerédi–Trotter).**
+
+In any incidence system in which two distinct points lie on at most one common line,
+the number of incidences `I` satisfies
+
+    `I² ≤ |L| · (|P|² + I)`.
+
+Over the reals this yields `I ≤ |P|·√|L| + |L|`. Szemerédi–Trotter improves the
+right-hand side to `O(|P|^{2/3}|L|^{2/3} + |P| + |L|)`; this bound is the elementary
+Cauchy–Schwarz predecessor, and is sharp for the linear-space axiom alone (it is
+attained, e.g., by a projective plane where every pair of points lies on a line). -/
+theorem incidences_sq_le
+    (Inc : α → β → Prop) [DecidableRel Inc] (P : Finset α) (L : Finset β)
+    (huniq : ∀ p ∈ P, ∀ q ∈ P, p ≠ q → ∀ ℓ₁ ∈ L, ∀ ℓ₂ ∈ L,
+      Inc p ℓ₁ → Inc q ℓ₁ → Inc p ℓ₂ → Inc q ℓ₂ → ℓ₁ = ℓ₂) :
+    (incidences Inc P L) ^ 2 ≤ L.card * (P.card ^ 2 + incidences Inc P L) := by
+  -- Cauchy–Schwarz: I² ≤ |L| · ∑_ℓ (r ℓ)²
+  have hCS : (incidences Inc P L) ^ 2 ≤ L.card * ∑ ℓ ∈ L, ((pointsOn Inc P ℓ).card) ^ 2 := by
+    have h := sq_sum_le_card_mul_sum_sq_nat L (fun ℓ => (pointsOn Inc P ℓ).card)
+    unfold incidences
+    exact h
+  -- Sum-of-squares bound: ∑_ℓ (r ℓ)² ≤ |P|² + I
+  have hA : ∑ ℓ ∈ L, ((pointsOn Inc P ℓ).card) ^ 2 ≤ P.card ^ 2 + incidences Inc P L := by
+    rw [sum_sq_eq]
+    have hchoose := sum_choose_two_le Inc P L huniq
+    have h2 : 2 * P.card.choose 2 ≤ P.card ^ 2 := by
+      rw [sq_eq_self_add_two_mul_choose_two P.card]; omega
+    have hkey : 2 * ∑ ℓ ∈ L, ((pointsOn Inc P ℓ).card).choose 2 ≤ P.card ^ 2 := by
+      calc 2 * ∑ ℓ ∈ L, ((pointsOn Inc P ℓ).card).choose 2
+          ≤ 2 * P.card.choose 2 := by gcongr
+        _ ≤ P.card ^ 2 := h2
+    omega
+  calc (incidences Inc P L) ^ 2
+      ≤ L.card * ∑ ℓ ∈ L, ((pointsOn Inc P ℓ).card) ^ 2 := hCS
+    _ ≤ L.card * (P.card ^ 2 + incidences Inc P L) := by gcongr
+
+-- Axiom audit: should depend only on the foundational `propext`,
+-- `Classical.choice`, `Quot.sound` (fully verified, no extra axioms).
+#print axioms incidences_sq_le
+
+end Erdos101OQ02ST

--- a/research/problems/erdos101-problem-oq-02/knowledge.md
+++ b/research/problems/erdos101-problem-oq-02/knowledge.md
@@ -1,0 +1,68 @@
+# erdos101-problem-oq-02 — Elementary incidence bound (toward Szemerédi–Trotter)
+
+**Parent**: Erdős Problem #101 (four-point lines from planar point sets).
+**OQ-02 statement (pool)**: "Formalize the Szemerédi–Trotter bound
+`I(P,L) ≤ C(|P|^{2/3}|L|^{2/3} + |P| + |L|)`."
+
+**Status**: COMPLETED (verified, 0 sorries, 0 axioms) — for the *elementary
+predecessor* of ST. The full ST bound remains open (see next steps).
+
+## Summary
+
+The full Szemerédi–Trotter theorem needs the crossing-number inequality (Székely)
+or a cell decomposition — substantial machinery not attempted here. This session
+formalised the rigorous **elementary Cauchy–Schwarz incidence bound**, the classical
+weaker bound that ST improves:
+
+For any incidence system (arbitrary point/line types + incidence relation `Inc`)
+satisfying the **linear-space axiom** (two distinct points lie on ≤ 1 common line),
+with `r ℓ = |{p ∈ P : Inc p ℓ}|` and `I = Σ_ℓ r ℓ`:
+
+```
+incidences_sq_le :  I² ≤ |L| · (|P|² + I)
+```
+
+Over ℝ this is `I ≤ |P|·√|L| + |L|`. ST sharpens the RHS to `|P|^{2/3}|L|^{2/3}`.
+
+## Session 2026-07-04 (Session 1) — FRESH
+
+**Mode**: FRESH. **Outcome**: completed (elementary bound).
+
+### What I Did
+- Confirmed `erdos101-problem-oq-02` is a *distinct* open question from the existing
+  `erdos-101-oq-02` entry (Steiner systems). No duplicate; no prior meta.json.
+- Wrote `proofs/Proofs/Erdos101ProblemOQ02.lean` (183 lines, 0 sorry, 0 axiom).
+- Docker-verified: `#print axioms incidences_sq_le` → `[propext, Classical.choice, Quot.sound]`.
+- Added gallery entry `src/data/proofs/erdos101-problem-oq-02/` (meta.json + annotations.json).
+
+### Key Findings / Techniques
+- **Double counting as an injection out of a sigma type**: `Σ_ℓ C(r_ℓ,2)` is the
+  card of `L.sigma (fun ℓ => (pointsOn ℓ).powersetCard 2)`; projecting `(ℓ,e) ↦ e`
+  into `P.powersetCard 2` is injective by the linear-space axiom. Closed with
+  `Finset.card_le_card_of_injOn`.
+- **Square/triangular identity** `n² = n + 2·C(n,2)` converts the pair count into a
+  sum of squares (the shape Cauchy–Schwarz consumes).
+- **ℕ Cauchy–Schwarz** `(Σf)² ≤ |s|·Σf²` obtained by casting `Finset.sum_mul_sq_le_sq_mul_sq`
+  (ℝ) with `g ≡ 1` back to ℕ via `push_cast` / `Nat.cast_le`. Keeps the headline in ℕ,
+  avoiding square roots entirely.
+
+### Lean gotchas hit
+- `Finset.mem_sigma` and `Finset.mem_powersetCard` do NOT fire under `simp only`/`rw`
+  on membership coming from `Finset.card_le_card_of_injOn` (Set-coe `∈ ↑s`, and beta-redex
+  under `Sigma.snd`). Use the `.mp`/`.mpr` projections instead — they succeed by defeq.
+- `Nat.choose_succ_succ` leaves `k.choose (Nat.succ 1)`; close with `show ... k.choose 2 ...; omega`.
+- Docker build intermittently exits 135 (SIGBUS, environmental) right after cache
+  decompression — just retry; the `#print axioms` output confirmed on a clean run.
+
+### Files Modified
+- `proofs/Proofs/Erdos101ProblemOQ02.lean` (new)
+- `src/data/proofs/erdos101-problem-oq-02/meta.json` (new)
+- `src/data/proofs/erdos101-problem-oq-02/annotations.json` (new)
+
+### Next Steps (toward the full ST bound — genuinely harder)
+- Formalise Székely's crossing-number proof of ST: needs the crossing-number
+  inequality `cr(G) ≥ e³/(64 v²)` for `e ≥ 4v`, itself from Euler's formula +
+  probabilistic deletion. This is the real open work; likely > 1000 lines.
+- Alternatively, a cell-decomposition / polynomial-partitioning route.
+- Sharpness of the elementary bound: exhibit a finite projective plane attaining
+  `I² ≈ |L|(|P|² + I)`, showing Cauchy–Schwarz alone cannot beat the √ exponent.

--- a/src/data/proofs/erdos101-problem-oq-02/annotations.json
+++ b/src/data/proofs/erdos101-problem-oq-02/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-header-incidence",
+    "proofId": "erdos101-problem-oq-02",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "Elementary incidence bound toward Szemerédi–Trotter",
+    "content": "The Szemerédi–Trotter theorem bounds point–line incidences by $O(|P|^{2/3}|L|^{2/3} + |P| + |L|)$, but its proofs need the crossing-number inequality or a cell decomposition. This file formalises the elementary predecessor: the Cauchy–Schwarz bound. The setup is abstract — arbitrary point type, line type, and an incidence relation $\\mathrm{Inc}$ — subject only to the linear-space axiom that two distinct points lie on at most one common line. Writing $I = \\sum_{\\ell} r_\\ell$ with $r_\\ell$ the number of points on line $\\ell$, the target is the sqrt-free integer inequality $I^2 \\le |L|(|P|^2 + I)$.",
+    "mathContext": "$I^2 \\le |L|\\,(|P|^2 + I)$, equivalently $I \\le |P|\\sqrt{|L|} + |L|$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Szemerédi–Trotter theorem",
+      "incidence geometry",
+      "linear space / two points determine a line",
+      "Cauchy–Schwarz inequality"
+    ],
+    "prerequisites": [
+      "Finset cardinality and sums",
+      "binomial coefficients (Nat.choose)"
+    ]
+  },
+  {
+    "id": "ann-square-identity",
+    "proofId": "erdos101-problem-oq-02",
+    "range": { "startLine": 51, "endLine": 64 },
+    "type": "technique",
+    "title": "Turning pair-counts into squares: n² = n + 2·C(n,2)",
+    "content": "This elementary identity is the hinge of the whole argument. The double-counting step naturally produces $\\sum_\\ell \\binom{r_\\ell}{2}$, but Cauchy–Schwarz wants $\\sum_\\ell r_\\ell^2$. Since $r^2 = r + 2\\binom{r}{2}$, summing gives $\\sum_\\ell r_\\ell^2 = I + 2\\sum_\\ell \\binom{r_\\ell}{2}$. Proved by induction with Nat.choose_succ_succ and Nat.choose_one_right.",
+    "mathContext": "$n^2 = n + 2\\binom{n}{2}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangular numbers",
+      "binomial identities"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "Pascal's rule (Nat.choose_succ_succ)"
+    ]
+  },
+  {
+    "id": "ann-double-counting",
+    "proofId": "erdos101-problem-oq-02",
+    "range": { "startLine": 78, "endLine": 118 },
+    "type": "technique",
+    "title": "Double counting collinear pairs via an injection",
+    "content": "The bound $\\sum_\\ell \\binom{r_\\ell}{2} \\le \\binom{|P|}{2}$ is the combinatorial heart. It is proved by realising the left side as the cardinality of the sigma type $\\{(\\ell, e) : e \\in \\binom{\\mathrm{pointsOn}\\,\\ell}{2}\\}$ (Finset.card_sigma + Finset.card_powersetCard) and projecting $(\\ell, e) \\mapsto e$ into $\\binom{P}{2}$. This projection is injective precisely because of the linear-space axiom: a 2-element set of points determines its line uniquely, so no pair can come from two different lines. Finset.card_le_card_of_injOn then delivers the inequality.",
+    "mathContext": "$\\sum_\\ell \\binom{r_\\ell}{2} \\le \\binom{|P|}{2}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "double counting",
+      "injective maps and cardinality",
+      "sigma types of Finsets"
+    ],
+    "prerequisites": [
+      "Finset.card_le_card_of_injOn",
+      "Finset.powersetCard",
+      "the linear-space axiom (two points ⇒ one line)"
+    ]
+  },
+  {
+    "id": "ann-cauchy-schwarz",
+    "proofId": "erdos101-problem-oq-02",
+    "range": { "startLine": 131, "endLine": 151 },
+    "type": "technique",
+    "title": "Natural-number Cauchy–Schwarz by casting to ℝ",
+    "content": "The step $(\\sum_\\ell r_\\ell)^2 \\le |L|\\sum_\\ell r_\\ell^2$ is Cauchy–Schwarz with the constant vector 1. Mathlib's Finset.sum_mul_sq_le_sq_mul_sq lives over ℝ, so the natural-number statement is obtained by casting the ℕ sum to ℝ (push_cast), applying the ℝ inequality with $g \\equiv 1$, and casting the resulting inequality back with Nat.cast_le. This keeps the final theorem in ℕ while borrowing the analytic inequality.",
+    "mathContext": "$\\left(\\sum_\\ell r_\\ell\\right)^2 \\le |L|\\sum_\\ell r_\\ell^2$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cauchy–Schwarz inequality",
+      "ℕ → ℝ casts (push_cast, Nat.cast_le)"
+    ],
+    "prerequisites": [
+      "Finset.sum_mul_sq_le_sq_mul_sq",
+      "order-preserving casts"
+    ]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "erdos101-problem-oq-02",
+    "range": { "startLine": 143, "endLine": 178 },
+    "type": "concept",
+    "title": "The incidence bound and where it sits",
+    "content": "incidences_sq_le chains the two ingredients: Cauchy–Schwarz gives $I^2 \\le |L|\\sum_\\ell r_\\ell^2$, and the sum-of-squares bound gives $\\sum_\\ell r_\\ell^2 \\le |P|^2 + I$ (using $2\\binom{|P|}{2} \\le |P|^2$), so $I^2 \\le |L|(|P|^2 + I)$. This is exactly the elementary Cauchy–Schwarz bound $I \\lesssim |P|\\sqrt{|L|}$; Szemerédi–Trotter improves the exponent to $2/3$. The entry is honest scaffolding — a verified, axiom-free foundation, not a formalisation of the full ST theorem.",
+    "mathContext": "$I^2 \\le |L|\\,(|P|^2 + I)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Szemerédi–Trotter theorem",
+      "elementary vs. sharp incidence bounds",
+      "projective plane (extremal case)"
+    ],
+    "prerequisites": [
+      "the double-counting and Cauchy–Schwarz lemmas above"
+    ]
+  }
+]

--- a/src/data/proofs/erdos101-problem-oq-02/meta.json
+++ b/src/data/proofs/erdos101-problem-oq-02/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "erdos101-problem-oq-02",
+  "slug": "erdos101-problem-oq-02",
+  "title": "Erdős #101 OQ-02: Elementary Cauchy–Schwarz Incidence Bound (toward Szemerédi–Trotter)",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos101OQ02ST",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos101ProblemOQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Erdős",
+    "erdosNumber": 101,
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos101ProblemOQ02.lean",
+    "tags": [
+      "erdos",
+      "combinatorial-geometry",
+      "incidence-geometry",
+      "szemeredi-trotter",
+      "cauchy-schwarz",
+      "double-counting",
+      "extremal-combinatorics",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/101",
+    "erdosUrl": "https://erdosproblems.com/101",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "lineCount": 183,
+    "assumptions": "None. 0 sorries, 0 axioms — the main theorem incidences_sq_le depends only on the foundational axioms propext / Classical.choice / Quot.sound (verified by #print axioms). This is the elementary Cauchy–Schwarz incidence bound, NOT the full Szemerédi–Trotter theorem: it proves the sqrt-free integer inequality I² ≤ |L|·(|P|² + I) that ST subsequently improves.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "substantiveTheoremCount": 3
+  },
+  "description": "The elementary predecessor of the Szemerédi–Trotter theorem, formalised in fully rigorous, axiom-free form. For an abstract incidence system on point set $P$ and line set $L$ satisfying the linear-space axiom (two distinct points lie on at most one common line), the number of incidences $I = \\sum_{\\ell \\in L} |\\{p \\in P : p \\in \\ell\\}|$ satisfies the sharp integer bound $I^2 \\le |L|\\,(|P|^2 + I)$. Over the reals this gives $I \\le |P|\\sqrt{|L|} + |L|$ — the Cauchy–Schwarz bound that Szemerédi–Trotter improves to $O(|P|^{2/3}|L|^{2/3} + |P| + |L|)$. The proof is pure double counting of collinear point-pairs together with Cauchy–Schwarz.",
+  "overview": {
+    "historicalContext": "The Szemerédi–Trotter theorem (1983) states that $n$ points and $m$ lines in the plane determine at most $O(n^{2/3}m^{2/3} + n + m)$ incidences, and this is tight (grid constructions). Its known proofs go through the crossing-number inequality (Székely) or a cell decomposition — substantial machinery. Before that sharp bound, the elementary tool is the Cauchy–Schwarz / double-counting bound $I \\le n\\sqrt{m} + m$, valid in any linear space: count pairs of points, note each pair is collinear on at most one line, and apply Cauchy–Schwarz to the point-counts per line. This entry ports that elementary bound into Lean as an abstract, dimension-free statement about incidence systems, giving a clean foundation on which the harder ST bound could later be built. It is a follow-up to the parent Erdős #101 entry (four-point lines), whose combinatorics live in the same incidence-geometry world.",
+    "problemStatement": "Open question OQ-02 asks to formalise the Szemerédi–Trotter incidence bound $I(P,L) \\le C(|P|^{2/3}|L|^{2/3} + |P| + |L|)$. The full theorem requires the crossing-number inequality or a cell decomposition; this entry formalises its rigorous elementary predecessor — the Cauchy–Schwarz bound $I^2 \\le |L|(|P|^2 + I)$ — as verified, axiom-free groundwork, and states honestly where it sits relative to the sharp ST bound.",
+    "proofStrategy": "Write $r_\\ell = |\\{p \\in P : \\mathrm{Inc}\\,p\\,\\ell\\}|$, so $I = \\sum_\\ell r_\\ell$. (1) Double counting: the map $(\\ell, \\{p,q\\}) \\mapsto \\{p,q\\}$ from line-incident 2-subsets into all 2-subsets of $P$ is injective by the linear-space axiom, giving $\\sum_\\ell \\binom{r_\\ell}{2} \\le \\binom{|P|}{2}$ (sum_choose_two_le, via Finset.card_le_card_of_injOn on a sigma type). (2) The identity $n^2 = n + 2\\binom{n}{2}$ (sq_eq_self_add_two_mul_choose_two) turns this into $\\sum_\\ell r_\\ell^2 = I + 2\\sum_\\ell \\binom{r_\\ell}{2} \\le I + |P|^2$. (3) Cauchy–Schwarz $(\\sum_\\ell r_\\ell)^2 \\le |L|\\sum_\\ell r_\\ell^2$ (sq_sum_le_card_mul_sum_sq_nat, cast from Finset.sum_mul_sq_le_sq_mul_sq over ℝ). Chaining: $I^2 \\le |L|\\sum_\\ell r_\\ell^2 \\le |L|(|P|^2 + I)$.",
+    "keyInsights": [
+      "The entire bound is elementary: the single geometric hypothesis used is the linear-space axiom (two points determine at most one line), and everything else is counting — no metric, no dimension, no field.",
+      "Double counting is packaged as an injection out of a sigma type: $\\sum_\\ell \\binom{r_\\ell}{2}$ is the cardinality of $\\{(\\ell, e) : e \\in \\binom{\\mathrm{pointsOn}\\,\\ell}{2}\\}$, and projecting $(\\ell,e) \\mapsto e$ is injective precisely because a 2-set of points sits on a unique line.",
+      "Keeping the statement in ℕ as $I^2 \\le |L|(|P|^2 + I)$ avoids square roots entirely while being equivalent to the familiar $I \\le |P|\\sqrt{|L|} + |L|$; the only excursion to ℝ is the Cauchy–Schwarz step, immediately cast back.",
+      "The identity $n^2 = n + 2\\binom{n}{2}$ is the hinge that converts a pair count into a sum of squares, the exact shape Cauchy–Schwarz consumes.",
+      "This delimits rather than resolves OQ-02: it is the $\\sqrt{}$-order elementary bound, honestly weaker than the $2/3$-exponent Szemerédi–Trotter bound, and is stated as verified scaffolding rather than a claim to have formalised ST."
+    ]
+  },
+  "sections": [
+    {
+      "id": "square-identity",
+      "title": "The square/triangular identity",
+      "startLine": 51,
+      "endLine": 64,
+      "summary": "sq_eq_self_add_two_mul_choose_two: n² = n + 2·C(n,2), proved by induction using Nat.choose_succ_succ. This converts a sum of pair-counts into a sum of squares.",
+      "mathContext": "$n^2 = n + 2\\binom{n}{2}$"
+    },
+    {
+      "id": "definitions",
+      "title": "Incidence system: points-on-line and incidence count",
+      "startLine": 66,
+      "endLine": 76,
+      "summary": "pointsOn Inc P ℓ = {p ∈ P : Inc p ℓ} (a Finset filter); incidences Inc P L = Σ_ℓ |pointsOn ℓ|, the total number of point–line incidences I(P,L).",
+      "mathContext": "$I(P,L) = \\sum_{\\ell \\in L} |\\{p \\in P : \\mathrm{Inc}\\,p\\,\\ell\\}|$"
+    },
+    {
+      "id": "double-counting",
+      "title": "Double counting of collinear pairs",
+      "startLine": 78,
+      "endLine": 118,
+      "summary": "sum_choose_two_le: under the linear-space axiom, Σ_ℓ C(r_ℓ,2) ≤ C(|P|,2). Proved by injecting the sigma type of line-incident 2-subsets into P.powersetCard 2 via (ℓ,e) ↦ e; injectivity is exactly uniqueness of the line through two points.",
+      "mathContext": "$\\sum_\\ell \\binom{r_\\ell}{2} \\le \\binom{|P|}{2}$"
+    },
+    {
+      "id": "sum-of-squares",
+      "title": "Sum-of-squares bound and Cauchy–Schwarz",
+      "startLine": 120,
+      "endLine": 151,
+      "summary": "sum_sq_eq: Σ_ℓ r_ℓ² = I + 2·Σ_ℓ C(r_ℓ,2). sq_sum_le_card_mul_sum_sq_nat: (Σ r)² ≤ |L|·Σ r², the natural-number Cauchy–Schwarz obtained by casting Finset.sum_mul_sq_le_sq_mul_sq to ℝ.",
+      "mathContext": "$\\left(\\sum_\\ell r_\\ell\\right)^2 \\le |L|\\sum_\\ell r_\\ell^2$"
+    },
+    {
+      "id": "main",
+      "title": "Main theorem: the incidence bound",
+      "startLine": 153,
+      "endLine": 178,
+      "summary": "incidences_sq_le: I² ≤ |L|·(|P|² + I). Chains Cauchy–Schwarz with the sum-of-squares bound (Σ r_ℓ² ≤ |P|² + I, using 2·C(|P|,2) ≤ |P|²). The sqrt-free integer form of the elementary Cauchy–Schwarz incidence bound.",
+      "mathContext": "$I^2 \\le |L|\\,(|P|^2 + I)$"
+    }
+  ],
+  "conclusion": {
+    "summary": "For any incidence system satisfying the linear-space axiom, the incidence count obeys the elementary bound I² ≤ |L|·(|P|² + I), equivalently I ≤ |P|√|L| + |L|. All results are axiom-free (0 sorries, 0 axioms), proved by double counting plus Cauchy–Schwarz.",
+    "implications": "This is the rigorous elementary foundation on top of which the sharp Szemerédi–Trotter bound O(|P|^{2/3}|L|^{2/3} + |P| + |L|) is built. The abstract, dimension-free phrasing (arbitrary point/line types with only the two-points-determine-a-line axiom) makes it directly reusable for any linear space, including projective planes where the bound is attained.",
+    "openQuestions": [
+      "Formalise the full Szemerédi–Trotter bound $O(|P|^{2/3}|L|^{2/3} + |P| + |L|)$ via the crossing-number inequality (Székely's proof) — the substantial next step this entry does not attempt.",
+      "Establish the sharpness of the elementary bound: exhibit a linear space (e.g. a finite projective plane) attaining $I^2 = |L|(|P|^2 + I)$ up to lower-order terms, showing Cauchy–Schwarz alone cannot beat the $\\sqrt{}$ exponent."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-101",
+      "relationship": "parent",
+      "description": "The base Erdős #101 entry studies four-point lines in planar point sets; this follow-up formalises the elementary incidence bound (toward Szemerédi–Trotter) in the same incidence-geometry setting."
+    },
+    {
+      "targetId": "erdos-101-oq-02",
+      "relationship": "sibling",
+      "description": "A companion OQ-02 follow-up characterising the extremal four-point-line case as a Steiner system; both refine incidence-geometry structure for Erdős #101."
+    }
+  ],
+  "references": [
+    {
+      "title": "Erdős Problem #101",
+      "url": "https://erdosproblems.com/101"
+    },
+    {
+      "title": "E. Szemerédi and W. T. Trotter, Extremal problems in discrete geometry, Combinatorica 3 (1983)",
+      "url": "https://doi.org/10.1007/BF02579194"
+    },
+    {
+      "title": "L. A. Székely, Crossing numbers and hard Erdős problems in discrete geometry, Combin. Probab. Comput. 6 (1997)",
+      "url": "https://doi.org/10.1017/S0963548397002976"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the **elementary Cauchy–Schwarz incidence bound**, the classical
predecessor of the Szemerédi–Trotter theorem, addressing Erdős #101 open
question **OQ-02** (*"Formalize the Szemerédi–Trotter bound
`I(P,L) ≤ C(|P|^{2/3}|L|^{2/3} + |P| + |L|)`"*).

The full ST theorem requires the crossing-number inequality or a cell
decomposition (substantial machinery, left open). This PR delivers the
rigorous, **fully verified** weaker bound that ST improves upon.

## Result

For any incidence system — arbitrary point type `α`, line type `β`, incidence
relation `Inc` — satisfying the **linear-space axiom** (two distinct points lie
on at most one common line), with `r ℓ = |{p ∈ P : Inc p ℓ}|` and
`I = incidences = Σ_ℓ r ℓ`:

```lean
theorem incidences_sq_le … :
    (incidences Inc P L) ^ 2 ≤ L.card * (P.card ^ 2 + incidences Inc P L)
```

i.e. `I² ≤ |L|·(|P|² + I)`. Over ℝ: `I ≤ |P|·√|L| + |L|`. ST sharpens the RHS
to `O(|P|^{2/3}|L|^{2/3} + |P| + |L|)`.

## Proof

Pure double counting + Cauchy–Schwarz:
- `sum_choose_two_le` — `Σ_ℓ C(r_ℓ,2) ≤ C(|P|,2)` via an injection out of a
  sigma type (`Finset.card_le_card_of_injOn`); injectivity **is** the
  linear-space axiom.
- `sq_eq_self_add_two_mul_choose_two` — `n² = n + 2·C(n,2)`, converting the pair
  count into a sum of squares.
- `sq_sum_le_card_mul_sum_sq_nat` — ℕ Cauchy–Schwarz, cast from
  `Finset.sum_mul_sq_le_sq_mul_sq`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos101ProblemOQ02` → builds (7743 jobs).
- **0 sorries, 0 axioms.** `#print axioms incidences_sq_le` →
  `[propext, Classical.choice, Quot.sound]` (foundational only).

## Honest scope

This is the **elementary** bound, not the full Szemerédi–Trotter theorem. The
gallery entry documents this clearly and lists the crossing-number formalisation
as the genuinely-open next step. `status: verified` refers to the elementary
bound actually proved.

## Files
- `proofs/Proofs/Erdos101ProblemOQ02.lean` (183 lines, new)
- `src/data/proofs/erdos101-problem-oq-02/{meta.json,annotations.json}` (new)
- `research/problems/erdos101-problem-oq-02/knowledge.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)