### PR TITLE
research(kronecker-oq03-oq02): repair #33901 for v4.26 — odd-positive multiplicativity + QR, machine-verified [0 sorries, 0 axioms]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -57,23 +57,23 @@ def kronecker0 (a : ℤ) : ℤ :=
 
 /-- (1/2) = 1 -/
 theorem kronecker2_one : kronecker2 1 = 1 := by
-  simp [kronecker2]; decide
+  decide
 
 /-- (-1/2) = 1 -/
 theorem kronecker2_neg_one : kronecker2 (-1) = 1 := by
-  simp [kronecker2]; decide
+  decide
 
 /-- (3/2) = -1 -/
 theorem kronecker2_three : kronecker2 3 = -1 := by
-  simp [kronecker2]; decide
+  decide
 
 /-- (5/2) = -1 -/
 theorem kronecker2_five : kronecker2 5 = -1 := by
-  simp [kronecker2]; decide
+  decide
 
 /-- (7/2) = 1 -/
 theorem kronecker2_seven : kronecker2 7 = 1 := by
-  simp [kronecker2]; decide
+  decide
 
 /-- (0/2) = 0 -/
 theorem kronecker2_zero : kronecker2 0 = 0 := by
@@ -81,11 +81,13 @@ theorem kronecker2_zero : kronecker2 0 = 0 := by
 
 /-- (a/(-1)) = 1 for nonneg a -/
 theorem kroneckerNeg1_nonneg (a : ℤ) (ha : 0 ≤ a) : kroneckerNeg1 a = 1 := by
-  simp [kroneckerNeg1]; omega
+  simp only [kroneckerNeg1]
+  rw [if_neg (not_lt.mpr ha)]
 
 /-- (a/(-1)) = -1 for neg a -/
 theorem kroneckerNeg1_neg (a : ℤ) (ha : a < 0) : kroneckerNeg1 a = -1 := by
-  simp [kroneckerNeg1, ha]
+  simp only [kroneckerNeg1]
+  rw [if_pos ha]
 
 /-- (1/0) = 1 -/
 theorem kronecker0_one : kronecker0 1 = 1 := by simp [kronecker0]
@@ -94,7 +96,7 @@ theorem kronecker0_one : kronecker0 1 = 1 := by simp [kronecker0]
 theorem kronecker0_neg_one : kronecker0 (-1) = 1 := by simp [kronecker0]
 
 /-- (2/0) = 0 -/
-theorem kronecker0_two : kronecker0 2 = 0 := by simp [kronecker0]; decide
+theorem kronecker0_two : kronecker0 2 = 0 := by decide
 
 -- ============================================================
 -- Section 3: The Full Kronecker Symbol
@@ -120,26 +122,37 @@ noncomputable def kronecker (a n : ℤ) : ℤ :=
 /-- For odd positive n, Kronecker agrees with Jacobi -/
 theorem kronecker_eq_jacobi (a : ℤ) (n : ℕ) (hn : 0 < n) (hodd : n % 2 = 1) :
     kronecker a n = jacobiSym a n := by
-  simp only [kronecker, show (n : ℤ) ≠ 0 from by omega,
-    show (n : ℤ) ≠ -1 from by omega, show ¬((n : ℤ) < 0) from by omega]
-  split_ifs with h1 h2
-  · omega
-  · omega
-  · simp [Int.natAbs_ofNat]; ring
+  by_cases h1 : n = 1
+  · subst h1
+    simp [kronecker, jacobiSym.one_right]
+  · have h0 : (n : ℤ) ≠ 0 := by omega
+    have hm1 : (n : ℤ) ≠ -1 := by omega
+    have h1' : (n : ℤ) ≠ 1 := by omega
+    have hneg : ¬((n : ℤ) < 0) := by omega
+    simp only [kronecker, if_neg h0, if_neg hm1, if_neg h1', if_neg hneg,
+      Int.natAbs_natCast, one_mul]
 
 -- ============================================================
 -- Section 5: The Kronecker Symbol Values at Known Discriminants
 -- ============================================================
 
-/-- The Kronecker symbol encodes quadratic character of discriminants.
-    For the fundamental discriminant d of a quadratic number field ℚ(√d):
-    (d/·) is the associated primitive Dirichlet character. -/
+/- The Kronecker symbol encodes quadratic character of discriminants.
+   For the fundamental discriminant d of a quadratic number field ℚ(√d):
+   (d/·) is the associated primitive Dirichlet character. -/
 
-/-- (-4/n) for n = 1,2,3,4: the character of ℤ[i] -/
+/-- (-4/n) at n = 1, 3: the character of ℤ[i].
+    χ₋₄(n) = (-1)^((n-1)/2) for odd n, so χ₋₄(1) = 1 and χ₋₄(3) = -1.
+    (The original statement claimed (-4/3) = 1, which is false:
+    (-4/3) = J(-4|3) = J(2|3) = -1 since 2 is not a square mod 3.) -/
 theorem kronecker_neg4_values :
     kronecker (-4) 1 = 1 ∧
-    kronecker (-4) 3 = 1 := by
-  constructor <;> simp [kronecker, kroneckerNeg1, jacobiSym]
+    kronecker (-4) 3 = -1 := by
+  constructor
+  · simp [kronecker]
+  · have h := kronecker_eq_jacobi (-4) 3 (by norm_num) (by norm_num)
+    norm_num at h
+    -- `norm_num` evaluates J(-4 | 3) = -1 via the Jacobi-symbol extension
+    exact h
 
 -- ============================================================
 -- Section 6: Multiplicativity
@@ -150,44 +163,42 @@ theorem kronecker_neg4_values :
 private theorem kroneckerNeg1_mul (a b : ℤ) (ha : a ≠ 0) (hb : b ≠ 0) :
     kroneckerNeg1 (a * b) = kroneckerNeg1 a * kroneckerNeg1 b := by
   simp only [kroneckerNeg1]
-  by_cases ha0 : a < 0 <;> by_cases hb0 : b < 0 <;> simp_all
+  by_cases ha0 : a < 0 <;> by_cases hb0 : b < 0
   · -- a < 0, b < 0 → a*b > 0
-    constructor
-    · intro h; exact absurd (Int.mul_pos_of_neg_of_neg ha0 hb0) (not_lt.mpr (le_of_lt h))
-    · ring
-  · -- a < 0, b ≥ 0 → b > 0 → a*b < 0
-    have : 0 < b := lt_of_le_of_ne (not_lt.mp hb0) (Ne.symm hb)
-    exact ⟨Int.mul_neg_of_neg_of_pos ha0 this, by ring⟩
-  · -- a ≥ 0, b < 0 → a > 0 → a*b < 0
-    have : 0 < a := lt_of_le_of_ne (not_lt.mp ha0) (Ne.symm ha)
-    exact ⟨Int.mul_neg_of_pos_of_neg this hb0, by ring⟩
-  · -- a ≥ 0, b ≥ 0 → a*b ≥ 0
+    norm_num [if_pos ha0, if_pos hb0,
+      if_neg (not_lt.mpr (mul_pos_of_neg_of_neg ha0 hb0).le)]
+  · -- a < 0, b > 0 → a*b < 0
+    have hb' : 0 < b := lt_of_le_of_ne (not_lt.mp hb0) (Ne.symm hb)
+    norm_num [if_pos ha0, if_neg hb0, if_pos (mul_neg_of_neg_of_pos ha0 hb')]
+  · -- a > 0, b < 0 → a*b < 0
+    have ha' : 0 < a := lt_of_le_of_ne (not_lt.mp ha0) (Ne.symm ha)
+    norm_num [if_neg ha0, if_pos hb0, if_pos (mul_neg_of_pos_of_neg ha' hb0)]
+  · -- a > 0, b > 0 → a*b > 0
     have ha' : 0 < a := lt_of_le_of_ne (not_lt.mp ha0) (Ne.symm ha)
     have hb' : 0 < b := lt_of_le_of_ne (not_lt.mp hb0) (Ne.symm hb)
-    exact ⟨fun h => absurd (Int.mul_pos ha' hb') (not_lt.mpr (le_of_lt h)), by ring⟩
+    norm_num [if_neg ha0, if_neg hb0, if_neg (not_lt.mpr (mul_pos ha' hb').le)]
 
 /-- kronecker0 is multiplicative for nonzero arguments.
     Uses: |a·b| = 1 iff |a| = 1 ∧ |b| = 1 (units in ℤ). -/
 private theorem kronecker0_mul (a b : ℤ) (hab : a * b ≠ 0) :
     kronecker0 (a * b) = kronecker0 a * kronecker0 b := by
-  simp only [kronecker0]
-  by_cases hab1 : a * b = 1 ∨ a * b = -1
-  · -- |a*b| = 1 implies |a| = 1 and |b| = 1
-    have ha1 : a = 1 ∨ a = -1 := by
-      rcases hab1 with h | h
-      · exact Int.isUnit_eq_one_or.mp (isUnit_of_mul_eq_one _ _ h)
-      · have := Int.isUnit_eq_one_or.mp (isUnit_of_mul_eq_one _ _ (neg_eq_iff_eq_neg.mpr h ▸
-          show a * b * -1 = 1 from by linarith))
-        rcases this with h1 | h1 <;> [right; left] <;> linarith
-    have hb1 : b = 1 ∨ b = -1 := by
-      rcases ha1 with rfl | rfl <;> simp_all
-    simp [ha1, hb1]
-  · -- |a*b| ≠ 1
-    simp [hab1]
-    by_cases ha1 : a = 1 ∨ a = -1
-    · -- |a| = 1 but |a*b| ≠ 1, so |b| ≠ 1
-      rcases ha1 with rfl | rfl <;> simp_all
-    · simp [ha1]
+  by_cases ha : a = 1 ∨ a = -1
+  · by_cases hb : b = 1 ∨ b = -1
+    · -- both a and b are units ⇒ a*b = ±1
+      rcases ha with rfl | rfl <;> rcases hb with rfl | rfl <;> decide
+    · -- a is a unit, b is not ⇒ a*b is not a unit
+      have hnu : ¬(a * b = 1 ∨ a * b = -1) := by
+        rcases ha with rfl | rfl
+        · simpa using hb
+        · push_neg at hb ⊢; omega
+      simp only [kronecker0, if_neg hnu, if_neg hb, mul_zero]
+  · -- a is not a unit ⇒ a*b is not a unit
+    have hnu : ¬(a * b = 1 ∨ a * b = -1) := by
+      rintro (h | h)
+      · exact ha (Int.eq_one_or_neg_one_of_mul_eq_one h)
+      · exact ha (Int.eq_one_or_neg_one_of_mul_eq_one
+          (show a * (-b) = 1 by simp [mul_neg, h]))
+    simp only [kronecker0, if_neg hnu, if_neg ha, zero_mul]
 
 /-- The Kronecker symbol is completely multiplicative in the first argument:
     (ab/n) = (a/n)(b/n), provided a*b ≠ 0.
@@ -199,7 +210,7 @@ theorem kronecker_mul_left (a b n : ℤ) (hab : a * b ≠ 0) :
   have ha : a ≠ 0 := left_ne_zero_of_mul hab
   have hb : b ≠ 0 := right_ne_zero_of_mul hab
   simp only [kronecker]
-  split_ifs with h0 hm1 h1 h0' hm1' h1' h0'' hm1'' h1''
+  split_ifs with h0 hm1 h1 h0'
   -- Many cases from nested if-then-else; most are contradictions
   all_goals try (simp_all; done)
   all_goals try (rw [kronecker0_mul a b hab]; done)
@@ -208,16 +219,78 @@ theorem kronecker_mul_left (a b n : ℤ) (hab : a * b ≠ 0) :
   · rw [jacobiSym.mul_left, kroneckerNeg1_mul a b ha hb]; ring
   · rw [jacobiSym.mul_left]; ring
 
-/-- The Kronecker symbol is completely multiplicative in the second argument:
-    (a/mn) = (a/m)(a/n), provided m * n ≠ 0 or |a| ≤ 1.
+/-- **Multiplicativity in the second argument, odd positive case.**
+    For odd positive moduli m, n, the Kronecker symbol satisfies
+    (a/mn) = (a/m)(a/n).
 
-    Same edge case as kronecker_mul_left: kroneckerNeg1(0) = 1 causes
-    issues when one of m, n is -1 and the other introduces a 0.
-    Fix: require m * n ≠ 0. -/
-/-- **Quadratic reciprocity for the Kronecker symbol**:
-    For fundamental discriminants d₁, d₂ with gcd(d₁,d₂) = 1:
-    (d₁/|d₂|)(d₂/|d₁|) = (-1)^{((d₁-1)/2)·((d₂-1)/2)}
+    Here both moduli lie in the odd positive range where the Kronecker
+    symbol coincides with the Jacobi symbol, so the result reduces to
+    `jacobiSym.mul_right'`. The fully general statement (even and negative
+    moduli) requires tracking the sign character and the mod-8 factor for
+    powers of 2; that case is left open — see the module note below. -/
+theorem kronecker_mul_right_odd (a : ℤ) (m n : ℕ)
+    (hm : 0 < m) (hn : 0 < n) (hmo : m % 2 = 1) (hno : n % 2 = 1) :
+    kronecker a ((m : ℤ) * n) = kronecker a m * kronecker a n := by
+  have hmn : 0 < m * n := Nat.mul_pos hm hn
+  have hmno : (m * n) % 2 = 1 :=
+    Nat.odd_iff.mp ((Nat.odd_iff.mpr hmo).mul (Nat.odd_iff.mpr hno))
+  have ecast : ((m : ℤ) * (n : ℤ)) = ((m * n : ℕ) : ℤ) := by push_cast; ring
+  rw [ecast, kronecker_eq_jacobi a (m * n) hmn hmno,
+    kronecker_eq_jacobi a m hm hmo, kronecker_eq_jacobi a n hn hno,
+    jacobiSym.mul_right' a (by omega) (by omega)]
 
-    This generalizes Gauss's QR to arbitrary discriminants and
-    is the form used in class field theory. -/
+/-- **Quadratic reciprocity for the Kronecker symbol, odd positive case.**
+    For odd positive m, n:
+    (m/n) = (-1)^{((m-1)/2)·((n-1)/2)} · (n/m).
+
+    For odd positive moduli the Kronecker symbol agrees with the Jacobi
+    symbol, so this is exactly `jacobiSym.quadratic_reciprocity` transported
+    across `kronecker_eq_jacobi`. No coprimality hypothesis is needed: when
+    gcd(m,n) > 1 both sides vanish.
+
+    The general reciprocity law for arbitrary (even/negative) discriminants
+    d₁, d₂ — the form used in class field theory, equivalent to Artin
+    reciprocity for quadratic extensions of ℚ — additionally requires the
+    supplementary laws (2/n) and (-1/n) and is left open here. -/
+theorem kronecker_quadratic_reciprocity (m n : ℕ)
+    (hm : 0 < m) (hn : 0 < n) (hmo : m % 2 = 1) (hno : n % 2 = 1) :
+    kronecker (m : ℤ) n = (-1) ^ (m / 2 * (n / 2)) * kronecker (n : ℤ) m := by
+  rw [kronecker_eq_jacobi (m : ℤ) n hn hno, kronecker_eq_jacobi (n : ℤ) m hm hmo]
+  exact jacobiSym.quadratic_reciprocity (Nat.odd_iff.mpr hmo) (Nat.odd_iff.mpr hno)
+
+/-- **Quadratic reciprocity, congruence form.**
+    If additionally m ≡ 1 (mod 4), the sign factor is trivial and reciprocity
+    becomes a plain equality (m/n) = (n/m). -/
+theorem kronecker_reciprocity_one_mod_four (m n : ℕ)
+    (hm : m % 4 = 1) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker (m : ℤ) n = kronecker (n : ℤ) m := by
+  have hmo : m % 2 = 1 := by omega
+  have hmpos : 0 < m := by omega
+  rw [kronecker_eq_jacobi (m : ℤ) n hn hno, kronecker_eq_jacobi (n : ℤ) m hmpos hmo]
+  exact jacobiSym.quadratic_reciprocity_one_mod_four hm (Nat.odd_iff.mpr hno)
+
+/-!
+## Module note: what remains open
+
+The full Kronecker symbol is completely multiplicative in *both* arguments
+over all of ℤ×ℤ, and satisfies a generalized quadratic reciprocity law for
+arbitrary fundamental discriminants. The theorems above establish these
+properties on the odd positive range, where the symbol coincides with the
+Jacobi symbol and the results follow from Mathlib's Jacobi API.
+
+The remaining even/negative cases require the supplementary laws for the
+special moduli — `kronecker2` (the mod-8 pattern for n = 2) and
+`kroneckerNeg1` (the sign character for n = -1) — together with a Gauss-sum
+or induction argument to combine them with the odd part. These are not yet
+in Mathlib and are left as open work.
+-/
+
+-- Axiom audits: headline theorems should use only the standard foundational
+-- axioms (propext, Classical.choice, Quot.sound) — no sorryAx, no ofReduceBool.
+#print axioms kronecker_eq_jacobi
+#print axioms kronecker_mul_left
+#print axioms kronecker_mul_right_odd
+#print axioms kronecker_quadratic_reciprocity
+#print axioms kronecker_reciprocity_one_mod_four
+
 end KroneckerSymbol

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 19,
     "defCount": 4,
-    "lineCount": 223,
+    "lineCount": 296,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 223,
+    "lineCount": 296,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 19,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
   "title": "Kronecker Symbol WIP Completion",
-  "phase": "NEW",
+  "phase": "PROGRESS",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -11,29 +11,53 @@
     "whyMatters": []
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "kronecker_mul_right_odd: (a/mn)=(a/m)(a/n) for odd positive m,n (via jacobiSym.mul_right')",
+      "kronecker_quadratic_reciprocity: (m/n)=(-1)^((m/2)(n/2))*(n/m) for odd positive m,n (via jacobiSym.quadratic_reciprocity)",
+      "kronecker_reciprocity_one_mod_four: (m/n)=(n/m) when m%4=1 (via jacobiSym.quadratic_reciprocity_one_mod_four)"
+    ],
+    "open": [
+      "Multiplicativity in the second argument for general (even/negative) moduli",
+      "Generalized quadratic reciprocity for arbitrary fundamental discriminants (needs supplementary laws (2/n),(-1/n) + Gauss sums)"
+    ],
+    "goal": "Fill the two Section-6 stubs (mul in n, QR) with proven theorems; keep hard general cases honestly open."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-05T06:55:50.081Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "PROGRESS",
+    "since": "2026-07-07T00:00:00Z",
+    "iteration": 3,
+    "focus": "Repaired v4.26 drift across the whole file (dead trailing tactics, omega/split_ifs breakage in kronecker_eq_jacobi, Int.natAbs_ofNat rename, dangling Section-5 docstring, simp_all-shaped kroneckerNeg1_mul) and fixed a false concrete value: kronecker_neg4_values claimed (-4/3)=1 but (-4/3)=J(2|3)=-1. Machine-verified via docker-build.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Optional: general mul-in-n via 2-adic valuation + odd part factorization.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Section 6 had two dangling docstrings (parse error) for mul-in-n and generalized QR. Replaced with three proven theorems on the odd-positive-modulus range where kronecker = jacobiSym, each a direct transport of a Mathlib Jacobi lemma across the file's kronecker_eq_jacobi. Separately fixed a pre-existing build break in kronecker0_mul. Originally PR #33901 (draft, build-blocked); repaired for Mathlib v4.26 and machine-verified in the superseding PR (2026-07-07), which also corrected the false (-4/3)=1 claim in kronecker_neg4_values to -1.",
+    "builtItems": [
+      "kronecker_mul_right_odd",
+      "kronecker_quadratic_reciprocity",
+      "kronecker_reciprocity_one_mod_four",
+      "kronecker0_mul (repaired)"
+    ],
+    "insights": [
+      "For odd positive moduli the Kronecker symbol IS the Jacobi symbol (kronecker_eq_jacobi), so mul-in-n and QR come for free from jacobiSym.mul_right' and jacobiSym.quadratic_reciprocity.",
+      "No coprimality hypothesis is needed for the odd-positive QR: when gcd(m,n)>1 both sides vanish.",
+      "The general even/negative case genuinely needs the supplementary laws (2/n) and (-1/n) plus a Gauss-sum/induction combination not yet in Mathlib.",
+      "kronecker0_mul had bit-rotted: Int.isUnit_eq_one_or is now IsUnit u -> (u=1 v u=-1), not an iff; use Int.isUnit_iff instead.",
+      "kronecker_neg4_values originally claimed (-4/3)=1, which is FALSE: (-4/3)=J(-4|3)=J(2|3)=-1 (2 is a non-residue mod 3); the character of Z[i] has chi(3)=-1. Corrected to -1 and proved via kronecker_eq_jacobi + norm_num's Jacobi-symbol extension.",
+      "v4.26 drift: simp now closes the concrete kronecker2/kronecker0 value goals, leaving trailing decide/omega calls dead ('No goals to be solved'); Int.natAbs_ofNat renamed to Int.natAbs_natCast; simp_all case shapes changed under kroneckerNeg1_mul - replaced with explicit if_pos/if_neg + norm_num per sign case."
+    ],
+    "mathlibGaps": [
+      "No Kronecker symbol in Mathlib (only jacobiSym for odd positive denominators).",
+      "No supplementary-law lemmas connecting (2/n)/(-1/n) to the odd part for a generalized reciprocity."
+    ],
+    "nextSteps": [
+      "Attempt general mul-in-n by factoring n into 2-adic valuation + odd part and combining kronecker2/kroneckerNeg1 with the odd part."
+    ]
   },
   "tags": [
     "seeker-selected",
@@ -53,7 +77,7 @@
     "mathlib": []
   },
   "started": "2026-04-05T08:58:43.841Z",
-  "lastUpdate": "2026-04-05T08:58:43.841Z",
+  "lastUpdate": "2026-07-07T00:00:00Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Supersedes draft PR #33901 (`research/kronecker-oq03-oq02-wip`), which completed the Kronecker-symbol WIP (`Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean`) but was never machine-verified due to a broken Docker host. This PR ports that work onto current main and repairs every item in the **2026-07-07 v4.26 error profile** posted on #33901. Main had not touched the file since the merge-base, so the PR's version was taken verbatim and then fixed.

### Fixes, per error
| Error (v4.26 profile) | Fix |
|---|---|
| 6× `No goals to be solved` (lines 60–97) | `simp` now closes the concrete value goals, leaving trailing `decide`s dead. Replaced `simp [kronecker2]; decide` with plain `decide` (`kronecker2_one/neg_one/three/five/seven`, `kronecker0_two`); `kroneckerNeg1_nonneg/neg` rewritten with explicit `if_neg`/`if_pos`. |
| 2× `omega` failure (126–127) + `Unknown constant 'Int.natAbs_ofNat'` (128) | `kronecker_eq_jacobi` rewritten: explicit `n = 1` / `n > 1` split, `Int.natAbs_natCast` (the v4.26 name), `jacobiSym.one_right`. |
| Parser error `unexpected token '/--'` (136) | Section-5 dangling docstring (no attached declaration) demoted to a plain `/- -/` comment. |
| Unsolved goals at 141 (`kronecker_neg4_values`) | **The original statement was false**: it claimed `(-4/3) = 1`, but `(-4/3) = J(-4|3) = J(2|3) = -1` (2 is a non-residue mod 3; the character of ℤ[i] has χ(3) = −1). Corrected to `-1` and proved via `kronecker_eq_jacobi` + `norm_num`'s Jacobi-symbol extension. |
| Constructor mismatches 150–160 (`kroneckerNeg1_mul`) | `simp_all` case shapes changed under v4.26; rewritten with explicit `if_pos`/`if_neg` + `norm_num` per sign quadrant. |
| `isUnit_of_mul_eq_one` signature change (found during build) | `kronecker0_mul` switched to `Int.eq_one_or_neg_one_of_mul_eq_one`. |
| Lint | `split_ifs` name list in `kronecker_mul_left` trimmed to the 4 names actually bound. |

### Verification (honest accounting)
- `./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02` → **Build succeeded** on v4.26 (one intermittent exit-135 on first attempt, clean on retry).
- **0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions, no `native_decide`** (only plain `decide` on concrete ±1/mod-8 arithmetic).
- `#print axioms` audits (in-file, lines 289–294) on all five headline theorems — `kronecker_eq_jacobi`, `kronecker_mul_left`, `kronecker_mul_right_odd`, `kronecker_quadratic_reciprocity`, `kronecker_reciprocity_one_mod_four`:
  `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
- Gallery `meta.json` stat blocks (both `meta.*` and `leanFile.*`) synced: 223→296 lines, 16→19 theorems; **status stays `axiomatized`/badge `wip`** — the general even/negative-modulus multiplicativity and fully general reciprocity remain honestly open (module note in the file).
- Research-state JSON ported from #33901 with the stale Docker blocker cleared and the false-value finding recorded.

#33901 is left open per routing instructions; it can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)