### PR TITLE
Enrich handshake-lemma: add cross-references

### DIFF
--- a/src/data/proofs/handshake-lemma/meta.json
+++ b/src/data/proofs/handshake-lemma/meta.json
@@ -88,7 +88,18 @@
       "mathContext": "$K_3$ is $2$-regular with $|V| = 3$ odd, so even regularity permits odd order."
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting",
+      "relationship": "related",
+      "description": "A companion double-counting result: Burnside's lemma counts orbits by double-counting fixed points, just as the handshake lemma counts edges by double-counting incident (vertex, edge) pairs. Both are archetypes of the 'count the same set two ways' technique."
+    },
+    {
+      "targetId": "erdos-divisibility-pigeonhole",
+      "relationship": "related",
+      "description": "Another elementary parity/pigeonhole cornerstone of olympiad combinatorics. Where the handshake lemma forces the number of odd-degree vertices to be even, the divisibility pigeonhole forces a divisibility relation among n+1 integers in {1,…,2n}."
+    }
+  ],
   "conclusion": {
     "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the handshake lemma ∑_v deg(v) = 2·|E(G)| together with its parity corollaries and their structural consequences for regular graphs, capped by an explicit sharpness witness.",
     "implications": "Beyond re-exporting Mathlib's degree-sum identity and even-odd-degree corollary, the entry supplies the reusable structural lemma that odd-regular finite graphs have even order, and pins down with the triangle K₃ that the oddness of the regularity degree is exactly the hypothesis doing the work.",


### PR DESCRIPTION
Follow-up enrichment for `handshake-lemma`. The annotations.json (7 annotations) landed earlier via #35001; this PR adds the `crossReferences` that were reverted by a concurrent build in that pass.

## Change
Populates the empty `crossReferences` array with 2 links:
- **burnside-counting** — companion double-counting archetype (orbits via fixed points ↔ edges via incident pairs).
- **erdos-divisibility-pigeonhole** — sibling parity/pigeonhole olympiad cornerstone.

## Verification
- meta.json valid JSON, 11.5 KB (well under the 60 KB cap).
- Diff is 13 insertions / 2 deletions — crossReferences only; no other field touched.
- No Lean source change; status/badge/axiomCount (verified/mathlib/0) unchanged.
