### PR TITLE
research(cauchy-schwarz-lp-duality-synthesis): S24 — common-carrier σ-finiteness reduction, one named gap [ORIENT]

### DIFF
--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -1245,3 +1245,55 @@ takes `(int-finite gS)(int-finite gS')(setIntegral-eq)(aefsm gS)(aefsm gS')`; `m
 disjunction order is `c = 0 ∨ μ s ≠ ∞`; `MemLp.integrable hq1` needs `[IsFiniteMeasure]` (supply
 via `restrict_apply_univ`); `Measure.restrict_restrict hs` needs the OUTER `in`-set measurable;
 `Lp.ext : f =ᵐ[μ] g → f = g`.
+
+### 2026-07-07 (Session 24, researcher-2) — COMMON-CARRIER σ-finiteness brick: sum-bound reduction compiles up to ONE named gap
+
+**Mode:** ACT on step (2) of the σ-finite-support reduction (see
+`CauchySchwarzIntegralLpSigmaFiniteSupport.lean` header) — the COMMON CARRIER
+σ-finiteness: a countable union of σ-finite-restricted sets is σ-finite under
+`μ.restrict`. Mathlib has only the binary `SigmaFinite (μ.restrict (s ∪ t))` instance.
+
+**Result:** the clean *sum-bound* proof of
+`sigmaFinite_restrict_iUnion : (∀ n, SigmaFinite (μ.restrict (s n))) → SigmaFinite (μ.restrict (⋃ n, s n))`
+**compiles end-to-end except one line.** The whole chain type-checks in Lean v4.26:
+
+```lean
+have hle : μ.restrict (⋃ n, s n) ≤ Measure.sum (fun n => μ.restrict (s n)) := by
+  refine Measure.le_iff.mpr (fun E hE => ?_)
+  rw [Measure.restrict_apply hE, Measure.sum_apply _ hE]
+  calc μ (E ∩ ⋃ n, s n)
+      = μ (⋃ n, E ∩ s n) := by rw [inter_iUnion]
+    _ ≤ ∑' n, μ (E ∩ s n) := measure_iUnion_le _
+    _ = ∑' n, (μ.restrict (s n)) E := by simp_rw [Measure.restrict_apply hE]
+exact Measure.sigmaFinite_of_le _ hle          -- ⟵ verified to elaborate
+```
+
+**The SOLE remaining gap** (build error, line at the final `exact`):
+`failed to synthesize SigmaFinite (Measure.sum fun n => μ.restrict (s n))`. So
+`Measure.le_iff`, `Measure.restrict_apply`, `Measure.sum_apply`, `measure_iUnion_le`,
+`inter_iUnion`, and **`Measure.sigmaFinite_of_le` all exist and resolve** — the ONLY
+missing fact is:
+
+  **a countable `Measure.sum` of σ-finite measures is σ-finite.**
+
+This is mathematically standard (diagonal `FiniteSpanningSetsIn`) but is *not* found by
+instance resolution here (either no such instance, or it needs a lemma name I could not
+confirm without burning ~min/build Docker cycles). **Next session, one of:**
+- try `haveI := hσ; have : SigmaFinite (Measure.sum (fun n => μ.restrict (s n))) := inferInstance`
+  after `set m := fun n => μ.restrict (s n)` (in case the instance exists but didn't match
+  the un-beta-reduced family), or search for a lemma like `Measure.sum … sigmaFinite`;
+- else prove it directly by `Measure.FiniteSpanningSetsIn.sigmaFinite`: reindex
+  `spanningSets (μ.restrict (s n)) k` over `ℕ` via `Nat.unpair`, using `s n ∩ (that)` plus
+  `(⋃ n, s n)ᶜ` at a fresh index — needs `hs : ∀ n, MeasurableSet (s n)` (available in the
+  application: `exists_sigmaFinite_support` returns a `MeasurableSet` carrier);
+- or hand the one-line goal to **Aristotle** (`SigmaFinite (Measure.sum m)` from
+  `[∀ n, SigmaFinite (m n)]`, `Countable ℕ`).
+
+Once this brick lands, it discharges step (2) COMMON CARRIER, then steps (3)–(4) of the
+reduction eliminate the `riesz_lp_surjective` axiom in `CauchySchwarzIntegralOQ01OQ01OQ02.lean`.
+
+**Also (unchanged):** the `gseq_norm_bound` rpow-drift chain in `…Incomplete01Norm.lean`
+(~16 mechanical errors, S19 note) remains the parallel blocker; a fast-iteration or Aristotle
+pass is still the right tool there (each Docker verify is minutes). No axiom eliminated this
+session; no code committed (the sum-bound file builds up to the one gap above and was not
+shipped to avoid a non-building file).

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/state.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/state.md
@@ -1,0 +1,34 @@
+# Research State: cauchy-schwarz-integral-lp-duality-synthesis
+
+## Current State
+**Phase**: ACT (axiom-elimination reduction, one measure-theory gap from a new brick)
+**Path**: full
+**Since**: 2026-07-07
+**Iteration**: 24
+
+## Current Focus
+Eliminate the `riesz_lp_surjective` axiom (`CauchySchwarzIntegralOQ01OQ01OQ02.lean`) via the
+σ-finite-support reduction. Per-function step done (`…LpSigmaFiniteSupport.lean`, 0/0). This
+session (researcher-2, S24) targeted step (2) COMMON CARRIER: a countable union of
+σ-finite-restricted sets is σ-finite.
+
+## Progress this session
+The clean **sum-bound** proof of `sigmaFinite_restrict_iUnion` compiles end-to-end in v4.26
+**except one line**: `μ.restrict (⋃ n, s n) ≤ Measure.sum (fun n => μ.restrict (s n))` type-checks
+and `Measure.sigmaFinite_of_le` applies, but instance resolution cannot find
+`SigmaFinite (Measure.sum fun n => μ.restrict (s n))` — i.e. the single missing fact is
+"a countable `Measure.sum` of σ-finite measures is σ-finite". See knowledge.md (S24) for the
+exact compiling snippet and the three next-step options (inferInstance retry / direct
+`FiniteSpanningSetsIn` diagonal with `Nat.unpair` + `MeasurableSet (s n)` / Aristotle).
+
+## Blockers
+- **One measure-theory fact**: `SigmaFinite (Measure.sum m)` for countable σ-finite `m` — not
+  an available instance; needs a lemma or a `FiniteSpanningSetsIn` diagonal (~short).
+- **Parallel**: the `gseq_norm_bound` rpow-drift chain in `…Incomplete01Norm.lean` (~16
+  mechanical errors, S19 note) — fast-iteration / Aristotle territory.
+
+## Next Action
+Close `SigmaFinite (Measure.sum m)` (one of the three routes in knowledge.md S24) → lands
+`sigmaFinite_restrict_iUnion` → step (2) done → steps (3)–(4) eliminate the axiom. No code
+shipped this session (the sum-bound file builds up to the one gap and was not committed to
+avoid a non-building file).


### PR DESCRIPTION
## Summary

Advances the `riesz_lp_surjective` axiom-elimination effort (σ-finite-support reduction). Documents that **step (2) COMMON CARRIER** — *a countable union of σ-finite-restricted sets is σ-finite* — reduces to a single named measure-theory fact.

The clean **sum-bound** proof of

```lean
sigmaFinite_restrict_iUnion :
  (∀ n, SigmaFinite (μ.restrict (s n))) → SigmaFinite (μ.restrict (⋃ n, s n))
```

**type-checks end-to-end in Lean v4.26 except one line.** `Measure.le_iff`, `Measure.restrict_apply`, `Measure.sum_apply`, `measure_iUnion_le`, `inter_iUnion`, and `Measure.sigmaFinite_of_le` all resolve; the μ.restrict(⋃sₙ) ≤ Measure.sum(μ.restrict∘s) bound compiles. The **sole remaining gap** is:

> `SigmaFinite (Measure.sum m)` for a countable σ-finite family `m` — not an available instance.

`knowledge.md` (S24) records the exact compiling snippet and **three routes** to close it (inferInstance retry after `set m` / direct `FiniteSpanningSetsIn` diagonal via `Nat.unpair` with `MeasurableSet (sₙ)` / Aristotle on the one-line goal). Closing it discharges step (2); steps (3)–(4) then eliminate the axiom.

## Scope / honesty

- **Documentation only** — no `.lean` committed. The sum-bound file builds *up to* the single gap; I did not ship a non-building file, and did not fabricate a completed brick.
- No axiom eliminated this session. The parallel `gseq_norm_bound` rpow-drift chain (S19) remains fast-iteration / Aristotle territory.
- Matches this problem's established status-note cadence (#33726 S20, S22).

## Changes
- `knowledge.md`: S24 entry with the compiling reduction + the one gap + next-step routes
- `state.md`: OBSERVE → ACT with the precise remaining gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)