### PR TITLE
Enrich Coprime Companion Blocks Nonderogatory: dimension consistency + non-coprime case

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
@@ -47,7 +47,9 @@
       "In general lcm p q strictly divides p·q, so a block sum of companion matrices is derogatory (minpoly ≠ charpoly); coprimality is exactly what removes the gap and makes the block sum cyclic.",
       "The equality minpoly = charpoly = p·q is the matrix-level statement of K[X]/(p·q) ≅ K[X]/(p) × K[X]/(q): two coprime cyclic modules merge into one cyclic module.",
       "The whole argument reduces to a clean GCD-monoid fact about monic polynomials — lcm = product for coprimes — showing how much of rational canonical form theory is arithmetic in K[X].",
-      "The GCDMonoid structure on F[X] requires a DecidableEq F instance; supplying it is the only fix needed to machine-check the coprime merge."
+      "The GCDMonoid structure on F[X] requires a DecidableEq F instance; supplying it is the only fix needed to machine-check the coprime merge.",
+      "Nonderogatory is equivalently the degree condition deg(minpoly) = n (the matrix size): the block sum has size dp + dq = deg p + deg q = deg(p·q), and its minimal polynomial p·q has exactly that degree — the minimal polynomial is as large as it can be, which is what forces a cyclic vector to exist. The similar single block C(p·q) is (deg p·q)×(deg p·q), so the CRT collapse is dimension-preserving, as any similarity must be.",
+      "Only the two scalar facts charpoly = p·q and minpoly = lcm p q from the parent are used; after importing them the block-matrix structure is never touched again, so the entire 'matrix CRT' theorem is decided by the one-line polynomial identity lcm = product — the matrix statement is scalar CRT in disguise."
     ],
     "prerequisites": [
       "Companion matrices and the rational canonical form",
@@ -91,7 +93,8 @@
     "implications": "Provides the CRT building block for assembling the full multi-block rational canonical form from the parent's single-block cyclic criterion. It isolates the exact arithmetic content — lcm = product for coprimes — that turns a derogatory block sum into a cyclic one.",
     "openQuestions": [
       "Can the coprime merge be iterated over the elementary-divisor factorization to reconstruct the full rational canonical form for an arbitrary matrix?",
-      "Does the explicit similarity C(p) ⊕ C(q) ~ C(p·q) admit a constructive change-of-basis via the companionMatrix restatement of the cyclic-vector bridge?"
+      "Does the explicit similarity C(p) ⊕ C(q) ~ C(p·q) admit a constructive change-of-basis via the companionMatrix restatement of the cyclic-vector bridge?",
+      "The complementary non-coprime case: when p, q share a factor (e.g. p = q) one has lcm p q ∣ p·q strictly, so the block sum is genuinely derogatory (minpoly ≠ charpoly). Formalize this obstruction and the invariant-factor normalization that reorganizes overlapping blocks into the canonical divisibility chain d₁ ∣ d₂ ∣ ⋯."
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05` (quality 93, 0 passes).

The entry was already comprehensive (5 rich annotations, full sections/conclusion, complete ancestor cross-reference chain from #35204). It sat at the *floor* on keyInsights (4) and openQuestions (2), and is small (10.5 KB), so two genuinely new, non-duplicative additions:

- **keyInsight** — the `deg(minpoly) = n` characterization of nonderogatory: the block sum has size `dp + dq = deg p + deg q = deg(p·q)`, and its minimal polynomial `p·q` has exactly that degree, so the CRT collapse to `C(p·q)` is dimension-preserving.
- **keyInsight** — the whole matrix theorem is decided by the one-line scalar identity `lcm = product`; after importing the parent's two scalar facts the block-matrix structure is never touched again (matrix CRT is scalar CRT in disguise).
- **openQuestion** — the complementary non-coprime case: when `p, q` share a factor, `lcm p q ∣ p·q` strictly and the block sum is genuinely derogatory; formalize that obstruction and the invariant-factor normalization.

Result: 6 keyInsights, 3 openQuestions, meta.json 11.6 KB (well under all caps). `pnpm build` passes; annotations unchanged. No axiom/status changes.