### PR TITLE
audit(re-audit): refresh tracker for 77 recently-changed proofs (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -436,9 +436,9 @@
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-05": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-07-01T12:27:37Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-05-oq-04": {
@@ -508,8 +508,8 @@
       "issues": []
     },
     "alternating-series-test-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T17:08:20Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -520,8 +520,8 @@
       "issues": []
     },
     "alternating-series-test-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T01:13:17Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -1147,9 +1147,9 @@
       "issues": []
     },
     "angle-trisection-oq-05-oq-04-incomplete-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-01T17:43:53Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "antitone-integral-sum-comparison-oq-01": {
@@ -1480,14 +1480,14 @@
       "issues": []
     },
     "area-of-circle-oq-07-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T17:14:04Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-07-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T17:16:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -1516,8 +1516,8 @@
       "result": "clean"
     },
     "area-of-circle-oq-07-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T17:16:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -1540,8 +1540,8 @@
       "result": "clean"
     },
     "area-of-circle-oq-07-oq-05": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T20:04:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -1779,9 +1779,9 @@
       "issues": []
     },
     "arsinh-log-formula-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "arsinh-log-formula-oq-01-oq-01-oq-01": {
@@ -2040,9 +2040,9 @@
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-06-18T05:35:38Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-02-oq-01": {
@@ -2071,8 +2071,8 @@
       "result": "clean"
     },
     "ballot-problem-oq-04-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T04:16:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -2083,8 +2083,8 @@
       "result": "clean"
     },
     "ballot-problem-oq-04-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T01:23:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -2257,26 +2257,26 @@
       "result": "clean"
     },
     "basel-problem-oq-08": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T20:05:53Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
     "basel-problem-oq-08-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "basel-problem-oq-08-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "basel-problem-oq-09": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T20:06:14Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -2299,8 +2299,8 @@
       "result": "clean"
     },
     "basel-problem-oq-11": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T20:11:41Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -2311,9 +2311,9 @@
       "issues": []
     },
     "basel-problem-oq-12": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T20:13:09Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
       "issues": []
     },
     "basel-problem-oq-13": {
@@ -2341,8 +2341,8 @@
       "issues": []
     },
     "basel-problem-oq-14": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T20:14:06Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -2353,14 +2353,14 @@
       "issues": []
     },
     "basel-problem-oq-15": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "bernoulli-inequality-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T20:16:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -2644,9 +2644,9 @@
       "issues": []
     },
     "bezout-identity-oq-02-oq-01-oq-02-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-01-oq-03": {
@@ -2942,8 +2942,8 @@
       "result": "clean"
     },
     "binomial-theorem-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T16:58:19Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -4356,8 +4356,8 @@
       "result": "clean"
     },
     "cassini-identity-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T19:48:26Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -5638,9 +5638,9 @@
       "issues": []
     },
     "central-limit-theorem-oq-02-oq-04": {
-      "auditCount": 3,
-      "lastAudited": "2026-05-13T01:40:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
       "issues": []
     },
     "central-limit-theorem-oq-03": {
@@ -5904,9 +5904,9 @@
       "result": "clean"
     },
     "chebyshev-pnt-bridge-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-27T07:14:09Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "chebyshev-pnt-bridge-oq-05": {
@@ -5940,9 +5940,9 @@
       "issues": []
     },
     "chebyshev-polynomials-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T20:49:18Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
       "issues": []
     },
     "chebyshev-polynomials-oq-01-oq-01": {
@@ -6551,9 +6551,9 @@
       "issues": []
     },
     "compactness-finite-subcover-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "compactness-finite-subcover-oq-02-oq-02": {
@@ -8003,8 +8003,8 @@
       "issues": []
     },
     "eisenstein-criterion-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -8262,9 +8262,9 @@
       ]
     },
     "erdos-1-wip-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-08T20:14:27Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "erdos-1-wip-01-oq-02": {
@@ -8873,9 +8873,10 @@
     },
     "erdos-1018": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-06-02T13:15:49Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-1018-oq-01": {
       "auditCount": 1,
@@ -10692,9 +10693,9 @@
       "result": "clean"
     },
     "erdos-12": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:35Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "erdos-12-wip-01": {
@@ -11149,9 +11150,9 @@
       "result": "clean"
     },
     "erdos-152": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-18T20:56:51Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "erdos-152-oq-01": {
@@ -11181,9 +11182,9 @@
       "result": "clean"
     },
     "erdos-156": {
-      "auditCount": 10,
+      "auditCount": 11,
       "issues": [],
-      "lastAudited": "2026-06-28T17:38:16Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "erdos-157": {
@@ -12416,9 +12417,10 @@
     },
     "erdos-307": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:25Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-307-oq-02": {
       "auditCount": 3,
@@ -15159,8 +15161,8 @@
     },
     "erdos-634": {
       "agentId": "auditor-loop-1777752145",
-      "auditCount": 6,
-      "lastAudited": "2026-06-04T17:10:20Z",
+      "auditCount": 7,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": [
         "sorries claim 7 actual 1 (PR #14856 reduced 7\u21921 but meta.json not refreshed); lineCount 298\u2192332; assumptions string still says \"7 sorries\"; deeper concern: Dissection structure has placeholder area condition (line 93), so *_dissectable theorems use trivial constant-function witness \u2014 issue #14859",
@@ -15442,10 +15444,11 @@
     },
     "erdos-666": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-25T08:18:51Z",
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
-      "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14107"
+      "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14107",
+      "issues": []
     },
     "erdos-667": {
       "agentId": "auditor-cycle-20-batch",
@@ -16000,9 +16003,10 @@
     },
     "erdos-741": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-24T23:50:43Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-742": {
       "agentId": "auditor-cycle-20-batch",
@@ -16766,9 +16770,10 @@
     },
     "erdos-846": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:13:08Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-847": {
       "agentId": "auditor-cycle-20-batch",
@@ -18538,8 +18543,8 @@
       "issues": []
     },
     "fermat-defect-one": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-09T19:17:59Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -19043,10 +19048,10 @@
       "result": "clean"
     },
     "fourier-series-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-05T05:31:13Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean"
     },
     "fourier-series-oq-02-incomplete-01": {
       "auditCount": 5,
@@ -19109,8 +19114,8 @@
       "result": "clean"
     },
     "fourier-series-oq-04-wip-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T15:11:29Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -19133,8 +19138,8 @@
       "result": "clean"
     },
     "fourth-root-2-irrational-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T22:20:48Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -19696,10 +19701,10 @@
       "issues": []
     },
     "geometric-series-oq-04-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
       "result": "clean",
-      "lastAudited": "2026-07-01T12:19:41Z"
+      "lastAudited": "2026-07-08T05:49:40Z"
     },
     "geometric-series-oq-06": {
       "auditCount": 1,
@@ -20506,10 +20511,10 @@
       "issues": []
     },
     "hilbert-13-oq-04": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T17:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean"
     },
     "hilbert-14": {
       "agentId": "auditor-cycle-20-batch",
@@ -20590,8 +20595,8 @@
       "issues": []
     },
     "hilbert-17-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-01T01:39:30Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -20804,9 +20809,9 @@
       "result": "clean"
     },
     "hurwitz-theorem-oq-03-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-07T10:30:00Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "hurwitz-theorem-oq-03-oq-01-incomplete-01": {
@@ -20995,8 +21000,8 @@
       "result": "clean"
     },
     "integral-root-theorem-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -21067,10 +21072,10 @@
       "issues": []
     },
     "intermediate-value-theorem-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
       "result": "clean",
-      "lastAudited": "2026-07-01T12:19:41Z"
+      "lastAudited": "2026-07-08T05:49:40Z"
     },
     "inverse-galois": {
       "auditCount": 8,
@@ -21972,15 +21977,15 @@
       "issues": []
     },
     "law-of-cosines-oq-07-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T12:47:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
     "law-of-cosines-oq-07-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-25T00:30:00Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "law-of-cosines-oq-08": {
@@ -22238,9 +22243,9 @@
       "result": "clean"
     },
     "leibniz-pi-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-01T17:43:53Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "lhopital": {
@@ -22353,8 +22358,8 @@
       "issues": []
     },
     "little-wedderburn-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -22891,8 +22896,8 @@
       "issues": []
     },
     "minpoly-charpoly-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-05T04:51:13Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -24012,9 +24017,9 @@
     },
     "puiseux-theorem": {
       "agentId": "lean-auditor",
-      "auditCount": 4,
-      "lastAudited": "2026-07-08T05:12:03Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
       "issues": []
     },
     "puiseux-theorem-oq-01": {
@@ -24030,8 +24035,8 @@
       "issues": []
     },
     "puiseux-theorem-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T05:58:19Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -24073,9 +24078,10 @@
     },
     "pythagorean-triples-oq-01": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:20Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
+      "issues": []
     },
     "pythagorean-triples-oq-02": {
       "auditCount": 3,
@@ -24084,8 +24090,8 @@
       "result": "clean"
     },
     "pythagorean-triples-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T10:49:50Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -24120,8 +24126,8 @@
       "issues": []
     },
     "pythagorean-triples-oq-06": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -24416,12 +24422,12 @@
       "issues": []
     },
     "rh-consequences": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "axiomCount was 18 but Lean file has exactly 9 axiom declarations (assumptions field also enumerates 9); corrected meta.axiomCount and leanFile.axiomCount 18->9"
       ],
-      "lastAudited": "2026-07-08T05:36:57Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean"
     },
     "riemann-hypothesis": {
       "auditCount": 5,
@@ -24444,9 +24450,9 @@
       "result": "issues-fixed"
     },
     "roth-theorem-k3-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:10:01Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "roth-theorem-k3-oq-01-oq-01": {
@@ -24848,8 +24854,8 @@
       "result": "clean"
     },
     "simson-line-theorem-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-16T18:15:37Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -25713,9 +25719,9 @@
       "result": "clean"
     },
     "summation-by-parts-oq-01-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01": {
@@ -25725,9 +25731,9 @@
       "result": "clean"
     },
     "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01": {
@@ -25743,9 +25749,9 @@
       "result": "clean"
     },
     "summation-by-parts-oq-01-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "sylow-theorem": {
@@ -26038,9 +26044,9 @@
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-06-03T21:41:20Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-03-incomplete-01": {
@@ -26182,8 +26188,8 @@
       "result": "clean"
     },
     "triangle-angle-sum-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -26362,9 +26368,9 @@
       "issues": []
     },
     "urysohns-lemma-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "van-aubel-theorem-oq-01": {
@@ -26738,8 +26744,8 @@
       "result": "clean"
     },
     "zeckendorf-representation-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T23:40:32Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -26780,8 +26786,8 @@
       "issues": []
     },
     "buffons-noodle-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-01T18:11:04Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -26924,8 +26930,8 @@
       "issues": []
     },
     "angle-trisection-oq-03-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-01T22:34:45Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -27086,8 +27092,8 @@
       "issues": []
     },
     "frobenius-number-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-02T01:18:09Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean",
       "issues": []
     },
@@ -27200,15 +27206,15 @@
       "issues": []
     },
     "algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-08T04:29:16Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:49:40Z",
+      "result": "clean",
       "issues": []
     },
     "alternating-series-boole-summation-oq-01-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-08T04:59:24Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "alternating-series-boole-summation-oq-02": {
@@ -27272,9 +27278,9 @@
       "result": "clean"
     },
     "antitone-integral-sum-comparison-oq-01-oq-02-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-08T04:59:24Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "area-of-circle-oq-02-oq-03-oq-02": {
@@ -27326,9 +27332,9 @@
       "result": "clean"
     },
     "automorphic-number-oq-01-oq-02-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-08T04:59:24Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "ballot-problem-oq-05": {
@@ -27620,9 +27626,9 @@
       "result": "clean"
     },
     "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-08T04:59:24Z",
+      "lastAudited": "2026-07-08T05:49:40Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-01-oq-01": {
@@ -29547,5 +29553,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T05:36:57Z"
+  "lastUpdated": "2026-07-08T05:49:40Z"
 }


### PR DESCRIPTION
## Re-audit sweep (backlog = 0)

All 4775 gallery proofs are audited, so this sweep re-audited proofs whose `meta.json` changed **after** their recorded `lastAudited` timestamp — i.e. merges since ~2026-07-05.

### Scope
77 proofs re-audited (existing tracker entries bumped: `auditCount`, `lastAudited`, `result: clean`).

### Method
Mechanical integrity check on each: `meta.status`/`badge` vs actual sorry count, `axiom` declarations, `True`-stubs, and `native_decide`/`ofReduceBool` usage — cross-checking both the nested `meta.*` block and the `leanFile.*` block.

### Findings: all clean
Three proofs tripped the `native_decide`/`ofReduceBool` heuristic; all verified as **false positives**:
- `angle-trisection-oq-03-oq-02-oq-03` — 7 `native_decide` hits are all illustrative `example :` sanity checks, not in the theorem chain.
- `ballot-problem-oq-04-oq-02-oq-01` — sole hit is a doc comment noting the `n ≤ 3` corollary uses kernel `decide` (not `native_decide`); file documents "no Lean.ofReduceBool".
- `hilbert-17-oq-01-oq-01-oq-01` — sole `ofReduceBool` hit is a comment stating the axiom footprint is only propext/Classical.choice/Quot.sound.

### Note
6 slugs surfaced by git history (`amgm-inequality-oq-02-oq-03-oq-03-oq-02`, `erdos-1207-oq-04`, `fundamental-theorem-algebra-oq-04-oq-02`, `inverse-galois-oq-04-oq-02`, `inverse-galois-oq-06-oq-02-oq-01`, `lagrange-theorem-oq-02-...`, `shannon-channel-coding-bec-oq-03`) have no on-disk directory (cleanly removed in #34796) and are referenced by no listing — not integrity issues, skipped.

Only `src/data/proofs/audit-tracker.json` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)