### PR TITLE
research(shannon-entropy-oq-03): repair masked broken build — SSA + 3-var corollaries [VERIFIED, 0-sorry, 0-axiom]

### DIFF
--- a/proofs/Proofs/ShannonEntropySSA.lean
+++ b/proofs/Proofs/ShannonEntropySSA.lean
@@ -1,526 +1,92 @@
+/-
+  Strong Subadditivity of Shannon Entropy — statement and information-theoretic
+  corollaries.
+
+  The deepest classical entropy inequality,
+
+      H(X, Y, Z) + H(Y) ≤ H(X, Y) + H(Y, Z),
+
+  is proved (0 sorries, 0 axioms) in `Proofs/ShannonEntropy.lean` as
+  `InformationTheory.strong_subadditivity`, via the conditional-mutual-information
+  identity
+
+      I(X ; Z | Y) = Σ p(x,y,z) · log[ p(x,y,z)·p_Y(y) / (p_XY(x,y)·p_YZ(y,z)) ] ≥ 0,
+
+  each term of which is bounded below by a KL-divergence (Gibbs) inequality
+  `p·log(p/q) ≥ p - q`, the block sum telescoping to `1 - 1 = 0`.
+
+  This file records that theorem and derives its two standard corollaries in the
+  three-variable setting, which are *not* present in the parent file:
+
+  * `conditioning_reduces_entropy_general` — conditioning on more variables cannot
+    increase entropy: `H(X | Y, Z) ≤ H(X | Y)`;
+  * `conditional_mi_nonneg` — the conditional mutual information is non-negative:
+    `I(X ; Z | Y) ≥ 0`.
+
+  Both are immediate linear rearrangements of strong subadditivity.
+
+  A previous revision of this file re-derived the entire marginal / chain-rule /
+  strong-subadditivity infrastructure inline while also `import`ing the parent
+  file, which declares the same names (`marginalXY`, `marginalYZ`,
+  `strong_subadditivity`, …) in the same `InformationTheory` namespace. That made
+  the file fail to elaborate ("already been declared") and was never CI-checked.
+  This revision reuses the parent's verified development directly, so the file
+  builds cleanly and stays axiom-free.
+
+  STATUS: [VERIFIED] — machine-checked with `docker-build.sh Proofs.ShannonEntropySSA`.
+  `#print axioms` on each theorem reports only the foundational trio
+  `[propext, Classical.choice, Quot.sound]`; no `sorryAx`, `Lean.ofReduceBool`,
+  or added axioms (inherited from the parent's axiom-free proof).
+-/
 import Mathlib
 import Proofs.ShannonEntropy
 
-/-
-# Strong Subadditivity of Shannon Entropy
-
-## What This Proves
-
-Strong subadditivity (SSA) is the deepest inequality in Shannon information theory:
-
-  H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z)
-
-This says: the total information in three variables, plus the information
-in the "shared" variable Y, is at most the sum of the informations in the
-two pairs (X,Y) and (Y,Z) that overlap in Y.
-
-Equivalently: conditioning on more variables can only reduce entropy:
-  H(X|Y,Z) ≤ H(X|Y)
-
-Or: conditional mutual information is non-negative:
-  I(X;Z|Y) = H(X|Y) - H(X|Y,Z) ≥ 0
-
-## Proof Strategy
-
-For each value y with p(y) > 0, the conditional distribution
-p(x,z|y) = p(x,y,z)/p(y) is a valid joint distribution on α × γ.
-Its mutual information I_y(X;Z) ≥ 0 by the already-proved
-mutual_info_nonneg. The conditional MI is the weighted average:
-  I(X;Z|Y) = Σ_y p(y) I_y(X;Z) ≥ 0
-
-## Historical Note
-
-SSA was conjectured by Lanford and Robinson (1968) and proved by
-Lieb and Ruskai (1973) for quantum entropy. The classical (Shannon)
-case is simpler and follows from properties of KL divergence.
-
-## Mathlib Dependencies
-
-Uses only the Shannon entropy infrastructure from ShannonEntropy.lean.
--/
-
-namespace InformationTheory
-
 open Finset
 
--- ═══════════════════════════════════════════════════════════════
--- PART I: Three-Variable Marginal Distributions
--- ═══════════════════════════════════════════════════════════════
+namespace InformationTheory.SSA
 
--- Reproduce definitions for self-containment (same as ShannonEntropy.lean)
-noncomputable def shannonEntropy' {α : Type*} [Fintype α] [DecidableEq α]
-    (p : α → ℝ) : ℝ :=
-  -∑ x : α, if p x = 0 then 0 else p x * Real.log (p x)
+open InformationTheory
 
-/-- Marginal distribution on (X,Y) from a joint on (X,Y,Z):
-    p_{XY}(x,y) = Σ_z p(x,y,z) -/
-noncomputable def marginalXY {α β γ : Type*} [Fintype γ]
-    (pXYZ : α × β × γ → ℝ) : α × β → ℝ :=
-  fun ⟨x, y⟩ => ∑ z : γ, pXYZ (x, y, z)
+variable {α β γ : Type*}
+  [Fintype α] [Fintype β] [Fintype γ]
+  [DecidableEq α] [DecidableEq β] [DecidableEq γ]
 
-/-- Marginal distribution on (Y,Z) from a joint on (X,Y,Z):
-    p_{YZ}(y,z) = Σ_x p(x,y,z) -/
-noncomputable def marginalYZ {α β γ : Type*} [Fintype α]
-    (pXYZ : α × β × γ → ℝ) : β × γ → ℝ :=
-  fun ⟨y, z⟩ => ∑ x : α, pXYZ (x, y, z)
+/-- **Strong subadditivity of Shannon entropy.**
 
-/-- Marginal distribution on Y from a joint on (X,Y,Z):
-    p_Y(y) = Σ_x Σ_z p(x,y,z) -/
-noncomputable def marginalY_3 {α β γ : Type*} [Fintype α] [Fintype γ]
-    (pXYZ : α × β × γ → ℝ) : β → ℝ :=
-  fun y => ∑ x : α, ∑ z : γ, pXYZ (x, y, z)
+    `H(X, Y, Z) + H(Y) ≤ H(X, Y) + H(Y, Z)`.
 
--- ═══════════════════════════════════════════════════════════════
--- PART II: Marginal Properties
--- ═══════════════════════════════════════════════════════════════
-
-/-- The XY-marginal preserves non-negativity. -/
-theorem marginalXY_nonneg {α β γ : Type*} [Fintype γ]
-    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz) :
-    ∀ xy : α × β, 0 ≤ marginalXY pXYZ xy := by
-  intro ⟨x, y⟩
-  exact Finset.sum_nonneg fun z _ => hp (x, y, z)
-
-/-- The YZ-marginal preserves non-negativity. -/
-theorem marginalYZ_nonneg {α β γ : Type*} [Fintype α]
-    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz) :
-    ∀ yz : β × γ, 0 ≤ marginalYZ pXYZ yz := by
-  intro ⟨y, z⟩
-  exact Finset.sum_nonneg fun x _ => hp (x, y, z)
-
-/-- The Y-marginal preserves non-negativity. -/
-theorem marginalY_3_nonneg {α β γ : Type*} [Fintype α] [Fintype γ]
-    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz) :
-    ∀ y : β, 0 ≤ marginalY_3 pXYZ y := by
-  intro y
-  exact Finset.sum_nonneg fun x _ =>
-    Finset.sum_nonneg fun z _ => hp (x, y, z)
-
-/-- The XY-marginal sums to 1. -/
-theorem marginalXY_sum {α β γ : Type*} [Fintype α] [Fintype β] [Fintype γ]
-    {pXYZ : α × β × γ → ℝ}
+    This is `InformationTheory.strong_subadditivity` (proved in
+    `Proofs/ShannonEntropy.lean`), re-exported here as the headline theorem of the
+    strong-subadditivity gallery entry. -/
+theorem strong_subadditivity {pXYZ : α × β × γ → ℝ}
+    (hp : ∀ xyz, 0 ≤ pXYZ xyz)
     (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
-    ∑ xy : α × β, marginalXY pXYZ xy = 1 := by
-  unfold marginalXY
-  simp only
-  rw [show ∑ xy : α × β, ∑ z : γ, pXYZ (xy.1, xy.2, z) =
-      ∑ xyz : α × β × γ, pXYZ xyz from by
-    rw [Fintype.sum_prod_type, Fintype.sum_prod_type]
-    congr 1; ext x; congr 1; ext y; rfl]
-  exact hsum
+    shannonEntropy pXYZ + shannonEntropy (marginalY pXYZ) ≤
+      shannonEntropy (marginalXY pXYZ) + shannonEntropy (marginalYZ pXYZ) :=
+  InformationTheory.strong_subadditivity hp hsum
 
-/-- The YZ-marginal sums to 1. -/
-theorem marginalYZ_sum {α β γ : Type*} [Fintype α] [Fintype β] [Fintype γ]
-    {pXYZ : α × β × γ → ℝ}
+/-- **Conditioning reduces entropy (three-variable form).**
+
+    `H(X | Y, Z) ≤ H(X | Y)`, where `H(X | Y, Z) = H(X, Y, Z) − H(Y, Z)` and
+    `H(X | Y) = H(X, Y) − H(Y)`.  A direct rearrangement of strong subadditivity:
+    the deficit is exactly the conditional mutual information `I(X ; Z | Y) ≥ 0`. -/
+theorem conditioning_reduces_entropy_general {pXYZ : α × β × γ → ℝ}
+    (hp : ∀ xyz, 0 ≤ pXYZ xyz)
     (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
-    ∑ yz : β × γ, marginalYZ pXYZ yz = 1 := by
-  unfold marginalYZ
-  simp only
-  rw [show ∑ yz : β × γ, ∑ x : α, pXYZ (x, yz.1, yz.2) =
-      ∑ xyz : α × β × γ, pXYZ xyz from by
-    rw [Fintype.sum_prod_type, Fintype.sum_prod_type]
-    rw [Finset.sum_comm]
-    congr 1; ext x
-    rw [Fintype.sum_prod_type]]
-  exact hsum
+    shannonEntropy pXYZ - shannonEntropy (marginalYZ pXYZ) ≤
+      shannonEntropy (marginalXY pXYZ) - shannonEntropy (marginalY pXYZ) := by
+  linarith [InformationTheory.strong_subadditivity hp hsum]
 
-/-- The Y-marginal sums to 1. -/
-theorem marginalY_3_sum {α β γ : Type*} [Fintype α] [Fintype β] [Fintype γ]
-    {pXYZ : α × β × γ → ℝ}
+/-- **Conditional mutual information is non-negative.**
+
+    `I(X ; Z | Y) = H(X, Y) + H(Y, Z) − H(X, Y, Z) − H(Y) ≥ 0`.  This is the
+    information-theoretic content of strong subadditivity: knowing `Y`, the
+    variables `X` and `Z` carry non-negative mutual information. -/
+theorem conditional_mi_nonneg {pXYZ : α × β × γ → ℝ}
+    (hp : ∀ xyz, 0 ≤ pXYZ xyz)
     (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
-    ∑ y : β, marginalY_3 pXYZ y = 1 := by
-  unfold marginalY_3
-  rw [show ∑ y : β, ∑ x : α, ∑ z : γ, pXYZ (x, y, z) =
-      ∑ xyz : α × β × γ, pXYZ xyz from by
-    rw [Fintype.sum_prod_type, Fintype.sum_prod_type]
-    rw [Finset.sum_comm]
-    congr 1; ext x; rfl]
-  exact hsum
+    shannonEntropy (marginalXY pXYZ) + shannonEntropy (marginalYZ pXYZ) -
+      shannonEntropy pXYZ - shannonEntropy (marginalY pXYZ) ≥ 0 := by
+  linarith [InformationTheory.strong_subadditivity hp hsum]
 
--- ═══════════════════════════════════════════════════════════════
--- PART III: Entropy Chain Rule for Pairs
--- ═══════════════════════════════════════════════════════════════
-
-/-- The Y-marginal of a joint distribution on α × β. -/
-noncomputable def marginalSnd {α β : Type*} [Fintype α]
-    (pXY : α × β → ℝ) : β → ℝ :=
-  fun y => ∑ x : α, pXY (x, y)
-
-/-- Conditional entropy H(X|Y) from ShannonEntropy.lean, reproduced. -/
-noncomputable def condEntropy {α β : Type*} [Fintype α] [Fintype β]
-    [DecidableEq α] [DecidableEq β]
-    (pXY : α × β → ℝ) : ℝ :=
-  -(∑ x : α, ∑ y : β,
-    if pXY (x, y) = 0 then 0
-    else pXY (x, y) * Real.log (pXY (x, y) / (∑ x' : α, pXY (x', y))))
-
-/-- **Entropy Chain Rule**: H(X,Y) = H(Y) + H(X|Y)
-
-    The joint entropy decomposes into the marginal entropy of Y
-    plus the conditional entropy of X given Y.
-
-    Proof: H(X,Y) = -Σ p(x,y) log p(x,y)
-    H(Y) + H(X|Y) = -Σ p(y) log p(y) - Σ p(x,y) log(p(x,y)/p(y))
-
-    Split the conditional term: p(x,y) log(p(x,y)/p(y))
-    = p(x,y) [log p(x,y) - log p(y)]
-    = p(x,y) log p(x,y) - p(x,y) log p(y)
-
-    Summing over x: Σ_x p(x,y) log p(x,y) - p(y) log p(y)
-    So -Σ_x Σ_y p(x,y) log(p(x,y)/p(y)) = H(X,Y) - H(Y)
-    Thus H(Y) + H(X|Y) = H(Y) + H(X,Y) - H(Y) = H(X,Y). -/
-theorem entropy_chain_rule {α β : Type*} [Fintype α] [Fintype β]
-    [DecidableEq α] [DecidableEq β]
-    {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
-    (hsum : ∑ xy : α × β, pXY xy = 1) :
-    shannonEntropy' pXY =
-    shannonEntropy' (marginalSnd pXY) + condEntropy pXY := by
-  -- H(X,Y) = H(Y) + H(X|Y) by splitting log p(x,y) = log(p(x,y)/p_Y(y)) + log p_Y(y)
-  -- Step 1: Term-by-term identity
-  have hterm : ∀ x y,
-      (if pXY (x, y) = 0 then (0 : ℝ) else pXY (x, y) * Real.log (pXY (x, y))) =
-      (if pXY (x, y) = 0 then 0
-       else pXY (x, y) * Real.log (pXY (x, y) / (∑ x' : α, pXY (x', y)))) +
-      (if pXY (x, y) = 0 then 0
-       else pXY (x, y) * Real.log (∑ x' : α, pXY (x', y))) := by
-    intro x y
-    by_cases hpxy : pXY (x, y) = 0
-    · simp [hpxy]
-    · simp only [hpxy, ↓reduceIte]
-      have hpxy_pos : 0 < pXY (x, y) := lt_of_le_of_ne (hp (x, y)) (Ne.symm hpxy)
-      have hpy_pos : 0 < ∑ x' : α, pXY (x', y) :=
-        lt_of_lt_of_le hpxy_pos
-          (Finset.single_le_sum (fun x' _ => hp (x', y)) (Finset.mem_univ x))
-      rw [show pXY (x, y) * Real.log (pXY (x, y) / (∑ x', pXY (x', y))) +
-          pXY (x, y) * Real.log (∑ x', pXY (x', y)) =
-          pXY (x, y) * (Real.log (pXY (x, y) / (∑ x', pXY (x', y))) +
-          Real.log (∑ x', pXY (x', y))) from by ring]
-      congr 1
-      rw [Real.log_div (ne_of_gt hpxy_pos) (ne_of_gt hpy_pos)]
-      ring
-  -- Step 2: Marginal telescoping
-  have hmarg : ∀ y,
-      ∑ x : α, (if pXY (x, y) = 0 then (0 : ℝ)
-        else pXY (x, y) * Real.log (∑ x' : α, pXY (x', y))) =
-      (if (∑ x : α, pXY (x, y)) = 0 then 0
-       else (∑ x : α, pXY (x, y)) * Real.log (∑ x : α, pXY (x, y))) := by
-    intro y
-    by_cases hpy : (∑ x : α, pXY (x, y)) = 0
-    · have hall : ∀ x, pXY (x, y) = 0 := by
-        intro x; have h1 := hp (x, y)
-        have h2 : pXY (x, y) ≤ ∑ x', pXY (x', y) :=
-          Finset.single_le_sum (fun x' _ => hp (x', y)) (Finset.mem_univ x)
-        linarith
-      simp [hpy, hall]
-    · simp only [hpy, ↓reduceIte]
-      have : ∑ x : α, (if pXY (x, y) = 0 then (0 : ℝ)
-          else pXY (x, y) * Real.log (∑ x' : α, pXY (x', y))) =
-          ∑ x : α, pXY (x, y) * Real.log (∑ x' : α, pXY (x', y)) := by
-        apply Finset.sum_congr rfl; intro x _
-        by_cases hpxy : pXY (x, y) = 0
-        · simp [hpxy]
-        · simp [hpxy]
-      rw [this, ← Finset.sum_mul]
-  -- Step 3: Assembly
-  unfold shannonEntropy' condEntropy marginalSnd
-  dsimp only
-  -- Convert product-type sum to nested sum
-  conv_lhs =>
-    rw [show ∑ xy : α × β, (if pXY xy = 0 then (0 : ℝ)
-        else pXY xy * Real.log (pXY xy)) =
-        ∑ x : α, ∑ y : β, (if pXY (x, y) = 0 then 0
-        else pXY (x, y) * Real.log (pXY (x, y))) from Fintype.sum_prod_type _]
-  -- Apply the term splitting and distribute sums
-  simp_rw [hterm]
-  simp only [Finset.sum_add_distrib]
-  -- Swap sum order and apply marginal telescoping
-  rw [show ∑ x : α, ∑ y : β, (if pXY (x, y) = 0 then (0 : ℝ) else
-      pXY (x, y) * Real.log (∑ x', pXY (x', y))) =
-      ∑ y : β, (if (∑ x, pXY (x, y)) = 0 then 0 else
-      (∑ x, pXY (x, y)) * Real.log (∑ x, pXY (x, y))) from by
-    rw [Finset.sum_comm]; congr 1; ext y; exact hmarg y]
-  ring
-
--- ═══════════════════════════════════════════════════════════════
--- PART IV: Subadditivity from Chain Rule
--- ═══════════════════════════════════════════════════════════════
-
-/-- **Subadditivity**: H(X,Y) ≤ H(X) + H(Y)
-
-    Proof: H(X,Y) = H(Y) + H(X|Y) ≤ H(Y) + H(X)
-    since conditioning reduces entropy: H(X|Y) ≤ H(X). -/
-theorem subadditivity {α β : Type*} [Fintype α] [Fintype β]
-    [DecidableEq α] [DecidableEq β]
-    {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
-    (hsum : ∑ xy : α × β, pXY xy = 1) :
-    shannonEntropy' pXY ≤
-    shannonEntropy' (fun x => ∑ y : β, pXY (x, y)) +
-    shannonEntropy' (marginalSnd pXY) := by
-  -- From chain rule: H(X,Y) = H(Y) + H(X|Y)
-  -- From conditioning reduces entropy: H(X|Y) ≤ H(X)
-  -- Combined: H(X,Y) ≤ H(Y) + H(X) = H(X) + H(Y)
-  rw [entropy_chain_rule hp hsum]
-  -- Goal: H(Y) + H(X|Y) ≤ H(X) + H(Y)
-  -- shannonEntropy' = shannonEntropy and condEntropy = conditionalEntropy by def
-  -- Use conditioning_reduces_entropy from ShannonEntropy.lean
-  have hcond : condEntropy pXY ≤ shannonEntropy' (fun x => ∑ y : β, pXY (x, y)) := by
-    -- condEntropy and conditionalEntropy are definitionally equal, as are shannonEntropy' and shannonEntropy
-    exact conditioning_reduces_entropy hp hsum
-  linarith
-
--- ═══════════════════════════════════════════════════════════════
--- PART V: Strong Subadditivity
--- ═══════════════════════════════════════════════════════════════
-
-/-- **Strong Subadditivity** (Lieb-Ruskai 1973):
-    H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z)
-
-    Equivalent formulations:
-    - I(X;Z|Y) ≥ 0 (conditional MI non-negative)
-    - H(X|Y,Z) ≤ H(X|Y) (conditioning on more reduces entropy)
-    - H(X|Y) + H(Z|Y) ≥ H(X,Z|Y) (subadditivity conditioned on Y)
-
-    Proof: The deficit H(X,Y) + H(Y,Z) - H(X,Y,Z) - H(Y)
-    equals the conditional mutual information I(X;Z|Y),
-    which is a weighted average of MI values:
-      I(X;Z|Y) = Σ_y p(y) D(p(x,z|y) || p(x|y)p(z|y))
-    Each term is ≥ 0 by non-negativity of KL divergence.
-
-    This is the deepest inequality in classical information theory.
-    The quantum version (von Neumann entropy) was proved by Lieb
-    and Ruskai using the concavity of the trace function. -/
-theorem strong_subadditivity {α β γ : Type*}
-    [Fintype α] [Fintype β] [Fintype γ]
-    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
-    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz)
-    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
-    shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ) ≤
-    shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ) := by
-  -- kl_term_bound (private in ShannonEntropy.lean — copied here)
-  have kl_tb : ∀ {p q : ℝ}, 0 < p → 0 < q → p * Real.log (p / q) ≥ p - q := by
-    intro p q hp hq
-    have h1 : Real.log (q / p) ≤ q / p - 1 := Real.log_le_sub_one_of_pos (div_pos hq hp)
-    have h2 : p * Real.log (q / p) ≤ q - p :=
-      calc p * Real.log (q / p) ≤ p * (q / p - 1) :=
-              mul_le_mul_of_nonneg_left h1 (le_of_lt hp)
-            _ = q - p := by field_simp; ring
-    linarith [show p * Real.log (p / q) = -(p * Real.log (q / p)) by
-      rw [Real.log_div (ne_of_gt hp) (ne_of_gt hq),
-          Real.log_div (ne_of_gt hq) (ne_of_gt hp)]; ring]
-
-  -- Nested sum = 1
-  have hsum_n : ∑ x : α, ∑ y : β, ∑ z : γ, pXYZ (x, y, z) = 1 := by
-    have h := hsum; rw [Fintype.sum_prod_type] at h; simp_rw [Fintype.sum_prod_type] at h; exact h
-
-  -- Marginal telescoping: if S=0 then 0 else S·log S = Σ (if aᵢ=0 then 0 else aᵢ·log S)
-  have htele : ∀ {ι : Type*} [Fintype ι] (a : ι → ℝ) (_ : ∀ i, 0 ≤ a i),
-      (if (∑ i, a i) = 0 then (0 : ℝ) else (∑ i, a i) * Real.log (∑ i, a i)) =
-      ∑ i, (if a i = 0 then 0 else a i * Real.log (∑ j, a j)) := by
-    intro ι _ a ha
-    by_cases hs : (∑ i, a i) = 0
-    · have : ∀ i, a i = 0 := fun i =>
-        le_antisymm (by linarith [Finset.single_le_sum (fun j _ => ha j) (Finset.mem_univ i)]) (ha i)
-      simp [hs, this]
-    · simp only [hs, ↓reduceIte]; symm
-      rw [show ∑ i, (if a i = 0 then (0 : ℝ) else a i * Real.log (∑ j, a j)) =
-          ∑ i, a i * Real.log (∑ j, a j) from
-        Finset.sum_congr rfl fun i _ => by by_cases h : a i = 0 <;> simp [h]]
-      rw [← Finset.sum_mul]
-
-  -- XY marginal telescoping
-  have hXY : ∀ x y, (if (∑ z : γ, pXYZ (x, y, z)) = 0 then (0 : ℝ)
-      else (∑ z, pXYZ (x, y, z)) * Real.log (∑ z, pXYZ (x, y, z))) =
-      ∑ z : γ, (if pXYZ (x, y, z) = 0 then 0
-        else pXYZ (x, y, z) * Real.log (∑ z' : γ, pXYZ (x, y, z'))) := by
-    intro x y; exact htele (fun z => pXYZ (x, y, z)) (fun z => hp (x, y, z))
-
-  -- YZ marginal telescoping
-  have hYZ : ∀ y z, (if (∑ x : α, pXYZ (x, y, z)) = 0 then (0 : ℝ)
-      else (∑ x, pXYZ (x, y, z)) * Real.log (∑ x, pXYZ (x, y, z))) =
-      ∑ x : α, (if pXYZ (x, y, z) = 0 then 0
-        else pXYZ (x, y, z) * Real.log (∑ x' : α, pXYZ (x', y, z))) := by
-    intro y z; exact htele (fun x => pXYZ (x, y, z)) (fun x => hp (x, y, z))
-
-  -- Y marginal telescoping
-  have hY : ∀ y, (if (∑ x : α, ∑ z : γ, pXYZ (x, y, z)) = 0 then (0 : ℝ)
-      else (∑ x, ∑ z, pXYZ (x, y, z)) * Real.log (∑ x, ∑ z, pXYZ (x, y, z))) =
-      ∑ x : α, ∑ z : γ, (if pXYZ (x, y, z) = 0 then 0
-        else pXYZ (x, y, z) * Real.log (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z'))) := by
-    intro y
-    have h := htele (fun (xz : α × γ) => pXYZ (xz.1, y, xz.2)) (fun xz => hp (xz.1, y, xz.2))
-    simp_rw [Fintype.sum_prod_type] at h; exact h
-
-  -- Term splitting: p·log(p) = CMI_term + p·log(pXY) + p·log(pYZ) - p·log(pY)
-  have hterm : ∀ x y z,
-      (if pXYZ (x, y, z) = 0 then (0 : ℝ) else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z))) =
-      (if pXYZ (x, y, z) = 0 then 0
-       else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) *
-         (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) /
-         ((∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z))))) +
-      (if pXYZ (x, y, z) = 0 then 0
-       else pXYZ (x, y, z) * Real.log (∑ z' : γ, pXYZ (x, y, z'))) +
-      (if pXYZ (x, y, z) = 0 then 0
-       else pXYZ (x, y, z) * Real.log (∑ x' : α, pXYZ (x', y, z))) -
-      (if pXYZ (x, y, z) = 0 then 0
-       else pXYZ (x, y, z) * Real.log (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z'))) := by
-    intro x y z
-    by_cases hpxyz : pXYZ (x, y, z) = 0
-    · simp [hpxyz]
-    · simp only [hpxyz, ↓reduceIte]
-      have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hpxyz)
-      have hpXY : 0 < ∑ z', pXYZ (x, y, z') :=
-        lt_of_lt_of_le hpos (Finset.single_le_sum (fun z' _ => hp _) (Finset.mem_univ z))
-      have hpYZ : 0 < ∑ x', pXYZ (x', y, z) :=
-        lt_of_lt_of_le hpos (Finset.single_le_sum (fun x' _ => hp _) (Finset.mem_univ x))
-      have hpY : 0 < ∑ x' : α, ∑ z' : γ, pXYZ (x', y, z') :=
-        lt_of_lt_of_le hpXY (Finset.single_le_sum
-          (fun x' _ => Finset.sum_nonneg fun z' _ => hp _) (Finset.mem_univ x))
-      have hlog : Real.log (pXYZ (x, y, z)) =
-          Real.log (pXYZ (x, y, z) * (∑ x', ∑ z', pXYZ (x', y, z')) /
-            ((∑ z', pXYZ (x, y, z')) * (∑ x', pXYZ (x', y, z)))) +
-          Real.log (∑ z', pXYZ (x, y, z')) +
-          Real.log (∑ x', pXYZ (x', y, z)) -
-          Real.log (∑ x', ∑ z', pXYZ (x', y, z')) := by
-        rw [Real.log_div (ne_of_gt (mul_pos hpos hpY)) (ne_of_gt (mul_pos hpXY hpYZ)),
-            Real.log_mul (ne_of_gt hpos) (ne_of_gt hpY),
-            Real.log_mul (ne_of_gt hpXY) (ne_of_gt hpYZ)]
-        ring
-      calc pXYZ (x, y, z) * Real.log (pXYZ (x, y, z))
-          = pXYZ (x, y, z) * (
-            Real.log (pXYZ (x, y, z) * (∑ x', ∑ z', pXYZ (x', y, z')) /
-              ((∑ z', pXYZ (x, y, z')) * (∑ x', pXYZ (x', y, z)))) +
-            Real.log (∑ z', pXYZ (x, y, z')) +
-            Real.log (∑ x', pXYZ (x', y, z)) -
-            Real.log (∑ x', ∑ z', pXYZ (x', y, z'))) := by congr 1; exact hlog
-        _ = _ := by ring
-
-  -- === PART 1: Show the conditional MI ≥ 0 ===
-  set q := fun x y z => (∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z)) /
-    (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) with hq_def
-  have hq_nn : ∀ x y z, 0 ≤ q x y z := fun x y z => div_nonneg
-    (mul_nonneg (Finset.sum_nonneg fun z' _ => hp _) (Finset.sum_nonneg fun x' _ => hp _))
-    (Finset.sum_nonneg fun x' _ => Finset.sum_nonneg fun z' _ => hp _)
-  have hq_sum_y : ∀ y, ∑ x : α, ∑ z : γ, q x y z = ∑ x, ∑ z, pXYZ (x, y, z) := by
-    intro y
-    simp only [hq_def]
-    by_cases hpy : (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) = 0
-    · have hall : ∀ x z, pXYZ (x, y, z) = 0 := by
-        intro x z; linarith [hp (x, y, z),
-          Finset.single_le_sum (fun z' _ => hp (x, y, z')) (Finset.mem_univ z),
-          Finset.single_le_sum (fun x' _ =>
-            Finset.sum_nonneg fun z' _ => hp (x', y, z')) (Finset.mem_univ x)]
-      simp [hall, hpy]
-    · have hpy_ne : (∑ x', ∑ z', pXYZ (x', y, z')) ≠ 0 := hpy
-      simp_rw [mul_div_assoc]
-      simp_rw [← Finset.sum_div, ← Finset.mul_sum]
-      rw [← Finset.sum_div, ← Finset.sum_mul]
-      rw [show ∑ z : γ, ∑ x' : α, pXYZ (x', y, z) = ∑ x' : α, ∑ z : γ, pXYZ (x', y, z) from
-        Finset.sum_comm]
-      rw [mul_div_cancel₀ _ hpy_ne]
-  have hq_sum : ∑ x : α, ∑ y : β, ∑ z : γ, q x y z = 1 := by
-    conv_lhs => rw [Finset.sum_comm]
-    simp_rw [hq_sum_y]
-    rw [Finset.sum_comm]; exact hsum_n
-  have h_cmi : 0 ≤ ∑ x : α, ∑ y : β, ∑ z : γ,
-      (if pXYZ (x, y, z) = 0 then (0 : ℝ)
-       else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) *
-         (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) /
-         ((∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z))))) := by
-    suffices h_lb : ∑ x, ∑ y, ∑ z, (pXYZ (x, y, z) - q x y z) ≤
-        ∑ x, ∑ y, ∑ z, (if pXYZ (x, y, z) = 0 then (0 : ℝ)
-         else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) *
-           (∑ x', ∑ z', pXYZ (x', y, z')) /
-           ((∑ z', pXYZ (x, y, z')) * (∑ x', pXYZ (x', y, z))))) by
-      have hzero : ∑ x, ∑ y, ∑ z, (pXYZ (x, y, z) - q x y z) = 0 := by
-        simp only [Finset.sum_sub_distrib]; rw [hsum_n, hq_sum, sub_self]
-      linarith
-    apply Finset.sum_le_sum; intro x _; apply Finset.sum_le_sum; intro y _
-    apply Finset.sum_le_sum; intro z _
-    by_cases hpxyz : pXYZ (x, y, z) = 0
-    · simp [hpxyz]; exact hq_nn x y z
-    · simp only [hpxyz, ↓reduceIte]
-      have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hpxyz)
-      have hpXY : 0 < ∑ z', pXYZ (x, y, z') :=
-        lt_of_lt_of_le hpos (Finset.single_le_sum (fun z' _ => hp _) (Finset.mem_univ z))
-      have hpYZ : 0 < ∑ x', pXYZ (x', y, z) :=
-        lt_of_lt_of_le hpos (Finset.single_le_sum (fun x' _ => hp _) (Finset.mem_univ x))
-      have hpY : 0 < ∑ x' : α, ∑ z' : γ, pXYZ (x', y, z') :=
-        lt_of_lt_of_le hpXY (Finset.single_le_sum
-          (fun x' _ => Finset.sum_nonneg fun z' _ => hp _) (Finset.mem_univ x))
-      have hq_pos : 0 < q x y z := by
-        simp only [hq_def]; exact div_pos (mul_pos hpXY hpYZ) hpY
-      have hlog_eq : pXYZ (x, y, z) * (∑ x', ∑ z', pXYZ (x', y, z')) /
-          ((∑ z', pXYZ (x, y, z')) * (∑ x', pXYZ (x', y, z))) =
-          pXYZ (x, y, z) / q x y z := by
-        simp only [hq_def]; field_simp; ring
-      rw [hlog_eq]
-      exact kl_tb hpos hq_pos
-
-  -- === PART 2: Entropy algebra — connect CMI to SSA deficit ===
-  unfold shannonEntropy' marginalXY marginalYZ marginalY_3
-  dsimp only
-  conv_lhs => arg 1; arg 1; rw [show ∑ xyz : α × β × γ,
-    (if pXYZ xyz = 0 then (0 : ℝ) else pXYZ xyz * Real.log (pXYZ xyz)) =
-    ∑ x : α, ∑ y : β, ∑ z : γ,
-    (if pXYZ (x, y, z) = 0 then 0 else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z))) from by
-      rw [Fintype.sum_prod_type]; simp_rw [Fintype.sum_prod_type]]
-  conv_rhs => arg 1; arg 1; rw [show ∑ xy : α × β,
-    (if (fun xy => ∑ z : γ, pXYZ (xy.1, xy.2, z)) xy = 0 then (0 : ℝ)
-     else (fun xy => ∑ z, pXYZ (xy.1, xy.2, z)) xy *
-       Real.log ((fun xy => ∑ z, pXYZ (xy.1, xy.2, z)) xy)) =
-    ∑ x : α, ∑ y : β,
-    (if (∑ z : γ, pXYZ (x, y, z)) = 0 then 0
-     else (∑ z, pXYZ (x, y, z)) * Real.log (∑ z, pXYZ (x, y, z))) from by
-      rw [Fintype.sum_prod_type]]
-  conv_rhs => arg 2; arg 1; rw [show ∑ yz : β × γ,
-    (if (fun yz => ∑ x : α, pXYZ (x, yz.1, yz.2)) yz = 0 then (0 : ℝ)
-     else (fun yz => ∑ x, pXYZ (x, yz.1, yz.2)) yz *
-       Real.log ((fun yz => ∑ x, pXYZ (x, yz.1, yz.2)) yz)) =
-    ∑ y : β, ∑ z : γ,
-    (if (∑ x : α, pXYZ (x, y, z)) = 0 then 0
-     else (∑ x, pXYZ (x, y, z)) * Real.log (∑ x, pXYZ (x, y, z))) from by
-      rw [Fintype.sum_prod_type]]
-  simp_rw [hXY]
-  simp_rw [hYZ]
-  simp_rw [hY]
-  simp_rw [hterm]
-  simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
-  linarith [h_cmi]
-
--- ═══════════════════════════════════════════════════════════════
--- PART VI: Consequences of SSA
--- ═══════════════════════════════════════════════════════════════
-
-/-- **Conditioning reduces entropy** (general form):
-    H(X|Y,Z) ≤ H(X|Y)
-
-    Extra conditioning can only reduce uncertainty.
-    This follows directly from SSA. -/
-theorem conditioning_reduces_entropy_general {α β γ : Type*}
-    [Fintype α] [Fintype β] [Fintype γ]
-    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
-    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz)
-    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
-    -- H(X|Y,Z) ≤ H(X|Y)
-    -- where H(X|Y,Z) = H(X,Y,Z) - H(Y,Z) and H(X|Y) = H(X,Y) - H(Y)
-    shannonEntropy' pXYZ - shannonEntropy' (marginalYZ pXYZ) ≤
-    shannonEntropy' (marginalXY pXYZ) - shannonEntropy' (marginalY_3 pXYZ) := by
-  -- This is a direct rearrangement of SSA:
-  -- H(XYZ) + H(Y) ≤ H(XY) + H(YZ)
-  -- ⟺ H(XYZ) - H(YZ) ≤ H(XY) - H(Y)
-  linarith [strong_subadditivity hp hsum]
-
-/-- **Data processing for conditional entropy**:
-    Processing Z cannot increase the information X provides about Z conditioned on Y.
-    This is a direct corollary of SSA. -/
-theorem conditional_mi_nonneg {α β γ : Type*}
-    [Fintype α] [Fintype β] [Fintype γ]
-    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
-    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz)
-    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
-    -- I(X;Z|Y) = H(X,Y) + H(Y,Z) - H(X,Y,Z) - H(Y) ≥ 0
-    shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ) -
-    shannonEntropy' pXYZ - shannonEntropy' (marginalY_3 pXYZ) ≥ 0 := by
-  linarith [strong_subadditivity hp hsum]
-
-end InformationTheory
+end InformationTheory.SSA

--- a/research/problems/shannon-entropy-oq-03-incomplete-01/state.md
+++ b/research/problems/shannon-entropy-oq-03-incomplete-01/state.md
@@ -1,25 +1,51 @@
 # Research State: shannon-entropy-oq-03-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETE (build repair + status correction)
 **Path**: full
-**Since**: 2026-04-03T02:25:34-07:00
+**Since**: 2026-07-07
 **Iteration**: 1
+**Status**: resolved — gallery entry now builds and is VERIFIED
 
-## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+## Outcome (researcher-9, 2026-07-07)
 
-## Active Approach
-None yet.
+The task as originally written ("only the main theorem at line 303 remains as
+`sorry`") was stale: `Proofs/ShannonEntropySSA.lean` had **no sorry** but was a
+**masked broken build** (merged without Lean CI — math PRs bypass it). Building
+`docker-build.sh Proofs.ShannonEntropySSA` surfaced a cascade of ~11 errors:
 
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- 5× `... has already been declared` — the file redeclared `marginalXY`,
+  `marginalYZ`, `entropy_chain_rule`, `subadditivity`, `strong_subadditivity`
+  (namespace `InformationTheory`) **while also `import`ing the parent
+  `Proofs/ShannonEntropy.lean` that already declares all of them**.
+- Cascading parse error (calc `:=` at L306) and `linarith` failures (L511/524)
+  downstream of the poisoned `strong_subadditivity` elaboration.
+
+Root cause: the file was a self-contained duplicate of infrastructure the parent
+file **already proves cleanly (0 sorries, 0 axioms, builds)**, plus a spurious
+`import Proofs.ShannonEntropy` that made every duplicated name collide.
+
+### Fix
+Replaced the 526-line broken duplicate with a 92-line file that reuses the
+parent's verified development:
+- `strong_subadditivity` — re-exported from `InformationTheory.strong_subadditivity`
+  (H(X,Y,Z)+H(Y) ≤ H(X,Y)+H(Y,Z));
+- `conditioning_reduces_entropy_general` — H(X|Y,Z) ≤ H(X|Y);
+- `conditional_mi_nonneg` — I(X;Z|Y) ≥ 0.
+
+The two 3-variable corollaries are genuinely new (absent from the parent). New
+namespace `InformationTheory.SSA` avoids all collisions. **VERIFIED**:
+`docker-build.sh Proofs.ShannonEntropySSA` → ✔ [7744/7744] built (0 sorries,
+inherits the parent's axiom-free proof; foundational trio only, no
+`native_decide`). Gallery meta upgraded `formalized` → `verified`; sections /
+theorem counts / line count synced to the new file.
+
+The full self-contained SSA proof (marginals, chain rule, subadditivity, the KL
+telescoping argument) is preserved in the parent `Proofs/ShannonEntropy.lean`, so
+no mathematical content is lost.
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — resolved. PR opened.

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lieb & Ruskai (1973)",
     "date": "1973",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "information-theory",
       "analysis",
@@ -16,10 +16,10 @@
       "verified"
     ],
     "proofRepoPath": "Proofs/ShannonEntropySSA.lean",
-    "badge": "original",
+    "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All theorems proved from Mathlib primitives. Strong subadditivity proved via conditional KL divergence ≥ 0 (kl_term_bound applied to the conditional independence distribution q(x,y,z) = pXY(x,y)·pYZ(y,z)/pY(y)).",
+    "assumptions": "None. The strong-subadditivity inequality H(X,Y,Z)+H(Y) ≤ H(X,Y)+H(Y,Z) is proved axiom-free (0 sorries) in the parent file Proofs/ShannonEntropy.lean as InformationTheory.strong_subadditivity (conditional-KL-divergence argument: each term p·log(p/q) ≥ p−q via the Gibbs inequality, block sum telescoping to 0). This file re-exports that theorem and derives its two three-variable corollaries (conditioning_reduces_entropy_general, conditional_mi_nonneg) by linear rearrangement. #print axioms reports only [propext, Classical.choice, Quot.sound].",
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_nonneg",
@@ -38,20 +38,18 @@
       }
     ],
     "originalContributions": [
-      "Three-variable marginal distributions: marginalXY, marginalYZ, marginalY_3 with proved properties",
-      "Entropy chain rule statement: H(X,Y) = H(Y) + H(X|Y)",
-      "Strong subadditivity statement with proof strategy via conditional KL divergence",
-      "Conditioning reduces entropy (general): H(X|Y,Z) ≤ H(X|Y) from SSA",
-      "Conditional MI non-negativity: I(X;Z|Y) ≥ 0 from SSA"
+      "Three-variable 'conditioning reduces entropy' H(X|Y,Z) ≤ H(X|Y) as a corollary of SSA",
+      "Non-negativity of conditional mutual information I(X;Z|Y) ≥ 0"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 526,
-    "theoremCount": 11,
-    "definitionCount": 6,
+    "lineCount": 92,
+    "theoremCount": 3,
+    "definitionCount": 0,
     "additionalFiles": [
       "Proofs/ShannonEntropySSAAristotle.lean"
     ],
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "verifiedAt": "2026-07-07"
   },
   "overview": {
     "historicalContext": "Strong subadditivity (SSA) of entropy was conjectured by Lanford and Robinson in 1968 (Comm. Math. Phys. 9, 327–338) in the context of quantum statistical mechanics, where they identified it as the missing inequality required for the existence of the thermodynamic limit of mean entropy. After five years of intensive effort by mathematical physicists, Lieb and Ruskai (1973, J. Math. Phys. 14, 1938–1941) proved the quantum (von Neumann) version using Lieb's deep concavity theorem on operator-monotone functions of two matrix arguments. The classical (Shannon) case, formalized here, is comparatively elementary: it follows from the non-negativity of KL divergence applied per-slice to the conditional distribution p(x,z|y), with the y-average preserving non-negativity. SSA is equivalent to the non-negativity of conditional mutual information I(X;Z|Y) ≥ 0, and to the statement that conditioning on more variables can only reduce entropy: H(X|Y,Z) ≤ H(X|Y) — the data-processing intuition for entropy. Pippenger (2003) proved that for three random variables every valid linear entropy inequality is a non-negative combination of submodularity (SSA) and non-negativity, classifying the three-variable entropy cone. The four-variable analogue is famously NOT a finitely generated cone: Zhang and Yeung (1998) discovered the first 'non-Shannon-type' inequality, opening the modern study of the (still incompletely understood) entropy cone for n ≥ 4.",
@@ -78,59 +76,27 @@
   },
   "sections": [
     {
-      "id": "header",
       "title": "Module Header & Overview",
+      "id": "header",
       "startLine": 1,
-      "endLine": 45,
-      "summary": "Imports (Mathlib and the parent ShannonEntropy.lean) and the module docstring stating the SSA inequality H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z), its three equivalent formulations (conditional MI non-negativity, conditioning reduces entropy, conditional subadditivity), the per-slice KL proof strategy, the Lanford-Robinson/Lieb-Ruskai history, and the dependency note that only ShannonEntropy.lean infrastructure is used. Opens the InformationTheory namespace and the Finset namespace.",
+      "endLine": 52,
+      "summary": "Module docstring and imports (Mathlib and the parent Proofs/ShannonEntropy.lean). States the strong-subadditivity inequality H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z), its conditional-mutual-information reading I(X;Z|Y) ≥ 0, and the conditional-KL proof strategy (each term p·log(p/q) ≥ p − q via the Gibbs inequality, block sum telescoping to 0). Records that the full self-contained proof — the marginal operators, their distribution laws, the entropy chain rule, subadditivity, and strong subadditivity — lives in the parent file as InformationTheory.strong_subadditivity (0 sorries, 0 axioms), and that this file reuses it directly to stay in the axiom-free, collision-free state. Opens namespace InformationTheory.SSA.",
       "mathContext": "$H(X,Y,Z) + H(Y) \\leq H(X,Y) + H(Y,Z)$, equivalently $I(X;Z|Y) = H(X|Y) - H(X|Y,Z) \\geq 0$ and $H(X|Y,Z) \\leq H(X|Y)$."
     },
     {
-      "id": "marginals",
-      "title": "Part I — Three-Variable Marginal Distributions",
-      "startLine": 46,
-      "endLine": 72,
-      "summary": "Reproduces shannonEntropy' for self-containment and defines the three marginalization operators marginalXY, marginalYZ, and marginalY_3 that collapse a 3-variable joint distribution onto its 2-variable and 1-variable marginals by summing out the omitted coordinates.",
-      "mathContext": "$p_{XY}(x,y) = \\sum_z p(x,y,z)$, $p_{YZ}(y,z) = \\sum_x p(x,y,z)$, $p_Y(y) = \\sum_x \\sum_z p(x,y,z)$"
-    },
-    {
-      "id": "properties",
-      "title": "Part II — Marginal Properties",
-      "startLine": 73,
-      "endLine": 139,
-      "summary": "Proves the six lemmas establishing that each marginal is a valid probability distribution: marginalXY/marginalYZ/marginalY_3_nonneg (non-negativity is preserved via Finset.sum_nonneg) and marginalXY/marginalYZ/marginalY_3_sum (each marginal sums to 1, proved by rewriting the iterated sum as a single sum over the product type with Fintype.sum_prod_type and Finset.sum_comm).",
-      "mathContext": "If $p \\geq 0$ and $\\sum p = 1$, then each marginal distribution is also non-negative and sums to 1: $\\sum_{x,y} p_{XY}(x,y) = \\sum_{y,z} p_{YZ}(y,z) = \\sum_y p_Y(y) = 1$."
-    },
-    {
-      "id": "chain-rule",
-      "title": "Part III — Entropy Chain Rule for Pairs",
-      "startLine": 140,
-      "endLine": 243,
-      "summary": "Defines the Y-marginal marginalSnd and the conditional entropy condEntropy, then fully proves (0 sorries) the entropy chain rule H(X,Y) = H(Y) + H(X|Y). The proof splits log p(x,y) = log(p(x,y)/p_Y(y)) + log p_Y(y) term-by-term (hterm), telescopes the marginal term over x (hmarg via Finset.sum_mul), converts the product-type sum to a nested sum, and reassembles with ring.",
-      "mathContext": "$H(X,Y) = H(Y) + H(X|Y)$ where $H(X|Y) = -\\sum_{x,y} p(x,y) \\log \\frac{p(x,y)}{p_Y(y)}$; the key identity is $\\log p(x,y) = \\log\\frac{p(x,y)}{p_Y(y)} + \\log p_Y(y)$."
-    },
-    {
-      "id": "subadditivity",
-      "title": "Part IV — Subadditivity from the Chain Rule",
-      "startLine": 244,
-      "endLine": 270,
-      "summary": "Proves subadditivity H(X,Y) ≤ H(X) + H(Y) by rewriting the joint entropy via entropy_chain_rule and bounding the conditional entropy by the marginal entropy using conditioning_reduces_entropy (imported from ShannonEntropy.lean), closing with linarith.",
-      "mathContext": "$H(X,Y) = H(Y) + H(X|Y) \\leq H(Y) + H(X) = H(X) + H(Y)$, using $H(X|Y) \\leq H(X)$."
-    },
-    {
+      "title": "Strong Subadditivity",
       "id": "ssa",
-      "title": "Part V — Strong Subadditivity",
-      "startLine": 271,
-      "endLine": 489,
-      "summary": "The technical core: a complete (0-sorry) proof of strong subadditivity H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z). A local copy of the KL bound kl_tb (p·log(p/q) ≥ p − q) is established, then four telescoping identities (htele and its XY/YZ/Y specializations) rewrite each marginal entropy as a nested sum, and a term-splitting identity (hterm) decomposes log p(x,y,z) into the conditional-MI term plus the three marginal log terms minus the Y-marginal term. Part 1 builds the conditional-independence distribution q(x,y,z) = p_{XY}·p_{YZ}/p_Y, proves it sums to 1, and applies kl_tb per-slice to show the conditional mutual information is ≥ 0 (h_cmi). Part 2 unfolds all entropies, normalizes every sum to nested form, applies the telescoping and splitting identities, and closes with linarith [h_cmi].",
+      "startLine": 54,
+      "endLine": 66,
+      "summary": "The headline theorem strong_subadditivity: H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z), re-exported from the parent's InformationTheory.strong_subadditivity. The parent proof establishes a local KL bound p·log(p/q) ≥ p − q, rewrites each marginal entropy as a nested sum via four telescoping identities, and sums the per-slice divergences I(X;Z|Y) = Σ_y p(y)·D(p(x,z|y) ‖ p(x|y)p(z|y)) ≥ 0.",
       "mathContext": "$H(X,Y,Z) + H(Y) \\leq H(X,Y) + H(Y,Z)$, equivalently $I(X;Z|Y) = \\sum_y p(y)\\, D\\!\\left(p(x,z\\mid y)\\,\\|\\,p(x\\mid y)p(z\\mid y)\\right) \\geq 0$, each term non-negative by $p\\log(p/q) \\geq p - q$."
     },
     {
+      "title": "Consequences of SSA",
       "id": "consequences",
-      "title": "Part VI — Consequences of SSA",
-      "startLine": 490,
-      "endLine": 526,
-      "summary": "Derives two corollaries directly from strong_subadditivity by linear rearrangement (linarith): conditioning_reduces_entropy_general (H(X|Y,Z) ≤ H(X|Y), i.e. extra conditioning cannot increase entropy) and conditional_mi_nonneg (I(X;Z|Y) ≥ 0, the conditional mutual information is non-negative). Closes the InformationTheory namespace.",
+      "startLine": 68,
+      "endLine": 92,
+      "summary": "Two three-variable corollaries derived from strong subadditivity by linear rearrangement (linarith), not present in the parent file: conditioning_reduces_entropy_general (H(X|Y,Z) ≤ H(X|Y), extra conditioning cannot increase entropy) and conditional_mi_nonneg (I(X;Z|Y) ≥ 0, the conditional mutual information is non-negative).",
       "mathContext": "SSA implies (1) $H(X|Y,Z) \\leq H(X|Y)$ and (2) $I(X;Z|Y) = H(X,Y) + H(Y,Z) - H(X,Y,Z) - H(Y) \\geq 0$."
     }
   ],
@@ -198,11 +164,11 @@
     "opens": [
       "Finset"
     ],
-    "namespace": "InformationTheory",
-    "lineCount": 526,
+    "namespace": "InformationTheory.SSA",
+    "lineCount": 92,
     "axiomCount": 0,
-    "theoremCount": 11,
-    "definitionCount": 6,
+    "theoremCount": 3,
+    "definitionCount": 0,
     "path": "Proofs/ShannonEntropySSA.lean",
     "sorries": 0,
     "additionalFiles": [
@@ -211,17 +177,24 @@
   },
   "mainTheorems": [
     {
-      "name": "entropy_chain_rule",
-      "type": "core",
-      "description": "Entropy chain rule: H(X,Y) = H(Y) + H(X|Y)",
-      "leanType": "shannonEntropy' pXY = shannonEntropy' (marginalSnd pXY) + condEntropy pXY"
-    },
-    {
       "name": "strong_subadditivity",
       "type": "core",
-      "description": "SSA: H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z)",
-      "leanType": "shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ) ≤ shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)"
+      "description": "Strong subadditivity of Shannon entropy: H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z)",
+      "leanType": "shannonEntropy pXYZ + shannonEntropy (marginalY pXYZ) ≤ shannonEntropy (marginalXY pXYZ) + shannonEntropy (marginalYZ pXYZ)"
+    },
+    {
+      "name": "conditioning_reduces_entropy_general",
+      "type": "corollary",
+      "description": "Conditioning reduces entropy: H(X | Y,Z) ≤ H(X | Y)",
+      "leanType": "shannonEntropy pXYZ - shannonEntropy (marginalYZ pXYZ) ≤ shannonEntropy (marginalXY pXYZ) - shannonEntropy (marginalY pXYZ)"
+    },
+    {
+      "name": "conditional_mi_nonneg",
+      "type": "corollary",
+      "description": "Conditional mutual information is non-negative: I(X;Z | Y) ≥ 0",
+      "leanType": "shannonEntropy (marginalXY pXYZ) + shannonEntropy (marginalYZ pXYZ) - shannonEntropy pXYZ - shannonEntropy (marginalY pXYZ) ≥ 0"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "status": "verified"
 }


### PR DESCRIPTION
## Summary

`Proofs/ShannonEntropySSA.lean` (gallery entry **shannon-entropy-oq-03**, "Strong Subadditivity of Shannon Entropy") was a **masked broken build** — merged without Lean CI (math PRs bypass it) and claiming `status: formalized, sorries: 0`, but it **did not compile**.

Building it surfaced ~11 errors, root-caused to a self-collision:

- The file redeclared `marginalXY`, `marginalYZ`, `entropy_chain_rule`, `subadditivity`, `strong_subadditivity` in namespace `InformationTheory` **while also `import`ing the parent `Proofs/ShannonEntropy.lean`, which already declares all of them** → 5× `... has already been declared`.
- Those cascaded into a calc parse break (L306) and `linarith` failures (L511/524) once `strong_subadditivity` failed to elaborate.

The parent `ShannonEntropy.lean` already contains a **complete, axiom-free, building** proof of `strong_subadditivity` (0 sorries), so the duplicated infrastructure was redundant.

## Fix

Replaced the 526-line broken duplicate with a 92-line file (new namespace `InformationTheory.SSA`, no collisions) that reuses the parent's verified proof and adds the two **genuinely-new three-variable corollaries** (absent from the parent):

| Theorem | Statement |
|---|---|
| `strong_subadditivity` (re-export) | `H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z)` |
| `conditioning_reduces_entropy_general` | `H(X\|Y,Z) ≤ H(X\|Y)` |
| `conditional_mi_nonneg` | `I(X;Z\|Y) ≥ 0` |

The full self-contained SSA development (marginal laws, chain rule, KL telescoping) is **preserved in the parent `ShannonEntropy.lean`** — no mathematical content lost.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ShannonEntropySSA` → ✔ **[7744/7744] built** (0 sorries; inherits the parent's axiom-free proof — foundational trio `[propext, Classical.choice, Quot.sound]` only, no `native_decide`).
- Gallery `meta.json` upgraded `formalized` → `verified`; `sections`, `mainTheorems`, `theoremCount` (11→3), `definitionCount` (6→0), `lineCount` (526→92), and `namespace` synced to the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)