### PR TITLE
Enrich Weyl's Inequalities (cauchy-interlacing-theorem-oq-03): annotate module header

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-weyl-oq03-header",
+    "proofId": "cauchy-interlacing-theorem-oq-03",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "context",
+    "title": "Framing: Weyl's Inequalities as Corollaries of the Courant–Fischer Keystone",
+    "content": "The module docstring fixes the file's strategy: derive the two classical Weyl spectral inequalities — monotonicity and the additive (subadditive) inequality — for symmetric operators purely as corollaries of the bound-form Courant–Fischer max–min keystone from CauchyInterlacingKeystone.lean, introducing no new spectral theory. Each operator is presented by an orthonormal eigenbasis with a descending (antitone) eigenvalue enumeration μ : Fin n → ℝ — the spectral-theorem input is taken as given so the file stays purely variational. The whole argument is a pairing game between the keystone's two variational halves: feed the optimal (k+1)-dimensional subspace from the lower half into the upper-tail Rayleigh ceiling, using the Grassmann dimension count to guarantee a common nonzero test vector. This is a research file, intentionally not registered in Proofs.lean.",
+    "mathContext": "Weyl monotonicity: $T \\preceq U \\Rightarrow \\mu_k \\le \\nu_k$. Weyl's inequality: $i+j \\le k \\Rightarrow \\rho_k \\le \\mu_i + \\nu_j$ for the eigenvalues $\\rho$ of $T+U$. Grassmann count $(k{+}1)+(n{-}i)+(n{-}j)-2n = k{+}1{-}i{-}j \\ge 1$ forces a common vector.",
+    "significance": "context",
+    "relatedConcepts": ["Weyl's inequalities", "Courant–Fischer min-max", "Rayleigh quotient", "Loewner order", "Grassmann dimension formula", "spectral theorem"],
+    "prerequisites": ["symmetric operators on EuclideanSpace", "Courant–Fischer variational characterization", "finrank / Grassmann identity"]
+  },
+  {
     "id": "ann-weyl-oq03-grassmann",
     "proofId": "cauchy-interlacing-theorem-oq-03",
     "range": { "startLine": 49, "endLine": 61 },


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-03` (quality 94).

**Change (JSON-only):** Added one `context` annotation covering the module docstring (lines 1–45), previously uncovered — the first annotation began at line 49. The annotation frames the file's strategy: derive Weyl monotonicity ($T \preceq U \Rightarrow \mu_k \le \nu_k$) and Weyl's additive inequality ($i+j\le k \Rightarrow \rho_k \le \mu_i+\nu_j$) as corollaries of the Courant–Fischer max–min keystone, via a lower-into-upper-tail pairing plus the Grassmann dimension count that guarantees a common test vector. Notes the purely-variational setup (spectral theorem taken as input) and research-file status.

**Not deepened:** entry already meets all quality minimums and is under size caps; this pass only closes the header coverage gap.