### PR TITLE
Enrich: Erdős #793 OQ-03 — add annotations.json (0 → 7 annotations)

### DIFF
--- a/src/data/proofs/erdos-793-oq-03/annotations.json
+++ b/src/data/proofs/erdos-793-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-793oq03-header",
+    "proofId": "erdos-793-oq-03",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "context",
+    "title": "The r-product primitive framework and OQ-03",
+    "content": "The parent Erdős #793 studies F(n), the largest A ⊆ {1,…,n} in which no element divides the product of two other distinct elements, with conjectured second-order asymptotic F(n) = π(n) + (C + o(1))·n^{2/3}(log n)^{-2}. This file generalizes 'two' to r: F_r(n) forbids an element dividing a product of r distinct others, shifting the exponent 2/3 → 2/(r+1). OQ-03 asks whether the normalized secondary term (F_r(n) − π(n)) converges to a constant C_r. The file verifies the r-independent structural core — heredity, primes-are-free, the lower bound F_r(n) ≥ π(n), the descending chain in r, and the r=1 / r=2 endpoint identifications — while isolating the open constant as an unproven proposition. Imports Mathlib and the parent Erdos793Problem.",
+    "mathContext": "$F_r(n) = \\max\\{|A| : A \\subseteq \\{1,\\dots,n\\},\\ \\forall a\\in A,\\ a \\nmid \\textstyle\\prod_{b\\in B} b\\ \\text{for all } B \\subseteq A\\setminus\\{a\\},\\ |B|=r\\}$; OQ-03: does $\\big(F_r(n) - \\pi(n)\\big)\\big/\\big(n^{2/(r+1)}(\\log n)^{-2}\\big) \\to C_r$?",
+    "significance": "context",
+    "relatedConcepts": ["primitive sets", "Erdős product-divisibility", "extremal set function", "prime counting π(n)", "second-order asymptotics"],
+    "prerequisites": ["divisibility and primes", "extremal combinatorics", "asymptotic density"]
+  },
+  {
+    "id": "ann-793oq03-heredity",
+    "proofId": "erdos-793-oq-03",
+    "range": { "startLine": 51, "endLine": 55 },
+    "type": "theorem",
+    "title": "conditionR_hereditary: the condition passes to subsets",
+    "content": "conditionR_hereditary shows satisfiesConditionR A r and B ⊆ A imply satisfiesConditionR B r: a smaller ground set has strictly fewer r-products to avoid, so any forbidden configuration in B already lives in A. This heredity is what makes F_r a well-posed maximum — the family of valid configurations is downward closed, so a largest valid subset exists. The one-line proof just relays each witness through the inclusion B ⊆ A.",
+    "mathContext": "$B \\subseteq A \\ \\wedge\\ \\mathrm{satisfiesConditionR}(A,r) \\ \\Rightarrow\\ \\mathrm{satisfiesConditionR}(B,r)$ — the valid configurations form a downward-closed (hereditary) family.",
+    "significance": "supporting",
+    "relatedConcepts": ["hereditary property", "downward-closed family", "well-posed extremal maximum"],
+    "prerequisites": ["Finset subset relation", "quantifier relaying"]
+  },
+  {
+    "id": "ann-793oq03-primes",
+    "proofId": "erdos-793-oq-03",
+    "range": { "startLine": 65, "endLine": 75 },
+    "type": "theorem",
+    "title": "primes_satisfy_conditionR: primes are free for every r",
+    "content": "primes_satisfy_conditionR proves any finset of primes satisfies the r-product condition for every r, with no size threshold. The argument is Euclid's lemma in finset form: if prime a divides ∏_{b∈B} b, then Prime.dvd_finset_prod_iff yields some b ∈ B with a ∣ b; since b is also prime, Nat.prime_dvd_prime_iff_eq forces a = b, contradicting a ∉ B. This is a clean, fully general reason primes always work — the parent file could only postulate the r=2 case (with a p > n^{2/3} threshold) as an axiom.",
+    "mathContext": "$a$ prime, $a \\mid \\prod_{b\\in B} b$, all $b$ prime $\\Rightarrow \\exists b\\in B,\\ a = b$. Hence a set of primes never has an element dividing a product of the others, for any $r$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclid's lemma", "Prime.dvd_finset_prod_iff", "prime divides prime iff equal", "threshold-free construction"],
+    "prerequisites": ["primes and Euclid's lemma", "Finset.prod", "divisibility among primes"]
+  },
+  {
+    "id": "ann-793oq03-lowerbound",
+    "proofId": "erdos-793-oq-03",
+    "range": { "startLine": 77, "endLine": 98 },
+    "type": "theorem",
+    "title": "primePi_le_F_r: the verified lower bound F_r(n) ≥ π(n)",
+    "content": "primePi_le_F_r turns 'primes are free' into the trivial lower bound F_r(n) ≥ π(n). The primes in [1,n] form the set P = (Icc 1 n).filter Nat.Prime, which is a valid configuration (primes_satisfy_conditionR) of cardinality π(n), hence a member of the value set defining F_r. The value set is bounded above by n = |Icc_nat n| (any valid A has A.card ≤ (Icc_nat n).card), so le_csSup applies with an explicit BddAbove witness. The parent only asserted this bound axiomatically; here it is machine-checked, anchoring the whole secondary-term question on solid ground.",
+    "mathContext": "$P = \\{p \\le n : p \\text{ prime}\\}$ is valid and $|P| = \\pi(n)$, so $\\pi(n) \\in \\{|A| : \\dots\\}$; with the set bounded above by $n$, $\\pi(n) \\le \\sup = F_r(n)$ via $\\mathrm{le\\_csSup}$.",
+    "significance": "key",
+    "relatedConcepts": ["le_csSup", "BddAbove witness", "supremum of an extremal set", "prime counting function"],
+    "prerequisites": ["conditional completeness of ℝ / csSup", "BddAbove and Finset cardinality", "prime filtering"]
+  },
+  {
+    "id": "ann-793oq03-antitone",
+    "proofId": "erdos-793-oq-03",
+    "range": { "startLine": 107, "endLine": 146 },
+    "type": "theorem",
+    "title": "conditionR_antitone: the conditions form a descending chain in r",
+    "content": "conditionR_antitone shows that on a ground set with r < |A|, satisfiesConditionR A r implies satisfiesConditionR A r' for every r' ≤ r — the condition is stronger for larger r. Given a divisible r'-product B (a ∣ ∏B), the proof pads B up to size r inside A \\ {a}: exists_subset_card_eq supplies r − r' fresh elements D disjoint from B (room guaranteed by card_sdiff and the size hypothesis), and C := B ∪ D has |C| = r with a ∉ C. Divisibility extends through prod_dvd_prod_of_subset (a ∣ ∏B ∣ ∏C), so the r-violation contradicts the r-condition. The size bound r < |A| is genuinely necessary: for |A| ≤ r the r-product condition is vacuous.",
+    "mathContext": "$r' \\le r < |A|$: a divisible $r'$-product extends to a divisible $r$-product by padding with $r - r'$ fresh elements, so $\\mathrm{satisfiesConditionR}(A,r) \\Rightarrow \\mathrm{satisfiesConditionR}(A,r')$. Vacuous when $|A| \\le r$.",
+    "significance": "key",
+    "relatedConcepts": ["monotone/antitone family", "exists_subset_card_eq", "prod_dvd_prod_of_subset", "disjoint union padding", "vacuous truth boundary"],
+    "prerequisites": ["Finset cardinality arithmetic (card_sdiff, card_erase)", "divisibility of products", "disjoint unions"]
+  },
+  {
+    "id": "ann-793oq03-endpoints",
+    "proofId": "erdos-793-oq-03",
+    "range": { "startLine": 154, "endLine": 196 },
+    "type": "theorem",
+    "title": "conditionR_one/two_iff: faithful endpoints r=1 and r=2",
+    "content": "Two iff-theorems pin down the extremes of the framework. conditionR_one_iff_primitive: the r=1 condition (no element divides a singleton product, i.e. another element) is exactly the classical primitive-set / divisibility-antichain condition ∀ a b ∈ A, a ≠ b → ¬(a ∣ b). conditionR_two_iff_noDividesProduct: the r=2 condition coincides with the parent's noDividesProduct (no element divides a product of two distinct others), using Finset.prod_pair to identify {b,c}.prod id = b·c. Together they show F_r interpolates faithfully between the primitive-set counting function (r=1) and Erdős #793 (r=2).",
+    "mathContext": "$r=1$: $\\forall a\\ne b \\in A,\\ a \\nmid b$ (primitive / divisibility antichain). $r=2$: $\\forall$ distinct $a,b,c \\in A,\\ a \\nmid bc$ (the parent's noDividesProduct). $F_r$ interpolates between the two.",
+    "significance": "supporting",
+    "relatedConcepts": ["primitive set (Besicovitch/Behrend)", "divisibility antichain", "noDividesProduct", "Finset.prod_pair", "framework faithfulness"],
+    "prerequisites": ["Finset.card_eq_one / card_eq_two destructuring", "pair products", "the parent noDividesProduct definition"]
+  },
+  {
+    "id": "ann-793oq03-open-constant",
+    "proofId": "erdos-793-oq-03",
+    "range": { "startLine": 203, "endLine": 220 },
+    "type": "definition",
+    "title": "The open constant C_r and the sign constraint C_r ≥ 0",
+    "content": "The open question is stated, not assumed. secondaryTermR n r := F_r(n) − π(n) is the excess beyond the primes; normalizedSecondaryR divides it by the conjectured order n^{2/(r+1)}(log n)^{-2}; and erdos793ConstantConjectureR r := ∃ C, Tendsto normalizedSecondaryR atTop (nhds C) is OQ-03 as a bare Prop, deliberately left unproven. The one unconditional fact is secondaryTermR_nonneg: since the primes already realize π(n), the secondary term is ≥ 0, so any limiting constant C_r must satisfy C_r ≥ 0 — a small but genuine piece of information about the open problem.",
+    "mathContext": "$\\mathrm{secondaryTermR}(n,r) = F_r(n) - \\pi(n) \\ge 0$; $\\mathrm{normalizedSecondaryR}(n,r) = \\dfrac{F_r(n)-\\pi(n)}{n^{2/(r+1)}(\\log n)^{-2}}$; OQ-03: $\\exists C_r,\\ \\mathrm{normalizedSecondaryR}(n,r) \\to C_r$, with $C_r \\ge 0$ forced.",
+    "significance": "key",
+    "relatedConcepts": ["Filter.Tendsto / nhds", "open conjecture as a Prop", "secondary-order asymptotics", "nonnegativity constraint", "smooth numbers"],
+    "prerequisites": ["limits and Tendsto in ℝ", "real powers and logarithms", "stating vs assuming a conjecture"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-793-oq-03` (quality **45**, pass 0).

The low quality score came from a concrete, high-impact gap: the entry had **no `annotations.json` at all** (0 annotations), while its meta.json was already rich (full historicalContext, 5 keyInsights, 6 sections, conclusion).

## Change
- **Created `annotations.json` with 7 substantive annotations**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, anchored to the real Lean declarations:
  1. header/context — the r-product primitive framework and OQ-03 (exponent shift 2/3 → 2/(r+1))
  2. `conditionR_hereditary` — heredity makes F_r a well-posed maximum
  3. `primes_satisfy_conditionR` — primes are free for every r (Euclid's lemma in finset form)
  4. `primePi_le_F_r` — the verified lower bound F_r(n) ≥ π(n) via `le_csSup`
  5. `conditionR_antitone` — descending chain in r via product padding
  6. `conditionR_one/two_iff` — faithful r=1 (primitive) / r=2 (noDividesProduct) endpoints
  7. the open constant C_r + the verified sign constraint C_r ≥ 0

## Verification
- JSON validates; `scripts/annotations/build.ts` resolves all 7 anchors with **0 warnings**.
- Axiom integrity preserved: meta already correctly records status `verified`, 0 axioms, 0 sorries, with the open conjecture stated (not assumed).