### PR TITLE
Enrich Effective Bisection Depth for Vincent Root Isolation

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-mingap-def",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
+    "range": { "startLine": 74, "endLine": 80 },
+    "type": "definition",
+    "title": "Minimum root gap δ = minGap S",
+    "content": "Defines the minimum distance between two distinct points of a finite set S ⊆ ℝ. It takes the image of the off-diagonal pairs under |p₁ − p₂| and returns its minimum; when S has fewer than two elements the off-diagonal is empty and the definition falls back to the harmless positive default 1 (any interval then trivially isolates). This δ is the separation parameter that the whole bisection-depth analysis is measured against.",
+    "mathContext": "$\\delta = \\min\\{\\,|x-y| : x,y \\in S,\\; x \\neq y\\,\\}$, with $\\delta = 1$ by convention when $|S| < 2$.",
+    "significance": "key",
+    "relatedConcepts": ["root separation", "separated set", "finite set", "off-diagonal", "Finset.min'"],
+    "prerequisites": ["real analysis", "finite sets"]
+  },
+  {
+    "id": "ann-mingap-pos",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
+    "range": { "startLine": 82, "endLine": 95 },
+    "type": "technique",
+    "title": "Positivity of the minimum gap",
+    "content": "Proves 0 < minGap S by cases on whether the off-diagonal image is nonempty. In the nonempty case, Finset.lt_min'_iff reduces the goal to showing every member of the image is positive; each such member is |p₁ − p₂| with p₁ ≠ p₂, so sub_ne_zero and abs_pos give strict positivity. In the empty case the default value 1 is positive. Positivity of δ is essential: the target width w / 2^k is divided against δ, and the whole clog analysis presupposes δ > 0.",
+    "mathContext": "$\\delta > 0$ because a finite set of reals has no two distinct points at distance $0$: $x \\neq y \\Rightarrow |x-y| > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["absolute value", "positivity", "case analysis", "Finset.min'"],
+    "prerequisites": ["real analysis", "order theory"]
+  },
+  {
+    "id": "ann-mingap-le",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
+    "range": { "startLine": 97, "endLine": 106 },
+    "type": "technique",
+    "title": "δ lower-bounds every distinct-pair distance",
+    "content": "Shows minGap S ≤ |x − y| for any two distinct points x, y ∈ S. Since (x, y) lies in the off-diagonal, |x − y| is a member of the image set, so it is bounded below by the minimum Finset.min'_le. This is the defining property of δ that powers the isolation argument: if two roots both land in a width-s interval with s < δ, then |x − y| ≤ s < δ ≤ |x − y| is a contradiction.",
+    "mathContext": "For distinct $x,y \\in S$: $\\delta = \\min_{p \\neq q}|p-q| \\le |x-y|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["infimum", "lower bound", "separated set", "Finset.min'_le"],
+    "prerequisites": ["real analysis", "order theory"]
+  },
+  {
+    "id": "ann-subsingleton",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
+    "range": { "startLine": 108, "endLine": 121 },
+    "type": "concept",
+    "title": "Sub-gap width ⇒ at most one root (isolation)",
+    "content": "The isolation criterion: any interval [c, c + s] of width s < minGap S meets S in at most one point (its intersection with S is a subsingleton). Given two roots x, y in the interval, the triangle bound abs_sub_le_iff gives |x − y| ≤ s, while minGap_le gives δ ≤ |x − y|; combined with s < δ this forces x = y by linarith. This lemma converts a purely metric width bound into the combinatorial 'root-isolated' property the algorithm cares about.",
+    "mathContext": "If $s < \\delta$ then $|[c,c+s] \\cap S| \\le 1$: two points in a width-$s$ window would satisfy $|x-y| \\le s < \\delta \\le |x-y|$, contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["root isolation", "subsingleton", "triangle inequality", "pigeonhole"],
+    "prerequisites": ["real analysis", "metric spaces"]
+  },
+  {
+    "id": "ann-threshold-engine",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
+    "range": { "startLine": 128, "endLine": 154 },
+    "type": "insight",
+    "title": "Threshold engine: any level above the ceiling-log forces width < δ",
+    "content": "The core lemma. For every level k strictly above c := Nat.clog 2 ⌈w / δ⌉₊, the width w / 2^k is strictly below δ. The proof chains four facts entirely in ℕ before casting to ℝ: (1) w/δ ≤ ⌈w/δ⌉₊ = n by Nat.le_ceil; (2) n ≤ 2^{clog 2 n} by Nat.le_pow_clog (the defining property of the integer ceiling-logarithm); (3) 2^{clog 2 n} < 2^k from clog 2 n < k by Nat.pow_lt_pow_right; hence (4) n < 2^k, cast to ℝ. Composing gives w/δ < 2^k, which div_lt_iff₀ rearranges to w/2^k < δ. Doing the exponent comparison in ℕ sidesteps real-logarithm machinery entirely.",
+    "mathContext": "For $k > \\lceil \\log_2(w/\\delta) \\rceil$: $\\dfrac{w}{\\delta} \\le \\lceil w/\\delta \\rceil_{\\mathbb N} \\le 2^{\\operatorname{clog}_2 n} < 2^{k} \\;\\Rightarrow\\; \\dfrac{w}{2^{k}} < \\delta.$",
+    "significance": "key",
+    "relatedConcepts": ["ceiling logarithm", "Nat.clog", "Nat.le_pow_clog", "dyadic bisection", "monotone termination"],
+    "prerequisites": ["real analysis", "natural number arithmetic", "logarithms"]
+  },
+  {
+    "id": "ann-explicit-bound",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
+    "range": { "startLine": 156, "endLine": 162 },
+    "type": "insight",
+    "title": "The explicit witness k₀ = clog + 1 and the necessity of +1",
+    "content": "Instantiates the threshold lemma at k₀ = Nat.clog 2 ⌈w/δ⌉₊ + 1 via Nat.lt_succ_self, yielding w / 2^{k₀} < δ. The '+1' is mathematically necessary, not cosmetic: the bare candidate k = clog 2 ⌈w/δ⌉₊ gives only the NON-strict w/2^k ≤ δ (Nat.le_pow_clog), and strict isolation fails exactly at powers of two — e.g. w/δ = 4 gives ⌈w/δ⌉₊ = 4, clog 2 4 = 2, and w/2² = δ, an equality. One extra bisection is genuinely required, matching the classical k ≤ log₂(w/δ) + 1 VAS depth bound.",
+    "mathContext": "$k_0 = \\lceil \\log_2(w/\\delta) \\rceil + 1$. At $w/\\delta = 4$: bare $k=2$ gives $w/2^2 = \\delta$ (equality); $k_0 = 3$ gives $w/2^3 = \\delta/2 < \\delta$.",
+    "significance": "key",
+    "relatedConcepts": ["explicit witness", "effective bound", "powers of two", "VAS complexity", "ceiling logarithm"],
+    "prerequisites": ["natural number arithmetic", "logarithms"]
+  },
+  {
+    "id": "ann-isolates-explicit",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
+    "range": { "startLine": 164, "endLine": 172 },
+    "type": "concept",
+    "title": "Effective eventual isolation at the explicit level",
+    "content": "The explicit-witness upgrade of the parent's existential exists_level_isolates: at the concrete level k₀ = Nat.clog 2 ⌈w/δ⌉₊ + 1 every subinterval [c, c + w/2^{k₀}] contains at most one root of S. It simply feeds the explicit width bound to subsingleton_of_width_lt_minGap. The point is that the isolating level is now a closed-form formula of the correct O(log(w/δ)) order rather than an unspecified ∃ k, so it doubles as a computable termination certificate.",
+    "mathContext": "At $k_0 = \\lceil \\log_2(w/\\delta)\\rceil + 1$, every $[c,\\,c + w/2^{k_0}]$ satisfies $|[c,c+w/2^{k_0}] \\cap S| \\le 1$.",
+    "significance": "key",
+    "relatedConcepts": ["root isolation", "computable termination", "existential to explicit", "Vincent's theorem"],
+    "prerequisites": ["real analysis", "algorithms"]
+  },
+  {
+    "id": "ann-isolates-each",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
+    "range": { "startLine": 174, "endLine": 184 },
+    "type": "concept",
+    "title": "Per-subinterval isolation over a concrete [a, b]",
+    "content": "Packages the result for a concrete interval [a, b] with a < b, mirroring the parent's exists_level_isolates_each but with the explicit level k₀ = Nat.clog 2 ⌈(b − a)/δ⌉₊ + 1. Each dyadic subinterval [a + j·s, a + j·s + s] with s = (b − a) / 2^{k₀} is root-isolated. This is the form a bisection implementation actually consumes: it enumerates the 2^{k₀} equal pieces of [a, b] and certifies that each holds at most one root, so the sign-variation (Descartes) test on each piece returns 0 or 1.",
+    "mathContext": "With $s = (b-a)/2^{k_0}$, every piece $[a + js,\\; a + js + s]$ for $j = 0,\\dots,2^{k_0}-1$ isolates at most one root.",
+    "significance": "supporting",
+    "relatedConcepts": ["dyadic subdivision", "bisection algorithm", "Descartes' rule of signs", "interval enumeration"],
+    "prerequisites": ["real analysis", "algorithms"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02` (quality 39, pass 0).

## Gap addressed
The entry had a rich `meta.json` but **no `annotations.json`** — the largest quality gap. This PR adds a line-anchored annotation layer over the full 186-line Lean file.

## What was added
`annotations.json` with **8 annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

- **minGap infrastructure** (§1): definition of the minimum root gap δ, its positivity, the distinct-pair lower bound, and the sub-gap ⇒ isolation (subsingleton) criterion.
- **Effective depth** (§2): the threshold engine `width_lt_minGap_of_clog_lt` (the ℕ→ℝ `Nat.le_pow_clog` chain), the explicit witness `k₀ = clog + 1` with the powers-of-two argument for why the +1 is mathematically necessary, and the two isolation wrappers upgrading the parent's existential to an explicit computable level.

## Verification
- `annotations.json` and `meta.json` both parse as valid JSON; all 8 ranges lie within the 186-line file.
- The `pnpm build` data-generation/manifest step processed the entry with no error. (The subsequent `tsc` step fails only because this worktree has no `node_modules`; the change is pure JSON data untouched by `tsc`.)
- Axiom integrity unchanged: `status: verified`, `badge: original`, 0 axioms / 0 sorries — accurate to the Lean file (`#print axioms` reports only propext / Classical.choice / Quot.sound).

No `meta.json` changes; already well under all size caps (~12.8 KB).