### PR TITLE
research(erdos-1013-oq-02): any limit of the consecutive ratio is forced to be 1 (no side-condition)

### DIFF
--- a/proofs/Proofs/Erdos1013UnconditionalRatio.lean
+++ b/proofs/Proofs/Erdos1013UnconditionalRatio.lean
@@ -350,6 +350,38 @@ theorem ratio_liminf_le_one_le_limsup {h : ℕ → ℝ} (hb : PolyBounded h)
       1 ≤ limsup (fun k => h (k + 1) / h k) atTop :=
   ⟨ratio_liminf_le_one hb hbelow, one_le_ratio_limsup hb habove⟩
 
+/- ## The sharp corollary: any limit of the ratio is forced to be `1` -/
+
+/-- **The unconditional pinch, in its sharpest user-facing form.**  For any polynomially
+bounded positive `h`, *if* the consecutive ratio converges to some `L`, then `L = 1` — with
+**no boundedness side-condition** (a convergent sequence is automatically bounded on both
+sides, so the cobounded hypotheses of `ratio_liminf_le_one` / `one_le_ratio_limsup` come for
+free via `Tendsto.isBoundedUnder_ge` / `isBoundedUnder_le`).  A convergent sequence has
+`liminf = limsup = L`, and the straddle `liminf ≤ 1 ≤ limsup` then forces `L ≤ 1 ≤ L`.
+
+This is the direct statement about the open (⋆): we cannot prove the ratio converges, but we
+prove **unconditionally** that it *cannot converge to any value other than `1`*. -/
+theorem ratio_tendsto_imp_one {h : ℕ → ℝ} (hb : PolyBounded h) {L : ℝ}
+    (hlim : Tendsto (fun k => h (k + 1) / h k) atTop (𝓝 L)) : L = 1 := by
+  -- a convergent sequence is bounded above and below
+  have hbelow : IsBoundedUnder (· ≥ ·) atTop (fun k => h (k + 1) / h k) :=
+    hlim.isBoundedUnder_ge
+  have habove : IsBoundedUnder (· ≤ ·) atTop (fun k => h (k + 1) / h k) :=
+    hlim.isBoundedUnder_le
+  -- for a convergent sequence, liminf = limsup = L
+  have hliminf : liminf (fun k => h (k + 1) / h k) atTop = L := hlim.liminf_eq
+  have hlimsup : limsup (fun k => h (k + 1) / h k) atTop = L := hlim.limsup_eq
+  have h1 : L ≤ 1 := by rw [← hliminf]; exact ratio_liminf_le_one hb hbelow
+  have h2 : 1 ≤ L := by rw [← hlimsup]; exact one_le_ratio_limsup hb habove
+  linarith
+
+/-- **Contrapositive form.**  The consecutive ratio of a polynomially bounded positive `h`
+does not converge to any value `L ≠ 1`.  So the only candidate limit is `1` — every other
+value is ruled out unconditionally. -/
+theorem ratio_not_tendsto_of_ne_one {h : ℕ → ℝ} (hb : PolyBounded h) {L : ℝ} (hL : L ≠ 1) :
+    ¬ Tendsto (fun k => h (k + 1) / h k) atTop (𝓝 L) :=
+  fun hlim => hL (ratio_tendsto_imp_one hb hlim)
+
 /- ## Specialisation to the genuine threshold `h₃` -/
 
 /-- The genuine triangle-free chromatic threshold (as a real candidate `h₃`) is
@@ -412,6 +444,18 @@ theorem h3_ratio_liminf_le_one_le_limsup (h₃ : ℕ → ℝ) (hpos : ∀ k, 0 <
   have hbddb : IsBoundedUnder (· ≥ ·) atTop (fun k => h₃ (k + 1) / h₃ k) := ⟨m, hbelow⟩
   have hbdda : IsBoundedUnder (· ≤ ·) atTop (fun k => h₃ (k + 1) / h₃ k) := ⟨M, habove⟩
   exact ratio_liminf_le_one_le_limsup hb hbddb hbdda
+
+/-- **Erdős #1013 (oq-02), the forced-limit corollary for `h₃`.**  Purely from the known
+`k² ≤ h₃(k) ≤ k³` bounds — no bounded-ratio leaf, no hypothesis on the asymptotic constant —
+*if* the consecutive ratio `h₃(k+1)/h₃(k)` converges to some `L`, then `L = 1`.  Convergence
+supplies its own two-sided boundedness, so this is strictly cleaner than
+`h3_ratio_liminf_le_one_le_limsup` (no `m`, `M` inputs).  It is the sharpest unconditional
+statement toward the open (⋆): the ratio *cannot* converge to anything but `1`. -/
+theorem h3_ratio_tendsto_imp_one (h₃ : ℕ → ℝ) (hpos : ∀ k, 0 < h₃ k)
+    (hlow : ∀ᶠ (k : ℕ) in atTop, (k : ℝ) ^ 2 ≤ h₃ k)
+    (hup : ∀ᶠ (k : ℕ) in atTop, h₃ k ≤ (k : ℝ) ^ 3) {L : ℝ}
+    (hlim : Tendsto (fun k => h₃ (k + 1) / h₃ k) atTop (𝓝 L)) : L = 1 :=
+  ratio_tendsto_imp_one (polyBounded_of_h3 h₃ hpos hlow hup) hlim
 
 /-
 ## Remarks — why the *pointwise* ratio (⋆) is not settled here

--- a/research/problems/erdos-1013-oq-02/state.md
+++ b/research/problems/erdos-1013-oq-02/state.md
@@ -4,16 +4,32 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-05
-**Iteration**: 4
+**Iteration**: 5
 
-## Current Focus
-Promoted the frequency straddle to the **honest `Filter.liminf`/`Filter.limsup` form** in
-`Erdos1013UnconditionalRatio.lean`. New theorems (0 sorry / 0 axiom, Docker lean 4.26.0):
+## Current Focus (Iteration 5, 2026-07-05)
+Packaged the pinch into its **sharpest user-facing form** in
+`Erdos1013UnconditionalRatio.lean` (0 sorry / 0 axiom, Docker lean 4.26.0 VERIFIED,
+first-try build). Three new theorems:
+- `ratio_tendsto_imp_one` (general PolyBounded): if the consecutive ratio converges to `L`,
+  then `L = 1`, **with no boundedness side-condition** — a convergent sequence is
+  automatically bounded on both sides, so the cobounded hypotheses of `ratio_liminf_le_one`
+  / `one_le_ratio_limsup` come for free via `Tendsto.isBoundedUnder_ge` / `isBoundedUnder_le`,
+  and `Tendsto.liminf_eq` / `limsup_eq` collapse the straddle to `L ≤ 1 ≤ L`.
+- `ratio_not_tendsto_of_ne_one` (contrapositive): the ratio does not converge to any `L ≠ 1`.
+- `h3_ratio_tendsto_imp_one` (`h₃` specialisation): purely from `k² ≤ h₃(k) ≤ k³`, no
+  bounded-ratio leaf and no constant hypothesis, any limit of `h₃(k+1)/h₃(k)` equals `1`.
+
+This is strictly cleaner than iteration-4's `h3_ratio_liminf_le_one_le_limsup` (which needed
+externally-supplied `m`, `M` bounds): convergence supplies its own two-sided boundedness. It
+is the most direct unconditional statement toward the open (⋆): the ratio *cannot converge to
+anything but `1`*. File now 21 theorems, 476 lines.
+
+## Prior Iteration (4)
+Promoted the frequency straddle to the **honest `Filter.liminf`/`Filter.limsup` form**:
 `ratio_liminf_le_one`, `one_le_ratio_limsup`, `ratio_liminf_le_one_le_limsup`, and the `h₃`
 specialisation `h3_ratio_liminf_le_one_le_limsup`. Given the ratio is eventually two-sided
-bounded (the `[1/2,2]` bounded-ratio leaf supplies this cobounded side-condition), we now
-have `liminf_k h₃(k+1)/h₃ k ≤ 1 ≤ limsup_k h₃(k+1)/h₃ k` as genuine `Filter` statements —
-so **if the ratio converges at all, the limit is forced to be `1`**.
+bounded (the `[1/2,2]` bounded-ratio leaf supplies this cobounded side-condition),
+`liminf_k h₃(k+1)/h₃ k ≤ 1 ≤ limsup_k h₃(k+1)/h₃ k` as genuine `Filter` statements.
 
 ## Prior Iteration (3)
 Added the unconditional **straddle-1** frequency result: for every `ε > 0` the ratio is


### PR DESCRIPTION
## Erdős #1013 (oq-02) — unconditional progress on the consecutive-ratio question

Erdős #1013 asks whether \`h₃(k+1)/h₃(k) → 1\`, where \`h₃(k)\` is the least number of vertices in a triangle-free graph of chromatic number \`k\`. The pointwise convergence (⋆) is **genuinely open** (the \`log log k\` gap between the known bounds permits local oscillation).

This PR packages the existing unconditional \`liminf ≤ 1 ≤ limsup\` straddle into its **sharpest user-facing form**, adding three verified theorems to \`Erdos1013UnconditionalRatio.lean\`:

- **\`ratio_tendsto_imp_one\`** (general \`PolyBounded\`): if the consecutive ratio converges to \`L\`, then \`L = 1\` — **with no boundedness side-condition**. A convergent sequence is automatically bounded on both sides (\`Tendsto.isBoundedUnder_ge\` / \`isBoundedUnder_le\`), so the cobounded hypotheses of the iteration-4 liminf/limsup theorems come for free; \`Tendsto.liminf_eq\` / \`limsup_eq\` then collapse the straddle to \`L ≤ 1 ≤ L\`.
- **\`ratio_not_tendsto_of_ne_one\`** (contrapositive): the ratio does not converge to any \`L ≠ 1\`.
- **\`h3_ratio_tendsto_imp_one\`** (\`h₃\` specialisation): purely from \`k² ≤ h₃(k) ≤ k³\`, with no bounded-ratio leaf and no hypothesis on the asymptotic constant, **any limit of \`h₃(k+1)/h₃(k)\` equals \`1\`**.

### Why this is a real increment

Iteration 4's \`h3_ratio_liminf_le_one_le_limsup\` required externally-supplied \`m, M\` ratio bounds (from the \`[1/2, 2]\` bounded-ratio leaf). The new corollary is strictly cleaner: convergence supplies its own two-sided boundedness, so the statement needs only the known \`k²/k³\` bounds. It is the most direct unconditional statement toward the open (⋆): **we cannot prove the ratio converges, but we prove unconditionally that it cannot converge to anything but 1.**

### Verification

- Docker \`lean 4.26.0\` build clean (first try): \`✔ Built Proofs.Erdos1013UnconditionalRatio\`.
- 0 sorries, 0 \`axiom\` declarations, 0 structure-encoded assumptions.
- New theorems compose already-verified lemmas + standard Mathlib filter lemmas only (no \`native_decide\`), so foundational axioms remain \`propext\` / \`Classical.choice\` / \`Quot.sound\`.
- File: 18 → 21 theorems, 432 → 476 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)