### PR TITLE
Research: pythagorean-theorem-oq-01 — reduce PythagoreanTriplesOQ01 axioms 6→3 (remove 3 unused, incl. a false one)

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ01.lean
@@ -2121,13 +2121,31 @@ theorem r2_pos_iff (n : ℕ) (_hn : 0 < n) :
     have hp : q.Prime := Nat.prime_of_mem_primeFactors hq
     rw [← Nat.factorization_def n hp]; exact H q hp hq4
 
-/-- The average order of r₂: (1/N) Σ_{n≤N} r₂(n) → π.
-    This is equivalent to the Gauss circle problem: the number of
-    lattice points in the disk x²+y² ≤ N is πN + O(N^{1/2+ε}). -/
-axiom r2_average_order :
-    Tendsto (fun N : ℕ =>
-      (∑ n ∈ Finset.range (N + 1), (r2 n : ℝ)) / (N : ℝ))
-      atTop (𝓝 π)
+/-
+  **Average order of r₂ (documented target, formerly an axiom — removed).**
+
+  The `r2 n` defined above counts *nonnegative ordered* pairs `(a, b)` with
+  `a, b ≥ 0` and `a² + b² = n` (see the `r2_pos_iff` docstring, which calls it
+  the "nonnegative-pair" count). Hence
+
+      Σ_{n ≤ N} r2 n = #{ (a, b) ∈ ℕ² : a² + b² ≤ N },
+
+  the number of lattice points in the **closed first-quadrant quarter disk** of
+  radius √N. By the Gauss circle problem this is `(π/4)·N + O(√N)`, so the true
+  average order is
+
+      (1/N) Σ_{n ≤ N} r2 n  →  π/4      (NOT π).
+
+  The previous `axiom r2_average_order` asserted the limit was `π`, conflating
+  this nonnegative-pair count with the *full-plane signed* representation count
+  `r₂(n) = 4(d₁(n) − d₃(n))` (whose sum over the full disk is `π·N`). As stated
+  it was FALSE for this definition — a latent unsoundness (combined with a proof
+  of the π/4 limit it yields `π = π/4`). It was also unused: nothing in this
+  file consumed it. It is removed here rather than corrected-and-kept, because
+  the corrected π/4 statement is a genuine Gauss-circle result not yet available
+  in Mathlib (v4.26) and proving it needs lattice-point-counting infrastructure
+  that does not yet exist. Documented here as a target for future work.
+-/
 
 /-- The algebraic identity connecting the three factors to the density constant.
     (π/8) × (6/π²) × (2/3) = 1/(2π). The 1/8 comes from restricting
@@ -2144,14 +2162,17 @@ theorem triple_count_from_r2_connection :
 noncomputable def sumOfTwoSquaresCount (N : ℕ) : ℕ :=
   ((Finset.range (N + 1)).filter (fun n => 0 < r2 n)).card
 
-/-- Landau's theorem: #{n ≤ N : n is a sum of two squares} ∼ C·N/√(log N)
-    for a constant C > 0 (the Landau-Ramanujan constant ≈ 0.7642).
-    Equivalently, sumOfTwoSquaresCount(N) × √(log N) / N → C. -/
-axiom landau_two_squares :
-    ∃ C : ℝ, 0 < C ∧
-    Tendsto (fun N : ℕ =>
-      (sumOfTwoSquaresCount N : ℝ) * Real.sqrt (Real.log N) / (N : ℝ))
-      atTop (𝓝 C)
+/-
+  **Landau's theorem (documented target, formerly an axiom — removed).**
+
+  Landau–Ramanujan: `#{n ≤ N : n is a sum of two squares} ∼ C·N/√(log N)` for a
+  constant `C > 0` (the Landau–Ramanujan constant ≈ 0.7642); equivalently
+  `sumOfTwoSquaresCount(N) · √(log N) / N → C`. This is a deep analytic result
+  not available in Mathlib (v4.26) and it was **not used** anywhere in this file
+  — it stood only as a decorative assumption inflating the trusted-axiom base.
+  Removed to keep the axiom base to the three assumptions the main density
+  theorem actually depends on. Retained here as prose for future formalization.
+-/
 
 /-
 ## Part XXI: Pythagorean Triples by Leg and Area
@@ -2175,13 +2196,17 @@ noncomputable def primitiveByArea (N : ℕ) : ℕ :=
     (a * a + b * b).sqrt ^ 2 = a * a + b * b ∧
     a * b ≤ 2 * N) |>.card
 
-/-- The leg count: #{primitive triples with leg a ≤ N} ~ N/π.
-    This is exactly twice the hypotenuse density, reflecting
-    the parametrization: if c = m²+n², then a = m²-n² < c. -/
-axiom primitive_by_leg_density :
-    Tendsto (fun N : ℕ =>
-      (primitiveByLeg N : ℝ) / (N : ℝ))
-      atTop (𝓝 (1 / π))
+/-
+  **Leg-count density (documented target, formerly an axiom — removed).**
+
+  `#{primitive triples with leg a ≤ N} ~ N/π`, twice the hypotenuse density
+  (from the parametrization `c = m²+n²`, `a = m²−n² < c`). This is a separate
+  density result — it is NOT an exact `2×` of `primitiveTripleCount` at finite
+  `N`, so it does not follow algebraically from the main theorem and would need
+  its own asymptotic analysis. It was **not used** anywhere in this file.
+  Removed as a decorative, unproven assumption; retained here as a documented
+  target for future work.
+-/
 
 /-
 ## Part XXII: Generalizations — Gaussian Integers
@@ -2243,20 +2268,27 @@ theorem all_primitive_triples_from_gaussian :
 ## Part XXII Summary
 
 ### New Definitions and Theorems:
-- **r2**: representation function r₂(n) = #{(a,b) : a²+b² = n}
+- **r2**: representation function counting *nonnegative ordered* pairs
+  #{(a,b) ∈ ℕ² : a²+b² = n}
 - **r2_pos_iff**: characterization via prime factorization [PROVED from Mathlib's
   `Nat.eq_sq_add_sq_iff` — no longer an axiom]
-- **r2_average_order**: (1/N)Σr₂(n) → π (Gauss circle) [AXIOM]
+- **r2_average_order**: [REMOVED] was `(1/N)Σr2(n) → π` but the correct limit for
+  the nonnegative-pair `r2` is π/4; unused and false as stated (documented target)
 - **GaussianInt**: Gaussian integer structure
 - **gaussian_norm_mul**: norm multiplicativity (PROVED)
 - **gaussian_square_pythagorean**: z² gives Pythagorean triple (PROVED)
 - **gaussian_square_components**: real and imaginary parts of z² (PROVED)
 - **landau_two_squares_statement**: Landau-Ramanujan constant (documentation)
 
-### Axiom Count: 6 total — 3 core (sector_lattice_point_density,
-###   coprime_fraction_in_sector, bothOdd_fraction_in_coprime_sector) +
-###   3 supplementary (r2_average_order, landau_two_squares, primitive_by_leg_density).
+### Axiom Count: 3 total — the 3 core axioms the main density theorem depends on:
+###   sector_lattice_point_density (Gauss circle, sector), coprime_fraction_in_sector
+###   (Möbius, 6/π²), bothOdd_fraction_in_coprime_sector (parity sieve, 1/3).
 ###   (r2_pos_iff was previously an axiom; it is now PROVED.)
+###   The 3 former "supplementary" axioms — r2_average_order, landau_two_squares,
+###   primitive_by_leg_density — were REMOVED: they were unused (fed no result),
+###   and r2_average_order was in fact FALSE as stated (asserted the nonnegative-
+###   pair average order → π when the correct value for that def is π/4). Their
+###   mathematical content is retained as documented targets in the body.
 ### Sorries: 0
 -/
 
@@ -2515,9 +2547,12 @@ The straddling analysis explains WHY the parity axiom holds:
 - Summing: total straddling = O(sqrt(N)) << coprime sector = Theta(N)
 
 ### Overall File Statistics:
-- **Axioms**: 6 (3 core + 3 supplementary: r2_average_order, landau_two_squares,
-  primitive_by_leg_density). `r2_pos_iff` was eliminated — it is now a proved
-  theorem (`Nat.eq_sq_add_sq_iff`), so the file is down from 7 axioms to 6.
+- **Axioms**: 3 (the core density axioms only). The 3 former supplementary
+  axioms — r2_average_order (FALSE as stated: nonnegative-pair average order is
+  π/4, not π), landau_two_squares, primitive_by_leg_density — were unused and are
+  now removed (content retained as documented targets). `r2_pos_iff` was earlier
+  eliminated — it is now a proved theorem (`Nat.eq_sq_add_sq_iff`). Axiom history:
+  7 → 6 (r2_pos_iff proved) → 3 (3 unused/incorrect supplementary axioms removed).
 - **Sorries**: 0
 - **Theorems proved**: ~121
 - **Definitions**: ~39

--- a/src/data/proofs/pythagorean-triples-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "pythagorean-triples-oq-01",
   "title": "Density of Primitive Pythagorean Triples",
   "slug": "pythagorean-triples-oq-01",
-  "description": "Proves that the number of primitive Pythagorean triples with hypotenuse c ≤ N is asymptotically N/(2π). Decomposes the result into sector lattice point density (π/8), coprime fraction (6/π²), and parity correction (2/3). Includes parity involutions, column decomposition, and computational verification. 118 theorems, 6 axioms, 0 sorries.",
+  "description": "Proves that the number of primitive Pythagorean triples with hypotenuse c ≤ N is asymptotically N/(2π). Decomposes the result into sector lattice point density (π/8), coprime fraction (6/π²), and parity correction (2/3). Includes parity involutions, column decomposition, and computational verification. 118 theorems, 3 axioms, 0 sorries.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Pythagorean_triple#Generating_a_triple",
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "axiom",
-    "assumptions": "6 axiom declarations encoding deep analytic number theory results: sector lattice point density (π/8, from Gauss circle problem), coprime fraction in sector (6/π², from Möbius inversion), bothOdd fraction (1/3, from parity equidistribution), r2 average order, Landau two-squares counting, and primitive-by-leg density. Full proofs would require sieve methods or complex analysis beyond current Mathlib. (The r2 positivity criterion r2_pos_iff was previously axiomatized but is now PROVED from Mathlib's Nat.eq_sq_add_sq_iff.) native_decide is used for small-N computational checks, so Lean.ofReduceBool is also relied upon.",
+    "assumptions": "3 axiom declarations encoding deep analytic number theory results: sector lattice point density (π/8, from the Gauss circle problem), coprime fraction in sector (6/π², from Möbius inversion), and bothOdd fraction (1/3, from parity equidistribution). These are the only assumptions the main density theorem (primitiveTripleCount · 2π/N → 1) depends on; full proofs would require sieve methods or complex analysis beyond current Mathlib. Three formerly-present 'supplementary' axioms — r2 average order, Landau two-squares counting, and primitive-by-leg density — were removed as unused (they fed no result); r2 average order was additionally FALSE as stated (it asserted the nonnegative-pair r2 average order → π, whereas the correct value for that definition is π/4). The r2 positivity criterion r2_pos_iff was previously axiomatized but is now PROVED from Mathlib's Nat.eq_sq_add_sq_iff. native_decide is used for small-N computational checks, so Lean.ofReduceBool is also relied upon.",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -85,8 +85,8 @@
         "relationship": "CRT structure underlies the independence of coprime conditions modulo different primes"
       }
     ],
-    "axiomCount": 6,
-    "lineCount": 2531,
+    "axiomCount": 3,
+    "lineCount": 2566,
     "mathlib_version": "4.26.0",
     "theoremCount": 118,
     "definitionCount": 40,
@@ -97,7 +97,7 @@
   "overview": {
     "historicalContext": "**Density of Primitive Pythagorean Triples**\n\nPythagorean triples have been studied since Babylonian times (the tablet Plimpton 322, c. 1800 BCE, lists 15 triples). Euclid gave the first complete parametrization in Book X of the *Elements*: every primitive triple $(a,b,c)$ with $a^2+b^2=c^2$ and $\\gcd(a,b,c)=1$ corresponds to a unique pair $(m,n)$ with $m>n>0$, $\\gcd(m,n)=1$, $m \\not\\equiv n \\pmod{2}$, via $a=m^2-n^2$, $b=2mn$, $c=m^2+n^2$.\n\nThe asymptotic density question—how many primitive triples have hypotenuse $c \\le N$?—was answered by D. N. Lehmer in 1900 and refined by subsequent work connecting it to the Gauss circle problem and the density of coprime integers. The result $N/(2\\pi)$ combines three classical facts: lattice point counting in circular sectors (Gauss, 1801), the probability $6/\\pi^2$ that two random integers are coprime (Euler/Cesàro, 1883), and the parity structure of coprime pairs. This formalization appears to be the first mechanized proof of this density result.",
     "problemStatement": "**Theorem**: lim_{N→∞} primitiveTripleCount(N) · (2π)/N = 1. That is, the number of primitive Pythagorean triples with hypotenuse ≤ N grows as N/(2π).",
-    "text": "Proves that the number of primitive Pythagorean triples with hypotenuse c ≤ N is asymptotically N/(2π). Decomposes the result into sector lattice point density (π/8), coprime fraction (6/π²), and parity correction (2/3). Includes parity involutions, column decomposition, and computational verification. 118 theorems, 6 axioms, 0 sorries.",
+    "text": "Proves that the number of primitive Pythagorean triples with hypotenuse c ≤ N is asymptotically N/(2π). Decomposes the result into sector lattice point density (π/8), coprime fraction (6/π²), and parity correction (2/3). Includes parity involutions, column decomposition, and computational verification. 118 theorems, 3 axioms, 0 sorries.",
     "proofStrategy": "The proof decomposes the density into three independent factors, then telescopes their limits:\n\n1. **Sector lattice density** (axiom): The sector $\\{(m,n) : 0 < n < m,\\, m^2+n^2 \\le N\\}$ contains $\\sim \\pi N/8$ lattice points (from the Gauss circle problem — the sector is $1/8$ of the full disk of area $\\pi N$)\n2. **Coprime density** (axiom): Among lattice points in the sector, the fraction with $\\gcd(m,n)=1$ tends to $6/\\pi^2 = 1/\\zeta(2)$ (from Möbius inversion on the Euler product)\n3. **Parity correction** (axiom + proved structure): Among coprime pairs, $2/3$ have $m \\not\\equiv n \\pmod{2}$. This is reduced to showing the both-odd fraction is $1/3$, then verified structurally via the involution $(m,n) \\mapsto (m, m-n)$ which bijects OE and OO classes\n\n**Telescoping**: $\\frac{\\text{count}(N)}{N} = \\frac{\\text{count}}{\\text{coprime}} \\cdot \\frac{\\text{coprime}}{\\text{sector}} \\cdot \\frac{\\text{sector}}{N} \\to \\frac{2}{3} \\cdot \\frac{6}{\\pi^2} \\cdot \\frac{\\pi}{8} = \\frac{1}{2\\pi}$\n\nThe proof also verifies the algebraic identity and establishes growth/monotonicity of intermediate counting functions needed for the ratio convergence.",
     "keyInsights": [
       "The three-factor decomposition $\\pi N/8 \\times 6/\\pi^2 \\times 2/3 = N/(2\\pi)$ cleanly separates geometry (lattice counting), number theory (coprime density via $\\zeta(2)$), and combinatorics (parity sieving) into independent ingredients",
@@ -275,18 +275,18 @@
     {
       "id": "sum-of-two-squares",
       "title": "Part XX: Sum of Two Squares and r₂(n)",
-      "summary": "Connects to the sum-of-two-squares function r2: r2_pos_iff (Fermat's two-square characterization, now PROVED from Mathlib's Nat.eq_sq_add_sq_iff) and the r2_average_order axiom, triple_count_from_r2_connection, sumOfTwoSquaresCount, and the landau_two_squares counting axiom.",
+      "summary": "Connects to the sum-of-two-squares function r2: r2_pos_iff (Fermat's two-square characterization, now PROVED from Mathlib's Nat.eq_sq_add_sq_iff), triple_count_from_r2_connection, and sumOfTwoSquaresCount. The former r2_average_order and landau_two_squares axioms (unused; r2_average_order was false as stated) have been removed and are retained only as documented targets.",
       "startLine": 2064,
       "endLine": 2116,
-      "mathContext": "Connects to the sum-of-two-squares function r2: r2_pos_iff (Fermat's two-square characterization, now PROVED from Mathlib's Nat.eq_sq_add_sq_iff) and the r2_average_order axiom, triple_count_from_r2_connection, sumOfTwoSquaresCount, and the landau_two_squares counting axiom."
+      "mathContext": "Connects to the sum-of-two-squares function r2: r2_pos_iff (Fermat's two-square characterization, now PROVED from Mathlib's Nat.eq_sq_add_sq_iff), triple_count_from_r2_connection, and sumOfTwoSquaresCount. The former r2_average_order and landau_two_squares axioms (unused; r2_average_order was false as stated) have been removed and are retained only as documented targets."
     },
     {
       "id": "triples-by-leg-and-area",
       "title": "Part XXI: Pythagorean Triples by Leg and Area",
-      "summary": "Counts primitive triples organized by leg and by area (primitiveByLeg, primitiveByArea) with the primitive_by_leg_density axiom giving the leg-indexed density.",
+      "summary": "Counts primitive triples organized by leg and by area (primitiveByLeg, primitiveByArea); the former primitive_by_leg_density axiom (leg-indexed density, unused) has been removed and is retained as a documented target.",
       "startLine": 2117,
       "endLine": 2146,
-      "mathContext": "Counts primitive triples organized by leg and by area (primitiveByLeg, primitiveByArea) with the primitive_by_leg_density axiom giving the leg-indexed density."
+      "mathContext": "Counts primitive triples organized by leg and by area (primitiveByLeg, primitiveByArea); the former primitive_by_leg_density axiom (leg-indexed density, unused) has been removed and is retained as a documented target."
     },
     {
       "id": "gaussian-integers",
@@ -377,27 +377,6 @@
       "description": "Pure field identity closed by field_simp; ring after recording π>0 and π²≠0."
     },
     {
-      "name": "r2_average_order",
-      "type": "axiom",
-      "statement": "(1/N)·∑_{n≤N} r₂(n) → π, where r₂(n)=#{(a,b): a²+b²=n}",
-      "significance": "Supplementary input linking the sum-of-two-squares representation function to the Gauss circle problem: the average order of r₂ is π, i.e. lattice points in x²+y²≤N number πN+O(N^{1/2+ε}).",
-      "description": "Axiomatized average-order statement (Gauss circle) supporting the r₂ perspective on the density; r2_pos_iff, by contrast, is now proved from Mathlib's Nat.eq_sq_add_sq_iff."
-    },
-    {
-      "name": "landau_two_squares",
-      "type": "axiom",
-      "statement": "∃ C>0: sumOfTwoSquaresCount(N)·√(log N)/N → C (Landau–Ramanujan)",
-      "significance": "Landau's theorem that integers ≤ N expressible as a sum of two squares number ~ C·N/√(log N), with C the Landau–Ramanujan constant ≈ 0.7642 — context distinguishing 'which n are hypotenuses' from 'how many triples'.",
-      "description": "Axiomatized existence-of-constant limit; the Landau–Ramanujan constant is not formalized in Mathlib. Included to situate the density result within the sum-of-two-squares landscape."
-    },
-    {
-      "name": "primitive_by_leg_density",
-      "type": "axiom",
-      "statement": "primitiveByLeg(N)/N → 1/π",
-      "significance": "Counting primitive triples by shorter leg a ≤ N gives density 1/π, exactly twice the hypotenuse density 1/(2π) — reflecting that a = m²-n² < c = m²+n² in the parametrization.",
-      "description": "Axiomatized companion density for the leg-based count primitiveByLeg, complementing the hypotenuse-based primitiveTripleCount_density."
-    },
-    {
       "name": "gaussian_square_pythagorean",
       "type": "theorem",
       "statement": "For z = m+ni, (Re z²)² + (Im z²)² = (m²+n²)²",
@@ -420,7 +399,7 @@
     }
   ],
   "conclusion": {
-    "summary": "A thorough formalization of the primitive Pythagorean triple density theorem, establishing $\\text{primitiveTripleCount}(N)/N \\to 1/(2\\pi)$ via a clean three-factor decomposition. The proof comprises 118 theorems, 6 axioms (encoding deep analytic number theory), and 0 sorries. The axioms isolate analytic content (Gauss circle problem, Möbius inversion, parity equidistribution, Landau two-squares counting) that would require sieve methods or complex analysis to prove formally.",
+    "summary": "A thorough formalization of the primitive Pythagorean triple density theorem, establishing $\\text{primitiveTripleCount}(N)/N \\to 1/(2\\pi)$ via a clean three-factor decomposition. The proof comprises 118 theorems, 3 axioms (encoding deep analytic number theory), and 0 sorries. The axioms isolate analytic content (Gauss circle problem, Möbius inversion, parity equidistribution) that would require sieve methods or complex analysis to prove formally. Three formerly-present supplementary axioms (r2 average order — which was false as stated, Landau two-squares counting, and primitive-by-leg density) were unused and have been removed, with their content retained as documented targets.",
     "implications": "**Theoretical Significance**: **Significance**\n\n1. **First mechanized proof**: This appears to be the first formal verification of the $N/(2\\pi)$ density result for primitive Pythagorean triples in any proof assistant.\n2. **Modular architecture**: The three-factor decomposition into geometry ($\\pi/8$), number theory ($6/\\pi^2$), and combinatorics ($2/3$) makes each component independently verifiable and replaceable.\n**3. Bijective technique**: The parity involution $(m,n) \\mapsto (m, m-n)$ is a general technique applicable to any coprime-parity counting problem, not just Pythagorean triples.\n4. **Computational confidence**: Verification of counting functions for $N = 0, 4, 5, 13, 25, 50, 100$ via native_decide confirms the formalized definitions match the intended mathematical objects.\n5. **Connection to $\\zeta(2)$**: The coprime density factor $6/\\pi^2 = 1/\\zeta(2)$ links this result to the Basel problem, demonstrating how the Riemann zeta function controls the distribution of coprime pairs.",
     "openQuestions": [
       "Can the sector lattice point density axiom ($\\pi/8$) be proved from Gauss circle problem results in Mathlib, using the error term $O(\\sqrt{N})$?",
@@ -447,8 +426,8 @@
       "Topology"
     ],
     "namespace": "PythagoreanTriplesDensity",
-    "lineCount": 2531,
-    "axiomCount": 6,
+    "lineCount": 2566,
+    "axiomCount": 3,
     "theoremCount": 118,
     "definitionCount": 40,
     "path": "Proofs/PythagoreanTriplesOQ01.lean",

--- a/src/data/research/problems/pythagorean-theorem-oq-01.json
+++ b/src/data/research/problems/pythagorean-theorem-oq-01.json
@@ -39,20 +39,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: base 2-D Pythagorean theorem solved (PythagoreanTheorem.lean, 0 sorry). As family follow-up, closed the only open sorry in the flat-limit file (PythagoreanTheoremOQ05.lean spherical_flat_limit) and repaired pervasive Mathlib-cache drift across that file.",
+    "progressSummary": "AXIOM REDUCTION: PythagoreanTriplesOQ01.lean 6→3 axioms. Removed 3 unused supplementary axioms (r2_average_order was additionally FALSE as stated — nonneg-pair average order is π/4 not π). Remaining 3 are the load-bearing Gauss-circle/Möbius/parity assumptions. Full docker verification memory-blocked (>90GB for fresh elaboration; change is compile-safe removal of unused decls).",
     "builtItems": [
-      "sin_eq_sinc_mul, tendsto_one_sub_cos_mul_div_sq, tendsto_cos_mul_one, tendsto_one_sub_cos_prod_div_sq, spherical_flat_limit in Proofs/PythagoreanTheoremOQ05.lean (0 sorry, 0 axioms, verified via lake env lean 4.26.0)"
+      "sin_eq_sinc_mul, tendsto_one_sub_cos_mul_div_sq, tendsto_cos_mul_one, tendsto_one_sub_cos_prod_div_sq, spherical_flat_limit in Proofs/PythagoreanTheoremOQ05.lean (0 sorry, 0 axioms, verified via lake env lean 4.26.0)",
+      "Removed 3 unused axioms from Proofs/PythagoreanTriplesOQ01.lean (r2_average_order [false as stated], landau_two_squares, primitive_by_leg_density), reducing 6→3; content retained as documented targets. Updated meta.json axiomCount 6→3 in both stat blocks + assumptions/keyStatements/annotations."
     ],
     "insights": [
       "Spherical flat limit: from cos(tc)=cos(ta)cos(tb) ∀t>0, c²=a²+b² follows by the exact identity (1-cos(tx))/t² = (x²/2)·sinc(tx/2)², using half-angle 1-cos(tx)=2sin(tx/2)² and sin u = sinc u · u; sinc continuity (sinc 0 = 1) gives the limit. No range restriction on a,b,c needed.",
-      "This sinc-identity route is cleaner than the hyperbolic squeeze: it avoids all monotonicity/second-derivative machinery and reduces the limit to continuity of Real.sinc at 0."
+      "This sinc-identity route is cleaner than the hyperbolic squeeze: it avoids all monotonicity/second-derivative machinery and reduces the limit to continuity of Real.sinc at 0.",
+      "PythagoreanTriplesOQ01.lean had 6 axioms but only 3 (sector_lattice_point_density, coprime_fraction_in_sector, bothOdd_fraction_in_coprime_sector) are consumed by the main density theorem; the other 3 were decorative/unused.",
+      "The `r2_average_order` axiom was FALSE as stated: this file's `r2` counts nonnegative ordered pairs (quarter disk), so Σ_{n≤N} r2(n) ~ (π/4)N and the average order → π/4, not π. The axiom conflated it with the full-plane signed r₂ (whose disk sum ~ πN). An unused false axiom is a latent unsoundness (π = π/4 derivable)."
     ],
     "mathlibGaps": [
       "Mathlib cache drift broke the existing hyperbolic section: le_div_iff→le_div_iff₀, div_le_div_iff→div_le_div_iff₀, Filter.eventually_nhdsWithin_of_forall→eventually_nhdsWithin_of_forall, Tendsto.congr! argument order (eventuallyEq first), pointwise squeeze tendsto_of_tendsto_of_tendsto_of_le_of_le→eventually variant (prime), HasDerivAt.sub of a const now yields x-0 (needs simpa/convert), and let-bound f 0 = 0 no longer closes by bare simp (needs show)."
     ],
     "nextSteps": [
       "Optionally create a gallery entry (src/data/proofs/pythagorean-theorem-oq-05) for the now-complete flat-limit file.",
-      "Audit sibling pythagorean files (OQ03 etc.) for the same Mathlib drift."
+      "Audit sibling pythagorean files (OQ03 etc.) for the same Mathlib drift.",
+      "Future: prove the corrected quarter-disk average order (→π/4) once Mathlib gains lattice-point-counting / Gauss-circle infrastructure; likewise Landau–Ramanujan and leg-density."
     ],
     "markdown": "# Knowledge Base: pythagorean-theorem-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
`PythagoreanTriplesOQ01.lean` declared **6 axioms**, but only **3** are consumed by the main density theorem (`primitiveTripleCount(N)·2π/N → 1`). The other 3 were decorative — no result depended on them. This PR removes those 3 unused axioms, reducing the file's trusted-assumption base **6 → 3**, and updates the gallery meta to match.

## The removed axioms
- **`r2_average_order`** — *FALSE as stated.* This file's `r2 n` counts **nonnegative ordered** pairs `(a,b)` (`a,b ≥ 0`), so `Σ_{n≤N} r2 n` is the **quarter-disk** lattice count `~ (π/4)·N`, giving average order **π/4, not π**. The axiom asserted `→ π`, conflating this with the full-plane *signed* `r₂(n)=4(d₁−d₃)` (whose full-disk sum is `~ πN`). An unused false axiom is a latent unsoundness (combined with a proof of the π/4 limit it yields `π = π/4`). Removed; the correct π/4 statement is kept as a documented Gauss-circle target.
- **`landau_two_squares`** (Landau–Ramanujan) and **`primitive_by_leg_density`** — deep, unproven, and unused. Removed; content retained as documented targets in the file body.

## Remaining 3 axioms (load-bearing)
`sector_lattice_point_density` (Gauss circle, π/8), `coprime_fraction_in_sector` (Möbius, 6/π²), `bothOdd_fraction_in_coprime_sector` (parity sieve, 1/3) — the only assumptions the main theorem actually uses.

## Files modified
- `proofs/Proofs/PythagoreanTriplesOQ01.lean` — 3 `axiom` declarations replaced with documented-target comments; accounting comments updated.
- `src/data/proofs/pythagorean-triples-oq-01/meta.json` — `axiomCount` 6→3 (both stat blocks), `lineCount` 2531→2566, `assumptions`/`keyStatements`/annotations updated.
- `src/data/research/problems/pythagorean-theorem-oq-01.json` — knowledge insights/builtItems.

## Verification
The change is a **pure removal of unused declarations plus comment edits** — compile-safe by construction: nothing references the removed axioms (grep-confirmed), and no def or theorem was touched. Block-comment delimiters verified balanced.

Full docker rebuild could **not** complete on this host: fresh elaboration of this 2531-line file exceeds 90 GB (OOM-killed at 32/64/90 GB limits), and the cached path hit a corrupt-cache `SIGBUS` (exit 135 at 509 ms). This matches prior sessions' experience with this memory-intensive file. The file remains `status: axiomatized` (3 axioms); no "verified" claim is made.

## Status
**Outcome**: progress (axiom reduction 6→3, incl. eliminating a false axiom)
**Next Steps**: prove the corrected π/4 quarter-disk average order once Mathlib gains Gauss-circle / lattice-counting infrastructure.

🤖 Generated by researcher-9