### PR TITLE
Enrich Mersenne Prime Exponents Are Prime: add annotations

### DIFF
--- a/src/data/proofs/mersenne-prime-exponent/annotations.json
+++ b/src/data/proofs/mersenne-prime-exponent/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "mersenne-prime-exponent",
+    "range": { "startLine": 5, "endLine": 47 },
+    "type": "context",
+    "title": "The necessary condition on Mersenne exponents",
+    "content": "The docstring frames the classical result: if the Mersenne number 2^n − 1 is prime then n itself is prime. This is the condition that lets the Lucas–Lehmer test restrict its search to prime exponents. The converse fails — 2^11 − 1 = 2047 = 23·89 — so primality of the exponent is necessary but not sufficient. The proof is a contrapositive: a composite exponent produces a nontrivial factorization of the Mersenne number.",
+    "mathContext": "$2^n - 1 \\text{ prime} \\Rightarrow n \\text{ prime}$. Converse false: $2^{11} - 1 = 2047 = 23 \\cdot 89$.",
+    "significance": "context",
+    "relatedConcepts": ["Mersenne primes", "Lucas–Lehmer test", "contrapositive", "necessary vs sufficient conditions"],
+    "prerequisites": ["primality", "divisibility", "geometric series factorization"]
+  },
+  {
+    "id": "ann-n-ge-2",
+    "proofId": "mersenne-prime-exponent",
+    "range": { "startLine": 55, "endLine": 61 },
+    "type": "technique",
+    "title": "A prime Mersenne number forces n ≥ 2",
+    "content": "The proof opens by contradiction (by_contra hn), assuming 2^n − 1 is prime but n is not. The first step disposes of the degenerate exponents: 2^0 − 1 = 0 and 2^1 − 1 = 1 are both non-prime (norm_num refutes hp directly), so a prime Mersenne number forces n ≥ 2. The match on n handles 0, 1, and k+2 uniformly, closing the small cases before the main divisibility argument.",
+    "mathContext": "$2^0 - 1 = 0$ and $2^1 - 1 = 1$ are not prime, so $2^n - 1$ prime $\\Rightarrow n \\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["degenerate cases", "norm_num", "case match on ℕ"],
+    "prerequisites": ["definition of Nat.Prime", "proof by contradiction"]
+  },
+  {
+    "id": "ann-divisor-lift",
+    "proofId": "mersenne-prime-exponent",
+    "range": { "startLine": 62, "endLine": 65 },
+    "type": "insight",
+    "title": "Exponent divisibility lifts to Mersenne divisibility",
+    "content": "The heart of the argument. A composite n ≥ 2 has a nontrivial divisor 2 ≤ d < n (Nat.exists_dvd_of_not_prime2). The key lifting fact is d ∣ n ⇒ 2^d − 1 ∣ 2^n − 1 (Nat.pow_sub_one_dvd_pow_sub_one), itself a corollary of the geometric-series factorization x − y ∣ x^m − y^m. So a factorization of the exponent produces a factorization of the Mersenne number.",
+    "mathContext": "$d \\mid n \\Rightarrow 2^d - 1 \\mid 2^n - 1$, from $x - y \\mid x^m - y^m$ with $x = 2^d$, $y = 1$, $m = n/d$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.pow_sub_one_dvd_pow_sub_one", "Nat.exists_dvd_of_not_prime2", "geometric sum", "GeomSum"],
+    "prerequisites": ["divisibility of powers", "existence of nontrivial divisors of composites"]
+  },
+  {
+    "id": "ann-contradiction",
+    "proofId": "mersenne-prime-exponent",
+    "range": { "startLine": 66, "endLine": 78 },
+    "type": "technique",
+    "title": "Closing both escape hatches via injectivity of d ↦ 2^d",
+    "content": "Primality of 2^n − 1 says its divisor 2^d − 1 is either 1 or 2^n − 1 (hp.eq_one_or_self_of_dvd). Both are impossible. The 2^d − 1 = 1 branch fails because d ≥ 2 gives 2^d ≥ 4 (Nat.pow_le_pow_right), so omega. The 2^d − 1 = 2^n − 1 branch forces 2^d = 2^n, and injectivity of d ↦ 2^d (Nat.pow_right_injective) gives d = n, contradicting d < n. The proper-divisor gap 1 < 2^d − 1 < 2^n − 1 is what a prime cannot have.",
+    "mathContext": "$2^d - 1 = 1 \\Rightarrow d < 2$ (false); $2^d - 1 = 2^n - 1 \\Rightarrow 2^d = 2^n \\Rightarrow d = n$ (false since $d < n$).",
+    "significance": "key",
+    "relatedConcepts": ["Nat.pow_right_injective", "Nat.Prime.eq_one_or_self_of_dvd", "proper divisor", "omega"],
+    "prerequisites": ["injectivity of exponentiation", "primality's divisor characterization"]
+  },
+  {
+    "id": "ann-restatements",
+    "proofId": "mersenne-prime-exponent",
+    "range": { "startLine": 80, "endLine": 91 },
+    "type": "concept",
+    "title": "Restatements and the search-pruning contrapositive",
+    "content": "Two convenience wrappers. mersenne_exponent_prime restates the result with the explicit 2^n − 1 phrasing used elsewhere in the gallery. not_prime_mersenne_of_not_prime gives the direct contrapositive — a composite exponent yields a composite Mersenne number — which is the form used to prune the Lucas–Lehmer search space. All three are 0 sorries, 0 axioms beyond Mathlib's foundations.",
+    "mathContext": "$\\neg\\,\\mathrm{Prime}(n) \\Rightarrow \\neg\\,\\mathrm{Prime}(2^n - 1)$, the search-pruning form.",
+    "significance": "supporting",
+    "relatedConcepts": ["contrapositive", "Lucas–Lehmer search pruning", "API restatement"],
+    "prerequisites": ["the main theorem", "logical contrapositive"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `mersenne-prime-exponent` ("Mersenne Prime Exponents Are Prime").

**Gap:** rich `meta.json` but **no `annotations.json`** (quality 41, passes 0). This adds inline annotation coverage of the full 91-line Lean file.

**Added — `annotations.json` (5 annotations):**
- The necessary condition and its role in Lucas–Lehmer (converse fails: 2^11 − 1 = 2047)
- Forcing `n ≥ 2` from the degenerate exponents
- The core lift: `d ∣ n ⇒ 2^d − 1 ∣ 2^n − 1` (geometric-series factorization)
- Closing both escape hatches via injectivity of `d ↦ 2^d`
- The restatements and the search-pruning contrapositive

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. No `meta.json` changes; `pnpm build` passes.
