### PR TITLE
Repair BetaCentralBinomialAsymptotic v4.26 drift + recover 3 proofs from cleanup backups

### DIFF
--- a/proofs/Proofs/BetaCentralBinomialAsymptotic.lean
+++ b/proofs/Proofs/BetaCentralBinomialAsymptotic.lean
@@ -107,7 +107,7 @@ theorem centralBinom_isEquivalent :
   refine (hcb.trans hdiv).trans (Filter.EventuallyEq.isEquivalent ?_)
   filter_upwards [eventually_ge_atTop 1] with n hn
   have hm : (0 : ℝ) < (n : ℝ) := Nat.cast_pos.mpr (by omega)
-  simp only [Function.comp_apply]
+  simp only [Pi.div_apply, Pi.mul_apply, Function.comp_apply]
   rw [show ((2 * n : ℕ) : ℝ) = 2 * (n : ℝ) by push_cast; ring]
   exact stirling_ratio_identity hm (Real.exp_pos 1) n
 
@@ -131,7 +131,8 @@ theorem betaDiag_isEquivalent :
   have hR : (fun n : ℕ => (2 * (n : ℝ) + 1)⁻¹ * ((4 : ℝ) ^ n / Real.sqrt (π * n))⁻¹) =ᶠ[atTop]
       (fun n : ℕ => Real.sqrt (π * n) / ((2 * (n : ℝ) + 1) * 4 ^ n)) := by
     apply Filter.Eventually.of_forall; intro n
-    rw [inv_div]; ring
+    dsimp only
+    rw [inv_div, inv_mul_eq_div, div_div, mul_comm ((4 : ℝ) ^ n) (2 * (n : ℝ) + 1)]
   exact (hL.isEquivalent.trans hmul).trans hR.isEquivalent
 
 /-- The complex Euler Beta integral on the diagonal equals the real value

--- a/proofs/Proofs/BetaDiagEffectiveRate.lean
+++ b/proofs/Proofs/BetaDiagEffectiveRate.lean
@@ -1,0 +1,278 @@
+import Mathlib
+import Proofs.BetaCentralBinomialAsymptotic
+
+/-
+# An Effective Two-Sided Rate for the Diagonal Beta Value (OQ-01…-OQ-01)
+
+## The Open Question
+
+`BetaCentralBinomialAsymptotic.lean` proves the *asymptotic*
+
+  B(n+1, n+1) = betaDiag n  ~  √(πn) / ((2n+1)·4ⁿ)      (as n → ∞)
+
+as an `Asymptotics.IsEquivalent` statement (`betaDiag_isEquivalent`).  Its first
+listed open question asks to **upgrade the `~` to an explicit two-sided rate with
+effective constants**, using the fact — already in Mathlib — that
+`√π ≤ stirlingSeq n` for every `n ≠ 0`.
+
+## What This File Proves
+
+Write the *ratio* of the true value to the target as
+
+  ratioR n  :=  stirlingSeq n ² / (√π · stirlingSeq (2n)),
+
+so that (Part II) for every `n ≥ 1`
+
+  betaDiag n  =  √(πn) / ((2n+1)·4ⁿ)  ·  ratioR n.                 -- betaDiag_eq
+
+This makes the correction factor completely explicit.  Mathlib's *effective*
+Stirling bounds — `√π ≤ stirlingSeq n` (a genuine lower bound for all `n ≥ 1`)
+and antitonicity giving `stirlingSeq n ≤ stirlingSeq 1 = e/√2` — pin `ratioR` to
+an explicit interval (Part III):
+
+  √(2π)/e  ≤  ratioR n  ≤  e²/(2π)        for every n ≥ 1,          -- ratioR_ge / ratioR_le
+
+with `ratioR n → 1` (Part IV, `ratioR_tendsto_one`).  Feeding the interval into
+`betaDiag_eq` yields the requested **effective two-sided rate** (Part V):
+
+  (√(2π)/e) · √(πn)/((2n+1)·4ⁿ)  ≤  betaDiag n  ≤  (e²/(2π)) · √(πn)/((2n+1)·4ⁿ).
+
+Numerically the constants are `√(2π)/e ≈ 0.922` and `e²/(2π) ≈ 1.176`, and both
+hold for **all** `n ≥ 1` — an effective, if not asymptotically sharp, envelope.
+
+## Honest Scope
+
+These are **constant-factor** two-sided bounds, valid for all `n ≥ 1`.  The
+sharper `1 + O(1/n)` form with the optimal constant would require the Robbins
+refinement of Stirling's series, which Mathlib notes is *not yet formalised*
+(`Stirling.le_factorial_stirling` docstring).  The core exact identity
+`centralBinom n = stirlingSeq (2n) / stirlingSeq n ² · 4ⁿ/√n` (Part I) is proved
+here from Mathlib's `stirlingSeq` definition with 0 axioms.
+-/
+
+namespace BetaDiagEffectiveRate
+
+open Real Filter Asymptotics Stirling BetaDiagAsymptotic
+open scoped Topology Nat
+
+/-!
+## Part I: The exact Stirling identity for the central binomial coefficient
+
+`centralBinom n · √n · stirlingSeq n ² = stirlingSeq (2n) · 4ⁿ`, equivalently
+`centralBinom n = stirlingSeq (2n)/stirlingSeq n ² · 4ⁿ/√n`.  This is pure algebra
+from `stirlingSeq n = n!/(√(2n)·(n/e)ⁿ)`; the `4ⁿ` comes from
+`(2n/e)^{2n} = 4ⁿ·((n/e)ⁿ)²`.
+-/
+
+/-- **Exact central-binomial / Stirling identity.** -/
+theorem centralBinom_stirlingSeq (n : ℕ) (hn : n ≠ 0) :
+    (Nat.centralBinom n : ℝ) * Real.sqrt n * stirlingSeq n ^ 2
+      = stirlingSeq (2 * n) * 4 ^ n := by
+  have hn0 : (0 : ℝ) < (n : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero hn
+  have he : (0 : ℝ) < Real.exp 1 := Real.exp_pos 1
+  have hsn : (0 : ℝ) < Real.sqrt (n : ℝ) := Real.sqrt_pos.mpr hn0
+  -- √(2·(2n)) = 2·√n
+  have hA : Real.sqrt (2 * ((2 * n : ℕ) : ℝ)) = 2 * Real.sqrt (n : ℝ) := by
+    push_cast
+    rw [show (2 : ℝ) * (2 * (n : ℝ)) = 2 ^ 2 * (n : ℝ) by ring, Real.sqrt_mul (by positivity),
+        Real.sqrt_sq (by norm_num)]
+  -- (2n/e)^{2n} = 4ⁿ·((n/e)ⁿ)²
+  have hB : (((2 * n : ℕ) : ℝ) / Real.exp 1) ^ (2 * n)
+      = 4 ^ n * (((n : ℝ) / Real.exp 1) ^ n) ^ 2 := by
+    push_cast
+    have h2 : (2 : ℝ) ^ (2 * n) = 4 ^ n := by rw [pow_mul]; norm_num
+    rw [show (2 * (n : ℝ)) / Real.exp 1 = 2 * ((n : ℝ) / Real.exp 1) by rw [mul_div_assoc],
+        mul_pow, h2, ← pow_mul, Nat.mul_comm n 2]
+  -- centralBinom·(n!·n!) = (2n)!
+  have hfac : (Nat.centralBinom n : ℝ) * ((n ! : ℝ) * (n ! : ℝ)) = ((2 * n)! : ℝ) := by
+    have h : Nat.centralBinom n * (n ! * n !) = (2 * n)! := by
+      have hh := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+      rw [show 2 * n - n = n by omega] at hh
+      simpa [Nat.centralBinom, mul_assoc] using hh
+    exact_mod_cast h
+  -- explicit values of the two Stirling terms
+  have hval_n : stirlingSeq n
+      = (n ! : ℝ) / (Real.sqrt (2 * (n : ℝ)) * ((n : ℝ) / Real.exp 1) ^ n) := rfl
+  have hval_2n : stirlingSeq (2 * n)
+      = ((2 * n)! : ℝ) / (2 * Real.sqrt (n : ℝ) * (4 ^ n * (((n : ℝ) / Real.exp 1) ^ n) ^ 2)) := by
+    rw [stirlingSeq, hA, hB]
+  have hP : (0 : ℝ) < ((n : ℝ) / Real.exp 1) ^ n := pow_pos (div_pos hn0 he) n
+  have hP2 : (0 : ℝ) < (((n : ℝ) / Real.exp 1) ^ n) ^ 2 := pow_pos hP 2
+  -- rewrite both sides as single fractions
+  have hLHS : (Nat.centralBinom n : ℝ) * Real.sqrt n * stirlingSeq n ^ 2
+      = ((Nat.centralBinom n : ℝ) * Real.sqrt n * (n ! : ℝ) ^ 2)
+          / (2 * (n : ℝ) * (((n : ℝ) / Real.exp 1) ^ n) ^ 2) := by
+    rw [hval_n, div_pow, mul_pow, Real.sq_sqrt (by positivity)]
+    ring
+  have hRHS : stirlingSeq (2 * n) * 4 ^ n
+      = ((2 * n)! : ℝ) / (2 * Real.sqrt (n : ℝ) * (((n : ℝ) / Real.exp 1) ^ n) ^ 2) := by
+    rw [hval_2n]
+    have hPne : (((n : ℝ) / Real.exp 1) ^ n) ≠ 0 := hP.ne'
+    have hP2ne : (((n : ℝ) / Real.exp 1) ^ n) ^ 2 ≠ 0 := hP2.ne'
+    have h4ne : (4 : ℝ) ^ n ≠ 0 := by positivity
+    have hqne : Real.sqrt (n : ℝ) ≠ 0 := ne_of_gt hsn
+    field_simp
+  have hBne : (2 * (n : ℝ) * (((n : ℝ) / Real.exp 1) ^ n) ^ 2) ≠ 0 :=
+    mul_ne_zero (mul_ne_zero two_ne_zero hn0.ne') hP2.ne'
+  have hDne : (2 * Real.sqrt (n : ℝ) * (((n : ℝ) / Real.exp 1) ^ n) ^ 2) ≠ 0 :=
+    mul_ne_zero (mul_ne_zero two_ne_zero hsn.ne') hP2.ne'
+  rw [hLHS, hRHS, div_eq_div_iff hBne hDne]
+  -- goal: (c·√n·(n !)²)·(2√n·P²) = (2n)!·(2n·P²)
+  linear_combination
+    (2 * (((n : ℝ) / Real.exp 1) ^ n) ^ 2 * Real.sqrt (n : ℝ) ^ 2) * hfac
+    + (2 * (((n : ℝ) / Real.exp 1) ^ n) ^ 2 * ((2 * n)! : ℝ)) * Real.sq_sqrt hn0.le
+
+/-!
+## Part II: The explicit correction factor `ratioR`
+-/
+
+/-- The correction factor: the ratio of `betaDiag n` to its leading term. -/
+noncomputable def ratioR (n : ℕ) : ℝ :=
+  stirlingSeq n ^ 2 / (Real.sqrt π * stirlingSeq (2 * n))
+
+/-- **The exact factored form.**  `betaDiag n = √(πn)/((2n+1)·4ⁿ) · ratioR n`. -/
+theorem betaDiag_eq (n : ℕ) (hn : n ≠ 0) :
+    betaDiag n = Real.sqrt (π * n) / ((2 * (n : ℝ) + 1) * 4 ^ n) * ratioR n := by
+  have hn0 : (0 : ℝ) < (n : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero hn
+  have hπ : (0 : ℝ) < π := Real.pi_pos
+  have hsπ : (0 : ℝ) < Real.sqrt π := Real.sqrt_pos.mpr hπ
+  have hs2n : (0 : ℝ) < stirlingSeq (2 * n) :=
+    lt_of_lt_of_le hsπ (Stirling.sqrt_pi_le_stirlingSeq (by omega))
+  have hcb : (0 : ℝ) < (Nat.centralBinom n : ℝ) := by
+    have := Nat.centralBinom_pos n; exact_mod_cast this
+  have hsplit : Real.sqrt (π * (n : ℝ)) = Real.sqrt π * Real.sqrt (n : ℝ) :=
+    Real.sqrt_mul hπ.le _
+  have hcru := centralBinom_stirlingSeq n hn
+  have hD1ne : ((2 * (n : ℝ) + 1) * (Nat.centralBinom n : ℝ)) ≠ 0 :=
+    mul_ne_zero (by positivity) hcb.ne'
+  have hD2ne : ((2 * (n : ℝ) + 1) * 4 ^ n * (Real.sqrt π * stirlingSeq (2 * n))) ≠ 0 :=
+    mul_ne_zero (by positivity) (mul_ne_zero hsπ.ne' hs2n.ne')
+  rw [betaDiag, ratioR, hsplit, div_mul_div_comm, div_eq_div_iff hD1ne hD2ne]
+  -- goal: 1 * ((2n+1)·4ⁿ·(√π·S₂)) = (√π·√n·S²) · ((2n+1)·centralBinom)
+  linear_combination (-(Real.sqrt π * (2 * (n : ℝ) + 1))) * hcru
+
+/-!
+## Part III: Effective two-sided bounds on `ratioR`
+
+Mathlib gives `√π ≤ stirlingSeq n` (all `n ≥ 1`) and antitonicity gives the upper
+value `stirlingSeq n ≤ stirlingSeq 1 = e/√2`.  Both plug into `ratioR`.
+-/
+
+/-- Upper bound for `stirlingSeq`: it never exceeds its first value `e/√2`. -/
+theorem stirlingSeq_le (n : ℕ) (hn : n ≠ 0) : stirlingSeq n ≤ Real.exp 1 / Real.sqrt 2 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hn
+  have h := Stirling.stirlingSeq'_antitone (Nat.zero_le m)
+  simpa [Function.comp, Stirling.stirlingSeq_one] using h
+
+/-- Lower envelope: `√(2π)/e ≤ ratioR n` for all `n ≥ 1`. -/
+theorem ratioR_ge (n : ℕ) (hn : n ≠ 0) : Real.sqrt (2 * π) / Real.exp 1 ≤ ratioR n := by
+  have hπ : (0 : ℝ) < π := Real.pi_pos
+  have hsπ : (0 : ℝ) < Real.sqrt π := Real.sqrt_pos.mpr hπ
+  have he : (0 : ℝ) < Real.exp 1 := Real.exp_pos 1
+  have hlow_n : Real.sqrt π ≤ stirlingSeq n := Stirling.sqrt_pi_le_stirlingSeq hn
+  have hlow_2n : Real.sqrt π ≤ stirlingSeq (2 * n) :=
+    Stirling.sqrt_pi_le_stirlingSeq (by omega)
+  have hup_2n : stirlingSeq (2 * n) ≤ Real.exp 1 / Real.sqrt 2 :=
+    stirlingSeq_le (2 * n) (by omega)
+  have hsn_pos : (0 : ℝ) < stirlingSeq n := lt_of_lt_of_le hsπ hlow_n
+  -- numerator ≥ π, denominator ≤ √π·(e/√2)
+  have hnum : π ≤ stirlingSeq n ^ 2 := by
+    have := mul_le_mul hlow_n hlow_n hsπ.le hsn_pos.le
+    rw [Real.mul_self_sqrt hπ.le] at this
+    calc π = π := rfl
+      _ ≤ stirlingSeq n * stirlingSeq n := this
+      _ = stirlingSeq n ^ 2 := by ring
+  have hden : Real.sqrt π * stirlingSeq (2 * n) ≤ Real.sqrt π * (Real.exp 1 / Real.sqrt 2) :=
+    mul_le_mul_of_nonneg_left hup_2n hsπ.le
+  have hden_pos : (0 : ℝ) < Real.sqrt π * stirlingSeq (2 * n) :=
+    mul_pos hsπ (lt_of_lt_of_le hsπ hlow_2n)
+  rw [ratioR, le_div_iff₀ hden_pos]
+  calc Real.sqrt (2 * π) / Real.exp 1 * (Real.sqrt π * stirlingSeq (2 * n))
+      ≤ Real.sqrt (2 * π) / Real.exp 1 * (Real.sqrt π * (Real.exp 1 / Real.sqrt 2)) := by
+        apply mul_le_mul_of_nonneg_left _ (by positivity)
+        exact mul_le_mul_of_nonneg_left hup_2n hsπ.le
+    _ = π := by
+        have h2 : Real.sqrt π * Real.sqrt π = π := Real.mul_self_sqrt hπ.le
+        have he' : Real.exp 1 ≠ 0 := he.ne'
+        have hs2' : Real.sqrt 2 ≠ 0 := (Real.sqrt_pos.mpr (by norm_num)).ne'
+        rw [Real.sqrt_mul (by norm_num : (0:ℝ) ≤ 2) π]
+        field_simp
+        linear_combination h2
+    _ ≤ stirlingSeq n ^ 2 := hnum
+
+/-- Upper envelope: `ratioR n ≤ e²/(2π)` for all `n ≥ 1`. -/
+theorem ratioR_le (n : ℕ) (hn : n ≠ 0) : ratioR n ≤ Real.exp 1 ^ 2 / (2 * π) := by
+  have hπ : (0 : ℝ) < π := Real.pi_pos
+  have hsπ : (0 : ℝ) < Real.sqrt π := Real.sqrt_pos.mpr hπ
+  have he : (0 : ℝ) < Real.exp 1 := Real.exp_pos 1
+  have hup_n : stirlingSeq n ≤ Real.exp 1 / Real.sqrt 2 := stirlingSeq_le n hn
+  have hlow_2n : Real.sqrt π ≤ stirlingSeq (2 * n) :=
+    Stirling.sqrt_pi_le_stirlingSeq (by omega)
+  have hsn_pos : (0 : ℝ) < stirlingSeq n :=
+    lt_of_lt_of_le hsπ (Stirling.sqrt_pi_le_stirlingSeq hn)
+  have hs2 : (0 : ℝ) < Real.sqrt 2 := Real.sqrt_pos.mpr (by norm_num)
+  -- numerator ≤ e²/2, denominator ≥ √π·√π = π
+  have hnum : stirlingSeq n ^ 2 ≤ Real.exp 1 ^ 2 / 2 := by
+    have hup_nonneg : (0 : ℝ) ≤ Real.exp 1 / Real.sqrt 2 := by positivity
+    have := mul_le_mul hup_n hup_n hsn_pos.le hup_nonneg
+    calc stirlingSeq n ^ 2 = stirlingSeq n * stirlingSeq n := by ring
+      _ ≤ (Real.exp 1 / Real.sqrt 2) * (Real.exp 1 / Real.sqrt 2) := this
+      _ = Real.exp 1 ^ 2 / 2 := by
+            rw [div_mul_div_comm, Real.mul_self_sqrt (by norm_num : (0:ℝ) ≤ 2)]; ring
+  have hden : π ≤ Real.sqrt π * stirlingSeq (2 * n) := by
+    have := mul_le_mul_of_nonneg_left hlow_2n hsπ.le
+    rwa [Real.mul_self_sqrt hπ.le] at this
+  have hden_pos : (0 : ℝ) < Real.sqrt π * stirlingSeq (2 * n) :=
+    mul_pos hsπ (lt_of_lt_of_le hsπ hlow_2n)
+  have hπ' : π ≠ 0 := hπ.ne'
+  rw [ratioR, div_le_iff₀ hden_pos]
+  calc stirlingSeq n ^ 2 ≤ Real.exp 1 ^ 2 / 2 := hnum
+    _ = Real.exp 1 ^ 2 / (2 * π) * π := by field_simp
+    _ ≤ Real.exp 1 ^ 2 / (2 * π) * (Real.sqrt π * stirlingSeq (2 * n)) :=
+        mul_le_mul_of_nonneg_left hden (by positivity)
+
+/-!
+## Part IV: The ratio tends to one (recovering the asymptotic)
+-/
+
+/-- `ratioR n → 1`, so `betaDiag_eq` recovers `betaDiag_isEquivalent`. -/
+theorem ratioR_tendsto_one : Tendsto ratioR atTop (𝓝 1) := by
+  have hπ : (0 : ℝ) < π := Real.pi_pos
+  have hsπ : (0 : ℝ) < Real.sqrt π := Real.sqrt_pos.mpr hπ
+  have hk : Tendsto (fun n : ℕ => 2 * n) atTop atTop :=
+    tendsto_atTop_atTop.2 (fun b => ⟨b, fun a ha => by omega⟩)
+  have h1 : Tendsto (fun n : ℕ => stirlingSeq n) atTop (𝓝 (Real.sqrt π)) :=
+    Stirling.tendsto_stirlingSeq_sqrt_pi
+  have h2 : Tendsto (fun n : ℕ => stirlingSeq (2 * n)) atTop (𝓝 (Real.sqrt π)) :=
+    Stirling.tendsto_stirlingSeq_sqrt_pi.comp hk
+  have hden_ne : Real.sqrt π * Real.sqrt π ≠ 0 := by positivity
+  have hlim : Tendsto ratioR atTop
+      (𝓝 (Real.sqrt π ^ 2 / (Real.sqrt π * Real.sqrt π))) :=
+    (h1.pow 2).div (tendsto_const_nhds.mul h2) hden_ne
+  have hval : Real.sqrt π ^ 2 / (Real.sqrt π * Real.sqrt π) = 1 := by
+    rw [Real.sq_sqrt hπ.le, Real.mul_self_sqrt hπ.le, div_self hπ.ne']
+  rwa [hval] at hlim
+
+/-!
+## Part V: The effective two-sided rate for `betaDiag`
+-/
+
+/-- **Effective lower bound.** `(√(2π)/e)·√(πn)/((2n+1)·4ⁿ) ≤ betaDiag n`, all `n ≥ 1`. -/
+theorem betaDiag_lower (n : ℕ) (hn : n ≠ 0) :
+    Real.sqrt (2 * π) / Real.exp 1 * (Real.sqrt (π * n) / ((2 * (n : ℝ) + 1) * 4 ^ n))
+      ≤ betaDiag n := by
+  have hn0 : (0 : ℝ) < (n : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero hn
+  have htnn : (0 : ℝ) ≤ Real.sqrt (π * n) / ((2 * (n : ℝ) + 1) * 4 ^ n) := by positivity
+  rw [betaDiag_eq n hn, mul_comm (Real.sqrt (2 * π) / Real.exp 1)]
+  exact mul_le_mul_of_nonneg_left (ratioR_ge n hn) htnn
+
+/-- **Effective upper bound.** `betaDiag n ≤ (e²/(2π))·√(πn)/((2n+1)·4ⁿ)`, all `n ≥ 1`. -/
+theorem betaDiag_upper (n : ℕ) (hn : n ≠ 0) :
+    betaDiag n
+      ≤ Real.exp 1 ^ 2 / (2 * π) * (Real.sqrt (π * n) / ((2 * (n : ℝ) + 1) * 4 ^ n)) := by
+  have hn0 : (0 : ℝ) < (n : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero hn
+  have htnn : (0 : ℝ) ≤ Real.sqrt (π * n) / ((2 * (n : ℝ) + 1) * 4 ^ n) := by positivity
+  rw [betaDiag_eq n hn, mul_comm (Real.exp 1 ^ 2 / (2 * π))]
+  exact mul_le_mul_of_nonneg_left (ratioR_le n hn) htnn
+
+end BetaDiagEffectiveRate

--- a/proofs/Proofs/Erdos1010OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos1010OQ02OQ01.lean
@@ -1,0 +1,160 @@
+/-
+Erdős Problem #1010, Open Question 2, Sub-question 1:
+  Exact Minimum K_r Density for r ≥ 5
+
+Parent open question (#1010 OQ2, `Erdos1010OQ02Problem.lean`) asks for the exact
+minimum number of copies of K_r forced in a graph whose edge count exceeds the
+Turán threshold ex(n, K_r).  It is known for r = 3 (Razborov 2010) and r = 4
+(Reiher 2016) via flag algebras, and OPEN for r ≥ 5.
+
+The parent formalization states the qualitative Turán forcing step as an
+`axiom turan_theorem`.  This file DE-AXIOMATIZES that forcing step for every r,
+using Mathlib's extremal-graph API, and establishes the rigorous *endpoints and
+structural constraints* of the still-unknown K_r density curve g_r(d):
+
+  * `exists_clique_of_extremalNumber_lt` — the general-r Turán forcing threshold:
+    any graph with strictly more than `extremalNumber n (K_{r+1})` edges contains
+    at least one K_{r+1}.  (This is exactly what the parent axiomatized.)
+
+  * `turanGraph_cliqueDensity_eq_zero` — the LOWER endpoint of the density curve:
+    the extremal Turán graph `turanGraph n r` contains **zero** copies of K_{r+1}
+    and hence has K_{r+1}-density exactly 0.  The open problem is the shape of the
+    curve strictly above this point.
+
+  * `cliqueDensity_nonneg` / `cliqueDensity_le_one` — the density lives in [0,1].
+
+  * `card_cliqueFinset_mono` — clique counts are monotone under adding edges, the
+    structural monotonicity underlying every supersaturation argument.
+
+Everything here is fully machine-checked with **no axioms** and no `sorry`.
+It does not resolve the open problem; it pins down its provable boundary.
+
+Reference: https://erdosproblems.com/1010 (open question 2)
+-/
+
+import Mathlib
+
+open SimpleGraph Finset
+open Fintype (card)
+
+namespace Erdos1010OQ02OQ01
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-!
+## Clique counting via Mathlib's `cliqueFinset`
+
+We use Mathlib's `SimpleGraph.cliqueFinset G k`, the finset of `k`-cliques of `G`,
+and its cardinality as the K_k count.  This is definitionally the same object the
+parent problem counts by hand, but comes with a developed API.
+-/
+
+/-- The number of `k`-cliques of `G`. -/
+def cliqueCount (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ) : ℕ :=
+  (G.cliqueFinset k).card
+
+/-- The `k`-clique count never exceeds `C(n, k)`: a `k`-clique is in particular a
+`k`-subset of the vertex set. -/
+theorem cliqueCount_le_choose (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ) :
+    cliqueCount G k ≤ (card V).choose k :=
+  G.card_cliqueFinset_le
+
+/-- **Monotonicity of clique counts.**  Adding edges can only create cliques, never
+destroy them: if `G ≤ H` then every `k`-clique of `G` is a `k`-clique of `H`. This
+is the structural backbone of all supersaturation arguments. -/
+theorem cliqueCount_mono {G H : SimpleGraph V} [DecidableRel G.Adj] [DecidableRel H.Adj]
+    (h : G ≤ H) (k : ℕ) : cliqueCount G k ≤ cliqueCount H k :=
+  Finset.card_le_card (G.cliqueFinset_mono H h)
+
+/-!
+## The general-r Turán forcing threshold (de-axiomatizing `turan_theorem`)
+
+`extremalNumber n H` is Mathlib's Turán-type extremal number: the maximum number of
+edges of an `H`-free graph on `n` vertices.  For `H = K_{r+1} = ⊤ : SimpleGraph (Fin (r+1))`
+this is `ex(n, K_{r+1})`.  Exceeding it forces a copy of `K_{r+1}`.
+-/
+
+omit [DecidableEq V] in
+/-- **General-r Turán forcing.** If a graph on `V` has strictly more than
+`ex(n, K_{r+1})` edges, then it contains at least one copy of `K_{r+1}`, i.e. it is
+not `(r+1)`-clique-free.  This is precisely the statement the parent problem posits
+as `axiom turan_theorem`, here proved from Mathlib's extremal-graph theory. -/
+theorem not_cliqueFree_of_extremalNumber_lt (G : SimpleGraph V) [DecidableRel G.Adj]
+    (r : ℕ)
+    (h : extremalNumber (card V) (⊤ : SimpleGraph (Fin (r + 1))) < G.edgeFinset.card) :
+    ¬ G.CliqueFree (r + 1) := by
+  have hcontained : (⊤ : SimpleGraph (Fin (r + 1))) ⊑ G :=
+    IsContained.of_extremalNumber_lt_card_edgeFinset h
+  -- `CliqueFree (r+1)` is exactly `⊤`-freeness for a vertex set of size `r+1`.
+  have hiff : G.CliqueFree (r + 1) ↔ (⊤ : SimpleGraph (Fin (r + 1))).Free G := by
+    have := cliqueFree_iff_top_free (G := G) (β := Fin (r + 1))
+    simpa only [Fintype.card_fin] using this
+  rw [hiff]
+  exact fun hfree => hfree hcontained
+
+/-- **Clique-count form of Turán forcing.** Exceeding `ex(n, K_{r+1})` edges forces
+at least one `K_{r+1}`. -/
+theorem one_le_cliqueCount_of_extremalNumber_lt (G : SimpleGraph V) [DecidableRel G.Adj]
+    (r : ℕ)
+    (h : extremalNumber (card V) (⊤ : SimpleGraph (Fin (r + 1))) < G.edgeFinset.card) :
+    1 ≤ cliqueCount G (r + 1) := by
+  have hnf : ¬ G.CliqueFree (r + 1) := not_cliqueFree_of_extremalNumber_lt G r h
+  rw [← SimpleGraph.cliqueFinset_eq_empty_iff] at hnf
+  have hne : (G.cliqueFinset (r + 1)).Nonempty := Finset.nonempty_of_ne_empty hnf
+  have hpos : 0 < (G.cliqueFinset (r + 1)).card := hne.card_pos
+  simp only [cliqueCount]
+  omega
+
+/-!
+## The lower endpoint of the density curve: the Turán graph
+
+`turanGraph n r` is the canonical balanced `r`-partite graph — the extremal
+`K_{r+1}`-free graph.  It sits *at* the Turán threshold and contains **no** copies
+of `K_{r+1}`, so its `K_{r+1}`-density is exactly `0`.  This is the lower endpoint
+of the open density curve `g_{r+1}(d)`.
+-/
+
+/-- The Turán graph has no `(r+1)`-cliques (for `r ≥ 1`). -/
+theorem turanGraph_cliqueFinset_eq_empty (n r : ℕ) (hr : 0 < r) :
+    (turanGraph n r).cliqueFinset (r + 1) = ∅ :=
+  (turanGraph_cliqueFree hr).cliqueFinset
+
+/-- The `K_{r+1}` count of the Turán graph is exactly `0`. -/
+theorem turanGraph_cliqueCount_eq_zero (n r : ℕ) (hr : 0 < r) :
+    cliqueCount (turanGraph n r) (r + 1) = 0 := by
+  unfold cliqueCount
+  rw [turanGraph_cliqueFinset_eq_empty n r hr, Finset.card_empty]
+
+/-!
+## Clique density in [0,1]
+
+The `k`-clique density `ρ_k(G) = (# K_k) / C(n, k)` is the normalized quantity whose
+minimum over graphs of a given edge density the open problem seeks.
+-/
+
+/-- The `k`-clique density of `G`: `(# K_k) / C(n, k)`. -/
+noncomputable def cliqueDensity (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ) : ℝ :=
+  (cliqueCount G k : ℝ) / ((card V).choose k : ℝ)
+
+theorem cliqueDensity_nonneg (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ) :
+    0 ≤ cliqueDensity G k := by
+  unfold cliqueDensity
+  positivity
+
+theorem cliqueDensity_le_one (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ) :
+    cliqueDensity G k ≤ 1 := by
+  unfold cliqueDensity
+  rcases Nat.eq_zero_or_pos ((card V).choose k) with h0 | hpos
+  · rw [h0]; simp
+  · rw [div_le_one (by exact_mod_cast hpos)]
+    exact_mod_cast cliqueCount_le_choose G k
+
+/-- **Lower endpoint of the K_{r+1} density curve.** The extremal Turán graph
+realizes `K_{r+1}`-density exactly `0`. -/
+theorem turanGraph_cliqueDensity_eq_zero (n r : ℕ) (hr : 0 < r) :
+    cliqueDensity (turanGraph n r) (r + 1) = 0 := by
+  unfold cliqueDensity
+  rw [turanGraph_cliqueCount_eq_zero n r hr]
+  simp
+
+end Erdos1010OQ02OQ01

--- a/proofs/Proofs/FibonacciDivisibilityOQ07OQ03.lean
+++ b/proofs/Proofs/FibonacciDivisibilityOQ07OQ03.lean
@@ -1,0 +1,225 @@
+import Mathlib
+
+/-
+# The Rank of Apparition: `k ∣ Fₙ ↔ (entry point of k) ∣ n`
+
+For a fixed modulus `k ≥ 1`, the set of indices `n` at which `k` divides the
+Fibonacci number `Fₙ` is exactly the set of multiples of a single index `α(k)`,
+the **rank of apparition** (or *Fibonacci entry point*) of `k`.  This is the
+exact divisibility characterization
+
+  `k ∣ Fₙ  ↔  α(k) ∣ n`,
+
+generalizing the modulus-specific corollaries `2 ∣ Fₙ ↔ 3 ∣ n`, `3 ∣ Fₙ ↔ 4 ∣ n`
+of `fibonacci-divisibility-oq-07`, and dual to the parent's index-divisibility
+statement `Fₘ ∣ Fₙ ↔ m ∣ n`.
+
+Mathlib records the *strong divisibility* backbone
+`Nat.fib_gcd : fib (gcd m n) = gcd (fib m) (fib n)` and its consequence
+`Nat.fib_dvd : m ∣ n → fib m ∣ fib n`, but says nothing about the rank of
+apparition itself: neither that it exists (that every `k ≥ 1` divides *some*
+positive-index Fibonacci number) nor that it characterizes the divisibility set.
+
+This file supplies both.
+
+## The characterization from minimality
+
+The heart of the matter needs no finiteness at all.  If `a` is *any* least
+positive index with `k ∣ fib a`, then `k ∣ fib n ↔ a ∣ n`:
+
+* (⟸) `a ∣ n` gives `fib a ∣ fib n` by `Nat.fib_dvd`, and `k ∣ fib a`
+  transports across;
+* (⟹) `k ∣ fib n` together with `k ∣ fib a` gives
+  `k ∣ gcd (fib a) (fib n) = fib (gcd a n)` via `Nat.fib_gcd`, so `gcd a n` is a
+  positive index (for `n > 0`) with `k ∣ fib (gcd a n)`; minimality forces
+  `a ≤ gcd a n`, while `gcd a n ∣ a` forces `gcd a n ≤ a`, hence `gcd a n = a`
+  and `a ∣ n`.
+
+## Existence of the rank of apparition
+
+That `α(k)` exists for every `k ≥ 1` is the substantive input.  We prove it by a
+pigeonhole/periodicity argument on the pair sequence
+`pₙ = (Fₙ, Fₙ₊₁) ∈ (ZMod k)²`.  The Fibonacci shift `(a, b) ↦ (b, a + b)` is a
+*bijection* of `(ZMod k)²` (its inverse is `(a, b) ↦ (b − a, a)`), and
+`pₙ₊₁ = shift pₙ`, so `pₙ = shiftⁿ p₀`.  Since `(ZMod k)²` is finite and `ℕ` is
+infinite, two indices collide, `pᵢ = pⱼ` with `i < j`; injectivity of `shiftⁱ`
+cancels the common prefix, giving `p₀ = p_{j−i}`.  Reading the first coordinate,
+`F_{j−i} ≡ F₀ = 0 (mod k)`, so `k ∣ F_{j−i}` with `j − i > 0`.
+
+`entryPoint k := Nat.find` of this existence is then a genuine, computable
+definition, and the biconditional holds unconditionally for `k ≥ 1`.
+
+Fully verified: 0 sorries, 0 axioms, no `native_decide`.  `decide` appears only
+in the concrete examples to evaluate closed Fibonacci numerals `fib 1 … fib 5`,
+which reduce in the kernel.
+-/
+
+namespace FibonacciDivisibilityOQ0703
+
+open Nat
+
+/-! ## The characterization from a least positive index -/
+
+/-- **Rank-of-apparition characterization, from minimality.**  If `a` is a least
+positive index with `k ∣ fib a` — i.e. `0 < a`, `k ∣ fib a`, and every positive
+index `m` with `k ∣ fib m` satisfies `a ≤ m` — then for every `n`,
+`k ∣ fib n ↔ a ∣ n`.
+
+This is the mathematical core; it uses only `Nat.fib_dvd` and `Nat.fib_gcd` and
+needs no hypothesis on `k` beyond the supplied minimal witness `a`. -/
+theorem dvd_fib_iff_of_least {k a : ℕ} (ha : 0 < a) (hdvd : k ∣ fib a)
+    (hleast : ∀ m, 0 < m → k ∣ fib m → a ≤ m) (n : ℕ) :
+    k ∣ fib n ↔ a ∣ n := by
+  constructor
+  · intro hn
+    rcases Nat.eq_zero_or_pos n with rfl | hnpos
+    · exact Dvd.intro 0 rfl
+    · -- `k` divides `fib (gcd a n)` because it divides both `fib a` and `fib n`.
+      have hkd : k ∣ fib (Nat.gcd a n) := by
+        rw [Nat.fib_gcd]; exact Nat.dvd_gcd hdvd hn
+      have hdpos : 0 < Nat.gcd a n := by
+        rcases Nat.eq_zero_or_pos (Nat.gcd a n) with h | h
+        · rw [Nat.gcd_eq_zero_iff] at h; omega
+        · exact h
+      -- minimality (`a ≤ gcd`) and `gcd ∣ a` (`gcd ≤ a`) pin `gcd a n = a`.
+      have hle : a ≤ Nat.gcd a n := hleast _ hdpos hkd
+      have hge : Nat.gcd a n ≤ a := Nat.le_of_dvd ha (Nat.gcd_dvd_left a n)
+      have heq : Nat.gcd a n = a := le_antisymm hge hle
+      exact heq ▸ Nat.gcd_dvd_right a n
+  · intro hn
+    exact dvd_trans hdvd (Nat.fib_dvd a n hn)
+
+/-! ## Existence of the rank of apparition via periodicity mod `k` -/
+
+/-- The Fibonacci pair `(Fₙ, Fₙ₊₁)` reduced modulo `k`. -/
+def fibPair (k n : ℕ) : ZMod k × ZMod k := ((fib n : ZMod k), (fib (n + 1) : ZMod k))
+
+/-- The Fibonacci shift on pairs, `(a, b) ↦ (b, a + b)`, as an equivalence of
+`(ZMod k)²` (inverse `(a, b) ↦ (b − a, a)`).  This is what makes the pair
+sequence *purely* periodic. -/
+def shift (k : ℕ) : ZMod k × ZMod k ≃ ZMod k × ZMod k where
+  toFun p := (p.2, p.1 + p.2)
+  invFun p := (p.2 - p.1, p.1)
+  left_inv := by rintro ⟨a, b⟩; simp
+  right_inv := by rintro ⟨a, b⟩; simp
+
+@[simp] lemma shift_apply (k : ℕ) (p : ZMod k × ZMod k) :
+    shift k p = (p.2, p.1 + p.2) := rfl
+
+/-- One step of the pair sequence is one application of the shift. -/
+lemma shift_fibPair (k n : ℕ) : shift k (fibPair k n) = fibPair k (n + 1) := by
+  have h2 : (fib n : ZMod k) + (fib (n + 1) : ZMod k) = (fib (n + 2) : ZMod k) := by
+    rw [fib_add_two]; push_cast; ring
+  show ((fib (n + 1) : ZMod k), (fib n : ZMod k) + (fib (n + 1) : ZMod k))
+      = ((fib (n + 1) : ZMod k), (fib (n + 1 + 1) : ZMod k))
+  rw [Prod.mk.injEq]
+  exact ⟨rfl, h2⟩
+
+/-- The pair sequence is the shift orbit of the initial pair `(F₀, F₁) = (0, 1)`. -/
+lemma fibPair_eq_iterate (k n : ℕ) : fibPair k n = (shift k)^[n] (fibPair k 0) := by
+  induction n with
+  | zero => rfl
+  | succ m ih =>
+    rw [Function.iterate_succ', Function.comp_apply, ← ih, shift_fibPair]
+
+/-- From a repeat `fibPair k i = fibPair k j` with `i < j`, cancel the common
+prefix (`shiftⁱ` is injective) to get `fibPair k 0 = fibPair k (j - i)`, whose
+first coordinate says `k ∣ fib (j - i)` with `j - i > 0`. -/
+private lemma exists_pos_dvd_of_pair_eq (k : ℕ) {i j : ℕ} (hlt : i < j)
+    (hpair : fibPair k i = fibPair k j) : ∃ n, 0 < n ∧ k ∣ fib n := by
+  refine ⟨j - i, by omega, ?_⟩
+  have hinj : Function.Injective ((shift k)^[i]) := (shift k).injective.iterate i
+  have hcol : fibPair k 0 = fibPair k (j - i) := by
+    apply hinj
+    have e1 : (shift k)^[i] (fibPair k 0) = fibPair k i := (fibPair_eq_iterate k i).symm
+    have e2 : (shift k)^[i] (fibPair k (j - i)) = fibPair k (i + (j - i)) := by
+      rw [fibPair_eq_iterate k (j - i), ← Function.iterate_add_apply,
+        fibPair_eq_iterate k (i + (j - i))]
+    rw [e1, e2]
+    have hij : i + (j - i) = j := by omega
+    rw [hij]; exact hpair
+  have hfst : ((fib 0 : ℕ) : ZMod k) = ((fib (j - i) : ℕ) : ZMod k) :=
+    (Prod.ext_iff.mp hcol).1
+  rw [fib_zero, Nat.cast_zero] at hfst
+  exact (ZMod.natCast_eq_zero_iff _ _).mp hfst.symm
+
+/-- **Existence of the rank of apparition.**  Every modulus `k ≥ 1` divides some
+positive-index Fibonacci number.  Proof: the pair sequence `(Fₙ, Fₙ₊₁) mod k`
+lives in the finite set `(ZMod k)²`, so by pigeonhole two indices collide; the
+Fibonacci shift is a bijection, so the collision propagates back to index `0`. -/
+theorem exists_pos_dvd_fib (k : ℕ) [NeZero k] : ∃ n, 0 < n ∧ k ∣ fib n := by
+  obtain ⟨i, j, hij, hpair⟩ := Finite.exists_ne_map_eq_of_infinite (fibPair k)
+  rcases lt_or_gt_of_ne hij with hlt | hlt
+  · exact exists_pos_dvd_of_pair_eq k hlt hpair
+  · exact exists_pos_dvd_of_pair_eq k hlt hpair.symm
+
+/-! ## The entry point and the unconditional characterization -/
+
+/-- The **rank of apparition** (Fibonacci entry point) of `k ≥ 1`: the least
+positive index `n` with `k ∣ Fₙ`.  Total and computable, since existence is a
+theorem. -/
+def entryPoint (k : ℕ) [NeZero k] : ℕ := Nat.find (exists_pos_dvd_fib k)
+
+lemma entryPoint_pos (k : ℕ) [NeZero k] : 0 < entryPoint k :=
+  (Nat.find_spec (exists_pos_dvd_fib k)).1
+
+lemma dvd_fib_entryPoint (k : ℕ) [NeZero k] : k ∣ fib (entryPoint k) :=
+  (Nat.find_spec (exists_pos_dvd_fib k)).2
+
+/-- Minimality of the entry point: any positive index at which `k` divides a
+Fibonacci number is at least `entryPoint k`. -/
+lemma entryPoint_le (k : ℕ) [NeZero k] {m : ℕ} (hm : 0 < m) (hd : k ∣ fib m) :
+    entryPoint k ≤ m :=
+  Nat.find_min' (exists_pos_dvd_fib k) ⟨hm, hd⟩
+
+/-- **Main theorem — the rank of apparition characterizes Fibonacci
+divisibility.**  For every `k ≥ 1` and every `n`,
+
+  `k ∣ Fₙ  ↔  entryPoint k ∣ n`.
+
+The divisibility set of `k` in the Fibonacci sequence is exactly the multiples of
+the single index `entryPoint k`. -/
+theorem dvd_fib_iff_entryPoint_dvd (k : ℕ) [NeZero k] (n : ℕ) :
+    k ∣ fib n ↔ entryPoint k ∣ n :=
+  dvd_fib_iff_of_least (entryPoint_pos k) (dvd_fib_entryPoint k)
+    (fun _ hm hd => entryPoint_le k hm hd) n
+
+/-! ## Concrete entry points
+
+Verified via `dvd_fib_iff_of_least`, so no evaluation of `Nat.find` is needed —
+only the finitely many small Fibonacci numerals below the claimed entry point. -/
+
+/-- Entry point of `2` is `3`: `2 ∣ Fₙ ↔ 3 ∣ n`  (`F₃ = 2`, and `F₁ = F₂ = 1`). -/
+example (n : ℕ) : 2 ∣ fib n ↔ 3 ∣ n := by
+  refine dvd_fib_iff_of_least (by norm_num) (by decide) ?_ n
+  intro m hm hd
+  rcases m with _ | _ | _ | m
+  · omega
+  · exact absurd hd (by decide)
+  · exact absurd hd (by decide)
+  · omega
+
+/-- Entry point of `3` is `4`: `3 ∣ Fₙ ↔ 4 ∣ n`  (`F₄ = 3`). -/
+example (n : ℕ) : 3 ∣ fib n ↔ 4 ∣ n := by
+  refine dvd_fib_iff_of_least (by norm_num) (by decide) ?_ n
+  intro m hm hd
+  rcases m with _ | _ | _ | _ | m
+  · omega
+  · exact absurd hd (by decide)
+  · exact absurd hd (by decide)
+  · exact absurd hd (by decide)
+  · omega
+
+/-- Entry point of `5` is `5`: `5 ∣ Fₙ ↔ 5 ∣ n`  (`F₅ = 5`, the fixed point). -/
+example (n : ℕ) : 5 ∣ fib n ↔ 5 ∣ n := by
+  refine dvd_fib_iff_of_least (by norm_num) (by decide) ?_ n
+  intro m hm hd
+  rcases m with _ | _ | _ | _ | _ | m
+  · omega
+  · exact absurd hd (by decide)
+  · exact absurd hd (by decide)
+  · exact absurd hd (by decide)
+  · exact absurd hd (by decide)
+  · omega
+
+end FibonacciDivisibilityOQ0703


### PR DESCRIPTION
## Summary

Implements the Builder scope of #35069: repairs the pre-existing Mathlib v4.26 drift in `BetaCentralBinomialAsymptotic.lean` (silently unbuildable on main) and recovers the 3 near-fixable proof candidates from the 2026-07-05 cleanup backups. All 4 modules Docker-verified against Mathlib v4.26, 0 sorries / 0 `axiom` declarations / no `native_decide`.

## What was fixed

### 1. `proofs/Proofs/BetaCentralBinomialAsymptotic.lean` (drift repair, already on main)
- `simp only [Function.comp_apply]` made no progress: the goal is now `(f ∘ g / (f * f)) n`, so `Pi.div_apply`/`Pi.mul_apply` are needed to distribute the application before `comp_apply` can fire.
- Final `EventuallyEq` goal is no longer beta-reduced and `ring` can no longer close the inverse-of-product form; replaced with `dsimp only` + explicit `rw [inv_div, inv_mul_eq_div, div_div, mul_comm ...]`.

### 2. `proofs/Proofs/BetaDiagEffectiveRate.lean` (recovered from bundle branch `research/beta-diag-effective-rate`)
- Added `open scoped Nat` (the `n !` factorial notation is scoped; previously pulled in transitively).
- `field_simp` output changed: `linear_combination` coefficient in `ratioR_ge` is now `h2` (coefficient 1), and two trailing `ring` calls after fully-closing `field_simp` removed.

### 3. `proofs/Proofs/Erdos1010OQ02OQ01.lean` (recovered from tarball `Users__rwalters__lg-r11-erdos1010.tar.gz`)
- The audit-flagged type mismatch: v4.26 makes both graph arguments of `SimpleGraph.cliqueFinset_mono` explicit; pass `H` explicitly.
- `omit [DecidableEq V] in` on the Turan forcing theorem to silence the unused-section-variable lint.

### 4. `proofs/Proofs/FibonacciDivisibilityOQ07OQ03.lean` (recovered from tarball `Users__rwalters__lg-fib-r7.tar.gz`)
- The audit-flagged rewrite failure: the `fibPair` terms must be unfolded to shift-iterates (`fibPair_eq_iterate` forward) before `← Function.iterate_add_apply` can match.

## Verification (all via `./proofs/scripts/docker-build.sh`, never raw `lake build`)

```
✔ [7745/7745] Built Proofs.BetaCentralBinomialAsymptotic (2.7s)  => Build succeeded
✔ [7746/7746] Built Proofs.BetaDiagEffectiveRate (2.9s)          => Build succeeded
✔ [7743/7743] Built Proofs.Erdos1010OQ02OQ01 (2.5s)              => Build succeeded
✔ [7743/7743] Built Proofs.FibonacciDivisibilityOQ07OQ03 (2.5s)  => Build succeeded
```

Comment-aware sorry/axiom check: `grep -n "sorry\|^axiom\|native_decide"` over all four files returns only docstring mentions ("no axioms", "0 sorries") — zero real sorries, zero `axiom` declarations, no `native_decide`.

Backup artifacts untouched: `~/lean-genius-cleanup-backup-20260705.bundle` and `~/lean-genius-cleanup-20260705/` both still present.

## Remaining follow-ups (out of scope here, tracked in #35069)

- Gallery integration (`src/data/proofs/<slug>/`) for the 12 orphans from PR #35070 and the 3 proofs recovered here.
- The 282 uncommitted enricher annotation JSONs in the `lean-genius-e3-wt` tarball.
- The remaining 8 drift-broken candidates in backups (`AbundantNumberOQ0102`, `CauchySchwarzIntegral…Incomplete01{Infra,Loc,Norm}`, `Erdos1014OQ04`, `FourSquareDistributionOQ04ArrangeFinal`, `KroneckersJugendtraumRealQuadAbelian`, `LovaszLocalLemmaOQ01Pairwise`) — these need substantive rework.
- Stash WIP deltas.

Closes #35069

🤖 Generated with [Claude Code](https://claude.com/claude-code)
