### PR TITLE
Research(erdos-1000-oq-02): repair Mathlib v4.26 drift so the verified entry actually builds [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1000OQ02.lean
+++ b/proofs/Proofs/Erdos1000OQ02.lean
@@ -76,7 +76,7 @@ theorem cesaroAvg_ge_inv_N (A : IncreasingSeq) (N : ℕ) (hN : 0 < N) :
     1 / (N : ℝ) ≤ cesaroAvg A N := by
   have hNpos : (0 : ℝ) < N := by exact_mod_cast hN
   unfold cesaroAvg
-  rw [div_le_div_right₀ hNpos]
+  rw [div_le_div_iff_of_pos_right hNpos]
   exact sum_densityRatio_ge_one A N hN
 
 /-- Restatement of the floor as `1 ≤ N · C_A(N)`. -/
@@ -103,7 +103,7 @@ theorem cesaroAvg_ge_harmonic (A : IncreasingSeq) (N : ℕ) :
   unfold cesaroAvg
   rcases Nat.eq_zero_or_pos N with rfl | hN
   · simp
-  · rw [div_le_div_right₀ (by exact_mod_cast hN : (0 : ℝ) < N)]
+  · rw [div_le_div_iff_of_pos_right (by exact_mod_cast hN : (0 : ℝ) < N)]
     exact Finset.sum_le_sum fun k _ => densityRatio_ge_inv A k
 
 /-! ## Part III: The large-ratio frequency floor
@@ -138,7 +138,7 @@ theorem cesaroAvg_ge_largeCount (A : IncreasingSeq) (N : ℕ) (hN : 0 < N) :
   rw [show (((range N).filter (fun k => 1 / 2 ≤ densityRatio A k)).card : ℝ) / (2 * N)
         = ((1 / 2) * ((range N).filter (fun k => 1 / 2 ≤ densityRatio A k)).card) / N by
         ring]
-  rw [div_le_div_right₀ hNpos]
+  rw [div_le_div_iff_of_pos_right hNpos]
   exact hbase
 
 /-! ## Part IV: The prime-density floor
@@ -160,7 +160,7 @@ theorem cesaroAvg_ge_primeCount (A : IncreasingSeq) (N : ℕ) (hN : 0 < N) :
   have hcard : (((range N).filter (fun k => Nat.Prime (A.seq k))).card : ℝ)
       ≤ (((range N).filter (fun k => 1 / 2 ≤ densityRatio A k)).card : ℝ) := by
     exact_mod_cast Finset.card_le_card hsub
-  rw [div_le_div_right₀ (mul_pos (by norm_num : (0 : ℝ) < 2) hNpos)]
+  rw [div_le_div_iff_of_pos_right (mul_pos (by norm_num : (0 : ℝ) < 2) hNpos)]
   exact hcard
 
 /-! ## Part V: Capstone — no vanishing average for prime-dense sequences

--- a/proofs/Proofs/Erdos1000Problem.lean
+++ b/proofs/Proofs/Erdos1000Problem.lean
@@ -444,7 +444,7 @@ theorem usedSum_le (A : IncreasingSeq) (k : ℕ) :
 theorem phiA_pos (A : IncreasingSeq) (k : ℕ) :
     1 ≤ phiA A k := by
   have := phiA_ge_totient A k
-  have := Nat.totient_pos (A.pos k)
+  have := Nat.totient_pos.mpr (A.pos k)
   omega
 
 /-- ρ_A(k) > 0 for all k. -/
@@ -544,7 +544,9 @@ theorem not_density_zero_of_infinitely_many_primes (A : IncreasingSeq)
 theorem naturalSeq_not_density_zero : ¬ DensityToZero naturalSeq :=
   not_density_zero_of_infinitely_many_primes naturalSeq (fun k => by
     obtain ⟨p, hp_ge, hp_prime⟩ := Nat.exists_infinite_primes (k + 2)
-    exact ⟨p - 1, by omega, by simp [naturalSeq]; omega⟩)
+    exact ⟨p - 1, by omega, by
+      have hpp : p - 1 + 1 = p := by omega
+      simpa [naturalSeq, hpp] using hp_prime⟩)
 
 /- ## Part V-C: Complement and DensityToZero Infrastructure -/
 
@@ -585,7 +587,8 @@ theorem erdos_no_zero_limit (A : IncreasingSeq) : ¬ DensityToZero A := by
   intro hDZ
   -- ρ → 0 gives ρ < ε frequently (eventually implies frequently)
   have h_freq : ∀ ε > 0, ∃ᶠ k in atTop, densityRatio A k < ε :=
-    fun ε hε => (hDZ (Iio_mem_nhds hε)).frequently
+    fun ε hε =>
+      (show ∀ᶠ k in atTop, densityRatio A k < ε from hDZ (Iio_mem_nhds hε)).frequently
   -- Dichotomy: frequently near 0 ⟹ frequently near 1
   have h1 := erdos_dichotomy A h_freq (1/2) (by norm_num)
   -- But ρ → 0 gives eventually ρ < 1/2
@@ -613,7 +616,8 @@ axiom haight_resolution : ∃ A : IncreasingSeq, VanishingAverage A
 theorem cassels_liminf_zero :
     ∃ A : IncreasingSeq, ∀ ε > 0, ∃ᶠ N in atTop, cesaroAvg A N < ε := by
   obtain ⟨A, hA⟩ := haight_resolution
-  exact ⟨A, fun ε hε => (hA (Iio_mem_nhds hε)).frequently⟩
+  exact ⟨A, fun ε hε =>
+    (show ∀ᶠ N in atTop, cesaroAvg A N < ε from hA (Iio_mem_nhds hε)).frequently⟩
 
 /- ## Part IX: Corollaries -/
 
@@ -730,7 +734,7 @@ theorem usedSum_zero (A : IncreasingSeq) : usedSum A 0 = 0 := by
 theorem densityRatio_ge_inv (A : IncreasingSeq) (k : ℕ) :
     1 / (A.seq k : ℝ) ≤ densityRatio A k := by
   unfold densityRatio
-  rw [div_le_div_right₀ (Nat.cast_pos.mpr (A.pos k))]
+  rw [div_le_div_iff_of_pos_right (Nat.cast_pos.mpr (A.pos k))]
   exact_mod_cast phiA_pos A k
 
 /-- The Cesàro average is bounded below by the average totient ratio:
@@ -742,7 +746,7 @@ theorem cesaroAvg_ge_totient_avg (A : IncreasingSeq) (N : ℕ) :
   unfold cesaroAvg
   rcases Nat.eq_zero_or_pos N with rfl | hN
   · simp
-  · rw [div_le_div_right₀ (Nat.cast_pos.mpr hN)]
+  · rw [div_le_div_iff_of_pos_right (Nat.cast_pos.mpr hN)]
     exact Finset.sum_le_sum fun k _ => densityRatio_ge_totient_ratio A k
 
 /-- Any subset of unused divisors of n_k gives a lower bound on φ_A(k).
@@ -802,8 +806,9 @@ theorem phiA_ge_self_and_quotient (A : IncreasingSeq) (k : ℕ) (hk : 0 < k)
   -- Both are large (exceed n_{k-1})
   have h_nk_large : A.seq (k - 1) < A.seq k := A.strictMono (by omega)
   have h_div_large : A.seq (k - 1) < A.seq k / p := by
-    have := Nat.div_mul_cancel hp_dvd
-    omega
+    have hcancel := Nat.div_mul_cancel hp_dvd
+    have hmul : A.seq (k - 1) * p < A.seq k / p * p := by rw [hcancel]; exact hgap
+    exact lt_of_mul_lt_mul_right hmul (Nat.zero_le p)
   -- Both are unused
   have h_nk_unused := divisor_gt_prev_unused A k hk (A.seq k) (dvd_refl _) h_nk_large
   have h_div_unused := divisor_gt_prev_unused A k hk (A.seq k / p)
@@ -975,9 +980,9 @@ theorem divPairs_fiber_j_card_le (A : IncreasingSeq) (N j : ℕ) (hj : j < N)
         apply Finset.card_le_card_of_injOn (fun k => A.seq k / A.seq j)
         · -- Maps into Ico 1 (M+1)
           intro k hk
-          simp only [Finset.mem_filter, Finset.mem_range] at hk
+          simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_range] at hk
           obtain ⟨hkN, _, hdvd⟩ := hk
-          rw [Finset.mem_Ico]
+          simp only [Finset.mem_coe, Finset.mem_Ico]
           constructor
           · -- quotient ≥ 1 (from divisibility and positivity)
             exact Nat.div_pos (Nat.le_of_dvd (A.pos k) hdvd) (A.pos j)
@@ -1001,7 +1006,7 @@ theorem divPairs_fiber_j_card_le (A : IncreasingSeq) (N j : ℕ) (hj : j < N)
               _ = A.seq k₂ / A.seq j * A.seq j := congr_arg (· * A.seq j) heq
               _ = A.seq k₂ := h2
           exact A.strictMono.injective this
-    _ = M := by rw [Nat.card_Ico]; omega
+    _ = M := by rw [Nat.card_Ico, Nat.add_sub_cancel]
 
 /- ## Part XIII: Growth Constraints from Low Density -/
 


### PR DESCRIPTION
## Summary

The **erdos-1000-oq-02** gallery entry (universal lower bounds on the rate of convergence of the Cesàro average of Cassels' new-denominator density) and its parent `Erdos1000Problem` were merged in #34948 **while both verifiers were down**, so the `verified / 0-axiom / 0-sorry` claim in `meta.json` was never machine-checked. In fact the parent file did **not** compile under Mathlib v4.26 — meaning the entry was silently overclaiming.

This PR repairs **11 real API-drift errors** so the entry's `verified` status is now truthful. The full build `lake build Proofs.Erdos1000OQ02` (which transitively builds the parent) completes **7745 jobs, exit 0**.

## Drift fixes

**`Erdos1000Problem.lean` (parent):**
- `Nat.totient_pos` is now an `Iff` (`0 < φ n ↔ 0 < n`) → `.mpr`
- `div_le_div_right₀` → `div_le_div_iff_of_pos_right` (renamed, identical signature)
- `Filter.Tendsto` membership no longer resolves `.frequently` by field notation (the type now prints as `atTop.1 (f ⁻¹' Iio ε)`); added `show ∀ᶠ … from` type ascriptions so `Eventually.frequently` applies (2 sites)
- `Finset.card_le_card_of_injOn` now takes `Set.MapsTo`, so the maps-into hypothesis/goal are Set-coe memberships → added `Finset.mem_coe` to the `simp only` sets
- `phiA_ge_self_and_quotient`: `omega` cannot cancel the variable factor `p`; replaced with explicit `lt_of_mul_lt_mul_right` over the `Nat.div_mul_cancel` form
- `naturalSeq_not_density_zero`: prove `Nat.Prime (p-1+1)` via `p-1+1 = p` + `simpa using hp_prime`, not `omega` on a primality goal
- `Nat.card_Ico, Nat.add_sub_cancel` instead of `Nat.card_Ico; omega`

**`Erdos1000OQ02.lean`:** `div_le_div_right₀` → `div_le_div_iff_of_pos_right` (4 sites).

## Verification

- `#print axioms` on `cesaroAvg_ge_inv_N`, `cesaroAvg_ge_primeCount`, and the capstone `not_vanishingAverage_of_frequently_prime_dense` reports **only** `propext`, `Classical.choice`, `Quot.sound` → genuinely 0-axiom (the parent's 2 axioms `erdos_dichotomy`/`haight_resolution` are not used by any OQ-02 theorem).
- No `meta.json` change needed — it already declares `verified / 0-axiom / 0-sorry`; this PR makes that claim machine-checked for the first time.

## Note (infra)
The multi-day "Docker/mathlib cache dead" blocker that prevented earlier verification was diagnosed as corrupt `.trace` files in the `lean-mathlib-packages` docker volume (leantar fails to decompress into corrupt destinations, `cache get && lake build` then never runs `lake build`). Wiping `.lake/packages/mathlib/.lake/build` before `lake exe cache get` restores a clean cache — this is how the build above was obtained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)