### PR TITLE
Enrich Product Formula for τ (sum-of-divisors-oq-06-oq-01): add annotations.json

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/sum-of-divisors-oq-06-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "sod-oq0601-ann-product-formula",
+    "proofId": "sum-of-divisors-oq-06-oq-01",
+    "range": { "startLine": 37, "endLine": 39 },
+    "type": "technique",
+    "title": "The product formula τ(n) = ∏(vₚ(n)+1)",
+    "content": "The headline identity. `Nat.card_divisors hn` supplies τ(n) as the Finsupp product `n.factorization.prod (fun _ k => k + 1)` — a product indexed by the *support* of the factorization Finsupp. The single rewrite `← Nat.support_factorization` re-expresses that support as `n.primeFactors`, turning the Finsupp product into the ordinary Finset product ∏_{p ∈ primeFactors n} (vₚ(n) + 1) that every number-theory text writes. Because `Finsupp.prod` is *defined* as a `Finset.prod` over the support, the rewrite closes the goal definitionally — no arithmetic manipulation is needed, only alignment of the index set.",
+    "mathContext": "$\\tau(n) = \\prod_{p \\mid n} \\bigl(v_p(n) + 1\\bigr)$ where $v_p(n)$ is the $p$-adic valuation (exponent of $p$ in $n = \\prod_p p^{v_p(n)}$).",
+    "significance": "key",
+    "relatedConcepts": ["divisor function", "prime factorization", "multiplicative function", "p-adic valuation", "Finsupp product"],
+    "prerequisites": ["prime factorization", "arithmetic functions", "finite products"]
+  },
+  {
+    "id": "sod-oq0601-ann-hn-hypothesis",
+    "proofId": "sum-of-divisors-oq-06-oq-01",
+    "range": { "startLine": 37, "endLine": 38 },
+    "type": "insight",
+    "title": "Why n ≠ 0 is required",
+    "content": "The hypothesis `hn : n ≠ 0` is not incidental. In Mathlib `Nat.divisors 0 = ∅` by convention (0 has no finite set of divisors in this bookkeeping), so #(0).divisors = 0, whereas the empty product ∏_{p ∈ primeFactors 0} (…) evaluates to 1. The formula would therefore assert 0 = 1 at n = 0; excluding n = 0 is exactly what makes it true. Every downstream count inherits this: the prime-power result needs no such guard only because pᵃ ≠ 0 for a prime p.",
+    "mathContext": "$\\#(\\mathrm{divisors}\\,0) = 0 \\neq 1 = \\prod_{p \\in \\emptyset}(\\cdots)$, so $n \\neq 0$ is necessary.",
+    "significance": "technical",
+    "relatedConcepts": ["empty product", "edge cases", "Mathlib conventions", "divisors of zero"],
+    "prerequisites": ["finite products", "conventions in number theory"]
+  },
+  {
+    "id": "sod-oq0601-ann-prime-power",
+    "proofId": "sum-of-divisors-oq-06-oq-01",
+    "range": { "startLine": 43, "endLine": 45 },
+    "type": "technique",
+    "title": "Prime powers are the atoms: τ(pᵃ) = a+1",
+    "content": "The multiplicative building block. `Nat.divisors_prime_pow pp` exhibits the divisors of pᵃ as the image of `Finset.range (a+1)` under the injective map `p^·` (i.e. k ↦ pᵏ), so the divisors are precisely p⁰, p¹, …, pᵃ. Counting is then purely combinatorial: `Finset.card_map` discards the injective relabelling and `Finset.card_range` gives |{0,…,a}| = a + 1. This is the fact Mathlib does not state directly, and it is the single-prime case from which the full product formula assembles by multiplicativity.",
+    "mathContext": "$\\tau(p^a) = a + 1$ because the divisors of $p^a$ are exactly $\\{p^0, p^1, \\ldots, p^a\\}$, in bijection with $\\{0, 1, \\ldots, a\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["prime power", "divisor bijection", "injective map", "Finset.card", "geometric progression of divisors"],
+    "prerequisites": ["prime powers", "cardinality of finite sets", "injections"]
+  },
+  {
+    "id": "sod-oq0601-ann-prime-two-divisors",
+    "proofId": "sum-of-divisors-oq-06-oq-01",
+    "range": { "startLine": 48, "endLine": 50 },
+    "type": "definition",
+    "title": "τ(p) = 2 characterises primes",
+    "content": "The a = 1 specialisation: substituting a = 1 into τ(pᵃ) = a + 1 and rewriting p¹ = p (via `pow_one`) gives τ(p) = 2. Conceptually this is the defining property of a prime — exactly two divisors, 1 and p itself — recovered here as a corollary of the prime-power count rather than taken as an axiom. The converse (τ(n) = 2 ⟹ n prime) is the structural classification flagged in the entry's open questions.",
+    "mathContext": "$\\tau(p) = 2$ for prime $p$ — the divisors are exactly $1$ and $p$. Conversely $\\tau(n) = 2 \\iff n$ is prime.",
+    "significance": "supporting",
+    "relatedConcepts": ["primality", "number of divisors", "corollary", "characterization of primes"],
+    "prerequisites": ["definition of prime", "prime powers"]
+  },
+  {
+    "id": "sod-oq0601-ann-coprime-multiplicative",
+    "proofId": "sum-of-divisors-oq-06-oq-01",
+    "range": { "startLine": 55, "endLine": 57 },
+    "type": "concept",
+    "title": "Multiplicativity on coprime arguments",
+    "content": "The multiplicative law τ(m·n) = τ(m)·τ(n) for coprime m, n, re-exported directly from `Nat.Coprime.card_divisors_mul` (itself a consequence of `isMultiplicative_sigma`). Placing it beside the product formula makes the entry self-contained: the product formula *is* this law applied across the coprime prime-power factors of n. The proof is a one-line re-export — the mathematical weight sits in Mathlib's `ArithmeticFunction.IsMultiplicative` machinery, where multiplicativity of σ₀ is established via the CRT bijection divisors(m·n) ≅ divisors(m) × divisors(n).",
+    "mathContext": "$\\gcd(m,n) = 1 \\Rightarrow \\tau(mn) = \\tau(m)\\,\\tau(n)$, via the bijection $d \\mapsto (\\gcd(d,m), \\gcd(d,n))$ on divisors.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative function", "Chinese remainder theorem", "coprimality", "arithmetic functions", "isMultiplicative_sigma"],
+    "prerequisites": ["coprimality", "Chinese remainder theorem", "multiplicative arithmetic functions"]
+  },
+  {
+    "id": "sod-oq0601-ann-sharpness",
+    "proofId": "sum-of-divisors-oq-06-oq-01",
+    "range": { "startLine": 64, "endLine": 68 },
+    "type": "insight",
+    "title": "Sharpness: multiplicative but NOT completely multiplicative",
+    "content": "The theory-level payload of the entry. Taking m = n = 2 (so gcd = 2 ≠ 1) breaks the multiplicative law: τ(2·2) = τ(4) = 3 while τ(2)·τ(2) = 2·2 = 4, and 3 ≠ 4. Kernel `decide` certifies the concrete inequality; the companion `not_coprime_two_two` (also by `decide`) confirms the pair is genuinely non-coprime, so the failure is a real witness that the coprimality hypothesis of `card_divisors_coprime_mul` cannot be dropped. This pins down the precise distinction between a *multiplicative* function (factors across coprime arguments) and a *completely multiplicative* one (factors across all arguments): τ is the former but not the latter.",
+    "mathContext": "$\\tau(2 \\cdot 2) = \\tau(4) = 3 \\neq 4 = \\tau(2)\\cdot\\tau(2)$. Multiplicative $\\not\\Rightarrow$ completely multiplicative.",
+    "significance": "key",
+    "relatedConcepts": ["completely multiplicative function", "counterexample", "sharpness", "necessity of hypotheses", "decidability"],
+    "prerequisites": ["multiplicative vs completely multiplicative functions", "coprimality"]
+  },
+  {
+    "id": "sod-oq0601-ann-worked-computations",
+    "proofId": "sum-of-divisors-oq-06-oq-01",
+    "range": { "startLine": 72, "endLine": 84 },
+    "type": "context",
+    "title": "Worked computations assembling the formula",
+    "content": "Concrete instances that exercise both the product formula and the multiplicative law. τ(12) = 6 from 12 = 2²·3 giving (2+1)(1+1); τ(100) = 9 from 100 = 2²·5² giving (2+1)(2+1) — both discharged by kernel `decide`. The final two examples show the *assembly* pattern: τ(4·3) = τ(4)·τ(3) via `card_divisors_coprime_mul` on the coprime factors 4 and 3, and τ(2⁵) = 6 via `card_divisors_prime_pow` directly. Together they demonstrate that the general τ(∏ pᵢ^{aᵢ}) = ∏(aᵢ+1) reduces to these two lemmas — the induction flagged in the open questions.",
+    "mathContext": "$\\tau(12) = (2{+}1)(1{+}1) = 6$; $\\tau(100) = (2{+}1)(2{+}1) = 9$; $\\tau(4 \\cdot 3) = \\tau(4)\\tau(3) = 3 \\cdot 2 = 6$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "kernel decide", "assembly by induction", "concrete verification"],
+    "prerequisites": ["prime factorization", "the product formula"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `sum-of-divisors-oq-06-oq-01`. The entry had a rich meta.json (11 KB, under all size caps) but **no annotations.json** — the highest-impact gap.

## Changes
- **Added annotations.json** (7 annotations, previously absent), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. The product formula τ(n) = ∏(vₚ(n)+1) and its definitional Finsupp→Finset rewrite
  2. Why n ≠ 0 is required (empty product = 1 vs #divisors 0 = 0)
  3. Prime powers as atoms: τ(pᵃ) = a+1 via the p⁰…pᵃ bijection
  4. τ(p) = 2 characterising primality
  5. Coprime multiplicativity via isMultiplicative_sigma / CRT
  6. Sharpness: multiplicative but NOT completely multiplicative (τ(4)=3≠4)
  7. Worked computations assembling the formula

## Verification
- Data build steps pass: `gallery:check-size` (meta ≤ 60 KB), `annotations:build`, `research:enrich`
- JSON validated; meta.json left unchanged
- Line ranges checked against `Proofs/SumOfDivisorsOQ06OQ01.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)