### PR TITLE
audit(backlog-0): abel-ruffini clean + re-audit 2 enriched proofs (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4029,9 +4029,9 @@
       "issues": []
     },
     "burnside-counting-oq-05-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T06:22:08Z",
       "result": "clean"
     },
     "burnside-counting-oq-05-oq-02": {
@@ -26897,8 +26897,8 @@
       "issues": []
     },
     "composition-parts-choose-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-01T20:12:12Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T06:22:08Z",
       "result": "clean",
       "issues": []
     },
@@ -29553,8 +29553,14 @@
       "issues": [],
       "lastAudited": "2026-07-08T04:59:24Z",
       "result": "clean"
+    },
+    "abel-ruffini-oq-04-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-08T06:22:08Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T06:13:49Z"
+  "lastUpdated": "2026-07-08T06:22:08Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Backlog cleared to 0 unaudited, plus re-audit of 2 proofs whose meta.json changed since last audit.

### Audited (all CLEAN)

| Proof | Reason | Result |
|-------|--------|--------|
| \`abel-ruffini-oq-04-oq-01-oq-03\` | unaudited (#35245) | clean |
| \`burnside-counting-oq-05-oq-01\` | re-audit after enrich #35244 | clean |
| \`composition-parts-choose-oq-01-oq-03\` | re-audit after enrich #35242 | clean |

### Verification

**abel-ruffini-oq-04-oq-01-oq-03** — generic Sylow-elimination lemma. 2 real theorems (\`zpowers_order5_normal\`, \`conj_mem_zpowers_order5\`) + 3 examples. \`grep sorry\`/\`grep native_decide\` each hit exactly line 25, which is a **docstring** stating the file *avoids* them. Actual proof: 0 sorry, 0 axiom, 0 native_decide, 0 True-stubs. status=verified / badge=original accurate — builds on Mathlib's Sylow API but proves a genuine composite group-theory lemma.

**burnside-counting-oq-05-oq-01** — 0/0, badge=mathlib, 13 theorems. meta claims (verified, 0 sorry, 0 axiom, foundational axioms only) match Lean source.

**composition-parts-choose-oq-01-oq-03** — 0/0, no native_decide, badge=original, 5 theorems. meta claims match source; assumptions field confirms #print axioms check.

Both enrichment changes touched prose/sections only — no status/badge/sorries/axiom field drift. No overclaiming introduced.

---
Discovered during gallery integrity audit. Tracker-only change.