### PR TITLE
audit(erdos-437): correct stale sorry count 1→0 in meta

### DIFF
--- a/src/data/proofs/erdos-437/meta.json
+++ b/src/data/proofs/erdos-437/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 437,
     "erdosUrl": "https://erdosproblems.com/437",
     "erdosProblemStatus": "solved",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 290,
-    "assumptions": "4 axioms: L_little_o_x, erdos_437, L_lower_bound, L_upper_bound. 1 sorry remains.",
+    "assumptions": "4 axioms: L_little_o_x, erdos_437, L_lower_bound, L_upper_bound. 0 sorries.",
     "theoremCount": 5,
     "definitionCount": 9,
     "additionalFiles": [


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-437 (Erdős Problem #437: Square Partial Products)
**Severity**: LOW (stale sorry count; conservative direction — no overclaim)

## Issue

`meta.meta.sorries` was `1` and the `assumptions` field read "…4 axioms…. 1 sorry remains", but the Lean source has **0 sorries**.

PR #35050 repaired the broken build and fixed the false example lemma, landing at "[0 sorry / 4 axiom]", but the meta's sorry count / assumptions text were not fully updated. The internally-consistent fields (top-level `sorries: 0`, `leanFile.sorries: 0`) already agreed with reality.

## Evidence

- `grep -c sorry` (raw, incl. comments) = 0 in both `Erdos437Problem.lean` and `Erdos437Aristotle.lean`
- 4 `axiom` declarations present (L_little_o_x, erdos_437, L_lower_bound, L_upper_bound) → `axiomCount: 4` accurate
- `erdos_437_answer := erdos_437` transparently invokes the axiom → `status: axiomatized`, `badge: axiom` correct
- `native_decide` at line 67 is a standalone `example` sanity check, not in the main theorem chain → correctly excluded from axiom counting

## Fix

- `meta.sorries`: `1` → `0`
- `assumptions`: "1 sorry remains." → "0 sorries."

No change to status/badge/axiomCount — those were already accurate.

---
Discovered during gallery integrity audit.