### PR TITLE
Enrich De Moivre oq-05-oq-02-oq-03 (∑ primitive roots = μ(n) over a domain)

### DIFF
--- a/src/data/proofs/de-moivre-oq-05-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02-oq-03/annotations.json
@@ -25,6 +25,29 @@
     ]
   },
   {
+    "id": "ann-de-moivre-oq-05-oq-02-oq-03-image",
+    "proofId": "de-moivre-oq-05-oq-02-oq-03",
+    "range": {
+      "startLine": 71,
+      "endLine": 84
+    },
+    "type": "technique",
+    "title": "Enumerating the k-th roots as {ζ⁰, …, ζ^{k-1}}",
+    "content": "nthRootsFinset_eq_image is the enabling helper: in a domain with a primitive k-th root ζ, the finset of all k-th roots of unity is exactly the image of range k under i ↦ ζⁱ. The forward inclusion uses IsPrimitiveRoot.eq_pow_of_pow_eq_one (every root x with xᵏ=1 is a power of ζ); the reverse checks (ζⁱ)ᵏ = (ζᵏ)ⁱ = 1 by commuting the exponents (pow_mul, mul_comm) and hζ.pow_eq_one. The [DecidableEq R] instance is required only so Finset.image is computable, and NeZero k is supplied from 0 < k. This lemma converts an abstract root set into a concrete indexed power list, which is what lets the next lemma turn the root sum into a geometric series.",
+    "mathContext": "$\\{x : x^k = 1\\} = \\{\\zeta^i : 0 \\le i < k\\}$ in a domain with primitive $k$-th root $\\zeta$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "roots of unity finset",
+      "IsPrimitiveRoot.eq_pow_of_pow_eq_one",
+      "Finset.image",
+      "cyclic enumeration"
+    ],
+    "prerequisites": [
+      "primitive roots as generators",
+      "DecidableEq for Finset.image"
+    ]
+  },
+  {
     "id": "ann-de-moivre-oq-05-oq-02-oq-03-02",
     "proofId": "de-moivre-oq-05-oq-02-oq-03",
     "range": {

--- a/src/data/proofs/de-moivre-oq-05-oq-02-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02-oq-03/meta.json
@@ -178,6 +178,16 @@
       "targetId": "de-moivre-oq-05-oq-02",
       "relationship": "extends",
       "description": "Parent proves ∑ primitive n-th roots = μ(n) over ℂ; this entry generalizes to any commutative integral domain containing a primitive n-th root of unity, answering the parent's stated open question."
+    },
+    {
+      "targetId": "de-moivre-oq-05",
+      "relationship": "descends-from",
+      "description": "Grandparent in the oq-05 line on sums of primitive roots of unity and their arithmetic (Möbius) interpretation, of which the parent's ℂ result and this integral-domain generalization are successive refinements."
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "root-entry",
+      "description": "Base De Moivre / roots-of-unity gallery entry from which the whole oq-05 lineage on cyclotomic sums descends."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-05-oq-02-oq-03`.

## Gaps addressed
Rich `meta.json` (conclusion, 5 keyInsights) and 3 good annotations, but the `nthRootsFinset_eq_image` helper (lines 71–84) was un-annotated and only the parent was cross-linked.

## Added
**annotations.json (3 → 4):**
- `technique` annotation for `nthRootsFinset_eq_image`: enumerating the k-th roots of unity as $\{\zeta^0,\dots,\zeta^{k-1}\}$ via `IsPrimitiveRoot.eq_pow_of_pow_eq_one`, the step that turns the root sum into a geometric series.

**meta.json crossReferences (1 → 3):**
- Added lineage links to grandparent `de-moivre-oq-05` and base `de-moivre`.

## Verification
- meta.json and annotations.json validated; meta 15 KB (well under 60 KB cap).
- Axiom integrity unchanged: no status/badge/axiom claims altered.
- Only `src/data/proofs/de-moivre-oq-05-oq-02-oq-03/` changed; dedicated branch.