### PR TITLE
Enrich power-map dichotomy over finite monoids: add annotations

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 8, "endLine": 72 },
+    "type": "context",
+    "title": "From the group iff to a monoid threshold",
+    "content": "The parent established the sharp group dichotomy Bijective (·^n : G → G) ↔ (Nat.card G).Coprime n, whose hard direction rests on Cauchy's theorem — a statement about groups that needs every element invertible. This file asks what survives over a finite monoid M, where non-invertible elements exist and Cauchy is unavailable. The answer: coprimality to |Mˣ| stays necessary but is no longer sufficient, with the gap governed exactly by the non-unit (nilpotent/idempotent) part of M.",
+    "mathContext": "$\\mathrm{Bijective}\\,(x \\mapsto x^n : M \\to M) \\Rightarrow \\gcd(|M^\\times|, n) = 1$, but not conversely.",
+    "significance": "context",
+    "relatedConcepts": ["Cauchy's theorem", "unit group", "power map", "finite monoids", "nilpotence"],
+    "prerequisites": ["group and monoid basics", "coprimality", "order of an element"]
+  },
+  {
+    "id": "ann-cauchy-hard",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 84, "endLine": 105 },
+    "type": "insight",
+    "title": "Hard direction via Cauchy's theorem",
+    "content": "not_injective_pow_of_not_coprime is the group core, recalled self-contained. If n is not coprime to |G|, take the least prime p dividing gcd(n, |G|). Cauchy's theorem (exists_prime_orderOf_dvd_card') produces an element g of order p; since p ∣ n, g^n = 1 (orderOf_dvd_iff_pow_eq_one), yet g ≠ 1. So g^n = 1^n with g ≠ 1 breaks injectivity of the n-th power map. This is exactly the step that requires a group — Cauchy needs invertibility.",
+    "mathContext": "$p \\mid \\gcd(n, |G|)$, $p$ prime $\\Rightarrow \\exists g,\\ \\mathrm{ord}(g) = p,\\ g^n = 1 = 1^n,\\ g \\ne 1$.",
+    "significance": "key",
+    "relatedConcepts": ["exists_prime_orderOf_dvd_card'", "orderOf_dvd_iff_pow_eq_one", "Nat.minFac", "contrapositive"],
+    "prerequisites": ["Cauchy's theorem", "order divides exponent", "prime factors of gcd"]
+  },
+  {
+    "id": "ann-group-iff",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 107, "endLine": 117 },
+    "type": "theorem",
+    "title": "The group dichotomy (both directions)",
+    "content": "pow_bijective_iff_coprime packages the equivalence for a finite group. The forward direction is the Cauchy contrapositive above (bijective ⇒ injective ⇒ coprime). The reverse is Mathlib's h.pow_left_bijective: when gcd(|G|, n) = 1 the power map is a bijection because n is invertible modulo the exponent. This is the parent result that the monoid section applies verbatim to the unit group Mˣ.",
+    "mathContext": "$\\mathrm{Bijective}\\,(x \\mapsto x^n : G \\to G) \\iff \\gcd(|G|, n) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.Coprime.pow_left_bijective", "bijectivity iff coprimality", "group exponent"],
+    "prerequisites": ["the hard direction", "coprime power maps in groups"]
+  },
+  {
+    "id": "ann-monoid-bridge",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 125, "endLine": 163 },
+    "type": "insight",
+    "title": "The monoid bridge: restricting to the unit group",
+    "content": "The structural fact isUnit_pow_iff (n ≠ 0 ⇒ IsUnit (xⁿ) ↔ IsUnit x) says the power map neither creates nor destroys units, so it maps Mˣ into itself. units_pow_bijective_of_pow_bijective then shows a bijective power map on M restricts to a bijection on Mˣ: injectivity is inherited through the coercion Units.val, and surjectivity pulls a preimage back into Mˣ via isUnit_pow_iff (a preimage of a unit is a unit). Feeding this into the group iff for Mˣ gives coprime_card_units_of_pow_bijective — the necessary condition.",
+    "mathContext": "$n \\ne 0 \\Rightarrow (\\mathrm{IsUnit}\\,x^n \\iff \\mathrm{IsUnit}\\,x)$, so $x \\mapsto x^n$ restricts to $M^\\times \\to M^\\times$.",
+    "significance": "key",
+    "relatedConcepts": ["isUnit_pow_iff", "Units.val_injective", "Units.val_pow_eq_pow_val", "IsUnit.unit"],
+    "prerequisites": ["unit group of a monoid", "reflecting equality through coercions"]
+  },
+  {
+    "id": "ann-converse-fails",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 174, "endLine": 202 },
+    "type": "insight",
+    "title": "The converse fails: nilpotence beats coprimality",
+    "content": "Over monoids coprimality is not sufficient, witnessed by M = ZMod 4, n = 3. The unit group has order φ(4) = 2 (card_units_zmod4 via ZMod.card_units_eq_totient), and gcd(3, 2) = 1 (coprime_three_card_units_zmod4). Yet 2³ = 8 = 0 = 0³ in ZMod 4 while 2 ≠ 0, so cubing is not injective (pow3_not_injective_zmod4), hence not bijective. converse_fails packages the counterexample: the nilpotent element 2 is invisible to the unit group, so the coprimality threshold cannot detect it. All computations discharged by decide.",
+    "mathContext": "$|(\\mathbb{Z}/4)^\\times| = \\varphi(4) = 2$, $\\gcd(3,2) = 1$, but $2^3 = 0 = 0^3$ with $2 \\ne 0$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod.card_units_eq_totient", "nilpotent element", "Euler totient", "counterexample", "decide"],
+    "prerequisites": ["ZMod arithmetic", "units of ZMod n", "nilpotence"]
+  },
+  {
+    "id": "ann-consistency",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 204, "endLine": 211 },
+    "type": "concept",
+    "title": "Consistency with the parent group case",
+    "content": "group_consistency confirms the refinement degrades gracefully: on a finite group every element is a unit, so Mˣ ≃ G, the non-unit gap is empty, and the monoid necessary condition becomes the parent's iff again. The group dichotomy is exactly the special case where the ZMod 4 obstruction cannot occur — there is no non-unit part to hide a nilpotent. 0 sorries, 0 axioms.",
+    "mathContext": "For a finite group $G$: $M^\\times \\simeq G$, so the monoid threshold recovers $\\mathrm{Bijective}\\,(x \\mapsto x^n) \\iff \\gcd(|G|, n) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["special case recovery", "every group element is a unit", "degeneration to iff"],
+    "prerequisites": ["the group iff", "the monoid necessary condition"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cauchy-group-theorem-oq-01-oq-01-oq-01-oq-03` ("The power-map dichotomy over finite monoids").

**Gap:** rich `meta.json` but **no `annotations.json`** (quality 43, passes 0). This adds inline annotation coverage of the full 213-line Lean file.

**Added — `annotations.json` (6 annotations):**
- The group→monoid framing (coprimality to |Mˣ| necessary but not sufficient)
- The Cauchy-theorem hard direction (why it needs a group)
- The group dichotomy iff
- The unit-group bridge (`isUnit_pow_iff` + restriction lemma)
- The converse failure: `M = ZMod 4`, `n = 3`, nilpotence beats coprimality
- Consistency with the parent group case

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. No `meta.json` changes; `pnpm build` passes.
