### PR TITLE
research(erdos-153-oq-03): canonical translation form + downward affine inverses [verified]

### DIFF
--- a/proofs/Proofs/Erdos153OQ03.lean
+++ b/proofs/Proofs/Erdos153OQ03.lean
@@ -43,6 +43,9 @@ constrained* as the Sidon (h = 2) case, because every B_h set is Sidon.
 - `card_finset_sym_eq_choose`: the stars-and-bars bridge |A.sym h| = C(|A|+h−1, h)
 - `card_hSumset_eq_choose_of_isBhSet` : saturation in closed binomial form
 - `choose_le_of_isBhSet`     : the B_h density bound C(|A|+h−1, h) ≤ hN+1 in closed form
+- `isBhSet_sub`            : translation invariance (downward) — A−m is B_h (m ≤ A)
+- `isBhSet_div`            : dilation invariance (downward) — A/c is B_h (c ∣ A, c ≥ 1)
+- `isBhSet_translate_min_zero` : canonical form — every B_h set is a translate of a min-0 B_h set
 -/
 import Mathlib
 
@@ -641,5 +644,152 @@ theorem card_pow_le_of_isBhSet {h N : ℕ} {A : Finset ℕ}
     _ = h.factorial * (A.card + h - 1).choose h :=
         Nat.descFactorial_eq_factorial_mul_choose _ _
     _ ≤ h.factorial * (h * N + 1) := Nat.mul_le_mul (le_refl _) hbound
+
+/-!
+## Section X: Inverse affine maps and the canonical translation form
+
+Section V established that `B_h`-ness is preserved by every order-preserving
+affine map `a ↦ c·a + t` (`isBhSet_affine`), built from dilation-up
+(`isBhSet_smul`) and translation-up (`isBhSet_add`).  To turn "affine geometry
+determines `B_h`-ness" into a genuine *reduction* — every `B_h` set is
+affine-equivalent to a canonical representative — we need the inverse maps as
+well: translation *down* (`isBhSet_sub`, valid once we translate by no more than
+the minimum) and dilation *down* (`isBhSet_div`, valid when the common factor
+divides every element).  These are the exact converses of the Section V maps and
+are proved by the same lift-back template: pull each competing multiset back
+through the inverse map into `A`, where `A`'s `B_h` property forces equality,
+then push the equality forward again.
+
+The payoff is `isBhSet_translate_min_zero`: every nonempty `B_h` set `A` is the
+upward translate `B + min A` of a `B_h` set `B` with minimum `0`.  Position is
+thus inessential — the study of `B_h` sets reduces to those anchored at `0`.
+-/
+
+/-- **Translation invariance (downward).**  The converse of `isBhSet_add`: if
+`A` is a `B_h` set and `m` is at most every element of `A`, then the
+down-translate `A − m = {a − m : a ∈ A}` (here `A.image (· - m)`) is again a
+`B_h` set.  The hypothesis `m ≤ a` makes truncated `ℕ`-subtraction behave like
+genuine subtraction, so lifting back by `· + m` recovers `A` exactly; the shift
+`h·m` cancels between two size-`h` sums, and the `B_h` property of `A` closes the
+gap.  Applying it with `m = min A` down-translates any set to one containing `0`. -/
+theorem isBhSet_sub {h m : ℕ} {A : Finset ℕ} (hm : ∀ a ∈ A, m ≤ a)
+    (H : IsBhSet h A) : IsBhSet h (A.image (fun a => a - m)) := by
+  -- lifting back by `· + m` shifts the sum up by `card · m`
+  have hshift : ∀ s : Multiset ℕ,
+      (s.map (fun x => x + m)).sum = s.sum + Multiset.card s * m := by
+    intro s
+    refine Multiset.induction_on s ?_ ?_
+    · simp
+    · intro a s ih
+      simp only [Multiset.map_cons, Multiset.sum_cons, Multiset.card_cons, ih,
+        Nat.add_mul, Nat.one_mul]
+      ring
+  -- `· + m` inverts `· - m` on the down-translated set, landing back in `A`
+  have hinv : ∀ s : Multiset ℕ, (∀ x ∈ s, x ∈ A.image (fun a => a - m)) →
+      (s.map (fun x => x + m)).map (fun x => x - m) = s ∧
+      (∀ y ∈ s.map (fun x => x + m), y ∈ A) := by
+    intro s hs
+    refine ⟨?_, ?_⟩
+    · rw [Multiset.map_map]
+      conv_rhs => rw [← Multiset.map_id' s]
+      apply Multiset.map_congr rfl
+      intro x _
+      show x + m - m = x
+      omega
+    · intro y hy
+      obtain ⟨x, hx, rfl⟩ := Multiset.mem_map.mp hy
+      obtain ⟨a, ha, rfl⟩ := Finset.mem_image.mp (hs x hx)
+      have : a - m + m = a := by have := hm a ha; omega
+      rw [this]; exact ha
+  intro s t hs ht hcs hct hsum
+  obtain ⟨hs_rec, hsA⟩ := hinv s hs
+  obtain ⟨ht_rec, htA⟩ := hinv t ht
+  set s₀ : Multiset ℕ := s.map (fun x => x + m) with hs₀
+  set t₀ : Multiset ℕ := t.map (fun x => x + m) with ht₀
+  have hcs₀ : Multiset.card s₀ = h := by rw [hs₀, Multiset.card_map]; exact hcs
+  have hct₀ : Multiset.card t₀ = h := by rw [ht₀, Multiset.card_map]; exact hct
+  have hsum₀ : s₀.sum = t₀.sum := by
+    have es : s₀.sum = s.sum + Multiset.card s * m := by rw [hs₀]; exact hshift s
+    have et : t₀.sum = t.sum + Multiset.card t * m := by rw [ht₀]; exact hshift t
+    rw [hcs] at es; rw [hct] at et; omega
+  have h0 : s₀ = t₀ := H s₀ t₀ hsA htA hcs₀ hct₀ hsum₀
+  calc s = s₀.map (fun x => x - m) := hs_rec.symm
+    _ = t₀.map (fun x => x - m) := by rw [h0]
+    _ = t := ht_rec
+
+/-- **Dilation invariance (downward).**  The converse of `isBhSet_smul`: if `A`
+is a `B_h` set, `c ≥ 1`, and `c` divides every element of `A`, then the
+contracted set `A / c = {a / c : a ∈ A}` (here `A.image (· / c)`) is again a
+`B_h` set.  Divisibility makes `ℕ`-division exact, so lifting back by `· * c`
+recovers `A`; the common factor `c` cancels from an equality of size-`h` sums,
+and `A`'s `B_h` property closes the gap.  Together with `isBhSet_sub` this lets a
+`B_h` set be contracted by the gcd of its differences. -/
+theorem isBhSet_div {h c : ℕ} {A : Finset ℕ} (hc : 0 < c) (hdvd : ∀ a ∈ A, c ∣ a)
+    (H : IsBhSet h A) : IsBhSet h (A.image (fun a => a / c)) := by
+  -- lifting back by `· * c` scales the sum by `c`
+  have hscale : ∀ s : Multiset ℕ, (s.map (fun x => x * c)).sum = s.sum * c := by
+    intro s
+    refine Multiset.induction_on s ?_ ?_
+    · simp
+    · intro a s ih
+      simp only [Multiset.map_cons, Multiset.sum_cons, ih, Nat.add_mul]
+  -- `· * c` inverts `· / c` on the contracted set, landing back in `A`
+  have hinv : ∀ s : Multiset ℕ, (∀ x ∈ s, x ∈ A.image (fun a => a / c)) →
+      (s.map (fun x => x * c)).map (fun x => x / c) = s ∧
+      (∀ y ∈ s.map (fun x => x * c), y ∈ A) := by
+    intro s hs
+    refine ⟨?_, ?_⟩
+    · rw [Multiset.map_map]
+      conv_rhs => rw [← Multiset.map_id' s]
+      apply Multiset.map_congr rfl
+      intro x _
+      show x * c / c = x
+      rw [Nat.mul_comm x c, Nat.mul_div_cancel_left x hc]
+    · intro y hy
+      obtain ⟨x, hx, rfl⟩ := Multiset.mem_map.mp hy
+      obtain ⟨a, ha, rfl⟩ := Finset.mem_image.mp (hs x hx)
+      have : a / c * c = a := Nat.div_mul_cancel (hdvd a ha)
+      rw [this]; exact ha
+  intro s t hs ht hcs hct hsum
+  obtain ⟨hs_rec, hsA⟩ := hinv s hs
+  obtain ⟨ht_rec, htA⟩ := hinv t ht
+  set s₀ : Multiset ℕ := s.map (fun x => x * c) with hs₀
+  set t₀ : Multiset ℕ := t.map (fun x => x * c) with ht₀
+  have hcs₀ : Multiset.card s₀ = h := by rw [hs₀, Multiset.card_map]; exact hcs
+  have hct₀ : Multiset.card t₀ = h := by rw [ht₀, Multiset.card_map]; exact hct
+  have hsum₀ : s₀.sum = t₀.sum := by
+    rw [hs₀, ht₀, hscale, hscale, hsum]
+  have h0 : s₀ = t₀ := H s₀ t₀ hsA htA hcs₀ hct₀ hsum₀
+  calc s = s₀.map (fun x => x / c) := hs_rec.symm
+    _ = t₀.map (fun x => x / c) := by rw [h0]
+    _ = t := ht_rec
+
+/-- **Canonical translation form.**  Every nonempty `B_h` set `A` is the upward
+translate `B + m` (with `m = min A`) of a `B_h` set `B := {a − m : a ∈ A}` whose
+minimum is `0` — witnessed here by `0 ∈ B`.  Hence, up to the affine map
+`b ↦ b + min A`, every `B_h` set is one anchored at the origin: absolute
+position carries no `B_h` information.  The translation analogue of the
+normal-form reduction, obtained from `isBhSet_sub` at `m = min A`. -/
+theorem isBhSet_translate_min_zero {h : ℕ} {A : Finset ℕ} (hA : A.Nonempty)
+    (H : IsBhSet h A) :
+    IsBhSet h (A.image (fun a => a - A.min' hA)) ∧
+    (0 : ℕ) ∈ A.image (fun a => a - A.min' hA) ∧
+    A = (A.image (fun a => a - A.min' hA)).image (fun b => b + A.min' hA) := by
+  set m := A.min' hA with hm
+  have hmle : ∀ a ∈ A, m ≤ a := fun a ha => Finset.min'_le A a ha
+  refine ⟨isBhSet_sub hmle H, ?_, ?_⟩
+  · -- `0 = m − m` lies in the down-translate since `m = min A ∈ A`
+    rw [Finset.mem_image]
+    exact ⟨m, A.min'_mem hA, by omega⟩
+  · -- re-adding `m` recovers `A` exactly, since `m ≤ a` for every `a ∈ A`
+    symm
+    ext x
+    simp only [Finset.image_image, Finset.mem_image, Function.comp]
+    constructor
+    · rintro ⟨a, ha, rfl⟩
+      have := hmle a ha
+      rwa [Nat.sub_add_cancel this]
+    · intro hx
+      exact ⟨x, hx, Nat.sub_add_cancel (hmle x hx)⟩
 
 end Erdos153OQ03

--- a/src/data/research/problems/erdos-153-oq-03.json
+++ b/src/data/research/problems/erdos-153-oq-03.json
@@ -19,19 +19,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-04",
-    "iteration": 4,
-    "focus": "Explicit stars-and-bars bridge CLOSED and NOW BUILD-VERIFIED: card_finset_sym_eq_choose proves (A.sym h).card = C(|A|+h-1, h) by exhibiting A.sym h as the injective image of univ : Finset (Sym ↥A h) under Sym.map Subtype.val (injective via Subtype.val_injective; onto via Sym.attach + Sym.attach_map_coe), then transporting Sym.card_sym_eq_choose across it and using Fintype.card_coe. This removes the honest-quantity caveat from Sections VII-VIII: added closed-form corollaries card_hSumset_eq_choose_of_isBhSet (saturation) and choose_le_of_isBhSet (density bound C(|A|+h-1,h) ≤ hN+1). 0 sorry, 0 axiom. VERIFIED 2026-07-04: `lake build Proofs.Erdos153OQ03` completed successfully (7743 jobs) after repairing Docker (containerd content-store corruption cleared by a Docker Desktop restart; built in fresh private cache volumes to bypass the leantar-corrupt shared volumes). `#print axioms` on the five headline theorems reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no ofReduceBool. Only 4 cosmetic linter warnings (unreachable `exact Multiset.cons_swap` fallback branches in a defensive `first | rfl | ...` at lines 225/232).",
+    "since": "2026-07-05",
+    "iteration": 5,
+    "focus": "Canonical-form reduction ADDED and BUILD-VERIFIED (Section X). Added the two inverse affine maps that were missing companions to Section V: isBhSet_sub (translation DOWN — A.image(·-m) is B_h whenever m ≤ every element, proved by lifting back through ·+m so the h·m shift cancels) and isBhSet_div (dilation DOWN — A.image(·/c) is B_h when c ≥ 1 divides every element, via lift-back through ·*c). Capstone isBhSet_translate_min_zero: every nonempty B_h set A equals (A.image(·-min A)).image(·+min A) where the down-translate is B_h and contains 0 — i.e. every B_h set is an affine translate of a min-0 normalized B_h set, so absolute position carries no B_h information. 0 sorry, 0 axiom. VERIFIED 2026-07-05: docker-build.sh Proofs.Erdos153OQ03 succeeded (7743 jobs); #print axioms on isBhSet_sub/isBhSet_div/isBhSet_translate_min_zero reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no ofReduceBool. Only the 4 pre-existing cosmetic linter warnings at lines 225/232 remain.",
     "blockers": [],
-    "nextAction": "Build confirmed. Attempt the actual gap-variance statement via the Sidon (isSidon_of_isBhSet) reduction + the now-closed-form density bound choose_le_of_isBhSet — the genuinely open frontier. (Optional cleanup: silence the two unreachable-tactic warnings by replacing the redundant `first | rfl | exact Multiset.cons_swap _ _ _` with plain `rfl` at lines 225/232.)",
+    "nextAction": "Complete the canonical form: add the gcd normalization (dilate A by 1/gcd of its differences via isBhSet_div to reach gcd 1), giving the full affine-normal representative (min 0, gcd 1) for A.card ≥ 2. Then the genuinely OPEN frontier: the gap-variance statement for B_h (h ≥ 3) via the Sidon reduction + density bound — unsolved, needs a new idea, not more infrastructure.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 2,
-      "approachesTried": 1
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: affine invariance + sharp counting identity + density bound + now the SATURATION CHARACTERIZATION (isBhSet_iff_card_hSumset: B_h ⟺ (hΣA).card=(A.sym h).card) all machine-verified (Erdos153OQ03.lean, 19 thm + 3 def, 0 sorry/0 axiom/0 native_decide). Explicit-binomial bridge blocked by missing Finset.card_sym (needs hand-built equiv, deferred). Gap-variance conjecture itself remains OPEN.",
+    "progressSummary": "PROGRESS: canonical translation form + downward affine inverses added and build-verified (Section X, 0-axiom); B_h invariance toolkit now complete both directions. Gap-variance conjecture (h≥3) still OPEN.",
     "builtItems": [
       "IsBhSet def (Erdos153OQ03.lean)",
       "isBhSet_one: every set is B₁",
@@ -46,7 +46,10 @@
       "isBhSet_affine: affine invariance — {c·a+t} is B_h whenever A is (c≥1), composing dilation+translation (Erdos153OQ03.lean, Section V)",
       "hSumset_subset_range: B_h set A⊆range(N+1) ⟹ hSumset h A ⊆ range(hN+1) (each h-fold sum ≤ hN via Multiset.sum_le_card_nsmul) (Erdos153OQ03.lean §VII)",
       "card_sym_le_of_isBhSet: DENSITY BOUND — IsBhSet h A, A⊆{0..N} ⟹ (A.sym h).card ≤ hN+1 = C(|A|+h-1,h)≤hN+1 ⟹ |A|=O(N^{1/h}) (Erdos153OQ03.lean §VII, 0 sorry/axiom, VERIFIED)",
-      "isBhSet_iff_card_hSumset: SATURATION CHARACTERIZATION — IsBhSet h A ↔ (hSumset h A).card = (A.sym h).card (Erdos153OQ03.lean §VIII, 0 sorry/axiom, VERIFIED). Converse of card_hSumset_of_isBhSet via Finset.injOn_of_card_image_eq; B_h sets are EXACTLY those whose h-fold sumset saturates the pigeonhole max."
+      "isBhSet_iff_card_hSumset: SATURATION CHARACTERIZATION — IsBhSet h A ↔ (hSumset h A).card = (A.sym h).card (Erdos153OQ03.lean §VIII, 0 sorry/axiom, VERIFIED). Converse of card_hSumset_of_isBhSet via Finset.injOn_of_card_image_eq; B_h sets are EXACTLY those whose h-fold sumset saturates the pigeonhole max.",
+      "isBhSet_sub in Erdos153OQ03.lean:~700 — translation-down invariance A.image(·-m) is B_h for m ≤ A (converse of isBhSet_add), 0-axiom",
+      "isBhSet_div in Erdos153OQ03.lean:~740 — dilation-down invariance A.image(·/c) is B_h for c≥1, c∣A (converse of isBhSet_smul), 0-axiom",
+      "isBhSet_translate_min_zero in Erdos153OQ03.lean:~775 — canonical translation form: nonempty B_h A = (A.image(·-min A)).image(·+min A), down-translate is B_h and contains 0, 0-axiom"
     ],
     "insights": [
       "A B_h set (h-fold sums distinct) is cleanly encoded as: Multiset.sum injective on size-h multisets drawn from A. Avoids ordered-tuple/reindexing friction.",
@@ -56,17 +59,20 @@
       "The B_h class is closed under every order-preserving affine map a↦c·a+t: sum is ℕ-linear, so h-fold sums scale by c and shift by the constant h·t, both cancellable — completing the affine-structure claim in Section V (dilation was already there; translation was the missing companion).",
       "DENSITY BOUND executed: the sharp counting identity card_hSumset=(A.sym h).card + the trivial containment hSumset⊆{0..hN} gives (A.sym h).card ≤ hN+1 in ~15 lines. Mathlib GAP: only Fintype-form stars-and-bars (Sym.card_sym_eq_choose) exists; the Finset-form (A.sym h).card = C(|A|+h-1,h) is missing, so the bound is stated with the honest quantity (A.sym h).card (which IS that coefficient).",
       "Finset-form stars-and-bars (A.sym h).card = C(|A|+h-1,h) is NOT one lemma in Mathlib v4.26.0: Finset.card_sym is Unknown constant; only Sym.card_sym_eq_choose (Fintype form) exists. Bridging needs a hand-built equiv ↥(A.sym h) ≃ Sym ↥A h. Deferred; density bound kept honest via (A.sym h).card.",
-      "B_h ⟺ h-fold-sumset saturation is now a full iff (isBhSet_iff_card_hSumset): forward = Finset.card_image_of_injOn, backward = Finset.injOn_of_card_image_eq. Parallels the h=2 Sidon 'maximal sumset' characterization."
+      "B_h ⟺ h-fold-sumset saturation is now a full iff (isBhSet_iff_card_hSumset): forward = Finset.card_image_of_injOn, backward = Finset.injOn_of_card_image_eq. Parallels the h=2 Sidon 'maximal sumset' characterization.",
+      "Section V only supplied the UPWARD affine maps (isBhSet_smul, isBhSet_add); the downward inverses are needed to turn affine-invariance into a canonical-form REDUCTION. Both inverses follow the same lift-back template as the forward maps.",
+      "Translation-down needs m ≤ every element (m = min A) so that truncated ℕ-subtraction is exact and ·+m recovers A; dilation-down needs c ∣ every element so ℕ-division is exact and ·*c recovers A.",
+      "Canonical form: every nonempty B_h set is the affine translate B + min A of a min-0 B_h set B — position is inessential to B_h-ness (the geometric refinement of affine invariance from a symmetry into a normal-form theorem)."
     ],
     "mathlibGaps": [
       "No dedicated B_h / Sidon-of-order-h API in Mathlib; multiset-sum-injectivity encoding is self-sufficient.",
       "Finset-form stars-and-bars: (A.sym h).card = C(|A|+h-1,h) not in Mathlib (only Fintype form Sym.card_sym_eq_choose). Needs an equiv ↥(A.sym h) ≃ Sym ↥A h."
     ],
     "nextSteps": [
-      "Prove the h-fold sumset cardinality analog of sidon_sumset_card: a B_h set of size n has exactly C(n+h-1,h) distinct h-fold sums (multiset count).",
-      "Transfer sidon_density_bound to B_h: |A|=n B_h in {0..N} forces C(n+h-1,h) ≤ hN+1, giving |A| = O(N^{1/h}).",
       "Attempt the actual gap-variance statement for B_h using the Sidon reduction + density bound.",
-      "Consider a converse-flavored structural fact: B_h is NOT preserved by general injections (only affine maps), or the normalization corollary (every B_h set is affine-equiv to one with min 0 and gcd of differences 1)."
+      "Consider a converse-flavored structural fact: B_h is NOT preserved by general injections (only affine maps), or the normalization corollary (every B_h set is affine-equiv to one with min 0 and gcd of differences 1).",
+      "Add the gcd normalization via isBhSet_div: for A.card ≥ 2, contract by gcd of differences to reach a gcd-1 min-0 representative — completing the full affine-normal form.",
+      "The genuinely OPEN gap-variance statement for B_h (h ≥ 3) — needs a new idea beyond the now-complete invariance/density infrastructure."
     ]
   },
   "tags": [
@@ -95,8 +101,8 @@
     {
       "path": "Proofs/Erdos153OQ03.lean",
       "filename": "Erdos153OQ03.lean",
-      "lineCount": 616,
-      "theoremCount": 22,
+      "lineCount": 795,
+      "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Section X of `Erdos153OQ03.lean`: the two **inverse affine maps** that were missing companions to the Section V invariance lemmas, plus the **canonical-form reduction** they enable.

Section V established that `B_h`-ness is preserved by every order-preserving affine map `a ↦ c·a + t` (`isBhSet_smul` up-dilation, `isBhSet_add` up-translation). To turn *"affine geometry determines `B_h`-ness"* from a symmetry into a genuine **normal-form reduction**, we need the inverse maps:

- **`isBhSet_sub`** — translation DOWN: `A.image (· - m)` is `B_h` whenever `m ≤` every element of `A`. Truncated ℕ-subtraction is exact under `m ≤ a`, so lifting back through `· + m` recovers `A`; the constant shift `h·m` cancels between two size-`h` sums.
- **`isBhSet_div`** — dilation DOWN: `A.image (· / c)` is `B_h` when `c ≥ 1` divides every element of `A`. Divisibility makes ℕ-division exact; lift back through `· * c`.
- **`isBhSet_translate_min_zero`** — canonical form: every nonempty `B_h` set `A` equals `(A.image (· - min A)).image (· + min A)`, where the down-translate is `B_h` and contains `0`. **Every `B_h` set is an affine translate of a min-0 normalized `B_h` set** — absolute position carries no `B_h` information.

This is nextStep #4 (converse-flavored structural / normalization corollary) and reduces the study of `B_h` sets to those anchored at the origin.

## Verification

- **0 sorry, 0 axiom.**
- Build-verified via `./proofs/scripts/docker-build.sh Proofs.Erdos153OQ03` — succeeded (7743 jobs).
- `#print axioms` on `isBhSet_sub`, `isBhSet_div`, `isBhSet_translate_min_zero` reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.
- Only the 4 pre-existing cosmetic linter warnings (lines 225/232) remain; no new warnings.

## Files

- `proofs/Proofs/Erdos153OQ03.lean`: +150 lines (Section X, 3 theorems + header entries).
- `src/data/research/problems/erdos-153-oq-03.json`: leanFile stats resynced (616/22 → 795/26 — were stale), currentState + knowledge updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)