### PR TITLE
audit(rh-consequences): correct axiomCount 18→9 to match Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3909,8 +3909,8 @@
       "issues": []
     },
     "buffons-noodle": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-16T22:05:22Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:36:57Z",
       "result": "clean",
       "issues": []
     },
@@ -24416,10 +24416,12 @@
       "issues": []
     },
     "rh-consequences": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-05-04T04:06:37Z",
-      "result": "clean"
+      "auditCount": 4,
+      "issues": [
+        "axiomCount was 18 but Lean file has exactly 9 axiom declarations (assumptions field also enumerates 9); corrected meta.axiomCount and leanFile.axiomCount 18->9"
+      ],
+      "lastAudited": "2026-07-08T05:36:57Z",
+      "result": "issues-fixed"
     },
     "riemann-hypothesis": {
       "auditCount": 5,
@@ -29545,5 +29547,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T05:29:02Z"
+  "lastUpdated": "2026-07-08T05:36:57Z"
 }

--- a/src/data/proofs/rh-consequences/meta.json
+++ b/src/data/proofs/rh-consequences/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 18,
+    "axiomCount": 9,
     "assumptions": "9 axioms for classical RH consequences: rh_implies_mertens_bound (|M(x)| = O(√x)), lis_criterion (LI series criterion), riemann_von_mangoldt_formula, RH_implies_DensityHypothesis, rh_implies_psi_bound, explicit_formula_error, zeta_in_selberg_class, explicit_formula_zero_free, hadamard_product_exists. These are known results not yet formalized in Mathlib.",
     "lineCount": 1735,
     "theoremCount": 122,
@@ -71,7 +71,7 @@
   "leanFile": {
     "namespace": "RHConsequences",
     "lineCount": 1735,
-    "axiomCount": 18,
+    "axiomCount": 9,
     "theoremCount": 122,
     "definitionCount": 17,
     "path": "Proofs/RiemannHypothesisConsequences.lean",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: rh-consequences (Riemann Hypothesis Consequences)
**Problem**: `axiomCount` overstated as 18; the Lean source has exactly 9 `axiom` declarations.

## Evidence

`proofs/Proofs/RiemannHypothesisConsequences.lean`:
- **9** literal `axiom` declarations (lines 150, 545, 576, 724, 1053, 1237, 1353, 1414, 1480)
- **0** sorries
- **No** structure/class definitions carrying assumption fields; imports are Mathlib-only (no local module pulling in outside axioms)

The meta `assumptions` field already states *"9 axioms for classical RH consequences"* and enumerates all 9 by name. But `meta.axiomCount` and `leanFile.axiomCount` both read **18** — stale: the file documents that several axioms were converted to proofs (e.g. *"Trivial Mertens bound |M(x)| ≤ x (PROVEN, no axiom)"*, *"Previously an axiom with `True` conclusion"*).

## Fix

- `meta.axiomCount`: 18 → 9
- `leanFile.axiomCount`: 18 → 9

Direction is conservative (the entry was over-counting assumptions, not overclaiming), but the meta was internally self-contradictory (count vs. enumerated `assumptions`). Status/badge remain `axiomatized`/`axiom` (correct for a Millennium Prize problem).

Also records a re-audit of **buffons-noodle** as clean — its `leanFile.axiomCount=2` is accurate (the second axiom is a `noncomputable axiom` at line 250).

---
Discovered during gallery integrity re-audit of metas changed since last audit.