### PR TITLE
Fix: replace removed unfold_let in 5 build-glob-breakage files (Mathlib v4.26)

### DIFF
--- a/proofs/Proofs/Erdos263Aristotle.lean
+++ b/proofs/Proofs/Erdos263Aristotle.lean
@@ -69,7 +69,7 @@ theorem doubleExp_tail_bound (N : ℕ) :
   set r := (1 : ℝ) / D ^ 2 with hr_def
   have hr_nn : (0 : ℝ) ≤ r := by positivity
   have hr_lt1 : r < 1 := by
-    unfold_let r; rw [div_lt_one (by positivity)]; nlinarith
+    simp only [hr_def]; rw [div_lt_one (by positivity)]; nlinarith
   -- Rewrite each term: 1/2^{2^{k+N+1}} = 1/D^{2^{k+1}}
   have hterm : ∀ k : ℕ, (1 : ℝ) / (2 : ℝ) ^ (2 ^ (k + N + 1)) = 1 / D ^ (2 ^ (k + 1)) := by
     intro k; congr 1; rw [hD_def, ← pow_mul]; congr 1
@@ -94,7 +94,7 @@ theorem doubleExp_tail_bound (N : ℕ) :
         ≤ 1 / D ^ (2 * (k + 1)) :=
             one_div_le_one_div_of_le (by positivity) (pow_le_pow_right hD_ge1 (key_arith k))
       _ = r ^ (k + 1) := by
-            unfold_let r; rw [div_pow, one_pow, ← pow_mul]
+            simp only [hr_def]; rw [div_pow, one_pow, ← pow_mul]
   -- Summability
   have hTsumm : Summable (fun k : ℕ => r ^ (k + 1)) :=
     (summable_nat_add_iff 1).mpr (summable_geometric_of_lt_one hr_nn hr_lt1)
@@ -104,7 +104,7 @@ theorem doubleExp_tail_bound (N : ℕ) :
   have hgeo : ∑' k : ℕ, r ^ (k + 1) = 1 / (D ^ 2 - 1) := by
     rw [show (fun k : ℕ => r ^ (k + 1)) = (fun k => r * r ^ k) from funext (fun k => by ring)]
     rw [tsum_mul_left, tsum_geometric_of_lt_one hr_nn hr_lt1]
-    unfold_let r
+    simp only [hr_def]
     have hD2_ne : D ^ 2 ≠ 0 := by positivity
     have h1r_pos : (0 : ℝ) < 1 - 1 / D ^ 2 := by
       rw [sub_pos, div_lt_one (by positivity)]; nlinarith

--- a/proofs/Proofs/Erdos263Problem.lean
+++ b/proofs/Proofs/Erdos263Problem.lean
@@ -575,7 +575,7 @@ private lemma doubleExp_tail_bound (N : ℕ) :
   set r := (1 : ℝ) / D ^ 2 with hr_def
   have hr_nn : (0 : ℝ) ≤ r := by positivity
   have hr_lt1 : r < 1 := by
-    unfold_let r; rw [div_lt_one (by positivity)]; nlinarith
+    simp only [hr_def]; rw [div_lt_one (by positivity)]; nlinarith
   -- Rewrite each term: 1/2^{2^{k+N+1}} = 1/D^{2^{k+1}}
   have hterm : ∀ k : ℕ, (1 : ℝ) / (2 : ℝ) ^ (2 ^ (k + N + 1)) = 1 / D ^ (2 ^ (k + 1)) := by
     intro k; congr 1; rw [hD_def, ← pow_mul]; congr 1
@@ -600,7 +600,7 @@ private lemma doubleExp_tail_bound (N : ℕ) :
         ≤ 1 / D ^ (2 * (k + 1)) :=
             one_div_le_one_div_of_le (by positivity) (pow_le_pow_right hD_ge1 (key_arith k))
       _ = r ^ (k + 1) := by
-            unfold_let r; rw [div_pow, one_pow, ← pow_mul]
+            simp only [hr_def]; rw [div_pow, one_pow, ← pow_mul]
   -- Summability
   have hTsumm : Summable (fun k : ℕ => r ^ (k + 1)) :=
     (summable_nat_add_iff 1).mpr (summable_geometric_of_lt_one hr_nn hr_lt1)
@@ -610,7 +610,7 @@ private lemma doubleExp_tail_bound (N : ℕ) :
   have hgeo : ∑' k : ℕ, r ^ (k + 1) = 1 / (D ^ 2 - 1) := by
     rw [show (fun k : ℕ => r ^ (k + 1)) = (fun k => r * r ^ k) from funext (fun k => by ring)]
     rw [tsum_mul_left, tsum_geometric_of_lt_one hr_nn hr_lt1]
-    unfold_let r
+    simp only [hr_def]
     have hD2_ne : D ^ 2 ≠ 0 := by positivity
     have h1r_pos : (0 : ℝ) < 1 - 1 / D ^ 2 := by
       rw [sub_pos, div_lt_one (by positivity)]; nlinarith

--- a/proofs/Proofs/Erdos299Problem.lean
+++ b/proofs/Proofs/Erdos299Problem.lean
@@ -228,7 +228,7 @@ theorem erdos_299_no_such_sequence :
   -- The gap a(n+1) - a(n) is positive (strict mono), so bounded by a(N₀+1) for n ≤ N₀
   set Cnat := Nat.max (a (N₀ + 1)) (Nat.ceil C + 1) with hCnat_def
   have hCnat_pos : Cnat > 0 := by
-    unfold_let Cnat; exact Nat.lt_of_lt_of_le (hpos (N₀ + 1)) (Nat.le_max_left _ _)
+    simp only [hCnat_def]; exact Nat.lt_of_lt_of_le (hpos (N₀ + 1)) (Nat.le_max_left _ _)
   -- Uniform gap bound
   have hunif : HasUniformBoundedGaps a Cnat := by
     intro n

--- a/proofs/Proofs/FourierSeriesOQ02OQ03OQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ03OQ02.lean
@@ -153,14 +153,14 @@ theorem exp_decay_summable (δ : ℝ) (hδ : 0 < δ) :
                (fun n : ℕ => Real.exp (-c * ↑n)) := by
       ext n; congr 1
       rw [Int.cast_natCast, abs_of_nonneg (Nat.cast_nonneg n)]
-      unfold_let c; ring
+      simp only [hc_def]; ring
     rw [heq]; exact hsumm
   · -- Negative half: f(-↑n) for n : ℕ, where |↑(-↑n)| = n
     have heq : (fun n : ℕ => Real.exp (-(2 * Real.pi * δ * |(↑(-↑n : ℤ) : ℝ)|) / T)) =
                (fun n : ℕ => Real.exp (-c * ↑n)) := by
       ext n; congr 1
       rw [Int.cast_neg, Int.cast_natCast, abs_neg, abs_of_nonneg (Nat.cast_nonneg n)]
-      unfold_let c; ring
+      simp only [hc_def]; ring
     rw [heq]; exact hsumm
 
 /-- Exponential decay of Fourier coefficients implies absolute convergence

--- a/proofs/Proofs/Stubs/Erdos263Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos263Problem.lean
@@ -575,7 +575,7 @@ private lemma doubleExp_tail_bound (N : ℕ) :
   set r := (1 : ℝ) / D ^ 2 with hr_def
   have hr_nn : (0 : ℝ) ≤ r := by positivity
   have hr_lt1 : r < 1 := by
-    unfold_let r; rw [div_lt_one (by positivity)]; nlinarith
+    simp only [hr_def]; rw [div_lt_one (by positivity)]; nlinarith
   -- Rewrite each term: 1/2^{2^{k+N+1}} = 1/D^{2^{k+1}}
   have hterm : ∀ k : ℕ, (1 : ℝ) / (2 : ℝ) ^ (2 ^ (k + N + 1)) = 1 / D ^ (2 ^ (k + 1)) := by
     intro k; congr 1; rw [hD_def, ← pow_mul]; congr 1
@@ -600,7 +600,7 @@ private lemma doubleExp_tail_bound (N : ℕ) :
         ≤ 1 / D ^ (2 * (k + 1)) :=
             one_div_le_one_div_of_le (by positivity) (pow_le_pow_right hD_ge1 (key_arith k))
       _ = r ^ (k + 1) := by
-            unfold_let r; rw [div_pow, one_pow, ← pow_mul]
+            simp only [hr_def]; rw [div_pow, one_pow, ← pow_mul]
   -- Summability
   have hTsumm : Summable (fun k : ℕ => r ^ (k + 1)) :=
     (summable_nat_add_iff 1).mpr (summable_geometric_of_lt_one hr_nn hr_lt1)
@@ -610,7 +610,7 @@ private lemma doubleExp_tail_bound (N : ℕ) :
   have hgeo : ∑' k : ℕ, r ^ (k + 1) = 1 / (D ^ 2 - 1) := by
     rw [show (fun k : ℕ => r ^ (k + 1)) = (fun k => r * r ^ k) from funext (fun k => by ring)]
     rw [tsum_mul_left, tsum_geometric_of_lt_one hr_nn hr_lt1]
-    unfold_let r
+    simp only [hr_def]
     have hD2_ne : D ^ 2 ≠ 0 := by positivity
     have h1r_pos : (0 : ℝ) < 1 - 1 / D ^ 2 := by
       rw [sub_pos, div_lt_one (by positivity)]; nlinarith


### PR DESCRIPTION
## Fix

The `unfold_let` tactic was **removed** in the pinned Mathlib (v4.26.0). Because `proofs/lakefile.toml` auto-discovers all files under `proofs/Proofs/` via a recursive glob, every file that still uses `unfold_let` fails `lake build` with `unknown tactic`.

This PR replaces `unfold_let` in five files that use the `set X := e with hX_def` pattern, where `unfold_let X` → `simp only [hX_def]` is a faithful one-for-one drop-in (`hX_def : X = e` rewrites `X → e`, identical to `unfold_let`'s effect on the goal). Same substitution verified for the merged amgm fix (#34919) and pappus fix (#34929).

## Files (5)

| file | var → hypothesis |
|------|------------------|
| `Erdos299Problem.lean` | `Cnat` → `hCnat_def` |
| `Erdos263Aristotle.lean` | `r` → `hr_def` (×3) |
| `Erdos263Problem.lean` | `r` → `hr_def` (×3) |
| `Stubs/Erdos263Problem.lean` | `r` → `hr_def` (×3) |
| `FourierSeriesOQ02OQ03OQ02.lean` | `c` → `hc_def` (×2) |

## Scope: this is an INCREMENTAL fix, not a full compile-restore

⚠️ **These files carry additional Mathlib v4.26 drift beyond `unfold_let`** (reported by a peer mechanic during #34921 investigation):
- `Erdos263Problem` / `Stubs/Erdos263Problem` / `Erdos263Aristotle` — `tsum_eq_zero_add` may be renamed/unknown in v4.26.
- `Erdos299Problem` — a downstream type-mismatch around `Nat.not_eq_zero_of_lt`.

This PR fixes **only** the `unfold_let` blocker (which must be replaced regardless). It removes one drift source and is **strictly non-regressing** — all five files already fail to compile, so this cannot break a passing file — but it may not, by itself, fully restore compilation. Completing these likely needs a researcher drift-repair pass once the build cache is rebuilt.

## Verification note

Full Docker build verification is **unavailable**: the shared Mathlib/aesop olean package cache is corrupted (`exit 135`/SIGBUS on every target, incl. trivial deps like `Proofs.SzemerediCoreOQ01`). The `unfold_let` → `simp only [hX_def]` substitution is verified by pattern-equivalence to the merged #34919; each replaced var's `with hX_def` hypothesis was confirmed in scope.

## Not touched (need per-file care — tracked in #34921)

- `LebesgueMeasureOQ06.lean` — `Mφ/Mψ` are bare `let` bindings; `unfold_let`-on-`let` ≠ `simp only [h]`.
- `FourierSeriesOQ02OQ04.lean` — unfolds global `def`s (`geomRatio`, `wFunc`).
- `Erdos700Problem.lean` — multiple `set` **without** `with`.

Refs #34921

---
Automated fix by lean-mechanic agent.