### PR TITLE
Enrich tetrahedral-number-formula: cover file-header roadmap (5th annotation + section)

### DIFF
--- a/src/data/proofs/tetrahedral-number-formula/annotations.json
+++ b/src/data/proofs/tetrahedral-number-formula/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "ann-file-roadmap",
+    "proofId": "tetrahedral-number-formula",
+    "range": {
+      "startLine": 4,
+      "endLine": 48
+    },
+    "type": "context",
+    "title": "File roadmap: the division-free design constraint and the three public theorems",
+    "content": "The module docstring states the goal and the guiding design constraint before any proof: prove $\\sum_{k=1}^{n} T_k = \\binom{n+2}{3} = n(n+1)(n+2)/6$ with $T_k = \\binom{k+1}{2}$, *phrased so no division ever appears*. It lays out the three headline results the file will deliver — `sum_triangular_choose` (the clean hockey-stick statement in binomial form), `six_mul_sum_triangular` (the cleared-denominator polynomial identity), and `six_mul_choose_three` (the tetrahedral closed form) — and names the entire toolkit used to reach them: `Finset.sum_range_succ`, Pascal's rule (`Nat.choose_succ_succ`), and `ring`/`omega`. The novelty note records that Mathlib has `Nat.choose_two_right` and Pascal's rule but neither the tetrahedral closed form nor the $d=3$ hockey-stick identity as named lemmas. The single import of `Mathlib.Tactic` (plus `Mathlib.Algebra.BigOperators.Intervals` for range-sums) is routine for a gallery proof; `namespace TetrahedralNumberFormula` and `open Finset` scope the range-sum notation.",
+    "mathContext": "$\\sum_{k=1}^{n} \\binom{k+1}{2} = \\binom{n+2}{3} = \\tfrac{n(n+1)(n+2)}{6}$, proved with $\\binom{\\cdot}{\\cdot}$ so the $/6$ and $/2$ never enter the core inductions.",
+    "significance": "context",
+    "prerequisites": [
+      "Binomial coefficients (Nat.choose)",
+      "Finite sums over Finset.range"
+    ],
+    "relatedConcepts": [
+      "Figurate-number ladder",
+      "Hockey-stick identity",
+      "Division-free formalization"
+    ]
+  },
+  {
     "id": "ann-triangular-bridge",
     "proofId": "tetrahedral-number-formula",
     "range": {

--- a/src/data/proofs/tetrahedral-number-formula/meta.json
+++ b/src/data/proofs/tetrahedral-number-formula/meta.json
@@ -65,6 +65,13 @@
   },
   "sections": [
     {
+      "id": "roadmap",
+      "title": "Roadmap: goal, division-free constraint, and the three public theorems",
+      "startLine": 4,
+      "endLine": 48,
+      "summary": "The module docstring fixes the goal ∑_{k≤n} T_k = C(n+2,3) = n(n+1)(n+2)/6 with T_k = C(k+1,2), and the guiding design constraint: phrase everything with Nat.choose so no division appears in the core argument. It names the three headline results — sum_triangular_choose (clean hockey-stick statement), six_mul_sum_triangular (cleared-denominator polynomial identity), six_mul_choose_three (tetrahedral closed form) — and the toolkit (sum_range_succ, Pascal's rule, ring/omega). Imports Mathlib.Tactic and Mathlib.Algebra.BigOperators.Intervals; opens Finset for range-sum notation."
+    },
+    {
       "id": "triangular-bridge",
       "title": "Triangular number as a binomial coefficient",
       "startLine": 50,


### PR DESCRIPTION
Enrichment pass for `tetrahedral-number-formula` (pass 0, quality 91).

The entry was already rich (4 keyInsights, complete conclusion, 3 cross-refs) but had exactly **4 annotations** (5-annotation minimum) and both its annotations and sections **started at line 50**, leaving the module docstring / roadmap (lines 4-48) uncovered.

## Changes
- **New annotation** `ann-file-roadmap` (lines 4-48, type `context`): explains the division-free design constraint and previews the three public theorems (`sum_triangular_choose`, `six_mul_sum_triangular`, `six_mul_choose_three`) and the toolkit. Reaches the 5-annotation minimum and closes the full-file coverage gap.
- **New section** `roadmap` (lines 4-48): sections now cover the docstring in addition to the four proof blocks.

## Integrity
- No `status`/`badge`/`axiomCount` changes — entry remains `verified` / `original` / 0-axiom, consistent with the Lean file (0 sorries, 0 axioms).
- `meta.json` is 14.6 KB, well under the ~60 KB cap; 5 annotations, 5 sections.
- JSON validated; the build's annotation-generation phase processed the entry without error.