### PR TITLE
research: recover 4 drift-broken proofs from cleanup backups (Part 2 of #35084)

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ0102.lean
+++ b/proofs/Proofs/AbundantNumberOQ0102.lean
@@ -1,0 +1,103 @@
+/-
+  The smallest ODD abundant number is 945.
+
+  A positive integer `n` is *abundant* when the sum of its proper divisors
+  exceeds `n` (`Nat.Abundant n : n < ∑ d ∈ n.properDivisors, d`). The smallest
+  abundant number is 12 (see `AbundantNumberOQ01.lean`), but 12 is even. Every
+  abundant number below 945 turns out to be even; the smallest *odd* abundant
+  number is `945 = 3³·5·7`, whose proper divisors sum to
+  `1+3+5+7+9+15+21+27+35+45+63+105+135+189+315 = 975 > 945`
+  (equivalently `σ(945) = 40·6·8 = 1920 > 1890 = 2·945`). This is OEIS A005231.
+
+  ## Discharging the bounded range
+
+  The minimality claim quantifies over the odd numbers below 945. Discharging
+  `∀ n < 945, Odd n → ¬ Nat.Abundant n` by kernel `decide` directly on Mathlib's
+  `Nat.Abundant` would force the kernel to evaluate `Finset.filter`/`Finset.sum`
+  over `Finset.range n` for each `n` — a `Quotient`-backed computation the Lean
+  kernel reduces very slowly.
+
+  We compute the proper-divisor sum with a `List`-based function `pdSum`
+  (structural recursion on `List` plus GMP-accelerated `Nat.mod` for the
+  divisibility tests, no `Quotient`). The bridge lemma `pdSum_eq` identifies it
+  with `∑ d ∈ n.properDivisors, d` once, symbolically; the bounded check then
+  runs on `pdSum` and `Odd n` short-circuits the even cases.
+
+  ### Verification status: `native_decide` (Lean.ofReduceBool)
+
+  The two large finite computations (`abundant_945` and the bounded minimality
+  check `check_odd_below`) are discharged with `native_decide`. Under the pinned
+  Lean/Mathlib v4.26 toolchain, kernel `decide` over the full 945-range exhausts
+  the kernel's native reduction stack (build aborts with signal 135), so the
+  computation is delegated to the compiler. `native_decide` therefore introduces
+  the `Lean.ofReduceBool` axiom: this entry is **axiomatized**, not axiom-free.
+  The symbolic bridge lemmas (`listRange_filter_sum_eq`, `pdSum_eq`) and the
+  small checks (`odd_945`) remain ordinary kernel proofs.
+-/
+import Mathlib
+
+namespace AbundantNumberOQ0102
+
+/-- `List`-based sum of the proper divisors of `n`: the divisors `d` with
+`d < n` (and `d ≥ 1`, automatic since `0 ∣ n` only for `n = 0`). Defined over
+`List.range n` so the kernel can reduce it without `Finset`/`Quotient` overhead. -/
+def pdSum (n : ℕ) : ℕ := ((List.range n).filter (fun d => decide (d ∣ n))).sum
+
+/-- Bridge: the `List`-based filtered sum over `List.range n` agrees with the
+`Finset`-based filtered sum over `Finset.range n`. Proved by induction so it does
+not depend on exact Mathlib lemma names; used purely symbolically (never under
+`decide`). -/
+theorem listRange_filter_sum_eq (n : ℕ) (p : ℕ → Prop) [DecidablePred p] :
+    ((List.range n).filter (fun d => decide (p d))).sum
+      = ∑ i ∈ (Finset.range n).filter p, i := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [List.range_succ, List.filter_append, List.sum_append, ih,
+        Finset.range_succ, Finset.filter_insert]
+    by_cases hk : p k
+    · rw [if_pos hk, Finset.sum_insert (by simp)]
+      simp [List.filter_cons, hk, Nat.add_comm]
+    · rw [if_neg hk]
+      simp [List.filter_cons, hk]
+
+/-- `pdSum n` equals the proper-divisor sum used in `Nat.Abundant` (for `n ≠ 0`). -/
+theorem pdSum_eq (n : ℕ) (hn : n ≠ 0) :
+    pdSum n = ∑ d ∈ n.properDivisors, d := by
+  rw [pdSum, listRange_filter_sum_eq n (· ∣ n), Nat.filter_dvd_eq_properDivisors hn]
+
+/-- **945 is abundant.** Its proper divisors sum to `975 > 945`. -/
+theorem abundant_945 : Nat.Abundant 945 := by
+  unfold Nat.Abundant
+  rw [← pdSum_eq 945 (by decide)]
+  native_decide
+
+/-- 945 is odd. -/
+theorem odd_945 : Odd (945 : ℕ) := by decide
+
+/-- The bounded minimality check: every odd `n < 945` has proper-divisor sum at
+most `n`, i.e. is not abundant. The `Odd n` hypothesis is evaluated first, so the
+even cases are discharged immediately without computing `pdSum`. Discharged by
+`native_decide` (see the header note on verification status). -/
+theorem check_odd_below : ∀ n < 945, Odd n → pdSum n ≤ n := by native_decide
+
+/-- No odd number below 945 is abundant. -/
+theorem not_abundant_odd_below (n : ℕ) (hlt : n < 945) (hodd : Odd n) :
+    ¬ Nat.Abundant n := by
+  have hn : n ≠ 0 := by rintro rfl; exact absurd hodd (by decide)
+  unfold Nat.Abundant
+  rw [← pdSum_eq n hn]
+  exact Nat.not_lt.mpr (check_odd_below n hlt hodd)
+
+/-- **945 is the smallest odd abundant number.** It is odd and abundant, and it
+is a lower bound for the set of odd abundant numbers. -/
+theorem smallest_odd_abundant :
+    IsLeast {n : ℕ | Odd n ∧ Nat.Abundant n} 945 := by
+  refine ⟨⟨odd_945, abundant_945⟩, ?_⟩
+  intro n hn
+  obtain ⟨hodd, hab⟩ := hn
+  by_contra h
+  push_neg at h
+  exact not_abundant_odd_below n h hodd hab
+
+end AbundantNumberOQ0102

--- a/proofs/Proofs/Erdos1014OQ01.lean
+++ b/proofs/Proofs/Erdos1014OQ01.lean
@@ -75,8 +75,10 @@ theorem ramsey_pos (k l : ℕ) (hk : k ≥ 1) (hl : l ≥ 1) :
   -- HasRamseyProperty (Fin 0) k l is impossible: Fin 0 is empty, can't form any clique
   let c : EdgeColoring (Fin 0) := ⟨fun i => Fin.elim0 i, fun i => Fin.elim0 i, fun i => Fin.elim0 i⟩
   obtain (⟨red, hred, _⟩ | ⟨blue, hblue, _⟩) := hspec c
-  · have := red.card_le_univ; simp [Fintype.card_fin] at this; omega
-  · have := blue.card_le_univ; simp [Fintype.card_fin] at this; omega
+  · have hc : red.card ≤ Fintype.card (Fin 0) := red.card_le_univ
+    rw [Fintype.card_fin] at hc; omega
+  · have hc : blue.card ≤ Fintype.card (Fin 0) := blue.card_le_univ
+    rw [Fintype.card_fin] at hc; omega
 
 -- ══════════════════════════════════════════════════════════════════
 -- § Property 2: Monotonicity R(k, l) ≤ R(k, l+1)
@@ -91,7 +93,7 @@ theorem ramsey_monotone_right (k l : ℕ) :
       show ¬((0 : ℕ) ≥ 1 ∧ l + 1 ≥ 1) from by omega]
   rcases Nat.eq_zero_or_pos l with rfl | hl
   · show ramseyNumber k 0 ≤ ramseyNumber k (0 + 1)
-    unfold ramseyNumber; simp [show ¬(k ≥ 1 ∧ (0 : ℕ) ≥ 1) from by omega]; omega
+    unfold ramseyNumber; simp [show ¬(k ≥ 1 ∧ (0 : ℕ) ≥ 1) from by omega]
   · -- Main case: k ≥ 1, l ≥ 1
     -- HasRamseyProperty (Fin (R(k,l+1))) k (l+1) holds by spec
     -- From a blue (l+1)-clique, take an l-subset to get HasRamseyProperty for k l
@@ -101,8 +103,8 @@ theorem ramsey_monotone_right (k l : ℕ) :
       ramseyNumber_spec k (l + 1) hk (by omega) c
     · left; exact ⟨red, hred_card, hred⟩
     · right
-      obtain ⟨t, ht_sub, ht_card⟩ := Finset.exists_smaller_set blue l (by omega)
-      exact ⟨t, ht_card, hblue.mono (Finset.coe_subset.mpr ht_sub)⟩
+      obtain ⟨t, ht_sub, ht_card⟩ := Finset.exists_subset_card_eq (show l ≤ blue.card by omega)
+      exact ⟨t, ht_card, hblue.subset (Finset.coe_subset.mpr ht_sub)⟩
 
 -- ══════════════════════════════════════════════════════════════════
 -- § Property 3: R(2, l) = l for l ≥ 1

--- a/proofs/Proofs/Erdos1014OQ04.lean
+++ b/proofs/Proofs/Erdos1014OQ04.lean
@@ -1,0 +1,210 @@
+/-
+Erdős Problem #1014 OQ-04: Ratio Convergence for k = 4 via Mattheus–Verstraëte Bounds
+
+We prove that R(4, l+1) / R(4, l) → 1 as l → ∞, resolving the k = 4 case
+of Erdős Problem #1014.
+
+The parent problem asks: for fixed k ≥ 3, does R(k, l+1)/R(k, l) → 1 as l → ∞?
+OQ-01 resolved k = 3 using the Kim–Shearer quadratic lower bound R(3,l) ≥ c·l²/log l.
+This file resolves **k = 4** using the recent breakthrough of Mattheus and
+Verstraëte (2024), who determined the order of magnitude of the off-diagonal
+Ramsey number R(4,l):
+      R(4, l) = Θ( l³ / (log l)⁴ ).
+
+The proof structure exactly mirrors OQ-01 one dimension up:
+
+  (1) The Ramsey recurrence R(4, l+1) ≤ R(4, l) + R(3, l+1)   [proved in OQ-01]
+  (2) The classical AKS upper bound R(3, l) ≤ C · l²/log l    [axiom]
+  (3) The Mattheus–Verstraëte lower bound R(4, l) ≥ c · l³/(log l)⁴  [axiom]
+
+Key insight: the increment R(4,l+1) − R(4,l) ≤ R(3,l+1) grows only like l²
+(one Ramsey dimension below), while R(4,l) itself grows like l³.  Hence
+      R(4,l+1)/R(4,l) − 1  ≤  R(3,l+1)/R(4,l)
+                           ≤  (4C/c) · (log l)⁴ / l  →  0.
+
+So the *cubic* growth of R(4,l) dominates the *quadratic* increment, forcing the
+ratio to 1.  The polylog factors are irrelevant to convergence: any bounds of
+order l² (numerator) and l³ (denominator) suffice, which is exactly the
+qualitative content the Mattheus–Verstraëte theorem now guarantees for k = 4.
+
+Axioms used (both are published theorems, stated as hypotheses):
+  * R3_upper_bound_aks — Ajtai–Komlós–Szemerédi (1980): R(3,l) = O(l²/log l).
+  * R4_lower_bound_mv  — Mattheus–Verstraëte (2024): R(4,l) = Ω(l³/(log l)⁴).
+All Ramsey-number infrastructure (the *definition* and the recurrence,
+monotonicity, positivity) is imported from OQ-01 and is axiom-free.
+
+References:
+- Erdős [Er71], Problem 1014, p. 99
+- Ajtai, Komlós, Szemerédi (1980): R(3,l) ≤ C·l²/log l
+- Mattheus, Verstraëte, "The asymptotics of r(4,t)", Annals of Mathematics (2024):
+  R(4,l) = Θ(l³/(log l)⁴)
+- <https://erdosproblems.com/1014>
+-/
+
+import Mathlib
+import Proofs.Erdos1014OQ01
+
+open Real Filter Topology Asymptotics
+
+namespace Erdos1014OQ04
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Deep-result axioms (published theorems, stated as hypotheses)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- **Ajtai–Komlós–Szemerédi (1980)** upper bound: there is a constant `C > 0`
+    with `R(3, l) ≤ C · l² / log l` for all large `l`. -/
+axiom R3_upper_bound_aks :
+    ∃ C : ℝ, C > 0 ∧ ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
+      (Erdos1014OQ01.ramseyNumber 3 l : ℝ) ≤ C * (l : ℝ) ^ 2 / Real.log (l : ℝ)
+
+/-- **Mattheus–Verstraëte (2024)** lower bound: there is a constant `c > 0`
+    with `R(4, l) ≥ c · l³ / (log l)⁴` for all large `l`.  This is the recent
+    determination of the order of magnitude of `R(4, l)`. -/
+axiom R4_lower_bound_mv :
+    ∃ c : ℝ, c > 0 ∧ ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
+      (Erdos1014OQ01.ramseyNumber 4 l : ℝ) ≥ c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Step 1: Increment bound from the Ramsey recurrence
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The Ramsey recurrence `R(4, l+1) ≤ R(4, l) + R(3, l+1)` (the `k = 4`
+    specialisation of the general recurrence proved in OQ-01). -/
+theorem increment_bound_k4 (l : ℕ) (hl : l ≥ 1) :
+    Erdos1014OQ01.ramseyNumber 4 (l + 1) ≤
+      Erdos1014OQ01.ramseyNumber 4 l + Erdos1014OQ01.ramseyNumber 3 (l + 1) := by
+  have h := Erdos1014OQ01.ramsey_recurrence 4 l (by norm_num) hl
+  simpa using h
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Step 2: Analysis lemma — (log l)⁴ / l → 0
+-- ══════════════════════════════════════════════════════════════════
+
+/-- `(x ^ (1/4)) ^ 4 = x` for `x ≥ 0`. -/
+private lemma rpow_quarter_pow_four {x : ℝ} (hx : 0 ≤ x) :
+    (x ^ ((1 : ℝ) / 4)) ^ (4 : ℕ) = x := by
+  rw [← Real.rpow_natCast (x ^ ((1 : ℝ) / 4)) 4, ← Real.rpow_mul hx,
+      show ((1 : ℝ) / 4) * ((4 : ℕ) : ℝ) = 1 by push_cast; ring, Real.rpow_one]
+
+/-- `(log x)⁴ / x → 0` as `x → ∞`.  Proof: `log x =o[atTop] x^(1/4)`, raise to
+    the 4th power to get `(log x)⁴ =o[atTop] (x^(1/4))⁴ = x`, then divide. -/
+private lemma tendsto_log_pow_four_div_atTop :
+    Tendsto (fun x : ℝ => (Real.log x) ^ 4 / x) atTop (𝓝 0) := by
+  have hr : (0 : ℝ) < 1 / 4 := by norm_num
+  have hlo : (fun x : ℝ => (Real.log x) ^ 4) =o[atTop]
+      (fun x : ℝ => (x ^ ((1 : ℝ) / 4)) ^ 4) :=
+    (isLittleO_log_rpow_atTop hr).pow (by norm_num)
+  have htd := hlo.tendsto_div_nhds_zero
+  refine htd.congr' ?_
+  filter_upwards [eventually_gt_atTop (0 : ℝ)] with x hx
+  rw [rpow_quarter_pow_four hx.le]
+
+/-- For every `ε > 0`, eventually `(log l)⁴ / l < ε` (over natural `l`). -/
+private lemma eventually_log4_div_small (ε : ℝ) (hε : 0 < ε) :
+    ∃ L : ℕ, ∀ l : ℕ, l > L → (Real.log (l : ℝ)) ^ 4 / (l : ℝ) < ε := by
+  have hnat : Tendsto (fun n : ℕ => (Real.log (n : ℝ)) ^ 4 / (n : ℝ)) atTop (𝓝 0) :=
+    tendsto_log_pow_four_div_atTop.comp tendsto_natCast_atTop_atTop
+  have hev := hnat.eventually (Iio_mem_nhds hε)
+  obtain ⟨L, hL⟩ := Filter.eventually_atTop.mp hev
+  exact ⟨L, fun l hl => Set.mem_Iio.mp (hL l (le_of_lt hl))⟩
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Main Theorem
+-- ══════════════════════════════════════════════════════════════════
+
+/-- **Erdős Problem #1014 for k = 4**: `R(4, l+1) / R(4, l) → 1` as `l → ∞`.
+
+    Proved from the Ramsey recurrence together with the AKS upper bound on
+    `R(3,·)` and the Mattheus–Verstraëte lower bound on `R(4,·)`. -/
+theorem erdos_1014_k4_ratio_convergence :
+    ∀ ε : ℝ, ε > 0 → ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
+      |(Erdos1014OQ01.ramseyNumber 4 (l + 1) : ℝ) /
+        (Erdos1014OQ01.ramseyNumber 4 l : ℝ) - 1| < ε := by
+  intro ε hε
+  obtain ⟨C, hC, L₁, hL₁⟩ := R3_upper_bound_aks
+  obtain ⟨c, hc, L₂, hL₂⟩ := R4_lower_bound_mv
+  obtain ⟨L₃, hL₃⟩ := eventually_log4_div_small (ε * c / (4 * C)) (by positivity)
+  refine ⟨max (max (max L₁ L₂) L₃) 3, fun l hl => ?_⟩
+  have hlL₁ : l > L₁ := by omega
+  have hlL₂ : l > L₂ := by omega
+  have hlL₃ : l > L₃ := by omega
+  have hl4 : (4 : ℝ) ≤ (l : ℝ) := by exact_mod_cast (show 4 ≤ l by omega)
+  have hl_pos : (0 : ℝ) < (l : ℝ) := by linarith
+  have hl_ge1 : l ≥ 1 := by omega
+  have hlog_pos : 0 < Real.log (l : ℝ) := Real.log_pos (by linarith)
+  set R := (Erdos1014OQ01.ramseyNumber 4 l : ℝ) with hR_def
+  set R' := (Erdos1014OQ01.ramseyNumber 4 (l + 1) : ℝ) with hR'_def
+  -- Positivity of the denominator R(4,l).
+  have hR_pos : R > 0 := by
+    simp only [hR_def]
+    have := Erdos1014OQ01.ramsey_pos 4 l (by omega) hl_ge1
+    exact_mod_cast (show 0 < Erdos1014OQ01.ramseyNumber 4 l by omega)
+  -- Monotonicity R(4,l) ≤ R(4,l+1) makes the ratio ≥ 1.
+  have hmon : R ≤ R' := by
+    simp only [hR_def, hR'_def]
+    exact_mod_cast Erdos1014OQ01.ramsey_monotone_right 4 l
+  -- Increment: R' − R ≤ R(3, l+1).
+  have hInc : R' - R ≤ (Erdos1014OQ01.ramseyNumber 3 (l + 1) : ℝ) := by
+    simp only [hR_def, hR'_def]
+    have h := increment_bound_k4 l hl_ge1
+    have : (Erdos1014OQ01.ramseyNumber 4 (l + 1) : ℝ) ≤
+        (Erdos1014OQ01.ramseyNumber 4 l : ℝ) +
+          (Erdos1014OQ01.ramseyNumber 3 (l + 1) : ℝ) := by exact_mod_cast h
+    linarith
+  -- Numerator bound: R(3, l+1) ≤ 4·C·l² (AKS, then drop the log and the +1).
+  have hlog1 : (1 : ℝ) ≤ Real.log ((l : ℝ) + 1) := by
+    have hexp : Real.exp 1 ≤ (l : ℝ) + 1 := by
+      have h9 := Real.exp_one_lt_d9
+      linarith
+    calc (1 : ℝ) = Real.log (Real.exp 1) := by rw [Real.log_exp]
+      _ ≤ Real.log ((l : ℝ) + 1) := Real.log_le_log (Real.exp_pos 1) hexp
+  have hNum : (Erdos1014OQ01.ramseyNumber 3 (l + 1) : ℝ) ≤ 4 * C * (l : ℝ) ^ 2 := by
+    have hUB := hL₁ (l + 1) (by omega)
+    -- hUB : R(3,l+1) ≤ C·(l+1)²/log(l+1)
+    have hcast : ((l + 1 : ℕ) : ℝ) = (l : ℝ) + 1 := by push_cast; ring
+    rw [hcast] at hUB
+    have hstep1 : C * ((l : ℝ) + 1) ^ 2 / Real.log ((l : ℝ) + 1) ≤
+        C * ((l : ℝ) + 1) ^ 2 :=
+      div_le_self (by positivity) hlog1
+    have hstep2 : C * ((l : ℝ) + 1) ^ 2 ≤ 4 * C * (l : ℝ) ^ 2 := by
+      have hsq : ((l : ℝ) + 1) ^ 2 ≤ 4 * (l : ℝ) ^ 2 := by
+        nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ (l : ℝ) - 1)
+          (by linarith : (0 : ℝ) ≤ 3 * (l : ℝ) + 1)]
+      nlinarith [hsq, hC.le]
+    linarith
+  -- Denominator bound: R ≥ c·l³/(log l)⁴ > 0.
+  have hDen : c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4 ≤ R := by
+    simp only [hR_def]; exact hL₂ l hlL₂
+  have hDenPos : 0 < c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4 := by
+    apply div_pos (by positivity) (pow_pos hlog_pos 4)
+  -- |R'/R − 1| = (R' − R)/R since R ≤ R' and R > 0.
+  have habs : |R' / R - 1| = (R' - R) / R := by
+    have h_eq : R' / R - 1 = (R' - R) / R := by field_simp
+    rw [abs_of_nonneg]
+    · exact h_eq
+    · rw [h_eq]; exact div_nonneg (by linarith) (by linarith)
+  rw [habs]
+  -- Rewrite the target upper bound in the (log l)⁴/l shape.
+  have hl_ne : (l : ℝ) ≠ 0 := ne_of_gt hl_pos
+  have hc_ne : c ≠ 0 := ne_of_gt hc
+  have hC_ne : C ≠ 0 := ne_of_gt hC
+  have hlog_ne : Real.log (l : ℝ) ≠ 0 := ne_of_gt hlog_pos
+  have hcast_eq : (4 * C * (l : ℝ) ^ 2) / (c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4)
+      = (4 * C / c) * ((Real.log (l : ℝ)) ^ 4 / (l : ℝ)) := by
+    rw [div_div_eq_mul_div]
+    field_simp
+  have hfac : (0 : ℝ) < 4 * C / c := by positivity
+  calc (R' - R) / R
+      ≤ (Erdos1014OQ01.ramseyNumber 3 (l + 1) : ℝ) / R :=
+        div_le_div_of_nonneg_right hInc (le_of_lt hR_pos)
+    _ ≤ (4 * C * (l : ℝ) ^ 2) / R :=
+        div_le_div_of_nonneg_right hNum (le_of_lt hR_pos)
+    _ ≤ (4 * C * (l : ℝ) ^ 2) / (c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4) :=
+        div_le_div_of_nonneg_left (by positivity) hDenPos hDen
+    _ = (4 * C / c) * ((Real.log (l : ℝ)) ^ 4 / (l : ℝ)) := hcast_eq
+    _ < (4 * C / c) * (ε * c / (4 * C)) :=
+        mul_lt_mul_of_pos_left (hL₃ l hlL₃) hfac
+    _ = ε := by field_simp
+
+end Erdos1014OQ04

--- a/proofs/Proofs/FourSquareDistributionOQ04ArrangeFinal.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ04ArrangeFinal.lean
@@ -1,0 +1,162 @@
+import Mathlib
+import Proofs.FourSquareDistributionOQ04Surj
+
+/-
+# Four-Square Distribution — OQ-04: the arrangement-count residue, discharged
+
+This file closes the single open combinatorial residue of the OQ-04
+generalization, `arrangement_card`:
+
+  `(arrangements s).card = Nat.multinomial s.toFinset s.count = m! / ∏_v (count_v)!`,
+
+where `arrangements s = { g : Fin m → ℤ | multiset(g) = s }`. Prior sessions
+reduced the entire open question (`fiber_card_eq_contribution` in
+`…OQ04Decomp/Sign/Keystone`) to exactly this count, and flagged the orbit
+–surjectivity step ("two tuples with equal value-multiset differ by a
+permutation") as the genuine blocker with no direct Mathlib lemma.
+
+That blocker is discharged by `FourSquareDistributionOQ04Surj.exists_perm_comp`
+(via `Tuple.sort` + sorted-list uniqueness). This file assembles the rest by
+orbit–stabilizer counting of the precomposition action of `Equiv.Perm (Fin m)`:
+
+* `stabilizer_card_eq_prod_count` — the stabilizer of an arrangement has order
+  `∏_v (count_v)!`, via `DomMulAct.stabilizer_card'`;
+* `comp_perm_mem` — precomposition preserves the arrangement set;
+* `fiber_card` — every fiber of `σ ↦ g₀ ∘ σ` over `arrangements s` has size
+  `∏_v (count_v)!` (translate of the stabilizer by a surjectivity witness);
+* `arrangements_card_mul_prod_count` — `card(arrangements) · ∏count! = m!`
+  (fiberwise count of `Equiv.Perm (Fin m)`, `Fintype.card_perm`);
+* `arrangement_card` — the `Nat.multinomial` headline, by `Nat.multinomial_spec`.
+
+All Mathlib API name-checked against the project pin (`2df2f0150c`, v4.26.0).
+-/
+
+namespace FourSquareDistributionOQ04ArrangeFinal
+
+open Finset
+open scoped Nat
+
+/-- Arrangements of a multiset `s` as functions `Fin m → ℤ` (verbatim from the
+parent `…Arrange.lean`). -/
+def arrangements {m : ℕ} (s : Multiset ℤ) : Finset (Fin m → ℤ) :=
+  (Fintype.piFinset (fun _ : Fin m => s.toFinset)).filter
+    (fun g => Multiset.map g (Finset.univ : Finset (Fin m)).val = s)
+
+theorem mem_arrangements_iff {m : ℕ} (s : Multiset ℤ) (g : Fin m → ℤ) :
+    g ∈ arrangements s ↔ Multiset.map g (Finset.univ : Finset (Fin m)).val = s := by
+  classical
+  simp only [arrangements, Finset.mem_filter, Fintype.mem_piFinset, Multiset.mem_toFinset]
+  constructor
+  · rintro ⟨_, h⟩; exact h
+  · intro h
+    refine ⟨fun i => ?_, h⟩
+    rw [← h]
+    exact Multiset.mem_map_of_mem g (Finset.mem_val.mpr (Finset.mem_univ i))
+
+/-- The image of an arrangement is exactly `s.toFinset`. -/
+theorem image_eq_toFinset_of_mem {m : ℕ} (s : Multiset ℤ) {g : Fin m → ℤ}
+    (hg : g ∈ arrangements s) :
+    (Finset.univ : Finset (Fin m)).image g = s.toFinset := by
+  classical
+  rw [mem_arrangements_iff] at hg
+  rw [← hg, Multiset.toFinset_map, Finset.val_toFinset]
+
+/-- The `i`-fiber of an arrangement has size `s.count i`. -/
+theorem card_fiber_eq_count {m : ℕ} (s : Multiset ℤ) {g : Fin m → ℤ}
+    (hg : g ∈ arrangements s) (i : ℤ) :
+    Fintype.card {a : Fin m // g a = i} = s.count i := by
+  classical
+  rw [mem_arrangements_iff] at hg
+  have hfeq : (Finset.univ : Finset (Fin m)).val.filter (fun a : Fin m => g a = i)
+      = (Finset.univ : Finset (Fin m)).val.filter (fun a : Fin m => i = g a) :=
+    Multiset.filter_congr (fun a _ => eq_comm)
+  rw [Fintype.card_subtype, ← hg, Multiset.count_map, Finset.card_def, Finset.filter_val, hfeq]
+
+/-- **Stabilizer order = ∏ count!** for an arrangement `g`, from
+`DomMulAct.stabilizer_card'`. -/
+theorem stabilizer_card_eq_prod_count {m : ℕ} (s : Multiset ℤ) {g : Fin m → ℤ}
+    (hg : g ∈ arrangements s) :
+    Fintype.card {σ : Equiv.Perm (Fin m) // g ∘ σ = g}
+      = ∏ v ∈ s.toFinset, (s.count v)! := by
+  classical
+  rw [DomMulAct.stabilizer_card' (f := g), image_eq_toFinset_of_mem s hg]
+  refine Finset.prod_congr rfl (fun v _ => ?_)
+  rw [card_fiber_eq_count s hg v]
+
+/-- Precomposition by a permutation preserves arrangement membership. -/
+theorem comp_perm_mem {m : ℕ} {s : Multiset ℤ} {g : Fin m → ℤ}
+    (hg : g ∈ arrangements s) (σ : Equiv.Perm (Fin m)) :
+    g ∘ σ ∈ arrangements s := by
+  rw [mem_arrangements_iff] at hg ⊢
+  rw [← hg, ← Multiset.map_map, Multiset.map_univ_val_equiv]
+
+/-- **Every fiber has size `∏ count!`.** For `h ∈ arrangements s`, the fiber of
+`σ ↦ g₀ ∘ σ` over `h` is a translate of the stabilizer of `g₀` (by a
+surjectivity witness `ρ` with `g₀ ∘ ρ = h`), hence has the stabilizer's order. -/
+theorem fiber_card {m : ℕ} (s : Multiset ℤ) {g₀ : Fin m → ℤ}
+    (hg₀ : g₀ ∈ arrangements s) {h : Fin m → ℤ} (hh : h ∈ arrangements s) :
+    (Finset.univ.filter (fun σ : Equiv.Perm (Fin m) => g₀ ∘ σ = h)).card
+      = ∏ v ∈ s.toFinset, (s.count v)! := by
+  classical
+  have hms : Multiset.map g₀ (Finset.univ : Finset (Fin m)).val
+           = Multiset.map h (Finset.univ : Finset (Fin m)).val := by
+    rw [(mem_arrangements_iff s g₀).1 hg₀, (mem_arrangements_iff s h).1 hh]
+  obtain ⟨ρ, hρ⟩ := FourSquareDistributionOQ04Surj.exists_perm_comp hms
+  rw [← stabilizer_card_eq_prod_count s hg₀, Fintype.card_subtype]
+  refine Finset.card_nbij' (fun σ => σ * ρ⁻¹) (fun σ => σ * ρ) ?_ ?_ ?_ ?_
+  · intro σ hσ
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hσ ⊢
+    rw [Equiv.Perm.coe_mul, ← Function.comp_assoc, hσ, ← hρ, Function.comp_assoc,
+        ← Equiv.Perm.coe_mul, mul_inv_cancel, Equiv.Perm.coe_one, Function.comp_id]
+  · intro σ hσ
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hσ ⊢
+    rw [Equiv.Perm.coe_mul, ← Function.comp_assoc, hσ]
+    exact hρ
+  · intro σ _
+    show σ * ρ⁻¹ * ρ = σ
+    rw [mul_assoc, inv_mul_cancel, mul_one]
+  · intro σ _
+    show σ * ρ * ρ⁻¹ = σ
+    rw [mul_assoc, mul_inv_cancel, mul_one]
+
+/-- **Residue: `card (arrangements s) · ∏count! = m!`.** Fiberwise count of
+`Equiv.Perm (Fin m)` under `σ ↦ g₀ ∘ σ`, with all fibers of size `∏count!`. -/
+theorem arrangements_card_mul_prod_count {m : ℕ} (s : Multiset ℤ)
+    (hm : Multiset.card s = m) :
+    (arrangements (m := m) s).card * ∏ v ∈ s.toFinset, (s.count v)! = m ! := by
+  classical
+  obtain ⟨g₀, hg₀⟩ : (arrangements (m := m) s).Nonempty := by
+    have hlen : s.toList.length = m := by rw [Multiset.length_toList, hm]
+    exact ⟨s.toList.get ∘ ⇑(finCongr hlen.symm), by
+      rw [mem_arrangements_iff, ← Multiset.map_map, Multiset.map_univ_val_equiv,
+          Fin.univ_val_map, List.ofFn_get, Multiset.coe_toList]⟩
+  have key : Fintype.card (Equiv.Perm (Fin m))
+      = (arrangements (m := m) s).card * ∏ v ∈ s.toFinset, (s.count v)! := by
+    rw [← Finset.card_univ,
+        Finset.card_eq_sum_card_fiberwise
+          (f := fun σ : Equiv.Perm (Fin m) => g₀ ∘ σ)
+          (t := arrangements (m := m) s) (fun σ _ => comp_perm_mem hg₀ σ),
+        Finset.sum_congr rfl (fun h hh => fiber_card s hg₀ hh),
+        Finset.sum_const, smul_eq_mul]
+  rw [← key, Fintype.card_perm, Fintype.card_fin]
+
+/-- **The residue, in `Nat.multinomial` form** — discharging the parent's
+`arrangement_card` sorry. -/
+theorem arrangement_card {m : ℕ} (s : Multiset ℤ) (hm : Multiset.card s = m) :
+    (arrangements (m := m) s).card
+      = Nat.multinomial s.toFinset (fun v => s.count v) := by
+  have hmul := arrangements_card_mul_prod_count s hm
+  have hspec : (∏ v ∈ s.toFinset, (s.count v)!)
+        * Nat.multinomial s.toFinset (fun v => s.count v) = m ! := by
+    have h := Nat.multinomial_spec s.toFinset (fun v => s.count v)
+    rwa [Multiset.toFinset_sum_count_eq, hm] at h
+  have hP : (0 : ℕ) < ∏ v ∈ s.toFinset, (s.count v)! :=
+    Finset.prod_pos (fun v _ => Nat.factorial_pos _)
+  refine mul_right_cancel₀ hP.ne' ?_
+  rw [hmul, mul_comm]
+  exact hspec.symm
+
+#check @arrangement_card
+#check @arrangements_card_mul_prod_count
+
+end FourSquareDistributionOQ04ArrangeFinal

--- a/proofs/Proofs/LovaszLocalLemmaOQ01Pairwise.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01Pairwise.lean
@@ -1,0 +1,108 @@
+/-
+# Lovász Local Lemma — OQ-01: Pairwise (two-event) inclusion–exclusion avoidance
+
+The sibling entry `LovaszLocalLemmaOQ01.lean` lands the `d = 0` (mutually
+independent) base case of the measure-theoretic Lovász Local Lemma, and
+`LovaszLocalLemmaOQ01UnionBound.lean` gives the dependency-free first-moment
+(union) bound `μ (⋂ᵢ Aᵢᶜ) ≥ 1 - Σ μ (Aᵢ)`. Both bottom out where the events carry
+*no* dependency information.
+
+This file takes the **first inductive increment beyond full independence** flagged
+as an open question of OQ-01: the exact **two-event inclusion–exclusion** avoidance,
+valid for *any* dependency structure. For two measurable events `A, B` in a real
+probability space,
+
+  `μ ((A ∪ B)ᶜ) + μ A + μ B = 1 + μ (A ∩ B)`,
+
+the cancellation-free form of `μ ((A ∪ B)ᶜ) = 1 - μ A - μ B + μ (A ∩ B)` (stated
+additively to sidestep the truncated subtraction of `ℝ≥0∞`). The `μ (A ∩ B)` term is
+exactly the correction the union bound discards, so:
+
+* joint avoidance is positive **iff** `μ (A ∪ B) < 1` (`avoidance_two_pos`);
+* it stays positive under the *weaker* hypothesis `μ A + μ B < 1 + μ (A ∩ B)`, so
+  overlap (positive dependency) strictly relaxes the union-bound threshold
+  (`avoidance_two_pos_of_lt`);
+* the two-event avoidance always dominates the first-moment bound
+  (`avoidance_two_ge_union`);
+* under independence the correction becomes `μ A · μ B`, matching the `n = 2` case
+  of the base-case factorization (`avoidance_two_indep_add`).
+
+Everything is over an arbitrary real `IsProbabilityMeasure`; fully verified,
+0 sorries, 0 axioms.
+-/
+import Mathlib.Probability.Independence.Basic
+
+open MeasureTheory ProbabilityTheory
+open scoped ENNReal
+
+namespace LovaszLocalLemmaOQ01Pairwise
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} {A B : Set Ω}
+
+/-- **Exact two-event avoidance (inclusion–exclusion, additive form).**
+For any two measurable events in a probability space, the joint-avoidance
+probability `μ ((A ∪ B)ᶜ)` obeys the cancellation-free inclusion–exclusion identity
+`μ ((A ∪ B)ᶜ) + μ A + μ B = 1 + μ (A ∩ B)` — the additive rendering of
+`μ ((A ∪ B)ᶜ) = 1 - μ A - μ B + μ (A ∩ B)`, which avoids the truncated subtraction
+of `ℝ≥0∞`. -/
+theorem avoidance_two_add [IsProbabilityMeasure μ]
+    (hA : MeasurableSet A) (hB : MeasurableSet B) :
+    μ ((A ∪ B)ᶜ) + μ A + μ B = 1 + μ (A ∩ B) := by
+  have hcompl : μ (A ∪ B) + μ ((A ∪ B)ᶜ) = 1 := by
+    rw [measure_add_measure_compl (hA.union hB), measure_univ]
+  have hincl : μ (A ∪ B) + μ (A ∩ B) = μ A + μ B := measure_union_add_inter A hB
+  calc μ ((A ∪ B)ᶜ) + μ A + μ B
+      = μ ((A ∪ B)ᶜ) + (μ A + μ B) := by rw [add_assoc]
+    _ = μ ((A ∪ B)ᶜ) + (μ (A ∪ B) + μ (A ∩ B)) := by rw [← hincl]
+    _ = (μ (A ∪ B) + μ ((A ∪ B)ᶜ)) + μ (A ∩ B) := by rw [add_left_comm, ← add_assoc]
+    _ = 1 + μ (A ∩ B) := by rw [hcompl]
+
+/-- **Two-event avoidance is positive iff the union is not almost sure.**
+Two bad events — with *any* dependency structure — can be jointly avoided with
+positive probability exactly when `μ (A ∪ B) < 1`. This is the honest two-event
+instance of the Lovász Local Lemma conclusion `μ (⋂ Aᵢᶜ) > 0`. -/
+theorem avoidance_two_pos [IsProbabilityMeasure μ]
+    (hA : MeasurableSet A) (hB : MeasurableSet B) :
+    0 < μ ((A ∪ B)ᶜ) ↔ μ (A ∪ B) < 1 := by
+  rw [prob_compl_eq_one_sub (hA.union hB), tsub_pos_iff_lt]
+
+/-- **Dependency-aware positivity threshold.**
+Joint avoidance of two events is positive as soon as `μ A + μ B < 1 + μ (A ∩ B)`.
+When the events overlap (`μ (A ∩ B) > 0`) this is strictly weaker than the
+union-bound requirement `μ A + μ B < 1`: positive dependency *relaxes* the
+threshold, the first quantitative sign that dependency information helps — the
+phenomenon the general LLL exploits. -/
+theorem avoidance_two_pos_of_lt [IsProbabilityMeasure μ]
+    (hA : MeasurableSet A) (hB : MeasurableSet B)
+    (h : μ A + μ B < 1 + μ (A ∩ B)) :
+    0 < μ ((A ∪ B)ᶜ) := by
+  rw [pos_iff_ne_zero]
+  intro h0
+  have hkey := avoidance_two_add (μ := μ) hA hB
+  rw [h0, zero_add] at hkey
+  exact absurd hkey h.ne
+
+/-- **Two-event avoidance dominates the first-moment (union) bound.**
+`1 - (μ A + μ B) ≤ μ ((A ∪ B)ᶜ)`, recovering the dependency-free union bound; the
+exact surplus over it is the correction term `μ (A ∩ B)` supplied by
+`avoidance_two_add`. -/
+theorem avoidance_two_ge_union [IsProbabilityMeasure μ]
+    (hA : MeasurableSet A) (hB : MeasurableSet B) :
+    1 - (μ A + μ B) ≤ μ ((A ∪ B)ᶜ) := by
+  rw [tsub_le_iff_right]
+  calc (1 : ℝ≥0∞) ≤ 1 + μ (A ∩ B) := le_self_add
+    _ = μ ((A ∪ B)ᶜ) + μ A + μ B := (avoidance_two_add hA hB).symm
+    _ = μ ((A ∪ B)ᶜ) + (μ A + μ B) := by rw [add_assoc]
+
+/-- **Independence specialization (consistency with the `d = 0` base case).**
+When `A` and `B` are independent, `μ (A ∩ B) = μ A · μ B`, so the two-event
+inclusion–exclusion identity becomes the product form
+`μ ((A ∪ B)ᶜ) + μ A + μ B = 1 + μ A · μ B`, i.e. `μ ((A ∪ B)ᶜ) = (1 - μ A)(1 - μ B)`.
+This is exactly the `n = 2` instance of `lll_independent_meas_iInter_compl`, so the
+pairwise and independent developments agree where they overlap. -/
+theorem avoidance_two_indep_add [IsProbabilityMeasure μ]
+    (hA : MeasurableSet A) (hB : MeasurableSet B) (hind : IndepSet A B μ) :
+    μ ((A ∪ B)ᶜ) + μ A + μ B = 1 + μ A * μ B := by
+  rw [avoidance_two_add hA hB, hind.measure_inter_eq_mul]
+
+end LovaszLocalLemmaOQ01Pairwise


### PR DESCRIPTION
## Part of #35084 — Part 2 (8 hard drift candidates)

Recovers/repairs 4 of the 8 "harder repair" candidates whose sole copies lived in the 2026-07-05 cleanup backups. Each was extracted from a bundle branch or worktree tarball (extraction refs per #35069), repaired against **Mathlib v4.26.0**, and **verified SOLO** with `./proofs/scripts/docker-build.sh` (never raw `lake build`).

### Landed (build EXIT=0)
| Module | Status | Repair |
|---|---|---|
| `LovaszLocalLemmaOQ01Pairwise` | verified (0/0) | `add_comm` rewrite drift → `add_left_comm`; stuck `IsProbabilityMeasure` metavar → explicit `(μ := μ)` |
| `FourSquareDistributionOQ04ArrangeFinal` | verified (0/0) | stale factorial `!` → `open scoped Nat` |
| `AbundantNumberOQ0102` | **axiomatized** (`Lean.ofReduceBool`) | kernel `decide` over the 945-range exhausts the kernel stack under v4.26 (signal 135); the two large finite checks now use `native_decide`; docstring updated to disclose the axiom honestly |
| `Erdos1014OQ04` | **axiomatized** (2 stated hypotheses: AKS `R(3,l)` upper, Mattheus–Verstraëte `R(4,l)` lower) | trailing `ring` after `field_simp` removed |

Also fixes pre-existing v4.26 drift in the **on-main** base file `Proofs/Erdos1014OQ01.lean` (silently unbuildable, was blocking `Erdos1014OQ04`): `Finset.exists_smaller_set` → `Finset.exists_subset_card_eq`, `IsClique.mono` → `IsClique.subset`, a redundant `omega`, and simp-normal-form `omega` failures. **No new sorries/axioms** (its pre-existing Kim–Shearer axiom is untouched).

### Written off this pass (per-candidate rationale commented on #35084)
- `CauchySchwarzIntegral…Incomplete01{Infra,Loc,Norm}` — deep measure-theory Lp-Riesz API drift (10+ errors in `Infra` alone: stuck typeclasses, rewrite/synthesis failures).
- `KroneckersJugendtraumRealQuadAbelian` — candidate file is clean, but its on-main base `KroneckersJugendtraum.lean` has 15 deep errors (`IsCyclotomicExtension` index-type change, removed `IsCyclotomicExtension.refl`, `finrank` rename, `∃`-instance-binder syntax, double docstrings).

### Axiom accounting
All four landed files pass a comment-aware `sorry`/`axiom` audit. `AbundantNumberOQ0102` and `Erdos1014OQ04` are **axiomatized** (not verified) with honest disclosure; the other two are fully verified 0/0.

### Follow-ups (NOT this PR)
- Gallery integration (`src/data/proofs/<slug>/`) for the 4 recovered proofs — researcher-pipeline work.
- The 2 written-off candidates (need substantive base-file rework).
- Part 3 enricher-JSON batch — audited and found **fully superseded** by later main enrichment + enum normalization (0 survivors); no PR needed.
- Backups left untouched (Part 4 disposition on #35084).

🤖 Generated with [Claude Code](https://claude.com/claude-code)