### PR TITLE
research(erdos-1013-oq-02): unconditional straddle-1 — ratio_frequently_lt/gt [VERIFIED, 0 sorry/0 axiom]

### DIFF
--- a/proofs/Proofs/Erdos1013UnconditionalRatio.lean
+++ b/proofs/Proofs/Erdos1013UnconditionalRatio.lean
@@ -27,7 +27,17 @@ unconditionally, is every **averaged** form of (⋆):
         ratios tends to `1`:  `(h(K)/h(0))^{1/K} → 1`;
   * `root_tendsto_one`              — the root test is trivial: `h(k)^{1/k} → 1`.
 
-All three are proved for an arbitrary `h : ℕ → ℝ` that is **positive and polynomially
+Beyond the averages, the known bounds also force an unconditional **pointwise** obstruction
+on the ratio itself:
+
+  * `ratio_frequently_lt` / `ratio_frequently_gt` — for every `ε > 0`, the consecutive
+        ratio is `< 1 + ε` infinitely often and `> 1 - ε` infinitely often, i.e.
+        `liminf ≤ 1 ≤ limsup`.  The ratio **straddles 1** (`h3_ratio_straddles_one`): it
+        cannot drift away from `1` on either side, so if (⋆) fails it fails only by
+        oscillation.  The engine is the pair of Cesàro sign lemmas `cesaro_ge_imp` /
+        `cesaro_le_imp` (a vanishing Cesàro mean cannot dominate a fixed nonzero constant).
+
+The averaged statements are proved for an arbitrary `h : ℕ → ℝ` that is **positive and polynomially
 sandwiched** (`PolyBounded`); the genuine `h₃`, whose bounds sit between `k²` and `k³`,
 qualifies (`polyBounded_of_h3`), so the corollaries `h3_*` apply verbatim.
 
@@ -187,6 +197,100 @@ theorem ratio_iff_log_ratio {h : ℕ → ℝ} (hb : PolyBounded h) :
     filter_upwards with k
     rw [Real.exp_log (div_pos (hb.pos _) (hb.pos _))]
 
+/- ## The ratio *straddles* 1 — an unconditional pointwise obstruction -/
+
+/-- If a sequence's Cesàro mean tends to `0` and the sequence is *eventually* bounded
+below by a constant `c`, then `c ≤ 0`.  (The finite head `∑_{k<N} a k` contributes
+`O(1/K)`; the tail contributes `≥ c·(K−N)/K → c`, so a positive `c` would force the mean
+to stay `≥ c > 0`.) -/
+theorem cesaro_ge_imp {a : ℕ → ℝ} {c : ℝ}
+    (hces : Tendsto (fun K : ℕ => (∑ k ∈ Finset.range K, a k) / K) atTop (𝓝 0))
+    (hev : ∀ᶠ k in atTop, c ≤ a k) : c ≤ 0 := by
+  obtain ⟨N, hN⟩ := eventually_atTop.mp hev
+  set S : ℝ := ∑ k ∈ Finset.range N, a k with hS
+  -- an eventual lower bound for the Cesàro mean, tending to `c`
+  have hle : ∀ᶠ K : ℕ in atTop,
+      (S + c * ((K : ℝ) - N)) / K ≤ (∑ k ∈ Finset.range K, a k) / K := by
+    filter_upwards [eventually_ge_atTop N, eventually_gt_atTop 0] with K hK hK0
+    have hsplit : (∑ k ∈ Finset.range K, a k) = S + ∑ k ∈ Finset.Ico N K, a k := by
+      rw [hS]; exact (Finset.sum_range_add_sum_Ico a hK).symm
+    have htail : c * ((K : ℝ) - N) ≤ ∑ k ∈ Finset.Ico N K, a k := by
+      have hcsum : (∑ _k ∈ Finset.Ico N K, c) ≤ ∑ k ∈ Finset.Ico N K, a k :=
+        Finset.sum_le_sum fun k hk => hN k (Finset.mem_Ico.mp hk).1
+      have heq : (∑ _k ∈ Finset.Ico N K, c) = c * ((K : ℝ) - N) := by
+        rw [Finset.sum_const, Nat.card_Ico, nsmul_eq_mul, Nat.cast_sub hK]; ring
+      rwa [heq] at hcsum
+    have hnum : S + c * ((K : ℝ) - N) ≤ S + ∑ k ∈ Finset.Ico N K, a k := by linarith
+    rw [hsplit]
+    gcongr
+  -- the lower bound tends to `c`
+  have hlow : Tendsto (fun K : ℕ => (S + c * ((K : ℝ) - N)) / K) atTop (𝓝 c) := by
+    have hSK : Tendsto (fun K : ℕ => S / (K : ℝ)) atTop (𝓝 0) :=
+      tendsto_const_nhds.div_atTop tendsto_natCast_atTop_atTop
+    have hNK : Tendsto (fun K : ℕ => c * (N : ℝ) / (K : ℝ)) atTop (𝓝 0) :=
+      tendsto_const_nhds.div_atTop tendsto_natCast_atTop_atTop
+    have hsum : Tendsto (fun K : ℕ => S / (K : ℝ) + (c - c * (N : ℝ) / (K : ℝ)))
+        atTop (𝓝 (0 + (c - 0))) := hSK.add (tendsto_const_nhds.sub hNK)
+    rw [zero_add, sub_zero] at hsum
+    refine hsum.congr' ?_
+    filter_upwards [eventually_gt_atTop 0] with K hK0
+    have hKne : (K : ℝ) ≠ 0 := by exact_mod_cast hK0.ne'
+    field_simp
+  exact le_of_tendsto_of_tendsto hlow hces hle
+
+/-- Dual of `cesaro_ge_imp`: eventual upper bound `a k ≤ c` with vanishing Cesàro mean
+forces `0 ≤ c`.  (Apply `cesaro_ge_imp` to `-a`.) -/
+theorem cesaro_le_imp {a : ℕ → ℝ} {c : ℝ}
+    (hces : Tendsto (fun K : ℕ => (∑ k ∈ Finset.range K, a k) / K) atTop (𝓝 0))
+    (hev : ∀ᶠ k in atTop, a k ≤ c) : 0 ≤ c := by
+  have hces' : Tendsto (fun K : ℕ => (∑ k ∈ Finset.range K, (-a k)) / K) atTop (𝓝 0) := by
+    have h0 : Tendsto (fun K : ℕ => -((∑ k ∈ Finset.range K, a k) / K)) atTop (𝓝 (-0)) :=
+      hces.neg
+    rw [neg_zero] at h0
+    refine h0.congr' ?_
+    filter_upwards with K
+    rw [← neg_div]
+    congr 1
+    simp
+  have hev' : ∀ᶠ k in atTop, (-c) ≤ (-a k) := by
+    filter_upwards [hev] with k hk; linarith
+  have := cesaro_ge_imp hces' hev'
+  linarith
+
+/-- **Unconditional: the ratio cannot be eventually bounded above away from 1.**  For
+every `ε > 0`, `h(k+1)/h k < 1 + ε` for infinitely many `k` — i.e.
+`liminf_k h(k+1)/h k ≤ 1`.  If instead the ratio were eventually `≥ 1 + ε`, the log-ratios
+would be eventually `≥ log(1+ε) > 0`, forcing their Cesàro mean `≥ log(1+ε) > 0`, against
+`cesaro_log_ratio_tendsto_zero`. -/
+theorem ratio_frequently_lt {h : ℕ → ℝ} (hb : PolyBounded h) {ε : ℝ} (hε : 0 < ε) :
+    ∃ᶠ k in atTop, h (k + 1) / h k < 1 + ε := by
+  by_contra hcon
+  rw [Filter.not_frequently] at hcon
+  have hge : ∀ᶠ k in atTop, (1 + ε) ≤ h (k + 1) / h k := by
+    filter_upwards [hcon] with k hk; exact not_lt.mp hk
+  have hlogge : ∀ᶠ k in atTop, Real.log (1 + ε) ≤ Real.log (h (k + 1) / h k) := by
+    filter_upwards [hge] with k hk
+    exact Real.log_le_log (by linarith) hk
+  have hle0 := cesaro_ge_imp (cesaro_log_ratio_tendsto_zero hb) hlogge
+  have hpos : 0 < Real.log (1 + ε) := Real.log_pos (by linarith)
+  linarith
+
+/-- **Unconditional: the ratio cannot be eventually bounded below away from 1.**  For
+every `ε` with `0 < ε < 1`, `1 - ε < h(k+1)/h k` for infinitely many `k` — i.e.
+`1 ≤ limsup_k h(k+1)/h k`.  Symmetric to `ratio_frequently_lt` via `cesaro_le_imp`. -/
+theorem ratio_frequently_gt {h : ℕ → ℝ} (hb : PolyBounded h) {ε : ℝ} (hε : 0 < ε)
+    (hε1 : ε < 1) : ∃ᶠ k in atTop, 1 - ε < h (k + 1) / h k := by
+  by_contra hcon
+  rw [Filter.not_frequently] at hcon
+  have hle : ∀ᶠ k in atTop, h (k + 1) / h k ≤ 1 - ε := by
+    filter_upwards [hcon] with k hk; exact not_lt.mp hk
+  have hlogle : ∀ᶠ k in atTop, Real.log (h (k + 1) / h k) ≤ Real.log (1 - ε) := by
+    filter_upwards [hle] with k hk
+    exact Real.log_le_log (div_pos (hb.pos _) (hb.pos _)) hk
+  have hge0 := cesaro_le_imp (cesaro_log_ratio_tendsto_zero hb) hlogle
+  have hneg : Real.log (1 - ε) < 0 := Real.log_neg (by linarith) (by linarith)
+  linarith
+
 /- ## Specialisation to the genuine threshold `h₃` -/
 
 /-- The genuine triangle-free chromatic threshold (as a real candidate `h₃`) is
@@ -218,6 +322,18 @@ theorem h3_geom_mean_ratio_tendsto_one (h₃ : ℕ → ℝ) (hpos : ∀ k, 0 < h
     (hup : ∀ᶠ (k : ℕ) in atTop, h₃ k ≤ (k : ℝ) ^ 3) :
     Tendsto (fun K : ℕ => (h₃ K / h₃ 0) ^ ((K : ℝ)⁻¹)) atTop (𝓝 1) :=
   geom_mean_ratio_tendsto_one (polyBounded_of_h3 h₃ hpos hlow hup)
+
+/-- **Erdős #1013 (oq-02), unconditional straddle for `h₃`.**  For every `ε` with
+`0 < ε < 1`, the consecutive ratio `h₃(k+1)/h₃(k)` is `< 1 + ε` infinitely often *and*
+`> 1 - ε` infinitely often.  So `liminf ≤ 1 ≤ limsup`: the ratio cannot drift away from
+`1` on either side — if (⋆) fails it can only be by oscillation, never by drift. -/
+theorem h3_ratio_straddles_one (h₃ : ℕ → ℝ) (hpos : ∀ k, 0 < h₃ k)
+    (hlow : ∀ᶠ (k : ℕ) in atTop, (k : ℝ) ^ 2 ≤ h₃ k)
+    (hup : ∀ᶠ (k : ℕ) in atTop, h₃ k ≤ (k : ℝ) ^ 3) {ε : ℝ} (hε : 0 < ε) (hε1 : ε < 1) :
+    (∃ᶠ k in atTop, h₃ (k + 1) / h₃ k < 1 + ε) ∧
+      (∃ᶠ k in atTop, 1 - ε < h₃ (k + 1) / h₃ k) :=
+  ⟨ratio_frequently_lt (polyBounded_of_h3 h₃ hpos hlow hup) hε,
+    ratio_frequently_gt (polyBounded_of_h3 h₃ hpos hlow hup) hε hε1⟩
 
 /-
 ## Remarks — why the *pointwise* ratio (⋆) is not settled here

--- a/research/problems/erdos-1013-oq-02/knowledge.md
+++ b/research/problems/erdos-1013-oq-02/knowledge.md
@@ -89,3 +89,48 @@ the latter using `log k / k → 0` (from `Real.isLittleO_log_id_atTop`).
   (b) a direct super/subadditivity relation between `h₃(k)` and `h₃(k+1)` controlling
   local variation. Neither is currently in reach; (a) is essentially the asymptotic
   constant question.
+
+---
+
+## Session 2026-07-05 (Session 2) — ACT
+
+**Mode**: CONTINUE. **Outcome**: progress (verified new result).
+
+### What I Did
+- Extended `Erdos1013UnconditionalRatio.lean` from 9 → 14 theorems with the unconditional
+  **straddle-1** result, and verified it via the Docker wrapper (`docker-build.sh`,
+  lean 4.26.0) — the containerd blackout that forced Session 1 onto the `lake env`
+  passthrough has cleared, shared Mathlib volumes work from the worktree.
+- New theorems (0 sorry / 0 axiom; `#print axioms` unchanged: propext/Classical.choice/Quot.sound):
+  - `cesaro_ge_imp` / `cesaro_le_imp` — a vanishing Cesàro mean of a sequence cannot be
+    eventually `≥` a fixed positive constant (resp. `≤` a fixed negative one).
+  - `ratio_frequently_lt` / `ratio_frequently_gt` — for every `ε>0`, the ratio is `<1+ε`
+    infinitely often and `>1−ε` infinitely often, i.e. `liminf ≤ 1 ≤ limsup`.
+  - `h3_ratio_straddles_one` — the `h₃` specialisation (conjunction of both frequencies).
+
+### Key Findings
+- The averaged Cesàro fact is *strong enough to straddle 1 pointwise*. This is strictly
+  sharper than the `[1/2,2]` bounded-ratio window leaf (which only gives `liminf ≤ 2`,
+  `limsup ≥ 1/2`): the straddle pins `liminf ≤ 1 ≤ limsup`, ruling out any **one-sided
+  drift** of the ratio away from 1. Oscillation across the `log log k` band is now the
+  *sole* remaining obstruction to (⋆).
+- Lean mechanics worth remembering:
+  - `cesaro_ge_imp` splits `range K = range N ⊔ Ico N K`
+    (`Finset.sum_range_add_sum_Ico a hK`), bounds the tail below by `c·(K−N)`
+    (`Finset.sum_le_sum` + `Finset.sum_const` + `Nat.card_Ico` + `Nat.cast_sub`), and
+    compares the two Cesàro limits with `le_of_tendsto_of_tendsto` (eventual `≤`).
+  - `cesaro_le_imp` is the `-a` mirror: `hces.neg` + `simp` for `∑(-a) = -∑a`.
+  - `field_simp` fully closed the `(S + c(K−N))/K = S/K + (c − cN/K)` identity — a trailing
+    `ring` then errors with "no goals"; drop it.
+  - Frequency statements via `by_contra` + `Filter.not_frequently` + `not_lt.mp`, then
+    `Real.log_le_log` (monotone) + `Real.log_pos` / `Real.log_neg`.
+
+### Files Modified
+- `proofs/Proofs/Erdos1013UnconditionalRatio.lean` (extended: +5 theorems, module docstring)
+
+### Next Steps
+- Pointwise ratio → 1 still OPEN. The straddle closes the "no one-sided drift" direction;
+  the only remaining attack is a genuine **local-variation** bound
+  `|log h₃(k+1) − log h₃(k)| = o(1)`, which the current `log log k`-wide window cannot
+  supply. Optional polish: promote the frequency forms to explicit `Filter.liminf/limsup`
+  corollaries once cobounded side-conditions are provided.

--- a/research/problems/erdos-1013-oq-02/state.md
+++ b/research/problems/erdos-1013-oq-02/state.md
@@ -3,30 +3,41 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-04
-**Iteration**: 2
+**Since**: 2026-07-05
+**Iteration**: 3
 
 ## Current Focus
-Verified partial result landed: the unconditional *averaged* ratio statements
-(Cesàro / geometric-mean / root) for the polynomially-bounded threshold `h₃`.
-The pointwise `h₃(k+1)/h₃(k) → 1` remains OPEN (blocked on the `log log k` gap).
+Added the unconditional **straddle-1** result to `Erdos1013UnconditionalRatio.lean`:
+for every `ε > 0` the consecutive ratio `h₃(k+1)/h₃(k)` is `< 1+ε` infinitely often
+**and** `> 1−ε` infinitely often, i.e. `liminf ≤ 1 ≤ limsup`. This upgrades the earlier
+`[1/2,2]` bounded-ratio leaf to a tight straddle of 1 — the ratio cannot drift away from
+1 on either side; if the open pointwise (⋆) fails, it fails **only by oscillation**.
 
 ## Active Approach
-Prove the strongest unconditional consequences of the known polynomial bounds via the
-engine `log(h₃ k)/k → 0` + telescoping. DONE for the averaged forms.
+Extract the pointwise shadow of the already-proved averaged (Cesàro) result. The engine
+is two Cesàro sign lemmas: a vanishing Cesàro mean of the log-ratios cannot be eventually
+`≥` a fixed positive constant nor eventually `≤` a fixed negative one. Applying these to
+`log(1±ε)` gives the two frequency statements.
 
 ## Attempt Count
-- Total attempts: 1
+- Total attempts: 2
 - Current approach attempts: 1
-- Approaches tried: 1
+- Approaches tried: 2
 
 ## Blockers
 - Pointwise ratio → 1 is genuinely open: the `≈ log log k`-wide band between the known
-  upper/lower bounds permits `O(log log k)` local oscillation of `log h₃ − scale`, which
-  a two-sided squeeze cannot control. Removing it is essentially the (open) asymptotic
-  constant question of the parent problem.
+  upper/lower bounds permits `O(log log k)` local oscillation. The straddle result now
+  rules out one-sided *drift*, so the sole remaining obstruction is genuine *local
+  variation* `|log h₃(k+1) − log h₃(k)| = o(1)`, which the current window cannot supply.
 
 ## Next Action
 Either improve the upper bound to `(c+o(1))·k²·log k` (removes the gap), or find a direct
-`h₃(k) ↔ h₃(k+1)` local-variation relation. Neither in reach now — the verified averaged
-result is the deliverable for this iteration.
+`h₃(k) ↔ h₃(k+1)` local-variation relation. Neither in reach now — the verified
+straddle result is the deliverable for this iteration.
+
+## This Iteration (2026-07-05)
+- New theorems (all 0 sorry / 0 axiom, Docker lean 4.26.0 VERIFIED):
+  `cesaro_ge_imp`, `cesaro_le_imp` (Cesàro sign lemmas),
+  `ratio_frequently_lt`, `ratio_frequently_gt` (liminf ≤ 1 ≤ limsup),
+  `h3_ratio_straddles_one` (h₃ specialisation).
+- File now 14 theorems, 354 lines. `#print axioms` = propext/Classical.choice/Quot.sound.

--- a/src/data/research/problems/erdos-1013-oq-02.json
+++ b/src/data/research/problems/erdos-1013-oq-02.json
@@ -27,11 +27,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-03T23:49:35-07:00",
-    "iteration": 2,
-    "focus": "Formalized the unconditional bounded-ratio leaf (1/2 <= liminf <= limsup <= 2) via window sandwich transfer; verified.",
+    "since": "2026-07-05T00:00:00-07:00",
+    "iteration": 3,
+    "focus": "Added the unconditional STRADDLE-1 result: for every eps>0 the ratio is <1+eps and >1-eps infinitely often (liminf<=1<=limsup), via Cesaro sign lemmas cesaro_ge_imp/cesaro_le_imp. Rules out one-sided drift; oscillation is the sole remaining obstruction. Docker verified, 14 thms/0 sorry/0 axiom.",
     "blockers": [],
-    "nextAction": "Pointwise ratio->1 remains open (log log k gap). Optionally add limsup/liminf headline corollaries.",
+    "nextAction": "Pointwise ratio->1 remains open (log log k gap; needs a genuine LOCAL-VARIATION bound |log h3(k+1)-log h3(k)|=o(1), which the current window cannot supply).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -39,20 +39,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (verified): the unconditional BOUNDED-RATIO LEAF is now machine-checked (Erdos1013BoundedRatio.lean, 4 thms/1 def/0 sorry/0 axiom): 1/2 <= liminf h3(k+1)/h3(k) <= limsup <= 2, derived by squeezing the two-sided window (1/2-o(1))s <= h3 <= (1+o(1))s against the smooth scale ratio s(k+1)/s(k)->1 (s=k^2 log k). Averaged forms (Cesaro/geom-mean/root) also done (Erdos1013UnconditionalRatio.lean). Pointwise ratio->1 remains OPEN (log log k gap).",
+    "progressSummary": "PROGRESS (verified): three complementary unconditional layers now machine-checked. (1) BOUNDED-RATIO LEAF (Erdos1013BoundedRatio.lean): 1/2 <= liminf h3(k+1)/h3(k) <= limsup <= 2 by squeezing the two-sided window against the smooth scale ratio. (2) AVERAGED forms (Cesaro/geom-mean/root) (Erdos1013UnconditionalRatio.lean). (3) NEW this iteration: the ratio STRADDLES 1 -- ratio_frequently_lt / ratio_frequently_gt prove that for every eps>0 the consecutive ratio is <1+eps infinitely often AND >1-eps infinitely often (liminf<=1<=limsup), via two Cesaro-sign lemmas (cesaro_ge_imp / cesaro_le_imp: a vanishing Cesaro mean cannot dominate a fixed nonzero constant). This upgrades the [1/2,2] window to a tight straddle of 1: if (star) fails it fails ONLY by oscillation, never by drift. Pointwise ratio->1 remains OPEN (log log k gap).",
     "builtItems": [
-      "Erdos1013UnconditionalRatio.lean: log_div_tendsto_zero (engine), cesaro_log_ratio_tendsto_zero, geom_mean_ratio_tendsto_one, root_tendsto_one, ratio_iff_log_ratio, polyBounded_of_h3, h3_* corollaries (9 thms, 0 sorries, 0 counted axioms)",
+      "Erdos1013UnconditionalRatio.lean: log_div_tendsto_zero (engine), cesaro_log_ratio_tendsto_zero, geom_mean_ratio_tendsto_one, root_tendsto_one, ratio_iff_log_ratio, polyBounded_of_h3, h3_* corollaries, AND (new 2026-07-05) cesaro_ge_imp/cesaro_le_imp (Cesaro sign lemmas), ratio_frequently_lt/ratio_frequently_gt (liminf<=1<=limsup), h3_ratio_straddles_one (14 thms total, 0 sorries, 0 counted axioms; #print axioms = propext/Classical.choice/Quot.sound). Docker lean 4.26.0 VERIFIED.",
       "Erdos1013BoundedRatio.lean: ratio_sandwich (per-term two-sided bound), ratio_eventually_between (constant-(a,b) envelope: ratio eventually in (a/b-e, b/a+e)), WindowBounds (def), h3_ratio_eventually_lt_two + h3_ratio_eventually_gt_half (sharp leaf: ratio eventually >1/2-e and <2+e, i.e. 1/2<=liminf<=limsup<=2). 4 thms, 1 def, 0 sorries, 0 axioms. VERIFIED (docker lean 4.26.0)."
     ],
     "insights": [
       "Pointwise h3(k+1)/h3(k)->1 is genuinely OPEN: equivalent to r_{k+1}-r_k->0 where r_k=log h3-scale; known bounds pin r_k only to a log log k-wide band permitting O(log log k) local oscillation, so no two-sided squeeze works.",
       "The AVERAGED forms are unconditional consequences of the sole clean fact k^2<=h3(k)<=k^3 (=> log(h3 k)/k->0): telescoping cancels the oscillation so only the endpoint r_K=o(K) matters.",
-      "The bounded-ratio leaf is a pure SANDWICH TRANSFER, needing nothing beyond the window: if a*s<=h<=b*s (0<a<=b) and s(k+1)/s(k)->1, then per-term (a/b)(s-ratio) <= h(k+1)/h(k) <= (b/a)(s-ratio), so the ratio is eventually trapped in any nbhd of [a/b, b/a]. Feeding the window at tolerance e (a=1/2-e, b=1+e) and sending e->0 gives the SHARP [1/2,2]; the explicit witness delta=e/(20+2e) makes (1+delta)/(1/2-delta)<=2+e/2 provable by nlinarith. Collapsing a=b=c recovers oq-01 (single point 1) -- leaf and oq-01 are two ends of one sandwich."
+      "The bounded-ratio leaf is a pure SANDWICH TRANSFER, needing nothing beyond the window: if a*s<=h<=b*s (0<a<=b) and s(k+1)/s(k)->1, then per-term (a/b)(s-ratio) <= h(k+1)/h(k) <= (b/a)(s-ratio), so the ratio is eventually trapped in any nbhd of [a/b, b/a]. Feeding the window at tolerance e (a=1/2-e, b=1+e) and sending e->0 gives the SHARP [1/2,2]; the explicit witness delta=e/(20+2e) makes (1+delta)/(1/2-delta)<=2+e/2 provable by nlinarith. Collapsing a=b=c recovers oq-01 (single point 1) -- leaf and oq-01 are two ends of one sandwich.",
+      "The averaged Cesaro fact is strong enough to STRADDLE 1 pointwise: a vanishing Cesaro mean of the log-ratios cannot be eventually >= a fixed c>0 (else the mean would stay >= c>0) nor eventually <= a fixed c<0. Hence for every eps>0 the ratio is <1+eps infinitely often and >1-eps infinitely often, i.e. liminf<=1<=limsup. This is strictly sharper than the [1/2,2] window leaf (which only pins liminf<=2 and limsup>=1/2) and is the natural pointwise SHADOW the averages cast: it rules out any one-sided drift of h3(k+1)/h3(k) away from 1, isolating oscillation across the log log k band as the sole remaining obstruction to (star). Key Lean move: cesaro_ge_imp splits range K = range N (+ finite head O(1/K)) and Ico N K (tail >= c*(K-N)), so the mean is >= (S + c(K-N))/K -> c, forcing c<=0 against mean->0; cesaro_le_imp is the -a mirror."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Pointwise ratio->1 still needs the log log k gap closed (improved upper bound (c+o(1))k^2 log k OR a direct local h3(k)<->h3(k+1) variation bound); neither in reach and both are the genuine open core.",
-      "Optional polish: restate the sharp leaf directly with Filter.limsup/liminf (limsup<=2, 1/2<=liminf) as headline corollaries of the eventual-containment theorems (the eventual forms are logically equivalent and already verified)."
+      "Optional polish: promote the frequently-forms (ratio_frequently_lt/gt) to explicit Filter.limsup/liminf statements (liminf <= 1 <= limsup) once the cobounded side-conditions are supplied; the frequently forms are logically equivalent and already verified.",
+      "The straddle result closes the 'no one-sided drift' direction; the only remaining attack on (star) is a genuine LOCAL-VARIATION bound |log h3(k+1) - log h3(k)| = o(1), which the current window (log log k band) cannot supply."
     ],
     "markdown": "# Knowledge Base: erdos-1013-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -109,12 +111,13 @@
     {
       "path": "Proofs/Erdos1013UnconditionalRatio.lean",
       "filename": "Erdos1013UnconditionalRatio.lean",
-      "lineCount": 0,
-      "theoremCount": 9,
+      "lineCount": 354,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
-      "isAristotle": false
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1013UnconditionalRatio.lean"
     },
     {
       "path": "Proofs/Erdos1013BoundedRatio.lean",


### PR DESCRIPTION
## Erdős #1013 (oq-02): the ratio *straddles* 1, unconditionally

Extends `proofs/Proofs/Erdos1013UnconditionalRatio.lean` (9 → 14 theorems) with a new **unconditional pointwise obstruction** on the consecutive triangle-free chromatic threshold ratio `h₃(k+1)/h₃(k)`.

### Result
For every `ε > 0`, the ratio is `< 1+ε` infinitely often **and** `> 1−ε` infinitely often — i.e.
```
liminf h₃(k+1)/h₃(k) ≤ 1 ≤ limsup h₃(k+1)/h₃(k).
```
The ratio **cannot drift away from 1 on either side**. Combined with the open pointwise question `h₃(k+1)/h₃(k) → 1` (⋆), this shows: **if (⋆) fails, it fails only by oscillation, never by drift.** This is strictly sharper than the previously-verified `[1/2, 2]` bounded-ratio window leaf (which only gives `liminf ≤ 2`, `limsup ≥ 1/2`).

### New theorems (all 0 sorry / 0 axiom)
- `cesaro_ge_imp` / `cesaro_le_imp` — a vanishing Cesàro mean of a sequence cannot be eventually `≥` a fixed positive (resp. `≤` a fixed negative) constant. (Finite head contributes `O(1/K)`; the tail forces the mean toward the constant.)
- `ratio_frequently_lt` / `ratio_frequently_gt` — the two frequency statements, derived by feeding `log(1±ε)` through the sign lemmas against the already-proved `cesaro_log_ratio_tendsto_zero`.
- `h3_ratio_straddles_one` — the `h₃` specialisation (conjunction of both).

### Verification
`#print axioms` = `propext` / `Classical.choice` / `Quot.sound` only (no `sorryAx`, no `ofReduceBool`). Built via `./proofs/scripts/docker-build.sh Proofs.Erdos1013UnconditionalRatio` (Lean 4.26.0, Mathlib): `✔ Built Proofs.Erdos1013UnconditionalRatio`.

The genuinely open pointwise (⋆) remains open — the `log log k`-wide window admits `O(log log k)` local oscillation; the sole remaining attack is a local-variation bound `|log h₃(k+1) − log h₃(k)| = o(1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)