### PR TITLE
Enrich: Prime-Degree Radical Extensions — Affine Lower Bound ℓ(ℓ−1) ∣ |Gal(Xˡ−p)|

### DIFF
--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-04/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-context-affine",
+    "proofId": "inverse-galois-d4-oq-02-oq-04",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "context",
+    "title": "Radical Extensions and the Metacyclic / Affine Structure",
+    "content": "The Galois group of Xⁿ − p over ℚ is metacyclic: it embeds in the affine group AGL(1,n) = ℤ/n ⋊ (ℤ/n)ˣ, the semidirect product of the order-n root-shuffling kernel by the order-φ(n) cyclotomic action. The parent established n ∣ |Gal| ∣ n! and φ(n) ∣ |Gal|, with the product n·φ(n) ∣ |Gal| only under gcd(n,φ(n)) = 1. This file makes that hypothesis automatic at prime degree.",
+    "mathContext": "$\\mathrm{Gal}(X^n - p/\\mathbb{Q}) \\hookrightarrow \\mathrm{AGL}(1,n) = \\mathbb{Z}/n \\rtimes (\\mathbb{Z}/n)^\\times, \\quad |\\mathrm{AGL}(1,n)| = n\\,\\varphi(n)$",
+    "significance": "context",
+    "relatedConcepts": ["inverse Galois problem", "radical extensions", "affine group AGL(1,n)"],
+    "prerequisites": ["Galois theory", "semidirect products", "Euler totient"]
+  },
+  {
+    "id": "ann-coprime-prime-totient",
+    "proofId": "inverse-galois-d4-oq-02-oq-04",
+    "range": { "startLine": 59, "endLine": 71 },
+    "type": "insight",
+    "title": "A Prime Is Coprime to Its Totient",
+    "content": "coprime_prime_totient is the key number-theoretic observation. Since Nat.totient_prime gives φ(ℓ) = ℓ − 1, and a prime ℓ is coprime to m iff ℓ ∤ m (hℓ.coprime_iff_not_dvd), the claim reduces to ℓ ∤ (ℓ − 1). This holds because any divisor would force ℓ ≤ ℓ − 1 (Nat.le_of_dvd on the positive ℓ − 1), impossible — omega closes it. Consecutive integers are coprime, so no per-ℓ case analysis is needed.",
+    "mathContext": "$\\gcd(\\ell, \\varphi(\\ell)) = \\gcd(\\ell, \\ell - 1) = 1 \\quad (\\ell \\text{ prime})$",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient", "coprimality", "consecutive integers"],
+    "prerequisites": ["Nat.totient_prime", "Nat.Prime.coprime_iff_not_dvd", "Nat.le_of_dvd"]
+  },
+  {
+    "id": "ann-affine-lower-bound",
+    "proofId": "inverse-galois-d4-oq-02-oq-04",
+    "range": { "startLine": 77, "endLine": 91 },
+    "type": "insight",
+    "title": "The Affine Lower Bound ℓ(ℓ−1) ∣ |Gal|",
+    "content": "gal_card_affine_lower_bound is the main theorem. The parent supplies two divisibilities — the kernel factor ℓ ∣ |Gal| (n_dvd_gal_card) and the cyclotomic quotient factor φ(ℓ) ∣ |Gal| (totient_dvd_gal_card). Because they are coprime at a prime degree, Nat.Coprime.mul_dvd_of_dvd_of_dvd multiplies them into ℓ·φ(ℓ) ∣ |Gal|, and rewriting φ(ℓ) = ℓ − 1 gives the full affine order ℓ(ℓ−1) ∣ |Gal(Xˡ−p/ℚ)| with no extra hypothesis.",
+    "mathContext": "$\\ell \\mid |G|, \\;\\; (\\ell-1) \\mid |G|, \\;\\; \\gcd(\\ell,\\ell-1)=1 \\;\\Rightarrow\\; \\ell(\\ell-1) \\mid |G|$",
+    "significance": "key",
+    "relatedConcepts": ["metacyclic group", "divisibility of group order", "affine group order"],
+    "prerequisites": ["Nat.Coprime.mul_dvd_of_dvd_of_dvd", "Fintype.card of Gal", "the parent divisibility lemmas"]
+  },
+  {
+    "id": "ann-bracket",
+    "proofId": "inverse-galois-d4-oq-02-oq-04",
+    "range": { "startLine": 93, "endLine": 102 },
+    "type": "insight",
+    "title": "The Two-Sided Bracket ℓ(ℓ−1) ∣ |Gal| ∣ ℓ!",
+    "content": "gal_card_prime_degree_bracket sandwiches the group order between the affine lower bound (AGL(1,ℓ) ⊆ Gal) and the symmetric-group upper bound (Gal ⊆ Sₗ, from the parent's gal_card_dvd_factorial). Equality on the left is the genericity conjecture; the two bounds coincide (ℓ(ℓ−1) = ℓ!) only at ℓ ∈ {2,3}, recovering the parent's exact pins |Gal(X²−p)| = 2 and |Gal(X³−p)| = 6.",
+    "mathContext": "$\\ell(\\ell-1) \\mid |\\mathrm{Gal}(X^\\ell - p/\\mathbb{Q})| \\mid \\ell!$",
+    "significance": "supporting",
+    "relatedConcepts": ["two-sided bounds", "symmetric group embedding", "genericity conjecture"],
+    "prerequisites": ["divisibility bracket", "factorial upper bound", "conjunction of divisibilities"]
+  },
+  {
+    "id": "ann-numerical-bound",
+    "proofId": "inverse-galois-d4-oq-02-oq-04",
+    "range": { "startLine": 104, "endLine": 109 },
+    "type": "technique",
+    "title": "From Divisibility to a Quadratic Numerical Bound",
+    "content": "gal_card_ge_affine converts the affine divisibility into the numerical inequality |Gal| ≥ ℓ(ℓ−1) via Nat.le_of_dvd applied with Fintype.card_pos (the Galois group is finite and nonempty). The order of the Galois group of a prime-degree radical extension therefore grows at least quadratically in the degree.",
+    "mathContext": "$|\\mathrm{Gal}(X^\\ell - p/\\mathbb{Q})| \\ge \\ell(\\ell-1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility implies inequality", "finite group order", "quadratic growth"],
+    "prerequisites": ["Nat.le_of_dvd", "Fintype.card_pos"]
+  },
+  {
+    "id": "ann-instance-seven",
+    "proofId": "inverse-galois-d4-oq-02-oq-04",
+    "range": { "startLine": 129, "endLine": 135 },
+    "type": "context",
+    "title": "The New Prime Degree ℓ = 7",
+    "content": "Beyond the parent's hand-checked ℓ ∈ {3,5}, this instance records 42 = 7·6 ∣ |Gal(X⁷−p/ℚ)| ∣ 5040 = 7! for every prime p: the affine group AGL(1,7) of order 42 sits inside the Galois group, which in turn embeds in S₇. It is discharged by specialising gal_card_affine_lower_bound at ℓ = 7 and norm_num — no bespoke coprimality check, unlike the parent's decide-based ℓ = 3, 5.",
+    "mathContext": "$42 = 7\\cdot 6 \\mid |\\mathrm{Gal}(X^7 - p/\\mathbb{Q})| \\mid 5040 = 7!$",
+    "significance": "context",
+    "relatedConcepts": ["concrete instance", "affine group AGL(1,7)", "symmetric group S₇"],
+    "prerequisites": ["norm_num", "specialisation of the affine bound"]
+  }
+]

--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-04/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-04/meta.json
@@ -34,6 +34,65 @@
     ]
   },
   "sorries": 0,
+  "overview": {
+    "historicalContext": "The Galois group of a radical extension ℚ(ᵖ√p, ζₙ)/ℚ obtained by adjoining an n-th root of a prime p is one of the oldest concrete testing grounds for the inverse Galois problem — the question, going back to Hilbert and pursued through the twentieth century by Shafarevich and others, of which finite groups arise as Galois groups over ℚ. For the polynomial Xⁿ − p the group is always metacyclic: it embeds in the affine group AGL(1,n) = ℤ/n ⋊ (ℤ/n)ˣ, the semidirect product of the cyclic 'root-shuffling' kernel of order n by the cyclotomic action of order φ(n). The parent entry established the divisibility bracket n ∣ |Gal| ∣ n! together with φ(n) ∣ |Gal|, and the sharper product n·φ(n) ∣ |Gal| — but only under the coprimality hypothesis gcd(n, φ(n)) = 1, verified example by example with explicit decide calls at n = 3 and n = 5. This file makes a small but clarifying number-theoretic observation that dissolves those ad-hoc checks for an entire family: when the degree is a prime ℓ, Euler's totient gives φ(ℓ) = ℓ − 1, and ℓ is automatically coprime to ℓ − 1 because consecutive integers share no common factor. The coprime hypothesis is therefore free at every prime degree, yielding uniformly the affine lower bound ℓ(ℓ−1) ∣ |Gal(Xˡ−p)| — the full order of AGL(1,ℓ), conjecturally the exact generic Galois group. The composite degree n = 4 of the base entry is pointedly excluded (gcd(4, φ(4)) = 2), which is exactly why the dihedral case needed a separate real-embedding argument; the affine bracket here applies precisely to the prime degrees the parent sampled by hand, and it records ℓ = 7 (42 ∣ |Gal| ∣ 5040) as a new instance.",
+    "problemStatement": "For a prime degree ℓ and a prime p, let $G = \\mathrm{Gal}(X^\\ell - p/\\mathbb{Q})$. Prove that $\\gcd(\\ell, \\varphi(\\ell)) = 1$ for every prime $\\ell$, and deduce the uniform affine divisibility $\\ell(\\ell-1) \\mid |G|$, the two-sided bracket $\\ell(\\ell-1) \\mid |G| \\mid \\ell!$, and the quadratic numerical lower bound $|G| \\ge \\ell(\\ell-1) = |\\mathrm{AGL}(1,\\ell)|$, with no per-degree coprimality computation.",
+    "proofStrategy": "Part I proves coprime_prime_totient: since Nat.totient_prime gives φ(ℓ) = ℓ − 1, and a prime ℓ is coprime to m iff ℓ ∤ m, it suffices to note 0 < ℓ − 1 < ℓ so ℓ ∤ (ℓ − 1); omega closes it. Part II combines this with the parent's two divisibility facts n ∣ |Gal| (kernel) and φ(n) ∣ |Gal| (cyclotomic quotient): because the two factors are coprime at a prime degree, Nat.Coprime.mul_dvd_of_dvd_of_dvd multiplies them into ℓ·φ(ℓ) = ℓ(ℓ−1) ∣ |Gal| (gal_card_affine_lower_bound). Pairing this with the parent's Sₗ-embedding upper bound |Gal| ∣ ℓ! gives the bracket (gal_card_prime_degree_bracket), and Nat.le_of_dvd with Fintype.card_pos turns the divisibility into the numerical bound |Gal| ≥ ℓ(ℓ−1) (gal_card_ge_affine). Part III instantiates ℓ = 3, 5, 7 by norm_num.",
+    "keyInsights": [
+      "The entire family of prime-degree coprimality checks collapses to one elementary fact: consecutive integers $\\ell$ and $\\ell - 1$ are always coprime, so $\\gcd(\\ell, \\varphi(\\ell)) = 1$ holds for free at every prime degree — no per-$\\ell$ decide.",
+      "At a prime degree the kernel order $\\ell$ and the cyclotomic quotient order $\\varphi(\\ell) = \\ell - 1$ are coprime, so their divisibilities multiply: $\\ell \\mid |G|$ and $(\\ell-1) \\mid |G|$ combine into $\\ell(\\ell-1) \\mid |G|$, recovering the full order of the affine group $\\mathrm{AGL}(1,\\ell)$.",
+      "The lower bound $\\ell(\\ell-1)$ is exactly $|\\mathrm{AGL}(1,\\ell)| = |\\mathbb{Z}/\\ell \\rtimes (\\mathbb{Z}/\\ell)^\\times|$, the conjectured generic Galois group of a prime-degree radical extension, so the divisibility is the sharp structural bound rather than a crude estimate.",
+      "The bracket collapses to an exact order $\\ell(\\ell-1) = \\ell!$ only at $\\ell \\in \\{2, 3\\}$, which is precisely why the parent could pin $|\\mathrm{Gal}(X^2-p)| = 2$ and $|\\mathrm{Gal}(X^3-p)| = 6$ exactly but not higher degrees.",
+      "Composite degree $n = 4$ is excluded by design: $\\gcd(4, \\varphi(4)) = \\gcd(4,2) = 2 \\ne 1$, so the product bound fails and the dihedral case genuinely needs the separate real-embedding argument — the prime hypothesis is not a convenience but the exact condition."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context",
+      "title": "Context — Radical Extensions and the Affine Group",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "The header recalls the parent's metacyclic bracket n ∣ |Gal(Xⁿ−p)| ∣ n! with the coprime sharpening n·φ(n) ∣ |Gal| valid only when gcd(n,φ(n)) = 1, and states the goal: at prime degree ℓ the hypothesis is automatic, giving the affine bound ℓ(ℓ−1) = |AGL(1,ℓ)| uniformly, with ℓ = 7 as a new instance and n = 4 explicitly excluded."
+    },
+    {
+      "id": "coprime-prime-totient",
+      "title": "Part I — Automatic Coprimality of a Prime with Its Totient",
+      "startLine": 55,
+      "endLine": 72,
+      "summary": "coprime_prime_totient proves gcd(ℓ, φ(ℓ)) = 1 for every prime ℓ. Using Nat.totient_prime (φ(ℓ) = ℓ−1) and the fact that a prime is coprime to m iff it does not divide m, the claim reduces to ℓ ∤ (ℓ−1), which holds because 0 < ℓ−1 < ℓ — closed by omega, no case analysis."
+    },
+    {
+      "id": "affine-lower-bound",
+      "title": "Part II — The Affine Lower Bound ℓ(ℓ−1) ∣ |Gal|",
+      "startLine": 73,
+      "endLine": 92,
+      "summary": "gal_card_affine_lower_bound multiplies the parent's coprime divisibilities: the kernel factor ℓ ∣ |Gal| (n_dvd_gal_card) and the cyclotomic factor φ(ℓ) ∣ |Gal| (totient_dvd_gal_card), coprime at a prime degree, combine via Nat.Coprime.mul_dvd_of_dvd_of_dvd into ℓ·(ℓ−1) ∣ |Gal(Xˡ−p/ℚ)| — the full order of AGL(1,ℓ)."
+    },
+    {
+      "id": "bracket-and-numerical",
+      "title": "Part II — Two-Sided Bracket and Numerical Bound",
+      "startLine": 93,
+      "endLine": 110,
+      "summary": "gal_card_prime_degree_bracket pairs the affine lower bound with the parent's Sₗ-embedding upper bound to sandwich ℓ(ℓ−1) ∣ |Gal| ∣ ℓ!; equality of the two bounds happens only at ℓ ∈ {2,3}. gal_card_ge_affine turns the divisibility into the quadratic numerical bound |Gal| ≥ ℓ(ℓ−1) via Nat.le_of_dvd and Fintype.card_pos."
+    },
+    {
+      "id": "instances",
+      "title": "Part III — Concrete Instances ℓ = 3, 5, 7",
+      "startLine": 111,
+      "endLine": 137,
+      "summary": "Three examples instantiate the affine bound by norm_num: 6 ∣ |Gal(X³−p)| (|S₃|), 20 ∣ |Gal(X⁵−p)| (|F₂₀|), and the new degree 42 = 7·6 ∣ |Gal(X⁷−p)| ∣ 5040 = 7! — AGL(1,7) sitting inside Gal, which embeds in S₇."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry proves that for every prime degree ℓ and prime p the Galois group of Xˡ − p over ℚ satisfies the affine divisibility ℓ(ℓ−1) ∣ |Gal|, the two-sided bracket ℓ(ℓ−1) ∣ |Gal| ∣ ℓ!, and the quadratic numerical bound |Gal| ≥ ℓ(ℓ−1) = |AGL(1,ℓ)|. The single new ingredient is the observation that a prime ℓ and its totient φ(ℓ) = ℓ−1 are coprime as consecutive integers, which makes the parent's coprime metacyclic bound apply uniformly across all prime degrees without any per-degree decide. Instances ℓ = 3, 5, 7 are recorded. Everything is machine-checked with 0 axioms, 0 sorries, and no native_decide.",
+    "implications": "By replacing example-by-example coprimality checks with a single number-theoretic lemma, the entry turns the parent's scattered observations into a uniform structural statement about the whole family of prime-degree radical extensions, and identifies the lower bound as the exact order of the affine group AGL(1,ℓ) — the conjectured generic Galois group. This clarifies the boundary of the phenomenon: the prime hypothesis is precisely the condition gcd(n,φ(n)) = 1, and composite degrees like n = 4 genuinely fall outside it, explaining why the dihedral case required separate treatment. The result is a reusable building block for the inverse-Galois development, giving a clean quadratic-in-degree lower bound available at every prime.",
+    "openQuestions": [
+      "Is the affine lower bound sharp — i.e. is |Gal(Xˡ−p/ℚ)| = ℓ(ℓ−1) exactly under a genericity condition on p, realising AGL(1,ℓ) as the full Galois group?",
+      "For composite degrees n with gcd(n,φ(n)) > 1, what is the correct replacement lower bound, and can it be given uniformly rather than case by case?",
+      "Can the exact Galois group be pinned for the next prime ℓ = 11 or 13, distinguishing AGL(1,ℓ) from larger metacyclic possibilities?",
+      "Does the affine bracket extend to radical extensions Xˡ − a for a a prime power or a general integer, where ramification may enlarge or shrink the group?"
+    ]
+  },
   "leanFile": {
     "path": "Proofs/InverseGaloisD4OQ02OQ04.lean",
     "lineCount": 137,


### PR DESCRIPTION
Enrichment pass for `inverse-galois-d4-oq-02-oq-04` (quality 0 → 100).

## Added
- **overview**: historicalContext (inverse Galois problem, metacyclic/affine structure AGL(1,ℓ), consecutive-integer coprimality, exclusion of composite n=4), problemStatement, proofStrategy, 5 keyInsights.
- **sections**: 5 sections partitioning the full 137-line file (context, coprimality of prime & totient, affine lower bound, bracket + numerical bound, instances ℓ=3,5,7).
- **conclusion**: summary, implications, 4 openQuestions.
- **annotations.json**: 6 annotations with mathContext (LaTeX), significance, relatedConcepts, prerequisites, anchored to the header, coprime_prime_totient, gal_card_affine_lower_bound, gal_card_prime_degree_bracket, gal_card_ge_affine, and the ℓ=7 instance.

Content only (meta.json + annotations.json). 0 axioms, 0 sorries, no native_decide preserved; status/badge unchanged.