### PR TITLE
fix: replace hallucinated Set.interIio in Erdos26APN_Tenenbaum port

### DIFF
--- a/proofs/Proofs/Erdos26APN_Tenenbaum.lean
+++ b/proofs/Proofs/Erdos26APN_Tenenbaum.lean
@@ -56,7 +56,7 @@ open scoped Topology
 @[inline]
 noncomputable abbrev partialDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (A : Set β := Set.univ) (b : β) : ℝ :=
-  (Set.interIio (S ∩ A) b).ncard / (Set.interIio A b).ncard
+  ((S ∩ A) ∩ Iio b).ncard / (A ∩ Iio b).ncard
 
 /-- Lower density: liminf of partial densities. -/
 noncomputable def lowerDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
@@ -1075,11 +1075,14 @@ lemma tendsto_X_seq : Filter.Tendsto X_seq Filter.atTop Filter.atTop := by
     omega
   exact StrictMono.tendsto_atTop h_mono
 
+private lemma set_iio_ncard (n : ℕ) : (Set.Iio n).ncard = n := by
+  rw [← Finset.coe_Iio, Set.ncard_coe_finset, Nat.card_Iio]
+
 lemma lowerDensity_le_of_seq (S : Set ℕ) (c : ℝ)
   (h : ∀ m, (((Finset.Icc 1 (X_seq m)).filter (· ∈ S)).card : ℝ) ≤ c * X_seq m) :
   S.lowerDensity ≤ c := by
   simp_rw [Set.lowerDensity, Finset.card_filter] at h⊢
-  simp_all -contextual[Filter.liminf_eq,Set.partialDensity]
+  simp_all -contextual[Filter.liminf_eq,Set.partialDensity,set_iio_ncard]
   delta X_seq at h
   use Real.sSup_le (@ fun and ⟨a, H⟩=>not_lt.mp fun and=>(((tendsto_natCast_atTop_atTop.atTop_mul_const ↑(sub_pos.mpr and)).eventually_gt_atTop (a+1)).frequently (@Filter.eventually_atTop.mpr ⟨a+2,? _,⟩))) @?_
   · use fun and μ=>match and with|n + 1=>(((mul_sub _ _ _).trans_le (sub_le_iff_le_add'.2 (((le_div_iff₀' (by bound)).1 (H (n + 1) (by valid))).trans (?_))))).not_gt


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos26APN_Tenenbaum.lean` failed to build (5 errors). The root cause was a hallucinated identifier `Set.interIio` in the `partialDensity` definition (line 59), which exists nowhere in Mathlib v4.26.0, FormalConjectures, or the AlphaProof Nexus source. Its elaboration failure cascaded into `unsolved goals` / `sorry` warnings downstream.

## Changes
- **Line 59**: Replace `(Set.interIio (S ∩ A) b).ncard / (Set.interIio A b).ncard` with the FormalConjectures-canonical `((S ∩ A) ∩ Iio b).ncard / (A ∩ Iio b).ncard` (the curator-verified fix, matching upstream `partialDensity`).
- **`lowerDensity_le_of_seq`**: After the primary fix, a residual, non-cascade type mismatch surfaced — the terse proof term's coefficient `(Set.Iio (n+1)).ncard` was not definitionally equal to the natCast `↑(n+1)` emitted by `eventually_gt_atTop`. Added a local `private lemma set_iio_ncard : (Set.Iio n).ncard = n` and included it in the `simp_all` at line 1082 so the density denominators normalize to `n`, aligning both sides. The proof term was written assuming this normalization.

No new imports (`import Mathlib` remains the sole import). No new sorries or axioms.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Docker build exits 0, zero errors | ✅ | `./proofs/scripts/docker-build.sh Proofs.Erdos26APN_Tenenbaum` → `Build succeeded`, exit 0, no warnings |
| `grep -c sorry` returns 0 | ✅ | Confirmed 0 |
| `grep -c '^axiom '` returns 0 | ✅ | Confirmed 0 |
| Change confined to the one file | ✅ | `git diff --stat`: 1 file, +5/-2 |
| No new imports | ✅ | Only `import Mathlib` |
| Residual line-1085 error repaired minimally, in-scope | ✅ | Local helper lemma + one simp arg; no statement weakening |

## Notes on the 1085 residual
It did **not** clear on its own after the primary fix. Build 1 (line-59 only) left exactly one clean positivity hole; filling it inline caused nondeterministic elaboration instability (code 135 crash / spurious metavar mismatch) in the giant terse term. The stable, minimal fix was to normalize `ncard (Iio b) → b` in the existing `simp_all`, which is what the proof term was authored against.

## Test Plan
- `./proofs/scripts/docker-build.sh Proofs.Erdos26APN_Tenenbaum` → exit 0, `Built Proofs.Erdos26APN_Tenenbaum`, no warnings.
- `grep -c sorry` = 0, `grep -c '^axiom '` = 0.

Closes #35081