### PR TITLE
research: recover 8 unmerged proof-work branches (#35088)

### DIFF
--- a/proofs/Proofs/BellNumbersOQ01OQ03.lean
+++ b/proofs/Proofs/BellNumbersOQ01OQ03.lean
@@ -1,0 +1,89 @@
+/-
+# The row sum of the unsigned Stirling numbers of the first kind is `n!`
+
+The unsigned Stirling number of the first kind `c(n, k) = Nat.stirlingFirst n k`
+counts the permutations of an `n`-element set having exactly `k` disjoint cycles.
+Conditioning on the number of cycles partitions *all* permutations of an
+`n`-element set, so grouping the `n!` permutations by their cycle count gives the
+classical "companion" identity to the Bell / second-kind row sum
+(`bell-numbers-oq-01`):
+
+    Σ_{k=0}^{n} c(n, k) = n!.
+
+Pinned Mathlib carries `Nat.stirlingFirst` with its triangular recurrence
+`c(n+1, k+1) = n·c(n, k+1) + c(n, k)` and a handful of boundary values
+(`stirlingFirst_self`, `stirlingFirst_one_right`, `stirlingFirst_succ_self_left`),
+but it does **not** record that the rows sum to the factorial.  This file fills
+that gap and connects the arithmetic identity to the actual count of permutations.
+
+The proof is a direct induction on `n` using only the triangular recurrence.  The
+`(n+1)`-st row sum splits, via `c(n+1, k+1) = n·c(n, k+1) + c(n, k)`, into
+`n·(Σ_k c(n, k+1)) + (Σ_k c(n, k))`.  Re-indexing turns the first inner sum back
+into the `n`-th row sum — the `k = 0` boundary term `c(n, 0)` that the shift drops
+is killed by the factor `n` (`n·c(n, 0) = 0` for all `n`) — so the recurrence
+collapses to `(n+1)·n! = (n+1)!`.
+
+## Main results (0 sorry, 0 axiom)
+* `mul_stirlingFirst_zero`      — `n · c(n, 0) = 0`.
+* `stirlingFirst_row_sum`       — `Σ_{k≤n} c(n, k) = n!`.
+* `stirlingFirst_row_sum_eq_card_perm` — `Σ_{k≤n} c(n, k) = card (Perm (Fin n))`.
+
+Fully machine-checked, no extra axioms, no `native_decide`.
+-/
+
+import Mathlib.Combinatorics.Enumerative.Stirling
+import Mathlib.Data.Fintype.Perm
+import Mathlib.Tactic
+
+namespace BellNumbersOQ01OQ03
+
+open Finset Nat
+
+/-- `n · c(n, 0) = 0`: the zeroth unsigned Stirling number of the first kind is `1`
+at `n = 0` (where the factor `n` kills the product) and `0` for every `n ≥ 1`. -/
+theorem mul_stirlingFirst_zero (n : ℕ) : n * Nat.stirlingFirst n 0 = 0 := by
+  cases n with
+  | zero => simp
+  | succ n => simp [Nat.stirlingFirst_succ_zero]
+
+/-- **Row sum of the unsigned Stirling numbers of the first kind.**
+`Σ_{k=0}^{n} c(n, k) = n!`.  Summing the number of `n`-permutations with exactly
+`k` cycles over all `k` recovers the total number `n!` of permutations.  Absent
+from pinned Mathlib, which records only boundary values of `stirlingFirst`. -/
+theorem stirlingFirst_row_sum (n : ℕ) :
+    ∑ k ∈ range (n + 1), Nat.stirlingFirst n k = n ! := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    -- Peel the `k = 0` term (which vanishes) and expand each `c(n+1, i+1)` by the
+    -- triangular recurrence `c(n+1, i+1) = n·c(n, i+1) + c(n, i)`.
+    rw [Finset.sum_range_succ' (fun k => Nat.stirlingFirst (n + 1) k) (n + 1)]
+    simp only [Nat.stirlingFirst_succ_zero, add_zero, Nat.stirlingFirst_succ_succ]
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum]
+    -- Goal: `n · (Σ_{i≤n} c(n, i+1)) + (Σ_{i≤n} c(n, i)) = (n+1)!`.
+    -- The second sum is the induction hypothesis.
+    rw [ih]
+    -- Re-index the first inner sum: `c(n,0) + Σ_{i≤n} c(n, i+1) = Σ_{k≤n+1} c(n,k) = n!`.
+    have hsplit :
+        (∑ i ∈ range (n + 1), Nat.stirlingFirst n (i + 1)) + Nat.stirlingFirst n 0 = n ! := by
+      have h2 : ∑ k ∈ range (n + 1 + 1), Nat.stirlingFirst n k = n ! := by
+        rw [Finset.sum_range_succ (fun k => Nat.stirlingFirst n k) (n + 1),
+          Nat.stirlingFirst_eq_zero_of_lt (Nat.lt_succ_self n), add_zero, ih]
+      rwa [Finset.sum_range_succ' (fun k => Nat.stirlingFirst n k) (n + 1)] at h2
+    -- Multiply `hsplit` by `n`; the boundary term `n·c(n,0)` vanishes.
+    have hnB : n * (∑ i ∈ range (n + 1), Nat.stirlingFirst n (i + 1)) = n * n ! := by
+      have h : n * ((∑ i ∈ range (n + 1), Nat.stirlingFirst n (i + 1)) + Nat.stirlingFirst n 0)
+          = n * n ! := by rw [hsplit]
+      rwa [Nat.mul_add, mul_stirlingFirst_zero, add_zero] at h
+    rw [hnB, Nat.factorial_succ]
+    ring
+
+/-- **The Stirling first-kind row sum equals the number of permutations.**
+`Σ_{k=0}^{n} c(n, k) = |Perm (Fin n)|`.  This is the combinatorial content of
+`stirlingFirst_row_sum`: the left side sorts the permutations of `Fin n` by their
+cycle count, and the right side counts them all at once. -/
+theorem stirlingFirst_row_sum_eq_card_perm (n : ℕ) :
+    ∑ k ∈ range (n + 1), Nat.stirlingFirst n k = Fintype.card (Equiv.Perm (Fin n)) := by
+  rw [stirlingFirst_row_sum, Fintype.card_perm, Fintype.card_fin]
+
+end BellNumbersOQ01OQ03

--- a/proofs/Proofs/BinaryGcdOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ01OQ01.lean
@@ -1,0 +1,157 @@
+/-
+  Binary GCD OQ-01-OQ-01-OQ-01: A matching Ω((log N)²) lower bound for the
+  total bit-operation cost of Stein's binary GCD.
+
+  The parent file `BinaryGcdOQ01OQ01` defines the honest total bit-operation
+  cost `binaryGcdCost a b` (each reduction step on the pair `(a, b)` costs
+  `Nat.size a + Nat.size b` bit operations) and proves the classical *upper*
+  bound
+
+      binaryGcdCost a b ≤ (2·(log₂ a + log₂ b) + 2)·(log₂ a + log₂ b + 2)
+                        = O((log N)²)      (Brent 1976, Knuth TAOCP 4.5.2).
+
+  The open question asks whether this quadratic bound is *tight* — i.e. whether
+  there is an input family on which the cost is genuinely `Ω((log N)²)`, rather
+  than the bound being a loose over-estimate.
+
+  This file answers it affirmatively, and in the sharpest possible form: on the
+  **diagonal power-of-two family** `a = b = 2^k` the cost is not merely bounded
+  below by a quadratic, it is *exactly* a quadratic:
+
+      binaryGcdCost (2^k) (2^k) = (k+1)·(k+2).
+
+  Reason: `(2^k, 2^k)` is an even/even pair, so a single step halves both
+  operands to `(2^(k-1), 2^(k-1))` at cost `2·size(2^k) = 2·(k+1)`. Iterating,
+  the algorithm walks through `(2^k,2^k), (2^(k-1),2^(k-1)), …, (1,1)` and pays
+
+      Σ_{j=0}^{k} 2·(j+1) = (k+1)·(k+2).
+
+  Since `log₂(2^k) = k`, this gives the matching lower bound
+
+      (log₂ N)² ≤ binaryGcdCost N N        for  N = 2^k,
+
+  and, combined with the parent's upper bound, squeezes the cost on this family
+  into `Θ((log N)²)`. The quadratic upper bound is therefore asymptotically
+  tight, not a loose over-estimate.
+
+  Main results.
+
+  * `binaryGcdCost_two_pow_diag`
+        binaryGcdCost (2^k) (2^k) = (k+1)·(k+2)          (exact closed form)
+  * `binaryGcdCost_two_pow_diag_lower`
+        k² ≤ binaryGcdCost (2^k) (2^k)                   (clean quadratic floor)
+  * `binaryGcdCost_diag_log_lower`
+        (log₂ (2^k))² ≤ binaryGcdCost (2^k) (2^k)        (Ω((log N)²), N = 2^k)
+  * `binaryGcdCost_omega_log_sq`
+        an explicit family with cost ≥ (log N)²          (the requested family)
+  * `binaryGcdCost_diag_two_sided`
+        (L/2)² ≤ binaryGcdCost ≤ (2L+2)(L+2), L = log a + log b
+                                                          (Θ((log N)²) squeeze)
+
+  All results are axiom-free (only the foundational propext / Classical.choice /
+  Quot.sound), 0 sorries, no `native_decide`.
+
+  References:
+  - Stein (1967), Binary GCD Algorithm
+  - Brent (1976), analysis of the binary GCD
+  - Knuth, TAOCP 4.5.2
+  - BinaryGcdOQ01OQ01.lean (total bit-operation cost model `binaryGcdCost`)
+-/
+import Mathlib
+import Proofs.BinaryGcdOQ01
+import Proofs.BinaryGcdOQ01OQ01
+
+namespace BinaryGcdOQ01OQ01OQ01
+
+open Nat BinaryGcdOQ01 BinaryGcdOQ01OQ01
+
+/-! ## One even/even reduction step on the diagonal
+
+The engine of the exact formula: on an even positive operand `a`, the diagonal
+pair `(a, a)` is halved to `(a/2, a/2)` at cost `2·Nat.size a`. -/
+
+/-- A single binary-GCD reduction step on a diagonal even pair `(a, a)` with
+    `a` positive and even: it halves both operands, charging `2·Nat.size a`. -/
+theorem cost_even_diag (a : ℕ) (ha : 0 < a) (he : a % 2 = 0) :
+    binaryGcdCost a a = 2 * Nat.size a + binaryGcdCost (a / 2) (a / 2) := by
+  obtain ⟨a', rfl⟩ := Nat.exists_eq_succ_of_ne_zero ha.ne'
+  rw [binaryGcdCost.eq_3]
+  rw [if_pos he, if_pos he]
+  ring
+
+/-! ## Exact cost on the diagonal power-of-two family -/
+
+/-- **Exact total cost on the diagonal power-of-two family.** For every `k`,
+
+        binaryGcdCost (2^k) (2^k) = (k+1)·(k+2).
+
+    The `k+1` even/even reduction steps `(2^k,2^k) → (2^(k-1),2^(k-1)) → … →
+    (1,1)` each cost `2·(j+1)` bit operations, and these sum to `(k+1)(k+2)`. -/
+theorem binaryGcdCost_two_pow_diag (k : ℕ) :
+    binaryGcdCost (2 ^ k) (2 ^ k) = (k + 1) * (k + 2) := by
+  induction k with
+  | zero =>
+      -- (1,1) is odd/odd: one step to (1,0) at cost size 1 + size 1 = 2.
+      have h : binaryGcdCost (0 + 1) (0 + 1) = 2 := by
+        rw [binaryGcdCost.eq_3]
+        norm_num [Nat.size_one, binaryGcdCost_zero_right]
+      simpa using h
+  | succ n ih =>
+      have hev : 2 ^ (n + 1) % 2 = 0 := by
+        rw [pow_succ]; omega
+      have hhalf : 2 ^ (n + 1) / 2 = 2 ^ n := by
+        rw [pow_succ]; omega
+      rw [cost_even_diag (2 ^ (n + 1)) (by positivity) hev, hhalf, ih,
+        Nat.size_pow]
+      ring
+
+/-! ## The matching lower bound -/
+
+/-- **Clean quadratic floor.** `k² ≤ binaryGcdCost (2^k) (2^k)`. -/
+theorem binaryGcdCost_two_pow_diag_lower (k : ℕ) :
+    k ^ 2 ≤ binaryGcdCost (2 ^ k) (2 ^ k) := by
+  rw [binaryGcdCost_two_pow_diag]; nlinarith [sq_nonneg k]
+
+/-- **Ω((log N)²) on the power-of-two family.** Writing `N = 2^k` so that
+    `log₂ N = k`, the cost is bounded below by `(log₂ N)²`. This matches the
+    parent's `O((log N)²)` upper bound: the quadratic bound is tight. -/
+theorem binaryGcdCost_diag_log_lower (k : ℕ) :
+    (Nat.log 2 (2 ^ k)) ^ 2 ≤ binaryGcdCost (2 ^ k) (2 ^ k) := by
+  rw [Nat.log_pow (by norm_num)]
+  exact binaryGcdCost_two_pow_diag_lower k
+
+/-- **The requested input family.** For every `k` there are positive inputs
+    `a = b = 2^k` with `log₂ a = log₂ b = k` whose binary-GCD cost is at least
+    `k² = (log N)²`. This exhibits the `Ω((log N)²)` lower bound explicitly. -/
+theorem binaryGcdCost_omega_log_sq (k : ℕ) :
+    ∃ a b : ℕ, 0 < a ∧ 0 < b ∧ Nat.log 2 a = k ∧ Nat.log 2 b = k ∧
+      k ^ 2 ≤ binaryGcdCost a b :=
+  ⟨2 ^ k, 2 ^ k, by positivity, by positivity,
+    Nat.log_pow (by norm_num) k, Nat.log_pow (by norm_num) k,
+    binaryGcdCost_two_pow_diag_lower k⟩
+
+/-! ## Two-sided squeeze: the cost is Θ((log N)²) on the diagonal family -/
+
+/-- **Matching two-sided bound.** With `L = log₂ a + log₂ b` the combined input
+    bit-length, on the diagonal family `a = b = 2^k` the cost satisfies
+
+        (L/2)² ≤ binaryGcdCost a b ≤ (2·L + 2)·(L + 2).
+
+    Both bounds are quadratic in `L`, so the cost is `Θ(L²) = Θ((log N)²)`; the
+    parent's `O((log N)²)` upper bound is asymptotically tight, not a loose
+    over-estimate. -/
+theorem binaryGcdCost_diag_two_sided (k : ℕ) :
+    ((Nat.log 2 (2 ^ k) + Nat.log 2 (2 ^ k)) / 2) ^ 2 ≤
+        binaryGcdCost (2 ^ k) (2 ^ k) ∧
+      binaryGcdCost (2 ^ k) (2 ^ k) ≤
+        (2 * (Nat.log 2 (2 ^ k) + Nat.log 2 (2 ^ k)) + 2) *
+          (Nat.log 2 (2 ^ k) + Nat.log 2 (2 ^ k) + 2) := by
+  have hlog : Nat.log 2 (2 ^ k) = k := Nat.log_pow (by norm_num) k
+  refine ⟨?_, ?_⟩
+  · -- lower: L/2 = k, so (L/2)² = k² ≤ cost
+    rw [hlog, show (k + k) / 2 = k by omega]
+    exact binaryGcdCost_two_pow_diag_lower k
+  · -- upper: the parent's quadratic bound, specialised to a = b = 2^k
+    exact binaryGcdCost_le_quadratic (2 ^ k) (2 ^ k) (by positivity) (by positivity)
+
+end BinaryGcdOQ01OQ01OQ01

--- a/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02OQ04.lean
@@ -1403,6 +1403,37 @@ theorem survival_covariance_integrand_le_alpha
   simp only [measureReal_def]
   exact davydov_indicator_bound σPair hA hB
 
+/-- **Inner survival integral bound** (S26 inner assembly): integrating the uniform
+α-bound of `survival_covariance_integrand_le_alpha` over the inner window `(0, N]`
+majorises the inner survival integral by `α · N`. This is the inner half of the
+double-integral assembly, feeding the bounded-variable Davydov estimate. -/
+theorem inner_survival_covariance_le_alpha_length
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (σPair : Fin 2 → MeasurableSpace Ω)
+    {f g : Ω → ℝ}
+    (hf : Measurable[σPair 0] f) (hg : Measurable[σPair 1] g)
+    (t N : ℝ) (hN : 0 ≤ N) :
+    |∫ s in Set.Ioc 0 N,
+        (μ.real {ω | t < f ω ∧ s < g ω}
+          - μ.real {ω | t < f ω} * μ.real {ω | s < g ω})|
+      ≤ CentralLimitTheoremOQ02.alphaMixingCoeff μ (σPair 0) (σPair 1) * N := by
+  have hbound : ∀ s ∈ Set.Ioc (0 : ℝ) N,
+      ‖μ.real {ω | t < f ω ∧ s < g ω}
+          - μ.real {ω | t < f ω} * μ.real {ω | s < g ω}‖
+        ≤ CentralLimitTheoremOQ02.alphaMixingCoeff μ (σPair 0) (σPair 1) := by
+    intro s _
+    rw [Real.norm_eq_abs]
+    exact survival_covariance_integrand_le_alpha σPair hf hg t s
+  have hkey := norm_setIntegral_le_of_norm_le_const
+    (μ := volume) (s := Set.Ioc (0 : ℝ) N)
+    (f := fun s => μ.real {ω | t < f ω ∧ s < g ω}
+        - μ.real {ω | t < f ω} * μ.real {ω | s < g ω})
+    measure_Ioc_lt_top hbound
+  rw [Real.norm_eq_abs] at hkey
+  have hmr : volume.real (Set.Ioc (0 : ℝ) N) = N := by
+    rw [Real.volume_real_Ioc, sub_zero, max_eq_left hN]
+  rwa [hmr] at hkey
+
 /-- **Bounded-variable Davydov estimate** (S26, this session): the double-integral
 assembly.
 

--- a/proofs/Proofs/Erdos307Problem.lean
+++ b/proofs/Proofs/Erdos307Problem.lean
@@ -28,9 +28,10 @@
 
 import Mathlib.NumberTheory.Divisors
 import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Rat.Basic
+import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Algebra.BigOperators.Group.Finset
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.ZMod.Basic
 import Mathlib.Tactic
 
 namespace Erdos307
@@ -42,7 +43,7 @@ open Finset BigOperators
 /-- The sum of reciprocals of elements in a finite set.
     For a set S = {a₁, a₂, ..., aₙ}, this computes 1/a₁ + 1/a₂ + ... + 1/aₙ. -/
 noncomputable def reciprocalSum (S : Finset ℕ) : ℚ :=
-  ∑ n in S, (n : ℚ)⁻¹
+  ∑ n ∈ S, (n : ℚ)⁻¹
 
 /-- The product of two reciprocal sums.
     We ask when this equals 1. -/
@@ -113,7 +114,6 @@ theorem cambieExample1Q_sum : reciprocalSum cambieExample1Q = 5/6 := by
 /-- Cambie's first example: (1 + 1/5)(1/2 + 1/3) = 1. -/
 theorem cambieExample1_works : reciprocalProduct cambieExample1P cambieExample1Q = 1 := by
   simp [reciprocalProduct, cambieExample1P_sum, cambieExample1Q_sum]
-  norm_num
 
 /-- **Cambie's Second Example**:
     P = {1, 41}, Q = {2, 3, 7}
@@ -134,14 +134,13 @@ theorem cambieExample2Q_sum : reciprocalSum cambieExample2Q = 41/42 := by
 /-- Cambie's second example: (1 + 1/41)(1/2 + 1/3 + 1/7) = 1. -/
 theorem cambieExample2_works : reciprocalProduct cambieExample2P cambieExample2Q = 1 := by
   simp [reciprocalProduct, cambieExample2P_sum, cambieExample2Q_sum]
-  norm_num
 
 /-- The coprime version is SOLVED: Cambie's examples prove existence. -/
 theorem erdos_307_coprime_solved : ErdosProblem307Coprime := by
   use cambieExample1P, cambieExample1Q
   refine ⟨?_, ?_, cambieExample1P_coprime, cambieExample1Q_coprime, cambieExample1_works⟩
-  · simp [cambieExample1P]; decide
-  · simp [cambieExample1Q]; decide
+  · simp [cambieExample1P]
+  · simp [cambieExample1Q]
 
 /- ## Part IV: The Strengthened Coprime Version (Open) -/
 
@@ -157,19 +156,107 @@ def ErdosProblem307CoprimeStrengthened : Prop :=
 
 /- ## Part V: Constraints on Prime Solutions -/
 
+/-- The integer numerator of `reciprocalSum P`:  `Σ_{p ∈ P} ∏_{q ∈ P\{p}} q`. -/
+def primeNumer (P : Finset ℕ) : ℕ :=
+  ∑ p ∈ P, ∏ q ∈ P.erase p, q
+
+/-- The integer denominator of `reciprocalSum P`:  `∏_{p ∈ P} p`. -/
+def primeDenom (P : Finset ℕ) : ℕ :=
+  ∏ p ∈ P, p
+
+/-- Clearing denominators:  `(Σ 1/p) · (∏ p) = Σ_{p} ∏_{q ≠ p} q`.
+    Requires only that no element is `0` (true for primes). -/
+lemma reciprocalSum_mul_denom (P : Finset ℕ) (hP : ∀ p ∈ P, p ≠ 0) :
+    reciprocalSum P * (primeDenom P : ℚ) = (primeNumer P : ℚ) := by
+  unfold reciprocalSum primeDenom primeNumer
+  push_cast
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro p hp
+  have hpne : (p : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (hP p hp)
+  rw [← Finset.mul_prod_erase P (fun q => (q : ℚ)) hp, inv_mul_cancel_left₀ hpne]
+
+/-- The cleared-denominator INTEGER identity.  From `(Σ1/p)(Σ1/q) = 1` we get
+    `NP · NQ = DP · DQ` in ℕ. -/
+lemma primeNumer_mul_eq (P Q : Finset ℕ)
+    (hP : ∀ p ∈ P, p ≠ 0) (hQ : ∀ q ∈ Q, q ≠ 0)
+    (h : reciprocalProduct P Q = 1) :
+    primeNumer P * primeNumer Q = primeDenom P * primeDenom Q := by
+  have hA := reciprocalSum_mul_denom P hP
+  have hB := reciprocalSum_mul_denom Q hQ
+  unfold reciprocalProduct at h
+  have key : (primeNumer P : ℚ) * (primeNumer Q : ℚ)
+      = (primeDenom P : ℚ) * (primeDenom Q : ℚ) := by
+    have e : (primeNumer P : ℚ) * (primeNumer Q : ℚ)
+        = (reciprocalSum P * reciprocalSum Q)
+            * ((primeDenom P : ℚ) * (primeDenom Q : ℚ)) := by
+      rw [← hA, ← hB]; ring
+    rw [e, h, one_mul]
+  exact_mod_cast key
+
+/-- For a prime `p₀ ∈ P` (with `P` a set of primes), `p₀` does NOT divide the
+    numerator `NP`.  Equivalently `v_{p₀}(Σ_{p∈P} 1/p) = -1`.
+
+    Proof: reduce `NP = Σ_p ∏_{q≠p} q` modulo `p₀` in the field `𝔽_{p₀}`.
+    Every summand with `p ≠ p₀` contains the factor `p₀`, hence vanishes; the
+    `p = p₀` summand is `∏_{q ≠ p₀} q`, a product of primes all distinct from
+    `p₀`, hence a nonzero product in the field. -/
+lemma prime_not_dvd_primeNumer (P : Finset ℕ) (hP : IsSetOfPrimes P)
+    {p₀ : ℕ} (hp₀ : p₀ ∈ P) : ¬ (p₀ ∣ primeNumer P) := by
+  have hp₀prime : Nat.Prime p₀ := hP p₀ hp₀
+  haveI : Fact (Nat.Prime p₀) := ⟨hp₀prime⟩
+  haveI : NeZero p₀ := ⟨hp₀prime.pos.ne'⟩
+  -- Reduce `NP` modulo `p₀`: only the `p = p₀` summand survives.
+  have hcast : ((primeNumer P : ℕ) : ZMod p₀) = ∏ q ∈ P.erase p₀, (q : ZMod p₀) := by
+    unfold primeNumer
+    push_cast
+    exact Finset.sum_eq_single_of_mem p₀ hp₀ (fun b _ hbne =>
+      Finset.prod_eq_zero (Finset.mem_erase.mpr ⟨Ne.symm hbne, hp₀⟩)
+        (ZMod.natCast_self p₀))
+  -- That surviving product is a nonempty product of nonzero units → nonzero.
+  have hne : ((primeNumer P : ℕ) : ZMod p₀) ≠ 0 := by
+    rw [hcast, Finset.prod_ne_zero_iff]
+    intro q hq
+    rw [Finset.mem_erase] at hq
+    have hqprime : Nat.Prime q := hP q hq.2
+    rw [Ne, ZMod.natCast_eq_zero_iff]
+    exact fun hdvdq => hq.1 ((Nat.prime_dvd_prime_iff_eq hp₀prime hqprime).mp hdvdq).symm
+  -- A divisor would force the cast to vanish.
+  intro hdvd
+  exact hne ((ZMod.natCast_eq_zero_iff _ _).mpr hdvd)
+
 /-- If P and Q are sets of primes with product 1, then P ∩ Q = ∅.
 
-    Proof sketch: If p ∈ P ∩ Q, the product would have p² in the denominator
-    somewhere, but also p² in the numerator. The constraint that the product
-    equals 1 (a rational with denominator 1) forces this.
+    Proof: if `p₀ ∈ P ∩ Q`, then `p₀` divides neither numerator `NP`, `NQ`
+    (each prime-reciprocal sum has `p`-adic valuation `-1` at each of its
+    primes, so `p₀ ∤ NP`), hence `p₀ ∤ NP·NQ`.  But the cleared-denominator
+    identity `NP·NQ = DP·DQ` and `p₀ ∣ DP` give `p₀ ∣ NP·NQ` — contradiction.
 
-    Actually, more directly: if p ∈ P ∩ Q, then 1/p appears in both sums,
-    so the product includes (1/p)² = 1/p². But the product of two sums of
-    distinct primes' reciprocals can't simplify to 1 with repeated primes. -/
+    This is the elementary (mod-`p₀`) form of the `p`-adic valuation argument;
+    it is the same proof verified independently in the `erdos-307-oq-02-oq-01`
+    gallery entry (`Erdos307OQ02OQ01.lean`), ported here to discharge the
+    documented sorry in the main file. -/
 theorem prime_sets_disjoint {P Q : Finset ℕ} (hP : IsSetOfPrimes P)
     (hQ : IsSetOfPrimes Q) (hPQ : reciprocalProduct P Q = 1) :
     P ∩ Q = ∅ := by
-  sorry
+  rw [Finset.eq_empty_iff_forall_notMem]
+  intro p₀ hmem
+  rw [Finset.mem_inter] at hmem
+  obtain ⟨hp₀P, hp₀Q⟩ := hmem
+  have hp₀prime : Nat.Prime p₀ := hP p₀ hp₀P
+  -- p₀ divides neither numerator.
+  have hnP : ¬ p₀ ∣ primeNumer P := prime_not_dvd_primeNumer P hP hp₀P
+  have hnQ : ¬ p₀ ∣ primeNumer Q := prime_not_dvd_primeNumer Q hQ hp₀Q
+  have hnPQ : ¬ p₀ ∣ primeNumer P * primeNumer Q := by
+    rw [hp₀prime.dvd_mul]; exact not_or.mpr ⟨hnP, hnQ⟩
+  -- but p₀ divides both denominators, hence their product.
+  have hdP : p₀ ∣ primeDenom P := by
+    unfold primeDenom; exact Finset.dvd_prod_of_mem (fun p => p) hp₀P
+  have heq := primeNumer_mul_eq P Q
+    (fun p hp => (hP p hp).pos.ne') (fun q hq => (hQ q hq).pos.ne') hPQ
+  have hdvd : p₀ ∣ primeNumer P * primeNumer Q := by
+    rw [heq]; exact hdP.mul_right _
+  exact hnPQ hdvd
 
 /-- A lower bound: if P, Q are prime sets with product 1, then
     Σ_{p ∈ P ∪ Q} 1/p ≥ 2.
@@ -183,7 +270,7 @@ theorem prime_reciprocal_sum_lower_bound {P Q : Finset ℕ}
   -- reciprocalSum (P ∪ Q) = reciprocalSum P + reciprocalSum Q when P, Q disjoint
   have hunion : reciprocalSum (P ∪ Q) = reciprocalSum P + reciprocalSum Q := by
     unfold reciprocalSum
-    rw [Finset.sum_union (Finset.disjoint_iff_disjoint_coe.mp hdisj)]
+    rw [Finset.sum_union hdisj]
   rw [hunion]
   -- Let a = reciprocalSum P, b = reciprocalSum Q
   -- We know a * b = 1 and a, b > 0 (sums of positive terms, nonempty)
@@ -198,6 +285,7 @@ theorem prime_reciprocal_sum_lower_bound {P Q : Finset ℕ}
     have ha_le : a ≤ 0 := h
     -- If a ≤ 0, then a * b ≤ 0, contradicting a * b = 1
     have hb_nn : 0 ≤ b := by
+      show (0 : ℚ) ≤ reciprocalSum Q
       unfold reciprocalSum
       apply Finset.sum_nonneg
       intro n _; positivity
@@ -234,7 +322,7 @@ theorem prime_set_size_lower_bound {P Q : Finset ℕ}
     p₁ = 2, p₂ = 3, p₃ = 5, ...
     S_n = 1/2 + 1/3 + 1/5 + ... + 1/pₙ -/
 noncomputable def primeReciprocalPartialSum (n : ℕ) : ℚ :=
-  ∑ i in (Finset.range n).filter (fun k => (k + 1).minFac = k + 1 ∧ k + 1 > 1),
+  ∑ i ∈ (Finset.range n).filter (fun k => (k + 1).minFac = k + 1 ∧ k + 1 > 1),
     ((i + 1) : ℚ)⁻¹
 
 /-
@@ -299,21 +387,23 @@ theorem one_helps_balance {P Q : Finset ℕ} (h1P : 1 ∈ P)
 
 /-- If P = {1, n}, then reciprocalSum P = 1 + 1/n = (n+1)/n.
     For this to multiply to 1, we need reciprocalSum Q = n/(n+1). -/
-theorem pair_with_one (n : ℕ) (hn : n > 0) :
+theorem pair_with_one (n : ℕ) (hn : 2 ≤ n) :
     reciprocalSum ({1, n} : Finset ℕ) = (n + 1 : ℚ) / n := by
-  simp [reciprocalSum]
+  have h1n : (1 : ℕ) ≠ n := by omega
+  have hn0 : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  rw [reciprocalSum, Finset.sum_pair h1n]
+  push_cast
   field_simp
-  ring
 
 /- ## Part X: Alternative Formulations -/
 
 /-- Multiplicative form: Find P, Q with
     ∏_{p ∈ P} p · ∏_{q ∈ Q} q = (Σ subsets give 1). -/
 def MultiplicativeForm (P Q : Finset ℕ) : Prop :=
-  let pProd := ∏ p in P, p
-  let qProd := ∏ q in Q, q
-  pProd * qProd = (∑ S in P.powerset, ∏ p in S, (∏ q in Q, q)) *
-                  (∑ T in Q.powerset, ∏ q in T, (∏ p in P, p))
+  let pProd := ∏ p ∈ P, p
+  let qProd := ∏ q ∈ Q, q
+  pProd * qProd = (∑ S ∈ P.powerset, ∏ p ∈ S, (∏ q ∈ Q, q)) *
+                  (∑ T ∈ Q.powerset, ∏ q ∈ T, (∏ p ∈ P, p))
 
 /-
 Note: The product equals 1 iff LCD(P) · LCD(Q) = (Σ complements),
@@ -336,19 +426,21 @@ private lemma reciprocal_sum_two_primes_le {P : Finset ℕ} (hcard : P.card = 2)
   -- One of them ≥ 3 since a ≠ b and both ≥ 2
   have hab3 : (3 : ℚ) ≤ a ∨ (3 : ℚ) ≤ b := by
     by_contra h; push_neg at h
-    have : a = 2 := by exact_mod_cast (le_antisymm (by linarith) ha.two_le)
-    have : b = 2 := by exact_mod_cast (le_antisymm (by linarith) hb.two_le)
+    have hlt : a < 3 := by exact_mod_cast h.1
+    have hblt : b < 3 := by exact_mod_cast h.2
+    have hA : a = 2 := le_antisymm (by omega) ha.two_le
+    have hB : b = 2 := le_antisymm (by omega) hb.two_le
     exact hab (by omega)
   have ha_pos : (0 : ℚ) < a := by linarith
   have hb_pos : (0 : ℚ) < b := by linarith
   rcases hab3 with h3 | h3
   · -- a ≥ 3, b ≥ 2: 1/a + 1/b ≤ 1/3 + 1/2 = 5/6
-    have : (a : ℚ)⁻¹ ≤ 1 / 3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
-    have : (b : ℚ)⁻¹ ≤ 1 / 2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) hb2
+    have : (a : ℚ)⁻¹ ≤ 1 / 3 := by rw [one_div]; exact inv_anti₀ (by norm_num) h3
+    have : (b : ℚ)⁻¹ ≤ 1 / 2 := by rw [one_div]; exact inv_anti₀ (by norm_num) hb2
     linarith
   · -- a ≥ 2, b ≥ 3: 1/a + 1/b ≤ 1/2 + 1/3 = 5/6
-    have : (a : ℚ)⁻¹ ≤ 1 / 2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) ha2
-    have : (b : ℚ)⁻¹ ≤ 1 / 3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
+    have : (a : ℚ)⁻¹ ≤ 1 / 2 := by rw [one_div]; exact inv_anti₀ (by norm_num) ha2
+    have : (b : ℚ)⁻¹ ≤ 1 / 3 := by rw [one_div]; exact inv_anti₀ (by norm_num) h3
     linarith
 
 /-- No solution with |P| = |Q| = 2 exists among primes.
@@ -377,6 +469,7 @@ private lemma reciprocal_sum_three_primes_le {Q : Finset ℕ} (hcard : Q.card = 
     (hQ : IsSetOfPrimes Q) : reciprocalSum Q ≤ 31 / 30 := by
   obtain ⟨c, t, hct, rfl, ht2⟩ := Finset.card_eq_succ.mp hcard
   obtain ⟨a, b, hab, rfl⟩ := Finset.card_eq_two.mp ht2
+  have hct' : c ∉ ({a, b} : Finset ℕ) := hct
   simp only [Finset.mem_insert, Finset.mem_singleton, not_or] at hct
   obtain ⟨hca, hcb⟩ := hct
   have ha := hQ a (by simp)
@@ -385,13 +478,13 @@ private lemma reciprocal_sum_three_primes_le {Q : Finset ℕ} (hcard : Q.card = 
   have ha2 : (2 : ℚ) ≤ a := by exact_mod_cast ha.two_le
   have hb2 : (2 : ℚ) ≤ b := by exact_mod_cast hb.two_le
   have hc2 : (2 : ℚ) ≤ c := by exact_mod_cast hc.two_le
-  simp only [reciprocalSum, Finset.sum_insert hct, Finset.sum_pair hab]
+  simp only [reciprocalSum, Finset.sum_insert hct', Finset.sum_pair hab]
   -- At least one ≥ 5 (pigeonhole: only 2 primes < 5, namely {2, 3})
   have h5 : 5 ≤ a ∨ 5 ≤ b ∨ 5 ≤ c := by
     by_contra hall; push_neg at hall; obtain ⟨h5a, h5b, h5c⟩ := hall
-    have : a = 2 ∨ a = 3 := by have := ha.two_le; interval_cases a <;> simp_all
-    have : b = 2 ∨ b = 3 := by have := hb.two_le; interval_cases b <;> simp_all
-    have : c = 2 ∨ c = 3 := by have := hc.two_le; interval_cases c <;> simp_all
+    have : a = 2 ∨ a = 3 := by have := ha.two_le; interval_cases a <;> revert ha <;> decide
+    have : b = 2 ∨ b = 3 := by have := hb.two_le; interval_cases b <;> revert hb <;> decide
+    have : c = 2 ∨ c = 3 := by have := hc.two_le; interval_cases c <;> revert hc <;> decide
     rcases ‹a = 2 ∨ a = 3› with rfl | rfl <;> rcases ‹b = 2 ∨ b = 3› with rfl | rfl <;>
       rcases ‹c = 2 ∨ c = 3› with rfl | rfl <;> simp_all
   -- Among any 2 distinct primes, one ≥ 3 (only 1 prime < 3)
@@ -405,29 +498,29 @@ private lemma reciprocal_sum_three_primes_le {Q : Finset ℕ} (hcard : Q.card = 
     exact hxy (by omega)
   -- Bound each reciprocal, then combine
   rcases h5 with h5a | h5b | h5c
-  · have : (a : ℚ)⁻¹ ≤ 1/5 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) (by exact_mod_cast h5a)
+  · have : (a : ℚ)⁻¹ ≤ 1/5 := by rw [one_div]; exact inv_anti₀ (by norm_num) (by exact_mod_cast h5a)
     rcases pair3 b c hb hc (Ne.symm hcb) with h3 | h3
-    · have : (b : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
-      have : (c : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) hc2
+    · have : (b : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_anti₀ (by norm_num) h3
+      have : (c : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_anti₀ (by norm_num) hc2
       linarith
-    · have : (c : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
-      have : (b : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) hb2
+    · have : (c : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_anti₀ (by norm_num) h3
+      have : (b : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_anti₀ (by norm_num) hb2
       linarith
-  · have : (b : ℚ)⁻¹ ≤ 1/5 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) (by exact_mod_cast h5b)
+  · have : (b : ℚ)⁻¹ ≤ 1/5 := by rw [one_div]; exact inv_anti₀ (by norm_num) (by exact_mod_cast h5b)
     rcases pair3 a c ha hc (Ne.symm hca) with h3 | h3
-    · have : (a : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
-      have : (c : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) hc2
+    · have : (a : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_anti₀ (by norm_num) h3
+      have : (c : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_anti₀ (by norm_num) hc2
       linarith
-    · have : (c : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
-      have : (a : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) ha2
+    · have : (c : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_anti₀ (by norm_num) h3
+      have : (a : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_anti₀ (by norm_num) ha2
       linarith
-  · have : (c : ℚ)⁻¹ ≤ 1/5 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) (by exact_mod_cast h5c)
+  · have : (c : ℚ)⁻¹ ≤ 1/5 := by rw [one_div]; exact inv_anti₀ (by norm_num) (by exact_mod_cast h5c)
     rcases pair3 a b ha hb hab with h3 | h3
-    · have : (a : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
-      have : (b : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) hb2
+    · have : (a : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_anti₀ (by norm_num) h3
+      have : (b : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_anti₀ (by norm_num) hb2
       linarith
-    · have : (b : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
-      have : (a : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) ha2
+    · have : (b : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_anti₀ (by norm_num) h3
+      have : (a : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_anti₀ (by norm_num) ha2
       linarith
 
 /-- No solution with |P| = 2 and |Q| = 3 exists among primes.

--- a/proofs/Proofs/FermatDefectOneBounded.lean
+++ b/proofs/Proofs/FermatDefectOneBounded.lean
@@ -1,0 +1,103 @@
+/-
+  Bounded non-existence certificates for the Fermat Defect-One Conjecture
+
+  Companion to `FermatDefectOne.lean`. The headline conjecture
+
+      ∀ n ≥ 3, ∃ primitive (a,b,c) with |aⁿ + bⁿ − cⁿ| = 1
+
+  is verified only at n = 3 (both signs, infinitely often — see
+  `FermatDefectOneFamilies.lean` and `FermatDefectOneNegInfinitude.lean`). For
+  n ≥ 4 *no* witness is known, and the productive research vector recorded in
+  `research/problems/fermat-defect-one/notes/leads.md` is a per-exponent
+  *witness search*: "a single positive hit clears the exponent."
+
+  This file discharges the complementary, fully decidable half of that search:
+  an **exhaustive verification that the smallest defect-one witness at n = 4 and
+  n = 5 — if one exists at all — must have c ≥ 20.** Equivalently, the bounded
+  Diophantine systems
+
+      a⁴ + b⁴ + 1 = c⁴   and   a⁴ + b⁴ = c⁴ + 1   (n = 4)
+      a⁵ + b⁵ + 1 = c⁵   and   a⁵ + b⁵ = c⁵ + 1   (n = 5)
+
+  have **no** solution in the ordered range 2 ≤ a ≤ b < c < 20. (The primitivity
+  condition gcd(a,b,c) = 1 is not even needed to rule these out; the raw
+  equations already fail.) The gallery's `no_witness_n_eq_4_below_20` research
+  target is met here.
+
+  Method. The claim is a bounded universal statement over `ℕ` and is therefore
+  decidable (`Nat.decidableBallLT` / `Nat.decidableBallLE`), so the kernel
+  discharges it by `decide` — **no `native_decide`, no `Lean.ofReduceBool`**.
+  These theorems are 0-axiom (only the ordinary foundational axioms of Lean).
+
+  Significance. This does not resolve the open conjecture (existence for n ≥ 4
+  remains open), but it converts the informal "an exhaustive search to c ≤ 100
+  has not been documented in this repository" (leads.md) into a machine-checked
+  lower bound on the size of any n ∈ {4,5} witness, and rules out the naive hope
+  of a small n = 4 or n = 5 example.
+-/
+
+import Mathlib
+import Proofs.FermatDefectOne
+
+namespace FermatDefectOne
+
+/-! ## Decidable bounded search kernels
+
+Each kernel is a bounded universal statement whose innermost predicate is the
+conjunction of the two Nat-form defect equations failing. The outermost bound is
+always an *upper* bound (`c < 20`, `b < c`, `a ≤ b`), which is what makes the
+statement decidable; the lower bound `2 ≤ a` enters as an inner implication. -/
+
+/-- **n = 4 exhaustive kernel.** For every ordered triple `2 ≤ a ≤ b < c < 20`
+neither defect-one equation `a⁴ + b⁴ + 1 = c⁴` (negative sign) nor
+`a⁴ + b⁴ = c⁴ + 1` (positive sign) holds. Verified by `decide`. -/
+theorem defect_n4_below_20_kernel :
+    ∀ c, c < 20 → ∀ b, b < c → ∀ a, a ≤ b → 2 ≤ a →
+      a ^ 4 + b ^ 4 + 1 ≠ c ^ 4 ∧ a ^ 4 + b ^ 4 ≠ c ^ 4 + 1 := by
+  decide
+
+/-- **n = 5 exhaustive kernel.** For every ordered triple `2 ≤ a ≤ b < c < 20`
+neither defect-one equation `a⁵ + b⁵ + 1 = c⁵` nor `a⁵ + b⁵ = c⁵ + 1` holds.
+Verified by `decide`. -/
+theorem defect_n5_below_20_kernel :
+    ∀ c, c < 20 → ∀ b, b < c → ∀ a, a ≤ b → 2 ≤ a →
+      a ^ 5 + b ^ 5 + 1 ≠ c ^ 5 ∧ a ^ 5 + b ^ 5 ≠ c ^ 5 + 1 := by
+  decide
+
+/-! ## Non-existence of small witnesses (gallery predicate form) -/
+
+/-- **No n = 4 defect-one witness below c = 20.** There is no primitive
+nontrivial Fermat defect-one witness at exponent 4 with `c < 20`. In particular
+the smallest n = 4 witness, should the open conjecture hold at n = 4, has
+`c ≥ 20`. Fully verified (0-axiom, `decide`). -/
+theorem no_defect_witness_n4_below_20 (a b c : ℕ) (hc : c < 20) :
+    ¬ FermatDefectWitness 4 a b c := by
+  rintro ⟨ha, hab, hbc, -, hdef⟩
+  obtain ⟨hne1, hne2⟩ := defect_n4_below_20_kernel c hc b hbc a hab ha
+  rcases hdef with h | h
+  · exact hne1 h
+  · exact hne2 h
+
+/-- **No n = 5 defect-one witness below c = 20.** There is no primitive
+nontrivial Fermat defect-one witness at exponent 5 with `c < 20`. Fully verified
+(0-axiom, `decide`). -/
+theorem no_defect_witness_n5_below_20 (a b c : ℕ) (hc : c < 20) :
+    ¬ FermatDefectWitness 5 a b c := by
+  rintro ⟨ha, hab, hbc, -, hdef⟩
+  obtain ⟨hne1, hne2⟩ := defect_n5_below_20_kernel c hc b hbc a hab ha
+  rcases hdef with h | h
+  · exact hne1 h
+  · exact hne2 h
+
+/-- **No small defect-one witness at n = 4 or n = 5, either sign.** Packaged
+statement: for every exponent `n ∈ {4, 5}` there is no primitive defect-one
+witness with `c < 20`. This is the machine-checked content behind the informal
+"no small n = 4/5 example" claim; the open conjecture (existence for some, or
+every, larger `c`) is untouched. -/
+theorem no_defect_witness_n4_n5_below_20 :
+    ∀ a b c : ℕ, c < 20 →
+      ¬ FermatDefectWitness 4 a b c ∧ ¬ FermatDefectWitness 5 a b c :=
+  fun a b c hc =>
+    ⟨no_defect_witness_n4_below_20 a b c hc, no_defect_witness_n5_below_20 a b c hc⟩
+
+end FermatDefectOne

--- a/proofs/Proofs/FourthRoot2IrrationalOQ02.lean
+++ b/proofs/Proofs/FourthRoot2IrrationalOQ02.lean
@@ -35,14 +35,114 @@ The real radical is modeled as `(p : ℝ) ^ ((1 : ℝ) / n)` (`Real.rpow`), matc
 `NthRootIrrationalOQ01`, so the present degree results sit on top of that file's
 irrationality results for the *same* term.
 
-Zero axioms; reuses only Mathlib and the sibling irreducibility lemma.
+Zero axioms; self-contained on top of Mathlib. The reusable Eisenstein-then-Gauss
+irreducibility core (`irreducible_X_pow_sub_C_prime_int/rat`, `minpoly_eq_of_pow_eq_prime`)
+is proved directly below, so this file no longer depends on the sibling
+`CubeRoot3IrrationalOQ01` module.
 -/
 import Mathlib
-import Proofs.CubeRoot3IrrationalOQ01
 
 open Polynomial IntermediateField
 
 namespace FourthRoot2IrrationalOQ02
+
+/-! ## Reusable Eisenstein-then-Gauss core: `Xⁿ − p` irreducible for every `n ≥ 1`
+
+Mathlib's Kummer lemmas (`X_pow_sub_C_irreducible_of_odd`,
+`X_pow_sub_C_irreducible_of_prime_pow`) require odd `n` or `p ≠ 2` and carry
+explicit `TODO`s for the even / `p = 2` corners. The Eisenstein route below is
+uniform in the exponent `n` and covers those corners directly. -/
+
+/-- The coefficients of `Xⁿ − C a` over any commutative ring: `1` at index `n`,
+`−a` at index `0`, and `0` elsewhere. -/
+theorem coeff_X_pow_sub_C {R : Type*} [CommRing R] (n : ℕ) (a : R) (k : ℕ) :
+    (X ^ n - C a : R[X]).coeff k
+      = (if k = n then (1 : R) else 0) - (if k = 0 then a else 0) := by
+  simp only [coeff_sub, coeff_X_pow, coeff_C]
+
+/-- **Reusable Eisenstein lemma.** For a prime `p : ℤ` and any exponent `n ≥ 1`,
+the polynomial `Xⁿ − p` is irreducible over `ℤ`, uniformly in `n`. -/
+theorem irreducible_X_pow_sub_C_prime_int {p : ℤ} (hp : Prime p) {n : ℕ}
+    (hn : 0 < n) : Irreducible (X ^ n - C p : ℤ[X]) := by
+  have hn0 : n ≠ 0 := hn.ne'
+  have hmonic : (X ^ n - C p : ℤ[X]).Monic := monic_X_pow_sub_C _ hn0
+  have hdeg : (X ^ n - C p : ℤ[X]).degree = n := degree_X_pow_sub_C hn p
+  apply irreducible_of_eisenstein_criterion (P := Ideal.span {p})
+  · exact (Ideal.span_singleton_prime hp.ne_zero).mpr hp
+  · have hlc : (X ^ n - C p : ℤ[X]).leadingCoeff = 1 := hmonic
+    rw [hlc, Ideal.mem_span_singleton]
+    exact fun h => hp.not_unit (isUnit_of_dvd_one h)
+  · intro k hk
+    rw [hdeg] at hk
+    have hkn : k ≠ n := by
+      have : k < n := by exact_mod_cast hk
+      exact this.ne
+    rw [coeff_X_pow_sub_C, if_neg hkn, Ideal.mem_span_singleton]
+    split_ifs <;> simp [dvd_neg]
+  · rw [hdeg]; exact_mod_cast hn
+  · rw [coeff_X_pow_sub_C, if_neg (Ne.symm hn0), if_pos rfl, zero_sub,
+      Ideal.span_singleton_pow, Ideal.mem_span_singleton]
+    intro h
+    rw [dvd_neg, sq] at h
+    have : p ∣ 1 := by
+      have h1 : p * p ∣ p * 1 := by simpa using h
+      exact (mul_dvd_mul_iff_left hp.ne_zero).mp h1
+    exact hp.not_unit (isUnit_of_dvd_one this)
+  · exact hmonic.isPrimitive
+
+/-- **Reusable Eisenstein-then-Gauss lemma over ℚ.** For a prime `p : ℤ` and any
+`n ≥ 1`, `Xⁿ − p` is irreducible over ℚ. -/
+theorem irreducible_X_pow_sub_C_prime_rat {p : ℤ} (hp : Prime p) {n : ℕ}
+    (hn : 0 < n) : Irreducible (X ^ n - C (p : ℚ) : ℚ[X]) := by
+  have hprim : (X ^ n - C p : ℤ[X]).IsPrimitive :=
+    (monic_X_pow_sub_C _ hn.ne').isPrimitive
+  have h := (IsPrimitive.Int.irreducible_iff_irreducible_map_cast hprim).mp
+    (irreducible_X_pow_sub_C_prime_int hp hn)
+  have hmap : (X ^ n - C p : ℤ[X]).map (Int.castRingHom ℚ) = X ^ n - C (p : ℚ) := by
+    simp [Polynomial.map_sub, Polynomial.map_pow, map_X, map_C]
+  rwa [hmap] at h
+
+/-- Convenience form for a natural-number prime `p`. -/
+theorem irreducible_X_pow_sub_C_natPrime_rat {p : ℕ} (hp : p.Prime) {n : ℕ}
+    (hn : 0 < n) : Irreducible (X ^ n - C (p : ℚ) : ℚ[X]) := by
+  have h := irreducible_X_pow_sub_C_prime_rat (p := (p : ℤ))
+    (Nat.prime_iff_prime_int.mp hp) hn
+  simpa using h
+
+/-- **Headline even family.** `X^(2^k) − 2` is irreducible over ℚ for every `k` —
+the `n = 2^k`, base `= 2` corner excluded by both Kummer `TODO`s. -/
+theorem irreducible_X_two_pow_sub_two_rat (k : ℕ) :
+    Irreducible (X ^ (2 ^ k) - C (2 : ℚ) : ℚ[X]) :=
+  irreducible_X_pow_sub_C_natPrime_rat (Nat.prime_two) (pow_pos (by norm_num) k)
+
+/-- The `⁴√2` instance (`k = 2`) recovered from the general even family. -/
+theorem irreducible_X4_sub_2_rat : Irreducible (X ^ 4 - C (2 : ℚ) : ℚ[X]) := by
+  have h := irreducible_X_two_pow_sub_two_rat 2
+  norm_num at h
+  exact h
+
+/-- **Prime-power exponents at arbitrary prime base**, including `p = 2`. -/
+theorem irreducible_X_pow_sub_C_primePow_prime_rat {p q : ℕ}
+    (hp : p.Prime) (hq : q.Prime) (k : ℕ) :
+    Irreducible (X ^ (p ^ k) - C (q : ℚ) : ℚ[X]) :=
+  irreducible_X_pow_sub_C_natPrime_rat hq (pow_pos hp.pos k)
+
+/-- **Reusable minimal-polynomial lemma.** If `α` in a ℚ-algebra domain satisfies
+`αⁿ = p` for a prime `p` (`n ≥ 1`), then `minpoly ℚ α = Xⁿ − p`. -/
+theorem minpoly_eq_of_pow_eq_prime {A : Type*} [CommRing A] [IsDomain A]
+    [Algebra ℚ A] {α : A} {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n)
+    (hpow : α ^ n = (p : A)) :
+    minpoly ℚ α = X ^ n - C (p : ℚ) := by
+  refine (minpoly.eq_of_irreducible_of_monic
+    (irreducible_X_pow_sub_C_natPrime_rat hp hn) ?_ (monic_X_pow_sub_C _ hn.ne')).symm
+  rw [map_sub, map_pow, aeval_X, aeval_C, map_natCast, hpow, sub_self]
+
+/-- The field degree `[ℚ(α) : ℚ] = n` whenever `αⁿ = p` is prime. -/
+theorem natDegree_minpoly_eq_of_pow_eq_prime {A : Type*} [CommRing A] [IsDomain A]
+    [Algebra ℚ A] {α : A} {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n)
+    (hpow : α ^ n = (p : A)) :
+    (minpoly ℚ α).natDegree = n := by
+  rw [minpoly_eq_of_pow_eq_prime hp hn hpow, natDegree_X_pow_sub_C]
 
 /-! ### The real radical and its defining power relation -/
 
@@ -75,7 +175,7 @@ minimal polynomial is *the* full Eisenstein polynomial, not a proper factor. -/
 theorem minpoly_primeRoot {p n : ℕ} (hp : p.Prime) (hn : 0 < n) :
     minpoly ℚ ((p : ℝ) ^ ((1 : ℝ) / n)) = X ^ n - C (p : ℚ) :=
   (minpoly.eq_of_irreducible_of_monic
-    (CubeRoot3IrrationalOQ01.irreducible_X_pow_sub_C_prime_rat hp hn)
+    (irreducible_X_pow_sub_C_natPrime_rat hp hn)
     (aeval_primeRoot hp.pos hn)
     (monic_X_pow_sub_C _ hn.ne')).symm
 

--- a/proofs/Proofs/FrobeniusNumberOQ01OQ01.lean
+++ b/proofs/Proofs/FrobeniusNumberOQ01OQ01.lean
@@ -177,3 +177,112 @@ theorem frobeniusNumber_triple_strict {m n : ℕ}
   exact frobeniusNumber_lt_of_mem_closure hsub hpair hg hkmem
 
 end FrobeniusMultiGenerator
+
+
+open Nat
+
+namespace FrobeniusNumberOQ01OQ01
+
+/-! ## Explicit representability by `{6, 9, 20}` -/
+
+/-- `n` is representable by `6, 9, 20` if `n = 6x + 9y + 20z` for some naturals `x, y, z`. -/
+def Representable3 (n : ℕ) : Prop := ∃ x y z : ℕ, n = 6 * x + 9 * y + 20 * z
+
+/-- `43` is not representable: no non-negative combination of `6, 9, 20` equals `43`.
+    (`omega` decides this linear Diophantine (non-)existence directly.) -/
+theorem not_representable3_43 : ¬ Representable3 43 := by
+  rintro ⟨x, y, z, h⟩
+  omega
+
+/-- Every integer `≥ 44` is representable by `6, 9, 20`.
+    Base residues `44, 45, 46, 47, 48, 49` are given explicit witnesses; larger values
+    reduce by `6` to a smaller representable value (strong induction). -/
+theorem representable3_ge : ∀ n, 44 ≤ n → Representable3 n := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro hn
+    by_cases h : n ≤ 49
+    · interval_cases n
+      · exact ⟨4, 0, 1, by norm_num⟩   -- 44 = 6·4 + 20
+      · exact ⟨0, 5, 0, by norm_num⟩   -- 45 = 9·5
+      · exact ⟨1, 0, 2, by norm_num⟩   -- 46 = 6 + 20·2
+      · exact ⟨0, 3, 1, by norm_num⟩   -- 47 = 9·3 + 20
+      · exact ⟨8, 0, 0, by norm_num⟩   -- 48 = 6·8
+      · exact ⟨0, 1, 2, by norm_num⟩   -- 49 = 9 + 20·2
+    · obtain ⟨x, y, z, hxyz⟩ := ih (n - 6) (by omega) (by omega)
+      exact ⟨x + 1, y, z, by omega⟩
+
+/-! ## Bridge to Mathlib's `AddSubmonoid.closure` -/
+
+/-- The representable numbers, packaged as the additive submonoid they form. -/
+def R3 : AddSubmonoid ℕ where
+  carrier := {n | Representable3 n}
+  zero_mem' := ⟨0, 0, 0, by norm_num⟩
+  add_mem' := by
+    intro a b ha hb
+    simp only [Set.mem_setOf_eq] at ha hb ⊢
+    obtain ⟨x₁, y₁, z₁, rfl⟩ := ha
+    obtain ⟨x₂, y₂, z₂, rfl⟩ := hb
+    exact ⟨x₁ + x₂, y₁ + y₂, z₁ + z₂, by ring⟩
+
+/-- A submonoid absorbs natural-number multiples of its members. -/
+private theorem nat_mul_mem {S : AddSubmonoid ℕ} {m : ℕ} (hm : m ∈ S) (k : ℕ) : m * k ∈ S := by
+  induction k with
+  | zero => simpa using S.zero_mem
+  | succ k ih => rw [Nat.mul_succ]; exact S.add_mem ih hm
+
+/-- Membership in the closure of `{6, 9, 20}` is exactly representability by `6, 9, 20`. -/
+theorem mem_closure_iff (n : ℕ) :
+    n ∈ AddSubmonoid.closure ({6, 9, 20} : Set ℕ) ↔ Representable3 n := by
+  constructor
+  · intro hn
+    have hle : AddSubmonoid.closure ({6, 9, 20} : Set ℕ) ≤ R3 := by
+      rw [AddSubmonoid.closure_le]
+      intro x hx
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+      rcases hx with rfl | rfl | rfl
+      · exact ⟨1, 0, 0, by norm_num⟩
+      · exact ⟨0, 1, 0, by norm_num⟩
+      · exact ⟨0, 0, 1, by norm_num⟩
+    exact hle hn
+  · rintro ⟨x, y, z, rfl⟩
+    have h6 : (6 : ℕ) ∈ AddSubmonoid.closure ({6, 9, 20} : Set ℕ) :=
+      AddSubmonoid.subset_closure (by simp)
+    have h9 : (9 : ℕ) ∈ AddSubmonoid.closure ({6, 9, 20} : Set ℕ) :=
+      AddSubmonoid.subset_closure (by simp)
+    have h20 : (20 : ℕ) ∈ AddSubmonoid.closure ({6, 9, 20} : Set ℕ) :=
+      AddSubmonoid.subset_closure (by simp)
+    exact add_mem (add_mem (nat_mul_mem h6 x) (nat_mul_mem h9 y)) (nat_mul_mem h20 z)
+
+/-! ## The Chicken McNugget number: `g(6, 9, 20) = 43` -/
+
+/-- **The Chicken McNugget theorem.** The Frobenius number of `{6, 9, 20}` is `43`:
+    `43` cannot be written as a non-negative combination of `6, 9, 20`, but every
+    larger integer can. This is the canonical three-generator instance; no closed-form
+    formula produces it (the pair formula `frobeniusNumber_pair` does not apply). -/
+theorem chickenMcNugget : FrobeniusNumber 43 ({6, 9, 20} : Set ℕ) := by
+  rw [frobeniusNumber_iff]
+  refine ⟨?_, ?_⟩
+  · rw [mem_closure_iff]
+    exact not_representable3_43
+  · intro k hk
+    rw [mem_closure_iff]
+    exact representable3_ge k (by omega)
+
+/-! ## Well-definedness for any number of generators (Schur's theorem) -/
+
+/-- **n-generator well-definedness.** For any set of generators `s`, if `gcd s = 1`
+    and `1 ∉ s` then a Frobenius number exists. This is the structural generalization
+    to `n ≥ 3` generators of the fact that the Frobenius number is well-defined; the
+    (impossible) part of the open question is a *closed form*, not existence. -/
+theorem exists_frobeniusNumber_of_setGcd_one {s : Set ℕ} (hgcd : Nat.setGcd s = 1)
+    (h1 : (1 : ℕ) ∉ s) : ∃ n, FrobeniusNumber n s :=
+  exists_frobeniusNumber_iff.mpr ⟨hgcd, h1⟩
+
+/-- The Chicken McNugget set does have a Frobenius number, and (by `chickenMcNugget`
+    together with the uniqueness built into `IsGreatest`) it is `43`. -/
+theorem exists_frobeniusNumber_mcnugget : ∃ n, FrobeniusNumber n ({6, 9, 20} : Set ℕ) :=
+  ⟨43, chickenMcNugget⟩
+
+end FrobeniusNumberOQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ04OQ03.lean
+++ b/proofs/Proofs/GeometricSeriesOQ04OQ03.lean
@@ -37,18 +37,18 @@ An illustrative expansion `qBinom q 4 2 = 1 + q + 2q² + q³ + q⁴` is checked 
 the end, exhibiting the Gaussian binomial as a genuine polynomial in `q` whose
 `q = 1` value is `C(4,2) = 6`.
 
-## Follow-up (documented, not formalized here)
+## The q-binomial theorem (Gauss / Rothe)
 
-The **q-binomial theorem** (Gauss / Rothe)
+The headline consequence is now **formalized** at the end of this file
+(`qBinomial_theorem`):
 
-  `∏_{i<n} (1 + q^i · x) = ∑_{k≤n} q^{C(k,2)} · [n choose k]_q · x^k`
+  `∏_{i<n} (1 + q^i · x) = ∑_{k≤n} q^{C(k,2)} · [n choose k]_q · x^k`.
 
-follows from the recurrence by induction on `n` (peel the first factor,
-re-substitute `x ↦ q·x`, match coefficients via q-Pascal and the identity
-`C(k+1,2) = C(k,2) + k`).  Likewise the **box-partition generating function**
-`∑_{λ ⊆ (n-k)^k} q^{|λ|}` satisfies the same recurrence, giving the combinatorial
-interpretation.  Both are left as follow-up work; the automated prover has been
-tasked with the q-binomial theorem.
+It follows from the recurrence by induction on `n` (peel the first factor with
+`Finset.prod_range_succ'`, re-substitute `x ↦ q·x`, match coefficients via the
+functional recurrence `qbinomSum_succ`, which uses only q-Pascal I and the
+identity `C(k+1,2) = C(k,2) + k`).  The **box-partition generating function**
+`∑_{λ ⊆ (n-k)^k} q^{|λ|}` satisfies the same recurrence and is left as follow-up.
 
 ## Why Mathlib Doesn't Already Have This
 
@@ -140,5 +140,72 @@ polynomial in `q`.  Its value at `q = 1` is `1 + 1 + 2 + 1 + 1 = 6 = C(4,2)`. -/
 example (q : R) : qBinom q 4 2 = 1 + q + 2 * q ^ 2 + q ^ 3 + q ^ 4 := by
   simp only [qBinom]
   ring
+
+/-! ### The q-binomial theorem (Gauss / Rothe) -/
+
+/-- `(k+1).choose 2 = k.choose 2 + k`, the exponent recurrence used below. -/
+theorem choose_two_succ (k : ℕ) : (k + 1).choose 2 = k.choose 2 + k := by
+  have h : (k + 1).choose 2 = k.choose 1 + k.choose 2 := Nat.choose_succ_succ k 1
+  rw [Nat.choose_one_right] at h
+  omega
+
+/-- The weighted sum `∑_{k≤n} q^{C(k,2)} · [n choose k]_q · x^k` appearing on the
+right-hand side of the q-binomial theorem. -/
+def qbinomSum (q x : R) (n : ℕ) : R :=
+  ∑ k ∈ Finset.range (n + 1), q ^ (k.choose 2) * qBinom q n k * x ^ k
+
+/-- **Functional recurrence** `S_{n+1}(x) = (1 + x) · S_n(q·x)`, proved using
+only q-Pascal I (`qBinom_succ_succ`) and vanishing above the diagonal. -/
+theorem qbinomSum_succ (q x : R) (n : ℕ) :
+    qbinomSum q x (n + 1) = (1 + x) * qbinomSum q (q * x) n := by
+  have hbody : ∀ k, q ^ ((k + 1).choose 2) * qBinom q (n + 1) (k + 1) * x ^ (k + 1)
+      = x * (q ^ (k.choose 2) * qBinom q n k * (q * x) ^ k)
+        + q ^ (k.choose 2 + (2 * k + 1)) * qBinom q n (k + 1) * x ^ (k + 1) := by
+    intro k
+    rw [choose_two_succ, qBinom_succ_succ]
+    ring
+  have hg : ∀ k, q ^ ((k + 1).choose 2) * qBinom q n (k + 1) * (q * x) ^ (k + 1)
+      = q ^ (k.choose 2 + (2 * k + 1)) * qBinom q n (k + 1) * x ^ (k + 1) := by
+    intro k
+    rw [choose_two_succ]
+    ring
+  have hsum_g : (∑ k ∈ Finset.range (n + 1),
+        q ^ (k.choose 2) * qBinom q n k * (q * x) ^ k)
+      = (∑ k ∈ Finset.range n,
+          q ^ (k.choose 2 + (2 * k + 1)) * qBinom q n (k + 1) * x ^ (k + 1)) + 1 := by
+    rw [Finset.sum_range_succ']
+    simp only [hg]
+    have h0 : q ^ ((0 : ℕ).choose 2) * qBinom q n 0 * (q * x) ^ 0 = 1 := by simp
+    rw [h0]
+  have hsum_h : (∑ k ∈ Finset.range (n + 1),
+        q ^ (k.choose 2 + (2 * k + 1)) * qBinom q n (k + 1) * x ^ (k + 1))
+      = (∑ k ∈ Finset.range n,
+          q ^ (k.choose 2 + (2 * k + 1)) * qBinom q n (k + 1) * x ^ (k + 1)) := by
+    rw [Finset.sum_range_succ, qBinom_eq_zero_of_lt q n (n + 1) (Nat.lt_succ_self n)]
+    ring
+  rw [qbinomSum, Finset.sum_range_succ']
+  simp only [hbody]
+  have h0 : q ^ ((0 : ℕ).choose 2) * qBinom q (n + 1) 0 * x ^ 0 = 1 := by simp
+  rw [h0, Finset.sum_add_distrib, qbinomSum, add_mul, one_mul, Finset.mul_sum,
+      hsum_g, hsum_h]
+  ring
+
+/-- **q-binomial theorem (Rothe's formula).**
+`∏_{i<n} (1 + q^i · x) = ∑_{k≤n} q^{C(k,2)} · [n choose k]_q · x^k`.
+
+Proved by induction on `n` (generalizing `x`): peel the *first* factor of the
+product with `Finset.prod_range_succ'`, rewrite `q^{i+1}x = q^i(qx)` to invoke the
+induction hypothesis at `q·x`, then close with the functional recurrence
+`qbinomSum_succ`. -/
+theorem qBinomial_theorem (q x : R) (n : ℕ) :
+    (∏ i ∈ Finset.range n, (1 + q ^ i * x)) = qbinomSum q x n := by
+  induction n generalizing x with
+  | zero => simp [qbinomSum]
+  | succ n ih =>
+    rw [Finset.prod_range_succ']
+    simp only [show ∀ i, 1 + q ^ (i + 1) * x = 1 + q ^ i * (q * x) from
+      fun i => by rw [pow_succ]; ring]
+    rw [ih (q * x), pow_zero, one_mul, qbinomSum_succ]
+    ring
 
 end GaussianBinomial

--- a/proofs/Proofs/LeibnizPiOQ04.lean
+++ b/proofs/Proofs/LeibnizPiOQ04.lean
@@ -115,4 +115,37 @@ theorem arctan_add_partner_eq_pi_div_four {x : ℝ} (hx0 : 0 < x) (hx1 : x < 1) 
   field_simp [h1x]
   ring
 
+/-! ### A genuinely three-term companion needing two folds
+
+Beyond the two-term Euler identity, `π/4` also decomposes as
+`arctan(1/3) + arctan(1/4) + arctan(2/9)`, assembled by iterating the arctangent
+addition law until the combined argument is exactly `1`. -/
+
+/-- A reusable warm-up fold: `arctan(1/2) + arctan(1/5) = arctan(7/9)`.
+    Here `xy = 1/10 < 1` and `(1/2 + 1/5)/(1 − 1/10) = (7/10)/(9/10) = 7/9`. -/
+theorem fold_half_fifth :
+    arctan (1/2 : ℝ) + arctan (1/5) = arctan (7/9) := by
+  rw [arctan_add (by norm_num : (1/2 : ℝ) * (1/5) < 1)]
+  congr 1
+  norm_num
+
+/-- First fold of the three-term identity: `arctan(1/3) + arctan(1/4) = arctan(7/11)`.
+    Here `xy = 1/12 < 1` and `(1/3 + 1/4)/(1 − 1/12) = (7/12)/(11/12) = 7/11`. -/
+theorem fold_third_fourth :
+    arctan (1/3 : ℝ) + arctan (1/4) = arctan (7/11) := by
+  rw [arctan_add (by norm_num : (1/3 : ℝ) * (1/4) < 1)]
+  congr 1
+  norm_num
+
+/-- **A genuinely three-term companion needing two folds.**
+    `arctan(1/3) + arctan(1/4) + arctan(2/9) = π/4`.
+
+    Fold 1 (`fold_third_fourth`): `arctan(1/3) + arctan(1/4) = arctan(7/11)`.
+    Fold 2: `arctan(7/11) + arctan(2/9) = arctan 1`, since `(7/11)(2/9) = 14/99 < 1`
+    and `(7/11 + 2/9)/(1 − 14/99) = (85/99)/(85/99) = 1`. -/
+theorem machin_three_term :
+    arctan (1/3 : ℝ) + arctan (1/4) + arctan (2/9) = π / 4 := by
+  rw [fold_third_fourth, arctan_add (by norm_num : (7/11 : ℝ) * (2/9) < 1),
+    show ((7/11 + 2/9) / (1 - (7/11 : ℝ) * (2/9))) = 1 by norm_num, arctan_one]
+
 end LeibnizPiOQ04

--- a/research/problems/fermat-defect-one/claims/2026-07-01-bounded-nonexistence-0axiom-decide.md
+++ b/research/problems/fermat-defect-one/claims/2026-07-01-bounded-nonexistence-0axiom-decide.md
@@ -1,0 +1,63 @@
+# Claim: 0-axiom (`decide`) bounded non-existence for n = 4, 5 — researcher-2, 2026-07-01
+
+## Summary
+
+Drafted `proofs/Proofs/FermatDefectOneBounded.lean` (branch
+`research/fermat-defect-bounded`, commit `b2cc2bff352`, pushed to origin, **no
+PR**). It proves, by kernel `decide` (0-axiom — **no** `native_decide`, no
+`Lean.ofReduceBool`), that no primitive Fermat defect-one witness exists at
+exponent 4 or 5 with `c < 20`, either sign:
+
+- `no_defect_witness_n4_below_20 : ∀ a b c, c < 20 → ¬ FermatDefectWitness 4 a b c`
+- `no_defect_witness_n5_below_20 : ∀ a b c, c < 20 → ¬ FermatDefectWitness 5 a b c`
+- plus decidable kernels `defect_n{4,5}_below_20_kernel` and the combined
+  `no_defect_witness_n4_n5_below_20`.
+
+This directly targets the gallery's named research target
+`no_witness_n_eq_4_below_20`.
+
+## Status: UNVERIFIED (build infra failure)
+
+The file was **never compiled**. Build attempt on 2026-07-01 crashed Docker
+Desktop: with 6 concurrent `lean-build` containers racing the shared cache
+volume, the host disk fell from ~1.6 GB to **119 MB free** while building Mathlib
+(reached module 7274/7744 — never reached `FermatDefectOne.lean` or my file),
+triggering "Docker Desktop is unable to start". A `.trace` cache-corruption
+warning ("unexpected end of input") also appeared mid-build — the concurrent
+`.lake` race documented across researcher memories. Aborted to protect the host;
+freed disk by removing the worktree (work preserved on origin).
+
+The math is Python-confirmed: **no** defect-one solution (even without the gcd
+filter) for n = 4 or n = 5 with c ≤ 60; none for n = 4 with c < 300. The Lean is
+a routine `decide` over `Nat.decidableBallLT`/`decidableBallLE` bounded
+quantifiers at bound 20, so it is very likely to compile — but this must be
+confirmed on working infra before any "verified" claim.
+
+## Value assessment: MARGINAL / duplicative — decide before shipping
+
+`FermatDefectOneOQ04.lean` **already** proves the strictly stronger bounded
+result `no_small_witness_{4,5,6}` for `c ≤ 100`, both signs, via `native_decide`.
+So the *mathematical content* here is fully subsumed. The **only** delta is
+verification purity: my `c < 20` slice is axiom-free (`decide`) whereas OQ04
+relies on `Lean.ofReduceBool` (`native_decide`).
+
+- Kernel `decide` cannot scale to OQ04's `c ≤ 100` (170k+ triples with 4th–6th
+  powers) — that is exactly why OQ04 used `native_decide`. `c < 20` (~1.3k
+  triples) is the realistic ceiling for a 0-axiom certificate.
+- This delta does **not** change the entry's `axiomatized` status (headline
+  `sorry` + native_decide n=3 benchmarks remain), so practical gallery value is
+  low.
+
+Recommendation for a future session with healthy infra: build the branch; if it
+compiles, it is a legitimate (if small) verification-quality improvement closing
+the named `no_witness_n_eq_4_below_20` target axiom-free — worth a small PR then.
+If not deemed worth the churn, drop it. Do **not** ship unverified.
+
+## Infra note
+
+Building from a fresh `$HOME` worktree tries to *clone* Mathlib (worktree lacks
+`.lake/packages/mathlib`); build from the main checkout which has packages +
+partial olean volume. Even so, this branch's Mathlib toolchain required
+rebuilding ~500+ modules from source against a partial cache volume, which is
+what exhausted the disk under concurrency. Retry only when
+`docker ps | grep -c lean-build` is low AND `df` shows several GB free.

--- a/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
@@ -23,9 +23,9 @@
       "Topology"
     ],
     "namespace": "CentralLimitTheoremOQ02OQ04",
-    "lineCount": 1953,
+    "lineCount": 1984,
     "axiomCount": 0,
-    "theoremCount": 37,
+    "theoremCount": 38,
     "definitionCount": 3,
     "path": "Proofs/CentralLimitTheoremOQ02OQ04.lean",
     "sorries": 2

--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -17,7 +17,7 @@
       "reciprocals"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 307,
     "erdosUrl": "https://erdosproblems.com/307",
     "erdosProblemStatus": "open",
@@ -272,9 +272,10 @@
     "imports": [
       "Mathlib.NumberTheory.Divisors",
       "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Rat.Basic",
+      "Mathlib.Data.Rat.Defs",
       "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Algebra.BigOperators.Group.Finset",
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
+      "Mathlib.Data.ZMod.Basic",
       "Mathlib.Tactic"
     ],
     "opens": [
@@ -282,15 +283,15 @@
       "BigOperators"
     ],
     "namespace": "Erdos307",
-    "lineCount": 514,
+    "lineCount": 607,
     "axiomCount": 0,
-    "theoremCount": 22,
-    "definitionCount": 15,
+    "theoremCount": 25,
+    "definitionCount": 17,
     "path": "Proofs/Erdos307Problem.lean",
-    "sorries": 2,
+    "sorries": 1,
     "additionalFiles": [
       "Proofs/Erdos307Aristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 1
 }

--- a/src/data/proofs/fourth-root-2-irrational-oq-02/meta.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-02/meta.json
@@ -135,17 +135,16 @@
   ],
   "leanFile": {
     "imports": [
-      "Mathlib",
-      "Proofs.CubeRoot3IrrationalOQ01"
+      "Mathlib"
     ],
     "opens": [
       "Polynomial",
       "IntermediateField"
     ],
     "namespace": "FourthRoot2IrrationalOQ02",
-    "lineCount": 127,
+    "lineCount": 227,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 19,
     "definitionCount": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/frobenius-number-oq-01-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-01/meta.json
@@ -164,10 +164,10 @@
       "Mathlib.Tactic"
     ],
     "namespace": "FrobeniusMultiGenerator",
-    "lineCount": 179,
-    "theoremCount": 6,
+    "lineCount": 288,
+    "theoremCount": 12,
     "axiomCount": 0,
-    "definitionCount": 0,
+    "definitionCount": 2,
     "sorries": 0,
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FrobeniusNumberOQ01OQ01.lean"

--- a/src/data/proofs/geometric-series-oq-04-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-04-oq-03/meta.json
@@ -70,7 +70,7 @@
       "title": "Overview: Gaussian (q-)Binomial Coefficients — q-Pascal, Boundaries, Classical Limit",
       "startLine": 1,
       "endLine": 75,
-      "summary": "Imports (parent GeometricSeriesOQ04, Nat.Choose.Basic, Tactic), module docstring, and setup (open Finset, QuantumInteger; namespace GaussianBinomial; CommRing R). Building on the quantum integer [n]_q = ∑_{i<n} qⁱ, the file develops the Gaussian q-binomial coefficient qBinom q n k = [n choose k]_q over any commutative ring, defined BY the q-Pascal recurrence [n+1 choose k+1]_q = [n choose k]_q + q^{k+1}·[n choose k+1]_q (so definitional, rfl). Proves boundary conditions (qBinom_zero_right, qBinom_self, qBinom_eq_zero_of_lt), the quantum-integer bridge qBinom_one_right ([n choose 1]_q = [n]_q), and the classical limit qBinom_at_one ([n choose k]_1 = C(n,k), the counting interpretation). An expansion qBinom q 4 2 = 1+q+2q²+q³+q⁴ is checked (value C(4,2)=6 at q=1). The q-binomial theorem and box-partition generating function are documented as follow-up. Mathlib has no named Gaussian binomial or q-Pascal; all proofs 0-axiom.",
+      "summary": "Imports (parent GeometricSeriesOQ04, Nat.Choose.Basic, Tactic), module docstring, and setup (open Finset, QuantumInteger; namespace GaussianBinomial; CommRing R). Building on the quantum integer [n]_q = ∑_{i<n} qⁱ, the file develops the Gaussian q-binomial coefficient qBinom q n k = [n choose k]_q over any commutative ring, defined BY the q-Pascal recurrence [n+1 choose k+1]_q = [n choose k]_q + q^{k+1}·[n choose k+1]_q (so definitional, rfl). Proves boundary conditions (qBinom_zero_right, qBinom_self, qBinom_eq_zero_of_lt), the quantum-integer bridge qBinom_one_right ([n choose 1]_q = [n]_q), and the classical limit qBinom_at_one ([n choose k]_1 = C(n,k), the counting interpretation). An expansion qBinom q 4 2 = 1+q+2q²+q³+q⁴ is checked (value C(4,2)=6 at q=1). The q-binomial theorem (Rothe's formula) is proved at the end of the file (qBinomial_theorem); the box-partition generating function remains documented as follow-up. Mathlib has no named Gaussian binomial or q-Pascal; all proofs 0-axiom.",
       "mathContext": "The q=1 value is the shadow of subspace-counting over 𝔽_q: the Gaussian binomial is a genuine polynomial in q degenerating to the ordinary binomial coefficient. Honest note: a faithful formalization of standard textbook q-analog identities (Andrews; Kac–Cheung), not a new result."
     },
     {
@@ -107,10 +107,9 @@
     }
   ],
   "conclusion": {
-    "summary": "Starting from the q-Pascal recurrence as a definition, this entry constructs the Gaussian (q-)binomial coefficient over an arbitrary commutative ring and proves its structural laws: the boundary conditions [n choose 0]_q = [n choose n]_q = 1 and vanishing above the diagonal, the bridge [n choose 1]_q = [n]_q to the parent's quantum integer, and the classical limit [n choose k]_1 = C(n,k). All are fully machine-checked with 0 axioms.",
+    "summary": "Starting from the q-Pascal recurrence as a definition, this entry constructs the Gaussian (q-)binomial coefficient over an arbitrary commutative ring and proves its structural laws: the boundary conditions [n choose 0]_q = [n choose n]_q = 1 and vanishing above the diagonal, the bridge [n choose 1]_q = [n]_q to the parent's quantum integer, and the classical limit [n choose k]_1 = C(n,k). All are fully machine-checked with 0 axioms. The q-binomial theorem (Gauss/Rothe / Rothe's formula) ∏_{i<n}(1 + q^i x) = ∑_{k≤n} q^{C(k,2)} [n choose k]_q x^k is now formalized (qBinomial_theorem) via the functional recurrence qbinomSum_succ, which uses only q-Pascal I.",
     "implications": "The Gaussian binomial and its q-Pascal recurrence are the foundation for the q-binomial theorem, the box-partition/lattice-path generating functions, and the subspace count over F_q. This entry supplies the definition and structural core that Mathlib lacks, on top of the parent's quantum-integer layer.",
     "openQuestions": [
-      "Prove the q-binomial theorem (Gauss/Rothe) ∏_{i<n}(1 + q^i x) = ∑_{k≤n} q^{C(k,2)} [n choose k]_q x^k by induction on n, peeling the first factor and re-substituting x ↦ q·x, matching coefficients via the q-Pascal recurrence and C(k+1,2) = C(k,2) + k.",
       "Establish the box-partition combinatorial interpretation: the generating polynomial ∑_{λ ⊆ (n-k)^k} q^{|λ|} over integer partitions fitting in a k×(n-k) box satisfies the same q-Pascal recurrence and boundary conditions, hence equals [n choose k]_q — a self-contained combinatorial proof.",
       "Prove the symmetry [n choose k]_q = [n choose n-k]_q (reflection of the box) and the q-factorial product formula [n choose k]_q = [n]_q! / ([k]_q! [n-k]_q!) over Z[q] via an exact-divisibility argument."
     ]
@@ -139,10 +138,10 @@
       "QuantumInteger"
     ],
     "namespace": "GaussianBinomial",
-    "lineCount": 144,
+    "lineCount": 211,
     "axiomCount": 0,
-    "theoremCount": 8,
-    "definitionCount": 1,
+    "theoremCount": 11,
+    "definitionCount": 2,
     "sorries": 0,
     "path": "Proofs/GeometricSeriesOQ04OQ03.lean"
   }

--- a/src/data/proofs/leibniz-pi-oq-04/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-04/meta.json
@@ -149,9 +149,9 @@
       "Real"
     ],
     "namespace": "LeibnizPiOQ04",
-    "lineCount": 118,
+    "lineCount": 151,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/LeibnizPiOQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Recovers proof work from the branches surfaced by the #35088 local-branch triage. Each ported file was docker-built (`./proofs/scripts/docker-build.sh`, never raw `lake build`, all builds run solo) and has honest sorry/axiom accounting per the Axiom Integrity Policy. Where branches were never built, Mathlib-drift was repaired.

## Candidates ported (8)

| # | Candidate | File | Result | Build |
|---|-----------|------|--------|-------|
| 1 | erdos-307-disjoint | `Erdos307Problem.lean` | discharges `prime_sets_disjoint` (sorries 2→1) via p-adic valuation helpers; also repaired extensive pre-existing Mathlib drift (`∑ in`→`∑ ∈`, `inv_le_inv_of_le`→`inv_anti₀`, `Finset.sum_union`, false `pair_with_one`) | 3058 jobs ✅ |
| 2 | fourth-root-2-eisenstein | `FourthRoot2IrrationalOQ02.lean` | reusable Eisenstein-then-Gauss core (`irreducible_X_pow_sub_C_prime_int/rat`, `minpoly_eq_of_pow_eq_prime`); dropped CubeRoot3 dep; 0 sorry/axiom | 7743 jobs ✅ |
| 3 | geom-gaussian-binomial | `GeometricSeriesOQ04OQ03.lean` | q-binomial theorem (Gauss/Rothe) `qBinomial_theorem` + `qbinomSum_succ`; appended to preserve all prior names/annotations | 3059 jobs ✅ |
| 4 | frobenius-mcnugget | `FrobeniusNumberOQ01OQ01.lean` | concrete Chicken McNugget `FrobeniusNumber 43 {6,9,20}` + representability + Schur well-definedness | 3062 jobs ✅ |
| 5 | leibniz-pi-oq-04 | `LeibnizPiOQ04.lean` | three-term Machin fold `arctan(1/3)+arctan(1/4)+arctan(2/9)=π/4` (partial port — only the new fold) | 3060 jobs ✅ |
| 6 | clt-oq0204-s26 | `CentralLimitTheoremOQ02OQ04.lean` | the one new sorry-free theorem `inner_survival_covariance_le_alpha_length` (theorem-only port from diverged file) | 3132 jobs ✅ |
| 8 | binary-gcd | `BinaryGcdOQ01OQ01OQ01.lean` | Ω((log N)²) lower bound (new file, 0 sorry/axiom) | 7746 jobs ✅ |
| 10 | stirling-first-row-sum | `BellNumbersOQ01OQ03.lean` | Stirling first-kind row sum = n! (new file, 0 sorry/axiom) | 3059 jobs ✅ |
| 12 | fermat-defect-bounded | `FermatDefectOneBounded.lean` | 0-axiom `decide` bounded non-existence n=4,5 c<20 (extracted from `b2cc2bff352`, built solo) | 7744 jobs ✅ |

Gallery `meta.json` stat blocks (sorries/lineCount/theoremCount/definitionCount/imports) were kept consistent for every touched entry.

## Written off / deferred (documented on #35088)

- **#7 erdos-3-base-cases** — superseded: main's restructured `Erdos3Problem.lean` already proves the stronger `hasDivergentSum_containsAP_le_two` (k≤2), subsuming the branch's k=0,1 base cases.
- **#9 erdos-1162** — superseded: main already has `Erdos1162OQ04.lean` with `numSubgroupsAn_le` (g(n)≤f(n)) (the `Oq04` vs `OQ04` casing hid it from triage).
- **#11 vieta-sumprod** — superseded: main already has a complete `VietasFormulasOQ05.lean` (sum/product of roots).
- **#13 amgm** — deferred: blocked on a delicate rotted dependency `AmgmInequalityOQ02OQ02.lean` (Newton-inequality discriminant proof with `nlinarith`/`ring` drift) requiring a dedicated repair.

This PR resolves 8 of the 12 candidates plus the 13th (amgm); the remaining are dispositioned via comments, so the issue stays open until all are closed out.

Part of #35088

🤖 Generated with [Claude Code](https://claude.com/claude-code)