### PR TITLE
Enrich Cantor's Theorem OQ-05: annotate module header

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-05/annotations.json
+++ b/src/data/proofs/cantors-theorem-oq-05/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "ann-cantor-oq05-header",
+    "proofId": "cantors-theorem-oq-05",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "context",
+    "title": "Open Question, Approach, and the GCH Subtlety",
+    "content": "The module docstring frames the entry as a *structural reading* of Cantor's theorem rather than a new diagonal construction. The base entry and OQ-03 prove a < 2^a via Cantor/König/Lawvere diagonalisation; here that inequality is imported as Cardinal.cantor and its global consequences are extracted: ∃ b, a < b, ¬ IsMax a, and the strictly monotone iterated-powerset tower. The header flags the one genuine pitfall up front — the map c ↦ 2^c is NOT provably strictly monotone on cardinals (whether a < b → 2^a < 2^b is the GCH-adjacent question, independent of ZFC), so the tower's ascent must be sourced from a fresh application of Cantor at each rung, exactly the consecutive comparisons strictMono_nat_of_lt_succ consumes.",
+    "mathContext": "$$a < 2^a \\;\\Rightarrow\\; \\big(\\forall a,\\exists b,\\ a<b\\big)\\ \\wedge\\ \\neg\\,\\mathrm{IsMax}\\,a\\ \\wedge\\ \\mathrm{StrictMono}\\,(\\mathrm{powTower}\\,a).$$ The global rule $a<b\\Rightarrow 2^a<2^b$ is independent of ZFC and is deliberately avoided.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Cantor's theorem",
+      "generalized continuum hypothesis",
+      "independence from ZFC",
+      "beth numbers",
+      "cumulative hierarchy"
+    ],
+    "prerequisites": [
+      "Cantor's inequality",
+      "GCH and independence results",
+      "cardinal order"
+    ]
+  },
+  {
     "id": "ann-cantor-oq05-engine",
     "proofId": "cantors-theorem-oq-05",
     "range": { "startLine": 32, "endLine": 35 },


### PR DESCRIPTION
Enrichment pass for `cantors-theorem-oq-05` (No Greatest Cardinal / powerset tower).

The entry was already strong (rich meta, 4 keyInsights, sections with mathContext, cross-references, references) but had one genuine annotation-coverage gap: every *code* section carried an annotation while the **module header (lines 1–30)** — which states the open question, the take-Cantor-as-input approach, and the crucial GCH-independence subtlety — had none.

**Change:** added one `context` annotation covering lines 1–30. It frames the structural-reading approach and surfaces why the tower's monotonicity must come from per-rung `Cardinal.cantor` rather than the ZFC-independent `a < b → 2^a < 2^b`.

Non-bloating: annotations 7 → 8; meta.json untouched (10.4 KB). JSON validated by the gallery enrichment build.