### PR TITLE
research(handshake-lemma-oq-02): Erdős–Gallai necessity — subset counting inequality [verified, 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/ErdosGallaiNecessity.lean
+++ b/proofs/Proofs/ErdosGallaiNecessity.lean
@@ -1,0 +1,145 @@
+/-
+# Erdős–Gallai: the necessity (counting) core
+
+## Problem (handshake-lemma-oq-02)
+The Erdős–Gallai theorem characterises which non-increasing sequences
+`d₁ ≥ d₂ ≥ ⋯ ≥ dₙ ≥ 0` are *graphical* (are the degree sequence of some finite
+simple graph): the sum must be even and, for every `k`,
+
+  `∑_{i≤k} dᵢ ≤ k(k-1) + ∑_{i>k} min(dᵢ, k)`.
+
+The hard direction is **sufficiency** (these inequalities let one *build* a graph,
+e.g. via a Havel–Hakimi / edge-swap argument). This file proves the **necessity**
+direction in its sharpest, sorting-free form: the inequality holds for *every*
+vertex subset `A`, not just the top-`k` by degree. Specialising `A` to the `k`
+highest-degree vertices of a graph realising a sorted sequence recovers the
+classical statement.
+
+## Main result
+`erdos_gallai_necessity` : for a finite simple graph `G` and any `A : Finset V`,
+
+  `∑_{v ∈ A} G.degree v ≤ |A|·(|A|-1) + ∑_{w ∈ Aᶜ} min (G.degree w) |A|`.
+
+The proof is the standard two-part count:
+* edges inside `A` contribute `∑_{v∈A} |N(v) ∩ A| ≤ |A|·(|A|-1)` (each vertex has
+  at most `|A|-1` neighbours inside `A`);
+* edges from `A` to its complement are counted from the `Aᶜ` side via a
+  double-counting swap, `∑_{v∈A} |N(v) ∩ Aᶜ| = ∑_{w∈Aᶜ} |N(w) ∩ A|`, and each
+  `|N(w) ∩ A| ≤ min (G.degree w) |A|`.
+
+`Even`-ness of `∑ v, G.degree v` (the other necessity condition) is the handshake
+lemma, already in the gallery (`HandshakeLemma.even_sum_degrees`).
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace ErdosGallaiNecessity
+
+open Finset SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+variable (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-- Neighbours of `v` lying inside the finset `s`. -/
+private def nbrIn (v : V) (s : Finset V) : Finset V := s.filter (fun w => G.Adj v w)
+
+/-- The degree of `v` splits as (neighbours in `A`) + (neighbours outside `A`). -/
+theorem degree_eq_nbr_add_nbr_compl (v : V) (A : Finset V) :
+    G.degree v = (nbrIn G v A).card + (nbrIn G v Aᶜ).card := by
+  classical
+  have hfilter : G.neighborFinset v = Finset.univ.filter (fun w => G.Adj v w) := by
+    ext w; simp [SimpleGraph.mem_neighborFinset]
+  have hdeg : G.degree v = (Finset.univ.filter (fun w => G.Adj v w)).card := by
+    rw [← SimpleGraph.card_neighborFinset_eq_degree, hfilter]
+  have huniv : (Finset.univ.filter (fun w => G.Adj v w))
+      = (nbrIn G v A) ∪ (nbrIn G v Aᶜ) := by
+    unfold nbrIn
+    rw [← Finset.filter_union, Finset.union_compl]
+  have hdisj : Disjoint (nbrIn G v A) (nbrIn G v Aᶜ) := by
+    unfold nbrIn
+    exact (Finset.disjoint_filter_filter (disjoint_compl_right))
+  rw [hdeg, huniv, Finset.card_union_of_disjoint hdisj]
+
+omit [Fintype V] in
+/-- A vertex `v ∈ A` has at most `|A|-1` neighbours inside `A` (it is not its own
+neighbour, so its `A`-neighbours lie in `A.erase v`). -/
+theorem card_nbrIn_le {v : V} {A : Finset V} (hv : v ∈ A) :
+    (nbrIn G v A).card ≤ A.card - 1 := by
+  classical
+  have hsub : nbrIn G v A ⊆ A.erase v := by
+    intro w hw
+    unfold nbrIn at hw
+    rw [Finset.mem_filter] at hw
+    rw [Finset.mem_erase]
+    refine ⟨?_, hw.1⟩
+    rintro rfl
+    exact (SimpleGraph.irrefl G) hw.2
+  calc (nbrIn G v A).card ≤ (A.erase v).card := Finset.card_le_card hsub
+    _ = A.card - 1 := Finset.card_erase_of_mem hv
+
+/-- Double-counting swap for the `A`–`Aᶜ` edges:
+`∑_{v∈A} |N(v) ∩ Aᶜ| = ∑_{w∈Aᶜ} |N(w) ∩ A|`. -/
+theorem sum_cross_swap (A : Finset V) :
+    ∑ v ∈ A, (nbrIn G v Aᶜ).card = ∑ w ∈ Aᶜ, (nbrIn G w A).card := by
+  classical
+  have hL : ∀ v, (nbrIn G v Aᶜ).card
+      = ∑ w ∈ Aᶜ, (if G.Adj v w then 1 else 0) := by
+    intro v; unfold nbrIn; rw [Finset.card_filter]
+  have hR : ∀ w, (nbrIn G w A).card
+      = ∑ v ∈ A, (if G.Adj w v then 1 else 0) := by
+    intro w; unfold nbrIn; rw [Finset.card_filter]
+  simp only [hL, hR]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro w _
+  apply Finset.sum_congr rfl
+  intro v _
+  simp [SimpleGraph.adj_comm]
+
+/-- **Erdős–Gallai, necessity (subset form).**
+For any finite simple graph `G` and any vertex subset `A`,
+`∑_{v∈A} deg v ≤ |A|·(|A|-1) + ∑_{w∈Aᶜ} min (deg w) |A|`.
+This is the counting inequality every graphical sequence must satisfy; taking `A`
+to be the `k` highest-degree vertices gives the classical Erdős–Gallai bound. -/
+theorem erdos_gallai_necessity (A : Finset V) :
+    ∑ v ∈ A, G.degree v
+      ≤ A.card * (A.card - 1) + ∑ w ∈ Aᶜ, min (G.degree w) A.card := by
+  classical
+  -- Split each degree into inside-A and outside-A parts.
+  have hsplit : ∑ v ∈ A, G.degree v
+      = (∑ v ∈ A, (nbrIn G v A).card) + (∑ v ∈ A, (nbrIn G v Aᶜ).card) := by
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun v _ => degree_eq_nbr_add_nbr_compl G v A)
+  -- Inside part ≤ |A|·(|A|-1).
+  have hinside : ∑ v ∈ A, (nbrIn G v A).card ≤ A.card * (A.card - 1) := by
+    calc ∑ v ∈ A, (nbrIn G v A).card
+        ≤ ∑ _v ∈ A, (A.card - 1) := Finset.sum_le_sum (fun v hv => card_nbrIn_le G hv)
+      _ = A.card * (A.card - 1) := by rw [Finset.sum_const, smul_eq_mul]
+  -- Cross part = ∑_{w∈Aᶜ} |N(w)∩A| ≤ ∑_{w∈Aᶜ} min (deg w) |A|.
+  have hcross : ∑ v ∈ A, (nbrIn G v Aᶜ).card ≤ ∑ w ∈ Aᶜ, min (G.degree w) A.card := by
+    rw [sum_cross_swap G A]
+    apply Finset.sum_le_sum
+    intro w _
+    apply le_min
+    · -- |N(w) ∩ A| ≤ deg w
+      have : nbrIn G w A ⊆ G.neighborFinset w := by
+        intro x hx
+        unfold nbrIn at hx
+        rw [Finset.mem_filter] at hx
+        rw [SimpleGraph.mem_neighborFinset]
+        exact hx.2
+      calc (nbrIn G w A).card ≤ (G.neighborFinset w).card := Finset.card_le_card this
+        _ = G.degree w := SimpleGraph.card_neighborFinset_eq_degree G w
+    · -- |N(w) ∩ A| ≤ |A|
+      have : nbrIn G w A ⊆ A := by
+        intro x hx; unfold nbrIn at hx; exact (Finset.mem_filter.mp hx).1
+      exact Finset.card_le_card this
+  rw [hsplit]
+  omega
+
+-- Axiom audit: only the foundational propext / Classical.choice / Quot.sound.
+-- No sorryAx, no Lean.ofReduceBool.
+#print axioms erdos_gallai_necessity
+
+end ErdosGallaiNecessity

--- a/src/data/proofs/handshake-lemma-oq-02/meta.json
+++ b/src/data/proofs/handshake-lemma-oq-02/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "handshake-lemma-oq-02",
+  "title": "Erdős–Gallai Necessity: the Subset Counting Inequality for Graphical Sequences",
+  "slug": "handshake-lemma-oq-02",
+  "description": "The Erdős–Gallai theorem (1960) characterises which non-increasing sequences d₁ ≥ ⋯ ≥ dₙ are graphical (realised as the degree sequence of a finite simple graph): the sum must be even and, for every k, ∑_{i≤k} dᵢ ≤ k(k−1) + ∑_{i>k} min(dᵢ, k). The parity condition is exactly the handshake lemma (parent entry handshake-lemma). This entry formalises the necessity of the inequality family in its sharpest, sorting-free form: for ANY finite simple graph G and ANY vertex subset A, ∑_{v∈A} G.degree v ≤ |A|·(|A|−1) + ∑_{w∈Aᶜ} min(G.degree w, |A|). Specialising A to the k highest-degree vertices of a graph realising a sorted sequence recovers the classical indexed inequality, so this is precisely the necessity content of Erdős–Gallai with the order-statistics bookkeeping stripped away. The proof is the standard two-part double count: edges inside A contribute ∑_{v∈A}|N(v)∩A| ≤ |A|(|A|−1) (loopless graph, each vertex has ≤ |A|−1 neighbours in A), and the A–Aᶜ edges are counted from the complement side via an adjacency-symmetry swap ∑_{v∈A}|N(v)∩Aᶜ| = ∑_{w∈Aᶜ}|N(w)∩A|, with each |N(w)∩A| ≤ min(deg w, |A|). Mathlib contains no Erdős–Gallai theorem, so this is a genuine new formalisation. Verified, 0 axioms, 0 sorries, no native_decide. It is Milestone 1 of the full theorem; the sufficiency direction (inequalities + parity ⟹ a graph exists, constructively via Havel–Hakimi / edge swaps) remains open.",
+  "meta": {
+    "author": "Paul Erdős, Tibor Gallai (1960); necessity core formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93Gallai_theorem",
+    "date": "1960",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosGallaiNecessity.lean",
+    "tags": [
+      "graph-theory",
+      "degree-sequence",
+      "erdos-gallai",
+      "combinatorics",
+      "double-counting",
+      "handshake-lemma"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.card_neighborFinset_eq_degree",
+        "description": "(G.neighborFinset v).card = G.degree v. Identifies the degree of a vertex with the cardinality of its neighbour finset, the starting point for splitting a degree into inside-A and outside-A neighbour counts.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "SimpleGraph.mem_neighborFinset",
+        "description": "w ∈ G.neighborFinset v ↔ G.Adj v w. Rewrites the neighbour finset as the univ-filter of the adjacency relation so it can be partitioned along a subset A and its complement.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "SimpleGraph.irrefl",
+        "description": "¬ G.Adj v v. Looplessness: a vertex is not its own neighbour, so its A-neighbours lie in A.erase v, giving the ≤ |A|−1 inside bound.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "SimpleGraph.adj_comm",
+        "description": "G.Adj v w ↔ G.Adj w v. Symmetry of adjacency powers the double-counting swap of the A–Aᶜ cross edges (counting from A equals counting from Aᶜ).",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "Finset.card_filter",
+        "description": "(s.filter p).card = ∑ x ∈ s, if p x then 1 else 0. Turns each neighbour-count into a sum of adjacency indicators so Finset.sum_comm can swap the two summation orders.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "∑_{v∈A} ∑_{w∈Aᶜ} f v w = ∑_{w∈Aᶜ} ∑_{v∈A} f v w. Interchanges the double sum of adjacency indicators, the formal heart of the cross-edge double count.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.card_union_of_disjoint",
+        "description": "Disjoint s t → (s ∪ t).card = s.card + t.card. Adds the inside-A and outside-A neighbour counts (disjoint because A and Aᶜ are disjoint) to reconstruct the full degree.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_erase_of_mem",
+        "description": "a ∈ s → (s.erase a).card = s.card − 1. Gives |A.erase v| = |A|−1, the exact bound on the number of A-internal neighbours of a vertex v ∈ A.",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "erdos_gallai_necessity: the necessity (counting) direction of the Erdős–Gallai theorem, stated in sorting-free subset form. For any finite simple graph G and any A : Finset V, ∑_{v∈A} G.degree v ≤ |A|·(|A|−1) + ∑_{w∈Aᶜ} min(G.degree w, |A|). This is exactly the top-k Erdős–Gallai inequality with A unrestricted; the classical indexed statement is the specialisation A = {k highest-degree vertices}. Mathlib has no Erdős–Gallai formalisation, so this necessity core is new.",
+      "degree_eq_nbr_add_nbr_compl: the degree-splitting identity G.degree v = |N(v)∩A| + |N(v)∩Aᶜ|, obtained by partitioning the neighbour finset (rewritten as a univ-filter of adjacency) along A and its complement and adding the disjoint cardinalities.",
+      "card_nbrIn_le: the inside bound |N(v)∩A| ≤ |A|−1 for v ∈ A, from looplessness (A-neighbours of v avoid v, so lie in A.erase v). Summed over A this yields the |A|(|A|−1) term — the edges-inside-A contribution.",
+      "sum_cross_swap: the double-counting swap ∑_{v∈A}|N(v)∩Aᶜ| = ∑_{w∈Aᶜ}|N(w)∩A|, proved by expanding each cardinality as a sum of adjacency indicators, interchanging the sums (Finset.sum_comm), and applying adjacency symmetry. This routes the A–Aᶜ cross edges through the complement, where each |N(w)∩A| ≤ min(deg w, |A|)."
+    ],
+    "dateAdded": "2026-07-05",
+    "relatedProblems": [
+      {
+        "id": "handshake-lemma",
+        "relationship": "Parent entry. The handshake lemma supplies the parity necessity condition (the degree sum is even); this entry supplies the necessity of the Erdős–Gallai inequality family, the second half of the theorem's necessity direction."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 145,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms erdos_gallai_necessity reports only the foundational propext, Classical.choice, Quot.sound — no sorryAx, no Lean.ofReduceBool. Scope: this is the NECESSITY direction of Erdős–Gallai (Milestone 1), and in the strong sorting-free subset form. The full theorem additionally requires (a) an order-statistics specialisation matching the subset inequality to the classical indexed one, and (b) the SUFFICIENCY direction (the inequalities plus even sum imply a realising graph exists), which is the hard constructive part (Havel–Hakimi / edge-swaps) and is NOT formalised here.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The handshake lemma gives the one easy necessary condition for a list of numbers to be a graph's degree sequence: the sum is even. It is far from sufficient — (3,3,1,1) sums to 8 yet no simple graph realises it. Erdős and Gallai (1960) closed the question completely: a non-increasing sequence d₁ ≥ ⋯ ≥ dₙ is graphical iff the sum is even AND, for every k, ∑_{i≤k} dᵢ ≤ k(k−1) + ∑_{i>k} min(dᵢ, k). The inequality bounds the degree mass concentrated on the k largest-degree vertices: at most k(k−1) from edges among themselves, plus at most min(dᵢ,k) from each remaining vertex. Mathlib formalises neither the theorem nor a graphical-sequence predicate. This entry contributes the necessity of the inequality family.",
+    "problemStatement": "Formalise the necessity of the Erdős–Gallai inequalities: any finite simple graph forces, on every set A of its vertices, ∑_{v∈A} deg v ≤ |A|(|A|−1) + ∑_{w∉A} min(deg w, |A|). Prove it in Lean 4 over Mathlib's SimpleGraph, in the subset-general form (no sorting), from which the classical indexed statement follows by taking A to be the top-|A| vertices by degree.",
+    "text": "Fix a finite simple graph G on vertex type V and a subset A. For v ∈ A write its degree as neighbours inside A plus neighbours outside A: deg v = |N(v)∩A| + |N(v)∩Aᶜ|. Summing over A splits ∑_{v∈A} deg v into an inside part and a cross part. Inside: each v ∈ A has ≤ |A|−1 neighbours in A (it is not its own neighbour), so the inside part is ≤ |A|(|A|−1). Cross: the A–Aᶜ edges are symmetric, so ∑_{v∈A}|N(v)∩Aᶜ| = ∑_{w∈Aᶜ}|N(w)∩A|, and each term |N(w)∩A| is at most both deg w (a subset of all of w's neighbours) and |A| (a subset of A), hence ≤ min(deg w, |A|). Adding the two bounds gives the Erdős–Gallai inequality. Choosing A to be the k vertices of largest degree makes the left side the prefix sum ∑_{i≤k} dᵢ and the right side the classical k(k−1) + ∑_{i>k} min(dᵢ,k).",
+    "proofStrategy": "Everything is finite, over ℕ, and elementary once the neighbour finset is partitioned.\n\n1. **Degree split (degree_eq_nbr_add_nbr_compl).** Rewrite G.neighborFinset v as univ.filter (G.Adj v); since univ = A ∪ Aᶜ with A, Aᶜ disjoint, filtering distributes and the cardinalities add: deg v = |N(v)∩A| + |N(v)∩Aᶜ|.\n\n2. **Inside bound (card_nbrIn_le).** For v ∈ A, N(v)∩A ⊆ A.erase v (looplessness via SimpleGraph.irrefl), so |N(v)∩A| ≤ |A.erase v| = |A|−1. Summing the constant over A gives |A|(|A|−1).\n\n3. **Cross swap (sum_cross_swap).** Expand |N(v)∩Aᶜ| = ∑_{w∈Aᶜ} 1[Adj v w] (Finset.card_filter), interchange the double sum (Finset.sum_comm), and use adjacency symmetry (adj_comm) to obtain ∑_{w∈Aᶜ}|N(w)∩A|.\n\n4. **Cross bound.** Each |N(w)∩A| ≤ deg w (subset of the full neighbour finset) and ≤ |A| (subset of A), so ≤ min(deg w, |A|) by le_min. Sum over Aᶜ.\n\n5. **Combine (erdos_gallai_necessity).** ∑_{v∈A} deg v equals inside + cross (step 1 summed); bounding inside by |A|(|A|−1) and cross by ∑_{w∈Aᶜ} min(deg w, |A|), a single omega closes the arithmetic.",
+    "keyInsights": [
+      "**Necessity needs no sorting.** The classical Erdős–Gallai inequality is stated for the top-k prefix of a sorted sequence, but the underlying fact is a statement about an arbitrary vertex subset A. Proving the subset form first cleanly separates the genuine combinatorics (a double count) from the order-statistics bookkeeping that merely matches A to the sorted prefix.",
+      "**The count is edges-inside-A plus edges-crossing.** Splitting each degree along A vs Aᶜ turns the degree sum on A into (twice the internal edges, bounded by |A|(|A|−1)) plus (the A–Aᶜ cut, counted from the complement side). The two bounds correspond exactly to the two terms k(k−1) and ∑ min(dᵢ,k).",
+      "**The min is where both viewpoints meet.** From the complement side each cross contribution |N(w)∩A| is simultaneously ≤ w's total degree and ≤ the size of A; the tighter of the two is min(deg w, |A|), which is precisely the summand in the Erdős–Gallai tail.",
+      "**Adjacency symmetry is the only nontrivial rewrite.** The cross-edge equality ∑_{v∈A}|N(v)∩Aᶜ| = ∑_{w∈Aᶜ}|N(w)∩A| is a Fubini swap of adjacency indicators; symmetry of the edge relation is what makes counting from either side give the same total."
+    ],
+    "prerequisites": [
+      "Simple graphs, vertex degrees, and neighbour finsets (Mathlib SimpleGraph)",
+      "The handshake lemma and the notion of a graphical degree sequence",
+      "Finset cardinality, filtering, and the double-counting (Fubini) principle for indicator sums",
+      "The statement of the Erdős–Gallai theorem and the role of its k-inequalities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Neighbours Inside a Subset and the Degree Split",
+      "startLine": 1,
+      "endLine": 66,
+      "mathContext": "$\\deg v = |N(v)\\cap A| + |N(v)\\cap A^c|$",
+      "summary": "Module docstring framing Erdős–Gallai and the necessity milestone, the import of Mathlib, the helper definition nbrIn (neighbours of v inside a finset s), and degree_eq_nbr_add_nbr_compl: partitioning the neighbour finset along A and its complement writes a vertex degree as inside-A plus outside-A neighbour counts."
+    },
+    {
+      "id": "bounds",
+      "title": "The Inside Bound and the Cross Double-Count",
+      "startLine": 67,
+      "endLine": 130,
+      "mathContext": "$\\sum_{v\\in A}|N(v)\\cap A|\\le |A|(|A|-1),\\quad \\sum_{v\\in A}|N(v)\\cap A^c| = \\sum_{w\\in A^c}|N(w)\\cap A|$",
+      "summary": "card_nbrIn_le bounds a vertex's A-internal neighbours by |A|−1 (looplessness), and sum_cross_swap proves the adjacency-symmetry double-count that re-expresses the A–Aᶜ cut from the complement side, where each contribution is at most min(deg w, |A|)."
+    },
+    {
+      "id": "main",
+      "title": "The Erdős–Gallai Necessity Inequality",
+      "startLine": 131,
+      "endLine": 145,
+      "mathContext": "$\\sum_{v\\in A}\\deg v \\le |A|(|A|-1) + \\sum_{w\\in A^c}\\min(\\deg w, |A|)$",
+      "summary": "erdos_gallai_necessity assembles the degree split, the inside bound, and the cross bound into the subset-general Erdős–Gallai inequality, closed by omega. A #print axioms confirms dependence only on the foundational propext / Classical.choice / Quot.sound."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "handshake-lemma",
+      "relationship": "extends",
+      "description": "The handshake lemma gives the parity necessity condition for a graphical sequence; this entry adds the necessity of the Erdős–Gallai inequality family, completing the necessity direction of the full characterisation."
+    }
+  ],
+  "conclusion": {
+    "summary": "The necessity direction of the Erdős–Gallai theorem is formalised in sorting-free subset form: every finite simple graph forces ∑_{v∈A} deg v ≤ |A|(|A|−1) + ∑_{w∉A} min(deg w, |A|) on each vertex subset A, via a two-part double count (edges inside A, plus the A–Aᶜ cut counted from the complement). Verified, 0 axioms, 0 sorries. Mathlib has no Erdős–Gallai theorem, so the result is new; it is Milestone 1 of a full formalisation.",
+    "implications": "Provides the reusable counting core of Erdős–Gallai. The subset-general statement is strictly stronger bookkeeping than the classical indexed inequality and can be specialised to the top-k vertices to recover it. The double-count pattern (split degree along a cut, bound the internal part by the clique bound, swap the cross part to the complement) is the standard route to degree-sequence inequalities.",
+    "openQuestions": [
+      "Milestone 2: introduce a monotone (sorted) realisation of a degree sequence and specialise A to the k highest-degree vertices, proving the left side equals the prefix sum ∑_{i≤k} dᵢ and the right side matches the classical tail, to obtain the indexed Erdős–Gallai inequality verbatim.",
+      "Milestone 3 (hard, open): the SUFFICIENCY direction — an even sum plus the Erdős–Gallai inequalities imply a realising simple graph exists — via a constructive Havel–Hakimi recursion or an edge-swapping / threshold-graph argument. No Mathlib support exists.",
+      "Define a Mathlib-style IsGraphical predicate on degree sequences and package both directions into the full iff characterisation."
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/ErdosGallaiNecessity.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "SimpleGraph"
+    ],
+    "namespace": "ErdosGallaiNecessity",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 4
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul; Gallai, Tibor",
+      "title": "Gráfok előírt fokszámú pontokkal (Graphs with prescribed degrees of vertices)",
+      "year": "1960",
+      "venue": "Matematikai Lapok 11, 264–274",
+      "note": "Original statement of the characterisation of graphical degree sequences whose necessity direction is formalised here."
+    },
+    {
+      "authors": "Choudum, S. A.",
+      "title": "A simple proof of the Erdős–Gallai theorem on graph sequences",
+      "year": "1986",
+      "venue": "Bulletin of the Australian Mathematical Society 33, 67–70",
+      "note": "A short modern proof; the necessity double count formalised here follows the same edges-inside / edges-crossing decomposition."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "erdos_gallai_necessity",
+      "type": "core",
+      "description": "Necessity of the Erdős–Gallai inequality in subset form: for any finite simple graph G and any vertex subset A, ∑_{v∈A} G.degree v ≤ |A|·(|A|−1) + ∑_{w∈Aᶜ} min(G.degree w, |A|).",
+      "leanType": "(A : Finset V) → ∑ v ∈ A, G.degree v ≤ A.card * (A.card - 1) + ∑ w ∈ Aᶜ, min (G.degree w) A.card"
+    },
+    {
+      "name": "degree_eq_nbr_add_nbr_compl",
+      "type": "supporting",
+      "description": "A vertex degree splits as neighbours inside A plus neighbours outside A.",
+      "leanType": "(v : V) → (A : Finset V) → G.degree v = (nbrIn G v A).card + (nbrIn G v Aᶜ).card"
+    },
+    {
+      "name": "sum_cross_swap",
+      "type": "supporting",
+      "description": "Double-counting swap of the A–Aᶜ cross edges via adjacency symmetry.",
+      "leanType": "(A : Finset V) → ∑ v ∈ A, (nbrIn G v Aᶜ).card = ∑ w ∈ Aᶜ, (nbrIn G w A).card"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Milestone 1 of formalizing the **Erdős–Gallai theorem** (which non-increasing sequences are graphical): the **necessity of the inequality family**, proved in the sharp sorting-free **subset form**.

For any finite simple graph `G` and any vertex subset `A`:

```
∑_{v∈A} G.degree v  ≤  |A|·(|A|−1)  +  ∑_{w∈Aᶜ} min(G.degree w, |A|)
```

This is exactly the classical top-`k` Erdős–Gallai inequality with `A` unrestricted; specialising `A` to the `k` highest-degree vertices of a sorted realisation recovers the indexed statement. The parity necessity condition is the parent entry's handshake lemma.

## Proof

Standard two-part double count:
- **Inside `A`:** `deg v` splits into neighbours in `A` and outside `A`; each `v∈A` has `≤ |A|−1` neighbours in `A` (looplessness ⇒ `N(v)∩A ⊆ A.erase v`), so the inside sum is `≤ |A|(|A|−1)`.
- **Cross `A`–`Aᶜ`:** the cut is symmetric, `∑_{v∈A}|N(v)∩Aᶜ| = ∑_{w∈Aᶜ}|N(w)∩A|` (adjacency-symmetry Fubini swap), and each `|N(w)∩A| ≤ min(deg w, |A|)`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ErdosGallaiNecessity` — **succeeds**, no warnings.
- `#print axioms erdos_gallai_necessity` → `[propext, Classical.choice, Quot.sound]` only. No `sorryAx`, no `Lean.ofReduceBool`.
- **0 sorries, 0 axioms, no native_decide.**
- Mathlib has no Erdős–Gallai theorem, so this necessity core is a genuine new formalisation.

## Scope / open

This is the **necessity** direction only (Milestone 1). Still open: Milestone 2 (order-statistics specialisation to the indexed inequality) and Milestone 3 (the hard **sufficiency** direction via Havel–Hakimi / edge swaps). Documented in `research/problems/handshake-lemma-oq-02/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)