### PR TITLE
Enrich: Aggregating the Cotangent Sum ∑ 1/(2‖a/q‖) = O(q log q)

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-dist-frac-eq",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 57, "endLine": 92 },
+    "type": "technique",
+    "title": "The Nearest-Integer Distance of a Proper Fraction",
+    "content": "dist_frac_eq is the bridge from the transcendental to the rational world. For 0 < a < q the fraction a/q lies in (0,1), so it rounds either to 0 (when 2a < q) or to 1 (when 2a ≥ q). A two-case split establishes round(a/q) via round_eq and Int.floor_eq_iff, computes the matching min(a,q−a), and takes the absolute value. The result ‖a/q‖ = min(a,q−a)/q makes the summand 1/(2‖a/q‖) the exact rational q/(2·min(a,q−a)).",
+    "mathContext": "$\\left\\|\\dfrac{a}{q}\\right\\| = \\dfrac{\\min(a, q-a)}{q}, \\qquad 0 < a < q$",
+    "significance": "key",
+    "relatedConcepts": ["distance to nearest integer", "rounding", "Diophantine approximation"],
+    "prerequisites": ["round and Int.floor", "absolute value", "rational fractions"]
+  },
+  {
+    "id": "ann-round-cases",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 68, "endLine": 92 },
+    "type": "concept",
+    "title": "The Two-Case Rounding Geometry",
+    "content": "The only place the geometry of the nearest integer enters: when 2a < q the fraction is below 1/2 and rounds down to 0 with distance a/q and min = a; when 2a ≥ q it is at least 1/2 and rounds up to 1 with distance 1 − a/q = (q−a)/q and min = q−a. Each branch discharges round(a/q) with Int.floor_eq_iff and simplifies the absolute value symmetrically.",
+    "mathContext": "$\\mathrm{round}(a/q) = \\begin{cases} 0 & 2a < q \\\\ 1 & 2a \\ge q \\end{cases}$",
+    "significance": "supporting",
+    "relatedConcepts": ["rounding half-up", "floor function", "case analysis"],
+    "prerequisites": ["Int.floor_eq_iff", "round_eq", "linear arithmetic"]
+  },
+  {
+    "id": "ann-termwise-bound",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 106, "endLine": 138 },
+    "type": "technique",
+    "title": "Termwise Reduction to a Sum of Reciprocals",
+    "content": "Step 1 of the majorant. Using dist_frac_eq to rewrite the distance, the summand becomes (q/2)·(1/min(a,q−a)). The key inequality hrecip — 1/min(a,q−a) ≤ 1/a + 1/(q−a) — holds because min is one of the two positive denominators, so its reciprocal is the larger of 1/a and 1/(q−a) and is dominated by their sum (a le_total split with positivity of the discarded term). A calc chain delivers the per-term bound.",
+    "mathContext": "$\\dfrac{1}{2\\|a/q\\|} = \\dfrac{q}{2\\min(a,q-a)} \\le \\dfrac{q}{2}\\left(\\dfrac{1}{a} + \\dfrac{1}{q-a}\\right)$",
+    "significance": "key",
+    "relatedConcepts": ["reciprocal inequalities", "minimum of two terms", "harmonic terms"],
+    "prerequisites": ["monotonicity of reciprocals", "le_total case split", "positivity"]
+  },
+  {
+    "id": "ann-reflection",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 142, "endLine": 156 },
+    "type": "insight",
+    "title": "The Index Reflection a ↦ q − a",
+    "content": "Step 2 and the structural crux. After distributing the sum, the reflection a ↦ q − a is a bijection of Finset.Ico 1 q to itself (proved with Finset.sum_nbij' and omega on membership), under which (q−a)⁻¹ becomes a⁻¹. Hence ∑ 1/(q−a) = ∑ 1/a = H_{q-1}, so both halves of the termwise bound equal the same harmonic number and the leading q/2·(H + H) collapses exactly to q·H_{q-1}.",
+    "mathContext": "$\\sum_{a=1}^{q-1} \\dfrac{1}{q-a} = \\sum_{a=1}^{q-1} \\dfrac{1}{a} = H_{q-1}$",
+    "significance": "key",
+    "relatedConcepts": ["index reflection", "bijective reindexing", "harmonic number"],
+    "prerequisites": ["Finset.sum_nbij'", "harmonic numbers", "Nat.cast_sub"]
+  },
+  {
+    "id": "ann-harmonic-majorant",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 94, "endLine": 156 },
+    "type": "insight",
+    "title": "The Exact Elementary Majorant S(q) ≤ q·H_{q-1}",
+    "content": "cotangent_sum_le_harmonic assembles Steps 1 and 2 into the exact elementary majorant of the cotangent sum: S(q) = ∑_{a=1}^{q-1} 1/(2‖a/q‖) ≤ q·H_{q-1}. This is the precise output of aggregating the parent's per-residue cosecant bound, expressed entirely through the harmonic number with no trigonometry remaining.",
+    "mathContext": "$S(q) = \\sum_{a=1}^{q-1} \\dfrac{1}{2\\|a/q\\|} \\le q\\,H_{q-1}$",
+    "significance": "key",
+    "relatedConcepts": ["cotangent sum", "harmonic number", "Polya-Vinogradov aggregation"],
+    "prerequisites": ["Finset.sum_le_sum", "Finset.mul_sum", "harmonic numbers"]
+  },
+  {
+    "id": "ann-bigO-bound",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 166, "endLine": 188 },
+    "type": "insight",
+    "title": "The Explicit O(q log q) Estimate",
+    "content": "cotangent_sum_bigO turns the harmonic majorant into an explicit closed form. It identifies the real reciprocal sum with Mathlib's harmonic (q−1) via harmonic_eq_sum_Icc, applies the library bound harmonic_le_one_add_log to get H_{q-1} ≤ 1 + log(q−1), and uses monotonicity of log (log(q−1) ≤ log q) to conclude S(q) ≤ q·(1 + log q). This is the O(q log q) estimate that closes the Pólya–Vinogradov character-sum bound.",
+    "mathContext": "$S(q) \\le q\\,(1 + \\log q) = O(q \\log q)$",
+    "significance": "key",
+    "relatedConcepts": ["Euler-Mascheroni asymptotic", "logarithmic bound", "Polya-Vinogradov inequality"],
+    "prerequisites": ["harmonic_le_one_add_log", "Real.log_le_log", "harmonic_eq_sum_Icc"]
+  }
+]

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01/meta.json
@@ -30,6 +30,65 @@
     ]
   },
   "sorries": 0,
+  "overview": {
+    "historicalContext": "The Pólya–Vinogradov inequality, proved independently by George Pólya and Ivan Vinogradov in 1918, bounds an incomplete character sum by |∑_{n≤N} χ(n)| = O(√q log q) for a non-principal Dirichlet character χ mod q. Its classical proof expands χ in additive characters and completes the sum, at which point the geometric-series kernel produces terms 1/|sin(πa/q)|; controlling their aggregate is the analytic core of the estimate. The standard route bounds the cosecant per residue by 1/(2‖a/q‖), where ‖x‖ denotes the distance to the nearest integer — a quantity systematically exploited since Weyl's work on equidistribution and central to the theory of Diophantine approximation. The aggregate ∑_{a=1}^{q-1} 1/(2‖a/q‖) is then a cotangent-type sum whose size is governed by the harmonic number H_{q-1} = ∑ 1/a, and Euler's 1734 estimate H_n = log n + γ + O(1/n) (with γ the Euler–Mascheroni constant) supplies the log q factor. This file lives inside a bounded-prime-gaps development — the circle of ideas around Zhang's 2013 breakthrough and the Maynard–Tao refinements — where Pólya–Vinogradov-type control of character sums feeds the sieve machinery. Its contribution is the elementary aggregation lemma: it converts the per-residue cosecant bound (proved in the parent file) into the explicit majorant q·(1 + log q), reusing Mathlib's harmonic_le_one_add_log so that the entire O(q log q) step is machine-checked from first principles with no trigonometric case analysis.",
+    "problemStatement": "For $q \\ge 2$ let $\\|x\\| = |x - \\mathrm{round}(x)|$ be the distance to the nearest integer and $S(q) = \\sum_{a=1}^{q-1} \\tfrac{1}{2\\|a/q\\|}$ the aggregated cotangent sum. Prove the exact nearest-integer identity $\\|a/q\\| = \\min(a, q-a)/q$ for $0 < a < q$, the elementary majorant $S(q) \\le q\\,H_{q-1}$ where $H_{q-1} = \\sum_{a=1}^{q-1} 1/a$, and the explicit estimate $S(q) \\le q\\,(1 + \\log q) = O(q\\log q)$.",
+    "proofStrategy": "The bridge lemma dist_frac_eq computes the nearest-integer distance of a proper fraction a/q ∈ (0,1) by a two-case split on whether 2a < q (round to 0, distance a/q, min = a) or 2a ≥ q (round to 1, distance (q−a)/q, min = q−a), giving ‖a/q‖ = min(a,q−a)/q exactly. This turns the transcendental summand into the rational q/(2·min(a,q−a)). The majorant cotangent_sum_le_harmonic then runs in two steps: (1) termwise, since min(a,q−a) is one of a or q−a, its reciprocal is at most 1/a + 1/(q−a), so 1/(2‖a/q‖) ≤ (q/2)(1/a + 1/(q−a)); (2) summing, the reflection a ↦ q−a identifies ∑ 1/(q−a) with ∑ 1/a = H_{q-1}, so the two halves each give H_{q-1} and the q/2 doubles back to q·H_{q-1} — no pairing case-analysis needed. Finally cotangent_sum_bigO identifies the real harmonic sum with Mathlib's harmonic (q−1), applies harmonic_le_one_add_log, and monotonicity of log to bound log(q−1) ≤ log q, yielding q·(1 + log q).",
+    "keyInsights": [
+      "The transcendental cosecant summand becomes an exact rational once ‖a/q‖ is computed: $\\|a/q\\| = \\min(a,q-a)/q$, so $1/(2\\|a/q\\|) = q/(2\\min(a,q-a))$ — the entire estimate is thereafter elementary arithmetic on reciprocals.",
+      "The reflection $a \\mapsto q-a$ is the single structural trick: it identifies $\\sum 1/(q-a)$ with $\\sum 1/a$, so both halves of the termwise bound collapse to the same harmonic number $H_{q-1}$ and the leading $q/2$ doubles cleanly to $q$.",
+      "Bounding $1/\\min(a,q-a) \\le 1/a + 1/(q-a)$ instead of pairing terms avoids all case analysis: whichever of $a$ or $q-a$ is the minimum, its reciprocal is the larger summand and is dominated by the sum of both positive reciprocals.",
+      "The harmonic number is the natural size of a cotangent sum: $S(q) \\le q\\,H_{q-1}$ is exact-in-spirit, and Euler's $H_{q-1} = \\log q + O(1)$ (packaged in Mathlib as harmonic_le_one_add_log) is what injects the $\\log q$ into the Pólya–Vinogradov $\\sqrt q\\,\\log q$.",
+      "The two-case round computation ($a/q$ rounds to 0 or 1 according as $2a < q$ or $2a \\ge q$) is the only place the geometry of the nearest integer enters; everything downstream is monotone reciprocal algebra and a bijective reindexing."
+    ]
+  },
+  "sections": [
+    {
+      "id": "elementary-mechanism",
+      "title": "Overview — The Elementary Aggregation Mechanism",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "The header documents how the per-residue cosecant bound 1/|sin(πa/q)| ≤ 1/(2‖a/q‖) from the parent file is aggregated over a = 1,…,q−1 into the cotangent sum S(q), and outlines the elementary route: rewrite ‖a/q‖ as min(a,q−a)/q, bound the reciprocal of the minimum by a sum of reciprocals, and reflect the index set — avoiding all pairing case-analysis and trigonometry."
+    },
+    {
+      "id": "nearest-integer-distance",
+      "title": "The Nearest-Integer Distance Identity",
+      "startLine": 57,
+      "endLine": 93,
+      "summary": "dist_frac_eq proves ‖a/q‖ = min(a,q−a)/q for 0 < a < q. A two-case split on 2a < q versus 2a ≥ q fixes round(a/q) to 0 or 1 respectively (via round_eq and Int.floor_eq_iff), identifies the corresponding min, and computes the absolute value. This converts the transcendental summand into the exact rational q/(2·min(a,q−a))."
+    },
+    {
+      "id": "termwise-reciprocal-bound",
+      "title": "Termwise Bound via the Reciprocal of the Minimum",
+      "startLine": 94,
+      "endLine": 138,
+      "summary": "Step 1 of the majorant: for each a, since min(a,q−a) equals a or q−a, its reciprocal is at most 1/a + 1/(q−a) (hrecip, by le_total case split with positivity of the other term). A short calc then yields 1/(2‖a/q‖) = (q/2)·(1/min) ≤ (q/2)(1/a + 1/(q−a))."
+    },
+    {
+      "id": "summation-and-reflection",
+      "title": "Summation and Index Reflection",
+      "startLine": 139,
+      "endLine": 157,
+      "summary": "Step 2: summing the termwise bound and distributing, the reflection a ↦ q−a (Finset.sum_nbij') shows ∑ 1/(q−a) = ∑ 1/a, so both halves equal H_{q-1}; the q/2·(H + H) collapses to q·H_{q-1}, completing cotangent_sum_le_harmonic."
+    },
+    {
+      "id": "harmonic-to-log",
+      "title": "The O(q log q) Bound via the Harmonic Number",
+      "startLine": 158,
+      "endLine": 190,
+      "summary": "cotangent_sum_bigO identifies the real reciprocal sum with Mathlib's harmonic (q−1) (harmonic_eq_sum_Icc), applies harmonic_le_one_add_log to get H_{q-1} ≤ 1 + log(q−1), and uses monotonicity log(q−1) ≤ log q to conclude S(q) ≤ q·(1 + log q), the explicit O(q log q) estimate closing the aggregation."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry completes the Pólya–Vinogradov aggregation step by proving three linked results with 0 axioms and 0 sorries: the exact nearest-integer identity ‖a/q‖ = min(a,q−a)/q, the elementary majorant S(q) = ∑_{a=1}^{q-1} 1/(2‖a/q‖) ≤ q·H_{q-1}, and the explicit estimate S(q) ≤ q·(1 + log q) = O(q log q). The argument is entirely elementary: the transcendental cosecant summand becomes a rational once the nearest-integer distance is computed, a single reflection a ↦ q−a collapses the two reciprocal sums into the harmonic number, and Mathlib's harmonic_le_one_add_log injects the log q. No trigonometry or pairing case-analysis survives into the aggregation.",
+    "implications": "This lemma supplies the analytic heart of a machine-checked Pólya–Vinogradov inequality: once the aggregated cotangent sum is known to be O(q log q), the completion method yields the character-sum bound |∑_{n≤N} χ(n)| = O(√q log q) that underlies bounds on the least quadratic non-residue and feeds the sieve-theoretic bounded-prime-gaps development around Zhang and Maynard–Tao. The identity ‖a/q‖ = min(a,q−a)/q and the reflection technique are reusable for any cotangent- or cosecant-type sum over reduced residues, and the entry demonstrates that such estimates need not import trigonometric machinery — an exact rational rewrite plus a harmonic-number bound suffices.",
+    "openQuestions": [
+      "Can the majorant be sharpened from q·H_{q-1} to the true asymptotic constant of the cotangent sum, capturing the (2/π²)·q log q leading behaviour known classically?",
+      "Does restricting the sum to residues coprime to q (as needed for primitive characters) admit the same elementary reflection treatment with a φ(q)-weighted harmonic bound?",
+      "Can this aggregation be assembled with the parent per-term cosecant bound into a fully formalised Pólya–Vinogradov inequality inside the gallery?",
+      "Is there an analogous elementary majorant for the higher-moment sums ∑ 1/‖a/q‖^k that appear in refined character-sum estimates?"
+    ]
+  },
   "leanFile": {
     "path": "Proofs/BoundedPrimeGapsOQ04OQ01Incomplete01OQ01.lean",
     "lineCount": 190,


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-04-oq-01-incomplete-01-oq-01` (quality 0 → 100).

## Added
- **overview**: historicalContext (Pólya–Vinogradov 1918, nearest-integer distance / Weyl, Euler harmonic asymptotic H_n = log n + γ, bounded-prime-gaps context), problemStatement, proofStrategy, 5 keyInsights.
- **sections**: 5 sections partitioning the full 190-line file (elementary mechanism, nearest-integer distance identity, termwise reciprocal bound, summation & reflection, harmonic→log bound).
- **conclusion**: summary, implications (feeds Pólya–Vinogradov / sieve machinery), 4 openQuestions.
- **annotations.json**: 6 annotations with mathContext (LaTeX), significance, relatedConcepts, prerequisites, anchored to dist_frac_eq, the round case split, the termwise bound, the a↦q−a reflection, the harmonic majorant, and cotangent_sum_bigO.

Content only (meta.json + annotations.json). 0 axioms, 0 sorries preserved; status/badge unchanged.