### PR TITLE
research(mersenne-prime-exponent-oq-02): prime-factor congruences q≡1 mod 2p and q≡±1 mod 8 [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/MersennePrimeExponentOQ02.lean
+++ b/proofs/Proofs/MersennePrimeExponentOQ02.lean
@@ -1,0 +1,126 @@
+import Mathlib
+
+/-
+# Congruence Restrictions on Prime Factors of Mersenne Numbers
+
+## Open Question (mersenne-prime-exponent-oq-02)
+
+The base result (`mersenne-prime-exponent`) shows that if `2^n − 1` is prime then
+`n` is prime.  A natural follow-up asks what can be said about the *prime factors*
+of a Mersenne number `2^p − 1` when the exponent `p` is an odd prime — even when
+`2^p − 1` is **not** itself prime.  The classical answer is a pair of strong
+congruence restrictions:
+
+    If `p` is an odd prime and `q` is a prime dividing `2^p − 1`, then
+        q ≡ 1  (mod 2p)      and      q ≡ ±1  (mod 8).
+
+These restrictions are exactly what makes trial division for Mersenne factors so
+efficient: instead of testing every prime `q`, one only tests primes of the form
+`q = 2kp + 1` that additionally lie in the residue classes `±1 (mod 8)`.  For
+example, the factors of `2^11 − 1 = 23 · 89` satisfy `23 = 2·11 + 1`,
+`89 = 8·11 + 1`, and `23 ≡ -1`, `89 ≡ 1 (mod 8)`.
+
+## Proof
+
+Fix an odd prime `p` and a prime `q ∣ 2^p − 1`.  Working in the field `ZMod q`:
+
+* From `q ∣ 2^p − 1` we get `(2 : ZMod q)^p = 1`, so the multiplicative order of
+  `2` divides the prime `p`.  Order `1` would force `2 = 1` in `ZMod q`, i.e.
+  `q ∣ 1`, impossible; hence `orderOf (2 : ZMod q) = p`.
+
+* **`q ≡ 1 (mod 2p)`.**  Fermat's little theorem gives `(2 : ZMod q)^{q-1} = 1`,
+  so `p = orderOf 2 ∣ q − 1`.  Since `q` is an odd prime we also have `2 ∣ q − 1`,
+  and `gcd(2, p) = 1` (as `p` is odd), so `2p ∣ q − 1`, i.e. `q ≡ 1 (mod 2p)`.
+
+* **`q ≡ ±1 (mod 8)`.**  Because `p` is odd, write `p = 2k + 1`.  Then
+  `2 = 2 · 1 = 2 · (2^p) = 2^{p+1} = (2^{k+1})^2` in `ZMod q`, so `2` is a
+  quadratic residue mod `q`.  Mathlib's `ZMod.exists_sq_eq_two_iff` then gives
+  `q ≡ 1` or `q ≡ 7 (mod 8)`, i.e. `q ≡ ±1 (mod 8)`.
+
+Both statements are fully machine-checked (0 sorries, 0 axioms beyond Mathlib's
+foundations).
+-/
+
+namespace MersennePrimeExponentOQ02
+
+/-- If `q` is prime and divides the Mersenne number `2^p − 1`, then `2` has
+`p`-th power equal to `1` in `ZMod q`.  This is the shared entry point for both
+congruence restrictions. -/
+private theorem two_pow_eq_one_of_dvd {p q : ℕ} (hq : q.Prime)
+    (hdvd : q ∣ 2 ^ p - 1) : (2 : ZMod q) ^ p = 1 := by
+  haveI : Fact q.Prime := ⟨hq⟩
+  haveI : NeZero q := ⟨hq.pos.ne'⟩
+  have h2p : 1 ≤ 2 ^ p := Nat.one_le_pow p 2 (by norm_num)
+  have hz : ((2 ^ p - 1 : ℕ) : ZMod q) = 0 :=
+    (ZMod.natCast_eq_zero_iff _ _).mpr hdvd
+  rw [Nat.cast_sub h2p] at hz
+  push_cast at hz
+  rwa [sub_eq_zero] at hz
+
+/-- `2^p − 1` is odd, hence every prime factor `q` is odd (`q ≠ 2`). -/
+private theorem ne_two_of_dvd {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hdvd : q ∣ 2 ^ p - 1) : q ≠ 2 := by
+  have hmodd : Odd (2 ^ p - 1) :=
+    Nat.Even.sub_odd (Nat.one_le_pow p 2 (by norm_num))
+      (Nat.even_pow.mpr ⟨even_two, hp.pos.ne'⟩) odd_one
+  rintro rfl
+  obtain ⟨k, hk⟩ := hmodd
+  obtain ⟨j, hj⟩ := hdvd
+  omega
+
+/-- **Congruence restriction mod `2p`.**  Every prime factor `q` of the Mersenne
+number `2^p − 1` (for `p` an odd prime) satisfies `q ≡ 1 (mod 2p)`. -/
+theorem prime_factor_congr_one_mod_two_mul {p q : ℕ} (hp : p.Prime) (hpodd : Odd p)
+    (hq : q.Prime) (hdvd : q ∣ 2 ^ p - 1) : q ≡ 1 [MOD 2 * p] := by
+  haveI : Fact q.Prime := ⟨hq⟩
+  haveI : NeZero q := ⟨hq.pos.ne'⟩
+  have hz : (2 : ZMod q) ^ p = 1 := two_pow_eq_one_of_dvd hq hdvd
+  have hq2 : q ≠ 2 := ne_two_of_dvd hp hq hdvd
+  have hqodd : Odd q := hq.odd_of_ne_two hq2
+  -- `2 ≠ 0` in `ZMod q` since `q ∤ 2`.
+  have ha0 : (2 : ZMod q) ≠ 0 := by
+    intro h
+    have hdvd2 : (q : ℕ) ∣ 2 :=
+      (ZMod.natCast_eq_zero_iff 2 q).mp (by push_cast; exact h)
+    exact hq2 ((Nat.prime_dvd_prime_iff_eq hq Nat.prime_two).mp hdvd2)
+  -- `2 ≠ 1` in `ZMod q`, so the order is not `1`.
+  have hne1 : (2 : ZMod q) ≠ 1 := fun h => one_ne_zero (by linear_combination h : (1 : ZMod q) = 0)
+  -- The order of `2` is exactly the prime `p`.
+  have hord : orderOf (2 : ZMod q) = p := by
+    rcases hp.eq_one_or_self_of_dvd _ (orderOf_dvd_of_pow_eq_one hz) with h1 | hpp
+    · exact absurd (orderOf_eq_one_iff.mp h1) hne1
+    · exact hpp
+  -- Fermat: order divides `q − 1`, hence `p ∣ q − 1`.
+  have hp_dvd : p ∣ q - 1 := by
+    rw [← hord]
+    exact orderOf_dvd_of_pow_eq_one (ZMod.pow_card_sub_one_eq_one ha0)
+  -- `q` odd gives `2 ∣ q − 1`.
+  have h2_dvd : 2 ∣ q - 1 := by
+    obtain ⟨k, hk⟩ := hqodd; exact ⟨k, by omega⟩
+  -- Combine coprime divisors: `2p ∣ q − 1`.
+  have hpne2 : p ≠ 2 := by rintro rfl; exact (by decide : ¬ Odd 2) hpodd
+  have hcop : Nat.Coprime 2 p := (Nat.coprime_primes Nat.prime_two hp).mpr (Ne.symm hpne2)
+  have h2p_dvd : 2 * p ∣ q - 1 := hcop.mul_dvd_of_dvd_of_dvd h2_dvd hp_dvd
+  exact ((Nat.modEq_iff_dvd' hq.pos).mpr h2p_dvd).symm
+
+/-- **Congruence restriction mod `8`.**  Every prime factor `q` of the Mersenne
+number `2^p − 1` (for `p` an odd prime) satisfies `q ≡ ±1 (mod 8)`, expressed as
+`q % 8 = 1 ∨ q % 8 = 7`. -/
+theorem prime_factor_pm_one_mod_eight {p q : ℕ} (hp : p.Prime) (hpodd : Odd p)
+    (hq : q.Prime) (hdvd : q ∣ 2 ^ p - 1) : q % 8 = 1 ∨ q % 8 = 7 := by
+  haveI : Fact q.Prime := ⟨hq⟩
+  have hz : (2 : ZMod q) ^ p = 1 := two_pow_eq_one_of_dvd hq hdvd
+  have hq2 : q ≠ 2 := ne_two_of_dvd hp hq hdvd
+  -- `2` is a quadratic residue mod `q`: with `p = 2k+1`, `2 = (2^{k+1})²`.
+  have hsq : IsSquare (2 : ZMod q) := by
+    obtain ⟨k, hk⟩ := hpodd
+    refine ⟨(2 : ZMod q) ^ (k + 1), ?_⟩
+    have h1 : (2 : ZMod q) ^ (k + 1) * (2 : ZMod q) ^ (k + 1)
+        = (2 : ZMod q) ^ p * (2 : ZMod q) := by
+      rw [← pow_add, ← pow_succ]
+      congr 1
+      omega
+    rw [h1, hz, one_mul]
+  exact (ZMod.exists_sq_eq_two_iff hq2).mp hsq
+
+end MersennePrimeExponentOQ02

--- a/src/data/proofs/mersenne-prime-exponent-oq-02/meta.json
+++ b/src/data/proofs/mersenne-prime-exponent-oq-02/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "mersenne-prime-exponent-oq-02",
+  "title": "Congruence Restrictions on Prime Factors of Mersenne Numbers",
+  "slug": "mersenne-prime-exponent-oq-02",
+  "description": "The parent entry (mersenne-prime-exponent) shows that if 2^n − 1 is prime then n is prime. This follow-up formalises the classical constraints on the prime FACTORS of a Mersenne number 2^p − 1 when the exponent p is an odd prime — even when 2^p − 1 is composite. Two congruence restrictions are proved: every prime q dividing 2^p − 1 satisfies (1) q ≡ 1 (mod 2p) and (2) q ≡ ±1 (mod 8). These are exactly the conditions that make Mersenne trial division efficient: factors have the shape q = 2kp + 1 restricted to the residue classes ±1 (mod 8). Both proofs work in the field ZMod q. From q ∣ 2^p − 1 we get (2 : ZMod q)^p = 1, so the multiplicative order of 2 divides the prime p and (order 1 forcing q ∣ 1) equals p exactly. Fermat's little theorem then gives p ∣ q − 1; combined with 2 ∣ q − 1 (q odd) and gcd(2,p) = 1, this yields 2p ∣ q − 1, i.e. q ≡ 1 (mod 2p). For the mod-8 restriction, oddness of p writes 2 = 2·2^p = 2^{p+1} = (2^{(p+1)/2})² in ZMod q, so 2 is a quadratic residue mod q, and Mathlib's ZMod.exists_sq_eq_two_iff gives q ≡ 1 or 7 (mod 8). Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (Fermat/Euler era); formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mersenne_prime",
+    "date": "1750",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MersennePrimeExponentOQ02.lean",
+    "tags": [
+      "number-theory",
+      "mersenne",
+      "quadratic-residue",
+      "order-of-an-element",
+      "fermat-little-theorem",
+      "congruences"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(↑a : ZMod b) = 0 ↔ b ∣ a (for b ≠ 0). Transfers the divisibility q ∣ 2^p − 1 into the field ZMod q, where it becomes (2 : ZMod q)^p = 1 after a cast of the Nat subtraction.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "orderOf_dvd_of_pow_eq_one",
+        "description": "a ^ n = 1 → orderOf a ∣ n. Applied twice: to (2:ZMod q)^p = 1 (order divides p) and to Fermat's (2:ZMod q)^(q−1) = 1 (order divides q−1), giving p ∣ q−1.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "orderOf_eq_one_iff",
+        "description": "orderOf a = 1 ↔ a = 1. Rules out order 1 for (2 : ZMod q): 2 = 1 in ZMod q would force q ∣ 1, so the order of 2 is exactly the prime p.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "ZMod.pow_card_sub_one_eq_one",
+        "description": "a ≠ 0 → a ^ (q − 1) = 1 in ZMod q (Fermat's little theorem). Supplies (2:ZMod q)^(q−1) = 1, from which orderOf 2 = p divides q − 1.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime.mul_dvd_of_dvd_of_dvd",
+        "description": "Coprime a b → a ∣ n → b ∣ n → a*b ∣ n. Combines 2 ∣ q−1 (q odd) and p ∣ q−1 (order argument), coprime since p is odd, to conclude 2p ∣ q−1.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "ZMod.exists_sq_eq_two_iff",
+        "description": "For q an odd prime, IsSquare (2 : ZMod q) ↔ q % 8 = 1 ∨ q % 8 = 7. This is the second supplementary law of quadratic reciprocity; it converts the quadratic-residue fact into the ±1 (mod 8) congruence.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "Nat.modEq_iff_dvd'",
+        "description": "a ≤ b → (a ≡ b [MOD n] ↔ n ∣ b − a). Converts the divisibility 2p ∣ q − 1 into the congruence q ≡ 1 (mod 2p).",
+        "module": "Mathlib.Data.Nat.ModCast"
+      }
+    ],
+    "originalContributions": [
+      "prime_factor_congr_one_mod_two_mul: for an odd prime p and any prime q ∣ 2^p − 1, q ≡ 1 (mod 2p). Proved by identifying the multiplicative order of 2 in ZMod q with p and applying Fermat's little theorem, then merging the coprime divisors 2 and p of q − 1.",
+      "prime_factor_pm_one_mod_eight: for an odd prime p and any prime q ∣ 2^p − 1, q ≡ ±1 (mod 8) (i.e. q % 8 ∈ {1, 7}). Proved by exhibiting 2 as an explicit square 2 = (2^{(p+1)/2})² in ZMod q (using p odd and (2:ZMod q)^p = 1) and invoking the quadratic-residue characterisation of 2.",
+      "two_pow_eq_one_of_dvd: shared lemma casting q ∣ 2^p − 1 to (2 : ZMod q)^p = 1, the common entry point for both restrictions.",
+      "ne_two_of_dvd: 2^p − 1 is odd, so every prime factor q is odd (q ≠ 2), the hypothesis needed for both the coprimality merge and the quadratic-residue law."
+    ],
+    "dateAdded": "2026-07-05",
+    "relatedProblems": [
+      {
+        "id": "mersenne-prime-exponent",
+        "relationship": "Parent entry. It constrains the EXPONENT (2^n − 1 prime ⟹ n prime); this entry constrains the FACTORS (prime divisors of 2^p − 1 for p an odd prime lie in fixed residue classes mod 2p and mod 8)."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 126,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only the foundational propext, Classical.choice, Quot.sound — no sorryAx, no Lean.ofReduceBool. Hypotheses are exactly the mathematically necessary ones: p is an odd prime (required — for p = 2, 2^2 − 1 = 3 and 3 ≢ 1 mod 4 and 3 ≢ ±1 mod 8, so the restrictions genuinely fail at p = 2) and q is a prime dividing 2^p − 1.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Mersenne numbers M_p = 2^p − 1 have been studied since antiquity, but the systematic search for Mersenne primes rests on two elementary factorisation facts. First (parent entry): M_n prime forces n prime. Second, due to Fermat and Euler: any prime factor q of M_p, for p an odd prime, is heavily constrained. Fermat showed q ≡ 1 (mod p) — in fact q ≡ 1 (mod 2p) — and Euler added q ≡ ±1 (mod 8). Euler used exactly these restrictions to factor small Mersenne numbers by hand (e.g. finding 2^37 − 1 = 223 · 616318177 with 223 = 6·37 + 1). The mod-8 condition is the second supplementary law of quadratic reciprocity: 2 is a quadratic residue mod q iff q ≡ ±1 (mod 8).",
+    "problemStatement": "Formalise, over Mathlib, the two classical congruence restrictions on the prime factors of a Mersenne number 2^p − 1 with p an odd prime: every prime q dividing 2^p − 1 satisfies q ≡ 1 (mod 2p) and q ≡ ±1 (mod 8).",
+    "text": "Let p be an odd prime and q a prime with q ∣ 2^p − 1. Cast the divisibility into the finite field ZMod q: it says (2 : ZMod q)^p = 1. The multiplicative order d of 2 in ZMod q therefore divides p. Since p is prime, d = 1 or d = p; but d = 1 means 2 = 1 in ZMod q, i.e. q ∣ 1, impossible, so d = p. Fermat's little theorem gives 2^{q−1} = 1 in ZMod q, hence d = p divides q − 1. As q is an odd prime, q − 1 is even, so 2 ∣ q − 1 as well; p and 2 are coprime (p odd), so 2p ∣ q − 1, which is q ≡ 1 (mod 2p). For the mod-8 restriction, oddness of p lets us write 2 = 2 · 1 = 2 · 2^p = 2^{p+1} = (2^{(p+1)/2})² in ZMod q, exhibiting 2 as a square; the quadratic-residue characterisation of 2 then gives q ≡ 1 or 7 (mod 8).",
+    "proofStrategy": "Two theorems share a cast lemma and an oddness lemma.\n\n1. **Cast (two_pow_eq_one_of_dvd).** ZMod.natCast_eq_zero_iff turns q ∣ 2^p − 1 into ((2^p − 1 : ℕ) : ZMod q) = 0; Nat.cast_sub (valid since 1 ≤ 2^p) and push_cast rewrite it to (2 : ZMod q)^p − 1 = 0, i.e. (2 : ZMod q)^p = 1.\n\n2. **Oddness (ne_two_of_dvd).** 2^p is even and ≥ 2, so 2^p − 1 is odd (Nat.Even.sub_odd); a prime factor of an odd number cannot be 2 (an omega contradiction from the two parity witnesses).\n\n3. **Order = p (mod-2p theorem).** orderOf_dvd_of_pow_eq_one gives orderOf 2 ∣ p; Nat.Prime.eq_one_or_self_of_dvd splits into 1 or p; orderOf_eq_one_iff rules out 1 (since 2 ≠ 1 in ZMod q, as q ∤ 2). Fermat (ZMod.pow_card_sub_one_eq_one) gives orderOf 2 ∣ q − 1, so p ∣ q − 1. Add 2 ∣ q − 1 (q odd) and coprimality of 2, p to reach 2p ∣ q − 1, then Nat.modEq_iff_dvd' delivers q ≡ 1 (mod 2p).\n\n4. **Quadratic residue (mod-8 theorem).** Write p = 2k + 1; then (2^{k+1})² = 2^{2k+2} = 2^{p+1} = 2^p · 2 = 2 in ZMod q, so IsSquare (2 : ZMod q). ZMod.exists_sq_eq_two_iff converts this to q % 8 = 1 ∨ q % 8 = 7.",
+    "keyInsights": [
+      "**The order of 2 pins down the modulus.** The single fact orderOf (2 : ZMod q) = p carries the whole mod-2p restriction: it forces p ∣ q − 1 via Fermat, and the only extra ingredient is the trivial 2 ∣ q − 1 from q being odd. Primality of p is what collapses the order to exactly p (not a proper divisor).",
+      "**p = 2 must be excluded, and the proof shows why.** The argument uses p odd twice: for coprimality of 2 and p (the mod-2p merge) and to write 2 as a square (the mod-8 residue). Both genuinely fail at p = 2, where 2^2 − 1 = 3 violates each restriction — so the odd-prime hypothesis is necessary, not cosmetic.",
+      "**2 is a square mod q for free.** Because 2^p = 1 in ZMod q and p is odd, 2 = 2^{p+1} is an even power, hence a perfect square, with the square root written explicitly as 2^{(p+1)/2}. No Legendre-symbol computation is needed to see that 2 is a quadratic residue — the Mersenne relation supplies it.",
+      "**The mod-8 law is quadratic reciprocity's second supplement.** Converting 'IsSquare 2' to 'q ≡ ±1 (mod 8)' is exactly ZMod.exists_sq_eq_two_iff, the formal content of the second supplementary law; the Mersenne structure only has to deliver the residue hypothesis."
+    ],
+    "prerequisites": [
+      "Modular arithmetic and the finite field ZMod q for q prime",
+      "Multiplicative order of an element and its divisibility properties",
+      "Fermat's little theorem",
+      "Quadratic residues and the second supplementary law (2 is a QR mod q ⟺ q ≡ ±1 mod 8)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "shared",
+      "title": "Casting the Divisibility and Oddness of Factors",
+      "startLine": 48,
+      "endLine": 71,
+      "mathContext": "$q \\mid 2^p - 1 \\;\\Rightarrow\\; (2 : \\mathbb{Z}/q)^p = 1,\\qquad q \\ne 2$",
+      "summary": "two_pow_eq_one_of_dvd casts q ∣ 2^p − 1 into ZMod q as (2 : ZMod q)^p = 1 via ZMod.natCast_eq_zero_iff and a Nat-subtraction cast; ne_two_of_dvd shows 2^p − 1 is odd so every prime factor q is odd."
+    },
+    {
+      "id": "mod2p",
+      "title": "The Modulus Restriction q ≡ 1 (mod 2p)",
+      "startLine": 72,
+      "endLine": 107,
+      "mathContext": "$\\operatorname{ord}_q(2) = p,\\quad p \\mid q-1,\\quad 2 \\mid q-1 \\;\\Rightarrow\\; q \\equiv 1 \\pmod{2p}$",
+      "summary": "prime_factor_congr_one_mod_two_mul identifies orderOf (2 : ZMod q) with the prime p (ruling out order 1), applies Fermat's little theorem to get p ∣ q − 1, adds 2 ∣ q − 1 from oddness, and merges the coprime divisors into 2p ∣ q − 1, i.e. q ≡ 1 (mod 2p)."
+    },
+    {
+      "id": "mod8",
+      "title": "The Residue Restriction q ≡ ±1 (mod 8)",
+      "startLine": 108,
+      "endLine": 126,
+      "mathContext": "$2 = (2^{(p+1)/2})^2 \\text{ in } \\mathbb{Z}/q \\;\\Rightarrow\\; q \\bmod 8 \\in \\{1, 7\\}$",
+      "summary": "prime_factor_pm_one_mod_eight exhibits 2 as an explicit square in ZMod q (using p odd and (2:ZMod q)^p = 1), then applies ZMod.exists_sq_eq_two_iff to conclude q % 8 = 1 ∨ q % 8 = 7."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "mersenne-prime-exponent",
+      "relationship": "extends",
+      "description": "The parent entry constrains the exponent of a Mersenne prime; this entry constrains the prime factors of a (possibly composite) Mersenne number, giving the residue-class restrictions used in Mersenne trial division."
+    }
+  ],
+  "conclusion": {
+    "summary": "For an odd prime p, every prime factor q of the Mersenne number 2^p − 1 satisfies q ≡ 1 (mod 2p) and q ≡ ±1 (mod 8). Both restrictions are formalised in Lean 4 over Mathlib by working in the field ZMod q: the multiplicative order of 2 is exactly p (Fermat ⟹ p ∣ q−1, merged with 2 ∣ q−1), and 2 is an explicit quadratic residue (⟹ q ≡ ±1 mod 8 via the second supplementary law). Verified, 0 axioms, 0 sorries.",
+    "implications": "These are the residue-class filters underlying efficient Mersenne trial division: candidate factors need only be tested among primes q = 2kp + 1 with q ≡ ±1 (mod 8). The order-of-2 argument is the standard template for factor restrictions of numbers a^n ± 1, and the 'even power ⟹ quadratic residue' trick generalises to other bases.",
+    "openQuestions": [
+      "Formalise the sharper factor restriction for the base-a case a^p − 1 (p odd prime, q ∤ a): orderOf a = p, giving q ≡ 1 (mod 2p); and characterise when a is a quadratic residue mod q to obtain the analogue of the mod-8 condition.",
+      "Package the two restrictions into a trial-division search-space bound: the smallest prime factor of a composite 2^p − 1 is ≥ 2p + 1, and enumerate the admissible residue classes mod 8p explicitly."
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/MersennePrimeExponentOQ02.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "MersennePrimeExponentOQ02",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Observations on a theorem of Fermat and others on prime factors of Mersenne numbers",
+      "year": "1750",
+      "venue": "Novi Commentarii academiae scientiarum Petropolitanae",
+      "note": "Euler's determination that prime factors of 2^p − 1 satisfy q ≡ 1 (mod 2p) and q ≡ ±1 (mod 8), used to factor Mersenne numbers by hand."
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press (6th ed.), §6.15",
+      "note": "Textbook treatment of the order-of-2 argument and the quadratic-residue restriction for Mersenne factors."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "prime_factor_congr_one_mod_two_mul",
+      "type": "core",
+      "description": "For an odd prime p and any prime q dividing 2^p − 1, q ≡ 1 (mod 2p).",
+      "leanType": "(hp : p.Prime) → (hpodd : Odd p) → (hq : q.Prime) → (hdvd : q ∣ 2 ^ p - 1) → q ≡ 1 [MOD 2 * p]"
+    },
+    {
+      "name": "prime_factor_pm_one_mod_eight",
+      "type": "core",
+      "description": "For an odd prime p and any prime q dividing 2^p − 1, q ≡ ±1 (mod 8), i.e. q % 8 = 1 ∨ q % 8 = 7.",
+      "leanType": "(hp : p.Prime) → (hpodd : Odd p) → (hq : q.Prime) → (hdvd : q ∣ 2 ^ p - 1) → q % 8 = 1 ∨ q % 8 = 7"
+    },
+    {
+      "name": "two_pow_eq_one_of_dvd",
+      "type": "supporting",
+      "description": "Casting lemma: a prime q dividing 2^p − 1 gives (2 : ZMod q)^p = 1.",
+      "leanType": "(hq : q.Prime) → (hdvd : q ∣ 2 ^ p - 1) → (2 : ZMod q) ^ p = 1"
+    },
+    {
+      "name": "ne_two_of_dvd",
+      "type": "supporting",
+      "description": "Every prime factor of the odd number 2^p − 1 is odd.",
+      "leanType": "(hp : p.Prime) → (hq : q.Prime) → (hdvd : q ∣ 2 ^ p - 1) → q ≠ 2"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **mersenne-prime-exponent-oq-02** — the classical congruence restrictions on the prime *factors* of a Mersenne number `2^p − 1` when the exponent `p` is an odd prime. This is precisely the open question posed in the parent entry's conclusion (`mersenne-prime-exponent`).

For an odd prime `p` and any prime `q ∣ 2^p − 1`:
- `prime_factor_congr_one_mod_two_mul` : **q ≡ 1 (mod 2p)**
- `prime_factor_pm_one_mod_eight`      : **q ≡ ±1 (mod 8)** (i.e. `q % 8 ∈ {1, 7}`)

These are the classical trial-division shortcuts (Euler/Lagrange) that make Mersenne factor search feasible.

## Proof sketch

Working in the field `ZMod q`:
- `q ∣ 2^p − 1` ⟹ `(2 : ZMod q)^p = 1`, so `orderOf 2 ∣ p`; order `1` would force `q ∣ 1`, hence `orderOf 2 = p`.
- **mod 2p:** Fermat (`ZMod.pow_card_sub_one_eq_one`) gives `p ∣ q−1`; `q` odd gives `2 ∣ q−1`; coprimality of `2, p` (p odd) yields `2p ∣ q−1`.
- **mod 8:** `p` odd ⟹ `2 = 2·2^p = (2^{(p+1)/2})²` in `ZMod q`, so `2` is a QR; `ZMod.exists_sq_eq_two_iff` gives `q % 8 ∈ {1, 7}`.

## Verification

- Builds under Mathlib 4.26.0 via `./proofs/scripts/docker-build.sh Proofs.MersennePrimeExponentOQ02` ✓
- **0 sorries, 0 axioms**, no `native_decide` (`#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound`).
- Hypotheses are exactly the necessary ones: `p` odd prime (the restrictions genuinely fail at `p = 2`) and `q` prime dividing `2^p − 1`.

## Files
- `proofs/Proofs/MersennePrimeExponentOQ02.lean` (126 lines, 4 theorems)
- `src/data/proofs/mersenne-prime-exponent-oq-02/meta.json` (gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)