### PR TITLE
fix: define IsSidon locally in Erdos152ProblemAPN and repair one grind proof

### DIFF
--- a/proofs/Proofs/Erdos152ProblemAPN.lean
+++ b/proofs/Proofs/Erdos152ProblemAPN.lean
@@ -255,8 +255,21 @@ lemma num_isolated_Z_rel (A : Set ℕ) :
   · exact (Set.Infinite.ncard (h.comp (·.preimage Nat.cast_injective.injOn|>.insert 0|>.subset ↑ fun and⟨A, B, C⟩=>and.eq_zero_or_pos.imp_right fun and' =>⟨⟨ _,B, rfl⟩,by grind⟩))).trans_le bot_le
 
 lemma N_k_Z_rel_1 (A : Set ℕ) : N_k_Z (Z_S (A + A)) (1 : ℤ) = N_k_N (A + A) 1 := by
-  delta N_k_N and N_k_Z Z_S
-  exact (congr_arg ↑_ ↑(Set.ext (by·grind))).trans (Set.ncard_image_of_injective ↑_ Nat.cast_injective)
+  -- Explicit replacement for an AlphaProof `grind` call that fails under Mathlib v4.26.0:
+  -- push the `Nat.cast` image through the "x and x+1 both in the sumset" predicate by hand.
+  have h_im : {x ∈ Z_S (A + A) | x + (1 : ℤ) ∈ Z_S (A + A)}
+      = (fun x : ℕ => (x : ℤ)) '' {x ∈ A + A | x + 1 ∈ A + A} := by
+    ext x
+    simp only [Z_S, Set.mem_setOf_eq, Set.mem_image]
+    constructor
+    · rintro ⟨⟨w, hw, rfl⟩, w₁, hw₁, hcast⟩
+      have hw₁' : w₁ = w + 1 := by exact_mod_cast hcast
+      subst hw₁'
+      exact ⟨w, ⟨hw, hw₁⟩, rfl⟩
+    · rintro ⟨w, ⟨hw, hw1⟩, rfl⟩
+      exact ⟨⟨w, hw, rfl⟩, w + 1, hw1, by norm_cast⟩
+  delta N_k_Z N_k_N
+  exact (congr_arg Set.ncard h_im).trans (Set.ncard_image_of_injective _ Nat.cast_injective)
 
 lemma N_k_Z_rel_2 (A : Set ℕ) : N_k_Z (Z_S (A + A)) (2 : ℤ) = N_k_N (A + A) 2 := by
   norm_num (config := {singlePass :=1}) [N_k_Z, N_k_N, Z_S]

--- a/proofs/Proofs/Erdos152ProblemAPN.lean
+++ b/proofs/Proofs/Erdos152ProblemAPN.lean
@@ -43,6 +43,14 @@ open scoped Pointwise Asymptotics
 
 open Filter
 
+/-- A Sidon set (B₂ set): all pairwise sums of elements are distinct up to commutativity.
+    Defined locally; `IsSidon` is not in Mathlib — it lives in google-deepmind/formal-conjectures
+    (`FormalConjecturesForMathlib/Combinatorics/Basic.lean`). The original `erdos_152.lean` imported
+    that library; this port replaces it with `import Mathlib` and supplies the definition here. -/
+def IsSidon {α : Type*} [Add α] (A : Set α) : Prop :=
+  ∀ᵉ (i₁ ∈ A) (j₁ ∈ A) (i₂ ∈ A) (j₂ ∈ A),
+  i₁ + i₂ = j₁ + j₂ → (i₁ = j₁ ∧ i₂ = j₂) ∨ (i₁ = j₂ ∧ i₂ = j₁)
+
 namespace Erdos152APN
 
 /-- Define `f n` to be the minimum of `|{s | s - 1 ∉ A + A, s ∈ A + A, s + 1 ∉ A + A}|` as `A`


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos152ProblemAPN.lean` (AlphaProof Nexus port of Erdős #152) failed to build with 49 cascading errors. Root cause (per Curator analysis on the issue): the port replaced the upstream `FormalConjectures.Util.ProblemImports` with `import Mathlib`, dropping the `IsSidon` predicate — which was never in Mathlib; it lives in google-deepmind/formal-conjectures. This PR defines it locally and repairs the single residual proof failure that surfaced once the definition was in place.

## Changes

- Add `def IsSidon` (verbatim from `FormalConjecturesForMathlib/Combinatorics/Basic.lean`) after the `open` preamble and before `namespace Erdos152APN`. All ~30 existing usage sites work unchanged; the `delta IsSidon` unfold site keeps working because it remains a `def`.
- Replace the failing `grind` call in `N_k_Z_rel_1` (the one error remaining after the cascade cleared) with an explicit `Set.ext` proof pushing the `Nat.cast` image through the `{x | x ∈ A+A ∧ x+1 ∈ A+A}` predicate, followed by the same `Set.ncard_image_of_injective` step. Minimal, local, semantics-preserving.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `./proofs/scripts/docker-build.sh Proofs.Erdos152ProblemAPN` exits 0 | PASS | "Build completed successfully (7743 jobs). === Build succeeded ===", exit 0; only pre-existing style warnings |
| Zero new sorries | PASS | `grep -c sorry` = 0 (unchanged from pre-failure state) |
| Zero new axiom declarations | PASS | `grep -c '^axiom '` = 0 |
| `IsSidon` defined locally, not imported | PASS | Local `def` in the file; no new imports |
| No other `.lean` files modified | PASS | `git diff --stat`: only `proofs/Proofs/Erdos152ProblemAPN.lean` (15 insertions, 2 deletions) |
| `target_theorem_0` in `Erdos152APN` type-checks | PASS | Full module builds with zero errors, so every declaration including `target_theorem_0` elaborates |

## Test Plan

- Docker-wrapper build (never direct `lake build`): `./proofs/scripts/docker-build.sh Proofs.Erdos152ProblemAPN` — exit 0.
- Before fix: 49 errors rooted at `Unknown identifier IsSidon` (line 51). After `IsSidon` def: exactly 1 residual error (`grind` failed at N_k_Z_rel_1). After explicit proof: 0 errors.

Note: the Curator predicted the def alone would clear all 49 errors; in practice one `grind` call in `N_k_Z_rel_1` still failed under Mathlib v4.26.0 and needed the explicit replacement above — a minimal in-scope repair of the same build failure, not a deep repair.

Closes #35075