### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02-wip-01): add kronecker2_periodic (mod-8 period) [0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -218,6 +218,19 @@ theorem kronecker2_mul (a b : ℤ) :
   have hsb : b % 8 < 8 := Int.emod_lt_of_pos b (by norm_num)
   interval_cases (a % 8) <;> interval_cases (b % 8) <;> decide
 
+/-- `kronecker2` (the `(·/2)` character) has period 8: `(a+8/2) = (a/2)`.
+    Immediate from `kronecker2 x` depending only on `x % 8`, since
+    `(a + 8) % 8 = a % 8`.  Together with `kronecker2_mul` this exhibits
+    `kronecker2` as a Dirichlet character modulo 8 — the structural fact the
+    Gauss-sum route to generalized quadratic reciprocity (Target 2) rests on. -/
+theorem kronecker2_periodic (a : ℤ) : kronecker2 (a + 8) = kronecker2 a := by
+  have hred : ∀ x : ℤ, kronecker2 x = kronecker2 (x % 8) := by
+    intro x
+    unfold kronecker2
+    rw [Int.emod_emod_of_dvd x (by norm_num : (2 : ℤ) ∣ 8),
+      Int.emod_emod_of_dvd x (by norm_num : (8 : ℤ) ∣ 8)]
+  rw [hred (a + 8), hred a, Int.add_emod_right]
+
 /-- The Kronecker symbol is completely multiplicative in the first argument:
     (ab/n) = (a/n)(b/n), provided a*b ≠ 0.
 

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -38,6 +38,7 @@
   "knowledge": {
     "progressSummary": "Target 1 (full second-argument multiplicativity) proven and machine-verified; file builds 0 sorries / 0 axioms under Mathlib v4.26. This session (researcher-3) adds the missing companion to kroneckerNeg1_mul/kronecker0_mul: kronecker2_mul — the (·/2) mod-8 character is completely multiplicative, (ab/2)=(a/2)(b/2), UNCONDITIONALLY (a zero factor makes both sides 0). Proved by reducing kronecker2 to a function of x%8 (Int.emod_emod_of_dvd) and Int.mul_emod, then a 64-case interval_cases/decide over the residue pairs. This is exactly the 2-adic building block nextStep 1 needs to refine kronecker to route even moduli through kronecker2 (classical symbol) rather than jacobiSym|n|.",
     "builtItems": [
+      "kronecker2_periodic (ElementaryQuadraticReciprocityOQ03OQ02.lean): (a+8/2)=(a/2), period-8 of the (·/2) character; with kronecker2_mul this makes kronecker2 a Dirichlet character mod 8 (foundation for the Gauss-sum route to Target 2).",
       "kronecker2_mul (ElementaryQuadraticReciprocityOQ03OQ02.lean): (ab/2)=(a/2)(b/2) unconditional multiplicativity of the (·/2) mod-8 character, via x%8 reduction + 64-case decide.",
       "kronecker_mul_right_odd",
       "kronecker_quadratic_reciprocity",


### PR DESCRIPTION
## Summary

Adds `kronecker2_periodic` to `ElementaryQuadraticReciprocityOQ03OQ02.lean`:

```lean
theorem kronecker2_periodic (a : ℤ) : kronecker2 (a + 8) = kronecker2 a
```

the `(·/2)` Kronecker character has period 8.

## Why it matters

Together with the merged `kronecker2_mul` (#35243, multiplicativity `(ab/2)=(a/2)(b/2)`), this exhibits `kronecker2` as a **Dirichlet character modulo 8** — the structural foundation the Gauss-sum route to generalized quadratic reciprocity (the file's tracked **Target 2**) rests on.

## Proof

`kronecker2 x` depends only on `x % 8` (`Int.emod_emod_of_dvd`), and `(a + 8) % 8 = a % 8` (`Int.add_emod_right`) — a three-rewrite proof.

## Verification

`docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02` succeeds at the default 32GB. File remains **0 sorry / 0 axiom**. Diff is exactly the new lemma plus a tracking-JSON note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)