### PR TITLE
Enrich: Hilbert 17 root-multiplicity of a real 2-SOS — add mathContext + 5th annotation/section

### DIFF
--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -8,7 +8,19 @@
     },
     "type": "concept",
     "title": "Pointwise non-cancellation: real roots are common roots",
-    "content": "The pointwise twin of the parent file's top-degree non-cancellation. For a real number t, u(t)² + v(t)² is a sum of two real squares, so it is 0 only when both u(t) and v(t) are 0 (sq_nonneg on each, closed by nlinarith). Hence eval_sq_add_sq_eq_zero_iff: the real roots of u² + v² are EXACTLY the common real roots of u and v. The same positivity also shows sq_add_sq_ne_zero: if u ≠ 0 then u² + v² ≠ 0 — were it the zero polynomial it would vanish at every point (Polynomial.funext over the infinite field ℝ), forcing u(x)² ≤ u(x)² + v(x)² = 0 and hence u = 0. These two facts make the entire root set of p computable from u and v and underwrite the nonvanishing side-conditions in the multiplicity argument."
+    "content": "The pointwise twin of the parent file's top-degree non-cancellation. For a real number t, u(t)² + v(t)² is a sum of two real squares, so it is 0 only when both u(t) and v(t) are 0 (sq_nonneg on each, closed by nlinarith). Hence eval_sq_add_sq_eq_zero_iff: the real roots of u² + v² are EXACTLY the common real roots of u and v. The same positivity also shows sq_add_sq_ne_zero: if u ≠ 0 then u² + v² ≠ 0 — were it the zero polynomial it would vanish at every point (Polynomial.funext over the infinite field ℝ), forcing u(x)² ≤ u(x)² + v(x)² = 0 and hence u = 0. These two facts make the entire root set of p computable from u and v and underwrite the nonvanishing side-conditions in the multiplicity argument.",
+    "mathContext": "$u(t)^2 + v(t)^2 = 0 \\iff u(t) = 0 \\wedge v(t) = 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum of squares",
+      "real non-cancellation",
+      "common roots"
+    ],
+    "prerequisites": [
+      "polynomial evaluation",
+      "sq_nonneg",
+      "nlinarith"
+    ]
   },
   {
     "id": "ann-h17-rootmult-factor-at-root",
@@ -19,7 +31,19 @@
     },
     "type": "technique",
     "title": "Local factorisation u = (X−r)^a·u₁ with u₁(r) ≠ 0",
-    "content": "factor_at_root extracts the exact local structure at a root. The factor (X − C r)^(rootMultiplicity r u) ∣ u comes for free from pow_rootMultiplicity_dvd. The point is the cofactor u₁ does NOT vanish at r: if it did, dvd_iff_isRoot would give (X − C r) ∣ u₁, and then u = (X−r)^a·u₁ would be divisible by (X − C r)^(a+1), contradicting pow_rootMultiplicity_not_dvd (which says a is the LARGEST such power). A subtle Lean point: when proving (X−r)^(a+1) ∣ u one must avoid rewriting the bare u, because u also appears inside the index rootMultiplicity r u; the proof builds the witness equation u = (X−r)^(a+1)·w by pow_succ, mul_assoc and ← hw without touching the exponent."
+    "content": "factor_at_root extracts the exact local structure at a root. The factor (X − C r)^(rootMultiplicity r u) ∣ u comes for free from pow_rootMultiplicity_dvd. The point is the cofactor u₁ does NOT vanish at r: if it did, dvd_iff_isRoot would give (X − C r) ∣ u₁, and then u = (X−r)^a·u₁ would be divisible by (X − C r)^(a+1), contradicting pow_rootMultiplicity_not_dvd (which says a is the LARGEST such power). A subtle Lean point: when proving (X−r)^(a+1) ∣ u one must avoid rewriting the bare u, because u also appears inside the index rootMultiplicity r u; the proof builds the witness equation u = (X−r)^(a+1)·w by pow_succ, mul_assoc and ← hw without touching the exponent.",
+    "mathContext": "$u = (X - r)^{\\mathrm{rootMult}_r u}\\cdot u_1, \\quad u_1(r) \\ne 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "root multiplicity",
+      "local factorisation",
+      "cofactor"
+    ],
+    "prerequisites": [
+      "pow_rootMultiplicity_dvd",
+      "pow_rootMultiplicity_not_dvd",
+      "dvd_iff_isRoot"
+    ]
   },
   {
     "id": "ann-h17-rootmult-exact-formula",
@@ -30,7 +54,19 @@
     },
     "type": "concept",
     "title": "The exact multiplicity is 2·min(a, b)",
-    "content": "rootMultiplicity_sq_add_sq_of_le proves the ordered case a = rootMult r u ≤ b = rootMult r v. Factor u² + v² = (X−r)^{2a}·q with q = u₁² + (X−r)^{2(b−a)}·v₁²; the only delicate algebra is the power split (X−r)^{2b} = (X−r)^{2a}·(X−r)^{2(b−a)}, a single ← pow_add with the exponent identity discharged by omega. The crux is q(r) ≠ 0: evaluating, the (X−r)^{2(b−a)} factor becomes 0^{positive} = 0 when a < b (zero_pow), leaving u₁(r)² ≠ 0; when a = b the exponent is 0, leaving u₁(r)² + v₁(r)², strictly positive. Either way the cofactor survives, so rootMultiplicity_mul splits rootMult r ((X−r)^{2a}·q) = 2a (by rootMultiplicity_X_sub_C_pow) + 0 (by rootMultiplicity_eq_zero on q). rootMultiplicity_sq_add_sq then drops the ordering hypothesis using le_total and add_comm (u² + v² = v² + u²), giving the symmetric 2·min(a,b). Note min, not sum: the summand vanishing to the LOWER order dominates the local behaviour."
+    "content": "rootMultiplicity_sq_add_sq_of_le proves the ordered case a = rootMult r u ≤ b = rootMult r v. Factor u² + v² = (X−r)^{2a}·q with q = u₁² + (X−r)^{2(b−a)}·v₁²; the only delicate algebra is the power split (X−r)^{2b} = (X−r)^{2a}·(X−r)^{2(b−a)}, a single ← pow_add with the exponent identity discharged by omega. The crux is q(r) ≠ 0: evaluating, the (X−r)^{2(b−a)} factor becomes 0^{positive} = 0 when a < b (zero_pow), leaving u₁(r)² ≠ 0; when a = b the exponent is 0, leaving u₁(r)² + v₁(r)², strictly positive. Either way the cofactor survives, so rootMultiplicity_mul splits rootMult r ((X−r)^{2a}·q) = 2a (by rootMultiplicity_X_sub_C_pow) + 0 (by rootMultiplicity_eq_zero on q). rootMultiplicity_sq_add_sq then drops the ordering hypothesis using le_total and add_comm (u² + v² = v² + u²), giving the symmetric 2·min(a,b). Note min, not sum: the summand vanishing to the LOWER order dominates the local behaviour.",
+    "mathContext": "$\\mathrm{rootMult}_r(u^2 + v^2) = 2\\,\\min(\\mathrm{rootMult}_r u,\\, \\mathrm{rootMult}_r v)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "root multiplicity",
+      "order of vanishing",
+      "sum of squares"
+    ],
+    "prerequisites": [
+      "rootMultiplicity_mul",
+      "factor_at_root",
+      "power splitting"
+    ]
   },
   {
     "id": "ann-h17-rootmult-even-order",
@@ -41,6 +77,41 @@
     },
     "type": "concept",
     "title": "Even multiplicity: an obstruction to being a sum of two squares",
-    "content": "even_rootMultiplicity_sq_add_sq packages the headline structural fact: every real root of a nonzero real 2-SOS has even multiplicity. When both summands are nonzero this is immediate from the 2·min formula (Even n unfolds to ∃ r, n = r + r, witnessed by min with two_mul); the degenerate single-square cases u = 0 (p = v·v) and v = 0 (p = u·u) use rootMultiplicity_mul to get 2·rootMult directly. The contrapositive is the useful obstruction: a polynomial with ANY simple real root — anything that changes sign, like X itself — is never u² + v² over ℝ. IsPSD.even_rootMultiplicity specialises to nonnegative polynomials by feeding the grandparent's PSD ⟹ two-squares existence theorem into this obstruction, recovering the classical even-order-of-contact statement from ordered-field algebra alone, with no appeal to the complex factorisation. This strictly strengthens the grandparent's sq_dvd_of_psd_root, which only gave (X−r)² ∣ p."
+    "content": "even_rootMultiplicity_sq_add_sq packages the headline structural fact: every real root of a nonzero real 2-SOS has even multiplicity. When both summands are nonzero this is immediate from the 2·min formula (Even n unfolds to ∃ r, n = r + r, witnessed by min with two_mul); the degenerate single-square cases u = 0 (p = v·v) and v = 0 (p = u·u) use rootMultiplicity_mul to get 2·rootMult directly. The contrapositive is the useful obstruction: a polynomial with ANY simple real root — anything that changes sign, like X itself — is never u² + v² over ℝ. IsPSD.even_rootMultiplicity specialises to nonnegative polynomials by feeding the grandparent's PSD ⟹ two-squares existence theorem into this obstruction, recovering the classical even-order-of-contact statement from ordered-field algebra alone, with no appeal to the complex factorisation. This strictly strengthens the grandparent's sq_dvd_of_psd_root, which only gave (X−r)² ∣ p.",
+    "mathContext": "$p = u^2 + v^2 \\ne 0 \\Rightarrow \\mathrm{rootMult}_r(p) = 2\\min(a,b) \\text{ is even}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "even multiplicity",
+      "order of contact",
+      "obstruction to SOS"
+    ],
+    "prerequisites": [
+      "rootMultiplicity_sq_add_sq",
+      "even numbers",
+      "degenerate square cases"
+    ]
+  },
+  {
+    "id": "ann-h17-rootmult-psd-even-order",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 165,
+      "endLine": 173
+    },
+    "type": "insight",
+    "title": "PSD Polynomials Touch the Axis to Even Order",
+    "content": "IsPSD.even_rootMultiplicity is the capstone tying the multiplicity structure back to Hilbert’s 17th problem. Combining the parent’s theorem that a nonnegative (PSD) univariate polynomial is a sum of two squares (univariate_psd_is_two_sos_deg) with the even-multiplicity obstruction above, it concludes that every real root of a nonzero PSD polynomial has even multiplicity — a nonnegative real polynomial can only touch the axis, never cross it. This recovers the classical order-of-contact fact from the elementary 2-SOS analysis.",
+    "mathContext": "$p \\ge 0 \\text{ on } \\mathbb{R},\\; p \\ne 0 \\;\\Rightarrow\\; \\mathrm{rootMult}_r(p) \\text{ even}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hilbert's 17th problem",
+      "positive semidefinite",
+      "even order of contact"
+    ],
+    "prerequisites": [
+      "univariate_psd_is_two_sos_deg",
+      "even_rootMultiplicity_sq_add_sq",
+      "IsPSD"
+    ]
   }
 ]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -179,6 +179,13 @@
   "crossReferences": [],
   "sections": [
     {
+      "id": "overview-governing-principle",
+      "title": "Overview — The Governing Non-Cancellation Principle",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "The header lays out the governing principle: a real sum of two squares vanishes at a point only when both summands do, so the real roots of u²+v² are exactly the common roots of u and v. It previews the exact 2·min multiplicity formula, the even-multiplicity obstruction, and the PSD corollary, and states sq_add_sq_ne_zero (a nonzero summand keeps the 2-SOS nonzero)."
+    },
+    {
       "id": "pointwise-non-cancellation",
       "title": "Nonzero 2-SOS and the common-root characterisation",
       "startLine": 51,


### PR DESCRIPTION
Enrichment pass for `hilbert-17-oq-01-oq-01-oq-01-oq-01` (quality 63 → 100).

The entry had 4 annotations lacking mathContext/significance/relatedConcepts and only 4 sections.

## Added
- **mathContext, significance, relatedConcepts, prerequisites** added to all 4 existing annotations (their content preserved verbatim).
- **5th annotation**: the PSD even-order corollary IsPSD.even_rootMultiplicity.
- **5th section**: module overview / the governing non-cancellation principle (lines 1–50).

Fills the mathContext (+10), significance (+10), crossRefs (+10) buckets and completes annotations (+5) and sections (+2). Content preserved (meta diff is pure addition). 0 axioms, 0 sorries; status/badge unchanged.