### PR TITLE
audit(re-audit): fix 3 stale top-level meta.sorries fields

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8872,10 +8872,10 @@
       "issues": []
     },
     "erdos-1018": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
-      "lastAudited": "2026-07-08T05:49:40Z",
-      "result": "clean",
+      "agentId": "auditor-reaudit-20260708",
+      "auditCount": 7,
+      "lastAudited": "2026-07-08T06:27:08Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1018-oq-01": {
@@ -16397,10 +16397,10 @@
       "result": "clean"
     },
     "erdos-798": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:44Z",
-      "result": "clean"
+      "agentId": "auditor-reaudit-20260708",
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T06:27:08Z",
+      "result": "issues-fixed"
     },
     "erdos-799": {
       "agentId": "auditor-cycle-20-batch",
@@ -26047,10 +26047,11 @@
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-03": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-07-08T05:49:40Z",
-      "result": "clean"
+      "lastAudited": "2026-07-08T06:27:08Z",
+      "result": "issues-fixed",
+      "agentId": "auditor-reaudit-20260708"
     },
     "taylor-sincos-convergence-oq-03-incomplete-01": {
       "auditCount": 1,

--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -254,5 +254,5 @@
       "Proofs/Stubs/Erdos1018Problem.lean"
     ]
   },
-  "sorries": 5
+  "sorries": 3
 }

--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -214,5 +214,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, geometry, solved"
     }
   ],
-  "sorries": 5
+  "sorries": 4
 }

--- a/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
@@ -137,5 +137,5 @@
       "Quantitative sharpness: at x = 1, the alternating bound for n = 5 is 1/5040 ≈ 0.0002, while the actual error is much smaller. Is the alternating bound itself tight, or can it be further improved for specific values of x?"
     ]
   },
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Auditor re-audit sweep

Backlog is fully audited (0 unaudited / 0 open issues), so this cycle re-audits gallery entries whose `meta.json` content changed since their last audit.

### Findings

Three metas had a stale **top-level** `sorries` field: a recent sorry-count edit updated `meta.sorries` and `leanFile.sorries` but left the top-level scalar untouched.

| slug | top-level (was → now) | nested meta.sorries | actual source |
|------|----------------------|--------------------|---------------|
| erdos-798 | 5 → 4 | 4 ✓ | 4 sorries, 3 axioms |
| erdos-1018 | 5 → 3 | 3 ✓ | 3 sorries |
| taylor-sincos-convergence-oq-03 | 3 → 2 | 2 ✓ | 2 sorries |

All three **understated** completeness (top-level count was higher than reality), so no integrity overclaim — but the field contradicted both the source and the nested `meta.sorries`. `status`/`badge` and nested counts were already correct and are unchanged. erdos-1018's `meta.axiomCount=14` vs `leanFile.axiomCount=7` is the legitimate literal-vs-structure split (policy-compliant), left as-is.

### Also verified clean (no changes)
abel-ruffini-oq-04-oq-01-oq-03, birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01, burnside-counting-oq-05-oq-01, cauchy-interlacing-theorem-oq-01-oq-01, composition-parts-choose-oq-01-oq-03, erdos-3.

Tracker updated (`issues-fixed`) for the 3 corrected slugs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)