### PR TITLE
research(erdos-1018): fix universe bug in sparse_hides_nonplanarity (kernel-elaborates clean; build blocked by v4.26 codegen SIGBUS)

### DIFF
--- a/proofs/Proofs/Erdos1018Problem.lean
+++ b/proofs/Proofs/Erdos1018Problem.lean
@@ -198,10 +198,14 @@ axiom constant_grows : ∀ M : ℕ, ∃ ε₀ > 0, ∀ ε < ε₀,
     for **every** vertex type with **no** cardinality threshold — is strictly
     stronger than `existsBoundingConstant ε` (which only needs *some* threshold
     `N`). We discharge `existsBoundingConstant ε` by taking `N = 0`, then feed it
-    to `constant_grows` to conclude `C ≥ M`. -/
+    to `constant_grows` to conclude `C ≥ M`.
+
+    The vertex quantifier ranges over `Type` (matching `existsBoundingConstant`,
+    which is itself stated over `Type`) so that the `N = 0` witness lands in
+    exactly the universe the goal expects. -/
 theorem sparse_hides_nonplanarity :
     ∀ M : ℕ, ∃ ε₀ > 0, ∀ ε < ε₀, ∀ C,
-      (∀ (V : Type*) [Fintype V] [DecidableEq V],
+      (∀ (V : Type) [Fintype V] [DecidableEq V],
         ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
           isDense G ε → hasSmallNonPlanarSubgraph G C) → C ≥ M := by
   intro M

--- a/proofs/Proofs/Erdos1018Problem.lean
+++ b/proofs/Proofs/Erdos1018Problem.lean
@@ -191,13 +191,31 @@ Erdős noted that C_ε → ∞ as ε → 0.
 axiom constant_grows : ∀ M : ℕ, ∃ ε₀ > 0, ∀ ε < ε₀,
   ∀ C, existsBoundingConstant ε → C ≥ M
 
-/-- Intuition: sparser graphs hide non-planarity in larger structures. -/
+/-- Intuition: sparser graphs hide non-planarity in larger structures.
+
+    Derived from the stated `constant_grows` axiom (no new assumptions). The
+    hypothesis here — that *this* `C` already bounds the non-planar subgraph size
+    for **every** vertex type with **no** cardinality threshold — is strictly
+    stronger than `existsBoundingConstant ε` (which only needs *some* threshold
+    `N`). We discharge `existsBoundingConstant ε` by taking `N = 0`, then feed it
+    to `constant_grows` to conclude `C ≥ M`. -/
 theorem sparse_hides_nonplanarity :
     ∀ M : ℕ, ∃ ε₀ > 0, ∀ ε < ε₀, ∀ C,
       (∀ (V : Type*) [Fintype V] [DecidableEq V],
         ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
           isDense G ε → hasSmallNonPlanarSubgraph G C) → C ≥ M := by
-  sorry
+  intro M
+  obtain ⟨ε₀, hε₀, hgrow⟩ := constant_grows M
+  refine ⟨ε₀, hε₀, ?_⟩
+  intro ε hε C hP
+  -- `constant_grows` reduces the goal to establishing `existsBoundingConstant ε`.
+  refine hgrow ε hε C ?_
+  -- Discharge `existsBoundingConstant ε`: the witnessing constant is `C` itself
+  -- and the threshold is `N = 0`, since `hP` holds uniformly over all `V`.
+  intro _hεpos
+  refine ⟨C, 0, ?_⟩
+  intro V instF instD _hcard G instR hDense
+  exact @hP V instF instD G instR hDense
 
 /-
 ## Connection to Extremal Graph Theory


### PR DESCRIPTION
## Summary

Erdős #1018 (dense graphs contain small non-planar subgraphs). This PR fixes a **real universe bug** in `sparse_hides_nonplanarity` so the proof now kernel-elaborates cleanly, and documents a separate, pre-existing v4.26 codegen regression that blocks a green `lake build`.

## The fix

The theorem derives `sparse_hides_nonplanarity` from the `constant_grows` axiom (no new assumptions), discharging `existsBoundingConstant ε` with threshold `N = 0`. The prior proof did **not** elaborate:

- `hP` quantified the vertex type over `Type*` — the theorem's *fixed* universe `u`;
- the goal `existsBoundingConstant ε` is stated over `Type` (universe 0);
- so `@hP V` for the Type-0 witness `V` failed universe unification (*Application type mismatch* at the `@hP` application, line 218).

Aligning the hypothesis binder with `existsBoundingConstant`'s `Type` binder closes the proof. After the fix the file elaborates with **0 errors** — only the 2 expected definitional sorries (`isPlanar`, `containsSubdivision`, both blocked on absent Mathlib planarity theory) remain, so the kernel accepts the proof.

## Build status — blocked by a v4.26 toolchain regression (not this proof)

A full `./proofs/scripts/docker-build.sh Proofs.Erdos1018Problem` fails at the **post-elaboration codegen phase** with SIGBUS (`exit 135`), reproducibly. This is **independent of the proof**:

- it reproduces on the last-merged VERIFIED commit `5edef2f92c5` (#34643), where `sparse_hides_nonplanarity` is still a `sorry`;
- it triggers whenever the file is error-free and reaches codegen (the committed universe-error version stops at elaboration, code 1, and never reaches codegen);
- it is not cleared by retry, and persists with `noncomputable` on the computable defs and with `compiler.enableNew false`.

Elaboration is clean; the build blocker is environmental/toolchain. Left as **draft** so the deployer skips it until the codegen regression is resolved by infra/mechanic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)