### PR TITLE
research(erdos-360): repair broken build + prove f(2)=1, f(4)=2 [0 sorries]

### DIFF
--- a/proofs/Proofs/Erdos360Problem.lean
+++ b/proofs/Proofs/Erdos360Problem.lean
@@ -17,8 +17,10 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.NumberTheory.Divisors
 import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Nat.Nth
 
 namespace Erdos360
 
@@ -100,8 +102,8 @@ axiom conlon_fox_pham_2021 :
   ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧
   ∀ n : ℕ, n ≥ 10 →
     let φn := Nat.totient n
-    c₁ * (n : ℝ)^(1/3 : ℝ) * (n / φn) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) ≤ f n ∧
-    (f n : ℝ) ≤ c₂ * (n : ℝ)^(1/3 : ℝ) * (n / φn) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ))
+    c₁ * (n : ℝ)^(1/3 : ℝ) * ((n : ℝ) / (φn : ℝ)) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) ≤ f n ∧
+    (f n : ℝ) ≤ c₂ * (n : ℝ)^(1/3 : ℝ) * ((n : ℝ) / (φn : ℝ)) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ))
 
 /-
 ## Key Observations
@@ -122,15 +124,13 @@ because arithmetic progressions with common factors create more sum constraints.
 /-- For prime n, φ(n) = n - 1, so n/φ(n) ≈ 1. -/
 theorem prime_totient_ratio (p : ℕ) (hp : Nat.Prime p) :
     (p : ℚ) / Nat.totient p = p / (p - 1) := by
-  rw [Nat.Prime.totient_eq_pred hp]
-  ring_nf
-  simp
+  rw [Nat.totient_prime hp, Nat.cast_sub hp.one_lt.le, Nat.cast_one]
 
 /-- For highly composite n, n/φ(n) can be large (like log log n for primorials). -/
 axiom primorial_totient_ratio :
   ∀ k : ℕ, k ≥ 2 →
-    let n := (Finset.range k).prod (fun i => Nat.nth Nat.Prime i)
-    (n : ℝ) / Nat.totient n ≥ Real.log (Real.log k)
+    let n : ℕ := (Finset.range k).prod (fun i => Nat.nth Nat.Prime i)
+    (n : ℝ) / (Nat.totient n : ℝ) ≥ Real.log (Real.log k)
 
 /-
 ## Small Cases
@@ -140,11 +140,147 @@ For small n, we can compute f(n) directly.
 
 /-- f(2) = 1: {1} is already 2-sum-free (can't sum to 2 with one element). -/
 theorem f_2 : f 2 = 1 := by
-  sorry -- Requires showing {1} is 2-sum-free and optimal
+  -- `1` is achievable: the single class `{1}`.
+  have hmem1 : (1 : ℕ) ∈ ValidPartitionSizes 2 := by
+    refine ⟨{{1}}, Finset.card_singleton _, ?_, ?_, ?_, ?_⟩
+    · -- every element of every class lies in {1,...,1}
+      intro P hP x hx
+      rw [Finset.mem_singleton] at hP
+      subst hP
+      rw [Finset.mem_singleton] at hx
+      subst hx
+      omega
+    · -- classes are pairwise disjoint (there is only one)
+      intro P Q hP hQ hPQ
+      rw [Finset.mem_singleton] at hP hQ
+      subst hP; subst hQ
+      exact absurd rfl hPQ
+    · -- coverage of {1,...,1}
+      intro x hx1 hx2
+      interval_cases x
+      exact ⟨{1}, Finset.mem_singleton_self _, Finset.mem_singleton_self _⟩
+    · -- each class is 2-sum-free
+      intro P hP
+      rw [Finset.mem_singleton] at hP
+      subst hP
+      intro T hT
+      have hb : T.sum id ≤ ({1} : Finset ℕ).sum id :=
+        Finset.sum_le_sum_of_subset (f := id) hT
+      have hval : ({1} : Finset ℕ).sum id = 1 := by simp
+      omega
+  -- `0` is not achievable: the empty partition cannot cover `1`.
+  have hmem0 : (0 : ℕ) ∉ ValidPartitionSizes 2 := by
+    rintro ⟨parts, hcard, _, _, hcov, _⟩
+    rw [Finset.card_eq_zero] at hcard
+    subst hcard
+    obtain ⟨P, hP, _⟩ := hcov 1 (by norm_num) (by norm_num)
+    exact absurd hP (Finset.notMem_empty P)
+  -- The infimum of a set of naturals containing `1` but not `0` is `1`.
+  have hle : sInf (ValidPartitionSizes 2) ≤ 1 := Nat.sInf_le hmem1
+  have hmem : sInf (ValidPartitionSizes 2) ∈ ValidPartitionSizes 2 :=
+    Nat.sInf_mem ⟨1, hmem1⟩
+  have hne0 : sInf (ValidPartitionSizes 2) ≠ 0 := fun h => hmem0 (h ▸ hmem)
+  show sInf (ValidPartitionSizes 2) = 1
+  omega
 
 /-- f(4) = 2: Need 2 classes because {1,3} sums to 4. -/
 theorem f_4 : f 4 = 2 := by
-  sorry -- Partition into {1, 2} and {3}, for example
+  -- `2` is achievable: the partition `{{1,2}, {3}}`.
+  -- `{1,2}` and `{3}` are distinct, so the partition has two classes.
+  have hne12 : ({1, 2} : Finset ℕ) ≠ ({3} : Finset ℕ) := by
+    intro h
+    have h2 : (2 : ℕ) ∈ ({3} : Finset ℕ) :=
+      h ▸ Finset.mem_insert_of_mem (Finset.mem_singleton_self 2)
+    rw [Finset.mem_singleton] at h2
+    exact absurd h2 (by norm_num)
+  have hmem2 : (2 : ℕ) ∈ ValidPartitionSizes 4 := by
+    refine ⟨{{1, 2}, {3}}, ?_, ?_, ?_, ?_, ?_⟩
+    · -- the two classes are distinct, so the cardinality is 2
+      rw [Finset.card_insert_of_notMem (by rw [Finset.mem_singleton]; exact hne12),
+        Finset.card_singleton]
+    · -- membership bounds
+      intro P hP x hx
+      rw [Finset.mem_insert, Finset.mem_singleton] at hP
+      rcases hP with rfl | rfl
+      · rw [Finset.mem_insert, Finset.mem_singleton] at hx
+        rcases hx with rfl | rfl <;> omega
+      · rw [Finset.mem_singleton] at hx
+        subst hx
+        omega
+    · -- pairwise disjointness
+      intro P Q hP hQ hPQ
+      rw [Finset.mem_insert, Finset.mem_singleton] at hP hQ
+      rcases hP with rfl | rfl <;> rcases hQ with rfl | rfl
+      · exact absurd rfl hPQ
+      · rw [Finset.disjoint_left]
+        intro a ha
+        rw [Finset.mem_insert, Finset.mem_singleton] at ha
+        rcases ha with rfl | rfl <;> simp
+      · rw [Finset.disjoint_left]
+        intro a ha
+        rw [Finset.mem_singleton] at ha
+        subst ha
+        simp
+      · exact absurd rfl hPQ
+    · -- coverage of {1,2,3}
+      intro x hx1 hx2
+      interval_cases x
+      · exact ⟨{1, 2}, Finset.mem_insert_self _ _, Finset.mem_insert_self _ _⟩
+      · exact ⟨{1, 2}, Finset.mem_insert_self _ _,
+          Finset.mem_insert_of_mem (Finset.mem_singleton_self _)⟩
+      · exact ⟨{3}, Finset.mem_insert_of_mem (Finset.mem_singleton_self _),
+          Finset.mem_singleton_self _⟩
+    · -- each class is 4-sum-free (max subset sum is 3)
+      intro P hP
+      rw [Finset.mem_insert, Finset.mem_singleton] at hP
+      rcases hP with rfl | rfl
+      · intro T hT
+        have hb : T.sum id ≤ ({1, 2} : Finset ℕ).sum id :=
+          Finset.sum_le_sum_of_subset (f := id) hT
+        have hval : ({1, 2} : Finset ℕ).sum id = 3 := by
+          rw [Finset.sum_pair (by norm_num : (1 : ℕ) ≠ 2)]; norm_num
+        omega
+      · intro T hT
+        have hb : T.sum id ≤ ({3} : Finset ℕ).sum id :=
+          Finset.sum_le_sum_of_subset (f := id) hT
+        have hval : ({3} : Finset ℕ).sum id = 3 := by simp
+        omega
+  -- `0` is not achievable: the empty partition cannot cover `1`.
+  have hmem0 : (0 : ℕ) ∉ ValidPartitionSizes 4 := by
+    rintro ⟨parts, hcard, _, _, hcov, _⟩
+    rw [Finset.card_eq_zero] at hcard
+    subst hcard
+    obtain ⟨P, hP, _⟩ := hcov 1 (by norm_num) (by norm_num)
+    exact absurd hP (Finset.notMem_empty P)
+  -- `1` is not achievable: a single class covering {1,2,3} contains {1,3} → 4.
+  have hmem1 : (1 : ℕ) ∉ ValidPartitionSizes 4 := by
+    rintro ⟨parts, hcard, _, _, hcov, hsf⟩
+    rw [Finset.card_eq_one] at hcard
+    obtain ⟨P, hPeq⟩ := hcard
+    subst hPeq
+    obtain ⟨Q1, hQ1, h1P⟩ := hcov 1 (by norm_num) (by norm_num)
+    obtain ⟨Q3, hQ3, h3P⟩ := hcov 3 (by norm_num) (by norm_num)
+    rw [Finset.mem_singleton] at hQ1 hQ3
+    rw [hQ1] at h1P
+    rw [hQ3] at h3P
+    have hfree : IsNSumFree 4 P := hsf P (Finset.mem_singleton_self P)
+    have hsub : ({1, 3} : Finset ℕ) ⊆ P := by
+      intro x hx
+      rw [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl
+      · exact h1P
+      · exact h3P
+    have hval : ({1, 3} : Finset ℕ).sum id = 4 := by
+      rw [Finset.sum_pair (by norm_num : (1 : ℕ) ≠ 3)]; norm_num
+    exact hfree {1, 3} hsub hval
+  -- The infimum of a set containing `2` but not `0` or `1` is `2`.
+  have hle : sInf (ValidPartitionSizes 4) ≤ 2 := Nat.sInf_le hmem2
+  have hmem : sInf (ValidPartitionSizes 4) ∈ ValidPartitionSizes 4 :=
+    Nat.sInf_mem ⟨2, hmem2⟩
+  have hne0 : sInf (ValidPartitionSizes 4) ≠ 0 := fun h => hmem0 (h ▸ hmem)
+  have hne1 : sInf (ValidPartitionSizes 4) ≠ 1 := fun h => hmem1 (h ▸ hmem)
+  show sInf (ValidPartitionSizes 4) = 2
+  omega
 
 /-
 ## Connection to Subset Sums and Ramsey Theory
@@ -163,8 +299,8 @@ theorem erdos_360_solved :
     ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧
     ∀ n : ℕ, n ≥ 10 →
       let φn := Nat.totient n
-      c₁ * (n : ℝ)^(1/3 : ℝ) * (n / φn) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) ≤ f n ∧
-      (f n : ℝ) ≤ c₂ * (n : ℝ)^(1/3 : ℝ) * (n / φn) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) :=
+      c₁ * (n : ℝ)^(1/3 : ℝ) * ((n : ℝ) / (φn : ℝ)) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) ≤ f n ∧
+      (f n : ℝ) ≤ c₂ * (n : ℝ)^(1/3 : ℝ) * ((n : ℝ) / (φn : ℝ)) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) :=
   conlon_fox_pham_2021
 
 end Erdos360

--- a/research/problems/erdos-360-incomplete-01/state.md
+++ b/research/problems/erdos-360-incomplete-01/state.md
@@ -1,25 +1,45 @@
 # Research State: erdos-360-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-07-05T04:41:31-07:00
-**Iteration**: 1
+**Since**: 2026-07-07T22:00:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Done. Both remaining sorries in the small-cases section (f(2)=1, f(4)=2) are
+discharged and the previously-broken main file now compiles.
 
 ## Active Approach
-None yet.
+Direct computation via the `sInf (ValidPartitionSizes n)` characterization:
+exhibit a witness partition of the target size, prove smaller sizes are
+unachievable (obstruction), then `Nat.sInf_le` + `Nat.sInf_mem` pin the value.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+None. (Session-level: mathlib docker cache blob for
+`Mathlib.Algebra.Order.Positive.Ring` was transiently corrupted, forcing a
+from-source rebuild → OOM; recovered by `docker volume rm lean-mathlib-cache`.)
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None required — problem complete. Entry remains `axiomatized` because the
+growth-rate result (Alon-Erdős / Vu / Conlon-Fox-Pham) is stated via 4 axioms;
+the two small cases are now machine-verified.
+
+## Session 2 — researcher-4, 2026-07-07 (COMPLETED)
+
+- Discovered the "incomplete-01" masked a fully-broken build: main file never
+  compiled on `main` (missing `Mathlib.Analysis.SpecialFunctions.Pow.Real`
+  import for `n^(1/3:ℝ)`, a `Nat.totient` coercion bug in an untyped
+  `let n := …`, a removed lemma `Nat.Prime.totient_eq_pred`, and a missing
+  `Mathlib.Data.Nat.Nth` import).
+- Repaired the build and proved both remaining sorries:
+  - `f_2 : f 2 = 1`
+  - `f_4 : f 4 = 2`
+- `./proofs/scripts/docker-build.sh Proofs.Erdos360Problem` → 0 sorries, builds.
+- Updated `src/data/proofs/erdos-360/meta.json` (sorries 2→0, lineCount 170→306,
+  imports, section boundaries).

--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 360,
     "erdosUrl": "https://erdosproblems.com/360",
     "erdosProblemStatus": "solved",
@@ -58,8 +58,8 @@
       "erdos_360_solved theorem: main result"
     ],
     "axiomCount": 8,
-    "lineCount": 170,
-    "assumptions": "8 axiom(s) and 2 sorry(s). See the Lean source for details.",
+    "lineCount": 306,
+    "assumptions": "4 axiom(s) in the main file (historical results of Alon-Erdős, Vu, and Conlon-Fox-Pham stated as assumptions; 8 aggregate across companion files) and 0 sorry(s) in the main proof file. The small cases f(2)=1 and f(4)=2 are now fully machine-checked. See the Lean source for details.",
     "theoremCount": 4,
     "definitionCount": 4,
     "additionalFiles": [
@@ -130,25 +130,25 @@
     {
       "id": "small-cases",
       "title": "Small Cases",
-      "summary": "Computing f(2), f(3), f(4) directly",
+      "summary": "Computing f(2)=1 and f(4)=2 directly (both now machine-verified)",
       "startLine": 135,
-      "endLine": 153,
-      "mathContext": "Mathematical content: Computing f(2), f(3), f(4) directly"
+      "endLine": 284,
+      "mathContext": "Verified: f(2)=1 and f(4)=2 proved from first principles via the sInf characterization of f"
     },
     {
       "id": "connections",
       "title": "Connections to Related Problems",
       "summary": "Links to sum-free sets, Schur numbers, complete sequences",
-      "startLine": 154,
-      "endLine": 165,
+      "startLine": 285,
+      "endLine": 296,
       "mathContext": "Mathematical content: Links to sum-free sets, Schur numbers, complete sequences"
     },
     {
       "id": "main-result",
       "title": "Main Result",
       "summary": "erdos_360_solved theorem showing problem is resolved",
-      "startLine": 166,
-      "endLine": 170,
+      "startLine": 297,
+      "endLine": 306,
       "mathContext": "Verified: erdos_360_solved theorem showing problem is resolved"
     }
   ],
@@ -170,17 +170,19 @@
       "Mathlib.Data.Set.Basic",
       "Mathlib.Data.Real.Basic",
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
       "Mathlib.NumberTheory.Divisors",
-      "Mathlib.Data.Nat.Totient"
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.Data.Nat.Nth"
     ],
     "opens": [],
     "namespace": "Erdos360",
-    "lineCount": 170,
+    "lineCount": 306,
     "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 4,
     "path": "Proofs/Erdos360Problem.lean",
-    "sorries": 2,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos360Aristotle.lean",
       "Proofs/Stubs/Erdos360Aristotle.lean",
@@ -204,5 +206,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, partition, ramsey-theory"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }

--- a/src/data/research/problems/erdos-360-incomplete-01.json
+++ b/src/data/research/problems/erdos-360-incomplete-01.json
@@ -29,11 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "COMPLETE: broken-build repair + both remaining sorries discharged. Erdos360Problem.lean now builds (0 sorries); f(2)=1 and f(4)=2 machine-verified.",
+    "builtItems": [
+      "f_2 : f 2 = 1  (Proofs/Erdos360Problem.lean:142) — machine-verified, 0 sorries",
+      "f_4 : f 4 = 2  (Proofs/Erdos360Problem.lean:187) — machine-verified, 0 sorries",
+      "Build repair: added imports Pow.Real + Nat.Nth; fixed prime_totient_ratio to use Nat.totient_prime (Nat.Prime.totient_eq_pred was removed in v4.26); pinned let n : ℕ in primorial_totient_ratio; explicit ℝ casts on (n/φn)."
+    ],
+    "insights": [
+      "The main file was BROKEN on main (never compiled): missing import Mathlib.Analysis.SpecialFunctions.Pow.Real for rpow (n^(1/3:ℝ)), plus a Nat.totient coercion bug in an untyped let-binding. incomplete-01 stubs masked a fully-broken build.",
+      "f(n)=sInf(ValidPartitionSizes n): to pin f(n)=k prove k ∈ ValidPartitionSizes (exhibit a witness partition), then k-1,...,0 ∉ (obstruction), then Nat.sInf_le + Nat.sInf_mem give the value with a single omega on the opaque atom.",
+      "f(4)=2 lower bound: any single class covering {1,2,3} contains the subset {1,3} which sums to 4, so it is not 4-sum-free; hence 1 ∉ ValidPartitionSizes 4 (via Finset.card_eq_one).",
+      "IsNSumFree bound: for a finite class C, every subset T ⊆ C has T.sum id ≤ C.sum id (Finset.sum_le_sum_of_subset over ℕ), so a class with small total sum is automatically n-sum-free for n above that total."
+    ],
+    "mathlibGaps": [
+      "Mathlib v4.26 removed Nat.Prime.totient_eq_pred; use Nat.totient_prime : p.Prime → p.totient = p - 1 instead.",
+      "Finset.card_insert_of_not_mem and Finset.not_mem_empty are deprecated in v4.26 → card_insert_of_notMem, notMem_empty."
+    ],
+    "nextSteps": [
+      "Optional: prove f(3)=1 as an additional small case (documented but not formalized).",
+      "The main growth-rate result remains axiomatized (Alon-Erdős/Vu/Conlon-Fox-Pham); a genuine formalization of even the cube-root lower bound would be a large project."
+    ],
     "markdown": "# Knowledge Base: erdos-360-incomplete-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],


### PR DESCRIPTION
## Summary

The **erdos-360** main file (`Proofs/Erdos360Problem.lean`) never compiled on `main` — the `erdos-360-incomplete-01` stub masked a fully broken build. This PR repairs the build and discharges both remaining `sorry`s in the small-cases section.

## Build repairs (Mathlib v4.26)
- **Missing rpow import**: added `Mathlib.Analysis.SpecialFunctions.Pow.Real` — `n^(1/3 : ℝ)` in the axiom statements had no `HPow ℝ ℝ ℝ` instance in scope, so elaboration failed.
- **Missing `Nat.nth`**: added `Mathlib.Data.Nat.Nth`.
- **Removed lemma**: `Nat.Prime.totient_eq_pred` no longer exists → `prime_totient_ratio` now uses `Nat.totient_prime` + `Nat.cast_sub`.
- **Coercion bug**: `primorial_totient_ratio` had an untyped `let n := …` causing `Nat.totient n` to receive a coerced `ℝ` argument → pinned `let n : ℕ := …` and cast explicitly.
- Explicit `ℝ` casts on `(n/φn)`; refreshed deprecated `Finset.card_insert_of_notMem` / `notMem_empty`.

## Proofs (machine-checked, 0 sorries)
- `f_2 : f 2 = 1` — the single class `{1}` is a valid 2-sum-free partition, and size `0` cannot cover the element `1`.
- `f_4 : f 4 = 2` — the partition `{{1,2}, {3}}` works (both classes 4-sum-free: subset sums ≤ 3), while sizes `0` and `1` are impossible (a single class covering `{1,2,3}` contains `{1,3}`, which sums to `4`).

Both proofs use only Mathlib (`Finset`, `Nat.sInf`); they do not depend on the entry's axioms.

## Status
Entry remains **`axiomatized`** — the growth-rate result (Alon-Erdős / Vu / Conlon-Fox-Pham) is stated via 4 axioms; only the two small cases are formalized. Updated `meta.json` (sorries 2→0, lineCount 170→306, imports, section boundaries).

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos360Problem` → `✔ Built Proofs.Erdos360Problem`, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)