### PR TITLE
Enrich Bounded-Part Weak Compositions (IE): add annotations

### DIFF
--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-01-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-03",
+    "range": { "startLine": 4, "endLine": 35 },
+    "type": "context",
+    "title": "Bounded-part weak compositions and the sieve",
+    "content": "The docstring sets up the target: count weak compositions f : Fin k → ℕ of n with every part capped at r, and prove the classical inclusion-exclusion closed form. The argument is a subset sieve over the k overflow events A_i = {f | f i ≥ r+1}: admissible compositions are U \\ ⋃ᵢ A_i, and subtracting r+1 from each coordinate in a size-j subset S gives a bijection A_S ≃ {weak compositions of n − j(r+1)}, so |A_S| = C(n − j(r+1) + k − 1, k − 1). Grouping the 2^k subsets by size collapses to the single alternating j-sum.",
+    "mathContext": "$N_{\\le r}(n,k) = \\sum_{S \\subseteq [k]} (-1)^{|S|} |A_S| = \\sum_{j=0}^{k} (-1)^j \\binom{k}{j} \\binom{n - j(r+1) + k - 1}{k-1}$.",
+    "significance": "context",
+    "relatedConcepts": ["inclusion-exclusion", "stars and bars", "overflow-shift bijection", "weak compositions"],
+    "prerequisites": ["binomial coefficients", "finite set cardinality", "subset sieve"]
+  },
+  {
+    "id": "ann-integer-subtlety",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-03",
+    "range": { "startLine": 37, "endLine": 65 },
+    "type": "insight",
+    "title": "Why the sum must live in ℤ and be guarded",
+    "content": "A key formalisation subtlety: the signed sum genuinely subtracts, so it lives in ℤ. Crucially the convention C(m, k−1) = 0 for m < k − 1 must NOT be emulated with truncated ℕ subtraction inside the binomial's top argument — if j(r+1) > n, ℕ truncation makes n − j(r+1) = 0 and yields C(k−1, k−1) = 1 ≠ 0, wrongly cancelling the leading term already at k = 1. The fix is to guard each term by the exact predicate j(r+1) ≤ n, under which the subtraction is honest. This annotation records the axiom-integrity boundary: 0 sorries, 1 axiom (the general identity).",
+    "mathContext": "Guard $j(r+1) \\le n$ keeps $n - j(r+1)$ a genuine subtraction; without it $\\binom{k-1}{k-1} = 1 \\ne 0$ corrupts the count at $k=1$.",
+    "significance": "key",
+    "relatedConcepts": ["ℕ truncated subtraction", "ℤ signed sum", "binomial vanishing convention", "axiom integrity"],
+    "prerequisites": ["Nat vs Int arithmetic", "conditional summands"]
+  },
+  {
+    "id": "ann-defs",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-03",
+    "range": { "startLine": 71, "endLine": 85 },
+    "type": "definition",
+    "title": "boundedCount and boundedRHS",
+    "content": "boundedCount r k n is the LHS: the card of the filter (∀ i, f.1 i ≤ r) over the finite unbounded weak-composition type imported from the parent entry. boundedRHS r k n is the ℤ-valued sieve sum over range (k+1), with each term guarded by if j*(r+1) ≤ n (else 0). These are the two sides whose equality is the target identity.",
+    "mathContext": "$\\mathrm{boundedCount} = \\#\\{f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\sum f = n,\\ \\forall i,\\ f\\,i \\le r\\}$; $\\mathrm{boundedRHS} = \\sum_{j \\in \\mathrm{range}(k+1)} [\\,j(r+1) \\le n\\,]\\,(-1)^j \\binom{k}{j}\\binom{n-j(r+1)+k-1}{k-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.filter", "Finset.card", "guarded summation"],
+    "prerequisites": ["subtype of functions with sum constraint", "Finset.sum over range"]
+  },
+  {
+    "id": "ann-recovery-lhs",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-03",
+    "range": { "startLine": 87, "endLine": 98 },
+    "type": "technique",
+    "title": "Recovery (LHS): the cap is vacuous for n ≤ r",
+    "content": "boundedCount_of_le shows that when n ≤ r every part is automatically ≤ r, because each part is bounded by the total: f.1 i ≤ ∑ⱼ f.1 j = n ≤ r via Finset.single_le_sum. So Finset.filter_true_of_mem collapses the filter to univ, and Finset.card_univ plus the imported card_weakComposition give C(n + k − 1, n).",
+    "mathContext": "$n \\le r \\Rightarrow \\forall i,\\ f\\,i \\le \\sum_j f\\,j = n \\le r$, so $N_{\\le r}(n,k) = \\binom{n+k-1}{n}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.single_le_sum", "Finset.filter_true_of_mem", "card_weakComposition"],
+    "prerequisites": ["monotonicity of finite sums", "stars and bars count"]
+  },
+  {
+    "id": "ann-recovery-rhs",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-03",
+    "range": { "startLine": 100, "endLine": 129 },
+    "type": "technique",
+    "title": "Recovery (RHS): the sum collapses to its leading term",
+    "content": "boundedRHS_of_le shows the matching collapse: for n ≤ r every j ≥ 1 term is dropped (j(r+1) ≥ r+1 > n via Nat.le_mul_of_pos_left), so Finset.sum_eq_single 0 isolates the j = 0 term. Then Nat.choose_symm rewrites C(n+k−1, k−1) as C(n+k−1, n). This confirms the closed form is normalised so its n ≤ r specialisation agrees with the LHS recovery — a cross-check on the axiom's statement.",
+    "mathContext": "Only $j=0$ survives: $\\mathrm{boundedRHS} = \\binom{n+k-1}{k-1} = \\binom{n+k-1}{n}$ by $\\mathrm{choose\\_symm}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_eq_single", "Nat.choose_symm", "Nat.le_mul_of_pos_left"],
+    "prerequisites": ["isolating a single summand", "symmetry of binomials"]
+  },
+  {
+    "id": "ann-k1-instance",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-03",
+    "range": { "startLine": 131, "endLine": 174 },
+    "type": "insight",
+    "title": "The k = 1 instance: first cap-active confirmation",
+    "content": "boundedCount_eq_rhs_of_le chains the two recovery lemmas for the vacuous regime. boundedCount_eq_rhs_of_one then proves the identity for a single part for ALL n — including the cap-active regime n > r that the vacuous lemma never reaches. With one box the composition is forced (f 0 = n via Fin.sum_univ_one), so the LHS is 1 if n ≤ r else 0 (empty filter via Finset.filter_eq_empty_iff). The RHS over range 2 has both binomials equal to C(·, 0) = 1 (since k − 1 = 0), giving 1 − [r+1 ≤ n] = [n ≤ r] after split_ifs; omega. This is the first genuinely non-vacuous check of the axiom.",
+    "mathContext": "$k=1$: LHS $= [n \\le r]$; RHS $= 1 - [r+1 \\le n] = [n \\le r]$, the $j=1$ correction term active exactly when $n > r$.",
+    "significance": "key",
+    "relatedConcepts": ["Fin.sum_univ_one", "Finset.filter_eq_empty_iff", "split_ifs", "omega"],
+    "prerequisites": ["degenerate case analysis", "indicator arithmetic"]
+  },
+  {
+    "id": "ann-axiom",
+    "proofId": "stars-and-bars-weak-compositions-oq-01-oq-03",
+    "range": { "startLine": 176, "endLine": 191 },
+    "type": "context",
+    "title": "The general identity, recorded as an axiom",
+    "content": "boundedCount_eq_rhs is the full bounded-part inclusion-exclusion identity for all k ≥ 1. It is recorded as a single classical axiom: its statement and normalisation are pinned down and cross-checked by the two verified special cases (n ≤ r for all k, and k = 1 for all n), but the general subset sieve — Finset.inclusion_exclusion over the k overflow events plus the overflow-shift bijection identifying each |A_S| — is not yet discharged in Lean. This is the entry's sole assumption (badge: axiom, status: axiomatized); completing it is HARD known-mathematics work.",
+    "mathContext": "$(\\mathrm{boundedCount}\\,r\\,k\\,n : \\mathbb{Z}) = \\mathrm{boundedRHS}\\,r\\,k\\,n$ for $k \\ge 1$ — axiomatized pending a full sieve proof.",
+    "significance": "context",
+    "relatedConcepts": ["Finset.inclusion_exclusion", "axiomatized status", "overflow-shift bijection"],
+    "prerequisites": ["inclusion-exclusion principle", "assumption accounting"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `stars-and-bars-weak-compositions-oq-01-oq-03` ("Bounded-Part Weak Compositions via Inclusion–Exclusion").

**Gap:** rich `meta.json` but **no `annotations.json`** (quality 45, passes 0). This adds inline annotation coverage of the full 191-line Lean file.

**Added — `annotations.json` (7 annotations, ~7.8 KB):**
- Sieve overview (overflow events + shift bijection)
- The ℤ-vs-ℕ guard subtlety (why truncated `ℕ` subtraction corrupts the count)
- `boundedCount` / `boundedRHS` definitions
- Recovery lemma (LHS): the cap is vacuous for `n ≤ r`
- Recovery lemma (RHS): the sum collapses to its leading term
- The verified `k = 1` cap-active instance
- The general identity `boundedCount_eq_rhs`, recorded as an axiom

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Axiom accounting verified consistent (status `axiomatized`, badge `axiom`, axiomCount 1, matching the single `axiom` in the Lean file). No `meta.json` changes; `pnpm build` passes.
