### PR TITLE
Enrich Coprime Normalization of a Real 2-SOS (hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -8,7 +8,21 @@
     },
     "type": "concept",
     "title": "Bézout at a point ⟹ positive-definiteness",
-    "content": "Coprimality of u and v is an algebraic statement (∃ a b, a·u + b·v = 1), but it has an immediate pointwise consequence: evaluate the Bézout identity at any real t. If u(t) and v(t) were both 0 the left side would be 0, contradicting the right side 1 (no_common_root_of_isCoprime). Feeding this into the parent file's non-cancellation lemma eval_sq_add_sq_eq_zero_iff (u(t)² + v(t)² = 0 ⟺ u(t) = v(t) = 0) shows the coprime sum u² + v² is never zero; combined with u(t)² + v(t)² ≥ 0 (positivity) it is strictly positive at every point (sq_add_sq_pos_of_isCoprime), hence root-free. This is the strict, primitive-case form of Fejér–Riesz nonnegativity."
+    "content": "Coprimality of u and v is an algebraic statement (∃ a b, a·u + b·v = 1), but it has an immediate pointwise consequence: evaluate the Bézout identity at any real t. If u(t) and v(t) were both 0 the left side would be 0, contradicting the right side 1 (no_common_root_of_isCoprime). Feeding this into the parent file's non-cancellation lemma eval_sq_add_sq_eq_zero_iff (u(t)² + v(t)² = 0 ⟺ u(t) = v(t) = 0) shows the coprime sum u² + v² is never zero; combined with u(t)² + v(t)² ≥ 0 (positivity) it is strictly positive at every point (sq_add_sq_pos_of_isCoprime), hence root-free. This is the strict, primitive-case form of Fejér–Riesz nonnegativity.",
+    "mathContext": "$a\\,u + b\\,v = 1 \\;\\xRightarrow{\\text{eval at }t}\\; a(t)u(t) + b(t)v(t) = 1$, so $u(t)=v(t)=0$ would give $0=1$. With $u(t)^2+v(t)^2=0 \\iff u(t)=v(t)=0$ and $u(t)^2+v(t)^2\\ge 0$, coprimality forces $(u^2+v^2)(t) > 0$ for all $t\\in\\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bézout's identity",
+      "coprimality (IsCoprime)",
+      "positive-definite polynomial",
+      "sum of two squares",
+      "polynomial evaluation homomorphism"
+    ],
+    "prerequisites": [
+      "Bézout identity in a Euclidean domain",
+      "ring homomorphism property of polynomial evaluation",
+      "positivity of real squares"
+    ]
   },
   {
     "id": "ann-h17-coprime-cofactors",
@@ -19,18 +33,71 @@
     },
     "type": "technique",
     "title": "Coprime cofactors by cancelling the gcd in its own Bézout identity",
-    "content": "Mathlib has no ready lemma that u/gcd and v/gcd are coprime for a general Euclidean domain (unlike Nat.coprime_div_gcd_div_gcd), so this is proved by hand in four lines. Take the Bézout identity for the gcd itself, d = u·gcdA + v·gcdB (EuclideanDomain.gcd_eq_gcd_ab). Substitute u = d·u₁, v = d·v₁ to get d = d·(u₁·gcdA + v₁·gcdB), then cancel d — nonzero exactly when (u,v) ≠ (0,0), via gcd_eq_zero_iff and mul_left_cancel₀ — to obtain 1 = u₁·gcdA + v₁·gcdB, a Bézout certificate for IsCoprime u₁ v₁. Implementation note: the gcd, gcdA, gcdB are frozen with `set` (after the Bézout hypothesis is created) so that `rw [hu, hv]` rewrites only the standalone u, v and never descends into `gcd u v`; and the cancellation goal is closed with `linear_combination` rather than `rw` to avoid rewriting every copy of d at once."
+    "content": "Mathlib has no ready lemma that u/gcd and v/gcd are coprime for a general Euclidean domain (unlike Nat.coprime_div_gcd_div_gcd), so this is proved by hand in four lines. Take the Bézout identity for the gcd itself, d = u·gcdA + v·gcdB (EuclideanDomain.gcd_eq_gcd_ab). Substitute u = d·u₁, v = d·v₁ to get d = d·(u₁·gcdA + v₁·gcdB), then cancel d — nonzero exactly when (u,v) ≠ (0,0), via gcd_eq_zero_iff and mul_left_cancel₀ — to obtain 1 = u₁·gcdA + v₁·gcdB, a Bézout certificate for IsCoprime u₁ v₁. Implementation note: the gcd, gcdA, gcdB are frozen with `set` (after the Bézout hypothesis is created) so that `rw [hu, hv]` rewrites only the standalone u, v and never descends into `gcd u v`; and the cancellation goal is closed with `linear_combination` rather than `rw` to avoid rewriting every copy of d at once.",
+    "mathContext": "From $d = u\\,A + v\\,B$ with $u = d\\,u_1$, $v = d\\,v_1$: $d = d(u_1 A + v_1 B)$. Since $d = \\gcd(u,v) \\neq 0$ when $(u,v)\\neq(0,0)$, cancel it to get $1 = u_1 A + v_1 B$, i.e. $\\operatorname{IsCoprime}(u_1, v_1)$. This is the Euclidean-domain analogue of $\\gcd\\!\\left(\\tfrac{u}{d},\\tfrac{v}{d}\\right)=1$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "greatest common divisor",
+      "cofactors / primitive part",
+      "cancellation in an integral domain",
+      "Euclidean domain",
+      "Nat.coprime_div_gcd_div_gcd"
+    ],
+    "prerequisites": [
+      "EuclideanDomain gcd API (gcd_eq_gcd_ab, gcd_dvd_left/right, gcd_eq_zero_iff)",
+      "cancellation law mul_left_cancel₀ in a domain",
+      "linear_combination tactic"
+    ]
   },
   {
     "id": "ann-h17-coprime-factorisation",
     "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01",
     "range": {
       "startLine": 97,
-      "endLine": 143
+      "endLine": 116
     },
     "type": "key-step",
     "title": "p = (gcd u v)² · (positive-definite primitive 2-SOS)",
-    "content": "Assembling the pieces: with u = d·u₁ and v = d·v₁ (d = gcd u v), u² + v² = d²·(u₁² + v₁²) by ring, the cofactors are coprime (previous step), and the primitive part u₁² + v₁² is positive definite (Bézout-at-a-point step). So exists_primitive_factorization exhibits every real 2-SOS as a perfect square times a strictly positive polynomial. The root-multiplicity corollary rootMultiplicity_two_sos then splits rootMult r (d²·q) = rootMult r (d²) + rootMult r q via rootMultiplicity_mul; rootMult r q = 0 because q is positive definite (rootMultiplicity_eq_zero on the not-a-root fact), leaving 2·rootMult r d. Since rootMult r (gcd u v) = min(rootMult r u, rootMult r v), this re-derives the parent's 2·min multiplicity formula directly from the factorisation."
+    "content": "Assembling the pieces: with u = d·u₁ and v = d·v₁ (d = gcd u v), u² + v² = d²·(u₁² + v₁²) by ring, the cofactors are coprime (previous step), and the primitive part u₁² + v₁² is positive definite (Bézout-at-a-point step). So exists_primitive_factorization exhibits every real 2-SOS as a perfect square times a strictly positive polynomial — the multiplicative normal form that answers the parent entry's second open question. The gcd_dvd_left/right divisibilities supply the cofactors u₁, v₁; the `set d := gcd u v` freeze keeps the goal readable while `rw [hu₁, hv₁]; ring` verifies the algebraic identity and `sq_add_sq_pos_of_isCoprime hcop` supplies the strict positivity of the primitive part.",
+    "mathContext": "$u = d\\,u_1,\\; v = d\\,v_1,\\; d=\\gcd(u,v)\\;\\Rightarrow\\; u^2+v^2 = d^2\\,(u_1^2+v_1^2)$, with $\\operatorname{IsCoprime}(u_1,v_1)$ and $(u_1^2+v_1^2)(t) > 0\\ \\forall t$. Every real $p = u^2+v^2$ is thus a perfect square times a strictly positive polynomial.",
+    "significance": "key",
+    "relatedConcepts": [
+      "primitive (square-free) decomposition",
+      "content and primitive part of a polynomial",
+      "positive-definite polynomial",
+      "perfect square factor",
+      "Fejér–Riesz theorem"
+    ],
+    "prerequisites": [
+      "divisibility gcd_dvd_left / gcd_dvd_right",
+      "the coprime-cofactor lemma (previous step)",
+      "positive-definiteness of a coprime 2-SOS (first step)"
+    ]
+  },
+  {
+    "id": "ann-h17-coprime-rootmult",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 143
+    },
+    "type": "key-step",
+    "title": "The gcd carries every real zero: rootMult = 2·rootMult(gcd)",
+    "content": "The root-multiplicity corollary makes the parent entry's 2·min formula transparent. In p = d²·q with q = u₁² + v₁² positive definite, q has no real root, so rootMultiplicity r q = 0 (rootMultiplicity_eq_zero applied to the not-a-root fact). Then rootMultiplicity_mul splits rootMult r (d²·q) = rootMult r (d²) + 0, and a second application to d² = d·d (rootMultiplicity_mul again, pow_two) gives 2·rootMult r d. Both applications need the nonvanishing side conditions d ≠ 0 (from gcd_eq_zero_iff) and q ≠ 0 (from positivity at r). Since rootMultiplicity r (gcd u v) = min(rootMultiplicity r u, rootMultiplicity r v), this recovers the parent's rootMult(u²+v²) = 2·min(rootMult u, rootMult v) directly from the factorisation.",
+    "mathContext": "$\\operatorname{rootMult}_r(u^2+v^2) = \\operatorname{rootMult}_r(d^2\\,q) = \\operatorname{rootMult}_r(d^2) + \\operatorname{rootMult}_r(q) = 2\\,\\operatorname{rootMult}_r(d) + 0$, using additivity of root multiplicity over products (both factors $\\neq 0$) and $\\operatorname{rootMult}_r(q)=0$ since $q>0$. With $\\operatorname{rootMult}_r(\\gcd) = \\min$, this is the parent's $2\\min$ law.",
+    "significance": "key",
+    "relatedConcepts": [
+      "root multiplicity",
+      "additivity of multiplicity over products",
+      "greatest common divisor of polynomials",
+      "min of valuations",
+      "order of vanishing"
+    ],
+    "prerequisites": [
+      "rootMultiplicity_mul (additivity for nonzero factors)",
+      "rootMultiplicity_eq_zero (non-root ⟹ multiplicity 0)",
+      "positive-definiteness of the primitive part"
+    ]
   },
   {
     "id": "ann-h17-coprime-nonuniqueness",
@@ -41,6 +108,20 @@
     },
     "type": "concept",
     "title": "The primitive part is not an invariant of p",
-    "content": "The natural uniqueness conjecture — that a real 2-SOS has a well-defined primitive part — is FALSE. The single polynomial (X²+1)² admits two 2-SOS decompositions of opposite character: the non-coprime square (X²+1)² + 0², whose gcd is X²+1 and primitive part is the constant 1; and the coprime sum (X²−1)² + (2X)² (the real and imaginary parts of (X+i)²), whose gcd is a unit and primitive part is (X²+1)² itself. So coprimality of the summands is not preserved across decompositions, and 'primitive normalisation' is a property of a chosen (u,v), not a canonical operation on p (coprimality_not_invariant). The coprime witness a·(X²−1) + b·(2X) = 1 with a = −1, b = ½X is checked by Polynomial.funext (evaluation over the infinite field ℝ) to avoid ring's inability to simplify C(½)·2 = 1; the non-coprimality of (X²+1, 0) reduces via isCoprime_zero_right to X²+1 not being a unit, refuted by its degree (natDegree_X_pow_add_C)."
+    "content": "The natural uniqueness conjecture — that a real 2-SOS has a well-defined primitive part — is FALSE. The single polynomial (X²+1)² admits two 2-SOS decompositions of opposite character: the non-coprime square (X²+1)² + 0², whose gcd is X²+1 and primitive part is the constant 1; and the coprime sum (X²−1)² + (2X)² (the real and imaginary parts of (X+i)²), whose gcd is a unit and primitive part is (X²+1)² itself. So coprimality of the summands is not preserved across decompositions, and 'primitive normalisation' is a property of a chosen (u,v), not a canonical operation on p (coprimality_not_invariant). The coprime witness a·(X²−1) + b·(2X) = 1 with a = −1, b = ½X is checked by Polynomial.funext (evaluation over the infinite field ℝ) to avoid ring's inability to simplify C(½)·2 = 1; the non-coprimality of (X²+1, 0) reduces via isCoprime_zero_right to X²+1 not being a unit, refuted by its degree (natDegree_X_pow_add_C).",
+    "mathContext": "$(X^2+1)^2 = \\underbrace{(X^2+1)^2 + 0^2}_{\\gcd = X^2+1,\\ \\text{primitive } 1} = \\underbrace{(X^2-1)^2 + (2X)^2}_{\\gcd = 1,\\ \\text{primitive } (X^2+1)^2}$. The second is $\\operatorname{Re}((X+i)^2)^2 + \\operatorname{Im}((X+i)^2)^2$. Coprime witness: $(-1)(X^2-1) + (\\tfrac12 X)(2X) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gaussian-integer / complex modulus identity",
+      "counterexample to uniqueness",
+      "units in ℝ[X] (nonzero constants)",
+      "Polynomial.funext (agreement over an infinite domain)",
+      "Brahmagupta–Fibonacci two-square identity"
+    ],
+    "prerequisites": [
+      "isCoprime_zero_right and units of a polynomial ring",
+      "degree of X² + 1 (natDegree_X_pow_add_C)",
+      "Polynomial.funext for identities over ℝ[X]"
+    ]
   }
 ]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -158,8 +158,15 @@
       "id": "primitive-factorisation",
       "title": "The square-times-positive-definite normal form",
       "startLine": 97,
+      "endLine": 116,
+      "summary": "exists_primitive_factorization: u² + v² = (gcd u v)²·(u₁² + v₁²) with coprime, positive-definite primitive part. gcd_dvd_left/right supply the cofactors u₁, v₁; ring verifies the algebraic identity; sq_add_sq_pos_of_isCoprime supplies the strict positivity of the primitive part."
+    },
+    {
+      "id": "root-multiplicity-corollary",
+      "title": "The gcd carries every real zero",
+      "startLine": 118,
       "endLine": 143,
-      "summary": "exists_primitive_factorization: u² + v² = (gcd u v)²·(u₁² + v₁²) with coprime, positive-definite primitive part. rootMultiplicity_two_sos: rootMult r (u² + v²) = 2·rootMult r (gcd u v), splitting the product multiplicity and using that the primitive part is root-free."
+      "summary": "rootMultiplicity_two_sos: rootMult r (u² + v²) = 2·rootMult r (gcd u v). The positive-definite primitive part has multiplicity 0 (rootMultiplicity_eq_zero), so rootMultiplicity_mul splits the product multiplicity into 2·rootMult r (gcd u v). Recovers the parent's 2·min formula since rootMult r (gcd u v) = min(rootMult r u, rootMult r v)."
     },
     {
       "id": "non-uniqueness",
@@ -191,7 +198,28 @@
       "url": "https://www.ams.org/books/conm/253/"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-17-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent root-multiplicity entry: characterises the real roots of a 2-SOS (rootMult(u²+v²) = 2·min(rootMult u, rootMult v)) and asks to factor p = d²·(primitive 2-SOS) with d = gcd(u,v) and to decide uniqueness. This entry proves that factorisation with a positive-definite primitive part and settles uniqueness negatively; its eval_sq_add_sq_eq_zero_iff is reused directly."
+    },
+    {
+      "targetId": "hilbert-17-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Grandparent (degree/Fejér–Riesz sharpness): pins down the degree of the summands in p = u² + v². The coprime normalisation here is the multiplicative counterpart on the root side — p is a square of the gcd times a strictly positive primitive factor."
+    },
+    {
+      "targetId": "hilbert-17-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Great-grandparent (Fejér–Riesz existence/upper bound: PSD ⟹ u² + v²). The positive-definiteness of a coprime 2-SOS proved here is the strict form of nonnegativity for the primitive part."
+    },
+    {
+      "targetId": "hilbert-17",
+      "relationship": "related",
+      "description": "Root ancestor: Hilbert's 17th problem and Artin's theorem. The univariate strand now has existence, exact certificate degree, exact real-root multiplicities, and this coprime (square-times-positive-definite) normal form."
+    }
+  ],
   "mainTheorems": [
     {
       "name": "sq_add_sq_pos_of_isCoprime",


### PR DESCRIPTION
Enrichment pass for the coprime (primitive) normalization of a real sum of two squares.

## Improvements
- **Annotation depth**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation — all 5 are now field-complete (previously 4 annotations had none of these).
- **Coverage granularity**: split the combined factorisation annotation into a dedicated `exists_primitive_factorization` step (lines 97–116) and a new root-multiplicity corollary step (lines 118–143), and added the matching `root-multiplicity-corollary` section so `sections` now cover lines 55–167 at theorem granularity.
- **Cross-references**: populated the previously-empty `crossReferences` with the four Hilbert-17 ancestor entries (parent root-multiplicity, degree-sharpness grandparent, Fejér–Riesz great-grandparent, root ancestor).

## Integrity
- 0 axioms / 0 sorries unchanged; `status: verified`, `badge: original` accurate to the Lean file.
- meta.json 21.7 KB — well under the ~60 KB cap; no collection near its cap.
- JSON validated; all four crossReference targets exist in the gallery.