### PR TITLE
Enrich: Wallis/Stirling Asymptotics of the Diagonal Beta Value

### DIFF
--- a/src/data/proofs/beta-central-binomial-asymptotic/annotations.json
+++ b/src/data/proofs/beta-central-binomial-asymptotic/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-centralbinom-cast",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": { "startLine": 50, "endLine": 62 },
+    "type": "definition",
+    "title": "The Central Binomial as a Factorial Quotient",
+    "content": "centralBinom_cast establishes the exact real identity C(2n,n) = (2n)!/(n!·n!). It proves the natural-number version C(2n,n)·(n!·n!) = (2n)! from Mathlib's Nat.choose_mul_factorial_mul_factorial (after rewriting 2n − n = n) and casts to ℝ via eq_div_iff. This factorial form is the bridge that lets Mathlib's Stirling factorial equivalence be applied to each factorial appearing in the central binomial.",
+    "mathContext": "$C(2n,n) = \\dfrac{(2n)!}{n!\\,n!}$",
+    "significance": "supporting",
+    "relatedConcepts": ["central binomial coefficient", "factorial", "binomial coefficients"],
+    "prerequisites": ["Nat.choose_mul_factorial_mul_factorial", "casting between ℕ and ℝ"]
+  },
+  {
+    "id": "ann-wallis-ratio",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": { "startLine": 64, "endLine": 88 },
+    "type": "technique",
+    "title": "The Wallis Ratio Identity — Source of the 4ⁿ",
+    "content": "stirling_ratio_identity is the algebraic heart of the file. For m, e > 0 it shows the ratio of the Stirling expressions for (2k)! and (k!)² collapses exactly to 4ᵏ/√(πm). The two key reductions are √(2·2m·π) = 2√(πm) and (2m/e)^(2k) = 4ᵏ·((m/e)ᵏ)²; the latter is the ONLY place the 4ᵏ arises, coming from 2^(2k) = 4ᵏ. A linear_combination of the two square-root self-products closes the goal. Isolating this identity keeps the asymptotic proof pure transport.",
+    "mathContext": "$\\dfrac{\\sqrt{2(2m)\\pi}\\,(2m/e)^{2k}}{\\big(\\sqrt{2m\\pi}\\,(m/e)^k\\big)^2} = \\dfrac{4^k}{\\sqrt{\\pi m}}$",
+    "significance": "key",
+    "relatedConcepts": ["Wallis product", "Stirling's approximation", "exact algebraic identities"],
+    "prerequisites": ["field arithmetic", "linear_combination tactic", "square roots"]
+  },
+  {
+    "id": "ann-centralbinom-equiv",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": { "startLine": 90, "endLine": 112 },
+    "type": "insight",
+    "title": "The Central Binomial Asymptotic",
+    "content": "centralBinom_isEquivalent derives C(2n,n) ~ 4ⁿ/√(πn), a result absent from Mathlib. It composes Stirling.factorial_isEquivalent_stirling with the tendsto map n ↦ 2n to get the (2n)! equivalence, divides by the product Stirling·Stirling for (n!·n!), rewrites the central binomial in factorial form, and applies the Wallis ratio identity pointwise for n ≥ 1. Asymptotic equivalence being a congruence for quotients and composition is what makes this an algebraic transport rather than an ε-argument.",
+    "mathContext": "$C(2n,n) \\sim_{\\,n\\to\\infty} \\dfrac{4^n}{\\sqrt{\\pi n}}$",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic equivalence", "Stirling's approximation", "central binomial coefficient"],
+    "prerequisites": ["Asymptotics.IsEquivalent", "Filter.Tendsto", "factorial_isEquivalent_stirling"]
+  },
+  {
+    "id": "ann-betadiag-def",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": { "startLine": 114, "endLine": 116 },
+    "type": "definition",
+    "title": "The Diagonal Beta Value",
+    "content": "betaDiag n = 1/((2n+1)·C(2n,n)) is the real diagonal Euler Beta value B(n+1,n+1), inherited as a closed form from the parent entry. It is the total (unrescaled) mass of the symmetric Beta density t^n(1-t)^n on [0,1], and the object whose decay the file quantifies.",
+    "mathContext": "$\\mathrm{betaDiag}(n) = B(n+1,n+1) = \\dfrac{1}{(2n+1)\\,C(2n,n)}$",
+    "significance": "context",
+    "relatedConcepts": ["Euler Beta function", "central binomial coefficient", "symmetric Beta density"],
+    "prerequisites": ["Euler Beta integral", "binomial coefficients"]
+  },
+  {
+    "id": "ann-betadiag-equiv",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": { "startLine": 118, "endLine": 136 },
+    "type": "insight",
+    "title": "The Diagonal Beta Value Asymptotic",
+    "content": "betaDiag_isEquivalent proves B(n+1,n+1) ~ √(πn)/((2n+1)·4ⁿ). It inverts the central binomial equivalence, multiplies by the refl-equivalence of the (2n+1)⁻¹ factor (which is asymptotic to itself), and rewrites the quotient (2n+1)⁻¹·(4ⁿ/√(πn))⁻¹ into the target leading term. This is the Wallis-rate mass collapse: the density's total mass decays like √π·2^(−2n−1)·n^(−1/2).",
+    "mathContext": "$B(n+1,n+1) \\sim_{\\,n\\to\\infty} \\dfrac{\\sqrt{\\pi n}}{(2n+1)\\,4^n}$",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic equivalence", "Beta function decay", "Gaussian concentration"],
+    "prerequisites": ["IsEquivalent.inv", "IsEquivalent.mul", "asymptotic congruence"]
+  },
+  {
+    "id": "ann-complex-beta",
+    "proofId": "beta-central-binomial-asymptotic",
+    "range": { "startLine": 138, "endLine": 145 },
+    "type": "context",
+    "title": "Anchoring to the Complex Euler Beta Integral",
+    "content": "betaIntegral_diag_eq proves Complex.betaIntegral (n+1) (n+1) = (betaDiag n : ℂ) using the parent lemma betaIntegral_diag_centralBinom. This certifies that the real sequence analysed throughout is literally the value of Mathlib's complex Euler Beta integral on the diagonal, so the asymptotic is a genuine statement about B(n+1,n+1) rather than an ad-hoc surrogate sequence.",
+    "mathContext": "$\\mathrm{betaIntegral}(n+1,\\,n+1) = (\\mathrm{betaDiag}(n) : \\mathbb{C})$",
+    "significance": "context",
+    "relatedConcepts": ["complex Beta integral", "Euler Beta function", "analytic continuation"],
+    "prerequisites": ["Complex.betaIntegral", "casting ℝ to ℂ"]
+  }
+]

--- a/src/data/proofs/beta-central-binomial-asymptotic/meta.json
+++ b/src/data/proofs/beta-central-binomial-asymptotic/meta.json
@@ -35,6 +35,65 @@
     ]
   },
   "sorries": 0,
+  "overview": {
+    "historicalContext": "The central binomial coefficient C(2n,n) is one of the oldest objects in combinatorial analysis, and its growth rate 4ⁿ/√(πn) is a direct descendant of John Wallis's 1656 infinite product π/2 = ∏ (2k)²/((2k-1)(2k+1)) from Arithmetica Infinitorum — the first appearance of π as a limit of rational quantities. The factorial scale in the estimate comes from the Stirling–de Moivre approximation n! ~ √(2πn)(n/e)ⁿ established around 1730: de Moivre found the √n shape while investigating the normal approximation to the binomial distribution, and James Stirling identified the constant √(2π). It is exactly the central binomial coefficient that appears in de Moivre's central term of the binomial, so the appearance of √(πn) here is the same √(2π) that certifies the de Moivre–Laplace central limit theorem. The Euler Beta function B(x,y) = ∫₀¹ t^{x-1}(1-t)^{y-1} dt, introduced by Euler in the 1730s, has diagonal values B(n+1,n+1) equal to the total mass of the symmetric Beta density t^n(1-t)^n; this entry shows that mass collapses at the Wallis rate √(πn)·4⁻ⁿ/(2n+1), the quantitative form of the classical fact that the rescaled symmetric Beta density converges to a Gaussian. Mathlib ships the Stirling equivalence and the central binomial coefficient but states neither the central binomial asymptotic nor any Beta asymptotic; both are assembled here from Stirling.factorial_isEquivalent_stirling.",
+    "problemStatement": "Let $C(2n,n)$ be the central binomial coefficient and $B(n+1,n+1) = \\mathrm{betaDiag}(n) = 1/((2n+1)\\,C(2n,n))$ the diagonal Euler Beta value. Prove the asymptotic equivalences $C(2n,n) \\sim 4^n/\\sqrt{\\pi n}$ and $B(n+1,n+1) \\sim \\sqrt{\\pi n}/((2n+1)\\,4^n)$ as $n \\to \\infty$, in the sense of Asymptotics.IsEquivalent, and identify $\\mathrm{betaDiag}(n)$ with the real value of the complex Euler Beta integral on the diagonal.",
+    "proofStrategy": "The central binomial coefficient is first written exactly as C(2n,n) = (2n)!/(n!·n!) (centralBinom_cast). The engine is a pure-algebra Wallis ratio identity (stirling_ratio_identity) showing that the ratio of the Stirling expressions for (2k)! and (k!)² collapses to 4ᵏ/√(πm) — the single place the 4ᵏ arises, from (2m/e)^{2k}/(m/e)^{2k} = 2^{2k} = 4ᵏ. Composing Mathlib's Stirling equivalence with n ↦ 2n and forming the quotient (centralBinom_isEquivalent) transports this to C(2n,n) ~ 4ⁿ/√(πn). Taking reciprocals and multiplying by the refl-equivalence of the (2n+1)⁻¹ factor (betaDiag_isEquivalent) yields the Beta asymptotic. A final identity (betaIntegral_diag_eq) shows betaDiag n is literally the real value of Complex.betaIntegral on the diagonal, so the asymptotic is a statement about the Euler Beta integral itself.",
+    "keyInsights": [
+      "The 4ⁿ in the central binomial asymptotic is not put in by hand but emerges from a single algebraic collapse: $(2m/e)^{2k}/(m/e)^{2k} = 2^{2k} = 4^k$, isolated in stirling_ratio_identity so the rest of the proof is transport of equivalences.",
+      "Asymptotic equivalence is a congruence for products, quotients and composition, so the whole argument is assembled by algebra on ~: compose Stirling with n ↦ 2n, divide by Stirling·Stirling, and the central binomial estimate falls out without touching a single ε.",
+      "The $\\sqrt{\\pi n}$ that governs the decay is the same $\\sqrt{2\\pi}$ of the de Moivre–Laplace central limit theorem — the central binomial coefficient is de Moivre's central term, so the Beta mass collapse and the Gaussian limit are two faces of one estimate.",
+      "The diagonal Beta value's decay $\\sqrt{\\pi n}\\,4^{-n}/(2n+1) \\approx \\sqrt\\pi\\,2^{-2n-1}\\,n^{-1/2}$ quantifies the concentration of the symmetric Beta$(n+1,n+1)$ density: as $n$ grows the density spikes at $t = 1/2$ and its total unrescaled mass vanishes at the Wallis rate.",
+      "betaIntegral_diag_eq anchors the whole analysis to Mathlib's complex Euler Beta integral, so the real sequence studied here is not a toy surrogate but the genuine value of B(n+1,n+1) as an integral — the asymptotic is about the Beta function proper."
+    ]
+  },
+  "sections": [
+    {
+      "id": "factorial-form",
+      "title": "The Central Binomial as a Factorial Quotient",
+      "startLine": 50,
+      "endLine": 63,
+      "summary": "centralBinom_cast records the exact real identity C(2n,n) = (2n)!/(n!·n!), proved from Mathlib's Nat.choose_mul_factorial_mul_factorial after rewriting 2n − n = n. This factorial form is what lets the Stirling equivalence be applied term by term."
+    },
+    {
+      "id": "wallis-ratio-identity",
+      "title": "The Core Wallis Ratio Identity",
+      "startLine": 64,
+      "endLine": 89,
+      "summary": "stirling_ratio_identity is the algebraic heart: for m, e > 0 the ratio of the Stirling expressions for (2k)! and (k!)² collapses exactly to 4ᵏ/√(πm). It pins down √(2·2m·π) = 2√(πm) and (2m/e)^{2k} = 4ᵏ·((m/e)ᵏ)² — the sole origin of the 4ᵏ — and finishes with a linear_combination of the two square-root self-products."
+    },
+    {
+      "id": "central-binomial-asymptotic",
+      "title": "The Central Binomial Asymptotic",
+      "startLine": 90,
+      "endLine": 113,
+      "summary": "centralBinom_isEquivalent derives C(2n,n) ~ 4ⁿ/√(πn) by composing Mathlib's factorial_isEquivalent_stirling with n ↦ 2n, dividing by Stirling·Stirling, rewriting the central binomial in factorial form, and applying the Wallis ratio identity pointwise for large n. This estimate is absent from Mathlib."
+    },
+    {
+      "id": "beta-value-asymptotic",
+      "title": "The Diagonal Beta Value and Its Asymptotic",
+      "startLine": 114,
+      "endLine": 137,
+      "summary": "Defines betaDiag n = 1/((2n+1)·C(2n,n)) and proves betaDiag_isEquivalent: B(n+1,n+1) ~ √(πn)/((2n+1)·4ⁿ). The argument inverts the central binomial equivalence, multiplies by the refl-equivalence of the (2n+1)⁻¹ factor, and rewrites the resulting quotient into the target leading term."
+    },
+    {
+      "id": "complex-beta-integral",
+      "title": "Connection to the Complex Euler Beta Integral",
+      "startLine": 138,
+      "endLine": 147,
+      "summary": "betaIntegral_diag_eq proves Complex.betaIntegral (n+1) (n+1) = (betaDiag n : ℂ) via the parent's betaIntegral_diag_centralBinom, so the real sequence analysed here is literally the value of the Euler Beta integral on the diagonal — the asymptotic therefore describes Complex.betaIntegral itself."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry supplies two asymptotics that Mathlib omits: the central binomial estimate C(2n,n) ~ 4ⁿ/√(πn) and the diagonal Euler Beta decay B(n+1,n+1) ~ √(πn)/((2n+1)·4ⁿ). Both are assembled from Mathlib's Stirling equivalence n! ~ √(2πn)(n/e)ⁿ by a single pure-algebra Wallis ratio identity that isolates the 4ⁿ, followed by congruence transport of asymptotic equivalence through composition, quotient and reciprocal. A closing identity ties betaDiag n to the value of the complex Euler Beta integral on the diagonal, so the decay is genuinely a statement about B(n+1,n+1). The whole development is machine-checked with 0 axioms and 0 sorries.",
+    "implications": "The central binomial asymptotic is a workhorse estimate underlying Catalan-number growth, random-walk return probabilities, and the de Moivre–Laplace central limit theorem, so having it as a reusable Lean lemma unlocks quantitative versions of all of these inside the gallery. The Beta decay quantifies the concentration of the symmetric Beta density toward a point mass at 1/2, the analytic shadow of Gaussian concentration. The entry also seeds a family of refinements: the sibling effective-rate entry pins the correction to a constant-factor envelope [√(2π)/e, e²/(2π)], and the explicit-rate entry sharpens it to the honest 1 + O(1/n) form via a telescoped Stirling tail bound.",
+    "openQuestions": [
+      "Can the bare equivalence be upgraded to an effective two-sided rate with explicit constants valid for all n? (Answered affirmatively in the sibling entry beta-diag-effective-rate.)",
+      "Can the correction be sharpened to a 1 + O(1/n) Landau statement with an explicit constant? (Answered in beta-central-binomial-explicit-rate.)",
+      "Do the analogous asymptotics for the off-diagonal Beta values B(a n+1, b n+1) with a ≠ b admit the same Wallis-ratio treatment?",
+      "Would the central binomial asymptotic proved here be a suitable candidate for upstreaming into Mathlib alongside factorial_isEquivalent_stirling?"
+    ]
+  },
   "leanFile": {
     "path": "Proofs/BetaCentralBinomialAsymptotic.lean",
     "lineCount": 147,


### PR DESCRIPTION
Enrichment pass for `beta-central-binomial-asymptotic` (quality 0 → 100).

## Added
- **overview**: historicalContext (Wallis 1656 product, de Moivre–Laplace / Stirling constant, Euler Beta density concentration), problemStatement, proofStrategy, 5 keyInsights.
- **sections**: 5 sections covering the full 147-line file (factorial form, Wallis ratio identity, central binomial asymptotic, Beta value asymptotic, complex Beta integral link).
- **conclusion**: summary, implications (Catalan/random-walk/CLT reuse + sibling refinements), 4 openQuestions.
- **annotations.json**: 6 annotations with mathContext (LaTeX), significance, relatedConcepts, prerequisites, anchored to centralBinom_cast, stirling_ratio_identity, centralBinom_isEquivalent, betaDiag, betaDiag_isEquivalent, betaIntegral_diag_eq.

Content only (meta.json + annotations.json). 0 axioms, 0 sorries preserved; status/badge unchanged.