### PR TITLE
Research(stars-and-bars-last-part-recurrence-oq-01-oq-01): elementary last-part recurrence for weak compositions

### DIFF
--- a/proofs/Proofs/StarsAndBarsLastPartRecurrenceOQ01OQ01.lean
+++ b/proofs/Proofs/StarsAndBarsLastPartRecurrenceOQ01OQ01.lean
@@ -1,0 +1,156 @@
+import Mathlib
+
+/-
+# Last-Part Recurrence for Weak Compositions (stars-and-bars OQ-01/OQ-01)
+
+A **weak composition** of `n` into `k` parts is an ordered `k`-tuple of
+non-negative integers `(x₀, …, x_{k-1})` with `x₀ + ⋯ + x_{k-1} = n`.
+Write `wc n k` for the number of such tuples.  Mathlib packages the set of
+tuples as `Finset.Nat.antidiagonalTuple k n`, so we take
+
+  `wc n k := (Finset.Nat.antidiagonalTuple k n).card`.
+
+## The open question
+
+The seeker-selected research problem asks to formalize the **last-part
+(equivalently first-part) recurrence**
+
+  `C(n, k) = ∑_{j=0}^{n} C(n − j, k − 1)`   for `k ≥ 1`,   with `C(n, 0) = [n = 0]`.
+
+Conditioning a weak composition of `n` into `k` parts on the value `j` of its
+first coordinate leaves a weak composition of `n − j` into `k − 1` parts, and
+`j` ranges over `0, 1, …, n`.  This is the *combinatorial recurrence* underlying
+stars-and-bars — a different, self-contained angle from the generating-function
+and `Sym`-bijection treatments already in the gallery
+(`StarsAndBarsWeakCompositions.lean` and its `OQ01` siblings).
+
+## Main results
+
+* `wc_zero`            : `wc n 0 = if n = 0 then 1 else 0`               (the base case `C(n,0) = [n = 0]`)
+* `wc_recurrence`      : `wc n (k+1) = ∑ j ∈ range (n+1), wc (n − j) k`  (**the stated theorem**)
+* `wc_closed`          : `wc n (k+1) = (n + k).choose k`                 (full stars-and-bars, from the recurrence)
+* `wc_eq_card_weakComposition` : bridges `wc` to the gallery's `Fintype.card` count.
+
+The recurrence is proved by partitioning the tuples according to the value of
+their first coordinate (`Finset.card_eq_sum_card_fiberwise`) and identifying
+each fibre with a shorter antidiagonal tuple via `Fin.cons` / `Fin.tail`.  The
+closed form is then a clean induction on `k` using the recurrence together with
+the hockey-stick identity `Nat.sum_range_add_choose`.  Everything is
+machine-checked with no `sorry` and no extra axioms.
+-/
+
+open Finset
+
+namespace StarsAndBarsLastPartRecurrence
+
+open Finset.Nat (antidiagonalTuple mem_antidiagonalTuple)
+
+/-- `wc n k` = the number of weak compositions of `n` into `k` parts, i.e. the
+number of `k`-tuples of naturals summing to `n`. -/
+def wc (n k : ℕ) : ℕ := (antidiagonalTuple k n).card
+
+/-- Membership rewrite for the tuple set. -/
+theorem mem_antidiagonalTuple' {n k : ℕ} {x : Fin k → ℕ} :
+    x ∈ antidiagonalTuple k n ↔ ∑ i, x i = n :=
+  mem_antidiagonalTuple
+
+/-- Base case `k = 0`: the only tuple is the empty tuple, which sums to `0`, so
+`wc n 0 = [n = 0]`. -/
+theorem wc_zero (n : ℕ) : wc n 0 = if n = 0 then 1 else 0 := by
+  cases n with
+  | zero => simp [wc]
+  | succ m => simp [wc, Finset.Nat.antidiagonalTuple_zero_succ]
+
+@[simp] theorem wc_zero_zero : wc 0 0 = 1 := by simp [wc_zero]
+
+/-- Exactly one weak composition of `n` into a single part, namely `![n]`. -/
+@[simp] theorem wc_one (n : ℕ) : wc n 1 = 1 := by
+  simp [wc, Finset.Nat.antidiagonalTuple_one]
+
+/-- **Fibre identification.**  Among the weak compositions of `n` into `k + 1`
+parts, those whose first coordinate equals `j` (with `j ≤ n`) are in bijection
+with the weak compositions of `n − j` into `k` parts.  The bijection strips off
+(`Fin.tail`) resp. prepends (`Fin.cons j`) the first coordinate. -/
+theorem fiber_card (n k j : ℕ) (hj : j ≤ n) :
+    #{x ∈ antidiagonalTuple (k + 1) n | x 0 = j} = wc (n - j) k := by
+  unfold wc
+  apply Finset.card_nbij' Fin.tail (Fin.cons j)
+  · -- `Fin.tail` maps the fibre into the shorter antidiagonal
+    intro x hx
+    simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_coe,
+      mem_antidiagonalTuple'] at hx ⊢
+    obtain ⟨hsum, h0⟩ := hx
+    have key : ∑ i, x i = x 0 + ∑ i, Fin.tail x i := Fin.sum_univ_succ x
+    omega
+  · -- `Fin.cons j` maps back into the fibre
+    intro y hy
+    simp only [Finset.mem_coe, mem_antidiagonalTuple'] at hy
+    simp only [Finset.coe_filter, Set.mem_setOf_eq,
+      mem_antidiagonalTuple', Fin.cons_zero, and_true]
+    rw [Fin.sum_univ_succ, Fin.cons_zero]
+    simp only [Fin.cons_succ, hy]
+    omega
+  · -- left inverse: `cons (x 0) (tail x) = x`, and `x 0 = j` on the fibre
+    intro x hx
+    simp only [Finset.coe_filter, Set.mem_setOf_eq] at hx
+    rw [← hx.2, Fin.cons_self_tail]
+  · -- right inverse: `tail (cons j y) = y`
+    intro y _
+    rw [Fin.tail_cons]
+
+/-- **Last-part recurrence for weak compositions** (the stated open question).
+The number of weak compositions of `n` into `k + 1` parts equals the sum over
+`j = 0, …, n` of the number of weak compositions of `n − j` into `k` parts. -/
+theorem wc_recurrence (n k : ℕ) :
+    wc n (k + 1) = ∑ j ∈ Finset.range (n + 1), wc (n - j) k := by
+  have H : Set.MapsTo (fun x : Fin (k + 1) → ℕ => x 0)
+      (antidiagonalTuple (k + 1) n : Finset _) (Finset.range (n + 1)) := by
+    intro x hx
+    simp only [Finset.mem_coe, mem_antidiagonalTuple'] at hx
+    simp only [Finset.coe_range, Set.mem_Iio]
+    have hle : x 0 ≤ ∑ i, x i :=
+      Finset.single_le_sum (fun i _ => Nat.zero_le _) (Finset.mem_univ 0)
+    omega
+  rw [wc, Finset.card_eq_sum_card_fiberwise H]
+  apply Finset.sum_congr rfl
+  intro j hj
+  rw [Finset.mem_range] at hj
+  exact fiber_card n k j (by omega)
+
+/-- **Closed form via the recurrence.**  Solving the last-part recurrence with
+the hockey-stick identity recovers the full stars-and-bars count: the number of
+weak compositions of `n` into `k + 1` parts is `C(n + k, k)`. -/
+theorem wc_closed (n k : ℕ) : wc n (k + 1) = (n + k).choose k := by
+  induction k generalizing n with
+  | zero => simp
+  | succ k ih =>
+    rw [wc_recurrence]
+    have step : ∀ j ∈ Finset.range (n + 1),
+        wc (n - j) (k + 1) = ((n - j) + k).choose k := fun j _ => ih (n - j)
+    rw [Finset.sum_congr rfl step]
+    have hreflect : ∑ j ∈ Finset.range (n + 1), ((n - j) + k).choose k
+                  = ∑ i ∈ Finset.range (n + 1), (i + k).choose k := by
+      rw [← Finset.sum_range_reflect (fun i => (i + k).choose k) (n + 1)]
+      apply Finset.sum_congr rfl
+      intro j _
+      have hj : n + 1 - 1 - j = n - j := by omega
+      rw [hj]
+    rw [hreflect, Nat.sum_range_add_choose, Nat.add_assoc]
+
+/-- **Bridge to the gallery count.**  `wc n k` agrees with the subtype
+cardinality `Fintype.card {f : Fin k → ℕ // ∑ i, f i = n}` used in
+`StarsAndBarsWeakCompositions.lean`, so the recurrence and the generating-function
+treatments count the same objects. -/
+theorem wc_eq_card_weakComposition (n k : ℕ)
+    [Fintype {f : Fin k → ℕ // ∑ i, f i = n}] :
+    Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} = wc n k := by
+  rw [wc]
+  rw [← Fintype.card_coe (antidiagonalTuple k n)]
+  exact Fintype.card_congr (Equiv.subtypeEquivRight (fun _ => mem_antidiagonalTuple'.symm))
+
+/-- Sanity check: two parts give `n + 1` weak compositions `(0,n), …, (n,0)`. -/
+example (n : ℕ) : wc n 2 = n + 1 := by
+  have := wc_closed n 1
+  simpa using this
+
+end StarsAndBarsLastPartRecurrence

--- a/src/data/proofs/stars-and-bars-last-part-recurrence-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/stars-and-bars-last-part-recurrence-oq-01-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "stars-and-bars-last-part-recurrence-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 72
+    },
+    "type": "concept",
+    "title": "Weak compositions and the last-part recurrence",
+    "content": "A weak composition of n into k parts is an ordered k-tuple (x₀, …, x_{k−1}) of non-negative integers with x₀ + ⋯ + x_{k−1} = n. Writing C(n,k) for the number of these, conditioning on the value j of one distinguished part leaves a weak composition of n−j into k−1 parts, giving C(n,k) = ∑_{j=0}^n C(n−j, k−1) for k ≥ 1, with base case C(n,0) = [n=0]. The count is modelled definitionally as wc n k = (Finset.Nat.antidiagonalTuple k n).card, whose membership is exactly ∑ᵢ xᵢ = n (mem_antidiagonalTuple). The base cases wc_zero (only the empty tuple, so C(n,0) = [n=0]) and wc_one (the unique 1-tuple ![n], so C(n,1) = 1) fall straight out of Mathlib's antidiagonalTuple simp lemmas."
+  },
+  {
+    "id": "ann-fibre",
+    "proofId": "stars-and-bars-last-part-recurrence-oq-01-oq-01",
+    "range": {
+      "startLine": 74,
+      "endLine": 102
+    },
+    "type": "technique",
+    "title": "The first-coordinate fibre bijection",
+    "content": "fiber_card is the combinatorial core: among the weak compositions of n into k+1 parts, those with first coordinate equal to j (for j ≤ n) biject with the weak compositions of n−j into k parts. The bijection drops the first part (Fin.tail) with inverse prepending j (Fin.cons j), discharged by Finset.card_nbij'. The four side conditions are pure sum bookkeeping: Fin.sum_univ_succ splits the total as x₀ + ∑(tail x), so ∑(tail) = n − j; Fin.cons_zero and Fin.cons_succ evaluate the restored tuple (first part j, rest y) to give j + ∑ y = n; and Fin.cons_self_tail / Fin.tail_cons close the two round trips."
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "stars-and-bars-last-part-recurrence-oq-01-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 121
+    },
+    "type": "concept",
+    "title": "The recurrence as a fibre partition",
+    "content": "wc_recurrence is the stated open question. Finset.card_eq_sum_card_fiberwise partitions the (k+1)-tuples summing to n by the value of their first coordinate x₀, viewed as a map into range (n+1) — legitimate because a single coordinate is at most the total (Finset.single_le_sum), hence ≤ n. Summing the fibre sizes and rewriting each block by fiber_card yields C(n,k+1) = ∑_{j=0}^n C(n−j,k). Conditioning on the first part equals conditioning on the last (the tuple order is a relabelling), so this is the last-part recurrence."
+  },
+  {
+    "id": "ann-closed-form",
+    "proofId": "stars-and-bars-last-part-recurrence-oq-01-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 150
+    },
+    "type": "concept",
+    "title": "Solving the recurrence with hockey-stick",
+    "content": "wc_closed recovers the stars-and-bars closed form C(n,k+1) = (n+k).choose k by induction on k. The base case is wc_one. The step rewrites by wc_recurrence, applies the inductive hypothesis to each summand, reflects the summation index with Finset.sum_range_reflect (∑_j ((n−j)+k).choose k becomes ∑_i (i+k).choose k), and collapses the telescoping sum with the hockey-stick (Zhu Shijie) identity Nat.sum_range_add_choose. The bridge wc_eq_card_weakComposition identifies wc n k with the subtype cardinality Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} used by the generating-function siblings (via Equiv.subtypeEquivRight and Fintype.card_coe), and a worked example checks wc n 2 = n+1."
+  }
+]

--- a/src/data/proofs/stars-and-bars-last-part-recurrence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stars-and-bars-last-part-recurrence-oq-01-oq-01/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "stars-and-bars-last-part-recurrence-oq-01-oq-01",
+  "title": "Last-Part Recurrence for Weak Compositions: C(n,k) = ∑ⱼ C(n−j, k−1)",
+  "slug": "stars-and-bars-last-part-recurrence-oq-01-oq-01",
+  "description": "A weak composition of n into k parts is an ordered k-tuple (x₀, …, x_{k−1}) of non-negative integers with x₀ + ⋯ + x_{k−1} = n; write C(n,k) for the number of these. Conditioning on the value j of one distinguished coordinate (the first, equivalently the last, part) leaves a weak composition of n−j into the remaining k−1 parts, with j ranging over 0, 1, …, n. This gives the elementary last-part recurrence C(n, k) = ∑_{j=0}^{n} C(n−j, k−1) for k ≥ 1, with base case C(n, 0) = [n = 0]. This entry formalizes that recurrence directly and combinatorially, taking C(n,k) to be the cardinality of Mathlib's Finset.Nat.antidiagonalTuple k n (the finset of k-tuples summing to n). The recurrence is proved by partitioning the tuples according to the value of their first coordinate (Finset.card_eq_sum_card_fiberwise) and identifying each fibre with a shorter antidiagonal tuple via the Fin.cons / Fin.tail bijection (Finset.card_nbij'). Solving the recurrence by induction on k together with the hockey-stick identity Nat.sum_range_add_choose recovers the full stars-and-bars closed form C(n, k+1) = (n+k).choose k, and a bridge lemma identifies C(n,k) with the subtype cardinality Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} used by the generating-function entries in the same family. The content beyond Mathlib is the combinatorial recurrence itself and its packaging as an elementary, self-contained derivation of stars-and-bars — a different route from the Sym-multiset bijection and generating-function treatments already in the gallery.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Finset.Nat"
+    ],
+    "namespace": "StarsAndBarsLastPartRecurrence",
+    "lineCount": 156,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/StarsAndBarsLastPartRecurrenceOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Stars_and_bars_(combinatorics)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StarsAndBarsLastPartRecurrenceOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "stars-and-bars",
+      "weak-compositions",
+      "recurrence",
+      "binomial-coefficients",
+      "hockey-stick-identity",
+      "counting",
+      "bijective-proof"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "relatedProblems": [
+      {
+        "id": "stars-and-bars-weak-compositions",
+        "relationship": "Parent family. That entry counts weak compositions of n into k parts via the bijection with size-n multisets over a k-element index set (weakCompositionEquivSym) and Sym.card_sym_eq_choose, obtaining the closed form C(n+k−1, n). This entry counts the same objects (Fintype.card {f : Fin k → ℕ // ∑ i, f i = n}, bridged by wc_eq_card_weakComposition) but derives the count from the elementary last-part recurrence instead of the multiset bijection, recovering (n+k).choose k by induction and the hockey-stick identity."
+      },
+      {
+        "id": "stars-and-bars-weak-compositions-oq-01",
+        "relationship": "Sibling in the family. OQ-01 packages the weak-composition counts as the generating function W k = 1/(1−X)ᵏ = invOneSubPow S k. This entry gives the recurrence those counts satisfy, C(n,k) = ∑_{j=0}^n C(n−j, k−1) — the combinatorial shadow of the algebraic identity W k = (1/(1−X)) · W (k−1)."
+      },
+      {
+        "id": "stars-and-bars-weak-compositions-oq-01-oq-01",
+        "relationship": "Sibling that shares the seeker's open-question path (oq-01/oq-01) but a distinct theorem. That entry is the generating-function identity for POSITIVE compositions, P k = Xᵏ · W k; this entry is the elementary last-part RECURRENCE for weak compositions. They are complementary faces of the same family: the generating-function recursion versus the coefficient (count) recursion."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 156,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. Every public result — wc_zero (base case C(n,0) = [n=0]), wc_one (C(n,1) = 1), fiber_card (the first-coordinate fibre of the (k+1)-tuples equals a k-tuple count), wc_recurrence (the headline last-part recurrence C(n,k+1) = ∑_{j=0}^n C(n−j,k)), wc_closed (the closed form C(n,k+1) = (n+k).choose k derived from the recurrence via the hockey-stick identity), and wc_eq_card_weakComposition (bridge to the subtype cardinality used by the generating-function entries) — was verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The count is defined as (Finset.Nat.antidiagonalTuple k n).card, which Mathlib's mem_antidiagonalTuple characterizes as the k-tuples of naturals summing to n; the recurrence proof uses Finset.card_eq_sum_card_fiberwise to partition by the first coordinate and Finset.card_nbij' with Fin.tail / Fin.cons j for the fibre bijection, and the closed form uses Finset.sum_range_reflect (to turn ∑ C(n−j,·) into ∑ C(j,·)) followed by Nat.sum_range_add_choose. Sanity check (proved as an example in the file): wc n 2 = n+1, the n+1 weak compositions (0,n), (1,n−1), …, (n,0). Note on naming: the seeker assigned this research problem the slug stars-and-bars-weak-compositions-oq-01-oq-01, which was already taken by the (distinct) positive-composition generating-function entry; this gallery entry therefore uses the descriptive slug stars-and-bars-last-part-recurrence-oq-01-oq-01.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Stars and bars — the count of ways to write n as an ordered sum of k non-negative integers — is one of the oldest results in enumerative combinatorics, with the closed form C(n+k−1, k−1). The standard bijective proof places k−1 bars among n stars; Mathlib's gallery already carries that route (via multisets and Sym) and the generating-function route (1/(1−x)ᵏ). Cutting across both is the humble recurrence obtained by conditioning on a single part: the number of weak compositions of n into k parts, split according to the value j of the last (or first) part, is the sum over j of the number of weak compositions of n−j into k−1 parts. This last-part recurrence is the combinatorial engine behind Pascal-style triangles for compositions and the coefficient-level image of the generating-function recursion 1/(1−x)ᵏ = (1/(1−x)) · 1/(1−x)^{k−1}. Solving it — collapsing the telescoping sum with the hockey-stick (Zhu Shijie) identity — is a clean, elementary derivation of the stars-and-bars formula that uses no multiset or power-series machinery.",
+    "problemStatement": "Let C(n,k) denote the number of weak compositions of n into k parts, i.e. the number of k-tuples (x₀, …, x_{k−1}) ∈ ℕᵏ with ∑ᵢ xᵢ = n. Prove the last-part recurrence C(n,k) = ∑_{j=0}^{n} C(n−j, k−1) for k ≥ 1, with base case C(n,0) = [n = 0], and derive from it the closed form C(n,k+1) = (n+k).choose k.",
+    "text": "The count is modelled by C(n,k) := (Finset.Nat.antidiagonalTuple k n).card, whose membership predicate is exactly ∑ᵢ xᵢ = n (Mathlib's mem_antidiagonalTuple). The base case reads off antidiagonalTuple_zero_zero / antidiagonalTuple_zero_succ: the only 0-tuple is the empty tuple, summing to 0, so C(n,0) = [n=0]. The recurrence partitions the (k+1)-part compositions of n by the value of their first coordinate and identifies each block with a k-part composition of the residual sum; summing the block sizes over the possible first-part values 0, …, n gives the recurrence. Iterating and simplifying with the hockey-stick identity yields the stars-and-bars closed form, and a bridge lemma ties the antidiagonalTuple count to the subtype cardinality used elsewhere in the family.",
+    "proofStrategy": "Define wc n k = (antidiagonalTuple k n).card. Base cases wc_zero and wc_one follow from Mathlib's antidiagonalTuple_zero_* and antidiagonalTuple_one simp lemmas. The core is fiber_card: among the (k+1)-tuples summing to n, those whose first coordinate equals j (for j ≤ n) biject with the k-tuples summing to n−j. The bijection strips off the first coordinate (Fin.tail) with inverse prepending j (Fin.cons j); Finset.card_nbij' discharges it, the sum identities Fin.sum_univ_succ / Fin.cons_zero / Fin.cons_succ tracking that the first part j plus the remaining sum equals n. The headline wc_recurrence then applies Finset.card_eq_sum_card_fiberwise with fibre map x ↦ x 0 into range (n+1) — every first coordinate is ≤ n since it is a single summand of the total (Finset.single_le_sum) — and rewrites each fibre by fiber_card. Finally wc_closed proves wc n (k+1) = (n+k).choose k by induction on k: the base case is wc_one; the step rewrites by wc_recurrence, applies the inductive hypothesis to each summand, reflects the summation index with Finset.sum_range_reflect (turning ∑_j C(n−j+k−1, ·) into ∑_i C(i+k−1, ·)), and collapses the resulting telescoping sum with Nat.sum_range_add_choose (the hockey-stick identity ∑_{i≤n} (i+k).choose k = (n+k+1).choose (k+1)).",
+    "keyInsights": [
+      "**Conditioning on one part is the whole proof**: fixing the value j of the first coordinate turns a weak composition of n into k+1 parts into a weak composition of n−j into k parts, a bijection realized by Fin.tail (forget the first part) and Fin.cons j (restore it). The recurrence is nothing more than counting the (k+1)-tuples fibre-by-fibre over the k+1 possible values of that one part — Finset.card_eq_sum_card_fiberwise does the bookkeeping.",
+      "**The recurrence and the hockey-stick identity together give stars-and-bars for free**: once C(n,k+1) = ∑_{j=0}^n C(n−j,k) is in hand, a single induction plus Nat.sum_range_add_choose collapses the sum to (n+k).choose k. No multiset bijection, no generating function — just the fibre partition and Zhu Shijie's identity. This is the most elementary derivation of the closed form in the family.",
+      "**Reflecting the summation index aligns the recurrence with hockey-stick**: the recurrence sums C(n−j, k) over j = 0, …, n (largest residual first), while the hockey-stick identity sums C(i+k−1, ·) over i = 0, …, n (smallest first). Finset.sum_range_reflect bridges the two orientations without touching the summands, so the telescoping identity applies verbatim.",
+      "**antidiagonalTuple makes the model definitional**: taking C(n,k) = (antidiagonalTuple k n).card means membership is literally ∑ᵢ xᵢ = n, so the base cases are Mathlib simp lemmas and the fibre bijection manipulates honest tuples rather than an abstract counting function. The bridge wc_eq_card_weakComposition (via Equiv.subtypeEquivRight and Fintype.card_coe) confirms this count agrees with the subtype cardinality the generating-function entries use, so the elementary and algebraic developments provably count the same objects.",
+      "**A different angle on a well-covered result**: the gallery already proves stars-and-bars by the Sym-multiset bijection (parent) and packages the counts as 1/(1−x)ᵏ (siblings). The last-part recurrence is the coefficient-level shadow of the generating-function recursion 1/(1−x)ᵏ = (1/(1−x))·1/(1−x)^{k−1}; formalizing it completes the picture with the purely combinatorial recursion, the one a first course actually teaches."
+    ],
+    "prerequisites": [
+      "Mathlib's finset of tuples summing to n, Finset.Nat.antidiagonalTuple, and its membership characterization mem_antidiagonalTuple (x ∈ antidiagonalTuple k n ↔ ∑ i, x i = n), plus the base simp lemmas antidiagonalTuple_zero_zero, antidiagonalTuple_zero_succ and antidiagonalTuple_one",
+      "Finset.card_eq_sum_card_fiberwise (partition a finset's cardinality over the fibres of a map into a finite index set) and Finset.card_nbij' (equate two cardinalities from an explicit bijection and inverse, with MapsTo / LeftInvOn / RightInvOn side conditions)",
+      "The Fin-tuple cons/tail calculus: Fin.cons, Fin.tail, Fin.cons_zero, Fin.cons_succ, Fin.tail_cons, Fin.cons_self_tail, and the sum split Fin.sum_univ_succ",
+      "Finset.single_le_sum (a single term is at most a sum of non-negative terms) to bound the first coordinate by the total",
+      "The hockey-stick (Zhu Shijie) identity Nat.sum_range_add_choose (∑_{i∈range(n+1)} (i+k).choose k = (n+k+1).choose (k+1)) and the index reflection Finset.sum_range_reflect"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition-and-base-cases",
+      "title": "Counting Weak Compositions and the Base Cases",
+      "startLine": 1,
+      "endLine": 72,
+      "mathContext": "$C(n,k) = \\#\\{x : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\textstyle\\sum_i x_i = n\\}$, with $C(n,0) = [\\,n = 0\\,]$ and $C(n,1) = 1$.",
+      "summary": "The module docstring fixes the object (weak compositions of n into k parts, ordered k-tuples of naturals summing to n) and the target recurrence. wc n k is defined as (Finset.Nat.antidiagonalTuple k n).card, and mem_antidiagonalTuple' re-exports Mathlib's membership characterization ∑ᵢ xᵢ = n. wc_zero establishes the base case C(n,0) = [n=0] (the empty tuple sums to 0, so only n = 0 is counted) via antidiagonalTuple_zero_zero / antidiagonalTuple_zero_succ, and wc_one gives C(n,1) = 1 from antidiagonalTuple_one (the unique 1-tuple ![n])."
+    },
+    {
+      "id": "fibre-bijection",
+      "title": "The First-Coordinate Fibre Bijection",
+      "startLine": 74,
+      "endLine": 102,
+      "mathContext": "$\\#\\{x \\in \\mathrm{antidiagonalTuple}(k{+}1)\\,n \\mid x_0 = j\\} = C(n-j, k)$ for $j \\le n$.",
+      "summary": "fiber_card is the combinatorial heart: among the weak compositions of n into k+1 parts, those whose first coordinate equals j (with j ≤ n) are in bijection with the weak compositions of n−j into k parts. Finset.card_nbij' discharges the bijection with forward map Fin.tail (drop the first part) and inverse Fin.cons j (prepend j). The four obligations track the sum bookkeeping: Fin.sum_univ_succ splits the total as x₀ + ∑(tail), Fin.cons_zero / Fin.cons_succ evaluate the restored tuple, and Fin.cons_self_tail / Fin.tail_cons close the two round trips."
+    },
+    {
+      "id": "last-part-recurrence",
+      "title": "The Last-Part Recurrence",
+      "startLine": 104,
+      "endLine": 121,
+      "mathContext": "$C(n, k{+}1) = \\sum_{j=0}^{n} C(n-j,\\,k)$.",
+      "summary": "wc_recurrence is the stated open question. Finset.card_eq_sum_card_fiberwise partitions the (k+1)-tuples of n by the value of their first coordinate x₀, a map into range (n+1): every first coordinate is at most the total (Finset.single_le_sum), hence ≤ n. Summing the fibre sizes and rewriting each by fiber_card yields C(n,k+1) = ∑_{j=0}^n C(n−j,k). Conditioning on the first part is the same as conditioning on the last (the tuple order is a relabelling), so this is exactly the last-part recurrence."
+    },
+    {
+      "id": "closed-form",
+      "title": "Solving the Recurrence: Stars and Bars",
+      "startLine": 123,
+      "endLine": 150,
+      "mathContext": "$C(n, k{+}1) = \\binom{n+k}{k}$, via $\\sum_{i=0}^{n}\\binom{i+k}{k} = \\binom{n+k+1}{k+1}$.",
+      "summary": "wc_closed derives the full stars-and-bars closed form C(n,k+1) = (n+k).choose k by induction on k. The base case is wc_one. The step rewrites by wc_recurrence, applies the inductive hypothesis to each summand C(n−j,k+1) = ((n−j)+k).choose k, reflects the summation index with Finset.sum_range_reflect (converting ∑_j ((n−j)+k).choose k into ∑_i (i+k).choose k), and collapses the telescoping sum with the hockey-stick identity Nat.sum_range_add_choose. The bridge wc_eq_card_weakComposition then identifies wc n k with the subtype cardinality Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} (via Equiv.subtypeEquivRight and Fintype.card_coe), confirming this count matches the one the generating-function siblings use; a worked example checks wc n 2 = n+1."
+    }
+  ],
+  "conclusion": {
+    "summary": "The last-part recurrence for weak compositions is formalized sorry-free and axiom-free. Modelling C(n,k) as the cardinality of Finset.Nat.antidiagonalTuple k n, the entry proves the base case C(n,0) = [n=0] (wc_zero), the headline recurrence C(n,k+1) = ∑_{j=0}^n C(n−j,k) (wc_recurrence) by partitioning the tuples over the value of their first coordinate and identifying each fibre with a shorter antidiagonal tuple (fiber_card, a Fin.cons / Fin.tail bijection), and the resulting stars-and-bars closed form C(n,k+1) = (n+k).choose k (wc_closed) by induction plus the hockey-stick identity. A bridge lemma (wc_eq_card_weakComposition) confirms this count agrees with the subtype cardinality used by the family's generating-function entries. All results were checked with #print axioms to rest only on propext / Classical.choice / Quot.sound.",
+    "implications": "The recurrence is the coefficient-level image of the generating-function recursion 1/(1−x)ᵏ = (1/(1−x)) · 1/(1−x)^{k−1}: conditioning on one part corresponds to peeling off one geometric factor. Placed beside the Sym-multiset bijection (parent) and the 1/(1−x)ᵏ generating function (siblings), it supplies the elementary combinatorial recursion — the derivation of stars-and-bars a first course teaches — and its solution, all from the fibre partition and Zhu Shijie's identity, with no multiset or power-series machinery.",
+    "openQuestions": [
+      "Formalize the two-dimensional Pascal recurrence C(n,k) = C(n−1,k) + C(n,k−1) for weak compositions (peel off whether the last part is 0 or positive) and show it is equivalent to the last-part recurrence proved here, giving the binomial triangle for compositions directly.",
+      "Prove the bounded-part analogue: for weak compositions with every part ≤ b, the last-part recurrence becomes C_b(n,k) = ∑_{j=0}^{min(n,b)} C_b(n−j,k−1), whose solution is the truncated (Gaussian-style) coefficient extraction of ((1−x^{b+1})/(1−x))ᵏ, connecting this recurrence to the bounded-parts generating-function sibling."
+    ]
+  },
+  "crossReferences": [
+    "stars-and-bars-weak-compositions",
+    "stars-and-bars-weak-compositions-oq-01",
+    "stars-and-bars-weak-compositions-oq-01-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the **last-part recurrence for weak compositions** (seeker research problem `stars-and-bars-weak-compositions-oq-01-oq-01`, *"Last-Part Recurrence for Weak Compositions"*):

$$C(n,k) = \sum_{j=0}^{n} C(n-j,\, k-1) \quad (k \ge 1), \qquad C(n,0) = [\,n=0\,],$$

where `C(n,k)` counts weak compositions of `n` into `k` parts (ordered `k`-tuples of naturals summing to `n`), taken as `(Finset.Nat.antidiagonalTuple k n).card`.

## Results (all verified, 0 sorry / 0 axioms)

- **`wc_recurrence`** — the stated theorem. Proved by partitioning the `(k+1)`-tuples of `n` by the value of their first coordinate (`Finset.card_eq_sum_card_fiberwise`) and identifying each fibre with a shorter antidiagonal tuple via a `Fin.cons`/`Fin.tail` bijection (`fiber_card`, `Finset.card_nbij'`).
- **`wc_closed`** — solves the recurrence to the full stars-and-bars closed form `C(n,k+1) = (n+k).choose k`, by induction plus the hockey-stick identity `Nat.sum_range_add_choose` (and `Finset.sum_range_reflect` to align the summation order).
- **`wc_zero` / `wc_one`** — base cases `C(n,0) = [n=0]`, `C(n,1) = 1`.
- **`wc_eq_card_weakComposition`** — bridges the count to `Fintype.card {f : Fin k → ℕ // ∑ i, f i = n}`, the representation used by the family's generating-function entries, so the elementary and algebraic developments provably count the same objects.

This is an **elementary combinatorial route** to stars-and-bars — the derivation a first course teaches — complementary to the gallery's existing `Sym`-multiset bijection (`stars-and-bars-weak-compositions`) and `1/(1−x)ᵏ` generating-function entries.

## Verification

- `#print axioms` on every public result → only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). Status **verified**.
- Machine-checked via `lake env lean` against the pinned Mathlib (v4.26.0, rev `2df2f01`). ⚠️ The Docker build cache is currently corrupt (`leantar` `.ltar` decode failure), so the containerized CI build is **pending**; the file elaborates cleanly (exit 0, no warnings) against a prebuilt Mathlib of the same revision.

## Naming note

The seeker gave this problem the slug `stars-and-bars-weak-compositions-oq-01-oq-01`, which is **already owned** by a distinct completed entry (positive-composition generating function). This gallery entry therefore uses the descriptive slug `stars-and-bars-last-part-recurrence-oq-01-oq-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)