### PR TITLE
Enrich Factorial Telescoping Sum (fractional): add annotations

### DIFF
--- a/src/data/proofs/factorial-telescoping-sum-oq-02/annotations.json
+++ b/src/data/proofs/factorial-telescoping-sum-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "factorial-telescoping-sum-oq-02",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "context",
+    "title": "The telescoping idea and why ℚ",
+    "content": "The docstring states the finite closed form ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)!, the finite version of the convergent series ∑ k/(k+1)! = 1. It is the reciprocal counterpart of the sibling entry ∑ k·k! = (n+1)! − 1. The whole proof rests on one exact identity: each summand is a difference of consecutive factorial reciprocals, so the sum telescopes to its first minus last term. Working over ℚ is essential — division must be genuine, not ℕ truncation.",
+    "mathContext": "$\\sum_{k=1}^{n} \\frac{k}{(k+1)!} = 1 - \\frac{1}{(n+1)!}$, the finite form of $\\sum_{k=1}^{\\infty} \\frac{k}{(k+1)!} = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["telescoping sums", "factorial reciprocals", "convergent series", "field arithmetic over ℚ"],
+    "prerequisites": ["factorial", "finite sums", "rational arithmetic"]
+  },
+  {
+    "id": "ann-term-telescope",
+    "proofId": "factorial-telescoping-sum-oq-02",
+    "range": { "startLine": 37, "endLine": 50 },
+    "type": "insight",
+    "title": "The pointwise telescoping identity (the real content)",
+    "content": "term_telescope is where all the mathematical content lives: k/(k+1)! = 1/k! − 1/(k+1)!. The proof rewrites (k+1)! = (k+1)·k! (Nat.factorial_succ, cast to ℚ) so both reciprocals share the common denominator (k+1)·k!, then field_simp clears denominators (using k! ≠ 0 and k+1 ≠ 0) and ring closes it. Algebraically: 1/k! − 1/(k+1)! = ((k+1) − 1)/(k+1)! = k/(k+1)!.",
+    "mathContext": "$\\frac{k}{(k+1)!} = \\frac{1}{k!} - \\frac{1}{(k+1)!}$, using $(k+1)! = (k+1)\\cdot k!$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.factorial_succ", "field_simp", "partial fractions", "common denominator"],
+    "prerequisites": ["factorial recurrence", "nonvanishing denominators"]
+  },
+  {
+    "id": "ann-range-induction",
+    "proofId": "factorial-telescoping-sum-oq-02",
+    "range": { "startLine": 52, "endLine": 64 },
+    "type": "technique",
+    "title": "The inductive engine (range form)",
+    "content": "sum_range_div_factorial proves the identity over range (n+1) by a one-line induction. The base case k=0 is norm_num on a single term. The successor step peels off the top summand via Finset.sum_range_succ, applies the inductive hypothesis, rewrites the new term (n+1)/(n+2)! with term_telescope, and lets ring cancel the interior 1/(n+1)! contributions — the telescoping collapse made mechanical.",
+    "mathContext": "$\\sum_{k=0}^{n} \\frac{k}{(k+1)!} = 1 - \\frac{1}{(n+1)!}$; the interior terms cancel pairwise, leaving $\\frac{1}{1!} - \\frac{1}{(n+1)!}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_range_succ", "induction on ℕ", "telescoping cancellation"],
+    "prerequisites": ["structural induction", "big-operator sums over range"]
+  },
+  {
+    "id": "ann-reindex",
+    "proofId": "factorial-telescoping-sum-oq-02",
+    "range": { "startLine": 66, "endLine": 73 },
+    "type": "technique",
+    "title": "Matching the literal lower limit k = 1",
+    "content": "sum_Icc_eq_sum_range bridges the range (n+1) form (indices 0..n) to the literal ∑_{k=1}^{n} over Finset.Icc 1 n. The only difference is the k=0 index, whose summand 0/1! = 0 vanishes, so the two sums are equal. Proved by induction using Finset.sum_Icc_succ_top and Finset.sum_range_succ in lock-step.",
+    "mathContext": "$\\sum_{k \\in \\mathrm{Icc}\\,1\\,n} = \\sum_{k \\in \\mathrm{range}(n+1)}$ since the extra $k=0$ term is $\\frac{0}{1!} = 0$.",
+    "significance": "technical",
+    "relatedConcepts": ["Finset.sum_Icc_succ_top", "reindexing sums", "vanishing summand"],
+    "prerequisites": ["Finset.Icc vs range", "sum over intervals"]
+  },
+  {
+    "id": "ann-headline",
+    "proofId": "factorial-telescoping-sum-oq-02",
+    "range": { "startLine": 75, "endLine": 87 },
+    "type": "concept",
+    "title": "Headline identity and concrete sanity checks",
+    "content": "sum_Icc_div_factorial is the stated theorem over Finset.Icc 1 n, obtained by chaining the reindexing lemma with the range-form result. The two examples verify concrete instances derived from the closed form: n=3 gives 1/2 + 2/6 + 3/24 = 23/24 = 1 − 1/4!, and n=4 adds 4/120 to reach 119/120 = 1 − 1/5!. Both are discharged by rewriting with the headline identity and norm_num — 0 sorries, 0 axioms, no native_decide.",
+    "mathContext": "$\\sum_{k=1}^{3} = \\frac{23}{24} = 1 - \\frac{1}{4!}$; $\\sum_{k=1}^{4} = \\frac{119}{120} = 1 - \\frac{1}{5!}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["norm_num verification", "closed-form evaluation", "sanity checks"],
+    "prerequisites": ["the headline identity", "rational normalization"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `factorial-telescoping-sum-oq-02` ("Finite Factorial Telescoping: ∑ k/(k+1)! = 1 − 1/(n+1)!").

**Gap:** rich `meta.json` but **no `annotations.json`** (quality 41, passes 0). This adds inline annotation coverage of the full 89-line Lean file.

**Added — `annotations.json` (5 annotations):**
- Telescoping overview and why the proof works over ℚ
- `term_telescope` — the pointwise identity `k/(k+1)! = 1/k! − 1/(k+1)!` (the real content)
- `sum_range_div_factorial` — the inductive telescoping engine
- `sum_Icc_eq_sum_range` — matching the literal `k = 1` lower limit
- `sum_Icc_div_factorial` — headline identity + concrete sanity checks (n=3, n=4)

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. No `meta.json` changes; `pnpm build` passes.
