### PR TITLE
research(erdos-1138-oq-03-oq-01): sync stale state.md to COMPLETED

### DIFF
--- a/research/problems/erdos-1138-oq-03-oq-01/state.md
+++ b/research/problems/erdos-1138-oq-03-oq-01/state.md
@@ -1,10 +1,15 @@
 # Research State: erdos-1138-oq-03-oq-01
 
 ## Current State
-**Phase**: SURVEYED
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-07-02
-**Iteration**: 1
+**Since**: 2026-07-05
+**Iteration**: 2
+
+## Completion
+VERIFIED and merged in PR #35062: `proofs/Proofs/Erdos1138OQ03OQ01.lean`, 0 sorries,
+0 local axioms, 3 theorems, 1 inherited axiom (`Erdos1138OQ03.baker_harman_pintz`).
+The build-blocked survey note below is superseded. Do not re-serve.
 
 ## Current Focus
 Scoped a tractable oq-01 for the fresh (previously EMPTY, no problem.md) candidate:


### PR DESCRIPTION
## Summary
`erdos-1138-oq-03-oq-01` was re-served by `claim-random` despite being **already completed and merged** in #35062. Root cause: its `state.md` still read `Phase: SURVEYED` with a build-blocked note from the pre-build survey session.

## Verification
- `proofs/Proofs/Erdos1138OQ03OQ01.lean`: **0 sorries, 0 local axioms, 3 theorems**
- 1 inherited axiom (`Erdos1138OQ03.baker_harman_pintz`) — status `axiomatized`, matching meta.json
- No proof content changed; this only marks `state.md` COMPLETED to stop phantom re-serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)