### PR TITLE
Enrich Four-Square Distribution OQ-04: Orbit-Surjectivity of Value-Multiset Tuples

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-04-surj/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-04-surj/annotations.json
@@ -1,1 +1,115 @@
-[]
+[
+  {
+    "id": "ann-fsdoq04s-docstring",
+    "proofId": "four-square-distribution-oq-04-surj",
+    "range": {
+      "startLine": 4,
+      "endLine": 26
+    },
+    "type": "concept",
+    "title": "The orbit-surjectivity residue",
+    "content": "Discharges the single combinatorial residue flagged as the heart of `arrangement_card`: two functions $\\mathrm{Fin}\\,m\\to\\mathbb{Z}$ with the same value-multiset differ by a permutation of positions. This is the transitivity (orbit-surjectivity) half of the orbit-stabiliser reduction behind the multiset arrangement count, and it underlies the two remaining sorries of `FourSquareDistributionOQ04ArrangeProof`. The proof is a canonical-form argument: sort both tuples and invoke uniqueness of sorted representatives.",
+    "mathContext": "Same value-multiset $\\Rightarrow\\exists\\sigma\\in S_m,\\ g\\circ\\sigma=h$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "orbit-stabiliser theorem",
+      "multiset arrangements",
+      "canonical form",
+      "Tuple.sort"
+    ],
+    "prerequisites": [
+      "group actions",
+      "multisets"
+    ]
+  },
+  {
+    "id": "ann-fsdoq04s-statement",
+    "proofId": "four-square-distribution-oq-04-surj",
+    "range": {
+      "startLine": 32,
+      "endLine": 38
+    },
+    "type": "theorem",
+    "title": "exists_perm_comp: orbit-surjectivity stated",
+    "content": "The theorem: from $\\mathrm{Multiset.map}\\,g\\,\\mathrm{univ}=\\mathrm{Multiset.map}\\,h\\,\\mathrm{univ}$ (the value-multisets coincide), produce $\\sigma:\\mathrm{Equiv.Perm}(\\mathrm{Fin}\\,m)$ with $g\\circ\\sigma=h$. Phrasing the hypothesis as multiset equality of the image under `univ.val` is exactly the 'same value-multiset' condition.",
+    "mathContext": "$\\mathrm{map}\\,g\\,\\mathrm{univ.val}=\\mathrm{map}\\,h\\,\\mathrm{univ.val}\\Rightarrow\\exists\\sigma,\\ g\\circ\\sigma=h$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Equiv.Perm",
+      "Multiset.map",
+      "value-multiset"
+    ],
+    "prerequisites": [
+      "Finset.univ",
+      "permutations of Fin m"
+    ]
+  },
+  {
+    "id": "ann-fsdoq04s-toperm",
+    "proofId": "four-square-distribution-oq-04-surj",
+    "range": {
+      "startLine": 39,
+      "endLine": 46
+    },
+    "type": "tactic",
+    "title": "From value-multiset to list permutation, and sorting",
+    "content": "Rewrites the multiset equality into a list permutation $\\mathrm{ofFn}\\,g\\sim\\mathrm{ofFn}\\,h$ using `Multiset.coe_eq_coe` and `Fin.univ_val_map` (which identifies $\\mathrm{map}\\,g\\,\\mathrm{univ.val}$ with the coerced `ofFn` list). Introduces the sort permutations $\\tau_g=\\mathrm{Tuple.sort}\\,g$, $\\tau_h=\\mathrm{Tuple.sort}\\,h$ and records that $g\\circ\\tau_g$, $h\\circ\\tau_h$ are monotone via `Tuple.monotone_sort`.",
+    "mathContext": "$\\mathrm{ofFn}\\,g\\sim\\mathrm{ofFn}\\,h$; $g\\circ\\tau_g$, $h\\circ\\tau_h$ monotone.",
+    "significance": "key",
+    "relatedConcepts": [
+      "List.Perm",
+      "Fin.univ_val_map",
+      "Tuple.sort",
+      "Tuple.monotone_sort"
+    ],
+    "prerequisites": [
+      "multiset/list coercion",
+      "sorting a tuple"
+    ]
+  },
+  {
+    "id": "ann-fsdoq04s-sorted",
+    "proofId": "four-square-distribution-oq-04-surj",
+    "range": {
+      "startLine": 47,
+      "endLine": 55
+    },
+    "type": "tactic",
+    "title": "Sorted lists with the same multiset are equal",
+    "content": "Each sorted list $\\mathrm{ofFn}(g\\circ\\tau_g)$ is a permutation of $\\mathrm{ofFn}\\,g$ (`Equiv.Perm.ofFn_comp_perm`); transitivity with $g\\sim h$ gives $\\mathrm{ofFn}(g\\circ\\tau_g)\\sim\\mathrm{ofFn}(h\\circ\\tau_h)$. Then `List.Perm.eq_of_pairwise'` with the two monotone `SortedLE` witnesses (`hmg.sortedLE_ofFn.pairwise`) forces the sorted lists *equal*, and `List.ofFn_injective` lifts to $g\\circ\\tau_g=h\\circ\\tau_h$ — the canonical-form heart of the argument.",
+    "mathContext": "sorted + same multiset $\\Rightarrow\\mathrm{ofFn}(g\\circ\\tau_g)=\\mathrm{ofFn}(h\\circ\\tau_h)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "List.Perm.eq_of_pairwise'",
+      "sorted-list uniqueness",
+      "List.ofFn_injective",
+      "canonical form"
+    ],
+    "prerequisites": [
+      "Pairwise / SortedLE",
+      "list permutations"
+    ]
+  },
+  {
+    "id": "ann-fsdoq04s-witness",
+    "proofId": "four-square-distribution-oq-04-surj",
+    "range": {
+      "startLine": 56,
+      "endLine": 59
+    },
+    "type": "tactic",
+    "title": "Assembling the witness permutation",
+    "content": "With $g\\circ\\tau_g=h\\circ\\tau_h$ in hand, the witness is $\\sigma=\\tau_h^{-1}\\circ\\tau_g$ (`τh.symm.trans τg`). Pointwise, `congrFun` at $\\tau_h^{-1} i$ and `Equiv.trans_apply` collapse $g(\\sigma i)=h(i)$, so $g\\circ\\sigma=h$ by `funext`. This turns the two sort canonical forms into the single required permutation.",
+    "mathContext": "$\\sigma=\\tau_h^{-1}\\circ\\tau_g$, $g\\circ\\sigma=h$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Equiv.trans",
+      "composition of permutations",
+      "funext"
+    ],
+    "prerequisites": [
+      "Equiv API",
+      "the canonical-form equality"
+    ]
+  }
+]

--- a/src/data/proofs/four-square-distribution-oq-04-surj/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-04-surj/meta.json
@@ -39,5 +39,82 @@
     "imports": [
       "import Mathlib"
     ]
-  }
+  },
+  "overview": {
+    "historicalContext": "Counting the arrangements of a multiset is a staple of enumerative combinatorics: the number of distinct orderings of a length-$m$ tuple with repeated values is the multinomial coefficient $m!/\\prod_v (\\#v)!$, and the modern way to see this is as an orbit-count under the symmetric group $S_m$ acting on tuples by permuting positions. The orbit-stabiliser theorem then reduces the arrangement count to two facts: the stabiliser of a tuple is the product of the symmetric groups on its equal-value blocks, and the action is *transitive on tuples with a fixed value-multiset* — i.e. any two tuples with the same multiset of values differ by a permutation. This last fact, orbit-surjectivity, is the combinatorial residue that earlier sessions flagged as the heart of `arrangement_card` in the four-square distribution development, blocking the two remaining `sorry`s of `FourSquareDistributionOQ04ArrangeProof`. This file discharges it with a clean canonical-form argument: sort both tuples and use uniqueness of sorted representatives, leveraging Mathlib's `Tuple.sort` and `List.Perm` API. 0 sorries, 0 axioms.",
+    "problemStatement": "Prove that two tuples $g,h:\\mathrm{Fin}\\,m\\to\\mathbb{Z}$ with the same value-multiset differ by a permutation of positions — $\\exists\\sigma\\in S_m,\\ g\\circ\\sigma=h$ — the orbit-surjectivity statement underlying the arrangement count, with 0 sorries and 0 axioms.",
+    "proofStrategy": "A canonical-form argument via `Tuple.sort`. Convert the value-multiset equality into a list permutation $\\mathrm{ofFn}\\,g\\sim\\mathrm{ofFn}\\,h$ (`Fin.univ_val_map`). Sort both tuples: `Tuple.monotone_sort` makes $g\\circ\\tau_g$ and $h\\circ\\tau_h$ monotone, so their `ofFn` lists are sorted; each sorted list is a permutation of its tuple (`Equiv.Perm.ofFn_comp_perm`), and $g\\sim h$ chains them together. Uniqueness of sorted lists with equal multiset (`List.Perm.eq_of_pairwise'`) forces the two sorted lists *equal*; `List.ofFn_injective` lifts to $g\\circ\\tau_g=h\\circ\\tau_h$, and the witness permutation is $\\sigma=\\tau_h^{-1}\\circ\\tau_g$.",
+    "keyInsights": [
+      "Orbit-surjectivity — any two tuples with the same value-multiset differ by a position permutation — is exactly the transitivity half of the orbit-stabiliser reduction behind the arrangement count.",
+      "The clean route is a *canonical form*: sort each tuple. Sorted representatives of permutation-equivalent lists are unique, so equal-multiset tuples share a sorted form.",
+      "Value-multiset equality is repackaged as a `List.Perm` on `ofFn` lists via `Fin.univ_val_map`, moving the problem into Mathlib's well-developed list-permutation API.",
+      "`Tuple.monotone_sort` guarantees $g\\circ\\tau_g$ is monotone, so its `ofFn` list is `SortedLE`; sorted + same-multiset $\\Rightarrow$ equal by `List.Perm.eq_of_pairwise'`.",
+      "The explicit witness $\\sigma=\\tau_h^{-1}\\circ\\tau_g$ is recovered by composing the two sort permutations, and `List.ofFn_injective` turns list equality back into tuple equality.",
+      "Discharging `exists_perm_comp` removes the last combinatorial blocker for two downstream `sorry`s (`card_orbit_eq_card_arrangements`, `arrangements_card_mul_prod_count`)."
+    ],
+    "prerequisites": [
+      "multiset arrangements and the multinomial coefficient",
+      "group actions and orbit-stabiliser",
+      "Tuple.sort and sorted-list uniqueness",
+      "List.Perm API"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: the orbit-surjectivity residue",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Imports Mathlib and a docstring explaining that this file discharges the single combinatorial residue at the heart of `arrangement_card` — that two functions $\\mathrm{Fin}\\,m\\to\\mathbb{Z}$ with the same value-multiset differ by a permutation — the orbit-surjectivity underlying two downstream `sorry`s. Sketches the canonical-form (`Tuple.sort`) proof and opens `namespace` / `Finset`."
+    },
+    {
+      "id": "statement",
+      "title": "exists_perm_comp: the statement",
+      "startLine": 32,
+      "endLine": 38,
+      "summary": "States orbit-surjectivity: given $\\mathrm{Multiset.map}\\,g\\,\\mathrm{univ}=\\mathrm{Multiset.map}\\,h\\,\\mathrm{univ}$, there exists $\\sigma:\\mathrm{Perm}(\\mathrm{Fin}\\,m)$ with $g\\circ\\sigma=h$."
+    },
+    {
+      "id": "multiset-to-perm",
+      "title": "From value-multiset to list permutation, and sorting",
+      "startLine": 39,
+      "endLine": 46,
+      "summary": "Converts the value-multiset equality into $\\mathrm{ofFn}\\,g\\sim\\mathrm{ofFn}\\,h$ via `Multiset.coe_eq_coe`/`Fin.univ_val_map`, sets the sort permutations $\\tau_g,\\tau_h$, and records that $g\\circ\\tau_g$, $h\\circ\\tau_h$ are monotone (`Tuple.monotone_sort`)."
+    },
+    {
+      "id": "sorted-unique",
+      "title": "Sorted lists with the same multiset are equal",
+      "startLine": 47,
+      "endLine": 55,
+      "summary": "Each sorted `ofFn` list is a permutation of its tuple (`Equiv.Perm.ofFn_comp_perm`); chaining with $g\\sim h$ gives $\\mathrm{ofFn}(g\\circ\\tau_g)\\sim\\mathrm{ofFn}(h\\circ\\tau_h)$. Sorted-list uniqueness (`List.Perm.eq_of_pairwise'` with the monotone `SortedLE` witnesses) forces them equal, and `List.ofFn_injective` lifts to $g\\circ\\tau_g=h\\circ\\tau_h$."
+    },
+    {
+      "id": "witness",
+      "title": "Assembling the witness permutation",
+      "startLine": 56,
+      "endLine": 61,
+      "summary": "Takes $\\sigma=\\tau_h^{-1}\\circ\\tau_g$ and verifies $g\\circ\\sigma=h$ pointwise: applying $\\tau_h^{-1}$ and using $g\\circ\\tau_g=h\\circ\\tau_h$ collapses the composition via `Equiv.trans_apply`, completing the proof."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves orbit-surjectivity for value-multiset tuples: two functions $g,h:\\mathrm{Fin}\\,m\\to\\mathbb{Z}$ with the same value-multiset differ by a permutation $\\sigma$ with $g\\circ\\sigma=h$ (`exists_perm_comp`), by a canonical-form argument through `Tuple.sort` and sorted-list uniqueness. 0 sorries, 0 axioms.",
+    "implications": "This discharges the combinatorial residue underlying the four-square arrangement count, unblocking the two remaining `sorry`s of `FourSquareDistributionOQ04ArrangeProof` (`card_orbit_eq_card_arrangements`, `arrangements_card_mul_prod_count`). More broadly it packages the transitivity half of the orbit-stabiliser reduction for multiset arrangements as a reusable lemma, with the sort-canonical-form technique applicable to any equal-multiset tuple equivalence.",
+    "openQuestions": [
+      "Can the two downstream `sorry`s now be closed to complete the full multiset-arrangement count `arrangement_card`?",
+      "Does the same sort-canonical-form argument generalise from $\\mathbb{Z}$ to an arbitrary `LinearOrder` codomain, removing the integer-specific phrasing?",
+      "Can the explicit witness $\\tau_h^{-1}\\circ\\tau_g$ be used to compute stabiliser sizes and recover the multinomial arrangement formula constructively?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "four-square-distribution-oq-04",
+      "relationship": "extends",
+      "description": "Direct parent (OQ-04): its arrangement-count proof FourSquareDistributionOQ04ArrangeProof has two sorries (card_orbit_eq_card_arrangements, arrangements_card_mul_prod_count) that rest on this orbit-surjectivity lemma."
+    },
+    {
+      "targetId": "four-square-distribution",
+      "relationship": "related",
+      "description": "Root four-square distribution entry; the multiset-arrangement count enriched here supports its counting arguments."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass: quality 0 → 100.

- **overview**: historical context (multiset arrangements, orbit-stabiliser, sort canonical form), problem statement, proof strategy, 6 key insights, prerequisites
- **sections**: 5 line-anchored sections covering the 61-line single-theorem file by proof phase
- **annotations**: 5 annotations, each with mathContext, significance, relatedConcepts, prerequisites
- **conclusion**: summary, implications, 3 open questions
- **crossReferences**: `four-square-distribution-oq-04`, `four-square-distribution`

No Lean changes; gallery data only.