### PR TITLE
Enrich automorphic-number-oq-01-oq-01-oq-02: add annotations.json (8 annotations)

### DIFF
--- a/src/data/proofs/automorphic-number-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-def-unitary-divisors",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-02",
+    "range": { "startLine": 58, "endLine": 66 },
+    "type": "definition",
+    "title": "Unitary divisors and their membership criterion",
+    "content": "`unitaryDivisors n` is defined as the divisors $d$ of $n$ that are coprime to their cofactor $n/d$ — a `Finset.filter` of `n.divisors`. The lemma `mem_unitaryDivisors` unfolds membership to $(d \\mid n \\wedge n \\ne 0) \\wedge \\gcd(d, n/d) = 1$. Geometrically a unitary divisor is a 'block' divisor: at each prime $p \\mid n$ it takes either the full prime power $p^{v_p(n)}$ or nothing, never a proper intermediate power — because splitting a prime power would leave $p$ dividing both $d$ and $n/d$.",
+    "mathContext": "$\\operatorname{unitaryDivisors}(n) = \\{\\, d \\mid n : \\gcd(d, n/d) = 1 \\,\\}$",
+    "significance": "key",
+    "relatedConcepts": ["unitary divisor", "coprimality", "divisor function", "Finset.filter"],
+    "prerequisites": ["divisibility", "greatest common divisor"]
+  },
+  {
+    "id": "ann-prod-pow-primefactors",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-02",
+    "range": { "startLine": 68, "endLine": 74 },
+    "type": "context",
+    "title": "The prime factorization as a Finset product",
+    "content": "`prod_pow_primeFactors` re-expresses the fundamental theorem of arithmetic (`Nat.factorization_prod_pow_eq_self`) as a product over the prime-factor Finset: for $m \\ne 0$, $m = \\prod_{p \\in m.\\text{primeFactors}} p^{v_p(m)}$. Rewriting through `Nat.support_factorization` converts the `Finsupp`-indexed product into a `Finset.prod` over `primeFactors`. This identity underpins the crucial $a \\cdot b = n$ step in the 'into' direction: the disjoint union of a subset of primes and its complement reassembles the full factorization.",
+    "mathContext": "$m = \\prod_{p \\in m.\\mathrm{primeFactors}} p^{\\,v_p(m)} \\qquad (m \\neq 0)$",
+    "significance": "supporting",
+    "relatedConcepts": ["fundamental theorem of arithmetic", "p-adic valuation", "prime factorization", "Finset product"],
+    "prerequisites": ["unique factorization", "prime factorization"]
+  },
+  {
+    "id": "ann-primefactors-prod-pow",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-02",
+    "range": { "startLine": 76, "endLine": 99 },
+    "type": "technique",
+    "title": "primeFactors is a left inverse of the maximal-prime-power map",
+    "content": "`primeFactors_prod_pow` shows the set of prime factors of $\\prod_{p \\in S} p^{v_p(n)}$ is exactly $S$ (for $S \\subseteq n.\\text{primeFactors}$). One direction uses `Prime.dvd_finset_prod_iff`: a prime dividing the product divides one factor $p^{v_p(n)}$, hence equals that $p \\in S$. The reverse uses `Finset.dvd_prod_of_mem`: each $q \\in S$ has positive valuation, so $q \\mid q^{v_q(n)}$ divides the product. Establishing that `primeFactors` recovers $S$ is precisely what makes the powerset map injective.",
+    "mathContext": "$\\Bigl(\\prod_{p \\in S} p^{\\,v_p(n)}\\Bigr).\\mathrm{primeFactors} = S \\qquad (S \\subseteq n.\\mathrm{primeFactors})$",
+    "significance": "supporting",
+    "relatedConcepts": ["left inverse", "prime divides product", "injectivity", "prime factorization"],
+    "prerequisites": ["prime factorization", "Euclid's lemma"]
+  },
+  {
+    "id": "ann-prod-mem-into",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-02",
+    "range": { "startLine": 101, "endLine": 131 },
+    "type": "insight",
+    "title": "The 'into' direction via complementary primes",
+    "content": "`prod_mem_unitaryDivisors` proves that for any $S \\subseteq n.\\text{primeFactors}$, the product $a = \\prod_{p \\in S} p^{v_p(n)}$ is a genuine unitary divisor. The elegant device is the complementary set $T = n.\\text{primeFactors} \\setminus S$ with $b = \\prod_{p \\in T} p^{v_p(n)}$. Since $S$ and $T$ are disjoint and union to all of $n$'s primes, `Finset.prod_union` gives $a \\cdot b = n$ in one stroke — so $a \\mid n$ and $n/a = b$ with no explicit division. Coprimality $\\gcd(a,b)=1$ follows from `Nat.Coprime.prod_left`/`prod_right` reducing to distinct prime powers $p^{a} \\perp q^{b}$ ($p \\ne q$) via `Nat.coprime_primes` and `Nat.Coprime.pow`. Hence $\\gcd(a, n/a) = \\gcd(a,b) = 1$.",
+    "mathContext": "$a = \\prod_{p \\in S} p^{v_p(n)},\\ b = \\prod_{p \\in T} p^{v_p(n)} \\ \\Rightarrow\\ a \\cdot b = n,\\ \\gcd(a,b)=1,\\ n/a = b$",
+    "significance": "key",
+    "relatedConcepts": ["complementary set", "disjoint prime supports", "coprimality of products", "Finset.prod_union"],
+    "prerequisites": ["coprimality", "prime factorization", "Finset operations"]
+  },
+  {
+    "id": "ann-factorization-eq-unitary",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-02",
+    "range": { "startLine": 133, "endLine": 152 },
+    "type": "insight",
+    "title": "The unitary condition keeps whole prime powers",
+    "content": "`factorization_eq_of_unitary` is the one genuinely new ingredient beyond the squarefree-divisor count: it shows a unitary divisor $d$ satisfies $v_p(d) = v_p(n)$ at every prime $p \\mid d$. The proof is by contradiction — if $v_p(d) < v_p(n)$, then `Nat.factorization_div` gives $v_p(n/d) = v_p(n) - v_p(d) > 0$, so $p \\mid n/d$ (via `Nat.dvd_of_factorization_pos`). Combined with $p \\mid d$, this makes $p \\mid \\gcd(d, n/d) = 1$, forcing $p = 1$, impossible for a prime. Thus the coprimality with the cofactor is exactly what prevents splitting a prime power, giving $d = \\prod_{p \\mid d} p^{v_p(n)}$.",
+    "mathContext": "$\\gcd(d, n/d) = 1,\\ p \\mid d \\ \\Longrightarrow\\ v_p(d) = v_p(n)$",
+    "significance": "key",
+    "relatedConcepts": ["p-adic valuation", "proof by contradiction", "coprimality", "factorization of quotient"],
+    "prerequisites": ["p-adic valuation", "modular arithmetic"]
+  },
+  {
+    "id": "ann-eq-image-injon",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-02",
+    "range": { "startLine": 154, "endLine": 183 },
+    "type": "technique",
+    "title": "Assembling the powerset bijection",
+    "content": "`unitaryDivisors_eq_image` identifies the unitary divisors with the image of $n.\\text{primeFactors.powerset}$ under $S \\mapsto \\prod_{p \\in S} p^{v_p(n)}$. The 'onto' inclusion recovers each unitary divisor $d$ as $\\prod_{p \\in d.\\text{primeFactors}} p^{v_p(n)}$ using `factorization_eq_of_unitary`; the 'into' inclusion is `prod_mem_unitaryDivisors`. `injOn_prod_pow` then supplies injectivity on the powerset by applying the left inverse `primeFactors_prod_pow` to both sides. Together these establish a bijection between subsets of the primes and unitary divisors.",
+    "mathContext": "$\\operatorname{unitaryDivisors}(n) = \\Bigl\\{ \\textstyle\\prod_{p \\in S} p^{v_p(n)} : S \\subseteq n.\\mathrm{primeFactors} \\Bigr\\}$",
+    "significance": "supporting",
+    "relatedConcepts": ["bijection", "image of a map", "injectivity on a set", "powerset"],
+    "prerequisites": ["set image", "injective functions", "powerset"]
+  },
+  {
+    "id": "ann-main-count-bridge",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-02",
+    "range": { "startLine": 185, "endLine": 197 },
+    "type": "insight",
+    "title": "The count 2^ω(n) and the idempotent bridge",
+    "content": "`unitaryDivisors_card` delivers the headline: $\\#(\\operatorname{unitaryDivisors} n) = 2^{\\omega(n)}$, obtained by feeding the bijection into `Finset.card_image_of_injOn` and `Finset.card_powerset` (the powerset of a $k$-element set has $2^k$ members). `idempotents_eq_unitaryDivisors` then composes this with the parent entry's `idempotent_count` to conclude that the automorphic residues of $n$ (idempotents of $\\mathbb{Z}/n\\mathbb{Z}$) are equinumerous with its unitary divisors — a second concrete divisor-theoretic meaning for the abstract count $2^{\\omega(n)}$.",
+    "mathContext": "$\\#(\\operatorname{unitaryDivisors} n) = 2^{\\omega(n)} = \\#\\{ e \\in \\mathbb{Z}/n\\mathbb{Z} : e^2 = e \\}$",
+    "significance": "key",
+    "relatedConcepts": ["cardinality of powerset", "idempotents", "omega function", "arithmetic bijection"],
+    "prerequisites": ["cardinality", "idempotent elements", "ring ZMod n"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "automorphic-number-oq-01-oq-01-oq-02",
+    "range": { "startLine": 199, "endLine": 212 },
+    "type": "context",
+    "title": "Degenerate cases: prime powers and n = 1",
+    "content": "Two corollaries pin the extremes of the count. `unitaryDivisors_card_prime_pow` shows a prime power $p^k$ ($k \\ge 1$) has exactly $2 = 2^1$ unitary divisors, namely $1$ and $p^k$ — since $\\omega(p^k) = 1$ (`Nat.primeFactors_prime_pow`). `unitaryDivisors_card_eq_one_iff` shows the count is $1$ exactly when $n = 1$, i.e. $2^{\\omega(n)} = 1 \\iff \\omega(n) = 0 \\iff n$ has no prime factors, closed by `omega`. These confirm the count behaves correctly at the multiplicative boundary.",
+    "mathContext": "$\\#(\\operatorname{unitaryDivisors}(p^k)) = 2 \\ (k \\ge 1); \\qquad \\#(\\operatorname{unitaryDivisors} n) = 1 \\iff n = 1$",
+    "significance": "context",
+    "relatedConcepts": ["prime power", "boundary cases", "multiplicativity", "empty product"],
+    "prerequisites": ["prime powers", "modular arithmetic"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `automorphic-number-oq-01-oq-01-oq-02` (The Unitary-Divisor Count: #(unitaryDivisors n) = 2^ω(n)).

**Genuine gap:** quality 41, 0 passes, **no annotations.json**. The meta.json is already exceptionally complete (20 KB — full overview, sections, mainTheorems, conclusion, crossReferences) and under all caps. The single high-impact addition is inline annotations.

## What was added
A new `annotations.json` with **8 annotations** covering every key Lean structure:

1. `unitaryDivisors` definition + membership criterion (key)
2. `prod_pow_primeFactors` — factorization as a Finset product (supporting)
3. `primeFactors_prod_pow` — left inverse of the maximal-prime-power map (supporting)
4. `prod_mem_unitaryDivisors` — 'into' direction via complementary primes (key)
5. `factorization_eq_of_unitary` — the unitary condition keeps whole prime powers (key, the one new ingredient)
6. `unitaryDivisors_eq_image` + `injOn_prod_pow` — assembling the bijection (supporting)
7. `unitaryDivisors_card` + `idempotents_eq_unitaryDivisors` — the 2^ω(n) count and idempotent bridge (key)
8. corollaries: prime powers and n = 1 (ctx)

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; line ranges aligned to the Lean source (58–212).

## Validation
- JSON validates; schema keys identical to the merged `handshake-lemma/annotations.json`
- Mathematical content checked against the Lean file (the complementary-set $a\cdot b = n$ trick, the contradiction $p \mid \gcd(d, n/d)=1$, the powerset bijection giving $2^{\omega(n)}$)

No meta.json changes — status/badge/axiomCount untouched (verified, 0 axioms, 0 sorries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)