### PR TITLE
Enrich: derangement quotient A000255 (derangements-convergence-oq-04-oq-01) — add annotations

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-04-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-context-a000255",
+    "proofId": "derangements-convergence-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "The Derangement Quotient and OEIS A000255",
+    "content": "The parent entry showed (n−1) divides the derangement count D(n) via the additive recurrence D(n) = (n−1)(D(n−2)+D(n−1)). This file identifies the resulting integer quotient q(n) = D(n)/(n−1) = D(n−2)+D(n−1) as OEIS A000255, which counts permutations of an (m+1)-set with exactly one fixed point (divided by m+1), with terms 1, 1, 3, 11, 53, 309, …",
+    "mathContext": "$q(n) = \\dfrac{D(n)}{n-1} = D(n-2) + D(n-1), \\qquad \\text{A000255}: 1,1,3,11,53,309,\\dots$",
+    "significance": "context",
+    "relatedConcepts": ["derangements", "OEIS A000255", "subfactorial"],
+    "prerequisites": ["derangement number", "integer divisibility", "OEIS"]
+  },
+  {
+    "id": "ann-q-def",
+    "proofId": "derangements-convergence-oq-04-oq-01",
+    "range": { "startLine": 51, "endLine": 57 },
+    "type": "definition",
+    "title": "The Reindexed Quotient Sequence q",
+    "content": "q is defined subtraction-free as q m = D(m) + D(m+1), which under the parent's indexing equals q(m+2) = D(m+2)/(m+1). Working over ℕ without subtraction keeps every downstream lemma clean (no truncated-subtraction side conditions). q_eq is the trivial unfolding lemma.",
+    "mathContext": "$q\\,m := \\mathrm{numDerangements}(m) + \\mathrm{numDerangements}(m+1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["reindexing", "derangement number", "natural-number arithmetic"],
+    "prerequisites": ["numDerangements", "definitional unfolding"]
+  },
+  {
+    "id": "ann-quotient-identity",
+    "proofId": "derangements-convergence-oq-04-oq-01",
+    "range": { "startLine": 59, "endLine": 67 },
+    "type": "insight",
+    "title": "q Really Is the Integer Quotient D(n)/(n−1)",
+    "content": "numDerangements_eq_sub_one_mul_q proves D(n) = (n−1)·q(n−2) for n ≥ 2. Writing n = m+2 and unfolding q, the parent's additive recurrence numDerangements_add_two closes it directly. Combined with the parent's divisibility result, this pins q(n−2) as exactly the integer quotient D(n)/(n−1) — the object the open question asked to identify.",
+    "mathContext": "$\\mathrm{numDerangements}(n) = (n-1)\\cdot q(n-2), \\qquad n \\ge 2$",
+    "significance": "key",
+    "relatedConcepts": ["integer quotient", "divisibility", "derangement recurrence"],
+    "prerequisites": ["numDerangements_add_two", "existence reindexing (obtain)"]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "derangements-convergence-oq-04-oq-01",
+    "range": { "startLine": 69, "endLine": 86 },
+    "type": "insight",
+    "title": "The Second-Order A000255 Recurrence",
+    "content": "q_add_two establishes q(m+2) = (m+2)·q(m+1) + (m+1)·q(m), the defining recurrence of A000255. It is NOT a restatement of the derangement recurrence: expanding both D(m+2) and D(m+3) via numDerangements_add_two and regrouping, the four consecutive derangement values reassemble into q(m+1) and q(m) with polynomial coefficients m+2 and m+1, closed by ring.",
+    "mathContext": "$q(m+2) = (m+2)\\,q(m+1) + (m+1)\\,q(m)$",
+    "significance": "key",
+    "relatedConcepts": ["linear recurrence", "OEIS A000255", "generating recurrence"],
+    "prerequisites": ["numDerangements_add_two", "ring tactic", "second-order recurrence"]
+  },
+  {
+    "id": "ann-base-values",
+    "proofId": "derangements-convergence-oq-04-oq-01",
+    "range": { "startLine": 88, "endLine": 92 },
+    "type": "technique",
+    "title": "Base Values q(0) = q(1) = 1",
+    "content": "q_zero and q_one compute the two initial values by decide: q 0 = D(0)+D(1) = 1+0 = 1 and q 1 = D(1)+D(2) = 0+1 = 1. These pin the initial conditions that, together with the second-order recurrence, uniquely determine the sequence as A000255 (whose convention is a(0)=a(1)=1).",
+    "mathContext": "$q(0) = D(0)+D(1) = 1, \\qquad q(1) = D(1)+D(2) = 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["initial conditions", "decidable evaluation", "sequence determination"],
+    "prerequisites": ["decide tactic", "small derangement values"]
+  },
+  {
+    "id": "ann-terms-verification",
+    "proofId": "derangements-convergence-oq-04-oq-01",
+    "range": { "startLine": 94, "endLine": 103 },
+    "type": "context",
+    "title": "Tabulated Terms and Cross-Checks",
+    "content": "The examples verify q 2..5 = 3, 11, 53, 309 by decide (the first A000255 terms), that the recurrence reproduces them (q 4 = 4·q 3 + 3·q 2 = 53), and the quotient identity D(6) = 5·q(4) = 265. These decidable checks certify the closed recurrence and quotient identity against the tabulated integer sequence, guarding against off-by-one indexing errors.",
+    "mathContext": "$q(2),\\dots,q(5) = 3, 11, 53, 309; \\quad D(6) = 5\\cdot q(4) = 265$",
+    "significance": "context",
+    "relatedConcepts": ["numerical verification", "OEIS A000255", "sanity checks"],
+    "prerequisites": ["decide tactic", "the recurrence and quotient identity"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `derangements-convergence-oq-04-oq-01` (quality 45 → 100).

The entry already had overview, 5 sections, and conclusion but **no annotations.json** (annotations/mathContext/significance/crossRefs all scored 0). This adds the missing file.

## Added
- **annotations.json**: 6 annotations, each with mathContext (LaTeX), significance, relatedConcepts, prerequisites — anchored to the A000255 context header, the q definition, the quotient identity D(n)=(n−1)·q(n−2), the second-order recurrence q(m+2)=(m+2)q(m+1)+(m+1)q(m), the base values, and the tabulated-term cross-checks.

Fills the only empty scorer buckets. Content only (single file). 0 axioms, 0 sorries; status/badge unchanged.