### PR TITLE
audit(puiseux-theorem): correct assumptions prose — 4 String-stub theorems remain

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24011,10 +24011,11 @@
       "issues": []
     },
     "puiseux-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:21Z",
-      "result": "clean"
+      "agentId": "lean-auditor",
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T05:12:03Z",
+      "result": "issues-fixed",
+      "issues": []
     },
     "puiseux-theorem-oq-01": {
       "auditCount": 1,
@@ -29544,5 +29545,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T04:59:24Z"
+  "lastUpdated": "2026-07-08T05:12:03Z"
 }

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -48,14 +48,14 @@
       "Binomial base case of algebraic closure proved (puiseux_binomial_root): over any algebraically closed K, every binomial Yⁿ = c·xᵐ has an honest Puiseux root c^(1/n)·x^(m/n)",
       "Genuine ramification witnessed (puiseux_binomial_ramification): the root of Yⁿ = c·x has orderTop exactly 1/n, so for n≥2 it lies strictly outside the Laurent field",
       "isPuiseux_single helper: every single-term Hahn series is a Puiseux series",
-      "Galois group Gal(Puiseux/Laurent) ≅ Ẑ described structurally",
-      "Characteristic zero requirement demonstrated via Artin-Schreier counterexample",
+      "Galois group Gal(Puiseux/Laurent) ≅ Ẑ noted as an informal String descriptor (galois_group_is_profinite_integers), not formalized",
+      "Characteristic-zero requirement noted as an informal String descriptor (char_zero_required, Artin-Schreier obstruction), not formalized",
       "Binomial root lifted to an honest Polynomial.IsRoot (puiseux_binomial_isRoot): the Puiseux series c^(1/n)·x^(m/n) is a genuine root of the polynomial Xⁿ - C(single m c) over the Hahn/Puiseux field, the polynomial-level form of a single Newton-polygon edge"
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
     "lineCount": 640,
-    "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The file no longer contains any vacuous True-stub theorems: the last two placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
+    "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The two headline placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). Four narrative theorems remain as String-literal descriptors carrying no formal content (curve_branches_are_puiseux, newton_polygon_tropicalization, galois_group_is_profinite_integers, char_zero_required); each merely asserts ∃ desc : String, desc = \"…\" and marks an informal application/connection rather than a machine-checked result. This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
     "definitionCount": 2


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `puiseux-theorem`
**Severity**: LOW–MEDIUM (prose accuracy; badge/status already conservative)

### Problem

The `assumptions` field asserted:
> "The file no longer contains any vacuous True-stub theorems"

This is **false**. `proofs/Proofs/PuiseuxTheorem.lean` still contains four vacuous String-existence placeholders, each proved by `⟨_, rfl⟩`:

- `curve_branches_are_puiseux` (L421)
- `newton_polygon_tropicalization` (L447)
- `galois_group_is_profinite_integers` (L477)
- `char_zero_required` (L611)

Each merely asserts `∃ desc : String, desc = "…"` — the same vacuous pattern as a `: True` stub, just dressed with a mathematical description string. Two `originalContributions` entries ("Galois group ≅ Ẑ described structurally", "char-0 requirement demonstrated via Artin-Schreier counterexample") pointed at these String stubs, implying formalized content that does not exist.

### What is genuine

The file **does** contain real, fully-computed Hahn-series theorems: `puiseux_binomial_root`, `puiseux_binomial_ramification`, `puiseux_binomial_orderTop`, `puiseux_binomial_isRoot`, `square_root_puiseux`, `cusp_parameterization`, etc. The `wip`/`axiomatized` badge/status are correct — no headline overclaim.

### Fix (meta.json prose only)

- `assumptions`: removed the false "no vacuous stubs" claim; now discloses the four String-literal descriptor theorems and clarifies they carry no formal content.
- `originalContributions`: reworded the Galois-group and char-0 entries to "noted as an informal String descriptor … not formalized".

No Lean source changes; no change to sorries (0), axioms (0), badge (`wip`), or status (`axiomatized`).

---
Discovered during gallery integrity audit.