### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02-wip-01): Kronecker supplementary laws (-1/n), (2/n) at odd moduli [VERIFIED]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -343,6 +343,37 @@ theorem kronecker_reciprocity_one_mod_four (m n : ℕ)
   rw [kronecker_eq_jacobi (m : ℤ) n hn hno, kronecker_eq_jacobi (n : ℤ) m hmpos hmo]
   exact jacobiSym.quadratic_reciprocity_one_mod_four hm (Nat.odd_iff.mpr hno)
 
+-- ============================================================
+-- Section 8: Supplementary Laws at Odd Moduli
+-- ============================================================
+
+/-- **First supplementary law `(-1/n)` at odd moduli.**
+    For odd positive `n`, `(-1/n) = 1` if `n ≡ 1 (mod 4)` and `-1` if
+    `n ≡ 3 (mod 4)`. This is the `-1` half of the supplementary laws that
+    generalized quadratic reciprocity for arbitrary fundamental discriminants
+    (refinement 2) needs. It follows from agreement with the Jacobi symbol
+    (`kronecker_eq_jacobi`) and Mathlib's `jacobiSym.at_neg_one`
+    (`J(-1 | n) = χ₄ n`), unfolded via `ZMod.χ₄_nat_eq_if_mod_four`.
+    `sorry`-free, axiom-free. -/
+theorem kronecker_neg_one_odd (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker (-1) n = if n % 4 = 1 then 1 else -1 := by
+  rw [kronecker_eq_jacobi (-1) n hn hno, jacobiSym.at_neg_one (Nat.odd_iff.mpr hno),
+    ZMod.χ₄_nat_eq_if_mod_four, if_neg (show ¬ n % 2 = 0 by omega)]
+
+/-- **Second supplementary law `(2/n)` at odd moduli.**
+    For odd positive `n`, `(2/n) = 1` if `n ≡ ±1 (mod 8)` and `-1` if
+    `n ≡ ±3 (mod 8)`. This is the `2` half of the supplementary laws needed for
+    refinement 2. It follows from `kronecker_eq_jacobi` and Mathlib's
+    `jacobiSym.at_two` (`J(2 | n) = χ₈ n`), unfolded via
+    `ZMod.χ₈_nat_eq_if_mod_eight`. Note this is the value of the symbol at a
+    fixed *numerator* `2` as the odd *denominator* `n` varies — complementary to
+    `kronecker2` (the `(·/2)` character, a function of the numerator).
+    `sorry`-free, axiom-free. -/
+theorem kronecker_two_odd (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker 2 n = if n % 8 = 1 ∨ n % 8 = 7 then 1 else -1 := by
+  rw [kronecker_eq_jacobi 2 n hn hno, jacobiSym.at_two (Nat.odd_iff.mpr hno),
+    ZMod.χ₈_nat_eq_if_mod_eight, if_neg (show ¬ n % 2 = 0 by omega)]
+
 /-!
 ## Module note: what remains open
 
@@ -367,9 +398,12 @@ moduli and at `n = ±1`). Two refinements remain open: (1) wiring `kronecker2`
 into the definition so it becomes the classical Kronecker symbol at even
 moduli, and re-proving multiplicativity for that refined symbol; and (2) the
 **generalized quadratic reciprocity** law for arbitrary fundamental
-discriminants (the class-field-theory / Artin form), which needs the
-supplementary laws `(2/n)`, `(-1/n)` and a Gauss-sum argument. The odd
-positive reciprocity case is `kronecker_quadratic_reciprocity` above.
+discriminants (the class-field-theory / Artin form), which still needs a
+Gauss-sum argument. Two of its ingredients — the supplementary laws `(-1/n)`
+and `(2/n)` at odd moduli — are now proved (`kronecker_neg_one_odd`,
+`kronecker_two_odd` in Section 8), leaving the Gauss-sum / reciprocity core.
+The odd positive main reciprocity case is `kronecker_quadratic_reciprocity`
+above.
 -/
 
 -- Axiom audits: headline theorems should use only the standard foundational

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
@@ -22,15 +22,22 @@ None for Target 1. Two refinements remain open (documented, not axiomatized):
    Kronecker symbol at even moduli (current def routes even moduli through
    `jacobiSym |n|`), then re-prove multiplicativity for that refined symbol.
 2. Generalized quadratic reciprocity for arbitrary fundamental discriminants
-   (Target 2) — needs the supplementary laws `(2/n)`, `(-1/n)` + Gauss sums.
+   (Target 2) — needs a Gauss-sum argument. **Its two supplementary-law
+   ingredients are now proved** (build-verified, 3058 jobs):
+   `kronecker_neg_one_odd` — `(-1/n) = 1` if `n≡1 mod 4`, `-1` if `n≡3 mod 4`;
+   `kronecker_two_odd` — `(2/n) = 1` if `n≡±1 mod 8`, `-1` if `n≡±3 mod 8`.
+   Both reduce to `kronecker_eq_jacobi` + `jacobiSym.at_neg_one`/`at_two` +
+   `ZMod.χ₄`/`χ₈` conditional forms. Only the Gauss-sum / reciprocity core remains.
 
 ## Next Action
 
-Optionally attempt refinement (1): redefine `kronecker` to use `kronecker2` for the
-2-adic part and re-establish `kronecker_mul_right` via `kronecker2` multiplicativity.
+Refinement (2) core: the generalized-reciprocity law itself (Gauss sums) — the
+supplementary laws are done. Or refinement (1): redefine `kronecker` to use
+`kronecker2` for the 2-adic part and re-establish `kronecker_mul_right` via
+`kronecker2` multiplicativity.
 
 ## Attempt Counts
 
-- Total attempts: 1
+- Total attempts: 2
 - Current approach attempts: 1
 - Approaches tried: 1


### PR DESCRIPTION
## Summary

Adds the two **supplementary laws** for the Kronecker symbol at odd moduli — the ingredients that the module note's *refinement (2)* (generalized quadratic reciprocity for arbitrary fundamental discriminants) explicitly listed as still-needed:

| Theorem | Statement (odd `n > 0`) |
|---|---|
| `kronecker_neg_one_odd` | `(-1/n) = 1` if `n ≡ 1 (mod 4)`, `-1` if `n ≡ 3 (mod 4)` |
| `kronecker_two_odd` | `(2/n) = 1` if `n ≡ ±1 (mod 8)`, `-1` if `n ≡ ±3 (mod 8)` |

Each reduces cleanly to agreement with the Jacobi symbol (`kronecker_eq_jacobi`) composed with Mathlib's `jacobiSym.at_neg_one` (`J(-1|n) = χ₄ n`) / `jacobiSym.at_two` (`J(2|n) = χ₈ n`), unfolded through the explicit conditional forms `ZMod.χ₄_nat_eq_if_mod_four` / `ZMod.χ₈_nat_eq_if_mod_eight`; the outer `n % 2 = 0` branch is discharged by `omega` from oddness.

## Verification

**VERIFIED**: `Built Proofs.ElementaryQuadraticReciprocityOQ03OQ02` (3058 jobs, 2.1s), **0 sorry, 0 axiom**.

## Context

This builds on the merged Target 1 (#35163, full second-argument multiplicativity). The module note and `state.md` are updated to record the supplementary laws as done, leaving only the Gauss-sum reciprocity core for refinement (2). Note `kronecker_two_odd` (value at fixed numerator `2`, varying odd denominator) is complementary to the existing `kronecker2` (the `(·/2)` character, a function of the numerator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)