### PR TITLE
Research: erdos-490 — verified combinatorial crux of the Chebyshev θ-gap axiom

### DIFF
--- a/proofs/Proofs/Erdos490Chebyshev.lean
+++ b/proofs/Proofs/Erdos490Chebyshev.lean
@@ -1,0 +1,206 @@
+/-
+  Chebyshev θ-gap lower bound for Erdős Problem #490.
+
+  This file works toward eliminating the analytic axiom
+  `chebyshev_theta_upper_half_lower_bound` in `Erdos490Problem.lean`, namely
+  `∃ c > 0, ∀ N ≥ 4, c·N ≤ θ(N) − θ(N/2)`.
+
+  The combinatorial heart is the classical central-binomial decomposition
+  (the same estimate that powers Mathlib's proof of Bertrand's postulate):
+  the prime factorisation of `centralBinom n = C(2n, n)` splits into
+    * small primes `p ≤ 2n/3`, contributing at most `(2n)^√(2n) · 4^(2n/3)`, and
+    * large primes `n < p ≤ 2n`, contributing exactly `∏_{n < p ≤ 2n} p`,
+  with the middle band `(2n/3, n]` contributing nothing.  Hence
+    `centralBinom n ≤ (2n)^√(2n) · 4^(2n/3) · ∏_{n < p ≤ 2n} p`.
+  Combined with the standard lower bound `4^n < n · centralBinom n`, this yields
+  a lower bound on `∏_{n < p ≤ 2n} p`, whose logarithm is the θ-gap.
+-/
+import Mathlib
+
+open Finset
+
+namespace Erdos490Cheb
+
+open Nat
+
+/-- **Small-prime contribution bound.** The primes `p ≤ 2n/3` contribute at most
+`(2n)^√(2n) · 4^(2n/3)` to `centralBinom n`.  This is exactly the estimate inside
+Mathlib's `Nat.centralBinom_le_of_no_bertrand_prime`, extracted as a standalone lemma
+(the Bertrand proof only needs it under a "no large prime" hypothesis; we keep the large
+primes as a separate factor). -/
+lemma small_prime_prod_le (n : ℕ) (hn : 0 < n) :
+    ∏ p ∈ {p ∈ range (2 * n / 3 + 1) | p.Prime}, p ^ (n.centralBinom.factorization p)
+      ≤ (2 * n) ^ Nat.sqrt (2 * n) * 4 ^ (2 * n / 3) := by
+  have n2_pos : 1 ≤ 2 * n := by omega
+  let S := {p ∈ range (2 * n / 3 + 1) | p.Prime}
+  let f : ℕ → ℕ := fun x => x ^ n.centralBinom.factorization x
+  show ∏ p ∈ S, f p ≤ (2 * n) ^ Nat.sqrt (2 * n) * 4 ^ (2 * n / 3)
+  rw [← Finset.prod_filter_mul_prod_filter_not S (· ≤ Nat.sqrt (2 * n))]
+  apply mul_le_mul'
+  · -- primes `≤ √(2n)`: each contributes `≤ 2n`, and there are `≤ √(2n)` of them.
+    refine (Finset.prod_le_prod' fun p _ => (?_ : f p ≤ 2 * n)).trans ?_
+    · exact pow_factorization_choose_le (mul_pos two_pos hn)
+    have hcard : (Finset.Icc 1 (Nat.sqrt (2 * n))).card = Nat.sqrt (2 * n) := by
+      rw [Nat.card_Icc]; omega
+    rw [Finset.prod_const]
+    refine pow_right_mono₀ n2_pos ((Finset.card_le_card fun x hx => ?_).trans hcard.le)
+    obtain ⟨h1, h2⟩ := Finset.mem_filter.1 hx
+    exact Finset.mem_Icc.mpr ⟨(Finset.mem_filter.1 h1).2.one_lt.le, h2⟩
+  · -- primes `√(2n) < p ≤ 2n/3`: each has multiplicity `≤ 1`, product `≤ primorial ≤ 4^(2n/3)`.
+    refine le_trans ?_ (primorial_le_4_pow (2 * n / 3))
+    refine (Finset.prod_le_prod' fun p hp => (?_ : f p ≤ p)).trans ?_
+    · obtain ⟨h1, h2⟩ := Finset.mem_filter.1 hp
+      refine (pow_right_mono₀ (Finset.mem_filter.1 h1).2.one_lt.le ?_).trans (pow_one p).le
+      exact Nat.factorization_choose_le_one (Nat.sqrt_lt'.mp <| not_le.1 h2)
+    refine Finset.prod_le_prod_of_subset_of_one_le' (Finset.filter_subset _ _) ?_
+    exact fun p hp _ => (Finset.mem_filter.1 hp).2.one_lt.le
+
+/-- **Central-binomial decomposition (the combinatorial crux).**
+The prime factorisation of `centralBinom n` splits so that the primes `p ≤ 2n/3`
+contribute at most `(2n)^√(2n) · 4^(2n/3)` (see `small_prime_prod_le`), the primes in
+`(2n/3, n]` contribute nothing, and the large primes `n < p ≤ 2n` contribute at most
+`∏_{n < p ≤ 2n} p`.  Hence
+`centralBinom n ≤ (2n)^√(2n) · 4^(2n/3) · ∏_{n < p ≤ 2n, p prime} p`. -/
+theorem centralBinom_le_small_mul_large (n : ℕ) (hn : 2 < n) :
+    n.centralBinom ≤
+      (2 * n) ^ Nat.sqrt (2 * n) * 4 ^ (2 * n / 3) *
+        ∏ p ∈ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}, p := by
+  have hn0 : 0 < n := by omega
+  rw [← Nat.prod_pow_factorization_centralBinom n,
+    ← Finset.prod_filter_mul_prod_filter_not (range (2 * n + 1)) (· ≤ n)
+        (fun x => x ^ n.centralBinom.factorization x)]
+  apply mul_le_mul'
+  · -- small + middle band: reduces to the primes `≤ 2n/3`
+    have hSsub : {p ∈ range (2 * n / 3 + 1) | p.Prime}
+        ⊆ (range (2 * n + 1)).filter (· ≤ n) := by
+      intro p hp
+      simp only [Finset.mem_filter, Finset.mem_range] at hp ⊢
+      exact ⟨by omega, by omega⟩
+    have hone : ∀ x ∈ (range (2 * n + 1)).filter (· ≤ n),
+        x ∉ {p ∈ range (2 * n / 3 + 1) | p.Prime} →
+        x ^ n.centralBinom.factorization x = 1 := by
+      intro x hx hxnot
+      simp only [Finset.mem_filter, Finset.mem_range] at hx hxnot
+      by_cases hxp : x.Prime
+      · have hgt : 2 * n / 3 < x := by
+          by_contra h; push_neg at h
+          exact hxnot ⟨by omega, hxp⟩
+        rw [Nat.factorization_centralBinom_of_two_mul_self_lt_three_mul hn (by omega) (by omega),
+          pow_zero]
+      · rw [Nat.factorization_eq_zero_of_not_prime _ hxp, pow_zero]
+    rw [← Finset.prod_subset hSsub hone]
+    exact small_prime_prod_le n hn0
+  · -- large primes: multiplicity `≤ 1`, so `p ^ v_p ≤ p`
+    have hLsub : {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}
+        ⊆ (range (2 * n + 1)).filter (fun x => ¬ x ≤ n) := by
+      intro p hp
+      simp only [Finset.mem_filter, Finset.mem_range] at hp ⊢
+      exact ⟨hp.1, by omega⟩
+    have hone : ∀ x ∈ (range (2 * n + 1)).filter (fun x => ¬ x ≤ n),
+        x ∉ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime} →
+        x ^ n.centralBinom.factorization x = 1 := by
+      intro x hx hxnot
+      simp only [Finset.mem_filter, Finset.mem_range] at hx hxnot
+      have hnx : n < x := by omega
+      have hxp : ¬ x.Prime := fun hp => hxnot ⟨hx.1, hnx, hp⟩
+      rw [Nat.factorization_eq_zero_of_not_prime _ hxp, pow_zero]
+    rw [← Finset.prod_subset hLsub hone]
+    refine Finset.prod_le_prod' ?_
+    intro p hp
+    simp only [Finset.mem_filter, Finset.mem_range] at hp
+    obtain ⟨_, hnp, hpp⟩ := hp
+    have hv1 : n.centralBinom.factorization p ≤ 1 := by
+      have hp2 : 2 * n < p ^ 2 := by nlinarith [hnp]
+      exact Nat.factorization_choose_le_one hp2
+    calc p ^ n.centralBinom.factorization p
+        ≤ p ^ 1 := Nat.pow_le_pow_right hpp.pos hv1
+      _ = p := pow_one p
+
+/-- **Lower bound on the large-prime product (nat).** Combining the decomposition with the
+standard exponential lower bound `4^n < n · centralBinom n` gives an exponential lower bound
+on `∏_{n < p ≤ 2n} p` (up to the sub-exponential factor `n · (2n)^√(2n) · 4^(2n/3)`). -/
+theorem four_pow_lt_bound (n : ℕ) (hn : 4 ≤ n) :
+    4 ^ n < n * ((2 * n) ^ Nat.sqrt (2 * n) * 4 ^ (2 * n / 3)) *
+      ∏ p ∈ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}, p := by
+  have h1 : 4 ^ n < n * n.centralBinom := Nat.four_pow_lt_mul_centralBinom n hn
+  have h2 := centralBinom_le_small_mul_large n (by omega)
+  have h3 : n * n.centralBinom
+      ≤ n * ((2 * n) ^ Nat.sqrt (2 * n) * 4 ^ (2 * n / 3) *
+          ∏ p ∈ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}, p) :=
+    Nat.mul_le_mul le_rfl h2
+  rw [← mul_assoc] at h3
+  exact lt_of_lt_of_le h1 h3
+
+/-- **The θ-gap equals the log of the large-prime product.** Since `θ x = ∑_{p ≤ x} log p`,
+the difference `θ(2n) − θ(n)` sums `log p` over the primes `p ∈ (n, 2n]`, i.e. exactly the
+`large` product used above.  (Mirror of `theta_gap_eq_sum_optimalB` in the main file, for the
+interval `(n, 2n]`.) -/
+theorem theta_gap_eq_log_prod (n : ℕ) :
+    Chebyshev.theta ((2 * n : ℕ) : ℝ) - Chebyshev.theta ((n : ℕ) : ℝ)
+      = Real.log ((∏ p ∈ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}, p : ℕ) : ℝ) := by
+  have e1 : Chebyshev.theta ((2 * n : ℕ) : ℝ)
+      = ∑ p ∈ {p ∈ Finset.Ioc 0 (2 * n) | p.Prime}, Real.log (p : ℝ) := by
+    simp only [Chebyshev.theta, Nat.floor_natCast]
+  have e2 : Chebyshev.theta ((n : ℕ) : ℝ)
+      = ∑ p ∈ {p ∈ Finset.Ioc 0 n | p.Prime}, Real.log (p : ℝ) := by
+    simp only [Chebyshev.theta, Nat.floor_natCast]
+  have hsub : {p ∈ Finset.Ioc 0 n | p.Prime} ⊆ {p ∈ Finset.Ioc 0 (2 * n) | p.Prime} :=
+    Finset.filter_subset_filter _ (Finset.Ioc_subset_Ioc_right (by omega))
+  have hset : {p ∈ Finset.Ioc 0 (2 * n) | p.Prime} \ {p ∈ Finset.Ioc 0 n | p.Prime}
+      = {p ∈ range (2 * n + 1) | n < p ∧ p.Prime} := by
+    ext p
+    simp only [Finset.mem_sdiff, Finset.mem_filter, Finset.mem_Ioc, Finset.mem_range]
+    constructor
+    · rintro ⟨⟨⟨hp0, hp2n⟩, hpr⟩, hnot⟩
+      refine ⟨by omega, ?_, hpr⟩
+      by_contra h; push_neg at h; exact hnot ⟨⟨hp0, by omega⟩, hpr⟩
+    · rintro ⟨_, hnp, hpr⟩
+      exact ⟨⟨⟨hpr.pos, by omega⟩, hpr⟩, by rintro ⟨⟨_, h2⟩, _⟩; omega⟩
+  rw [e1, e2, ← Finset.sum_sdiff_eq_sub hsub, hset, Nat.cast_prod]
+  refine (Real.log_prod (fun p hp => ?_)).symm
+  simp only [Finset.mem_filter, Finset.mem_range] at hp
+  exact_mod_cast hp.2.2.pos.ne'
+
+/-- **Chebyshev θ-gap lower bound, reduced to an elementary expression (0 axioms, 0 sorries).**
+For `n ≥ 4`,
+`θ(2n) − θ(n) ≥ n·log 4 − ⌊2n/3⌋·log 4 − log n − √(2n)·log(2n)`
+where `√` is `Nat.sqrt`.  The right-hand side is `≥ (n/3)·log 4 − log n − √(2n)·log(2n)`, which is
+`≥ c·n` for all large `n` since `log n` and `√(2n)·log(2n)` are `o(n)`.  This is the classical
+Chebyshev-strength lower bound, whose analytic tail (`√n·log n = o(n)`) and small-`n` reconciliation
+(via Bertrand) are the only remaining steps to fully eliminate the axiom
+`chebyshev_theta_upper_half_lower_bound` in `Erdos490Problem.lean`. -/
+theorem theta_gap_lower_bound (n : ℕ) (hn : 4 ≤ n) :
+    (n : ℝ) * Real.log 4 - ((2 * n / 3 : ℕ) : ℝ) * Real.log 4 - Real.log (n : ℝ)
+        - (Nat.sqrt (2 * n) : ℝ) * Real.log (2 * (n : ℝ))
+      ≤ Chebyshev.theta ((2 * n : ℕ) : ℝ) - Chebyshev.theta ((n : ℕ) : ℝ) := by
+  rw [theta_gap_eq_log_prod]
+  have hnR : (0 : ℝ) < (n : ℝ) := by exact_mod_cast (by omega : 0 < n)
+  have h2n : (0 : ℝ) < 2 * (n : ℝ) := by linarith
+  have hsmall_pos : (0 : ℝ) < (2 * (n : ℝ)) ^ Nat.sqrt (2 * n) * (4 : ℝ) ^ (2 * n / 3) :=
+    mul_pos (pow_pos h2n _) (pow_pos (by norm_num) _)
+  have hPpos : (0 : ℝ) < ((∏ p ∈ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}, p : ℕ) : ℝ) := by
+    rw [Nat.cast_pos]
+    exact Finset.prod_pos fun p hp => by
+      simp only [Finset.mem_filter, Finset.mem_range] at hp; exact hp.2.2.pos
+  have hnat : 4 ^ n < n * ((2 * n) ^ Nat.sqrt (2 * n) * 4 ^ (2 * n / 3)) *
+      ∏ p ∈ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}, p := four_pow_lt_bound n hn
+  have hcast : (4 : ℝ) ^ n < (n : ℝ) *
+      ((2 * (n : ℝ)) ^ Nat.sqrt (2 * n) * (4 : ℝ) ^ (2 * n / 3)) *
+      ((∏ p ∈ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}, p : ℕ) : ℝ) := by
+    have : ((4 ^ n : ℕ) : ℝ) < ((n * ((2 * n) ^ Nat.sqrt (2 * n) * 4 ^ (2 * n / 3)) *
+        ∏ p ∈ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}, p : ℕ) : ℝ) := by exact_mod_cast hnat
+    push_cast at this ⊢
+    linarith [this]
+  have hlog : Real.log ((4 : ℝ) ^ n) < Real.log ((n : ℝ) *
+      ((2 * (n : ℝ)) ^ Nat.sqrt (2 * n) * (4 : ℝ) ^ (2 * n / 3)) *
+      ((∏ p ∈ {p ∈ range (2 * n + 1) | n < p ∧ p.Prime}, p : ℕ) : ℝ)) :=
+    Real.log_lt_log (by positivity) hcast
+  rw [Real.log_pow,
+    Real.log_mul (mul_ne_zero (ne_of_gt hnR) (ne_of_gt hsmall_pos)) (ne_of_gt hPpos),
+    Real.log_mul (ne_of_gt hnR) (ne_of_gt hsmall_pos),
+    Real.log_mul (ne_of_gt (pow_pos h2n _)) (ne_of_gt (pow_pos (by norm_num : (0:ℝ) < 4) _)),
+    Real.log_pow, Real.log_pow] at hlog
+  linarith [hlog]
+
+end Erdos490Cheb
+

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -325,3 +325,52 @@ justified without a green build).
 No math change. Both axioms remain correctly isolated and minimal. Problem stays at a stable,
 well-characterized frontier: the sole in-scope elimination target is blocked on an input that
 Mathlib upstream itself lists as future work.
+
+## Session 2026-07-07 (researcher-4) — combinatorial crux of Chebyshev θ-gap axiom VERIFIED
+
+**Mode**: ACT (axiom-reduction). **Outcome**: progress — new standalone 0-axiom/0-sorry file
+`Erdos490Chebyshev.lean` (205 lines, 5 lemmas) reduces the remaining analytic axiom
+`chebyshev_theta_upper_half_lower_bound` to an elementary explicit lower bound. Axiom NOT
+eliminated (main file unchanged, still 2 axioms).
+
+### What I built (verified 0-axiom: `#print axioms` = [propext, Classical.choice, Quot.sound])
+- `small_prime_prod_le`: `∏_{p≤2n/3, prime} p^{v_p} ≤ (2n)^√(2n)·4^(2n/3)` — extracted/adapted
+  from Mathlib's `centralBinom_le_of_no_bertrand_prime` inner argument (kept the large primes
+  as a separate factor instead of assuming they don't exist).
+- `centralBinom_le_small_mul_large` (THE CRUX): `centralBinom n ≤ (2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n}p`.
+  Three-way factorisation split of `range(2n+1)` by `(·≤n)`: small band via the lemma above,
+  middle band `(2n/3,n]` contributes 1 (`factorization_centralBinom_of_two_mul_self_lt_three_mul`),
+  large band `n<p≤2n` has `v_p ≤ 1` (`factorization_choose_le_one`, since `p>n ⇒ 2n<p²`).
+- `four_pow_lt_bound`: `4^n < n·(2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n}p` (combine crux with
+  `Nat.four_pow_lt_mul_centralBinom`).
+- `theta_gap_eq_log_prod`: `θ(2n)−θ(n) = log ∏_{n<p≤2n}p` (mirror of main file's
+  `theta_gap_eq_sum_optimalB` for the interval (n,2n]; `Chebyshev.theta` + `sum_sdiff` + `log_prod`).
+- `theta_gap_lower_bound` (deliverable): `θ(2n)−θ(n) ≥ n·log4 − ⌊2n/3⌋·log4 − log n − √(2n)·log(2n)`
+  for `n≥4` (cast `four_pow_lt_bound` to ℝ, take logs, `linarith`). RHS `≥ (n/3)log4 − log n − √(2n)log(2n)`.
+
+### Key facts
+- Mathlib's `Mathlib.NumberTheory.Chebyshev` explicitly TODOs "Prove Chebyshev's lower bound" — so
+  the θ lower bound is a genuine gap, and the axiom is not laziness.
+- The Mathlib Bertrand factorisation lemmas are PUBLIC (`Nat.` namespace): `pow_factorization_choose_le`,
+  `factorization_choose_le_one`, `factorization_centralBinom_of_two_mul_self_lt_three_mul`,
+  `prod_pow_factorization_centralBinom`, `four_pow_lt_mul_centralBinom`, `primorial_le_4_pow`.
+- To reuse Mathlib's `centralBinom_le_of_no_bertrand_prime` inner argument as a standalone lemma,
+  use `let S/f` + `show ∏ p ∈ S, f p ≤ ...` (NOT `set`, which breaks the `primorial` defeq at the
+  `prod_le_prod_of_subset_of_one_le'`/`primorial_le_4_pow` step).
+- `Real.log_prod {s}{f}(hf)` takes ONLY the ≠0 hypothesis (s,f implicit) — `Real.log_prod _ _ (…)` errors.
+
+### Gotchas / infra
+- **exit-135 with NO line number that reproduces on a KNOWN-GOOD file = corrupt Mathlib cache volume**
+  (built Erdos490Problem.lean, on main, → identical 135 at 462ms). Fix: `LEAN_SKIP_CACHE=true
+  ./proofs/scripts/docker-build.sh …` rebuilds fresh and SUCCEEDS. Retrying with cache did NOT clear it.
+- `.loom/worktrees/researcher-4` was DELETED mid-session (concurrent cleanup) → durable worktree at
+  `/Users/rwalters/lg-r4-wt`. Heartbeat needs `RESEARCHER_ID=researcher-4` exported (else it reports a
+  random runtime id and refuses).
+- Aristotle MCP down ("Resource not found").
+
+### Remaining to eliminate the axiom (NOT done here)
+1. Analytic tail: `√(2n)·log(2n) = o(n)` and `log n = o(n)` (Mathlib has `Real.isLittleO_log_id_atTop`)
+   ⇒ `∃c>0 ∃N₀ ∀n≥N₀, (n/3)log4 − log n − √(2n)log(2n) ≥ c·n`.
+2. Small-n reconciliation (4 ≤ N < N₀) via Bertrand (`optimalB_nonempty`, finite min of positive values).
+3. Alignment `(2n,n) ↦ (N,N/2)`: set `n=⌊N/2⌋`, `2n∈{N−1,N}`, use `Chebyshev.theta_mono`.
+Then replace `axiom chebyshev_theta_upper_half_lower_bound` with a theorem importing this file (2→1 axioms).

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -77,7 +77,8 @@
       "productSet_eq_image: productSet A B = image of product map on A×ˢB",
       "optimalB_nonempty: for N ≥ 2 the interval (N/2,N] contains a prime (0-axiom, via Mathlib's Bertrand postulate Nat.exists_prime_lt_and_le_two_mul) — discharges the qualitative content of the Chebyshev axiom",
       "optimalB_card_pos: |optimalB N| ≥ 1 for N ≥ 2 (0-axiom, via Bertrand)",
-      "primeCounting_half_lt: π(N/2) < π(N) for N ≥ 2 (0-axiom) — the strict prime-counting gap, combining optimalB_card_pos with optimalB_card_eq_primeCounting"
+      "primeCounting_half_lt: π(N/2) < π(N) for N ≥ 2 (0-axiom) — the strict prime-counting gap, combining optimalB_card_pos with optimalB_card_eq_primeCounting",
+      "Erdos490Chebyshev.lean (NEW, standalone, 0-axiom/0-sorry): verified central-binomial decomposition centralBinom_le_small_mul_large (centralBinom n ≤ (2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n}p, the combinatorial crux of Chebyshev's θ lower bound — Mathlib's own stated TODO), plus theta_gap_lower_bound reducing θ(2n)−θ(n) to the elementary explicit lower bound n·log4 − ⌊2n/3⌋·log4 − log n − √(2n)·log(2n). Reduces (does NOT yet eliminate) the axiom chebyshev_theta_upper_half_lower_bound to the analytic tail √n·log n = o(n) + small-n Bertrand reconciliation."
     ],
     "axiomCount": 2,
     "lineCount": 660,
@@ -86,7 +87,8 @@
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
-      "Proofs/Erdos490Aristotle.lean"
+      "Proofs/Erdos490Aristotle.lean",
+      "Proofs/Erdos490Chebyshev.lean"
     ]
   },
   "overview": {
@@ -222,7 +224,8 @@
     "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
-      "Proofs/Erdos490Aristotle.lean"
+      "Proofs/Erdos490Aristotle.lean",
+      "Proofs/Erdos490Chebyshev.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-490-incomplete-01.json
+++ b/src/data/research/problems/erdos-490-incomplete-01.json
@@ -39,7 +39,10 @@
       "optimalA N = Finset.Icc 1 (N/2), so |optimalA N| = N/2 exactly (proved 0-axiom via Finset.ext + Nat.card_Icc + omega).",
       "optimal_has_distinct_products is NOT a real axiom: it follows from optimal_works_because_primes (already proved) once you bridge the elementwise ProductMapInjective definition to the cardinality-based HasDistinctProducts via Finset.card_image_iff. Eliminated 2026-06-30, axioms 3→2.",
       "2026-07-07 (researcher-9): Mathlib.NumberTheory.Chebyshev (θ, ψ = first/second Chebyshev functions) exists and is imported, but supplies ONLY upper bounds (theta_le_log4_mul_x, psi_le_const_mul_self) — no lower bound on θ, ψ, or Nat.primeCounting. Eliminating the analytic axiom fully still needs the classical Chebyshev θ-gap lower bound θ(N)−θ(N/2) ≥ c·N, whose elementary proof is Erdős's central-binomial argument (the (2n/3,2n] product estimate from the proof of Bertrand); genuinely multi-session infrastructure.",
-      "θ→π bridge is elementary and now verified: θ(N)−θ(N/2)=∑_{N/2<p≤N} log p (= sum over optimalB via Finset.sum_sdiff_eq_sub on prime-filtered Ioc intervals), and each log p ≤ log N gives θ-gap ≤ |optimalB|·log N; dividing by log N turns any Chebyshev θ lower bound directly into the π(N)−π(N/2) ≳ N/log N bound."
+      "θ→π bridge is elementary and now verified: θ(N)−θ(N/2)=∑_{N/2<p≤N} log p (= sum over optimalB via Finset.sum_sdiff_eq_sub on prime-filtered Ioc intervals), and each log p ≤ log N gives θ-gap ≤ |optimalB|·log N; dividing by log N turns any Chebyshev θ lower bound directly into the π(N)−π(N/2) ≳ N/log N bound.",
+      "The Chebyshev θ-gap axiom θ(N)−θ(N/2)≥c·N has a known elementary proof via the central binomial coefficient (Erdős's Bertrand argument): primes n<p≤2n divide C(2n,n) exactly once, and small primes ≤2n/3 contribute at most (2n)^√(2n)·4^(2n/3). Mathlib's Bertrand internals (factorization_centralBinom_*, pow_factorization_choose_le, primorial_le_4_pow) are PUBLIC and suffice for the combinatorial half.",
+      "Mathlib's Mathlib.NumberTheory.Chebyshev explicitly lists 'Prove Chebyshev's lower bound' as an open TODO — so a θ lower bound is genuinely NOT available and must be built.",
+      "Remaining to fully eliminate the axiom: (a) the analytic tail √(2n)·log(2n)=o(n) and log n=o(n) (Mathlib has Real.isLittleO_log_id_atTop); (b) small-n reconciliation via Bertrand (finite min); (c) alignment (2n,n)↦(N,N/2) via θ monotonicity."
     ],
     "builtItems": [
       "Build repair: Nat.card_Icc, open scoped Classical, orphan-comment fixes (Erdos490Problem.lean)",
@@ -52,7 +55,12 @@
       "optimal_has_distinct_products: converted axiom→theorem (0-axiom, derived from optimal_works_because_primes)",
       "theta_gap_eq_sum_optimalB (Erdos490Problem.lean) — θ(N)−θ(N/2) = ∑_{p∈optimalB N} log p, 0-axiom",
       "theta_gap_le_card_mul_log (Erdos490Problem.lean) — θ(N)−θ(N/2) ≤ |optimalB N|·log N, 0-axiom",
-      "primes_upper_half_lower_bound is NOW a THEOREM (was an axiom), derived from chebyshev_theta_upper_half_lower_bound via the θ→π bridge — 0 new axioms"
+      "primes_upper_half_lower_bound is NOW a THEOREM (was an axiom), derived from chebyshev_theta_upper_half_lower_bound via the θ→π bridge — 0 new axioms",
+      "Erdos490Chebyshev.lean:small_prime_prod_le — ∏_{p≤2n/3} p^{v_p} ≤ (2n)^√(2n)·4^(2n/3) (0-axiom, adapts Mathlib centralBinom_le_of_no_bertrand_prime)",
+      "Erdos490Chebyshev.lean:centralBinom_le_small_mul_large — centralBinom n ≤ (2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n}p (0-axiom, the combinatorial crux)",
+      "Erdos490Chebyshev.lean:four_pow_lt_bound — 4^n < n·(2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n}p (0-axiom)",
+      "Erdos490Chebyshev.lean:theta_gap_eq_log_prod — θ(2n)−θ(n) = log ∏_{n<p≤2n}p (0-axiom)",
+      "Erdos490Chebyshev.lean:theta_gap_lower_bound — θ(2n)−θ(n) ≥ n·log4−⌊2n/3⌋·log4−log n−√(2n)·log(2n) (0-axiom; reduces axiom to analytic tail)"
     ],
     "mathlibGaps": [
       "No prime-counting lower bound (π(N) − π(N/2)) readily available for the optimal-example lower bound.",
@@ -63,7 +71,7 @@
       "DONE (2026-06-30): proved (optimalB N).card = N.primeCounting - (N/2).primeCounting (optimalB_card_eq_primeCounting), bridging the axiom to Mathlib's primeCounting API.",
       "Prove chebyshev_theta_upper_half_lower_bound: θ(N)−θ(N/2) ≥ c·N via central binomial coefficient. Path: log(centralBinom n) ≤ ψ(2n) (Legendre valuation ≤ prime-power count) + centralBinom n ≥ 4^n/(2n+1) gives ψ lower bound; then the Erdős (2n/3,2n] product estimate (already partly in Mathlib.NumberTheory.Bertrand internals: centralBinom_factorization_small) refines this to the θ-difference. Multi-session (~300-500 lines)."
     ],
-    "progressSummary": "2026-07-07 (researcher-9): PROGRESS (axiom count unchanged at 2, quality improved). Restated the bespoke analytic axiom primes_upper_half_lower_bound as the standard Chebyshev θ-gap axiom chebyshev_theta_upper_half_lower_bound (θ(N)−θ(N/2) ≥ c·N) against Mathlib.NumberTheory.Chebyshev, and DERIVED the former axiom as a theorem via the fully-verified θ→π bridge (theta_gap_eq_sum_optimalB + theta_gap_le_card_mul_log). 0 sorries, 2 axioms (szemeredi_theorem + the θ-gap), builds against Mathlib 4.26. File 557→660 lines. The remaining analytic axiom is now the single classical Chebyshev θ-gap fact, cleanly aligned with Mathlib's new Chebyshev API. Prior: researcher-3/5/8 built the 0-sorry construction and pinned the axiom to Nat.primeCounting."
+    "progressSummary": "PROGRESS (researcher-4, 2026-07-07): Added standalone 0-axiom/0-sorry file Erdos490Chebyshev.lean proving the central-binomial decomposition crux of the Chebyshev θ-gap lower bound (Mathlib's own TODO) and reducing the remaining axiom chebyshev_theta_upper_half_lower_bound to the elementary bound θ(2n)−θ(n) ≥ n·log4−⌊2n/3⌋·log4−log n−√(2n)·log(2n). Axiom NOT yet eliminated: remaining is the analytic tail √n·log n=o(n) + small-n Bertrand reconciliation. Main file unchanged (2 axioms)."
   },
   "knownResults": {
     "established": [


### PR DESCRIPTION
## Summary

Research session for **erdos-490-incomplete-01** (Erdős #490, distinct products of two sets).
The gallery file is already 0-sorry with **2 axioms**; this PR attacks the more tractable one,
`chebyshev_theta_upper_half_lower_bound` — the classical Chebyshev θ-gap lower bound
`θ(N) − θ(N/2) ≥ c·N`. Mathlib's own `Mathlib.NumberTheory.Chebyshev` lists *"Prove Chebyshev's
lower bound"* as an open TODO, so this is a genuine gap, not laziness.

Adds a **standalone, 0-axiom / 0-sorry** file `proofs/Proofs/Erdos490Chebyshev.lean`
(205 lines, 5 lemmas) that machine-checks the **combinatorial heart** of that bound and
**reduces** the axiom to a purely analytic tail.

## What is verified (0-axiom)

`#print axioms` on both headline results returns exactly `[propext, Classical.choice, Quot.sound]`.

- `small_prime_prod_le` — `∏_{p ≤ 2n/3} p^{v_p} ≤ (2n)^√(2n)·4^(2n/3)` (extracted/adapted from
  Mathlib's `Nat.centralBinom_le_of_no_bertrand_prime`, keeping the large primes as a separate factor).
- **`centralBinom_le_small_mul_large` (the crux)** — `centralBinom n ≤ (2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n} p`,
  via the three-way prime-factorisation split of `C(2n,n)` (small band bounded; middle band `(2n/3,n]`
  vanishes; large band `n<p≤2n` has multiplicity ≤ 1).
- `four_pow_lt_bound` — `4^n < n·(2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n} p` (with `Nat.four_pow_lt_mul_centralBinom`).
- `theta_gap_eq_log_prod` — `θ(2n) − θ(n) = log ∏_{n<p≤2n} p` (via `Chebyshev.theta` + `sum_sdiff` + `log_prod`).
- **`theta_gap_lower_bound`** — `θ(2n) − θ(n) ≥ n·log 4 − ⌊2n/3⌋·log 4 − log n − √(2n)·log(2n)` for `n ≥ 4`.

## Status

**Outcome**: progress (axiom-reduction). The axiom is **NOT** eliminated — the main file is
unchanged (still 2 axioms, `status: axiomatized`). What remains to close it:

1. Analytic tail `√(2n)·log(2n) = o(n)` and `log n = o(n)` (Mathlib: `Real.isLittleO_log_id_atTop`),
   giving `RHS ≥ c·n` for large `n`.
2. Small-`n` reconciliation (`4 ≤ N < N₀`) via Bertrand (`optimalB_nonempty`, finite minimum).
3. Alignment `(2n, n) ↦ (N, N/2)` via `Chebyshev.theta_mono`.

**Next Steps**: complete (1)–(3), then replace `axiom chebyshev_theta_upper_half_lower_bound`
with a theorem importing this file (2 → 1 axioms).

## Verification note

Built with `LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh Proofs.Erdos490Chebyshev`
(the shared Mathlib cache volume was serving corrupt artifacts this session — a known-good file
on `main` reproduced the same `exit 135`; skipping the cache rebuilds cleanly and succeeds).

🤖 Generated by researcher-4