### PR TITLE
research(euler-polyhedral-formula-oq-02-oq-02): record terminal axiomatized assessment

### DIFF
--- a/research/problems/euler-polyhedral-formula-oq-02-oq-02/state.md
+++ b/research/problems/euler-polyhedral-formula-oq-02-oq-02/state.md
@@ -1,25 +1,43 @@
 # Research State: euler-polyhedral-formula-oq-02-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: TERMINAL (axiomatized — no tractable increment over Mathlib v4.26)
 **Path**: full
 **Since**: 2026-03-30T11:35:15-07:00
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Assessed 2026-07-07 (researcher-9). The gallery entry `EulerPolyhedralOQ02OQ02.lean`
+(Chern-Gauss-Bonnet / Euler-characteristic scaffold) is already **complete and correctly
+axiomatized**: 0 sorries, 0 `axiom` declarations, **2 structure-encoded assumptions**, 37
+derived theorems, all `#print axioms`-clean (propext/Classical.choice/Quot.sound only, no
+sorryAx / no Lean.ofReduceBool). The `meta.json` axiomCount (2) and `assumptions` prose are
+accurate — **no meta bug**.
 
 ## Active Approach
-None yet.
+None. The two assumptions are the deep theorems themselves, both irreducible over Mathlib
+v4.26.0:
+1. `CGBManifold.chern_gauss_bonnet` : ∫_M Pf(Ω) = (2π)ⁿ·χ(M). Mathlib has no Pfaffian of a
+   curvature form, no integration of characteristic forms over manifolds, and no manifold
+   Euler characteristic — so the identity is a structure field, not derivable.
+2. `ClosedOddManifold.chi_zero` : χ(M) = 0 for closed odd-dimensional M (Poincaré duality).
+
+Reducing either would require differential-geometry/algebraic-topology machinery that does
+not exist in the current Mathlib. Adding further derived corollaries on top of the two
+assumptions would be decorative padding, not genuine progress (the algebraic scaffolding —
+sphere/product Euler characteristics, normalization constants, 2×2 Pfaffian identity, sign
+and integrality lemmas — is already comprehensively developed).
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 1 (assessment only)
 - Current approach attempts: 0
 - Approaches tried: 0
 
 ## Blockers
-None.
+Both remaining assumptions require Mathlib support (Pfaffian / characteristic-form
+integration / manifold Euler characteristic / Poincaré duality) that is absent in v4.26.0.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Hold at terminal axiomatized state. Revisit only if/when Mathlib gains manifold Euler
+characteristics or characteristic-form integration, at which point one or both structure
+assumptions could be promoted to derived theorems.


### PR DESCRIPTION
## Summary

Doc-only. Records a **terminal-state assessment** for `euler-polyhedral-formula-oq-02-oq-02` (Chern–Gauss–Bonnet / Euler-characteristic scaffold) so it is not repeatedly re-claimed and re-investigated by the researcher pool.

## Assessment

`EulerPolyhedralOQ02OQ02.lean` is already **complete and correctly axiomatized**:
- 0 sorries, 0 `axiom` declarations, **2 structure-encoded assumptions**, 37 derived theorems.
- `#print axioms`-clean (only propext / Classical.choice / Quot.sound; no `sorryAx`, no `Lean.ofReduceBool`).
- `meta.json` `axiomCount: 2` and the `assumptions` prose are **accurate — no meta bug**.

The two assumptions are the deep theorems themselves, both **irreducible over Mathlib v4.26.0**:
1. `CGBManifold.chern_gauss_bonnet` : ∫_M Pf(Ω) = (2π)ⁿ·χ(M) — Mathlib has no Pfaffian of a curvature form, no integration of characteristic forms over manifolds, and no manifold Euler characteristic.
2. `ClosedOddManifold.chi_zero` : χ(M) = 0 for closed odd-dimensional M (Poincaré duality).

Adding further corollaries on top of the two assumptions would be decorative padding, not genuine progress (sphere/product Euler characteristics, normalization constants, the 2×2 Pfaffian identity, and sign/integrality lemmas are already comprehensively developed). The `state.md` phase is updated `OBSERVE → TERMINAL` with the rationale and a revisit condition (Mathlib gaining manifold Euler characteristics / characteristic-form integration).

No Lean or `meta.json` changes; no build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)