### PR TITLE
research(factorial-telescoping-sum-oq-02): ∑ k/(k+1)! = 1 − 1/(n+1)! [VERIFIED, 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/FactorialTelescopingSumOQ02.lean
+++ b/proofs/Proofs/FactorialTelescopingSumOQ02.lean
@@ -1,0 +1,89 @@
+/-
+  Finite Factorial Telescoping (fractional form):
+      ∑_{k=1}^{n} k / (k+1)!  =  1 − 1/(n+1)!
+
+  Source / context: the finite closed form underlying the convergent series
+      ∑_{k=1}^{∞} k/(k+1)! = 1.
+  Sibling of `FactorialTelescopingSumOQ01` (∑ k·k! = (n+1)! − 1); this is the
+  reciprocal (division) counterpart, worked over ℚ.
+  Status: VERIFIED (0 sorries, 0 axioms, no native_decide).
+
+  Statement:
+    For every natural number n,
+        ∑_{k=1}^{n} (k : ℚ)/(k+1)!  =  1 − 1/(n+1)!.
+
+  The Key Insight (telescoping):
+    Each summand is an exact factorial-reciprocal difference,
+        k/(k+1)!  =  1/k! − 1/(k+1)!,
+    since  1/k! − 1/(k+1)! = ((k+1) − 1)/(k+1)! = k/(k+1)!  (using (k+1)! = (k+1)·k!).
+    Hence the sum telescopes:
+        ∑_{k=1}^{n} k/(k+1)! = ∑_{k=1}^{n} (1/k! − 1/(k+1)!) = 1/1! − 1/(n+1)! = 1 − 1/(n+1)!.
+
+  Lean strategy:
+    Work over ℚ so that division is genuine (no ℕ truncation).  The engine is a
+    one-line induction on the `range (n+1)` form; the `k = 0` term is `0/1! = 0`,
+    so it agrees with the literal `∑_{k=1}^{n}` over `Finset.Icc 1 n`.  The pointwise
+    step is discharged by `field_simp`/`ring` after rewriting `(k+1)! = (k+1)·k!`.
+-/
+
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Tactic
+
+open Finset Nat
+
+namespace FactorialTelescopingSumFractional
+
+/-- **Pointwise telescoping identity.**  `k/(k+1)! = 1/k! − 1/(k+1)!` over ℚ.
+
+    This is the genuine content: `1/k! − 1/(k+1)! = ((k+1) − 1)/(k+1)! = k/(k+1)!`,
+    using `(k+1)! = (k+1)·k!`. -/
+theorem term_telescope (k : ℕ) :
+    (k : ℚ) / (k + 1)! = 1 / (k ! : ℚ) - 1 / ((k + 1)! : ℚ) := by
+  have hk : (k ! : ℚ) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero k
+  have hk1' : (k : ℚ) + 1 ≠ 0 := by positivity
+  -- `(k+1)! = (k+1)·k!`, cast to ℚ, so both reciprocals share the common denominator.
+  have hrec : ((k + 1)! : ℚ) = ((k : ℚ) + 1) * k ! := by
+    rw [Nat.factorial_succ]; push_cast; ring
+  rw [hrec]
+  field_simp
+  ring
+
+/-- **Range form.**  `∑_{k=0}^{n} k/(k+1)! = 1 − 1/(n+1)!` over ℚ.
+
+    Proved directly by induction using the telescoping step
+    `(n+1)/(n+2)! + 1/(n+2)! = 1/(n+1)!` (equivalently `(n+2)/(n+2)! = 1/(n+1)!`). -/
+theorem sum_range_div_factorial (n : ℕ) :
+    ∑ k ∈ range (n + 1), (k : ℚ) / (k + 1)! = 1 - 1 / (n + 1)! := by
+  induction n with
+  | zero => norm_num [Finset.sum_range_one]
+  | succ n ih =>
+      -- Peel off the top summand `(n+1)/(n+2)!`, rewrite it via the pointwise
+      -- telescoping identity, and let `ring` cancel the interior `1/(n+1)!` terms.
+      rw [Finset.sum_range_succ, ih, term_telescope (n + 1)]
+      ring
+
+/-- The `range (n+1)` sum equals the literal `∑_{k=1}^{n}` over `Finset.Icc 1 n`:
+    the only extra index is `k = 0`, whose summand `0/1! = 0` vanishes. -/
+theorem sum_Icc_eq_sum_range (n : ℕ) :
+    ∑ k ∈ Finset.Icc 1 n, (k : ℚ) / (k + 1)! = ∑ k ∈ range (n + 1), (k : ℚ) / (k + 1)! := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Finset.sum_Icc_succ_top (by omega : 1 ≤ n + 1), Finset.sum_range_succ, ih]
+
+/-- **Headline identity.**  `∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)!`,
+    stated over `Finset.Icc 1 n` to match the usual lower limit `k = 1`. -/
+theorem sum_Icc_div_factorial (n : ℕ) :
+    ∑ k ∈ Finset.Icc 1 n, (k : ℚ) / (k + 1)! = 1 - 1 / (n + 1)! := by
+  rw [sum_Icc_eq_sum_range, sum_range_div_factorial]
+
+-- Sanity checks (small concrete values), derived from the closed form.
+-- n = 3:  1/2 + 2/6 + 3/24 = 23/24 = 1 − 1/4!.
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 3, (k : ℚ) / (k + 1)! = 23 / 24 := by
+  rw [sum_Icc_div_factorial]; norm_num
+-- n = 4:  add 4/120 = 1/30 → 119/120 = 1 − 1/5!.
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 4, (k : ℚ) / (k + 1)! = 119 / 120 := by
+  rw [sum_Icc_div_factorial]; norm_num
+
+end FactorialTelescopingSumFractional

--- a/src/data/proofs/factorial-telescoping-sum-oq-02/meta.json
+++ b/src/data/proofs/factorial-telescoping-sum-oq-02/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "factorial-telescoping-sum-oq-02",
+  "slug": "factorial-telescoping-sum-oq-02",
+  "title": "Finite Factorial Telescoping: ∑ k/(k+1)! = 1 − 1/(n+1)!",
+  "status": "verified",
+  "badge": "original",
+  "description": "The fractional factorial telescoping identity ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)!, formalized in Lean 4 over ℚ. This is the reciprocal counterpart of the sibling entry ∑ k·k! = (n+1)! − 1: each summand is an exact difference of factorial reciprocals, k/(k+1)! = 1/k! − 1/(k+1)! (since (k+1)! = (k+1)·k!), so the sum telescopes to 1/1! − 1/(n+1)! = 1 − 1/(n+1)!. Working over ℚ makes the division genuine (no ℕ truncation); the engine is a one-line induction whose step just rewrites the top summand by the pointwise identity and lets ring cancel the interior terms. The finite identity is the partial-sum form of the classical series ∑_{k=1}^{∞} k/(k+1)! = 1. Fully verified: 4 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "The identity ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)! is the fractional, reciprocal analogue of the integer factorial telescoping ∑_{k=1}^{n} k·k! = (n+1)! − 1: dividing the per-term collapse k·k! = (k+1)! − k! by k!·(k+1)! turns it into the reciprocal difference k/(k+1)! = 1/k! − 1/(k+1)!. Summing this telescopes to the single boundary term 1/1! − 1/(n+1)!. Letting n → ∞ recovers the classical evaluation ∑_{k=1}^{∞} k/(k+1)! = 1, a standard exercise in convergent factorial series; the finite closed form here also exhibits the exact truncation error 1/(n+1)! of that limit.",
+    "problemStatement": "Prove, for every natural number n, that ∑_{k=1}^{n} (k)/(k+1)! = 1 − 1/(n+1)!, working over ℚ so that division is honest, and provide both the standard Finset.range form and the literal ∑_{k=1}^{n} form over Finset.Icc 1 n.",
+    "proofStrategy": "Work over ℚ. First establish the pointwise telescoping identity term_telescope: k/(k+1)! = 1/k! − 1/(k+1)!, by rewriting (k+1)! = (k+1)·k! (Nat.factorial_succ, cast to ℚ) to expose the common denominator and closing with field_simp/ring (using k! ≠ 0 and k+1 ≠ 0). The range form ∑_{k=0}^{n} k/(k+1)! = 1 − 1/(n+1)! is then a one-line induction: Finset.sum_range_succ peels the top summand (n+1)/(n+2)!, term_telescope (n+1) rewrites it to 1/(n+1)! − 1/(n+2)!, and ring cancels the interior 1/(n+1)! against the inductive hypothesis. A separate induction (sum_Icc_eq_sum_range) shows the Finset.Icc 1 n sum equals the range (n+1) sum — the only extra index k = 0 contributes 0/1! = 0 — giving the literal ∑_{k=1}^{n} headline form.",
+    "keyInsights": [
+      "The summand is an exact reciprocal difference: k/(k+1)! = 1/k! − 1/(k+1)!, because (k+1)! = (k+1)·k! gives ((k+1) − 1)/(k+1)! = k/(k+1)!.",
+      "Working over ℚ (not ℕ) makes the division genuine, so the whole identity — including the 1/(n+1)! error term — is stated and proved without truncated subtraction.",
+      "Once the pointwise identity is a lemma, the induction step needs no factorial arithmetic: rewrite the top term by term_telescope and ring cancels the telescoping interior, so the step is a single ring call over three opaque atoms.",
+      "The lower limit k = 1 is cosmetic: the k = 0 term 0/1! vanishes, so the Finset.range (n+1) sum and the Finset.Icc 1 n sum coincide.",
+      "The finite form is the partial sum of ∑_{k=1}^{∞} k/(k+1)! = 1; the closed form exhibits the exact truncation tail 1/(n+1)!."
+    ],
+    "prerequisites": [
+      "The factorial Nat.factorial and its recurrence (n+1)! = (n+1)·n!, cast into ℚ",
+      "Finite sums over Finset.range and Finset.Icc, with sum_range_succ and sum_Icc_succ_top",
+      "Field arithmetic in ℚ via field_simp and ring, and factorial-nonzero facts Nat.factorial_ne_zero"
+    ]
+  },
+  "sections": [
+    {
+      "id": "pointwise",
+      "title": "Section I: The Pointwise Telescoping Identity",
+      "startLine": 41,
+      "endLine": 50,
+      "summary": "term_telescope: k/(k+1)! = 1/k! − 1/(k+1)! over ℚ — the exact reciprocal difference that makes the sum telescope.",
+      "mathContext": "Rewrite (k+1)! = (k+1)·k! (Nat.factorial_succ, push_cast) to expose the shared denominator, then field_simp/ring close the goal using k! ≠ 0 and k+1 ≠ 0."
+    },
+    {
+      "id": "range-engine",
+      "title": "Section II: The Inductive Engine (range form)",
+      "startLine": 56,
+      "endLine": 64,
+      "summary": "sum_range_div_factorial: ∑_{k=0}^{n} k/(k+1)! = 1 − 1/(n+1)!, proved by induction — the genuine content.",
+      "mathContext": "Finset.sum_range_succ peels the top summand; term_telescope (n+1) rewrites it as 1/(n+1)! − 1/(n+2)!; ring cancels the interior 1/(n+1)! against the inductive hypothesis, leaving 1 − 1/(n+2)!."
+    },
+    {
+      "id": "literal-form",
+      "title": "Section III: The Literal ∑_{k=1}^{n} Form",
+      "startLine": 68,
+      "endLine": 79,
+      "summary": "sum_Icc_eq_sum_range bridges Finset.Icc 1 n to range (n+1) (the k=0 term vanishes), and sum_Icc_div_factorial states the headline identity with the usual lower limit k = 1.",
+      "mathContext": "Induction via Finset.sum_Icc_succ_top matches Finset.sum_range_succ term by term; the extra index 0 contributes 0/1! = 0, so the two sums agree."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 89 lines and 4 theorems establishing the fractional factorial telescoping identity ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)! over ℚ. The pointwise reciprocal difference k/(k+1)! = 1/k! − 1/(k+1)! is the engine; the range induction and the literal ∑_{k=1}^{n} form over Finset.Icc 1 n are derived. #print axioms reports only [propext, Classical.choice, Quot.sound] for term_telescope and sum_Icc_div_factorial.",
+    "implications": "An elementary, cleanly formalized identity: the reciprocal (division, over ℚ) mirror of the sibling integer identity ∑ k·k! = (n+1)! − 1. It demonstrates that once the pointwise telescoping lemma is isolated, the finite-sum induction collapses to a single ring step, and it makes the truncation tail 1/(n+1)! of the classical series ∑ k/(k+1)! = 1 explicit. The result is routine in difficulty; its value is a tidy, axiom-free gallery entry completing the integer/fractional telescoping pair.",
+    "openQuestions": [
+      "Take the limit: prove ∑_{k=1}^{∞} k/(k+1)! = 1 (tsum over ℝ) from this finite form, with the error bound |1 − ∑_{k=1}^{n}| = 1/(n+1)! giving the rate of convergence.",
+      "Generalize to ∑_{k=1}^{n} k/(k+m)! or reciprocal telescoping ∑ (1/a_k − 1/a_{k+1}) over a strictly increasing positive sequence a_k, recovering this as the a_k = k! instance."
+    ]
+  },
+  "references": [
+    {
+      "key": "ConcreteMath",
+      "citation": "Graham, R.L., Knuth, D.E., Patashnik, O., Concrete Mathematics, 2nd ed., Addison-Wesley (1994), Ch. 2 (sums, telescoping, and factorial identities).",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "factorial-telescoping-sum-oq-01",
+      "relationship": "relatedTo",
+      "description": "The integer sibling ∑_{k=1}^{n} k·k! = (n+1)! − 1. This entry is its reciprocal (division) counterpart over ℚ: dividing the per-term collapse k·k! = (k+1)! − k! by k!·(k+1)! yields the pointwise identity k/(k+1)! = 1/k! − 1/(k+1)! used here."
+    },
+    {
+      "targetId": "telescoping-product-oq-01",
+      "relationship": "relatedTo",
+      "description": "A neighbouring telescoping entry; both collapse a structured sum/product to a single boundary term via a per-term identity."
+    },
+    {
+      "targetId": "legendre-factorial-formula-oq-01",
+      "relationship": "relatedTo",
+      "description": "A companion factorial-arithmetic entry; shares the factorial recurrence (n+1)! = (n+1)·n! that drives the reciprocal telescoping collapse here."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Algebra.BigOperators.Intervals",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "FactorialTelescopingSumFractional",
+    "lineCount": 89,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/FactorialTelescopingSumOQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Factorial",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FactorialTelescopingSumOQ02.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "factorial",
+      "telescoping",
+      "finite-sums",
+      "induction",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-05",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(n+1)! = (n+1)·n! — the factorial recurrence, cast into ℚ to expose the common denominator of the reciprocal difference",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_ne_zero",
+        "description": "n! ≠ 0 — supplies the nonzero denominators for field_simp over ℚ",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{k ∈ range (n+1)} f k = (∑_{k ∈ range n} f k) + f n — peels the top summand in the induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Icc_succ_top",
+        "description": "a ≤ b+1 → ∑_{k ∈ Icc a (b+1)} f k = (∑_{k ∈ Icc a b} f k) + f (b+1) — bridges the Icc form to the range form",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      }
+    ],
+    "originalContributions": [
+      "term_telescope: the pointwise reciprocal telescoping identity k/(k+1)! = 1/k! − 1/(k+1)! over ℚ, the heart of the proof",
+      "sum_range_div_factorial: the inductive engine ∑_{k=0}^{n} k/(k+1)! = 1 − 1/(n+1)!, whose step is a single ring call after rewriting the top term by term_telescope",
+      "sum_Icc_div_factorial with sum_Icc_eq_sum_range: the literal headline ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)! over Finset.Icc 1 n, proving the lower limit k = 1 is cosmetic"
+    ],
+    "axiomCount": 0,
+    "lineCount": 89,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for term_telescope and sum_Icc_div_factorial (and hence for sum_range_div_factorial and sum_Icc_eq_sum_range). The two `example` sanity checks (∑_{Icc 1 3} = 23/24, ∑_{Icc 1 4} = 119/120) are derived from the closed form via norm_num, not native_decide. Compiled against Mathlib v4.26.0. The identity is elementary/classical; the formalization is built from primitives (sum_range_succ, factorial_succ, field_simp) rather than wrapping a single named Mathlib lemma.",
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "prerequisites": [
+      "The factorial and its recurrence (n+1)! = (n+1)·n!, cast into ℚ",
+      "Finite sums over Finset.range and Finset.Icc",
+      "Field arithmetic in ℚ (field_simp, ring) and factorial-nonzero facts"
+    ],
+    "relatedProblems": [
+      "factorial-telescoping-sum-oq-01"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **finite fractional factorial telescoping identity** over ℚ:

$$\sum_{k=1}^{n} \frac{k}{(k+1)!} = 1 - \frac{1}{(n+1)!}.$$

This is the reciprocal (division) counterpart of the sibling gallery entry `factorial-telescoping-sum-oq-01` ($\sum k\cdot k! = (n+1)! - 1$), and the finite partial-sum form of the classical series $\sum_{k=1}^{\infty} k/(k+1)! = 1$ — the closed form makes the truncation tail $1/(n+1)!$ explicit.

## Key idea

Each summand is an exact reciprocal difference:
$$\frac{k}{(k+1)!} = \frac{1}{k!} - \frac{1}{(k+1)!}\qquad\text{since }(k+1)! = (k+1)\cdot k!,$$
so the sum telescopes to $1/1! - 1/(n+1)!$. Working over ℚ keeps division honest (no ℕ truncation). Once the pointwise lemma `term_telescope` is isolated, the induction step is a single `ring` call after rewriting the top summand.

## Contents (`proofs/Proofs/FactorialTelescopingSumOQ02.lean`)

- `term_telescope`: $k/(k+1)! = 1/k! - 1/(k+1)!$ (field_simp/ring)
- `sum_range_div_factorial`: range-form induction $\sum_{k=0}^{n} k/(k+1)! = 1 - 1/(n+1)!$
- `sum_Icc_eq_sum_range`: bridge (the $k=0$ term $0/1!$ vanishes)
- `sum_Icc_div_factorial`: headline literal $\sum_{k=1}^{n}$ form over `Finset.Icc 1 n`

## Verification

- **4 theorems, 0 sorries, 0 axioms, no `native_decide`.**
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`.
- Builds via `./proofs/scripts/docker-build.sh Proofs.FactorialTelescopingSumOQ02` (2.1s) against Mathlib v4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)