### PR TITLE
audit(re-audit): refresh tracker for 3 changed-since-audit proofs (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3149,8 +3149,8 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "binomial-theorem-oq-04-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T18:57:01Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T05:59:18Z",
       "result": "clean",
       "issues": []
     },
@@ -3272,9 +3272,9 @@
       "issues": []
     },
     "birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-06-24T20:41:47Z",
+      "lastAudited": "2026-07-08T05:59:18Z",
       "result": "clean"
     },
     "birthday-problem-oq-02-oq-01-oq-03": {
@@ -12878,9 +12878,10 @@
     },
     "erdos-360": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-06-02T13:08:36Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T05:59:18Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-361": {
       "agentId": "auditor-cycle-20-batch",
@@ -29553,5 +29554,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T05:49:40Z"
+  "lastUpdated": "2026-07-08T05:59:18Z"
 }


### PR DESCRIPTION
## Re-Audit Sweep (backlog=0)

All 4775 gallery proofs are audited with 0 open issues. This sweep re-audits the 3 proofs whose `meta.json` was modified **after** its recorded `lastAudited` timestamp.

### Verified clean (mechanical check: status/badge vs sorries/axioms vs Lean source)

| Slug | status/badge | sorries | axioms |
|------|-------------|---------|--------|
| binomial-theorem-oq-04-oq-01-oq-03 | verified/original | 0 | 0 |
| birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01 | verified/original | 0 | 0 |
| erdos-360 | axiomatized/axiom | 0 (main) | 8 aggregate |

**erdos-360 detail:** meta.axiomCount=8 = 4 axioms in `Erdos360Problem.lean` + 4 in stub companion `Stubs/Erdos360Problem.lean`, disclosed transparently in the `assumptions` field. Main proof file has 0 real sorries; the small cases f(2)=1, f(4)=2 are now machine-checked (#35225). Companion Aristotle/stub sorries are scaffolds, not counted (established convention). Status/badge are conservative (axiomatized) — no overclaim.

The other 86 recently-changed metas already had `lastAudited` newer than their meta commit (covered by prior sweeps incl. #35224).

Only `audit-tracker.json` is touched (auditCount++/lastAudited refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)