### PR TITLE
Enrich Buffon Crossing-Factor Monotonicity (buffons-needle-oq-02-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01/meta.json
@@ -40,7 +40,8 @@
       "The recurrence multiplies by n/(n+1) < 1 each two-dimension step, so the crossing factor strictly decreases along even and along odd dimensions.",
       "Both subsequences start at their first term, and alpha_3 = 1/2 < 2/pi = alpha_2, so the global maximum is the classical Buffon value alpha_2 = 2/pi.",
       "Therefore alpha_n < 1 in every dimension: a unit-length curve has expected crossings per spacing strictly below one, with the bound 2/pi attained only in the plane.",
-      "Self-containment is forced by upstream bit-rot — the companion crossing-factor file no longer builds — but the recurrence is a one-line definition, so the monotone theory is fully reproducible."
+      "Self-containment is forced by upstream bit-rot — the companion crossing-factor file no longer builds — but the recurrence is a one-line definition, so the monotone theory is fully reproducible.",
+      "The n/(n+1) factor and the even/odd split are structural, not incidental: the closed form alpha_n = Gamma(n/2)/(sqrt(pi)·Gamma((n+1)/2)) turns the shift n -> n+2 into (n/2)/((n+1)/2) = n/(n+1) via the Gamma functional equation Gamma(x+1) = x·Gamma(x), while the parity of n/2 is left fixed. So the two interleaved subsequences descend independently through pure factorial algebra, never invoking the reflection formula that would couple them — which is exactly why the two-step strong induction, not a one-step argument, is the natural proof shape."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `buffons-needle-oq-02-oq-02-oq-01` (quality 94, pass 0).

Entry was already thorough and under caps (meta.json 12.9 KB, 5 annotations covering the full file). One genuine gap: keyInsights had 4 (target 4–5) and none explained the *origin* of the recurrence.

**keyInsights 4 → 5.** Added the Gamma-closed-form insight: αₙ = Γ(n/2)/(√π·Γ((n+1)/2)), and the functional equation Γ(x+1)=x·Γ(x) turns the shift n→n+2 into exactly (n/2)/((n+1)/2) = n/(n+1) while leaving the parity of n/2 fixed. This explains *why* the factor is n/(n+1), *why* even/odd subsequences descend independently, and *why* a two-step (not one-step) strong induction is the natural proof shape — connecting the re-declared recurrence to its analytic source. Verified: α_{n+2} = Γ(n/2+1)/(√π Γ((n+1)/2+1)) = (n/2)/((n+1)/2)·αₙ = (n/(n+1))αₙ. ✓

No content deleted. Axiom/status fields verified accurate (0 sorries, 0 axioms, status verified, no native_decide). meta.json 12.9 KB, 5 keyInsights — under every cap.