### PR TITLE
fix(erdos-156): repair Erdos156Problem.lean for Mathlib v4.26.0 (0 sorries, verified)

### DIFF
--- a/proofs/Proofs/Erdos156Problem.lean
+++ b/proofs/Proofs/Erdos156Problem.lean
@@ -18,6 +18,10 @@ import Mathlib
 
 namespace Erdos156
 
+-- Sidon-set membership and the greedy construction branch on undecidable
+-- propositions (`IsSidonSet`, `Set.Finite`); use classical decidability.
+open scoped Classical
+
 /-
 ## Sidon Sets
 
@@ -35,49 +39,31 @@ def IsSidonSetAlt (A : Set ℕ) : Prop :=
   ∀ a b c d : ℕ, a ∈ A → b ∈ A → c ∈ A → d ∈ A →
     a < b → c < d → a + b = c + d → a = c ∧ b = d
 
-/-- The two definitions are equivalent -/
+/-- Order-free characterization: `A` is Sidon iff whenever two (not necessarily
+    ordered) pairs of elements have equal sums, they are the same pair.
+
+    Note: the previous form of this lemma additionally gated the hypothesis with
+    `a ≠ b` and `c ≠ d`. That statement is *false* — dropping the diagonal case
+    (`a = b`) makes the right-hand side strictly weaker than `IsSidonSet`
+    (e.g. `A = {1,2,3}` satisfies the gated condition, since the distinct-element
+    sums `3,4,5` are distinct, yet `2 + 2 = 1 + 3` violates `IsSidonSet`).
+    The correct characterization drops the `≠` gating. -/
 theorem sidonSet_iff_alt (A : Set ℕ) :
     IsSidonSet A ↔
     (∀ a b c d : ℕ, a ∈ A → b ∈ A → c ∈ A → d ∈ A →
-      a ≠ b → c ≠ d → a + b = c + d → ({a, b} : Set ℕ) = {c, d}) := by
+      a + b = c + d → ({a, b} : Set ℕ) = {c, d}) := by
   constructor
-  · intro hS a b c d ha hb hc hd hab hcd heq
-    by_cases hle : a ≤ b
-    · by_cases hle' : c ≤ d
-      · exact hS a b c d ha hb hc hd hle hle' heq
-      · push_neg at hle'
-        have heq' : a + b = d + c := by linarith
-        have h := hS a b d c ha hb hd hc hle (le_of_lt hle') heq'
-        ext x
-        simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at h ⊢
-        constructor <;> intro hx <;> {
-          rw [Set.insert_eq, Set.insert_eq, Set.union_comm {d}, Set.union_comm {c}] at h
-          tauto
-        }
-    · push_neg at hle
-      have heq' : b + a = c + d := by linarith
-      by_cases hle' : c ≤ d
-      · have h := hS b a c d hb ha hc hd (le_of_lt hle) hle' heq'
-        ext x; simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at h ⊢
-        have h' : x = b ∨ x = a ↔ x = c ∨ x = d := by
-          constructor <;> intro hx <;> {
-            have := h.subset
-            simp at this
-            tauto
-          }
-        tauto
-      · push_neg at hle'
-        have heq'' : b + a = d + c := by linarith
-        have h := hS b a d c hb ha hd hc (le_of_lt hle) (le_of_lt hle') heq''
-        ext x; simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at h ⊢
-        tauto
-  · intro hS a b c d ha hb hc hd hab hcd heq
-    by_cases h : a = b
-    · by_cases h' : c = d
-      · simp [h, h'] at heq ⊢
-        linarith
-      · exact hS a b c d ha hb hc hd (by intro H; simp [H, h] at heq; linarith) h' heq
-    · exact hS a b c d ha hb hc hd h (by intro H; simp [H] at heq hab; linarith) heq
+  · intro hS a b c d ha hb hc hd heq
+    rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd
+    · exact hS a b c d ha hb hc hd hab hcd heq
+    · have h := hS a b d c ha hb hd hc hab hcd (by omega)
+      rw [Set.pair_comm d c] at h; exact h
+    · have h := hS b a c d hb ha hc hd hab hcd (by omega)
+      rw [Set.pair_comm b a] at h; exact h
+    · have h := hS b a d c hb ha hd hc hab hcd (by omega)
+      rw [Set.pair_comm b a, Set.pair_comm d c] at h; exact h
+  · intro hS a b c d ha hb hc hd _ _ heq
+    exact hS a b c d ha hb hc hd heq
 
 /-
 ## Maximal Sidon Sets
@@ -107,9 +93,9 @@ the Sidon property. This gives maximal Sidon sets of size approximately N^{1/2}.
 -/
 
 /-- Greedy Sidon set construction (specification) -/
-def greedySidon : ℕ → Set ℕ
+noncomputable def greedySidon : ℕ → Set ℕ
   | 0 => ∅
-  | n + 1 => 
+  | n + 1 =>
     let A := greedySidon n
     if IsSidonSet (A ∪ {n + 1}) then A ∪ {n + 1} else A
 
@@ -131,12 +117,13 @@ theorem greedySidon_subset_interval (N : ℕ) : greedySidon N ⊆ Interval N := 
   | zero => intro x hx; simp [greedySidon] at hx
   | succ n ih =>
     intro x hx
-    unfold greedySidon at hx
+    simp only [greedySidon] at hx
     split_ifs at hx with h
     · -- Case: added n+1
-      rcases Set.mem_union.mp hx with hx' | hx'
+      rcases (Set.mem_union _ _ _).mp hx with hx' | hx'
       · exact ⟨(ih hx').1, le_trans (ih hx').2 (Nat.le_succ n)⟩
-      · exact ⟨by omega, le_of_eq (Set.mem_singleton_iff.mp hx').symm⟩
+      · have hxe : x = n + 1 := Set.mem_singleton_iff.mp hx'
+        exact ⟨by omega, by omega⟩
     · -- Case: didn't add
       exact ⟨(ih hx).1, le_trans (ih hx).2 (Nat.le_succ n)⟩
 
@@ -144,17 +131,17 @@ theorem greedySidon_subset_interval (N : ℕ) : greedySidon N ⊆ Interval N := 
 private lemma greedySidon_mono (m n : ℕ) (hmn : m ≤ n) :
     greedySidon m ⊆ greedySidon n := by
   induction n with
-  | zero => simp only [Nat.le_zero] at hmn; subst hmn
+  | zero => simp only [Nat.le_zero] at hmn; subst hmn; exact Set.Subset.rfl
   | succ k ih =>
     rcases eq_or_lt_of_le hmn with rfl | hlt
     · exact Set.Subset.rfl
     · exact Set.Subset.trans (ih (by omega)) (by
-        unfold greedySidon; split_ifs <;> [exact Set.subset_union_left; exact Set.Subset.rfl])
+        simp only [greedySidon]; split_ifs <;> [exact Set.subset_union_left; exact Set.Subset.rfl])
 
 /-- If x was not added at its step, the Sidon check failed. -/
 private lemma greedySidon_rejected (n : ℕ) (h : n + 1 ∉ greedySidon (n + 1)) :
     ¬IsSidonSet (greedySidon n ∪ {n + 1}) := by
-  unfold greedySidon at h
+  simp only [greedySidon] at h
   split_ifs at h with h_check
   · exact absurd (Set.mem_union_right _ rfl) h
   · exact h_check
@@ -188,9 +175,9 @@ Classical results show that Sidon sets in {1,...,N} have size at most √N + O(N
 The greedy algorithm achieves close to this bound.
 -/
 
-/-- Upper bound: any Sidon set in {1,...,N} has size at most √N + O(1) -/
+/- Upper bound: any Sidon set in {1,...,N} has size at most √N + O(1) -/
 
-/-- The greedy construction achieves size Ω(√N) -/
+/- The greedy construction achieves size Ω(√N) -/
 
 /-
 ## Ruzsa's Construction
@@ -199,7 +186,7 @@ Ruzsa [Ru98b] showed there exist maximal Sidon sets of size much smaller than
 the greedy algorithm achieves. Specifically, size o((N log N)^{1/3}) is possible.
 -/
 
-/-- Ruzsa's result: maximal Sidon sets of size close to N^{1/3} exist -/
+/- Ruzsa's result: maximal Sidon sets of size close to N^{1/3} exist -/
 
 /-
 ## The Main Conjecture
@@ -209,7 +196,7 @@ This is stronger than Ruzsa's result, asking for exactly N^{1/3} rather than
 N^{1/3+ε}.
 -/
 
-/-- 
+/-
 Erdős Problem #156 (Open):
 
 Does there exist a maximal Sidon set A ⊂ {1,...,N} of size O(N^{1/3})?
@@ -229,10 +216,9 @@ The current state of knowledge shows a significant gap:
 
 /-- The minimum size of a maximal Sidon set in {1,...,N} -/
 noncomputable def minMaximalSidonSize (N : ℕ) : ℕ :=
-  Nat.find (⟨greedySidon N, greedySidon_is_sidon N,
-    greedySidon_subset_interval N⟩ : ∃ A, IsSidonSet A ∧ A ⊆ Interval N)
+  sInf {n | ∃ A, IsMaximalSidonSet A N ∧ size A = n}
 
-/-- The exponent of the minimum size growth -/
+/- The exponent of the minimum size growth -/
 
 /-
 ## Connection to Additive Combinatorics
@@ -290,7 +276,7 @@ private lemma sumset_eq_image (A : Set ℕ) :
   · rintro ⟨a, b, ha, hb, rfl⟩
     by_cases h : a ≤ b
     · exact ⟨a, b, ⟨ha, hb, h⟩, rfl⟩
-    · exact ⟨b, a, ⟨hb, ha, le_of_not_le h⟩, by ring⟩
+    · exact ⟨b, a, ⟨hb, ha, le_of_not_ge h⟩, by ring⟩
   · rintro ⟨a, b, ⟨ha, hb, _⟩, rfl⟩
     exact ⟨a, b, ha, hb, rfl⟩
 
@@ -365,12 +351,13 @@ private lemma card_upper_tri (s : Finset ℕ) :
         · exact Or.inr (Or.inl ⟨hmem, rfl⟩)
         · exact Or.inr (Or.inr ⟨hmem, hgt⟩)
       · rintro (⟨hmem, _⟩ | ⟨hmem, _⟩ | ⟨hmem, _⟩) <;> exact hmem
-    rw [h_total_eq,
-      Finset.card_union_of_disjoint (by
+    conv_lhs => rw [h_total_eq]
+    rw [Finset.card_union_of_disjoint (by
         rw [Finset.disjoint_left]; intro ⟨a, b⟩ h1 h2
         simp only [Finset.mem_filter, Finset.mem_union, Finset.mem_product] at h1 h2
         rcases h2 with ⟨_, hab⟩ | ⟨_, hab⟩ <;> omega),
       Finset.card_union_of_disjoint (Finset.disjoint_filter.2 fun ⟨a, b⟩ _ h1 h2 => by omega)]
+    omega
   -- Combine: from h_three and symmetry, 2*|{<}| + |diag| = s.card²
   rw [Finset.card_product, h_diag, h_sym] at h_three
   -- h_three: s.card * s.card = |{<}| + s.card + |{<}|
@@ -390,7 +377,7 @@ theorem sidon_sumset_size (A : Set ℕ) (hA : IsSidonSet A) (hfin : A.Finite) :
   rw [sumset_eq_image]
   have hpairs_fin : Set.Finite {p : ℕ × ℕ | p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 ≤ p.2} :=
     (hfin.prod hfin).subset (fun p hp => ⟨hp.1, hp.2.1⟩)
-  rw [Set.ncard_image_of_injOn (sidon_sum_injOn A hA) hpairs_fin]
+  rw [Set.ncard_image_of_injOn (sidon_sum_injOn A hA)]
   -- Convert Set.ncard to Finset.card
   rw [Set.ncard_eq_toFinset_card _ hpairs_fin, Set.ncard_eq_toFinset_card _ hfin]
   -- Show the pair set's toFinset equals the filtered product
@@ -398,7 +385,7 @@ theorem sidon_sumset_size (A : Set ℕ) (hA : IsSidonSet A) (hfin : A.Finite) :
       (hfin.toFinset ×ˢ hfin.toFinset).filter (fun p : ℕ × ℕ => p.1 ≤ p.2) := by
     ext ⟨a, b⟩
     simp only [Set.Finite.mem_toFinset, Set.mem_setOf_eq,
-               Finset.mem_filter, Finset.mem_product]
+               Finset.mem_filter, Finset.mem_product, and_assoc]
   rw [h_eq]
   exact card_upper_tri hfin.toFinset
 
@@ -408,16 +395,19 @@ theorem sidon_sumset_size (A : Set ℕ) (hA : IsSidonSet A) (hfin : A.Finite) :
     is not injective (two distinct pairs collide), so |A+A| < |ordered pairs| = n(n+1)/2. -/
 theorem sidon_of_sumset_size (A : Set ℕ) (hfin : A.Finite)
     (h : (sumset A).ncard = A.ncard * (A.ncard + 1) / 2) : IsSidonSet A := by
-  set S := {p : ℕ × ℕ | p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 ≤ p.2}
+  set S := {p : ℕ × ℕ | p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 ≤ p.2} with hSdef
   set f := (fun p : ℕ × ℕ => p.1 + p.2)
   have hS_fin : S.Finite := (hfin.prod hfin).subset fun p hp => ⟨hp.1, hp.2.1⟩
   -- |S| = n(n+1)/2
   have h_S : S.ncard = A.ncard * (A.ncard + 1) / 2 := by
     rw [Set.ncard_eq_toFinset_card _ hS_fin, Set.ncard_eq_toFinset_card _ hfin]
-    convert card_upper_tri hfin.toFinset using 1
-    congr 1; ext ⟨a, b⟩
-    simp only [Set.Finite.mem_toFinset, Set.mem_setOf_eq,
-               Finset.mem_filter, Finset.mem_product]
+    have h_eq : hS_fin.toFinset =
+        (hfin.toFinset ×ˢ hfin.toFinset).filter (fun p : ℕ × ℕ => p.1 ≤ p.2) := by
+      ext ⟨a, b⟩
+      simp only [Set.Finite.mem_toFinset, hSdef, Set.mem_setOf_eq,
+                 Finset.mem_filter, Finset.mem_product, and_assoc]
+    rw [h_eq]
+    exact card_upper_tri hfin.toFinset
   -- sumset A = f '' S
   have h_im : sumset A = f '' S := sumset_eq_image A
   -- |f '' S| = |S| (from hypothesis and h_S)
@@ -430,16 +420,16 @@ theorem sidon_of_sumset_size (A : Set ℕ) (hfin : A.Finite)
     push_neg at h_not_inj
     obtain ⟨p, hp, q, hq, hfpq, hne⟩ := h_not_inj
     -- f '' S = f '' (S \ {q}) since f(q) = f(p) and p ∈ S \ {q}
-    have hp_diff : p ∈ S \ {q} := Set.mem_diff_singleton.mpr ⟨hp, Ne.symm hne⟩
+    have hp_diff : p ∈ S \ {q} := Set.mem_diff_singleton.mpr ⟨hp, hne⟩
     have h_im_eq : f '' S = f '' (S \ {q}) := by
       apply Set.Subset.antisymm
-      · intro z ⟨w, hw, rfl⟩
+      · rintro z ⟨w, hw, rfl⟩
         by_cases hwq : w = q
         · exact ⟨p, hp_diff, by rw [hwq, hfpq]⟩
         · exact ⟨w, Set.mem_diff_singleton.mpr ⟨hw, hwq⟩, rfl⟩
-      · exact Set.image_subset f Set.diff_subset
+      · exact Set.image_mono Set.diff_subset
     -- |S \ {q}| < |S| since q ∈ S and S is finite
-    have hS_fin_diff := hS_fin.diff ({q} : Set _)
+    have hS_fin_diff : (S \ ({q} : Set _)).Finite := hS_fin.diff
     have h_lt : (S \ {q}).ncard < S.ncard := by
       apply Set.ncard_lt_ncard _ hS_fin
       exact ⟨Set.diff_subset, fun h_sub =>
@@ -488,7 +478,7 @@ The question is whether this infimum is O(N^{1/3}).
 noncomputable def infMaximalSidonSize (N : ℕ) : ℝ :=
   ⨅ (A : Set ℕ) (_ : IsMaximalSidonSet A N), (size A : ℝ)
 
-/-- The main open question in precise form -/
+/- The main open question in precise form -/
 
 /-
 ## Greedy Sidon Size Lower Bound
@@ -511,7 +501,7 @@ Proof outline:
 
 /-- The greedy Sidon set is finite for each N -/
 lemma greedySidon_finite (N : ℕ) : (greedySidon N).Finite :=
-  Set.Finite.subset (Set.finite_Icc 1 N) fun x hx =>
+  Set.Finite.subset (Set.finite_Icc 1 N) fun _ hx =>
     Set.mem_Icc.mpr (greedySidon_subset_interval N hx)
 
 /-- Type-I shadow: elements expressible as b+c-a for a,b,c ∈ A (via a+x = b+c) -/
@@ -577,12 +567,18 @@ lemma not_sidon_after_insert (A : Set ℕ) (x : ℕ)
       · rcases orx d hd with hdA | rfl
         · -- c,d ∈ A: 2x=c+d, type II
           exact Or.inr ⟨c, d, hcA, hdA, by linarith⟩
-        · -- c∈A, d=x: 2x=c+x → c=x, contradicts c∈A and x∉A
-          exact absurd (show c = x by linarith) (fun h => hxA (h ▸ hcA))
+        · -- c∈A, d=x: from 2x=c+x get c=x, contradicting c∈A and x∉A
+          -- (after the `rfl` substitutions the inserted point is named `d` here)
+          exfalso; apply hxA
+          have hcd_eq : c = d := by omega
+          rw [← hcd_eq]; exact hcA
       · -- a=b=c=x
         rcases orx d hd with hdA | rfl
-        · -- d∈A: 2x=x+d → d=x, contradicts d∈A and x∉A
-          exact absurd (show d = x by linarith) (fun h => hxA (h ▸ hdA))
+        · -- d∈A: from 2x=x+d get d=x, contradicting d∈A and x∉A
+          -- (after the `rfl` substitutions the inserted point is named `c` here)
+          exfalso; apply hxA
+          have hcd_eq : c = d := by omega
+          rw [hcd_eq]; exact hdA
         · -- all four = x: {x,x}={x,x}, contradiction with hne
           exact absurd rfl hne
 
@@ -647,7 +643,7 @@ lemma sumset_ncard_le (A : Set ℕ) (hfin : A.Finite) :
 /-- The diffShadow of A has size at most |A| * |sumset A| ≤ |A| * (|A|*(|A|+1)/2).
     Every element of diffShadow A is `σ - a` for some `a ∈ A` and `σ ∈ sumset A`,
     so diffShadow A is contained in the image of `A ×ˢ sumset A`. -/
-lemma diffShadow_ncard_le (A : Set ℕ) (hA : IsSidonSet A) (hfin : A.Finite) :
+lemma diffShadow_ncard_le (A : Set ℕ) (_hA : IsSidonSet A) (hfin : A.Finite) :
     (diffShadow A).ncard ≤ A.ncard * (A.ncard * (A.ncard + 1) / 2) := by
   have hsfin : (sumset A).Finite := sumset_finite A hfin
   have hprodfin : (A ×ˢ sumset A).Finite := hfin.prod hsfin

--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -10,7 +10,7 @@
       "Sós"
     ],
     "sourceUrl": "https://erdosproblems.com/156",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos156Problem.lean",
     "tags": [
       "erdos",
@@ -18,8 +18,8 @@
       "additive-combinatorics",
       "extremal-combinatorics"
     ],
-    "badge": "wip",
-    "sorries": 15,
+    "badge": "verified",
+    "sorries": 0,
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",
     "erdosProblemStatus": "open",
@@ -36,41 +36,40 @@
         "module": "Mathlib.Data.Set.Finite"
       },
       {
-        "theorem": "Nat.find",
-        "description": "Finds smallest natural number satisfying a predicate",
-        "module": "Mathlib.Data.Nat.Find"
+        "theorem": "Set.ncard",
+        "description": "Natural-number cardinality of a set (0 for infinite sets)",
+        "module": "Mathlib.Data.Set.Card"
       },
       {
-        "theorem": "Real.sqrt",
-        "description": "Real square root function",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "theorem": "Finset.card_union_of_disjoint",
+        "description": "Cardinality of a disjoint union of finsets",
+        "module": "Mathlib.Data.Finset.Card"
       },
       {
-        "theorem": "Filter.Tendsto",
-        "description": "Tendsto for filter limits",
-        "module": "Mathlib.Order.Filter.Basic"
+        "theorem": "sInf",
+        "description": "Infimum over a set of naturals (minMaximalSidonSize)",
+        "module": "Mathlib.Order.CompleteLattice"
       },
       {
         "theorem": "iInf",
-        "description": "Infimum over indexed family",
+        "description": "Infimum over indexed family (infMaximalSidonSize)",
         "module": "Mathlib.Order.CompleteLattice"
       }
     ],
     "originalContributions": [
-      "STATUS CAVEAT (2026-06-27): the '(proved)'/'fully proved' annotations below describe the INTENDED formalization, not current machine-verified status. The file does NOT compile against pinned Mathlib v4.26.0 (~30 errors, 5 sorry-emitting declarations); see `assumptions`. A reformalization is required before any of these contributions can be claimed as verified.",
-      "Two equivalent formal definitions of Sidon sets (IsSidonSet with ≤, IsSidonSetAlt with <) with detailed equivalence proof (sidonSet_iff_alt) via four-case analysis",
-      "Greedy Sidon construction (greedySidon) with proved Sidon-ness (greedySidon_is_sidon), interval containment (greedySidon_subset_interval), and maximality (greedySidon_maximal) — all fully proved",
+      "Order-free characterization of Sidon sets (sidonSet_iff_alt): A is Sidon iff a+b=c+d ⟹ {a,b}={c,d} for all quadruples in A, proved via a four-way le_total case split with Set.pair_comm. (The earlier ≠-gated form of this lemma was mathematically false — dropping the diagonal a=b makes it strictly weaker than IsSidonSet, e.g. {1,2,3}; the corrected statement drops the gating.)",
+      "Greedy Sidon construction (greedySidon) with proved Sidon-ness (greedySidon_is_sidon), interval containment (greedySidon_subset_interval), monotonicity (greedySidon_mono), rejection condition (greedySidon_rejected), and maximality (greedySidon_maximal) — all fully proved",
       "Maximal Sidon set predicate (IsMaximalSidonSet), interval definition (Interval), and size function",
-      "Complete Sidon sumset characterization: |A+A| = n(n+1)/2 iff A is a Sidon set — three proved theorems: sidon_sumset_size (forward), sidon_of_sumset_size (converse), sidon_iff_sumset_size (biconditional)",
-      "Minimum maximal Sidon set size (minMaximalSidonSize via Nat.find) and real-valued infimum formulation (infMaximalSidonSize via iInf)",
+      "Complete Sidon sumset characterization: |A+A| = n(n+1)/2 iff A is a Sidon set — three proved theorems: sidon_sumset_size (forward), sidon_of_sumset_size (converse via image/injectivity counting), sidon_iff_sumset_size (biconditional)",
+      "Minimum maximal Sidon set size (minMaximalSidonSize via sInf over maximal-Sidon sizes) and real-valued infimum formulation (infMaximalSidonSize via iInf)",
       "Shadow framework for greedy lower bound: diffShadow and midShadow set definitions, not_sidon_after_insert lemma (proved), greedySidon_complement_in_shadow lemma (proved)",
-      "Three sorry lemmas forming the N^{1/3} lower bound: diffShadow_ncard_le (shadow union bound), midShadow_ncard_le (midpoint image bound), greedySidon_cube_lower_bound (N ≤ n + n·(n(n+1)/2) + n(n+1)/2)"
+      "Complete N^{1/3} lower-bound chain (all proved): diffShadow_ncard_le (shadow union bound), midShadow_ncard_le (midpoint image bound), and greedySidon_cube_lower_bound (N ≤ n + n·(n(n+1)/2) + n(n+1)/2, giving n ≥ Ω(N^{1/3}))"
     ],
     "axiomCount": 0,
-    "lineCount": 741,
-    "assumptions": "0 axioms. NOT machine-verified: as of 2026-06-27 this file does NOT compile against the pinned Mathlib v4.26.0 — `lake env lean Proofs/Erdos156Problem.lean` reports ~30 errors and 5 declarations emitting `sorry`. The breakage is pre-existing and pervasive (not confined to the 3 shadow-bound lemmas): the greedy construction declarations (greedySidon and helpers, L121/131/152/157) elaborate to `sorry`, the Sidon-set equivalence (L55/66/73/79/80) and sumset characterization (L354/388/393/415/433/436/437/442, incl. sidon_sumset_size and sidon_of_sumset_size) have unsolved goals / type-mismatches, and several orphan `/-- -/` docstrings (L191/193/202/219/235/491) are parse errors. The 3 shadow-bound fills added UNVERIFIED in #30726 (diffShadow_ncard_le, midShadow_ncard_le, greedySidon_cube_lower_bound) also fail (greedySidon_cube_lower_bound still emits `sorry` at L688; unknown identifier `x` at L581/585). A full reformalization against pinned Mathlib v4.26.0 is required before any 'proved'/'verified' claim. No part of this file is currently kernel-checked.",
+    "lineCount": 737,
+    "assumptions": "0 axioms, 0 sorries. Machine-verified: the file compiles cleanly (exit 0, no errors, no warnings, no `sorry`) against the pinned Mathlib v4.26.0 via `./proofs/scripts/docker-build.sh Proofs.Erdos156Problem`. Only the standard foundational axioms (propext, Classical.choice, Quot.sound) are used — `Classical.choice` enters through `open scoped Classical`, which supplies decidability for branching on the undecidable predicates IsSidonSet and Set.Finite in the greedy construction and size function; no `axiom` declarations, no `native_decide`/`Lean.ofReduceBool`, no `sorryAx`. Note: the file does not resolve the open Erdős conjecture itself (the O(N^{1/3}) existence question) — that remains stated as an open question. It formalizes and verifies the supporting theory (greedy maximal construction, sumset size characterization, and the Ω(N^{1/3}) greedy lower bound). Repaired from the prior non-compiling state in #30959 (Mathlib v4.26.0 drift: orphan docstrings, classical-decidability synthesis, renamed lemmas, tactic regressions, plus correction of the false sidonSet_iff_alt statement).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 19,
+    "theoremCount": 20,
     "definitionCount": 12,
     "additionalFiles": [
       "Proofs/Erdos156ProblemAristotle.lean",
@@ -82,7 +81,7 @@
     "historicalContext": "Simon Sidon introduced what are now called Sidon sets (or $B_2$ sequences) in 1932 while studying lacunary Fourier series. A Sidon set is a set of integers where all pairwise sums $a + b$ (with $a \\leq b$) are distinct. Erdős and Turán proved in 1941 that any Sidon set $A \\subseteq \\{1, \\ldots, N\\}$ has size at most $\\sqrt{N} + O(N^{1/4})$, and constructions based on modular arithmetic (Singer difference sets, Erdős-Turán) achieve this bound up to lower-order terms. The greedy algorithm — include each element that preserves the Sidon property — produces sets of size $\\Theta(\\sqrt{N})$.\n\nThe study of *maximal* Sidon sets — those that cannot be extended within $\\{1, \\ldots, N\\}$ — reveals a subtler landscape. The greedy construction automatically produces maximal sets, but these are large (size $\\sim \\sqrt{N}$). Erdős, Sárközy, and Sós [ESS94] asked whether much smaller maximal Sidon sets exist, specifically of size $O(N^{1/3})$. Ruzsa [Ru98b] made a breakthrough by constructing maximal Sidon sets of size $O(N^{1/3+\\varepsilon})$ for any $\\varepsilon > 0$, using a clever recursive method that creates sufficient 'coverage' of sums while keeping the set sparse.\n\nThe gap between Ruzsa's $N^{1/3+\\varepsilon}$ and the conjectured $N^{1/3}$ remains open. The exponent $1/3$ is natural: a maximal Sidon set of size $s$ must 'cover' all $\\sim N$ elements (each absent element must have its sum represented), and each pair in the set covers $O(s)$ sums, requiring $s^2 \\cdot s \\sim N$ — i.e., $s \\sim N^{1/3}$. Whether logarithmic factors can be eliminated is the core question. OEIS A382397 tracks related sequences.",
     "problemStatement": "A Sidon set $A \\subseteq \\{1, \\ldots, N\\}$ is **maximal** if for every $x \\in \\{1, \\ldots, N\\} \\setminus A$, the set $A \\cup \\{x\\}$ is not a Sidon set (i.e., adding $x$ creates a repeated sum).\n\n**Question**: Does there exist a constant $C > 0$ and a family of maximal Sidon sets $\\{A_N\\}_{N \\geq 1}$ with $|A_N| \\leq C \\cdot N^{1/3}$ for all $N$?",
     "text": "Does there exist a maximal Sidon set A ⊂ {1,...,N} of size O(N^{1/3})?",
-    "proofStrategy": "The formalization provides two equivalent definitions of Sidon sets — the standard version (`IsSidonSet`, requiring $a + b = c + d$ with $a \\leq b, c \\leq d$ to imply $\\{a,b\\} = \\{c,d\\}$) and a strict version (`IsSidonSetAlt`, requiring $a < b, c < d$ to imply $a = c, b = d$) — with a detailed proved equivalence. The greedy construction is defined recursively and proved to always yield Sidon sets (greedySidon_is_sidon) and to be maximal (greedySidon_maximal). The Erdős-Turán upper bound and Ruzsa's N^{1/3+ε} construction are mentioned in docstring comments only — they are not axiomatized or proved in this file. The main open conjecture (O(N^{1/3}) maximal Sidon sets) is stated as an open question in the description. The N^{1/3} lower bound framework is developed via diffShadow and midShadow sets, with greedySidon_complement_in_shadow proved, leaving three final shadow-size estimates as sorries.",
+    "proofStrategy": "The formalization provides two equivalent definitions of Sidon sets — the standard version (`IsSidonSet`, requiring $a + b = c + d$ with $a \\leq b, c \\leq d$ to imply $\\{a,b\\} = \\{c,d\\}$) and a strict version (`IsSidonSetAlt`, requiring $a < b, c < d$ to imply $a = c, b = d$) — with a detailed proved equivalence. The greedy construction is defined recursively and proved to always yield Sidon sets (greedySidon_is_sidon) and to be maximal (greedySidon_maximal). The Erdős-Turán upper bound and Ruzsa's N^{1/3+ε} construction are mentioned in docstring comments only — they are not axiomatized or proved in this file. The main open conjecture (O(N^{1/3}) maximal Sidon sets) is stated as an open question in the description. The N^{1/3} lower bound is fully proved via diffShadow and midShadow sets: greedySidon_complement_in_shadow shows every element of {1,...,N} lies in the greedy set or its shadow, and the three shadow-size estimates (diffShadow_ncard_le, midShadow_ncard_le, greedySidon_cube_lower_bound) are all proved, yielding N ≤ n + n·(n(n+1)/2) + n(n+1)/2 and hence n ≥ Ω(N^{1/3}).",
     "keyInsights": [
       "**Sidon sets are maximally spread sumsets**: A Sidon set $A$ has $|A + A| = |A|(|A|+1)/2$ — the maximum possible for its cardinality. This is because all pairwise sums are distinct, making Sidon sets extremal objects in additive combinatorics",
       "**The Erdős-Turán bound is tight**: The classical bound $|A| \\leq \\sqrt{N} + O(N^{1/4})$ for Sidon sets in $\\{1,\\ldots,N\\}$ is essentially sharp — constructions from finite geometry (Singer difference sets) achieve $|A| \\sim \\sqrt{N}$. The proof uses the pigeonhole principle: all $\\binom{|A|}{2} + |A|$ sums lie in $\\{2, \\ldots, 2N\\}$",
@@ -109,8 +108,8 @@
       "title": "Sidon Set Definitions",
       "startLine": 19,
       "endLine": 81,
-      "summary": "IsSidonSet (pairwise-sum-distinct with ≤ ordering), IsSidonSetAlt (strict < ordering), and proved equivalence sidonSet_iff_alt via four-case analysis on a ≤ b vs a > b and c ≤ d vs c > d.",
-      "mathContext": "IsSidonSet (pairwise-sum-distinct with ≤ ordering), IsSidonSetAlt (strict < ordering), and proved equivalence sidonSet_iff_alt via four-case analysis on a ≤ b vs a > b and c ≤ d vs c > d."
+      "summary": "IsSidonSet (pairwise-sum-distinct with ≤ ordering), IsSidonSetAlt (strict < ordering, provided as an auxiliary definition), and the order-free characterization sidonSet_iff_alt: A is Sidon iff a+b=c+d ⟹ {a,b}={c,d} for all quadruples, proved via a four-way le_total case split with Set.pair_comm.",
+      "mathContext": "IsSidonSet (pairwise-sum-distinct with ≤ ordering), IsSidonSetAlt (strict < ordering, provided as an auxiliary definition), and the order-free characterization sidonSet_iff_alt: A is Sidon iff a+b=c+d ⟹ {a,b}={c,d} for all quadruples, proved via a four-way le_total case split with Set.pair_comm."
     },
     {
       "id": "maximal-sidon",
@@ -133,8 +132,8 @@
       "title": "Classical Bounds and Minimum Size",
       "startLine": 184,
       "endLine": 235,
-      "summary": "Section comments on known bounds (Erdős-Turán, Ruzsa) and orphan docstrings (no Lean declarations for upper bound, Ruzsa result, or main conjecture — these are descriptive comments only). Defines minMaximalSidonSize via Nat.find using existence of greedySidon.",
-      "mathContext": "Section comments on known bounds (Erdős-Turán, Ruzsa) and orphan docstrings (no Lean declarations for upper bound, Ruzsa result, or main conjecture — these are descriptive comments only). Defines minMaximalSidonSize via Nat.find using existence of greedySidon."
+      "summary": "Section comments on known bounds (Erdős-Turán, Ruzsa) as descriptive block comments (no Lean declarations for upper bound, Ruzsa result, or main conjecture). Defines minMaximalSidonSize as the sInf of sizes of maximal Sidon sets in {1,...,N}.",
+      "mathContext": "Section comments on known bounds (Erdős-Turán, Ruzsa) as descriptive block comments (no Lean declarations for upper bound, Ruzsa result, or main conjecture). Defines minMaximalSidonSize as the sInf of sizes of maximal Sidon sets in {1,...,N}."
     },
     {
       "id": "additive-combinatorics",
@@ -161,16 +160,16 @@
       "mathContext": "Proof outline for greedy Ω(N^{1/3}) lower bound. greedySidon_finite (proved). diffShadow A = {x | ∃ a,b,c ∈ A, a+x=b+c} (Type-I shadow). midShadow A = {x | ∃ b,c ∈ A, b+c=2x} (Type-II shadow). not_sidon_after_insert (if A is Sidon and A∪{x} is not, then x ∈ diffShadow A or x ∈ midShadow A — proved). greedySidon_complement_in_shadow (every k ∈ {1,...,N} not in greedySidon N lies in its shadow — proved)."
     },
     {
-      "id": "shadow-bounds-sorries",
-      "title": "Shadow Size Bounds (3 Sorries)",
-      "startLine": 621,
-      "endLine": 652,
-      "summary": "Three sorry lemmas completing the N^{1/3} lower bound: diffShadow_ncard_le (|diffShadow A| ≤ |A|·(|A|(|A|+1)/2)), midShadow_ncard_le (|midShadow A| ≤ |A|(|A|+1)/2), greedySidon_cube_lower_bound (N ≤ n + n·(n(n+1)/2) + n(n+1)/2, giving n ≥ Ω(N^{1/3})). These are the Aristotle companion targets.",
-      "mathContext": "Three sorry lemmas completing the N^{1/3} lower bound: diffShadow_ncard_le (|diffShadow A| ≤ |A|·(|A|(|A|+1)/2)), midShadow_ncard_le (|midShadow A| ≤ |A|(|A|+1)/2), greedySidon_cube_lower_bound (N ≤ n + n·(n(n+1)/2) + n(n+1)/2, giving n ≥ Ω(N^{1/3})). These are the Aristotle companion targets."
+      "id": "shadow-bounds-proved",
+      "title": "Shadow Size Bounds (Proved)",
+      "startLine": 617,
+      "endLine": 737,
+      "summary": "Three proved lemmas completing the N^{1/3} lower bound: sumset_ncard_le (|A+A| ≤ n(n+1)/2 for any finite A), diffShadow_ncard_le (|diffShadow A| ≤ |A|·(|A|(|A|+1)/2) via image of A×(A+A)), midShadow_ncard_le (|midShadow A| ≤ |A|(|A|+1)/2 via image of A+A under σ↦σ/2), greedySidon_cube_lower_bound (N ≤ n + n·(n(n+1)/2) + n(n+1)/2 by covering {1,...,N} with A and its two shadows, giving n ≥ Ω(N^{1/3})).",
+      "mathContext": "Three proved lemmas completing the N^{1/3} lower bound: sumset_ncard_le (|A+A| ≤ n(n+1)/2 for any finite A), diffShadow_ncard_le (|diffShadow A| ≤ |A|·(|A|(|A|+1)/2) via image of A×(A+A)), midShadow_ncard_le (|midShadow A| ≤ |A|(|A|+1)/2 via image of A+A under σ↦σ/2), greedySidon_cube_lower_bound (N ≤ n + n·(n(n+1)/2) + n(n+1)/2 by covering {1,...,N} with A and its two shadows, giving n ≥ Ω(N^{1/3}))."
     }
   ],
   "conclusion": {
-    "summary": "This 652-line formalization of Erdős Problem #156 proves two equivalent Sidon set characterizations, constructs and fully proves the greedy Sidon algorithm (including maximality), and establishes the complete Sidon sumset size theorem (|A+A| = n(n+1)/2 iff A is Sidon — all three directions proved). The shadow framework (diffShadow, midShadow, greedySidon_complement_in_shadow) is fully proved, leaving three shadow-size estimates as sorries. Classical bounds (Erdős-Turán, Ruzsa's N^{1/3+ε}) and the main conjecture are mentioned in docstring comments only — they are not formalized as axioms or theorems in this file.",
+    "summary": "This 737-line formalization of Erdős Problem #156 (machine-verified, 0 sorries, 0 axioms against Mathlib v4.26.0) proves an order-free Sidon-set characterization, constructs and fully proves the greedy Sidon algorithm (including maximality), and establishes the complete Sidon sumset size theorem (|A+A| = n(n+1)/2 iff A is Sidon — all three directions proved). The shadow framework (diffShadow, midShadow, greedySidon_complement_in_shadow) and all three shadow-size estimates are proved, yielding the greedy Ω(N^{1/3}) lower bound. Classical bounds (Erdős-Turán, Ruzsa's N^{1/3+ε}) and the main open conjecture are mentioned in docstring comments only — they are not formalized as axioms or theorems in this file.",
     "implications": "**Theoretical Significance**: Resolution would determine the exact sparsity threshold for Sidon-type coverage: how few elements suffice to 'block' all possible extensions in {1,...,N}.\n\nAn affirmative answer (O(N^{1/3}) achievable) would require new constructions beyond Ruzsa's recursive method, potentially using algebraic or probabilistic techniques. A negative answer would establish a fundamental barrier separating the combinatorial notion of maximality from pure counting arguments.",
     "openQuestions": [
       "Does the growth exponent α = lim log(minMaximalSidonSize N)/log N exist, and if so, is it exactly 1/3?",
@@ -186,12 +185,12 @@
     ],
     "opens": [],
     "namespace": "Erdos156",
-    "lineCount": 741,
+    "lineCount": 737,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 20,
     "definitionCount": 12,
     "path": "Proofs/Erdos156Problem.lean",
-    "sorries": 15,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos156ProblemAristotle.lean",
       "Proofs/Erdos156Aristotle.lean",
@@ -229,5 +228,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
     }
   ],
-  "sorries": 15
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Repairs `proofs/Proofs/Erdos156Problem.lean` (Erdős Problem #156, minimum size of maximal Sidon sets) so it compiles cleanly against pinned Mathlib **v4.26.0**. The file now builds with **exit 0, zero errors, zero warnings, zero sorries** via `./proofs/scripts/docker-build.sh Proofs.Erdos156Problem`.

Contrary to the issue's estimate of "3 shadow-bound lemmas may need sorry", the shadow-bound lemmas had complete proofs all along — their prior "declaration uses sorry" was a **cascade** from upstream errors. Fixing the real errors makes the entire file **0-sorry / 0-axiom** (only foundational `propext` / `Classical.choice` / `Quot.sound`).

## Changes (per region)

| Region | Fix |
|--------|-----|
| Orphan `/-- -/` docstrings (L191/193/202/212/235/491) | → `/- -/` block comments |
| `size`, `greedySidon` defs | `open scoped Classical` for decidability on `IsSidonSet` / `Set.Finite`; mark `noncomputable` |
| greedy proofs (subset_interval, mono, rejected) | `unfold` → `simp only [greedySidon]` so `split_ifs` sees the `ite` through the `let`; fix zero-case `Subset.rfl`; singleton-membership branch omega |
| `sidonSet_iff_alt` | **Corrected a false statement.** The `a≠b, c≠d` gating drops the diagonal and is strictly weaker than `IsSidonSet` (counterexample `{1,2,3}`: distinct-pair sums 3,4,5 are distinct so the gated RHS holds, yet `2+2=1+3` breaks `IsSidonSet`). Restated as the order-free `a+b=c+d ⟹ {a,b}={c,d}` and proved via four-way `le_total` split + `Set.pair_comm`. |
| `card_upper_tri` | `conv_lhs` so `rw [h_total_eq]` no longer rewrites the RHS filters |
| `sidon_sumset_size` / `sidon_of_sumset_size` | drop removed finiteness arg from `Set.ncard_image_of_injOn`; `and_assoc` in toFinset↔filter simp; `Set.mem_diff_singleton` direction; `intro`→`rintro`; `Set.image_subset`→`Set.image_mono`; `Set.Finite.diff` implicit-arg signature |
| `not_sidon_after_insert` | diagonal branches referenced `x` after it was substituted away by `rfl`; derive the `c=d` contradiction via `omega` instead |
| `minMaximalSidonSize` | replace broken `Nat.find` (existential was over `Set ℕ`, not `ℕ`) with `sInf` over maximal-Sidon sizes |

## Build evidence

```
$ ./proofs/scripts/docker-build.sh Proofs.Erdos156Problem
✖→✔ [7743/7743] Building Proofs.Erdos156Problem
EXIT=0   (0 errors, 0 warnings, 0 'declaration uses sorry')
```

Final inventory: **0 sorries, 0 `axiom` declarations, 0 `native_decide`**. Foundational axioms only (`Classical.choice` via `open scoped Classical`, `propext`, `Quot.sound`) — these do not count per the axiom-integrity policy.

## Acceptance Criteria Verification

| Criterion (from issue) | Status | Verification |
|---|---|---|
| Orphan docstrings → block comments | ✅ | L191/193/202/212/235/491 converted |
| Repair Sidon-equivalence / greedy / sumset proofs | ✅ | All compile; `sidonSet_iff_alt` corrected (was false) |
| Shadow-bound lemmas: complete or honest sorry | ✅ | All three **completed** (cascade sorry, not real) |
| Build clean via docker wrapper, exit 0 | ✅ | Exit 0, no errors/warnings/sorries |
| Update gallery meta honestly | ✅ | `status`→verified, `badge`→verified, sorries 15→0 (meta + leanFile + top-level), counts/line updated, caveat/assumptions rewritten |

## Meta changes (`src/data/proofs/erdos-156/meta.json`)

- `status`: `formalized` → `verified`; `badge`: `wip` → `verified`
- `sorries`: 15 → 0 (all three locations); `lineCount` 741→737; `theoremCount` 19→20
- Removed the "NOT machine-verified" caveat and rewrote `assumptions` to describe the verified 0-sorry/0-axiom state (and the `Classical.choice` provenance)
- Corrected contribution/section prose that described `sidonSet_iff_alt` (false gated form) and the "3 sorry" shadow bounds

Note: this file does **not** resolve the open Erdős conjecture (O(N^{1/3}) existence) — that remains stated as an open question. It verifies the supporting theory (greedy maximal construction, sumset-size characterization, greedy Ω(N^{1/3}) lower bound).

Closes #30959