### PR TITLE
research(cube-root-3-oq-02-oq-03): norm-descent keystone — shrink 2-power Capelli sorry to the −a∈K² case

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
@@ -56,10 +56,15 @@ fully discharged (all `n`), the odd `iff` complete, the **even base case `n = 2`
 (via Mathlib's prime-exponent criterion `X_pow_sub_C_irreducible_iff_of_prime`, whose
 `4 ∤ 2` makes the `−4·K⁴` obstruction vacuous), and now the **`4 ∣ n` base case `n = 4`
 proved** (`vahlen_capelli_four_suff`, the full Sophie-Germain quartic factor analysis),
-`vahlen_capelli` isolates the sole remaining `sorry` to **even `n ≥ 6`** — the higher
-2-power regime that needs coprime-exponent multiplicativity on top of the `n = 4` base
-case, where Mathlib's prime-power criterion `X_pow_sub_C_irreducible_iff_of_prime_pow`
-is restricted to *odd* primes.
+`vahlen_capelli` reduces the entire even case to the pure `2`-power base
+`two_power_capelli` (via the verified odd-multiplicativity transfer
+`vahlen_capelli_even_mul_odd`). Within that base, the norm-descent keystone
+`two_power_capelli_of_neg_not_square` discharges — for **every** `k` — the branch where
+`−a` is *not* a square, needing only condition (1). The **sole remaining `sorry`** is thus
+confined to the pure `2`-power regime `8 ∣ n` (`k ≥ 3`) **and** `−a ∈ K²` (equivalently
+`a = −c²`): the one place where the `−4·K⁴` obstruction (condition (2)) is genuinely
+required and where Mathlib's prime-power criterion `X_pow_sub_C_irreducible_of_prime_pow`
+(restricted to *odd* primes) has no analogue.
 
 ## Roadmap for the base case `n = 4` (the smallest `4 ∣ n` instance)
 
@@ -102,9 +107,11 @@ Substituting `a ↦ X^m` shows that whenever `a = −4b⁴` and `4 ∣ n = 4m`, 
 `X^n − C a = (X^m)⁴ + 4(C b)⁴` splits into two degree-`2m` factors — so condition (2) is
 *necessary*. Capelli's theorem is that (1)+(2) are also *sufficient*.
 
-## Status: sole `sorry` = even-sufficiency (Mathlib TODO). Body previously Docker-verified;
-`capelli_four_coeff_contra` (new) is a self-contained scalar-field argument checked by hand
-(Docker build infra currently returns an I/O error, so it was not re-built this session).
+## Status: sole `sorry` = even-sufficiency in the pure `2`-power regime `8 ∣ n` **with
+`−a ∈ K²`** (Mathlib TODO, Lang VI §9). The `−a ∉ K²` branch of that regime is now fully
+discharged by the verified norm-descent keystone `two_power_capelli_of_neg_not_square`
+(condition (2) unused). Docker-verified this session: `3061` jobs, exactly one `sorry`
+warning (the `−a ∈ K²` sub-case), `0` new axioms.
 -/
 
 import Mathlib.FieldTheory.KummerExtension
@@ -717,9 +724,11 @@ theorem two_power_capelli {K : Type*} [Field K] {k : ℕ} (hk : 1 ≤ k) {a : K}
   `n = 2^k · t` with `t` odd, the odd part `t` is handled by the norm-transfer reduction
   `vahlen_capelli_even_mul_odd`, leaving only the pure `2`-power base `X^(2^k) − C a`. The
   base cases `k = 1` (`n = 2`, prime) and `k = 2` (`n = 4`, `vahlen_capelli_four_suff`) are
-  proved, so **every even `n` with `8 ∤ n` is fully discharged**. The **sole remaining
-  `sorry`** is the higher `2`-power regime **`8 ∣ n`** (`k ≥ 3`). Both directions of the odd
-  case and the necessity of the even case are fully machine-checked.
+  proved, so **every even `n` with `8 ∤ n` is fully discharged**. In the higher `2`-power
+  regime **`8 ∣ n`** (`k ≥ 3`) the norm-descent keystone
+  `two_power_capelli_of_neg_not_square` further discharges the `−a ∉ K²` branch, so the
+  **sole remaining `sorry`** is `8 ∣ n` **with `−a ∈ K²`** (`a = −c²`). Both directions of the
+  odd case and the necessity of the even case are fully machine-checked.
 
 Proof sketch for the remaining step (`8 ∣ n`, cf. Lang VI §9): for the pure `2`-power base
 `X^(2^k) − C a` one argues by induction on `k`; the inductive obstruction is precisely the

--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ03.lean
@@ -606,6 +606,56 @@ theorem vahlen_capelli_even_mul_odd {K : Type*} [Field K] {m t : ℕ}
 -- PART 5d: The pure 2-power base (isolated open lemma = Mathlib's exact TODO)
 -- ============================================================
 
+/-- **Norm-descent keystone for the pure `2`-power tower.** If `a` is neither a square nor
+the negative of a square (`−a ∉ K²`), then `X^(2^k) − C a` is irreducible for every `k ≥ 1`.
+
+This is the branch of the even Kummer criterion that needs **only** condition (1) at the
+prime `2` — the `−4·K⁴` obstruction (condition (2)) is never invoked. The mechanism is the
+same norm transfer that drives `vahlen_capelli_even_mul_odd`: reducing
+`X^(2·2^k) − C a = (X²)^(2^k) − C a` to the base `X^(2^k) − C a` via
+`X_pow_mul_sub_C_irreducible`, a root `x` of the (irreducible, even-degree) base has field
+norm `N(x) = (−1)^(2^k)·(−a) = −a`; if `x = b²` in `K⟮x⟯` then `N(b)² = N(x) = −a`, so `−a`
+is a square in `K` — excluded by hypothesis. Because `2^k` is even at **every** level of the
+tower, `−a ∉ K²` is a single field-level condition preserved unchanged as `k` grows, so the
+induction closes with no auxiliary hypothesis.
+
+This isolates the genuinely open content of `two_power_capelli` to the residual case
+`−a ∈ K²` (equivalently `a = −c²`), which is exactly where the `−4·K⁴` factorisation
+`sophie_germain` becomes indispensable (cf. the `k = 2` base `capelli_four_coeff_contra`). -/
+theorem two_power_capelli_of_neg_not_square {K : Type*} [Field K] {k : ℕ} (hk : 1 ≤ k)
+    {a : K} (h1 : ∀ b : K, b ^ 2 ≠ a) (hneg : ∀ b : K, b ^ 2 ≠ -a) :
+    Irreducible (X ^ 2 ^ k - C a : K[X]) := by
+  induction k, hk using Nat.le_induction with
+  | base =>
+    -- `k = 1`: `X² − C a`, prime exponent; `a` not a square is condition (1) at `p = 2`.
+    rw [pow_one]
+    exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr h1
+  | succ n hn IH =>
+    -- `X^(2^(n+1)) − C a = X^(2·2^n) − C a`; reduce to the base `X^(2^n) − C a` (= `IH`).
+    have hm0 : (2 : ℕ) ^ n ≠ 0 := pow_ne_zero n two_ne_zero
+    have hm_even : Even ((2 : ℕ) ^ n) := by rw [Nat.even_pow]; exact ⟨even_two, by omega⟩
+    rw [pow_succ, mul_comm (2 ^ n) 2]
+    apply X_pow_mul_sub_C_irreducible IH
+    intro E _ _ x hx
+    -- `x` is a root of the even-degree irreducible base, so it is integral over `K`.
+    have hInt : IsIntegral K x := not_not.mp fun h ↦ by
+      simpa only [degree_zero, degree_X_pow_sub_C (Nat.pos_of_ne_zero hm0),
+        WithBot.natCast_ne_bot] using congr_arg degree (hx.symm.trans (dif_neg h))
+    -- Suffices: the base root `x` is not a square in `K⟮x⟯` — then `X² − C x` is irreducible.
+    apply (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
+    intro b hb
+    -- `hb : b² = x`.  Take the field norm: `N(b)² = N(x) = −a`, contradicting `−a ∉ K²`.
+    apply hneg (Algebra.norm K b)
+    have hpb := Algebra.PowerBasis.norm_gen_eq_coeff_zero_minpoly
+      (IntermediateField.adjoin.powerBasis hInt)
+    rw [IntermediateField.adjoin.powerBasis_gen, IntermediateField.adjoin.powerBasis_dim,
+      IntermediateField.minpoly_gen, hx, natDegree_X_pow_sub_C, hm_even.neg_one_pow, one_mul,
+      coeff_sub, coeff_X_pow, if_neg (Ne.symm hm0), coeff_C_zero, zero_sub] at hpb
+    calc (Algebra.norm K b) ^ 2
+        = Algebra.norm K (b ^ 2) := by rw [map_pow]
+      _ = Algebra.norm K (IntermediateField.AdjoinSimple.gen K x) := by rw [hb]
+      _ = -a := hpb
+
 /-- **Pure `2`-power base `X^(2^k) − C a`.** If `a` is not a square and `a ∉ −4·K⁴`, then
 `X^(2^k) − C a` is irreducible over the field `K`, for every `k ≥ 1`.
 
@@ -620,12 +670,16 @@ The two low base cases are discharged here:
 * `k = 1` (`X² − C a`): Mathlib's prime-exponent Kummer criterion — condition (1) at `p = 2`.
 * `k = 2` (`X⁴ − C a`): the Sophie-Germain quartic analysis `vahlen_capelli_four_suff`.
 
-The sole remaining `sorry` is the genuine open content `k ≥ 3`: the induction on `k` for the
-`2`-power tower, whose inductive obstruction is the `−4b⁴` factorisation (`sophie_germain`)
-ruled out by condition (2). Concretely, `X^(2^(k+1)) − C a = (X²)^(2^k) − C a`, so
-`X_pow_mul_sub_C_irreducible` reduces the step to showing that a root `x` of the base
-(`x^(2^k) = a`) is **not a square** in `K(x)`; condition (2) is exactly what forbids
-`x = −4y⁴`-type squares from appearing in the tower. -/
+For `k ≥ 3` the tower is split on whether `−a` is a square:
+* `−a ∉ K²` — discharged **unconditionally** by the norm-descent keystone
+  `two_power_capelli_of_neg_not_square` (condition (2) is not needed here).
+* `−a ∈ K²` (equivalently `a = −c²`) — the sole remaining `sorry`: the genuine open content,
+  where the `−4b⁴` factorisation (`sophie_germain`) ruled out by condition (2) is
+  indispensable. Concretely, `X^(2^(k+1)) − C a = (X²)^(2^k) − C a`, so
+  `X_pow_mul_sub_C_irreducible` reduces the step to showing a root `x` of the base
+  (`x^(2^k) = a`) is **not a square** in `K(x)`; when `−a` is itself a square the norm
+  descent is inconclusive and condition (2) is exactly what forbids the `x = −4y⁴`-type
+  squares from appearing in the tower. -/
 theorem two_power_capelli {K : Type*} [Field K] {k : ℕ} (hk : 1 ≤ k) {a : K}
     (h1 : ∀ b : K, b ^ 2 ≠ a) (h2 : ∀ b : K, a ≠ -(4 * b ^ 4)) :
     Irreducible (X ^ 2 ^ k - C a : K[X]) := by
@@ -637,9 +691,15 @@ theorem two_power_capelli {K : Type*} [Field K] {k : ℕ} (hk : 1 ≤ k) {a : K}
   · -- `k = 2`: `X⁴ − C a`, the Sophie-Germain quartic base `vahlen_capelli_four_suff`.
     rw [show (2 : ℕ) ^ 2 = 4 from by norm_num]
     exact vahlen_capelli_four_suff h1 h2
-  · -- `k ≥ 3`: the genuine open case — the `2`-power induction on the `−4b⁴` obstruction,
-    -- Mathlib's `X_pow_sub_C_irreducible_of_prime_pow` generalised to `p = 2` (Lang VI §9).
-    sorry
+  · -- `k ≥ 3`: split on whether `−a` is a square.
+    by_cases hna : ∃ c : K, c ^ 2 = -a
+    · -- `−a ∈ K²` (i.e. `a = −c²`): the genuine open sub-case, where the `−4·K⁴`
+      -- factorisation (condition (2)) is indispensable.  Mathlib TODO (Lang VI §9).
+      sorry
+    · -- `−a ∉ K²`: discharged unconditionally by the norm-descent keystone.
+      push_neg at hna
+      refine two_power_capelli_of_neg_not_square ?_ h1 hna
+      omega
 
 -- ============================================================
 -- PART 6: The full criterion (even sufficiency = the open Mathlib gap)

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
@@ -37,12 +37,12 @@
     ]
   },
   "leanFile": {
-    "lineCount": 299,
+    "lineCount": 799,
     "path": "Proofs/CubeRoot3IrrationalOQ02OQ03.lean",
     "axiomCount": 0,
     "sorries": 1,
     "definitionCount": 1,
-    "theoremCount": 9
+    "theoremCount": 10
   },
   "overview": {
     "historicalContext": "The irreducibility of pure binomials X^n − a is one of the oldest questions in the theory of equations. Abel and Galois already understood the odd-prime case, but the definitive criterion is due to Theodor Vahlen (1895) and Alfredo Capelli (1897), who independently settled when X^n − a is irreducible over a field: it is irreducible iff a is not a p-th power for any prime p ∣ n and — the subtle extra clause — a ∉ −4·K⁴ whenever 4 ∣ n. This last condition traces directly to the Sophie Germain identity u⁴+4v⁴ = (u²−2uv+2v²)(u²+2uv+2v²), which Germain introduced around 1825 during her work on Fermat's Last Theorem. Serge Lang's Algebra (VI §9) gives the modern textbook treatment. Mathlib formalises only the odd-exponent half (X_pow_sub_C_irreducible_iff_forall_prime_of_odd) and leaves the even case as an explicit TODO citing exactly this Lang reference — so this entry attacks a concrete, named gap in the library. The problem descends from the parent gallery entry proving ∛3 irrational by Eisenstein: that argument is the case n = 3, a = 3, and Vahlen–Capelli is the exact iff that generalises the ad hoc Eisenstein bound to every exponent and radicand.",


### PR DESCRIPTION
## Summary

Advances the even-sufficiency direction of the **Vahlen–Capelli criterion** (`X^n − C a` irreducible ⟺ conditions (1)+(2)), whose 2-power base `two_power_capelli` was the file's sole open `sorry`. This is Mathlib's explicit open `TODO` in `FieldTheory/KummerExtension.lean` ("criteria for even `n`", "generalize to `p = 2`"; Lang, *Algebra*, VI §9).

**New verified theorem** `two_power_capelli_of_neg_not_square` (0 sorries, 0 axioms):

> If `a ∉ K²` **and** `−a ∉ K²`, then `X^(2^k) − C a` is irreducible for every `k ≥ 1`.

This discharges — unconditionally, using only condition (1) at the prime 2 — the entire `−a ∉ K²` branch of the 2-power tower at **all** `k`, with the `−4·K⁴` obstruction (condition (2)) never invoked.

## Mechanism

The same norm transfer that drives the already-verified `vahlen_capelli_even_mul_odd`: reduce `X^(2·2^k) − C a = (X²)^(2^k) − C a` to the base via Mathlib's `X_pow_mul_sub_C_irreducible`. A root `x` of the even-degree irreducible base has field norm `N(x) = (−1)^(2^k)·(−a) = −a`; if `x = b²` in `K⟮x⟯` then `N(b)² = N(x) = −a`, making `−a` a square in `K` — excluded by hypothesis. Since `2^k` is even at every level, `−a ∉ K²` is a single field-level condition preserved unchanged as the tower grows, so the induction closes with no auxiliary hypothesis.

## Effect on the open sorry

`two_power_capelli` (k ≥ 3) now `by_cases` on whether `−a` is a square:
- **`−a ∉ K²`** → closed by the keystone (verified).
- **`−a ∈ K²`** (i.e. `a = −c²`) → the **sole remaining `sorry`**.

This is a genuine narrowing: the open problem is now isolated to the single case where the norm descent is inconclusive and the Sophie-Germain `−4·K⁴` factorisation (`sophie_germain`) becomes indispensable — exactly the qualitative content flagged by Lang VI §9.

## Verification

- Docker build: **3061 jobs succeed**, exactly **one** `sorry` warning (the `−a ∈ K²` sub-case), **0 new axioms**.
- Second commit is comment/docstring + meta.json only (no code touched); the verified build state is the first commit.
- `meta.json` `leanFile` synced: `lineCount 299→799`, `theoremCount 9→10`, `sorries 1`, `axiomCount 0`. Status remains `formalized`/`wip` (one sorry remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)