### PR TITLE
Enrich Cosecant→Distance Bound |sin(πθ)| ≥ 2‖θ‖ (bounded-prime-gaps-oq-04-oq-01-incomplete-01)

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/meta.json
@@ -56,7 +56,8 @@
       "**|sin(πθ)| ≥ 2‖θ‖ is the sharp periodized Jordan inequality.** On [−1/2,1/2] it is Mathlib's 2/π·|x| ≤ |sin x| at x = πθ (the factor π cancels exactly), and π·ℤ-periodicity of |sin| extends it to all θ via the distance to the nearest integer.",
       "**The factor of 2 is exact at θ = 1/2.** sin(π/2) = 1 = 2·(1/2), so the bound is tight at the boundary — the cosecant 1/(2‖θ‖) is the right size, not merely an order-of-magnitude estimate.",
       "**This is the conversion that makes Pólya–Vinogradov work.** Combined with the sibling's |∑ e^{2πiθn}| ≤ 1/|sin(πθ)|, it gives |∑ e^{2πiθn}| ≤ 1/(2‖θ‖); summing 1/(2‖a/q‖) over residues a is exactly the cotangent sum that aggregates to O(q log q).",
-      "**round / distance-to-nearest-integer is the natural variable.** Using Mathlib's round and abs_sub_round keeps the statement coordinate-free and matches the standard ‖·‖ notation of analytic number theory."
+      "**round / distance-to-nearest-integer is the natural variable.** Using Mathlib's round and abs_sub_round keeps the statement coordinate-free and matches the standard ‖·‖ notation of analytic number theory.",
+      "**Why the constant is 2 and not π.** The ratio |sin(πθ)|/‖θ‖ decreases monotonically from π (as θ→0, where sin(πθ) ≈ πθ) down to 2 (at θ = 1/2). A *global* linear lower bound c·‖θ‖ must therefore take the endpoint value c = 2 — near 0 the tangent-line behavior would allow the far larger slope π, but the boundary θ = 1/2 forces the smaller constant. The 2‖θ‖ bound is thus best-possible as a single linear estimate across the whole period, at the cost of a factor π/2 of slack near the integers."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-04-oq-01-incomplete-01` (quality 94, pass 0).

Entry was already strong and well under caps (meta.json 11.2 KB). Annotation coverage is complete (5 annotations covering all 4 theorems + overview). One genuine gap: keyInsights had 4 (target 4–5) and lacked the explanation of the constant.

**keyInsights 4 → 5.** Added *why the constant is 2 and not π*: the ratio |sin(πθ)|/‖θ‖ decreases monotonically from π (as θ→0, tangent-line regime sin(πθ)≈πθ) to 2 (at θ=1/2). A single global linear lower bound c·‖θ‖ is therefore forced to the endpoint value c=2 — best-possible across the whole period, at the cost of π/2 slack near the integers. Complements the existing insight #2 (tightness at θ=1/2) by explaining the local-vs-global constant gap.

No content deleted. Axiom/status fields verified accurate (0 sorries, 0 axioms, status verified). meta.json stays 11.2 KB, 5 keyInsights — under every guardrail cap.