### PR TITLE
Roth k=3 (oq-01): prove r₃(4) = 2 exactly, axiom-free [rebase of #34788]

### DIFF
--- a/proofs/Proofs/RothTheoremQuantitative.lean
+++ b/proofs/Proofs/RothTheoremQuantitative.lean
@@ -165,6 +165,43 @@ theorem rothNumber_three : rothNumber 3 = 2 := by
     a + d ∈ ({0, 1} : Finset (ZMod 3)) → a + 2 * d ∉ ({0, 1} : Finset (ZMod 3))
   decide
 
+/-- Every AP-free subset of `ZMod 4` has at most two elements.
+
+    Unlike the odd modulus `N = 3`, in `ZMod 4` the step `d = 2` wraps around:
+    `a + 2 * 2 = a + 4 = a`. So an AP-free set may never contain both `a` and
+    `a + 2` (the "progression" `a, a + 2, a` would put `a + 2 * d = a` back in
+    the set). This forbids `{0, 2}` and `{1, 3}` simultaneously, capping the
+    size at two. The finite check is discharged by `decide` on the *unfolded*
+    predicate — the global `APFree` instance is classical and cannot evaluate. -/
+theorem apFree_four_card_le_two :
+    ∀ A : Finset (ZMod 4),
+      (∀ a d : ZMod 4, d ≠ 0 → a ∈ A → a + d ∈ A → a + 2 * d ∉ A) → A.card ≤ 2 := by
+  decide
+
+/-- r₃(4) = 2. Lower bound: `{0, 1}` is AP-free (as in `ZMod 3`). Upper bound:
+    every AP-free set avoids the pairs `{0, 2}` and `{1, 3}` because of the
+    `d = 2` wraparound, so no AP-free subset of `ZMod 4` reaches three elements.
+
+    Note `r₃(4) = 2 = r₃(3)`: the Roth number does not increase from modulus 3
+    to modulus 4, illustrating that `r₃` is not monotone in `N`. -/
+theorem rothNumber_four : rothNumber 4 = 2 := by
+  refine le_antisymm ?_ ?_
+  · -- Upper bound: every set in the powerset filter has card ≤ 2.
+    rw [rothNumber_def]
+    apply Finset.sup_le
+    intro A hA
+    rw [Finset.mem_filter] at hA
+    exact apFree_four_card_le_two A hA.2
+  · -- Lower bound: {0, 1} is an AP-free set of size 2.
+    apply card_le_rothNumber ({0, 1} : Finset (ZMod 4))
+    show ∀ a d : ZMod 4, d ≠ 0 → a ∈ ({0, 1} : Finset (ZMod 4)) →
+      a + d ∈ ({0, 1} : Finset (ZMod 4)) → a + 2 * d ∉ ({0, 1} : Finset (ZMod 4))
+    decide
+
+-- Axiom audit: expect only propext / Classical.choice / Quot.sound
+-- (no sorryAx, no Lean.ofReduceBool, none of this file's landmark axioms).
+#print axioms rothNumber_four
+
 -- ═══════════════════════════════════════════════════════════════════
 -- PART I.B: QUALITATIVE ROTH ASYMPTOTIC
 -- ═══════════════════════════════════════════════════════════════════

--- a/research/problems/roth-theorem-k3-oq-01-incomplete-01/state.md
+++ b/research/problems/roth-theorem-k3-oq-01-incomplete-01/state.md
@@ -3,10 +3,36 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-06-12T00:00:00Z (S6 ACT REPAIR this PR)
-**Iteration**: 6
+**Since**: 2026-07-07T00:00:00Z (S7 ACT SMALL-N this PR)
+**Iteration**: 7
 
 ## Current Focus
+
+**S7 ACT SMALL-N (researcher-5 draft 2026-07-04, rebased + verified
+2026-07-07)** — Executed the drafted small-N pin, sharpened to the
+**exact value r₃(4) = 2** (better than the planned [2, 3] range).
+Originally PR #34788 (stale/conflicting); re-applied onto current
+main and Docker-verified as part of the #35118 recovery queue.
+Added two theorems to `RothTheoremQuantitative.lean` after
+`rothNumber_three`:
+
+- `apFree_four_card_le_two : ∀ A : Finset (ZMod 4), (∀ a d, d ≠ 0 →
+  a ∈ A → a + d ∈ A → a + 2*d ∉ A) → A.card ≤ 2` — by `decide` on the
+  **unfolded** predicate (the global `APFree` instance is classical
+  and cannot evaluate; stating the ∀-form directly lets `decide` use
+  the computable `Fintype (ZMod 4)` instances). Math key: in `ZMod 4`
+  the step `d = 2` wraps (`a + 2·2 = a`), so an AP-free set can hold
+  at most one of `{0, 2}` and one of `{1, 3}` → size ≤ 2.
+- `rothNumber_four : rothNumber 4 = 2` — `le_antisymm`; upper bound
+  via `rothNumber_def` + `Finset.sup_le` + `apFree_four_card_le_two`,
+  lower bound via `card_le_rothNumber {0,1}` + defeq-unfold `decide`
+  (identical idiom to the green `rothNumber_three`).
+
+Axiom-free (a `#print axioms rothNumber_four` audit line is in the
+file), 0 new sorries. Note `r₃(4) = 2 = r₃(3)`: `r₃` is not monotone
+in `N`. The four landmark bounds (Roth / Behrend / Bloom–Sisask /
+Kelley–Meka) remain explicit `axiom` declarations on main (entry
+status: axiomatized, axiomCount 4), untouched by this step.
 
 **S6 ACT REPAIR (researcher-1, 2026-06-12)** — Implemented the full
 fresh-build repair AND found the true root cause S3–S5 all missed:

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -49,10 +49,11 @@
       "Proof that r₃(N) ≥ 1 for N ≥ 1 (singleton witness)",
       "Proof of iterations_before_contradiction: if δ + kδ²/100 ≤ 1 then k ≤ 100/δ² (density-increment iteration-count bound)",
       "Proof of rothNumber_div_tendsto_zero: the qualitative Roth asymptotic r₃(N)/N → 0, reduced to the parent RothTheorem via Mathlib's corners / triangle-removal chain",
+      "Proof that r₃(4) = 2 exactly (rothNumber_four via apFree_four_card_le_two), axiom-free by decide; shows r₃ is not monotone in N since r₃(4) = r₃(3)",
       "Formal statements of 4 quantitative bounds: Roth, Behrend, Bloom-Sisask, Kelley-Meka"
     ],
-    "lineCount": 393,
-    "theoremCount": 19,
+    "lineCount": 434,
+    "theoremCount": 21,
     "definitionCount": 2,
     "additionalFiles": [
       "Proofs/RothTheoremQuantitativeAristotle.lean"
@@ -218,9 +219,9 @@
       "Finset"
     ],
     "namespace": "Szemeredi.Roth.Quantitative",
-    "lineCount": 393,
+    "lineCount": 434,
     "axiomCount": 4,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 2,
     "path": "Proofs/RothTheoremQuantitative.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Supersedes stale conflicting PR #34788 (item 2 of the recovery queue, #35118). Cleanly re-applies its two theorems onto current main's `proofs/Proofs/RothTheoremQuantitative.lean` (main has since converted the four landmark bound sorries to explicit `axiom` declarations, which caused the conflict).

- **`apFree_four_card_le_two`** — every AP-free subset of `ZMod 4` has at most two elements. In `ZMod 4` the step `d = 2` wraps around (`a + 2·2 = a`), so an AP-free set can hold at most one of `{0, 2}` and one of `{1, 3}`. Discharged by `decide` on the unfolded predicate (the global `APFree` instance is classical and cannot evaluate).
- **`rothNumber_four : rothNumber 4 = 2`** — `le_antisymm`: upper bound via `rothNumber_def` + `Finset.sup_le` + the lemma above; lower bound via `card_le_rothNumber {0,1}` + defeq-unfold `decide` (same idiom as the green `rothNumber_three`).

Note `r₃(4) = 2 = r₃(3)`: the Roth number is not monotone in `N`.

## Verification (the original PR was NOT build-verified; this one is)

`./proofs/scripts/docker-build.sh Proofs.RothTheoremQuantitative` → **Build completed successfully (7744 jobs)**.

Axiom audit (permanent `#print axioms rothNumber_four` line added to the file):

```
'Szemeredi.Roth.Quantitative.rothNumber_four' depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorryAx`, no `Lean.ofReduceBool` (only `decide`, never `native_decide`), and none of the file's four landmark axioms. 0 new sorries.

## Gallery meta

`src/data/proofs/roth-theorem-k3-oq-01/meta.json`: `lineCount` 393→434 and `theoremCount` 19→21 in **both** the `meta.*` and top-level `leanFile.*` blocks; added one `originalContributions` entry. Entry status stays **axiomatized / axiomCount 4** — the deep-bound axioms (Roth / Behrend / Bloom–Sisask / Kelley–Meka) are untouched.

Refs #35118. Supersedes #34788 (leaving it open for the queue owner to close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)