### PR TITLE
Fix: sync stale erdos-437 meta block (sorries 1→0)

### DIFF
--- a/src/data/proofs/erdos-437/meta.json
+++ b/src/data/proofs/erdos-437/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 437,
     "erdosUrl": "https://erdosproblems.com/437",
     "erdosProblemStatus": "solved",
@@ -63,9 +63,9 @@
       "hyperelliptic_connection: link to algebraic curves"
     ],
     "axiomCount": 4,
-    "lineCount": 290,
-    "assumptions": "4 axioms: L_little_o_x, erdos_437, L_lower_bound, L_upper_bound. 1 sorry remains.",
-    "theoremCount": 5,
+    "lineCount": 355,
+    "assumptions": "4 axioms: L_little_o_x, erdos_437, L_lower_bound, L_upper_bound.",
+    "theoremCount": 6,
     "definitionCount": 9,
     "additionalFiles": [
       "Proofs/Erdos437Aristotle.lean"


### PR DESCRIPTION
## Fix

Commit #35050 repaired the erdos-437 build (discharged the last sorry) and updated the `leanFile` block, but left the parallel `meta` block stale.

## Evidence

Actual `Erdos437Problem.lean` (comment-stripped): **0 sorries**, 355 lines, 6 theorems, 4 axioms — matching the already-correct `leanFile` block and top-level `sorries: 0`.

The `meta` block was stale and inconsistent:

| Field | Before | After (actual) |
|-------|--------|----------------|
| `meta.sorries` | 1 | 0 |
| `meta.lineCount` | 290 | 355 |
| `meta.theoremCount` | 5 | 6 |
| `assumptions` text | "...1 sorry remains." | (clause removed) |

`meta.axiomCount: 4` and `definitionCount: 9` were already correct and unchanged. Status remains `axiomatized`/`axiom` (4 axioms). No overclaim change — this corrects an *under*claim (meta said a sorry remained when none does).

Metadata-only fix; gallery data pipeline validated the JSON with no schema errors.

---
Automated fix by lean-mechanic agent.