### PR TITLE
research(erdos-1064): eliminate glw_infinitely_many axiom via explicit 15·2^(k+1) family [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1064Problem.lean
+++ b/proofs/Proofs/Erdos1064Problem.lean
@@ -108,11 +108,61 @@ axiom lucaPomerance_density_one :
     (Finset.filter (fun n => totient n > totient (n - totient n)) (Finset.range M)).card
     ≥ (1 - ε) * M
 
-/-- **Axiom (Grytczuk-Luca-Wójtowicz 2001):**
-    The set A₋ = {n : φ(n) < φ(n - φ(n))} is infinite.
+/-- **Theorem (Grytczuk-Luca-Wójtowicz 2001), constructively verified.**
+    The set `A₋ = {n : φ(n) < φ(n - φ(n))}` is infinite.
 
-    Explicit examples include n = 15 · 2^k for any k ≥ 1. -/
-axiom glw_infinitely_many : A_less.Infinite
+    We eliminate the former axiom by exhibiting the explicit family
+    `n = 15 · 2^(k+1)` (`k : ℕ`).  For each such `n`:
+    * `φ(n) = φ(15) · φ(2^(k+1)) = 8 · 2^k`  (since `gcd(15, 2^(k+1)) = 1`);
+    * `n − φ(n) = 15·2^(k+1) − 8·2^k = 11·2^(k+1)`;
+    * `φ(n − φ(n)) = φ(11) · φ(2^(k+1)) = 10 · 2^k > 8 · 2^k = φ(n)`.
+    The map `k ↦ 15·2^(k+1)` is injective, so `A₋` is infinite. -/
+theorem mem_A_less_pow (k : ℕ) : 15 * 2 ^ (k + 1) ∈ A_less := by
+  -- φ(15) = φ(3) · φ(5) = 8
+  have h15 : Nat.totient 15 = 8 := by
+    have h35 : (15 : ℕ) = 3 * 5 := by norm_num
+    rw [h35, Nat.totient_mul (by norm_num), Nat.totient_prime (by norm_num),
+        Nat.totient_prime (by norm_num)]
+  -- φ(11) = 10
+  have h11 : Nat.totient 11 = 10 := Nat.totient_prime (by norm_num)
+  -- φ(2^(k+1)) = 2^k
+  have hp2 : Nat.totient (2 ^ (k + 1)) = 2 ^ k := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos k)]
+    simp
+  -- 15 and 11 are coprime to any power of two
+  have cop15 : Nat.Coprime 15 (2 ^ (k + 1)) :=
+    (show Nat.Coprime 15 2 by norm_num).pow_right (k + 1)
+  have cop11 : Nat.Coprime 11 (2 ^ (k + 1)) :=
+    (show Nat.Coprime 11 2 by norm_num).pow_right (k + 1)
+  -- φ(n) = 8 · 2^k
+  have hφn : Nat.totient (15 * 2 ^ (k + 1)) = 8 * 2 ^ k := by
+    rw [Nat.totient_mul cop15, h15, hp2]
+  -- n − φ(n) = 11 · 2^(k+1)
+  have hsub : 15 * 2 ^ (k + 1) - 8 * 2 ^ k = 11 * 2 ^ (k + 1) := by
+    have h2 : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+    rw [h2]; omega
+  -- φ(n − φ(n)) = 10 · 2^k
+  have hφsub : Nat.totient (11 * 2 ^ (k + 1)) = 10 * 2 ^ k := by
+    rw [Nat.totient_mul cop11, h11, hp2]
+  -- assemble: 8·2^k < 10·2^k
+  have hpos : 0 < 2 ^ k := pow_pos (by norm_num) k
+  show Nat.totient (15 * 2 ^ (k + 1))
+      < Nat.totient (15 * 2 ^ (k + 1) - Nat.totient (15 * 2 ^ (k + 1)))
+  rw [hφn, hsub, hφsub]
+  omega
+
+/-- The map `k ↦ 15·2^(k+1)` is injective. -/
+theorem witness_injective : Function.Injective (fun k : ℕ => 15 * 2 ^ (k + 1)) := by
+  intro a b hab
+  simp only at hab
+  have h2 : (2 : ℕ) ^ (a + 1) = 2 ^ (b + 1) := Nat.eq_of_mul_eq_mul_left (by norm_num) hab
+  have := Nat.pow_right_injective (le_refl 2) h2
+  omega
+
+/-- **Theorem (Grytczuk-Luca-Wójtowicz 2001).** `A₋` is infinite —
+    formerly an axiom, now derived from the explicit family above. -/
+theorem glw_infinitely_many : A_less.Infinite :=
+  Set.infinite_of_injective_forall_mem witness_injective mem_A_less_pow
 
 /-- **Erdős Problem 1064** (Solved)
 

--- a/src/data/proofs/erdos-1064/meta.json
+++ b/src/data/proofs/erdos-1064/meta.json
@@ -45,7 +45,7 @@
       "The pattern 15·2^k for the reverse inequality",
       "Generalized statement for f(n) = o(n)"
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 132,
     "prerequisites": [
       "Euler's totient function φ(n) and its multiplicativity",
@@ -53,8 +53,8 @@
       "Asymptotic notation (o(n), almost all)",
       "Prime factorization and coprimality"
     ],
-    "assumptions": "2 axioms: lucaPomerance_density_one, glw_infinitely_many. See Lean source for complete statements.",
-    "theoremCount": 1,
+    "assumptions": "1 axiom: lucaPomerance_density_one (the density-1 result of Luca-Pomerance 2002, requiring analytic number theory). The former glw_infinitely_many axiom (Grytczuk-Luca-Wojtowicz 2001, infinitely many n with phi(n) < phi(n-phi(n))) is now constructively PROVED via the explicit family n = 15*2^(k+1). Concrete illustrative examples use native_decide (Lean.ofReduceBool). See Lean source for complete statements.",
+    "theoremCount": 4,
     "definitionCount": 4
   },
   "overview": {
@@ -127,7 +127,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures both parts of Erdős Problem 1064. Luca-Pomerance showed φ(n) > φ(n - φ(n)) has density 1, while Grytczuk-Luca-Wójtowicz showed the reverse inequality holds for infinitely many n (including all n = 15·2^k). We state both results as axioms and verify concrete examples.",
+    "summary": "This formalization captures both parts of Erdős Problem 1064. Luca-Pomerance showed φ(n) > φ(n - φ(n)) has density 1, while Grytczuk-Luca-Wójtowicz showed the reverse inequality holds for infinitely many n (including all n = 15·2^k). The infinitely-often part (Grytczuk-Luca-Wojtowicz) is constructively PROVED here from the explicit family n = 15*2^(k+1), eliminating its former axiom; only the density-1 result of Luca-Pomerance remains stated as an axiom (it requires analytic number theory).",
     "implications": "**Theoretical Significance**: The resolution illustrates fundamental themes in analytic number theory:\n\n1. **Typical vs exceptional behavior:** The set $A_>$ has density 1 but its complement $A_<$ is infinite — a common pattern for arithmetic functions where 'almost all' coexists with infinitely many exceptions. This parallels the Erdős-Kac theorem (1940), which shows that $\\omega(n) \\sim \\log\\log n$ for almost all $n$ but fluctuates on exceptional sets.\n\n2. **Smooth number structure:** The Luca-Pomerance proof exploits that $n - \\phi(n)$ tends to be smooth (divisible by many small primes) for typical $n$. Smooth numbers have low totient ratios, which is why $\\phi(n - \\phi(n))$ is typically small. This connects to the broader theory of smooth number distribution (Dickman's function, Canfield-Erdős-Pomerance theorem).\n\n3. **Multiplicative structure and explicit constructions:** The pattern $15 \\cdot 2^k$ exploits the multiplicativity of $\\phi$ to construct infinitely many exceptions. Similar techniques appear throughout Erdős's work: finding sparse but infinite exceptional sets via arithmetic structure.\n\n4. **Iterated arithmetic functions:** The map $n \\mapsto n - \\phi(n) \\mapsto n - \\phi(n) - \\phi(n - \\phi(n)) \\mapsto \\cdots$ defines a dynamical system on $\\mathbb{N}$ whose long-term behavior is not well understood. The Carmichael conjecture — that for every $n$, the equation $\\phi(x) = n$ has either 0 or $\\geq 2$ solutions — relates to the 'fiber structure' of $\\phi$ over its range.\n\n5. **Analogues for other functions:** Similar questions for the sum-of-divisors function $\\sigma(n)$ — comparing $\\sigma(n)$ with $\\sigma(n - \\sigma(n))$ when $\\sigma(n) < n$ (deficient numbers) — lead to different density behavior due to the different growth rate of $\\sigma$.",
     "openQuestions": [
       "What is the density of A₌ where φ(n) = φ(n - φ(n))?",
@@ -193,9 +193,9 @@
       "Nat"
     ],
     "namespace": "Erdos1064",
-    "lineCount": 132,
-    "axiomCount": 2,
-    "theoremCount": 1,
+    "lineCount": 182,
+    "axiomCount": 1,
+    "theoremCount": 4,
     "definitionCount": 4,
     "path": "Proofs/Erdos1064Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős Problem #1064 compares φ(n) with φ(n − φ(n)). Two results resolve it:
1. **Luca–Pomerance (2002):** φ(n) > φ(n − φ(n)) has density 1 — deep analytic NT, remains an axiom.
2. **Grytczuk–Luca–Wójtowicz (2001):** φ(n) < φ(n − φ(n)) for infinitely many n — **was an axiom, now constructively proved.**

This PR eliminates the `glw_infinitely_many` axiom by machine-checking the explicit witness family the file already documented informally.

## The proof (fully elementary, 0 sorry / no `native_decide`)

For every `k : ℕ`, take `n = 15 · 2^(k+1)`. Since `gcd(15, 2^(k+1)) = 1`:
- `φ(n) = φ(15)·φ(2^(k+1)) = 8 · 2^k`
- `n − φ(n) = 15·2^(k+1) − 8·2^k = 11·2^(k+1)`
- `φ(n − φ(n)) = φ(11)·φ(2^(k+1)) = 10 · 2^k > 8 · 2^k = φ(n)`  ✓

The map `k ↦ 15·2^(k+1)` is injective, so `A₋ = {n | φ(n) < φ(n − φ(n))}` is infinite
(`Set.infinite_of_injective_forall_mem`). New verified theorems: `mem_A_less_pow`,
`witness_injective`, `glw_infinitely_many` (`erdos_1064_resolution` now rests on a theorem, not an axiom).

Uses only `Nat.totient_mul`, `Nat.totient_prime`, `Nat.totient_prime_pow`, `Nat.Coprime.pow_right`.

## Axiom delta
- `axiomCount` 2 → **1** (only `lucaPomerance_density_one` remains; it genuinely needs analytic NT).
- Status stays `axiomatized` (density-1 axiom + illustrative `native_decide` examples).

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos1064Problem` → ✔ Built (7743 jobs), 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)