### PR TITLE
research(erdos-1138-oq-03-oq-01): unconditional prime-gap sublinearity from Baker–Harman–Pintz [VERIFIED build, 0 sorry / 1 inherited axiom]

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -1,0 +1,85 @@
+/-
+# Erdős #1138 (OQ-03 · OQ-01): Unconditional sublinearity of prime gaps from Baker–Harman–Pintz
+
+The parent entry `Erdos1138OQ03` establishes a chain of prime-gap results, ending in the
+*conditional* statement `cramer_implies_gap_sublinear` (Cramér's heuristic bound
+`C·(log x)² = o(x)`), together with the *unconditional* Baker–Harman–Pintz bound recorded
+as `axiom baker_harman_pintz`:
+
+    (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ (0.525 : ℝ)   for x ≥ 25.
+
+This follow-up derives the **unconditional** twin of the conditional sublinearity result:
+directly from the BHP bound, the normalised maximal prime gap `maxPrimeGap x / x` tends to `0`.
+
+The argument is a real-analysis squeeze:
+
+  0 ≤ maxPrimeGap x / x ≤ x^0.525 / x = x^(-0.475) → 0.
+
+The upper envelope `x^(-0.475) → 0` is `Real.tendsto_rpow_neg_atTop`, moved from `ℝ` to the
+`ℕ`-indexed sequence by `tendsto_natCast_atTop_atTop`. The whole thing is closed by
+`squeeze_zero'`, valid eventually (for `x ≥ 25`).
+
+No axioms are added beyond the parent's `baker_harman_pintz`; the entry is `axiomatized`
+(it depends on the BHP bound, which is quoted rather than proved).
+-/
+
+import Mathlib
+import Proofs.Erdos1138OQ03
+
+namespace Erdos1138OQ03
+
+open Filter Topology
+
+/-- For `x ≥ 25`, the normalised maximal prime gap is bounded by `x^(-0.475)`.
+
+    This is the pointwise upper envelope: dividing the BHP bound
+    `maxPrimeGap x ≤ x^0.525` by `x` and using `x^0.525 / x = x^(0.525 - 1) = x^(-0.475)`. -/
+theorem gap_div_le_rpow_neg (x : ℕ) (hx : 25 ≤ x) :
+    (maxPrimeGap x : ℝ) / x ≤ (x : ℝ) ^ (-(0.475 : ℝ)) := by
+  have hx_pos : (0 : ℝ) < (x : ℝ) := by
+    have : (0 : ℕ) < x := lt_of_lt_of_le (by norm_num) hx
+    exact_mod_cast this
+  -- x^0.525 / x = x^0.525 / x^1 = x^(0.525 - 1) = x^(-0.475)
+  have hdiv : (x : ℝ) ^ (0.525 : ℝ) / x = (x : ℝ) ^ (-(0.475 : ℝ)) := by
+    rw [← Real.rpow_one (x : ℝ), ← Real.rpow_sub hx_pos]
+    congr 1
+    norm_num
+  calc (maxPrimeGap x : ℝ) / x
+      ≤ (x : ℝ) ^ (0.525 : ℝ) / x := by
+        gcongr
+        exact baker_harman_pintz x hx
+    _ = (x : ℝ) ^ (-(0.475 : ℝ)) := hdiv
+
+/-- **Unconditional sublinearity of prime gaps (BHP).**
+
+    From the Baker–Harman–Pintz bound `maxPrimeGap x ≤ x^0.525`, the normalised maximal
+    prime gap `maxPrimeGap x / x` tends to `0` as `x → ∞`. This is the unconditional
+    counterpart of the conditional `cramer_implies_gap_sublinear`. -/
+theorem bhp_implies_gap_littleo :
+    Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / x) atTop (𝓝 0) := by
+  -- Upper envelope: g(x) = x^(-0.475) tends to 0 (compose ℝ-limit with ℕ-cast).
+  have h_env : Tendsto (fun x : ℕ => (x : ℝ) ^ (-(0.475 : ℝ))) atTop (𝓝 0) :=
+    (Real.tendsto_rpow_neg_atTop (by norm_num : (0 : ℝ) < 0.475)).comp
+      tendsto_natCast_atTop_atTop
+  -- Lower bound: 0 ≤ maxPrimeGap x / x everywhere.
+  have h_lo : ∀ x : ℕ, 0 ≤ (maxPrimeGap x : ℝ) / x := fun x =>
+    div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+  -- Upper bound: holds eventually (for x ≥ 25).
+  have h_hi : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) / x ≤ (x : ℝ) ^ (-(0.475 : ℝ)) :=
+    (eventually_ge_atTop 25).mono fun x hx => gap_div_le_rpow_neg x hx
+  -- Squeeze between the constant 0 and the envelope.
+  exact squeeze_zero' (Eventually.of_forall h_lo) h_hi h_env
+
+/-- ε-form of unconditional sublinearity: for every `ε > 0`, eventually
+    `maxPrimeGap x ≤ ε · x`. -/
+theorem bhp_gap_eventually_le_eps (ε : ℝ) (hε : 0 < ε) :
+    ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ ε * x := by
+  -- From the limit, `maxPrimeGap x / x < ε` eventually; clear the denominator.
+  have hev : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) / x < ε :=
+    bhp_implies_gap_littleo.eventually_lt_const hε
+  filter_upwards [hev, eventually_ge_atTop 1] with x hxlt hx1
+  have hx_pos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast (lt_of_lt_of_le Nat.zero_lt_one hx1)
+  rw [div_lt_iff₀ hx_pos] at hxlt
+  exact le_of_lt hxlt
+
+end Erdos1138OQ03

--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -41,9 +41,8 @@ theorem gap_div_le_rpow_neg (x : ℕ) (hx : 25 ≤ x) :
     exact_mod_cast this
   -- x^0.525 / x = x^0.525 / x^1 = x^(0.525 - 1) = x^(-0.475)
   have hdiv : (x : ℝ) ^ (0.525 : ℝ) / x = (x : ℝ) ^ (-(0.475 : ℝ)) := by
-    rw [← Real.rpow_one (x : ℝ), ← Real.rpow_sub hx_pos]
-    congr 1
-    norm_num
+    have h1 : (-(0.475 : ℝ)) = (0.525 : ℝ) - 1 := by norm_num
+    rw [h1, Real.rpow_sub hx_pos, Real.rpow_one]
   calc (maxPrimeGap x : ℝ) / x
       ≤ (x : ℝ) ^ (0.525 : ℝ) / x := by
         gcongr
@@ -59,7 +58,7 @@ theorem bhp_implies_gap_littleo :
     Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / x) atTop (𝓝 0) := by
   -- Upper envelope: g(x) = x^(-0.475) tends to 0 (compose ℝ-limit with ℕ-cast).
   have h_env : Tendsto (fun x : ℕ => (x : ℝ) ^ (-(0.475 : ℝ))) atTop (𝓝 0) :=
-    (Real.tendsto_rpow_neg_atTop (by norm_num : (0 : ℝ) < 0.475)).comp
+    (tendsto_rpow_neg_atTop (by norm_num : (0 : ℝ) < 0.475)).comp
       tendsto_natCast_atTop_atTop
   -- Lower bound: 0 ≤ maxPrimeGap x / x everywhere.
   have h_lo : ∀ x : ℕ, 0 ≤ (maxPrimeGap x : ℝ) / x := fun x =>
@@ -76,7 +75,7 @@ theorem bhp_gap_eventually_le_eps (ε : ℝ) (hε : 0 < ε) :
     ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ ε * x := by
   -- From the limit, `maxPrimeGap x / x < ε` eventually; clear the denominator.
   have hev : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) / x < ε :=
-    bhp_implies_gap_littleo.eventually_lt_const hε
+    bhp_implies_gap_littleo.eventually (eventually_lt_nhds hε)
   filter_upwards [hev, eventually_ge_atTop 1] with x hxlt hx1
   have hx_pos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast (lt_of_lt_of_le Nat.zero_lt_one hx1)
   rw [div_lt_iff₀ hx_pos] at hxlt

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "erdos-1138-oq-03-oq-01",
+  "title": "Unconditional Sublinearity of Prime Gaps from Baker-Harman-Pintz",
+  "slug": "erdos-1138-oq-03-oq-01",
+  "description": "Follow-up to erdos-1138-oq-03. From the Baker-Harman-Pintz axiom (maxPrimeGap x <= x^0.525 for x >= 25) derives the unconditional limit maxPrimeGap x / x -> 0, the unconditional twin of the parent's conditional Cramer sublinearity. Proved by a real-analysis squeeze against the envelope x^(-0.475) -> 0. Also gives the epsilon-form: eventually maxPrimeGap x <= epsilon * x.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Prime_gap",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1138OQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "prime-gaps",
+      "baker-harman-pintz",
+      "analytic-number-theory",
+      "asymptotics",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "tendsto_rpow_neg_atTop",
+        "description": "For y > 0, x^(-y) -> 0 as x -> infinity (real power envelope)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics"
+      },
+      {
+        "theorem": "tendsto_natCast_atTop_atTop",
+        "description": "The natural-number cast into an archimedean ordered field tends to infinity",
+        "module": "Mathlib.Order.Filter.AtTopBot.Archimedean"
+      },
+      {
+        "theorem": "squeeze_zero'",
+        "description": "If 0 <= f eventually, f <= g eventually, and g -> 0, then f -> 0",
+        "module": "Mathlib.Order.Filter.Basic"
+      },
+      {
+        "theorem": "Real.rpow_sub",
+        "description": "x^(y - z) = x^y / x^z for x > 0, used to rewrite x^0.525 / x as x^(-0.475)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "originalContributions": [
+      "gap_div_le_rpow_neg: pointwise upper envelope maxPrimeGap x / x <= x^(-0.475) for x >= 25, via BHP divided by x and the identity x^0.525 / x = x^(0.525 - 1)",
+      "bhp_implies_gap_littleo: unconditional maxPrimeGap x / x -> 0, squeezing between 0 and the envelope x^(-0.475) -> 0 (unconditional twin of cramer_implies_gap_sublinear)",
+      "bhp_gap_eventually_le_eps: epsilon-form, for every epsilon > 0 eventually maxPrimeGap x <= epsilon * x"
+    ],
+    "dateAdded": "2026-07-05",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 1,
+    "lineCount": 84,
+    "assumptions": "1 axiom, inherited from the parent Erdos1138OQ03: baker_harman_pintz (maxPrimeGap x <= x^0.525 for x >= 25). No axiom is declared in this file (leanFile.axiomCount = 0); the assumption is imported. #print axioms confirms the results depend only on {propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}. No sorries, no native_decide.",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry erdos-1138-oq-03 formalizes prime-gap bounds around the maximal gap function $G(x) = \\max\\{q - p : p, q \\text{ consecutive primes}, q \\leq x\\}$. It proves the *conditional* Cramer-flavored sublinearity $C(\\log x)^2 = o(x)$ and records the deep *unconditional* Baker-Harman-Pintz bound $G(x) \\leq x^{0.525}$ (2001) as `axiom baker_harman_pintz`.\n\nCramer's probabilistic model (1936) predicts $G(x) \\sim (\\log x)^2$; the parent's `cramer_implies_gap_sublinear` records the trivial consequence that this heuristic order is $o(x)$. That statement is conditional in spirit — it packages the size of the *conjectured* gap. The Baker-Harman-Pintz theorem instead gives an *unconditional* power-saving bound $G(x) \\leq x^{0.525}$, the culmination of a line from Hoheisel (1930) through Ingham, Huxley, Heath-Brown, and finally Baker-Harman-Pintz.\n\nThis follow-up asks: what does the unconditional BHP bound say about the *normalised* maximal gap $G(x)/x$? Since $0.525 < 1$, dividing gives $G(x)/x \\leq x^{-0.475} \\to 0$, so prime gaps are unconditionally sublinear: $G(x) = o(x)$. This is the honest unconditional counterpart of the parent's conditional lemma, and it is what the entry formalizes.",
+    "problemStatement": "**The Problem**\n\nFrom the parent's `axiom baker_harman_pintz` — $G(x) \\leq x^{0.525}$ for $x \\geq 25$ — derive the unconditional normalised limit\n\n$$\\lim_{x \\to \\infty} \\frac{G(x)}{x} = 0,$$\n\ni.e. `Tendsto (fun x => (maxPrimeGap x : \\mathbb{R}) / x) atTop (nhds 0)`, together with its $\\varepsilon$-form: for every $\\varepsilon > 0$, eventually $G(x) \\leq \\varepsilon x$.\n\n**Resolution**\n\nProved unconditionally-modulo-BHP by a real-analysis squeeze. No new axiom is introduced; only the inherited BHP bound is used.",
+    "text": "From the Baker-Harman-Pintz axiom maxPrimeGap x <= x^0.525, the normalised maximal prime gap maxPrimeGap x / x tends to 0. Proved by squeezing between the constant 0 and the envelope x^(-0.475), which tends to 0 by tendsto_rpow_neg_atTop.",
+    "proofStrategy": "**Strategy: divide the BHP bound and squeeze**\n\n**Step 1 (upper envelope).** For $x \\geq 25$ we have $x > 0$, so dividing the BHP bound by $x$:\n$$\\frac{G(x)}{x} \\leq \\frac{x^{0.525}}{x} = x^{0.525 - 1} = x^{-0.475}.$$\nThe algebraic identity is `Real.rpow_sub` (rewriting $-0.475$ as $0.525 - 1$) plus `Real.rpow_one`. The inequality direction under division is handled by `gcongr`.\n\n**Step 2 (envelope tends to 0).** $x^{-0.475} \\to 0$ is `tendsto_rpow_neg_atTop` (needs $0 < 0.475$), composed with `tendsto_natCast_atTop_atTop` to pass from the $\\mathbb{N}$-indexed sequence to the real power.\n\n**Step 3 (lower bound).** $0 \\leq G(x)/x$ trivially, since both numerator and denominator are nonnegative casts.\n\n**Step 4 (squeeze).** `squeeze_zero'` between the constant $0$ (eventually, in fact always) and the envelope $x^{-0.475}$ (eventually, for $x \\geq 25$) yields $G(x)/x \\to 0$.\n\n**Epsilon-form.** From the limit, `Tendsto.eventually (eventually_lt_nhds hε)` gives $G(x)/x < \\varepsilon$ eventually; clearing the denominator with `div_lt_iff₀` for $x \\geq 1$ gives $G(x) \\leq \\varepsilon x$.",
+    "keyInsights": [
+      "**Power saving is the whole point**: because BHP gives an exponent $0.525 < 1$, one division by $x$ already produces a *negative* power $x^{-0.475}$, and negative real powers vanish at infinity. No finer analysis is needed.",
+      "**rpow_sub, not rpow_one rewriting**: writing $x^{0.525}/x = x^{-0.475}$ must avoid rewriting the numerator base; `Real.rpow_sub hx_pos` on $x^{0.525 - 1}$ is the clean route (rewriting $x$ as $x^1$ via `rpow_one` hits the wrong occurrence).",
+      "**Cast bridge**: the maximal gap is $\\mathbb{N}$-indexed but the envelope lemma is stated over $\\mathbb{R}$; `.comp tendsto_natCast_atTop_atTop` bridges the two filters.",
+      "**Unconditional vs conditional**: this is the honest unconditional counterpart of the parent's `cramer_implies_gap_sublinear` — it depends only on the proved-elsewhere BHP bound, not on Cramer's conjecture."
+    ],
+    "prerequisites": [
+      "Filter.Tendsto and the neighbourhood filter nhds",
+      "Real.rpow and its arithmetic (rpow_sub, rpow_one)",
+      "Asymptotics of real powers (tendsto_rpow_neg_atTop)",
+      "The squeeze theorem squeeze_zero' and eventually filters at atTop"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "summary": "Module docstring explaining the follow-up: derive unconditional sublinearity of the normalised maximal prime gap from the parent's Baker-Harman-Pintz axiom. Imports Mathlib and the parent Proofs.Erdos1138OQ03, reopens namespace Erdos1138OQ03, opens Filter and Topology.",
+      "startLine": 1,
+      "endLine": 35,
+      "mathContext": "Continues in namespace Erdos1138OQ03 so that maxPrimeGap and baker_harman_pintz are in scope."
+    },
+    {
+      "id": "envelope",
+      "title": "Pointwise Upper Envelope",
+      "summary": "`gap_div_le_rpow_neg`: for $x \\geq 25$, $G(x)/x \\leq x^{-0.475}$. Divides the BHP bound by $x$ and uses the identity $x^{0.525}/x = x^{0.525 - 1} = x^{-0.475}$ via `Real.rpow_sub` and `Real.rpow_one`; `gcongr` handles the division monotonicity.",
+      "startLine": 37,
+      "endLine": 55,
+      "mathContext": "$G(x)/x \\leq x^{0.525}/x = x^{-0.475}$ for $x \\geq 25 > 0$."
+    },
+    {
+      "id": "limit",
+      "title": "Unconditional Sublinearity Limit",
+      "summary": "`bhp_implies_gap_littleo`: $G(x)/x \\to 0$. Squeezes with `squeeze_zero'` between the constant $0$ (always) and the envelope $x^{-0.475}$ (eventually, for $x \\geq 25$), where the envelope tends to $0$ by `tendsto_rpow_neg_atTop` composed with `tendsto_natCast_atTop_atTop`.",
+      "startLine": 57,
+      "endLine": 72,
+      "mathContext": "$0 \\leq G(x)/x \\leq x^{-0.475} \\to 0 \\Rightarrow G(x)/x \\to 0$."
+    },
+    {
+      "id": "eps-form",
+      "title": "Epsilon Form",
+      "summary": "`bhp_gap_eventually_le_eps`: for every $\\varepsilon > 0$, eventually $G(x) \\leq \\varepsilon x$. Derived from the limit via `Tendsto.eventually (eventually_lt_nhds hε)` and clearing the denominator with `div_lt_iff₀` for $x \\geq 1$.",
+      "startLine": 74,
+      "endLine": 84,
+      "mathContext": "$G(x)/x \\to 0 \\Rightarrow \\forall \\varepsilon > 0,\\ \\text{eventually } G(x) \\leq \\varepsilon x$."
+    }
+  ],
+  "conclusion": {
+    "summary": "From the single inherited Baker-Harman-Pintz axiom, this follow-up proves the unconditional sublinearity of the normalised maximal prime gap: $G(x)/x \\to 0$, together with its $\\varepsilon$-form. Three theorems, zero sorries, and no new axiom — the entry is axiomatized only through the imported BHP bound, confirmed by #print axioms.",
+    "implications": "**Unconditional counterpart**: the parent's `cramer_implies_gap_sublinear` packages the *conjectured* Cramer order $(\\log x)^2$; this entry instead extracts what is *provable* — the BHP power-saving bound already forces $G(x) = o(x)$ unconditionally. Recording both side by side clarifies which sublinearity is heuristic and which is theorem.\n\n**Envelope technique**: the proof is a template for turning any power-saving pointwise bound $f(x) \\leq x^{1 - \\delta}$ into a normalised limit $f(x)/x \\to 0$ via `tendsto_rpow_neg_atTop` and `squeeze_zero'`; the same three-line skeleton applies whenever the exponent is strictly below 1.",
+    "openQuestions": [
+      "Can the exponent be sharpened inside the formalization if a stronger unconditional gap bound (e.g. a future improvement below 0.525) is added as an axiom, reusing the same squeeze skeleton?",
+      "Can the epsilon-form be upgraded to an explicit-rate statement, e.g. an explicit N(epsilon) from the BHP exponent?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "Parent entry providing maxPrimeGap and the baker_harman_pintz axiom that this follow-up consumes",
+      "targetId": "erdos-1138-oq-03"
+    },
+    {
+      "relationship": "Grandparent Erdos 1138 prime gap formalization",
+      "targetId": "erdos-1138"
+    }
+  ],
+  "relatedProblems": [
+    {
+      "id": "erdos-1138-oq-03",
+      "relationship": "Parent entry; this derives the unconditional twin of its conditional cramer_implies_gap_sublinear"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos1138OQ03"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "Erdos1138OQ03",
+    "lineCount": 84,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1138OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "R. C. Baker, G. Harman, J. Pintz",
+      "title": "The difference between consecutive primes, II",
+      "year": "2001",
+      "venue": "Proc. London Math. Soc.",
+      "note": "Unconditional bound G(x) <= x^0.525, the axiom consumed here"
+    },
+    {
+      "authors": "H. Cramer",
+      "title": "On the order of magnitude of the difference between consecutive prime numbers",
+      "year": "1936",
+      "venue": "Acta Arithmetica",
+      "note": "Conjectured order G(x) ~ (log p)^2; motivates the parent's conditional sublinearity"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **erdos-1138-oq-03** (Erdős #1138, Prime Gap Bounds). From the parent's existing `axiom baker_harman_pintz` (`maxPrimeGap x ≤ x^0.525` for `x ≥ 25`), this derives the **unconditional** normalised limit

```
Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / x) atTop (𝓝 0)
```

i.e. prime gaps are unconditionally sublinear, `G(x) = o(x)`. This is the honest unconditional twin of the parent's *conditional* `cramer_implies_gap_sublinear`.

## What's proved (`proofs/Proofs/Erdos1138OQ03OQ01.lean`, 84 lines, 3 theorems)

- `gap_div_le_rpow_neg` — pointwise envelope `G(x)/x ≤ x^(-0.475)` for `x ≥ 25` (BHP ÷ x, using `x^0.525 / x = x^(0.525-1)` via `Real.rpow_sub`).
- `bhp_implies_gap_littleo` — `G(x)/x → 0`, by `squeeze_zero'` between `0` and the envelope `x^(-0.475) → 0` (`tendsto_rpow_neg_atTop ∘ tendsto_natCast_atTop_atTop`).
- `bhp_gap_eventually_le_eps` — ε-form: for every `ε > 0`, eventually `G(x) ≤ ε·x`.

## Verification

- Builds clean via `./proofs/scripts/docker-build.sh Proofs.Erdos1138OQ03OQ01` (Lean 4.26.0 / Mathlib).
- `#print axioms` on both main results: `{propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}` — **no sorries, no new axioms, no native_decide**.
- Status `axiomatized` / badge `axiom`: depends only on the inherited BHP bound. `leanFile.axiomCount = 0` (no axiom declared in this file); `meta.axiomCount = 1` (the inherited assumption).

## Files
- `proofs/Proofs/Erdos1138OQ03OQ01.lean` (new)
- `src/data/proofs/erdos-1138-oq-03-oq-01/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)