### PR TITLE
Enrich Sylvester's sequence doubly-exponential bound (sylvester-sequence-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/sylvester-sequence-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/sylvester-sequence-oq-01-oq-02/annotations.json
@@ -14,14 +14,26 @@
   {
     "id": "ann-invariant",
     "proofId": "sylvester-sequence-oq-01-oq-02",
-    "range": { "startLine": 52, "endLine": 80 },
-    "type": "lemma",
+    "range": { "startLine": 52, "endLine": 61 },
+    "type": "theorem",
     "title": "The Strengthened +1 Invariant",
-    "content": "The heart of the entry. The naive induction $a_n \\ge b_n$ with $b_n = 2^{2^{n-1}}$ (so $b_{n+1} = b_n^2$) fails: the step needs $a_{n+1} = a_n^2 - a_n + 1 \\ge b_n^2$, but at the tight point $a_n = b_n$ the value $b_n^2 - b_n + 1$ is strictly below $b_n^2$ — the $-a_n$ term wins. The fix is to prove MORE: $a_{n+1} \\ge b_{n+1} + 1$, i.e. $2^{2^n} + 1 \\le a_{n+1}$. With $B = 2^{2^n}$ and $a \\ge B+1$, the step $a^2 - a + 1 \\ge (B+1)^2 - (B+1) + 1 = B^2 + B + 1 \\ge B^2 + 1 = 2^{2^{n+1}} + 1$ is self-sustaining. The Lean proof works in $\\mathbb{Z}$ (via `syl_cast_succ`, dodging truncated $\\mathbb{N}$ subtraction), rewrites $2^{2^{n+1}} = B^2$ with `pow_succ`/`pow_mul`, and lets `nlinarith` close the degree-2 inequality with the hint `sq_nonneg (a - B - 1)`.",
-    "mathContext": "$a \\ge B + 1 \\ \\Rightarrow\\ a^2 - a + 1 \\ge B^2 + B + 1 \\ge B^2 + 1.$",
+    "content": "The heart of the entry, and a textbook case of why a stronger hypothesis is easier to prove. The naive induction $a_n \\ge b_n$ with $b_n = 2^{2^{n-1}}$ (so $b_{n+1} = b_n^2$) fails: the step needs $a_{n+1} = a_n^2 - a_n + 1 \\ge b_n^2$, but at the tight point $a_n = b_n$ the value $b_n^2 - b_n + 1$ is strictly below $b_n^2$ — the $-a_n$ term wins. The fix is to prove MORE: $a_{n+1} \\ge b_{n+1} + 1$, i.e. $2^{2^n} + 1 \\le a_{n+1}$. The extra $+1$ is precisely the slack that absorbs the $-a_n$ term at the next step. The base case is the sharp equality $a_1 = 3 = 2^{2^0} + 1$, discharged by `norm_num [show syl 1 = 3 from rfl]`.",
+    "mathContext": "Strengthened claim $2^{2^n} + 1 \\le a_{n+1}$; base case $a_1 = 3 = 2^{2^0}+1$ (equality, the tightest point).",
     "significance": "key",
-    "relatedConcepts": ["strengthening the induction hypothesis", "sum of squares", "nlinarith", "ℕ→ℤ casting"],
-    "prerequisites": ["induction with a stronger hypothesis", "Positivstellensatz certificates"]
+    "relatedConcepts": ["strengthening the induction hypothesis", "doubly-exponential growth", "sharp base case"],
+    "prerequisites": ["induction with a stronger hypothesis", "the recurrence a_{n+1} = a_n² − a_n + 1"]
+  },
+  {
+    "id": "ann-invariant-step",
+    "proofId": "sylvester-sequence-oq-01-oq-02",
+    "range": { "startLine": 62, "endLine": 80 },
+    "type": "technique",
+    "title": "The inductive step: closing a degree-2 bound in ℤ",
+    "content": "The self-sustaining step. With $B = 2^{2^k}$ and $a = a_{k+1} \\ge B+1$, one needs $a_{k+2} = a^2 - a + 1 \\ge B^2 + 1 = 2^{2^{k+1}} + 1$. Two Lean-specific moves make this go through: (1) everything is lifted to $\\mathbb{Z}$ via `syl_cast_succ` so that the $-a_n$ term is genuine subtraction rather than truncated $\\mathbb{N}$ subtraction, and (2) $2^{2^{k+1}}$ is rewritten as $B^2$ using `pow_succ` (to get $2^{k+1} = 2^k \\cdot 2$) and `pow_mul`. The degree-2 inequality is then discharged by `nlinarith` with the single hint `sq_nonneg (a - B - 1)` — encoding $(a-B-1)^2 \\ge 0$, which together with $a \\ge B+1$ and $B \\ge 1$ certifies $a^2 - a + 1 \\ge B^2 + 1$. Finally `exact_mod_cast` transports the ℤ result back to ℕ.",
+    "mathContext": "$(a-B-1)^2 \\ge 0$ and $a \\ge B+1 \\Rightarrow a^2 - a + 1 \\ge B^2 + B + 1 \\ge B^2 + 1$; with $2^{2^{k+1}} = (2^{2^k})^2 = B^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["nlinarith", "sq_nonneg Positivstellensatz hint", "ℕ→ℤ casting to avoid truncated subtraction", "pow_succ / pow_mul"],
+    "prerequisites": ["nonlinear arithmetic certificates", "integer casting of recurrences"]
   },
   {
     "id": "ann-bound",


### PR DESCRIPTION
Enrichment pass for the doubly-exponential lower bound on Sylvester's sequence.

## Improvements
- Split the `ann-invariant` annotation (previously one 52–80 block) into two focused annotations: the **conceptual strengthening + sharp base case** (`syl_ge_double_exp_succ`, why the naive induction fails and how the +1 slack fixes it, lines 52–61) and the **ℤ-lifted inductive step** (casting to dodge truncated ℕ subtraction, `pow_succ`/`pow_mul`, and the `nlinarith`/`sq_nonneg (a-B-1)` certificate, lines 62–80).
- Annotations now 4 → 5, all with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- Fixed a type mismatch: `ann-invariant` was typed `lemma` but the construct is a `theorem` — now `theorem` (validator-clean per `scripts/annotations/resolver.ts`).

## Integrity
- 0 axioms / 0 sorries unchanged; content only split/deepened, none removed.
- meta.json unchanged; JSON validated.