### PR TITLE
Enrich The p-adic Obstruction to Euler's Identity

### DIFF
--- a/src/data/proofs/euler-identity-oq-02/annotations.json
+++ b/src/data/proofs/euler-identity-oq-02/annotations.json
@@ -1,1 +1,137 @@
-[]
+[
+  {
+    "id": "ann-eioq02-docstring",
+    "proofId": "euler-identity-oq-02",
+    "range": {
+      "startLine": 4,
+      "endLine": 65
+    },
+    "type": "concept",
+    "title": "Why there is no p-adic Euler identity",
+    "content": "Frames the parent open question — is Euler's identity $e^{\\pi i}=-1$ a theorem in the $p$-adic setting? — and answers no. The three ingredients $\\exp$, $i$, $\\pi$ fail to coexist over $\\mathbb{Q}_p$: there is no $p$-adic period ($\\exp$ is injective on its convergence disk), the $p$-adic $\\exp$ converges only on $p\\mathbb{Z}_p$ (odd $p$) and isn't even in Mathlib, and its range $1+p\\mathbb{Z}_p$ misses $-1$. This file formalises ingredient (3), the algebraic obstruction, plus the surviving residue-level $\\sqrt{-1}$.",
+    "mathContext": "$\\exp(p\\mathbb{Z}_p)\\subseteq 1+p\\mathbb{Z}_p$ and $-1\\notin 1+p\\mathbb{Z}_p$ for odd $p$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Euler's identity",
+      "p-adic exponential",
+      "principal units",
+      "p-adic period"
+    ],
+    "prerequisites": [
+      "p-adic analysis",
+      "Euler's formula"
+    ]
+  },
+  {
+    "id": "ann-eioq02-norm-neg-two",
+    "proofId": "euler-identity-oq-02",
+    "range": {
+      "startLine": 72,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "padicInt_norm_neg_two: −2 is a p-adic unit",
+    "content": "For an odd prime $p$, $\\lVert(-2:\\mathbb{Z}_p)\\rVert=1$. Since $p$ and $2$ are distinct primes, $p\\nmid 2$ (`Nat.prime_dvd_prime_iff_eq`), so after casting $-2$ from $\\mathbb{Z}$ the norm is not $<1$ (`PadicInt.norm_int_lt_one_iff_dvd`); combined with `PadicInt.norm_le_one`, `le_antisymm` gives exactly $1$. This single unit fact drives the whole obstruction.",
+    "mathContext": "$p\\ne 2\\implies \\lVert(-2:\\mathbb{Z}_p)\\rVert=1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "p-adic norm",
+      "units of ℤ_p",
+      "PadicInt.norm_int_lt_one_iff_dvd",
+      "distinct primes"
+    ],
+    "prerequisites": [
+      "p-adic integer norm",
+      "divisibility of primes"
+    ]
+  },
+  {
+    "id": "ann-eioq02-far-from-one",
+    "proofId": "euler-identity-oq-02",
+    "range": {
+      "startLine": 86,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "neg_one_sub_one_norm_eq_one: −1 sits far from 1",
+    "content": "For odd $p$, $\\lVert(-1:\\mathbb{Z}_p)-1\\rVert=1$. Immediate by rewriting $(-1)-1=-2$ and invoking `padicInt_norm_neg_two`. Geometrically, $-1$ lies at the maximal possible distance $1$ from $1$ in $\\mathbb{Z}_p$ — it is as far as possible from being a principal unit.",
+    "mathContext": "$\\lVert(-1:\\mathbb{Z}_p)-1\\rVert=1$ for odd $p$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ultrametric distance",
+      "principal units",
+      "p-adic norm"
+    ],
+    "prerequisites": [
+      "padicInt_norm_neg_two"
+    ]
+  },
+  {
+    "id": "ann-eioq02-obstruction",
+    "proofId": "euler-identity-oq-02",
+    "range": {
+      "startLine": 94,
+      "endLine": 106
+    },
+    "type": "theorem",
+    "title": "neg_one_not_principal_unit: the algebraic obstruction",
+    "content": "For odd $p$ and any $x$ in the maximal ideal $p\\mathbb{Z}_p$, $1+x\\ne -1$. Assuming $1+x=-1$ forces $x=-2$ (`linear_combination`); but $x\\in\\mathfrak{m}$ means $\\lVert x\\rVert<1$ (`PadicInt.mem_nonunits`), contradicting $\\lVert -2\\rVert=1$. This is the crux: the principal units $1+p\\mathbb{Z}_p$ — the target of the convergent $p$-adic $\\exp$ — never contain $-1$, so $\\exp(x)=-1$ is unsolvable.",
+    "mathContext": "$\\forall x\\in\\mathfrak{m}_{\\mathbb{Z}_p},\\ 1+x\\ne -1$ (odd $p$).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "maximal ideal",
+      "principal units",
+      "nonunits",
+      "proof by contradiction"
+    ],
+    "prerequisites": [
+      "local ring maximal ideal",
+      "p-adic norm of units"
+    ]
+  },
+  {
+    "id": "ann-eioq02-sharpness",
+    "proofId": "euler-identity-oq-02",
+    "range": {
+      "startLine": 108,
+      "endLine": 122
+    },
+    "type": "theorem",
+    "title": "neg_two_mem_maximalIdeal_iff: sharpness at p = 2",
+    "content": "Proves $-2\\in\\mathfrak{m}_{\\mathbb{Z}_p}\\iff p=2$, showing the odd-prime hypothesis of the obstruction is sharp. At $p=2$, $-2$ is a nonunit so $-1=1+(-2)$ *is* a principal unit and this level of the argument collapses — though the 2-adic $\\exp$ converges only on $4\\mathbb{Z}_2$ and still misses $-1$ by a finer argument the entry flags but does not need.",
+    "mathContext": "$(-2:\\mathbb{Z}_p)\\in\\mathfrak{m}\\iff p=2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sharpness of hypotheses",
+      "2-adic exceptional case",
+      "maximal ideal membership"
+    ],
+    "prerequisites": [
+      "padicInt_norm_neg_two",
+      "prime divisibility"
+    ]
+  },
+  {
+    "id": "ann-eioq02-surviving-i",
+    "proofId": "euler-identity-oq-02",
+    "range": {
+      "startLine": 124,
+      "endLine": 131
+    },
+    "type": "theorem",
+    "title": "padic_i_exists_residue_iff: the surviving √(−1)",
+    "content": "Records the one ingredient of Euler's identity that survives $p$-adically at the residue level: $\\sqrt{-1}$ exists in $\\mathbb{Z}/p$ iff $p\\bmod 4\\ne 3$, delivered directly by `ZMod.exists_sq_eq_neg_one_iff`. This is the residue-field shadow of when $i\\in\\mathbb{Q}_p$; for odd $p$ the residue root lifts to $\\mathbb{Q}_p$ by Hensel's lemma. It is the classical $p\\equiv 1\\bmod 4$ criterion behind Fermat's two-squares theorem.",
+    "mathContext": "$\\mathrm{IsSquare}(-1:\\mathbb{Z}/p)\\iff p\\bmod 4\\ne 3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic residues",
+      "Hensel's lemma",
+      "√(−1) mod p",
+      "two-squares theorem"
+    ],
+    "prerequisites": [
+      "quadratic residues mod p",
+      "ZMod API"
+    ]
+  }
+]

--- a/src/data/proofs/euler-identity-oq-02/meta.json
+++ b/src/data/proofs/euler-identity-oq-02/meta.json
@@ -41,5 +41,89 @@
     "imports": [
       "import Mathlib"
     ]
-  }
+  },
+  "overview": {
+    "historicalContext": "Euler's identity $e^{\\pi i}+1=0$ is the flagship consequence of Euler's formula $e^{ix}=\\cos x+i\\sin x$ over $\\mathbb{C}$, tying together $e$, $i$ and $\\pi$. Asking whether it survives in the $p$-adic world is a natural extension question, and the answer is a clean no — for reasons that expose how differently analysis behaves over $\\mathbb{Q}_p$. The $p$-adic exponential, studied since the early twentieth century (Mahler, and the standard references of Koblitz and Robert), converges only on the tiny disk $v_p(x)>1/(p-1)$ — exactly the maximal ideal $p\\mathbb{Z}_p$ for odd $p$ — and there it is *injective*, so there is no period and no $p$-adic $\\pi$. Worse, its image lands in the principal units $1+p\\mathbb{Z}_p$, and $-1$ simply is not there. Mathlib has no $p$-adic exponential file at all, so the honest formal content is the algebraic obstruction: $-1\\notin 1+p\\mathbb{Z}_p$ for odd $p$, together with the one surviving ingredient — a residue-level $\\sqrt{-1}$ existing in $\\mathbb{Z}/p$ exactly when $p\\not\\equiv 3\\ (\\mathrm{mod}\\ 4)$, the classical criterion behind Fermat's two-squares theorem. Everything here is machine-checked with 0 axioms and 0 sorries.",
+    "problemStatement": "Record the precise, machine-checked reason there is no $p$-adic Euler identity: formalise that for an odd prime $p$ no principal unit of $\\mathbb{Z}_p$ equals $-1$ (so a convergent $p$-adic $\\exp$, whose range is $1+p\\mathbb{Z}_p$, can never equal $-1$), pin the sharpness of the odd-prime hypothesis at $p=2$, and record the surviving residue-level $\\sqrt{-1}$ criterion $p\\bmod 4\\ne 3$.",
+    "proofStrategy": "The whole obstruction reduces to a single norm computation: $-1-1=-2$ is a $p$-adic *unit* for odd $p$ ($p\\nmid 2$), so $\\lVert -2\\rVert=1$ (`padicInt_norm_neg_two`), hence $-1$ sits at maximal distance $1$ from $1$ (`neg_one_sub_one_norm_eq_one`). Any principal unit $1+x$ with $x$ in the maximal ideal has $\\lVert x\\rVert<1$; equating $1+x=-1$ forces $x=-2$ with $\\lVert x\\rVert=1$, a contradiction (`neg_one_not_principal_unit`). Sharpness at $p=2$ comes from $-2\\in\\mathfrak{m}\\iff p=2$, and the surviving $i$ is `ZMod.exists_sq_eq_neg_one_iff`.",
+    "keyInsights": [
+      "There is no $p$-adic Euler identity because the three ingredients — $\\exp$, $i$, $\\pi$ — do not coexist over $\\mathbb{Q}_p$: no period ($\\pi$), a barely-convergent $\\exp$, and a range that misses $-1$.",
+      "The entire algebraic obstruction is one norm fact: for odd $p$, $-2$ is a unit, so $\\lVert(-1)-1\\rVert=1$ and $-1$ lies at maximal distance from $1$.",
+      "The convergent $p$-adic exponential maps $p\\mathbb{Z}_p$ into the principal units $1+p\\mathbb{Z}_p$ (elements $\\equiv 1\\bmod p$); since $-1\\not\\equiv 1\\bmod p$ for odd $p$, $\\exp(x)=-1$ is unsolvable.",
+      "The odd-prime hypothesis is sharp: $-2\\in\\mathfrak{m}_{\\mathbb{Z}_p}\\iff p=2$, so at $p=2$ the obstruction fails at this level (though the 2-adic $\\exp$ still misses $-1$ for a finer reason).",
+      "One ingredient survives at the residue level: $\\sqrt{-1}$ exists in $\\mathbb{Z}/p$ iff $p\\not\\equiv 3\\bmod 4$ (`ZMod.exists_sq_eq_neg_one_iff`), the residue shadow of when $i\\in\\mathbb{Q}_p$ via Hensel lifting.",
+      "The entry is scrupulous about scope: it formalises the purely algebraic statement $-1\\notin 1+p\\mathbb{Z}_p$ and flags that the bridge to '$\\exp$ never equals $-1$' is prose, because Mathlib has no $p$-adic $\\exp$ to state it against."
+    ],
+    "prerequisites": [
+      "p-adic integers and their norm",
+      "local rings and maximal ideals",
+      "p-adic exponential (convergence disk)",
+      "quadratic residues mod p"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: the question and the obstruction, framed",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Imports Mathlib and a detailed docstring: states the parent open question (is there a $p$-adic Euler identity?), answers no, and lays out the three failing ingredients (no $\\pi$; barely-convergent $\\exp$; range misses $-1$). Lists the five theorems proved and an explicit honesty note that the $\\exp$-to-principal-units bridge is prose, not a Lean theorem."
+    },
+    {
+      "id": "norm-neg-two",
+      "title": "padicInt_norm_neg_two: −2 is a p-adic unit",
+      "startLine": 68,
+      "endLine": 84,
+      "summary": "For odd $p$, $\\lVert(-2:\\mathbb{Z}_p)\\rVert=1$. Shows $p\\nmid 2$ via `Nat.prime_dvd_prime_iff_eq`, casts $-2$ from $\\mathbb{Z}$, and combines `PadicInt.norm_int_lt_one_iff_dvd` (norm not $<1$) with `PadicInt.norm_le_one` to force equality $1$."
+    },
+    {
+      "id": "norm-neg-one-sub-one",
+      "title": "neg_one_sub_one_norm_eq_one: −1 is far from 1",
+      "startLine": 86,
+      "endLine": 92,
+      "summary": "For odd $p$, $\\lVert(-1:\\mathbb{Z}_p)-1\\rVert=1$. Immediate from $(-1)-1=-2$ and the previous lemma — $-1$ sits at maximal distance from $1$, the geometric heart of the obstruction."
+    },
+    {
+      "id": "obstruction",
+      "title": "neg_one_not_principal_unit: the obstruction",
+      "startLine": 94,
+      "endLine": 106,
+      "summary": "For odd $p$ and any $x$ in the maximal ideal, $1+x\\ne -1$. Assuming equality forces $x=-2$; but $x\\in\\mathfrak{m}$ gives $\\lVert x\\rVert<1$ while $\\lVert -2\\rVert=1$, a contradiction. This is the algebraic core: the principal units $1+p\\mathbb{Z}_p$ — the range of the convergent $p$-adic $\\exp$ — never contain $-1$."
+    },
+    {
+      "id": "sharpness",
+      "title": "neg_two_mem_maximalIdeal_iff: sharpness at p = 2",
+      "startLine": 108,
+      "endLine": 122,
+      "summary": "$-2\\in\\mathfrak{m}_{\\mathbb{Z}_p}\\iff p=2$, proving the odd-prime hypothesis is sharp: at $p=2$, $-1$ *is* a principal unit and this level of the obstruction disappears (a finer 2-adic argument, on $4\\mathbb{Z}_2$, is noted but not needed)."
+    },
+    {
+      "id": "surviving-i",
+      "title": "padic_i_exists_residue_iff: the surviving √(−1)",
+      "startLine": 124,
+      "endLine": 131,
+      "summary": "Records the one ingredient that survives: $\\sqrt{-1}$ exists in the residue field $\\mathbb{Z}/p$ iff $p\\bmod 4\\ne 3$, directly via `ZMod.exists_sq_eq_neg_one_iff` — the residue-field shadow of $i\\in\\mathbb{Q}_p$, liftable by Hensel's lemma for odd $p$."
+    }
+  ],
+  "conclusion": {
+    "summary": "There is no $p$-adic Euler identity, and this entry records the precise machine-checked reason (0 axioms, 0 sorries): for an odd prime $p$, $-1$ is not a principal unit (`neg_one_not_principal_unit`), because $-2$ is a $p$-adic unit (`padicInt_norm_neg_two`, `neg_one_sub_one_norm_eq_one`). Since a convergent $p$-adic $\\exp$ maps into $1+p\\mathbb{Z}_p$, it can never equal $-1$. Sharpness at $p=2$ and the surviving residue-level $\\sqrt{-1}$ criterion $p\\bmod 4\\ne 3$ are also recorded.",
+    "implications": "The result crisply explains why a beloved complex identity has no $p$-adic analogue, isolating the failure in a single norm computation rather than any deep analytic fact. It also honestly scopes what formalisation can claim when Mathlib lacks a $p$-adic $\\exp$: the algebraic membership statement is proved, the analytic bridge is prose. The reusable takeaway is that principal-unit membership $(1+p\\mathbb{Z}_p)$ is the right target group for any $p$-adic exponential-image question.",
+    "openQuestions": [
+      "Once a $p$-adic exponential is formalised in Mathlib, can the prose bridge ($\\exp$ maps $p\\mathbb{Z}_p$ into $1+p\\mathbb{Z}_p$) be turned into a Lean theorem, making 'no $p$-adic Euler identity' fully machine-checked?",
+      "Can the finer $p=2$ argument (2-adic $\\exp$ converges only on $4\\mathbb{Z}_2$ and still misses $-1$) be formalised to close the sharp case?",
+      "Does the surviving residue $\\sqrt{-1}$ lift explicitly via Hensel's lemma to an $i\\in\\mathbb{Q}_p$, and can that construction be recorded alongside this obstruction?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-identity",
+      "relationship": "extends",
+      "description": "The complex Euler identity $e^{\\pi i}+1=0$. This entry is the parent open question's answer in the $p$-adic setting: the identity does not survive, and the obstruction is recorded algebraically."
+    },
+    {
+      "targetId": "euler-identity-oq-01",
+      "relationship": "related",
+      "description": "Sibling open-question entry in the Euler-identity family; this one isolates the $p$-adic principal-unit obstruction."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass: quality 0 → 100.

- **overview**: historical context (p-adic exp convergence disk, principal units, Fermat two-squares criterion), problem statement, proof strategy, 6 key insights, prerequisites
- **sections**: 6 line-anchored sections covering the 132-line file
- **annotations**: 6 annotations, each with mathContext, significance, relatedConcepts, prerequisites
- **conclusion**: summary, implications, 3 open questions
- **crossReferences**: `euler-identity`, `euler-identity-oq-01`

No Lean changes; gallery data only.