### PR TITLE
Enrich Schur-Convexity of Collision Probability (birthday-oq-02-oq-01-oq-02-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["majorization order", "doubly stochastic matrices"]
   },
   {
+    "id": "ann-birthday-oq0201020101-statement",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 74 },
+    "type": "definition",
+    "title": "The global inequality: statement and Lean encoding",
+    "content": "The hypothesis `hD : D ∈ doublyStochastic ℝ (Fin d)` is membership in Mathlib's `doublyStochastic` submonoid — matrices with nonnegative entries whose rows and columns each sum to 1 — and `D *ᵥ q` is the matrix–vector product `Matrix.mulVec`, i.e. `(D *ᵥ q) i = ∑ⱼ Dᵢⱼ qⱼ`. The claim `∑ᵢ (D *ᵥ q)ᵢ² ≤ ∑ᵢ qᵢ²` is therefore the pure operator form of Schur-convexity, quantifier-free in the majorization order: it holds for the whole polytope of averaging operators at once. The single line of analytic input for the whole proof is `hconv := Even.convexOn_pow (by norm_num)`, which certifies `x ↦ x²` is convex on all of ℝ; everything after is the row/column stochasticity of `D`.",
+    "mathContext": "$D \\in \\mathrm{doublyStochastic}\\,\\mathbb{R}\\,(\\mathrm{Fin}\\,d)$, $(D \\ast_v q)_i = \\sum_j D_{ij} q_j$; claim $\\sum_i (D\\ast_v q)_i^2 \\le \\sum_i q_i^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Matrix.mulVec", "doublyStochastic submonoid", "Even.convexOn_pow", "operator form of Schur-convexity"],
+    "prerequisites": ["matrix-vector multiplication", "doubly stochastic matrices"]
+  },
+  {
     "id": "ann-birthday-oq0201020101-jensen",
     "proofId": "birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01",
     "range": { "startLine": 76, "endLine": 86 },

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -40,7 +40,8 @@
       "Schur-convexity of ∑ xᵢ² is, in operator form, a one-line Jensen argument: every doubly stochastic operator is a row-wise convex combination, and squaring is convex, so applying it can only decrease the sum of squares. No transfer-chain combinatorics are needed once the doubly-stochastic formulation is adopted.",
       "The two stochasticity constraints play distinct roles: the *row* sums = 1 make each output a convex combination (the Jensen step), while the *column* sums = 1 make the doubled sum collapse back to ∑ qⱼ² (the global step).",
       "The uniform-minimizer endpoint is not a separate computation but a single instance of the global inequality at the all-1/d matrix, exhibiting the uniform vector as the unique HLP-bottom of the majorization order on the simplex.",
-      "Mathlib supplies the doubly-stochastic matrix API (entrywise nonnegativity, row/column sums) but no majorization or Schur-convexity layer; this monotonicity-under-averaging result is the missing global statement the parent's open question requested."
+      "Mathlib supplies the doubly-stochastic matrix API (entrywise nonnegativity, row/column sums) but no majorization or Schur-convexity layer; this monotonicity-under-averaging result is the missing global statement the parent's open question requested.",
+      "Because x ↦ x² is *strictly* convex, the Jensen step is an equality only when each row of D is a degenerate convex combination — a 0/1 row selecting a single coordinate — so the sum of squares is preserved exactly when D acts as a permutation on the support of q. This is why permutation matrices are the only extreme points of the Birkhoff polytope that leave collision probability unchanged, and it is the seed of the equality-case open question below."
     ],
     "prerequisites": [
       "doublyStochastic and its API: nonneg_of_mem_doublyStochastic, sum_row_of_mem_doublyStochastic, sum_col_of_mem_doublyStochastic, mem_doublyStochastic_iff_sum",


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01` (quality 94, pass 0).

This entry was already strong and well under the 60 KB size cap (meta.json 12.4 KB). Two genuine, non-inflating gaps addressed:

**1. Annotation coverage gap.** The main theorem *statement* (lines 64–74) was unannotated — coverage jumped from the header (ends line 54) straight to the first proof-step annotation (line 76). Added `ann-...-statement` explaining the Lean encoding: `doublyStochastic ℝ (Fin d)` membership, the `*ᵥ` (`Matrix.mulVec`) product, and `Even.convexOn_pow` as the single analytic input to the whole proof.

**2. keyInsights 4 → 5.** Added the strict-convexity observation: since x² is *strictly* convex, the Jensen step is an equality iff each row of D is a 0/1 selector, i.e. D permutes the support of q — so permutation matrices are the only Birkhoff extreme points that preserve collision probability. This directly motivates the equality-case open question already listed.

No content deleted; all existing fields preserved. Axiom/status fields verified accurate against the Lean source (0 sorries, 0 axioms, status `verified`). meta.json stays at 12.4 KB, 6 annotations, 5 keyInsights — comfortably under every guardrail cap.