### PR TITLE
research(puiseux-theorem-wip-01): sync stale meta counts (11→12 theorems, 603→640 lines)

### DIFF
--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -54,10 +54,10 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 603,
+    "lineCount": 640,
     "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The file no longer contains any vacuous True-stub theorems: the last two placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 2
   },
   "overview": {


### PR DESCRIPTION
## Summary

Aligns the stale `meta` stat block for the `puiseux-theorem` gallery entry with the actual Lean file and the (already-correct) `leanFile` stat block.

## The drift

PR #35154 added `puiseux_binomial_orderTop` (arbitrary-slope `m/n` Newton-polygon-edge ramification) and updated the `leanFile` block but left the `meta` block stale:

| field | meta (stale) | leanFile (correct) | actual file |
|-------|--------------|--------------------|-------------|
| theoremCount | 11 | 12 | `grep -cE '^theorem ' ` = **12** |
| lineCount | 603 | 640 | `wc -l` = **640** |

This PR sets `meta.theoremCount = 12`, `meta.lineCount = 640`.

## Status is unchanged (and correct)

`status: axiomatized`, `badge: wip`, `axiomCount: 0`, `sorries: 0` are left as-is. The file has 0 `axiom` declarations, 0 sorries, and **0 structure-encoded assumptions** (`grep -cE '^structure ' = 0`). The headline Puiseux algebraic-closure theorem is honestly **absent** (only concrete binomial-ramification fragments are proven), so keeping `axiomatized`/`wip` is the conservative reading per the Axiom Integrity policy — it avoids overclaiming `verified` of a fragment.

## Verification

No Lean rebuild needed — pure metadata count alignment, verified by `grep`/`wc` against the file already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)