### PR TITLE
Enrich: Sylvester Sequence arithmetic skeleton — add cross-references

### DIFF
--- a/src/data/proofs/sylvester-sequence-oq-01-oq-03/meta.json
+++ b/src/data/proofs/sylvester-sequence-oq-01-oq-03/meta.json
@@ -143,7 +143,23 @@
     }
   ],
   "conclusion": "The three classical faces of Sylvester's sequence beyond its reciprocal sum — coprimality, the Euclid product, and the modular skeleton (parity and residue mod 6, and mod every earlier term) — all descend from one identity, a_{n+1} - 1 = a_n(a_n - 1). The formalization keeps everything in ℕ, defusing truncated subtraction by a single change of variable, and derives the mod-6 invariant by a two-line induction rather than case analysis. NOTE: this entry is BUILD-PENDING (status 'pending'/'wip') — the proof is complete and self-reviewed but was not machine-checked this session because the Docker toolchain was unavailable; it must be compiled with docker-build.sh before being promoted to 'verified'.",
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "sylvester-sequence-oq-01",
+      "relationship": "complements",
+      "description": "Companion entry proving the telescoping reciprocal-sum identity for ∑ 1/aₖ together with pairwise coprimality of the terms. This entry shares the Euclid-product and coprimality facts (parts 1–2, 4) but adds the modular skeleton the companion does not treat: parity, residue mod 6, and residue modulo every earlier term."
+    },
+    {
+      "targetId": "sylvester-sequence-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Formalizes that the reciprocal sum ∑ 1/aₖ converges to 1 (the Egyptian-fraction / Tendsto face of the sequence). Where that entry studies the analytic limit, this one isolates the arithmetic — divisibility, congruence, and residue — structure of the same recurrence."
+    },
+    {
+      "targetId": "sylvester-sequence-oq-03",
+      "relationship": "related",
+      "description": "Studies the doubly-exponential growth rate of the terms and the speed of reciprocal-sum convergence. It governs the size of aₙ; this entry governs their divisibility and residues — the two complementary halves of the sequence's structure, both descending from a_{n+1} = a_n² - a_n + 1."
+    }
+  ],
   "references": {
     "papers": [],
     "urls": [


### PR DESCRIPTION
Enrichment pass for `sylvester-sequence-oq-01-oq-03` (quality 85, passes 0).

## Change
`crossReferences` was empty `[]` even though the entry's own description names `sylvester-sequence-oq-01` as its companion. Added 3 curated, navigable links to sibling gallery entries:

- **sylvester-sequence-oq-01** (`complements`) — companion with the shared Euclid-product and coprimality facts; this entry adds the modular skeleton (parity, mod 6, mod earlier terms).
- **sylvester-sequence-oq-01-oq-01** (`related`) — the reciprocal-sum-converges-to-1 (analytic) face of the same sequence.
- **sylvester-sequence-oq-03** (`related`) — doubly-exponential growth; governs size where this entry governs divisibility/residues.

All three target ids verified to exist in `src/data/proofs/`.

## Not changed
- Annotations already cover the full Lean file (9 annotations, lines 3–145) and meta already meets quality targets (5 keyInsights, sections, mainTheorems, historicalContext), so no deepening was needed.
- `status: pending` / `badge: wip` and the build-pending disclosure left untouched — accurately reflects that the Lean file is written but not yet machine-checked. Enrichment does not verify builds.

meta.json 12.2 KB → 13.5 KB (well under 60 KB cap; `check-meta-size.ts` passes).