### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02-wip-01): add kronecker2_mul [0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -200,6 +200,24 @@ private theorem kronecker0_mul (a b : ℤ) (hab : a * b ≠ 0) :
           (show a * (-b) = 1 by simp [mul_neg, h]))
     simp only [kronecker0, if_neg hnu, if_neg ha, zero_mul]
 
+/-- `kronecker2` (the `(·/2)` character) is completely multiplicative:
+    `(ab/2) = (a/2)(b/2)`, unconditionally (a zero factor makes both sides 0).
+    Since `kronecker2 x` depends only on `x % 8`, this reduces to a finite check
+    over the 64 residue pairs mod 8. -/
+theorem kronecker2_mul (a b : ℤ) :
+    kronecker2 (a * b) = kronecker2 a * kronecker2 b := by
+  have hred : ∀ x : ℤ, kronecker2 x = kronecker2 (x % 8) := by
+    intro x
+    unfold kronecker2
+    rw [Int.emod_emod_of_dvd x (by norm_num : (2 : ℤ) ∣ 8),
+      Int.emod_emod_of_dvd x (by norm_num : (8 : ℤ) ∣ 8)]
+  rw [hred a, hred b, hred (a * b), Int.mul_emod]
+  have hra : 0 ≤ a % 8 := Int.emod_nonneg a (by norm_num)
+  have hrb : a % 8 < 8 := Int.emod_lt_of_pos a (by norm_num)
+  have hsa : 0 ≤ b % 8 := Int.emod_nonneg b (by norm_num)
+  have hsb : b % 8 < 8 := Int.emod_lt_of_pos b (by norm_num)
+  interval_cases (a % 8) <;> interval_cases (b % 8) <;> decide
+
 /-- The Kronecker symbol is completely multiplicative in the first argument:
     (ab/n) = (a/n)(b/n), provided a*b ≠ 0.
 

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -36,8 +36,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Target 1 (full second-argument multiplicativity) proven and machine-verified: added kronecker_eq_sign_jacobi (normal form sign(n)*J(a||n|) for nonzero n), kroneckerNeg1_sq, and kronecker_mul_right over all nonzero moduli. File builds 0 sorries / 0 axioms under Mathlib v4.26. The prior session assumed the general case needs supplementary (2/n),(-1/n) laws; that holds for the classical symbol but not for this file, whose definition routes the whole modulus through jacobiSym |n|, making multiplicativity a direct consequence of jacobiSym.mul_right' (nonzero, no oddness).",
+    "progressSummary": "Target 1 (full second-argument multiplicativity) proven and machine-verified; file builds 0 sorries / 0 axioms under Mathlib v4.26. This session (researcher-3) adds the missing companion to kroneckerNeg1_mul/kronecker0_mul: kronecker2_mul — the (·/2) mod-8 character is completely multiplicative, (ab/2)=(a/2)(b/2), UNCONDITIONALLY (a zero factor makes both sides 0). Proved by reducing kronecker2 to a function of x%8 (Int.emod_emod_of_dvd) and Int.mul_emod, then a 64-case interval_cases/decide over the residue pairs. This is exactly the 2-adic building block nextStep 1 needs to refine kronecker to route even moduli through kronecker2 (classical symbol) rather than jacobiSym|n|.",
     "builtItems": [
+      "kronecker2_mul (ElementaryQuadraticReciprocityOQ03OQ02.lean): (ab/2)=(a/2)(b/2) unconditional multiplicativity of the (·/2) mod-8 character, via x%8 reduction + 64-case decide.",
       "kronecker_mul_right_odd",
       "kronecker_quadratic_reciprocity",
       "kronecker_reciprocity_one_mod_four",


### PR DESCRIPTION
## Summary

Adds `kronecker2_mul` to `ElementaryQuadraticReciprocityOQ03OQ02.lean`: the `(·/2)` mod-8 character is completely multiplicative,

```
(ab/2) = (a/2)(b/2)
```

**unconditionally** (a zero factor makes both sides 0 — no oddness/nonzero hypothesis).

## Why it matters

The file already proves multiplicativity of the two other special-modulus symbols — `kroneckerNeg1_mul` (the sign character `(·/−1)`) and `kronecker0_mul` (the `(·/0)` symbol) — but was **missing** the `(·/2)` case. `kronecker2_mul` fills that gap. It is precisely the 2-adic building block the tracked **nextStep 1** needs to refine `kronecker` so that even moduli route through `kronecker2` (the classical `(·/2)` symbol) instead of `jacobiSym |n|`.

## Proof

`kronecker2 x` depends only on `x % 8`, so:
1. `kronecker2 x = kronecker2 (x % 8)` via `Int.emod_emod_of_dvd` (`2 ∣ 8`, `8 ∣ 8`);
2. `Int.mul_emod` pushes the product inside;
3. `interval_cases (a % 8) <;> interval_cases (b % 8) <;> decide` — a finite check over the 64 residue pairs.

## Verification

`docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02` succeeds at the default 32GB limit. File remains **0 sorry / 0 axiom**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)