### PR TITLE
Fill 9 of 12 sorries in Erdos125PositiveLowerDensity (digit + Dirichlet layers)

### DIFF
--- a/proofs/Proofs/Erdos125PositiveLowerDensity.lean
+++ b/proofs/Proofs/Erdos125PositiveLowerDensity.lean
@@ -30,9 +30,15 @@ we inline the relevant density definitions below.
 The AlphaProof Nexus proof is 370 lines of highly compressed automated-proof-search
 tactic output. Many lemmas use elaborate one-line proofs that interleave dozens of
 tactics including `bound`, `valid`, and other custom tactics from FormalConjectures.
-A faithful line-by-line port is left as a follow-up task; this file presently
-**states** each lemma with a `sorry` placeholder so the high-level structure
-matches the AlphaProof source, and the dependency graph is correct.
+Most of these have now been ported to pure Mathlib v4.26.0 (see #20842): the
+digit-combinatorics layer (`A_max_k`, `B_max_m`, `A_B_gap`, `A_decomp`, `B_decomp`
+and their `head`/`tail` helpers), the irrationality of `log 4 / log 3`, and the
+Dirichlet-reduction chain (`exists_small_pos_lin_comb`,
+`exists_small_pos_lin_comb_large_k`, `dirichlet_approx`). Three deep lemmas still
+carry `sorry` placeholders: `exists_small_pos_lin_comb_help` (the Dirichlet
+approximation theorem for an irrational), `scale_step` (the multi-scale counting
+core), and `AB_lowerDensity_eq_zero` (the `liminf` bridge). The high-level
+structure and dependency graph match the AlphaProof source throughout.
 
 ## Proof strategy (from the natural-language note)
 
@@ -101,9 +107,10 @@ def B : Set ℕ := { x : ℕ | (Nat.digits 4 x).toFinset ⊆ {0, 1} }
 The lemmas below mirror exactly the structure of the AlphaProof Nexus proof
 (see https://github.com/google-deepmind/alphaproof-nexus-results, file
 `APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`).
-Their one-line AlphaProof tactic proofs do not port cleanly to a pure Mathlib
-setup; we therefore state them with `sorry` here. A faithful line-by-line port
-is tracked as a follow-up sub-issue. -/
+The AlphaProof one-line `bound`/`valid` tactic proofs were re-derived in pure
+Mathlib v4.26.0 (#20842); three deep lemmas — `exists_small_pos_lin_comb_help`,
+`scale_step`, and `AB_lowerDensity_eq_zero` — remain `sorry` and are tracked as
+follow-up work. -/
 
 lemma zero_in_A : 0 ∈ A := by
   -- AlphaProof: `norm_num`

--- a/proofs/Proofs/Erdos125PositiveLowerDensity.lean
+++ b/proofs/Proofs/Erdos125PositiveLowerDensity.lean
@@ -117,13 +117,186 @@ lemma zero_in_A_plus_B : 0 ∈ A + B := by
   refine ⟨0, zero_in_A, 0, zero_in_B, ?_⟩
   simp
 
+/-! ### Digit helper lemmas for `A` (base 3)
+
+Membership in `A` is stable under taking the low digit (`% 3`) and the tail
+(`/ 3`), which lets us reason about `A` by peeling one base-3 digit at a time.
+These replace the AlphaProof `bound`/`valid` golf with explicit `Nat.digits`
+manipulation. -/
+
+/-- The lowest base-3 digit of an element of `A` is `0` or `1`. -/
+lemma A_head3 (x : ℕ) (hx : x ∈ A) : x % 3 ≤ 1 := by
+  rcases Nat.eq_zero_or_pos x with rfl | hpos
+  · omega
+  · have hsub : (Nat.digits 3 x).toFinset ⊆ {0, 1} := hx
+    have hd : Nat.digits 3 x = x % 3 :: Nat.digits 3 (x / 3) :=
+      Nat.digits_def' (by norm_num) hpos
+    have hmem : x % 3 ∈ (Nat.digits 3 x).toFinset := by rw [hd]; simp
+    have hcase := hsub hmem
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hcase
+    omega
+
+/-- Dropping the lowest base-3 digit (`/ 3`) keeps an element inside `A`. -/
+lemma A_tail3 (x : ℕ) (hx : x ∈ A) : x / 3 ∈ A := by
+  rcases Nat.eq_zero_or_pos x with rfl | hpos
+  · rw [Nat.zero_div]; exact zero_in_A
+  · have hsub : (Nat.digits 3 x).toFinset ⊆ {0, 1} := hx
+    have hd : Nat.digits 3 x = x % 3 :: Nat.digits 3 (x / 3) :=
+      Nat.digits_def' (by norm_num) hpos
+    show (Nat.digits 3 (x / 3)).toFinset ⊆ {0, 1}
+    intro d hd2
+    apply hsub
+    rw [hd]
+    simp only [List.toFinset_cons, Finset.mem_insert]
+    exact Or.inr hd2
+
+/-- Reassemble membership in `A` from the lowest digit and the tail. -/
+lemma mem_A_of_head_tail (x : ℕ) (h1 : x % 3 ≤ 1) (h2 : x / 3 ∈ A) : x ∈ A := by
+  rcases Nat.eq_zero_or_pos x with rfl | hpos
+  · exact zero_in_A
+  · have hsub2 : (Nat.digits 3 (x / 3)).toFinset ⊆ {0, 1} := h2
+    have hd : Nat.digits 3 x = x % 3 :: Nat.digits 3 (x / 3) :=
+      Nat.digits_def' (by norm_num) hpos
+    show (Nat.digits 3 x).toFinset ⊆ {0, 1}
+    rw [hd, List.toFinset_cons, Finset.insert_subset_iff]
+    refine ⟨?_, hsub2⟩
+    simp only [Finset.mem_insert, Finset.mem_singleton]
+    omega
+
+/-- Dividing by `3 ^ k` (dropping the low `k` base-3 digits) keeps `A`. -/
+lemma A_div_pow (k a : ℕ) (ha : a ∈ A) : a / 3 ^ k ∈ A := by
+  induction k with
+  | zero => simpa using ha
+  | succ k ih =>
+    have h : a / 3 ^ (k + 1) = a / 3 ^ k / 3 := by
+      rw [pow_succ, Nat.div_div_eq_div_mul]
+    rw [h]
+    exact A_tail3 _ ih
+
+/-- Reducing mod `3 ^ k` (keeping the low `k` base-3 digits) keeps `A`. -/
+lemma A_mod_pow : ∀ (k a : ℕ), a ∈ A → a % 3 ^ k ∈ A := by
+  intro k
+  induction k with
+  | zero => intro a _; rw [pow_zero, Nat.mod_one]; exact zero_in_A
+  | succ k ih =>
+    intro a ha
+    have htail : a / 3 ∈ A := A_tail3 a ha
+    have hs : (a / 3) % 3 ^ k ∈ A := ih (a / 3) htail
+    have hhead : a % 3 ≤ 1 := A_head3 a ha
+    have hmod : a % 3 ^ (k + 1) = a % 3 + 3 * (a / 3 % 3 ^ k) := by
+      rw [pow_succ']; exact Nat.mod_mul
+    rw [hmod]
+    set T := a / 3 % 3 ^ k with hT
+    apply mem_A_of_head_tail
+    · have h3 : (a % 3 + 3 * T) % 3 = a % 3 := by omega
+      rw [h3]; exact hhead
+    · have h4 : (a % 3 + 3 * T) / 3 = T := by omega
+      rw [h4]; exact hs
+
+/-! ### Digit helper lemmas for `B` (base 4) -/
+
+/-- The lowest base-4 digit of an element of `B` is `0` or `1`. -/
+lemma B_head4 (y : ℕ) (hy : y ∈ B) : y % 4 ≤ 1 := by
+  rcases Nat.eq_zero_or_pos y with rfl | hpos
+  · omega
+  · have hsub : (Nat.digits 4 y).toFinset ⊆ {0, 1} := hy
+    have hd : Nat.digits 4 y = y % 4 :: Nat.digits 4 (y / 4) :=
+      Nat.digits_def' (by norm_num) hpos
+    have hmem : y % 4 ∈ (Nat.digits 4 y).toFinset := by rw [hd]; simp
+    have hcase := hsub hmem
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hcase
+    omega
+
+/-- Dropping the lowest base-4 digit (`/ 4`) keeps an element inside `B`. -/
+lemma B_tail4 (y : ℕ) (hy : y ∈ B) : y / 4 ∈ B := by
+  rcases Nat.eq_zero_or_pos y with rfl | hpos
+  · rw [Nat.zero_div]; exact zero_in_B
+  · have hsub : (Nat.digits 4 y).toFinset ⊆ {0, 1} := hy
+    have hd : Nat.digits 4 y = y % 4 :: Nat.digits 4 (y / 4) :=
+      Nat.digits_def' (by norm_num) hpos
+    show (Nat.digits 4 (y / 4)).toFinset ⊆ {0, 1}
+    intro d hd2
+    apply hsub
+    rw [hd]
+    simp only [List.toFinset_cons, Finset.mem_insert]
+    exact Or.inr hd2
+
+/-- Reassemble membership in `B` from the lowest digit and the tail. -/
+lemma mem_B_of_head_tail (y : ℕ) (h1 : y % 4 ≤ 1) (h2 : y / 4 ∈ B) : y ∈ B := by
+  rcases Nat.eq_zero_or_pos y with rfl | hpos
+  · exact zero_in_B
+  · have hsub2 : (Nat.digits 4 (y / 4)).toFinset ⊆ {0, 1} := h2
+    have hd : Nat.digits 4 y = y % 4 :: Nat.digits 4 (y / 4) :=
+      Nat.digits_def' (by norm_num) hpos
+    show (Nat.digits 4 y).toFinset ⊆ {0, 1}
+    rw [hd, List.toFinset_cons, Finset.insert_subset_iff]
+    refine ⟨?_, hsub2⟩
+    simp only [Finset.mem_insert, Finset.mem_singleton]
+    omega
+
+/-- Dividing by `4 ^ m` (dropping the low `m` base-4 digits) keeps `B`. -/
+lemma B_div_pow (m b : ℕ) (hb : b ∈ B) : b / 4 ^ m ∈ B := by
+  induction m with
+  | zero => simpa using hb
+  | succ m ih =>
+    have h : b / 4 ^ (m + 1) = b / 4 ^ m / 4 := by
+      rw [pow_succ, Nat.div_div_eq_div_mul]
+    rw [h]
+    exact B_tail4 _ ih
+
+/-- Reducing mod `4 ^ m` (keeping the low `m` base-4 digits) keeps `B`. -/
+lemma B_mod_pow : ∀ (m b : ℕ), b ∈ B → b % 4 ^ m ∈ B := by
+  intro m
+  induction m with
+  | zero => intro b _; rw [pow_zero, Nat.mod_one]; exact zero_in_B
+  | succ m ih =>
+    intro b hb
+    have htail : b / 4 ∈ B := B_tail4 b hb
+    have hs : (b / 4) % 4 ^ m ∈ B := ih (b / 4) htail
+    have hhead : b % 4 ≤ 1 := B_head4 b hb
+    have hmod : b % 4 ^ (m + 1) = b % 4 + 4 * (b / 4 % 4 ^ m) := by
+      rw [pow_succ']; exact Nat.mod_mul
+    rw [hmod]
+    set T := b / 4 % 4 ^ m with hT
+    apply mem_B_of_head_tail
+    · have h3 : (b % 4 + 4 * T) % 4 = b % 4 := by omega
+      rw [h3]; exact hhead
+    · have h4 : (b % 4 + 4 * T) / 4 = T := by omega
+      rw [h4]; exact hs
+
 /-- If `x < 3^k` and `x ∈ A` then `x ≤ (3^k - 1) / 2`. -/
 lemma A_max_k (k x : ℕ) (hx : x < 3 ^ k) (hA : x ∈ A) : x ≤ (3 ^ k - 1) / 2 := by
-  sorry
+  induction k generalizing x with
+  | zero => simp only [pow_zero] at hx ⊢; omega
+  | succ k ih =>
+    have hh : x % 3 ≤ 1 := A_head3 x hA
+    have ht : x / 3 ∈ A := A_tail3 x hA
+    have hlt : x / 3 < 3 ^ k := by
+      have hx' : x < 3 ^ k * 3 := by rw [← pow_succ]; exact hx
+      exact (Nat.div_lt_iff_lt_mul (by norm_num)).mpr hx'
+    have hih := ih (x / 3) hlt ht
+    have hP : 1 ≤ 3 ^ k := Nat.one_le_pow _ _ (by norm_num)
+    have hodd : 3 ^ k % 2 = 1 := by rw [Nat.pow_mod]; norm_num
+    have hdm : 3 * (x / 3) + x % 3 = x := Nat.div_add_mod x 3
+    have hpow : 3 ^ (k + 1) = 3 * 3 ^ k := by rw [pow_succ']
+    omega
 
 /-- If `y < 4^m` and `y ∈ B` then `y ≤ (4^m - 1) / 3`. -/
 lemma B_max_m (m y : ℕ) (hy : y < 4 ^ m) (hB : y ∈ B) : y ≤ (4 ^ m - 1) / 3 := by
-  sorry
+  induction m generalizing y with
+  | zero => simp only [pow_zero] at hy ⊢; omega
+  | succ m ih =>
+    have hh : y % 4 ≤ 1 := B_head4 y hB
+    have ht : y / 4 ∈ B := B_tail4 y hB
+    have hlt : y / 4 < 4 ^ m := by
+      have hy' : y < 4 ^ m * 4 := by rw [← pow_succ]; exact hy
+      exact (Nat.div_lt_iff_lt_mul (by norm_num)).mpr hy'
+    have hih := ih (y / 4) hlt ht
+    have hP : 1 ≤ 4 ^ m := Nat.one_le_pow _ _ (by norm_num)
+    have hmod3 : 4 ^ m % 3 = 1 := by rw [Nat.pow_mod]; norm_num
+    have hdm : 4 * (y / 4) + y % 4 = y := Nat.div_add_mod y 4
+    have hpow : 4 ^ (m + 1) = 4 * 4 ^ m := by rw [pow_succ']
+    omega
 
 /--
 **Gap lemma.** If `(3^k - 1)/2 + (4^m - 1)/3 < x`, `x < 3^k`, and `x < 4^m`,
@@ -133,17 +306,31 @@ interval below `min(3^k, 4^m)`.)
 lemma A_B_gap (k m x : ℕ)
     (hx_gt : (3 ^ k - 1) / 2 + (4 ^ m - 1) / 3 < x)
     (hx_lt_A : x < 3 ^ k) (hx_lt_B : x < 4 ^ m) : x ∉ A + B := by
-  sorry
+  intro h
+  rcases Set.mem_add.mp h with ⟨a, ha, b, hb, hab⟩
+  have hak : a < 3 ^ k ∨ 3 ^ k ≤ a := by omega
+  have hbm : b < 4 ^ m ∨ 4 ^ m ≤ b := by omega
+  rcases hak with hak1 | hak2
+  · rcases hbm with hbm1 | hbm2
+    · have h1 := A_max_k k a hak1 ha
+      have h2 := B_max_m m b hbm1 hb
+      omega
+    · omega
+  · omega
 
 /-- Decomposition: every `a ∈ A` factors as `a = a₁ · 3^k + a₀` with both pieces in `A`. -/
 lemma A_decomp (k a : ℕ) (ha : a ∈ A) :
     ∃ a1 a0 : ℕ, a1 ∈ A ∧ a0 ∈ A ∧ a0 < 3 ^ k ∧ a = a1 * 3 ^ k + a0 := by
-  sorry
+  refine ⟨a / 3 ^ k, a % 3 ^ k, A_div_pow k a ha, A_mod_pow k a ha,
+    Nat.mod_lt a (by positivity), ?_⟩
+  exact (Nat.div_add_mod' a (3 ^ k)).symm
 
 /-- Decomposition: every `b ∈ B` factors as `b = b₁ · 4^m + b₀` with both pieces in `B`. -/
 lemma B_decomp (m b : ℕ) (hb : b ∈ B) :
     ∃ b1 b0 : ℕ, b1 ∈ B ∧ b0 ∈ B ∧ b0 < 4 ^ m ∧ b = b1 * 4 ^ m + b0 := by
-  sorry
+  refine ⟨b / 4 ^ m, b % 4 ^ m, B_div_pow m b hb, B_mod_pow m b hb,
+    Nat.mod_lt b (by positivity), ?_⟩
+  exact (Nat.div_add_mod' b (4 ^ m)).symm
 
 /-- `log 4 / log 3` is irrational. -/
 lemma log_ratio_irrational : Irrational (Real.log 4 / Real.log 3) := by

--- a/proofs/Proofs/Erdos125PositiveLowerDensity.lean
+++ b/proofs/Proofs/Erdos125PositiveLowerDensity.lean
@@ -334,7 +334,39 @@ lemma B_decomp (m b : ℕ) (hb : b ∈ B) :
 
 /-- `log 4 / log 3` is irrational. -/
 lemma log_ratio_irrational : Irrational (Real.log 4 / Real.log 3) := by
-  sorry
+  have hlog3 : 0 < Real.log 3 := Real.log_pos (by norm_num)
+  have hlog4 : 0 < Real.log 4 := Real.log_pos (by norm_num)
+  have hlog3ne : Real.log 3 ≠ 0 := hlog3.ne'
+  intro h
+  obtain ⟨q, hq⟩ := h
+  have hdenpos : 0 < q.den := q.den_pos
+  have hden_posR : (0 : ℝ) < (q.den : ℝ) := by exact_mod_cast hdenpos
+  have hden0 : (q.den : ℝ) ≠ 0 := hden_posR.ne'
+  -- From `↑q = log 4 / log 3` and `↑q = q.num / q.den`, cross-multiply.
+  have hcast : (q.num : ℝ) / (q.den : ℝ) = Real.log 4 / Real.log 3 := by
+    rw [← Rat.cast_def]; exact hq
+  have h2 : (q.num : ℝ) * Real.log 3 = (q.den : ℝ) * Real.log 4 := by
+    field_simp [hlog3ne, hden0] at hcast
+    linear_combination hcast
+  have hprod : 0 < (q.num : ℝ) * Real.log 3 := by rw [h2]; exact mul_pos hden_posR hlog4
+  have hnumpos : 0 < q.num := by
+    have hR : 0 < (q.num : ℝ) := by nlinarith [hprod, hlog3]
+    exact_mod_cast hR
+  set n := q.num.toNat with hn
+  have hnum_cast : (q.num : ℝ) = (n : ℝ) := by
+    rw [hn]; exact_mod_cast (Int.toNat_of_nonneg hnumpos.le).symm
+  rw [hnum_cast] at h2
+  -- `n * log 3 = q.den * log 4` forces `3 ^ n = 4 ^ q.den`.
+  have hlogeq : Real.log ((3 : ℝ) ^ n) = Real.log ((4 : ℝ) ^ q.den) := by
+    rw [Real.log_pow, Real.log_pow]; linarith [h2]
+  have hpoweq : (3 : ℝ) ^ n = (4 : ℝ) ^ q.den :=
+    Real.log_injOn_pos (Set.mem_Ioi.mpr (by positivity))
+      (Set.mem_Ioi.mpr (by positivity)) hlogeq
+  have hnateq : (3 : ℕ) ^ n = (4 : ℕ) ^ q.den := by exact_mod_cast hpoweq
+  -- But `3 ^ n` is odd and `4 ^ q.den` is even (`q.den ≥ 1`).
+  have hodd : (3 : ℕ) ^ n % 2 = 1 := by rw [Nat.pow_mod]; norm_num
+  have hdvd : 2 ∣ (4 : ℕ) ^ q.den := dvd_pow (by norm_num) hdenpos.ne'
+  omega
 
 /--
 **Dirichlet helper.** For any irrational `α > 0` and any `δ > 0`, there exist
@@ -351,14 +383,57 @@ lemma exists_small_pos_lin_comb (δ : ℝ) (hδ : 0 < δ) :
     ∃ m k : ℕ, 0 < m ∧ 0 < k ∧
       0 < (m : ℝ) * Real.log 4 - (k : ℝ) * Real.log 3 ∧
       (m : ℝ) * Real.log 4 - (k : ℝ) * Real.log 3 < δ := by
-  sorry
+  have h_irr : Irrational (Real.log 4 / Real.log 3) := log_ratio_irrational
+  have hlog3 : 0 < Real.log 3 := Real.log_pos (by norm_num)
+  have hlog3ne : Real.log 3 ≠ 0 := hlog3.ne'
+  have h_pos : 0 < Real.log 4 / Real.log 3 :=
+    div_pos (Real.log_pos (by norm_num)) hlog3
+  have hdd : 0 < δ / Real.log 3 := div_pos hδ hlog3
+  obtain ⟨m, k, hm, hk, hlo, hhi⟩ :=
+    exists_small_pos_lin_comb_help (Real.log 4 / Real.log 3) h_irr h_pos
+      (δ / Real.log 3) hdd
+  -- Rescale by `log 3`: `(m·(log4/log3) − k)·log3 = m·log4 − k·log3`.
+  have heq : (m : ℝ) * Real.log 4 - (k : ℝ) * Real.log 3
+      = ((m : ℝ) * (Real.log 4 / Real.log 3) - (k : ℝ)) * Real.log 3 := by
+    field_simp
+  refine ⟨m, k, hm, hk, ?_, ?_⟩
+  · rw [heq]; exact mul_pos hlo hlog3
+  · rw [heq]
+    have hcancel : δ / Real.log 3 * Real.log 3 = δ := by field_simp
+    have hmul := mul_lt_mul_of_pos_right hhi hlog3
+    rwa [hcancel] at hmul
 
 /-- Refinement: also `K ≤ 3^k`. -/
 lemma exists_small_pos_lin_comb_large_k (δ : ℝ) (hδ : 0 < δ) (K : ℝ) :
     ∃ m k : ℕ, 0 < m ∧ 0 < k ∧ K ≤ (3 ^ k : ℝ) ∧
       0 < (m : ℝ) * Real.log 4 - (k : ℝ) * Real.log 3 ∧
       (m : ℝ) * Real.log 4 - (k : ℝ) * Real.log 3 < δ := by
-  sorry
+  -- Archimedean: choose `N ≥ 1` with `K ≤ 3 ^ N`.
+  obtain ⟨N0, hN0⟩ := pow_unbounded_of_one_lt K (by norm_num : (1 : ℝ) < 3)
+  set N := N0 + 1 with hNdef
+  have hNpos : 0 < N := by omega
+  have hNR : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hNpos
+  have hKN : K ≤ (3 : ℝ) ^ N := by
+    have hmono : (3 : ℝ) ^ N0 ≤ (3 : ℝ) ^ N :=
+      pow_le_pow_right₀ (by norm_num) (by omega)
+    linarith [hN0]
+  have hdivN : 0 < δ / (N : ℝ) := div_pos hδ hNR
+  obtain ⟨m0, k0, hm0, hk0, hlo, hhi⟩ := exists_small_pos_lin_comb (δ / (N : ℝ)) hdivN
+  have hexp : ((N * m0 : ℕ) : ℝ) * Real.log 4 - ((N * k0 : ℕ) : ℝ) * Real.log 3
+      = (N : ℝ) * ((m0 : ℝ) * Real.log 4 - (k0 : ℝ) * Real.log 3) := by
+    push_cast; ring
+  refine ⟨N * m0, N * k0, Nat.mul_pos hNpos hm0, Nat.mul_pos hNpos hk0, ?_, ?_, ?_⟩
+  · -- `K ≤ 3 ^ (N * k0)`.
+    have hNk : N ≤ N * k0 := Nat.le_mul_of_pos_right N hk0
+    have hle : (3 : ℝ) ^ N ≤ (3 : ℝ) ^ (N * k0) :=
+      pow_le_pow_right₀ (by norm_num) hNk
+    calc K ≤ (3 : ℝ) ^ N := hKN
+      _ ≤ (3 : ℝ) ^ (N * k0) := hle
+  · rw [hexp]; exact mul_pos hNR hlo
+  · rw [hexp]
+    have hmul := mul_lt_mul_of_pos_left hhi hNR
+    have hcancel : (N : ℝ) * (δ / (N : ℝ)) = δ := by field_simp
+    rwa [hcancel] at hmul
 
 /--
 **Dirichlet approximation.** For any `ε > 0`, there exist `k, m > 0` with
@@ -367,7 +442,24 @@ lemma exists_small_pos_lin_comb_large_k (δ : ℝ) (hδ : 0 < δ) (K : ℝ) :
 lemma dirichlet_approx (ε : ℝ) (hε : 0 < ε) :
     ∃ k m : ℕ, 0 < k ∧ 0 < m ∧ (3 ^ k : ℝ) ≤ 4 ^ m ∧
       (4 ^ m : ℝ) ≤ (3 ^ k : ℝ) * (1 + ε) ∧ (3 ^ k : ℝ) * ε ≥ 3 := by
-  sorry
+  have h_log_eps : 0 < Real.log (1 + ε) := Real.log_pos (by linarith)
+  obtain ⟨m, k, hm, hk, hk_large, h_diff_pos, h_diff_lt⟩ :=
+    exists_small_pos_lin_comb_large_k (Real.log (1 + ε)) h_log_eps (3 / ε)
+  refine ⟨k, m, hk, hm, ?_, ?_, ?_⟩
+  · -- `3 ^ k ≤ 4 ^ m`, via monotonicity of `log`.
+    have hkpos : (0 : ℝ) < (3 : ℝ) ^ k := by positivity
+    have hmpos : (0 : ℝ) < (4 : ℝ) ^ m := by positivity
+    rw [← Real.log_le_log_iff hkpos hmpos, Real.log_pow, Real.log_pow]
+    linarith [h_diff_pos]
+  · -- `4 ^ m ≤ 3 ^ k · (1 + ε)`.
+    have hmpos : (0 : ℝ) < (4 : ℝ) ^ m := by positivity
+    have hrhs : (0 : ℝ) < (3 : ℝ) ^ k * (1 + ε) := by positivity
+    rw [← Real.log_le_log_iff hmpos hrhs, Real.log_pow,
+        Real.log_mul (by positivity) (by positivity), Real.log_pow]
+    linarith [h_diff_lt]
+  · -- `3 ^ k · ε ≥ 3`, from `3 / ε ≤ 3 ^ k`.
+    rw [ge_iff_le, ← div_le_iff₀ hε]
+    exact hk_large
 
 /-- Algebraic identity used in the scale-step. -/
 lemma hz_eq_lemma (x a b a1 a0 b1 b0 k m : ℕ)

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -21,13 +21,13 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 3,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 92,
-    "assumptions": "Original Erdos125Problem.lean (92 lines): 0 axioms, 0 sorries, 7 definitions, 0 theorems — states the open question without proving it. Companion Erdos125PositiveLowerDensity.lean (277 lines): integrates the structural skeleton of DeepMind AlphaProof Nexus's 2026-05-21 proof (arXiv:2605.22763v1) that the positive_lower_density variant of Erdős #125 is FALSE — i.e., lower density of A+B equals 0. The companion file declares 20 lemmas/theorems mirroring the AlphaProof Nexus source (`APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`) with 14 sorry placeholders pending a faithful tactic-by-tactic port from FormalConjectures.Util.ProblemImports to pure Mathlib v4.26.0. The Aristotle companion Erdos125PositiveLowerDensityAristotle.lean (114 lines) exposes 6 additional routine digit-combinatorics targets (`A_max_k`, `B_max_m`, `A_B_gap`, `A_decomp`, `B_decomp`) as `sorry` for automated proof search. The canonical statement file (proofRepoPath) carries 0 sorries; the two WIP companion files contain 14 + 6 = 20 sorries between them, tracked separately in #20842. The mathematical result is established in the AlphaProof Nexus repository; this gallery entry awaits full mechanization here.",
+    "assumptions": "Original Erdos125Problem.lean (92 lines): 0 axioms, 0 sorries, 7 definitions, 0 theorems — states the open question without proving it. Companion Erdos125PositiveLowerDensity.lean integrates DeepMind AlphaProof Nexus's 2026-05-21 proof (arXiv:2605.22763v1) that the positive_lower_density variant of Erdős #125 is FALSE — i.e., lower density of A+B equals 0. Porting from FormalConjectures.Util.ProblemImports to pure Mathlib v4.26.0 is in progress (#20842): 9 of the original 12 sorries are now discharged — the full digit-combinatorics layer (`A_max_k`, `B_max_m`, `A_B_gap`, `A_decomp`, `B_decomp` plus base-3/base-4 head/tail helpers), the irrationality of `log 4 / log 3`, and the Dirichlet-reduction chain (`exists_small_pos_lin_comb`, `exists_small_pos_lin_comb_large_k`, `dirichlet_approx`). 3 deep lemmas remain as `sorry`: `exists_small_pos_lin_comb_help` (the Dirichlet approximation theorem for an irrational), `scale_step` (the multi-scale counting core), and `AB_lowerDensity_eq_zero` (the `liminf` bridge). The Aristotle companion Erdos125PositiveLowerDensityAristotle.lean (114 lines) exposes 6 additional routine digit-combinatorics targets as `sorry` for automated proof search. The canonical statement file (proofRepoPath) carries 0 sorries. The mathematical result is established in the AlphaProof Nexus repository; this gallery entry awaits full mechanization here.",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
     "definitionCount": 7
@@ -203,5 +203,5 @@
       "note": "Source of the ported Lean proof: APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean (370 lines)."
     }
   ],
-  "sorries": 0
+  "sorries": 3
 }


### PR DESCRIPTION
## Summary

Ports most of DeepMind's AlphaProof Nexus proof of the `positive_lower_density`
variant of Erdős #125 (lower density of `A + B = 0`) from the FormalConjectures
`bound`/`valid` tactic golf into pure Mathlib v4.26.0. Discharges **9 of the 12**
`sorry` placeholders in `proofs/Proofs/Erdos125PositiveLowerDensity.lean`; the file
builds cleanly with exactly 3 remaining sorry warnings.

Source: https://github.com/google-deepmind/alphaproof-nexus-results (Apache-2.0),
`APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`.

## Changes

- **Digit-combinatorics layer (5 sorries + new helpers).** Added base-3/base-4
  `head`/`tail`/`div_pow`/`mod_pow` helper lemmas built on `Nat.digits_def'`,
  and used them to prove `A_max_k`, `B_max_m`, `A_B_gap`, `A_decomp`, `B_decomp`.
- **Analysis layer (4 sorries).** `log_ratio_irrational` (parity: `3^n` odd vs
  `4^d` even), `exists_small_pos_lin_comb` (rescale by `log 3`),
  `exists_small_pos_lin_comb_large_k` (Archimedean padding), `dirichlet_approx`
  (log→power inequalities).
- Refreshed the file header / supporting-lemmas docstrings.
- `meta.json`: set stale `meta.sorries` and top-level `sorries` from `0` to the
  honest remaining count `3` (both consistent); refreshed the `assumptions` prose.
  Status kept at `axiomatized` (sorries remain).

## Per-sorry status

| Lemma | Status | Notes |
|-------|--------|-------|
| `A_max_k` | ✅ filled | induction peeling base-3 digits |
| `B_max_m` | ✅ filled | induction peeling base-4 digits |
| `A_B_gap` | ✅ filled | verbatim port (omega + max lemmas) |
| `A_decomp` | ✅ filled | `a/3^k`, `a%3^k` via div/mod-pow helpers |
| `B_decomp` | ✅ filled | `b/4^m`, `b%4^m` via div/mod-pow helpers |
| `log_ratio_irrational` | ✅ filled | `3^n = 4^d` parity contradiction |
| `exists_small_pos_lin_comb` | ✅ filled | rescale `_help` by `log 3` |
| `exists_small_pos_lin_comb_large_k` | ✅ filled | Archimedean `3^k ≥ K` |
| `dirichlet_approx` | ✅ filled | `log_le_log_iff` + `log_pow`/`log_mul` |
| `exists_small_pos_lin_comb_help` | ⬜ sorry | Dirichlet approximation theorem for an irrational (deep) |
| `scale_step` | ⬜ sorry | multi-scale `5/6`-fraction counting core (deep) |
| `AB_lowerDensity_eq_zero` | ⬜ sorry | `liminf` bridge; note the stated `density_tends_to_zero` yields only one window per ε, so this needs unbounded windows to close |

## Test Plan

`./proofs/scripts/docker-build.sh Proofs.Erdos125PositiveLowerDensity` — build
succeeds (3058 jobs) with exactly 3 `declaration uses 'sorry'` warnings for the
three remaining lemmas above. No new axioms, no statement changes.

Part of #20842