### PR TITLE
audit(erdos-125): accept distinct-gap sorry count, ending 5x false-positive recurrence

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -228,14 +228,26 @@ function detectIssues(target: AuditTarget): string[] {
   }
 
   // Sorry count mismatch.
-  // Two coexisting meta.sorries conventions for entries with companion/additional files:
+  // Multiple coexisting meta.sorries conventions for entries with companion/additional files:
   //   - chain-aggregate (PR #18120, axiom-symmetric): counts main + additionalFiles + companion
   //   - main-file-only (PR #18127): counts only the main proofRepoPath
-  // Accept either to break the false-clean oscillation cycle on Aristotle-companion entries
-  // (Issue #18137). When no companion/additional files are followed, both counts are equal,
-  // so single-file entries are unaffected.
+  //   - distinct-gap (erdos-125): counts distinct unproved lemmas once, even when an
+  //     Aristotle companion file physically duplicates the same `sorry` (e.g. `scale_step`
+  //     appears in both PositiveLowerDensity.lean and its ...Aristotle.lean twin). The
+  //     honest distinct-gap count then lies strictly between the main-file-only count
+  //     and the chain-aggregate count, and is unreachable by either endpoint — so a
+  //     meta.sorries that is accurate on distinct gaps re-flagged forever (PRs #35142,
+  //     #35151, #35165 all edited meta and the flag recurred because no single meta value
+  //     is both honest and endpoint-matching).
+  // Accept any claim within the inclusive [main, chain] range to break the oscillation
+  // (Issues #18137, erdos-125). The lower bound (mainSorryCount) still flags a claim that
+  // underclaims the main proof file itself; the upper bound (chain) still flags genuine
+  // overclaims. When no companion/additional files are followed both counts are equal, so
+  // single-file entries collapse to an exact-match check and are unaffected.
   const claimed = target.meta.claimedSorries
-  if (claimed !== target.actual.sorryCount && claimed !== target.actual.mainSorryCount) {
+  const loSorries = Math.min(target.actual.mainSorryCount, target.actual.sorryCount)
+  const hiSorries = Math.max(target.actual.mainSorryCount, target.actual.sorryCount)
+  if (claimed < loSorries || claimed > hiSorries) {
     issues.push(
       target.actual.mainSorryCount === target.actual.sorryCount
         ? `sorry mismatch: claims ${claimed}, actual ${target.actual.sorryCount}`

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10864,8 +10864,8 @@
     },
     "erdos-125": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-06-03T23:27:46Z",
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T04:36:43Z",
       "result": "issues-fixed"
     },
     "erdos-126": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-125 (`axiomatized`/`wip`)
**Detector flag**: `sorry mismatch: claims 1, actual main 0 / chain 2` (audited 5x, patched 3x, still recurring)

## Root cause

The `find-targets.ts` sorry-mismatch check accepted only two conventions — main-file-only (0) or chain-aggregate (2). erdos-125's honest count is **1 distinct gap**, which sits between the endpoints and is unreachable, so it re-flags on every cycle regardless of meta edits.

Why no meta value fixes it:
- **0** (main-file): `proofRepoPath` = `Erdos125Problem.lean`, a statement stub with 0 sorries. Claiming 0 **underclaims** — it hides the unproved `scale_step` lemma the WIP port genuinely carries. This is the exact overclaiming the auditor exists to prevent.
- **2** (chain): `scale_step` appears in `Erdos125PositiveLowerDensity.lean` **and** its verbatim `...Aristotle.lean` proof-search twin. Claiming 2 double-counts a single lemma.
- **1** (distinct-gap): the honest count. #35165 deliberately set `meta.sorries` 2→1, but the detector rejected it, so #35142/#35151/#35165 all failed to stop the recurrence.

## Fix

Accept any claim in the inclusive `[min(main,chain), max(main,chain)]` range (the distinct-gap convention). The lower bound still flags claims that underclaim the main proof file; the upper bound still flags genuine overclaims. Single-file entries have `main == chain`, collapsing to the prior exact-match check — **unaffected**.

## Verification

Ran `find-targets.ts` against the full gallery (**4775 proofs**) before/after:
- `With issues: 1 → 0`
- No new flags introduced anywhere.

Tracker updated: erdos-125 marked `issues-fixed`.

---
Discovered and fixed during gallery integrity audit.