### PR TITLE
research: salvage unique content from stale rolling-branch PR #34683

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean
@@ -76,6 +76,34 @@ theorem not_isGδ_of_dense_countable
     [Nonempty X] {D : Set X} (hcount : D.Countable) (hdense : Dense D) : ¬ IsGδ D :=
   (dense_countable_isFσ_and_not_isGδ hcount hdense).2
 
+/-! ### The dual (`Gδ`-only) side and the packaged dichotomy -/
+
+/-- **The complement of a dense countable set is `Gδ` but not `Fσ`** — the dual half of the
+dichotomy.
+
+*`Gδ`*: immediate from `compl_countable_isDenseGδ`. *Not `Fσ`*: were the complement `Fσ`, its
+complement — the original set — would be `Gδ` (`IsFσ.isGδ_compl` together with `compl_compl`),
+contradicting `dense_countable_isFσ_and_not_isGδ`. -/
+theorem dense_countable_compl_isGδ_not_isFσ
+    {X : Type*} [TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X]
+    [Nonempty X] {D : Set X} (hcount : D.Countable) (hdense : Dense D) :
+    IsGδ Dᶜ ∧ ¬ IsFσ Dᶜ := by
+  refine ⟨(compl_countable_isDenseGδ hcount).1, fun hf => ?_⟩
+  have hs : IsGδ D := by
+    have h := hf.isGδ_compl
+    rwa [compl_compl] at h
+  exact (dense_countable_isFσ_and_not_isGδ hcount hdense).2 hs
+
+/-- **The complete generic dichotomy.** A dense countable set and its complement sit on
+opposite, `Fσ`-only and `Gδ`-only, sides of the Borel hierarchy: `D` is `Fσ` but not `Gδ`,
+while `Dᶜ` is `Gδ` but not `Fσ`. -/
+theorem dense_countable_gδ_fσ_dichotomy
+    {X : Type*} [TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X]
+    [Nonempty X] {D : Set X} (hcount : D.Countable) (hdense : Dense D) :
+    (IsFσ D ∧ ¬ IsGδ D) ∧ (IsGδ Dᶜ ∧ ¬ IsFσ Dᶜ) :=
+  ⟨dense_countable_isFσ_and_not_isGδ hcount hdense,
+    dense_countable_compl_isGδ_not_isFσ hcount hdense⟩
+
 /-! ### The classical `ℚ ⊆ ℝ` instance -/
 
 /-- **`ℚ` is `Fσ` but not `Gδ` in `ℝ`.** The rationals are the range of the (countable,
@@ -87,3 +115,7 @@ theorem rationals_isFσ_and_not_isGδ :
   dense_countable_isFσ_and_not_isGδ (Set.countable_range _) Rat.denseRange_cast
 
 end AlgebraicNumbersCountableOQ02OQ03OQ02OQ01
+
+-- Axiom audit (salvaged from PR #34683): expect only propext / Classical.choice / Quot.sound.
+#print axioms AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.dense_countable_compl_isGδ_not_isFσ
+#print axioms AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.dense_countable_gδ_fσ_dichotomy

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean
@@ -102,4 +102,23 @@ theorem newton_k2_equality_iff (x y z : ℝ) :
       rw [d1, d2, d3]; norm_num
     linarith [hid, hz]
 
+/-- **Newton's k = 2 inequality in symmetric-means (Maclaurin) form, n = 3, ALL reals.**
+With `S₁ = e₁/C(3,1) = e₁/3`, `S₂ = e₂/C(3,2) = e₂/3`, `S₃ = e₃/C(3,3) = e₃/1`, we have
+`S₂² ≥ S₁ · S₃`. The constant denominators need no positivity side-conditions, so this is
+the literal `S₂² ≥ S₁S₃` statement of the open question, sign-agnostic.
+(Salvaged from PR #34683, restated over this file's `newton_k2_*` API.) -/
+theorem newton_k2_symmetric_means (x y z : ℝ) :
+    (e2 x y z / 3) ^ 2 ≥ (e1 x y z / 3) * (e3 x y z / 1) := by
+  have h := newton_k2_allreals_three x y z
+  have key : (e2 x y z / 3) ^ 2 - (e1 x y z / 3) * (e3 x y z / 1)
+      = (e2 x y z ^ 2 - 3 * e1 x y z * e3 x y z) / 9 := by ring
+  have hnn : (0 : ℝ) ≤ (e2 x y z ^ 2 - 3 * e1 x y z * e3 x y z) / 9 := by
+    apply div_nonneg
+    · linarith [h]
+    · norm_num
+  linarith [key, hnn]
+
 end AmgmInequalityOQ02OQ01OQ05OQ01
+
+-- Axiom audit (salvaged from PR #34683): expect only propext / Classical.choice / Quot.sound.
+#print axioms AmgmInequalityOQ02OQ01OQ05OQ01.newton_k2_symmetric_means

--- a/proofs/Proofs/ChebyshevPNTBridgeOQ01OQ04.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ01OQ04.lean
@@ -1,0 +1,150 @@
+/-
+# Chebyshev–PNT bridge, OQ-01-OQ-04: multinomial prime-power bounds
+
+This file addresses the open question:
+
+  *Does the carry-counting bound `p^{v_p(C(2n,n))} ≤ 2n` generalize to the
+  multinomial coefficient `C(kn; n,…,n) = (kn)!/(n!)^k`, giving `p^{v_p} ≤ kn`?*
+
+The central-binomial bound (Mathlib `Nat.pow_factorization_choose_le`) is a
+Kummer/Legendre consequence: the number of base-`p` carries when adding `n + n`
+is at most `log_p (2n)`, so `p^{v_p(C(2n,n))} ≤ 2n`.
+
+## Results
+
+* `multiProd_mul_pow_factorial` — the identity
+  `(∏_{j=1}^{k} C(jn, n)) · (n!)^k = (kn)!`, i.e. the product of binomials
+  `∏_{j=1}^{k} C(jn, n)` equals the multinomial coefficient `(kn)!/(n!)^k`.
+  (Standard telescoping identity; proved here by induction on `k`.)
+
+* `multiProd_prime_pow_le` — the **correct** Kummer-type bound:
+  `p ^ v_p(∏_{j=1}^{k} C(jn,n)) ≤ n^k · k!`.
+  This is the honest generalization: `v_p` of a product is the sum of the
+  `v_p`'s, and each factor obeys `p^{v_p(C(jn,n))} ≤ jn`, so the product is at
+  most `∏_{j=1}^{k} (jn) = n^k · k!`.
+
+* `naive_multinomial_bound_false` — the **refutation** of the naively conjectured
+  generalization `p^{v_p} ≤ kn`. It is FALSE. Smallest witness: `k = 3, n = 2,
+  p = 3`, where the multinomial coefficient is `90 = 2 · 3² · 5`, so
+  `p^{v_p} = 3² = 9 > 6 = kn`. (The product bound `n^k·k! = 48` is respected.)
+
+The takeaway: the central-binomial bound is special because `v_p` telescopes over
+a *two-term* sum; for `k ≥ 3` terms the carries accumulate and the bound `kn`
+must be replaced by the multiplicative bound `n^k · k!` (equivalently, by the
+weaker `(kn)^{k-1}`).
+-/
+import Mathlib.Data.Nat.Choose.Factorization
+import Mathlib.Data.Nat.Choose.Central
+import Mathlib.Tactic
+
+open Nat Finset
+
+namespace ChebyshevPNTBridgeOQ01OQ04
+
+/-- `multiProd k n = ∏_{j=1}^{k} C(jn, n)`.  By the telescoping identity below
+this equals the multinomial coefficient `(kn)! / (n!)^k`. -/
+def multiProd (k n : ℕ) : ℕ := ∏ j ∈ Finset.Icc 1 k, (j * n).choose n
+
+@[simp] lemma multiProd_zero (n : ℕ) : multiProd 0 n = 1 := by
+  simp [multiProd]
+
+/-- One-step unfolding: `multiProd (k+1) n = multiProd k n · C((k+1)n, n)`. -/
+lemma multiProd_succ (k n : ℕ) :
+    multiProd (k + 1) n = multiProd k n * (((k + 1) * n).choose n) := by
+  unfold multiProd
+  rw [Finset.prod_Icc_succ_top (by omega : 1 ≤ k + 1)]
+
+/-- **Product–multinomial identity.**  The product of binomials
+`∏_{j=1}^{k} C(jn, n)` equals `(kn)! / (n!)^k`, stated multiplicatively:
+`(∏_{j=1}^{k} C(jn, n)) · (n!)^k = (kn)!`. -/
+lemma multiProd_mul_pow_factorial (k n : ℕ) :
+    multiProd k n * (n !) ^ k = (k * n)! := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have hle : n ≤ (k + 1) * n := le_mul_of_one_le_left (Nat.zero_le n) (by omega)
+    have hsub : (k + 1) * n - n = k * n := by
+      have : (k + 1) * n = k * n + n := by ring
+      omega
+    have key := Nat.choose_mul_factorial_mul_factorial hle
+    rw [hsub] at key
+    -- key : ((k+1)*n).choose n * n ! * (k*n)! = ((k+1)*n)!
+    calc multiProd (k + 1) n * (n !) ^ (k + 1)
+        = (multiProd k n * (n !) ^ k) * (((k + 1) * n).choose n * n !) := by
+          rw [multiProd_succ, pow_succ]; ring
+      _ = (k * n)! * (((k + 1) * n).choose n * n !) := by rw [ih]
+      _ = ((k + 1) * n).choose n * n ! * (k * n)! := by ring
+      _ = ((k + 1) * n)! := key
+
+/-- Auxiliary: `∏_{j=1}^{k} (jn) = n^k · k!`. -/
+lemma prod_Icc_mul_const (k n : ℕ) :
+    ∏ j ∈ Finset.Icc 1 k, (j * n) = n ^ k * k ! := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rw [Finset.prod_Icc_succ_top (by omega : 1 ≤ k + 1), ih, Nat.factorial_succ, pow_succ]
+    ring
+
+/-- **Correct Kummer-type bound.**  For every prime power `p` (indeed every
+`p`), the highest power of `p` dividing `∏_{j=1}^{k} C(jn, n) = (kn)!/(n!)^k`
+is at most `n^k · k!`:
+`p ^ v_p(multiProd k n) ≤ n^k · k!`.
+
+This is the honest generalization of `Nat.pow_factorization_choose_le`
+(`p^{v_p(C(2n,n))} ≤ 2n`) to `k`-fold multinomial coefficients. -/
+theorem multiProd_prime_pow_le (k n p : ℕ) (hn : 0 < n) :
+    p ^ ((multiProd k n).factorization p) ≤ n ^ k * k ! := by
+  have hne : ∀ j ∈ Finset.Icc 1 k, (j * n).choose n ≠ 0 := by
+    intro j hj
+    rw [Finset.mem_Icc] at hj
+    have : n ≤ j * n := le_mul_of_one_le_left (Nat.zero_le n) (by omega)
+    exact (Nat.choose_pos this).ne'
+  -- v_p of the product is the sum of the v_p's
+  have hsum : (multiProd k n).factorization p
+      = ∑ j ∈ Finset.Icc 1 k, ((j * n).choose n).factorization p := by
+    unfold multiProd
+    rw [Nat.factorization_prod hne]
+    exact Finsupp.finset_sum_apply _ _ _
+  rw [hsum, ← Finset.prod_pow_eq_pow_sum, ← prod_Icc_mul_const]
+  apply Finset.prod_le_prod
+  · intro i _; exact Nat.zero_le _
+  · intro j hj
+    rw [Finset.mem_Icc] at hj
+    exact Nat.pow_factorization_choose_le (mul_pos (by omega) hn)
+
+/-- **Refutation of the naive generalization.**  The conjectured bound
+`p ^ v_p(multiProd k n) ≤ k · n` (the direct analogue of the central-binomial
+bound `≤ 2n`) is FALSE.
+
+Witness: `k = 3, n = 2, p = 3`.  Here `multiProd 3 2 = C(2,2)·C(4,2)·C(6,2)
+= 1·6·15 = 90 = 2 · 3² · 5`, so `v_3 = 2` and `3² = 9 > 6 = 3·2`. -/
+theorem naive_multinomial_bound_false :
+    ¬ ∀ (k n p : ℕ), 0 < n → p.Prime →
+      p ^ ((multiProd k n).factorization p) ≤ k * n := by
+  intro h
+  have hp : Nat.Prime 3 := by norm_num
+  -- The identity pins down the value: multiProd 3 2 · (2!)^3 = 6!, i.e. · 8 = 720.
+  have hval : multiProd 3 2 = 90 := by
+    have hid := multiProd_mul_pow_factorial 3 2
+    have e1 : (2 !) ^ 3 = 8 := by decide
+    have e2 : (3 * 2)! = 720 := by decide
+    rw [e1, e2] at hid
+    omega
+  -- 3² ∣ 90, so v₃(90) ≥ 2.
+  have hfact : 2 ≤ (multiProd 3 2).factorization 3 := by
+    rw [hval]
+    exact (Nat.Prime.pow_dvd_iff_le_factorization hp (by norm_num)).mp (by norm_num)
+  -- The (false) hypothesis at k=3, n=2, p=3 gives 3^{v₃} ≤ 6.
+  have hle := h 3 2 3 (by norm_num) hp
+  have h9 : (9 : ℕ) ≤ 3 ^ ((multiProd 3 2).factorization 3) := by
+    calc (9 : ℕ) = 3 ^ 2 := by norm_num
+      _ ≤ 3 ^ ((multiProd 3 2).factorization 3) :=
+          Nat.pow_le_pow_right (by norm_num) hfact
+  omega
+
+end ChebyshevPNTBridgeOQ01OQ04
+
+-- Axiom audit: expect only propext / Classical.choice / Quot.sound.
+#print axioms ChebyshevPNTBridgeOQ01OQ04.multiProd_mul_pow_factorial
+#print axioms ChebyshevPNTBridgeOQ01OQ04.multiProd_prime_pow_le
+#print axioms ChebyshevPNTBridgeOQ01OQ04.naive_multinomial_bound_false

--- a/proofs/Proofs/Erdos1017OQ05.lean
+++ b/proofs/Proofs/Erdos1017OQ05.lean
@@ -1,0 +1,317 @@
+import Mathlib.Data.Finset.Card
+import Mathlib.Order.Antichain
+import Mathlib.Tactic
+
+/-
+# Erdos Problem #1017 (OQ-05): Complete-Subhypergraph Cover vs Partition
+
+## The Open Question
+> Does the clique-cover / clique-partition problem extend naturally to
+> hypergraphs?  For a `k`-uniform hypergraph, what is the minimum number of
+> *complete sub-hypergraphs* needed to partition its edge set?
+
+This is the `k`-uniform generalization of OQ-04 (`Erdos1017OQ04.lean`), which
+treats the graph case `k = 2`.  In a graph, a *clique* is a vertex set all of
+whose 2-subsets (pairs) are edges.  The uniform generalization is immediate:
+
+* A **`k`-uniform hypergraph** `H` on `V` is a finite family of `k`-element
+  vertex sets (its *hyperedges*).
+* A **complete sub-hypergraph** is a vertex set `S` all of whose `k`-subsets are
+  hyperedges of `H` -- the exact analog of a clique (`k = 2` recovers a clique:
+  a vertex set all of whose pairs are edges).
+* A **complete-subhypergraph cover** is a family of complete sub-hypergraphs such
+  that every hyperedge lies inside (`⊆`) at least one of them; a **partition**
+  requires *exactly one*.
+
+Write `ccₖ(H)` for the minimum cover size and `cpₖ(H)` for the minimum partition
+size.  OQ-04's always-true direction extends verbatim to every uniformity `k`:
+
+    ccₖ(H) ≤ cpₖ(H).
+
+## What This File Proves (0 axioms, 0 sorries)
+- `Hypergraph`            : a `k`-uniform hypergraph (finite family of `k`-sets).
+- `Hypergraph.IsCompleteSub` : the clique analog (every `k`-subset is a hyperedge).
+- `CompleteCover` / `CompletePartition` : the cover and partition structures
+  (edge contained in ≥ 1 / in exactly 1 complete sub-hypergraph).
+- `CompletePartition.toCover` : every partition is a cover -- the structural heart
+  of the always-true direction.
+- `trivialPartition` : each hyperedge is its own complete sub-hypergraph, giving a
+  partition that always exists (so `partitionNum` is a genuine minimum, not the
+  vacuous `sInf ∅`).
+- `coverNum_le_partitionNum` : **ccₖ(H) ≤ cpₖ(H)** for every `k`-uniform hypergraph.
+- `partitionNum_le_edgesCard`, `coverNum_le_edgesCard` : both numbers are at most
+  the number of hyperedges (each edge its own complete sub-hypergraph).
+- `CompletePartition.edge_unique_clique` : the disjointness keystone -- a hyperedge
+  lies in a UNIQUE partition clique -- on which every partition-number lower bound
+  rests, and the reason `cpₖ` can exceed `ccₖ`.
+- `coverNum_pos_of_edge`, `partitionNum_pos_of_edge` : both numbers are ≥ 1 once
+  `H` has a hyperedge (base case of the lower-bound ladder).
+
+## Honest Scope
+This establishes the always-true direction `ccₖ ≤ cpₖ` rigorously for all `k` with
+zero axioms, showing OQ-04's structure lifts cleanly to hypergraphs.  It does
+**not** prove the gap can be strict for any fixed `k` (that requires a concrete
+witness hypergraph and a counting lower bound, exactly as the strict graph gap
+`K_4 - e` does at `k = 2`).  The strict `k`-uniform gap remains open here; the
+keystone `edge_unique_clique` and the positivity base cases are the reusable
+lemmas a future lower-bound argument builds on.
+-/
+
+set_option maxHeartbeats 400000
+
+namespace Erdos1017OQ05
+
+open Finset
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-
+====================================================================
+PART I: HYPERGRAPHS AND COMPLETE SUB-HYPERGRAPHS
+==================================================================== -/
+
+/-- A **`k`-uniform hypergraph** on `V`: a finite family of hyperedges, each a
+    `k`-element vertex set.  For `k = 2` this is (the edge set of) a graph. -/
+structure Hypergraph (V : Type*) (k : ℕ) where
+  /-- The hyperedges. -/
+  edges : Finset (Finset V)
+  /-- Every hyperedge has exactly `k` vertices. -/
+  uniform : ∀ e ∈ edges, e.card = k
+
+variable {k : ℕ} {H : Hypergraph V k}
+
+/-- A vertex set `S` is a **complete sub-hypergraph** of `H` when every `k`-subset
+    of `S` is a hyperedge of `H`.  This is the hypergraph analog of a clique: for
+    `k = 2` it says every pair inside `S` is an edge. -/
+def Hypergraph.IsCompleteSub (H : Hypergraph V k) (S : Finset V) : Prop :=
+  ∀ ⦃e : Finset V⦄, e ⊆ S → e.card = k → e ∈ H.edges
+
+/-- **Two `k`-sets nested by `⊆` are equal.**  If `e ⊆ f` and both have `k`
+    vertices, then `e = f`.  This is the workhorse behind the trivial partition and
+    the disjointness keystone. -/
+theorem eq_of_subset_of_card_eq {e f : Finset V} (hsub : e ⊆ f)
+    (he : e.card = k) (hf : f.card = k) : e = f :=
+  Finset.eq_of_subset_of_card_le hsub (by rw [he, hf])
+
+/-- **Every hyperedge is a complete sub-hypergraph.**  Viewing a hyperedge `e` as a
+    vertex set, its only `k`-subset is `e` itself (both have `k` vertices), and `e`
+    is a hyperedge.  This is what makes the trivial partition valid. -/
+theorem isCompleteSub_of_mem_edges {e : Finset V} (he : e ∈ H.edges) :
+    H.IsCompleteSub e := by
+  intro f hf hfc
+  rwa [eq_of_subset_of_card_eq hf hfc (H.uniform e he)]
+
+/-
+====================================================================
+PART II: COVER AND PARTITION STRUCTURES
+==================================================================== -/
+
+/-- A **complete-subhypergraph cover** of `H`: a finite family of complete
+    sub-hypergraphs such that every hyperedge lies inside at least one of them.
+    Members may overlap. -/
+structure CompleteCover (H : Hypergraph V k) where
+  /-- The complete sub-hypergraphs in the cover. -/
+  cliques : Finset (Finset V)
+  /-- Each listed set is a complete sub-hypergraph of `H`. -/
+  isComplete : ∀ S ∈ cliques, H.IsCompleteSub S
+  /-- Every hyperedge is contained in some member. -/
+  covers : ∀ ⦃e⦄, e ∈ H.edges → ∃ S ∈ cliques, e ⊆ S
+
+/-- A **complete-subhypergraph partition** of `H`: every hyperedge is contained in
+    *exactly one* complete sub-hypergraph.  This is a cover with the disjointness
+    constraint, phrased as unique existence. -/
+structure CompletePartition (H : Hypergraph V k) where
+  /-- The complete sub-hypergraphs in the partition. -/
+  cliques : Finset (Finset V)
+  /-- Each listed set is a complete sub-hypergraph of `H`. -/
+  isComplete : ∀ S ∈ cliques, H.IsCompleteSub S
+  /-- Every hyperedge lies in exactly one member. -/
+  partitions : ∀ ⦃e⦄, e ∈ H.edges → ∃! S, S ∈ cliques ∧ e ⊆ S
+
+/-- **Every partition is a cover.**  Forgetting the uniqueness (disjointness)
+    constraint turns a complete-subhypergraph partition into a cover with the same
+    underlying family.  This is the structural core of `ccₖ(H) ≤ cpₖ(H)`. -/
+def CompletePartition.toCover (P : CompletePartition H) : CompleteCover H where
+  cliques := P.cliques
+  isComplete := P.isComplete
+  covers := by
+    intro e he
+    obtain ⟨S, ⟨hS, hsub⟩, _⟩ := P.partitions he
+    exact ⟨S, hS, hsub⟩
+
+@[simp] theorem CompletePartition.toCover_cliques (P : CompletePartition H) :
+    P.toCover.cliques = P.cliques := rfl
+
+/-
+====================================================================
+PART III: THE COVER AND PARTITION NUMBERS
+==================================================================== -/
+
+/-- The **complete-cover number** `ccₖ(H)`: the least size of a
+    complete-subhypergraph cover. -/
+noncomputable def coverNum (H : Hypergraph V k) : ℕ :=
+  sInf { m | ∃ C : CompleteCover H, C.cliques.card = m }
+
+/-- The **complete-partition number** `cpₖ(H)`: the least size of a
+    complete-subhypergraph partition. -/
+noncomputable def partitionNum (H : Hypergraph V k) : ℕ :=
+  sInf { m | ∃ P : CompletePartition H, P.cliques.card = m }
+
+/-
+====================================================================
+PART IV: THE TRIVIAL PARTITION (EACH HYPEREDGE ITS OWN CLIQUE)
+==================================================================== -/
+
+/-- The **trivial complete-subhypergraph partition**: every hyperedge is its own
+    complete sub-hypergraph.  This witnesses that a partition of `H` always exists,
+    so `partitionNum H` is achieved rather than a vacuous infimum. -/
+noncomputable def trivialPartition (H : Hypergraph V k) : CompletePartition H where
+  cliques := H.edges
+  isComplete := fun _ hS => isCompleteSub_of_mem_edges hS
+  partitions := by
+    intro e he
+    refine ⟨e, ⟨he, Finset.Subset.refl e⟩, ?_⟩
+    -- Uniqueness: any hyperedge `S` (as a vertex set) containing `e` equals `e`.
+    rintro S ⟨hS, hsub⟩
+    exact (eq_of_subset_of_card_eq hsub (H.uniform e he) (H.uniform S hS)).symm
+
+/-- The trivial partition uses one clique per hyperedge. -/
+theorem trivialPartition_card (H : Hypergraph V k) :
+    (trivialPartition H).cliques.card = H.edges.card := rfl
+
+/-
+====================================================================
+PART V: THE MAIN INEQUALITY  ccₖ(H) ≤ cpₖ(H)
+==================================================================== -/
+
+/-- The partition-number witness set is nonempty: the trivial partition exists. -/
+theorem partitionNum_set_nonempty (H : Hypergraph V k) :
+    { m | ∃ P : CompletePartition H, P.cliques.card = m }.Nonempty :=
+  ⟨(trivialPartition H).cliques.card, trivialPartition H, rfl⟩
+
+/-- **Main result.** The complete-cover number is at most the complete-partition
+    number: `ccₖ(H) ≤ cpₖ(H)` for every `k`-uniform hypergraph.  Every partition is
+    a cover of the same size, so any minimum partition yields a cover of that size,
+    whence the minimum cover size is at most it.  This lifts OQ-04's always-true
+    direction from graphs (`k = 2`) to all uniformities. -/
+theorem coverNum_le_partitionNum (H : Hypergraph V k) :
+    coverNum H ≤ partitionNum H := by
+  obtain ⟨P, hP⟩ := Nat.sInf_mem (partitionNum_set_nonempty H)
+  refine Nat.sInf_le ?_
+  exact ⟨P.toCover, by rw [CompletePartition.toCover_cliques]; exact hP⟩
+
+/-
+====================================================================
+PART VI: UPPER BOUNDS BY THE NUMBER OF HYPEREDGES
+==================================================================== -/
+
+/-- `cpₖ(H) ≤ |edges|`: partition each hyperedge into its own complete
+    sub-hypergraph. -/
+theorem partitionNum_le_edgesCard (H : Hypergraph V k) :
+    partitionNum H ≤ H.edges.card :=
+  Nat.sInf_le ⟨trivialPartition H, rfl⟩
+
+/-- `ccₖ(H) ≤ |edges|`: immediate from `ccₖ ≤ cpₖ ≤ |edges|`. -/
+theorem coverNum_le_edgesCard (H : Hypergraph V k) :
+    coverNum H ≤ H.edges.card :=
+  (coverNum_le_partitionNum H).trans (partitionNum_le_edgesCard H)
+
+/-
+====================================================================
+PART VII: TOWARD THE STRICT GAP  ccₖ(H) < cpₖ(H)
+
+The always-true direction `ccₖ(H) ≤ cpₖ(H)` is Part V.  The genuinely open content
+of OQ-05, mirroring OQ-04, is that this inequality can be *strict*.  The results
+below are the reusable keystones for that lower-bound program, stated for arbitrary
+`k`-uniform hypergraphs (no concrete witness yet).
+==================================================================== -/
+
+/-- **A hyperedge determines its partition clique uniquely.**  In a
+    complete-subhypergraph *partition*, if a hyperedge `e` lies inside two listed
+    cliques `S` and `T`, then `S = T`.  This is the disjointness distinguishing a
+    partition from a cover, the structural obstruction behind a strict gap
+    `ccₖ(H) < cpₖ(H)`, and the keystone for every partition-number lower bound. -/
+theorem CompletePartition.edge_unique_clique (P : CompletePartition H)
+    {e : Finset V} (he : e ∈ H.edges) {S T : Finset V}
+    (hSmem : S ∈ P.cliques) (hSsub : e ⊆ S)
+    (hTmem : T ∈ P.cliques) (hTsub : e ⊆ T) : S = T := by
+  obtain ⟨_, _, huniq⟩ := P.partitions he
+  rw [huniq S ⟨hSmem, hSsub⟩, huniq T ⟨hTmem, hTsub⟩]
+
+/-- **`ccₖ(H) ≥ 1` whenever `H` has a hyperedge.**  A hyperedge must be covered by
+    at least one complete sub-hypergraph, so the empty cover is invalid and the
+    cover number is positive.  Base case of the cover-number lower-bound ladder. -/
+theorem coverNum_pos_of_edge {e : Finset V} (he : e ∈ H.edges) : 0 < coverNum H := by
+  have hne : {m | ∃ C : CompleteCover H, C.cliques.card = m}.Nonempty :=
+    ⟨_, (trivialPartition H).toCover, rfl⟩
+  obtain ⟨C, hC⟩ := Nat.sInf_mem hne
+  have hC' : C.cliques.card = coverNum H := hC
+  rcases Nat.eq_zero_or_pos (coverNum H) with h0 | hpos
+  · exfalso
+    rw [h0, Finset.card_eq_zero] at hC'
+    obtain ⟨S, hS, _⟩ := C.covers he
+    rw [hC'] at hS
+    exact Finset.notMem_empty S hS
+  · exact hpos
+
+/-- **`cpₖ(H) ≥ 1` whenever `H` has a hyperedge.**  A hyperedge must lie in some
+    clique of any partition, so the empty partition is invalid and the partition
+    number is positive.  Base case of the partition-number lower-bound ladder. -/
+theorem partitionNum_pos_of_edge {e : Finset V} (he : e ∈ H.edges) :
+    0 < partitionNum H := by
+  obtain ⟨P, hP⟩ := Nat.sInf_mem (partitionNum_set_nonempty H)
+  have hP' : P.cliques.card = partitionNum H := hP
+  rcases Nat.eq_zero_or_pos (partitionNum H) with h0 | hpos
+  · exfalso
+    rw [h0, Finset.card_eq_zero] at hP'
+    obtain ⟨S, ⟨hS, _⟩, _⟩ := P.partitions he
+    rw [hP'] at hS
+    exact Finset.notMem_empty S hS
+  · exact hpos
+
+/-
+====================================================================
+PART VIII: SANITY CHECK — THE GRAPH CASE k = 2
+
+For `k = 2` the definitions collapse to OQ-04's graph notions: a hyperedge is a
+pair of vertices, a complete sub-hypergraph is a vertex set all of whose pairs are
+edges (a clique), and the two extremal numbers are exactly `cc(G)` and `cp(G)`.
+The following records that the uniform machinery specializes correctly: a `2`-set
+is a complete sub-hypergraph iff it is a hyperedge.
+==================================================================== -/
+
+/-- At uniformity `k = 2`, a two-element vertex set is a complete sub-hypergraph iff
+    it is itself a hyperedge -- matching the graph case, where a single edge is the
+    smallest clique.  (One direction is `isCompleteSub_of_mem_edges`; this gives the
+    converse for `2`-sets.) -/
+theorem mem_edges_of_isCompleteSub_card_eq {H : Hypergraph V k} {S : Finset V}
+    (hS : H.IsCompleteSub S) (hcard : S.card = k) : S ∈ H.edges :=
+  hS (Finset.Subset.refl S) hcard
+
+/-
+====================================================================
+PART IX: VERIFICATION
+==================================================================== -/
+
+#check @Hypergraph
+#check @Hypergraph.IsCompleteSub
+#check @CompleteCover
+#check @CompletePartition
+#check @CompletePartition.toCover
+#check @coverNum
+#check @partitionNum
+#check @trivialPartition
+#check @coverNum_le_partitionNum
+#check @partitionNum_le_edgesCard
+#check @coverNum_le_edgesCard
+#check @CompletePartition.edge_unique_clique
+#check @coverNum_pos_of_edge
+#check @partitionNum_pos_of_edge
+#check @mem_edges_of_isCompleteSub_card_eq
+
+end Erdos1017OQ05
+
+-- Axiom audit: expect only propext / Classical.choice / Quot.sound.
+#print axioms Erdos1017OQ05.coverNum_le_partitionNum
+#print axioms Erdos1017OQ05.partitionNum_le_edgesCard
+#print axioms Erdos1017OQ05.mem_edges_of_isCompleteSub_card_eq

--- a/proofs/Proofs/FibonacciIdentitiesOQ01OQ04.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ01OQ04.lean
@@ -1,0 +1,131 @@
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Tactic
+import Proofs.FibonacciIdentitiesOQ01OQ02OQ01
+
+/-
+# The Gelin–Cesàro Identity for Fibonacci Numbers
+
+## What This Proves
+
+With `Fₙ = Nat.fib n` the Fibonacci sequence (`F₀ = 0, F₁ = 1, Fₙ₊₂ = Fₙ + Fₙ₊₁`),
+the **Gelin–Cesàro identity** is the quartic product relation
+
+    F_{n-2} · F_{n-1} · F_{n+1} · F_{n+2} = Fₙ⁴ − 1        (for n ≥ 2).
+
+The four Fibonacci numbers symmetrically flanking `Fₙ` (two on each side) multiply to
+exactly one less than the fourth power of the central term.
+
+## Approach
+
+The identity factors through **Catalan's identity** (proved in the sibling entry
+`fibonacci-identities-oq-01-oq-02-oq-01` as `fib_catalan_gap`):
+
+    F_{m+r}² − Fₘ · F_{m+2r} = (−1)ᵐ · Fᵣ².
+
+Writing `m = n − 2` and pairing the outer and inner factors of the product:
+
+* **Outer pair** (`r = 2`, `F₂ = 1`):  `Fₘ · F_{m+4} = F_{m+2}² − (−1)ᵐ`.
+* **Inner pair** (`r = 1`, `F₁ = 1`):  `F_{m+1} · F_{m+3} = F_{m+2}² + (−1)ᵐ`.
+
+Multiplying the two is a difference of squares:
+
+    (F_{m+2}² − (−1)ᵐ)(F_{m+2}² + (−1)ᵐ) = F_{m+2}⁴ − ((−1)ᵐ)² = F_{m+2}⁴ − 1,
+
+using `((−1)ᵐ)² = 1`. Re-indexing `m + 2 = n` recovers the named form for `n ≥ 2`.
+
+No closed form, Binet formula, or `decide`/`native_decide` is used in the theorems, so
+the proofs are axiom-free (only Mathlib's foundational axioms). The single sign fact
+`((−1)ᵐ)² = 1` is discharged from `Even (m + m)`.
+
+## Distinctness
+
+Gelin–Cesàro is **not** in Mathlib (`Mathlib.Data.Nat.Fib.Basic` has the recurrence and
+`fib_add` but no product identities). It is a genuine two-sided consequence of Catalan —
+distinct from Cassini (`i = j = 1`), d'Ocagne (`j = 1`), and Catalan itself (a single
+symmetric determinant) — obtained by *combining* the `r = 1` and `r = 2` Catalan slices.
+This answers the fourth open question of `fibonacci-identities-oq-01`.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms (beyond Mathlib's foundational set)
+-/
+
+namespace FibonacciIdentitiesOQ01OQ04
+
+open Nat
+
+/-- `((−1)ᵐ)² = 1` over `ℤ`, the sign fact that collapses the difference of squares. -/
+private theorem neg_one_pow_sq (m : ℕ) : ((-1 : ℤ) ^ m) ^ 2 = 1 := by
+  rw [← pow_mul]
+  exact Even.neg_one_pow ⟨m, by ring⟩
+
+/-- **Outer pair from Catalan (`r = 2`).**  `Fₘ · F_{m+4} = F_{m+2}² − (−1)ᵐ`. -/
+private theorem fib_outer_pair (m : ℕ) :
+    (Nat.fib m : ℤ) * Nat.fib (m + 4) = (Nat.fib (m + 2) : ℤ) ^ 2 - (-1) ^ m := by
+  have h := FibonacciIdentitiesOQ01OQ02OQ01.fib_catalan_gap m 2
+  rw [show m + 2 * 2 = m + 4 by norm_num, Nat.fib_two] at h
+  -- h : F_{m+2}² − Fₘ·F_{m+4} = (−1)ᵐ · (1)²
+  push_cast at h
+  linarith
+
+/-- **Inner pair from Catalan (`r = 1`).**  `F_{m+1} · F_{m+3} = F_{m+2}² + (−1)ᵐ`. -/
+private theorem fib_inner_pair (m : ℕ) :
+    (Nat.fib (m + 1) : ℤ) * Nat.fib (m + 3) = (Nat.fib (m + 2) : ℤ) ^ 2 + (-1) ^ m := by
+  have h := FibonacciIdentitiesOQ01OQ02OQ01.fib_catalan_gap (m + 1) 1
+  rw [show m + 1 + 1 = m + 2 by norm_num, show m + 1 + 2 * 1 = m + 3 by norm_num,
+      Nat.fib_one] at h
+  -- h : F_{m+2}² − F_{m+1}·F_{m+3} = (−1)^{m+1} · (1)²
+  have hs : ((-1 : ℤ)) ^ (m + 1) = -((-1) ^ m) := by rw [pow_succ]; ring
+  rw [hs] at h
+  simp only [Nat.cast_one, one_pow, mul_one] at h
+  -- h : F_{m+2}² − F_{m+1}·F_{m+3} = −(−1)ᵐ
+  linarith
+
+/-- **Gelin–Cesàro identity, gap-parameterised (subtraction-free) form.**  For all `m`,
+
+    Fₘ · F_{m+1} · F_{m+3} · F_{m+4} = F_{m+2}⁴ − 1.
+
+The engine: the outer pair (Catalan `r = 2`) and inner pair (Catalan `r = 1`) multiply
+as a difference of squares, and `((−1)ᵐ)² = 1` kills the cross term. -/
+theorem fib_gelin_cesaro_gap (m : ℕ) :
+    (Nat.fib m : ℤ) * Nat.fib (m + 1) * Nat.fib (m + 3) * Nat.fib (m + 4)
+      = (Nat.fib (m + 2) : ℤ) ^ 4 - 1 := by
+  calc
+    (Nat.fib m : ℤ) * Nat.fib (m + 1) * Nat.fib (m + 3) * Nat.fib (m + 4)
+        = ((Nat.fib m : ℤ) * Nat.fib (m + 4))
+            * ((Nat.fib (m + 1) : ℤ) * Nat.fib (m + 3)) := by ring
+    _ = ((Nat.fib (m + 2) : ℤ) ^ 2 - (-1) ^ m)
+            * ((Nat.fib (m + 2) : ℤ) ^ 2 + (-1) ^ m) := by
+          rw [fib_outer_pair, fib_inner_pair]
+    _ = (Nat.fib (m + 2) : ℤ) ^ 4 - ((-1) ^ m) ^ 2 := by ring
+    _ = (Nat.fib (m + 2) : ℤ) ^ 4 - 1 := by rw [neg_one_pow_sq]
+
+/-- **Gelin–Cesàro identity (named form).**  For `n ≥ 2`,
+
+    F_{n−2} · F_{n−1} · F_{n+1} · F_{n+2} = Fₙ⁴ − 1.
+
+The four Fibonacci numbers flanking `Fₙ` symmetrically multiply to `Fₙ⁴ − 1`. Obtained
+from the gap form by the re-index `m = n − 2`. -/
+theorem fib_gelin_cesaro (n : ℕ) (hn : 2 ≤ n) :
+    (Nat.fib (n - 2) : ℤ) * Nat.fib (n - 1) * Nat.fib (n + 1) * Nat.fib (n + 2)
+      = (Nat.fib n : ℤ) ^ 4 - 1 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hn   -- n = 2 + m
+  have h := fib_gelin_cesaro_gap m
+  rw [show 2 + m - 2 = m by omega, show 2 + m - 1 = m + 1 by omega,
+      show 2 + m + 1 = m + 3 by omega, show 2 + m + 2 = m + 4 by omega,
+      show 2 + m = m + 2 by omega]
+  exact h
+
+/-! ## Concrete examples -/
+
+-- n = 4:  F₂·F₃·F₅·F₆ = 1·2·5·8 = 80 = F₄⁴ − 1 = 3⁴ − 1 = 81 − 1 = 80.
+example : (Nat.fib 2 : ℤ) * Nat.fib 3 * Nat.fib 5 * Nat.fib 6 = (Nat.fib 4 : ℤ) ^ 4 - 1 := by
+  decide
+-- n = 6:  F₄·F₅·F₇·F₈ = 3·5·13·21 = 4095 = F₆⁴ − 1 = 8⁴ − 1 = 4096 − 1 = 4095.
+example : (Nat.fib 4 : ℤ) * Nat.fib 5 * Nat.fib 7 * Nat.fib 8 = (Nat.fib 6 : ℤ) ^ 4 - 1 := by
+  decide
+
+end FibonacciIdentitiesOQ01OQ04
+
+-- Axiom audit: expect only propext / Classical.choice / Quot.sound.
+#print axioms FibonacciIdentitiesOQ01OQ04.fib_gelin_cesaro_gap
+#print axioms FibonacciIdentitiesOQ01OQ04.fib_gelin_cesaro

--- a/proofs/Proofs/ProbMethodAlterationOQ01.lean
+++ b/proofs/Proofs/ProbMethodAlterationOQ01.lean
@@ -1,0 +1,139 @@
+/-
+  Alteration / Deletion Bound: α(G) ≥ n − m   (verified, 0-axiom)
+
+  Open Question OQ-01 from `prob-method-alteration`.
+
+  The base entry `ProbMethodAlteration.lean` states its independent-set bound only in
+  a vacuous "existence form",
+        `independent_set_bound : ∃ k, k ≥ n / (2 * d) ∧ k > 0`,
+  which never mentions a graph and is therefore trivially true.  This file replaces
+  that placeholder with the genuine, purest instance of the deletion method, proved
+  against the real independence number `α(G) = sSup {|S| : S independent}` (the same
+  definition used in `ProbMethodAlterationOQ02` / `OQ03`):
+
+        For every finite simple graph G on n vertices with m edges,
+              α(G) ≥ n − m.
+
+  Proof (deletion method, no probability needed).  Delete ONE endpoint from every
+  edge.  Concretely, from each edge pick its lesser endpoint (a symmetric choice,
+  hence well-defined on `Sym2 V` via `Sym2.lift ⟨min, min_comm⟩`).  The deleted set
+  `D` satisfies `|D| ≤ m`, and its complement `univ \ D` is independent: any surviving
+  edge would have kept both endpoints, contradicting that its lesser endpoint was
+  deleted.  Thus `univ \ D` is an independent set of size `≥ n − m`.
+
+  This is the WEAK end of the alteration spectrum (tight for a perfect matching,
+  where `m = n/2` and `α = n/2`).  The classical STRONG bound `α(G) ≥ n²/(4m)` comes
+  instead from random *sub-sampling* — keep each vertex with probability `p`, then
+  delete a surviving endpoint per edge — leaving `n·p − m·p²` vertices in expectation.
+  We record the arithmetic heart of that optimization (`sample_delete_le` /
+  `sample_delete_attained`) as a companion; bridging it to the graph requires the
+  probabilistic existence step, documented as the remaining gap.
+
+  Status: verified, 0 axioms (only Lean/Mathlib foundations).
+-/
+
+import Mathlib
+
+namespace ProbMethod.Deletion
+
+open Finset SimpleGraph
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+
+/-- The independence number `α(G)`: the size of the largest independent set.
+    (Same definition as in `ProbMethodAlterationOQ02` / `OQ03`.) -/
+noncomputable def independenceNumber (G : SimpleGraph V) : ℕ :=
+  sSup { k : ℕ | ∃ s : Finset V, s.card = k ∧
+    ∀ v ∈ s, ∀ w ∈ s, v ≠ w → ¬G.Adj v w }
+
+/-- The lesser endpoint of an edge: a symmetric choice function on `Sym2 V`. -/
+noncomputable def pick : Sym2 V → V := Sym2.lift ⟨min, min_comm⟩
+
+@[simp] theorem pick_mk (a b : V) : pick s(a, b) = min a b := rfl
+
+/-- The chosen endpoint of an edge is one of its two endpoints. -/
+theorem pick_mem_pair (a b : V) : pick s(a, b) = a ∨ pick s(a, b) = b := by
+  rw [pick_mk]
+  rcases le_total a b with h | h
+  · exact Or.inl (min_eq_left h)
+  · exact Or.inr (min_eq_right h)
+
+variable (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-- Vertices chosen for deletion: the lesser endpoint of each edge. -/
+noncomputable def deletionSet : Finset V := G.edgeFinset.image pick
+
+/-- At most one vertex is deleted per edge, so `|D| ≤ m`. -/
+theorem deletionSet_card_le : (deletionSet G).card ≤ G.edgeFinset.card :=
+  Finset.card_image_le
+
+/-- **Independence of the complement.**  The complement of the deletion set contains
+    no edge: if it did, that edge's chosen endpoint would have been deleted. -/
+theorem indep_compl_deletionSet :
+    ∀ a ∈ (univ \ deletionSet G), ∀ b ∈ (univ \ deletionSet G), a ≠ b →
+      ¬ G.Adj a b := by
+  intro a ha b hb _ hadj
+  rw [Finset.mem_sdiff] at ha hb
+  have hedge : s(a, b) ∈ G.edgeFinset := by
+    rw [SimpleGraph.mem_edgeFinset]; exact (G.mem_edgeSet).mpr hadj
+  have hpick : pick s(a, b) ∈ deletionSet G := Finset.mem_image_of_mem pick hedge
+  -- The chosen endpoint is `a` or `b`; both are supposed to be undeleted.
+  rcases pick_mem_pair a b with h | h
+  · rw [h] at hpick; exact ha.2 hpick
+  · rw [h] at hpick; exact hb.2 hpick
+
+/-- **Alteration / deletion bound.**  For every finite simple graph,
+    `α(G) ≥ (number of vertices) − (number of edges)`. -/
+theorem independenceNumber_ge_card_sub_edges :
+    Fintype.card V - G.edgeFinset.card ≤ independenceNumber G := by
+  set P : Set ℕ := { k : ℕ | ∃ s : Finset V, s.card = k ∧
+    ∀ v ∈ s, ∀ w ∈ s, v ≠ w → ¬G.Adj v w } with hP
+  set S : Finset V := univ \ deletionSet G with hS
+  -- `S` is an independent set, so `|S| ∈ P`.
+  have hSmem : S.card ∈ P := ⟨S, rfl, indep_compl_deletionSet G⟩
+  -- `P` is bounded above by `|V|`.
+  have hbdd : BddAbove P := by
+    refine ⟨Fintype.card V, ?_⟩
+    intro k hk
+    obtain ⟨s, rfl, -⟩ := hk
+    exact Finset.card_le_univ s
+  have hle : S.card ≤ independenceNumber G := le_csSup hbdd hSmem
+  -- Lower bound on `|S| = n − |D| ≥ n − m`.
+  have hScard : Fintype.card V - G.edgeFinset.card ≤ S.card := by
+    have hcard : S.card = Fintype.card V - (deletionSet G).card := by
+      rw [hS, Finset.card_sdiff, Finset.inter_univ, Finset.card_univ]
+    rw [hcard]
+    exact Nat.sub_le_sub_left (deletionSet_card_le G) _
+  exact hScard.trans hle
+
+-- ═══════════════════════════════════════════════════
+--  Companion: the sub-sampling optimization behind α(G) ≥ n²/(4m)
+-- ═══════════════════════════════════════════════════
+
+/-- **Alteration optimization identity.**  Keeping each vertex with probability `p`
+    and deleting one endpoint of every surviving edge leaves `n·p − m·p²` vertices in
+    expectation.  Completing the square exhibits the maximum. -/
+theorem sample_delete_optimum (n m p : ℝ) (hm : 0 < m) :
+    n * p - m * p ^ 2 = n ^ 2 / (4 * m) - m * (p - n / (2 * m)) ^ 2 := by
+  have hm' : m ≠ 0 := ne_of_gt hm
+  field_simp
+  ring
+
+/-- The expected surplus `n·p − m·p²` never exceeds `n²/(4m)`. -/
+theorem sample_delete_le (n m p : ℝ) (hm : 0 < m) :
+    n * p - m * p ^ 2 ≤ n ^ 2 / (4 * m) := by
+  rw [sample_delete_optimum n m p hm]
+  have : 0 ≤ m * (p - n / (2 * m)) ^ 2 := mul_nonneg hm.le (sq_nonneg _)
+  linarith
+
+/-- The maximum `n²/(4m)` is attained at `p = n/(2m)`. -/
+theorem sample_delete_attained (n m : ℝ) (hm : 0 < m) :
+    n * (n / (2 * m)) - m * (n / (2 * m)) ^ 2 = n ^ 2 / (4 * m) := by
+  rw [sample_delete_optimum n m (n / (2 * m)) hm]; ring
+
+end ProbMethod.Deletion
+
+-- Axiom audit: expect only propext / Classical.choice / Quot.sound.
+#print axioms ProbMethod.Deletion.independenceNumber_ge_card_sub_edges
+#print axioms ProbMethod.Deletion.sample_delete_optimum
+#print axioms ProbMethod.Deletion.sample_delete_attained

--- a/proofs/Proofs/SzemerediRegularityOQ02OQ02.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ02OQ02.lean
@@ -1,0 +1,229 @@
+/-
+# Szemerédi ⟹ Frieze-Kannan: the cut-approximation constant is 1, not 2
+
+OQ-02-OQ-02 follow-up to `szemeredi-regularity-oq-02` (Frieze-Kannan comparison).
+
+## The question
+
+`SzemerediRegularityOQ02.szemeredi_implies_fk` proves that every ε-regular
+partition is a **2ε**-cut-approximation. The open question asks:
+
+> Is the factor-of-2 constant tight, or can it be improved to 1?
+
+## The answer: improvable to 1
+
+The factor of 2 is **not** intrinsic — it is an artifact of a loose triangle-inequality
+step in the "small subset" case of the per-pair bound. We sharpen the per-pair estimate
+to the optimal `ε·|P|·|Q|` and conclude that every ε-regular partition is already an
+**ε**-cut-approximation (`szemeredi_implies_fk_sharp`).
+
+### Why the sharp bound holds
+
+For an ε-regular pair `(P,Q)` and `A ⊆ P`, `B ⊆ Q`, write `e = e(A,B)` and
+`d = d(P,Q) ∈ [0,1]`. We bound `|e − d·|A|·|B||`:
+
+- **Large case** (`|A| ≥ ε|P|`, `|B| ≥ ε|Q|`): ε-regularity gives
+  `|d(A,B) − d| ≤ ε`; multiplying by `|A||B| ≤ |P||Q|` yields `≤ ε|P||Q|`.
+- **Small case** (`|A| < ε|P|` or `|B| < ε|Q|`): here `|A||B| ≤ ε|P||Q|`, so
+  **both** `e ≤ |A||B| ≤ ε|P||Q|` and `d·|A||B| ≤ |A||B| ≤ ε|P||Q|` individually.
+  For nonnegative `x, y` one has `|x − y| ≤ max(x, y)`, hence `|e − d|A||B|| ≤ ε|P||Q|`.
+
+The old proof used the weaker `|e − d|A||B|| ≤ e + d|A||B| ≤ 2ε|P||Q|` in the small
+case. Replacing `x + y` by `max(x, y)` recovers the factor of 1. Summing over all
+`|parts|²` pairs (via the same partition decomposition as the original) turns the
+per-pair `ε|P||Q|` into the global `ε·n²`.
+
+This is optimal: the large case already forces the `ε` rate, so no constant below 1
+is achievable by this route. Thus the answer to the OQ is **1** (the constant 2 was
+slack, not tight).
+
+## Main results
+
+- `pair_cut_error_bound_sharp` : single ε-regular pair ⟹ cut error ≤ ε|P||Q|
+- `szemeredi_implies_fk_sharp` : ε-regular partition ⟹ **ε**-cut-approximation
+
+## Tags
+graph-theory, combinatorics, szemeredi, regularity, frieze-kannan, cut-norm, sharp-constant
+-/
+
+import Mathlib
+import Proofs.SzemerediCore
+import Proofs.SzemerediRegularity
+import Proofs.SzemerediRegularityOQ02
+
+namespace SzemerediFKComparisonSharp
+
+open Szemeredi.Core Szemeredi.Regularity SzemerediFKComparison Classical
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Sharp per-pair cut error bound: ε|P||Q| (was 2ε|P||Q|)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Sharp per-pair lemma**: For an ε-regular pair `(P, Q)`, any `A ⊆ P`, `B ⊆ Q`
+    satisfy `|e(A,B) − d(P,Q)·|A|·|B|| ≤ ε·|P|·|Q|`.
+
+    This improves `SzemerediRegularityOQ02.pair_cut_error_bound` (which gives
+    `2ε·|P|·|Q|`) by a factor of 2. The improvement is in the "small" case: instead of
+    `|e − d|A||B|| ≤ e + d|A||B| ≤ 2ε|P||Q|`, we observe that `e` and `d|A||B|` are
+    *each* `≤ ε|P||Q|`, so their difference is too (`|x − y| ≤ max(x,y)` for `x,y ≥ 0`). -/
+theorem pair_cut_error_bound_sharp (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (heps : 0 < eps) (P Q A B : Finset V)
+    (hA : A ⊆ P) (hB : B ⊆ Q)
+    (hreg : IsEpsilonRegular G eps P Q) :
+    |(((A.product B).filter (fun p => G.Adj p.1 p.2)).card : ℚ) -
+      edgeDensity G P Q * A.card * B.card| ≤
+    eps * P.card * Q.card := by
+  set e := (((A.product B).filter (fun p => G.Adj p.1 p.2)).card : ℚ) with he_def
+  set d := edgeDensity G P Q with hd_def
+  have hnA : (0 : ℚ) ≤ A.card := Nat.cast_nonneg _
+  have hnB : (0 : ℚ) ≤ B.card := Nat.cast_nonneg _
+  have hnP : (0 : ℚ) ≤ P.card := Nat.cast_nonneg _
+  have hnQ : (0 : ℚ) ≤ Q.card := Nat.cast_nonneg _
+  have hAP : (A.card : ℚ) ≤ P.card := by exact_mod_cast Finset.card_le_card hA
+  have hBQ : (B.card : ℚ) ≤ Q.card := by exact_mod_cast Finset.card_le_card hB
+  have he_bound : e ≤ (A.card : ℚ) * B.card := by
+    simp only [he_def]
+    exact_mod_cast (Finset.card_filter_le _ _).trans (Finset.card_product A B).le
+  have he_nonneg : (0 : ℚ) ≤ e := by simp only [he_def]; positivity
+  have hd_nn : 0 ≤ d := edgeDensity_nonneg G P Q
+  have hd_le1 : d ≤ 1 := edgeDensity_le_one G P Q
+  by_cases hA_large : (A.card : ℚ) ≥ eps * P.card
+  · by_cases hB_large : (B.card : ℚ) ≥ eps * Q.card
+    · -- Both large: use ε-regularity — the difference is ≤ ε|A||B| ≤ ε|P||Q|.
+      rcases eq_or_lt_of_le hnA with hnA0 | hnA_pos
+      · have hA_eq0 : (A.card : ℚ) = 0 := hnA0.symm
+        have he0 : e = 0 := le_antisymm
+          (he_bound.trans (by simp [hA_eq0])) he_nonneg
+        simp [hA_eq0, he0]
+        positivity
+      rcases eq_or_lt_of_le hnB with hnB0 | hnB_pos
+      · have hB_eq0 : (B.card : ℚ) = 0 := hnB0.symm
+        have he0 : e = 0 := le_antisymm
+          (he_bound.trans (by simp [hB_eq0])) he_nonneg
+        simp [hB_eq0, he0]
+        positivity
+      have hnAB_pos : (0 : ℚ) < A.card * B.card := mul_pos hnA_pos hnB_pos
+      have hnAB_ne : (A.card : ℚ) * B.card ≠ 0 := ne_of_gt hnAB_pos
+      have h_dAB : edgeDensity G A B = e / (A.card * B.card) := by
+        unfold edgeDensity e; rw [dif_neg hnAB_ne]
+      have hdev : |edgeDensity G A B - d| ≤ eps := hreg A B hA hB hA_large hB_large
+      have h_err : |e - d * (A.card * B.card)| ≤ eps * (A.card * B.card) := by
+        have h1 : |e / (A.card * B.card) - d| ≤ eps := h_dAB ▸ hdev
+        have h2 : |e - d * (A.card * B.card)| / (A.card * B.card) ≤ eps := by
+          rwa [show e / (A.card * B.card) - d =
+            (e - d * (A.card * B.card)) / (A.card * B.card) from by field_simp,
+            abs_div, abs_of_pos hnAB_pos] at h1
+        calc |e - d * (A.card * B.card)|
+            = |e - d * (A.card * B.card)| / (A.card * B.card) * (A.card * B.card) :=
+                (div_mul_cancel₀ _ (ne_of_gt hnAB_pos)).symm
+          _ ≤ eps * (A.card * B.card) :=
+                mul_le_mul_of_nonneg_right h2 (le_of_lt hnAB_pos)
+      rw [show d * A.card * B.card = d * (A.card * B.card) from by ring]
+      calc |e - d * (A.card * B.card)|
+          ≤ eps * (A.card * B.card) := h_err
+        _ ≤ eps * (P.card * Q.card) :=
+              mul_le_mul_of_nonneg_left
+                (mul_le_mul hAP hBQ hnB_pos.le (hnA_pos.trans_le hAP).le)
+                (le_of_lt heps)
+        _ = eps * P.card * Q.card := by ring
+    · -- B small (|B| < ε|Q|): both e and d|A||B| are ≤ ε|P||Q| individually.
+      push_neg at hB_large
+      have hAB_le : (A.card : ℚ) * B.card ≤ eps * (P.card * Q.card) :=
+        calc (A.card : ℚ) * B.card
+            ≤ A.card * (eps * Q.card) :=
+                mul_le_mul_of_nonneg_left hB_large.le hnA
+          _ ≤ P.card * (eps * Q.card) :=
+                mul_le_mul_of_nonneg_right hAP (mul_nonneg (le_of_lt heps) hnQ)
+          _ = eps * (P.card * Q.card) := by ring
+      have he_le : e ≤ eps * (P.card * Q.card) := he_bound.trans hAB_le
+      have hd_AB : d * (A.card * B.card) ≤ eps * (P.card * Q.card) :=
+        (mul_le_of_le_one_left (by positivity) hd_le1).trans hAB_le
+      have hd_AB_nn : (0 : ℚ) ≤ d * (A.card * B.card) := by positivity
+      rw [show d * A.card * B.card = d * (A.card * B.card) from by ring, abs_le]
+      exact ⟨by nlinarith, by nlinarith⟩
+  · -- A small (|A| < ε|P|): both e and d|A||B| are ≤ ε|P||Q| individually.
+    push_neg at hA_large
+    have hAB_le : (A.card : ℚ) * B.card ≤ eps * (P.card * Q.card) :=
+      calc (A.card : ℚ) * B.card
+          ≤ A.card * Q.card :=
+              mul_le_mul_of_nonneg_left hBQ hnA
+        _ ≤ (eps * P.card) * Q.card :=
+              mul_le_mul_of_nonneg_right hA_large.le hnQ
+        _ = eps * (P.card * Q.card) := by ring
+    have he_le : e ≤ eps * (P.card * Q.card) := he_bound.trans hAB_le
+    have hd_AB : d * (A.card * B.card) ≤ eps * (P.card * Q.card) :=
+      (mul_le_of_le_one_left (by positivity) hd_le1).trans hAB_le
+    have hd_AB_nn : (0 : ℚ) ≤ d * (A.card * B.card) := by positivity
+    rw [show d * A.card * B.card = d * (A.card * B.card) from by ring, abs_le]
+    exact ⟨by nlinarith, by nlinarith⟩
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Sharp main comparison: ε-regular ⟹ ε-cut-approximation
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Szemerédi ⟹ Frieze-Kannan, sharp constant**: Every ε-regular partition is an
+    **ε**-cut-approximation (not merely `2ε`).
+
+    This answers `szemeredi-regularity-oq-02-oq-02`: the factor-of-2 in
+    `SzemerediRegularityOQ02.szemeredi_implies_fk` is *not* tight — it improves to 1.
+    The proof is identical to the original, but calls the sharp per-pair bound
+    `pair_cut_error_bound_sharp`, so the summed error is `ε·n²` rather than `2ε·n²`. -/
+theorem szemeredi_implies_fk_sharp (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (heps : 0 < eps)
+    (parts : Finset (Finset V))
+    (hcover : ∀ v : V, ∃ P ∈ parts, v ∈ P)
+    (hdisjoint : ∀ P Q : Finset V, P ∈ parts → Q ∈ parts → P ≠ Q → Disjoint P Q)
+    (hall_reg : ∀ P Q : Finset V, P ∈ parts → Q ∈ parts → IsEpsilonRegular G eps P Q) :
+    IsCutApproximation G eps parts := by
+  intro A B
+  rw [edge_count_partition_sum G A B parts hcover hdisjoint]
+  simp only [Nat.cast_sum]
+  rw [← Finset.sum_sub_distrib]
+  calc |(parts.product parts).sum (fun pq =>
+          (((A ∩ pq.1).product (B ∩ pq.2)).filter fun p => G.Adj p.1 p.2).card -
+          edgeDensity G pq.1 pq.2 * (A ∩ pq.1).card * (B ∩ pq.2).card)|
+      ≤ (parts.product parts).sum (fun pq =>
+          |(((A ∩ pq.1).product (B ∩ pq.2)).filter (fun p => G.Adj p.1 p.2)).card -
+            edgeDensity G pq.1 pq.2 * (A ∩ pq.1).card * (B ∩ pq.2).card|) :=
+        Finset.abs_sum_le_sum_abs _ _
+    _ ≤ (parts.product parts).sum (fun pq => eps * pq.1.card * pq.2.card) := by
+        apply Finset.sum_le_sum
+        intro ⟨P, Q⟩ hpq
+        exact pair_cut_error_bound_sharp G eps heps P Q (A ∩ P) (B ∩ Q)
+          Finset.inter_subset_right Finset.inter_subset_right
+          (hall_reg P Q (Finset.mem_product.mp hpq).1 (Finset.mem_product.mp hpq).2)
+    _ = eps * (Fintype.card V : ℚ) ^ 2 := by
+        simp_rw [show ∀ pq : Finset V × Finset V, eps * (pq.1.card : ℚ) * pq.2.card =
+            eps * ((pq.1.card : ℚ) * pq.2.card) from fun pq => by ring]
+        rw [← Finset.mul_sum]
+        congr 1
+        exact parts_product_sum_eq_card_sq parts hcover hdisjoint
+
+/-- Sanity check: the sharp bound really is stronger. Since `ε ≤ 2ε` for `ε ≥ 0`,
+    an `ε`-cut-approximation is in particular a `2ε`-cut-approximation, so
+    `szemeredi_implies_fk_sharp` recovers the original `szemeredi_implies_fk`. -/
+theorem sharp_recovers_original (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (heps : 0 < eps)
+    (parts : Finset (Finset V))
+    (hcover : ∀ v : V, ∃ P ∈ parts, v ∈ P)
+    (hdisjoint : ∀ P Q : Finset V, P ∈ parts → Q ∈ parts → P ≠ Q → Disjoint P Q)
+    (hall_reg : ∀ P Q : Finset V, P ∈ parts → Q ∈ parts → IsEpsilonRegular G eps P Q) :
+    IsCutApproximation G (2 * eps) parts := by
+  intro A B
+  have hsharp := szemeredi_implies_fk_sharp G eps heps parts hcover hdisjoint hall_reg A B
+  have hmono : eps * (Fintype.card V : ℚ) ^ 2 ≤ 2 * eps * (Fintype.card V : ℚ) ^ 2 := by
+    have : (0 : ℚ) ≤ eps * (Fintype.card V : ℚ) ^ 2 := by positivity
+    nlinarith
+  linarith
+
+#check @pair_cut_error_bound_sharp
+#check @szemeredi_implies_fk_sharp
+
+end SzemerediFKComparisonSharp
+
+-- Axiom audit: expect only propext / Classical.choice / Quot.sound.
+#print axioms SzemerediFKComparisonSharp.pair_cut_error_bound_sharp
+#print axioms SzemerediFKComparisonSharp.szemeredi_implies_fk_sharp
+#print axioms SzemerediFKComparisonSharp.sharp_recovers_original

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-04/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-cheb-oq0104-overview",
+    "proofId": "chebyshev-pnt-bridge-oq-01-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Overview: the ≤ 2n bound does not survive to multinomials",
+    "content": "The parent result (OQ-01) is the Kummer/carry-counting bound p^{v_p(C(2n,n))} ≤ 2n. This file asks whether it generalizes to the multinomial coefficient C(kn; n,…,n) = (kn)!/(n!)^k in the clean shape p^{v_p} ≤ kn, and shows it does NOT. The obstruction is genuinely mathematical, not a formalization artifact: for the two-term sum n + n every base-p carry is 0 or 1, so v_p equals the number of carry positions ≤ log_p(2n); but when adding k ≥ 3 copies of n a single column can carry up to k−1, so the valuation grows faster than one unit per digit. The correct replacement, proved here, is p^{v_p} ≤ n^k·k!, obtained from additivity of v_p over the product decomposition ∏_{j=1}^{k} C(jn,n).",
+    "mathContext": "Refutation witness $k=3,n=2,p=3$: $\\binom{6}{2,2,2}=90=2\\cdot 3^2\\cdot 5$, so $3^{v_3}=9>6=kn$. Correct bound: $p^{v_p} \\le \\prod_{j=1}^{k}(jn)=n^k\\,k!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kummer's theorem",
+      "multinomial coefficient",
+      "p-adic valuation",
+      "carry counting",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "p-adic valuation",
+      "base-p carries",
+      "binomial and multinomial coefficients",
+      "Nat.factorization API"
+    ]
+  },
+  {
+    "id": "ann-cheb-oq0104-identity",
+    "proofId": "chebyshev-pnt-bridge-oq-01-oq-04",
+    "range": {
+      "startLine": 57,
+      "endLine": 77
+    },
+    "type": "insight",
+    "title": "Product–multinomial identity (∏ C(jn,n))·(n!)^k = (kn)!",
+    "content": "The multinomial coefficient (kn)!/(n!)^k equals the telescoping product ∏_{j=1}^{k} C(jn,n). Rather than divide in ℕ, the identity is stated multiplicatively as (∏_{j=1}^{k} C(jn,n))·(n!)^k = (kn)! and proved by induction on k. The inductive step multiplies by C((k+1)n, n) and applies Nat.choose_mul_factorial_mul_factorial : k ≤ m → C(m,k)·k!·(m−k)! = m!, with m = (k+1)n and (k+1)n − n = kn. This one identity does double duty: it establishes the connection to the multinomial coefficient AND, specialized to k=3,n=2, evaluates the coefficient to exactly 90 for the refutation.",
+    "mathContext": "$\\binom{kn}{n,\\dots,n}=\\prod_{j=1}^{k}\\binom{jn}{n}$; step uses $\\binom{(k+1)n}{n}\\,n!\\,(kn)! = ((k+1)n)!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multinomial coefficient",
+      "telescoping product",
+      "factorial identities"
+    ],
+    "prerequisites": [
+      "induction",
+      "Nat.choose_mul_factorial_mul_factorial"
+    ]
+  },
+  {
+    "id": "ann-cheb-oq0104-bound",
+    "proofId": "chebyshev-pnt-bridge-oq-01-oq-04",
+    "range": {
+      "startLine": 79,
+      "endLine": 111
+    },
+    "type": "insight",
+    "title": "Corrected bound p^{v_p} ≤ n^k·k! via additivity of valuation",
+    "content": "Because the p-adic valuation is additive over products, v_p(∏_{j=1}^{k} C(jn,n)) = ∑_{j=1}^{k} v_p(C(jn,n)) (Nat.factorization_prod, requiring each factor nonzero, i.e. n ≤ jn). Exponentiating, p^{v_p} = ∏_{j} p^{v_p(C(jn,n))}, and each factor obeys the parent bound p^{v_p(C(jn,n))} ≤ jn (Mathlib's Nat.pow_factorization_choose_le, valid since 0 < jn). Multiplying the per-factor bounds gives p^{v_p} ≤ ∏_{j=1}^{k}(jn) = n^k·k!. The final product monotonicity is Finset.prod_le_prod, and ∏_{j=1}^{k}(jn) = n^k·k! is the auxiliary prod_Icc_mul_const (Finset.prod_Icc_id_eq_factorial gives ∏ j = k!).",
+    "mathContext": "$p^{v_p(\\prod_j \\binom{jn}{n})}=\\prod_j p^{v_p(\\binom{jn}{n})}\\le\\prod_{j=1}^{k}(jn)=n^k k!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "additivity of p-adic valuation",
+      "Nat.pow_factorization_choose_le",
+      "Nat.factorization_prod"
+    ],
+    "prerequisites": [
+      "factorization of products",
+      "monotonicity of finite products"
+    ]
+  },
+  {
+    "id": "ann-cheb-oq0104-refutation",
+    "proofId": "chebyshev-pnt-bridge-oq-01-oq-04",
+    "range": {
+      "startLine": 113,
+      "endLine": 143
+    },
+    "type": "insight",
+    "title": "The refutation: 3² ∣ 90 kills the ≤ kn conjecture",
+    "content": "To disprove ∀ k n p, p^{v_p} ≤ kn it suffices to exhibit one failing instance. Taking k=3, n=2, p=3, the identity fixes multiProd 3 2 = 90 (from multiProd 3 2 · (2!)^3 = 6!, i.e. · 8 = 720). Divisibility 3² ∣ 90 gives, via Nat.Prime.pow_dvd_iff_le_factorization, the lower bound v_3(90) ≥ 2. Hence 3^{v_3} ≥ 3² = 9, while the conjecture would force 3^{v_3} ≤ kn = 6 — and 9 ≤ 6 is absurd. Note the corrected bound is respected here: n^k·k! = 2³·3! = 48 ≥ 9.",
+    "mathContext": "$3^2\\mid 90\\Rightarrow v_3(90)\\ge 2\\Rightarrow 3^{v_3}\\ge 9>6=kn$; corrected bound $2^3\\cdot 3!=48\\ge 9$ holds.",
+    "significance": "key",
+    "relatedConcepts": [
+      "counterexample",
+      "p-adic valuation lower bound",
+      "Nat.Prime.pow_dvd_iff_le_factorization"
+    ],
+    "prerequisites": [
+      "divisibility and valuation",
+      "proof by counterexample"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-04/meta.json
@@ -1,0 +1,100 @@
+{
+  "id": "chebyshev-pnt-bridge-oq-01-oq-04",
+  "title": "Multinomial Prime-Power Bounds: the ≤ 2n Central-Binomial Bound Does NOT Generalize to ≤ kn",
+  "slug": "chebyshev-pnt-bridge-oq-01-oq-04",
+  "description": "Investigates whether the Kummer/carry-counting bound p^{v_p(C(2n,n))} ≤ 2n generalizes to the multinomial coefficient C(kn; n,…,n) = (kn)!/(n!)^k as p^{v_p} ≤ kn. It does NOT: refuted with the explicit witness k=3, n=2, p=3 (the coefficient is 90 = 2·3²·5, so 3² = 9 > 6). The honest generalization is p^{v_p} ≤ n^k·k!, proved from Mathlib's Nat.pow_factorization_choose_le via the product-of-binomials decomposition ∏_{j=1}^{k} C(jn,n).",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ01OQ04.lean",
+    "tags": [
+      "number-theory",
+      "analytic-number-theory",
+      "Kummer",
+      "Chebyshev",
+      "multinomial",
+      "p-adic-valuation",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 150,
+    "assumptions": "None. 0 literal `axiom` declarations, 0 structure-encoded assumptions, 0 sorries, no native_decide (small factorial identities use kernel `decide` only). Build-verified 2026-07-07 via `./proofs/scripts/docker-build.sh Proofs.ChebyshevPNTBridgeOQ01OQ04` (Lean v4.26.0, Mathlib pin): #print axioms reports only [propext, Classical.choice, Quot.sound] for multiProd_mul_pow_factorial, multiProd_prime_pow_le, and naive_multinomial_bound_false. (The original 2026-07-04 session wrote this entry BUILD-PENDING during a Docker outage; one v4.26 drift fix was applied on salvage: `Finset.prod_Icc_id_eq_factorial` no longer exists, `prod_Icc_mul_const` is now proved by induction.)",
+    "dateAdded": "2026-07-04",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Refutation: the naive multinomial generalization p^{v_p} ≤ kn is FALSE (smallest witness k=3,n=2,p=3, coefficient 90, 3²=9>6) — theorem naive_multinomial_bound_false",
+      "Corrected Kummer-type bound p^{v_p(∏_{j=1}^k C(jn,n))} ≤ n^k·k! — theorem multiProd_prime_pow_le",
+      "Product–multinomial identity (∏_{j=1}^k C(jn,n))·(n!)^k = (kn)! by induction — lemma multiProd_mul_pow_factorial",
+      "Identification of the mechanism: the ≤ 2n bound is special to two-term sums; for k ≥ 3 terms base-p carries accumulate beyond a single digit position"
+    ],
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The bound p^{v_p(C(2n,n))} ≤ 2n on the p-adic valuation of the central binomial coefficient is the combinatorial heart of Chebyshev's (1852) elementary lower bound on π(x) and of Erdős's (1932) proof of Bertrand's postulate. By Kummer's theorem, v_p(C(2n,n)) counts the carries when adding n + n in base p; since carries occur only at digit positions i with p^i ≤ 2n, the valuation is at most log_p(2n) and hence p^{v_p} ≤ 2n. A natural research question (parent OQ-01) asks whether this carry-counting bound extends to the multinomial coefficient C(kn; n,…,n) = (kn)!/(n!)^k that governs the analogous k-fold problem, in the clean form p^{v_p} ≤ kn.",
+    "problemStatement": "Does p^{v_p(C(kn; n,…,n))} ≤ kn hold for all k, n and primes p (the direct analogue of the central-binomial bound ≤ 2n)? If not, what is the correct bound?",
+    "proofStrategy": "1. Represent the multinomial coefficient as the telescoping product ∏_{j=1}^{k} C(jn, n), proved multiplicatively as (∏ C(jn,n))·(n!)^k = (kn)! by induction on k using Nat.choose_mul_factorial_mul_factorial. 2. Since v_p is additive over products (Nat.factorization_prod), p^{v_p(∏)} = ∏ p^{v_p(C(jn,n))} ≤ ∏ (jn) = n^k·k! using Nat.pow_factorization_choose_le on each factor. 3. Refute the ≤ kn conjecture: the identity pins multiProd 3 2 = 90; since 3² ∣ 90 we get v_3 ≥ 2, so 3^{v_3} ≥ 9 > 6 = 3·2, contradicting the conjectured ≤ kn.",
+    "keyInsights": [
+      "**The conjecture is false.** Unlike the two-term central-binomial case, the k-fold multinomial bound p^{v_p} ≤ kn fails already at k=3, n=2, p=3: the coefficient is 90 = 2·3²·5, so the 3-part is 9 > 6.",
+      "**Why two terms are special.** For C(2n,n) the carries in n + n are each 0 or 1, so v_p equals the *number* of carry positions ≤ log_p(2n). When adding k ≥ 3 copies of n, a single column can carry up to k−1, so the valuation accumulates faster than one unit per digit and can exceed log_p(kn).",
+      "**The honest replacement bound.** Additivity of v_p over the product ∏_{j=1}^{k} C(jn,n) gives p^{v_p} ≤ ∏_{j=1}^{k}(jn) = n^k·k!, a clean multiplicative bound that holds for every prime power (verified numerically over a wide range).",
+      "**The product–multinomial identity is the workhorse.** (∏_{j=1}^{k} C(jn,n))·(n!)^k = (kn)! both connects the explicit product to the multinomial coefficient (kn)!/(n!)^k and, evaluated at k=3,n=2, computes the exact value 90 needed for the refutation — a single lemma serving both the positive and negative result."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Documentation",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "States the open question and summarizes the three results: the product–multinomial identity, the corrected bound p^{v_p} ≤ n^k·k!, and the refutation of the naive ≤ kn conjecture."
+    },
+    {
+      "id": "multiprod-def",
+      "title": "The product object multiProd",
+      "startLine": 45,
+      "endLine": 55,
+      "summary": "Defines multiProd k n = ∏_{j=1}^{k} C(jn,n) and its one-step unfolding via Finset.prod_Icc_succ_top."
+    },
+    {
+      "id": "identity",
+      "title": "Product–multinomial identity",
+      "startLine": 57,
+      "endLine": 77,
+      "summary": "Proves (∏_{j=1}^{k} C(jn,n))·(n!)^k = (kn)! by induction on k, using Nat.choose_mul_factorial_mul_factorial for the step. Establishes multiProd = (kn)!/(n!)^k."
+    },
+    {
+      "id": "bound",
+      "title": "Corrected Kummer-type bound",
+      "startLine": 79,
+      "endLine": 113,
+      "summary": "Auxiliary ∏_{j=1}^{k}(jn) = n^k·k!, then p^{v_p(multiProd k n)} ≤ n^k·k! via additivity of factorization over products (Nat.factorization_prod) and Nat.pow_factorization_choose_le per factor."
+    },
+    {
+      "id": "refutation",
+      "title": "Refutation of the naive bound",
+      "startLine": 115,
+      "endLine": 150,
+      "summary": "Shows ¬ ∀ k n p, … , p^{v_p} ≤ kn. Uses the identity to compute multiProd 3 2 = 90, divisibility 3²∣90 to get v_3 ≥ 2, hence 3^{v_3} ≥ 9 > 6 = 3·2."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Factorization",
+      "Mathlib.Data.Nat.Choose.Central",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "ChebyshevPNTBridgeOQ01OQ04",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/ChebyshevPNTBridgeOQ01OQ04.lean"
+  }
+}

--- a/src/data/proofs/erdos-1017-oq-05/annotations.json
+++ b/src/data/proofs/erdos-1017-oq-05/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "erdos1017oq05-ann-structures",
+    "proofId": "erdos-1017-oq-05",
+    "range": { "startLine": 70, "endLine": 109 },
+    "type": "definition",
+    "title": "Hypergraphs and the Complete-Sub-hypergraph (Clique) Analog",
+    "content": "A k-uniform hypergraph H (structure Hypergraph) is a finite family of k-element vertex sets, its hyperedges; at k=2 this is a graph's edge set. The clique generalizes to Hypergraph.IsCompleteSub: a vertex set S all of whose k-subsets are hyperedges of H (for k=2, every pair inside S is an edge — an ordinary clique). The one arithmetic fact carrying the whole framework is eq_of_subset_of_card_eq: two k-sets nested by ⊆ are equal (Finset.eq_of_subset_of_card_le). It immediately gives isCompleteSub_of_mem_edges — a hyperedge is its own complete sub-hypergraph, since its only k-subset is itself.",
+    "mathContext": "$S$ is complete when $\\forall e \\subseteq S,\\ |e| = k \\Rightarrow e \\in E(H)$; nested $k$-sets $e \\subseteq f$ with $|e| = |f| = k$ satisfy $e = f$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "k-uniform hypergraph",
+      "complete sub-hypergraph",
+      "clique",
+      "Finset cardinality"
+    ],
+    "prerequisites": [
+      "finite sets and subsets",
+      "hypergraph terminology"
+    ]
+  },
+  {
+    "id": "erdos1017oq05-ann-cover-partition",
+    "proofId": "erdos-1017-oq-05",
+    "range": { "startLine": 111, "endLine": 158 },
+    "type": "definition",
+    "title": "Cover, Partition, and the Two Extremal Numbers",
+    "content": "A CompleteCover asks each hyperedge to lie inside (⊆) at least one complete sub-hypergraph; a CompletePartition strengthens this to exactly one, phrased with ExistsUnique. Forgetting the uniqueness clause (CompletePartition.toCover) turns any partition into a cover on the same family — the structural heart of the always-true direction. The extremal numbers coverNum = ccₖ(H) and partitionNum = cpₖ(H) are the infima of achievable family sizes.",
+    "mathContext": "$cc_k(H) = \\inf\\{|\\mathcal C| : \\mathcal C \\text{ a complete-sub cover}\\}$, $cp_k(H)$ likewise over partitions.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "edge clique cover",
+      "edge clique partition",
+      "ExistsUnique",
+      "infimum over ℕ (sInf)"
+    ],
+    "prerequisites": [
+      "unique existence",
+      "infimum of a set of naturals"
+    ]
+  },
+  {
+    "id": "erdos1017oq05-ann-main",
+    "proofId": "erdos-1017-oq-05",
+    "range": { "startLine": 160, "endLine": 208 },
+    "type": "theorem",
+    "title": "The Main Inequality ccₖ(H) ≤ cpₖ(H)",
+    "content": "The trivialPartition — each hyperedge as its own complete sub-hypergraph — witnesses that a partition always exists (its uniqueness clause is exactly eq_of_subset_of_card_eq: a hyperedge sits inside only itself). So partitionNum is a genuine minimum, not the vacuous sInf ∅. The main theorem coverNum_le_partitionNum then follows structurally: take a minimum partition (Nat.sInf_mem), forget disjointness via toCover to get a cover of the same size, and conclude coverNum ≤ that size by Nat.sInf_le. The argument never mentions k, so the inequality is uniform across all uniformities — the graph result cc(G) ≤ cp(G) of OQ-04 (k=2) lifts verbatim.",
+    "mathContext": "Every partition is a cover of the same size, hence $\\inf(\\text{cover sizes}) \\le \\inf(\\text{partition sizes})$, i.e. $cc_k(H) \\le cp_k(H)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "clique cover vs partition",
+      "Nat.sInf_mem",
+      "Nat.sInf_le",
+      "uniform-in-k argument"
+    ],
+    "prerequisites": [
+      "infima achieve their value when the witness set is nonempty",
+      "structural forgetting of a constraint"
+    ]
+  },
+  {
+    "id": "erdos1017oq05-ann-keystones",
+    "proofId": "erdos-1017-oq-05",
+    "range": { "startLine": 210, "endLine": 290 },
+    "type": "theorem",
+    "title": "Upper Bounds, Disjointness Keystone, and Positivity",
+    "content": "Both numbers are bounded by the hyperedge count (partitionNum_le_edgesCard, coverNum_le_edgesCard) via the trivial partition. The disjointness keystone CompletePartition.edge_unique_clique states a hyperedge lies in a UNIQUE partition clique — exactly the property a cover lacks, and (as in the graph case) the structural reason cpₖ can exceed ccₖ; every partition-number lower bound rests on it. The base cases coverNum_pos_of_edge and partitionNum_pos_of_edge show both numbers are ≥ 1 once H has a hyperedge, by a card_eq_zero contradiction: an empty family cannot contain any hyperedge. These are the reusable lemmas a future strict-gap argument (a concrete witness hypergraph plus a counting identity over k-subsets) would build on. The strict gap ccₖ(H) < cpₖ(H) is left open, honestly parallel to the open strict graph gap.",
+    "mathContext": "$cc_k(H), cp_k(H) \\le |E(H)|$; a hyperedge determines its partition clique uniquely; both numbers $\\ge 1$ when $E(H) \\ne \\varnothing$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "edge-disjointness",
+      "partition-number lower bound",
+      "counting identity",
+      "strict gap witness"
+    ],
+    "prerequisites": [
+      "Finset.card_eq_zero",
+      "unique existence extraction"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1017-oq-05/meta.json
+++ b/src/data/proofs/erdos-1017-oq-05/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "erdos-1017-oq-05",
+  "title": "Erdős #1017 (OQ-05): the cover ≤ partition inequality ccₖ(H) ≤ cpₖ(H) lifts to k-uniform hypergraphs",
+  "slug": "erdos-1017-oq-05",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1017OQ05",
+    "lineCount": 317,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1017OQ05.lean",
+    "sorries": 0
+  },
+  "description": "Generalizes the clique-cover vs clique-partition problem of Erdős #1017 (OQ-04) from graphs to k-uniform hypergraphs, and proves the always-true direction ccₖ(H) ≤ cpₖ(H) for every uniformity k with zero axioms and zero sorries. A k-uniform hypergraph is a finite family of k-element vertex sets (hyperedges); a *complete sub-hypergraph* is a vertex set S all of whose k-subsets are hyperedges — the exact clique analog, recovering a graph clique at k=2. A complete-subhypergraph *cover* asks each hyperedge to lie inside (⊆) at least one complete sub-hypergraph; a *partition* requires exactly one (phrased as ExistsUnique). Defines the two extremal numbers coverNum = ccₖ(H) and partitionNum = cpₖ(H) as infima over achievable family sizes. Main theorem coverNum_le_partitionNum: every partition is a cover of the same size (CompletePartition.toCover), so ccₖ(H) ≤ cpₖ(H). The trivial partition (each hyperedge its own complete sub-hypergraph) witnesses that a partition always exists — so partitionNum is a genuine minimum, not the vacuous sInf ∅ — and gives the upper bounds cpₖ(H), ccₖ(H) ≤ |edges|. Includes the disjointness keystone CompletePartition.edge_unique_clique (a hyperedge lies in a UNIQUE partition clique) and the positivity base cases coverNum_pos_of_edge, partitionNum_pos_of_edge, the reusable lemmas for a future strict-gap lower bound. Directly mirrors the proven graph case in Erdos1017OQ04.lean (k=2). 12 theorems, 8 definitions/structures, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1017OQ05.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "hypergraphs",
+      "extremal-combinatorics",
+      "clique-partition",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ05` builds green (Lean v4.26.0, Mathlib pin, 3058 jobs). 0 sorries, 0 axiom declarations, no native_decide, no structure-encoded assumptions; only the standard foundational axioms (propext / Classical.choice / Quot.sound) via Mathlib. Self-contained: the hypergraph, cover, and partition structures are declared here and depend only on Mathlib (no import of the graph companion Erdos1017OQ04.lean). Honest scope: this proves the always-true direction ccₖ(H) ≤ cpₖ(H) for all k, showing OQ-04's structure lifts cleanly to hypergraphs. It does NOT prove the gap can be strict for any fixed k — that remains open (as the strict graph gap does at k=2) and needs a concrete witness hypergraph plus a counting lower bound built on the edge_unique_clique keystone provided here.",
+    "lineCount": 317,
+    "theoremCount": 12,
+    "definitionCount": 8,
+    "originalContributions": [
+      "Hypergraph: a k-uniform hypergraph as a finite family of k-element vertex sets (the k=2 case is a graph's edge set)",
+      "Hypergraph.IsCompleteSub: the clique analog for hypergraphs — a vertex set all of whose k-subsets are hyperedges",
+      "CompleteCover / CompletePartition: the cover (hyperedge ⊆ ≥1 complete sub-hypergraph) and partition (⊆ exactly one, via ExistsUnique) structures",
+      "CompletePartition.toCover: every partition is a cover of the same underlying family — the structural heart of the always-true direction",
+      "trivialPartition + isCompleteSub_of_mem_edges: each hyperedge is its own complete sub-hypergraph, giving a partition that always exists (partitionNum is a genuine minimum, not sInf ∅)",
+      "coverNum_le_partitionNum: the MAIN result ccₖ(H) ≤ cpₖ(H) for every k-uniform hypergraph, lifting OQ-04's cc(G) ≤ cp(G) from graphs to all uniformities",
+      "partitionNum_le_edgesCard, coverNum_le_edgesCard: both numbers are at most the number of hyperedges (each edge its own clique)",
+      "CompletePartition.edge_unique_clique: the disjointness keystone — a hyperedge lies in a UNIQUE partition clique — on which every partition-number lower bound and any strict-gap argument rests",
+      "coverNum_pos_of_edge, partitionNum_pos_of_edge: both numbers are ≥ 1 once H has a hyperedge (base case of the lower-bound ladder)",
+      "mem_edges_of_isCompleteSub_card_eq: the k=2 sanity check — a k-set is a complete sub-hypergraph iff it is a hyperedge, matching the graph case where a single edge is the smallest clique"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1017 (Erdős-Goodman-Pósa, 1966) concerns f(n,k), the minimum number of complete subgraphs needed to edge-partition every n-vertex k-edge graph. OQ-04 (Erdos1017OQ04.lean) isolates the well-defined structural content behind the 'covering vs partition' gap: the clique cover number cc(G) (each edge in ≥ 1 clique) versus the clique partition number cp(G) (each edge in exactly one clique), with the always-true direction cc(G) ≤ cp(G). This OQ-05 entry answers the natural follow-up — does the problem extend to hypergraphs? — by lifting the whole cover/partition framework to k-uniform hypergraphs, where a clique becomes a complete sub-hypergraph (a vertex set all of whose k-subsets are hyperedges).",
+    "problemStatement": "For a k-uniform hypergraph H, let ccₖ(H) be the minimum number of complete sub-hypergraphs needed to cover its hyperedges (each hyperedge inside at least one) and cpₖ(H) the minimum number to partition them (each hyperedge inside exactly one). Does the graph inequality cc ≤ cp persist at every uniformity k?",
+    "proofStrategy": "The argument is structural and uniform in k, mirroring the graph proof. A complete sub-hypergraph S contains a hyperedge e when e ⊆ S. Every partition P forgets to a cover P.toCover on the same family (drop uniqueness), so any partition of size cpₖ(H) yields a cover of that size, and the infimum coverNum is ≤ it. The one arithmetic fact that makes the framework work is eq_of_subset_of_card_eq: two k-sets nested by ⊆ are equal (Finset.eq_of_subset_of_card_le). It powers both isCompleteSub_of_mem_edges (a hyperedge is its own complete sub-hypergraph, since its only k-subset is itself) and the uniqueness clause of the trivial partition (a hyperedge sits inside exactly one hyperedge-clique — itself). Positivity is a card_eq_zero contradiction: an empty cover/partition cannot contain any hyperedge.",
+    "keyInsights": [
+      "The graph clique = 'vertex set all of whose pairs are edges' generalizes verbatim to the hypergraph complete sub-hypergraph = 'vertex set all of whose k-subsets are hyperedges'; at k=2 the two coincide.",
+      "The always-true direction cc ≤ cp is purely structural (partition ⟹ cover by forgetting disjointness) and never uses k, so it lifts to every uniformity with no new mathematics.",
+      "The single fact carrying the k-uniform framework is that two k-sets nested by ⊆ are equal — it makes each hyperedge its own unique complete sub-hypergraph and validates the trivial partition.",
+      "The disjointness keystone edge_unique_clique (a hyperedge lies in a unique partition clique) is exactly the property a cover lacks, and — as in the graph case — the structural reason cpₖ can exceed ccₖ. It is the hypothesis any partition-number lower bound (e.g. a counting identity over the k-subsets) is built on.",
+      "The strict gap ccₖ(H) < cpₖ(H) is left open for every k, honestly parallel to the open strict graph gap; this entry supplies the reusable positivity base cases and disjointness keystone a witness argument would need."
+    ]
+  },
+  "sections": [
+    {
+      "id": "structures",
+      "title": "Hypergraphs and Complete Sub-hypergraphs",
+      "summary": "Hypergraph (k-uniform family), Hypergraph.IsCompleteSub (the clique analog), eq_of_subset_of_card_eq (nested k-sets are equal), and isCompleteSub_of_mem_edges (each hyperedge is its own complete sub-hypergraph).",
+      "startLine": 70,
+      "endLine": 109,
+      "mathContext": "A complete sub-hypergraph S requires every k-subset of S to be a hyperedge. Two k-sets nested by ⊆ are equal via Finset.eq_of_subset_of_card_le, so a hyperedge's only k-subset is itself."
+    },
+    {
+      "id": "cover-partition",
+      "title": "Cover and Partition Structures and Numbers",
+      "summary": "CompleteCover, CompletePartition (ExistsUnique), CompletePartition.toCover (partition ⟹ cover), and the numbers coverNum = ccₖ(H), partitionNum = cpₖ(H) as infima over achievable sizes.",
+      "startLine": 111,
+      "endLine": 158,
+      "mathContext": "A partition strengthens a cover by requiring each hyperedge inside exactly one complete sub-hypergraph; toCover drops the uniqueness to recover a cover on the same family."
+    },
+    {
+      "id": "trivial-and-main",
+      "title": "Trivial Partition and the Main Inequality",
+      "summary": "trivialPartition (each hyperedge its own clique) with trivialPartition_card, partitionNum_set_nonempty, and coverNum_le_partitionNum — the MAIN result ccₖ(H) ≤ cpₖ(H).",
+      "startLine": 160,
+      "endLine": 208,
+      "mathContext": "The trivial partition witnesses a partition always exists; the minimum partition forgets to a cover of the same size, so the minimum cover size is at most it."
+    },
+    {
+      "id": "bounds-and-keystones",
+      "title": "Upper Bounds, Disjointness Keystone, and Positivity",
+      "summary": "partitionNum_le_edgesCard, coverNum_le_edgesCard (both ≤ |edges|), CompletePartition.edge_unique_clique (unique partition clique per hyperedge), and coverNum_pos_of_edge, partitionNum_pos_of_edge (≥ 1 once H has a hyperedge).",
+      "startLine": 210,
+      "endLine": 290,
+      "mathContext": "Each edge as its own clique bounds both numbers by |edges|; the uniqueness clause of a partition gives the disjointness keystone; an empty family cannot contain any hyperedge, giving positivity via card_eq_zero."
+    }
+  ],
+  "conclusion": {
+    "summary": "The clique-cover vs clique-partition framework of Erdős #1017 (OQ-04) lifts cleanly from graphs to k-uniform hypergraphs: with a complete sub-hypergraph (every k-subset a hyperedge) as the clique analog, the always-true direction ccₖ(H) ≤ cpₖ(H) holds for every uniformity k, proved with zero axioms and zero sorries. The trivial partition (each hyperedge its own complete sub-hypergraph) guarantees a partition always exists and bounds both numbers by the hyperedge count; the disjointness keystone edge_unique_clique and the positivity base cases are supplied for future lower-bound work.",
+    "implications": "The result answers the natural hypergraph extension question of OQ-05 in the structural direction: nothing about the cover ≤ partition inequality depends on the uniformity, so it is a genuinely uniform phenomenon. The framework (Hypergraph, IsCompleteSub, CompleteCover, CompletePartition) and the edge_unique_clique keystone are the reusable scaffolding for attacking the still-open strict gap ccₖ(H) < cpₖ(H) on a concrete witness hypergraph — the k-uniform analog of the graph book-graph witness K_4 - e.",
+    "openQuestions": [
+      "Exhibit, for some fixed k ≥ 2 and a concrete k-uniform hypergraph H, a strict gap ccₖ(H) < cpₖ(H), using the edge_unique_clique keystone and a counting identity over k-subsets.",
+      "Formulate and bound the extremal function f_k(n, m) — the maximum, over m-hyperedge k-uniform hypergraphs on n vertices, of the minimum complete sub-hypergraphs needed to partition — as the hypergraph analog of the Erdős-Goodman-Pósa bound floor(n^2/4).",
+      "Bridge the k=2 specialization formally to the SimpleGraph EdgeCliquePartition of Erdos1017OQ04.lean, exhibiting an explicit isomorphism of the two partition numbers."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1017-oq-04",
+      "relationship": "parent",
+      "description": "The graph case (k=2): defines EdgeCliqueCover / EdgeCliquePartition on a SimpleGraph and proves cc(G) ≤ cp(G) with the same partition ⟹ cover structure, the trivial partition, the edge_unique_clique keystone, and positivity. This entry lifts that whole framework to k-uniform hypergraphs, showing the inequality is uniform in k."
+    }
+  ]
+}

--- a/src/data/proofs/fibonacci-identities-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-04/annotations.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "fibonacci-identities-oq-01-oq-04",
+    "range": { "startLine": 5, "endLine": 50 },
+    "type": "concept",
+    "title": "Gelin–Cesàro from Catalan",
+    "content": "The Gelin–Cesàro identity F(n−2)·F(n−1)·F(n+1)·F(n+2) = F(n)⁴ − 1 (Gelin–Cesàro, 1880s) is a quartic Fibonacci product identity, one degree above the quadratic Cassini/Catalan/d'Ocagne relations. This file answers the fourth open question of the parent fibonacci-identities-oq-01 by reducing it to Catalan's identity. Grouping the four flanking terms as an outer pair F(n−2)·F(n+2) and an inner pair F(n−1)·F(n+1), each pair is a Catalan slice; the two Catalan values are F(n)² − (−1)ⁿ and F(n)² + (−1)ⁿ, whose product is the difference of squares F(n)⁴ − 1. Mathlib has no Fibonacci product identities of this degree, so the engine here is original.",
+    "mathContext": "$F_{n-2}F_{n-1}F_{n+1}F_{n+2}=(F_n^2-(-1)^n)(F_n^2+(-1)^n)=F_n^4-1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gelin–Cesàro identity",
+      "Catalan's identity",
+      "difference of squares",
+      "Fibonacci product identities"
+    ]
+  },
+  {
+    "id": "ann-sign",
+    "proofId": "fibonacci-identities-oq-01-oq-04",
+    "range": { "startLine": 56, "endLine": 59 },
+    "type": "technique",
+    "title": "The only content of the −1",
+    "content": "neg_one_pow_sq proves ((−1)ᵐ)² = 1 by rewriting (a^m)^2 = a^(m·2) (← pow_mul) and applying Even.neg_one_pow to Even (m+m). This single sign fact is the entire arithmetic reason the identity ends in −1: after the difference of squares, the leftover term is exactly ((−1)ᵐ)², which this lemma collapses to 1.",
+    "mathContext": "$((-1)^m)^2=(-1)^{2m}=1$ since $2m$ is even.",
+    "significance": "supporting",
+    "relatedConcepts": ["parity", "Even.neg_one_pow", "sign tracking"]
+  },
+  {
+    "id": "ann-pairs",
+    "proofId": "fibonacci-identities-oq-01-oq-04",
+    "range": { "startLine": 61, "endLine": 81 },
+    "type": "technique",
+    "title": "Two Catalan slices, opposite signs",
+    "content": "fib_outer_pair applies Catalan's gap identity fib_catalan_gap m 2: with F(2) = 1 it gives F(m)·F(m+4) = F(m+2)² − (−1)ᵐ. fib_inner_pair applies fib_catalan_gap (m+1) 1: with F(1) = 1 and (−1)^{m+1} = −(−1)ᵐ it gives F(m+1)·F(m+3) = F(m+2)² + (−1)ᵐ. The shift-by-one between the r=2 and r=1 base points flips the sign, so the two pairs carry −(−1)ᵐ and +(−1)ᵐ — precisely the ± halves a difference of squares needs. Each is rearranged from Catalan by linarith after normalising the index (2·2 = 4, m+1+2·1 = m+3) and the base value.",
+    "mathContext": "$F_mF_{m+4}=F_{m+2}^2-(-1)^m,\\qquad F_{m+1}F_{m+3}=F_{m+2}^2+(-1)^m.$",
+    "significance": "key",
+    "relatedConcepts": ["Catalan's identity", "index normalisation", "linarith"]
+  },
+  {
+    "id": "ann-gap",
+    "proofId": "fibonacci-identities-oq-01-oq-04",
+    "range": { "startLine": 83, "endLine": 100 },
+    "type": "technique",
+    "title": "The difference-of-squares engine",
+    "content": "fib_gelin_cesaro_gap is the subtraction-free heart of the file: F(m)·F(m+1)·F(m+3)·F(m+4) = F(m+2)⁴ − 1. A calc regroups the four-fold product as (outer pair)·(inner pair) by ring, rewrites both pairs with fib_outer_pair/fib_inner_pair to get (F(m+2)² − (−1)ᵐ)(F(m+2)² + (−1)ᵐ), expands the difference of squares to F(m+2)⁴ − ((−1)ᵐ)² by ring, and finishes by rewriting ((−1)ᵐ)² = 1 (neg_one_pow_sq). No induction is needed — all the recurrence content is already inside Catalan.",
+    "mathContext": "$F_mF_{m+1}F_{m+3}F_{m+4}=F_{m+2}^4-((-1)^m)^2=F_{m+2}^4-1.$",
+    "significance": "key",
+    "relatedConcepts": ["difference of squares", "calc proof", "ring"]
+  },
+  {
+    "id": "ann-named",
+    "proofId": "fibonacci-identities-oq-01-oq-04",
+    "range": { "startLine": 102, "endLine": 116 },
+    "type": "technique",
+    "title": "Re-indexing to the named form",
+    "content": "fib_gelin_cesaro recovers the classical statement for n ≥ 2. Writing n = 2 + m (Nat.exists_eq_add_of_le) turns the subtraction indices into sums — 2+m−2 = m, 2+m−1 = m+1, 2+m+1 = m+3, 2+m+2 = m+4, 2+m = m+2 — each discharged by omega, after which the gap engine applies verbatim. Deferring ℕ-subtraction to this final step keeps the core proof subtraction-free.",
+    "mathContext": "$n=2+m\\ \\Rightarrow\\ (F_{n-2},F_{n-1},F_n,F_{n+1},F_{n+2})=(F_m,F_{m+1},F_{m+2},F_{m+3},F_{m+4}).$",
+    "significance": "supporting",
+    "relatedConcepts": ["ℕ-subtraction", "Nat.exists_eq_add_of_le", "omega"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "fibonacci-identities-oq-01-oq-04",
+    "range": { "startLine": 118, "endLine": 127 },
+    "type": "example",
+    "title": "Numeric sanity checks",
+    "content": "Two kernel-decidable instances confirm the identity: n=4 gives F₂·F₃·F₅·F₆ = 1·2·5·8 = 80 = 3⁴ − 1, and n=6 gives F₄·F₅·F₇·F₈ = 3·5·13·21 = 4095 = 8⁴ − 1. These use `decide` (kernel reduction), contributing no axioms beyond the foundational set.",
+    "mathContext": "$F_4F_5F_7F_8=3\\cdot5\\cdot13\\cdot21=4095=8^4-1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["decide", "numeric verification"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-01-oq-04/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ01OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOq01Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOq01Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOq01Oq04Data: ProofData = {
+  proof: fibonacciIdentitiesOq01Oq04Proof,
+  annotations: fibonacciIdentitiesOq01Oq04Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-01-oq-04/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-04/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "fibonacci-identities-oq-01-oq-04",
+  "title": "The Gelin–Cesàro Identity via Catalan's Identity",
+  "slug": "fibonacci-identities-oq-01-oq-04",
+  "description": "The Gelin–Cesàro identity F(n−2)·F(n−1)·F(n+1)·F(n+2) = F(n)⁴ − 1 (for n ≥ 2): the product of the four Fibonacci numbers symmetrically flanking F(n) is exactly one less than F(n)⁴. The proof factors through Catalan's identity F(m+r)² − F(m)·F(m+2r) = (−1)ᵐ·F(r)² (proved as fib_catalan_gap in the sibling entry fibonacci-identities-oq-01-oq-02-oq-01). Writing m = n−2 and pairing the outer and inner factors: the outer pair (Catalan r=2, F(2)=1) gives F(m)·F(m+4) = F(m+2)² − (−1)ᵐ, and the inner pair (Catalan r=1, F(1)=1) gives F(m+1)·F(m+3) = F(m+2)² + (−1)ᵐ. Their product is a difference of squares (F(m+2)² − (−1)ᵐ)(F(m+2)² + (−1)ᵐ) = F(m+2)⁴ − ((−1)ᵐ)² = F(m+2)⁴ − 1, using the single sign fact ((−1)ᵐ)² = 1. Re-indexing m+2 = n recovers the named form. Gelin–Cesàro is not in Mathlib, and unlike Cassini/d'Ocagne/Catalan (each a single determinant slice of Vajda) it is a genuine two-sided consequence obtained by combining the r=1 and r=2 Catalan slices. Answers the fourth open question of fibonacci-identities-oq-01.",
+  "meta": {
+    "author": "E. Gelin & E. Cesàro (1880s); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Other_identities",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "gelin-cesaro",
+      "catalan-identity",
+      "difference-of-squares",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ01OQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_one",
+        "description": "fib 1 = 1 — collapses the inner-pair Catalan slice's F(1)² factor to 1",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_two",
+        "description": "fib 2 = 1 — collapses the outer-pair Catalan slice's F(2)² factor to 1",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Even.neg_one_pow",
+        "description": "Even n → (−1)ⁿ = 1 over a monoid with −1; applied to n = m + m to prove ((−1)ᵐ)² = 1, the sign fact that kills the cross term in the difference of squares",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.exists_eq_add_of_le",
+        "description": "From 2 ≤ n write n = 2 + m, transporting the subtraction-free gap identity to the named n ≥ 2 statement with F(n−2), F(n−1)",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "fib_gelin_cesaro_gap: ∀ m, F(m)·F(m+1)·F(m+3)·F(m+4) = F(m+2)⁴ − 1 — the subtraction-free (gap-parameterised) engine, absent from Mathlib, obtained by multiplying the r=2 and r=1 Catalan slices as a difference of squares",
+      "fib_gelin_cesaro: ∀ n ≥ 2, F(n−2)·F(n−1)·F(n+1)·F(n+2) = F(n)⁴ − 1 — the named Gelin–Cesàro identity recovered from the gap form by the re-index m = n−2",
+      "fib_outer_pair / fib_inner_pair: the two product-solved Catalan slices F(m)·F(m+4) = F(m+2)² − (−1)ᵐ and F(m+1)·F(m+3) = F(m+2)² + (−1)ᵐ, the ± halves of the difference of squares"
+    ],
+    "dateAdded": "2026-07-05",
+    "lineCount": 131,
+    "assumptions": "None. Fully verified with 0 sorries and 0 axioms beyond Lean/Mathlib's foundational propext / Classical.choice / Quot.sound. The main theorems use no decide/native_decide; only the trailing numeric sanity-check examples use kernel `decide` (which contributes no extra axioms).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Gelin–Cesàro identity (E. Gelin, posed; E. Cesàro, proved, 1880s) is one of the classical higher-degree Fibonacci product identities: the four Fibonacci numbers two-on-each-side of F(n) multiply to F(n)⁴ − 1. It sits one level above the quadratic determinant identities (Cassini, Catalan, d'Ocagne): where those relate a single product F(n−r)·F(n+r) to F(n)², Gelin–Cesàro is a quartic relation, and its cleanest derivation is precisely to reduce it to two Catalan slices and multiply them.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-01, Q4)**: Derive the Gelin–Cesàro identity F(n−2)·F(n−1)·F(n+1)·F(n+2) = F(n)⁴ − 1 from Catalan's identity.\n\n**Result**: fib_gelin_cesaro_gap establishes the subtraction-free engine F(m)·F(m+1)·F(m+3)·F(m+4) = F(m+2)⁴ − 1 by multiplying the r=2 and r=1 Catalan slices as a difference of squares; fib_gelin_cesaro re-indexes to the named form for n ≥ 2.",
+    "text": "With Fₙ = Nat.fib n, the product of the four Fibonacci numbers symmetrically flanking Fₙ equals Fₙ⁴ − 1 for n ≥ 2. Grouping the product as [F(n−2)·F(n+2)]·[F(n−1)·F(n+1)] and applying Catalan's identity to each bracket turns the two brackets into F(n)² − (−1)ⁿ and F(n)² + (−1)ⁿ, whose product is the difference of squares F(n)⁴ − 1.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Work with the subtraction-free substitution m = n − 2, so the four flanking terms are F(m), F(m+1), F(m+3), F(m+4) and the centre is F(m+2).\n2. **Outer pair (fib_outer_pair).** Catalan's gap identity fib_catalan_gap m 2 reads F(m+2)² − F(m)·F(m+4) = (−1)ᵐ·F(2)². Since F(2) = 1 (Nat.fib_two), rearranging gives F(m)·F(m+4) = F(m+2)² − (−1)ᵐ.\n3. **Inner pair (fib_inner_pair).** Catalan's gap identity fib_catalan_gap (m+1) 1 reads F(m+2)² − F(m+1)·F(m+3) = (−1)^{m+1}·F(1)². Since F(1) = 1 (Nat.fib_one) and (−1)^{m+1} = −(−1)ᵐ (pow_succ), rearranging gives F(m+1)·F(m+3) = F(m+2)² + (−1)ᵐ.\n4. **Difference of squares (fib_gelin_cesaro_gap).** Multiply the two pairs: (F(m+2)² − (−1)ᵐ)(F(m+2)² + (−1)ᵐ) = F(m+2)⁴ − ((−1)ᵐ)². The sign fact ((−1)ᵐ)² = 1 (neg_one_pow_sq, from Even (m+m)) closes it to F(m+2)⁴ − 1.\n5. **Re-index (fib_gelin_cesaro).** For n ≥ 2 write n = 2 + m (Nat.exists_eq_add_of_le); the index rewrites 2+m−2 = m, 2+m−1 = m+1, 2+m+1 = m+3, 2+m+2 = m+4, 2+m = m+2 (all by omega) turn the gap form into the named statement.",
+    "keyInsights": [
+      "**Gelin–Cesàro = two Catalan slices multiplied.** The quartic identity is not proved by its own induction; it is the product of the r=2 and r=1 Catalan slices. This makes Gelin–Cesàro a genuine *combination* of determinant identities rather than a single determinant, distinguishing it from Cassini/Catalan/d'Ocagne.",
+      "**Difference of squares supplies the −1.** Pairing outer × inner gives (F(n)² − (−1)ⁿ)(F(n)² + (−1)ⁿ); the (−1)ⁿ terms cancel as a difference of squares, leaving F(n)⁴ − ((−1)ⁿ)². The entire arithmetic content of the '−1' is the single fact ((−1)ⁿ)² = 1.",
+      "**The sign parities align.** The outer pair carries (−1)ᵐ and the inner pair carries (−1)^{m+1} = −(−1)ᵐ; the opposite signs are exactly what a difference of squares needs. This is not a coincidence but a consequence of the shift-by-one between the r=2 and r=1 base points.",
+      "**Subtraction-free engine.** Stating the result at m = n−2 as F(m)·F(m+1)·F(m+3)·F(m+4) = F(m+2)⁴ − 1 keeps every Fibonacci index a genuine sum, avoiding ℕ-subtraction inside the induction-free proof; the F(n−2), F(n−1) form is recovered once at the end by omega re-indexing.",
+      "**Not in Mathlib.** Mathlib has the Fibonacci recurrence and fib_add but no product identities of this degree; the gap engine fib_gelin_cesaro_gap is an original contribution built directly on the sibling entry's Catalan lemma."
+    ],
+    "prerequisites": [
+      "Catalan's identity in gap form: fib_catalan_gap from fibonacci-identities-oq-01-oq-02-oq-01",
+      "The Fibonacci base values fib 1 = 1 and fib 2 = 1 (Nat.fib_one, Nat.fib_two)",
+      "The sign identity ((−1)ᵐ)² = 1 via Even.neg_one_pow, and (−1)^{m+1} = −(−1)ᵐ via pow_succ",
+      "Casting ℕ → ℤ and eliminating n−2 via Nat.exists_eq_add_of_le plus omega index arithmetic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring stating the Gelin–Cesàro identity, the reduction to two Catalan slices, and the difference-of-squares closure; imports of Fibonacci basics, tactics, and the sibling Catalan entry; namespace and open Nat.",
+      "mathContext": "$F_{n-2}F_{n-1}F_{n+1}F_{n+2}=F_n^4-1$ for $n\\ge 2$."
+    },
+    {
+      "id": "sign",
+      "title": "The sign fact",
+      "startLine": 56,
+      "endLine": 59,
+      "summary": "neg_one_pow_sq: ((−1)ᵐ)² = 1 over ℤ, proved by rewriting (a^m)^2 = a^(m·2) and invoking Even.neg_one_pow on Even (m+m) — the fact that collapses the difference of squares.",
+      "mathContext": "$((-1)^m)^2=(-1)^{2m}=1$."
+    },
+    {
+      "id": "pairs",
+      "title": "The outer and inner Catalan pairs",
+      "startLine": 61,
+      "endLine": 81,
+      "summary": "fib_outer_pair (Catalan r=2, F(2)=1): F(m)·F(m+4) = F(m+2)² − (−1)ᵐ. fib_inner_pair (Catalan r=1, F(1)=1, with (−1)^{m+1} = −(−1)ᵐ): F(m+1)·F(m+3) = F(m+2)² + (−1)ᵐ. The ± halves of the difference of squares.",
+      "mathContext": "$F_mF_{m+4}=F_{m+2}^2-(-1)^m,\\quad F_{m+1}F_{m+3}=F_{m+2}^2+(-1)^m.$"
+    },
+    {
+      "id": "gap",
+      "title": "Gelin–Cesàro, gap-parameterised form (engine)",
+      "startLine": 83,
+      "endLine": 100,
+      "summary": "fib_gelin_cesaro_gap: F(m)·F(m+1)·F(m+3)·F(m+4) = F(m+2)⁴ − 1, by a calc that regroups the product as (outer pair)·(inner pair), rewrites with fib_outer_pair/fib_inner_pair, and closes the difference of squares with neg_one_pow_sq.",
+      "mathContext": "$(F_{m+2}^2-(-1)^m)(F_{m+2}^2+(-1)^m)=F_{m+2}^4-1.$"
+    },
+    {
+      "id": "named",
+      "title": "Gelin–Cesàro, named form",
+      "startLine": 102,
+      "endLine": 116,
+      "summary": "fib_gelin_cesaro: for n ≥ 2, F(n−2)·F(n−1)·F(n+1)·F(n+2) = F(n)⁴ − 1, obtained from the gap form by writing n = 2 + m (Nat.exists_eq_add_of_le) and discharging the five index rewrites with omega.",
+      "mathContext": "$F_{n-2}F_{n-1}F_{n+1}F_{n+2}=F_n^4-1$ for $n\\ge 2$."
+    },
+    {
+      "id": "examples",
+      "title": "Numeric sanity checks",
+      "startLine": 118,
+      "endLine": 127,
+      "summary": "Kernel-decidable checks at n=4 (F₂F₃F₅F₆ = 1·2·5·8 = 80 = 3⁴−1) and n=6 (F₄F₅F₇F₈ = 3·5·13·21 = 4095 = 8⁴−1).",
+      "mathContext": "$F_4F_5F_7F_8=3\\cdot5\\cdot13\\cdot21=4095=8^4-1.$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-01",
+      "relationship": "answers",
+      "description": "Derives the Gelin–Cesàro identity F(n−2)·F(n−1)·F(n+1)·F(n+2) = F(n)⁴ − 1 from Catalan's identity — the fourth open question of the parent entry."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-01-oq-02-oq-01",
+      "relationship": "uses",
+      "description": "Consumes fib_catalan_gap (Catalan's identity in gap form) as the sole non-trivial engine: the outer pair is its r=2 slice and the inner pair its r=1 slice."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Cassini via the Q-matrix (sibling leaf) is the quadratic degenerate case r=1 of the same Catalan family; Gelin–Cesàro multiplies the r=1 and r=2 slices into a quartic identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) derivation of the Gelin–Cesàro identity F(n−2)·F(n−1)·F(n+1)·F(n+2) = F(n)⁴ − 1 for n ≥ 2. The subtraction-free engine fib_gelin_cesaro_gap multiplies the r=2 and r=1 slices of Catalan's identity (from the sibling entry) as a difference of squares, and re-indexing recovers the named form.",
+    "implications": "Demonstrates that the classical higher-degree Fibonacci product identities are not independent facts but structured products of the quadratic Catalan slices; the same outer×inner difference-of-squares pattern generalises to wider symmetric flanking products.",
+    "openQuestions": [
+      "Generalise to the wider flanking product: is F(n−k)·…·F(n+k) (2k symmetric terms) always a polynomial in F(n) with constant term ±1, and does the difference-of-squares pattern iterate?",
+      "Prove the Lucas-number analogue L(n−2)·L(n−1)·L(n+1)·L(n+2) = L(n)⁴ − 25·(something) and identify the exact correction term via the Lucas Catalan identity."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Fib.Basic",
+      "Mathlib.Tactic",
+      "Proofs.FibonacciIdentitiesOQ01OQ02OQ01"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "FibonacciIdentitiesOQ01OQ04",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ01OQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cesàro, Ernesto",
+      "title": "Sur les nombres de Fibonacci (Gelin–Cesàro identity)",
+      "year": "1880s",
+      "venue": "Nouvelle correspondance mathématique",
+      "note": "The quartic product identity F(n−2)·F(n−1)·F(n+1)·F(n+2) = F(n)⁴ − 1"
+    },
+    {
+      "authors": "Vajda, S.",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood / Dover",
+      "note": "Catalan's identity and the family of index-arithmetic Fibonacci identities from which Gelin–Cesàro is derived"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Gelin–Cesàro identity and related higher-degree product identities"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/prob-method-alteration-oq-01/annotations.json
+++ b/src/data/proofs/prob-method-alteration-oq-01/annotations.json
@@ -1,0 +1,101 @@
+[
+  {
+    "id": "ann-deletion-oq01-overview",
+    "proofId": "prob-method-alteration-oq-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "The elementary deletion bound, replacing a vacuous placeholder",
+    "content": "The parent entry prob-method-alteration records its independent-set claim only as the vacuous existence form ∃ k, k ≥ n/(2d) ∧ k > 0, which never mentions a graph. This file proves the genuine, probability-free core of the alteration method: delete one endpoint from each of the m edges of a finite simple graph, and the n − |deleted| ≥ n − m remaining vertices form an independent set. Read against the real independence number α(G) = sSup {|S| : S independent}, this gives α(G) ≥ n − m. It is the weak end of the spectrum whose sharp end (Caro–Wei) is proved in the sibling OQ-03.",
+    "mathContext": "$\\alpha(G) \\ge n - m$ for a finite simple graph with $n$ vertices and $m$ edges.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "independence number",
+      "alteration method",
+      "deletion method",
+      "probabilistic method",
+      "hitting set of edges"
+    ],
+    "prerequisites": [
+      "independent sets in graphs",
+      "unordered pairs (Sym2)",
+      "conditional suprema over ℕ"
+    ]
+  },
+  {
+    "id": "ann-deletion-oq01-pick",
+    "proofId": "prob-method-alteration-oq-01",
+    "range": { "startLine": 45, "endLine": 60 },
+    "type": "technique",
+    "title": "A symmetric per-edge endpoint choice via Sym2.lift",
+    "content": "An edge is an unordered pair, an element of Sym2 V, so any function selecting an endpoint must not depend on the (nonexistent) orientation. Sym2.lift lifts a symmetric binary function to Sym2 V; feeding it ⟨min, min_comm⟩ produces pick, which returns the lesser endpoint. pick_mk computes pick s(a,b) = min a b definitionally, and pick_mem_pair records that min a b is one of a, b (by le_total). Choosing min — rather than, say, a first coordinate — is exactly what makes the map well-typed on unordered pairs.",
+    "mathContext": "$\\mathrm{pick}\\, \\{a,b\\} = \\min(a,b) \\in \\{a,b\\}$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Sym2 (unordered pairs)",
+      "symmetric functions",
+      "choice function"
+    ],
+    "prerequisites": [
+      "quotient types",
+      "linear order min"
+    ]
+  },
+  {
+    "id": "ann-deletion-oq01-independence",
+    "proofId": "prob-method-alteration-oq-01",
+    "range": { "startLine": 62, "endLine": 85 },
+    "type": "key-step",
+    "title": "The complement of the deletion set is independent",
+    "content": "Let D = edgeFinset.image pick be the chosen endpoints. Then |D| ≤ m (Finset.card_image_le). Independence of univ ∖ D is a one-line contradiction: if a, b both survive and are adjacent, then s(a,b) is a genuine edge (mem_edgeFinset with mem_edgeSet), so its chosen endpoint pick s(a,b) ∈ D; but pick s(a,b) equals a or b (pick_mem_pair), each of which was assumed outside D. The symmetric min-choice is what guarantees the deleted vertex is provably one of the two endpoints under consideration.",
+    "mathContext": "If $a,b \\notin D$ and $a \\sim b$ then $\\min(a,b) \\in D$ and $\\min(a,b)\\in\\{a,b\\}$ — contradiction.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "independent set",
+      "edge finset",
+      "image cardinality bound"
+    ],
+    "prerequisites": [
+      "SimpleGraph.edgeSet / edgeFinset",
+      "Finset.image"
+    ]
+  },
+  {
+    "id": "ann-deletion-oq01-mainbound",
+    "proofId": "prob-method-alteration-oq-01",
+    "range": { "startLine": 87, "endLine": 107 },
+    "type": "key-step",
+    "title": "Lifting the surviving independent set to α(G) ≥ n − m",
+    "content": "The complement S = univ ∖ D is independent, so its cardinality lies in the set {k | ∃ independent s, |s| = k} whose supremum is α(G). That set is bounded above by Fintype.card V, so le_csSup gives |S| ≤ α(G). Size bookkeeping computes |S| = n − |D| (Finset.card_sdiff, then Finset.inter_univ and Finset.card_univ), and |D| ≤ m combines via Nat.sub_le_sub_left to n − m ≤ n − |D| = |S|. Chaining the two inequalities yields the deletion bound.",
+    "mathContext": "$n - m \\le n - |D| = |S| \\le \\alpha(G)$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "conditional supremum",
+      "bounded-above set",
+      "natural subtraction"
+    ],
+    "prerequisites": [
+      "le_csSup / BddAbove",
+      "Finset.card_sdiff"
+    ]
+  },
+  {
+    "id": "ann-deletion-oq01-subsampling",
+    "proofId": "prob-method-alteration-oq-01",
+    "range": { "startLine": 109, "endLine": 132 },
+    "type": "concept",
+    "title": "The sub-sampling optimization behind the strong bound n²/(4m)",
+    "content": "The n − m bound is tight for a perfect matching but vacuous once m ≥ n; the strong bound α(G) ≥ n²/(4m) instead keeps each vertex with probability p and deletes one endpoint of every surviving edge, leaving n·p − m·p² vertices in expectation. sample_delete_optimum completes the square, n·p − m·p² = n²/(4m) − m(p − n/(2m))², whence sample_delete_le (the surplus never exceeds n²/(4m)) and sample_delete_attained (equality at p = n/(2m)). Only the expectation-to-existence step is missing to reach the graph bound — recorded as an open question.",
+    "mathContext": "$\\max_p\\,(np - mp^2) = \\frac{n^2}{4m}$ at $p = \\frac{n}{2m}$.",
+    "significance": "supplementary",
+    "relatedConcepts": [
+      "random induced subgraph",
+      "linearity of expectation",
+      "completing the square",
+      "optimization"
+    ],
+    "prerequisites": [
+      "quadratic optimization",
+      "expectation of a random construction"
+    ]
+  }
+]

--- a/src/data/proofs/prob-method-alteration-oq-01/meta.json
+++ b/src/data/proofs/prob-method-alteration-oq-01/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "prob-method-alteration-oq-01",
+  "slug": "prob-method-alteration-oq-01",
+  "title": "The Deletion Bound α(G) ≥ n − m — De-vacuifying the Alteration Method's Independent-Set Claim",
+  "description": "The parent entry prob-method-alteration states its independent-set result only in a vacuous 'existence form', independent_set_bound : ∃ k, k ≥ n/(2d) ∧ k > 0, which never mentions a graph and is trivially true. This entry replaces that placeholder with the genuine, purest instance of the alteration/deletion method, proved against the real independence number α(G) = sSup {|S| : S independent} (the same definition used in ProbMethodAlterationOQ02/OQ03): for every finite simple graph G on n vertices with m edges, α(G) ≥ n − m. The proof is the deletion method in its most elementary form, with no probability at all: delete ONE endpoint from every edge. Concretely, from each edge pick its lesser endpoint — a symmetric choice, hence well-defined on Sym2 V via Sym2.lift ⟨min, min_comm⟩. The deleted set D = edgeFinset.image pick has |D| ≤ m (Finset.card_image_le), and its complement univ ∖ D is independent: any edge inside the complement would have kept both endpoints, contradicting that its lesser endpoint was deleted. Hence univ ∖ D is an independent set of size ≥ n − m, and le_csSup lifts this to α(G) ≥ n − m. This bound is the WEAK end of the alteration spectrum — it is tight for a perfect matching (m = n/2, α = n/2) but useless once m ≥ n. The classical STRONG bound α(G) ≥ n²/(4m) comes instead from random sub-sampling (keep each vertex with probability p, then delete a surviving endpoint per edge), leaving n·p − m·p² vertices in expectation. The arithmetic heart of that optimization is recorded as a verified companion: sample_delete_optimum completes the square, n·p − m·p² = n²/(4m) − m(p − n/(2m))², whence sample_delete_le (the surplus never exceeds n²/(4m)) and sample_delete_attained (equality at p = n/(2m)). Bridging that identity to the graph requires the probabilistic existence step, documented as the remaining gap. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodAlterationOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "independence-number",
+      "probabilistic-method",
+      "alteration-method",
+      "deletion-method",
+      "extremal-graph-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 139,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. #print axioms independenceNumber_ge_card_sub_edges reports only [propext, Classical.choice, Quot.sound] (Classical.choice / Quot.sound enter via the noncomputable sSup defining the independence number and via Sym2.lift). Self-contained: does not import the parent, but proves a genuine graph-theoretic statement against the same independenceNumber definition the parent's placeholder gestures at.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Sym2.lift",
+        "description": "Lifts a symmetric binary function to the unordered-pair type Sym2 — with ⟨min, min_comm⟩ it defines the per-edge choice `pick` selecting an edge's lesser endpoint, well-defined precisely because min is symmetric",
+        "module": "Mathlib.Data.Sym.Sym2"
+      },
+      {
+        "theorem": "Finset.card_image_le",
+        "description": "|s.image f| ≤ |s| — bounds the deletion set |D| = |edgeFinset.image pick| ≤ |edgeFinset| = m, the '≤ one deleted vertex per edge' estimate",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "SimpleGraph.mem_edgeFinset",
+        "description": "e ∈ G.edgeFinset ↔ e ∈ G.edgeSet — together with G.mem_edgeSet turns an adjacency G.Adj a b into membership s(a,b) ∈ edgeFinset, so the edge's chosen endpoint lands in the deletion set",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "Finset.mem_image_of_mem",
+        "description": "a ∈ s → f a ∈ s.image f — places pick s(a,b) into the deletion set for any actual edge, the mechanism by which every edge loses an endpoint",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "Finset.card_sdiff",
+        "description": "|s ∖ t| = |s| − |s ∩ t| — computes |univ ∖ D| = n − |D| (after Finset.inter_univ and Finset.card_univ), giving the size of the surviving independent set",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "le_csSup",
+        "description": "Any member of a bounded-above set of naturals is ≤ its supremum — lifts 'univ ∖ D is an independent set of size ≥ n − m' to 'α(G) ≥ n − m', since the independence number is defined as a sSup over independent-set cardinalities bounded by Fintype.card V",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "Nat.sub_le_sub_left",
+        "description": "n ≤ m → k − m ≤ k − n — combines |D| ≤ m with |univ ∖ D| = n − |D| to yield n − m ≤ n − |D| = |S|, the natural-subtraction bookkeeping of the deletion bound",
+        "module": "Mathlib.Algebra.Order.Sub.Basic"
+      }
+    ],
+    "dateAdded": "2026-07-04",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "SimpleGraph"
+    ],
+    "namespace": "ProbMethod.Deletion",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "path": "Proofs/ProbMethodAlterationOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "independenceNumber_ge_card_sub_edges",
+      "type": "headline",
+      "statement": "(G : SimpleGraph V) [Fintype V] [LinearOrder V] [DecidableRel G.Adj] → Fintype.card V − G.edgeFinset.card ≤ independenceNumber G",
+      "description": "The deletion bound: the independence number of any finite simple graph is at least n − m, where n is the number of vertices and m the number of edges. Proved by deleting the lesser endpoint of every edge and observing the complement is independent.",
+      "significance": "The purest, probability-free instance of the alteration/deletion method, and a genuine graph-theoretic replacement for the parent entry's vacuous existence-form placeholder. Tight for a perfect matching."
+    },
+    {
+      "name": "indep_compl_deletionSet",
+      "type": "core",
+      "statement": "(G : SimpleGraph V) [DecidableRel G.Adj] → univ ∖ deletionSet G is an independent set (∀ a b in it, a ≠ b → ¬G.Adj a b)",
+      "description": "The heart of the deletion argument: after removing one endpoint from each edge, the surviving vertices form an independent set. If two survivors were adjacent, their edge's chosen (lesser) endpoint would be among them yet also in the deletion set — a contradiction.",
+      "significance": "Turns the crude 'remove a vertex per edge' construction into an actual independent set; the symmetric min-choice is what makes the chosen endpoint provably one of the two survivors."
+    },
+    {
+      "name": "deletionSet_card_le",
+      "type": "supporting",
+      "statement": "(deletionSet G).card ≤ G.edgeFinset.card",
+      "description": "At most one vertex is deleted per edge, so the deletion set has size ≤ m. Immediate from Finset.card_image_le, since deletionSet is the image of the edge finset under the endpoint-choice map.",
+      "significance": "Supplies the |D| ≤ m estimate that turns |univ ∖ D| = n − |D| into the n − m lower bound."
+    },
+    {
+      "name": "sample_delete_optimum",
+      "type": "core",
+      "statement": "(n m p : ℝ) → 0 < m → n·p − m·p² = n²/(4m) − m·(p − n/(2m))²",
+      "description": "Completing the square on the expected surplus n·p − m·p² of the random-sub-sampling version of the deletion method (keep each vertex with probability p, delete one endpoint of each surviving edge). Exhibits the maximum explicitly.",
+      "significance": "The arithmetic engine behind the classical strong bound α(G) ≥ n²/(4m); it isolates exactly why p = n/(2m) is optimal and where the constant 1/4 comes from."
+    },
+    {
+      "name": "sample_delete_le",
+      "type": "supporting",
+      "statement": "(n m p : ℝ) → 0 < m → n·p − m·p² ≤ n²/(4m)",
+      "description": "The expected surplus never exceeds n²/(4m). Immediate from sample_delete_optimum, since the subtracted square term m·(p − n/(2m))² is nonnegative.",
+      "significance": "The upper envelope that would, once combined with a probabilistic existence step, yield the graph bound α(G) ≥ n²/(4m)."
+    },
+    {
+      "name": "sample_delete_attained",
+      "type": "supporting",
+      "statement": "(n m : ℝ) → 0 < m → n·(n/(2m)) − m·(n/(2m))² = n²/(4m)",
+      "description": "The maximum n²/(4m) is attained at p = n/(2m). Direct from sample_delete_optimum with the square term vanishing.",
+      "significance": "Confirms the optimizer, pinning the tight constant of the sub-sampling bound."
+    }
+  ],
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Part I: Independence number and the per-edge endpoint choice",
+      "startLine": 43,
+      "endLine": 60,
+      "summary": "independenceNumber G := sSup {k | ∃ s : Finset V, s.card = k ∧ s is independent} — identical to the definition in ProbMethodAlterationOQ02/OQ03. pick : Sym2 V → V := Sym2.lift ⟨min, min_comm⟩ selects the lesser endpoint of an edge; it is well-defined on the unordered pair type exactly because min is symmetric (min_comm). pick_mk computes pick s(a,b) = min a b by rfl, and pick_mem_pair notes min a b ∈ {a, b} via le_total.",
+      "mathContext": "α(G) as a supremum over independent-set sizes; a symmetric choice function selecting one endpoint from each edge."
+    },
+    {
+      "id": "deletion-set",
+      "title": "Part II: The deletion set and independence of its complement",
+      "startLine": 62,
+      "endLine": 85,
+      "summary": "deletionSet G := G.edgeFinset.image pick collects the chosen endpoint of each edge; deletionSet_card_le bounds |D| ≤ m by Finset.card_image_le. indep_compl_deletionSet proves univ ∖ D is independent: for adjacent a, b in the complement, s(a,b) ∈ edgeFinset (mem_edgeFinset + mem_edgeSet), so pick s(a,b) ∈ D; but pick s(a,b) is a or b (pick_mem_pair), each assumed outside D — contradiction.",
+      "mathContext": "Removing one endpoint per edge leaves an independent set; |removed| ≤ number of edges."
+    },
+    {
+      "id": "main-bound",
+      "title": "Part III: The deletion bound α(G) ≥ n − m",
+      "startLine": 87,
+      "endLine": 107,
+      "summary": "independenceNumber_ge_card_sub_edges. The complement S = univ ∖ D is independent, so |S| lies in the independence-number set, which is bounded above by Fintype.card V; le_csSup gives |S| ≤ α(G). Meanwhile |S| = n − |D| (Finset.card_sdiff, Finset.inter_univ, Finset.card_univ) and |D| ≤ m, so n − m ≤ n − |D| = |S| (Nat.sub_le_sub_left). Chaining gives n − m ≤ α(G).",
+      "mathContext": "α(G) ≥ n − m for every finite simple graph — the elementary deletion bound."
+    },
+    {
+      "id": "subsampling-companion",
+      "title": "Part IV: The sub-sampling optimization behind n²/(4m)",
+      "startLine": 109,
+      "endLine": 132,
+      "summary": "The companion real-analysis lemmas. sample_delete_optimum completes the square: n·p − m·p² = n²/(4m) − m·(p − n/(2m))² (field_simp; ring). sample_delete_le reads off the upper bound n²/(4m) from nonnegativity of the square term, and sample_delete_attained shows equality at p = n/(2m). These capture the arithmetic of the stronger random-sub-sampling bound whose graph-theoretic form needs an additional probabilistic existence step.",
+      "mathContext": "max_p (n·p − m·p²) = n²/(4m) at p = n/(2m), the source of the classical α(G) ≥ n²/(4m)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The alteration (or deletion) method is one of the pillars of the probabilistic method (Alon–Spencer, The Probabilistic Method): build a random structure, then deterministically remove the few parts that violate the desired property, and argue that enough survives. Its textbook application to the independence number comes in two strengths. The crude version deletes one endpoint from each of the m edges of a graph, leaving an independent set of size at least n − m; this is sharp for a perfect matching but vacuous once the graph has more than n edges. The strong version first passes to a random induced subgraph — keep each vertex independently with probability p — so the expected vertex count is np and the expected edge count is mp²; deleting one endpoint of each surviving edge leaves np − mp² vertices in expectation, and optimizing p = n/(2m) yields the classical α(G) ≥ n²/(4m). In the Lean Genius gallery, the parent entry prob-method-alteration recorded its independent-set claim only as the vacuous existence form ∃ k, k ≥ n/(2d) ∧ k > 0, which mentions no graph at all.",
+    "problemStatement": "Give a genuine, machine-checked graph-theoretic statement of the alteration method's independent-set bound — replacing the parent's vacuous placeholder — by proving the elementary deletion bound α(G) ≥ n − m against the real (sSup-based) independence number, and record the arithmetic optimization n·p − m·p² ≤ n²/(4m) underlying the stronger sub-sampling bound.",
+    "proofStrategy": "For the deletion bound, avoid all probability: construct the deleted set explicitly. Pick a symmetric endpoint-choice pick = Sym2.lift ⟨min, min_comm⟩ so that each edge contributes one vertex; let D = edgeFinset.image pick. Then |D| ≤ m (card_image_le), and univ ∖ D is independent because any adjacent pair surviving in the complement would have its edge's chosen endpoint simultaneously deleted and undeleted. Size bookkeeping |univ ∖ D| = n − |D| ≥ n − m and le_csSup (the independence number is a supremum over independent-set sizes, bounded by n) finish it. For the companion, complete the square on n·p − m·p² to expose the maximum n²/(4m) and its optimizer p = n/(2m); the graph-level strong bound would additionally require formalizing the expectation-to-existence step over random vertex subsets, which is left as the documented gap.",
+    "keyInsights": [
+      "The alteration method's independent-set claim has a fully deterministic, elementary core: deleting one endpoint per edge already proves α(G) ≥ n − m, with no probability, expectation, or measure theory in the formalization.",
+      "Choosing the endpoint symmetrically is what makes the construction well-typed on unordered pairs: Sym2.lift demands a symmetric function, and min (with min_comm) supplies one, so `pick` is a genuine function on Sym2 V rather than a choice depending on edge orientation.",
+      "Independence of the complement is a one-line contradiction once the choice is symmetric: an edge surviving inside univ ∖ D would place its chosen lesser endpoint both in D (as an image element) and outside D (as a survivor).",
+      "The n − m bound is honestly weak — tight only for a perfect matching and vacuous for m ≥ n — which is exactly why the parent's n/(2d) claim really refers to the STRONG sub-sampling bound n²/(4m), not to this elementary one.",
+      "The strong bound's content is almost entirely arithmetic: completing the square n·p − m·p² = n²/(4m) − m(p − n/(2m))² pins both the value n²/(4m) and the optimizer p = n/(2m); the only genuinely probabilistic ingredient left is turning an expectation into an existence witness."
+    ]
+  },
+  "conclusion": {
+    "summary": "The elementary deletion bound α(G) ≥ n − m is proved for every finite simple graph by explicitly deleting the lesser endpoint of each edge and lifting the resulting independent set to the sSup-based independence number — no probability required. A verified companion completes the square on n·p − m·p² to expose the maximum n²/(4m) at p = n/(2m), the arithmetic behind the stronger sub-sampling bound. Together they give a genuine, machine-checked graph-theoretic account of the alteration method's independent-set claim in place of the parent entry's vacuous existence-form placeholder. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+    "implications": "This upgrades the parent prob-method-alteration from a placeholder to a real theorem: the independent-set consequence of the deletion method is now stated and proved about an actual graph and the actual independence number, complementing the sharper Caro–Wei bound proved in OQ-03. The explicit min-endpoint deletion construction is reusable for any 'hitting set of the edges' argument, and the completed-square companion isolates precisely the probabilistic step (expectation ⟹ existence) that a full formalization of α(G) ≥ n²/(4m) still needs.",
+    "openQuestions": [
+      "Formalize the missing probabilistic existence step: over a uniformly random vertex subset (each vertex kept independently with probability p = n/(2m)), show an actual independent set of size ≥ n²/(4m) exists, upgrading sample_delete_le from an expectation identity to the graph bound α(G) ≥ n²/(4m).",
+      "Characterize equality in the deletion bound α(G) = n − m: is it exactly the disjoint unions of edges and isolated vertices (graphs whose components are single edges or points), and can that classification be proved from the min-endpoint construction?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "prob-method-alteration",
+      "relationship": "parent",
+      "description": "Alteration Method (Probabilistic Method) — states its independent-set result only as the vacuous existence form ∃ k, k ≥ n/(2d) ∧ k > 0; this entry gives the genuine graph-theoretic deletion bound α(G) ≥ n − m and the arithmetic of the stronger n²/(4m) sub-sampling bound."
+    },
+    {
+      "proofId": "prob-method-alteration-oq-03",
+      "relationship": "sibling",
+      "description": "Caro–Wei bound α(G) ≥ ∑ 1/(deg v + 1) — the sharp degree-sequence lower bound on the same independenceNumber; this entry supplies the crude but probability-free deletion bound α(G) ≥ n − m at the weak end of the same spectrum."
+    }
+  ]
+}

--- a/src/data/proofs/szemeredi-regularity-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02-oq-02/annotations.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "szemeredifk-sharp-ann-pair",
+    "proofId": "szemeredi-regularity-oq-02-oq-02",
+    "range": {
+      "startLine": 71,
+      "endLine": 160
+    },
+    "type": "theorem",
+    "title": "Sharp Per-Pair Cut Error Bound: ε|P||Q|, not 2ε|P||Q|",
+    "content": "pair_cut_error_bound_sharp proves that for an ε-regular pair (P,Q) and any A ⊆ P, B ⊆ Q, the cut error |e(A,B) − d(P,Q)·|A|·|B|| is at most ε·|P|·|Q| — the tight constant, halving the parent's pair_cut_error_bound. The proof splits on whether A and B are 'large' (≥ ε fraction of their part). In the large case, ε-regularity gives |d(A,B) − d(P,Q)| ≤ ε directly, which after multiplying by |A||B| ≤ |P||Q| yields ε|P||Q|. In the small case (A or B below the ε threshold), one has |A||B| ≤ ε|P||Q|, so the actual edge count e ≤ |A||B| ≤ ε|P||Q| and the predicted count d(P,Q)|A||B| ≤ |A||B| ≤ ε|P||Q| are each individually at most ε|P||Q|. Because both are nonnegative and |x − y| ≤ max(x, y) for x, y ≥ 0, their difference is at most ε|P||Q|. The parent instead bounded the small case by the sum e + d|A||B| ≤ 2ε|P||Q|; replacing that sum by the maximum is exactly the factor-of-2 improvement.",
+    "mathContext": "Small case: $0 \\le e \\le |A||B| \\le \\varepsilon|P||Q|$ and $0 \\le d\\,|A||B| \\le |A||B| \\le \\varepsilon|P||Q|$, hence $|e - d\\,|A||B|| \\le \\max(e, d\\,|A||B|) \\le \\varepsilon|P||Q|$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "ε-regular pair",
+      "edge density",
+      "cut norm",
+      "triangle inequality vs max bound"
+    ],
+    "prerequisites": [
+      "Szemerédi ε-regularity",
+      "absolute value inequalities"
+    ]
+  },
+  {
+    "id": "szemeredifk-sharp-ann-main",
+    "proofId": "szemeredi-regularity-oq-02-oq-02",
+    "range": {
+      "startLine": 162,
+      "endLine": 224
+    },
+    "type": "theorem",
+    "title": "Sharp Szemerédi ⟹ Frieze-Kannan: ε-cut-approximation",
+    "content": "szemeredi_implies_fk_sharp is the main result: every ε-regular partition is an ε-cut-approximation (not merely 2ε). The proof is structurally identical to the parent's szemeredi_implies_fk — it decomposes e(A,B) over the partition product (edge_count_partition_sum), applies the triangle inequality for the sum, bounds each pair term by the sharp per-pair estimate ε|Pᵢ||Pⱼ|, and collapses Σᵢⱼ|Pᵢ||Pⱼ| = n² (parts_product_sum_eq_card_sq) — so the global error is ε·n² instead of 2ε·n². The corollary sharp_recovers_original then shows the ε-cut-approximation entails the parent's 2ε-cut-approximation (since ε ≤ 2ε for ε ≥ 0), so the sharp theorem strictly generalizes the original. Together they resolve the open question: the factor-of-2 constant is not tight — it is 1.",
+    "mathContext": "$|e(A,B) - \\sum_{i,j} d(P_i,P_j)|A\\cap P_i||B\\cap P_j|| \\le \\sum_{i,j} \\varepsilon|P_i||P_j| = \\varepsilon n^2$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Frieze-Kannan weak regularity",
+      "cut-approximation",
+      "partition decomposition",
+      "sharp constant"
+    ],
+    "prerequisites": [
+      "per-pair cut error bound",
+      "Finset partition sum identities"
+    ]
+  }
+]

--- a/src/data/proofs/szemeredi-regularity-oq-02-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02-oq-02/meta.json
@@ -1,0 +1,108 @@
+{
+  "id": "szemeredi-regularity-oq-02-oq-02",
+  "title": "Szemerédi ⟹ Frieze-Kannan: the cut-approximation constant is 1, not 2",
+  "slug": "szemeredi-regularity-oq-02-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SzemerediCore",
+      "Proofs.SzemerediRegularity",
+      "Proofs.SzemerediRegularityOQ02"
+    ],
+    "opens": [
+      "Szemeredi.Core",
+      "Szemeredi.Regularity",
+      "SzemerediFKComparison",
+      "Classical"
+    ],
+    "namespace": "SzemerediFKComparisonSharp",
+    "lineCount": 229,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/SzemerediRegularityOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "description": "Resolves szemeredi-regularity-oq-02-oq-02: is the factor-of-2 constant in szemeredi_implies_fk (every ε-regular partition is a 2ε-cut-approximation) tight, or improvable to 1? Answer: improvable to 1. The factor of 2 was an artifact of a loose triangle-inequality step, not an intrinsic feature. In the 'small subset' case of the per-pair error bound (where A or B occupies less than an ε fraction of its part), the original proof used |e − d|A||B|| ≤ e + d|A||B| ≤ 2ε|P||Q|. But in that case both e and d|A||B| are individually ≤ ε|P||Q| (since |A||B| ≤ ε|P||Q| and both the edge count e/|A||B| and the density d lie in [0,1]); and for nonnegative x, y one has |x − y| ≤ max(x, y). So |e − d|A||B|| ≤ ε|P||Q| — the same rate the large case already achieves via ε-regularity. pair_cut_error_bound_sharp establishes the tight per-pair bound ε|P||Q|; szemeredi_implies_fk_sharp sums it over all |parts|² pairs (using the unchanged partition decomposition Σᵢⱼ|Pᵢ||Pⱼ| = n²) to conclude every ε-regular partition is an ε-cut-approximation. sharp_recovers_original derives the original 2ε statement as a corollary (ε ≤ 2ε). This corrects the parent entry's keyInsight that the factor of 2 'is sharp … and cannot be reduced to 1 with this proof strategy': the same two-case analysis, with max in place of sum, gives 1. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SzemerediRegularityOQ02OQ02.lean",
+    "additionalFiles": [
+      "Proofs/SzemerediRegularityOQ02.lean",
+      "Proofs/SzemerediCore.lean",
+      "Proofs/SzemerediRegularity.lean"
+    ],
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "szemeredi",
+      "regularity",
+      "frieze-kannan",
+      "cut-norm",
+      "sharp-constant",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ02OQ02` builds green (Lean v4.26.0, Mathlib pin, 7746 jobs). 0 sorries, 0 axiom declarations, no native_decide, no structure-encoded assumptions; only the standard foundational axioms (propext / Classical.choice / Quot.sound) via Mathlib. Reuses the definitions IsEpsilonRegular, edgeDensity, IsCutApproximation and the partition-decomposition lemmas (edge_count_partition_sum, parts_product_sum_eq_card_sq) from the parent szemeredi-regularity-oq-02 entry, all themselves 0-axiom. Scope: this is a factor-of-2 constant improvement that answers the stated open question (the 2 is not tight — it is 1) and corrects the parent's 'sharpness' claim. It does not change the qualitative Szemerédi ⟹ FK hierarchy, nor the tower-vs-singly-exponential parts-count comparison, both established in the parent.",
+    "lineCount": 229,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "pair_cut_error_bound_sharp: the tight per-pair bound |e(A,B) − d(P,Q)|A||B|| ≤ ε|P||Q| for an ε-regular pair (P,Q) with A ⊆ P, B ⊆ Q — a factor-of-2 improvement over the parent's pair_cut_error_bound",
+      "The sharpening insight: in the small-subset case, e and d|A||B| are each ≤ ε|P||Q|, so |e − d|A||B|| ≤ max(e, d|A||B|) ≤ ε|P||Q|; replacing the parent's e + d|A||B| ≤ 2ε|P||Q| (triangle/sum bound) by the max bound recovers the factor of 1",
+      "szemeredi_implies_fk_sharp: the MAIN result — every ε-regular partition is an ε-cut-approximation (not merely 2ε), summing the sharp per-pair bound over all |parts|² pairs via the unchanged partition identity Σᵢⱼ|Pᵢ||Pⱼ| = n²",
+      "sharp_recovers_original: the sharp ε-cut-approximation entails the parent's 2ε-cut-approximation (ε ≤ 2ε for ε ≥ 0), so the new theorem strictly generalizes szemeredi_implies_fk",
+      "A correction to the parent entry's keyInsight asserting the factor of 2 is sharp and irreducible with this proof strategy: the identical two-case analysis, with max replacing sum in the small case, yields the optimal constant 1"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry szemeredi-regularity-oq-02 formalizes the Frieze-Kannan (FK) weak regularity lemma and proves the Szemerédi ⟹ FK implication: every ε-regular partition (Szemerédi's per-pair condition) is a 2ε-cut-approximation (FK's global cut-norm condition). The factor of 2 there came from a per-pair error bound that, in the case where a subset A ⊆ P or B ⊆ Q is 'small' (occupies less than an ε fraction of its part), bounded the error by the sum e + d|A||B| ≤ 2ε|P||Q|. The parent explicitly recorded this factor of 2 as 'sharp … cannot be reduced to 1 with this proof strategy'. This follow-up (OQ-02-OQ-02) revisits exactly that claim.",
+    "problemStatement": "In szemeredi_implies_fk, every ε-regular partition is shown to be a 2ε-cut-approximation. Is the constant 2 tight, or can it be improved to 1?",
+    "proofStrategy": "The large-subset case of the per-pair bound already yields ε|P||Q| directly from ε-regularity (|d(A,B) − d(P,Q)| ≤ ε, multiplied by |A||B| ≤ |P||Q|). Only the small case carried the factor of 2. There, |A||B| ≤ ε|P||Q|, so the edge count e ≤ |A||B| ≤ ε|P||Q| and the predicted count d(P,Q)|A||B| ≤ |A||B| ≤ ε|P||Q| are each at most ε|P||Q|. Since both are nonnegative and |x − y| ≤ max(x, y) for x, y ≥ 0, their difference is at most ε|P||Q|. This gives pair_cut_error_bound_sharp with the tight ε|P||Q|. Summing over the |parts|² pairs with the same partition decomposition (Σᵢⱼ e(A∩Pᵢ, B∩Pⱼ) = e(A,B) and Σᵢⱼ|Pᵢ||Pⱼ| = n²) turns the per-pair ε|P||Q| into the global ε·n², i.e. an ε-cut-approximation (szemeredi_implies_fk_sharp).",
+    "keyInsights": [
+      "The factor of 2 in the original Szemerédi ⟹ FK bound was slack, not intrinsic: it came from bounding a difference of two nonnegative quantities by their sum rather than their maximum.",
+      "In the small-subset case, e(A,B) and d(P,Q)|A||B| are each individually ≤ ε|P||Q| (because |A||B| ≤ ε|P||Q| and the edge density and edge-fraction both lie in [0,1]); the elementary inequality |x − y| ≤ max(x, y) for nonnegative x, y then gives the difference bound ε|P||Q| with constant 1.",
+      "The large-subset case already delivered the ε rate directly from ε-regularity, so 1 is the optimal constant reachable by this case analysis — no rate below ε is possible, matching the Szemerédi guarantee itself.",
+      "The improvement is entirely local to the per-pair lemma: the partition decomposition and the parts-product identity Σᵢⱼ|Pᵢ||Pⱼ| = n² are reused verbatim, so the global bound sharpens from 2ε·n² to ε·n² with no change to the summation argument.",
+      "This corrects the parent's recorded belief that the constant 2 was sharp under this strategy: the strategy is unchanged; only the small-case estimate is tightened from a sum to a max."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sharp-pair-bound",
+      "title": "Sharp Per-Pair Cut Error Bound",
+      "summary": "pair_cut_error_bound_sharp: for an ε-regular pair (P,Q) and A ⊆ P, B ⊆ Q, the cut error |e(A,B) − d(P,Q)|A||B|| ≤ ε|P||Q| — the tight constant, improving the parent's 2ε|P||Q|.",
+      "startLine": 71,
+      "endLine": 160,
+      "mathContext": "Large case: ε-regularity gives |d(A,B) − d(P,Q)| ≤ ε, so the error is ≤ ε|A||B| ≤ ε|P||Q|. Small case: both e and d|A||B| are ≤ |A||B| ≤ ε|P||Q|, and |x − y| ≤ max(x, y) for x, y ≥ 0 bounds the difference by ε|P||Q|."
+    },
+    {
+      "id": "sharp-main",
+      "title": "Sharp Main Comparison and Corollary",
+      "summary": "szemeredi_implies_fk_sharp: every ε-regular partition is an ε-cut-approximation, summing the sharp per-pair bound over all |parts|² pairs. sharp_recovers_original: the ε result entails the parent's 2ε result.",
+      "startLine": 162,
+      "endLine": 224,
+      "mathContext": "The partition decomposition e(A,B) = Σᵢⱼ e(A∩Pᵢ, B∩Pⱼ) and the parts-product identity Σᵢⱼ|Pᵢ||Pⱼ| = n² (both from the parent) convert per-pair ε|P||Q| into global ε·n²."
+    }
+  ],
+  "conclusion": {
+    "summary": "The factor-of-2 constant in the Szemerédi ⟹ Frieze-Kannan implication is improvable to 1: every ε-regular partition is in fact an ε-cut-approximation, not merely 2ε. The improvement is local — a single per-pair estimate in the small-subset case is tightened from bounding a difference of two nonnegative quantities by their sum (2ε|P||Q|) to bounding it by their maximum (ε|P||Q|). Proved with 0 sorries and 0 axioms, reusing the parent's partition-decomposition machinery unchanged.",
+    "implications": "This answers szemeredi-regularity-oq-02-oq-02 definitively (the constant is 1, not 2) and corrects the parent entry's claim that 2 was sharp under this proof strategy. Constant 1 is optimal for this case analysis, since the large-subset case already forces the ε rate from ε-regularity. The sharp per-pair bound pair_cut_error_bound_sharp is the drop-in replacement any downstream use of the Szemerédi ⟹ FK bound should prefer.",
+    "openQuestions": [
+      "Is ε the globally optimal cut-approximation constant for a Szemerédi ε-regular partition, i.e. does there exist a graph and ε-regular partition whose cut-approximation error is asymptotically ε·n² (a matching lower bound), certifying 1 is tight and not merely reachable by this proof?",
+      "Does the sharp per-pair bound tighten the constants in the downstream FK applications formalized elsewhere (e.g. cut-norm / MAX-CUT approximation guarantees), halving their error terms?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "szemeredi-regularity-oq-02",
+      "relationship": "parent",
+      "description": "Formalizes the FK weak regularity lemma and proves Szemerédi ⟹ FK with the 2ε constant (szemeredi_implies_fk), plus the partition decomposition (edge_count_partition_sum), the parts-product identity (parts_product_sum_eq_card_sq), and the tower-vs-singly-exponential parts-count comparison. This entry sharpens the constant from 2ε to ε, reusing that machinery, and corrects the parent's keyInsight that 2 was sharp."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Per-file salvage of the unique content of the stale rolling-branch PR #34683 (`feature/researcher-8`, ~349 commits diverged from main). **Supersedes #34683** (do not close it here; queue item on #35118). No rebase/merge of the rolling branch — files and declarations were extracted individually and statement-level checked against main.

## Ported (whole files, all build-verified)

| Module | Content | Build | #print axioms |
|---|---|---|---|
| `ChebyshevPNTBridgeOQ01OQ04` | Refutation of naive multinomial bound `p^v ≤ kn` (witness k=3,n=2,p=3) + corrected Kummer-type bound `p^v ≤ n^k·k!` + product–multinomial identity | PASS (1 drift fix) | propext, Classical.choice, Quot.sound |
| `Erdos1017OQ05` | k-uniform hypergraph complete-cover/partition framework: `coverNum ≤ partitionNum ≤ edges.card`, positivity, membership characterization | PASS | foundational only (`mem_edges_of_isCompleteSub_card_eq` even drops Classical.choice) |
| `ProbMethodAlterationOQ01` | Deterministic deletion bound `α(G) ≥ n − m`; sample-then-delete optimum `n·p − m·p² ≤ n²/(4m)` attained at `p = n/(2m)` | PASS | foundational only |
| `SzemerediRegularityOQ02OQ02` | Sharp Frieze–Kannan comparison: `pair_cut_error_bound_sharp`, `szemeredi_implies_fk_sharp`, `sharp_recovers_original` | PASS (after repairing a corrupted docker cache file) | foundational only |
| `FibonacciIdentitiesOQ01OQ04` | Gelin–Cesàro identity for `Nat.fib` via two Catalan slices: `fib_gelin_cesaro_gap` + named form (distinct from main's `Int.fib` versions in `FibonacciIdentitiesOQ04OQ01/OQ04OQ03`) | PASS | foundational only |

Note on `Erdos1017OQ05`: main's `Erdos1017OQ04` shares lemma *names* (`coverNum_le_partitionNum`, …) but is the graph (k=2, `SimpleGraph` edge-clique) case; the branch file is the k-uniform hypergraph generalization — statement-level distinct, ported in its own namespace.

## Appended to existing hosts (statement-level absent from main)

- `AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean`: `dense_countable_compl_isGδ_not_isFσ` (dual `Gδ`-only side) and `dense_countable_gδ_fσ_dichotomy` (packaged four-way split), restated over main's `dense_countable_isFσ_and_not_isGδ` API. Build PASS, foundational axioms only.
- `AmgmInequalityOQ02OQ01OQ05OQ01.lean`: `newton_k2_symmetric_means` — the literal Maclaurin form `S₂² ≥ S₁·S₃` (n = 3, all reals), restated over the `newton_k2_*` API merged in #35127. Build PASS, foundational axioms only.

`#print axioms` audit lines added for every salvaged headline theorem; all report only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).

## v4.26 drift fixes applied

- `ChebyshevPNTBridgeOQ01OQ04.prod_Icc_mul_const`: `Finset.prod_Icc_id_eq_factorial` no longer exists; reproved by induction with `Finset.prod_Icc_succ_top`.

## Gallery

Ported the 5 absent gallery dirs (`chebyshev-pnt-bridge-oq-01-oq-04`, `erdos-1017-oq-05`, `prob-method-alteration-oq-01`, `szemeredi-regularity-oq-02-oq-02`, `fibonacci-identities-oq-01-oq-04`). Honest meta in BOTH `meta.*` and `leanFile.*` blocks; line counts updated for the audit-line appends. `chebyshev-pnt-bridge-oq-01-oq-04` was written BUILD-PENDING during the 2026-07-04 Docker outage — now build-verified and upgraded `formalized` → `verified`/`original`, with a `leanFile` block added and section ranges re-anchored. Stale research-state JSONs from the branch were NOT ported.

## Dropped manifest (with reasons)

- `newton_sos_identity`, `newton_cleared`, `newton_eq_of_all_eq`, `newton_products_eq_of_eq` — superseded by the stronger `newton_k2_*` API in main (#35127: identical SOS identity, inequality, and an equality **iff**).
- `primeCounting_ge_log2` — subsumed by `ChebyshevBounds.primeCounting_ge_log` (identical statement with a `2 ≤ n` hypothesis; the `n ∈ {0,1}` cases are trivial). Its companions `nth_prime_le_two_pow_succ` / `log2_nth_prime_le` are a re-export of `PrimeGapBounds` and a 2-line corollary.
- Branch rewrites of `Erdos101ProblemOQ02` (identical), `Erdos1018Problem`, `CubeRoot3IrrationalOQ02OQ03`, `LegendrePartialOQ04`, `AmgmInequalityOQ02OQ02`, `ChebyshevPNTBridgeOQ03OQ01`, `Erdos3Problem` — deletion-heavy diffs against strictly richer main versions (per the 2026-07-07 triage).
- Branch gallery/research-state JSONs for superseded slugs.

Part of #35118. Supersedes #34683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)