### PR TITLE
Enrich: The LLL Threshold T(d) Strictly Beats the Classical e-Bound

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-02-wip-01/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02-wip-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-threshold-cast",
+    "proofId": "lovasz-local-lemma-oq-02-wip-01",
+    "range": { "startLine": 40, "endLine": 45 },
+    "type": "definition",
+    "title": "The Real Closed Form of the Sharp Threshold",
+    "content": "lllThreshold_cast rewrites the parent entry's rational threshold lllThreshold d as the real closed form T(d) = dᵈ/(d+1)ᵈ⁺¹ for d ≥ 1. It discharges the definitional if_neg branch (d ≠ 0) and closes with push_cast and ring. The cast into ℝ is not cosmetic: the comparison target 1/(e(d+1)) is irrational, so the statement cannot live in ℚ.",
+    "mathContext": "$T(d) = \\dfrac{d^d}{(d+1)^{d+1}} = \\dfrac{1}{d+1}\\left(\\dfrac{d}{d+1}\\right)^d$",
+    "significance": "supporting",
+    "relatedConcepts": ["Lovász Local Lemma", "sharp threshold", "rational-to-real cast"],
+    "prerequisites": ["rational and real casts", "push_cast", "the parent threshold lllThreshold"]
+  },
+  {
+    "id": "ann-one-plus-inv-pow",
+    "proofId": "lovasz-local-lemma-oq-02-wip-01",
+    "range": { "startLine": 47, "endLine": 61 },
+    "type": "insight",
+    "title": "The Single Analytic Ingredient: (1 + 1/d)ᵈ < e",
+    "content": "one_add_inv_pow_lt_exp_one is the sole analytic input. It applies Mathlib's STRICT exponential bound Real.add_one_lt_exp at x = 1/d to get 1 + 1/d < exp(1/d), then raises both positive sides to the d-th power (pow_lt_pow_left₀) and simplifies exp(1/d)ᵈ = exp(d·(1/d)) = exp 1 via Real.exp_nat_mul. This is the classical fact that the sequence approaching e does so strictly from below at every finite d.",
+    "mathContext": "$\\left(1 + \\dfrac{1}{d}\\right)^d < e, \\qquad d \\ge 1$",
+    "significance": "key",
+    "relatedConcepts": ["exponential function", "Euler's number e", "strict monotone convergence"],
+    "prerequisites": ["Real.add_one_lt_exp", "Real.exp_nat_mul", "pow_lt_pow_left₀"]
+  },
+  {
+    "id": "ann-cleared-denominator",
+    "proofId": "lovasz-local-lemma-oq-02-wip-01",
+    "range": { "startLine": 63, "endLine": 76 },
+    "type": "technique",
+    "title": "Clearing the Denominator to (d+1)ᵈ < dᵈ·e",
+    "content": "succ_pow_lt_pow_mul_exp reformulates the previous inequality into the denominator-free (d+1)ᵈ < dᵈ·e. It multiplies (1+1/d)ᵈ < e through by the positive dᵈ and uses the identity (1+1/d)ᵈ·dᵈ = (d+1)ᵈ (from ← mul_pow and one_div_mul_cancel) to absorb the factor. This is the exact algebraic fact the main comparison consumes.",
+    "mathContext": "$(d+1)^d < d^d \\cdot e$",
+    "significance": "supporting",
+    "relatedConcepts": ["power laws", "clearing denominators", "monotonicity of multiplication"],
+    "prerequisites": ["mul_pow", "one_div_mul_cancel", "mul_lt_mul_of_pos_right"]
+  },
+  {
+    "id": "ann-main-comparison",
+    "proofId": "lovasz-local-lemma-oq-02-wip-01",
+    "range": { "startLine": 78, "endLine": 91 },
+    "type": "insight",
+    "title": "The Sharp Threshold Beats the Classical e-Bound",
+    "content": "lllThreshold_gt_classical_ebound is the main theorem: 1/(e(d+1)) < T(d) for all d ≥ 1. After the real cast it cross-multiplies (both denominators positive via div_lt_div_iff₀), uses pow_succ to expose (d+1)ᵈ·(d+1) from (d+1)ᵈ⁺¹, and applies (d+1)ᵈ < dᵈ·e. The classical criterion e·p·(d+1) ≤ 1 is thereby shown strictly weaker than the sharp threshold.",
+    "mathContext": "$\\dfrac{1}{e\\,(d+1)} < T(d), \\qquad d \\ge 1$",
+    "significance": "key",
+    "relatedConcepts": ["Lovász Local Lemma", "Erdős–Lovász criterion", "sharp vs. sufficient bounds"],
+    "prerequisites": ["div_lt_div_iff₀", "pow_succ", "cross-multiplication of inequalities"]
+  },
+  {
+    "id": "ann-product-form",
+    "proofId": "lovasz-local-lemma-oq-02-wip-01",
+    "range": { "startLine": 93, "endLine": 100 },
+    "type": "insight",
+    "title": "The Operational Product Form e·(d+1)·T(d) > 1",
+    "content": "exp_mul_threshold_gt_one restates the main theorem in product form: 1 < e·(d+1)·T(d). Clearing the division (div_lt_iff₀) and commuting the product, it exhibits p = T(d) as a concrete probability that violates the classical avoidance criterion e·p·(d+1) ≤ 1 yet is still avoidable — a quantitative witness to the conservatism of the textbook bound.",
+    "mathContext": "$1 < e\\,(d+1)\\,T(d)$",
+    "significance": "supporting",
+    "relatedConcepts": ["probabilistic method", "avoidance criterion", "conservatism gap"],
+    "prerequisites": ["div_lt_iff₀", "mul_comm", "linear arithmetic"]
+  },
+  {
+    "id": "ann-context-threshold",
+    "proofId": "lovasz-local-lemma-oq-02-wip-01",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "context",
+    "title": "The Local Lemma and Where the Constant e Comes From",
+    "content": "The Erdős–Lovász symmetric Local Lemma (1975) guarantees simultaneous avoidance of bad events when e·p·(d+1) ≤ 1, with d the dependency degree. The constant e appears because the inductive proof optimises x(1−x)ᵈ, whose maximiser drives an (1+1/d)ᵈ → e limit; the sharp threshold is the exact maximum T(d), and the classical 1/(e(d+1)) is its d → ∞ shadow. This entry quantifies the strict finite-d gap between them.",
+    "mathContext": "$\\text{classical: } e\\,p\\,(d+1) \\le 1 \\;\\Longleftrightarrow\\; p \\le \\dfrac{1}{e\\,(d+1)}$",
+    "significance": "context",
+    "relatedConcepts": ["Lovász Local Lemma", "probabilistic method", "Shearer optimality"],
+    "prerequisites": ["probability of events", "dependency graph", "Alon–Spencer probabilistic method"]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-02-wip-01/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02-wip-01/meta.json
@@ -33,6 +33,65 @@
     ]
   },
   "sorries": 0,
+  "overview": {
+    "historicalContext": "The Lovász Local Lemma, introduced by Paul Erdős and László Lovász in their 1975 paper on 3-chromatic hypergraphs, is a cornerstone of the probabilistic method: if each of a family of 'bad' events has probability at most p and depends on at most d others, and if e·p·(d+1) ≤ 1, then with positive probability none of the bad events occurs. The constant e = exp(1) in this criterion is not an accident of the proof — it arises because the standard inductive argument optimises a bound of the form x(1−x)ᵈ and the maximiser feeds an (1 + 1/d)ᵈ → e limit. The textbook statement (as popularised in Alon and Spencer's The Probabilistic Method) quotes the clean sufficient condition p ≤ 1/(e(d+1)), but the genuinely sharp symmetric threshold is the exact algebraic quantity T(d) = dᵈ/(d+1)ᵈ⁺¹, the maximum of x(1−x)ᵈ over [0,1], established in the parent entry. Shearer showed in 1985 that this is the optimal density for the symmetric setting. This file pins down the elementary but frequently glossed-over fact that the sharp threshold is strictly larger than the classical e-bound for every d ≥ 1: T(d) > 1/(e(d+1)). The whole gap reduces to the classical strict inequality (1 + 1/d)ᵈ < e — the statement that the famous sequence approaching e does so strictly from below — which the file derives from Mathlib's strict exponential bound Real.add_one_lt_exp. Because 1/e is irrational, the comparison is made over ℝ using the real cast of the parent's rational threshold.",
+    "problemStatement": "Let $T(d) = \\mathrm{lllThreshold}(d) = d^d/(d+1)^{d+1}$ be the sharp symmetric Lovász Local Lemma threshold (the maximum of $x(1-x)^d$ on $[0,1]$) and let $1/(e(d+1))$ be the classical Erdős–Lovász sufficient bound, $e = \\exp 1$. Prove that for every $d \\ge 1$ the sharp threshold strictly exceeds the classical bound, $1/(e(d+1)) < T(d)$, equivalently $e\\,(d+1)\\,T(d) > 1$, so the classical criterion $e\\,p\\,(d+1) \\le 1$ is strictly weaker than the algebraic threshold.",
+    "proofStrategy": "First lllThreshold_cast rewrites the parent's rational threshold as the real closed form T(d) = dᵈ/(d+1)ᵈ⁺¹. The analytic core is one_add_inv_pow_lt_exp_one: (1 + 1/d)ᵈ < e, proved by applying Mathlib's strict bound 1 + x < exp(x) at x = 1/d and raising to the d-th power, since exp(1/d)ᵈ = exp(d·(1/d)) = exp 1. Clearing the dᵈ denominator (succ_pow_lt_pow_mul_exp) turns this into (d+1)ᵈ < dᵈ·e, the exact fact the main theorem consumes. The main theorem lllThreshold_gt_classical_ebound cross-multiplies the target inequality 1/(e(d+1)) < dᵈ/(d+1)ᵈ⁺¹ (both denominators positive), reduces via pow_succ to (d+1)ᵈ·(d+1) on one side, and applies (d+1)ᵈ < dᵈ·e. Finally exp_mul_threshold_gt_one restates the result in product form e·(d+1)·T(d) > 1 by clearing the division.",
+    "keyInsights": [
+      "The entire gap between the sharp threshold and the classical bound collapses to one classical inequality: $(1 + 1/d)^d < e$, the statement that the canonical sequence converging to $e$ does so strictly from below for every finite $d$.",
+      "The constant $e$ in the Erdős–Lovász criterion is exactly the $d \\to \\infty$ limit of $(1 + 1/d)^d$, so the classical bound is precisely the asymptotic version of the sharp threshold — the finite-$d$ strictness is what makes $T(d)$ genuinely better.",
+      "Raising a strict inequality $1 + 1/d < \\exp(1/d)$ to the $d$-th power is legitimate because both sides are positive and the base is nonzero; the exponent then simplifies via $\\exp(1/d)^d = \\exp(d\\cdot 1/d) = \\exp 1$, converting a transcendental bound into an algebraic one.",
+      "Working over $\\mathbb{R}$ rather than $\\mathbb{Q}$ is forced: $1/e$ is irrational, so the comparison cannot even be stated with the parent's rational threshold without the real cast lllThreshold_cast.",
+      "The product form $e(d+1)T(d) > 1$ makes the improvement operational: it exhibits $p = T(d)$ as a probability that violates the classical criterion $e\\,p\\,(d+1) \\le 1$ yet is still avoidable, quantifying exactly how much slack the textbook bound leaves on the table."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-and-statement",
+      "title": "Context — Sharp Threshold vs. Classical e-Bound",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "The header recalls the parent's sharp threshold T(d) = dᵈ/(d+1)ᵈ⁺¹ = (1/(d+1))(d/(d+1))ᵈ (the exact maximum of x(1−x)ᵈ) and the classical Erdős–Lovász symmetric criterion e·p·(d+1) ≤ 1, and states the goal: T(d) > 1/(e(d+1)) for all d ≥ 1, with the single analytic ingredient (1+1/d)ᵈ < e."
+    },
+    {
+      "id": "real-closed-form",
+      "title": "The Real Closed Form of the Threshold",
+      "startLine": 40,
+      "endLine": 46,
+      "summary": "lllThreshold_cast casts the parent's rational threshold lllThreshold d into the real closed form T(d) = dᵈ/(d+1)ᵈ⁺¹ for d ≥ 1, discharging the definitional if_neg branch and finishing with push_cast and ring. The cast to ℝ is necessary because the comparison target 1/(e(d+1)) is irrational."
+    },
+    {
+      "id": "one-plus-inv-pow",
+      "title": "The Classical Inequality (1 + 1/d)ᵈ < e",
+      "startLine": 47,
+      "endLine": 62,
+      "summary": "one_add_inv_pow_lt_exp_one proves (1 + 1/d)ᵈ < e. It applies Mathlib's strict bound Real.add_one_lt_exp at x = 1/d to get 1 + 1/d < exp(1/d), raises to the d-th power via pow_lt_pow_left₀, and simplifies exp(1/d)ᵈ = exp(d·(1/d)) = exp 1 using Real.exp_nat_mul. This is the sole analytic ingredient."
+    },
+    {
+      "id": "cleared-denominator",
+      "title": "Clearing the Denominator: (d+1)ᵈ < dᵈ·e",
+      "startLine": 63,
+      "endLine": 77,
+      "summary": "succ_pow_lt_pow_mul_exp multiplies (1+1/d)ᵈ < e through by dᵈ and uses (1+1/d)ᵈ·dᵈ = (d+1)ᵈ (via ← mul_pow and one_div_mul_cancel) to obtain (d+1)ᵈ < dᵈ·e — the exact algebraic fact the main theorem consumes, freed of any denominator."
+    },
+    {
+      "id": "main-and-product-form",
+      "title": "The Main Comparison and Its Product Form",
+      "startLine": 78,
+      "endLine": 102,
+      "summary": "lllThreshold_gt_classical_ebound proves 1/(e(d+1)) < T(d) by cross-multiplying, applying pow_succ to expose (d+1)ᵈ, and invoking (d+1)ᵈ < dᵈ·e. exp_mul_threshold_gt_one restates it in the operational product form e·(d+1)·T(d) > 1, exhibiting p = T(d) as a probability that beats the classical criterion."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry proves that the sharp symmetric Lovász Local Lemma threshold T(d) = dᵈ/(d+1)ᵈ⁺¹ strictly exceeds the classical Erdős–Lovász bound 1/(e(d+1)) for every d ≥ 1, equivalently e·(d+1)·T(d) > 1. The comparison is reduced entirely to the classical strict inequality (1 + 1/d)ᵈ < e, derived from Mathlib's Real.add_one_lt_exp and Real.exp_nat_mul, cleared of denominators into (d+1)ᵈ < dᵈ·e, and cross-multiplied against the real cast of the parent's rational threshold. Everything is machine-checked with 0 axioms and 0 sorries.",
+    "implications": "The result makes precise a fact that textbooks state only asymptotically: the familiar 1/(e(d+1)) sufficient condition is genuinely conservative, and the exact algebraic threshold T(d) certifies avoidability for a strictly larger range of probabilities at every finite dependency degree d. Since the e-bound is the d → ∞ limit of the sharp threshold, the entry also isolates the exact source of the constant e in the Local Lemma — the sequence (1 + 1/d)ᵈ — and shows the loss is entirely explained by that sequence's strict monotone approach to its limit. This kind of quantified conservatism gap is exactly what one needs when the Local Lemma is applied at small, concrete dependency degrees, where the difference between T(d) and 1/(e(d+1)) can decide feasibility.",
+    "openQuestions": [
+      "Can the gap T(d) − 1/(e(d+1)) be given an explicit asymptotic expansion in 1/d, quantifying how fast the classical bound approaches the sharp threshold?",
+      "Does an analogous strict improvement over the classical bound hold in the asymmetric Lovász Local Lemma, where dependencies vary across events?",
+      "How does the sharp threshold T(d) compare to Shearer's optimal bound in the lopsided or cluster-expansion formulations of the Local Lemma?",
+      "Can the algorithmic Local Lemma (Moser–Tardos) be shown to reach probabilities up to T(d) rather than only 1/(e(d+1)) in the constructive setting?"
+    ]
+  },
   "leanFile": {
     "path": "Proofs/LovaszLocalLemmaOQ02Wip01.lean",
     "lineCount": 102,


### PR DESCRIPTION
Enrichment pass for `lovasz-local-lemma-oq-02-wip-01` (quality 0 → 100).

## Added
- **overview**: historicalContext (Erdős–Lovász 1975, Alon–Spencer, origin of the constant e, Shearer optimality), problemStatement, proofStrategy, 5 keyInsights.
- **sections**: 5 sections partitioning the full 102-line file (context, real closed form, (1+1/d)ᵈ<e, cleared denominator, main + product form).
- **conclusion**: summary, implications, 4 openQuestions.
- **annotations.json**: 6 annotations with mathContext (LaTeX), significance, relatedConcepts, prerequisites, anchored to lllThreshold_cast, one_add_inv_pow_lt_exp_one, succ_pow_lt_pow_mul_exp, lllThreshold_gt_classical_ebound, exp_mul_threshold_gt_one, and the header context.

Content only (meta.json + annotations.json). 0 axioms, 0 sorries preserved; status/badge unchanged.