### PR TITLE
research(birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01): general closed form for the k=3 birthday count [VERIFIED, 0 sorry / 0 axiom]

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean
@@ -1,0 +1,127 @@
+/-
+Birthday problem — general closed form for the k=3 count (OQ-03-OQ-01-OQ-01-OQ-05-OQ-01)
+
+The parent entry `birthday-problem-oq-03-oq-01-oq-01-oq-05` introduces the slot recurrence
+
+  R 0 e s         = 1
+  R (n+1) e s     = e · R n (e-1) (s+1) + s · R n e (s-1)
+
+with `birthdayCount3 n d = R n d 0`, the number of ways to seat `n` labelled people on
+`d` days with **at most two per day**, and proves the individual closed forms for
+`n = 1, 2, 3, 4` (`d`, `d²`, `d³−d`, `d⁴−4d²+3d`).
+
+This file proves the **general** closed form, valid for every `n`:
+
+  birthdayCount3 n d = ∑_{p=0}^{⌊n/2⌋} C(n, 2p) · (2p−1)‼ · (d)_{n−p}
+
+where `(2p−1)‼ = 1·3·5···(2p−1)` is the number of perfect matchings on `2p` points
+(the count of ways to pick `p` disjoint pairs), and `(d)_m = d(d−1)···(d−m+1)` is the
+falling factorial `Nat.descFactorial d m`.  The term with `p` pairs seats `2p` of the
+people in `p` doubly-occupied days and the remaining `n−2p` people in singly-occupied
+days, using `n−p` distinct days in total.
+
+The proof is entirely elementary and lives over `ℕ` (all quantities are natural numbers,
+the falling factorial vanishing automatically once a day-count is exhausted).  It proceeds
+by:
+
+* `R_peel_single` — the ladder identity `R n e (s+1) = R n e s + n · R (n-1) e s`
+  (multiplying the per-day generating function by the single-day factor `(1+x)`), proved
+  by induction on `n`;
+* `birthdayCount3_rec` — the resulting two-term recurrence
+  `birthdayCount3 (n+1) d = d · (birthdayCount3 n (d-1) + n · birthdayCount3 (n-1) (d-1))`;
+* `birthdayCount3_closed` — the general closed form, by strong induction on `n`, the
+  inductive step reducing to Pascal's rule and the absorption identity
+  `k·C(n,k) = n·C(n-1,k-1)`.
+
+The recurrence definition is reproduced here so the file is self-contained and fast to
+compile.
+-/
+
+import Mathlib
+
+namespace BirthdayGeneralClosed
+
+/-- Slot recurrence for the k=3 birthday count (state `(e, s)` = empty / single days). -/
+def R : ℕ → ℕ → ℕ → ℕ
+  | 0, _, _ => 1
+  | n + 1, e, s => e * R n (e - 1) (s + 1) + s * R n e (s - 1)
+
+/-- Number of ways to seat `n` labelled people on `d` days with at most two per day. -/
+def birthdayCount3 (n d : ℕ) : ℕ := R n d 0
+
+@[simp] theorem R_zero (e s : ℕ) : R 0 e s = 1 := rfl
+
+@[simp] theorem R_succ (n e s : ℕ) :
+    R (n + 1) e s = e * R n (e - 1) (s + 1) + s * R n e (s - 1) := rfl
+
+theorem R_one (e s : ℕ) : R 1 e s = e + s := by simp
+
+/-- **Single-day ladder identity.** Adding one already-occupied ("single") day multiplies
+the per-day generating function by `(1 + x)`, i.e.
+
+  `R n e (s+1) = R n e s + n · R (n-1) e s`.
+
+Proved by strong induction on `n`: the inductive step expands `R (m+2) e (s+1)` by the
+slot recurrence, applies the identity at level `m+1` to the `(e-1)` argument, and then
+reduces to the identity at level `m+1` again (at the `s-1` argument), using the slot
+recurrence to rewrite the auxiliary term.  The residual algebraic identity is closed by a
+`linear_combination` over `ℤ`. -/
+theorem R_peel_single : ∀ n e s, R n e (s + 1) = R n e s + n * R (n - 1) e s := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    match n with
+    | 0 => intro e s; simp
+    | 1 => intro e s; simp only [R_one, Nat.sub_self, R_zero, one_mul]; omega
+    | (m + 2) =>
+      intro e s
+      rcases Nat.eq_zero_or_pos s with hs | hs
+      · -- s = 0.
+        subst hs
+        show R (m + 2) e 1 = R (m + 2) e 0 + (m + 2) * R (m + 1) e 0
+        have hL : R (m + 2) e 1
+            = e * R (m + 1) (e - 1) 2 + R (m + 1) e 0 := by simp [R_succ]
+        have h1 : R (m + 1) (e - 1) 2
+            = R (m + 1) (e - 1) 1 + (m + 1) * R m (e - 1) 1 := by
+          have := ih (m + 1) (by omega) (e - 1) 1; simpa using this
+        have hR0 : R (m + 2) e 0 = e * R (m + 1) (e - 1) 1 := by simp [R_succ]
+        have hRe : R (m + 1) e 0 = e * R m (e - 1) 1 := by simp [R_succ]
+        rw [hL, h1, hR0, hRe]; ring
+      · obtain ⟨t, rfl⟩ : ∃ t, s = t + 1 := ⟨s - 1, by omega⟩
+        show R (m + 2) e (t + 2) = R (m + 2) e (t + 1) + (m + 2) * R (m + 1) e (t + 1)
+        -- Expand the LHS by the slot recurrence.
+        have hL : R (m + 2) e (t + 2)
+            = e * R (m + 1) (e - 1) (t + 3) + (t + 2) * R (m + 1) e (t + 1) := by
+          simp [R_succ]
+        -- Ladder at level m+1 on the (e-1) argument.
+        have h1 : R (m + 1) (e - 1) (t + 3)
+            = R (m + 1) (e - 1) (t + 2) + (m + 1) * R m (e - 1) (t + 2) := by
+          have := ih (m + 1) (by omega) (e - 1) (t + 2); simpa using this
+        -- Expand the target RHS by the slot recurrence.
+        have hR : R (m + 2) e (t + 1)
+            = e * R (m + 1) (e - 1) (t + 2) + (t + 1) * R (m + 1) e t := by simp [R_succ]
+        -- Slot recurrence for the auxiliary term  C = R (m+1) e (t+1).
+        have hC : R (m + 1) e (t + 1)
+            = e * R m (e - 1) (t + 2) + (t + 1) * R m e t := by simp [R_succ]
+        -- Ladder at level m+1 for the (e, t) argument:  C = D + (m+1)·E.
+        have hD : R (m + 1) e (t + 1)
+            = R (m + 1) e t + (m + 1) * R m e t := by
+          have := ih (m + 1) (by omega) e t; simpa using this
+        rw [hL, h1, hR]
+        zify at hC hD ⊢
+        linear_combination (-(m : ℤ) - 1) * hC + ((t : ℤ) + 1) * hD
+
+/-- **Two-term recurrence for the birthday count.** Seating person `n+1` fixes one of the
+`d` days; the remaining `n` people are then distributed over the other days, one of which
+already holds person `n+1` (contributing the `n · …` term via `R_peel_single`).
+
+  `birthdayCount3 (n+1) d = d · (birthdayCount3 n (d-1) + n · birthdayCount3 (n-1) (d-1))`. -/
+theorem birthdayCount3_rec (n d : ℕ) :
+    birthdayCount3 (n + 1) d
+      = d * (birthdayCount3 n (d - 1) + n * birthdayCount3 (n - 1) (d - 1)) := by
+  have hpeel : R n (d - 1) 1 = R n (d - 1) 0 + n * R (n - 1) (d - 1) 0 :=
+    R_peel_single n (d - 1) 0
+  simp only [birthdayCount3, R_succ, Nat.zero_sub, zero_mul, add_zero, Nat.zero_add]
+  rw [hpeel]
+
+end BirthdayGeneralClosed

--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean
@@ -187,7 +187,64 @@ coefficient identity is `choose_absorb_M` (Pascal + absorption), after reindexin
 `F n` contribution by `p ↦ p+1`. -/
 theorem F_rec (n d : ℕ) :
     F (n + 1 + 1) (d + 1) = (d + 1) * (F (n + 1) d + (n + 1) * F n d) := by
-  sorry
+  -- LHS as a sum over `range (n+1+1+1)`, coefficient `C(n+2,2p)·M p`.
+  have hL : F (n + 1 + 1) (d + 1)
+      = ∑ p ∈ Finset.range (n + 1 + 1 + 1),
+          (n + 2).choose (2 * p) * M p * (d + 1).descFactorial (n + 2 - p) := rfl
+  -- `(d+1)·F(n+1) d` as a sum over the same range, coefficient `C(n+1,2p)·M p`.
+  have hA : (d + 1) * F (n + 1) d
+      = ∑ p ∈ Finset.range (n + 1 + 1 + 1),
+          (n + 1).choose (2 * p) * M p * (d + 1).descFactorial (n + 2 - p) := by
+    rw [F, Finset.mul_sum,
+        Finset.sum_range_succ (fun p =>
+          (n + 1).choose (2 * p) * M p * (d + 1).descFactorial (n + 2 - p)) (n + 1 + 1),
+        show (n + 1).choose (2 * (n + 1 + 1)) = 0 from Nat.choose_eq_zero_of_lt (by omega),
+        zero_mul, zero_mul, add_zero]
+    apply Finset.sum_congr rfl
+    intro p hp
+    simp only [Finset.mem_range] at hp
+    rw [show (d + 1) * ((n + 1).choose (2 * p) * M p * d.descFactorial (n + 1 - p))
+          = (n + 1).choose (2 * p) * M p * ((d + 1) * d.descFactorial (n + 1 - p)) from by ring,
+        descFactorial_pull, show n + 1 - p + 1 = n + 2 - p from by omega]
+  -- `(n+1)·(d+1)·F n d` as a sum over the same range, with a `p = 0` guard.
+  have hB : (n + 1) * ((d + 1) * F n d)
+      = ∑ p ∈ Finset.range (n + 1 + 1 + 1),
+          (n + 1) * (if p = 0 then 0 else n.choose (2 * (p - 1)) * M (p - 1))
+            * (d + 1).descFactorial (n + 2 - p) := by
+    rw [F, Finset.mul_sum, Finset.mul_sum,
+        Finset.sum_range_succ' (fun p =>
+          (n + 1) * (if p = 0 then 0 else n.choose (2 * (p - 1)) * M (p - 1))
+            * (d + 1).descFactorial (n + 2 - p)) (n + 1 + 1)]
+    simp only [↓reduceIte, mul_zero, zero_mul, add_zero]
+    rw [Finset.sum_range_succ (fun p =>
+          (n + 1) * (if p + 1 = 0 then 0 else n.choose (2 * (p + 1 - 1)) * M (p + 1 - 1))
+            * (d + 1).descFactorial (n + 2 - (p + 1))) (n + 1)]
+    rw [show (if n + 1 + 1 = 0 then 0
+              else n.choose (2 * (n + 1 + 1 - 1)) * M (n + 1 + 1 - 1)) = 0 from by
+          rw [if_neg (by omega), Nat.add_sub_cancel,
+              show n.choose (2 * (n + 1)) = 0 from Nat.choose_eq_zero_of_lt (by omega), zero_mul],
+        mul_zero, zero_mul, add_zero]
+    apply Finset.sum_congr rfl
+    intro p hp
+    simp only [Finset.mem_range] at hp
+    rw [if_neg (by omega : ¬ p + 1 = 0), Nat.add_sub_cancel,
+        show (n + 1) * ((d + 1) * (n.choose (2 * p) * M p * d.descFactorial (n - p)))
+          = (n + 1) * (n.choose (2 * p) * M p) * ((d + 1) * d.descFactorial (n - p)) from by ring,
+        descFactorial_pull, show n - p + 1 = n + 2 - (p + 1) from by omega]
+  -- Assemble the three sums and match coefficients pointwise.
+  rw [mul_add, show (d + 1) * ((n + 1) * F n d) = (n + 1) * ((d + 1) * F n d) from by ring,
+      hA, hB, hL, ← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro p hp
+  match p with
+  | 0 => simp
+  | (q + 1) =>
+    rw [if_neg (by omega : ¬ q + 1 = 0), Nat.add_sub_cancel,
+        show (n + 2).choose (2 * (q + 1)) * M (q + 1) * (d + 1).descFactorial (n + 2 - (q + 1))
+          = ((n + 2).choose (2 * (q + 1)) * M (q + 1)) * (d + 1).descFactorial (n + 2 - (q + 1))
+          from by ring,
+        choose_absorb_M]
+    ring
 
 /-- **General closed form for the birthday count.**  For every `n` and `d`,
 
@@ -225,5 +282,9 @@ theorem birthdayCount3_closed : ∀ n d, birthdayCount3 n d = F n d := by
         simp only [Nat.add_sub_cancel] at hrec
         rw [hrec, ih (m + 1) (by omega) d', ih m (by omega) d']
         exact (F_rec m d').symm
+
+-- Axiom audit: the file contains no `sorry`, no `axiom` declarations, no `native_decide`
+-- and no `decide` on the stated results, so the closed form depends only on the standard
+-- foundational axioms (`propext`, `Classical.choice`, `Quot.sound`) — no assumptions.
 
 end BirthdayGeneralClosed

--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean
@@ -124,4 +124,106 @@ theorem birthdayCount3_rec (n d : ℕ) :
   simp only [birthdayCount3, R_succ, Nat.zero_sub, zero_mul, add_zero, Nat.zero_add]
   rw [hpeel]
 
+/-!
+### The general closed form
+
+`birthdayCount3 n d = ∑_{p} C(n, 2p) · (2p−1)‼ · (d)_{n−p}`.
+-/
+
+/-- Perfect-matching numbers: `M p = (2p−1)‼ = 1·3·5···(2p−1)`, the number of ways to
+partition `2p` labelled points into `p` unordered pairs. -/
+def M : ℕ → ℕ
+  | 0 => 1
+  | p + 1 => (2 * p + 1) * M p
+
+@[simp] theorem M_zero : M 0 = 1 := rfl
+theorem M_succ (p : ℕ) : M (p + 1) = (2 * p + 1) * M p := rfl
+
+/-- Closed-form summand `F n d = ∑_{p=0}^{n} C(n,2p)·(2p−1)‼·(d)_{n−p}`.  Terms with
+`2p > n` vanish because `C(n,2p) = 0`. -/
+def F (n d : ℕ) : ℕ :=
+  ∑ p ∈ Finset.range (n + 1), n.choose (2 * p) * M p * d.descFactorial (n - p)
+
+/-- Pascal + absorption identity underlying the recurrence for the closed form:
+`C(n+2,2q+2)·(2q+1) = C(n+1,2q+2)·(2q+1) + (n+1)·C(n,2q)`. -/
+theorem choose_absorb (n q : ℕ) :
+    (n + 2).choose (2 * q + 2) * (2 * q + 1)
+      = (n + 1).choose (2 * q + 2) * (2 * q + 1) + (n + 1) * n.choose (2 * q) := by
+  have hpascal : (n + 2).choose (2 * q + 2)
+      = (n + 1).choose (2 * q + 1) + (n + 1).choose (2 * q + 2) :=
+    Nat.choose_succ_succ (n + 1) (2 * q + 1)
+  have habs : (n + 1) * n.choose (2 * q)
+      = (n + 1).choose (2 * q + 1) * (2 * q + 1) := by
+    simpa using Nat.succ_mul_choose_eq n (2 * q)
+  rw [hpascal, add_mul, habs]; ring
+
+/-- The same identity with the matching numbers attached:
+`C(n+2,2(q+1))·M(q+1) = C(n+1,2(q+1))·M(q+1) + (n+1)·(C(n,2q)·M q)`. -/
+theorem choose_absorb_M (n q : ℕ) :
+    (n + 2).choose (2 * (q + 1)) * M (q + 1)
+      = (n + 1).choose (2 * (q + 1)) * M (q + 1) + (n + 1) * (n.choose (2 * q) * M q) := by
+  have h := choose_absorb n q
+  have e2 : 2 * (q + 1) = 2 * q + 2 := by ring
+  rw [e2, M_succ]
+  rw [show (n + 2).choose (2 * q + 2) * ((2 * q + 1) * M q)
+        = ((n + 2).choose (2 * q + 2) * (2 * q + 1)) * M q from by ring,
+      show (n + 1).choose (2 * q + 2) * ((2 * q + 1) * M q)
+        = ((n + 1).choose (2 * q + 2) * (2 * q + 1)) * M q from by ring,
+      show (n + 1) * (n.choose (2 * q) * M q)
+        = ((n + 1) * n.choose (2 * q)) * M q from by ring,
+      h, add_mul]
+
+/-- Pulling a factor out of a falling factorial:
+`(d+1)·(d)_k = (d+1)_{k+1}`. -/
+theorem descFactorial_pull (d k : ℕ) :
+    (d + 1) * d.descFactorial k = (d + 1).descFactorial (k + 1) :=
+  (Nat.succ_descFactorial_succ d k).symm
+
+/-- **The closed form satisfies the birthday recurrence.**
+`F (n+2) (d+1) = (d+1)·(F (n+1) d + (n+1)·F n d)`.
+
+Both sides are expressed as sums over `p` of `(coefficient) · (d+1)_{n+2−p}`; the
+coefficient identity is `choose_absorb_M` (Pascal + absorption), after reindexing the
+`F n` contribution by `p ↦ p+1`. -/
+theorem F_rec (n d : ℕ) :
+    F (n + 1 + 1) (d + 1) = (d + 1) * (F (n + 1) d + (n + 1) * F n d) := by
+  sorry
+
+/-- **General closed form for the birthday count.**  For every `n` and `d`,
+
+  `birthdayCount3 n d = ∑_{p=0}^{⌊n/2⌋} C(n, 2p) · (2p−1)‼ · (d)_{n−p}`. -/
+theorem birthdayCount3_closed : ∀ n d, birthdayCount3 n d = F n d := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases n with _ | _ | m
+    · -- n = 0
+      intro d; simp [birthdayCount3, F, M, Finset.sum_range_one]
+    · -- n = 1
+      intro d
+      simp only [birthdayCount3, R_one, add_zero, F]
+      rw [Finset.sum_range_succ, Finset.sum_range_one]
+      simp [M, Nat.choose_eq_zero_of_lt (show (1 : ℕ) < 2 by omega)]
+    · -- n = m + 2
+      intro d
+      rcases d with _ | d'
+      · -- d = 0 : both sides are 0
+        have hb : birthdayCount3 (m + 1 + 1) 0 = 0 := by simp [birthdayCount3, R_succ]
+        have hF : F (m + 1 + 1) 0 = 0 := by
+          rw [F]; apply Finset.sum_eq_zero; intro p hp
+          simp only [Finset.mem_range] at hp
+          rcases Nat.lt_or_ge p (m + 2) with h | h
+          · have : (0 : ℕ).descFactorial (m + 1 + 1 - p) = 0 := by
+              rw [Nat.descFactorial_eq_zero_iff_lt]; omega
+            rw [this, mul_zero]
+          · have : (m + 1 + 1).choose (2 * p) = 0 :=
+              Nat.choose_eq_zero_of_lt (by omega)
+            rw [this, zero_mul, zero_mul]
+        rw [hb, hF]
+      · -- d = d' + 1 : use the recurrence and the closed-form recurrence F_rec
+        have hrec := birthdayCount3_rec (m + 1) (d' + 1)
+        simp only [Nat.add_sub_cancel] at hrec
+        rw [hrec, ih (m + 1) (by omega) d', ih m (by omega) d']
+        exact (F_rec m d').symm
+
 end BirthdayGeneralClosed

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01/annotations.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "concept",
+    "title": "From Tabulated Values to a General Formula",
+    "content": "The **k=3 birthday count** $\\mathrm{birthdayCount3}\\,n\\,d$ is the number of ways to seat $n$ labelled people on $d$ days with **at most two per day** — the seatings that avoid a triple coincidence. The parent chain computed it case by case: $d$, $d^2$, $d^3-d$, $d^4-4d^2+3d$ for $n=1,2,3,4$. This entry proves the **single formula behind all of them**:\n$$\\mathrm{birthdayCount3}\\,n\\,d = \\sum_{p=0}^{\\lfloor n/2\\rfloor} \\binom{n}{2p}\\,(2p-1)!!\\,(d)_{n-p},$$\nwhere $(2p-1)!! = 1\\cdot 3\\cdots(2p-1)$ counts the perfect matchings on $2p$ points and $(d)_{n-p}=d(d-1)\\cdots(d-n+p+1)$ is the falling factorial. The index $p$ is the number of **doubly-occupied days**: choose which $2p$ people are paired ($\\binom{n}{2p}$), match them into $p$ pairs ($(2p-1)!!$), and place the $n-p$ occupied days among the $d$ available ($(d)_{n-p}$)."
+  },
+  {
+    "id": "ann-egf",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+    "range": { "startLine": 44, "endLine": 51 },
+    "type": "concept",
+    "title": "The Generating Function Behind the Recurrence",
+    "content": "The slot recurrence $R\\,0\\,e\\,s=1$, $R\\,(n{+}1)\\,e\\,s = e\\,R\\,n\\,(e{-}1)\\,(s{+}1) + s\\,R\\,n\\,e\\,(s{-}1)$ tracks the number of **empty** ($e$) and **singly-occupied** ($s$) days as people are seated one at a time, with $\\mathrm{birthdayCount3}\\,n\\,d = R\\,n\\,d\\,0$. Conceptually $R\\,n\\,e\\,s = n!\\,[x^n]\\,(1+x+\\tfrac{x^2}{2})^{e}(1+x)^{s}$: an empty day contributes the factor $1+x+\\tfrac{x^2}{2}$ (zero, one, or two people) and a single day the factor $1+x$ (zero or one more). Every identity in this file is the combinatorial shadow of manipulating that product — but the proof stays elementary and never formalises power series."
+  },
+  {
+    "id": "ann-ladder",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+    "range": { "startLine": 58, "endLine": 114 },
+    "type": "key-step",
+    "title": "The Single-Day Ladder Identity",
+    "content": "**`R_peel_single`:** $R\\,n\\,e\\,(s{+}1) = R\\,n\\,e\\,s + n\\cdot R\\,(n{-}1)\\,e\\,s$. Adding one already-occupied day multiplies the generating function by the single-day factor $(1+x)$, and extracting the $x^n$ coefficient of $(1+x)\\cdot g$ produces exactly $g$ plus $n$ times the shifted coefficient. This is the one lemma that lets us extract a *two-parameter* recurrence from the one-step slot recurrence without dragging the $(e,s)$ state through the induction. It is proved by strong induction on $n$: the step expands $R\\,(m{+}2)\\,e\\,(s{+}1)$ by the recurrence, applies the identity at level $m{+}1$, and closes the residual algebra with a `linear_combination` over $\\mathbb{Z}$ (Nat subtraction is kept honest by casing on $s=0$)."
+  },
+  {
+    "id": "ann-rec",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+    "range": { "startLine": 116, "endLine": 125 },
+    "type": "key-step",
+    "title": "The Two-Term Recurrence",
+    "content": "**`birthdayCount3_rec`:** $\\mathrm{birthdayCount3}\\,(n{+}1)\\,d = d\\big(\\mathrm{birthdayCount3}\\,n\\,(d{-}1) + n\\cdot\\mathrm{birthdayCount3}\\,(n{-}1)\\,(d{-}1)\\big)$. Person $n{+}1$ takes one of the $d$ days; the remaining $n$ people are then seated on a board where that day is already **singly** occupied. Applying `R_peel_single` at $s=0$ splits this into 'the day stays a pair-free single' (the $\\mathrm{birthdayCount3}\\,n\\,(d{-}1)$ term) versus 'someone joins person $n{+}1$' (the $n\\cdot\\mathrm{birthdayCount3}\\,(n{-}1)\\,(d{-}1)$ term). This is the recurrence the induction runs on."
+  },
+  {
+    "id": "ann-absorb",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+    "range": { "startLine": 127, "endLine": 186 },
+    "type": "technique",
+    "title": "Pascal + Absorption: the Coefficient Engine",
+    "content": "The matching numbers satisfy $M(p{+}1) = (2p{+}1)\\,M(p)$, and the closed form is $F\\,n\\,d = \\sum_p \\binom{n}{2p}\\,M(p)\\,(d)_{n-p}$. Checking that $F$ obeys the recurrence reduces, coefficient by coefficient, to two standard facts: **Pascal's rule** $\\binom{n+2}{2q+2} = \\binom{n+1}{2q+1}+\\binom{n+1}{2q+2}$ and the **absorption identity** $(2q{+}1)\\binom{n+1}{2q+1} = (n{+}1)\\binom{n}{2q}$ (`Nat.succ_mul_choose_eq`). Together (`choose_absorb`, then `choose_absorb_M` after factoring out $M(q)$) they give $\\binom{n+2}{2(q+1)}M(q{+}1) = \\binom{n+1}{2(q+1)}M(q{+}1) + (n{+}1)\\binom{n}{2q}M(q)$ — the entire arithmetic content of the induction. `descFactorial_pull` ($(d{+}1)(d)_k = (d{+}1)_{k+1}$) threads the recurrence's extra day into the shared falling-factorial term."
+  },
+  {
+    "id": "ann-frec",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+    "range": { "startLine": 188, "endLine": 250 },
+    "type": "key-step",
+    "title": "The Closed Form Satisfies the Recurrence",
+    "content": "**`F_rec`:** $F\\,(n{+}2)\\,(d{+}1) = (d{+}1)\\big(F\\,(n{+}1)\\,d + (n{+}1)\\,F\\,n\\,d\\big)$. Each of the three pieces is rewritten as a sum over $p$ of $(\\text{coefficient})\\cdot(d{+}1)_{n+2-p}$ — the same falling-factorial basis — using `descFactorial_pull` to absorb the $(d{+}1)$ prefactor and range extension to align the summation bounds. The $F\\,n$ contribution is reindexed $p\\mapsto p{+}1$ so that its power $(d+1)_{n+1-p}$ lands on the same basis element as the others. Matching the coefficient of each basis element is precisely `choose_absorb_M`, with the $p=0$ term handled separately."
+  },
+  {
+    "id": "ann-main",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+    "range": { "startLine": 252, "endLine": 290 },
+    "type": "key-step",
+    "title": "The Main Theorem by Strong Induction",
+    "content": "**`birthdayCount3_closed`:** $\\mathrm{birthdayCount3}\\,n\\,d = F\\,n\\,d$ for all $n,d$. Strong induction on $n$: the base cases $n=0,1$ are direct, and the $d=0$ case is a shared vanishing (both sides are $0$ for $n\\ge 1$, the falling factorial and the choose factor each killing their terms). For $n=m{+}2$, $d=d'{+}1$, the two-term recurrence `birthdayCount3_rec` plus the induction hypothesis at levels $m{+}1$ and $m$ turn the goal into exactly `F_rec`. The whole development is over $\\mathbb{N}$, sorry-free and axiom-free (no `native_decide`), so it depends only on `propext`, `Classical.choice`, `Quot.sound`."
+  }
+]

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01/index.ts
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const birthdayProblemOQ03OQ01OQ01OQ05OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const birthdayProblemOQ03OQ01OQ01OQ05OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const birthdayProblemOQ03OQ01OQ01OQ05OQ01Data: ProofData = {
+  proof: birthdayProblemOQ03OQ01OQ01OQ05OQ01Proof,
+  annotations: birthdayProblemOQ03OQ01OQ01OQ05OQ01Annotations,
+}

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+  "title": "General Closed Form for the k=3 Birthday Count",
+  "slug": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+  "description": "Resolves the parent's open question by proving the general closed form of the k=3 birthday count for every n, not just the tabulated n = 1, 2, 3, 4. The number of ways to seat n labelled people on d days with at most two per day is birthdayCount3 n d = Σ_{p=0}^{⌊n/2⌋} C(n, 2p) · (2p−1)‼ · (d)_{n−p}, where (2p−1)‼ = 1·3·5···(2p−1) counts perfect matchings on 2p points and (d)_{n−p} = d(d−1)···(d−n+p+1) is the falling factorial. The proof is entirely over ℕ (no truncated-subtraction artefacts, since the falling factorial vanishes on its own) and 0-axiom: no native_decide. The key steps are a single-day ladder identity R n e (s+1) = R n e s + n·R (n−1) e s for the slot recurrence, the resulting two-term recurrence birthdayCount3 (n+1) d = d·(birthdayCount3 n (d−1) + n·birthdayCount3 (n−1) (d−1)), and a strong induction on n whose inductive step reduces, coefficient by coefficient, to Pascal's rule together with the binomial absorption identity k·C(n,k) = n·C(n−1,k−1).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-05",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "birthday-problem",
+      "generating-functions",
+      "recurrence",
+      "closed-form",
+      "falling-factorial",
+      "perfect-matchings",
+      "induction"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-05",
+    "axiomCount": 0,
+    "assumptions": "None. The file has no sorry, no axiom declarations, no native_decide and no decide on the stated results, so it depends only on propext, Classical.choice and Quot.sound — no Lean.ofReduceBool.",
+    "lineCount": 290,
+    "theoremCount": 12,
+    "definitionCount": 4,
+    "originalContributions": [
+      "birthdayCount3_closed: the general closed form birthdayCount3 n d = Σ_p C(n,2p)·(2p−1)‼·(d)_{n−p}, valid for all n and d, over ℕ (resolves the parent's open question)",
+      "R_peel_single: the single-day ladder identity R n e (s+1) = R n e s + n·R (n−1) e s for the slot recurrence, proved by strong induction on n",
+      "birthdayCount3_rec: the two-term recurrence birthdayCount3 (n+1) d = d·(birthdayCount3 n (d−1) + n·birthdayCount3 (n−1) (d−1))",
+      "F_rec: the closed form satisfies the same recurrence, reduced coefficient-by-coefficient to Pascal + absorption via choose_absorb_M"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "birthdayCount3_closed",
+      "type": "core",
+      "description": "The general closed form: for every n and d, the number of ways to seat n labelled people on d days with at most two per day is Σ_{p=0}^{⌊n/2⌋} C(n,2p)·(2p−1)‼·(d)_{n−p}. Proved by strong induction on n: the base cases n = 0, 1 are direct, and for n = m+2 the two-term recurrence birthdayCount3_rec plus the induction hypothesis reduce the goal to F_rec.",
+      "leanType": "(n d : ℕ) → birthdayCount3 n d = F n d"
+    },
+    {
+      "name": "R_peel_single",
+      "type": "lemma",
+      "description": "The single-day ladder identity: adding one already-occupied ('single') day multiplies the per-day generating function by (1 + x), giving R n e (s+1) = R n e s + n·R (n−1) e s. Proved by strong induction on n; the inductive step expands R (m+2) e (s+1) by the slot recurrence, applies the identity at level m+1, and closes the residual with a linear_combination over ℤ.",
+      "leanType": "(n e s : ℕ) → R n e (s + 1) = R n e s + n * R (n - 1) e s"
+    },
+    {
+      "name": "birthdayCount3_rec",
+      "type": "lemma",
+      "description": "The two-term recurrence for the count. Seating person n+1 fixes one of the d days; the remaining n people are distributed over the other days, one of which already holds person n+1 — the source of the n·… term, supplied by R_peel_single at s = 0.",
+      "leanType": "(n d : ℕ) → birthdayCount3 (n + 1) d = d * (birthdayCount3 n (d - 1) + n * birthdayCount3 (n - 1) (d - 1))"
+    },
+    {
+      "name": "F_rec",
+      "type": "lemma",
+      "description": "The closed form F satisfies the birthday recurrence: F (n+2) (d+1) = (d+1)·(F (n+1) d + (n+1)·F n d). Both sides are written as sums over p of (coefficient)·(d+1)_{n+2−p}; after reindexing the F n contribution by p ↦ p+1 the coefficient identity is choose_absorb_M. This is the crux linking the recurrence to the explicit formula.",
+      "leanType": "(n d : ℕ) → F (n + 1 + 1) (d + 1) = (d + 1) * (F (n + 1) d + (n + 1) * F n d)"
+    },
+    {
+      "name": "choose_absorb_M",
+      "type": "lemma",
+      "description": "The Pascal + absorption identity with the matching numbers attached: C(n+2,2(q+1))·M(q+1) = C(n+1,2(q+1))·M(q+1) + (n+1)·(C(n,2q)·M q). This is the per-coefficient content of F_rec; it follows from choose_absorb by factoring out M q = (2q−1)‼.",
+      "leanType": "(n q : ℕ) → (n + 2).choose (2 * (q + 1)) * M (q + 1) = (n + 1).choose (2 * (q + 1)) * M (q + 1) + (n + 1) * (n.choose (2 * q) * M q)"
+    },
+    {
+      "name": "choose_absorb",
+      "type": "lemma",
+      "description": "The underlying binomial identity C(n+2,2q+2)·(2q+1) = C(n+1,2q+2)·(2q+1) + (n+1)·C(n,2q), proved from Pascal's rule (Nat.choose_succ_succ) and the absorption identity k·C(n,k) = n·C(n−1,k−1) (Nat.succ_mul_choose_eq).",
+      "leanType": "(n q : ℕ) → (n + 2).choose (2 * q + 2) * (2 * q + 1) = (n + 1).choose (2 * q + 2) * (2 * q + 1) + (n + 1) * n.choose (2 * q)"
+    },
+    {
+      "name": "descFactorial_pull",
+      "type": "lemma",
+      "description": "Pulling a factor into a falling factorial: (d+1)·(d)_k = (d+1)_{k+1}, i.e. Nat.succ_descFactorial_succ. Used to convert the (d+1)· prefactor of the recurrence into the shared falling-factorial term (d+1)_{n+2−p}.",
+      "leanType": "(d k : ℕ) → (d + 1) * d.descFactorial k = (d + 1).descFactorial (k + 1)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The classical birthday problem (von Mises 1939; Feller) asks for the probability of a shared birthday among n people. Its k=3 (triple-coincidence) variant counts the seatings that avoid any triple: n labelled people on d days with at most two per day. The parent chain built an O(n²) slot recurrence R(n,e,s) tracking the numbers of empty and singly-occupied days, and read off the individual closed forms birthdayCount3 1 d = d, = d², = d³ − d, and (in the immediate parent) = d⁴ − 4d² + 3d for n = 4 — leaving as an explicit open question the general closed form for all n. The single-day case d = 1 is the involution / telephone-number sequence OEIS A000085.",
+    "problemStatement": "Prove the general closed form of birthdayCount3 n d — valid for every n, not just tabulated values — as a polynomial in d with the involution / perfect-matching structure, by induction on n.",
+    "text": "Write the count as an exponential generating function: birthdayCount3 n d = n! · [xⁿ] (1 + x + x²/2)^d, each per-day factor 1 + x + x²/2 encoding 'zero, one, or two people that day'. Expanding the d-th power and extracting the xⁿ coefficient groups the seatings by the number p of doubly-occupied days: choose the p pair-days and the n−2p single-days among n−p distinct days ((d)_{n−p} ways), and match the 2p paired people ((2p−1)‼ ways), giving birthdayCount3 n d = Σ_{p} C(n,2p)·(2p−1)‼·(d)_{n−p}. We do not formalise power series; instead we prove the identity by induction on n through the slot recurrence. The single-day ladder identity R n e (s+1) = R n e s + n·R (n−1) e s (multiplying the generating function by the single-day factor 1 + x) turns R n d 0 into the two-term recurrence birthdayCount3 (n+1) d = d·(birthdayCount3 n (d−1) + n·birthdayCount3 (n−1) (d−1)). Strong induction on n then reduces to showing that the explicit sum F satisfies this same recurrence (F_rec); matching the coefficient of each falling factorial (d+1)_{n+2−p} on both sides is exactly Pascal's rule plus the absorption identity k·C(n,k) = n·C(n−1,k−1).",
+    "proofStrategy": "Prove the single-day ladder identity R_peel_single by strong induction on n (residual closed by linear_combination over ℤ); derive the two-term recurrence birthdayCount3_rec; prove that the closed form F satisfies the recurrence (F_rec) by rewriting both sides as sums over a common falling-factorial basis, reindexing, and matching coefficients via choose_absorb_M (Pascal + absorption); conclude by strong induction on n with base cases n = 0, 1 and the d = 0 vanishing case handled directly.",
+    "keyInsights": [
+      "The whole d-polynomial sequence is generated by (1 + x + x²/2)^d: birthdayCount3 n d = n! · [xⁿ] (1 + x + x²/2)^d, so the ad-hoc closed forms d, d², d³−d, d⁴−4d²+3d are coefficients of one clean generating function.",
+      "Grouping by the number p of doubly-occupied days gives the perfect-matching structure: C(n,2p) chooses the paired people, (2p−1)‼ matches them into p pairs, and (d)_{n−p} places the n−p occupied days — a division-free ℕ formula.",
+      "The single-day ladder identity R n e (s+1) = R n e s + n·R (n−1) e s is the combinatorial shadow of multiplying the generating function by the single-day factor (1 + x); it is the one lemma that unlocks a two-parameter recurrence from the one-step slot recurrence without carrying the (e, s) state.",
+      "Verifying that the explicit formula obeys the recurrence collapses, coefficient by coefficient, to Pascal's rule C(n+2,2q+2) = C(n+1,2q+1) + C(n+1,2q+2) and the absorption identity (2q+1)·C(n+1,2q+1) = (n+1)·C(n,2q) — no heavy machinery, just two standard binomial facts.",
+      "Falling factorials keep the statement over ℕ with no truncated-subtraction artefacts: (d)_{n−p} vanishes automatically once the day-count is exhausted, and (d+1)·(d)_k = (d+1)_{k+1} threads the recurrence's extra day cleanly."
+    ],
+    "prerequisites": [
+      "The parent slot recurrence R and birthdayCount3 n d = R n d 0",
+      "Falling factorials (Nat.descFactorial) and the double factorial / perfect-matching count",
+      "Binomial coefficient identities: Pascal's rule and absorption k·C(n,k) = n·C(n−1,k−1)",
+      "Finset.sum manipulation: reindexing, range splitting, and coefficient matching"
+    ]
+  },
+  "conclusion": {
+    "summary": "birthdayCount3 n d = Σ_{p=0}^{⌊n/2⌋} C(n,2p)·(2p−1)‼·(d)_{n−p} for all n and d, the general closed form the parent left open, proved 0-axiom by strong induction on n through a single-day ladder identity and a Pascal + absorption coefficient match. 12 theorems, 4 definitions, 290 lines.",
+    "implications": "Replaces the parent chain's per-n tabulated formulas (d, d², d³−d, d⁴−4d²+3d) with a single uniform formula valid for every n, exhibiting the perfect-matching / involution structure explicitly and confirming the (1 + x + x²/2)^d generating function at the level of coefficients — without formalising power series. The ladder identity R_peel_single is reusable for any two-parameter slot-recurrence analysis.",
+    "openQuestions": [
+      "Derive the same closed form directly from the exponential generating function (1 + x + x²/2)^d using Mathlib's PowerSeries, cross-checking the coefficient extraction.",
+      "Prove the general k-way count R_k (at most k−1 per day) as a sum over the number of days at each multiplicity, generalising the p-indexed pair sum here.",
+      "Establish the three-term recurrence 2·a_{n+1} = 2(d−n)·a_n + n(2d−n+1)·a_{n−1} in n (fixed d) and use it for an alternative, matching-number-free proof."
+    ]
+  },
+  "leanFile": {
+    "namespace": "BirthdayGeneralClosed",
+    "lineCount": 290,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 4,
+    "path": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "title": "Birthday problem (and its k-coincidence variants)",
+      "url": "https://en.wikipedia.org/wiki/Birthday_problem"
+    },
+    {
+      "title": "OEIS A000085 — involutions / telephone numbers, the d = 1 case of ≤2-per-day seatings",
+      "url": "https://oeis.org/A000085"
+    },
+    {
+      "title": "Double factorial (2p−1)‼ — the number of perfect matchings on 2p points",
+      "url": "https://en.wikipedia.org/wiki/Double_factorial"
+    },
+    {
+      "title": "H. S. Wilf, generatingfunctionology (2nd ed., 1994) — exponential generating functions and the product/convolution rule",
+      "url": "https://www2.math.upenn.edu/~wilf/DownldGF.html"
+    },
+    {
+      "title": "Falling factorial and finite differences",
+      "url": "https://en.wikipedia.org/wiki/Falling_and_rising_factorials"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-05",
+      "relationship": "extends",
+      "description": "Parent: the n = 4 closed form d⁴ − 4d² + 3d, whose stated open question 'find the general closed form birthdayCount3 n d as a polynomial in d and prove it by induction on n' this entry resolves."
+    },
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent: the O(n²) slot recurrence R(n,e,s) with the closed forms for n = 1, 2, 3. This entry generalises those tabulated cases to a single formula for all n."
+    },
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling generalising the k=3 slot recurrence to a multiplicity-histogram recurrence R_k. The p-indexed pair sum here is the k = 3 specialisation, and the k-way generalisation is listed as an open question."
+    },
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-03",
+      "relationship": "complementary",
+      "description": "Complementary asymptotic view: that entry derives the large-n coincidence threshold, whereas this entry pins down the exact count for every n. Together they bracket birthdayCount3 from the asymptotic and exact-enumeration sides."
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "related",
+      "description": "The classical birthday problem at the root of this open-question chain; the k=3 'at most two per day' count is its triple-coincidence analogue."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Module header and statement of the general form",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Recalls the parent slot recurrence and tabulated closed forms, and states the general result birthdayCount3 n d = Σ_p C(n,2p)·(2p−1)‼·(d)_{n−p}, outlining the ladder-identity → recurrence → Pascal/absorption plan."
+    },
+    {
+      "title": "The slot recurrence and the single-day ladder identity",
+      "startLine": 44,
+      "endLine": 114,
+      "summary": "Reproduces R n e s and birthdayCount3 n d = R n d 0 with the base lemmas R_zero, R_succ, R_one, then proves R_peel_single: R n e (s+1) = R n e s + n·R (n−1) e s by strong induction on n, closing the residual with a linear_combination over ℤ."
+    },
+    {
+      "title": "The two-term birthday recurrence",
+      "startLine": 116,
+      "endLine": 125,
+      "summary": "birthdayCount3_rec: birthdayCount3 (n+1) d = d·(birthdayCount3 n (d−1) + n·birthdayCount3 (n−1) (d−1)), from the slot recurrence at s = 0 and the ladder identity."
+    },
+    {
+      "title": "The closed form and the Pascal + absorption identity",
+      "startLine": 127,
+      "endLine": 186,
+      "summary": "Defines the matching numbers M p = (2p−1)‼ and the closed-form sum F n d, and proves the binomial identities choose_absorb and choose_absorb_M together with the falling-factorial identity descFactorial_pull."
+    },
+    {
+      "title": "The closed form satisfies the recurrence (F_rec)",
+      "startLine": 188,
+      "endLine": 250,
+      "summary": "F_rec: F (n+2) (d+1) = (d+1)·(F (n+1) d + (n+1)·F n d), by writing both sides as sums over a shared falling-factorial basis, reindexing the F n contribution by p ↦ p+1, and matching coefficients via choose_absorb_M."
+    },
+    {
+      "title": "Main theorem by strong induction on n",
+      "startLine": 252,
+      "endLine": 290,
+      "summary": "birthdayCount3_closed: strong induction on n with base cases n = 0, 1 and the d = 0 vanishing case handled directly; the n = m+2, d = d'+1 step combines birthdayCount3_rec, the induction hypothesis, and F_rec."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Resolves the parent entry's stated open question by proving the **general closed form** of the k=3 birthday count for **every** `n` — the parent chain only computed the individual values `d`, `d²`, `d³−d`, `d⁴−4d²+3d` for `n = 1, 2, 3, 4`.

For `birthdayCount3 n d` = number of ways to seat `n` labelled people on `d` days with **at most two per day**:

```
birthdayCount3 n d = ∑_{p=0}^{⌊n/2⌋} C(n, 2p) · (2p−1)‼ · (d)_{n−p}
```

where `(2p−1)‼ = 1·3·5···(2p−1)` is the number of perfect matchings on `2p` points and `(d)_{n−p}` is the falling factorial `Nat.descFactorial`. The index `p` is the number of doubly-occupied days.

**`birthdayCount3_closed : ∀ n d, birthdayCount3 n d = F n d` — 0 sorry, 0 axiom, entirely over ℕ.**

## Proof architecture

1. **`R_peel_single`** — the single-day ladder identity `R n e (s+1) = R n e s + n·R (n−1) e s` (the combinatorial shadow of multiplying the per-day generating function `(1+x+x²/2)^e (1+x)^s` by the single-day factor `(1+x)`), by strong induction on `n`; the residual is closed by a `linear_combination` over ℤ.
2. **`birthdayCount3_rec`** — the resulting two-term recurrence `birthdayCount3 (n+1) d = d·(birthdayCount3 n (d−1) + n·birthdayCount3 (n−1) (d−1))`.
3. **`F_rec`** — the closed form satisfies the same recurrence; both sides are put over a shared falling-factorial basis, the `F n` term is reindexed `p ↦ p+1`, and the coefficient match is **Pascal's rule + the absorption identity `k·C(n,k) = n·C(n−1,k−1)`** (`choose_absorb` / `choose_absorb_M`).
4. **`birthdayCount3_closed`** — strong induction on `n` (bases `n=0,1`, `d=0` vanishing case direct).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BirthdayProblemOQ03OQ01OQ01OQ05OQ01` — **builds clean**.
- No `sorry`, no `axiom` declarations, no `native_decide`, no `decide` on the results → depends only on `propext`, `Classical.choice`, `Quot.sound`.
- 12 theorems, 4 definitions, 290 lines.

## Files

- `proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ05OQ01.lean` — the proof.
- `src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01/` — gallery entry (meta.json, index.ts, annotations.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)