### PR TITLE
feat(research/db): reconcile inflated 'available' statuses + make migrate incremental by default

### DIFF
--- a/research/db/migrate.py
+++ b/research/db/migrate.py
@@ -3,13 +3,21 @@
 Migration script to populate SQLite database from existing JSON research files.
 
 Usage:
-    python migrate.py [--dry-run]
+    python migrate.py [--dry-run] [--reset]
 
 This script:
-1. Creates the database from schema.sql
-2. Imports problems from candidate-pool.json
+1. Ensures the database exists (creating it from schema.sql if missing)
+2. Imports problems from candidate-pool.json (UPSERT; the status-downgrade
+   guard preserves protected statuses on re-runs)
 3. Imports detailed knowledge from src/data/research/problems/*.json
 4. Parses markdown session histories into separate session records
+
+By default the import is INCREMENTAL: it upserts into the existing database so
+the ON CONFLICT status-downgrade guard fires and reconciled statuses survive.
+Pass --reset to drop and recreate the database from scratch (dangerous: the
+guard cannot fire on a fresh empty DB, so a stale candidate-pool.json will
+re-inflate 'available' rows -- only use after reconcile_db.py has patched
+research/candidate-pool.json).
 """
 
 import json
@@ -431,18 +439,23 @@ def print_summary(conn: sqlite3.Connection):
 
 def main():
     dry_run = "--dry-run" in sys.argv
+    reset = "--reset" in sys.argv
 
     if dry_run:
         print("DRY RUN - no changes will be made")
         return
 
-    # Remove existing database
-    if DB_PATH.exists():
+    # --reset drops and recreates the DB from scratch. WARNING: the
+    # status-downgrade guard cannot fire on a fresh empty DB, so a stale
+    # candidate-pool.json will re-inflate 'available' rows. Only use --reset
+    # after reconcile_db.py has patched research/candidate-pool.json.
+    if reset and DB_PATH.exists():
         backup_path = DB_PATH.with_suffix('.db.bak')
         DB_PATH.rename(backup_path)
         print(f"✓ Backed up existing database to {backup_path}")
 
-    # Create new database
+    # Default (incremental): create the schema only if the DB does not exist,
+    # then UPSERT so the guard preserves reconciled statuses.
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
 

--- a/research/db/reconcile_db.py
+++ b/research/db/reconcile_db.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+One-time reconciliation of inflated `status='available'` rows in knowledge.db.
+
+Background (see #35085, #26802, #35077):
+    Seeker's jq-patching of the consumed pool (.lean/state/candidate-pool.json)
+    kept that file honest (~18 available), but the SQLite database drifted to
+    117 'available' rows. Most are phantom-complete: a gallery proof or a
+    verified research commit exists, yet the DB still lists the problem as
+    'available'. Running sync_pool.py against the drifted DB would flood the
+    consumed pool with false availables, defeating the pipeline fix from
+    PR #35077.
+
+This script reclassifies ONLY the rows currently marked 'available', using
+ground-truth evidence, and leaves every other row untouched. It is idempotent
+(a second run is a no-op) and defaults to a non-mutating dry run.
+
+Evidence sources, in priority order:
+    1. Gallery directory  src/data/proofs/<slug>/    -> definitive completion
+    2. git log --all       research/VERIFIED commit    -> definitive completion
+    3. Consumed pool status (Seeker-maintained)        -> deliberate signal
+
+Note on research JSON status: the per-problem research JSON
+(src/data/research/problems/<slug>.json) `status` field is NOT trusted here.
+It frequently reports "graduated"/"COMPLETED" for never-started stubs whose
+markdown is an empty template (verified: shannon-channel-coding-awgn-oq-02-oq-02
+and algebraic-reals-meager-oq-02-oq-01). Only gallery dirs and git commits are
+treated as completion evidence.
+
+Classification rules (applied to each row WHERE status='available'):
+
+    Rule 1  gallery dir exists                         -> completed
+    Rule 2  no gallery, pool status = 'available'      -> available (keep)
+    Rule 3  no gallery, pool status in {completed,
+            in-progress, blocked, surveyed}:
+              - 'completed'   -> completed IF git evidence, else Rule 4
+              - other         -> adopt the pool status
+    Rule 4  no gallery, pool = 'completed' but NO git  -> available
+            evidence (bad jq-patch: notes usually still
+            read "AVAILABLE:")
+    Rule 5  no gallery, not in consumed pool           -> available (keep)
+
+Special override:
+    erdos-1013-oq-02  (pool status: in-progress) -> completed.
+        Rationale: commit e318cffc20f on main (2026-07-05) --
+        "any limit of the ratio is forced to be 1 (no boundedness
+        side-condition) [VERIFIED, 0 sorry/0 axiom]" -- removes the side
+        condition from the earlier straddle result (#35041) and pins the
+        ratio limit to 1, resolving the open question. Six VERIFIED commits
+        (#35036, #35041, #35052, e318cffc, ...) back this. The consumed pool
+        still says in-progress with stale "AVAILABLE:" notes.
+
+Usage:
+    python reconcile_db.py                 # dry run against the live DB
+    python reconcile_db.py --apply         # mutate the DB + patch source pool
+    python reconcile_db.py --repo-root /path/to/lean-genius   # explicit root
+                                           # (required when run from a worktree,
+                                           #  since knowledge.db is gitignored
+                                           #  and lives only in the main checkout)
+"""
+
+import argparse
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+# Statuses a reclassified 'available' row may adopt from the consumed pool.
+_POOL_ADOPTABLE = {"completed", "in-progress", "blocked", "surveyed"}
+
+# Slugs that need an evidence-backed manual decision (documented above).
+SPECIAL_OVERRIDES = {
+    "erdos-1013-oq-02": (
+        "completed",
+        "Special: e318cffc on main [VERIFIED 0/0] forces the ratio limit to 1 "
+        "with no side-condition, resolving the open question (6 VERIFIED commits)",
+    ),
+}
+
+# Trailing Seeker stub suffixes ('-incomplete-01', '-wip-01', chains thereof).
+# The underlying problem shares the base slug, so completion commits reference
+# the base rather than the stub.
+_STUB_SUFFIX_RE = re.compile(r"(?:-(?:incomplete|wip)-\d+)+$")
+
+# Right token-boundary for slug matching in commit subjects: the slug must be a
+# complete token, not a prefix of a longer slug. This both (a) prevents
+# parent/child collisions (e.g. slug 'erdos-153-oq-03' must not match a child
+# 'erdos-153-oq-03-oq-01') and (b) prevents numeric-prefix collisions (e.g.
+# base 'erdos-437' must not match 'erdos-4371'). A trailing '-' is excluded so
+# only end-of-token characters like ')', ':', space follow. This is the
+# curator's "definitive completion check" (git log grep for the slug) made
+# collision-safe -- no message-keyword filter, since legitimate research/result
+# commits do not always use the words 'research'/'verified' in the subject
+# (e.g. "BEC operational converse via Fano (shannon-channel-coding-bec-oq-03)").
+_RIGHT_BOUNDARY = r"(?![0-9a-z-])"
+
+
+class Paths:
+    def __init__(self, repo_root: Path, db: Path | None = None):
+        self.repo_root = repo_root
+        self.db = db or (repo_root / "research" / "db" / "knowledge.db")
+        self.consumed_pool = repo_root / ".lean" / "state" / "candidate-pool.json"
+        self.source_pool = repo_root / "research" / "candidate-pool.json"
+        self.proofs_dir = repo_root / "src" / "data" / "proofs"
+
+
+def load_gallery_slugs(paths: Paths) -> set[str]:
+    if not paths.proofs_dir.is_dir():
+        print(f"WARNING: proofs dir not found: {paths.proofs_dir}")
+        return set()
+    return {p.name for p in paths.proofs_dir.iterdir() if p.is_dir()}
+
+
+def load_consumed_pool(paths: Paths) -> dict[str, dict]:
+    if not paths.consumed_pool.exists():
+        print(f"WARNING: consumed pool not found: {paths.consumed_pool}")
+        return {}
+    data = json.loads(paths.consumed_pool.read_text())
+    return {c["id"]: c for c in data.get("candidates", []) if c.get("id")}
+
+
+def load_git_log(paths: Paths) -> str:
+    """One-shot dump of all commit subjects (per-slug --grep loops time out on
+    this repo's ~58k-commit history)."""
+    result = subprocess.run(
+        ["git", "-C", str(paths.repo_root), "log", "--all",
+         "--oneline", "--no-decorate"],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def has_completion_evidence(slug: str, gitlog: str) -> bool:
+    """True if any commit subject references the slug as a complete token (or,
+    for a Seeker stub, its base slug)."""
+    candidates = [slug]
+    base = _STUB_SUFFIX_RE.sub("", slug)
+    if base != slug:
+        candidates.append(base)
+    patterns = [re.compile(re.escape(c) + _RIGHT_BOUNDARY) for c in candidates]
+    for line in gitlog.splitlines():
+        if any(p.search(line) for p in patterns):
+            return True
+    return False
+
+
+def classify(slug: str, gallery: set[str], pool: dict[str, dict],
+             gitlog: str) -> tuple[str, str, str]:
+    """Return (new_status, rule_code, reason) for an 'available' DB row."""
+    if slug in gallery:
+        return "completed", "Rule 1", "gallery dir exists"
+
+    if slug in SPECIAL_OVERRIDES:
+        new_status, reason = SPECIAL_OVERRIDES[slug]
+        return new_status, "SPECIAL", reason
+
+    entry = pool.get(slug)
+    if entry is None:
+        return "available", "Rule 5", "not in consumed pool (cannot verify)"
+
+    pstatus = entry.get("status", "available")
+
+    if pstatus == "available":
+        return "available", "Rule 2", "consumed pool = available (genuine)"
+
+    if pstatus == "completed":
+        if has_completion_evidence(slug, gitlog):
+            return "completed", "Rule 3", "pool=completed + git research/VERIFIED commit"
+        return ("available", "Rule 4",
+                "pool=completed but NO git evidence (bad jq-patch)")
+
+    if pstatus in _POOL_ADOPTABLE:
+        return pstatus, "Rule 3", f"adopt consumed pool status = {pstatus}"
+
+    # Unknown / invalid pool status -> keep available conservatively.
+    return "available", "Rule 5", f"unhandled pool status = {pstatus!r}"
+
+
+def build_plan(conn: sqlite3.Connection, gallery: set[str],
+               pool: dict[str, dict], gitlog: str) -> list[dict]:
+    rows = conn.execute(
+        "SELECT slug, status FROM problems WHERE status='available' ORDER BY slug"
+    ).fetchall()
+    plan = []
+    for slug, cur in rows:
+        new_status, rule, reason = classify(slug, gallery, pool, gitlog)
+        plan.append({
+            "slug": slug,
+            "current": cur,
+            "new": new_status,
+            "rule": rule,
+            "reason": reason,
+            "changed": new_status != cur,
+        })
+    return plan
+
+
+def print_plan(plan: list[dict]) -> None:
+    by_rule = defaultdict(list)
+    for item in plan:
+        by_rule[item["rule"]].append(item)
+
+    for rule in sorted(by_rule):
+        items = by_rule[rule]
+        changed = sum(1 for i in items if i["changed"])
+        print(f"\n=== {rule}  ({len(items)} slugs, {changed} changed) ===")
+        for i in sorted(items, key=lambda x: x["slug"]):
+            arrow = f"{i['current']} -> {i['new']}"
+            flag = "" if i["changed"] else "  (no change)"
+            print(f"  {i['slug']}")
+            print(f"      {arrow}{flag} :: {i['reason']}")
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    outcome = Counter(i["new"] for i in plan)
+    print(f"Total 'available' rows examined: {len(plan)}")
+    for status in sorted(outcome):
+        print(f"  -> {status:12s}: {outcome[status]}")
+    still_available = outcome.get("available", 0)
+    print(f"\nDB 'available' after reconciliation: {still_available}")
+    print(f"Rows changed: {sum(1 for i in plan if i['changed'])}")
+
+
+def apply_db(conn: sqlite3.Connection, plan: list[dict]) -> int:
+    changed = 0
+    for i in plan:
+        if not i["changed"]:
+            continue
+        conn.execute(
+            "UPDATE problems SET status = ? WHERE slug = ?",
+            (i["new"], i["slug"]),
+        )
+        changed += 1
+    conn.commit()
+    return changed
+
+
+def patch_source_pool(paths: Paths, plan: list[dict]) -> int:
+    """Patch research/candidate-pool.json statuses so migrate.py --reset
+    reproduces the reconciled DB (the guard does not fire on a fresh DB)."""
+    if not paths.source_pool.exists():
+        print(f"WARNING: source pool not found, skipping patch: {paths.source_pool}")
+        return 0
+    data = json.loads(paths.source_pool.read_text())
+    index = {c.get("id"): c for c in data.get("candidates", [])}
+    patched = 0
+    for i in plan:
+        cand = index.get(i["slug"])
+        if cand is None:
+            continue
+        if cand.get("status") != i["new"]:
+            cand["status"] = i["new"]
+            patched += 1
+    paths.source_pool.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    )
+    return patched
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--apply", action="store_true",
+                        help="mutate the DB and patch research/candidate-pool.json "
+                             "(default is a non-mutating dry run)")
+    parser.add_argument("--repo-root", type=Path, default=None,
+                        help="repo root (default: two levels above this script; "
+                             "pass the MAIN checkout when running from a worktree)")
+    parser.add_argument("--db", type=Path, default=None,
+                        help="explicit knowledge.db path (default: <repo-root>/research/db/knowledge.db)")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    repo_root = (args.repo_root or SCRIPT_DIR.parent.parent).resolve()
+    paths = Paths(repo_root, db=args.db.resolve() if args.db else None)
+
+    print(f"Repo root:     {paths.repo_root}")
+    print(f"Database:      {paths.db}")
+    print(f"Consumed pool: {paths.consumed_pool}")
+    print(f"Source pool:   {paths.source_pool}")
+    print(f"Mode:          {'APPLY' if args.apply else 'DRY RUN'}")
+
+    if not paths.db.exists():
+        print(f"\nERROR: database not found: {paths.db}")
+        return 1
+
+    gallery = load_gallery_slugs(paths)
+    pool = load_consumed_pool(paths)
+    gitlog = load_git_log(paths)
+    print(f"\nLoaded {len(gallery)} gallery dirs, {len(pool)} consumed-pool "
+          f"entries, {len(gitlog.splitlines())} git commits.")
+
+    conn = sqlite3.connect(paths.db)
+    try:
+        plan = build_plan(conn, gallery, pool, gitlog)
+        print_plan(plan)
+
+        if not args.apply:
+            print("\n[DRY RUN] No changes written. Re-run with --apply to mutate.")
+            return 0
+
+        changed = apply_db(conn, plan)
+        patched = patch_source_pool(paths, plan)
+        print(f"\n[APPLIED] Updated {changed} DB rows.")
+        print(f"[APPLIED] Patched {patched} statuses in research/candidate-pool.json.")
+        print("Next: run sync_pool.py to regenerate the consumed pool from the DB.")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/db/test_status_guard.py
+++ b/research/db/test_status_guard.py
@@ -134,8 +134,73 @@ def test_pool_path_targets_consumed_state():
     print(f"PASS: sync_pool.POOL_PATH -> {p}")
 
 
+def test_create_database_is_idempotent():
+    """migrate.py now defaults to INCREMENTAL (no --reset): create_database must
+    be safe to run against an already-populated DB (schema uses IF NOT EXISTS),
+    otherwise the incremental default would crash on the second run."""
+    conn = _fresh_conn(SCRIPT_DIR / "schema.sql")
+    conn.execute(
+        "INSERT INTO problems (slug, title, status) VALUES (?, ?, ?)",
+        ("keeper", "Keeper", "completed"),
+    )
+    conn.commit()
+    # Re-running the schema against the existing DB must not error or wipe rows.
+    migrate.create_database(conn)
+    assert _status(conn, "keeper") == "completed", "incremental re-create lost data"
+    conn.close()
+    print("PASS: create_database is idempotent (incremental default is safe)")
+
+
+def test_incremental_reimport_preserves_reconciled_statuses():
+    """Post-reconciliation regression (see #35085): once reconcile_db.py has set
+    the true statuses, an incremental migrate.py re-run against a STALE pool that
+    still marks everything 'available' must NOT resurrect any reconciled row back
+    to 'available'."""
+    tmp = Path(tempfile.mkdtemp())
+    conn = _fresh_conn(SCRIPT_DIR / "schema.sql")
+
+    # Simulate the reconciled DB: a gallery-completed row, an adopted
+    # in-progress row, a blocked row, and a genuinely-available row.
+    reconciled = {
+        "gallery-done": "completed",
+        "adopted-progress": "in-progress",
+        "adopted-blocked": "blocked",
+        "genuine-available": "available",
+    }
+    for slug, st in reconciled.items():
+        conn.execute(
+            "INSERT INTO problems (slug, title, status) VALUES (?, ?, ?)",
+            (slug, slug, st),
+        )
+    conn.commit()
+
+    # A stale source pool that pre-dates reconciliation: everything 'available'.
+    pool = tmp / "stale-pool.json"
+    _write_pool(pool, [
+        {"id": slug, "name": slug, "status": "available"}
+        for slug in reconciled
+    ])
+
+    orig = migrate.CANDIDATE_POOL
+    try:
+        migrate.CANDIDATE_POOL = pool
+        migrate.import_candidate_pool(conn)
+    finally:
+        migrate.CANDIDATE_POOL = orig
+
+    for slug, st in reconciled.items():
+        got = _status(conn, slug)
+        assert got == st, (
+            f"reconciled status not preserved: {slug} was {st}, became {got}"
+        )
+    conn.close()
+    print("PASS: incremental re-import preserves reconciled statuses (no resurrection)")
+
+
 if __name__ == "__main__":
     test_pool_path_targets_consumed_state()
     test_guard_preserves_protected_statuses()
     test_guard_allows_forward_transitions()
+    test_create_database_is_idempotent()
+    test_incremental_reimport_preserves_reconciled_statuses()
     print("\nAll status-guard regression tests passed.")


### PR DESCRIPTION
## Summary

One-time reconciliation of `research/db/knowledge.db`, whose `available` count had drifted to **117** while the Seeker-maintained consumed pool held only 18. Most were phantom-complete (a gallery proof or a verified research commit exists, yet the row still read `available`). Running `sync_pool.py` against the drifted DB would have flooded the consumed pool with false availables, defeating the pipeline fix from #35077. This lands Step 3 of #26802 (deferred from #35077).

Adds `reconcile_db.py` (idempotent, dry-run by default, `--apply` to mutate), makes `migrate.py` incremental by default with an opt-in `--reset`, and adds regression tests. The DB mutation itself is gitignored and was applied out-of-band (documented below).

## Changes

- **New `research/db/reconcile_db.py`** — reclassifies only `status='available'` rows from ground truth (gallery dir + `git log` + consumed-pool status). Dry-run by default; `--apply` mutates the DB and patches `research/candidate-pool.json`; `--repo-root` locates the gitignored live data. Prints a per-slug plan with rule codes and per-rule/summary counts. Idempotent (second run: 0 changes).
- **`research/db/migrate.py`** — add `--reset`; incremental UPSERT (guard-protected) is now the default. Previously `main()` always dropped/recreated the DB, which re-inflated `available` because the `ON CONFLICT` downgrade guard cannot fire on a fresh empty DB. (~19 lines.)
- **`research/db/test_status_guard.py`** — add `test_create_database_is_idempotent` (incremental default is safe on an existing DB) and `test_incremental_reimport_preserves_reconciled_statuses` (a stale all-available re-import does not resurrect reconciled rows).

## Classification rules & applied result

| Rule | Criterion | Outcome | Count |
|------|-----------|---------|-------|
| 1 | gallery dir `src/data/proofs/<slug>/` exists | → completed | 69 |
| 2 | no gallery, consumed pool = `available` | keep available | 18 |
| 3 | no gallery, adopt consumed-pool status (`completed` requires a git commit referencing the slug or its `-incomplete`/`-wip` stub base) | → completed (19) / in-progress (2) / blocked (2) / surveyed (1) | 24 |
| 4 | no gallery, pool=`completed` but NO git evidence (bad jq-patch) | keep available | 5 |
| 5 | no gallery, not in consumed pool | keep available | 0 |
| SPECIAL | `erdos-1013-oq-02` | → completed | 1 |

**DB `available`: 117 → 23.** The token-boundary git match (not a keyword filter) is the curator's "definitive completion check" made collision-safe: e.g. `shannon-channel-coding-bec-oq-03` is correctly completed via `BEC operational converse via Fano (...)` even though the subject contains no "research"/"verified" keyword.

### Before / after DB status counts

| status | before | after |
|--------|-------:|------:|
| completed | 3517 | 3606 |
| in-progress | 232 | 234 |
| **available** | **117** | **23** |
| blocked | 72 | 74 |
| surveyed | 0 | 1 |
| skipped | 17 | 17 |
| graduated | 7 | 7 |
| total | 3962 | 3962 |

### `erdos-1013-oq-02` decision → **completed**

Consumed pool says `in-progress` (with stale `AVAILABLE:` notes), but the most recent commit `e318cffc20f` on main (2026-07-05) — *"any limit of the ratio is forced to be 1 (no boundedness side-condition) [VERIFIED, 0 sorry/0 axiom]"* — removes the side condition from the earlier straddle result (#35041) and pins the ratio limit to 1, resolving the open question. Six VERIFIED commits (#35036, #35041, #35052, e318cffc, …) back this. Documented as a `SPECIAL` override in the script.

### Note on the 18–22 estimate → landed at 23

The curator's estimate was "18 genuine + up to 4 suspicious". Evidence-based reconciliation yields **23**: the 4 named-suspicious slugs (`wilson-theorem-oq-01`, `cevas-theorem-oq-01-oq-01`, `tietze-extension-theorem-oq-01-oq-02`, `shannon-channel-coding-awgn-oq-02-oq-02`) plus `algebraic-reals-meager-oq-02-oq-01`. The curator counted the latter as completed by matching its *parent* `algebraic-reals-meager-oq-02`, but the exact slug has no gallery dir and no exact-slug commit; its research JSON is empty (`currentState.phase: NEW`, "Begin problem exploration"), symmetric to `shannon-awgn-oq-02-oq-02` (empty template, `graduated` status is phantom metadata). Keeping a genuinely-open, never-started slug `available` is the correct, safe direction (a Seeker replenishment opportunity), so both are treated identically. Research-JSON `status` is deliberately NOT trusted as completion evidence for this reason.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `reconcile_db.py` created, `--dry-run` (default), per-slug rule codes | ✅ | dry-run prints grouped plan with Rule 1–5/SPECIAL + reason per slug |
| Reduces DB `available` 117 → 18–22 | ⚠️→23 | Evidence-based 23 (one over the soft estimate); justified above |
| All 69 gallery-dir slugs → `completed` | ✅ | Rule 1 = 69 changed |
| All 18 consumed-pool genuine availables stay `available` | ✅ | Rule 2 = 18, 0 changed |
| 4 suspicious slugs stay `available` unless git confirms | ✅ | all 4 in Rule 4, still `available`; git=0 |
| `erdos-1013-oq-02` explicitly decided | ✅ | SPECIAL → completed, documented in script + PR |
| `research/candidate-pool.json` patched to match | ✅ | 94 statuses patched; 0 mismatches vs reconciled DB |
| `migrate.py` gains `--reset`; incremental default | ✅ | diff + sandbox test |
| test verifying no resurrection post-reconciliation | ✅ | `test_incremental_reimport_preserves_reconciled_statuses` |
| Dated backup before mutation | ✅ | `knowledge.db.backup.20260706`, `research/candidate-pool.json.backup.20260706`, `.lean/state/candidate-pool.json.backup.20260706` |

## Test Plan

- `python3 -m pytest research/db/test_status_guard.py` → **5 passed**.
- Dry-run against live DB → plan sane vs curator table (Rule 1=69, 2=18, 3=24, 4=5, SPECIAL=1; 94 changed).
- `--apply` → DB `available` 117→23; totals preserved (3962); re-run dry-run = 0 changes (idempotent).
- `sync_pool.py` round-trip → consumed pool `available` = 23, mirrors DB; 0 now-available slugs have a gallery dir or git evidence (no resurrections).
- Sandbox `migrate.main()`: `--reset` reproduces pool statuses; incremental (no `--reset`) with a stale all-available pool preserves statuses; `--reset` with a stale pool re-inflates (why the source pool is patched first).

## Out-of-band (gitignored, not in this PR)

The DB mutation was applied to the live gitignored files: `research/db/knowledge.db` (117→23 available), `research/candidate-pool.json` (94 statuses patched), and `.lean/state/candidate-pool.json` (regenerated by `sync_pool.py`). Dated backups were taken first.

Closes #35085