### PR TITLE
Enrich Congruence Restrictions on Prime Factors of Mersenne Numbers

### DIFF
--- a/src/data/proofs/mersenne-prime-exponent-oq-02/annotations.json
+++ b/src/data/proofs/mersenne-prime-exponent-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-statement",
+    "proofId": "mersenne-prime-exponent-oq-02",
+    "range": { "startLine": 3, "endLine": 42 },
+    "type": "context",
+    "title": "The two factor restrictions and why they matter",
+    "content": "States the goal: for an odd prime p and any prime q dividing the Mersenne number 2^p − 1, both q ≡ 1 (mod 2p) and q ≡ ±1 (mod 8) hold — even when 2^p − 1 is composite. These are the residue filters that make Mersenne trial division efficient: candidate factors have the shape q = 2kp + 1 restricted to ±1 (mod 8). The worked example 2^11 − 1 = 23·89 illustrates 23 = 2·11 + 1 ≡ −1 and 89 = 8·11 + 1 ≡ 1 (mod 8).",
+    "mathContext": "$p \\text{ odd prime},\\; q \\text{ prime},\\; q \\mid 2^p - 1 \\;\\Rightarrow\\; q \\equiv 1 \\pmod{2p} \\;\\wedge\\; q \\equiv \\pm 1 \\pmod 8.$",
+    "significance": "context",
+    "relatedConcepts": ["Mersenne numbers", "trial division", "prime factorization", "residue classes"],
+    "prerequisites": ["elementary number theory", "modular arithmetic"]
+  },
+  {
+    "id": "ann-cast-lemma",
+    "proofId": "mersenne-prime-exponent-oq-02",
+    "range": { "startLine": 46, "endLine": 58 },
+    "type": "technique",
+    "title": "Cast: q ∣ 2^p − 1 becomes (2 : ZMod q)^p = 1",
+    "content": "The shared entry point for both restrictions. ZMod.natCast_eq_zero_iff turns the divisibility q ∣ 2^p − 1 into ((2^p − 1 : ℕ) : ZMod q) = 0. Because 1 ≤ 2^p, Nat.cast_sub lets push_cast rewrite the Nat subtraction as (2 : ZMod q)^p − 1, and sub_eq_zero delivers (2 : ZMod q)^p = 1. Moving from ℕ-divisibility into the field ZMod q is what unlocks the multiplicative-order machinery used in both theorems.",
+    "mathContext": "$q \\mid 2^p - 1 \\iff (2^p - 1 \\bmod q) = 0 \\iff (2 : \\mathbb{Z}/q)^p = 1.$",
+    "significance": "key",
+    "relatedConcepts": ["finite field ZMod q", "natural-number subtraction cast", "push_cast"],
+    "prerequisites": ["modular arithmetic", "finite fields"]
+  },
+  {
+    "id": "ann-oddness",
+    "proofId": "mersenne-prime-exponent-oq-02",
+    "range": { "startLine": 60, "endLine": 69 },
+    "type": "technique",
+    "title": "Every prime factor of 2^p − 1 is odd",
+    "content": "Shows q ≠ 2. Since 2^p is even (Nat.even_pow, p > 0) and ≥ 2, the number 2^p − 1 is odd (Nat.Even.sub_odd, even minus odd). A prime factor of an odd number cannot be 2, discharged by omega from the two parity witnesses. This oddness (q odd ⇒ 2 ∣ q − 1) feeds the coprime-merge step of the mod-2p proof, and q ≠ 2 is the hypothesis required by the quadratic-residue law for the mod-8 proof.",
+    "mathContext": "$2^p$ even $\\Rightarrow 2^p - 1$ odd $\\Rightarrow q \\mid 2^p - 1 \\Rightarrow q \\ne 2.$",
+    "significance": "supporting",
+    "relatedConcepts": ["parity", "even and odd", "prime divisors", "omega tactic"],
+    "prerequisites": ["elementary number theory"]
+  },
+  {
+    "id": "ann-order-is-p",
+    "proofId": "mersenne-prime-exponent-oq-02",
+    "range": { "startLine": 80, "endLine": 92 },
+    "type": "insight",
+    "title": "The multiplicative order of 2 is exactly p",
+    "content": "The heart of the mod-2p argument. From (2 : ZMod q)^p = 1, orderOf_dvd_of_pow_eq_one gives orderOf 2 ∣ p; since p is prime it is 1 or p. Order 1 would mean 2 = 1 in ZMod q (orderOf_eq_one_iff), i.e. q ∣ 1 — impossible, since q ∤ 2 makes 2 ≠ 0 and 2 ≠ 1. Hence orderOf (2 : ZMod q) = p exactly. Primality of p is precisely what collapses the order to the full p rather than a proper divisor.",
+    "mathContext": "$\\operatorname{ord}_q(2) \\mid p,\\; p \\text{ prime},\\; 2 \\ne 1 \\text{ in } \\mathbb{Z}/q \\;\\Rightarrow\\; \\operatorname{ord}_q(2) = p.$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative order", "orderOf", "prime divisor dichotomy", "cyclic group"],
+    "prerequisites": ["group theory", "order of an element"]
+  },
+  {
+    "id": "ann-fermat-merge",
+    "proofId": "mersenne-prime-exponent-oq-02",
+    "range": { "startLine": 93, "endLine": 104 },
+    "type": "concept",
+    "title": "Fermat + coprime merge ⇒ q ≡ 1 (mod 2p)",
+    "content": "Fermat's little theorem (ZMod.pow_card_sub_one_eq_one) gives (2 : ZMod q)^{q−1} = 1, so orderOf 2 = p divides q − 1. Oddness of q gives 2 ∣ q − 1. Since p is an odd prime, gcd(2, p) = 1, so Nat.Coprime.mul_dvd_of_dvd_of_dvd merges the two coprime divisors into 2p ∣ q − 1. Finally Nat.modEq_iff_dvd' converts this to the congruence q ≡ 1 (mod 2p).",
+    "mathContext": "$p \\mid q-1,\\; 2 \\mid q-1,\\; \\gcd(2,p)=1 \\;\\Rightarrow\\; 2p \\mid q-1 \\iff q \\equiv 1 \\pmod{2p}.$",
+    "significance": "key",
+    "relatedConcepts": ["Fermat's little theorem", "coprime divisibility", "least common multiple", "congruence"],
+    "prerequisites": ["Fermat's little theorem", "modular arithmetic", "gcd/lcm"]
+  },
+  {
+    "id": "ann-mod8-square",
+    "proofId": "mersenne-prime-exponent-oq-02",
+    "range": { "startLine": 106, "endLine": 124 },
+    "type": "insight",
+    "title": "2 is a quadratic residue ⇒ q ≡ ±1 (mod 8)",
+    "content": "The mod-8 restriction. Writing p = 2k + 1 (p odd), the Mersenne relation 2^p = 1 in ZMod q makes 2 an even power: 2 = 2^{p+1} = (2^{k+1})², an explicit perfect square. So IsSquare (2 : ZMod q) holds — no Legendre-symbol computation needed, the structure supplies the square root. ZMod.exists_sq_eq_two_iff (the second supplementary law of quadratic reciprocity) then converts 'IsSquare 2' into q % 8 = 1 ∨ q % 8 = 7.",
+    "mathContext": "$2 = 2^{p+1} = (2^{(p+1)/2})^2 \\text{ in } \\mathbb{Z}/q \\Rightarrow \\left(\\tfrac{2}{q}\\right)=1 \\iff q \\equiv \\pm 1 \\pmod 8.$",
+    "significance": "key",
+    "relatedConcepts": ["quadratic residue", "second supplementary law", "quadratic reciprocity", "Legendre symbol", "perfect square"],
+    "prerequisites": ["quadratic residues", "quadratic reciprocity"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `mersenne-prime-exponent-oq-02` (quality 39, pass 0).

## Gap addressed
Rich `meta.json` but **no `annotations.json`** — the largest quality gap. Adds a line-anchored annotation layer over the 126-line Lean file.

## What was added
`annotations.json` with **6 annotations**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

- **Statement** — the two factor restrictions q ≡ 1 (mod 2p), q ≡ ±1 (mod 8) and their role in Mersenne trial division.
- **Cast lemma** (`two_pow_eq_one_of_dvd`) — q ∣ 2^p − 1 ⟹ (2 : ZMod q)^p = 1.
- **Oddness** (`ne_two_of_dvd`) — every prime factor of the odd 2^p − 1 is odd.
- **Order = p** — the multiplicative order of 2 is exactly the prime p.
- **Fermat + coprime merge** — p ∣ q−1 and 2 ∣ q−1 with gcd(2,p)=1 ⟹ q ≡ 1 (mod 2p).
- **Quadratic-residue mod 8** — 2 = (2^{(p+1)/2})² ⟹ q ≡ ±1 (mod 8) via the second supplementary law.

## Verification
- `annotations.json` parses as valid JSON; all 6 ranges lie within the 126-line file; schema matches existing gallery annotations.
- Axiom integrity unchanged: `status: verified`, `badge: original`, 0 axioms / 0 sorries — accurate to the Lean file.

No `meta.json` changes; well under all size caps (~15.7 KB).