### PR TITLE
Gallery enrichment: address 3 minor peer-review findings for APN entries (#35108)

### DIFF
--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -153,16 +153,16 @@
     },
     {
       "id": "question1",
-      "title": "Question 1: √N Density (OPEN)",
-      "summary": "Defines sqrtLiminfDensity (∃ c > 0 with A(N)/√N ≥ c eventually) and Erdos12Question1 (∃ A with this property). Axiomatizes elsholtz_planitzer_construction: A(N) ≥ √N/(√(log N)·(log log N)²), the best known bound falling short of √N by logarithmic factors.",
+      "title": "Question 1: √N Density (Resolved — part (i) YES, in APN companion)",
+      "summary": "Defines sqrtLiminfDensity (∃ c > 0 with A(N)/√N ≥ c eventually) and Erdos12Question1 (∃ A with this property). Axiomatizes elsholtz_planitzer_construction: A(N) ≥ √N/(√(log N)·(log log N)²), the best known bound falling short of √N by logarithmic factors. The gallery Prop here states the question; part (i) is resolved affirmatively in the APN companion (Erdos12ProblemAPNPartI.lean) via the explicit prime-tower good set MyGoodSet with proved positive √N liminf density.",
       "startLine": 200,
       "endLine": 216,
       "mathContext": "Defines sqrtLiminfDensity (∃ c > 0 with A(N)/√N ≥ c eventually) and Erdos12Question1 (∃ A with this property). Axiomatizes elsholtz_planitzer_construction: A(N) ≥ √N/(√(log N)·(log log N)²), the best known bound falling short of √N by logarithmic factors."
     },
     {
       "id": "question2",
-      "title": "Question 2: Sparse Infinitely Often (OPEN)",
-      "summary": "Defines Erdos12Question2: ∀ A div-free, ∃ c > 0 with A(N) < N^{1-c} for infinitely many N. This asks whether the counting function must dip below polynomial growth infinitely often, even if it occasionally reaches √N.",
+      "title": "Question 2: Sparse Infinitely Often (Resolved — part (ii) NO, in APN companion)",
+      "summary": "Defines Erdos12Question2: ∀ A div-free, ∃ c > 0 with A(N) < N^{1-c} for infinitely many N. This asks whether the counting function must dip below polynomial growth infinitely often, even if it occasionally reaches √N. The gallery Prop here states the question; part (ii) is resolved negatively in the APN companion (Erdos12ProblemAPNPartII.lean) via a Sárközy/CRT sequence with an explicit density lower bound that violates the universal-sparseness assertion.",
       "startLine": 217,
       "endLine": 224,
       "mathContext": "Defines Erdos12Question2: ∀ A div-free, ∃ c > 0 with A(N) < N^{1-c} for infinitely many N. This asks whether the counting function must dip below polynomial growth infinitely often, even if it occasionally reaches √N."

--- a/src/data/proofs/erdos-152/annotations.json
+++ b/src/data/proofs/erdos-152/annotations.json
@@ -195,5 +195,29 @@
       "infinite set truncation",
       "Filter.atTop"
     ]
+  },
+  {
+    "id": "erdos-152-apn-lower-bound",
+    "proofId": "erdos-152",
+    "type": "concept",
+    "range": {
+      "startLine": 51,
+      "endLine": 60
+    },
+    "title": "APN Companion: The Explicit $n^2$ Lower Bound",
+    "content": "The weak form is actually resolved in the companion file `Erdos152ProblemAPN.lean` (a verbatim AlphaProof-Nexus port, 0 sorries / 0 axioms). Its load-bearing lemma is `num_isolated_lower_bound`: for every Sidon set $A$ with $|A| = n > 0$, $16 \\cdot I(A) + 100n + 16 \\geq n^2$. Rearranged, $I(A) \\geq (n^2 - 100n - 16)/16$, which $\\to \\infty$, so the isolated count diverges. This is the theorem that makes the entry a resolution rather than a restatement — the gallery file above states the conjecture, and the companion supplies the proof.",
+    "mathContext": "`num_isolated_lower_bound (n : ℕ) (hn : n > 0) (A : Set ℕ) (h_card : A.ncard = n) (h_sidon : IsSidon A) : 16 * num_isolated A + 100 * n + 16 ≥ n * n`. The proof assembles: the isolated-count identity $I(A) + 2N_1(A+A) = |A+A| + V_2(A+A)$ (`I_identity_Z`), a universal local-pattern parity bound (`universal_parity_3`, `local_pattern_bound_Z`), and fibered Sidon-quadruple counts (`quad_upper`, `quad_lower`) that bound the near-collision terms $N_k(A+A)$ — all discharged by a final `omega`. Combined with `exists_sidon_set_n` (the witness family $\\{2^k\\}$), the file concludes `tendsto_f : Tendsto f atTop atTop` and `target_theorem_0 : True ↔ Tendsto f atTop atTop`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "isolated-count identity",
+      "Sidon-quadruple counting",
+      "local-pattern parity",
+      "APN companion file"
+    ],
+    "prerequisites": [
+      "num_isolated_lower_bound",
+      "IsSidon",
+      "Filter.Tendsto atTop"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-741",
   "title": "Splitting Sumsets with Positive Density",
   "slug": "erdos-741",
-  "description": "Can A with A+A of positive density be split A = A₁ ⊔ A₂ with both A₁+A₁ and A₂+A₂ positive density? Is there a basis where no split makes both syndetic? Both parts were resolved by DeepMind AlphaProof Nexus on 2026-05-21 (part i: False; part ii: True).",
+  "description": "Can A with A+A of positive density be split A = A₁ ⊔ A₂ with both A₁+A₁ and A₂+A₂ positive density? Is there a basis where no split makes both syndetic? Both of the two posed parts were resolved by DeepMind AlphaProof Nexus on 2026-05-21 (part i: False; part ii: True); the k≥3-colour split and optimal-density variants of Erdős #741 remain open, so the problem's overall status stays open.",
   "meta": {
     "author": "Burr, Erdős (1994); parts (i)/(ii) by DeepMind AlphaProof Nexus (2026)",
     "sourceUrl": "https://erdosproblems.com/741",

--- a/src/data/proofs/erdos-846/annotations.json
+++ b/src/data/proofs/erdos-846/annotations.json
@@ -221,5 +221,30 @@
       "startLine": 187,
       "endLine": 199
     }
+  },
+  {
+    "id": "ann-e846-apn-construction",
+    "proofId": "erdos-846",
+    "type": "concept",
+    "title": "APN Companion: The Explicit Counterexample (Elekes Parametrisation)",
+    "content": "The hard direction is not open here — it is DISPROVED in the companion file `Erdos846ProblemAPN.lean` (verbatim AlphaProof-Nexus port, 0 sorries / 0 axioms). The construction takes the Elekes-parametrised map $q(i,j) = (t_i + t_j,\\ t_i^2 + t_i t_j + t_j^2)$ with the fast-growing sequence $t_n = 100^{4^n}$. The resulting infinite set `A_set q` is $(1/2)$-non-trilinear yet admits no finite non-collinear partition, so it satisfies the density hypothesis while refuting the structural conclusion. This is what promotes the entry from 'conjecture stated' to 'conjecture resolved (negatively)'.",
+    "mathContext": "Two load-bearing companion lemmas: (1) `A_set_nontrilinear (q) (hq : IsGoodMap q) : NonTrilinearFor (A_set q) (1/2)` — every finite $B \\subseteq A$ has a non-collinear subset of size $\\geq |B|/2$, produced by a bipartite max-cut argument (`bipartite_max_cut_nat`, which halves any edge set into a triangle-free bipartite subgraph); (2) `A_set_not_weakly (q) (hq : IsGoodMap q) : ¬ WeaklyNonTrilinear (A_set q)` — any finite colouring of the edges yields, via `ramsey_for_triangles`, a monochromatic triangle $q(i,j), q(j,k), q(i,k)$, which `collinear_iff_det2` shows is collinear, contradicting the partition. These combine in `target_false` / `target_theorem_0 : False ↔ (∀ A ε, ε>0 → A.Infinite → NonTrilinearFor A ε → WeaklyNonTrilinear A)`, i.e. the Erdős–Nešetřil–Rödl conjecture is false.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Elekes parametrisation",
+      "bipartite max-cut",
+      "Ramsey for triangles",
+      "APN companion file"
+    ],
+    "prerequisites": [
+      "A_set_nontrilinear",
+      "A_set_not_weakly",
+      "NonTrilinearFor",
+      "WeaklyNonTrilinear"
+    ],
+    "range": {
+      "startLine": 187,
+      "endLine": 199
+    }
   }
 ]


### PR DESCRIPTION
Follow-through on the three **non-blocking** minor findings from the peer review on #35108 (badge graduation wip → verified already merged via #35113). JSON-only changes; no status/badge/count changes.

## Findings addressed

**1. [minor/coverage] erdos-152 & erdos-846 — annotate the APN companion resolution**
The existing annotations cover only the gallery file, not the APN companion that carries the actual resolution content. Added one `concept` annotation per entry pointing at the load-bearing companion lemmas:
- **erdos-152**: `num_isolated_lower_bound` (`16·I(A)+100n+16 ≥ n²`) → `tendsto_f` / `target_theorem_0`, in `Erdos152ProblemAPN.lean`.
- **erdos-846**: `A_set_nontrilinear` (bipartite max-cut) + `A_set_not_weakly` (Ramsey-for-triangles) → `target_false`, the Elekes-parametrised counterexample in `Erdos846ProblemAPN.lean`.

**2. [minor/inconsistency] erdos-12 — retitle Q1/Q2 sections**
`sections` still titled Q1/Q2 "(OPEN)" while the description marks parts (i)/(ii) resolved. Retitled to note resolution in the APN companion (part i YES, part ii NO) and appended a clarifying clause to each summary. Q3 stays "(OPEN)".

**3. [minor/precision] erdos-741 — clarify open variants**
Description said "Both parts were resolved" while `erdosProblemStatus: open`. Added a note that the k≥3-colour split and optimal-density variants remain open, keeping `erdosProblemStatus: open` unchanged.

## Constraints honored
- JSON-only edits in `src/data/proofs/{erdos-152,erdos-846,erdos-12,erdos-741}/`.
- No `status` / `badge` / `axiomCount` / `erdosProblemStatus` field changes (settled via #35113).
- All four files validated with `python3 -m json.tool`.
- `pnpm build` not run, so no regenerated files included.

Refs #35108 (already closed — this is quality-polish follow-through, not a close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)