### PR TITLE
Enrich Faulhaber Fifth-Power Sum: add 5th annotation (sanity checks)

### DIFF
--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-04/annotations.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-04/annotations.json
@@ -74,5 +74,27 @@
       "Faulhaber's formula",
       "Bernoulli numbers"
     ]
+  },
+  {
+    "id": "ann-sanity-checks",
+    "proofId": "nicomachus-sum-of-cubes-oq-04",
+    "range": {
+      "startLine": 109,
+      "endLine": 113
+    },
+    "type": "context",
+    "title": "Concrete sanity checks by decide",
+    "content": "Two closed-universe verifications pin the abstract identity to concrete arithmetic. The first checks the raw sum $\\sum_{k\\le 3} k^5 = 1 + 32 + 243 = 276$; the second checks the factored $\\mathbb{Z}$ form at the same point, $12\\cdot\\sum_{k\\le 3} k^5 = 9\\cdot 16\\cdot 23 = 3312$. Both are discharged by `decide`, which evaluates the finite `range 4` sum kernel-side — no `native_decide`, so the proofs stay axiom-free (they rest only on `propext`/`Classical.choice`/`Quot.sound`, not `Lean.ofReduceBool`). These guard against an off-by-one in the indexing or a sign error in $2n^2+2n-1$: at $n=3$ the factor is $2\\cdot 9 + 6 - 1 = 23$, matching $276\\cdot 12 = 3312$.",
+    "mathContext": "$\\sum_{k\\le 3} k^5 = 276$ and $12\\cdot 276 = 9\\cdot 16\\cdot 23 = 3312$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide tactic",
+      "kernel reduction",
+      "regression testing of identities"
+    ],
+    "prerequisites": [
+      "Finite Finset.sum evaluation",
+      "Decidable equality on ℕ"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `nicomachus-sum-of-cubes-oq-04` ("Faulhaber's Fifth-Power Sum").

**Gap:** the entry had 4 annotations — one short of the 5-annotation quality minimum — with the concrete sanity-checks section (lines 109–113) uncovered.

**Added — a 5th annotation (`ann-sanity-checks`):**
- Covers the two `decide`-based checks: `∑_{k≤3} k⁵ = 276` and `12·∑ = 9·16·23 = 3312`
- Notes these use `decide` (not `native_decide`), so the entry stays axiom-free
- Explains their role as regression guards against indexing/sign errors in `2n²+2n−1`
- Carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`

No `meta.json` changes; schema validated by `pnpm build`. Reaches the 5-annotation minimum; the entry was already otherwise rich (4 keyInsights, 4 sections, conclusion, 4 crossRefs).
