### PR TITLE
Enrich: Coprime Companion Blocks are Nonderogatory (full-file section coverage)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
@@ -58,6 +58,13 @@
   },
   "sections": [
     {
+      "id": "header-setup",
+      "title": "Module header, imports, and parent scaffold",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Imports Mathlib and the sorry-free parent CayleyHamiltonReductionOQ02OQ01WIP01, which supplies charpoly (C(p) ⊕ C(q)) = p·q and minpoly (C(p) ⊕ C(q)) = lcm p q. The docstring frames the goal: since lcm p q ∣ p·q strictly in general the block sum is derogatory, and the coprime case (lcm = product) is exactly where it becomes nonderogatory. Opens the parent namespaces and fixes the ambient variable {F : Type*} [Field F] under which the entire merge is generic."
+    },
+    {
       "id": "lcm-coprime",
       "title": "lcm = product for coprime monic polynomials",
       "startLine": 55,


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05` (quality 91, pass 0).

The entry already met all annotation/insight/conclusion minimums (5 rich annotations, 4 keyInsights, full conclusion). The one genuine gap was **section coverage**: `sections` began at line 55, leaving the header, imports, parent-scaffold docstring, and generic-field setup (lines 1–54) with no section.

## Change
- **meta.json:** added a `header-setup` section (lines 1–54) summarizing the Mathlib/parent imports, the two sorry-free parent facts reused (charpoly = p·q, minpoly = lcm p q), the derogatory→nonderogatory framing of the coprime case, and the `variable {F : Type*} [Field F]` genericity. `sections` now cover the full 106-line file.

Kept curation-minded — no deepening of already-complete fields; meta.json 8.9→9.5 KB, well under caps.

## Verification
- JSON validates; `scripts/annotations/build.ts` resolves all annotations for this entry with 0 warnings.