### PR TITLE
Research: fermat-prime-exponent-oq-01 — Fermat prime exponents are powers of two [verified, 0 sorry/0 axiom]

### DIFF
--- a/proofs/Proofs/FermatPrimeExponent.lean
+++ b/proofs/Proofs/FermatPrimeExponent.lean
@@ -1,0 +1,148 @@
+import Mathlib
+
+/-
+# Fermat Prime Exponents Are Powers of Two
+
+## Open Question (mersenne-prime-exponent-oq-01)
+
+A **Fermat number** is a number of the form `2^n + 1`.  The famous Fermat primes
+`3 = 2^1 + 1`, `5 = 2^2 + 1`, `17 = 2^4 + 1`, `257 = 2^8 + 1`, `65537 = 2^16 + 1`
+all have exponents that are powers of two (`1, 2, 4, 8, 16, …`), and this is no
+accident:
+
+    If `2^n + 1` is prime and `n ≥ 1`, then `n` is a power of two.
+
+This is the exact analogue, for the `+1` (Fermat) family, of the classical
+necessary condition on Mersenne exponents (`2^n − 1` prime ⇒ `n` prime) proved in
+`MersennePrimeExponent.lean`.  Whereas a *composite* exponent kills a Mersenne
+number through a **proper-divisor** factor `2^d − 1`, a Fermat number is killed by
+any **odd** factor `d > 1` of the exponent, through the proper divisor `2^m + 1`
+(where `n = d·m`).  Hence the surviving exponents are precisely those with no odd
+factor larger than `1` — the powers of two.
+
+The hypothesis `n ≥ 1` is genuinely needed: `2^0 + 1 = 2` is prime, yet `0` is not
+a power of two.  It is the sole exception, so the full statement reads
+"`n = 0` or `n` is a power of two".
+
+## Proof
+
+The engine is the elementary divisibility
+
+    `d` odd  ⇒  `a + 1 ∣ a^d + 1`,
+
+proved over `ℤ` from `a + 1 = a − (−1)` and `a^d + 1 = a^d − (−1)^d` (using
+`(−1)^d = −1` for odd `d`) together with `x − y ∣ x^n − y^n`, then transferred back
+to `ℕ`.
+
+Given a Fermat prime `2^n + 1` with `n ≥ 1`, suppose `d ∣ n` is odd with `d > 1`
+and write `n = d·m` (so `m ≥ 1`).  With `a = 2^m` we have
+`2^n + 1 = a^d + 1`, and the divisibility above makes `a + 1 = 2^m + 1` a divisor.
+Primality forces `2^m + 1 = 1` (impossible, `2^m ≥ 1`) or `2^m + 1 = 2^n + 1`,
+i.e. `2^m = 2^n`, i.e. `m = n` by injectivity of `d ↦ 2^d` — contradicting
+`m < n` (which holds because `d ≥ 2`, `m ≥ 1`).  So the only odd divisor of `n`
+is `1`, and a positive natural whose odd part is `1` is a power of two.
+
+Fully machine-checked and self-contained (0 sorries, 0 axioms beyond Mathlib's
+foundations).
+-/
+
+namespace FermatPrimeExponent
+
+/-- **Odd exponents preserve `a + 1` divisibility.**  For every natural `a` and
+every odd `d`, `a + 1` divides `a ^ d + 1`.  (Proved over `ℤ` via
+`x − y ∣ x^n − y^n` with `y = −1`, then cast back to `ℕ`.) -/
+theorem add_one_dvd_pow_add_one_of_odd (a : ℕ) {d : ℕ} (hd : Odd d) :
+    a + 1 ∣ a ^ d + 1 := by
+  -- Work over ℤ, where `a + 1 = a - (-1)` and `a^d + 1 = a^d - (-1)^d`.
+  have hz : ((a : ℤ) + 1) ∣ ((a : ℤ) ^ d + 1) := by
+    have h1 : ((a : ℤ) + 1) = (a : ℤ) - (-1) := by ring
+    have h2 : ((a : ℤ) ^ d + 1) = (a : ℤ) ^ d - (-1) ^ d := by
+      rw [hd.neg_one_pow]; ring
+    rw [h1, h2]
+    exact sub_dvd_pow_sub_pow (a : ℤ) (-1) d
+  -- Transfer the divisibility back to ℕ.
+  have hcast : (((a + 1 : ℕ) : ℤ)) ∣ (((a ^ d + 1 : ℕ) : ℤ)) := by
+    push_cast; exact hz
+  exact_mod_cast hcast
+
+/-- **Core dichotomy.**  If `2 ^ n + 1` is prime and `n ≥ 1`, then every odd
+divisor of `n` equals `1`.  (An odd `d > 1` would make `2^{n/d} + 1` a proper
+divisor of `2 ^ n + 1`.) -/
+theorem odd_divisor_eq_one {n : ℕ} (hn : 0 < n) (hp : Nat.Prime (2 ^ n + 1)) :
+    ∀ d, d ∣ n → Odd d → d = 1 := by
+  intro d hdn hodd
+  by_contra hd1
+  -- An odd `d ≠ 1` is at least `3`, in particular `2 ≤ d`.
+  have hd2 : 2 ≤ d := by
+    rcases hodd with ⟨t, rfl⟩; omega
+  -- Write `n = d * m`.
+  obtain ⟨m, rfl⟩ := hdn
+  have hm : 0 < m := by
+    rcases Nat.eq_zero_or_pos m with h | h
+    · simp [h] at hn
+    · exact h
+  -- `2 ^ (d*m) + 1 = (2^m) ^ d + 1`, so `2^m + 1` divides it (d odd).
+  have hrw : (2 : ℕ) ^ (d * m) + 1 = (2 ^ m) ^ d + 1 := by
+    rw [← pow_mul, Nat.mul_comm m d]
+  have hdvd : (2 ^ m + 1) ∣ (2 ^ (d * m) + 1) := by
+    rw [hrw]; exact add_one_dvd_pow_add_one_of_odd (2 ^ m) hodd
+  -- Primality: the divisor `2^m + 1` is either `1` or the whole number.
+  rcases (hp.eq_one_or_self_of_dvd _ hdvd) with h1 | h2
+  · -- `2^m + 1 = 1` is impossible since `2^m ≥ 1`.
+    have : 1 ≤ 2 ^ m := Nat.one_le_pow m 2 (by norm_num)
+    omega
+  · -- `2^m + 1 = 2^(d*m) + 1` forces `m = d*m`, contradicting `d ≥ 2`, `m ≥ 1`.
+    have hpe : (2 : ℕ) ^ m = 2 ^ (d * m) := by omega
+    have hmn : m = d * m := Nat.pow_right_injective (le_refl 2) hpe
+    -- `m = d * m` with `m > 0` gives `d = 1`.
+    have : m * 1 = m * d := by rw [mul_one, mul_comm]; exact hmn
+    have hd1' : (1 : ℕ) = d := Nat.eq_of_mul_eq_mul_left hm this
+    omega
+
+/-- A positive natural whose only odd divisor is `1` is a power of two.  Proved by
+strong induction: an odd `n` is its own odd divisor (so `n = 1 = 2^0`); an even
+`n = 2m` inherits the hypothesis on `m` (odd divisors of `m` divide `n`), giving
+`m = 2^k` and hence `n = 2^{k+1}`. -/
+theorem isPowerOfTwo_of_odd_divisor_eq_one :
+    ∀ {n : ℕ}, 0 < n → (∀ d, d ∣ n → Odd d → d = 1) → ∃ k, n = 2 ^ k := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro hn h
+    rcases Nat.even_or_odd n with he | ho
+    · -- `n` even: write `n = 2 * m` and recurse on `m`.
+      obtain ⟨m, hm⟩ := he
+      have hm2 : n = 2 * m := by omega
+      have hmpos : 0 < m := by omega
+      have hmlt : m < n := by omega
+      have hmdvd : m ∣ n := ⟨2, by omega⟩
+      have hh : ∀ d, d ∣ m → Odd d → d = 1 :=
+        fun d hd hodd => h d (hd.trans hmdvd) hodd
+      obtain ⟨k, hk⟩ := ih m hmlt hmpos hh
+      exact ⟨k + 1, by rw [hm2, hk]; ring⟩
+    · -- `n` odd: `n` divides itself and is odd, so `n = 1 = 2^0`.
+      have : n = 1 := h n dvd_rfl ho
+      exact ⟨0, by simp [this]⟩
+
+/-- **Fermat prime exponents are powers of two.**  If `2 ^ n + 1` is prime and
+`n ≥ 1`, then `n = 2 ^ k` for some `k`. -/
+theorem exponent_isPowerOfTwo {n : ℕ} (hn : 0 < n) (hp : Nat.Prime (2 ^ n + 1)) :
+    ∃ k, n = 2 ^ k :=
+  isPowerOfTwo_of_odd_divisor_eq_one hn (odd_divisor_eq_one hn hp)
+
+/-- Restated as the classical "`0` or a power of two" dichotomy, dropping the
+positivity hypothesis (`2^0 + 1 = 2` is the sole prime with a non-power-of-two
+exponent). -/
+theorem exponent_zero_or_isPowerOfTwo {n : ℕ} (hp : Nat.Prime (2 ^ n + 1)) :
+    n = 0 ∨ ∃ k, n = 2 ^ k := by
+  rcases Nat.eq_zero_or_pos n with h | h
+  · exact Or.inl h
+  · exact Or.inr (exponent_isPowerOfTwo h hp)
+
+/-- Contrapositive search-pruning form: an exponent with an odd factor `> 1`
+yields a composite Fermat number. -/
+theorem not_prime_of_odd_factor {n d : ℕ} (hdn : d ∣ n) (hodd : Odd d)
+    (hd1 : 1 < d) (hn : 0 < n) : ¬ Nat.Prime (2 ^ n + 1) :=
+  fun hp => by have := odd_divisor_eq_one hn hp d hdn hodd; omega
+
+end FermatPrimeExponent

--- a/src/data/proofs/mersenne-prime-exponent-oq-01/meta.json
+++ b/src/data/proofs/mersenne-prime-exponent-oq-01/meta.json
@@ -1,0 +1,130 @@
+{
+  "id": "mersenne-prime-exponent-oq-01",
+  "title": "Fermat Prime Exponents Are Powers of Two",
+  "slug": "mersenne-prime-exponent-oq-01",
+  "description": "A fully machine-checked, self-contained proof of the classical necessary condition on Fermat primes: if the Fermat number 2^n + 1 is prime and n ≥ 1, then the exponent n is a power of two. This is the +1 analogue of the Mersenne condition (2^n − 1 prime ⇒ n prime) and is exactly the follow-up question posed by that entry. The engine is the elementary divisibility d odd ⇒ a + 1 ∣ a^d + 1, proved over ℤ from a + 1 = a − (−1) and a^d + 1 = a^d − (−1)^d (using (−1)^d = −1 for odd d) together with x − y ∣ x^n − y^n (sub_dvd_pow_sub_pow), then transferred back to ℕ. Given a Fermat prime 2^n + 1 with n ≥ 1, any odd divisor d > 1 of n, writing n = d·m, makes 2^m + 1 = a + 1 (with a = 2^m) a divisor of 2^n + 1 = a^d + 1. Primality forces 2^m + 1 = 1 (impossible) or 2^m + 1 = 2^n + 1, i.e. m = n by injectivity of d ↦ 2^d, contradicting m < n. So the only odd divisor of n is 1, and a positive natural whose odd part is 1 is a power of two — established here by a self-contained strong induction rather than the factorization API. The hypothesis n ≥ 1 is essential: 2^0 + 1 = 2 is prime yet 0 is not a power of two, the sole exception.",
+  "meta": {
+    "author": "Classical (Fermat, 1640s; the powers-of-two necessary condition for Fermat primes); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat_number",
+    "date": "1640",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fermat-primes",
+      "primality",
+      "divisibility",
+      "powers-of-two",
+      "contrapositive",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FermatPrimeExponent.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "sub_dvd_pow_sub_pow",
+        "description": "In a commutative ring, x − y ∣ x^n − y^n. The arithmetic engine: with x = a, y = −1 and n odd it yields a + 1 ∣ a^d + 1, the Fermat-side analogue of the Mersenne divisibility lift.",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      },
+      {
+        "theorem": "Odd.neg_one_pow",
+        "description": "For odd n, (−1)^n = −1. Converts a^d − (−1)^d into a^d + 1, letting the odd-exponent divisibility fall out of sub_dvd_pow_sub_pow.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.eq_one_or_self_of_dvd",
+        "description": "Every divisor of a prime is 1 or the prime itself. Applied to the divisor 2^m + 1 of the prime 2^n + 1 to force the contradiction.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.pow_right_injective",
+        "description": "For a base ≥ 2, x ↦ a^x is injective. Closes the surviving escape hatch: 2^m = 2^n forces m = n, contradicting m < n.",
+        "module": "Mathlib.Data.Nat.Basic"
+      },
+      {
+        "theorem": "Nat.strong_induction_on",
+        "description": "Strong induction on ℕ. Drives the elementary proof that a positive natural whose only odd divisor is 1 is a power of two: halve the even case, terminate the odd case at n = 1.",
+        "module": "Mathlib.Data.Nat.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The classical theorem 'a Fermat prime has power-of-two exponent' — Nat.Prime (2^n + 1) ∧ 0 < n → ∃ k, n = 2^k — machine-checked with 0 axioms and 0 sorries. Mathlib supplies the Fermat number definition and the ring-level divisibility x − y ∣ x^n − y^n, but does not package this necessary-condition direction as a standalone lemma.",
+      "A reusable odd-exponent divisibility lemma add_one_dvd_pow_add_one_of_odd : Odd d → a + 1 ∣ a^d + 1 over ℕ, obtained by casting to ℤ, applying sub_dvd_pow_sub_pow with y = −1, and transferring back — the +1 counterpart of Nat.pow_sub_one_dvd_pow_sub_one used on the Mersenne side.",
+      "A self-contained proof (isPowerOfTwo_of_odd_divisor_eq_one) that a positive natural whose only odd divisor is 1 is a power of two, by strong induction on the value (halving the even case, terminating the odd case at 1), avoiding the Nat.factorization / ord_compl API entirely.",
+      "Two downstream packagings: exponent_zero_or_isPowerOfTwo (the hypothesis-free dichotomy n = 0 ∨ ∃ k, n = 2^k, recording the genuine n = 0 exception 2^0 + 1 = 2) and not_prime_of_odd_factor (the direct search-pruning contrapositive: an exponent with an odd factor > 1 gives a composite Fermat number)."
+    ],
+    "dateAdded": "2026-07-05",
+    "axiomCount": 0,
+    "lineCount": 148,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only standard tactics (by_contra, omega, norm_num, ring, push_cast, strong induction) and named Mathlib lemmas — no decide or native_decide, so no Lean.ofReduceBool. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No sorryAx, no structure-encoded hypotheses. The hypothesis 0 < n is a genuine mathematical hypothesis (2^0 + 1 = 2 is prime but 0 is not a power of two), not an assumption on the ambient theory.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "odd-exponent-divisibility",
+      "title": "Odd exponents preserve a + 1 divisibility",
+      "startLine": 51,
+      "endLine": 68,
+      "summary": "add_one_dvd_pow_add_one_of_odd proves a + 1 ∣ a^d + 1 for odd d. The work is done over ℤ: a + 1 = a − (−1) (ring) and a^d + 1 = a^d − (−1)^d (via Odd.neg_one_pow), so sub_dvd_pow_sub_pow applies directly; push_cast and exact_mod_cast transfer the divisibility back to ℕ."
+    },
+    {
+      "id": "odd-divisor-eq-one",
+      "title": "A Fermat prime kills every odd exponent factor > 1",
+      "startLine": 71,
+      "endLine": 104,
+      "summary": "odd_divisor_eq_one shows that if 2^n + 1 is prime and n ≥ 1 then every odd divisor of n equals 1. An odd d ≠ 1 is at least 3; writing n = d·m (m ≥ 1) rewrites 2^n + 1 as (2^m)^d + 1, so 2^m + 1 divides it. Nat.Prime.eq_one_or_self_of_dvd forces 2^m + 1 = 1 (impossible, 2^m ≥ 1) or 2^m + 1 = 2^n + 1, whence 2^m = 2^n and Nat.pow_right_injective gives m = n, contradicting m < n."
+    },
+    {
+      "id": "odd-part-one-implies-power-of-two",
+      "title": "Odd part 1 ⇒ power of two (self-contained strong induction)",
+      "startLine": 106,
+      "endLine": 127,
+      "summary": "isPowerOfTwo_of_odd_divisor_eq_one proves that a positive natural whose only odd divisor is 1 is a power of two, by strong induction on the value. An odd n divides itself, forcing n = 1 = 2^0; an even n = 2m inherits the hypothesis on m (odd divisors of m divide n), giving m = 2^k and hence n = 2^{k+1}. No Nat.factorization / ord_compl machinery is used."
+    },
+    {
+      "id": "main-and-packagings",
+      "title": "Main theorem and search-pruning packagings",
+      "startLine": 129,
+      "endLine": 147,
+      "summary": "exponent_isPowerOfTwo composes the two halves: n ≥ 1 and Nat.Prime (2^n + 1) ⇒ ∃ k, n = 2^k. exponent_zero_or_isPowerOfTwo drops positivity to the dichotomy n = 0 ∨ ∃ k, n = 2^k (recording the 2^0 + 1 = 2 exception), and not_prime_of_odd_factor is the contrapositive search filter: an odd factor > 1 of the exponent yields a composite Fermat number."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Fermat numbers and their powers-of-two exponents**\n\nPierre de Fermat (1607–1665) conjectured around 1640 that every number of the form $F_k = 2^{2^k} + 1$ is prime, having checked $F_0 = 3$, $F_1 = 5$, $F_2 = 17$, $F_3 = 257$, and $F_4 = 65537$. Euler refuted the conjecture in 1732 by factoring $F_5 = 2^{32} + 1 = 641 \\cdot 6700417$, and no Fermat prime beyond $F_4$ has ever been found. Underlying the very definition $F_k = 2^{2^k}+1$ is a necessary condition Fermat knew: **if $2^n + 1$ is prime (with $n \\ge 1$) then $n$ must be a power of two.** The reason is the mirror image of the Mersenne fact $2^n - 1$ prime $\\Rightarrow$ $n$ prime: any *odd* factor $d > 1$ of the exponent produces a factor $2^{n/d} + 1$ of $2^n + 1$. So only exponents with no odd factor beyond $1$ — the powers of two — can yield primes, which is exactly why the Fermat primes are indexed by $k$ with exponent $2^k$.",
+    "problemStatement": "**Fermat prime ⇒ power-of-two exponent**\n\nProve that for every natural number $n \\ge 1$, if the Fermat number $2^n + 1$ is prime, then $n$ is a power of two:\n$$\\text{Prime}(2^n + 1) \\wedge n \\ge 1 \\implies \\exists k,\\ n = 2^k.$$\nThe hypothesis $n \\ge 1$ cannot be dropped: $2^0 + 1 = 2$ is prime, yet $0$ is not a power of two. The goal is a fully machine-checked proof with no axioms and no sorries.",
+    "proofStrategy": "**Odd factors of the exponent factor the Fermat number**\n\nThe key arithmetic fact is the odd-exponent divisibility $d$ odd $\\Rightarrow a + 1 \\mid a^d + 1$, the $+1$ counterpart of $x - y \\mid x^k - y^k$. It is proved over $\\mathbb{Z}$: write $a + 1 = a - (-1)$ and, since $d$ is odd, $a^d + 1 = a^d - (-1)^d$, so $\\text{sub\\_dvd\\_pow\\_sub\\_pow}$ applies and the divisibility casts back to $\\mathbb{N}$.\n\nNow suppose $2^n + 1$ is prime with $n \\ge 1$, and let $d > 1$ be an odd divisor of $n$, say $n = d\\cdot m$ with $m \\ge 1$. With $a = 2^m$ we have $2^n + 1 = a^d + 1$, so $2^m + 1 = a + 1$ divides it. Primality forces $2^m + 1 = 1$ (impossible, $2^m \\ge 1$) or $2^m + 1 = 2^n + 1$, i.e. $2^m = 2^n$; injectivity of $d \\mapsto 2^d$ then gives $m = n$, contradicting $m < n$ (which holds because $d \\ge 2$). Hence the only odd divisor of $n$ is $1$. Finally, a positive natural whose only odd divisor is $1$ is a power of two — proved here by strong induction (halve the even case, stop the odd case at $1$) rather than through the factorization API.",
+    "keyInsights": [
+      "**Odd exponents lift $a + 1$ divisibility.** The whole proof turns on $d$ odd $\\Rightarrow a + 1 \\mid a^d + 1$, a special case of $x - y \\mid x^k - y^k$ with $y = -1$. Where the Mersenne argument uses $x - y \\mid x^k - y^k$ directly (even/odd irrelevant), the Fermat argument needs the *odd* exponent so that $(-1)^d = -1$ turns the subtraction into the desired $+1$.",
+      "**Only odd factors of the exponent are dangerous.** An even factor of $n$ does nothing; it is precisely the odd factors $> 1$ that yield proper divisors $2^{n/d} + 1$. Ruling them all out is equivalent to saying $n$ has no odd part beyond $1$, i.e. $n$ is a power of two.",
+      "**The $n = 0$ exception is real.** $2^0 + 1 = 2$ is prime but $0$ is not a power of two, so the theorem genuinely needs $n \\ge 1$. The hypothesis-free packaging honestly records this as the dichotomy $n = 0 \\vee \\exists k,\\ n = 2^k$.",
+      "**Elementary throughout.** 'Odd part $1$ $\\Rightarrow$ power of two' is discharged by a four-line strong induction on the value, sidestepping `Nat.factorization`/`ord_compl`; the rest is `omega`, `ring`, `push_cast`, and two named Mathlib lemmas."
+    ],
+    "prerequisites": [
+      "Divisibility and prime numbers in ℕ",
+      "The identity x − y ∣ xⁿ − yⁿ and the odd-exponent specialization a + 1 ∣ aᵈ + 1",
+      "Injectivity of a ↦ aⁿ",
+      "Strong induction on ℕ"
+    ]
+  },
+  "conclusion": {
+    "summary": "The necessary condition on Fermat primes, $\\text{Prime}(2^n + 1) \\wedge n \\ge 1 \\implies \\exists k,\\ n = 2^k$, is established by combining an odd-exponent divisibility lemma with an elementary odd-part argument. Any odd divisor $d > 1$ of the exponent, via $2^{n/d} + 1 \\mid 2^n + 1$ (from `sub_dvd_pow_sub_pow` with $y = -1$), would exhibit a proper divisor of the prime $2^n + 1$, contradiction; so $n$ has no odd factor beyond $1$ and is a power of two (self-contained strong induction). 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the standalone necessary-condition lemma for Fermat primes — Prime(2^n + 1) ∧ 0 < n → ∃ k, n = 2^k — answering the top open question left by the Mersenne-exponent entry (whether the same divisibility lift handles the +1 family).",
+      "The contrapositive not_prime_of_odd_factor (an odd exponent factor > 1 ⇒ composite Fermat number) is the direct justification for indexing Fermat primes as 2^{2^k} + 1 and for restricting Fermat-primality searches to power-of-two exponents.",
+      "Isolates the +1 analogue of the Mersenne toolkit: to show a^n + 1 is composite when n has an odd factor, lift the factorization through the odd-exponent divisibility a + 1 ∣ a^d + 1 and bound the resulting divisor away from 1 and the whole."
+    ],
+    "openQuestions": [
+      "Can the argument be sharpened to the classical restriction on prime factors of Fermat numbers, that every prime q dividing F_k = 2^{2^k} + 1 (with k ≥ 2) satisfies q ≡ 1 (mod 2^{k+2})?",
+      "Does the shared divisibility engine x − y ∣ x^n − y^n yield a uniform Lean development of both necessary conditions (Mersenne: n prime; Fermat: n a power of two) from a single parametrized lemma about factors of a^n ± 1?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "mersenne-prime-exponent",
+      "relationship": "Sibling necessary condition (the +1 mirror)",
+      "description": "This entry answers the first open question posed by the Mersenne-exponent proof: whether the exponent-divisibility lift gives an equally short proof that a Fermat prime 2^n + 1 forces n to be a power of two. Both turn on x − y ∣ x^n − y^n; Mersenne uses it directly (2^d − 1 ∣ 2^n − 1) to force n prime, Fermat uses its odd specialization (2^m + 1 ∣ 2^n + 1) to force n a power of two."
+    }
+  ]
+}

--- a/src/data/research/problems/mersenne-prime-exponent-oq-01.json
+++ b/src/data/research/problems/mersenne-prime-exponent-oq-01.json
@@ -1,0 +1,30 @@
+{
+  "id": "mersenne-prime-exponent-oq-01",
+  "title": "Fermat Prime Exponents Are Powers of Two",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "insights": [
+      "Fermat analogue of the Mersenne condition: 2^n+1 prime with n≥1 ⇒ n is a power of two. The n=0 case (2^0+1=2 prime, 0 not a power of two) is the sole genuine exception, so the hypothesis-free form is the dichotomy n=0 ∨ ∃k, n=2^k.",
+      "The obstruction is odd factors of the exponent: an odd d>1 with d∣n gives (writing n=d·m) a proper divisor 2^m+1 of 2^n+1, since a+1 ∣ a^d+1 for odd d with a=2^m.",
+      "Key lemma a+1 ∣ a^d+1 (d odd) is proved over ℤ from a+1 = a−(−1), a^d+1 = a^d−(−1)^d (Odd.neg_one_pow), and sub_dvd_pow_sub_pow, then cast to ℕ — the +1 mirror of Nat.pow_sub_one_dvd_pow_sub_one used on the Mersenne side.",
+      "'Positive n whose only odd divisor is 1 is a power of two' is cleanest via strong induction on the value (odd n divides itself ⇒ n=1; even n=2m inherits the hypothesis on m), avoiding the Nat.factorization / ord_compl API entirely."
+    ],
+    "builtItems": [
+      "add_one_dvd_pow_add_one_of_odd (Odd d → a+1 ∣ a^d+1 over ℕ) — Proofs/FermatPrimeExponent.lean:54",
+      "odd_divisor_eq_one (Fermat prime forces every odd exponent factor to be 1) — Proofs/FermatPrimeExponent.lean:71",
+      "isPowerOfTwo_of_odd_divisor_eq_one (odd-part-1 ⇒ power of two, strong induction) — Proofs/FermatPrimeExponent.lean:106",
+      "exponent_isPowerOfTwo (main: 0<n ∧ Prime(2^n+1) → ∃k, n=2^k) — Proofs/FermatPrimeExponent.lean:129",
+      "exponent_zero_or_isPowerOfTwo, not_prime_of_odd_factor (packagings) — Proofs/FermatPrimeExponent.lean:136,144"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the Fermat number definition and sub_dvd_pow_sub_pow but no standalone lemma 'Fermat prime ⇒ power-of-two exponent'.",
+      "The ord_compl[·] notation and Nat.ord_compl_dvd / Nat.not_dvd_ord_compl names were not directly usable here (notation not in scope under a bare import); an elementary strong induction was preferable to fighting the factorization API."
+    ],
+    "nextSteps": [
+      "Sharpen toward the classical prime-factor restriction: every prime q ∣ F_k = 2^{2^k}+1 (k≥2) satisfies q ≡ 1 (mod 2^{k+2}).",
+      "Unify Mersenne (n prime) and Fermat (n power of two) necessary conditions from a single parametrized lemma about factors of a^n ± 1."
+    ],
+    "progressSummary": "COMPLETE: verified 0 sorry / 0 axiom, gallery entry added, PR opened."
+  }
+}


### PR DESCRIPTION
## Fermat Prime Exponents Are Powers of Two

Answers the **top open question** posed by the `mersenne-prime-exponent` gallery entry: whether the exponent-divisibility lift gives an equally short proof that a Fermat prime `2^n + 1` forces `n` to be a power of two.

**Theorem.** If `2^n + 1` is prime and `n ≥ 1`, then `n = 2^k` for some `k`.
The hypothesis `n ≥ 1` is essential (`2^0 + 1 = 2` is prime, `0` is not a power of two) — the hypothesis-free form is the honest dichotomy `n = 0 ∨ ∃ k, n = 2^k`.

### Proof sketch
- **Odd-exponent divisibility** `add_one_dvd_pow_add_one_of_odd`: `Odd d → a + 1 ∣ a^d + 1`, proved over ℤ from `a + 1 = a − (−1)`, `a^d + 1 = a^d − (−1)^d` (`Odd.neg_one_pow`) and `sub_dvd_pow_sub_pow`, then cast to ℕ. The `+1` mirror of `Nat.pow_sub_one_dvd_pow_sub_one` used on the Mersenne side.
- **Dichotomy** `odd_divisor_eq_one`: an odd factor `d > 1` of `n` (write `n = d·m`) makes `2^m + 1` a proper divisor of `2^n + 1 = (2^m)^d + 1`, contradicting primality via `Nat.Prime.eq_one_or_self_of_dvd` + `Nat.pow_right_injective`.
- **Odd part 1 ⇒ power of two** `isPowerOfTwo_of_odd_divisor_eq_one`: self-contained strong induction on the value (halve the even case, terminate the odd case at 1) — avoids the `Nat.factorization` / `ord_compl` API.
- Packagings: `exponent_zero_or_isPowerOfTwo`, `not_prime_of_odd_factor` (search-pruning contrapositive).

### Verification
- `./proofs/scripts/docker-build.sh Proofs.FermatPrimeExponent` — **builds clean**
- **0 sorries, 0 axioms** (no `decide`/`native_decide`; only `propext`/`Classical.choice`/`Quot.sound`)
- 148 lines, 6 theorems; gallery `pnpm build` passes and cross-links the Mersenne sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)