### PR TITLE
Gallery meta: graduate erdos-12/152/741/846 badges wip → verified after peer review

### DIFF
--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -16,7 +16,7 @@
       "density",
       "additive-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos12ProblemAPNPartI.lean",

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -15,7 +15,7 @@
       "sumsets",
       "alphaproof-nexus"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "erdosNumber": 152,
     "erdosUrl": "https://erdosproblems.com/152",

--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -17,7 +17,7 @@
       "open",
       "partition-regularity"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos741ProblemAPNPartI.lean",

--- a/src/data/proofs/erdos-846/meta.json
+++ b/src/data/proofs/erdos-846/meta.json
@@ -21,7 +21,7 @@
       "density-to-structure",
       "alphaproof-nexus"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "erdosNumber": 846,
     "erdosUrl": "https://erdosproblems.com/846",


### PR DESCRIPTION
Peer review (issue #35108, review comment posted there) returned **PASS for all four** entries promoted in PR #35101. This PR performs the sanctioned badge graduation: `meta.badge` wip → verified in the four meta.json files (4 files, 4 lines; `meta.status` already verified, no other fields touched, no top-level badge fields exist).

Three minor non-blocking findings from the review (annotation coverage gaps on erdos-152/846, a stale '(OPEN)' section title in erdos-12, an erdos-741 phrasing tension) are documented on #35108 and routed to enricher follow-up — deliberately NOT bundled here.

Closes #35108

🤖 Generated with [Claude Code](https://claude.com/claude-code)