### PR TITLE
research(erdos-882-oq-03): membership range subsetSums A ⊆ {1,…,n·|A|}

### DIFF
--- a/proofs/Proofs/Erdos882ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos882ProblemOQ03.lean
@@ -20,6 +20,8 @@ This file supplies that missing structural layer — all fully machine-checked
   * `subset_subsetSums`       — `A ⊆ subsetSums A` (elements are subset sums);
   * `subsetSums_card_ge`      — **`|A| ≤ |subsetSums A|`** (counting lower bound);
   * `subsetSums_card_bounds`  — the sandwich `|A| ≤ |subsetSums A| ≤ 2^|A| − 1`;
+  * `subsetSums_le`           — every subset sum is `≤ n·|A|`;
+  * `subsetSums_subset_Icc`   — **`subsetSums A ⊆ {1,…,n·|A|}`** (membership range);
   * `subsetSums_singleton`    — `subsetSums {a} = {a}`.
 
 The headline is downward closure: any subset of a valid set is valid — the
@@ -128,6 +130,34 @@ theorem subsetSums_card_le (A : Finset ℕ) :
     (subsetSums A).card ≤ 2 ^ A.card - 1 := by
   unfold subsetSums
   exact le_trans Finset.card_image_le (le_of_eq (nonemptySubsets_card A))
+
+/-- **Membership upper bound.**  If every element of `A` is at most `n`, then
+    every non-empty subset sum is at most `n · |A|`: each of the (at most `|A|`)
+    summands of a subset `S ⊆ A` contributes at most `n`. -/
+theorem subsetSums_le {A : Finset ℕ} {n : ℕ} (hA : ∀ a ∈ A, a ≤ n) :
+    ∀ s ∈ subsetSums A, s ≤ n * A.card := by
+  intro s hs
+  unfold subsetSums nonemptySubsets at hs
+  rw [Finset.mem_image] at hs
+  obtain ⟨S, hS, rfl⟩ := hs
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS
+  obtain ⟨hSsub, _⟩ := hS
+  have hcard : S.card ≤ A.card := Finset.card_le_card hSsub
+  calc S.sum id ≤ ∑ _a ∈ S, n := Finset.sum_le_sum (fun i hi => hA i (hSsub hi))
+    _ = n * S.card := by rw [Finset.sum_const, smul_eq_mul, Nat.mul_comm]
+    _ ≤ n * A.card := Nat.mul_le_mul (le_refl n) hcard
+
+/-- **Membership range.**  For a set of positive integers each `≤ n`, every
+    non-empty subset sum lies in the explicit interval `{1,…,n·|A|}`.  Together
+    with `subsetSums_card_le` this pins down the counting side of the
+    `(1+o(1))log₂ n` upper bound: the `≤ 2^|A| − 1` distinct subset sums are all
+    confined to an interval of length `n·|A|`. -/
+theorem subsetSums_subset_Icc {A : Finset ℕ} {n : ℕ}
+    (hlo : ∀ a ∈ A, 1 ≤ a) (hhi : ∀ a ∈ A, a ≤ n) :
+    subsetSums A ⊆ Finset.Icc 1 (n * A.card) := by
+  intro s hs
+  rw [Finset.mem_Icc]
+  exact ⟨subsetSums_pos hlo s hs, subsetSums_le hhi s hs⟩
 
 /-- The subset-sum set of a singleton is the singleton itself: the only non-empty
     subset of `{a}` is `{a}`, whose sum is `a`. -/

--- a/src/data/research/problems/erdos-882-oq-03.json
+++ b/src/data/research/problems/erdos-882-oq-03.json
@@ -11,18 +11,19 @@
       "Built from two monotonicities: subsetSums_mono (A ⊆ B ⟹ subsetSums A ⊆ subsetSums B, since any non-empty S ⊆ A is a non-empty subset of B) and DivisibilityFree.mono (hereditary).",
       "subsetSums_nonempty (a non-empty set has a non-empty subset sum via a singleton) and subsetSums_pos (positive sets have positive subset sums, via Finset.single_le_sum) pin down basic positivity/non-triviality.",
       "The parent Erdos882Problem.lean is BIT-ROTTED on the current toolchain (Finset.sum_le_sum unknown, Algebra.id.smul_eq_mul unknown, maxValidSize Nat.find Decidable synthesis fails) — so this child re-declares the four predicates self-contained with the modern Finset API.",
-      "Counting anchor: |subsetSums A| ≤ 2^|A| − 1 (subsetSums_card_le) follows from Finset.card_image_le composed with nonemptySubsets_card (|A.powerset.filter (·≠∅)| = 2^|A| − 1, via Finset.filter_ne' + card_erase_of_mem + card_powerset). The sum map can only collapse the 2^|A|−1 non-empty subsets, never create values — this is the information-theoretic side of the (1+o(1))log₂ n upper bound."
+      "Counting anchor: |subsetSums A| ≤ 2^|A| − 1 (subsetSums_card_le) follows from Finset.card_image_le composed with nonemptySubsets_card (|A.powerset.filter (·≠∅)| = 2^|A| − 1, via Finset.filter_ne' + card_erase_of_mem + card_powerset). The sum map can only collapse the 2^|A|−1 non-empty subsets, never create values — this is the information-theoretic side of the (1+o(1))log₂ n upper bound.",
+      "Membership range: for A with elements in [1,n], every subset sum lies in {1,…,n·|A|} (subsetSums_subset_Icc), proved from subsetSums_pos (lower) and subsetSums_le (upper, via Finset.sum_le_sum bounding each summand by n then Nat.mul_le_mul on card_le_card). Combined with subsetSums_card_le (≤2^|A|−1 distinct sums) this pins BOTH sides of the information-theoretic (1+o(1))log₂n upper bound: few sums, all confined to a short interval."
     ],
     "builtItems": [
       "Erdos882ProblemOQ03.lean: 4 defs + 8 theorems, 0 axioms, 0 sorries, self-contained.",
       "subsetSums_mono, DivisibilityFree.mono, validSubset_subset (downward closure), subsetSums_nonempty, subsetSums_pos.",
-      "nonemptySubsets_card (|nonemptySubsets A| = 2^|A| − 1), subsetSums_card_le (|subsetSums A| ≤ 2^|A| − 1 — the information-theoretic counting anchor), subsetSums_singleton (subsetSums {a} = {a})."
+      "nonemptySubsets_card (|nonemptySubsets A| = 2^|A| − 1), subsetSums_card_le (|subsetSums A| ≤ 2^|A| − 1 — the information-theoretic counting anchor), subsetSums_singleton (subsetSums {a} = {a}).",
+      "subsetSums_le (every non-empty subset sum ≤ n·|A|) and subsetSums_subset_Icc (subsetSums A ⊆ Icc 1 (n·|A|)) — the MEMBERSHIP-range side of the counting bound, complementing subsetSums_card_le's cardinality side. All 0-axiom verified (7743 jobs)."
     ],
     "progressSummary": "Child of erdos-882 (Subset Sums Without Divisibility). The parent states the analytic bounds as axioms but proves no structural facts; this entry supplies the structural layer: subset-sum and divisibility-free monotonicity, the downward closure of ValidSubset (WLOG sub-configuration tool), basic non-emptiness/positivity, the exact non-empty-subset count 2^|A|−1, the cardinality bound |subsetSums A| ≤ 2^|A|−1 anchoring the information-theoretic side of the (1+o(1))log₂ n upper bound, and the singleton sum set. All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. Self-contained re-declaration of the four predicates (parent file no longer builds on the current Mathlib).",
     "nextSteps": [
       "Prove subsetSums of an insert (subsetSums (insert a A) in terms of subsetSums A) to compute sum sets of explicit constructions.",
       "Formalize 'distinct subset sums' as a consequence of, or relation to, divisibility-free sums (the parent's DistinctSubsetSums is defined but unconnected).",
-      "Combine subsetSums_card_le with the membership bound subsetSums A ⊆ {1,…,n·|A|} to make the counting side of the upper bound explicit.",
       "Repair the parent Erdos882Problem.lean toolchain drift so the structural lemmas can be imported back."
     ]
   },
@@ -46,8 +47,8 @@
     {
       "path": "Proofs/Erdos882ProblemOQ03.lean",
       "filename": "Erdos882ProblemOQ03.lean",
-      "lineCount": 150,
-      "theoremCount": 8,
+      "lineCount": 180,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds two verified structural lemmas to `Erdos882ProblemOQ03.lean` (Erdős #882, subset sums without divisibility), completing the entry's own nextStep #3 — the **membership-range** side of the information-theoretic upper bound.

The existing file supplied the *cardinality* side (`subsetSums_card_le`: at most `2^|A|−1` distinct non-empty subset sums). This PR supplies the *membership* side:

- `subsetSums_le` — for `A` with every element `≤ n`, every non-empty subset sum is `≤ n·|A|` (each of the `≤|A|` summands contributes `≤n`).
- `subsetSums_subset_Icc` — for positive elements each `≤ n`, `subsetSums A ⊆ Finset.Icc 1 (n·|A|)`, combining `subsetSums_pos` (lower) and `subsetSums_le` (upper).

Together these pin **both** sides of the `(1+o(1))log₂ n` upper bound: `≤2^|A|−1` distinct subset sums, all confined to an interval of length `n·|A|`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos882ProblemOQ03` — **build green, 7743 jobs**
- 0 sorries, 0 `axiom` declarations, no `native_decide`
- `#print axioms` = propext / Classical.choice / Quot.sound only (0-axiom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)