### PR TITLE
Enrich Divisibility Rules (both signs, all widths): add annotations

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/divisibility-rules-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header-openq",
+    "proofId": "divisibility-rules-oq-04-oq-01-oq-01",
+    "range": { "startLine": 5, "endLine": 32 },
+    "type": "context",
+    "title": "One rule for the whole 9/11/99/101/1001 zoo",
+    "content": "The docstring frames the parent's open question and the single idea that answers it: read n in base 10^k (group its decimal digits into k-digit blocks) and use that 10^k is congruent to +1 or -1 modulo the tested divisor. The plain block sum certifies divisibility by every divisor of 10^k - 1; the alternating block sum certifies divisibility by every divisor of 10^k + 1. Every classical decimal rule is one instantiation of a single lemma.",
+    "mathContext": "$n \\bmod m$ is read off the base-$10^k$ blocks $b_0,b_1,\\dots$ because $10^k \\equiv \\varepsilon \\pmod m$ with $\\varepsilon = \\pm 1$: block sum for $m \\mid 10^k-1$, alternating block sum for $m \\mid 10^k+1$.",
+    "significance": "context",
+    "relatedConcepts": ["casting out nines", "positional notation", "modular arithmetic", "divisibility tests"],
+    "prerequisites": ["base-b representation of integers", "congruence modulo m"]
+  },
+  {
+    "id": "ann-ofDigits-one",
+    "proofId": "divisibility-rules-oq-04-oq-01-oq-01",
+    "range": { "startLine": 38, "endLine": 46 },
+    "type": "technique",
+    "title": "ℤ-coefficient bridge: ofDigits 1 = list sum",
+    "content": "Mathlib's Nat.ofDigits_one evaluates a digit list at base 1 but is stated only for the natural-number base. This two-line list induction proves the ℤ-coefficient companion, so that the ε = 1 branch of the master lemma lands on an explicit integer block sum rather than an opaque ofDigits term. The cons step is just ofDigits_one_cons followed by List.sum_cons.",
+    "mathContext": "$\\mathrm{ofDigits}\\,(1:\\mathbb{Z})\\,L = \\sum_{d \\in L} (d:\\mathbb{Z})$, proved by induction on $L$ using $\\mathrm{ofDigits}\\,1\\,(d::L) = d + \\mathrm{ofDigits}\\,1\\,L$.",
+    "significance": "technical",
+    "relatedConcepts": ["list induction", "Horner evaluation", "coercion ℕ → ℤ"],
+    "prerequisites": ["structural induction on lists", "Nat.ofDigits"]
+  },
+  {
+    "id": "ann-defs",
+    "proofId": "divisibility-rules-oq-04-oq-01-oq-01",
+    "range": { "startLine": 48, "endLine": 57 },
+    "type": "definition",
+    "title": "blockSum and blockAltSum: the two certificates",
+    "content": "blockSum k n is the sum of the base-10^k digit blocks of n (least-significant first), the certificate for divisors of 10^k - 1. blockAltSum k n is the alternating sum b₀ - b₁ + b₂ - ⋯ of the same blocks, the certificate for divisors of 10^k + 1. Both coerce the ℕ blocks to ℤ so the alternating sum has genuine subtraction; the widths are unified by leaving k free.",
+    "mathContext": "$\\mathrm{blockSum}\\,k\\,n = \\sum_i b_i$ and $\\mathrm{blockAltSum}\\,k\\,n = \\sum_i (-1)^i b_i$, where $b_i$ are the base-$10^k$ digits of $n$.",
+    "significance": "key",
+    "relatedConcepts": ["List.sum", "List.alternatingSum", "base-10^k digits", "digit blocks"],
+    "prerequisites": ["Nat.digits", "list folds"]
+  },
+  {
+    "id": "ann-master",
+    "proofId": "divisibility-rules-oq-04-oq-01-oq-01",
+    "range": { "startLine": 59, "endLine": 71 },
+    "type": "insight",
+    "title": "The master parametric lemma",
+    "content": "dvd_iff_dvd_ofDigits_pow_ten is the single theorem behind everything. For any block width k, any signed evaluation ε : ℤ, and any modulus m with (m:ℤ) ∣ 10^k - ε, divisibility of n by m equals divisibility of the signed base-10^k digit evaluation. It is proved by specializing Mathlib's Nat.dvd_iff_dvd_ofDigits to base b' = 10^k; the only real work is a push_cast/ring to match ((10^k : ℕ) : ℤ) with (10 : ℤ)^k. The side condition m ∣ 10^k - ε is the sole hypothesis.",
+    "mathContext": "$m \\mid n \\iff (m:\\mathbb{Z}) \\mid \\mathrm{ofDigits}\\,\\varepsilon\\,(\\mathrm{digits}\\,(10^k)\\,n)$ whenever $(m:\\mathbb{Z}) \\mid 10^k - \\varepsilon$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.dvd_iff_dvd_ofDigits", "specialization", "signed digit evaluation"],
+    "prerequisites": ["base-b divisibility machinery", "integer casts of powers"]
+  },
+  {
+    "id": "ann-branches",
+    "proofId": "divisibility-rules-oq-04-oq-01-oq-01",
+    "range": { "startLine": 73, "endLine": 98 },
+    "type": "technique",
+    "title": "The two signed branches and their packaging",
+    "content": "dvd_iff_dvd_blockSum (ε = 1) rewrites the master lemma through ofDigits_one_eq_map_sum to reach blockSum; dvd_iff_dvd_blockAltSum (ε = -1) uses simpa to supply m ∣ 10^k - (-1) and Nat.ofDigits_neg_one to reach blockAltSum. block_divisibility_families then packages both signs and all widths as a single conjunction, making explicit that one theorem tests every divisor of 10^k ∓ 1.",
+    "mathContext": "$\\varepsilon = +1$: divisors of $10^k-1$ via $\\sum b_i$. $\\varepsilon = -1$: divisors of $10^k+1$ via $\\sum (-1)^i b_i$ (using $\\mathrm{ofDigits}\\,(-1)\\,L = L.\\mathrm{alternatingSum}$).",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.ofDigits_neg_one", "alternating sum", "case split on sign"],
+    "prerequisites": ["rewriting with derived identities", "simpa"]
+  },
+  {
+    "id": "ann-residue",
+    "proofId": "divisibility-rules-oq-04-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 128 },
+    "type": "insight",
+    "title": "Residue identities: the full congruence, not just yes/no",
+    "content": "modEq_blockSum and modEq_blockAltSum upgrade the divisibility predicate to a congruence: n ≡ blockSum k n and n ≡ blockAltSum k n modulo any m ∣ 10^k ∓ 1. The proofs feed the pivot 10^k ≡ ±1 (mod m) — obtained from Int.modEq_iff_dvd and a dvd_neg — into Nat.zmodeq_ofDigits_digits, then rewrite to the explicit (alternating) sum. The actual remainder of n is read directly off the block sum.",
+    "mathContext": "$n \\equiv \\mathrm{blockSum}\\,k\\,n \\pmod m$ for $m \\mid 10^k-1$; $n \\equiv \\mathrm{blockAltSum}\\,k\\,n \\pmod m$ for $m \\mid 10^k+1$, from $10^k \\equiv \\pm 1 \\pmod m$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.zmodeq_ofDigits_digits", "Int.modEq_iff_dvd", "ZMOD congruence"],
+    "prerequisites": ["integer congruences", "modular pivots"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "divisibility-rules-oq-04-oq-01-oq-01",
+    "range": { "startLine": 130, "endLine": 178 },
+    "type": "concept",
+    "title": "Every textbook rule as a one-line corollary",
+    "content": "The classical rules are single instantiations of the two branches, discharged by norm_num on the side condition: 3, 9 (k=1 block sum), 11 (k=1 alternating); 99, 9, 11 (k=2 block sum), 101 (k=2 alternating); 7, 11, 13 (k=3 alternating, the parent's 1001 rule). Because 11 divides both 10+1 and 10^2-1 and 10^3+1, it appears in three corollaries — one modulus, several tests — dramatizing that the family is parametric, not a list of tricks.",
+    "mathContext": "$3,9 \\mid 10-1$; $11 \\mid 10+1$; $99 \\mid 10^2-1$; $101 \\mid 10^2+1$; $7,11,13 \\mid 10^3+1 = 1001$. Each is $\\texttt{norm\\_num}$ on $(m:\\mathbb{Z}) \\mid 10^k \\mp 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["1001 = 7·11·13", "divisibility by 3/9/11", "norm_num", "instantiation"],
+    "prerequisites": ["the master lemma", "elementary divisibility facts"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `divisibility-rules-oq-04-oq-01-oq-01` ("One Parametric Rule for Every Block-Divisibility Test").

**Gap:** the entry had a rich `meta.json` but **no `annotations.json`** (quality 45, passes 0). This adds inline annotation coverage of the full 181-line Lean file.

**Added — `annotations.json` (7 annotations, ~7.4 KB):**
- Docstring framing (the one-rule-for-the-whole-zoo idea)
- `ofDigits_one_eq_map_sum` — the ℤ-coefficient bridge to `List.sum`
- `blockSum` / `blockAltSum` definitions (the two certificates)
- `dvd_iff_dvd_ofDigits_pow_ten` — the master parametric lemma
- The two signed branches (ε = ±1) and their packaging
- `modEq_blockSum` / `modEq_blockAltSum` — the full residue identities
- The ten classical rules as one-line corollaries (3/9/11/99/101/7-11-13)

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. No `meta.json` changes; `pnpm build` passes. Well under all size caps.
