### PR TITLE
Gallery meta: recover 3 fixes from stale local branches (arsinh mainTheorems, alg05 Mathlib deps, angle-trisection count)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -25,6 +25,33 @@
     "definitionCount": 2,
     "dateAdded": "2026-04-26",
     "assumptions": "",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.finite_setOf_isRoot",
+        "description": "A nonzero polynomial has finitely many roots — used for finite_real_roots (each stratum's root fibers are finite)",
+        "module": "Mathlib.Algebra.Polynomial.Roots"
+      },
+      {
+        "theorem": "IsLocalization.integerNormalization_aeval_eq_zero",
+        "description": "Clearing denominators of a rational polynomial preserves its roots — used in algebraic_reals_eq_iUnion_height to pass from ℚ[X] to ℤ[X]",
+        "module": "Mathlib.RingTheory.Localization.Integral"
+      },
+      {
+        "theorem": "Polynomial.aeval_map_algebraMap",
+        "description": "Scalar-tower compatibility of aeval under a base ring map — used for the reverse (ℤ → ℚ) direction of the height decomposition",
+        "module": "Mathlib.RingTheory.Polynomial.Tower"
+      },
+      {
+        "theorem": "Set.countable_iUnion",
+        "description": "A countable union of countable sets is countable — assembles the countable union of finite height strata into the main theorem",
+        "module": "Mathlib.Data.Set.Countable"
+      },
+      {
+        "theorem": "Algebraic.cardinalMk_of_countable_of_charZero",
+        "description": "The algebraic numbers over ℚ in a char-zero field have cardinality ℵ₀ — invoked as a black box to obtain card_algebraic_reals_eq_aleph0 (this corollary is NOT derived from the height argument)",
+        "module": "Mathlib.Algebra.AlgebraicCard"
+      }
+    ],
     "originalContributions": [
       "cantorHeight: The Cantor height function H(p) = natDegree(p) + ∑ᵢ |pᵢ| on integer polynomials",
       "cantorHeight_degree_le: natDegree(p) ≤ H(p) — degree is bounded by height",
@@ -36,7 +63,7 @@
       "algebraic_reals_eq_iUnion_height: IsAlgebraic ℚ x ↔ x ∈ ⋃ₕ algebraicRealsOfHeight(h)",
       "algebraic_reals_countable_via_height: the algebraic reals are countable (main theorem)",
       "algebraicRealsOfHeight_mono: the filtration is monotone — height strata nest",
-      "card_algebraic_reals_eq_aleph0: #(algebraic reals) = ℵ₀",
+      "card_algebraic_reals_eq_aleph0: #(algebraic reals) = ℵ₀ — derived directly from Mathlib's Algebraic.cardinalMk_of_countable_of_charZero (a black-box corollary, not obtained from the height argument)",
       "finite_algebraicReals_bounded_height: explicit characterization of height-bounded algebraic reals"
     ]
   },

--- a/src/data/proofs/angle-trisection-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02-oq-03/meta.json
@@ -23,7 +23,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 223,
-    "theoremCount": 15,
+    "theoremCount": 14,
     "definitionCount": 1
   },
   "references": [
@@ -127,7 +127,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 15
+    "theoremCount": 14
   },
   "crossReferences": [
     {

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01/meta.json
@@ -146,6 +146,43 @@
       "description": "The parent develops the algebraic theory of arsinh (logarithmic closed form, addition/subtraction/doubling laws, concrete values). This entry answers its first open question, supplying the calculus side: arsinh as the antiderivative of 1/√(1+x²) and the resulting definite-integral evaluations."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "hasDerivAt_arsinh'",
+      "type": "theorem",
+      "statement": "theorem hasDerivAt_arsinh' (x : ℝ) : HasDerivAt arsinh (1 / Real.sqrt (1 + x ^ 2)) x",
+      "significance": "This is the exact content of the parent's open question: it establishes that arsinh is an antiderivative of the integrand 1/√(1 + x²) at every real point, i.e. the '∫ 1/√(1 + x²) dx = arsinh x + C' fact in differential form. It bridges the parent's algebraic theory of arsinh to the calculus side.",
+      "description": "Restates Mathlib's Real.hasDerivAt_arsinh, which records the derivative as (√(1 + x²))⁻¹, in the fractional form 1/√(1 + x²) that matches the integrand; the rewrite is discharged by `simpa [one_div]`."
+    },
+    {
+      "name": "integral_one_div_sqrt_one_add_sq",
+      "type": "theorem",
+      "statement": "theorem integral_one_div_sqrt_one_add_sq (a b : ℝ) : ∫ x in a..b, 1 / Real.sqrt (1 + x ^ 2) = arsinh b - arsinh a",
+      "significance": "The definite-integral incarnation of the antiderivative fact, giving the precise Fundamental Theorem of Calculus evaluation of ∫_a^b 1/√(1 + t²) dt over an arbitrary interval. This is the headline capstone result the file is built to prove.",
+      "description": "Applies intervalIntegral.integral_eq_sub_of_hasDerivAt, feeding it the pointwise derivative hasDerivAt_arsinh' and the interval-integrability of the (continuous) integrand."
+    },
+    {
+      "name": "integral_eq_log_sub_log",
+      "type": "theorem",
+      "statement": "theorem integral_eq_log_sub_log (a b : ℝ) : ∫ x in a..b, 1 / Real.sqrt (1 + x ^ 2) = Real.log (b + Real.sqrt (1 + b ^ 2)) - Real.log (a + Real.sqrt (1 + a ^ 2))",
+      "significance": "Expresses the definite integral in fully explicit logarithmic closed form, connecting the FTC evaluation back to the parent's logarithmic identity arsinh x = log(x + √(1 + x²)). It turns the integral into an elementary closed-form expression free of arsinh.",
+      "description": "Rewrites with integral_one_div_sqrt_one_add_sq and then unfolds arsinh to its logarithmic definition via `rfl`."
+    },
+    {
+      "name": "integral_zero_to",
+      "type": "theorem",
+      "statement": "theorem integral_zero_to (b : ℝ) : ∫ x in (0 : ℝ)..b, 1 / Real.sqrt (1 + x ^ 2) = arsinh b",
+      "significance": "The normalised antiderivative with the integration constant pinned to C = 0 by anchoring the lower limit at 0 (where arsinh 0 = 0). This is the genuine 'arsinh x + C with C = 0' antiderivative and the cleanest statement of the open question's answer.",
+      "description": "Specialises integral_one_div_sqrt_one_add_sq at a = 0 and simplifies using arsinh_zero and sub_zero."
+    },
+    {
+      "name": "integral_symmetric",
+      "type": "theorem",
+      "statement": "theorem integral_symmetric (a : ℝ) : ∫ x in (-a)..a, 1 / Real.sqrt (1 + x ^ 2) = 2 * arsinh a",
+      "significance": "Captures the even-integrand / odd-antiderivative symmetry: because 1/√(1 + t²) is even and arsinh is odd, the integral over a symmetric interval [-a, a] collapses to 2·arsinh a. A clean structural consequence of the FTC evaluation.",
+      "description": "Rewrites with integral_one_div_sqrt_one_add_sq and the oddness Real.arsinh_neg, then closes with `ring`."
+    }
+  ],
   "references": [
     {
       "title": "Mathlib4: Analysis.SpecialFunctions.Arsinh",


### PR DESCRIPTION
Cherry-picks three never-PR'd fixes found during local-branch triage (each verified absent from current main by semantic review):

- **arsinh-log-formula-oq-01-oq-01**: adds structured `mainTheorems` (5 entries) — main had the theorems only as prose (from `enrich/arsinh-log-formula-oq-01-oq-01-e5`, 2026-07-02)
- **algebraic-numbers-countable-oq-05**: adds `mathlibDependencies` disclosure (5 module-path entries) — main only mentioned the black-box dependency in prose (from `fix/auditor-alg05-mathlib-deps`, 2026-07-01)
- **angle-trisection-oq-03-oq-02-oq-03**: `theoremCount` 15→14 — the Lean file has exactly 14 theorem/lemma decls; main's 15 is stale (from `fix/auditor-angletrisection-oq030203-theoremcount`, 2026-07-01)

JSON-only; all three files jq-validated. Math/meta PR — no Judge review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)