### PR TITLE
Enrich Antitone integral–sum comparison: γ identification (antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "ann-antitoneoq02020q01-identify",
     "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 74, "endLine": 95 },
+    "range": { "startLine": 74, "endLine": 81 },
     "type": "insight",
-    "title": "Identification by uniqueness of limits, and the sharp enclosure",
-    "content": "generalizedEuler_one_div_eq_eulerMascheroniConstant: tendsto_defect antitoneOn_one_div one_div_nonneg_on gives Tendsto (defect (1/·)) atTop (𝓝 (generalizedEuler (1/·))); rewriting defect (1/·) to fun n => harmonic n − log(n+1) (funext defect_one_div_eq) makes it literally the sequence of Real.tendsto_harmonic_sub_log_add_one (→ γ), so tendsto_nhds_unique equates the two limits: generalizedEuler (1/·) = γ. Because the sequences are equal (not merely asymptotic), no squeeze or error estimate is needed. generalizedEuler_one_div_mem_Ioo then sharpens the parent's crude [0, 1] enclosure to γ ∈ (1/2, 2/3) using Mathlib's numeric bounds. #print axioms confirms only propext / Classical.choice / Quot.sound.",
-    "mathContext": "$\\mathrm{generalizedEuler}(1/\\cdot)=\\gamma\\in(\\tfrac12,\\tfrac23)$ by $\\mathrm{tendsto\\_nhds\\_unique}$.",
+    "title": "Identification by uniqueness of limits",
+    "content": "generalizedEuler_one_div_eq_eulerMascheroniConstant is the main result. tendsto_defect antitoneOn_one_div one_div_nonneg_on gives Tendsto (defect (1/·)) atTop (𝓝 (generalizedEuler (1/·))); rewriting defect (1/·) to fun n => harmonic n − log(n+1) (funext defect_one_div_eq) makes it literally the sequence of Real.tendsto_harmonic_sub_log_add_one (→ γ), so tendsto_nhds_unique equates the two limits: generalizedEuler (1/·) = γ. The crux is that the two sequences are termwise EQUAL, not merely asymptotic, so uniqueness of limits in a Hausdorff space closes the goal directly — no squeeze, no error estimate, no rate.",
+    "mathContext": "$\\mathrm{defect}(1/\\cdot)\\to\\mathrm{generalizedEuler}(1/\\cdot)$ and $H_n-\\log(n+1)\\to\\gamma$ are the SAME sequence, so $\\mathrm{tendsto\\_nhds\\_unique}$ gives $\\mathrm{generalizedEuler}(1/\\cdot)=\\gamma$.",
     "significance": "key",
-    "relatedConcepts": ["tendsto_nhds_unique", "Real.tendsto_harmonic_sub_log_add_one", "uniqueness of limits", "eulerMascheroniConstant bounds", "value identification"],
+    "relatedConcepts": ["tendsto_nhds_unique", "Real.tendsto_harmonic_sub_log_add_one", "uniqueness of limits", "Hausdorff space", "value identification"],
     "prerequisites": ["the parent tendsto_defect", "Mathlib's sequence convergence to γ", "Hausdorff uniqueness of limits"]
+  },
+  {
+    "id": "ann-antitoneoq02020q01-enclosure",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 83, "endLine": 95 },
+    "type": "corollary",
+    "title": "Sharp enclosure: from [0,1] to γ ∈ (1/2, 2/3)",
+    "content": "generalizedEuler_one_div_mem_Ioo upgrades the parent's crude abstract enclosure generalizedEuler (1/·) ∈ [0, f 1] = [0, 1] to the sharp numeric window γ ∈ (1/2, 2/3). The proof simply rewrites the constant to γ via the main identification and then invokes Mathlib's two numeric facts Real.one_half_lt_eulerMascheroniConstant and Real.eulerMascheroniConstant_lt_two_thirds — so the whole value-localization is inherited from Mathlib's Euler–Mascheroni development rather than re-derived. The trailing #print axioms directives confirm both public theorems depend only on the foundational trio propext / Classical.choice / Quot.sound (0 axioms, 0 sorries).",
+    "mathContext": "$\\gamma\\approx 0.5772\\in(\\tfrac12,\\tfrac23)$, refining the parent's $[0,1]$; established by rewriting through the identification and Mathlib's numeric bounds.",
+    "significance": "supporting",
+    "relatedConcepts": ["eulerMascheroniConstant bounds", "Real.one_half_lt_eulerMascheroniConstant", "sharp enclosure", "axiom audit", "corollary of value identification"],
+    "prerequisites": ["the main identification theorem", "Mathlib's numeric bounds on γ"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for the identification generalizedEuler(1/x) = γ.

## Improvements
- Split the previously-combined `identify` annotation (which bundled the main identification and the sharp-enclosure corollary into one 74–95 block) into two focused annotations: the **uniqueness-of-limits identification** (`generalizedEuler_one_div_eq_eulerMascheroniConstant`, lines 74–81) and the **sharp enclosure corollary** (`generalizedEuler_one_div_mem_Ioo`: γ ∈ (1/2, 2/3), lines 83–95, incl. the axiom audit).
- Annotations now 4 → 5, all with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- Each new annotation `startLine` is anchored to its Lean construct span and `type` matches the construct kind (verified against `scripts/annotations/resolver.ts`).

## Integrity
- 0 axioms / 0 sorries unchanged; content only split/deepened, none removed.
- meta.json unchanged (~15.6 KB, well under cap); JSON validated.