### PR TITLE
research(antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01): generalizedEuler(1/x) = Euler–Mascheroni constant γ [0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01.lean
+++ b/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01.lean
@@ -1,0 +1,95 @@
+/-
+  Antitone integral–sum comparison — OQ-01-OQ-02-OQ-02-OQ-01:
+  identifying the generalized Euler constant of `1/x` with the Euler–Mascheroni constant `γ`.
+
+  The parent thread (`AntitoneIntegralSumComparisonOQ01OQ02OQ02`) builds, for an antitone
+  nonnegative summand `f` on `[1, ∞)`, the **generalized Euler constant**
+
+      `generalizedEuler f := ⨆ n, defect f n`,   `defect f n := ∑_{i<n} f(1+i) − ∫₁^{1+n} f`,
+
+  and proves its abstract properties: the defect is monotone, bounded by `f 1`, and converges
+  to `generalizedEuler f` (`tendsto_defect`). That is a *gap constant* attached to any such `f`,
+  with no claim about its value. This file pins the value in the archetypal case `f = 1/x`:
+
+      `generalizedEuler (fun x => 1/x) = Real.eulerMascheroniConstant`.
+
+  The identification is exact and 0-axiom. For `f = 1/x` the defect is, term for term,
+  Mathlib's Euler–Mascheroni sequence:
+
+      `defect (1/·) n = ∑_{i<n} 1/(1+i) − ∫₁^{1+n} 1/x = harmonic n − log (n+1)`,
+
+  using `harmonic n = ∑_{i<n} (i+1)⁻¹` and `∫₁^{1+n} x⁻¹ = log((1+n)/1) = log(n+1)`
+  (`integral_one_div_of_pos`). Both `defect (1/·)` (via the parent's `tendsto_defect`) and
+  `n ↦ harmonic n − log (n+1)` (via Mathlib's `Real.tendsto_harmonic_sub_log_add_one`) converge,
+  the latter to `γ`; since they are the *same* sequence, uniqueness of limits
+  (`tendsto_nhds_unique`) forces `generalizedEuler (1/·) = γ`.
+
+  This turns the parent's abstract enclosure `generalizedEuler (1/·) ∈ [0, 1]` into the sharp
+  value `γ ≈ 0.5772…`, and connects the bespoke gap-constant construction to Mathlib's canonical
+  Euler–Mascheroni development.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+-/
+
+import Mathlib
+import Proofs.AntitoneIntegralSumComparisonOQ01OQ02OQ02
+
+namespace AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01
+
+open Finset Filter Topology MeasureTheory intervalIntegral Real
+
+/-- `fun x => 1/x` is antitone on `[1, ∞)` (indeed on the positive reals). -/
+theorem antitoneOn_one_div : AntitoneOn (fun x => 1 / x) (Set.Ici (1 : ℝ)) := by
+  intro a ha b _ hab
+  simp only [Set.mem_Ici] at ha
+  exact one_div_le_one_div_of_le (by linarith) hab
+
+/-- `fun x => 1/x` is nonnegative on `[1, ∞)`. -/
+theorem one_div_nonneg_on (x : ℝ) (hx : (1 : ℝ) ≤ x) : 0 ≤ (fun x => 1 / x) x := by
+  simp only
+  positivity
+
+/-- **The `1/x` defect is exactly the Euler–Mascheroni sequence.**  Term for term,
+`defect (1/·) n = harmonic n − log (n+1)`: the Riemann sum `∑_{i<n} 1/(1+i)` is `harmonic n`,
+and the integral `∫₁^{1+n} 1/x` is `log (n+1)`. -/
+theorem defect_one_div_eq (n : ℕ) :
+    AntitoneIntegralSumComparisonOQ01OQ02OQ02.defect (fun x => 1 / x) n
+      = (harmonic n : ℝ) - Real.log ((n : ℝ) + 1) := by
+  simp only [AntitoneIntegralSumComparisonOQ01OQ02OQ02.defect]
+  have hsum : ∑ i ∈ Finset.range n, 1 / (1 + (i : ℝ)) = (harmonic n : ℝ) := by
+    rw [harmonic]
+    push_cast
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [one_div, add_comm]
+  have hint : (∫ x in (1 : ℝ)..(1 + (n : ℝ)), 1 / x) = Real.log ((n : ℝ) + 1) := by
+    rw [integral_one_div_of_pos (by norm_num) (by positivity), div_one, add_comm]
+  rw [hsum, hint]
+
+/-- **Main identification.**  The generalized Euler constant of the harmonic summand `1/x`
+equals the Euler–Mascheroni constant `γ`.
+
+`defect (1/·)` converges to `generalizedEuler (1/·)` (parent `tendsto_defect`, from antitonicity
+and nonnegativity), and — being termwise equal to `harmonic n − log (n+1)` — it also converges
+to `γ` (`Real.tendsto_harmonic_sub_log_add_one`).  Uniqueness of limits identifies the two. -/
+theorem generalizedEuler_one_div_eq_eulerMascheroniConstant :
+    AntitoneIntegralSumComparisonOQ01OQ02OQ02.generalizedEuler (fun x => 1 / x)
+      = Real.eulerMascheroniConstant := by
+  have h1 := AntitoneIntegralSumComparisonOQ01OQ02OQ02.tendsto_defect
+    antitoneOn_one_div one_div_nonneg_on
+  rw [show AntitoneIntegralSumComparisonOQ01OQ02OQ02.defect (fun x => 1 / x)
+        = (fun n => (harmonic n : ℝ) - Real.log ((n : ℝ) + 1)) from funext defect_one_div_eq] at h1
+  exact tendsto_nhds_unique h1 Real.tendsto_harmonic_sub_log_add_one
+
+/-- **Sharp enclosure, as a corollary.**  The parent's abstract bound
+`generalizedEuler (1/·) ∈ [0, 1]` (`f 1 = 1`) is now pinned to the value `γ ∈ (1/2, 2/3)`. -/
+theorem generalizedEuler_one_div_mem_Ioo :
+    AntitoneIntegralSumComparisonOQ01OQ02OQ02.generalizedEuler (fun x => 1 / x)
+      ∈ Set.Ioo (1 / 2 : ℝ) (2 / 3) := by
+  rw [generalizedEuler_one_div_eq_eulerMascheroniConstant]
+  exact ⟨Real.one_half_lt_eulerMascheroniConstant, Real.eulerMascheroniConstant_lt_two_thirds⟩
+
+end AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01
+
+#print axioms
+  AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01.generalizedEuler_one_div_eq_eulerMascheroniConstant
+#print axioms AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01.generalizedEuler_one_div_mem_Ioo

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-antitoneoq02020q01-context",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "Pinning the abstract generalized Euler constant at f = 1/x",
+    "content": "The parent (antitone-integral-sum-comparison-oq-01-oq-02-oq-02) attaches to every antitone nonnegative summand f on [1, ∞) an abstract constant generalizedEuler f := ⨆ n, defect f n, where defect f n := ∑_{i<n} f(1+i) − ∫₁^{1+n} f is the Riemann-sum-minus-integral gap, and proves only the enclosure generalizedEuler f ∈ [0, f 1] — nothing about its value. This file identifies the value in the archetypal harmonic case: generalizedEuler (fun x => 1/x) = Real.eulerMascheroniConstant, the classical γ ≈ 0.5772…, connecting the bespoke construction to Mathlib's canonical Euler–Mascheroni development.",
+    "mathContext": "$\\mathrm{generalizedEuler}(1/\\cdot)=\\gamma$, where $\\gamma$ is Mathlib's $\\mathrm{Real.eulerMascheroniConstant}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler–Mascheroni constant", "generalized Euler constant", "integral test", "harmonic numbers", "abstract vs concrete constant"],
+    "prerequisites": ["the parent generalizedEuler construction", "the Euler–Mascheroni constant γ", "convergence of the defect sequence"]
+  },
+  {
+    "id": "ann-antitoneoq02020q01-hyps",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 42, "endLine": 53 },
+    "type": "tactic",
+    "title": "The two hypotheses tendsto_defect needs",
+    "content": "antitoneOn_one_div proves 1/x is antitone on [1, ∞) via one_div_le_one_div_of_le (needing 0 < a from 1 ≤ a). one_div_nonneg_on proves 1/x ≥ 0 on [1, ∞) by positivity. These feed the parent's tendsto_defect, whose conclusion Tendsto (defect (1/·)) atTop (𝓝 (generalizedEuler (1/·))) is half of the uniqueness-of-limits argument.",
+    "mathContext": "$1/x$ is antitone and $\\ge 0$ on $[1,\\infty)$ — exactly the hypotheses of the parent bounded-monotone convergence theorem.",
+    "significance": "supporting",
+    "relatedConcepts": ["AntitoneOn", "one_div_le_one_div_of_le", "positivity", "hypotheses of tendsto_defect"],
+    "prerequisites": ["monotonicity of x ↦ 1/x on positives", "the parent convergence theorem's signature"]
+  },
+  {
+    "id": "ann-antitoneoq02020q01-defect",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 55, "endLine": 72 },
+    "type": "insight",
+    "title": "The 1/x defect is termwise the Euler–Mascheroni sequence",
+    "content": "defect_one_div_eq proves defect (1/·) n = harmonic n − log(n+1) as an exact termwise identity, not up to o(1). The right-open Riemann sum ∑_{i∈range n} 1/(1+i) equals (harmonic n : ℝ) — rw [harmonic] (harmonic n = ∑_{i<n} (i+1)⁻¹), push_cast, and a per-term one_div / add_comm. The integral ∫₁^{1+n} 1/x equals log(n+1) via integral_one_div_of_pos (0<1) (0<1+n) = log((1+n)/1), then div_one and add_comm. The right-open sum (indices 1..n) is what makes the sum harmonic n on the nose, and the endpoint 1+n is what makes the integral log(n+1) — matching Mathlib's Hₙ − log(n+1) normalization.",
+    "mathContext": "$\\mathrm{defect}(1/\\cdot)\\,n=\\sum_{i<n}\\tfrac1{1+i}-\\int_1^{1+n}\\tfrac1x=H_n-\\log(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["harmonic numbers", "integral_one_div_of_pos", "right-open Riemann sum", "push_cast", "termwise identity"],
+    "prerequisites": ["definition of harmonic", "∫ 1/x = log", "casting ℚ harmonic to ℝ"]
+  },
+  {
+    "id": "ann-antitoneoq02020q01-identify",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 74, "endLine": 95 },
+    "type": "insight",
+    "title": "Identification by uniqueness of limits, and the sharp enclosure",
+    "content": "generalizedEuler_one_div_eq_eulerMascheroniConstant: tendsto_defect antitoneOn_one_div one_div_nonneg_on gives Tendsto (defect (1/·)) atTop (𝓝 (generalizedEuler (1/·))); rewriting defect (1/·) to fun n => harmonic n − log(n+1) (funext defect_one_div_eq) makes it literally the sequence of Real.tendsto_harmonic_sub_log_add_one (→ γ), so tendsto_nhds_unique equates the two limits: generalizedEuler (1/·) = γ. Because the sequences are equal (not merely asymptotic), no squeeze or error estimate is needed. generalizedEuler_one_div_mem_Ioo then sharpens the parent's crude [0, 1] enclosure to γ ∈ (1/2, 2/3) using Mathlib's numeric bounds. #print axioms confirms only propext / Classical.choice / Quot.sound.",
+    "mathContext": "$\\mathrm{generalizedEuler}(1/\\cdot)=\\gamma\\in(\\tfrac12,\\tfrac23)$ by $\\mathrm{tendsto\\_nhds\\_unique}$.",
+    "significance": "key",
+    "relatedConcepts": ["tendsto_nhds_unique", "Real.tendsto_harmonic_sub_log_add_one", "uniqueness of limits", "eulerMascheroniConstant bounds", "value identification"],
+    "prerequisites": ["the parent tendsto_defect", "Mathlib's sequence convergence to γ", "Hausdorff uniqueness of limits"]
+  }
+]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/index.ts
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const antitoneIntegralSumComparisonOq01Oq02Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const antitoneIntegralSumComparisonOq01Oq02Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const antitoneIntegralSumComparisonOq01Oq02Oq02Oq01Data: ProofData = {
+  proof: antitoneIntegralSumComparisonOq01Oq02Oq02Oq01Proof,
+  annotations: antitoneIntegralSumComparisonOq01Oq02Oq02Oq01Annotations,
+}

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
+  "title": "The Generalized Euler Constant of 1/x is the Euler–Mascheroni Constant",
+  "slug": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
+  "description": "The parent entry (antitone-integral-sum-comparison-oq-01-oq-02-oq-02) attaches to every antitone nonnegative summand f on [1, ∞) an abstract 'generalized Euler constant' generalizedEuler f := ⨆ n, defect f n, where defect f n := ∑_{i<n} f(1+i) − ∫₁^{1+n} f is the excess of the right-open Riemann sum over the integral; it proves this defect is monotone, bounded by f 1, and convergent (tendsto_defect), but says nothing about its value. This entry pins the value in the archetypal case f = 1/x: generalizedEuler (fun x => 1/x) = Real.eulerMascheroniConstant. The identification is exact and 0-axiom. For f = 1/x the defect is, term for term, Mathlib's Euler–Mascheroni sequence: ∑_{i<n} 1/(1+i) = harmonic n and ∫₁^{1+n} 1/x = log((1+n)/1) = log(n+1) (integral_one_div_of_pos), so defect (1/·) n = harmonic n − log(n+1). Both defect (1/·) (via the parent's tendsto_defect, from antitonicity and nonnegativity) and n ↦ harmonic n − log(n+1) (via Mathlib's Real.tendsto_harmonic_sub_log_add_one) converge, the latter to γ; being the same sequence, uniqueness of limits (tendsto_nhds_unique) forces generalizedEuler (1/·) = γ. A corollary sharpens the parent's abstract enclosure [0, 1] to the value γ ∈ (1/2, 2/3). 5 theorems, 0 axioms, 0 sorries, verified.",
+  "leanFile": {
+    "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01.lean",
+    "namespace": "AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01",
+    "imports": [
+      "Mathlib",
+      "Proofs.AntitoneIntegralSumComparisonOQ01OQ02OQ02"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology",
+      "MeasureTheory",
+      "intervalIntegral",
+      "Real"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 95,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "openQuestion": {
+    "id": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
+    "parentId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+    "question": "The parent constructs, for any antitone nonnegative summand f on [1, ∞), the abstract generalized Euler constant generalizedEuler f := ⨆ n, defect f n (the limit of the Riemann-sum-minus-integral defect), and proves only its enclosure generalizedEuler f ∈ [0, f 1] — nothing about its actual value. Pin the value in the archetypal case f = 1/x: is generalizedEuler (fun x => 1/x) equal to Mathlib's canonical Euler–Mascheroni constant Real.eulerMascheroniConstant, and can that be proved 0-axiom?",
+    "answer": "Yes. For f = 1/x the defect is termwise Mathlib's Euler–Mascheroni sequence: the right-open Riemann sum ∑_{i<n} 1/(1+i) equals harmonic n (by the definition harmonic n = ∑_{i<n} (i+1)⁻¹), and the integral ∫₁^{1+n} 1/x equals log((1+n)/1) = log(n+1) (integral_one_div_of_pos), so defect (1/·) n = harmonic n − log(n+1). The parent's tendsto_defect (needing antitoneOn_one_div and 1/x ≥ 0 on [1,∞)) gives defect (1/·) → generalizedEuler (1/·); Mathlib's Real.tendsto_harmonic_sub_log_add_one gives the same sequence → γ. tendsto_nhds_unique identifies the two: generalizedEuler (fun x => 1/x) = Real.eulerMascheroniConstant. As a corollary the parent's abstract enclosure [0, 1] is sharpened to γ ∈ (1/2, 2/3) via Mathlib's one_half_lt/lt_two_thirds bounds. Fully machine-checked, 0 axioms (#print axioms shows only propext / Classical.choice / Quot.sound)."
+  },
+  "highlights": [
+    "generalizedEuler (fun x => 1/x) = Real.eulerMascheroniConstant: the parent's abstract gap constant for the harmonic summand IS the Euler–Mascheroni constant γ",
+    "defect_one_div_eq: the 1/x defect is termwise harmonic n − log(n+1) — Riemann sum = harmonic n, integral = log(n+1) (integral_one_div_of_pos)",
+    "Proof by uniqueness of limits: parent tendsto_defect and Mathlib Real.tendsto_harmonic_sub_log_add_one converge the SAME sequence, so tendsto_nhds_unique equates the limits",
+    "Sharpens the parent's abstract enclosure generalizedEuler (1/·) ∈ [0, 1] to the value γ ∈ (1/2, 2/3)",
+    "Connects the bespoke ⨆-of-defects construction to Mathlib's canonical Euler–Mascheroni development; 0 axioms"
+  ],
+  "assumptions": [],
+  "implications": [
+    {
+      "statement": "For f = 1/x the defect ∑_{i<n} 1/(1+i) − ∫₁^{1+n} 1/x equals harmonic n − log(n+1)",
+      "type": "theorem"
+    },
+    {
+      "statement": "generalizedEuler (fun x => 1/x) = Real.eulerMascheroniConstant (γ)",
+      "type": "theorem"
+    },
+    {
+      "statement": "generalizedEuler (fun x => 1/x) ∈ (1/2, 2/3)",
+      "type": "theorem"
+    }
+  ],
+  "overview": {
+    "historicalContext": "This closes a loop opened several levels up in the antitone integral–sum comparison thread. The grandparent antitone-integral-sum-comparison-oq-01-oq-02 re-exported Mathlib's sequence convergence Hₙ − log(n+1) → γ; the parent antitone-integral-sum-comparison-oq-01-oq-02-oq-02 then generalized the *construction*, attaching to ANY antitone nonnegative f the constant generalizedEuler f := ⨆ n, defect f n and proving its abstract enclosure [0, f 1], but deliberately leaving its value unidentified. The Euler–Mascheroni constant γ ≈ 0.5772… (the limit of Hₙ − log n, whose irrationality is famously open) is the value of exactly this construction at the harmonic summand f = 1/x. This entry supplies that identification, tying the bespoke general construction back to Mathlib's canonical Real.eulerMascheroniConstant.",
+    "problemStatement": "Show that the parent's abstract generalized Euler constant of the harmonic summand, generalizedEuler (fun x => 1/x) = ⨆ n, (∑_{i<n} 1/(1+i) − ∫₁^{1+n} 1/x), equals Mathlib's Euler–Mascheroni constant Real.eulerMascheroniConstant, at 0 axioms.",
+    "proofStrategy": "Two ingredients. (1) defect_one_div_eq: unfold the parent's defect at f = 1/x; the Riemann sum ∑_{i∈range n} 1/(1+i) equals (harmonic n : ℝ) after rw [harmonic]; push_cast and a per-term one_div / add_comm; the integral ∫₁^{1+n} 1/x equals log(n+1) by integral_one_div_of_pos (0<1) (0<1+n) then div_one and add_comm. Hence defect (1/·) n = harmonic n − log(n+1) pointwise. (2) The identification: antitoneOn_one_div (via one_div_le_one_div_of_le) and one_div_nonneg_on (positivity) feed the parent's tendsto_defect to get Tendsto (defect (1/·)) atTop (𝓝 (generalizedEuler (1/·))); rewrite defect (1/·) to the harmonic-minus-log sequence by funext defect_one_div_eq; this is exactly the sequence of Mathlib's Real.tendsto_harmonic_sub_log_add_one (→ γ), so tendsto_nhds_unique yields generalizedEuler (1/·) = γ. The Ioo corollary rewrites by the identification and applies Real.one_half_lt_eulerMascheroniConstant and Real.eulerMascheroniConstant_lt_two_thirds.",
+    "keyInsights": [
+      "The parent's abstract construction was engineered so that the harmonic case reproduces the classical Euler–Mascheroni sequence exactly, not merely up to an o(1) error: defect (1/·) n = harmonic n − log(n+1) is a termwise identity, so no limit comparison or squeeze is needed — the two convergent sequences are literally equal and uniqueness of limits does all the work.",
+      "The right-open Riemann sum ∑_{i<n} f(1+i) is what makes the sum equal harmonic n on the nose (indices 1..n), and the integral endpoint 1+n is what makes the integral log(n+1) rather than log n — matching Mathlib's Hₙ − log(n+1) normalization rather than the textbook Hₙ − log n (both converge to the same γ since log(n+1) − log n → 0).",
+      "This is a value identification, not a new convergence result: the convergence of defect (1/·) is the parent's bounded-monotone theorem and the convergence to γ is Mathlib's; the contribution is the bridge that forces them to be the same number.",
+      "The corollary shows the payoff of pinning the value: the parent could only bound generalizedEuler (1/·) ∈ [0, 1] (the crude f 1 = 1 enclosure), whereas the identification imports Mathlib's sharp γ ∈ (1/2, 2/3) for free."
+    ],
+    "prerequisites": [
+      "Parent: antitone-integral-sum-comparison-oq-01-oq-02-oq-02 (defect, generalizedEuler, tendsto_defect)",
+      "Mathlib: Real.eulerMascheroniConstant, Real.tendsto_harmonic_sub_log_add_one, harmonic, integral_one_div_of_pos, one_div_le_one_div_of_le, tendsto_nhds_unique",
+      "Mathlib bounds: Real.one_half_lt_eulerMascheroniConstant, Real.eulerMascheroniConstant_lt_two_thirds"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Roadmap and Imports",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "The doc-comment recalls the parent's abstract generalizedEuler f := ⨆ n, defect f n and states the goal: pin its value at f = 1/x to Mathlib's Euler–Mascheroni constant. Imports Mathlib and the parent file, opens the analysis namespaces plus Real.",
+      "mathContext": "$\\mathrm{generalizedEuler}\\,f:=\\bigsqcup_n\\big(\\sum_{i<n}f(1+i)-\\int_1^{1+n}f\\big)$; here evaluated at $f=1/x$."
+    },
+    {
+      "id": "hypotheses",
+      "title": "Antitonicity and Nonnegativity of 1/x",
+      "startLine": 42,
+      "endLine": 53,
+      "summary": "antitoneOn_one_div: 1/x is antitone on [1, ∞) via one_div_le_one_div_of_le. one_div_nonneg_on: 1/x ≥ 0 on [1, ∞) via positivity. These are the two hypotheses the parent's tendsto_defect requires.",
+      "mathContext": "$1/x$ antitone and nonnegative on $[1,\\infty)$ — the hypotheses of the parent convergence theorem."
+    },
+    {
+      "id": "defect",
+      "title": "The 1/x Defect is the Euler–Mascheroni Sequence",
+      "startLine": 55,
+      "endLine": 72,
+      "summary": "defect_one_div_eq: defect (1/·) n = harmonic n − log(n+1) termwise. The sum ∑_{i<n} 1/(1+i) equals harmonic n (rw [harmonic]; push_cast; per-term one_div / add_comm); the integral ∫₁^{1+n} 1/x equals log(n+1) (integral_one_div_of_pos, div_one, add_comm).",
+      "mathContext": "$\\mathrm{defect}(1/\\cdot)\\,n=\\sum_{i<n}\\tfrac1{1+i}-\\int_1^{1+n}\\tfrac1x=H_n-\\log(n+1)$."
+    },
+    {
+      "id": "identify",
+      "title": "The Identification and Sharp Enclosure",
+      "startLine": 74,
+      "endLine": 95,
+      "summary": "generalizedEuler_one_div_eq_eulerMascheroniConstant: feed the two hypotheses to tendsto_defect, rewrite the defect to the harmonic-minus-log sequence (funext defect_one_div_eq), and apply tendsto_nhds_unique against Real.tendsto_harmonic_sub_log_add_one to get generalizedEuler (1/·) = γ. generalizedEuler_one_div_mem_Ioo sharpens the parent's [0,1] enclosure to γ ∈ (1/2, 2/3). #print axioms confirms only propext / Classical.choice / Quot.sound.",
+      "mathContext": "$\\mathrm{generalizedEuler}(1/\\cdot)=\\gamma\\in(\\tfrac12,\\tfrac23)$; $\\#\\mathrm{print\\ axioms}=\\{\\mathrm{propext},\\mathrm{Classical.choice},\\mathrm{Quot.sound}\\}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Identifies the parent's abstract generalized Euler constant of the harmonic summand with Mathlib's Euler–Mascheroni constant: generalizedEuler (fun x => 1/x) = Real.eulerMascheroniConstant. The proof shows defect (1/·) n = harmonic n − log(n+1) termwise and applies uniqueness of limits to the parent's tendsto_defect and Mathlib's tendsto_harmonic_sub_log_add_one; a corollary sharpens the enclosure to γ ∈ (1/2, 2/3). 5 theorems, 0 axioms, 0 sorries.",
+    "implications": "The bespoke ⨆-of-defects construction is now anchored to a named classical constant, so all of Mathlib's knowledge about γ (its numeric bounds; future irrationality results) transfers to generalizedEuler (1/·). The general-antitone constant remains a genuine generalization whose values at other f are still open to identification.",
+    "openQuestions": [
+      "Identify generalizedEuler f for other explicit antitone summands (e.g. f = 1/x^s, giving generalized Stieltjes / zeta-related constants).",
+      "Give an effective error term |defect (1/·) n − γ| = Θ(1/n), refining the bare convergence into a rate."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02",
+      "relationship": "parent",
+      "description": "Parent: defines the abstract generalizedEuler f := ⨆ n, defect f n for antitone nonnegative f and proves its enclosure [0, f 1] and convergence tendsto_defect, leaving the value unidentified. This entry pins the value at f = 1/x."
+    },
+    {
+      "targetId": "antitone-integral-sum-comparison-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Grandparent: re-exports Mathlib's Hₙ − log(n+1) → γ sequence convergence, the classical fact this entry connects to the abstract constant."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lagarias, J. C.",
+      "title": "Euler's constant: Euler's work and modern developments",
+      "year": "2013",
+      "note": "Survey of γ and generalized Euler constants."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026-07-05",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "euler-mascheroni",
+      "integral-test",
+      "generalized-euler-constant",
+      "convergence",
+      "harmonic-numbers",
+      "mathlib"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.eulerMascheroniConstant",
+        "description": "The Euler–Mascheroni constant γ, defined as limUnder atTop eulerMascheroniSeq",
+        "module": "Mathlib.NumberTheory.Harmonic.EulerMascheroni"
+      },
+      {
+        "theorem": "Real.tendsto_harmonic_sub_log_add_one",
+        "description": "harmonic n − log (n+1) → γ",
+        "module": "Mathlib.NumberTheory.Harmonic.EulerMascheroni"
+      },
+      {
+        "theorem": "integral_one_div_of_pos",
+        "description": "∫ x in a..b, 1/x = log (b/a) for 0 < a, 0 < b",
+        "module": "Mathlib.Analysis.SpecialFunctions.Integrals.Basic"
+      },
+      {
+        "theorem": "harmonic",
+        "description": "harmonic n = ∑ i ∈ range n, (i+1)⁻¹ (the nth harmonic number)",
+        "module": "Mathlib.NumberTheory.Harmonic.Defs"
+      },
+      {
+        "theorem": "tendsto_nhds_unique",
+        "description": "A sequence has at most one limit in a Hausdorff space",
+        "module": "Mathlib.Topology.Separation.Basic"
+      }
+    ],
+    "originalContributions": [
+      "generalizedEuler_one_div_eq_eulerMascheroniConstant: the parent's abstract generalized Euler constant of 1/x equals Real.eulerMascheroniConstant",
+      "defect_one_div_eq: the 1/x defect equals harmonic n − log(n+1) termwise (Riemann sum = harmonic n, integral = log(n+1))",
+      "generalizedEuler_one_div_mem_Ioo: sharpens the parent's [0,1] enclosure to γ ∈ (1/2, 2/3)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 95,
+    "assumptions": "0 axioms. Imports the verified parent (defect, generalizedEuler, tendsto_defect) and standard Mathlib (Real.eulerMascheroniConstant, Real.tendsto_harmonic_sub_log_add_one, harmonic, integral_one_div_of_pos, one_div_le_one_div_of_le, tendsto_nhds_unique). #print axioms shows only propext / Classical.choice / Quot.sound.",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Identifying the generalized Euler constant of 1/x with γ

**Problem:** `antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01` (fresh, EMPTY tier). "Identify `generalizedEuler (fun x => 1/x)` with the Euler–Mascheroni constant."

The parent (`…-oq-02-oq-02`) attaches to every antitone nonnegative summand `f` on `[1,∞)` an abstract **generalized Euler constant** `generalizedEuler f := ⨆ n, defect f n`, where `defect f n := ∑_{i<n} f(1+i) − ∫₁^{1+n} f`, and proves only its enclosure `∈ [0, f 1]` — **nothing about its value**. This entry pins the value at the archetypal harmonic summand:

```
generalizedEuler (fun x => 1/x) = Real.eulerMascheroniConstant
```

### Proof (`Proofs/AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01.lean`, 0-axiom, 0-sorry)

- **`defect_one_div_eq`** — the `1/x` defect is *termwise* Mathlib's Euler–Mascheroni sequence: `∑_{i<n} 1/(1+i) = harmonic n` and `∫₁^{1+n} 1/x = log((1+n)/1) = log(n+1)` (`integral_one_div_of_pos`), so `defect (1/·) n = harmonic n − log(n+1)`.
- **`generalizedEuler_one_div_eq_eulerMascheroniConstant`** — the parent's `tendsto_defect` (fed `antitoneOn_one_div` + nonnegativity) and Mathlib's `Real.tendsto_harmonic_sub_log_add_one` converge the **same** sequence; `tendsto_nhds_unique` equates the limits. Because the sequences are *equal*, not merely asymptotic, no squeeze is needed.
- **`generalizedEuler_one_div_mem_Ioo`** — sharpens the parent's crude `[0, 1]` enclosure to `γ ∈ (1/2, 2/3)`.

### Significance (honest scope)

A **value identification**, not a new convergence result: the two convergences are the parent's and Mathlib's; the contribution is the bridge that forces them to be the same number, anchoring the bespoke `⨆`-of-defects construction to Mathlib's canonical `Real.eulerMascheroniConstant`. No overlap with the grandparent (`…-oq-01-oq-02`), which only re-exports Mathlib's sequence convergence and never touches the abstract `generalizedEuler`.

### Verification

`#print axioms` on both headline theorems: `[propext, Classical.choice, Quot.sound]` only. Built via `./proofs/scripts/docker-build.sh Proofs.AntitoneIntegralSumComparisonOQ01OQ02OQ02OQ01` — succeeds, no warnings. Gallery entry: `meta.json` + 4 annotations + cross-refs to the parent thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)