### PR TITLE
Enrich Carnot's Theorem uniqueness maximiser

### DIFF
--- a/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-01/meta.json
@@ -60,7 +60,8 @@
       "**Strict concavity is exactly the uniqueness ingredient**: ordinary concavity (used by the parent) gives the bound but allows the chord to touch the graph off the barycentre; the strict version forbids this, so a saturated Jensen step *forces its two points equal*",
       "**The maximiser is unique, not just exhibited**: equality in sin A + sin B + sin C ≤ 3√3/2 holds at exactly one angle configuration A = B = C = π/3, the strongest form of the extremal-perimeter statement",
       "**Two tight steps decode to two equalities**: saturating the global bound makes both Jensen averaging steps simultaneously tight (their slacks are non-negative and sum to zero), and each tightness decodes — via the strict-Jensen lemma — to one coincidence (B = C, then A = M), which the angle-sum closes to the equilateral triangle",
-      "**The strict-Jensen equality lemma is reusable**: a saturated two-point Jensen for any strictly concave function forces its sample points equal — the generic mechanism behind 'the symmetric point is the unique optimiser' in symmetric extremal problems"
+      "**The strict-Jensen equality lemma is reusable**: a saturated two-point Jensen for any strictly concave function forces its sample points equal — the generic mechanism behind 'the symmetric point is the unique optimiser' in symmetric extremal problems",
+      "**The hypotheses are minimal**: only the *lower* bounds A, B, C ≥ 0 are assumed — the upper memberships A, B, C ≤ π needed to invoke concavity are automatic from the angle-sum (e.g. A = π − B − C ≤ π), so the characterisation holds across the full boundary of the angle simplex without redundant assumptions"
     ],
     "prerequisites": [
       "Real trigonometric function sin and its value sin(π/3) = √3/2",


### PR DESCRIPTION
Enrichment pass for `carnot-theorem-oq-01-oq-03-oq-01`.

This entry was already at target quality (score 94: rich historicalContext, full conclusion with implications + open questions, 11 annotations each carrying mathContext/significance/relatedConcepts/prerequisites, complete section coverage, cross-references, and references). Per the size guardrails I avoided accretion and made a single substantive addition.

**Change:** added one keyInsight surfacing that the theorem assumes only the *lower* bounds `A, B, C ≥ 0` — the upper memberships `A, B, C ≤ π` needed for concavity are automatic from the angle-sum `A + B + C = π`. This minimal-hypothesis nicety was previously only buried in an annotation.

Non-bloating: keyInsights now 5/12; meta.json 15.4 KB (well under the 60 KB cap). JSON validated by the gallery enrichment build.