### PR TITLE
Enrich Antipodal Parity Refinement of the Sperner Door-Counting Engine

### DIFF
--- a/src/data/proofs/sperner-mathlib-oq-03/annotations.json
+++ b/src/data/proofs/sperner-mathlib-oq-03/annotations.json
@@ -1,1 +1,138 @@
-[]
+[
+  {
+    "id": "ann-smoq03-docstring",
+    "proofId": "sperner-mathlib-oq-03",
+    "range": {
+      "startLine": 9,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "The Tucker frontier of the door-counting engine",
+    "content": "Locates the file relative to the parent `sperner-mathlib`, which proves the master identity $\\#\\text{panchromatic}\\equiv\\#\\text{boundary doors}\\pmod2$. Sperner forces a witness from an *odd* boundary count; Tucker's lemma concerns the antipodally symmetric setting. The natural question — does the same engine yield Tucker from antipodal symmetry? — is answered no: the antipodal map is a fixed-point-free involution on boundary doors, so the raw count is even. The docstring is honest that this is parity *infrastructure*, not a Tucker proof.",
+    "mathContext": "Antipodal symmetry $\\Rightarrow$ even boundary-door count $\\Rightarrow$ even panchromatic count, never the odd seed Tucker needs.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Sperner's lemma",
+      "Tucker's lemma",
+      "Borsuk–Ulam",
+      "door-counting parity"
+    ],
+    "prerequisites": [
+      "Sperner door-counting",
+      "antipodal symmetry"
+    ]
+  },
+  {
+    "id": "ann-smoq03-boundarydoors",
+    "proofId": "sperner-mathlib-oq-03",
+    "range": {
+      "startLine": 66,
+      "endLine": 72
+    },
+    "type": "definition",
+    "title": "boundaryDoors: the parity-governing finset",
+    "content": "Defines `boundaryDoors` as the finset of door facets $(s,k)$ that are genuine doors (`IsDoor vertex c`) with no adjacent cell (`adj p.1 p.2 = none`). This is precisely the object whose cardinality parity controls the panchromatic count in the parent's `sperner_parity`, so all antipodal reasoning happens on this finset — purely combinatorially, with no triangulation or geometry.",
+    "mathContext": "$\\text{boundaryDoors}=\\{(s,k):\\ \\text{IsDoor}\\wedge\\ \\text{adj}(s,k)=\\text{none}\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "boundary doors",
+      "door facets",
+      "adjacency",
+      "Finset.filter"
+    ],
+    "prerequisites": [
+      "cell-complex abstraction",
+      "IsDoor predicate"
+    ]
+  },
+  {
+    "id": "ann-smoq03-even-boundary",
+    "proofId": "sperner-mathlib-oq-03",
+    "range": {
+      "startLine": 74,
+      "endLine": 87
+    },
+    "type": "theorem",
+    "title": "even_card_boundary_doors_of_antipodal: even boundary count",
+    "content": "If the boundary doors carry a fixed-point-free involution `neg` (each door maps to a distinct boundary door, `neg (neg p)=p`, `neg p ≠ p`), then their number is even. This is a direct specialisation of the parent's reusable `Sperner.even_card_fpf_invol` — whose docstring already advertises 'Tucker's lemma, Borsuk–Ulam' — to the antipodal boundary map. The fixed-point-freeness is what pairs the doors up.",
+    "mathContext": "fixed-point-free involution on boundaryDoors $\\Rightarrow$ $\\text{Even}\\ |\\text{boundaryDoors}|$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "fixed-point-free involution",
+      "even_card_fpf_invol",
+      "pairing argument",
+      "parity"
+    ],
+    "prerequisites": [
+      "involutions on finsets",
+      "boundaryDoors"
+    ]
+  },
+  {
+    "id": "ann-smoq03-even-panchromatic",
+    "proofId": "sperner-mathlib-oq-03",
+    "range": {
+      "startLine": 89,
+      "endLine": 118
+    },
+    "type": "theorem",
+    "title": "even_card_panchromatic_of_antipodal: the main theorem",
+    "content": "Under the same adjacency hypotheses as `sperner_parity`, an antipodal (fixed-point-free involutive) boundary forces an *even* panchromatic count. Proof chains `even_card_boundary_doors_of_antipodal` with the master identity `sperner_parity`: after rewriting `boundaryDoors` to its defining filter and passing to `Nat.even_iff`, the mod-2 identity transports the even boundary count to the panchromatic count. This is the antipodal analogue of Sperner's lemma — even where Sperner is odd.",
+    "mathContext": "antipodal boundary $\\Rightarrow$ $\\text{Even}\\ |\\{s:\\text{IsPanchromatic}\\}|$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sperner_parity master identity",
+      "Nat.even_iff",
+      "panchromatic cells",
+      "mod-2 counting"
+    ],
+    "prerequisites": [
+      "even boundary count",
+      "the parent parity identity"
+    ]
+  },
+  {
+    "id": "ann-smoq03-not-odd",
+    "proofId": "sperner-mathlib-oq-03",
+    "range": {
+      "startLine": 120,
+      "endLine": 142
+    },
+    "type": "theorem",
+    "title": "not_odd_panchromatic_of_antipodal: the obstruction stated",
+    "content": "The payoff corollary: since the antipodal panchromatic count is even, it is never odd (`Nat.not_odd_iff_even.mpr`). Hence the odd-boundary hypothesis of `Sperner.exists_panchromatic` is unreachable from the raw antipodal boundary alone — the naive door-count route to Tucker is ruled out, and the odd seed must be imported from a finer object.",
+    "mathContext": "$\\neg\\ \\text{Odd}\\ |\\{s:\\text{IsPanchromatic}\\}|$ under antipodal symmetry.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.not_odd_iff_even",
+      "exists_panchromatic hypothesis",
+      "obstruction",
+      "Tucker's odd seed"
+    ],
+    "prerequisites": [
+      "the main even-count theorem"
+    ]
+  },
+  {
+    "id": "ann-smoq03-nonvacuity",
+    "proofId": "sperner-mathlib-oq-03",
+    "range": {
+      "startLine": 144,
+      "endLine": 152
+    },
+    "type": "insight",
+    "title": "Non-vacuity: the engine actually fires",
+    "content": "A concrete check that the parity core is not vacuous: the two-element door set $\\{(\\text{true},0),(\\text{false},0)\\}$, swapped by the involution $(b,k)\\mapsto(!b,k)$, has even cardinality 2 by the very same `even_card_fpf_invol` mechanism the main theorem uses, with all three obligations closed by `decide`. Together with the `#print axioms` audit (foundational axioms only), it certifies the result is real and clean.",
+    "mathContext": "$|\\{(\\text{true},0),(\\text{false},0)\\}|=2$ is even via the antipodal swap.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked example",
+      "decide tactic",
+      "non-vacuity",
+      "axiom audit"
+    ],
+    "prerequisites": [
+      "even_card_fpf_invol"
+    ]
+  }
+]

--- a/src/data/proofs/sperner-mathlib-oq-03/meta.json
+++ b/src/data/proofs/sperner-mathlib-oq-03/meta.json
@@ -50,5 +50,89 @@
     "additionalFiles": [
       "Proofs/SpernerMathlib.lean"
     ]
-  }
+  },
+  "overview": {
+    "historicalContext": "Sperner's lemma (1928) — every proper 'Sperner colouring' of a triangulated simplex has an odd number of panchromatic (rainbow) cells — is the combinatorial heart of Brouwer's fixed-point theorem. Its antipodal cousin is Tucker's lemma (1945), the combinatorial engine behind the Borsuk–Ulam theorem: an antipodally symmetric labelling of a triangulated $n$-ball must contain a complementary edge. Both are usually proved by the same 'door-counting' idea — count facets shared between cells modulo 2 — but the parities they need are opposite in character: Sperner wants an *odd* boundary count to force a witness, while the antipodal symmetry Tucker supplies makes counts *even*. The parent entry `sperner-mathlib` formalises the master door-counting identity $\\#\\{\\text{panchromatic}\\}\\equiv\\#\\{\\text{boundary doors}\\}\\pmod 2$. This entry addresses the recurring question of whether that same engine yields Tucker by simply feeding in the antipodal map. The answer, made precise here at the abstract cell-complex level, is that it cannot: the antipodal map is a fixed-point-free involution on boundary doors, so the raw boundary count is even and can never be the odd seed Tucker requires. The odd parity must be imported from a finer object — the lower-dimensional Tucker instance or an oriented sign rule.",
+    "problemStatement": "At the abstract, geometry-free cell-complex level of the `sperner-mathlib` door-counting engine, determine whether antipodal symmetry alone can produce Tucker's required odd parity — and if not, isolate the exact obstruction, with 0 sorries and no non-foundational axioms.",
+    "proofStrategy": "Model the antipodal map abstractly as a fixed-point-free involution `neg` on the finset of boundary doors (each door maps to a distinct door and `neg (neg p) = p`). Feed this straight into the parent's reusable `Sperner.even_card_fpf_invol` to get that the boundary-door count is even (`even_card_boundary_doors_of_antipodal`). Combine with the master identity `sperner_parity` (via `Nat.even_iff`) to conclude the panchromatic count is even (`even_card_panchromatic_of_antipodal`), and therefore never odd (`not_odd_panchromatic_of_antipodal` through `Nat.not_odd_iff_even`). A concrete two-door example certifies the engine is non-vacuous.",
+    "keyInsights": [
+      "The antipodal map is a fixed-point-free involution on boundary doors: a door and its antipode are always *distinct* boundary doors, which is exactly the input `even_card_fpf_invol` needs.",
+      "A fixed-point-free involution pairs up its domain, so the raw antipodal boundary-door count is always even — the structural fact that dooms the naive route.",
+      "Sperner and Tucker need opposite parities: Sperner's *odd* boundary count forces an *odd* (hence positive) panchromatic count, whereas the antipodal boundary forces an *even* one, which cannot on its own force a witness.",
+      "Chaining the even boundary count through the parent's master identity `sperner_parity` (mod-2) yields an even panchromatic count, so the hypothesis of `exists_panchromatic` (odd count) is unreachable from the raw antipodal boundary.",
+      "The obstruction is dimension-free and engine-level: previously seen only for the $n=2$ hexagon by a 64-case `decide`, it is here established abstractly with no triangulation data.",
+      "It sharpens the remaining open input for a door-counting Tucker proof: the odd seed must come from a finer object — the lower-dimensional Tucker instance, or the *oriented* sign door rule whose antipode acts by transpose rather than by pairing."
+    ],
+    "prerequisites": [
+      "Sperner's lemma and door-counting",
+      "fixed-point-free involutions and parity",
+      "Tucker's lemma / Borsuk–Ulam",
+      "Finset cardinality mod 2"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: where this sits and what it proves",
+      "startLine": 1,
+      "endLine": 57,
+      "summary": "License header, imports of Mathlib and the parent `SpernerMathlib`, and a docstring locating the file at the 'Tucker frontier': the parent's master identity $\\#\\text{panchromatic}\\equiv\\#\\text{boundary doors}\\pmod2$, the question of deriving Tucker by feeding antipodal symmetry, the three results proved, and an honest-status note (parity infrastructure, not a Tucker proof; foundational axioms only)."
+    },
+    {
+      "id": "boundary-doors-def",
+      "title": "boundaryDoors: the finset whose parity governs everything",
+      "startLine": 59,
+      "endLine": 72,
+      "summary": "Opens `Finset Sperner`, fixes the abstract cell-complex variables, and defines `boundaryDoors` — door facets $(s,k)$ that are genuine doors with no adjacent cell (`adj = none`). This is exactly the finset whose parity governs the panchromatic count in `sperner_parity`."
+    },
+    {
+      "id": "even-boundary",
+      "title": "even_card_boundary_doors_of_antipodal: the boundary count is even",
+      "startLine": 74,
+      "endLine": 87,
+      "summary": "If the boundary doors carry a fixed-point-free involution `neg` (the abstract antipodal map: `neg (neg p)=p`, `neg p` a boundary door, `neg p ≠ p`), their count is even. A direct specialisation of the parent's `Sperner.even_card_fpf_invol`."
+    },
+    {
+      "id": "even-panchromatic",
+      "title": "even_card_panchromatic_of_antipodal: the main theorem",
+      "startLine": 89,
+      "endLine": 118,
+      "summary": "Under the same adjacency hypotheses as `sperner_parity`, an antipodal (fixed-point-free involutive) boundary forces an *even* panchromatic count. Chains `even_card_boundary_doors_of_antipodal` through the master identity via `Nat.even_iff` — the antipodal analogue of Sperner's odd-count lemma."
+    },
+    {
+      "id": "not-odd",
+      "title": "not_odd_panchromatic_of_antipodal: the obstruction",
+      "startLine": 120,
+      "endLine": 142,
+      "summary": "Corollary: since the antipodal panchromatic count is even, it is never odd, so the odd-boundary hypothesis of `exists_panchromatic` is unreachable from the raw antipodal boundary. The odd seed Tucker needs must come from a finer object. Proof: `Nat.not_odd_iff_even.mpr` of the main theorem."
+    },
+    {
+      "id": "nonvacuity",
+      "title": "Non-vacuity example and axiom audit",
+      "startLine": 144,
+      "endLine": 163,
+      "summary": "A concrete two-element door set $\\{(\\text{true},0),(\\text{false},0)\\}$ swapped by $(b,k)\\mapsto(!b,k)$ certifies the even count 2 by the same `even_card_fpf_invol` mechanism, proving the engine is not vacuous. `#check`/`#print axioms` confirm only foundational axioms (no `sorryAx`, no `Lean.ofReduceBool`)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry isolates, abstractly and dimension-free, why the `sperner-mathlib` door-counting engine cannot deliver Tucker's lemma from raw antipodal symmetry: the antipodal map is a fixed-point-free involution on boundary doors, so the boundary count is even (`even_card_boundary_doors_of_antipodal`), the panchromatic count is even (`even_card_panchromatic_of_antipodal`), and hence never odd (`not_odd_panchromatic_of_antipodal`). Self-contained, 0 sorries, foundational axioms only.",
+    "implications": "The result rules out the naive door-count route to Tucker and pins the obstruction precisely: the odd parity Tucker requires must be imported from a finer object — the lower-dimensional Tucker instance, or the oriented sign door rule of `sperner-mathlib4-oq-02-oq-07`, whose antipode acts by transpose rather than by pairing. It thereby sharpens exactly what the remaining open geometric input for a door-counting Tucker proof has to be, and packages a reusable parity layer (even counts from antipodal involutions) on the shared engine.",
+    "openQuestions": [
+      "Can the odd seed be supplied by the oriented *sign* door rule (antipode acting by transpose), turning this obstruction into an actual door-counting proof of Tucker's lemma?",
+      "Does induction on dimension — importing the lower-dimensional Tucker instance as the odd seed — close the gap left open here?",
+      "Can the abstract fixed-point-free involution be instantiated from genuine triangulation/antipodal geometry, connecting this engine-level statement to a concrete simplicial ball?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sperner-mathlib",
+      "relationship": "extends",
+      "description": "Parent entry: proves the master door-counting identity $\\#\\text{panchromatic}\\equiv\\#\\text{boundary doors}\\pmod2$ and provides `even_card_fpf_invol`. This entry specialises that engine to the antipodal setting."
+    },
+    {
+      "targetId": "sperner-mathlib4-oq-02-oq-07",
+      "relationship": "related",
+      "description": "Sibling developing the *oriented* sign door rule whose antipode acts by transpose rather than by pairing — the finer object from which Tucker's odd parity could be imported."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass: quality 0 → 100.

- **overview**: historical context (Sperner 1928 / Tucker 1945 / Borsuk–Ulam; door-counting parity), problem statement, proof strategy, 6 key insights, prerequisites
- **sections**: 6 line-anchored sections covering the 163-line file
- **annotations**: 6 annotations, each with mathContext, significance, relatedConcepts, prerequisites
- **conclusion**: summary, implications, 3 open questions
- **crossReferences**: `sperner-mathlib`, `sperner-mathlib4-oq-02-oq-07`

No Lean changes; gallery data only.