### PR TITLE
Enrich Unconditional Sublinearity of Prime Gaps from BHP

### DIFF
--- a/src/data/proofs/erdos-1138-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "erdos-1138-oq-03-oq-01-header",
+    "proofId": "erdos-1138-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "context",
+    "title": "Setup: inheriting the BHP bound from the parent",
+    "content": "The module docstring frames the follow-up: the parent `Erdos1138OQ03` records the deep Baker–Harman–Pintz bound $G(x) \\leq x^{0.525}$ (for $x \\geq 25$) as `axiom baker_harman_pintz`, alongside the *conditional* Cramér-flavoured `cramer_implies_gap_sublinear`. Reopening `namespace Erdos1138OQ03` (line 29) brings both `maxPrimeGap` and the BHP axiom into scope without re-declaring anything, and `open Filter Topology` (line 31) makes `Tendsto`, `atTop`, and `𝓝` available unqualified. No new axiom is introduced here — the entry stays `axiomatized` purely through the imported BHP bound.",
+    "mathContext": "$G(x) = \\max\\{q - p : p, q \\text{ consecutive primes}, q \\leq x\\}$, with the inherited assumption $G(x) \\leq x^{0.525}$ for $x \\geq 25$.",
+    "significance": "context",
+    "relatedConcepts": ["prime gaps", "Baker–Harman–Pintz theorem", "axiom inheritance", "namespaces in Lean"],
+    "prerequisites": ["analytic number theory", "Lean 4 module system"]
+  },
+  {
+    "id": "erdos-1138-oq-03-oq-01-envelope",
+    "proofId": "erdos-1138-oq-03-oq-01",
+    "range": { "startLine": 33, "endLine": 50 },
+    "type": "technique",
+    "title": "Pointwise upper envelope via power subtraction",
+    "content": "`gap_div_le_rpow_neg` divides the BHP bound by $x$ to expose a *negative* power. The crux is the identity $x^{0.525}/x = x^{0.525 - 1} = x^{-0.475}$, proved on line 45 by rewriting $-0.475$ as $0.525 - 1$ (line 44) and applying `Real.rpow_sub hx_pos` followed by `Real.rpow_one`. This route avoids the common trap of rewriting the denominator $x$ as $x^1$, which `rpow_one` would attach to the wrong occurrence. The inequality itself (line 47–48) is monotonicity of division under a fixed positive denominator, discharged by `gcongr` with the BHP bound `baker_harman_pintz x hx` supplied as the numerator inequality.",
+    "mathContext": "$\\dfrac{G(x)}{x} \\leq \\dfrac{x^{0.525}}{x} = x^{0.525 - 1} = x^{-0.475}$ for $x \\geq 25 > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["real powers (rpow)", "power laws", "monotonicity of division", "gcongr"],
+    "prerequisites": ["Real.rpow arithmetic", "ordered field inequalities"]
+  },
+  {
+    "id": "erdos-1138-oq-03-oq-01-positivity",
+    "proofId": "erdos-1138-oq-03-oq-01",
+    "range": { "startLine": 39, "endLine": 41 },
+    "type": "technique",
+    "title": "Casting positivity from ℕ to ℝ",
+    "content": "Before any real-power manipulation, the proof establishes $0 < (x : \\mathbb{R})$ from $25 \\leq x$. The natural-number inequality $0 < x$ comes from `lt_of_lt_of_le (by norm_num) hx`, then `exact_mod_cast` transports it across the `Nat → ℝ` cast. This `hx_pos` hypothesis is the side condition required by both `Real.rpow_sub` (which needs a positive base) and the division-monotonicity step.",
+    "mathContext": "$25 \\leq x \\Rightarrow 0 < x \\Rightarrow 0 < (x : \\mathbb{R})$, the base-positivity hypothesis for `rpow_sub`.",
+    "significance": "technical",
+    "relatedConcepts": ["numeric casts", "exact_mod_cast", "rpow base positivity"],
+    "prerequisites": ["Lean coercions", "order lemmas"]
+  },
+  {
+    "id": "erdos-1138-oq-03-oq-01-limit",
+    "proofId": "erdos-1138-oq-03-oq-01",
+    "range": { "startLine": 52, "endLine": 70 },
+    "type": "insight",
+    "title": "Unconditional sublinearity by the squeeze theorem",
+    "content": "`bhp_implies_gap_littleo` is the headline result: $G(x)/x \\to 0$. It assembles three ingredients for `squeeze_zero'`. The upper envelope $x^{-0.475} \\to 0$ (lines 60–62) is `tendsto_rpow_neg_atTop` — which needs only $0 < 0.475$ — composed with `tendsto_natCast_atTop_atTop` to move from the real variable to the $\\mathbb{N}$-indexed sequence. The lower bound $0 \\leq G(x)/x$ (lines 64–65) is `div_nonneg` on two nonnegative casts and holds *everywhere*. The upper bound (lines 67–68) holds only *eventually*, for $x \\geq 25$, packaged via `(eventually_ge_atTop 25).mono`. `squeeze_zero'` (line 70) tolerates the eventual (rather than pointwise) upper bound, delivering the limit.",
+    "mathContext": "$0 \\leq \\dfrac{G(x)}{x} \\leq x^{-0.475} \\to 0 \\;\\Rightarrow\\; \\dfrac{G(x)}{x} \\to 0.$",
+    "significance": "key",
+    "relatedConcepts": ["squeeze theorem", "Filter.Tendsto", "eventually filters", "little-o asymptotics", "filter composition"],
+    "prerequisites": ["limits and neighbourhood filters", "asymptotics of real powers"]
+  },
+  {
+    "id": "erdos-1138-oq-03-oq-01-cast-bridge",
+    "proofId": "erdos-1138-oq-03-oq-01",
+    "range": { "startLine": 60, "endLine": 62 },
+    "type": "technique",
+    "title": "Bridging ℝ-asymptotics to an ℕ-indexed sequence",
+    "content": "The envelope lemma `tendsto_rpow_neg_atTop` is stated for a real variable, but `maxPrimeGap` is indexed by $\\mathbb{N}$. Composing with `tendsto_natCast_atTop_atTop` — which says the cast $\\mathbb{N} \\hookrightarrow \\mathbb{R}$ tends to $+\\infty$ along `atTop` — pulls the real limit back to the natural-number filter. This `.comp` pattern is the idiomatic Mathlib bridge whenever a continuous-variable asymptotic must be applied to a sequence.",
+    "mathContext": "$(n \\mapsto (n:\\mathbb{R})) \\to \\infty$ composed with $(t \\mapsto t^{-0.475}) \\to 0$ gives $(n \\mapsto n^{-0.475}) \\to 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["filter composition", "Tendsto.comp", "natCast", "atTop filter"],
+    "prerequisites": ["filter limits", "function composition of limits"]
+  },
+  {
+    "id": "erdos-1138-oq-03-oq-01-eps-form",
+    "proofId": "erdos-1138-oq-03-oq-01",
+    "range": { "startLine": 72, "endLine": 82 },
+    "type": "concept",
+    "title": "ε-form: clearing the denominator",
+    "content": "`bhp_gap_eventually_le_eps` restates the limit in the classical $\\varepsilon$-language: for every $\\varepsilon > 0$, eventually $G(x) \\leq \\varepsilon x$. From the limit, `bhp_implies_gap_littleo.eventually (eventually_lt_nhds hε)` (lines 77–78) gives $G(x)/x < \\varepsilon$ eventually. `filter_upwards` then intersects that with $x \\geq 1$ (guaranteeing $0 < x$), and `div_lt_iff₀ hx_pos` (line 81) clears the denominator to $G(x) < \\varepsilon x$, weakened to $\\leq$ by `le_of_lt`. This is the human-readable face of `Tendsto (·/x) atTop (𝓝 0)`.",
+    "mathContext": "$\\dfrac{G(x)}{x} \\to 0 \\;\\Longleftrightarrow\\; \\forall \\varepsilon > 0,\\ \\text{eventually } G(x) \\leq \\varepsilon x.$",
+    "significance": "supporting",
+    "relatedConcepts": ["epsilon–delta limits", "div_lt_iff₀", "filter_upwards", "Tendsto.eventually"],
+    "prerequisites": ["definition of limit via neighbourhoods", "inequality manipulation"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-1138-oq-03-oq-01`.

## Gap addressed
The entry had a rich `meta.json` (12 KB, well under caps) but **no `annotations.json`** — zero inline annotation coverage of the Lean file.

## Added
Created `annotations.json` with **6 annotations** spanning the whole proof, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. **Setup** — inheriting the `baker_harman_pintz` axiom and `maxPrimeGap` from the parent via namespace reopening (context).
2. **Pointwise upper envelope** — the `Real.rpow_sub` power-subtraction identity $x^{0.525}/x = x^{-0.475}$ plus `gcongr` (key).
3. **Positivity cast** — `exact_mod_cast` transporting $0<x$ from ℕ to ℝ for the `rpow_sub` base condition (technical).
4. **Squeeze limit** — `squeeze_zero'` between the constant 0 and the vanishing envelope (key).
5. **Filter bridge** — `.comp tendsto_natCast_atTop_atTop` moving ℝ-asymptotics to the ℕ-indexed sequence (supporting).
6. **ε-form** — `div_lt_iff₀` clearing the denominator to $G(x) \le \varepsilon x$ (supporting).

## Verification
- JSON validated (6 annotations parse cleanly); enrichment build step processed the entry.
- Axiom integrity unchanged: entry remains `axiomatized` on the single inherited BHP axiom; no meta claims altered.
- Only `src/data/proofs/erdos-1138-oq-03-oq-01/` staged.