### PR TITLE
research(erdos-165-oq-05): mark resolved — target sorry already eliminated by #29795 [state sync]

### DIFF
--- a/research/problems/erdos-165-oq-05/state.md
+++ b/research/problems/erdos-165-oq-05/state.md
@@ -1,25 +1,30 @@
 # Research State: erdos-165-oq-05
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED (target sorry resolved upstream)
 **Path**: fast
-**Since**: 2026-04-04T02:41:26-07:00
-**Iteration**: 1
+**Since**: 2026-07-07
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Stated target: "Complete the sorry in `R3_asymptotic_order`" (Erdős #165, R(3,k) ~ c·k²/log k).
 
-## Active Approach
-None yet.
+## Resolution (researcher-2, 2026-07-07)
+**Already resolved.** PR #29795 (`formalize PGM-conjecture refutation; repair latent build
+breakage`) refactored the asymptotic-order content and left `Erdos165Problem.lean` with
+**0 sorries** (verified against origin/main). The old `R3_asymptotic_order` sorry no longer
+exists; the asymptotic results now live in the fully-proved `asymptotic_constant_le` /
+`R3_upper_constant_ge_half` / incompatibility lemmas. The pool re-served this slug with stale
+April OBSERVE state.
 
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
-
-## Blockers
-None.
+## Blockers (remaining axioms — NOT eliminable here)
+`Erdos165Problem.lean` carries 10 axioms: `ramseyNumber` (opaque def), `ramseyNumber_symm`,
+`ramseyNumber_recurrence`, `R3_small_values` (exact R(3,3..9), computer-verified), and six
+deep asymptotic bounds (aks/shearer/kim/bk_pgm/cjms/hhkp). **Mathlib 4.26 has NO Ramsey-number
+theory at all** (confirmed: no `*ramsey*` module/olean), so none of these can be grounded in
+Mathlib — the opaque `ramseyNumber` cannot be de-axiomatised without building Ramsey theory
+from scratch (>500 lines), and the exact values / research bounds are genuinely axioms.
 
 ## Next Action
-Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.
-See FAST_PATH.md for protocol.
+None — target sorry is resolved. Any future work is a separate, BLOCKED-scale project
+(formalize SimpleGraph Ramsey numbers from scratch), not this OQ.


### PR DESCRIPTION
## Summary

Phantom-complete verification + state sync. The stated target — *complete the sorry in `R3_asymptotic_order`* — is **already resolved**: PR #29795 refactored the asymptotic-order content and `Erdos165Problem.lean` is now **0-sorry** on `origin/main`. The old `R3_asymptotic_order` sorry no longer exists (results now in the proved `asymptotic_constant_le` / `R3_upper_constant_ge_half` / incompatibility lemmas). The pool re-served this slug with stale April OBSERVE state.

## Why no further work

The file's 10 axioms (`ramseyNumber` opaque def, `ramseyNumber_symm`, `ramseyNumber_recurrence`, `R3_small_values`, and six deep asymptotic bounds — aks/shearer/kim/bk_pgm/cjms/hhkp) are **not eliminable**: Mathlib 4.26 has **no Ramsey-number theory** (confirmed — no `*ramsey*` module/olean). Grounding `ramseyNumber` would mean building SimpleGraph Ramsey numbers from scratch (>500 lines) — a separate BLOCKED-scale project, not this OQ.

## Changes
- `state.md`: OBSERVE (Apr) → COMPLETED with the resolution + blocked-axiom verdict (doc only, no `.lean` change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)