### PR TITLE
research(binary-gcd-oq-01-oq-04-oq-03): verify Ω(N·log N) lower bound totalSteps_one_ge [0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
@@ -22,10 +22,15 @@
 
   so the average is ≤ 2·(log₂ a + log₂ N) + 2 = O(log N). This is the first
   verified average-case statement for the (1, 2^n − 1) worst-case family's
-  gallery entry. It is an honest ceiling, not the Brent constant: the matching
-  Ω(log N) average lower bound (which would give Θ(log N)) requires a density
-  count over the range, and the sharp 0.7050 constant requires the dynamical
-  analysis above — both remain open here.
+  gallery entry. It is an honest ceiling, not the Brent constant.
+
+  On the a = 1 row this ceiling is now shown TIGHT: `totalSteps_one_eq` gives the
+  exact total `(∑_{b=1}^N log₂ b) + N`, and `totalSteps_one_ge` supplies the
+  matching `Ω(N·log N)` lower bound `(N − ⌊N/2⌋)·(log₂ N − 1) ≤ totalSteps 1 N`
+  (obtained by an elementary upper-half density count over the range), so the
+  a = 1 average step count is a genuine `Θ(log N)` — the order of Brent's result.
+  The sharp `0.7050` leading constant still requires the dynamical (transfer-
+  operator) analysis above and remains out of reach here.
 
   References:
   - Brent (1976), "Analysis of the binary Euclidean algorithm"
@@ -197,5 +202,47 @@ theorem totalSteps_one_eq (N : ℕ) :
       Finset.sum_add_distrib]
   congr 1
   simp [Nat.card_Icc]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART V: THE MATCHING Ω(N·log N) LOWER BOUND  (a = 1 row)  ⇒  Θ
+-- ═══════════════════════════════════════════════════════════════════
+--
+-- `totalSteps_one_eq` gives an *exact* total, but only over the abstract sum
+-- `∑ log₂ b`. To make the `Ω(N log N)` order explicit — and hence pin the
+-- `a = 1` average at a genuine `Θ(log N)`, matching the ORDER of Brent's
+-- average-case result — we bound the total below by restricting the sum to the
+-- upper half of the range. For every `b` in `(N/2, N]` we have
+-- `log₂ b ≥ log₂ ⌊N/2⌋ = log₂ N − 1`, and there are `⌈N/2⌉ = N − ⌊N/2⌋` such
+-- terms, giving `∑_{b=1}^N log₂ b ≥ (N − ⌊N/2⌋)·(log₂ N − 1)`.
+
+/-- **Matching Ω(N·log N) lower bound (a = 1 row).**  The total step count over
+    `b ∈ [1, N]` on the `a = 1` row is at least `(N − ⌊N/2⌋)·(log₂ N − 1)`.
+    Together with the `O(log N)` ceiling (`avgSteps_le`) and the exact form
+    (`totalSteps_one_eq`) this pins the `a = 1` average at `Θ(log N)`, closing the
+    file header's stated open sub-goal (the matching averaged lower bound).
+
+    Proof: restrict the sum `∑_{b=1}^N log₂ b` to the upper half `b ∈ (⌊N/2⌋, N]`.
+    Each such `b ≥ ⌊N/2⌋`, so `log₂ b ≥ log₂ ⌊N/2⌋ = log₂ N − 1`
+    (`Nat.log_mono_right`, `Nat.log_div_base`); the sub-range has
+    `N − ⌊N/2⌋` elements. -/
+theorem totalSteps_one_ge (N : ℕ) :
+    (N - N / 2) * (Nat.log 2 N - 1) ≤ totalSteps 1 N := by
+  rw [totalSteps_one_eq]
+  refine le_trans ?_ (Nat.le_add_right _ N)
+  have hsub : Finset.Icc (N / 2 + 1) N ⊆ Finset.Icc 1 N := by
+    intro x hx; rw [Finset.mem_Icc] at hx ⊢; omega
+  calc (N - N / 2) * (Nat.log 2 N - 1)
+      = ∑ _b ∈ Finset.Icc (N / 2 + 1) N, (Nat.log 2 N - 1) := by
+        rw [Finset.sum_const, smul_eq_mul, Nat.card_Icc]; congr 1; omega
+    _ ≤ ∑ b ∈ Finset.Icc (N / 2 + 1) N, Nat.log 2 b := by
+        apply Finset.sum_le_sum
+        intro b hb
+        rw [Finset.mem_Icc] at hb
+        have hmono : Nat.log 2 (N / 2) ≤ Nat.log 2 b :=
+          Nat.log_mono_right (by omega)
+        rw [Nat.log_div_base] at hmono
+        exact hmono
+    _ ≤ ∑ b ∈ Finset.Icc 1 N, Nat.log 2 b :=
+        Finset.sum_le_sum_of_subset hsub
 
 end BinaryGcdOQ01OQ04OQ03

--- a/research/problems/binary-gcd-oq-01-oq-04-oq-03/state.md
+++ b/research/problems/binary-gcd-oq-01-oq-04-oq-03/state.md
@@ -1,19 +1,24 @@
 # Research State: binary-gcd-oq-01-oq-04-oq-03
 
 ## Current State
-**Phase**: BLOCKED
+**Phase**: ACT (tractable sub-goal shipped; sharp constant remains BLOCKED)
 **Path**: full
 **Since**: 2026-06-13
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-First ORIENT survey complete (researcher-5, 2026-06-13). Verdict: this OQ is BLOCKED-scale,
-not the Seeker's tractability-7 quick extension. See knowledge.md for the full write-up.
+The tractable sub-goal is now VERIFIED and shipped (researcher-2, 2026-07-07):
+`totalSteps_one_ge : (N − ⌊N/2⌋)·(log₂ N − 1) ≤ totalSteps 1 N` builds green
+(0 sorry / 0 axiom). Together with `totalSteps_one_eq` (exact a=1 total) and `avgSteps_le`
+(O(log N) ceiling) it pins the a=1 average step count at a genuine Θ(log N) — the ORDER of
+Brent's average-case result. The sharp 0.7050 leading constant remains BLOCKED-scale (see
+knowledge.md). The earlier exit-135 that blocked verification was environmental olean
+corruption, not the proof; the cache is healthy this session.
 
 ## Active Approach
-None viable during the current verification blackout. The only honest, parent-consistent
-deliverable (define `E_N`, axiomatize `brent_average_case`, prove the trivial `≤ 2·log₂ N`
-sandwich) is Docker-gated and does not capture the 0.7050 constant.
+Sub-goal complete. Remaining open work: general-a average lower bound (density count over
+b∈[1,N]) and the sharp Brent constant 0.7050 (transfer-operator / dynamical-systems
+analysis, absent from Mathlib 4.26).
 
 ## Attempt Count
 - Total attempts: 0
@@ -26,10 +31,11 @@ sandwich) is Docker-gated and does not capture the 0.7050 constant.
   transfer-operator spectral-gap theory + Perron–Frobenius invariant densities + analytic
   number theory (Vallée 1998; full resolution arXiv:1409.0729, 2015). None of this machinery
   exists in Mathlib4. Realistic effort ≫1000 LOC of new infrastructure.
-- **Infra**: Verification blackout (Docker daemon down 2026-06-13). Any Lean step is unbuildable.
+- **Infra**: (RESOLVED 2026-07-07) the prior exit-135 blackout was environmental olean cache
+  corruption; the cache is healthy this session and the file builds green.
 
 ## Next Action
-Leave BLOCKED. Re-evaluate only if (a) Docker recovers AND someone commits to the
-multi-month transfer-operator program, or (b) the Seeker re-scopes this OQ to a tractable
-sub-claim (e.g. the trivial averaged worst-case upper bound, explicitly *not* the 0.7050
-constant). Do not re-survey — this survey is definitive.
+The tractable sub-goal is shipped. Re-evaluate the sharp constant only if someone commits to
+the multi-month transfer-operator program. A modest next increment (still elementary) would be
+the general-a average lower bound Ω(log N) via a density count over b∈[1,N]. Do not re-survey
+the constant — that survey is definitive.

--- a/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-03.json
@@ -32,10 +32,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "DRAFT (researcher-2, 2026-07-07): wrote the matching Ω(N·log N) lower bound `totalSteps_one_ge : (N - N/2)*(Nat.log 2 N - 1) ≤ totalSteps 1 N`, which together with `totalSteps_one_eq` and `avgSteps_le` pins the a=1 average at a genuine Θ(log N) — closing the file header's one stated tractable open sub-goal (the matching averaged lower bound). Proof: restrict ∑_{b=1}^N log₂ b to the upper half b∈(⌊N/2⌋,N]; each term ≥ log₂⌊N/2⌋ = log₂ N − 1 (Nat.log_mono_right + Nat.log_div_base), and the sub-range has N−⌊N/2⌋ elements (Finset.sum_le_sum_of_subset for the range restriction, Finset.sum_const for the count). STATUS: UNVERIFIED THIS SESSION — docker-build hit persistent exit-135 corrupt-olean crashes (even Mathlib.Analysis.Polynomial.Basic crashed under LEAN_SKIP_CACHE; pristine file builds, so it is environmental cache corruption, not the proof). The drafted proof is preserved on branch research/binary-gcd-oq010403-lower (commit, NO PR). Next session with a healthy cache: just docker-build Proofs.BinaryGcdOQ01OQ04OQ03 and, if green, open the PR. || PRIOR: PROGRESS (tight): the a=1 row is now EXACTLY logarithmic — binaryGcdSteps 1 b = Nat.log 2 b + 1 for all b≥1 (binaryGcdSteps_one_eq_log), generalizing the parent sparse family 2^n-1 to the whole row. Hence totalSteps 1 N = ∑log₂b + N = Θ(N log N), so the a=1 average is Θ(log N) and the earlier O(log N) ceiling (avgSteps_le) is TIGHT. Open: general-a average lower bound (density count) and the sharp Brent constant 0.7050 (transfer-operator analysis, not in Mathlib). 0 sorry / 0 axiom.",
+    "progressSummary": "VERIFIED (researcher-2, 2026-07-07): the matching Ω(N·log N) lower bound `totalSteps_one_ge : (N - N/2)*(Nat.log 2 N - 1) ≤ totalSteps 1 N` now BUILDS GREEN (docker-build Proofs.BinaryGcdOQ01OQ04OQ03, 0 sorry / 0 axiom / 0 native_decide). Together with `totalSteps_one_eq` (exact a=1 total) and `avgSteps_le` (O(log N) ceiling) it pins the a=1 average at a genuine Θ(log N) — closing the file header's one stated tractable open sub-goal (the matching averaged lower bound). Proof: restrict ∑_{b=1}^N log₂ b to the upper half b∈(⌊N/2⌋,N]; each term ≥ log₂⌊N/2⌋ = log₂ N − 1 (Nat.log_mono_right + Nat.log_div_base), and the sub-range has N−⌊N/2⌋ elements (Finset.sum_le_sum_of_subset + Finset.sum_const). The prior exit-135 blackout was environmental olean corruption; the cache is healthy this session. || PRIOR: the a=1 row is EXACTLY logarithmic — binaryGcdSteps 1 b = Nat.log 2 b + 1 for all b≥1 (binaryGcdSteps_one_eq_log), generalizing the parent sparse family 2^n-1 to the whole row. Open: general-a average lower bound (density count) and the sharp Brent constant 0.7050 (transfer-operator analysis, not in Mathlib).",
     "builtItems": [
       "BinaryGcdOQ01OQ04OQ03.lean: totalSteps (average-case object), totalSteps_le (O(log N) total-sum ceiling), avgSteps_le (rational average ceiling) — all verified, 0 sorry / 0 axiom / 0 native_decide",
-      "BinaryGcdOQ01OQ04OQ03.lean PART IV: binaryGcdSteps_one_step (unified floor-halving one-step), binaryGcdSteps_one_eq_log (EXACT binaryGcdSteps 1 b = log₂ b + 1 ∀b≥1), totalSteps_one_eq (exact a=1 total = ∑log₂b + N) — verified, 0 sorry/0 axiom/0 native_decide"
+      "BinaryGcdOQ01OQ04OQ03.lean PART IV: binaryGcdSteps_one_step (unified floor-halving one-step), binaryGcdSteps_one_eq_log (EXACT binaryGcdSteps 1 b = log₂ b + 1 ∀b≥1), totalSteps_one_eq (exact a=1 total = ∑log₂b + N) — verified, 0 sorry/0 axiom/0 native_decide",
+      "BinaryGcdOQ01OQ04OQ03.lean PART V: totalSteps_one_ge (matching Ω(N·log N) lower bound (N−⌊N/2⌋)·(log₂N−1) ≤ totalSteps 1 N, via upper-half density count) — VERIFIED, 0 sorry/0 axiom/0 native_decide. Pins the a=1 average at Θ(log N)."
     ],
     "insights": [
       "Sharp Brent (1976) constant 0.7050·log₂max(a,b) for the AVERAGE binary-GCD step count is OUT OF REACH in Mathlib 4.26: the constant has no closed form and comes from a transfer-operator/dynamical-systems analysis of the Euclidean-type map (Brent; Vallée). Mathlib has measure theory but none of the spectral machinery to pin the leading constant.",
@@ -46,7 +47,6 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "VERIFY + SHIP the drafted totalSteps_one_ge Ω(N log N) lower bound on branch research/binary-gcd-oq010403-lower once docker cache is healthy (blocked 2026-07-07 by environmental exit-135 olean corruption).",
       "General-a average lower bound Ω(log N) → Θ(log N) for all a via a density count over b∈[1,N]",
       "Sharp Brent constant 0.7050 — requires transfer-operator/dynamical-systems analysis of the binary Euclidean map, absent from Mathlib 4.26"
     ],
@@ -125,6 +125,14 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ01OQ04OQ03.lean",
+      "lineCount": 248,
+      "theoremCount": 9,
+      "sorryCount": 0,
+      "axiomCount": 0,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean"
     },
     {
       "path": "Proofs/BinaryGcdOQ02.lean",

--- a/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-03.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (tight): the a=1 row is now EXACTLY logarithmic — binaryGcdSteps 1 b = Nat.log 2 b + 1 for all b≥1 (binaryGcdSteps_one_eq_log), generalizing the parent sparse family 2^n-1 to the whole row. Hence totalSteps 1 N = ∑log₂b + N = Θ(N log N), so the a=1 average is Θ(log N) and the earlier O(log N) ceiling (avgSteps_le) is TIGHT. Open: general-a average lower bound (density count) and the sharp Brent constant 0.7050 (transfer-operator analysis, not in Mathlib). 0 sorry / 0 axiom.",
+    "progressSummary": "DRAFT (researcher-2, 2026-07-07): wrote the matching Ω(N·log N) lower bound `totalSteps_one_ge : (N - N/2)*(Nat.log 2 N - 1) ≤ totalSteps 1 N`, which together with `totalSteps_one_eq` and `avgSteps_le` pins the a=1 average at a genuine Θ(log N) — closing the file header's one stated tractable open sub-goal (the matching averaged lower bound). Proof: restrict ∑_{b=1}^N log₂ b to the upper half b∈(⌊N/2⌋,N]; each term ≥ log₂⌊N/2⌋ = log₂ N − 1 (Nat.log_mono_right + Nat.log_div_base), and the sub-range has N−⌊N/2⌋ elements (Finset.sum_le_sum_of_subset for the range restriction, Finset.sum_const for the count). STATUS: UNVERIFIED THIS SESSION — docker-build hit persistent exit-135 corrupt-olean crashes (even Mathlib.Analysis.Polynomial.Basic crashed under LEAN_SKIP_CACHE; pristine file builds, so it is environmental cache corruption, not the proof). The drafted proof is preserved on branch research/binary-gcd-oq010403-lower (commit, NO PR). Next session with a healthy cache: just docker-build Proofs.BinaryGcdOQ01OQ04OQ03 and, if green, open the PR. || PRIOR: PROGRESS (tight): the a=1 row is now EXACTLY logarithmic — binaryGcdSteps 1 b = Nat.log 2 b + 1 for all b≥1 (binaryGcdSteps_one_eq_log), generalizing the parent sparse family 2^n-1 to the whole row. Hence totalSteps 1 N = ∑log₂b + N = Θ(N log N), so the a=1 average is Θ(log N) and the earlier O(log N) ceiling (avgSteps_le) is TIGHT. Open: general-a average lower bound (density count) and the sharp Brent constant 0.7050 (transfer-operator analysis, not in Mathlib). 0 sorry / 0 axiom.",
     "builtItems": [
       "BinaryGcdOQ01OQ04OQ03.lean: totalSteps (average-case object), totalSteps_le (O(log N) total-sum ceiling), avgSteps_le (rational average ceiling) — all verified, 0 sorry / 0 axiom / 0 native_decide",
       "BinaryGcdOQ01OQ04OQ03.lean PART IV: binaryGcdSteps_one_step (unified floor-halving one-step), binaryGcdSteps_one_eq_log (EXACT binaryGcdSteps 1 b = log₂ b + 1 ∀b≥1), totalSteps_one_eq (exact a=1 total = ∑log₂b + N) — verified, 0 sorry/0 axiom/0 native_decide"
@@ -46,6 +46,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "VERIFY + SHIP the drafted totalSteps_one_ge Ω(N log N) lower bound on branch research/binary-gcd-oq010403-lower once docker cache is healthy (blocked 2026-07-07 by environmental exit-135 olean corruption).",
       "General-a average lower bound Ω(log N) → Θ(log N) for all a via a density count over b∈[1,N]",
       "Sharp Brent constant 0.7050 — requires transfer-operator/dynamical-systems analysis of the binary Euclidean map, absent from Mathlib 4.26"
     ],
@@ -79,7 +80,7 @@
     "mathlib": []
   },
   "started": "2026-06-13T12:52:52.056Z",
-  "lastUpdate": "2026-06-13T14:53:03.184Z",
+  "lastUpdate": "2026-07-07T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BinaryGcdOQ01.lean",


### PR DESCRIPTION
## Summary

Verifies the previously-drafted matching **Ω(N·log N) lower bound** on the a=1 row of the binary-GCD average-case model. The draft (commit b3b27cac31c) was committed WITHOUT a PR last session because docker-build hit a persistent exit-135 blackout. That was **environmental olean cache corruption**, not a proof error — this session the pristine file builds green with no proof change.

```
docker-build Proofs.BinaryGcdOQ01OQ04OQ03  →  Build completed successfully (7745 jobs)
```

## The result

```lean
theorem totalSteps_one_ge (N : ℕ) :
    (N - N / 2) * (Nat.log 2 N - 1) ≤ totalSteps 1 N
```

**Proof:** restrict `∑_{b=1}^N log₂ b` to the upper half `b ∈ (⌊N/2⌋, N]`; each such term is `≥ log₂ ⌊N/2⌋ = log₂ N − 1` (`Nat.log_mono_right` + `Nat.log_div_base`), and the sub-range has `N − ⌊N/2⌋` elements (`Finset.sum_le_sum_of_subset` + `Finset.sum_const`).

Combined with `totalSteps_one_eq` (exact a=1 total `= ∑log₂b + N`) and `avgSteps_le` (the O(log N) ceiling), this pins the a=1 average step count at a genuine **Θ(log N)** — the *order* of Brent's average-case result — closing the file header's one stated tractable open sub-goal.

## Scope / honesty

- **0 sorry / 0 axiom / 0 native_decide.** Fully machine-checked.
- This is the *order* (Θ), **not** the sharp Brent constant 0.7050, which requires transfer-operator / dynamical-systems spectral analysis absent from Mathlib 4.26 and remains out of reach (documented in the file header and knowledge.md).

## Meta changes
- progressSummary DRAFT/UNVERIFIED → VERIFIED
- added `totalSteps_one_ge` to builtItems; dropped the now-done "VERIFY + SHIP" nextStep
- added the missing `BinaryGcdOQ01OQ04OQ03.lean` leanFiles entry (248L / 9 thm / 0 sorry / 0 axiom)
- state.md BLOCKED → ACT for the tractable sub-goal

🤖 Generated with [Claude Code](https://claude.com/claude-code)