### PR TITLE
fix: gate clean-research.sh worktree removal on structural guards, not claim state

### DIFF
--- a/scripts/lib/worktree-cleanup.sh
+++ b/scripts/lib/worktree-cleanup.sh
@@ -44,6 +44,98 @@ _wc_log() {
     return 0
 }
 
+# would_remove_own_worktree <worktree_path>
+#
+# Predicate-only variant of the guards used by remove_own_worktree. Runs the
+# read-only structural guards 1-5 WITHOUT performing any removal, and echoes a
+# single word describing the decision to stdout:
+#
+#   remove   - all guards pass; a real run would remove this worktree.
+#   absent   - path is empty or does not exist (nothing to remove).
+#   current  - guard 1: this is the current checkout.
+#   locked   - guard 2: worktree is locked.
+#   busy     - guard 3: an owning process is alive.
+#   dirty    - guard 4: working tree has uncommitted changes.
+#   unpushed - guard 5: carries commits that exist on no remote.
+#
+# Return code: 0 when the decision is "remove", 1 otherwise (preserve/absent).
+# This lets callers implement an honest --dry-run that reflects the same guard
+# decision a real remove_own_worktree call would make, rather than a weaker
+# claim-state check. All guard logic here is intentionally kept in lock-step
+# with remove_own_worktree below.
+would_remove_own_worktree() {
+    local wt_path="$1"
+
+    # Idempotency: nothing to remove.
+    if [[ -z "$wt_path" || ! -d "$wt_path" ]]; then
+        echo "absent"
+        return 1
+    fi
+
+    local wt_real
+    wt_real="$(cd "$wt_path" 2>/dev/null && pwd -P || echo "$wt_path")"
+
+    # GUARD 1: never remove the current checkout.
+    local current_wt_path current_real
+    current_wt_path="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+    if [[ -n "$current_wt_path" ]]; then
+        current_real="$(cd "$current_wt_path" 2>/dev/null && pwd -P || echo "$current_wt_path")"
+        if [[ "$wt_real" == "$current_real" ]]; then
+            echo "current"
+            return 1
+        fi
+    fi
+
+    # GUARD 2: never remove a locked worktree.
+    local locked_wt_paths
+    locked_wt_paths="$(git worktree list --porcelain 2>/dev/null \
+        | awk '/^worktree /{p=$2} /^locked/{print p}')"
+    if [[ -n "$locked_wt_paths" ]]; then
+        local locked_path locked_real
+        while IFS= read -r locked_path; do
+            [[ -z "$locked_path" ]] && continue
+            locked_real="$(cd "$locked_path" 2>/dev/null && pwd -P || echo "$locked_path")"
+            if [[ "$locked_real" == "$wt_real" ]]; then
+                echo "locked"
+                return 1
+            fi
+        done <<< "$locked_wt_paths"
+    fi
+
+    # GUARD 3: never remove a worktree with an active owning process.
+    if pgrep -f "$wt_path" &>/dev/null; then
+        echo "busy"
+        return 1
+    fi
+
+    # GUARD 4: never remove a worktree with a dirty working tree.
+    if [[ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]]; then
+        echo "dirty"
+        return 1
+    fi
+
+    # GUARD 5: never remove a worktree carrying commits that exist on no remote.
+    if git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null; then
+        local unpushed
+        unpushed="$(git -C "$wt_path" log --oneline '@{u}..HEAD' 2>/dev/null || echo "")"
+        if [[ -n "$unpushed" ]]; then
+            echo "unpushed"
+            return 1
+        fi
+    else
+        local remote_containing
+        remote_containing="$(git -C "$wt_path" branch -r --contains HEAD 2>/dev/null \
+            | grep -v '\->' | sed 's/^[[:space:]]*//' | head -n 1)"
+        if [[ -z "$remote_containing" ]]; then
+            echo "unpushed"
+            return 1
+        fi
+    fi
+
+    echo "remove"
+    return 0
+}
+
 # remove_own_worktree <worktree_path>
 #
 # Idempotent: if the path does not exist (already removed), returns 0 quietly.

--- a/scripts/research/clean-research.sh
+++ b/scripts/research/clean-research.sh
@@ -68,6 +68,14 @@ WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 
+# Shared worktree reclaim helper (remove_own_worktree, guards 1-5). The deep
+# worktree cleanup below routes every removal through these structural guards so
+# a dirty tree, unpushed commits, a live owning process, or a locked/current
+# worktree is never force-removed — even when the claim tracker shows no active
+# claim (issue #35256). Mirrors parallel-research.sh's reclaim_worktrees().
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+
 # Parse arguments
 DRY_RUN=false
 DEEP_CLEAN=false
@@ -243,45 +251,70 @@ if [[ "$DEEP_CLEAN" == true ]]; then
     worktree_count=0
 
     if [[ -d "$WORKTREES_DIR" ]]; then
-        # Clean researcher-{N} worktrees without active claims
+        # Clean researcher-{N} worktrees.
+        #
+        # The removal decision is gated by the structural guards 1-5 in
+        # `remove_own_worktree` (via `would_remove_own_worktree` for the
+        # predicate), NOT by claim-tracker state. Claim state is racy — a
+        # concurrently-wiped or TTL-expired claim can make an actively-used
+        # worktree look idle — so trusting it alone can force-remove a worktree
+        # with a live session or uncommitted work (issue #35256). The guards
+        # (dirty tree, unpushed commits, live process, locked, current checkout)
+        # are a superset of anything claim correctness could tell us. The claim
+        # scan below is retained for diagnostic messaging ONLY.
         for worktree_dir in "$WORKTREES_DIR"/researcher-*; do
             [[ ! -d "$worktree_dir" ]] && continue
 
             researcher_id=$(basename "$worktree_dir")
 
-            # Check if researcher has any active claims
-            has_active_work=false
+            # Diagnostic only: note if a live claim references this researcher.
+            claim_note=""
             for claim_file in "$CLAIMS_DIR"/*.json; do
                 [[ ! -f "$claim_file" ]] && continue
                 agent_id=$(jq -r '.agent_id' "$claim_file" 2>/dev/null || echo "")
                 if [[ "$agent_id" == "$researcher_id" ]] && ! is_claim_expired "$claim_file"; then
-                    has_active_work=true
+                    claim_note=" (active claim by $agent_id)"
                     break
                 fi
             done
 
-            if [[ "$has_active_work" == false ]]; then
-                ((++worktree_count))
-                if [[ "$DRY_RUN" == true ]]; then
-                    info "Would remove worktree: $researcher_id (no active claims)"
-                elif [[ "$FORCE" == true ]]; then
-                    git worktree remove "$worktree_dir" --force 2>/dev/null && \
-                        success "Removed worktree: $researcher_id" || \
-                        warning "Failed to remove: $researcher_id"
+            # Structural guard decision (read-only; matches what a real
+            # remove_own_worktree call would do). The predicate returns non-zero
+            # for any "preserve" outcome; `|| true` keeps that from tripping the
+            # script's `set -e` — the decision is carried by the echoed word.
+            decision="$(would_remove_own_worktree "$worktree_dir")" || true
+
+            if [[ "$decision" != "remove" ]]; then
+                # A guard preserves this worktree regardless of claim state.
+                info "Preserving worktree: $researcher_id (guard: $decision)"
+                continue
+            fi
+
+            # All guards pass: this worktree is idle, clean, and fully backed up.
+            ((++worktree_count))
+            if [[ "$DRY_RUN" == true ]]; then
+                info "Would remove worktree: $researcher_id${claim_note}"
+            elif [[ "$FORCE" == true ]]; then
+                remove_own_worktree "$worktree_dir"
+                if [[ ! -d "$worktree_dir" ]]; then
+                    success "Removed worktree: $researcher_id"
                 else
-                    echo -e "  ${YELLOW}$researcher_id${NC} (no active claims)"
-                    read -r -p "  Remove this worktree? [y/N] " -n 1 CONFIRM
-                    echo ""
-                    if [[ $CONFIRM =~ ^[Yy]$ ]]; then
-                        git worktree remove "$worktree_dir" --force 2>/dev/null && \
-                            success "Removed worktree: $researcher_id" || \
-                            warning "Failed to remove: $researcher_id"
-                    else
-                        info "Skipping: $researcher_id"
-                    fi
+                    warning "Preserved (guard triggered): $researcher_id"
                 fi
             else
-                info "Preserving worktree: $researcher_id (active claims)"
+                echo -e "  ${YELLOW}$researcher_id${NC}${claim_note}"
+                read -r -p "  Remove this worktree? [y/N] " -n 1 CONFIRM
+                echo ""
+                if [[ $CONFIRM =~ ^[Yy]$ ]]; then
+                    remove_own_worktree "$worktree_dir"
+                    if [[ ! -d "$worktree_dir" ]]; then
+                        success "Removed worktree: $researcher_id"
+                    else
+                        warning "Preserved (guard triggered): $researcher_id"
+                    fi
+                else
+                    info "Skipping: $researcher_id"
+                fi
             fi
         done
     fi


### PR DESCRIPTION
## Summary

`scripts/research/clean-research.sh --deep` force-removed `researcher-N` worktrees whenever it found no non-expired claim file matching the researcher. Claim-tracker state is racy (TTL expiry mid-session, concurrent wipes), so an actively-used worktree with a live session or uncommitted work could appear unclaimed and get reaped — one of the data-loss paths that drove agents to create defensive worktrees in `$HOME` (item 3 of #35223).

This applies defense-in-depth (option 2 only, per the curator's scoping): every worktree removal now routes through the structural guards 1-5 in `remove_own_worktree` (from `scripts/lib/worktree-cleanup.sh`), mirroring `parallel-research.sh:363-369`'s `reclaim_worktrees()`. The guards (dirty tree, unpushed/unbacked commits, live owning process, locked, current checkout) are a superset of anything claim correctness could ever tell us — a live agent mid-edit always fails the process or dirty-tree guard regardless of claim state. Option 1 (claim-tracker write atomicity) is explicitly out of scope.

## Changes

- **`scripts/lib/worktree-cleanup.sh`**: added `would_remove_own_worktree()` — a predicate-only variant that runs the same read-only guards 1-5 without mutating, echoing the decision (`remove`/`dirty`/`unpushed`/`busy`/`locked`/`current`/`absent`). This lets `--dry-run` reflect the true guard decision instead of the weaker claim check. Guard logic kept in lock-step with `remove_own_worktree`.
- **`scripts/research/clean-research.sh`**: sources `worktree-cleanup.sh`; replaced the claim-based `has_active_work` removal gate with a `would_remove_own_worktree` decision and a `remove_own_worktree` call. `--dry-run`, `-f/--force`, and interactive modes all route through the same guards (no bypass). The claim-file scan is retained for diagnostic messaging only (`(active claim by X)`), no longer gating removal. Post-call `[[ -d ]]` re-test distinguishes removed vs preserved (pattern from #35237).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Removal loop calls guards (not claim state alone) | ✅ | Loop sources `worktree-cleanup.sh` and gates on `would_remove_own_worktree` / `remove_own_worktree` |
| Dirty / unpushed / live-process / locked worktree never removed even with no claim | ✅ | Sandbox (no claim files): dirty preserved (SCRATCH.txt intact), unpushed preserved (commit intact), locked preserved |
| Clean, idle, claimless worktree still reclaimed (no regression) | ✅ | Sandbox: clean+remote-backed researcher-2 removed in both `--force` and `--dry-run` |
| `--dry-run` reflects guard decision, not misleading | ✅ | Dry-run prints "Preserving … (guard: dirty)" / "Preserving … (guard: unpushed)" / "Would remove …" |
| `-f/--force` and interactive both route through guards | ✅ | Interactive prompts only guard-eligible worktrees; force auto-applies guards; neither bypasses |
| Claim diagnostic retained, not sole gate | ✅ | "(active claim by X)" shown on a removable clean worktree while guards make the actual decision |

## Test Plan

Sandbox git repo with a remote and three claimless `researcher-N` worktrees:
- **researcher-1** (dirty tree, no claim) → preserved, `SCRATCH.txt` intact
- **researcher-2** (clean, HEAD on `origin/main`, no claim) → removed
- **researcher-3** (unpushed local commit, no upstream, no claim) → preserved, commit intact
- **researcher-2 locked** → preserved (guard: locked)
- `--dry-run` reports "would preserve" for guarded worktrees, "would remove" only for the clean one
- Interactive (non-`-f`) mode prompts only for guard-eligible worktrees; answering `n` skips

Lint: `bash -n` clean on both files; `shellcheck` shows no new findings in changed regions (only pre-existing SC1091 source-not-followed — same as sibling `parallel-research.sh` — and SC2015 in the untouched branch-delete path).

Closes #35256

🤖 Generated with [Claude Code](https://claude.com/claude-code)