### PR TITLE
audit(borsuk-ulam-oq-02-oq-01-oq-01): disclose Lean.ofReduceBool from native_decide

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
@@ -17,11 +17,11 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 187,
     "theoremCount": 13,
     "definitionCount": 1,
-    "assumptions": "1 axiom: buDim_le_formula (the open conjecture: buDim(n,d) ≤ max_{p|n} buDim(p,d)). Lower bound direction proved from buDim_mono in parent file. Specific cases n=4,6,9 proved. buDim function and known results axiomatized in parent file BorsukUlamOQ02OQ01.lean.",
+    "assumptions": "1 axiom: buDim_le_formula (the open conjecture: buDim(n,d) ≤ max_{p|n} buDim(p,d)). Lower bound direction proved from buDim_mono in parent file. Specific cases n=4,6,9 proved. buDim function and known results axiomatized in parent file BorsukUlamOQ02OQ01.lean. The specific cases n=4,6,9 are discharged via `native_decide` (computing `Nat.primeFactors 4 = {2}`, `{2,3}`, `{3}`), so those presented theorems additionally depend on `Lean.ofReduceBool` (kernel-trusted compiler reduction). Counting this compiler-trust assumption alongside the buDim_le_formula axiom gives meta.axiomCount = 2; leanFile.axiomCount = 1 counts only the literal `axiom` declaration.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: borsuk-ulam-oq-02-oq-01-oq-01
**Severity**: LOW (disclosure gap; no verified-overclaim)

The specific-case theorems `buDim_four_eq_two`, `buDim_six_eq_max`, `buDim_nine_eq_three` (presented as "specific cases n=4,6,9 proved" and consumed downstream by `buDim_four_succ`/`buDim_six_even`) are discharged with `native_decide` computing `Nat.primeFactors 4/6/9`. Per the project's axiom-integrity policy, a substantive `native_decide` result depends on `Lean.ofReduceBool` and must disclose it.

## Evidence

- **meta.json claimed**: `axiomCount: 1`, assumptions listed only `buDim_le_formula`.
- **Lean file shows**: 3 real `native_decide` uses (lines 119, 128, 138) backing presented theorems ⇒ `Lean.ofReduceBool` in the footprint, undisclosed.
- status/badge were already `axiomatized`/`axiom` — no "verified" overclaim, hence LOW not CRITICAL.

## Fix

- `meta.axiomCount` 1 → 2 (buDim_le_formula axiom + `Lean.ofReduceBool` compiler trust).
- `leanFile.axiomCount` stays 1 (literal `axiom` declaration only, per policy).
- `assumptions` now discloses the `native_decide`/`ofReduceBool` dependency.

Also re-audited 5 sibling metas changed since last audit (descartes-rule-of-signs-oq-01-oq-03, burnside-counting-oq-04-oq-01-oq-01, buffons-needle-oq-02-oq-02-oq-01, erdos-1110, bounded-prime-gaps-oq-04-oq-01-incomplete-01) — all CLEAN (descartes = well-disclosed `SturmReduction` structure; burnside/buffons native_decide grep hits were docstring FPs). Tracker updated for all 6.

---
Discovered during gallery integrity re-audit.