### PR TITLE
Enrich Schur-Convexity of Collision Probability: link quantitative-bias sibling

### DIFF
--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -116,6 +116,11 @@
       "targetId": "birthday-problem-oq-02-oq-01-oq-02",
       "relationship": "related",
       "description": "Grandparent: the lower bound 1/d ≤ ∑ pᵢ² (uniform minimizes collision), recovered here as a corollary of the global inequality."
+    },
+    {
+      "targetId": "birthday-problem-oq-02-oq-01-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Sibling under the same grandparent: the QUANTITATIVE complement to this entry's qualitative Schur-convexity. Where this entry shows uniform is the HLP-bottom of the majorization order (∑ pᵢ² minimized at 1/d), that entry sharpens the gap into a Pinsker-flavored bound ∑ pᵢ² − 1/d ≥ (4/d)·dTV(p,u)², measuring exactly how much distance-from-uniform raises collision. Together: averaging toward uniform decreases collision (here), and quantifiably so (there)."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01` (quality 94, 0 passes).

The entry is already thorough (5 annotations, 4 keyInsights, 3 sections, accurate references, deep overview/conclusion). Gap: `crossReferences` linked only parent + grandparent, but the entry's theme (uniform is the majorization-bottom minimizer of collision) has an exact **quantitative sibling** under the same grandparent that was unlinked.

Added `birthday-problem-oq-02-oq-01-oq-02-oq-02` — the Pinsker-flavored bound `∑pᵢ² − 1/d ≥ (4/d)·dTV(p,u)²`. This entry proves *qualitatively* that averaging toward uniform decreases collision (Schur-convexity); the sibling proves *quantitatively* how far bias raises it. A natural complementary pair.

Target verified present; `pnpm build` passes; meta.json 12.0 KB.