### PR TITLE
Recover automorphic-number-oq-01-oq-02-oq-01-oq-02 (idempotents as per-prime Bool choice / unitary divisors)

### DIFF
--- a/proofs/Proofs/AutomorphicNumberOQ01OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/AutomorphicNumberOQ01OQ02OQ01OQ02.lean
@@ -1,0 +1,143 @@
+import Mathlib
+import Proofs.AutomorphicNumberOQ01
+import Proofs.AutomorphicNumberOQ01OQ02OQ01
+
+/-!
+# Idempotents of `ZMod (m ^ k)`, structurally: a per-prime `Bool` choice and the unitary divisors
+
+## What This Proves
+
+The parent entry `automorphic-number-oq-01-oq-02-oq-01`
+(`AutomorphicNumberOQ01OQ02OQ01.card_idempotents_eq_two_pow_omega`) *counts* the idempotents of
+`ZMod (m ^ k)`: there are exactly `2 ^ ω(m)` of them.  A count is not a description — it says how
+many idempotents exist without saying which elements they are, or why the total is a power of two.
+
+This follow-up upgrades the count to an explicit **structural bijection**.  Every idempotent of
+`ZMod (m ^ k)` is exactly a free choice, independently at each prime `p ∣ m`, of the local unit
+`1` or the local zero `0`:
+
+```
+idemEquivPrimeBool :
+  {e : ZMod (m ^ k) // e * e = e}  ≃  ((m ^ k).primeFactors → Bool)
+```
+
+Under the Chinese-Remainder isomorphism `ZMod (m ^ k) ≃ ∏_{p} ZMod (p ^ v_p)`
+(`ZMod.equivPi`), an idempotent is a family of local idempotents (`idemPi`), and each local
+(prime-power) ring is *local*, so its only idempotents are `0` and `1`
+(`AutomorphicNumberOQ01.idem_eq_zero_or_one`).  Hence an idempotent is exactly a function
+`p ↦ (0 or 1)` — a `Bool` at each prime — i.e. a subset `S ⊆ primeFactors(m)`: the primes at which
+the idempotent is the local `1`.  This makes the power-of-two count *transparent*
+(`card_idempotents_via_bool`): `2 ^ ω(m)` is the number of subsets of the prime factors.
+
+## Unitary divisors
+
+Reading each subset `S` as a divisor gives the classical correspondence with the **unitary
+divisors** of `n = m ^ k`.  A *unitary divisor* of `n` is a divisor `d ∣ n` with
+`gcd(d, n / d) = 1` (`unitaryDivisors`); equivalently, `d` takes at each prime `p ∣ n` either the
+full prime-power `p ^ v_p(n)` or `1`.  So unitary divisors also biject with subsets of
+`primeFactors(n)`, and there are `2 ^ ω(n)` of them.  The idempotent attached to a unitary divisor
+`d ∣ n` is the CRT element that is `1` on the `d`-part and `0` on the `n / d`-part.  The
+`idempotents ↔ unitary divisors` correspondence is exhibited concretely below for
+`n = 12` (`ω = 2`, four each) and `n = 30` (`ω = 3`, eight each).
+
+The general identity `#(unitaryDivisors n) = 2 ^ ω(n)` (hence the general
+`#idempotents = #unitaryDivisors`) is the natural next step; it is stated in the sanity checks for
+concrete moduli here and left for a follow-up (a finite-set bijection
+`powerset (primeFactors n) ≃ unitaryDivisors n`).
+
+## Status
+
+Fully machine-checked: `0` sorries, `0` axioms.
+-/
+
+namespace AutomorphicNumberOQ01OQ02OQ01OQ02
+
+open Finset AutomorphicNumberOQ01 AutomorphicNumberOQ01OQ02OQ01
+
+/-! ## The local factor: two idempotents, named by `Bool` -/
+
+/-- In a prime-power ring `ZMod (p ^ v)` (`p` prime, `v ≥ 1`) the only idempotents are `0` and
+`1` (`idem_eq_zero_or_one`), so the idempotent subtype is `Bool`: `true ↔ 1`, `false ↔ 0`.
+This is the explicit form of the parent's cardinality fact `idem_card_prime_pow`. -/
+def idemEquivBool {p : ℕ} [hp : Fact p.Prime] {v : ℕ} (hv : 0 < v) :
+    {a : ZMod (p ^ v) // a * a = a} ≃ Bool := by
+  haveI : Fact (1 < p ^ v) :=
+    ⟨lt_of_lt_of_le hp.out.one_lt (Nat.le_self_pow hv.ne' p)⟩
+  have h01 : (0 : ZMod (p ^ v)) ≠ 1 := zero_ne_one
+  refine
+    { toFun := fun a => decide (a.1 = 1)
+      invFun := fun b => ⟨cond b 1 0, by cases b <;> simp⟩
+      left_inv := fun a => ?_
+      right_inv := fun b => ?_ }
+  · obtain ⟨a, ha⟩ := a
+    rcases idem_eq_zero_or_one hv a ha with h | h <;> subst h
+    · simp [h01]
+    · simp
+  · rcases b with _ | _
+    · simp [h01]
+    · simp
+
+/-! ## The global structural bijection -/
+
+/-- **Every idempotent is a per-prime `Bool` choice.**  For a nonzero modulus `m` and exponent
+`k ≥ 1`, the idempotents of `ZMod (m ^ k)` biject with functions `primeFactors(m^k) → Bool`.
+Concretely: transport an idempotent across the Chinese-Remainder product `ZMod.equivPi`
+(`idemCongr`), split it componentwise into local idempotents (`idemPi`), and name each local
+idempotent by a `Bool` (`idemEquivBool`).  The chosen subset `{p : the local value is 1}` is the
+structural content the parent's bare count `2 ^ ω(m)` leaves implicit. -/
+noncomputable def idemEquivPrimeBool (m k : ℕ) [NeZero m] (hk : 1 ≤ k) :
+    {e : ZMod (m ^ k) // e * e = e} ≃ ((m ^ k).primeFactors → Bool) := by
+  have hn : m ^ k ≠ 0 := pow_ne_zero k (NeZero.ne m)
+  haveI hNZ : ∀ p : (m ^ k).primeFactors,
+      NeZero ((p : ℕ) ^ ((m ^ k).factorization (p : ℕ))) :=
+    fun p => ⟨pow_ne_zero _ (Nat.prime_of_mem_primeFactors p.2).pos.ne'⟩
+  refine ((idemCongr (ZMod.equivPi (m ^ k) hn).toMulEquiv).trans idemPi).trans
+    (Equiv.piCongrRight (fun p => ?_))
+  haveI : Fact ((p : ℕ).Prime) := ⟨Nat.prime_of_mem_primeFactors p.2⟩
+  have hpos : 0 < (m ^ k).factorization (p : ℕ) := by
+    obtain ⟨hp, hdvd, -⟩ := Nat.mem_primeFactors.mp p.2
+    exact hp.factorization_pos_of_dvd hn hdvd
+  exact idemEquivBool hpos
+
+/-- The structural bijection recovers the parent count `2 ^ ω(m)` — now visibly as the number of
+subsets of the prime factors, exhibiting *why* the count is a power of two. -/
+theorem card_idempotents_via_bool (m k : ℕ) [NeZero m] (hk : 1 ≤ k) :
+    Fintype.card {e : ZMod (m ^ k) // e * e = e} = 2 ^ m.primeFactors.card := by
+  have hk0 : k ≠ 0 := by omega
+  classical
+  rw [Fintype.card_congr (idemEquivPrimeBool m k hk), Fintype.card_pi]
+  simp only [Fintype.card_bool, Finset.prod_const, Finset.card_univ, Fintype.card_coe,
+    Nat.primeFactors_pow m hk0]
+
+/-! ## Unitary divisors -/
+
+/-- The **unitary divisors** of `n`: divisors `d ∣ n` with `gcd(d, n / d) = 1`.  Equivalently,
+`d` takes, at each prime `p ∣ n`, either the full prime-power `p ^ v_p(n)` or `1`.  There are
+`2 ^ ω(n)` of them — the same count as the idempotents of `ZMod n`. -/
+def unitaryDivisors (n : ℕ) : Finset ℕ :=
+  n.divisors.filter (fun d => Nat.Coprime d (n / d))
+
+/-! ## Idempotents ↔ unitary divisors (concrete moduli) -/
+
+/-- `12 = 2² · 3` has `ω = 2`.  Its four unitary divisors `{1, 3, 4, 12}` are the four
+subset-products of the maximal prime-powers `{4, 3}`, matching the four idempotents of
+`ZMod 12` element-for-element. -/
+example : unitaryDivisors 12 = {1, 3, 4, 12} := by decide
+
+/-- The `ZMod 12` idempotents number `2 ^ ω(12) = 4` (`card_idempotents_via_bool`); `12` has
+exactly `4` unitary divisors, so the two counts agree.  The joint equality
+`#idempotents = #unitaryDivisors` follows from these two facts, but is not stated as a single goal
+here: `decide` cannot reduce `Nat.primeFactors` (well-founded recursion the kernel will not
+evaluate), so the unitary-divisor count is checked directly. -/
+example : (unitaryDivisors 12).card = 4 := by decide
+
+/-- `30 = 2 · 3 · 5` has `ω = 3`, so `ZMod 30` has `2 ^ 3 = 8` idempotents
+(`card_idempotents_via_bool`); `30` has exactly `8` unitary divisors, matching the idempotent
+count. -/
+example : (unitaryDivisors 30).card = 8 := by decide
+
+/-- A prime power `9 = 3²` has `ω = 1`: only the two trivial unitary divisors `{1, 9}`, matching
+the two trivial idempotents `0, 1` of `ZMod 9`. -/
+example : unitaryDivisors 9 = {1, 9} := by decide
+
+end AutomorphicNumberOQ01OQ02OQ01OQ02

--- a/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "ann-autonum-oq01020102-context",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "From counting to structure: idempotents of ℤ/mᵏ as a per-prime Bool choice",
+    "content": "The parent entry automorphic-number-oq-01-oq-02-oq-01 counts the idempotents of ZMod (m^k): there are exactly 2^ω(m). But a count says how many idempotents exist without saying which elements they are or why the total is a power of two. This follow-up upgrades the count to an explicit structural bijection: every idempotent of ZMod (m^k) is exactly a free, independent choice at each prime p ∣ m of the local unit 1 or the local zero 0 — a function (m^k).primeFactors → Bool. Under the Chinese Remainder isomorphism ZMod.equivPi, an idempotent is a family of local idempotents, and each prime-power ring ZMod (p^v) is local, so its only idempotents are 0 and 1. Hence an idempotent is a subset S ⊆ primeFactors(m): the primes at which it is the local 1. This makes the power-of-two count transparent — 2^ω(m) is the number of subsets of the prime factors, i.e. the vertices of a Boolean cube of dimension ω(m).",
+    "mathContext": "By CRT, $\\mathbb{Z}/m^k\\cong\\prod_{p\\mid m}\\mathbb{Z}/p^{v_p}$; each local factor has only the idempotents $0,1$, so an idempotent is a function $p\\mapsto\\{0,1\\}$, i.e. a subset of the primes, giving $2^{\\omega(m)}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "idempotents",
+      "Chinese Remainder Theorem",
+      "local rings",
+      "Boolean cube",
+      "distinct prime factors ω(m)"
+    ],
+    "prerequisites": [
+      "idempotents in a commutative ring",
+      "ZMod (m^k) and the CRT"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq01020102-idemequivbool",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 57,
+      "endLine": 78
+    },
+    "type": "technique",
+    "title": "idemEquivBool: the two local idempotents named by a single Bool",
+    "content": "In a prime-power ring ZMod (p^v) with p prime and v ≥ 1, the only idempotents are 0 and 1 (the sibling AutomorphicNumberOQ01.idem_eq_zero_or_one), so the idempotent subtype is equivalent to Bool: true ↔ 1, false ↔ 0. The forward map is fun a => decide (a.1 = 1); the inverse sends b to ⟨cond b 1 0, _⟩. Both round-trips are discharged by casing on the idempotent (0 or 1 via idem_eq_zero_or_one) or on the Bool, using zero_ne_one — which holds because Fact (1 < p^v) makes the local ring nontrivial (lt_of_lt_of_le hp.out.one_lt (Nat.le_self_pow hv.ne' p)). This is the explicit Bool-named form of the sibling's cardinality fact idem_card_prime_pow.",
+    "mathContext": "A finite local ring $\\mathbb{Z}/p^v$ has exactly the two trivial idempotents $0,1$, so its idempotent set is canonically the two-element type $\\mathrm{Bool}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "local ring",
+      "trivial idempotents",
+      "two-element type",
+      "Bool"
+    ],
+    "prerequisites": [
+      "idem_eq_zero_or_one for prime-power rings",
+      "nontriviality of ZMod (p^v)"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq01020102-idemequivprimebool",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 80,
+      "endLine": 100
+    },
+    "type": "proof-step",
+    "title": "idemEquivPrimeBool: transport by CRT, split, then name each prime by Bool",
+    "content": "The global bijection {e : ZMod (m^k) // e*e = e} ≃ ((m^k).primeFactors → Bool) composes three equivalences. First idemCongr (ZMod.equivPi (m^k) hn).toMulEquiv transports the idempotent subtype across the finite-product Chinese Remainder isomorphism into the idempotent subtype of ∏ p ∈ (m^k).primeFactors, ZMod (p^v_p). Then idemPi splits that into ∏ p, (idempotents of the factor). Finally Equiv.piCongrRight applies idemEquivBool at every prime: each factor exponent is positive because p ∈ (m^k).primeFactors gives Nat.Prime.factorization_pos_of_dvd, and Nat.prime_of_mem_primeFactors supplies the Fact p.Prime instance. The result identifies an idempotent with the function p ↦ (its local value is 1) — the subset of primes at which the idempotent is the local unit.",
+    "mathContext": "$\\{e:e^2=e\\}\\;\\xrightarrow{\\text{CRT}}\\;\\prod_p\\{e_p:e_p^2=e_p\\}\\;\\xrightarrow{\\text{local}}\\;\\prod_p\\mathrm{Bool}\\;=\\;(\\mathrm{primeFactors}\\to\\mathrm{Bool})$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "idemCongr transport",
+      "idemPi",
+      "Equiv.piCongrRight",
+      "positive prime-power exponent"
+    ],
+    "prerequisites": [
+      "ZMod.equivPi",
+      "idempotents of a product ring",
+      "Nat.factorization"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq01020102-cardviabool",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 102,
+      "endLine": 110
+    },
+    "type": "proof-step",
+    "title": "card_idempotents_via_bool: the count 2^ω(m) as a subset count",
+    "content": "The headline theorem re-derives the parent count from the structural bijection. Fintype.card_congr (idemEquivPrimeBool m k hk) rewrites the idempotent count as Fintype.card ((m^k).primeFactors → Bool); Fintype.card_pi turns that into a product over the primes, Fintype.card_bool makes each factor 2, and Finset.prod_const collapses ∏ 2 to 2^(#primeFactors). Fintype.card_coe converts the coe-Fintype card to the Finset card and Nat.primeFactors_pow (needing k ≠ 0, obtained from hk by omega) rewrites (m^k).primeFactors = m.primeFactors, landing on 2 ^ m.primeFactors.card. Now the power of two is visibly the number of subsets of the prime factors — the structural content the parent's bare cardinality left implicit.",
+    "mathContext": "$\\#\\{e:e^2=e\\}=\\#(\\mathrm{primeFactors}\\to\\mathrm{Bool})=2^{\\#\\mathrm{primeFactors}}=2^{\\omega(m)}$, independent of $k$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Fintype.card_pi",
+      "Fintype.card_bool",
+      "Finset.prod_const",
+      "Nat.primeFactors_pow",
+      "subset count"
+    ],
+    "prerequisites": [
+      "cardinality of function types",
+      "the bijection idemEquivPrimeBool"
+    ]
+  },
+  {
+    "id": "ann-autonum-oq01020102-unitarydivisors",
+    "proofId": "automorphic-number-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 112,
+      "endLine": 143
+    },
+    "type": "concept",
+    "title": "Unitary divisors: the same Boolean cube, read multiplicatively",
+    "content": "unitaryDivisors n := n.divisors.filter (fun d => Nat.Coprime d (n / d)) collects the divisors d ∣ n with gcd(d, n/d) = 1. Equivalently d takes at each prime p ∣ n either the full prime-power p^v_p(n) or 1, so unitary divisors also biject with subsets of primeFactors(n) — the same 2^ω(n) Boolean cube as the idempotents of ℤ/n. The idempotent attached to a unitary divisor d is the CRT element that is 1 on the d-part and 0 on the n/d-part. Four decide-checked examples exhibit the correspondence concretely: unitaryDivisors 12 = {1,3,4,12} and (unitaryDivisors 12).card = 4 for ω(12) = 2, (unitaryDivisors 30).card = 8 for ω(30) = 3, and unitaryDivisors 9 = {1,9} for the prime power ω(9) = 1. Crucially these decide-checks reduce only through Nat.divisors.filter and Nat.Coprime (both kernel-reducible); they never reduce the well-founded Nat.primeFactors recursion, so the entry stays verified with only foundational axioms. The general finite-set bijection powerset(primeFactors n) ≃ unitaryDivisors n is left for a follow-up.",
+    "mathContext": "A unitary divisor $d\\mid n$ ($\\gcd(d,n/d)=1$) chooses at each prime the full prime-power or $1$; unitary divisors biject with subsets of $\\mathrm{primeFactors}(n)$ and hence with the idempotents of $\\mathbb{Z}/n$, matching $2^{\\omega(n)}$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "unitary divisors",
+      "coprime complement gcd(d, n/d) = 1",
+      "subset of prime factors",
+      "kernel-reducible decide"
+    ],
+    "prerequisites": [
+      "divisors of n and Nat.Coprime",
+      "the count 2^ω(n)"
+    ]
+  }
+]

--- a/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "automorphic-number-oq-01-oq-02-oq-01-oq-02",
+  "slug": "automorphic-number-oq-01-oq-02-oq-01-oq-02",
+  "title": "Idempotents of ℤ/mᵏ as a Per-Prime Bool Choice, and the Unitary Divisors",
+  "description": "The parent entry automorphic-number-oq-01-oq-02-oq-01 COUNTS the idempotents of ZMod (m^k): there are exactly 2^ω(m) of them. A count says how many idempotents exist without saying which elements they are or why the total is a power of two. This follow-up upgrades the count to an explicit STRUCTURAL bijection: every idempotent of ZMod (m^k) is exactly a free, independent choice at each prime p ∣ m of the local unit 1 or the local zero 0 — a function (m^k).primeFactors → Bool. Under the Chinese Remainder isomorphism ZMod.equivPi, an idempotent is a family of local idempotents (idemPi), and each prime-power ring ZMod (p^v) is local, so its only idempotents are 0 and 1 (idemEquivBool, the Bool-named form of the sibling AutomorphicNumberOQ01.idem_eq_zero_or_one). Composing these gives idemEquivPrimeBool : {e : ZMod (m^k) // e*e = e} ≃ ((m^k).primeFactors → Bool), and card_idempotents_via_bool re-derives the parent count 2^ω(m) now VISIBLY as the number of subsets of the prime factors — a Boolean cube of dimension ω(m). Reading each subset S as a divisor gives the classical correspondence with the UNITARY DIVISORS of n = m^k: divisors d ∣ n with gcd(d, n/d) = 1 (unitaryDivisors), which also biject with subsets of primeFactors(n). The idempotents ↔ unitary-divisors correspondence is exhibited concretely for n = 12 (ω = 2, four each), n = 30 (ω = 3, eight each), and the prime power n = 9 (ω = 1, two trivial each). The general finite-set bijection powerset(primeFactors n) ≃ unitaryDivisors n is left for a follow-up. Machine-checked with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Builder",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AutomorphicNumberOQ01OQ02OQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "automorphic-numbers",
+      "idempotents",
+      "zmod",
+      "chinese-remainder-theorem",
+      "prime-factorization",
+      "local-ring",
+      "unitary-divisors",
+      "boolean-algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 143,
+    "theoremCount": 1,
+    "definitionCount": 3,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. #print axioms card_idempotents_via_bool reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]. The three `decide` calls in the sanity examples are kernel decisions on concrete finite Finset data — unitaryDivisors 12 = {1,3,4,12}, (unitaryDivisors 12).card = 4, (unitaryDivisors 30).card = 8, unitaryDivisors 9 = {1,9} — which reduce only through Nat.divisors.filter and Nat.Coprime (both kernel-reducible); no well-founded recursion (Nat.primeFactors) is reduced. Builds on the verified siblings AutomorphicNumberOQ01.lean (idem_eq_zero_or_one, idemCongr, idemPi) and AutomorphicNumberOQ01OQ02OQ01.lean.",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.equivPi",
+        "description": "The finite-product form of the Chinese Remainder Theorem: ZMod n ≃+* Π p ∈ n.primeFactors, ZMod (p ^ n.factorization p) for n ≠ 0; applied at n = m^k it decomposes the ring into its local prime-power factors so that an idempotent becomes a family of local idempotents",
+        "module": "Mathlib.Data.ZMod.QuotientRing"
+      },
+      {
+        "theorem": "Equiv.piCongrRight",
+        "description": "Combines the per-prime equivalences idemEquivBool factor-by-factor into a single equivalence on the dependent product, turning the family of local idempotents into a function primeFactors → Bool",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Fintype.card_pi",
+        "description": "The cardinality of a dependent function type is the product of the factor cardinalities; turns Fintype.card (primeFactors → Bool) into ∏ 2 = 2^(#primeFactors)",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      },
+      {
+        "theorem": "Nat.primeFactors_pow",
+        "description": "(m ^ k).primeFactors = m.primeFactors for k ≠ 0; drops the exponent k so the count depends only on ω(m)",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Nat.prime_of_mem_primeFactors",
+        "description": "Membership in n.primeFactors gives primality; supplies the Fact p.Prime instance needed to name each local factor's two idempotents by Bool",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Nat.Prime.factorization_pos_of_dvd",
+        "description": "A prime dividing n ≠ 0 has positive exponent in n.factorization; guarantees each prime-power factor ZMod (p^v) has v ≥ 1 and is a nontrivial local ring, so idemEquivBool applies",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01.idem_eq_zero_or_one",
+        "description": "In a prime-power ring ZMod (p^v) with v ≥ 1 the only idempotents are 0 and 1; the fact that makes idemEquivBool a genuine equivalence with Bool",
+        "module": "Proofs.AutomorphicNumberOQ01"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01.idemCongr",
+        "description": "Idempotents transport across a multiplicative isomorphism; used with (ZMod.equivPi _).toMulEquiv to move the idempotent subtype into the CRT product ring",
+        "module": "Proofs.AutomorphicNumberOQ01"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01.idemPi",
+        "description": "An idempotent of a dependent product ring is exactly a family of idempotents of the factors; the Π-type equivalence that splits the transported idempotent into per-prime local idempotents",
+        "module": "Proofs.AutomorphicNumberOQ01"
+      }
+    ],
+    "dateAdded": "2026-07-05",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AutomorphicNumberOQ01",
+      "Proofs.AutomorphicNumberOQ01OQ02OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "AutomorphicNumberOQ01",
+      "AutomorphicNumberOQ01OQ02OQ01"
+    ],
+    "namespace": "AutomorphicNumberOQ01OQ02OQ01OQ02",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 3,
+    "path": "Proofs/AutomorphicNumberOQ01OQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "card_idempotents_via_bool",
+      "type": "headline",
+      "statement": "[NeZero m] → 1 ≤ k → Fintype.card {e : ZMod (m ^ k) // e * e = e} = 2 ^ m.primeFactors.card",
+      "description": "The structural bijection idemEquivPrimeBool recovers the parent count 2^ω(m), now visibly as the number of subsets of the prime factors: Fintype.card_congr through the equivalence with (m^k).primeFactors → Bool, then Fintype.card_pi collapses ∏ (card Bool) = ∏ 2 into 2^(#primeFactors), and Nat.primeFactors_pow drops the exponent k.",
+      "significance": "Upgrades the parent's bare count of idempotents to a transparent count of Boolean choices: 2^ω(m) is a power of two BECAUSE the idempotents are the vertices of a Boolean cube of dimension ω(m), one Bool per prime factor. The proof exhibits the count as a corollary of the explicit bijection idemEquivPrimeBool rather than as an abstract cardinality identity."
+    },
+    {
+      "name": "idemEquivPrimeBool",
+      "type": "supporting",
+      "statement": "[NeZero m] → 1 ≤ k → {e : ZMod (m ^ k) // e * e = e} ≃ ((m ^ k).primeFactors → Bool)",
+      "description": "The global structural bijection: every idempotent of ZMod (m^k) is exactly a per-prime Bool choice. Transport an idempotent across the Chinese-Remainder product ZMod.equivPi (idemCongr), split it componentwise into local idempotents (idemPi), and name each local idempotent by a Bool (idemEquivBool), assembled factor-by-factor with Equiv.piCongrRight.",
+      "significance": "The structural content the parent's bare count 2^ω(m) leaves implicit: it identifies each idempotent with the subset {p : the local value is 1} ⊆ primeFactors(m), making the idempotents into a concrete Boolean cube and the power-of-two count into a subset count."
+    },
+    {
+      "name": "idemEquivBool",
+      "type": "supporting",
+      "statement": "{p : ℕ} → [Fact p.Prime] → {v : ℕ} → 0 < v → {a : ZMod (p ^ v) // a * a = a} ≃ Bool",
+      "description": "The local factor: in a prime-power ring ZMod (p^v) with p prime and v ≥ 1 the only idempotents are 0 and 1 (idem_eq_zero_or_one), so the idempotent subtype is Bool with true ↔ 1 and false ↔ 0. This is the explicit Bool-named form of the sibling's cardinality fact idem_card_prime_pow.",
+      "significance": "The atom of the whole bijection: naming the two local idempotents by a single Bool is what turns the CRT decomposition into a function primeFactors → Bool, exhibiting the idempotents as independent 0/1 choices across the primes."
+    }
+  ],
+  "sections": [
+    {
+      "id": "local-factor-bool",
+      "title": "Part I: The local factor — two idempotents, named by Bool",
+      "startLine": 57,
+      "endLine": 78,
+      "summary": "idemEquivBool: for a prime-power ring ZMod (p^v) with v ≥ 1, the idempotent subtype is equivalent to Bool (true ↔ 1, false ↔ 0). The forward map decides a.1 = 1; the inverse sends b to cond b 1 0. The two round-trips use idem_eq_zero_or_one (only 0 and 1 are idempotent in the local ring) and zero_ne_one (nontriviality from Fact (1 < p^v)).",
+      "mathContext": "A finite local ring ℤ/p^v has exactly the two trivial idempotents 0 and 1, so its idempotent set is a two-element type — canonically Bool."
+    },
+    {
+      "id": "global-bijection",
+      "title": "Part II: The global structural bijection",
+      "startLine": 80,
+      "endLine": 110,
+      "summary": "idemEquivPrimeBool composes three equivalences: idemCongr (ZMod.equivPi hn).toMulEquiv transports idempotents of ZMod (m^k) across the finite-product CRT isomorphism; idemPi splits the transported idempotent into a family of local idempotents; Equiv.piCongrRight applies idemEquivBool at each prime (each exponent positive by factorization_pos_of_dvd). card_idempotents_via_bool then reads off 2^ω(m) via Fintype.card_pi, Fintype.card_bool, Finset.prod_const and Nat.primeFactors_pow.",
+      "mathContext": "ℤ/m^k ≅ ∏ over the distinct primes p of m of the local ring ℤ/p^{v_p}, so an idempotent is a function p ↦ (0 or 1) — a subset of primeFactors(m), giving 2^ω(m) idempotents."
+    },
+    {
+      "id": "unitary-divisors",
+      "title": "Part III: Unitary divisors and concrete correspondences",
+      "startLine": 112,
+      "endLine": 143,
+      "summary": "unitaryDivisors n := n.divisors.filter (fun d => Nat.Coprime d (n / d)) collects the divisors d ∣ n with gcd(d, n/d) = 1 — equivalently d takes at each prime either the full prime-power p^v_p(n) or 1, so unitary divisors also biject with subsets of primeFactors(n). Four decide-checked examples exhibit the correspondence: unitaryDivisors 12 = {1,3,4,12} and (card = 4) for ω(12) = 2, (unitaryDivisors 30).card = 8 for ω(30) = 3, and unitaryDivisors 9 = {1,9} for the prime power ω(9) = 1. These decide only through Nat.divisors.filter / Nat.Coprime, never reducing Nat.primeFactors.",
+      "mathContext": "A unitary divisor d ∣ n (gcd(d, n/d) = 1) chooses, at each prime, the full prime-power or 1; unitary divisors biject with subsets of primeFactors(n) and hence with the idempotents of ℤ/n, matching the count 2^ω(n)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Automorphic numbers — whose squares end in the number itself (5²=25, 76²=5776) — are an old piece of recreational number theory whose modern framing is ring-theoretic: an automorphic residue mod 10^k is exactly an idempotent of ℤ/10^k. The parent tower formalized the base-10 story and then the general COUNT 2^ω(m) of idempotents of ℤ/m^k. But a count is only a shadow of the structure. The idempotents of ℤ/m^k are, by the Chinese Remainder Theorem, tuples of the trivial 0/1 idempotents of the local prime-power factors — a Boolean cube of dimension ω(m). This entry formalizes that Boolean-cube structure explicitly as a bijection with functions primeFactors → Bool, and connects it to the classical notion of unitary divisors of n = m^k.",
+    "problemStatement": "Upgrade the parent's count of the idempotents of ℤ/m^k from a cardinality 2^ω(m) to an explicit structural bijection: identify every idempotent with a per-prime choice of 0 or 1 — a function (m^k).primeFactors → Bool — and exhibit the resulting correspondence with the unitary divisors of n = m^k (divisors d ∣ n with gcd(d, n/d) = 1), which likewise biject with subsets of the prime factors.",
+    "proofStrategy": "Three layers. (1) Local atom (idemEquivBool): a prime-power ring ℤ/p^v (v ≥ 1) is local, so its idempotents are exactly 0 and 1 — name them by a Bool via the sibling's idem_eq_zero_or_one. (2) Global bijection (idemEquivPrimeBool): transport an idempotent of ℤ/m^k across the finite-product CRT isomorphism ZMod.equivPi (idemCongr), split it into local idempotents (idemPi), and apply idemEquivBool at each prime with Equiv.piCongrRight, giving an equivalence with (m^k).primeFactors → Bool. (3) Count (card_idempotents_via_bool): Fintype.card_pi and Fintype.card_bool collapse the equivalence to 2^(#primeFactors), and Nat.primeFactors_pow drops the exponent k to land on 2^ω(m). Unitary divisors are defined as n.divisors.filter (gcd(d, n/d) = 1), and the idempotent ↔ unitary-divisor correspondence is checked concretely by decide for n = 12, 30, 9.",
+    "keyInsights": [
+      "**Idempotents are a Boolean cube**: idemEquivPrimeBool identifies each idempotent of ℤ/m^k with a function primeFactors(m^k) → Bool — an independent 0/1 choice at each prime — so 2^ω(m) is transparently a subset count, not an abstract cardinality.",
+      "**Naming the local idempotents by Bool is the hinge**: idemEquivBool turns the two trivial idempotents 0 and 1 of each local factor ℤ/p^v into a single Bool, which is exactly what converts the CRT decomposition into a function type.",
+      "**Unitary divisors are the same cube, read multiplicatively**: a unitary divisor d ∣ n (gcd(d, n/d) = 1) takes at each prime either the full prime-power or 1, so unitary divisors also biject with subsets of primeFactors(n) — the same 2^ω(n) Boolean cube as the idempotents.",
+      "**decide stays kernel-friendly**: the concrete examples check unitaryDivisors via Nat.divisors.filter and Nat.Coprime (kernel-reducible), never reducing the well-founded Nat.primeFactors recursion, keeping the entry verified with only foundational axioms."
+    ],
+    "prerequisites": [
+      "Idempotents in a commutative ring (e² = e) and the Boolean algebra they form",
+      "The ring ℤ/nℤ and the Chinese Remainder Theorem for ℤ/m^k as a product over prime powers",
+      "Local rings and the fact that a prime-power ring ℤ/p^v has only the trivial idempotents 0 and 1",
+      "Equivalences of types (Equiv) and their composition; Fintype.card_pi",
+      "Unitary divisors: d ∣ n with gcd(d, n/d) = 1, and the arithmetic function ω(n)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Every idempotent of ℤ/m^k is exactly a per-prime choice of 0 or 1: idemEquivPrimeBool is an explicit bijection between the idempotents and functions (m^k).primeFactors → Bool, and card_idempotents_via_bool re-derives the parent count 2^ω(m) as the number of subsets of the prime factors. The proof names the two trivial idempotents of each local prime-power factor by a Bool (idemEquivBool), transports across the Chinese Remainder isomorphism, and splits componentwise. The classical unitary divisors of n = m^k — divisors d with gcd(d, n/d) = 1 — biject with the same subsets, and the correspondence is checked concretely for n = 12, 30, 9. Machine-checked with no axioms and no sorries.",
+    "implications": "This makes the automorphic-number count structural: the 2^ω(m) idempotents are the vertices of a Boolean cube of dimension ω(m), of which the parent's four residues mod 10^k are the 2-dimensional case. The Bool-per-prime bijection and the unitary-divisor viewpoint provide an effective enumeration of the idempotents and set up the full BooleanAlgebra / power-set isomorphism as the natural next step.",
+    "openQuestions": [
+      "Prove the general finite-set bijection powerset(primeFactors n) ≃ unitaryDivisors n, upgrading the concrete decide-checks for n = 12, 30, 9 into #(unitaryDivisors n) = 2^ω(n) for all n, and hence #idempotents = #unitaryDivisors in full generality.",
+      "Exhibit the explicit idempotent attached to a unitary divisor d ∣ n as the CRT element that is 1 on the d-part and 0 on the n/d-part, realizing the idempotents ↔ unitary-divisors bijection as a definable map rather than a case-checked correspondence.",
+      "Upgrade idemEquivPrimeBool to a BooleanAlgebra isomorphism between the idempotents of ℤ/m^k and the power set 𝒫(primeFactors m), identifying meet = e·f, join = e+f−ef, and complement = 1−e with the set operations."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "automorphic-number-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: this entry upgrades the parent's COUNT of 2^ω(m) idempotents of ℤ/m^k to an explicit structural bijection with per-prime Bool choices (idemEquivPrimeBool), and connects the count to the unitary divisors of m^k — answering the parent's open question about describing idempotents via unitary divisors."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Recovers `proofs/Proofs/AutomorphicNumberOQ01OQ02OQ01OQ02.lean` (sourced from `origin/research/automorphic-oq01020102-recover`) and adds gallery data, repairing the two failing illustrative examples so the entry builds cleanly as **verified / 0-axiom**.

The main theorem `card_idempotents_via_bool` and all definitions (`idemEquivBool`, `idemEquivPrimeBool`, `unitaryDivisors`) already compiled. Only two illustrative `example` blocks failed: they combined an idempotent-count fact with a `unitaryDivisors` count and closed it with `decide`, which the Lean kernel cannot reduce because it hits `Nat.primeFactors` (well-founded recursion the kernel will not evaluate).

## Fix (Curator Option B — decide-friendly variants)

Replaced the two failing joint-equality examples with:

```lean
example : (unitaryDivisors 12).card = 4 := by decide
example : (unitaryDivisors 30).card = 8 := by decide
```

These reduce only through `Nat.divisors.filter` / `Nat.Coprime` (both kernel-reducible), preserving the demonstrative value (ω(12)=2 → 4 unitary divisors; ω(30)=3 → 8) while the separate `card_idempotents_via_bool` theorem supplies the `2^ω(m)` idempotent count. **No `native_decide`**, so the entry stays `verified`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AutomorphicNumberOQ01OQ02OQ01OQ02` — **exits 0**, `Build completed successfully (7745 jobs)`.
- `#print axioms card_idempotents_via_bool` (checked during build) → `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool`, no `sorryAx`.
- `grep sorry` → 0 non-comment sorries; no `native_decide`; no `axiom` declarations.
- `pnpm build` — completes; no validation errors or warnings for slug `automorphic-number-oq-01-oq-02-oq-01-oq-02` (pre-existing gallery-wide validation errors are unrelated and unchanged).

## Gallery data

Modeled on the parent `automorphic-number-oq-01-oq-02-oq-01`:
- `meta.json` — `status: verified`, `badge: original`, `sorries: 0`, `axiomCount: 0`, `lineCount: 143`, `theoremCount: 1`, `definitionCount: 3`, cross-reference to the parent (extends).
- `annotations.json` — 5 annotations (docstring concept, `idemEquivBool`, `idemEquivPrimeBool`, `card_idempotents_via_bool`, unitary-divisors section).

## Files

- `proofs/Proofs/AutomorphicNumberOQ01OQ02OQ01OQ02.lean` (new, 143 lines)
- `src/data/proofs/automorphic-number-oq-01-oq-02-oq-01-oq-02/meta.json` (new)
- `src/data/proofs/automorphic-number-oq-01-oq-02-oq-01-oq-02/annotations.json` (new)

Closes #35067

🤖 Generated with [Claude Code](https://claude.com/claude-code)