### PR TITLE
feat(janitor): reclaim git-registered worktrees outside .loom/worktrees/

### DIFF
--- a/.lean/roles/aristotle-agent.md
+++ b/.lean/roles/aristotle-agent.md
@@ -16,7 +16,7 @@ You receive these environment variables:
 - `ARISTOTLE_INTERVAL` - Check interval in minutes (default: 30)
 - `ARISTOTLE_API_KEY` - API key for Aristotle (or loaded from ~/.aristotle_key)
 
-You work in an **isolated worktree** at `.loom/worktrees/aristotle` with branch `feature/aristotle-integrations`.
+You work in an **isolated worktree** at `.loom/worktrees/aristotle` with branch `feature/aristotle-integrations`. That is the sanctioned location; the backstop janitor (`scripts/clean-branches.sh`) automatically reclaims any stray `$HOME`/`/private/tmp` worktree once it is clean and stale, while always preserving dirty or unpushed ones.
 
 ## Logging
 

--- a/.lean/roles/enricher.md
+++ b/.lean/roles/enricher.md
@@ -61,6 +61,12 @@ You receive these environment variables:
 
 You work in an **isolated worktree** with your own branch (e.g., `feature/enricher-1`).
 
+**IMPORTANT:** The sanctioned worktree location is `$REPO_ROOT/.loom/worktrees/enricher-$N`. Always work there — the create path preserves in-flight work, so there is no need to make defensive worktrees under `$HOME` or `/tmp`. Any stray worktree you do leave outside `.loom/worktrees/` is automatically reclaimed by the backstop janitor (`scripts/clean-branches.sh`) once it is clean and stale; dirty or unpushed worktrees are always preserved.
+
+```bash
+cd $REPO_ROOT/.loom/worktrees/enricher-$N
+```
+
 ## Logging
 
 Log your actions for observability. After each major step, append to your log:

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -168,6 +168,8 @@ Knowledge score: 8 (MODERATE)
 cd $REPO_ROOT/.loom/worktrees/researcher-$N
 ```
 
+`.loom/worktrees/researcher-$N` is the sanctioned location — the create path preserves in-flight work, so avoid making defensive worktrees under `$HOME` or `/tmp`. The backstop janitor (`scripts/clean-branches.sh`) automatically reclaims any stray `$HOME`/`/private/tmp` worktree once it is clean and stale; dirty or unpushed worktrees are always preserved.
+
 If no problems are available, wait 5 minutes and retry.
 
 ## Step 3: Research the Problem

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -3,7 +3,8 @@
 # clean-branches.sh - Comprehensive branch and worktree cleanup
 #
 # Cleans ALL stale local branches (not just agent-specific patterns) by checking
-# GitHub PR status. Also cleans orphaned worktrees in .claude/ and .loom/.
+# GitHub PR status. Also cleans orphaned worktrees in .claude/ and .loom/, plus
+# git-registered worktrees outside those roots (e.g. loose dirs under $HOME).
 #
 # Usage: ./scripts/clean-branches.sh [options]
 #
@@ -127,6 +128,13 @@ Worktree cleanup:
     active owning process, AND its branch is merged/closed/gone on origin
     OR its mtime exceeds WORKTREE_MAX_AGE_DAYS (default 30). Preserved
     otherwise.
+  - git-registered worktrees OUTSIDE .loom/worktrees/ and .claude/worktrees/
+    (e.g. loose dirs under \$HOME or /private/tmp created during data-loss
+    incidents): discovered via 'git worktree list' (never by walking \$HOME),
+    verified to belong to THIS repo, then reclaimed under the SAME guards as
+    the scratch pass. Dirty/unpushed/active/open-PR ones are preserved and
+    reported. Recovery bundles/snapshots under \$HOME are not git worktrees,
+    so they are never touched.
   - git worktree prune (clean orphaned references)
 
 Environment:
@@ -785,8 +793,6 @@ echo ""
 #   upstream present + stale             => REMOVE   (reason: stale)
 #   upstream present + recent            => PRESERVE (unmerged, recent)
 
-header "  Checking .loom/worktrees/* (scratch)..."
-
 # Resolve the current checkout's worktree path so we never remove ourselves.
 current_wt_path="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
 
@@ -796,8 +802,186 @@ locked_wt_paths=$(git worktree list --porcelain 2>/dev/null \
 
 is_locked_wt() {
     local path="$1"
-    [[ -n "$locked_wt_paths" ]] && grep -qxF "$path" <<< "$locked_wt_paths"
+    local real
+    real="$(cd "$path" 2>/dev/null && pwd -P || echo "$path")"
+    [[ -z "$locked_wt_paths" ]] && return 1
+    local locked_path locked_real
+    while IFS= read -r locked_path; do
+        [[ -z "$locked_path" ]] && continue
+        locked_real="$(cd "$locked_path" 2>/dev/null && pwd -P || echo "$locked_path")"
+        [[ "$locked_real" == "$real" || "$locked_path" == "$path" ]] && return 0
+    done <<< "$locked_wt_paths"
+    return 1
 }
+
+# reclaim_worktree <worktree_path> <display_label>
+#
+# Shared guard + reclaim-eligibility + removal/report logic for a single
+# worktree. Used by BOTH the .loom/worktrees/* scratch pass and the new
+# "git-registered worktrees outside .loom/worktrees/" pass so the two share one
+# decision contract (mirrors the guards 1-5 in scripts/lib/worktree-cleanup.sh).
+#
+# <display_label> is the human-facing name shown in log lines (e.g.
+# ".loom/worktrees/enricher-1" or "$HOME/lg-r1-wt").
+#
+# Structural guards (a worktree is PRESERVED if ANY hold):
+#   - it is the current checkout
+#   - it is locked (`git worktree list` marks it `locked`)
+#   - it has an active owning process (`pgrep` on the worktree path)
+#   - it has a dirty working tree (`git status --porcelain` non-empty)
+#   - it carries commits on no remote (upstream set: `@{u}..HEAD` non-empty;
+#     no upstream: HEAD reachable from no remote ref)
+#   - its branch has an OPEN PR
+# Only after every guard passes is reclaim-eligibility checked: the branch's PR
+# is MERGED/CLOSED, OR its upstream branch is gone on origin, OR its mtime
+# exceeds WORKTREE_MAX_AGE_DAYS. Anything not eligible is preserved as
+# "(unmerged, recent)". Honors DRY_RUN / FORCE / interactive modes and updates
+# the worktrees_removed / worktrees_preserved counters in the caller's scope.
+reclaim_worktree() {
+    local wt_path="$1"
+    local label="$2"
+    local wt_real
+    wt_real="$(cd "$wt_path" 2>/dev/null && pwd -P || echo "$wt_path")"
+
+    # GUARD: never remove the current checkout.
+    if [[ -n "$current_wt_path" && "$wt_real" == "$(cd "$current_wt_path" 2>/dev/null && pwd -P || echo "$current_wt_path")" ]]; then
+        ((worktrees_preserved++)) || true
+        info "    Preserving: $label (current checkout)"
+        return 0
+    fi
+
+    # GUARD: never remove a locked worktree.
+    if is_locked_wt "$wt_path"; then
+        ((worktrees_preserved++)) || true
+        info "    Preserving: $label (locked)"
+        return 0
+    fi
+
+    # GUARD: never remove a worktree with an active owning process.
+    if pgrep -f "$wt_path" &>/dev/null; then
+        ((worktrees_preserved++)) || true
+        info "    Preserving: $label (active process)"
+        return 0
+    fi
+
+    # GUARD: never remove a worktree with a dirty working tree.
+    if [[ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]]; then
+        ((worktrees_preserved++)) || true
+        info "    Preserving: $label (uncommitted changes)"
+        return 0
+    fi
+
+    # GUARD: never remove a worktree carrying commits that exist on no
+    # remote. Two cases must both be covered:
+    #   - upstream IS configured: preserve if `@{u}..HEAD` is non-empty
+    #     (real commits ahead of the tracked remote branch).
+    #   - upstream is NOT configured (@{u} unresolved): "no upstream" is
+    #     NOT "nothing to lose". A never-pushed branch can carry local-only
+    #     exploratory commits. Preserve unless HEAD is reachable from some
+    #     remote ref (`git branch -r --contains HEAD` non-empty ⇒ backed up
+    #     on a remote ⇒ safe). If no remote branch contains HEAD, the
+    #     commits are unbacked ⇒ preserve.
+    if git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null; then
+        local unpushed
+        unpushed=$(git -C "$wt_path" log --oneline '@{u}..HEAD' 2>/dev/null || echo "")
+        if [[ -n "$unpushed" ]]; then
+            ((worktrees_preserved++)) || true
+            info "    Preserving: $label (unpushed commits)"
+            return 0
+        fi
+    else
+        # No upstream configured: is HEAD backed up on any remote ref?
+        # Trailing `|| true` keeps `set -e -o pipefail` from aborting when the
+        # branch is on NO remote ref: `git branch -r --contains` is then empty
+        # and `grep -v` exits 1 (the "preserve unpushed" case we must handle,
+        # not crash on). This is the common state for out-of-tree worktrees.
+        local remote_containing
+        remote_containing=$(git -C "$wt_path" branch -r --contains HEAD 2>/dev/null \
+            | grep -v '\->' | sed 's/^[[:space:]]*//' | head -n 1 || true)
+        if [[ -z "$remote_containing" ]]; then
+            ((worktrees_preserved++)) || true
+            info "    Preserving: $label (no upstream; HEAD not on any remote)"
+            return 0
+        fi
+    fi
+
+    # Determine reclaim eligibility. Removed only if at least one of:
+    #   (a) the branch's PR is MERGED/CLOSED,
+    #   (b) the upstream branch is gone on origin, or
+    #   (c) the worktree mtime exceeds WORKTREE_MAX_AGE_DAYS.
+    local wt_branch reclaim_reason
+    wt_branch=$(git -C "$wt_path" symbolic-ref --short HEAD 2>/dev/null || echo "")
+    reclaim_reason=""
+
+    if [[ -n "$wt_branch" ]]; then
+        local pr_status
+        pr_status=$(get_pr_status "$wt_branch")
+        # GUARD: an OPEN PR must ALWAYS be preserved, regardless of mtime.
+        # Without this, a long-lived feature branch under active review
+        # whose dir mtime drifts past WORKTREE_MAX_AGE_DAYS would fall
+        # through to path (c) and be removed. Preserve before any mtime
+        # check.
+        if [[ "$pr_status" == "OPEN" ]]; then
+            ((worktrees_preserved++)) || true
+            info "    Preserving: $label (open PR)"
+            return 0
+        fi
+        if [[ "$pr_status" == "MERGED" || "$pr_status" == "CLOSED" ]]; then
+            reclaim_reason="PR $pr_status"
+        fi
+    fi
+
+    # (b) Upstream gone on origin: branch tracks origin but the remote ref
+    # no longer exists (a fetch --prune would drop it).
+    if [[ -z "$reclaim_reason" && -n "$wt_branch" ]]; then
+        local upstream
+        upstream=$(git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+        if [[ -n "$upstream" ]] && ! git -C "$wt_path" rev-parse --verify --quiet "refs/remotes/$upstream" &>/dev/null; then
+            reclaim_reason="upstream gone on origin"
+        fi
+    fi
+
+    # (c) Stale by mtime.
+    if [[ -z "$reclaim_reason" ]]; then
+        local now_epoch wt_mtime age_days
+        now_epoch=$(date +%s)
+        wt_mtime=$(stat -f %m "$wt_path" 2>/dev/null || stat -c %Y "$wt_path" 2>/dev/null || echo "$now_epoch")
+        age_days=$(( (now_epoch - wt_mtime) / 86400 ))
+        if [[ "$age_days" -gt "$WORKTREE_MAX_AGE_DAYS" ]]; then
+            reclaim_reason="stale ${age_days}d > ${WORKTREE_MAX_AGE_DAYS}d"
+        fi
+    fi
+
+    if [[ -z "$reclaim_reason" ]]; then
+        ((worktrees_preserved++)) || true
+        info "    Preserving: $label (unmerged, recent)"
+        return 0
+    fi
+
+    ((worktrees_removed++)) || true
+    if [[ "$DRY_RUN" == true ]]; then
+        info "    [REMOVE] $label ($reclaim_reason)"
+    elif [[ "$FORCE" == true ]]; then
+        git worktree remove "$wt_path" --force 2>/dev/null && \
+            success "    Removed: $label ($reclaim_reason)" || \
+            { warning "    Fallback: rm -rf"; rm -rf "$wt_path"; git worktree prune 2>/dev/null || true; }
+    else
+        echo -e "    ${YELLOW}$label${NC} ($reclaim_reason)"
+        read -r -p "      Remove? [Y/n] " -n 1 CONFIRM
+        echo ""
+        if [[ ! $CONFIRM =~ ^[Nn]$ ]]; then
+            git worktree remove "$wt_path" --force 2>/dev/null && \
+                success "    Removed: $label" || \
+                { warning "    Fallback: rm -rf"; rm -rf "$wt_path"; git worktree prune 2>/dev/null || true; }
+        else
+            ((worktrees_removed--)) || true
+            ((worktrees_preserved++)) || true
+        fi
+    fi
+    return 0
+}
+
+header "  Checking .loom/worktrees/* (scratch)..."
 
 if [[ -d "$REPO_ROOT/.loom/worktrees" ]]; then
     for wt_dir in "$REPO_ROOT/.loom/worktrees"/*/; do
@@ -809,138 +993,86 @@ if [[ -d "$REPO_ROOT/.loom/worktrees" ]]; then
             issue-*|temp-*) continue ;;
         esac
 
-        # Normalize trailing slash for path comparisons.
-        wt_path="${wt_dir%/}"
-        wt_real="$(cd "$wt_path" 2>/dev/null && pwd -P || echo "$wt_path")"
-
-        # GUARD: never remove the current checkout.
-        if [[ -n "$current_wt_path" && "$wt_real" == "$(cd "$current_wt_path" 2>/dev/null && pwd -P || echo "$current_wt_path")" ]]; then
-            ((worktrees_preserved++)) || true
-            info "    Preserving: .loom/worktrees/$wt_name (current checkout)"
-            continue
-        fi
-
-        # GUARD: never remove a locked worktree.
-        if is_locked_wt "$wt_path"; then
-            ((worktrees_preserved++)) || true
-            info "    Preserving: .loom/worktrees/$wt_name (locked)"
-            continue
-        fi
-
-        # GUARD: never remove a worktree with an active owning process.
-        if pgrep -f "$wt_path" &>/dev/null; then
-            ((worktrees_preserved++)) || true
-            info "    Preserving: .loom/worktrees/$wt_name (active process)"
-            continue
-        fi
-
-        # GUARD: never remove a worktree with a dirty working tree.
-        if [[ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]]; then
-            ((worktrees_preserved++)) || true
-            info "    Preserving: .loom/worktrees/$wt_name (uncommitted changes)"
-            continue
-        fi
-
-        # GUARD: never remove a worktree carrying commits that exist on no
-        # remote. Two cases must both be covered:
-        #   - upstream IS configured: preserve if `@{u}..HEAD` is non-empty
-        #     (real commits ahead of the tracked remote branch).
-        #   - upstream is NOT configured (@{u} unresolved): "no upstream" is
-        #     NOT "nothing to lose". A never-pushed branch can carry local-only
-        #     exploratory commits. Preserve unless HEAD is reachable from some
-        #     remote ref (`git branch -r --contains HEAD` non-empty ⇒ backed up
-        #     on a remote ⇒ safe). If no remote branch contains HEAD, the
-        #     commits are unbacked ⇒ preserve.
-        if git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null; then
-            unpushed=$(git -C "$wt_path" log --oneline '@{u}..HEAD' 2>/dev/null || echo "")
-            if [[ -n "$unpushed" ]]; then
-                ((worktrees_preserved++)) || true
-                info "    Preserving: .loom/worktrees/$wt_name (unpushed commits)"
-                continue
-            fi
-        else
-            # No upstream configured: is HEAD backed up on any remote ref?
-            remote_containing=$(git -C "$wt_path" branch -r --contains HEAD 2>/dev/null \
-                | grep -v '\->' | sed 's/^[[:space:]]*//' | head -n 1)
-            if [[ -z "$remote_containing" ]]; then
-                ((worktrees_preserved++)) || true
-                info "    Preserving: .loom/worktrees/$wt_name (no upstream; HEAD not on any remote)"
-                continue
-            fi
-        fi
-
-        # Determine reclaim eligibility. Removed only if at least one of:
-        #   (a) the branch's PR is MERGED/CLOSED,
-        #   (b) the upstream branch is gone on origin, or
-        #   (c) the worktree mtime exceeds WORKTREE_MAX_AGE_DAYS.
-        wt_branch=$(git -C "$wt_path" symbolic-ref --short HEAD 2>/dev/null || echo "")
-        reclaim_reason=""
-
-        if [[ -n "$wt_branch" ]]; then
-            pr_status=$(get_pr_status "$wt_branch")
-            # GUARD: an OPEN PR must ALWAYS be preserved, regardless of mtime.
-            # Without this, a long-lived feature branch under active review
-            # whose dir mtime drifts past WORKTREE_MAX_AGE_DAYS would fall
-            # through to path (c) and be removed. Preserve before any mtime
-            # check.
-            if [[ "$pr_status" == "OPEN" ]]; then
-                ((worktrees_preserved++)) || true
-                info "    Preserving: .loom/worktrees/$wt_name (open PR)"
-                continue
-            fi
-            if [[ "$pr_status" == "MERGED" || "$pr_status" == "CLOSED" ]]; then
-                reclaim_reason="PR $pr_status"
-            fi
-        fi
-
-        # (b) Upstream gone on origin: branch tracks origin but the remote ref
-        # no longer exists (a fetch --prune would drop it).
-        if [[ -z "$reclaim_reason" && -n "$wt_branch" ]]; then
-            upstream=$(git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
-            if [[ -n "$upstream" ]] && ! git -C "$wt_path" rev-parse --verify --quiet "refs/remotes/$upstream" &>/dev/null; then
-                reclaim_reason="upstream gone on origin"
-            fi
-        fi
-
-        # (c) Stale by mtime.
-        if [[ -z "$reclaim_reason" ]]; then
-            now_epoch=$(date +%s)
-            wt_mtime=$(stat -f %m "$wt_path" 2>/dev/null || stat -c %Y "$wt_path" 2>/dev/null || echo "$now_epoch")
-            age_days=$(( (now_epoch - wt_mtime) / 86400 ))
-            if [[ "$age_days" -gt "$WORKTREE_MAX_AGE_DAYS" ]]; then
-                reclaim_reason="stale ${age_days}d > ${WORKTREE_MAX_AGE_DAYS}d"
-            fi
-        fi
-
-        if [[ -z "$reclaim_reason" ]]; then
-            ((worktrees_preserved++)) || true
-            info "    Preserving: .loom/worktrees/$wt_name (unmerged, recent)"
-            continue
-        fi
-
-        ((worktrees_removed++)) || true
-        if [[ "$DRY_RUN" == true ]]; then
-            info "    [REMOVE] .loom/worktrees/$wt_name ($reclaim_reason)"
-        elif [[ "$FORCE" == true ]]; then
-            git worktree remove "$wt_path" --force 2>/dev/null && \
-                success "    Removed: .loom/worktrees/$wt_name ($reclaim_reason)" || \
-                { warning "    Fallback: rm -rf"; rm -rf "$wt_path"; }
-        else
-            echo -e "    ${YELLOW}.loom/worktrees/$wt_name${NC} ($reclaim_reason)"
-            read -r -p "      Remove? [Y/n] " -n 1 CONFIRM
-            echo ""
-            if [[ ! $CONFIRM =~ ^[Nn]$ ]]; then
-                git worktree remove "$wt_path" --force 2>/dev/null && \
-                    success "    Removed: .loom/worktrees/$wt_name" || \
-                    { warning "    Fallback: rm -rf"; rm -rf "$wt_path"; }
-            else
-                ((worktrees_removed--)) || true
-                ((worktrees_preserved++)) || true
-            fi
-        fi
+        reclaim_worktree "${wt_dir%/}" ".loom/worktrees/$wt_name"
     done
 else
     info "    No .loom/worktrees/ directory found"
+fi
+
+echo ""
+
+# --- git-registered worktrees outside .loom/worktrees/ and .claude/worktrees/ ---
+#
+# Data-loss incidents drove agents to create defensive worktrees OUTSIDE the
+# sanctioned .loom/worktrees/ location — loose directories under $HOME
+# (e.g. ~/lg-r1-wt) and /private/tmp (e.g. /private/tmp/lg-r6-burnside) that no
+# other Phase 4 pass reclaims. This pass discovers them via
+# `git worktree list --porcelain` (the ONLY signal — we NEVER walk $HOME or
+# infer worktree-ness from directory names) and feeds each through the same
+# reclaim_worktree guard/reclaim contract used above.
+#
+# Safety posture (blast radius is larger than .loom/worktrees/, so err toward
+# preserve): only paths git itself reports as worktrees of THIS repository are
+# candidates. Recovery bundles/snapshots (~*.bundle, ~*recover*) are never
+# git-registered worktrees, so they never enter this loop — they are operator-
+# review-only and categorically out of scope. Any candidate whose repo identity
+# can't be confirmed, or where a stat/cd probe fails, is logged-and-skipped, not
+# removed.
+
+header "  Checking git-registered worktrees outside .loom/worktrees/..."
+
+# Canonical repo identity: the common git dir shared by all worktrees of this
+# repo. `git rev-parse --git-common-dir` resolves to <repo>/.git (or the shared
+# gitdir), identical for every worktree that belongs to this repository. We use
+# it to reject worktrees that happen to live under $HOME but belong to some
+# other, unrelated repository.
+repo_common_dir="$(cd "$REPO_ROOT" 2>/dev/null && git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")"
+loom_wt_root="$(cd "$REPO_ROOT/.loom/worktrees" 2>/dev/null && pwd -P || echo "$REPO_ROOT/.loom/worktrees")"
+claude_wt_root="$(cd "$REPO_ROOT/.claude/worktrees" 2>/dev/null && pwd -P || echo "$REPO_ROOT/.claude/worktrees")"
+repo_root_real="$(cd "$REPO_ROOT" 2>/dev/null && pwd -P || echo "$REPO_ROOT")"
+
+# Parse `git worktree list --porcelain` for every registered worktree path.
+out_of_tree_found=0
+while IFS= read -r line; do
+    [[ "$line" != worktree\ * ]] && continue
+    oot_path="${line#worktree }"
+    [[ -z "$oot_path" ]] && continue
+
+    oot_real="$(cd "$oot_path" 2>/dev/null && pwd -P || echo "$oot_path")"
+
+    # Skip the main checkout itself.
+    [[ "$oot_real" == "$repo_root_real" ]] && continue
+
+    # Skip anything already handled by the passes above: entries under
+    # .loom/worktrees/ or .claude/worktrees/. Prefix-match on the real path.
+    [[ "$oot_real" == "$loom_wt_root"/* ]] && continue
+    [[ "$oot_real" == "$claude_wt_root"/* ]] && continue
+
+    # Log-and-skip if the directory is gone (a prune candidate, handled below).
+    if [[ ! -d "$oot_real" ]]; then
+        info "    Skipping (path missing, will prune): $oot_path"
+        continue
+    fi
+
+    # Repo-identity check: confirm this worktree's git-common-dir points back at
+    # THIS repository. Guards against acting on an unrelated repo's worktree that
+    # happens to live under $HOME. On any probe failure, log-and-skip.
+    oot_common_dir="$(cd "$oot_real" 2>/dev/null && git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")"
+    if [[ -z "$oot_common_dir" || -z "$repo_common_dir" ]]; then
+        info "    Skipping (could not resolve git dir): $oot_path"
+        continue
+    fi
+    if [[ "$oot_common_dir" != "$repo_common_dir" ]]; then
+        info "    Skipping (belongs to a different repository): $oot_path"
+        continue
+    fi
+
+    out_of_tree_found=1
+    reclaim_worktree "$oot_real" "$oot_path"
+done < <(git worktree list --porcelain 2>/dev/null)
+
+if [[ "$out_of_tree_found" -eq 0 ]]; then
+    info "    No git-registered worktrees outside .loom/worktrees/ found"
 fi
 
 echo ""

--- a/scripts/lib/worktree-cleanup.sh
+++ b/scripts/lib/worktree-cleanup.sh
@@ -8,6 +8,12 @@
 # EXACT structural safety guards 1-5 from that janitor so the two paths share a
 # single decision contract and a crashed agent mid-edit never loses work.
 #
+# On the janitor side, those guards 1-5 (plus the reclaim-eligibility triggers)
+# live in a single `reclaim_worktree` function shared by both the
+# `.loom/worktrees/*` scratch pass and the pass that reclaims git-registered
+# worktrees located OUTSIDE `.loom/worktrees/` (issue #35257); this helper stays
+# in lock-step with those guards.
+#
 # Guards (a worktree is removed ONLY when ALL hold):
 #   1. Not the current checkout (real-path normalized compare).
 #   2. Not locked (`git worktree list --porcelain` does not flag it `locked`).


### PR DESCRIPTION
## Summary

Item 4 of #35223. Data-loss incidents drove agents to create defensive worktrees outside `.loom/worktrees/` — currently ~20 loose git-registered worktrees under `$HOME` (`lg-r1-wt`, `lg-enricher1-wt`, …) and 4 under `/private/tmp` that no Phase 4 pass reclaims. This extends the backstop janitor (`scripts/clean-branches.sh`) to reclaim those, applying the exact same structural guards the `.loom/worktrees/*` scratch pass already uses, and updates the one role doc (`enricher.md`) that lacked explicit worktree-path guidance.

## Changes

- **Shared `reclaim_worktree()` function**: factored the `.loom/worktrees/*` scratch pass's guard + reclaim-eligibility + removal/report logic into one function, so the existing scratch pass and the new out-of-tree pass share a single decision contract (mirrors guards 1-5 in `scripts/lib/worktree-cleanup.sh`) instead of duplicating ~150 lines.
- **New out-of-tree discovery pass**: parses `git worktree list --porcelain` (the ONLY signal — never walks `$HOME`, never infers worktree-ness from names), skips the main checkout and anything already under `.loom/worktrees/` or `.claude/worktrees/`, and verifies repo identity via `git rev-parse --git-common-dir` before acting. Ambiguous entries (unresolvable git dir, different repo, missing path) are **logged-and-skipped**, never removed.
- **`set -e` hardening**: `git branch -r --contains HEAD | grep -v '\->'` exits 1 when HEAD is on no remote ref (the common state for out-of-tree worktrees), which aborted the loop under `set -euo pipefail`. Added `|| true`. This was a latent bug in the pre-existing scratch pass, only exposed now that out-of-tree worktrees routinely have no upstream.
- **Role docs**: `.lean/roles/enricher.md` now names `.loom/worktrees/enricher-$N` explicitly (it was the only role doc with no path); added a one-line "janitor reclaims stray `$HOME`/`/tmp` worktrees once clean+stale" note to `researcher.md` and `aristotle-agent.md`.
- Recovery bundles/snapshots under `$HOME` are not git-registered worktrees, so they never enter the discovery loop and remain operator-review-only.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Discovers out-of-tree worktrees via `git worktree list` (no hardcoded name patterns), applies guards 1-5, reclaims only clean+stale | ✅ | Real-repo dry-run: only PR-merged/closed clean worktrees marked `[REMOVE]` |
| Dry-run shows what would be reclaimed without acting | ✅ | `--dry-run` prints `[REMOVE]`/`Preserving` with reasons; sandbox confirmed no disk changes |
| Dirty or unpushed out-of-tree worktrees preserved and reported, not deleted | ✅ | Sandbox + real-repo: dirty → `(uncommitted changes)`, unpushed → `(no upstream; HEAD not on any remote)` / `(unpushed commits)` |
| Role docs point agents back to `.loom/worktrees/` | ✅ | `enricher.md` names `.loom/worktrees/enricher-$N`; researcher/aristotle got janitor note |
| Never walks `$HOME`; recovery bundles categorically out of scope | ✅ | Real-repo dry-run: zero mentions of `*.bundle`/`*recover*`/snapshots |
| Different-repo worktree under `$HOME` is skipped, not touched | ✅ | Sandbox: repo-identity check via git-common-dir excludes unrelated worktree |
| Existing `.claude`/`issue-*`/`temp-*`/scratch passes unchanged | ✅ | Out-of-tree pass skips `.loom`/`.claude` entries (no double-handling); scratch pass still reclaims via shared fn |

## Test Plan

- `bash -n scripts/clean-branches.sh` → SYNTAX OK.
- `shellcheck` → no new finding classes (only the pre-existing info-level SC2015 `remove … && success || fallback` idiom used throughout the file).
- **Sandbox repo** (isolated clone with bare origin, 6 out-of-tree worktrees + 1 unrelated-repo worktree + non-worktree bundle/snapshot dirs), run under `set -euo pipefail`:
  - clean+stale → `[REMOVE] (stale)`; clean+recent → `Preserving (unmerged, recent)`
  - dirty → `Preserving (uncommitted changes)` (guard wins over old mtime)
  - unpushed → `Preserving (no upstream; HEAD not on any remote)` (guard wins over old mtime)
  - upstream-gone → `[REMOVE] (upstream gone on origin)`; open-PR (stubbed) → `Preserving (open PR)` despite stale
  - **Actual reclaim** (`FORCE`): removed exactly the 2 eligible worktrees from `git worktree list` + disk; preserved the rest; unrelated-repo worktree and bundle/snapshot dirs untouched.
  - Regression: `.loom/worktrees/mechanic-1` still handled by scratch pass; `.claude/worktrees/agent-9` and `.loom` entries never double-handled by the out-of-tree pass.
- **Real-repo dry-run** (`./scripts/clean-branches.sh --dry-run`, no reclaim mode run against the live fleet): exit 0, all 20 out-of-tree worktrees classified correctly:

```
Preserving: /private/tmp/lg-enricher2-bezout (uncommitted changes)
Preserving: /private/tmp/lg-r6-burnside (unpushed commits)
Preserving: /Users/rwalters/lg-r1-wt (active process)
Preserving: /Users/rwalters/lg-r11-wt (locked)
Preserving: /Users/rwalters/lg-r2-hurwitz-wt (open PR)
[REMOVE]    /Users/rwalters/lg-r4-wt (PR MERGED)      # PR #35278 confirmed MERGED
[REMOVE]    /Users/rwalters/lg-r7-wt (PR MERGED)
[REMOVE]    /Users/rwalters/lg-r8-erdos79 (PR MERGED)
[REMOVE]    /Users/rwalters/lg-r9-wt (PR CLOSED)
... (dirty/unpushed/no-remote worktrees all preserved)
```
  Zero mentions of recovery bundles/snapshots. No active/dirty/unpushed/open-PR worktree is a removal target.

Closes #35257

🤖 Generated with [Claude Code](https://claude.com/claude-code)