### PR TITLE
research(lp-duality-synthesis): representer consistency-under-inclusion brick [VERIFIED 0-sorry/0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualityConsistency.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualityConsistency.lean
@@ -1,0 +1,185 @@
+/-
+# Lᵖ-duality synthesis — the representer *consistency* lemma
+
+This file supplies the remaining structural brick of the Folland-6.16 maximality
+construction that the existing standalone ingredients did not yet package: the
+step that says the σ-finite Riesz representers are *consistent under set
+inclusion*.
+
+Setup recap (see `CauchySchwarzIntegralLpDualitySynthesis.lean`). To represent an
+arbitrary functional `φ ∈ (Lᵖ(μ))*` one exhausts `μ` by σ-finite sets, obtains a
+representer `g_S ∈ Lᵠ(μ.restrict S)` on each with `‖g_S‖_q ≤ ‖φ‖`, and realizes the
+supremum `c = ⨆_S ‖g_S‖_q` on a countable-union hull `T`. Two separate steps of that
+argument — "the union hull realizes the supremum" and "for `U ⊇ T` the larger
+representer agrees a.e. with `g_T` on `T`" — both rest on the same underlying fact:
+
+  **if `S ⊆ S'` are measurable and `g_S`, `g_{S'}` represent (the `extByZero`-pullbacks
+  of) the *same* functional `φ` on their respective restricted spaces, then
+  `g_S = g_{S'}` a.e. on `S`.**
+
+That is the content below (`representer_ae_eq_of_subset`). It is exactly the
+uniqueness input the synthesis file's top-of-file sketch refers to as "by uniqueness
+of the representing function"; it was assumed there but never packaged as a lemma.
+
+## Proof
+
+`g_S` and `g_{S'}` are two `Lᵠ(μ.restrict S)` functions (the second, `g_{S'}`,
+restricts to `μ.restrict S` since `S ⊆ S'`). By Mathlib's
+`AEFinStronglyMeasurable.ae_eq_of_forall_setIntegral_eq` it suffices to check that
+their set-integrals agree over every finite-measure set. Testing against the `Lᵖ`
+indicator `𝟙_t` of a finite set `t ⊆ S`, both `∫_t g_S ∂μ` and `∫_t g_{S'} ∂μ` equal
+`φ` evaluated at the *same* extension-by-zero of `𝟙_t` (the two extensions
+`extS 𝟙_t` and `extS' 𝟙_t` are `μ`-a.e. equal to `𝟙_t`, hence equal in `Lᵖ(μ)`), so
+the two integrals coincide.
+
+## Decoupling
+
+The extension maps enter only through their **coeFn characterization**
+`extS f =ᵐ[μ] S.indicator f`, so they are taken here as *abstract* continuous linear
+hypotheses (`extS`, `hextS`, …) rather than the concrete `extByZeroCLM`. Consequently
+this file imports **only Mathlib** and does not touch the build-heavy σ-finite Riesz
+chain (`…Incomplete01.lean`); any concrete extension (the decoupled
+`RieszLpDualityExtension.extByZeroCLM` or the in-chain `RieszSigmaFiniteComplete`
+one) satisfies the coeFn hypothesis and can consume this lemma.
+
+**Standalone / verified.** `0 sorry`, `0 axiom` (foundational axioms only). It is a
+kernel-checked building block for the eventual maximality construction, not itself the
+axiom elimination.
+-/
+
+import Mathlib
+
+noncomputable section
+
+open MeasureTheory ENNReal
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+namespace RieszLpDualityConsistency
+
+/-- **Representer consistency under set inclusion.** Let `1 < p < ∞` with Hölder
+    conjugate `q`, and `S ⊆ S'` measurable. Suppose `g_S ∈ Lᵠ(μ.restrict S)` and
+    `g_{S'} ∈ Lᵠ(μ.restrict S')` represent the extension-by-zero pullbacks of the
+    *same* functional `φ ∈ (Lᵖ(μ))*` on `Lᵖ(μ.restrict S)` and `Lᵖ(μ.restrict S')`
+    respectively. Then `g_S = g_{S'}` a.e. on `S`.
+
+    The two extension-by-zero maps enter only through their coeFn characterization
+    `extS f =ᵐ[μ] S.indicator f`, so they are abstract `Lᵖ`-continuous-linear
+    hypotheses; the concrete `extByZeroCLM` (either the decoupled or in-chain version)
+    satisfies them. -/
+theorem representer_ae_eq_of_subset
+    {p q : ℝ≥0∞} (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)]
+    {S S' : Set α} (hS : MeasurableSet S) (hS' : MeasurableSet S') (hSS' : S ⊆ S')
+    (φ : Lp ℝ p μ →L[ℝ] ℝ)
+    {gS gS' : α → ℝ}
+    (hgS : MemLp gS q (μ.restrict S)) (hgS' : MemLp gS' q (μ.restrict S'))
+    (extS : Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ)
+    (hextS : ∀ f : Lp ℝ p (μ.restrict S),
+      (extS f : α → ℝ) =ᵐ[μ] S.indicator (f : α → ℝ))
+    (extS' : Lp ℝ p (μ.restrict S') →L[ℝ] Lp ℝ p μ)
+    (hextS' : ∀ f : Lp ℝ p (μ.restrict S'),
+      (extS' f : α → ℝ) =ᵐ[μ] S'.indicator (f : α → ℝ))
+    (hrepS : ∀ f : Lp ℝ p (μ.restrict S),
+      φ (extS f) = ∫ a, (f : α → ℝ) a * gS a ∂(μ.restrict S))
+    (hrepS' : ∀ f : Lp ℝ p (μ.restrict S'),
+      φ (extS' f) = ∫ a, (f : α → ℝ) a * gS' a ∂(μ.restrict S')) :
+    gS =ᵐ[μ.restrict S] gS' := by
+  -- `q` is a genuine finite exponent `1 < q < ∞`.
+  have hqtr : (1 : ℝ) < q.toReal := (Real.holderConjugate_iff.mp hpq.symm).1
+  have hqtr0 : q.toReal ≠ 0 := ne_of_gt (lt_trans one_pos hqtr)
+  obtain ⟨hq0, hqtop⟩ := ENNReal.toReal_ne_zero.mp hqtr0
+  have hq1 : (1 : ℝ≥0∞) ≤ q := by
+    have h := ENNReal.toReal_le_toReal (a := (1 : ℝ≥0∞)) (by simp) hqtop
+    rw [ENNReal.toReal_one] at h
+    exact h.mp hqtr.le
+  -- `g_{S'}` also lies in `Lᵠ(μ.restrict S)` (restrict the bigger-set membership).
+  have hgS'_S : MemLp gS' q (μ.restrict S) := by
+    have h := hgS'.restrict S
+    rwa [Measure.restrict_restrict hS, Set.inter_eq_left.mpr hSS'] at h
+  -- Core: set-integrals over `t ⊆ S` (finite measure) agree, via the shared functional.
+  have key : ∀ t : Set α, MeasurableSet t → t ⊆ S → μ t < ∞ →
+      ∫ x in t, gS x ∂μ = ∫ x in t, gS' x ∂μ := by
+    intro t ht htS htfin
+    -- the `Lᵖ` indicator of `t` on each restricted space
+    have hνt : μ.restrict S t ≠ ∞ := by
+      rw [Measure.restrict_apply ht, Set.inter_eq_left.mpr htS]; exact htfin.ne
+    have hν't : μ.restrict S' t ≠ ∞ := by
+      rw [Measure.restrict_apply ht, Set.inter_eq_left.mpr (htS.trans hSS')]; exact htfin.ne
+    have hmemS : MemLp (t.indicator (fun _ => (1 : ℝ))) p (μ.restrict S) :=
+      memLp_indicator_const p ht 1 (Or.inr hνt)
+    have hmemS' : MemLp (t.indicator (fun _ => (1 : ℝ))) p (μ.restrict S') :=
+      memLp_indicator_const p ht 1 (Or.inr hν't)
+    set cs := hmemS.toLp _ with hcs_def
+    set cs' := hmemS'.toLp _ with hcs'_def
+    have hcs_coe : (cs : α → ℝ) =ᵐ[μ.restrict S] t.indicator (fun _ => (1 : ℝ)) :=
+      hmemS.coeFn_toLp
+    have hcs'_coe : (cs' : α → ℝ) =ᵐ[μ.restrict S'] t.indicator (fun _ => (1 : ℝ)) :=
+      hmemS'.coeFn_toLp
+    -- both extensions are `μ`-a.e. equal to `𝟙_t`, hence equal as `Lᵖ(μ)` elements
+    have hextScoe : (extS cs : α → ℝ) =ᵐ[μ] t.indicator (fun _ => (1 : ℝ)) := by
+      filter_upwards [hextS cs, (ae_restrict_iff' hS).mp hcs_coe] with a ha hcoe
+      rw [ha]
+      by_cases haS : a ∈ S
+      · rw [Set.indicator_of_mem haS, hcoe haS]
+      · rw [Set.indicator_of_notMem haS, Set.indicator_of_notMem (fun h => haS (htS h))]
+    have hextS'coe : (extS' cs' : α → ℝ) =ᵐ[μ] t.indicator (fun _ => (1 : ℝ)) := by
+      filter_upwards [hextS' cs', (ae_restrict_iff' hS').mp hcs'_coe] with a ha hcoe
+      rw [ha]
+      by_cases haS' : a ∈ S'
+      · rw [Set.indicator_of_mem haS', hcoe haS']
+      · rw [Set.indicator_of_notMem haS',
+          Set.indicator_of_notMem (fun h => haS' (htS.trans hSS' h))]
+    have hφeq : φ (extS cs) = φ (extS' cs') := by
+      rw [Lp.ext (hextScoe.trans hextS'coe.symm)]
+    -- evaluate each side as `∫_t · ∂μ`
+    have hgSval : φ (extS cs) = ∫ x in t, gS x ∂μ := by
+      rw [hrepS cs]
+      have h1 : (fun a => (cs : α → ℝ) a * gS a) =ᵐ[μ.restrict S] t.indicator gS := by
+        filter_upwards [hcs_coe] with a ha
+        rw [ha]
+        by_cases hat : a ∈ t
+        · rw [Set.indicator_of_mem hat, Set.indicator_of_mem hat, one_mul]
+        · rw [Set.indicator_of_notMem hat, Set.indicator_of_notMem hat, zero_mul]
+      rw [integral_congr_ae h1, integral_indicator ht,
+        Measure.restrict_restrict ht, Set.inter_eq_left.mpr htS]
+    have hgS'val : φ (extS' cs') = ∫ x in t, gS' x ∂μ := by
+      rw [hrepS' cs']
+      have h1 : (fun a => (cs' : α → ℝ) a * gS' a) =ᵐ[μ.restrict S'] t.indicator gS' := by
+        filter_upwards [hcs'_coe] with a ha
+        rw [ha]
+        by_cases hat : a ∈ t
+        · rw [Set.indicator_of_mem hat, Set.indicator_of_mem hat, one_mul]
+        · rw [Set.indicator_of_notMem hat, Set.indicator_of_notMem hat, zero_mul]
+      rw [integral_congr_ae h1, integral_indicator ht,
+        Measure.restrict_restrict ht, Set.inter_eq_left.mpr (htS.trans hSS')]
+    calc ∫ x in t, gS x ∂μ = φ (extS cs) := hgSval.symm
+      _ = φ (extS' cs') := hφeq
+      _ = ∫ x in t, gS' x ∂μ := hgS'val
+  -- Apply the `setIntegral` uniqueness criterion on `μ.restrict S`.
+  refine AEFinStronglyMeasurable.ae_eq_of_forall_setIntegral_eq ?_ ?_ ?_
+    (hgS.aefinStronglyMeasurable hq0 hqtop) (hgS'_S.aefinStronglyMeasurable hq0 hqtop)
+  · -- `gS` integrable on finite-measure subsets
+    intro s _ hνs
+    haveI : IsFiniteMeasure ((μ.restrict S).restrict s) :=
+      ⟨by rw [Measure.restrict_apply_univ]; exact hνs⟩
+    exact (hgS.restrict s).integrable hq1
+  · -- `gS'` integrable on finite-measure subsets
+    intro s _ hνs
+    haveI : IsFiniteMeasure ((μ.restrict S).restrict s) :=
+      ⟨by rw [Measure.restrict_apply_univ]; exact hνs⟩
+    exact (hgS'_S.restrict s).integrable hq1
+  · -- set-integrals agree, reduced to `key` on `s ∩ S`
+    intro s hs hνs
+    have hsS_fin : μ (s ∩ S) < ∞ := by
+      rwa [Measure.restrict_apply hs] at hνs
+    have e1 : ∫ x in s, gS x ∂(μ.restrict S) = ∫ x in (s ∩ S), gS x ∂μ := by
+      rw [Measure.restrict_restrict hs]
+    have e2 : ∫ x in s, gS' x ∂(μ.restrict S) = ∫ x in (s ∩ S), gS' x ∂μ := by
+      rw [Measure.restrict_restrict hs]
+    rw [e1, e2]
+    exact key (s ∩ S) (hs.inter hS) Set.inter_subset_right hsS_fin
+
+end RieszLpDualityConsistency
+
+end

--- a/proofs/Proofs/CauchySchwarzIntegralLpDualityConsistency.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualityConsistency.lean
@@ -68,7 +68,7 @@ namespace RieszLpDualityConsistency
     hypotheses; the concrete `extByZeroCLM` (either the decoupled or in-chain version)
     satisfies them. -/
 theorem representer_ae_eq_of_subset
-    {p q : ℝ≥0∞} (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    {p q : ℝ≥0∞}
     (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)]
     {S S' : Set α} (hS : MeasurableSet S) (hS' : MeasurableSet S') (hSS' : S ⊆ S')
     (φ : Lp ℝ p μ →L[ℝ] ℝ)
@@ -179,6 +179,40 @@ theorem representer_ae_eq_of_subset
       rw [Measure.restrict_restrict hs]
     rw [e1, e2]
     exact key (s ∩ S) (hs.inter hS) Set.inter_subset_right hsS_fin
+
+/-- **Monotonicity of the representer `Lᵠ`-seminorm under set inclusion.** With the
+    same data as `representer_ae_eq_of_subset`, the seminorm of the smaller-set
+    representer does not exceed that of the larger one:
+    `‖g_S‖_{q, S} ≤ ‖g_{S'}‖_{q, S'}`.
+
+    This is the input that forces the union-hull representer to *realize* the supremum
+    `c = ⨆_S ‖g_S‖_q` in the maximality construction: since `S_n ⊆ T = ⋃ₙ S_n`, one has
+    `‖g_{S_n}‖ ≤ ‖g_T‖ ≤ c`, so `‖g_T‖ = c`. It follows from consistency
+    (`g_S = g_{S'}` a.e. on `S`) plus the monotonicity of `eLpNorm` in the measure. -/
+theorem representer_eLpNorm_mono_of_subset
+    {p q : ℝ≥0∞}
+    (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)]
+    {S S' : Set α} (hS : MeasurableSet S) (hS' : MeasurableSet S') (hSS' : S ⊆ S')
+    (φ : Lp ℝ p μ →L[ℝ] ℝ)
+    {gS gS' : α → ℝ}
+    (hgS : MemLp gS q (μ.restrict S)) (hgS' : MemLp gS' q (μ.restrict S'))
+    (extS : Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ)
+    (hextS : ∀ f : Lp ℝ p (μ.restrict S),
+      (extS f : α → ℝ) =ᵐ[μ] S.indicator (f : α → ℝ))
+    (extS' : Lp ℝ p (μ.restrict S') →L[ℝ] Lp ℝ p μ)
+    (hextS' : ∀ f : Lp ℝ p (μ.restrict S'),
+      (extS' f : α → ℝ) =ᵐ[μ] S'.indicator (f : α → ℝ))
+    (hrepS : ∀ f : Lp ℝ p (μ.restrict S),
+      φ (extS f) = ∫ a, (f : α → ℝ) a * gS a ∂(μ.restrict S))
+    (hrepS' : ∀ f : Lp ℝ p (μ.restrict S'),
+      φ (extS' f) = ∫ a, (f : α → ℝ) a * gS' a ∂(μ.restrict S')) :
+    eLpNorm gS q (μ.restrict S) ≤ eLpNorm gS' q (μ.restrict S') := by
+  have hcons : gS =ᵐ[μ.restrict S] gS' :=
+    representer_ae_eq_of_subset hpq hS hS' hSS' φ hgS hgS' extS hextS extS' hextS' hrepS hrepS'
+  calc eLpNorm gS q (μ.restrict S)
+      = eLpNorm gS' q (μ.restrict S) := eLpNorm_congr_ae hcons
+    _ ≤ eLpNorm gS' q (μ.restrict S') :=
+        eLpNorm_mono_measure _ (Measure.restrict_mono hSS' le_rfl)
 
 end RieszLpDualityConsistency
 

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -1151,3 +1151,63 @@ Lean-side much longer than S18's "180s" figure but well under the 60min envelope
 reaped mid-session once** (killed an in-flight build; branch survived) — commit before every
 Docker build; recreate via `git worktree add .loom/worktrees/researcher-5 feature/researcher-5`
 then `git reset --hard origin/main`.
+
+### 2026-07-08 (Session 22, researcher-6) — REPRESENTER CONSISTENCY brick VERIFIED: `representer_ae_eq_of_subset` + norm-monotonicity corollary [0-sorry/0-axiom, first-try green]
+
+**State of the world (re-read of `origin/main`, not the stale S16–S19 notes).** The
+σ-finite Riesz theorem is now **fully verified** on main: `Incomplete01.lean` is a clean
+47-line file (`RieszSigmaFiniteComplete.riesz_lp_surjective_sigma_finite`, 0 sorry)
+assembled from the split `…Incomplete01{Infra,Norm,Loc}.lean` pieces (the S18/S19
+"split + drift" mandate was completed in the intervening unlogged sessions #34741/#34744).
+It **returns the norm bound** `eLpNorm g q μ ≤ ofReal ‖φ‖`. The ONLY remaining `sorry`
+in the whole strand is `RieszLpDualitySynthesis.riesz_lp_surjective_general`
+(Synthesis.lean:345) — the arbitrary-measure **maximality assembly** (Folland 6.16).
+
+**All HARD analysis was already packaged by prior sessions** (verified, decoupled,
+Mathlib-only): nondegeneracy/uniqueness `RieszLpDualityAnnihilator.lp_pairing_eq_zero_ae_zero`;
+gluing-forces-vanishing `RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le`; q-power
+additivity `RieszLpDualityIngredients.eLpNorm_rpow_restrict_{union,iUnion,diff,mono}`;
+σ-finite countable union `sigmaFinite_restrict_iUnion`; step-1 pullback-with-norm-bound
+`RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set`; decoupled isometric
+`RieszLpDualityExtension.extByZeroCLM{,_coeFn}`.
+
+**The one structural brick that was still MISSING** — the "by uniqueness of the
+representing function" that the Synthesis top-of-file sketch (steps 2–3) *assumes* but never
+packaged: **representer consistency under set inclusion**. Added this session as a new
+standalone Mathlib-only file `CauchySchwarzIntegralLpDualityConsistency.lean` (namespace
+`RieszLpDualityConsistency`), **first-try Docker-green, 0 sorry / 0 axiom**:
+
+- `representer_ae_eq_of_subset`: for `S ⊆ S'` measurable and `g_S ∈ Lᵠ(μ|S)`,
+  `g_{S'} ∈ Lᵠ(μ|S')` representing the `extByZero`-pullbacks of the **same** `φ`, then
+  `g_S =ᵐ[μ|S] g_{S'}`. Proof: Mathlib
+  `AEFinStronglyMeasurable.ae_eq_of_forall_setIntegral_eq` (AEEqOfIntegral.lean:303), tested
+  against the Lᵖ indicator `𝟙_t` of finite `t ⊆ S`. Both `∫_t g_S ∂μ` and `∫_t g_{S'} ∂μ`
+  equal `φ` at the **same** Lᵖ(μ) element (`extS 𝟙_t =ᵐ[μ] 𝟙_t =ᵐ extS' 𝟙_t` ⟹ equal via
+  `Lp.ext`), so they coincide.
+- `representer_eLpNorm_mono_of_subset`: `‖g_S‖_{q,S} ≤ ‖g_{S'}‖_{q,S'}` (consistency +
+  `eLpNorm_congr_ae` + `eLpNorm_mono_measure`). This is exactly the input that pins
+  `‖g_T‖ = c` in the maximality step (since `Sₙ ⊆ T ⟹ ‖g_{Sₙ}‖ ≤ ‖g_T‖ ≤ c`).
+
+**DECOUPLED design.** The two extension maps enter only through the coeFn characterization
+`extS f =ᵐ[μ] S.indicator f`, taken as abstract CLM hypotheses ⇒ **`import Mathlib` only**,
+does NOT touch the σ-finite chain. Either concrete `extByZeroCLM` (decoupled or in-chain)
+satisfies the hypothesis. `hp1`/`hptop` were unused (consistency needs only `q` finite via
+`hpq`) so dropped; kept `[Fact (1 ≤ p)]`.
+
+**What remains to eliminate the axiom = pure maximizing-sequence bookkeeping in
+`riesz_lp_surjective_general`** (no new analysis). Sketch, now with EVERY ingredient in hand:
+(1) `c := ⨆_S ‖g_S‖_q` over measurable σ-finite-restriction `S`, choice-selecting a
+representer per `S` from `riesz_representer_on_sigmaFinite_set`; `c ≤ ofReal‖φ‖`. (2) maximizing
+seq `Sₙ` with `‖g_{Sₙ}‖ → c`; `T = ⋃ₙ Sₙ` σ-finite (`sigmaFinite_restrict_iUnion`); `‖g_T‖ = c`
+via `representer_eLpNorm_mono_of_subset` (`≥`) and `T` qualifying (`≤`). (3) arbitrary
+`f ∈ Lᵖ(μ)` has σ-finite support `S_f` (`memLp_exists_sigmaFinite_support`); `U = T ∪ S_f`;
+`g_U =ᵐ g_T` on `T` (`representer_ae_eq_of_subset`), and `‖g_U‖_{q,U} ≤ c = ‖g_U‖_{q,T}` ⟹
+`g_U = 0` a.e. off `T` (`eLpNorm_ae_zero_on_diff_of_le`), so `φ f = ∫ f·g_U = ∫ f·(ext-by-0 of
+g_T)`. The remaining friction is the `sSup`/choice/maximizing-sequence extraction (ℝ≥0∞ or
+`.toReal` bounded by `‖φ‖`), est. ~200 lines of glue.
+
+**Mathlib v4.26 API notes (this session):** `AEFinStronglyMeasurable.ae_eq_of_forall_setIntegral_eq`
+takes `(int-finite gS)(int-finite gS')(setIntegral-eq)(aefsm gS)(aefsm gS')`; `memLp_indicator_const`
+disjunction order is `c = 0 ∨ μ s ≠ ∞`; `MemLp.integrable hq1` needs `[IsFiniteMeasure]` (supply
+via `restrict_apply_univ`); `Measure.restrict_restrict hs` needs the OUTER `in`-set measurable;
+`Lp.ext : f =ᵐ[μ] g → f = g`.


### PR DESCRIPTION
## Summary

Adds the one **structural brick** still missing from the Folland-6.16 maximality construction that discharges the Lᵖ-duality axiom `riesz_lp_surjective` — **representer consistency under set inclusion**.

New file `proofs/Proofs/CauchySchwarzIntegralLpDualityConsistency.lean` (`import Mathlib` only, fully decoupled from the σ-finite Riesz chain), **Docker build green, 0 sorry / 0 axiom** (foundational axioms only):

- **`representer_ae_eq_of_subset`** — for `S ⊆ S'` measurable, if `g_S ∈ Lᵠ(μ|S)` and `g_{S'} ∈ Lᵠ(μ|S')` represent the extension-by-zero pullbacks of the *same* functional `φ ∈ (Lᵖ(μ))*`, then `g_S =ᵐ[μ|S] g_{S'}`. Proof: Mathlib `AEFinStronglyMeasurable.ae_eq_of_forall_setIntegral_eq`, tested against the Lᵖ indicator of finite `t ⊆ S`; both set-integrals equal `φ` at the *same* Lᵖ(μ) element (the two extensions of `𝟙_t` are μ-a.e. equal, hence equal via `Lp.ext`).
- **`representer_eLpNorm_mono_of_subset`** — `‖g_S‖_{q,S} ≤ ‖g_{S'}‖_{q,S'}` (consistency + `eLpNorm_mono_measure`), the input that pins `‖g_T‖ = c` in the maximality step.

## Context

This is the "by uniqueness of the representing function" that the synthesis file's maximality sketch *assumes* but never packaged. With it, **all ingredients of `riesz_lp_surjective_general` are now in hand** (nondegeneracy, gluing, q-power additivity, σ-finite union, step-1 pullback-with-norm-bound). What remains to eliminate the axiom is pure maximizing-sequence bookkeeping (the `sSup`/choice extraction) — no new analysis. Details + assembly sketch appended to the problem `knowledge.md` (Session 22).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CauchySchwarzIntegralLpDualityConsistency` → **Build succeeded**, clean (no warnings, no sorry, no axiom).
- Decoupled design: extensions enter only via the coeFn characterization `extS f =ᵐ[μ] S.indicator f`, so both the decoupled and in-chain `extByZeroCLM` satisfy the hypotheses.

The axiom is **not** yet eliminated — the headline `riesz_lp_surjective_general` still carries its maximality `sorry`; this PR is an additive verified building block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)