### PR TITLE
research(erdos-634): area-only dissection predicate collapses — IsDissectable n for all n≥1 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos634AreaCollapse.lean
+++ b/proofs/Proofs/Erdos634AreaCollapse.lean
@@ -1,0 +1,172 @@
+/-
+  Erdős Problem #634 — Why the area-only dissection predicate is vacuous
+
+  Source: https://erdosproblems.com/634
+
+  The base formalization (`Erdos634Problem.lean`) models a dissection of a
+  triangle `T` into `n` pieces by the single condition
+
+      area_partition : (∑ i, (pieces i).area) = T.area
+
+  i.e. the piece areas *add up* to the area of `T`. This is explicitly flagged
+  there as "necessary but not sufficient": it says nothing about the pieces
+  actually covering `T` or being interior-disjoint.
+
+  This file makes the inadequacy precise. We prove that the area-only predicate
+  `IsDissectable` is satisfied by **every** `n ≥ 1`:
+
+      dissectable_of_pos : ∀ n, 1 ≤ n → IsDissectable n
+
+  The witness is trivial: take `T` to be a unit equilateral triangle and take
+  the `n` pieces to be `n` congruent equilateral triangles each of side
+  `1/√n`, hence each of area `(1/n)·√3/4`; their areas sum to `√3/4 = area(T)`.
+
+  Consequences:
+  * The positive results of the problem (`k²`, `2k²`, `3k²`, `6k²`, `k²+m²`,
+    `27`, …) all become one-line corollaries — but *vacuously*, carrying no
+    geometric content.
+  * More importantly, `IsDissectable 7` and `IsDissectable 11` are **provable**
+    here. Since Beeson's theorem asserts `¬IsDissectable 7` and
+    `¬IsDissectable 11` (postulated as axioms in the base file), the area-only
+    predicate is logically *incompatible* with Beeson's negative results: it
+    cannot express them without inconsistency.
+
+  Moral: a faithful formalization must require genuine covering and
+  interior-disjointness of the pieces — exactly the strengthening carried out
+  in the `-oq-02` covering line of work (`Erdos634MedialCoveringOQ02.lean`).
+  This file is a self-contained, axiom-free critique of the naive definition;
+  it deliberately does **not** import the false Beeson axioms, so it is itself
+  consistent.
+
+  Tags: geometry, dissection, formalization-critique, erdos, open-problem
+-/
+
+import Mathlib
+
+namespace Erdos634AreaCollapse
+
+open Finset
+
+/-- A triangle represented by its three side lengths, with positivity and the
+    three triangle inequalities. (Mirrors `Erdos634.Triangle`.) -/
+structure Triangle where
+  a : ℝ
+  b : ℝ
+  c : ℝ
+  ha : a > 0
+  hb : b > 0
+  hc : c > 0
+  tab : a + b > c
+  tbc : b + c > a
+  tca : c + a > b
+
+/-- Congruence: equality of the (unordered) multiset of side lengths. -/
+def Congruent (T₁ T₂ : Triangle) : Prop :=
+  Multiset.ofList [T₁.a, T₁.b, T₁.c] = Multiset.ofList [T₂.a, T₂.b, T₂.c]
+
+/-- Semiperimeter. -/
+noncomputable def Triangle.s (T : Triangle) : ℝ := (T.a + T.b + T.c) / 2
+
+/-- Area via Heron's formula. -/
+noncomputable def Triangle.area (T : Triangle) : ℝ :=
+  Real.sqrt (T.s * (T.s - T.a) * (T.s - T.b) * (T.s - T.c))
+
+/-- Area-only dissection: the piece areas sum to the area of `T`.
+    This is the exact predicate used in the base formalization. -/
+structure Dissection (T : Triangle) (n : ℕ) where
+  pieces : Fin n → Triangle
+  area_partition : (∑ i, (pieces i).area) = T.area
+
+/-- All pieces are congruent to each other. -/
+def IsCongruentDissection (T : Triangle) (n : ℕ) (D : Dissection T n) : Prop :=
+  ∀ i j : Fin n, Congruent (D.pieces i) (D.pieces j)
+
+/-- `n` is (area-only) dissectable: some triangle has an area-only dissection
+    into `n` mutually congruent triangles. -/
+def IsDissectable (n : ℕ) : Prop :=
+  ∃ T : Triangle, ∃ D : Dissection T n, IsCongruentDissection T n D
+
+/-- The equilateral triangle with side length `s > 0`. -/
+noncomputable def equil (s : ℝ) (hs : 0 < s) : Triangle where
+  a := s
+  b := s
+  c := s
+  ha := hs
+  hb := hs
+  hc := hs
+  tab := by linarith
+  tbc := by linarith
+  tca := by linarith
+
+/-- The area of an equilateral triangle of side `s > 0` is `s²·√3/4`. -/
+theorem equil_area (s : ℝ) (hs : 0 < s) :
+    (equil s hs).area = s ^ 2 * Real.sqrt 3 / 4 := by
+  unfold Triangle.area
+  have hs2 : (equil s hs).s = 3 * s / 2 := by
+    unfold Triangle.s equil; ring
+  rw [hs2]
+  show Real.sqrt (3 * s / 2 * (3 * s / 2 - s) * (3 * s / 2 - s) * (3 * s / 2 - s))
+      = s ^ 2 * Real.sqrt 3 / 4
+  rw [show 3 * s / 2 * (3 * s / 2 - s) * (3 * s / 2 - s) * (3 * s / 2 - s)
+        = (s ^ 2 * Real.sqrt 3 / 4) ^ 2 from ?_]
+  · exact Real.sqrt_sq (by positivity)
+  · rw [div_pow, mul_pow, Real.sq_sqrt (by norm_num)]
+    ring
+
+/-- **Collapse of the area-only predicate.** Every `n ≥ 1` is area-dissectable:
+    cut a unit equilateral triangle into `n` congruent equilateral pieces of
+    side `1/√n`. The construction ignores geometry entirely — it only balances
+    areas — which is exactly the defect being exposed. -/
+theorem dissectable_of_pos (n : ℕ) (hn : 1 ≤ n) : IsDissectable n := by
+  have hnR : (0 : ℝ) < n := by exact_mod_cast hn
+  have hnR' : (n : ℝ) ≠ 0 := ne_of_gt hnR
+  have hpos : 0 < Real.sqrt (1 / n) := Real.sqrt_pos.mpr (by positivity)
+  refine ⟨equil 1 one_pos, ⟨fun _ => equil (Real.sqrt (1 / n)) hpos, ?_⟩, ?_⟩
+  · -- area balance
+    simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+    rw [equil_area, equil_area, Real.sq_sqrt (by positivity), nsmul_eq_mul]
+    field_simp
+  · -- all pieces are the same triangle, hence congruent
+    intro i j; rfl
+
+/-- Positive-result corollaries — all *vacuous* under the area-only predicate. -/
+theorem squares_dissectable (k : ℕ) (hk : 1 ≤ k) : IsDissectable (k ^ 2) :=
+  dissectable_of_pos _ (Nat.one_le_pow 2 k (by omega))
+
+theorem two_squares_dissectable (n : ℕ) (hn : 1 ≤ n) : IsDissectable (2 * n ^ 2) :=
+  dissectable_of_pos _ (by have := Nat.one_le_pow 2 n (by omega); omega)
+
+theorem three_squares_dissectable (n : ℕ) (hn : 1 ≤ n) : IsDissectable (3 * n ^ 2) :=
+  dissectable_of_pos _ (by have := Nat.one_le_pow 2 n (by omega); omega)
+
+theorem six_squares_dissectable (n : ℕ) (hn : 1 ≤ n) : IsDissectable (6 * n ^ 2) :=
+  dissectable_of_pos _ (by have := Nat.one_le_pow 2 n (by omega); omega)
+
+theorem sum_squares_dissectable (n m : ℕ) (hn : 1 ≤ n) (_hm : 1 ≤ m) :
+    IsDissectable (n ^ 2 + m ^ 2) :=
+  dissectable_of_pos _ (by have := Nat.one_le_pow 2 n (by omega); omega)
+
+theorem twenty_seven_dissectable : IsDissectable 27 :=
+  dissectable_of_pos 27 (by norm_num)
+
+/-- **The punchline.** `7` is area-dissectable — even though Beeson proved it is
+    *not* dissectable as a genuine geometric tiling. Hence the area-only
+    predicate provably contradicts Beeson's theorem. -/
+theorem area_dissectable_seven : IsDissectable 7 :=
+  dissectable_of_pos 7 (by norm_num)
+
+/-- Likewise `11`. -/
+theorem area_dissectable_eleven : IsDissectable 11 :=
+  dissectable_of_pos 11 (by norm_num)
+
+/-- Stated as an incompatibility: **no** predicate that both (i) is implied by
+    the area-only dissection data and (ii) forbids `7` can be consistent.
+    Concretely, adjoining Beeson's `¬IsDissectable 7` to this file yields `False`. -/
+theorem beeson_axiom_inconsistent_with_area_predicate
+    (beeson : ¬ IsDissectable 7) : False :=
+  beeson area_dissectable_seven
+
+#check @dissectable_of_pos
+#check @area_dissectable_seven
+
+end Erdos634AreaCollapse

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -43,24 +43,26 @@
     "originalContributions": [
       "Formal definition of triangle congruence via side length multisets",
       "Triangle area via Heron's formula (Triangle.semiperimeter + Triangle.area using Real.sqrt)",
-      "Strengthened Dissection structure: area_partition requiring (∑ pieces).area = T.area, preventing trivial constant-function witnesses from making all n ≥ 1 dissectable",
+      "Dissection structure uses area_partition (∑ pieces.area = T.area) as a necessary condition; NOTE this alone does NOT rule out degenerate witnesses (see Erdos634AreaCollapse.lean)",
       "Statement of known positive results as honest sorries (k², 2k², 3k², 6k², k²+m²) pending explicit construction proofs",
       "Axiomatization of Beeson's negative results (7, 11)",
       "Statement of the 4k+3 prime conjecture",
       "Soifer's theorem on similar dissections",
       "Snover-Waiveris-Williams self-similar characterization",
-      "Analysis of open case n = 19"
+      "Analysis of open case n = 19",
+      "Erdos634AreaCollapse.lean (machine-checked, 0-sorry/0-axiom): proves the area-only IsDissectable predicate is satisfied by EVERY n ≥ 1 — witness is n congruent equilateral pieces of side 1/√n whose areas sum to T.area — refuting the prior claim that the area_partition requirement removed the internal inconsistency. Consequently the Beeson axioms (¬IsDissectable 7, ¬IsDissectable 11) are inconsistent with the area-only definition; a faithful predicate needs genuine covering + interior-disjointness (cf. oq-02 covering work)."
     ],
     "relatedProblems": [
       "erdos-633"
     ],
     "axiomCount": 3,
-    "assumptions": "3 axioms: seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 6 sorries: congruent_implies_similar (sorry pending), squares_dissectable, two_squares_dissectable, three_squares_dissectable, six_squares_dissectable, sum_squares_dissectable (all pending explicit dissection constructions with Heron-formula area equality). The Dissection structure was strengthened from a placeholder positivity condition to a proper area-partition requirement via Heron's formula — removing a prior internal inconsistency where trivial constant-function witnesses made IsDissectable provable for all n ≥ 1, contradicting the Beeson axioms.",
+    "assumptions": "3 axioms: seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 6 sorries in Erdos634Problem.lean: congruent_implies_similar plus the five positive-result stubs (squares/two/three/six/sum). IMPORTANT CAVEAT (proven in Erdos634AreaCollapse.lean, 0-sorry/0-axiom): the area_partition condition does NOT remove the internal inconsistency an earlier note claimed it did — IsDissectable n is provable for every n ≥ 1 by taking n congruent equilateral pieces of side 1/√n (a constant-function witness that DOES satisfy area_partition). Hence the Beeson non-dissectability axioms are logically incompatible with the area-only Dissection predicate; only a definition enforcing genuine covering and interior-disjointness (the oq-02 covering line) resolves this.",
     "lineCount": 331,
     "theoremCount": 16,
     "definitionCount": 20,
     "additionalFiles": [
-      "Proofs/Erdos634Aristotle.lean"
+      "Proofs/Erdos634Aristotle.lean",
+      "Proofs/Erdos634AreaCollapse.lean"
     ]
   },
   "overview": {
@@ -206,7 +208,8 @@
     "sorries": 6,
     "path": "Proofs/Erdos634Problem.lean",
     "additionalFiles": [
-      "Proofs/Erdos634Aristotle.lean"
+      "Proofs/Erdos634Aristotle.lean",
+      "Proofs/Erdos634AreaCollapse.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Summary

New companion file **`proofs/Proofs/Erdos634AreaCollapse.lean`** (machine-checked, **0 sorries / 0 axioms**, `import Mathlib`, Lean v4.26) formalizes a soundness critique of the base Erdős #634 formalization.

The base `Erdos634Problem.lean` models a triangle dissection by the single condition `area_partition : (∑ i, (pieces i).area) = T.area`. This file proves that predicate is **vacuous**:

```
dissectable_of_pos : ∀ n, 1 ≤ n → IsDissectable n
```

**Witness:** cut a unit equilateral triangle into `n` congruent equilateral pieces of side `1/√n`; each has Heron area `(1/n)·√3/4`, so the `n` areas sum to `√3/4 = area(T)`, and all pieces are congruent (identical).

## Why this matters

The base `meta.json` previously **claimed** the `area_partition` requirement *removed* an internal inconsistency by "preventing trivial constant-function witnesses from making all n ≥ 1 dissectable." That claim is **false**, and this PR proves it: the witness above **is** a constant function and **does** satisfy `area_partition`. Consequently:

- The positive results (`k²`, `2k²`, `3k²`, `6k²`, `k²+m²`, `27`) are one-line corollaries — but *vacuous*, carrying no geometric content.
- `IsDissectable 7` and `IsDissectable 11` are **provable** (`area_dissectable_seven/eleven`), so the base file's Beeson axioms `¬IsDissectable 7` / `¬IsDissectable 11` are **logically incompatible** with the area-only definition (`beeson_axiom_inconsistent_with_area_predicate`).

A faithful predicate must require genuine **covering + interior-disjointness** — exactly the strengthening already carried out in the `-oq-02` covering line (#32615). This file deliberately does **not** import the Beeson axioms, so it is itself consistent (0-axiom). It complements the sibling erdos-633 "dissection model collapses" finding (#30356/#30393).

## Changes
- Add `proofs/Proofs/Erdos634AreaCollapse.lean` (verified: `Build completed successfully (7743 jobs)`).
- `src/data/proofs/erdos-634/meta.json`: register the companion file and **correct** the false "inconsistency removed" claim in `originalContributions` / `assumptions`.

## Verification
Built via Docker wrapper: `LEAN_SKIP_CACHE=true LEAN_MEMORY_LIMIT=16384 ./proofs/scripts/docker-build.sh Proofs.Erdos634AreaCollapse` → `Build completed successfully (7743 jobs)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)