### PR TITLE
Enrich Sylvester's Sequence (arithmetic skeleton): add scholarly references

### DIFF
--- a/src/data/proofs/sylvester-sequence-oq-01-oq-03/meta.json
+++ b/src/data/proofs/sylvester-sequence-oq-01-oq-03/meta.json
@@ -161,7 +161,29 @@
     }
   ],
   "references": {
-    "papers": [],
+    "papers": [
+      {
+        "authors": "Sylvester, J. J.",
+        "title": "On a point in the theory of vulgar fractions",
+        "year": "1880",
+        "venue": "American Journal of Mathematics, vol. 3, no. 4, pp. 332–335",
+        "note": "The origin of the sequence: Sylvester's analysis of the greedy expansion of 1 as a sum of distinct unit fractions, from which the recurrence aₙ₊₁ = a₀a₁⋯aₙ + 1 and the terms 2, 3, 7, 43, … arise."
+      },
+      {
+        "authors": "Graham, R. L., Knuth, D. E., and Patashnik, O.",
+        "title": "Concrete Mathematics: A Foundation for Computer Science",
+        "year": "1994",
+        "venue": "Addison-Wesley, 2nd ed., §4.3 (Euclid numbers)",
+        "note": "Develops the Euclid-style product recurrence aₙ₊₁ = a₀⋯aₙ + 1 and the coprimality argument used here, in the same 'each term is one more than the product of all previous' form."
+      },
+      {
+        "authors": "Erdős, P. and Graham, R. L.",
+        "title": "Old and New Problems and Results in Combinatorial Number Theory",
+        "year": "1980",
+        "venue": "L'Enseignement Mathématique, Monographie no. 28",
+        "note": "Places Sylvester's sequence in the theory of Egyptian fractions and Sylvester–Fibonacci greedy expansions, the broader context for the reciprocal-sum face treated in the companion entries."
+      }
+    ],
     "urls": [
       "https://en.wikipedia.org/wiki/Sylvester%27s_sequence",
       "https://oeis.org/A000058"


### PR DESCRIPTION
Enrichment pass for `sylvester-sequence-oq-01-oq-03`. This entry is already comprehensively enriched (9 annotations with mathContext/significance/relatedConcepts/prerequisites, 5 keyInsights, 5 sections covering all 145 lines, mainTheorems, 3 crossReferences). Per the diminishing-returns rule I did **not** inflate it — I filled the one genuine, safe gap.

## Change
- **`references.papers`** was empty (only a Wikipedia URL for attribution). Added 3 primary/scholarly references:
  1. **Sylvester, J. J. (1880)**, *On a point in the theory of vulgar fractions*, Amer. J. Math. 3 — the origin of the sequence
  2. **Graham, Knuth, Patashnik (1994)**, *Concrete Mathematics* §4.3 — the Euclid-number recurrence and coprimality argument
  3. **Erdős & Graham (1980)** — Egyptian-fraction context

## Verification
- `gallery:check-size`: within caps (meta 14.8 KB ≤ 60 KB)
- `annotations:build`: no errors for this entry
- JSON validated; no other content changed; entry remains `status: pending` / build-pending (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)