### PR TITLE
Enrich Catalan's Identity (Cassini OQ-01-01): complete annotation prerequisites

### DIFF
--- a/src/data/proofs/cassini-identity-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01/annotations.json
@@ -27,7 +27,8 @@
       "Cassini's identity",
       "Fibonacci recurrence",
       "Induction"
-    ]
+    ],
+    "prerequisites": ["Fibonacci recurrence F_{n+2}=F_n+F_{n+1}", "induction on ℕ", "the linear_combination tactic"]
   },
   {
     "id": "ann-addition-formula",
@@ -45,7 +46,8 @@
       "Fibonacci addition formula",
       "linear_combination",
       "Bilinear Fibonacci identities"
-    ]
+    ],
+    "prerequisites": ["Fibonacci addition formula Nat.fib_add", "the Cassini core (cassini_sub)", "polynomial algebra via linear_combination and ring"]
   },
   {
     "id": "ann-classical-form",
@@ -63,7 +65,8 @@
       "Natural-number subtraction",
       "Reindexing",
       "Catalan's identity"
-    ]
+    ],
+    "prerequisites": ["truncated natural-number subtraction (Nat.sub_add_cancel)", "the subtraction-free lemma catalan_aux", "omega for linear ℕ arithmetic"]
   },
   {
     "id": "ann-sanity-checks",
@@ -80,6 +83,7 @@
     "relatedConcepts": [
       "Cassini's identity",
       "Worked examples"
-    ]
+    ],
+    "prerequisites": ["the general theorem catalan", "small Fibonacci values F_1..F_8", "decidable arithmetic (decide / norm_num)"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cassini-identity-oq-01-oq-01` (Catalan's Identity). Added the missing `prerequisites` field to the 4 annotations that lacked it (only the header carried it); all 5 annotations are now uniformly populated with mathContext + significance + relatedConcepts + prerequisites, naming the specific lemmas/tactics each step depends on. Non-bloating: no new annotations, meta.json untouched.