### PR TITLE
research(hurwitz-theorem-oq-03-wip-01): verified product engine for the n≡2(mod4) reduction [0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/HurwitzTheoremOQ03WIP01.lean
+++ b/proofs/Proofs/HurwitzTheoremOQ03WIP01.lean
@@ -135,4 +135,69 @@ example (hodd : Odd m)
     (hanti : A * B = -(B * A)) : False :=
   no_anticommuting_complex_structures_of_odd (by norm_num) hodd A B hAsq hBsq hanti
 
+-- ═══════════════════════════════════════════════════════════════════
+-- THE PRODUCT ENGINE: moving an anticommuting element through `P = M₁⋯M_k`
+-- ═══════════════════════════════════════════════════════════════════
+--
+-- The `n ≡ 2 (mod 4)` reduction (see `HurwitzTheorem.lean`) forms the product
+-- `P = M₁ ⋯ M_{n-1}` of the anticommuting complex structures and studies how a
+-- fresh structure `a` (one of the `Mᵢ`, or a probe) moves through it. The single
+-- algebraic fact behind that whole step is: **an element that anticommutes with
+-- every factor of a product acquires the sign `(-1)^(length)` when moved across
+-- the entire product.** These lemmas are stated over an arbitrary ring, so they
+-- apply verbatim to the real `crossMat` family and to its complexification.
+
+section ProductEngine
+
+variable {R : Type*} [Ring R]
+
+/-- **Move-through sign.** If `a` anticommutes with every entry of the list `t`,
+    then moving `a` across the whole product `t.prod` picks up the sign
+    `(-1)^(t.length)`:
+
+      `a * t.prod = (-1)^(t.length) * (t.prod * a)`.
+
+    This is the reusable engine behind the `P = M₁⋯M_{n-1}` construction in the
+    `n ≡ 2 (mod 4)` Hurwitz reduction: with all factors pairwise anticommuting,
+    parity of the length controls whether `a` commutes or anticommutes with `P`. -/
+theorem mul_prod_anticomm {a : R} :
+    ∀ {t : List R}, (∀ x ∈ t, a * x = -(x * a)) →
+      a * t.prod = (-1 : R) ^ t.length * (t.prod * a) := by
+  intro t
+  induction t with
+  | nil => intro _; simp
+  | cons b s ih =>
+    intro h
+    have hb : a * b = -(b * a) := h b (by simp)
+    have hs : ∀ x ∈ s, a * x = -(x * a) := fun x hx => h x (by simp [hx])
+    have hcb : b * (-1 : R) ^ s.length = (-1 : R) ^ s.length * b :=
+      ((Commute.neg_one_left b).pow_left s.length).eq.symm
+    calc a * (b :: s).prod
+        = -(b * (a * s.prod)) := by
+          rw [List.prod_cons, ← mul_assoc, hb, neg_mul, mul_assoc]
+      _ = -(b * ((-1 : R) ^ s.length * (s.prod * a))) := by rw [ih hs]
+      _ = -((-1 : R) ^ s.length * (b * (s.prod * a))) := by
+          rw [← mul_assoc, hcb, mul_assoc]
+      _ = (-1 : R) ^ (b :: s).length * ((b :: s).prod * a) := by
+          rw [List.length_cons, List.prod_cons, pow_succ]
+          noncomm_ring
+
+/-- **Even length ⇒ commutes.** If `a` anticommutes with every factor of `L` and
+    `L` has even length, then `a` commutes with the whole product `L.prod`. -/
+theorem commute_prod_of_anticomm_of_even {a : R} {L : List R}
+    (h : ∀ x ∈ L, a * x = -(x * a)) (hlen : Even L.length) :
+    a * L.prod = L.prod * a := by
+  rw [mul_prod_anticomm h, hlen.neg_one_pow, one_mul]
+
+/-- **Odd length ⇒ anticommutes.** If `a` anticommutes with every factor of `L`
+    and `L` has odd length, then `a` anticommutes with the product `L.prod`. This
+    is the shape used on the `M₁⋯M_{n-1}` product (odd for even `n`): a fresh
+    complex structure anticommuting with each factor also anticommutes with `P`. -/
+theorem anticommute_prod_of_anticomm_of_odd {a : R} {L : List R}
+    (h : ∀ x ∈ L, a * x = -(x * a)) (hlen : Odd L.length) :
+    a * L.prod = -(L.prod * a) := by
+  rw [mul_prod_anticomm h, hlen.neg_one_pow, neg_one_mul]
+
+end ProductEngine
+
 end HurwitzOQ03WIP01

--- a/research/problems/hurwitz-theorem-oq-03-wip-01/knowledge.md
+++ b/research/problems/hurwitz-theorem-oq-03-wip-01/knowledge.md
@@ -1,0 +1,96 @@
+# Knowledge Base: hurwitz-theorem-oq-03-wip-01
+
+Insights accumulated during research on completing the even-case impossibility of
+Hurwitz's theorem (`n`-square identities exist only for `n ∈ {1,2,4,8}`).
+
+---
+
+## Problem Understanding
+
+`HurwitzTheorem.lean` (`hurwitz_only_if`, line ~1904) discharges every case except a
+single `sorry` (line ~1937) for the **even, non-admissible** case. The `crossMat`
+family `Mⱼ = crossMat nsi j₀ j` (`j ∈ Fin n \ {j₀}`) gives `n-1` matrices with
+`Mⱼᵀ = -Mⱼ`, `MⱼᵀMⱼ = I`, `Mⱼ² = -I`, `MⱼMₖ + MₖMⱼ = 0` — a representation of the
+Clifford algebra `Cl(0, n-1)` on `ℝⁿ`. The odd case dies by `no_odd_nsquare`
+(`det(M)² = (-1)ⁿ = -1`, impossible over `ℝ`). The even case is the classical
+Hurwitz–Radon obstruction; the sharp form needs the minimal faithful real
+representation dimension of `Cl(0,n-1)` (Bott periodicity + Artin–Wedderburn),
+which is **not in Mathlib**.
+
+## The tractable strip: `n ≡ 2 (mod 4)`
+
+The `HurwitzTheoremOQ03WIP01.lean` gallery entry (`HurwitzOQ03WIP01` namespace)
+pushes the *elementary* determinant argument one residue class further, into
+`n ≡ 2 (mod 4)`, via the field-agnostic engine
+`anticommuting_invertible_forces_even` (two anticommuting invertible matrices force
+even dimension over any field with `2 ≠ 0`) and its odd-dimension contrapositive
+`no_anticommuting_complex_structures_of_odd`.
+
+The plan to close `n ≡ 2 (mod 4)` (only `n ≡ 0 mod 4` then remains blocked):
+
+1. Form `P = M₁ ⋯ M_{n-1}` over the `crossMat` family.
+2. `P` commutes with each `Mᵢ`.
+3. `P² = -I` for `n ≡ 2 (mod 4)`.
+4. View `(ℝⁿ, P)` as a `ℂ`-vector space of complex dimension `m = n/2` (odd when
+   `n ≡ 2 mod 4`); `M₁, M₂` become anticommuting `ℂ`-linear complex structures, and
+   `no_anticommuting_complex_structures_of_odd` over `ℂ` (with `m` odd) gives the
+   contradiction — mirroring the real odd case one level up.
+
+## Progress this session (researcher-2, 2026-07-07) — VERIFIED
+
+Added the **product engine** to `HurwitzTheoremOQ03WIP01.lean` (0 sorry / 0 axiom,
+docker-build green, arbitrary ring `R`):
+
+- `mul_prod_anticomm : (∀ x ∈ t, a*x = -(x*a)) → a * t.prod = (-1)^t.length * (t.prod * a)`
+  — the move-through sign lemma. Proof: induction on the list; the head anticommutes
+  (`hb`), the tail commute of `(-1)^k` past the head factor is `Commute.neg_one_left`
+  `|>.pow_left`, closed with `noncomm_ring` (`-1` is central; do **not** use `ring` —
+  the ring is noncommutative).
+- `commute_prod_of_anticomm_of_even` — even length ⇒ `a` commutes with `t.prod`
+  (via `Even.neg_one_pow`).
+- `anticommute_prod_of_anticomm_of_odd` — odd length ⇒ `a` anticommutes with `t.prod`
+  (via `Odd.neg_one_pow`).
+
+This is the reusable algebraic core behind steps 1–2 of the plan, stated abstractly so
+it applies verbatim to the real `crossMat` family and to its complexification. It does
+**not** by itself close the case.
+
+## Concrete next steps (worked out; a future session / Aristotle can finish)
+
+- **`P² = -I` (step 3), abstract form.** For a list `L` whose entries pairwise
+  anticommute and each square to `-1`, `L.prod * L.prod = (-1)^((L.length+1).choose 2)`.
+  Induction on `L = a :: t`, `t.length = j`: using `mul_prod_anticomm` twice,
+  `(a*t.prod)² = (-1)^(j+1) · (t.prod)²`, and the exponent recurrence is
+  `(j+2).choose 2 = (j+1).choose 1 + (j+1).choose 2 = (j+1) + (j+1).choose 2`
+  (`Nat.choose_succ_succ`, `Nat.choose_one_right`) — this avoids all `Nat` division.
+  Then for `n ≡ 2 (mod 4)`, `L = [M₁,…,M_{n-1}]`, `(n-1+1).choose 2 = n(n-1)/2`, which is
+  **odd** (n = 4k+2 ⇒ n(n-1)/2 = (2k+1)(4k+1), a product of two odds), so `P² = -I`.
+- **`P` commutes with each factor `Mᵢ` (step 2).** Not a direct corollary of
+  `mul_prod_anticomm` (a factor does not anticommute with itself). Needs a split
+  `L.prod = pre * Mᵢ * suf` at index `i` (`List.take/List.drop`), moving `Mᵢ` to its
+  own slot and collapsing `Mᵢ² = -1`; the two positional signs `(-1)^{i-1}` and
+  `(-1)^{k-i}` combine to `(-1)^{k+1} = +1` for `k = n-1` odd. ~100–200 lines.
+- **THE BLOCKER — complexification (step 4).** Turning `(ℝⁿ, P)` with `P² = -I` into a
+  `ℂ`-module and reinterpreting the real `M₁, M₂` (which commute with `P`) as `m × m`
+  **complex** matrices preserving `det`/anticommutation is the genuine Mathlib gap:
+  the equivalence `Mat_n(ℝ)^{commutes with J} ≅ Mat_{n/2}(ℂ)` (for `J² = -I`) is not in
+  Mathlib. Without it, the engine (which lives over `ℂ`) cannot be applied to halve the
+  dimension to the odd `m = n/2`. This — not steps 1–3 — is what keeps even `n ≡ 2 mod 4`
+  from being fully closed by elementary means.
+- The residual `n ≡ 0 (mod 4)`, `n ∉ {4,8}` case remains genuinely blocked on Clifford
+  representation theory (Bott periodicity + Artin–Wedderburn), as before.
+
+## Dead Ends / Gotchas
+
+- `ring` fails inside these lemmas: `Matrix (Fin m) (Fin m) K` and the abstract `R` are
+  **noncommutative**; use `noncomm_ring` and supply centrality of `(-1)^k` explicitly via
+  `Commute.neg_one_left … |>.pow_left`.
+- Transient `exit 135` (SIGBUS, ~370 ms, no Lean error) is shared-cache corruption, not a
+  proof error — retry clears it (observed this session: first run 135, retry surfaced the
+  real elaboration error, third run green).
+
+## References
+
+- Hurwitz (1898); Radon (1922). Hurwitz–Radon function.
+- `HurwitzTheorem.lean` (`hurwitz_only_if`, `no_odd_nsquare`, `crossMat_*`).
+- `HurwitzTheoremOQ03WIP01.lean` (`anticommuting_invertible_forces_even`, product engine).

--- a/src/data/proofs/hurwitz-theorem-oq-03-wip-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-wip-01/meta.json
@@ -49,12 +49,13 @@
       "A field-agnostic theorem anticommuting_invertible_forces_even: over any field with 2 ≠ 0, two anticommuting invertible m×m matrices force m to be even — the elementary determinant engine behind the Hurwitz impossibility argument, stated once and reused over ℝ and ℂ",
       "The contrapositive no_anticommuting_invertible_of_odd and the complex-structure form no_anticommuting_complex_structures_of_odd, packaging exactly the hypotheses (M²=-I, anticommuting) produced by the parent's crossMat infrastructure",
       "Identifies and formalizes the precise reduction that extends the parent's elementary ODD-case argument to the n≡2 (mod 4) case, narrowing the parent's remaining sorry to n≡0 (mod 4), n∉{4,8}",
-      "ℝ and ℂ specializations recorded as sanity examples, exhibiting the same engine driving the real odd case and the complex n≡2 (mod 4) reduction"
+      "ℝ and ℂ specializations recorded as sanity examples, exhibiting the same engine driving the real odd case and the complex n≡2 (mod 4) reduction",
+      "Product engine (arbitrary ring): mul_prod_anticomm — moving an element that anticommutes with every factor of a list-product acquires the sign (-1)^length; with even/odd corollaries (commute_prod_of_anticomm_of_even, anticommute_prod_of_anticomm_of_odd). This is the reusable algebraic core of the P = M₁⋯M_{n-1} construction in the n ≡ 2 (mod 4) Hurwitz reduction."
     ],
     "axiomCount": 0,
     "assumptions": "None. 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound), 0 sorries — confirmed via #print axioms. This entry proves ONLY the reusable determinant obstruction and its odd-dimension corollaries; it does NOT close the parent hurwitz-theorem-oq-03 sorry. The full even case still requires (a) constructing the product complex structure P=M₁⋯M_{n-1} and verifying P²=-I and its commutation with each Mᵢ for n≡2 mod 4, then reinterpreting ℝⁿ as a complex space to invoke this theorem over ℂ; and (b) the genuinely blocked residue class n≡0 (mod 4), n∉{4,8}, which needs Clifford-algebra representation theory (Bott periodicity + Artin–Wedderburn) not present in Mathlib.",
-    "lineCount": 138,
-    "theoremCount": 3,
+    "lineCount": 203,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -147,9 +148,9 @@
       "Matrix"
     ],
     "namespace": "HurwitzOQ03WIP01",
-    "lineCount": 138,
+    "lineCount": 203,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/HurwitzTheoremOQ03WIP01.lean",
     "sorries": 0
@@ -173,6 +174,11 @@
       "type": "key",
       "description": "Complex-structure form: in odd dimension, no two anticommuting complex structures (A²=B²=-1) exist. Packages exactly the crossMat hypotheses from the parent proof; invertibility is derived from M·(-M)=1.",
       "leanType": "(2 : K) ≠ 0 → Odd m → (A B : Matrix (Fin m) (Fin m) K) → A * A = -1 → B * B = -1 → A * B = -(B * A) → False"
+    },
+    {
+      "name": "mul_prod_anticomm",
+      "statement": "For a : R and t : List R with a anticommuting with every entry of t, a * t.prod = (-1)^(t.length) * (t.prod * a).",
+      "significance": "The move-through sign lemma: reusable engine behind P = M₁⋯M_{n-1}; parity of the length decides whether a fresh anticommuting complex structure commutes or anticommutes with the product P."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the reusable algebraic core behind the `P = M₁⋯M_{n-1}` construction that extends Hurwitz's elementary determinant argument (`n`-square identities exist only for `n ∈ {1,2,4,8}`) into the **`n ≡ 2 (mod 4)`** strip. Appended to the verified `HurwitzTheoremOQ03WIP01.lean` gallery entry.

```
docker-build Proofs.HurwitzTheoremOQ03WIP01  →  Build completed successfully (7743 jobs)
203 lines / 6 theorems / 0 sorry / 0 axiom
```

## New verified lemmas (arbitrary ring `R`)

- `mul_prod_anticomm` — an element that anticommutes with every factor of a list product acquires the sign `(-1)^length` when moved across it:
  `(∀ x ∈ t, a*x = -(x*a)) → a * t.prod = (-1)^(t.length) * (t.prod * a)`
- `commute_prod_of_anticomm_of_even` — even length ⇒ `a` commutes with `t.prod`
- `anticommute_prod_of_anticomm_of_odd` — odd length ⇒ `a` anticommutes with `t.prod`

These package steps 1–2 of the reduction plan (how a fresh anticommuting complex structure interacts with the product `P`) abstractly, so they apply verbatim to the real `crossMat` family in `HurwitzTheorem.lean` and to its complexification.

## Scope / honesty

- **0 sorry / 0 axiom** (foundational axioms only). Fully machine-checked.
- This **does not close** the even case. `knowledge.md` records the worked-out next steps: `P² = -I` via the division-free exponent `(L.length+1).choose 2`; the commutes-with-a-factor positional split; and **the genuine blocker** — the complexification `Mat_n(ℝ)^{commutes with J} ≅ Mat_{n/2}(ℂ)` (for `J² = -I`) needed for step 4, which is absent from Mathlib. The `n ≡ 0 (mod 4)` case remains blocked on Clifford representation theory (Bott periodicity + Artin–Wedderburn) as before.

## Meta changes
- `leanFile` + `meta.*` lineCount 138→203, theoremCount 3→6 (status stays `verified`/`original`, axiomCount 0)
- added `research/problems/hurwitz-theorem-oq-03-wip-01/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)