### PR TITLE
research(sum-of-divisors-oq-06-oq-01): divisor-count product formula τ(n)=∏(vₚ+1) + sharpness of coprime multiplicativity [verified]

### DIFF
--- a/proofs/Proofs/SumOfDivisorsOQ06OQ01.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ06OQ01.lean
@@ -1,0 +1,86 @@
+/-
+# Sum of Divisors OQ-06-01: the product formula for the divisor-counting function τ
+
+## Open Question
+The parent entry (OQ-06) proves the *parity* criterion `τ(n) odd ⟺ n is a perfect square`,
+using the prime-factorisation form of `τ = σ₀` internally. This follow-up isolates and
+packages the underlying **multiplicative structure of τ itself** as a standalone gallery
+identity, exactly as requested by the pool note:
+
+  **τ(n) = ∏_{p ∣ n} (vₚ(n) + 1)**,  and in particular  **τ(pᵃ) = a + 1**.
+
+## Honest scope note
+Mathlib already contains the two headline facts in `Finsupp.prod` form
+(`Nat.card_divisors`) and for coprime products (`Nat.Coprime.card_divisors_mul`). The value
+this entry adds over a raw citation is:
+
+  1. A gallery-facing restatement of the formula as an ordinary product `∏ p ∈ n.primeFactors`.
+  2. The prime-power specialisation `τ(pᵃ) = a + 1` (derived from `Nat.divisors_prime_pow`),
+     which Mathlib does not state directly, together with its `τ(p) = 2` corollary.
+  3. A **sharpness** result: the coprimality hypothesis in the multiplicative law is
+     genuinely necessary — `τ(2·2) = 3 ≠ 4 = τ(2)·τ(2)`. This is the theory-level content
+     that distinguishes "multiplicative on coprimes" from "completely multiplicative", and
+     it is not recorded anywhere in the gallery.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace SumOfDivisorsOQ06OQ01
+
+open ArithmeticFunction Finset
+
+/-- **The divisor-counting product formula.** For `n ≠ 0`,
+`τ(n) = ∏_{p ∈ primeFactors n} (vₚ(n) + 1)`. This is `Nat.card_divisors` rephrased from the
+`Finsupp.prod` over the factorisation support to an ordinary `Finset.prod` over the prime
+factors, the form used in elementary number theory. -/
+theorem card_divisors_eq_prod {n : ℕ} (hn : n ≠ 0) :
+    #n.divisors = ∏ p ∈ n.primeFactors, (n.factorization p + 1) := by
+  rw [Nat.card_divisors hn, ← Nat.support_factorization]
+
+/-- **Divisor count of a prime power.** `τ(pᵃ) = a + 1`. The divisors of `pᵃ` are exactly
+`p⁰, p¹, …, pᵃ`, giving `a + 1` of them. -/
+theorem card_divisors_prime_pow {p : ℕ} (pp : p.Prime) (a : ℕ) :
+    #(p ^ a).divisors = a + 1 := by
+  rw [Nat.divisors_prime_pow pp, Finset.card_map, Finset.card_range]
+
+/-- **A prime has exactly two divisors.** The `a = 1` case of the prime-power formula. -/
+theorem card_divisors_prime {p : ℕ} (pp : p.Prime) : #p.divisors = 2 := by
+  have h := card_divisors_prime_pow pp 1
+  rwa [pow_one] at h
+
+/-- **Multiplicativity on coprime arguments.** For coprime `m, n`,
+`τ(m·n) = τ(m)·τ(n)`. Re-exported from `Nat.Coprime.card_divisors_mul` so the product
+formula and its multiplicative law live together in one entry. -/
+theorem card_divisors_coprime_mul {m n : ℕ} (h : m.Coprime n) :
+    #(m * n).divisors = #m.divisors * #n.divisors :=
+  Nat.Coprime.card_divisors_mul h
+
+/-- **Sharpness of the coprimality hypothesis.** The multiplicative law fails without
+coprimality: with `m = n = 2` (so `gcd = 2 ≠ 1`),
+`τ(4) = 3` while `τ(2)·τ(2) = 4`. Hence `τ` is multiplicative but **not** completely
+multiplicative — the coprimality hypothesis in `card_divisors_coprime_mul` cannot be
+dropped. -/
+theorem card_divisors_mul_ne_of_not_coprime :
+    #(2 * 2 : ℕ).divisors ≠ #(2 : ℕ).divisors * #(2 : ℕ).divisors := by decide
+
+/-- The failing pair really is non-coprime, pinning down why the law does not apply. -/
+theorem not_coprime_two_two : ¬ (2 : ℕ).Coprime 2 := by decide
+
+/-! ### Worked computations via the product formula -/
+
+/-- `12 = 2²·3`, so `τ(12) = (2+1)(1+1) = 6`. -/
+example : #(12 : ℕ).divisors = 6 := by decide
+
+/-- `100 = 2²·5²`, so `τ(100) = (2+1)(2+1) = 9`. -/
+example : #(100 : ℕ).divisors = 9 := by decide
+
+/-- Assembling `τ(12)` from its coprime prime-power factors `4` and `3` via the
+multiplicative law: `τ(4·3) = τ(4)·τ(3) = 3·2 = 6` (and `4·3 = 12`). -/
+example : #(4 * 3 : ℕ).divisors = #(4 : ℕ).divisors * #(3 : ℕ).divisors :=
+  card_divisors_coprime_mul (by decide)
+
+/-- The same via the prime-power formula: `τ(2⁵) = 6`. -/
+example : #(2 ^ 5 : ℕ).divisors = 6 := card_divisors_prime_pow (by norm_num) 5
+
+end SumOfDivisorsOQ06OQ01

--- a/src/data/proofs/sum-of-divisors-oq-06-oq-01/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-06-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "sum-of-divisors-oq-06-oq-01",
+  "title": "The Product Formula for the Divisor-Counting Function τ",
+  "slug": "sum-of-divisors-oq-06-oq-01",
+  "description": "Packages the multiplicative structure of the divisor-counting function τ = σ₀ as a standalone gallery identity: τ(n) = ∏_{p∣n}(vₚ(n)+1), the prime-power specialisation τ(pᵃ) = a+1 (and τ(p) = 2), and multiplicativity on coprime arguments τ(m·n) = τ(m)·τ(n). Directly answers the follow-up question posed in the parent entry OQ-06. Also proves a sharpness result — the coprimality hypothesis is genuinely necessary, since τ(2·2) = 3 ≠ 4 = τ(2)·τ(2), so τ is multiplicative but not completely multiplicative. Routes through Nat.card_divisors, Nat.divisors_prime_pow, and Nat.Coprime.card_divisors_mul.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Divisor_function",
+    "date": "antiquity",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-function",
+      "tau",
+      "sigma",
+      "multiplicative",
+      "prime-power",
+      "factorization",
+      "arithmetic-functions",
+      "sharpness",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfDivisorsOQ06OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.card_divisors",
+        "description": "n ≠ 0 → #n.divisors = n.factorization.prod (fun _ k => k + 1) — the divisor count as a product over prime exponents, the source of the product formula",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "Nat.divisors_prime_pow",
+        "description": "p.Prime → (p^k).divisors = (Finset.range (k+1)).map ⟨(p^·), _⟩ — the divisors of a prime power are p⁰,…,pᵏ, giving τ(pᵃ) = a+1",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Nat.Coprime.card_divisors_mul",
+        "description": "m.Coprime n → #(m·n).divisors = #m.divisors · #n.divisors — multiplicativity of τ on coprime arguments (from isMultiplicative_sigma)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "Nat.support_factorization",
+        "description": "n.factorization.support = n.primeFactors — bridges the Finsupp product and the Finset product over prime factors",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      }
+    ],
+    "originalContributions": [
+      "card_divisors_eq_prod: #n.divisors = ∏_{p ∈ primeFactors n} (vₚ(n) + 1) — the divisor-count product formula restated as an ordinary Finset product (Mathlib states it only in Finsupp.prod form)",
+      "card_divisors_prime_pow: #(p^a).divisors = a + 1 for prime p — the prime-power specialisation, not stated directly in Mathlib",
+      "card_divisors_prime: #p.divisors = 2 for prime p — the a = 1 corollary",
+      "card_divisors_mul_ne_of_not_coprime: #(2·2).divisors ≠ #2.divisors · #2.divisors — sharpness witness showing τ is NOT completely multiplicative, so the coprimality hypothesis cannot be dropped",
+      "not_coprime_two_two: ¬ (2).Coprime 2 — certifies the sharpness witness really is non-coprime"
+    ],
+    "dateAdded": "2026-07-05",
+    "lineCount": 86,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Numeric examples use kernel `decide` (not `native_decide`), so no additional trust assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The divisor-counting function τ(n) = σ₀(n) = #{d : d ∣ n} is one of the two basic multiplicative functions of classical number theory, alongside the divisor sum σ(n). Its computational backbone is the product formula τ(n) = ∏ (aᵢ + 1) over the exponents of the factorisation n = ∏ pᵢ^{aᵢ}, first written down in this generality by Euler and standard in every introductory text (Hardy–Wright §XVI, Apostol Thm 2.13). The formula rests on two facts: divisors of a prime power pᵃ are exactly p⁰,…,pᵃ (so τ(pᵃ) = a+1), and τ is multiplicative on coprime arguments, so the count factors across the coprime prime-power components. This entry isolates that multiplicative structure — the input to the parent entry's perfect-square parity criterion — as a self-contained gallery identity, and additionally pins down that multiplicativity requires coprimality: τ is multiplicative but not completely multiplicative.",
+    "problemStatement": "**Open Question (sum-of-divisors-oq-06-oq-01, posed in OQ-06)**: Prove the multiplicative closed form τ(n) = ∏_p (vₚ(n) + 1) as a standalone gallery identity and derive τ(pᵃ) = a + 1.\n\n**Result**: card_divisors_eq_prod (the product formula over prime factors), card_divisors_prime_pow (τ(pᵃ) = a+1) with its corollary card_divisors_prime (τ(p) = 2), card_divisors_coprime_mul (multiplicativity on coprimes), and the sharpness pair card_divisors_mul_ne_of_not_coprime / not_coprime_two_two witnessing that coprimality cannot be dropped.",
+    "text": "For n ≠ 0, the number of divisors #n.divisors = τ(n) = σ₀(n) equals the product ∏_{p ∈ primeFactors n} (vₚ(n) + 1). In particular τ(pᵃ) = a + 1 for a prime p, τ(p) = 2, and τ(m·n) = τ(m)·τ(n) whenever m and n are coprime. The coprimality hypothesis is necessary: τ(2·2) = τ(4) = 3 while τ(2)·τ(2) = 4.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `card_divisors_eq_prod`: `Nat.card_divisors` gives τ(n) = n.factorization.prod (fun _ k => k+1); rewriting the Finsupp product's index set with `Nat.support_factorization` (support = primeFactors) turns it into the ordinary Finset product ∏_{p ∈ primeFactors n} (vₚ(n) + 1) definitionally.\n2. `card_divisors_prime_pow`: `Nat.divisors_prime_pow` exhibits the divisors of pᵃ as the image of range (a+1) under an injective map p^·; `Finset.card_map` and `Finset.card_range` count them as a+1.\n3. `card_divisors_prime`: the a = 1 case, using pow_one.\n4. `card_divisors_coprime_mul`: re-exports `Nat.Coprime.card_divisors_mul` (multiplicativity of σ₀ on coprime arguments), placing the multiplicative law beside the product formula.\n5. `card_divisors_mul_ne_of_not_coprime` and `not_coprime_two_two`: kernel `decide` on the concrete pair m = n = 2 (τ(4) = 3 ≠ 4 = τ(2)²) certifies that dropping coprimality breaks the law.",
+    "keyInsights": [
+      "**The formula is the factorisation.** τ(n) = ∏ (vₚ(n) + 1) is Nat.card_divisors up to rewriting the index set from the factorisation support to the prime factors; the arithmetic content lives entirely in the prime-power count.",
+      "**Prime powers are the atoms.** τ(pᵃ) = a + 1 because the divisors of pᵃ are exactly p⁰,…,pᵃ — an explicit bijection with {0,…,a}, formalised by Nat.divisors_prime_pow as a map from range (a+1).",
+      "**Multiplicative, not completely multiplicative.** τ(m·n) = τ(m)·τ(n) holds for coprime m,n but fails in general: τ(4) = 3 ≠ 4 = τ(2)². The sharpness witness records exactly where the coprimality hypothesis earns its place — the distinction between the two notions of multiplicativity for an arithmetic function."
+    ]
+  },
+  "sections": [
+    {
+      "title": "The product formula and prime-power values",
+      "startLine": 37,
+      "endLine": 52,
+      "summary": "card_divisors_eq_prod (τ(n) = ∏_{p∣n}(vₚ(n)+1)), card_divisors_prime_pow (τ(pᵃ)=a+1), and card_divisors_prime (τ(p)=2).",
+      "mathContext": "$\\tau(n) = \\prod_{p \\mid n} (v_p(n)+1)$, $\\tau(p^a) = a+1$."
+    },
+    {
+      "title": "Multiplicativity and its sharpness",
+      "startLine": 54,
+      "endLine": 69,
+      "summary": "card_divisors_coprime_mul (coprime multiplicativity) and the sharpness pair showing τ(2·2) ≠ τ(2)·τ(2).",
+      "mathContext": "$\\gcd(m,n)=1 \\Rightarrow \\tau(mn)=\\tau(m)\\tau(n)$, but $\\tau(4)=3\\neq 4=\\tau(2)^2$."
+    },
+    {
+      "title": "Worked computations",
+      "startLine": 71,
+      "endLine": 84,
+      "summary": "τ(12)=6, τ(100)=9, and the assembly τ(4·3)=τ(4)·τ(3), τ(2⁵)=6 via the formulas.",
+      "mathContext": "$\\tau(12)=6$, $\\tau(100)=9$, $\\tau(2^5)=6$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-divisors-oq-06",
+      "relationship": "extends",
+      "description": "Answers the explicit follow-up question posed in OQ-06: proves the product formula τ(n) = ∏(vₚ+1) as a standalone identity and derives τ(pᵃ) = a+1, supplying the multiplicative structure underlying OQ-06's parity criterion"
+    },
+    {
+      "targetId": "sum-of-divisors-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 develops σₖ on primes and prime powers; this entry packages the analogous multiplicative closed form for σ₀ = τ together with the sharpness of coprime multiplicativity"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) packaging of the multiplicative structure of the divisor-counting function τ = σ₀: the product formula τ(n) = ∏_{p∣n}(vₚ(n)+1), the prime-power values τ(pᵃ) = a+1 and τ(p) = 2, multiplicativity on coprime arguments, and a sharpness witness showing coprimality is necessary.",
+    "implications": "Provides the computational closed form for τ as reusable gallery lemmas and records the multiplicative-but-not-completely-multiplicative distinction with an explicit counterexample, directly discharging the follow-up question raised by OQ-06.",
+    "openQuestions": [
+      "Prove the general assembly τ(∏ pᵢ^{aᵢ}) = ∏ (aᵢ + 1) over an arbitrary finset of coprime prime powers by induction from card_divisors_coprime_mul and card_divisors_prime_pow.",
+      "Characterise the n with τ(n) = k for small fixed k (e.g. τ(n) = 2 ⟺ n prime, τ(n) = 3 ⟺ n = p² ) as a structural classification."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "ArithmeticFunction",
+      "Finset"
+    ],
+    "namespace": "SumOfDivisorsOQ06OQ01",
+    "lineCount": 86,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/SumOfDivisorsOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Chapter XVI: the divisor function d(n) = τ(n), its multiplicativity and value on prime powers d(pᵃ) = a+1"
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer Undergraduate Texts in Mathematics",
+      "note": "Theorem 2.13: d(n) = ∏ (aᵢ + 1) for n = ∏ pᵢ^{aᵢ}; Theorem 2.14: multiplicativity of d on coprime arguments"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the explicit follow-up question posed in the parent entry **OQ-06** (`sum-of-divisors-oq-06`), whose `openQuestions` list asks to "prove the multiplicative closed form τ(n) = ∏_p (vₚ(n)+1) as a standalone gallery identity and derive τ(pᵃ) = a+1."

New gallery entry **`sum-of-divisors-oq-06-oq-01`** packaging the multiplicative structure of the divisor-counting function τ = σ₀:

| Theorem | Statement |
|---|---|
| `card_divisors_eq_prod` | `#n.divisors = ∏_{p ∈ primeFactors n} (vₚ(n)+1)` (ordinary Finset product form) |
| `card_divisors_prime_pow` | `#(p^a).divisors = a+1` for prime `p` |
| `card_divisors_prime` | `#p.divisors = 2` for prime `p` |
| `card_divisors_coprime_mul` | `#(m·n).divisors = #m.divisors · #n.divisors` for coprime `m,n` |
| `card_divisors_mul_ne_of_not_coprime` | `#(2·2).divisors ≠ #2.divisors · #2.divisors` — **sharpness** |
| `not_coprime_two_two` | `¬ (2).Coprime 2` — certifies the witness |

## Mathematical content

Mathlib already provides `Nat.card_divisors` (Finsupp.prod form) and `Nat.Coprime.card_divisors_mul`. The value added over a raw citation:
1. The gallery-facing **ordinary product** restatement over `primeFactors`.
2. The prime-power specialisation `τ(pᵃ)=a+1` (from `Nat.divisors_prime_pow`), not stated directly in Mathlib.
3. A **sharpness** result: τ(4)=3 ≠ 4=τ(2)², so τ is multiplicative but **not completely multiplicative** — the coprimality hypothesis is necessary. This theory-level distinction is not recorded elsewhere in the gallery.

## Verification

- **0 sorries, 0 axioms.** Builds against Mathlib v4.26.0 via `./proofs/scripts/docker-build.sh Proofs.SumOfDivisorsOQ06OQ01` ✔ (7743 jobs).
- Numeric examples use kernel `decide` (**not** `native_decide`), so no `Lean.ofReduceBool` trust assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)