### PR TITLE
fix(gallery): downgrade fourier-series-oq-02 verified overclaim to formalized/wip (interim, #34767)

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -37,7 +37,7 @@
     "author": "Classical (Bernstein, Zygmund)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fourier_series#Rate_of_convergence",
     "date": "1912",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/FourierSeriesOQ02.lean",
     "tags": [
       "analysis",
@@ -47,7 +47,7 @@
       "coefficient-decay",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
@@ -105,7 +105,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 495,
-    "assumptions": "0 axioms — fully proved via Weierstrass lacunary series construction in FourierSeriesOQ02OQ04.lean.",
+    "assumptions": "Build-broken: FourierSeriesOQ02OQ04.lean (imported for the optimality witness and partial converse) fails to compile against Mathlib 4.26.0 with ~30 API drift errors plus one genuine math gap. Full repair tracked in #34767 (loom:blocked). Revert to status: verified / badge: original once #34767 migration passes docker-build.sh Proofs.FourierSeriesOQ02OQ04.",
     "theoremCount": 19,
     "additionalFiles": [
       "Proofs/FourierSeriesOQ02Incomplete01.lean",


### PR DESCRIPTION
## Summary

Interim honesty fix for the `fourier-series-oq-02` gallery entry, which claims `status: verified` / `badge: verified` while its dependency `proofs/Proofs/FourierSeriesOQ02OQ04.lean` (imported for the optimality witness and partial converse) does not compile against pinned Mathlib 4.26.0 (~30 API drift errors + one genuine math gap). Per the Axiom Integrity Policy (overclaiming "verified" damages credibility), this downgrades the entry until the full migration lands.

## Changes (single file, `meta` block only)

`src/data/proofs/fourier-series-oq-02/meta.json`:
- `meta.status`: `verified` -> `formalized`
- `meta.badge`: `verified` -> `wip` (note: `verified` was never a valid `ProofBadge` per `src/types/proof.ts`)
- `meta.assumptions`: replaced with a build-broken note referencing #34767 and revert instructions
- `meta.sorries` / `meta.axiomCount`: unchanged at `0` (the breakage is in the imported dependency, not the top-level `FourierSeriesOQ02.lean`)
- `leanFile.*` block: unchanged

## Validation

- JSON well-formedness confirmed (`python3 -m json.tool`).
- `badge: "wip"` is a valid `ProofBadge`; `status: "formalized"` matches the established convention used by 65 existing entries for build-broken/repair-pending gallery items (per curator schema analysis).
- `git diff --stat` shows exactly one changed file.

## Scope

This is the interim downgrade only. The full Mathlib migration remains tracked in #34767 (`loom:blocked`), which stays open. Revert to `status: verified` / `badge: original` once #34767 passes `docker-build.sh Proofs.FourierSeriesOQ02OQ04`.

Closes #35086