### PR TITLE
audit: re-audit 22 recently-merged gallery entries — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -660,15 +660,15 @@
       "issues": []
     },
     "amgm-inequality-oq-02-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-04T12:54:27Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
     "amgm-inequality-oq-02-oq-03": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-06-27T05:01:53Z",
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03-oq-03": {
@@ -1376,8 +1376,8 @@
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-28T18:46:29Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -4735,12 +4735,12 @@
       "auditor": "auditor-agent",
       "completedAt": "2026-06-14T10:36:07Z",
       "notes": "Re-audit 2026-06-14: stale issues-found flag cleared. The 3 sorries from the former Tier C scaffold (status formalized) were eliminated; main file now delegates all 3 theorems (lp_truncation_tendsto_zero, localization_existence, riesz_lp_surjective_sigma_finite) via exact-calls to the sorry-free RieszSigmaFiniteComplete namespace in the Incomplete01 companion. Confirmed 0 actual sorry tactics and 0 axioms in BOTH files (the 11/1 grep hits are docstring text). meta.json verified/original/0-sorries/0-axioms is accurate; lineCount 208 and theoremCount 5 match source. Genuine independent proof (built from project parent finite-measure Riesz + localization), not a Mathlib wrapper. Minor non-blocking: main-file docstring still describes outdated 3-sorry design (cosmetic, non-public); companion (~950 LOC where the proof lives) not listed in additionalFiles.",
-      "auditCount": 3,
-      "lastAudited": "2026-06-14T10:36:07Z"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T05:29:02Z"
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-06-18T12:40:46Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -6697,8 +6697,8 @@
       "result": "clean"
     },
     "cramers-rule-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-28T17:38:16Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -8199,9 +8199,9 @@
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:33Z",
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01": {
@@ -8496,9 +8496,9 @@
       ]
     },
     "erdos-1003-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-28T18:46:29Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:29:02Z",
+      "result": "clean",
       "issues": [
         "Orphan-from-Proofs.lean finding (2026-06-28) obsolete: PR #31501 (f4b5b2e3b26) migrated proofs/ to Lake glob discovery (lakefile.toml globs=[\"Proofs\",\"Proofs.*\"]); module is in the aggregate build. Per-file integrity clean: 0 sorry, 0 axiom, counts match meta.json."
       ]
@@ -8528,8 +8528,8 @@
       "result": "clean"
     },
     "erdos-1005-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T20:00:17Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -8860,9 +8860,9 @@
       "result": "clean"
     },
     "erdos-1017-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean"
     },
     "erdos-1017-oq-03-oq-01": {
@@ -8946,8 +8946,8 @@
       "result": "clean"
     },
     "erdos-1020-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-27T23:10:02Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -8988,9 +8988,9 @@
       "result": "clean"
     },
     "erdos-1022-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean"
     },
     "erdos-1022-oq-04": {
@@ -13571,9 +13571,9 @@
     },
     "erdos-437": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-05T06:04:15Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T05:29:02Z",
+      "result": "clean",
       "issues": []
     },
     "erdos-438": {
@@ -14003,9 +14003,9 @@
     },
     "erdos-490": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 7,
-      "lastAudited": "2026-06-25T18:57:21Z",
-      "result": "issues-fixed",
+      "auditCount": 8,
+      "lastAudited": "2026-07-08T05:29:02Z",
+      "result": "clean",
       "issues": [
         "phantom sidon_bound axiom + van_doorn_observation + their-equivalence narrative; section line drift (issue #14335)"
       ]
@@ -14641,8 +14641,8 @@
       "result": "clean"
     },
     "erdos-57-oq-04": {
-      "auditCount": 7,
-      "lastAudited": "2026-06-28T17:38:16Z",
+      "auditCount": 8,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -16018,9 +16018,9 @@
     },
     "erdos-744": {
       "agentId": "auditor-agent-20260621",
-      "auditCount": 5,
-      "lastAudited": "2026-06-21T12:09:59Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T05:29:02Z",
+      "result": "clean"
     },
     "erdos-745": {
       "agentId": "auditor-cycle-20-batch",
@@ -16211,8 +16211,8 @@
     },
     "erdos-771": {
       "agentId": "auditor-agent",
-      "auditCount": 4,
-      "lastAudited": "2026-05-17T00:50:00Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean"
     },
     "erdos-771-construction": {
@@ -21123,8 +21123,8 @@
       "issues": []
     },
     "inverse-galois-d4-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T22:20:48Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -21135,8 +21135,8 @@
       "issues": []
     },
     "inverse-galois-d4-oq-02-oq-03-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-28T00:28:12Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -23583,8 +23583,8 @@
       "issues": []
     },
     "picks-theorem-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-28T18:46:29Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": [],
       "note": "Mechanic re-verification 2026-07-01: prior 'issues-found' flag carried an empty issues array (no defect recorded). meta.json matches source exactly (lineCount 308, theoremCount 14 counting the @[simp] lemma cross_self, 0 sorries, 0 axioms, no native_decide/structures, no True-stubs); status verified/badge original justified for the shoelace/fan-triangulation development. Reconciled to clean."
@@ -23887,8 +23887,8 @@
       "result": "clean"
     },
     "property-b-first-moment-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-28T17:38:15Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -26378,8 +26378,8 @@
       "issues": []
     },
     "van-der-waerden-first-moment-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-27T23:04:23Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T05:29:02Z",
       "result": "clean",
       "issues": []
     },
@@ -29545,5 +29545,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T05:12:03Z"
+  "lastUpdated": "2026-07-08T05:29:02Z"
 }


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Re-audited **22 gallery entries** whose `meta.json` changed *after* their last recorded audit (enrichment/research merges since the last full backlog sweep). Ran mechanical integrity checks comparing `meta.status` / `badge` / `sorries` / `axiomCount` against the actual Lean source (`sorry` counts, `axiom` declarations, `True` stubs).

## Result: all clean, no overclaims

| Check | Outcome |
|-------|---------|
| Sorry count vs source | ✅ all match declared convention |
| `verified` status with hidden sorry/stub | ✅ none |
| True-stub theorems claimed verified | ✅ none |
| Axiom count vs `axiom` decls + structure fields | ✅ consistent |

### One flag investigated → clean
- **erdos-771**: main file `Erdos771Problem.lean` was repaired 7→3 sorries in #35161; `meta.sorries=3` and `leanFile.sorries=3` correctly track the **main** file. Companion `*Aristotle.lean` proof-search scaffolds carry their own sorries (standard, not counted). `status=axiomatized` / `badge=axiom` is honest — no overclaim.

This PR only bumps `auditCount` / `lastAudited` / `result` in `audit-tracker.json` for the re-audited slugs so they aren't perpetually re-served as stale. No gallery-facing content changes.

---
Discovered during gallery integrity audit.