### PR TITLE
research(erdos-729-oq-02): repair Erdos729Problem.lean build (broken on main, never CI-verified) [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos729Problem.lean
+++ b/proofs/Proofs/Erdos729Problem.lean
@@ -45,14 +45,14 @@ theorem legendre_formula (p n : ℕ) (hp : Nat.Prime p) :
   haveI : Fact p.Prime := ⟨hp⟩
   rcases eq_or_ne n 0 with rfl | hn
   · simp [factorialPadicVal]
-  · have hlog : Nat.log p n < n + 1 := by
-      rw [Nat.log_lt hp.one_lt hn]
-      calc n < 2 ^ n := Nat.lt_two_pow n
-        _ ≤ p ^ n := Nat.pow_le_pow_left hp.two_le n
-        _ ≤ p ^ (n + 1) := Nat.pow_le_pow_right hp.pos (Nat.le_succ n)
+  · have hlog : Nat.log p n < n + 1 :=
+      Nat.log_lt_of_lt_pow hn <| by
+        calc n < 2 ^ n := n.lt_two_pow_self
+          _ ≤ p ^ n := Nat.pow_le_pow_left hp.two_le n
+          _ ≤ p ^ (n + 1) := Nat.pow_le_pow_right hp.pos (Nat.le_succ n)
     rw [padicValNat_factorial hlog, Finset.sum_Ico_eq_sum_range]
     unfold factorialPadicVal
-    exact Finset.sum_congr (by omega) fun k _ => by rw [add_comm]
+    exact Finset.sum_congr (by rw [Nat.add_sub_cancel]) fun k _ => by rw [Nat.add_comm 1 k]
 
 /-- The quotient n!/(a!b!) as a rational (may not be an integer) -/
 def factorialQuotient (n a b : ℕ) : ℚ :=
@@ -135,33 +135,31 @@ axiom barreto_leeham_bound (C : ℝ) (hC : C > 0) :
 Modification of the argument for Problem #728.
 -/
 
-/-- The proof extends the powers-of-2 argument: large primes contribute
-    significantly to the p-adic valuation constraints. For any prime p > C,
-    the constraint v_p(a!) + v_p(b!) ≤ v_p(n!) still yields a + b ≤ n + O(log n). -/
+/-
+The proof extends the powers-of-2 argument: large primes contribute
+significantly to the p-adic valuation constraints. For any prime p > C,
+the constraint v_p(a!) + v_p(b!) ≤ v_p(n!) still yields a + b ≤ n + O(log n).
+-/
 /-
 ## Part 7: Legendre's Formula Details
 
 The p-adic valuation of factorials.
 -/
 
-/-- v_p(n!) = (n - s_p(n))/(p-1) where s_p(n) is digit sum in base p -/
-noncomputable def digitSum (p n : ℕ) : ℕ :=
-  if n = 0 then 0
-  else n % p + digitSum p (n / p)
+/-- `s_p(n)`, the digit sum of `n` in base `p`, defined directly from Mathlib's
+    base-`p` digit list `Nat.digits p n`.
 
-/-- The file's recursive `digitSum p n` agrees with Mathlib's base-`p` digit sum
-    `(Nat.digits p n).sum` for any base `p > 1`. -/
-theorem digitSum_eq_digits_sum (p : ℕ) (hp : 1 < p) (n : ℕ) :
-    digitSum p n = (Nat.digits p n).sum := by
-  induction n using Nat.strong_induction_on with
-  | _ n ih =>
-    rcases eq_or_ne n 0 with rfl | hn
-    · simp [digitSum]
-    · have hpos : 0 < n := Nat.pos_of_ne_zero hn
-      have hunfold : digitSum p n = n % p + digitSum p (n / p) := by
-        rw [digitSum.eq_def, if_neg hn]
-      rw [hunfold, Nat.digits_def' hp hpos, List.sum_cons,
-        ih (n / p) (Nat.div_lt_self hpos hp)]
+    (A naive recursion `n % p + digitSum p (n / p)` is ill-founded for `p ≤ 1`
+    — e.g. `p = 1` gives `n / 1 = n` and never terminates — so we reuse
+    Mathlib's `Nat.digits`, which is defined by well-founded recursion on `n`
+    with the base handled correctly.) -/
+def digitSum (p n : ℕ) : ℕ := (Nat.digits p n).sum
+
+/-- The file's `digitSum p n` agrees with Mathlib's base-`p` digit sum
+    `(Nat.digits p n).sum`. Definitional; the `1 < p` hypothesis is retained for
+    call-site compatibility. -/
+theorem digitSum_eq_digits_sum (p : ℕ) (_hp : 1 < p) (n : ℕ) :
+    digitSum p n = (Nat.digits p n).sum := rfl
 
 /-- For p = 2: v_2(n!) = n - s_2(n).
 
@@ -183,9 +181,9 @@ theorem legendre_for_two (n : ℕ) :
 What the result tells us about factorial structure.
 -/
 
-/-- The structure of factorials is rigid: the constraint a + b ≤ n + O(log n)
-    comes from ALL sufficiently large primes, not just a few small ones. -/
-/-- Binomial coefficients inherit this rigidity -/
+/-- Binomial coefficients inherit the factorial rigidity: the constraint
+    `a + b ≤ n + O(log n)` comes from ALL sufficiently large primes, not just a
+    few small ones. -/
 theorem binomial_rigidity (n a b : ℕ) (hab : a + b = n) :
     -- n!/(a!b!) = C(n, a) is always an integer
     DividesFactorial n a b := by

--- a/research/problems/erdos-729-oq-02/state.md
+++ b/research/problems/erdos-729-oq-02/state.md
@@ -7,27 +7,37 @@
 **Iteration**: 2
 
 ## Current Focus
-OQ-02 resolved: `legendre_for_two` ($v_2(n!) = n - s_2(n)$) is now proved
-axiom-free from Mathlib's `sub_one_mul_padicValNat_factorial`. The
-`legendre_identity` axiom has been deleted (file axiom count 4 → 3).
+OQ-02 resolved and now BUILD-VERIFIED: `legendre_for_two` ($v_2(n!) = n - s_2(n)$)
+is proved axiom-free from Mathlib's `sub_one_mul_padicValNat_factorial`. The
+`legendre_identity` axiom was deleted (file axiom count 4 → 3). The three
+remaining axioms (`erdos_1968_classical`, `barreto_leeham_theorem`,
+`barreto_leeham_bound`) are the genuinely deep open math, out of scope.
 
 ## Active Approach
-Direct application of Mathlib's Legendre theorem at $p = 2$, plus a strong-induction
-bridge `digitSum_eq_digits_sum` from the file's recursive digit sum to
-`(Nat.digits p n).sum`.
+Direct application of Mathlib's Legendre theorem at $p = 2$. `digitSum p n` is now
+defined directly as `(Nat.digits p n).sum` (the previous naive recursion
+`n % p + digitSum p (n / p)` was ill-founded for `p ≤ 1`), so the bridge
+`digitSum_eq_digits_sum` is definitional (`rfl`).
 
 ## Attempt Count
-- Total attempts: 1
+- Total attempts: 2
 - Current approach attempts: 1
 - Approaches tried: 1
 
 ## Blockers
-Docker build wrapper unavailable this session (blackout). Proof shipped
-build-pending after full name-check against sibling mathlib4 v4.26.0.
-Sole at-risk line: `rw [digitSum.eq_def, if_neg hn]` (wf-def unfold idiom).
+None. `Erdos729Problem.lean` builds cleanly (`Built Proofs.Erdos729Problem`,
+0 sorries, 3 axioms).
 
 ## Next Action
-Build-verify when Docker returns:
-`./proofs/scripts/docker-build.sh Proofs.Erdos729Problem`.
+Build-repair complete. The file had been committed build-pending during a Docker
+blackout and merged without Lean CI (math PRs auto-merge); the first real build
+exposed four latent errors, all now fixed:
+- ill-founded `digitSum` recursion → redefined via `Nat.digits`;
+- `Nat.log_lt` (removed) → `Nat.log_lt_of_lt_pow`;
+- `Nat.lt_two_pow n` (removed in v4.26) → `n.lt_two_pow_self`;
+- `Finset.sum_congr (by omega)` (omega can't prove a Finset equality) →
+  `by rw [Nat.add_sub_cancel]`, with the `1+k = k+1` index shift via `Nat.add_comm`;
+- two orphaned `/--` doc comments causing parse errors → `/-` block comments.
+
 Remaining axioms (Erdős 1968, Barreto–Leeham) are the genuinely deep open math,
 out of scope for OQ-02.


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos729Problem.lean` did **not compile on main**. It was committed build-pending during a Docker blackout and merged without Lean CI (math PRs auto-merge; the sibling "verified" PRs #27257/#27264 built only the recurrence/general files, never this one). The first real build exposed **four pre-existing errors**, all fixed here.

**VERIFIED**: `Built Proofs.Erdos729Problem` (7743 jobs, 3.4s), **0 sorries, 3 axioms** (unchanged).

## Fixes

| Location | Problem | Fix |
|---|---|---|
| `digitSum` def | Naive recursion `n % p + digitSum p (n/p)` is **ill-founded for `p ≤ 1`** (`p=1`: `n/1=n`, never terminates) → Lean can't prove termination, no `digitSum.eq_def` generated | Redefined via Mathlib: `digitSum p n := (Nat.digits p n).sum`; bridge `digitSum_eq_digits_sum` now definitional (`rfl`), `1<p` hyp kept for call-site compat |
| L49 | `Nat.log_lt` — unknown constant | `Nat.log_lt_of_lt_pow` |
| L50 | `Nat.lt_two_pow n` — removed in v4.26 | `n.lt_two_pow_self` |
| L55 | `Finset.sum_congr (by omega)` — omega can't prove the Finset equality `range (n+1-1) = range n` | `by rw [Nat.add_sub_cancel]`; index shift `1+k=k+1` via `Nat.add_comm` |
| L138, L186 | Two orphaned `/--` doc comments (not attached to a declaration) → `unexpected token` parse errors | Converted to `/-` block comments / merged into the theorem docstring |

## Scope

The three remaining axioms (`erdos_1968_classical`, `barreto_leeham_theorem`, `barreto_leeham_bound`) are the genuinely deep open math and are out of scope. No new axioms, no sorries, no statement changes to `legendre_for_two` / `legendre_formula`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)