### PR TITLE
research(amgm-oq020201): build-verify signed Newton + drop nonzero hypothesis at top index [0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/NewtonSignedInputs.lean
+++ b/proofs/Proofs/NewtonSignedInputs.lean
@@ -27,6 +27,9 @@
     obtained by applying the (already signed) k = 1 inequality to the
     reciprocals yᵢ = 1/xᵢ and clearing eₙ².  This transports signedness from
     the bottom index to the top index for every n.
+  * `newton_signed_top_general`: the same top-index inequality with the nonzero
+    hypothesis removed — it holds for ALL real inputs, since a zero coordinate
+    forces eₙ = 0 and collapses the right-hand side.
   * `newton_n3_k2_signed`: the n = 3, k = 2 case for arbitrary reals (including
     zeros), by an explicit sum-of-squares certificate
         (ab+bc+ca)² - 3abc(a+b+c) = ½[(ab-bc)² + (bc-ca)² + (ca-ab)²].
@@ -128,6 +131,28 @@ theorem newton_signed_top {n : ℕ} (hn : 2 ≤ n) (x : Fin n → ℝ)
       = (Nat.choose n 2 : ℝ) * elemSymm (n - 1) x ^ 2 := by rw [mul_assoc, h1]
   rw [hL, hR] at key
   exact key
+
+/-- **Newton's inequality at the top index, for ALL real inputs (no nonzero
+hypothesis).**  For all `n ≥ 2` and all reals `x₁,…,xₙ`,
+    C(n,2)·e_{n-1}(x)² ≥ n²·e_{n-2}(x)·eₙ(x).
+The nonzero hypothesis of `newton_signed_top` is unnecessary: if some `xᵢ = 0`
+then `eₙ(x) = ∏ xᵢ = 0`, so the right-hand side vanishes while the left-hand
+side `C(n,2)·e_{n-1}²` is a nonnegative multiple of a square.  Combined with the
+nonzero case (`newton_signed_top`) this gives the fully general signed top-index
+Newton inequality. -/
+theorem newton_signed_top_general {n : ℕ} (hn : 2 ≤ n) (x : Fin n → ℝ) :
+    (Nat.choose n 2 : ℝ) * (elemSymm (n - 1) x) ^ 2
+      ≥ (n : ℝ) ^ 2 * (elemSymm (n - 2) x * elemSymm n x) := by
+  rcases eq_or_ne (elemSymm n x) 0 with hen | hen
+  · -- eₙ(x) = 0 (e.g. some coordinate is zero): the right-hand side collapses.
+    rw [hen, mul_zero, mul_zero]
+    exact mul_nonneg (Nat.cast_nonneg _) (sq_nonneg _)
+  · -- eₙ(x) = ∏ xᵢ ≠ 0, so every coordinate is nonzero; use the nonzero case.
+    have hx : ∀ i, x i ≠ 0 := by
+      rw [elemSymm_n_eq_prod] at hen
+      intro i hi
+      exact hen (Finset.prod_eq_zero (Finset.mem_univ i) hi)
+    exact newton_signed_top hn x hx
 
 /-
 ## Part III: The n = 3, k = 2 case for arbitrary reals (via sum of squares)

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-01.json
@@ -29,8 +29,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (build-unverified this session - Docker infra corrupt): proved Newton at the TOP index k=n-1 for all n and all nonzero real inputs, via reciprocal duality e_k(1/x)*e_n(x)=e_{n-k}(x) reducing to the already-signed k=1 case; plus n=3,k=2 signed via explicit SOS. Intermediate indices 1<k<n-1 remain the frontier (need Rolle/real-rootedness).",
+    "progressSummary": "VERIFIED (0 sorries, 0 axioms; docker-build clean, 7744 jobs). Signed-input Newton at the TOP index k=n-1 for all n, now for ALL real inputs: newton_signed_top (nonzero xᵢ, via reciprocal duality e_k(1/x)·e_n(x)=e_{n-k}(x) reducing to the signed k=1 Cauchy–Schwarz case) plus newton_signed_top_general (nonzero hypothesis REMOVED — a zero coordinate forces eₙ=0, collapsing the RHS). Also newton_n3_k2_signed (n=3,k=2 for arbitrary reals via SOS). Frontier: intermediate indices 1<k<n-1 for general n still need Rolle/real-rootedness.",
     "builtItems": [
+      "newton_signed_top_general (NewtonSignedInputs.lean): C(n,2)·e_{n-1}²≥n²·e_{n-2}·eₙ for ALL real xᵢ (no nonzero hypothesis) — case split on eₙ=0 (RHS collapses, LHS≥0) vs eₙ≠0 (⇒all xᵢ≠0, apply newton_signed_top).",
       "elemSymm_inv_mul (NewtonSignedInputs.lean): reciprocal identity e_k(1/x)*e_n(x)=e_{n-k}(x) for nonzero x, k<=n - complement bijection via Finset.sum_bij'",
       "newton_signed_top (NewtonSignedInputs.lean): C(n,2)*e_{n-1}(x)^2 >= n^2*e_{n-2}(x)*e_n(x) for n>=2, all x_i != 0 (signed top-index Newton)",
       "newton_n3_k2_signed (NewtonSignedInputs.lean): ((ab+bc+ca)/3)^2 >= ((a+b+c)/3)*abc for ALL reals a,b,c (SOS, no sign hyp)"
@@ -45,9 +46,7 @@
       "No packaged lemma 'derivative of a real-rooted polynomial is real-rooted' (needs Rolle across a multiset of real roots + Vieta for the derivative). Missing ingredient for intermediate indices 1<k<n-1 for general n."
     ],
     "nextSteps": [
-      "BUILD-VERIFY NewtonSignedInputs.lean once Docker infra recovers (this session blocked by containerd meta.db I/O error + SIGBUS 135). Mechanical risks: Finset.sum_bij' arg order and the rw chains.",
-      "Prove intermediate indices via real-rootedness: P(t)=prod(t-x_i) real-rooted => P' real-rooted (Rolle), coeffs of P' are (n-j)e_j, then discriminant of a real quadratic gives Newton at general k.",
-      "Handle the zero case for the top index (some x_i=0) via continuity/density or a direct e_n=0 split, to drop x_i != 0."
+      "Prove intermediate indices via real-rootedness: P(t)=prod(t-x_i) real-rooted => P' real-rooted (Rolle), coeffs of P' are (n-j)e_j, then discriminant of a real quadratic gives Newton at general k."
     ],
     "markdown": "# Knowledge Base: amgm-inequality-oq-02-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Problem: **amgm-inequality-oq-02-oq-02-oq-01** (signed-input Newton inequality).

`NewtonSignedInputs.lean` was landed build-pending in #34949. This session:

1. **Build-verifies** the file — `docker-build.sh Proofs.NewtonSignedInputs` completes cleanly (7744 jobs), confirming the prior session's reciprocal-duality argument is kernel-correct. 0 sorries, 0 axioms.
2. **Adds `newton_signed_top_general`** — Newton's inequality at the top index $k=n-1$ for **all real inputs**, removing the nonzero hypothesis of `newton_signed_top`.

## The new theorem

```
C(n,2)·e_{n-1}(x)² ≥ n²·e_{n-2}(x)·eₙ(x)   for all n ≥ 2 and all x : Fin n → ℝ
```

Proof is a two-case split on `eₙ(x)`:
- **`eₙ(x) = 0`** (e.g. some coordinate is zero): the RHS collapses to 0, and the LHS `C(n,2)·e_{n-1}²` is a nonnegative multiple of a square.
- **`eₙ(x) ≠ 0`**: since `eₙ(x) = ∏ xᵢ`, every coordinate is nonzero, so the existing `newton_signed_top` applies.

This upgrades the top-index signed Newton inequality from *nonzero* inputs to *all real* inputs.

## File state

4 lemmas / 193 lines / **0 sorries / 0 axioms**.

## Frontier (unchanged, still open)

Intermediate indices $1 < k < n-1$ for general $n$ still require the real-rootedness / Rolle machinery (differentiate $∏(t-xᵢ)$, which stays real-rooted) — noted at the end of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)