### PR TITLE
research(hurwitz-oq-03-oq-01-wip-01): metric-level Frobenius cap — rank-nullity + quaternion-triple obstruction [VERIFIED]

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ02OQ01.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ02OQ01.lean
@@ -1,0 +1,152 @@
+/-
+# Derangements: the nearest-integer characterization of the subfactorial
+
+Open Question: derangements-convergence-oq-02-oq-01
+
+The grandparent file `DerangementsConvergence.lean` proves the *magnitude* of the
+approximation error
+  |D(n)/n! - e⁻¹| ≤ 1/(n+1)!,
+and the parent `DerangementsConvergenceOQ02.lean` pins down its *sign*.
+
+This file draws the classical arithmetic consequence: the derangement number is
+literally the **nearest integer** to `n!/e`.  Scaling the ratio bound by `n!`,
+  |D(n) - n!·e⁻¹| ≤ n!/(n+1)! = 1/(n+1) ≤ 1/2   for n ≥ 1,
+and the inequality is *strict* (`< 1/2`) once the single boundary value `n = 1`
+is handled by the elementary bound `e⁻¹ < 1/2`.  A real number lying within
+`1/2` of an integer rounds to that integer, so
+
+  D(n) = round(n!/e)      for every n ≥ 1.
+
+## Main Results
+
+- `round_eq_of_abs_sub_lt_half` : reusable rounding criterion `|x - m| < ½ → round x = m`
+- `exp_neg_one_lt_half` : the boundary estimate `e⁻¹ < 1/2`
+- `abs_numDerangements_sub_lt_half` : `|D(n) - n!·e⁻¹| < 1/2` for `n ≥ 1` (strict)
+- `numDerangements_eq_round` : **D(n) = round(n!/e)** for `n ≥ 1`
+- `numDerangements_eq_floor` : the equivalent floor form `D(n) = ⌊n!·e⁻¹ + 1/2⌋`
+- `round_factorial_exp_zero` / `numDerangements_round_ne_at_zero` : the identity
+  genuinely fails at `n = 0` (`round(0!·e⁻¹) = 0 ≠ 1 = D(0)`), so the hypothesis
+  `n ≥ 1` is **sharp**.
+
+All results are fully machine-checked: no `sorry`, no `axiom` declarations, and
+no structure-encoded assumptions (only Lean/Mathlib's foundational
+`propext` / `Classical.choice` / `Quot.sound`).
+
+## References
+
+- Montmort (1708), Euler (1751) — derangement numbers
+- The rounding identity `!n = round(n!/e)` is standard folklore for `n ≥ 1`.
+-/
+
+import Proofs.DerangementsConvergence
+import Mathlib.Tactic
+
+open Nat Real Filter Topology
+
+noncomputable section
+
+namespace DerangementsConvergenceOQ02OQ01
+
+/- ## §1. A reusable rounding criterion -/
+
+/-- If a real number `x` is within `1/2` of an integer `m`, then `round x = m`.
+This is the elementary bridge from an analytic distance bound to an exact
+integer identity. -/
+lemma round_eq_of_abs_sub_lt_half {x : ℝ} {m : ℤ} (h : |x - (m : ℝ)| < 1 / 2) :
+    round x = m := by
+  rw [round_eq, Int.floor_eq_iff]
+  rw [abs_sub_lt_iff] at h
+  refine ⟨by linarith [h.1, h.2], by linarith [h.1, h.2]⟩
+
+/- ## §2. `e⁻¹ < 1/2` (the single boundary estimate) -/
+
+/-- The reciprocal of `e` is strictly below `1/2`, because `e > 2`. -/
+lemma exp_neg_one_lt_half : rexp (-1) < 1 / 2 := by
+  have h2 : (2 : ℝ) < rexp 1 := by
+    have := Real.add_one_lt_exp (x := 1) (by norm_num)
+    linarith
+  rw [Real.exp_neg, inv_eq_one_div]
+  exact one_div_lt_one_div_of_lt (by norm_num) h2
+
+/- ## §3. The strict distance bound `|D(n) - n!·e⁻¹| < 1/2` -/
+
+/-- The subfactorial `D(n)` lies strictly within `1/2` of `n!/e`, for every
+`n ≥ 1`.  This is the heart of the nearest-integer characterization. -/
+theorem abs_numDerangements_sub_lt_half (n : ℕ) (hn : 1 ≤ n) :
+    |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| < 1 / 2 := by
+  have hpos := factorial_cast_pos' n
+  have hne := factorial_cast_ne_zero' n
+  -- `D(n) - n!·e⁻¹ = n! · (D(n)/n! - e⁻¹)`.
+  have hstep : (n.factorial : ℝ)
+        * ((numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1))
+      = (numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1) := by
+    rw [mul_sub, ← mul_div_assoc, mul_div_cancel_left₀ (numDerangements n : ℝ) hne]
+  rw [← hstep, abs_mul, abs_of_pos hpos]
+  rcases eq_or_lt_of_le hn with h1 | h2
+  · -- Boundary case `n = 1`: `D(1) = 0`, so the distance is exactly `e⁻¹ < 1/2`.
+    rw [← h1]
+    have hd : numDerangements 1 = 0 := rfl
+    rw [hd]
+    simp only [Nat.cast_zero, Nat.factorial_one, Nat.cast_one, zero_div, zero_sub,
+      abs_neg, abs_of_pos (Real.exp_pos (-1)), one_mul]
+    exact exp_neg_one_lt_half
+  · -- Interior case `n ≥ 2`: the ratio bound gives `1/(n+1) ≤ 1/3 < 1/2`.
+    have hrate := derangements_convergence_rate n
+    have hbound : (n.factorial : ℝ)
+        * |(numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)|
+        ≤ (n.factorial : ℝ) * (1 / ((n + 1).factorial : ℝ)) :=
+      mul_le_mul_of_nonneg_left hrate hpos.le
+    have hval : (n.factorial : ℝ) * (1 / ((n + 1).factorial : ℝ))
+        = 1 / ((n : ℝ) + 1) := by
+      rw [Nat.factorial_succ]
+      push_cast
+      rw [mul_one_div, mul_comm ((n : ℝ) + 1) (n.factorial : ℝ), ← div_div,
+        div_self hne]
+    rw [hval] at hbound
+    have hle3 : (1 : ℝ) / ((n : ℝ) + 1) ≤ 1 / 3 := by
+      apply one_div_le_one_div_of_le (by norm_num)
+      have h2' : 2 ≤ n := h2
+      have hcast : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast h2'
+      linarith
+    linarith
+
+/- ## §4. Main theorem: `D(n) = round(n!/e)` -/
+
+/-- **Nearest-integer characterization of the subfactorial.**
+For every `n ≥ 1`, the number of derangements of `n` objects is exactly the
+nearest integer to `n!/e`. -/
+theorem numDerangements_eq_round (n : ℕ) (hn : 1 ≤ n) :
+    round ((n.factorial : ℝ) * rexp (-1)) = (numDerangements n : ℤ) := by
+  apply round_eq_of_abs_sub_lt_half
+  rw [abs_sub_comm,
+    show ((numDerangements n : ℤ) : ℝ) = (numDerangements n : ℝ) by push_cast; ring]
+  exact abs_numDerangements_sub_lt_half n hn
+
+/-- The equivalent floor form: `D(n) = ⌊n!·e⁻¹ + 1/2⌋` for `n ≥ 1`. -/
+theorem numDerangements_eq_floor (n : ℕ) (hn : 1 ≤ n) :
+    ⌊(n.factorial : ℝ) * rexp (-1) + 1 / 2⌋ = (numDerangements n : ℤ) := by
+  have h := numDerangements_eq_round n hn
+  rwa [round_eq] at h
+
+/- ## §5. Sharpness of the hypothesis `n ≥ 1` -/
+
+/-- At `n = 0` the rounded value is `0`: the nearest integer to `0!/e = e⁻¹`
+(≈ 0.3679) is `0`. -/
+theorem round_factorial_exp_zero :
+    round (((0 : ℕ).factorial : ℝ) * rexp (-1)) = 0 := by
+  apply round_eq_of_abs_sub_lt_half
+  simp only [Nat.factorial_zero, Nat.cast_one, one_mul, Int.cast_zero, sub_zero,
+    abs_of_pos (Real.exp_pos (-1))]
+  exact exp_neg_one_lt_half
+
+/-- **Sharpness.** The identity `D(n) = round(n!/e)` genuinely fails at `n = 0`:
+there `round(0!·e⁻¹) = 0` while `D(0) = 1`.  Hence the hypothesis `n ≥ 1` in
+`numDerangements_eq_round` cannot be dropped. -/
+theorem numDerangements_round_ne_at_zero :
+    round (((0 : ℕ).factorial : ℝ) * rexp (-1)) ≠ (numDerangements 0 : ℤ) := by
+  rw [round_factorial_exp_zero]
+  have hd : numDerangements 0 = 1 := rfl
+  rw [hd]
+  norm_num
+
+end DerangementsConvergenceOQ02OQ01

--- a/proofs/Proofs/HurwitzOnlyIf.lean
+++ b/proofs/Proofs/HurwitzOnlyIf.lean
@@ -811,6 +811,96 @@ theorem eq_zero_of_anticomm_pair_and_product (A : Type*) [NormedDivisionRing A]
   have hxy : x * y ≠ 0 := mul_ne_zero hx hy
   exact (mul_eq_zero.mp hz).resolve_left hxy
 
+/-! ### The metric-level Frobenius cap: `finrank ℝ (Im A)` bookkeeping
+
+The three algebraic obstructions above (`isImaginary_mul_of_anticomm`, `mul_anticomm_*`,
+`eq_zero_of_anticomm_pair_and_product`) and the metric bridge
+(`imaginaryBilin_eq_zero_iff_anticomm`) are here recast purely in terms of the
+positive-definite form `B = imaginaryBilin A` on `Im A = imaginarySubmodule A`.  This is the
+inner-product-space packaging on which the final `finrank ℝ (Im A) ∈ {0, 1, 3}` count runs:
+
+* `finrank_eq_imaginary_add_one` reduces the whole theorem to a statement about `Im A`:
+  `finrank ℝ A = finrank ℝ (Im A) + 1` (rank–nullity for the surjective `realPart : A →ₗ ℝ`).
+* `imaginary_mul_mem_imaginarySubmodule` + `imaginaryBilin_mul_orthogonal` manufacture the
+  *third* imaginary unit: for `B`-orthogonal imaginary `x, y`, the product `x*y` is again
+  imaginary and `B`-orthogonal to both `x` and `y` (a fresh quaternion generator).
+* `eq_zero_of_orthogonal_to_triple` is the *no fourth unit* obstruction: any `w ∈ Im A`
+  that is `B`-orthogonal to `x`, `y`, and `x*y` must vanish, capping `finrank ℝ (Im A) ≤ 3`.
+
+Together with positive-definiteness (which forbids `finrank ℝ (Im A) = 2`, since the third
+unit `x*y` would be a nonzero vector orthogonal to a full basis) these pin
+`finrank ℝ (Im A) ∈ {0, 1, 3}`, i.e. `finrank ℝ A ∈ {1, 2, 4}`. -/
+
+/-- **Rank–nullity reduction.** `realPart : A →ₗ[ℝ] ℝ` is surjective (it sends `c•1 ↦ c`),
+and `Im A = ker realPart`, so rank–nullity gives `finrank ℝ A = finrank ℝ (Im A) + 1`.
+This reduces the Hurwitz dimension count entirely to `finrank ℝ (Im A) ∈ {0, 1, 3}`. -/
+theorem finrank_eq_imaginary_add_one (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] :
+    Module.finrank ℝ A = Module.finrank ℝ (imaginarySubmodule A) + 1 := by
+  have hsurj : Function.Surjective (realPart A) := by
+    intro c
+    exact ⟨c • (1 : A), by rw [realPart_apply]; exact realPartValue_smul_one A c⟩
+  have hrange : Module.finrank ℝ (LinearMap.range (realPart A)) = 1 := by
+    rw [LinearMap.range_eq_top.mpr hsurj, finrank_top, Module.finrank_self]
+  have hrn := LinearMap.finrank_range_add_finrank_ker (realPart A)
+  rw [hrange] at hrn
+  -- `imaginarySubmodule A` is definitionally `LinearMap.ker (realPart A)`; matching the
+  -- goal's atom to `hrn`'s atom syntactically lets `omega` finish without reducing inside
+  -- the (noncomputable) kernel term.
+  show Module.finrank ℝ A = Module.finrank ℝ (LinearMap.ker (realPart A)) + 1
+  omega
+
+/-- **The third imaginary unit is imaginary.** For `B`-orthogonal imaginary `x, y`
+(`imaginaryBilin A x y = 0`, equivalently `x*y + y*x = 0`), the product `x*y` lies in
+`Im A`: it is again an imaginary element (`isImaginary_mul_of_anticomm`). -/
+theorem imaginary_mul_mem_imaginarySubmodule (A : Type*) [NormedDivisionRing A]
+    [NormedAlgebra ℝ A] [Module.Finite ℝ A] (x y : imaginarySubmodule A)
+    (hxy : imaginaryBilin A x y = 0) : (x : A) * (y : A) ∈ imaginarySubmodule A := by
+  have hac : (x : A) * (y : A) + (y : A) * (x : A) = 0 :=
+    (imaginaryBilin_eq_zero_iff_anticomm A x y).mp hxy
+  rw [mem_imaginarySubmodule_iff]
+  exact isImaginary_mul_of_anticomm A ((mem_imaginarySubmodule_iff A (x : A)).mp x.2)
+    ((mem_imaginarySubmodule_iff A (y : A)).mp y.2) hac
+
+/-- **The third imaginary unit is orthogonal to both factors.** For `B`-orthogonal imaginary
+`x, y` and any `z ∈ Im A` with `z = x*y`, the fresh unit `z` is `B`-orthogonal to `x` and to
+`y`.  Metric-level restatement of `mul_anticomm_left` / `mul_anticomm_right`: anticommutation
+of the factors propagates to their product, so `B(z, x) = B(z, y) = 0`.  This is the step
+that grows an orthonormal pair `⟨x, y⟩` into an orthonormal quaternion triple `⟨x, y, x*y⟩`. -/
+theorem imaginaryBilin_mul_orthogonal (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (x y z : imaginarySubmodule A) (hxy : imaginaryBilin A x y = 0)
+    (hz : (z : A) = (x : A) * (y : A)) :
+    imaginaryBilin A z x = 0 ∧ imaginaryBilin A z y = 0 := by
+  have hac : (x : A) * (y : A) + (y : A) * (x : A) = 0 :=
+    (imaginaryBilin_eq_zero_iff_anticomm A x y).mp hxy
+  refine ⟨?_, ?_⟩
+  · rw [imaginaryBilin_eq_zero_iff_anticomm A z x, hz, add_comm]
+    exact mul_anticomm_left A hac
+  · rw [imaginaryBilin_eq_zero_iff_anticomm A z y, hz, add_comm]
+    exact mul_anticomm_right A hac
+
+/-- **No fourth orthogonal imaginary unit — the `finrank ℝ (Im A) ≤ 3` obstruction.**
+Let `x, y` be nonzero imaginary elements and `z = x*y` their product (the third quaternion
+generator).  Any `w ∈ Im A` that is `B`-orthogonal to all three of `x`, `y`, `z` must be
+zero.  Metric-level restatement of `eq_zero_of_anticomm_pair_and_product`: `w` orthogonal to
+`x` and `y` means `w` anticommutes with both, hence *commutes* with `z = x*y`; being also
+orthogonal to `z` forces `w` to anticommute with `z`, so `z*w = -z*w`, giving `w = 0` (no
+zero divisors, characteristic `≠ 2`).  Thus `Im A` carries at most three mutually orthogonal
+directions. -/
+theorem eq_zero_of_orthogonal_to_triple (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (x y w z : imaginarySubmodule A) (hx : (x : A) ≠ 0) (hy : (y : A) ≠ 0)
+    (hz : (z : A) = (x : A) * (y : A)) (hwx : imaginaryBilin A w x = 0)
+    (hwy : imaginaryBilin A w y = 0) (hwz : imaginaryBilin A w z = 0) : w = 0 := by
+  have hax : (w : A) * (x : A) + (x : A) * (w : A) = 0 :=
+    (imaginaryBilin_eq_zero_iff_anticomm A w x).mp hwx
+  have hay : (w : A) * (y : A) + (y : A) * (w : A) = 0 :=
+    (imaginaryBilin_eq_zero_iff_anticomm A w y).mp hwy
+  have hazr : (w : A) * (z : A) + (z : A) * (w : A) = 0 :=
+    (imaginaryBilin_eq_zero_iff_anticomm A w z).mp hwz
+  rw [hz] at hazr
+  have hw0 : (w : A) = 0 := eq_zero_of_anticomm_pair_and_product A hx hy hax hay hazr
+  exact Submodule.coe_eq_zero.mp hw0
+
 /-! ### The General (Division Ring) Case -/
 
 /-- **Frobenius Step 3, commutative subcase — fully verified.** If a normed division ring

--- a/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
@@ -3,49 +3,60 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-04
-**Iteration**: 5
+**Since**: 2026-07-05
+**Iteration**: 8
 
 ## Current Focus
-Iter 5 (Docker blackout — `docker run` EIO, no kernel-check possible): **gallery-sync
-increment**. The gallery `meta.json` for `hurwitz-theorem-oq-03-oq-01` was stale by two
-merged/verified commits (#34762 `hurwitz_only_if_ring_comm`, #34770
-`anticommutator_real_affine`) — it still reported 231 lines / 7 theorems and omitted both
-new theorems from `originalContributions`, `assumptions`, and `sections`. Synced counts
-(281 lines / 9 theorems), added the `frobenius-step3-prep` section, and documented both
-verified additions. No new Lean written (blackout precludes verification of hard Step-3
-math). The one remaining sorry is unchanged: the strictly non-commutative global-structure
-argument.
+Iter 8 (build-VERIFIED, docker 2715 jobs, 0 sorry/0 axiom added): **the metric-level
+Frobenius cap package** — recast all remaining algebraic obstructions in terms of the
+positive-definite form `B = imaginaryBilin A` on `Im A`, plus the rank–nullity reduction.
+Four new verified lemmas:
+
+1. `finrank_eq_imaginary_add_one`: `finrank ℝ A = finrank ℝ (Im A) + 1`. `realPart : A →ₗ[ℝ] ℝ`
+   is surjective (`c•1 ↦ c` via `realPartValue_smul_one`) and `Im A = ker realPart`, so
+   rank–nullity (`LinearMap.finrank_range_add_finrank_ker` + `finrank_top`/`Module.finrank_self`)
+   gives the reduction. **This collapses the whole theorem to `finrank ℝ (Im A) ∈ {0,1,3}`.**
+2. `imaginary_mul_mem_imaginarySubmodule`: for B-orthogonal imaginary x,y, `x*y ∈ Im A`
+   (metric wrapper over `isImaginary_mul_of_anticomm` via the bridge).
+3. `imaginaryBilin_mul_orthogonal`: the third unit `z = x*y` is B-orthogonal to both x and y
+   (metric wrapper over `mul_anticomm_left`/`mul_anticomm_right`). Grows an orthonormal pair
+   into an orthonormal quaternion triple ⟨x, y, x*y⟩.
+4. `eq_zero_of_orthogonal_to_triple`: **no fourth orthogonal unit** — any `w ∈ Im A`
+   B-orthogonal to x, y, and x*y is zero (metric wrapper over
+   `eq_zero_of_anticomm_pair_and_product`). Caps `finrank ℝ (Im A) ≤ 3`.
+
+The whole file still has exactly ONE sorry (`hurwitz_only_if_ring` non-commutative branch),
+now scoped PURELY to the linear-algebra assembly: pick a B-orthonormal basis of `Im A`, use
+(2)+(3) to manufacture the third generator and (4) + positive-definiteness to rule out
+`finrank = 2` and `finrank ≥ 4`, concluding `finrank ℝ (Im A) ∈ {0,1,3}`; combine with (1).
 
 ## Active Approach
-Whittling the Clifford structure down from provable pieces:
-- commutative → hurwitz_only_if_ring_comm (0 sorry): Gelfand-Mazur. VERIFIED (iter 3).
-- `anticommutator_real_affine` (0 sorry, NEW iter 4): polarise the Step-1 quadratics of
-  x, y, x+y ⟹ x*y + y*x = c₁•x + c₂•y + c₃•1. The first algebraic constraint toward the
-  Clifford relations. VERIFIED.
-- non-commutative → remaining sorry (Clifford / Radon-Hurwitz, blocked on Mathlib).
+All ALGEBRAIC and METRIC prerequisites are now in place (0 sorry). What remains is a pure
+finite-dimensional inner-product-space counting argument with NO further division-ring
+input:
+- Reduction to Im A: DONE (`finrank_eq_imaginary_add_one`).
+- Positive-definite inner product on Im A: DONE (`imaginaryBilin*`, iter 6).
+- Metric↔algebra bridge: DONE (`imaginaryBilin_eq_zero_iff_anticomm`, iter 7).
+- Third-unit manufacture + no-fourth-unit obstruction: DONE (iter 8, this commit).
 
 ## Attempt Count
-- Total attempts: 2 (code, shipped)
-- Approaches tried: 2
+- Total attempts: 4 (code, shipped)
+- Approaches tried: 3
 
 ## Blockers
-- Non-commutative case genuinely open: needs Clifford-algebra / positive-definite
-  anticommutator bilinear-form machinery not yet in Mathlib.
-- The keystone anticommutator lemma (xy+yx ∈ ℝ·1 for *imaginary* x,y) still needs the
-  trace-additivity / Im A subspace-closure that drops the x,y coefficients in
-  `anticommutator_real_affine` to 0. That closure is the remaining hard step.
+- The last sorry needs: an orthonormal basis of the positive-definite space `(Im A, B)` and
+  the standard "orthogonal complement is trivial ⟹ full" reasoning to convert lemmas (2)–(4)
+  into the numerical bound `finrank ℝ (Im A) ∈ {0,1,3}`. This is now pure Mathlib linear
+  algebra (needs an `InnerProductSpace`/`BilinForm.Nondegenerate` packaging of `imaginaryBilin`,
+  or a hand-rolled Gram–Schmidt), no more algebra of `A`.
 
 ## Next Action
-(Requires working Docker to kernel-check — do not attempt new hard Lean under blackout.)
-Prove trace-additivity: define the real-part functional `re : A → ℝ` (from Step-1's `p/2`)
-and show it is ℝ-linear, so imaginary x, y ⟹ x+y imaginary ⟹ c₁ = c₂ = 0 in
-`anticommutator_real_affine`, yielding `x*y + y*x ∈ ℝ•1`. Then Im A is a subspace and the
-bilinear form `-(xy+yx)` is defined. Aristotle unusable (OPEN, not tactical).
-
-CAUTION on `re` well-definedness: the shift constant `c(a)=p/2` from
-`exists_real_shift_sq_scalar` is NOT unique for scalars a=s•1 (every c gives a real
-square), so the real-part functional cannot be read off the ad-hoc quadratic. The clean
-route is via `minpoly ℝ a` (degree ≤2, genuinely unique): for a ∉ ℝ•1, minpoly = X²−t·X+n
-and `re a := t/2`; for a ∈ ℝ•1, `re a := s`. Uniqueness of the ℝ-or-ℂ subalgebra structure
-then gives ℝ-linearity. Build this on Mathlib's `minpoly` API rather than `exists_quadratic`.
+Convert `imaginaryBilin` into an inner product (via `InnerProductSpace.ofCore` or a
+`LinearMap.BilinForm` that is positive-definite hence nondegenerate) so that:
+- `finrank ≠ 2`: with orthonormal e₁,e₂ spanning Im A, `e₁*e₂` (lemma 2) is nonzero and
+  B-orthogonal to the full basis (lemma 3) ⇒ B(e₁*e₂, e₁*e₂)=0 ⇒ e₁*e₂=0, contradiction.
+- `finrank ≤ 3`: a fourth vector orthogonal to e₁,e₂,e₁*e₂ vanishes (lemma 4).
+Then `finrank ℝ (Im A) ∈ {0,1,3}` and `finrank_eq_imaginary_add_one` closes the sorry.
+Consider submitting the fully-scaffolded `hurwitz_only_if_ring` to Aristotle with all four
+new lemmas as context, hint = "finish Frobenius: finrank ℝ (Im A) ∈ {0,1,3} via the
+positive-definite form imaginaryBilin".

--- a/src/data/proofs/derangements-convergence-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-02-oq-01/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "ann-dcoq0201-header",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "Module Overview: The Sharp Nearest-Integer Threshold",
+    "content": "This module determines the exact domain on which the folklore identity D(n) = round(n!/e) holds. The sibling entry derangements-convergence-oq-03 proves it for n ≥ 2, where the rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! scales to |D(n) − n!/e| ≤ 1/(n+1) ≤ 1/3, comfortably under the ½ threshold that rounding needs. Two things remain: the boundary index n = 1 (where the same bound gives only the non-strict ≤ 1/2) and the failure at n = 0. This module supplies the extra analytic input e⁻¹ < 1/2 to settle n = 1, then proves the identity is genuinely false at n = 0, establishing n ≥ 1 as the optimal threshold. Imports pull in the grandparent DerangementsConvergence (for the rate bound) and all of Mathlib.Tactic.",
+    "mathContext": "D(n)/n! = ∑_{k=0}^n (−1)^k/k! → e⁻¹; the rounding identity D(n) = round(n!/e) is standard for n ≥ 1 but false at n = 0 since D(0) = 1 while round(e⁻¹) = 0."
+  },
+  {
+    "id": "ann-dcoq0201-round-criterion",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 50, "endLine": 59 },
+    "type": "technique",
+    "title": "§1 A Reusable Rounding Criterion",
+    "content": "round_eq_of_abs_sub_lt_half proves the elementary bridge from analysis to arithmetic: if |x − m| < 1/2 for an integer m then round x = m. The proof rewrites round x = ⌊x + 1/2⌋ (round_eq) and applies Int.floor_eq_iff to reduce ⌊x + 1/2⌋ = m to the pair ↑m ≤ x + 1/2 and x + 1/2 < ↑m + 1; abs_sub_lt_iff unpacks the hypothesis into x − m < 1/2 and m − x < 1/2, and linarith closes both inequalities. Isolating this lemma lets it serve both the positive identity (m = D(n)) and the negative sharpness fact (m = 0).",
+    "mathContext": "round x = m ⟺ m − 1/2 ≤ x < m + 1/2; a strict distance < 1/2 to an integer determines the rounded value uniquely."
+  },
+  {
+    "id": "ann-dcoq0201-exp-half",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 61, "endLine": 68 },
+    "type": "technique",
+    "title": "§2 The Boundary Estimate e⁻¹ < 1/2",
+    "content": "exp_neg_one_lt_half proves the single analytic fact that separates the n = 1 boundary case from failure. From Real.add_one_lt_exp at x = 1 one gets 1 + 1 < e, i.e. 2 < e; rewriting rexp(−1) = (rexp 1)⁻¹ = 1/rexp 1 and applying one_div_lt_one_div_of_lt to 2 < e yields 1/e < 1/2. This is exactly the strictness the rate bound cannot provide at n = 1.",
+    "mathContext": "e ≈ 2.718 > 2, so e⁻¹ ≈ 0.3679 < 0.5. This is why D(1) = 0 is within ½ of 1!·e⁻¹ = e⁻¹."
+  },
+  {
+    "id": "ann-dcoq0201-distance",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 71, "endLine": 111 },
+    "type": "key-step",
+    "title": "§3 The Strict Distance Bound |D(n) − n!·e⁻¹| < 1/2",
+    "content": "abs_numDerangements_sub_lt_half is the heart of the entry. It factors D(n) − n!·e⁻¹ = n!·(D(n)/n! − e⁻¹) (via mul_sub, mul_div_assoc, mul_div_cancel_left₀), so |D(n) − n!·e⁻¹| = n!·|D(n)/n! − e⁻¹| after abs_mul and abs_of_pos. The proof then splits on n ≥ 1: (interior, n ≥ 2) the grandparent's derangements_convergence_rate gives n!·|D(n)/n! − e⁻¹| ≤ n!·(1/(n+1)!) = 1/(n+1) ≤ 1/3 < 1/2; (boundary, n = 1) D(1) = 0 reduces the quantity to exactly e⁻¹, and exp_neg_one_lt_half finishes. This is the one place where the n ≥ 1 result strictly improves on the sibling's n ≥ 2.",
+    "mathContext": "For n ≥ 2 the margin 1/(n+1) ≤ 1/3 is generous; at n = 1 the generic bound is exactly 1/2 (non-strict), so the boundary genuinely needs e⁻¹ < 1/2."
+  },
+  {
+    "id": "ann-dcoq0201-main",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 113, "endLine": 129 },
+    "type": "key-step",
+    "title": "§4 The Nearest-Integer Identity on n ≥ 1",
+    "content": "numDerangements_eq_round applies the rounding criterion to the strict distance bound (after abs_sub_comm and a cast normalisation) to conclude round(n!·e⁻¹) = D(n) for all n ≥ 1 — extending the sibling's n ≥ 2 identity to include the boundary index n = 1. numDerangements_eq_floor restates it in the explicit floor form D(n) = ⌊n!·e⁻¹ + 1/2⌋ by unfolding round_eq.",
+    "mathContext": "round(n!/e) = ⌊n!/e + 1/2⌋; the two forms are definitionally linked by round_eq."
+  },
+  {
+    "id": "ann-dcoq0201-sharpness",
+    "proofId": "derangements-convergence-oq-02-oq-01",
+    "range": { "startLine": 131, "endLine": 152 },
+    "type": "key-step",
+    "title": "§5 Sharpness: the Identity Fails at n = 0",
+    "content": "round_factorial_exp_zero computes round(0!·e⁻¹) = round(e⁻¹) = 0 (again via the rounding criterion at m = 0, using |e⁻¹ − 0| = e⁻¹ < 1/2). numDerangements_round_ne_at_zero then observes D(0) = 1 (by rfl), so round(0!·e⁻¹) = 0 ≠ 1 = D(0): the identity is genuinely false at n = 0. This pins n ≥ 1 as the exact, optimal hypothesis — the lower endpoint cannot be weakened.",
+    "mathContext": "0!·e⁻¹ = e⁻¹ ≈ 0.3679 rounds to 0, but the empty permutation is a derangement so D(0) = 1. The universal statement 'D(n) = round(n!/e)' must start at n = 1."
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-02-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-02-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "derangements-convergence-oq-02-oq-01",
+  "title": "The subfactorial is the nearest integer to n!/e — sharp at n ≥ 1",
+  "slug": "derangements-convergence-oq-02-oq-01",
+  "description": "Sharpens the rounding identity D(n) = round(n!/e) to its exact domain of validity. The sibling entry derangements-convergence-oq-03 proves it for n ≥ 2 (where the lossy bound |D(n) − n!/e| ≤ 1/(n+1) ≤ 1/3 is comfortably strict). This entry extends it to the boundary index n = 1 — which needs the separate elementary input e⁻¹ < 1/2, since the rate bound only gives the non-strict ≤ 1/2 there — and proves that the identity genuinely FAILS at n = 0 (round(0!·e⁻¹) = 0 ≠ 1 = D(0)). Hence n ≥ 1 is the exact, optimal threshold.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-05",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ02OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "e-constant",
+      "rounding",
+      "nearest-integer",
+      "sharp-threshold",
+      "alternating-series",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked with only Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). Builds on the grandparent DerangementsConvergence.lean for the rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! and on Mathlib for numDerangements, round, and Real.add_one_lt_exp (the e > 2 estimate).",
+    "dateAdded": "2026-07-05",
+    "lineCount": 152,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "abs_numDerangements_sub_lt_half (PROVED): the STRICT distance bound |D(n) − n!·e⁻¹| < 1/2 for every n ≥ 1. The interior case n ≥ 2 uses the rate bound (giving 1/(n+1) ≤ 1/3), but the boundary n = 1 is genuinely new: there the rate bound only yields the non-strict ≤ 1/2, so strictness is obtained separately from |D(1) − 1!·e⁻¹| = e⁻¹ and the elementary estimate e⁻¹ < 1/2.",
+      "numDerangements_eq_round (PROVED): D(n) = round(n!/e) for all n ≥ 1 — the nearest-integer characterization on its full (optimal) domain, extending the sibling oq-03 result from n ≥ 2 to include n = 1.",
+      "round_factorial_exp_zero + numDerangements_round_ne_at_zero (PROVED): SHARPNESS. At n = 0 the rounded value is round(0!·e⁻¹) = round(e⁻¹) = 0, whereas D(0) = 1; so the identity is FALSE at n = 0 and the hypothesis n ≥ 1 cannot be weakened. This pins n ≥ 1 as the exact threshold, which neither the sibling nor the parent records.",
+      "exp_neg_one_lt_half (PROVED): the standalone estimate e⁻¹ < 1/2 (from e > 2 via Real.add_one_lt_exp), the single analytic fact separating the n = 1 boundary case from failure at n = 0.",
+      "round_eq_of_abs_sub_lt_half (PROVED): a reusable rounding criterion |x − m| < 1/2 ⟹ round x = m, isolated as a clean lemma (proved from round_eq and Int.floor_eq_iff) rather than inlined, so it serves both the positive n ≥ 1 identity and the n = 0 sharpness computation.",
+      "numDerangements_eq_floor (PROVED): the equivalent explicit floor form D(n) = ⌊n!·e⁻¹ + 1/2⌋ for n ≥ 1."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "numDerangements",
+        "description": "The derangement counting function D(n) (permutations with no fixed point); base values D(0) = 1, D(1) = 0 reduce by rfl.",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "round / round_eq",
+        "description": "round x = ⌊x + 1/2⌋ : the nearest-integer function on a linear ordered field, and its defining identity used to reduce the rounding claim to a floor computation.",
+        "module": "Mathlib.Algebra.Order.Round"
+      },
+      {
+        "theorem": "Int.floor_eq_iff",
+        "description": "⌊r⌋ = z ↔ ↑z ≤ r ∧ r < z + 1 : converts the floor equality into the two linear inequalities discharged by linarith in the rounding criterion.",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Real.add_one_lt_exp",
+        "description": "x + 1 < exp x for x ≠ 0 : instantiated at x = 1 to get 2 < e, hence e⁻¹ < 1/2 — the analytic input for the n = 1 boundary case.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "derangements_convergence_rate",
+        "description": "The grandparent's magnitude bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)!, scaled by n! to bound |D(n) − n!·e⁻¹| in the interior case n ≥ 2.",
+        "module": "Proofs.DerangementsConvergence"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "That the number of derangements D(n) is the integer nearest to n!/e is a classical fact (the derangement ratio D(n)/n! = ∑_{k=0}^n (−1)^k/k! is the n-th partial sum of e⁻¹, so it converges to e⁻¹ fast enough to round exactly). The sibling entry derangements-convergence-oq-03 formalises D(n) = round(n!/e) for n ≥ 2, where the rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! comfortably beats the ½ threshold. The parent entry oq-02 supplies the exact sign of the error. What is left open by those entries is the precise boundary: for which n does the identity hold? This entry answers it — n ≥ 1 exactly, no more and no less.",
+    "problemStatement": "**OQ-02-OQ-01 of derangements-convergence.** Determine the exact set of n for which D(n) = round(n!/e). Extend the sibling's n ≥ 2 identity to its optimal domain and exhibit the failure that fixes the threshold.",
+    "text": "For every n ≥ 1, D(n) = round(n!/e) = ⌊n!·e⁻¹ + 1/2⌋, and this is sharp: at n = 0 one has round(0!·e⁻¹) = 0 while D(0) = 1, so the identity fails. The extra ingredient over the n ≥ 2 case is the strict boundary estimate e⁻¹ < 1/2, which upgrades the n = 1 distance from the non-strict ≤ 1/2 to a strict < 1/2.",
+    "proofStrategy": "The heart is the strict distance bound |D(n) − n!·e⁻¹| < 1/2 for n ≥ 1 (abs_numDerangements_sub_lt_half). Factor D(n) − n!·e⁻¹ = n!·(D(n)/n! − e⁻¹), so |D(n) − n!·e⁻¹| = n!·|D(n)/n! − e⁻¹|. Split on n: for n ≥ 2 the grandparent's rate bound gives n!·|D(n)/n! − e⁻¹| ≤ n!/(n+1)! = 1/(n+1) ≤ 1/3 < 1/2; for the boundary n = 1, D(1) = 0 so the quantity is exactly e⁻¹, and e⁻¹ < 1/2 because e > 2 (Real.add_one_lt_exp at x = 1). A generic rounding criterion round_eq_of_abs_sub_lt_half — proved once from round_eq and Int.floor_eq_iff — turns |x − m| < 1/2 into round x = m, delivering D(n) = round(n!/e) for n ≥ 1 and, applied at m = 0, round(0!·e⁻¹) = 0. Since D(0) = 1 ≠ 0, the threshold n ≥ 1 is sharp.",
+    "keyInsights": [
+      "The threshold n ≥ 1 is not cosmetic. The lossy bound |D(n) − n!/e| ≤ 1/(n+1) equals exactly 1/2 at n = 1, so the n ≥ 2 argument of the sibling cannot reach n = 1 — strictness there requires an independent analytic fact, namely e⁻¹ < 1/2. This is the whole gap between 'n ≥ 2' and the true 'n ≥ 1'.",
+      "n = 0 is a genuine counterexample, not a vacuous edge case. 0!·e⁻¹ = e⁻¹ ≈ 0.3679 rounds to 0, but D(0) = 1 (the empty permutation is a derangement). So the folklore statement 'D(n) = round(n!/e) for all n' is literally false at n = 0; the correct universal statement starts at n = 1.",
+      "Separating the rounding criterion |x − m| < 1/2 ⟹ round x = m as its own lemma pays off twice: the same lemma proves the positive identity (m = D(n)) and the negative sharpness fact (m = 0). The mathematics of 'rounds to' is the same object whether the target integer is the right answer or the wrong one.",
+      "Everything downstream of the ½-gap is purely formal: round_eq reduces to a floor, Int.floor_eq_iff to two inequalities, and linarith closes them. The only real content is the distance bound, and within it the only real content beyond the sibling is the single line e⁻¹ < 1/2."
+    ],
+    "prerequisites": [
+      "The grandparent rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! (derangements_convergence_rate) and factorial positivity helpers",
+      "Mathlib's round / round_eq and Int.floor_eq_iff",
+      "The estimate e > 2 via Real.add_one_lt_exp"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling entry proving D(n) = round(n!/e) for n ≥ 2. This entry sharpens that result to its optimal domain n ≥ 1 (adding the boundary case n = 1, which needs e⁻¹ < 1/2) and proves the identity fails at n = 0, fixing the exact threshold."
+    },
+    {
+      "targetId": "derangements-convergence-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry: the exact sign law (−1)^n·(D(n)/n! − e⁻¹) > 0. Its own open-questions list poses precisely this nearest-integer upgrade; this entry carries it out and adds the sharp-threshold analysis."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "foundational",
+      "description": "Grandparent entry supplying the magnitude bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! and the partial-sum representation used to scale the error by n!."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "foundational",
+      "description": "Root entry: derangement definitions and the counting function numDerangements, including the base values D(0) = 1 and D(1) = 0 that drive the boundary analysis."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified sharp form of the nearest-integer characterization of the subfactorial: D(n) = round(n!/e) = ⌊n!·e⁻¹ + 1/2⌋ holds for exactly n ≥ 1. The lower endpoint is optimal — the identity fails at n = 0, where round(e⁻¹) = 0 ≠ 1 = D(0). Zero sorries, zero axioms beyond the foundational ones.",
+    "implications": "Pins down the precise domain of a piece of standard folklore that is usually stated 'for all n' and is in fact false at n = 0. The extension from the sibling's n ≥ 2 to n ≥ 1 isolates the exact analytic content needed at the boundary (e⁻¹ < 1/2), and the reusable rounding criterion round_eq_of_abs_sub_lt_half is a small, general tool for turning any ½-distance bound into an exact integer identity.",
+    "openQuestions": [
+      "The same ½-distance method characterises other e-adjacent integer sequences as nearest integers: is the number of involutions, or ⌊n!·e^{c}⌉ for other rational c, similarly pinned to an exact threshold, and does the boundary index depend on c in a describable way?",
+      "Quantify the margin: for n ≥ 1 the distance |D(n) − n!/e| is not just < 1/2 but < 1/(n+1) (and ~ 1/(n+1) asymptotically). Formalise the exact asymptotic of this rounding margin and identify the n at which n!/e is closest to a half-integer, the worst case for the rounding."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "numDerangements_eq_round",
+      "type": "theorem",
+      "description": "Nearest-integer characterization on its optimal domain: for every n ≥ 1, D(n) = round(n!/e).",
+      "leanType": "(n : ℕ) → 1 ≤ n → round ((n.factorial : ℝ) * rexp (-1)) = (numDerangements n : ℤ)"
+    },
+    {
+      "name": "abs_numDerangements_sub_lt_half",
+      "type": "theorem",
+      "description": "The strict distance bound |D(n) − n!·e⁻¹| < 1/2 for n ≥ 1; the boundary case n = 1 uses e⁻¹ < 1/2.",
+      "leanType": "(n : ℕ) → 1 ≤ n → |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| < 1 / 2"
+    },
+    {
+      "name": "numDerangements_round_ne_at_zero",
+      "type": "theorem",
+      "description": "Sharpness: at n = 0 the identity fails, round(0!·e⁻¹) = 0 ≠ 1 = D(0), so the hypothesis n ≥ 1 cannot be dropped.",
+      "leanType": "round (((0 : ℕ).factorial : ℝ) * rexp (-1)) ≠ (numDerangements 0 : ℤ)"
+    },
+    {
+      "name": "round_eq_of_abs_sub_lt_half",
+      "type": "lemma",
+      "description": "Reusable rounding criterion: a real within 1/2 of an integer rounds to it.",
+      "leanType": "{x : ℝ} → {m : ℤ} → |x - (m : ℝ)| < 1 / 2 → round x = m"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.DerangementsConvergence",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Real",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DerangementsConvergenceOQ02OQ01",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 6,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Origin of the derangement series D(n)/n! = ∑(−1)^k/k! underlying the rounding identity."
+    },
+    {
+      "authors": "Pierre Rémond de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris",
+      "note": "The matching/rencontre problem; first appearance of derangement counts, including D(0) = 1."
+    },
+    {
+      "authors": "Ronald L. Graham, Donald E. Knuth, Oren Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "venue": "Addison-Wesley, §5.3",
+      "note": "States !n = round(n!/e) as the nearest-integer formula for the subfactorial; the n ≥ 1 restriction and the n = 0 failure are the sharp form formalised here."
+    }
+  ]
+}

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
@@ -175,9 +175,9 @@
   ],
   "leanFile": {
     "namespace": "HurwitzOnlyIf",
-    "lineCount": 793,
+    "lineCount": 973,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 39,
     "definitionCount": 7,
     "path": "Proofs/HurwitzOnlyIf.lean",
     "sorries": 1


### PR DESCRIPTION
## Summary

Advances the Hurwitz only-if theorem (`HurwitzOnlyIf.lean`) by adding **four machine-checked lemmas** that reduce the single remaining `sorry` (the finrank count in `hurwitz_only_if_ring`) to a pure finite-dimensional inner-product-space argument with no further division-ring input.

**Build**: docker 2715 jobs, `=== Build succeeded ===`, **0 new sorry / 0 axiom / 0 native_decide**. The file still has exactly ONE sorry (the pre-existing non-commutative branch).

## New lemmas (metric-level Frobenius cap)

| Lemma | Statement | Basis |
|-------|-----------|-------|
| `finrank_eq_imaginary_add_one` | `finrank ℝ A = finrank ℝ (Im A) + 1` | rank–nullity for surjective `realPart : A →ₗ[ℝ] ℝ`, `Im A = ker realPart` |
| `imaginary_mul_mem_imaginarySubmodule` | B-orthogonal imaginary `x,y` ⟹ `x*y ∈ Im A` | `isImaginary_mul_of_anticomm` via bridge |
| `imaginaryBilin_mul_orthogonal` | third unit `x*y` is B-orthogonal to `x` and `y` | `mul_anticomm_left/right` via bridge |
| `eq_zero_of_orthogonal_to_triple` | `w ⊥ {x, y, x*y}` ⟹ `w = 0` (no fourth unit) | `eq_zero_of_anticomm_pair_and_product` via bridge |

Together these recast every remaining algebraic obstruction in terms of the positive-definite form `B = imaginaryBilin A`. `finrank_eq_imaginary_add_one` collapses the whole Hurwitz dimension count to **`finrank ℝ (Im A) ∈ {0,1,3}`**; lemmas 2–3 manufacture the third quaternion generator `x*y`, and lemma 4 (plus positive-definiteness) rules out `finrank = 2` and `finrank ≥ 4`.

## Remaining gap

The last `sorry` is now purely linear-algebraic: package `imaginaryBilin` as an `InnerProductSpace` (or nondegenerate `BilinForm`), pick a B-orthonormal basis of `Im A`, and apply lemmas 2–4 + `finrank_eq_imaginary_add_one`. No more algebra of `A` is needed.

## Notes
- Gallery `meta.json` synced (`lineCount` 793→973, `theoremCount` 32→39); status remains `formalized`/`wip` (open problem, 1 sorry).
- Implementation note: `unfold imaginarySubmodule; omega` crashed the Lean kernel (exit 135) by reducing inside the `Classical.choose`-based kernel term; replaced with a `show` that keeps the finrank atoms syntactic so `omega` never reduces inside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)