### PR TITLE
research(nicomachus-sum-of-cubes-oq-04): Faulhaber fifth-power sum ∑k⁵ = n²(n+1)²(2n²+2n−1)/12 [verified]

### DIFF
--- a/proofs/Proofs/NicomachusFifthPowers.lean
+++ b/proofs/Proofs/NicomachusFifthPowers.lean
@@ -1,0 +1,115 @@
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Tactic
+
+/-
+# Faulhaber's Fifth-Power Sum: ∑ k⁵ = n²(n+1)²(2n²+2n−1)/12
+
+## Open Question (nicomachus-sum-of-cubes-oq-04)
+
+The fifth-power (`p = 5`) member of the Faulhaber family, extending the parent
+Nicomachus sum-of-cubes identity `∑ k³ = (∑ k)²` and the sibling fourth-power
+entry.  The classical closed form is
+
+    1⁵ + 2⁵ + ⋯ + n⁵ = n²(n+1)²(2n²+2n−1)/12.
+
+Indexing over `range (n+1)` (the `k = 0` term vanishes) the sum reads
+`∑_{k ≤ n} k⁵`.
+
+Check: `n=1 → 1 = 1·4·3/12`, `n=2 → 1+32 = 33 = 4·9·11/12`,
+`n=3 → 1+32+243 = 276 = 9·16·23/12`.
+
+## Result
+
+A fully machine-checked, self-contained proof by induction.
+
+The closed form `n²(n+1)²(2n²+2n−1)/12` carries both a division and (after
+clearing it) a subtraction — `12·∑ k⁵ = 2n⁶ + 6n⁵ + 5n⁴ − n²` — and truncated
+subtraction is the enemy of `ring` over ℕ.  We sidestep both by proving the
+**subtraction-free, division-free** equivalent
+
+    `12·(∑_{k ≤ n} k⁵) + n² = 2n⁶ + 6n⁵ + 5n⁴`        (`sum_fifth_powers_add`),
+
+obtained by adding `n²` to both sides.  Every term is a genuine natural number,
+so the inductive step closes by a single polynomial identity (`ring` for the
+algebra, `omega` to splice it with the hypothesis, treating the powers as opaque
+atoms).  The headline factored form is then recovered over ℤ
+(`twelve_mul_sum_fifth`, where the subtraction is honest) and finally over ℚ with
+the explicit `/12` (`sum_fifth_powers_rat`).
+
+## Novelty
+
+The gallery already carries the Nicomachus cube sum (`p = 3`), the odd-cube sum,
+and the `p = 4` Faulhaber closed form.  This file supplies the next member,
+`p = 5`, mirroring the additive clear-denominator technique used for the sibling
+power-sum entries.  Mathlib has Bernoulli-polynomial Faulhaber machinery but not
+this elementary factored integer identity.
+
+0 sorries, 0 axioms.
+-/
+
+namespace NicomachusFifthPowers
+
+open Finset
+
+/-- **Subtraction-free fifth-power identity.**  Adding `n²` to both sides of the
+headline `12·∑ k⁵ = 2n⁶ + 6n⁵ + 5n⁴ − n²` clears the truncated subtraction, so
+the whole statement lives cleanly in ℕ:
+
+`12·(∑_{k ≤ n} k⁵) + n² = 2n⁶ + 6n⁵ + 5n⁴`.
+
+The induction step is a pure polynomial identity; `omega` splices it together
+with the inductive hypothesis (treating the powers as opaque atoms). -/
+theorem sum_fifth_powers_add (n : ℕ) :
+    12 * (∑ k ∈ range (n + 1), k ^ 5) + n ^ 2
+      = 2 * n ^ 6 + 6 * n ^ 5 + 5 * n ^ 4 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [sum_range_succ]
+    -- The algebraic heart, a subtraction-free polynomial identity over ℕ:
+    have key : 2 * m ^ 6 + 6 * m ^ 5 + 5 * m ^ 4 + 12 * (m + 1) ^ 5 + (m + 1) ^ 2
+        = 2 * (m + 1) ^ 6 + 6 * (m + 1) ^ 5 + 5 * (m + 1) ^ 4 + m ^ 2 := by ring
+    -- `ih` and `key` are linear in the nonlinear atoms; `omega` closes the goal.
+    omega
+
+/-- **Factored form over ℤ.**  Twelve times the sum of the first `n` fifth powers
+equals the classical product `n²(n+1)²(2n²+2n−1)`:
+
+`12·(∑_{k ≤ n} k⁵) = n²(n+1)²(2n²+2n−1)`.
+
+Stated over ℤ so the factor `2n²+2n−1` uses honest subtraction. -/
+theorem twelve_mul_sum_fifth (n : ℕ) :
+    12 * (∑ k ∈ range (n + 1), (k : ℤ) ^ 5)
+      = (n : ℤ) ^ 2 * (n + 1) ^ 2 * (2 * n ^ 2 + 2 * n - 1) := by
+  have h := sum_fifth_powers_add n
+  have hℤ := congrArg (Nat.cast : ℕ → ℤ) h
+  push_cast at hℤ
+  -- hℤ : 12·(∑ ↑k⁵) + ↑n² = 2·↑n⁶ + 6·↑n⁵ + 5·↑n⁴
+  have hsum : 12 * (∑ k ∈ range (n + 1), (k : ℤ) ^ 5)
+      = 2 * (n : ℤ) ^ 6 + 6 * (n : ℤ) ^ 5 + 5 * (n : ℤ) ^ 4 - (n : ℤ) ^ 2 := by
+    linarith [hℤ]
+  rw [hsum]; ring
+
+/-- **Headline closed form over ℚ.**  The Faulhaber `p = 5` identity in its
+classical divided form:
+
+`∑_{k ≤ n} k⁵ = n²(n+1)²(2n²+2n−1)/12`. -/
+theorem sum_fifth_powers_rat (n : ℕ) :
+    (∑ k ∈ range (n + 1), (k : ℚ) ^ 5)
+      = (n : ℚ) ^ 2 * (n + 1) ^ 2 * (2 * n ^ 2 + 2 * n - 1) / 12 := by
+  have h := sum_fifth_powers_add n
+  have hℚ := congrArg (Nat.cast : ℕ → ℚ) h
+  push_cast at hℚ
+  -- hℚ : 12·(∑ ↑k⁵) + ↑n² = 2·↑n⁶ + 6·↑n⁵ + 5·↑n⁴
+  have hsum : (∑ k ∈ range (n + 1), (k : ℚ) ^ 5)
+      = (2 * (n : ℚ) ^ 6 + 6 * (n : ℚ) ^ 5 + 5 * (n : ℚ) ^ 4 - (n : ℚ) ^ 2) / 12 := by
+    linarith [hℚ]
+  rw [hsum]; ring
+
+/-- Sanity check: `∑_{k ≤ 3} k⁵ = 1 + 32 + 243 = 276`. -/
+example : ∑ k ∈ range 4, k ^ 5 = 276 := by decide
+
+/-- Sanity check (factored): `12·∑_{k ≤ 3} k⁵ = 9·16·23 = 3312`. -/
+example : 12 * (∑ k ∈ range 4, k ^ 5) = 3312 := by decide
+
+end NicomachusFifthPowers

--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-04/annotations.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-04/annotations.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": "ann-subtraction-free",
+    "proofId": "nicomachus-sum-of-cubes-oq-04",
+    "range": {
+      "startLine": 62,
+      "endLine": 73
+    },
+    "type": "theorem",
+    "title": "Subtraction-free, division-free core: 12·∑k⁵ + n² = 2n⁶+6n⁵+5n⁴",
+    "content": "The whole development is built on this lemma. The target closed form $n^2(n+1)^2(2n^2+2n-1)/12$ has a division by 12 and, once cleared, a subtraction: $12\\sum k^5 = 2n^6 + 6n^5 + 5n^4 - n^2$. Both are hostile to `ring` over $\\mathbb{N}$ (no division; truncated subtraction is not a ring operation). Multiplying by 12 and moving the $-n^2$ to the left gives $12\\sum_{k\\le n} k^5 + n^2 = 2n^6 + 6n^5 + 5n^4$, where every term is a genuine natural number. The induction's base case is `simp` (the $k=0$ term vanishes); the step uses `sum_range_succ` to expose the top fifth power $(m+1)^5$, then leans on the standalone polynomial identity proved on the next line.",
+    "mathContext": "$12\\sum_{k\\le n} k^5 + n^2 = 2n^6 + 6n^5 + 5n^4$.",
+    "significance": "critical",
+    "prerequisites": [
+      "Mathematical induction",
+      "Finset.sum_range_succ"
+    ],
+    "relatedConcepts": [
+      "Truncated natural subtraction",
+      "Power sums",
+      "Faulhaber's formula"
+    ]
+  },
+  {
+    "id": "ann-ring-omega-step",
+    "proofId": "nicomachus-sum-of-cubes-oq-04",
+    "range": {
+      "startLine": 67,
+      "endLine": 73
+    },
+    "type": "insight",
+    "title": "ring for the algebra, omega for the splice",
+    "content": "The inductive step is closed by a clean division of labor. The `key` hypothesis $2m^6 + 6m^5 + 5m^4 + 12(m+1)^5 + (m+1)^2 = 2(m+1)^6 + 6(m+1)^5 + 5(m+1)^4 + m^2$ is a fixed, subtraction-free degree-6 polynomial identity that `ring` verifies outright. Then `omega` finishes: it treats the nonlinear terms $m^6, m^5, m^4, (m+1)^6, (m+1)^5, (m+1)^4, (m+1)^2$ and the sum as opaque atoms and does the purely *linear* algebra needed to combine `key` with the inductive hypothesis $12\\sum_{k\\le m} k^5 + m^2 = 2m^6 + 6m^5 + 5m^4$. Neither tactic does the other's job — `ring` cannot use the hypothesis, `omega` cannot expand the polynomials.",
+    "mathContext": "$2m^6 + 6m^5 + 5m^4 + 12(m+1)^5 + (m+1)^2 = 2(m+1)^6 + 6(m+1)^5 + 5(m+1)^4 + m^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ring tactic",
+      "omega tactic",
+      "Atomization of nonlinear terms"
+    ]
+  },
+  {
+    "id": "ann-factored-int",
+    "proofId": "nicomachus-sum-of-cubes-oq-04",
+    "range": {
+      "startLine": 81,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Factored form over ℤ: 12·∑k⁵ = n²(n+1)²(2n²+2n−1)",
+    "content": "The headline factored identity is stated over $\\mathbb{Z}$ so the factor $2n^2+2n-1$ can use honest subtraction. The $\\mathbb{N}$ core lemma is cast up with `congrArg (Nat.cast : ℕ → ℤ)` and `push_cast`, giving $12\\sum \\uparrow k^5 + \\uparrow n^2 = 2\\uparrow n^6 + 6\\uparrow n^5 + 5\\uparrow n^4$. From there `linarith` isolates $12\\sum k^5 = 2n^6 + 6n^5 + 5n^4 - n^2$, and a single `ring` confirms that the product $n^2(n+1)^2(2n^2+2n-1)$ expands to exactly that. The heavy lifting never leaves $\\mathbb{N}$; the cast is used only to phrase the subtraction honestly.",
+    "mathContext": "$12\\sum_{k\\le n} k^5 = n^2(n+1)^2(2n^2+2n-1)$ over $\\mathbb{Z}$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "push_cast",
+      "Integer casts",
+      "Polynomial factorization"
+    ]
+  },
+  {
+    "id": "ann-headline-rat",
+    "proofId": "nicomachus-sum-of-cubes-oq-04",
+    "range": {
+      "startLine": 97,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Headline closed form over ℚ: ∑k⁵ = n²(n+1)²(2n²+2n−1)/12",
+    "content": "The classical divided form. The same $\\mathbb{N}$ core is cast to $\\mathbb{Q}$ with `push_cast`; `linarith` isolates the sum as $(2n^6 + 6n^5 + 5n^4 - n^2)/12$, and `ring` clears the explicit $/12$ against the product $n^2(n+1)^2(2n^2+2n-1)$. This is the form a reader recognizes as Faulhaber's $p=5$ polynomial. Together with the $\\mathbb{Z}$ and $\\mathbb{N}$ versions it gives three interoperable phrasings of the identity for downstream use.",
+    "mathContext": "$\\sum_{k\\le n} k^5 = \\dfrac{n^2(n+1)^2(2n^2+2n-1)}{12}$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Rational casts",
+      "Faulhaber's formula",
+      "Bernoulli numbers"
+    ]
+  }
+]

--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-04/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "nicomachus-sum-of-cubes-oq-04",
+  "title": "Faulhaber's Fifth-Power Sum: ∑ k⁵ = n²(n+1)²(2n²+2n−1)/12",
+  "slug": "nicomachus-sum-of-cubes-oq-04",
+  "description": "A fully machine-checked, self-contained proof of the Faulhaber p=5 closed form: the sum of the first n fifth powers equals n²(n+1)²(2n²+2n−1)/12, i.e. ∑_{k≤n} k⁵ = n²(n+1)²(2n²+2n−1)/12. The closed form carries both a division (/12) and, after clearing it, a subtraction (12·∑ = 2n⁶+6n⁵+5n⁴ − n²), and truncated subtraction is hostile to `ring` over ℕ. The engine of the proof is the subtraction-free, division-free repackaging 12·(∑ k⁵) + n² = 2n⁶+6n⁵+5n⁴, proved by induction with a single polynomial `ring` identity spliced into the hypothesis by `omega`. The factored form is recovered over ℤ and the headline /12 form over ℚ via push_cast. This answers the open question posed by the sibling fourth-power entry — whether the clear-denominator recipe extends past p=4 — in the affirmative for p=5. Mathlib has neither this identity nor its parents.",
+  "meta": {
+    "author": "Classical (Faulhaber, 1631; Jakob Bernoulli); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Faulhaber%27s_formula",
+    "date": "1631",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "power-sums",
+      "faulhaber",
+      "fifth-powers",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/NicomachusFifthPowers.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term off a range-sum: ∑_{i<n+1} f i = (∑_{i<n} f i) + f n. The engine of the inductive step.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The Faulhaber fifth-power identity ∑_{k≤n} k⁵ = n²(n+1)²(2n²+2n−1)/12 — the sum of the first n fifth powers 1⁵ + 2⁵ + ⋯ + n⁵ — machine-checked with 0 axioms and 0 sorries (Mathlib provides Bernoulli-polynomial Faulhaber machinery but not this elementary factored closed form, nor its parents)",
+      "The subtraction-free, division-free repackaging 12·(∑_{k≤n} k⁵) + n² = 2n⁶ + 6n⁵ + 5n⁴: clearing the /12 and moving the −n² of the closed form to the left makes every term a genuine natural number, so the whole induction lives in ℕ with no truncated subtraction, no division, and no casts in the core lemma",
+      "The 'ring-then-omega' inductive step at degree 6: the algebraic content is a single subtraction-free polynomial identity 2m⁶ + 6m⁵ + 5m⁴ + 12(m+1)⁵ + (m+1)² = 2(m+1)⁶ + 6(m+1)⁵ + 5(m+1)⁴ + m² (closed by `ring`), which `omega` then combines linearly with the inductive hypothesis treating the power terms as opaque atoms",
+      "Two downstream packagings: the factored integer form 12·∑ k⁵ = n²(n+1)²(2n²+2n−1) over ℤ (`twelve_mul_sum_fifth`) and the classical divided form over ℚ with the explicit /12 (`sum_fifth_powers_rat`)",
+      "A direct affirmative answer to the open question raised by the sibling p=4 entry: the clear-denominator, ring-then-omega recipe does extend to p=5 — the higher Bernoulli denominator (12) and the repeated square factors n²(n+1)² do not obstruct a subtraction-free integer core"
+    ],
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "lineCount": 115,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions) for all three theorems (sum_fifth_powers_add, twelve_mul_sum_fifth, sum_fifth_powers_rat). The two sanity-check examples use kernel `decide` (not native_decide), so no Lean.ofReduceBool. No sorryAx, no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "subtraction-free",
+      "title": "Subtraction-free, division-free core",
+      "startLine": 62,
+      "endLine": 73,
+      "summary": "The core lemma 12·(∑_{k≤n} k⁵) + n² = 2n⁶ + 6n⁵ + 5n⁴, proved by induction. The base case is `simp`. The step peels the top fifth power with sum_range_succ, then a single subtraction-free `ring` identity 2m⁶ + 6m⁵ + 5m⁴ + 12(m+1)⁵ + (m+1)² = 2(m+1)⁶ + 6(m+1)⁵ + 5(m+1)⁴ + m² is combined with the inductive hypothesis by `omega` (which atomizes the power terms). No truncated ℕ subtraction and no division ever appears."
+    },
+    {
+      "id": "factored-int",
+      "title": "Factored form over ℤ",
+      "startLine": 81,
+      "endLine": 91,
+      "summary": "12·(∑_{k≤n} k⁵) = n²(n+1)²(2n²+2n−1). Casting the ℕ identity to ℤ with push_cast lets the factor 2n²+2n−1 use honest subtraction; `linarith` isolates 12·∑ = 2n⁶+6n⁵+5n⁴ − n² and a final `ring` recognizes that the product equals 2n⁶+6n⁵+5n⁴ − n²."
+    },
+    {
+      "id": "headline-rat",
+      "title": "Headline closed form over ℚ",
+      "startLine": 97,
+      "endLine": 107,
+      "summary": "∑_{k≤n} k⁵ = n²(n+1)²(2n²+2n−1)/12, the classical divided form. The same ℕ core is cast to ℚ, `linarith` isolates the sum as (2n⁶+6n⁵+5n⁴ − n²)/12, and `ring` clears the product against the /12."
+    },
+    {
+      "id": "sanity",
+      "title": "Concrete sanity checks",
+      "startLine": 109,
+      "endLine": 113,
+      "summary": "Two kernel-`decide` checks at n=3: ∑_{k≤3} k⁵ = 1+32+243 = 276, and the factored 12·∑ = 9·16·23 = 3312. Kernel decide, not native_decide — no Lean.ofReduceBool."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Faulhaber's formula and the power sums**\n\nNicomachus of Gerasa (c. 100 AD) observed that the sum of the *first n cubes* is the square of the $n$-th triangular number, $\\sum_{k\\le n} k^3 = (\\sum_{k\\le n} k)^2$. The general question — a closed form for $\\sum_{k\\le n} k^p$ for each fixed power $p$ — was settled by Johann Faulhaber (1631) and put on a uniform footing by Jakob Bernoulli, whose numbers $B_p$ encode the coefficients. For $p = 5$ the closed form is\n$$1^5 + 2^5 + \\cdots + n^5 = \\frac{n^2(n+1)^2(2n^2+2n-1)}{12},$$\na degree-6 polynomial in $n$ that Mathlib's BigOperators library does not provide in elementary factored form. This entry supplies it, as the $p=5$ sibling of the parent Nicomachus sum-of-cubes formalization and the $p=4$ fourth-power entry.",
+    "problemStatement": "**Sum of the first n fifth powers**\n\nIndexing over `range (n+1)` (the $k=0$ term vanishes, so the sum counts $1^5, \\ldots, n^5$), prove that for every natural number $n$,\n$$\\sum_{k\\le n} k^5 = \\frac{n^2(n+1)^2(2n^2+2n-1)}{12}.$$\nThe goal is a fully machine-checked proof with no axioms and no sorries.",
+    "proofStrategy": "**Clear the division and the subtraction, then induct**\n\nThe closed form has two features hostile to a `ring`-driven induction over $\\mathbb{N}$: the division by $12$, and the subtraction that survives clearing it, $12\\sum k^5 = 2n^6 + 6n^5 + 5n^4 - n^2$. The fix is to clear both at once — multiply through by $12$ and add $n^2$ to both sides — giving the **subtraction-free, division-free** identity\n$$12\\Big(\\sum_{k\\le n} k^5\\Big) + n^2 = 2n^6 + 6n^5 + 5n^4,$$\nin which every term is an honest natural number. This is proved by induction: `sum_range_succ` peels off the top fifth power $(m+1)^5$, and the inductive step is the single polynomial identity $2m^6 + 6m^5 + 5m^4 + 12(m+1)^5 + (m+1)^2 = 2(m+1)^6 + 6(m+1)^5 + 5(m+1)^4 + m^2$ — proved by `ring` — which `omega` then splices together with the inductive hypothesis (treating $m^6, m^5, \\ldots$ as opaque atoms). The classical factored form $n^2(n+1)^2(2n^2+2n-1)$ is recovered over $\\mathbb{Z}$ (`push_cast`, where the subtraction is honest), and the headline $/12$ form over $\\mathbb{Q}$.",
+    "keyInsights": [
+      "**Clear the denominator *and* the subtraction up front.** Multiplying by $12$ removes the rational coefficient, and adding $n^2$ removes the only remaining minus sign, so the entire core induction lives in $\\mathbb{N}$ with no casts and no truncated subtraction.",
+      "**ring for algebra, omega for bookkeeping.** The genuinely algebraic content of the step is one subtraction-free degree-6 polynomial identity; `omega` does only the linear splicing with the hypothesis, atomizing the nonlinear power terms. Neither tactic does the other's job.",
+      "**Cast only at the end.** $\\mathbb{Z}$ and $\\mathbb{Q}$ are needed solely to *state* the headline factored and divided forms honestly; `push_cast` plus `ring` transports the $\\mathbb{N}$ result there, so the heavy lifting never leaves $\\mathbb{N}$.",
+      "**The recipe survives the jump past p=4.** The fourth-power entry left open whether the clear-denominator technique scales to $\\sum k^5$; it does, unchanged. The larger denominator ($12$) and the repeated square factors $n^2(n+1)^2$ leave the integer core just as subtraction-free, so the ring-then-omega step closes at degree 6 exactly as at degree 5."
+    ],
+    "prerequisites": [
+      "Mathematical induction",
+      "Finite sums over `Finset.range`",
+      "Truncated natural-number subtraction",
+      "Integer/rational casts (push_cast)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Faulhaber fifth-power identity $\\sum_{k\\le n} k^5 = n^2(n+1)^2(2n^2+2n-1)/12$ is established by a short induction. The closed form's division and subtraction are dissolved by proving the equivalent subtraction-free, division-free statement $12\\sum k^5 + n^2 = 2n^6 + 6n^5 + 5n^4$ in $\\mathbb{N}$; the inductive step is one `ring` identity combined with the hypothesis by `omega`, and the headline forms are recovered over $\\mathbb{Z}$ and $\\mathbb{Q}$ with `push_cast`. The proof depends on a single Mathlib lemma (`sum_range_succ`). 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the p=5 Faulhaber power-sum identity ∑ k⁵ = n²(n+1)²(2n²+2n−1)/12, absent from Mathlib's BigOperators library in elementary factored form, in three reusable forms (ℕ subtraction-free, ℤ factored, ℚ divided).",
+      "Confirms that the 'clear the denominator, add a term to clear the subtraction' technique extends from the cube, odd-cube, and fourth-power sums to the fifth-power sum without modification, directly answering the sibling entry's open question.",
+      "The 'ring-then-omega' split scales to a degree-6 polynomial step, reinforcing it as a robust pattern for inductive sum identities whose step is a fixed polynomial identity plus linear hypothesis bookkeeping."
+    ],
+    "openQuestions": [
+      "Does the same recipe continue through ∑ k⁶ (denominator 42, factor 2n⁴+6n³+... ) and beyond, or does the growing Bernoulli denominator eventually force a genuinely different core lemma?",
+      "Can the whole family ∑ k^p be unified into a single Lean theorem parameterized by p via the Bernoulli numbers (Faulhaber's formula proper), so that the per-power entries become instances rather than separate proofs?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "nicomachus-sum-of-cubes-oq-02",
+      "relationship": "The p=4 sibling whose open question this entry answers",
+      "description": "Faulhaber's fourth-power sum ∑ k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30. That entry explicitly asked whether the clear-denominator, ring-then-omega recipe extends to ∑ k⁵; this p=5 entry answers yes, using the identical technique at degree 6."
+    },
+    {
+      "proofId": "nicomachus-sum-of-cubes-oq-01",
+      "relationship": "The p=3 case at the root of this family",
+      "description": "Nicomachus's theorem ∑ k³ = (∑ k)². The parent identity; where the cube sum collapses to a perfect square, the p=5 closed form keeps a genuine /12 denominator and the irreducible factor 2n²+2n−1, requiring the clear-denominator technique."
+    },
+    {
+      "proofId": "nicomachus-sum-of-cubes-oq-03",
+      "relationship": "Sibling power-sum variant",
+      "description": "The odd-cube analogue ∑ (2k+1)³ = n²(2n²−1). A companion in the same family, illustrating the same induction-plus-fixed-polynomial-identity pattern applied to a restricted (odd-index) cube sum."
+    },
+    {
+      "proofId": "newton-power-sum-identities-oq-01",
+      "relationship": "General power-sum framework",
+      "description": "Newton's identities relate power sums pₖ = ∑ Xᵢᵏ to elementary symmetric polynomials — the broader symmetric-function setting in which per-degree Faulhaber formulas like this one live."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **p=5** member of the Nicomachus/Faulhaber power-sum family, completing the gallery series: cubes (`oq-01`), fourth powers (`oq-02`), odd cubes (`oq-03`), and now **fifth powers (`oq-04`)**.

$$\sum_{k\le n} k^5 = \frac{n^2(n+1)^2(2n^2+2n-1)}{12}.$$

## Proof architecture (mirrors the sibling p=4 entry)

The closed form has a division (/12) and, once cleared, a subtraction ($12\sum k^5 = 2n^6+6n^5+5n^4-n^2$) — both hostile to `ring` over ℕ. The engine is the **subtraction-free, division-free** repackaging, proved entirely in ℕ:

- `sum_fifth_powers_add`: `12·(∑_{k≤n} k⁵) + n² = 2n⁶ + 6n⁵ + 5n⁴`, by induction. `sum_range_succ` peels the top fifth power; a single subtraction-free `ring` identity is spliced into the inductive hypothesis by `omega` (atomizing the nonlinear power terms).
- `twelve_mul_sum_fifth`: factored form `12·∑k⁵ = n²(n+1)²(2n²+2n−1)` over ℤ (honest subtraction via `push_cast`).
- `sum_fifth_powers_rat`: classical divided form over ℚ.

This **directly answers the open question** posed by the `oq-02` fourth-power entry — whether the clear-denominator + ring-then-omega recipe extends past p=4. It does, unchanged, at degree 6.

## Verification

Built under the Docker wrapper (`LEAN_SKIP_CACHE=true` bypass for the shared-cache `.ltar` corruption):

- `✔ Built Proofs.NicomachusFifthPowers` — 0 errors.
- `#print axioms` on all three theorems → `[propext, Classical.choice, Quot.sound]` only. **0 sorries, 0 axioms.**
- Sanity checks use kernel `decide` (not `native_decide`) → no `Lean.ofReduceBool`.

Genuinely `verified`. Mathlib has Bernoulli-polynomial Faulhaber machinery but not this elementary factored integer identity.

## Files
- `proofs/Proofs/NicomachusFifthPowers.lean` (115 lines, 3 theorems)
- `src/data/proofs/nicomachus-sum-of-cubes-oq-04/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)