### PR TITLE
Enrich Coprime Companion Blocks Nonderogatory: Bézout-vs-gcd insight

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
@@ -47,7 +47,8 @@
       "In general lcm p q strictly divides p·q, so a block sum of companion matrices is derogatory (minpoly ≠ charpoly); coprimality is exactly what removes the gap and makes the block sum cyclic.",
       "The equality minpoly = charpoly = p·q is the matrix-level statement of K[X]/(p·q) ≅ K[X]/(p) × K[X]/(q): two coprime cyclic modules merge into one cyclic module.",
       "The whole argument reduces to a clean GCD-monoid fact about monic polynomials — lcm = product for coprimes — showing how much of rational canonical form theory is arithmetic in K[X].",
-      "The GCDMonoid structure on F[X] requires a DecidableEq F instance; supplying it is the only fix needed to machine-check the coprime merge."
+      "The GCDMonoid structure on F[X] requires a DecidableEq F instance; supplying it is the only fix needed to machine-check the coprime merge.",
+      "Coprimality is stated as IsCoprime p q — the Bézout condition ∃ a, b, a·p + b·q = 1 — not as gcd(p,q) = 1. This is deliberate: the key step p·q ∣ lcm p q is IsCoprime.mul_dvd, whose proof multiplies the Bézout identity by lcm p q. Over the PID F[X] the two formulations are equivalent, but the Bézout form is what actually powers the divisibility, making the argument portable to any Bézout domain, not just fields."
     ],
     "prerequisites": [
       "Companion matrices and the rational canonical form",


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05` (quality 93, pass 0).

This entry was already comprehensive (10.5 KB meta, all fields under caps; 5 annotations, 4 sections, ancestor cross-reference chain). `keyInsights` sat at the floor (4), and none explained why the coprimality hypothesis is stated as `IsCoprime` rather than `gcd = 1`.

**Change (meta.json only):**
- Added a 5th `keyInsight` (4→5): coprimality is stated as `IsCoprime p q` — the Bézout condition ∃ a,b, a·p + b·q = 1 — because `IsCoprime.mul_dvd` (which multiplies the Bézout identity by `lcm p q`) is the exact step proving `p·q ∣ lcm p q`. Over the PID F[X] this is equivalent to gcd = 1, but the Bézout form powers the divisibility and makes the merge portable to any Bézout domain.
- Non-redundant with existing insights; meta 10.9 KB, under all caps.

Gallery build validates the entry cleanly.