### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-03): make linear Sturm⟹Descartes validation fully unconditional [VERIFIED, 0-sorry]

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -216,7 +216,7 @@ theorem linear_signChanges (hc : 0 < c) :
   rw [dif_neg hne, natDegree_X_sub_C]
   apply countSignChanges_two
   have e0 : DescartesRuleOfSigns.coeffSequence (X - C c) 1 0 = 1 := by
-    simp [DescartesRuleOfSigns.coeffSequence, coeff_sub, coeff_X_one, coeff_C]
+    simp [DescartesRuleOfSigns.coeffSequence, coeff_sub, coeff_X_one]
   have e1 : DescartesRuleOfSigns.coeffSequence (X - C c) 1 1 = -c := by
     simp [DescartesRuleOfSigns.coeffSequence, coeff_sub, coeff_X_zero, coeff_C]
   rw [e0, e1]

--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -137,6 +137,43 @@ theorem descartes_rule_via_sturm {p : ℝ[X]} (d : SturmReduction p) :
   obtain ⟨m, hm⟩ := descartes_parity_via_sturm d
   exact ⟨m, by omega⟩
 
+/- ## § 2½. Computing the two-term coefficient sign-change count (verified, axiom-free)
+
+The gallery's base file only ever *axiomatised* concrete sign-change counts
+(`example_x2_minus_1_sign_changes` and friends are `axiom` declarations, because the
+`countSignChanges` definition filters over `Fin n × Fin n` with a classically-decided
+predicate that `decide` cannot reduce).  Here we discharge the length-2 case by hand:
+a two-term real sequence whose entries have opposite signs has exactly one sign change.
+This lets the linear validation below assume *nothing* about the coefficient count. -/
+
+/-- **Sign-change count of a two-term sequence.**  If the two entries of `f : Fin 2 → ℝ`
+have opposite signs (`f 0 * f 1 < 0`) then `f` has exactly one sign change.  Proved by
+exhibiting the single qualifying index pair `(0, 1)`; axiom-free. -/
+theorem countSignChanges_two {f : Fin 2 → ℝ} (h : f 0 * f 1 < 0) :
+    DescartesRuleOfSigns.countSignChanges f = 1 := by
+  have h0 : f 0 ≠ 0 := fun he => by rw [he, zero_mul] at h; exact lt_irrefl 0 h
+  have h1 : f 1 ≠ 0 := fun he => by rw [he, mul_zero] at h; exact lt_irrefl 0 h
+  unfold DescartesRuleOfSigns.countSignChanges
+  rw [Finset.card_eq_one]
+  refine ⟨(0, 1), ?_⟩
+  ext ⟨i, j⟩
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_singleton,
+    decide_eq_true_eq, DescartesRuleOfSigns.SignChangeBetween,
+    DescartesRuleOfSigns.oppositeSign, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hij, -, -, -, -⟩
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact ⟨rfl, rfl⟩
+        | exact absurd hij (by decide)
+  · rintro ⟨rfl, rfl⟩
+    refine ⟨by decide, h0, h1, ?_, h⟩
+    intro k hk0 hk1
+    fin_cases k <;>
+      first
+        | exact absurd hk0 (by decide)
+        | exact absurd hk1 (by decide)
+
 /- ## § 3. Axiom-free validation of the Sturm half on linear polynomials
 
 For `p = X − c` with `c > 0`, the gallery already proves (axiom-free) that the
@@ -168,12 +205,28 @@ theorem linear_sturm_count (hc : 0 < c) :
   have hp : countPositiveRoots (X - C c) = 1 := linear_positiveRoots c hc
   omega
 
+/-- **Coefficient sign-change count of `X − c` (`c > 0`), computed axiom-free.**  The
+coefficient sequence of `X − c` is `[1, −c]` (leading coefficient `1`, constant term
+`−c`), whose two entries have opposite signs — exactly one sign change.  This discharges
+the coefficient fact that `linearReduction` previously took as an unproved hypothesis. -/
+theorem linear_signChanges (hc : 0 < c) :
+    signChangesInCoeffs (X - C c) = 1 := by
+  have hne : (X - C c : ℝ[X]) ≠ 0 := (monic_X_sub_C c).ne_zero
+  unfold signChangesInCoeffs
+  rw [dif_neg hne, natDegree_X_sub_C]
+  apply countSignChanges_two
+  have e0 : DescartesRuleOfSigns.coeffSequence (X - C c) 1 0 = 1 := by
+    simp [DescartesRuleOfSigns.coeffSequence, coeff_sub, coeff_X_one, coeff_C]
+  have e1 : DescartesRuleOfSigns.coeffSequence (X - C c) 1 1 = -c := by
+    simp [DescartesRuleOfSigns.coeffSequence, coeff_sub, coeff_X_zero, coeff_C]
+  rw [e0, e1]
+  simpa using hc
+
 /-- The full `SturmReduction` data for `X − c` (`c > 0`).  The Sturm half is
-discharged axiom-free; only the coefficient-comparison facts (B1)–(B3) remain as
-the data's standing assumptions — and for this polynomial they are the trivial
-`1 ≤ 1`, `Even 0`, `Even 0`, supplied here against the single coefficient fact
-`V(X − c) = 1`. -/
-def linearReduction (hc : 0 < c) (hV : signChangesInCoeffs (X - C c) = 1) :
+discharged axiom-free; the coefficient-comparison facts (B1)–(B3) are now *also*
+discharged axiom-free, using the computed count `V(X − c) = 1` (`linear_signChanges`).
+For this polynomial the reduction therefore carries **no standing assumption**. -/
+def linearReduction (hc : 0 < c) :
     SturmReduction (X - C c) where
   B := c + 1
   hB := by linarith
@@ -185,10 +238,12 @@ def linearReduction (hc : 0 < c) (hV : signChangesInCoeffs (X - C c) = 1) :
     omega
   bridge_bound := by
     have h0 : sturmVariations (X - C c) 0 = 1 := sturm_linear_left c 0 hc
+    have hV : signChangesInCoeffs (X - C c) = 1 := linear_signChanges c hc
     omega
   bridge_parity := by
     rw [Nat.even_iff]
     have h0 : sturmVariations (X - C c) 0 = 1 := sturm_linear_left c 0 hc
+    have hV : signChangesInCoeffs (X - C c) = 1 := linear_signChanges c hc
     omega
   tail_even := by
     rw [Nat.even_iff]
@@ -197,11 +252,11 @@ def linearReduction (hc : 0 < c) (hV : signChangesInCoeffs (X - C c) = 1) :
     omega
 
 /-- End-to-end check: feeding the linear data through the reduction reproduces
-Descartes' upper bound for `X − c`. -/
-theorem linear_descartes_bound (hc : 0 < c)
-    (hV : signChangesInCoeffs (X - C c) = 1) :
+Descartes' upper bound for `X − c`, now **unconditionally** — no coefficient count is
+assumed, only `c > 0`. -/
+theorem linear_descartes_bound (hc : 0 < c) :
     countPositiveRoots (X - C c) ≤ signChangesInCoeffs (X - C c) :=
-  descartes_upper_bound_via_sturm (linearReduction c hc hV)
+  descartes_upper_bound_via_sturm (linearReduction c hc)
 
 end Linear
 

--- a/research/problems/descartes-rule-of-signs-oq-01-oq-03/state.md
+++ b/research/problems/descartes-rule-of-signs-oq-01-oq-03/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: SOLVED
 **Since**: 2026-06-25T21:00:00.000Z
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
@@ -14,7 +14,9 @@ Reduction skeleton over ℕ (`upper_bound_core`, `parity_core`, both omega-close
 
 ## Result
 
-`proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean` — 8 theorems, 1 definition, 1 structure, 0 sorries, 0 `axiom` declarations. The general direction is conditional on the `SturmReduction` bridge data (counted as the entry's single standing assumption); the linear-polynomial validation is unconditional and axiom-free. Gallery entry: `descartes-rule-of-signs-oq-01-oq-03`.
+`proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean` — 10 theorems, 1 definition, 1 structure, 0 sorries, 0 `axiom` declarations. The general direction is conditional on the `SturmReduction` bridge data (counted as the entry's single standing assumption); the linear-polynomial validation is unconditional and axiom-free.
+
+**Iteration 3 increment (2026-07-07):** made the linear branch *fully* unconditional. Previously `linearReduction`/`linear_descartes_bound` took `hV : signChangesInCoeffs (X − C c) = 1` as an unproved hypothesis. That coefficient count is now computed directly by a new axiom-free lemma `linear_signChanges`, built on a new general helper `countSignChanges_two` (a length-2 real sequence with opposite-sign entries has exactly one sign change — the base file had only ever *axiomatised* such concrete counts, e.g. `example_x2_minus_1_sign_changes`). So the `hV` hypothesis is discharged and the linear case carries no assumption beyond `c > 0`. Gallery entry: `descartes-rule-of-signs-oq-01-oq-03`.
 
 A prerequisite Mathlib-rot repair was made to the base file `Proofs/DescartesRuleOfSigns.lean` (renamed `Polynomial.card_roots_le_degree` → `Polynomial.card_roots'`, fixed `Fin.castSucc_lt_succ` application, and supplied the explicit multiset argument to `Multiset.countP_le_card`) so the dependency chain compiles against Mathlib 4.26.0.
 
@@ -24,7 +26,7 @@ None.
 
 ## Next Action
 
-Solved. Open question: prove the three comparison facts (B1)-(B3) for general polynomials to make the general Sturm ⟹ Descartes implication unconditional.
+Solved. Remaining open question: prove the three comparison facts (B1)-(B3) for *general* polynomials to make the general Sturm ⟹ Descartes implication unconditional. (For linear polynomials this is now done — the (B1)-(B3) facts are discharged axiom-free via `linear_signChanges`/`countSignChanges_two`.) A natural next intermediate step is extending the axiom-free coefficient sign-change computation from `Fin 2` to `Fin 3` (quadratics), which would let the base file's axiomatised examples `example_x2_minus_1_sign_changes`/`example_x2_plus_1_sign_changes` be de-axiomatised.
 
 ## Attempt Counts
 

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
@@ -49,9 +49,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 208,
-    "assumptions": "The general direction (Sturm ⟹ Descartes for an arbitrary polynomial) is a reduction: it is conditional on a `SturmReduction p` bridge structure whose five fields package Sturm's exact positive-root count on (0, B] together with the three classical coefficient-comparison facts σ_p(0) ≤ V(p), Even(V(p) − σ_p(0)), and Even(σ_p(B)). Per the project's axiom-integrity policy these structure fields are mathematical assumptions (counted here as axiomCount 1; obtaining the data for a general p requires Sturm's theorem, axiomatized in the parent entry as sturm_exact_count_axiom, plus standard Sturm/Descartes comparison theory). No `axiom` declarations and no sorries appear in the file (leanFile.axiomCount = 0). The reduction theorems (upper_bound_core, parity_core, descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm) are fully machine-checked implications, and the Sturm half is validated UNCONDITIONALLY and axiom-free on linear polynomials X − c (c > 0), reusing the gallery's axiom-free Sturm computations.",
-    "theoremCount": 8,
+    "lineCount": 263,
+    "assumptions": "The general direction (Sturm ⟹ Descartes for an arbitrary polynomial) is a reduction: it is conditional on a `SturmReduction p` bridge structure whose five fields package Sturm's exact positive-root count on (0, B] together with the three classical coefficient-comparison facts σ_p(0) ≤ V(p), Even(V(p) − σ_p(0)), and Even(σ_p(B)). Per the project's axiom-integrity policy these structure fields are mathematical assumptions (counted here as axiomCount 1; obtaining the data for a general p requires Sturm's theorem, axiomatized in the parent entry as sturm_exact_count_axiom, plus standard Sturm/Descartes comparison theory). No `axiom` declarations and no sorries appear in the file (leanFile.axiomCount = 0). The reduction theorems (upper_bound_core, parity_core, descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm) are fully machine-checked implications, and the Sturm half is validated UNCONDITIONALLY and axiom-free on linear polynomials X − c (c > 0), reusing the gallery's axiom-free Sturm computations. The linear-polynomial validation (X − c, c > 0) is now fully unconditional and axiom-free: the coefficient sign-change count V(X − c) = 1 is computed directly (linear_signChanges, via the new axiom-free countSignChanges_two), so the previously-assumed hypothesis hV has been discharged and linearReduction/linear_descartes_bound carry no standing assumption for the linear case.",
+    "theoremCount": 10,
     "mathlib_version": "4.26.0",
     "definitionCount": 1
   },
@@ -122,9 +122,9 @@
       "Proofs.DescartesRuleOfSignsOQ02OQ01OQ02"
     ],
     "namespace": "DescartesRuleOfSignsOQ01OQ03",
-    "lineCount": 208,
+    "lineCount": 263,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 1,
     "path": "Proofs/DescartesRuleOfSignsOQ01OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Incremental strengthening of the existing (SOLVED) entry `descartes-rule-of-signs-oq-01-oq-03`. The gallery entry formalizes "Sturm's exact-count theorem ⟹ Descartes' rule of signs" as an axiom-free reduction, with a validation on linear polynomials `X − c` (`c > 0`).

Previously that linear validation was **not** fully self-contained: `linearReduction` and `linear_descartes_bound` took

```lean
hV : signChangesInCoeffs (X - C c) = 1
```

as an **unproved hypothesis**. This PR discharges it by computing the coefficient sign-change count directly, so the linear branch now carries no assumption beyond `c > 0`.

## What's new (both axiom-free)

- **`countSignChanges_two`** — a general helper: a length-2 real sequence `f : Fin 2 → ℝ` whose entries have opposite signs (`f 0 * f 1 < 0`) has exactly one sign change. Proved by exhibiting the unique qualifying index pair `(0,1)` in the `Fin 2 × Fin 2` filter. This is the first *proved* concrete `countSignChanges` value in the codebase — the base file only ever **axiomatised** such counts (`example_x2_minus_1_sign_changes`, `example_x2_plus_1_sign_changes` are `axiom` declarations, because the classically-decided filter predicate does not reduce under `decide`).
- **`linear_signChanges`** — `signChangesInCoeffs (X − C c) = 1` for `c > 0`, computing the coefficient sequence `[1, −c]` via `coeff_sub`/`coeff_X_one`/`coeff_X_zero`/`coeff_C` and applying `countSignChanges_two`.

`linearReduction` / `linear_descartes_bound` drop the `hV` parameter and derive it internally. `linear_descartes_bound` is now unconditional (only `c > 0`).

## Status

- **Verified**: builds green (`3064 jobs`, `docker-build.sh Proofs.DescartesRuleOfSignsOQ01OQ03`), 0 sorries, 0 `axiom` declarations in the file.
- Entry status unchanged: `axiomatized`, `axiomCount = 1`. The single standing assumption remains the `SturmReduction` bridge structure for **general** polynomials (constructing it needs Sturm's theorem, which Mathlib v4.26 lacks). This PR does not touch that; it only makes the *linear* witness genuinely assumption-free.
- meta.json / state.md synced: `theoremCount 8 → 10`, `lineCount 208 → 263`.

## Remaining open question

Proving the comparison facts (B1)–(B3) for general polynomials (the full Sturm/Descartes comparison theory) remains open and is not tractable over Mathlib v4.26. A natural next intermediate step is extending the axiom-free sign-change computation from `Fin 2` to `Fin 3`, which would de-axiomatise the base file's quadratic examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)