### PR TITLE
research(minpoly-charpoly-oq-02-incomplete-01): power closure law Mᵏ diagonalizable [0-axiom, 0-sorry]

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
@@ -27,8 +27,11 @@ the definition but which the parent omits:
   * `IsDiagonalizable.inv`       — the inverse `M⁻¹` is diagonalizable (same `P`),
     because `P⁻¹ M⁻¹ P = (P⁻¹ M P)⁻¹` and the inverse of a diagonal matrix is
     diagonal (`isDiag_inv`).
+  * `IsDiagonalizable.pow`       — every power `Mᵏ` is diagonalizable (same `P`),
+    because `P⁻¹ Mᵏ P = (P⁻¹ M P)ᵏ` (`conj_pow`) and powers of a diagonal matrix
+    are diagonal (`isDiag_pow`, built on `isDiag_mul`).
 
-All five are fully machine-checked (0 axioms, 0 sorries) and reuse only the
+All are fully machine-checked (0 axioms, 0 sorries) and reuse only the
 parent's *definition* (not its open reverse-direction obligation).
 
 Reference: Axler, *Linear Algebra Done Right* §5–8; Dummit–Foote §12.
@@ -126,5 +129,53 @@ theorem IsDiagonalizable.inv {M : Matrix n n K} (hM : M.IsDiagonalizable) :
       ← mul_assoc]
   rw [← key]
   exact isDiag_inv hD
+
+/-- **The product of two diagonal matrices is diagonal.**  Off the diagonal
+    (`i ≠ j`), every term `A i k * B k j` of `(A * B) i j = ∑ₖ A i k * B k j`
+    vanishes: if `k ≠ i` then `A i k = 0`, and if `k = i` then `B k j = B i j = 0`
+    (since `i ≠ j`). -/
+theorem isDiag_mul {A B : Matrix n n K} (hA : A.IsDiag) (hB : B.IsDiag) :
+    (A * B).IsDiag := by
+  intro i j hij
+  rw [Matrix.mul_apply]
+  apply Finset.sum_eq_zero
+  intro k _
+  rcases eq_or_ne i k with rfl | hik
+  · rw [hB hij, mul_zero]
+  · rw [hA hik, zero_mul]
+
+/-- **Powers of a diagonal matrix are diagonal.**  Immediate induction on the
+    exponent: `A⁰ = 1` is diagonal and `Aᵏ⁺¹ = Aᵏ * A` is a product of diagonals. -/
+theorem isDiag_pow {A : Matrix n n K} (h : A.IsDiag) (k : ℕ) : (A ^ k).IsDiag := by
+  induction k with
+  | zero => rw [pow_zero]; exact Matrix.isDiag_one
+  | succ k ih => rw [pow_succ]; exact isDiag_mul ih h
+
+/-- **Conjugation commutes with taking powers.**  For invertible `P`,
+    `P⁻¹ Mᵏ P = (P⁻¹ M P)ᵏ`.  Proof by induction, cancelling the interior
+    `P * P⁻¹ = 1` at each step. -/
+theorem conj_pow {M P : Matrix n n K} (hP : IsUnit P.det) (k : ℕ) :
+    P⁻¹ * M ^ k * P = (P⁻¹ * M * P) ^ k := by
+  induction k with
+  | zero => rw [pow_zero, pow_zero, mul_one, Matrix.nonsing_inv_mul P hP]
+  | succ k ih =>
+      have hPP : P * P⁻¹ = 1 := Matrix.mul_nonsing_inv P hP
+      rw [pow_succ, pow_succ, ← ih]
+      have hcollapse : P⁻¹ * M ^ k * P * (P⁻¹ * M * P)
+          = P⁻¹ * M ^ k * (P * P⁻¹) * (M * P) := by simp only [mul_assoc]
+      rw [hcollapse, hPP]
+      simp only [mul_one, mul_assoc]
+
+/-- **Powers stay diagonalizable.**  The *same* `P` diagonalizes `Mᵏ`: since
+    `P⁻¹ Mᵏ P = (P⁻¹ M P)ᵏ` (`conj_pow`) and powers of the diagonal matrix
+    `P⁻¹ M P` are diagonal (`isDiag_pow`), `P⁻¹ Mᵏ P` is diagonal.  Completes the
+    documented `nextSteps` item on powers of a diagonalizable matrix. -/
+theorem IsDiagonalizable.pow {M : Matrix n n K} (hM : M.IsDiagonalizable) (k : ℕ) :
+    (M ^ k).IsDiagonalizable := by
+  obtain ⟨P, hP, hD⟩ := hM
+  have hPdet : IsUnit P.det := (Matrix.isUnit_iff_isUnit_det P).mp hP
+  refine ⟨P, hP, ?_⟩
+  rw [conj_pow hPdet]
+  exact isDiag_pow hD k
 
 end MinpolyCharpolyOQ02Incomplete01

--- a/src/data/research/problems/minpoly-charpoly-oq-02-incomplete-01.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-02-incomplete-01.json
@@ -1,6 +1,6 @@
 {
   "slug": "minpoly-charpoly-oq-02-incomplete-01",
-  "title": "Closure properties of Matrix.IsDiagonalizable (similarity, scaling, transpose)",
+  "title": "Closure properties of Matrix.IsDiagonalizable (similarity, scaling, transpose, inverse, powers)",
   "phase": "COMPLETED",
   "status": "completed",
   "tier": "C",
@@ -21,37 +21,39 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-06-22T00:00:00-07:00",
-    "iteration": 1,
-    "focus": "Formalized the four closure properties of Matrix.IsDiagonalizable.",
+    "iteration": 2,
+    "focus": "Added the power closure law IsDiagonalizable.pow (Mᵏ diagonalizable) with supporting isDiag_mul/isDiag_pow/conj_pow.",
     "blockers": [],
-    "nextAction": "None — complete. (Note: the parent's open reverse-direction obligation, squarefree minpoly ⇒ diagonalizable, is NOT addressed here and remains open.)",
+    "nextAction": "None for the elementary closure laws — 6 laws now formalized (conj/smul/neg/transpose/inv/pow). Optional: commuting-product simultaneous diagonalization (hard).",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "UPDATE (researcher-6, 2026-07-04): added a 5th closure law IsDiagonalizable.inv (the inverse of a diagonalizable matrix is diagonalizable, same diagonalizer P) plus the supporting lemma isDiag_inv (inverse of a diagonal matrix is diagonal, via Matrix.inv_diagonal). File now 6 theorems, still 0 axioms / 0 sorries, docker-build verified (Mathlib v4.26.0). Also fixed a stray unused-simp-arg lint (one_mul) in IsDiagonalizable.conj. Prior: COMPLETE (verified, 0 sorries — despite the 'incomplete' slot name). Child of minpoly-charpoly-oq-02. The parent defines Matrix.IsDiagonalizable M := ∃ P, IsUnit P ∧ IsDiag (P⁻¹·M·P) and proves only trivial instances. This entry adds the four elementary closure laws: IsDiagonalizable.conj (similarity invariance — the conjugate U⁻¹MU is diagonalizable, diagonalizer U⁻¹P), .smul (c•M, same P), .neg (−M), .transpose (Mᵀ, diagonalizer (Pᵀ)⁻¹). MinpolyCharpolyOQ02Incomplete01.lean, 4 theorems, 0 axioms, 0 sorries. Reuses only the parent's DEFINITION, not its open reverse-direction sorry (#print axioms confirms propext/Classical.choice/Quot.sound only — no sorryAx inheritance).",
+    "progressSummary": "UPDATE (researcher-2, 2026-07-07): added a 6th closure law IsDiagonalizable.pow — every power Mᵏ of a diagonalizable matrix is diagonalizable with the SAME diagonalizer P, since P⁻¹ Mᵏ P = (P⁻¹ M P)ᵏ and powers of a diagonal matrix are diagonal. Supporting lemmas: isDiag_mul (product of two diagonal matrices is diagonal, proved pointwise via Matrix.mul_apply + Finset.sum_eq_zero), isDiag_pow (induction on the exponent), and conj_pow (P⁻¹ Mᵏ P = (P⁻¹ M P)ᵏ for invertible P, by induction cancelling the interior P·P⁻¹=1). File now 10 theorems, still 0 axioms / 0 sorries, docker-build verified (Mathlib v4.26.0). Prior (researcher-6, 2026-07-04): 5th closure law IsDiagonalizable.inv + isDiag_inv. Prior: the four elementary closure laws conj/smul/neg/transpose. Child of minpoly-charpoly-oq-02; reuses only the parent's Matrix.IsDiagonalizable DEFINITION, not its (now-discharged) reverse-direction obligation. #print axioms confirms propext/Classical.choice/Quot.sound only — no sorryAx inheritance.",
     "builtItems": [
       "MinpolyCharpolyOQ02Incomplete01.lean: 4 theorems, 0 axioms, 0 sorries. Imports Proofs.MinpolyCharpolyOQ02 for the Matrix.IsDiagonalizable definition.",
       "IsDiagonalizable.conj (similarity invariance: U⁻¹MU diagonalizable; witness U⁻¹P, key (U⁻¹P)⁻¹ = P⁻¹U via mul_inv_rev + nonsing_inv_nonsing_inv, cancel U·U⁻¹=1).",
       "IsDiagonalizable.smul (c•M; P⁻¹(c•M)P = c•(P⁻¹MP) via mul_smul/smul_mul + IsDiag.smul).",
       "IsDiagonalizable.neg (−M; via mul_neg/neg_mul + IsDiag.neg).",
       "IsDiagonalizable.transpose (Mᵀ; diagonalizer (Pᵀ)⁻¹, ((Pᵀ)⁻¹)⁻¹MᵀᵀP... = (P⁻¹MP)ᵀ via nonsing_inv_nonsing_inv + transpose_nonsing_inv + IsDiag.transpose).",
-      "IsDiagonalizable.inv + isDiag_inv (MinpolyCharpolyOQ02Incomplete01.lean): the inverse M⁻¹ of a diagonalizable matrix is diagonalizable with the same P, since P⁻¹M⁻¹P = (P⁻¹MP)⁻¹ and the inverse of a diagonal matrix is diagonal. 0-axiom, 0-sorry, docker-build verified."
+      "IsDiagonalizable.inv + isDiag_inv (MinpolyCharpolyOQ02Incomplete01.lean): the inverse M⁻¹ of a diagonalizable matrix is diagonalizable with the same P, since P⁻¹M⁻¹P = (P⁻¹MP)⁻¹ and the inverse of a diagonal matrix is diagonal. 0-axiom, 0-sorry, docker-build verified.",
+      "IsDiagonalizable.pow + conj_pow + isDiag_pow + isDiag_mul (MinpolyCharpolyOQ02Incomplete01.lean): Mᵏ of a diagonalizable matrix is diagonalizable, same P. conj_pow shows P⁻¹ Mᵏ P = (P⁻¹ M P)ᵏ (induction, interior P·P⁻¹=1 cancels); isDiag_pow inducts on k over isDiag_mul; isDiag_mul is pointwise (off-diagonal terms A i k · B k j all vanish). 0-axiom, 0-sorry, docker-build verified."
     ],
     "insights": [
       "Matrix nonsing-inverse lemmas (mul_nonsing_inv, nonsing_inv_nonsing_inv, mul_inv_rev, transpose_nonsing_inv) take IsUnit A.det, but IsDiagonalizable carries IsUnit P — bridge with Matrix.isUnit_iff_isUnit_det.",
       "IsUnit of the matrix inverse: Matrix.isUnit_nonsing_inv_iff : IsUnit A⁻¹ ↔ IsUnit A. For transpose: IsUnit Pᵀ via isUnit_iff_isUnit_det + det_transpose.",
       "Cancellation trick for conj: regroup with simp only [mul_assoc] (both sides reassociate to the same right-nested product), then rw U·U⁻¹=1 and clear with mul_one/one_mul — more robust than mul_nonsing_inv_cancel_left, whose A argument is explicit (positional `_ hUdet` mis-binds).",
       "Importing a sorry-bearing parent does NOT taint axiom-cleanliness as long as the new theorems use only sorry-free declarations (here just the definition); always #print axioms to confirm no sorryAx.",
-      "IsDiag has the needed closure API in Mathlib: IsDiag.smul (k) (h), IsDiag.neg (h), IsDiag.transpose (h)."
+      "IsDiag has the needed closure API in Mathlib: IsDiag.smul (k) (h), IsDiag.neg (h), IsDiag.transpose (h).",
+      "isDiag_mul is cleanest proved pointwise (intro i j hij; Matrix.mul_apply; Finset.sum_eq_zero; case k=i gives B i j = 0 since i≠j, case k≠i gives A i k = 0) — AVOID `rw [← IsDiag.diagonal_diag]` which rewrites a variable A into `diagonal (diag A)` (a term containing A) and can crash the elaborator. Conjugation-power P⁻¹ Mᵏ P = (P⁻¹ M P)ᵏ: induct, then simp only [mul_assoc] to reassociate and rw the interior P·P⁻¹=1."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "The parent's open reverse direction (squarefree minpoly ⇒ diagonalizable over alg-closed char-0) remains the real target: eigenspace internal direct sum ⇒ conjugating matrix.",
-      "Further closure: product of commuting diagonalizable matrices is diagonalizable (needs simultaneous diagonalization); powers Mᵏ of a diagonalizable matrix."
+      "The parent's reverse direction (squarefree minpoly ⇒ diagonalizable) is now DISCHARGED (minpoly-charpoly-oq-02 verified); this extension file needs only elementary closure laws.",
+      "Further closure: product of COMMUTING diagonalizable matrices is diagonalizable (needs simultaneous diagonalization — substantially harder, not a same-P argument)."
     ]
   },
   "tags": [
@@ -61,5 +63,5 @@
     "minpoly-charpoly",
     "minpoly-charpoly-oq-02"
   ],
-  "lastUpdate": "2026-07-04T00:00:00.000Z"
+  "lastUpdate": "2026-07-07T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

Adds the **power closure law** for `Matrix.IsDiagonalizable` to `MinpolyCharpolyOQ02Incomplete01.lean`, the last tractable item on the entry's documented `nextSteps`. The five prior closure laws were conj/smul/neg/transpose/inv; this adds `pow`.

- `isDiag_mul` — the product of two diagonal matrices is diagonal (pointwise: `Matrix.mul_apply` + `Finset.sum_eq_zero`; off the diagonal every term `A i k · B k j` vanishes).
- `isDiag_pow` — powers of a diagonal matrix are diagonal (induction on the exponent).
- `conj_pow` — for invertible `P`, `P⁻¹ Mᵏ P = (P⁻¹ M P)ᵏ` (induction, cancelling the interior `P·P⁻¹ = 1`).
- `IsDiagonalizable.pow` — every power `Mᵏ` of a diagonalizable matrix is diagonalizable, with the **same** diagonalizer `P`.

## Verification

- File now **10 theorems, 0 axioms, 0 sorries**.
- `docker-build.sh Proofs.MinpolyCharpolyOQ02Incomplete01` succeeds against pinned **Mathlib v4.26.0**.
- Reuses only the parent's `Matrix.IsDiagonalizable` *definition*; `#print axioms` inheritance is limited to `propext`/`Classical.choice`/`Quot.sound` (no `sorryAx`).

> Note: an intermittent build exit-135 during development was traced to a corrupted `.ltar` Mathlib cache file ("removing corrupted file"), not a proof error — a clean retry built in 4.9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)