### PR TITLE
Enrich derangements-convergence-oq-02-oq-01: complete annotation metadata (6 anns)

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-02-oq-01/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "Module Overview: The Sharp Nearest-Integer Threshold",
     "content": "This module determines the exact domain on which the folklore identity D(n) = round(n!/e) holds. The sibling entry derangements-convergence-oq-03 proves it for n ≥ 2, where the rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! scales to |D(n) − n!/e| ≤ 1/(n+1) ≤ 1/3, comfortably under the ½ threshold that rounding needs. Two things remain: the boundary index n = 1 (where the same bound gives only the non-strict ≤ 1/2) and the failure at n = 0. This module supplies the extra analytic input e⁻¹ < 1/2 to settle n = 1, then proves the identity is genuinely false at n = 0, establishing n ≥ 1 as the optimal threshold. Imports pull in the grandparent DerangementsConvergence (for the rate bound) and all of Mathlib.Tactic.",
-    "mathContext": "D(n)/n! = ∑_{k=0}^n (−1)^k/k! → e⁻¹; the rounding identity D(n) = round(n!/e) is standard for n ≥ 1 but false at n = 0 since D(0) = 1 while round(e⁻¹) = 0."
+    "mathContext": "D(n)/n! = ∑_{k=0}^n (−1)^k/k! → e⁻¹; the rounding identity D(n) = round(n!/e) is standard for n ≥ 1 but false at n = 0 since D(0) = 1 while round(e⁻¹) = 0.",
+    "significance": "context",
+    "relatedConcepts": ["derangements", "nearest-integer function", "subfactorial", "exponential series", "sharp threshold"],
+    "prerequisites": ["combinatorics", "real analysis", "asymptotic estimates"]
   },
   {
     "id": "ann-dcoq0201-round-criterion",
@@ -15,7 +18,10 @@
     "type": "technique",
     "title": "§1 A Reusable Rounding Criterion",
     "content": "round_eq_of_abs_sub_lt_half proves the elementary bridge from analysis to arithmetic: if |x − m| < 1/2 for an integer m then round x = m. The proof rewrites round x = ⌊x + 1/2⌋ (round_eq) and applies Int.floor_eq_iff to reduce ⌊x + 1/2⌋ = m to the pair ↑m ≤ x + 1/2 and x + 1/2 < ↑m + 1; abs_sub_lt_iff unpacks the hypothesis into x − m < 1/2 and m − x < 1/2, and linarith closes both inequalities. Isolating this lemma lets it serve both the positive identity (m = D(n)) and the negative sharpness fact (m = 0).",
-    "mathContext": "round x = m ⟺ m − 1/2 ≤ x < m + 1/2; a strict distance < 1/2 to an integer determines the rounded value uniquely."
+    "mathContext": "round x = m ⟺ m − 1/2 ≤ x < m + 1/2; a strict distance < 1/2 to an integer determines the rounded value uniquely.",
+    "significance": "supporting",
+    "relatedConcepts": ["rounding function", "floor function", "Int.floor_eq_iff", "linarith"],
+    "prerequisites": ["floor and ceiling", "absolute value inequalities"]
   },
   {
     "id": "ann-dcoq0201-exp-half",
@@ -24,33 +30,45 @@
     "type": "technique",
     "title": "§2 The Boundary Estimate e⁻¹ < 1/2",
     "content": "exp_neg_one_lt_half proves the single analytic fact that separates the n = 1 boundary case from failure. From Real.add_one_lt_exp at x = 1 one gets 1 + 1 < e, i.e. 2 < e; rewriting rexp(−1) = (rexp 1)⁻¹ = 1/rexp 1 and applying one_div_lt_one_div_of_lt to 2 < e yields 1/e < 1/2. This is exactly the strictness the rate bound cannot provide at n = 1.",
-    "mathContext": "e ≈ 2.718 > 2, so e⁻¹ ≈ 0.3679 < 0.5. This is why D(1) = 0 is within ½ of 1!·e⁻¹ = e⁻¹."
+    "mathContext": "e ≈ 2.718 > 2, so e⁻¹ ≈ 0.3679 < 0.5. This is why D(1) = 0 is within ½ of 1!·e⁻¹ = e⁻¹.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's number", "exponential function", "Real.add_one_lt_exp", "reciprocal inequalities"],
+    "prerequisites": ["exponential function", "real inequalities"]
   },
   {
     "id": "ann-dcoq0201-distance",
     "proofId": "derangements-convergence-oq-02-oq-01",
     "range": { "startLine": 71, "endLine": 111 },
-    "type": "key-step",
+    "type": "insight",
     "title": "§3 The Strict Distance Bound |D(n) − n!·e⁻¹| < 1/2",
     "content": "abs_numDerangements_sub_lt_half is the heart of the entry. It factors D(n) − n!·e⁻¹ = n!·(D(n)/n! − e⁻¹) (via mul_sub, mul_div_assoc, mul_div_cancel_left₀), so |D(n) − n!·e⁻¹| = n!·|D(n)/n! − e⁻¹| after abs_mul and abs_of_pos. The proof then splits on n ≥ 1: (interior, n ≥ 2) the grandparent's derangements_convergence_rate gives n!·|D(n)/n! − e⁻¹| ≤ n!·(1/(n+1)!) = 1/(n+1) ≤ 1/3 < 1/2; (boundary, n = 1) D(1) = 0 reduces the quantity to exactly e⁻¹, and exp_neg_one_lt_half finishes. This is the one place where the n ≥ 1 result strictly improves on the sibling's n ≥ 2.",
-    "mathContext": "For n ≥ 2 the margin 1/(n+1) ≤ 1/3 is generous; at n = 1 the generic bound is exactly 1/2 (non-strict), so the boundary genuinely needs e⁻¹ < 1/2."
+    "mathContext": "For n ≥ 2 the margin 1/(n+1) ≤ 1/3 is generous; at n = 1 the generic bound is exactly 1/2 (non-strict), so the boundary genuinely needs e⁻¹ < 1/2.",
+    "significance": "key",
+    "relatedConcepts": ["derangement asymptotics", "convergence rate", "case split", "factorial telescoping"],
+    "prerequisites": ["real analysis", "asymptotic estimates", "factorials"]
   },
   {
     "id": "ann-dcoq0201-main",
     "proofId": "derangements-convergence-oq-02-oq-01",
     "range": { "startLine": 113, "endLine": 129 },
-    "type": "key-step",
+    "type": "insight",
     "title": "§4 The Nearest-Integer Identity on n ≥ 1",
     "content": "numDerangements_eq_round applies the rounding criterion to the strict distance bound (after abs_sub_comm and a cast normalisation) to conclude round(n!·e⁻¹) = D(n) for all n ≥ 1 — extending the sibling's n ≥ 2 identity to include the boundary index n = 1. numDerangements_eq_floor restates it in the explicit floor form D(n) = ⌊n!·e⁻¹ + 1/2⌋ by unfolding round_eq.",
-    "mathContext": "round(n!/e) = ⌊n!/e + 1/2⌋; the two forms are definitionally linked by round_eq."
+    "mathContext": "round(n!/e) = ⌊n!/e + 1/2⌋; the two forms are definitionally linked by round_eq.",
+    "significance": "key",
+    "relatedConcepts": ["nearest-integer function", "closed-form subfactorial", "floor form", "derangements"],
+    "prerequisites": ["rounding function", "combinatorics"]
   },
   {
     "id": "ann-dcoq0201-sharpness",
     "proofId": "derangements-convergence-oq-02-oq-01",
     "range": { "startLine": 131, "endLine": 152 },
-    "type": "key-step",
+    "type": "insight",
     "title": "§5 Sharpness: the Identity Fails at n = 0",
     "content": "round_factorial_exp_zero computes round(0!·e⁻¹) = round(e⁻¹) = 0 (again via the rounding criterion at m = 0, using |e⁻¹ − 0| = e⁻¹ < 1/2). numDerangements_round_ne_at_zero then observes D(0) = 1 (by rfl), so round(0!·e⁻¹) = 0 ≠ 1 = D(0): the identity is genuinely false at n = 0. This pins n ≥ 1 as the exact, optimal hypothesis — the lower endpoint cannot be weakened.",
-    "mathContext": "0!·e⁻¹ = e⁻¹ ≈ 0.3679 rounds to 0, but the empty permutation is a derangement so D(0) = 1. The universal statement 'D(n) = round(n!/e)' must start at n = 1."
+    "mathContext": "0!·e⁻¹ = e⁻¹ ≈ 0.3679 rounds to 0, but the empty permutation is a derangement so D(0) = 1. The universal statement 'D(n) = round(n!/e)' must start at n = 1.",
+    "significance": "key",
+    "relatedConcepts": ["sharpness", "empty permutation", "counterexample", "optimal hypothesis"],
+    "prerequisites": ["combinatorics", "rounding function"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `derangements-convergence-oq-02-oq-01` (the sharp nearest-integer threshold D(n) = round(n!/e) on n ≥ 1).

**Genuine gap (quality 68):** the 6 existing annotations carried `content` and `mathContext` but were **missing the required `significance`, `relatedConcepts`, and `prerequisites` fields** — the role's quality target asks for ≥5 annotations with significance + relatedConcepts. Two annotations also used a non-standard `type: "key-step"`.

## What changed
- Added `significance`, `relatedConcepts`, and `prerequisites` to **all 6** annotations
- Normalized `type: "key-step"` → `"insight"` (valid schema enum) on §3 (distance bound), §4 (identity), §5 (sharpness)
- **Content and mathContext preserved verbatim** — this is metadata completion, not rewriting

## Validation
- JSON validates; all 6 annotations now carry full metadata
- `type` values ∈ {concept, technique, insight}; `significance` ∈ {context, supporting, key}
- No meta.json changes (overview / conclusion / crossReferences already complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)