### PR TITLE
research(erdos-153-oq-03): explicit stars-and-bars bridge |A.sym h| = C(|A|+h−1, h) [verified]

### DIFF
--- a/proofs/Proofs/Erdos153OQ03.lean
+++ b/proofs/Proofs/Erdos153OQ03.lean
@@ -40,6 +40,9 @@ constrained* as the Sidon (h = 2) case, because every B_h set is Sidon.
 - `hSumset`                : the h-fold sumset {a₁+⋯+a_h : aᵢ ∈ A}
 - `isBhSet_iff_injOn`      : B_h ⟺ Multiset.sum is injective on `A.sym h`
 - `card_hSumset_of_isBhSet`: sharp count — |h-fold sumset| = |A.sym h| = C(|A|+h−1, h)
+- `card_finset_sym_eq_choose`: the stars-and-bars bridge |A.sym h| = C(|A|+h−1, h)
+- `card_hSumset_eq_choose_of_isBhSet` : saturation in closed binomial form
+- `choose_le_of_isBhSet`     : the B_h density bound C(|A|+h−1, h) ≤ hN+1 in closed form
 -/
 import Mathlib
 
@@ -537,5 +540,77 @@ theorem isBhSet_iff_card_hSumset (h : ℕ) (A : Finset ℕ) :
     exact Finset.card_image_of_injOn H
   · intro H
     exact Finset.injOn_of_card_image_eq H
+
+/-!
+## Section IX: The explicit stars-and-bars bridge  `(A.sym h).card = C(|A|+h−1, h)`
+
+Sections VII–VIII stated every quantitative result with the *honest* quantity
+`(A.sym h).card`, noting only that it "is" the multiset coefficient
+`C(|A| + h − 1, h)` — because Mathlib supplies the stars-and-bars identity only
+in its `Fintype` form `Sym.card_sym_eq_choose` (for `Fintype.card (Sym α h)`),
+with no ready-made `Finset`-level `(A.sym h).card` companion.
+
+Here we close that gap.  The finset `A.sym h` of size-`h` multisets drawn from
+`A` is in explicit bijection with `Sym ↥A h`, the size-`h` multisets on the
+subtype `↥A = {a // a ∈ A}`: the map `Sym.map (Subtype.val)` sends a multiset on
+`↥A` to the underlying multiset on `ℕ` (whose elements all lie in `A`, so it
+lands in `A.sym h`), it is injective (`Subtype.val` is), and it is onto
+`A.sym h` (any size-`h` multiset with elements in `A` lifts back via
+`Sym.attach`).  Transporting `Sym.card_sym_eq_choose` across this bijection and
+using `Fintype.card ↥A = |A|` gives the closed form, upgrading the density bound
+and the saturation identity to their textbook binomial statements.
+-/
+
+/-- **The stars-and-bars identity for `Finset.sym`.**  The number of size-`h`
+multisets drawable from a finite set `A ⊆ ℕ` is the multiset coefficient
+    `(A.sym h).card = C(|A| + h − 1, h)`.
+Proof: `A.sym h` is the injective image of the universe of `Sym ↥A h` under
+`Sym.map Subtype.val`, so its cardinality is `Fintype.card (Sym ↥A h)`; the
+`Fintype`-level `Sym.card_sym_eq_choose` then evaluates that to
+`C(Fintype.card ↥A + h − 1, h)`, and `Fintype.card ↥A = |A|`. -/
+theorem card_finset_sym_eq_choose {h : ℕ} (A : Finset ℕ) :
+    (A.sym h).card = (A.card + h - 1).choose h := by
+  have hinj : Function.Injective (Sym.map (Subtype.val : {x // x ∈ A} → ℕ)) :=
+    Sym.map_injective Subtype.val_injective h
+  -- `A.sym h` is exactly the image of `Sym ↥A h` under `Sym.map Subtype.val`.
+  have key : A.sym h
+      = (Finset.univ : Finset (Sym {x // x ∈ A} h)).image (Sym.map Subtype.val) := by
+    ext s
+    simp only [Finset.mem_sym_iff, Finset.mem_image, Finset.mem_univ, true_and]
+    constructor
+    · -- a multiset with all elements in `A` lifts to `Sym ↥A h` via `attach`
+      intro hs
+      refine ⟨Sym.map (fun x : {a // a ∈ s} => (⟨x.1, hs x.1 x.2⟩ : {a // a ∈ A}))
+                s.attach, ?_⟩
+      rw [Sym.map_map]
+      exact Sym.attach_map_coe s
+    · -- every element of an image multiset is a `Subtype.val`, hence in `A`
+      rintro ⟨t, rfl⟩ a ha
+      rw [Sym.mem_map] at ha
+      obtain ⟨x, _, rfl⟩ := ha
+      exact x.2
+  rw [key, Finset.card_image_of_injective _ hinj, Finset.card_univ,
+      Sym.card_sym_eq_choose, Fintype.card_coe]
+
+/-- **Saturation in closed binomial form.**  For a `B_h` set `A`, the `h`-fold
+sumset has cardinality exactly the multiset coefficient:
+    `(hSumset h A).card = C(|A| + h − 1, h)`.
+The closed-form refinement of `card_hSumset_of_isBhSet`, obtained by evaluating
+`(A.sym h).card` via `card_finset_sym_eq_choose`. -/
+theorem card_hSumset_eq_choose_of_isBhSet {h : ℕ} {A : Finset ℕ} (H : IsBhSet h A) :
+    (hSumset h A).card = (A.card + h - 1).choose h := by
+  rw [card_hSumset_of_isBhSet H, card_finset_sym_eq_choose]
+
+/-- **The `B_h` density bound in closed binomial form.**  A `B_h` set
+`A ⊆ {0, …, N}` satisfies
+    `C(|A| + h − 1, h) ≤ hN + 1`.
+Since the left side is `∼ |A|^h / h!`, this is the sharp `|A| = O(N^{1/h})`
+generalisation of the Sidon (`h = 2`) bound `|A| = O(√N)`.  The closed-form
+refinement of `card_sym_le_of_isBhSet`, via `card_finset_sym_eq_choose`. -/
+theorem choose_le_of_isBhSet {h N : ℕ} {A : Finset ℕ}
+    (H : IsBhSet h A) (hA : A ⊆ Finset.range (N + 1)) :
+    (A.card + h - 1).choose h ≤ h * N + 1 := by
+  rw [← card_finset_sym_eq_choose]
+  exact card_sym_le_of_isBhSet H hA
 
 end Erdos153OQ03

--- a/src/data/research/problems/erdos-153-oq-03.json
+++ b/src/data/research/problems/erdos-153-oq-03.json
@@ -21,9 +21,9 @@
     "phase": "ACT",
     "since": "2026-07-04",
     "iteration": 4,
-    "focus": "Explicit stars-and-bars bridge CLOSED: card_finset_sym_eq_choose proves (A.sym h).card = C(|A|+h-1, h) by exhibiting A.sym h as the injective image of univ : Finset (Sym ↥A h) under Sym.map Subtype.val (injective via Subtype.val_injective; onto via Sym.attach + Sym.attach_map_coe), then transporting Sym.card_sym_eq_choose across it and using Fintype.card_coe. This removes the honest-quantity caveat from Sections VII-VIII: added closed-form corollaries card_hSumset_eq_choose_of_isBhSet (saturation) and choose_le_of_isBhSet (density bound C(|A|+h-1,h) ≤ hN+1). 0 sorry, 0 axiom. Build-pending: Docker infra corrupt this session (containerd content-store I/O error on the lean4 image blob), so verification is by static lemma-name/typing analysis against current Mathlib source, not a compile.",
+    "focus": "Explicit stars-and-bars bridge CLOSED and NOW BUILD-VERIFIED: card_finset_sym_eq_choose proves (A.sym h).card = C(|A|+h-1, h) by exhibiting A.sym h as the injective image of univ : Finset (Sym ↥A h) under Sym.map Subtype.val (injective via Subtype.val_injective; onto via Sym.attach + Sym.attach_map_coe), then transporting Sym.card_sym_eq_choose across it and using Fintype.card_coe. This removes the honest-quantity caveat from Sections VII-VIII: added closed-form corollaries card_hSumset_eq_choose_of_isBhSet (saturation) and choose_le_of_isBhSet (density bound C(|A|+h-1,h) ≤ hN+1). 0 sorry, 0 axiom. VERIFIED 2026-07-04: `lake build Proofs.Erdos153OQ03` completed successfully (7743 jobs) after repairing Docker (containerd content-store corruption cleared by a Docker Desktop restart; built in fresh private cache volumes to bypass the leantar-corrupt shared volumes). `#print axioms` on the five headline theorems reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no ofReduceBool. Only 4 cosmetic linter warnings (unreachable `exact Multiset.cons_swap` fallback branches in a defensive `first | rfl | ...` at lines 225/232).",
     "blockers": [],
-    "nextAction": "Confirm the build once Docker recovers (defeq check on `exact Sym.attach_map_coe s` and the closing rw chain). Then attempt the actual gap-variance statement via the Sidon (isSidon_of_isBhSet) reduction — the genuinely open frontier.",
+    "nextAction": "Build confirmed. Attempt the actual gap-variance statement via the Sidon (isSidon_of_isBhSet) reduction + the now-closed-form density bound choose_le_of_isBhSet — the genuinely open frontier. (Optional cleanup: silence the two unreachable-tactic warnings by replacing the redundant `first | rfl | exact Multiset.cons_swap _ _ _` with plain `rfl` at lines 225/232.)",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 2,
@@ -95,8 +95,8 @@
     {
       "path": "Proofs/Erdos153OQ03.lean",
       "filename": "Erdos153OQ03.lean",
-      "lineCount": 458,
-      "theoremCount": 16,
+      "lineCount": 616,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-153-oq-03.json
+++ b/src/data/research/problems/erdos-153-oq-03.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-04",
-    "iteration": 3,
-    "focus": "Saturation CHARACTERIZATION added and VERIFIED: isBhSet_iff_card_hSumset — A is B_h ⟺ (hSumset h A).card = (A.sym h).card (converse of Section VI's card_hSumset_of_isBhSet, via Finset.injOn_of_card_image_eq). Explicit-binomial bridge attempted but Finset.card_sym does NOT exist in Mathlib v4.26.0 (only Fintype-form Sym.card_sym_eq_choose) — gap stays; density bound remains stated with the honest (A.sym h).card. Gap-variance conjecture still OPEN.",
+    "iteration": 4,
+    "focus": "Explicit stars-and-bars bridge CLOSED: card_finset_sym_eq_choose proves (A.sym h).card = C(|A|+h-1, h) by exhibiting A.sym h as the injective image of univ : Finset (Sym ↥A h) under Sym.map Subtype.val (injective via Subtype.val_injective; onto via Sym.attach + Sym.attach_map_coe), then transporting Sym.card_sym_eq_choose across it and using Fintype.card_coe. This removes the honest-quantity caveat from Sections VII-VIII: added closed-form corollaries card_hSumset_eq_choose_of_isBhSet (saturation) and choose_le_of_isBhSet (density bound C(|A|+h-1,h) ≤ hN+1). 0 sorry, 0 axiom. Build-pending: Docker infra corrupt this session (containerd content-store I/O error on the lean4 image blob), so verification is by static lemma-name/typing analysis against current Mathlib source, not a compile.",
     "blockers": [],
-    "nextAction": "Explicit binomial bridge (A.sym h).card = C(|A|+h-1,h) needs a hand-built equiv ↥(A.sym h) ≃ Sym ↥A h (Sym.map Subtype.val is injective with range A.sym h) then Sym.card_sym_eq_choose + Fintype.card_coe — ~40 lines, deferred. Then attempt the actual gap-variance statement via Sidon reduction.",
+    "nextAction": "Confirm the build once Docker recovers (defeq check on `exact Sym.attach_map_coe s` and the closing rw chain). Then attempt the actual gap-variance statement via the Sidon (isSidon_of_isBhSet) reduction — the genuinely open frontier.",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 2,


### PR DESCRIPTION
## Summary

Closes the gap flagged in Sections VII–VIII of `Erdos153OQ03.lean` (the B_h / Sidon generalization, Erdős #153 OQ-03). Those sections stated every quantitative result with the *honest* quantity `(A.sym h).card`, noting only that it "is" the multiset coefficient `C(|A|+h−1, h)` — because Mathlib supplies the stars-and-bars identity only in `Fintype` form (`Sym.card_sym_eq_choose`), with no `Finset`-level companion for `(A.sym h).card`.

**New Section IX** supplies the missing `Finset`-level bridge and its downstream closed forms:

- `card_finset_sym_eq_choose : (A.sym h).card = (A.card + h − 1).choose h`
  Realizes `A.sym h` as the injective image of `univ : Finset (Sym ↥A h)` under `Sym.map Subtype.val` (injective via `Subtype.val_injective`; onto `A.sym h` via `Sym.attach` + `Sym.attach_map_coe`), then transports `Sym.card_sym_eq_choose` across the bijection and evaluates `Fintype.card ↥A = |A|` with `Fintype.card_coe`.
- `card_hSumset_eq_choose_of_isBhSet` — saturation identity in closed binomial form (refines `card_hSumset_of_isBhSet`).
- `choose_le_of_isBhSet` — the B_h density bound `C(|A|+h−1, h) ≤ hN+1` in closed form (refines `card_sym_le_of_isBhSet`); the sharp `|A| = O(N^{1/h})` generalization of the Sidon `|A| = O(√N)` bound motivating OQ-03.

**0 sorry, 0 axiom.** The full gap-variance conjecture remains open (already open for h=2) — this PR extends the reusable B_h infrastructure, it does not resolve OQ-03.

## Verification status — DRAFT (build-pending)

Docker build infrastructure is corrupt this session: the containerd content store returns an I/O error reading the `lean4-arm64:v4.26.0` image blob, so **no `lake build` could be run**. Every lemma used was verified by name and signature against the current Mathlib source (`Sym.map_injective`, `Sym.coe_map`, `Sym.mem_map`, `Sym.attach`, `Sym.attach_map_coe`, `Sym.card_sym_eq_choose`, `Subtype.val_injective`, `Finset.card_image_of_injective`, `Fintype.card_coe`), and the proof was checked by hand for typing/defeq, but it is **not compiled**. Kept as a draft until a build-capable session confirms it (or a mechanic verifies once Docker recovers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)