### PR TITLE
Enrich: Generalized Euler Constant (1/x=γ) + Hurwitz oq-03 WIP obstruction

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/annotations.json
@@ -38,25 +38,25 @@
   {
     "id": "ann-antitoneoq02020q01-identify",
     "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 74, "endLine": 81 },
+    "range": { "startLine": 74, "endLine": 82 },
     "type": "insight",
     "title": "Identification by uniqueness of limits",
-    "content": "generalizedEuler_one_div_eq_eulerMascheroniConstant is the main result. tendsto_defect antitoneOn_one_div one_div_nonneg_on gives Tendsto (defect (1/·)) atTop (𝓝 (generalizedEuler (1/·))); rewriting defect (1/·) to fun n => harmonic n − log(n+1) (funext defect_one_div_eq) makes it literally the sequence of Real.tendsto_harmonic_sub_log_add_one (→ γ), so tendsto_nhds_unique equates the two limits: generalizedEuler (1/·) = γ. The crux is that the two sequences are termwise EQUAL, not merely asymptotic, so uniqueness of limits in a Hausdorff space closes the goal directly — no squeeze, no error estimate, no rate.",
-    "mathContext": "$\\mathrm{defect}(1/\\cdot)\\to\\mathrm{generalizedEuler}(1/\\cdot)$ and $H_n-\\log(n+1)\\to\\gamma$ are the SAME sequence, so $\\mathrm{tendsto\\_nhds\\_unique}$ gives $\\mathrm{generalizedEuler}(1/\\cdot)=\\gamma$.",
+    "content": "generalizedEuler_one_div_eq_eulerMascheroniConstant: tendsto_defect antitoneOn_one_div one_div_nonneg_on gives Tendsto (defect (1/·)) atTop (𝓝 (generalizedEuler (1/·))); a single rw with funext defect_one_div_eq rewrites the function defect (1/·) to fun n => harmonic n − log(n+1) throughout the hypothesis, making it literally the sequence of Real.tendsto_harmonic_sub_log_add_one (→ γ). tendsto_nhds_unique then equates the two limits: generalizedEuler (1/·) = γ. The whole identification is three lines because the sequences are *equal*, not merely asymptotic — no squeeze, no o(1) error estimate, no Cesàro argument is needed. The rewrite of a function-valued term (defect (1/·) is a ℕ → ℝ) rather than a pointwise value is what lets tendsto_nhds_unique fire without further massaging.",
+    "mathContext": "$\\mathrm{generalizedEuler}(1/\\cdot)=\\lim_n\\big(H_n-\\log(n+1)\\big)=\\gamma$ by $\\mathrm{tendsto\\_nhds\\_unique}$ against the parent's $\\mathrm{tendsto\\_defect}$.",
     "significance": "key",
-    "relatedConcepts": ["tendsto_nhds_unique", "Real.tendsto_harmonic_sub_log_add_one", "uniqueness of limits", "Hausdorff space", "value identification"],
+    "relatedConcepts": ["tendsto_nhds_unique", "Real.tendsto_harmonic_sub_log_add_one", "uniqueness of limits", "funext on a sequence", "value identification"],
     "prerequisites": ["the parent tendsto_defect", "Mathlib's sequence convergence to γ", "Hausdorff uniqueness of limits"]
   },
   {
-    "id": "ann-antitoneoq02020q01-enclosure",
+    "id": "ann-antitoneoq02020q01-ioo",
     "proofId": "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01",
     "range": { "startLine": 83, "endLine": 95 },
-    "type": "corollary",
-    "title": "Sharp enclosure: from [0,1] to γ ∈ (1/2, 2/3)",
-    "content": "generalizedEuler_one_div_mem_Ioo upgrades the parent's crude abstract enclosure generalizedEuler (1/·) ∈ [0, f 1] = [0, 1] to the sharp numeric window γ ∈ (1/2, 2/3). The proof simply rewrites the constant to γ via the main identification and then invokes Mathlib's two numeric facts Real.one_half_lt_eulerMascheroniConstant and Real.eulerMascheroniConstant_lt_two_thirds — so the whole value-localization is inherited from Mathlib's Euler–Mascheroni development rather than re-derived. The trailing #print axioms directives confirm both public theorems depend only on the foundational trio propext / Classical.choice / Quot.sound (0 axioms, 0 sorries).",
-    "mathContext": "$\\gamma\\approx 0.5772\\in(\\tfrac12,\\tfrac23)$, refining the parent's $[0,1]$; established by rewriting through the identification and Mathlib's numeric bounds.",
+    "type": "insight",
+    "title": "Sharpening the enclosure, and the axiom audit",
+    "content": "generalizedEuler_one_div_mem_Ioo is the payoff of pinning the value. The parent could only offer the crude enclosure generalizedEuler (1/·) ∈ [0, f 1] = [0, 1] (the f 1 = 1 bound from boundedness of the defect). Rewriting by the identification and supplying Mathlib's numeric bounds Real.one_half_lt_eulerMascheroniConstant and Real.eulerMascheroniConstant_lt_two_thirds tightens this to γ ∈ (1/2, 2/3) — a strict two-sided Ioo enclosure of width 1/6, obtained for free from the classical γ development the moment the constant is named. The trailing #print axioms on both main theorems confirms the reduction bottoms out at only propext / Classical.choice / Quot.sound: no Lean.ofReduceBool (no native_decide) and no sorryAx, so the entry's status: verified / axiomCount: 0 is honest.",
+    "mathContext": "$\\tfrac12<\\gamma<\\tfrac23$, so $\\mathrm{generalizedEuler}(1/\\cdot)\\in(\\tfrac12,\\tfrac23)$; $\\#\\mathrm{print\\ axioms}=\\{\\mathrm{propext},\\mathrm{Classical.choice},\\mathrm{Quot.sound}\\}$.",
     "significance": "supporting",
-    "relatedConcepts": ["eulerMascheroniConstant bounds", "Real.one_half_lt_eulerMascheroniConstant", "sharp enclosure", "axiom audit", "corollary of value identification"],
-    "prerequisites": ["the main identification theorem", "Mathlib's numeric bounds on γ"]
+    "relatedConcepts": ["eulerMascheroniConstant bounds", "Set.Ioo enclosure", "sharpening an abstract bound", "axiom audit", "0-axiom verification"],
+    "prerequisites": ["the main identification theorem", "Mathlib's numeric bounds on γ", "how #print axioms reads a proof term"]
   }
 ]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -120,6 +120,16 @@
       "targetId": "antitone-integral-sum-comparison-oq-01-oq-02",
       "relationship": "related",
       "description": "Grandparent: re-exports Mathlib's Hₙ − log(n+1) → γ sequence convergence, the classical fact this entry connects to the abstract constant."
+    },
+    {
+      "targetId": "harmonic-divergence-oq-01",
+      "relationship": "related",
+      "description": "A dedicated formalization of the Euler–Mascheroni constant γ: convergence and monotonicity of the defining sequences, log bounds on harmonic numbers, and numeric enclosures. The named constant Real.eulerMascheroniConstant that this entry identifies with generalizedEuler (1/·) is the subject there; the (1/2, 2/3) enclosure used in the corollary lives in the same γ development."
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "related",
+      "description": "The harmonic series ∑ 1/n diverges — the complementary fact to this entry's convergence: it is precisely because Hₙ grows like log n (Hₙ → ∞) that the *centered* sequence Hₙ − log(n+1) can settle to the finite constant γ. Divergence of the sum and convergence of the defect are two sides of the same asymptotic Hₙ ≈ log n + γ."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment batch (two entries, one per commit).

## 1. `antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01` — Generalized Euler Constant of 1/x = γ
- **Annotations 4 → 5**: split the bundled 74–95 annotation into *Identification by uniqueness of limits* (74–82) and *Sharpening the enclosure, and the axiom audit* (83–95), one theorem each.
- Deepened with the `funext`-on-a-sequence mechanism and the 0-axiom reduction (propext / Classical.choice / Quot.sound; no `ofReduceBool`/`sorryAx`).
- **Cross-references 2 → 4**: added `harmonic-divergence-oq-01` (the γ development supplying the (1/2,2/3) bounds) and `harmonic-divergence` (∑1/n divergence as the complement of Hₙ − log(n+1) convergence).

## 2. `hurwitz-theorem-oq-03-wip-01` — Anticommuting-Determinant Obstruction
- **Annotations 4 → 5**: split the bundled 88–121 'Odd-Dimension Corollaries' annotation into *Contrapositive* `no_anticommuting_invertible_of_odd` (88–97) and *Complex-structure form* `no_anticommuting_complex_structures_of_odd` (99–121), one theorem each.
- The complex-structure annotation now details how invertibility is *derived* from M²=-1 (A·(-A)=1 ⇒ det A a unit via `left_ne_zero_of_mul_eq_one`), enabling the call from `crossMat` with no extra hypotheses.
- Split the matching meta.json section into `odd-contrapositive` and `complex-structures`.

## Verification
- JSON validated for both; `pnpm annotations:build` reports no misalignment for either target (all ranges resolve to real Lean constructs).
- Both meta.json files well under the ~60 KB cap (16.5 KB, 14.7 KB); all collections under caps.
- Every meta claim checked against the respective `.lean` file (theorem/sorry/axiom counts accurate).