### PR TITLE
Enrich: Dobiński's Formula for Bell Numbers (header/roadmap section)

### DIFF
--- a/src/data/proofs/bell-numbers-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bell-numbers-oq-01-oq-02/meta.json
@@ -24,6 +24,14 @@
   },
   "sections": [
     {
+      "id": "header-overview",
+      "title": "Module header, imports, and proof roadmap",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "States Dobiński's formula Bₙ = (1/e)·Σ_k kⁿ/k! (1877) and the product form e·Bₙ = Σ_k kⁿ/k! actually proved. Lays out the bridge: the Stirling/falling-factorial expansion kⁿ = Σ_{j≤n} S(n,j)·(k)_j (absent from pinned Mathlib), divided by k! and summed so the falling factorial telescopes to Σ_k (k)_j/k! = e, then combined with the row-sum identity Bₙ = Σ_j S(n,j) from the parent BellNumbersOQ01. Imports the real exponential and normed-limit machinery and the parent file; opens Finset and scoped Nat.",
+      "mathContext": "$B_n = \\frac{1}{e}\\sum_{k=0}^{\\infty}\\frac{k^n}{k!}$, obtained from $k^n = \\sum_{j\\le n} S(n,j)\\,(k)_j$, $\\sum_k (k)_j/k! = e$, and $B_n = \\sum_j S(n,j)$."
+    },
+    {
       "id": "power-expansion",
       "title": "Section I: The Stirling / Falling-Factorial Expansion of a Power",
       "startLine": 56,


### PR DESCRIPTION
Enrichment pass for `bell-numbers-oq-01-oq-02` (quality 94, pass 0).

The entry already met all content minimums (7 rich annotations, 4 keyInsights, full conclusion). The one gap: `sections` began at line 56, leaving the header docstring, imports, and proof roadmap (lines 1–55) with no section.

## Change
- **meta.json:** added a `header-overview` section (lines 1–55) summarizing Dobiński's 1877 formula, the product form actually proved (e·Bₙ = Σ_k kⁿ/k!), the Stirling/falling-factorial bridge, the telescoping Σ_k (k)_j/k! = e, the parent row-sum identity Bₙ = Σ_j S(n,j), and the imports/opens. `sections` now cover the full 209-line file.

Curation-minded — no deepening of complete fields; meta.json 14.3→15.2 KB, well under caps.

## Verification
- JSON validates; `scripts/annotations/build.ts` reports 0 warnings for this entry.