### PR TITLE
research(hurwitz-theorem-oq-03-oq-01-wip-01): quaternion-generation keystone for Frobenius Step 3 [VERIFIED]

### DIFF
--- a/proofs/Proofs/HurwitzOnlyIf.lean
+++ b/proofs/Proofs/HurwitzOnlyIf.lean
@@ -663,6 +663,64 @@ theorem imaginaryBilin_self_eq_zero_iff (A : Type*) [NormedDivisionRing A] [Norm
         _ = 0 := realPartValue_smul_one A 0
     linarith
 
+/-! ### Quaternion generation: products of anticommuting imaginaries
+
+The dimension count `finrank ℝ (Im A) ∈ {0, 1, 3}` that closes Frobenius' theorem runs on the
+following structural mechanism.  Choose orthonormal imaginary units `e₁, …, eₘ` for the
+positive-definite form `B` (`imaginaryBilin`).  Orthogonality `B(eᵢ, eⱼ) = 0` is exactly
+anticommutation `eᵢeⱼ + eⱼeᵢ = 0`, and the two lemmas below show that the product `eᵢeⱼ` is
+*again* an imaginary element that anticommutes with both factors — a fresh imaginary unit.
+Starting from two anticommuting units `i, j` this manufactures a third `k := i*j`, closing a
+quaternion triple `⟨i, j, k⟩` inside `A`; associativity then prevents a *fourth* independent
+unit, pinning `finrank ℝ (Im A) ≤ 3`. -/
+
+/-- **Anticommutation propagates to products.** If `x` and `y` anticommute
+(`x*y + y*x = 0`) then `x` anticommutes with their product `x*y` as well:
+`x*(x*y) + (x*y)*x = 0`.  Purely associative — no imaginary or division hypothesis is used;
+`(x*y)*x = x*(y*x) = -x*(x*y)`. -/
+theorem mul_anticomm_left (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    {x y : A} (hac : x * y + y * x = 0) : x * (x * y) + (x * y) * x = 0 := by
+  have hyx : y * x = -(x * y) := eq_neg_of_add_eq_zero_right hac
+  calc x * (x * y) + (x * y) * x = x * x * y + x * (y * x) := by noncomm_ring
+    _ = x * x * y + x * (-(x * y)) := by rw [hyx]
+    _ = 0 := by noncomm_ring
+
+/-- **Anticommutation propagates to products (right factor).** Symmetric companion of
+`mul_anticomm_left`: if `x*y + y*x = 0` then `y` anticommutes with `x*y`,
+`y*(x*y) + (x*y)*y = 0`.  Here `y*(x*y) = (y*x)*y = -(x*y)*y`. -/
+theorem mul_anticomm_right (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    {x y : A} (hac : x * y + y * x = 0) : y * (x * y) + (x * y) * y = 0 := by
+  have hyx : y * x = -(x * y) := eq_neg_of_add_eq_zero_right hac
+  calc y * (x * y) + (x * y) * y = (y * x) * y + x * y * y := by noncomm_ring
+    _ = (-(x * y)) * y + x * y * y := by rw [hyx]
+    _ = 0 := by noncomm_ring
+
+/-- **Quaternion-generating keystone: the product of two anticommuting imaginaries is
+imaginary.** If `x, y ∈ Im A` (so `x² = a•1`, `y² = b•1` with `a, b ≤ 0`) anticommute
+(`x*y + y*x = 0`), then `x*y ∈ Im A`.  By associativity and `y*x = -(x*y)`,
+`(x*y)² = x*(y*x)*y = -x²·y² = -(a·b)•1`, and `a·b ≥ 0` makes the scalar `-(a·b) ≤ 0`.
+Combined with `mul_anticomm_left`/`mul_anticomm_right` this shows two orthogonal imaginary
+units generate a quaternion triple `⟨x, y, x*y⟩` — the inductive engine of the
+`finrank ℝ (Im A) ∈ {0, 1, 3}` count. -/
+theorem isImaginary_mul_of_anticomm (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    {x y : A} (hx : IsImaginary A x) (hy : IsImaginary A y)
+    (hac : x * y + y * x = 0) : IsImaginary A (x * y) := by
+  obtain ⟨a, ha, hxsq⟩ := hx
+  obtain ⟨b, hb, hysq⟩ := hy
+  have hxx : x * x = a • (1 : A) := by rw [← pow_two]; exact hxsq
+  have hyy : y * y = b • (1 : A) := by rw [← pow_two]; exact hysq
+  have hyx : y * x = -(x * y) := eq_neg_of_add_eq_zero_right hac
+  refine ⟨-(a * b), ?_, ?_⟩
+  · have hab : 0 ≤ a * b := by
+      have := mul_nonneg (neg_nonneg.2 ha) (neg_nonneg.2 hb); simpa using this
+    linarith
+  · have hsq : (x * y) ^ 2 = -(x * x * (y * y)) := by
+      rw [pow_two]
+      calc x * y * (x * y) = x * (y * x) * y := by noncomm_ring
+        _ = x * (-(x * y)) * y := by rw [hyx]
+        _ = -(x * x * (y * y)) := by noncomm_ring
+    rw [hsq, hxx, hyy, smul_mul_smul_comm, mul_one, neg_smul]
+
 /-! ### The General (Division Ring) Case -/
 
 /-- **Frobenius Step 3, commutative subcase — fully verified.** If a normed division ring

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
@@ -21,10 +21,10 @@
     "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "1 sorry: hurwitz_only_if_ring (the remaining strictly-non-commutative global structure argument of Frobenius' theorem — Step 3: show Im A is an ℝ-subspace carrying a positive-definite bilinear form / Clifford structure). Frobenius Steps 1 and 2 are VERIFIED (0 sorries): minpoly_natDegree_le_two and exists_quadratic show every element satisfies a real quadratic (generates ℝ or ℂ); exists_real_shift_sq_scalar completes the square so the imaginary part squares to a real scalar, and eq_smul_one_of_sq_eq_nonneg_smul shows a nonnegative such scalar forces the element into ℝ•1 (via no zero divisors), isolating the genuinely imaginary elements as those with negative square scalar. Two further pieces of Step 3 are now also VERIFIED (0 sorries): anticommutator_real_affine shows x*y+y*x ∈ span_ℝ{x,y,1} for all x,y (Step 3 preparation via polarisation), and hurwitz_only_if_ring_comm discharges the commutative subcase of the general-ring statement via Gelfand-Mazur, scoping the remaining sorry to the strictly non-commutative case. Four further Step-3 pieces are now VERIFIED (0 sorries): IsImaginary defines the imaginary summand a²=r•1 with r≤0; eq_zero_of_smul_one_sq_nonpos and isImaginary_smul_one_iff establish the directness ℝ•1 ∩ Im A = {0}; and anticommutator_scalar_of_sq_scalar proves the Clifford relation x*y+y*x = (c−a−b)•1 whenever x², y², (x+y)² are real scalars. The one remaining sorry is now precisely the single global fact that Im A is closed under addition (equivalently the real-part functional A→ℝ is ℝ-linear), which would supply the (x+y)²∈ℝ•1 hypothesis for imaginary x,y and upgrade the scalar anticommutator to a positive-definite bilinear form forcing finrank ℝ (Im A) ∈ {0,1,3}. The commutative subcase (hurwitz_field_case) is axiom-free.",
-    "lineCount": 637,
-    "theoremCount": 23,
-    "definitionCount": 5,
+    "assumptions": "1 sorry: hurwitz_only_if_ring, scoped (via by_cases + hurwitz_only_if_ring_comm) to the strictly NON-COMMUTATIVE case of Frobenius' theorem. Everything up to and including the positive-definite symmetric bilinear form on Im A is now VERIFIED (0 sorries): Frobenius Steps 1-2 (minpoly_natDegree_le_two, exists_quadratic, exists_real_shift_sq_scalar, eq_smul_one_of_sq_eq_nonneg_smul) give the quadratic + completing-the-square structure; the imaginary summand Im A is packaged as an honest ℝ-submodule (imaginarySubmodule = ker realPart, with isImaginary_add / isImaginary_smul closure and the real-part functional realPart : A →ₗ[ℝ] ℝ); and imaginaryBilin realises the inner product B(x,y) = -(x*y+y*x)/2, proved symmetric, positive semi-definite, and positive-definite (imaginaryBilin_self_eq_zero_iff). The quaternion-generating mechanism is also VERIFIED: isImaginary_mul_of_anticomm shows the product of two anticommuting imaginary elements is imaginary, and mul_anticomm_left/right show it anticommutes with both factors — so two B-orthogonal imaginary units generate a quaternion triple. The SINGLE remaining sorry is the Radon-Hurwitz / Frobenius dimension count itself: that these Clifford relations force finrank ℝ (Im A) ∈ {0,1,3}, hence finrank ℝ A ∈ {1,2,4} ⊆ {1,2,4,8}. This last step (no 4th independent anticommuting imaginary unit can exist in an associative division ring) is the genuinely open formalisation gap; Mathlib currently lacks the Clifford-algebra representation machinery to discharge it directly. The commutative subcase (hurwitz_field_case, via Gelfand-Mazur) is axiom-free.",
+    "lineCount": 793,
+    "theoremCount": 32,
+    "definitionCount": 7,
     "originalContributions": [
       "admissibleDimensions: Def {1,2,4,8} — the four admissible finranks",
       "finrank_normed_field_eq_one_or_two: Gelfand-Mazur consequence (0 sorries)",
@@ -43,7 +43,9 @@
       "isImaginary_neg / isImaginary_smul / isImaginary_sub: Im A is closed under negation, real scalar multiplication, and subtraction (0 sorries) — Frobenius Step 3, scalar-closure of the imaginary set",
       "exists_unique_real_part: every a has a UNIQUE real c with a-c•1 imaginary (0 sorries) — existence by completing the square + Step 2b, uniqueness by isImaginary_smul_one_iff",
       "realPart : A →ₗ[ℝ] ℝ: the real-part functional assembled as an ℝ-linear map (0 sorries) — additivity from isImaginary_add, homogeneity from isImaginary_smul",
-      "imaginarySubmodule := LinearMap.ker realPart with mem_imaginarySubmodule_iff: Im A packaged as an honest ℝ-Submodule, kernel identified with {a | a² ∈ ℝ≤0•1} (0 sorries) — the linear scaffolding for the Frobenius bilinear form"
+      "imaginarySubmodule := LinearMap.ker realPart with mem_imaginarySubmodule_iff: Im A packaged as an honest ℝ-Submodule, kernel identified with {a | a² ∈ ℝ≤0•1} (0 sorries) — the linear scaffolding for the Frobenius bilinear form",
+      "mul_anticomm_left / mul_anticomm_right: anticommutation propagates to products — if x*y+y*x=0 then x (resp. y) anticommutes with x*y (0 sorries) — purely associative, no imaginary/division hypothesis",
+      "isImaginary_mul_of_anticomm: QUATERNION-GENERATING KEYSTONE — the product of two anticommuting imaginary elements is again imaginary, (x*y)²=-(x²·y²)=-(a·b)•1 with a·b≥0 (0 sorries). With mul_anticomm_left/right this shows two orthogonal imaginary units generate a quaternion triple ⟨x,y,x*y⟩, the inductive engine of the finrank ℝ(Im A)∈{0,1,3} count that closes Frobenius' theorem"
     ]
   },
   "overview": {
@@ -173,10 +175,10 @@
   ],
   "leanFile": {
     "namespace": "HurwitzOnlyIf",
-    "lineCount": 347,
+    "lineCount": 793,
     "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 2,
+    "theoremCount": 32,
+    "definitionCount": 7,
     "path": "Proofs/HurwitzOnlyIf.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Summary

Advances the open **Hurwitz Only-If** entry (`hurwitz-theorem-oq-03-oq-01`, Frobenius' theorem for normed division rings) by adding the **quaternion-generation keystone** — the structural mechanism behind the `finrank ℝ (Im A) ∈ {0,1,3}` dimension count that closes the strictly non-commutative case.

The entry already had (from prior sessions) the full `A = ℝ•1 ⊕ Im A` decomposition, `Im A` as an honest ℝ-submodule (`imaginarySubmodule = ker realPart`), and the positive-definite symmetric bilinear form `B(x,y) = -(x*y+y*x)/2` (`imaginaryBilin`, proved symmetric / pos-semidef / pos-definite). This PR supplies the next link.

## New verified lemmas (0 sorries, 0 axioms)

- **`isImaginary_mul_of_anticomm`** — the product of two anticommuting imaginary elements is again imaginary. By associativity and `y*x = -(x*y)`, `(x*y)² = x*(y*x)*y = -(x²·y²) = -(a·b)•1` with `a·b ≥ 0`, so the square is a nonpositive real scalar.
- **`mul_anticomm_left` / `mul_anticomm_right`** — anticommutation propagates to the product: `x` and `y` each anticommute with `x*y`. Purely associative; no imaginary or division hypothesis.

Together, from any two `B`-orthogonal imaginary units `i, j` (orthogonality ⟺ anticommutation `ij + ji = 0`) these manufacture a third imaginary unit `k := i*j` anticommuting with both — a quaternion triple `⟨i, j, k⟩` inside `A`. This is the inductive engine of the remaining dimension count.

## Verification

`./proofs/scripts/docker-build.sh Proofs.HurwitzOnlyIf` → **`⚠ Built Proofs.HurwitzOnlyIf (3.0s)`**, forced full recompile (cleared the shared olean cache to defeat stale-replay). Only the pre-existing main sorry (the Radon–Hurwitz bound itself, line 791) remains; 0 axiom declarations, 0 structure-encoded assumptions beyond that sorry.

## Status (unchanged)

Still `formalized` / `wip` with **1 sorry**. The remaining sorry is the genuinely open gap: proving these Clifford relations force `finrank ℝ (Im A) ≤ 3` (no fourth independent anticommuting imaginary unit in an associative division ring). `meta.json` counts were stale (637→793 lines, 23→32 theorems) and are synced; the `assumptions` text is corrected to describe the actual remaining gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)