### PR TITLE
research(automorphic-number-oq-01-oq-01-oq-02): unitary-divisor count #(unitaryDivisors n)=2^ω(n) [verified, 0 sorry/0 axiom]

### DIFF
--- a/proofs/Proofs/AutomorphicNumberOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/AutomorphicNumberOQ01OQ01OQ02.lean
@@ -1,0 +1,212 @@
+import Mathlib
+import Proofs.AutomorphicNumberOQ01OQ01
+
+/-!
+# The unitary-divisor count `#(unitaryDivisors n) = 2 ^ ω(n)`
+
+## What This Proves
+
+The parent file `AutomorphicNumberOQ01OQ01` shows that the idempotents of `ZMod n` — the
+automorphic residues `e ^ 2 ≡ e (mod n)` — number exactly `2 ^ ω(n)`, where
+`ω(n) = n.primeFactors.card` is the number of distinct primes dividing `n`
+(`idempotent_count`).  Its sibling `AutomorphicNumberOQ01OQ01OQ01` reads that count as the
+number of **squarefree divisors** of `n`.
+
+This file gives the count its other classical arithmetic meaning: it is the number of
+**unitary divisors** of `n`.
+
+```
+unitaryDivisors_card :
+  #(unitaryDivisors n) = 2 ^ n.primeFactors.card            (n ≠ 0)
+
+idempotents_eq_unitaryDivisors :
+  Nat.card {e : ZMod n // e * e = e} = #(unitaryDivisors n)  (0 < n)
+```
+
+A *unitary divisor* of `n` is a divisor `d ∣ n` with `gcd(d, n / d) = 1`.  Equivalently, at
+each prime `p ∣ n` a unitary divisor takes either the full prime-power `p ^ v_p(n)` or `1` —
+it never splits a prime power.  So unitary divisors biject with subsets of `n.primeFactors`,
+and there are `2 ^ ω(n)` of them, matching both the idempotents and the squarefree divisors.
+
+## Strategy
+
+We mirror the squarefree-divisor count `AutomorphicNumberOQ01OQ01OQ01.squarefreeDivisors_card`,
+replacing the exponent-one product `∏ p ∈ s, p` by the maximal-prime-power product
+`∏ p ∈ s, p ^ v_p(n)`.  The map `s ↦ ∏ p ∈ s, p ^ v_p(n)` sends `n.primeFactors.powerset`
+onto `unitaryDivisors n`:
+
+* **into `unitaryDivisors`** (`prod_mem_unitaryDivisors`): for a subset `S`, writing
+  `T = n.primeFactors \ S`, the products `a = ∏_{S}` and `b = ∏_{T}` satisfy `a * b = n`
+  (disjoint union of prime powers, `prod_pow_primeFactors`), so `a ∣ n` and `n / a = b`; and
+  `a`, `b` are coprime because they range over disjoint sets of primes.
+* **onto** (`unitaryDivisors_eq_image`): a unitary divisor `d` is recovered as
+  `∏_{p ∈ d.primeFactors} p ^ v_p(n)`, because `gcd(d, n/d) = 1` forces
+  `v_p(d) = v_p(n)` at every prime `p ∣ d` (`factorization_eq_of_unitary`).
+* **injective** (`injOn_prod_pow`): `primeFactors` is a left inverse (`primeFactors_prod_pow`).
+
+Then `Finset.card_image_of_injOn` and `Finset.card_powerset` give `2 ^ ω(n)`.
+
+## Status
+
+Fully machine-checked: `0` sorries, `0` axioms.  Builds on the verified parent file.
+-/
+
+open Finset
+
+namespace AutomorphicNumberOQ01OQ01OQ02
+
+/-- The **unitary divisors** of `n`: divisors `d ∣ n` with `gcd(d, n / d) = 1`. -/
+def unitaryDivisors (n : ℕ) : Finset ℕ :=
+  n.divisors.filter (fun d => Nat.Coprime d (n / d))
+
+/-- Membership in `unitaryDivisors`, unfolded: a unitary divisor of `n` is a divisor of a
+nonzero `n` that is coprime to its cofactor. -/
+lemma mem_unitaryDivisors {n d : ℕ} :
+    d ∈ unitaryDivisors n ↔ (d ∣ n ∧ n ≠ 0) ∧ Nat.Coprime d (n / d) := by
+  simp only [unitaryDivisors, Finset.mem_filter, Nat.mem_divisors]
+
+/-- **Prime factorisation as a product over the prime factors.** For `m ≠ 0`,
+`m = ∏ p ∈ m.primeFactors, p ^ v_p(m)`.  This is `Nat.factorization_prod_pow_eq_self`
+re-expressed as a `Finset` product over `m.primeFactors`. -/
+lemma prod_pow_primeFactors {m : ℕ} (hm : m ≠ 0) :
+    (∏ p ∈ m.primeFactors, p ^ m.factorization p) = m := by
+  rw [← Nat.support_factorization]
+  exact Nat.factorization_prod_pow_eq_self hm
+
+/-- The maximal-prime-power product `∏ p ∈ S, p ^ v_p(n)` over a set `S ⊆ n.primeFactors`
+has exactly `S` as its set of prime factors: `primeFactors` is a left inverse of the map. -/
+lemma primeFactors_prod_pow {n : ℕ} {S : Finset ℕ} (hS : S ⊆ n.primeFactors) :
+    (∏ p ∈ S, p ^ n.factorization p).primeFactors = S := by
+  have hpos : (∏ p ∈ S, p ^ n.factorization p) ≠ 0 := by
+    refine Finset.prod_ne_zero_iff.mpr (fun p hp => ?_)
+    exact pow_ne_zero _ (Nat.prime_of_mem_primeFactors (hS hp)).pos.ne'
+  ext q
+  rw [Nat.mem_primeFactors]
+  constructor
+  · rintro ⟨hq, hqdvd, -⟩
+    obtain ⟨p, hpS, hqp⟩ := (Prime.dvd_finset_prod_iff hq.prime _).mp hqdvd
+    have hp : p.Prime := Nat.prime_of_mem_primeFactors (hS hpS)
+    have hqp' : q ∣ p := hq.prime.dvd_of_dvd_pow hqp
+    have hqeqp : q = p := (Nat.prime_dvd_prime_iff_eq hq hp).mp hqp'
+    exact hqeqp ▸ hpS
+  · intro hqS
+    have hqpf : q ∈ n.primeFactors := hS hqS
+    have hq : q.Prime := Nat.prime_of_mem_primeFactors hqpf
+    refine ⟨hq, ?_, hpos⟩
+    have hvq : 0 < n.factorization q := by
+      rw [← Nat.support_factorization] at hqpf
+      exact Nat.pos_of_ne_zero (Finsupp.mem_support_iff.mp hqpf)
+    exact (dvd_pow_self q hvq.ne').trans (Finset.dvd_prod_of_mem _ hqS)
+
+/-- **The maximal-prime-power product lands in `unitaryDivisors`.** For `S ⊆ n.primeFactors`,
+the product `∏ p ∈ S, p ^ v_p(n)` is a unitary divisor of `n`: with `T` the complementary
+primes, `a := ∏_S` and `b := ∏_T` satisfy `a * b = n` and are coprime, so `a ∣ n`,
+`n / a = b`, and `gcd(a, n/a) = gcd(a, b) = 1`. -/
+lemma prod_mem_unitaryDivisors {n : ℕ} (hn : n ≠ 0) {S : Finset ℕ} (hS : S ⊆ n.primeFactors) :
+    (∏ p ∈ S, p ^ n.factorization p) ∈ unitaryDivisors n := by
+  set a := ∏ p ∈ S, p ^ n.factorization p with ha
+  set T := n.primeFactors \ S with hT
+  set b := ∏ p ∈ T, p ^ n.factorization p with hb
+  have ha_pos : 0 < a := by
+    rw [ha]
+    exact Finset.prod_pos (fun p hp => pow_pos (Nat.prime_of_mem_primeFactors (hS hp)).pos _)
+  have hdisj : Disjoint S T := by rw [hT]; exact Finset.disjoint_sdiff
+  have hunion : S ∪ T = n.primeFactors := by rw [hT]; exact Finset.union_sdiff_of_subset hS
+  have hab : a * b = n := by
+    rw [ha, hb, ← Finset.prod_union hdisj, hunion]
+    exact prod_pow_primeFactors hn
+  have hdvd : a ∣ n := ⟨b, hab.symm⟩
+  have hquot : n / a = b := by rw [← hab, Nat.mul_div_cancel_left b ha_pos]
+  have hcop : Nat.Coprime a b := by
+    rw [ha, hb]
+    apply Nat.Coprime.prod_left
+    intro p hpS
+    apply Nat.Coprime.prod_right
+    intro q hqT
+    have hp : p.Prime := Nat.prime_of_mem_primeFactors (hS hpS)
+    have hq : q.Prime := Nat.prime_of_mem_primeFactors (Finset.mem_sdiff.mp (hT ▸ hqT)).1
+    have hpq : p ≠ q := fun h => absurd hqT (h ▸ Finset.disjoint_left.mp hdisj hpS)
+    exact Nat.Coprime.pow _ _ ((Nat.coprime_primes hp hq).mpr hpq)
+  rw [mem_unitaryDivisors]
+  exact ⟨⟨hdvd, hn⟩, by rw [hquot]; exact hcop⟩
+
+/-- **A unitary divisor keeps full prime powers.** If `d ∣ n`, `gcd(d, n/d) = 1`, and `p ∣ d`,
+then `v_p(d) = v_p(n)`: were `v_p(d) < v_p(n)`, the prime `p` would divide both `d` and `n/d`,
+contradicting their coprimality. -/
+lemma factorization_eq_of_unitary {n d : ℕ} (hn : n ≠ 0) (hdvd : d ∣ n)
+    (hcop : Nat.Coprime d (n / d)) {p : ℕ} (hp : p ∈ d.primeFactors) :
+    d.factorization p = n.factorization p := by
+  have hd0 : d ≠ 0 := by rintro rfl; exact hn (Nat.eq_zero_of_zero_dvd hdvd)
+  have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+  have hpd : p ∣ d := Nat.dvd_of_mem_primeFactors hp
+  have hle : d.factorization p ≤ n.factorization p :=
+    Finsupp.le_def.mp ((Nat.factorization_le_iff_dvd hd0 hn).mpr hdvd) p
+  rcases lt_or_eq_of_le hle with hlt | heq
+  · exfalso
+    have key : (n / d).factorization p = n.factorization p - d.factorization p := by
+      rw [Nat.factorization_div hdvd, Finsupp.coe_tsub, Pi.sub_apply]
+    have hp_ndd : p ∣ n / d := Nat.dvd_of_factorization_pos (by rw [key]; omega)
+    have hg : Nat.gcd d (n / d) = 1 := hcop
+    have hp1 : p ∣ 1 := hg ▸ Nat.dvd_gcd hpd hp_ndd
+    exact absurd (Nat.dvd_one.mp hp1) hpp.one_lt.ne'
+  · exact heq
+
+/-- **Unitary divisors are the image of the powerset of the prime factors** under
+`S ↦ ∏ p ∈ S, p ^ v_p(n)`. -/
+lemma unitaryDivisors_eq_image {n : ℕ} (hn : n ≠ 0) :
+    unitaryDivisors n =
+      n.primeFactors.powerset.image (fun S => ∏ p ∈ S, p ^ n.factorization p) := by
+  ext d
+  constructor
+  · intro hd
+    rw [mem_unitaryDivisors] at hd
+    obtain ⟨⟨hdvd, _⟩, hcop⟩ := hd
+    have hd0 : d ≠ 0 := by rintro rfl; exact hn (Nat.eq_zero_of_zero_dvd hdvd)
+    refine Finset.mem_image.mpr
+      ⟨d.primeFactors, Finset.mem_powerset.mpr (Nat.primeFactors_mono hdvd hn), ?_⟩
+    conv_rhs => rw [← prod_pow_primeFactors hd0]
+    exact Finset.prod_congr rfl
+      (fun p hp => by rw [factorization_eq_of_unitary hn hdvd hcop hp])
+  · intro hd
+    obtain ⟨S, hS, rfl⟩ := Finset.mem_image.mp hd
+    exact prod_mem_unitaryDivisors hn (Finset.mem_powerset.mp hS)
+
+/-- The map `S ↦ ∏ p ∈ S, p ^ v_p(n)` is injective on `n.primeFactors.powerset`, with left
+inverse `primeFactors` (`primeFactors_prod_pow`). -/
+lemma injOn_prod_pow (n : ℕ) :
+    Set.InjOn (fun S : Finset ℕ => ∏ p ∈ S, p ^ n.factorization p)
+      (n.primeFactors.powerset : Set (Finset ℕ)) := by
+  intro S hS T hT hST
+  have h1 := primeFactors_prod_pow (Finset.mem_powerset.mp (by simpa using hS))
+  have h2 := primeFactors_prod_pow (Finset.mem_powerset.mp (by simpa using hT))
+  rw [← h1, ← h2]
+  exact congrArg Nat.primeFactors hST
+
+/-- **Main counting theorem.** The number of unitary divisors of `n ≥ 1` is `2 ^ ω(n)`,
+where `ω(n) = n.primeFactors.card` is the number of distinct primes dividing `n`. -/
+theorem unitaryDivisors_card (n : ℕ) (hn : n ≠ 0) :
+    (unitaryDivisors n).card = 2 ^ n.primeFactors.card := by
+  rw [unitaryDivisors_eq_image hn, Finset.card_image_of_injOn (injOn_prod_pow n),
+    Finset.card_powerset]
+
+/-- **Bridge to the idempotent count.** The number of idempotents of `ZMod n` — the
+automorphic residues `e ^ 2 ≡ e (mod n)` — equals the number of unitary divisors of `n`,
+for every `n ≥ 1`. -/
+theorem idempotents_eq_unitaryDivisors (n : ℕ) (hn : 0 < n) :
+    Nat.card {e : ZMod n // e * e = e} = (unitaryDivisors n).card := by
+  rw [AutomorphicNumberOQ01OQ01.idempotent_count n hn, unitaryDivisors_card n hn.ne']
+
+/-- A prime power `p ^ k` (`k ≥ 1`) has exactly two unitary divisors, `1` and `p ^ k` — the
+count `2 ^ 1`. -/
+theorem unitaryDivisors_card_prime_pow {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : 0 < k) :
+    (unitaryDivisors (p ^ k)).card = 2 := by
+  rw [unitaryDivisors_card _ (pow_ne_zero k hp.pos.ne'), Nat.primeFactors_prime_pow hk.ne' hp,
+    Finset.card_singleton, pow_one]
+
+/-- The unitary-divisor count is `1` exactly for `n = 1` (the empty product only). -/
+theorem unitaryDivisors_card_eq_one_iff {n : ℕ} (hn : n ≠ 0) :
+    (unitaryDivisors n).card = 1 ↔ n = 1 := by
+  rw [unitaryDivisors_card n hn, Nat.pow_eq_one, Finset.card_eq_zero, Nat.primeFactors_eq_empty]
+  omega
+
+end AutomorphicNumberOQ01OQ01OQ02

--- a/src/data/proofs/automorphic-number-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,212 @@
+{
+  "id": "automorphic-number-oq-01-oq-01-oq-02",
+  "slug": "automorphic-number-oq-01-oq-01-oq-02",
+  "title": "The Unitary-Divisor Count: #(unitary divisors of n) = 2^ω(n)",
+  "description": "The parent entry proves that ZMod n has exactly 2^ω(n) idempotents (equivalently, 2^ω(n) automorphic residues e²≡e mod n), where ω(n) is the number of distinct primes dividing n. Its sibling reads that count as the number of squarefree divisors of n. This entry gives the count its other classical arithmetic meaning: it is the number of UNITARY divisors of n. A unitary divisor of n is a divisor d ∣ n with gcd(d, n/d)=1 — equivalently, at each prime p ∣ n it takes either the full prime power p^v_p(n) or 1, never splitting a prime power. The main theorem unitaryDivisors_card proves #(unitaryDivisors n) = 2^ω(n) for every n ≠ 0, via the bijection S ↦ ∏_{p∈S} p^v_p(n) from the powerset of n.primeFactors onto the unitary divisors: the maximal-prime-power product of a subset of primes is a unitary divisor (with the complementary primes giving the coprime cofactor, so a·b=n and gcd(a,b)=1), every unitary divisor is recovered this way because gcd(d,n/d)=1 forces v_p(d)=v_p(n) at each prime p ∣ d, and the map is injective because primeFactors is a left inverse. Composing with the parent's idempotent_count gives idempotents_eq_unitaryDivisors: the automorphic residues of n are equinumerous with its unitary divisors, for every n ≥ 1. The proof mirrors the sibling squarefree-divisor count, replacing the exponent-one product ∏_{p∈s} p by the maximal-prime-power product ∏_{p∈s} p^v_p(n); the new ingredient is factorization_eq_of_unitary, which shows the unitary condition keeps whole prime powers.",
+  "meta": {
+    "author": "Lean Genius Researcher-5",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AutomorphicNumberOQ01OQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "automorphic-numbers",
+      "idempotents",
+      "unitary-divisors",
+      "prime-factorization",
+      "divisor-function",
+      "arithmetic-functions",
+      "combinatorial-bijection"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 212,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide, no decide. Both main theorems (unitaryDivisors_card, idempotents_eq_unitaryDivisors) were confirmed via #print axioms to depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (Classical.choice / Quot.sound enter through Nat.card in the idempotent bridge). Builds on the verified parent entry AutomorphicNumberOQ01OQ01, reusing its idempotent_count theorem.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorization_prod_pow_eq_self",
+        "description": "For n ≠ 0, n equals the product of p^v_p(n) over its prime factorization; recast here as ∏ p∈n.primeFactors, p^v_p(n) = n (prod_pow_primeFactors), the identity a·b=n rests on",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.factorization_le_iff_dvd",
+        "description": "For nonzero d, n: d.factorization ≤ n.factorization ↔ d ∣ n; gives v_p(d) ≤ v_p(n) for a divisor, the ≤ half of factorization_eq_of_unitary",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.factorization_div",
+        "description": "For d ∣ n, (n/d).factorization = n.factorization − d.factorization; used to show p ∣ n/d whenever v_p(d) < v_p(n)",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_of_factorization_pos",
+        "description": "If n.factorization p ≠ 0 then p ∣ n; turns the positive p-adic valuation of n/d into the divisibility p ∣ n/d that contradicts coprimality",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime.prod_left",
+        "description": "A product ∏ f i is coprime to k when each factor is; with prod_right reduces coprimality of the two maximal-prime-power products to coprimality of distinct prime powers",
+        "module": "Mathlib.Data.Nat.GCD.BigOperators"
+      },
+      {
+        "theorem": "Nat.coprime_primes",
+        "description": "Distinct primes are coprime; with Nat.Coprime.pow gives coprimality of p^a and q^b for p ≠ q, the per-prime input to the product-coprimality argument",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "Cardinality of an injective image; with Finset.card_powerset this converts the powerset bijection into #(unitaryDivisors n) = 2^ω(n)",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Prime.dvd_finset_prod_iff",
+        "description": "A prime dividing a finite product divides one of its factors; used to show primeFactors is a left inverse of the maximal-prime-power map (primeFactors_prod_pow)",
+        "module": "Mathlib.Algebra.BigOperators.Associated"
+      },
+      {
+        "theorem": "Nat.primeFactors_mono",
+        "description": "d ∣ n (n ≠ 0) ⟹ d.primeFactors ⊆ n.primeFactors; places the prime-factor set of a unitary divisor inside the powerset that indexes the image",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01OQ01.idempotent_count",
+        "description": "The parent entry's theorem Nat.card {e : ZMod n // e*e=e} = 2^ω(n) for 0 < n; reused verbatim to bridge the unitary-divisor count to the idempotent count",
+        "module": "Proofs.AutomorphicNumberOQ01OQ01"
+      }
+    ],
+    "dateAdded": "2026-07-05",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AutomorphicNumberOQ01OQ01"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "AutomorphicNumberOQ01OQ01OQ02",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/AutomorphicNumberOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "unitaryDivisors_card",
+      "type": "headline",
+      "statement": "n ≠ 0 → (unitaryDivisors n).card = 2 ^ n.primeFactors.card",
+      "description": "The number of unitary divisors of n is 2^ω(n), via the bijection S ↦ ∏_{p∈S} p^v_p(n) from the powerset of n.primeFactors onto the unitary divisors of n (Finset.card_image_of_injOn + Finset.card_powerset).",
+      "significance": "The general form of the identity the parent file's concrete moduli only checked case by case: unitary divisors are indexed by subsets of the prime-factor set, so there are exactly 2^ω(n) of them — the same count as the idempotents of ZMod n and the squarefree divisors of n."
+    },
+    {
+      "name": "idempotents_eq_unitaryDivisors",
+      "type": "headline",
+      "statement": "0 < n → Nat.card {e : ZMod n // e * e = e} = (unitaryDivisors n).card",
+      "description": "The automorphic residues of n — the idempotents of ZMod n — are equinumerous with the unitary divisors of n. Both counts equal 2^ω(n). Obtained by composing the parent's idempotent_count with unitaryDivisors_card.",
+      "significance": "Gives the parent's abstract count 2^ω(n) a second concrete divisor-theoretic meaning: each idempotent corresponds to a unitary divisor built by taking, at each prime, either the full prime power or 1."
+    },
+    {
+      "name": "prod_mem_unitaryDivisors",
+      "type": "core",
+      "statement": "n ≠ 0 → S ⊆ n.primeFactors → (∏ p ∈ S, p ^ n.factorization p) ∈ unitaryDivisors n",
+      "description": "The maximal-prime-power product over a subset S of n's prime factors is a unitary divisor. Writing T = n.primeFactors \\ S, the products a = ∏_S and b = ∏_T satisfy a·b = n (disjoint union of prime powers) and are coprime (disjoint prime supports), so a ∣ n, n/a = b, and gcd(a, n/a) = gcd(a, b) = 1.",
+      "significance": "The 'into' half of the bijection: every subset of the primes yields a genuine unitary divisor, with its complementary primes supplying the coprime cofactor."
+    },
+    {
+      "name": "factorization_eq_of_unitary",
+      "type": "core",
+      "statement": "n ≠ 0 → d ∣ n → gcd(d, n/d) = 1 → p ∈ d.primeFactors → d.factorization p = n.factorization p",
+      "description": "A unitary divisor keeps whole prime powers: at every prime p dividing d, its p-adic valuation matches that of n. Were v_p(d) < v_p(n), then p would divide n/d (its valuation there is positive) as well as d, contradicting gcd(d, n/d) = 1.",
+      "significance": "The 'onto' half's key step and the one genuinely new ingredient beyond the squarefree count: it is exactly the unitary condition (coprimality with the cofactor) that prevents a prime power from being split, so d = ∏_{p ∣ d} p^v_p(n)."
+    },
+    {
+      "name": "primeFactors_prod_pow",
+      "type": "supporting",
+      "statement": "S ⊆ n.primeFactors → (∏ p ∈ S, p ^ n.factorization p).primeFactors = S",
+      "description": "primeFactors is a left inverse of the maximal-prime-power map on subsets of n's prime factors: the product ∏_{p∈S} p^v_p(n) has exactly S as its set of prime factors (each factor contributes its own prime, and a prime dividing the product divides one factor).",
+      "significance": "Supplies injectivity of the map (injOn_prod_pow), completing the bijection that yields the 2^ω(n) count."
+    },
+    {
+      "name": "unitaryDivisors_card_prime_pow",
+      "type": "supporting",
+      "statement": "p.Prime → 0 < k → (unitaryDivisors (p ^ k)).card = 2",
+      "description": "A prime power p^k (k ≥ 1) has exactly two unitary divisors, 1 and p^k — the count 2^1, since ω(p^k) = 1.",
+      "significance": "The base case of the count: a single prime power admits only the two trivial complementary coprime factorizations."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-overview",
+      "title": "Overview: the unitary-divisor count",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Imports (Mathlib + parent AutomorphicNumberOQ01OQ01) and module docstring. The parent shows ZMod n has 2^ω(n) idempotents; the sibling reads this as the number of squarefree divisors. This file gives the count its unitary-divisor meaning: #(unitaryDivisors n) = 2^ω(n), and hence #idempotents = #unitaryDivisors. The strategy mirrors the squarefree count with the exponent-one product ∏ p replaced by the maximal-prime-power product ∏ p^v_p(n). 0 axioms, 0 sorries.",
+      "mathContext": "Unitary divisors of n ⟷ subsets of the prime-factor set of n, via the maximal-prime-power product of a subset of primes."
+    },
+    {
+      "id": "unitary-def-and-inverse",
+      "title": "Part I: definition, the factorization identity, and the left inverse",
+      "startLine": 57,
+      "endLine": 99,
+      "summary": "unitaryDivisors n := {d ∈ n.divisors | Coprime d (n/d)} with its membership unfolding (mem_unitaryDivisors). prod_pow_primeFactors recasts Nat.factorization_prod_pow_eq_self as ∏ p∈n.primeFactors, p^v_p(n) = n. primeFactors_prod_pow shows primeFactors is a left inverse of the map S ↦ ∏_{p∈S} p^v_p(n): a prime divides the product iff it lies in S (Prime.dvd_finset_prod_iff one way, Finset.dvd_prod_of_mem the other).",
+      "mathContext": "The maximal-prime-power map and its inverse primeFactors set up the bijection with subsets of the primes."
+    },
+    {
+      "id": "into-and-onto",
+      "title": "Part II: the product is a unitary divisor, and every unitary divisor arises",
+      "startLine": 100,
+      "endLine": 175,
+      "summary": "prod_mem_unitaryDivisors: for S ⊆ primeFactors, with T the complementary primes, a = ∏_S and b = ∏_T satisfy a·b = n (Finset.prod_union on the disjoint union) and are coprime (Nat.Coprime.prod_left/prod_right over distinct prime powers), so a is a unitary divisor with n/a = b. factorization_eq_of_unitary: the unitary condition forces v_p(d) = v_p(n) at each prime p ∣ d (else p ∣ gcd(d, n/d) = 1). unitaryDivisors_eq_image assembles these into the image characterization, and injOn_prod_pow gives injectivity from the left inverse.",
+      "mathContext": "The coprimality gcd(d, n/d)=1 is precisely what prevents splitting a prime power, making the maximal-prime-power products exactly the unitary divisors."
+    },
+    {
+      "id": "count-and-bridge",
+      "title": "Part III: the count 2^ω(n), the idempotent bridge, and corollaries",
+      "startLine": 176,
+      "endLine": 212,
+      "summary": "unitaryDivisors_card: card_image_of_injOn on the bijection plus Finset.card_powerset gives #unitaryDivisors = 2^ω(n). idempotents_eq_unitaryDivisors: composing with the parent's idempotent_count shows the automorphic residues of n are equinumerous with its unitary divisors. Corollaries pin the degenerate cases: count = 2 for prime powers (unitaryDivisors_card_prime_pow) and count = 1 ⟺ n = 1 (unitaryDivisors_card_eq_one_iff).",
+      "mathContext": "#{idempotents of ZMod n} = #{unitary divisors of n} = #{squarefree divisors of n} = 2^ω(n)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Unitary divisors were introduced by R. Vaidyanathaswamy (1931) and studied extensively by Eckford Cohen in the 1960s. A unitary divisor d of n is one for which d and n/d are coprime — a 'block' divisor that takes, at each prime, either the entire prime power dividing n or none of it. The count of unitary divisors, written 2^ω(n) or d*(n), is one of the standard multiplicative arithmetic functions: it is multiplicative, equals 2 on every prime power, and hence equals 2^ω(n) in general, where ω is the number of distinct prime divisors. That the count coincides with the number of squarefree divisors of n and with the number of idempotents of ℤ/nℤ is no accident: all three are counted by the subsets of the prime-factor set of n. The idempotents of ℤ/nℤ correspond, under the Chinese Remainder decomposition ℤ/nℤ ≅ ∏ ℤ/pᵢ^{eᵢ}ℤ, to choices of 0 or 1 in each local factor; the unitary divisors correspond to the same choices realized as the full prime power pᵢ^{eᵢ} or 1; and the squarefree divisors realize them as pᵢ or 1. This entry formalizes the unitary-divisor member of that triple and links it back to the idempotent count.",
+    "problemStatement": "The parent entry proves #{idempotents of ℤ/nℤ} = 2^{ω(n)} and, in a follow-up, verifies for a few concrete moduli that this equals the number of unitary divisors, leaving the general identity as the natural next step. This entry proves that general identity: for every n ≠ 0 the number of unitary divisors of n (divisors d with gcd(d, n/d) = 1) is 2^{ω(n)}, and consequently, for n ≥ 1, the idempotents of ℤ/nℤ are equinumerous with the unitary divisors of n.",
+    "proofStrategy": "Exhibit the bijection S ↦ ∏_{p∈S} p^{v_p(n)} from the powerset of n.primeFactors onto the unitary divisors of n, mirroring the sibling squarefree-divisor count with the exponent-one product replaced by the maximal-prime-power product. INTO: for a subset S, let T = n.primeFactors \\ S and a = ∏_S, b = ∏_T; the disjoint union of prime supports gives a·b = ∏_{n.primeFactors} p^{v_p(n)} = n (Nat.factorization_prod_pow_eq_self), so a ∣ n and n/a = b, and a, b are coprime because they range over disjoint sets of primes (Nat.Coprime.prod_left/prod_right plus Nat.coprime_primes and Nat.Coprime.pow), whence gcd(a, n/a) = 1. ONTO: a unitary divisor d is recovered as ∏_{p∈d.primeFactors} p^{v_p(n)}, because the unitary condition gcd(d, n/d)=1 forces v_p(d) = v_p(n) at every prime p ∣ d — were v_p(d) < v_p(n), then p would divide n/d (Nat.factorization_div gives positive valuation there) as well as d, so p ∣ gcd(d, n/d) = 1, a contradiction. INJECTIVE: primeFactors is a left inverse of the map (a prime divides ∏_{p∈S} p^{v_p(n)} iff it lies in S). Finset.card_image_of_injOn and Finset.card_powerset then give 2^{ω(n)}, and composing with the parent's idempotent_count bridges to the automorphic-residue count.",
+    "keyInsights": [
+      "Unitary divisors, squarefree divisors, and idempotents of ℤ/nℤ are all counted by the subsets of the prime-factor set of n — three realizations of the same binary choice at each prime, and all equal to 2^{ω(n)}.",
+      "The single new ingredient beyond the squarefree count is factorization_eq_of_unitary: the coprimality gcd(d, n/d)=1 is exactly the condition that prevents a prime power from being split, so a unitary divisor keeps, at each of its primes, the full prime power dividing n.",
+      "The 'into' direction is cleanest through the complementary primes: a = ∏_S and b = ∏_{complement} multiply to n and have disjoint prime supports, giving both a ∣ n with n/a = b and the coprimality gcd(a, n/a) = 1 in one stroke — avoiding any explicit computation of n/a.",
+      "Replacing the squarefree count's product ∏_{p∈s} p by the maximal-prime-power product ∏_{p∈s} p^{v_p(n)} reuses the entire powerset-bijection skeleton; only the membership and left-inverse lemmas need the exponent v_p(n)."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every n ≠ 0 the number of unitary divisors of n — divisors d with gcd(d, n/d) = 1 — is 2^{ω(n)}, proved via the bijection S ↦ ∏_{p∈S} p^{v_p(n)} between subsets of n's prime factors and its unitary divisors. Composed with the parent entry's idempotent count, this shows the automorphic residues of n (idempotents of ℤ/nℤ) are equinumerous with the unitary divisors of n. Together with the sibling squarefree-divisor count, the entry completes the identification #{idempotents} = #{squarefree divisors} = #{unitary divisors} = 2^{ω(n)}. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+    "implications": "The result places the unitary divisor-count function d*(n) = 2^{ω(n)} on the same combinatorial footing as the idempotent count, and its proof isolates the exact role of the unitary condition (keeping whole prime powers) in the powerset bijection. The reusable lemma factorization_eq_of_unitary characterizes unitary divisors through their factorizations and is independent of the automorphic-number context.",
+    "openQuestions": [
+      "Can the multiplicativity of d*(n) = #(unitaryDivisors n) be extracted as an ArithmeticFunction.IsMultiplicative instance, recovering the count 2^{ω(n)} from the prime-power value 2 via the standard multiplicative machinery instead of the direct powerset bijection?",
+      "Does the same maximal-prime-power bijection give the finer count of unitary divisors d with a prescribed number of prime factors as the binomial coefficient C(ω(n), k), refining 2^{ω(n)} = Σ_k C(ω(n), k)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "automorphic-number-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Counting Automorphic Residues mod n as 2^ω(n) — proves the idempotent count 2^ω(n) that this entry reinterprets as the number of unitary divisors; its idempotent_count is reused directly in the bridge theorem idempotents_eq_unitaryDivisors."
+    },
+    {
+      "proofId": "automorphic-number-oq-01-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Automorphic Residues Count Squarefree Divisors — the parallel arithmetic reinterpretation of 2^ω(n) as the number of squarefree divisors; this entry mirrors its powerset-bijection proof with the maximal-prime-power product, giving the unitary-divisor count and the identity #squarefree = #unitary."
+    },
+    {
+      "proofId": "fundamental-arithmetic",
+      "relationship": "foundation",
+      "description": "Fundamental Theorem of Arithmetic — unique factorization underlies ω(n), the identity n = ∏ p^v_p(n), and the powerset bijection between subsets of the primes and unitary divisors."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **general** unitary-divisor count identity, the natural next step flagged by the automorphic-number idempotent line:

- `unitaryDivisors_card`: `#(unitaryDivisors n) = 2 ^ ω(n)` for all `n ≠ 0`
- `idempotents_eq_unitaryDivisors`: `Nat.card {e : ZMod n // e*e=e} = #(unitaryDivisors n)` for `0 < n`

A unitary divisor is a divisor `d ∣ n` with `gcd(d, n/d)=1`. The proof exhibits the bijection `S ↦ ∏_{p∈S} p^{v_p(n)}` from `n.primeFactors.powerset` onto the unitary divisors, mirroring the sibling squarefree-divisor count (`AutomorphicNumberOQ01OQ01OQ01`) with the exponent-one product replaced by the maximal-prime-power product. The one new ingredient, `factorization_eq_of_unitary`, shows the coprimality condition keeps whole prime powers (`v_p(d)=v_p(n)` at each `p ∣ d`).

Together with the sibling entry this completes: `#idempotents(ZMod n) = #squarefree divisors = #unitary divisors = 2^ω(n)`.

## Verification

- Builds via `./proofs/scripts/docker-build.sh Proofs.AutomorphicNumberOQ01OQ01OQ02` ✓
- **0 sorries, 0 axioms** — both headline theorems confirmed via `#print axioms` to depend only on `propext / Classical.choice / Quot.sound`.
- No `decide` / `native_decide`.
- 212 lines, 11 theorems/lemmas, 1 def. Builds on the verified parent `AutomorphicNumberOQ01OQ01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)