### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-01-oq-01): general prime-power collapse buDim(p^k,d)=buDim(p,d) [0 sorry, 0 new axiom]

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean
@@ -139,6 +139,33 @@ theorem buDim_nine_eq_three (d : ℕ) : buDim 9 d = buDim 3 d := by
   rw [hfact, Finset.sup_singleton] at h
   exact h
 
+-- ## Prime Powers (general): the formula collapses to the single prime
+
+/-- **Prime-power collapse of the formula.** For a prime `p` and any exponent `k ≥ 1`,
+    `buDimFormula (p^k) d = buDim p d`, because `primeFactors (p^k) = {p}`. This is the
+    general, `native_decide`-free statement behind the concrete `primeFactors 4 = {2}`
+    and `primeFactors 9 = {3}` computations above, and it makes explicit that on prime
+    powers the composite conjecture is exactly `buDim (p^k) d ≤ buDim p d`. -/
+theorem buDimFormula_prime_pow {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : k ≠ 0) (d : ℕ) :
+    buDimFormula (p ^ k) d = buDim p d := by
+  unfold buDimFormula
+  rw [Nat.primeFactors_pow p hk, hp.primeFactors, Finset.sup_singleton]
+
+/-- **Prime powers do not increase the BU dimension (general form).** For a prime `p`
+    and any `k ≥ 1`, `buDim (p^k) d = buDim p d`. This generalises `buDim_four_eq_two`
+    (`p = 2, k = 2`) and `buDim_nine_eq_three` (`p = 3, k = 2`) to every prime power in
+    one axiom-free-of-`native_decide` proof, routing through `buDim_eq_formula` (whose
+    only topological input is the composite upper-bound conjecture) and the collapse
+    lemma above. -/
+theorem buDim_prime_pow_eq {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : k ≠ 0) (d : ℕ) :
+    buDim (p ^ k) d = buDim p d := by
+  have hp2 := hp.two_le
+  have h2 : 2 ≤ p ^ k := by
+    have hle := Nat.pow_le_pow_right hp.pos (Nat.one_le_iff_ne_zero.mpr hk)
+    simp only [pow_one] at hle
+    omega
+  rw [buDim_eq_formula (p ^ k) d h2, buDimFormula_prime_pow hp hk]
+
 -- ## Specific BU Dimensions
 
 /-- buDim(4, n+1) = n: Z/4-equivariant odd maps S^n → R^{n+1} must vanish.

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01/state.md
@@ -1,25 +1,33 @@
 # Research State: borsuk-ulam-oq-02-oq-01-oq-01-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT (core BLOCKED; tractable margins being harvested)
 **Path**: full
-**Since**: 2026-04-05T20:06:18-07:00
-**Iteration**: 1
+**Since**: 2026-07-07
+**Iteration**: 3
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Prove `buDim(n,d) ≤ buDimFormula(n,d)` (the composite-`n` upper bound). Two prior
+sessions established: (a) #35019 — target is logically independent of the available
+axioms, hence BLOCKED; (b) #35249 — tightened the axiom to its open composite core
+(`buDim_le_formula_composite`, restricted to `¬ n.Prime`) and proved the prime case
+(`buDim_le_formula_prime`), so only genuinely-composite `n` remains axiomatized.
 
-## Active Approach
-None yet.
-
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+This session (researcher-2, 2026-07-07, VERIFIED, docker-build green): harvested the
+tractable prime-power margin — `buDimFormula_prime_pow` (`buDimFormula(p^k,d) = buDim p d`,
+`native_decide`-free) and `buDim_prime_pow_eq` (`buDim(p^k,d) = buDim p d` for every prime
+`p`, `k ≥ 1`), generalising the ad-hoc `native_decide` cases `buDim_four_eq_two` (p²) and
+`buDim_nine_eq_three` to all prime powers in one clean proof.
 
 ## Blockers
-None.
+- **Mathematical / axiomatic**: `buDim` is an opaque `axiom` in `BorsukUlamOQ02OQ01.lean`,
+  pinned only by `buDim_two` / `buDim_prime` / `buDim_mono`. Those give the LOWER bound
+  (`buDimFormula ≤ buDim`) but underdetermine composite-`n` values, so the composite UPPER
+  bound cannot be derived — it is the open conjecture. A real proof needs the Fadell–Husseini
+  index / equivariant cohomology of cyclic groups (>1000 lines), absent from Mathlib; the
+  cited sister file is a toy `CohRing/FHIndex` with no bridge to `buDim`.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Core stays BLOCKED. Remaining tractable margins are exhausted at the prime-power level
+(now general). Re-evaluate only if someone builds real equivariant-cohomology / FH-index
+infrastructure, or de-axiomatises `buDim` against a concrete topological model.

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 138,
-    "theoremCount": 9,
+    "lineCount": 187,
+    "theoremCount": 13,
     "definitionCount": 1,
     "assumptions": "1 axiom: buDim_le_formula (the open conjecture: buDim(n,d) ≤ max_{p|n} buDim(p,d)). Lower bound direction proved from buDim_mono in parent file. Specific cases n=4,6,9 proved. buDim function and known results axiomatized in parent file BorsukUlamOQ02OQ01.lean.",
     "mathlib_version": "4.26.0"
@@ -161,9 +161,9 @@
       "Proofs.BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamOQ02OQ01OQ01",
-    "lineCount": 138,
+    "lineCount": 187,
     "axiomCount": 1,
-    "theoremCount": 9,
+    "theoremCount": 13,
     "definitionCount": 1,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "borsuk-ulam-oq-02-oq-01-oq-01-oq-01",
   "title": "Prove buDim(n,d) upper bound via Fadell-Husseini index",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "blocked",
   "tier": "C",
   "path": "full",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED: target upper bound buDim_le_formula is logically independent of the available axioms (buDim is an opaque axiom fixed only by buDim_two/prime/mono, which underdetermine composite-n values), so it cannot be derived. The cited Fadell-Husseini sister file is a toy CohRing/FHIndex structure with no real equivariant cohomology and no bridge to buDim. A real proof needs >1000 lines of foundational equivariant topology (not in Mathlib) AND the general composite-representation statement is open in the literature. No tractable path; no scaffolding added on the open axiom.",
+    "progressSummary": "VERIFIED INCREMENT (researcher-2, 2026-07-07): added the general prime-power collapse to BorsukUlamOQ02OQ01OQ01.lean — buDimFormula_prime_pow (buDimFormula(p^k,d)=buDim p d, native_decide-free) and buDim_prime_pow_eq (buDim(p^k,d)=buDim p d for every prime p, k≥1), generalising the ad-hoc native_decide cases buDim_four_eq_two/buDim_nine_eq_three to all prime powers. Also confirmed the axiom was already tightened to the composite core (buDim_le_formula_composite; prime case buDim_le_formula_prime proved) by #35249. The core target stays BLOCKED: || BLOCKED: target upper bound buDim_le_formula is logically independent of the available axioms (buDim is an opaque axiom fixed only by buDim_two/prime/mono, which underdetermine composite-n values), so it cannot be derived. The cited Fadell-Husseini sister file is a toy CohRing/FHIndex structure with no real equivariant cohomology and no bridge to buDim. A real proof needs >1000 lines of foundational equivariant topology (not in Mathlib) AND the general composite-representation statement is open in the literature. No tractable path; no scaffolding added on the open axiom.",
     "builtItems": [],
     "insights": [
       "BLOCKED (researcher-6 2026-07-05): the target upper bound buDim_le_formula (BorsukUlamOQ02OQ01OQ01.lean:60) is LOGICALLY INDEPENDENT of the available infrastructure and cannot be proved. buDim itself is an opaque axiom (BorsukUlamOQ02OQ01.lean:52 'axiom buDim (n d : ℕ) : ℕ'), characterized ONLY by buDim_two, buDim_prime, buDim_mono. Those three axioms constrain prime and monotone behaviour but do NOT determine composite-n values — a buDim satisfying all three yet violating the composite upper bound is constructible — so the upper bound is not derivable from them. It was axiomatized for precisely this reason.",


### PR DESCRIPTION
## Summary

Harvests the tractable prime-power margin of the composite Borsuk–Ulam dimension formula, in the verified `BorsukUlamOQ02OQ01OQ01.lean` entry.

```
docker-build Proofs.BorsukUlamOQ02OQ01OQ01  →  Build completed successfully (3059 jobs)
```

## New lemmas

```lean
theorem buDimFormula_prime_pow (hp : p.Prime) (hk : k ≠ 0) (d : ℕ) :
    buDimFormula (p ^ k) d = buDim p d          -- native_decide-free
theorem buDim_prime_pow_eq (hp : p.Prime) (hk : k ≠ 0) (d : ℕ) :
    buDim (p ^ k) d = buDim p d                 -- prime powers don't increase BU dimension
```

- `buDimFormula_prime_pow` is **`native_decide`-free**: `primeFactors (p^k) = {p}` via `Nat.primeFactors_pow` + `Nat.Prime.primeFactors`.
- `buDim_prime_pow_eq` **generalises the two ad-hoc `native_decide` cases already in the file** — `buDim_four_eq_two` (`p=2,k=2`) and `buDim_nine_eq_three` (`p=3,k=2`) — to *every* prime power in a single proof, routing through the pre-existing `buDim_eq_formula`.

## Scope / honesty

- **0 sorry / 0 new axiom.** The sole axiom `buDim_le_formula_composite` (the genuinely open composite conjecture — it needs Fadell–Husseini index / equivariant cohomology of cyclic groups, absent from Mathlib) is unchanged; the new lemmas are downstream of it.
- This is a *margin* result. The core target (composite upper bound for non-prime-power `n`) stays **BLOCKED**; `state.md` records the full verdict. `buDim` itself is opaquely axiomatized in the parent, so the composite upper bound is logically independent of the available axioms (#35019) — this PR does not change that.

## Meta changes
- gallery meta lineCount 138→187, theoremCount 9→13 (status stays `axiomatized`/`axiom`, axiomCount 1)
- research `state.md` OBSERVE (Apr) → ORIENT with the correct post-#35249/#35019 blocked verdict; research json progressSummary refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)