### PR TITLE
Enrich Sylvester's Sequence (arithmetic skeleton): annotations + cross-refs

### DIFF
--- a/src/data/proofs/sylvester-sequence-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/sylvester-sequence-oq-01-oq-03/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "sylvester-sequence-oq-01-oq-03",
+    "range": { "startLine": 3, "endLine": 36 },
+    "type": "concept",
+    "title": "The Arithmetic Skeleton of Sylvester's Sequence",
+    "content": "Sylvester's sequence $a_0 = 2,\\ a_{n+1} = a_n^2 - a_n + 1$ produces $2, 3, 7, 43, 1807, 3263443, \\dots$ (OEIS A000058). Beyond its famous reciprocal sum, the sequence carries a rigid *arithmetic skeleton* — a Euclid product formula, congruences modulo every earlier term, pairwise coprimality, a parity pattern, and a fixed residue modulo $6$ — and this file proves that the entire skeleton descends from one algebraic identity, $a_{n+1} - 1 = a_n(a_n - 1)$. The docstring is explicit that the product-formula and coprimality facts overlap the companion entry `sylvester-sequence-oq-01`; the parity, the $\\bmod\\,6$ residue, and the $\\equiv 1 \\pmod{a_i}$ phrasing are the genuinely new content.",
+    "mathContext": "$a_0 = 2,\\quad a_{n+1} = a_n^2 - a_n + 1,\\qquad a_{n+1} - 1 = a_n(a_n - 1).$",
+    "significance": "key",
+    "relatedConcepts": ["quadratic recurrence", "Euclid product formula", "modular arithmetic", "OEIS A000058"],
+    "prerequisites": ["mathematical induction", "elementary number theory"]
+  },
+  {
+    "id": "ann-defn",
+    "proofId": "sylvester-sequence-oq-01-oq-03",
+    "range": { "startLine": 40, "endLine": 48 },
+    "type": "definition",
+    "title": "The Sequence in ℕ and Its Base Values",
+    "content": "`syl : ℕ → ℕ` is defined by structural recursion, with `syl_zero`, `syl_one`, `syl_two`, and `syl_succ` exposing $a_0 = 2$, $a_1 = 3$, $a_2 = 7$, and the recurrence as `@[simp]` rewrite lemmas. Keeping the sequence valued in $\\mathbb{N}$ (rather than $\\mathbb{Z}$ or $\\mathbb{Q}$) is a deliberate choice: every divisibility, gcd, and congruence statement downstream is a native $\\mathbb{N}$ fact, at the cost of having to manage truncated subtraction carefully.",
+    "mathContext": "$\\mathrm{syl}(0)=2,\\ \\mathrm{syl}(1)=3,\\ \\mathrm{syl}(2)=7,\\quad \\mathrm{syl}(n+1)=\\mathrm{syl}(n)^2-\\mathrm{syl}(n)+1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["structural recursion", "natural-number arithmetic"],
+    "prerequisites": ["recursive definitions in Lean"]
+  },
+  {
+    "id": "ann-two-le",
+    "proofId": "sylvester-sequence-oq-01-oq-03",
+    "range": { "startLine": 51, "endLine": 57 },
+    "type": "theorem",
+    "title": "Every Term Is at Least 2",
+    "content": "An induction proving $a_n \\ge 2$ for all $n$, with the inductive step closed by `nlinarith` from $\\mathrm{syl}(k) + 2 \\le \\mathrm{syl}(k)^2$. This lower bound is the guardrail for the whole file: it guarantees $a_n \\ge 2$ so that $a_n - 1 \\ge 1$, keeping the truncated subtractions in $a_{n+1} - 1$ and $a_n - 1$ honest and the modulus $a_i$ strictly greater than $1$ in every congruence.",
+    "mathContext": "$a_n \\ge 2 \\implies a_n^2 \\ge a_n + 2 \\implies a_{n+1} = a_n^2 - a_n + 1 \\ge 3.$",
+    "significance": "supporting",
+    "relatedConcepts": ["monotone growth", "induction", "truncated subtraction"],
+    "prerequisites": ["mathematical induction", "quadratic inequalities"]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "sylvester-sequence-oq-01-oq-03",
+    "range": { "startLine": 61, "endLine": 72 },
+    "type": "technique",
+    "title": "The Multiplicative Engine (Consecutive-Integer Factorization)",
+    "content": "`syl_succ_sub_one` proves the identity that drives everything: $a_{n+1} - 1 = a_n(a_n - 1)$, a product of two *consecutive* integers. The proof sidesteps $\\mathbb{N}$'s truncated subtraction entirely by the change of variable $a_n = p + 2$ (legitimate because $a_n \\ge 2$), after which both sides become honest polynomials in $p$ and `ring`/`omega` finish. This one lemma is reused verbatim in the product identity, the parity argument, and the $\\bmod\\,6$ induction — the single point from which the arithmetic skeleton radiates.",
+    "mathContext": "$a_{n+1}-1 = (a_n^2 - a_n + 1) - 1 = a_n^2 - a_n = a_n(a_n - 1).$",
+    "significance": "key",
+    "relatedConcepts": ["consecutive-integer product", "change of variable", "truncated subtraction"],
+    "prerequisites": ["polynomial identities", "ℕ subtraction pitfalls"]
+  },
+  {
+    "id": "ann-product",
+    "proofId": "sylvester-sequence-oq-01-oq-03",
+    "range": { "startLine": 75, "endLine": 81 },
+    "type": "theorem",
+    "title": "Euclid Product Identity",
+    "content": "`syl_sub_one_eq_prod` telescopes the multiplicative engine into the Euclid-style product formula $a_{n+1} - 1 = \\prod_{k \\le n} a_k$. The induction is short: the successor case rewrites $\\prod_{k \\le m+1} a_k = a_{m+1}\\prod_{k \\le m} a_k$ (`Finset.prod_range_succ`), folds in the hypothesis, and applies the engine at index $m+1$. This is the recursive form of Euclid's $a_{n+1} = a_0 a_1 \\cdots a_n + 1$, the very construction behind Euclid's proof that there are infinitely many primes.",
+    "mathContext": "$a_{n+1} - 1 = \\prod_{k=0}^{n} a_k \\quad\\Longleftrightarrow\\quad a_{n+1} = a_0 a_1 \\cdots a_n + 1.$",
+    "significance": "key",
+    "relatedConcepts": ["telescoping product", "Euclid's construction", "Finset.prod_range_succ"],
+    "prerequisites": ["finite products", "induction on Finset.range"]
+  },
+  {
+    "id": "ann-residue",
+    "proofId": "sylvester-sequence-oq-01-oq-03",
+    "range": { "startLine": 84, "endLine": 97 },
+    "type": "insight",
+    "title": "Residue mod Earlier Terms",
+    "content": "From the product identity, $a_i \\mid a_n - 1$ for every $i < n$ is immediate — $a_i$ is one of the factors of $a_n - 1 = \\prod_{k < n} a_k$ (`Finset.dvd_prod_of_mem`, in `syl_dvd_sub_one`). `syl_mod_earlier` then repackages this divisibility as the congruence $a_n \\equiv 1 \\pmod{a_i}$ by passing through `Nat.modEq_iff_dvd'` and reducing $1 \\bmod a_i = 1$ (valid since $a_i \\ge 2$). This is the sharp form of coprimality: not merely that distinct terms share no factor, but that every term is exactly $1$ modulo each of its predecessors.",
+    "mathContext": "$i < n \\implies a_i \\mid a_n - 1 \\iff a_n \\equiv 1 \\pmod{a_i}.$",
+    "significance": "key",
+    "relatedConcepts": ["divisibility", "congruences", "Nat.modEq_iff_dvd'", "Finset.dvd_prod_of_mem"],
+    "prerequisites": ["modular arithmetic", "divisibility in ℕ"]
+  },
+  {
+    "id": "ann-coprime",
+    "proofId": "sylvester-sequence-oq-01-oq-03",
+    "range": { "startLine": 100, "endLine": 115 },
+    "type": "theorem",
+    "title": "Pairwise Coprimality",
+    "content": "`syl_coprime_of_lt` (then the symmetric `syl_coprime`) shows distinct terms are coprime. The argument is the classic Euclid gcd cancellation: for $i < j$, any $d = \\gcd(a_i, a_j)$ divides $a_j$ and (via $a_i \\mid a_j - 1$) also $a_j - 1$, so $d \\mid a_j - (a_j - 1) = 1$. Because it rests on the residue structure rather than on prime factorizations, the coprimality is *forced* — no term can accidentally share a factor with an earlier one.",
+    "mathContext": "$d \\mid a_j \\ \\wedge\\ d \\mid a_j - 1 \\implies d \\mid 1 \\implies \\gcd(a_i, a_j) = 1.$",
+    "significance": "key",
+    "relatedConcepts": ["coprimality", "gcd cancellation", "Euclid's lemma"],
+    "prerequisites": ["gcd properties", "divisibility"]
+  },
+  {
+    "id": "ann-parity",
+    "proofId": "sylvester-sequence-oq-01-oq-03",
+    "range": { "startLine": 118, "endLine": 128 },
+    "type": "insight",
+    "title": "Parity: Every Term Past the First Is Odd",
+    "content": "`syl_odd` proves $a_n$ is odd for $n \\ge 1$. The reason is structural, not computational: $a_n = a_m(a_m - 1) + 1$ where $a_m(a_m - 1)$ is a product of two consecutive integers, hence always even (one of the two factors is even, handled by the `Nat.even_or_odd` split with `Even.mul_right` / `Nat.Odd.sub_odd`). Adding $1$ to an even number gives an odd number — so oddness holds for *every* successor, independent of $n$.",
+    "mathContext": "$a_{n+1} = \\underbrace{a_n(a_n - 1)}_{\\text{even}} + 1 \\implies a_{n+1} \\text{ odd}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["parity", "consecutive-integer product", "Even/Odd"],
+    "prerequisites": ["parity of integers"]
+  },
+  {
+    "id": "ann-mod6",
+    "proofId": "sylvester-sequence-oq-01-oq-03",
+    "range": { "startLine": 131, "endLine": 145 },
+    "type": "insight",
+    "title": "The mod-6 Invariant",
+    "content": "`six_dvd_syl_sub_one` establishes $6 \\mid a_n - 1$ for $n \\ge 2$ by `Nat.le_induction` from the base $a_2 - 1 = 6$. The inductive step needs no case analysis: since $a_{n+1} - 1 = a_n(a_n - 1)$ and $a_n - 1$ is literally a factor, $6 \\mid a_n - 1 \\implies 6 \\mid a_{n+1} - 1$ (`Dvd.mul_left`). `syl_mod_six` then reads off $a_n \\equiv 1 \\pmod 6$. So from $7$ onward every term ends the same way modulo $6$ — a clean example of a divisibility invariant inherited multiplicatively rather than re-derived.",
+    "mathContext": "$6 \\mid a_2 - 1 = 6;\\quad 6 \\mid a_n - 1 \\implies 6 \\mid a_n(a_n-1) = a_{n+1}-1.$",
+    "significance": "key",
+    "relatedConcepts": ["invariant propagation", "Nat.le_induction", "residue classes mod 6"],
+    "prerequisites": ["induction from a fixed base", "divisibility"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `sylvester-sequence-oq-01-oq-03` (quality 30, passes 0).

**Gaps addressed** (meta was already rich in overview/sections/keyInsights, but had no annotations and empty crossReferences):

- **New `annotations.json`** — 9 annotations covering the full 145-line proof, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: intro concept, the ℕ definition, the ≥2 lower bound, the multiplicative engine $a_{n+1}-1=a_n(a_n-1)$, the Euclid product identity, residue-mod-earlier-terms, pairwise coprimality, parity, and the mod-6 invariant.
- **4 `crossReferences`** — companion `sylvester-sequence-oq-01` (shared engine), `sylvester-sequence-oq-03` (doubly-exponential growth), `sylvester-sequence-oq-02` (exact reciprocal sum), and `infinitude-primes` (Euclid product-plus-one).

All annotation anchors validate against the Lean source (`scripts/annotations/build.ts` clean for this entry); meta.json is 13.7 KB, well under the 60 KB cap. No changes to status/badge — entry remains `pending`/`wip` (build-pending, unchanged).