### PR TITLE
Enrich: Boole transform preserves the sharp alternating-series remainder bound

### DIFF
--- a/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02-oq-02/annotations.json
@@ -47,17 +47,40 @@
     ]
   },
   {
-    "id": "ann-sharp-bound",
+    "id": "ann-boole-limit",
     "proofId": "alternating-series-boole-summation-oq-01-oq-02-oq-02",
     "range": {
       "startLine": 90,
+      "endLine": 111
+    },
+    "type": "theorem",
+    "title": "The Boole series converges to a₀ − 2S",
+    "content": "fdiff_tendsto identifies the limit of the forward-difference (Boole) series: altSum (Δa) 0 m → a_0 − 2S, obtained by specializing the grandparent's fdiff_altSum_tendsto to n = 0 (where (-1)^0 a_0 = a_0). Establishing this limit FIRST is what makes the next theorem's bound a statement about a genuine remainder rather than about an arbitrary target: the quantity (a_0 − 2S) − altSum (Δa) 0 m is the true truncation error of a convergent series. The hypothesis is only a → 0 (plus the original limit S); antitonicity is not yet needed here — it enters with the sharp bound.",
+    "mathContext": "$\\mathrm{altSum}\\,(\\Delta a)\\,0\\,m \\to a_0 - 2S = T$, the Boole value (grandparent's limit at $n=0$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Boole value T = a₀ − 2S",
+      "fdiff_altSum_tendsto at n = 0",
+      "limit of forward-difference series",
+      "genuine remainder vs arbitrary target"
+    ],
+    "prerequisites": [
+      "fdiff_altSum_tendsto (grandparent)",
+      "convergence of the original alternating series to S"
+    ]
+  },
+  {
+    "id": "ann-sharp-bound",
+    "proofId": "alternating-series-boole-summation-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 112,
       "endLine": 140
     },
     "type": "theorem",
-    "title": "The Boole limit and the sharp remainder bound",
-    "content": "fdiff_tendsto identifies a_0 − 2S as the true limit of the Boole series (fdiff_altSum_tendsto at n = 0), so the quantity bounded is a genuine remainder. fdiff_remainder_bound is the headline result: rewriting by the exact remainder identity and casing on the parity of m, the parent's brackets even_partial_le / le_odd_partial pin r_m to [0, a_m] for even m and [−a_m, 0] for odd m. The identity then reads a_m − 2 r_m (even) or −a_m − 2 r_m (odd), both of absolute value ≤ a_m by abs_le and linarith. The sign correlation between (-1)^m a_m and r_m is exactly what makes the two terms partially cancel, sharpening the naive 3 a_m to a_m; nonnegativity a_m ≥ 0 is derived from the bracket, not assumed, so only antitonicity and convergence are needed.",
+    "title": "The sharp remainder bound |T − altSum (Δa) 0 m| ≤ aₘ",
+    "content": "fdiff_remainder_bound is the headline result: rewriting by the exact remainder identity and casing on the parity of m, the parent's brackets even_partial_le / le_odd_partial pin r_m to [0, a_m] for even m and [−a_m, 0] for odd m. The identity then reads a_m − 2 r_m (even) or −a_m − 2 r_m (odd), both of absolute value ≤ a_m by abs_le and linarith. The sign correlation between (-1)^m a_m and r_m is exactly what makes the two terms partially cancel, sharpening the naive 3 a_m to a_m; nonnegativity a_m ≥ 0 is derived from the bracket, not assumed, so only antitonicity and convergence are needed.",
     "mathContext": "$|(a_0 - 2S) - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m| \\le a_m$, matching the original series' sharp bound.",
-    "significance": "essential",
+    "significance": "key",
     "relatedConcepts": [
       "sharp remainder / first-omitted-term bound",
       "even/odd bracketing",
@@ -66,7 +89,7 @@
     ],
     "prerequisites": [
       "even_partial_le and le_odd_partial (parent brackets)",
-      "fdiff_altSum_tendsto (Boole limit, grandparent)",
+      "the exact remainder identity fdiff_remainder_eq",
       "abs_le, parity case split, linarith"
     ]
   },

--- a/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01-oq-02-oq-02/meta.json
@@ -101,12 +101,20 @@
       "summary": "fdiff_altSum_eq solves the grandparent's boole_first (at n = 0) for the forward-difference partial sum via a single linear_combination — an exact identity holding for every m with no convergence assumed. fdiff_remainder_eq subtracts it from the limit value a_0 − 2S (ring), producing the exact remainder identity that ties the Boole-series remainder to the original-series remainder r_m = S − altSum a 0 m. These two algebraic identities carry all the quantitative content; only the sign of r_m remains to be supplied."
     },
     {
-      "id": "boole-limit-and-sharp-bound",
-      "title": "The Boole Limit and the Sharp Remainder Bound",
+      "id": "boole-limit",
+      "title": "The Boole Series Converges to a₀ − 2S",
       "startLine": 90,
+      "endLine": 111,
+      "mathContext": "$\\mathrm{altSum}\\,(\\Delta a)\\,0\\,m \\to a_0 - 2S = T$ (grandparent's fdiff_altSum_tendsto at $n = 0$).",
+      "summary": "fdiff_tendsto identifies a_0 − 2S as the true limit of the forward-difference (Boole) series, specializing the grandparent's fdiff_altSum_tendsto to n = 0. Establishing this limit first is what makes the next theorem's estimate a bound on a genuine remainder rather than an arbitrary target; only a → 0 (and the original limit S) is needed here."
+    },
+    {
+      "id": "sharp-bound",
+      "title": "The Sharp Remainder Bound",
+      "startLine": 112,
       "endLine": 140,
-      "mathContext": "$\\mathrm{altSum}\\,(\\Delta a)\\,0\\,m \\to a_0 - 2S$; $\\;|(a_0 - 2S) - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m| \\le a_m$.",
-      "summary": "fdiff_tendsto identifies a_0 − 2S as the true limit of the Boole series (fdiff_altSum_tendsto at n = 0), so the quantity bounded below is a genuine remainder. fdiff_remainder_bound is the headline: rewriting by the exact remainder identity and casing on the parity of m, the parent's brackets even_partial_le / le_odd_partial pin r_m to [0, a_m] (even) or [−a_m, 0] (odd); the identity then reads a_m − 2 r_m resp. −a_m − 2 r_m, both of absolute value ≤ a_m by abs_le and linarith. a_m ≥ 0 is derived from the bracket, so only Antitone a and convergence are needed."
+      "mathContext": "$|(a_0 - 2S) - \\mathrm{altSum}\\,(\\Delta a)\\,0\\,m| \\le a_m$, matching the original series' sharp bound.",
+      "summary": "fdiff_remainder_bound is the headline: rewriting by the exact remainder identity and casing on the parity of m, the parent's brackets even_partial_le / le_odd_partial pin r_m to [0, a_m] (even) or [−a_m, 0] (odd); the identity then reads a_m − 2 r_m resp. −a_m − 2 r_m, both of absolute value ≤ a_m by abs_le and linarith. a_m ≥ 0 is derived from the bracket, so only Antitone a and convergence are needed."
     },
     {
       "id": "rate-and-packaging",
@@ -126,8 +134,20 @@
     ]
   },
   "crossReferences": [
-    "alternating-series-boole-summation-oq-01-oq-02",
-    "alternating-series-boole-summation-oq-01",
-    "alternating-series-boole-summation"
+    {
+      "targetId": "alternating-series-boole-summation-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Direct parent: proves the sharp remainder bound |S − altSum a 0 m| ≤ a_m for the ORIGINAL alternating series via the even/odd bracketing (even_partial_le / le_odd_partial), and closes by asking for the acceleration rate of the Boole series. This entry answers that question, transporting the same sharp a_m bound across the first-order Boole transform."
+    },
+    {
+      "targetId": "alternating-series-boole-summation-oq-01",
+      "relationship": "related",
+      "description": "Grandparent: passes the finite Boole identity to the limit, proving the forward-difference series converges to T = (-1)^n a_n − 2S (fdiff_altSum_tendsto) and, for antitone null sequences, that the original series converges (altSum_tendsto_of_antitone). This entry reuses fdiff_altSum_tendsto (at n = 0) and altSum_tendsto_of_antitone to make the grandparent's qualitative convergence quantitative."
+    },
+    {
+      "targetId": "alternating-series-boole-summation",
+      "relationship": "related",
+      "description": "Base entry of the family: establishes the first-order finite Boole summation identity ∑ (-1)^j a_j = ½((-1)^n a_n − (-1)^m a_m) − ½ ∑ (-1)^j Δa_j (boole_first), the algebraic seed that every later entry — including this one's exact remainder identity — is derived from."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `alternating-series-boole-summation-oq-01-oq-02-oq-02` (quality 93, pass 0).

## Changes
- **Annotations 4 → 5**: split the bundled 90–140 annotation into two, one theorem each — *The Boole series converges to a₀ − 2S* (`fdiff_tendsto`, 90–111) and *The sharp remainder bound |T − altSum (Δa) 0 m| ≤ aₘ* (`fdiff_remainder_bound`, 112–140). The new limit annotation makes explicit why establishing the limit first is what turns the subsequent estimate into a statement about a *genuine* remainder.
- Split the matching meta.json `sections` entry likewise (`boole-limit` + `sharp-bound`).
- **crossReferences upgraded** from bare-string form (`["slug", ...]`) to the rich `{targetId, relationship, description}` objects used across the gallery. Each of the three family links (parent oq-01-oq-02 / grandparent oq-01 / base) now carries a labeled relationship and a descriptive blurb that renders in the overview, instead of an unlabeled `related` link with no context.

## Verification
- JSON validated; `pnpm annotations:build` reports no misalignment (all 5 ranges resolve to real Lean constructs in `AlternatingSeriesBooleSummationOQ01OQ02OQ02.lean`, 6 theorems).
- All three cross-ref target slugs confirmed present in the gallery (the normalizer drops any missing slug).
- meta.json 21.5 KB — well under the ~60 KB cap; all collections under caps.
- theorem/sorry/axiom counts unchanged and accurate (6 theorems, 0 sorries, 0 axioms).