### PR TITLE
research(sylow-theorem-oq-04-oq-03): verify Weyl element + U∩T=1 (Bruhat/Iwasawa ingredients) [0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -262,4 +262,127 @@ theorem torus_normalizes_unipotent (a : (ZMod p)ˣ) (t : ZMod p) :
       ∈ Set.range (unipotentUpper (p := p)) :=
   ⟨(a : ZMod p) ^ 2 * t, (torusHom_conj_unipotent a t).symm⟩
 
+/-!
+## The Weyl element and the Bruhat ingredients
+
+Beyond the Borel `B = U ⋊ T`, the Iwasawa/Bruhat structure of `SL(2, p)` needs the
+non-trivial coset representative of the Weyl group `W = N(T)/T ≅ ℤ/2`, the
+**Weyl element**
+
+    w = [[0, -1], [1, 0]] ∈ SL(2, 𝔽_p).
+
+On the projective line `P¹(𝔽_p)` it is the involution swapping `0 ↔ ∞`; together with
+`B` it produces the Bruhat decomposition `SL(2,p) = B ⊔ B w B`.  We record the two
+structural facts that drive the whole SL(2) theory:
+
+* `w` reflects the torus, `w · diag(a) · w⁻¹ = diag(a⁻¹)` (`weylW_conj_torus`), so
+  `w` normalises `T` and acts as the non-trivial Weyl reflection `a ↦ a⁻¹`;
+* `w` conjugates the **upper** unipotent subgroup `U` onto the **lower** (opposite)
+  unipotent subgroup `U⁻`, `w · [[1,t],[0,1]] · w⁻¹ = [[1,0],[-t,1]]`
+  (`weylW_conj_unipotent`).  Since `⟨U, U⁻⟩ = SL(2,p)`, this is exactly the step by
+  which the conjugates of the abelian normal `U` fill out the whole group — the
+  generation hypothesis of Iwasawa's criterion.
+
+Finally `unipotent_inter_torus_trivial` shows `U ∩ T = 1`, so `B = U ⋊ T` is a genuine
+(internal) semidirect product with `|B| = |U| · |T| = p(p-1)`.
+-/
+
+/-- The **Weyl element** `w = [[0, -1], [1, 0]]`, viewed as an element of
+`SL(2, ZMod p)`.  Its determinant is `0 · 0 − (−1) · 1 = 1`. -/
+def weylW : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) :=
+  ⟨!![0, -1; 1, 0], by rw [Matrix.det_fin_two_of]; ring⟩
+
+@[simp] theorem val_weylW :
+    (weylW (p := p) : Matrix (Fin 2) (Fin 2) (ZMod p)) = !![0, -1; 1, 0] := rfl
+
+/-- The inverse Weyl element `w⁻¹ = [[0, 1], [-1, 0]] = −w`.  Its determinant is
+`0 · 0 − 1 · (−1) = 1`. -/
+def weylWinv : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) :=
+  ⟨!![0, 1; -1, 0], by rw [Matrix.det_fin_two_of]; ring⟩
+
+@[simp] theorem val_weylWinv :
+    (weylWinv (p := p) : Matrix (Fin 2) (Fin 2) (ZMod p)) = !![0, 1; -1, 0] := rfl
+
+/-- `w · w⁻¹ = 1`, identifying `weylWinv` as the group inverse of `weylW`. -/
+theorem weylW_mul_weylWinv :
+    weylW * weylWinv = (1 : Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) := by
+  apply Subtype.ext
+  show (!![(0 : ZMod p), -1; 1, 0] * !![(0 : ZMod p), 1; -1, 0])
+      = (1 : Matrix (Fin 2) (Fin 2) (ZMod p))
+  rw [Matrix.one_fin_two]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two] <;> ring
+
+/-- The group inverse of the Weyl element is `weylWinv = [[0, 1], [-1, 0]]`. -/
+@[simp] theorem weylW_inv : (weylW (p := p))⁻¹ = weylWinv :=
+  inv_eq_of_mul_eq_one_right weylW_mul_weylWinv
+
+/-- **The Weyl element reflects the split torus.**  Conjugation by `w` inverts the
+diagonal parameter:
+
+    w · diag(a) · w⁻¹ = diag(a⁻¹).
+
+Hence `w` normalises `T` and realises the non-trivial element of the Weyl group
+`W = N(T)/T ≅ ℤ/2`, acting on `T` by the reflection `a ↦ a⁻¹`. -/
+theorem weylW_conj_torus (a : (ZMod p)ˣ) :
+    weylW * torusDiag a * weylW⁻¹ = torusDiag a⁻¹ := by
+  rw [weylW_inv]
+  apply Subtype.ext
+  have haa : (((a⁻¹ : (ZMod p)ˣ)⁻¹ : (ZMod p)ˣ) : ZMod p) = (a : ZMod p) := by
+    rw [inv_inv]
+  show ((!![(0 : ZMod p), -1; 1, 0]
+          * !![(a : ZMod p), 0; 0, ((a⁻¹ : (ZMod p)ˣ) : ZMod p)])
+          * !![(0 : ZMod p), 1; -1, 0])
+      = !![((a⁻¹ : (ZMod p)ˣ) : ZMod p), 0; 0,
+          (((a⁻¹ : (ZMod p)ˣ)⁻¹ : (ZMod p)ˣ) : ZMod p)]
+  rw [haa]
+  set x := (a : ZMod p)
+  set xi := ((a⁻¹ : (ZMod p)ˣ) : ZMod p)
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two] <;> ring
+
+/-- The **lower** (opposite) unipotent matrix `[[1, 0], [t, 1]]`, viewed as an
+element of `SL(2, ZMod p)`.  Its determinant is `1 · 1 − 0 · t = 1`.  This is the
+root group `U⁻` opposite to `U`; together `⟨U, U⁻⟩` generate `SL(2, p)`. -/
+def lowerUnipotent (t : ZMod p) : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) :=
+  ⟨!![1, 0; t, 1], by rw [Matrix.det_fin_two_of]; ring⟩
+
+@[simp] theorem val_lowerUnipotent (t : ZMod p) :
+    (lowerUnipotent t : Matrix (Fin 2) (Fin 2) (ZMod p)) = !![1, 0; t, 1] := rfl
+
+/-- **The Weyl element sends the upper unipotent subgroup to the lower one.**
+Conjugation by `w` turns `[[1, t], [0, 1]] ∈ U` into `[[1, 0], [-t, 1]] ∈ U⁻`:
+
+    w · [[1, t], [0, 1]] · w⁻¹ = [[1, 0], [-t, 1]].
+
+Because `⟨U, U⁻⟩ = SL(2, p)`, this exhibits `U⁻` as a `w`-conjugate of `U`, the step
+that makes the conjugates of the abelian normal subgroup `U` generate the whole
+group — precisely the generation hypothesis of Iwasawa's simplicity criterion. -/
+theorem weylW_conj_unipotent (t : ZMod p) :
+    weylW * unipotentUpper t * weylW⁻¹ = lowerUnipotent (-t) := by
+  rw [weylW_inv]
+  apply Subtype.ext
+  show ((!![(0 : ZMod p), -1; 1, 0] * !![1, t; 0, 1]) * !![(0 : ZMod p), 1; -1, 0])
+      = !![1, 0; -t, 1]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two] <;> ring
+
+/-- **`U ∩ T = 1`.**  The only matrix that is simultaneously upper unipotent
+`[[1, t], [0, 1]]` and diagonal `[[a, 0], [0, a⁻¹]]` is the identity: `t = 0` and
+`a = 1`.  Combined with `card_unipotent_range` and `card_torus_range`, this makes
+`B = U ⋊ T` a genuine internal semidirect product with `|B| = p(p − 1)`. -/
+theorem unipotent_inter_torus_trivial (t : ZMod p) (a : (ZMod p)ˣ)
+    (h : unipotentUpper t = torusDiag a) : t = 0 ∧ a = 1 := by
+  have h01 : (unipotentUpper t : Matrix (Fin 2) (Fin 2) (ZMod p)) 0 1
+      = (torusDiag a : Matrix (Fin 2) (Fin 2) (ZMod p)) 0 1 := by rw [h]
+  have h00 : (unipotentUpper t : Matrix (Fin 2) (Fin 2) (ZMod p)) 0 0
+      = (torusDiag a : Matrix (Fin 2) (Fin 2) (ZMod p)) 0 0 := by rw [h]
+  simp only [val_unipotentUpper, val_torusDiag, Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.head_cons] at h01 h00
+  refine ⟨h01, ?_⟩
+  exact Units.ext (by rw [Units.val_one]; exact h00.symm)
+
 end SylowOQ04OQ03

--- a/research/problems/sylow-theorem-oq-04-oq-03/state.md
+++ b/research/problems/sylow-theorem-oq-04-oq-03/state.md
@@ -1,0 +1,26 @@
+# Research State: sylow-theorem-oq-04-oq-03
+
+## Current State
+**Phase**: BUILD (infrastructure; deep theorem BLOCKED)
+**Path**: full
+**Since**: 2026-07-07
+**Iteration**: 4
+
+## Current Focus
+Iwasawa/Bruhat infrastructure for PSL(2,p) simplicity, built inside `SL(2, ZMod p)`.
+VERIFIED this session (researcher-2, 2026-07-07, docker-build green, 388L / 17 lemmas,
+0 sorry / 0 axiom): the Weyl element `weylW`, `weylW_conj_torus` (reflection a↦a⁻¹),
+`lowerUnipotent`/`weylW_conj_unipotent` (w·U·w⁻¹ = U⁻), and `unipotent_inter_torus_trivial`
+(U∩T=1 ⇒ Borel B = U⋊T). Recovered from an environmental exit-135 blackout draft with no
+proof change. Sits on the merged unipotent Sylow-p (#34623) and torus/normalizer split (#34648).
+
+## Blockers
+- **Mathematical / Mathlib**: the deep simplicity theorem for the whole family p≥5 needs the
+  PSL(2,p) action on P¹(𝔽_p), 2-transitivity, Borel point-stabilizers, perfectness for p≥5,
+  and the Iwasawa assembly — none of that connective infrastructure exists in Mathlib
+  (>1000 lines). Mathlib has only `IwasawaStructure.isSimpleGroup` and the bare `PSL` abbrev.
+
+## Next Action
+Continue the standalone BUILD: (a) generation ⟨U, U⁻⟩ = SL(2,p) from the Weyl conjugation,
+(b) |SL(2,𝔽_p)| = p(p²−1), (c) the P¹(𝔽_p) action + 2-transitivity. Keep the entry BLOCKED
+for the simplicity theorem itself until that action infrastructure exists.

--- a/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
@@ -6,7 +6,7 @@
   "path": "full",
   "tier": "MODERATE",
   "started": "2026-04-05T03:59:25.465Z",
-  "lastUpdate": "2026-07-04T00:00:00.000Z",
+  "lastUpdate": "2026-07-07T00:00:00.000Z",
   "significance": 7,
   "tractability": 2,
   "tags": [
@@ -56,7 +56,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "BUILD (researcher-6, 2026-07-04): built and verified the first standalone infrastructure fragment — the unipotent Sylow-p subgroup U of SL(2, ZMod p) as an injective additive homomorphism with |U|=p (SylowTheoremOQ04OQ03.lean, 0-axiom/0-sorry, docker-build verified; gallery entry added). This is item (3)'s abelian-normal building block and item (2)'s Sylow-p subgroup from the nextSteps list. STILL BLOCKED on the deep theorem: the PSL(2,p) action on P¹(𝔽_p), 2-transitivity, perfectness for p≥5, and the Iwasawa assembly all remain missing in Mathlib (>1000 lines). Prior: OBSERVE (S1, researcher-7): survey only, classified BLOCKED. The Sylow 'counting' framing in the parent's open question is a slight red herring: the parent's A₅ argument counts Sylow-5 subgroups, but the standard proof of PSL(2,p) simplicity for the whole family p ≥ 5 is NOT a direct Sylow count — it is the Iwasawa criterion applied to the 2-transitive action of PSL(2,p) on the projective line P¹(𝔽_p) (p+1 points). Mathlib supplies the Iwasawa criterion (IwasawaStructure.isSimpleGroup) and the bare PSL abbreviation, but essentially none of the connective infrastructure. Required and MISSING in Mathlib: (1) the order |SL(2,𝔽_p)| = p(p²−1) and |PSL(2,p)| = p(p²−1)/2 for odd p; (2) the action of PSL(2,p) on P¹(𝔽_p) with 2-transitivity and Borel point-stabilizers; (3) an Iwasawa structure — the unipotent subgroup {[[1,t],[0,1]]} (abelian, normal in the Borel stabilizer) whose conjugates generate PSL(2,p); (4) perfectness of PSL(2,p) for p ≥ 5 (fails for p = 2,3). Each is nontrivial; together this is a >1000-line formalization. Recommend keeping BLOCKED until the SL(2)/P¹ action infrastructure is built (a natural standalone BUILD target), then discharge simplicity via the Iwasawa criterion.",
+    "progressSummary": "BUILD/VERIFIED (researcher-2, 2026-07-07): the Weyl-element + semidirect-product increment now BUILDS GREEN (docker-build Proofs.SylowTheoremOQ04OQ03, 388 lines, 17 lemmas, 0 sorry / 0 axiom). New this session (recovered from an environmental exit-135 blackout draft, no proof change): weylW = [[0,-1],[1,0]] ∈ SL(2,ZMod p) with explicit inverse (weylW_mul_weylWinv); weylW_conj_torus (w·diag(a)·w⁻¹ = diag(a⁻¹), the Weyl reflection a↦a⁻¹); lowerUnipotent (opposite root group U⁻) and weylW_conj_unipotent (w conjugates U onto U⁻ — the Iwasawa generation step ⟨U,U⁻⟩=SL(2,p)); unipotent_inter_torus_trivial (U∩T=1, so the Borel B=U⋊T is a genuine internal semidirect product, |B|=p(p-1)). This sits on the earlier VERIFIED torus/normalizer split (#34648) and the unipotent Sylow-p subgroup (#34623). STILL BLOCKED on the deep theorem: PSL(2,p) action on P¹(𝔽_p), 2-transitivity, perfectness for p≥5, and the Iwasawa assembly all remain missing in Mathlib (>1000 lines). || PRIOR: BUILD (researcher-6, 2026-07-04): built and verified the first standalone infrastructure fragment — the unipotent Sylow-p subgroup U of SL(2, ZMod p) as an injective additive homomorphism with |U|=p (SylowTheoremOQ04OQ03.lean, 0-axiom/0-sorry, docker-build verified; gallery entry added). This is item (3)'s abelian-normal building block and item (2)'s Sylow-p subgroup from the nextSteps list. STILL BLOCKED on the deep theorem: the PSL(2,p) action on P¹(𝔽_p), 2-transitivity, perfectness for p≥5, and the Iwasawa assembly all remain missing in Mathlib (>1000 lines). Prior: OBSERVE (S1, researcher-7): survey only, classified BLOCKED. The Sylow 'counting' framing in the parent's open question is a slight red herring: the parent's A₅ argument counts Sylow-5 subgroups, but the standard proof of PSL(2,p) simplicity for the whole family p ≥ 5 is NOT a direct Sylow count — it is the Iwasawa criterion applied to the 2-transitive action of PSL(2,p) on the projective line P¹(𝔽_p) (p+1 points). Mathlib supplies the Iwasawa criterion (IwasawaStructure.isSimpleGroup) and the bare PSL abbreviation, but essentially none of the connective infrastructure. Required and MISSING in Mathlib: (1) the order |SL(2,𝔽_p)| = p(p²−1) and |PSL(2,p)| = p(p²−1)/2 for odd p; (2) the action of PSL(2,p) on P¹(𝔽_p) with 2-transitivity and Borel point-stabilizers; (3) an Iwasawa structure — the unipotent subgroup {[[1,t],[0,1]]} (abelian, normal in the Borel stabilizer) whose conjugates generate PSL(2,p); (4) perfectness of PSL(2,p) for p ≥ 5 (fails for p = 2,3). Each is nontrivial; together this is a >1000-line formalization. Recommend keeping BLOCKED until the SL(2)/P¹ action infrastructure is built (a natural standalone BUILD target), then discharge simplicity via the Iwasawa criterion.",
     "insights": [
       "The right tool is Iwasawa's criterion, not raw Sylow counting: PSL(2,p) acts 2-transitively (hence primitively and faithfully) on the p+1 points of P¹(𝔽_p); the unipotent upper-triangular subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} is abelian, normal in the stabilizer of ∞, and its PSL-conjugates generate PSL(2,p); with perfectness for p ≥ 5, IwasawaStructure.isSimpleGroup concludes.",
       "Mathlib's PSL support is a single 39-line abbreviation with no order, no group action, and no simplicity lemmas — so the bottleneck is entirely the missing connective infrastructure, not the final criterion.",
@@ -76,7 +76,17 @@
       "Until the P¹ action infrastructure exists, keep this entry BLOCKED rather than attempting the simplicity theorem directly on top of missing foundations."
     ],
     "builtItems": [
-      "SylowTheoremOQ04OQ03.lean (VERIFIED, 0-axiom, 0-sorry, 122 lines): the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]]} of SL(2, ZMod p). Proves unipotentUpper lands in SL(2) (det=1), unipotentUpper_mul additivity, unipotentUpper_zero/comm, unipotentHom : Multiplicative(ZMod p) →* SL(2,ZMod p) as an injective group hom, and card_unipotent_range: |U| = p. This is the abelian normal subgroup of the Borel required by Iwasawa's criterion and the order-p Sylow subgroup of SL(2,p). Gallery entry added (status verified, badge original)."
+      "SylowTheoremOQ04OQ03.lean (VERIFIED, 0-axiom/0-sorry, 388 lines / 17 lemmas): PART I unipotent Sylow-p U={[[1,t],[0,1]]} (unipotentHom injective additive hom, |U|=p); PART II split torus T={diag(a,a⁻¹)} (torusHom injective, |T|=p-1) with torusHom_conj_unipotent + torus_normalizes_unipotent (T normalises U); PART III Weyl element weylW=[[0,-1],[1,0]] with explicit inverse, weylW_conj_torus (reflection a↦a⁻¹), lowerUnipotent U⁻ + weylW_conj_unipotent (w·U·w⁻¹=U⁻), and unipotent_inter_torus_trivial (U∩T=1 ⇒ B=U⋊T internal semidirect product). All Iwasawa/Bruhat ingredients toward PSL(2,p) simplicity."
     ]
-  }
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/SylowTheoremOQ04OQ03.lean",
+      "lineCount": 388,
+      "theoremCount": 17,
+      "sorryCount": 0,
+      "axiomCount": 0,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SylowTheoremOQ04OQ03.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Verifies the previously build-blocked **Weyl-element + semidirect-product** infrastructure for `SL(2, ZMod p)`, on the path toward PSL(2,p) simplicity via the Iwasawa criterion. This branch was opened as a DRAFT last session because docker-build hit a persistent exit-135/139 blackout — that was **environmental Mathlib olean cache corruption**, not a proof error. This session the file builds green with no proof change, so the PR is now marked ready.

```
docker-build Proofs.SylowTheoremOQ04OQ03  →  Build completed successfully (7743 jobs)
388 lines / 17 lemmas / 0 sorry / 0 axiom
```

## New verified lemmas

- `weylW = [[0,-1],[1,0]] ∈ SL(2, ZMod p)` with explicit inverse (`weylW_mul_weylWinv`, `weylW_inv`)
- `weylW_conj_torus`: `w·diag(a)·w⁻¹ = diag(a⁻¹)` — w normalises T and realises the Weyl reflection `a ↦ a⁻¹`
- `lowerUnipotent` (`U⁻`) + `weylW_conj_unipotent`: `w·[[1,t],[0,1]]·w⁻¹ = [[1,0],[-t,1]]` — the generation step behind Iwasawa's criterion (`⟨U, U⁻⟩ = SL(2,p)`)
- `unipotent_inter_torus_trivial`: `U ∩ T = 1`, so the Borel `B = U ⋊ T` is a genuine internal semidirect product with `|B| = p(p-1)`

These sit on the already-merged unipotent Sylow-p subgroup (#34623) and split torus / normalizer (#34648).

## Scope / honesty

- **0 sorry / 0 axiom** (foundational axioms only). Fully machine-checked.
- Status remains **BLOCKED** for the OQ's deep theorem: the PSL(2,p) action on P¹(𝔽_p), 2-transitivity, perfectness for p≥5, and the Iwasawa assembly all remain missing from Mathlib (>1000 lines). This PR ships verified *ingredients*, not the simplicity theorem.

## Meta changes
- progressSummary + builtItems refreshed to the current 388-line file (was stale at 122 lines)
- added the missing `SylowTheoremOQ04OQ03.lean` leanFiles entry
- added `state.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)