### PR TITLE
research(casting-out-nines): digit-sum congruence package [verified, 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/CastingOutNines.lean
+++ b/proofs/Proofs/CastingOutNines.lean
@@ -1,0 +1,138 @@
+/-
+Casting Out Nines: Digit-Sum Congruences and the Multiplicative Check
+
+Source: Open question from the casting-out-nines gallery entry
+Status: VERIFIED (0 axioms, 0 sorries)
+
+"Casting out nines" is the classical hand-computation error check. Its
+mathematical basis is that the decimal digit sum S(n) of a natural number is
+congruent to n itself modulo 9, and that this congruence is compatible with
+both addition and multiplication. Concretely, to sanity-check a product
+a · b = c one verifies S(a) · S(b) ≡ S(c) (mod 9); a mismatch certifies an
+arithmetic error.
+
+This file assembles the elementary theory:
+
+  * The base-agnostic congruence  n ≡ (digits b' n).sum (mod b)  whenever
+    b' ≡ 1 (mod b), via `Nat.modEq_digits_sum`.
+  * The mod-9 and mod-3 congruences, and the resulting divisibility rules
+    packaged as `↔` statements on the digit sum.
+  * The additive and multiplicative compatibility laws — the actual justification
+    of the casting-out-nines check — S(a+b) ≡ S(a)+S(b) and
+    S(a·b) ≡ S(a)·S(b) modulo 9, together with a soundness statement for the
+    multiplication check.
+  * The alternating-digit-sum divisibility rule for 11.
+  * Worked numerical instances that require no digit computation.
+
+Everything reduces to Mathlib's `Nat.modEq_*_digits_sum` congruences; the
+content surfaced here is packaging them as usable divisibility criteria plus
+the compatibility laws that make the check sound.
+-/
+
+import Mathlib
+
+namespace CastingOutNines
+
+/-! ## Digit sum -/
+
+/-- The decimal digit sum of `n`. -/
+def S (n : ℕ) : ℕ := (Nat.digits 10 n).sum
+
+/-! ## Part I: The base-agnostic congruence
+
+For any base `b'` congruent to `1` modulo `b`, a number is congruent to its
+base-`b'` digit sum modulo `b`. Taking `b = 9, 3` and `b' = 10` (since
+`10 ≡ 1 (mod 9)` and `10 ≡ 1 (mod 3)`) recovers the classical rules. -/
+
+/-- Base-agnostic form: `n ≡ (digits b' n).sum (mod b)` when `b' ≡ 1 (mod b)`. -/
+theorem modEq_digitSum_base (b b' : ℕ) (h : b' % b = 1) (n : ℕ) :
+    n ≡ (Nat.digits b' n).sum [MOD b] :=
+  Nat.modEq_digits_sum b b' h n
+
+/-- `n ≡ S(n) (mod 9)`: the core casting-out-nines congruence. -/
+theorem modEq_nine (n : ℕ) : n ≡ S n [MOD 9] :=
+  Nat.modEq_nine_digits_sum n
+
+/-- `n ≡ S(n) (mod 3)`: the digit-sum rule for divisibility by three. -/
+theorem modEq_three (n : ℕ) : n ≡ S n [MOD 3] :=
+  Nat.modEq_three_digits_sum n
+
+/-! ## Part II: Divisibility rules
+
+The congruences of Part I turn into `↔` divisibility criteria on the digit
+sum. -/
+
+/-- **Divisibility rule for 9.** `n` is divisible by 9 iff its digit sum is. -/
+theorem nine_dvd_iff (n : ℕ) : 9 ∣ n ↔ 9 ∣ S n := by
+  rw [← Nat.modEq_zero_iff_dvd, ← Nat.modEq_zero_iff_dvd]
+  exact ⟨(modEq_nine n).symm.trans, (modEq_nine n).trans⟩
+
+/-- **Divisibility rule for 3.** `n` is divisible by 3 iff its digit sum is. -/
+theorem three_dvd_iff (n : ℕ) : 3 ∣ n ↔ 3 ∣ S n := by
+  rw [← Nat.modEq_zero_iff_dvd, ← Nat.modEq_zero_iff_dvd]
+  exact ⟨(modEq_three n).symm.trans, (modEq_three n).trans⟩
+
+/-! ## Part III: Compatibility laws — the check itself
+
+The digit sum is a mod-9 homomorphism for both `+` and `·`. These are the
+laws that make the casting-out-nines check sound: they say that reducing to
+digit sums before adding/multiplying does not change the residue mod 9. -/
+
+/-- Digit sum is additive modulo 9: `S(a + b) ≡ S(a) + S(b) (mod 9)`. -/
+theorem digitSum_add (a b : ℕ) : S (a + b) ≡ S a + S b [MOD 9] :=
+  calc S (a + b) ≡ a + b [MOD 9] := (modEq_nine (a + b)).symm
+    _ ≡ S a + S b [MOD 9] := (modEq_nine a).add (modEq_nine b)
+
+/-- Digit sum is multiplicative modulo 9: `S(a · b) ≡ S(a) · S(b) (mod 9)`. -/
+theorem digitSum_mul (a b : ℕ) : S (a * b) ≡ S a * S b [MOD 9] :=
+  calc S (a * b) ≡ a * b [MOD 9] := (modEq_nine (a * b)).symm
+    _ ≡ S a * S b [MOD 9] := (modEq_nine a).mul (modEq_nine b)
+
+/-- **Soundness of the multiplication check.** If `a · b = c` then the digit
+sums satisfy `S(a) · S(b) ≡ S(c) (mod 9)`. Contrapositively, a failure of this
+congruence proves that `a · b ≠ c` — this is exactly casting out nines. -/
+theorem check_mul (a b c : ℕ) (h : a * b = c) : S a * S b ≡ S c [MOD 9] := by
+  have hd := digitSum_mul a b
+  rw [h] at hd
+  exact hd.symm
+
+/-- **Soundness of the addition check.** If `a + b = c` then
+`S(a) + S(b) ≡ S(c) (mod 9)`. -/
+theorem check_add (a b c : ℕ) (h : a + b = c) : S a + S b ≡ S c [MOD 9] := by
+  have hd := digitSum_add a b
+  rw [h] at hd
+  exact hd.symm
+
+/-! ## Part IV: The alternating rule for 11
+
+Divisibility by 11 is governed not by the digit sum but by the *alternating*
+digit sum, because `10 ≡ -1 (mod 11)`. Mathlib phrases this over `ℤ`. -/
+
+/-- The alternating decimal digit sum of `n`, as an integer. -/
+def altS (n : ℕ) : ℤ := ((Nat.digits 10 n).map (fun d : ℕ => (d : ℤ))).alternatingSum
+
+/-- `n ≡ altS(n) (mod 11)`: the alternating-sum congruence. -/
+theorem modEq_eleven (n : ℕ) : (n : ℤ) ≡ altS n [ZMOD 11] :=
+  Nat.modEq_eleven_digits_sum n
+
+/-- **Divisibility rule for 11.** `n` is divisible by 11 iff its alternating
+digit sum is. -/
+theorem eleven_dvd_iff (n : ℕ) : (11 : ℤ) ∣ (n : ℤ) ↔ (11 : ℤ) ∣ altS n := by
+  rw [← Int.modEq_zero_iff_dvd, ← Int.modEq_zero_iff_dvd]
+  exact ⟨(modEq_eleven n).symm.trans, (modEq_eleven n).trans⟩
+
+/-! ## Part V: Worked instances
+
+These require no digit computation — they follow abstractly from the
+compatibility laws, illustrating the check on genuine arithmetic identities. -/
+
+/-- Casting out nines on `12 · 12 = 144`: `S(12)·S(12) ≡ S(144) (mod 9)`. -/
+example : S 12 * S 12 ≡ S 144 [MOD 9] := check_mul 12 12 144 (by norm_num)
+
+/-- Casting out nines on `123 · 456 = 56088`. -/
+example : S 123 * S 456 ≡ S 56088 [MOD 9] := check_mul 123 456 56088 (by norm_num)
+
+/-- The additive check on `999 + 1 = 1000`. -/
+example : S 999 + S 1 ≡ S 1000 [MOD 9] := check_add 999 1 1000 (by norm_num)
+
+end CastingOutNines

--- a/src/data/research/problems/casting-out-nines.json
+++ b/src/data/research/problems/casting-out-nines.json
@@ -1,0 +1,72 @@
+{
+  "slug": "casting-out-nines",
+  "title": "Casting Out Nines — n Is Congruent to Its Digit Sum mod 9",
+  "phase": "COMPLETED",
+  "status": "active",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\forall n \\in \\mathbb{N}, \\quad n \\equiv \\sum_{d \\in \\text{digits}_{10}(n)} d \\pmod 9",
+    "plain": "The base-10 digit sum of any natural number leaves the same remainder mod 9 as",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [
+      "n ≡ S(n) (mod 9) and (mod 3) via Nat.modEq_{nine,three}_digits_sum",
+      "Divisibility rules 9∣n ↔ 9∣S(n) and 3∣n ↔ 3∣S(n)",
+      "Compatibility laws S(a+b)≡S(a)+S(b) and S(a·b)≡S(a)·S(b) (mod 9)",
+      "Soundness of the multiplication/addition check (check_mul, check_add)",
+      "Alternating-sum divisibility rule for 11: 11∣n ↔ 11∣altS(n)"
+    ],
+    "open": [],
+    "goal": "Package the digit-sum congruences into usable divisibility criteria and the compatibility laws underpinning the casting-out-nines error check."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-05T00:06:20-07:00",
+    "iteration": 2,
+    "focus": "Proof complete and kernel-verified (0 sorry / 0 axiom).",
+    "blockers": [],
+    "nextAction": "Gallery enrichment (meta.json) handled downstream.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: fully-verified casting-out-nines package (0 sorry / 0 axiom) in proofs/Proofs/CastingOutNines.lean.",
+    "builtItems": [
+      "modEq_digitSum_base — base-agnostic n ≡ digitSum (mod b) when b%b?=1 (CastingOutNines.lean)",
+      "nine_dvd_iff, three_dvd_iff — divisibility rules as ↔ on the digit sum",
+      "digitSum_add, digitSum_mul — mod-9 homomorphism laws",
+      "check_mul, check_add — soundness of the error check",
+      "eleven_dvd_iff — alternating-sum rule for 11 (over ℤ)"
+    ],
+    "insights": [
+      "The whole theory reduces to Mathlib Nat.modEq_digits_sum (b%: 10≡1 mod 9 and mod 3); the genuine content is repackaging as divisibility ↔ and homomorphism laws.",
+      "The multiplicative check S(a)·S(b)≡S(c) is the actual justification of casting out nines; it is digitSum_mul plus a rewrite.",
+      "Divisibility by 11 is NOT the digit sum but the ALTERNATING digit sum, since 10≡-1 (mod 11); Mathlib phrases it over ℤ (Nat.modEq_eleven_digits_sum).",
+      "Worked instances can avoid brittle Nat.digits kernel-reduction by proving them abstractly through check_mul/check_add on norm_num identities."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Optional follow-up: sharpness/converse — the error check has one-sided soundness (mod-9 agreement does not imply a·b=c); formalize the false-positive characterization.",
+      "Optional: generalize the divisibility rule to arbitrary base b and modulus dividing b-1 / b+1."
+    ],
+    "markdown": "# Knowledge Base: casting-out-nines\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "number-theory",
+    "digit-representations",
+    "modular-arithmetic"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-05T07:14:39.753Z",
+  "lastUpdate": "2026-07-05T00:14:00.000Z"
+}


### PR DESCRIPTION
## Summary

Fully-verified elementary package for the **casting-out-nines** entry (fresh digit-representation domain). Kernel-checked: **0 `sorry`, 0 `axiom`, no `native_decide`**.

`proofs/Proofs/CastingOutNines.lean` proves:

- **Base-agnostic congruence** `modEq_digitSum_base`: `n ≡ (digits b' n).sum (mod b)` when `b' ≡ 1 (mod b)`.
- **Core congruences** `modEq_nine`, `modEq_three`: `n ≡ S(n) (mod 9)` and `(mod 3)`.
- **Divisibility rules** `nine_dvd_iff`, `three_dvd_iff`: `9 ∣ n ↔ 9 ∣ S(n)`, and the mod-3 analogue.
- **Compatibility laws** `digitSum_add`, `digitSum_mul`: `S` is a mod-9 homomorphism for `+` and `·`.
- **Soundness of the check** `check_mul`, `check_add`: `a·b=c ⟹ S(a)·S(b) ≡ S(c) (mod 9)` — the actual justification of casting out nines; a mismatch certifies an arithmetic error.
- **Alternating rule for 11** `eleven_dvd_iff`: divisibility by 11 is governed by the *alternating* digit sum (since `10 ≡ -1 (mod 11)`), phrased over `ℤ`.
- Worked instances (12·12=144, 123·456=56088, 999+1=1000) proven abstractly via the compatibility laws, avoiding brittle `Nat.digits` kernel reduction.

## Honest scope

Everything reduces to Mathlib's `Nat.modEq_{digits,nine,three,eleven}_digits_sum`. The contribution is the **repackaging** into usable divisibility criteria and the additive/multiplicative homomorphism laws that make the error check sound — not new mathematics. Elementary but complete and verified.

## Build

`./proofs/scripts/docker-build.sh Proofs.CastingOutNines` → `Built Proofs.CastingOutNines`, 7743 jobs, success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)