### PR TITLE
Enrich The Multiplicative Derangement Recurrence D(n) = n·D(n−1) + (−1)ⁿ

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-04-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-04-oq-04-oq-01/annotations.json
@@ -1,1 +1,137 @@
-[]
+[
+  {
+    "id": "ann-dcoq040401-docstring",
+    "proofId": "derangements-convergence-oq-04-oq-04-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "Multiplicative recurrence from the same decomposition",
+    "content": "The parent proved the *additive* derangement recurrence $D(n)=(n-1)(D(n-1)+D(n-2))$ from the `Option` decomposition. Its open question asks for the *multiplicative* recurrence $D(n)=n\\,D(n-1)+(-1)^n$ as a corollary of the same decomposition (Mathlib proves it independently as `numDerangements_succ`). This file delivers it via the derangement defect $e(m)=D(m+1)-(m+1)D(m)$: the defect flips sign each step and telescopes to $(-1)^{m+1}$, and $|D(n)-n\\,D(n-1)|=1$ is the source of $D(n)=\\mathrm{round}(n!/e)$.",
+    "mathContext": "$D(n)=n\\,D(n-1)+(-1)^n$ derived from $D(n)=(n-1)(D(n-1)+D(n-2))$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "derangements",
+      "additive vs multiplicative recurrence",
+      "derangement defect",
+      "D(n)=round(n!/e)"
+    ],
+    "prerequisites": [
+      "numDerangements",
+      "recurrences"
+    ]
+  },
+  {
+    "id": "ann-dcoq040401-defect-step",
+    "proofId": "derangements-convergence-oq-04-oq-04-oq-01",
+    "range": {
+      "startLine": 70,
+      "endLine": 83
+    },
+    "type": "theorem",
+    "title": "defect and defect_step: the sign flip",
+    "content": "Defines the defect `defect m = D(m+1) - (m+1)·D(m)` over $\\mathbb{Z}$ and proves `defect_step`: $e(m+1)=-e(m)$. The proof substitutes Mathlib's additive recurrence `numDerangements_add_two` (the counted `Option` decomposition) into the definition and finishes with `push_cast`/`ring`. This single sign-flip is the entire combinatorial content of the file.",
+    "mathContext": "$e(m)=D(m+1)-(m+1)D(m)$; $e(m+1)=-e(m)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "numDerangements_add_two",
+      "Option decomposition",
+      "integer algebra",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "additive recurrence",
+      "ℤ casts"
+    ]
+  },
+  {
+    "id": "ann-dcoq040401-defect-eq",
+    "proofId": "derangements-convergence-oq-04-oq-04-oq-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 90
+    },
+    "type": "theorem",
+    "title": "defect_eq: telescoping to an alternating sign",
+    "content": "Proves $e(m)=(-1)^{m+1}$ by induction: the base $e(0)=D(1)-D(0)=0-1=-1$ is closed by `decide`, and the step applies `defect_step` then `ih` with `pow_succ`/`ring`. Telescoping the sign flip turns the defect into a pure alternating sign — the key quantitative fact.",
+    "mathContext": "$e(m)=(-1)^{m+1}$ for all $m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping",
+      "induction",
+      "alternating sign",
+      "pow_succ"
+    ],
+    "prerequisites": [
+      "defect_step",
+      "induction on ℕ"
+    ]
+  },
+  {
+    "id": "ann-dcoq040401-mul-rec",
+    "proofId": "derangements-convergence-oq-04-oq-04-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 109
+    },
+    "type": "theorem",
+    "title": "The multiplicative recurrence, both forms",
+    "content": "`numDerangements_mul_recurrence` reads the defect off `defect_eq` to conclude $D(m+1)=(m+1)D(m)+(-1)^{m+1}$ for every $m$ (unfold `defect`, then `linarith`). `numDerangements_mul_recurrence'` rewrites it, for $n\\ge1$, in the classical truncated-subtraction form $D(n)=n\\,D(n-1)+(-1)^n$ by substituting $n=m+1$. No $n\\ge1$ hypothesis is needed for the shifted form — the base case already fits.",
+    "mathContext": "$D(m+1)=(m+1)D(m)+(-1)^{m+1}$; $D(n)=n\\,D(n-1)+(-1)^n$ for $n\\ge1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "multiplicative recurrence",
+      "linarith",
+      "truncated subtraction",
+      "index shift"
+    ],
+    "prerequisites": [
+      "defect_eq"
+    ]
+  },
+  {
+    "id": "ann-dcoq040401-exact-defect",
+    "proofId": "derangements-convergence-oq-04-oq-04-oq-01",
+    "range": {
+      "startLine": 113,
+      "endLine": 123
+    },
+    "type": "theorem",
+    "title": "The exact defect: D(n) nearest to n·D(n−1)",
+    "content": "`numDerangements_sub_mul_pred` gives the signed defect $D(n)-n\\,D(n-1)=(-1)^n$ (rewrite the recurrence, `ring`), and `abs_defect_eq_one` gives $|D(n)-n\\,D(n-1)|=1$ (`abs_pow`/`abs_neg`/`one_pow`). So $D(n)$ is always the integer nearest to $n\\,D(n-1)$, off by exactly one with alternating sign — the arithmetic root of the closed form $D(n)=\\mathrm{round}(n!/e)$.",
+    "mathContext": "$|D(n)-n\\,D(n-1)|=1$ for $n\\ge1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "nearest integer",
+      "round(n!/e)",
+      "absolute value",
+      "alternating defect"
+    ],
+    "prerequisites": [
+      "the multiplicative recurrence"
+    ]
+  },
+  {
+    "id": "ann-dcoq040401-compat",
+    "proofId": "derangements-convergence-oq-04-oq-04-oq-01",
+    "range": {
+      "startLine": 127,
+      "endLine": 152
+    },
+    "type": "insight",
+    "title": "Agreement with Mathlib and numerical checks",
+    "content": "`agrees_with_mathlib` proves the derived $+(-1)^{m+1}$ form equals Mathlib's `numDerangements_succ` $-(-1)^m$ form (`pow_succ`/`ring`), certifying this is a derivation of the *same* statement, not a variant. A block of `decide` examples then sanity-checks $D(1)=0,\\dots,D(5)=44$, the recurrence at $n=5,6$, and the $\\pm1$ defect at $n=6$ — all with plain `decide` (0 axioms, no `native_decide`).",
+    "mathContext": "$(m+1)D(m)+(-1)^{m+1}=(m+1)D(m)-(-1)^m$; $D(5)=44,\\ D(6)=265$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "numDerangements_succ",
+      "decide tactic",
+      "compatibility check",
+      "sanity checks"
+    ],
+    "prerequisites": [
+      "the derived recurrence"
+    ]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-04-oq-04-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-04-oq-04-oq-01/meta.json
@@ -39,5 +39,89 @@
     "imports": [
       "import Mathlib"
     ]
-  }
+  },
+  "overview": {
+    "historicalContext": "Derangements — permutations with no fixed point — go back to Pierre Rémond de Montmort's 1713 'problème des rencontres', with the inclusion–exclusion count $D(n)=n!\\sum_{k=0}^n(-1)^k/k!$ and the famous limit $D(n)/n!\\to 1/e$. Two recurrences organise the sequence: the *additive* one $D(n)=(n-1)(D(n-1)+D(n-2))$, which is the counted form of the bijective `Option` decomposition, and the *multiplicative* one $D(n)=n\\,D(n-1)+(-1)^n$, which is the arithmetic engine behind the closed form $D(n)=\\mathrm{round}(n!/e)$. Mathlib records the multiplicative recurrence as `numDerangements_succ`, proved there by a self-contained integer induction. The parent entry `derangements-convergence-oq-04-oq-04` established the additive recurrence bijectively; its open question asks for the multiplicative recurrence as a genuine corollary of the *same* decomposition. This entry supplies exactly that, via the derangement defect $e(m)=D(m+1)-(m+1)D(m)$: the additive recurrence forces the defect merely to flip sign at each step, and telescoping from $e(0)=-1$ gives $e(m)=(-1)^{m+1}$ — the multiplicative recurrence read straight off. Machine-checked over $\\mathbb{Z}$/$\\mathbb{N}$ with no extra axioms.",
+    "problemStatement": "Derive the multiplicative derangement recurrence $D(n)=n\\,D(n-1)+(-1)^n$ (for $n\\ge1$) as a corollary of the additive recurrence / `Option` decomposition — rather than by a fresh integer induction — and pin the exact defect $|D(n)-n\\,D(n-1)|=1$, all with 0 sorries and no non-foundational axioms.",
+    "proofStrategy": "Introduce the derangement defect $e(m)=D(m+1)-(m+1)D(m)$ over $\\mathbb{Z}$. Feed Mathlib's additive recurrence `numDerangements_add_two` (the counted `Option` decomposition) into the definition to get `defect_step`: $e(m+1)=-e(m)$ — the entire combinatorial content is this sign flip. Telescope from $e(0)=D(1)-D(0)=-1$ by induction (`defect_eq`) to $e(m)=(-1)^{m+1}$. Reading the defect off gives the multiplicative recurrence (`numDerangements_mul_recurrence` and its $n\\ge1$ subtracted-index form), and `abs_defect_eq_one` records $|D(n)-n\\,D(n-1)|=1$. `agrees_with_mathlib` checks the derived statement is definitionally Mathlib's `numDerangements_succ`.",
+    "keyInsights": [
+      "The multiplicative recurrence is not independent: it is a corollary of the additive one (the `Option` decomposition), obtained through the single algebraic device of the derangement defect $e(m)=D(m+1)-(m+1)D(m)$.",
+      "The whole combinatorial content is one line: the additive recurrence forces $e(m+1)=-e(m)$, so the defect merely flips sign at each step.",
+      "Telescoping that sign flip from the base value $e(0)=D(1)-D(0)=0-1=-1$ gives the pure alternating sign $e(m)=(-1)^{m+1}$, with the base case fitting so no $n\\ge1$ hypothesis is needed for the shifted form.",
+      "Reading the defect off yields $D(n)=n\\,D(n-1)+(-1)^n$ directly — and hence $|D(n)-n\\,D(n-1)|=1$, so $D(n)$ is always the integer nearest $n\\,D(n-1)$, the arithmetic source of $D(n)=\\mathrm{round}(n!/e)$.",
+      "Working over $\\mathbb{Z}$ lets `push_cast`/`ring`/`linarith` handle the signed algebra cleanly, keeping the derivation free of case analysis on parity.",
+      "`agrees_with_mathlib` certifies the two sign conventions $+(-1)^{m+1}$ and $-(-1)^m$ coincide, so the corollary is definitionally Mathlib's `numDerangements_succ` — a derivation, not a re-proof of a different statement."
+    ],
+    "prerequisites": [
+      "derangements and numDerangements",
+      "additive vs multiplicative recurrences",
+      "telescoping / induction over ℤ",
+      "inclusion–exclusion and D(n)=round(n!/e)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: additive to multiplicative, the plan",
+      "startLine": 1,
+      "endLine": 67,
+      "summary": "Docstring situating the file: the parent proved the additive recurrence $D(n)=(n-1)(D(n-1)+D(n-2))$ from the `Option` decomposition; the open question asks for the multiplicative $D(n)=n\\,D(n-1)+(-1)^n$ as a corollary. Introduces the derangement defect $e(m)$ and the six results, notes Mathlib's `numDerangements_succ` and the `decide` numerical checks. Imports Mathlib; opens the namespace."
+    },
+    {
+      "id": "defect-step",
+      "title": "defect and defect_step: the sign flip",
+      "startLine": 68,
+      "endLine": 83,
+      "summary": "Defines `defect m = D(m+1) - (m+1)·D(m)` over $\\mathbb{Z}$ and proves `defect_step`: feeding the additive recurrence `numDerangements_add_two` into the definition collapses it to $e(m+1)=-e(m)$ (via `push_cast`/`ring`). This sign flip is the whole combinatorial content."
+    },
+    {
+      "id": "defect-eq",
+      "title": "defect_eq: telescoping to an alternating sign",
+      "startLine": 85,
+      "endLine": 90,
+      "summary": "Telescopes `defect_step` by induction from the base $e(0)=D(1)-D(0)=-1$ (`decide`) to $e(m)=(-1)^{m+1}$, so the defect is a pure alternating sign."
+    },
+    {
+      "id": "mul-recurrence",
+      "title": "The multiplicative recurrence, both forms",
+      "startLine": 92,
+      "endLine": 109,
+      "summary": "`numDerangements_mul_recurrence` reads the defect off `defect_eq` to get $D(m+1)=(m+1)D(m)+(-1)^{m+1}$ for every $m$ (via `linarith`); `numDerangements_mul_recurrence'` rewrites it in the classical $n\\ge1$ truncated-subtraction form $D(n)=n\\,D(n-1)+(-1)^n$."
+    },
+    {
+      "id": "exact-defect",
+      "title": "The exact defect: D(n) nearest to n·D(n−1)",
+      "startLine": 111,
+      "endLine": 123,
+      "summary": "`numDerangements_sub_mul_pred` gives $D(n)-n\\,D(n-1)=(-1)^n$, and `abs_defect_eq_one` gives $|D(n)-n\\,D(n-1)|=1$ — $D(n)$ is always the integer nearest $n\\,D(n-1)$, the arithmetic heart of $D(n)=\\mathrm{round}(n!/e)$."
+    },
+    {
+      "id": "compat-checks",
+      "title": "Compatibility with Mathlib and numerical checks",
+      "startLine": 125,
+      "endLine": 154,
+      "summary": "`agrees_with_mathlib` proves the derived $+(-1)^{m+1}$ form is definitionally Mathlib's `numDerangements_succ` $-(-1)^m$ form. A block of `decide` examples checks $D(1..5)$, the recurrence at $n=5,6$, and the $\\pm1$ defect at $n=6$ — all 0-axiom (no `native_decide`)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Derives the multiplicative derangement recurrence $D(n)=n\\,D(n-1)+(-1)^n$ as a genuine corollary of the additive recurrence (`Option` decomposition), through the derangement defect $e(m)=D(m+1)-(m+1)D(m)$: it flips sign at each step (`defect_step`) and telescopes to $(-1)^{m+1}$ (`defect_eq`). Also records the exact defect $|D(n)-n\\,D(n-1)|=1$ and definitional agreement with Mathlib's `numDerangements_succ`. 0 sorries, no non-foundational axioms.",
+    "implications": "The entry answers the parent's open question by unifying the two classical derangement recurrences under a single decomposition, and exposes the arithmetic reason $D(n)=\\mathrm{round}(n!/e)$: $D(n)$ is always one away from $n\\,D(n-1)$ with alternating sign. The defect device is a reusable template for turning a two-term (additive) recurrence into a one-term (multiplicative) one for any sequence whose defect satisfies a simple sign law.",
+    "openQuestions": [
+      "Can the defect argument be pushed to derive the closed form $D(n)=\\mathrm{round}(n!/e)$ directly from $|D(n)-n\\,D(n-1)|=1$?",
+      "Does the same defect-telescoping technique yield the analogous one-term recurrence for other rencontres-type statistics (partial derangements, ménage numbers)?",
+      "Can the additive-to-multiplicative bridge be phrased abstractly for any strong recurrence sequence, isolating exactly which decompositions admit a sign-flipping defect?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-04-oq-04",
+      "relationship": "extends",
+      "description": "Direct parent: proves the additive recurrence $D(n)=(n-1)(D(n-1)+D(n-2))$ bijectively from the `Option` decomposition. This entry answers its open question by deriving the multiplicative recurrence from the same decomposition."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "related",
+      "description": "Root derangements entry (convergence $D(n)/n!\\to1/e$); the multiplicative recurrence and $\\pm1$ defect proved here underlie the closed form $D(n)=\\mathrm{round}(n!/e)$."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass: quality 0 → 100.

- **overview**: historical context (Montmort 1713, additive vs multiplicative recurrences, D(n)=round(n!/e)), problem statement, proof strategy, 6 key insights, prerequisites
- **sections**: 6 line-anchored sections covering the 154-line file (defect, sign-flip, telescoping, both recurrence forms, exact defect, compat/checks)
- **annotations**: 6 annotations, each with mathContext, significance, relatedConcepts, prerequisites
- **conclusion**: summary, implications, 3 open questions
- **crossReferences**: `derangements-convergence-oq-04-oq-04`, `derangements-convergence`

No Lean changes; gallery data only.