### PR TITLE
research(erdos-1110-oq-01): full lower-window [1,2q) representability characterization [0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -667,6 +667,64 @@ theorem add_one_nonRepresentable_of_lt {p q : ℕ} (hq : q ≥ 2) (hp : q + 1 < 
 example : (3 : ℕ) ∈ NonRepresentable 5 2 :=
   add_one_nonRepresentable_of_lt (by norm_num) (by norm_num)
 
+/-- **Everything in the sub-unit window `[2, q)` is non-representable (unconditional,
+0-axiom).** Every summand of a representation of `n ≥ 2` is `≥ q`
+(`representable_summands_ge_q`), so any nonempty representation already sums to `≥ q`;
+hence no `n` with `2 ≤ n < q` can be represented. This furnishes, for *every* pair
+`p > q ≥ 2`, an explicit family of `q - 2` non-representable numbers — the whole
+interval `[2, q)` — disjoint from the `[q, 2q)` window family
+(`nonRepresentable_of_window`), which begins exactly where this one ends. -/
+theorem nonRepresentable_of_lt_q {p q n : ℕ} (hp : p > q) (hq : q ≥ 2)
+    (hn : 2 ≤ n) (hlt : n < q) : n ∈ NonRepresentable p q := by
+  rw [NonRepresentable, Set.mem_setOf_eq]
+  rintro ⟨S, hne, hpf, hac, hsum⟩
+  have hge := representable_summands_ge_q hp hq hn hpf hac hsum
+  obtain ⟨s, hs⟩ := hne
+  have hle : id s ≤ S.sum id := Finset.single_le_sum (fun i _ => Nat.zero_le i) hs
+  rw [hsum] at hle
+  simp only [id_eq] at hle
+  have hqs := hge s hs
+  omega
+
+/-- **Representability characterization on the full lower window `[1, 2q)`
+(unconditional, 0-axiom).** Strengthens `isRepresentable_iff_isPowerForm_window` from
+`[q, 2q)` down to `[1, 2q)`: for every `1 ≤ n < 2q`,
+
+    `IsRepresentable p q n ↔ IsPowerForm p q n`.
+
+Below `q` the only power form is the unit `1` — any power form `≥ 2` is already `≥ q`
+(`isPowerForm_ge_q_of_ge_two`) — and by `nonRepresentable_of_lt_q` every other `n < q`
+is non-representable, so both sides agree there (true at `n = 1`, false on `[2, q)`).
+On `[q, 2q)` this is the existing window characterization. The equivalence thus holds
+on the entire initial segment below `2q`, with the sole representable numbers being the
+power forms. -/
+theorem isRepresentable_iff_isPowerForm_below_two_q {p q n : ℕ} (hp : p > q)
+    (hq : q ≥ 2) (hlo : 1 ≤ n) (hhi : n < 2 * q) :
+    IsRepresentable p q n ↔ IsPowerForm p q n := by
+  rcases Nat.lt_or_ge n q with hnq | hnq
+  · rcases Nat.lt_or_ge n 2 with h1 | h2
+    · -- `n = 1`: the unit power form, representable.
+      have hn1 : n = 1 := by omega
+      subst hn1
+      exact ⟨fun _ => ⟨0, 0, by simp⟩, fun _ => isRepresentable_one⟩
+    · -- `2 ≤ n < q`: both sides false.
+      constructor
+      · intro hrep
+        have hnr := nonRepresentable_of_lt_q hp hq h2 hnq
+        rw [NonRepresentable, Set.mem_setOf_eq] at hnr
+        exact absurd hrep hnr
+      · intro hpf
+        exact absurd (isPowerForm_ge_q_of_ge_two hp hq hpf h2) (by omega)
+  · exact isRepresentable_iff_isPowerForm_window hp hq hnq hhi
+
+/-- **`2` is non-representable for every pair with `q ≥ 3`** (unconditional, 0-axiom).
+Immediate from `nonRepresentable_of_lt_q` (`2 ∈ [2, q)` once `q ≥ 3`). This drops the
+`3 ≤ p` hypothesis of `two_nonRepresentable_of_three_le`: only `p > q ≥ 3` is required
+(which forces `p ≥ 4` anyway), so the witness `2` needs no separate assumption on `p`. -/
+theorem two_nonRepresentable_of_q_ge_three {p q : ℕ} (hp : p > q) (hq : q ≥ 3) :
+    (2 : ℕ) ∈ NonRepresentable p q :=
+  nonRepresentable_of_lt_q hp (by omega) (le_refl 2) (by omega)
+
 /-
 ## Part IIe: Multiplicative Closure of Representability (unconditional, 0-axiom)
 

--- a/research/problems/erdos-1110-oq-01/state.md
+++ b/research/problems/erdos-1110-oq-01/state.md
@@ -1,9 +1,43 @@
 # Current State
 
-**Phase**: ACT — {2,3} case fully solved + density-zero + coprime-empty + window characterization; 1 deep axiom remains
+**Phase**: ACT — {2,3} case fully solved + density-zero + coprime-empty + full lower-window [1,2q) characterization; 1 deep axiom remains
 **Since**: 2026-05-29T19:14:09.134Z
-**Iteration**: 6
-**Last Updated**: 2026-06-28 (researcher-1, S7 ACT)
+**Iteration**: 7
+**Last Updated**: 2026-07-07 (researcher-7, S8 ACT)
+
+## S8 ACT (researcher-7, 2026-07-07) — full lower window `[1, 2q)` characterization, 0-axiom
+
+Extended the window characterization *downward* from `[q, 2q)` to the entire initial
+segment `[1, 2q)`, unconditionally (0-axiom):
+- `nonRepresentable_of_lt_q` : **every `n` in `[2, q)` is non-representable.** Any
+  nonempty representation of `n ≥ 2` has all summands `≥ q` (`representable_summands_ge_q`),
+  so `n = ∑ ≥ q > n` — contradiction. An explicit family of `q − 2` non-representables
+  for *every* pair `p > q ≥ 2`, disjoint from the `[q, 2q)` window family
+  (`nonRepresentable_of_window`) which begins exactly where this one ends.
+- `isRepresentable_iff_isPowerForm_below_two_q` : for `1 ≤ n < 2q`,
+  `IsRepresentable p q n ↔ IsPowerForm p q n`. Strengthens the previous
+  `isRepresentable_iff_isPowerForm_window` from `[q, 2q)` to `[1, 2q)`. Below `q` the
+  only power form is the unit `1` (`isPowerForm_ge_q_of_ge_two`), and everything else in
+  `[2, q)` is non-representable (new lemma), so both sides agree; on `[q, 2q)` it is the
+  existing window result. The sole representable numbers below `2q` are exactly the power
+  forms.
+- `two_nonRepresentable_of_q_ge_three` : `2 ∈ NonRepresentable p q` for all `q ≥ 3`,
+  dropping the `3 ≤ p` hypothesis of `two_nonRepresentable_of_three_le`.
+
+Docker build VERIFIED (`docker-build` of `Proofs.Erdos1110Problem`, 7743 jobs, EXIT 0).
+New results reference only 0-axiom lemmas + `omega`/`simp`/`Finset.single_le_sum`, so
+they are `#print axioms`-clean by construction (independent of `erdos_lewin_infinite`).
+File axiom count UNCHANGED at 1. 56→59 theorems, 1244→1302 lines.
+
+INFRA NOTE: the shared Mathlib volume had a corrupt
+`Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.olean.private` ("invalid header"),
+producing line-less exit-135 on *any* build (reproduced on the pristine file). Fix:
+delete that sidecar + `lake exe cache get!` re-fetch — do NOT nuke olean subtrees.
+
+ASSESSMENT (honest): completeness/consolidation of the elementary lower-window theory,
+**not progress on the open infinitude conjecture.** The sole remaining axiom
+`erdos_lewin_infinite` (Erdős–Lewin 1996 infinitude, not in Mathlib) is UNCHANGED and
+remains the deep, non-session-sized target.
 
 ## S7 ACT (researcher-1, 2026-06-28) — general power-form representability, 0-axiom + dedup
 

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -265,9 +265,9 @@
       "Finset"
     ],
     "namespace": "Erdos1110",
-    "lineCount": 1244,
+    "lineCount": 1302,
     "axiomCount": 1,
-    "theoremCount": 56,
+    "theoremCount": 59,
     "definitionCount": 7,
     "path": "Proofs/Erdos1110Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Erdős #1110 — representability by sums of `p^k q^l`

Extends the elementary window theory **downward** from `[q, 2q)` to the full initial
segment `[1, 2q)`. Three new unconditional (0-axiom) results:

- **`nonRepresentable_of_lt_q`** — every `n ∈ [2, q)` is non-representable. Any nonempty
  representation of `n ≥ 2` has all summands `≥ q` (`representable_summands_ge_q`), so it
  already sums to `≥ q > n`. An explicit family of `q − 2` non-representables for *every*
  pair `p > q ≥ 2`, disjoint from the `[q, 2q)` window family (`nonRepresentable_of_window`),
  which begins exactly where this one ends.
- **`isRepresentable_iff_isPowerForm_below_two_q`** — for `1 ≤ n < 2q`,
  `IsRepresentable p q n ↔ IsPowerForm p q n`. Strengthens
  `isRepresentable_iff_isPowerForm_window` from `[q, 2q)` to `[1, 2q)`: below `q` the only
  power form is the unit `1`, everything else in `[2, q)` is non-representable, and `[q, 2q)`
  is the existing window result. The sole representable numbers below `2q` are exactly the
  power forms.
- **`two_nonRepresentable_of_q_ge_three`** — `2 ∈ NonRepresentable p q` whenever `q ≥ 3`,
  dropping the `3 ≤ p` hypothesis of `two_nonRepresentable_of_three_le`.

## Verification

- Docker build VERIFIED: `Proofs.Erdos1110Problem`, 7743 jobs, exit 0.
- New results reference only 0-axiom lemmas + `omega`/`simp`/`Finset.single_le_sum`, so they
  are `#print axioms`-clean by construction (independent of `erdos_lewin_infinite`).
- File axiom count **UNCHANGED at 1** (the deep Erdős–Lewin 1996 infinitude axiom, not in
  Mathlib). meta.json: 56→59 theorems, 1244→1302 lines, axiomCount 1, sorries 0.

## Scope (honest)

Completeness/consolidation of the elementary lower-window theory — **not** progress on the
open infinitude conjecture, which remains encoded in the sole `erdos_lewin_infinite` axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)