### PR TITLE
research(hurwitz-theorem-oq-03-oq-01): sync gallery meta with #34895 Step-3 verified additions

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
@@ -21,10 +21,10 @@
     "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "1 sorry: hurwitz_only_if_ring (the remaining strictly-non-commutative global structure argument of Frobenius' theorem — Step 3: show Im A is an ℝ-subspace carrying a positive-definite bilinear form / Clifford structure). Frobenius Steps 1 and 2 are VERIFIED (0 sorries): minpoly_natDegree_le_two and exists_quadratic show every element satisfies a real quadratic (generates ℝ or ℂ); exists_real_shift_sq_scalar completes the square so the imaginary part squares to a real scalar, and eq_smul_one_of_sq_eq_nonneg_smul shows a nonnegative such scalar forces the element into ℝ•1 (via no zero divisors), isolating the genuinely imaginary elements as those with negative square scalar. Two further pieces of Step 3 are now also VERIFIED (0 sorries): anticommutator_real_affine shows x*y+y*x ∈ span_ℝ{x,y,1} for all x,y (Step 3 preparation via polarisation), and hurwitz_only_if_ring_comm discharges the commutative subcase of the general-ring statement via Gelfand-Mazur, scoping the remaining sorry to the strictly non-commutative case. The commutative subcase (hurwitz_field_case) is axiom-free.",
-    "lineCount": 281,
-    "theoremCount": 9,
-    "definitionCount": 1,
+    "assumptions": "1 sorry: hurwitz_only_if_ring (the remaining strictly-non-commutative global structure argument of Frobenius' theorem — Step 3: show Im A is an ℝ-subspace carrying a positive-definite bilinear form / Clifford structure). Frobenius Steps 1 and 2 are VERIFIED (0 sorries): minpoly_natDegree_le_two and exists_quadratic show every element satisfies a real quadratic (generates ℝ or ℂ); exists_real_shift_sq_scalar completes the square so the imaginary part squares to a real scalar, and eq_smul_one_of_sq_eq_nonneg_smul shows a nonnegative such scalar forces the element into ℝ•1 (via no zero divisors), isolating the genuinely imaginary elements as those with negative square scalar. Two further pieces of Step 3 are now also VERIFIED (0 sorries): anticommutator_real_affine shows x*y+y*x ∈ span_ℝ{x,y,1} for all x,y (Step 3 preparation via polarisation), and hurwitz_only_if_ring_comm discharges the commutative subcase of the general-ring statement via Gelfand-Mazur, scoping the remaining sorry to the strictly non-commutative case. Four further Step-3 pieces are now VERIFIED (0 sorries): IsImaginary defines the imaginary summand a²=r•1 with r≤0; eq_zero_of_smul_one_sq_nonpos and isImaginary_smul_one_iff establish the directness ℝ•1 ∩ Im A = {0}; and anticommutator_scalar_of_sq_scalar proves the Clifford relation x*y+y*x = (c−a−b)•1 whenever x², y², (x+y)² are real scalars. The one remaining sorry is now precisely the single global fact that Im A is closed under addition (equivalently the real-part functional A→ℝ is ℝ-linear), which would supply the (x+y)²∈ℝ•1 hypothesis for imaginary x,y and upgrade the scalar anticommutator to a positive-definite bilinear form forcing finrank ℝ (Im A) ∈ {0,1,3}. The commutative subcase (hurwitz_field_case) is axiom-free.",
+    "lineCount": 347,
+    "theoremCount": 12,
+    "definitionCount": 2,
     "originalContributions": [
       "admissibleDimensions: Def {1,2,4,8} — the four admissible finranks",
       "finrank_normed_field_eq_one_or_two: Gelfand-Mazur consequence (0 sorries)",
@@ -35,7 +35,11 @@
       "eq_smul_one_of_sq_eq_nonneg_smul: b²=r•1 with r≥0 ⟹ b∈ℝ•1 via absence of zero divisors (0 sorries) — Frobenius Step 2b, isolating imaginary elements as those with negative square scalar",
       "anticommutator_real_affine: x*y+y*x ∈ span_ℝ{x,y,1} for all x,y (0 sorries) — Frobenius Step 3 preparation, the anticommutator is real-affine, obtained by polarising the Step-1 quadratics of x, y, x+y",
       "hurwitz_only_if_ring_comm: the commutative subcase of the general division-ring statement, finrank ∈ {1,2} ⊆ {1,2,4,8} via a NormedField instance + Gelfand-Mazur (0 sorries) — discharges the easy half of Step 3's case split, scoping the remaining sorry to the strictly non-commutative case",
-      "hurwitz_only_if_ring: general division ring case (1 sorry: remaining strictly-non-commutative global Frobenius structure argument, Step 3)"
+      "IsImaginary: Def of the imaginary elements a² = r•1 with r ≤ 0 — the Im A summand of the A = ℝ•1 ⊕ Im A decomposition (Frobenius Step 3)",
+      "eq_zero_of_smul_one_sq_nonpos: a real multiple s•1 whose square is a nonpositive real scalar must be zero, via injectivity of algebraMap ℝ A (0 sorries) — Frobenius Step 3, directness of ℝ•1 ⊕ Im A",
+      "isImaginary_smul_one_iff: s•1 is imaginary iff s = 0, i.e. ℝ•1 ∩ Im A = {0} (0 sorries) — Frobenius Step 3, the direct-sum intersection",
+      "anticommutator_scalar_of_sq_scalar: whenever x², y², (x+y)² are real scalars a•1, b•1, c•1, the anticommutator x*y+y*x equals the real scalar (c−a−b)•1 by polarisation (0 sorries) — Frobenius Step 3, the exact Clifford relation eᵢeⱼ+eⱼeᵢ ∈ ℝ•1 for imaginary inputs",
+      "hurwitz_only_if_ring: general division ring case (1 sorry: remaining strictly-non-commutative global Frobenius structure argument, Step 3 — closure of Im A under addition / ℝ-linearity of the real-part functional)"
     ]
   },
   "overview": {
@@ -147,20 +151,28 @@
       "mathContext": "Polarisation identity (x+y)²=x²+(xy+yx)+y² is discharged by noncomm_ring (associative, non-commutative); the coefficient bookkeeping across the three Step-1 quadratics is closed by linear_combination with the module normaliser."
     },
     {
+      "id": "frobenius-step3",
+      "title": "Frobenius Step 3: The Imaginary Subspace and its Scalar Anticommutator",
+      "startLine": 217,
+      "endLine": 277,
+      "summary": "IsImaginary (def: a²=r•1 with r≤0) names the Im A summand. eq_zero_of_smul_one_sq_nonpos and isImaginary_smul_one_iff (0 sorries) prove the directness ℝ•1 ∩ Im A = {0}: a real multiple s•1 with nonpositive square scalar is 0 (s²≥0 forces s=0 via injectivity of algebraMap ℝ A). anticommutator_scalar_of_sq_scalar (0 sorries) proves the Clifford relation: whenever x², y², (x+y)² are real scalars a•1, b•1, c•1, the anticommutator x*y+y*x = (c−a−b)•1, by polarising (x+y)²=x²+(x*y+y*x)+y².",
+      "mathContext": "Directness uses that s²≥0 and r≤0 force s²=r=0 (le_antisymm + mul_self_nonneg) with algebraMap ℝ A injective. The scalar anticommutator is pure polarisation (noncomm_ring for the associative-but-noncommutative square expansion) closed by linear_combination with the module normaliser; no division-ring hypothesis beyond the ambient algebra is used. For imaginary x, y it is exactly eᵢeⱼ+eⱼeᵢ ∈ ℝ•1 — the missing input being (x+y)²∈ℝ•1, i.e. closure of Im A under addition."
+    },
+    {
       "id": "general-case",
       "title": "General Division Ring Case (1 sorry)",
-      "startLine": 217,
-      "endLine": 281,
-      "summary": "hurwitz_only_if_ring_comm (0 sorries) discharges the commutative subcase of the general-ring statement — a commutative NormedDivisionRing is a NormedField, so hurwitz_field_case (Gelfand-Mazur) gives finrank ∈ {1,2} ⊆ {1,2,4,8}. hurwitz_only_if_ring then case-splits on commutativity: the commutative branch is closed by hurwitz_only_if_ring_comm, leaving 1 sorry scoped to the strictly non-commutative case (hnc : ∃ x y, x*y ≠ y*x available). The remaining Step 3 is the global structure argument — Im A is a subspace with a positive-definite bilinear form / Clifford structure forcing finrank ∈ {1,2,4}.",
+      "startLine": 278,
+      "endLine": 347,
+      "summary": "hurwitz_only_if_ring_comm (0 sorries) discharges the commutative subcase of the general-ring statement — a commutative NormedDivisionRing is a NormedField, so hurwitz_field_case (Gelfand-Mazur) gives finrank ∈ {1,2} ⊆ {1,2,4,8}. hurwitz_only_if_ring then case-splits on commutativity: the commutative branch is closed by hurwitz_only_if_ring_comm, leaving 1 sorry scoped to the strictly non-commutative case (hnc : ∃ x y, x*y ≠ y*x available). The remaining Step 3 is the single global fact that Im A is closed under addition (the real-part functional A→ℝ is ℝ-linear), which upgrades the scalar anticommutator to a positive-definite bilinear form forcing finrank ℝ (Im A) ∈ {0,1,3}, hence finrank ∈ {1,2,4}.",
       "mathContext": "The commutative subcase builds a NormedField instance from the commutativity hypothesis via letI and reuses hurwitz_field_case. The remaining sorry covers strictly non-commutative NormedDivisionRing A, NormedAlgebra ℝ A, Module.Finite ℝ A. By Frobenius, the associative case only admits dims 1, 2, 4 — the '8' entry is vacuous for NormedDivisionRing."
     }
   ],
   "leanFile": {
     "namespace": "HurwitzOnlyIf",
-    "lineCount": 281,
+    "lineCount": 347,
     "axiomCount": 0,
-    "theoremCount": 9,
-    "definitionCount": 1,
+    "theoremCount": 12,
+    "definitionCount": 2,
     "path": "Proofs/HurwitzOnlyIf.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Summary

Gallery meta-sync for the **Hurwitz Only-If (Gelfand–Mazur)** entry `hurwitz-theorem-oq-03-oq-01`.

Commit #34895 added four **verified (0-sorry)** Frobenius Step-3 declarations to `Proofs/HurwitzOnlyIf.lean`:

- `IsImaginary` (def) — the imaginary summand `a² = r•1`, `r ≤ 0`
- `eq_zero_of_smul_one_sq_nonpos` + `isImaginary_smul_one_iff` — directness `ℝ•1 ∩ Im A = {0}`
- `anticommutator_scalar_of_sq_scalar` — the Clifford relation `x*y + y*x = (c−a−b)•1` whenever `x²`, `y²`, `(x+y)²` are real scalars

The gallery `meta.json` was last synced only through #34770 (in #34857) and did not record these, still reporting **281 lines / 9 theorems / 1 def**.

## Changes (meta.json only)

- `lineCount` 281 → **347**, `theoremCount` 9 → **12**, `definitionCount` 1 → **2** (both `meta` and `leanFile`)
- Added the four #34895 declarations to `originalContributions` (10 → 14)
- Added a **"Frobenius Step 3: The Imaginary Subspace and its Scalar Anticommutator"** section (lines 217–277); re-ranged `general-case` to 278–347
- Refined `assumptions`: the sole remaining `sorry` is now precisely that **Im A is closed under addition** (the real-part functional `A → ℝ` is ℝ-linear)

## Verification

Verified by inspection against the source file on `origin/main` (byte-identical, 347 lines). Docker's containerd content-store is corrupt this session (`input/output error` on image build), so no fresh compile was run — but **no Lean was changed**; this is a documentation/metadata sync of already-merged verified theorems.

Source status is unchanged: `formalized` / `wip`, **1 sorry** (strictly non-commutative Frobenius Step 3), `axiomCount 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)