### PR TITLE
meta(erdos-1022-oq-02): promote stale wip→verified/original [0 sorry, 0 axiom]

### DIFF
--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (first-moment slice)",
     "sourceUrl": "https://erdosproblems.com/1022",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1022OQ02.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "first moment",
       "open question"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "erdosNumber": 1022,
     "erdosUrl": "https://erdosproblems.com/1022",


### PR DESCRIPTION
## Summary

`Erdos1022OQ02.lean` (Growth Rate of the Property-B Sparseness Threshold, first-moment
regime) is fully machine-checked but its gallery meta still carried the *initial*
`status: axiomatized` / `badge: wip`. There are **no axioms and no assumptions** in the
file, so that classification is stale.

## Verification
- **Rebuilt** under Mathlib v4.26: `docker-build.sh Proofs.Erdos1022OQ02` → **Build succeeded** (7744 jobs).
- **0 sorries, 0 axioms** (`grep` + `#`-scan); the `leanFile` block already reported this.
- **8 substantive theorems**, no `True`/String-description stubs: `sparse_card_lt`,
  `card_mono_le_of_min`, `property_b_min_size`, `propertyB_of_sparse`,
  `firstMoment_threshold_doubles`, `firstMoment_threshold_lt`,
  `firstMoment_threshold_ge_self`, `firstMomentThreshold_two`.

## Change
`meta.status`: `axiomatized` → `verified`; `meta.badge`: `wip` → `original`.

This matches the sibling entry `erdos-1022-oq-04`, the analogous 0-axiom first-moment OQ
(already `verified`/`original`). The entry honestly scopes itself to the first-moment
regime and does **not** claim to resolve open Erdős #1022 — the parent `erdos-1022` entry
correctly stays `axiomatized` (it carries 1 axiom for the open conjecture).

## Note
Sibling `erdos-1022-oq-01` appears to be in the same stale state (`wip` with 0 axiom/0
sorry) and may warrant the same fix in a follow-up; left untouched here (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)