### PR TITLE
audit(re-audit): refresh tracker for 4 changed-since-audit proofs (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4556,9 +4556,9 @@
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T06:13:49Z",
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-01-oq-01": {
@@ -9859,8 +9859,8 @@
       "result": "clean"
     },
     "erdos-1098-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T15:54:06Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T06:13:49Z",
       "result": "clean",
       "issues": []
     },
@@ -12357,9 +12357,10 @@
     },
     "erdos-3": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:26Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T06:13:49Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-30": {
       "agentId": "auditor-cycle-20-batch",
@@ -27334,9 +27335,9 @@
       "result": "clean"
     },
     "automorphic-number-oq-01-oq-02-oq-01-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-07-08T05:49:40Z",
+      "lastAudited": "2026-07-08T06:13:49Z",
       "result": "clean"
     },
     "ballot-problem-oq-05": {
@@ -29555,5 +29556,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T06:05:08Z"
+  "lastUpdated": "2026-07-08T06:13:49Z"
 }


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Backlog is 0 (all 4775 proofs audited). Re-audited the 4 proofs whose `meta.json` was committed *after* their last audit timestamp. All **CLEAN** — public claims match the Lean kernel.

| Slug | status/badge | sorries | axiomCount | Verdict |
|------|-------------|---------|-----------|---------|
| erdos-1098-oq-01-oq-03 | axiomatized / axiom | 0 | 1 (`neumann_hard_direction` L310) | ✅ accurate |
| automorphic-number-oq-01-oq-02-oq-01-oq-02 | verified / original | 0 | 0 | ✅ file clean |
| erdos-3 | axiomatized / axiom | 1 (real gap L170) | 0 | ✅ honest disclosure |
| cauchy-interlacing-theorem-oq-01-oq-01 | verified / mathlib | 0 | 0 | ✅ Mathlib bridge credited |

**Checks run per proof:** actual `sorry` count vs `meta.sorries`, literal `axiom` + structure-field assumptions vs `axiomCount`, `native_decide`/`Lean.ofReduceBool` exposure, True-stub detection, badge/tier alignment.

- `erdos-3` `meta.sorries=1` correctly tracks the genuine open analytic-summation sorry at `Erdos3Problem.lean:170`; `axiomatized` is the conservative status for an open Erdős problem.
- `cauchy-interlacing` badge `mathlib` correctly signals the core result comes via a Mathlib bridge (Tier B).

Only `audit-tracker.json` changed (4 entries + `lastUpdated`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)