### PR TITLE
fix: guard worktree reuse in lean launch.sh and erdos parallel-enhance.sh

### DIFF
--- a/scripts/erdos/parallel-enhance.sh
+++ b/scripts/erdos/parallel-enhance.sh
@@ -26,6 +26,14 @@ LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 CLAIM_TTL=90  # Minutes
 
+# Shared per-workflow worktree reclaim helper. Provides `remove_own_worktree`,
+# which applies structural safety guards (1-5) before removing an agent's
+# worktree instead of the unconditional `git worktree remove --force || rm -rf`
+# that could silently destroy an in-flight agent's uncommitted work (#35255,
+# follow-up to #35223 / PR #35237).
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -66,24 +74,74 @@ get_running_agents() {
     tmux list-sessions 2>/dev/null | grep "^$SESSION_PREFIX" | cut -d: -f1 || true
 }
 
-# Create worktree for an agent
+# Create worktree for an agent.
+#
+# Historically this force-deleted any existing worktree at the slot-keyed path
+# (.loom/worktrees/enhancer-N) with `git worktree remove --force || rm -rf`,
+# silently destroying an in-flight agent's uncommitted work (#35223 / #35255).
+#
+# This version:
+#   1. Uses the shared `remove_own_worktree` guards (1-5) from
+#      scripts/lib/worktree-cleanup.sh instead of an unconditional force-delete,
+#      so a dirty / unpushed / locked / busy / current-checkout worktree is
+#      preserved rather than discarded.
+#   2. If a guard preserves the existing worktree, allocates a fresh,
+#      non-colliding path (enhancer-N-2, enhancer-N-3, ...) instead of deleting
+#      in-flight work.
+#   3. Guards the branch deletion: a branch carrying unpushed commits is never
+#      force-deleted; a fresh branch name is allocated instead.
+#
+# Emits two tab-separated fields on stdout: "<worktree_path>\t<branch_name>".
+# All human-readable progress is routed to stderr so the caller can safely
+# capture the machine-readable line. The branch is returned because a
+# reallocated path uses a matching unique branch, and the caller must reference
+# the real branch in the agent prompt.
 create_agent_worktree() {
     local agent_num="$1"
-    local worktree_path="$WORKTREES_DIR/enhancer-$agent_num"
-    local branch_name="feature/enhancer-$agent_num"
+    local base_path="$WORKTREES_DIR/enhancer-$agent_num"
+    local base_branch="feature/enhancer-$agent_num"
 
-    # Remove existing worktree if it exists
+    local worktree_path="$base_path"
+    local branch_name="$base_branch"
+
+    # Reclaim any existing worktree at the primary path with the shared safety
+    # guards. `remove_own_worktree` returns 0 whether it removed OR preserved
+    # the worktree, so re-test the directory afterwards to distinguish.
     if [[ -d "$worktree_path" ]]; then
-        print_info "Removing existing worktree for agent $agent_num..."
-        git worktree remove "$worktree_path" --force 2>/dev/null || rm -rf "$worktree_path"
+        print_info "Reclaiming existing worktree for agent $agent_num (guarded)..." >&2
+        remove_own_worktree "$worktree_path"
     fi
 
-    # Delete existing branch if it exists (force fresh start)
-    git branch -D "$branch_name" 2>/dev/null || true
+    # If the primary path is still occupied, a guard preserved in-flight work.
+    # Allocate a fresh, non-colliding path/branch rather than deleting it.
+    if [[ -d "$worktree_path" ]]; then
+        print_warning "Worktree for agent $agent_num preserved (in-flight work); allocating a fresh path..." >&2
+        local suffix=2
+        while [[ -d "$base_path-$suffix" ]]; do
+            remove_own_worktree "$base_path-$suffix"
+            [[ -d "$base_path-$suffix" ]] || break
+            suffix=$((suffix + 1))
+        done
+        worktree_path="$base_path-$suffix"
+        branch_name="$base_branch-$suffix"
+    fi
 
-    # Create fresh worktree with new branch from main
-    print_info "Creating worktree for agent $agent_num..."
-    git worktree add "$worktree_path" -b "$branch_name" main
+    # Delete the target branch only when safe. `git branch -d` refuses to drop a
+    # branch with unmerged/unpushed commits or one still checked out, so it will
+    # never force-discard in-flight work the way the old unconditional `-D` did.
+    if git show-ref --verify --quiet "refs/heads/$branch_name" \
+        && ! git branch -d "$branch_name" >/dev/null 2>&1; then
+        print_warning "Branch $branch_name has unpushed work; allocating a fresh branch..." >&2
+        local bsuffix=2
+        while git show-ref --verify --quiet "refs/heads/${base_branch}-$bsuffix"; do
+            bsuffix=$((bsuffix + 1))
+        done
+        branch_name="${base_branch}-$bsuffix"
+    fi
+
+    # Create fresh worktree with the (possibly reallocated) branch from main.
+    print_info "Creating worktree for agent $agent_num at $worktree_path (branch $branch_name)..." >&2
+    git worktree add "$worktree_path" -b "$branch_name" main >&2
 
     # Initialize submodules if needed
     if [[ -f "$worktree_path/.gitmodules" ]]; then
@@ -96,7 +154,7 @@ create_agent_worktree() {
         ln -s "$REPO_ROOT/proofs/.lake" "$worktree_path/proofs/.lake"
     fi
 
-    echo "$worktree_path"
+    printf '%s\t%s\n' "$worktree_path" "$branch_name"
 }
 
 # Show status of all agents
@@ -232,12 +290,28 @@ cleanup_worktrees() {
 
         if [[ -d "$worktree_path" ]]; then
             print_info "Removing worktree: $worktree_path"
-            git worktree remove "$worktree_path" --force 2>/dev/null || rm -rf "$worktree_path"
+            # Full-teardown path (operator-invoked `cleanup`). Use the guarded
+            # remove so a genuinely dirty/unpushed worktree survives an
+            # accidental cleanup invocation instead of being force-discarded.
+            # remove_own_worktree returns 0 whether it removed OR preserved, so
+            # re-test the directory to surface a preserved worktree to the
+            # operator. No fresh-path reallocation here — this is a teardown, not
+            # a create path.
+            remove_own_worktree "$worktree_path"
+            if [[ -d "$worktree_path" ]]; then
+                print_warning "Worktree preserved (in-flight work): $worktree_path — cleanup incomplete"
+            fi
         fi
 
-        # Delete branch
-        git branch -D "$branch_name" 2>/dev/null && \
-            print_info "Deleted branch: $branch_name" || true
+        # Delete branch only when safe (`-d` refuses branches with
+        # unmerged/unpushed commits or still checked out).
+        if git show-ref --verify --quiet "refs/heads/$branch_name"; then
+            if git branch -d "$branch_name" 2>/dev/null; then
+                print_info "Deleted branch: $branch_name"
+            else
+                print_warning "Branch preserved (unpushed work): $branch_name — cleanup incomplete"
+            fi
+        fi
     done
 
     # Prune worktree references
@@ -350,9 +424,11 @@ launch_agents() {
         local log_file="$LOGS_DIR/$session.log"
         local enhancer_id="enhancer-$i"
 
-        # Create isolated worktree for this agent
-        local worktree_path
-        worktree_path=$(create_agent_worktree "$i")
+        # Create isolated worktree for this agent. create_agent_worktree emits
+        # "<path>\t<branch>"; the branch may differ from feature/enhancer-$i when
+        # a guard preserved in-flight work and a fresh path/branch was allocated.
+        local worktree_path branch_name
+        IFS=$'\t' read -r worktree_path branch_name < <(create_agent_worktree "$i")
 
         # Create tmux session starting in the worktree
         tmux new-session -d -s "$session" -c "$worktree_path"
@@ -370,7 +446,7 @@ launch_agents() {
 You are working in an isolated git worktree with your own branch.
 
 **Your worktree:** $worktree_path
-**Your branch:** feature/enhancer-$i
+**Your branch:** $branch_name
 **Claim script:** \$REPO_ROOT/scripts/erdos/claim-stub.sh
 
 ## Quick Start
@@ -382,10 +458,10 @@ You are working in an isolated git worktree with your own branch.
 4. Enhance it (Lean proof, meta.json, annotations.json)
 5. Build: \`pnpm build\`
 6. Commit: \`git add src/data/proofs/erdos-N/ proofs/Proofs/ErdosNProblem.lean && git commit -m "Enhance Erdős #N: Title"\`
-7. Push: \`git push -u origin feature/enhancer-$i\`
+7. Push: \`git push -u origin $branch_name\`
 8. Create PR: \`gh pr create --title "Enhance Erdős #N" --body "Stub enhancement" --label erdos-enhancement\`
 9. Mark complete: \`\$REPO_ROOT/scripts/erdos/claim-stub.sh complete N\` (fails if quality issues remain; use --force to override)
-10. Reset for next: \`git checkout main && git pull && git checkout -B feature/enhancer-$i main\`
+10. Reset for next: \`git checkout main && git pull && git checkout -B $branch_name main\`
 11. Repeat from step 2
 
 Start now by running step 1 to read the full instructions, then claim and enhance a stub.

--- a/scripts/erdos/parallel-enhance.sh
+++ b/scripts/erdos/parallel-enhance.sh
@@ -145,7 +145,10 @@ create_agent_worktree() {
 
     # Initialize submodules if needed
     if [[ -f "$worktree_path/.gitmodules" ]]; then
-        (cd "$worktree_path" && git submodule update --init --recursive 2>/dev/null) || true
+        # Route submodule stdout ("Submodule path '...': checked out '...'")
+        # to stderr so it cannot corrupt the function's `<path>\t<branch>`
+        # tab-return contract on stdout; suppress git's own stderr noise.
+        (cd "$worktree_path" && git submodule update --init --recursive >&2 2>/dev/null) || true
     fi
 
     # Symlink .lake for fast Lean builds

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -14,6 +14,16 @@
 
 set -euo pipefail
 
+# Shared per-workflow worktree reclaim helper. Provides `remove_own_worktree`,
+# which applies structural safety guards (1-5) before removing an agent's
+# worktree instead of the unconditional `git worktree remove --force || rm -rf`
+# that could silently destroy an in-flight agent's uncommitted work (#35255,
+# follow-up to #35223 / PR #35237). Anchored to this script's own directory so
+# it resolves regardless of the caller's cwd.
+_LAUNCH_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$_LAUNCH_SCRIPT_DIR/../lib/worktree-cleanup.sh"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -1523,19 +1533,47 @@ _do_respawn_agent() {
             # Spawn a specific enricher slot directly (parallel-enrich.sh refuses
             # to start if any enricher is already running, so we inline the logic)
             local agent_num="${session##*-}"
-            local worktree_dir=".loom/worktrees/enricher-$agent_num"
-            local branch="feature/enricher-$agent_num"
+            local base_dir=".loom/worktrees/enricher-$agent_num"
+            local base_branch="feature/enricher-$agent_num"
+            local worktree_dir="$base_dir"
+            local branch="$base_branch"
             local enricher_id="enricher-$agent_num"
             local log_file=".loom/logs/$session.log"
             local prompt_file=".loom/logs/$session-prompt.md"
             local repo_root
             repo_root=$(pwd)
 
-            # Recreate worktree from current main
+            # Reclaim any existing worktree at the primary path using the shared
+            # safety guards instead of an unconditional force-delete.
+            # `remove_own_worktree` returns 0 whether it removed OR preserved the
+            # worktree, so re-test the directory afterwards to distinguish.
             if [[ -d "$worktree_dir" ]]; then
-                git worktree remove "$worktree_dir" --force 2>/dev/null || rm -rf "$worktree_dir"
+                remove_own_worktree "$worktree_dir"
             fi
-            git branch -D "$branch" 2>/dev/null || true
+            # If a guard preserved in-flight work, allocate a fresh,
+            # non-colliding path/branch rather than discarding it.
+            if [[ -d "$worktree_dir" ]]; then
+                daemon_log "WARN" "Worktree $worktree_dir preserved (in-flight work); allocating fresh path"
+                local suffix=2
+                while [[ -d "$base_dir-$suffix" ]]; do
+                    remove_own_worktree "$base_dir-$suffix"
+                    [[ -d "$base_dir-$suffix" ]] || break
+                    suffix=$((suffix + 1))
+                done
+                worktree_dir="$base_dir-$suffix"
+                branch="$base_branch-$suffix"
+            fi
+            # Delete the target branch only when safe (`-d` refuses to drop a
+            # branch with unmerged/unpushed commits or one still checked out).
+            if git show-ref --verify --quiet "refs/heads/$branch" \
+                && ! git branch -d "$branch" >/dev/null 2>&1; then
+                daemon_log "WARN" "Branch $branch has unpushed work; allocating fresh branch"
+                local bsuffix=2
+                while git show-ref --verify --quiet "refs/heads/${base_branch}-$bsuffix"; do
+                    bsuffix=$((bsuffix + 1))
+                done
+                branch="${base_branch}-$bsuffix"
+            fi
             git worktree add "$worktree_dir" -b "$branch" main 2>/dev/null || {
                 daemon_log "WARN" "Cannot create worktree for $session"
                 return
@@ -1574,18 +1612,46 @@ _do_respawn_agent() {
         researcher)
             # Respawn the specific researcher slot (mirrors enricher respawn pattern)
             local agent_num="${session##*-}"
-            local worktree_dir=".loom/worktrees/researcher-$agent_num"
-            local branch="feature/researcher-$agent_num"
+            local base_dir=".loom/worktrees/researcher-$agent_num"
+            local base_branch="feature/researcher-$agent_num"
+            local worktree_dir="$base_dir"
+            local branch="$base_branch"
             local log_file=".loom/logs/$session.log"
             local prompt_file=".loom/logs/$session-prompt.md"
             local repo_root
             repo_root=$(pwd)
 
-            # Recreate worktree from current main
+            # Reclaim any existing worktree at the primary path using the shared
+            # safety guards instead of an unconditional force-delete.
+            # `remove_own_worktree` returns 0 whether it removed OR preserved the
+            # worktree, so re-test the directory afterwards to distinguish.
             if [[ -d "$worktree_dir" ]]; then
-                git worktree remove "$worktree_dir" --force 2>/dev/null || rm -rf "$worktree_dir"
+                remove_own_worktree "$worktree_dir"
             fi
-            git branch -D "$branch" 2>/dev/null || true
+            # If a guard preserved in-flight work, allocate a fresh,
+            # non-colliding path/branch rather than discarding it.
+            if [[ -d "$worktree_dir" ]]; then
+                daemon_log "WARN" "Worktree $worktree_dir preserved (in-flight work); allocating fresh path"
+                local suffix=2
+                while [[ -d "$base_dir-$suffix" ]]; do
+                    remove_own_worktree "$base_dir-$suffix"
+                    [[ -d "$base_dir-$suffix" ]] || break
+                    suffix=$((suffix + 1))
+                done
+                worktree_dir="$base_dir-$suffix"
+                branch="$base_branch-$suffix"
+            fi
+            # Delete the target branch only when safe (`-d` refuses to drop a
+            # branch with unmerged/unpushed commits or one still checked out).
+            if git show-ref --verify --quiet "refs/heads/$branch" \
+                && ! git branch -d "$branch" >/dev/null 2>&1; then
+                daemon_log "WARN" "Branch $branch has unpushed work; allocating fresh branch"
+                local bsuffix=2
+                while git show-ref --verify --quiet "refs/heads/${base_branch}-$bsuffix"; do
+                    bsuffix=$((bsuffix + 1))
+                done
+                branch="${base_branch}-$bsuffix"
+            fi
             git worktree add "$worktree_dir" -b "$branch" main 2>/dev/null || {
                 daemon_log "WARN" "Cannot create worktree for $session"
                 return


### PR DESCRIPTION
## Summary

Fast-follow to #35223 (fixed by PR #35237). The unconditional force-delete +
immediate re-add pattern — `git worktree remove --force || rm -rf` plus
`git branch -D`, with no dirty-tree / unpushed-commit / locked / active-process
guards — existed in two more agent launchers and could silently destroy an
in-flight agent's uncommitted work on relaunch. This applies the reference fix
from PR #35237 (commit `006a9c7`, `scripts/enricher/parallel-enrich.sh`) to both.

## Changes

- **Both files** now `source scripts/lib/worktree-cleanup.sh` (neither did before).
- **`scripts/lean/launch.sh`** — `_do_respawn_agent()` has no extracted
  create-worktree function; the logic is inlined in the `enricher)` and
  `researcher)` case arms with local scalars. In each arm:
  - Reclaim any existing worktree via `remove_own_worktree` (guards 1-5) instead
    of `git worktree remove --force || rm -rf`.
  - Re-test `[[ -d "$worktree_dir" ]]` (the helper returns 0 whether it removed
    OR preserved) and, on preservation, allocate a fresh non-colliding
    path/branch (`enricher-N-2` / `researcher-N-2`, ...) — inline, updating the
    arm's own `worktree_dir`/`branch` locals directly (no caller boundary, so no
    tab-return contract, per the curator's guidance).
  - Guard `git branch -D` → safe `-d` with a fresh-branch-name fallback.
- **`scripts/erdos/parallel-enhance.sh`** — `create_agent_worktree()` matches
  the reference shape, so it gets the full #35237 recipe: guarded reuse,
  fresh-path allocation on preservation, guarded `-d` branch deletion, and a
  `"<path>\t<branch>"` stdout contract with all `print_info`/`print_warning`
  progress routed to stderr. Its single caller (`launch_agents`) parses both
  fields via `IFS=$'\t' read -r` and threads the returned branch through the
  agent prompt text (push / reset steps) instead of the hard-coded
  `feature/enhancer-$i`.
- **`cleanup_worktrees()`** (the second, unrelated occurrence — a full-teardown
  path, not a create path) swaps the unconditional remove for
  `remove_own_worktree` and `-D` for `-d`, surfacing any preserved
  worktree/branch to the operator via a warning, **without** fresh-path
  reallocation (per the curator's guidance).

### Scope note (curator question 3)

Only the `enricher)` and `researcher)` arms in `launch.sh`'s
`_do_respawn_agent()` inline worktree create/delete. All other agent-type arms
(`aristotle`, `seeker`, `auditor`, `deployer`, `tester`, `herald`, `mechanic`)
delegate to separate `scripts/.../launch-agent.sh` scripts and contain no inline
worktree logic — they are correctly untouched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `launch.sh` sources `worktree-cleanup.sh` | ✅ | `source` added after `set -euo pipefail`, anchored via `${BASH_SOURCE[0]}` |
| `parallel-enhance.sh` sources `worktree-cleanup.sh` | ✅ | `source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"` added after config |
| Both `enricher)`/`researcher)` arms use `remove_own_worktree` + re-test + fresh-path realloc (inline, no extraction) | ✅ | Sandbox: dirty/locked → preserved + `-2`/`-3` allocated; clean → reused at primary |
| `create_agent_worktree()` follows #35237 recipe (guarded reuse, realloc, `-d`, tab stdout, stderr progress); caller parses both fields + threads branch through prompt | ✅ | Sandbox: single `path\tbranch` stdout line, no leak; prompt now uses `$branch_name` |
| `cleanup_worktrees()` swaps remove → guarded + `-D` → `-d`, NO realloc, warns on preserve | ✅ | Sandbox: clean removed, dirty preserved + warned, no `-2` created |
| `git branch -D` guarded everywhere touched (`-d` + fresh-name fallback) | ✅ | Sandbox guard-5: unpushed branch not force-deleted, original commit still reachable |
| No change to tmux naming, agent numbering, `seq` bounds | ✅ | Diff touches only worktree/branch reclaim blocks + source lines |
| No regression on clean/fresh path | ✅ | Sandbox: fresh → primary path/branch, no prompts; clean prior → reused at primary |
| `bash -n` + `shellcheck` clean (no new findings vs baseline) | ✅ | `bash -n` passes both; only new shellcheck finding is the harmless SC1091 source-follow note (same as reference PR) |

## Test Plan

Mirrored PR #35237's sandbox methodology in isolated git repos with a real
remote (live fleet **not** restarted):

1. `bash -n` on both files — pass.
2. `shellcheck` on both files — the only new finding vs. `origin/main` baseline
   is SC1091 (`Not following: ../lib/worktree-cleanup.sh`) for the added
   `source` line; identical to the reference PR. No new code-quality findings in
   changed regions (SC2015/SC2295/SC2155/SC2034/SC2009 counts unchanged).
3. `create_agent_worktree` extracted and run against: fresh-create,
   clean-remote-backed reuse, dirty-preserve → `-2`, second relaunch → `-3`,
   locked-preserve → realloc, unpushed-branch preservation (commit still
   reachable). Verified single tab-separated stdout line (no progress leak) and
   caller `IFS` split. **11/11 assertions passed.**
4. `launch.sh` inlined enricher-arm block extracted and run against
   fresh / dirty-realloc / clean-reuse. **4/4 passed.**
5. `cleanup_worktrees` teardown loop verified: clean worktree+branch removed,
   dirty worktree+branch preserved + operator-warned, no realloc. **3/3 passed.**

Closes #35255

🤖 Generated with [Claude Code](https://claude.com/claude-code)