### PR TITLE
audit: record 7 clean gallery-integrity audits

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -27123,6 +27123,48 @@
       "lastAudited": "2026-07-05T02:27:44Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-06-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:18:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-galois-extensions-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:19:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-galois-extensions-oq-10": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:19:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abundant-number-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:19:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abundant-number-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:19:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abundant-number-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:19:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abundant-number-oq-03-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:19:29Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Records 7 clean audits in \`audit-tracker.json\`. All claims verified to match Lean source — no integrity violations found.

| Slug | Claim | Verdict |
|------|-------|---------|
| abel-ruffini-galois-extensions-oq-03-oq-01 | verified/original | ✅ genuine general-n Aₙ simplicity (773-line Jordan argument, NOT a Mathlib Fin-5 wrapper) |
| abel-ruffini-galois-extensions-oq-10 | verified/mathlib | ✅ honest S_n/A_n Galois-realization bridge |
| abel-ruffini-oq-06-oq-01-oq-03 | verified/mathlib | ✅ A₄ solvability, 0 sorry/axiom |
| abundant-number-oq-01-oq-02 | axiomatized/axiom | ✅ native_decide → Lean.ofReduceBool correctly counted + disclosed |
| abundant-number-oq-01-oq-04 | verified/original | ✅ 0 sorry/axiom |
| abundant-number-oq-02-oq-01 | verified/verified | ✅ kernel \`decide\` only, no native_decide |
| abundant-number-oq-03-oq-01-oq-03 | verified/verified | ✅ kernel \`decide\` only, no native_decide |

Also note: the 3 previously-flagged issues (erdos-741 True-stub FP, erdos-437/erdos-125 sorry mismatches) were resolved by #35151, now merged. \`find-targets --issues\` is clean (0).

---
Discovered during gallery integrity audit.