### PR TITLE
Enrich: An Explicit 1 + O(1/n) Rate for the Diagonal Beta Value

### DIFF
--- a/src/data/proofs/beta-central-binomial-explicit-rate/annotations.json
+++ b/src/data/proofs/beta-central-binomial-explicit-rate/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-betadiag-def",
+    "proofId": "beta-central-binomial-explicit-rate",
+    "range": { "startLine": 65, "endLine": 80 },
+    "type": "definition",
+    "title": "The Diagonal Beta Value as a Central-Binomial Reciprocal",
+    "content": "The file is kept independent of the parent build by restating the one fact it needs: the diagonal Beta value equals 1/((2n+1)·C(2n,n)). The helper lemma centralBinom_cast re-expresses the central binomial coefficient in factorial form C(2n,n) = (2n)!/(n!·n!), proved directly from Mathlib's Nat.choose_mul_factorial_mul_factorial after rewriting 2n − n = n. This factorial form is what lets the later Stirling identity be pure algebra.",
+    "mathContext": "$B(n+1,n+1) = \\dfrac{1}{(2n+1)\\,C(2n,n)}, \\qquad C(2n,n) = \\dfrac{(2n)!}{n!\\,n!}$",
+    "significance": "context",
+    "relatedConcepts": ["Euler Beta function", "central binomial coefficient", "factorial identities"],
+    "prerequisites": ["binomial coefficients", "Euler Beta integral"]
+  },
+  {
+    "id": "ann-telescope-step",
+    "proofId": "beta-central-binomial-explicit-rate",
+    "range": { "startLine": 84, "endLine": 104 },
+    "type": "technique",
+    "title": "Telescoping the Per-Step Stirling Estimate",
+    "content": "log_gap_le_telescope replaces Mathlib's per-step bound of 1/(4(m+j+1)^2) on the gap of log∘stirlingSeq by a strictly larger but telescoping difference 1/(4(m+j)) − 1/(4(m+j+1)). The key inequality is that this difference equals 1/(4(m+j)(m+j+1)), which dominates 1/(4(m+j+1)^2), discharged by one_div_le_one_div_of_le and nlinarith. Trading the summable per-step estimates for a telescoping envelope is precisely what makes the infinite sum collapse to a clean 1/(4m) tail.",
+    "mathContext": "$\\log\\mathrm{stirlingSeq}(m{+}j{+}1) - \\log\\mathrm{stirlingSeq}(m{+}j{+}2) \\le \\dfrac{1}{4(m+j)} - \\dfrac{1}{4(m+j+1)} = \\dfrac{1}{4(m+j)(m+j+1)}$",
+    "significance": "technical",
+    "relatedConcepts": ["telescoping series", "Stirling sequence", "monotone convergence"],
+    "prerequisites": ["telescoping sums", "real analysis inequalities"]
+  },
+  {
+    "id": "ann-tail-bound",
+    "proofId": "beta-central-binomial-explicit-rate",
+    "range": { "startLine": 106, "endLine": 155 },
+    "type": "insight",
+    "title": "The New Quantitative Stirling Tail Bound",
+    "content": "This lemma is the technical heart of the entry and the piece Mathlib does not provide. Summing the telescoping steps over range N gives the exact partial value 1/(4m) − 1/(4(m+N)), so every partial sum of the actual log-gaps is bounded uniformly by 1/(4m). Because the partial sums also converge to log stirlingSeq(m+1) − log√π (using stirlingSeq → √π and continuity of log), le_of_tendsto' upgrades the uniform bound on the sequence to a bound on its limit. The result is the sharp tail estimate that supplies the O(1/n) rate.",
+    "mathContext": "$\\log\\mathrm{stirlingSeq}(m{+}1) - \\log\\sqrt\\pi \\le \\dfrac{1}{4m}, \\qquad m \\ge 1$",
+    "significance": "key",
+    "relatedConcepts": ["Stirling's approximation", "limit of monotone sequence", "asymptotic tail bounds"],
+    "prerequisites": ["convergence of sequences", "Finset.sum_range_sub'", "le_of_tendsto"]
+  },
+  {
+    "id": "ann-centralbinom-stirling",
+    "proofId": "beta-central-binomial-explicit-rate",
+    "range": { "startLine": 168, "endLine": 203 },
+    "type": "technique",
+    "title": "The Exact Central-Binomial / Stirling Identity",
+    "content": "centralBinom_stirling unfolds the definition stirlingSeq k = k!/(√(2k)(k/e)^k) on both sides and collapses the central binomial to a pure ratio of Stirling values times 4ⁿ/√n. The proof pre-computes the two algebraic reductions that field_simp cannot guess — √(2·2n) = 2√n and ((2n)/e)^(2n) = 4ⁿ·((n/e)ⁿ)² — then lets field_simp and the substitution u² = 2s² finish. This exact (not asymptotic) identity is what removes every constant from the correction factor.",
+    "mathContext": "$C(2n,n) = \\dfrac{\\mathrm{stirlingSeq}(2n)}{\\mathrm{stirlingSeq}(n)^2}\\cdot\\dfrac{4^n}{\\sqrt n}$",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficient", "Stirling sequence", "exact algebraic identities"],
+    "prerequisites": ["field arithmetic", "square root manipulation", "power laws"]
+  },
+  {
+    "id": "ann-log-bracket",
+    "proofId": "beta-central-binomial-explicit-rate",
+    "range": { "startLine": 256, "endLine": 310 },
+    "type": "insight",
+    "title": "Linearising the Correction via Logarithms",
+    "content": "Taking logs turns the multiplicative correction into a signed combination of two Stirling deviations: log q n = 2·δ(n) − δ(2n) where δ(k) = log stirlingSeq(k) − log√π. The upper bound uses the tail bound on δ(n) (doubled) plus δ(2n) ≥ 0; the lower bound uses δ(n) ≥ 0 plus the tail bound on δ(2n). This is why the bracket is asymmetric — the two ends invoke the same tail estimate but at indices n and 2n.",
+    "mathContext": "$\\log q(n) = 2\\big(\\log\\mathrm{stirlingSeq}(n){-}\\log\\sqrt\\pi\\big) - \\big(\\log\\mathrm{stirlingSeq}(2n){-}\\log\\sqrt\\pi\\big)$",
+    "significance": "supporting",
+    "relatedConcepts": ["logarithmic linearisation", "Stirling deviation", "two-sided bounds"],
+    "prerequisites": ["properties of logarithm", "sign analysis"]
+  },
+  {
+    "id": "ann-bracket-and-bigo",
+    "proofId": "beta-central-binomial-explicit-rate",
+    "range": { "startLine": 314, "endLine": 378 },
+    "type": "insight",
+    "title": "From Effective Bracket to the Landau O(1/n) Form",
+    "content": "betaDiag_correction_bracket exponentiates the log-bracket into the effective two-sided estimate exp(−1/(4(2n−1))) ≤ q n ≤ exp(1/(2(n−1))). betaDiag_correction_isBigO then extracts the honest Landau statement with the explicit constant 3, using only elementary convexity of exp: 1 − x ≤ e^(−x) on the lower side and e^x − 1 ≤ x·e^x on the upper side, together with exp(b) ≤ 3 from e < 3. No qualitative limit is used for the rate itself.",
+    "mathContext": "$\\exp\\!\\big(\\tfrac{-1}{4(2n-1)}\\big) \\le q(n) \\le \\exp\\!\\big(\\tfrac{1}{2(n-1)}\\big) \\Longrightarrow |q(n)-1| \\le \\tfrac{3}{n}$",
+    "significance": "key",
+    "relatedConcepts": ["Landau notation", "big-O asymptotics", "convexity of exponential"],
+    "prerequisites": ["Asymptotics.isBigO", "exponential inequalities", "filters and atTop"]
+  }
+]

--- a/src/data/proofs/beta-central-binomial-explicit-rate/meta.json
+++ b/src/data/proofs/beta-central-binomial-explicit-rate/meta.json
@@ -31,6 +31,65 @@
     ]
   },
   "sorries": 0,
+  "overview": {
+    "historicalContext": "The Euler Beta function B(x,y) = ∫₀¹ t^{x-1}(1-t)^{y-1} dt was introduced by Euler in the 1730s and later named by Jacques Binet; its diagonal values B(n+1,n+1) measure the total mass of the symmetric Beta density and collapse to the reciprocal central binomial expression 1/((2n+1)·C(2n,n)). The asymptotics of that central binomial coefficient, C(2n,n) ~ 4ⁿ/√(πn), descend from two of the oldest results in analysis: John Wallis's 1656 infinite product for π/2 (from Arithmetica Infinitorum) and the Stirling–de Moivre factorial approximation n! ~ √(2πn)(n/e)ⁿ established around 1730. Abraham de Moivre found the √(2πn) shape while Stirling identified the constant √(2π); Mathlib packages the modern reconstruction through the monotone `stirlingSeq k = k!/(√(2k)(k/e)ᵏ) → √π`. The language of asymptotic rates — the O(·) symbol — is due to Paul Bachmann (1894) and Edmund Landau (1909). This entry sits exactly at the junction of these classical threads: it takes the qualitative Wallis/Stirling limit and sharpens it into an effective, machine-checked Landau statement, supplying the explicit tail bound on the Stirling sequence that the qualitative Mathlib development leaves unstated.",
+    "problemStatement": "Let $B(n+1,n+1) = 1/((2n+1)\\,C(2n,n))$ be the diagonal Beta value and $T(n) = \\sqrt{\\pi n}/((2n+1)\\,4^n)$ its leading term. Define the multiplicative correction $q(n) = B(n+1,n+1)/T(n)$. Prove the effective two-sided bracket $\\exp(-1/(4(2n-1))) \\le q(n) \\le \\exp(1/(2(n-1)))$ for $n \\ge 2$, and deduce the clean Landau statement $q(n) - 1 = O(1/n)$ as $n \\to \\infty$.",
+    "proofStrategy": "The correction factor is reduced by pure algebra to a ratio of Stirling-sequence values, $q(n) = \\mathrm{stirlingSeq}(n)^2/(\\sqrt\\pi\\,\\mathrm{stirlingSeq}(2n))$, via the exact identity $C(2n,n) = \\mathrm{stirlingSeq}(2n)/\\mathrm{stirlingSeq}(n)^2 \\cdot 4^n/\\sqrt n$. Taking logarithms turns the multiplicative bracket into an additive one governed by the deviation $\\log\\mathrm{stirlingSeq}(k) - \\log\\sqrt\\pi$. The quantitative engine is a new tail bound $\\log\\mathrm{stirlingSeq}(m+1) - \\log\\sqrt\\pi \\le 1/(4m)$, obtained by telescoping Mathlib's per-step estimate $\\le 1/(4(m+1)^2)$ against the exact partial sum $1/(4m) - 1/(4(m+N))$ and passing to the limit using $\\mathrm{stirlingSeq} \\to \\sqrt\\pi$. Combined with Mathlib's lower bound $\\sqrt\\pi \\le \\mathrm{stirlingSeq}(k)$, this brackets $\\log q(n)$ between $-1/(4(2n-1))$ and $1/(2(n-1))$; exponentiating gives the effective bracket, and elementary $\\exp$ inequalities ($1 - x \\le e^{-x}$ and $e^x - 1 \\le x e^x$) convert it into the $O(1/n)$ Landau form with explicit constant 3.",
+    "keyInsights": [
+      "The rate problem is entirely a Stirling-sequence problem: the exact identity $C(2n,n) = \\mathrm{stirlingSeq}(2n)/\\mathrm{stirlingSeq}(n)^2\\cdot 4^n/\\sqrt n$ shows every $\\sqrt\\pi$, $4^n$ and $\\sqrt n$ cancels, leaving the correction $q(n)$ as a pure ratio of Stirling values with no free constants.",
+      "Passing to logarithms linearises the problem: $\\log q(n) = 2(\\log\\mathrm{stirlingSeq}(n) - \\log\\sqrt\\pi) - (\\log\\mathrm{stirlingSeq}(2n) - \\log\\sqrt\\pi)$, so a single one-sided deviation bound plus a one-sided nonnegativity fact controls both ends of the bracket.",
+      "Mathlib supplies a per-step estimate $O(1/m^2)$ but no tail bound; the missing $O(1/m)$ tail is recovered by telescoping — $\\sum_{j<N}(1/(4(m+j)) - 1/(4(m+j+1))) = 1/(4m) - 1/(4(m+N))$ — a device that trades the summable $1/m^2$ steps for the sharp $1/(4m)$ envelope.",
+      "The two ends of the bracket are asymmetric by design: the upper exponent $1/(2(n-1))$ comes from doubling the deviation of $\\mathrm{stirlingSeq}(n)$, while the lower exponent $-1/(4(2n-1))$ comes from the deviation of $\\mathrm{stirlingSeq}(2n)$ — the same tail bound evaluated at two different indices.",
+      "Effectivity is preserved end to end: because both bracketing exponents are explicit rational functions of $n$, the qualitative limit is never invoked for the rate itself — only elementary convexity inequalities for $\\exp$ turn the effective bracket into the Landau bound $|q(n)-1| \\le 3/n$."
+    ]
+  },
+  "sections": [
+    {
+      "id": "diagonal-beta-restatement",
+      "title": "The Diagonal Beta Value (Self-Contained Restatement)",
+      "startLine": 58,
+      "endLine": 80,
+      "summary": "Restates the two facts borrowed from the parent chain so the file is build-independent: the diagonal Beta value as the central-binomial reciprocal betaDiag n = 1/((2n+1)·C(2n,n)), and the factorial form C(2n,n) = (2n)!/(n!·n!) proved directly from Mathlib's choose_mul_factorial_mul_factorial."
+    },
+    {
+      "id": "stirling-tail-bound",
+      "title": "A Quantitative Tail Bound for the Stirling Sequence",
+      "startLine": 82,
+      "endLine": 164,
+      "summary": "The quantitative engine. log_gap_le_telescope dominates each per-step gap of log∘stirlingSeq by a telescoping difference of 1/(4·); log_stirlingSeq_sub_sqrt_pi_le sums these, bounds the partial sums uniformly, and sends N→∞ against stirlingSeq→√π to yield the new tail bound log stirlingSeq(m+1) − log√π ≤ 1/(4m). A companion lemma records nonnegativity of the deviation from Mathlib's √π ≤ stirlingSeq."
+    },
+    {
+      "id": "central-binomial-stirling-identity",
+      "title": "The Exact Central-Binomial / Stirling Identity",
+      "startLine": 166,
+      "endLine": 203,
+      "summary": "centralBinom_stirling proves the exact algebraic identity C(2n,n) = stirlingSeq(2n)/stirlingSeq(n)² · (4ⁿ/√n) by unfolding the definition of stirlingSeq and the factorial form of the central binomial, handling the √(2·2n)=2√n and ((2n)/e)^{2n} = 4ⁿ·((n/e)ⁿ)² reductions before a field_simp collapse."
+    },
+    {
+      "id": "correction-factor-bracket",
+      "title": "The Correction Factor and Its Log-Bracket",
+      "startLine": 205,
+      "endLine": 310,
+      "summary": "Defines the leading term target n and the correction q n = stirlingSeq(n)²/(√π·stirlingSeq(2n)), proves positivity, and establishes the exact factorisation betaDiag_eq_target_mul: B(n+1,n+1) = T n · q n. log_correction_eq expresses log q n via Stirling deviations, and log_correction_upper / log_correction_lower bracket it between −1/(4(2n−1)) and 1/(2(n−1)) using the tail bound at indices n and 2n."
+    },
+    {
+      "id": "explicit-rate-and-landau",
+      "title": "The Explicit Two-Sided Rate and the O(1/n) Corollary",
+      "startLine": 312,
+      "endLine": 390,
+      "summary": "Exponentiates the log-bracket into the effective statement betaDiag_correction_bracket: exp(−1/(4(2n−1))) ≤ q n ≤ exp(1/(2(n−1))) for n ≥ 2. betaDiag_correction_isBigO converts this to the clean Landau form (q n − 1) =O[atTop](1/n) with explicit constant 3, via 1−x ≤ e^{−x} and e^x−1 ≤ x e^x. The capstone betaDiag_rate transports the bound to B(n+1,n+1)/T n − 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry delivers a fully machine-checked, effective 1 + O(1/n) rate for the diagonal Euler Beta value B(n+1,n+1) relative to its Wallis/Stirling leading term √(πn)/((2n+1)·4ⁿ). Its core technical contribution is a quantitative Stirling tail bound, log stirlingSeq(m+1) − log√π ≤ 1/(4m), assembled by telescoping from Mathlib's per-step O(1/m²) estimate — a bound Mathlib proves the limit of but never packages as a rate. From it, the correction factor q n is bracketed between two explicit exponentials whose exponents are rational functions of n, and this bracket is distilled into the honest Landau statement (q n − 1) = O(1/n) with explicit constant 3, together with an exact factorisation B(n+1,n+1) = T n · q n and the transported capstone betaDiag_rate. Nothing is assumed: 0 axioms, 0 sorries.",
+    "implications": "By making the convergence rate effective rather than merely asymptotic, the result turns a qualitative statement about the symmetric Beta density's mass collapse into a computable error bar usable in downstream numerical or probabilistic estimates — for instance bounding the maximum of the density $t^n(1-t)^n$ or the normalising constant of a symmetric Beta(n+1,n+1) prior with a guaranteed relative error below 3/n. More broadly it demonstrates a reusable pattern: Mathlib's Stirling development yields sharp rates for any factorial-ratio quantity once the missing tail bound is telescoped out of the per-step estimate, so the same machinery extends to off-diagonal Beta values, Catalan-number asymptotics, and other central-binomial-driven sequences without re-deriving Stirling from scratch.",
+    "openQuestions": [
+      "Can the constant in the Landau bound be improved from 3/n toward the true first-order coefficient of q n − 1, giving a sharp effective constant rather than a convenient over-estimate?",
+      "Does the telescoping tail-bound technique extend to a full asymptotic expansion q n = 1 + c₁/n + c₂/n² + ⋯ with effective, machine-checked remainder terms?",
+      "Can the effective rate be lifted to the off-diagonal Beta values B(a n+1, b n+1) for rational ratios a/b, where the leading term and correction involve stirlingSeq at three distinct indices?",
+      "Would upstreaming the tail bound log stirlingSeq(m+1) − log√π ≤ 1/(4m) into Mathlib's Stirling file enable effective versions of the many Mathlib results that currently use only the qualitative stirlingSeq → √π?"
+    ]
+  },
   "leanFile": {
     "path": "Proofs/BetaCentralBinomialExplicitRate.lean",
     "lineCount": 390,


### PR DESCRIPTION
Enrichment pass for `beta-central-binomial-explicit-rate` (quality 0 → 100).

## Added
- **overview**: historicalContext (Euler Beta / Wallis 1656 / Stirling–de Moivre / Bachmann–Landau O-notation), problemStatement, proofStrategy, and 5 keyInsights.
- **sections**: 5 sections covering Parts 0–4 of the 390-line Lean file (diagonal Beta restatement, quantitative Stirling tail bound, exact central-binomial/Stirling identity, correction-factor log-bracket, explicit rate + O(1/n) corollary).
- **conclusion**: summary, implications, and 4 openQuestions.
- **annotations.json**: 6 annotations, each with mathContext (LaTeX), significance, relatedConcepts, and prerequisites, anchored to real constructs (betaDiag, log_gap_le_telescope, log_stirlingSeq_sub_sqrt_pi_le, centralBinom_stirling, log_correction_eq, betaDiag_correction_bracket/isBigO).

Content only (meta.json + annotations.json). 0 axioms, 0 sorries preserved; status/badge unchanged.