### PR TITLE
research(amgm-oq020201): signed Newton n=4 k=2 — first intermediate index [VERIFIED]

### DIFF
--- a/proofs/Proofs/NewtonSignedInputs.lean
+++ b/proofs/Proofs/NewtonSignedInputs.lean
@@ -35,10 +35,15 @@
         (ab+bc+ca)² - 3abc(a+b+c) = ½[(ab-bc)² + (bc-ca)² + (ca-ab)²].
     The gallery's `newton_n3_k2` states the same inequality but assumes
     a,b,c ≥ 0; the certificate above shows the hypothesis is unnecessary.
+  * `newton_n4_k2_signed`: the FIRST genuinely intermediate index, n = 4, k = 2
+    (1 < 2 < 3 = n-1), for arbitrary reals a,b,c,d, via the SOS certificate
+        4e₂² − 9e₁e₃ = 3·∑(ab−cd)² + ½·∑((a−b)(c−d))².
+    This is neither the k = 1 base nor the top index k = n-1; it shows the
+    smallest interior Newton inequality is still elementary.
 
-  Frontier.  The intermediate indices 1 < k < n-1 for general n still require
-  the real-rootedness / Rolle machinery (differentiate ∏(t-xᵢ), which stays
-  real-rooted, to reduce k) and are NOT proved here; see the note at the end.
+  Frontier.  The remaining intermediate indices 1 < k < n-1 for n ≥ 5 still
+  require the real-rootedness / Rolle machinery (differentiate ∏(t-xᵢ), which
+  stays real-rooted, to reduce k) and are NOT proved here; see the note at the end.
 
   References:
   - Hardy–Littlewood–Pólya, "Inequalities" (1934), §2.22, Theorem 51.
@@ -170,11 +175,54 @@ theorem newton_n3_k2_signed (a b c : ℝ) :
              sq_nonneg (c * a - a * b)]
 
 /-
-## Frontier: the intermediate indices 1 < k < n-1
+## Part IV: The first genuinely intermediate index — n = 4, k = 2 (signed)
+
+For `n = 3` the index `k = 2` coincides with the top index `n - 1`, so it is
+covered by reciprocal duality.  The *first* index strictly between the bottom
+(`k = 1`, Cauchy–Schwarz) and the top (`k = n - 1`, `newton_signed_top`) occurs
+at `n = 4, k = 2` (here `1 < 2 < 3`).  It is not reachable by either the k = 1
+Cauchy–Schwarz argument or the top-index reciprocal duality, yet — like every
+Newton inequality — it holds for ALL real inputs, because `∏ᵢ (t - xᵢ)` is
+real-rooted regardless of the signs of the `xᵢ`.
+
+The proof below is a direct sum-of-squares certificate, exhibiting the frontier
+case as elementary after all.  With `eⱼ` the elementary symmetric polynomials of
+`a, b, c, d`, Newton at `k = 2` is `p₂² ≥ p₁ p₃` with
+`p₁ = e₁/4, p₂ = e₂/6, p₃ = e₃/4`; clearing the `144` denominator this reads
+`4 e₂² ≥ 9 e₁ e₃`, and the exact identity
+
+    4 e₂² − 9 e₁ e₃
+      = 3·[(ab−cd)² + (ac−bd)² + (ad−bc)²]
+        + ½·[((a−b)(c−d))² + ((a−c)(b−d))² + ((a−d)(b−c))²]
+
+(both sides verified by expansion) certifies non-negativity for every real
+`a, b, c, d`.  The two square families are indexed by the three ways to split the
+four indices into complementary pairs.
+-/
+
+/-- **Newton's inequality for n = 4, k = 2, signed inputs (the first genuinely
+intermediate index).**  With `p₁ = e₁/4`, `p₂ = e₂/6`, `p₃ = e₃/4` the
+normalized Newton means of four arbitrary reals `a, b, c, d`,
+    p₂² ≥ p₁ · p₃,
+i.e. `((ab+ac+ad+bc+bd+cd)/6)² ≥ ((a+b+c+d)/4)·((abc+abd+acd+bcd)/4)`.
+No non-negativity is required: this is the first Newton index that is neither the
+Cauchy–Schwarz base (`k = 1`) nor the reciprocal-duality top (`k = n-1`), proved
+here by the sum-of-squares certificate `4e₂² − 9e₁e₃ = 3·∑(pair−pair)² +
+½·∑((diff)(diff))²`. -/
+theorem newton_n4_k2_signed (a b c d : ℝ) :
+    ((a * b + a * c + a * d + b * c + b * d + c * d) / 6) ^ 2
+      ≥ ((a + b + c + d) / 4) * ((a * b * c + a * b * d + a * c * d + b * c * d) / 4) := by
+  nlinarith [sq_nonneg (a * b - c * d), sq_nonneg (a * c - b * d),
+             sq_nonneg (a * d - b * c), sq_nonneg ((a - b) * (c - d)),
+             sq_nonneg ((a - c) * (b - d)), sq_nonneg ((a - d) * (b - c))]
+
+/-
+## Frontier: the remaining intermediate indices 1 < k < n-1 for n ≥ 5
 
 For general `n`, the indices strictly between the bottom (k = 1, Cauchy–Schwarz)
-and the top (k = n-1, this file, via reciprocal duality) are not covered by an
-elementary sum-of-squares or duality argument.  The classical route is:
+and the top (k = n-1, this file, via reciprocal duality) — with the smallest
+case `n = 4, k = 2` now settled above by an explicit SOS certificate — are not
+covered by a single uniform elementary argument.  The classical route is:
 
   1.  P(t) = ∏ᵢ (t - xᵢ) has all real roots.
   2.  P'(t) has all real roots (Rolle between consecutive roots of P).

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-01/knowledge.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-01/knowledge.md
@@ -16,6 +16,46 @@ because `∏(t - xᵢ)` is real-rooted regardless of the signs of its roots.
 - The general **k ≥ 2** case (`newton_log_concavity_proved`) requires
   non-negativity — the cleared-denominator induction uses `eⱼ ≥ 0` essentially.
 
+## Session 2026-07-07 (REVISIT) — first genuinely intermediate index n=4, k=2
+
+**Mode:** REVISIT (MODERATE-tier knowledge, highest priority in pool)
+**Outcome:** progress — **build-VERIFIED** (docker 7744 jobs, 0 sorry / 0 axiom).
+
+### What I did
+Added `newton_n4_k2_signed` to `NewtonSignedInputs.lean`. This is the **first
+Newton index that is genuinely interior**: for `n = 4`, `k = 2` satisfies
+`1 < 2 < 3 = n-1`, so it is neither the Cauchy–Schwarz base (`k = 1`, already
+signed) nor the reciprocal-duality top (`k = n-1`, `newton_signed_top`). Prior
+to this session every signed case in the file was one of those two endpoints (or
+`n = 3, k = 2`, which is the top index for `n = 3`).
+
+### Key finding — the interior case is still elementary (SOS)
+The normalized inequality `p₂² ≥ p₁ p₃` (with `p₁=e₁/4, p₂=e₂/6, p₃=e₃/4`),
+cleared of its `144` denominator, is `4 e₂² ≥ 9 e₁ e₃`, and the **exact
+identity** (verified by expansion in sympy)
+
+    4 e₂² − 9 e₁ e₃
+      = 3·[(ab−cd)² + (ac−bd)² + (ad−bc)²]
+        + ½·[((a−b)(c−d))² + ((a−c)(b−d))² + ((a−d)(b−c))²]
+
+certifies non-negativity for **all** real `a,b,c,d`. The two square families are
+indexed by the three complementary-pair splits of `{a,b,c,d}`. `nlinarith` with
+these six `sq_nonneg` hints closes the goal directly. So the smallest interior
+Newton inequality does **not** require the real-rootedness / Rolle machinery.
+
+### Files modified
+- `proofs/Proofs/NewtonSignedInputs.lean` (+`newton_n4_k2_signed`, Part IV +
+  header/frontier note updates)
+- `src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-01.json` (knowledge)
+
+### Next steps
+- Probe how far plain SOS reaches: try `n=5, k=2` and other small interior
+  `(n,k)`. Newton differences are PSD but not always plain SOS in the elementary
+  symmetric variables; the first `nlinarith` failure flags where a genuine
+  multiplier/denominator (hence real-rootedness) becomes necessary.
+- Long-term uniform route: formalize "derivative of a real-rooted polynomial is
+  real-rooted" (Rolle across the root multiset + Vieta for `P'`).
+
 ## Session 2026-07-04 (FRESH) — top-index via reciprocal duality
 
 **Outcome:** progress (proof written, 0 sorry / 0 axiom by construction) but

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-01.json
@@ -29,24 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED (0 sorries, 0 axioms; docker-build clean, 7744 jobs). Signed-input Newton at the TOP index k=n-1 for all n, now for ALL real inputs: newton_signed_top (nonzero xᵢ, via reciprocal duality e_k(1/x)·e_n(x)=e_{n-k}(x) reducing to the signed k=1 Cauchy–Schwarz case) plus newton_signed_top_general (nonzero hypothesis REMOVED — a zero coordinate forces eₙ=0, collapsing the RHS). Also newton_n3_k2_signed (n=3,k=2 for arbitrary reals via SOS). Frontier: intermediate indices 1<k<n-1 for general n still need Rolle/real-rootedness.",
+    "progressSummary": "PROGRESS: signed Newton now covers k=1 (all n), k=n-1 (all n), n=3 k=2, AND n=4 k=2 (first genuinely intermediate index) — all elementary/SOS. Remaining frontier: intermediate indices for n>=5 (needs real-rootedness/Rolle for a uniform argument).",
     "builtItems": [
       "newton_signed_top_general (NewtonSignedInputs.lean): C(n,2)·e_{n-1}²≥n²·e_{n-2}·eₙ for ALL real xᵢ (no nonzero hypothesis) — case split on eₙ=0 (RHS collapses, LHS≥0) vs eₙ≠0 (⇒all xᵢ≠0, apply newton_signed_top).",
       "elemSymm_inv_mul (NewtonSignedInputs.lean): reciprocal identity e_k(1/x)*e_n(x)=e_{n-k}(x) for nonzero x, k<=n - complement bijection via Finset.sum_bij'",
       "newton_signed_top (NewtonSignedInputs.lean): C(n,2)*e_{n-1}(x)^2 >= n^2*e_{n-2}(x)*e_n(x) for n>=2, all x_i != 0 (signed top-index Newton)",
-      "newton_n3_k2_signed (NewtonSignedInputs.lean): ((ab+bc+ca)/3)^2 >= ((a+b+c)/3)*abc for ALL reals a,b,c (SOS, no sign hyp)"
+      "newton_n3_k2_signed (NewtonSignedInputs.lean): ((ab+bc+ca)/3)^2 >= ((a+b+c)/3)*abc for ALL reals a,b,c (SOS, no sign hyp)",
+      "newton_n4_k2_signed (NewtonSignedInputs.lean): ((ab+ac+ad+bc+bd+cd)/6)^2 >= ((a+b+c+d)/4)*((abc+abd+acd+bcd)/4) for ALL reals a,b,c,d, via nlinarith with the 6 SOS hints. Build-verified 0 sorry/0 axiom (docker 7744 jobs)."
     ],
     "insights": [
       "Newton at k=1 is ALREADY signed in the gallery: maclaurin_sq_m1_ge_m2_general (AmgmInequalityOQ02Defs) proves C(n,2)*(sum x_i)^2 >= n^2*e_2 for arbitrary real x (Cauchy-Schwarz / sum_ij (x_i-x_j)^2 >= 0), no sign hypothesis. So is the n=3,n=4 k=1 case.",
       "Reciprocal duality: for x_i != 0, e_k(1/x)*e_n(x)=e_{n-k}(x), via the complement bijection S -> S^c on k-subsets and (prod_{i in S} x_i^-1)*prod x_i = prod_{i in S^c} x_i. Transports Newton from index k to index n-k.",
       "Applying the signed k=1 inequality to y_i=1/x_i and clearing the positive factor e_n(x)^2 yields Newton at the TOP index k=n-1 for all n, all nonzero signed inputs: C(n,2)*e_{n-1}^2 >= n^2*e_{n-2}*e_n.",
-      "n=3,k=2 signed needs no nonnegativity: (ab+bc+ca)^2 - 3abc(a+b+c) = (1/2)[(ab-bc)^2+(bc-ca)^2+(ca-ab)^2]. Gallery newton_n3_k2 assumed a,b,c>=0 unnecessarily."
+      "n=3,k=2 signed needs no nonnegativity: (ab+bc+ca)^2 - 3abc(a+b+c) = (1/2)[(ab-bc)^2+(bc-ca)^2+(ca-ab)^2]. Gallery newton_n3_k2 assumed a,b,c>=0 unnecessarily.",
+      "n=4,k=2 signed Newton (the FIRST genuinely intermediate index, 1<2<3=n-1) has an elementary SOS certificate: 4e_2^2-9e_1e_3 = 3*[(ab-cd)^2+(ac-bd)^2+(ad-bc)^2] + (1/2)*[((a-b)(c-d))^2+((a-c)(b-d))^2+((a-d)(b-c))^2], verified exactly by expansion (sympy). The two square families are indexed by the 3 complementary-pair splits of {a,b,c,d}. No real-rootedness/Rolle needed for this case."
     ],
     "mathlibGaps": [
       "No packaged lemma 'derivative of a real-rooted polynomial is real-rooted' (needs Rolle across a multiset of real roots + Vieta for the derivative). Missing ingredient for intermediate indices 1<k<n-1 for general n."
     ],
     "nextSteps": [
-      "Prove intermediate indices via real-rootedness: P(t)=prod(t-x_i) real-rooted => P' real-rooted (Rolle), coeffs of P' are (n-j)e_j, then discriminant of a real quadratic gives Newton at general k."
+      "Attempt n=5,k=2 and n=4,k=2-style SOS for other small (n,k) interior indices to map how far the elementary SOS approach reaches before real-rootedness becomes necessary (Newton differences are PSD but not always plain SOS; when nlinarith fails, that flags a genuine denominator/multiplier requirement).",
+      "Long-term: formalize derivative-of-real-rooted-polynomial-is-real-rooted (Rolle + Vieta) for a uniform proof of all intermediate indices."
     ],
     "markdown": "# Knowledge Base: amgm-inequality-oq-02-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the signed-input Newton inequality research (`amgm-inequality-oq-02-oq-02-oq-01`) to the **first genuinely intermediate index**: `n = 4, k = 2`.

Prior to this PR, `NewtonSignedInputs.lean` covered the signed case only at the two *endpoints*:
- **k = 1** (all n) — Cauchy–Schwarz (`maclaurin_sq_m1_ge_m2_general`)
- **k = n−1** (all n) — reciprocal duality (`newton_signed_top`/`_general`)
- **n = 3, k = 2** — which *is* the top index for n = 3.

For `n = 4`, `k = 2` satisfies `1 < 2 < 3 = n−1`, so it is the smallest index that is neither endpoint.

## Result

```lean
theorem newton_n4_k2_signed (a b c d : ℝ) :
    ((a*b + a*c + a*d + b*c + b*d + c*d) / 6) ^ 2
      ≥ ((a + b + c + d) / 4) * ((a*b*c + a*b*d + a*c*d + b*c*d) / 4)
```

i.e. Newton's `p₂² ≥ p₁ p₃` for **all real** `a,b,c,d` (no non-negativity).

## Method — elementary SOS certificate

Clearing the 144 denominator gives `4e₂² ≥ 9e₁e₃`, and the exact identity (verified by expansion)

```
4e₂² − 9e₁e₃ = 3·[(ab−cd)² + (ac−bd)² + (ad−bc)²]
             + ½·[((a−b)(c−d))² + ((a−c)(b−d))² + ((a−d)(b−c))²]
```

certifies non-negativity. The two square families are the three complementary-pair splits of `{a,b,c,d}`. `nlinarith` closes it with the six `sq_nonneg` hints.

**Insight:** the smallest interior Newton inequality is still elementary — it does *not* need the real-rootedness / Rolle machinery. That frontier remains for `n ≥ 5`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.NewtonSignedInputs` → **7744 jobs, built clean, 0 sorry / 0 axiom.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)