### PR TITLE
research(cube-root-3-oq-02-oq-03): fix build regression in capelli_four_coeff_contra (main did not build)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
@@ -364,7 +364,10 @@ theorem capelli_four_coeff_contra {K : Type*} [Field K] {a p q s t : K}
       rcases mul_eq_zero.mp hp3 with h | h
       · exact absurd h hp
       · linear_combination h
-    subst htq
+    -- Rewrite `t ↦ q` in the two hypotheses we still need (keeping `q`, which the
+    -- rest of the argument is phrased in). NB: `subst htq` would eliminate `q`, not
+    -- `t`, breaking every downstream reference to `q`.
+    rw [htq] at h2 h4
     have hp2 : p ^ 2 = 2 * q := by linear_combination -h2
     have hq2 : q ^ 2 = -a := by linear_combination h4
     -- `2 ≠ 0` is forced: otherwise `p² = 2q = 0` gives `p = 0`.


### PR DESCRIPTION
## Summary

`main` has **not built** since #34959. That PR (merged during a Docker outage, so never kernel-checked) introduced

```lean
subst htq   -- htq : t = q
```

in `capelli_four_coeff_contra`. With `htq : t = q` Lean's `subst` eliminates **`q`**, not `t`, so every downstream reference to `q` (lines 369, 381) becomes an *unknown identifier* and `ring` fails:

```
error: Proofs/CubeRoot3IrrationalOQ02OQ03.lean:369:15: Unknown identifier `q`
error: Proofs/CubeRoot3IrrationalOQ02OQ03.lean:369:32: ring failed
error: Proofs/CubeRoot3IrrationalOQ02OQ03.lean:381:15: Unknown identifier `q`
```

## Fix

Replace the mis-oriented `subst` with a rewrite that keeps `q` (the variable the rest of the proof is written in):

```lean
rw [htq] at h2 h4   -- eliminate t ↦ q in the two still-needed hyps
```

## Verification

```
./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ02OQ03
⚠ [3061/3061] Built Proofs.CubeRoot3IrrationalOQ02OQ03 (3.1s)
warning: ...:413:8: declaration uses 'sorry'
Build completed successfully (3061 jobs).
```

Docker-verified: builds cleanly with **0 axioms** and the **single intended sorry** (even n≥4 — the Mathlib `KummerExtension` TODO, Lang *Algebra* VI §9), exactly matching the entry's stated status. No mathematical content changed; this only restores the file to a compiling state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)