### PR TITLE
research(erdos-1003-oq-03): recover upper-density (limsup) layer from stale PR #31611 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1003OQ03.lean
+++ b/proofs/Proofs/Erdos1003OQ03.lean
@@ -35,6 +35,15 @@ exact logical relationships that pin down what an eventual answer must supply.
      infinite worlds, and any *positive* density is equivalent to a strong form of
      the open #1003 conjecture.
 
+  5. **The upper density is the unconditional carrier**: the natural-density
+     *limit* may fail to exist (existence is itself open), but the upper density
+     `upperDensity = limsup_N count(N)/(N+1)` always exists for our bounded
+     sequence.  We show it lies in `[0,1]`, agrees with the natural density when
+     the latter exists, vanishes on finite solution sets, and — most usefully —
+     that a *positive upper density* already forces infinitude
+     (`infinite_of_pos_upperDensity`).  This strengthens (3): one no longer needs
+     the limit to exist, only its limsup to be positive.
+
 These are fully machine-checked (0 sorry, 0 axiom) consequences of the
 definitions.  The definitions agree verbatim with the parent #1003 entry
 (`Proofs.Erdos1003Problem`) and the sibling OQ-02 file.
@@ -45,6 +54,7 @@ Reference: https://erdosproblems.com/1003
 import Mathlib.Data.Nat.Totient
 import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Topology.Algebra.Order.LiminfLimsup
 
 open Nat Set Filter Topology
 
@@ -225,5 +235,70 @@ theorem oq03_answer_constraints :
   ⟨fun _ _ => hasNaturalDensity_unique,
    fun _ => hasNaturalDensity_mem_Icc,
    fun _ => pos_density_count_unbounded⟩
+
+/-! ## Upper density (the unconditional object)
+
+The natural-density *limit* may fail to exist (its existence is itself open).
+The *upper density* — the `limsup` of the same ratios — always exists for our
+bounded sequence and is the right unconditional carrier of OQ-03.
+Recovered from PR #31611. -/
+
+/-- The upper density of the solution set: the `limsup` of the counting ratios
+`count(N)/(N+1)`.  Unlike the natural density, this always exists (the sequence
+is bounded in `[0,1]`). -/
+noncomputable def upperDensity : ℝ :=
+  limsup (fun N : ℕ => (countConsecutiveEqual N : ℝ) / (N + 1)) atTop
+
+/-- The ratio sequence is bounded above (by `1`); used to feed the `limsup`
+order lemmas. -/
+theorem isBoundedUnder_ratio :
+    IsBoundedUnder (· ≤ ·) atTop
+      (fun N : ℕ => (countConsecutiveEqual N : ℝ) / (N + 1)) :=
+  ⟨1, Filter.eventually_map.mpr (by filter_upwards with N using density_ratio_le_one N)⟩
+
+/-- The ratio sequence is cobounded above (witness `0`, since it is `≥ 0`); used
+to feed the `limsup` order lemmas. -/
+theorem isCoboundedUnder_ratio :
+    IsCoboundedUnder (· ≤ ·) atTop
+      (fun N : ℕ => (countConsecutiveEqual N : ℝ) / (N + 1)) :=
+  isCoboundedUnder_le_of_le atTop density_ratio_nonneg
+
+/-- The upper density is nonnegative. -/
+theorem upperDensity_nonneg : 0 ≤ upperDensity :=
+  Filter.le_limsup_of_frequently_le
+    (Filter.Frequently.of_forall density_ratio_nonneg) isBoundedUnder_ratio
+
+/-- The upper density never exceeds `1`. -/
+theorem upperDensity_le_one : upperDensity ≤ 1 :=
+  Filter.limsup_le_of_le isCoboundedUnder_ratio
+    (by filter_upwards with N using density_ratio_le_one N)
+
+/-- When the natural density exists it coincides with the upper density (the
+`limsup` of a convergent sequence is its limit). -/
+theorem upperDensity_eq_of_hasNaturalDensity {d : ℝ} (h : HasNaturalDensity d) :
+    upperDensity = d :=
+  h.limsup_eq
+
+/-- If the solution set is finite, its upper density is `0`. -/
+theorem upperDensity_zero_of_finite
+    (hfin : ConsecutiveEqualTotients.Finite) : upperDensity = 0 :=
+  (hasNaturalDensity_zero_of_finite hfin).limsup_eq
+
+/-- A *positive upper density* already forces the solution set to be infinite —
+strengthening `infinite_of_pos_density`, since the upper density always exists
+whereas the natural-density limit may not.  (Proof: a finite set has upper
+density `0`.) -/
+theorem infinite_of_pos_upperDensity (h : 0 < upperDensity) :
+    ConsecutiveEqualTotients.Infinite := by
+  by_contra hfin
+  rw [Set.not_infinite] at hfin
+  rw [upperDensity_zero_of_finite hfin] at h
+  exact lt_irrefl 0 h
+
+-- Axiom audits (expected: propext, Classical.choice, Quot.sound only)
+#print axioms infinite_of_pos_upperDensity
+#print axioms upperDensity_eq_of_hasNaturalDensity
+#print axioms upperDensity_nonneg
+#print axioms upperDensity_le_one
 
 end Erdos1003.OQ03

--- a/src/data/proofs/erdos-1003-oq-03/meta.json
+++ b/src/data/proofs/erdos-1003-oq-03/meta.json
@@ -20,9 +20,9 @@
     "badge": "verified",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 229,
-    "theoremCount": 14,
-    "definitionCount": 3,
+    "lineCount": 304,
+    "theoremCount": 21,
+    "definitionCount": 4,
     "dateAdded": "2026-06-28",
     "assumptions": "0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound, the foundational Lean axioms). Fully machine-verified; no native_decide. Does NOT resolve the open question — it formalizes the logical scaffolding of the density question and its exact relationship to the (open) infinitude conjecture.",
     "originalContributions": [
@@ -34,7 +34,8 @@
       "hasNaturalDensity_unique: the natural density, when it exists, is unique (limits in ℝ are unique; atTop is NeBot). So OQ-03 asks for a well-defined real number, not merely some limit point of the ratios.",
       "hasNaturalDensity_nonneg / hasNaturalDensity_le_one / hasNaturalDensity_mem_Icc: any natural density lies in [0,1] — the density ratio is confined to [0,1] (density_ratio_nonneg / density_ratio_le_one), so its limit is, via ge_of_tendsto' / le_of_tendsto'. An admissible answer to OQ-03 must be a unit-interval real.",
       "pos_density_count_unbounded: a positive density makes the counting function unbounded — threading the density view back to the counting/infinitude view by composing infinite_of_pos_density with infinite_iff_count_unbounded. Contrapositively, while #1003's infinitude is open, no positive density can be exhibited (the counting-function sharpening of infinite_of_pos_density).",
-      "oq03_answer_constraints: bundled summary — any answer d is unique, lies in [0,1], and is positive only if the counting function is unbounded (i.e. the solution set is infinite, the open #1003)."
+      "oq03_answer_constraints: bundled summary — any answer d is unique, lies in [0,1], and is positive only if the counting function is unbounded (i.e. the solution set is infinite, the open #1003).",
+      "infinite_of_pos_upperDensity (with upperDensity := limsup count(N)/(N+1)): a strengthening of infinite_of_pos_density. Since the natural-density LIMIT may fail to exist (its existence is itself part of the open question), the upper density (limsup) is the right unconditional carrier — it always exists for the bounded ratio sequence. We prove it lies in [0,1] (upperDensity_nonneg via le_limsup_of_frequently_le, upperDensity_le_one via the cobounded ratio lemma), coincides with the natural density when the latter exists (upperDensity_eq_of_hasNaturalDensity, the limsup of a convergent sequence), and vanishes on finite solution sets (upperDensity_zero_of_finite). Hence a positive UPPER density already forces infinitude, with no need to assume the limit exists."
     ],
     "mathlibDependencies": [
       {
@@ -56,6 +57,11 @@
         "theorem": "tendsto_nhds_unique",
         "description": "Limits in a Hausdorff space are unique. Turns 'finite ⇒ density 0' into 'positive density ⇒ infinite' by contradiction, and gives uniqueness of the natural density (hasNaturalDensity_unique).",
         "module": "Mathlib.Topology.Separation.Hausdorff"
+      },
+      {
+        "theorem": "Filter.Tendsto.limsup_eq / le_limsup_of_frequently_le / limsup_le_of_le / isCoboundedUnder_le_of_le",
+        "description": "The limsup toolkit for the upper-density layer: the limsup of a convergent sequence is its limit (upperDensity_eq_of_hasNaturalDensity, upperDensity_zero_of_finite), and the frequently/eventually order lemmas with the bounded/cobounded ratio witnesses confine upperDensity to [0,1].",
+        "module": "Mathlib.Order.LiminfLimsup"
       },
       {
         "theorem": "le_of_tendsto' / ge_of_tendsto'",
@@ -129,6 +135,14 @@
       "startLine": 125,
       "endLine": 175,
       "mathContext": "Finite $\\Rightarrow$ density $0$ (squeeze $0 \\le \\text{count}/(N+1) \\le C/(N+1) \\to 0$); density $> 0 \\Rightarrow$ infinite."
+    },
+    {
+      "id": "upper-density",
+      "title": "Upper Density — the Unconditional Object",
+      "summary": "upperDensity := limsup count(N)/(N+1) always exists (bounded sequence), unlike the natural-density limit whose existence is itself open. Proved: upperDensity ∈ [0,1] (upperDensity_nonneg, upperDensity_le_one via the bounded/cobounded ratio lemmas), coincidence with the natural density when it exists (upperDensity_eq_of_hasNaturalDensity), vanishing on finite solution sets (upperDensity_zero_of_finite), and the headline infinite_of_pos_upperDensity: a positive limsup already forces infinitude — strengthening infinite_of_pos_density by removing the limit-existence hypothesis.",
+      "startLine": 239,
+      "endLine": 303,
+      "mathContext": "$\\overline{d} := \\limsup_N \\text{count}(N)/(N+1) \\in [0,1]$ always exists; $\\overline{d} > 0 \\Rightarrow$ infinite; $\\overline{d} = d$ whenever the natural density $d$ exists."
     }
   ],
   "conclusion": {
@@ -136,7 +150,7 @@
     "implications": "**Frames an open question**: locates OQ-03's difficulty precisely — positivity of the density is equivalent to (a strong form of) the open #1003 conjecture, while the conjectured value 0 is the finiteness baseline. **Connects siblings**: the bridge theorem ties the density view to the infinitude view formalized by the parent and OQ-02. **Honest scope**: the analytic Erdős–Pomerance–Sárközy sparsity bound that would establish density exactly 0 is cited as an external input, not claimed.",
     "openQuestions": [
       "Formalize the Erdős–Pomerance–Sárközy upper bound #{n ≤ x : φ(n)=φ(n+1)} ≤ x/exp((log x)^{1/3}), which would give natural density 0 unconditionally (independent of infinitude).",
-      "Is the natural density even known to exist (i.e. does count/(N+1) converge), or only that its limsup is 0? Formalize the upper-density formulation and its relationship to the limit formulation used here."
+      "The upper-density (limsup) formulation and its relationship to the limit formulation is now formalized (upperDensity, infinite_of_pos_upperDensity); it remains open whether the natural density exists at all (does count/(N+1) converge?), and whether upperDensity = 0 unconditionally (which the EPS sparsity bound would give)."
     ]
   },
   "crossReferences": [
@@ -160,7 +174,8 @@
     "imports": [
       "Mathlib.Data.Nat.Totient",
       "Mathlib.Data.Set.Finite.Basic",
-      "Mathlib.Analysis.SpecificLimits.Basic"
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Topology.Algebra.Order.LiminfLimsup"
     ],
     "opens": [
       "Nat",
@@ -169,10 +184,10 @@
       "Topology"
     ],
     "namespace": "Erdos1003.OQ03",
-    "lineCount": 229,
+    "lineCount": 304,
     "axiomCount": 0,
-    "theoremCount": 14,
-    "definitionCount": 3,
+    "theoremCount": 21,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1003OQ03.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Recovers the **upper-density (limsup) layer** of Erdős #1003 OQ-03 from stale conflicting PR #31611. Per-declaration extraction onto a fresh branch from current main — NOT a mechanical rebase (the old branch predates the #31619 admissibility layer that landed in the same file). **Supersedes #31611. Part of the #35118 recovery queue.**

## Ported (8 declarations, all verified absent from main by grep before porting)

| declaration | content |
|---|---|
| `upperDensity` (def) | `limsup_N count(N)/(N+1)` — always exists (bounded sequence), unlike the natural-density limit whose existence is itself open |
| `isBoundedUnder_ratio`, `isCoboundedUnder_ratio` | the order-lemma witnesses for the ratio sequence |
| `upperDensity_nonneg`, `upperDensity_le_one` | upper density lies in `[0,1]` |
| `upperDensity_eq_of_hasNaturalDensity` | coincides with the natural density when the limit exists |
| `upperDensity_zero_of_finite` | finite solution set ⇒ upper density 0 |
| **`infinite_of_pos_upperDensity`** | **positive upper density ⇒ infinite** — strengthens main's `infinite_of_pos_density` by removing the limit-existence hypothesis |

## Dropped, with reasons

- `hasNaturalDensity_unique`, `hasNaturalDensity_mem_Icc` — **already on main** via merged sibling #31619 (identical statements; main's `mem_Icc` is even better factored through `hasNaturalDensity_nonneg`/`hasNaturalDensity_le_one`).
- `src/data/research/problems/erdos-1003-oq-03.json` — stale research-state JSON, skipped per recovery policy.

## Drift fix

- `upperDensity_nonneg`: Mathlib v4.26 changed `Filter.le_limsup_of_le`'s second argument shape; reproved via `Filter.le_limsup_of_frequently_le (Filter.Frequently.of_forall density_ratio_nonneg) isBoundedUnder_ratio`. All other proofs ported verbatim.

## Verification

`LEAN_MEMORY_LIMIT=16384 ./proofs/scripts/docker-build.sh Proofs.Erdos1003OQ03` — **build succeeded** (1662 jobs). `#print axioms` audit lines added on the four headline theorems; all report exactly `[propext, Classical.choice, Quot.sound]`:

```
'Erdos1003.OQ03.infinite_of_pos_upperDensity'      depends on axioms: [propext, Classical.choice, Quot.sound]
'Erdos1003.OQ03.upperDensity_eq_of_hasNaturalDensity' depends on axioms: [propext, Classical.choice, Quot.sound]
'Erdos1003.OQ03.upperDensity_nonneg'               depends on axioms: [propext, Classical.choice, Quot.sound]
'Erdos1003.OQ03.upperDensity_le_one'               depends on axioms: [propext, Classical.choice, Quot.sound]
```

0 sorries, 0 `axiom` declarations, no structure-encoded assumptions, no `native_decide`.

## Gallery meta

`src/data/proofs/erdos-1003-oq-03/meta.json` reconciled in BOTH blocks: `meta.*` and top-level `leanFile.*` (lineCount 229→304, theoremCount 14→21, definitionCount 3→4, new import, new section entry, new originalContributions item, openQuestions updated). Status stays `verified`/`verified`/0/0 — honest per the Axiom Integrity Policy (entry never claims to resolve the open question; EPS sparsity bound remains a cited external input).

## Honesty

Does **NOT** resolve OQ-03; it formalizes the unconditional limsup carrier of the density question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)