### PR TITLE
Enrich Vajda's Identity (Cassini OQ-01-01-01): annotate module header

### DIFF
--- a/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-vajda-header",
+    "proofId": "cassini-identity-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "Vajda's Identity: the master identity above Cassini, Catalan, and d'Ocagne",
+    "content": "The header positions the entry as the apex of the Fibonacci bilinear family. Vajda's identity F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} = (−1)ⁿ·Fᵢ·Fⱼ specializes to all three classical laws: Cassini (i = j = 1), Catalan (i = j = r, the parent file's catalan_aux), and the d'Ocagne shift form (j = 1). Its defining formal advantage is that the offsets enter only additively (n+i, n+j, n+i+j), so — unlike the signed Catalan/d'Ocagne statements — no truncated ℕ subtraction ever appears, keeping the whole proof friction-free over ℕ. The docstring also flags that this is an *independent* derivation: the gallery already proves the same identity in the fibonacci-identities lineage (fib_vajda_gap) by a two-step induction on j off d'Ocagne, whereas this Cassini-lineage proof uses no induction beyond the one already inside the imported Cassini core — a single addition-formula expansion collapsing against cassini_sub.",
+    "mathContext": "$F_{n+i}F_{n+j} - F_n F_{n+i+j} = (-1)^n F_i F_j$; specializations: Cassini $(i{=}j{=}1)$, Catalan $(i{=}j{=}r)$, d'Ocagne $(j{=}1)$. Fully additive indices $\\Rightarrow$ no $\\mathbb{N}$-subtraction.",
+    "significance": "context",
+    "relatedConcepts": ["Vajda's identity", "Cassini / Catalan / d'Ocagne family", "master identity", "additive index form"],
+    "prerequisites": ["Fibonacci numbers", "the parent Catalan/Cassini entries", "the Fibonacci addition formula Nat.fib_add"]
+  },
+  {
     "id": "ann-vajda-master",
     "proofId": "cassini-identity-oq-01-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `cassini-identity-oq-01-oq-01-oq-01` (Vajda's Identity, the bilinear master identity).

The entry was already strong (rich meta, mainTheorems, 4 keyInsights, sections, 3 cross-references, references, 5 fully-populated annotations). The one coverage gap: the module header (lines 1–49) — which states the master identity, its three classical specializations (Cassini/Catalan/d'Ocagne), and the independent-derivation note — had no annotation, while the sibling Catalan entry carries exactly such a header annotation.

**Change:** added one `context` annotation covering lines 1–49. Non-bloating: annotations 5 → 6; meta.json untouched (15 KB). JSON validated.