### PR TITLE
Enrich Erdős–Gallai necessity (handshake-lemma-oq-02): add annotations.json

### DIFF
--- a/src/data/proofs/handshake-lemma-oq-02/annotations.json
+++ b/src/data/proofs/handshake-lemma-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "egn-ann-docstring",
+    "proofId": "handshake-lemma-oq-02",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "context",
+    "title": "Erdős–Gallai and the Necessity Milestone",
+    "content": "The module docstring frames the whole theorem and pins down exactly what this file proves. A non-increasing sequence d₁ ≥ ⋯ ≥ dₙ is graphical iff its sum is even AND it satisfies the Erdős–Gallai inequalities for every k. The even-sum condition is the handshake lemma (the parent gallery entry). The inequality family has two directions: necessity (any graph forces them) and sufficiency (they let you build a graph). Sufficiency is the hard, constructive half (Havel–Hakimi / edge swaps); this file delivers necessity, and in the strongest form — for an arbitrary vertex subset A rather than only the top-k by degree.",
+    "mathContext": "$\\sum_{i\\le k} d_i \\le k(k-1) + \\sum_{i>k}\\min(d_i,k)\\quad\\text{for all }k,\\ \\text{plus }\\textstyle\\sum_i d_i\\text{ even}$",
+    "significance": "context",
+    "relatedConcepts": ["graphical sequence", "degree sequence", "Erdős–Gallai theorem", "handshake lemma", "Havel–Hakimi algorithm"],
+    "prerequisites": ["graph degree sequences", "the statement of the Erdős–Gallai theorem"]
+  },
+  {
+    "id": "egn-ann-nbrin",
+    "proofId": "handshake-lemma-oq-02",
+    "range": { "startLine": 37, "endLine": 45 },
+    "type": "definition",
+    "title": "Neighbours Inside a Subset (nbrIn)",
+    "content": "The single definition of the file: nbrIn G v s is the finset of neighbours of v that lie in s, realised as s.filter (G.Adj v ·). This one primitive drives everything — taking s = A gives the neighbours of v inside A, and s = Aᶜ gives those outside. Working with a filtered finset (rather than the intersection N(v) ∩ s) keeps the later card_filter → sum_comm rewrite direct, since an indicator sum is exactly a filtered cardinality. The variables fix a finite vertex type V with decidable equality and a simple graph G with decidable adjacency, so all finsets and cardinalities are computable.",
+    "mathContext": "$N(v)\\cap s = \\{\\,w\\in s : v\\sim w\\,\\}$",
+    "significance": "supporting",
+    "relatedConcepts": ["neighbour finset", "Finset.filter", "adjacency relation", "decidable adjacency"],
+    "prerequisites": ["Finset.filter", "simple graphs in Mathlib"]
+  },
+  {
+    "id": "egn-ann-degree-split",
+    "proofId": "handshake-lemma-oq-02",
+    "range": { "startLine": 47, "endLine": 62 },
+    "type": "technique",
+    "title": "Splitting a Degree Along a Cut",
+    "content": "degree_eq_nbr_add_nbr_compl writes deg v as (neighbours in A) + (neighbours in Aᶜ). The proof rewrites the neighbour finset as the univ-filter of the adjacency relation, then uses univ = A ∪ Aᶜ with A, Aᶜ disjoint to distribute the filter (filter_union) and add the disjoint cardinalities (card_union_of_disjoint). This is the elementary but essential first move: it converts a global quantity (the degree) into a piece measured against the subset A. Summed over A it separates the degree mass into an inside-A part and a cross-cut part — the two terms that become k(k−1) and ∑ min(dᵢ,k).",
+    "mathContext": "$\\deg v = |N(v)\\cap A| + |N(v)\\cap A^{c}|,\\qquad U = A \\sqcup A^{c}$",
+    "significance": "key",
+    "relatedConcepts": ["disjoint union", "Finset.card_union_of_disjoint", "filter_union", "neighbourFinset as univ-filter", "double counting"],
+    "prerequisites": ["Finset cardinality of disjoint unions", "complement of a finset"]
+  },
+  {
+    "id": "egn-ann-inside-bound",
+    "proofId": "handshake-lemma-oq-02",
+    "range": { "startLine": 65, "endLine": 79 },
+    "type": "insight",
+    "title": "The Inside Bound from Looplessness",
+    "content": "card_nbrIn_le bounds a vertex's A-internal neighbours by |A|−1. The key fact is looplessness (SimpleGraph.irrefl: no vertex is its own neighbour), so the A-neighbours of v ∈ A avoid v itself and hence lie in A.erase v; card_erase_of_mem gives |A.erase v| = |A|−1. Summing this constant bound over the |A| vertices of A yields |A|(|A|−1) — exactly the clique-edge term k(k−1) in Erdős–Gallai, which counts (twice) the maximum number of edges internal to a set of |A| vertices. The `omit [Fintype V]` marks that this lemma needs no finiteness of the whole vertex type, only of A.",
+    "mathContext": "$v\\in A \\Rightarrow N(v)\\cap A \\subseteq A\\setminus\\{v\\},\\quad |N(v)\\cap A|\\le |A|-1,\\quad \\sum_{v\\in A}(|A|-1)=|A|(|A|-1)$",
+    "significance": "key",
+    "relatedConcepts": ["looplessness / irreflexivity", "Finset.erase", "clique edge count", "Finset.sum_const", "monotonicity of card under ⊆"],
+    "prerequisites": ["simple graph irreflexivity", "Finset.card_erase_of_mem"]
+  },
+  {
+    "id": "egn-ann-cross-swap",
+    "proofId": "handshake-lemma-oq-02",
+    "range": { "startLine": 81, "endLine": 98 },
+    "type": "technique",
+    "title": "The Double-Counting Swap (Fubini for Adjacency)",
+    "content": "sum_cross_swap is the combinatorial heart: it re-routes the A→Aᶜ edges to be counted from the complement side, ∑_{v∈A}|N(v)∩Aᶜ| = ∑_{w∈Aᶜ}|N(w)∩A|. Each cardinality is first expanded as a sum of adjacency indicators (Finset.card_filter turns |s.filter p| into ∑ 1[p]); Finset.sum_comm interchanges the two summations (the discrete Fubini step); and adjacency symmetry (adj_comm: v∼w ↔ w∼v) matches the two indicator matrices. This is the only place where the *symmetry* of a simple graph's edge relation is genuinely used — it is what makes counting a cut from either side give the same total.",
+    "mathContext": "$\\sum_{v\\in A}\\sum_{w\\in A^{c}} \\mathbf{1}[v\\sim w] \\;=\\; \\sum_{w\\in A^{c}}\\sum_{v\\in A} \\mathbf{1}[w\\sim v]$",
+    "significance": "key",
+    "relatedConcepts": ["double counting", "Fubini / Finset.sum_comm", "Finset.card_filter", "adjacency symmetry", "indicator sums", "bipartite cut"],
+    "prerequisites": ["interchanging finite double sums", "indicator function of a predicate", "symmetry of graph adjacency"]
+  },
+  {
+    "id": "egn-ann-main",
+    "proofId": "handshake-lemma-oq-02",
+    "range": { "startLine": 100, "endLine": 145 },
+    "type": "concept",
+    "title": "Assembling the Necessity Inequality (and the Axiom Audit)",
+    "content": "erdos_gallai_necessity combines the three lemmas. hsplit sums the degree split over A; hinside bounds the internal part by |A|(|A|−1); hcross applies the swap and then bounds each complement term by min(deg w, |A|) via le_min — because N(w)∩A is a subset both of all of w's neighbours (giving ≤ deg w) and of A itself (giving ≤ |A|). With the sum written as inside + cross and both parts bounded, a single `omega` discharges the final natural-number arithmetic. Taking A to be the k highest-degree vertices specialises the left side to the prefix sum ∑_{i≤k} dᵢ and the right side to the classical tail, recovering the indexed Erdős–Gallai inequality. The closing #print axioms confirms the proof rests only on the three foundational axioms propext / Classical.choice / Quot.sound — no sorryAx and no Lean.ofReduceBool — so the 'verified, 0 axioms, 0 sorries' claim is honest and needs no native_decide.",
+    "mathContext": "$\\sum_{v\\in A}\\deg v \\le |A|(|A|-1) + \\sum_{w\\in A^{c}}\\min(\\deg w, |A|)$",
+    "significance": "key",
+    "relatedConcepts": ["le_min", "Finset.sum_le_sum", "subset-general form", "order statistics specialisation", "omega decision procedure", "axiom audit"],
+    "prerequisites": ["min as a greatest lower bound (le_min)", "monotonicity of finite sums", "the prefix-sum reading of Erdős–Gallai"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for **handshake-lemma-oq-02** (Erdős–Gallai necessity, subset-counting inequality).

**Gap:** the entry had a comprehensive `meta.json` (overview, sections, conclusion, cross-references, main theorems) but **no `annotations.json` at all** — the primary driver of its low quality score (39, 0 passes).

**Added:** a new `annotations.json` with **6 inline annotations** covering the full Lean file (lines 1–145), each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. Module docstring — Erdős–Gallai framing and the necessity milestone
2. `nbrIn` definition — neighbours inside a subset
3. `degree_eq_nbr_add_nbr_compl` — splitting a degree along the A / Aᶜ cut
4. `card_nbrIn_le` — the inside bound |A|−1 from looplessness
5. `sum_cross_swap` — the double-counting (Fubini) swap via adjacency symmetry
6. `erdos_gallai_necessity` — assembling the inequality + the axiom audit

All annotations anchor cleanly to Lean constructs (`scripts/annotations/build.ts` reports 0 errors for this entry). `meta.json` is unchanged (already within size caps). Axiom claims (0 axioms / 0 sorries / no native_decide) verified against the source.
