### PR TITLE
Enrich Erdős #1000 OQ-02 annotations: mathContext + significance + relatedConcepts

### DIFF
--- a/src/data/proofs/erdos-1000-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1000-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 54 },
     "type": "concept",
     "title": "The rate-of-convergence question for the Cesàro average",
-    "content": "The docstring frames OQ-02 of Erdős #1000. The parent studies Cassels' generalized totient φ_A(k) and its new-denominator density ρ_A(k) = φ_A(k)/n_k; Erdős asked whether the Cesàro average C_A(N) = (1/N)Σ_{k<N} ρ_A(k) can tend to 0, and Haight proved that it can. This file answers the quantitative follow-up — how fast? — by assembling the parent's density-ratio theory into a hierarchy of universal lower bounds on C_A(N): an Ω(1/N) floor, a harmonic floor, a large-ratio frequency floor, a prime-density floor, and a prime-sparsity necessary condition. Everything is 0-axiom, 0-sorry; the parent's two axioms (erdos_dichotomy, haight_resolution) are imported but never invoked."
+    "content": "The docstring frames OQ-02 of Erdős #1000. The parent studies Cassels' generalized totient φ_A(k) and its new-denominator density ρ_A(k) = φ_A(k)/n_k; Erdős asked whether the Cesàro average C_A(N) = (1/N)Σ_{k<N} ρ_A(k) can tend to 0, and Haight proved that it can. This file answers the quantitative follow-up — how fast? — by assembling the parent's density-ratio theory into a hierarchy of universal lower bounds on C_A(N): an Ω(1/N) floor, a harmonic floor, a large-ratio frequency floor, a prime-density floor, and a prime-sparsity necessary condition. Everything is 0-axiom, 0-sorry; the parent's two axioms (erdos_dichotomy, haight_resolution) are imported but never invoked.",
+    "mathContext": "$\\rho_A(k) = \\dfrac{\\varphi_A(k)}{n_k}, \\qquad C_A(N) = \\dfrac{1}{N}\\sum_{k<N}\\rho_A(k).$",
+    "significance": "context",
+    "relatedConcepts": ["Cassels generalized totient", "new-denominator density", "Cesàro average", "Erdős #1000", "Haight's theorem"],
+    "prerequisites": ["Euler totient", "Diophantine approximation", "Cesàro means"]
   },
   {
     "id": "ann-sum-ge-one",
@@ -13,7 +17,11 @@
     "range": { "startLine": 64, "endLine": 72 },
     "type": "proof-step",
     "title": "The running total is pinned at ≥ 1",
-    "content": "`sum_densityRatio_ge_one`: for N ≥ 1 the partial sum Σ_{k<N} ρ_A(k) is at least 1. The mechanism is a single boundary term — ρ_A(0) = 1 (`densityRatio_zero`), because the first fraction m/n₀ has no earlier sequence term whose denominator it could equal, so no m is filtered out. `Finset.single_le_sum` with nonnegativity (`densityRatio_nonneg`) of all other terms delivers the bound. This one fact is the seed of the entire Ω(1/N) floor."
+    "content": "`sum_densityRatio_ge_one`: for N ≥ 1 the partial sum Σ_{k<N} ρ_A(k) is at least 1. The mechanism is a single boundary term — ρ_A(0) = 1 (`densityRatio_zero`), because the first fraction m/n₀ has no earlier sequence term whose denominator it could equal, so no m is filtered out. `Finset.single_le_sum` with nonnegativity (`densityRatio_nonneg`) of all other terms delivers the bound. This one fact is the seed of the entire Ω(1/N) floor.",
+    "mathContext": "$\\rho_A(0)=1 \\ \\wedge\\ \\rho_A(k)\\ge 0 \\ \\Rightarrow\\ \\sum_{k<N}\\rho_A(k) \\ge \\rho_A(0) = 1.$",
+    "significance": "key",
+    "relatedConcepts": ["boundary term", "Finset.single_le_sum", "nonnegativity", "densityRatio_zero"],
+    "prerequisites": ["finite sums", "sum lower bounds"]
   },
   {
     "id": "ann-inv-n",
@@ -21,7 +29,11 @@
     "range": { "startLine": 73, "endLine": 88 },
     "type": "key-insight",
     "title": "Universal Ω(1/N) rate floor",
-    "content": "`cesaroAvg_ge_inv_N`: C_A(N) ≥ 1/N for every increasing sequence and every N ≥ 1. Dividing the pinned running total (≥ 1) by N via the `div_le_div_right₀` rewrite gives the floor directly. This is the headline answer to the rate question at the coarsest scale: no generalized-totient sequence — not even Haight's vanishing-average constructions — can drive its Cesàro average below 1/N. The restatement `one_le_N_mul_cesaroAvg` (1 ≤ N·C_A(N)) rescales the same fact. Notably no arithmetic of the sequence is used — it is pure boundary-term plus nonnegativity — which is why the bound holds universally."
+    "content": "`cesaroAvg_ge_inv_N`: C_A(N) ≥ 1/N for every increasing sequence and every N ≥ 1. Dividing the pinned running total (≥ 1) by N via the `div_le_div_right₀` rewrite gives the floor directly. This is the headline answer to the rate question at the coarsest scale: no generalized-totient sequence — not even Haight's vanishing-average constructions — can drive its Cesàro average below 1/N. The restatement `one_le_N_mul_cesaroAvg` (1 ≤ N·C_A(N)) rescales the same fact. Notably no arithmetic of the sequence is used — it is pure boundary-term plus nonnegativity — which is why the bound holds universally.",
+    "mathContext": "$C_A(N) = \\dfrac{1}{N}\\sum_{k<N}\\rho_A(k) \\ge \\dfrac{1}{N}\\cdot 1 = \\dfrac{1}{N}.$",
+    "significance": "key",
+    "relatedConcepts": ["universal lower bound", "rate of convergence", "div_le_div_right₀", "Cesàro average"],
+    "prerequisites": ["order arithmetic of division", "monotonicity"]
   },
   {
     "id": "ann-not-lt",
@@ -29,7 +41,11 @@
     "range": { "startLine": 90, "endLine": 94 },
     "type": "proof-step",
     "title": "1/N cannot be beaten",
-    "content": "`not_cesaroAvg_lt_inv_N`: there is no sequence and no N with C_A(N) < 1/N. A direct contrapositive of the floor, recording that 1/N is the best possible *universal* upper envelope for the rate — any claimed faster-than-1/N decay is impossible term by term."
+    "content": "`not_cesaroAvg_lt_inv_N`: there is no sequence and no N with C_A(N) < 1/N. A direct contrapositive of the floor, recording that 1/N is the best possible *universal* upper envelope for the rate — any claimed faster-than-1/N decay is impossible term by term.",
+    "mathContext": "$\\neg\\,\\bigl(C_A(N) < \\tfrac{1}{N}\\bigr) \\quad\\text{for all } A,\\ N\\ge 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["contrapositive", "optimal envelope", "impossibility statement"],
+    "prerequisites": ["negation of inequalities"]
   },
   {
     "id": "ann-harmonic",
@@ -37,7 +53,11 @@
     "range": { "startLine": 96, "endLine": 108 },
     "type": "proof-step",
     "title": "The harmonic floor",
-    "content": "`cesaroAvg_ge_harmonic`: C_A(N) ≥ (1/N)Σ_{k<N} 1/n_k. Summing the parent's pointwise reciprocal bound ρ_A(k) ≥ 1/n_k (`densityRatio_ge_inv`, itself from φ_A(k) ≥ 1) and dividing by N. This refines the constant Ω(1/N) floor to one that tracks the reciprocals of the actual sequence terms; it is nontrivial precisely when the n_k grow slowly."
+    "content": "`cesaroAvg_ge_harmonic`: C_A(N) ≥ (1/N)Σ_{k<N} 1/n_k. Summing the parent's pointwise reciprocal bound ρ_A(k) ≥ 1/n_k (`densityRatio_ge_inv`, itself from φ_A(k) ≥ 1) and dividing by N. This refines the constant Ω(1/N) floor to one that tracks the reciprocals of the actual sequence terms; it is nontrivial precisely when the n_k grow slowly.",
+    "mathContext": "$\\rho_A(k) \\ge \\dfrac{1}{n_k} \\ \\Rightarrow\\ C_A(N) \\ge \\dfrac{1}{N}\\sum_{k<N}\\dfrac{1}{n_k}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["harmonic sum", "pointwise reciprocal bound", "densityRatio_ge_inv", "term-by-term summation"],
+    "prerequisites": ["monotonicity of finite sums", "reciprocal bounds"]
   },
   {
     "id": "ann-large-count",
@@ -45,7 +65,11 @@
     "range": { "startLine": 109, "endLine": 143 },
     "type": "key-insight",
     "title": "The rate is governed by the frequency of large ratios",
-    "content": "`sum_densityRatio_ge_half_largeCount` and `cesaroAvg_ge_largeCount`: each index with ρ_A(k) ≥ 1/2 contributes at least 1/2 to the running total (a sub-sum bound via `Finset.sum_le_sum_of_subset_of_nonneg`), giving C_A(N) ≥ #{k<N : ρ_A(k) ≥ 1/2}/(2N). This is the genuine content of the rate question: C_A(N) → 0 forces the large-ratio indices to have density 0. Where the harmonic floor tracks the sequence's size, this floor tracks *how often* the density ratio is large — the actual driver of the convergence rate."
+    "content": "`sum_densityRatio_ge_half_largeCount` and `cesaroAvg_ge_largeCount`: each index with ρ_A(k) ≥ 1/2 contributes at least 1/2 to the running total (a sub-sum bound via `Finset.sum_le_sum_of_subset_of_nonneg`), giving C_A(N) ≥ #{k<N : ρ_A(k) ≥ 1/2}/(2N). This is the genuine content of the rate question: C_A(N) → 0 forces the large-ratio indices to have density 0. Where the harmonic floor tracks the sequence's size, this floor tracks *how often* the density ratio is large — the actual driver of the convergence rate.",
+    "mathContext": "$C_A(N) \\ge \\dfrac{\\#\\{k<N : \\rho_A(k) \\ge \\tfrac12\\}}{2N}.$",
+    "significance": "key",
+    "relatedConcepts": ["counting measure", "sub-sum bound", "Finset.sum_le_sum_of_subset_of_nonneg", "density of large ratios"],
+    "prerequisites": ["Finset cardinality", "subset-sum inequalities"]
   },
   {
     "id": "ann-prime-count",
@@ -53,7 +77,11 @@
     "range": { "startLine": 144, "endLine": 165 },
     "type": "proof-step",
     "title": "The prime-density floor",
-    "content": "`cesaroAvg_ge_primeCount`: C_A(N) ≥ #{k<N : n_k prime}/(2N). A prime term n_k = p has only divisors {1, p}, and p exceeds all earlier terms so it is unused, forcing φ_A(k) ≥ φ(p) = p−1 and ρ_A(k) ≥ (p−1)/p ≥ 1/2 (the parent's `densityRatio_ge_of_prime`). The prime indices thus embed in the large-ratio indices; monotonicity of card and of x ↦ x/(2N) transports the frequency floor to a concrete, checkable number-theoretic bound in terms of the density of prime terms."
+    "content": "`cesaroAvg_ge_primeCount`: C_A(N) ≥ #{k<N : n_k prime}/(2N). A prime term n_k = p has only divisors {1, p}, and p exceeds all earlier terms so it is unused, forcing φ_A(k) ≥ φ(p) = p−1 and ρ_A(k) ≥ (p−1)/p ≥ 1/2 (the parent's `densityRatio_ge_of_prime`). The prime indices thus embed in the large-ratio indices; monotonicity of card and of x ↦ x/(2N) transports the frequency floor to a concrete, checkable number-theoretic bound in terms of the density of prime terms.",
+    "mathContext": "$n_k = p \\text{ prime} \\Rightarrow \\rho_A(k) \\ge \\tfrac{p-1}{p} \\ge \\tfrac12 \\ \\Rightarrow\\ C_A(N) \\ge \\dfrac{\\#\\{k<N: n_k \\text{ prime}\\}}{2N}.$",
+    "significance": "key",
+    "relatedConcepts": ["prime density", "Euler totient of a prime", "densityRatio_ge_of_prime", "subset monotonicity"],
+    "prerequisites": ["φ(p) = p − 1", "divisibility of primes"]
   },
   {
     "id": "ann-capstone",
@@ -61,6 +89,10 @@
     "range": { "startLine": 166, "endLine": 195 },
     "type": "key-insight",
     "title": "Vanishing-average sequences must be prime-sparse",
-    "content": "`not_vanishingAverage_of_frequently_prime_dense`: if the prime terms have density ≥ c > 0 for infinitely many N, then C_A(N) does not converge to 0. Along the frequent prime-dense indices the prime-density floor gives C_A(N) ≥ c/2, contradicting eventual C_A(N) < c/2 (extracted with `tendsto_order` and `Filter.Frequently.and_eventually`). Contrapositively, any Haight-type (vanishing-average) sequence must be sparse in primes — its prime terms have density 0 — a concrete structural necessary condition complementing Haight's highly-composite construction."
+    "content": "`not_vanishingAverage_of_frequently_prime_dense`: if the prime terms have density ≥ c > 0 for infinitely many N, then C_A(N) does not converge to 0. Along the frequent prime-dense indices the prime-density floor gives C_A(N) ≥ c/2, contradicting eventual C_A(N) < c/2 (extracted with `tendsto_order` and `Filter.Frequently.and_eventually`). Contrapositively, any Haight-type (vanishing-average) sequence must be sparse in primes — its prime terms have density 0 — a concrete structural necessary condition complementing Haight's highly-composite construction.",
+    "mathContext": "$\\bigl(\\exists c>0,\\ \\tfrac{\\#\\{k<N: n_k \\text{ prime}\\}}{N} \\ge c \\text{ i.o.}\\bigr) \\Rightarrow C_A(N) \\not\\to 0.$",
+    "significance": "key",
+    "relatedConcepts": ["Frequently/Eventually filters", "tendsto_order", "necessary condition", "Haight's construction", "prime sparsity"],
+    "prerequisites": ["filter limits", "liminf/limsup along atTop", "proof by contradiction"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1000-oq-02` (was quality 70, the highest-priority gap in the gallery).

The entry already had 8 substantive annotations, rich overview, 5 sections, full conclusion, cross-references and references — but the annotations were **content-only**, missing the structured enrichment fields. This pass adds to all 8:

- **`mathContext`** — LaTeX for each floor: the pinned running total, the Ω(1/N) floor, the harmonic/large-ratio/prime-density floors, and the prime-sparsity capstone.
- **`significance`** (key/supporting/context) and **`relatedConcepts`** / **`prerequisites`**.

Quality score **70 → 100** (mathContext 0→10, significance 0→10, crossRefs 0→10). Anchors validate against `Proofs/Erdos1000OQ02.lean`; `meta.json` untouched.