### PR TITLE
research(roth-theorem-oq-01): derive rothNumberNat N = o(N) from the explicit Bourgain bound [VERIFIED — 0 sorry, 0 new axiom]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ01.lean
@@ -248,6 +248,65 @@ theorem rothNumberNat_le_min_bourgain_blasi (N : ℕ) (hN : 3 ≤ N) :
           ((N : ℝ) / Real.log N ^ (1 + RothTheoremOQ02.blasiConst)) :=
   le_min (rothNumberNat_le_bourgain N hN) (RothTheoremOQ02.rothNumberNat_le_blasi N hN)
 
+/-- **The Bourgain density factor `(log log N / log N)^{1/2}` tends to `0`.**
+This is the analytic heart of "explicit rate ⟹ `o(N)`": `log log N / log N → 0`
+because `log =o[atTop] id` (so `log u / u → 0`, applied at `u = log N → ∞`), and the
+continuous `·^{1/2}` map carries the limit `0 ↦ 0`.  Axiom-free (uses only Mathlib's
+`Real.isLittleO_log_id_atTop`). -/
+theorem bourgain_factor_tendsto_zero :
+    Filter.Tendsto
+      (fun N : ℕ => (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2))
+      Filter.atTop (nhds 0) := by
+  -- `log u / u → 0` as `u → ∞`, from `log =o[atTop] id`.
+  have hbase : Filter.Tendsto (fun u : ℝ => Real.log u / u) Filter.atTop (nhds 0) := by
+    simpa using Real.isLittleO_log_id_atTop.tendsto_div_nhds_zero
+  -- `log N → ∞` as `N → ∞` (over ℕ).
+  have hlogN : Filter.Tendsto (fun N : ℕ => Real.log N) Filter.atTop Filter.atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  -- compose: `log (log N) / log N → 0`.
+  have hratio : Filter.Tendsto
+      (fun N : ℕ => Real.log (Real.log N) / Real.log N) Filter.atTop (nhds 0) :=
+    hbase.comp hlogN
+  -- `√·` is continuous and sends `0 ↦ 0`; `√x = x ^ (1/2)`.
+  have hsqrt : Filter.Tendsto
+      (fun N : ℕ => Real.sqrt (Real.log (Real.log N) / Real.log N))
+      Filter.atTop (nhds 0) := by
+    have := (Real.continuous_sqrt.tendsto 0).comp hratio
+    simpa [Real.sqrt_zero] using this
+  exact hsqrt.congr (fun N => Real.sqrt_eq_rpow _)
+
+/-- **Bourgain's explicit bound recovers the qualitative Roth theorem — derived, not
+re-exported.**  From `rothNumberNat N ≤ C · N · (log log N / log N)^{1/2}` with the density
+factor tending to `0`, we obtain `rothNumberNat N = o(N)` directly.  Unlike
+`bourgain_consistent_with_isLittleO` (which merely re-exports Mathlib's independent
+`rothNumberNat_isLittleO_id`), this theorem *proves* the little-o statement **from the
+quantitative Bourgain bound**, so it certifies that the explicit rate is genuinely strong
+enough to yield `o(N)`. -/
+theorem rothNumberNat_isLittleO_of_bourgain :
+    Asymptotics.IsLittleO Filter.atTop
+      (fun N : ℕ => (rothNumberNat N : ℝ)) (fun N : ℕ => (N : ℝ)) := by
+  rw [Asymptotics.isLittleO_iff]
+  intro ε hε
+  -- `bourgainConst · (factor N) → 0`, so eventually it is `< ε`.
+  have hfac : Filter.Tendsto
+      (fun N : ℕ => bourgainConst *
+        (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2))
+      Filter.atTop (nhds 0) := by
+    simpa using bourgain_factor_tendsto_zero.const_mul bourgainConst
+  have hev : ∀ᶠ N : ℕ in Filter.atTop,
+      bourgainConst * (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2) < ε := by
+    have hmem : Set.Iio ε ∈ nhds (0 : ℝ) := Iio_mem_nhds hε
+    simpa [Set.mem_Iio] using hfac.eventually hmem
+  filter_upwards [hev, Filter.eventually_ge_atTop 3] with N hbound hN3
+  rw [Real.norm_eq_abs, Real.norm_eq_abs, Nat.abs_cast, Nat.abs_cast]
+  calc (rothNumberNat N : ℝ)
+      ≤ bourgainConst * (N : ℝ) *
+          (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2) :=
+        rothNumberNat_le_bourgain N hN3
+    _ = (bourgainConst *
+          (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2)) * (N : ℝ) := by ring
+    _ ≤ ε * (N : ℝ) := mul_le_mul_of_nonneg_right hbound.le (Nat.cast_nonneg N)
+
 #check rothNumberNat_bourgain
 #check bourgainConst
 #check bourgainConst_pos
@@ -255,6 +314,8 @@ theorem rothNumberNat_le_min_bourgain_blasi (N : ℕ) (hN : 3 ≤ N) :
 #check bourgain_consistent_with_isLittleO
 #check bourgain_consistent_with_Behrend
 #check rothNumberNat_le_min_bourgain_blasi
+#check bourgain_factor_tendsto_zero
+#check rothNumberNat_isLittleO_of_bourgain
 
 -- Axiom audit: `rothNumberNat_bourgain` is now a THEOREM.  Its only non-foundational
 -- dependency is the imported `RothTheoremOQ02.rothNumberNat_bloom_sisask` — there is NO

--- a/research/problems/roth-theorem-oq-01/knowledge.md
+++ b/research/problems/roth-theorem-oq-01/knowledge.md
@@ -4,6 +4,47 @@ Insights accumulated during research on this problem.
 
 ---
 
+## Session 2026-07-07 (researcher-2) — ACT: explicit bound ⟹ o(N), derived not re-exported
+
+**Mode**: REVISIT (add verified content). The from-scratch Bourgain/Bloom–Sisask proof stays
+BLOCKED (>1000 LOC Bohr-set/Fourier infra not in Mathlib v4.26), and the axiom count is already
+minimal (0 own axioms; rests on the single imported OQ-02 Bloom–Sisask axiom). The realistic
+deliverable was to upgrade the weakest link: `bourgain_consistent_with_isLittleO` merely
+**re-exported** Mathlib's independent `rothNumberNat_isLittleO_id` — it did NOT show the
+*explicit* Bourgain rate actually yields `o(N)`.
+
+**Outcome**: COMPLETED this deliverable (machine-verified, `docker-build.sh Proofs.RothTheoremOQ01`
+→ `=== Build succeeded ===`, first try). Added **2 theorems** (7→9), file 264→325 L, still
+0 own axioms / 0 sorries:
+- **`bourgain_factor_tendsto_zero`** (axiom-free): `(log log N/log N)^(1/2) → 0`. Proof chain:
+  `Real.isLittleO_log_id_atTop.tendsto_div_nhds_zero` gives `log u/u → 0` (real atTop); compose
+  with `Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop` (`log N → ∞` over ℕ) to get
+  `log(log N)/log N → 0`; then push through `·^(1/2)` via `Real.sqrt` (`Real.continuous_sqrt.tendsto 0`,
+  `Real.sqrt_zero`) and convert back with `hsqrt.congr (fun N => Real.sqrt_eq_rpow _)`.
+- **`rothNumberNat_isLittleO_of_bourgain`**: `rothNumberNat N = o(N)` DERIVED from the Bourgain
+  bound. `Asymptotics.isLittleO_iff`; for ε>0, `bourgainConst · factor → 0` so eventually `< ε`
+  (`hfac.eventually (Iio_mem_nhds hε)`); `filter_upwards` with `eventually_ge_atTop 3`; clear
+  norms with `Real.norm_eq_abs` + `Nat.abs_cast`; `calc` through `rothNumberNat_le_bourgain` then
+  `mul_le_mul_of_nonneg_right`.
+
+### Lean gotchas (v4.26)
+- **`Real.continuousAt_rpow_const` does NOT exist** (Unknown constant). Route `y^(1/2)` through
+  `Real.sqrt` instead: `Real.sqrt_eq_rpow x : √x = x^(1/2:ℝ)` (unconditional) + `Real.continuous_sqrt`.
+- `Filter.Tendsto.eventually_lt_const` is unreliable; use `hfac.eventually (Iio_mem_nhds hε)` +
+  `simpa [Set.mem_Iio]` to get eventual `< ε` from a `nhds 0` limit.
+- `Real.norm_eq_abs` then `Nat.abs_cast` clears `‖(n:ℝ)‖` for a ℕ-cast (both `rothNumberNat N`
+  and `N`); `mul_le_mul_of_nonneg_right ... (Nat.cast_nonneg N)`.
+- Build-host note: same corrupt-cache/OOM-under-contention flakiness as elsewhere — plain retries
+  self-heal (each auto-purges + re-fetches the bad `.ltar`/`.ir`); this session built first try.
+
+### Honest status
+Still **axiomatized** — the presented Bourgain bound rests on the imported Bloom–Sisask axiom;
+`rothNumberNat_isLittleO_of_bourgain` inherits that single assumption (via `rothNumberNat_le_bourgain`),
+while `bourgain_factor_tendsto_zero` is fully axiom-free. No new axioms. The genuine remaining
+open work (a from-scratch quantitative proof) is unchanged and BLOCKED.
+
+---
+
 ## Problem Understanding
 
 Target: a **quantitative** upper bound on the Roth number `r₃(N)` (largest 3-AP-free subset

--- a/src/data/proofs/roth-theorem-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-oq-01/meta.json
@@ -20,18 +20,20 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "assumptions": "This entry bundles two files and ships two axioms total. Main file Proofs/RothTheoremOQ01.lean declares 0 axioms of its own and 0 sorries; every one of its 7 theorems is machine-checked. Its presented result `rothNumberNat_bourgain` rests on exactly one assumption: `RothTheoremOQ02.rothNumberNat_bloom_sisask` (Bloom–Sisask 2020 logarithmic-barrier bound rothNumberNat N ≤ N/(log N)^(1+c), arXiv:2007.03528), imported from the companion file Proofs/RothTheoremOQ02.lean and used to derive the weaker Bourgain bound by rpow monotonicity. The companion file additionally declares a second axiom `rothNumberNat_kelley_meka` (Kelley–Meka 2023, quasi-polynomial bound); it is NOT in the dependency chain of the main Bourgain result, but it IS used by the companion's own theorems `rothNumberNat_le_kelley_meka`, `kelley_meka_consistent_with_Behrend`, and `rothNumberNat_le_min_blasi_kelley_meka`, so it counts as an assumption the entry carries. Both axioms encode state-of-the-art quantitative refinements requiring Bohr-set / density-increment infrastructure not yet in Mathlib v4.26.0. The former standalone `axiom rothNumberNat_bourgain` has been eliminated: Bourgain is now a derived theorem.",
+    "assumptions": "This entry bundles two files and ships two axioms total. Main file Proofs/RothTheoremOQ01.lean declares 0 axioms of its own and 0 sorries; every one of its 9 theorems is machine-checked (including the axiom-free `bourgain_factor_tendsto_zero`). Its presented result `rothNumberNat_bourgain` rests on exactly one assumption: `RothTheoremOQ02.rothNumberNat_bloom_sisask` (Bloom–Sisask 2020 logarithmic-barrier bound rothNumberNat N ≤ N/(log N)^(1+c), arXiv:2007.03528), imported from the companion file Proofs/RothTheoremOQ02.lean and used to derive the weaker Bourgain bound by rpow monotonicity. The companion file additionally declares a second axiom `rothNumberNat_kelley_meka` (Kelley–Meka 2023, quasi-polynomial bound); it is NOT in the dependency chain of the main Bourgain result, but it IS used by the companion's own theorems `rothNumberNat_le_kelley_meka`, `kelley_meka_consistent_with_Behrend`, and `rothNumberNat_le_min_blasi_kelley_meka`, so it counts as an assumption the entry carries. Both axioms encode state-of-the-art quantitative refinements requiring Bohr-set / density-increment infrastructure not yet in Mathlib v4.26.0. The former standalone `axiom rothNumberNat_bourgain` has been eliminated: Bourgain is now a derived theorem.",
     "originalContributions": [
       "rothNumberNat_bourgain: Bourgain's 1999 bound ∃ C > 0, ∀ N ≥ 3, rothNumberNat N ≤ C·N·(log log N/log N)^(1/2), derived (not axiomatized) from the imported Bloom–Sisask bound",
       "Explicit analytic reduction Bloom–Sisask ⟹ Bourgain: cancel N, split L^(1+c) = L^(1/2)·L^(1/2+c) via Real.rpow_add and (LL/L)^(1/2) = LL^(1/2)/L^(1/2) via Real.div_rpow, then close by base-monotonicity (Real.rpow_le_rpow) reading the constant C = 1/(B·E) off the N = 3 endpoint",
       "bourgainConst / bourgainConst_pos / rothNumberNat_le_bourgain: a stable downstream API hiding the Exists.choose extraction of the constant",
       "bourgain_consistent_with_isLittleO: consistency with Mathlib's unconditional qualitative rothNumberNat_isLittleO_id",
       "bourgain_consistent_with_Behrend: the Bourgain upper bound dominates Behrend's unconditional lower bound N·exp(-4√(log N)), verified transitively",
-      "rothNumberNat_le_min_bourgain_blasi: the formal record that OQ-02 ⟹ OQ-01 — rothNumberNat N is bounded by the min of the Bourgain and Bloom–Sisask right-hand sides"
+      "rothNumberNat_le_min_bourgain_blasi: the formal record that OQ-02 ⟹ OQ-01 — rothNumberNat N is bounded by the min of the Bourgain and Bloom–Sisask right-hand sides",
+      "bourgain_factor_tendsto_zero: the density factor (log log N/log N)^(1/2) → 0 as N → ∞ — axiom-free, from Real.isLittleO_log_id_atTop (log u/u → 0 at u = log N → ∞) and continuity of √· = ·^(1/2)",
+      "rothNumberNat_isLittleO_of_bourgain: rothNumberNat N = o(N) DERIVED from the explicit Bourgain bound (not re-exported from Mathlib) — certifies the quantitative rate is genuinely strong enough to recover the qualitative Roth theorem"
     ],
     "dateAdded": "2026-07-02",
-    "lineCount": 264,
-    "theoremCount": 7,
+    "lineCount": 325,
+    "theoremCount": 9,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/RothTheoremOQ02.lean"
@@ -41,7 +43,7 @@
   "overview": {
     "historicalContext": "Roth's 1953 theorem showed that any subset of {1,…,N} with no 3-term arithmetic progression has size o(N); his Fourier-analytic density-increment argument gives r₃(N) ≪ N/log log N. Bourgain (1999) improved the saving from a single log log to a power of log: r₃(N) ≪ N·(log log N/log N)^(1/2). A long chain of refinements followed — Bourgain (2008), Sanders (2011), Bloom (2016), and finally Bloom–Sisask (2020), who broke the logarithmic barrier with r₃(N) ≪ N/(log N)^(1+c), and Kelley–Meka (2023) with the quasi-polynomial r₃(N) ≪ N·exp(-c(log N)^β). This entry records Bourgain's landmark bound as a typed Lean target and, crucially, does not assume it: because the later Bloom–Sisask bound decays strictly faster, it implies Bourgain, and the implication is discharged formally.",
     "problemStatement": "**Bourgain's bound (OQ-01)**: There exists C > 0 such that for all N ≥ 3, the Roth number satisfies rothNumberNat N ≤ C · N · (log log N / log N)^(1/2). Equivalently r₃(N) = O(N·(log log N/log N)^(1/2)).",
-    "text": "A 264-line Lean 4 formalization built over Mathlib's `rothNumberNat`. The distinguishing content is the explicit analytic proof that the Bloom–Sisask 2020 bound implies the Bourgain 1999 bound, turning what was previously a standalone axiom into a derived theorem. Supporting exports record consistency with Mathlib's qualitative Roth result, with Behrend's lower bound, and the minimum-of-both-bounds statement that formalizes OQ-02 ⟹ OQ-01.",
+    "text": "A 325-line Lean 4 formalization built over Mathlib's `rothNumberNat`. The distinguishing content is the explicit analytic proof that the Bloom–Sisask 2020 bound implies the Bourgain 1999 bound, turning what was previously a standalone axiom into a derived theorem, together with a from-the-bound derivation that the explicit Bourgain rate recovers the qualitative o(N) statement. Supporting exports record consistency with Mathlib's qualitative Roth result, with Behrend's lower bound, and the minimum-of-both-bounds statement that formalizes OQ-02 ⟹ OQ-01.",
     "proofStrategy": "**Main theorem (rothNumberNat_bourgain)**: Obtain the Bloom–Sisask witness ⟨c, hc, hbs⟩ with rothNumberNat N ≤ N/(log N)^(1+c). Fix the endpoint constants B = (log log 3)^(1/2) and E = (log 3)^(1/2+c), both positive because N ≥ 3 forces log N ≥ log 3 > 1 (via exp 1 < 3) and hence log log N > 0. Choose C = 1/(B·E).\n\n**Analytic core (Bloom–Sisask ⟹ Bourgain)**: After clearing the common factor N > 0, write L = log N, LL = log log N. Split L^(1+c) = L^(1/2)·L^(1/2+c) (Real.rpow_add) and (LL/L)^(1/2) = LL^(1/2)/L^(1/2) (Real.div_rpow), reducing the goal to 1 ≤ (LL^(1/2)·L^(1/2+c))/(B·E). Both LL^(1/2) ≥ B and L^(1/2+c) ≥ E hold by base-monotonicity of Real.rpow (log 3 ≤ log N, log log 3 ≤ log log N), and mul_le_mul closes it. Compose with the Bloom–Sisask bound by le_trans.\n\n**API and consistency exports**: bourgainConst extracts C via Exists.choose; rothNumberNat_le_bourgain instantiates the bound. bourgain_consistent_with_isLittleO re-exports Mathlib's qualitative rothNumberNat_isLittleO_id. bourgain_consistent_with_Behrend chains Behrend.roth_lower_bound through rothNumberNat N to the Bourgain upper bound. rothNumberNat_le_min_bourgain_blasi is le_min of the Bourgain and Bloom–Sisask bounds.",
     "keyInsights": [
       "**A weaker bound need not be assumed if a stronger one is available.** The previous version of this file carried a standalone `axiom rothNumberNat_bourgain`. But Bloom–Sisask (N/(log N)^(1+c)) decays strictly faster than Bourgain (N·(log log N/log N)^(1/2)), so it implies Bourgain — the axiom was redundant and is now a derived theorem resting on the single OQ-02 assumption.",
@@ -73,9 +75,9 @@
       "Proofs.RothTheoremOQ02"
     ],
     "namespace": "RothTheoremOQ01",
-    "lineCount": 264,
+    "lineCount": 325,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 1,
     "path": "Proofs/RothTheoremOQ01.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Upgrades `RothTheoremOQ01.lean` so the **explicit** Bourgain 1999 rate is shown to genuinely recover the qualitative Roth theorem `rothNumberNat N = o(N)` — previously the file only *re-exported* Mathlib's independent `rothNumberNat_isLittleO_id` without deriving `o(N)` from the quantitative bound.

Adds **2 machine-verified theorems** (7→9 theorems, 264→325 L; **0 sorry, 0 new axioms**):

- **`bourgain_factor_tendsto_zero`** (fully **axiom-free**): the density factor `(log log N / log N)^{1/2} → 0`. Chain: `Real.isLittleO_log_id_atTop.tendsto_div_nhds_zero` (`log u/u → 0`) at `u = log N → ∞`, then through `·^{1/2}` via `Real.sqrt` continuity (`Real.sqrt_eq_rpow`, `Real.continuous_sqrt`).
- **`rothNumberNat_isLittleO_of_bourgain`**: `rothNumberNat N = o(N)` **derived from** the Bourgain bound via `Asymptotics.isLittleO_iff` + `bourgainConst · factor → 0`.

## Status
Remains **axiomatized** — the presented Bourgain bound rests on the single imported OQ-02 Bloom–Sisask axiom; the new little-o theorem inherits exactly that one assumption, and the tendsto lemma is axiom-free. No new axioms introduced. The genuine open work (a from-scratch quantitative Bourgain/Bloom–Sisask proof) is unchanged and remains BLOCKED on >1000 LOC of Bohr-set/Fourier infrastructure absent from Mathlib v4.26.

## Verification
`./proofs/scripts/docker-build.sh Proofs.RothTheoremOQ01` → `=== Build succeeded ===` (first try). 0 sorry, 0 axiom declarations, 0 `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)