### PR TITLE
Research(erdos-793-oq-03): VERIFIED r-product primitive framework (0 sorry, 0 axiom)

### DIFF
--- a/proofs/Proofs/Erdos793OQ03.lean
+++ b/proofs/Proofs/Erdos793OQ03.lean
@@ -1,0 +1,228 @@
+/-
+# Erdős Problem #793 — OQ-03: the r-product primitive framework
+
+Follow-up to Erdős Problem #793 (`Erdos793Problem.lean`), open question OQ-03:
+*"Asymptotic constant for the r-product primitive-set counting function."*
+
+The parent problem asks about `F(n)`, the maximum size of `A ⊆ {1,…,n}` in which no
+element divides the product of **two** other distinct elements, and conjectures a
+precise second-order asymptotic
+`F(n) = π(n) + (C + o(1)) · n^{2/3} · (log n)^{-2}`.
+The generalized function `F_r(n)` replaces "two" by `r`: no element may divide the
+product of `r` other distinct elements.  Erdős's exponent `2/3` becomes `2/(r+1)`,
+and OQ-03 asks whether `F_r(n) − π(n)`, suitably normalized, converges to a
+constant `C_r`.
+
+This file builds the **verified structural core** of that generalized framework —
+the facts that hold for *every* `r`, independent of the (open) asymptotic constant:
+
+* `conditionR_hereditary`      : the r-product condition passes to subsets;
+* `primes_satisfy_conditionR`  : **any** finset of primes satisfies the condition,
+  for every `r` (no size threshold needed) — the source of the trivial lower bound;
+* `primePi_le_F_r`             : hence `F_r(n) ≥ π(n)` for all `r ≥ 0`
+  (a *verified* lower bound; the parent only stated this axiomatically for `r = 2`);
+* `conditionR_antitone`        : if `r < |A|`, the condition for `r` implies it for
+  every smaller `r'` — the conditions form a descending chain;
+* `conditionR_one_iff_primitive`      : the `r = 1` case is exactly the classical
+  primitive-set (divisibility-antichain) condition;
+* `conditionR_two_iff_noDividesProduct` : the `r = 2` case is exactly the parent's
+  `noDividesProduct`, so `F_r(·,2)` faithfully generalizes `F`;
+* `secondaryTermR_nonneg`      : the secondary term `F_r(n) − π(n)` is `≥ 0`,
+  so any limiting constant `C_r` (should it exist) is nonnegative.
+
+The genuinely open question — existence of the asymptotic constant — is isolated as
+the *unproven* proposition `erdos793ConstantConjectureR`; it is **stated, not
+assumed**.  Every theorem in this file is axiom-free (0 sorries, 0 `axiom`s).
+-/
+
+import Mathlib
+import Proofs.Erdos793Problem
+
+namespace Erdos793RProduct
+
+open Finset
+
+/-! ## Heredity
+
+The r-product condition is preserved under taking subsets: a smaller ground set has
+fewer products to avoid.  This is the reason `F_r` is well-defined as a maximum over
+all valid subsets. -/
+
+/-- The r-product condition passes to subsets. -/
+theorem conditionR_hereditary {A B : Finset ℕ} (hBA : B ⊆ A) {r : ℕ}
+    (hA : satisfiesConditionR A r) : satisfiesConditionR B r := by
+  intro a ha C hCB hCcard haC
+  exact hA a (hBA ha) C (hCB.trans hBA) hCcard haC
+
+/-! ## Primes satisfy the condition for every `r`
+
+A prime `p` can divide a product of distinct primes only by *being* one of them.
+Hence any finset all of whose elements are prime satisfies the r-product condition,
+with **no** lower size threshold on the primes (contrast the parent file, which
+imposed `p > n^{2/3}` and only handled `r = 2`).  This is the structural source of
+the trivial lower bound `F_r(n) ≥ π(n)`. -/
+
+/-- Any finset of primes satisfies the r-product condition, for every `r`. -/
+theorem primes_satisfy_conditionR (A : Finset ℕ) (hA : ∀ p ∈ A, Nat.Prime p)
+    (r : ℕ) : satisfiesConditionR A r := by
+  intro a ha B hBA hBcard haB hdvd
+  have hpa : Nat.Prime a := hA a ha
+  -- a ∣ ∏_{b ∈ B} b  ⟹  ∃ b ∈ B, a ∣ b
+  obtain ⟨b, hbB, hab⟩ := (hpa.prime.dvd_finset_prod_iff id).mp hdvd
+  have hpb : Nat.Prime b := hA b (hBA hbB)
+  -- a ∣ b with both prime forces a = b, contradicting a ∉ B ∋ b
+  have hEq : a = b := (Nat.prime_dvd_prime_iff_eq hpa hpb).mp hab
+  exact haB (hEq ▸ hbB)
+
+/-- **Verified lower bound.** The primes in `[1,n]` form a valid configuration, so
+`F_r(n) ≥ π(n)` for every `r`. -/
+theorem primePi_le_F_r (n r : ℕ) : primePi n ≤ F_r n r := by
+  -- The set of primes ≤ n.
+  set P : Finset ℕ := (Finset.Icc 1 n).filter Nat.Prime with hP
+  have hPsub : P ⊆ Icc_nat n := by
+    intro x hx; exact (Finset.mem_filter.mp hx).1
+  have hPcond : satisfiesConditionR P r :=
+    primes_satisfy_conditionR P (fun p hp => (Finset.mem_filter.mp hp).2) r
+  have hPcard : P.card = primePi n := rfl
+  have hmem : primePi n ∈
+      { k : ℕ | ∃ A : Finset ℕ, A ⊆ Icc_nat n ∧ satisfiesConditionR A r ∧ A.card = k } :=
+    ⟨P, hPsub, hPcond, hPcard⟩
+  -- The value set is bounded above by n = |Icc_nat n|.
+  have hbdd : BddAbove
+      { k : ℕ | ∃ A : Finset ℕ, A ⊆ Icc_nat n ∧ satisfiesConditionR A r ∧ A.card = k } := by
+    refine ⟨n, ?_⟩
+    rintro k ⟨A, hAsub, -, rfl⟩
+    calc A.card ≤ (Icc_nat n).card := Finset.card_le_card hAsub
+      _ = n := by simp [Icc_nat, Nat.card_Icc]
+  unfold F_r
+  exact le_csSup hbdd hmem
+
+/-! ## The conditions form a descending chain in `r`
+
+If no element divides a product of `r` others, then (provided the ground set is big
+enough to pad a short product up to length `r`) no element divides a product of
+fewer others either: a short divisible product extends to a long divisible product.
+Thus `satisfiesConditionR A r` is *stronger* for larger `r`. -/
+
+/-- Downward monotonicity in `r`: on a ground set of size `> r`, the r-product
+condition implies the `r'`-product condition for every `r' ≤ r`.  (The size bound
+`r < |A|` is genuinely needed: for `|A| ≤ r` the r-product condition is vacuous.) -/
+theorem conditionR_antitone {A : Finset ℕ} {r r' : ℕ}
+    (hrr : r' ≤ r) (hcard : r < A.card)
+    (hA : satisfiesConditionR A r) : satisfiesConditionR A r' := by
+  intro a ha B hBA hBcard haB hdvd
+  -- B lives in A \ {a}
+  have hBsub' : B ⊆ A \ {a} := by
+    intro x hx
+    rw [Finset.mem_sdiff]
+    exact ⟨hBA hx, by simp only [Finset.mem_singleton]; rintro rfl; exact haB hx⟩
+  -- |A \ {a}| = |A| - 1
+  have hAa_card : (A \ {a}).card = A.card - 1 := by
+    rw [← Finset.erase_eq, Finset.card_erase_of_mem ha]
+  -- there is room to pick `r - r'` fresh elements of `A \ {a}` avoiding `B`
+  have hDroom : r - r' ≤ ((A \ {a}) \ B).card := by
+    rw [Finset.card_sdiff_of_subset hBsub', hAa_card, hBcard]; omega
+  obtain ⟨D, hDsub, hDcard⟩ := Finset.exists_subset_card_eq hDroom
+  have hdisj : Disjoint D B := by
+    rw [Finset.disjoint_left]
+    intro x hxD hxB
+    exact (Finset.mem_sdiff.mp (hDsub hxD)).2 hxB
+  -- pad B up to a set C of size r inside A \ {a}
+  set C : Finset ℕ := B ∪ D with hC
+  have hBC : B ⊆ C := Finset.subset_union_left
+  have hCsub : C ⊆ A \ {a} :=
+    Finset.union_subset hBsub' (hDsub.trans (Finset.sdiff_subset))
+  have hCcard : C.card = r := by
+    rw [hC, Finset.card_union_of_disjoint hdisj.symm, hBcard, hDcard]; omega
+  have hCA : C ⊆ A := hCsub.trans (Finset.sdiff_subset)
+  have haC : a ∉ C := by
+    intro h
+    have h2 := hCsub h
+    rw [Finset.mem_sdiff] at h2
+    exact h2.2 (Finset.mem_singleton_self a)
+  -- the short divisible product extends to a long one
+  have hdvdC : a ∣ C.prod id :=
+    hdvd.trans (Finset.prod_dvd_prod_of_subset B C id hBC)
+  exact hA a ha C hCA hCcard haC hdvdC
+
+/-! ## Endpoints of the framework
+
+The `r = 1` and `r = 2` cases identify the generalized condition with familiar
+notions, confirming that `F_r` genuinely extends the classical primitive-set counting
+function (`r = 1`) and the parent problem's `F` (`r = 2`). -/
+
+/-- The `r = 1` condition is exactly the classical primitive-set condition: no element
+divides another. -/
+theorem conditionR_one_iff_primitive (A : Finset ℕ) :
+    satisfiesConditionR A 1 ↔ ∀ a ∈ A, ∀ b ∈ A, a ≠ b → ¬(a ∣ b) := by
+  constructor
+  · intro h a ha b hb hab
+    have hsub : ({b} : Finset ℕ) ⊆ A := by simpa using hb
+    have hnotmem : a ∉ ({b} : Finset ℕ) := by simp [hab]
+    have := h a ha {b} hsub (by simp) hnotmem
+    simpa using this
+  · intro h a ha B hBA hBcard haB
+    obtain ⟨b, rfl⟩ := Finset.card_eq_one.mp hBcard
+    have hbA : b ∈ A := hBA (Finset.mem_singleton_self b)
+    have hab : a ≠ b := fun heq => haB (heq ▸ Finset.mem_singleton_self b)
+    simpa using h a ha b hbA hab
+
+/-- The `r = 2` condition is exactly the parent file's `noDividesProduct`: no element
+divides the product of two *distinct* others. -/
+theorem conditionR_two_iff_noDividesProduct (A : Finset ℕ) :
+    satisfiesConditionR A 2 ↔ noDividesProduct A := by
+  constructor
+  · intro h a ha b hb c hc hab hac hbc hdvd
+    have hsub : ({b, c} : Finset ℕ) ⊆ A := by
+      intro x hx
+      rcases Finset.mem_insert.mp hx with rfl | hx'
+      · exact hb
+      · rw [Finset.mem_singleton] at hx'; exact hx' ▸ hc
+    have hcard : ({b, c} : Finset ℕ).card = 2 := by
+      rw [Finset.card_insert_of_notMem (by simp [hbc]), Finset.card_singleton]
+    have hnotmem : a ∉ ({b, c} : Finset ℕ) := by
+      simp only [Finset.mem_insert, Finset.mem_singleton]
+      push_neg; exact ⟨hab, hac⟩
+    have hprod : ({b, c} : Finset ℕ).prod id = b * c := by
+      simp [Finset.prod_pair hbc]
+    exact h a ha {b, c} hsub hcard hnotmem (hprod ▸ hdvd)
+  · intro h a ha B hBA hBcard haB hdvd
+    obtain ⟨b, c, hbc, rfl⟩ := Finset.card_eq_two.mp hBcard
+    have hbA : b ∈ A := hBA (by simp)
+    have hcA : c ∈ A := hBA (by simp)
+    have hab : a ≠ b := fun heq => haB (heq ▸ by simp)
+    have hac : a ≠ c := fun heq => haB (heq ▸ by simp)
+    have hprod : ({b, c} : Finset ℕ).prod id = b * c := by simp [Finset.prod_pair hbc]
+    exact h a ha b hbA c hcA hab hac hbc (hprod ▸ hdvd)
+
+/-! ## The open asymptotic constant (OQ-03)
+
+Everything below is the *statement* of the open problem, together with the one sign
+fact we can verify unconditionally.  Nothing here is asserted true. -/
+
+/-- Secondary term `F_r(n) − π(n)`: the number of extra elements beyond the primes. -/
+noncomputable def secondaryTermR (n r : ℕ) : ℝ := (F_r n r : ℝ) - primePi n
+
+/-- Secondary term normalized by the conjectured order `n^{2/(r+1)}·(log n)^{-2}`. -/
+noncomputable def normalizedSecondaryR (n r : ℕ) : ℝ :=
+  secondaryTermR n r / ((n : ℝ) ^ ((2 : ℝ) / (r + 1)) * (Real.log n) ^ (-2 : ℝ))
+
+/-- **OQ-03 (open).** For each `r`, does the normalized secondary term converge to a
+constant `C_r`?  Stated as a proposition; deliberately not proved or assumed. -/
+def erdos793ConstantConjectureR (r : ℕ) : Prop :=
+  ∃ C : ℝ, Filter.Tendsto (fun n => normalizedSecondaryR n r) Filter.atTop (nhds C)
+
+/-- **Verified constraint on the open constant.** The secondary term is nonnegative
+(the primes alone already realize `π(n)`), so any limiting constant `C_r` must satisfy
+`C_r ≥ 0`. -/
+theorem secondaryTermR_nonneg (n r : ℕ) : 0 ≤ secondaryTermR n r := by
+  have h : (primePi n : ℝ) ≤ (F_r n r : ℝ) := by exact_mod_cast primePi_le_F_r n r
+  unfold secondaryTermR; linarith
+
+#check @primePi_le_F_r
+#check @conditionR_antitone
+#check @conditionR_one_iff_primitive
+#check @conditionR_two_iff_noDividesProduct
+#check erdos793ConstantConjectureR
+
+end Erdos793RProduct

--- a/src/data/proofs/erdos-793-oq-03/meta.json
+++ b/src/data/proofs/erdos-793-oq-03/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "erdos-793-oq-03",
+  "title": "Erdős #793 OQ-03: The r-Product Primitive Framework",
+  "slug": "erdos-793-oq-03",
+  "description": "Follow-up to Erdős #793: the generalized r-product primitive-set condition (no element divides a product of r other distinct elements) and its extremal function F_r(n). Verified structural core — primes are always valid (F_r(n) ≥ π(n)), downward monotonicity in r, and the r=1 / r=2 endpoint identifications — with the open asymptotic constant C_r isolated as an unproven proposition. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/793",
+    "date": "2026-07-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos793OQ03.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "divisibility",
+      "primitive-sets",
+      "primes",
+      "extremal-combinatorics",
+      "open-problem"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 793,
+    "erdosUrl": "https://erdosproblems.com/793",
+    "erdosProblemStatus": "open",
+    "axiomCount": 0,
+    "lineCount": 228,
+    "assumptions": "None. All results depend only on Lean's standard foundational axioms (propext, Classical.choice, Quot.sound); no `axiom` declarations and no structure-encoded assumptions. The open asymptotic constant is stated as an unproven proposition, not assumed.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #793 grows out of his 1938 paper 'On sequences of integers no one of which divides the product of two others', where he studied subsets of $\\{1,\\ldots,n\\}$ in which no element divides the product of two others. The classical primitive sets of Besicovitch (1934) and Behrend (1935) forbid only $a \\mid b$; Erdős's condition is strictly stronger, forbidding $a \\mid bc$. The natural generalization — forbidding $a \\mid b_1 \\cdots b_r$ for $r$ distinct others — shifts the critical prime threshold from $n^{2/3}$ to $n^{2/(r+1)}$, so the secondary-term exponent $2/3$ becomes $2/(r+1)$. OQ-03 of the parent formalization asks whether the normalized secondary term $F_r(n) - \\pi(n)$ converges to a constant $C_r$ for each $r$. This file supplies the verified structural scaffolding for that question: the facts that hold for every $r$, independent of the (still open) constant.",
+    "problemStatement": "For $r \\geq 1$, let $F_r(n)$ be the maximum size of $A \\subseteq \\{1,\\ldots,n\\}$ such that no element of $A$ divides the product of $r$ other distinct elements of $A$. Does the normalized secondary term $\\big(F_r(n) - \\pi(n)\\big) \\big/ \\big(n^{2/(r+1)} (\\log n)^{-2}\\big)$ converge to a constant $C_r$ as $n \\to \\infty$?",
+    "text": "The r-product generalization of Erdős #793. F_r(n) is the largest subset of {1,…,n} in which no element divides a product of r distinct others. OQ-03 asks whether the secondary term F_r(n) − π(n), normalized by n^{2/(r+1)}(log n)^{-2}, has a limiting constant C_r. This file verifies the structural core and isolates the open constant.",
+    "proofStrategy": "The generalized condition `satisfiesConditionR A r` and extremal function `F_r` are inherited from the parent file. The verified contributions are: (1) `conditionR_hereditary` — the condition passes to subsets, so `F_r` is a well-posed maximum. (2) `primes_satisfy_conditionR` — any finset of primes satisfies the condition for every $r$, since a prime dividing a product of distinct primes must equal one of them (via `Prime.dvd_finset_prod_iff` and `Nat.prime_dvd_prime_iff_eq`); this removes the parent's $r=2$-only, threshold-dependent hypothesis. (3) `primePi_le_F_r` — hence $F_r(n) \\geq \\pi(n)$ for every $r$, obtained by exhibiting the prime set as a member of the value set and applying `le_csSup` with an explicit `BddAbove` witness ($n = |[1,n]|$); the parent only asserted this axiomatically. (4) `conditionR_antitone` — for $r < |A|$, the $r$-condition implies the $r'$-condition for $r' \\leq r$, proved by padding an $r'$-subset up to size $r$ inside $A \\setminus \\{a\\}$ (disjoint-union of a fresh $(r-r')$-set from `exists_subset_card_eq`) and extending divisibility through `prod_dvd_prod_of_subset`; the size bound is shown necessary (the condition is vacuous when $|A| \\leq r$). (5) `conditionR_one_iff_primitive` and `conditionR_two_iff_noDividesProduct` — the $r=1$ and $r=2$ cases coincide with the classical primitive condition and the parent's `noDividesProduct`, confirming the generalization is faithful. (6) `secondaryTermR_nonneg` — the secondary term is nonnegative, constraining any limiting constant to $C_r \\geq 0$. The open question itself is defined as the proposition `erdos793ConstantConjectureR`, stated but not assumed.",
+    "keyInsights": [
+      "**Primes are free for every $r$**: A prime dividing a product of *distinct* primes must be one of them, so any set of primes satisfies the $r$-product condition with no size threshold. This is the clean, general reason $F_r(n) \\geq \\pi(n)$ — a fact the parent file could only postulate as an axiom for $r = 2$.",
+      "**The verified trivial lower bound**: $F_r(n) \\geq \\pi(n)$ becomes a machine-checked theorem via `le_csSup`, once the prime set is shown to be a valid configuration and the value set is bounded above by $n$. This anchors the entire secondary-term question on solid ground.",
+      "**Conditions form a descending chain**: Requiring that no element divide an $r$-product is *stronger* for larger $r$ — provided the ground set has more than $r$ elements. A short divisible product can always be padded up to length $r$, so a violation at level $r'$ propagates to level $r$. Below the size threshold the condition is vacuous, and this boundary is genuinely necessary.",
+      "**Faithful endpoints**: $r = 1$ recovers the classical primitive-set (divisibility-antichain) condition, and $r = 2$ recovers the parent problem's `noDividesProduct`. The generalized $F_r$ therefore interpolates between the primitive-set counting function and Erdős's #793.",
+      "**A sign constraint on the open constant**: Since the primes alone realize $\\pi(n)$, the secondary term $F_r(n) - \\pi(n)$ is nonnegative, so any limiting constant $C_r$ must satisfy $C_r \\geq 0$ — a small but unconditional piece of information about the open problem."
+    ],
+    "prerequisites": [
+      "Number theory (primes, divisibility, Euclid's lemma)",
+      "Extremal combinatorics (extremal set functions, supremum/BddAbove)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview and Statement",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Documents OQ-03 of Erdős #793: the r-product generalization, the exponent shift 2/3 → 2/(r+1), and the plan to verify the r-independent structural core while isolating the open constant. Imports Mathlib and the parent file.",
+      "mathContext": "Verified: header documenting the generalized r-product framework and the split between verified structure and the open asymptotic constant."
+    },
+    {
+      "id": "heredity",
+      "title": "Heredity",
+      "startLine": 48,
+      "endLine": 62,
+      "summary": "`conditionR_hereditary`: the r-product condition passes to subsets, so F_r is a well-defined maximum over valid configurations.",
+      "mathContext": "Verified theorem: satisfiesConditionR A r and B ⊆ A imply satisfiesConditionR B r."
+    },
+    {
+      "id": "primes",
+      "title": "Primes Satisfy the Condition for Every r",
+      "startLine": 63,
+      "endLine": 116,
+      "summary": "`primes_satisfy_conditionR`: any finset of primes satisfies the condition for all r (via Prime.dvd_finset_prod_iff). `primePi_le_F_r`: the verified trivial lower bound F_r(n) ≥ π(n) via le_csSup with an explicit BddAbove witness.",
+      "mathContext": "Verified: prime sets are valid configurations for every r, yielding the machine-checked lower bound F_r(n) ≥ π(n)."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Descending Chain in r",
+      "startLine": 117,
+      "endLine": 163,
+      "summary": "`conditionR_antitone`: for r < |A|, the r-product condition implies the r'-product condition for r' ≤ r. Proof pads a short subset up to size r inside A \\ {a} using a disjoint fresh set and extends divisibility through prod_dvd_prod_of_subset. The size hypothesis is necessary (vacuity for |A| ≤ r).",
+      "mathContext": "Verified theorem: downward monotonicity of the r-product condition on ground sets of size greater than r."
+    },
+    {
+      "id": "endpoints",
+      "title": "Endpoints r = 1 and r = 2",
+      "startLine": 164,
+      "endLine": 200,
+      "summary": "`conditionR_one_iff_primitive`: r=1 coincides with the classical primitive-set condition. `conditionR_two_iff_noDividesProduct`: r=2 coincides with the parent's noDividesProduct, confirming F_r faithfully generalizes both the primitive counting function and Erdős #793.",
+      "mathContext": "Verified: identification of the r=1 and r=2 cases with classical notions."
+    },
+    {
+      "id": "open-constant",
+      "title": "The Open Asymptotic Constant (OQ-03)",
+      "startLine": 201,
+      "endLine": 228,
+      "summary": "Defines the secondary term, its normalization by n^{2/(r+1)}(log n)^{-2}, and the open proposition `erdos793ConstantConjectureR` (convergence to C_r), stated but not assumed. `secondaryTermR_nonneg` verifies the secondary term is ≥ 0, constraining C_r ≥ 0.",
+      "mathContext": "The open question stated as an unproven proposition, plus the verified nonnegativity constraint on any limiting constant."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file establishes the verified structural core of the r-product generalization of Erdős #793: any set of primes is a valid configuration for every r (turning the parent's r=2 axiom into a general theorem), giving the machine-checked lower bound F_r(n) ≥ π(n); the r-product conditions form a descending chain in r on sufficiently large ground sets; and the r=1 and r=2 cases faithfully recover the classical primitive-set condition and the parent's noDividesProduct. The genuinely open content — existence of the normalized asymptotic constant C_r — is isolated as an unproven proposition, with the sole unconditional constraint C_r ≥ 0. All results are axiom-free (0 sorries, 0 axioms).",
+    "implications": "**Theoretical significance**: The generalized function F_r interpolates between the classical primitive-set counting function (r=1) and Erdős's product-divisibility problem (r=2), and the verified lower bound F_r(n) ≥ π(n) grounds the whole secondary-term question rigorously rather than axiomatically. The descending-chain structure clarifies how the difficulty of the extremal problem varies with r. What remains open is the arithmetic heart: the exact secondary-order constant, which connects to the distribution of n^{2/(r+1)}-smooth numbers and the multiplicative structure of integers near n.",
+    "openQuestions": [
+      "Does `erdos793ConstantConjectureR r` hold — that is, does the normalized secondary term converge to a constant C_r for each r? This is the core of OQ-03.",
+      "Is the constant C_r monotone (or otherwise structured) in r, and how does it degenerate as r → ∞ where the exponent 2/(r+1) → 0?",
+      "Can the verified lower bound F_r(n) ≥ π(n) be upgraded to a verified secondary-order lower bound F_r(n) ≥ π(n) + c·n^{2/(r+1)} by an explicit smooth-number construction?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos793Problem"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos793RProduct",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos793OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-793",
+      "relationship": "parent",
+      "description": "Parent problem: Erdős #793 on product-divisibility primitive sets. This file generalizes its r=2 condition to arbitrary r and verifies the structural core."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős #793 OQ-03 — the r-product primitive framework

Follow-up to **Erdős Problem #793**, open question OQ-03: *does the secondary term of the r-product primitive-set counting function have a limiting asymptotic constant $C_r$?*

The parent (`Erdos793Problem.lean`) defines the r-product condition (`satisfiesConditionR`) and its extremal function `F_r`, but leaves the r-general facts **axiomatized**. This PR replaces the axiomatic scaffolding with a **verified structural core** and isolates the genuinely open constant.

### Verified theorems (0 sorries, 0 axioms — `#print axioms` shows only `propext`/`Classical.choice`/`Quot.sound`)

| Theorem | Statement |
|---|---|
| `primes_satisfy_conditionR` | Any finset of primes satisfies the condition for **every** `r`, with no size threshold — generalizes the parent's `r=2`-only, `p > n^{2/3}` lemma |
| `primePi_le_F_r` | Machine-checked trivial lower bound **`F_r(n) ≥ π(n)`** (the parent only asserted this as an axiom) |
| `conditionR_antitone` | The r-product conditions form a **descending chain** for `r < |A|` (size bound shown necessary — vacuous when `|A| ≤ r`) |
| `conditionR_one_iff_primitive` | `r = 1` ⟺ the classical primitive-set (divisibility-antichain) condition |
| `conditionR_two_iff_noDividesProduct` | `r = 2` ⟺ the parent's `noDividesProduct` — faithful generalization |
| `conditionR_hereditary` | The condition passes to subsets |
| `secondaryTermR_nonneg` | The secondary term `F_r(n) − π(n) ≥ 0`, so any limiting `C_r ≥ 0` |

### Open core (stated, not assumed)
`erdos793ConstantConjectureR r` — convergence of the normalized secondary term to `C_r` — is defined as an **unproven proposition**. Nothing in the file assumes it.

### Verification
- Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos793OQ03` — succeeds (7744 jobs).
- `#print axioms` on all 7 theorems: only the three standard foundational axioms; no `axiom` declarations, no `sorryAx`, no structure-encoded assumptions.

### Files
- `proofs/Proofs/Erdos793OQ03.lean` (228 lines, 7 theorems, 3 defs)
- `src/data/proofs/erdos-793-oq-03/meta.json` (status `verified`, badge `verified`, axiomCount 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)