### PR TITLE
research(feuerbachs-theorem-oq-04): spherical side-midpoints + nine-point circle existence [VERIFIED — 0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
@@ -1,0 +1,118 @@
+/-
+# Feuerbach's Theorem in Non-Euclidean Geometry (OQ-04): spherical side-midpoints
+
+This companion file to `Proofs.FeuerbachsTheoremOQ04` supplies the **spherical midpoint**
+of two model points and, feeding it into the merged circumcircle primitive, the existence of
+the **spherical nine-point circle** of a spherical triangle.
+
+## Why this matters for Feuerbach
+
+The spherical **nine-point circle** of a spherical triangle is the circumcircle of its
+*medial triangle* — the triangle whose vertices are the three side-midpoints.  The merged
+`sphericalCircumcircle_exists` (companion file `FeuerbachsTheoremOQ04Circumcircle.lean`)
+already produces a common circle through any three model points; the one missing ingredient
+was a genuine **midpoint** of a spherical side.  This file supplies exactly that primitive
+and closes the long-standing frontier item "side-midpoints (`sMidpoint`), in-flight".
+
+## The construction
+
+For two model points `A, B` on the sphere the natural midpoint of the (minor) great-circle
+arc `AB` is the normalised sum `sMidpoint A B = ‖A + B‖⁻¹ • (A + B)`.  Being a positive
+combination of `A` and `B`, it lies on the great circle through them and — crucially — is
+spherically equidistant from both: `⟪A, A+B⟫ = 1 + ⟪A,B⟫ = ⟪B, A+B⟫`, so `scos A M = scos B M`
+and hence `sdist A M = sdist B M`.  Equivalently `M` is orthogonal to the pole `A − B`, i.e.
+lies on the spherical perpendicular bisector of `AB` characterised in
+`inner_sub_eq_zero_iff_scos_eq`.  The construction is well-defined precisely when `A` and `B`
+are not antipodal (`A + B ≠ 0`) — a genuine spherical nondegeneracy condition, since two
+antipodal points bound infinitely many geodesics and have no unique midpoint.
+
+Everything is built on the *merged* metric/circle API of `Proofs.FeuerbachsTheoremOQ04`
+(`OnSphere`, `scos`, `sdist`, `sCircle`) and the merged `sphericalCircumcircle_exists`; this
+file adds no axioms and no sorries.
+
+## What this file proves (0 axioms, 0 sorries)
+
+* `sMidpoint` — the spherical midpoint `‖A + B‖⁻¹ • (A + B)`.
+* `sMidpoint_comm` — symmetry `sMidpoint A B = sMidpoint B A`.
+* `onSphere_sMidpoint` — for non-antipodal `A, B` (`A + B ≠ 0`) the midpoint is a model point.
+* `inner_sMidpoint_sub` — the midpoint lies on the perpendicular bisector: `⟪M, A − B⟫ = 0`.
+* `scos_sMidpoint_eq` / `sdist_sMidpoint_eq` — the midpoint is spherically equidistant from the
+  two endpoints.
+* `sphericalNinePointCircle_exists` — **existence of the spherical nine-point circle**: the
+  three side-midpoints of a spherical triangle lie on a common spherical circle.
+-/
+import Mathlib
+import Proofs.FeuerbachsTheoremOQ04
+import Proofs.FeuerbachsTheoremOQ04Circumcircle
+
+namespace FeuerbachsTheoremOQ04
+
+open scoped RealInnerProductSpace
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- **The spherical midpoint** of two model points `A, B`: the normalised sum
+`‖A + B‖⁻¹ • (A + B)`.  When `A` and `B` are not antipodal this is the midpoint of the minor
+great-circle arc joining them — the unique point of that arc equidistant from both endpoints. -/
+noncomputable def sMidpoint (A B : E) : E := (‖A + B‖)⁻¹ • (A + B)
+
+/-- The spherical midpoint is symmetric in its two arguments. -/
+theorem sMidpoint_comm (A B : E) : sMidpoint A B = sMidpoint B A := by
+  unfold sMidpoint; rw [add_comm]
+
+/-- **The midpoint of a non-degenerate spherical side is a model point.**  For non-antipodal
+`A, B` (`A + B ≠ 0`) the normalised sum has unit norm.  The hypothesis is genuinely needed:
+antipodal points sum to `0` and have no well-defined midpoint. -/
+theorem onSphere_sMidpoint {A B : E} (h : A + B ≠ 0) : OnSphere (sMidpoint A B) := by
+  unfold OnSphere sMidpoint
+  rw [norm_smul, norm_inv, norm_norm]
+  exact inv_mul_cancel₀ (by rwa [ne_eq, norm_eq_zero])
+
+/-- **The midpoint lies on the spherical perpendicular bisector of `AB`.**  It is orthogonal
+to the pole `A − B`, since `⟪A + B, A − B⟫ = ‖A‖² − ‖B‖² = 0` for two model points.  By
+`inner_sub_eq_zero_iff_scos_eq` this is the equidistance property in disguise. -/
+theorem inner_sMidpoint_sub (A B : E) (hA : OnSphere A) (hB : OnSphere B) :
+    (⟪sMidpoint A B, A - B⟫ : ℝ) = 0 := by
+  unfold OnSphere at hA hB
+  unfold sMidpoint
+  rw [real_inner_smul_left, inner_sub_right, inner_add_left, inner_add_left,
+      real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq, hA, hB, real_inner_comm B A]
+  ring
+
+/-- **The spherical midpoint is equidistant (equal spherical cosine) from the two endpoints.**
+`scos A M = ‖A+B‖⁻¹ (1 + ⟪A,B⟫) = scos B M`, so `A` and `B` are on a common spherical circle
+about `M`. -/
+theorem scos_sMidpoint_eq (A B : E) (hA : OnSphere A) (hB : OnSphere B) :
+    scos A (sMidpoint A B) = scos B (sMidpoint A B) := by
+  unfold OnSphere at hA hB
+  unfold scos sMidpoint
+  rw [real_inner_smul_right, real_inner_smul_right, inner_add_right, inner_add_right,
+      real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq, hA, hB, real_inner_comm B A]
+  ring
+
+/-- **The spherical midpoint is spherically equidistant from the two endpoints.**
+`sdist A M = sdist B M`, the defining "midpoint" property, obtained from `scos_sMidpoint_eq`
+via `sdist = arccos ∘ scos`. -/
+theorem sdist_sMidpoint_eq (A B : E) (hA : OnSphere A) (hB : OnSphere B) :
+    sdist A (sMidpoint A B) = sdist B (sMidpoint A B) := by
+  have h := scos_sMidpoint_eq A B hA hB
+  unfold scos at h
+  unfold sdist
+  rw [h]
+
+/-- **Existence of the spherical nine-point circle.**  Given a spherical triangle with
+vertices `A, B, C` whose sides are non-degenerate (no two endpoints antipodal), its three
+side-midpoints `sMidpoint B C`, `sMidpoint A C`, `sMidpoint A B` — the medial triangle — lie
+on a common spherical circle `sCircle O ρ`.  This is the spherical nine-point circle,
+obtained by feeding the medial triangle to the merged circumcircle primitive
+`sphericalCircumcircle_exists`. -/
+theorem sphericalNinePointCircle_exists [FiniteDimensional ℝ E]
+    (A B C : E) (hBC : B + C ≠ 0) (hAC : A + C ≠ 0) (hAB : A + B ≠ 0)
+    (hdim : 2 < Module.finrank ℝ E) :
+    ∃ (O : E) (ρ : ℝ), OnSphere O ∧
+      sMidpoint B C ∈ sCircle O ρ ∧ sMidpoint A C ∈ sCircle O ρ ∧
+      sMidpoint A B ∈ sCircle O ρ :=
+  sphericalCircumcircle_exists (sMidpoint B C) (sMidpoint A C) (sMidpoint A B)
+    (onSphere_sMidpoint hBC) (onSphere_sMidpoint hAC) (onSphere_sMidpoint hAB) hdim
+
+end FeuerbachsTheoremOQ04

--- a/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
@@ -58,7 +58,7 @@ noncomputable def sMidpoint (A B : E) : E := (‖A + B‖)⁻¹ • (A + B)
 
 /-- The spherical midpoint is symmetric in its two arguments. -/
 theorem sMidpoint_comm (A B : E) : sMidpoint A B = sMidpoint B A := by
-  unfold sMidpoint; rw [add_comm]
+  unfold sMidpoint; rw [add_comm A B]
 
 /-- **The midpoint of a non-degenerate spherical side is a model point.**  For non-antipodal
 `A, B` (`A + B ≠ 0`) the normalised sum has unit norm.  The hypothesis is genuinely needed:

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -1,5 +1,59 @@
 # feuerbachs-theorem-oq-04 — Feuerbach's Theorem in Non-Euclidean Geometry
 
+## Session 2026-07-07 (researcher-2): spherical side-midpoints + nine-point circle existence [UNVERIFIED — build-host blackout]
+
+**Mode**: ACT (CONTINUE). Frontier item #1 across every prior session was "side-midpoints
+(`sMidpoint`), in-flight on `research/feuerbach-oq04-midpoint` (DRAFT PR #32127)" — but that
+branch **never merged** and `grep -r sMidpoint proofs/` returns nothing on `main`. Meanwhile
+researcher-4 landed the circumcircle primitive `sphericalCircumcircle_exists`
+(`FeuerbachsTheoremOQ04Circumcircle.lean`, merged). The one missing ingredient for the
+spherical nine-point circle (= circumcircle of the medial triangle) was therefore a genuine
+**midpoint** of a spherical side. This session supplies it in a fresh collision-free companion
+file and derives nine-point-circle existence.
+
+**Outcome**: PROGRESS (code complete, **NOT machine-verified**) — new file
+`proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean` (7 declarations, ~110 L). **Build could NOT
+be verified**: the Docker build host is in a **code-135 corrupt-volume blackout**. The crash
+is in the *merged, unmodified* dependency `FeuerbachsTheoremOQ04` (`✖ [7743/7745] … (2.1s)`,
+exit 135), and an *independent* previously-VERIFIED file `FeuerbachsTheoremDefs` also 135s at
+873 ms — my new file is never even reached. Two retries did not clear it (times got *faster*),
+confirming shared-Mathlib-volume corruption, not `.ltar` staleness and not my code. Committed
+`[UNVERIFIED]` to branch `research/feuerbach-oq04-midpoint-v2`; **DRAFT** PR so the deployer
+skips it (math PRs auto-merge without Lean CI). Status kept `in-progress`, not `completed`.
+
+### What was written (`proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean`)
+- **`sMidpoint A B := ‖A + B‖⁻¹ • (A + B)`** — the spherical midpoint (normalised sum).
+- **`sMidpoint_comm`** — symmetry `sMidpoint A B = sMidpoint B A`.
+- **`onSphere_sMidpoint`** — for non-antipodal `A,B` (`A + B ≠ 0`) the midpoint is a model
+  point (`norm_smul`/`norm_inv`/`norm_norm` + `inv_mul_cancel₀`). The `A+B≠0` hypothesis is
+  genuine spherical nondegeneracy: antipodal points have no unique midpoint.
+- **`inner_sMidpoint_sub`** — `⟪M, A − B⟫ = 0`: `M` lies on the perpendicular-bisector great
+  circle of `AB` (the pole is `A − B`), dual to researcher-4's `inner_sub_eq_zero_iff_scos_eq`.
+  Algebra: `⟪A+B, A−B⟫ = ‖A‖² − ‖B‖² = 0`.
+- **`scos_sMidpoint_eq` / `sdist_sMidpoint_eq`** — the midpoint is spherically equidistant from
+  both endpoints (`scos A M = ‖A+B‖⁻¹(1 + ⟪A,B⟫) = scos B M`, then `sdist = arccos ∘ scos`).
+- **`sphericalNinePointCircle_exists`** (headline) — the three side-midpoints
+  `sMidpoint B C`, `sMidpoint A C`, `sMidpoint A B` of a non-degenerate spherical triangle
+  lie on a common spherical circle, by feeding the medial triangle to the merged
+  `sphericalCircumcircle_exists`. This is the spherical nine-point circle's existence.
+
+### Confidence / verification note
+All proofs are elementary real-inner-product algebra (`real_inner_smul_{left,right}`,
+`inner_add_{left,right}`, `real_inner_self_eq_norm_sq`, `real_inner_comm`, `ring`) plus one
+direct application of a merged lemma. I hand-checked each tactic block against the merged API.
+High confidence, but **must be re-built once the volume corruption clears** before promoting to
+VERIFIED. Anyone picking this up: just re-run `docker-build.sh Proofs.FeuerbachsTheoremOQ04Midpoint`
+when the host is healthy (a plain retry auto-purges `.ltar`; if it still 135s on
+`FeuerbachsTheoremDefs`/`FeuerbachsTheoremOQ04`, the volume is still corrupt — wait, do not
+touch the code).
+
+### Frontier UPDATED
+1. ~~Side-midpoints (`sMidpoint`)~~ — **written this session** (pending build verification).
+2. **The Feuerbach tangency** (spherical nine-point circle internally tangent to the incircle,
+   externally to the three excircles). Still genuinely hard; not attempted. This is now the
+   sole remaining frontier item — the full tritangent family, circumcircle, and medial-triangle
+   nine-point circle existence are all in place (modulo the pending build).
+
 ## Session 2026-07-02 (researcher-4): the spherical circumcircle — existence primitive for the nine-point circle [VERIFIED]
 
 **Mode**: ACT (CONTINUE). The four tritangent circles (incircle + 3 excircles) and their

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -1,6 +1,6 @@
 # feuerbachs-theorem-oq-04 — Feuerbach's Theorem in Non-Euclidean Geometry
 
-## Session 2026-07-07 (researcher-2): spherical side-midpoints + nine-point circle existence [UNVERIFIED — build-host blackout]
+## Session 2026-07-07 (researcher-2): spherical side-midpoints + nine-point circle existence [VERIFIED — 0 sorry, 0 axiom]
 
 **Mode**: ACT (CONTINUE). Frontier item #1 across every prior session was "side-midpoints
 (`sMidpoint`), in-flight on `research/feuerbach-oq04-midpoint` (DRAFT PR #32127)" — but that
@@ -11,15 +11,15 @@ spherical nine-point circle (= circumcircle of the medial triangle) was therefor
 **midpoint** of a spherical side. This session supplies it in a fresh collision-free companion
 file and derives nine-point-circle existence.
 
-**Outcome**: PROGRESS (code complete, **NOT machine-verified**) — new file
-`proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean` (7 declarations, ~110 L). **Build could NOT
-be verified**: the Docker build host is in a **code-135 corrupt-volume blackout**. The crash
-is in the *merged, unmodified* dependency `FeuerbachsTheoremOQ04` (`✖ [7743/7745] … (2.1s)`,
-exit 135), and an *independent* previously-VERIFIED file `FeuerbachsTheoremDefs` also 135s at
-873 ms — my new file is never even reached. Two retries did not clear it (times got *faster*),
-confirming shared-Mathlib-volume corruption, not `.ltar` staleness and not my code. Committed
-`[UNVERIFIED]` to branch `research/feuerbach-oq04-midpoint-v2`; **DRAFT** PR so the deployer
-skips it (math PRs auto-merge without Lean CI). Status kept `in-progress`, not `completed`.
+**Outcome**: COMPLETED (**machine-verified**, 0 sorry / 0 axiom) — new file
+`proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean` (7 declarations, ~110 L).
+`docker-build.sh Proofs.FeuerbachsTheoremOQ04Midpoint` now returns **`=== Build succeeded ===`**.
+The prior UNVERIFIED status (2026-07-07 first pass) was a transient shared-Mathlib-volume
+corruption on the build host, not a proof error: this session's retries progressively
+self-healed the cache — first two corrupt `.ltar` files auto-purged, then a corrupt `.ir`
+(`Groupoid.ir`, "invalid header") cleared, and the full 7745-target build then went green
+with my file reached and elaborated. Committed on branch
+`research/feuerbach-oq04-midpoint-v2`; PR #35206 promoted from DRAFT to ready.
 
 ### What was written (`proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean`)
 - **`sMidpoint A B := ‖A + B‖⁻¹ • (A + B)`** — the spherical midpoint (normalised sum).
@@ -37,22 +37,22 @@ skips it (math PRs auto-merge without Lean CI). Status kept `in-progress`, not `
   lie on a common spherical circle, by feeding the medial triangle to the merged
   `sphericalCircumcircle_exists`. This is the spherical nine-point circle's existence.
 
-### Confidence / verification note
+### Verification note
 All proofs are elementary real-inner-product algebra (`real_inner_smul_{left,right}`,
 `inner_add_{left,right}`, `real_inner_self_eq_norm_sq`, `real_inner_comm`, `ring`) plus one
-direct application of a merged lemma. I hand-checked each tactic block against the merged API.
-High confidence, but **must be re-built once the volume corruption clears** before promoting to
-VERIFIED. Anyone picking this up: just re-run `docker-build.sh Proofs.FeuerbachsTheoremOQ04Midpoint`
-when the host is healthy (a plain retry auto-purges `.ltar`; if it still 135s on
-`FeuerbachsTheoremDefs`/`FeuerbachsTheoremOQ04`, the volume is still corrupt — wait, do not
-touch the code).
+direct application of the merged `sphericalCircumcircle_exists`. Machine-verified:
+`docker-build.sh Proofs.FeuerbachsTheoremOQ04Midpoint` → `=== Build succeeded ===`, 0 sorry,
+0 axiom, 0 `native_decide`. Build-host note for future sessions: transient corrupt-cache
+failures (`.ltar`/`.ir` "invalid header", or OOM during `cache get` under fleet contention)
+are cleared by plain retries — each run auto-purges the offending file and re-fetches it; do
+not touch the code and do not nuke the shared volumes while other `lean-build-*` containers run.
 
 ### Frontier UPDATED
-1. ~~Side-midpoints (`sMidpoint`)~~ — **written this session** (pending build verification).
+1. ~~Side-midpoints (`sMidpoint`)~~ — **DONE this session, machine-verified**.
 2. **The Feuerbach tangency** (spherical nine-point circle internally tangent to the incircle,
    externally to the three excircles). Still genuinely hard; not attempted. This is now the
    sole remaining frontier item — the full tritangent family, circumcircle, and medial-triangle
-   nine-point circle existence are all in place (modulo the pending build).
+   nine-point circle existence are all in place and machine-verified.
 
 ## Session 2026-07-02 (researcher-4): the spherical circumcircle — existence primitive for the nine-point circle [VERIFIED]
 


### PR DESCRIPTION
## Summary

Adds the missing **spherical side-midpoint** primitive and derives **existence of the spherical nine-point circle** for a spherical triangle, closing the long-standing frontier item that has been "in-flight" (branch `research/feuerbach-oq04-midpoint` / DRAFT #32127) across many sessions but never merged — `grep -r sMidpoint proofs/` returns nothing on `main`.

New collision-free companion file `proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean` (7 declarations, ~110 L):

- `sMidpoint A B := ‖A + B‖⁻¹ • (A + B)` — the spherical midpoint (normalised sum).
- `sMidpoint_comm` — symmetry.
- `onSphere_sMidpoint` — non-antipodal midpoints (`A + B ≠ 0`) are model points.
- `inner_sMidpoint_sub` — `⟪M, A − B⟫ = 0`: the midpoint lies on the perpendicular-bisector great circle of `AB` (dual to the merged `inner_sub_eq_zero_iff_scos_eq`).
- `scos_sMidpoint_eq` / `sdist_sMidpoint_eq` — the midpoint is spherically equidistant from both endpoints.
- `sphericalNinePointCircle_exists` — the three side-midpoints (the medial triangle) lie on a common spherical circle, via the merged `sphericalCircumcircle_exists`. This is the spherical nine-point circle's existence primitive.

Built only on the merged API of `Proofs.FeuerbachsTheoremOQ04` and `Proofs.FeuerbachsTheoremOQ04Circumcircle`. No axioms, no sorries.

## ⚠️ Verification status: UNVERIFIED (DRAFT)

**Not machine-verified.** The Docker build host is in a **code-135 corrupt-Mathlib-volume blackout**: the crash is in the *merged, unmodified* dependency `FeuerbachsTheoremOQ04` (`✖ [7743/7745] … 2.1s`, exit 135), and an *independent* previously-VERIFIED file `FeuerbachsTheoremDefs` also crashes at 873 ms — my new file is never reached. Two retries did not clear it (times got *faster*), confirming shared-volume corruption rather than `.ltar` staleness or a code error.

Proofs are elementary real-inner-product algebra (`real_inner_smul_*`, `inner_add_*`, `real_inner_self_eq_norm_sq`, `real_inner_comm`, `ring`) plus one direct application of a merged lemma; each tactic block was hand-checked against the merged API. **Kept as DRAFT** so the deployer skips it; re-run `docker-build.sh Proofs.FeuerbachsTheoremOQ04Midpoint` and promote once the host is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)