### PR TITLE
Research: hurwitz-theorem-oq-03-oq-01 — real-part functional realPart : A →ₗ[ℝ] ℝ + imaginary submodule [build-verified]

### DIFF
--- a/proofs/Proofs/HurwitzOnlyIf.lean
+++ b/proofs/Proofs/HurwitzOnlyIf.lean
@@ -419,6 +419,152 @@ theorem isImaginary_add (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
     have hyimg : IsImaginary A (s • (1 : A)) := by rw [← hy_real]; exact ⟨b, hb, hysq⟩
     exact hs0 ((isImaginary_smul_one_iff A s).mp hyimg)
 
+/-! ### Frobenius Step 3 (continued): the real-part functional and the imaginary submodule
+
+With `Im A` now closed under addition (`isImaginary_add`) the decomposition `A = ℝ ⬝ 1 ⊕ Im A`
+becomes genuinely *linear*: we can assemble the **real-part functional** `realPart : A →ₗ[ℝ] ℝ`.
+For each `a`, completing the square (`exists_real_shift_sq_scalar`) together with Step 2b
+(`eq_smul_one_of_sq_eq_nonneg_smul`) produces a *unique* real `c` with `a - c ⬝ 1` imaginary
+(`exists_unique_real_part`); `realPart a` is that `c`.  Additivity of `realPart` follows from
+`isImaginary_add`, homogeneity from `isImaginary_smul` (both scalar-closure facts for `Im A`
+proved just below), and its kernel is *exactly* the imaginary elements
+(`mem_imaginarySubmodule_iff`) — so `Im A` is packaged as an honest `ℝ`-submodule
+`imaginarySubmodule = ker realPart`.  This is the linear scaffolding on which the
+positive-definite symmetric bilinear form `B(x,y) = -(x*y+y*x)/2` — real-valued by
+`anticommutator_scalar_imaginary` — lives, the last structural input needed for the quaternion
+dimension count `finrank ℝ (Im A) ∈ {0, 1, 3}` and hence `finrank ℝ A ∈ {1, 2, 4}`. -/
+
+/-- **`Im A` is closed under negation.**  `(-x)² = x²`, so `-x` squares to the same nonpositive
+real scalar as `x`. -/
+theorem isImaginary_neg (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    {x : A} (hx : IsImaginary A x) : IsImaginary A (-x) := by
+  obtain ⟨r, hr, hsq⟩ := hx
+  refine ⟨r, hr, ?_⟩
+  rw [pow_two, neg_mul_neg, ← pow_two, hsq]
+
+/-- **`Im A` is closed under real scalar multiplication.**  If `x² = r ⬝ 1` with `r ≤ 0` then
+`(c • x)² = (c²·r) ⬝ 1` and `c²·r ≤ 0`. -/
+theorem isImaginary_smul (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    (c : ℝ) {x : A} (hx : IsImaginary A x) : IsImaginary A (c • x) := by
+  obtain ⟨r, hr, hsq⟩ := hx
+  refine ⟨c * c * r, ?_, ?_⟩
+  · have hcc : 0 ≤ c * c := mul_self_nonneg c
+    nlinarith
+  · have hxx : x * x = r • (1 : A) := by rw [← pow_two]; exact hsq
+    rw [pow_two, smul_mul_smul_comm, hxx, smul_smul]
+
+/-- **`Im A` is closed under subtraction** (hence an additive subgroup), combining
+`isImaginary_add` and `isImaginary_neg`. -/
+theorem isImaginary_sub (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] {x y : A} (hx : IsImaginary A x) (hy : IsImaginary A y) :
+    IsImaginary A (x - y) := by
+  rw [sub_eq_add_neg]
+  exact isImaginary_add A hx (isImaginary_neg A hy)
+
+/-- **Existence and uniqueness of the real part.**  Every `a : A` has a *unique* real `c` such
+that `a - c ⬝ 1` is imaginary.  Existence: complete the square via `exists_real_shift_sq_scalar`;
+if the resulting square scalar is positive, Step 2b makes the shifted element itself real, so `a`
+is a real multiple of `1` and its imaginary part is `0`.  Uniqueness: two such shifts differ by an
+imaginary real multiple `(c - c') ⬝ 1`, which `isImaginary_smul_one_iff` forces to vanish. -/
+theorem exists_unique_real_part (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (a : A) : ∃! c : ℝ, IsImaginary A (a - c • (1 : A)) := by
+  obtain ⟨c₀, r, hr⟩ := exists_real_shift_sq_scalar A a
+  have hexist : ∃ c : ℝ, IsImaginary A (a - c • (1 : A)) := by
+    rcases le_or_gt r 0 with hle | hlt
+    · exact ⟨c₀, r, hle, hr⟩
+    · obtain ⟨s, hs⟩ := eq_smul_one_of_sq_eq_nonneg_smul A (a - c₀ • 1) r hlt.le hr
+      refine ⟨s + c₀, 0, le_refl 0, ?_⟩
+      have ha : a - (s + c₀) • (1 : A) = 0 := by
+        have hsplit : a = (a - c₀ • (1 : A)) + c₀ • (1 : A) := by abel
+        rw [hsplit, hs, add_smul]; abel
+      rw [ha]; simp
+  obtain ⟨c, hc⟩ := hexist
+  refine ⟨c, hc, ?_⟩
+  intro c' hc'
+  have hdiff : IsImaginary A ((c' - c) • (1 : A)) := by
+    have hrw : (c' - c) • (1 : A) = (a - c • (1 : A)) - (a - c' • (1 : A)) := by
+      rw [sub_smul]; abel
+    rw [hrw]; exact isImaginary_sub A hc hc'
+  have hzero : c' - c = 0 := (isImaginary_smul_one_iff A (c' - c)).mp hdiff
+  linear_combination hzero
+
+open Classical in
+/-- The **real part** of `a`: the unique real scalar `c` with `a - c ⬝ 1` imaginary
+(`exists_unique_real_part`).  Packaged as the `ℝ`-linear map `realPart` below. -/
+noncomputable def realPartValue (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (a : A) : ℝ :=
+  (exists_unique_real_part A a).choose
+
+/-- Defining property of `realPartValue`: `a - realPartValue a ⬝ 1` is imaginary. -/
+theorem isImaginary_sub_realPartValue (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (a : A) :
+    IsImaginary A (a - (realPartValue A a) • (1 : A)) :=
+  (exists_unique_real_part A a).choose_spec.1
+
+/-- Characterising property: any `c` making `a - c ⬝ 1` imaginary *is* `realPartValue a`. -/
+theorem realPartValue_eq (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] {a : A} {c : ℝ} (h : IsImaginary A (a - c • (1 : A))) :
+    realPartValue A a = c :=
+  ((exists_unique_real_part A a).choose_spec.2 c h).symm
+
+/-- The real part is **additive**. -/
+theorem realPartValue_add (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (a b : A) :
+    realPartValue A (a + b) = realPartValue A a + realPartValue A b := by
+  apply realPartValue_eq
+  have hrw : a + b - (realPartValue A a + realPartValue A b) • (1 : A)
+      = (a - realPartValue A a • (1 : A)) + (b - realPartValue A b • (1 : A)) := by
+    rw [add_smul]; abel
+  rw [hrw]
+  exact isImaginary_add A (isImaginary_sub_realPartValue A a) (isImaginary_sub_realPartValue A b)
+
+/-- The real part is **homogeneous** over `ℝ`. -/
+theorem realPartValue_smul (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (c : ℝ) (a : A) :
+    realPartValue A (c • a) = c * realPartValue A a := by
+  apply realPartValue_eq
+  have hrw : c • a - (c * realPartValue A a) • (1 : A)
+      = c • (a - realPartValue A a • (1 : A)) := by
+    rw [smul_sub, smul_smul]
+  rw [hrw]
+  exact isImaginary_smul A c (isImaginary_sub_realPartValue A a)
+
+/-- **The real-part functional** `realPart : A →ₗ[ℝ] ℝ`: the unique real scalar `c` with
+`a - c ⬝ 1` imaginary, now assembled into an `ℝ`-linear map.  Additivity and homogeneity are
+`realPartValue_add` / `realPartValue_smul`. -/
+noncomputable def realPart (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] : A →ₗ[ℝ] ℝ where
+  toFun := realPartValue A
+  map_add' := realPartValue_add A
+  map_smul' := by
+    intro c a
+    simp only [RingHom.id_apply, smul_eq_mul]
+    exact realPartValue_smul A c a
+
+@[simp] theorem realPart_apply (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (a : A) : realPart A a = realPartValue A a := rfl
+
+/-- **The imaginary submodule** `Im A := ker realPart`, an honest `ℝ`-submodule of `A`. -/
+noncomputable def imaginarySubmodule (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] : Submodule ℝ A :=
+  LinearMap.ker (realPart A)
+
+/-- **Membership in `Im A` is exactly imaginarity.**  `a ∈ imaginarySubmodule` iff `a` is
+imaginary (`a² ∈ ℝ≤0 ⬝ 1`), because `realPart a = 0` iff `a - 0 ⬝ 1 = a` is imaginary.  This
+identifies the abstract kernel with the concrete set `{a | a² ∈ ℝ≤0 ⬝ 1}`. -/
+theorem mem_imaginarySubmodule_iff (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (a : A) : a ∈ imaginarySubmodule A ↔ IsImaginary A a := by
+  unfold imaginarySubmodule
+  rw [LinearMap.mem_ker, realPart_apply]
+  constructor
+  · intro h
+    have himg := isImaginary_sub_realPartValue A a
+    rw [h, zero_smul, sub_zero] at himg
+    exact himg
+  · intro h
+    apply realPartValue_eq
+    rwa [zero_smul, sub_zero]
+
 /-! ### The General (Division Ring) Case -/
 
 /-- **Frobenius Step 3, commutative subcase — fully verified.** If a normed division ring

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
@@ -22,9 +22,9 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "1 sorry: hurwitz_only_if_ring (the remaining strictly-non-commutative global structure argument of Frobenius' theorem — Step 3: show Im A is an ℝ-subspace carrying a positive-definite bilinear form / Clifford structure). Frobenius Steps 1 and 2 are VERIFIED (0 sorries): minpoly_natDegree_le_two and exists_quadratic show every element satisfies a real quadratic (generates ℝ or ℂ); exists_real_shift_sq_scalar completes the square so the imaginary part squares to a real scalar, and eq_smul_one_of_sq_eq_nonneg_smul shows a nonnegative such scalar forces the element into ℝ•1 (via no zero divisors), isolating the genuinely imaginary elements as those with negative square scalar. Two further pieces of Step 3 are now also VERIFIED (0 sorries): anticommutator_real_affine shows x*y+y*x ∈ span_ℝ{x,y,1} for all x,y (Step 3 preparation via polarisation), and hurwitz_only_if_ring_comm discharges the commutative subcase of the general-ring statement via Gelfand-Mazur, scoping the remaining sorry to the strictly non-commutative case. Four further Step-3 pieces are now VERIFIED (0 sorries): IsImaginary defines the imaginary summand a²=r•1 with r≤0; eq_zero_of_smul_one_sq_nonpos and isImaginary_smul_one_iff establish the directness ℝ•1 ∩ Im A = {0}; and anticommutator_scalar_of_sq_scalar proves the Clifford relation x*y+y*x = (c−a−b)•1 whenever x², y², (x+y)² are real scalars. The one remaining sorry is now precisely the single global fact that Im A is closed under addition (equivalently the real-part functional A→ℝ is ℝ-linear), which would supply the (x+y)²∈ℝ•1 hypothesis for imaginary x,y and upgrade the scalar anticommutator to a positive-definite bilinear form forcing finrank ℝ (Im A) ∈ {0,1,3}. The commutative subcase (hurwitz_field_case) is axiom-free.",
-    "lineCount": 347,
-    "theoremCount": 12,
-    "definitionCount": 2,
+    "lineCount": 637,
+    "theoremCount": 23,
+    "definitionCount": 5,
     "originalContributions": [
       "admissibleDimensions: Def {1,2,4,8} — the four admissible finranks",
       "finrank_normed_field_eq_one_or_two: Gelfand-Mazur consequence (0 sorries)",
@@ -39,7 +39,11 @@
       "eq_zero_of_smul_one_sq_nonpos: a real multiple s•1 whose square is a nonpositive real scalar must be zero, via injectivity of algebraMap ℝ A (0 sorries) — Frobenius Step 3, directness of ℝ•1 ⊕ Im A",
       "isImaginary_smul_one_iff: s•1 is imaginary iff s = 0, i.e. ℝ•1 ∩ Im A = {0} (0 sorries) — Frobenius Step 3, the direct-sum intersection",
       "anticommutator_scalar_of_sq_scalar: whenever x², y², (x+y)² are real scalars a•1, b•1, c•1, the anticommutator x*y+y*x equals the real scalar (c−a−b)•1 by polarisation (0 sorries) — Frobenius Step 3, the exact Clifford relation eᵢeⱼ+eⱼeᵢ ∈ ℝ•1 for imaginary inputs",
-      "hurwitz_only_if_ring: general division ring case (1 sorry: remaining strictly-non-commutative global Frobenius structure argument, Step 3 — closure of Im A under addition / ℝ-linearity of the real-part functional)"
+      "hurwitz_only_if_ring: general division ring case (1 sorry: remaining strictly-non-commutative global Frobenius structure argument, Step 3 — closure of Im A under addition / ℝ-linearity of the real-part functional)",
+      "isImaginary_neg / isImaginary_smul / isImaginary_sub: Im A is closed under negation, real scalar multiplication, and subtraction (0 sorries) — Frobenius Step 3, scalar-closure of the imaginary set",
+      "exists_unique_real_part: every a has a UNIQUE real c with a-c•1 imaginary (0 sorries) — existence by completing the square + Step 2b, uniqueness by isImaginary_smul_one_iff",
+      "realPart : A →ₗ[ℝ] ℝ: the real-part functional assembled as an ℝ-linear map (0 sorries) — additivity from isImaginary_add, homogeneity from isImaginary_smul",
+      "imaginarySubmodule := LinearMap.ker realPart with mem_imaginarySubmodule_iff: Im A packaged as an honest ℝ-Submodule, kernel identified with {a | a² ∈ ℝ≤0•1} (0 sorries) — the linear scaffolding for the Frobenius bilinear form"
     ]
   },
   "overview": {

--- a/src/data/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01.json
@@ -17,16 +17,16 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-04",
-    "iteration": 4,
-    "focus": "Frobenius Step 3 keystone CLOSED (0 sorry, VERIFIED docker LEAN_SKIP_CACHE): anticommutator_scalar_imaginary — for imaginary x,y the anticommutator x*y+y*x is a real scalar — proved WITHOUT the classical {1,x,y} linear-independence split, via a purely computational route. Its corollary isImaginary_add — Im A closed under addition — is also VERIFIED, resolving the prior blocker (re:A→ℝ is now additive, so Im A is an ℝ-subspace). Remaining single sorry now scoped to finrank ℝ (Im A) ∈ {0,1,3}.",
+    "since": "2026-07-05",
+    "iteration": 5,
+    "focus": "Real-part functional + imaginary submodule ASSEMBLED and BUILD-VERIFIED (docker lake build, 0 errors, only the single pre-existing open sorry at hurwitz_only_if_ring). Executing the prior nextAction: added the scalar-closure lemmas isImaginary_neg / isImaginary_smul / isImaginary_sub, then exists_unique_real_part (every a has a UNIQUE real c with a-c•1 imaginary; existence via completing the square + Step 2b, uniqueness via isImaginary_smul_one_iff), and packaged the real part as the ℝ-linear map realPart : A →ₗ[ℝ] ℝ (additivity from isImaginary_add, homogeneity from isImaginary_smul). Defined imaginarySubmodule := LinearMap.ker realPart with mem_imaginarySubmodule_iff : a ∈ Im A ↔ IsImaginary A a, identifying the abstract kernel with {a | a² ∈ ℝ≤0•1}. Im A is now an honest ℝ-Submodule — the linear scaffolding for the bilinear form. 13 new decls (10 theorems + 3 defs), 0 sorry / 0 axiom in the new code.",
     "blockers": [
-      "Only the final dimension count remains: with the symmetric bilinear form B(x,y) = -(x*y+y*x)/2 on Im A (real-valued by anticommutator_scalar_imaginary), show finrank ℝ (Im A) ∈ {0,1,3} (the quaternion trichotomy). If dim Im A ≥ 2 pick B-orthogonal i,j; k := i*j gives {1,i,j,k} with quaternion relations; associativity forbids dim ≥ 4. Mathlib still lacks Clifford/Radon-Hurwitz machinery, so this is built by hand."
+      "Final dimension count only: on imaginarySubmodule equip the symmetric bilinear form B(x,y) = -(x*y+y*x)/2 (real-valued by anticommutator_scalar_imaginary), show it is positive-definite, then finrank ℝ (Im A) ∈ {0,1,3} (quaternion trichotomy): if dim Im A ≥ 2 pick B-orthogonal i,j; k:=i*j gives {1,i,j,k} with quaternion relations; associativity forbids dim ≥ 4. Mathlib still lacks Clifford/Radon-Hurwitz machinery, built by hand."
     ],
-    "nextAction": "Assemble the real-part functional re : A → ℝ (unique c with a - c•1 ∈ Im A) and prove it ℝ-linear from isImaginary_add + scalar-closure; define Im A := LinearMap.ker re as a Submodule; equip with B(x,y) = -(x*y+y*x)/2 (real by anticommutator_scalar_imaginary), positive-definite on Im A. Then the quaternion argument for finrank ∈ {0,1,3}, giving finrank ℝ A ∈ {1,2,4}.",
+    "nextAction": "Define the ℝ-bilinear form B : Im A →ₗ Im A →ₗ ℝ by B(x,y) = -realPart(x*y) (equivalently -(x*y+y*x)/2, real by anticommutator_scalar_imaginary restricted to Im A via mem_imaginarySubmodule_iff), prove symmetric and positive-definite (B(x,x) = -realPart(x²) = -r ≥ 0, =0 iff x=0 since x²=r•1 with r<0 for x≠0 imaginary). Then the quaternion argument: dim ≤ 1 ⟹ finrank A ∈ {1,2}; dim = 3 ⟹ finrank A = 4; rule out dim ≥ 2-with-more via associativity of the i,j,k=i*j triple, discharging the last sorry to finrank ∈ {1,2,4}.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
+      "total": 3,
+      "currentApproach": 3,
       "approachesTried": 0
     }
   },
@@ -83,5 +83,5 @@
     "mathlib": []
   },
   "started": "2026-07-04T22:16:23.695Z",
-  "lastUpdate": "2026-07-04"
+  "lastUpdate": "2026-07-05"
 }


### PR DESCRIPTION
## Summary

Advances **Frobenius Step 3** for the Hurwitz only-if direction (`Proofs/HurwitzOnlyIf.lean`): with `Im A` now closed under addition (`isImaginary_add`, verified previously), this PR assembles the **real-part functional** and packages `Im A` as an honest `ℝ`-submodule — the linear scaffolding the remaining dimension count needs.

This executes the metadata's stated `nextAction` verbatim ("Assemble the real-part functional `re : A → ℝ` … prove it `ℝ`-linear … define `Im A := LinearMap.ker re` as a Submodule").

## New declarations (0 sorry, 0 axiom in the new code)

- **`isImaginary_neg` / `isImaginary_smul` / `isImaginary_sub`** — `Im A` is closed under negation, real scalar multiplication, and subtraction (`(-x)²=x²`; `(c•x)²=(c²r)•1` with `c²r≤0`).
- **`exists_unique_real_part`** — every `a : A` has a **unique** real `c` with `a - c•1` imaginary. Existence: complete the square (`exists_real_shift_sq_scalar`) + Step 2b (`eq_smul_one_of_sq_eq_nonneg_smul`) for the positive-square case. Uniqueness: two shifts differ by an imaginary real multiple `(c-c')•1`, which `isImaginary_smul_one_iff` forces to zero.
- **`realPart : A →ₗ[ℝ] ℝ`** — the real-part functional as an `ℝ`-linear map. Additivity from `isImaginary_add`, homogeneity from `isImaginary_smul`.
- **`imaginarySubmodule := LinearMap.ker realPart`** with **`mem_imaginarySubmodule_iff : a ∈ Im A ↔ IsImaginary A a`**, identifying the abstract kernel with `{a | a² ∈ ℝ≤0 • 1}`.

`Im A` is now a genuine `ℝ`-`Submodule`, on which the positive-definite symmetric bilinear form `B(x,y) = -(x*y+y*x)/2` (real-valued by `anticommutator_scalar_imaginary`) lives — the last structural input for the quaternion count `finrank ℝ (Im A) ∈ {0,1,3}`, hence `finrank ℝ A ∈ {1,2,4}`.

## Verification

**BUILD-VERIFIED**: `docker lake build Proofs.HurwitzOnlyIf` — 0 errors, only the single pre-existing open `sorry` (`hurwitz_only_if_ring`, the final dimension count) remains. File 491→637 lines, 16→23 theorems.

Status stays **formalized / wip** — the file still has one open sorry, so this is not a "verified" claim; it is a set of individually clean building-block lemmas toward closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)