### PR TITLE
research(puiseux-theorem-wip-01): general Newton-polygon-edge ramification [0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -251,6 +251,43 @@ theorem puiseux_binomial_ramification (hK : IsAlgClosed K) (n : ℕ+) (c : K) (h
     rw [hexp, ha]
   · rw [HahnSeries.orderTop_single ha0]
 
+/-- **General binomial ramification** — the Newton-polygon edge of arbitrary slope.
+
+For `n : ℕ+`, `m : ℚ`, and `c ≠ 0` over an algebraically closed field, the binomial
+`Yⁿ = c·xᵐ` has a Puiseux root `y` whose leading exponent (`orderTop`) is exactly `m/n`.
+This is the general single-edge statement of Newton–Puiseux: an edge of slope `-m/n`
+contributes a leading term of exponent `m/n`. It unifies the three concrete ramification
+facts already in this file:
+
+* `puiseux_binomial_ramification` — the case `m = 1`, exponent `1/n`;
+* `square_root_puiseux` — the case `n = 2, m = 1`, exponent `1/2`;
+* `cusp_parameterization` — the case `n = 2, m = 3`, exponent `3/2`.
+
+Whenever the reduced denominator of `m/n` exceeds `1` the exponent is genuinely
+fractional, so the root lies outside the Laurent field `K((x))` (integer exponents only)
+— the concrete obstruction to `K((x))` being algebraically closed, now stated for an
+arbitrary Newton-polygon slope rather than a fixed one. The proof is the same direct
+`HahnSeries.single` computation as the special cases, with the general exponent `m/n`
+satisfying `n • (m/n) = m`. -/
+theorem puiseux_binomial_orderTop (hK : IsAlgClosed K) (n : ℕ+) (m : ℚ) (c : K) (hc : c ≠ 0) :
+    ∃ y : HahnSeries ℚ K,
+      IsPuiseuxSeries y ∧
+      y ^ (n : ℕ) = HahnSeries.single m c ∧
+      y.orderTop = (m / (n : ℚ) : ℚ) := by
+  haveI := hK
+  obtain ⟨a, ha⟩ := IsAlgClosed.exists_pow_nat_eq c n.pos
+  have ha0 : a ≠ 0 := by
+    rintro rfl
+    rw [zero_pow n.ne_zero] at ha
+    exact hc ha.symm
+  refine ⟨HahnSeries.single (m / (n : ℚ)) a, isPuiseux_single _ _, ?_, ?_⟩
+  · rw [HahnSeries.single_pow]
+    have hn : (n : ℚ) ≠ 0 := by exact_mod_cast n.ne_zero
+    have hexp : (n : ℕ) • (m / (n : ℚ)) = m := by
+      rw [nsmul_eq_mul, mul_comm, div_mul_cancel₀ _ hn]
+    rw [hexp, ha]
+  · rw [HahnSeries.orderTop_single ha0]
+
 /-- **Binomial polynomial root** — the binomial Puiseux root expressed as an honest
 `Polynomial.IsRoot`.
 

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -6,16 +6,44 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Original goal: replace 5 `True`-stub theorems in `PuiseuxTheorem.lean` (Wiedijk #41)
+with real content. **This goal is already achieved** by predecessor PRs #30441,
+#33067, #33838:
+
+- `square_root_puiseux` (`Y² = x`) and `cusp_parameterization` (`Y² = x³`) now
+  construct actual Hahn-series roots and verify the defining equation.
+- `puiseux_binomial_root` / `puiseux_binomial_ramification` / `puiseux_binomial_isRoot`
+  cover the binomial base case `Yⁿ = c·xᵐ` over an algebraically closed field.
+- The two deepest stubs (`puiseux_theorem`, `puiseux_is_algebraic_closure`, plus
+  `newton_puiseux_terminates`) were removed rather than faked — the file header now
+  honestly states that full algebraic closure of the Puiseux field remains open
+  (the Newton–Puiseux convergence assembly is not in Mathlib).
+
+File state at session start: 603 lines, 0 sorries, 0 axioms, 11 theorems.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- The whole file is powered by one workhorse lemma `isPuiseux_single` (every
+  single-term Hahn series is a Puiseux series, ramification = `m.den`) plus the
+  computation `(single a c)ⁿ = single (n • a) (cⁿ)` via `HahnSeries.single_pow`
+  and `n • (m/n) = m` via `div_mul_cancel₀`.
+- **This session's contribution**: added `puiseux_binomial_orderTop`, the general
+  single-edge Newton–Puiseux statement for an *arbitrary* slope `m/n`. It proves
+  that `Yⁿ = c·xᵐ` (`c ≠ 0`, alg-closed `K`) has a Puiseux root with
+  `orderTop = m/n`. This unifies `puiseux_binomial_ramification` (`m=1`),
+  `square_root_puiseux` (`n=2,m=1`) and `cusp_parameterization` (`n=2,m=3`) as
+  instances of one theorem. Proof is a copy of `puiseux_binomial_ramification`
+  with the general exponent `m/n`; verified 0-sorry/0-axiom.
+- Build gotcha: `docker-build.sh Proofs.PuiseuxTheorem` hit an intermittent
+  `exit code 135` (elaborator stack-overflow, NOT a logic error) on the first
+  attempt; a plain re-run built cleanly. Code 135 ≠ proof failure here.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Full algebraic closure (`IsAlgClosed (PuiseuxField K)`) is not attemptable
+  without the Newton–Puiseux convergence machinery, which is absent from Mathlib
+  v4.26 — this is a >1000-line foundational build, out of scope for a session.

--- a/research/problems/puiseux-theorem-wip-01/state.md
+++ b/research/problems/puiseux-theorem-wip-01/state.md
@@ -1,25 +1,31 @@
 # Research State: puiseux-theorem-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-21T16:44:08+02:00
-**Iteration**: 1
+**Since**: 2026-07-07
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Original deliverable (eliminate the 5 `True`-stubs) was already met by predecessor
+PRs #30441 / #33067 / #33838. This session verified the current file builds clean
+(0 sorry, 0 axiom) and added a genuine generalization.
 
 ## Active Approach
-None yet.
+Added `puiseux_binomial_orderTop`: the general Newton-polygon-edge ramification
+theorem for arbitrary slope `m/n`, unifying the three existing concrete ramification
+results (`puiseux_binomial_ramification`, `square_root_puiseux`, `cusp_parameterization`).
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+Full algebraic closure of the Puiseux field remains open — requires Newton–Puiseux
+convergence machinery not present in Mathlib v4.26. Documented in the file header;
+this is out of scope for a single session (>1000 lines foundational).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — stubs are gone, file verified, generalization added. The remaining open
+direction (full algebraic closure) is tracked as a separate long-horizon effort.

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -172,9 +172,9 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 603,
+    "lineCount": 640,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 2,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Problem `puiseux-theorem-wip-01` asked to replace 5 `True`-stub theorems in
`PuiseuxTheorem.lean` (Wiedijk #41). **Those stubs were already eliminated** by
predecessor PRs #30441, #33067, and #33838 — the file is 0-sorry / 0-axiom and its
header honestly records that full algebraic closure of the Puiseux field remains open.

This session:
1. **Verified** the current file builds clean via `docker-build.sh Proofs.PuiseuxTheorem`
   (0 sorry, 0 axiom; an intermittent exit-135 elaborator crash cleared on re-run).
2. **Added a genuine generalization** — `puiseux_binomial_orderTop`:

   > Over an algebraically closed field `K`, for `n : ℕ+`, `m : ℚ`, `c ≠ 0`, the
   > binomial `Yⁿ = c·xᵐ` has a Puiseux root `y` with `orderTop = m/n`.

   This is the general single-edge Newton–Puiseux statement (slope `-m/n`), and it
   unifies the three concrete ramification results already in the file as instances:
   - `puiseux_binomial_ramification` (`m = 1`, exponent `1/n`)
   - `square_root_puiseux` (`n = 2, m = 1`, exponent `1/2`)
   - `cusp_parameterization` (`n = 2, m = 3`, exponent `3/2`)

## Honest scope

This is a **modest** generalization, not a breakthrough: the proof is the same direct
`HahnSeries.single` computation as the existing special cases, now with the general
exponent `m/n` (`n • (m/n) = m` via `div_mul_cancel₀`). Full algebraic closure of the
Puiseux field (arbitrary polynomials) remains open — the Newton–Puiseux convergence
assembly is not in Mathlib v4.26 — and stays documented as future work.

## Verification
- `docker-build.sh Proofs.PuiseuxTheorem` → **Build succeeded** (3069 jobs), 0 sorry, 0 axiom.
- meta.json updated: `theoremCount` 11→12, `lineCount` 603→640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)