### PR TITLE
research(erdos-1013-oq-02): Filter-level liminf≤1≤limsup straddle [VERIFIED, 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/Erdos1013UnconditionalRatio.lean
+++ b/proofs/Proofs/Erdos1013UnconditionalRatio.lean
@@ -36,6 +36,11 @@ on the ratio itself:
         cannot drift away from `1` on either side, so if (⋆) fails it fails only by
         oscillation.  The engine is the pair of Cesàro sign lemmas `cesaro_ge_imp` /
         `cesaro_le_imp` (a vanishing Cesàro mean cannot dominate a fixed nonzero constant).
+  * `ratio_liminf_le_one` / `one_le_ratio_limsup` — the same straddle in honest
+        `Filter.liminf`/`Filter.limsup` form: once the ratio is eventually two-sided bounded
+        (the `[1/2, 2]` bounded-ratio leaf supplies this for `h₃`),
+        `liminf_k h(k+1)/h k ≤ 1 ≤ limsup_k h(k+1)/h k`.  Hence if the ratio converges at
+        all, its limit is forced to be `1` — a genuine two-sided pinch on the cluster set.
 
 The averaged statements are proved for an arbitrary `h : ℕ → ℝ` that is **positive and polynomially
 sandwiched** (`PolyBounded`); the genuine `h₃`, whose bounds sit between `k²` and `k³`,
@@ -291,6 +296,60 @@ theorem ratio_frequently_gt {h : ℕ → ℝ} (hb : PolyBounded h) {ε : ℝ} (h
   have hneg : Real.log (1 - ε) < 0 := Real.log_neg (by linarith) (by linarith)
   linarith
 
+/- ## Filter-level `liminf ≤ 1 ≤ limsup` (the textbook straddle) -/
+
+/-- **`liminf ≤ 1` in honest `Filter.liminf` form.**  The frequency statement
+`ratio_frequently_lt` (`h(k+1)/h k < 1 + ε` infinitely often, for every `ε > 0`) is exactly
+the assertion `liminf_k h(k+1)/h k ≤ 1`.  Promoting it to the genuine `Filter.liminf`
+requires only that the ratio be *eventually bounded below* (so `liminf` is a real number and
+not `-∞`), supplied here as `IsBoundedUnder (· ≥ ·)`.  For `h₃` this cobounded side-condition
+is furnished by the `[1/2, 2]` bounded-ratio leaf (`Erdos1013BoundedRatio.lean`). -/
+theorem ratio_liminf_le_one {h : ℕ → ℝ} (hb : PolyBounded h)
+    (hbdd : IsBoundedUnder (· ≥ ·) atTop (fun k => h (k + 1) / h k)) :
+    liminf (fun k => h (k + 1) / h k) atTop ≤ 1 := by
+  set L := liminf (fun k => h (k + 1) / h k) atTop with hL
+  by_contra hcon
+  push_neg at hcon              -- hcon : 1 < L
+  set ε : ℝ := (L - 1) / 2 with hεdef
+  have hεpos : 0 < ε := by rw [hεdef]; linarith
+  have hfreq : ∃ᶠ k in atTop, h (k + 1) / h k ≤ 1 + ε :=
+    (ratio_frequently_lt hb hεpos).mono fun k hk => le_of_lt hk
+  have hle : L ≤ 1 + ε := by
+    rw [hL]; exact Filter.liminf_le_of_frequently_le hfreq hbdd
+  rw [hεdef] at hle
+  linarith
+
+/-- **`1 ≤ limsup` in honest `Filter.limsup` form.**  Dual to `ratio_liminf_le_one`: the
+frequency statement `ratio_frequently_gt` gives `1 - ε < h(k+1)/h k` infinitely often for
+every `0 < ε < 1`, i.e. `1 ≤ limsup_k h(k+1)/h k`.  Promotion needs the ratio *eventually
+bounded above* (`limsup` a real number, not `+∞`), supplied as `IsBoundedUnder (· ≤ ·)`. -/
+theorem one_le_ratio_limsup {h : ℕ → ℝ} (hb : PolyBounded h)
+    (hbdd : IsBoundedUnder (· ≤ ·) atTop (fun k => h (k + 1) / h k)) :
+    1 ≤ limsup (fun k => h (k + 1) / h k) atTop := by
+  set L := limsup (fun k => h (k + 1) / h k) atTop with hL
+  by_contra hcon
+  push_neg at hcon              -- hcon : L < 1
+  set ε : ℝ := min ((1 - L) / 2) (1 / 2) with hεdef
+  have hεpos : 0 < ε := lt_min (by linarith) (by norm_num)
+  have hε1 : ε < 1 := lt_of_le_of_lt (min_le_right _ _) (by norm_num)
+  have hεle : ε ≤ (1 - L) / 2 := min_le_left _ _
+  have hfreq : ∃ᶠ k in atTop, 1 - ε ≤ h (k + 1) / h k :=
+    (ratio_frequently_gt hb hεpos hε1).mono fun k hk => le_of_lt hk
+  have hle : 1 - ε ≤ L := by
+    rw [hL]; exact Filter.le_limsup_of_frequently_le hfreq hbdd
+  linarith
+
+/-- **The unconditional Filter-level straddle** for any polynomially bounded positive `h`
+whose consecutive ratio is eventually two-sided bounded:
+`liminf_k h(k+1)/h k ≤ 1 ≤ limsup_k h(k+1)/h k`.  In particular the ratio cannot converge to
+any limit other than `1`: if it converges at all, the limit is `1`. -/
+theorem ratio_liminf_le_one_le_limsup {h : ℕ → ℝ} (hb : PolyBounded h)
+    (hbelow : IsBoundedUnder (· ≥ ·) atTop (fun k => h (k + 1) / h k))
+    (habove : IsBoundedUnder (· ≤ ·) atTop (fun k => h (k + 1) / h k)) :
+    liminf (fun k => h (k + 1) / h k) atTop ≤ 1 ∧
+      1 ≤ limsup (fun k => h (k + 1) / h k) atTop :=
+  ⟨ratio_liminf_le_one hb hbelow, one_le_ratio_limsup hb habove⟩
+
 /- ## Specialisation to the genuine threshold `h₃` -/
 
 /-- The genuine triangle-free chromatic threshold (as a real candidate `h₃`) is
@@ -334,6 +393,25 @@ theorem h3_ratio_straddles_one (h₃ : ℕ → ℝ) (hpos : ∀ k, 0 < h₃ k)
       (∃ᶠ k in atTop, 1 - ε < h₃ (k + 1) / h₃ k) :=
   ⟨ratio_frequently_lt (polyBounded_of_h3 h₃ hpos hlow hup) hε,
     ratio_frequently_gt (polyBounded_of_h3 h₃ hpos hlow hup) hε hε1⟩
+
+/-- **Erdős #1013 (oq-02), the Filter-level straddle for `h₃`.**  Given the two-sided
+*bounded-ratio* input — the consecutive ratio is eventually `≥ m` and eventually `≤ M`
+(as established, with `m = 1/2`, `M = 2`, in `Erdos1013BoundedRatio.lean`) — the honest
+`Filter.liminf`/`Filter.limsup` obstruction holds:
+`liminf_k h₃(k+1)/h₃ k ≤ 1 ≤ limsup_k h₃(k+1)/h₃ k`.
+Consequently, should the ratio converge, its limit can only be `1` — the averaged evidence
+for (⋆) is now a genuine two-sided pinch on the extreme cluster points. -/
+theorem h3_ratio_liminf_le_one_le_limsup (h₃ : ℕ → ℝ) (hpos : ∀ k, 0 < h₃ k)
+    (hlow : ∀ᶠ (k : ℕ) in atTop, (k : ℝ) ^ 2 ≤ h₃ k)
+    (hup : ∀ᶠ (k : ℕ) in atTop, h₃ k ≤ (k : ℝ) ^ 3)
+    {m M : ℝ} (hbelow : ∀ᶠ k in atTop, m ≤ h₃ (k + 1) / h₃ k)
+    (habove : ∀ᶠ k in atTop, h₃ (k + 1) / h₃ k ≤ M) :
+    liminf (fun k => h₃ (k + 1) / h₃ k) atTop ≤ 1 ∧
+      1 ≤ limsup (fun k => h₃ (k + 1) / h₃ k) atTop := by
+  have hb := polyBounded_of_h3 h₃ hpos hlow hup
+  have hbddb : IsBoundedUnder (· ≥ ·) atTop (fun k => h₃ (k + 1) / h₃ k) := ⟨m, hbelow⟩
+  have hbdda : IsBoundedUnder (· ≤ ·) atTop (fun k => h₃ (k + 1) / h₃ k) := ⟨M, habove⟩
+  exact ratio_liminf_le_one_le_limsup hb hbddb hbdda
 
 /-
 ## Remarks — why the *pointwise* ratio (⋆) is not settled here

--- a/research/problems/erdos-1013-oq-02/knowledge.md
+++ b/research/problems/erdos-1013-oq-02/knowledge.md
@@ -134,3 +134,50 @@ the latter using `log k / k → 0` (from `Real.isLittleO_log_id_atTop`).
   `|log h₃(k+1) − log h₃(k)| = o(1)`, which the current `log log k`-wide window cannot
   supply. Optional polish: promote the frequency forms to explicit `Filter.liminf/limsup`
   corollaries once cobounded side-conditions are provided.
+
+---
+
+## Session 2026-07-05 (Session 3, researcher-11) — ACT
+
+**Mode**: CONTINUE. **Outcome**: progress (verified new result, first-try Docker build).
+
+### What I Did
+- Executed the "optional polish" flagged by Session 2: promoted the frequency straddle to
+  the genuine `Filter.liminf`/`Filter.limsup` order-theoretic form. Extended
+  `Erdos1013UnconditionalRatio.lean` from 14 → 18 theorems (0 sorry / 0 axiom;
+  `#print axioms` unchanged: propext/Classical.choice/Quot.sound).
+- New theorems:
+  - `ratio_liminf_le_one` — `liminf_k h(k+1)/h k ≤ 1`, needs `IsBoundedUnder (· ≥ ·)`.
+  - `one_le_ratio_limsup` — `1 ≤ limsup_k h(k+1)/h k`, needs `IsBoundedUnder (· ≤ ·)`.
+  - `ratio_liminf_le_one_le_limsup` — the conjunction (general `PolyBounded` `h`).
+  - `h3_ratio_liminf_le_one_le_limsup` — `h₃` specialisation; takes eventual two-sided
+    ratio bounds `m ≤ ratio ≤ M` and constructs the `IsBoundedUnder` witnesses.
+
+### Key Findings
+- The "frequently `< 1±ε` for all ε" facts are *definitionally* the liminf/limsup bounds;
+  the only extra content needed to state them as honest `Filter.liminf`/`Filter.limsup` is
+  a **cobounded side-condition** (ratio eventually bounded below / above), which the
+  `[1/2, 2]` bounded-ratio leaf (`Erdos1013BoundedRatio.lean`) already supplies for `h₃`.
+- **Corollary of independent interest:** `liminf ≤ 1 ≤ limsup` forces any *existing* limit
+  of the ratio to equal `1`. So the open (⋆) is now "does the limit exist?", never "what
+  is it?" — the value is pinned unconditionally.
+
+### Lean mechanics worth remembering
+- `Filter.liminf_le_of_frequently_le (hfreq : ∃ᶠ x, u x ≤ b) (hbdd : IsBoundedUnder (· ≥ ·) l u) : liminf u l ≤ b`
+  and dual `Filter.le_limsup_of_frequently_le` — pass the boundedness explicitly (it's an
+  `isBoundedDefault` autoparam that will NOT auto-discharge here).
+- Weaken `∃ᶠ x, u x < c` to `∃ᶠ x, u x ≤ c` via `Filter.Frequently.mono fun k hk => le_of_lt hk`.
+- `IsBoundedUnder (· ≤ ·) atTop u` unfolds (defeq, via `eventually_map`) to
+  `∃ b, ∀ᶠ x, u x ≤ b`, so the anonymous constructor `⟨M, habove⟩` builds it directly from
+  an eventual bound — no need for named `isBoundedUnder_of_eventually_*` lemmas.
+- `liminf ≤ 1` from `∀ ε>0, liminf ≤ 1+ε`: `by_contra`/`push_neg` to `1 < L`, pick
+  `ε = (L-1)/2`, apply the frequently-lemma, `linarith`. Symmetric for limsup with
+  `ε = min ((1-L)/2) (1/2)` to keep `ε < 1` (required by `ratio_frequently_gt`).
+
+### Files Modified
+- `proofs/Proofs/Erdos1013UnconditionalRatio.lean` (extended: +4 theorems, +docstring)
+
+### Next Steps
+- Pointwise (⋆) still OPEN — unchanged obstruction (local variation across the
+  `log log k` band). The value of any limit is now fully pinned to 1; only *existence*
+  remains, which needs the improved upper bound / local-variation relation.

--- a/research/problems/erdos-1013-oq-02/state.md
+++ b/research/problems/erdos-1013-oq-02/state.md
@@ -4,40 +4,55 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-05
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
-Added the unconditional **straddle-1** result to `Erdos1013UnconditionalRatio.lean`:
-for every `ε > 0` the consecutive ratio `h₃(k+1)/h₃(k)` is `< 1+ε` infinitely often
-**and** `> 1−ε` infinitely often, i.e. `liminf ≤ 1 ≤ limsup`. This upgrades the earlier
-`[1/2,2]` bounded-ratio leaf to a tight straddle of 1 — the ratio cannot drift away from
-1 on either side; if the open pointwise (⋆) fails, it fails **only by oscillation**.
+Promoted the frequency straddle to the **honest `Filter.liminf`/`Filter.limsup` form** in
+`Erdos1013UnconditionalRatio.lean`. New theorems (0 sorry / 0 axiom, Docker lean 4.26.0):
+`ratio_liminf_le_one`, `one_le_ratio_limsup`, `ratio_liminf_le_one_le_limsup`, and the `h₃`
+specialisation `h3_ratio_liminf_le_one_le_limsup`. Given the ratio is eventually two-sided
+bounded (the `[1/2,2]` bounded-ratio leaf supplies this cobounded side-condition), we now
+have `liminf_k h₃(k+1)/h₃ k ≤ 1 ≤ limsup_k h₃(k+1)/h₃ k` as genuine `Filter` statements —
+so **if the ratio converges at all, the limit is forced to be `1`**.
+
+## Prior Iteration (3)
+Added the unconditional **straddle-1** frequency result: for every `ε > 0` the ratio is
+`< 1+ε` infinitely often **and** `> 1−ε` infinitely often. If the open pointwise (⋆) fails,
+it fails **only by oscillation**.
 
 ## Active Approach
-Extract the pointwise shadow of the already-proved averaged (Cesàro) result. The engine
-is two Cesàro sign lemmas: a vanishing Cesàro mean of the log-ratios cannot be eventually
-`≥` a fixed positive constant nor eventually `≤` a fixed negative one. Applying these to
-`log(1±ε)` gives the two frequency statements.
+Extract the pointwise shadow of the already-proved averaged (Cesàro) result, then package
+it in standard order-theoretic form. The `Filter.liminf_le_of_frequently_le` /
+`Filter.le_limsup_of_frequently_le` lemmas convert the "frequently `< 1±ε`" facts (for all
+`ε`) into `liminf ≤ 1` / `1 ≤ limsup`, using only that the ratio is eventually two-sided
+bounded (cobounded side-conditions), which the bounded-ratio leaf provides.
 
 ## Attempt Count
-- Total attempts: 2
+- Total attempts: 3
 - Current approach attempts: 1
-- Approaches tried: 2
+- Approaches tried: 3
 
 ## Blockers
 - Pointwise ratio → 1 is genuinely open: the `≈ log log k`-wide band between the known
-  upper/lower bounds permits `O(log log k)` local oscillation. The straddle result now
-  rules out one-sided *drift*, so the sole remaining obstruction is genuine *local
-  variation* `|log h₃(k+1) − log h₃(k)| = o(1)`, which the current window cannot supply.
+  upper/lower bounds permits `O(log log k)` local oscillation. The straddle (now in
+  liminf/limsup form) rules out one-sided *drift* and forces any limit to equal 1, so the
+  sole remaining obstruction is genuine *local variation*
+  `|log h₃(k+1) − log h₃(k)| = o(1)`, which the current window cannot supply.
 
 ## Next Action
 Either improve the upper bound to `(c+o(1))·k²·log k` (removes the gap), or find a direct
 `h₃(k) ↔ h₃(k+1)` local-variation relation. Neither in reach now — the verified
-straddle result is the deliverable for this iteration.
+liminf/limsup straddle is the deliverable for this iteration.
 
-## This Iteration (2026-07-05)
-- New theorems (all 0 sorry / 0 axiom, Docker lean 4.26.0 VERIFIED):
-  `cesaro_ge_imp`, `cesaro_le_imp` (Cesàro sign lemmas),
-  `ratio_frequently_lt`, `ratio_frequently_gt` (liminf ≤ 1 ≤ limsup),
-  `h3_ratio_straddles_one` (h₃ specialisation).
-- File now 14 theorems, 354 lines. `#print axioms` = propext/Classical.choice/Quot.sound.
+## This Iteration (2026-07-05, Iteration 4)
+- New theorems (all 0 sorry / 0 axiom, Docker lean 4.26.0 VERIFIED, first-try build):
+  `ratio_liminf_le_one`, `one_le_ratio_limsup` (general),
+  `ratio_liminf_le_one_le_limsup` (conjunction),
+  `h3_ratio_liminf_le_one_le_limsup` (h₃ specialisation, takes eventual two-sided ratio
+  bounds and constructs `IsBoundedUnder` via anonymous constructor `⟨M, habove⟩`).
+- File now 18 theorems, 432 lines. `#print axioms` = propext/Classical.choice/Quot.sound.
+
+## Prior Iteration (3, 2026-07-05)
+- New theorems: `cesaro_ge_imp`, `cesaro_le_imp` (Cesàro sign lemmas),
+  `ratio_frequently_lt`, `ratio_frequently_gt`, `h3_ratio_straddles_one`.
+- File was 14 theorems, 354 lines.


### PR DESCRIPTION
## Summary

Erdős #1013 (oq-02) asks whether the triangle-free chromatic-threshold ratio `h₃(k+1)/h₃(k) → 1` — genuinely **open** (the `log log k` gap between the known bounds permits `O(log log k)` local oscillation).

This iteration promotes the previously-verified *frequency* straddle to the honest **`Filter.liminf` / `Filter.limsup`** order-theoretic form. Given the consecutive ratio is eventually two-sided bounded (the `[1/2, 2]` bounded-ratio leaf, `Erdos1013BoundedRatio.lean`, supplies this cobounded side-condition for `h₃`):

```
liminf_k h₃(k+1)/h₃(k)  ≤  1  ≤  limsup_k h₃(k+1)/h₃(k)
```

as genuine `Filter` statements. **Consequence:** any *existing* limit of the ratio is forced to equal `1` — the open question (⋆) now reduces purely to *existence* of the limit, never its *value*.

## New theorems (all 0 sorry / 0 axiom)

- `ratio_liminf_le_one` — `liminf ≤ 1` (needs `IsBoundedUnder (· ≥ ·)`)
- `one_le_ratio_limsup` — `1 ≤ limsup` (needs `IsBoundedUnder (· ≤ ·)`)
- `ratio_liminf_le_one_le_limsup` — the conjunction, general `PolyBounded` `h`
- `h3_ratio_liminf_le_one_le_limsup` — `h₃` specialisation (takes eventual two-sided ratio bounds)

## Verification

- Built via `./proofs/scripts/docker-build.sh Proofs.Erdos1013UnconditionalRatio` (Lean 4.26.0), first-try success.
- File now 18 theorems, 432 lines; `#print axioms` = `propext` / `Classical.choice` / `Quot.sound` only.
- The pointwise (⋆) remains **open** — this is an unconditional partial result, not a resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)