### PR TITLE
fix: define IsAddBasisOfOrder and IsSyndetic locally in Erdos741ProblemAPNPartII

### DIFF
--- a/proofs/Proofs/Erdos741ProblemAPNPartII.lean
+++ b/proofs/Proofs/Erdos741ProblemAPNPartII.lean
@@ -63,6 +63,16 @@ open scoped Pointwise
 
 open Set
 
+/-- A set `A : Set ℕ` is an additive basis of order `n` if every natural number
+can be expressed as a sum of `n` elements lying in `A`.
+(From FormalConjecturesForMathlib/Combinatorics/Additive/Basis.lean, instantiated for ℕ.) -/
+def IsAddBasisOfOrder (A : Set ℕ) (n : ℕ) : Prop := ∀ a : ℕ, a ∈ n • A
+
+/-- A set is syndetic if it has bounded gaps: there exists `p` such that every
+interval of length `p` meets the set.
+(From FormalConjecturesForMathlib/Combinatorics/Basic.lean.) -/
+def IsSyndetic (A : Set ℕ) : Prop := ∃ p, ∀ n, (A ∩ Set.Icc n (n + p)).Nonempty
+
 namespace Erdos741APN_II
 
 open MeasureTheory


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos741ProblemAPNPartII.lean` failed the Docker build with 12 cascading `Unknown identifier` errors for `IsAddBasisOfOrder` and `IsSyndetic`. The suspected cause (Mathlib v4.26.0 name drift) was ruled out by the Curator: neither predicate was ever in Mathlib. Both originate from `google-deepmind/formal-conjectures` (`FormalConjecturesForMathlib`), imported by the original AlphaProof Nexus proof via `FormalConjectures.Util.ProblemImports`. The port swapped that for `import Mathlib`, silently dropping both definitions.

This is the same failure class as the sibling issue #35075 (`IsSidon` in `Erdos152ProblemAPN.lean`), fixed by merged PR #35090. The fix pattern is identical: define the missing predicates locally in the proof file.

## Changes

- Added two local `def` declarations between `open Set` and `namespace Erdos741APN_II` (outside the namespace, after all `open` statements so `open scoped Pointwise` and `open Set` are in scope):
  - `def IsAddBasisOfOrder (A : Set ℕ) (n : ℕ) : Prop := ∀ a : ℕ, a ∈ n • A`
  - `def IsSyndetic (A : Set ℕ) : Prop := ∃ p, ∀ n, (A ∩ Set.Icc n (n + p)).Nonempty`
- Both are verbatim from `FormalConjecturesForMathlib` (Basis.lean instantiated for ℕ, and Combinatorics/Basic.lean respectively), matching every usage site in the file.
- Net +10 lines, single file. No other files modified.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `docker-build.sh Proofs.Erdos741ProblemAPNPartII` exits 0, zero errors | ✅ | Full rebuild exit 0: `Built Proofs.Erdos741ProblemAPNPartII`, 7743 jobs |
| Zero new `sorry` declarations | ✅ | `grep -c sorry` = 0 (unchanged from baseline) |
| Zero new `axiom` declarations | ✅ | `grep -c '^axiom '` = 0 |
| Predicates defined locally, not imported | ✅ | Two local `def`s inserted; import Mathlib unchanged |
| No other `.lean` files modified | ✅ | `git diff --stat`: 1 file, 10 insertions |
| `target_theorem_0` type-checks | ✅ | Implied by zero-error build |

## Residual repairs

None. The Curator flagged low-but-nonzero cascade risk (the sibling fix #35090 needed one `grind` repair). This file uses only explicit structural tactics and built cleanly with just the two definitions — no proof bodies required changes.

## Test Plan

Ran `./proofs/scripts/docker-build.sh Proofs.Erdos741ProblemAPNPartII` twice; both exit 0 with no Lean errors. Confirmed sorry/axiom counts unchanged (0/0).

Closes #35078