### PR TITLE
research: recover de-moivre-oq-05-oq-02-oq-03 (sum of primitive roots = μ(n)) + Buffon codim + eigenbasis lemmas from stale PR #32451

### DIFF
--- a/proofs/Proofs/BuffonsNoodleOQ03OQ02.lean
+++ b/proofs/Proofs/BuffonsNoodleOQ03OQ02.lean
@@ -1,3 +1,4 @@
+import Proofs.BuffonsNoodleOQ03
 import Mathlib.MeasureTheory.Measure.Hausdorff
 import Mathlib.Topology.MetricSpace.HausdorffDimension
 import Mathlib.Tactic
@@ -134,3 +135,225 @@ theorem crossing_ae_zero (hc : 2 ≤ c)
   (measure_eq_zero_iff_ae_notMem).1 (crossedOffsets_measure_zero hc hγ L)
 
 end BuffonsNoodleOQ03OQ02
+
+/-
+# Companion development: the combinatorial codimension dichotomy
+
+Recovered from PR #32451. The measure-theoretic treatment above shows that for
+codimension `c ≥ 2` a Lipschitz curve almost surely misses every flat. The
+development below expresses the same dichotomy at the level of the parent's
+polygonal-noodle bookkeeping (`BuffonsNoodleOQ03.lean`): a codimension-aware
+expected-crossings functional that reduces to the parent noodle law `α·L/d`
+exactly in codimension 1 and vanishes identically otherwise, together with the
+deterministic grid-crossing count underlying the Buffon averaging mechanism.
+
+### The codimension dichotomy
+
+Fix a family of parallel `k`-flats spaced `d` apart in `ℝⁿ`, and let `c = n - k` be
+the codimension. A curve is 1-dimensional. Two 1-dimensional and `k`-dimensional
+affine pieces in general position meet in dimension `1 + k - n = 1 - c`:
+
+* `c = 1` (i.e. `k = n-1`, **hyperplanes**): the intersection is `0`-dimensional —
+  isolated crossing points. The family is exactly a hyperplane family, so the expected
+  intersection count is the parent's noodle law `αₙ·L/d`.
+* `c ≥ 2` (i.e. `k ≤ n-2`): the "intersection" has negative dimension, so a generic
+  curve **almost surely misses every flat** (proved rigorously above). The expected
+  intersection count is `0`, independently of the length or shape.
+* `c = 0` (i.e. `k = n`): the only such flat is all of `ℝⁿ`; there is no proper spaced
+  family, and we record the degenerate value `0`.
+
+### The deterministic backbone
+
+Underneath the averaged law is a deterministic counting fact proved from scratch
+(`gridCount_bounds`): as one coordinate sweeps an interval `[a,b]`, the number of
+grid hyperplanes `{x = j·d : j ∈ ℤ}` it crosses is `⌊b/d⌋ - ⌊a/d⌋`, and this
+integer differs from the "extent in units of `d`", `(b-a)/d`, by strictly less
+than 1. Averaging the `±1` boundary fluctuation over a uniformly random offset is
+exactly what turns the deterministic count into the crossing factor
+`segmentCrossings α ℓ d = α·ℓ/d`.
+-/
+
+open BuffonsNoodleHighDim
+open Real Finset BigOperators
+
+namespace BuffonsNoodleCodim
+
+/-! ## Part I: The deterministic grid-crossing count
+
+Before any averaging, fix a single coordinate axis perpendicular to the family and let
+it sweep from `a` to `b`. The grid hyperplanes are at the multiples `j·d`, and the
+number crossed is the number of integers `j` with `a < j·d ≤ b`, i.e. `⌊b/d⌋ - ⌊a/d⌋`.
+-/
+
+/-- Number of grid lines `{x = j·d : j ∈ ℤ}` in the half-open interval `(a, b]`:
+    the count of integers `j` with `a/d < j ≤ b/d`. -/
+noncomputable def gridCount (d a b : ℝ) : ℤ := ⌊b / d⌋ - ⌊a / d⌋
+
+/-- **Deterministic Buffon accuracy.** The number of grid lines crossed as a coordinate
+    moves from `a` to `b` differs from the extent measured in units of `d`, namely
+    `(b - a)/d`, by strictly less than one. Averaging this `±1` fluctuation over a
+    uniform offset yields exactly the extent `(b-a)/d` — the segment-level Buffon law. -/
+theorem gridCount_bounds (d a b : ℝ) :
+    |(gridCount d a b : ℝ) - (b - a) / d| < 1 := by
+  have hfb_le : (⌊b / d⌋ : ℝ) ≤ b / d := Int.floor_le _
+  have hfa_le : (⌊a / d⌋ : ℝ) ≤ a / d := Int.floor_le _
+  have hfb_lt : b / d - 1 < (⌊b / d⌋ : ℝ) := Int.sub_one_lt_floor _
+  have hfa_lt : a / d - 1 < (⌊a / d⌋ : ℝ) := Int.sub_one_lt_floor _
+  have hsub : (b - a) / d = b / d - a / d := sub_div b a d
+  rw [abs_sub_lt_iff]
+  constructor
+  · -- gridCount - (b-a)/d < 1
+    simp only [gridCount, Int.cast_sub]
+    rw [hsub]; linarith
+  · -- (b-a)/d - gridCount < 1
+    simp only [gridCount, Int.cast_sub]
+    rw [hsub]; linarith
+
+/-- The grid count over an empty sweep is zero. -/
+@[simp] theorem gridCount_self (d a : ℝ) : gridCount d a a = 0 := by
+  simp [gridCount]
+
+/-! ## Part II: Codimension-aware crossings and the dichotomy
+
+We import the parent's `segmentCrossings α ℓ d = α·ℓ/d` and `Noodle` machinery. The
+codimension of a `k`-flat in `ℝⁿ` is `c = n - k`. Only `c = 1` (hyperplanes) yields a
+crossing; every other codimension gives the identically-zero count. -/
+
+/-- The codimension of a `k`-dimensional flat inside `ℝⁿ`. -/
+def codim (n k : ℕ) : ℕ := n - k
+
+/-- Per-segment expected intersection count with a family of parallel `k`-flats in
+    `ℝⁿ`. A `1`-dimensional segment meets a codimension-`c` flat in dimension `1 - c`,
+    so the count is the hyperplane value `segmentCrossings α ℓ d` when `c = 1` and
+    vanishes otherwise. -/
+noncomputable def flatSegmentCrossings (n k : ℕ) (α ℓ d : ℝ) : ℝ :=
+  if codim n k = 1 then segmentCrossings α ℓ d else 0
+
+/-- In codimension 1, the per-segment count is the parent noodle value. -/
+theorem flatSegmentCrossings_codim_one {n k : ℕ} (h : codim n k = 1) (α ℓ d : ℝ) :
+    flatSegmentCrossings n k α ℓ d = segmentCrossings α ℓ d := by
+  simp [flatSegmentCrossings, h]
+
+/-- In any codimension other than 1, the per-segment count vanishes. -/
+theorem flatSegmentCrossings_of_codim_ne_one {n k : ℕ} (h : codim n k ≠ 1)
+    (α ℓ d : ℝ) : flatSegmentCrossings n k α ℓ d = 0 := by
+  simp [flatSegmentCrossings, h]
+
+/-- A hyperplane family (`k = n - 1`, with `n ≥ 1`) is codimension 1 and recovers the
+    parent per-segment law. -/
+theorem flatSegmentCrossings_hyperplane {n : ℕ} (hn : 1 ≤ n) (α ℓ d : ℝ) :
+    flatSegmentCrossings n (n - 1) α ℓ d = segmentCrossings α ℓ d := by
+  apply flatSegmentCrossings_codim_one
+  simp only [codim]
+  omega
+
+/-- Linearity of the per-segment count in the length. -/
+theorem flatSegmentCrossings_linear (n k : ℕ) (α ℓ d c : ℝ) :
+    flatSegmentCrossings n k α (c * ℓ) d = c * flatSegmentCrossings n k α ℓ d := by
+  unfold flatSegmentCrossings
+  split
+  · exact segmentCrossings_linear α ℓ d c
+  · ring
+
+/-- Nonnegativity of the per-segment count. -/
+theorem flatSegmentCrossings_nonneg (n k : ℕ) (α ℓ d : ℝ)
+    (hα : 0 ≤ α) (hℓ : 0 ≤ ℓ) (hd : 0 < d) :
+    0 ≤ flatSegmentCrossings n k α ℓ d := by
+  unfold flatSegmentCrossings
+  split
+  · exact segmentCrossings_nonneg α ℓ d hα hℓ hd
+  · exact le_refl 0
+
+/-! ## Part III: The noodle-level codimension law -/
+
+/-- Expected total intersections of a noodle `N` with a family of parallel `k`-flats in
+    `ℝⁿ`, spaced `d` apart, in a dimension with crossing factor `α`. -/
+noncomputable def expectedFlatCrossings {p : ℕ} (N : Noodle p) (n k : ℕ) (α d : ℝ) : ℝ :=
+  ∑ i : Fin p, flatSegmentCrossings n k α (N.segLen i) d
+
+/-- **Codimension-1 law.** For hyperplane-codimension families the expected count is the
+    parent noodle law `α·L/d`; length-proportionality survives. -/
+theorem expectedFlatCrossings_codim_one {p : ℕ} (N : Noodle p) {n k : ℕ}
+    (h : codim n k = 1) (α d : ℝ) :
+    expectedFlatCrossings N n k α d = α * N.totalLength / d := by
+  unfold expectedFlatCrossings
+  simp_rw [flatSegmentCrossings_codim_one h]
+  have : (∑ i : Fin p, segmentCrossings α (N.segLen i) d) = N.expectedCrossings α d := rfl
+  rw [this, noodle_highdim]
+
+/-- **The dichotomy.** For every codimension other than 1, a generic curve misses all the
+    flats: the expected intersection count is identically zero, independent of the total
+    length or shape. Length-proportionality is a strictly codimension-1 phenomenon. -/
+theorem expectedFlatCrossings_dichotomy {p : ℕ} (N : Noodle p) {n k : ℕ}
+    (h : codim n k ≠ 1) (α d : ℝ) :
+    expectedFlatCrossings N n k α d = 0 := by
+  unfold expectedFlatCrossings
+  simp_rw [flatSegmentCrossings_of_codim_ne_one h]
+  simp
+
+/-- **Hyperplane recovery.** Dropping the noodle against parallel hyperplanes
+    (`k = n-1`, `n ≥ 1`) gives exactly the parent higher-dimensional law `α·L/d`. -/
+theorem expectedFlatCrossings_hyperplane {p : ℕ} (N : Noodle p) {n : ℕ} (hn : 1 ≤ n)
+    (α d : ℝ) :
+    expectedFlatCrossings N n (n - 1) α d = α * N.totalLength / d := by
+  apply expectedFlatCrossings_codim_one
+  simp only [codim]; omega
+
+/-- Nonnegativity of the noodle-level codimension count. -/
+theorem expectedFlatCrossings_nonneg {p : ℕ} (N : Noodle p) (n k : ℕ) (α d : ℝ)
+    (hα : 0 ≤ α) (hd : 0 < d) :
+    0 ≤ expectedFlatCrossings N n k α d := by
+  unfold expectedFlatCrossings
+  exact Finset.sum_nonneg fun i _ =>
+    flatSegmentCrossings_nonneg n k α (N.segLen i) d hα (N.nonneg i) hd
+
+/-! ## Part IV: Structural laws in the codimension-1 regime
+
+For hyperplane-codimension families the count reduces to the parent law, so the noodle's
+shape-independence and monotonicity carry over verbatim. -/
+
+/-- **Shape independence (codimension 1).** Two noodles of equal total length have equal
+    expected intersections against a hyperplane-codimension family, regardless of shape. -/
+theorem flatShape_independence {p q : ℕ} (N₁ : Noodle p) (N₂ : Noodle q) {n k : ℕ}
+    (h : codim n k = 1) (α d : ℝ) (hLen : N₁.totalLength = N₂.totalLength) :
+    expectedFlatCrossings N₁ n k α d = expectedFlatCrossings N₂ n k α d := by
+  rw [expectedFlatCrossings_codim_one N₁ h, expectedFlatCrossings_codim_one N₂ h, hLen]
+
+/-- **Monotonicity (codimension 1).** A longer noodle has at least as many expected
+    intersections, given a nonnegative crossing factor and positive spacing. -/
+theorem flatCrossings_mono {p q : ℕ} (N₁ : Noodle p) (N₂ : Noodle q) {n k : ℕ}
+    (h : codim n k = 1) (α d : ℝ) (hα : 0 ≤ α) (hd : 0 < d)
+    (hLen : N₁.totalLength ≤ N₂.totalLength) :
+    expectedFlatCrossings N₁ n k α d ≤ expectedFlatCrossings N₂ n k α d := by
+  rw [expectedFlatCrossings_codim_one N₁ h, expectedFlatCrossings_codim_one N₂ h]
+  have hd' : (0 : ℝ) ≤ d := hd.le
+  gcongr
+
+/-! ## Part V: Concrete instances -/
+
+/-- **`ℝ³`, planes.** A family of parallel planes (`k = 2`) in `ℝ³` is codimension 1;
+    with the spatial crossing factor `α₃ = 1/2` the noodle law reads `E = L/(2d)`. -/
+theorem spatial_planes {p : ℕ} (N : Noodle p) (d : ℝ) :
+    expectedFlatCrossings N 3 2 (1 / 2) d = N.totalLength / (2 * d) := by
+  rw [expectedFlatCrossings_codim_one N (by decide) (1 / 2) d]
+  ring
+
+/-- **`ℝ³`, lines.** A family of parallel lines (`k = 1`) in `ℝ³` is codimension 2, so a
+    curve almost surely misses them: the expected intersection count is `0`, whatever the
+    length or shape. -/
+theorem spatial_lines_vanish {p : ℕ} (N : Noodle p) (α d : ℝ) :
+    expectedFlatCrossings N 3 1 α d = 0 :=
+  expectedFlatCrossings_dichotomy N (by decide) α d
+
+/-- **`ℝ²`, lines.** The classical planar Buffon–Barbier setting: lines (`k = 1`) in the
+    plane are codimension 1, and with `α₂ = 2/π` the law recovers `E = 2L/(πd)`. -/
+theorem planar_lines {p : ℕ} (N : Noodle p) (d : ℝ) :
+    expectedFlatCrossings N 2 1 (2 / π) d = 2 * N.totalLength / (π * d) := by
+  rw [expectedFlatCrossings_codim_one N (by decide) (2 / π) d]
+  ring
+
+/- Axiom audit: expect only `propext`, `Classical.choice`, `Quot.sound`. -/
+#print axioms expectedFlatCrossings_codim_one
+#print axioms expectedFlatCrossings_dichotomy
+
+end BuffonsNoodleCodim

--- a/proofs/Proofs/DeMoivreOQ05OQ02OQ03.lean
+++ b/proofs/Proofs/DeMoivreOQ05OQ02OQ03.lean
@@ -1,0 +1,160 @@
+import Mathlib
+
+/-
+# De Moivre OQ-05-OQ-02-OQ-03: Sum of Primitive n-th Roots = μ(n) in any Integral Domain
+
+## Research Problem: de-moivre-oq-05-oq-02-oq-03
+
+> Formalize the companion identity `∑_{ord ζ = n} ζ` over a general field
+> containing a primitive n-th root of unity.
+
+The parent file `DeMoivreOQ05OQ02.lean` proves, in `ℂ`,
+
+  ∑_{ζ primitive n-th root of unity} ζ = μ(n).
+
+Here we remove `ℂ` entirely: the identity holds, verbatim, in **any commutative
+integral domain `R`** as soon as `R` contains a primitive n-th root of unity.
+Concretely, for a fixed primitive n-th root `ζ : R` (existence is a *hypothesis*,
+not a construction),
+
+  ∑_{z ∈ primitiveRoots n R} z = (μ n : R).
+
+This subsumes the requested "general field" statement (every field is a domain)
+and strictly extends the parent (`ℂ` is one such domain), covering e.g. finite
+fields `𝔽_q` with `n ∣ q - 1`, cyclotomic number fields, and `p`-adic fields.
+
+## Why the domain hypothesis is exactly right
+
+If `IsPrimitiveRoot ζ n` holds in a domain of characteristic `p`, then `p ∤ n`
+automatically: were `p ∣ n`, writing `n = pᵃ·m` with `p ∤ m`, injectivity of the
+Frobenius `x ↦ x^{pᵃ}` would force `ζ^m = 1` with `m < n`, contradicting
+primitivity. Hence `n` is invertible-order in `R` and the Möbius value `(μ n : R)`
+is the honest cast of an integer — no auxiliary characteristic hypothesis is
+needed. The single assumption `IsPrimitiveRoot ζ n` carries all of it.
+
+## Proof (identical skeleton to the parent, ℂ replaced by `R`)
+
+Let `f(k) = ∑_{z ∈ primitiveRoots k R} z` and `g(k) = ∑_{x ∈ nthRootsFinset k 1} x`.
+
+1. **Partition** (holds in *every* domain, no primitive root needed): the `k`-th
+   roots present in `R` split by their exact order, so `g(k) = ∑_{d ∣ k} f(d)`.
+   This is `IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots` + disjointness.
+
+2. **Local evaluation of `g`**: for each divisor `d ∣ n`, the element `ζ^{n/d}`
+   is a primitive `d`-th root (`IsPrimitiveRoot.pow`), which enumerates the `d`-th
+   roots as a geometric progression; hence `g(d) = [d = 1]`
+   (`IsPrimitiveRoot.geom_sum_eq_zero` for `d > 1`).
+
+3. **Möbius inversion** (`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`, valid
+   over any ring) turns (1) into `f(n) = ∑_{d ∣ n} μ(n/d)·g(d)`, and by (2) only
+   the divisor `d = 1` survives, giving `f(n) = μ(n)·g(1) = μ(n)`.
+
+## Mathlib ingredients
+- `IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots` — the partition (any domain).
+- `IsPrimitiveRoot.disjoint`, `IsPrimitiveRoot.injOn_pow` — bookkeeping.
+- `IsPrimitiveRoot.geom_sum_eq_zero` — geometric-series vanishing (any domain).
+- `IsPrimitiveRoot.pow` — `ζ^a` is a primitive `b`-th root when `n = a·b`.
+- `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` — Möbius inversion over a ring.
+
+All results are 0-axiom, no `sorry`, no `native_decide`.
+
+Parent: `DeMoivreOQ05OQ02.lean` (the `ℂ` case, 0 axioms).
+-/
+
+open Finset Polynomial
+open scoped ArithmeticFunction.Moebius
+
+namespace DeMoivreOQ05OQ02OQ03
+
+variable {R : Type*} [CommRing R] [IsDomain R]
+
+/-- If `ζ` is a primitive `k`-th root of unity in a domain `R` (with `0 < k`), the
+finset of `k`-th roots of unity is the image of `range k` under `i ↦ ζ ^ i`. -/
+lemma nthRootsFinset_eq_image [DecidableEq R] {k : ℕ} (hk : 0 < k) {ζ : R}
+    (hζ : IsPrimitiveRoot ζ k) :
+    nthRootsFinset k (1 : R) = (range k).image (ζ ^ ·) := by
+  haveI : NeZero k := ⟨hk.ne'⟩
+  ext x
+  simp only [mem_nthRootsFinset hk, mem_image, mem_range]
+  constructor
+  · intro hx
+    obtain ⟨i, hi, rfl⟩ := hζ.eq_pow_of_pow_eq_one hx
+    exact ⟨i, hi, rfl⟩
+  · rintro ⟨i, hi, rfl⟩
+    rw [← pow_mul, mul_comm, pow_mul, hζ.pow_eq_one, one_pow]
+
+/-- **Local evaluation of `g`.** If `R` contains a primitive `k`-th root of unity
+(`0 < k`), then the sum of all `k`-th roots of unity in `R` is `1` when `k = 1`
+and `0` otherwise. -/
+lemma sum_nthRootsFinset_of_prim [DecidableEq R] {k : ℕ} (hk : 0 < k) {ζ : R}
+    (hζ : IsPrimitiveRoot ζ k) :
+    ∑ x ∈ nthRootsFinset k (1 : R), x = if k = 1 then 1 else 0 := by
+  rw [nthRootsFinset_eq_image hk hζ, sum_image hζ.injOn_pow]
+  by_cases hk1 : k = 1
+  · subst hk1; simp
+  · rw [if_neg hk1]
+    exact hζ.geom_sum_eq_zero (by omega)
+
+/-- **Sum of the primitive `n`-th roots of unity equals `μ(n)` in any integral
+domain containing one.** Given a primitive `n`-th root of unity `ζ : R`, the sum
+over the primitive `n`-th roots of unity in `R` equals `(μ n : R)`. -/
+theorem sum_primitiveRoots_eq_moebius {n : ℕ} {ζ : R} (hζ : IsPrimitiveRoot ζ n) :
+    ∑ z ∈ primitiveRoots n R, z = (μ n : R) := by
+  classical
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp
+  -- (1) Partition: `∑_{d ∣ k} f(d) = g(k)` for every `k > 0`, in the ambient domain.
+  have hpart : ∀ k > 0,
+      ∑ d ∈ k.divisors, (∑ z ∈ primitiveRoots d R, z)
+        = ∑ x ∈ nthRootsFinset k (1 : R), x := by
+    intro k hk
+    haveI : NeZero k := ⟨hk.ne'⟩
+    have hdisj : Set.PairwiseDisjoint (↑k.divisors) (fun i => primitiveRoots i R) := by
+      intro a _ b _ hab
+      exact IsPrimitiveRoot.disjoint hab
+    rw [IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots, Finset.sum_biUnion hdisj]
+  -- (2) Möbius inversion turns the partition into a formula for `f(n)`.
+  have hinv := (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq
+      (f := fun k => ∑ z ∈ primitiveRoots k R, z)
+      (g := fun k => ∑ x ∈ nthRootsFinset k (1 : R), x)).mp hpart n hn
+  -- (3) Only the divisor `d = 1` survives; every other `g(d)` vanishes since `R`
+  --     contains the primitive `d`-th root `ζ^(n/d)`.
+  calc ∑ z ∈ primitiveRoots n R, z
+      = ∑ x ∈ n.divisorsAntidiagonal,
+          (μ x.1 : R) * (∑ y ∈ nthRootsFinset x.2 (1 : R), y) := hinv.symm
+    _ = (μ n : R) := by
+        rw [Finset.sum_eq_single (n, 1)]
+        · dsimp only
+          rw [show (∑ x ∈ nthRootsFinset 1 (1 : R), x) = 1 from by
+                simpa using sum_nthRootsFinset_of_prim (k := 1) one_pos
+                  (ζ := (1 : R)) IsPrimitiveRoot.one, mul_one]
+        · rintro ⟨a, b⟩ hab hne
+          dsimp only
+          simp only [Nat.mem_divisorsAntidiagonal] at hab
+          obtain ⟨hprod, hn0⟩ := hab
+          have hbpos : 0 < b := by
+            rcases Nat.eq_zero_or_pos b with rfl | h
+            · simp only [Nat.mul_zero] at hprod; exact absurd hprod.symm hn0
+            · exact h
+          have hb1 : b ≠ 1 := by
+            rintro rfl
+            exact hne (by simp only [Nat.mul_one] at hprod; rw [hprod])
+          -- `ζ^a` is a primitive `b`-th root of unity, since `n = a * b`.
+          have hprim_b : IsPrimitiveRoot (ζ ^ a) b := hζ.pow hn hprod.symm
+          rw [sum_nthRootsFinset_of_prim hbpos hprim_b, if_neg hb1, mul_zero]
+        · intro hns
+          exact absurd (Nat.mem_divisorsAntidiagonal.mpr ⟨Nat.mul_one n, hn.ne'⟩) hns
+
+/-- **Field specialization.** The requested statement over a general field `K`
+containing a primitive `n`-th root of unity is the immediate special case. -/
+theorem sum_primitiveRoots_eq_moebius_field {K : Type*} [Field K] {n : ℕ} {ζ : K}
+    (hζ : IsPrimitiveRoot ζ n) :
+    ∑ z ∈ primitiveRoots n K, z = (μ n : K) :=
+  sum_primitiveRoots_eq_moebius hζ
+
+/- Axiom audit: both headline theorems should report only the foundational
+   trio `propext`, `Classical.choice`, `Quot.sound`. -/
+#print axioms sum_primitiveRoots_eq_moebius
+#print axioms sum_primitiveRoots_eq_moebius_field
+
+end DeMoivreOQ05OQ02OQ03

--- a/proofs/Proofs/MinpolyCharpolyOQ02.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02.lean
@@ -386,4 +386,71 @@ theorem diagonalizable_iff_squarefree_minpoly
   rw [Module.Basis.reindex_apply, ← hf]
   exact heig
 
+-- ============================================================
+-- Recovered from PR #32451: standalone eigenbasis extraction and
+-- the CharZero-free headline
+-- ============================================================
+
+omit [DecidableEq n] in
+/-- **Reverse-direction eigenbasis construction (standalone).** Over an
+algebraically closed field, a semisimple endomorphism of `n → K` admits a basis
+of eigenvectors.
+
+Semisimplicity gives `⨆ μ, eigenspace f μ = ⊤` (Bridge B); the eigenspaces are
+always independent (`Module.End.eigenspaces_iSupIndep`), so the family is an
+internal direct sum. Collecting a basis of each eigenspace yields a basis of
+`n → K` indexed by a sigma type, reindexed onto `n` (both index a basis of the
+same finite-dimensional space). Each collected vector lies in a single
+eigenspace, hence is an eigenvector.
+
+This factors the eigenbasis step of `diagonalizable_iff_squarefree_minpoly`
+into a reusable lemma. -/
+theorem _root_.Matrix.exists_eigenbasis_of_isSemisimple [IsAlgClosed K]
+    {f : Module.End K (n → K)} (hss : f.IsSemisimple) :
+    ∃ (b : Module.Basis n K (n → K)) (c : n → K), ∀ i, f (b i) = c i • b i := by
+  classical
+  have htop : ⨆ μ : K, f.eigenspace μ = ⊤ :=
+    Module.End.iSup_eigenspace_eq_top_of_isSemisimple hss
+  have hindep : iSupIndep (fun μ : K => f.eigenspace μ) :=
+    Module.End.eigenspaces_iSupIndep f
+  have hInt : DirectSum.IsInternal (fun μ : K => f.eigenspace μ) :=
+    (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mpr ⟨hindep, htop⟩
+  set B := hInt.collectedBasis (fun μ => Module.finBasis K (f.eigenspace μ)) with hB
+  haveI : Fintype (Σ μ : K, Fin (Module.finrank K (f.eigenspace μ))) :=
+    FiniteDimensional.fintypeBasisIndex B
+  have hcard :
+      Fintype.card (Σ μ : K, Fin (Module.finrank K (f.eigenspace μ))) = Fintype.card n := by
+    rw [← Module.finrank_eq_card_basis B, ← Module.finrank_eq_card_basis (Pi.basisFun K n)]
+  set ρ := Fintype.equivOfCardEq hcard with hρ
+  refine ⟨B.reindex ρ, fun i => (ρ.symm i).1, fun i => ?_⟩
+  rw [Module.Basis.reindex_apply]
+  exact Module.End.mem_eigenspace_iff.mp (hInt.collectedBasis_mem _ (ρ.symm i))
+
+/-- **Headline biconditional without `CharZero` (recovered from PR #32451).**
+Over an algebraically closed field of *any* characteristic, a matrix is
+diagonalizable iff its minimal polynomial is squarefree.
+
+Only `[IsAlgClosed K]` is needed: over an algebraically closed field every
+polynomial splits into linear factors, so a squarefree minimal polynomial is a
+product of *distinct* linear factors and semisimplicity already forces an
+eigenbasis — no separability (hence no characteristic-zero) hypothesis is
+required. The textbook statement adds `[CharZero K]` (as
+`diagonalizable_iff_squarefree_minpoly` above does), but that hypothesis is
+redundant. The general-field form (with an explicit `Polynomial.Splits`
+hypothesis) is the target of OQ-02-OQ-03. -/
+theorem diagonalizable_iff_squarefree_minpoly'
+    [IsAlgClosed K] (M : Matrix n n K) :
+    M.IsDiagonalizable ↔ Squarefree (minpoly K M) := by
+  refine ⟨fun h => h.squarefree_minpoly, fun hsq => ?_⟩
+  have hsqf : Squarefree (minpoly K (Matrix.toLin' M : Module.End K (n → K))) := by
+    rw [Matrix.minpoly_toLin']; exact hsq
+  have hss : Module.End.IsSemisimple (Matrix.toLin' M : Module.End K (n → K)) :=
+    Module.End.isSemisimple_iff_squarefree_minpoly.mpr hsqf
+  obtain ⟨b, c, heig⟩ := Matrix.exists_eigenbasis_of_isSemisimple hss
+  exact isDiagonalizable_of_eigenbasis b c heig
+
+/- Axiom audit: expect only `propext`, `Classical.choice`, `Quot.sound`. -/
+#print axioms Matrix.exists_eigenbasis_of_isSemisimple
+#print axioms diagonalizable_iff_squarefree_minpoly'
+
 end Proofs.MinpolyCharpolyOQ02

--- a/src/data/proofs/buffons-noodle-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/buffons-noodle-oq-03-oq-02/annotations.json
@@ -121,5 +121,92 @@
       "orthogonal projection onto a complement",
       "the analytic core volume_lipschitzImage_eq_zero"
     ]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-03-oq-02-codim-01",
+    "proofId": "buffons-noodle-oq-03-oq-02",
+    "range": {
+      "startLine": 196,
+      "endLine": 219
+    },
+    "type": "concept",
+    "title": "The Deterministic Backbone: a Floor Sandwich",
+    "content": "Before any averaging, Buffon counting is a deterministic fact about floors. As one coordinate sweeps from a to b, the grid hyperplanes {x = j·d : j ∈ ℤ} it crosses are those with a/d < j ≤ b/d, i.e. gridCount = ⌊b/d⌋ − ⌊a/d⌋. Sandwiching each floor by x − 1 < ⌊x⌋ ≤ x and using (b−a)/d = b/d − a/d gives |gridCount − (b−a)/d| < 1: the integer count differs from the extent-in-units-of-d by strictly less than one. That ±1 discrepancy is exactly the boundary fluctuation which, averaged over a uniformly random offset t ∈ [0,d), integrates to zero — turning the deterministic count into the crossing factor E = extent/d. This lemma is the honest, non-definitional core of the whole Buffon mechanism and holds in every codimension.",
+    "mathContext": "$\\left|\\,(\\lfloor b/d\\rfloor - \\lfloor a/d\\rfloor) - \\dfrac{b-a}{d}\\,\\right| < 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "floor function",
+      "lattice point counting",
+      "uniform offset averaging",
+      "Buffon crossing factor"
+    ],
+    "prerequisites": [
+      "The floor sandwich x − 1 < ⌊x⌋ ≤ x"
+    ]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-03-oq-02-codim-02",
+    "proofId": "buffons-noodle-oq-03-oq-02",
+    "range": {
+      "startLine": 222,
+      "endLine": 249
+    },
+    "type": "concept",
+    "title": "Codimension and the General-Position Dimension Count",
+    "content": "The codimension of a k-dimensional flat in ℝⁿ is c = n − k. A curve is 1-dimensional, and two affine pieces of dimensions 1 and k in general position meet in dimension 1 + k − n = 1 − c. The per-segment intersection count flatSegmentCrossings is therefore defined to be the parent hyperplane value segmentCrossings α ℓ d exactly when c = 1 (isolated crossing points) and 0 otherwise (empty or negative-dimensional intersection). This encodes the almost-sure geometric behaviour directly: a generic curve meets a hyperplane in points, but slips past any lower-dimensional flat with probability one.",
+    "mathContext": "$\\dim(\\text{curve} \\cap k\\text{-flat}) = 1 + k - n = 1 - c$; isolated crossings $\\iff c = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "codimension",
+      "general position",
+      "integral geometry",
+      "Cauchy–Crofton"
+    ],
+    "prerequisites": [
+      "Affine dimension counting for intersections"
+    ]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-03-oq-02-codim-03",
+    "proofId": "buffons-noodle-oq-03-oq-02",
+    "range": {
+      "startLine": 270,
+      "endLine": 295
+    },
+    "type": "proof-step",
+    "title": "The Dichotomy: α·L/d at Codimension 1, Zero Otherwise",
+    "content": "Summing the per-segment counts over a noodle gives expectedFlatCrossings. Case-splitting on codim = 1 discharges both branches. In codimension 1, every per-segment term rewrites to the parent segmentCrossings, the sum becomes Noodle.expectedCrossings, and noodle_highdim closes it to α·L/d — length-proportionality survives, and the family is precisely a hyperplane family. In every other codimension the per-segment term is 0, so the sum is identically 0 regardless of the noodle's length or shape. Thus Barbier's length-proportionality is a strictly codimension-1 phenomenon: generalizing the target to lower-dimensional flats does not enlarge the regime, it extinguishes it.",
+    "mathContext": "$E = \\alpha \\cdot L / d$ if $c = 1$; $\\quad E = 0$ if $c \\neq 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "linearity of expectation",
+      "shape independence",
+      "dichotomy",
+      "noodle law"
+    ],
+    "prerequisites": [
+      "Parent noodle law E = αₙ·L/d (BuffonsNoodleOQ03)"
+    ]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-03-oq-02-codim-04",
+    "proofId": "buffons-noodle-oq-03-oq-02",
+    "range": {
+      "startLine": 334,
+      "endLine": 355
+    },
+    "type": "example",
+    "title": "Planes vs Lines in ℝ³: the Dichotomy Made Concrete",
+    "content": "The dichotomy is witnessed side by side in three dimensions. Parallel planes (k = 2) are codimension 1, so with the spatial crossing factor α₃ = 1/2 a noodle crosses them E = L/(2d) times. Parallel lines (k = 1) are codimension 2, so the same noodle almost surely misses them: E = 0, whatever its length or shape. The planar case (lines in ℝ², codimension 1) recovers the classical Buffon–Barbier constant E = 2L/(πd) with α₂ = 2/π. A curve dropped in space crosses planes but not lines — the geometric heart of the codimension question.",
+    "mathContext": "$\\mathbb{R}^3$ planes: $E = L/(2d)$; $\\quad \\mathbb{R}^3$ lines: $E = 0$; $\\quad \\mathbb{R}^2$ lines: $E = 2L/(\\pi d)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "planar Buffon constant",
+      "spatial crossing factor",
+      "codimension"
+    ],
+    "prerequisites": [
+      "Crossing factors α₂ = 2/π, α₃ = 1/2"
+    ]
   }
 ]

--- a/src/data/proofs/buffons-noodle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/buffons-noodle-oq-03-oq-02/meta.json
@@ -64,7 +64,7 @@
       "Hausdorff dimension and measure: Lipschitz maps do not increase Hausdorff dimension; a set of Hausdorff dimension below the ambient dimension is Lebesgue-null",
       "The identity μH[c] = volume on ℝᶜ (Hausdorff measure equals Lebesgue measure at the top dimension)"
     ],
-    "lineCount": 136,
+    "lineCount": 359,
     "relatedProblems": [
       {
         "id": "buffons-noodle-oq-03",
@@ -80,8 +80,8 @@
       }
     ],
     "assumptions": "None. 0 axioms, 0 sorries (the theorems depend only on the standard foundational axioms propext, Classical.choice, Quot.sound, which are not assumptions). The curve is modelled as a Lipschitz (rectifiable) map, the standard regularity for Buffon-type problems. Work is carried out in the coordinate space Fin c → ℝ with its product (sup) metric, where μH[c] = volume; the measure-zero conclusion is bi-Lipschitz invariant and so transfers verbatim to the Euclidean metric on ℝᶜ.",
-    "theoremCount": 4,
-    "definitionCount": 0,
+    "theoremCount": 20,
+    "definitionCount": 4,
     "structureCount": 0
   },
   "overview": {
@@ -120,7 +120,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 136,
+    "lineCount": 359,
     "namespace": "BuffonsNoodleOQ03OQ02",
     "opens": [
       "MeasureTheory",
@@ -128,18 +128,19 @@
     ],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 20,
     "substantiveTheoremCount": 2,
     "computationalVerifications": 0,
     "lemmaCount": 0,
     "imports": [
+      "Proofs.BuffonsNoodleOQ03",
       "Mathlib.MeasureTheory.Measure.Hausdorff",
       "Mathlib.Topology.MetricSpace.HausdorffDimension",
       "Mathlib.Tactic"
     ],
     "path": "Proofs/BuffonsNoodleOQ03OQ02.lean",
     "sorries": 0,
-    "definitionCount": 0
+    "definitionCount": 4
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/de-moivre-oq-05-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-de-moivre-oq-05-oq-02-oq-03-01",
+    "proofId": "de-moivre-oq-05-oq-02-oq-03",
+    "range": {
+      "startLine": 3,
+      "endLine": 62
+    },
+    "type": "concept",
+    "title": "From ℂ to an Arbitrary Integral Domain",
+    "content": "The classical identity ∑_{ord ζ = n} ζ = μ(n) is usually stated over ℂ, but its proof is purely algebraic — divisor partition plus Möbius inversion — so it lives in any commutative integral domain R that contains a primitive n-th root of unity. This entry takes that existence as a hypothesis (IsPrimitiveRoot ζ n) rather than constructing exp(2πi/n), so one theorem covers ℂ, finite fields 𝔽_q with n ∣ q-1, cyclotomic number fields, and p-adic fields at once. A key observation: the hypothesis alone forces char R ∤ n. If a prime p = char R divided n = pᵃ·m (p ∤ m), injectivity of the Frobenius x ↦ x^{pᵃ} would collapse ζ^m = 1 with m < n, contradicting primitivity. Hence the Möbius cast (μ n : R) is unambiguous with no extra characteristic assumption.",
+    "mathContext": "For any integral domain $R$ and primitive $n$-th root $\\zeta \\in R$: $\\sum_{z \\in \\operatorname{primitiveRoots}(n,R)} z = (\\mu(n):R)$, and $\\operatorname{char}R \\nmid n$ is automatic.",
+    "significance": "key",
+    "relatedConcepts": [
+      "primitive roots of unity",
+      "integral domain",
+      "Möbius function",
+      "Frobenius injectivity",
+      "characteristic of a ring"
+    ],
+    "prerequisites": [
+      "roots of unity in a general ring",
+      "Möbius function and Möbius inversion",
+      "characteristic and the Frobenius endomorphism"
+    ]
+  },
+  {
+    "id": "ann-de-moivre-oq-05-oq-02-oq-03-02",
+    "proofId": "de-moivre-oq-05-oq-02-oq-03",
+    "range": {
+      "startLine": 86,
+      "endLine": 96
+    },
+    "type": "tactic",
+    "title": "Local Evaluation g(k) = [k = 1] from a Single Primitive Root",
+    "content": "sum_nthRootsFinset_of_prim shows the sum of all k-th roots of unity in R is 1 when k = 1 and 0 otherwise, given a primitive k-th root ζ. The proof rewrites nthRootsFinset k 1 as (range k).image (ζ ^ ·) (helper nthRootsFinset_eq_image, which needs [DecidableEq R] for Finset.image), turns the sum into ∑_{i<k} ζⁱ via Finset.sum_image on the injective power map (IsPrimitiveRoot.injOn_pow), and finishes with IsPrimitiveRoot.geom_sum_eq_zero for k > 1 (the geometric series vanishes because ζ ≠ 1 yet ζᵏ = 1 in the domain). Crucially, in the main theorem the required primitive d-th root for each divisor d ∣ n is not assumed separately: it is manufactured as ζ^{n/d} via IsPrimitiveRoot.pow (from n = (n/d)·d).",
+    "mathContext": "$g(k) = \\sum_{i<k} \\zeta^i = \\begin{cases}1 & k=1\\\\ 0 & k>1\\end{cases}$, with the primitive $d$-th root supplied by $\\zeta^{n/d}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "geometric series",
+      "primitive root powers",
+      "Finset.image and DecidableEq",
+      "IsPrimitiveRoot.pow"
+    ],
+    "prerequisites": [
+      "finite geometric series",
+      "injectivity of i ↦ ζⁱ on range n"
+    ]
+  },
+  {
+    "id": "ann-de-moivre-oq-05-oq-02-oq-03-03",
+    "proofId": "de-moivre-oq-05-oq-02-oq-03",
+    "range": {
+      "startLine": 98,
+      "endLine": 155
+    },
+    "type": "concept",
+    "title": "Decoupled Partition + Möbius Inversion",
+    "content": "sum_primitiveRoots_eq_moebius assembles the proof. The divisor partition ∑_{d∣k} f(d) = g(k) is proved for ALL k > 0 over the ambient domain using IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots and Finset.sum_biUnion with disjointness — notably this step needs no primitive root to exist, it just groups whatever roots R contains by exact order. Möbius inversion (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq, valid over any ring) then yields f(n) = ∑_{ab=n} μ(a)·g(b). For each antidiagonal term the divisor b ∣ n has the primitive b-th root ζ^{n/b}, so g(b) = [b = 1]; only (a,b) = (n,1) survives, giving μ(n)·1 = μ(n). The field version sum_primitiveRoots_eq_moebius_field is the immediate specialization.",
+    "mathContext": "$f(n) = \\sum_{ab=n} \\mu(a)\\,g(b) = \\mu(n)\\,g(1) = \\mu(n)$; the partition holds over $R$ unconditionally, root existence is used only for the sparse support of $g$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Möbius inversion",
+      "divisor partition of roots of unity",
+      "Finset.sum_biUnion",
+      "Ramanujan sums"
+    ],
+    "prerequisites": [
+      "Möbius inversion over a ring",
+      "disjoint union of finsets",
+      "divisor antidiagonal"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-05-oq-02-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02-oq-03/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "de-moivre-oq-05-oq-02-oq-03",
+  "title": "De Moivre OQ-05-OQ-02-OQ-03: Sum of Primitive n-th Roots = μ(n) in Any Integral Domain",
+  "slug": "de-moivre-oq-05-oq-02-oq-03",
+  "description": "Generalizes the ℂ identity ∑ (primitive n-th roots) = μ(n) to any commutative integral domain R containing a primitive n-th root of unity (in particular any field). The existence of the primitive root is a hypothesis rather than a construction, so ℂ, finite fields 𝔽_q with n ∣ q-1, cyclotomic number fields, and p-adic fields are all covered by one theorem. The domain hypothesis automatically forces char ∤ n, making the Möbius cast (μ n : R) honest with no extra assumptions.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ05OQ02OQ03.lean",
+    "tags": [
+      "number-theory",
+      "roots-of-unity",
+      "primitive-roots",
+      "moebius",
+      "cyclotomy",
+      "mobius-inversion",
+      "integral-domain",
+      "de-moivre"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots",
+        "description": "In any integral domain, the n-th roots of unity present partition into primitive d-th roots over the divisors d ∣ n — no primitive root need exist for the partition itself",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.disjoint",
+        "description": "Primitive root sets of distinct orders are disjoint, making the divisor partition a genuine partition",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.geom_sum_eq_zero",
+        "description": "For a primitive k-th root ζ with 1 < k in an integral domain, the geometric sum ∑_{i<k} ζⁱ vanishes",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.pow",
+        "description": "If ζ is a primitive n-th root and n = a·b, then ζ^a is a primitive b-th root — supplies a primitive d-th root for every divisor d ∣ n from a single ζ",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.eq_pow_of_pow_eq_one",
+        "description": "Every n-th root of unity is a power ζⁱ (i < n) of a fixed primitive root ζ (over an integral domain)",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.one",
+        "description": "1 is a primitive 1st root of unity, evaluating the surviving divisor term g(1) = 1",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq",
+        "description": "Möbius inversion over any (NonAssoc) ring: ∑_{d∣n} f(d) = g(n) for all n>0 ⟺ ∑_{(a,b): ab=n} μ(a)·g(b) = f(n)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Moebius"
+      }
+    ],
+    "originalContributions": [
+      "Removes ℂ from the parent theorem: ∑ over the primitive n-th roots of unity equals (μ n : R) in ANY commutative integral domain R that contains a primitive n-th root of unity — existence of the root is a hypothesis, not the ℂ-specific exp(2πi/n) construction",
+      "Observation that the single hypothesis IsPrimitiveRoot ζ n forces char R ∤ n (Frobenius injectivity), so the Möbius cast (μ n : R) is well-defined with no auxiliary characteristic assumption",
+      "Decoupling of the partition step from root existence: the divisor partition ∑_{d∣n} f(d) = g(n) is proven over the ambient domain (no primitive root needed), while primitive d-th roots ζ^{n/d} are produced on demand only for the local evaluation g(d) = [d=1] via IsPrimitiveRoot.pow",
+      "Domain-level helper lemmas nthRootsFinset_eq_image and sum_nthRootsFinset_of_prim, generalizing the parent's ℂ-only helpers by threading [DecidableEq R] and taking the primitive root as an explicit argument",
+      "Explicit field specialization sum_primitiveRoots_eq_moebius_field answering the parent's stated open question verbatim (general field containing a primitive n-th root)"
+    ],
+    "dateAdded": "2026-07-07",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 160,
+    "assumptions": "0 axioms, 0 sorries (depends only on propext, Classical.choice, Quot.sound). The only mathematical hypothesis is IsPrimitiveRoot ζ n — the existence of a primitive n-th root of unity in the domain — which is exactly the classical hypothesis and automatically excludes characteristics dividing n. Builds on Mathlib's primitive-root, geometric-sum, and Möbius-inversion APIs; the assembly and the domain-level generalization are original to this entry.",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The identity $\\sum_{\\operatorname{ord}\\zeta=n}\\zeta=\\mu(n)$ (Apostol, *Introduction to Analytic Number Theory*, Theorem 2.7) is classically stated over $\\mathbb{C}$, but nothing analytic is used: the argument is the divisor partition of the roots of unity plus Möbius inversion, both purely algebraic. The natural home of the identity is therefore any integral domain that happens to contain a primitive $n$-th root of unity — finite fields $\\mathbb{F}_q$ with $n\\mid q-1$, cyclotomic number fields $\\mathbb{Q}(\\zeta_n)$, $p$-adic fields, and $\\mathbb{C}$ alike. In a finite field this reads as a Möbius-valued Gauss-type sum; in $\\mathbb{Q}(\\zeta_n)$ it is an integer relation among algebraic integers. The result is the $k=1$ case of the Ramanujan sum and encodes the second coefficient of the cyclotomic polynomial $\\Phi_n$.",
+    "problemStatement": "**Open Question** (from the parent de-moivre-oq-05-oq-02): does the identity $\\sum_{\\operatorname{ord}\\zeta=n}\\zeta=\\mu(n)$ hold over a general field — indeed a general integral domain — containing a primitive $n$-th root of unity, rather than only over $\\mathbb{C}$?\n\n**Answer**: Yes. For any commutative integral domain $R$ and any primitive $n$-th root of unity $\\zeta\\in R$, $\\displaystyle\\sum_{z\\in\\operatorname{primitiveRoots}(n,R)} z=(\\mu(n):R)$. The existence of $\\zeta$ is the sole hypothesis and forces $\\operatorname{char}R\\nmid n$, so the cast $(\\mu(n):R)$ is unambiguous.",
+    "text": "Generalizes the sum of primitive n-th roots of unity = μ(n) from ℂ to any integral domain containing a primitive n-th root, via the divisor partition of roots of unity and Möbius inversion.",
+    "proofStrategy": "Write $f(k)=\\sum_{z\\in\\operatorname{primitiveRoots}(k,R)} z$ and $g(k)=\\sum_{x^k=1} x$ over the fixed domain $R$.\n1. **Partition (needs no primitive root).** In any integral domain, `IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots` expresses the finset of $k$-th roots present in $R$ as a disjoint union over divisors $d\\mid k$; with `IsPrimitiveRoot.disjoint` and `Finset.sum_biUnion` this gives $\\sum_{d\\mid k} f(d)=g(k)$ for all $k>0$ — regardless of which roots $R$ actually contains.\n2. **Local evaluation of g.** For each divisor $d\\mid n$ the element $\\zeta^{n/d}$ is a primitive $d$-th root (`IsPrimitiveRoot.pow` with $n=(n/d)\\cdot d$). It enumerates the $d$-th roots as $\\{\\zeta^{(n/d)i}\\}$ (helper `nthRootsFinset_eq_image`), so $g(d)=\\sum_{i<d}(\\zeta^{n/d})^i$, which is $1$ for $d=1$ and $0$ for $d>1$ by `IsPrimitiveRoot.geom_sum_eq_zero` (helper `sum_nthRootsFinset_of_prim`).\n3. **Inversion.** `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` turns step 1 into $f(n)=\\sum_{ab=n}\\mu(a)\\,g(b)$. Since $g(b)=[b=1]$ for every divisor $b\\mid n$, the only surviving antidiagonal term is $(a,b)=(n,1)$, giving $\\mu(n)\\cdot 1=\\mu(n)$.",
+    "keyInsights": [
+      "Nothing in the classical proof is complex-analytic: the divisor **partition** and **Möbius inversion** are algebraic, so the identity lives in any integral domain, not just $\\mathbb{C}$",
+      "The partition $\\sum_{d\\mid k}f(d)=g(k)$ holds over the ambient domain **without any primitive root existing** — it simply groups whatever roots are present by their exact order",
+      "A **single** primitive $n$-th root $\\zeta$ supplies primitive $d$-th roots for every divisor $d\\mid n$ as $\\zeta^{n/d}$ (`IsPrimitiveRoot.pow`), which is all the local evaluation $g(d)=[d=1]$ needs",
+      "The hypothesis `IsPrimitiveRoot ζ n` silently rules out $\\operatorname{char}R\\mid n$ (Frobenius injectivity would collapse the order), so the Möbius cast $(\\mu(n):R)$ needs no separate characteristic assumption",
+      "Passing from $\\mathbb{C}$ to a general domain replaces the constructive generator $\\exp(2\\pi i/n)$ by a hypothesis and threads `[DecidableEq R]` through the image enumeration — the mathematical skeleton is otherwise unchanged"
+    ],
+    "prerequisites": [
+      "Roots of unity and primitive roots in a general integral domain",
+      "The Möbius function and Möbius inversion over the divisors of n",
+      "Finite geometric series; Frobenius injectivity in positive characteristic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: the target identity over any integral domain, why the domain hypothesis forces char ∤ n, the f/g notation, and the decoupled partition + local-evaluation + inversion strategy",
+      "startLine": 1,
+      "endLine": 62,
+      "mathContext": "**Goal**: $\\sum_{z\\in\\operatorname{primitiveRoots}(n,R)} z=(\\mu(n):R)$ for any integral domain $R$ with a primitive $n$-th root $\\zeta$; proved by the divisor partition over $R$ and Möbius inversion."
+    },
+    {
+      "id": "image-enumeration",
+      "title": "Part I: The k-th Roots as Powers of a Primitive Root",
+      "summary": "nthRootsFinset_eq_image: over a domain with [DecidableEq R], for a primitive k-th root ζ the finset of k-th roots of unity equals the image of range k under i ↦ ζⁱ",
+      "startLine": 71,
+      "endLine": 84,
+      "mathContext": "$\\{z:z^k=1\\}=\\{\\zeta^i:0\\le i<k\\}$ via `eq_pow_of_pow_eq_one` and $\\zeta^k=1$ — now over an arbitrary integral domain rather than $\\mathbb{C}$."
+    },
+    {
+      "id": "sum-all-roots",
+      "title": "Part II: Local Evaluation of g",
+      "summary": "sum_nthRootsFinset_of_prim: given a primitive k-th root in R, the sum of all k-th roots of unity is 1 if k = 1 and 0 otherwise, via the image enumeration and IsPrimitiveRoot.geom_sum_eq_zero",
+      "startLine": 86,
+      "endLine": 96,
+      "mathContext": "$g(k)=\\sum_{i<k}\\zeta^i$. For $k=1$ this is $\\zeta^0=1$; for $k>1$ the geometric series telescopes to $0$ since $\\zeta\\neq 1$ but $\\zeta^k=1$ in the domain."
+    },
+    {
+      "id": "main-inversion",
+      "title": "Part III: Möbius Inversion Yields μ(n)",
+      "summary": "sum_primitiveRoots_eq_moebius: the partition ∑_{d∣k} f(d) = g(k) over the domain (sum_biUnion + disjointness) feeds Möbius inversion; each divisor supplies a primitive root ζ^{n/d} so only d = 1 survives, giving μ(n)·g(1) = μ(n). Field specialization follows immediately.",
+      "startLine": 98,
+      "endLine": 155,
+      "mathContext": "$f(n)=\\sum_{ab=n}\\mu(a)g(b)=\\mu(n)g(1)=\\mu(n)$ — the sparse support of $g$, established divisor-by-divisor from a single ζ, collapses the inverted sum to one term."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization removes ℂ from the parent theorem: the sum of the primitive n-th roots of unity equals the Möbius function μ(n) in ANY commutative integral domain that contains a primitive n-th root of unity, with the root's existence taken as the sole hypothesis. The divisor partition of the roots of unity is established over the ambient domain with no root assumed; primitive d-th roots ζ^{n/d} are produced on demand for the local evaluation g(d) = [d = 1]; and Möbius inversion collapses the divisor sum to μ(n). The proof is fully machine-checked with zero sorries and zero axioms beyond Lean's foundations.",
+    "implications": "Answers the parent de-moivre-oq-05-oq-02's open question — the identity over a general field containing a primitive n-th root — and in fact strengthens it to arbitrary integral domains (finite fields 𝔽_q with n ∣ q-1, cyclotomic number fields, p-adic fields). It isolates precisely which hypothesis is needed (one primitive root, which alone forces char ∤ n) and exhibits the 'partition over divisors + Möbius inversion' template working purely algebraically, independent of the analytic setting of ℂ.",
+    "openQuestions": [
+      "Generalize to the full Ramanujan sum c_n(k) = ∑_{ord ζ = n} ζᵏ over an integral domain and prove c_n(k) = μ(n/gcd(n,k))·φ(n)/φ(n/gcd(n,k))",
+      "Drop the existence hypothesis by working in a splitting field / algebraic closure and descend the μ(n) value back to the base ring"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-05-oq-02",
+      "relationship": "Parent: the same identity over ℂ; this entry answers its open question by generalizing to any integral domain containing a primitive n-th root"
+    },
+    {
+      "id": "de-moivre-oq-05",
+      "relationship": "Grandparent: all n-th roots of unity sum to 0 for n > 1 — the function g inverted here"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Polynomial",
+      "ArithmeticFunction.Moebius"
+    ],
+    "namespace": "DeMoivreOQ05OQ02OQ03",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ05OQ02OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "title": "Introduction to Analytic Number Theory",
+      "author": "Tom M. Apostol",
+      "year": 1976,
+      "note": "Theorem 2.7: the Möbius function as the sum of the primitive n-th roots of unity (stated over ℂ; the proof is algebraic)"
+    },
+    {
+      "title": "Mathlib4: RingTheory.RootsOfUnity.PrimitiveRoots and NumberTheory.ArithmeticFunction.Moebius",
+      "author": "The mathlib Community",
+      "year": 2026,
+      "note": "Primitive-root partition and IsPrimitiveRoot.pow over integral domains, geometric-sum vanishing, and Möbius inversion over a ring"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-05-oq-02",
+      "relationship": "extends",
+      "description": "Parent proves ∑ primitive n-th roots = μ(n) over ℂ; this entry generalizes to any commutative integral domain containing a primitive n-th root of unity, answering the parent's stated open question."
+    }
+  ]
+}

--- a/src/data/proofs/minpoly-charpoly-oq-02/annotations.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-mcpoq02-imports",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 1, "endLine": 10 },
+    "range": {
+      "startLine": 1,
+      "endLine": 10
+    },
     "type": "concept",
     "title": "Import Stack: Charpoly + Semisimple + Eigenspace + Parent",
     "content": "Ten imports stage the three Mathlib layers used by the OQ-02 discharge plan:\n\n* **Minpoly / charpoly layer** (L1-2): `Matrix.Charpoly.Basic` for charpoly and `Matrix.Charpoly.Minpoly` for `Matrix.minpoly_toLin'` — the Bridge D used to transport squarefree across the matrix↔endo correspondence.\n* **Diagonal-matrix predicate** (L3): `LinearAlgebra.Matrix.IsDiag` — the codomain of the similarity-transform existential in `Matrix.IsDiagonalizable`. Note: the S7 ACT v4.26.0 import regression fix added this import after the silently-removed `Mathlib.Algebra.Polynomial.Squarefree` (file renamed in v4.26.0).\n* **Semisimplicity** (L4): `LinearAlgebra.Semisimple` — provides `Module.End.IsSemisimple`, the engine of the entire iff. Includes both directions of Bridge C: `Module.End.IsSemisimple.minpoly_squarefree` and `Module.End.isSemisimple_of_squarefree_aeval_eq_zero`.\n* **Eigenspace layer** (L5-6): `Eigenspace.Semisimple` for `IsFinitelySemisimple.maxGenEigenspace_eq_eigenspace` (the second link in Bridge B forward's 3-lemma chain); `Eigenspace.Triangularizable` for `Module.End.iSup_maxGenEigenspace_eq_top` (the third link, the endpoint).\n* **Finite-dim transport** (L7-8): `FreeModule.Finite.Matrix` for the `Matrix.toLin'` algebra hookups; `FieldTheory.IsAlgClosed.Basic` for the headline's `[IsAlgClosed K]` hypothesis.\n* **Tactic + Parent** (L9-10): `Mathlib.Tactic` for `simpa`/`refine`/calc; `Proofs.MinpolyCharpoly` for the parent's 17 minpoly | charpoly theorems.",
@@ -22,7 +25,10 @@
   {
     "id": "ann-mcpoq02-resolution",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 28, "endLine": 56 },
+    "range": {
+      "startLine": 28,
+      "endLine": 56
+    },
     "type": "concept",
     "title": "S1 OBSERVE Resolution — Three Ingredients, No Mathlib Gap",
     "content": "The S1 OBSERVE docstring resolves OQ-02 affirmatively by identifying three Mathlib-level ingredients that compose into the matrix-level iff:\n\n1. **Module.End.IsSemisimple ↔ Squarefree (minpoly K f)** — already in Mathlib at v4.26.0 (`Module.End.isSemisimple_iff_squarefree_minpoly` ships in `Mathlib.LinearAlgebra.Semisimple`, with both directions named). Bridge C ships this in-tree as a packaged iff (lines 162-167).\n\n2. **IsSemisimple + minpoly splits → diagonalizable**: over alg-closed `K` the splits hypothesis is automatic; semisimplicity then implies the eigenspaces span the whole space (Bridge B forward, lines 146-155). Composed with the converse direction (Bridge B reverse, deferred to S8 ACT) this gives the operator-theoretic characterisation.\n\n3. **Matrix ↔ endomorphism transport**: `Matrix.toLin' M` carries the minpoly across (`Matrix.minpoly_toLin'`, Bridge D) and lets us read the matrix-level diagonalizability statement back from the endomorphism-level iff.\n\nNo Mathlib gap is required. The remaining work for OQ-02 is purely *integrative* — assemble the three pieces into the headline matrix-level statement. The four sub-OQs (OQ-02-OQ-01..OQ-02-OQ-04) decompose this integration into ~450 LOC across four iterations.",
@@ -44,7 +50,10 @@
   {
     "id": "ann-mcpoq02-isdiagonalizable",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 100, "endLine": 108 },
+    "range": {
+      "startLine": 100,
+      "endLine": 108
+    },
     "type": "definition",
     "title": "Matrix.IsDiagonalizable — the Matrix-Level Predicate",
     "content": "`Matrix.IsDiagonalizable M` is defined as `∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P)` — the existential over similarity transforms `P` whose conjugate of `M` is a diagonal matrix.\n\nDesign choices:\n\n* **Existential over `P` rather than fixed `P`**: the definition is intrinsic to the similarity class. Two diagonalizable matrices may use very different `P`s, and the predicate abstracts that out.\n* **`IsUnit P` rather than `P.Invertible` or `Nonsing`**: `IsUnit` is the Mathlib idiom for invertibility in a monoid; `Matrix.IsUnit_iff_isUnit_det` connects it to the determinant for downstream calculations.\n* **`IsDiag` rather than `Matrix.diagonal d` for some explicit `d`**: `IsDiag` is the predicate ('every off-diagonal entry is zero'), which is what callers actually need. The explicit eigenvalue-multiplicity diagonal is reconstructable from `IsDiag` + `Matrix.diag` extraction.\n* **`_root_.Matrix.IsDiagonalizable`**: the `_root_` prefix exposes the predicate at the top-level `Matrix` namespace, matching `Matrix.IsDiag` / `Matrix.IsUnit_iff_isUnit_det` etc.\n\nThis predicate corresponds at the endomorphism level to `Module.End.IsSemisimple ∧ Polynomial.Splits (algebraMap K K) (minpoly K f)` — the alg-closed condition makes the splits clause vacuous, so under `[IsAlgClosed K]` the predicate is equivalent to `IsSemisimple (toLin' M)`.",
@@ -65,7 +74,10 @@
   {
     "id": "ann-mcpoq02-headline",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 110, "endLine": 122 },
+    "range": {
+      "startLine": 110,
+      "endLine": 122
+    },
     "type": "insight",
     "title": "diagonalizable_iff_squarefree_minpoly — The S1 Headline (Sorry-Guarded)",
     "content": "The S1 statement is the textbook gold form: over an algebraically closed field of characteristic zero, a matrix is diagonalizable iff its minimal polynomial is squarefree. A single `sorry` at line 122 carries the proof — the four sub-OQs (OQ-02-OQ-01..OQ-02-OQ-04) and the ~59 LOC ACT synthesis are designed to discharge it.\n\n**Why these specific hypotheses?**\n\n* **`[IsAlgClosed K]`**: makes `Polynomial.Splits (algebraMap K K) (minpoly K M)` automatic, so the textbook 'minpoly squarefree *and splits*' condition collapses to just 'minpoly squarefree'.\n* **`[CharZero K]`**: every polynomial is separable in char 0, so 'squarefree' and 'product of distinct irreducible factors' coincide. This is the cleanest target for the OQ-02-OQ-04 sub-OQ.\n\nThe minimum hypotheses are weaker — 'perfect field + minpoly splits in K' suffices — but the alg-closed-char-0 case is what most callers (linear-algebra texts, computer algebra systems, downstream applications) expect. The general-field form is the target of **OQ-02-OQ-03** and could be added as `diagonalizable_iff_squarefree_minpoly_general` once that sub-OQ ships.\n\n**Discharge plan (~59 LOC, picker-estimated by S7c PREP §5.1)**:\n\n| Bridge | Direction | Source | LOC |\n|---|---|---|---:|\n| A fwd | M.IsDiagonalizable → eigenbasis | S2 PREP-3 §2 | ~12 |\n| A rev | eigenbasis → M.IsDiagonalizable | S2 PREP-3 §3.2 | ~8 |\n| B fwd | IsSemisimple → ⨆ eigenspace = ⊤ | **In-tree** (this file, lines 146-155) | 0 |\n| B rev | ⨆ eigenspace = ⊤ → IsSemisimple | S5b PREP §5 + S7c §3.3 Option A | ~33 |\n| C | IsSemisimple ↔ Squarefree minpoly | **In-tree** (this file, lines 162-167) | 0 |\n| D | minpoly K (toLin' M) = minpoly K M | `Matrix.minpoly_toLin'` (Mathlib, @[simp]) | 1 |\n| Compose | iff headline | 4 bridges + finiteness | ~5 |",
@@ -87,7 +99,10 @@
   {
     "id": "ann-mcpoq02-sanity",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 124, "endLine": 134 },
+    "range": {
+      "startLine": 124,
+      "endLine": 134
+    },
     "type": "definition",
     "title": "Sanity Helpers — of_isDiag and zero (Unconditional)",
     "content": "Two unconditional sanity lemmas give the file a non-trivial public surface even before the headline discharge:\n\n* **`Matrix.IsDiagonalizable.of_isDiag`** (lines 126-129): any diagonal matrix is diagonalizable, witnessed by `P = 1`. Proof: `refine ⟨1, isUnit_one, ?_⟩; simpa using hM`. The `simpa` simp-set rewrites `1⁻¹ * M * 1 = M`, reducing the goal to `IsDiag M` which is the hypothesis. Note: the S7 ACT v4.26.0 patch dropped `Matrix.inv_one` from this `simpa` lemma list (now subsumed by the default simp set) and added the `Matrix.IsDiag` namespace qualification (M → Matrix.IsDiag M, since just `IsDiag` is ambiguous at v4.26.0).\n\n* **`Matrix.IsDiagonalizable.zero`** (lines 132-134): the zero matrix is diagonalizable. Proof: `Matrix.IsDiagonalizable.of_isDiag Matrix.isDiag_zero`. A one-liner combining the previous sanity helper with `Matrix.isDiag_zero` (the zero matrix is diagonal).\n\nThese helpers are not the discharge target — they exist so the file passes 'has-non-trivial-public-content' checks (e.g. for the gallery card thumbnail) and as worked examples of the `Matrix.IsDiagonalizable` predicate API.",
@@ -106,7 +121,10 @@
   {
     "id": "ann-mcpoq02-bridge-b-fwd",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 140, "endLine": 155 },
+    "range": {
+      "startLine": 140,
+      "endLine": 155
+    },
     "type": "definition",
     "title": "Bridge B Forward — Phantom-Corrected 3-Lemma Chain",
     "content": "**S7 ACT contribution (#19095, merged 2026-05-15)**. `Module.End.iSup_eigenspace_eq_top_of_isSemisimple`: over a finite-dimensional alg-closed-K space, if `f` is semisimple then its eigenspaces span the whole space (⨆ μ : K, f.eigenspace μ = ⊤).\n\n**Why a 3-lemma chain?** The natural-looking direct form `Module.End.IsSemisimple.iSup_eigenspace_eq_top` *does not exist in Mathlib*. S3 PREP #18481 originally claimed it as a single lemma — caught as phantom by the S4 PREP #18626 audit. The corrected route composes three steps:\n\n1. **`hss.isFinitelySemisimple`**: upgrade semisimplicity to its finitely-semisimple companion (uses `[FiniteDimensional K V]`).\n2. **`hfin.maxGenEigenspace_eq_eigenspace μ`**: under finite semisimplicity, the maximal generalized eigenspace equals the eigenspace at each `μ`. (Reverse direction taken via `.symm`.)\n3. **`Module.End.iSup_maxGenEigenspace_eq_top f`**: over alg-closed-K in finite dim, the sum of maximal generalized eigenspaces is the whole space.\n\nComposition: `iSup μ, eigenspace μ = iSup μ, maxGenEigenspace μ = ⊤`, fused by `iSup_congr`.\n\nThis is the **Bridge B forward** of the four-bridge synthesis. Combined with the (still-pending) Bridge B reverse (S5b PREP §5 + S7c §3.3 Option A) it gives the eigenspace-decomposition ↔ semisimple iff, which together with Bridge C (squarefree ↔ semisimple) and Bridges A/D (matrix↔endo) discharges the headline.",
@@ -128,7 +146,10 @@
   {
     "id": "ann-mcpoq02-bridge-c",
     "proofId": "minpoly-charpoly-oq-02",
-    "range": { "startLine": 157, "endLine": 167 },
+    "range": {
+      "startLine": 157,
+      "endLine": 167
+    },
     "type": "theorem",
     "title": "Bridge C — IsSemisimple ↔ Squarefree minpoly",
     "content": "**S7 ACT contribution (#19095, merged 2026-05-15)**. `Module.End.isSemisimple_iff_squarefree_minpoly`: over a finite-dimensional `K`-space, an endomorphism `f` is semisimple iff its minimal polynomial is squarefree.\n\n* **Forward**: `Module.End.IsSemisimple.minpoly_squarefree` (Mathlib, in `LinearAlgebra.Semisimple`). Directly gives `f.IsSemisimple → Squarefree (minpoly K f)`.\n* **Reverse**: `Module.End.isSemisimple_of_squarefree_aeval_eq_zero` (Mathlib) applied to `minpoly.aeval K f`. The lemma's general form takes any polynomial `p` that's squarefree and annihilates `f` and concludes `f.IsSemisimple`; specialising `p := minpoly K f` (with `minpoly.aeval` witnessing `p.aeval f = 0`) gives the reverse direction.\n\nThis Bridge C is the **endomorphism-level iff** — the heart of OQ-02. Transporting it to the matrix level via Bridge D (`Matrix.minpoly_toLin'`) yields `IsSemisimple (toLin' M) ↔ Squarefree (minpoly K M)`, and combining with Bridges A/B yields the headline.\n\n**Note**: this iff is field-independent and characteristic-independent — `[CharZero K]` is *not* required for the iff itself. The CharZero hypothesis on the headline enters only to simplify the OQ-02-OQ-04 sub-OQ (where 'squarefree' coincides with 'separable + product of distinct linear factors over `K`').",
@@ -145,5 +166,55 @@
       "Squarefree polynomial predicate",
       "Annihilating polynomial"
     ]
+  },
+  {
+    "id": "ann-mcpoq02-headline-charzero-free",
+    "proofId": "minpoly-charpoly-oq-02",
+    "range": {
+      "startLine": 432,
+      "endLine": 450
+    },
+    "type": "insight",
+    "title": "diagonalizable_iff_squarefree_minpoly' — CharZero-Free Headline",
+    "content": "The headline is now fully proved with **no sorries** over any algebraically closed field `K` (of arbitrary characteristic): a matrix `M` is diagonalizable iff its minimal polynomial is squarefree.\n\n**Forward** (`→`, unconditional over any field): `Matrix.IsDiagonalizable.squarefree_minpoly` — if `M = P⁻¹ D P` with `D` diagonal, then `minpoly K M = minpoly K D` (similarity invariance via the `matConj` algebra automorphism) divides `∏ (X − c)` over the distinct diagonal entries, hence is squarefree.\n\n**Reverse** (`←`, needs `[IsAlgClosed K]` only): four steps —\n\n| Step | Lemma | Role |\n|---|---|---|\n| Bridge D | `Matrix.minpoly_toLin'` | transport squarefreeness to the endomorphism `M.toLin'` |\n| Bridge C | `Module.End.isSemisimple_iff_squarefree_minpoly` | squarefree minpoly ⇒ semisimple |\n| Eigenbasis | `Matrix.exists_eigenbasis_of_isSemisimple` | semisimple + alg-closed ⇒ basis of eigenvectors (via Bridge B + `DirectSum.IsInternal`) |\n| Conjugation | `Matrix.isDiagonalizable_of_eigenbasis` | eigenbasis ⇒ diagonalizing similarity |\n\n**Why no `[CharZero K]`?** The textbook statement carries it, but it is redundant. Bridge C's reverse arm (`isSemisimple_of_squarefree_aeval_eq_zero`) needs only squarefreeness — separability is not required for *semisimplicity* (squarefree minpoly ⇒ the module is a sum of simple `K[X]`-submodules regardless of characteristic). Algebraic closure then forces those simple factors to be `1`-dimensional (all irreducibles are linear), giving an eigenbasis. Characteristic zero never enters, so the hypothesis was dropped — strengthening the result to all characteristics. The general-field form (with an explicit `Polynomial.Splits` hypothesis in place of algebraic closure) is the target of **OQ-02-OQ-03**.",
+    "mathContext": "For $K$ algebraically closed of characteristic 0 and $M \\in \\mathrm{Mat}_n(K)$: $M$ is diagonalizable $\\Leftrightarrow$ $\\mathrm{minpoly}_K(M) \\in K[X]$ is squarefree.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Polynomial.Squarefree",
+      "minpoly",
+      "Diagonalizability",
+      "Algebraically closed field",
+      "Characteristic zero"
+    ],
+    "prerequisites": [
+      "Minimum polynomial of a matrix",
+      "Squarefree polynomials",
+      "Splitting field"
+    ]
+  },
+  {
+    "id": "ann-mcpoq02-reverse-eigenbasis",
+    "type": "theorem",
+    "proofId": "minpoly-charpoly-oq-02",
+    "title": "Matrix.exists_eigenbasis_of_isSemisimple — Semisimple ⇒ Eigenbasis",
+    "significance": "critical",
+    "content": "The reverse-direction eigenbasis construction (over an algebraically closed field). A semisimple endomorphism `f` of `n → K` admits a basis of eigenvectors.\n\n**The chain.** Bridge B (`Module.End.iSup_eigenspace_eq_top_of_isSemisimple`) gives `⨆ μ, f.eigenspace μ = ⊤`. Eigenspaces are always independent (`Module.End.eigenspaces_iSupIndep`), so `DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top` assembles the family into an internal direct sum `DirectSum.IsInternal f.eigenspace`.\n\n**Collecting and reindexing.** `IsInternal.collectedBasis` glues a chosen basis of each eigenspace (`Module.finBasis`) into a basis of `n → K` indexed by the sigma type `Σ μ : K, Fin (finrank K (f.eigenspace μ))`. That index is automatically a `Fintype` (`FiniteDimensional.fintypeBasisIndex`, since it indexes a basis of a finite-dimensional space), and `Fintype.equivOfCardEq` (both index sets have cardinality `finrank K (n → K) = Fintype.card n`, by `Module.finrank_eq_card_basis`) produces an equivalence onto `n`. Reindexing yields `Basis n K (n → K)`.\n\n**Eigenvectors.** Each collected vector `B a` lies in `f.eigenspace a.1` (`IsInternal.collectedBasis_mem`), so `mem_eigenspace_iff` gives `f (B a) = a.1 • B a` — an eigenvector with eigenvalue `a.1`. After reindexing, the eigenvalue function is `c i = (ρ.symm i).1`.",
+    "mathContext": "Over $\\overline{K}$, a semisimple $f$ satisfies $\\bigoplus_\\mu \\ker(f-\\mu) = K^n$; collecting per-eigenspace bases yields an eigenbasis of $K^n$.",
+    "relatedConcepts": [
+      "DirectSum.IsInternal",
+      "collectedBasis",
+      "iSupIndep",
+      "Basis.indexEquiv",
+      "FiniteDimensional.fintypeBasisIndex"
+    ],
+    "prerequisites": [
+      "Internal direct sums of submodules",
+      "Eigenspace independence",
+      "Basis reindexing"
+    ],
+    "range": {
+      "startLine": 408,
+      "endLine": 430
+    }
   }
 ]

--- a/src/data/proofs/minpoly-charpoly-oq-02/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/meta.json
@@ -22,11 +22,11 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 389,
+    "lineCount": 456,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms on diagonalizable_iff_squarefree_minpoly and isDiagonalizable_of_eigenbasis reports only propext, Classical.choice, Quot.sound (the standard foundational axioms) — no sorryAx, no Lean.ofReduceBool. The headline hypotheses [IsAlgClosed K] [CharZero K] are explicit typeclass assumptions on the statement (the textbook gold form), not axioms; the general perfect-field-plus-splits form is the target of OQ-02-OQ-03. Pinned at Mathlib v4.26.0.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-04",
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 2,
     "originalContributions": [
       "diagonalizable_iff_squarefree_minpoly (VERIFIED, 0 sorries, 0 axioms): the FULL headline biconditional over an algebraically closed field of characteristic zero — M.IsDiagonalizable ↔ Squarefree (minpoly K M). The reverse direction (previously the sole sorry, blocked across multiple sessions) is now discharged.",
@@ -197,9 +197,9 @@
       "Polynomial"
     ],
     "namespace": "Proofs.MinpolyCharpolyOQ02",
-    "lineCount": 389,
+    "lineCount": 456,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 2,
     "path": "Proofs/MinpolyCharpolyOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
Supersedes #32451 (stale, unrebasable Dec-era branch; left open per queue instructions). Part of the recovery queue #35118.

## What was recovered (per-cluster extraction onto a fresh branch from main — no mechanical rebase)

### Cluster 1: DeMoivreOQ05OQ02OQ03 — PORTED VERBATIM (+ axiom audit)
`proofs/Proofs/DeMoivreOQ05OQ02OQ03.lean` was wholly absent from main. Sum of the primitive n-th roots of unity = `(μ n : R)` in **any integral domain** containing a primitive n-th root (field specialization included). Ported the full file plus the `src/data/proofs/de-moivre-oq-05-oq-02-oq-03/` gallery dir (meta.json with both `meta.*` and `leanFile.*` blocks, lineCount refreshed 155→160 for the added `#print axioms` audit lines).

- Build: `Proofs.DeMoivreOQ05OQ02OQ03` succeeded.
- Axiom audit (build log): both headline theorems depend on `[propext, Classical.choice, Quot.sound]` only. 0 sorries, 0 axioms → `verified`/`original` is honest.

### Cluster 2: Buffon flat-crossings — PORTED AS APPENDED COMPANION
Main's `BuffonsNoodleOQ03OQ02.lean` evolved into a measure-theoretic treatment (4 theorems); the PR's 20 combinatorial flat-crossings declarations (`gridCount`, `gridCount_bounds`, `codim`, `flatSegmentCrossings*`, `expectedFlatCrossings*` dichotomy/hyperplane-recovery/nonneg, `flatShape_independence`, `flatCrossings_mono`, ℝ²/ℝ³ instances) were all absent from main's entire tree (grep-verified per name). Appended them in their own `BuffonsNoodleCodim` namespace after main's content, with `import Proofs.BuffonsNoodleOQ03` added (parent machinery `segmentCrossings`/`Noodle`/`noodle_highdim` all still present on main).

- Build: `Proofs.BuffonsNoodleOQ03OQ02` succeeded; `expectedFlatCrossings_codim_one` / `expectedFlatCrossings_dichotomy` audit = foundational trio only.
- Gallery: meta counts updated (136→359 lines, 4→20 theorems, 0→4 defs, imports), PR's 4 codim annotations ported with remapped line ranges under new `-codim-0N` ids alongside main's existing annotations.

### Cluster 3: Minpoly diagonalizability — 2 DECLARATIONS PORTED, 1 DROPPED AS DUPLICATE
Main's `MinpolyCharpolyOQ02.lean` independently completed the headline via an inlined eigenbasis construction. Ported the two genuinely-unique pieces, appended inside the existing namespace:
- `Matrix.exists_eigenbasis_of_isSemisimple` — standalone reusable eigenbasis extraction (main only had it inlined in the headline proof).
- `diagonalizable_iff_squarefree_minpoly'` — the PR's **CharZero-free** headline (`[IsAlgClosed K]` only; main's unprimed version carries a redundant `[CharZero K]`, left untouched).

**Dropped**: the PR's `_root_.Matrix.isDiagonalizable_of_eigenbasis` — duplicate of main's existing `isDiagonalizable_of_eigenbasis` (same statement, main's proof retained). Also dropped: PR's `src/data/research/problems/minpoly-charpoly-oq-02.json` (stale ACT/blocked state that would regress main's COMPLETED record) and PR's buffons/minpoly meta.json overwrites (they described the PR-era file layouts; main's metas were count-updated instead).

- Build: `Proofs.MinpolyCharpolyOQ02` succeeded; both new declarations audit to the foundational trio only. `omit [DecidableEq n]` added to keep the unusedSectionVars linter clean.
- Gallery: meta counts updated (389→456 lines, 12→14 theorems); 2 annotations ported/adapted with corrected ranges.

## Verification
- All three modules built via `./proofs/scripts/docker-build.sh` (LEAN_MEMORY_LIMIT=16384), 0 errors, 0 warnings.
- `pnpm annotations:validate`: the touched slugs show only warnings that pre-exist on main (buffons -00/-04, minpoly stale headline anns); all newly added annotations resolve.
- 0 sorries anywhere (grep hits are docstring mentions); no `native_decide`; no `axiom` declarations; no structure-encoded assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)