### PR TITLE
Enrich euler-totient-oq-08-oq-01: add annotations.json (7 annotations)

### DIFF
--- a/src/data/proofs/euler-totient-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-08-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-module-overview",
+    "proofId": "euler-totient-oq-08-oq-01",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "context",
+    "title": "The composite-modulus goal and the CRT strategy",
+    "content": "The module docstring frames the objective: Euler's theorem reduces exponents modulo $\\varphi(n)$ only when $\\gcd(a,n)=1$, and Mathlib's `PowModTotient.lean` lists dropping that coprimality as an open TODO. The sibling file `EulerTotientOQ08` solved the non-coprime case for prime-power moduli $p^e$. This file assembles those prime-power periodicities into an arbitrary composite modulus $n$ by writing $n = \\prod_p p^{v_p(n)}$ and gluing the factorwise congruences with the Chinese Remainder Theorem. The imports pull in Mathlib plus the parent module `Proofs.EulerTotientOQ08`, and the namespace fixes $\\varphi = $ `Nat.totient`.",
+    "mathContext": "$n = \\prod_{p \\mid n} p^{v_p(n)}, \\qquad a^{k+\\varphi(n)} \\equiv a^k \\pmod n \\text{ once } k \\ge \\max_p v_p(n)$",
+    "significance": "context",
+    "relatedConcepts": ["Euler's theorem", "Chinese Remainder Theorem", "prime factorization", "totient function", "modular exponentiation"],
+    "prerequisites": ["elementary number theory", "modular arithmetic"]
+  },
+  {
+    "id": "ann-crt-helper",
+    "proofId": "euler-totient-oq-08-oq-01",
+    "range": { "startLine": 55, "endLine": 73 },
+    "type": "technique",
+    "title": "CRT assembly helper over a Finset of moduli",
+    "content": "`modEq_prod_of_pairwiseCoprime` packages the Chinese Remainder Theorem in its `Nat.ModEq` guise: if $x \\equiv y$ modulo every member $f\\,i$ of a pairwise-coprime family indexed by a `Finset`, then $x \\equiv y$ modulo the product $\\prod_{i} f\\,i$. The proof is a `Finset.induction`. The empty product is the modulus $1$, where every congruence holds trivially (`Nat.modEq_one`). The insert step peels one factor $f\\,a$ off: `Nat.Coprime.prod_right` shows $f\\,a$ is coprime to the product over the rest, and `Nat.modEq_and_modEq_iff_modEq_mul` fuses the congruence mod $f\\,a$ with the inductive congruence over the remaining product. This reusable lemma is the workhorse the main theorem instantiates on the prime-power factorization of $n$.",
+    "mathContext": "$\\bigl(\\forall i \\in s,\\ x \\equiv y \\pmod{f\\,i}\\bigr) \\wedge \\text{pairwise } \\gcd(f\\,i, f\\,j)=1 \\ \\Longrightarrow\\ x \\equiv y \\pmod{\\textstyle\\prod_{i \\in s} f\\,i}$",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "pairwise coprimality", "Finset induction", "Nat.ModEq"],
+    "prerequisites": ["Chinese Remainder Theorem", "induction on finite sets"]
+  },
+  {
+    "id": "ann-single-period",
+    "proofId": "euler-totient-oq-08-oq-01",
+    "range": { "startLine": 79, "endLine": 114 },
+    "type": "insight",
+    "title": "Single-period non-coprime composite periodicity",
+    "content": "`pow_add_totient_modEq` is the headline result: for any base $a$, modulus $n \\ne 0$, and exponent $k$ at least every prime-power exponent of $n$ (the hypothesis $v_p(n) \\le k$ for all $p$, i.e. $k \\ge \\max_p v_p(n)$), shifting the exponent by $\\varphi(n)$ leaves $a^k$ fixed mod $n$ — even when $\\gcd(a,n)\\neq 1$. The proof rewrites $n$ as its prime-power product via `factorization_prod_pow_eq_self`, keeping the $\\varphi(n)$-shift intact, then verifies the congruence factor by factor. Distinct prime powers are coprime (`Nat.coprime_primes` lifted through `Nat.Coprime.pow`), and on each factor $p^{v_p(n)}$ the divisibility $\\varphi(p^{v_p(n)}) \\mid \\varphi(n)$ (from `Nat.totient_dvd_of_dvd` applied to `Nat.ordProj_dvd`) recasts the $\\varphi(n)$-shift as a whole number $l$ of that factor's period, discharged by the parent's `pow_add_mul_totient_modEq_primePow`. The CRT helper glues the factorwise congruences back mod $n$.",
+    "mathContext": "$\\varphi(p^{v_p(n)}) \\mid \\varphi(n) \\ \\Rightarrow\\ \\varphi(n) = l\\cdot\\varphi(p^{v_p(n)}), \\qquad a^{k+\\varphi(n)} \\equiv a^k \\pmod{p^{v_p(n)}} \\text{ for each } p$",
+    "significance": "key",
+    "relatedConcepts": ["prime factorization", "multiplicativity of the totient", "ordProj", "modular periodicity", "Euler's theorem"],
+    "prerequisites": ["prime factorization", "totient function", "Chinese Remainder Theorem"]
+  },
+  {
+    "id": "ann-multi-period",
+    "proofId": "euler-totient-oq-08-oq-01",
+    "range": { "startLine": 116, "endLine": 130 },
+    "type": "technique",
+    "title": "The multi-period form by induction on the period count",
+    "content": "`pow_add_mul_totient_modEq` extends the single-period result to any integer multiple $l \\cdot \\varphi(n)$ of the period. The proof is a straightforward induction on $l$: the base case $l=0$ is reflexivity, and each successor step splits off one $\\varphi(n)$-shift — handled by the single-period `pow_add_totient_modEq` after a `ring` normalization of the exponent $(l+1)\\varphi(n) = l\\varphi(n) + \\varphi(n)$ — then chains it with the inductive hypothesis by transitivity of `Nat.ModEq`. This is the composite counterpart of Mathlib's coprime-only `Nat.pow_add_mul_totient_mod_eq`.",
+    "mathContext": "$a^{k + l\\cdot\\varphi(n)} \\equiv a^k \\pmod n \\quad \\text{for all } l \\in \\mathbb{N}$",
+    "significance": "supporting",
+    "relatedConcepts": ["mathematical induction", "transitivity of congruence", "modular periodicity"],
+    "prerequisites": ["induction", "modular arithmetic"]
+  },
+  {
+    "id": "ann-full-reduction",
+    "proofId": "euler-totient-oq-08-oq-01",
+    "range": { "startLine": 132, "endLine": 153 },
+    "type": "insight",
+    "title": "Full exponent reduction with a composite pre-period",
+    "content": "`pow_modEq` is the computational payoff and the non-coprime, composite analogue of `Nat.pow_totient_mod`: for any $K$ bounding every $v_p(n)$ and any $k \\ge K$, the exponent of $a^k \\bmod n$ collapses to $K + (k-K) \\bmod \\varphi(n)$. The leading constant $K$ is the composite pre-period — a base sharing a factor with $n$ is not yet stable below it, but from exponent $K$ onward the sequence $a^K, a^{K+1}, \\dots$ is periodic with period $\\varphi(n)$. The proof splits $k$ via the division algorithm (`Nat.mod_add_div'`) as $k = \\bigl(K + (k-K)\\bmod\\varphi(n)\\bigr) + \\lfloor (k-K)/\\varphi(n)\\rfloor \\cdot \\varphi(n)$, checks the reduced exponent still bounds every $v_p(n)$, and applies the multi-period form to strip the whole periods.",
+    "mathContext": "$a^k \\equiv a^{\\,K + (k-K)\\bmod \\varphi(n)} \\pmod n, \\qquad k = \\underbrace{K + (k-K)\\bmod\\varphi(n)}_{\\text{reduced}} + \\Bigl\\lfloor\\tfrac{k-K}{\\varphi(n)}\\Bigr\\rfloor\\varphi(n)$",
+    "significance": "key",
+    "relatedConcepts": ["division algorithm", "eventual periodicity", "pre-period", "last digits of powers"],
+    "prerequisites": ["division algorithm", "modular arithmetic"]
+  },
+  {
+    "id": "ann-factorization-free",
+    "proofId": "euler-totient-oq-08-oq-01",
+    "range": { "startLine": 155, "endLine": 163 },
+    "type": "technique",
+    "title": "A factorisation-free sufficient condition",
+    "content": "`pow_add_totient_modEq_of_le` removes the `factorization` hypothesis entirely, replacing it with the easily checked bound $n \\le 2^k$. Since $v_p(n) \\le \\log_2 n$ for every prime $p$, the inequality $n \\le 2^k \\le p^k$ forces $v_p(n) \\le k$ (`Nat.factorization_le_of_le_pow`), and non-primes contribute factorization $0$. This makes the periodicity trivially applicable to concrete data without factoring $n$ — at the cost of a coarser pre-period bound than the sharp $\\max_p v_p(n)$.",
+    "mathContext": "$n \\le 2^k \\ \\Longrightarrow\\ v_p(n) \\le k \\text{ for all primes } p \\ \\Longrightarrow\\ a^{k+\\varphi(n)} \\equiv a^k \\pmod n$",
+    "significance": "supporting",
+    "relatedConcepts": ["p-adic valuation", "logarithmic bounds", "prime factorization"],
+    "prerequisites": ["prime factorization", "exponential inequalities"]
+  },
+  {
+    "id": "ann-worked-examples",
+    "proofId": "euler-totient-oq-08-oq-01",
+    "range": { "startLine": 165, "endLine": 205 },
+    "type": "context",
+    "title": "Worked examples on genuinely non-coprime data",
+    "content": "The examples exhibit cases outside Euler's coprime theorem. For $2^k \\bmod 12$ with $\\gcd(2,12)=2$, the factorisation-free bound $12 \\le 2^4$ gives periodicity from $k=4$ ($2^8 \\equiv 2^4$, `decide`-checked). The sharp pre-period is actually $k=2$ since $12 = 2^2\\cdot 3$ has $\\max_p v_p(12) = 2$; the example proves $v_p(12) \\le 2$ for every $p$ by ruling out $p^3 \\mid 12$ (`interval_cases` on the only candidate $p=2$), beating the coarser $n \\le 2^k$ bound that needs $k\\ge 4$. Finally $10^{100} \\equiv 10^4 \\pmod{12}$ demonstrates full reduction of a huge exponent of a non-invertible base: $K=2$, $\\varphi(12)=4$, so $10^{100} \\equiv 10^{2 + (100-2)\\bmod 4} = 10^4$. The `decide` calls are kernel reductions over concrete small naturals — not `native_decide` — so the file stays axiom-free.",
+    "mathContext": "$2^8 \\equiv 2^4 \\equiv 4, \\quad 2^6 \\equiv 2^2 \\equiv 4, \\quad 10^{100} \\equiv 10^4 \\equiv 4 \\pmod{12}$",
+    "significance": "context",
+    "relatedConcepts": ["decide tactic", "interval_cases", "sharp pre-period", "non-coprime bases"],
+    "prerequisites": ["modular arithmetic", "Lean tactics"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-08-oq-01` (Non-Coprime Euler Periodicity for Composite Moduli via CRT).

**Genuine gap:** quality 10, 0 passes, **no annotations.json**. The meta.json is already rich (13.6 KB, under all caps) — the single high-impact addition is inline annotations.

## What was added
A new `annotations.json` with **7 annotations** covering all seven Lean sections:

1. Module overview & CRT strategy (ctx)
2. `modEq_prod_of_pairwiseCoprime` — CRT assembly helper (key)
3. `pow_add_totient_modEq` — single-period non-coprime periodicity (key)
4. `pow_add_mul_totient_modEq` — multi-period form (supporting)
5. `pow_modEq` — full exponent reduction with composite pre-period (key)
6. `pow_add_totient_modEq_of_le` — factorisation-free condition (supporting)
7. Worked examples on non-coprime data `2^k, 10^k mod 12` (ctx)

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; line ranges are aligned to the actual Lean source (1–205).

## Validation
- JSON validates; schema keys identical to the merged `handshake-lemma/annotations.json`
- All `type`/`significance` values are valid enum members
- Mathematical content checked against the Lean file (CRT gluing, $\varphi(p^{v_p(n)}) \mid \varphi(n)$, division-algorithm split, sharp pre-period $k=2$ for $12=2^2\cdot3$)

No meta.json changes — status/badge/axiomCount left untouched (verified, 0 axioms, 0 sorries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)