### PR TITLE
Enrich birthday-problem k=3 closed form: add mathContext/significance/relatedConcepts to all 7 annotations

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01/annotations.json
@@ -2,57 +2,160 @@
   {
     "id": "ann-intro",
     "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
-    "range": { "startLine": 1, "endLine": 38 },
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
     "type": "concept",
     "title": "From Tabulated Values to a General Formula",
-    "content": "The **k=3 birthday count** $\\mathrm{birthdayCount3}\\,n\\,d$ is the number of ways to seat $n$ labelled people on $d$ days with **at most two per day** — the seatings that avoid a triple coincidence. The parent chain computed it case by case: $d$, $d^2$, $d^3-d$, $d^4-4d^2+3d$ for $n=1,2,3,4$. This entry proves the **single formula behind all of them**:\n$$\\mathrm{birthdayCount3}\\,n\\,d = \\sum_{p=0}^{\\lfloor n/2\\rfloor} \\binom{n}{2p}\\,(2p-1)!!\\,(d)_{n-p},$$\nwhere $(2p-1)!! = 1\\cdot 3\\cdots(2p-1)$ counts the perfect matchings on $2p$ points and $(d)_{n-p}=d(d-1)\\cdots(d-n+p+1)$ is the falling factorial. The index $p$ is the number of **doubly-occupied days**: choose which $2p$ people are paired ($\\binom{n}{2p}$), match them into $p$ pairs ($(2p-1)!!$), and place the $n-p$ occupied days among the $d$ available ($(d)_{n-p}$)."
+    "content": "The **k=3 birthday count** $\\mathrm{birthdayCount3}\\,n\\,d$ is the number of ways to seat $n$ labelled people on $d$ days with **at most two per day** — the seatings that avoid a triple coincidence. The parent chain computed it case by case: $d$, $d^2$, $d^3-d$, $d^4-4d^2+3d$ for $n=1,2,3,4$. This entry proves the **single formula behind all of them**:\n$$\\mathrm{birthdayCount3}\\,n\\,d = \\sum_{p=0}^{\\lfloor n/2\\rfloor} \\binom{n}{2p}\\,(2p-1)!!\\,(d)_{n-p},$$\nwhere $(2p-1)!! = 1\\cdot 3\\cdots(2p-1)$ counts the perfect matchings on $2p$ points and $(d)_{n-p}=d(d-1)\\cdots(d-n+p+1)$ is the falling factorial. The index $p$ is the number of **doubly-occupied days**: choose which $2p$ people are paired ($\\binom{n}{2p}$), match them into $p$ pairs ($(2p-1)!!$), and place the $n-p$ occupied days among the $d$ available ($(d)_{n-p}$).",
+    "mathContext": "$\\mathrm{birthdayCount3}\\,n\\,d = \\sum_{p=0}^{\\lfloor n/2\\rfloor} \\binom{n}{2p}\\,(2p-1)!!\\,(d)_{n-p}$, with $(2p-1)!!$ the perfect-matching count and $(d)_{n-p}$ the falling factorial.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Double factorial",
+      "Perfect matchings",
+      "Birthday problem",
+      "Falling factorial"
+    ],
+    "prerequisites": [
+      "Binomial coefficients",
+      "Falling factorial",
+      "Combinatorial counting"
+    ]
   },
   {
     "id": "ann-egf",
     "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
-    "range": { "startLine": 44, "endLine": 51 },
+    "range": {
+      "startLine": 44,
+      "endLine": 51
+    },
     "type": "concept",
     "title": "The Generating Function Behind the Recurrence",
-    "content": "The slot recurrence $R\\,0\\,e\\,s=1$, $R\\,(n{+}1)\\,e\\,s = e\\,R\\,n\\,(e{-}1)\\,(s{+}1) + s\\,R\\,n\\,e\\,(s{-}1)$ tracks the number of **empty** ($e$) and **singly-occupied** ($s$) days as people are seated one at a time, with $\\mathrm{birthdayCount3}\\,n\\,d = R\\,n\\,d\\,0$. Conceptually $R\\,n\\,e\\,s = n!\\,[x^n]\\,(1+x+\\tfrac{x^2}{2})^{e}(1+x)^{s}$: an empty day contributes the factor $1+x+\\tfrac{x^2}{2}$ (zero, one, or two people) and a single day the factor $1+x$ (zero or one more). Every identity in this file is the combinatorial shadow of manipulating that product — but the proof stays elementary and never formalises power series."
+    "content": "The slot recurrence $R\\,0\\,e\\,s=1$, $R\\,(n{+}1)\\,e\\,s = e\\,R\\,n\\,(e{-}1)\\,(s{+}1) + s\\,R\\,n\\,e\\,(s{-}1)$ tracks the number of **empty** ($e$) and **singly-occupied** ($s$) days as people are seated one at a time, with $\\mathrm{birthdayCount3}\\,n\\,d = R\\,n\\,d\\,0$. Conceptually $R\\,n\\,e\\,s = n!\\,[x^n]\\,(1+x+\\tfrac{x^2}{2})^{e}(1+x)^{s}$: an empty day contributes the factor $1+x+\\tfrac{x^2}{2}$ (zero, one, or two people) and a single day the factor $1+x$ (zero or one more). Every identity in this file is the combinatorial shadow of manipulating that product — but the proof stays elementary and never formalises power series.",
+    "mathContext": "$R\\,n\\,e\\,s = n!\\,[x^n]\\,(1+x+\\tfrac{x^2}{2})^{e}(1+x)^{s}$; empty days carry $1+x+\\tfrac{x^2}{2}$, single days $1+x$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Generating functions",
+      "Recurrence relations",
+      "Slot recurrence"
+    ],
+    "prerequisites": [
+      "Exponential generating functions",
+      "Coefficient extraction"
+    ]
   },
   {
     "id": "ann-ladder",
     "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
-    "range": { "startLine": 58, "endLine": 114 },
+    "range": {
+      "startLine": 58,
+      "endLine": 114
+    },
     "type": "key-step",
     "title": "The Single-Day Ladder Identity",
-    "content": "**`R_peel_single`:** $R\\,n\\,e\\,(s{+}1) = R\\,n\\,e\\,s + n\\cdot R\\,(n{-}1)\\,e\\,s$. Adding one already-occupied day multiplies the generating function by the single-day factor $(1+x)$, and extracting the $x^n$ coefficient of $(1+x)\\cdot g$ produces exactly $g$ plus $n$ times the shifted coefficient. This is the one lemma that lets us extract a *two-parameter* recurrence from the one-step slot recurrence without dragging the $(e,s)$ state through the induction. It is proved by strong induction on $n$: the step expands $R\\,(m{+}2)\\,e\\,(s{+}1)$ by the recurrence, applies the identity at level $m{+}1$, and closes the residual algebra with a `linear_combination` over $\\mathbb{Z}$ (Nat subtraction is kept honest by casing on $s=0$)."
+    "content": "**`R_peel_single`:** $R\\,n\\,e\\,(s{+}1) = R\\,n\\,e\\,s + n\\cdot R\\,(n{-}1)\\,e\\,s$. Adding one already-occupied day multiplies the generating function by the single-day factor $(1+x)$, and extracting the $x^n$ coefficient of $(1+x)\\cdot g$ produces exactly $g$ plus $n$ times the shifted coefficient. This is the one lemma that lets us extract a *two-parameter* recurrence from the one-step slot recurrence without dragging the $(e,s)$ state through the induction. It is proved by strong induction on $n$: the step expands $R\\,(m{+}2)\\,e\\,(s{+}1)$ by the recurrence, applies the identity at level $m{+}1$, and closes the residual algebra with a `linear_combination` over $\\mathbb{Z}$ (Nat subtraction is kept honest by casing on $s=0$).",
+    "mathContext": "$R\\,n\\,e\\,(s{+}1) = R\\,n\\,e\\,s + n\\cdot R\\,(n{-}1)\\,e\\,s$ — the $x^n$-coefficient of $(1+x)\\cdot g$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "Coefficient of (1+x)g",
+      "Two-parameter recurrence extraction"
+    ],
+    "prerequisites": [
+      "Strong induction",
+      "Truncated natural subtraction"
+    ]
   },
   {
     "id": "ann-rec",
     "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
-    "range": { "startLine": 116, "endLine": 125 },
+    "range": {
+      "startLine": 116,
+      "endLine": 125
+    },
     "type": "key-step",
     "title": "The Two-Term Recurrence",
-    "content": "**`birthdayCount3_rec`:** $\\mathrm{birthdayCount3}\\,(n{+}1)\\,d = d\\big(\\mathrm{birthdayCount3}\\,n\\,(d{-}1) + n\\cdot\\mathrm{birthdayCount3}\\,(n{-}1)\\,(d{-}1)\\big)$. Person $n{+}1$ takes one of the $d$ days; the remaining $n$ people are then seated on a board where that day is already **singly** occupied. Applying `R_peel_single` at $s=0$ splits this into 'the day stays a pair-free single' (the $\\mathrm{birthdayCount3}\\,n\\,(d{-}1)$ term) versus 'someone joins person $n{+}1$' (the $n\\cdot\\mathrm{birthdayCount3}\\,(n{-}1)\\,(d{-}1)$ term). This is the recurrence the induction runs on."
+    "content": "**`birthdayCount3_rec`:** $\\mathrm{birthdayCount3}\\,(n{+}1)\\,d = d\\big(\\mathrm{birthdayCount3}\\,n\\,(d{-}1) + n\\cdot\\mathrm{birthdayCount3}\\,(n{-}1)\\,(d{-}1)\\big)$. Person $n{+}1$ takes one of the $d$ days; the remaining $n$ people are then seated on a board where that day is already **singly** occupied. Applying `R_peel_single` at $s=0$ splits this into 'the day stays a pair-free single' (the $\\mathrm{birthdayCount3}\\,n\\,(d{-}1)$ term) versus 'someone joins person $n{+}1$' (the $n\\cdot\\mathrm{birthdayCount3}\\,(n{-}1)\\,(d{-}1)$ term). This is the recurrence the induction runs on.",
+    "mathContext": "$\\mathrm{birthdayCount3}\\,(n{+}1)\\,d = d\\big(\\mathrm{birthdayCount3}\\,n\\,(d{-}1) + n\\cdot\\mathrm{birthdayCount3}\\,(n{-}1)\\,(d{-}1)\\big)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "R_peel_single at s=0",
+      "Seating one person at a time",
+      "Pair-free single vs joined pair"
+    ],
+    "prerequisites": [
+      "Recurrence relations",
+      "Combinatorial decomposition"
+    ]
   },
   {
     "id": "ann-absorb",
     "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
-    "range": { "startLine": 127, "endLine": 186 },
+    "range": {
+      "startLine": 127,
+      "endLine": 186
+    },
     "type": "technique",
     "title": "Pascal + Absorption: the Coefficient Engine",
-    "content": "The matching numbers satisfy $M(p{+}1) = (2p{+}1)\\,M(p)$, and the closed form is $F\\,n\\,d = \\sum_p \\binom{n}{2p}\\,M(p)\\,(d)_{n-p}$. Checking that $F$ obeys the recurrence reduces, coefficient by coefficient, to two standard facts: **Pascal's rule** $\\binom{n+2}{2q+2} = \\binom{n+1}{2q+1}+\\binom{n+1}{2q+2}$ and the **absorption identity** $(2q{+}1)\\binom{n+1}{2q+1} = (n{+}1)\\binom{n}{2q}$ (`Nat.succ_mul_choose_eq`). Together (`choose_absorb`, then `choose_absorb_M` after factoring out $M(q)$) they give $\\binom{n+2}{2(q+1)}M(q{+}1) = \\binom{n+1}{2(q+1)}M(q{+}1) + (n{+}1)\\binom{n}{2q}M(q)$ — the entire arithmetic content of the induction. `descFactorial_pull` ($(d{+}1)(d)_k = (d{+}1)_{k+1}$) threads the recurrence's extra day into the shared falling-factorial term."
+    "content": "The matching numbers satisfy $M(p{+}1) = (2p{+}1)\\,M(p)$, and the closed form is $F\\,n\\,d = \\sum_p \\binom{n}{2p}\\,M(p)\\,(d)_{n-p}$. Checking that $F$ obeys the recurrence reduces, coefficient by coefficient, to two standard facts: **Pascal's rule** $\\binom{n+2}{2q+2} = \\binom{n+1}{2q+1}+\\binom{n+1}{2q+2}$ and the **absorption identity** $(2q{+}1)\\binom{n+1}{2q+1} = (n{+}1)\\binom{n}{2q}$ (`Nat.succ_mul_choose_eq`). Together (`choose_absorb`, then `choose_absorb_M` after factoring out $M(q)$) they give $\\binom{n+2}{2(q+1)}M(q{+}1) = \\binom{n+1}{2(q+1)}M(q{+}1) + (n{+}1)\\binom{n}{2q}M(q)$ — the entire arithmetic content of the induction. `descFactorial_pull` ($(d{+}1)(d)_k = (d{+}1)_{k+1}$) threads the recurrence's extra day into the shared falling-factorial term.",
+    "mathContext": "Pascal $\\binom{n+2}{2q+2}=\\binom{n+1}{2q+1}+\\binom{n+1}{2q+2}$ and absorption $(2q{+}1)\\binom{n+1}{2q+1}=(n{+}1)\\binom{n}{2q}$; matching numbers $M(p{+}1)=(2p{+}1)M(p)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.succ_mul_choose_eq",
+      "Double-factorial recurrence",
+      "descFactorial_pull",
+      "Falling factorial"
+    ],
+    "prerequisites": [
+      "Pascal's rule",
+      "Binomial absorption identities"
+    ]
   },
   {
     "id": "ann-frec",
     "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
-    "range": { "startLine": 188, "endLine": 250 },
+    "range": {
+      "startLine": 188,
+      "endLine": 250
+    },
     "type": "key-step",
     "title": "The Closed Form Satisfies the Recurrence",
-    "content": "**`F_rec`:** $F\\,(n{+}2)\\,(d{+}1) = (d{+}1)\\big(F\\,(n{+}1)\\,d + (n{+}1)\\,F\\,n\\,d\\big)$. Each of the three pieces is rewritten as a sum over $p$ of $(\\text{coefficient})\\cdot(d{+}1)_{n+2-p}$ — the same falling-factorial basis — using `descFactorial_pull` to absorb the $(d{+}1)$ prefactor and range extension to align the summation bounds. The $F\\,n$ contribution is reindexed $p\\mapsto p{+}1$ so that its power $(d+1)_{n+1-p}$ lands on the same basis element as the others. Matching the coefficient of each basis element is precisely `choose_absorb_M`, with the $p=0$ term handled separately."
+    "content": "**`F_rec`:** $F\\,(n{+}2)\\,(d{+}1) = (d{+}1)\\big(F\\,(n{+}1)\\,d + (n{+}1)\\,F\\,n\\,d\\big)$. Each of the three pieces is rewritten as a sum over $p$ of $(\\text{coefficient})\\cdot(d{+}1)_{n+2-p}$ — the same falling-factorial basis — using `descFactorial_pull` to absorb the $(d{+}1)$ prefactor and range extension to align the summation bounds. The $F\\,n$ contribution is reindexed $p\\mapsto p{+}1$ so that its power $(d+1)_{n+1-p}$ lands on the same basis element as the others. Matching the coefficient of each basis element is precisely `choose_absorb_M`, with the $p=0$ term handled separately.",
+    "mathContext": "$F\\,(n{+}2)\\,(d{+}1) = (d{+}1)\\big(F\\,(n{+}1)\\,d + (n{+}1)\\,F\\,n\\,d\\big)$, matched coefficient-by-coefficient on the falling-factorial basis $(d+1)_{n+2-p}$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Falling-factorial basis",
+      "Sum reindexing p↦p+1",
+      "choose_absorb_M",
+      "Finset.sum manipulation"
+    ],
+    "prerequisites": [
+      "Finite sums",
+      "Reindexing a summation"
+    ]
   },
   {
     "id": "ann-main",
     "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
-    "range": { "startLine": 252, "endLine": 290 },
+    "range": {
+      "startLine": 252,
+      "endLine": 290
+    },
     "type": "key-step",
     "title": "The Main Theorem by Strong Induction",
-    "content": "**`birthdayCount3_closed`:** $\\mathrm{birthdayCount3}\\,n\\,d = F\\,n\\,d$ for all $n,d$. Strong induction on $n$: the base cases $n=0,1$ are direct, and the $d=0$ case is a shared vanishing (both sides are $0$ for $n\\ge 1$, the falling factorial and the choose factor each killing their terms). For $n=m{+}2$, $d=d'{+}1$, the two-term recurrence `birthdayCount3_rec` plus the induction hypothesis at levels $m{+}1$ and $m$ turn the goal into exactly `F_rec`. The whole development is over $\\mathbb{N}$, sorry-free and axiom-free (no `native_decide`), so it depends only on `propext`, `Classical.choice`, `Quot.sound`."
+    "content": "**`birthdayCount3_closed`:** $\\mathrm{birthdayCount3}\\,n\\,d = F\\,n\\,d$ for all $n,d$. Strong induction on $n$: the base cases $n=0,1$ are direct, and the $d=0$ case is a shared vanishing (both sides are $0$ for $n\\ge 1$, the falling factorial and the choose factor each killing their terms). For $n=m{+}2$, $d=d'{+}1$, the two-term recurrence `birthdayCount3_rec` plus the induction hypothesis at levels $m{+}1$ and $m$ turn the goal into exactly `F_rec`. The whole development is over $\\mathbb{N}$, sorry-free and axiom-free (no `native_decide`), so it depends only on `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathContext": "$\\mathrm{birthdayCount3}\\,n\\,d = F\\,n\\,d$ for all $n,d$; strong induction reducing $\\mathrm{birthdayCount3\\_rec}$ + IH to $F\\_rec$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Shared vanishing at d=0",
+      "F_rec",
+      "birthdayCount3_rec",
+      "Axiom-free verification"
+    ],
+    "prerequisites": [
+      "Strong induction",
+      "Base-case analysis"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01` (quality 70).

## Gap
The entry has a rich meta.json (overview with 5 keyInsights, 6 sections, conclusion, 5 cross-refs) and 7 annotations with substantial `content`/`title` covering the whole Lean file (lines 1-290) — but **every annotation was missing `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`**, the structured fields the gallery renders alongside each annotation.

## Change
Added those four fields to all 7 annotations:
- **mathContext** — the LaTeX formula for each lemma/identity (the closed-form sum, the slot-recurrence EGF, `R_peel_single`, the two-term recurrence, Pascal+absorption, `F_rec`, the main theorem)
- **significance** — `critical` for the load-bearing lemmas (ladder, two-term recurrence, absorption engine, main theorem), `high`/`supporting` for the setup
- **relatedConcepts** and **prerequisites** — 2-4 each

Existing `content`/`title` are unchanged and byte-identical (the file was re-serialized so inline `range` objects reflow to multi-line, but no prose was altered — reaching the role's target of ≥5 annotations carrying mathContext/significance/relatedConcepts).

## Integrity
No meta.json / `status` / `badge` / `axiomCount` changes — remains `verified` / `original` / 0-axiom. JSON validated.