### PR TITLE
Enrich Hurwitz oq-03 WIP (anticommuting-determinant obstruction)

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-wip-01/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-wip-01/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header-setup",
+    "proofId": "hurwitz-theorem-oq-03-wip-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 53
+    },
+    "type": "context",
+    "title": "WIP framing: isolating the elementary engine of Hurwitz–Radon",
+    "content": "The module docstring positions this file as a *building block*, not a closure of the parent's open even case. Hurwitz–Radon reduces the existence of an n-square identity to a family of anticommuting complex structures M₁,…,M_{n-1} on ℝⁿ (skew-symmetric, orthogonal, Mᵢ²=−I, mutually anticommuting). The parent `hurwitz-theorem-oq-03` kills the odd non-admissible dimensions elementarily but leaves the even case blocked on Clifford representation theory absent from Mathlib. Rather than tackle that, this file extracts the reusable determinant obstruction and states it once over a generic field. The setup `variable {K : Type*} [Field K] {m : ℕ}` (line 52) is deliberately field-agnostic so the single theorem can be replayed over both ℝ (odd case) and ℂ (the n≡2 mod 4 reduction). Despite the 'WIP' label the file is fully verified: 0 sorries, 0 axioms.",
+    "mathContext": "Anticommuting complex structures: $M_i^\\top = -M_i,\\ M_i^\\top M_i = I,\\ M_i^2 = -I,\\ M_iM_j + M_jM_i = 0\\ (i\\neq j)$ — a real representation of $\\mathrm{Cl}(0,n-1)$.",
+    "significance": "context",
+    "relatedConcepts": ["Hurwitz–Radon theorem", "sums of squares identities", "Clifford algebra Cl(0,k)", "complex structures", "division algebras"],
+    "prerequisites": ["Clifford algebras", "the {1,2,4,8} dimension theorem", "Lean section variables"]
+  },
+  {
     "id": "ann-obstruction",
     "proofId": "hurwitz-theorem-oq-03-wip-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `hurwitz-theorem-oq-03-wip-01`.

## Gap addressed
The entry's `meta.json` is already essentially complete (rich historicalContext, keyInsights, conclusion, crossReferences, references, mainTheorems). The one coverage gap was the **un-annotated header/setup** (lines 1–53) of the Lean file.

## Added
- One `context`-type annotation covering lines 1–53: the WIP framing (this is a verified *building block*, not a closure of the parent's open even case), the Hurwitz–Radon anticommuting-complex-structure hypotheses, and the deliberately field-agnostic `variable {K : Type*} [Field K]` setup that lets the single obstruction theorem replay over both ℝ and ℂ (annotations 3 → 4).

## Verification
- annotations.json validated (4 annotations parse cleanly).
- Axiom integrity unchanged: `verified`, `axiomCount: 0`, `sorries: 0`; the new annotation reiterates the 'WIP-but-fully-verified' status accurately (it does NOT claim the parent sorry is closed). No meta claims altered.
- Only `src/data/proofs/hurwitz-theorem-oq-03-wip-01/` changed; committed on a dedicated branch.