### PR TITLE
research(erdos-897-oq-01): prove Ω is completely additive [VERIFIED, 0-sorry, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos897Problem.lean
+++ b/proofs/Proofs/Erdos897Problem.lean
@@ -172,6 +172,38 @@ theorem omega_stronglyAdditive : IsStronglyAdditive omega := by
     simp only [omega]
     rw [Nat.primeFactors_pow p (by omega : k ≠ 0)]
 
+/-- `Ω(n)` (the total number of prime factors, counted with multiplicity) is
+**completely additive**: `Ω(ab) = Ω(a) + Ω(b)` for all positive `a, b`, and
+`Ω(p^k) = k·Ω(p) = k`.  This is the archetypal *integer-valued* completely additive
+function named in the `IsCompletelyAdditive` docstring, and the natural counterpart of
+`omega_stronglyAdditive`; here we verify the predicate holds so it is non-vacuous.
+
+Both parts reduce to the fact that `Ω` counts the length of `Nat.primeFactorsList`,
+which is additive under multiplication up to a permutation
+(`Nat.perm_primeFactorsList_mul`).  The prime-power identity follows by induction on the
+exponent, with the multiplier `Ω(p)` carried symbolically (no need to evaluate it). -/
+theorem bigOmega_completelyAdditive : IsCompletelyAdditive bigOmega := by
+  refine ⟨?_, ?_⟩
+  · -- additivity (in fact for all positive a, b, coprime or not)
+    intro a b ha hb _hab
+    simp only [bigOmega]
+    rw [(Nat.perm_primeFactorsList_mul ha.ne' hb.ne').length_eq, List.length_append]
+    push_cast
+    ring
+  · -- prime powers: Ω(p^k) = k · Ω(p), by induction on k
+    intro p k hp
+    have hpne : p ≠ 0 := hp.pos.ne'
+    simp only [bigOmega]
+    induction k with
+    | zero => simp [Nat.primeFactorsList_one]
+    | succ n ih =>
+        rw [pow_succ,
+            (Nat.perm_primeFactorsList_mul (pow_ne_zero n hpne) hpne).length_eq,
+            List.length_append]
+        push_cast at ih ⊢
+        rw [ih]
+        ring
+
 /-
 ## Reduction for Completely Additive Functions
 

--- a/src/data/proofs/erdos-897/meta.json
+++ b/src/data/proofs/erdos-897/meta.json
@@ -55,9 +55,9 @@
       "Definitions of omega, bigOmega, and log as concrete examples"
     ],
     "axiomCount": 0,
-    "lineCount": 210,
+    "lineCount": 242,
     "assumptions": "None. The supporting theory is fully machine-checked with 0 axioms and 0 sorries. The two main questions of Erdős #897 remain OPEN and are stated only as documentation, not asserted as theorems.",
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 7
   },
   "overview": {
@@ -154,11 +154,11 @@
       "Filter"
     ],
     "namespace": "Erdos897",
-    "lineCount": 210,
+    "lineCount": 242,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 7,
-    "theoremCount": 6
+    "theoremCount": 7
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Erdős Problem #897 (additive functions and consecutive differences) asks two questions that remain **OPEN**. The gallery entry `erdos-897` builds fully-verified supporting theory around them, including proofs that the canonical arithmetic functions genuinely satisfy the relevant predicates (non-vacuity): `logN_completelyAdditive` and `omega_stronglyAdditive`.

This PR fills the one missing companion. The file already **defines** `bigOmega` (Ω, total prime factors with multiplicity, `n.primeFactorsList.length`), and the `IsCompletelyAdditive` docstring explicitly names Ω as its example — but the corresponding instance theorem was absent. This adds it:

- **`bigOmega_completelyAdditive : IsCompletelyAdditive bigOmega`** — Ω is completely additive: `Ω(ab) = Ω(a) + Ω(b)` for positive `a, b`, and `Ω(p^k) = k·Ω(p)`.

Ω is the archetypal *integer-valued* completely additive function for this problem and the natural counterpart of the existing `omega_stronglyAdditive` (ω, strongly additive). With this, both canonical predicates now have a matching worked example.

## Proof

Both parts reduce to `Ω = length ∘ Nat.primeFactorsList` being additive up to a permutation of the factor list:

- **Additivity**: `Nat.perm_primeFactorsList_mul` gives `(a*b).primeFactorsList ~ a.primeFactorsList ++ b.primeFactorsList`; take `.length_eq` and `List.length_append`.
- **Prime powers**: induction on `k`, carrying the multiplier `Ω(p)` symbolically (no need to evaluate it); the successor step is one more application of the same permutation lemma via `pow_succ`.

## Status

- **Verified**: builds green (`7743 jobs`, `docker-build.sh Proofs.Erdos897Problem`), 0 sorries, 0 `axiom` declarations, axiom profile `[propext, Classical.choice, Quot.sound]`.
- The two main Erdős #897 questions remain OPEN and untouched; this only adds verified non-vacuity supporting theory.
- meta.json synced: `theoremCount 6 → 7`, `lineCount 210 → 242`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)