### PR TITLE
fix(research/db): repair Seeker candidate-pool feed (POOL_PATH + status-downgrade guard)

### DIFF
--- a/research/db/migrate.py
+++ b/research/db/migrate.py
@@ -66,11 +66,33 @@ def import_candidate_pool(conn: sqlite3.Connection):
         }
         status = status_map.get(status, "available")
 
+        # Status-downgrade guard (see #26802): never let a re-run from a stale
+        # input file resurrect a protected problem back to 'available'. If the
+        # existing DB row is completed/graduated/in-progress/blocked and the
+        # incoming status is 'available', keep the existing status. All other
+        # columns are refreshed from the incoming record, and non-downgrade
+        # status transitions are applied normally.
         cursor.execute("""
-            INSERT OR REPLACE INTO problems (
+            INSERT INTO problems (
                 slug, title, status, tier, significance, tractability,
                 statement_plain, tags, last_updated
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(slug) DO UPDATE SET
+                status = CASE
+                    WHEN excluded.status = 'available'
+                         AND problems.status IN (
+                             'completed', 'graduated', 'in-progress', 'blocked'
+                         )
+                    THEN problems.status
+                    ELSE excluded.status
+                END,
+                title = excluded.title,
+                tier = excluded.tier,
+                significance = excluded.significance,
+                tractability = excluded.tractability,
+                statement_plain = excluded.statement_plain,
+                tags = excluded.tags,
+                last_updated = excluded.last_updated
         """, (
             slug,
             candidate.get("name", slug),

--- a/research/db/sync_pool.py
+++ b/research/db/sync_pool.py
@@ -20,7 +20,10 @@ import difflib
 
 SCRIPT_DIR = Path(__file__).parent
 DB_PATH = SCRIPT_DIR / "knowledge.db"
-POOL_PATH = SCRIPT_DIR.parent / "candidate-pool.json"
+# Write directly to the CONSUMED pool that Seeker/Researcher agents read.
+# Previously this pointed at research/candidate-pool.json (SCRIPT_DIR.parent),
+# which no consumer reads, leaving the real pool permanently out of sync. See #26802.
+POOL_PATH = SCRIPT_DIR.parent.parent / ".lean" / "state" / "candidate-pool.json"
 
 
 def get_connection() -> sqlite3.Connection:
@@ -169,7 +172,8 @@ def main():
         print(f"\n[DRY RUN] Would write {len(pool_data['candidates'])} candidates to {POOL_PATH}")
         return
 
-    # Write the file
+    # Write the file (ensure the consumed .lean/state directory exists)
+    POOL_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(POOL_PATH, 'w') as f:
         f.write(new_content)
 

--- a/research/db/test_status_guard.py
+++ b/research/db/test_status_guard.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Regression test for the migrate.py status-downgrade guard and the
+sync_pool.py POOL_PATH target. See issue #26802.
+
+Runnable standalone (no pytest required):
+    python3 research/db/test_status_guard.py
+
+The functions are also named test_* so pytest can collect them if available.
+
+These tests operate ONLY on temporary databases and temporary output paths.
+They never touch the live research/db/knowledge.db or the consumed
+.lean/state/candidate-pool.json that Seeker/Researcher agents read.
+"""
+
+import json
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import migrate  # noqa: E402
+import sync_pool  # noqa: E402
+
+
+def _fresh_conn(schema_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    with open(schema_path) as f:
+        conn.executescript(f.read())
+    return conn
+
+
+def _write_pool(path: Path, candidates: list) -> None:
+    path.write_text(json.dumps({"candidates": candidates}))
+
+
+def _status(conn: sqlite3.Connection, slug: str):
+    row = conn.execute(
+        "SELECT status FROM problems WHERE slug = ?", (slug,)
+    ).fetchone()
+    return row["status"] if row else None
+
+
+def test_guard_preserves_protected_statuses(tmp_path=None):
+    """A stale 'available' input must NOT downgrade protected DB rows."""
+    tmp = Path(tmp_path or tempfile.mkdtemp())
+    conn = _fresh_conn(SCRIPT_DIR / "schema.sql")
+
+    # Seed the DB with one row in each protected status.
+    protected = ["completed", "graduated", "in-progress", "blocked"]
+    for i, st in enumerate(protected):
+        conn.execute(
+            "INSERT INTO problems (slug, title, status) VALUES (?, ?, ?)",
+            (f"protected-{i}", f"Protected {i}", st),
+        )
+    conn.commit()
+
+    # A stale candidate pool that marks EVERYTHING as available.
+    pool = tmp / "stale-pool.json"
+    _write_pool(pool, [
+        {"id": f"protected-{i}", "name": f"Protected {i}", "status": "available"}
+        for i in range(len(protected))
+    ])
+
+    # Point migrate at the stale pool and run the guarded import.
+    orig = migrate.CANDIDATE_POOL
+    try:
+        migrate.CANDIDATE_POOL = pool
+        migrate.import_candidate_pool(conn)
+    finally:
+        migrate.CANDIDATE_POOL = orig
+
+    for i, st in enumerate(protected):
+        got = _status(conn, f"protected-{i}")
+        assert got == st, (
+            f"guard failed: protected-{i} was {st}, resurrected to {got}"
+        )
+    conn.close()
+    print("PASS: protected statuses survive a stale 'available' re-run")
+
+
+def test_guard_allows_forward_transitions(tmp_path=None):
+    """Non-downgrade transitions and new inserts still apply."""
+    tmp = Path(tmp_path or tempfile.mkdtemp())
+    conn = _fresh_conn(SCRIPT_DIR / "schema.sql")
+
+    # Existing available row that legitimately advances to in-progress.
+    conn.execute(
+        "INSERT INTO problems (slug, title, status) VALUES (?, ?, ?)",
+        ("mover", "Mover", "available"),
+    )
+    # Existing completed row that is legitimately updated to completed again
+    # (idempotent) — must remain completed, and a completed->blocked change
+    # (not a downgrade to available) must be honored.
+    conn.execute(
+        "INSERT INTO problems (slug, title, status) VALUES (?, ?, ?)",
+        ("finisher", "Finisher", "completed"),
+    )
+    conn.commit()
+
+    pool = tmp / "pool.json"
+    _write_pool(pool, [
+        {"id": "mover", "name": "Mover", "status": "in-progress"},
+        {"id": "finisher", "name": "Finisher", "status": "blocked"},
+        {"id": "brand-new", "name": "Brand New", "status": "available"},
+    ])
+
+    orig = migrate.CANDIDATE_POOL
+    try:
+        migrate.CANDIDATE_POOL = pool
+        migrate.import_candidate_pool(conn)
+    finally:
+        migrate.CANDIDATE_POOL = orig
+
+    assert _status(conn, "mover") == "in-progress", "forward transition lost"
+    assert _status(conn, "finisher") == "blocked", "non-downgrade change lost"
+    assert _status(conn, "brand-new") == "available", "new insert missing"
+    conn.close()
+    print("PASS: forward transitions and new inserts still apply")
+
+
+def test_pool_path_targets_consumed_state():
+    """sync_pool.POOL_PATH must resolve to .lean/state/candidate-pool.json."""
+    p = sync_pool.POOL_PATH
+    assert p.name == "candidate-pool.json", p
+    assert p.parent.name == "state", p
+    assert p.parent.parent.name == ".lean", p
+    # Repo root is two levels above research/db/.
+    assert p.parent.parent.parent == SCRIPT_DIR.parent.parent, p
+    print(f"PASS: sync_pool.POOL_PATH -> {p}")
+
+
+if __name__ == "__main__":
+    test_pool_path_targets_consumed_state()
+    test_guard_preserves_protected_statuses()
+    test_guard_allows_forward_transitions()
+    print("\nAll status-guard regression tests passed.")

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -178,6 +178,8 @@ You are the **seeker** agent. Your mission is to keep the research pipeline fed 
    # script writes, interleaving stdout progress lines into the JSON and
    # corrupting the reservoir. (Caused 100+ no-op replenish cycles.)
    npx tsx .lean/scripts/extract-problems.ts --json 2>/dev/null
+   # sync_pool.py writes directly to the consumed pool at
+   # .lean/state/candidate-pool.json (see #26802). No copy step is needed.
    python3 research/db/sync_pool.py 2>/dev/null
    \`\`\`
 
@@ -194,11 +196,11 @@ You are the **seeker** agent. Your mission is to keep the research pipeline fed 
    - **CRITICAL - Database-first workflow**: When adding new problems, you MUST:
      a. Ensure database exists: \`if [ ! -f research/db/knowledge.db ]; then python3 research/db/migrate.py; fi\`
      b. Insert into database: \`sqlite3 research/db/knowledge.db "INSERT INTO problems ..."\`
-     c. Regenerate pool JSON: \`python3 research/db/sync_pool.py\`
+     c. Regenerate pool JSON: \`python3 research/db/sync_pool.py\` (writes .lean/state/candidate-pool.json directly)
      d. Then initialize workspace: \`./.lean/scripts/research.sh init <slug>\`
      e. Fill in \`research/problems/<slug>/problem.md\` and any matching site JSON
      f. Validate the filled stub: \`npx tsx scripts/research/validate-seeker-stubs.ts <slug>\`
-   - Without steps (a-c), Researchers will NOT see the new problems in candidate-pool.json
+   - Without steps (a-c), Researchers will NOT see the new problems in the consumed .lean/state/candidate-pool.json
    - Without step (f), unfilled template placeholders may leak into the public gallery
    - **After each problem is selected**, create a completion signal for stats tracking:
      \`\`\`bash


### PR DESCRIPTION
Closes #26802

Implements Steps 1, 2, and 4 of the curator's 2026-07-05 fix plan. Step 3 (one-time DB reconciliation of the inflated `available` rows) is deferred to a follow-up per the curator's scope note — this PR does **not** run a live sync (the DB is still inflated at 117 available vs. 18 in the consumed pool, so writing DB truth now would resurrect phantom-completes into the pool live agents read).

## Changes

### `research/db/sync_pool.py` (Step 1 — POOL_PATH drift)
- `POOL_PATH` now resolves to `.lean/state/candidate-pool.json` (the path every Seeker/Researcher consumer reads) instead of `research/candidate-pool.json`, which no consumer reads. This was the root cause of the two pools being permanently out of sync.
- Added `POOL_PATH.parent.mkdir(parents=True, exist_ok=True)` so a fresh checkout (where `.lean/state/` does not yet exist) works.

### `research/db/migrate.py` (Step 2 — status-downgrade guard)
- Replaced the unguarded `INSERT OR REPLACE` with `INSERT ... ON CONFLICT(slug) DO UPDATE SET` using a `CASE` that keeps the existing status when the DB row is `completed`/`graduated`/`in-progress`/`blocked` and the incoming status is `available`. A stale re-run can no longer silently resurrect terminal problems back to `available`. Non-downgrade transitions and brand-new inserts still apply; all other columns are refreshed from the incoming record.
- Note: `migrate.py` still reads the tracked `research/candidate-pool.json` as its **input seed** (unchanged), so it is intentionally NOT deleted — doing so would break migrate. The path fix cleanly separates input seed from consumed output.

### `scripts/research/launch-seeker.sh` (Step 4 — stale doc)
- Clarified that `sync_pool.py` now writes the consumed `.lean/state/candidate-pool.json` directly; no copy step is required.

### `research/db/test_status_guard.py` (new)
- Standalone regression test (also pytest-collectable) covering the guard and the `POOL_PATH` target. Uses in-memory / temp DBs only — never touches the live DB or consumed pool.

## Validation evidence

`python3 research/db/test_status_guard.py` — all pass:
- `POOL_PATH -> .../.lean/state/candidate-pool.json`
- protected statuses survive a stale `available` re-run
- forward transitions (`available`→`in-progress`, `completed`→`blocked`) and new inserts still apply

Before/after against a **copy** of the live DB (slug `poincare-conjecture`, currently `completed`), stale pool marking it `available`:
- GUARDED (new migrate.py): `completed` → `completed` (retained)
- UNGUARDED (old `INSERT OR REPLACE`): `completed` → `available` (reproduces the bug)

`sync_pool.py --dry-run` (run against a DB copy, no writes):
`[DRY RUN] Would write 3962 candidates to .../.lean/state/candidate-pool.json`

Confirmed the live consumed pool and the tracked `research/candidate-pool.json` were not modified by validation (dry-run only; guarded run used DB copies).

## Follow-up (not in this PR)
- Step 3: one-time reconciliation to bring the DB's `available` count (117, ~66 phantom-complete) down to the genuinely-open set via `sync_from_json.py` + a gallery-directory sweep, before running the first live `sync_pool.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)