### PR TITLE
fix: migrate Erdos125 imports to Mathlib v4.26.0 split module paths

### DIFF
--- a/proofs/Proofs/Erdos125PositiveLowerDensity.lean
+++ b/proofs/Proofs/Erdos125PositiveLowerDensity.lean
@@ -54,12 +54,12 @@ The key idea is a **multi-scale density argument**:
 - **DeepMind AlphaProof Nexus (2026-05-21)**: lower density `= 0`. (This file.)
 -/
 
-import Mathlib.Data.Nat.Digits
+import Mathlib.Data.Nat.Digits.Defs
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Order.Filter.Basic
 import Mathlib.Order.LiminfLimsup
-import Mathlib.Topology.Instances.Real
+import Mathlib.Topology.Instances.Real.Lemmas
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Algebra.Order.Group.Pointwise.Interval
 import Mathlib.Data.Set.Card


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos125PositiveLowerDensity.lean` failed to elaborate under Mathlib v4.26.0 because two monolithic modules were split into subdirectories with no umbrella re-export, leaving the old import paths unresolvable. This PR migrates the two imports to their v4.26.0 replacements. Pure import-path fix — no declaration, tactic, or sorry changes.

## Changes
- Line 57: `import Mathlib.Data.Nat.Digits` -> `import Mathlib.Data.Nat.Digits.Defs` (provides `Nat.digits`, used in `def A` / `def B`)
- Line 62: `import Mathlib.Topology.Instances.Real` -> `import Mathlib.Topology.Instances.Real.Lemmas` (provides the real-number topology instances)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Line 57 import replaced with `Digits.Defs` | ✅ | `git diff` shows exactly this line |
| Line 62 import replaced with `Real.Lemmas` | ✅ | `git diff` shows exactly this line |
| Sorry count remains exactly 14 | ✅ | `grep -c "sorry"` returns 14 before and after |
| No new axioms introduced | ✅ | Import-only change; no declarations touched |
| Only this file changed | ✅ | `git diff --stat`: 1 file, +2/-2 |

## Static verification (Docker build could not be run — see note)
The two new import targets exist and the two old monoliths are gone in the pinned Mathlib version:

- Project toolchain: `leanprover/lean4:v4.26.0`
- Reference `mathlib4` checkout at tag `v4.26.0` contains `Mathlib/Data/Nat/Digits/Defs.lean` and `Mathlib/Topology/Instances/Real/Lemmas.lean`; `Digits.lean` and `Instances/Real.lean` no longer exist.
- Sibling files already on `main` use these exact imports and build: `DivisibilityRules.lean` (`Digits.Defs`) and `Erdos285Problem.lean` (`Real.Lemmas`).

## ⚠️ Docker build not executed
Per repo policy the only sanctioned build is `./proofs/scripts/docker-build.sh Proofs.Erdos125PositiveLowerDensity` (direct `lake build` is a memory-bomb hazard and was NOT run). In this session Docker Desktop was stuck on an interactive administrator-password prompt ("Docker Desktop requires privileged access to configure privileged port mapping") that cannot be answered non-interactively, so the daemon never came up. The reviewer/deployer should run the Docker build to confirm elaboration; the static evidence above indicates the two-line migration resolves the imports. The 14 pre-existing sorries (tracked in #20842) are expected and out of scope.

## Scope notes
- Did NOT touch the 14 sorries (tracked separately under #20842).
- Did NOT touch `Erdos331Problem.lean`, which has the same `Digits` import drift — separate scope per the issue.

Closes #35076