### PR TITLE
Enrich Szemerédi ⟹ Frieze-Kannan sharp constant (annotations 2→6)

### DIFF
--- a/src/data/proofs/szemeredi-regularity-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02-oq-02/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "szemeredifk-sharp-ann-header",
+    "proofId": "szemeredi-regularity-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 70
+    },
+    "type": "context",
+    "title": "The open question: is the factor of 2 tight?",
+    "content": "The module docstring states the open question inherited from the parent: `szemeredi_implies_fk` shows every ε-regular partition is a 2ε-cut-approximation, and the parent recorded the constant 2 as sharp under this strategy. This file refutes that. The imports (lines 49–52) pull in the parent's machinery — `IsEpsilonRegular`, `edgeDensity`, `IsCutApproximation`, and the partition-decomposition lemmas — all reused verbatim; only the per-pair estimate changes. The `variable {V} [Fintype V] [DecidableEq V]` (line 58) fixes a finite vertex type, and `open ... Classical` provides decidability for the graph adjacency filters.",
+    "mathContext": "Question: in $|\\mathrm{Gal}|$-free terms, is the $2$ in `IsCutApproximation G (2ε) parts` optimal, or is `IsCutApproximation G ε parts` already true?",
+    "significance": "context",
+    "relatedConcepts": [
+      "Szemerédi regularity lemma",
+      "Frieze-Kannan weak regularity",
+      "cut norm",
+      "sharp constants"
+    ],
+    "prerequisites": [
+      "graph regularity",
+      "Lean module imports"
+    ]
+  },
+  {
     "id": "szemeredifk-sharp-ann-pair",
     "proofId": "szemeredi-regularity-oq-02-oq-02",
     "range": {
@@ -23,6 +46,52 @@
     ]
   },
   {
+    "id": "szemeredifk-sharp-ann-largecase",
+    "proofId": "szemeredi-regularity-oq-02-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 130
+    },
+    "type": "technique",
+    "title": "Large case: normalising by |A||B| to invoke ε-regularity",
+    "content": "When both A and B are large, the proof must convert ε-regularity's *density* statement into a *count* bound. After dispatching the degenerate |A|=0 or |B|=0 subcases (where e=0 and the goal is a positivity fact), it uses $d(A,B) = e/(|A||B|)$ (line 109, valid since |A||B| ≠ 0) to rewrite the regularity hypothesis $|d(A,B) - d| \\le \\varepsilon$. Dividing the target error by the positive $|A||B|$ (via `abs_div` and `abs_of_pos`) matches it against ε, then `div_mul_cancel₀` multiplies back through. The final `calc` climbs $\\varepsilon|A||B| \\le \\varepsilon|P||Q|$ using $|A|\\le|P|$, $|B|\\le|Q|$. This case already achieves the ε rate — which is why 1 is optimal.",
+    "mathContext": "$\\left|\\dfrac{e}{|A||B|} - d\\right| \\le \\varepsilon \\Rightarrow |e - d|A||B|| \\le \\varepsilon|A||B| \\le \\varepsilon|P||Q|.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "edge density normalization",
+      "abs_div",
+      "div_mul_cancel",
+      "monotonicity of multiplication"
+    ],
+    "prerequisites": [
+      "rational arithmetic in Lean",
+      "field_simp / division lemmas"
+    ]
+  },
+  {
+    "id": "szemeredifk-sharp-ann-smallcase",
+    "proofId": "szemeredi-regularity-oq-02-oq-02",
+    "range": {
+      "startLine": 131,
+      "endLine": 160
+    },
+    "type": "insight",
+    "title": "Small case: max beats sum — the factor-of-2 killer",
+    "content": "The two symmetric small subcases (B small at lines 131–145, A small at 146–160) are where the sharpening happens. Each establishes $|A||B| \\le \\varepsilon|P||Q|$ by a two-step `calc` bounding the small side by its ε-threshold and the other side by the full part. From this, both $e \\le |A||B| \\le \\varepsilon|P||Q|$ (`he_le`) and $d|A||B| \\le |A||B| \\le \\varepsilon|P||Q|$ (`hd_AB`, using $d \\le 1$ via `mul_le_of_le_one_left`) follow. The goal is then closed by `abs_le` plus two `nlinarith` calls — precisely encoding $|x - y| \\le \\max(x,y)$ for $0 \\le x,y \\le \\varepsilon|P||Q|$. The parent's slack came from bounding $|x-y|$ by $x+y$; using the max instead removes the extra factor.",
+    "mathContext": "For $0 \\le x, y \\le M$: $-M \\le x - y \\le M$, i.e. $|x-y| \\le \\max(x,y) \\le M = \\varepsilon|P||Q|$ — versus the loose $|x-y| \\le x+y \\le 2M$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "|x−y| ≤ max(x,y)",
+      "nlinarith",
+      "abs_le",
+      "density ≤ 1"
+    ],
+    "prerequisites": [
+      "linear arithmetic certificates",
+      "absolute-value characterisation"
+    ]
+  },
+  {
     "id": "szemeredifk-sharp-ann-main",
     "proofId": "szemeredi-regularity-oq-02-oq-02",
     "range": {
@@ -43,6 +112,29 @@
     "prerequisites": [
       "per-pair cut error bound",
       "Finset partition sum identities"
+    ]
+  },
+  {
+    "id": "szemeredifk-sharp-ann-axioms",
+    "proofId": "szemeredi-regularity-oq-02-oq-02",
+    "range": {
+      "startLine": 226,
+      "endLine": 229
+    },
+    "type": "context",
+    "title": "Axiom audit: foundational axioms only",
+    "content": "The closing `#print axioms` on all three theorems substantiates the entry's `verified` badge and `axiomCount: 0`. Each result depends only on $\\{$`propext`, `Classical.choice`, `Quot.sound`$\\}$ — the ordinary foundational axioms carried in via Mathlib and the `open Classical` decidability — with no `sorryAx`, no `axiom` declarations, no `native_decide`, and no structure-encoded assumptions. All reused parent lemmas are themselves 0-axiom, so the sharpening introduces no new mathematical assumption.",
+    "mathContext": "Dependency set $= \\{\\text{propext}, \\text{Classical.choice}, \\text{Quot.sound}\\}$ for all three theorems.",
+    "significance": "context",
+    "relatedConcepts": [
+      "axiom integrity",
+      "#print axioms",
+      "Classical.choice",
+      "kernel verification"
+    ],
+    "prerequisites": [
+      "Lean trusted kernel",
+      "axiom accounting"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `szemeredi-regularity-oq-02-oq-02`.

## Gap addressed
Rich `meta.json` but `annotations.json` had only **2 broad theorem-level annotations**; the header, the internal case structure of the per-pair proof, and the axiom audit were uncovered.

## Added (2 → 6 annotations)
Kept the 2 existing theorem annotations; added 4 finer ones, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. **Header / the open question** — imports of parent machinery, the 2-vs-1 question (context).
2. **Large case** — normalising by $|A||B|$ to turn ε-regularity's density bound into a count bound (`abs_div`, `div_mul_cancel₀`) (supporting).
3. **Small case — max beats sum** — the actual factor-of-2 killer: $|x-y|\le\max(x,y)$ via `abs_le`+`nlinarith`, versus the parent's loose $|x-y|\le x+y$ (key).
4. **Axiom audit** — `#print axioms` confirms only propext/Classical.choice/Quot.sound, substantiating `verified`/`axiomCount: 0` (context).

## Verification
- JSON validated (6 annotations parse cleanly); line ranges checked against the 229-line source.
- Axiom integrity unchanged: entry remains `verified`, `axiomCount: 0`; no meta claims altered.
- Only `src/data/proofs/szemeredi-regularity-oq-02-oq-02/` staged.