### PR TITLE
Enrich: Coprime Companion Blocks are Nonderogatory — link the ancestor chain

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
@@ -99,6 +99,16 @@
       "targetId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02",
       "relationship": "extends",
       "description": "Parent: the single-block nonderogatory ⟺ cyclic ⟺ similar-to-companion equivalence. This entry uses that scaffold to handle the coprime two-block merge toward the multi-block rational canonical form."
+    },
+    {
+      "targetId": "cayley-hamilton-cyclic-vector-all-fields-oq-01",
+      "relationship": "related",
+      "description": "Grandparent — 'Cyclic Vector Theorem: Factorization Bridge via Multiset UFD': builds the factorization machinery over K[X] that the single-block cyclic criterion rests on. The lcm = product step here (lcm_eq_mul_of_isCoprime_monic) is the two-factor, coprime specialization of that same UFD arithmetic."
+    },
+    {
+      "targetId": "cayley-hamilton-cyclic-vector-all-fields",
+      "relationship": "related",
+      "description": "Base of the chain — 'Nonderogatory → Cyclic Vector: All Fields (Primary Decomposition)': establishes the nonderogatory ⇒ cyclic-vector direction over an arbitrary field via primary decomposition. The CRT collapse proved here is the coprime instance of that primary-decomposition picture, where two coprime primary parts merge into one cyclic block."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05` (quality 93, pass 0).

The entry was already at target depth (5 annotations, all with mathContext/significance/relatedConcepts; 4 sections covering the full 106-line file; deep overview and conclusion). The one genuine gap was navigation: `crossReferences` linked only the direct parent, though the prose repeatedly invokes the "parent chain" and grandparent.

## Changes
- **crossReferences 1 → 3**: added the grandparent `cayley-hamilton-cyclic-vector-all-fields-oq-01` ('Factorization Bridge via Multiset UFD' — the K[X] factorization machinery the `lcm = product` step specializes) and the base `cayley-hamilton-cyclic-vector-all-fields` ('Nonderogatory → Cyclic Vector: All Fields' — the primary-decomposition picture the CRT collapse is the coprime instance of). Each carries a labeled relationship and a description.

## Verification
- Both new target slugs confirmed present in the gallery (the normalizer drops any missing slug).
- JSON validated; `pnpm annotations:build` reports no misalignment.
- meta.json 10.5 KB — far under the ~60 KB cap; crossReferences (3) well under the 20 cap.
- No claims about the proof itself changed (3 theorems, 0 sorries, 0 axioms — untouched).