### PR TITLE
research(erdos-744): eliminate chromaticNumber axiom via intrinsic definition [2→1 axioms]

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -36,13 +36,32 @@ structure SimpleGraph' (V : Type*) where
   sym : ∀ u v, Adj u v → Adj v u
   loopless : ∀ v, ¬Adj v v
 
-/-- The chromatic number of a graph (axiomatized).
-    The chromatic number χ(G) is the minimum number of colors needed
-    to properly color the vertices of G. -/
-axiom chromaticNumber {V : Type*} (G : SimpleGraph' V) : ℕ
+/-- The chromatic number of a graph, defined intrinsically (no axiom).
+
+    `χ(G)` is the least number of colors `k` admitting a *proper* coloring
+    `c : V → Fin k` — one in which adjacent vertices receive distinct colors.
+    Over a finite vertex type the coloring set is nonempty (the injective
+    coloring by `Fintype.equivFin` uses `Fintype.card V` colors and is proper),
+    so this infimum is genuinely attained and `chromaticNumber_le_card` below
+    records the bound. -/
+noncomputable def chromaticNumber {V : Type*} [Fintype V] (G : SimpleGraph' V) : ℕ :=
+  sInf { k | ∃ c : V → Fin k, ∀ u v, G.Adj u v → c u ≠ c v }
+
+/-- A proper coloring with `Fintype.card V` colors always exists (color each
+    vertex by its index under `Fintype.equivFin`; distinct indices for distinct
+    vertices, and adjacency forbids equal vertices via `loopless`). Hence the
+    chromatic number is well-defined and bounded by the number of vertices. -/
+theorem chromaticNumber_le_card {V : Type*} [Fintype V] (G : SimpleGraph' V) :
+    chromaticNumber G ≤ Fintype.card V := by
+  apply Nat.sInf_le
+  refine ⟨fun x => Fintype.equivFin V x, ?_⟩
+  intro u v hadj hc
+  have huv : u = v := (Fintype.equivFin V).injective hc
+  subst huv
+  exact G.loopless u hadj
 
 /-- A graph is k-chromatic if its chromatic number is exactly k. -/
-def isKChromatic {V : Type*} (G : SimpleGraph' V) (k : ℕ) : Prop :=
+def isKChromatic {V : Type*} [Fintype V] (G : SimpleGraph' V) (k : ℕ) : Prop :=
   chromaticNumber G = k
 
 /--
@@ -55,7 +74,7 @@ A graph G is k-chromatic critical if:
 Critical graphs are the "minimal" examples requiring k colors.
 Every k-chromatic graph contains a k-critical subgraph.
 -/
-def isCritical {V : Type*} (G : SimpleGraph' V) : Prop :=
+def isCritical {V : Type*} [Fintype V] (G : SimpleGraph' V) : Prop :=
   ∀ u v, G.Adj u v →
     chromaticNumber ⟨fun a b => G.Adj a b ∧ ¬(a = u ∧ b = v ∨ a = v ∧ b = u),
       fun _ _ h => ⟨G.sym _ _ h.1, fun hor => h.2 (Or.symm (Or.imp And.symm And.symm hor))⟩,
@@ -74,7 +93,7 @@ independent sets. Equivalently, it is 2-colorable.
 -/
 
 /-- A graph is bipartite if it has a 2-coloring (χ(G) ≤ 2). -/
-def isBipartite {V : Type*} (G : SimpleGraph' V) : Prop :=
+def isBipartite {V : Type*} [Fintype V] (G : SimpleGraph' V) : Prop :=
   chromaticNumber G ≤ 2
 
 /-

--- a/src/data/proofs/erdos-744/annotations.json
+++ b/src/data/proofs/erdos-744/annotations.json
@@ -32,7 +32,7 @@
     },
     "type": "definition",
     "title": "Graph and Chromatic Number Definitions",
-    "content": "**SimpleGraph'** defines a graph with three properties:\n1. An adjacency relation Adj : V → V → Prop\n2. Symmetry: if u ~ v then v ~ u\n3. No self-loops: ¬(v ~ v)\n\n**chromaticNumber** is axiomatized as a function from graphs to ℕ. The chromatic number χ(G) is the minimum k such that G has a proper k-coloring.\n\n**isKChromatic** G k means χ(G) = k exactly.",
+    "content": "**SimpleGraph'** defines a graph with three properties:\n1. An adjacency relation Adj : V → V → Prop\n2. Symmetry: if u ~ v then v ~ u\n3. No self-loops: ¬(v ~ v)\n\n**chromaticNumber** is defined intrinsically (no axiom) as the least k such that G admits a proper coloring c : V → Fin k, i.e. sInf over the set of admissible color counts. Over a finite vertex type this is attained — chromaticNumber_le_card colors by Fintype.equivFin to bound χ(G) ≤ |V| — so the infimum is a genuine minimum.\n\n**isKChromatic** G k means χ(G) = k exactly.",
     "mathContext": "We use a custom SimpleGraph' rather than Mathlib's SimpleGraph to have full control over the edge deletion definitions needed for criticality.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -41,7 +41,8 @@
     ],
     "originalContributions": [
       "SimpleGraph' structure with adjacency predicate",
-      "chromaticNumber axiom for graph coloring",
+      "chromaticNumber: intrinsic definition (least number of colors admitting a proper coloring c : V -> Fin k), replacing the former axiom",
+      "chromaticNumber_le_card theorem: proper coloring by Fintype.equivFin shows chi(G) <= |V|, so the intrinsic chromatic number is well-defined",
       "isKChromatic and isCritical definitions for critical graphs",
       "isBipartite definition via chromatic number",
       "bipartite_iff_no_odd_cycle (König characterization): discussed in docstrings, not formalized as axiom",
@@ -57,17 +58,17 @@
       "f_k_formula theorem: general formula via Rödl-Tuza",
       "erdos_744_statement theorem: combined main result"
     ],
-    "axiomCount": 2,
-    "lineCount": 388,
-    "assumptions": "2 axioms: chromaticNumber, rodl_tuza_theorem. 0 sorries.",
-    "theoremCount": 10,
-    "definitionCount": 11
+    "axiomCount": 1,
+    "lineCount": 407,
+    "assumptions": "1 axiom: rodl_tuza_theorem (the deep Rödl–Tuza 1985 result, stated as an assumption since a full formalization of the extremal argument is out of scope). The chromatic number is now defined intrinsically (least number of colors admitting a proper coloring) rather than axiomatized, and is proved well-defined by chromaticNumber_le_card. 0 sorries.",
+    "theoremCount": 11,
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "Erdős Problem #744 originates from a question posed by Erdős, Hajnal, and Szemerédi in the early 1980s (references [Er81] and [EHS82]). The problem concerns a fundamental question about the structure of k-chromatic critical graphs: how many edges must be removed to make such a graph bipartite? The function f_k(n) measures the minimum number of edge deletions needed across all k-critical graphs on n vertices.\n\nThe case k = 3 is trivial: the only 3-critical graphs are odd cycles, and removing any single edge yields a path (which is bipartite), so f_3(n) = 1. For k ≥ 4, early results were encouraging for the conjecture. Gallai (1968) established that f_4(n) ≤ O(√n), and Lovász extended this to f_k(n) ≤ O(n^{1-1/(k-2)}) for general k. Erdős and collaborators conjectured that f_k(n) → ∞ as n → ∞, and specifically asked whether f_4(n) grows at least as fast as log(n).\n\nIn a surprising turn, Rödl and Tuza disproved the conjecture entirely in 1985. They showed that for every fixed k ≥ 3, the function f_k(n) is eventually constant: f_k(n) = C(k-1, 2) = (k-1)(k-2)/2 for all sufficiently large n. This means the non-bipartiteness of large k-critical graphs is concentrated in a bounded substructure, regardless of the total graph size.",
     "problemStatement": "Let $f_k(n)$ be the minimum number of edges whose deletion makes a $k$-chromatic critical graph on $n$ vertices bipartite.\n\nDoes $f_k(n) \\to \\infty$ as $n \\to \\infty$?\n\n**Answer:** NO.\n\n**Rödl-Tuza Theorem (1985):** For all $k \\geq 3$ and sufficiently large $n$:\n$$f_k(n) = \\binom{k-1}{2} = \\frac{(k-1)(k-2)}{2}$$\n\nThe function is eventually constant, not unbounded.",
     "text": "Does f_k(n) tend to infinity, where f_k(n) is the minimum edges to delete from a k-chromatic critical graph on n vertices to make it bipartite? Disproved by Rödl and Tuza (1985): f_k(n) = C(k-1,2) for large n.",
-    "proofStrategy": "The formalization proceeds in ten parts:\n\n1. **Graph foundations:** We define SimpleGraph' with an adjacency predicate and axiomatize the chromatic number.\n\n2. **Critical graphs:** A graph is k-critical if χ(G) = k and removing any edge reduces the chromatic number. This captures the notion of \"minimal\" k-colorable graphs.\n\n3. **Bipartite characterization:** Bipartite graphs are defined as those with χ(G) ≤ 2, with an axiom connecting this to the absence of odd cycles.\n\n4. **The f_k function:** We define f_k(n) using the known values from Rödl-Tuza, which gives f_k(n) = (k-1)(k-2)/2 for k ≥ 4.\n\n5. **Disproof:** We state the original conjecture formally, axiomatize the Rödl-Tuza theorem, and derive that the conjecture is false. We also show specific instances like f_4 = 3 and f_5 = 6.",
+    "proofStrategy": "The formalization proceeds in ten parts:\n\n1. **Graph foundations:** We define SimpleGraph' with an adjacency predicate and define the chromatic number intrinsically as the least number of colors admitting a proper coloring (chromaticNumber_le_card proves it is attained, so no axiom is needed).\n\n2. **Critical graphs:** A graph is k-critical if χ(G) = k and removing any edge reduces the chromatic number. This captures the notion of \"minimal\" k-colorable graphs.\n\n3. **Bipartite characterization:** Bipartite graphs are defined as those with χ(G) ≤ 2, with an axiom connecting this to the absence of odd cycles.\n\n4. **The f_k function:** We define f_k(n) using the known values from Rödl-Tuza, which gives f_k(n) = (k-1)(k-2)/2 for k ≥ 4.\n\n5. **Disproof:** We state the original conjecture formally, take the Rödl-Tuza theorem as the single remaining axiom, and derive that the conjecture is false. We also show specific instances like f_4 = 3 and f_5 = 6.",
     "keyInsights": [
       "**Critical Graph Structure:** A k-critical graph is one requiring exactly k colors, where every proper subgraph needs fewer. These are the 'minimal' examples of k-colorability.",
       "**Odd Cycle Case (k=3):** The only 3-critical graphs are odd cycles. Removing one edge gives a path (bipartite), so f_3(n) = 1 — trivially bounded.",
@@ -184,10 +185,10 @@
       "Finset"
     ],
     "namespace": "Erdos744",
-    "lineCount": 388,
-    "axiomCount": 2,
-    "theoremCount": 10,
-    "definitionCount": 11,
+    "lineCount": 407,
+    "axiomCount": 1,
+    "theoremCount": 11,
+    "definitionCount": 12,
     "path": "Proofs/Erdos744Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Erdős Problem #744 (critical graphs → bipartiteness; disproved by Rödl–Tuza 1985). This session performs **axiom elimination**: the file's `chromaticNumber` was an opaque `axiom chromaticNumber : SimpleGraph' V → ℕ` that asserted no mathematical content. It is replaced with a genuine intrinsic definition.

## Changes

- **`chromaticNumber` axiom → definition.** Now `sInf { k | ∃ c : V → Fin k, ∀ u v, G.Adj u v → c u ≠ c v }` — the least number of colors admitting a proper coloring, over `[Fintype V]`.
- **New `chromaticNumber_le_card` theorem.** A proper coloring by `Fintype.equivFin` uses `|V|` colors (adjacency forbids equal vertices via `loopless`), so `χ(G) ≤ |V|` — the infimum is attained and the definition is well-defined.
- The dependent predicates `isBipartite` / `isKChromatic` / `isCritical` gain a `[Fintype V]` instance and become genuinely meaningful (were statements about an arbitrary function).

## Honesty / scope

The remaining axiom `rodl_tuza_theorem` is **kept as an axiom** on purpose: it records the deep Rödl–Tuza extremal result, whose full formalization is out of scope. Converting it to a tautological `theorem` (it is provable from the definitional `f`) would merely hide the assumption inside `def f` — assumption-smuggling. The entry therefore stays `status: axiomatized`, `badge: axiom`, now `axiomCount: 1`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos744Problem` → **Build succeeded (3060 jobs)**, 0 sorries, 1 axiom.
- Gallery meta + annotations updated: axiomCount 2→1, theoremCount 10→11, definitionCount 11→12, lineCount 388→407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)