### PR TITLE
Enrich: Erdős #1010 OQ-02 — Endpoints of the Minimum K_r Density Curve

### DIFF
--- a/src/data/proofs/erdos-1010-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1010-oq-02-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-context",
+    "proofId": "erdos-1010-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "Erdős #1010 and the Minimum K_r Density Problem",
+    "content": "Turán's theorem gives the maximum edge count ex(n, K_{r+1}) of a K_{r+1}-free graph; the deeper minimum-density problem asks how many copies of K_r are forced as edge density grows. Erdős #1010 OQ-02 seeks the exact minimum K_r density for r ≥ 5 — known for r = 3 (Razborov) and r = 4 (Reiher) via flag algebras, open beyond. This file de-axiomatizes the parent's forcing step and pins the provable endpoints of the unknown curve.",
+    "mathContext": "$g_r(d) = \\min\\{\\rho_r(G) : \\text{edge density}(G) = d\\}, \\quad \\rho_k(G) = \\dfrac{|\\{K_k \\subseteq G\\}|}{\\binom{n}{k}}$",
+    "significance": "context",
+    "relatedConcepts": ["Turán's theorem", "clique density", "flag algebras"],
+    "prerequisites": ["extremal graph theory", "clique", "edge density"]
+  },
+  {
+    "id": "ann-clique-mono",
+    "proofId": "erdos-1010-oq-02-oq-01",
+    "range": { "startLine": 62, "endLine": 67 },
+    "type": "technique",
+    "title": "Monotonicity of Clique Counts",
+    "content": "cliqueCount_mono proves that if G ≤ H then every k-clique of G is a k-clique of H, so cliqueCount G k ≤ cliqueCount H k — via Finset.card_le_card and cliqueFinset_mono. Adding edges can only create cliques, never destroy them. This structural monotonicity is the backbone of every supersaturation argument about how clique counts grow with edge density.",
+    "mathContext": "$G \\le H \\;\\Rightarrow\\; |\\mathrm{cliqueFinset}(G,k)| \\le |\\mathrm{cliqueFinset}(H,k)|$",
+    "significance": "supporting",
+    "relatedConcepts": ["monotonicity", "supersaturation", "subgraph order"],
+    "prerequisites": ["SimpleGraph order", "cliqueFinset_mono", "Finset.card_le_card"]
+  },
+  {
+    "id": "ann-turan-forcing",
+    "proofId": "erdos-1010-oq-02-oq-01",
+    "range": { "startLine": 77, "endLine": 93 },
+    "type": "insight",
+    "title": "De-axiomatizing the Turán Forcing Step",
+    "content": "not_cliqueFree_of_extremalNumber_lt is the key de-axiomatization: a graph with strictly more than ex(n, K_{r+1}) edges is not (r+1)-clique-free. It obtains ⊤ ⊑ G from IsContained.of_extremalNumber_lt_card_edgeFinset, then converts via cliqueFree_iff_top_free (CliqueFree(r+1) is ⊤-freeness on a size-(r+1) vertex set). This is exactly the statement the parent posited as axiom turan_theorem, now proved from Mathlib.",
+    "mathContext": "$\\mathrm{ex}(n, K_{r+1}) < |E(G)| \\;\\Rightarrow\\; \\neg\\, G.\\mathrm{CliqueFree}(r+1)$",
+    "significance": "key",
+    "relatedConcepts": ["Turán's theorem", "extremal number", "de-axiomatization"],
+    "prerequisites": ["extremalNumber", "IsContained", "cliqueFree_iff_top_free"]
+  },
+  {
+    "id": "ann-clique-count-form",
+    "proofId": "erdos-1010-oq-02-oq-01",
+    "range": { "startLine": 95, "endLine": 106 },
+    "type": "technique",
+    "title": "The Clique-Count Form of Forcing",
+    "content": "one_le_cliqueCount_of_extremalNumber_lt restates the qualitative forcing as a quantitative count: exceeding ex(n, K_{r+1}) forces at least one K_{r+1}. It turns ¬CliqueFree into a nonempty cliqueFinset (cliqueFinset_eq_empty_iff, nonempty_of_ne_empty), whose positive cardinality (card_pos) gives 1 ≤ cliqueCount G (r+1). This is the entry point to counting arguments above the threshold.",
+    "mathContext": "$\\mathrm{ex}(n, K_{r+1}) < |E(G)| \\;\\Rightarrow\\; 1 \\le \\mathrm{cliqueCount}(G, r+1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["clique count", "nonempty finset", "forcing threshold"],
+    "prerequisites": ["cliqueFinset_eq_empty_iff", "Finset.Nonempty.card_pos"]
+  },
+  {
+    "id": "ann-turan-endpoint",
+    "proofId": "erdos-1010-oq-02-oq-01",
+    "range": { "startLine": 117, "endLine": 158 },
+    "type": "insight",
+    "title": "The Turán Graph Realizes Density Zero — the Lower Endpoint",
+    "content": "turanGraph_cliqueFinset_eq_empty (from turanGraph_cliqueFree) shows the balanced r-partite Turán graph has no (r+1)-cliques; turanGraph_cliqueCount_eq_zero and turanGraph_cliqueDensity_eq_zero record count and density as exactly 0. Sitting at the Turán threshold with density 0, this graph is the rigorous lower endpoint of the open density curve g_{r+1}(d).",
+    "mathContext": "$\\rho_{r+1}(\\mathrm{turanGraph}\\, n\\, r) = 0$",
+    "significance": "key",
+    "relatedConcepts": ["Turán graph", "lower endpoint", "clique density"],
+    "prerequisites": ["turanGraph_cliqueFree", "cliqueFinset of a clique-free graph"]
+  },
+  {
+    "id": "ann-density-bounds",
+    "proofId": "erdos-1010-oq-02-oq-01",
+    "range": { "startLine": 135, "endLine": 150 },
+    "type": "definition",
+    "title": "Clique Density Confined to [0,1]",
+    "content": "cliqueDensity G k = |cliqueFinset G k| / C(n,k) is the normalized quantity whose minimum the open problem seeks. cliqueDensity_nonneg holds by positivity; cliqueDensity_le_one uses div_le_one against cliqueCount_le_choose (with the C(n,k) = 0 edge case handled separately). Normalizing by C(n,k) makes the density a well-defined object in [0,1] uniformly in n.",
+    "mathContext": "$0 \\le \\rho_k(G) = \\dfrac{\\mathrm{cliqueCount}(G,k)}{\\binom{n}{k}} \\le 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["normalized density", "unit interval", "binomial coefficient"],
+    "prerequisites": ["div_le_one", "positivity", "cliqueCount_le_choose"]
+  }
+]

--- a/src/data/proofs/erdos-1010-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1010-oq-02-oq-01/meta.json
@@ -32,6 +32,65 @@
     "erdosUrl": "https://www.erdosproblems.com/1010"
   },
   "sorries": 0,
+  "overview": {
+    "historicalContext": "Turán's theorem (Pál Turán, 1941) determines the maximum number of edges ex(n, K_{r+1}) in a graph on n vertices with no clique of size r+1, the extremal graph being the balanced r-partite Turán graph. A far deeper question — the clique density or supersaturation problem — asks not merely whether a clique is forced once the edge count exceeds the Turán threshold, but exactly how many copies are forced as the edge density grows: what is the minimum K_r-density g_r(d) among all graphs of edge density d? For triangles (r = 3) this minimum curve was famously determined by Razborov around 2008–2010 using his flag-algebra calculus, a landmark that brought semidefinite programming into extremal combinatorics; the r = 4 case was resolved by Reiher in 2016. Erdős problem #1010 sits in this circle, and its second open question concerns the exact minimum K_r density for r ≥ 5, which remains open. The parent Lean formalization of #1010 had stated the qualitative Turán forcing step — that exceeding the extremal edge count forces a clique — as an axiom, turan_theorem. This file removes that axiom entirely, deriving the forcing step for every r from Mathlib's extremal-graph API (extremalNumber and IsContained.of_extremalNumber_lt_card_edgeFinset), and then pins down the rigorous, machine-checked boundary of the still-unknown density curve: the extremal Turán graph realizes K_{r+1}-density exactly 0 (the lower endpoint), densities lie in [0,1], and clique counts are monotone under edge addition — the structural facts underlying every supersaturation argument. It does not resolve the r ≥ 5 problem; it certifies the provable frame within which the open curve must live.",
+    "problemStatement": "For each r, let ex(n, K_{r+1}) = extremalNumber n (⊤ : SimpleGraph (Fin (r+1))) be the Turán extremal number and ρ_{r+1}(G) = |cliqueFinset(r+1)| / C(n, r+1) the K_{r+1}-density. Prove, with no axioms: (i) any graph on n vertices with more than ex(n, K_{r+1}) edges contains a K_{r+1} (de-axiomatizing turan_theorem); (ii) the Turán graph turanGraph n r has K_{r+1}-density exactly 0; (iii) 0 ≤ ρ_{r+1}(G) ≤ 1; and (iv) clique counts are monotone under G ≤ H. This frames the endpoints and structural constraints of the open minimum-K_r-density curve g_r(d) for r ≥ 5.",
+    "proofStrategy": "Clique counting is done through Mathlib's SimpleGraph.cliqueFinset G k, with cliqueCount G k = |cliqueFinset G k|. cliqueCount_le_choose bounds counts by C(n,k) (a k-clique is a k-subset), and cliqueCount_mono lifts G ≤ H to counts via cliqueFinset_mono. The forcing step not_cliqueFree_of_extremalNumber_lt applies IsContained.of_extremalNumber_lt_card_edgeFinset to get ⊤ ⊑ G, then uses cliqueFree_iff_top_free to conclude ¬G.CliqueFree(r+1); one_le_cliqueCount_of_extremalNumber_lt restates it as a positive count via cliqueFinset_eq_empty_iff and card_pos. For the lower endpoint, turanGraph_cliqueFree gives turanGraph_cliqueFinset_eq_empty, hence turanGraph_cliqueCount_eq_zero and turanGraph_cliqueDensity_eq_zero. Density bounds follow by positivity and div_le_one against cliqueCount_le_choose.",
+    "keyInsights": [
+      "The parent's axiom turan_theorem is not an assumption but a theorem: Mathlib's extremalNumber API (IsContained.of_extremalNumber_lt_card_edgeFinset) discharges the general-r Turán forcing step directly, so the entire #1010 development becomes axiom-free.",
+      "CliqueFree(r+1) is definitionally ⊤-freeness on a vertex set of size r+1 (cliqueFree_iff_top_free), which is the precise hook that connects the extremal-number containment statement to the clique-count language the problem is phrased in.",
+      "The minimum-density problem is a supersaturation question, and its backbone is monotonicity: adding edges can only create cliques (cliqueCount_mono), so the density curve is studied as a lower envelope over graphs of fixed edge density.",
+      "The Turán graph anchors the lower endpoint: it sits exactly at the Turán threshold with K_{r+1}-density 0, so the open curve g_{r+1}(d) starts at 0 and the entire difficulty is its shape strictly above that point.",
+      "Normalizing counts by C(n, r+1) confines the density to [0,1] uniformly in n, which is what makes the minimum-density curve a well-defined analytic object amenable to the flag-algebra methods that solved r = 3 and r = 4."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context",
+      "title": "Context — The Minimum K_r Density Problem",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "The header frames Erdős #1010 OQ-02: the exact minimum number of K_r copies forced above the Turán threshold, known for r = 3 (Razborov) and r = 4 (Reiher) via flag algebras and open for r ≥ 5. It states the file's goal — de-axiomatize the parent's turan_theorem forcing step and pin the rigorous endpoints and structural constraints of the unknown density curve, without resolving the open problem."
+    },
+    {
+      "id": "clique-counting-api",
+      "title": "Clique Counting via cliqueFinset",
+      "startLine": 44,
+      "endLine": 67,
+      "summary": "Defines cliqueCount G k = |cliqueFinset G k| and proves the two structural facts every supersaturation argument rests on: cliqueCount_le_choose (a k-clique is a k-subset, so counts are ≤ C(n,k)) and cliqueCount_mono (adding edges only creates cliques, so G ≤ H implies count monotonicity via cliqueFinset_mono)."
+    },
+    {
+      "id": "turan-forcing",
+      "title": "General-r Turán Forcing (De-axiomatizing turan_theorem)",
+      "startLine": 69,
+      "endLine": 107,
+      "summary": "not_cliqueFree_of_extremalNumber_lt proves that exceeding ex(n, K_{r+1}) edges forces a K_{r+1}, using IsContained.of_extremalNumber_lt_card_edgeFinset and cliqueFree_iff_top_free — exactly the parent's axiom, now a theorem. one_le_cliqueCount_of_extremalNumber_lt restates it as a positive clique count via cliqueFinset_eq_empty_iff."
+    },
+    {
+      "id": "turan-graph-endpoint",
+      "title": "The Lower Endpoint — the Turán Graph",
+      "startLine": 108,
+      "endLine": 127,
+      "summary": "turanGraph_cliqueFinset_eq_empty (from turanGraph_cliqueFree) shows the balanced r-partite Turán graph has no (r+1)-cliques, and turanGraph_cliqueCount_eq_zero records the count as exactly 0. This graph sits at the Turán threshold and marks the lower endpoint of the open density curve g_{r+1}(d)."
+    },
+    {
+      "id": "density-in-unit-interval",
+      "title": "Clique Density in [0,1] and the Lower Endpoint",
+      "startLine": 128,
+      "endLine": 160,
+      "summary": "Defines the normalized density cliqueDensity G k = |cliqueFinset G k|/C(n,k) and proves cliqueDensity_nonneg and cliqueDensity_le_one (via div_le_one and cliqueCount_le_choose), confining it to [0,1]. turanGraph_cliqueDensity_eq_zero concludes the Turán graph realizes K_{r+1}-density exactly 0 — the rigorous lower endpoint of the curve."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry de-axiomatizes the Turán forcing step of the parent Erdős #1010 development for every r, deriving from Mathlib's extremal-graph API that exceeding ex(n, K_{r+1}) edges forces a K_{r+1}. It then establishes the rigorous frame of the still-unknown minimum K_r density curve g_r(d): the extremal Turán graph has K_{r+1}-density exactly 0 (the lower endpoint), all densities lie in [0,1], and clique counts are monotone under edge addition. It does not resolve the r ≥ 5 open problem — it certifies the provable boundary within which the open curve must live. Everything is machine-checked with 0 axioms and 0 sorries.",
+    "implications": "By replacing the axiom turan_theorem with a genuine proof, the entry makes the whole #1010 formalization axiom-free and demonstrates that Mathlib's extremalNumber development is strong enough to carry Turán-type forcing at full generality. The structural lemmas — clique-count monotonicity, the C(n,k) upper bound, and the Turán-graph zero-density endpoint — are exactly the ingredients a formalized supersaturation or flag-algebra argument would build on, so this is a foundation for future work toward the r = 3 (Razborov) and r = 4 (Reiher) density curves and, aspirationally, the open r ≥ 5 case. It also models the discipline of separating what is rigorously provable (the endpoints) from the open analytic content (the curve's shape).",
+    "openQuestions": [
+      "What is the exact minimum K_r density curve g_r(d) for r ≥ 5 — the central open content of Erdős #1010 OQ-02?",
+      "Can Razborov's flag-algebra certificate for r = 3 be transcribed into Lean to formalize the full triangle-density curve, building on the clique-count API established here?",
+      "Is there a machine-checkable supersaturation bound quantifying how the K_{r+1} count grows just above the Turán threshold, sharpening the qualitative forcing step?",
+      "Does the upper endpoint of the density curve (the complete graph, density 1) admit an equally clean characterization, and what is the provable shape of the curve near both endpoints?"
+    ]
+  },
   "leanFile": {
     "path": "Proofs/Erdos1010OQ02OQ01.lean",
     "lineCount": 160,


### PR DESCRIPTION
Enrichment pass for `erdos-1010-oq-02-oq-01` (quality 0 → 100).

## Added
- **overview**: historicalContext (Turán's theorem, clique-density/supersaturation, Razborov r=3 & Reiher r=4 flag algebras, open r≥5), problemStatement, proofStrategy, 5 keyInsights.
- **sections**: 5 sections partitioning the full 160-line file (context, clique-counting API, Turán forcing de-axiomatization, Turán-graph lower endpoint, density in [0,1]).
- **conclusion**: summary, implications, 4 openQuestions.
- **annotations.json**: 6 annotations with mathContext (LaTeX), significance, relatedConcepts, prerequisites, anchored to the header, cliqueCount_mono, not_cliqueFree_of_extremalNumber_lt, one_le_cliqueCount_of_extremalNumber_lt, the Turán-graph endpoint, and cliqueDensity bounds.

Content only (meta.json + annotations.json); meta built by merging into the original (all fields incl erdosNumber/erdosUrl preserved, diff is pure addition). 0 axioms, 0 sorries preserved; status/badge unchanged.