### PR TITLE
audit: re-apply #35142 gallery-integrity fixes reverted by stale-base PR #35145

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -313,10 +313,16 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     if (i === 0) mainSorryCount = fileSorryCount
     axiomCount += (content.match(/^(?:(?:private|noncomputable)\s+)*axiom /gm) || []).length
 
-    // True stubs: only count theorem/lemma declarations, not example (Issue #6130)
+    // True stubs: only count theorem/lemma declarations, not example (Issue #6130).
+    // A genuine True stub proves `True` as its *entire* conclusion (`: True :=`,
+    // `: True := by ...`, or bare `: True`). Do NOT flag declarations where `True`
+    // is merely part of a larger proposition, e.g. the Aristotle answer idiom
+    // `answer : True ↔ ∃ x, P x := by ...` (real content is the RHS existential) or
+    // helper lemmas like `True ↔ True`. Requiring the type to terminate at `True`
+    // (followed by `:=` or end-of-line) removes a recurring erdos-741 false positive.
     for (const line of content.split('\n')) {
       const trimmed = line.trim()
-      if (/^(theorem|lemma)\b/.test(trimmed) && /(:= trivial\b|: True\b)/.test(trimmed)) {
+      if (/^(theorem|lemma)\b/.test(trimmed) && /(:=\s*trivial\b|:\s*True\s*(?::=|$))/.test(trimmed)) {
         trueStubCount++
       }
     }

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -21,7 +21,7 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-437/meta.json
+++ b/src/data/proofs/erdos-437/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 437,
     "erdosUrl": "https://erdosproblems.com/437",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Summary

Research PR #35145 (erdos-214, commit `5ed1fed`) was built off a base branch predating the gallery-integrity fixes in **#35142** (`66afaed`). Its merge reverted **all three** of those fixes, reintroducing:

- ❌ **CRITICAL** false positive on `erdos-741` ("1 True stubs but status is verified")
- ❌ `erdos-437` sorry mismatch (claims 0, actual 1)
- ❌ `erdos-125` sorry mismatch (claims 1, actual chain 2)

`npx tsx scripts/auditor/find-targets.ts --stats` was again reporting **1 critical / 3 with issues**.

## Fix

Re-applies #35142 verbatim, ground truth re-confirmed at HEAD `78150eda376`:

- **`find-targets.ts`** — restore the tightened True-stub regex `/(:=\s*trivial\b|:\s*True\s*(?::=|$))/`. The loose `: True\b` re-flagged erdos-741's Aristotle helper `answer_true_iff : True ↔ True` (real content on the RHS ↔) as a True stub. erdos-741 is genuinely verified (0 sorries, 0 axioms).
- **`erdos-437/meta.json`** — `meta.sorries` 0 → 1. `Erdos437Problem.lean` carries a real sorry (line 216); `leanFile.sorries` and top-level `sorries` already read 1.
- **`erdos-125/meta.json`** — `meta.sorries` 1 → 2 (chain-aggregate: main 0 + PositiveLowerDensity port 1 + Aristotle scaffold 1). badge=wip/axiomatized, honest.

## Verification

Post-fix: `find-targets.ts --stats` reports **0 issues / 0 critical**.

---
Discovered during gallery integrity audit. Root cause: a research PR merged from a stale base silently reverted merged auditor fixes to shared files (`find-targets.ts`, gallery meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)