### PR TITLE
audit: fix erdos-437/125 sorry counts + kill erdos-741 True-stub false positive

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -313,10 +313,16 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     if (i === 0) mainSorryCount = fileSorryCount
     axiomCount += (content.match(/^(?:(?:private|noncomputable)\s+)*axiom /gm) || []).length
 
-    // True stubs: only count theorem/lemma declarations, not example (Issue #6130)
+    // True stubs: only count theorem/lemma declarations, not example (Issue #6130).
+    // A genuine True stub proves `True` as its *entire* conclusion (`: True :=`,
+    // `: True := by ...`, or bare `: True`). Do NOT flag declarations where `True`
+    // is merely part of a larger proposition, e.g. the Aristotle answer idiom
+    // `answer : True ↔ ∃ x, P x := by ...` (real content is the RHS existential) or
+    // helper lemmas like `True ↔ True`. Requiring the type to terminate at `True`
+    // (followed by `:=` or end-of-line) removes a recurring erdos-741 false positive.
     for (const line of content.split('\n')) {
       const trimmed = line.trim()
-      if (/^(theorem|lemma)\b/.test(trimmed) && /(:= trivial\b|: True\b)/.test(trimmed)) {
+      if (/^(theorem|lemma)\b/.test(trimmed) && /(:=\s*trivial\b|:\s*True\s*(?::=|$))/.test(trimmed)) {
         trueStubCount++
       }
     }

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -21,7 +21,7 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",
@@ -203,5 +203,5 @@
       "note": "Source of the ported Lean proof: APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean (370 lines)."
     }
   ],
-  "sorries": 1
+  "sorries": 2
 }

--- a/src/data/proofs/erdos-437/meta.json
+++ b/src/data/proofs/erdos-437/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 437,
     "erdosUrl": "https://erdosproblems.com/437",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Gallery Integrity Audit

Three findings from the auditor loop (HEAD `bea319d8e3b`). Post-fix, the gallery audit reports **0 issues / 0 critical** (was 3 issues, 1 critical).

### 1. erdos-437 — sorry count mismatch (HIGH)
`meta.sorries` said `0`, but `Erdos437Problem.lean` carries a genuine `sorry` — the stubbed example theorem `powers_of_four_all_squares` (line 216). The `leanFile.sorries` block already recorded `1`, so the meta block was internally inconsistent. **Fix:** `meta.sorries → 1`. Status remains `axiomatized`/`axiom` (core reduction rests on 4 disclosed axioms; the sorry is an unfinished illustrative example).

### 2. erdos-125 — sorry count mismatch (HIGH)
`meta.sorries` said `1`, matching neither counting convention the auditor accepts: main-file (`0`) nor chain-aggregate (`2` = `PositiveLowerDensity` port + `Aristotle` scaffold, each with one real `sorry`). The entry is `badge: wip` / `axiomatized` — honestly presented as WIP. **Fix:** `meta.sorries → 2` (chain-aggregate) to disclose all remaining work; top-level `sorries` aligned to match.

### 3. erdos-741 — recurring CRITICAL false positive (tooling)
Flagged 4× as `CRITICAL: 1 True stubs but status is "verified"`. The entry is actually **clean**: 0 sorries, 0 axioms, genuine theorems. The crude `: True` grep in `find-targets.ts` misfired on the Aristotle answer idiom `target_theorem_0 : True ↔ ∃ A, P A` (real content is the RHS existential, proved via `cassels_set`) and its *used* helper `answer_true_iff : True ↔ True`. **Fix:** tightened the True-stub heuristic to only count declarations whose conclusion type is exactly `True` (`: True :=`, bare `: True`, or `:= trivial`). Verified against 11 pattern cases — genuine stubs still caught, idioms no longer flagged.

## Verification
- `npx tsx scripts/auditor/find-targets.ts --issues` → 0 targets
- `--stats` → With issues: 0, Critical issues: 0
- Regex unit-tested against 11 stub/non-stub patterns (all pass)

Discovered during autonomous gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)