### PR TITLE
audit(erdos-490): reconcile stale '3 axioms' prose to 2

### DIFF
--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -70,7 +70,7 @@
       "productRatio, LimitQuestion: open limit formalization",
       "IsMultiplicativeSidon: A = B special case",
       "multiplicativeEnergy: counting quadruples a₁b₁ = a₂b₂",
-      "bound_is_optimal: matching lower bound (proved from the 3 axioms, 0 sorries)",
+      "bound_is_optimal: matching lower bound (proved from the 2 axioms, 0 sorries)",
       "optimal_has_distinct_products: PROVED 0-axiom (formerly an axiom) — the optimal construction A=[1,N/2], B=primes in (N/2,N] has distinct products, derived from optimal_works_because_primes via the ProductMapInjective↔HasDistinctProducts bridge",
       "hasDistinctProducts_iff_injOn: HasDistinctProducts A B ↔ injectivity of (a,b)↦a·b on A×ˢB (via Finset.card_image_iff)",
       "productMapInjective_iff_hasDistinctProducts: the two distinctness notions agree",
@@ -185,10 +185,10 @@
     {
       "id": "summary",
       "title": "Summary and Optimality",
-      "summary": "erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 3 axioms, 0 sorries)",
+      "summary": "erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 2 axioms, 0 sorries)",
       "startLine": 228,
       "endLine": 282,
-      "mathContext": "Bound: erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 3 axioms, 0 sorries)"
+      "mathContext": "Bound: erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 2 axioms, 0 sorries)"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity fix

**Proof**: erdos-490
**Problem**: Three prose fields claim "proved from the 3 axioms" while the file has 2 axioms.

## Evidence

`proofs/Proofs/Erdos490Problem.lean` has exactly **2** `axiom` declarations:
- `szemeredi_theorem` (L141)
- `chebyshev_theta_upper_half_lower_bound` (L191)

`meta.axiomCount = 2` and the primary `assumptions` field correctly say "2 axioms". But commit #31625 (which eliminated `optimal_has_distinct_products`, 3→2) left three downstream prose fields stale:
- `meta.originalContributions[18]`
- `sections[9].summary`
- `sections[9].mathContext`

all reading "proved from the 3 axioms, 0 sorries".

## Fix

Changed the three "the 3 axioms" → "the 2 axioms". No numeric/status fields touched (already correct). Tracker updated (erdos-490 → issues-fixed).

---
Discovered during gallery integrity re-audit (changed-since-last-audit sweep). Not adding `loom:review-requested` per math-agent policy.