### PR TITLE
Enrich: Erdős #130 OQ-03 — Clique/Cardinality Sandwich for Integer-Distance Chromatic Numbers

### DIFF
--- a/src/data/proofs/erdos-130-wip-01-oq-03/annotations.json
+++ b/src/data/proofs/erdos-130-wip-01-oq-03/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-context",
+    "proofId": "erdos-130-wip-01-oq-03",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "context",
+    "title": "Integer-Distance Graphs and the Anning–Erdős Bound",
+    "content": "The integer-distance graph G(A) on a planar set A joins two distinct points iff their Euclidean distance is an integer. The Anning–Erdős theorem (1945) shows a general-position such set is finite, bounding its clique number ω by 4(2D+1)(2E+1). The chromatic number χ(G(A)) is the open main question of Erdős #130, a relative of the Hadwiger–Nelson chromatic-number-of-the-plane problem. This file pins the sandwich ω ≤ χ ≤ |A|.",
+    "mathContext": "$G(A): \\; p \\sim q \\iff p \\ne q \\text{ and } \\mathrm{dist}(p,q) \\in \\mathbb{Z}; \\quad \\omega(G(A)) \\le 4(2D+1)(2E+1)$",
+    "significance": "context",
+    "relatedConcepts": ["Anning–Erdős theorem", "chromatic number of the plane", "integer distances"],
+    "prerequisites": ["Euclidean distance", "graph colouring", "clique number"]
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "erdos-130-wip-01-oq-03",
+    "range": { "startLine": 55, "endLine": 82 },
+    "type": "definition",
+    "title": "The Graph-Theoretic Vocabulary",
+    "content": "The file defines the objects it reasons about: distSq (squared Euclidean distance), IsIntegerDist (distSq is a perfect natural square), the edge relation IntDistEdge (distinct points of A at integer distance), IsProperColoring and ChromaticAtMost (existence of a proper k-colouring), and HasClique (a k-subset pairwise at integer distance). These mirror the companion problem file so the sandwich results transfer directly.",
+    "mathContext": "$\\mathrm{distSq}(p,q) = (p_x-q_x)^2 + (p_y-q_y)^2, \\quad \\mathrm{IsIntegerDist}(p,q) \\iff \\exists n\\!\\in\\!\\mathbb{N},\\, \\mathrm{distSq}(p,q) = n^2$",
+    "significance": "supporting",
+    "relatedConcepts": ["squared distance", "proper colouring", "clique"],
+    "prerequisites": ["perfect squares", "graph edge relations"]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "erdos-130-wip-01-oq-03",
+    "range": { "startLine": 89, "endLine": 107 },
+    "type": "insight",
+    "title": "The Clique Lower Bound χ ≥ ω",
+    "content": "chromatic_ge_clique proves that a clique of size k together with a proper k'-colouring forces k ≤ k'. The proper colouring is injective on the clique S — any two distinct clique vertices are adjacent, hence differently coloured — so Finset.card_le_card_of_injOn maps S into Fin k' injectively, giving |S| = k ≤ k'. This is the pigeonhole lower bound ω(G(A)) ≤ χ(G(A)).",
+    "mathContext": "$\\text{clique size } k, \\; \\text{proper } k'\\text{-colouring} \\;\\Rightarrow\\; k \\le k'$",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "injective on a clique", "clique number"],
+    "prerequisites": ["Finset.card_le_card_of_injOn", "Set.InjOn", "proper colouring"]
+  },
+  {
+    "id": "ann-upper-bound",
+    "proofId": "erdos-130-wip-01-oq-03",
+    "range": { "startLine": 114, "endLine": 135 },
+    "type": "technique",
+    "title": "The Cardinality Upper Bound χ ≤ |A|",
+    "content": "injective_coloring_proper shows any injective colouring is proper, since edges join only distinct vertices (the injective map can never collide on an edge). chromatic_le_card then colours a finite nonempty A with A.card distinct colours by indexing vertices via A.equivFin : A ≃ Fin A.card and sending non-vertices to a fixed harmless colour — establishing χ(G(A)) ≤ |A|.",
+    "mathContext": "$A \\text{ finite nonempty} \\;\\Rightarrow\\; \\mathrm{ChromaticAtMost}(A, |A|)$",
+    "significance": "supporting",
+    "relatedConcepts": ["rainbow colouring", "equivFin indexing", "proper colouring"],
+    "prerequisites": ["Finset.equivFin", "Function.Injective", "distinct-vertex edges"]
+  },
+  {
+    "id": "ann-sandwich",
+    "proofId": "erdos-130-wip-01-oq-03",
+    "range": { "startLine": 139, "endLine": 147 },
+    "type": "insight",
+    "title": "The Sandwich ω ≤ χ ≤ |A|",
+    "content": "chromatic_finite combines the two bounds: for a finite nonempty set, any clique size k satisfies k ≤ |A| and G(A) is |A|-colourable. Together with the Anning–Erdős clique bound this locates the open chromatic number in the explicit window ω ≤ χ ≤ |A| ≤ 4(2D+1)(2E+1) for finite general-position integer-distance sets.",
+    "mathContext": "$\\omega(G(A)) \\le \\chi(G(A)) \\le |A| \\le 4(2D+1)(2E+1)$",
+    "significance": "key",
+    "relatedConcepts": ["sandwich bound", "finite chromatic number", "Anning–Erdős bound"],
+    "prerequisites": ["chromatic_ge_clique", "chromatic_le_card"]
+  },
+  {
+    "id": "ann-triangle",
+    "proofId": "erdos-130-wip-01-oq-03",
+    "range": { "startLine": 180, "endLine": 211 },
+    "type": "context",
+    "title": "The 3–4–5 Triangle Forces χ ≥ 3",
+    "content": "A concrete witness that χ(G(A)) can exceed 2: the right triangle P₀=(0,0), P₁=(3,0), P₂=(0,4) has pairwise distances 3, 4, 5 (all integers, verified by norm_num on the squared distances) and three distinct vertices, so it is a size-3 clique. triangle_345_needs_three_colors feeds this clique into chromatic_ge_clique to force at least three colours in any proper colouring.",
+    "mathContext": "$\\{(0,0),(3,0),(0,4)\\}: \\; 3^2, 4^2, 3^2{+}4^2{=}5^2 \\;\\Rightarrow\\; \\text{clique of size } 3 \\Rightarrow \\chi \\ge 3$",
+    "significance": "context",
+    "relatedConcepts": ["Pythagorean triple", "concrete clique", "lower-bound witness"],
+    "prerequisites": ["3–4–5 right triangle", "norm_num", "chromatic_ge_clique"]
+  }
+]

--- a/src/data/proofs/erdos-130-wip-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-130-wip-01-oq-03/meta.json
@@ -32,6 +32,65 @@
     "erdosUrl": "https://www.erdosproblems.com/130"
   },
   "sorries": 0,
+  "overview": {
+    "historicalContext": "In 1945 Norman Anning and Paul Erdős proved a striking rigidity theorem: any set of points in the plane with all pairwise distances integers, if it is not contained in a single line, must be finite. This 'Integral Distances' result (Bull. Amer. Math. Soc. 51) launched a long line of questions about integer- and rational-distance point sets, including the still-open Erdős–Ulam problem on dense rational-distance sets. Erdős problem #130 attaches a graph to such a set A ⊆ ℝ²: the integer-distance graph G(A) whose vertices are the points of A, with an edge between two distinct points exactly when their Euclidean distance is an integer. The Anning–Erdős theorem bounds the clique number ω(G(A)) of a general-position set by the explicit 4(2D+1)(2E+1), but the chromatic number χ(G(A)) — the minimum number of colour classes needed so that no two integer-distance points share a colour — is the open main question, a relative of the famous Hadwiger–Nelson chromatic-number-of-the-plane problem. This file does not resolve χ; instead it nails down the two elementary but load-bearing inequalities that sandwich it. Every proper colouring is injective on a clique (pigeonhole), giving χ ≥ ω; and colouring each of the |A| vertices a distinct colour is proper because edges only join distinct vertices, giving χ ≤ |A|. Together with the Anning–Erdős clique bound these locate the open chromatic number in the concrete window ω ≤ χ ≤ |A| ≤ 4(2D+1)(2E+1) for finite general-position sets, and an explicit 3–4–5 right triangle witnesses that χ can exceed 2.",
+    "problemStatement": "Let A ⊆ ℝ² and let G(A) be the integer-distance graph (vertices A, edges between distinct points at integer Euclidean distance). Writing ω for the clique number and χ for the chromatic number, prove the sandwich ω(G(A)) ≤ χ(G(A)) ≤ |A| for finite A: concretely, if G(A) has a clique of size k and a proper k'-colouring then k ≤ k' (chromatic_ge_clique), and a finite nonempty A is |A|-colourable (chromatic_le_card). Deduce that for finite general-position sets χ is finite and located in ω ≤ χ ≤ |A|, and exhibit a 3–4–5 triangle forcing χ ≥ 3.",
+    "proofStrategy": "The graph-theoretic vocabulary (Point2, distSq, IsIntegerDist, IntDistEdge, IsProperColoring, ChromaticAtMost, HasClique) mirrors the companion problem file. The lower bound chromatic_ge_clique observes that a proper colouring c must be injective on any clique S (adjacent vertices get distinct colours), so Finset.card_le_card_of_injOn against Fin k' gives |S| = k ≤ k'. The upper bound splits into injective_coloring_proper (an injective colouring is automatically proper since edges join only distinct vertices) and chromatic_le_card, which indexes the |A| vertices by A.equivFin : A ≃ Fin A.card, extending to ℝ² by sending non-vertices to a fixed colour. chromatic_finite combines the two into the window. The concrete bound builds the 3–4–5 right triangle P₀=(0,0), P₁=(3,0), P₂=(0,4), verifies its three pairwise distances are integers (3,4,5) and its vertices distinct, and feeds the resulting size-3 clique into chromatic_ge_clique to force χ ≥ 3.",
+    "keyInsights": [
+      "The chromatic number is squeezed by two facts of opposite character: a combinatorial obstruction from below (a clique of size k needs k colours) and a trivial construction from above (distinct colours for distinct vertices always work), so ω ≤ χ ≤ |A| with no deep input.",
+      "The lower bound is pure pigeonhole made precise: a proper colouring restricted to a clique is injective, so Finset.card_le_card_of_injOn transfers the clique size directly into a colour-count lower bound.",
+      "The upper bound hinges on edges relating only distinct vertices — injective_coloring_proper shows any injective colouring is proper, so the 'rainbow' colouring is the crude but valid witness that χ ≤ |A|.",
+      "Combining the sandwich with the Anning–Erdős clique bound 4(2D+1)(2E+1) converts a purely graph-theoretic window into an explicit numeric one, ω ≤ χ ≤ |A| ≤ 4(2D+1)(2E+1), for finite general-position integer-distance sets.",
+      "The 3–4–5 right triangle is a minimal concrete certificate that χ(G(A)) is genuinely a graph invariant and not trivially 2: three pairwise-integer-distance points form a triangle (clique of size 3), forcing at least three colours."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context",
+      "title": "Context — Integer-Distance Graphs and Erdős #130",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "The header introduces the integer-distance graph G(A) on a planar point set A, recalls the Anning–Erdős (1945) finiteness/clique bound 4(2D+1)(2E+1), and frames the open main question: the chromatic number χ(G(A)). It states this file's contribution — the sandwich χ ≥ ω and χ ≤ |A| and its consequence — with references to Anning–Erdős and erdosproblems.com/130."
+    },
+    {
+      "id": "graph-setup",
+      "title": "Graph-Theoretic Setup",
+      "startLine": 44,
+      "endLine": 83,
+      "summary": "Defines Point2, squared distance distSq, IsIntegerDist (distSq is a perfect square), the edge relation IntDistEdge (distinct points of A at integer distance), IsProperColoring, ChromaticAtMost (∃ proper k-colouring), and HasClique (a k-subset pairwise at integer distance). These mirror the companion problem file so results transfer directly."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Lower Bound χ(G(A)) ≥ ω(G(A))",
+      "startLine": 84,
+      "endLine": 108,
+      "summary": "chromatic_ge_clique proves that a clique of size k plus a proper k'-colouring forces k ≤ k'. The colouring is injective on the clique (adjacent vertices differ in colour), so Finset.card_le_card_of_injOn against Fin k' yields |S| = k ≤ k' — the pigeonhole lower bound ω ≤ χ."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Upper Bound χ(G(A)) ≤ |A|",
+      "startLine": 109,
+      "endLine": 136,
+      "summary": "injective_coloring_proper shows any injective colouring is proper (edges join only distinct vertices). chromatic_le_card then colours a finite nonempty A with A.card distinct colours via A.equivFin : A ≃ Fin A.card, extending to non-vertices by a fixed colour — establishing χ ≤ |A|."
+    },
+    {
+      "id": "sandwich-and-triangle",
+      "title": "The Sandwich and a Concrete χ ≥ 3 Witness",
+      "startLine": 137,
+      "endLine": 216,
+      "summary": "chromatic_finite combines the two bounds into the window ω ≤ χ ≤ |A| for finite general-position sets. The 3–4–5 right triangle P₀,P₁,P₂ is then shown to have integer pairwise distances (3,4,5) and distinct vertices, forming a size-3 clique; triangle_345_needs_three_colors feeds it into the lower bound to force χ ≥ 3. #print axioms confirms no axioms."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry establishes the two elementary but load-bearing inequalities sandwiching the open chromatic number χ(G(A)) of integer-distance graphs: χ ≥ ω via pigeonhole on a clique (chromatic_ge_clique) and χ ≤ |A| via the rainbow colouring (chromatic_le_card, resting on injective_coloring_proper). Their consequence chromatic_finite places χ in the window ω ≤ χ ≤ |A| for finite general-position sets, which together with the Anning–Erdős clique bound gives ω ≤ χ ≤ |A| ≤ 4(2D+1)(2E+1). An explicit 3–4–5 right triangle certifies χ ≥ 3. Everything is machine-checked with 0 axioms and 0 sorries, confirmed by #print axioms.",
+    "implications": "By fixing the rigorous frame ω ≤ χ ≤ |A|, the entry turns the open Erdős #130 chromatic-number question into a search for the true position of χ within an explicit, finite window rather than an unbounded quantity, and connects the integer-distance problem to the broader chromatic-number-of-the-plane circle (Hadwiger–Nelson). The graph-theoretic API — proper colourings, clique sizes, and the injective-colouring lemma — is reusable for any distance-graph colouring argument, and the concrete 3–4–5 witness shows the sandwich is non-trivial. It also cleanly separates what is provable (the endpoints) from the genuinely open content (the exact chromatic number for optimal general-position sets).",
+    "openQuestions": [
+      "What is the exact chromatic number χ(G(A)) for optimal general-position integer-distance sets — the open main question of Erdős #130?",
+      "Can the lower bound ω be improved beyond the largest clique, e.g. via odd-cycle or fractional-chromatic arguments specific to integer-distance graphs?",
+      "How does the integer-distance chromatic number relate quantitatively to the Hadwiger–Nelson chromatic number of the plane, and can bounds transfer between them?",
+      "Is there a finite general-position configuration with χ strictly between its clique number and |A|, exhibiting a genuine gap in the sandwich?"
+    ]
+  },
   "leanFile": {
     "path": "Proofs/Erdos130WIP01OQ03.lean",
     "lineCount": 216,


### PR DESCRIPTION
Enrichment pass for `erdos-130-wip-01-oq-03` (quality 0 → 100).

## Added
- **overview**: historicalContext (Anning–Erdős 1945 integral distances, chromatic-number-of-the-plane / Hadwiger–Nelson connection), problemStatement, proofStrategy, 5 keyInsights.
- **sections**: 5 sections partitioning the full 216-line file (context, graph setup, lower bound χ≥ω, upper bound χ≤|A|, sandwich + 3–4–5 triangle witness).
- **conclusion**: summary, implications, 4 openQuestions.
- **annotations.json**: 6 annotations with mathContext (LaTeX), significance, relatedConcepts, prerequisites, anchored to the header, the graph-setup defs, chromatic_ge_clique, chromatic_le_card, chromatic_finite, and triangle_345_needs_three_colors.

Content only (meta.json + annotations.json); meta merged into original (all fields incl erdosNumber/erdosUrl preserved, diff is pure addition). 0 axioms, 0 sorries preserved; status/badge unchanged.