### PR TITLE
Enrich Fermat Prime Exponents Are Powers of Two

### DIFF
--- a/src/data/proofs/mersenne-prime-exponent-oq-01/annotations.json
+++ b/src/data/proofs/mersenne-prime-exponent-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-statement",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": { "startLine": 3, "endLine": 47 },
+    "type": "context",
+    "title": "Fermat prime exponents are powers of two",
+    "content": "States the theorem: if 2^n + 1 is prime and n ≥ 1, then n is a power of two — the exact '+1' analogue of the Mersenne condition (2^n − 1 prime ⇒ n prime). The known Fermat primes 3, 5, 17, 257, 65537 have exponents 1, 2, 4, 8, 16. Where a composite Mersenne exponent is killed by a proper-divisor factor 2^d − 1, a Fermat number is killed by any odd factor d > 1 of the exponent through the proper divisor 2^m + 1 (n = d·m). The surviving exponents are exactly those with no odd factor > 1, i.e. the powers of two. The n ≥ 1 hypothesis is genuinely needed: 2^0 + 1 = 2 is prime but 0 is not a power of two.",
+    "mathContext": "$2^n + 1 \\text{ prime},\\; n \\ge 1 \\;\\Rightarrow\\; n = 2^k.$ Sole exception: $2^0 + 1 = 2.$",
+    "significance": "context",
+    "relatedConcepts": ["Fermat numbers", "Fermat primes", "Mersenne exponents", "powers of two"],
+    "prerequisites": ["elementary number theory", "divisibility"]
+  },
+  {
+    "id": "ann-divisibility-engine",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": { "startLine": 51, "endLine": 66 },
+    "type": "technique",
+    "title": "Odd exponents preserve a+1 divisibility",
+    "content": "The elementary engine: for every natural a and odd d, a + 1 divides a^d + 1. Proved over ℤ by rewriting a + 1 = a − (−1) and a^d + 1 = a^d − (−1)^d (using (−1)^d = −1 since d is odd, via Odd.neg_one_pow), then applying the standard factorization sub_dvd_pow_sub_pow: x − y ∣ x^n − y^n. The integer divisibility is transferred back to ℕ with push_cast and exact_mod_cast. This is the '+1' cousin of the a − 1 ∣ a^d − 1 identity behind the Mersenne result.",
+    "mathContext": "$d \\text{ odd} \\Rightarrow a+1 = a-(-1) \\mid a^d - (-1)^d = a^d + 1.$",
+    "significance": "key",
+    "relatedConcepts": ["difference of powers", "x-y ∣ xⁿ-yⁿ", "sign of (-1)^d", "integer-to-natural cast"],
+    "prerequisites": ["ring theory", "divisibility over ℤ"]
+  },
+  {
+    "id": "ann-core-dichotomy",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": { "startLine": 68, "endLine": 100 },
+    "type": "insight",
+    "title": "Core dichotomy: a Fermat prime has no odd factor > 1 in its exponent",
+    "content": "If 2^n + 1 is prime and n ≥ 1, then every odd divisor d of n equals 1. Suppose an odd d > 1 (so d ≥ 3) with n = d·m, m ≥ 1. Then 2^n + 1 = (2^m)^d + 1, so by the divisibility engine 2^m + 1 divides it. Primality forces 2^m + 1 = 1 (impossible, 2^m ≥ 1) or 2^m + 1 = 2^n + 1, i.e. 2^m = 2^n, i.e. m = n by injectivity of the exponential (Nat.pow_right_injective) — contradicting m < n since d ≥ 2. Hence the only odd divisor of n is 1.",
+    "mathContext": "$d \\mid n,\\; d \\text{ odd},\\; d > 1 \\Rightarrow 2^{n/d}+1 \\text{ is a proper factor of } 2^n+1,\\; \\bot.$",
+    "significance": "key",
+    "relatedConcepts": ["proper divisor", "primality dichotomy", "injectivity of n ↦ 2ⁿ", "proof by contradiction"],
+    "prerequisites": ["prime numbers", "divisibility"]
+  },
+  {
+    "id": "ann-strong-induction",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": { "startLine": 102, "endLine": 125 },
+    "type": "technique",
+    "title": "Odd part = 1 ⇒ power of two (strong induction)",
+    "content": "A self-contained lemma: a positive natural whose only odd divisor is 1 is a power of two. Proved by strong induction on n. If n is odd, then n divides itself and is odd, so the hypothesis forces n = 1 = 2^0. If n is even, write n = 2m; every odd divisor of m also divides n, so m inherits the hypothesis, the induction hypothesis gives m = 2^k, and hence n = 2^{k+1}. This isolates the purely combinatorial half of the argument from the number-theoretic dichotomy.",
+    "mathContext": "$(\\forall d \\mid n,\\; d \\text{ odd} \\Rightarrow d = 1) \\wedge n > 0 \\;\\Rightarrow\\; \\exists k,\\; n = 2^k.$",
+    "significance": "supporting",
+    "relatedConcepts": ["strong induction", "odd part of an integer", "2-adic valuation", "Nat.strong_induction_on"],
+    "prerequisites": ["induction", "elementary number theory"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": { "startLine": 127, "endLine": 140 },
+    "type": "concept",
+    "title": "Main theorem and the 0-or-power-of-two restatement",
+    "content": "exponent_isPowerOfTwo composes the two halves: the core dichotomy (odd divisors of n are all 1) feeds the strong-induction lemma to yield n = 2^k. exponent_zero_or_isPowerOfTwo drops the positivity hypothesis into the classical dichotomy n = 0 ∨ ∃ k, n = 2^k, honestly recording that 2^0 + 1 = 2 is the sole prime whose exponent is not a power of two.",
+    "mathContext": "$2^n+1 \\text{ prime} \\Rightarrow n = 0 \\;\\vee\\; \\exists k,\\; n = 2^k.$",
+    "significance": "key",
+    "relatedConcepts": ["Fermat primes", "necessary condition", "case analysis"],
+    "prerequisites": ["prime numbers"]
+  },
+  {
+    "id": "ann-search-pruning",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": { "startLine": 142, "endLine": 147 },
+    "type": "concept",
+    "title": "Contrapositive search-pruning form",
+    "content": "not_prime_of_odd_factor is the contrapositive packaging useful for computation: if the exponent n has any odd factor d > 1, then 2^n + 1 is composite. This is exactly the pruning rule for searching Fermat primes — one need only test exponents that are powers of two, which is why the search is restricted to 2^{2^k} + 1.",
+    "mathContext": "$d \\mid n,\\; d \\text{ odd},\\; d > 1,\\; n > 0 \\;\\Rightarrow\\; 2^n + 1 \\text{ composite}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["contrapositive", "search space pruning", "Fermat prime search"],
+    "prerequisites": ["prime numbers", "divisibility"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `mersenne-prime-exponent-oq-01` (quality 41, pass 0).

## Gap addressed
Rich `meta.json` but **no `annotations.json`**. Adds a line-anchored annotation layer over the 148-line Lean file (`FermatPrimeExponent.lean`).

## What was added
`annotations.json` with **6 annotations**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
- **Statement** — 2^n+1 prime, n≥1 ⟹ n a power of two; the '+1' analogue of the Mersenne exponent condition, with the n=0 exception.
- **Divisibility engine** (`add_one_dvd_pow_add_one_of_odd`) — d odd ⟹ a+1 ∣ a^d+1 via x−y ∣ xⁿ−yⁿ over ℤ.
- **Core dichotomy** (`odd_divisor_eq_one`) — a Fermat prime forces every odd divisor of the exponent to be 1.
- **Strong-induction lemma** (`isPowerOfTwo_of_odd_divisor_eq_one`) — odd-part-1 ⟹ power of two.
- **Main theorem** + 0-or-power-of-two restatement.
- **Search-pruning** contrapositive (`not_prime_of_odd_factor`).

## Verification
- Valid JSON; all 6 ranges within the 148-line file; schema matches existing gallery annotations.
- Axiom integrity unchanged: `status: verified`, `badge: original`, 0 axioms / 0 sorries.

No `meta.json` changes (~13.9 KB, under all caps).