### PR TITLE
research(handshake-lemma): degree-sum identity + odd-regular⟹even-order corollary [verified, 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/HandshakeLemma.lean
+++ b/proofs/Proofs/HandshakeLemma.lean
@@ -1,0 +1,94 @@
+/-
+# The Handshake Lemma and its parity corollaries
+
+## Statement
+For a finite simple graph `G`, the sum of all vertex degrees equals twice the
+number of edges:
+
+  **∑_{v} deg(v) = 2 · |E(G)|.**
+
+Equivalently, the degree sum is always even, and the number of vertices of odd
+degree is even ("at any party, an even number of people have shaken hands an odd
+number of times").
+
+## Honest scope note
+Mathlib already contains the two headline facts:
+  * `SimpleGraph.sum_degrees_eq_twice_card_edges` — the handshake identity itself;
+  * `SimpleGraph.even_card_odd_degree_vertices` — the even-odd-degree corollary.
+
+This entry restates those as gallery-facing theorems and then adds the corollaries
+that Mathlib does **not** state directly, which are the theory-level content here:
+
+  1. `even_sum_degrees` — the degree sum is even (the "counting parity" form).
+  2. `even_card_of_all_odd_degree` — if *every* vertex has odd degree the graph has an
+     even number of vertices (the filtered set is everything).
+  3. `even_card_of_oddRegular` — **an odd-regular finite graph has even order.** This is
+     the clean structural consequence combining regularity with the handshake parity, and
+     it is not recorded in Mathlib.
+  4. A **sharpness** witness: the triangle `K₃ = (⊤ : SimpleGraph (Fin 3))` is `2`-regular
+     (even degree) yet has `3` (odd) vertices, so the oddness hypothesis in
+     `even_card_of_oddRegular` genuinely cannot be dropped.
+
+Sorry-free and axiom-free (the sharpness witnesses use kernel `decide`, not
+`native_decide`, so no extra trust assumptions are introduced).
+-/
+import Mathlib
+
+namespace HandshakeLemma
+
+open Finset SimpleGraph
+
+variable {V : Type*} [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-- **The Handshake Lemma.** In a finite simple graph the sum of the vertex degrees
+equals twice the number of edges. (A gallery restatement of Mathlib's
+`SimpleGraph.sum_degrees_eq_twice_card_edges`.) -/
+theorem sum_degrees_eq_twice_card_edges :
+    ∑ v, G.degree v = 2 * G.edgeFinset.card :=
+  G.sum_degrees_eq_twice_card_edges
+
+/-- The sum of all vertex degrees is even — the counting-parity form of the handshake
+lemma, immediate from `∑ deg = 2·|E|`. -/
+theorem even_sum_degrees : Even (∑ v, G.degree v) := by
+  rw [sum_degrees_eq_twice_card_edges]
+  exact even_two_mul _
+
+/-- **Handshake corollary.** The number of vertices of odd degree is even. (A gallery
+restatement of Mathlib's `SimpleGraph.even_card_odd_degree_vertices`.) -/
+theorem even_card_odd_degree_vertices :
+    Even (univ.filter fun v => Odd (G.degree v)).card :=
+  G.even_card_odd_degree_vertices
+
+/-- If **every** vertex has odd degree, then the graph has an even number of vertices:
+the set of odd-degree vertices is all of `V`, and that set has even cardinality. -/
+theorem even_card_of_all_odd_degree
+    (h : ∀ v, Odd (G.degree v)) : Even (Fintype.card V) := by
+  have hfilter : (univ.filter fun v => Odd (G.degree v)) = univ := by
+    ext v; simp [h v]
+  have := G.even_card_odd_degree_vertices
+  rwa [hfilter, card_univ] at this
+
+/-- **Odd-regular graphs have even order.** If `G` is `d`-regular with `d` odd, then the
+number of vertices of `G` is even. This is the structural consequence of the handshake
+parity: every vertex then has odd degree, so the vertex set splits into pairs. Mathlib does
+not state this directly. -/
+theorem even_card_of_oddRegular {d : ℕ} (hodd : Odd d)
+    (hreg : G.IsRegularOfDegree d) : Even (Fintype.card V) :=
+  even_card_of_all_odd_degree G fun v => by rw [hreg v]; exact hodd
+
+section Sharpness
+
+/-- **Sharpness (part 1).** The triangle `K₃ = (⊤ : SimpleGraph (Fin 3))` is `2`-regular:
+every vertex has degree `Fintype.card (Fin 3) - 1 = 2`. -/
+theorem triangle_isRegular : (⊤ : SimpleGraph (Fin 3)).IsRegularOfDegree 2 := by
+  simpa using IsRegularOfDegree.top (V := Fin 3)
+
+/-- **Sharpness (part 2).** The triangle has an odd number (`3`) of vertices. Combined
+with `triangle_isRegular` and `Even 2`, this shows an *even*-regular graph can have odd
+order — so the oddness hypothesis in `even_card_of_oddRegular` cannot be dropped. -/
+theorem triangle_card_odd : Odd (Fintype.card (Fin 3)) := by
+  decide
+
+end Sharpness
+
+end HandshakeLemma

--- a/src/data/proofs/handshake-lemma/meta.json
+++ b/src/data/proofs/handshake-lemma/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "handshake-lemma",
+  "title": "The Handshake Lemma and its Parity Corollaries",
+  "slug": "handshake-lemma",
+  "description": "Formalizes the handshake lemma for finite simple graphs — ∑_v deg(v) = 2·|E(G)| — and its parity consequences: the degree sum is even, and the number of odd-degree vertices is even. Adds the corollaries Mathlib does not state directly: if every vertex has odd degree then the graph has even order, and its clean structural specialisation — an odd-regular finite graph has an even number of vertices. Includes a sharpness witness: the triangle K₃ = (⊤ : SimpleGraph (Fin 3)) is 2-regular with 3 (odd) vertices, showing the oddness hypothesis genuinely cannot be dropped. Routes through Mathlib's SimpleGraph.sum_degrees_eq_twice_card_edges, SimpleGraph.even_card_odd_degree_vertices, and IsRegularOfDegree.top.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Handshaking_lemma",
+    "date": "1736 (Euler)",
+    "status": "verified",
+    "tags": [
+      "graph-theory",
+      "combinatorics",
+      "degree-sum",
+      "handshake-lemma",
+      "parity",
+      "regular-graph",
+      "sharpness",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/HandshakeLemma.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.sum_degrees_eq_twice_card_edges",
+        "description": "∑ v, G.degree v = 2 * #G.edgeFinset — the degree-sum formula (handshake lemma) for a finite simple graph, proved via the double count of darts",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
+      },
+      {
+        "theorem": "SimpleGraph.even_card_odd_degree_vertices",
+        "description": "Even #{v | Odd (G.degree v)} — the number of odd-degree vertices is even, obtained by reducing the degree sum modulo 2",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
+      },
+      {
+        "theorem": "SimpleGraph.IsRegularOfDegree.top",
+        "description": "(⊤ : SimpleGraph V).IsRegularOfDegree (Fintype.card V - 1) — the complete graph is (n-1)-regular, used to build the sharpness witness K₃",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      }
+    ],
+    "originalContributions": [
+      "even_sum_degrees: Even (∑ v, G.degree v) — the counting-parity form of the handshake lemma, immediate from ∑ deg = 2·|E| (not stated separately in Mathlib)",
+      "even_card_of_all_odd_degree: (∀ v, Odd (G.degree v)) → Even (Fintype.card V) — if every vertex has odd degree the graph has even order; the odd-degree filter is all of V",
+      "even_card_of_oddRegular: Odd d → G.IsRegularOfDegree d → Even (Fintype.card V) — an odd-regular finite graph has even order, the clean structural consequence of the handshake parity, not recorded in Mathlib",
+      "triangle_isRegular: (⊤ : SimpleGraph (Fin 3)).IsRegularOfDegree 2 — K₃ is 2-regular (even degree), the first half of the sharpness witness",
+      "triangle_card_odd: Odd (Fintype.card (Fin 3)) — K₃ has an odd number of vertices, showing an even-regular graph can have odd order, so the oddness hypothesis in even_card_of_oddRegular cannot be dropped"
+    ],
+    "dateAdded": "2026-07-05",
+    "lineCount": 94,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The sharpness witnesses use kernel `decide` / `simp` (not `native_decide`), so no additional trust assumptions are introduced.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The handshake lemma is the oldest theorem of graph theory: it appears in Euler's 1736 solution of the Königsberg bridges, the paper usually cited as the birth of the subject. In modern terms, for a finite simple graph G the sum of the vertex degrees counts each edge exactly twice, so ∑_v deg(v) = 2·|E(G)|. The most quoted corollary is the parity statement — the number of vertices of odd degree is always even — popularly phrased as: at any gathering, the number of people who have shaken hands an odd number of times is even. Both statements are standard in Mathlib (SimpleGraph.sum_degrees_eq_twice_card_edges and SimpleGraph.even_card_odd_degree_vertices). This entry restates them as gallery-facing theorems and then draws out the structural corollaries that Mathlib leaves implicit, culminating in the clean fact that an odd-regular finite graph must have an even number of vertices, together with an explicit witness (the triangle) certifying that the regularity degree really must be odd.",
+    "problemStatement": "**Handshake lemma (handshake-lemma)**: For a finite simple graph G, prove ∑_v deg(v) = 2·|E(G)|, derive the parity corollary that the number of odd-degree vertices is even, and package the structural consequences for regular graphs.\n\n**Result**: sum_degrees_eq_twice_card_edges (the identity), even_sum_degrees and even_card_odd_degree_vertices (the parity forms), even_card_of_all_odd_degree (all-odd-degree ⟹ even order), even_card_of_oddRegular (odd-regular ⟹ even order), and the sharpness pair triangle_isRegular / triangle_card_odd witnessing that oddness of the regularity degree is necessary.",
+    "text": "For a finite simple graph G, ∑_v deg(v) = 2·|E(G)|; hence the degree sum is even and the set of odd-degree vertices has even cardinality. If every vertex has odd degree, |V| is even; in particular any d-regular graph with d odd has an even number of vertices. The oddness of d is necessary: the triangle K₃ is 2-regular yet has 3 vertices.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `sum_degrees_eq_twice_card_edges`: re-exports Mathlib's degree-sum formula (double count of darts).\n2. `even_sum_degrees`: rewrite the sum as 2·|E| and apply even_two_mul.\n3. `even_card_odd_degree_vertices`: re-exports Mathlib's handshake parity corollary.\n4. `even_card_of_all_odd_degree`: when every vertex has odd degree, the filter {v | Odd (deg v)} equals univ (ext + simp), so its card is Fintype.card V, which is even by the previous corollary.\n5. `even_card_of_oddRegular`: a d-regular graph with d odd has all degrees odd (rewrite by regularity), so the previous lemma applies.\n6. `triangle_isRegular`: IsRegularOfDegree.top gives (⊤ : SimpleGraph (Fin 3)).IsRegularOfDegree (Fintype.card (Fin 3) - 1); simp evaluates the degree to 2.\n7. `triangle_card_odd`: kernel `decide` on Odd (Fintype.card (Fin 3)) = Odd 3. Together these show an even-regular graph can have odd order.",
+    "keyInsights": [
+      "**Each edge is counted twice.** The degree sum ∑_v deg(v) counts incident (vertex, edge) pairs; every edge contributes its two endpoints, giving 2·|E|. This is the entire content of the handshake lemma.",
+      "**Parity is the payload.** Reducing 2·|E| modulo 2 forces the number of odd-degree vertices to be even — the statement most used in practice, and the seed of a dozen olympiad parity arguments.",
+      "**Odd regularity forces even order.** Combining the parity corollary with regularity yields a clean structural theorem: no graph can be d-regular with d odd on an odd number of vertices. The triangle (2-regular, 3 vertices) shows the hypothesis d odd is exactly what is needed — an even regularity degree lifts the constraint."
+    ]
+  },
+  "sections": [
+    {
+      "title": "The handshake lemma and its parity forms",
+      "startLine": 46,
+      "endLine": 62,
+      "summary": "sum_degrees_eq_twice_card_edges (∑ deg = 2·|E|), even_sum_degrees (degree sum even), and even_card_odd_degree_vertices (number of odd-degree vertices is even).",
+      "mathContext": "$\\sum_v \\deg(v) = 2\\,|E(G)|$; the number of $v$ with $\\deg(v)$ odd is even."
+    },
+    {
+      "title": "Structural corollaries for regular graphs",
+      "startLine": 64,
+      "endLine": 77,
+      "summary": "even_card_of_all_odd_degree (all-odd-degree ⟹ even order) and even_card_of_oddRegular (odd-regular ⟹ even order).",
+      "mathContext": "$(\\forall v,\\ \\deg(v)\\text{ odd}) \\Rightarrow |V|\\text{ even}$; $d$ odd and $G$ $d$-regular $\\Rightarrow |V|$ even."
+    },
+    {
+      "title": "Sharpness: the triangle K₃",
+      "startLine": 79,
+      "endLine": 92,
+      "summary": "triangle_isRegular (K₃ is 2-regular) and triangle_card_odd (K₃ has 3 vertices), witnessing that the oddness hypothesis in even_card_of_oddRegular cannot be dropped.",
+      "mathContext": "$K_3$ is $2$-regular with $|V| = 3$ odd, so even regularity permits odd order."
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the handshake lemma ∑_v deg(v) = 2·|E(G)| together with its parity corollaries and their structural consequences for regular graphs, capped by an explicit sharpness witness.",
+    "implications": "Beyond re-exporting Mathlib's degree-sum identity and even-odd-degree corollary, the entry supplies the reusable structural lemma that odd-regular finite graphs have even order, and pins down with the triangle K₃ that the oddness of the regularity degree is exactly the hypothesis doing the work.",
+    "openQuestions": [
+      "Quantify the parity obstruction: for d-regular graphs on n vertices with d odd and n odd (which cannot exist), describe the nearest realisable degree sequence — i.e. the minimal edge deficiency forced by the handshake parity.",
+      "Formalise the converse direction of realisability (Erdős–Gallai): characterise which degree sequences summing to an even number are graphical, situating the handshake parity as the first of the necessary conditions."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "SimpleGraph"
+    ],
+    "namespace": "HandshakeLemma",
+    "lineCount": 94,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/HandshakeLemma.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Solutio problematis ad geometriam situs pertinentis",
+      "year": "1736",
+      "venue": "Commentarii academiae scientiarum Petropolitanae 8, 128–140",
+      "note": "The Königsberg bridges paper; the degree-sum/parity observation is the founding argument of graph theory"
+    },
+    {
+      "authors": "Bondy, J. A. and Murty, U. S. R.",
+      "title": "Graph Theory",
+      "year": "2008",
+      "venue": "Springer Graduate Texts in Mathematics 244",
+      "note": "Theorem 1.1 (handshaking lemma) and its corollary on the parity of the number of odd-degree vertices"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/handshake-lemma.json
+++ b/src/data/research/problems/handshake-lemma.json
@@ -1,0 +1,44 @@
+{
+  "slug": "handshake-lemma",
+  "title": "Handshake Lemma: Sum of Vertex Degrees Equals Twice the Edge Count",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "Proofs/HandshakeLemma.lean",
+  "problemStatement": "Prove the handshake lemma ∑_v deg(v) = 2·|E(G)| for a finite simple graph, its parity corollary that the number of odd-degree vertices is even, and package the structural consequences for regular graphs.",
+  "knownResults": "The degree-sum identity and the even-odd-degree corollary are both in Mathlib (SimpleGraph.sum_degrees_eq_twice_card_edges, SimpleGraph.even_card_odd_degree_vertices). The structural corollary that odd-regular graphs have even order is standard but not stated directly in Mathlib.",
+  "currentState": "COMPLETE. Verified gallery entry (0 sorries, 0 axioms) proving the handshake lemma, its parity forms, the all-odd-degree ⟹ even-order corollary, the odd-regular ⟹ even-order theorem, and a sharpness witness (the triangle K₃ is 2-regular with odd order).",
+  "knowledge": {
+    "progressSummary": "COMPLETE: verified entry with the handshake lemma plus the odd-regular ⟹ even-order corollary and a triangle sharpness witness (0 sorry / 0 axiom, kernel-checked).",
+    "builtItems": [
+      "sum_degrees_eq_twice_card_edges in Proofs/HandshakeLemma.lean:46 — the handshake identity (re-export)",
+      "even_sum_degrees in Proofs/HandshakeLemma.lean:52 — the degree sum is even",
+      "even_card_odd_degree_vertices in Proofs/HandshakeLemma.lean:58 — number of odd-degree vertices is even (re-export)",
+      "even_card_of_all_odd_degree in Proofs/HandshakeLemma.lean:64 — all-odd-degree ⟹ even order",
+      "even_card_of_oddRegular in Proofs/HandshakeLemma.lean:75 — odd-regular ⟹ even order (not in Mathlib)",
+      "triangle_isRegular in Proofs/HandshakeLemma.lean:83 — K₃ is 2-regular",
+      "triangle_card_odd in Proofs/HandshakeLemma.lean:89 — K₃ has odd order (sharpness)"
+    ],
+    "insights": [
+      "Both the degree-sum identity and the even-odd-degree corollary already live in Mathlib, so the theory-level value of the entry is the structural corollary for regular graphs, not the identity itself.",
+      "even_card_of_oddRegular reduces to even_card_of_all_odd_degree by rewriting each degree with the regularity hypothesis; the parity comes entirely from Mathlib's even_card_odd_degree_vertices.",
+      "The oddness hypothesis in even_card_of_oddRegular is exactly necessary: the triangle K₃ = (⊤ : SimpleGraph (Fin 3)) is 2-regular (even degree) with 3 (odd) vertices, obtained cleanly from IsRegularOfDegree.top."
+    ],
+    "nextSteps": [
+      "Optional: quantify the parity obstruction (minimal edge deficiency for a would-be odd-regular graph on an odd number of vertices).",
+      "Optional: formalise the necessary direction of Erdős–Gallai, situating the handshake parity as the first graphical-sequence condition."
+    ]
+  },
+  "tags": [
+    "graph-theory",
+    "combinatorics",
+    "degree-sum",
+    "handshake-lemma",
+    "parity",
+    "regular-graph"
+  ],
+  "started": "2026-07-05",
+  "lastUpdate": "2026-07-05",
+  "significance": 5,
+  "tractability": 8
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **handshake-lemma**: the handshake lemma for finite simple graphs, ∑_v deg(v) = 2·|E(G)|, together with its parity corollaries and their structural consequences for regular graphs.

## Honest scope

Both headline facts are already in Mathlib (`SimpleGraph.sum_degrees_eq_twice_card_edges`, `SimpleGraph.even_card_odd_degree_vertices`). This entry restates them as gallery-facing theorems and adds the corollaries Mathlib does **not** state directly — that is the theory-level content:

- `even_sum_degrees` — the degree sum is even
- `even_card_of_all_odd_degree` — if every vertex has odd degree, the graph has even order
- **`even_card_of_oddRegular`** — an odd-regular finite graph has even order (the clean structural corollary)
- **Sharpness** — `triangle_isRegular` / `triangle_card_odd`: the triangle K₃ = (⊤ : SimpleGraph (Fin 3)) is 2-regular with 3 (odd) vertices, showing the oddness hypothesis genuinely cannot be dropped

## Verification

- Kernel-verified via `./proofs/scripts/docker-build.sh Proofs.HandshakeLemma` — build succeeded, 7743 jobs, exit 0
- **0 sorries, 0 axioms**; sharpness witnesses use kernel `decide` / `simp` (no `native_decide`), so no extra trust assumptions
- 7 theorems, 94 lines; meta.json 10.7 KB (within gallery cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)