### PR TITLE
audit: fix stat drift (algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01) + record 6 clean audits

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/meta.json
@@ -55,8 +55,8 @@
       "Two disjoint dense Gδ sets cannot coexist in a nonempty Baire space"
     ],
     "relatedProblems": [],
-    "lineCount": 89,
-    "theoremCount": 4,
+    "lineCount": 121,
+    "theoremCount": 6,
     "definitionCount": 0,
     "additionalFiles": []
   },
@@ -168,9 +168,9 @@
     "imports": ["Proofs.AlgebraicNumbersCountableOQ02OQ03OQ02", "Proofs.AlgebraicRealsMeagerDenseGDeltaOQ01", "Mathlib"],
     "opens": ["Set", "Topology"],
     "namespace": "AlgebraicNumbersCountableOQ02OQ03OQ02OQ01",
-    "lineCount": 89,
+    "lineCount": 121,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -27165,6 +27165,42 @@
       "lastAudited": "2026-07-08T04:19:29Z",
       "result": "clean",
       "issues": []
+    },
+    "abundant-number-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:29:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "algebraic-numbers-countable-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:29:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "algebraic-numbers-countable-oq-02-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:29:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "algebraic-numbers-countable-oq-05-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:29:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "alternating-series-boole-summation-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:29:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T04:29:16Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audit pass over 6 targets; five clean, one metadata fix.

### Issue found & fixed
**`algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01`** — stat drift (LOW severity):
- `lineCount` 89 → 121 (actual)
- `theoremCount` 4 → 6 (actual: 6 `theorem` declarations)
- Corrected in **both** the `meta.*` and `leanFile.*` stat blocks.

The Lean source grew after the counts were first recorded (file salvaged from PR #34683). Verification claims were already accurate and are unchanged: `status: verified`, `badge: original`, 0 sorries, 0 axioms. The `original` badge is justified — the Baire-category engine lives in this project's own parent files (`compl_countable_isDenseGδ`, `not_isGδ_of_dense_of_disjoint_denseGδ`), not a Mathlib black-box.

### Clean (no issues)
- `abundant-number-oq-03-oq-02` — 0 sorry / 0 axiom, all counts match, genuine counting-function bound (not a Mathlib wrapper)
- `algebraic-numbers-countable-oq-01-oq-01-oq-01`
- `algebraic-numbers-countable-oq-02-oq-02-oq-03`
- `algebraic-numbers-countable-oq-05-oq-04-oq-01`
- `alternating-series-boole-summation-oq-01-oq-02`

Also records these six completions in `audit-tracker.json` so they persist across the auditor's `reset --hard` sync cycle.

---
Discovered during autonomous gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)