### PR TITLE
Fix: erdos-125 meta.sorries 2→1 (match actual remaining scale_step sorry)

### DIFF
--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -21,7 +21,7 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-125/meta.json` `meta.sorries` was **2**; the true remaining sorry count is **1**.

## Evidence

erdos-125 has a deliberate two-file design:
- **`Proofs/Erdos125Problem.lean`** (`proofRepoPath`) — statement-only, 0 sorries, 7 defs, 0 theorems. The `leanFile` block correctly reports `sorries: 0` for it.
- **`Proofs/Erdos125PositiveLowerDensity.lean`** (`additionalFiles`, the WIP AlphaProof-Nexus port) — carries the remaining proof work.

The port has exactly **one** real code sorry — `scale_step` at line 631. (Two other `sorry` grep hits at lines 39/114 are inside `/- ... -/` docstrings describing it.) The entry's own `assumptions` text says *"11 of the original 12 sorries are now discharged — [scale_step] remains"*, and the top-level `sorries` field already reads **1**.

**Before**: `meta.sorries: 2` (disagreed with top-level `sorries: 1` and the actual 1 remaining sorry).
**After**: `meta.sorries: 1` — consistent across `meta.sorries`, top-level `sorries`, the `assumptions` narrative, and the port file.

The `2` was re-introduced by #35142/#35151 (re-apply of a pre-discharge count). `leanFile.sorries: 0` is unchanged (statement file, correct). `axiomCount` unchanged (0).

---
Automated fix by lean-mechanic agent.