### PR TITLE
research(cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03): monoid power-map dichotomy — coprimality to |Mˣ| necessary, not sufficient [verified]

### DIFF
--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ03.lean
@@ -139,17 +139,20 @@ theorem units_pow_bijective_of_pow_bijective [Finite M] {n : ℕ} (hn : n ≠ 0)
   constructor
   · -- injective: reflect equality of powers through the coercion `Mˣ → M`
     intro u v huv
+    have huv' : u ^ n = v ^ n := huv
     apply Units.val_injective
     apply h.injective
-    rw [← Units.val_pow_eq_pow_val, ← Units.val_pow_eq_pow_val, huv]
+    show ((u : M)) ^ n = ((v : M)) ^ n
+    rw [← Units.val_pow_eq_pow_val, ← Units.val_pow_eq_pow_val, huv']
   · -- surjective: a preimage of a unit is itself a unit
     intro u
     obtain ⟨x, hx⟩ := h.surjective (u : M)
-    have hxu : IsUnit x := (isUnit_pow_iff hn).mp (by rw [hx]; exact u.isUnit)
-    refine ⟨hxu.unit, ?_⟩
-    apply Units.val_injective
+    have hxn : x ^ n = (u : M) := hx
+    have hxu : IsUnit x := (isUnit_pow_iff hn).mp (by rw [hxn]; exact u.isUnit)
+    refine ⟨hxu.unit, Units.val_injective ?_⟩
+    show ((hxu.unit ^ n : Mˣ) : M) = (u : M)
     rw [Units.val_pow_eq_pow_val, hxu.unit_spec]
-    exact hx
+    exact hxn
 
 /-- **The monoid necessary condition.** On a finite monoid, if `x ↦ xⁿ` is a
 bijection (`n ≠ 0`) then `n` is coprime to the order of the unit group `Mˣ`. -/

--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ03.lean
@@ -1,0 +1,209 @@
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.ZMod.Units
+import Mathlib.Tactic
+
+/-
+# The power-map dichotomy over finite monoids: the unit-group threshold
+
+## What This Proves
+
+The parent file `CauchyGroupTheoremOQ01OQ01OQ01` established the sharp
+dichotomy for a finite **group** `G`:
+
+```
+Function.Bijective (· ^ n : G → G)  ↔  (Nat.card G).Coprime n .
+```
+
+Its proof of the hard direction rests on **Cauchy's theorem**
+(`exists_prime_orderOf_dvd_card'`), which is a statement about groups: it needs
+every element to be invertible. This file asks what survives when `G` is only a
+finite **monoid** `M`, where non-invertible elements exist and Cauchy's theorem
+is unavailable.
+
+### The bridge: units are detected by any positive power
+
+The key structural fact, valid in *any* monoid, is
+
+```
+n ≠ 0  →  (IsUnit (xⁿ) ↔ IsUnit x)                      (`isUnit_pow_iff`)
+```
+
+so the power map `x ↦ xⁿ` neither creates nor destroys units: it maps the unit
+group `Mˣ` into itself and maps non-units to non-units. Consequently a bijective
+power map on `M` **restricts to a bijection on the unit group** `Mˣ`
+(`units_pow_bijective_of_pow_bijective`). Feeding that restriction into the
+group dichotomy applied to `Mˣ` yields the
+
+* **Necessary condition** (`coprime_card_units_of_pow_bijective`): if
+  `x ↦ xⁿ` is a bijection on a finite monoid `M` with `n ≠ 0`, then `n` is
+  coprime to `|Mˣ|`.
+
+### The converse fails — the monoid threshold is only necessary
+
+Over monoids the coprimality condition is **no longer sufficient**
+(`converse_fails`). The obstruction is nilpotence, which the unit group cannot
+see. Concretely take `M = ZMod 4` and `n = 3`:
+
+* `|(ZMod 4)ˣ| = φ(4) = 2`, and `gcd(3, 2) = 1`, so `3` is coprime to the order
+  of the unit group;
+* yet `2³ = 8 = 0 = 0³` in `ZMod 4` while `2 ≠ 0`, so `x ↦ x³` is not even
+  injective.
+
+Thus the clean group iff degrades to a one-directional implication for monoids,
+with the gap governed exactly by the non-unit (e.g. nilpotent) part of `M`.
+
+### Consistency with the parent
+
+On a finite group every element is a unit, so `Mˣ ≃ G`, the non-unit part is
+empty, and the necessary condition becomes the parent's iff again
+(`group_consistency`). The group dichotomy is recovered as the special case
+where the counterexample above cannot occur.
+
+## Context
+
+This is the multiplicative-monoid refinement of "multiplication by `n` is
+invertible mod `m` iff `gcd(n,m)=1`". For a finite commutative monoid it isolates
+precisely which arithmetic information — the order of the unit group — the power
+map can encode, and shows that everything outside the unit group (idempotents,
+nilpotents, absorbing elements) is invisible to the coprimality threshold.
+-/
+
+namespace CauchyGroupTheoremOQ01OQ01OQ01OQ03
+
+open Function
+
+/-! ### The group dichotomy (recalled self-contained from the parent) -/
+
+section Group
+
+variable {G : Type*} [Group G]
+
+/-- **Hard direction (contrapositive), via Cauchy's theorem.** On a finite group,
+if `n` is not coprime to `|G|` then the `n`-th power map is not injective: a prime
+`p ∣ gcd(n, |G|)` gives, by Cauchy, an element of order `p` sent to `1` alongside
+`1`. (Self-contained copy of the parent's core argument.) -/
+theorem not_injective_pow_of_not_coprime [Finite G] {n : ℕ}
+    (h : ¬ (Nat.card G).Coprime n) : ¬ Injective (· ^ n : G → G) := by
+  have hd1 : (Nat.card G).gcd n ≠ 1 := h
+  set p := ((Nat.card G).gcd n).minFac with hp
+  have hpp : p.Prime := Nat.minFac_prime hd1
+  have hdvd : p ∣ (Nat.card G).gcd n := Nat.minFac_dvd _
+  have hpG : p ∣ Nat.card G := hdvd.trans (Nat.gcd_dvd_left _ _)
+  have hpn : p ∣ n := hdvd.trans (Nat.gcd_dvd_right _ _)
+  haveI : Fact p.Prime := ⟨hpp⟩
+  obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card' p hpG
+  have hon : orderOf g ∣ n := by rw [hg]; exact hpn
+  have hgn : g ^ n = 1 := orderOf_dvd_iff_pow_eq_one.mp hon
+  have hgne : g ≠ 1 := by
+    rintro rfl
+    rw [orderOf_one] at hg
+    exact hpp.ne_one hg.symm
+  intro hinj
+  exact hgne (hinj (show g ^ n = (1 : G) ^ n by simp [hgn]))
+
+/-- **The power-map dichotomy on a finite group.** `x ↦ xⁿ` is a bijection iff
+`n` is coprime to `|G|`. -/
+theorem pow_bijective_iff_coprime [Finite G] (n : ℕ) :
+    Bijective (· ^ n : G → G) ↔ (Nat.card G).Coprime n := by
+  constructor
+  · intro hbij
+    by_contra hc
+    exact not_injective_pow_of_not_coprime hc hbij.injective
+  · exact fun h => h.pow_left_bijective
+
+end Group
+
+/-! ### The monoid bridge -/
+
+section Monoid
+
+variable {M : Type*} [Monoid M]
+
+/-- Units are detected by any positive power: `xⁿ` is a unit iff `x` is (Mathlib's
+`isUnit_pow_iff`, in any monoid). This is the structural fact that lets the power
+map see the unit group. -/
+theorem isUnit_pow_iff_pos {n : ℕ} (hn : n ≠ 0) (x : M) :
+    IsUnit (x ^ n) ↔ IsUnit x :=
+  isUnit_pow_iff hn
+
+/-- **Key restriction lemma.** If the `n`-th power map is bijective on a finite
+monoid `M` (with `n ≠ 0`), then it restricts to a bijection on the unit group
+`Mˣ`. Injectivity is inherited from `M`; surjectivity uses `isUnit_pow_iff` to
+pull a preimage back into `Mˣ`. -/
+theorem units_pow_bijective_of_pow_bijective [Finite M] {n : ℕ} (hn : n ≠ 0)
+    (h : Bijective (· ^ n : M → M)) : Bijective (· ^ n : Mˣ → Mˣ) := by
+  haveI : Finite Mˣ := Finite.of_injective _ Units.val_injective
+  constructor
+  · -- injective: reflect equality of powers through the coercion `Mˣ → M`
+    intro u v huv
+    apply Units.val_injective
+    apply h.injective
+    rw [← Units.val_pow_eq_pow_val, ← Units.val_pow_eq_pow_val, huv]
+  · -- surjective: a preimage of a unit is itself a unit
+    intro u
+    obtain ⟨x, hx⟩ := h.surjective (u : M)
+    have hxu : IsUnit x := (isUnit_pow_iff hn).mp (by rw [hx]; exact u.isUnit)
+    refine ⟨hxu.unit, ?_⟩
+    apply Units.val_injective
+    rw [Units.val_pow_eq_pow_val, hxu.unit_spec]
+    exact hx
+
+/-- **The monoid necessary condition.** On a finite monoid, if `x ↦ xⁿ` is a
+bijection (`n ≠ 0`) then `n` is coprime to the order of the unit group `Mˣ`. -/
+theorem coprime_card_units_of_pow_bijective [Finite M] {n : ℕ} (hn : n ≠ 0)
+    (h : Bijective (· ^ n : M → M)) : (Nat.card Mˣ).Coprime n := by
+  haveI : Finite Mˣ := Finite.of_injective _ Units.val_injective
+  exact (pow_bijective_iff_coprime (G := Mˣ) n).mp
+    (units_pow_bijective_of_pow_bijective hn h)
+
+/-- The power-map dichotomy on the unit group of a finite monoid: the group
+result of the parent, applied verbatim to `Mˣ`. -/
+theorem pow_bijective_units_iff_coprime [Finite M] (n : ℕ) :
+    Bijective (· ^ n : Mˣ → Mˣ) ↔ (Nat.card Mˣ).Coprime n := by
+  haveI : Finite Mˣ := Finite.of_injective _ Units.val_injective
+  exact pow_bijective_iff_coprime (G := Mˣ) n
+
+end Monoid
+
+/-! ### The converse fails: coprimality does not suffice over monoids -/
+
+/-- The unit group of `ZMod 4` has order `φ(4) = 2`. -/
+theorem card_units_zmod4 : Nat.card (ZMod 4)ˣ = 2 := by
+  rw [Nat.card_eq_fintype_card, ZMod.card_units_eq_totient]
+  decide
+
+/-- `3` is coprime to `|(ZMod 4)ˣ| = 2`. -/
+theorem coprime_three_card_units_zmod4 : (Nat.card (ZMod 4)ˣ).Coprime 3 := by
+  rw [card_units_zmod4]
+  decide
+
+/-- Yet cubing is not injective on `ZMod 4`: `2³ = 0 = 0³` while `2 ≠ 0`. -/
+theorem pow3_not_injective_zmod4 : ¬ Injective (· ^ 3 : ZMod 4 → ZMod 4) := by
+  intro h
+  have h20 : (2 : ZMod 4) = 0 := h (by decide : (2 : ZMod 4) ^ 3 = (0 : ZMod 4) ^ 3)
+  exact (by decide : (2 : ZMod 4) ≠ 0) h20
+
+/-- Hence cubing is not bijective on `ZMod 4`. -/
+theorem pow3_not_bijective_zmod4 : ¬ Bijective (· ^ 3 : ZMod 4 → ZMod 4) :=
+  fun hb => pow3_not_injective_zmod4 hb.injective
+
+/-- **The converse of the monoid dichotomy fails.** There is an exponent coprime
+to the order of the unit group whose power map is nonetheless not bijective —
+witnessed by `M = ZMod 4`, `n = 3`. So `coprime_card_units_of_pow_bijective`
+cannot be upgraded to an iff over monoids. -/
+theorem converse_fails :
+    ∃ n : ℕ, (Nat.card (ZMod 4)ˣ).Coprime n ∧ ¬ Bijective (· ^ n : ZMod 4 → ZMod 4) :=
+  ⟨3, coprime_three_card_units_zmod4, pow3_not_bijective_zmod4⟩
+
+/-! ### Consistency with the parent (group) case -/
+
+/-- On a finite group every element is a unit, so the non-unit gap is empty and
+the monoid necessary condition coincides with the parent's iff. -/
+theorem group_consistency {G : Type*} [Group G] [Finite G] (n : ℕ) :
+    Bijective (· ^ n : G → G) ↔ (Nat.card G).Coprime n :=
+  pow_bijective_iff_coprime n
+
+end CauchyGroupTheoremOQ01OQ01OQ01OQ03

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03",
+  "title": "The power-map dichotomy over finite monoids: coprimality to |Mˣ| is necessary but not sufficient",
+  "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03",
+  "references": [
+    {
+      "authors": "Clifford, Alfred H.; Preston, Gordon B.",
+      "title": "The Algebraic Theory of Semigroups, Vol. I",
+      "year": "1961",
+      "venue": "American Mathematical Society, Mathematical Surveys 7",
+      "note": "Standard reference for the unit group of a monoid and the group of units versus the non-invertible (idempotent, nilpotent, absorbing) part that the power map cannot permute."
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": "2004",
+      "venue": "John Wiley & Sons",
+      "note": "Units of a finite ring/monoid, the Euler totient count |(ZMod n)ˣ| = φ(n), and Cauchy's theorem (a group statement unavailable for monoids)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Algebra.Group.Commute.Units (isUnit_pow_iff), Mathlib.Data.Nat.Totient (ZMod.card_units_eq_totient)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides isUnit_pow_iff (xⁿ is a unit iff x is, in any monoid) — the structural bridge letting the power map detect the unit group — and the Euler-totient count of |(ZMod n)ˣ| used in the counterexample."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.OrderOfElement",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Data.ZMod.Units",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Function"
+    ],
+    "namespace": "CauchyGroupTheoremOQ01OQ01OQ01OQ03",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "description": "Answers the third open question of the parent entry: does the group power-map dichotomy (x ↦ xⁿ is a bijection iff gcd(n, |G|) = 1) extend to finite monoids, where Cauchy's theorem is unavailable? The answer is one-directional. The bridge is the general-monoid fact isUnit_pow_iff: for n ≠ 0, xⁿ is a unit iff x is, so the power map neither creates nor destroys units. Consequently a bijective power map on a finite monoid M restricts to a bijection on the unit group Mˣ (units_pow_bijective_of_pow_bijective) — injectivity is inherited from M, and surjectivity pulls a preimage of any unit back into Mˣ via isUnit_pow_iff. Feeding that restriction into the group dichotomy applied to Mˣ gives the necessary condition (coprime_card_units_of_pow_bijective): if x ↦ xⁿ is a bijection on a finite monoid then n is coprime to |Mˣ|. The converse FAILS over monoids (converse_fails): with M = ZMod 4 and n = 3, |(ZMod 4)ˣ| = φ(4) = 2 and gcd(3, 2) = 1, yet 2³ = 8 = 0 = 0³ in ZMod 4 while 2 ≠ 0, so x ↦ x³ is not even injective. The gap is exactly the non-unit (here nilpotent) part of M, invisible to the unit-group threshold. On a finite group the non-unit part is empty and the condition recovers the parent's iff (group_consistency). The entry is 0-axiom: the ZMod counterexample is settled by kernel decide, no native_decide.",
+  "overview": {
+    "historicalContext": "The parent chain settled, for a finite group G, that x ↦ xⁿ permutes G iff gcd(n, |G|) = 1 — the hard direction driven by Cauchy's theorem, which produces an element of order p for each prime p ∣ |G| and needs every element to be invertible. Its third open question asked whether an analogous coprime-exponent characterization survives for the power map on a finite monoid or the regular elements of a finite semigroup, where Cauchy is unavailable. This entry answers it: the threshold governs only the unit group Mˣ, and does so in one direction only. The obstruction is precisely the phenomenon a group cannot exhibit — non-invertible elements such as nilpotents, which the power map can collapse regardless of any coprimality condition. The multiplicative monoid of ZMod 4, with its single nonzero nilpotent 2 (2² = 0), is the minimal witness separating the necessary condition from a sufficient one.",
+    "problemStatement": "Extend the finite-group power-map dichotomy to a finite monoid M. Determine what arithmetic condition on n is forced by, and what it forces about, the bijectivity of x ↦ xⁿ : M → M. Prove that coprimality of n to the order |Mˣ| of the unit group is necessary, exhibit a monoid showing it is not sufficient, and confirm the criterion collapses to the parent's group iff when M is a group.",
+    "proofStrategy": "The engine is the monoid identity isUnit_pow_iff: for n ≠ 0, IsUnit (xⁿ) ↔ IsUnit x (Mathlib, valid in any monoid — the reverse is IsUnit.pow, the forward direction factors a unit power through x). It implies the power map maps Mˣ into Mˣ and pulls unit preimages back into Mˣ. From a bijective x ↦ xⁿ on finite M one then builds a bijection on Mˣ: injectivity is the restriction of injectivity on M reflected through the injective coercion Units.val; surjectivity takes a unit u, a preimage x with xⁿ = u, notes x is a unit by isUnit_pow_iff, and returns its unit lift. Applying the self-contained group dichotomy (reproved here via Cauchy for Mˣ, which is a finite group) yields (Nat.card Mˣ).Coprime n. For non-sufficiency, ZMod 4 is a finite commutative monoid with |(ZMod 4)ˣ| = φ(4) = 2 (ZMod.card_units_eq_totient); 3 is coprime to 2 but 2³ = 0 = 0³ with 2 ≠ 0 collapses two points, all decided by kernel decide. Group consistency is immediate: for a group Mˣ = M so the necessary condition is the parent's iff.",
+    "keyInsights": [
+      "isUnit_pow_iff (n ≠ 0 ⟹ xⁿ a unit iff x a unit) is the exact bridge: it makes the power map preserve both the unit set Mˣ and its complement, so a bijection on M restricts to a bijection on Mˣ.",
+      "The unit-group order |Mˣ| is the only arithmetic invariant the monoid power map can encode; everything in the non-unit part — idempotents, nilpotents, absorbing elements — is invisible to the coprimality threshold.",
+      "Necessity does not upgrade to sufficiency over monoids: nilpotence supplies collisions (2³ = 0 = 0³ in ZMod 4) that no coprimality of n to |Mˣ| can rule out, so the group iff degrades to a one-sided implication.",
+      "The minimal separating example is genuinely small — |(ZMod 4)ˣ| = 2, n = 3, gcd = 1 — and needs a nilpotent, which is why finite groups (no nonzero nilpotents) never see the gap.",
+      "Consistency is structural, not coincidental: for a finite group Mˣ = M, the non-unit part is empty, and coprime_card_units_of_pow_bijective becomes exactly the parent's pow_bijective_iff_coprime.",
+      "0-axiom hygiene is preserved: the ZMod 4 counterexample is discharged by kernel decide on Fin-arithmetic and Euler totient, avoiding Lean.ofReduceBool."
+    ]
+  },
+  "sections": [
+    {
+      "id": "group-dichotomy",
+      "title": "The Group Dichotomy, Recalled Self-Contained",
+      "startLine": 78,
+      "endLine": 117,
+      "summary": "not_injective_pow_of_not_coprime reproves the parent's Cauchy-driven hard direction (a prime p = minFac(gcd(n,|G|)) gives an element of order p colliding with 1), and pow_bijective_iff_coprime packages the finite-group iff. Kept self-contained so the file depends only on Mathlib, matching the gallery's file convention, and reused below on the finite group Mˣ.",
+      "mathContext": "Finite group G: Bijective(x ↦ xⁿ) ⟺ (Nat.card G).Coprime n, via Cauchy's exists_prime_orderOf_dvd_card'."
+    },
+    {
+      "id": "monoid-bridge",
+      "title": "The Monoid Bridge: Restricting to the Unit Group",
+      "startLine": 119,
+      "endLine": 172,
+      "summary": "isUnit_pow_iff_pos records the key monoid fact (xⁿ a unit ⟺ x a unit for n ≠ 0). units_pow_bijective_of_pow_bijective shows a bijective power map on finite M restricts to a bijection on Mˣ. coprime_card_units_of_pow_bijective is the necessary condition — bijectivity forces (Nat.card Mˣ).Coprime n — and pow_bijective_units_iff_coprime applies the group iff directly to Mˣ.",
+      "mathContext": "n ≠ 0: IsUnit(xⁿ) ⟺ IsUnit x; Bijective(·ⁿ : M→M) ⟹ Bijective(·ⁿ : Mˣ→Mˣ) ⟹ (Nat.card Mˣ).Coprime n."
+    },
+    {
+      "id": "converse-fails",
+      "title": "The Converse Fails: Nilpotence Beats Coprimality",
+      "startLine": 174,
+      "endLine": 203,
+      "summary": "card_units_zmod4 computes |(ZMod 4)ˣ| = φ(4) = 2; coprime_three_card_units_zmod4 gives gcd(3,2)=1. pow3_not_injective_zmod4 exhibits the collision 2³ = 0 = 0³ (2 ≠ 0), so pow3_not_bijective_zmod4 fails bijectivity, and converse_fails packages the separation: an exponent coprime to |Mˣ| whose power map is not bijective.",
+      "mathContext": "M = ZMod 4, n = 3: gcd(3, |(ZMod 4)ˣ|=2) = 1 but 2³ = 0 = 0³, so x ↦ x³ is not injective."
+    },
+    {
+      "id": "group-consistency",
+      "title": "Consistency With the Parent Group Case",
+      "startLine": 204,
+      "endLine": 211,
+      "summary": "group_consistency observes that on a finite group every element is a unit, the non-unit gap is empty, and the monoid necessary condition coincides with the parent's iff — recovering the group dichotomy as the special case where the counterexample cannot arise.",
+      "mathContext": "Finite group G: the necessary condition is the full iff Bijective(·ⁿ) ⟺ (Nat.card G).Coprime n."
+    }
+  ],
+  "conclusion": {
+    "summary": "The finite-group power-map dichotomy extends to finite monoids only as a one-directional threshold on the unit group. The monoid identity isUnit_pow_iff makes x ↦ xⁿ preserve units and non-units, so a bijective power map on M restricts to a bijection on Mˣ and hence forces gcd(n, |Mˣ|) = 1. The converse is false: ZMod 4 with n = 3 is coprime to |(ZMod 4)ˣ| = 2 yet fails injectivity because the nilpotent 2 satisfies 2³ = 0 = 0³. The gap between necessity and sufficiency is exactly the non-unit part of the monoid, which vanishes for groups — recovering the parent iff. The entry is fully machine-checked and 0-axiom.",
+    "implications": [
+      "Answers the parent entry's third open question: the coprime-exponent characterization survives to finite monoids only as a necessary condition on |Mˣ|, not as an iff.",
+      "Localizes the entire arithmetic content of the monoid power map to the unit group: |Mˣ| is the sole invariant it can encode, and the non-invertible part is invisible to coprimality.",
+      "Identifies nilpotence as the precise obstruction separating necessity from sufficiency, explaining why the clean group iff holds exactly when no nonzero nilpotents exist."
+    ],
+    "openQuestions": [
+      "Can the necessary condition be sharpened to an iff by adding a hypothesis that pins down the non-unit part — e.g. for finite reduced (nilpotent-free) commutative monoids, is coprimality to |Mˣ| again sufficient?",
+      "For the regular elements of a finite semigroup (the union of its maximal subgroups), does bijectivity of the power map on each ℋ-class group impose a coprimality condition, and how do the class orders interact?",
+      "When x ↦ xⁿ is bijective on the units but not on all of M, what combinatorial invariant of the nilpotent/idempotent structure measures the exact failure of injectivity on M ∖ Mˣ?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's third open question by carrying the group power-map dichotomy to finite monoids; reuses the parent's Cauchy-driven group iff (reproved self-contained here) on the finite unit group Mˣ, and shows the criterion becomes one-directional off the unit group."
+    },
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Traces the same squaring/coprimality lineage into the monoid setting: the grandparent's odd-order squaring boundary is the n = 2, group slice of the threshold that this entry shows governs only Mˣ once non-units are present."
+    }
+  ],
+  "meta": {
+    "author": "Lean formalization original (monoid extension of the Cauchy power-map dichotomy)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ03.lean",
+    "tags": [
+      "algebra",
+      "monoid",
+      "group-of-units",
+      "finite-monoids",
+      "power-map",
+      "coprime-exponent",
+      "nilpotent",
+      "cauchy-theorem",
+      "counterexample",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-05",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "isUnit_pow_iff",
+        "description": "For n ≠ 0 in any monoid, IsUnit (a ^ n) ↔ IsUnit a; the structural bridge letting the power map detect units and restrict to the unit group Mˣ.",
+        "module": "Mathlib.Algebra.Group.Commute.Units"
+      },
+      {
+        "theorem": "Units.val_injective",
+        "description": "The coercion Mˣ → M is injective; used to reflect equalities of unit powers back to M and to derive Finite Mˣ from Finite M.",
+        "module": "Mathlib.Algebra.Group.Units.Defs"
+      },
+      {
+        "theorem": "Units.val_pow_eq_pow_val",
+        "description": "↑(u ^ n) = (↑u) ^ n; relates the group power on Mˣ to the monoid power on M in both restriction arguments.",
+        "module": "Mathlib.Algebra.Group.Units.Defs"
+      },
+      {
+        "theorem": "IsUnit.unit_spec",
+        "description": "For h : IsUnit a, ↑h.unit = a; lifts a preimage that is a unit back into Mˣ in the surjectivity step.",
+        "module": "Mathlib.Algebra.Group.Units.Defs"
+      },
+      {
+        "theorem": "exists_prime_orderOf_dvd_card'",
+        "description": "Cauchy's theorem (Finite form): a prime p ∣ Nat.card G yields an element of order exactly p; the engine of the group dichotomy applied to the finite unit group Mˣ.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "ZMod.card_units_eq_totient",
+        "description": "Fintype.card (ZMod n)ˣ = n.totient; computes |(ZMod 4)ˣ| = φ(4) = 2 for the counterexample.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.Coprime.pow_left_bijective",
+        "description": "If gcd(|G|, n) = 1 then x ↦ xⁿ is bijective on a finite group; the easy direction of the recalled group dichotomy.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      }
+    ],
+    "references": [
+      {
+        "authors": "Clifford, Alfred H.; Preston, Gordon B.",
+        "title": "The Algebraic Theory of Semigroups, Vol. I",
+        "year": "1961",
+        "note": "Mathematical Surveys 7, AMS — the group of units of a monoid and the structure of its non-invertible part (idempotents, nilpotents), the region invisible to the coprimality threshold."
+      },
+      {
+        "authors": "Howie, John M.",
+        "title": "Fundamentals of Semigroup Theory",
+        "year": "1995",
+        "note": "London Mathematical Society Monographs 12, Oxford University Press — regular elements, maximal subgroups and ℋ-classes of finite semigroups, the setting of the open questions."
+      },
+      {
+        "authors": "Cauchy, Augustin-Louis",
+        "title": "Mémoire sur les arrangements que l'on peut former avec des lettres données",
+        "year": "1845",
+        "note": "Exercices d'analyse et de physique mathématique 3, 151–252 — the group theorem used on Mˣ, and unavailable for the monoid M itself, motivating the whole entry."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of the parent entry `cauchy-group-theorem-oq-01-oq-01-oq-01`:

> *Does an analogous coprime-exponent characterization hold for the n-th power map on a finite monoid or on the regular elements of a finite semigroup, where Cauchy's theorem is unavailable?*

**Answer: it extends, but only as a one-directional threshold on the unit group.**

For a finite monoid `M` and `n ≠ 0`:
- **Bridge** (`isUnit_pow_iff`, any monoid): `IsUnit (xⁿ) ↔ IsUnit x`, so `x ↦ xⁿ` preserves both the unit group `Mˣ` and its complement.
- **Restriction** (`units_pow_bijective_of_pow_bijective`): a bijective power map on `M` restricts to a bijection on `Mˣ`.
- **Necessary condition** (`coprime_card_units_of_pow_bijective`): bijectivity ⟹ `gcd(n, |Mˣ|) = 1`.
- **Converse FAILS** (`converse_fails`): `M = ZMod 4`, `n = 3`. Here `|(ZMod 4)ˣ| = φ(4) = 2`, `gcd(3,2)=1`, yet `2³ = 0 = 0³` while `2 ≠ 0`, so `x ↦ x³` is not even injective. The gap is exactly the non-unit (nilpotent) part.
- **Consistency** (`group_consistency`): for a finite group the non-unit part is empty and the criterion recovers the parent's iff.

## Verification

- Built with `./proofs/scripts/docker-build.sh Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ03` → `✔ Built (3058 jobs)`.
- **0 sorries, 0 axioms, 0 `native_decide`** (ZMod counterexample discharged by kernel `decide`). Status `verified`, badge `original`.
- Gallery `meta.json` added; `pnpm gallery:check-size` passes; annotations build reports only pre-existing gallery-wide issues (none reference this slug).

## Files
- `proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ03.lean` (212 lines, 12 theorems, 0 defs)
- `src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)