### PR TITLE
Enrich Wallis/Stirling Asymptotics of the Diagonal Beta Value

### DIFF
--- a/src/data/proofs/beta-central-binomial-asymptotic/annotations.json
+++ b/src/data/proofs/beta-central-binomial-asymptotic/annotations.json
@@ -1,1 +1,138 @@
-[]
+[
+  {
+    "id": "ann-bcba-docstring",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": {
+      "startLine": 4,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "From closed form to asymptotic decay",
+    "content": "The parent `BetaCentralBinomial` establishes the diagonal Euler Beta value as a central binomial reciprocal, $B(n+1,n+1)=1/((2n+1)\\binom{2n}{n})$. This file establishes its asymptotic decay as $n\\to\\infty$. The engine is the classical Stirling/Wallis estimate of the central binomial coefficient — which Mathlib does not state — derived here from `Stirling.factorial_isEquivalent_stirling`. From the closed form this immediately yields the Wallis-rate mass collapse of the symmetric Beta density.",
+    "mathContext": "$\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$ and $B(n+1,n+1)\\sim \\sqrt{\\pi n}/((2n+1)4^n)$ as $n\\to\\infty$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Stirling's approximation",
+      "Wallis product",
+      "central binomial coefficient",
+      "Euler Beta function"
+    ],
+    "prerequisites": [
+      "asymptotic equivalence",
+      "Beta and Gamma functions"
+    ]
+  },
+  {
+    "id": "ann-bcba-centralbinom-cast",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": {
+      "startLine": 50,
+      "endLine": 62
+    },
+    "type": "lemma",
+    "title": "centralBinom_cast: binomial as a factorial quotient",
+    "content": "Rewrites the combinatorial $\\binom{2n}{n}$ as the real quotient $(2n)!/(n!\\,n!)$. The proof uses `Nat.choose_mul_factorial_mul_factorial` (with $2n-n=n$ supplied by `omega`) to get the integer identity $\\binom{2n}{n}\\cdot(n!)^2=(2n)!$, then `eq_div_iff` and `exact_mod_cast` transport it to the reals. This cast is what lets a Stirling equivalence stated over factorials be applied to the central binomial coefficient.",
+    "mathContext": "$\\binom{2n}{n}=\\dfrac{(2n)!}{n!\\,n!}$ over $\\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "factorials",
+      "casting ℕ to ℝ"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Nat.choose identities"
+    ]
+  },
+  {
+    "id": "ann-bcba-stirling-ratio",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": {
+      "startLine": 64,
+      "endLine": 88
+    },
+    "type": "lemma",
+    "title": "stirling_ratio_identity: where 4ⁿ comes from",
+    "content": "The exact algebraic heart of the file. It shows the ratio of the Stirling expressions for $(2k)!$ and $(k!)^2$ collapses to $4^k/\\sqrt{\\pi m}$. Three sub-facts do the work: $\\sqrt{2(2m)\\pi}=2\\sqrt{\\pi m}$; the crucial $(2m/e)^{2k}=4^k\\big((m/e)^k\\big)^2$ isolating the sole source of $4^k$; and the two square-root self-products $\\sqrt{\\pi m}^2=\\pi m$, $\\sqrt{2m\\pi}^2=2m\\pi$. A single `linear_combination` then closes the cross-multiplied goal. Keeping this step exact (not asymptotic) is what makes the main theorem a clean `IsEquivalent` manipulation.",
+    "mathContext": "$\\dfrac{\\sqrt{2(2m)\\pi}\\,((2m)/e)^{2k}}{\\big(\\sqrt{2m\\pi}\\,(m/e)^k\\big)^2}=\\dfrac{4^k}{\\sqrt{\\pi m}}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Wallis ratio",
+      "linear_combination tactic",
+      "square roots",
+      "algebraic simplification"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "field algebra in Lean"
+    ]
+  },
+  {
+    "id": "ann-bcba-centralbinom-asymptotic",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": {
+      "startLine": 90,
+      "endLine": 112
+    },
+    "type": "theorem",
+    "title": "centralBinom_isEquivalent: the missing Mathlib asymptotic",
+    "content": "Proves $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$. It takes Mathlib's `Stirling.factorial_isEquivalent_stirling`, composes it with the divergent $n\\mapsto 2n$ (`comp_tendsto`), multiplies two copies for the $(n!)^2$ denominator (`.mul`), and divides (`.div`). The `centralBinom_cast` equivalence bridges to $\\binom{2n}{n}$, and a final `filter_upwards` rewrites the leftover Stirling ratio through `stirling_ratio_identity`. The result is a standalone, reusable equivalence Mathlib lacks.",
+    "mathContext": "$\\big(n\\mapsto \\binom{2n}{n}\\big)\\ \\sim_{\\text{atTop}}\\ \\big(n\\mapsto 4^n/\\sqrt{\\pi n}\\big)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "IsEquivalent calculus",
+      "Stirling's formula",
+      "central binomial asymptotic",
+      "Filter.atTop"
+    ],
+    "prerequisites": [
+      "asymptotic equivalence",
+      "filters and limits"
+    ]
+  },
+  {
+    "id": "ann-bcba-betadiag",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": {
+      "startLine": 114,
+      "endLine": 136
+    },
+    "type": "theorem",
+    "title": "betaDiag_isEquivalent: transporting the rate to the Beta value",
+    "content": "Defines `betaDiag n = 1/((2n+1)\\binom{2n}{n})` — the parent's real closed form — and proves $B(n+1,n+1)\\sim \\sqrt{\\pi n}/((2n+1)4^n)$. The argument inverts `centralBinom_isEquivalent` (`.inv`), multiplies by the reflexive equivalence for the polynomial factor $1/(2n+1)$, and matches both sides via pointwise `EventuallyEq` rewrites (`inv_div`, `inv_mul_eq_div`, `div_div`). The polynomial factor is asymptotically inert, so the central-binomial rate passes straight through.",
+    "mathContext": "$\\big(n\\mapsto B(n+1,n+1)\\big)\\ \\sim_{\\text{atTop}}\\ \\big(n\\mapsto \\sqrt{\\pi n}/((2n+1)4^n)\\big)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsEquivalent.inv",
+      "Euler Beta function",
+      "asymptotic decay",
+      "Gaussian concentration"
+    ],
+    "prerequisites": [
+      "asymptotic equivalence",
+      "Beta function closed form"
+    ]
+  },
+  {
+    "id": "ann-bcba-complex-link",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": {
+      "startLine": 138,
+      "endLine": 145
+    },
+    "type": "theorem",
+    "title": "betaIntegral_diag_eq: it really is the Euler Beta integral",
+    "content": "Certifies that `Complex.betaIntegral (n+1) (n+1)` equals `(betaDiag n : ℂ)`, using the parent's `betaIntegral_diag_centralBinom` then `push_cast`/`ring`. This closes the loop: the real sequence whose decay was just established is literally the value of the genuine complex Euler Beta integral on the diagonal, so `betaDiag_isEquivalent` is an asymptotic about `Complex.betaIntegral` itself, not merely an ad hoc reciprocal sequence.",
+    "mathContext": "$\\mathrm{B}_{\\mathbb{C}}(n+1,n+1)=\\big(\\text{betaDiag }n\\big)\\in\\mathbb{R}\\subset\\mathbb{C}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Complex.betaIntegral",
+      "real-to-complex cast",
+      "Euler Beta integral"
+    ],
+    "prerequisites": [
+      "complex integration",
+      "Beta integral definition"
+    ]
+  }
+]

--- a/src/data/proofs/beta-central-binomial-asymptotic/meta.json
+++ b/src/data/proofs/beta-central-binomial-asymptotic/meta.json
@@ -49,5 +49,94 @@
     "additionalFiles": [
       "Proofs/BetaCentralBinomial.lean"
     ]
-  }
+  },
+  "overview": {
+    "historicalContext": "The central binomial coefficient $\\binom{2n}{n}$ and its growth rate sit at the crossroads of three classical threads. John Wallis (1656) discovered the infinite product $\\tfrac{\\pi}{2}=\\prod_k \\tfrac{2k\\cdot 2k}{(2k-1)(2k+1)}$ while computing $\\int_0^{\\pi/2}\\sin^{2n}$, and that product is exactly the $n\\to\\infty$ behaviour of $\\binom{2n}{n}$ in disguise. James Stirling and Abraham de Moivre (1730s) then gave the factorial asymptotic $n!\\sim\\sqrt{2\\pi n}\\,(n/e)^n$, from which $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$ follows by a two-line cancellation. Independently, Leonhard Euler introduced the Beta integral $B(x,y)=\\int_0^1 t^{x-1}(1-t)^{y-1}\\,dt=\\Gamma(x)\\Gamma(y)/\\Gamma(x+y)$, whose symmetric diagonal $B(n+1,n+1)$ is a rescaled central binomial reciprocal. Mathlib ships Stirling's equivalence (`Stirling.factorial_isEquivalent_stirling`) and the combinatorial `Nat.centralBinom`, but states neither the asymptotic of the central binomial coefficient nor any asymptotic for the Euler Beta value. This entry assembles both, deriving the Wallis-rate decay of the diagonal Beta density purely from Mathlib's Stirling formula and the parent entry's closed form $B(n+1,n+1)=1/((2n+1)\\binom{2n}{n})$.",
+    "problemStatement": "Prove, in Lean 4 with 0 sorries and 0 axioms, that the central binomial coefficient satisfies $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$ and that the diagonal Euler Beta value satisfies $B(n+1,n+1)\\sim \\sqrt{\\pi n}/((2n+1)\\,4^n)$ as $n\\to\\infty$, and connect the latter to the genuine complex Euler Beta integral `Complex.betaIntegral`.",
+    "proofStrategy": "Cast $\\binom{2n}{n}$ as the factorial quotient $(2n)!/(n!)^2$ (`centralBinom_cast`), then feed Mathlib's Stirling equivalence through the algebra of `IsEquivalent`: compose it with $n\\mapsto 2n$, multiply the denominator equivalence, and divide. The one non-formal step is an exact algebraic identity (`stirling_ratio_identity`) showing the ratio of the Stirling expressions collapses to $4^k/\\sqrt{\\pi m}$; a `linear_combination` of the two square-root self-products closes it. The Beta asymptotic then follows by inverting the central-binomial equivalence and multiplying by the $1/(2n+1)$ factor from the parent's closed form.",
+    "keyInsights": [
+      "The diagonal Euler Beta value is a central binomial reciprocal: $B(n+1,n+1)=1/((2n+1)\\binom{2n}{n})$, so its asymptotics are entirely governed by the growth of $\\binom{2n}{n}$.",
+      "Stirling's factorial equivalence, pushed through the `IsEquivalent` calculus (compose with $2n$, multiply, divide), yields $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$ — a statement Mathlib does not contain.",
+      "The factor $4^n$ has a single algebraic source: $((2m/e)^{2k})/((m/e)^k)^2 = 2^{2k}=4^k$. Everything else in the Stirling ratio cancels down to $1/\\sqrt{\\pi m}$.",
+      "Reducing the transcendental asymptotic to one exact identity means `linear_combination` on the square-root self-products $\\sqrt{\\pi m}^2=\\pi m$ discharges the only non-`IsEquivalent` step.",
+      "Inverting an equivalence and multiplying by a refl equivalence for $1/(2n+1)$ transports the central-binomial rate to the Beta value: $B(n+1,n+1)\\sim \\sqrt{\\pi n}/((2n+1)4^n)\\approx \\sqrt{\\pi}\\,2^{-2n-1}n^{-1/2}$.",
+      "`betaIntegral_diag_eq` certifies that the real sequence analysed is literally $\\mathrm{Re}$ of `Complex.betaIntegral (n+1) (n+1)`, so the decay is a theorem about the genuine Euler Beta integral, and quantifies the Wallis-rate mass collapse of the symmetric Beta density toward its Gaussian limit."
+    ],
+    "prerequisites": [
+      "Stirling's approximation",
+      "asymptotic equivalence (Landau/IsEquivalent)",
+      "central binomial coefficients",
+      "Euler Beta and Gamma functions"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: imports, statement, provenance",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Imports the parent `BetaCentralBinomial` closed form and Mathlib, and a module docstring stating the goal: derive the Stirling/Wallis asymptotic of the central binomial coefficient (absent from Mathlib) and transport it through the parent's closed form to the diagonal Beta value. Opens `Filter`, `Asymptotics` and enters `namespace BetaDiagAsymptotic`."
+    },
+    {
+      "id": "centralbinom-cast",
+      "title": "centralBinom_cast: factorial quotient identity",
+      "startLine": 50,
+      "endLine": 62,
+      "summary": "Rewrites $\\binom{2n}{n}$ as the real quotient $(2n)!/(n!\\,n!)$ using `Nat.choose_mul_factorial_mul_factorial` with $2n-n=n$, so the combinatorial coefficient can be fed to a Stirling equivalence stated in terms of factorials."
+    },
+    {
+      "id": "stirling-ratio",
+      "title": "stirling_ratio_identity: the Wallis ratio collapse",
+      "startLine": 64,
+      "endLine": 88,
+      "summary": "The exact algebraic core: the ratio of the Stirling expressions for $(2k)!$ and $(k!)^2$ collapses to $4^k/\\sqrt{\\pi m}$. Establishes $\\sqrt{2(2m)\\pi}=2\\sqrt{\\pi m}$, isolates $4^k$ as $(2m/e)^{2k}=4^k((m/e)^k)^2$, and closes with a `linear_combination` of the two square-root self-products."
+    },
+    {
+      "id": "centralbinom-asymptotic",
+      "title": "centralBinom_isEquivalent: C(2n,n) ~ 4ⁿ/√(πn)",
+      "startLine": 90,
+      "endLine": 112,
+      "summary": "The new central binomial asymptotic. Takes Mathlib's `Stirling.factorial_isEquivalent_stirling`, composes it with $n\\mapsto 2n$, multiplies to get the $(n!)^2$ denominator, divides, and rewrites the resulting Stirling ratio via `stirling_ratio_identity` to conclude $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$."
+    },
+    {
+      "id": "betadiag-asymptotic",
+      "title": "betaDiag and betaDiag_isEquivalent: the Beta decay",
+      "startLine": 114,
+      "endLine": 136,
+      "summary": "Defines `betaDiag n = 1/((2n+1)\\binom{2n}{n})` and proves $B(n+1,n+1)\\sim \\sqrt{\\pi n}/((2n+1)4^n)$ by inverting `centralBinom_isEquivalent`, multiplying by the reflexive equivalence for $1/(2n+1)$, and rearranging the reciprocal via `inv_div`/`div_div`."
+    },
+    {
+      "id": "complex-beta-link",
+      "title": "betaIntegral_diag_eq: link to Complex.betaIntegral",
+      "startLine": 138,
+      "endLine": 147,
+      "summary": "Certifies that `Complex.betaIntegral (n+1) (n+1)` equals the real `betaDiag n` cast to $\\mathbb{C}$, using the parent's `betaIntegral_diag_centralBinom`, so the asymptotic is genuinely a statement about the Euler Beta integral rather than an ad hoc sequence."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry proves two asymptotics Mathlib lacks: the central binomial estimate $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$ (`centralBinom_isEquivalent`) derived from Stirling, and its consequence for the diagonal Euler Beta value, $B(n+1,n+1)\\sim \\sqrt{\\pi n}/((2n+1)\\,4^n)$ (`betaDiag_isEquivalent`), all with 0 sorries and 0 axioms. `betaIntegral_diag_eq` ties the analysed sequence to the genuine `Complex.betaIntegral` on the diagonal.",
+    "implications": "The result quantifies the mass collapse of the symmetric $\\mathrm{Beta}(n+1,n+1)$ density: its total (unnormalised) mass decays like $\\sqrt{\\pi}\\,2^{-2n-1}n^{-1/2}$, the Wallis rate governed by the central binomial coefficient, and reflects the concentration of the rescaled Beta density toward a Gaussian. Because the central binomial asymptotic is proved as a standalone `IsEquivalent`, it is reusable: any Mathlib development needing $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$ (Wallis product, random-walk return probabilities, Catalan number growth) can cite it directly.",
+    "openQuestions": [
+      "Can the equivalence be sharpened to a full asymptotic expansion with the $1-1/(8n)+\\dots$ correction terms from the Stirling series?",
+      "Does the off-diagonal Beta value $B(m+1,n+1)$ admit an analogous two-parameter asymptotic assembled from the same Stirling ratio machinery?",
+      "Can `centralBinom_isEquivalent` be upstreamed to Mathlib as the missing companion to `Stirling.factorial_isEquivalent_stirling`?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "beta-central-binomial",
+      "relationship": "extends",
+      "description": "Parent entry: establishes the closed form $B(n+1,n+1)=1/((2n+1)\\binom{2n}{n})$ and `betaIntegral_diag_centralBinom`. This entry supplies the missing asymptotic decay of that closed form."
+    },
+    {
+      "targetId": "beta-central-binomial-explicit-rate",
+      "relationship": "related",
+      "description": "Sibling analysing an explicit (non-asymptotic) error rate for the same diagonal Beta value; complements this entry's leading-order equivalence."
+    },
+    {
+      "targetId": "beta-diag-effective-rate",
+      "relationship": "related",
+      "description": "Sibling giving an effective (quantitative) form of the diagonal Beta decay, versus the leading-order Landau equivalence proved here."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass: quality 0 → 100.

- **overview**: historical context (Wallis 1656 / Stirling–de Moivre / Euler Beta), problem statement, proof strategy, 6 key insights, prerequisites
- **sections**: 6 line-anchored sections covering the whole 147-line file
- **annotations**: 6 annotations, each with mathContext, significance, relatedConcepts, prerequisites
- **conclusion**: summary, implications, 3 open questions
- **crossReferences**: parent `beta-central-binomial` + two siblings

No Lean changes; gallery data only.