### PR TITLE
fix(amgm-oq02-oq02): repair Newton-discriminant proof for Mathlib v4.26 + land deferred Maclaurin-chain candidate (#35107)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02.lean
@@ -445,16 +445,21 @@ theorem newton_cleared_denom_inductive_step (m k : ℕ) (hk : 2 ≤ k) (hm_eq : 
     simp only [hAD_def]; nlinarith [mul_nonneg ha_nn hd_nn, mul_nonneg hb_nn hc_nn]
   -- binom_ineq ↔ c²·AD ≥ bd·B2
   have h_c2AD_ge_bdB2 : c ^ 2 * AD ≥ b * d * B2 := by nlinarith [h_binom]
-  -- Algebraic identity gives dual: b²·AD ≥ ac·B2
-  have h_binom_symm : (c ^ 2 - b ^ 2) * AD = (b * d - a * c) * B2 := by
-    simp only [hAD_def, hB2_def]; ring
+  -- Dual inequality b²·AD ≥ ac·B2 (from binom_ineq_dual — the earlier
+  -- `(c²-b²)·AD = (b·d-a·c)·B2` "symmetry" was not a ring identity).
+  have h_binom_dual := binom_ineq_dual m k hk hm_eq
   have h_b2AD_ge_acB2 : b ^ 2 * AD ≥ a * c * B2 := by
-    nlinarith [h_c2AD_ge_bdB2, h_binom_symm]
+    simp only [hAD_def, hB2_def]; simp only [ha_def, hb_def, hc_def, hd_def] at h_binom_dual ⊢
+    linarith [h_binom_dual]
   -- Positivity of binomial coefficients
-  have hb_pos : (0 : ℝ) < b := by exact_mod_cast Nat.choose_pos (show k - 1 ≤ m by omega)
-  have hc_pos : (0 : ℝ) < c := by exact_mod_cast Nat.choose_pos (show k ≤ m by omega)
-  have hd_pos : (0 : ℝ) < d := by exact_mod_cast Nat.choose_pos (show k + 1 ≤ m by omega)
-  have ha_pos : (0 : ℝ) < a := by exact_mod_cast Nat.choose_pos (show k - 2 ≤ m by omega)
+  have hb_pos : (0 : ℝ) < b := by
+    rw [hb_def]; exact_mod_cast Nat.choose_pos (show k - 1 ≤ m by omega)
+  have hc_pos : (0 : ℝ) < c := by
+    rw [hc_def]; exact_mod_cast Nat.choose_pos (show k ≤ m by omega)
+  have hd_pos : (0 : ℝ) < d := by
+    rw [hd_def]; exact_mod_cast Nat.choose_pos (show k + 1 ≤ m by omega)
+  have ha_pos : (0 : ℝ) < a := by
+    rw [ha_def]; exact_mod_cast Nat.choose_pos (show k - 2 ≤ m by omega)
   --
   -- Step 2: γ ≥ 0
   have hγ : ek ^ 2 * AD ≥ ekm1 * ekp1 * B2 := by
@@ -483,34 +488,69 @@ theorem newton_cleared_denom_inductive_step (m k : ℕ) (hk : 2 ≤ k) (hm_eq : 
     linarith [mul_neg_of_pos_of_neg (mul_pos ha_pos hc_pos) (by linarith :
       ekm1 ^ 2 * AD - ekm2 * ek * B2 < 0)]
   --
-  -- Step 4: Discriminant 4αγ ≥ β²
-  have hdisc : 4 * (ekm1 ^ 2 * AD - ekm2 * ek * B2) *
-      (ek ^ 2 * AD - ekm1 * ekp1 * B2) ≥
-      (2 * ek * ekm1 * AD - (ek * ekm1 + ekm2 * ekp1) * B2) ^ 2 := by
-    -- Non-negative excess terms from IH and log-concavity
-    have δ₁ : 0 ≤ ek ^ 2 * (b * d) - ekm1 * ekp1 * c ^ 2 := by nlinarith [h_ih_k]
-    have δ₂ : 0 ≤ ekm1 ^ 2 * (a * c) - ekm2 * ek * b ^ 2 := by nlinarith [h_ih_km1]
-    have hU : 0 ≤ ek ^ 2 - ekm1 * ekp1 := by nlinarith [h_unn_k]
-    have hV : 0 ≤ ekm1 ^ 2 - ekm2 * ek := by nlinarith [h_unn_km1]
-    have hW : 0 ≤ ek * ekm1 - ekm2 * ekp1 := by nlinarith [h_cross]
-    -- Products of excess terms (all non-negative)
-    nlinarith [mul_nonneg δ₁ hV, mul_nonneg δ₂ hU, mul_nonneg δ₁ δ₂,
-               mul_nonneg (mul_nonneg hW hekm2_nn) hekp1_nn,
-               sq_nonneg (ek * ekm1 - ekm2 * ekp1),
-               sq_nonneg ((ek ^ 2 - ekm1 * ekp1) * ekm2 * ekp1),
-               sq_nonneg (ek * ekm1 * c - ekm2 * ekp1 * b),
-               sq_nonneg (ek * ekm1 * d - ekm2 * ekp1 * c),
-               mul_nonneg (by nlinarith [h_c2AD_ge_bdB2] : 0 ≤ c ^ 2 * AD - b * d * B2) hU,
-               mul_nonneg (by nlinarith [h_b2AD_ge_acB2] : 0 ≤ b ^ 2 * AD - a * c * B2) hV,
-               mul_nonneg hek_nn hekm1_nn, mul_nonneg hekm2_nn hekp1_nn,
-               mul_nonneg (mul_nonneg hek_nn hekm1_nn) (mul_nonneg hekm2_nn hekp1_nn)]
+  -- Step 4: the quadratic α·t² + β·t + γ is non-negative for t ≥ 0.
+  -- Case split on the sign of β = 2·ek·ekm1·AD − (ek·ekm1 + ekm2·ekp1)·B2:
+  -- for β ≥ 0 all coefficients are non-negative; for β ≤ 0 the discriminant
+  -- inequality 4αγ ≥ β² holds (newton_disc_of_beta_nonpos — it is genuinely
+  -- FALSE without the β ≤ 0 restriction, which is why no nlinarith hint list
+  -- could ever close the former unconditional `hdisc` goal).
+  have h_quad : (ekm1 ^ 2 * AD - ekm2 * ek * B2) * t ^ 2 +
+      (2 * ek * ekm1 * AD - (ek * ekm1 + ekm2 * ekp1) * B2) * t +
+      (ek ^ 2 * AD - ekm1 * ekp1 * B2) ≥ 0 := by
+    by_cases hbsign : 0 ≤ 2 * ek * ekm1 * AD - (ek * ekm1 + ekm2 * ekp1) * B2
+    · -- β ≥ 0: every coefficient of the quadratic is non-negative
+      have h1t : 0 ≤ (ekm1 ^ 2 * AD - ekm2 * ek * B2) * t ^ 2 :=
+        mul_nonneg (by linarith [hα]) (sq_nonneg t)
+      have h2t : 0 ≤ (2 * ek * ekm1 * AD - (ek * ekm1 + ekm2 * ekp1) * B2) * t :=
+        mul_nonneg hbsign ht_nn
+      have h3t : 0 ≤ ek ^ 2 * AD - ekm1 * ekp1 * B2 := by linarith [hγ]
+      linarith
+    · -- β < 0: discriminant argument
+      push_neg at hbsign
+      -- absorption identities for the level-m binomial coefficients
+      have habs1 : (k : ℝ) * c = ((m : ℝ) - k + 1) * b := by
+        rw [hb_def, hc_def]
+        have h := Nat.choose_succ_right_eq m (k - 1)
+        rw [show k - 1 + 1 = k from by omega,
+            show m - (k - 1) = m - k + 1 from by omega] at h
+        have h' := congr_arg (Nat.cast : ℕ → ℝ) h
+        push_cast at h' ⊢
+        rw [Nat.cast_sub (show k ≤ m by omega)] at h'
+        linarith
+      have habs2 : ((k : ℝ) + 1) * d = (((m : ℝ) - k + 1) - 1) * c := by
+        rw [hc_def, hd_def]
+        have h := Nat.choose_succ_right_eq m k
+        have h' := congr_arg (Nat.cast : ℕ → ℝ) h
+        push_cast at h' ⊢
+        rw [Nat.cast_sub (show k ≤ m by omega)] at h'
+        linarith
+      have habs3 : (((m : ℝ) - k + 1) + 1) * a = ((k : ℝ) - 1) * b := by
+        rw [ha_def, hb_def]
+        have h := Nat.choose_succ_right_eq m (k - 2)
+        rw [show k - 2 + 1 = k - 1 from by omega,
+            show m - (k - 2) = m - k + 2 from by omega] at h
+        have h' := congr_arg (Nat.cast : ℕ → ℝ) h
+        push_cast at h' ⊢
+        rw [Nat.cast_sub (show 1 ≤ k by omega), Nat.cast_sub (show k ≤ m by omega),
+            Nat.cast_one] at h'
+        linarith
+      have hk2R : (2 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk
+      have hr2R : (2 : ℝ) ≤ (m : ℝ) - k + 1 := by
+        have h : (k : ℝ) + 1 ≤ (m : ℝ) := by exact_mod_cast hm_eq
+        linarith
+      have hdisc := newton_disc_of_beta_nonpos (k : ℝ) ((m : ℝ) - k + 1) a b c d
+        hk2R hr2R ha_pos hb_pos hc_pos hd_pos habs1 habs2 habs3
+        ekm2 ekm1 ek ekp1 hekm2_nn hekm1_nn hek_nn hekp1_nn
+        h_ih_k h_ih_km1 h_cross
+        (by rw [← hAD_def, ← hB2_def]; linarith)
+      rw [← hAD_def, ← hB2_def] at hdisc
+      exact quadratic_nonneg
+        (ekm1 ^ 2 * AD - ekm2 * ek * B2)
+        (2 * ek * ekm1 * AD - (ek * ekm1 + ekm2 * ekp1) * B2)
+        (ek ^ 2 * AD - ekm1 * ekp1 * B2)
+        t ht_nn (by linarith [hα]) (by linarith [hγ]) (by linarith [hdisc])
   --
-  -- Step 5: Apply quadratic_nonneg and connect to goal
-  have h_quad := quadratic_nonneg
-    (ekm1 ^ 2 * AD - ekm2 * ek * B2)
-    (2 * ek * ekm1 * AD - (ek * ekm1 + ekm2 * ekp1) * B2)
-    (ek ^ 2 * AD - ekm1 * ekp1 * B2)
-    t ht_nn (by linarith [hα]) (by linarith [hγ]) hdisc
+  -- Step 5: connect the quadratic to the goal
   -- Ring identity: LHS - RHS = α·t² + β·t + γ
   have h_ring : (ek + t * ekm1) ^ 2 * AD - (ekm1 + t * ekm2) * (ekp1 + t * ek) * B2 =
       (ekm1 ^ 2 * AD - ekm2 * ek * B2) * t ^ 2 +

--- a/proofs/Proofs/AmgmInequalityOQ02OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ03.lean
@@ -27,7 +27,6 @@ References:
   Maclaurin, C. (1729): Original derivation
 -/
 
-import Proofs.AmgmInequalityOQ02Defs
 import Proofs.AmgmInequalityOQ02
 import Proofs.AmgmInequalityOQ02OQ02
 

--- a/proofs/Proofs/AmgmInequalityOQ02OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ03.lean
@@ -165,7 +165,7 @@ theorem power_inequality (k : ℕ) (hkn : k + 1 ≤ n)
         calc normElemSymm (k + 1) x ^ (2 * (k + 1))
             = (normElemSymm (k + 1) x ^ 2) ^ (k + 1) := by rw [pow_mul]
           _ ≥ (normElemSymm k x * normElemSymm (k + 2) x) ^ (k + 1) := by
-              apply pow_le_pow_left (mul_nonneg hak hak2) hlc
+              apply pow_le_pow_left₀ (mul_nonneg hak hak2) hlc
       -- Expand the RHS
       rw [mul_pow] at hlc_pow
       -- From IH: a_k^{k+1} ≥ a_{k+1}^k

--- a/proofs/Proofs/AmgmInequalityOQ02OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ03.lean
@@ -68,7 +68,7 @@ private lemma normElemSymm_zero_succ (m : ℕ) (x : Fin n → ℝ)
   have h_terms : ∀ s ∈ (Finset.univ : Finset (Fin n)).powersetCard m,
       ∏ i ∈ s, x i = 0 := by
     intro s hs
-    have h_le := Finset.single_le_sum
+    have h_le := Finset.single_le_sum (f := fun s => ∏ i ∈ s, x i)
       (fun t _ => Finset.prod_nonneg fun i _ => hx i) hs
     have h_ge := Finset.prod_nonneg (s := s) fun i _ => hx i
     linarith
@@ -135,7 +135,8 @@ theorem power_inequality (k : ℕ) (hkn : k + 1 ≤ n)
     by_cases hak1_pos : normElemSymm (k + 1) x = 0
     · -- Case: a_{k+1} = 0
       -- From LC: 0 ≥ a_k * a_{k+2}, so a_k = 0 or a_{k+2} = 0
-      have : normElemSymm k x * normElemSymm (k + 2) x ≤ 0 := by linarith [hlc, hak1_pos]
+      have : normElemSymm k x * normElemSymm (k + 2) x ≤ 0 := by
+        nlinarith [hlc, hak1_pos]
       have : normElemSymm k x * normElemSymm (k + 2) x = 0 := by
         linarith [mul_nonneg hak hak2]
       have hak2_zero : normElemSymm (k + 2) x = 0 := by
@@ -158,9 +159,6 @@ theorem power_inequality (k : ℕ) (hkn : k + 1 ≤ n)
       -- Raise LC to (k+1)-th power
       have hlc_pow : normElemSymm (k + 1) x ^ (2 * (k + 1)) ≥
           (normElemSymm k x * normElemSymm (k + 2) x) ^ (k + 1) := by
-        have : normElemSymm (k + 1) x ^ 2 ^ (k + 1) ≤
-            normElemSymm (k + 1) x ^ (2 * (k + 1)) := by
-          rw [pow_mul]
         calc normElemSymm (k + 1) x ^ (2 * (k + 1))
             = (normElemSymm (k + 1) x ^ 2) ^ (k + 1) := by rw [pow_mul]
           _ ≥ (normElemSymm k x * normElemSymm (k + 2) x) ^ (k + 1) := by

--- a/proofs/Proofs/AmgmInequalityOQ02OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ03.lean
@@ -30,7 +30,7 @@ References:
 import Proofs.AmgmInequalityOQ02
 import Proofs.AmgmInequalityOQ02OQ02
 
-open Finset Real AmgmInequalityOQ02
+open Finset Real
 
 namespace AmgmInequalityOQ02OQ03
 
@@ -66,7 +66,7 @@ private lemma normElemSymm_zero_succ (m : ℕ) (x : Fin n → ℝ)
   unfold elemSymm at h_elem ⊢
   -- Each m-subset product is 0 (non-negative sum = 0 implies each term = 0)
   have h_terms : ∀ s ∈ (Finset.univ : Finset (Fin n)).powersetCard m,
-      ∏ i in s, x i = 0 := by
+      ∏ i ∈ s, x i = 0 := by
     intro s hs
     have h_le := Finset.single_le_sum
       (fun t _ => Finset.prod_nonneg fun i _ => hx i) hs
@@ -116,7 +116,7 @@ theorem power_inequality (k : ℕ) (hkn : k + 1 ≤ n)
   | succ k ih =>
     -- ih : a_k^{k+1} ≥ a_{k+1}^k (under appropriate hypotheses)
     have hkn' : k + 1 ≤ n := by omega
-    have ih_applied := ih hkn' x hx
+    have ih_applied := ih hkn'
     -- Newton's log-concavity at k+1: a_{k+1}² ≥ a_k · a_{k+2}
     have hlc := newton_lc (k + 1) (by omega) hkn x hx
     simp only [show k + 1 - 1 = k from by omega] at hlc
@@ -210,8 +210,15 @@ theorem maclaurin_step_from_newton (k : ℕ) (hk : 0 < k) (hkn : k + 1 ≤ n)
   have hkk1_pos : (0 : ℝ) < k * (k + 1) := by positivity
   -- (a_k^{k+1})^{1/(k(k+1))} = a_k^{(k+1)/(k(k+1))} = a_k^{1/k}
   -- (a_{k+1}^k)^{1/(k(k+1))} = a_{k+1}^{k/(k(k+1))} = a_{k+1}^{1/(k+1)}
-  have h_exp1 : (1 : ℝ) / k = (↑(k + 1)) / (↑k * (↑k + 1)) := by field_simp
-  have h_exp2 : (1 : ℝ) / (k + 1) = (↑k) / (↑k * (↑k + 1)) := by field_simp
+  have h_exp1 : (1 : ℝ) / k = (↑(k + 1)) / (↑k * (↑k + 1)) := by
+    rw [div_eq_div_iff hk_pos.ne' hkk1_pos.ne']
+    push_cast
+    ring
+  have h_exp2 : (1 : ℝ) / (↑(k + 1) : ℝ) = (↑k) / (↑k * (↑k + 1)) := by
+    rw [div_eq_div_iff (by exact_mod_cast Nat.succ_pos k : (0 : ℝ) < (↑(k + 1) : ℝ)).ne'
+      hkk1_pos.ne']
+    push_cast
+    ring
   rw [show elemSymm k x / (↑(Nat.choose n k) : ℝ) = normElemSymm k x from rfl,
       show elemSymm (k + 1) x / (↑(Nat.choose n (k + 1)) : ℝ) = normElemSymm (k + 1) x from rfl]
   rw [h_exp1, h_exp2]

--- a/proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean
@@ -1,0 +1,80 @@
+/-
+# Full Maclaurin Chain, Axiom-Free: M₁ ≥ M₂ ≥ ... ≥ Mₙ
+
+## Open Question: amgm-inequality-oq-02-oq-03-oq-03-oq-02
+
+The Maclaurin inequalities state that for non-negative reals x₁,...,xₙ,
+
+  M₁ ≥ M₂ ≥ ... ≥ Mₙ,   where  Mₖ = (eₖ(x)/C(n,k))^{1/k}.
+
+The parent file `AmgmInequalityOQ02OQ03OQ03.lean` proves this chain, but its
+inductive step is `maclaurin_step` from `AmgmInequalityOQ02.lean`, which is a
+theorem derived from the `newton_log_concavity` **axiom** (line 285 of
+`AmgmInequalityOQ02.lean`).  Consequently the parent chain still transitively
+depends on that axiom.
+
+This file removes the dependency.  It re-proves the identical chain using
+`AmgmInequalityOQ02OQ03.maclaurin_step_proved`, whose Newton log-concavity input
+is `NewtonLogConcavity.newton_log_concavity_proved` — the fully proved,
+axiom-free, 0-sorry version from `AmgmInequalityOQ02OQ02.lean`.  The proof is
+otherwise verbatim the parent's simple induction on the gap `d = k - j`; only the
+step lemma is swapped.  The step lemma handles the zero boundary case (some
+`xᵢ = 0`) via a `by_cases` split, so the chain holds for **all** non-negative
+inputs, not just strictly positive ones.
+
+## Main Results (all axiom-free)
+
+- `maclaurin_chain_aux_proved`: for j > 0 and j + d ≤ n, Mⱼ ≥ Mⱼ₊ₐ (induction on d)
+- `maclaurin_full_chain_proved`: for 0 < j ≤ k ≤ n, Mⱼ ≥ Mₖ
+- `maclaurin_m1_ge_mn_proved`: in particular M₁ ≥ Mₙ (AM ≥ n-th Maclaurin mean)
+
+## Status: VERIFIED (0 axioms)
+
+Whereas the parent `maclaurin_full_chain` reduces to `newton_log_concavity`
+(axiom), `maclaurin_full_chain_proved` reduces to
+`newton_log_concavity_proved` (theorem), so `#print axioms` lists only the
+foundational `propext`/`Classical.choice`/`Quot.sound`.
+-/
+
+import Proofs.AmgmInequalityOQ02OQ03
+import Mathlib.Tactic
+
+open Finset Real AmgmInequalityOQ02 AmgmInequalityOQ02OQ03
+
+namespace AmgmInequalityOQ02OQ03OQ03OQ02
+
+variable {n : ℕ}
+
+/-- Auxiliary: Mⱼ ≥ Mⱼ₊ₐ by induction on the gap `d`, using the axiom-free step
+`maclaurin_step_proved`. -/
+private lemma maclaurin_chain_aux_proved (x : Fin n → ℝ) (hx : ∀ i, 0 ≤ x i)
+    (j : ℕ) (hj : 0 < j) (d : ℕ) (hjn : j + d ≤ n) :
+    maclaurinMean j x ≥ maclaurinMean (j + d) x := by
+  induction d with
+  | zero => simp
+  | succ m ih =>
+    have hjm_le : j + m ≤ n := by omega
+    have hstep : j + m + 1 ≤ n := by omega
+    have hjm_pos : 0 < j + m := by omega
+    calc maclaurinMean j x
+        ≥ maclaurinMean (j + m) x := ih hjm_le
+      _ ≥ maclaurinMean (j + m + 1) x :=
+            maclaurin_step_proved (j + m) hjm_pos hstep x hx
+
+/-- **Full Maclaurin Chain (axiom-free)**: for 0 < j ≤ k ≤ n, the j-th Maclaurin
+mean dominates the k-th.  Identical statement to the parent's
+`maclaurin_full_chain`, but with no dependence on the `newton_log_concavity`
+axiom. -/
+theorem maclaurin_full_chain_proved (x : Fin n → ℝ) (hx : ∀ i, 0 ≤ x i)
+    (j k : ℕ) (hj : 0 < j) (hjk : j ≤ k) (hkn : k ≤ n) :
+    maclaurinMean j x ≥ maclaurinMean k x := by
+  obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hjk
+  exact maclaurin_chain_aux_proved x hx j hj d (by omega)
+
+/-- **M₁ ≥ Mₙ (axiom-free)**: the arithmetic mean dominates the n-th Maclaurin
+mean, for all non-negative inputs. -/
+theorem maclaurin_m1_ge_mn_proved (hn : 1 ≤ n) (x : Fin n → ℝ) (hx : ∀ i, 0 ≤ x i) :
+    maclaurinMean 1 x ≥ maclaurinMean n x :=
+  maclaurin_full_chain_proved x hx 1 n Nat.one_pos hn (le_refl n)
+
+end AmgmInequalityOQ02OQ03OQ03OQ02

--- a/proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean
@@ -39,7 +39,7 @@ foundational `propext`/`Classical.choice`/`Quot.sound`.
 import Proofs.AmgmInequalityOQ02OQ03
 import Mathlib.Tactic
 
-open Finset Real AmgmInequalityOQ02 AmgmInequalityOQ02OQ03
+open Finset Real AmgmInequalityOQ02OQ03
 
 namespace AmgmInequalityOQ02OQ03OQ03OQ02
 

--- a/proofs/Proofs/NewtonInductiveStep.lean
+++ b/proofs/Proofs/NewtonInductiveStep.lean
@@ -151,34 +151,155 @@ theorem binom_ineq (m k : ℕ) (hk : 2 ≤ k) (hkm : k + 1 ≤ m) :
     2 * (k : ℝ) * (r ^ 2 - 1) * key3 -
     (k : ℝ) ^ 2 * (r + 1) * key2
 
-set_option maxHeartbeats 1600000 in
-/-- Discriminant inequality `4·α·γ ≥ β²` for the normalized-Newton inductive step,
-    valid whenever the linear coefficient `β = 2·e₃·e₂·AD − (e₃e₂+e₁e₄)·B2` is
-    non-positive (the case where the discriminant is actually needed; for `β ≥ 0`
-    the quadratic `α·t² + β·t + γ` is trivially non-negative for `t ≥ 0`).
+set_option maxHeartbeats 800000 in
+/-- **Core discriminant inequality (normalized form)** for the normalized-Newton
+    inductive step, valid whenever the linear coefficient
+    `β̂ = (kr−k−r−1)·e₂e₃ − (k+1)(r+1)·e₁e₄` is non-positive (which is the only
+    case in which the discriminant is needed: for `β ≥ 0` the quadratic
+    `α·t² + β·t + γ` is trivially non-negative for `t ≥ 0`).
 
-    Here `a b c d` are (casts of) the binomial coefficients `C(m,k−2), …, C(m,k+1)`,
-    abstracted via the absorption identities `h1, h2, h3` (with `r = m−k+1`), and
-    `e1 e2 e3 e4` are the elementary symmetric values `e_{k−2}(y), …, e_{k+1}(y)`.
-    The hypotheses `hd1, hd2` are the normalized-Newton inductive hypotheses in
-    cleared form, and `hcross` is the unnormalized cross-product inequality.
+    Here `e1 e2 e3 e4` stand for `e_{k−2}(y), …, e_{k+1}(y)` and the binomial
+    structure has been normalized away via the absorption identities (with
+    `r = m−k+1`): `hP1`/`hP2` are the two normalized-Newton inductive hypotheses
+    and `hcross` the cross-product inequality.
 
-    The proof rests on the exact algebraic identity (verified by `ring` after
-    eliminating `a, c, d` via the absorption identities): with
-    `δ₁ = e₃²bd − e₂e₄c²`, `δ₂ = e₂²ac − e₁e₃b²`, `g = (k−1)(r−1)`,
-    `S = δ₂e₃²bd + δ₁e₁e₃b²`, `R = 2abcd·e₂²e₃² − gS`,
+    The proof is the exact algebraic certificate (verified by `ring`): with
+    `α̂ = kr·e₂² − (k+1)(r+1)e₁e₃`, `γ̂ = kr·e₃² − (k+1)(r+1)e₂e₄`,
+    `P̂₁ = k(r−1)e₃² − r(k+1)e₂e₄`, `P̂₂ = (k−1)r·e₂² − k(r+1)e₁e₃`,
+    `Ŝ = (r−1)P̂₂e₃² + (r+1)P̂₁e₁e₃`,
 
-    `((k+1)(r+1))²·a²b⁴c⁴d²·e₂²e₃²·(4αγ − β²)
-       = 2(k−1)(2k+r+1)·(c+b)⁴·ab⁴c³d²·δ₂·e₂²e₃⁴
-       + 2(r−1)(2r+k+1)·(c+b)⁴·a²b³c⁴d·δ₁·e₂⁴e₃²
-       + 2g(2kr+2k+2r+1)·(c+b)⁴·ab³c³d·δ₁δ₂·e₂²e₃²
-       + (c+b)⁴·b²c²·(gS)·R`,
+    `kr·e₂²e₃²·(4α̂γ̂ − β̂²)
+       = 2k(2k+r+1)·P̂₂·e₂²e₃⁴ + 2r(k+2r+1)·P̂₁·e₂⁴e₃²
+       + 2(2kr+2k+2r+1)·P̂₁P̂₂·e₂²e₃² + k·Ŝ·e₂e₃·(−β̂)`,
 
-    where every summand on the right is non-negative: `δ₁, δ₂ ≥ 0` by hypothesis,
-    `S ≥ 0` termwise, and `R ≥ 0` because `R·(c+b)² = (−β)·e₂e₃·(k+1)(r+1)·abcd`
-    (a second exact identity) and `β ≤ 0`. Equality holds exactly at geometric
-    data (all inputs equal), which is why no slack-based `nlinarith` hint list
-    could close this goal. -/
+    in which every summand is visibly non-negative (the last one because
+    `β̂ ≤ 0`). Equality holds exactly at geometric data (all inputs equal), which
+    is why no slack-based `nlinarith` hint list could close this goal, and the
+    inequality is genuinely FALSE without the `β̂ ≤ 0` restriction. -/
+theorem newton_disc_hat (k r : ℝ) (hk : 2 ≤ k) (hr : 2 ≤ r)
+    (e1 e2 e3 e4 : ℝ) (he1 : 0 ≤ e1) (he2 : 0 ≤ e2) (he3 : 0 ≤ e3) (he4 : 0 ≤ e4)
+    (hP1 : 0 ≤ k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4))
+    (hP2 : 0 ≤ (k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3))
+    (hcross : e1 * e4 ≤ e3 * e2)
+    (hbeta : (k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4) ≤ 0) :
+    ((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4)) ^ 2 ≤
+      4 * (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) *
+        (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) := by
+  have hk0 : (0 : ℝ) < k := by linarith
+  have hr0 : (0 : ℝ) < r := by linarith
+  have hk1 : (0 : ℝ) < k + 1 := by linarith
+  have hr1 : (0 : ℝ) < r + 1 := by linarith
+  -- Degenerate case: e2·e3 = 0 forces both sides to vanish.
+  rcases eq_or_lt_of_le (mul_nonneg he2 he3) with h23 | h23
+  · have h14 : e1 * e4 = 0 :=
+      le_antisymm (by linarith [hcross]) (mul_nonneg he1 he4)
+    rcases mul_eq_zero.mp h23.symm with h20 | h30
+    · -- e2 = 0: hP2 forces e1·e3 = 0, so both sides vanish
+      have h22 : (k - 1) * r * e2 ^ 2 = 0 := by rw [h20]; ring
+      have h13 : e1 * e3 = 0 := by
+        rcases eq_or_lt_of_le (mul_nonneg he1 he3) with h | h
+        · exact h.symm
+        · exfalso
+          have := mul_pos (mul_pos hk0 hr1) h
+          linarith [hP2, h22]
+      have hL : ((k * r - k - r - 1) * (e2 * e3) -
+          (k + 1) * (r + 1) * (e1 * e4)) ^ 2 = 0 := by
+        rw [h20, h14]; ring
+      have hR : (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) = 0 := by
+        rw [h20, h13]; ring
+      have hR0 : 0 ≤ 4 * (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) *
+          (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) := by
+        rw [hR]; simp
+      linarith [hL, hR0]
+    · -- e3 = 0: hP1 forces e2·e4 = 0, so both sides vanish
+      have h33 : k * (r - 1) * e3 ^ 2 = 0 := by rw [h30]; ring
+      have h24 : e2 * e4 = 0 := by
+        rcases eq_or_lt_of_le (mul_nonneg he2 he4) with h | h
+        · exact h.symm
+        · exfalso
+          have := mul_pos (mul_pos hr0 hk1) h
+          linarith [hP1, h33]
+      have hL : ((k * r - k - r - 1) * (e2 * e3) -
+          (k + 1) * (r + 1) * (e1 * e4)) ^ 2 = 0 := by
+        rw [h30, h14]; ring
+      have hR : (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) = 0 := by
+        rw [h30, h24]; ring
+      have hR0 : 0 ≤ 4 * (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) *
+          (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) := by
+        rw [hR]; simp
+      linarith [hL, hR0]
+  · -- Main case: e2, e3 > 0.
+    have he2' : 0 < e2 := by
+      rcases eq_or_lt_of_le he2 with h | h
+      · exfalso; nlinarith [h23]
+      · exact h
+    have he3' : 0 < e3 := by
+      rcases eq_or_lt_of_le he3 with h | h
+      · exfalso; nlinarith [h23]
+      · exact h
+    -- The exact certificate.
+    have master : k * r * (e2 ^ 2 * e3 ^ 2) *
+        (4 * (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) *
+            (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) -
+          ((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4)) ^ 2) =
+        2 * k * (2 * k + r + 1) *
+            ((k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3)) * (e2 ^ 2 * e3 ^ 4) +
+          2 * r * (k + 2 * r + 1) *
+            (k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4)) * (e2 ^ 4 * e3 ^ 2) +
+          2 * (2 * k * r + 2 * k + 2 * r + 1) *
+            ((k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4)) *
+              ((k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3))) * (e2 ^ 2 * e3 ^ 2) +
+          k * ((r - 1) * ((k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3)) * e3 ^ 2 +
+              (r + 1) * (k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4)) * (e1 * e3)) *
+            (e2 * e3) *
+            (-((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4))) := by
+      ring
+    -- Every right-hand summand is non-negative.
+    have hT1 : 0 ≤ 2 * k * (2 * k + r + 1) *
+        ((k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3)) * (e2 ^ 2 * e3 ^ 4) :=
+      mul_nonneg (mul_nonneg (by positivity) hP2) (by positivity)
+    have hT2 : 0 ≤ 2 * r * (k + 2 * r + 1) *
+        (k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4)) * (e2 ^ 4 * e3 ^ 2) :=
+      mul_nonneg (mul_nonneg (by positivity) hP1) (by positivity)
+    have hT3 : 0 ≤ 2 * (2 * k * r + 2 * k + 2 * r + 1) *
+        ((k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4)) *
+          ((k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3))) * (e2 ^ 2 * e3 ^ 2) :=
+      mul_nonneg (mul_nonneg (by positivity) (mul_nonneg hP1 hP2)) (by positivity)
+    have hS : 0 ≤ (r - 1) * ((k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3)) * e3 ^ 2 +
+        (r + 1) * (k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4)) * (e1 * e3) :=
+      add_nonneg
+        (mul_nonneg (mul_nonneg (by linarith) hP2) (sq_nonneg e3))
+        (mul_nonneg (mul_nonneg (by linarith) hP1) (mul_nonneg he1 he3))
+    have hT4 : 0 ≤ k * ((r - 1) * ((k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3)) * e3 ^ 2 +
+          (r + 1) * (k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4)) * (e1 * e3)) *
+        (e2 * e3) *
+        (-((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4))) :=
+      mul_nonneg (mul_nonneg (mul_nonneg hk0.le hS) (mul_nonneg he2 he3))
+        (neg_nonneg.mpr hbeta)
+    have hkey : 0 ≤ k * r * (e2 ^ 2 * e3 ^ 2) *
+        (4 * (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) *
+            (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) -
+          ((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4)) ^ 2) := by
+      rw [master]
+      linarith [hT1, hT2, hT3, hT4]
+    have hpref : 0 < k * r * (e2 ^ 2 * e3 ^ 2) := by positivity
+    by_contra hcon
+    push_neg at hcon
+    have hneg : 4 * (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) *
+        (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) -
+        ((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4)) ^ 2 < 0 := by
+      linarith
+    have := mul_neg_of_pos_of_neg hpref hneg
+    linarith [hkey]
+
+/-- Discriminant inequality `4·α·γ ≥ β²` for the normalized-Newton inductive
+    step at the cleared-denominator (binomial) level, valid when
+    `β = 2·e₃e₂·AD − (e₃e₂+e₁e₄)·B2 ≤ 0` (with `AD = (b+a)(d+c)`,
+    `B2 = (c+b)²`). Reduces to `newton_disc_hat` via the absorption identities
+    `h1, h2, h3` (where `a b c d` are the binomial coefficients
+    `C(m,k−2), …, C(m,k+1)` and `r = m−k+1`), using the exact ratio identity
+    `(k+1)(r+1)·AD = kr·B2` for the Pascal-combined level-(m+1) coefficients. -/
+set_option maxHeartbeats 800000 in
 theorem newton_disc_of_beta_nonpos
     (k r a b c d : ℝ) (hk : 2 ≤ k) (hr : 2 ≤ r)
     (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) (hd : 0 < d)
@@ -195,190 +316,100 @@ theorem newton_disc_of_beta_nonpos
   have hr0 : (0 : ℝ) < r := by linarith
   have hk1 : (0 : ℝ) < k + 1 := by linarith
   have hr1 : (0 : ℝ) < r + 1 := by linarith
-  have hkm1 : (0 : ℝ) ≤ k - 1 := by linarith
-  have hrm1 : (0 : ℝ) ≤ r - 1 := by linarith
   have hb2 : (0 : ℝ) < b ^ 2 := by positivity
   have hc2 : (0 : ℝ) < c ^ 2 := by positivity
-  -- Degenerate case: e2·e3 = 0 forces both sides to vanish.
-  rcases eq_or_lt_of_le (mul_nonneg he2 he3) with h23 | h23
-  · have h14 : e1 * e4 = 0 :=
-      le_antisymm (by linarith [hcross]) (mul_nonneg he1 he4)
-    rcases mul_eq_zero.mp h23.symm with h20 | h30
-    · -- e2 = 0: from hd2, e1·e3·b² ≤ 0, so e1·e3 = 0 and both sides vanish
-      have h22 : e2 ^ 2 * (a * c) = 0 := by rw [h20]; ring
-      have h13 : e1 * e3 = 0 := by
-        rcases eq_or_lt_of_le (mul_nonneg he1 he3) with h | h
-        · exact h.symm
-        · exfalso; nlinarith [mul_pos h hb2, hd2, h22]
-      have hLHS0 : 4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
-          (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) = 0 := by
-        rw [h20, h13]; ring
-      have hRHS0 : (2 * e3 * e2 * ((b + a) * (d + c)) -
-          (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2 = 0 := by
-        rw [h20, h14]; ring
-      linarith [hLHS0, hRHS0]
-    · -- e3 = 0: from hd1, e2·e4·c² ≤ 0, so e2·e4 = 0 and both sides vanish
-      have h33 : e3 ^ 2 * (b * d) = 0 := by rw [h30]; ring
-      have h24 : e2 * e4 = 0 := by
-        rcases eq_or_lt_of_le (mul_nonneg he2 he4) with h | h
-        · exact h.symm
-        · exfalso; nlinarith [mul_pos h hc2, hd1, h33]
-      have hLHS0 : 4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
-          (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) = 0 := by
-        rw [h30, h24]; ring
-      have hRHS0 : (2 * e3 * e2 * ((b + a) * (d + c)) -
-          (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2 = 0 := by
-        rw [h30, h14]; ring
-      linarith [hLHS0, hRHS0]
-  · -- Main case: e2, e3 > 0.
-    have he2' : 0 < e2 := by
-      rcases eq_or_lt_of_le he2 with h | h
-      · exfalso; nlinarith [h23]
-      · exact h
-    have he3' : 0 < e3 := by
-      rcases eq_or_lt_of_le he3 with h | h
-      · exfalso; nlinarith [h23]
-      · exact h
-    -- Eliminate a, c, d via the absorption identities.
-    have hc' : c = r * b / k := by
-      rw [eq_div_iff hk0.ne']
-      linear_combination h1
-    have hd' : d = (r - 1) * c / (k + 1) := by
-      rw [eq_div_iff hk1.ne']
-      linear_combination h2
-    have ha' : a = (k - 1) * b / (r + 1) := by
-      rw [eq_div_iff hr1.ne']
-      linear_combination h3
-    -- The exact identity R·(c+b)² = (−β)·e₂e₃·(k+1)(r+1)·abcd.
-    have hfact3 :
-        (2 * (a * b * c * d) * (e2 ^ 2 * e3 ^ 2) -
-            (k - 1) * (r - 1) *
-              ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
-                (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) * (c + b) ^ 2 =
-          ((e3 * e2 + e1 * e4) * (c + b) ^ 2 - 2 * e3 * e2 * ((b + a) * (d + c))) *
-            (e2 * e3 * ((k + 1) * (r + 1)) * (a * b * c * d)) := by
-      rw [ha', hd', hc']
-      field_simp [hk0.ne', hk1.ne', hr1.ne']
-      ring
-    -- R ≥ 0 (from β ≤ 0).
-    have hR : 0 ≤ 2 * (a * b * c * d) * (e2 ^ 2 * e3 ^ 2) -
-        (k - 1) * (r - 1) *
-          ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
-            (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2)) := by
-      have hrhs : 0 ≤ ((e3 * e2 + e1 * e4) * (c + b) ^ 2 -
-          2 * e3 * e2 * ((b + a) * (d + c))) *
-            (e2 * e3 * ((k + 1) * (r + 1)) * (a * b * c * d)) := by
-        apply mul_nonneg (by linarith)
-        have h : (0 : ℝ) < e2 * e3 * ((k + 1) * (r + 1)) * (a * b * c * d) := by positivity
-        exact h.le
-      by_contra hcon
-      push_neg at hcon
-      have hcb : (0 : ℝ) < (c + b) ^ 2 := by positivity
-      have hlt := mul_neg_of_neg_of_pos hcon hcb
-      rw [hfact3] at hlt
-      linarith
-    -- S ≥ 0 termwise.
-    have hd1' : 0 ≤ e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2 := by linarith
-    have hd2' : 0 ≤ e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2 := by linarith
-    have hS : 0 ≤ (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
-        (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2) :=
-      add_nonneg
-        (mul_nonneg hd2' (mul_nonneg (sq_nonneg e3) (mul_pos hb hd).le))
-        (mul_nonneg hd1' (mul_nonneg (mul_nonneg he1 he3) (sq_nonneg b)))
-    -- The master identity.
-    have master :
-        ((k + 1) * (r + 1)) ^ 2 * (a ^ 2 * b ^ 4 * c ^ 4 * d ^ 2) * (e2 ^ 2 * e3 ^ 2) *
-          (4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
-              (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) -
-            (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2) =
-        2 * (k - 1) * (2 * k + r + 1) * (c + b) ^ 4 * (a * b ^ 4 * c ^ 3 * d ^ 2) *
-            (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e2 ^ 2 * e3 ^ 4) +
-          2 * (r - 1) * (2 * r + k + 1) * (c + b) ^ 4 * (a ^ 2 * b ^ 3 * c ^ 4 * d) *
-            (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e2 ^ 4 * e3 ^ 2) +
-          2 * ((k - 1) * (r - 1)) * (2 * k * r + 2 * k + 2 * r + 1) * (c + b) ^ 4 *
-            (a * b ^ 3 * c ^ 3 * d) *
-            ((e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2)) *
-            (e2 ^ 2 * e3 ^ 2) +
-          (c + b) ^ 4 * (b ^ 2 * c ^ 2) *
-            ((k - 1) * (r - 1) *
-              ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
-                (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) *
-            (2 * (a * b * c * d) * (e2 ^ 2 * e3 ^ 2) -
-              (k - 1) * (r - 1) *
-                ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
-                  (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) := by
-      rw [ha', hd', hc']
-      field_simp [hk0.ne', hk1.ne', hr1.ne']
-      ring
-    -- Each right-hand summand is non-negative.
-    have hcb4 : (0 : ℝ) < (c + b) ^ 4 := by positivity
-    have hpos1 : 0 ≤ 2 * (k - 1) * (2 * k + r + 1) * (c + b) ^ 4 *
-        (a * b ^ 4 * c ^ 3 * d ^ 2) * (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) *
-        (e2 ^ 2 * e3 ^ 4) := by
-      have h1' : 0 ≤ 2 * (k - 1) * (2 * k + r + 1) := by
-        have := mul_nonneg hkm1 (show (0 : ℝ) ≤ 2 * k + r + 1 by linarith)
-        linarith
-      have h2' : (0 : ℝ) ≤ a * b ^ 4 * c ^ 3 * d ^ 2 := by positivity
-      have h3' : (0 : ℝ) ≤ e2 ^ 2 * e3 ^ 4 := by positivity
-      exact mul_nonneg (mul_nonneg (mul_nonneg (mul_nonneg h1' hcb4.le) h2') hd2') h3'
-    have hpos2 : 0 ≤ 2 * (r - 1) * (2 * r + k + 1) * (c + b) ^ 4 *
-        (a ^ 2 * b ^ 3 * c ^ 4 * d) * (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) *
-        (e2 ^ 4 * e3 ^ 2) := by
-      have h1' : 0 ≤ 2 * (r - 1) * (2 * r + k + 1) := by
-        have := mul_nonneg hrm1 (show (0 : ℝ) ≤ 2 * r + k + 1 by linarith)
-        linarith
-      have h2' : (0 : ℝ) ≤ a ^ 2 * b ^ 3 * c ^ 4 * d := by positivity
-      have h3' : (0 : ℝ) ≤ e2 ^ 4 * e3 ^ 2 := by positivity
-      exact mul_nonneg (mul_nonneg (mul_nonneg (mul_nonneg h1' hcb4.le) h2') hd1') h3'
-    have hpos3 : 0 ≤ 2 * ((k - 1) * (r - 1)) * (2 * k * r + 2 * k + 2 * r + 1) *
-        (c + b) ^ 4 * (a * b ^ 3 * c ^ 3 * d) *
-        ((e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2)) *
-        (e2 ^ 2 * e3 ^ 2) := by
-      have h1' : 0 ≤ 2 * ((k - 1) * (r - 1)) * (2 * k * r + 2 * k + 2 * r + 1) := by
-        have hg := mul_nonneg hkm1 hrm1
-        have hlin : (0 : ℝ) ≤ 2 * k * r + 2 * k + 2 * r + 1 := by
-          have := mul_pos hk0 hr0
-          nlinarith
-        have := mul_nonneg hg hlin
-        linarith
-      have h2' : (0 : ℝ) ≤ a * b ^ 3 * c ^ 3 * d := by positivity
-      have h3' : (0 : ℝ) ≤ e2 ^ 2 * e3 ^ 2 := by positivity
-      exact mul_nonneg (mul_nonneg (mul_nonneg (mul_nonneg h1' hcb4.le) h2')
-        (mul_nonneg hd1' hd2')) h3'
-    have hpos4 : 0 ≤ (c + b) ^ 4 * (b ^ 2 * c ^ 2) *
-        ((k - 1) * (r - 1) *
-          ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
-            (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) *
-        (2 * (a * b * c * d) * (e2 ^ 2 * e3 ^ 2) -
-          (k - 1) * (r - 1) *
-            ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
-              (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) := by
-      have h1' : (0 : ℝ) ≤ (c + b) ^ 4 * (b ^ 2 * c ^ 2) := by positivity
-      exact mul_nonneg (mul_nonneg h1'
-        (mul_nonneg (mul_nonneg hkm1 hrm1) hS)) hR
-    -- Assemble and divide by the positive prefactor.
-    have hkey : 0 ≤ ((k + 1) * (r + 1)) ^ 2 * (a ^ 2 * b ^ 4 * c ^ 4 * d ^ 2) *
-        (e2 ^ 2 * e3 ^ 2) *
-        (4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
-            (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) -
-          (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2) := by
-      rw [master]
-      have := add_nonneg (add_nonneg (add_nonneg hpos1 hpos2) hpos3) hpos4
-      linarith
-    have hpref : 0 < ((k + 1) * (r + 1)) ^ 2 * (a ^ 2 * b ^ 4 * c ^ 4 * d ^ 2) *
-        (e2 ^ 2 * e3 ^ 2) := by
-      have h1' : (0 : ℝ) < (k + 1) * (r + 1) := mul_pos hk1 hr1
-      have h2' : (0 : ℝ) < a ^ 2 * b ^ 4 * c ^ 4 * d ^ 2 := by positivity
-      have h3' : (0 : ℝ) < e2 ^ 2 * e3 ^ 2 := by positivity
-      exact mul_pos (mul_pos (pow_pos h1' 2) h2') h3'
+  have hB2 : (0 : ℝ) < (c + b) ^ 2 := by positivity
+  -- Conversion identities from the absorption relations.
+  have hbd : k * (r - 1) * c ^ 2 = r * (k + 1) * (b * d) := by
+    linear_combination (r - 1) * c * h1 - r * b * h2
+  have hac : (k - 1) * r * b ^ 2 = k * (r + 1) * (a * c) := by
+    linear_combination (-((k - 1) * b)) * h1 - k * c * h3
+  have hAD : (k + 1) * (r + 1) * ((b + a) * (d + c)) = k * r * ((c + b) ^ 2) := by
+    linear_combination (a * r + a + b - c * r) * h1 + ((a + b) * (r + 1)) * h2 +
+      (r * (b + c)) * h3
+  -- Hypothesis conversions to the normalized form.
+  have hP1c : (k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4)) * c ^ 2 =
+      r * (k + 1) * (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) := by
+    linear_combination e3 ^ 2 * hbd
+  have hP1 : 0 ≤ k * (r - 1) * e3 ^ 2 - r * (k + 1) * (e2 * e4) := by
     by_contra hcon
     push_neg at hcon
-    have hneg : 4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
-        (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) -
-        (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2 < 0 := by
-      linarith
-    have := mul_neg_of_pos_of_neg hpref hneg
+    have hlt := mul_neg_of_neg_of_pos hcon hc2
+    rw [hP1c] at hlt
+    have h0 : 0 ≤ r * (k + 1) * (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) :=
+      mul_nonneg (by positivity) (by linarith [hd1])
     linarith
+  have hP2b : ((k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3)) * b ^ 2 =
+      k * (r + 1) * (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) := by
+    linear_combination e2 ^ 2 * hac
+  have hP2 : 0 ≤ (k - 1) * r * e2 ^ 2 - k * (r + 1) * (e1 * e3) := by
+    by_contra hcon
+    push_neg at hcon
+    have hlt := mul_neg_of_neg_of_pos hcon hb2
+    rw [hP2b] at hlt
+    have h0 : 0 ≤ k * (r + 1) * (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) :=
+      mul_nonneg (by positivity) (by linarith [hd2])
+    linarith
+  -- β conversion.
+  have hbe : ((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4)) *
+      (c + b) ^ 2 =
+      (k + 1) * (r + 1) *
+        (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) := by
+    linear_combination (-(2 * (e2 * e3))) * hAD
+  have hbehat : (k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4) ≤ 0 := by
+    by_contra hcon
+    push_neg at hcon
+    have hgt := mul_pos hcon hB2
+    rw [hbe] at hgt
+    have h0 : 0 ≤ (k + 1) * (r + 1) *
+        ((e3 * e2 + e1 * e4) * (c + b) ^ 2 - 2 * e3 * e2 * ((b + a) * (d + c))) :=
+      mul_nonneg (by positivity) (by linarith)
+    linarith
+  -- Core inequality in normalized form.
+  have hat := newton_disc_hat k r hk hr e1 e2 e3 e4 he1 he2 he3 he4 hP1 hP2 hcross hbehat
+  -- Convert the conclusion back.
+  have hal : (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) * (c + b) ^ 2 =
+      (k + 1) * (r + 1) * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) := by
+    linear_combination (-(e2 ^ 2)) * hAD
+  have hga : (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) * (c + b) ^ 2 =
+      (k + 1) * (r + 1) * (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) := by
+    linear_combination (-(e3 ^ 2)) * hAD
+  have hconv : ((c + b) ^ 2) ^ 2 *
+      (4 * (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) *
+          (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) -
+        ((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4)) ^ 2) =
+      ((k + 1) * (r + 1)) ^ 2 *
+      (4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
+          (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) -
+        (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2) := by
+    linear_combination
+      (4 * (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) * (c + b) ^ 2) * hal +
+      (4 * ((k + 1) * (r + 1)) *
+        (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2)) * hga +
+      (-(((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4)) * (c + b) ^ 2 +
+        (k + 1) * (r + 1) *
+          (2 * e3 * e2 * ((b + a) * (d + c)) -
+            (e3 * e2 + e1 * e4) * (c + b) ^ 2))) * hbe
+  have hhatpos : 0 ≤ 4 * (k * r * e2 ^ 2 - (k + 1) * (r + 1) * (e1 * e3)) *
+      (k * r * e3 ^ 2 - (k + 1) * (r + 1) * (e2 * e4)) -
+      ((k * r - k - r - 1) * (e2 * e3) - (k + 1) * (r + 1) * (e1 * e4)) ^ 2 := by
+    linarith [hat]
+  have hfin : 0 ≤ ((k + 1) * (r + 1)) ^ 2 *
+      (4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
+          (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) -
+        (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2) := by
+    rw [← hconv]
+    exact mul_nonneg (sq_nonneg _) hhatpos
+  have hD2 : (0 : ℝ) < ((k + 1) * (r + 1)) ^ 2 := by positivity
+  by_contra hcon
+  push_neg at hcon
+  have hneg : 4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
+      (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) -
+      (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2 < 0 := by
+    linarith
+  have := mul_neg_of_pos_of_neg hD2 hneg
+  linarith [hfin]
+
 
 /-- Dual binomial inequality: b²·(b+a)·(d+c) ≥ a·c·(c+b)².
     Companion to `binom_ineq`, needed for the `α ≥ 0` branch of the

--- a/proofs/Proofs/NewtonInductiveStep.lean
+++ b/proofs/Proofs/NewtonInductiveStep.lean
@@ -258,7 +258,7 @@ theorem newton_disc_of_beta_nonpos
           ((e3 * e2 + e1 * e4) * (c + b) ^ 2 - 2 * e3 * e2 * ((b + a) * (d + c))) *
             (e2 * e3 * ((k + 1) * (r + 1)) * (a * b * c * d)) := by
       rw [ha', hd', hc']
-      field_simp
+      field_simp [hk0.ne', hk1.ne', hr1.ne']
       ring
     -- R ≥ 0 (from β ≤ 0).
     have hR : 0 ≤ 2 * (a * b * c * d) * (e2 ^ 2 * e3 ^ 2) -
@@ -308,7 +308,7 @@ theorem newton_disc_of_beta_nonpos
                 ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
                   (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) := by
       rw [ha', hd', hc']
-      field_simp
+      field_simp [hk0.ne', hk1.ne', hr1.ne']
       ring
     -- Each right-hand summand is non-negative.
     have hcb4 : (0 : ℝ) < (c + b) ^ 4 := by positivity

--- a/proofs/Proofs/NewtonInductiveStep.lean
+++ b/proofs/Proofs/NewtonInductiveStep.lean
@@ -151,6 +151,235 @@ theorem binom_ineq (m k : ℕ) (hk : 2 ≤ k) (hkm : k + 1 ≤ m) :
     2 * (k : ℝ) * (r ^ 2 - 1) * key3 -
     (k : ℝ) ^ 2 * (r + 1) * key2
 
+set_option maxHeartbeats 1600000 in
+/-- Discriminant inequality `4·α·γ ≥ β²` for the normalized-Newton inductive step,
+    valid whenever the linear coefficient `β = 2·e₃·e₂·AD − (e₃e₂+e₁e₄)·B2` is
+    non-positive (the case where the discriminant is actually needed; for `β ≥ 0`
+    the quadratic `α·t² + β·t + γ` is trivially non-negative for `t ≥ 0`).
+
+    Here `a b c d` are (casts of) the binomial coefficients `C(m,k−2), …, C(m,k+1)`,
+    abstracted via the absorption identities `h1, h2, h3` (with `r = m−k+1`), and
+    `e1 e2 e3 e4` are the elementary symmetric values `e_{k−2}(y), …, e_{k+1}(y)`.
+    The hypotheses `hd1, hd2` are the normalized-Newton inductive hypotheses in
+    cleared form, and `hcross` is the unnormalized cross-product inequality.
+
+    The proof rests on the exact algebraic identity (verified by `ring` after
+    eliminating `a, c, d` via the absorption identities): with
+    `δ₁ = e₃²bd − e₂e₄c²`, `δ₂ = e₂²ac − e₁e₃b²`, `g = (k−1)(r−1)`,
+    `S = δ₂e₃²bd + δ₁e₁e₃b²`, `R = 2abcd·e₂²e₃² − gS`,
+
+    `((k+1)(r+1))²·a²b⁴c⁴d²·e₂²e₃²·(4αγ − β²)
+       = 2(k−1)(2k+r+1)·(c+b)⁴·ab⁴c³d²·δ₂·e₂²e₃⁴
+       + 2(r−1)(2r+k+1)·(c+b)⁴·a²b³c⁴d·δ₁·e₂⁴e₃²
+       + 2g(2kr+2k+2r+1)·(c+b)⁴·ab³c³d·δ₁δ₂·e₂²e₃²
+       + (c+b)⁴·b²c²·(gS)·R`,
+
+    where every summand on the right is non-negative: `δ₁, δ₂ ≥ 0` by hypothesis,
+    `S ≥ 0` termwise, and `R ≥ 0` because `R·(c+b)² = (−β)·e₂e₃·(k+1)(r+1)·abcd`
+    (a second exact identity) and `β ≤ 0`. Equality holds exactly at geometric
+    data (all inputs equal), which is why no slack-based `nlinarith` hint list
+    could close this goal. -/
+theorem newton_disc_of_beta_nonpos
+    (k r a b c d : ℝ) (hk : 2 ≤ k) (hr : 2 ≤ r)
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) (hd : 0 < d)
+    (h1 : k * c = r * b) (h2 : (k + 1) * d = (r - 1) * c) (h3 : (r + 1) * a = (k - 1) * b)
+    (e1 e2 e3 e4 : ℝ) (he1 : 0 ≤ e1) (he2 : 0 ≤ e2) (he3 : 0 ≤ e3) (he4 : 0 ≤ e4)
+    (hd1 : e3 ^ 2 * (b * d) ≥ e2 * e4 * c ^ 2)
+    (hd2 : e2 ^ 2 * (a * c) ≥ e1 * e3 * b ^ 2)
+    (hcross : e3 * e2 ≥ e1 * e4)
+    (hbeta : 2 * e3 * e2 * ((b + a) * (d + c)) ≤ (e3 * e2 + e1 * e4) * (c + b) ^ 2) :
+    4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
+      (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) ≥
+    (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2 := by
+  have hk0 : (0 : ℝ) < k := by linarith
+  have hr0 : (0 : ℝ) < r := by linarith
+  have hk1 : (0 : ℝ) < k + 1 := by linarith
+  have hr1 : (0 : ℝ) < r + 1 := by linarith
+  have hkm1 : (0 : ℝ) ≤ k - 1 := by linarith
+  have hrm1 : (0 : ℝ) ≤ r - 1 := by linarith
+  have hb2 : (0 : ℝ) < b ^ 2 := by positivity
+  have hc2 : (0 : ℝ) < c ^ 2 := by positivity
+  -- Degenerate case: e2·e3 = 0 forces both sides to vanish.
+  rcases eq_or_lt_of_le (mul_nonneg he2 he3) with h23 | h23
+  · have h14 : e1 * e4 = 0 :=
+      le_antisymm (by linarith [hcross]) (mul_nonneg he1 he4)
+    rcases mul_eq_zero.mp h23.symm with h20 | h30
+    · -- e2 = 0: from hd2, e1·e3·b² ≤ 0, so e1·e3 = 0 and both sides vanish
+      have h22 : e2 ^ 2 * (a * c) = 0 := by rw [h20]; ring
+      have h13 : e1 * e3 = 0 := by
+        rcases eq_or_lt_of_le (mul_nonneg he1 he3) with h | h
+        · exact h.symm
+        · exfalso; nlinarith [mul_pos h hb2, hd2, h22]
+      have hLHS0 : 4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
+          (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) = 0 := by
+        rw [h20, h13]; ring
+      have hRHS0 : (2 * e3 * e2 * ((b + a) * (d + c)) -
+          (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2 = 0 := by
+        rw [h20, h14]; ring
+      linarith [hLHS0, hRHS0]
+    · -- e3 = 0: from hd1, e2·e4·c² ≤ 0, so e2·e4 = 0 and both sides vanish
+      have h33 : e3 ^ 2 * (b * d) = 0 := by rw [h30]; ring
+      have h24 : e2 * e4 = 0 := by
+        rcases eq_or_lt_of_le (mul_nonneg he2 he4) with h | h
+        · exact h.symm
+        · exfalso; nlinarith [mul_pos h hc2, hd1, h33]
+      have hLHS0 : 4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
+          (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) = 0 := by
+        rw [h30, h24]; ring
+      have hRHS0 : (2 * e3 * e2 * ((b + a) * (d + c)) -
+          (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2 = 0 := by
+        rw [h30, h14]; ring
+      linarith [hLHS0, hRHS0]
+  · -- Main case: e2, e3 > 0.
+    have he2' : 0 < e2 := by
+      rcases eq_or_lt_of_le he2 with h | h
+      · exfalso; nlinarith [h23]
+      · exact h
+    have he3' : 0 < e3 := by
+      rcases eq_or_lt_of_le he3 with h | h
+      · exfalso; nlinarith [h23]
+      · exact h
+    -- Eliminate a, c, d via the absorption identities.
+    have hc' : c = r * b / k := by
+      rw [eq_div_iff hk0.ne']
+      linear_combination h1
+    have hd' : d = (r - 1) * c / (k + 1) := by
+      rw [eq_div_iff hk1.ne']
+      linear_combination h2
+    have ha' : a = (k - 1) * b / (r + 1) := by
+      rw [eq_div_iff hr1.ne']
+      linear_combination h3
+    -- The exact identity R·(c+b)² = (−β)·e₂e₃·(k+1)(r+1)·abcd.
+    have hfact3 :
+        (2 * (a * b * c * d) * (e2 ^ 2 * e3 ^ 2) -
+            (k - 1) * (r - 1) *
+              ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
+                (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) * (c + b) ^ 2 =
+          ((e3 * e2 + e1 * e4) * (c + b) ^ 2 - 2 * e3 * e2 * ((b + a) * (d + c))) *
+            (e2 * e3 * ((k + 1) * (r + 1)) * (a * b * c * d)) := by
+      rw [ha', hd', hc']
+      field_simp
+      ring
+    -- R ≥ 0 (from β ≤ 0).
+    have hR : 0 ≤ 2 * (a * b * c * d) * (e2 ^ 2 * e3 ^ 2) -
+        (k - 1) * (r - 1) *
+          ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
+            (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2)) := by
+      have hrhs : 0 ≤ ((e3 * e2 + e1 * e4) * (c + b) ^ 2 -
+          2 * e3 * e2 * ((b + a) * (d + c))) *
+            (e2 * e3 * ((k + 1) * (r + 1)) * (a * b * c * d)) := by
+        apply mul_nonneg (by linarith)
+        have h : (0 : ℝ) < e2 * e3 * ((k + 1) * (r + 1)) * (a * b * c * d) := by positivity
+        exact h.le
+      by_contra hcon
+      push_neg at hcon
+      have hcb : (0 : ℝ) < (c + b) ^ 2 := by positivity
+      have hlt := mul_neg_of_neg_of_pos hcon hcb
+      rw [hfact3] at hlt
+      linarith
+    -- S ≥ 0 termwise.
+    have hd1' : 0 ≤ e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2 := by linarith
+    have hd2' : 0 ≤ e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2 := by linarith
+    have hS : 0 ≤ (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
+        (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2) :=
+      add_nonneg
+        (mul_nonneg hd2' (mul_nonneg (sq_nonneg e3) (mul_pos hb hd).le))
+        (mul_nonneg hd1' (mul_nonneg (mul_nonneg he1 he3) (sq_nonneg b)))
+    -- The master identity.
+    have master :
+        ((k + 1) * (r + 1)) ^ 2 * (a ^ 2 * b ^ 4 * c ^ 4 * d ^ 2) * (e2 ^ 2 * e3 ^ 2) *
+          (4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
+              (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) -
+            (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2) =
+        2 * (k - 1) * (2 * k + r + 1) * (c + b) ^ 4 * (a * b ^ 4 * c ^ 3 * d ^ 2) *
+            (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e2 ^ 2 * e3 ^ 4) +
+          2 * (r - 1) * (2 * r + k + 1) * (c + b) ^ 4 * (a ^ 2 * b ^ 3 * c ^ 4 * d) *
+            (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e2 ^ 4 * e3 ^ 2) +
+          2 * ((k - 1) * (r - 1)) * (2 * k * r + 2 * k + 2 * r + 1) * (c + b) ^ 4 *
+            (a * b ^ 3 * c ^ 3 * d) *
+            ((e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2)) *
+            (e2 ^ 2 * e3 ^ 2) +
+          (c + b) ^ 4 * (b ^ 2 * c ^ 2) *
+            ((k - 1) * (r - 1) *
+              ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
+                (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) *
+            (2 * (a * b * c * d) * (e2 ^ 2 * e3 ^ 2) -
+              (k - 1) * (r - 1) *
+                ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
+                  (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) := by
+      rw [ha', hd', hc']
+      field_simp
+      ring
+    -- Each right-hand summand is non-negative.
+    have hcb4 : (0 : ℝ) < (c + b) ^ 4 := by positivity
+    have hpos1 : 0 ≤ 2 * (k - 1) * (2 * k + r + 1) * (c + b) ^ 4 *
+        (a * b ^ 4 * c ^ 3 * d ^ 2) * (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) *
+        (e2 ^ 2 * e3 ^ 4) := by
+      have h1' : 0 ≤ 2 * (k - 1) * (2 * k + r + 1) := by
+        have := mul_nonneg hkm1 (show (0 : ℝ) ≤ 2 * k + r + 1 by linarith)
+        linarith
+      have h2' : (0 : ℝ) ≤ a * b ^ 4 * c ^ 3 * d ^ 2 := by positivity
+      have h3' : (0 : ℝ) ≤ e2 ^ 2 * e3 ^ 4 := by positivity
+      exact mul_nonneg (mul_nonneg (mul_nonneg (mul_nonneg h1' hcb4.le) h2') hd2') h3'
+    have hpos2 : 0 ≤ 2 * (r - 1) * (2 * r + k + 1) * (c + b) ^ 4 *
+        (a ^ 2 * b ^ 3 * c ^ 4 * d) * (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) *
+        (e2 ^ 4 * e3 ^ 2) := by
+      have h1' : 0 ≤ 2 * (r - 1) * (2 * r + k + 1) := by
+        have := mul_nonneg hrm1 (show (0 : ℝ) ≤ 2 * r + k + 1 by linarith)
+        linarith
+      have h2' : (0 : ℝ) ≤ a ^ 2 * b ^ 3 * c ^ 4 * d := by positivity
+      have h3' : (0 : ℝ) ≤ e2 ^ 4 * e3 ^ 2 := by positivity
+      exact mul_nonneg (mul_nonneg (mul_nonneg (mul_nonneg h1' hcb4.le) h2') hd1') h3'
+    have hpos3 : 0 ≤ 2 * ((k - 1) * (r - 1)) * (2 * k * r + 2 * k + 2 * r + 1) *
+        (c + b) ^ 4 * (a * b ^ 3 * c ^ 3 * d) *
+        ((e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2)) *
+        (e2 ^ 2 * e3 ^ 2) := by
+      have h1' : 0 ≤ 2 * ((k - 1) * (r - 1)) * (2 * k * r + 2 * k + 2 * r + 1) := by
+        have hg := mul_nonneg hkm1 hrm1
+        have hlin : (0 : ℝ) ≤ 2 * k * r + 2 * k + 2 * r + 1 := by
+          have := mul_pos hk0 hr0
+          nlinarith
+        have := mul_nonneg hg hlin
+        linarith
+      have h2' : (0 : ℝ) ≤ a * b ^ 3 * c ^ 3 * d := by positivity
+      have h3' : (0 : ℝ) ≤ e2 ^ 2 * e3 ^ 2 := by positivity
+      exact mul_nonneg (mul_nonneg (mul_nonneg (mul_nonneg h1' hcb4.le) h2')
+        (mul_nonneg hd1' hd2')) h3'
+    have hpos4 : 0 ≤ (c + b) ^ 4 * (b ^ 2 * c ^ 2) *
+        ((k - 1) * (r - 1) *
+          ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
+            (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) *
+        (2 * (a * b * c * d) * (e2 ^ 2 * e3 ^ 2) -
+          (k - 1) * (r - 1) *
+            ((e2 ^ 2 * (a * c) - e1 * e3 * b ^ 2) * (e3 ^ 2 * (b * d)) +
+              (e3 ^ 2 * (b * d) - e2 * e4 * c ^ 2) * (e1 * e3 * b ^ 2))) := by
+      have h1' : (0 : ℝ) ≤ (c + b) ^ 4 * (b ^ 2 * c ^ 2) := by positivity
+      exact mul_nonneg (mul_nonneg h1'
+        (mul_nonneg (mul_nonneg hkm1 hrm1) hS)) hR
+    -- Assemble and divide by the positive prefactor.
+    have hkey : 0 ≤ ((k + 1) * (r + 1)) ^ 2 * (a ^ 2 * b ^ 4 * c ^ 4 * d ^ 2) *
+        (e2 ^ 2 * e3 ^ 2) *
+        (4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
+            (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) -
+          (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2) := by
+      rw [master]
+      have := add_nonneg (add_nonneg (add_nonneg hpos1 hpos2) hpos3) hpos4
+      linarith
+    have hpref : 0 < ((k + 1) * (r + 1)) ^ 2 * (a ^ 2 * b ^ 4 * c ^ 4 * d ^ 2) *
+        (e2 ^ 2 * e3 ^ 2) := by
+      have h1' : (0 : ℝ) < (k + 1) * (r + 1) := mul_pos hk1 hr1
+      have h2' : (0 : ℝ) < a ^ 2 * b ^ 4 * c ^ 4 * d ^ 2 := by positivity
+      have h3' : (0 : ℝ) < e2 ^ 2 * e3 ^ 2 := by positivity
+      exact mul_pos (mul_pos (pow_pos h1' 2) h2') h3'
+    by_contra hcon
+    push_neg at hcon
+    have hneg : 4 * (e2 ^ 2 * ((b + a) * (d + c)) - e1 * e3 * (c + b) ^ 2) *
+        (e3 ^ 2 * ((b + a) * (d + c)) - e2 * e4 * (c + b) ^ 2) -
+        (2 * e3 * e2 * ((b + a) * (d + c)) - (e3 * e2 + e1 * e4) * (c + b) ^ 2) ^ 2 < 0 := by
+      linarith
+    have := mul_neg_of_pos_of_neg hpref hneg
+    linarith
+
 /-- Dual binomial inequality: b²·(b+a)·(d+c) ≥ a·c·(c+b)².
     Companion to `binom_ineq`, needed for the `α ≥ 0` branch of the
     normalized-Newton inductive step. Proved by the same absorption technique:

--- a/proofs/Proofs/NewtonInductiveStep.lean
+++ b/proofs/Proofs/NewtonInductiveStep.lean
@@ -292,6 +292,7 @@ theorem newton_disc_hat (k r : ℝ) (hk : 2 ≤ k) (hr : 2 ≤ r)
     have := mul_neg_of_pos_of_neg hpref hneg
     linarith [hkey]
 
+set_option maxHeartbeats 800000 in
 /-- Discriminant inequality `4·α·γ ≥ β²` for the normalized-Newton inductive
     step at the cleared-denominator (binomial) level, valid when
     `β = 2·e₃e₂·AD − (e₃e₂+e₁e₄)·B2 ≤ 0` (with `AD = (b+a)(d+c)`,
@@ -299,7 +300,6 @@ theorem newton_disc_hat (k r : ℝ) (hk : 2 ≤ k) (hr : 2 ≤ r)
     `h1, h2, h3` (where `a b c d` are the binomial coefficients
     `C(m,k−2), …, C(m,k+1)` and `r = m−k+1`), using the exact ratio identity
     `(k+1)(r+1)·AD = kr·B2` for the Pascal-combined level-(m+1) coefficients. -/
-set_option maxHeartbeats 800000 in
 theorem newton_disc_of_beta_nonpos
     (k r a b c d : ℝ) (hk : 2 ≤ k) (hr : 2 ≤ r)
     (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) (hd : 0 < d)

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -53,7 +53,7 @@
       "**Binomial log-concavity as a key lemma**: The normalized Newton inequality differs from the unnormalized one by the binomial coefficients. The fact that binomial coefficients themselves are log-concave ($\\binom{n}{k}^2 \\ge \\binom{n}{k-1} \\cdot \\binom{n}{k+1}$, Part III) ensures the normalized form follows from the unnormalized one without additional complications. The binomial log-concavity proof uses the explicit identity $\\binom{n}{k}^2 - \\binom{n}{k-1} \\binom{n}{k+1} = \\binom{n}{k}^2 \\cdot (1 - \\frac{(k+1)(n-k+1)}{k(n-k)})$ and is itself a clean instance of a discrete log-concavity argument.",
       "**rpow transfer for Maclaurin**: The Maclaurin step requires taking $k$-th and $(k+1)$-th roots, which in Lean are `Real.rpow`. The proof first establishes $a_k^{k+1} \\ge a_{k+1}^k$ as a `Nat`-power inequality (cleaner type-theoretically, no `rpow` framing), then transfers to real exponents via `rpow_ineq_of_pow_ineq` using `Real.rpow_natCast` and `Real.rpow_le_rpow` monotonicity. This natural-power-first strategy is reusable: any inequality of the form $a^p \\ge b^q$ with $p, q \\in \\mathbb{N}$ can be proved in `Nat`/`pow` and then transferred to reals.",
       "**Schur-concavity as a unifying frame**: The Newton-Maclaurin inequalities are corollaries of the *Schur-concavity* of $e_k$ on the non-negative orthant (Marshall-Olkin majorization theory). This file's proof is *self-contained* — it does not invoke majorization theory — but the same structural reason underlies it: $e_k$ is symmetric and concave-along-line-segments-preserving-the-AM, which forces the log-concavity inequality. A future Mathlib refactoring could unify Newton-Maclaurin with the general Schur-concavity framework once that framework lands.",
-      "**Two axioms eliminated, AM ≥ GM now closed**: Before this file, `AmgmInequalityOQ02.lean` had two axioms (`newton_log_concavity` and `maclaurin_step`) that any reader had to take on faith. After this file, both are theorems with explicit constructive proofs, and the entire chain $M_1 \\ge M_2 \\ge \\cdots \\ge M_n$ — including its famous corollary AM ≥ GM — is verified end-to-end with no remaining assumptions beyond Lean's standard library and Mathlib. This is a complete formalization of Newton-Maclaurin in 959 + parent lines."
+      "**Two axioms eliminated, AM ≥ GM now closed**: Before this file, `AmgmInequalityOQ02.lean` had two axioms (`newton_log_concavity` and `maclaurin_step`) that any reader had to take on faith. After this file, both are theorems with explicit constructive proofs, and the entire chain $M_1 \\ge M_2 \\ge \\cdots \\ge M_n$ — including its famous corollary AM ≥ GM — is verified end-to-end with no remaining assumptions beyond Lean's standard library and Mathlib. This is a complete formalization of Newton-Maclaurin in 999 + parent lines."
     ],
     "prerequisites": [
       "Elementary symmetric polynomials",
@@ -78,14 +78,21 @@
       "note": "First complete proof of Newton's inequalities, with the extension to the now-named Maclaurin chain $M_1 \\ge M_2 \\ge \\cdots \\ge M_n$ of normalized means. The chain endpoints AM ($M_1$) and GM ($M_n$) make it a classical route to AM-GM."
     },
     {
-      "authors": ["Hardy, G. H.", "Littlewood, J. E.", "Pólya, G."],
+      "authors": [
+        "Hardy, G. H.",
+        "Littlewood, J. E.",
+        "Pólya, G."
+      ],
       "title": "Inequalities",
       "year": "1934",
       "venue": "Cambridge University Press",
       "note": "Canonical 20th-century treatment. Theorem 51 (page 52) states Newton's inequality and Theorem 52 the Maclaurin chain. Chapter II §2.18 connects Newton-Maclaurin to Muirhead's inequalities and Schur-convexity via the Marshall-Olkin majorization order."
     },
     {
-      "authors": ["Niculescu, Constantin P.", "Persson, Lars-Erik"],
+      "authors": [
+        "Niculescu, Constantin P.",
+        "Persson, Lars-Erik"
+      ],
       "title": "Convex Functions and Their Applications: A Contemporary Approach",
       "year": "2018",
       "venue": "Springer (CMS Books in Mathematics, 2nd ed.)",
@@ -162,7 +169,7 @@
       "Proofs.NewtonInductiveStep"
     ],
     "namespace": "NewtonLogConcavity",
-    "lineCount": 959,
+    "lineCount": 999,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 1,
@@ -209,15 +216,15 @@
       "id": "sec-amgm-oq02-oq02-cleared",
       "title": "Parts IV–V: Cleared-Denominator Induction",
       "startLine": 395,
-      "endLine": 810,
+      "endLine": 850,
       "summary": "`newton_cleared_denom_inductive_step`: the key inductive step (520-line proof) via absorption + discriminant argument. `newton_cleared_denom`: full cleared-denominator Newton inequality by induction on $n$.",
       "mathContext": "Cleared-denominator form: $\\binom{n}{k-1}\\binom{n}{k+1} \\cdot e_k^2 \\ge \\binom{n}{k}^2 \\cdot e_{k-1} \\cdot e_{k+1}$. This is equivalent to the normalized Newton inequality without divisions."
     },
     {
       "id": "sec-amgm-oq02-oq02-normalized",
       "title": "Parts VI–VIII: Normalized Newton and Maclaurin Step",
-      "startLine": 811,
-      "endLine": 959,
+      "startLine": 851,
+      "endLine": 999,
       "summary": "`newton_log_concavity_proved`: normalized Newton $(e_k/\\binom{n}{k})^2 \\ge (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$. `power_ineq_of_log_concave` and `rpow_ineq_of_pow_ineq`: transfer to real exponents. `maclaurin_step_derived`: $M_k \\ge M_{k+1}$.",
       "mathContext": "Maclaurin's step: $M_k = \\left(\\frac{e_k}{\\binom{n}{k}}\\right)^{1/k} \\ge M_{k+1}$. The decreasing chain $M_1 \\ge M_2 \\ge \\cdots \\ge M_n$ connects AM to GM."
     }

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -55,41 +55,41 @@
     {
       "id": "docstring-imports",
       "title": "Documentation and Imports",
-      "summary": "Module docstring explaining the Maclaurin chain derivation from Newton's log-concavity, the power inequality strategy, and axiom status. Imports the parent AmgmInequalityOQ02 definitions and theorems, plus the shared definitions module AmgmInequalityOQ02Defs.",
+      "summary": "Module docstring explaining the Maclaurin chain derivation from Newton's log-concavity, the power inequality strategy, and axiom status. Imports the parent AmgmInequalityOQ02 definitions and theorems, plus AmgmInequalityOQ02OQ02 (the fully proved Newton log-concavity).",
       "startLine": 1,
-      "endLine": 34
+      "endLine": 33
     },
     {
       "id": "definitions",
       "title": "Normalized ESP Definitions and Helpers",
       "summary": "Defines normElemSymm k x = eₖ/C(n,k), proves normElemSymm_zero = 1, normElemSymm_nonneg ≥ 0, zero propagation (private), and newton_lc (restates newton_log_concavity for normalized inputs).",
-      "startLine": 35,
-      "endLine": 86,
+      "startLine": 34,
+      "endLine": 99,
       "mathContext": "$a_k := e_k/\\binom{n}{k}$; $a_0 = 1$; $a_k \\geq 0$ for non-negative inputs. Zero propagation: $a_m = 0 \\Rightarrow a_{m+1} = 0$ (used as boundary case in the induction). Newton log-concavity: $a_k^2 \\geq a_{k-1} a_{k+1}$."
     },
     {
       "id": "power-inequality",
       "title": "Power Inequality: aₖ^{k+1} ≥ aₖ₊₁^k",
       "summary": "Proves aₖ^{k+1} ≥ aₖ₊₁^k by induction on k. Base: trivial (a₀ = 1). Inductive step: raise Newton's log-concavity to (k+1)-th power, combine with IH to get a_{k+1}^{2(k+1)} ≥ a_{k+1}^k · a_{k+2}^{k+1}, then divide by a_{k+1}^k (or handle zero case via normElemSymm_zero_succ).",
-      "startLine": 88,
-      "endLine": 175,
+      "startLine": 100,
+      "endLine": 186,
       "mathContext": "$a_k^{k+1} \\geq a_{k+1}^k$ where $a_k = e_k/\\binom{n}{k}$. The induction: raise $a_k^2 \\geq a_{k-1} a_{k+1}$ to the $k$-th power, use IH $a_{k-1}^k \\geq a_k^{k-1}$, and cancel. Zero case: if $a_{k+1} = 0$, then $a_{k+2} = 0$ by zero propagation, making the goal trivial."
     },
     {
       "id": "maclaurin-step",
       "title": "Maclaurin Step via rpow Monotonicity",
       "summary": "Derives Mₖ ≥ Mₖ₊₁ from the power inequality by taking the 1/(k(k+1))-th root. Uses rpow_natCast_mul and rpow_le_rpow. Exponent algebra via field_simp: 1/k = (k+1)/(k(k+1)) and 1/(k+1) = k/(k(k+1)).",
-      "startLine": 177,
-      "endLine": 213,
+      "startLine": 187,
+      "endLine": 231,
       "mathContext": "$M_k = a_k^{1/k} = (a_k^{k+1})^{1/(k(k+1))} \\geq (a_{k+1}^k)^{1/(k(k+1))} = a_{k+1}^{1/(k+1)} = M_{k+1}$. Lean: `rpow_natCast_mul` rewrites $(a^n)^r = a^{nr}$; `rpow_le_rpow` applies the monotonicity $a \\leq b \\Rightarrow a^r \\leq b^r$ for non-negative reals."
     },
     {
       "id": "summary",
       "title": "Summary: maclaurin_step Now a Theorem",
-      "summary": "maclaurin_step_proved is a one-line wrapper around maclaurin_step_from_newton, explicitly marking the axiom elimination. The remaining dependency is newton_log_concavity (axiomatized in the parent file).",
-      "startLine": 215,
-      "endLine": 226,
-      "mathContext": "$M_k \\geq M_{k+1}$ for $k \\geq 1$ and non-negative inputs — proved, not assumed. The only remaining axiom is `newton_log_concavity`: $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$."
+      "summary": "maclaurin_step_proved is a one-line wrapper around maclaurin_step_from_newton, explicitly marking the axiom elimination. Newton log-concavity itself is supplied by the proved theorem NewtonLogConcavity.newton_log_concavity_proved (AmgmInequalityOQ02OQ02.lean), so no axiom remains in this chain.",
+      "startLine": 232,
+      "endLine": 242,
+      "mathContext": "$M_k \\geq M_{k+1}$ for $k \\geq 1$ and non-negative inputs — proved, not assumed. Newton's log-concavity input is the proved `newton_log_concavity_proved`: $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$."
     }
   ],
   "conclusion": {
@@ -139,7 +139,7 @@
       "AmgmInequalityOQ02"
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
-    "lineCount": 238,
+    "lineCount": 242,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1,


### PR DESCRIPTION
Closes #35107. Context: #35088 (deferred candidate #13), PR #35098, prior partial work on `feature/issue-35107` (banked via #35114).

## Stage 1 — repair `Proofs/AmgmInequalityOQ02OQ02.lean` (Newton log-concavity)

The blocker was `hdisc : 4αγ ≥ β²` in `newton_cleared_denom_inductive_step`. The builder's analysis on #35107 was right: that statement is **genuinely false** as an unconditional claim under the theorem's hypotheses — no nlinarith hint list could ever close it. The repair is a mathematical re-derivation, not a hint tweak:

- **Case split on the sign of β** (the linear coefficient of the quadratic in `t`). For `β ≥ 0` all three coefficients are non-negative and the quadratic is trivially ≥ 0 for `t ≥ 0` — this covers exactly the configurations where the discriminant fails (e.g. `e_{k+1}(y) = 0` with large `k, r`, where β > 0).
- For `β ≤ 0`, the discriminant inequality **does** hold, with an exact certificate found by normalizing the binomials away via the absorption identities (`r = m−k+1`): with `α̂ = kr·e₂²−(k+1)(r+1)e₁e₃`, `γ̂, β̂, P̂₁, P̂₂` analogous and `Ŝ = (r−1)P̂₂e₃² + (r+1)P̂₁e₁e₃`,

  `kr·e₂²e₃²·(4α̂γ̂−β̂²) = 2k(2k+r+1)P̂₂e₂²e₃⁴ + 2r(k+2r+1)P̂₁e₂⁴e₃² + 2(2kr+2k+2r+1)P̂₁P̂₂e₂²e₃² + k·Ŝ·e₂e₃·(−β̂)`

  — a `ring`-checkable identity (34 monomials) in which every summand is visibly non-negative given `β̂ ≤ 0`. Equality holds exactly at all-equal inputs, which is why the old goal was numerically tight (~1e-3 margins) yet unprovable. Certificate verified independently in sympy (400k-sample check + exact symbolic identity) before transcription.

- New lemmas in `Proofs/NewtonInductiveStep.lean`: `newton_disc_hat` (normalized core) and `newton_disc_of_beta_nonpos` (binomial-level wrapper via small `linear_combination` conversions, including the exact ratio identity `(k+1)(r+1)·AD = kr·B2`). A first single-identity version stack-overflowed Lean (exit 135); the split form elaborates quickly.
- Also applied the two fixes from `feature/issue-35107`: replaced the **false** `h_binom_symm` "ring identity" with `binom_ineq_dual` (already on main via #35114), and the four `set`-blocked `exact_mod_cast Nat.choose_pos` positivity proofs.

**Build:** `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ02` → **exit 0** (7745 jobs).

## Stage 2 — land the deferred amgm candidate

`Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean` (80 LOC, from `origin/research/amgm-oq0203030302-pending`, commit `5e2ae613a38`): the axiom-free full Maclaurin chain `M₁ ≥ M₂ ≥ … ≥ Mₙ` (`maclaurin_full_chain_proved`, `maclaurin_m1_ge_mn_proved`), swapping the parent chain's axiom-derived step for `maclaurin_step_proved`.

Its intermediate dependency `Proofs/AmgmInequalityOQ02OQ03.lean` had additional (previously unsurfaced) v4.26 drift, now fixed: duplicate-symbol import (`AmgmInequalityOQ02Defs` is a strict export-subset of `AmgmInequalityOQ02`), stale `open AmgmInequalityOQ02` (no such namespace), `∏ i in` → `∏ i ∈`, `induction` ih arity change, `Finset.single_le_sum` implicit-`f` inference, a `linarith` goal needing squaring (→ `nlinarith`), cast-coercion drift `↑(k+1)` vs `↑k+1` in the exponent rewrites (`field_simp` → deterministic `div_eq_div_iff` proofs), `pow_le_pow_left` → `pow_le_pow_left₀`, and a vacuous mis-parenthesized `have` deleted.

**Build:** `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ03OQ03OQ02` → **exit 0** (7747 jobs; builds the entire chain `NewtonInductiveStep` → `OQ02OQ02` → `OQ02OQ03` → candidate).

## Honest accounting (Axiom Integrity Policy)

All four touched Lean files (`NewtonInductiveStep`, `AmgmInequalityOQ02OQ02`, `AmgmInequalityOQ02OQ03`, `AmgmInequalityOQ02OQ03OQ03OQ02`):
- **0 `sorry`**, **0 `axiom` declarations**, **0 `native_decide`**, no structure-encoded assumptions (all hypotheses are ordinary theorem arguments discharged at call sites).
- The parent `AmgmInequalityOQ02.lean` (untouched) retains its two historical `axiom`s, but nothing in this chain uses them — the chain routes through `newton_log_concavity_proved`.
- No statement weakening: `newton_cleared_denom_inductive_step`, `newton_cleared_denom`, `newton_log_concavity_proved`, `maclaurin_step_derived` keep their exact original statements.
- Gallery meta for `amgm-inequality-oq-02-oq-02` / `oq-02-oq-03` synced (line counts, section ranges, stale "remaining axiom" text corrected; `verified`/`original`/0/0 status unchanged and now again accurate).

Post-merge: `origin/research/amgm-oq0203030302-pending` can be deleted (tombstone process per #35088).

🤖 Generated with [Claude Code](https://claude.com/claude-code)