### PR TITLE
fix: migrate FourierSeriesOQ02OQ04 to Mathlib 4.26 (unblock Fourier decay tree)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,0 +1,6 @@
+# Loom-managed worktree marker
+# Created by .loom/scripts/worktree.sh
+# Issue: 34767
+# Branch: feature/issue-34767
+# Removing this file makes Loom treat the worktree as user-owned and refuse
+# to clean it up automatically.

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,0 @@
-# Loom-managed worktree marker
-# Created by .loom/scripts/worktree.sh
-# Issue: 34767
-# Branch: feature/issue-34767
-# Removing this file makes Loom treat the worktree as user-owned and refuse
-# to clean it up automatically.

--- a/proofs/Proofs/FourierSeriesOQ02OQ04.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ04.lean
@@ -135,10 +135,10 @@ private theorem wFunc_fourierCoeff (α : ℝ) (hα : 0 < α) (k₀ : ℕ) :
   -- Unfold definition
   simp only [fourierCoeff, wFunc, smul_eq_mul]
   -- Interchange integral and tsum
-  rw [show (fun x => (∑' k : ℕ, (geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x) *
-        fourier (-(2:ℤ)^k₀) x) =
+  rw [show (fun x => fourier (-(2:ℤ)^k₀) x *
+        ∑' k : ℕ, (geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x) =
       fun x => ∑' k : ℕ, fourier (-(2:ℤ)^k₀) x * ((geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x)
-    from funext fun x => by rw [← tsum_mul_left]; congr 1; ext k; rw [smul_eq_mul]; ring]
+    from funext fun x => by rw [← tsum_mul_left]]
   rw [integral_tsum
     (fun k => (((fourier (-(2:ℤ)^k₀)).continuous.mul
       ((continuous_const.smul (fourier ((2:ℤ)^k)).continuous))).aestronglyMeasurable))
@@ -188,13 +188,17 @@ where p₀ = Nat.log 2 ⌈T / dist x y⌉.
 /-- Partial geometric sum bound: ∑_{k<p} s^k ≤ s^p / (s-1) for s > 1. -/
 private theorem geom_partial_sum_le {s : ℝ} (hs : 1 < s) (p : ℕ) :
     ∑ k ∈ Finset.range p, s^k ≤ s^p / (s - 1) := by
+  have hs1_pos : 0 < s - 1 := by linarith
   induction p with
-  | zero => simp; positivity
+  | zero =>
+      simp only [Finset.range_zero, Finset.sum_empty, pow_zero]
+      exact div_nonneg zero_le_one hs1_pos.le
   | succ n ih =>
     rw [Finset.sum_range_succ]
     calc ∑ k ∈ Finset.range n, s^k + s^n
         ≤ s^n / (s-1) + s^n := by linarith
       _ = s^(n+1) / (s-1) := by
+          have hne : s - 1 ≠ 0 := hs1_pos.ne'
           rw [pow_succ]; field_simp; ring
 
 /-- The geometric tail sum: ∑_{k≥p₀} r^k = r^{p₀} / (1-r). -/
@@ -213,14 +217,15 @@ private theorem dist_le_half_period (x y : AddCircle T) : dist x y ≤ T / 2 := 
   -- Lift to real representatives
   induction x using QuotientAddGroup.induction_on with | _ x =>
   induction y using QuotientAddGroup.induction_on with | _ y =>
-  set k : ℤ := round (T⁻¹ * (x - y)) with hk_def
   have hT_ne : T ≠ 0 := hT_pos.ne'
-  have h_dist : dist (↑x : AddCircle T) (↑y) = |x - y - ↑k * T| := by
+  have h_dist : dist (↑x : AddCircle T) (↑y) =
+      |x - y - round (T⁻¹ * (x - y)) * T| := by
     rw [dist_eq_norm, show (↑x : AddCircle T) - ↑y = ↑(x - y) from
       (map_sub (QuotientAddGroup.mk' (AddSubgroup.zmultiples T)) x y).symm,
       AddCircle.norm_eq]
   rw [h_dist]
   -- |x - y - k·T| = T · |(x-y)/T - round((x-y)/T)| ≤ T · (1/2) = T/2
+  set k : ℤ := round (T⁻¹ * (x - y)) with hk_def
   have hround : |T⁻¹ * (x - y) - ↑k| ≤ 1 / 2 := abs_sub_round _
   have hrw : x - y - ↑k * T = T * (T⁻¹ * (x - y) - ↑k) := by
     field_simp; ring
@@ -299,10 +304,10 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
     calc (2:ℝ)^α * ((2:ℝ)^((p₀:ℝ)+1))^(-α)
         < (2:ℝ)^α * ((T/d)^(-α)) := by
           apply mul_lt_mul_of_pos_left _ (Real.rpow_pos_of_pos (by norm_num) _)
-          exact Real.rpow_lt_rpow_of_exponent_gt hTd_pos h_pow_gt' (by linarith)
+          exact Real.rpow_lt_rpow_of_neg hTd_pos h_pow_gt' (by linarith)
       _ = (2:ℝ)^α * ((d/T)^α) := by
           rw [Real.rpow_neg hTd_pos.le,
-              show (d/T) = (T/d)⁻¹ from by rw [one_div_div],
+              show (d/T) = (T/d)⁻¹ from by rw [inv_div],
               Real.inv_rpow hTd_pos.le]
       _ = (2 * (d / T))^α := by rw [Real.mul_rpow (by norm_num) (by positivity)]
       _ ≤ (4 * d / T)^α := by
@@ -312,16 +317,15 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
   have h_diff : wFunc α x - wFunc α y =
       ∑' k : ℕ, (r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)) := by
     unfold wFunc
-    rw [← tsum_sub (wFunc_summable α hα_pos x) (wFunc_summable α hα_pos y)]
+    rw [← Summable.tsum_sub (wFunc_summable α hα_pos x) (wFunc_summable α hα_pos y)]
     simp_rw [← smul_sub]
   rw [h_diff]
   -- Summability of norms
   have h_summ_norm : Summable (fun k : ℕ => r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) := by
-    apply Summable.of_nonneg_of_le (fun k => by positivity)
-      (g := fun k => r^k * 2) (fun k => ?_)
-    · exact (summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2
-    · apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
-      exact pow_nonneg hr_pos.le _
+    refine Summable.of_nonneg_of_le (fun k => by positivity) (fun k => ?_)
+      ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2)
+    apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
+    exact pow_nonneg hr_pos.le _
   -- Norm bound via triangle inequality
   have h_norm_eq : ∀ k : ℕ, ‖r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)‖ =
       r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ := fun k => by
@@ -339,12 +343,13 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
       (∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) +
       ∑' k : ℕ, r^(k + p₀) * 2 := by
     rw [← h_summ_norm.sum_add_tsum_nat_add p₀]
-    apply add_le_add_left
-    apply Summable.tsum_le_tsum _ (h_summ_norm.nat_add p₀)
-      ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2 |>.nat_add p₀)
-    intro k
-    apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
-    exact pow_nonneg hr_pos.le _
+    gcongr ?_ + ?_
+    · exact le_refl _
+    · apply Summable.tsum_le_tsum _ (h_summ_norm.nat_add p₀)
+        ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2 |>.nat_add p₀)
+      intro k
+      apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
+      exact pow_nonneg hr_pos.le _
   -- Low sum bound: Lipschitz
   have h_low : ∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ ≤
       (2 * Real.pi * (2 * T)^(1-α)) / (T * ((2:ℝ)^(1-α) - 1)) * d^α := by
@@ -360,8 +365,12 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
       _ = (2 * Real.pi / T * d) * ∑ k ∈ Finset.range p₀, (r * 2)^k := by
           simp_rw [← Finset.mul_sum]; congr 1; ext k; ring
       _ ≤ (2 * Real.pi / T * d) * (s^p₀ / (s - 1)) := by
-          apply mul_le_mul_of_nonneg_left _ (by positivity)
-          apply geom_partial_sum_le hs_gt1
+          have hrs : r * 2 = s := by
+            rw [hr_def, hs_def]; unfold geomRatio
+            rw [show (1:ℝ) - α = -α + 1 from by ring, Real.rpow_add (by norm_num),
+                Real.rpow_one]
+          rw [hrs]
+          apply mul_le_mul_of_nonneg_left (geom_partial_sum_le hs_gt1 p₀) (by positivity)
       _ ≤ (2 * Real.pi * (2 * T)^(1-α)) / (T * ((2:ℝ)^(1-α) - 1)) * d^α := by
           -- Bound s^p₀ ≤ (2T/d)^(1-α), then split (2T/d)^(1-α) = (2T)^(1-α) / d^(1-α).
           have hsm1_pos : 0 < s - 1 := hs_pos
@@ -372,21 +381,18 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
             exact h_s_bound
           refine hstep.trans (le_of_eq ?_)
           rw [hs_def]
-          -- (2T/d)^(1-α) = (2T)^(1-α) · d^(-(1-α)); combine with d and simplify.
+          -- (2T/d)^(1-α) = (2T)^(1-α) · d^(α-1); combine with d and simplify.
           have hd_ne : d ≠ 0 := hd_pos.ne'
           have hexp : (2*T/d)^(1-α) = (2*T)^(1-α) * d^(α - 1) := by
-            rw [show (2*T/d) = (2*T) * d⁻¹ from by ring,
-                Real.mul_rpow (by positivity) (by positivity),
-                ← Real.rpow_neg_one d, ← Real.rpow_natCast d 1]
-            rw [← Real.rpow_mul hd_pos.le]
-            rw [show (1:ℝ) - α = -(α - 1) from by ring, Real.rpow_neg (by positivity)]
-            rw [Real.rpow_natCast, pow_one]
-            rw [show (α - 1) = -(1 - α) from by ring, Real.rpow_neg hd_pos.le]
-            rw [Real.inv_rpow hd_pos.le]
+            rw [Real.div_rpow (by positivity) hd_pos.le, div_eq_mul_inv,
+                ← Real.rpow_neg hd_pos.le, show -(1-α) = α - 1 from by ring]
           rw [hexp]
           have hdpow : d^(α - 1) * d = d^α := by
             rw [show d = d^(1:ℝ) from (Real.rpow_one d).symm, ← Real.rpow_add hd_pos]
-            · congr 1; ring
+            congr 1; ring
+          have hden_ne : (2:ℝ)^(1-α) - 1 ≠ 0 := by
+            have : (1:ℝ) < (2:ℝ)^(1-α) := hs_gt1
+            rw [hs_def] at this; linarith
           field_simp
           rw [show (2:ℝ)*Real.pi/T*d*((2*T)^(1-α)*d^(α-1)) =
               2*Real.pi*(2*T)^(1-α)*(d^(α-1)*d)/T from by ring, hdpow]
@@ -404,8 +410,7 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
     have hexp : (4 * d / T)^α = (4:ℝ)^α * d^α / T^α := by
       rw [show (4 * d / T) = 4 * d * T⁻¹ from by ring,
           Real.mul_rpow (by positivity) (by positivity),
-          Real.mul_rpow (by norm_num) hd_pos.le, Real.inv_rpow (by positivity),
-          Real.rpow_neg (by positivity)]
+          Real.mul_rpow (by norm_num) hd_pos.le, Real.inv_rpow hT_pos.le]
       ring
     -- Rewrite both sides over the common denominator (1 - 2^(-α)).
     rw [hr_eq, show (2 : ℝ) * (r^p₀ / (1 - (2:ℝ)^(-α))) = (2 * r^p₀) / (1 - (2:ℝ)^(-α)) from by
@@ -417,7 +422,8 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
     rw [← hexp]
     exact mul_le_mul_of_nonneg_left (le_of_lt h_r_bound) (by norm_num)
   -- Combine
-  calc ‖wFunc α (T := T) x - wFunc α y‖
+  rw [add_mul, hs_def]
+  calc ‖∑' k : ℕ, r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)‖
       ≤ ∑' k : ℕ, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ := h_tri
     _ ≤ _ + ∑' k : ℕ, r^(k + p₀) * 2 := h_split
     _ ≤ _ := add_le_add h_low h_high

--- a/proofs/Proofs/FourierSeriesOQ02OQ04.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ04.lean
@@ -145,14 +145,14 @@ private theorem wFunc_fourierCoeff (α : ℝ) (hα : 0 < α) (k₀ : ℕ) :
     (wFunc_norm_tsum_ne_top α hα _)]
   -- Simplify each integral: fourier(-2^k₀)(x) * r^k * fourier(2^k)(x)
   --   = r^k * fourier(2^k + (-(2^k₀)))(x)  [character multiplication]
-  simp_rw [smul_eq_mul]
+  simp_rw [Complex.real_smul, Complex.ofReal_pow]
   have h_orth : ∀ k : ℕ,
-      ∫ x : AddCircle T, fourier (-(2:ℤ)^k₀) x * ((geomRatio α : ℝ)^k * fourier ((2:ℤ)^k) x)
+      ∫ x : AddCircle T, fourier (-(2:ℤ)^k₀) x * (((geomRatio α : ℂ))^k * fourier ((2:ℤ)^k) x)
         ∂haarAddCircle =
       (geomRatio α : ℂ)^k * (if (2:ℤ)^k = (2:ℤ)^k₀ then 1 else 0) := by
     intro k
     have h_mul : ∀ x : AddCircle T,
-        fourier (-(2:ℤ)^k₀) x * ((geomRatio α : ℝ)^k * fourier ((2:ℤ)^k) x) =
+        fourier (-(2:ℤ)^k₀) x * ((geomRatio α : ℂ)^k * fourier ((2:ℤ)^k) x) =
         (geomRatio α : ℂ)^k * fourier ((2:ℤ)^k + (-(2:ℤ)^k₀)) x := by
       intro x
       rw [← fourier_add]
@@ -228,7 +228,7 @@ private theorem dist_le_half_period (x y : AddCircle T) : dist x y ≤ T / 2 := 
   set k : ℤ := round (T⁻¹ * (x - y)) with hk_def
   have hround : |T⁻¹ * (x - y) - ↑k| ≤ 1 / 2 := abs_sub_round _
   have hrw : x - y - ↑k * T = T * (T⁻¹ * (x - y) - ↑k) := by
-    field_simp; ring
+    field_simp
   rw [hrw, abs_mul, abs_of_pos hT_pos]
   calc T * |T⁻¹ * (x - y) - ↑k| ≤ T * (1 / 2) := by
         apply mul_le_mul_of_nonneg_left hround hT_pos.le
@@ -318,7 +318,7 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
       ∑' k : ℕ, (r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)) := by
     unfold wFunc
     rw [← Summable.tsum_sub (wFunc_summable α hα_pos x) (wFunc_summable α hα_pos y)]
-    simp_rw [← smul_sub]
+    simp_rw [← smul_sub, ← hr_def]
   rw [h_diff]
   -- Summability of norms
   have h_summ_norm : Summable (fun k : ℕ => r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) := by
@@ -343,13 +343,12 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
       (∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) +
       ∑' k : ℕ, r^(k + p₀) * 2 := by
     rw [← h_summ_norm.sum_add_tsum_nat_add p₀]
-    gcongr ?_ + ?_
-    · exact le_refl _
-    · apply Summable.tsum_le_tsum _ (h_summ_norm.nat_add p₀)
-        ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2 |>.nat_add p₀)
-      intro k
-      apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
-      exact pow_nonneg hr_pos.le _
+    refine add_le_add_left ?_ _
+    apply Summable.tsum_le_tsum _ (h_summ_norm.nat_add p₀)
+      ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2 |>.nat_add p₀)
+    intro k
+    apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
+    exact pow_nonneg hr_pos.le _
   -- Low sum bound: Lipschitz
   have h_low : ∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ ≤
       (2 * Real.pi * (2 * T)^(1-α)) / (T * ((2:ℝ)^(1-α) - 1)) * d^α := by
@@ -388,15 +387,19 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
                 ← Real.rpow_neg hd_pos.le, show -(1-α) = α - 1 from by ring]
           rw [hexp]
           have hdpow : d^(α - 1) * d = d^α := by
-            rw [show d = d^(1:ℝ) from (Real.rpow_one d).symm, ← Real.rpow_add hd_pos]
+            conv_lhs => rw [show d = d^(1:ℝ) from (Real.rpow_one d).symm]
+            rw [← Real.rpow_add hd_pos]
             congr 1; ring
           have hden_ne : (2:ℝ)^(1-α) - 1 ≠ 0 := by
-            have : (1:ℝ) < (2:ℝ)^(1-α) := hs_gt1
-            rw [hs_def] at this; linarith
-          field_simp
-          rw [show (2:ℝ)*Real.pi/T*d*((2*T)^(1-α)*d^(α-1)) =
-              2*Real.pi*(2*T)^(1-α)*(d^(α-1)*d)/T from by ring, hdpow]
-          ring
+            have h1 : (1:ℝ) < (2:ℝ)^(1-α) := by rw [← hs_def]; exact hs_gt1
+            linarith
+          -- Rearrange so d^(α-1)·d appears, then substitute hdpow.
+          rw [show (2 * Real.pi / T * d) * ((2*T)^(1-α) * d^(α-1) / ((2:ℝ)^(1-α) - 1)) =
+                2 * Real.pi * (2*T)^(1-α) * (d^(α-1) * d) / (T * ((2:ℝ)^(1-α) - 1)) from by
+                field_simp; ring,
+              hdpow,
+              show 2 * Real.pi * (2*T)^(1-α) * d^α / (T * ((2:ℝ)^(1-α) - 1)) =
+                2 * Real.pi * (2*T)^(1-α) / (T * ((2:ℝ)^(1-α) - 1)) * d^α from by ring]
   -- High sum bound: trivial
   have h_high : ∑' k : ℕ, r^(k + p₀) * 2 ≤
       (2 * (4:ℝ)^α) / (T^α * (1 - (2:ℝ)^(-α))) * d^α := by

--- a/proofs/Proofs/FourierSeriesOQ02OQ04.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ04.lean
@@ -469,7 +469,7 @@ private theorem lacunary_strictMono :
   exact Nat.pow_lt_pow_right (by norm_num) hab
 
 /-- The Fourier coefficient bound: 1 / (2^k)^α = r^k. -/
-private theorem coeff_bound (α : ℝ) (hα : 0 < α) (k : ℕ) :
+private theorem coeff_bound (α : ℝ) (_hα : 0 < α) (k : ℕ) :
     (1:ℝ) / (|(((2:ℤ)^k : ℤ) : ℝ)| ^ α) = (geomRatio α)^k := by
   simp only [Int.cast_pow, Int.cast_ofNat, abs_pow, abs_of_pos (by norm_num : (0:ℝ) < 2)]
   unfold geomRatio

--- a/proofs/Proofs/FourierSeriesOQ02OQ04.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ04.lean
@@ -155,9 +155,10 @@ private theorem wFunc_fourierCoeff (α : ℝ) (hα : 0 < α) (k₀ : ℕ) :
         fourier (-(2:ℤ)^k₀) x * ((geomRatio α : ℂ)^k * fourier ((2:ℤ)^k) x) =
         (geomRatio α : ℂ)^k * fourier ((2:ℤ)^k + (-(2:ℤ)^k₀)) x := by
       intro x
-      rw [← fourier_add]
-      push_cast; ring
-    simp_rw [h_mul, integral_mul_left]
+      rw [show fourier (-(2:ℤ)^k₀) x * ((geomRatio α : ℂ)^k * fourier ((2:ℤ)^k) x) =
+            (geomRatio α : ℂ)^k * (fourier ((2:ℤ)^k) x * fourier (-(2:ℤ)^k₀) x) from by ring,
+          ← fourier_add]
+    simp_rw [h_mul, integral_const_mul]
     rw [fourier_integral]
     simp only [add_neg_eq_zero]
   simp_rw [h_orth]
@@ -165,14 +166,12 @@ private theorem wFunc_fourierCoeff (α : ℝ) (hα : 0 < α) (k₀ : ℕ) :
   have h_inj : ∀ k : ℕ, (2:ℤ)^k = (2:ℤ)^k₀ ↔ k = k₀ := by
     intro k
     constructor
-    · intro h; exact_mod_cast Nat.pow_right_injective (by norm_num) (by exact_mod_cast h)
+    · intro h
+      have hnat : (2:ℕ)^k = (2:ℕ)^k₀ := by exact_mod_cast h
+      exact Nat.pow_right_injective (le_refl 2) hnat
     · intro h; subst h; rfl
-  simp_rw [h_inj]
-  rw [tsum_ite_eq_extract (summable_geometric_of_lt_one
-    (by exact_mod_cast pow_nonneg (geomRatio_pos α).le k₀)
-    (by push_cast; exact pow_lt_one (geomRatio_pos α).le (geomRatio_lt_one α hα) (by omega))
-    |>.mul_right _)]
-  simp
+  simp_rw [h_inj, mul_ite, mul_one, mul_zero]
+  rw [tsum_ite_eq k₀]
 
 /-!
 ## Part IV: Hölder continuity of wFunc
@@ -343,7 +342,8 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
       (∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) +
       ∑' k : ℕ, r^(k + p₀) * 2 := by
     rw [← h_summ_norm.sum_add_tsum_nat_add p₀]
-    refine add_le_add_left ?_ _
+    refine add_le_add_left ?_
+      (∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖)
     apply Summable.tsum_le_tsum _ (h_summ_norm.nat_add p₀)
       ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2 |>.nat_add p₀)
     intro k
@@ -362,7 +362,9 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
             _ = 2 * Real.pi * (2:ℝ)^k / T * d := by
                 congr 2; simp [abs_of_pos (pow_pos (by norm_num : (0:ℝ) < 2) k)]
       _ = (2 * Real.pi / T * d) * ∑ k ∈ Finset.range p₀, (r * 2)^k := by
-          simp_rw [← Finset.mul_sum]; congr 1; ext k; ring
+          rw [Finset.mul_sum]
+          apply Finset.sum_congr rfl; intro k _
+          rw [mul_pow]; ring
       _ ≤ (2 * Real.pi / T * d) * (s^p₀ / (s - 1)) := by
           have hrs : r * 2 = s := by
             rw [hr_def, hs_def]; unfold geomRatio
@@ -376,8 +378,7 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
           have hcoef_nonneg : 0 ≤ 2 * Real.pi / T * d := by positivity
           have hstep : (2 * Real.pi / T * d) * (s^p₀ / (s - 1)) ≤
               (2 * Real.pi / T * d) * ((2*T/d)^(1-α) / (s - 1)) := by
-            gcongr 2 * Real.pi / T * d * (?_ / (s - 1))
-            exact h_s_bound
+            gcongr
           refine hstep.trans (le_of_eq ?_)
           rw [hs_def]
           -- (2T/d)^(1-α) = (2T)^(1-α) · d^(α-1); combine with d and simplify.
@@ -386,20 +387,17 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
             rw [Real.div_rpow (by positivity) hd_pos.le, div_eq_mul_inv,
                 ← Real.rpow_neg hd_pos.le, show -(1-α) = α - 1 from by ring]
           rw [hexp]
-          have hdpow : d^(α - 1) * d = d^α := by
-            conv_lhs => rw [show d = d^(1:ℝ) from (Real.rpow_one d).symm]
-            rw [← Real.rpow_add hd_pos]
-            congr 1; ring
+          have hdpow : d^α = d^(α - 1) * d := by
+            nth_rewrite 1 [show d^α = d^((α - 1) + 1) from by congr 1; ring]
+            rw [Real.rpow_add hd_pos, Real.rpow_one]
           have hden_ne : (2:ℝ)^(1-α) - 1 ≠ 0 := by
             have h1 : (1:ℝ) < (2:ℝ)^(1-α) := by rw [← hs_def]; exact hs_gt1
             linarith
-          -- Rearrange so d^(α-1)·d appears, then substitute hdpow.
-          rw [show (2 * Real.pi / T * d) * ((2*T)^(1-α) * d^(α-1) / ((2:ℝ)^(1-α) - 1)) =
-                2 * Real.pi * (2*T)^(1-α) * (d^(α-1) * d) / (T * ((2:ℝ)^(1-α) - 1)) from by
-                field_simp; ring,
-              hdpow,
-              show 2 * Real.pi * (2*T)^(1-α) * d^α / (T * ((2:ℝ)^(1-α) - 1)) =
-                2 * Real.pi * (2*T)^(1-α) / (T * ((2:ℝ)^(1-α) - 1)) * d^α from by ring]
+          have hT_ne : T ≠ 0 := hT_pos.ne'
+          -- Substitute d^α = d^(α-1)·d on the RHS; everything is then rational in atoms.
+          rw [hdpow]
+          field_simp
+          ring
   -- High sum bound: trivial
   have h_high : ∑' k : ℕ, r^(k + p₀) * 2 ≤
       (2 * (4:ℝ)^α) / (T^α * (1 - (2:ℝ)^(-α))) * d^α := by

--- a/proofs/Proofs/FourierSeriesOQ02OQ04.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ04.lean
@@ -44,25 +44,21 @@ private theorem fourier_integral (m : ℤ) :
     ∫ t : AddCircle T, fourier m t ∂haarAddCircle = if m = 0 then 1 else 0 := by
   split_ifs with hm
   · subst hm; simp_rw [fourier_zero]
-    rw [integral_const, measure_univ, ENNReal.one_toReal, one_smul]
+    rw [integral_const]
+    simp [measureReal_def, measure_univ]
   · exact integral_eq_zero_of_add_right_eq_neg (fourier_add_half_inv_index hm hT.out)
 
 /-- The Fourier coefficient of a Fourier mode: ĉ_m(fourier n) = if n = m then 1 else 0. -/
 private theorem fourierCoeff_fourier_mode (n m : ℤ) :
     fourierCoeff (fourier n : AddCircle T → ℂ) m = if n = m then 1 else 0 := by
   simp only [fourierCoeff, smul_eq_mul]
-  -- Rewrite: fourier(-m)(x) * fourier(n)(x) = fourier(n + (-m))(x)
-  have h_prod : ∀ x : AddCircle T, fourier (-m) x * fourier n x = fourier (n + (-m)) x := by
-    intro x; rw [← fourier_add]
+  -- Rewrite: fourier(-m)(x) * fourier(n)(x) = fourier(n - m)(x)
+  have h_prod : ∀ x : AddCircle T, fourier (-m) x * fourier n x = fourier (n - m) x := by
+    intro x; rw [← fourier_add]; congr 1; ring
   simp_rw [h_prod]
-  -- Now ∫ x, fourier(n - m)(x) ∂μ = if n - m = 0 then 1 else 0
-  rw [show ∀ k : ℤ, (k = 0) ↔ (n + (-m) = 0) ↔ (n = m) from
-    fun k => Iff.rfl |>.trans (by constructor <;> intro h <;> omega)]
-  rw [show n + (-m) = n - m from by ring]
-  rw [show (if n - m = 0 then (1 : ℂ) else 0) = if n = m then 1 else 0 from by
-    split_ifs with h1 h2 h2 <;> simp_all <;> omega]
-  exact fourier_integral (n - m) |>.trans (by
-    split_ifs with h1 h2 h2 <;> simp_all <;> omega)
+  -- Now ∫ x, fourier(n - m)(x) ∂μ = if n = m then 1 else 0
+  rw [fourier_integral (n - m)]
+  split_ifs with h1 h2 h2 <;> first | rfl | (exfalso; omega)
 
 /-!
 ## Part II: The Weierstrass lacunary function
@@ -76,9 +72,8 @@ private theorem geomRatio_pos (α : ℝ) : 0 < geomRatio α :=
 
 private theorem geomRatio_lt_one (α : ℝ) (hα : 0 < α) : geomRatio α < 1 := by
   unfold geomRatio
-  rw [Real.rpow_neg (by norm_num)]
-  exact inv_lt_one (by rwa [show (1:ℝ) = (2:ℝ)^(0:ℝ) from by simp;
-    exact Real.rpow_lt_rpow_of_exponent_lt (by norm_num) hα])
+  rw [show (1:ℝ) = (2:ℝ)^(0:ℝ) from by simp]
+  exact Real.rpow_lt_rpow_of_exponent_lt (by norm_num) (by linarith)
 
 /-- The Weierstrass lacunary function f(x) = ∑_{k:ℕ} r^k • fourier(2^k)(x). -/
 private def wFunc (α : ℝ) : AddCircle T → ℂ :=
@@ -87,17 +82,15 @@ private def wFunc (α : ℝ) : AddCircle T → ℂ :=
 /-- Each term in the series has norm ≤ r^k (since ‖fourier(n)(x)‖ = 1). -/
 private theorem wFunc_term_norm (α : ℝ) (k : ℕ) (x : AddCircle T) :
     ‖(geomRatio α)^k • fourier ((2:ℤ)^k) x‖ ≤ (geomRatio α)^k := by
-  rw [norm_smul]
-  simp only [Real.norm_rpow_of_nonneg (by norm_num), Real.norm_ofNat]
-  rw [FourierDecayInfra.fourier_norm_eq_one]
-  simp [mul_one, norm_pow, Real.norm_of_nonneg (geomRatio_pos α).le]
+  rw [norm_smul, FourierDecayInfra.fourier_norm_eq_one,
+      Real.norm_of_nonneg (pow_nonneg (geomRatio_pos α).le _), mul_one]
 
 /-- The series defining wFunc is uniformly convergent (summable). -/
 private theorem wFunc_summable (α : ℝ) (hα : 0 < α) (x : AddCircle T) :
     Summable (fun k : ℕ => (geomRatio α)^k • fourier ((2:ℤ)^k) x) := by
-  apply Summable.of_norm_bounded (fun k => (geomRatio α)^k)
-  · exact summable_geometric_of_lt_one (geomRatio_pos α).le (geomRatio_lt_one α hα)
-  · exact fun k => wFunc_term_norm α k x
+  exact Summable.of_norm_bounded
+    (summable_geometric_of_lt_one (geomRatio_pos α).le (geomRatio_lt_one α hα))
+    (fun k => wFunc_term_norm α k x)
 
 /-- The norm-summable bound for use in integral_tsum. -/
 private theorem wFunc_norm_tsum_ne_top (α : ℝ) (hα : 0 < α) (n : ℤ) :
@@ -113,14 +106,16 @@ private theorem wFunc_norm_tsum_ne_top (α : ℝ) (hα : 0 < α) (n : ℤ) :
           apply lintegral_mono_ae; apply Filter.Eventually.of_forall; intro x
           show ‖fourier (-n) x • ((geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x)‖ₑ ≤
             ENNReal.ofReal ((geomRatio α)^k)
-          rw [enorm_le_ofReal (by positivity), norm_smul, norm_smul,
-              FourierDecayInfra.fourier_norm_eq_one,
-              Real.norm_rpow_of_nonneg (by norm_num), Real.norm_ofNat,
-              FourierDecayInfra.fourier_norm_eq_one,
-              Real.norm_of_nonneg (geomRatio_pos α).le]
-          ring_nf; linarith [pow_nonneg (geomRatio_pos α).le k]
+          have hnorm : ‖fourier (-n) x • ((geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x)‖ ≤
+              (geomRatio α)^k := by
+            rw [norm_smul, norm_smul, FourierDecayInfra.fourier_norm_eq_one,
+                FourierDecayInfra.fourier_norm_eq_one,
+                Real.norm_of_nonneg (pow_nonneg (geomRatio_pos α).le _)]
+            simp
+          rw [← ofReal_norm_eq_enorm]
+          exact ENNReal.ofReal_le_ofReal hnorm
       _ = ENNReal.ofReal ((geomRatio α)^k) := by
-          rw [lintegral_const, measure_univ, ENNReal.one_toReal, one_mul]
+          rw [lintegral_const, measure_univ, mul_one]
   calc ∑' k : ℕ, ∫⁻ x : AddCircle T,
       ‖fourier (-n) x • ((geomRatio α)^k • fourier ((2:ℤ)^k) x)‖ₑ ∂haarAddCircle
       ≤ ∑' k : ℕ, ENNReal.ofReal ((geomRatio α)^k) := ENNReal.tsum_le_tsum hbound
@@ -140,10 +135,10 @@ private theorem wFunc_fourierCoeff (α : ℝ) (hα : 0 < α) (k₀ : ℕ) :
   -- Unfold definition
   simp only [fourierCoeff, wFunc, smul_eq_mul]
   -- Interchange integral and tsum
-  rw [show (fun x => fourier (-(2:ℤ)^k₀) x *
-        ∑' k : ℕ, (geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x) =
+  rw [show (fun x => (∑' k : ℕ, (geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x) *
+        fourier (-(2:ℤ)^k₀) x) =
       fun x => ∑' k : ℕ, fourier (-(2:ℤ)^k₀) x * ((geomRatio α : ℝ)^k • fourier ((2:ℤ)^k) x)
-    from funext fun x => by rw [mul_comm, ← tsum_mul_left]; congr 1; ext k; ring]
+    from funext fun x => by rw [← tsum_mul_left]; congr 1; ext k; rw [smul_eq_mul]; ring]
   rw [integral_tsum
     (fun k => (((fourier (-(2:ℤ)^k₀)).continuous.mul
       ((continuous_const.smul (fourier ((2:ℤ)^k)).continuous))).aestronglyMeasurable))
@@ -192,12 +187,12 @@ where p₀ = Nat.log 2 ⌈T / dist x y⌉.
 
 /-- Partial geometric sum bound: ∑_{k<p} s^k ≤ s^p / (s-1) for s > 1. -/
 private theorem geom_partial_sum_le {s : ℝ} (hs : 1 < s) (p : ℕ) :
-    ∑ k in Finset.range p, s^k ≤ s^p / (s - 1) := by
+    ∑ k ∈ Finset.range p, s^k ≤ s^p / (s - 1) := by
   induction p with
   | zero => simp; positivity
   | succ n ih =>
     rw [Finset.sum_range_succ]
-    calc ∑ k in Finset.range n, s^k + s^n
+    calc ∑ k ∈ Finset.range n, s^k + s^n
         ≤ s^n / (s-1) + s^n := by linarith
       _ = s^(n+1) / (s-1) := by
           rw [pow_succ]; field_simp; ring
@@ -205,11 +200,34 @@ private theorem geom_partial_sum_le {s : ℝ} (hs : 1 < s) (p : ℕ) :
 /-- The geometric tail sum: ∑_{k≥p₀} r^k = r^{p₀} / (1-r). -/
 private theorem geom_tail_sum {r : ℝ} (hr0 : 0 < r) (hr1 : r < 1) (p₀ : ℕ) :
     ∑' k : ℕ, r^(k + p₀) = r^p₀ / (1 - r) := by
-  rw [tsum_geometric_of_lt_one hr0.le hr1 |>.symm ▸ rfl]
   rw [show (fun k : ℕ => r^(k + p₀)) = fun k => r^p₀ * r^k from funext fun k => by
     rw [pow_add, mul_comm]]
   rw [tsum_mul_left, tsum_geometric_of_lt_one hr0.le hr1]
   ring
+
+/-- The diameter bound on `AddCircle T`: any two points are within `T/2`.
+    Follows from `AddCircle.norm_eq` (`‖z‖ = |z.val - round (z.val/T)·T|`) and
+    `abs_sub_round` (`|w - round w| ≤ 1/2`) applied to `w = (x - y)/T`. -/
+private theorem dist_le_half_period (x y : AddCircle T) : dist x y ≤ T / 2 := by
+  have hT_pos := hT.out
+  -- Lift to real representatives
+  induction x using QuotientAddGroup.induction_on with | _ x =>
+  induction y using QuotientAddGroup.induction_on with | _ y =>
+  set k : ℤ := round (T⁻¹ * (x - y)) with hk_def
+  have hT_ne : T ≠ 0 := hT_pos.ne'
+  have h_dist : dist (↑x : AddCircle T) (↑y) = |x - y - ↑k * T| := by
+    rw [dist_eq_norm, show (↑x : AddCircle T) - ↑y = ↑(x - y) from
+      (map_sub (QuotientAddGroup.mk' (AddSubgroup.zmultiples T)) x y).symm,
+      AddCircle.norm_eq]
+  rw [h_dist]
+  -- |x - y - k·T| = T · |(x-y)/T - round((x-y)/T)| ≤ T · (1/2) = T/2
+  have hround : |T⁻¹ * (x - y) - ↑k| ≤ 1 / 2 := abs_sub_round _
+  have hrw : x - y - ↑k * T = T * (T⁻¹ * (x - y) - ↑k) := by
+    field_simp; ring
+  rw [hrw, abs_mul, abs_of_pos hT_pos]
+  calc T * |T⁻¹ * (x - y) - ↑k| ≤ T * (1 / 2) := by
+        apply mul_le_mul_of_nonneg_left hround hT_pos.le
+    _ = T / 2 := by ring
 
 /-- Main Hölder bound for wFunc. -/
 private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 1)
@@ -228,9 +246,12 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
   have hs_pos : 0 < s - 1 := by linarith
   have hT_pos := hT.out
   -- Handle trivial case d = 0
-  set d := dist x y
+  set d := dist x y with hd_def
   by_cases hd : d = 0
-  · simp [hd, hd ▸ dist_eq_zero |>.mp hd]
+  · have hxy : x = y := dist_eq_zero.mp hd
+    subst hxy
+    have hα_ne : α ≠ 0 := ne_of_gt hα_pos
+    simp [hd, Real.zero_rpow hα_ne]
   have hd_pos : 0 < d := lt_of_le_of_ne dist_nonneg (Ne.symm hd)
   -- Choose split index p₀ = Nat.log 2 ⌈T/d⌉
   set n₀ : ℕ := Nat.ceil (T / d) with hn₀_def
@@ -240,11 +261,15 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
   -- Key bounds: 2^{p₀} ≤ n₀ ≤ 2T/d, and T/d ≤ n₀ < 2^{p₀+1}
   have h_pow_le : (2:ℝ)^p₀ ≤ 2 * T / d := by
     calc (2:ℝ)^p₀ = ((2:ℕ)^p₀ : ℕ) := by push_cast; rfl
-      _ ≤ (n₀ : ℝ) := by exact_mod_cast Nat.pow_log_le_self 2 n₀
+      _ ≤ (n₀ : ℝ) := by exact_mod_cast Nat.pow_log_le_self 2 hn₀_pos.ne'
       _ ≤ 2 * T / d := by
-          rw [hn₀_def]; calc (Nat.ceil (T/d) : ℝ)
-            ≤ T/d + 1 := Nat.ceil_le_add_one_iff (by positivity) |>.le |>.trans_eq (by ring) |>.le
-            _ ≤ 2 * T / d := by rw [div_add_eq_add_div, div_le_div_iff hd_pos hd_pos]; linarith
+          rw [hn₀_def]
+          have hd_le_T : d ≤ T := le_trans (dist_le_half_period x y) (by linarith)
+          have hTd_ge_one : (1:ℝ) ≤ T / d := (one_le_div hd_pos).mpr hd_le_T
+          calc (Nat.ceil (T/d) : ℝ)
+            ≤ T/d + 1 := (Nat.ceil_lt_add_one (by positivity)).le
+            _ ≤ 2 * T / d := by
+                rw [mul_div_assoc]; linarith
   have h_pow_gt : T / d < (2:ℝ)^(p₀+1) := by
     calc T / d ≤ (n₀ : ℝ) := by
           rw [hn₀_def]; exact Nat.le_ceil _
@@ -253,50 +278,65 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
   -- Key rpow bounds
   have h_s_bound : s^p₀ ≤ (2 * T / d)^(1-α) := by
     rw [hs_def]
-    calc (2:ℝ)^(p₀ * (1-α))
-        = ((2:ℝ)^p₀)^(1-α) := by rw [← Real.rpow_natCast, ← Real.rpow_mul (by norm_num)]; ring_nf
-      _ ≤ (2 * T / d)^(1-α) := by
-          apply Real.rpow_le_rpow (by positivity) h_pow_le; linarith
+    have hconv : ((2:ℝ)^(1-α))^p₀ = ((2:ℝ)^p₀)^(1-α) := by
+      rw [← Real.rpow_natCast ((2:ℝ)^(1-α)) p₀, ← Real.rpow_natCast (2:ℝ) p₀,
+          ← Real.rpow_mul (by norm_num), ← Real.rpow_mul (by norm_num), mul_comm]
+    rw [hconv]
+    apply Real.rpow_le_rpow (by positivity) h_pow_le; linarith
+  -- Convert h_pow_gt to rpow exponent form for use below.
+  have h_pow_gt' : T / d < (2:ℝ)^((p₀:ℝ)+1) := by
+    rw [show ((p₀:ℝ)+1) = ((p₀+1 : ℕ):ℝ) from by push_cast; ring, Real.rpow_natCast]
+    exact h_pow_gt
   have h_r_bound : r^p₀ < (4 * d / T)^α := by
     rw [hr_def]; unfold geomRatio
-    calc (2:ℝ)^(-(p₀ * α))
-        = ((2:ℝ)^(p₀+1))^(-α) := by
-          rw [← Real.rpow_natCast, ← Real.rpow_mul (by norm_num)]; ring_nf
-      _ < (T/d)^(-α) := by
-          apply Real.rpow_lt_rpow_of_exponent_gt (by positivity) h_pow_gt
-          linarith [Real.rpow_pos_of_pos (by norm_num : (0:ℝ) < 2) (p₀+1 : ℝ)]
-      _ = (d/T)^α := by rw [Real.rpow_neg (by positivity)]; simp [Real.rpow_neg]
+    -- (2^(-α))^p₀ = 2^α · (2^(p₀+1))^(-α)
+    have hlhs : ((2:ℝ)^(-α))^p₀ = (2:ℝ)^α * ((2:ℝ)^((p₀:ℝ)+1))^(-α) := by
+      rw [← Real.rpow_natCast ((2:ℝ)^(-α)) p₀, ← Real.rpow_mul (by norm_num),
+          ← Real.rpow_mul (by norm_num), ← Real.rpow_add (by norm_num)]
+      congr 1; ring
+    rw [hlhs]
+    have hTd_pos : 0 < T / d := by positivity
+    calc (2:ℝ)^α * ((2:ℝ)^((p₀:ℝ)+1))^(-α)
+        < (2:ℝ)^α * ((T/d)^(-α)) := by
+          apply mul_lt_mul_of_pos_left _ (Real.rpow_pos_of_pos (by norm_num) _)
+          exact Real.rpow_lt_rpow_of_exponent_gt hTd_pos h_pow_gt' (by linarith)
+      _ = (2:ℝ)^α * ((d/T)^α) := by
+          rw [Real.rpow_neg hTd_pos.le,
+              show (d/T) = (T/d)⁻¹ from by rw [one_div_div],
+              Real.inv_rpow hTd_pos.le]
+      _ = (2 * (d / T))^α := by rw [Real.mul_rpow (by norm_num) (by positivity)]
       _ ≤ (4 * d / T)^α := by
-          apply Real.rpow_le_rpow (by positivity)
-          · linarith [hd_pos, hT_pos]
-          · linarith
+          apply Real.rpow_le_rpow (by positivity) _ hα_pos.le
+          rw [mul_div_assoc]; apply mul_le_mul_of_nonneg_right (by norm_num) (by positivity)
   -- The difference f(x) - f(y) = ∑' k, r^k • (fourier(2^k)(x) - fourier(2^k)(y))
   have h_diff : wFunc α x - wFunc α y =
       ∑' k : ℕ, (r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)) := by
     unfold wFunc
-    simp_rw [← smul_sub]
     rw [← tsum_sub (wFunc_summable α hα_pos x) (wFunc_summable α hα_pos y)]
+    simp_rw [← smul_sub]
   rw [h_diff]
   -- Summability of norms
-  have h_summ_norm : Summable (fun k : ℕ => r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) :=
-    Summable.of_nonneg_of_le (fun k => by positivity)
-      (fun k => by rw [norm_smul, Real.norm_of_nonneg (pow_nonneg hr_pos.le _)]; exact le_refl _)
-      ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2 |>.of_nonneg_of_le
-        (fun k => by positivity) (fun k => by
-          apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
-          exact pow_nonneg hr_pos.le _))
+  have h_summ_norm : Summable (fun k : ℕ => r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) := by
+    apply Summable.of_nonneg_of_le (fun k => by positivity)
+      (g := fun k => r^k * 2) (fun k => ?_)
+    · exact (summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2
+    · apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
+      exact pow_nonneg hr_pos.le _
   -- Norm bound via triangle inequality
+  have h_norm_eq : ∀ k : ℕ, ‖r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)‖ =
+      r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ := fun k => by
+    rw [norm_smul, Real.norm_of_nonneg (pow_nonneg hr_pos.le _)]
+  have h_summ_norm' : Summable (fun k : ℕ => ‖r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)‖) := by
+    simp_rw [h_norm_eq]; exact h_summ_norm
   have h_tri : ‖∑' k : ℕ, r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)‖ ≤
       ∑' k : ℕ, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ := by
     calc ‖∑' k, r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)‖
         ≤ ∑' k, ‖r^k • (fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y)‖ :=
-          norm_tsum_le_tsum_norm h_summ_norm.of_norm_bounded_eventually (by
-            apply Filter.Eventually.of_forall; intro k; rw [norm_smul, Real.norm_of_nonneg
-              (pow_nonneg hr_pos.le _)])
-      _ = _ := by congr 1; ext k; rw [norm_smul, Real.norm_of_nonneg (pow_nonneg hr_pos.le _)]
+          norm_tsum_le_tsum_norm h_summ_norm'
+      _ = _ := by simp_rw [h_norm_eq]
   -- Split the tsum at p₀
   have h_split : ∑' k : ℕ, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ ≤
-      (∑ k in Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) +
+      (∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) +
       ∑' k : ℕ, r^(k + p₀) * 2 := by
     rw [← h_summ_norm.sum_add_tsum_nat_add p₀]
     apply add_le_add_left
@@ -306,10 +346,10 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
     apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
     exact pow_nonneg hr_pos.le _
   -- Low sum bound: Lipschitz
-  have h_low : ∑ k in Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ ≤
+  have h_low : ∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ ≤
       (2 * Real.pi * (2 * T)^(1-α)) / (T * ((2:ℝ)^(1-α) - 1)) * d^α := by
-    calc ∑ k in Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖
-        ≤ ∑ k in Finset.range p₀, r^k * (2 * Real.pi * (2:ℝ)^k / T * d) := by
+    calc ∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖
+        ≤ ∑ k ∈ Finset.range p₀, r^k * (2 * Real.pi * (2:ℝ)^k / T * d) := by
           apply Finset.sum_le_sum; intro k _
           apply mul_le_mul_of_nonneg_left _ (pow_nonneg hr_pos.le _)
           calc ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖
@@ -317,41 +357,65 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
                 FourierDecayInfra.fourier_lipschitz_bound _ _ _
             _ = 2 * Real.pi * (2:ℝ)^k / T * d := by
                 congr 2; simp [abs_of_pos (pow_pos (by norm_num : (0:ℝ) < 2) k)]
-      _ = (2 * Real.pi / T * d) * ∑ k in Finset.range p₀, (r * 2)^k := by
+      _ = (2 * Real.pi / T * d) * ∑ k ∈ Finset.range p₀, (r * 2)^k := by
           simp_rw [← Finset.mul_sum]; congr 1; ext k; ring
       _ ≤ (2 * Real.pi / T * d) * (s^p₀ / (s - 1)) := by
           apply mul_le_mul_of_nonneg_left _ (by positivity)
           apply geom_partial_sum_le hs_gt1
       _ ≤ (2 * Real.pi * (2 * T)^(1-α)) / (T * ((2:ℝ)^(1-α) - 1)) * d^α := by
+          -- Bound s^p₀ ≤ (2T/d)^(1-α), then split (2T/d)^(1-α) = (2T)^(1-α) / d^(1-α).
+          have hsm1_pos : 0 < s - 1 := hs_pos
+          have hcoef_nonneg : 0 ≤ 2 * Real.pi / T * d := by positivity
+          have hstep : (2 * Real.pi / T * d) * (s^p₀ / (s - 1)) ≤
+              (2 * Real.pi / T * d) * ((2*T/d)^(1-α) / (s - 1)) := by
+            gcongr 2 * Real.pi / T * d * (?_ / (s - 1))
+            exact h_s_bound
+          refine hstep.trans (le_of_eq ?_)
           rw [hs_def]
-          rw [div_mul_eq_mul_div, div_le_div_iff (by positivity) (by positivity)]
-          calc (2 * Real.pi / T * d) * ((2:ℝ)^(p₀*(1-α)) / ((2:ℝ)^(1-α) - 1)) *
-              (T * ((2:ℝ)^(1-α) - 1))
-              = (2 * Real.pi * (2:ℝ)^(p₀*(1-α)) * d) / T := by ring
-            _ ≤ (2 * Real.pi * (2*T/d)^(1-α) * d) / T := by
-                apply div_le_div_of_nonneg_right _ hT_pos
-                apply mul_le_mul_of_nonneg_left h_s_bound (by positivity)
-            _ = 2 * Real.pi * (2*T)^(1-α) / T * d^α := by
-                rw [Real.mul_rpow (by norm_num) (by positivity)]
-                field_simp; ring
-            _ = 2 * Real.pi * (2*T)^(1-α) / T * d^α * (T * ((2:ℝ)^(1-α) - 1)) /
-                (T * ((2:ℝ)^(1-α) - 1)) := by
-                  field_simp
+          -- (2T/d)^(1-α) = (2T)^(1-α) · d^(-(1-α)); combine with d and simplify.
+          have hd_ne : d ≠ 0 := hd_pos.ne'
+          have hexp : (2*T/d)^(1-α) = (2*T)^(1-α) * d^(α - 1) := by
+            rw [show (2*T/d) = (2*T) * d⁻¹ from by ring,
+                Real.mul_rpow (by positivity) (by positivity),
+                ← Real.rpow_neg_one d, ← Real.rpow_natCast d 1]
+            rw [← Real.rpow_mul hd_pos.le]
+            rw [show (1:ℝ) - α = -(α - 1) from by ring, Real.rpow_neg (by positivity)]
+            rw [Real.rpow_natCast, pow_one]
+            rw [show (α - 1) = -(1 - α) from by ring, Real.rpow_neg hd_pos.le]
+            rw [Real.inv_rpow hd_pos.le]
+          rw [hexp]
+          have hdpow : d^(α - 1) * d = d^α := by
+            rw [show d = d^(1:ℝ) from (Real.rpow_one d).symm, ← Real.rpow_add hd_pos]
+            · congr 1; ring
+          field_simp
+          rw [show (2:ℝ)*Real.pi/T*d*((2*T)^(1-α)*d^(α-1)) =
+              2*Real.pi*(2*T)^(1-α)*(d^(α-1)*d)/T from by ring, hdpow]
+          ring
   -- High sum bound: trivial
   have h_high : ∑' k : ℕ, r^(k + p₀) * 2 ≤
       (2 * (4:ℝ)^α) / (T^α * (1 - (2:ℝ)^(-α))) * d^α := by
     rw [show (fun k : ℕ => r^(k+p₀) * 2) = fun k => 2 * r^(k+p₀) from funext (fun k => by ring)]
     rw [tsum_mul_left, geom_tail_sum hr_pos hr_lt1]
-    rw [hr_def]; unfold geomRatio
-    rw [div_mul_eq_mul_div, mul_div_assoc']
-    apply div_le_div_of_nonneg_right _ (by positivity)
-    calc 2 * (2:ℝ)^(-(p₀:ℝ) * α)
-        < 2 * (4 * d / T)^α := by
-          apply mul_lt_mul_of_pos_left h_r_bound (by norm_num)
-      _ = 2 * (4:ℝ)^α * d^α / T^α := by
-          rw [Real.mul_rpow (by norm_num) (by positivity), Real.mul_rpow (by norm_num) hd_pos.le]
-          ring
-      _ ≤ 2 * (4:ℝ)^α * d^α / T^α := le_refl _
+    -- Goal: 2 * (r^p₀ / (1 - r)) ≤ (2·4^α)/(T^α·(1-2^(-α)))·d^α
+    have h1mr_pos : 0 < 1 - r := by linarith
+    have hr_eq : (1:ℝ) - r = 1 - (2:ℝ)^(-α) := by rw [hr_def]; rfl
+    have hden_pos : 0 < 1 - (2:ℝ)^(-α) := by rw [← hr_eq]; exact h1mr_pos
+    -- (4d/T)^α = 4^α · d^α / T^α
+    have hexp : (4 * d / T)^α = (4:ℝ)^α * d^α / T^α := by
+      rw [show (4 * d / T) = 4 * d * T⁻¹ from by ring,
+          Real.mul_rpow (by positivity) (by positivity),
+          Real.mul_rpow (by norm_num) hd_pos.le, Real.inv_rpow (by positivity),
+          Real.rpow_neg (by positivity)]
+      ring
+    -- Rewrite both sides over the common denominator (1 - 2^(-α)).
+    rw [hr_eq, show (2 : ℝ) * (r^p₀ / (1 - (2:ℝ)^(-α))) = (2 * r^p₀) / (1 - (2:ℝ)^(-α)) from by
+          rw [mul_div_assoc],
+        show (2 * (4:ℝ)^α) / (T^α * (1 - (2:ℝ)^(-α))) * d^α
+            = (2 * ((4:ℝ)^α * d^α / T^α)) / (1 - (2:ℝ)^(-α)) from by
+          rw [mul_comm (T^α) (1 - (2:ℝ)^(-α)), ← div_div, div_mul_eq_mul_div]; ring]
+    gcongr (?_ / (1 - (2:ℝ)^(-α)))
+    rw [← hexp]
+    exact mul_le_mul_of_nonneg_left (le_of_lt h_r_bound) (by norm_num)
   -- Combine
   calc ‖wFunc α (T := T) x - wFunc α y‖
       ≤ ∑' k : ℕ, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖ := h_tri
@@ -363,17 +427,23 @@ private theorem wFunc_holderWith (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 1)
     ∃ (C : ℝ≥0), HolderWith C α.toNNReal (wFunc α (T := T)) := by
   set K : ℝ := (2 * Real.pi * (2 * T)^(1-α)) / (T * ((2:ℝ)^(1-α) - 1)) +
                (2 * (4:ℝ)^α) / (T^α * (1 - (2:ℝ)^(-α))) with hK_def
+  have hT_pos := hT.out
+  have h2_gt1 : (1:ℝ) < (2:ℝ)^(1-α) := by
+    rw [show (1:ℝ) = (2:ℝ)^(0:ℝ) from by simp]
+    exact Real.rpow_lt_rpow_of_exponent_lt (by norm_num) (by linarith)
+  have h2negα_lt1 : (2:ℝ)^(-α) < 1 := by
+    have := geomRatio_lt_one α hα_pos; unfold geomRatio at this; exact this
   have hK_pos : 0 < K := by
     rw [hK_def]
     apply add_pos
-    · apply div_pos (by positivity)
-      apply mul_pos hT.out
-      linarith [show (1:ℝ) < (2:ℝ)^(1-α) from by
-        rw [show (1:ℝ) = (2:ℝ)^(0:ℝ) from by simp]
-        exact Real.rpow_lt_rpow_of_exponent_lt (by norm_num) (by linarith)]
-    · apply div_pos (by positivity)
-      apply mul_pos (Real.rpow_pos_of_pos hT.out _)
-      linarith [geomRatio_lt_one α hα_pos]
+    · apply div_pos
+      · have : (0:ℝ) < (2 * T)^(1-α) := Real.rpow_pos_of_pos (by positivity) _
+        positivity
+      · apply mul_pos hT_pos; linarith
+    · apply div_pos
+      · have : (0:ℝ) < (4:ℝ)^α := Real.rpow_pos_of_pos (by norm_num) _
+        positivity
+      · apply mul_pos (Real.rpow_pos_of_pos hT_pos _); linarith
   refine ⟨⟨K, hK_pos.le⟩, FourierDecayInfra.holderWith_of_dist_bound fun x y => ?_⟩
   simp only [NNReal.coe_mk, Real.coe_toNNReal α hα_pos.le]
   exact wFunc_holder_bound α hα_pos hα_lt x y
@@ -386,7 +456,8 @@ private theorem wFunc_holderWith (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 1)
 private theorem lacunary_strictMono :
     StrictMono (fun k => ((2:ℤ)^k).natAbs) := by
   intro a b hab
-  simp only [Int.natAbs_pow, Int.natAbs_ofNat]
+  have h2 : (2 : ℤ).natAbs = 2 := rfl
+  simp only [Int.natAbs_pow, h2]
   exact Nat.pow_lt_pow_right (by norm_num) hab
 
 /-- The Fourier coefficient bound: 1 / (2^k)^α = r^k. -/
@@ -394,8 +465,10 @@ private theorem coeff_bound (α : ℝ) (hα : 0 < α) (k : ℕ) :
     (1:ℝ) / (|(((2:ℤ)^k : ℤ) : ℝ)| ^ α) = (geomRatio α)^k := by
   simp only [Int.cast_pow, Int.cast_ofNat, abs_pow, abs_of_pos (by norm_num : (0:ℝ) < 2)]
   unfold geomRatio
-  rw [← Real.rpow_natCast, ← Real.rpow_natCast (2:ℝ), ← Real.rpow_mul (by norm_num)]
-  simp [Real.rpow_neg (by norm_num : (0:ℝ) ≤ 2), Real.rpow_natCast]
+  rw [one_div, ← Real.rpow_natCast (2:ℝ) k, ← Real.rpow_mul (by norm_num : (0:ℝ) ≤ 2),
+      ← Real.rpow_neg (by norm_num : (0:ℝ) ≤ 2), ← Real.rpow_natCast ((2:ℝ)^(-α)) k,
+      ← Real.rpow_mul (by norm_num : (0:ℝ) ≤ 2)]
+  congr 1; ring
 
 /-- **Optimality**: For 0 < α < 1, there exists an α-Hölder function with
     Fourier coefficients ≥ 1/|n_k|^α along the lacunary sequence n_k = 2^k. -/
@@ -412,7 +485,8 @@ theorem holder_decay_is_optimal_seq_proof :
   refine ⟨C, wFunc α, hC, 1, one_pos, fun k => (2:ℤ)^k, lacunary_strictMono, fun k => ?_⟩
   -- Prove: 1 / |(2^k : ℝ)|^α ≤ ‖fourierCoeff (wFunc α) (2^k)‖
   rw [wFunc_fourierCoeff α hα_pos k, coeff_bound α hα_pos k]
-  simp [norm_pow, Complex.norm_real, Real.norm_of_nonneg (pow_nonneg (geomRatio_pos α).le _)]
+  refine le_of_eq ?_
+  rw [norm_pow, Complex.norm_real, Real.norm_of_nonneg (geomRatio_pos α).le]
 
 end WeierstrassOptimality
 

--- a/proofs/Proofs/FourierSeriesOQ02OQ04.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ04.lean
@@ -343,9 +343,11 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
       ∑' k : ℕ, r^(k + p₀) * 2 := by
     rw [← h_summ_norm.sum_add_tsum_nat_add p₀]
     refine add_le_add (le_refl _) ?_
-    apply Summable.tsum_le_tsum _ (h_summ_norm.nat_add p₀)
-      ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2 |>.nat_add p₀)
-    intro k
+    have hf : Summable (fun k : ℕ => r^(k + p₀) * ‖fourier ((2:ℤ)^(k+p₀)) x - fourier ((2:ℤ)^(k+p₀)) y‖) :=
+      (summable_nat_add_iff p₀).2 h_summ_norm
+    have hg : Summable (fun k : ℕ => r^(k + p₀) * 2) :=
+      (summable_nat_add_iff p₀).2 ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2)
+    refine Summable.tsum_le_tsum (fun k => ?_) hf hg
     apply mul_le_mul_of_nonneg_left (FourierDecayInfra.fourier_sub_norm_le_two _ _ _)
     exact pow_nonneg hr_pos.le _
   -- Low sum bound: Lipschitz

--- a/proofs/Proofs/FourierSeriesOQ02OQ04.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ04.lean
@@ -342,8 +342,7 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
       (∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖) +
       ∑' k : ℕ, r^(k + p₀) * 2 := by
     rw [← h_summ_norm.sum_add_tsum_nat_add p₀]
-    refine add_le_add_left ?_
-      (∑ k ∈ Finset.range p₀, r^k * ‖fourier ((2:ℤ)^k) x - fourier ((2:ℤ)^k) y‖)
+    refine add_le_add (le_refl _) ?_
     apply Summable.tsum_le_tsum _ (h_summ_norm.nat_add p₀)
       ((summable_geometric_of_lt_one hr_pos.le hr_lt1).mul_right 2 |>.nat_add p₀)
     intro k
@@ -397,7 +396,7 @@ private theorem wFunc_holder_bound (α : ℝ) (hα_pos : 0 < α) (hα_lt : α < 
           -- Substitute d^α = d^(α-1)·d on the RHS; everything is then rational in atoms.
           rw [hdpow]
           field_simp
-          ring
+          try ring
   -- High sum bound: trivial
   have h_high : ∑' k : ℕ, r^(k + p₀) * 2 ≤
       (2 * (4:ℝ)^α) / (T^α * (1 - (2:ℝ)^(-α))) * d^α := by

--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -37,7 +37,7 @@
     "author": "Classical (Bernstein, Zygmund)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fourier_series#Rate_of_convergence",
     "date": "1912",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FourierSeriesOQ02.lean",
     "tags": [
       "analysis",
@@ -47,7 +47,7 @@
       "coefficient-decay",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
@@ -105,7 +105,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 495,
-    "assumptions": "Build-broken: FourierSeriesOQ02OQ04.lean (imported for the optimality witness and partial converse) fails to compile against Mathlib 4.26.0 with ~30 API drift errors plus one genuine math gap. Full repair tracked in #34767 (loom:blocked). Revert to status: verified / badge: original once #34767 migration passes docker-build.sh Proofs.FourierSeriesOQ02OQ04.",
+    "assumptions": "0 axioms — fully proved via Weierstrass lacunary series construction in FourierSeriesOQ02OQ04.lean.",
     "theoremCount": 19,
     "additionalFiles": [
       "Proofs/FourierSeriesOQ02Incomplete01.lean",


### PR DESCRIPTION
## Summary

Full Mathlib 4.26.0 migration of `proofs/Proofs/FourierSeriesOQ02OQ04.lean` (namespace `WeierstrassOptimality`), which proves `holder_decay_is_optimal_seq`: for `0 < α < 1` there exists an α-Hölder function on `AddCircle T` whose Fourier coefficients achieve the `O(1/|n|^α)` rate along the lacunary sequence `n_k = 2^k`.

The file was broken under Mathlib 4.26 with ~40 distinct API-drift errors across every major proof (not the "3 scoped sites" the original curator comment estimated), plus **one genuine mathematical gap**. Because `FourierSeriesOQ02.lean` imports this file, the entire parent Fourier decay tree did not build — a live `verified` gallery overclaim (interim-downgraded by #35097).

Both targets now build clean with **0 sorries, 0 axioms**:
- `./proofs/scripts/docker-build.sh Proofs.FourierSeriesOQ02OQ04` → `Build succeeded` (3117 jobs, exit 0)
- `./proofs/scripts/docker-build.sh Proofs.FourierSeriesOQ02` → `Build succeeded` (3118 jobs, exit 0)

## The genuine math gap

`wFunc_holder_bound.h_pow_le` needs `⌈T/d⌉ ≤ 2T/d`, which reduces to `T/d + 1 ≤ 2T/d`, i.e. **`d ≤ T`** where `d = dist x y` on `AddCircle T`. That fact was assumed but never available in scope, and the companion `FourierSeriesOQ02Incomplete01.lean` provides no such lemma.

Repaired minimally by adding a new private helper `dist_le_half_period : dist x y ≤ T/2` (hence `≤ T`), proved from `AddCircle.norm_eq` (`‖z‖ = |z.val − round(z.val/T)·T|`) and `abs_sub_round` (`|w − round w| ≤ 1/2`) applied to `w = (x−y)/T` — the same rounding machinery the infra file's Lipschitz proof uses. No statement was weakened.

## Changes

- `proofs/Proofs/FourierSeriesOQ02OQ04.lean` — Mathlib 4.26 migration + `dist_le_half_period` helper. Representative fixes:
  - `integral_const` now yields `μ.real univ • c` → `measureReal`/probability-measure simp; `ENNReal.one_toReal` removed.
  - `∑ k in` → `∑ k ∈` big-operator notation (removed in 4.26).
  - `inv_lt_one` → direct rpow exponent monotonicity; `Int.natAbs_ofNat`, `Int.cast_ofNat` cast fixes; `integral_mul_left` → `integral_const_mul`.
  - `Summable.of_norm_bounded` / `of_nonneg_of_le` signature changes (bound fn now implicit); `enorm_le_ofReal` → `ofReal_norm_eq_enorm` + `ENNReal.ofReal_le_ofReal`.
  - `tsum_sub` → `Summable.tsum_sub`; `.nat_add` → `summable_nat_add_iff`; `tsum_ite_eq_extract` → `tsum_ite_eq`; `real_smul` handling in the orthogonality integral.
  - `div_le_div_iff` / `div_le_div_of_nonneg_right` removed → `gcongr` and rpow algebra; `Real.rpow_lt_rpow_of_exponent_gt` (wrong lemma for base-monotonicity) → `Real.rpow_lt_rpow_of_neg`.
  - Rebuilt the `h_r_bound` calc (original had a mathematically false `=` step that pre-4.26 tooling had tolerated) with the correct `2^α · (2^(p₀+1))^(-α)` factorization.
- `src/data/proofs/fourier-series-oq-02/meta.json` — reverted the #35097 interim downgrade per its own revert instructions: `status: formalized → verified`, `badge: wip → original`, restored the `0 axioms — fully proved …` assumptions text. Both stat blocks consistent (`leanFile.*` sorries/axiomCount = 0).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `docker-build.sh Proofs.FourierSeriesOQ02OQ04` exits 0, no `error:` | ✅ | `Build succeeded`, 0 error lines |
| `docker-build.sh Proofs.FourierSeriesOQ02` exits 0 (chain unblocked) | ✅ | `Build succeeded`, 0 error lines |
| No `sorry` introduced | ✅ | `grep sorry` → none |
| No new `axiom` | ✅ | `grep '^axiom'` → none |
| Theorem statements unchanged (faithful repair, no weakening) | ✅ | Only tactic blocks + one added helper lemma changed; all public signatures identical |
| Gallery meta honest after fix | ✅ | `verified` / `original` / 0 sorries / 0 axioms, both stat blocks consistent |

## Test Plan

- Primary build: `Proofs.FourierSeriesOQ02OQ04` — succeeds (exit 0).
- Downstream build: `Proofs.FourierSeriesOQ02` — succeeds (unblocks gallery entry).
- `grep -n "sorry\|^axiom " proofs/Proofs/FourierSeriesOQ02OQ04.lean` → none.
- `jq '.meta.status,.leanFile.sorries,.leanFile.axiomCount'` → `"verified"`, `0`, `0`.

Closes #34767