### PR TITLE
Enrich: Eisenstein Criterion over Integral Domains (header/OQ-04 section)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-04/meta.json
@@ -67,6 +67,14 @@
   },
   "sections": [
     {
+      "id": "header-overview",
+      "title": "Module header and the OQ-04 question",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Frames open question OQ-04 of the parent bezout-identity-oq-02-oq-01-oq-02 (FTA generalization to Euclidean domains): is Eisenstein's criterion in Mathlib and usable here? The answer is yes and beyond UFDs — Mathlib's Polynomial.irreducible_of_eisenstein_criterion applies at any prime ideal of any commutative ring. The file packages it as: for any integral domain R, prime p, and n ≥ 1, Xⁿ − p is irreducible over R[X], via Eisenstein at the ideal (p), with specializations R = ℤ (Yⁿ − 2, Yⁿ − 3) and R = ℚ[X] (Yⁿ − X, Eisenstein at the prime element X — the parent's Euclidean-domain theme). Imports Mathlib, opens Polynomial, and enters the namespace.",
+      "mathContext": "$X^n - p$ irreducible over $R[X]$ for $R$ an integral domain, $p$ prime, $n \\ge 1$ — Eisenstein at the prime ideal $(p)$, generalizing the classical $\\mathbb{Z}$ case (e.g. $Y^n - 2$) to arbitrary integral domains including $\\mathbb{Q}[X]$."
+    },
+    {
       "id": "general",
       "title": "The General Theorem",
       "startLine": 42,


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-01-oq-02-oq-04` (quality 94, pass 0).

The entry already met all content minimums (5 rich annotations, 5 keyInsights, full conclusion). The one gap: `sections` began at line 42, leaving the header docstring, the OQ-04 question framing, and the imports (lines 1–41) with no section.

## Change
- **meta.json:** added a `header-overview` section (lines 1–41) covering the parent OQ-04 question, Mathlib's `irreducible_of_eisenstein_criterion`, the integral-domain generalization (Xⁿ − p irreducible for prime p), and the ℤ / ℚ[X] specializations. `sections` now cover the full 108-line file.

Curation-minded — no deepening of complete fields; meta.json 12.3→13.4 KB, well under caps.

## Verification
- JSON validates; `scripts/annotations/build.ts` reports 0 warnings for this entry.