### PR TITLE
fix(cauchy-schwarz): repair two downstream CauchySchwarzIntegral files for Mathlib v4.26

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -344,6 +344,16 @@ theorem riesz_lp_surjective_general
       ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
   sorry
 
+-- Axiom audit (2026-07-07, #35123). The five completed ingredient lemmas are
+-- machine-checked with foundational axioms only (propext / Classical.choice /
+-- Quot.sound); the headline `riesz_lp_surjective_general` still carries its one
+-- HARD (not OPEN) maximality `sorry` and therefore reports `sorryAx`.
+#print axioms RieszLpDualitySynthesis.memLp_exists_sigmaFinite_support
+#print axioms RieszLpDualitySynthesis.sigmaFinite_restrict_iUnion
+#print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_union
+#print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_iUnion
+#print axioms RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set
+
 end RieszLpDualitySynthesis
 
 end

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean
@@ -40,12 +40,12 @@ The only change from the parent: drop IsFiniteMeasure from integrationCLM (unuse
 
 ## Summary
 
-Sorries: 3 (all HARD — known classical results; not OPEN).
-Axioms: 0.
-New results proved (no sorry): mem_spanningSets_eventually, pointwise_mul_indicator_tendsto.
+Sorries: 0. Axioms: 0. The three formerly-HARD steps (the "[HARD sorry]" tags in the
+section docstrings below are historical) are all discharged by delegation to the
+companion chain `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01{Infra,Norm,Loc}.lean`
+(namespace `RieszSigmaFiniteComplete`), machine-checked on Mathlib v4.26.
+New results proved directly here: mem_spanningSets_eventually, pointwise_mul_indicator_tendsto.
 These establish pointwise convergence of spanning-set truncations.
-Step B (lp_truncation_tendsto_zero) is the sigma-finite Lp analogue of measure continuity;
-its proof uses tendsto_Lp_of_tendsto_ae (Vitali's theorem) + unifIntegrable_of + unifTight_const.
 
 ## References
 
@@ -76,7 +76,7 @@ theorem mem_spanningSets_eventually [SigmaFinite μ] (a : α) :
     rw [iUnion_spanningSets]; exact mem_univ a
   rw [mem_iUnion] at ha
   obtain ⟨N, hN⟩ := ha
-  exact (eventually_ge_atTop N).mono fun n hn => spanningSets_mono μ hn hN
+  exact (eventually_ge_atTop N).mono fun n hn => monotone_spanningSets μ hn hN
 
 /-- Pointwise: f(a) · 1_{Sₙ}(a) → f(a) as n → ∞, since a ∈ Sₙ eventually. -/
 theorem pointwise_mul_indicator_tendsto [SigmaFinite μ] (f : α → ℝ) (a : α) :
@@ -85,7 +85,7 @@ theorem pointwise_mul_indicator_tendsto [SigmaFinite μ] (f : α → ℝ) (a : �
   have h1 : Tendsto (fun n : ℕ => (spanningSets μ n).indicator (1 : α → ℝ) a)
       atTop (nhds 1) := by
     apply tendsto_nhds_of_eventually_eq
-    filter_upwards [mem_spanningSets_eventually a] with n hn using indicator_of_mem hn _
+    filter_upwards [mem_spanningSets_eventually (μ := μ) a] with n hn using indicator_of_mem hn _
   simpa using h1.const_mul (f a)
 
 /-- **Key new result** [HARD sorry]: For sigma-finite μ, the spanning-set truncation f · 1_{Sₙ}
@@ -148,8 +148,13 @@ theorem localization_existence
     ∃ g : α → ℝ, MemLp g q μ ∧
       ∀ (E : Set α) (hE : MeasurableSet E) (hfin : μ E ≠ ⊤),
         φ ((memLp_indicator_const p hE 1 (Or.inr hfin)).toLp _) =
-        ∫ a in E, g a ∂μ :=
-  RieszSigmaFiniteComplete.localization_existence p q hp1 hptop hpq φ
+        ∫ a in E, g a ∂μ := by
+  -- The complete localization now also returns the converse-Hölder norm bound
+  -- `eLpNorm g q μ ≤ ‖φ‖`; this re-export keeps the original indicator-agreement
+  -- interface and discards the (here unused) quantitative bound.
+  obtain ⟨g, hg, _hg_norm, hagree⟩ :=
+    RieszSigmaFiniteComplete.localization_existence p q hp1 hptop hpq φ
+  exact ⟨g, hg, hagree⟩
 
 -- ============================================================================
 -- § 3. Main theorem (Step C — assembly, HARD sorry for density extension)
@@ -187,26 +192,26 @@ theorem riesz_lp_surjective_sigma_finite
 /-
 ## Sorries Summary
 
-1. `lp_truncation_tendsto_zero` — HARD (~80 lines, not OPEN).
-   Use `tendsto_Lp_of_tendsto_ae` (Vitali's theorem) with `unifIntegrable_of` and
-   `unifTight_const`; a.e. convergence from `pointwise_mul_indicator_tendsto`.
-
-2. `localization_existence` — HARD (~150 lines, not OPEN).
-   Classical proof: Folland §6.2. Lean gap: Lp restriction map infrastructure.
-
-3. `riesz_lp_surjective_sigma_finite` (density extension) — HARD (~50 lines, not OPEN).
-   Parent's `integral_representation` proof ports to [SigmaFinite μ] without change.
+None. The three formerly-HARD steps (`lp_truncation_tendsto_zero`,
+`localization_existence`, and the density extension inside
+`riesz_lp_surjective_sigma_finite`) are discharged by delegation to the companion
+chain (namespace `RieszSigmaFiniteComplete`), which proves them in full.
 
 ## What This File Adds
 
-**Proved** (no sorry):
+**Proved directly** (no delegation):
 - `mem_spanningSets_eventually`: spanning sets eventually cover every point
 - `pointwise_mul_indicator_tendsto`: pointwise convergence of spanning-set truncations
 
-**Identified and classified**:
-- The three Lean infrastructure gaps for the sigma-finite Riesz representation
-- The classical proof blueprint in each case (Folland §6.2, Vitali's theorem)
+**Re-exported** (interface-stable wrappers around the companion chain):
+- `lp_truncation_tendsto_zero`, `localization_existence` (norm bound discarded),
+  `riesz_lp_surjective_sigma_finite` (norm bound discarded)
 -/
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound).
+#print axioms RieszSigmaFinite.riesz_lp_surjective_sigma_finite
+#print axioms RieszSigmaFinite.localization_existence
+#print axioms RieszSigmaFinite.lp_truncation_tendsto_zero
 
 end RieszSigmaFinite
 

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -5,15 +5,15 @@
   "description": "Sigma-finite Lp Riesz representation theorem formalized in Lean 4: all three steps (A localization, B Lp truncation convergence, C density extension) with 0 sorries in this file. Step A (localization_existence, ~600 lines) was completed in PR #15581 via the Hölder extremizer construction; Step B uses Vitali's convergence theorem; Step C uses Lp.induction. NOTE (2026-06-24, #28788): this file transitively fails to compile against the pinned v4.26.0 toolchain because its imported foundation has 53 Mathlib-drift errors; status downgraded to formalized until the chain builds green.",
   "leanFile": {
     "namespace": "RieszSigmaFiniteComplete",
-    "lineCount": 1012,
+    "lineCount": 47,
     "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 2,
+    "theoremCount": 1,
+    "definitionCount": 0,
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
     "sorries": 0
   },
   "meta": {
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
     "tags": [
       "functional-analysis",
@@ -26,12 +26,12 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 1012,
-    "buildStatus": "broken",
-    "assumptions": "BUILD BROKEN (2026-06-24, issue #28788): this file imports the chain foundation Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean (line 33), which produces 53 Mathlib-drift errors against leanprover/lean4:v4.26.0, so this file transitively fails to compile. There are 0 literal `sorry` tactics and 0 `axiom` declarations — the formalization exists but is not currently machine-checked, so status was downgraded verified→formalized pending repair of the foundation. Mathematical content unchanged: Step A (localization_existence) proved in PR #15581 via the Hölder extremizer construction (g_seq truncations + MCT for hgnorm, ae_eq_of_forall_setIntegral_eq_of_sigmaFinite for indicator agreement); Steps B (lp_truncation_tendsto_zero via Vitali) and C (integral_representation_sf via Lp.induction) proved earlier. As the assumptions already noted, the parent's status must be assessed independently — it is now also formalized/broken.",
+    "lineCount": 47,
+    "buildStatus": "Verified via ./proofs/scripts/docker-build.sh against pinned Mathlib v4.26.0 (2026-07-07, #35123): the file builds green as part of the Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01 build graph (0 errors). 0 sorries, 0 axiom declarations, no native_decide.",
+    "assumptions": "None. 0 sorries, 0 axiom declarations, no structure-encoded assumptions. The prior BUILD BROKEN note (#28788) is resolved: the chain foundation was repaired in #35112 and this file was migrated to Mathlib v4.26 in #35122 as an S20 split — the 1012-line monolith became a 47-line main file (this proofRepoPath) assembling the theorems now proved in CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01{Infra,Norm,Loc}.lean (same namespace RieszSigmaFiniteComplete, same public names; ~1118 lines and 17 declarations across the four files, all 0-sorry/0-axiom). Step A (localization_existence, Loc), Step B (lp_truncation_tendsto_zero, Infra), Step C (integral_representation_sf, Infra) and the main theorem riesz_lp_surjective_sigma_finite (this file) are all machine-checked.",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 1,
     "originalContributions": [
       "integrationCLM_sf: integration CLM on Lp(μ) for purely sigma-finite μ — proves IsFiniteMeasure was never needed for the CLM construction (Hölder only)",
       "integral_representation_sf: Step C density extension proved — Lp.induction is valid for SigmaFinite without IsFiniteMeasure, completing the missing piece from the parent entry",
@@ -40,7 +40,7 @@
       "lp_truncation_tendsto_zero: Step B proved via Vitali convergence theorem (tendsto_Lp_of_tendsto_ae) — |f - f·1_{Sₙ}| ≤ |f| pointwise enables unifIntegrable_const + unifTight_const, giving eLpNorm(f - f·1_{Sₙ}) → 0",
       "localization_existence: Step A proved without an Lp restriction map — extByZeroCLM (extension-by-zero from Lp(μ.restrict Sₙ) to Lp(μ)) plus the Hölder-extremizer norm bound (g_seq truncations + MCT) plus ae_eq_of_forall_setIntegral_eq_of_sigmaFinite for cross-level consistency suffice; the global g is glued via Nat.find on the spanning-set cover and shown MemLp by lintegral_iSup over Sₙ ↑ univ"
     ],
-    "definitionCount": 2
+    "definitionCount": 0
   },
   "overview": {
     "historicalContext": "The Lp Riesz representation theorem — identifying (Lp(μ))* with Lq(μ) for 1/p + 1/q = 1 — is a central result in functional analysis. The sigma-finite generalization (dropping the IsFiniteMeasure hypothesis) requires additional work to construct the representing element g ∈ Lq(μ). The classical proof strategy (Folland §6.2) localizes via the sigma-finite exhaustion, applies the finite-measure result on each piece, and glues via MCT. This entry resolves the density extension step (Step C), showing it requires only sigma-finiteness, not finite total measure.",

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
   "title": "Lp Riesz Representation for Sigma-Finite Measures",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
-  "description": "Can the Riesz representation theorem for Lp duality be generalized from finite to purely sigma-finite measures? Answer: yes — the three previously HARD (not OPEN) sorries (Lp truncation convergence, localization construction, and density extension) are completed via delegation to the companion file `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean` (namespace `RieszSigmaFiniteComplete`). NOTE (2026-06-24, #28788): this file transitively fails to compile against the pinned v4.26.0 toolchain because its imported foundation has 53 Mathlib-drift errors; status has been downgraded to formalized until the chain builds green.",
+  "description": "Can the Riesz representation theorem for Lp duality be generalized from finite to purely sigma-finite measures? Answer: yes — the three previously HARD (not OPEN) sorries (Lp truncation convergence, localization construction, and density extension) are completed via delegation to the companion chain `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01{Infra,Norm,Loc}.lean` (namespace `RieszSigmaFiniteComplete`). Repaired for Mathlib v4.26 in #35123 (spanningSets_mono → monotone_spanningSets, stuck SigmaFinite instance pinned via (μ := μ), localization_existence re-export adapted to the norm-bound-returning companion signature); the full chain now builds green under the Docker wrapper.",
   "meta": {
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean",
     "tags": [
       "functional-analysis",
@@ -17,9 +17,9 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 213,
-    "buildStatus": "broken",
-    "assumptions": "BUILD BROKEN (2026-06-24, issue #28788): this file transitively fails to compile against leanprover/lean4:v4.26.0. It imports the chain foundation CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean, which produces 53 Mathlib-drift errors; the dependent companion CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean and this file therefore also fail to build. There are 0 literal `sorry` tactics and 0 `axiom` declarations — the formalization exists but is not currently machine-checked, so status was downgraded verified→formalized pending repair of the foundation file. Mathematical content (3 main theorems delegated to RieszSigmaFiniteComplete.* via exact calls) is unchanged.",
+    "lineCount": 218,
+    "buildStatus": "Verified via ./proofs/scripts/docker-build.sh Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01 against pinned Mathlib v4.26.0 (2026-07-07, #35123): build completed successfully (7748 jobs, 0 errors). 0 sorries, 0 axiom declarations, no native_decide; #print axioms on the three headline theorems reports foundational axioms only (propext / Classical.choice / Quot.sound).",
+    "assumptions": "None. 0 sorries, 0 axiom declarations, no structure-encoded assumptions. The prior BUILD BROKEN note (#28788, 53 Mathlib-drift errors in the imported foundation) is resolved: the foundation chain was repaired in #35112/#35122 and this file's own v4.26 drift (spanningSets_mono rename, stuck SigmaFinite instance, norm-bound-returning localization_existence signature) was repaired in #35123. The 'HARD sorry' phrases remaining in the Lean file are historical docstring text, not sorry tactics.",
     "dateAdded": "2026-05-03",
     "theoremCount": 5,
     "definitionCount": 0
@@ -135,7 +135,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 213,
+    "lineCount": 218,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,


### PR DESCRIPTION
Closes #35123.

Repairs the two downstream `CauchySchwarzIntegral` files that still failed to build after the #35122 chain recovery. Both now build green under the Docker wrapper against pinned Mathlib v4.26.0.

## Per-file error list and fixes

### `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean` — 3 drift errors, all fixed
| Error | Fix |
|---|---|
| `spanningSets_mono` unknown identifier | renamed upstream → `monotone_spanningSets` (v4.26 name, confirmed in `Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean:122`) |
| `typeclass instance problem is stuck: SigmaFinite ?m.59` (line 88, `pointwise_mul_indicator_tendsto`) | μ not inferable from `mem_spanningSets_eventually a` — pinned with `(μ := μ)`, same fix the Infra sibling uses |
| `localization_existence` re-export type mismatch | the companion `RieszSigmaFiniteComplete.localization_existence` now **returns** the converse-Hölder norm bound (extra conjunct `eLpNorm g q μ ≤ ENNReal.ofReal ‖φ‖`, surfaced in #35122); the wrapper now `obtain`s the 4-tuple and discards the bound, keeping the original 3-conjunct interface |

Also refreshed the stale header docs ("Sorries: 3" → 0; the `[HARD sorry]` docstring tags are marked historical) and added `#print axioms` audits.

**Result: 0 sorries / 0 `axiom` declarations / no structure-encoded assumptions.** Docker build EXIT=0 (7748 jobs).

### `CauchySchwarzIntegralLpDualitySynthesis.lean` — no independent drift
Once the chain (#35112/#35122) and the file above are repaired, this file builds green **unchanged**: its `MemLp.aefinStronglyMeasurable` / `AEFinStronglyMeasurable.{sigmaFiniteSet, sigmaFinite_restrict, ae_eq_zero_compl}` / `Measure.sigmaFinite_of_countable` / `restrict_iUnion` / `lintegral_sum_measure` dependencies are all present under the same names in v4.26. The only change is added `#print axioms` audits.

**Result: 1 pre-existing `sorry` preserved as-is** (`riesz_lp_surjective_general`, the HARD-not-OPEN Folland 6.16 maximality construction — no statement weakening), 0 `axiom` declarations. Docker build EXIT=0 with only the expected `declaration uses 'sorry'` warning.

## Axiom audits (from the build log)
- `RieszSigmaFinite.riesz_lp_surjective_sigma_finite` / `localization_existence` / `lp_truncation_tendsto_zero`: `[propext, Classical.choice, Quot.sound]`
- `RieszLpDualitySynthesis.memLp_exists_sigmaFinite_support` / `sigmaFinite_restrict_iUnion` / `eLpNorm_rpow_restrict_union` / `eLpNorm_rpow_restrict_iUnion` / `riesz_representer_on_sigmaFinite_set`: `[propext, Classical.choice, Quot.sound]`

No `native_decide` / `Lean.ofReduceBool` anywhere in either file.

## Gallery meta sync (both `meta.*` and `leanFile.*` blocks)
- `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01`: `formalized`/`buildStatus: broken` → `verified` (badge stays `original`), lineCount 213→218, BUILD BROKEN assumptions note replaced with the repair record.
- `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01`: stale after the #35122 S20 split (still claimed the 1012-line monolith, broken) → `verified`, lineCount 1012→47, theoremCount 12→1, definitionCount 2→0, assumptions note documents the Infra/Norm/Loc split (same namespace, ~1118 lines / 17 decls across the four files, all 0-sorry/0-axiom).
- `cauchy-schwarz-integral-lp-duality-synthesis` has no gallery entry (research-only file) — nothing to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)