### PR TITLE
research(pythagorean-triples-oq-07-oq-01): even leg divisible by 4 [verified, 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ07OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ07OQ01.lean
@@ -1,0 +1,133 @@
+/-
+The Even Leg of a Primitive Pythagorean Triple is Divisible by 4
+
+Source: Open question (oq-07-oq-01) refining the parity dichotomy of
+        pythagorean-triples-oq-07.
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The parent result (PythagoreanTriplesOQ07) shows that in a primitive Pythagorean
+triple exactly one leg is even. This file strengthens that: the even leg is not
+merely even, it is divisible by 4.
+
+The arithmetic heart is a mod-8 refinement of the parent's mod-4 fact:
+
+  * An ODD integer squared is `1 mod 8` (not just `1 mod 4`).
+    Reason: (2k+1)² = 4k(k+1) + 1, and k(k+1) is even, so 4k(k+1) ≡ 0 mod 8.
+
+In a primitive triple with even leg `x` (so `y`, `z` odd), the Pythagorean
+relation gives `x² = z² − y² ≡ 1 − 1 = 0 (mod 8)`. An even number whose square
+is `0 mod 8` must itself be `0 mod 4`: writing `x = 2k`, `x² = 4k² ≡ 0 mod 8`
+forces `k` even, i.e. `4 ∣ x`.
+
+Equivalently, in the Euclid parametrisation `x = 2mn` (even leg), `y = m²−n²`,
+`z = m²+n²` with `m, n` of opposite parity, `mn` is even, so `4 ∣ 2mn`. The
+proof below is parametrisation-free and works directly from the triple relation.
+-/
+
+import Mathlib
+
+namespace PythagoreanTriplesEvenLegDivFour
+
+open PythagoreanTriple
+
+variable {x y z : ℤ}
+
+/-! ## Part I: The mod-8 obstruction
+
+The sharper arithmetic fact behind divisibility by 4: an odd integer squared is
+`1 mod 8`. This upgrades the parent file's `sq_emod_four_of_odd`. -/
+
+/-- An odd integer squared is `1 mod 8`. -/
+theorem sq_emod_eight_of_odd {a : ℤ} (ha : a % 2 = 1) : a * a % 8 = 1 := by
+  obtain ⟨k, rfl⟩ := Int.odd_iff.mpr ha
+  -- k(k+1) is even: two consecutive integers, one is even.
+  obtain ⟨m, hm⟩ := Int.even_mul_succ_self k
+  have h : (2 * k + 1) * (2 * k + 1) = 4 * (k * (k + 1)) + 1 := by ring
+  omega
+
+/-! ## Part II: An even square that is `0 mod 8` gives a factor of 4
+
+If `x` is even and `x² ≡ 0 (mod 8)`, then `4 ∣ x`. -/
+
+/-- If an even integer's square is `0 mod 8`, the integer is divisible by `4`. -/
+theorem four_dvd_of_even_sq_emod_eight {a : ℤ} (ha : a % 2 = 0)
+    (h8 : a * a % 8 = 0) : 4 ∣ a := by
+  obtain ⟨k, rfl⟩ := Int.even_iff.mpr ha
+  -- (k+k)² = 4k², and 4k² ≡ 0 mod 8 forces k even.
+  have hsq : (k + k) * (k + k) = 4 * (k * k) := by ring
+  have hkk : k * k % 2 = 0 := by omega
+  -- k*k even ⇒ k even
+  have hke : Even k := by
+    have he2 : Even (k * k) := Int.even_iff.mpr hkk
+    rcases Int.even_mul.mp he2 with hk | hk <;> exact hk
+  obtain ⟨j, rfl⟩ := hke
+  -- a = (j+j)+(j+j) = 4j
+  exact ⟨j, by ring⟩
+
+/-! ## Part III: In a primitive triple the even leg's square is `0 mod 8`
+
+If `x` is the even leg (so, by coprimality, `y` is odd and hence `z` is odd),
+then `x² = z² − y² ≡ 1 − 1 = 0 (mod 8)`. -/
+
+/-- In a primitive triple with even leg `x`, the odd companion leg `y` and the
+hypotenuse `z` are both odd, so `x² ≡ 0 (mod 8)`. -/
+theorem even_leg_sq_emod_eight (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1)
+    (hx : x % 2 = 0) : x * x % 8 = 0 := by
+  have he : x * x + y * y = z * z := h
+  -- Coprimality forces the other leg odd.
+  have hy : y % 2 = 1 := by
+    rcases h.even_odd_of_coprime hc with ⟨_, hy1⟩ | ⟨hx1, _⟩
+    · exact hy1
+    · omega
+  -- The hypotenuse is odd: z² = x² + y² ≡ 0 + 1 = 1 mod 4, so z is odd.
+  have hz : z % 2 = 1 := by
+    have hx4 : x * x % 4 = 0 := by
+      obtain ⟨k, rfl⟩ := Int.even_iff.mpr hx
+      have : (k + k) * (k + k) = 4 * (k * k) := by ring
+      omega
+    have hy4 : y * y % 4 = 1 := by
+      obtain ⟨k, rfl⟩ := Int.odd_iff.mpr hy
+      have : (2 * k + 1) * (2 * k + 1) = 4 * (k * k + k) + 1 := by ring
+      omega
+    rcases Int.emod_two_eq_zero_or_one z with hz0 | hz1
+    · exfalso
+      obtain ⟨k, rfl⟩ := Int.even_iff.mpr hz0
+      have : (k + k) * (k + k) = 4 * (k * k) := by ring
+      omega
+    · exact hz1
+  -- odd squares are 1 mod 8; combine.
+  have hyy := sq_emod_eight_of_odd hy
+  have hzz := sq_emod_eight_of_odd hz
+  omega
+
+/-! ## Part IV: The even leg is divisible by 4 -/
+
+/-- If `x` is the even leg of a primitive triple, then `4 ∣ x`. -/
+theorem four_dvd_of_even_leg (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1)
+    (hx : x % 2 = 0) : 4 ∣ x :=
+  four_dvd_of_even_sq_emod_eight hx (even_leg_sq_emod_eight h hc hx)
+
+/-- **Main theorem.** In a primitive Pythagorean triple, exactly one leg is even
+and that leg is divisible by `4`: either `4 ∣ x` (with `y` odd), or `4 ∣ y`
+(with `x` odd). -/
+theorem four_dvd_even_leg (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    (4 ∣ x ∧ y % 2 = 1) ∨ (x % 2 = 1 ∧ 4 ∣ y) := by
+  rcases h.even_odd_of_coprime hc with ⟨hx, hy⟩ | ⟨hx, hy⟩
+  · exact Or.inl ⟨four_dvd_of_even_leg h hc hx, hy⟩
+  · -- swap to the symmetric triple y x z to reuse the even-leg lemma
+    have h' : PythagoreanTriple y x z := by
+      have he : x * x + y * y = z * z := h
+      show y * y + x * x = z * z
+      linarith
+    have hc' : Int.gcd y x = 1 := by rwa [Int.gcd_comm] at hc
+    exact Or.inr ⟨hx, four_dvd_of_even_leg h' hc' hy⟩
+
+/-- **Even/Odd packaging.** The even leg of a primitive triple is a multiple of
+`4`. -/
+theorem four_dvd_even_leg' (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    (4 ∣ x ∧ Odd y) ∨ (Odd x ∧ 4 ∣ y) := by
+  rcases four_dvd_even_leg h hc with ⟨hx, hy⟩ | ⟨hx, hy⟩
+  · exact Or.inl ⟨hx, Int.odd_iff.mpr hy⟩
+  · exact Or.inr ⟨Int.odd_iff.mpr hx, hy⟩
+
+end PythagoreanTriplesEvenLegDivFour

--- a/src/data/proofs/pythagorean-triples-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-07-oq-01/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "ann-pythag-oq07-oq01-header",
+    "proofId": "pythagorean-triples-oq-07-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "concept",
+    "title": "File Context: Sharpening the Parity Dichotomy to Divisibility by 4",
+    "content": "The parent entry (PythagoreanTriplesOQ07) proved exactly one leg of a primitive Pythagorean triple is even. This file strengthens that: the even leg is divisible by 4. The single new arithmetic input is a mod-8 refinement of the parent's mod-4 fact — an odd square is 1 mod 8, not merely 1 mod 4.",
+    "mathContext": "In the Euclid parametrisation $x=m^2-n^2,\\ y=2mn,\\ z=m^2+n^2$ with $m,n$ of opposite parity, the even leg is $2mn$; since one of $m,n$ is even, $4 \\mid 2mn$. The proof here is parametrisation-free.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pythagorean-triples-oq-07",
+      "PythagoreanTriple",
+      "primitive triple",
+      "modular arithmetic mod 8"
+    ],
+    "prerequisites": [
+      "PythagoreanTriplesOQ07 parity dichotomy",
+      "residues mod 4 and mod 8",
+      "divisibility in ℤ"
+    ]
+  },
+  {
+    "id": "ann-pythag-oq07-oq01-mod8",
+    "proofId": "pythagorean-triples-oq-07-oq-01",
+    "range": { "startLine": 35, "endLine": 47 },
+    "type": "insight",
+    "title": "The mod-8 Obstruction: odd² ≡ 1 (mod 8)",
+    "content": "sq_emod_eight_of_odd is the arithmetic heart. Writing an odd integer as 2k+1, (2k+1)² = 4k(k+1)+1. Because k(k+1) is the product of two consecutive integers it is even (Int.even_mul_succ_self), so 4k(k+1) ≡ 0 mod 8 and the square is 1 mod 8. This one extra factor of 2 over the parent's mod-4 fact is exactly what promotes 'even leg' to 'divisible by 4'.",
+    "mathContext": "$(2k+1)^2 = 4k(k+1)+1$ and $2 \\mid k(k+1) \\Rightarrow (2k+1)^2 \\equiv 1 \\pmod 8$. omega closes the goal once k(k+1)=2m is supplied.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Int.even_mul_succ_self",
+      "consecutive integers",
+      "quadratic residues mod 8"
+    ],
+    "prerequisites": [
+      "Int.odd_iff",
+      "product of consecutive integers is even"
+    ]
+  },
+  {
+    "id": "ann-pythag-oq07-oq01-even-sq-four",
+    "proofId": "pythagorean-triples-oq-07-oq-01",
+    "range": { "startLine": 48, "endLine": 66 },
+    "type": "insight",
+    "title": "Even Square 0 mod 8 ⇒ Divisible by 4",
+    "content": "four_dvd_of_even_sq_emod_eight is the converse-flavoured step. If a = 2k and a² = 4k² ≡ 0 mod 8, then k² is even, hence k is even (Int.even_mul), so a = 2k is a multiple of 4. This lemma is stated abstractly (no triple) and is reusable wherever an even square is known to vanish mod 8.",
+    "mathContext": "$a=2k,\\ 4k^2 \\equiv 0 \\pmod 8 \\Rightarrow k^2 \\text{ even} \\Rightarrow k \\text{ even} \\Rightarrow 4 \\mid a$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Int.even_mul",
+      "Int.even_iff",
+      "2-adic valuation"
+    ],
+    "prerequisites": [
+      "even times even reasoning",
+      "k² even ⇒ k even"
+    ]
+  },
+  {
+    "id": "ann-pythag-oq07-oq01-even-leg-sq",
+    "proofId": "pythagorean-triples-oq-07-oq-01",
+    "range": { "startLine": 67, "endLine": 102 },
+    "type": "proof-step",
+    "title": "The Even Leg's Square is 0 mod 8",
+    "content": "even_leg_sq_emod_eight assembles the ingredients. Given the even leg x, coprimality forces the companion leg y odd (even_odd_of_coprime), and a short mod-4 computation forces the hypotenuse z odd. Then both y² and z² are 1 mod 8, so x² = z² − y² ≡ 0 mod 8.",
+    "mathContext": "$y,z$ odd $\\Rightarrow y^2 \\equiv z^2 \\equiv 1 \\pmod 8 \\Rightarrow x^2 = z^2 - y^2 \\equiv 0 \\pmod 8$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "PythagoreanTriple.even_odd_of_coprime",
+      "hypotenuse is odd",
+      "residue cancellation"
+    ],
+    "prerequisites": [
+      "parity dichotomy",
+      "sq_emod_eight_of_odd"
+    ]
+  },
+  {
+    "id": "ann-pythag-oq07-oq01-main",
+    "proofId": "pythagorean-triples-oq-07-oq-01",
+    "range": { "startLine": 103, "endLine": 133 },
+    "type": "concept",
+    "title": "Main Theorem and the Symmetric-Triple Reduction",
+    "content": "four_dvd_of_even_leg combines the two lemmas: the even leg is divisible by 4. The two-sided main theorem four_dvd_even_leg handles both which-leg-is-even cases; the case where y is even is reduced to the case where x is even by passing to the symmetric triple y x z (a Pythagorean triple whenever x y z is, with the same coprimality), so no proof is duplicated. four_dvd_even_leg' repackages in Even/Odd form.",
+    "mathContext": "$(4 \\mid x \\wedge y \\text{ odd}) \\vee (x \\text{ odd} \\wedge 4 \\mid y)$; the triple $x^2+y^2=z^2$ is symmetric in the legs, so $y\\,x\\,z$ is again Pythagorean.",
+    "significance": "central",
+    "relatedConcepts": [
+      "symmetry of Pythagorean triples",
+      "Int.gcd_comm",
+      "case reduction"
+    ],
+    "prerequisites": [
+      "four_dvd_of_even_leg",
+      "commutativity of gcd"
+    ]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-07-oq-01/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-07-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ07OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOq07Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOq07Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOq07Oq01Data: ProofData = {
+  proof: pythagoreanTriplesOq07Oq01Proof,
+  annotations: pythagoreanTriplesOq07Oq01Annotations,
+}

--- a/src/data/proofs/pythagorean-triples-oq-07-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-07-oq-01/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "pythagorean-triples-oq-07-oq-01",
+  "title": "The Even Leg of a Primitive Pythagorean Triple is Divisible by 4",
+  "slug": "pythagorean-triples-oq-07-oq-01",
+  "description": "The parity dichotomy (oq-07) says exactly one leg of a primitive Pythagorean triple x²+y²=z² is even. This entry sharpens that: the even leg is divisible by 4. The core is a mod-8 refinement — an odd square is 1 mod 8, so the even leg's square is z²−y² ≡ 1−1 = 0 mod 8, forcing the even leg ≡ 0 mod 4. Equivalently 4 ∣ 2mn in the Euclid parametrisation, since m,n have opposite parity.",
+  "meta": {
+    "author": "researcher-5 (Lean Genius)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ07OQ01.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "parity",
+      "modular-arithmetic",
+      "diophantine",
+      "divisibility"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-05",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "PythagoreanTriple.even_odd_of_coprime",
+        "description": "For coprime legs, exactly one leg is even (x%2=0 ∧ y%2=1) ∨ (x%2=1 ∧ y%2=0)",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "Int.even_mul_succ_self",
+        "description": "Even (n * (n+1)): the product of two consecutive integers is even",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Int.even_mul",
+        "description": "Even (m * n) ↔ Even m ∨ Even n",
+        "module": "Mathlib.Algebra.Group.Int.Even"
+      },
+      {
+        "theorem": "Int.odd_iff",
+        "description": "Odd n ↔ n % 2 = 1",
+        "module": "Mathlib.Algebra.Ring.Int.Parity"
+      },
+      {
+        "theorem": "Int.even_iff",
+        "description": "Even n ↔ n % 2 = 0",
+        "module": "Mathlib.Algebra.Group.Int.Even"
+      }
+    ],
+    "originalContributions": [
+      "sq_emod_eight_of_odd: an odd integer squared is 1 mod 8 — the mod-8 sharpening of the parent's mod-4 fact, via (2k+1)² = 4k(k+1)+1 with k(k+1) even",
+      "four_dvd_of_even_sq_emod_eight: an even integer whose square is 0 mod 8 is divisible by 4 (k*k even ⇒ k even)",
+      "even_leg_sq_emod_eight: in a primitive triple with even leg x, both y and z are odd, so x² = z²−y² ≡ 0 mod 8",
+      "four_dvd_of_even_leg: the even leg of a primitive triple is divisible by 4",
+      "four_dvd_even_leg: main theorem — (4 ∣ x ∧ y odd) ∨ (x odd ∧ 4 ∣ y), reducing the second case to the first by the symmetric triple y x z",
+      "four_dvd_even_leg': Even/Odd packaging of the main theorem"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 133,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "In the Euclid parametrisation of a primitive Pythagorean triple, x = m²−n², y = 2mn, z = m²+n² with m > n coprime and of opposite parity, the even leg is 2mn. Because m and n have opposite parity, exactly one of them is even, so mn is even and the even leg 2mn is a multiple of 4. This '÷4' refinement of the parity dichotomy is a standard fact used, for instance, in the descent proof of Fermat's Last Theorem for n=4 and in counting primitive triples below a bound. The parent entry (oq-07) machine-checked that exactly one leg is even; its own open-question list asked precisely for this next layer — that the even leg is divisible by 4.",
+    "problemStatement": "The parity dichotomy shows one leg is even. Can we machine-check the sharper statement that the even leg is always divisible by 4?\n\n**Answer: Yes.** An odd square is 1 mod 8, so the even leg's square is z²−y² ≡ 0 mod 8, and an even integer with square 0 mod 8 is divisible by 4.",
+    "text": "The even leg of a primitive Pythagorean triple is not merely even but a multiple of 4 — a mod-8 refinement of the parity dichotomy.",
+    "proofStrategy": "Upgrade the parent's mod-4 residue fact to mod 8: an odd integer squared is 1 mod 8 (write (2k+1)² = 4k(k+1)+1 and use that k(k+1) is even). For a primitive triple with even leg x, coprimality makes the other leg y odd and a short mod-4 computation makes the hypotenuse z odd; then x² = z²−y² ≡ 1−1 = 0 mod 8. Finally, an even integer whose square is 0 mod 8 must be divisible by 4 (writing x = 2k, x² = 4k² ≡ 0 mod 8 forces k even). The two-sided main theorem reduces the case 'y is the even leg' to 'x is the even leg' by passing to the symmetric triple y x z.",
+    "keyInsights": [
+      "The whole strengthening comes from one residue upgrade: odd² is 1 mod 8, not just 1 mod 4 — the extra factor of 2 is exactly what promotes 'even leg' to 'divisible by 4'",
+      "k(k+1) even (two consecutive integers) is the arithmetic reason (2k+1)² = 4k(k+1)+1 ≡ 1 mod 8",
+      "The hypotenuse being odd is needed so that both y² and z² contribute residue 1 mod 8 and cancel, leaving x² ≡ 0 mod 8",
+      "An even integer with square ≡ 0 mod 8 is divisible by 4: x = 2k gives 4k² ≡ 0 mod 8, so k² is even, so k is even — this is a clean converse-flavoured lemma reusable elsewhere",
+      "The symmetric-triple trick (y x z is a Pythagorean triple whenever x y z is) removes all duplicate case work, so only the single even-leg lemma carries content"
+    ],
+    "prerequisites": [
+      "Modular arithmetic (residues mod 4 and mod 8)",
+      "Parity of integers and divisibility",
+      "Pythagorean triples and primitivity (coprime legs)",
+      "The parity dichotomy for primitive triples (pythagorean-triples-oq-07)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "mod-eight",
+      "title": "The mod-8 Obstruction",
+      "startLine": 35,
+      "endLine": 47,
+      "summary": "An odd integer squared is 1 mod 8 — the sharpening of the parent's 1-mod-4 fact.",
+      "mathContext": "$a$ odd $\\Rightarrow a^2 = 4k(k+1)+1 \\equiv 1 \\pmod 8$, since $k(k+1)$ is even."
+    },
+    {
+      "id": "even-sq-to-four",
+      "title": "Even Square 0 mod 8 Gives a Factor of 4",
+      "startLine": 48,
+      "endLine": 66,
+      "summary": "If an even integer's square is 0 mod 8, the integer is divisible by 4.",
+      "mathContext": "$a=2k,\\ a^2=4k^2\\equiv 0\\pmod 8 \\Rightarrow k$ even $\\Rightarrow 4 \\mid a$."
+    },
+    {
+      "id": "even-leg-sq",
+      "title": "The Even Leg's Square is 0 mod 8",
+      "startLine": 67,
+      "endLine": 102,
+      "summary": "In a primitive triple with even leg x, the companion leg and hypotenuse are odd, so x² ≡ 0 mod 8.",
+      "mathContext": "$y,z$ odd $\\Rightarrow x^2 = z^2 - y^2 \\equiv 1 - 1 = 0 \\pmod 8$."
+    },
+    {
+      "id": "main",
+      "title": "The Even Leg is Divisible by 4",
+      "startLine": 103,
+      "endLine": 133,
+      "summary": "Main theorem in mod-2 and Even/Odd forms: the even leg is a multiple of 4, via the symmetric-triple reduction.",
+      "mathContext": "$(4 \\mid x \\wedge y \\text{ odd}) \\vee (x \\text{ odd} \\wedge 4 \\mid y)$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Euclid",
+      "title": "Elements, Book X",
+      "year": "c. 300 BCE",
+      "note": "Classical parametrisation of Pythagorean triples"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "note": "Primitive-triple parametrisation; the even leg 2mn is divisible by 4"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples-oq-07",
+      "relationship": "extends",
+      "description": "Sharpens the parity dichotomy: oq-07 shows exactly one leg is even; this entry shows that even leg is divisible by 4. Directly answers oq-07's first listed open question."
+    },
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "related",
+      "description": "Refines the structure of the classical parametrisation, where the even leg 2mn is a multiple of 4 because m, n have opposite parity."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-06",
+      "relationship": "related",
+      "description": "Companion entry on the coprime-parameter classification (m²−n², 2mn, m²+n²); the 4 ∣ 2mn fact proved here is the divisibility content of that even leg."
+    }
+  ],
+  "conclusion": {
+    "summary": "The even leg of a primitive Pythagorean triple is divisible by 4, machine-checked with 0 axioms and 0 sorries. The proof upgrades the parent's mod-4 residue fact to mod 8 (odd² ≡ 1 mod 8), giving even leg² ≡ 0 mod 8 and hence 4 ∣ even leg.",
+    "implications": "Completes the elementary parity/divisibility layer of the primitive-triple structure: one leg is odd, one is ≡ 0 mod 4, and the hypotenuse is odd. This 4 ∣ 2mn fact is a standard ingredient in the infinite-descent proof of Fermat's Last Theorem for n=4 and in asymptotics for the count of primitive triples.",
+    "openQuestions": [
+      "Can the residue structure be pushed further — e.g. that in a primitive triple exactly one leg is divisible by 3 and exactly one of the three quantities (legs and hypotenuse) is divisible by 5, giving the classical '60 ∣ xyz' divisibility?",
+      "Does the mod-8 lemma odd² ≡ 1 mod 8 package into a clean Lean characterisation of the 2-adic valuation of the even leg (v₂(2mn) = 1 + v₂(mn)) across all primitive triples?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "PythagoreanTriple"
+    ],
+    "namespace": "PythagoreanTriplesEvenLegDivFour",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTriplesOQ07OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes and verifies the follow-up open question **oq-07-oq-01** to the parity dichotomy (`pythagorean-triples-oq-07`): in a primitive Pythagorean triple the even leg is not merely even but **divisible by 4**. This directly answers the first open question listed in the parent entry's `conclusion.openQuestions`.

## Mathematical content

The parent proved *exactly one leg is even* using the fact that an odd square is `1 mod 4`. This entry sharpens the residue analysis to **mod 8**:

- `sq_emod_eight_of_odd`: an odd integer squared is `1 mod 8`, via `(2k+1)² = 4k(k+1)+1` with `k(k+1)` even (`Int.even_mul_succ_self`).
- `four_dvd_of_even_sq_emod_eight`: an even integer whose square is `0 mod 8` is divisible by 4 (`a = 2k`, `4k² ≡ 0 mod 8 ⇒ k` even).
- `even_leg_sq_emod_eight`: for the even leg `x` (with `y, z` odd by coprimality), `x² = z² − y² ≡ 1 − 1 = 0 mod 8`.
- `four_dvd_even_leg` (main): `(4 ∣ x ∧ y odd) ∨ (x odd ∧ 4 ∣ y)`. The `y`-even case reduces to the `x`-even case via the symmetric triple `y x z`, so no case work is duplicated.

Equivalently `4 ∣ 2mn` in the Euclid parametrisation, since `m, n` have opposite parity.

## Verification

- `proofs/Proofs/PythagoreanTriplesOQ07OQ01.lean` — 6 theorems, 133 lines
- **0 sorries, 0 axiom declarations, no `native_decide`** — builds clean under the Docker wrapper (`Proofs.PythagoreanTriplesOQ07OQ01`, 3.3s)
- Depends only on standard Mathlib lemmas and the foundational axioms `propext` / `Classical.choice` / `Quot.sound`

## Gallery entry

`src/data/proofs/pythagorean-triples-oq-07-oq-01/` — meta.json, annotations.json (5 annotations), index.ts. Registered in listings/manifest via `pnpm annotations:build` (validates clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)