### PR TITLE
Enrich An Effective Two-Sided Rate for the Diagonal Beta Value

### DIFF
--- a/src/data/proofs/beta-diag-effective-rate/annotations.json
+++ b/src/data/proofs/beta-diag-effective-rate/annotations.json
@@ -1,1 +1,137 @@
-[]
+[
+  {
+    "id": "ann-bder-docstring",
+    "proofId": "beta-diag-effective-rate",
+    "range": {
+      "startLine": 4,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "Upgrading the asymptotic to an effective rate",
+    "content": "The parent `BetaCentralBinomialAsymptotic` proves only $B(n+1,n+1)\\sim\\sqrt{\\pi n}/((2n+1)4^n)$ as an `IsEquivalent`. Its first open question asks to make this an explicit two-sided rate with effective constants. This file does so by writing the correction factor `ratioR n = stirlingSeq(n)^2/(\\sqrt\\pi\\,stirlingSeq(2n))` and pinning it, for all $n\\ge1$, to $[\\sqrt{2\\pi}/e,\\,e^2/(2\\pi)]$ using Mathlib's effective Stirling bounds. Honest scope: constant-factor bounds, not the sharper $1+O(1/n)$ form that would need the not-yet-formalised Robbins series.",
+    "mathContext": "$(\\sqrt{2\\pi}/e)T_n\\le betaDiag\\,n\\le(e^2/(2\\pi))T_n$ where $T_n=\\sqrt{\\pi n}/((2n+1)4^n)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Stirling's approximation",
+      "effective bounds",
+      "Euler Beta function",
+      "Robbins refinement"
+    ],
+    "prerequisites": [
+      "asymptotic equivalence",
+      "Stirling sequence"
+    ]
+  },
+  {
+    "id": "ann-bder-identity",
+    "proofId": "beta-diag-effective-rate",
+    "range": {
+      "startLine": 67,
+      "endLine": 123
+    },
+    "type": "theorem",
+    "title": "centralBinom_stirlingSeq: the exact Stirling identity",
+    "content": "Proves $\\binom{2n}{n}\\cdot\\sqrt n\\cdot stirlingSeq(n)^2 = stirlingSeq(2n)\\cdot4^n$ for $n\\ne0$. It expands both Stirling terms by their definition $stirlingSeq\\,n=n!/(\\sqrt{2n}(n/e)^n)$, establishes $\\sqrt{2(2n)}=2\\sqrt n$ and the $4^n$-producing $(2n/e)^{2n}=4^n((n/e)^n)^2$, rewrites both sides as single fractions, and discharges the cleared goal with a `linear_combination` of the factorial identity $\\binom{2n}{n}(n!)^2=(2n)!$ and $\\sqrt n^2=n$. Pure algebra, 0 axioms.",
+    "mathContext": "$\\binom{2n}{n}\\cdot\\sqrt n\\cdot stirlingSeq(n)^2 = stirlingSeq(2n)\\cdot4^n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Stirling sequence",
+      "central binomial coefficient",
+      "linear_combination tactic",
+      "field algebra"
+    ],
+    "prerequisites": [
+      "definition of stirlingSeq",
+      "factorial identities"
+    ]
+  },
+  {
+    "id": "ann-bder-betadiag-eq",
+    "proofId": "beta-diag-effective-rate",
+    "range": {
+      "startLine": 129,
+      "endLine": 152
+    },
+    "type": "theorem",
+    "title": "ratioR and betaDiag_eq: the explicit factorisation",
+    "content": "Defines `ratioR n = stirlingSeq(n)^2/(\\sqrt\\pi\\,stirlingSeq(2n))` and proves the exact factored form $betaDiag\\,n = \\sqrt{\\pi n}/((2n+1)4^n)\\cdot ratioR\\,n$. This isolates all the $n$-dependent correction into the single factor `ratioR`, so bounding `ratioR` is exactly bounding the deviation of `betaDiag` from its leading term. Proof rewrites via the Part I identity and clears denominators with `div_eq_div_iff` and `linear_combination`.",
+    "mathContext": "$betaDiag\\,n=\\dfrac{\\sqrt{\\pi n}}{(2n+1)4^n}\\cdot ratioR\\,n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "correction factor",
+      "Euler Beta closed form",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "Part I identity",
+      "field algebra in Lean"
+    ]
+  },
+  {
+    "id": "ann-bder-bounds",
+    "proofId": "beta-diag-effective-rate",
+    "range": {
+      "startLine": 161,
+      "endLine": 232
+    },
+    "type": "theorem",
+    "title": "ratioR_ge / ratioR_le: the effective interval",
+    "content": "The two-sided heart of the file. `stirlingSeq_le` extracts the antitonicity upper value $stirlingSeq(n)\\le stirlingSeq(1)=e/\\sqrt2$ from `stirlingSeq'_antitone`. Combined with Mathlib's genuine lower bound $\\sqrt\\pi\\le stirlingSeq$, bounding numerator ($\\pi\\le stirlingSeq(n)^2\\le e^2/2$) and denominator ($\\pi\\le\\sqrt\\pi\\,stirlingSeq(2n)\\le\\sqrt\\pi\\cdot e/\\sqrt2$) via `mul_le_mul`, gives $\\sqrt{2\\pi}/e\\le ratioR\\,n\\le e^2/(2\\pi)$ for all $n\\ge1$ after `le_div_iff`/`div_le_iff` rearrangement.",
+    "mathContext": "$\\sqrt{2\\pi}/e\\approx0.922\\le ratioR\\,n\\le e^2/(2\\pi)\\approx1.176$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "effective Stirling bounds",
+      "monotonicity",
+      "mul_le_mul",
+      "interval estimation"
+    ],
+    "prerequisites": [
+      "Stirling sequence bounds",
+      "inequality manipulation in Lean"
+    ]
+  },
+  {
+    "id": "ann-bder-tendsto",
+    "proofId": "beta-diag-effective-rate",
+    "range": {
+      "startLine": 238,
+      "endLine": 254
+    },
+    "type": "theorem",
+    "title": "ratioR_tendsto_one: consistency with the asymptotic",
+    "content": "Proves `ratioR n → 1`. Both `stirlingSeq n` and `stirlingSeq(2n)` tend to $\\sqrt\\pi$ (the latter by composing `tendsto_stirlingSeq_sqrt_pi` with $n\\mapsto2n$), so the quotient tends to $\\sqrt\\pi^2/(\\sqrt\\pi\\cdot\\sqrt\\pi)=1$. This certifies that the effective envelope is asymptotically consistent — feeding `ratioR→1` into `betaDiag_eq` recovers the parent's `betaDiag_isEquivalent`.",
+    "mathContext": "$ratioR\\,n\\to1$ as $n\\to\\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Tendsto",
+      "stirlingSeq limit",
+      "asymptotic consistency"
+    ],
+    "prerequisites": [
+      "limits of sequences",
+      "filter composition"
+    ]
+  },
+  {
+    "id": "ann-bder-rate",
+    "proofId": "beta-diag-effective-rate",
+    "range": {
+      "startLine": 260,
+      "endLine": 277
+    },
+    "type": "theorem",
+    "title": "betaDiag_lower / betaDiag_upper: the effective rate",
+    "content": "Assembles the final result. Feeding the Part III interval on `ratioR` into the Part II factorisation `betaDiag_eq`, and using that the leading term $\\sqrt{\\pi n}/((2n+1)4^n)$ is nonnegative, `mul_le_mul_of_nonneg_left` yields $(\\sqrt{2\\pi}/e)T_n\\le betaDiag\\,n\\le(e^2/(2\\pi))T_n$ for all $n\\ge1$ — the requested effective two-sided rate with explicit constants.",
+    "mathContext": "$(\\sqrt{2\\pi}/e)T_n\\le betaDiag\\,n\\le(e^2/(2\\pi))T_n$, $T_n=\\sqrt{\\pi n}/((2n+1)4^n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-sided bounds",
+      "monotonic multiplication",
+      "effective estimates"
+    ],
+    "prerequisites": [
+      "Part II factorisation",
+      "Part III bounds"
+    ]
+  }
+]

--- a/src/data/proofs/beta-diag-effective-rate/meta.json
+++ b/src/data/proofs/beta-diag-effective-rate/meta.json
@@ -49,5 +49,94 @@
     "additionalFiles": [
       "Proofs/BetaCentralBinomialAsymptotic.lean"
     ]
-  }
+  },
+  "overview": {
+    "historicalContext": "Stirling's 1730 approximation $n!\\sim\\sqrt{2\\pi n}(n/e)^n$ is usually quoted as a bare asymptotic, but its real utility in analysis comes from the *effective* two-sided bounds that accompany it — Robbins (1955) famously sharpened the error to $e^{1/(12n+1)}<n!/(\\sqrt{2\\pi n}(n/e)^n)<e^{1/(12n)}$. Mathlib formalises the convergence of the Stirling sequence `stirlingSeq n = n!/(\\sqrt{2n}(n/e)^n)\\to\\sqrt\\pi$ together with a genuine lower bound `\\sqrt\\pi\\le stirlingSeq n$ and antitonicity, but does not package the Robbins refinement. The central binomial coefficient $\\binom{2n}{n}$ and the diagonal Euler Beta value $B(n+1,n+1)=1/((2n+1)\\binom{2n}{n})$ inherit their growth from these constants. The parent entry `BetaCentralBinomialAsymptotic` proves only the leading-order equivalence $B(n+1,n+1)\\sim\\sqrt{\\pi n}/((2n+1)4^n)$; its first open question asks to upgrade that $\\sim$ to an honest rate with explicit constants. This entry answers it, turning Mathlib's effective Stirling bounds into a constant-factor envelope valid for every $n\\ge 1$ rather than merely in the limit.",
+    "problemStatement": "Upgrade the asymptotic $B(n+1,n+1)\\sim\\sqrt{\\pi n}/((2n+1)4^n)$ to an explicit two-sided rate valid for all $n\\ge 1$, with effective numerical constants, using only Mathlib's existing `stirlingSeq` bounds and with 0 axioms / 0 sorries.",
+    "proofStrategy": "Factor $B(n+1,n+1)$ as its leading term times an explicit correction `ratioR n = stirlingSeq(n)^2/(\\sqrt\\pi\\,stirlingSeq(2n))` (Part II `betaDiag_eq`), which rests on an exact algebraic identity relating $\\binom{2n}{n}$ to `stirlingSeq` (Part I). Mathlib's lower bound $\\sqrt\\pi\\le stirlingSeq$ and antitonicity upper bound $stirlingSeq\\le stirlingSeq(1)=e/\\sqrt2$ then pin `ratioR` to the interval $[\\sqrt{2\\pi}/e,\\;e^2/(2\\pi)]$ (Part III), and `ratioR\\to1$ recovers the asymptotic (Part IV). Feeding the interval back through `betaDiag_eq` gives the effective two-sided rate (Part V).",
+    "keyInsights": [
+      "The whole rate reduces to controlling one explicit correction factor `ratioR n = stirlingSeq(n)^2/(\\sqrt\\pi\\,stirlingSeq(2n))`, so effective bounds on Mathlib's Stirling sequence transfer directly to the Beta value.",
+      "The exact identity $\\binom{2n}{n}\\cdot\\sqrt n\\cdot stirlingSeq(n)^2 = stirlingSeq(2n)\\cdot 4^n$ (Part I) is pure algebra from the definition of `stirlingSeq`; the $4^n$ arises solely from $(2n/e)^{2n}=4^n((n/e)^n)^2$.",
+      "Two-sidedness needs both directions Mathlib provides: the genuine lower bound $\\sqrt\\pi\\le stirlingSeq$ and the antitonicity upper value $stirlingSeq(1)=e/\\sqrt2$ — the latter extracted via `stirlingSeq'_antitone`.",
+      "Plugging the numerator bound $\\pi\\le stirlingSeq(n)^2\\le e^2/2$ and denominator bound $\\pi\\le\\sqrt\\pi\\,stirlingSeq(2n)\\le\\sqrt\\pi\\cdot e/\\sqrt2$ into `ratioR` yields the clean constants $\\sqrt{2\\pi}/e\\approx0.922$ and $e^2/(2\\pi)\\approx1.176$.",
+      "`ratioR_tendsto_one` (Part IV) shows the envelope is asymptotically consistent: since `stirlingSeq n` and `stirlingSeq(2n)` both tend to $\\sqrt\\pi$, the correction $\\to1$ and `betaDiag_eq` recovers the parent's `betaDiag_isEquivalent`.",
+      "Honest scope: these are constant-factor bounds, not the sharp $1+O(1/n)$ form, which would need the Robbins series Mathlib has not yet formalised — the entry states this limitation explicitly rather than overclaiming."
+    ],
+    "prerequisites": [
+      "Stirling's approximation and effective bounds",
+      "asymptotic analysis",
+      "central binomial coefficients",
+      "Euler Beta function"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: the open question and setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Imports Mathlib and the parent asymptotic entry, and a docstring framing the open question: upgrade `betaDiag_isEquivalent`'s $\\sim$ to an explicit two-sided rate with effective constants. Opens `Real Filter Asymptotics Stirling BetaDiagAsymptotic` and enters `namespace BetaDiagEffectiveRate`, laying out the five-part plan."
+    },
+    {
+      "id": "part1-stirling-identity",
+      "title": "Part I — centralBinom_stirlingSeq: the exact identity",
+      "startLine": 58,
+      "endLine": 123,
+      "summary": "Proves $\\binom{2n}{n}\\cdot\\sqrt n\\cdot stirlingSeq(n)^2 = stirlingSeq(2n)\\cdot4^n$ for $n\\ne0$. Expands both `stirlingSeq` terms by definition, uses $\\sqrt{2(2n)}=2\\sqrt n$ and $(2n/e)^{2n}=4^n((n/e)^n)^2$, rewrites each side as a single fraction, and closes the cross-multiplied goal with a `linear_combination` of the factorial identity and $\\sqrt n^2=n$."
+    },
+    {
+      "id": "part2-ratioR",
+      "title": "Part II — ratioR and betaDiag_eq: explicit factorisation",
+      "startLine": 125,
+      "endLine": 152,
+      "summary": "Defines the correction factor `ratioR n = stirlingSeq(n)^2/(\\sqrt\\pi\\,stirlingSeq(2n))` and proves the exact factored form $betaDiag\\,n = \\sqrt{\\pi n}/((2n+1)4^n)\\cdot ratioR\\,n$ by rewriting through the Part I identity and clearing denominators with `div_eq_div_iff` + `linear_combination`."
+    },
+    {
+      "id": "part3-bounds",
+      "title": "Part III — effective two-sided bounds on ratioR",
+      "startLine": 154,
+      "endLine": 232,
+      "summary": "`stirlingSeq_le` gives the antitonicity upper value $stirlingSeq(n)\\le stirlingSeq(1)=e/\\sqrt2$; combined with Mathlib's $\\sqrt\\pi\\le stirlingSeq$ it yields `ratioR_ge` ($\\sqrt{2\\pi}/e\\le ratioR$) and `ratioR_le` ($ratioR\\le e^2/(2\\pi)$) via `mul_le_mul` bounds on numerator and denominator and `le_div_iff`/`div_le_iff` rearrangements."
+    },
+    {
+      "id": "part4-tendsto-one",
+      "title": "Part IV — ratioR_tendsto_one: recovering the asymptotic",
+      "startLine": 234,
+      "endLine": 254,
+      "summary": "Proves `ratioR n → 1`. Since `stirlingSeq n` and `stirlingSeq(2n)` both tend to $\\sqrt\\pi$ (the second via composition with $n\\mapsto2n$), the quotient tends to $\\sqrt\\pi^2/(\\sqrt\\pi\\cdot\\sqrt\\pi)=1$, confirming the envelope is consistent with `betaDiag_isEquivalent`."
+    },
+    {
+      "id": "part5-effective-rate",
+      "title": "Part V — betaDiag_lower / betaDiag_upper: the rate",
+      "startLine": 256,
+      "endLine": 278,
+      "summary": "Feeds the Part III interval into `betaDiag_eq` to conclude $(\\sqrt{2\\pi}/e)\\sqrt{\\pi n}/((2n+1)4^n)\\le betaDiag\\,n\\le(e^2/(2\\pi))\\sqrt{\\pi n}/((2n+1)4^n)$ for all $n\\ge1$, via `mul_le_mul_of_nonneg_left` on the nonnegative leading term."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent's first open question: it upgrades the leading-order asymptotic $B(n+1,n+1)\\sim\\sqrt{\\pi n}/((2n+1)4^n)$ to an explicit two-sided rate $(\\sqrt{2\\pi}/e)\\sqrt{\\pi n}/((2n+1)4^n)\\le B(n+1,n+1)\\le(e^2/(2\\pi))\\sqrt{\\pi n}/((2n+1)4^n)$ holding for every $n\\ge1$, with numerical constants $\\approx0.922$ and $\\approx1.176$, all at 0 axioms / 0 sorries. The engine is an exact `stirlingSeq`/central-binomial identity plus Mathlib's effective Stirling bounds.",
+    "implications": "The result turns the qualitative concentration of the symmetric Beta density into a fully quantitative, all-$n$ envelope usable in explicit estimates — e.g. bounding tail masses or normalising constants without appealing to a limit. Because the correction factor `ratioR` and the exact identity `centralBinom_stirlingSeq` are proved as standalone lemmas, they are reusable for any effective central-binomial estimate. `ratioR_tendsto_one` guarantees the envelope collapses onto the sharp leading term, so no asymptotic information is lost.",
+    "openQuestions": [
+      "Can the constant-factor envelope be tightened to the sharp $1+O(1/n)$ form once the Robbins refinement of Stirling's series is formalised in Mathlib?",
+      "Do the same `stirlingSeq` bounds yield an effective two-parameter rate for the off-diagonal Beta value $B(m+1,n+1)$?",
+      "Can the explicit constants $\\sqrt{2\\pi}/e$ and $e^2/(2\\pi)$ be replaced by $n$-dependent bounds that shrink toward 1 at a proven rate?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "beta-central-binomial-asymptotic",
+      "relationship": "extends",
+      "description": "Parent entry: proves the leading-order equivalence $B(n+1,n+1)\\sim\\sqrt{\\pi n}/((2n+1)4^n)$ as an `IsEquivalent`. This entry answers its first open question by supplying explicit two-sided constants valid for all $n\\ge1$."
+    },
+    {
+      "targetId": "beta-central-binomial",
+      "relationship": "related",
+      "description": "Root entry establishing the closed form $B(n+1,n+1)=1/((2n+1)\\binom{2n}{n})$ that both the asymptotic and this effective rate build upon."
+    },
+    {
+      "targetId": "beta-central-binomial-explicit-rate",
+      "relationship": "related",
+      "description": "Sibling giving a multiplicative $1+O(1/n)$ correction bracket via a tail bound on the Stirling sequence; complements this entry's constant-factor two-sided envelope."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass: quality 0 → 100.

- **overview**: historical context (Stirling/Robbins effective bounds, Mathlib `stirlingSeq`), problem statement, proof strategy, 6 key insights, prerequisites
- **sections**: 6 line-anchored sections covering Parts I–V of the 278-line file
- **annotations**: 6 annotations, each with mathContext, significance, relatedConcepts, prerequisites
- **conclusion**: summary, implications, 3 open questions
- **crossReferences**: parent `beta-central-binomial-asymptotic` + root + explicit-rate sibling

No Lean changes; gallery data only.