### PR TITLE
research(erdos-798): correct FALSE t_2_bound (t 2 ≤ 3 is false; t(2)=4), sorries 5→4

### DIFF
--- a/proofs/Proofs/Erdos798Problem.lean
+++ b/proofs/Proofs/Erdos798Problem.lean
@@ -254,11 +254,39 @@ For small n, we can compute or bound t(n) explicitly.
 -/
 
 /--
-For n = 2: t(2) = 3
-Three points suffice to cover the 4 lattice points.
--/
-theorem t_2_bound : t 2 ≤ 3 := by
-  sorry
+For n = 2: t(2) = 4.
+
+**Correction.** An earlier version of this file claimed `t 2 ≤ 3`, which is *false*.
+For `n = 2` the grid `{1,2}²` is exactly its four corners, so any covering set is a
+subset of those four points. Three of them form a right triangle whose three lines
+are two sides and the hypotenuse (e.g. `{(1,1),(1,2),(2,1)}` gives the lines `x=1`,
+`y=1`, `x+y=3`), none of which passes through the fourth corner. Hence three points
+never cover the grid and `t 2 = 4`. All four points trivially do (each corner lies on
+a vertical line through two chosen points), giving the correct bound `t 2 ≤ 4`. -/
+theorem t_2_bound : t 2 ≤ 4 := by
+  -- Membership in the vertical line x = c, realized through the points (c,1),(c,2).
+  have vline : ∀ (c : ℤ) (r : ℤ × ℤ), r.1 = c →
+      r ∈ lineThroughPoints (c, 1) (c, 2) := by
+    intro c r hrc
+    have hne : ((c, 1) : ℤ × ℤ) ≠ (c, 2) := by simp
+    simp only [lineThroughPoints, if_neg hne, Set.mem_setOf_eq]
+    exact ⟨(r.2 : ℚ) - 1, by push_cast [hrc]; ring, by push_cast; ring⟩
+  apply Nat.sInf_le
+  refine ⟨{(1, 1), (1, 2), (2, 1), (2, 2)}, by decide, ?_, ?_⟩
+  · -- the four corners lie in the grid {1,2}²
+    intro p hp
+    simp only [Finset.coe_insert, Set.mem_insert_iff, Finset.coe_singleton,
+      Set.mem_singleton_iff] at hp
+    rcases hp with rfl | rfl | rfl | rfl <;>
+      · simp only [latticeGrid, Set.mem_setOf_eq]; refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
+  · -- every grid point is covered by a vertical line through two chosen corners
+    intro r hr
+    simp only [latticeGrid, Set.mem_setOf_eq] at hr
+    obtain ⟨h1, h2, h3, h4⟩ := hr
+    have hr1 : r.1 = 1 ∨ r.1 = 2 := by omega
+    rcases hr1 with e1 | e1
+    · exact ⟨(1, 1), (1, 2), by simp, by simp, by decide, vline 1 r e1⟩
+    · exact ⟨(2, 1), (2, 2), by simp, by simp, by decide, vline 2 r e1⟩
 
 /--
 For n = 3: t(3) = 4

--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 798,
     "erdosUrl": "https://erdosproblems.com/798",
     "erdosProblemStatus": "solved",
@@ -190,7 +190,7 @@
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 7,
-    "sorries": 5,
+    "sorries": 4,
     "path": "Proofs/Erdos798Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos798Aristotle.lean",


### PR DESCRIPTION
## Summary

Caught and corrected a **false theorem** in `Erdos798Problem.lean`.

## The bug

```lean
theorem t_2_bound : t 2 ≤ 3 := by sorry
```

This is **false**. For `n = 2` the grid `{1,2}²` is exactly its four corners, so any covering point set is a subset of those four points. Three of them form a right triangle whose three determined lines are two sides and the hypotenuse — e.g. `{(1,1),(1,2),(2,1)}` gives the lines `x=1`, `y=1`, `x+y=3`, none of which passes through the fourth corner `(2,2)`. So three points can never cover the grid, and **t(2) = 4**.

## The fix

Replaced with the true bound `t 2 ≤ 4`, **fully proven** (0 sorry): the four corners are the entire grid, and each corner lies on a vertical line through two chosen points (helper lemma `vline`). A docstring records why 3 fails.

Discharges one sorry (**5 → 4**); `meta.json` sorry counts synced (both blocks 5→4).

## Note on the sibling

`t_3_bound : t 3 ≤ 4` **is** true (the four corners of `{1,3}²` cover all nine points of `{1,2,3}²` via the four sides and the two diagonals — the interior point `(2,2)` sits on both diagonals). Left as a sorry for a future session.

## Verification

`docker-build.sh Proofs.Erdos798Problem` succeeds (1933 jobs). The file remains `axiomatized` (3 axioms unchanged: the Erdős–Purdy lower bound, Alon's upper bound, Alon's construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)