### PR TITLE
research(tetrahedral-number-formula): sum of triangular numbers = tetrahedral number [VERIFIED, 0 sorry/0 axiom]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormula.lean
+++ b/proofs/Proofs/TetrahedralNumberFormula.lean
@@ -1,0 +1,127 @@
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Tactic
+
+/-
+# Sum of Triangular Numbers Equals the Tetrahedral Number
+
+## Open Question (tetrahedral-number-formula)
+
+"The running total of the first `n` triangular numbers is the `n`-th tetrahedral
+number":
+
+    ∑_{k=1}^{n} T_k = C(n+2, 3) = n·(n+1)·(n+2)/6,   where T_k = C(k+1, 2) = k·(k+1)/2.
+
+This is the `d = 3` rung of the figurate-number ladder (linear → triangular →
+tetrahedral) and the `d = 3` case of the hockey-stick identity
+`∑_{k} C(k+d-2, d-1) = C(n+d-1, d)`.
+
+## Result
+
+A fully machine-checked, self-contained proof by induction, phrased with
+`Nat.choose` so that no division ever appears:
+
+* `sum_triangular_choose` : `∑_{k<n+1} C(k+1, 2) = C(n+2, 3)`   — the clean
+  hockey-stick statement (each summand is the triangular number `T_k`);
+* `six_mul_sum_triangular` : `6·∑_{k<n+1} C(k+1, 2) = n·(n+1)·(n+2)` — the
+  division-free polynomial identity requested by the problem;
+* `six_mul_choose_three` : `6·C(n+2, 3) = n·(n+1)·(n+2)`         — the cleared
+  closed form for the tetrahedral number itself.
+
+The inductive steps use only `Finset.sum_range_succ`, Pascal's rule
+(`Nat.choose_succ_succ`), and `ring`/`omega`; the sole ℕ-division in the
+classical statement is bypassed by working with `Nat.choose` and clearing
+denominators.
+
+## Novelty
+
+Mathlib has `Nat.choose_two_right` and Pascal's rule but neither the tetrahedral
+(sum-of-triangular-numbers) closed form nor the `d = 3` hockey-stick identity as
+a named lemma. This file supplies both, alongside the explicit
+`T_k = k·(k+1)/2` phrasing that connects the `choose` form to the elementary
+triangular-number definition.
+
+0 sorries, 0 axioms.
+-/
+
+namespace TetrahedralNumberFormula
+
+open Finset
+
+/-- The `k`-th triangular number as a binomial coefficient, `T_k = C(k+1, 2)`,
+equals the elementary closed form `k·(k+1)/2`. Provided so the `choose`-based
+identities below can be read in the familiar `T_k = k(k+1)/2` notation. -/
+theorem triangular_choose_eq (k : ℕ) : (k + 1).choose 2 = k * (k + 1) / 2 := by
+  rw [Nat.choose_two_right, Nat.add_sub_cancel, Nat.mul_comm]
+
+/-- Twice the `k`-th triangular number is `k·(k+1)`: a division-free restatement
+of `T_k = k·(k+1)/2`. Since `k·(k+1)` is even, clearing the `/2` is exact. -/
+theorem two_mul_triangular_choose (k : ℕ) :
+    2 * (k + 1).choose 2 = k * (k + 1) := by
+  rw [triangular_choose_eq]
+  exact Nat.mul_div_cancel' (Nat.even_mul_succ_self k).two_dvd
+
+/-- **Tetrahedral number formula (division-free).** Six times the sum of the
+first `n` triangular numbers `T_k = C(k+1, 2)` (for `k = 0,…,n`, the `k = 0`
+term being `0`) equals `n·(n+1)·(n+2)`:
+
+`6·∑_{k<n+1} C(k+1, 2) = n·(n+1)·(n+2)`.
+
+This is the cleared-denominator form of the classical
+`∑ T_k = n(n+1)(n+2)/6`. Proved directly by induction: the new summand
+`T_{m+1} = C(m+2, 2)` contributes `6·C(m+2, 2) = 3·(m+1)·(m+2)` via
+`two_mul_triangular_choose`, and `ring` closes the polynomial step. -/
+theorem six_mul_sum_triangular (n : ℕ) :
+    6 * ∑ k ∈ range (n + 1), (k + 1).choose 2 = n * (n + 1) * (n + 2) := by
+  induction n with
+  | zero => rfl
+  | succ m ih =>
+    rw [sum_range_succ, Nat.mul_add]
+    -- 6·∑_{k<m+1} + 6·C(m+2, 2) = (m+1)·(m+2)·(m+3)
+    rw [ih]
+    have hnew : 6 * (m + 1 + 1).choose 2 = 3 * ((m + 1) * (m + 1 + 1)) := by
+      have h := two_mul_triangular_choose (m + 1)
+      omega
+    rw [hnew]
+    ring
+
+/-- **Sum of triangular numbers = tetrahedral number (hockey-stick, `d = 3`).**
+The sum of the first `n` triangular numbers `T_k = C(k+1, 2)` equals the
+tetrahedral number `C(n+2, 3)`:
+
+`∑_{k<n+1} C(k+1, 2) = C(n+2, 3)`.
+
+The inductive step is a single application of Pascal's rule
+`C(m+3, 3) = C(m+2, 2) + C(m+2, 3)`, matching the newly added summand
+`T_{m+1} = C(m+2, 2)`. -/
+theorem sum_triangular_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), (k + 1).choose 2 = (n + 2).choose 3 := by
+  induction n with
+  | zero => rfl
+  | succ m ih =>
+    rw [sum_range_succ, ih]
+    -- C(m+2, 3) + C(m+1+1, 2) = C(m+1+2, 3)
+    have pascal : (m + 1 + 2).choose 3
+        = (m + 1 + 1).choose 2 + (m + 2).choose 3 :=
+      Nat.choose_succ_succ (m + 2) 2
+    rw [pascal]
+    omega
+
+/-- **Tetrahedral closed form.** Six times the tetrahedral number `C(n+2, 3)`
+equals `n·(n+1)·(n+2)`; the cleared-denominator form of
+`C(n+2, 3) = n(n+1)(n+2)/6`. Immediate from the hockey-stick identity and the
+polynomial sum formula. -/
+theorem six_mul_choose_three (n : ℕ) :
+    6 * (n + 2).choose 3 = n * (n + 1) * (n + 2) := by
+  rw [← sum_triangular_choose]
+  exact six_mul_sum_triangular n
+
+/-- The hockey-stick identity phrased with the elementary triangular number
+`T_k = k·(k+1)/2` in place of `C(k+1, 2)`:
+
+`∑_{k<n+1} k·(k+1)/2 = C(n+2, 3)`. -/
+theorem sum_triangular_div (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * (k + 1) / 2 = (n + 2).choose 3 := by
+  rw [← sum_triangular_choose]
+  exact Finset.sum_congr rfl fun k _ => (triangular_choose_eq k).symm
+
+end TetrahedralNumberFormula

--- a/src/data/proofs/tetrahedral-number-formula/annotations.json
+++ b/src/data/proofs/tetrahedral-number-formula/annotations.json
@@ -1,0 +1,89 @@
+[
+  {
+    "id": "ann-triangular-bridge",
+    "proofId": "tetrahedral-number-formula",
+    "range": {
+      "startLine": 50,
+      "endLine": 61
+    },
+    "type": "theorem",
+    "title": "Triangular number as a binomial: C(k+1,2) = k(k+1)/2 and 2·C(k+1,2) = k(k+1)",
+    "content": "These two bridge lemmas connect the clean binomial summand to the elementary triangular number. `triangular_choose_eq` rewrites $\\binom{k+1}{2}$ to $k(k+1)/2$ using `Nat.choose_two_right` ($\\binom{n}{2} = n(n-1)/2$) followed by `Nat.add_sub_cancel` and `Nat.mul_comm`. `two_mul_triangular_choose` then clears the halving *exactly*: $2\\binom{k+1}{2} = k(k+1)$. Because $k(k+1)$ is a product of consecutive integers it is even (`Nat.even_mul_succ_self`), so `Nat.mul_div_cancel'` cancels the $\\times 2$ against the $/2$ with no truncated-division reasoning. This division-free restatement is what lets the polynomial sum formula stay entirely in $\\mathbb{N}$.",
+    "mathContext": "$\\binom{k+1}{2} = \\tfrac{k(k+1)}{2}$ and $2\\binom{k+1}{2} = k(k+1)$.",
+    "significance": "high",
+    "prerequisites": [
+      "Binomial coefficients",
+      "Parity of consecutive products"
+    ],
+    "relatedConcepts": [
+      "Triangular numbers",
+      "Nat.choose_two_right",
+      "Truncated natural division"
+    ]
+  },
+  {
+    "id": "ann-polynomial-sum",
+    "proofId": "tetrahedral-number-formula",
+    "range": {
+      "startLine": 63,
+      "endLine": 85
+    },
+    "type": "theorem",
+    "title": "Cleared-denominator sum formula: 6·∑ C(k+1,2) = n(n+1)(n+2)",
+    "content": "The division-free polynomial identity requested by the problem, proved by direct induction. The base case is `rfl`. In the step, `sum_range_succ` peels off the new summand $\\binom{m+2}{2}$ and `Nat.mul_add` distributes the leading $6$. The inductive hypothesis rewrites the accumulated sum to $m(m+1)(m+2)$; the new term's contribution $6\\binom{m+2}{2}$ is turned into $3(m+1)(m+2)$ by `two_mul_triangular_choose (m+1)` (spliced in as a hypothesis and discharged by `omega`, which atomizes the binomial). A single `ring` then verifies the degree-3 polynomial step $m(m+1)(m+2) + 3(m+1)(m+2) = (m+1)(m+2)(m+3)$. No division and no truncated subtraction appear.",
+    "mathContext": "$6\\sum_{k\\le n} \\binom{k+1}{2} = n(n+1)(n+2)$.",
+    "significance": "critical",
+    "prerequisites": [
+      "Mathematical induction",
+      "Finset.sum_range_succ"
+    ],
+    "relatedConcepts": [
+      "ring tactic",
+      "omega tactic",
+      "Faulhaber-style clear-denominator inductions"
+    ]
+  },
+  {
+    "id": "ann-hockey-stick",
+    "proofId": "tetrahedral-number-formula",
+    "range": {
+      "startLine": 87,
+      "endLine": 107
+    },
+    "type": "insight",
+    "title": "Pascal's rule IS the inductive step (hockey-stick, d=3)",
+    "content": "The centerpiece $\\sum_{k\\le n} \\binom{k+1}{2} = \\binom{n+2}{3}$ has an inductive step that is nothing more than **Pascal's rule**. After `sum_range_succ` and the hypothesis, the goal is $\\binom{m+2}{3} + \\binom{m+2}{2} = \\binom{m+3}{3}$. The `have pascal := Nat.choose_succ_succ (m+2) 2` supplies exactly $\\binom{m+3}{3} = \\binom{m+2}{2} + \\binom{m+2}{3}$ — note the lemma's `k+1` and `2+1` unify with the literals `2` and `3` by definitional equality, so the `have`'s stated form is accepted directly. `omega` then closes the commutative-addition bookkeeping. Conceptually: the newly summed triangular number $\\binom{m+2}{2}$ is precisely the gap between consecutive tetrahedral numbers, which is the whole content of the diagonal 'hockey-stick' sum in Pascal's triangle.",
+    "mathContext": "$\\binom{m+3}{3} = \\binom{m+2}{2} + \\binom{m+2}{3}$ (Pascal), whence $\\sum_{k\\le n}\\binom{k+1}{2} = \\binom{n+2}{3}$.",
+    "significance": "critical",
+    "prerequisites": [
+      "Pascal's rule",
+      "Mathematical induction"
+    ],
+    "relatedConcepts": [
+      "Hockey-stick identity",
+      "Pascal's triangle diagonals",
+      "Nat.choose_succ_succ"
+    ]
+  },
+  {
+    "id": "ann-tetrahedral-closed-form",
+    "proofId": "tetrahedral-number-formula",
+    "range": {
+      "startLine": 109,
+      "endLine": 126
+    },
+    "type": "theorem",
+    "title": "Tetrahedral closed form for free, and the T_k = k(k+1)/2 phrasing",
+    "content": "`six_mul_choose_three` states the tetrahedral number's own closed form $6\\binom{n+2}{3} = n(n+1)(n+2)$. Rather than a separate degree-3 Pascal induction, it is obtained by a one-line backward rewrite: `rw [← sum_triangular_choose]` turns $6\\binom{n+2}{3}$ into $6\\sum \\binom{k+1}{2}$, which is exactly `six_mul_sum_triangular`. Finally `sum_triangular_div` restates the hockey-stick identity with the elementary summand $k(k+1)/2$ in place of $\\binom{k+1}{2}$, using `Finset.sum_congr` and `triangular_choose_eq` termwise — the reader-facing form $\\sum_{k\\le n} k(k+1)/2 = \\binom{n+2}{3}$.",
+    "mathContext": "$6\\binom{n+2}{3} = n(n+1)(n+2)$ and $\\sum_{k\\le n} \\tfrac{k(k+1)}{2} = \\binom{n+2}{3}$.",
+    "significance": "high",
+    "prerequisites": [
+      "Finset.sum_congr"
+    ],
+    "relatedConcepts": [
+      "Tetrahedral numbers",
+      "Corollary derivation",
+      "Termwise rewriting"
+    ]
+  }
+]

--- a/src/data/proofs/tetrahedral-number-formula/meta.json
+++ b/src/data/proofs/tetrahedral-number-formula/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "tetrahedral-number-formula",
+  "title": "Sum of Triangular Numbers = Tetrahedral Number: ∑ C(k+1,2) = C(n+2,3)",
+  "slug": "tetrahedral-number-formula",
+  "description": "A fully machine-checked, self-contained proof that the running total of the first n triangular numbers is the n-th tetrahedral number: ∑_{k≤n} T_k = C(n+2,3) = n(n+1)(n+2)/6, where T_k = C(k+1,2) = k(k+1)/2. This is the d=3 rung of the figurate-number ladder (linear → triangular → tetrahedral) and the d=3 case of the hockey-stick identity ∑_k C(k+d-2,d-1) = C(n+d-1,d). The proof is phrased entirely with Nat.choose so that no division ever appears: the hockey-stick identity ∑_{k<n+1} C(k+1,2) = C(n+2,3) is proved by induction, its inductive step a single application of Pascal's rule C(m+3,3) = C(m+2,2) + C(m+2,3) matching the newly added summand T_{m+1} = C(m+2,2). The cleared-denominator polynomial form 6·∑ T_k = n(n+1)(n+2) is proved by a parallel direct induction, using that k(k+1) is even to clear the /2 in T_k exactly. Mathlib has Nat.choose_two_right and Pascal's rule but neither the tetrahedral closed form nor the d=3 hockey-stick identity as a named lemma.",
+  "meta": {
+    "author": "Classical (figurate numbers, antiquity; hockey-stick identity); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Tetrahedral_number",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "figurate-numbers",
+      "binomial-coefficients",
+      "hockey-stick-identity",
+      "triangular-numbers",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/TetrahedralNumberFormula.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule: (n+1).choose (k+1) = n.choose k + n.choose (k+1). The engine of the hockey-stick inductive step.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_two_right",
+        "description": "n.choose 2 = n*(n-1)/2, used to identify the binomial summand C(k+1,2) with the elementary triangular number k(k+1)/2.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term off a range-sum: ∑_{i<n+1} f i = (∑_{i<n} f i) + f n. Exposes the new triangular-number summand in each inductive step.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.even_mul_succ_self",
+        "description": "Even (n*(n+1)): the consecutive-product parity fact that makes clearing the /2 in T_k = k(k+1)/2 exact.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel'",
+        "description": "a ∣ b → a*(b/a) = b, used to turn 2·C(k+1,2) into k(k+1) without truncated division.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "The tetrahedral number identity ∑_{k≤n} C(k+1,2) = C(n+2,3) — the running total of the first n triangular numbers equals the n-th tetrahedral number — machine-checked with 0 axioms and 0 sorries (Mathlib has neither this identity nor the d=3 hockey-stick sum as a named lemma)",
+      "A division-free formalization: every statement is phrased with Nat.choose, so the classical /6 (and the /2 inside T_k = k(k+1)/2) never appears in the core inductions; Pascal's rule and ring/omega do all the work over ℕ",
+      "The cleared-denominator polynomial form 6·∑_{k≤n} C(k+1,2) = n(n+1)(n+2), proved by a direct induction whose step uses two_mul_triangular_choose (2·C(m+2,2) = (m+1)(m+2)) so the whole argument stays in ℕ with no truncated subtraction and no division",
+      "The tetrahedral closed form 6·C(n+2,3) = n(n+1)(n+2) obtained for free by combining the hockey-stick identity with the polynomial sum formula, rather than by a separate degree-3 Pascal induction",
+      "The bridge lemmas triangular_choose_eq (C(k+1,2) = k(k+1)/2) and two_mul_triangular_choose (2·C(k+1,2) = k(k+1)), connecting the clean binomial statement to the elementary triangular-number definition, with the sum restated in the familiar ∑ k(k+1)/2 form (sum_triangular_div)"
+    ],
+    "dateAdded": "2026-07-05",
+    "axiomCount": 0,
+    "lineCount": 127,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions) for all four public theorems (sum_triangular_choose, six_mul_sum_triangular, six_mul_choose_three, sum_triangular_div). No native_decide, so no Lean.ofReduceBool; no sorryAx; no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "triangular-bridge",
+      "title": "Triangular number as a binomial coefficient",
+      "startLine": 50,
+      "endLine": 61,
+      "summary": "The bridge lemmas connecting the clean binomial summand C(k+1,2) to the elementary triangular number k(k+1)/2. triangular_choose_eq rewrites C(k+1,2) to k(k+1)/2 via Nat.choose_two_right and Nat.add_sub_cancel; two_mul_triangular_choose clears the /2 exactly, 2·C(k+1,2) = k(k+1), using that k(k+1) is even (Nat.even_mul_succ_self) and Nat.mul_div_cancel'."
+    },
+    {
+      "id": "polynomial-sum",
+      "title": "Cleared-denominator sum formula: 6·∑ T_k = n(n+1)(n+2)",
+      "startLine": 63,
+      "endLine": 85,
+      "summary": "The division-free polynomial identity six_mul_sum_triangular, proved by direct induction. sum_range_succ exposes the new summand C(m+2,2); its contribution 6·C(m+2,2) is rewritten to 3·(m+1)·(m+2) via two_mul_triangular_choose (spliced in by omega), and ring closes the degree-3 polynomial step m(m+1)(m+2) + 3(m+1)(m+2) = (m+1)(m+2)(m+3)."
+    },
+    {
+      "id": "hockey-stick",
+      "title": "Hockey-stick identity (d=3): ∑ C(k+1,2) = C(n+2,3)",
+      "startLine": 87,
+      "endLine": 107,
+      "summary": "The clean binomial statement sum_triangular_choose. The inductive step is a single application of Pascal's rule C(m+3,3) = C(m+2,2) + C(m+2,3) (Nat.choose_succ_succ), matching the newly added triangular summand T_{m+1} = C(m+2,2); omega closes the commutative-addition bookkeeping."
+    },
+    {
+      "id": "tetrahedral-closed-form",
+      "title": "Tetrahedral closed form and triangular-division phrasing",
+      "startLine": 109,
+      "endLine": 126,
+      "summary": "six_mul_choose_three (6·C(n+2,3) = n(n+1)(n+2)) is obtained for free by rewriting the hockey-stick identity backwards into the polynomial sum formula — no separate degree-3 Pascal induction is needed. sum_triangular_div restates the identity with the elementary summand k(k+1)/2 via Finset.sum_congr and triangular_choose_eq."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Figurate numbers and the hockey-stick identity**\n\nThe *figurate numbers* — counting dots in regular geometric arrangements — go back to the Pythagoreans. The **triangular numbers** $T_k = 1 + 2 + \\cdots + k = \\binom{k+1}{2} = \\tfrac{k(k+1)}{2}$ count dots in a triangle; stacking triangles of $1, 3, 6, \\ldots$ dots into a tetrahedron gives the **tetrahedral numbers** $\\mathrm{Te}_n = \\binom{n+2}{3} = \\tfrac{n(n+1)(n+2)}{6}$. That the running total of triangular numbers is exactly tetrahedral,\n$$\\sum_{k=1}^{n} T_k = \\binom{n+2}{3},$$\nis the $d=3$ case of the **hockey-stick identity** $\\sum_{k} \\binom{k+d-2}{d-1} = \\binom{n+d-1}{d}$ — a diagonal sum in Pascal's triangle. This entry sits one rung above the arithmetic series ($\\sum k = \\binom{n+1}{2}$) and alongside the Nicomachus sum-of-cubes family, rounding out the gallery's coverage of elementary closed-form summation.",
+    "problemStatement": "**Sum of the first n triangular numbers**\n\nWith $T_k = \\binom{k+1}{2} = \\tfrac{k(k+1)}{2}$ (indexing over `range (n+1)`, so the $k=0$ term vanishes and the sum counts $T_1, \\ldots, T_n$), prove that for every natural number $n$,\n$$\\sum_{k\\le n} \\binom{k+1}{2} = \\binom{n+2}{3} = \\frac{n(n+1)(n+2)}{6}.$$\nThe goal is a fully machine-checked proof with no axioms and no sorries, and — the design constraint — with no division appearing in the core argument.",
+    "proofStrategy": "**Work with Nat.choose so division never appears**\n\nThe classical statement carries a $/6$, and the summand $T_k = k(k+1)/2$ carries a $/2$; truncated $\\mathbb{N}$-division is hostile to `ring`. The fix is to phrase everything with binomial coefficients. The centerpiece $\\sum_{k\\le n} \\binom{k+1}{2} = \\binom{n+2}{3}$ is proved by induction: `sum_range_succ` exposes the new summand $\\binom{m+2}{2}$, and **Pascal's rule** $\\binom{m+3}{3} = \\binom{m+2}{2} + \\binom{m+2}{3}$ matches it exactly, so the step is pure diagonal-sum bookkeeping (`omega`). The cleared-denominator polynomial form $6\\sum T_k = n(n+1)(n+2)$ is proved by a parallel direct induction, where the new summand's contribution $6\\binom{m+2}{2}$ is turned into $3(m+1)(m+2)$ by the exact identity $2\\binom{k+1}{2} = k(k+1)$ (valid because $k(k+1)$ is even), and `ring` closes the degree-3 step. The tetrahedral closed form $6\\binom{n+2}{3} = n(n+1)(n+2)$ then follows for free by rewriting the hockey-stick identity backwards into the polynomial sum.",
+    "keyInsights": [
+      "**Phrase it with binomials, and the division evaporates.** Writing $T_k = \\binom{k+1}{2}$ and $\\mathrm{Te}_n = \\binom{n+2}{3}$ turns both the $/2$ and the $/6$ into `Nat.choose`, so the core inductions live in $\\mathbb{N}$ with no truncated division anywhere.",
+      "**Pascal's rule *is* the inductive step.** The hockey-stick identity's step is nothing more than $\\binom{m+3}{3} = \\binom{m+2}{2} + \\binom{m+2}{3}$: the newly summed triangular number $\\binom{m+2}{2}$ is exactly the difference between consecutive tetrahedral numbers. No algebra beyond commuting an addition is needed.",
+      "**Clear the /2 with a parity fact, not a division lemma.** For the polynomial form, $2\\binom{k+1}{2} = k(k+1)$ holds exactly because $k(k+1)$ is even; `Nat.mul_div_cancel'` fed by `Nat.even_mul_succ_self` clears the halving without ever reasoning about truncated division.",
+      "**The closed form is a corollary, not a third induction.** Once the hockey-stick identity and the polynomial sum formula are both in hand, $6\\binom{n+2}{3} = n(n+1)(n+2)$ falls out by a one-line backward rewrite — no separate degree-3 Pascal induction on the tetrahedral number itself."
+    ],
+    "prerequisites": [
+      "Mathematical induction",
+      "Finite sums over `Finset.range`",
+      "Binomial coefficients and Pascal's rule (Nat.choose)",
+      "Truncated natural-number subtraction and division"
+    ]
+  },
+  "conclusion": {
+    "summary": "The tetrahedral number formula $\\sum_{k\\le n} \\binom{k+1}{2} = \\binom{n+2}{3}$ — the $d=3$ hockey-stick identity — is established by a short induction whose step is a single application of Pascal's rule. Phrasing every statement with `Nat.choose` keeps the classical $/6$ (and the $/2$ in $T_k = k(k+1)/2$) out of the core argument entirely; the cleared-denominator polynomial form $6\\sum T_k = n(n+1)(n+2)$ is proved by a parallel `ring`-driven induction, and the tetrahedral closed form $6\\binom{n+2}{3} = n(n+1)(n+2)$ follows as a one-line corollary. 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the tetrahedral (sum-of-triangular-numbers) closed form and the d=3 hockey-stick identity, neither of which is a named lemma in Mathlib, in both binomial and cleared-denominator polynomial forms.",
+      "Demonstrates the 'phrase it with Nat.choose' technique for division-carrying figurate-number identities: Pascal's rule replaces algebraic manipulation of the /6 closed form with pure diagonal-sum bookkeeping.",
+      "Rounds out the gallery's figurate-number ladder (arithmetic series → triangular → tetrahedral) with a reusable 'column of Pascal's triangle' lemma."
+    ],
+    "openQuestions": [
+      "Does the same Pascal-rule induction give the general hockey-stick identity ∑_{k<n+1} C(k+d-2,d-1) = C(n+d-1,d) for arbitrary d (the r-simplicial / hyper-tetrahedral numbers) as a single Lean theorem, with the triangular (d=2) and tetrahedral (d=3) cases as instances?",
+      "Can the cleared-denominator polynomial form for general d be produced uniformly, or does the growing factorial denominator d! force per-dimension parity arguments?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "arithmetic-series",
+      "relationship": "The d=2 rung below this one",
+      "description": "The Gauss sum ∑_{k=1}^n k = n(n+1)/2 = C(n+1,2) — the triangular numbers themselves. This entry sums those triangular numbers one dimension up, ∑ C(k+1,2) = C(n+2,3), the next diagonal of Pascal's triangle."
+    },
+    {
+      "proofId": "nicomachus-sum-of-cubes-oq-01",
+      "relationship": "Sibling elementary closed-form summation",
+      "description": "Nicomachus's theorem ∑ k³ = (∑ k)². A companion figurate/power-sum identity proved by the same induction-plus-fixed-identity pattern; here the closed form is a binomial coefficient rather than a perfect square, so Pascal's rule replaces the triangular-number squaring."
+    },
+    {
+      "proofId": "nicomachus-sum-of-cubes-oq-04",
+      "relationship": "Sibling power-sum entry sharing the clear-denominator theme",
+      "description": "Faulhaber's fifth-power sum ∑ k⁵ = n²(n+1)²(2n²+2n−1)/12. Both entries dissolve a rational closed form into a division-free ℕ statement; there by clearing the denominator and a subtraction, here by re-expressing the whole identity with Nat.choose."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry filling the **tetrahedral-number-formula** gallery gap: a fully machine-checked proof (0 sorries, 0 axioms) that the running total of the first *n* triangular numbers is the *n*-th tetrahedral number.

$$\sum_{k\le n} \binom{k+1}{2} = \binom{n+2}{3} = \frac{n(n+1)(n+2)}{6}, \qquad T_k = \binom{k+1}{2} = \frac{k(k+1)}{2}.$$

This is the **d = 3 case of the hockey-stick identity** $\sum_k \binom{k+d-2}{d-1} = \binom{n+d-1}{d}$ — the diagonal sum in Pascal's triangle — and the next rung of the figurate-number ladder (arithmetic series → triangular → tetrahedral).

## Theorems (`Proofs/TetrahedralNumberFormula.lean`)

| Theorem | Statement |
|---|---|
| `sum_triangular_choose` | `∑_{k<n+1} C(k+1,2) = C(n+2,3)` (hockey-stick, d=3) |
| `six_mul_sum_triangular` | `6·∑_{k<n+1} C(k+1,2) = n(n+1)(n+2)` (cleared-denominator form) |
| `six_mul_choose_three` | `6·C(n+2,3) = n(n+1)(n+2)` (tetrahedral closed form) |
| `sum_triangular_div` | `∑_{k<n+1} k(k+1)/2 = C(n+2,3)` (elementary T_k phrasing) |
| `triangular_choose_eq`, `two_mul_triangular_choose` | bridge lemmas C(k+1,2) = k(k+1)/2 |

## Approach

**Phrase everything with `Nat.choose` so division never enters the core argument.** The classical statement carries a `/6` and the summand `T_k` carries a `/2`; truncated ℕ-division is hostile to `ring`. Writing $T_k = \binom{k+1}{2}$ and $\mathrm{Te}_n = \binom{n+2}{3}$ turns both into binomial coefficients.

- The hockey-stick identity's inductive step **is** Pascal's rule: $\binom{m+3}{3} = \binom{m+2}{2} + \binom{m+2}{3}$ matches the newly summed triangular number exactly, so the step is pure diagonal-sum bookkeeping (`omega`).
- The polynomial form clears the `/2` in $T_k$ via the parity fact that $k(k+1)$ is even (`Nat.even_mul_succ_self` + `Nat.mul_div_cancel'`), keeping the whole induction in ℕ; `ring` closes the degree-3 step.
- The tetrahedral closed form is a one-line corollary (backward rewrite), not a separate induction.

## Verification

- Built via `./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormula` against Mathlib 4.26.0 — build succeeds.
- `#print axioms` on all four public theorems reports only `propext`, `Classical.choice`, `Quot.sound`. No `native_decide`/`Lean.ofReduceBool`, no `sorryAx`, no structure-encoded assumptions. Status **verified**, badge **original**.

## Novelty

Mathlib has `Nat.choose_two_right` and Pascal's rule but neither the tetrahedral (sum-of-triangular-numbers) closed form nor the d=3 hockey-stick identity as a named lemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)