### PR TITLE
research(alternating-series-boole-summation-oq-01-oq-02-oq-02): first-order Boole transform preserves the sharp aₘ remainder bound

### DIFF
--- a/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ02.lean
@@ -1,0 +1,174 @@
+/-
+# Alternating-Series Boole Summation — OQ-01-OQ-02-OQ-02
+## A sharp remainder bound for the forward-difference (first-order Boole) series
+
+Two threads meet in this entry.
+
+* The grandparent `AlternatingSeriesBooleSummationOQ01.lean` passes the finite Boole
+  identity to the limit: for a null sequence `a → 0` whose alternating series converges,
+  `altSum a 0 m → S`, the **forward-difference alternating series** converges too, to the
+  Boole value `T = a₀ − 2S` (`fdiff_altSum_tendsto` / `boole_tendsto`, at `n = 0`).
+* The parent `AlternatingSeriesBooleSummationOQ01OQ02.lean` supplies the **sharp
+  remainder bound** for the *original* series, `|S − altSum a 0 m| ≤ aₘ`, via the even/odd
+  bracketing `altSum a 0 (2k) ≤ S ≤ altSum a 0 (2k+1)`.
+
+The open question is quantitative: **how fast does the forward-difference (Boole) series
+approach its limit `T`?**  This file answers it, and the answer is sharper than the naive
+triangle-inequality estimate suggests.
+
+## The result
+
+The finite Boole identity, solved for the forward-difference partial sum, is *exact*:
+
+  `altSum (Δa) 0 m = a₀ − (−1)ᵐ aₘ − 2·altSum a 0 m`   (`fdiff_altSum_eq`).
+
+Subtracting from the limit `T = a₀ − 2S` gives the **exact remainder identity**
+
+  `T − altSum (Δa) 0 m = (−1)ᵐ aₘ − 2·(S − altSum a 0 m)`   (`fdiff_remainder_eq`),
+
+tying the Boole-series remainder to the original-series remainder `rₘ = S − altSum a 0 m`.
+The triangle inequality alone only gives `|T − altSum (Δa) 0 m| ≤ 3 aₘ`.  But the sign of
+`rₘ` is *correlated* with the sign of `(−1)ᵐ aₘ` — the bracketing forces `rₘ ∈ [0, aₘ]` for
+even `m` and `rₘ ∈ [−aₘ, 0]` for odd `m` — so the two terms partially cancel and we get the
+**sharp** bound
+
+  `|T − altSum (Δa) 0 m| ≤ aₘ`   (`fdiff_remainder_bound`).
+
+That is exactly the same sharp bound the original alternating series enjoys: the first-order
+Boole transform **preserves** the sharp `aₘ` error control (it does not accelerate it — the
+naive `3 aₘ` would have suggested it *degrades* it, and both readings are wrong).
+
+This is not a corollary of the alternating-series test applied to the Boole series itself:
+the forward-difference terms `Δaⱼ = aⱼ₊₁ − aⱼ` are one-signed for antitone `a` but their
+magnitudes need not be monotone, so `Δa` need not satisfy the test's hypotheses.  The bound
+has to be routed through the original series' bracketing, which is what this entry does.
+
+`fdiff_remainder_tendsto_zero` records the resulting `O(aₘ)` convergence, and
+`fdiff_remainder_bound_of_antitone` packages the unconditional statement for antitone null
+sequences (existence of `S`, convergence of the Boole series to `a₀ − 2S`, and the sharp
+bound at every `m`).
+
+**Sorry count**: 0.  **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecificLimits.Normed
+import Proofs.AlternatingSeriesBooleSummationOQ01
+import Proofs.AlternatingSeriesBooleSummationOQ01OQ02
+
+namespace AlternatingSeriesBooleSummationOQ01OQ02OQ02
+
+open AlternatingSeriesBooleSummationOQ01 AlternatingSeriesBooleSummationOQ01OQ02
+open Finset Filter Topology
+
+variable {a : ℕ → ℝ}
+
+/-! ## The exact finite identity for the forward-difference partial sum -/
+
+/-- **Forward-difference partial sum, solved exactly.**  Rearranging the first-order Boole
+identity `boole_first` at `n = 0` isolates the forward-difference partial sum:
+
+`altSum (Δa) 0 m = a₀ − (−1)ᵐ aₘ − 2·altSum a 0 m`.
+
+No convergence is used — this holds for every `m`. -/
+theorem fdiff_altSum_eq (a : ℕ → ℝ) (m : ℕ) :
+    altSum (fdiff a) 0 m = a 0 - (-1 : ℝ) ^ m * a m - 2 * altSum a 0 m := by
+  have h := boole_first a 0 m (Nat.zero_le m)
+  linear_combination 2 * h
+
+/-- **Exact remainder identity.**  With `S = lim altSum a 0 m` and Boole limit `T = a₀ − 2S`,
+the Boole-series remainder is pinned to the original-series remainder `S − altSum a 0 m`:
+
+`(a₀ − 2S) − altSum (Δa) 0 m = (−1)ᵐ aₘ − 2·(S − altSum a 0 m)`.
+
+This is pure algebra from `fdiff_altSum_eq`; the analytic input enters only in identifying
+`a₀ − 2S` as the limit `T` (`fdiff_tendsto`). -/
+theorem fdiff_remainder_eq (a : ℕ → ℝ) (S : ℝ) (m : ℕ) :
+    (a 0 - 2 * S) - altSum (fdiff a) 0 m
+      = (-1 : ℝ) ^ m * a m - 2 * (S - altSum a 0 m) := by
+  rw [fdiff_altSum_eq]; ring
+
+/-! ## The Boole limit and the sharp remainder bound -/
+
+/-- The forward-difference (Boole) series converges to `a₀ − 2S`, where `S` is the sum of the
+original alternating series.  This is `fdiff_altSum_tendsto` at `n = 0`, so `a₀ − 2S` is the
+genuine limit that the remainder bound below measures against. -/
+theorem fdiff_tendsto (ha0 : Tendsto a atTop (𝓝 0)) {S : ℝ}
+    (hS : Tendsto (fun m => altSum a 0 m) atTop (𝓝 S)) :
+    Tendsto (fun m => altSum (fdiff a) 0 m) atTop (𝓝 (a 0 - 2 * S)) := by
+  have h := fdiff_altSum_tendsto ha0 hS
+  simpa using h
+
+/-- **Sharp remainder bound for the forward-difference (Boole) series.**  For an antitone
+null sequence with alternating sum `S`, the `m`-th partial sum of the forward-difference
+series approximates its limit `a₀ − 2S` to within the `m`-th term of `a`:
+
+`|(a₀ − 2S) − altSum (Δa) 0 m| ≤ aₘ`.
+
+The naive triangle inequality on `fdiff_remainder_eq` only gives `3 aₘ`; the sharp `aₘ`
+comes from the sign correlation supplied by the even/odd bracketing of the original series
+(`even_partial_le` / `le_odd_partial`).  Note that `aₘ ≥ 0` is *not* assumed: it is forced by
+the same bracketing (`altSum a 0 (2k) ≤ S ≤ altSum a 0 (2k+1) = altSum a 0 (2k) + aₘ`), so
+antitonicity and convergence of the original series are all that is needed. -/
+theorem fdiff_remainder_bound (ha : Antitone a)
+    {S : ℝ} (hS : Tendsto (fun m => altSum a 0 m) atTop (𝓝 S)) (m : ℕ) :
+    |(a 0 - 2 * S) - altSum (fdiff a) 0 m| ≤ a m := by
+  rw [fdiff_remainder_eq a S m]
+  rcases Nat.even_or_odd m with ⟨k, hk⟩ | ⟨k, hk⟩
+  · -- m = 2k : the original remainder rₘ = S − altSum lies in [0, aₘ]
+    have hm : m = 2 * k := by omega
+    subst hm
+    have hp : ((-1 : ℝ) ^ (2 * k)) = 1 := by rw [pow_mul]; norm_num
+    have hlo : altSum a 0 (2 * k) ≤ S := even_partial_le ha hS k
+    have hhi : S ≤ altSum a 0 (2 * k + 1) := le_odd_partial ha hS k
+    have hs : altSum a 0 (2 * k + 1) = altSum a 0 (2 * k) + a (2 * k) := by
+      rw [altSum_succ a (Nat.zero_le (2 * k)), hp]; ring
+    rw [hs] at hhi
+    rw [hp, abs_le]
+    constructor <;> linarith
+  · -- m = 2k+1 : the original remainder rₘ lies in [−aₘ, 0]
+    have hm : m = 2 * k + 1 := by omega
+    subst hm
+    have hp : ((-1 : ℝ) ^ (2 * k + 1)) = -1 := by rw [pow_succ, pow_mul]; norm_num
+    have hhi : S ≤ altSum a 0 (2 * k + 1) := le_odd_partial ha hS k
+    have hlo : altSum a 0 (2 * k + 1 + 1) ≤ S := by
+      have := even_partial_le ha hS (k + 1)
+      rwa [(by ring : 2 * (k + 1) = 2 * k + 1 + 1)] at this
+    have hs : altSum a 0 (2 * k + 1 + 1) = altSum a 0 (2 * k + 1) - a (2 * k + 1) := by
+      rw [altSum_succ a (Nat.zero_le (2 * k + 1)), hp]; ring
+    rw [hs] at hlo
+    rw [hp, abs_le]
+    constructor <;> linarith
+
+/-- **`O(aₘ)` convergence of the Boole series.**  The forward-difference remainder tends to
+`0`; combined with `fdiff_remainder_bound` this says the Boole series converges to its limit
+at the same `aₘ` rate as the original alternating series. -/
+theorem fdiff_remainder_tendsto_zero (ha0 : Tendsto a atTop (𝓝 0)) {S : ℝ}
+    (hS : Tendsto (fun m => altSum a 0 m) atTop (𝓝 S)) :
+    Tendsto (fun m => (a 0 - 2 * S) - altSum (fdiff a) 0 m) atTop (𝓝 0) := by
+  have h : Tendsto (fun m => altSum (fdiff a) 0 m) atTop (𝓝 (a 0 - 2 * S)) :=
+    fdiff_tendsto ha0 hS
+  have hc : Tendsto (fun _ : ℕ => a 0 - 2 * S) atTop (𝓝 (a 0 - 2 * S)) := tendsto_const_nhds
+  have h2 := hc.sub h
+  simpa using h2
+
+/-- **Unconditional packaging for antitone null sequences.**  Every antitone null sequence
+`a` has: a convergent alternating series `altSum a 0 m → S`, a convergent forward-difference
+(Boole) series `altSum (Δa) 0 m → a₀ − 2S`, and the sharp remainder bound
+`|(a₀ − 2S) − altSum (Δa) 0 m| ≤ aₘ` at every `m`. -/
+theorem fdiff_remainder_bound_of_antitone (ha : Antitone a) (ha0 : Tendsto a atTop (𝓝 0)) :
+    ∃ S, Tendsto (fun m => altSum a 0 m) atTop (𝓝 S) ∧
+      Tendsto (fun m => altSum (fdiff a) 0 m) atTop (𝓝 (a 0 - 2 * S)) ∧
+      ∀ m, |(a 0 - 2 * S) - altSum (fdiff a) 0 m| ≤ a m := by
+  obtain ⟨S, hS⟩ := altSum_tendsto_of_antitone ha ha0 0
+  exact ⟨S, hS, fdiff_tendsto ha0 hS, fun m => fdiff_remainder_bound ha hS m⟩
+
+#check @fdiff_altSum_eq
+#check @fdiff_remainder_eq
+#check @fdiff_remainder_bound
+#check @fdiff_remainder_bound_of_antitone
+
+-- Axiom audit: only the foundational `propext` / `Classical.choice` / `Quot.sound`.
+#print axioms fdiff_remainder_bound
+#print axioms fdiff_remainder_bound_of_antitone
+
+end AlternatingSeriesBooleSummationOQ01OQ02OQ02

--- a/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 63
+    },
+    "type": "concept",
+    "title": "Carrying the sharp remainder bound across the Boole transform",
+    "content": "The header sets up the meeting of two threads: the grandparent's limit-form Boole identity (the forward-difference series altSum (Δa) 0 m converges to T = a_0 − 2S) and the parent's sharp remainder bound |S − altSum a 0 m| ≤ a_m for the original series. The open question is the rate at which the Boole series approaches T. The preview answer: the sharp a_m bound is PRESERVED — obtained from an exact remainder identity plus the sign correlation of the parent's even/odd bracketing, which collapses the naive triangle-inequality estimate 3 a_m to a_m. Both parent entries are imported and opened to reuse altSum, fdiff, boole_first, altSum_succ, fdiff_altSum_tendsto, even_partial_le, and le_odd_partial.",
+    "mathContext": "Original: $|S - \\mathrm{altSum}\\,a\\,0\\,m| \\le a_m$; Boole limit $T = a_0 - 2S$; target $|T - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m| \\le a_m$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Boole / Euler summation transform",
+      "series acceleration",
+      "alternating-series remainder bound (parent)",
+      "forward differences"
+    ],
+    "prerequisites": [
+      "limit-form Boole identity S = ½(-1)^n a_n − ½T (grandparent)",
+      "sharp remainder bound for the original series (parent)",
+      "convergence of alternating partial sums as Filter.Tendsto"
+    ]
+  },
+  {
+    "id": "ann-exact-identities",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 65,
+      "endLine": 88
+    },
+    "type": "lemma",
+    "title": "The exact finite identity and the remainder identity",
+    "content": "fdiff_altSum_eq solves the grandparent's finite Boole formula boole_first (at n = 0) for the forward-difference partial sum, altSum (Δa) 0 m = a_0 − (-1)^m a_m − 2·altSum a 0 m, in a single linear_combination — exact for every m, no convergence used. fdiff_remainder_eq subtracts this from the limit value a_0 − 2S (a ring step) to get the exact remainder identity (a_0 − 2S) − altSum (Δa) 0 m = (-1)^m a_m − 2·(S − altSum a 0 m), tying the Boole-series remainder to the original-series remainder r_m = S − altSum a 0 m. These two algebraic identities hold the quantitative content; only the sign of r_m remains to be supplied.",
+    "mathContext": "$\\mathrm{altSum}\\,(\\Delta a)\\,0\\,m = a_0 - (-1)^m a_m - 2\\,\\mathrm{altSum}\\,a\\,0\\,m$; remainder $= (-1)^m a_m - 2 r_m$.",
+    "significance": "essential",
+    "relatedConcepts": [
+      "first-order Boole summation formula",
+      "linear_combination",
+      "exact (error-free) rearrangement",
+      "telescoping of finite differences"
+    ],
+    "prerequisites": [
+      "boole_first (finite Boole identity, grandparent)",
+      "algebraic solving via linear_combination and ring"
+    ]
+  },
+  {
+    "id": "ann-sharp-bound",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 90,
+      "endLine": 140
+    },
+    "type": "theorem",
+    "title": "The Boole limit and the sharp remainder bound",
+    "content": "fdiff_tendsto identifies a_0 − 2S as the true limit of the Boole series (fdiff_altSum_tendsto at n = 0), so the quantity bounded is a genuine remainder. fdiff_remainder_bound is the headline result: rewriting by the exact remainder identity and casing on the parity of m, the parent's brackets even_partial_le / le_odd_partial pin r_m to [0, a_m] for even m and [−a_m, 0] for odd m. The identity then reads a_m − 2 r_m (even) or −a_m − 2 r_m (odd), both of absolute value ≤ a_m by abs_le and linarith. The sign correlation between (-1)^m a_m and r_m is exactly what makes the two terms partially cancel, sharpening the naive 3 a_m to a_m; nonnegativity a_m ≥ 0 is derived from the bracket, not assumed, so only antitonicity and convergence are needed.",
+    "mathContext": "$|(a_0 - 2S) - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m| \\le a_m$, matching the original series' sharp bound.",
+    "significance": "essential",
+    "relatedConcepts": [
+      "sharp remainder / first-omitted-term bound",
+      "even/odd bracketing",
+      "sign cancellation vs. triangle inequality",
+      "error-preserving transform"
+    ],
+    "prerequisites": [
+      "even_partial_le and le_odd_partial (parent brackets)",
+      "fdiff_altSum_tendsto (Boole limit, grandparent)",
+      "abs_le, parity case split, linarith"
+    ]
+  },
+  {
+    "id": "ann-rate-packaging",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 142,
+      "endLine": 174
+    },
+    "type": "theorem",
+    "title": "Convergence rate and unconditional packaging",
+    "content": "fdiff_remainder_tendsto_zero derives the O(a_m) convergence of the Boole series from fdiff_tendsto (a constant minus a convergent sequence tends to the difference of the limits, here 0). fdiff_remainder_bound_of_antitone packages the whole result unconditionally for antitone null sequences: existence of the alternating sum S (altSum_tendsto_of_antitone, i.e. Mathlib's alternating-series test), convergence of the forward-difference (Boole) series to a_0 − 2S, and the sharp remainder bound at every m — from Antitone a and a → 0 alone. Closing #check and #print axioms confirm the four signatures and that the results rest only on propext / Classical.choice / Quot.sound.",
+    "mathContext": "$(a_0 - 2S) - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m \\to 0$ at rate $O(a_m)$; unconditional form for antitone null $a$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "convergence rate O(a_m)",
+      "alternating-series test (altSum_tendsto_of_antitone)",
+      "tendsto_const_nhds, Tendsto.sub",
+      "axiom audit (#print axioms)"
+    ],
+    "prerequisites": [
+      "altSum_tendsto_of_antitone (grandparent)",
+      "order limits: tendsto_const_nhds and Tendsto.sub"
+    ]
+  }
+]

--- a/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "alternating-series-boole-summation-oq-01-oq-02-oq-02",
+  "title": "The First-Order Boole Transform Preserves the Sharp Alternating-Series Remainder Bound",
+  "slug": "alternating-series-boole-summation-oq-01-oq-02-oq-02",
+  "description": "The grandparent entry (alternating-series-boole-summation-oq-01) passes the finite Boole summation identity to the limit m → ∞: for a null sequence a → 0 whose alternating partial sums altSum a 0 m = ∑_{j<m} (-1)^j a_j converge to S, the forward-difference alternating series altSum (Δa) 0 m (Δa_j = a_{j+1} − a_j) converges to the Boole value T = a_0 − 2S. The parent (oq-01-oq-02) supplies the sharp remainder bound |S − altSum a 0 m| ≤ a_m for the original series. Its closing open question asks to combine the two into an explicit error estimate for the Boole/Euler acceleration — how fast does the forward-difference (Boole) series approach its limit T? This entry answers it. Solving the finite Boole identity exactly gives altSum (Δa) 0 m = a_0 − (-1)^m a_m − 2·altSum a 0 m (fdiff_altSum_eq), hence the exact remainder identity (a_0 − 2S) − altSum (Δa) 0 m = (-1)^m a_m − 2·(S − altSum a 0 m) (fdiff_remainder_eq), pinning the Boole-series remainder to the original-series remainder r_m = S − altSum a 0 m. The naive triangle inequality gives only |T − altSum (Δa) 0 m| ≤ 3 a_m, but the sign of r_m is correlated with the sign of (-1)^m a_m — the even/odd bracketing forces r_m ∈ [0, a_m] for even m and r_m ∈ [−a_m, 0] for odd m — so the two terms partially cancel and the SHARP bound is |T − altSum (Δa) 0 m| ≤ a_m (fdiff_remainder_bound), exactly the bound the original series enjoys. The finding is that the first-order Boole transform PRESERVES the sharp a_m error control: it neither accelerates it (the naive 3 a_m would have suggested degradation, and the true answer is a_m) nor degrades it. This is not a corollary of the alternating-series test applied to the Boole series itself — the forward-difference terms Δa_j are one-signed for antitone a but their magnitudes need not be monotone, so Δa need not satisfy the test's hypotheses; the bound must be routed through the original series' bracketing. fdiff_remainder_tendsto_zero records the resulting O(a_m) convergence and fdiff_remainder_bound_of_antitone packages the unconditional statement for antitone null sequences.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Proofs.AlternatingSeriesBooleSummationOQ01",
+      "Proofs.AlternatingSeriesBooleSummationOQ01OQ02"
+    ],
+    "opens": [
+      "AlternatingSeriesBooleSummationOQ01",
+      "AlternatingSeriesBooleSummationOQ01OQ02",
+      "Finset",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "AlternatingSeriesBooleSummationOQ01OQ02OQ02",
+    "lineCount": 174,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Boole_summation_formula",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlternatingSeriesBooleSummationOQ01OQ02OQ02.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "alternating-series",
+      "boole-summation",
+      "euler-summation",
+      "remainder-bound",
+      "error-estimate",
+      "convergence-rate",
+      "finite-differences",
+      "limits"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-05",
+    "relatedProblems": [
+      {
+        "id": "alternating-series-boole-summation-oq-01-oq-02",
+        "relationship": "Direct parent. That entry proves the sharp remainder bound |S − altSum a 0 m| ≤ a_m for the ORIGINAL alternating series, via the even/odd bracketing altSum a 0 (2k) ≤ S ≤ altSum a 0 (2k+1) (even_partial_le / le_odd_partial). Its closing open question asks to combine that bound with the limit-form Boole identity to estimate how fast the Boole/Euler-accelerated series approaches its limit. This entry answers it: reusing even_partial_le and le_odd_partial, it proves the corresponding sharp bound |T − altSum (Δa) 0 m| ≤ a_m for the FORWARD-DIFFERENCE (Boole) series, showing the first-order transform preserves — not accelerates — the a_m error control."
+      },
+      {
+        "id": "alternating-series-boole-summation-oq-01",
+        "relationship": "Grandparent. That entry passes the finite Boole identity boole_first to the limit m → ∞, proving that for a null sequence the forward-difference alternating series converges to the Boole value T = (-1)^n a_n − 2S (fdiff_altSum_tendsto, boole_tendsto) and, for antitone null sequences, that the original series converges (altSum_tendsto_of_antitone). This entry reuses fdiff_altSum_tendsto (at n = 0), altSum_tendsto_of_antitone, altSum_succ, and boole_first to obtain the quantitative rate the grandparent's qualitative convergence left open."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 174,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All results — fdiff_altSum_eq (the exact finite identity for the forward-difference partial sum), fdiff_remainder_eq (the exact remainder identity linking the Boole-series remainder to the original-series remainder), fdiff_tendsto (the Boole series converges to a_0 − 2S), fdiff_remainder_bound (the sharp bound |T − altSum (Δa) 0 m| ≤ a_m), fdiff_remainder_tendsto_zero (O(a_m) convergence), and fdiff_remainder_bound_of_antitone (the unconditional packaging) — were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The sharp bound fdiff_remainder_bound requires only Antitone a and convergence of the original alternating series (Tendsto (fun m => altSum a 0 m) atTop (𝓝 S)); it does NOT separately assume a → 0, because a_m ≥ 0 is itself forced by the bracketing altSum a 0 (2k) ≤ S ≤ altSum a 0 (2k) + a_{2k}. Convergence of the original series is guaranteed by the grandparent's altSum_tendsto_of_antitone (Mathlib's alternating-series test), so the hypotheses are satisfiable and not vacuous; the unconditional fdiff_remainder_bound_of_antitone discharges them from Antitone a and a → 0 alone. The limit objects are limits of partial sums (Filter.Tendsto), not HasSum/tsum, since alternating series such as ∑ (-1)^j/(j+1) converge conditionally but are not summable. The genuinely new content is the exact remainder identity and the observation that the sign correlation between (-1)^m a_m and the original remainder r_m collapses the naive 3 a_m triangle bound to the sharp a_m — i.e. the first-order Boole transform preserves the sharp alternating-series error bound.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Boole (Euler) summation formula rewrites an alternating sum in terms of the successive forward differences of its terms; truncating after the first difference gives the first-order identity ∑_{j=n}^{m-1} (-1)^j a_j = ½((-1)^n a_n − (-1)^m a_m) − ½ ∑_{j=n}^{m-1} (-1)^j Δa_j proved in the base entry of this family. Passing it to the limit expresses the alternating sum S in terms of the sum T of the forward-difference series (S = ½(-1)^n a_n − ½T), and the folklore is that the transformed series converges faster — the Euler transformation is a classical series-acceleration device. At first order that folklore deserves scrutiny: the forward-difference series here is itself an alternating series, but of the differences, and the question is whether its truncation error is smaller than, equal to, or larger than that of the original. This entry settles it: at first order the transform is error-preserving. The remainder of the Boole series is bounded by the same first-omitted-term quantity a_m that bounds the original — no better, no worse — because the two remainders are tied by an exact identity whose two contributions partially cancel.",
+    "problemStatement": "Let a : ℕ → ℝ be antitone with alternating sum S (the limit of altSum a 0 m = ∑_{j<m} (-1)^j a_j), and let T = a_0 − 2S be the Boole value, i.e. the limit of the forward-difference alternating series altSum (Δa) 0 m where Δa_j = a_{j+1} − a_j. Bound the rate at which the Boole series approaches T: prove |T − altSum (Δa) 0 m| ≤ a_m for every m, matching the sharp remainder bound of the original series.",
+    "text": "The parent entry (alternating-series-boole-summation-oq-01-oq-02) established the sharp remainder bound |S − altSum a 0 m| ≤ a_m for the original alternating series, together with the even/odd bracketing that makes it sharp. This entry carries that quantitative control across the first-order Boole transform, showing the forward-difference (Boole) series obeys the very same bound. The mechanism is an exact identity between the two remainders, solved from the finite Boole formula, whose sign structure — supplied by the parent's bracketing — is what turns the naive 3 a_m estimate into the sharp a_m.",
+    "proofStrategy": "fdiff_altSum_eq solves the grandparent's finite Boole identity boole_first (at n = 0) for the forward-difference partial sum: altSum (Δa) 0 m = a_0 − (-1)^m a_m − 2·altSum a 0 m (a single linear_combination). Subtracting from the limit T = a_0 − 2S gives the exact remainder identity fdiff_remainder_eq: (a_0 − 2S) − altSum (Δa) 0 m = (-1)^m a_m − 2·(S − altSum a 0 m) (a ring rearrangement). fdiff_tendsto identifies a_0 − 2S as the genuine limit (fdiff_altSum_tendsto at n = 0), so this really is a remainder. The headline fdiff_remainder_bound casts by parity: for m = 2k the parent's brackets give altSum a 0 (2k) ≤ S ≤ altSum a 0 (2k) + a_{2k}, so r_m := S − altSum a 0 m ∈ [0, a_m], and the identity reads a_m − 2r_m with r_m ∈ [0, a_m], forcing |·| ≤ a_m; for m = 2k+1 the brackets give r_m ∈ [−a_m, 0] and the identity reads −a_m − 2r_m, again with |·| ≤ a_m. In both cases abs_le followed by linarith closes the goal; crucially a_m ≥ 0 is derived from the same brackets rather than assumed, so no separate a → 0 hypothesis is needed. fdiff_remainder_tendsto_zero deduces the O(a_m) convergence from fdiff_tendsto, and fdiff_remainder_bound_of_antitone packages existence of S (altSum_tendsto_of_antitone), convergence of the Boole series, and the bound at every m for any antitone null sequence.",
+    "keyInsights": [
+      "**The first-order Boole transform is error-preserving, not error-accelerating.** The forward-difference (Boole) series approaches its limit T with truncation error ≤ a_m — exactly the sharp bound of the original alternating series. The naive triangle inequality suggests 3 a_m (a degradation) and the acceleration folklore suggests something smaller; both are wrong at first order, and the honest answer is equality of the sharp bound.",
+      "**An exact remainder identity does the work.** Solving the finite Boole formula for the forward-difference partial sum yields (a_0 − 2S) − altSum (Δa) 0 m = (-1)^m a_m − 2·(S − altSum a 0 m) with NO error term — the Boole-series remainder is an exact linear expression in the original-series remainder r_m. Everything quantitative follows from controlling r_m.",
+      "**Sign correlation is what sharpens 3 a_m to a_m.** The parent's bracketing does more than bound |r_m| ≤ a_m: it pins the SIGN of r_m to the parity of m (r_m ≥ 0 for even m, r_m ≤ 0 for odd m), which is exactly the sign that makes (-1)^m a_m and −2 r_m partially cancel in the identity. Discarding the sign (bare triangle inequality) loses a factor of 3.",
+      "**The Boole series is not directly Leibniz-estimable.** For antitone a the differences Δa_j = a_{j+1} − a_j are one-signed, but their magnitudes |Δa_j| need not be monotone, so the forward-difference series need not satisfy the hypotheses of the alternating-series test. Its remainder therefore cannot be bounded by its own first omitted term directly; it must be routed through the original series' bracketing — which is precisely the reduction this entry performs.",
+      "**Nonnegativity comes for free from the bracket.** The bound |T − altSum (Δa) 0 m| ≤ a_m only makes sense with a_m ≥ 0, and indeed a_m ≥ 0 need not be assumed: the sandwich altSum a 0 (2k) ≤ S ≤ altSum a 0 (2k) + a_{2k} already yields it, so antitonicity plus convergence of the original series suffice."
+    ],
+    "prerequisites": [
+      "The grandparent entry's finite Boole identity boole_first, successor identity altSum_succ, limit fdiff_altSum_tendsto (forward-difference series → (-1)^n a_n − 2S), and convergence altSum_tendsto_of_antitone (Proofs/AlternatingSeriesBooleSummationOQ01.lean)",
+      "The parent entry's one-sided brackets even_partial_le (altSum a 0 (2k) ≤ S) and le_odd_partial (S ≤ altSum a 0 (2k+1)) (Proofs/AlternatingSeriesBooleSummationOQ01OQ02.lean)",
+      "linear_combination for the exact finite identity, and the abs_le characterization of two-sided estimates closed by linarith",
+      "Parity case analysis Nat.even_or_odd with the evaluations (-1)^{2k} = 1 and (-1)^{2k+1} = -1, and order limits (tendsto_const_nhds, Tendsto.sub) for the convergence corollary"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-and-setup",
+      "title": "Overview: Carrying the Remainder Bound Across the Boole Transform",
+      "startLine": 1,
+      "endLine": 63,
+      "mathContext": "Original remainder $|S - \\mathrm{altSum}\\,a\\,0\\,m| \\le a_m$; Boole limit $T = a_0 - 2S$. Target: $|T - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m| \\le a_m$.",
+      "summary": "The module docstring recalls the grandparent's limit-form Boole identity (forward-difference series → T = a_0 − 2S) and the parent's sharp remainder bound for the original series, states the open question (rate of the Boole series), and previews the answer: the sharp a_m bound is preserved, obtained from an exact remainder identity plus the sign correlation of the parent's bracketing, and the naive triangle inequality's 3 a_m is not sharp. Imports pull in both parent entries; the namespace opens both to reuse altSum, fdiff, boole_first, altSum_succ, fdiff_altSum_tendsto, even_partial_le, and le_odd_partial."
+    },
+    {
+      "id": "exact-identities",
+      "title": "The Exact Finite Identity and the Remainder Identity",
+      "startLine": 65,
+      "endLine": 88,
+      "mathContext": "$\\mathrm{altSum}\\,(\\Delta a)\\,0\\,m = a_0 - (-1)^m a_m - 2\\,\\mathrm{altSum}\\,a\\,0\\,m$; $\\;(a_0 - 2S) - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m = (-1)^m a_m - 2(S - \\mathrm{altSum}\\,a\\,0\\,m)$.",
+      "summary": "fdiff_altSum_eq solves the grandparent's boole_first (at n = 0) for the forward-difference partial sum via a single linear_combination — an exact identity holding for every m with no convergence assumed. fdiff_remainder_eq subtracts it from the limit value a_0 − 2S (ring), producing the exact remainder identity that ties the Boole-series remainder to the original-series remainder r_m = S − altSum a 0 m. These two algebraic identities carry all the quantitative content; only the sign of r_m remains to be supplied."
+    },
+    {
+      "id": "boole-limit-and-sharp-bound",
+      "title": "The Boole Limit and the Sharp Remainder Bound",
+      "startLine": 90,
+      "endLine": 140,
+      "mathContext": "$\\mathrm{altSum}\\,(\\Delta a)\\,0\\,m \\to a_0 - 2S$; $\\;|(a_0 - 2S) - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m| \\le a_m$.",
+      "summary": "fdiff_tendsto identifies a_0 − 2S as the true limit of the Boole series (fdiff_altSum_tendsto at n = 0), so the quantity bounded below is a genuine remainder. fdiff_remainder_bound is the headline: rewriting by the exact remainder identity and casing on the parity of m, the parent's brackets even_partial_le / le_odd_partial pin r_m to [0, a_m] (even) or [−a_m, 0] (odd); the identity then reads a_m − 2 r_m resp. −a_m − 2 r_m, both of absolute value ≤ a_m by abs_le and linarith. a_m ≥ 0 is derived from the bracket, so only Antitone a and convergence are needed."
+    },
+    {
+      "id": "rate-and-packaging",
+      "title": "Convergence Rate and Unconditional Packaging",
+      "startLine": 142,
+      "endLine": 174,
+      "mathContext": "$(a_0 - 2S) - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m \\to 0$ at rate $O(a_m)$; unconditional form for antitone null $a$.",
+      "summary": "fdiff_remainder_tendsto_zero derives the O(a_m) convergence of the Boole series from fdiff_tendsto (const minus a convergent sequence). fdiff_remainder_bound_of_antitone packages the whole story unconditionally for antitone null sequences: existence of the alternating sum S (altSum_tendsto_of_antitone), convergence of the forward-difference series to a_0 − 2S, and the sharp remainder bound at every m. Closing #check and #print axioms confirm the signatures and the dependence on only propext / Classical.choice / Quot.sound."
+    }
+  ],
+  "conclusion": {
+    "summary": "For an antitone null sequence a with alternating sum S, the first-order Boole (Euler) transform — the forward-difference alternating series altSum (Δa) 0 m, converging to T = a_0 − 2S — approaches its limit with the sharp remainder bound |T − altSum (Δa) 0 m| ≤ a_m, exactly matching the sharp bound of the original series. The proof is an exact remainder identity (Boole-series remainder = (-1)^m a_m − 2·original-series remainder, from solving the finite Boole formula) combined with the sign correlation the parent's even/odd bracketing supplies, which collapses the naive 3 a_m triangle estimate to the sharp a_m. Formalized sorry-free and axiom-free (propext / Classical.choice / Quot.sound only), with the O(a_m) convergence and an unconditional antitone packaging as corollaries.",
+    "implications": "This settles the parent's closing open question about the acceleration rate and corrects a natural misconception: at first order the Boole/Euler transform is error-preserving, not error-accelerating — the transformed series carries the same first-omitted-term guarantee, no smaller. It also isolates why the answer is not immediate: the forward-difference series is alternating but not necessarily antitone in magnitude, so its own remainder is not Leibniz-estimable, and the estimate must be transported from the original series. The exact remainder identity is the reusable object: it shows any control on the original-series remainder transfers verbatim (up to the explicit sign-cancellation constant) to the Boole-series remainder, the natural entry point for analyzing higher-order Boole transforms where genuine acceleration is expected to appear.",
+    "openQuestions": [
+      "Determine whether the sharp constant improves under a convexity hypothesis: if a is not merely antitone but convex (Δa itself antitone, so |Δa| is monotone), does the forward-difference series become Leibniz-estimable in its own right, giving |T − altSum (Δa) 0 m| ≤ |Δa_m| = a_m − a_{m+1} < a_m and hence genuine first-order acceleration?",
+      "Iterate the transform: define the second-order Boole series from the second forward difference Δ²a and prove the analogous exact remainder identity, quantifying whether the a_m bound strictly improves at second order (the regime where Euler acceleration is classically expected to help)."
+    ]
+  },
+  "crossReferences": [
+    "alternating-series-boole-summation-oq-01-oq-02",
+    "alternating-series-boole-summation-oq-01",
+    "alternating-series-boole-summation"
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes **alternating-series-boole-summation-oq-01-oq-02-oq-02**, answering the parent entry's closing open question on the Boole/Euler summation acceleration rate.

For an antitone null sequence `a` with alternating sum `S`, the forward-difference (first-order Boole) series `altSum (Δa) 0 m` (`Δaⱼ = aⱼ₊₁ − aⱼ`) converges to the Boole value `T = a₀ − 2S`. This entry proves the **sharp remainder bound**

```
|T − altSum (Δa) 0 m| ≤ aₘ
```

— *exactly* the sharp bound the original alternating series enjoys. The finding: at first order the Boole transform is **error-preserving, not error-accelerating**.

## The mathematics

- **Exact remainder identity** (`fdiff_remainder_eq`): solving the finite Boole formula gives `(a₀ − 2S) − altSum (Δa) 0 m = (−1)ᵐ aₘ − 2·(S − altSum a 0 m)`, pinning the Boole-series remainder to the original-series remainder `rₘ`.
- **Sign cancellation sharpens 3aₘ → aₘ**: the naive triangle inequality gives only `3aₘ`, but the parent's even/odd bracketing pins the *sign* of `rₘ` to the parity of `m` (`rₘ ∈ [0, aₘ]` even, `[−aₘ, 0]` odd), so `(−1)ᵐaₘ` and `−2rₘ` partially cancel.
- **Not directly Leibniz-estimable**: `Δa` is one-signed for antitone `a` but not monotone in magnitude, so the Boole series fails the alternating-series test's hypotheses — the bound must be routed through the original series' bracketing.

Also: `fdiff_remainder_tendsto_zero` (O(aₘ) convergence) and `fdiff_remainder_bound_of_antitone` (unconditional packaging). The sharp bound needs only antitonicity + convergence — `aₘ ≥ 0` is derived from the bracket, not assumed.

## Verification

- **6 theorems, 0 sorries, 0 axioms** — `#print axioms` confirms dependence only on `propext / Classical.choice / Quot.sound`.
- **Machine-checked**: Docker build succeeded (`3060 jobs`). Bypassed the corrupt Mathlib `.ltar` cache (`leantar failed`, `expected value at line 1 column 1`) via `LEAN_SKIP_CACHE=true` + SIGBUS retry.
- Gallery data (`meta.json`, `annotations.json`) mirrors the sibling `oq-01-oq-02` schema; `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)