### PR TITLE
research(euler-totient-oq-08-oq-01): non-coprime Euler periodicity for composite moduli via CRT [verified, 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ08OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ08OQ01.lean
@@ -1,0 +1,205 @@
+/-
+# Euler's totient periodicity beyond the coprime case (composite moduli)
+
+Euler's theorem reduces the exponent of `aᵏ (mod n)` modulo `φ n` **only when
+`gcd(a, n) = 1`**. `Mathlib/NumberTheory/PowModTotient.lean` records as an explicit
+TODO the removal of that coprimality hypothesis, and the sibling file
+`EulerTotientOQ08` carried this out for **prime-power moduli** `pᵉ`: for every base
+`a` (invertible or not) and every `k ≥ e`,
+
+  `a ^ (k + φ(pᵉ)) ≡ a ^ k [MOD pᵉ]`.
+
+This file assembles those prime-power periodicities into the statement for an
+**arbitrary composite modulus** `n` via the Chinese Remainder Theorem. Writing
+`n = ∏ p pᵉ⁽ᵖ⁾` for its prime factorisation, once the exponent `k` exceeds every
+`eₚ = vₚ(n)` (equivalently `k ≥ maxₚ vₚ(n)`) each prime-power factor is already in
+its periodic régime, and since `φ` is multiplicative `φ(pᵉ⁽ᵖ⁾) ∣ φ(n)`, so the
+`φ(n)`-shift is a whole number of periods for every factor. CRT glues the factorwise
+congruences back together modulo `n`.
+
+## Main results
+
+* `EulerTotientOQ08OQ01.pow_add_totient_modEq` — for any base `a` and any modulus
+  `n ≠ 0`, provided `k ≥ vₚ(n)` for every prime `p` (the composite pre-period
+  condition):  `a ^ (k + φ n) ≡ a ^ k [MOD n]`.
+* `EulerTotientOQ08OQ01.pow_add_mul_totient_modEq` — the multi-period version, adding
+  any multiple `l · φ n` to the exponent.
+* `EulerTotientOQ08OQ01.pow_modEq` — the full exponent reduction
+  `a ^ k ≡ a ^ (K + (k - K) % φ n) [MOD n]` for `k ≥ K` where `K` bounds every
+  `vₚ(n)`; the constant `K`-prefix is the composite pre-period.
+* `EulerTotientOQ08OQ01.pow_add_totient_modEq_of_le` — a convenient factorisation-free
+  sufficient condition: `n ≤ 2 ^ k` already forces `k ≥ vₚ(n)` for all `p`.
+
+These are genuinely outside Mathlib's coprime-only coverage: e.g. they apply to
+`2 ^ k (mod 12)` or `10 ^ k (mod 12)`, where the base shares a factor with the
+modulus and Euler's theorem says nothing.
+-/
+import Mathlib
+import Proofs.EulerTotientOQ08
+
+open Nat (totient)
+open Finset
+
+namespace EulerTotientOQ08OQ01
+
+open scoped Nat
+
+/-!
+### CRT assembly helper
+
+A congruence that holds modulo each member of a pairwise-coprime family holds
+modulo their product. This is the Chinese Remainder Theorem in its
+`Nat.ModEq`/divisibility guise, packaged for a `Finset` of moduli.
+-/
+
+/-- If `x ≡ y` modulo every `f i` for `i ∈ s`, and the `f i` are pairwise coprime,
+then `x ≡ y` modulo `∏ i ∈ s, f i`. -/
+theorem modEq_prod_of_pairwiseCoprime {x y : ℕ} {s : Finset ℕ} {f : ℕ → ℕ}
+    (hco : (s : Set ℕ).Pairwise (Function.onFun Nat.Coprime f))
+    (h : ∀ i ∈ s, x ≡ y [MOD f i]) :
+    x ≡ y [MOD ∏ i ∈ s, f i] := by
+  induction s using Finset.induction with
+  | empty => simpa using Nat.modEq_one
+  | @insert a s ha ih =>
+    rw [Finset.prod_insert ha]
+    -- `f a` is coprime to the product over the remaining factors.
+    have hcoprime : (f a).Coprime (∏ i ∈ s, f i) := by
+      refine Nat.Coprime.prod_right fun i hi => ?_
+      exact hco (Finset.mem_insert_self a s) (Finset.mem_insert_of_mem hi)
+        (by rintro rfl; exact ha hi)
+    refine (Nat.modEq_and_modEq_iff_modEq_mul hcoprime).mp
+      ⟨h a (Finset.mem_insert_self a s), ?_⟩
+    exact ih (hco.mono (Finset.coe_subset.mpr (Finset.subset_insert a s)))
+      (fun i hi => h i (Finset.mem_insert_of_mem hi))
+
+/-!
+### Composite-modulus periodicity
+-/
+
+/-- **Non-coprime composite Euler periodicity (single period).**
+For every base `a`, modulus `n ≠ 0`, and exponent `k` at least as large as every
+prime-power exponent of `n` (i.e. `n.factorization p ≤ k` for all `p`, equivalently
+`k ≥ maxₚ vₚ(n)`), adding `φ n` to the exponent leaves `aᵏ` unchanged modulo `n` —
+*even when `gcd(a, n) ≠ 1`*, the case Euler's theorem does not cover. -/
+theorem pow_add_totient_modEq {n : ℕ} (hn : n ≠ 0) {a k : ℕ}
+    (hk : ∀ p, n.factorization p ≤ k) :
+    a ^ (k + totient n) ≡ a ^ k [MOD n] := by
+  -- Rewrite the modulus as the product of its prime-power factors.
+  have hn_eq : (∏ p ∈ n.primeFactors, p ^ n.factorization p) = n := by
+    rw [← Nat.support_factorization]
+    exact Nat.factorization_prod_pow_eq_self hn
+  -- Rewrite only the modulus (keeping the `φ n` shift intact) as a product of
+  -- prime powers, and glue the factorwise congruences via CRT.
+  suffices h : a ^ (k + totient n) ≡ a ^ k
+      [MOD ∏ p ∈ n.primeFactors, p ^ n.factorization p] by
+    rwa [hn_eq] at h
+  refine modEq_prod_of_pairwiseCoprime (f := fun p => p ^ n.factorization p) ?_ ?_
+  · -- Distinct prime powers are coprime.
+    intro p hp q hq hpq
+    exact Nat.Coprime.pow _ _
+      ((Nat.coprime_primes (Nat.prime_of_mem_primeFactors (Finset.mem_coe.mp hp))
+        (Nat.prime_of_mem_primeFactors (Finset.mem_coe.mp hq))).mpr hpq)
+  · -- Factorwise: the `φ n`-shift is a whole number of `φ(pᵉ)`-periods.
+    intro p hp
+    have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+    have he : 1 ≤ n.factorization p := by
+      rw [← Nat.support_factorization] at hp
+      exact Nat.one_le_iff_ne_zero.mpr (Finsupp.mem_support_iff.mp hp)
+    -- `φ(pᵉ) ∣ φ n` because `pᵉ ∣ n` and `φ` is monotone under divisibility.
+    obtain ⟨l, hl⟩ := Nat.totient_dvd_of_dvd (Nat.ordProj_dvd n p)
+    rw [hl]
+    calc a ^ (k + totient (p ^ n.factorization p) * l)
+        = a ^ (k + l * totient (p ^ n.factorization p)) := by rw [Nat.mul_comm]
+      _ ≡ a ^ k [MOD p ^ n.factorization p] :=
+          EulerTotientOQ08.pow_add_mul_totient_modEq_primePow hpp he (hk p) l
+
+/-- The multi-period form: adding any multiple `l · φ n` of the period to the
+exponent leaves `aᵏ` unchanged modulo `n`, for every base `a` (non-coprime included),
+provided `k` exceeds every prime-power exponent of `n`. -/
+theorem pow_add_mul_totient_modEq {n : ℕ} (hn : n ≠ 0) {a k : ℕ}
+    (hk : ∀ p, n.factorization p ≤ k) (l : ℕ) :
+    a ^ (k + l * totient n) ≡ a ^ k [MOD n] := by
+  induction l with
+  | zero => simpa using Nat.ModEq.refl (a ^ k)
+  | succ l ih =>
+    have hstep : a ^ ((k + l * totient n) + totient n) ≡ a ^ (k + l * totient n) [MOD n] :=
+      pow_add_totient_modEq hn (fun p => (hk p).trans (Nat.le_add_right _ _))
+    calc a ^ (k + (l + 1) * totient n)
+        = a ^ ((k + l * totient n) + totient n) := by congr 1; ring
+      _ ≡ a ^ (k + l * totient n) [MOD n] := hstep
+      _ ≡ a ^ k [MOD n] := ih
+
+/-- **Full exponent reduction for composite moduli** (the non-coprime analogue of
+`Nat.pow_totient_mod`). Fix any `K` bounding every prime-power exponent of `n`
+(`n.factorization p ≤ K` for all `p`). Then for every base `a` and every `k ≥ K`,
+the exponent of `aᵏ (mod n)` reduces to `K + (k - K) % φ n`. The leading `K` is the
+composite pre-period: bases sharing a factor with `n` are not yet stable below it, but
+from exponent `K` onward the sequence is periodic with period `φ n`. -/
+theorem pow_modEq {n K : ℕ} (hn : n ≠ 0) (hK : ∀ p, n.factorization p ≤ K) {a k : ℕ}
+    (hk : K ≤ k) :
+    a ^ k ≡ a ^ (K + (k - K) % totient n) [MOD n] := by
+  have hsplit : k = (K + (k - K) % totient n)
+      + ((k - K) / totient n) * totient n := by
+    have hdm : (k - K) % totient n + (k - K) / totient n * totient n = k - K :=
+      Nat.mod_add_div' (k - K) (totient n)
+    omega
+  -- The reduced exponent still bounds every prime-power exponent of `n`.
+  have hbound : ∀ p, n.factorization p ≤ K + (k - K) % totient n :=
+    fun p => (hK p).trans (Nat.le_add_right _ _)
+  calc a ^ k
+      = a ^ ((K + (k - K) % totient n) + ((k - K) / totient n) * totient n) := by
+        rw [← hsplit]
+    _ ≡ a ^ (K + (k - K) % totient n) [MOD n] :=
+        pow_add_mul_totient_modEq hn hbound ((k - K) / totient n)
+
+/-- A factorisation-free sufficient condition. Since `vₚ(n) ≤ log₂ n` for every prime
+`p`, the bound `n ≤ 2 ^ k` already guarantees `k ≥ vₚ(n)` for all `p`, so the
+`φ n`-shift is periodic modulo `n`. -/
+theorem pow_add_totient_modEq_of_le {n k : ℕ} (hn : n ≠ 0) (hnk : n ≤ 2 ^ k) {a : ℕ} :
+    a ^ (k + totient n) ≡ a ^ k [MOD n] := by
+  refine pow_add_totient_modEq hn fun p => ?_
+  by_cases hpp : p.Prime
+  · exact Nat.factorization_le_of_le_pow (hnk.trans (Nat.pow_le_pow_left hpp.two_le k))
+  · simp [Nat.factorization_eq_zero_of_not_prime n hpp]
+
+/-! ### Worked examples (non-coprime bases, composite moduli) -/
+
+-- `2 ^ k (mod 12)`: `gcd(2, 12) = 2 ≠ 1`, so Euler's coprime theorem does not apply.
+-- Here `12 ≤ 2⁴`, so the factorisation-free bound gives the period from `k = 4` on.
+example : (2 : ℕ) ^ (4 + totient 12) ≡ 2 ^ 4 [MOD 12] :=
+  pow_add_totient_modEq_of_le (by norm_num) (by norm_num)
+
+-- Concrete sanity check of the same instance: `2⁸ = 256 ≡ 4` and `2⁴ = 16 ≡ 4 (mod 12)`.
+example : (2 : ℕ) ^ 8 ≡ 2 ^ 4 [MOD 12] := by decide
+
+-- Sharp pre-period for `n = 12 = 2²·3`: `maxₚ vₚ(12) = 2`, so the period already holds
+-- from `k = 2`, which the factorisation-free `n ≤ 2ᵏ` bound (needing `k ≥ 4`) misses.
+-- The bound `vₚ(12) ≤ 2` for every `p` holds because no `p³` divides `12`.
+example : (2 : ℕ) ^ (2 + totient 12) ≡ 2 ^ 2 [MOD 12] := by
+  refine pow_add_totient_modEq (by norm_num) fun p => ?_
+  by_cases hp : p.Prime
+  · by_contra hc
+    push_neg at hc
+    have hdvd : p ^ 3 ∣ 12 := (hp.pow_dvd_iff_le_factorization (by norm_num)).mpr (by omega)
+    have hle : p ^ 3 ≤ 12 := Nat.le_of_dvd (by norm_num) hdvd
+    have hp2 : 2 ≤ p := hp.two_le
+    have hpu : p < 3 := by
+      by_contra h
+      push_neg at h
+      have : 27 ≤ p ^ 3 := by
+        calc (27 : ℕ) = 3 ^ 3 := by norm_num
+          _ ≤ p ^ 3 := Nat.pow_le_pow_left h 3
+      omega
+    interval_cases p
+    · exact absurd hdvd (by decide)
+  · simp [Nat.factorization_eq_zero_of_not_prime 12 hp]
+
+-- `2⁶ = 64 ≡ 4` and `2² = 4 (mod 12)`: the sharp instance verified numerically.
+example : (2 : ℕ) ^ 6 ≡ 2 ^ 2 [MOD 12] := by decide
+
+-- `10 ^ k (mod 12)`: `gcd(10, 12) = 2`; full reduction of a large exponent of a
+-- non-invertible base. `K = 2` bounds `vₚ(12)`, `φ(12) = 4`, so
+-- `10 ^ 100 ≡ 10 ^ (2 + (100-2) % 4) = 10 ^ 4 (mod 12)`, and indeed `10⁴ ≡ 4`.
+example : (10 : ℕ) ^ 100 ≡ 10 ^ 4 [MOD 12] := by decide
+
+end EulerTotientOQ08OQ01

--- a/src/data/proofs/euler-totient-oq-08-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-08-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "euler-totient-oq-08-oq-01",
+  "title": "Non-Coprime Euler Periodicity for Composite Moduli: $a^{k+\\varphi(n)} \\equiv a^k \\pmod{n}$ via CRT",
+  "slug": "euler-totient-oq-08-oq-01",
+  "description": "Euler's theorem reduces the exponent of `a^k (mod n)` modulo `φ(n)` only when `gcd(a,n)=1`; Mathlib's `PowModTotient.lean` lists removing that coprimality as an explicit TODO. The parent entry `euler-totient-oq-08` handled the non-coprime case for prime-power moduli `p^e`. This entry assembles those prime-power periodicities into the statement for an ARBITRARY composite modulus `n` via the Chinese Remainder Theorem — directly answering open question #1 posed by the parent. Writing `n = ∏ p^{v_p(n)}`, once the exponent `k` exceeds every prime-power exponent `v_p(n)` (i.e. `k ≥ max_p v_p(n)`) each factor is already in its periodic régime, and since φ is multiplicative `φ(p^{v_p(n)}) ∣ φ(n)`, so the `φ(n)`-shift is a whole number of periods on every factor; CRT glues the factorwise congruences back modulo `n`. Four results, all valid for EVERY base a (not just units): `pow_add_totient_modEq` (single period a^(k+φ(n)) ≡ a^k [MOD n]); the multi-period `pow_add_mul_totient_modEq`; `pow_modEq`, the full exponent reduction a^k ≡ a^(K + (k−K) mod φ(n)) with a composite pre-period K bounding every v_p(n); and the factorisation-free sufficient condition `pow_add_totient_modEq_of_le` (n ≤ 2^k already forces k ≥ v_p(n) for all p). The CRT assembly is packaged as a reusable helper `modEq_prod_of_pairwiseCoprime`. Fully machine-checked: 0 sorries, 0 axioms (the `decide` examples are kernel reductions over concrete small naturals, not `native_decide`).",
+  "meta": {
+    "author": "Euler (1763); non-coprime composite-modulus extension formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_theorem",
+    "date": "1763",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ08OQ01.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "modular-arithmetic",
+      "modular-exponentiation",
+      "chinese-remainder-theorem",
+      "prime-factorization",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 205,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Each prime-power factor reuses the parent entry's `EulerTotientOQ08.pow_add_mul_totient_modEq_primePow` (itself 0-axiom); the composite assembly is the Chinese Remainder Theorem in its `Nat.ModEq` guise via `Nat.modEq_and_modEq_iff_modEq_mul` over the pairwise-coprime prime powers, with `φ(p^e) ∣ φ(n)` supplied by `Nat.totient_dvd_of_dvd`. The `decide` calls in the examples evaluate concrete powers and modular reductions over small naturals in the kernel (not `native_decide`), so the only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.modEq_and_modEq_iff_modEq_mul",
+        "description": "`m.Coprime n → (a ≡ b [MOD m] ∧ a ≡ b [MOD n] ↔ a ≡ b [MOD m*n])`. The Chinese Remainder Theorem step: it drives the Finset induction in `modEq_prod_of_pairwiseCoprime` gluing factorwise congruences into one modulo the product.",
+        "module": "Mathlib.Data.Nat.ModEq"
+      },
+      {
+        "theorem": "Nat.totient_dvd_of_dvd",
+        "description": "`a ∣ b → φ a ∣ φ b`. Applied to `p^{v_p(n)} ∣ n` (from `Nat.ordProj_dvd`), it yields `φ(p^{v_p(n)}) ∣ φ(n)`, so the `φ(n)`-shift is an integer multiple of each factor's period.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.factorization_prod_pow_eq_self",
+        "description": "`n ≠ 0 → n.factorization.prod (· ^ ·) = n`, i.e. `n = ∏_{p ∈ primeFactors} p^{v_p(n)}`. Rewrites the modulus as the pairwise-coprime prime-power product on which CRT is applied.",
+        "module": "Mathlib.Data.Nat.Factorization.Defs"
+      },
+      {
+        "theorem": "Nat.Coprime.pow / Nat.coprime_primes",
+        "description": "Distinct primes are coprime, and coprimality is preserved by taking powers; together they establish the pairwise coprimality of the prime-power factors required by the CRT assembly.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.factorization_le_of_le_pow",
+        "description": "`n ≤ p^b → n.factorization p ≤ b`. Underlies the factorisation-free corollary: `n ≤ 2^k ≤ p^k` gives `v_p(n) ≤ k` for every prime `p ≥ 2`.",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      }
+    ],
+    "originalContributions": [
+      "`pow_add_totient_modEq`: the headline non-coprime composite periodicity `a^(k + φ(n)) ≡ a^k [MOD n]` for any base `a` and any modulus `n ≠ 0`, under the sharp pre-period hypothesis `n.factorization p ≤ k` for all `p` (equivalently `k ≥ max_p v_p(n)`). This is the composite-modulus completion of Mathlib's coprime-only `Nat.pow_add_totient_mod_eq`, and directly answers open question #1 of the parent entry `euler-totient-oq-08`.",
+      "`modEq_prod_of_pairwiseCoprime`: a reusable Chinese Remainder Theorem assembly lemma — a congruence holding modulo each member of a pairwise-coprime `Finset` family holds modulo their product — proved by `Finset.induction` on `Nat.modEq_and_modEq_iff_modEq_mul`. The main theorem instantiates it on the prime-power factorization of `n`.",
+      "`pow_add_mul_totient_modEq`: the multi-period form, adding any multiple `l · φ(n)` of the period, by induction on `l`; the composite counterpart of `Nat.pow_add_mul_totient_mod_eq`.",
+      "`pow_modEq`: the full exponent reduction `a^k ≡ a^(K + (k − K) mod φ(n)) [MOD n]` for any `K` bounding every `v_p(n)` and any `k ≥ K` — the non-coprime, composite analogue of `Nat.pow_totient_mod`. The `K`-length pre-period is the composite generalization of the prime-power pre-period `e`: non-invertible bases stabilize only from exponent `K` onward, then run periodically with period `φ(n)`.",
+      "`pow_add_totient_modEq_of_le`: a factorisation-free sufficient condition — `n ≤ 2^k` already forces `k ≥ v_p(n)` for every prime `p` (since `v_p(n) ≤ log_2 n`), removing `factorization` from the hypothesis entirely and making the theorem trivially applicable to concrete data.",
+      "Worked examples on genuinely non-coprime composite data (`2^k mod 12`, `10^k mod 12`) where Euler's coprime theorem says nothing, including the sharp pre-period `k = 2` for `n = 12 = 2^2·3` (proved via `p^3 ∤ 12`) versus the coarser `n ≤ 2^k` bound requiring `k ≥ 4`, and `decide`-checked numerics `2^8 ≡ 2^4`, `2^6 ≡ 2^2`, `10^100 ≡ 10^4 (mod 12)`."
+    ],
+    "significance": "Completes the non-coprime Euler exponent-reduction theory from prime-power to arbitrary composite moduli, answering the parent entry's first open question and closing the composite half of Mathlib's standing `PowModTotient` TODO ('extend to results in cases where the base is not coprime to the modulus'). Five theorems, 205 lines, 0 sorries, 0 axioms.",
+    "implications": "The full-reduction form is the computational payoff for arbitrary moduli: it collapses astronomically large exponents of ANY base modulo ANY `n` — including last-digits-of-a-power computations where the base shares factors with the modulus (e.g. even bases mod 10^k, decimal-digit problems) — which the coprime-only `Nat.pow_totient_mod` cannot handle. The reusable `modEq_prod_of_pairwiseCoprime` CRT helper is applicable to any factorwise-verified congruence.",
+    "openQuestions": [
+      "Replace `φ(n)` by the Carmichael function `λ(n) = lcm_p λ(p^{v_p(n)})` for the tightest possible period, giving the minimal eventual period of modular exponentiation with a shorter pre-period than the `φ(n)`-based one.",
+      "Sharpen the composite pre-period `K = max_p v_p(n)` to the base-dependent threshold `max_p ⌈v_p(n) / max(1, v_p(a))⌉`, the exact exponent from which `a^k` stabilizes modulo each `p^{v_p(n)}`.",
+      "Derive the eventual-periodicity statement for iterated exponentials (tetration towers `a ↑↑ m mod n`), where each level's pre-period feeds the next via this composite reduction."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring framing the goal — assemble the parent's prime-power non-coprime periodicity into an arbitrary composite modulus via CRT — with the main-results list, imports (Mathlib plus the parent module `Proofs.EulerTotientOQ08`), and the EulerTotientOQ08OQ01 namespace (φ = Nat.totient)."
+    },
+    {
+      "id": "crt-helper",
+      "title": "CRT Assembly Helper",
+      "startLine": 47,
+      "endLine": 73,
+      "summary": "modEq_prod_of_pairwiseCoprime: a congruence holding modulo each member of a pairwise-coprime Finset family holds modulo their product. Proved by Finset.induction — the empty product is modulus 1 (Nat.modEq_one), and the insert step glues via Nat.modEq_and_modEq_iff_modEq_mul using coprime_prod_right to peel one factor off the product."
+    },
+    {
+      "id": "single-period",
+      "title": "Composite-Modulus Single-Period Periodicity",
+      "startLine": 75,
+      "endLine": 117,
+      "summary": "pow_add_totient_modEq: the headline a^(k + φ(n)) ≡ a^k [MOD n] for any base under the pre-period hypothesis n.factorization p ≤ k for all p. Rewrites n as its prime-power product (factorization_prod_pow_eq_self), then per factor uses φ(p^e) ∣ φ(n) (totient_dvd_of_dvd on ordProj_dvd) to cast the φ(n)-shift as a multiple of φ(p^e) and applies the parent's multi-period prime-power lemma, gluing by the CRT helper."
+    },
+    {
+      "id": "multi-period",
+      "title": "The Multi-Period Form",
+      "startLine": 119,
+      "endLine": 136,
+      "summary": "pow_add_mul_totient_modEq: adding any multiple l · φ(n) to the exponent leaves a^k unchanged mod n, by induction on l chaining the single-period step."
+    },
+    {
+      "id": "full-reduction",
+      "title": "Full Exponent Reduction",
+      "startLine": 138,
+      "endLine": 156,
+      "summary": "pow_modEq: the non-coprime composite analogue of Nat.pow_totient_mod, a^k ≡ a^(K + (k−K) mod φ(n)) for any K bounding every v_p(n) and k ≥ K, splitting k−K by the division algorithm (Nat.mod_add_div') into remainder + quotient·period and applying the multi-period form; the reduced exponent still bounds each v_p(n)."
+    },
+    {
+      "id": "factorization-free",
+      "title": "Factorisation-Free Sufficient Condition",
+      "startLine": 158,
+      "endLine": 164,
+      "summary": "pow_add_totient_modEq_of_le: n ≤ 2^k already guarantees k ≥ v_p(n) for all primes p (since 2^k ≥ n ≥ p^{v_p(n)} forces v_p(n) ≤ k via factorization_le_of_le_pow and 2^k ≤ p^k), removing factorization from the hypothesis."
+    },
+    {
+      "id": "worked-examples",
+      "title": "Worked Examples (non-coprime bases, composite moduli)",
+      "startLine": 165,
+      "endLine": 205,
+      "summary": "Genuinely non-coprime composite data outside Euler's coprime theorem: 2^k mod 12 via the n ≤ 2^k bound (period from k = 4), the sharp pre-period k = 2 for 12 = 2^2·3 proved by ruling out p^3 ∣ 12, and full reduction 10^100 ≡ 10^4 (mod 12), with decide checks 2^8 ≡ 2^4, 2^6 ≡ 2^2, 10^100 ≡ 10^4."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-08",
+      "relationship": "parent",
+      "description": "The parent proves the non-coprime Euler periodicity for prime-power moduli p^e and explicitly poses (open question #1) the composite-modulus assembly by CRT. This entry carries out exactly that assembly, invoking the parent's `pow_add_mul_totient_modEq_primePow` on each prime-power factor of n."
+    },
+    {
+      "targetId": "euler-totient-oq-05",
+      "relationship": "sibling",
+      "description": "oq-05 proves Euler's theorem a^φ(n) ≡ 1 (mod n) for coprime a (a unit). This entry drops coprimality entirely and recovers the eventual periodicity that survives, for arbitrary composite n, even when gcd(a,n) > 1."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "The base gallery family develops Euler's totient and the multiplicativity φ(mn) = φ(m)φ(n) for coprime m,n — the divisibility φ(p^e) ∣ φ(n) used here is a direct consequence — and Euler's generalization of Fermat's little theorem, of which this is the non-coprime, composite-modulus completion."
+    }
+  ],
+  "references": [
+    {
+      "authors": "L. Euler",
+      "title": "Theoremata arithmetica nova methodo demonstrata",
+      "year": 1763,
+      "venue": "Novi Comment. Acad. Sci. Petrop. 8",
+      "note": "Introduces the totient function and proves a^φ(n) ≡ 1 (mod n) for coprime a."
+    },
+    {
+      "authors": "T. M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer",
+      "note": "Chinese Remainder Theorem, multiplicative arithmetic functions, and the structure of (Z/nZ)*."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Nat.totient, Nat.factorization, Nat.ModEq, and the CRT lemma Nat.modEq_and_modEq_iff_modEq_mul underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extends the non-coprime Euler exponent-reduction theory from **prime-power moduli** (parent entry `euler-totient-oq-08`) to an **arbitrary composite modulus** `n`, via the Chinese Remainder Theorem. This directly answers **open question #1** posed by the parent and closes the composite half of Mathlib's standing `PowModTotient.lean` TODO: *"Extend to results in cases where the base is not coprime to the modulus."*

**Main statement** — for every base `a` (not just units), modulus `n ≠ 0`, and exponent `k ≥ maxₚ vₚ(n)`:
```
a ^ (k + φ(n)) ≡ a ^ k   [MOD n]
```

## Approach

Write `n = ∏ p^{vₚ(n)}`. Once `k` exceeds every prime-power exponent, each factor is already in its periodic régime; since φ is multiplicative, `φ(p^{vₚ(n)}) ∣ φ(n)`, so the `φ(n)`-shift is a whole number of periods on every factor. CRT (`Nat.modEq_and_modEq_iff_modEq_mul`, applied over `n.primeFactors`) glues the factorwise congruences back modulo `n`. Each factor reuses the parent's `pow_add_mul_totient_modEq_primePow`.

## Results (5 theorems, 0 sorry / 0 axiom)

| Theorem | Statement |
|---|---|
| `modEq_prod_of_pairwiseCoprime` | reusable CRT assembly over a pairwise-coprime `Finset` of moduli |
| `pow_add_totient_modEq` | headline `a^(k+φ(n)) ≡ a^k [MOD n]` |
| `pow_add_mul_totient_modEq` | multi-period form (any multiple `l·φ(n)`) |
| `pow_modEq` | full reduction `a^k ≡ a^(K + (k−K) mod φ(n))` |
| `pow_add_totient_modEq_of_le` | factorisation-free bound: `n ≤ 2^k` suffices |

Worked examples on genuinely non-coprime composite data (`2^k mod 12`, `10^k mod 12`), including the sharp pre-period `k = 2` for `12 = 2²·3` (vs. the coarser `n ≤ 2^k` bound needing `k ≥ 4`) and `decide`-checked numerics `2^8 ≡ 2^4`, `2^6 ≡ 2^2`, `10^100 ≡ 10^4 (mod 12)`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ08OQ01` — **builds clean**
- 0 `sorry`, 0 `axiom` declarations, no `native_decide` (the `decide` examples are kernel reductions over small concrete naturals — only the foundational `propext`/`Classical.choice`/`Quot.sound`).
- Gallery entry: `src/data/proofs/euler-totient-oq-08-oq-01/meta.json` (`status: verified`, `badge: original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)