### PR TITLE
Enrich: Pseudo-Dimension Covering Bound (header section + fix 2 annotation anchors)

### DIFF
--- a/src/data/proofs/pac-learning-bounds-wip-01-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01-oq-02-oq-04/annotations.json
@@ -38,7 +38,7 @@
   {
     "id": "ann-pac-wip01oq02oq04-04-injectivity",
     "proofId": "pac-learning-bounds-wip-01-oq-02-oq-04",
-    "range": { "startLine": 125, "endLine": 165 },
+    "range": { "startLine": 126, "endLine": 165 },
     "type": "theorem",
     "title": "hypoOn_eq_imp_eqOn / hypoOn_injOn: sample-injectivity via trichotomy",
     "content": "hypoOn_eq_imp_eqOn: if two b-bounded functions have the same hypograph over P, they agree on P. The proof is a clean lt-trichotomy needing no closed-form column count: if g x < g' x ≤ b at some x ∈ P, then i := ⟨g x, _⟩ is a valid threshold in Fin b, and (x,i) lies in the hypograph of g' (g' x > g x) but not of g (g x > g x is false), contradicting equality of the hypographs; the symmetric case is identical. hypoOn_injOn packages this as Set.InjOn (hypoOn P b) F for a b-bounded, P-separated class (distinct members already differ on the sample).",
@@ -50,7 +50,7 @@
   {
     "id": "ann-pac-wip01oq02oq04-05-growth",
     "proofId": "pac-learning-bounds-wip-01-oq-02-oq-04",
-    "range": { "startLine": 167, "endLine": 199 },
+    "range": { "startLine": 168, "endLine": 199 },
     "type": "theorem",
     "title": "growthFunction_le_sum_choose / growthFunction_le_pdim: the real-valued growth bound",
     "content": "growthFunction_le_sum_choose: for a b-bounded, P-separated class F of pseudo-dimension ≤ d, card_image_of_injOn turns injectivity into |hypoFam| = |F|, so F.card ≤ Σ_{i≤d} C(|P|·b, i) = O((|P|·b)^d). This is the honest lift of the Boolean growth-function bound to level-valued classes — the O((m/γ)^d) covering bound of oq-04. growthFunction_le_pdim states the same with d = Pdim P b F (the reflexive case), the form covering-number arguments consume. #print axioms confirms dependence only on propext / Classical.choice / Quot.sound: 0 sorries, 0 axioms, no native_decide.",

--- a/src/data/proofs/pac-learning-bounds-wip-01-oq-02-oq-04/meta.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01-oq-02-oq-04/meta.json
@@ -107,6 +107,13 @@
   },
   "sections": [
     {
+      "id": "header-overview",
+      "title": "Module header: the hypograph reduction and what is proved",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Imports the sorry-free parent Sauer–Shelah file (PACLearningBoundsWIP01SauerShelah) and frames open question oq-04: lift the Boolean growth bound |Π_H(S)| ≤ Σ_{i≤d} C(|S|,i) to level/integer-valued classes via Pollard–Haussler's hypograph/subgraph reduction. The docstring states the four results (hypoFam_card_le_sum_choose, hypoOn_injOn, growthFunction_le_sum_choose, growthFunction_le_pdim), records the 0-sorry / 0-axiom / no-native_decide status, and flags the deferred parts (the sharp (2/γ)^k constant and the L∞-cover-to-pattern reduction). Opens the namespace and fixes variable {α : Type*} [DecidableEq α]."
+    },
+    {
       "id": "hypograph-encoding",
       "title": "The Hypograph Encoding and the Pseudo-Dimension",
       "startLine": 66,


### PR DESCRIPTION
Enrichment pass for `pac-learning-bounds-wip-01-oq-02-oq-04` (quality 93, pass 0).

The entry already met all content minimums (5 rich annotations, 5 keyInsights, full conclusion). This pass closes two concrete gaps:

## Changes
- **Section coverage:** added a `header-overview` section (lines 1–65) covering imports, the Pollard–Haussler hypograph-reduction framing, the four proved results, the 0-sorry/0-axiom status, and the deferred follow-ups. `sections` now span the full 200-line file (previously started at line 66).
- **Annotation anchor fixes:** two annotations had `startLine` on a non-declaration line, producing "No Lean construct found" warnings in `scripts/annotations/build.ts`:
  - `ann-...-04-injectivity`: 125 → 126 (line 125 is `omit [DecidableEq α] in`; 126 is the theorem's doc-comment).
  - `ann-...-05-growth`: 167 → 168 (line 167 is blank; 168 is the theorem's doc-comment).
  Both now resolve; the resolver anchors from a construct's doc-comment start.

Curation-minded — no deepening of complete fields; meta.json ~19.8→20.6 KB, well under caps.

## Verification
- JSON validates; `scripts/annotations/build.ts` reports 0 warnings for this entry (both were present before this pass).