### PR TITLE
research(mersenne-prime-exponent): Mersenne prime ⇒ prime exponent [verified]

### DIFF
--- a/proofs/Proofs/MersennePrimeExponent.lean
+++ b/proofs/Proofs/MersennePrimeExponent.lean
@@ -1,0 +1,91 @@
+import Mathlib.Algebra.Ring.GeomSum
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+/-
+# Mersenne Prime Exponents Are Prime
+
+## Open Question (mersenne-prime-exponent)
+
+A **Mersenne number** is a number of the form `2^n - 1`.  A **Mersenne prime**
+is a Mersenne number that happens to be prime (`3 = 2² − 1`, `7 = 2³ − 1`,
+`31 = 2⁵ − 1`, `127 = 2⁷ − 1`, …).  The exponents `2, 3, 5, 7, …` are all prime,
+and this is no accident:
+
+    If `2^n − 1` is prime, then `n` is prime.
+
+This is the classical necessary condition on Mersenne exponents — the
+prerequisite that lets the Lucas–Lehmer test restrict its search to prime `n`.
+The converse is false (`2¹¹ − 1 = 2047 = 23 · 89`), so primality of the exponent
+is necessary but not sufficient.
+
+## Proof
+
+Contrapositive on the exponent.  Suppose `2^n − 1` is prime but `n` is **not**.
+
+* First, `n ≥ 2`: the degenerate exponents give `2⁰ − 1 = 0` and `2¹ − 1 = 1`,
+  neither of which is prime, so a prime Mersenne number forces `n ≥ 2`.
+
+* A composite `n ≥ 2` has a nontrivial divisor `d` with `2 ≤ d < n`
+  (`Nat.exists_dvd_of_not_prime2`).
+
+* Divisibility of exponents lifts to divisibility of Mersenne numbers:
+  `d ∣ n ⇒ 2^d − 1 ∣ 2^n − 1` (`Nat.pow_sub_one_dvd_pow_sub_one`, itself a
+  corollary of `x − y ∣ xⁿ − yⁿ`).
+
+* But `2^d − 1` is a *proper* divisor of `2^n − 1`: from `2 ≤ d` we get
+  `2^d − 1 ≥ 3 > 1`, and from `d < n` we get `2^d < 2^n`, hence
+  `2^d − 1 < 2^n − 1`.  A prime has no proper divisor strictly between `1` and
+  itself, contradicting the primality of `2^n − 1`.
+
+Both escape hatches offered by primality are closed using injectivity of
+`d ↦ 2^d` (`Nat.pow_right_injective`): `2^d − 1 = 1` would force `d = 1`, and
+`2^d − 1 = 2^n − 1` would force `d = n`.
+
+The result is fully machine-checked and self-contained (0 sorries, 0 axioms
+beyond Mathlib's foundations).
+-/
+
+namespace MersennePrimeExponent
+
+/-- **Mersenne prime exponents are prime.**  If the Mersenne number `2^n − 1`
+is prime, then the exponent `n` is prime. -/
+theorem prime_of_mersenne_prime {n : ℕ} (hp : Nat.Prime (2 ^ n - 1)) :
+    Nat.Prime n := by
+  by_contra hn
+  -- A prime Mersenne number forces the exponent to be at least 2.
+  have hn2 : 2 ≤ n := by
+    match n with
+    | 0 => norm_num at hp          -- `2⁰ − 1 = 0` is not prime
+    | 1 => norm_num at hp          -- `2¹ − 1 = 1` is not prime
+    | (k + 2) => omega
+  -- A composite `n ≥ 2` has a nontrivial divisor `2 ≤ d < n`.
+  obtain ⟨d, hd_dvd, hd2, hdn⟩ := Nat.exists_dvd_of_not_prime2 hn2 hn
+  -- Exponent divisibility lifts to Mersenne-number divisibility.
+  have hdvd : 2 ^ d - 1 ∣ 2 ^ n - 1 := Nat.pow_sub_one_dvd_pow_sub_one 2 hd_dvd
+  -- Primality of `2^n − 1` says its only divisors are `1` and itself.
+  rcases hp.eq_one_or_self_of_dvd _ hdvd with h1 | h2
+  · -- `2^d − 1 = 1` is impossible: `d ≥ 2 ⇒ 2^d ≥ 4`.
+    have h4 : 4 ≤ 2 ^ d := by
+      calc 4 = 2 ^ 2 := by norm_num
+        _ ≤ 2 ^ d := Nat.pow_le_pow_right (by norm_num) hd2
+    omega
+  · -- `2^d − 1 = 2^n − 1` forces `2^d = 2^n`, hence `d = n`, contradicting `d < n`.
+    have h2d : 1 ≤ 2 ^ d := Nat.one_le_pow d 2 (by norm_num)
+    have h2n : 1 ≤ 2 ^ n := Nat.one_le_pow n 2 (by norm_num)
+    have heq : 2 ^ d = 2 ^ n := by omega
+    have : d = n := Nat.pow_right_injective (le_refl 2) heq
+    omega
+
+/-- Restated with the explicit `2^n − 1` phrasing used in the gallery. -/
+theorem mersenne_exponent_prime (n : ℕ) (hp : Nat.Prime (2 ^ n - 1)) :
+    Nat.Prime n :=
+  prime_of_mersenne_prime hp
+
+/-- The contrapositive form: a composite exponent yields a composite Mersenne
+number.  Useful as the direct search-pruning statement for Lucas–Lehmer. -/
+theorem not_prime_mersenne_of_not_prime {n : ℕ} (hn : ¬ Nat.Prime n) :
+    ¬ Nat.Prime (2 ^ n - 1) :=
+  fun hp => hn (prime_of_mersenne_prime hp)
+
+end MersennePrimeExponent

--- a/src/data/proofs/mersenne-prime-exponent/meta.json
+++ b/src/data/proofs/mersenne-prime-exponent/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "mersenne-prime-exponent",
+  "title": "Mersenne Prime Exponents Are Prime",
+  "slug": "mersenne-prime-exponent",
+  "description": "A fully machine-checked, self-contained proof of the classical necessary condition on Mersenne primes: if the Mersenne number 2^n − 1 is prime, then the exponent n is prime. The proof is a contrapositive on the exponent. A prime Mersenne number forces n ≥ 2 (the degenerate exponents give 2⁰−1 = 0 and 2¹−1 = 1, neither prime). A composite n ≥ 2 has a nontrivial divisor d with 2 ≤ d < n (Nat.exists_dvd_of_not_prime2), and exponent divisibility lifts to Mersenne-number divisibility, 2^d − 1 ∣ 2^n − 1 (Nat.pow_sub_one_dvd_pow_sub_one, a corollary of x − y ∣ xⁿ − yⁿ). But 2^d − 1 is then a proper divisor strictly between 1 and 2^n − 1 (from 2 ≤ d one gets 2^d − 1 ≥ 3, and from d < n one gets 2^d − 1 < 2^n − 1), contradicting primality. The two escape hatches offered by primality, 2^d − 1 = 1 and 2^d − 1 = 2^n − 1, are closed with injectivity of d ↦ 2^d (Nat.pow_right_injective). The converse is false (2¹¹ − 1 = 2047 = 23·89), so primality of the exponent is necessary but not sufficient — exactly the fact that lets the Lucas–Lehmer test restrict its search to prime exponents.",
+  "meta": {
+    "author": "Classical (folklore; prerequisite of the Lucas–Lehmer test); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mersenne_prime",
+    "date": "1640",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "mersenne-primes",
+      "primality",
+      "divisibility",
+      "contrapositive",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/MersennePrimeExponent.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.pow_sub_one_dvd_pow_sub_one",
+        "description": "If m ∣ k then x^m − 1 ∣ x^k − 1. The arithmetic engine: it lifts d ∣ n to 2^d − 1 ∣ 2^n − 1. A corollary of x − y ∣ xⁿ − yⁿ (Nat.sub_dvd_pow_sub_pow).",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      },
+      {
+        "theorem": "Nat.exists_dvd_of_not_prime2",
+        "description": "A composite n ≥ 2 has a divisor m with 2 ≤ m < n. Supplies the nontrivial proper exponent divisor d.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.eq_one_or_self_of_dvd",
+        "description": "Every divisor of a prime is 1 or the prime itself. Applied to the divisor 2^d − 1 of the prime 2^n − 1 to force the contradiction.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.pow_right_injective",
+        "description": "For a base ≥ 2, x ↦ a^x is injective. Closes both escape hatches: 2^d = 2 forces d = 1, and 2^d = 2^n forces d = n.",
+        "module": "Mathlib.Data.Nat.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The classical theorem 'a Mersenne prime has prime exponent' — Nat.Prime (2^n − 1) → Nat.Prime n — machine-checked with 0 axioms and 0 sorries. Mathlib provides the Mersenne definition and the Lucas–Lehmer machinery but does not package this necessary-condition direction as a standalone lemma.",
+      "A short contrapositive assembly: reduce composite n to a proper exponent divisor 2 ≤ d < n, lift it through Nat.pow_sub_one_dvd_pow_sub_one to a proper Mersenne divisor 2^d − 1, and contradict primality via Nat.Prime.eq_one_or_self_of_dvd, with the two boundary cases (divisor = 1 and divisor = whole) discharged by injectivity of d ↦ 2^d.",
+      "Two downstream packagings: mersenne_exponent_prime (the same statement in the explicit 2^n − 1 phrasing) and not_prime_mersenne_of_not_prime (the direct contrapositive 'composite exponent ⇒ composite Mersenne number'), the form used to prune the Lucas–Lehmer search to prime exponents."
+    ],
+    "dateAdded": "2026-07-05",
+    "axiomCount": 0,
+    "lineCount": 91,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only standard tactics (by_contra, omega, norm_num, calc) and named Mathlib lemmas — no decide or native_decide, so no Lean.ofReduceBool. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No sorryAx, no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "exponent-at-least-two",
+      "title": "A prime Mersenne number forces n ≥ 2",
+      "startLine": 55,
+      "endLine": 62,
+      "summary": "Assuming n is not prime (for contradiction), the exponent is pinned to n ≥ 2 by a three-way match: n = 0 gives 2⁰ − 1 = 0 and n = 1 gives 2¹ − 1 = 1, both dispatched by norm_num against the primality hypothesis; n = k + 2 is handled by omega."
+    },
+    {
+      "id": "proper-divisor",
+      "title": "Nontrivial exponent divisor and its Mersenne lift",
+      "startLine": 63,
+      "endLine": 66,
+      "summary": "Nat.exists_dvd_of_not_prime2 extracts a divisor d with 2 ≤ d < n from the composite n. Nat.pow_sub_one_dvd_pow_sub_one then lifts d ∣ n to the Mersenne divisibility 2^d − 1 ∣ 2^n − 1."
+    },
+    {
+      "id": "primality-contradiction",
+      "title": "Contradiction with primality of 2^n − 1",
+      "startLine": 67,
+      "endLine": 79,
+      "summary": "Nat.Prime.eq_one_or_self_of_dvd forces the divisor 2^d − 1 to be either 1 or 2^n − 1. The first case is killed by 4 ≤ 2^d (from 2 ≤ d via Nat.pow_le_pow_right) plus omega. The second gives 2^d = 2^n (omega, using 1 ≤ 2^d and 1 ≤ 2^n), whence Nat.pow_right_injective yields d = n, contradicting d < n."
+    },
+    {
+      "id": "packagings",
+      "title": "Restated and contrapositive forms",
+      "startLine": 81,
+      "endLine": 89,
+      "summary": "mersenne_exponent_prime restates the result with the explicit 2^n − 1 phrasing; not_prime_mersenne_of_not_prime is the direct contrapositive ¬Nat.Prime n → ¬Nat.Prime (2^n − 1), the search-pruning form for Lucas–Lehmer."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Mersenne numbers and their prime exponents**\n\nMarin Mersenne (1588–1648) studied numbers of the form $M_n = 2^n - 1$ in his 1644 *Cogitata Physico-Mathematica*, conjecturing (with several errors) which are prime. A number $2^n - 1$ can be prime only when $n$ is prime — a fact already implicit in Euclid's work on perfect numbers, since Euclid's theorem pairs each Mersenne prime $2^p - 1$ with the perfect number $2^{p-1}(2^p - 1)$. The condition is *necessary but not sufficient*: $n = 11$ is prime yet $2^{11} - 1 = 2047 = 23 \\cdot 89$ is composite. This necessary condition is precisely what makes the modern search for Mersenne primes tractable: the Lucas–Lehmer test only needs to be run on prime exponents, and GIMPS (the Great Internet Mersenne Prime Search) has found all recent record primes this way.",
+    "problemStatement": "**Mersenne prime ⇒ prime exponent**\n\nProve that for every natural number $n$, if the Mersenne number $2^n - 1$ is prime, then $n$ is prime:\n$$\\text{Prime}(2^n - 1) \\implies \\text{Prime}(n).$$\nThe goal is a fully machine-checked proof with no axioms and no sorries.",
+    "proofStrategy": "**Contrapositive: a composite exponent factors the Mersenne number**\n\nSuppose $2^n - 1$ is prime but $n$ is not. First, primality of $2^n - 1$ rules out the degenerate exponents $n = 0$ ($2^0 - 1 = 0$) and $n = 1$ ($2^1 - 1 = 1$), so $n \\ge 2$. A composite $n \\ge 2$ has a nontrivial divisor $d$ with $2 \\le d < n$. The key arithmetic fact is that divisibility of exponents lifts to divisibility of Mersenne numbers: $d \\mid n \\implies 2^d - 1 \\mid 2^n - 1$ (writing $n = d\\cdot e$, $2^n - 1 = (2^d)^e - 1^e$ is divisible by $2^d - 1$). But $2^d - 1$ is then a *proper* divisor: $d \\ge 2$ gives $2^d - 1 \\ge 3 > 1$, and $d < n$ gives $2^d - 1 < 2^n - 1$. A prime has no divisor strictly between $1$ and itself, so this contradicts the primality of $2^n - 1$. The two boundary escapes offered by primality — $2^d - 1 = 1$ and $2^d - 1 = 2^n - 1$ — are closed by injectivity of $d \\mapsto 2^d$, forcing $d = 1$ or $d = n$ respectively, both excluded by $2 \\le d < n$.",
+    "keyInsights": [
+      "**Divisibility of exponents lifts to Mersenne numbers.** The whole proof turns on $d \\mid n \\implies 2^d - 1 \\mid 2^n - 1$, a special case of $x - y \\mid x^k - y^k$ with $x = 2^d$, $y = 1$. Mathlib packages exactly this as `Nat.pow_sub_one_dvd_pow_sub_one`.",
+      "**The divisor must be *proper*, not just any divisor.** Primality is contradicted only because $2^d - 1$ sits strictly between $1$ and $2^n - 1$. Both strict inequalities come for free from $2 \\le d < n$ via monotonicity of $2^{(\\cdot)}$, and injectivity of $2^{(\\cdot)}$ closes the two boundary cases.",
+      "**Necessary, not sufficient.** The converse fails at the smallest composite Mersenne exponent for a prime $n$: $2^{11} - 1 = 2047 = 23 \\cdot 89$. The theorem is a one-directional search filter, not a characterization.",
+      "**Tactic economy.** Once the right Mathlib lemmas are named, the arithmetic bookkeeping (peeling degenerate exponents, comparing $2^d$ against $2^n$, extracting $d = n$ from $2^d = 2^n$) is entirely mechanical: `norm_num`, `omega`, and one `calc` with `Nat.pow_le_pow_right`."
+    ],
+    "prerequisites": [
+      "Divisibility and prime numbers in ℕ",
+      "The identity x − y ∣ xⁿ − yⁿ",
+      "Monotonicity and injectivity of a ↦ aⁿ",
+      "Proof by contrapositive"
+    ]
+  },
+  "conclusion": {
+    "summary": "The necessary condition on Mersenne primes, $\\text{Prime}(2^n - 1) \\implies \\text{Prime}(n)$, is established by a short contrapositive. A composite exponent $n$ yields a proper divisor $d$ with $2 \\le d < n$; the divisibility lift $2^d - 1 \\mid 2^n - 1$ (`Nat.pow_sub_one_dvd_pow_sub_one`) then exhibits a proper divisor of $2^n - 1$ strictly between $1$ and itself, contradicting primality via `Nat.Prime.eq_one_or_self_of_dvd`, with the boundary cases closed by injectivity of $d \\mapsto 2^d$. 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the standalone necessary-condition lemma for Mersenne primes — Prime(2^n − 1) → Prime(n) — which Mathlib's Lucas–Lehmer development uses implicitly but does not expose as a named result.",
+      "The contrapositive form not_prime_mersenne_of_not_prime (composite exponent ⇒ composite Mersenne number) is exactly the statement that justifies restricting the Lucas–Lehmer / GIMPS search to prime exponents.",
+      "Isolates a reusable pattern: to show a parametrized family a^n − 1 is composite for composite n, lift the exponent factorization through Nat.pow_sub_one_dvd_pow_sub_one and bound the resulting divisor away from 1 and the whole."
+    ],
+    "openQuestions": [
+      "Does the same exponent-divisibility lift give an equally short proof that a Fermat prime 2^n + 1 forces n to be a power of 2 (the odd-divisor obstruction 2^d + 1 ∣ 2^n + 1 for odd d ∣ n)?",
+      "Can the necessary condition be strengthened toward the classical restriction that any prime factor q of a Mersenne number 2^p − 1 (p prime) satisfies q ≡ 1 (mod 2p) and q ≡ ±1 (mod 8)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "divisibility-rules",
+      "relationship": "Shared divisibility toolkit",
+      "description": "Both entries turn on elementary divisibility arithmetic in ℕ. This Mersenne result is a pointed application: exponent divisibility d ∣ n lifting to 2^d − 1 ∣ 2^n − 1."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a fully machine-checked, self-contained proof of the classical necessary condition on Mersenne primes:

> If the Mersenne number `2^n − 1` is prime, then the exponent `n` is prime.

**`Nat.Prime (2 ^ n - 1) → Nat.Prime n`** — 0 axioms, 0 sorries.

## Proof

Contrapositive on the exponent:
- A prime Mersenne number rules out `n = 0` (`2⁰−1 = 0`) and `n = 1` (`2¹−1 = 1`), so `n ≥ 2`.
- A composite `n ≥ 2` has a nontrivial divisor `2 ≤ d < n` (`Nat.exists_dvd_of_not_prime2`).
- Exponent divisibility lifts to Mersenne divisibility: `2^d − 1 ∣ 2^n − 1` (`Nat.pow_sub_one_dvd_pow_sub_one`, a corollary of `x − y ∣ xⁿ − yⁿ`).
- `2^d − 1` is a **proper** divisor (`2^d − 1 ≥ 3 > 1` and `2^d − 1 < 2^n − 1`), contradicting primality via `Nat.Prime.eq_one_or_self_of_dvd`. The two boundary escapes are closed with `Nat.pow_right_injective`.

The converse is false (`2¹¹ − 1 = 2047 = 23·89`), so the exponent's primality is necessary but not sufficient — exactly the fact that restricts the Lucas–Lehmer search to prime exponents.

## Theorems

- `prime_of_mersenne_prime` — the headline `Prime(2^n−1) → Prime(n)`
- `mersenne_exponent_prime` — explicit restatement
- `not_prime_mersenne_of_not_prime` — contrapositive `¬Prime n → ¬Prime(2^n−1)` (Lucas–Lehmer search-pruning form)

## Verification

- `./proofs/scripts/docker-build.sh Proofs.MersennePrimeExponent` → build succeeded (3058 jobs, Lean v4.26.0 / Mathlib 4.26.0).
- `#print axioms` on all three theorems reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Status: **verified**.

## Files

- `proofs/Proofs/MersennePrimeExponent.lean` (new, 91 lines)
- `src/data/proofs/mersenne-prime-exponent/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)