### PR TITLE
fix: route submodule init stdout to stderr in create_agent_worktree

### DIFF
--- a/scripts/enricher/parallel-enrich.sh
+++ b/scripts/enricher/parallel-enrich.sh
@@ -152,7 +152,10 @@ create_agent_worktree() {
 
     # Initialize submodules if needed
     if [[ -f "$worktree_path/.gitmodules" ]]; then
-        (cd "$worktree_path" && git submodule update --init --recursive 2>/dev/null) || true
+        # Route submodule stdout ("Submodule path '...': checked out '...'")
+        # to stderr so it cannot corrupt the function's `<path>\t<branch>`
+        # tab-return contract on stdout; suppress git's own stderr noise.
+        (cd "$worktree_path" && git submodule update --init --recursive >&2 2>/dev/null) || true
     fi
 
     printf '%s\t%s\n' "$worktree_path" "$branch_name"


### PR DESCRIPTION
## Summary

Fixes a latent stdout leak in `create_agent_worktree()` in `scripts/enricher/parallel-enrich.sh`. The submodule-init block only suppressed stderr, so on a fresh worktree with the repo's 3 real submodules git wrote `Submodule path '...': checked out '...'` lines to **stdout**, ahead of the function's `printf '%s\t%s\n'` tab-return. The caller's `IFS=$'\t' read -r worktree_path branch_name` then read the submodule progress as the path and got an empty branch, breaking the tmux `-c` working dir and the branch threaded into the agent prompt.

This mirrors the fix merged today in PR #35271 (commit `c2e2698e043`) for the sibling `scripts/erdos/parallel-enhance.sh`, which inherited the identical leak verbatim from this file when #35237 was used as its reference implementation.

## Changes

- `scripts/enricher/parallel-enrich.sh` (line 155): change `2>/dev/null` to `>&2 2>/dev/null` on the `git submodule update --init --recursive` subshell (stdout -> original stderr first, then fd2 -> /dev/null), so submodule progress stays visible on stderr, git's stderr noise is suppressed, and stdout carries only the `<path>\t<branch>` tab-return.
- Added a brief explanatory comment mirroring the one in commit `c2e2698e043`.

No other lines change.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| On a fresh create in a repo with submodules, `create_agent_worktree`'s stdout is exactly one line with two tab-separated fields | ✅ | Sandbox repo with a real submodule: captured only stdout (`2>/dev/null`), asserted 1 line, non-empty `path` and `branch`, `path` equals the worktree dir and is a real directory. Negative control with the old form produced 2 lines with a submodule-progress first line and empty branch. |
| No behavior change otherwise | ✅ | Only the redirection on one line changed; the no-`.gitmodules` fast path is untouched. |
| `bash -n` clean | ✅ | `bash -n scripts/enricher/parallel-enrich.sh` exits 0. |

## Test Plan

- `bash -n scripts/enricher/parallel-enrich.sh` — passes.
- Sandbox assertion (mirrors PR #35271 Doctor's verification): built a super repo with a real `file://` submodule, ran the exact fixed line, captured stdout only, and asserted a single line with two non-empty tab-separated fields where the first field is the worktree path (a real directory). PASS.
- Negative control: the old `2>/dev/null`-only form yielded 2 stdout lines with the first line being `Submodule path '...': checked out '...'` and an empty branch — confirming the bug the fix removes.

Closes #35277

🤖 Generated with [Claude Code](https://claude.com/claude-code)