### PR TITLE
Enrich Fermat Prime Exponents Are Powers of Two: add annotations.json (5 annotations)

### DIFF
--- a/src/data/proofs/mersenne-prime-exponent-oq-01/annotations.json
+++ b/src/data/proofs/mersenne-prime-exponent-oq-01/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "ann-file-roadmap",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 47
+    },
+    "type": "context",
+    "title": "File roadmap: the Fermat/Mersenne mirror and the n ≥ 1 exception",
+    "content": "The module docstring frames the result and its place beside the Mersenne condition. A **Fermat number** is $2^n + 1$; the known Fermat primes $3, 5, 17, 257, 65537$ have exponents $1, 2, 4, 8, 16$ — all powers of two — and the theorem shows this is forced: $\\text{Prime}(2^n+1) \\wedge n \\ge 1 \\Rightarrow n = 2^k$. The docstring draws the exact mirror with `MersennePrimeExponent.lean`: a *composite* exponent kills $2^n - 1$ through a **proper-divisor** factor $2^d - 1$, whereas $2^n + 1$ is killed by any **odd** factor $d > 1$ of the exponent (via the proper divisor $2^{n/d} + 1$). Hence the surviving exponents are exactly those with no odd factor $> 1$ — the powers of two. It also flags the sole exception $2^0 + 1 = 2$ (prime, but $0$ is not a power of two), which is why the hypothesis $n \\ge 1$ is genuinely needed. `import Mathlib` pulls in the full library; `namespace FermatPrimeExponent` scopes the five theorems that follow.",
+    "mathContext": "$\\text{Prime}(2^n+1) \\wedge n \\ge 1 \\implies \\exists k,\\ n = 2^k$; the $+1$ mirror of $2^n-1$ prime $\\Rightarrow n$ prime.",
+    "significance": "context",
+    "prerequisites": [
+      "Fermat and Mersenne numbers",
+      "Divisibility and primality in ℕ"
+    ],
+    "relatedConcepts": [
+      "Fermat primes",
+      "Mersenne primes",
+      "Powers of two"
+    ]
+  },
+  {
+    "id": "ann-odd-exponent-divisibility",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 66
+    },
+    "type": "technique",
+    "title": "The arithmetic engine: d odd ⇒ a + 1 ∣ aᵈ + 1 (via ℤ and sub_dvd_pow_sub_pow)",
+    "content": "`add_one_dvd_pow_add_one_of_odd` is the lemma the whole proof turns on: for odd $d$, $a + 1$ divides $a^d + 1$. The trick is to leave $\\mathbb{N}$ (where $+1$ is awkward) and work in $\\mathbb{Z}$, where $a + 1 = a - (-1)$ (`ring`) and, crucially for *odd* $d$, $a^d + 1 = a^d - (-1)^d$ because $(-1)^d = -1$ (`Odd.neg_one_pow`, `hd.neg_one_pow`). With both sides rewritten as differences, Mathlib's `sub_dvd_pow_sub_pow` — the ring identity $x - y \\mid x^n - y^n$ instantiated at $x = a$, $y = -1$ — delivers the divisibility directly. `push_cast` and `exact_mod_cast` then transfer $(\\mathbb{Z})$-divisibility of the cast naturals back to $\\mathbb{N}$. This is the $+1$ counterpart of the $2^d - 1 \\mid 2^n - 1$ lift used on the Mersenne side; the parity of $d$ is exactly what makes the minus-sign flip land on $+1$.",
+    "mathContext": "In $\\mathbb{Z}$: $a+1 = a-(-1)$, $a^d+1 = a^d-(-1)^d$ (as $(-1)^d=-1$), so $x-y \\mid x^n-y^n$ gives $a+1 \\mid a^d+1$.",
+    "significance": "critical",
+    "prerequisites": [
+      "The identity x − y ∣ xⁿ − yⁿ",
+      "Parity and (−1)^d for odd d",
+      "Casting divisibility between ℕ and ℤ"
+    ],
+    "relatedConcepts": [
+      "sub_dvd_pow_sub_pow",
+      "Odd.neg_one_pow",
+      "Geometric-sum factorization"
+    ]
+  },
+  {
+    "id": "ann-odd-divisor-eq-one",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 100
+    },
+    "type": "insight",
+    "title": "Core dichotomy: a Fermat prime kills every odd exponent factor > 1",
+    "content": "`odd_divisor_eq_one` is the heart of the argument: if $2^n + 1$ is prime and $n \\ge 1$, every odd divisor of $n$ equals $1$. By contradiction, take an odd $d \\ne 1$; being odd and $> 1$ it satisfies $d \\ge 2$ (unpack $d = 2t+1$, `omega`). Write $n = d\\cdot m$; since $n > 0$, also $m > 0$. Then $2^n + 1 = (2^m)^d + 1$ (rewrite $2^{d m} = (2^m)^d$ via `pow_mul`), and the odd-exponent lemma makes $2^m + 1 = a + 1$ a divisor. Now `Nat.Prime.eq_one_or_self_of_dvd` gives the fork: $2^m + 1 = 1$ is impossible since $2^m \\ge 1$ (`omega`), and $2^m + 1 = 2^n + 1$ forces $2^m = 2^n$, so `Nat.pow_right_injective` (base $\\ge 2$) yields $m = n$; but $m < n$ because $d \\ge 2$. Both branches contradict, so no odd $d > 1$ can divide $n$.",
+    "mathContext": "$d \\mid n$, $d$ odd, $d>1$, $n=dm$: then $2^m+1 \\mid 2^n+1$; primality forces $m=n$, contradicting $m<n$.",
+    "significance": "critical",
+    "prerequisites": [
+      "Nat.Prime.eq_one_or_self_of_dvd",
+      "Injectivity of a ↦ aⁿ",
+      "Proof by contradiction"
+    ],
+    "relatedConcepts": [
+      "Nat.pow_right_injective",
+      "pow_mul",
+      "Proper divisors of a prime"
+    ]
+  },
+  {
+    "id": "ann-odd-part-one-power-of-two",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": {
+      "startLine": 102,
+      "endLine": 125
+    },
+    "type": "technique",
+    "title": "Odd part 1 ⇒ power of two, by self-contained strong induction",
+    "content": "`isPowerOfTwo_of_odd_divisor_eq_one` closes the gap between 'no odd divisor $> 1$' and 'is a power of two', deliberately avoiding `Nat.factorization` / `ord_compl`. Strong induction (`Nat.strong_induction_on`) on the value splits on parity. If $n$ is **odd**, then $n$ divides itself and is odd, so the hypothesis forces $n = 1 = 2^0$. If $n$ is **even**, write $n = 2m$ with $0 < m < n$; every odd divisor of $m$ also divides $n$ (`hd.trans hmdvd`), so $m$ inherits the hypothesis, the induction gives $m = 2^k$, and hence $n = 2^{k+1}$. Four short lines, entirely elementary — the factorization API is never touched.",
+    "mathContext": "Strong induction: $n$ odd $\\Rightarrow n=1=2^0$; $n=2m \\Rightarrow m=2^k \\Rightarrow n=2^{k+1}$.",
+    "significance": "high",
+    "prerequisites": [
+      "Strong induction on ℕ",
+      "Parity case split (Nat.even_or_odd)",
+      "Divisibility transitivity"
+    ],
+    "relatedConcepts": [
+      "Nat.strong_induction_on",
+      "Odd part / 2-adic valuation",
+      "Powers of two"
+    ]
+  },
+  {
+    "id": "ann-main-and-packagings",
+    "proofId": "mersenne-prime-exponent-oq-01",
+    "range": {
+      "startLine": 127,
+      "endLine": 147
+    },
+    "type": "theorem",
+    "title": "Main theorem and its search-pruning packagings",
+    "content": "The two halves compose in one line: `exponent_isPowerOfTwo` feeds `odd_divisor_eq_one` (every odd divisor of $n$ is $1$) straight into `isPowerOfTwo_of_odd_divisor_eq_one`, giving $n \\ge 1 \\wedge \\text{Prime}(2^n+1) \\Rightarrow \\exists k,\\ n = 2^k$. Two downstream forms make the result usable: `exponent_zero_or_isPowerOfTwo` drops the positivity hypothesis and honestly records the exception as the dichotomy $n = 0 \\vee \\exists k,\\ n = 2^k$ (since $2^0 + 1 = 2$ is a prime with a non-power-of-two exponent); and `not_prime_of_odd_factor` is the contrapositive search filter — an exponent with an odd factor $> 1$ yields a composite Fermat number — which is exactly the fact that justifies indexing Fermat primes as $2^{2^k} + 1$ and restricting primality searches to power-of-two exponents.",
+    "mathContext": "$\\exists k,\\ n=2^k$ (main); $n=0 \\vee \\exists k,\\ n=2^k$ (hypothesis-free); odd factor $>1 \\Rightarrow \\neg\\text{Prime}(2^n+1)$ (contrapositive).",
+    "significance": "high",
+    "prerequisites": [
+      "Composition of lemmas",
+      "Contrapositive reasoning"
+    ],
+    "relatedConcepts": [
+      "Fermat number indexing 2^{2^k}+1",
+      "Search pruning",
+      "Necessary conditions for primality"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `mersenne-prime-exponent-oq-01` (pass 0, quality **41** — the lowest-scoring open target).

## Gap
The entry had a rich `meta.json` (4 keyInsights, 4 sections, full conclusion) but **no `annotations.json` at all** — zero inline annotations, which is why its quality score sat at 41.

## Change
Added `annotations.json` with **5 annotations covering the full Lean file** (lines 3-147), each with `mathContext`, `significance`, `prerequisites`, and `relatedConcepts`:
- **ann-file-roadmap** (context) — the Fermat/Mersenne mirror and the genuine `n ≥ 1` exception (^0+1=2$)
- **ann-odd-exponent-divisibility** (technique) — the engine $ odd $\Rightarrow a+1 \mid a^d+1$, proved over $\mathbb{Z}$ via `sub_dvd_pow_sub_pow` with =-1$
- **ann-odd-divisor-eq-one** (insight) — a Fermat prime forces every odd exponent factor $>1$ to be $
- **ann-odd-part-one-power-of-two** (technique) — odd part  \Rightarrow$ power of two by self-contained strong induction (no factorization API)
- **ann-main-and-packagings** (theorem) — main theorem plus the zero/dichotomy and contrapositive search-pruning forms

## Integrity
No `status`/`badge`/`axiomCount` changes — remains `verified` / `original` / 0-axiom, consistent with the Lean file (0 sorries, 0 axioms). Annotation ranges match the actual theorem blocks; JSON validated.