### PR TITLE
Enrich q-Vandermonde Convolution: correct inaccurate Mathlib reference note

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-01-oq-03/meta.json
@@ -125,7 +125,7 @@
       "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
       "year": 2020,
       "venue": "CPP",
-      "note": "Provides Nat.multinomial, Finset.piAntidiag, PMF, and the probability/binomial API underlying this formalization."
+      "note": "Provides the finite-sum API over Finset.range (Finset.sum, sum_range_succ / sum_range_succ', sum_add_distrib, sum_congr), the geometric-sum identity geom_sum_mul, and the linear_combination tactic over a CommRing that drive the absorption and q-Vandermonde inductions. Mathlib has no native Gaussian-binomial API as of v4.26, so qBinomial and the q-Pascal recurrence are supplied by the gallery's own development."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-04-oq-01-oq-03` (quality 94, 0 passes).

The entry is already thorough (8 annotations, 4 keyInsights, 3 sections, 3 crossReferences, deep overview/conclusion). Found and fixed a genuine **accuracy defect**: the Mathlib `references[2]` note claimed the proof "Provides Nat.multinomial, Finset.piAntidiag, PMF, and the probability/binomial API" — none of which appear in the Lean file (verified: 0 occurrences each). That note was copy-pasted from a probability entry.

Replaced with an accurate description of what Mathlib actually supplies here: the finite-sum API over `Finset.range` (`Finset.sum`, `sum_range_succ`/`sum_range_succ'`, `sum_add_distrib`, `sum_congr`), `geom_sum_mul`, and `linear_combination` over a `CommRing` — the tools that drive the absorption and q-Vandermonde inductions — plus the note that Mathlib has no native Gaussian-binomial API as of v4.26, so `qBinomial`/q-Pascal come from the gallery's own development.

`pnpm build` passes. Single-line correctness change; no other content touched.