### PR TITLE
research(erdos-3-incomplete-01): VERIFY Bertrand-series divergence ∑1/(n·log n) [0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/Erdos3LogHarmonic.lean
+++ b/proofs/Proofs/Erdos3LogHarmonic.lean
@@ -1,0 +1,127 @@
+/-
+  Erdős #3 supporting lemma: divergence of the log-harmonic (Bertrand) series
+  ∑ 1/(n · log n).
+
+  This substantiates the counterexample profile documented in the
+  `StrongRequiredBound` docstring of `Erdos3Problem.lean`: a set whose counting
+  function sits at the `o(N / log N)` threshold (e.g. the primes, counting function
+  ~ N / log N) can still have a *divergent* reciprocal sum, since by partial
+  summation ∑_{a ≤ N} 1/a ~ ∑ 1/(n log n) → ∞. Hence `RequiredBound` (the
+  `o(N/log N)` threshold) is genuinely insufficient to force the AP conclusion; the
+  strictly stronger `StrongRequiredBound` `O(N/(log N)^{1+δ})` threshold is needed.
+
+  Proof: Cauchy condensation (`summable_condensed_iff_of_nonneg`) reduces summability
+  of `1/(n log n)` to summability of `∑ 2^k / (2^k · log 2^k) ≍ ∑ 1/(k log 2)`, a
+  constant multiple of the harmonic series, which diverges
+  (`not_summable_one_div_natCast`).
+
+  STATUS: [VERIFIED] — machine-checked with `docker-build.sh Proofs.Erdos3LogHarmonic`
+  (7743 jobs, 0 sorries). `#print axioms not_summable_one_div_nat_mul_log` reports only
+  the foundational trio `[propext, Classical.choice, Quot.sound]`; no `sorryAx`,
+  `Lean.ofReduceBool`, or added axioms.
+-/
+import Mathlib
+
+open Filter Real
+
+namespace Erdos3Bertrand
+
+/-- Shifted log-harmonic term `1/((n+2)·log(n+2))`; positive and antitone for all `n`. -/
+private noncomputable def f₂ (n : ℕ) : ℝ :=
+  1 / (((n : ℝ) + 2) * Real.log ((n : ℝ) + 2))
+
+private lemma f₂_nonneg (n : ℕ) : 0 ≤ f₂ n := by
+  unfold f₂
+  apply div_nonneg (by norm_num)
+  apply mul_nonneg (by positivity)
+  have : (1 : ℝ) ≤ (n : ℝ) + 2 := by have := Nat.cast_nonneg (α := ℝ) n; linarith
+  exact Real.log_nonneg this
+
+private lemma f₂_antitone : ∀ ⦃m n : ℕ⦄, 0 < m → m ≤ n → f₂ n ≤ f₂ m := by
+  intro m n _ hmn
+  unfold f₂
+  have hcastm : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+  have hm2 : (0 : ℝ) < ((m : ℝ) + 2) * Real.log ((m : ℝ) + 2) := by
+    apply mul_pos (by linarith)
+    exact Real.log_pos (by linarith)
+  apply one_div_le_one_div_of_le hm2
+  have hmn' : ((m : ℝ) + 2) ≤ ((n : ℝ) + 2) := by
+    have : (m : ℝ) ≤ (n : ℝ) := by exact_mod_cast hmn
+    linarith
+  apply mul_le_mul hmn' (Real.log_le_log (by linarith) hmn')
+    (Real.log_nonneg (by linarith)) (by linarith)
+
+/-- The lower bound on the condensed term used to compare against the harmonic series. -/
+private lemma cond_lower (j : ℕ) (hj : 1 ≤ j) :
+    1 / (2 * ((j : ℝ) + 1) * Real.log 2)
+      ≤ (2 : ℝ) ^ j / (((2 : ℝ) ^ j + 2) * Real.log ((2 : ℝ) ^ j + 2)) := by
+  have hpos_pow : (0 : ℝ) < 2 ^ j := by positivity
+  have hlog2_pos : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  have h2j : (2 : ℝ) ≤ 2 ^ j := by
+    calc (2 : ℝ) = 2 ^ 1 := (pow_one 2).symm
+      _ ≤ 2 ^ j := pow_le_pow_right₀ (by norm_num) hj
+  have hb1 : (0 : ℝ) < (2 : ℝ) ^ j + 2 := by positivity
+  have hlogb : (0 : ℝ) < Real.log ((2 : ℝ) ^ j + 2) := Real.log_pos (by linarith)
+  -- `2^j + 2 ≤ 2^(j+1)`
+  have hsum_le : (2 : ℝ) ^ j + 2 ≤ 2 ^ (j + 1) := by
+    rw [pow_succ]; linarith [h2j]
+  -- `log(2^j+2) ≤ (j+1)·log 2`
+  have hlog_le : Real.log ((2 : ℝ) ^ j + 2) ≤ ((j : ℝ) + 1) * Real.log 2 := by
+    have hstep : Real.log ((2 : ℝ) ^ j + 2) ≤ Real.log ((2 : ℝ) ^ (j + 1)) :=
+      Real.log_le_log hb1 hsum_le
+    rwa [Real.log_pow, Nat.cast_add, Nat.cast_one] at hstep
+  -- denominator product bound
+  have hD : (((2 : ℝ) ^ j + 2) * Real.log ((2 : ℝ) ^ j + 2))
+      ≤ 2 ^ (j + 1) * (((j : ℝ) + 1) * Real.log 2) :=
+    mul_le_mul hsum_le hlog_le (le_of_lt hlogb) (by positivity)
+  -- rewrite RHS as `1 / (D / 2^j)` and compare denominators
+  rw [show (2 : ℝ) ^ j / (((2 : ℝ) ^ j + 2) * Real.log ((2 : ℝ) ^ j + 2))
+        = 1 / ((((2 : ℝ) ^ j + 2) * Real.log ((2 : ℝ) ^ j + 2)) / 2 ^ j) from
+      (one_div_div _ _).symm]
+  apply one_div_le_one_div_of_le (by positivity)
+  rw [div_le_iff₀ hpos_pow]
+  calc (((2 : ℝ) ^ j + 2) * Real.log ((2 : ℝ) ^ j + 2))
+      ≤ 2 ^ (j + 1) * (((j : ℝ) + 1) * Real.log 2) := hD
+    _ = 2 * ((j : ℝ) + 1) * Real.log 2 * 2 ^ j := by rw [pow_succ]; ring
+
+private lemma not_summable_f₂ : ¬ Summable f₂ := by
+  intro hsum
+  -- Cauchy condensation: `f₂` summable ⟹ `∑ 2^k · f₂(2^k)` summable.
+  have hcond : Summable (fun k : ℕ => (2 : ℝ) ^ k * f₂ (2 ^ k)) :=
+    (summable_condensed_iff_of_nonneg f₂_nonneg f₂_antitone).mpr hsum
+  -- drop the `k = 0` term so the lower bound (valid for `j ≥ 1`) applies termwise
+  have hS1 : Summable (fun k : ℕ => (2 : ℝ) ^ (k + 1) * f₂ (2 ^ (k + 1))) :=
+    (summable_nat_add_iff 1).mpr hcond
+  have hlog2_pos : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  -- compare with `1/(2(k+2)log2)`, a constant multiple of the harmonic series
+  have hcomp : Summable (fun k : ℕ => 1 / (2 * ((k : ℝ) + 2) * Real.log 2)) := by
+    refine Summable.of_nonneg_of_le (fun k => by positivity) (fun k => ?_) hS1
+    have key := cond_lower (k + 1) (Nat.le_add_left 1 k)
+    have hlhs : (1 : ℝ) / (2 * ((k : ℝ) + 2) * Real.log 2)
+        = 1 / (2 * (((k + 1 : ℕ) : ℝ) + 1) * Real.log 2) := by push_cast; ring
+    have hrhs : (2 : ℝ) ^ (k + 1) * f₂ (2 ^ (k + 1))
+        = (2 : ℝ) ^ (k + 1)
+            / (((2 : ℝ) ^ (k + 1) + 2) * Real.log ((2 : ℝ) ^ (k + 1) + 2)) := by
+      unfold f₂; push_cast; ring
+    rw [hlhs, hrhs]; exact key
+  -- derive the harmonic series and contradict its divergence
+  have h2 : Summable (fun k : ℕ => 1 / ((k : ℝ) + 2)) := by
+    have hm := hcomp.mul_left (2 * Real.log 2)
+    refine hm.congr (fun k => ?_)
+    have hk2 : ((k : ℝ) + 2) ≠ 0 := by positivity
+    have hl2 : Real.log 2 ≠ 0 := ne_of_gt hlog2_pos
+    field_simp
+  have h2' : Summable (fun n : ℕ => 1 / (((n + 2 : ℕ)) : ℝ)) :=
+    h2.congr (fun k => by push_cast; ring)
+  exact not_summable_one_div_natCast ((summable_nat_add_iff 2).mp h2')
+
+/-- **The log-harmonic (Bertrand) series `∑ 1/(n · log n)` diverges.** -/
+theorem not_summable_one_div_nat_mul_log :
+    ¬ Summable (fun n : ℕ => 1 / ((n : ℝ) * Real.log n)) := by
+  intro hsum
+  -- shift by two (dropping the `n = 0, 1` terms, where the summand vanishes) lands on `f₂`
+  have hshift : Summable f₂ :=
+    ((summable_nat_add_iff 2).mpr hsum).congr (fun n => by unfold f₂; push_cast; ring)
+  exact not_summable_f₂ hshift
+
+end Erdos3Bertrand

--- a/research/problems/erdos-3-incomplete-01/state.md
+++ b/research/problems/erdos-3-incomplete-01/state.md
@@ -82,3 +82,16 @@ daemon; commit in `/tmp` immediately —
 - 4: added the low-length regime `k ≤ 2` (`infinite_of_hasDivergentSum`,
   `containsAP_two_of_lt`, `containsAP_two_of_infinite`,
   `hasDivergentSum_containsAP_le_two`); 0-axiom, 0-sorry, 7743 jobs verified.
+- 5: **VERIFIED** the previously build-blocked Bertrand-series divergence.
+  Recovered `Proofs/Erdos3LogHarmonic.lean` (staged UNVERIFIED in commit
+  fcc4a776011 when the build host was OOM-killing at 32 GB) onto clean main and
+  machine-checked it with `docker-build.sh Proofs.Erdos3LogHarmonic` (7743 jobs,
+  6.7 s target build). `not_summable_one_div_nat_mul_log`: ∑ 1/(n·log n) diverges
+  via Cauchy condensation (`summable_condensed_iff_of_nonneg`) → constant multiple
+  of the harmonic series (`not_summable_one_div_natCast`). `#print axioms` reports
+  only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`/`ofReduceBool`.
+  This substantiates the o(N/log N) counterexample profile in the
+  `StrongRequiredBound` docstring. Build host was healthy this session (0 docker
+  lean-build containers at build time), unlike the OOM-blocked session that staged it.
+  The threshold-critical `required_bound_implies_conjecture` sorry remains
+  documented and untouched (as hard as Erdős #3 itself).

--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -48,7 +48,19 @@
       "Behrend and Elkin constructions axiomatized",
       "Formal proof that Erdos #3 implies Green-Tao",
       "arithProg_card: a genuine k-term AP (d > 0) has exactly k elements, via injectivity of i ↦ a + i·d on range k — a reusable counting fact turning AP-containment into cardinality lower bounds",
-      "infinite_of_containsArbitrarilyLongAP: only infinite sets contain arbitrarily long APs (a finite set of size n cannot contain the (n+1)-element AP it would need), a sorry-free axiom-free sanity check on the conjecture's conclusion side"
+      "infinite_of_containsArbitrarilyLongAP: only infinite sets contain arbitrarily long APs (a finite set of size n cannot contain the (n+1)-element AP it would need), a sorry-free axiom-free sanity check on the conjecture's conclusion side",
+      "not_summable_one_div_nat_mul_log (Proofs/Erdos3LogHarmonic.lean): a self-contained, sorry-free, axiom-free Cauchy-condensation proof that the log-harmonic (Bertrand) series ∑ 1/(n·log n) diverges — no equivalent exists in Mathlib v4.26. This substantiates the counterexample profile behind the o(N/log N) threshold: a set at that density (e.g. the primes, counting function ~ N/log N) can still have a divergent reciprocal sum, so RequiredBound alone cannot force the AP conclusion and the strictly stronger StrongRequiredBound O(N/(log N)^{1+δ}) threshold is genuinely needed"
+    ],
+    "additionalFiles": [
+      {
+        "path": "Proofs/Erdos3LogHarmonic.lean",
+        "description": "Divergence of the log-harmonic (Bertrand) series ∑ 1/(n·log n) via Cauchy condensation; substantiates the o(N/log N) counterexample profile in Erdos3Problem.lean's StrongRequiredBound docstring. Machine-checked, 0 sorries, axioms only [propext, Classical.choice, Quot.sound].",
+        "status": "verified",
+        "sorries": 0,
+        "axiomCount": 0,
+        "theoremCount": 1,
+        "lineCount": 127
+      }
     ],
     "axiomCount": 0,
     "lineCount": 163,


### PR DESCRIPTION
## Summary

Recovers and **machine-verifies** `proofs/Proofs/Erdos3LogHarmonic.lean` — a self-contained Cauchy-condensation proof that the log-harmonic (Bertrand) series ∑ 1/(n·log n) **diverges**. This file was staged UNVERIFIED in commit `fcc4a776011` when the build host was OOM-killing at 32 GB; it was never merged. This session the build host was healthy (0 concurrent lean-build containers), so the proof is now confirmed.

## The theorem

```lean
theorem not_summable_one_div_nat_mul_log :
    ¬ Summable (fun n : ℕ => 1 / ((n : ℝ) * Real.log n))
```

Proof route: Cauchy condensation (`summable_condensed_iff_of_nonneg`) reduces summability of `1/(n·log n)` to that of `∑ 2^k/(2^k·log 2^k) ≍ ∑ 1/(k·log 2)`, a constant multiple of the harmonic series, contradicted by `not_summable_one_div_natCast`. No equivalent lemma exists in Mathlib v4.26.

## Verification

- `docker-build.sh Proofs.Erdos3LogHarmonic` → **7743 jobs, 0 sorries**, target built in 6.7 s.
- `#print axioms not_summable_one_div_nat_mul_log` → `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`, no added axioms. **Fully verified.**

## Why it matters

It substantiates the `o(N/log N)` counterexample profile in `Erdos3Problem.lean`'s `StrongRequiredBound` docstring: a set at that density threshold (e.g. the primes, counting function ~ N/log N) can still have a divergent reciprocal sum. Hence `RequiredBound` alone cannot force the AP conclusion, and the strictly stronger `StrongRequiredBound` O(N/(log N)^{1+δ}) threshold is genuinely needed.

## Scope

Additive: a new supporting file plus meta/state bookkeeping. The main `Erdos3Problem.lean` is unchanged — its threshold-critical `required_bound_implies_conjecture` sorry remains documented and untouched (as hard as Erdős #3 itself; open \$5000 conjecture, status stays `axiomatized`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)