### PR TITLE
feat(gallery): entertaining loading screen with rotating math facts (#35117 Track B)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "export NODE_OPTIONS=\"${NODE_OPTIONS:-} --max-old-space-size=8192\" && pnpm gallery:check-size && pnpm annotations:build && pnpm research:build && pnpm research:enrich && tsc -b && vite build",
+    "build": "export NODE_OPTIONS=\"${NODE_OPTIONS:-} --max-old-space-size=8192\" && pnpm gallery:check-size && pnpm annotations:build && pnpm research:build && pnpm research:enrich && pnpm gallery:loading-facts && tsc -b && vite build",
     "lint": "eslint .",
     "gallery:check-size": "tsx scripts/gallery/check-meta-size.ts",
     "gallery:check-size:strict": "tsx scripts/gallery/check-meta-size.ts --strict",
     "gallery:size-report": "tsx scripts/gallery/check-meta-size.ts --report",
+    "gallery:loading-facts": "tsx scripts/gallery/build-loading-facts.ts",
     "preview": "vite preview",
     "deploy": "pnpm build && wrangler pages deploy dist --project-name=lean-genius --commit-dirty=true",
     "annotations:build": "tsx scripts/annotations/build.ts",

--- a/scripts/gallery/build-loading-facts.ts
+++ b/scripts/gallery/build-loading-facts.ts
@@ -1,0 +1,193 @@
+#!/usr/bin/env npx tsx
+/**
+ * Build loading-screen math facts (issue #35117, Track B)
+ *
+ * Samples ~100 short, self-contained, single-sentence facts from the
+ * gallery's existing `overview.keyInsights` arrays (src/data/proofs/x/meta.json)
+ * into a tiny static src/data/loading-facts.json that is safe to bundle
+ * eagerly. Each fact carries `{ fact, slug, title }` so the loading screen
+ * can attribute it and deep-link to the proof page. A handful of curated
+ * classic quotes (slug: null) are seeded in as fallback flavor.
+ *
+ * Selection is deterministic (sha1-based) so repeated builds over the same
+ * gallery produce a byte-identical file and don't churn git status.
+ *
+ * Usage: tsx scripts/gallery/build-loading-facts.ts
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { createHash } from 'node:crypto'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const PROOFS_DATA_DIR = path.join(__dirname, '../../src/data/proofs')
+const OUTPUT_FILE = path.join(__dirname, '../../src/data/loading-facts.json')
+
+/** Total facts to emit (insights + quotes). Keeps the file to a few KB. */
+const TARGET_COUNT = 100
+
+interface LoadingFact {
+  fact: string
+  /** Proof-page slug for deep-linking; null for classic quotes. */
+  slug: string | null
+  /** Proof title, or the quote's author when slug is null. */
+  title: string
+}
+
+/** Curated classic quotes — always included, attributed via `title`. */
+const CLASSIC_QUOTES: LoadingFact[] = [
+  {
+    fact: 'A mathematician is a machine for turning coffee into theorems.',
+    slug: null,
+    title: 'Alfréd Rényi (popularized by Paul Erdős)',
+  },
+  { fact: 'My brain is open.', slug: null, title: 'Paul Erdős' },
+  {
+    fact: 'Wir müssen wissen — wir werden wissen. (We must know — we will know.)',
+    slug: null,
+    title: 'David Hilbert',
+  },
+  {
+    fact: 'Mathematics is the queen of the sciences.',
+    slug: null,
+    title: 'Carl Friedrich Gauss',
+  },
+  {
+    fact: 'God made the integers; all else is the work of man.',
+    slug: null,
+    title: 'Leopold Kronecker',
+  },
+  {
+    fact: "In mathematics you don't understand things. You just get used to them.",
+    slug: null,
+    title: 'John von Neumann',
+  },
+  {
+    fact: 'The essence of mathematics lies in its freedom.',
+    slug: null,
+    title: 'Georg Cantor',
+  },
+  {
+    fact: 'Mathematics is the art of giving the same name to different things.',
+    slug: null,
+    title: 'Henri Poincaré',
+  },
+  {
+    fact: 'Beauty is the first test: there is no permanent place in the world for ugly mathematics.',
+    slug: null,
+    title: 'G. H. Hardy',
+  },
+]
+
+/**
+ * Reject insights that are LaTeX/Lean/markdown-heavy or not self-contained:
+ * math delimiters, code spans, dotted Lean identifiers, tactic talk, and
+ * references to "the parent" entry (meaningless out of context).
+ */
+const REJECT = new RegExp(
+  [
+    '[$\\\\`_{}^~|<>=]', // LaTeX / code / markup characters
+    '\\*\\*', // leftover bold markers
+    '\\b[A-Za-z][A-Za-z0-9]*\\.[A-Za-z]', // dotted identifiers (Nat.choose, …)
+    '\\bsimp\\b',
+    '\\bLean\\b',
+    '\\bMathlib\\b',
+    '\\bsorr(y|ies)\\b',
+    '\\btactic',
+    '\\baxiom',
+    '\\bparent\\b', // "the parent entry/identity" — not self-contained
+  ].join('|'),
+  'i'
+)
+
+const MIN_LEN = 60
+const MAX_LEN = 170
+
+function sha1(s: string): string {
+  return createHash('sha1').update(s).digest('hex')
+}
+
+/** Normalize a keyInsight: unwrap a leading `**Label:**` into `Label: …`. */
+function normalize(raw: string): string {
+  let s = raw.trim()
+  const labeled = s.match(/^\*\*([^*]+?)\*\*[:.]?\s*(.*)$/s)
+  if (labeled) {
+    const label = labeled[1].replace(/:$/, '').trim()
+    const rest = labeled[2].trim()
+    s = rest ? `${label}: ${rest}` : label
+  }
+  s = s.replace(/\*\*/g, '').replace(/\s+/g, ' ').trim()
+  if (s && !/[.!?]$/.test(s)) s += '.'
+  return s
+}
+
+/** Accept only short, single-sentence, markup-free insights. */
+function isGoodFact(s: string): boolean {
+  if (s.length < MIN_LEN || s.length > MAX_LEN) return false
+  if (REJECT.test(s)) return false
+  const body = s.slice(0, -1)
+  if (/[.!?]\s/.test(body)) return false // multiple sentences
+  return true
+}
+
+function main(): void {
+  const dirs = fs
+    .readdirSync(PROOFS_DATA_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
+
+  // Best candidate per slug (lowest hash) so no proof dominates the deck.
+  const bySlug = new Map<string, { hash: string; fact: LoadingFact }>()
+
+  for (const dir of dirs) {
+    const metaPath = path.join(PROOFS_DATA_DIR, dir, 'meta.json')
+    if (!fs.existsSync(metaPath)) continue
+    let meta: {
+      slug?: string
+      title?: string
+      overview?: { keyInsights?: unknown[] }
+    }
+    try {
+      meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'))
+    } catch {
+      continue // malformed meta.json — not this script's problem
+    }
+    const insights = meta.overview?.keyInsights
+    if (!Array.isArray(insights)) continue
+    const slug = meta.slug || dir
+    const title = meta.title || slug
+    for (const raw of insights) {
+      if (typeof raw !== 'string') continue
+      const fact = normalize(raw)
+      if (!isGoodFact(fact)) continue
+      const hash = sha1(`${slug}|${fact}`)
+      const prev = bySlug.get(slug)
+      if (!prev || hash < prev.hash) {
+        bySlug.set(slug, { hash, fact: { fact, slug, title } })
+      }
+    }
+  }
+
+  const sampled = [...bySlug.values()]
+    .sort((a, b) => (a.hash < b.hash ? -1 : 1))
+    .slice(0, Math.max(0, TARGET_COUNT - CLASSIC_QUOTES.length))
+    .map((c) => c.fact)
+
+  // Interleave quotes among facts deterministically via a second hash sort.
+  const all = [...CLASSIC_QUOTES, ...sampled].sort((a, b) =>
+    sha1(a.fact) < sha1(b.fact) ? -1 : 1
+  )
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(all, null, 2) + '\n')
+
+  const bytes = fs.statSync(OUTPUT_FILE).size
+  console.log(
+    `loading-facts: wrote ${all.length} facts (${sampled.length} insights from ${bySlug.size} eligible proofs + ${CLASSIC_QUOTES.length} quotes) to ${path.relative(process.cwd(), OUTPUT_FILE)} (${(bytes / 1024).toFixed(1)} KB)`
+  )
+}
+
+main()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { lazyWithRetry } from '@/utils/lazyWithRetry'
+import { LoadingScreen } from '@/components/LoadingScreen'
 
 // Lazy load pages with auto-reload on stale chunk errors
 const HomePage = lazyWithRetry(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })))
@@ -13,20 +14,12 @@ const SubmitPage = lazyWithRetry(() => import('@/pages/SubmitPage').then(m => ({
 const AboutPage = lazyWithRetry(() => import('@/pages/AboutPage').then(m => ({ default: m.AboutPage })))
 const ErdosPage = lazyWithRetry(() => import('@/pages/ErdosPage').then(m => ({ default: m.ErdosPage })))
 
-function LoadingSpinner() {
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-annotation" />
-    </div>
-  )
-}
-
 function App() {
   return (
     <ErrorBoundary>
       <AuthProvider>
         <BrowserRouter>
-          <Suspense fallback={<LoadingSpinner />}>
+          <Suspense fallback={<LoadingScreen />}>
             <Routes>
               <Route path="/" element={<HomePage />} />
               <Route path="/proof/:slug" element={<ProofPage />} />

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { cn } from '@/lib/utils'
+import loadingFactsData from '@/data/loading-facts.json'
+
+/**
+ * Entertaining loading screen (issue #35117, Track B).
+ *
+ * Shows a spinner plus a rotating math fact/quote sampled at build time from
+ * the gallery's keyInsights (scripts/gallery/build-loading-facts.ts). Facts
+ * with a slug deep-link to their proof page. Respects
+ * `prefers-reduced-motion` by pinning a single static fact.
+ */
+
+interface LoadingFact {
+  fact: string
+  slug: string | null
+  title: string
+}
+
+const FACTS = loadingFactsData as LoadingFact[]
+
+const ROTATE_MS = 3500
+const FADE_MS = 400
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+function RotatingFact() {
+  const [index, setIndex] = useState(() =>
+    Math.floor(Math.random() * FACTS.length)
+  )
+  const [visible, setVisible] = useState(true)
+  const [reducedMotion] = useState(prefersReducedMotion)
+
+  useEffect(() => {
+    if (reducedMotion || FACTS.length < 2) return
+    const interval = setInterval(() => {
+      setVisible(false)
+      // Swap the fact once the fade-out completes, then fade back in
+      setTimeout(() => {
+        setIndex((i) => (i + 1) % FACTS.length)
+        setVisible(true)
+      }, FADE_MS)
+    }, ROTATE_MS)
+    return () => clearInterval(interval)
+  }, [reducedMotion])
+
+  const fact = FACTS[index]
+  if (!fact) return null
+
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        'max-w-md min-h-24 px-6 text-center transition-opacity',
+        visible ? 'opacity-100' : 'opacity-0'
+      )}
+      style={{ transitionDuration: `${FADE_MS}ms` }}
+    >
+      <p className="text-sm text-muted-foreground italic">
+        &ldquo;{fact.fact}&rdquo;
+      </p>
+      {fact.slug ? (
+        <Link
+          to={`/proof/${fact.slug}`}
+          className="mt-2 inline-block text-xs text-annotation hover:underline"
+        >
+          from {fact.title}
+        </Link>
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground/70">
+          &mdash; {fact.title}
+        </p>
+      )}
+    </div>
+  )
+}
+
+interface LoadingScreenProps {
+  /** Status line under the spinner, e.g. "Loading proof..." */
+  message?: string
+  className?: string
+}
+
+export function LoadingScreen({ message, className }: LoadingScreenProps) {
+  return (
+    <div
+      className={cn(
+        'min-h-screen flex flex-col items-center justify-center gap-4',
+        className
+      )}
+    >
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-annotation" />
+      {message && <p className="text-muted-foreground">{message}</p>}
+      <RotatingFact />
+    </div>
+  )
+}

--- a/src/data/loading-facts.json
+++ b/src/data/loading-facts.json
@@ -1,0 +1,502 @@
+[
+  {
+    "fact": "The problem connects extremal graph theory to number-theoretic properties of integer sets.",
+    "slug": "erdos-72",
+    "title": "Erdős Problem #72: Unavoidable Cycle Lengths"
+  },
+  {
+    "fact": "Demonstrates 'motivic purity' - complex moduli spaces have simple motivic classes.",
+    "slug": "motivic-flag-maps",
+    "title": "Motivic Class of Genus 0 Maps to Flag Varieties"
+  },
+  {
+    "fact": "Bounds Gap: The √(log log n) gap between upper and lower bounds is the key mystery.",
+    "slug": "erdos-710",
+    "title": "Erdős Problem #710: Minimal Interval for Divisibility Matching"
+  },
+  {
+    "fact": "Yip's Construction (2025): For any nonzero t, there exists a counterexample sequence - the sequence depends on t.",
+    "slug": "erdos-967",
+    "title": "Erdős Problem #967: Zeros of Generalized Dirichlet Sums"
+  },
+  {
+    "fact": "Infinitude from parameters: Since a can be any integer ≥ 2, we get infinitely many distinct solutions, completely disproving the conjecture.",
+    "slug": "erdos-397",
+    "title": "Erdős Problem #397: Products of Central Binomial Coefficients"
+  },
+  {
+    "fact": "Working over ℝ is forced, since e is irrational — the rational gallery threshold cannot express the sharp constant directly.",
+    "slug": "prob-method-lovasz-local-oq-02",
+    "title": "Sharp Symmetric LLL Criterion: e·p·(d+1) ≤ 1"
+  },
+  {
+    "fact": "LRW conjectures Ramsey ⟺ subtransitive (alternate characterization).",
+    "slug": "erdos-174",
+    "title": "Erdős Problem #174: Euclidean Ramsey Sets"
+  },
+  {
+    "fact": "The gap problem: Erdős believed gaps between powerful numbers grow polynomially—if true, this is much stronger than just ruling out triples.",
+    "slug": "erdos-364",
+    "title": "Erdős Problem #364: Consecutive Powerful Numbers"
+  },
+  {
+    "fact": "The remaining gap is purely the global assembly — a multipliability framework for PowerSeries plus identification with numOverpartitions — not the per-factor mathematics.",
+    "slug": "partition-theorem-oq-03-oq-03",
+    "title": "Overpartition Generating Function: the Single-Part-Size Euler Factor"
+  },
+  {
+    "fact": "Recent breakthrough: The 2025 paper by van Doorn and Everts resolved this decades-old problem.",
+    "slug": "erdos-845",
+    "title": "Erdős Problem #845: Sums of 3-Smooth Numbers with Bounded Ratio"
+  },
+  {
+    "fact": "This bijection connects subsets to binary strings of length n.",
+    "slug": "subset-count",
+    "title": "Number of Subsets of a Set"
+  },
+  {
+    "fact": "Why the problem is hard: We need to understand the interplay between powers of 2 and arithmetic properties of numbers with few prime factors.",
+    "slug": "erdos-851",
+    "title": "Erdős Problem #851: Density of Integers 2^k + n"
+  },
+  {
+    "fact": "Connection to Problem 596: this is the (K₄, K₃) case of the general (G₁, G₂) decomposition question.",
+    "slug": "erdos-595",
+    "title": "Erdős Problem #595: Infinite Graphs and Countable Triangle-Free Decomposition"
+  },
+  {
+    "fact": "Admissibility: A set is admissible if for every prime p, at least one residue class mod p is not represented — this is the minimum necessary condition for a prime shift.",
+    "slug": "erdos-429",
+    "title": "Erdős Problem #429: Sparse Admissible Sets and Prime Shifts"
+  },
+  {
+    "fact": "V₄ equals the commutator subgroup [A₄, A₄], so the exhibited series IS the derived series — the two standard descriptions of A₄'s solvability coincide on the nose.",
+    "slug": "abel-ruffini-oq-04-oq-02-oq-02-oq-01",
+    "title": "The Chief Series of A₄ Made Explicit: A₄ ▷ V₄ ▷ 1 (factors ℤ/3ℤ and (ℤ/2ℤ)²)"
+  },
+  {
+    "fact": "The Constraint: All paths must be the same color (Red or Blue).",
+    "slug": "erdos-518",
+    "title": "Erdős Problem #518: Monochromatic Path Covers"
+  },
+  {
+    "fact": "Schmidt's counterexample has carefully controlled oscillating gaps.",
+    "slug": "erdos-492",
+    "title": "Erdős Problem #492: Uniform Distribution Relative to a Fixed Sequence"
+  },
+  {
+    "fact": "Over a commutative ring, invertibility of A is IsUnit (det A), strictly stronger than det A ≠ 0; this is the correct hypothesis and it is exactly what the proof needs.",
+    "slug": "cayley-hamilton-minpoly-oq-07-oq-02",
+    "title": "The Inverse is a Polynomial in A over a Commutative Ring"
+  },
+  {
+    "fact": "The special cases (primes 1 mod 4, 3 mod 4, etc.) serve as concrete instantiations — the 3 mod 4 case even admits an elementary proof via Euclid-style argument.",
+    "slug": "dirichlets-theorem",
+    "title": "Dirichlet's Theorem on Primes in Arithmetic Progressions"
+  },
+  {
+    "fact": "A weird number is abundant but not semiperfect; 70 is the smallest.",
+    "slug": "erdos-825",
+    "title": "Erdős Problem #825: Abundancy Bound for Weird Numbers"
+  },
+  {
+    "fact": "Harmonic Series Divergence: The expected sum (log N)/2 → ∞ explains why hitting exactly 1 is so rare among random subsets.",
+    "slug": "erdos-297",
+    "title": "Erdős Problem #297: Counting Egyptian Fraction Representations of 1"
+  },
+  {
+    "fact": "Value Distribution: phi tends to be small, sigma tends to be large.",
+    "slug": "erdos-48",
+    "title": "Erdos Problem #48: Infinitely Many Pairs with phi(n) = sigma(m)"
+  },
+  {
+    "fact": "Hexagonal Lattice: Thue-Minkowski shows hexagonal packing is asymptotically optimal.",
+    "slug": "erdos-103",
+    "title": "Erdős Problem #103: Incongruent Optimal Point Configurations"
+  },
+  {
+    "fact": "The difficulty is finding a single x that works for ALL intersecting subfamilies.",
+    "slug": "erdos-701",
+    "title": "Chvátal's Conjecture on Intersecting Families"
+  },
+  {
+    "fact": "Centralizing definitions prevents the regularity and counting modules from using incompatible variants of edge density or regularity.",
+    "slug": "szemeredi-core",
+    "title": "Szemeredi Core Definitions"
+  },
+  {
+    "fact": "Windmill graphs are the unique family satisfying the property.",
+    "slug": "friendship-theorem",
+    "title": "Friendship Theorem"
+  },
+  {
+    "fact": "Product simplex is compact convex: the product of the mixed strategy simplices is compact (Tychonoff) and convex, satisfying Brouwer's hypotheses.",
+    "slug": "brouwer-fixed-point-oq-04-oq-02",
+    "title": "Nash Equilibrium Existence via Nash's Brouwer Argument"
+  },
+  {
+    "fact": "Bertrand's postulate gives multiplicative control over prime density: doubling the range always captures at least one new prime.",
+    "slug": "prime-gap-bounds",
+    "title": "Explicit Prime Gap Bounds from Bertrand's Postulate"
+  },
+  {
+    "fact": "The Difficulty: For finite P, pattern of duplicates is hard to analyze.",
+    "slug": "erdos-269",
+    "title": "Erdos Problem #269: LCM Series Irrationality"
+  },
+  {
+    "fact": "Erdős's 'colleague from Zagreb' mystery was resolved after decades.",
+    "slug": "erdos-91",
+    "title": "Erdős Problem #91: Non-Uniqueness of Minimal Distance Sets"
+  },
+  {
+    "fact": "Latin Square: An n×n array with n symbols, each appearing exactly once in each row and column.",
+    "slug": "erdos-724",
+    "title": "Erdős Problem #724: Mutually Orthogonal Latin Squares"
+  },
+  {
+    "fact": "Sub-Ballistic: SAW in 2D grows slower than linearly but likely faster than √n.",
+    "slug": "erdos-529",
+    "title": "Erdős Problem #529: Self-Avoiding Walk End-to-End Distance"
+  },
+  {
+    "fact": "Trivial Counterexample: Powers of 2 as moduli cover almost all integers via binary representation.",
+    "slug": "erdos-280",
+    "title": "Erdős Problem #280: Covering Congruences and Sieve Methods"
+  },
+  {
+    "fact": "This result implies Roth's theorem on 3-term arithmetic progressions.",
+    "slug": "erdos-716",
+    "title": "Erdős Problem #716: The Ruzsa-Szemerédi (6,3) Problem"
+  },
+  {
+    "fact": "Θ(n log log n) bound: Both upper and lower bounds match, fully resolving the problem.",
+    "slug": "erdos-182",
+    "title": "Erdős Problem #182: Maximum Edges Avoiding k-Regular Subgraphs"
+  },
+  {
+    "fact": "Connection to Ramsey Theory: Like Ramsey numbers, the question asks which patterns are unavoidable in large combinatorial structures.",
+    "slug": "erdos-195",
+    "title": "Erdős Problem #195: Monotone Arithmetic Progressions in Permutations"
+  },
+  {
+    "fact": "Strip width delta for analytic functions plays the same structural role as Holder exponent alpha for continuous functions, but gives exponentially faster decay.",
+    "slug": "fourier-series-oq-02-oq-03-oq-02",
+    "title": "Sharp Constants for Analytic (Exponential) Fourier Decay"
+  },
+  {
+    "fact": "Two Threshold Functions: f(n) (maximum achievable) and F(n) (universal guarantee) capture different extremal questions.",
+    "slug": "erdos-1182",
+    "title": "Erdos Problem #1182: Ramsey-Theoretic Edge Thresholds"
+  },
+  {
+    "fact": "Vose's technique: The √(log b) upper bound uses continued fractions to construct efficient representations, improving Erdős's original log b / log log b bound.",
+    "slug": "erdos-304",
+    "title": "Erdős Problem #304: Egyptian Fractions Complexity"
+  },
+  {
+    "fact": "The formal (algebraic) polynomial derivative obeys the full Leibniz product rule over any commutative ring — no limits or topology involved.",
+    "slug": "polynomial-derivative-leibniz-oq-01",
+    "title": "The Leibniz Product Rule for Formal Polynomial Derivatives over a Finset"
+  },
+  {
+    "fact": "Sum-length-free is weaker than Sidon: only length must match.",
+    "slug": "erdos-789",
+    "title": "Erdős Problem #789: Sum-Length-Free Subsets"
+  },
+  {
+    "fact": "Structural method: Wang's proof uses minimal counterexample analysis and neighborhood structure — no algebraic or probabilistic techniques.",
+    "slug": "erdos-577",
+    "title": "Erdős Problem #577: Vertex-Disjoint 4-Cycles in Dense Graphs"
+  },
+  {
+    "fact": "The gap is the single function 1/(k-1): the entire 'how open is OQ-01 for each k' story reduces to one elementary function, whose behaviour is completely determined.",
+    "slug": "erdos-1021-oq-01-incomplete-01",
+    "title": "The Exponent Gap for ex(n, G_k): Verified Scaffolding Around Erdős #1021 OQ-01"
+  },
+  {
+    "fact": "ℵ₁ Minimality: ℵ₁ is not just uncountable but the MINIMUM uncountable cardinal: any uncountable κ satisfies ℵ₁ ≤ κ.",
+    "slug": "cantor-diagonalization-oq-02",
+    "title": "Cardinality of the Set of All Countable Ordinals"
+  },
+  {
+    "fact": "3-AP Connection: Bounds on W(3,k) are intimately connected to the density of 3-AP-free sets.",
+    "slug": "erdos-721",
+    "title": "Erdős Problem #721: Van der Waerden Numbers W(3,k)"
+  },
+  {
+    "fact": "Kakeya Connection: The proof uses ideas from discrete Kakeya problems - unexpected geometry in number theory!",
+    "slug": "erdos-806",
+    "title": "Erdős Problem #806: Small Bases for Sumsets"
+  },
+  {
+    "fact": "Wir müssen wissen — wir werden wissen. (We must know — we will know.)",
+    "slug": null,
+    "title": "David Hilbert"
+  },
+  {
+    "fact": "The Leibniz upper bound is therefore sharp to within one term: for strictly decreasing terms the error has a guaranteed nonzero size.",
+    "slug": "alternating-series-test-oq-01-oq-01",
+    "title": "Two-Sided, Two-Term Error Trapping for the Alternating Series Test"
+  },
+  {
+    "fact": "Equality on intervals reduces to a four-way case analysis (x+1 or x-1 lands inside [a,b]; x is or is not in [a,b]); linarith handles all branches uniformly.",
+    "slug": "isoperimetric-theorem-oq-02",
+    "title": "Discrete Isoperimetric Inequality (1D)"
+  },
+  {
+    "fact": "The quotient repairs the count: congruence collapses each translation-orbit to a single class, so hCong is finite/meaningful exactly where the raw count collapsed to 0.",
+    "slug": "erdos-103-oq-02",
+    "title": "Erdos #103 OQ-02: Is h(n) ≥ 2 for all large n? (a formalization audit)"
+  },
+  {
+    "fact": "The tower-type bound on the number of parts is necessary (Gowers 1997), showing the lemma is inherently non-polynomial.",
+    "slug": "szemeredi-regularity",
+    "title": "Szemeredi Regularity Lemma (Energy Machinery & Mathlib Bridge)"
+  },
+  {
+    "fact": "Quantum mechanics requires infinite-dimensional Hilbert spaces.",
+    "slug": "hilbert-6",
+    "title": "Hilbert's Sixth Problem: Axiomatization of Physics"
+  },
+  {
+    "fact": "The 2×2 matrix (Ceva/Menelaus × Euclidean/Spherical/Hyperbolic) is now complete in this gallery, all following the same algebraic pattern.",
+    "slug": "cevas-theorem-non-euclidean-oq-02-oq-01",
+    "title": "Spherical Menelaus Theorem via Sin Measure Function"
+  },
+  {
+    "fact": "Modified Problem: Ask for 'not all colors' instead of 'monochromatic'.",
+    "slug": "erdos-948",
+    "title": "Erdős Problem #948: Subset Sums and Colorings"
+  },
+  {
+    "fact": "Kummer's theorem connection: C(n,k) is odd iff there are no carries in binary addition of k and n-k.",
+    "slug": "erdos-1095-oq-01",
+    "title": "Erdős #1095 OQ01: Asymptotics of g(k) — Smooth Binomial Coefficients"
+  },
+  {
+    "fact": "Gap Problem: Current exponent gap is [5/12, 1/2], a span of 1/12.",
+    "slug": "erdos-813",
+    "title": "Erdős Problem #813: Triangles in Every 7-Vertex Set"
+  },
+  {
+    "fact": "Fractal Convergence Set: The convergence set has Hausdorff dimension 1 (as large as the circle) but Lebesgue measure zero — a fractal phenomenon.",
+    "slug": "erdos-527",
+    "title": "Erdős Problem #527: Convergence of Random Power Series on Unit Circle"
+  },
+  {
+    "fact": "Beauty is the first test: there is no permanent place in the world for ugly mathematics.",
+    "slug": null,
+    "title": "G. H. Hardy"
+  },
+  {
+    "fact": "Mathematics is the art of giving the same name to different things.",
+    "slug": null,
+    "title": "Henri Poincaré"
+  },
+  {
+    "fact": "No analogous rapid-convergence series is known for ζ(5) — the key obstacle to generalizing Apéry.",
+    "slug": "basel-problem-oq-01",
+    "title": "Is ζ(5) Irrational? (Open Question)"
+  },
+  {
+    "fact": "Sumset covering: A ⊆ B+B means every element of A is a sum of two elements from B.",
+    "slug": "erdos-333",
+    "title": "Erdős Problem #333: Sparse Sumset Bases"
+  },
+  {
+    "fact": "Related problems: The same result holds for n + σ(n), n + τ(n), and n + ω(n), showing a general phenomenon.",
+    "slug": "erdos-822",
+    "title": "Erdős Problem #822: Positive Density of n + φ(n)"
+  },
+  {
+    "fact": "A positive answer would show each element of the basis is quantitatively critical.",
+    "slug": "erdos-330",
+    "title": "Erdős Problem #330: Minimal Bases with Positive Density"
+  },
+  {
+    "fact": "3-Connected Rescue: Sørensen-Thomassen showed the vertex-disjoint conjecture holds for 3-connected graphs, indicating the counterexamples exploit low connectivity.",
+    "slug": "erdos-915",
+    "title": "Erdős Problem #915: Disjoint Paths in Graphs"
+  },
+  {
+    "fact": "Beautiful connection between set theory, linear algebra, and geometry.",
+    "slug": "erdos-1127",
+    "title": "Decomposing ℝⁿ into Sets with Distinct Distances"
+  },
+  {
+    "fact": "In mathematics you don't understand things. You just get used to them.",
+    "slug": null,
+    "title": "John von Neumann"
+  },
+  {
+    "fact": "The structural constraint 'exotic implies 2 prime factors' uses only the fact that prime powers are non-exotic, no topological content.",
+    "slug": "borsuk-ulam-oq-02-oq-01-oq-01-oq-02",
+    "title": "Exotic G-Representations and the Composite BU Dimension Gap"
+  },
+  {
+    "fact": "Mathematics is the queen of the sciences.",
+    "slug": null,
+    "title": "Carl Friedrich Gauss"
+  },
+  {
+    "fact": "God made the integers; all else is the work of man.",
+    "slug": null,
+    "title": "Leopold Kronecker"
+  },
+  {
+    "fact": "This module serves as shared infrastructure for Galois theory proofs, where knowing that nth roots of primes generate non-trivial field extensions is a foundational fact.",
+    "slug": "nth-root-irrational-oq-01",
+    "title": "Nth Root Irrationality via Irreducible Polynomials"
+  },
+  {
+    "fact": "This is the honest boundary of what is formalizable for OQ-05: the decidable skeleton is provable; a polynomial algorithm and NP-hardness are not, and remain open.",
+    "slug": "erdos-1012-oq-05",
+    "title": "Erdős #1012 (OQ-05): Decidability and the Brute-Force Search Space for (n−k)-Cycle Detection"
+  },
+  {
+    "fact": "Additive combinatorics meets Diophantine approximation: The problem bridges two major branches of number theory.",
+    "slug": "erdos-254",
+    "title": "Erdős Problem #254: Subset Sum Representation"
+  },
+  {
+    "fact": "Smooth numbers give limit point 1: When n+1 has only small prime factors, all factors in the product are near 1, so the ratio → 1.",
+    "slug": "erdos-419",
+    "title": "Erdős Problem #419: Limit Points of τ((n+1)!)/τ(n!)"
+  },
+  {
+    "fact": "The conjecture asks whether every interval of the natural scale captures Ω(1) contribution, with no anomalously empty intervals.",
+    "slug": "erdos-462",
+    "title": "Erdős Problem #462: Least Prime Factor Sums in Short Intervals"
+  },
+  {
+    "fact": "The physical explanation: strong coupling confines dynamics within single plaquettes; inter-plaquette correlations are exponentially suppressed regardless of L.",
+    "slug": "yang-mills-transfer-matrix-oq-01",
+    "title": "Yang-Mills Transfer Matrix OQ-01: Infinite-Volume Mass Gap"
+  },
+  {
+    "fact": "The conjecture applies only to lacunary sequences; irregular ones exist.",
+    "slug": "erdos-346",
+    "title": "Erdős Problem #346: Complete Sequences and the Golden Ratio"
+  },
+  {
+    "fact": "The essence of mathematics lies in its freedom.",
+    "slug": null,
+    "title": "Georg Cantor"
+  },
+  {
+    "fact": "K₄ is 3-regular but minimal: no proper 3-regular subgraph exists, showing the threshold is exactly 4.",
+    "slug": "erdos-715",
+    "title": "Erdős Problem #715: Regular Subgraphs in Regular Graphs"
+  },
+  {
+    "fact": "The antipodal condition is NECESSARY: without it, constant labelings have no complementary edges.",
+    "slug": "borsuk-ulam-oq-03-oq-03",
+    "title": "Constructive 2D Borsuk-Ulam via Tucker's Lemma"
+  },
+  {
+    "fact": "Vertices of odd degree must be endpoints of an Eulerian path (if one exists).",
+    "slug": "konigsberg",
+    "title": "Königsberg Bridges Problem"
+  },
+  {
+    "fact": "Collinearity of the three division points is captured by a single 2×2 signed-area determinant.",
+    "slug": "menelaus-theorem-oq-01",
+    "title": "Menelaus's Theorem: Collinearity via Signed Side Ratios"
+  },
+  {
+    "fact": "Optimal lower bound: Erdős showed infinitely many gaps achieve (π²/6)·log(sₙ)/log(log(sₙ)), so this would be tight.",
+    "slug": "erdos-208",
+    "title": "Erdős Problem #208: Gaps Between Squarefree Numbers"
+  },
+  {
+    "fact": "The Dickman function ρ(u) governs the density of smooth numbers.",
+    "slug": "erdos-334",
+    "title": "Erdős Problem #334: Smooth Number Representation"
+  },
+  {
+    "fact": "All 50 elements are even — the parity constraint (any admissible set containing 0 must be all-even) is satisfied.",
+    "slug": "bounded-prime-gaps-oq-01-oq-03",
+    "title": "Minimum Admissible 50-Tuple Diameter: The Engelsma 50-Tuple"
+  },
+  {
+    "fact": "30-Year Resolution: The problem was posed in 1993 and fully resolved only in 2024.",
+    "slug": "erdos-570",
+    "title": "Erdős Problem #570: Cycle-Graph Ramsey Numbers"
+  },
+  {
+    "fact": "Injectivity of extension-by-zero is immediate once a left inverse is exhibited — a split monomorphism — avoiding any direct kernel computation on Lᵖ classes.",
+    "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01",
+    "title": "The Lp Restriction Map and the Splitting of Extension-by-Zero"
+  },
+  {
+    "fact": "Liu-Sawhney's 2024 breakthrough connects Egyptian fractions to additive combinatorics via dense subset summing problems, reducing the exponent from 4 to 3.",
+    "slug": "erdos-305",
+    "title": "Maximum Denominator in Egyptian Fraction Representations"
+  },
+  {
+    "fact": "Prime Coverage: f(k,n) measures the minimum primes needed to cover k elements via smoothness.",
+    "slug": "erdos-983",
+    "title": "Erdős Problem #983: Prime Coverage Function for Smooth Numbers"
+  },
+  {
+    "fact": "Construction Method: Lacunary series and Weierstrass products place zeros at carefully chosen locations.",
+    "slug": "erdos-1116",
+    "title": "Erdős Problem #1116: Extreme Value Distribution of Entire Functions"
+  },
+  {
+    "fact": "Non-Computability: The problem cannot be resolved by checking finite cases.",
+    "slug": "erdos-197",
+    "title": "Erdős Problem #197: Partition of ℕ Avoiding Monotone 3-AP Permutations"
+  },
+  {
+    "fact": "If NO: quantitative strengthening of Erdős-Turán below density 1.",
+    "slug": "erdos-749",
+    "title": "Erdős Problem #749: Dense Sumsets with Bounded Representation"
+  },
+  {
+    "fact": "My brain is open.",
+    "slug": null,
+    "title": "Paul Erdős"
+  },
+  {
+    "fact": "Parallelograms have only 2-3 distinct distances and must be forbidden.",
+    "slug": "erdos-135",
+    "title": "Erdős Problem #135: Four Points, Five Distances"
+  },
+  {
+    "fact": "A mathematician is a machine for turning coffee into theorems.",
+    "slug": null,
+    "title": "Alfréd Rényi (popularized by Paul Erdős)"
+  },
+  {
+    "fact": "Working over a general normed group for the mechanism, and only specializing to inner product spaces for the √2 separation, keeps the argument modular and reusable.",
+    "slug": "lebesgue-measure-oq-03-wip-01",
+    "title": "The Infinite-Dimensional Impossibility Theorem: No Lebesgue Measure"
+  },
+  {
+    "fact": "Progressive lower bounds: 6 (Grekos 2003), 8 (Borwein) — the conjecture says ∞.",
+    "slug": "erdos-28-additive-bases",
+    "title": "Erdős Problem #28: Erdős-Turán Conjecture on Additive Bases"
+  },
+  {
+    "fact": "Split graphs (clique + independent set) are a key special case; the Chen-Erdős-Ordman bound of 3n²/16 is between the conjectured 1/6 and known 1/4.",
+    "slug": "erdos-81",
+    "title": "Erdős Problem #81: Clique Partitions of Chordal Graphs"
+  },
+  {
+    "fact": "Monotonicity is subtle: Adding vertices might create room for new C₄-avoiding configurations with high minimum degree.",
+    "slug": "erdos-85",
+    "title": "Erdős Problem #85: Minimum Degree for 4-Cycles"
+  },
+  {
+    "fact": "Transcendence Hierarchy: Erdős actually conjectured transcendence, not just irrationality.",
+    "slug": "erdos-68",
+    "title": "Erdős Problem #68: Irrationality of Factorial Sum"
+  },
+  {
+    "fact": "Structure Theorem: Most sum-free sets are subsets of [n/2, n] or odd numbers.",
+    "slug": "erdos-748",
+    "title": "Erdős Problem #748: The Cameron-Erdős Conjecture"
+  }
+]

--- a/src/pages/ProofPage.tsx
+++ b/src/pages/ProofPage.tsx
@@ -11,6 +11,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 import { UserMenu } from '@/components/auth'
+import { LoadingScreen } from '@/components/LoadingScreen'
 import { ProofBadge } from '@/components/ui/proof-badge'
 
 export function ProofPage() {
@@ -70,12 +71,7 @@ export function ProofPage() {
   }, [])
 
   if (loading) {
-    return (
-      <div className="h-screen flex flex-col items-center justify-center gap-4">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-annotation" />
-        <p className="text-muted-foreground">Loading proof...</p>
-      </div>
-    )
+    return <LoadingScreen className="h-screen min-h-0" message="Loading proof..." />
   }
 
   if (error) {


### PR DESCRIPTION
Part of #35117 (Track B) — the entertaining loading screen. Track A (bundle eviction) is deliberately not touched here.

## What

- **Build step** `scripts/gallery/build-loading-facts.ts` (wired into `pnpm build` as `gallery:loading-facts`, alongside the other data-generation steps): deterministically samples 91 short, self-contained, single-sentence facts from the gallery's existing `overview.keyInsights` arrays (`src/data/proofs/*/meta.json`), filtering out LaTeX/Lean/markdown-heavy and non-self-contained ones, at most one fact per proof. Adds 9 curated classic quotes (Erdős coffee/theorems, Hilbert "Wir müssen wissen", Gauss, Cantor, Hardy, …) with `slug: null`. Output: `src/data/loading-facts.json` — 100 entries of `{fact, slug, title}`, sha1-sorted so repeated builds are byte-identical.
- **Component** `src/components/LoadingScreen.tsx`: existing spinner styling + a rotating fact/quote (3.5 s interval, 400 ms opacity fade, `aria-live="polite"`). Facts with a slug link to `/proof/<slug>` ("from <title>"); quotes show an em-dash attribution. `prefers-reduced-motion` → one static fact, no rotation/fade. Random start index so repeat visitors see variety.
- **Wired in** at the two places users actually wait:
  - `App.tsx` route `<Suspense>` fallback (replaces the bare `LoadingSpinner`) — this is the HomePage gallery initial wait, since the giant eager listings chunk downloads during that fallback.
  - `ProofPage.tsx` `getProofAsync` loading state (enhanced, not replaced).

## Bundle impact

`loading-facts.json`: 22.4 KB pretty on disk → ~20 KB minified in the eager index chunk, **~8 KB gzip** — negligible vs the ~1.75 MB gzip this issue's Track A targets.

## Verification

- `pnpm build` passes (13.2 s vite build, exit 0); build-regenerated side-effect files were reverted before committing.
- `eslint` clean on all new/changed files. (The one reported error in `ProofPage.tsx` is the pre-existing `react-hooks/set-state-in-effect` in the untouched data-fetch effect; repo-wide lint has 67 pre-existing errors on main.)
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)