### PR TITLE
Enrich: Erdős #1047 OQ-02 — Chord-Exit De-axiomatization of the Goodman Counterexample

### DIFF
--- a/src/data/proofs/erdos-1047-oq-02-chord-exit/annotations.json
+++ b/src/data/proofs/erdos-1047-oq-02-chord-exit/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-goal-context",
+    "proofId": "erdos-1047-oq-02-chord-exit",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "context",
+    "title": "The Single Remaining Axiom and Its Reduction",
+    "content": "The flagship Erdős #1047 file rested on one analytic assumption, goodman_counterexample: the lemniscate {|f| ≤ c} of f = (X²+1)(X−2)² at c = 5^{3/2}/4 has a non-convex component. A companion reduction lemma turns this into a purely elementary task — exhibit a preconnected arc inside the sublevel set whose connecting chord pokes outside. This file supplies that certificate with all data exact and introduces no new axioms.",
+    "mathContext": "$f = (X^2+1)(X-2)^2, \\qquad c = 5^{3/2}/4, \\qquad L = \\{z : |f(z)| \\le c\\}$",
+    "significance": "context",
+    "relatedConcepts": ["lemniscate", "Grunsky conjecture", "de-axiomatization"],
+    "prerequisites": ["complex polynomials", "sublevel sets", "convexity"]
+  },
+  {
+    "id": "ann-normsq-poly",
+    "proofId": "erdos-1047-oq-02-chord-exit",
+    "range": { "startLine": 67, "endLine": 75 },
+    "type": "technique",
+    "title": "|f|² as a Real Polynomial in Re z, Im z",
+    "content": "normSq_goodman_eval expands |f(w)|² into a genuine real polynomial in x = Re w and y = Im w: the product of the first factor's squared modulus ((x²−y²+1)²+(2xy)²) with the fourth-power modulus ((x−2)²+y²)² of the double root. This polynomial form is what lets every membership test become an algebraic inequality amenable to nlinarith.",
+    "mathContext": "$|f(w)|^2 = \\big((x^2-y^2+1)^2 + (2xy)^2\\big)\\big((x-2)^2 + y^2\\big)^2$",
+    "significance": "supporting",
+    "relatedConcepts": ["complex modulus", "normSq", "real polynomials"],
+    "prerequisites": ["Complex.normSq", "real and imaginary parts", "ring normalization"]
+  },
+  {
+    "id": "ann-critical-value",
+    "proofId": "erdos-1047-oq-02-chord-exit",
+    "range": { "startLine": 81, "endLine": 98 },
+    "type": "concept",
+    "title": "The Critical Value c² = 125/16 and the Squaring Criterion",
+    "content": "goodmanCriticalValue_sq computes c² = 125/16 by unfolding c = 5^{3/2}/4 and simplifying the rpow via Real.rpow_mul. This is exactly the saddle level: the two non-trivial saddles (1±i)/2 satisfy |f|² = 125/16. norm_le_of_normSq_le then provides the bridge ‖z‖ ≤ c ⇐ normSq z ≤ c², converting every transcendental membership bound into a polynomial one.",
+    "mathContext": "$c^2 = \\left(\\tfrac{5^{3/2}}{4}\\right)^2 = \\tfrac{125}{16}, \\qquad \\mathrm{normSq}(z) \\le c^2 \\Rightarrow \\|z\\| \\le c$",
+    "significance": "supporting",
+    "relatedConcepts": ["critical/saddle value", "real rpow", "squaring criterion"],
+    "prerequisites": ["Real.rpow_mul", "Complex.sq_norm", "nlinarith"]
+  },
+  {
+    "id": "ann-arc-preconnected",
+    "proofId": "erdos-1047-oq-02-chord-exit",
+    "range": { "startLine": 124, "endLine": 139 },
+    "type": "technique",
+    "title": "The Preconnected Polyline Arc",
+    "content": "The arc is the polyline −i → (1−i)/2 → 2 → (1+i)/2 → +i threading the two saddles. arc_isPreconnected builds preconnectedness by repeatedly applying IsPreconnected.union at the shared endpoints (each segment is convex, hence preconnected, and consecutive segments meet at zB, zC, zD). Preconnectedness is what forces both endpoints −i and +i into a single component of the sublevel set.",
+    "mathContext": "$C = [z_A,z_B] \\cup [z_B,z_C] \\cup [z_C,z_D] \\cup [z_D,z_E], \\quad z_A=-i,\\, z_E=+i$",
+    "significance": "supporting",
+    "relatedConcepts": ["preconnected set", "polyline", "connected component"],
+    "prerequisites": ["IsPreconnected.union", "convex_segment", "segment endpoints"]
+  },
+  {
+    "id": "ann-sos-bernstein",
+    "proofId": "erdos-1047-oq-02-chord-exit",
+    "range": { "startLine": 143, "endLine": 176 },
+    "type": "insight",
+    "title": "The Sum-of-Squares / Bernstein Membership Certificate",
+    "content": "The technical heart. segment_subset_lemniscate reduces each segment to |f(z(s))|² ≤ 125/16 for s ∈ [0,1], with Re/Im affine in s. The degree-8 gap 125/16 − |f(z(s))|² has an all-nonnegative Bernstein decomposition, so nlinarith closes it when fed the nine boundary atoms sᵏ(1−s)^{8−k} ≥ 0 (k = 0…8): the gap is exactly a nonnegative linear combination of these, a Positivstellensatz-style certificate requiring no search.",
+    "mathContext": "$\\tfrac{125}{16} - |f(z(s))|^2 = \\sum_{k=0}^{8} c_k\\, s^k (1-s)^{8-k}, \\quad c_k \\ge 0$",
+    "significance": "key",
+    "relatedConcepts": ["sum of squares", "Bernstein basis", "Positivstellensatz"],
+    "prerequisites": ["nlinarith", "Bernstein polynomials", "nonnegativity certificates"]
+  },
+  {
+    "id": "ann-chord-exit-grunsky",
+    "proofId": "erdos-1047-oq-02-chord-exit",
+    "range": { "startLine": 258, "endLine": 291 },
+    "type": "insight",
+    "title": "The Chord Exit and the Falsity of the Grunsky Conjecture",
+    "content": "chord_exits shows the t = 1/2 chord point of ±i is the origin, where |f(0)| = 4 > c: the connecting chord leaves the sublevel set. goodman_counterexample_proof feeds the preconnected arc, its membership, and this chord exit into the topological reduction to witness a non-convex component, discharging the axiom. grunsky_false_of_chord_exit then re-derives ¬grunskyConjecture with no axioms — the whole conjecture is refuted from a checkable certificate.",
+    "mathContext": "$|f(0)| = |(0+1)(0-2)^2| = 4 > c \\;\\Rightarrow\\; \\text{component is non-convex} \\;\\Rightarrow\\; \\neg\\,\\text{grunskyConjecture}$",
+    "significance": "key",
+    "relatedConcepts": ["chord exit", "non-convexity", "Grunsky conjecture"],
+    "prerequisites": ["convex hull membership", "the topological reduction lemma", "proof by contradiction"]
+  }
+]

--- a/src/data/proofs/erdos-1047-oq-02-chord-exit/meta.json
+++ b/src/data/proofs/erdos-1047-oq-02-chord-exit/meta.json
@@ -38,6 +38,65 @@
     "erdosUrl": "https://www.erdosproblems.com/1047"
   },
   "sorries": 0,
+  "overview": {
+    "historicalContext": "A lemniscate is a sublevel set {z : |f(z)| ≤ c} of a polynomial (or entire) function f; its geometry — how its connected components sit and whether they are convex — has been studied since the nineteenth century and is bound up with the theory of univalent functions and the work of Helmut Grunsky on coefficient inequalities in the 1930s. A natural conjecture in this circle asks whether the connected components of such sublevel sets are convex; the question sharpens dramatically at the critical (saddle/merge) level c, where distinct components touch and change topology. Goodman is credited with the counterexample that the answer is no: for a suitably chosen low-degree f the component of the lemniscate at its critical value fails to be convex. Erdős problem #1047 sits in this landscape, and the Lean Genius formalization of it had been left resting on a single analytic assumption — the axiom goodman_counterexample asserting the existence of a non-convex component of the lemniscate of f = (X²+1)(X−2)² at c = 5^{3/2}/4 (the level at which the two non-trivial saddles (1±i)/2 satisfy |f| = c exactly). This file removes that axiom outright. The strategy is a triumph of the sum-of-squares paradigm that has reshaped real algebraic geometry since Artin's solution of Hilbert's 17th problem and its modern Positivstellensatz refinements: rather than reason about the transcendental region analytically, it exhibits a concrete piecewise-linear arc inside the sublevel set and certifies each segment's membership by an explicit, machine-checkable nonnegativity certificate in the Bernstein basis. The connecting chord of the arc's endpoints is then shown to leave the set — |f(0)| = 4 > c — so the component cannot be convex, and the headline ¬grunskyConjecture is re-derived with no axioms and no sorries.",
+    "problemStatement": "For f = (X²+1)(X−2)² and the critical value c = 5^{3/2}/4, prove that the connected component of the lemniscate L = {z : |f(z)| ≤ c} containing z₀ = −i is not convex, thereby discharging the axiom goodman_counterexample and re-deriving ¬grunskyConjecture. Concretely, exhibit a preconnected arc C ⊆ L joining −i to +i such that the connecting chord (at parameter t = 1/2, the origin) satisfies |f(0)| = 4 > c, so C's endpoints lie in one component whose convex hull escapes L.",
+    "proofStrategy": "The registered topological reduction componentContaining_lemniscate_not_convex_of_chord_exits reduces non-convexity to producing a preconnected arc inside L whose endpoints have a connecting chord leaving L. The arc is the polyline −i → (1−i)/2 → 2 → (1+i)/2 → +i through the two saddles (1±i)/2; arc_isPreconnected glues the four segments at shared endpoints. Membership of each segment reduces (segment_subset_lemniscate, via the squaring criterion norm_le_of_normSq_le and c² = 125/16) to the polynomial inequality |f(z(s))|² ≤ 125/16 for s ∈ [0,1], where |f|² = ((x²−y²+1)² + (2xy)²)·((x−2)²+y²)² with (x,y) affine in s. The gap 125/16 − |f(z(s))|² is a degree-8 polynomial with an all-nonnegative Bernstein decomposition, so nlinarith closes each segment when fed the nine boundary atoms sᵏ(1−s)^{8−k} ≥ 0. Finally chord_midpoint computes the t = 1/2 chord point as the origin, chord_exits shows |f(0)| = 4 > c, and goodman_counterexample_proof assembles these into the non-convexity witness; grunsky_false_of_chord_exit derives the conjecture's failure.",
+    "keyInsights": [
+      "Convexity is refuted constructively: producing one explicit chord whose interior leaves the sublevel set is enough, so the whole analytic problem collapses to bounding $|f|^2$ along four straight segments — a finite, decidable-in-spirit task.",
+      "The arc is threaded through the two non-trivial saddles $(1\\pm i)/2$, where $|f| = c$ exactly; $c = 5^{3/2}/4$ is precisely the merge/onset level, so the certificate operates right at the topological transition that makes the component non-convex.",
+      "Each segment bound is a genuine sum-of-squares certificate: the degree-8 gap $125/16 - |f(z(s))|^2$ is a nonnegative linear combination of the Bernstein atoms $s^k(1-s)^{8-k}$, which is exactly the data nlinarith needs to verify positivity without search.",
+      "Squaring is the bridge to polynomiality: norm_le_of_normSq_le converts the transcendental bound $\\|f(z)\\| \\le c$ into the polynomial bound $\\mathrm{normSq}(f(z)) \\le c^2 = 125/16$, and $|f|^2$ is a genuine real polynomial in $(\\mathrm{Re}\\,z, \\mathrm{Im}\\,z)$.",
+      "De-axiomatization matters for credibility: the parent development presented Erdős #1047 as resting on the single assumption goodman_counterexample; replacing it with a checkable certificate makes ¬grunskyConjecture a fully machine-verified theorem with #print axioms reporting only the foundational three."
+    ]
+  },
+  "sections": [
+    {
+      "id": "goal-and-reduction",
+      "title": "Goal — De-axiomatizing goodman_counterexample",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "The header states the single remaining axiom of the Erdős #1047 development — existence of a non-convex component of the lemniscate of f = (X²+1)(X−2)² at c = 5^{3/2}/4 — and the reduction (from the companion file) turning it into an elementary task: exhibit a preconnected arc inside {|f| ≤ c} whose connecting chord pokes outside. All certificate data (endpoints, chord, arc) is given exactly."
+    },
+    {
+      "id": "polynomial-and-critical-value",
+      "title": "The Goodman Polynomial and the Critical Value",
+      "startLine": 57,
+      "endLine": 99,
+      "summary": "goodman_eval and normSq_goodman_eval express f and |f|² = ((x²−y²+1)²+(2xy)²)((x−2)²+y²)² as ring-friendly real polynomials in Re/Im. goodmanCriticalValue_nonneg and goodmanCriticalValue_sq establish c ≥ 0 and c² = 125/16 (the saddle level), and norm_le_of_normSq_le is the squaring criterion converting ‖z‖ ≤ c to normSq z ≤ c²."
+    },
+    {
+      "id": "arc-endpoints-preconnected",
+      "title": "The Polyline Arc and Its Preconnectedness",
+      "startLine": 100,
+      "endLine": 140,
+      "summary": "Defines the five exact endpoints zA = −i, zB = (1−i)/2, zC = 2, zD = (1+i)/2, zE = +i (with re/im simp lemmas) and the polyline arc = [zA,zB]∪[zB,zC]∪[zC,zD]∪[zD,zE]. arc_isPreconnected glues the four convex segments at their shared endpoints via IsPreconnected.union."
+    },
+    {
+      "id": "segments-inside-sublevel",
+      "title": "Each Segment Inside the Sublevel Set via SOS/Bernstein",
+      "startLine": 141,
+      "endLine": 249,
+      "summary": "segment_subset_lemniscate reduces membership to |f(z(s))|² ≤ 125/16 on [0,1]. For each of the four segments (seg_AB/BC/CD/DE_subset) the real and imaginary parts are computed as affine functions of s, and the degree-8 gap is closed by nlinarith fed the nine Bernstein atoms sᵏ(1−s)^{8−k} ≥ 0. arc_subset_lemniscate unions them into arc ⊆ {|f| ≤ c}."
+    },
+    {
+      "id": "chord-exit-deaxiomatization",
+      "title": "The Chord Exit and De-axiomatization",
+      "startLine": 251,
+      "endLine": 292,
+      "summary": "chord_midpoint computes the t = 1/2 chord point of ±i as the origin; chord_exits shows |f(0)| = 4 > c. goodman_counterexample_proof feeds the preconnected arc, its sublevel membership, and the chord exit into the reduction to produce the non-convex component witness, discharging the axiom. grunsky_false_of_chord_exit re-derives ¬grunskyConjecture with no axioms."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry eliminates the last analytic axiom of the Erdős #1047 formalization. By constructing an explicit preconnected polyline arc through the lemniscate of f = (X²+1)(X−2)² at its critical value c = 5^{3/2}/4 and certifying each of its four segments' membership with an all-nonnegative degree-8 Bernstein/SOS decomposition (closed by nlinarith on the nine boundary atoms), it shows the connecting chord of the arc's endpoints leaves the sublevel set (|f(0)| = 4 > c). The registered topological reduction converts this into non-convexity of the −i component, discharging goodman_counterexample and re-deriving ¬grunskyConjecture. The result is fully machine-checked: 0 axioms, 0 sorries, and #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "implications": "Beyond closing Erdős #1047, the entry is a template for de-axiomatizing analytic existence claims by replacing them with explicit, checkable sum-of-squares certificates — the same paradigm that solved Hilbert's 17th problem, now applied inside a proof assistant. The Bernstein-basis nonnegativity trick (feeding nlinarith the atoms sᵏ(1−s)^{n−k}) is reusable for any polynomial bound along a parametrized segment, turning region-membership questions in complex geometry into finite algebra. The work also demonstrates the value of a topological reduction lemma that isolates the combinatorial core (arc + chord exit) from the analytic reasoning, so the hard verified content is a small, auditable certificate.",
+    "openQuestions": [
+      "Can the chord-exit certificate be generated automatically for other lemniscate counterexamples, or synthesized from the polynomial f by an SOS solver whose output is transcribed into Lean?",
+      "What is the minimal-degree polynomial f for which the lemniscate at its critical value has a non-convex component, and does the Bernstein-certificate method scale to prove minimality?",
+      "Does the convexity of lemniscate components hold below the critical level, and can that positive direction also be certified constructively rather than assumed?",
+      "Can the topological reduction (non-convexity from a chord exit through a preconnected arc) be generalized and upstreamed as a reusable Mathlib lemma about sublevel sets of continuous functions?"
+    ]
+  },
   "leanFile": {
     "path": "Proofs/Erdos1047OQ02ChordExit.lean",
     "lineCount": 292,


### PR DESCRIPTION
Enrichment pass for `erdos-1047-oq-02-chord-exit` (quality 0 → 100).

## Added
- **overview**: historicalContext (lemniscate convexity, Grunsky/Goodman, SOS paradigm & Hilbert's 17th), problemStatement, proofStrategy, 5 keyInsights.
- **sections**: 5 sections partitioning the full 292-line file (goal & reduction, polynomial & critical value, arc & preconnectedness, SOS/Bernstein segment bounds, chord exit & de-axiomatization).
- **conclusion**: summary, implications, 4 openQuestions.
- **annotations.json**: 6 annotations with mathContext (LaTeX), significance, relatedConcepts, prerequisites, anchored to the header, normSq_goodman_eval, goodmanCriticalValue_sq, arc_isPreconnected, the SOS/Bernstein certificate, and chord_exits/grunsky_false_of_chord_exit.

Content only (meta.json + annotations.json); original tags/erdosNumber/erdosUrl preserved (meta diff is pure addition). 0 axioms, 0 sorries preserved; status/badge unchanged.