### PR TITLE
research(derangements-convergence-oq-02-oq-01): sharp nearest-integer threshold for the subfactorial [verified, 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ02OQ01.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ02OQ01.lean
@@ -1,0 +1,152 @@
+/-
+# Derangements: the nearest-integer characterization of the subfactorial
+
+Open Question: derangements-convergence-oq-02-oq-01
+
+The grandparent file `DerangementsConvergence.lean` proves the *magnitude* of the
+approximation error
+  |D(n)/n! - e⁻¹| ≤ 1/(n+1)!,
+and the parent `DerangementsConvergenceOQ02.lean` pins down its *sign*.
+
+This file draws the classical arithmetic consequence: the derangement number is
+literally the **nearest integer** to `n!/e`.  Scaling the ratio bound by `n!`,
+  |D(n) - n!·e⁻¹| ≤ n!/(n+1)! = 1/(n+1) ≤ 1/2   for n ≥ 1,
+and the inequality is *strict* (`< 1/2`) once the single boundary value `n = 1`
+is handled by the elementary bound `e⁻¹ < 1/2`.  A real number lying within
+`1/2` of an integer rounds to that integer, so
+
+  D(n) = round(n!/e)      for every n ≥ 1.
+
+## Main Results
+
+- `round_eq_of_abs_sub_lt_half` : reusable rounding criterion `|x - m| < ½ → round x = m`
+- `exp_neg_one_lt_half` : the boundary estimate `e⁻¹ < 1/2`
+- `abs_numDerangements_sub_lt_half` : `|D(n) - n!·e⁻¹| < 1/2` for `n ≥ 1` (strict)
+- `numDerangements_eq_round` : **D(n) = round(n!/e)** for `n ≥ 1`
+- `numDerangements_eq_floor` : the equivalent floor form `D(n) = ⌊n!·e⁻¹ + 1/2⌋`
+- `round_factorial_exp_zero` / `numDerangements_round_ne_at_zero` : the identity
+  genuinely fails at `n = 0` (`round(0!·e⁻¹) = 0 ≠ 1 = D(0)`), so the hypothesis
+  `n ≥ 1` is **sharp**.
+
+All results are fully machine-checked: no `sorry`, no `axiom` declarations, and
+no structure-encoded assumptions (only Lean/Mathlib's foundational
+`propext` / `Classical.choice` / `Quot.sound`).
+
+## References
+
+- Montmort (1708), Euler (1751) — derangement numbers
+- The rounding identity `!n = round(n!/e)` is standard folklore for `n ≥ 1`.
+-/
+
+import Proofs.DerangementsConvergence
+import Mathlib.Tactic
+
+open Nat Real Filter Topology
+
+noncomputable section
+
+namespace DerangementsConvergenceOQ02OQ01
+
+/- ## §1. A reusable rounding criterion -/
+
+/-- If a real number `x` is within `1/2` of an integer `m`, then `round x = m`.
+This is the elementary bridge from an analytic distance bound to an exact
+integer identity. -/
+lemma round_eq_of_abs_sub_lt_half {x : ℝ} {m : ℤ} (h : |x - (m : ℝ)| < 1 / 2) :
+    round x = m := by
+  rw [round_eq, Int.floor_eq_iff]
+  rw [abs_sub_lt_iff] at h
+  refine ⟨by linarith [h.1, h.2], by linarith [h.1, h.2]⟩
+
+/- ## §2. `e⁻¹ < 1/2` (the single boundary estimate) -/
+
+/-- The reciprocal of `e` is strictly below `1/2`, because `e > 2`. -/
+lemma exp_neg_one_lt_half : rexp (-1) < 1 / 2 := by
+  have h2 : (2 : ℝ) < rexp 1 := by
+    have := Real.add_one_lt_exp (x := 1) (by norm_num)
+    linarith
+  rw [Real.exp_neg, inv_eq_one_div]
+  exact one_div_lt_one_div_of_lt (by norm_num) h2
+
+/- ## §3. The strict distance bound `|D(n) - n!·e⁻¹| < 1/2` -/
+
+/-- The subfactorial `D(n)` lies strictly within `1/2` of `n!/e`, for every
+`n ≥ 1`.  This is the heart of the nearest-integer characterization. -/
+theorem abs_numDerangements_sub_lt_half (n : ℕ) (hn : 1 ≤ n) :
+    |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| < 1 / 2 := by
+  have hpos := factorial_cast_pos' n
+  have hne := factorial_cast_ne_zero' n
+  -- `D(n) - n!·e⁻¹ = n! · (D(n)/n! - e⁻¹)`.
+  have hstep : (n.factorial : ℝ)
+        * ((numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1))
+      = (numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1) := by
+    rw [mul_sub, ← mul_div_assoc, mul_div_cancel_left₀ (numDerangements n : ℝ) hne]
+  rw [← hstep, abs_mul, abs_of_pos hpos]
+  rcases eq_or_lt_of_le hn with h1 | h2
+  · -- Boundary case `n = 1`: `D(1) = 0`, so the distance is exactly `e⁻¹ < 1/2`.
+    rw [← h1]
+    have hd : numDerangements 1 = 0 := rfl
+    rw [hd]
+    simp only [Nat.cast_zero, Nat.factorial_one, Nat.cast_one, zero_div, zero_sub,
+      abs_neg, abs_of_pos (Real.exp_pos (-1)), one_mul]
+    exact exp_neg_one_lt_half
+  · -- Interior case `n ≥ 2`: the ratio bound gives `1/(n+1) ≤ 1/3 < 1/2`.
+    have hrate := derangements_convergence_rate n
+    have hbound : (n.factorial : ℝ)
+        * |(numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)|
+        ≤ (n.factorial : ℝ) * (1 / ((n + 1).factorial : ℝ)) :=
+      mul_le_mul_of_nonneg_left hrate hpos.le
+    have hval : (n.factorial : ℝ) * (1 / ((n + 1).factorial : ℝ))
+        = 1 / ((n : ℝ) + 1) := by
+      rw [Nat.factorial_succ]
+      push_cast
+      rw [mul_one_div, mul_comm ((n : ℝ) + 1) (n.factorial : ℝ), ← div_div,
+        div_self hne]
+    rw [hval] at hbound
+    have hle3 : (1 : ℝ) / ((n : ℝ) + 1) ≤ 1 / 3 := by
+      apply one_div_le_one_div_of_le (by norm_num)
+      have h2' : 2 ≤ n := h2
+      have hcast : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast h2'
+      linarith
+    linarith
+
+/- ## §4. Main theorem: `D(n) = round(n!/e)` -/
+
+/-- **Nearest-integer characterization of the subfactorial.**
+For every `n ≥ 1`, the number of derangements of `n` objects is exactly the
+nearest integer to `n!/e`. -/
+theorem numDerangements_eq_round (n : ℕ) (hn : 1 ≤ n) :
+    round ((n.factorial : ℝ) * rexp (-1)) = (numDerangements n : ℤ) := by
+  apply round_eq_of_abs_sub_lt_half
+  rw [abs_sub_comm,
+    show ((numDerangements n : ℤ) : ℝ) = (numDerangements n : ℝ) by push_cast; ring]
+  exact abs_numDerangements_sub_lt_half n hn
+
+/-- The equivalent floor form: `D(n) = ⌊n!·e⁻¹ + 1/2⌋` for `n ≥ 1`. -/
+theorem numDerangements_eq_floor (n : ℕ) (hn : 1 ≤ n) :
+    ⌊(n.factorial : ℝ) * rexp (-1) + 1 / 2⌋ = (numDerangements n : ℤ) := by
+  have h := numDerangements_eq_round n hn
+  rwa [round_eq] at h
+
+/- ## §5. Sharpness of the hypothesis `n ≥ 1` -/
+
+/-- At `n = 0` the rounded value is `0`: the nearest integer to `0!/e = e⁻¹`
+(≈ 0.3679) is `0`. -/
+theorem round_factorial_exp_zero :
+    round (((0 : ℕ).factorial : ℝ) * rexp (-1)) = 0 := by
+  apply round_eq_of_abs_sub_lt_half
+  simp only [Nat.factorial_zero, Nat.cast_one, one_mul, Int.cast_zero, sub_zero,
+    abs_of_pos (Real.exp_pos (-1))]
+  exact exp_neg_one_lt_half
+
+/-- **Sharpness.** The identity `D(n) = round(n!/e)` genuinely fails at `n = 0`:
+there `round(0!·e⁻¹) = 0` while `D(0) = 1`.  Hence the hypothesis `n ≥ 1` in
+`numDerangements_eq_round` cannot be dropped. -/
+theorem numDerangements_round_ne_at_zero :
+    round (((0 : ℕ).factorial : ℝ) * rexp (-1)) ≠ (numDerangements 0 : ℤ) := by
+  rw [round_factorial_exp_zero]
+  have hd : numDerangements 0 = 1 := rfl
+  rw [hd]
+  norm_num
+
+end DerangementsConvergenceOQ02OQ01

--- a/src/data/proofs/derangements-convergence-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-02-oq-01/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "ann-dcoq0201-header",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "Module Overview: The Sharp Nearest-Integer Threshold",
+    "content": "This module determines the exact domain on which the folklore identity D(n) = round(n!/e) holds. The sibling entry derangements-convergence-oq-03 proves it for n ≥ 2, where the rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! scales to |D(n) − n!/e| ≤ 1/(n+1) ≤ 1/3, comfortably under the ½ threshold that rounding needs. Two things remain: the boundary index n = 1 (where the same bound gives only the non-strict ≤ 1/2) and the failure at n = 0. This module supplies the extra analytic input e⁻¹ < 1/2 to settle n = 1, then proves the identity is genuinely false at n = 0, establishing n ≥ 1 as the optimal threshold. Imports pull in the grandparent DerangementsConvergence (for the rate bound) and all of Mathlib.Tactic.",
+    "mathContext": "D(n)/n! = ∑_{k=0}^n (−1)^k/k! → e⁻¹; the rounding identity D(n) = round(n!/e) is standard for n ≥ 1 but false at n = 0 since D(0) = 1 while round(e⁻¹) = 0."
+  },
+  {
+    "id": "ann-dcoq0201-round-criterion",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 50, "endLine": 59 },
+    "type": "technique",
+    "title": "§1 A Reusable Rounding Criterion",
+    "content": "round_eq_of_abs_sub_lt_half proves the elementary bridge from analysis to arithmetic: if |x − m| < 1/2 for an integer m then round x = m. The proof rewrites round x = ⌊x + 1/2⌋ (round_eq) and applies Int.floor_eq_iff to reduce ⌊x + 1/2⌋ = m to the pair ↑m ≤ x + 1/2 and x + 1/2 < ↑m + 1; abs_sub_lt_iff unpacks the hypothesis into x − m < 1/2 and m − x < 1/2, and linarith closes both inequalities. Isolating this lemma lets it serve both the positive identity (m = D(n)) and the negative sharpness fact (m = 0).",
+    "mathContext": "round x = m ⟺ m − 1/2 ≤ x < m + 1/2; a strict distance < 1/2 to an integer determines the rounded value uniquely."
+  },
+  {
+    "id": "ann-dcoq0201-exp-half",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 61, "endLine": 68 },
+    "type": "technique",
+    "title": "§2 The Boundary Estimate e⁻¹ < 1/2",
+    "content": "exp_neg_one_lt_half proves the single analytic fact that separates the n = 1 boundary case from failure. From Real.add_one_lt_exp at x = 1 one gets 1 + 1 < e, i.e. 2 < e; rewriting rexp(−1) = (rexp 1)⁻¹ = 1/rexp 1 and applying one_div_lt_one_div_of_lt to 2 < e yields 1/e < 1/2. This is exactly the strictness the rate bound cannot provide at n = 1.",
+    "mathContext": "e ≈ 2.718 > 2, so e⁻¹ ≈ 0.3679 < 0.5. This is why D(1) = 0 is within ½ of 1!·e⁻¹ = e⁻¹."
+  },
+  {
+    "id": "ann-dcoq0201-distance",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 71, "endLine": 111 },
+    "type": "key-step",
+    "title": "§3 The Strict Distance Bound |D(n) − n!·e⁻¹| < 1/2",
+    "content": "abs_numDerangements_sub_lt_half is the heart of the entry. It factors D(n) − n!·e⁻¹ = n!·(D(n)/n! − e⁻¹) (via mul_sub, mul_div_assoc, mul_div_cancel_left₀), so |D(n) − n!·e⁻¹| = n!·|D(n)/n! − e⁻¹| after abs_mul and abs_of_pos. The proof then splits on n ≥ 1: (interior, n ≥ 2) the grandparent's derangements_convergence_rate gives n!·|D(n)/n! − e⁻¹| ≤ n!·(1/(n+1)!) = 1/(n+1) ≤ 1/3 < 1/2; (boundary, n = 1) D(1) = 0 reduces the quantity to exactly e⁻¹, and exp_neg_one_lt_half finishes. This is the one place where the n ≥ 1 result strictly improves on the sibling's n ≥ 2.",
+    "mathContext": "For n ≥ 2 the margin 1/(n+1) ≤ 1/3 is generous; at n = 1 the generic bound is exactly 1/2 (non-strict), so the boundary genuinely needs e⁻¹ < 1/2."
+  },
+  {
+    "id": "ann-dcoq0201-main",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 113, "endLine": 129 },
+    "type": "key-step",
+    "title": "§4 The Nearest-Integer Identity on n ≥ 1",
+    "content": "numDerangements_eq_round applies the rounding criterion to the strict distance bound (after abs_sub_comm and a cast normalisation) to conclude round(n!·e⁻¹) = D(n) for all n ≥ 1 — extending the sibling's n ≥ 2 identity to include the boundary index n = 1. numDerangements_eq_floor restates it in the explicit floor form D(n) = ⌊n!·e⁻¹ + 1/2⌋ by unfolding round_eq.",
+    "mathContext": "round(n!/e) = ⌊n!/e + 1/2⌋; the two forms are definitionally linked by round_eq."
+  },
+  {
+    "id": "ann-dcoq0201-sharpness",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 131, "endLine": 152 },
+    "type": "key-step",
+    "title": "§5 Sharpness: the Identity Fails at n = 0",
+    "content": "round_factorial_exp_zero computes round(0!·e⁻¹) = round(e⁻¹) = 0 (again via the rounding criterion at m = 0, using |e⁻¹ − 0| = e⁻¹ < 1/2). numDerangements_round_ne_at_zero then observes D(0) = 1 (by rfl), so round(0!·e⁻¹) = 0 ≠ 1 = D(0): the identity is genuinely false at n = 0. This pins n ≥ 1 as the exact, optimal hypothesis — the lower endpoint cannot be weakened.",
+    "mathContext": "0!·e⁻¹ = e⁻¹ ≈ 0.3679 rounds to 0, but the empty permutation is a derangement so D(0) = 1. The universal statement 'D(n) = round(n!/e)' must start at n = 1."
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-02-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-02-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "derangements-convergence-oq-02-oq-01",
+  "title": "The subfactorial is the nearest integer to n!/e — sharp at n ≥ 1",
+  "slug": "derangements-convergence-oq-02-oq-01",
+  "description": "Sharpens the rounding identity D(n) = round(n!/e) to its exact domain of validity. The sibling entry derangements-convergence-oq-03 proves it for n ≥ 2 (where the lossy bound |D(n) − n!/e| ≤ 1/(n+1) ≤ 1/3 is comfortably strict). This entry extends it to the boundary index n = 1 — which needs the separate elementary input e⁻¹ < 1/2, since the rate bound only gives the non-strict ≤ 1/2 there — and proves that the identity genuinely FAILS at n = 0 (round(0!·e⁻¹) = 0 ≠ 1 = D(0)). Hence n ≥ 1 is the exact, optimal threshold.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-05",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ02OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "e-constant",
+      "rounding",
+      "nearest-integer",
+      "sharp-threshold",
+      "alternating-series",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked with only Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). Builds on the grandparent DerangementsConvergence.lean for the rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! and on Mathlib for numDerangements, round, and Real.add_one_lt_exp (the e > 2 estimate).",
+    "dateAdded": "2026-07-05",
+    "lineCount": 152,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "abs_numDerangements_sub_lt_half (PROVED): the STRICT distance bound |D(n) − n!·e⁻¹| < 1/2 for every n ≥ 1. The interior case n ≥ 2 uses the rate bound (giving 1/(n+1) ≤ 1/3), but the boundary n = 1 is genuinely new: there the rate bound only yields the non-strict ≤ 1/2, so strictness is obtained separately from |D(1) − 1!·e⁻¹| = e⁻¹ and the elementary estimate e⁻¹ < 1/2.",
+      "numDerangements_eq_round (PROVED): D(n) = round(n!/e) for all n ≥ 1 — the nearest-integer characterization on its full (optimal) domain, extending the sibling oq-03 result from n ≥ 2 to include n = 1.",
+      "round_factorial_exp_zero + numDerangements_round_ne_at_zero (PROVED): SHARPNESS. At n = 0 the rounded value is round(0!·e⁻¹) = round(e⁻¹) = 0, whereas D(0) = 1; so the identity is FALSE at n = 0 and the hypothesis n ≥ 1 cannot be weakened. This pins n ≥ 1 as the exact threshold, which neither the sibling nor the parent records.",
+      "exp_neg_one_lt_half (PROVED): the standalone estimate e⁻¹ < 1/2 (from e > 2 via Real.add_one_lt_exp), the single analytic fact separating the n = 1 boundary case from failure at n = 0.",
+      "round_eq_of_abs_sub_lt_half (PROVED): a reusable rounding criterion |x − m| < 1/2 ⟹ round x = m, isolated as a clean lemma (proved from round_eq and Int.floor_eq_iff) rather than inlined, so it serves both the positive n ≥ 1 identity and the n = 0 sharpness computation.",
+      "numDerangements_eq_floor (PROVED): the equivalent explicit floor form D(n) = ⌊n!·e⁻¹ + 1/2⌋ for n ≥ 1."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "numDerangements",
+        "description": "The derangement counting function D(n) (permutations with no fixed point); base values D(0) = 1, D(1) = 0 reduce by rfl.",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "round / round_eq",
+        "description": "round x = ⌊x + 1/2⌋ : the nearest-integer function on a linear ordered field, and its defining identity used to reduce the rounding claim to a floor computation.",
+        "module": "Mathlib.Algebra.Order.Round"
+      },
+      {
+        "theorem": "Int.floor_eq_iff",
+        "description": "⌊r⌋ = z ↔ ↑z ≤ r ∧ r < z + 1 : converts the floor equality into the two linear inequalities discharged by linarith in the rounding criterion.",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Real.add_one_lt_exp",
+        "description": "x + 1 < exp x for x ≠ 0 : instantiated at x = 1 to get 2 < e, hence e⁻¹ < 1/2 — the analytic input for the n = 1 boundary case.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "derangements_convergence_rate",
+        "description": "The grandparent's magnitude bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)!, scaled by n! to bound |D(n) − n!·e⁻¹| in the interior case n ≥ 2.",
+        "module": "Proofs.DerangementsConvergence"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "That the number of derangements D(n) is the integer nearest to n!/e is a classical fact (the derangement ratio D(n)/n! = ∑_{k=0}^n (−1)^k/k! is the n-th partial sum of e⁻¹, so it converges to e⁻¹ fast enough to round exactly). The sibling entry derangements-convergence-oq-03 formalises D(n) = round(n!/e) for n ≥ 2, where the rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! comfortably beats the ½ threshold. The parent entry oq-02 supplies the exact sign of the error. What is left open by those entries is the precise boundary: for which n does the identity hold? This entry answers it — n ≥ 1 exactly, no more and no less.",
+    "problemStatement": "**OQ-02-OQ-01 of derangements-convergence.** Determine the exact set of n for which D(n) = round(n!/e). Extend the sibling's n ≥ 2 identity to its optimal domain and exhibit the failure that fixes the threshold.",
+    "text": "For every n ≥ 1, D(n) = round(n!/e) = ⌊n!·e⁻¹ + 1/2⌋, and this is sharp: at n = 0 one has round(0!·e⁻¹) = 0 while D(0) = 1, so the identity fails. The extra ingredient over the n ≥ 2 case is the strict boundary estimate e⁻¹ < 1/2, which upgrades the n = 1 distance from the non-strict ≤ 1/2 to a strict < 1/2.",
+    "proofStrategy": "The heart is the strict distance bound |D(n) − n!·e⁻¹| < 1/2 for n ≥ 1 (abs_numDerangements_sub_lt_half). Factor D(n) − n!·e⁻¹ = n!·(D(n)/n! − e⁻¹), so |D(n) − n!·e⁻¹| = n!·|D(n)/n! − e⁻¹|. Split on n: for n ≥ 2 the grandparent's rate bound gives n!·|D(n)/n! − e⁻¹| ≤ n!/(n+1)! = 1/(n+1) ≤ 1/3 < 1/2; for the boundary n = 1, D(1) = 0 so the quantity is exactly e⁻¹, and e⁻¹ < 1/2 because e > 2 (Real.add_one_lt_exp at x = 1). A generic rounding criterion round_eq_of_abs_sub_lt_half — proved once from round_eq and Int.floor_eq_iff — turns |x − m| < 1/2 into round x = m, delivering D(n) = round(n!/e) for n ≥ 1 and, applied at m = 0, round(0!·e⁻¹) = 0. Since D(0) = 1 ≠ 0, the threshold n ≥ 1 is sharp.",
+    "keyInsights": [
+      "The threshold n ≥ 1 is not cosmetic. The lossy bound |D(n) − n!/e| ≤ 1/(n+1) equals exactly 1/2 at n = 1, so the n ≥ 2 argument of the sibling cannot reach n = 1 — strictness there requires an independent analytic fact, namely e⁻¹ < 1/2. This is the whole gap between 'n ≥ 2' and the true 'n ≥ 1'.",
+      "n = 0 is a genuine counterexample, not a vacuous edge case. 0!·e⁻¹ = e⁻¹ ≈ 0.3679 rounds to 0, but D(0) = 1 (the empty permutation is a derangement). So the folklore statement 'D(n) = round(n!/e) for all n' is literally false at n = 0; the correct universal statement starts at n = 1.",
+      "Separating the rounding criterion |x − m| < 1/2 ⟹ round x = m as its own lemma pays off twice: the same lemma proves the positive identity (m = D(n)) and the negative sharpness fact (m = 0). The mathematics of 'rounds to' is the same object whether the target integer is the right answer or the wrong one.",
+      "Everything downstream of the ½-gap is purely formal: round_eq reduces to a floor, Int.floor_eq_iff to two inequalities, and linarith closes them. The only real content is the distance bound, and within it the only real content beyond the sibling is the single line e⁻¹ < 1/2."
+    ],
+    "prerequisites": [
+      "The grandparent rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! (derangements_convergence_rate) and factorial positivity helpers",
+      "Mathlib's round / round_eq and Int.floor_eq_iff",
+      "The estimate e > 2 via Real.add_one_lt_exp"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling entry proving D(n) = round(n!/e) for n ≥ 2. This entry sharpens that result to its optimal domain n ≥ 1 (adding the boundary case n = 1, which needs e⁻¹ < 1/2) and proves the identity fails at n = 0, fixing the exact threshold."
+    },
+    {
+      "targetId": "derangements-convergence-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry: the exact sign law (−1)^n·(D(n)/n! − e⁻¹) > 0. Its own open-questions list poses precisely this nearest-integer upgrade; this entry carries it out and adds the sharp-threshold analysis."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "foundational",
+      "description": "Grandparent entry supplying the magnitude bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! and the partial-sum representation used to scale the error by n!."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "foundational",
+      "description": "Root entry: derangement definitions and the counting function numDerangements, including the base values D(0) = 1 and D(1) = 0 that drive the boundary analysis."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified sharp form of the nearest-integer characterization of the subfactorial: D(n) = round(n!/e) = ⌊n!·e⁻¹ + 1/2⌋ holds for exactly n ≥ 1. The lower endpoint is optimal — the identity fails at n = 0, where round(e⁻¹) = 0 ≠ 1 = D(0). Zero sorries, zero axioms beyond the foundational ones.",
+    "implications": "Pins down the precise domain of a piece of standard folklore that is usually stated 'for all n' and is in fact false at n = 0. The extension from the sibling's n ≥ 2 to n ≥ 1 isolates the exact analytic content needed at the boundary (e⁻¹ < 1/2), and the reusable rounding criterion round_eq_of_abs_sub_lt_half is a small, general tool for turning any ½-distance bound into an exact integer identity.",
+    "openQuestions": [
+      "The same ½-distance method characterises other e-adjacent integer sequences as nearest integers: is the number of involutions, or ⌊n!·e^{c}⌉ for other rational c, similarly pinned to an exact threshold, and does the boundary index depend on c in a describable way?",
+      "Quantify the margin: for n ≥ 1 the distance |D(n) − n!/e| is not just < 1/2 but < 1/(n+1) (and ~ 1/(n+1) asymptotically). Formalise the exact asymptotic of this rounding margin and identify the n at which n!/e is closest to a half-integer, the worst case for the rounding."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "numDerangements_eq_round",
+      "type": "theorem",
+      "description": "Nearest-integer characterization on its optimal domain: for every n ≥ 1, D(n) = round(n!/e).",
+      "leanType": "(n : ℕ) → 1 ≤ n → round ((n.factorial : ℝ) * rexp (-1)) = (numDerangements n : ℤ)"
+    },
+    {
+      "name": "abs_numDerangements_sub_lt_half",
+      "type": "theorem",
+      "description": "The strict distance bound |D(n) − n!·e⁻¹| < 1/2 for n ≥ 1; the boundary case n = 1 uses e⁻¹ < 1/2.",
+      "leanType": "(n : ℕ) → 1 ≤ n → |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| < 1 / 2"
+    },
+    {
+      "name": "numDerangements_round_ne_at_zero",
+      "type": "theorem",
+      "description": "Sharpness: at n = 0 the identity fails, round(0!·e⁻¹) = 0 ≠ 1 = D(0), so the hypothesis n ≥ 1 cannot be dropped.",
+      "leanType": "round (((0 : ℕ).factorial : ℝ) * rexp (-1)) ≠ (numDerangements 0 : ℤ)"
+    },
+    {
+      "name": "round_eq_of_abs_sub_lt_half",
+      "type": "lemma",
+      "description": "Reusable rounding criterion: a real within 1/2 of an integer rounds to it.",
+      "leanType": "{x : ℝ} → {m : ℤ} → |x - (m : ℝ)| < 1 / 2 → round x = m"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.DerangementsConvergence",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Real",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DerangementsConvergenceOQ02OQ01",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 6,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Origin of the derangement series D(n)/n! = ∑(−1)^k/k! underlying the rounding identity."
+    },
+    {
+      "authors": "Pierre Rémond de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris",
+      "note": "The matching/rencontre problem; first appearance of derangement counts, including D(0) = 1."
+    },
+    {
+      "authors": "Ronald L. Graham, Donald E. Knuth, Oren Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "venue": "Addison-Wesley, §5.3",
+      "note": "States !n = round(n!/e) as the nearest-integer formula for the subfactorial; the n ≥ 1 restriction and the n = 0 failure are the sharp form formalised here."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes **derangements-convergence-oq-02-oq-01** — the *sharp* nearest-integer characterization of the subfactorial. Docker-verified, **0 sorry / 0 axiom** (only foundational `propext`/`Classical.choice`/`Quot.sound`).

The sibling entry `derangements-convergence-oq-03` already proves `D(n) = round(n!/e)` **for n ≥ 2**. This entry pins down the *exact* domain of validity:

- **`numDerangements_eq_round`** — `D(n) = round(n!/e)` for **all n ≥ 1**, extending the identity to the boundary index `n = 1`. This is a genuine extension, not a restatement: at `n = 1` the rate bound only gives the **non-strict** `|D(1) − 1!·e⁻¹| ≤ 1/2`, so strictness requires the separate elementary input `e⁻¹ < 1/2` (from `e > 2`).
- **`abs_numDerangements_sub_lt_half`** — the strict distance bound `|D(n) − n!·e⁻¹| < 1/2` for `n ≥ 1` (the heart of the argument).
- **`round_factorial_exp_zero` / `numDerangements_round_ne_at_zero`** — **sharpness**: the identity genuinely *fails* at `n = 0`, where `round(0!·e⁻¹) = round(e⁻¹) = 0` but `D(0) = 1`. So `n ≥ 1` is the optimal threshold and cannot be weakened.
- **`round_eq_of_abs_sub_lt_half`** — a reusable rounding criterion `|x − m| < ½ ⟹ round x = m` (serves both the positive identity and the `n = 0` sharpness computation).
- **`numDerangements_eq_floor`** — the explicit floor form `D(n) = ⌊n!·e⁻¹ + 1/2⌋`.

## Honest scope

This is an **incremental sharp-boundary refinement**, not a new theorem: the main identity overlaps `oq-03`'s `n ≥ 2` version. The genuinely new content is (a) the boundary index `n = 1`, requiring `e⁻¹ < 1/2`, and (b) the proof that `n = 0` fails — together fixing `n ≥ 1` as the exact threshold, which neither the sibling nor the parent records. The parent `oq-02`'s own open-questions list explicitly poses this upgrade.

## Verification

```
./proofs/scripts/docker-build.sh Proofs.DerangementsConvergenceOQ02OQ01
# Build completed successfully (3061 jobs)
```

7 theorems/lemmas, 152 lines, 0 sorry, 0 axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)