### PR TITLE
Enrich Inverse Galois at Prime Degree (AGL(1,ℓ))

### DIFF
--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "inverse-galois-prime-degree-header",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "context",
+    "title": "From a per-degree squeeze to a uniform prime-degree law",
+    "content": "The docstring recalls the parent's two-sided squeeze on $|\\mathrm{Gal}(X^n-p/\\mathbb{Q})|$: the metacyclic ceiling $|\\mathrm{Gal}| \\leq n\\varphi(n)$ meets the coprime lower bound $n\\varphi(n) \\mid |\\mathrm{Gal}|$ whenever $\\gcd(n,\\varphi(n))=1$, pinning the order at $n\\varphi(n)$. The parent extracted only the quintic instance $20$. Importing the verified parent lemma `gal_card_eq_n_mul_totient_of_coprime` (line 41) lets this file lift the pin to *every* prime degree at once — because at a prime $\\ell$ the coprimality side-condition becomes automatic. `open Polynomial` (line 45) brings `X`, `C`, and `.Gal` into scope.",
+    "mathContext": "$|\\mathrm{Gal}(X^n-p/\\mathbb{Q})| = n\\varphi(n)$ when $\\gcd(n,\\varphi(n)) = 1$; specialised below to $n = \\ell$ prime.",
+    "significance": "context",
+    "relatedConcepts": ["Galois theory", "metacyclic groups", "Kummer extensions", "cyclotomic fields", "Euler totient"],
+    "prerequisites": ["field extensions", "Galois groups of polynomials"]
+  },
+  {
+    "id": "inverse-galois-prime-degree-coprime",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 61 },
+    "type": "insight",
+    "title": "Coprimality is free at prime degree",
+    "content": "`coprime_self_totient_of_prime` is the keystone: for a prime $\\ell$, $\\gcd(\\ell, \\varphi(\\ell)) = 1$ automatically. The proof rewrites $\\varphi(\\ell) = \\ell - 1$ (`Nat.totient_prime`) and converts coprimality to non-divisibility via `hℓ.coprime_iff_not_dvd` (line 58). The remaining goal $\\ell \\nmid (\\ell - 1)$ is closed by contradiction: if $\\ell \\mid (\\ell-1)$ then `Nat.le_of_dvd` forces $\\ell \\leq \\ell - 1$ (line 60), and `omega` finishes since $\\ell \\geq 2$. A prime can never divide a strictly smaller positive number — this single observation is what makes the entire prime-degree family collapse to one theorem.",
+    "mathContext": "$\\varphi(\\ell) = \\ell - 1$ and $\\gcd(\\ell, \\ell-1) = 1$ (consecutive integers are always coprime).",
+    "significance": "key",
+    "relatedConcepts": ["coprimality", "Euler totient of a prime", "divisibility", "consecutive integers"],
+    "prerequisites": ["elementary number theory", "Nat.Prime API"]
+  },
+  {
+    "id": "inverse-galois-prime-degree-closed-form",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 76 },
+    "type": "concept",
+    "title": "The affine-group closed form |Gal(Xˡ−p)| = ℓ(ℓ−1)",
+    "content": "`gal_card_prime_degree` is the headline. It feeds the automatic coprimality into the parent's exact pin `gal_card_eq_n_mul_totient_of_coprime` (with $\\ell \\geq 2$ from `hℓ.two_le`), then rewrites $\\varphi(\\ell) = \\ell - 1$ to land on $\\ell(\\ell-1)$. This is $|\\mathrm{AGL}(1,\\ell)| = |\\mathbb{F}_\\ell \\rtimes \\mathbb{F}_\\ell^\\times|$, the largest solvable transitive subgroup of $S_\\ell$, and it is uniform in $p$ — no genericity hypothesis. One statement subsumes the cubic $6$ ($\\ell=3$), quintic $20$ ($\\ell=5$), and septic $42$ ($\\ell=7$).",
+    "mathContext": "$|\\mathrm{Gal}(X^\\ell-p/\\mathbb{Q})| = \\ell\\,\\varphi(\\ell) = \\ell(\\ell-1) = |\\mathrm{AGL}(1,\\ell)|$.",
+    "significance": "key",
+    "relatedConcepts": ["affine group AGL(1,ℓ)", "semidirect product", "solvable groups", "transitive permutation groups"],
+    "prerequisites": ["group order", "Galois group of a radical polynomial"]
+  },
+  {
+    "id": "inverse-galois-prime-degree-index",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 94 },
+    "type": "insight",
+    "title": "Index (ℓ−2)! inside Sₗ: proper subgroup for ℓ ≥ 5",
+    "content": "`gal_index_in_symm` locates the Galois group inside the symmetric group $S_\\ell$ acting on the $\\ell$ roots: $|\\mathrm{Gal}| \\cdot (\\ell-2)! = \\ell!$. After rewriting the order as $\\ell(\\ell-1)$, the proof substitutes $\\ell = m+2$ (line 90) and factors $\\ell! = (m+2)! = (m+2)(m+1)\\,m! = \\ell(\\ell-1)(\\ell-2)!$ via two `Nat.factorial_succ` rewrites and `ring`. The index $(\\ell-2)!$ exceeds $1$ once $\\ell \\geq 5$, proving the Galois group of the irreducible, separable $X^\\ell-p$ is a *proper* subgroup of $S_\\ell$ — radical polynomials are the antithesis of the generic $S_\\ell$ case.",
+    "mathContext": "$[S_\\ell : \\mathrm{Gal}] = \\dfrac{\\ell!}{\\ell(\\ell-1)} = (\\ell-2)! > 1$ for $\\ell \\geq 5$.",
+    "significance": "supporting",
+    "relatedConcepts": ["symmetric group", "subgroup index", "Lagrange's theorem", "factorial", "generic Galois group"],
+    "prerequisites": ["permutation groups", "factorial arithmetic"]
+  },
+  {
+    "id": "inverse-galois-prime-degree-septic",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 105 },
+    "type": "technique",
+    "title": "Septic witness: |Gal(X⁷−p)| = 42",
+    "content": "`gal_card_septic_eq_42` is a one-line instantiation of the closed form at $\\ell = 7$, giving $7 \\cdot 6 = 42 = |\\mathrm{AGL}(1,7)|$ for every prime $p$. It is the next case beyond the parent's quintic $20$, and dramatises how loose the naive factorial bound is: the symmetric-group divisibility only yields $|\\mathrm{Gal}| \\mid 7! = 5040$, leaving dozens of divisors open, whereas the metacyclic ceiling pins the value exactly at $42$. The gap $\\ell(\\ell-1) \\ll \\ell!$ widens super-exponentially in $\\ell$.",
+    "mathContext": "$|\\mathrm{Gal}(X^7-p/\\mathbb{Q})| = 7 \\cdot 6 = 42$, versus the useless bound $42 \\mid 5040$.",
+    "significance": "supporting",
+    "relatedConcepts": ["AGL(1,7)", "concrete instantiation", "divisor bounds"],
+    "prerequisites": ["theorem specialisation"]
+  },
+  {
+    "id": "inverse-galois-prime-degree-axiom-audit",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01",
+    "range": { "startLine": 109, "endLine": 113 },
+    "type": "context",
+    "title": "Axiom audit: foundational axioms only",
+    "content": "The trailing `#print axioms` on all three headline theorems confirms the entry's `verified` status: each depends on exactly $\\{$`propext`, `Classical.choice`, `Quot.sound`$\\}$ — the ordinary foundational axioms — with no `Lean.ofReduceBool` (no `native_decide`) and no `sorryAx`. In particular `gal_card_septic_eq_42` closes by definitional reduction of $7 \\cdot (7-1) = 42$, not by a compiler-kernel `decide`, so no `ofReduceBool` leaks in. This substantiates `axiomCount: 0` and `badge: verified`.",
+    "mathContext": "Dependency set $= \\{\\text{propext}, \\text{Classical.choice}, \\text{Quot.sound}\\}$ — no assumption-carrying axioms.",
+    "significance": "context",
+    "relatedConcepts": ["axiom integrity", "kernel verification", "#print axioms", "native_decide"],
+    "prerequisites": ["Lean trusted kernel", "axiom accounting"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01`.

## Gap addressed
Rich `meta.json` (13.5 KB, under caps) but **no `annotations.json`** — zero inline coverage of the 113-line Lean file.

## Added
Created `annotations.json` with **6 annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. **Setup** — lifting the parent's coprime pin $|\mathrm{Gal}| = n\varphi(n)$ to every prime degree (context).
2. **Coprimality for free** — `coprime_self_totient_of_prime`: $\gcd(\ell,\ell-1)=1$ closes the family in one lemma (key).
3. **AGL(1,ℓ) closed form** — `gal_card_prime_degree`: $|\mathrm{Gal}(X^\ell-p)| = \ell(\ell-1)$ (key).
4. **Index in Sₗ** — `gal_index_in_symm`: $(\ell-2)!$, proper subgroup for $\ell\ge5$ (supporting).
5. **Septic witness** — `gal_card_septic_eq_42`: $42 = |\mathrm{AGL}(1,7)|$ vs the useless $42\mid5040$ (supporting).
6. **Axiom audit** — `#print axioms` confirms only propext/Classical.choice/Quot.sound, substantiating `verified` (context).

## Verification
- JSON validated (6 annotations parse cleanly).
- Axiom integrity unchanged: entry remains `verified`, `axiomCount: 0`; annotation #6 documents the `#print axioms` basis. No meta claims altered.
- Only `src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01-oq-01-oq-01/` staged.