### PR TITLE
research(erdos-153-oq-03): primitive normal form — every B_h set is c·C+m for a primitive (gcd 1) B_h set [verified]

### DIFF
--- a/proofs/Proofs/Erdos153OQ03.lean
+++ b/proofs/Proofs/Erdos153OQ03.lean
@@ -46,6 +46,7 @@ constrained* as the Sidon (h = 2) case, because every B_h set is Sidon.
 - `isBhSet_sub`            : translation invariance (downward) — A−m is B_h (m ≤ A)
 - `isBhSet_div`            : dilation invariance (downward) — A/c is B_h (c ∣ A, c ≥ 1)
 - `isBhSet_translate_min_zero` : canonical form — every B_h set is a translate of a min-0 B_h set
+- `isBhSet_primitive_normal_form` : primitive normal form — every B_h set (≥2 elts) is `c·C+m` for a primitive (0∈C, gcd 1) B_h set C
 -/
 import Mathlib
 
@@ -791,5 +792,87 @@ theorem isBhSet_translate_min_zero {h : ℕ} {A : Finset ℕ} (hA : A.Nonempty)
       rwa [Nat.sub_add_cancel this]
     · intro hx
       exact ⟨x, hx, Nat.sub_add_cancel (hmle x hx)⟩
+
+/-!
+## Section XI: The primitive normal form
+
+Section X reduced every `B_h` set to an upward translate of a `B_h` set
+anchored at `0` (`isBhSet_translate_min_zero`).  Composing that downward
+translation with the downward dilation `isBhSet_div` lets us *also* strip out the
+common factor of the differences, landing on a **primitive** representative: a
+`B_h` set containing `0` whose elements have gcd `1`.
+
+Concretely, every nonempty `B_h` set with at least two elements is the affine
+image `b ↦ c · b + m` of a primitive (`0 ∈ C`, `gcd = 1`) `B_h` set `C`, where
+`m = min A` and `c = gcd {a − m : a ∈ A}` is the gcd of the differences.
+Absolute position *and* the common scale carry no `B_h` information — the study
+of `B_h` sets reduces to primitive ones.
+
+The gcd-stripping step uses `Finset.gcd_div_id_eq_one` (valid on `ℕ`, which is a
+`MulDivCancelClass`) together with the transport identity
+`(B.image (· / c)).gcd id = B.gcd (· / c)` (`Finset.gcd_eq_gcd_image`).
+-/
+
+/-- **Primitive normal form.**  Every nonempty `B_h` set `A` with at least two
+elements is the affine image `b ↦ c · b + m` of a *primitive* `B_h` set `C`: one
+that contains `0` and whose elements have gcd `1`.  Here `m = min A` and
+`c = gcd {a − m : a ∈ A}` (the gcd of the differences), both determined by `A`.
+Composing the downward translation `isBhSet_translate_min_zero` with the
+downward dilation `isBhSet_div` at `c` strips both the absolute position and the
+common scale, reducing the study of `B_h` sets to primitive ones. -/
+theorem isBhSet_primitive_normal_form {h : ℕ} {A : Finset ℕ} (hA : A.Nonempty)
+    (hcard : 1 < A.card) (H : IsBhSet h A) :
+    ∃ (c m : ℕ) (C : Finset ℕ),
+      0 < c ∧ IsBhSet h C ∧ (0 : ℕ) ∈ C ∧ C.gcd id = 1 ∧
+      A = (C.image (fun b => b * c)).image (fun b => b + m) := by
+  obtain ⟨hBh, h0B, hAB⟩ := isBhSet_translate_min_zero hA H
+  set m := A.min' hA with hm
+  set B := A.image (fun a => a - m) with hB
+  have hmle : ∀ a ∈ A, m ≤ a := fun a ha => Finset.min'_le A a ha
+  -- `· - m` is injective on `A`, so `|B| = |A| > 1`; hence `B` has a nonzero
+  -- element and the gcd `c := B.gcd id` is positive.
+  have hex : ∃ x ∈ B, id x ≠ 0 := by
+    have hBcard : 1 < B.card := by
+      have hcardeq : B.card = A.card := by
+        rw [hB]
+        apply Finset.card_image_of_injOn
+        intro x hx y hy hxy
+        simp only [Finset.mem_coe] at hx hy
+        have hx' := hmle x hx
+        have hy' := hmle y hy
+        have hxy' : x - m = y - m := hxy
+        omega
+      rw [hcardeq]; exact hcard
+    obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.mp hBcard
+    rcases eq_or_ne a 0 with rfl | ha0
+    · exact ⟨b, hb, fun hb0 => hab hb0.symm⟩
+    · exact ⟨a, ha, ha0⟩
+  set c := B.gcd id with hc_def
+  have hcne : c ≠ 0 := by rw [hc_def]; exact Finset.gcd_ne_zero_iff.mpr hex
+  have hcpos : 0 < c := Nat.pos_of_ne_zero hcne
+  have hdvd : ∀ a ∈ B, c ∣ a := by
+    intro a ha
+    have hd := Finset.gcd_dvd (f := id) ha
+    simpa [hc_def] using hd
+  -- The primitive representative.
+  set C := B.image (fun a => a / c) with hC
+  refine ⟨c, m, C, hcpos, isBhSet_div hcpos hdvd hBh, ?_, ?_, ?_⟩
+  · -- `0 ∈ C` because `0 ∈ B` and `0 / c = 0`.
+    rw [hC, Finset.mem_image]
+    exact ⟨0, h0B, by simp⟩
+  · -- `gcd C = 1`: transport `gcd` across the image, then divide out the gcd.
+    rw [hC, ← Finset.gcd_eq_gcd_image, hc_def]
+    obtain ⟨w, hwB, hw0⟩ := hex
+    exact Finset.gcd_div_id_eq_one hwB (by simpa using hw0)
+  · -- Reconstruct `A = (c · C) + m`.
+    have hBrec : C.image (fun b => b * c) = B := by
+      rw [hC, Finset.image_image]
+      conv_rhs => rw [← Finset.image_id (s := B)]
+      apply Finset.image_congr
+      intro x hx
+      simp only [Finset.mem_coe] at hx
+      simp only [Function.comp_apply, id_eq]
+      exact Nat.div_mul_cancel (hdvd x hx)
+    rw [hAB, hBrec]
 
 end Erdos153OQ03

--- a/src/data/research/problems/erdos-153-oq-03.json
+++ b/src/data/research/problems/erdos-153-oq-03.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-05",
-    "iteration": 5,
-    "focus": "Canonical-form reduction ADDED and BUILD-VERIFIED (Section X). Added the two inverse affine maps that were missing companions to Section V: isBhSet_sub (translation DOWN — A.image(·-m) is B_h whenever m ≤ every element, proved by lifting back through ·+m so the h·m shift cancels) and isBhSet_div (dilation DOWN — A.image(·/c) is B_h when c ≥ 1 divides every element, via lift-back through ·*c). Capstone isBhSet_translate_min_zero: every nonempty B_h set A equals (A.image(·-min A)).image(·+min A) where the down-translate is B_h and contains 0 — i.e. every B_h set is an affine translate of a min-0 normalized B_h set, so absolute position carries no B_h information. 0 sorry, 0 axiom. VERIFIED 2026-07-05: docker-build.sh Proofs.Erdos153OQ03 succeeded (7743 jobs); #print axioms on isBhSet_sub/isBhSet_div/isBhSet_translate_min_zero reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no ofReduceBool. Only the 4 pre-existing cosmetic linter warnings at lines 225/232 remain.",
+    "iteration": 6,
+    "focus": "Section XI PRIMITIVE NORMAL FORM added and BUILD-VERIFIED: isBhSet_primitive_normal_form proves every nonempty B_h set A with >=2 elements is the affine image b -> c*b+m of a PRIMITIVE B_h set C (0 in C, C.gcd id = 1), where m = min A and c = gcd of the differences {a-min A}. Composes isBhSet_translate_min_zero (min-0 form, Section X) with isBhSet_div at c (Section X down-dilation) and strips the common scale via Finset.gcd_div_id_eq_one (valid on ℕ since ℕ is MulDivCancelClass) + Finset.gcd_eq_gcd_image transport. 0 sorry, 0 axiom. VERIFIED 2026-07-05: `lake build Proofs.Erdos153OQ03` exit 0 (7743 jobs); `#print axioms Erdos153OQ03.isBhSet_primitive_normal_form` = [propext, Classical.choice, Quot.sound] only (no sorryAx, no ofReduceBool). Completes the normalization program (nextStep #4): B_h reduces to primitive representatives.",
     "blockers": [],
-    "nextAction": "Complete the canonical form: add the gcd normalization (dilate A by 1/gcd of its differences via isBhSet_div to reach gcd 1), giving the full affine-normal representative (min 0, gcd 1) for A.card ≥ 2. Then the genuinely OPEN frontier: the gap-variance statement for B_h (h ≥ 3) via the Sidon reduction + density bound — unsolved, needs a new idea, not more infrastructure.",
+    "nextAction": "Normalization program complete (min-0 in Section X, primitive/gcd-1 in Section XI). Remaining genuine frontier: the gap-variance statement itself via isSidon_of_isBhSet reduction + choose_le_of_isBhSet density bound (open, hard).",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 1,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: canonical translation form + downward affine inverses added and build-verified (Section X, 0-axiom); B_h invariance toolkit now complete both directions. Gap-variance conjecture (h≥3) still OPEN.",
+    "progressSummary": "PROGRESS: affine invariance (up+down) + sharp counting identity + closed-form binomial density bound + saturation characterization + min-0 canonical form + now the PRIMITIVE NORMAL FORM (isBhSet_primitive_normal_form: every |A|>=2 B_h set is affine image c·C+m of a primitive gcd-1 min-0 B_h set C) — all machine-verified (Erdos153OQ03.lean, 27 thm + 3 def, 0 sorry/0 axiom/0 native_decide). Normalization program COMPLETE. Gap-variance conjecture itself remains OPEN.",
     "builtItems": [
       "IsBhSet def (Erdos153OQ03.lean)",
       "isBhSet_one: every set is B₁",
@@ -49,7 +49,8 @@
       "isBhSet_iff_card_hSumset: SATURATION CHARACTERIZATION — IsBhSet h A ↔ (hSumset h A).card = (A.sym h).card (Erdos153OQ03.lean §VIII, 0 sorry/axiom, VERIFIED). Converse of card_hSumset_of_isBhSet via Finset.injOn_of_card_image_eq; B_h sets are EXACTLY those whose h-fold sumset saturates the pigeonhole max.",
       "isBhSet_sub in Erdos153OQ03.lean:~700 — translation-down invariance A.image(·-m) is B_h for m ≤ A (converse of isBhSet_add), 0-axiom",
       "isBhSet_div in Erdos153OQ03.lean:~740 — dilation-down invariance A.image(·/c) is B_h for c≥1, c∣A (converse of isBhSet_smul), 0-axiom",
-      "isBhSet_translate_min_zero in Erdos153OQ03.lean:~775 — canonical translation form: nonempty B_h A = (A.image(·-min A)).image(·+min A), down-translate is B_h and contains 0, 0-axiom"
+      "isBhSet_translate_min_zero in Erdos153OQ03.lean:~775 — canonical translation form: nonempty B_h A = (A.image(·-min A)).image(·+min A), down-translate is B_h and contains 0, 0-axiom",
+      "isBhSet_primitive_normal_form: PRIMITIVE NORMAL FORM (Section XI) — every nonempty B_h set A with |A|>=2 equals (C.image (·*c)).image (·+m) for a primitive B_h set C (0 in C, C.gcd id = 1), c = gcd of differences, m = min A (Erdos153OQ03.lean, 0 sorry/axiom, VERIFIED). Capstone of the normalization program: composes isBhSet_translate_min_zero (min-0) with isBhSet_div (gcd contraction)."
     ],
     "insights": [
       "A B_h set (h-fold sums distinct) is cleanly encoded as: Multiset.sum injective on size-h multisets drawn from A. Avoids ordered-tuple/reindexing friction.",
@@ -62,7 +63,8 @@
       "B_h ⟺ h-fold-sumset saturation is now a full iff (isBhSet_iff_card_hSumset): forward = Finset.card_image_of_injOn, backward = Finset.injOn_of_card_image_eq. Parallels the h=2 Sidon 'maximal sumset' characterization.",
       "Section V only supplied the UPWARD affine maps (isBhSet_smul, isBhSet_add); the downward inverses are needed to turn affine-invariance into a canonical-form REDUCTION. Both inverses follow the same lift-back template as the forward maps.",
       "Translation-down needs m ≤ every element (m = min A) so that truncated ℕ-subtraction is exact and ·+m recovers A; dilation-down needs c ∣ every element so ℕ-division is exact and ·*c recovers A.",
-      "Canonical form: every nonempty B_h set is the affine translate B + min A of a min-0 B_h set B — position is inessential to B_h-ness (the geometric refinement of affine invariance from a symmetry into a normal-form theorem)."
+      "Canonical form: every nonempty B_h set is the affine translate B + min A of a min-0 B_h set B — position is inessential to B_h-ness (the geometric refinement of affine invariance from a symmetry into a normal-form theorem).",
+      "Primitive normal form: after translating a B_h set to min 0 (Section X), the gcd g of its elements divides all of them, so dividing by g (isBhSet_div) yields a primitive B_h representative with gcd 1. The gcd-1 step is exactly Finset.gcd_div_id_eq_one, applicable over ℕ because ℕ has a MulDivCancelClass instance; transporting gcd across .image uses Finset.gcd_eq_gcd_image. Every B_h set is thus an affine image c·C+m of a primitive one — position AND common scale carry no B_h information."
     ],
     "mathlibGaps": [
       "No dedicated B_h / Sidon-of-order-h API in Mathlib; multiset-sum-injectivity encoding is self-sufficient.",
@@ -94,15 +96,15 @@
     "mathlib": []
   },
   "started": "2026-07-04T21:35:19.650Z",
-  "lastUpdate": "2026-07-04",
+  "lastUpdate": "2026-07-05",
   "significance": 5,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos153OQ03.lean",
       "filename": "Erdos153OQ03.lean",
-      "lineCount": 795,
-      "theoremCount": 26,
+      "lineCount": 878,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

**Section XI** of `Erdos153OQ03.lean`: `isBhSet_primitive_normal_form`, the capstone of the `B_h` normalization program.

Every nonempty `B_h` set `A` with **at least two elements** is the affine image `b ↦ c · b + m` of a **primitive** `B_h` set `C` — one that contains `0` and whose elements have `gcd = 1` — where `m = min A` and `c = gcd {a − min A : a ∈ A}` (the gcd of the differences).

```lean
theorem isBhSet_primitive_normal_form {h : ℕ} {A : Finset ℕ} (hA : A.Nonempty)
    (hcard : 1 < A.card) (H : IsBhSet h A) :
    ∃ (c m : ℕ) (C : Finset ℕ),
      0 < c ∧ IsBhSet h C ∧ (0 : ℕ) ∈ C ∧ C.gcd id = 1 ∧
      A = (C.image (fun b => b * c)).image (fun b => b + m)
```

### Why this closes the program

- **Section X** (`isBhSet_translate_min_zero`) reduced every `B_h` set to an upward translate of a `B_h` set anchored at `0` — stripping *absolute position*.
- **Section XI** composes that min-0 form with the downward dilation `isBhSet_div` at the gcd `c`, additionally stripping the *common scale*. What remains is a primitive representative (`0 ∈ C`, `gcd C = 1`).

So absolute position **and** common scale carry no `B_h` information: the study of `B_h` sets reduces to primitive ones. This is `nextStep #4` ("normalization corollary — min 0 and gcd of differences 1").

### Key lemmas used

- `isBhSet_translate_min_zero`, `isBhSet_div` (this file, Section X).
- `Finset.gcd_div_id_eq_one` — dividing a finset by its own gcd yields gcd 1; valid on `ℕ` because `ℕ` is a `MulDivCancelClass` (`instMulDivCancelClass`).
- `Finset.gcd_eq_gcd_image` — transports `gcd` across `.image`: `(B.image (·/c)).gcd id = B.gcd (·/c)`.

The hypothesis `1 < A.card` is exactly what makes the gcd `c` positive (a singleton has gcd-of-differences `0`, i.e. no scale to strip).

## Verification

- **0 sorry, 0 axiom.**
- Build-verified: `./proofs/scripts/docker-build.sh Proofs.Erdos153OQ03` → exit 0 (**7743 jobs**).
- `#print axioms Erdos153OQ03.isBhSet_primitive_normal_form` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.
- Only pre-existing cosmetic linter warnings (lines 229/236, unrelated to this change).

## Scope

This does **not** resolve the open gap-variance conjecture for `B_h` sets — it completes the structural/normalization infrastructure. The genuine frontier remains the gap-variance statement via the Sidon reduction (`isSidon_of_isBhSet`) + the density bound (`choose_le_of_isBhSet`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)