### PR TITLE
Research(binomial-theorem-oq-06-oq-01-oq-02): odd alternating squared-binomial sum via sign-reversing involution [VERIFIED]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ06OQ01OQ02.lean
+++ b/proofs/Proofs/BinomialTheoremOQ06OQ01OQ02.lean
@@ -1,0 +1,123 @@
+import Mathlib
+
+/-
+# The Alternating Squared-Binomial Sum Vanishes for Odd `n` — Involution Proof
+
+## Open Question OQ-06-OQ-01-OQ-02 (from `binomial-theorem-oq-06-oq-01`)
+
+The parent entry `binomial-theorem-oq-06-oq-01` proves
+
+  `∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0`  for odd `n`
+
+as a *corollary of the signed Vandermonde convolution*, i.e. by extracting the
+coefficient `[x^n] (1 - X^2)^n` in `ℤ[X]`.  That route is powerful (it also
+gives the even closed form `(-1)^{n/2} C(n, n/2)`) but it is heavy machinery for
+the odd-`n` vanishing, which is really a **pairing phenomenon**.
+
+This entry gives the *second, elementary proof*: the map `k ↦ n - k` is a
+**fixed-point-free, sign-reversing involution** on `{0, …, n}` when `n` is odd.
+Since `C(n, n-k) = C(n, k)` and, for odd `n`, `(-1)^{n-k} = -(-1)^k`, each term
+is sent to its own negative, so the whole sum equals its own negative and hence
+vanishes.  No polynomials, generating functions, or Vandermonde identity are
+used — only `Finset.sum_range_reflect`, `Nat.choose_symm`, and parity of `-1`
+powers.
+
+## Results
+
+* `neg_one_pow_sub`             — for odd `n` and `k ≤ n`, `(-1)^{n-k} = -(-1)^k` over `ℤ`;
+* `alternating_choose_sq_odd_reflect` — `∑_k (-1)^k C(n,k)^2 = 0` for odd `n`,
+  proved purely by reflection `k ↦ n - k`.
+
+## Comparison of the two proofs
+
+| Route | Engine | Also yields even case? | Machinery |
+|-------|--------|------------------------|-----------|
+| Parent (`…-oq-06-oq-01`) | `[x^n] (1-X^2)^n` in `ℤ[X]` | yes, `(-1)^{n/2} C(n,n/2)` | `Polynomial.coeff_mul`, binomial expansion |
+| This entry | involution `k ↦ n-k` on `range (n+1)` | no (odd only) | `Finset.sum_range_reflect`, parity |
+
+The reflection proof is strictly shorter and more transparent for the odd case,
+but is genuinely specific to it: the involution has a fixed point `k = n/2` when
+`n` is even, and there the pairing argument breaks down (the fixed term
+`(-1)^{n/2} C(n, n/2)^2` survives), which is exactly why the even sum is
+generally nonzero.
+
+## References
+
+- Sign-reversing involutions / the "reflection" evaluation of alternating sums.
+- Parent `binomial-theorem-oq-06-oq-01` (generating-function proof, closed form).
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace BinomialTheoremOQ06OQ01OQ02
+
+open Finset
+
+/-! ## The parity sign identity -/
+
+/-- For odd `n` and `k ≤ n`, `(-1)^{n-k} = -(-1)^k` over `ℤ`.
+
+This is the "sign-reversing" heart of the involution: reflecting the exponent
+across an odd total flips the sign, because `(n-k)` and `k` then have opposite
+parities. -/
+theorem neg_one_pow_sub (n k : ℕ) (hn : Odd n) (hk : k ≤ n) :
+    (-1 : ℤ) ^ (n - k) = -((-1) ^ k) := by
+  -- `(-1)^k` is a square root of `1`.
+  have hb : ((-1 : ℤ) ^ k) * ((-1) ^ k) = 1 := by
+    rw [← pow_add]; exact Even.neg_one_pow ⟨k, rfl⟩
+  -- The two exponents sum to the odd number `n`, so the powers multiply to `-1`.
+  have hprod : (-1 : ℤ) ^ (n - k) * (-1) ^ k = -1 := by
+    rw [← pow_add, Nat.sub_add_cancel hk, hn.neg_one_pow]
+  calc (-1 : ℤ) ^ (n - k)
+      = (-1 : ℤ) ^ (n - k) * ((-1) ^ k * (-1) ^ k) := by rw [hb, mul_one]
+    _ = ((-1 : ℤ) ^ (n - k) * (-1) ^ k) * (-1) ^ k := by ring
+    _ = (-1) * (-1) ^ k := by rw [hprod]
+    _ = -((-1) ^ k) := by ring
+
+/-! ## The vanishing theorem via reflection -/
+
+/-- **Odd alternating squared-binomial sum, involution proof.**
+For odd `n`, `∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0`, proved by the fixed-point-free
+sign-reversing involution `k ↦ n - k` on `range (n+1)`. -/
+theorem alternating_choose_sq_odd_reflect (n : ℕ) (hn : Odd n) :
+    ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2 = 0 := by
+  -- Each reflected term is the negative of the original term.
+  have key : ∀ k ∈ range (n + 1),
+      (-1 : ℤ) ^ (n - k) * (n.choose (n - k) : ℤ) ^ 2
+        = (-1) * ((-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2) := by
+    intro k hk
+    rw [mem_range, Nat.lt_succ_iff] at hk
+    rw [Nat.choose_symm hk, neg_one_pow_sub n k hn hk]
+    ring
+  -- Reflect the sum, apply `key` termwise, pull out the sign: `S = -S`.
+  have hSS :
+      (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2)
+        = -(∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2) := by
+    calc (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2)
+        = ∑ k ∈ range (n + 1), (-1 : ℤ) ^ (n - k) * (n.choose (n - k) : ℤ) ^ 2 := by
+          rw [← Finset.sum_range_reflect
+            (fun k => (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2) (n + 1)]
+          apply Finset.sum_congr rfl
+          intro j _
+          simp only [Nat.add_sub_cancel]
+      _ = ∑ k ∈ range (n + 1), (-1) * ((-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2) :=
+          Finset.sum_congr rfl key
+      _ = (-1) * ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2 := by
+          rw [← Finset.mul_sum]
+      _ = -(∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2) := by
+          rw [neg_one_mul]
+  linarith [hSS]
+
+/-! ## Numerical sanity checks -/
+
+/-- `∑_{k=0}^{3} (-1)^k C(3,k)^2 = 1 - 9 + 9 - 1 = 0`. -/
+theorem check_three :
+    ∑ k ∈ range 4, (-1 : ℤ) ^ k * ((3).choose k : ℤ) ^ 2 = 0 := by decide
+
+/-- `∑_{k=0}^{5} (-1)^k C(5,k)^2 = 1 - 25 + 100 - 100 + 25 - 1 = 0`. -/
+theorem check_five :
+    ∑ k ∈ range 6, (-1 : ℤ) ^ k * ((5).choose k : ℤ) ^ 2 = 0 := by decide
+
+#print axioms alternating_choose_sq_odd_reflect
+
+end BinomialTheoremOQ06OQ01OQ02

--- a/src/data/proofs/binomial-theorem-oq-06-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-06-oq-01-oq-02/annotations.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "ann-neg-one-pow-sub",
+    "proofId": "binomial-theorem-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 63,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "The Parity Sign Identity",
+    "content": "The sign-reversing core of the involution: for odd n and k ≤ n, (-1)^{n-k} = -(-1)^k over ℤ. The proof is algebraic rather than a parity case-split: since (n-k)+k = n is odd, (-1)^{n-k}·(-1)^k = (-1)^n = -1, and since ((-1)^k)^2 = 1, multiplying through by (-1)^k isolates (-1)^{n-k} = -(-1)^k.",
+    "mathContext": "$n$ odd, $k \\le n \\implies (-1)^{n-k} = -(-1)^k$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "parity",
+      "powers of -1",
+      "sign reversal"
+    ],
+    "prerequisites": [
+      "Odd.neg_one_pow",
+      "Even.neg_one_pow",
+      "Nat.sub_add_cancel"
+    ]
+  },
+  {
+    "id": "ann-alternating-choose-sq-odd-reflect",
+    "proofId": "binomial-theorem-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 82,
+      "endLine": 112
+    },
+    "type": "theorem",
+    "title": "The Vanishing Theorem via Reflection",
+    "content": "The main result: ∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0 for odd n, proved by the fixed-point-free sign-reversing involution k ↦ n-k. Finset.sum_range_reflect rewrites the sum over k as the sum over n-k; Nat.choose_symm keeps the squared binomial fixed, and the parity identity makes each reflected term the negation of the original. Thus the sum equals its own negation (S = -S) and vanishes over ℤ. No polynomials or generating functions appear — this is the purely combinatorial companion to the parent's coefficient-extraction proof.",
+    "mathContext": "$\\sum_{k=0}^{n} (-1)^k \\binom{n}{k}^2 = 0$ for odd $n$",
+    "significance": "central",
+    "relatedConcepts": [
+      "sign-reversing involution",
+      "reflection of finite sums",
+      "alternating binomial sums",
+      "fixed-point-free pairing"
+    ],
+    "prerequisites": [
+      "Finset.sum_range_reflect",
+      "Nat.choose_symm",
+      "Finset.mul_sum"
+    ]
+  },
+  {
+    "id": "ann-numerical-checks",
+    "proofId": "binomial-theorem-oq-06-oq-01-oq-02",
+    "range": {
+      "startLine": 114,
+      "endLine": 120
+    },
+    "type": "theorem",
+    "title": "Numerical Sanity Checks",
+    "content": "Kernel-decidable confirmations of the odd cases n=3 (1 - 9 + 9 - 1 = 0) and n=5 (1 - 25 + 100 - 100 + 25 - 1 = 0). These use `decide` (not `native_decide`), so they introduce no Lean.ofReduceBool axiom and the entry remains verified from the foundational axioms only.",
+    "mathContext": "$\\sum_{k=0}^{3}(-1)^k\\binom{3}{k}^2 = \\sum_{k=0}^{5}(-1)^k\\binom{5}{k}^2 = 0$",
+    "significance": "illustrative",
+    "relatedConcepts": [
+      "decidability",
+      "numerical verification"
+    ],
+    "prerequisites": [
+      "Finset.sum"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-06-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06-oq-01-oq-02/meta.json
@@ -1,0 +1,81 @@
+{
+  "id": "binomial-theorem-oq-06-oq-01-oq-02",
+  "slug": "binomial-theorem-oq-06-oq-01-oq-02",
+  "title": "Odd Alternating Squared-Binomial Sum via a Sign-Reversing Involution",
+  "description": "Gives a second, elementary proof that ∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0 for odd n, using the fixed-point-free sign-reversing involution k ↦ n-k on {0,…,n} instead of the parent entry's generating-function route. Because C(n,n-k)=C(n,k) and, for odd n, (-1)^{n-k} = -(-1)^k, each term maps to its own negative, so the sum equals its negation and vanishes. The whole argument uses only Finset.sum_range_reflect, Nat.choose_symm, and the parity of powers of -1 — no polynomials, generating functions, or Vandermonde identity. Answers open question #2 of the parent entry binomial-theorem-oq-06-oq-01.",
+  "leanFile": {
+    "namespace": "BinomialTheoremOQ06OQ01OQ02",
+    "lineCount": 123,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ06OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-05",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ06OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "alternating-sums",
+      "involution",
+      "reflection",
+      "parity"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-05",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified from the foundational axioms (propext, Classical.choice, Quot.sound). The named theorems use no native_decide; the two numerical checks use kernel decide, introducing no Lean.ofReduceBool.",
+    "lineCount": 123,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "alternating_choose_sq_odd_reflect: a self-contained involution proof of ∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0 for odd n, using Finset.sum_range_reflect to reflect the sum across k ↦ n-k and showing each reflected term is the negation of the original, so S = -S = 0",
+      "neg_one_pow_sub: the sign-reversal identity (-1)^{n-k} = -(-1)^k over ℤ for odd n and k ≤ n — the parity core of the involution, proved from (-1)^{(n-k)+k} = (-1)^n = -1 and ((-1)^k)^2 = 1 without case-splitting on the parity of k",
+      "A side-by-side comparison of the reflection proof with the parent's generating-function proof, documenting why the involution is specific to odd n: for even n the map has the fixed point k = n/2, whose term (-1)^{n/2} C(n,n/2)^2 survives and produces the nonzero even-case value"
+    ]
+  },
+  "conclusion": {
+    "summary": "Proves ∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0 for odd n by a fixed-point-free sign-reversing involution. Finset.sum_range_reflect rewrites the sum over k as the sum over n-k; Nat.choose_symm gives C(n,n-k)=C(n,k), and the parity identity (-1)^{n-k} = -(-1)^k (valid because n is odd) makes each reflected term the negation of the original. Hence the sum equals its own negation and, over ℤ (characteristic zero), vanishes. 4 theorems, 0 definitions, 0 axioms, 123 lines.",
+    "implications": "Complements the parent entry's generating-function proof with the combinatorial 'reflection' argument that is the usual textbook one-liner for alternating sums. The two proofs are genuinely different in scope: the polynomial route computes [x^n](1-x^2)^n and yields both the odd (zero) and even ((-1)^{n/2} C(n,n/2)) cases uniformly, whereas the involution proof is shorter and more transparent but intrinsically odd-only — its single fixed point at k=n/2 for even n is exactly the surviving central term that makes the even sum nonzero. This makes precise the folklore that 'the alternating squared-binomial sum vanishes in odd degree by pairing terms.'",
+    "openQuestions": [
+      "Formalize the general sign-reversing-involution principle 'a fixed-point-free involution σ on a finite set with f∘σ = -f forces ∑ f = 0 over a characteristic-zero ring' as a reusable lemma, and re-derive this odd case as a one-line instance.",
+      "Extend the reflection bookkeeping to the even case: isolate the fixed point k=n/2 and show the remaining terms pair off, recovering ∑ (-1)^k C(n,k)^2 = (-1)^{n/2} C(n,n/2) without leaving the elementary (non-generating-function) setting."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-06-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves ∑ (-1)^k C(n,k)^2 = 0 for odd n as a corollary of the signed Vandermonde convolution (coefficient extraction in ℤ[X]). This entry answers its second open question by re-proving the odd case directly via the involution k ↦ n-k and comparing the two approaches."
+    }
+  ],
+  "sections": [
+    "Module Overview and Comparison of the Two Proofs",
+    "The Parity Sign Identity",
+    "The Vanishing Theorem via Reflection",
+    "Numerical Sanity Checks"
+  ],
+  "sorries": [],
+  "overview": {
+    "historicalContext": "Sign-reversing involutions are one of the central tools of enumerative combinatorics: to show an alternating sum ∑ (-1)^{sign(x)} w(x) vanishes, one exhibits a weight-preserving, sign-reversing pairing of the objects. The alternating sum of squared binomial coefficients is the textbook first example — for odd n the reflection k ↦ n-k pairs each term with its negative and the sum collapses. This entry contrasts that classical pairing argument with the parent entry's generating-function computation of the same quantity.",
+    "problemStatement": "Prove ∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0 for odd n directly by the involution k ↦ n-k, independently of the signed-Vandermonde / generating-function route used by the parent entry, and compare the two proofs.",
+    "proofStrategy": "Reflect the sum with Finset.sum_range_reflect, which turns ∑_{k∈range(n+1)} f(k) into ∑_{k∈range(n+1)} f(n-k). Show termwise that f(n-k) = -f(k): the magnitude is unchanged by Nat.choose_symm (C(n,n-k)=C(n,k)), and the sign flips by the parity identity (-1)^{n-k} = -(-1)^k, which holds for odd n because (n-k)+k = n is odd. Consequently ∑ f(n-k) = -∑ f(k), i.e. S = -S, and over ℤ this forces S = 0 (linarith). The parity identity itself is proved algebraically from (-1)^{(n-k)+k}=(-1)^n=-1 together with ((-1)^k)^2=1, avoiding any case analysis on the parity of k.",
+    "keyInsights": [
+      "The map k ↦ n-k is a fixed-point-free involution on {0,…,n} precisely when n is odd (n=2k has no solution), which is exactly the hypothesis under which the sum vanishes.",
+      "Sign reversal is a pure parity fact: (n-k) and k have opposite parities when their sum n is odd, so (-1)^{n-k} = -(-1)^k.",
+      "Nat.choose_symm keeps the squared binomial invariant under reflection, so only the sign moves — the essential feature of a sign-reversing involution.",
+      "Reflecting the sum and applying the termwise negation gives S = -S; characteristic zero then yields S = 0, with no need to actually construct the quotient set of pairs.",
+      "The proof is intrinsically odd-only: for even n the involution fixes k=n/2, whose term survives and equals the nonzero even-case value (-1)^{n/2} C(n,n/2) — a structural explanation of the odd/even dichotomy the parent computes analytically."
+    ]
+  },
+  "references": [
+    "Graham, Knuth, Patashnik, Concrete Mathematics, §5.1–5.3 (alternating binomial sums).",
+    "Stanley, R. Enumerative Combinatorics, Vol. 1 (sign-reversing involutions).",
+    "Parent entry binomial-theorem-oq-06-oq-01 (generating-function proof and closed form)."
+  ]
+}

--- a/src/data/proofs/binomial-theorem-oq-06-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06-oq-01/meta.json
@@ -59,6 +59,11 @@
       "targetId": "binomial-theorem-oq-06-oq-02",
       "relationship": "sibling",
       "description": "Sibling under the same parent, proving the hockey-stick diagonal sums and the Catalan / lattice-path connection of the central identity; this entry instead pursues the signed (alternating) branch."
+    },
+    {
+      "targetId": "binomial-theorem-oq-06-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "Answers this entry's second open question: re-proves the odd-degree vanishing ∑ (-1)^k C(n,k)^2 = 0 directly by the sign-reversing involution k ↦ n-k, independently of the generating-function route used here, and compares the two proofs."
     }
   ],
   "sections": [


### PR DESCRIPTION
## Summary

New **verified** gallery entry `binomial-theorem-oq-06-oq-01-oq-02` that answers the **second open question** of the parent `binomial-theorem-oq-06-oq-01`:

> *Prove the odd-degree vanishing ∑_{k=0}^{n} (-1)^k C(n,k)^2 = 0 directly by the involution k ↦ n-k, independently of the generating-function route, and compare the two proofs.*

## Mathematical content

The parent proves the odd-case vanishing as a corollary of the signed Vandermonde convolution, by extracting the coefficient `[x^n](1-X²)ⁿ` in `ℤ[X]`. This entry gives the **elementary combinatorial proof**: the map `k ↦ n-k` is a **fixed-point-free, sign-reversing involution** on `{0,…,n}` when `n` is odd.

- `C(n, n-k) = C(n, k)` (`Nat.choose_symm`) — the squared binomial is invariant, and
- for odd `n`, `(-1)^{n-k} = -(-1)^k` (since `(n-k)+k = n` is odd) — the sign flips.

So each reflected term is the negation of the original; reflecting the sum (`Finset.sum_range_reflect`) gives `S = -S`, hence `S = 0` over `ℤ`. No polynomials, generating functions, or Vandermonde identity are used.

The entry also documents *why the involution is odd-only*: for even `n` it fixes `k = n/2`, whose surviving term `(-1)^{n/2} C(n,n/2)²` is exactly the nonzero even-case value the parent computes analytically.

## Theorems (4, 0 sorry / 0 axiom, 123 lines)

- `neg_one_pow_sub` — `(-1)^{n-k} = -(-1)^k` over `ℤ` for odd `n`, `k ≤ n` (proved algebraically, no parity case-split)
- `alternating_choose_sq_odd_reflect` — the vanishing theorem via reflection
- `check_three`, `check_five` — kernel-`decide` sanity checks (n=3, n=5)

## Verification

- Docker build: **7743 jobs, exit 0**.
- `#print axioms alternating_choose_sq_odd_reflect` = `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool` (the checks use kernel `decide`, not `native_decide`). Status `verified`, badge `original`, axiomCount 0.
- Gallery `meta.json` + `annotations.json` validate; reciprocal `extended-by` cross-reference added to the parent entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)