### PR TITLE
Enrich Effective Vincent Bisection Depth (descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02): annotate header

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-vincent-header",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 64 },
+    "type": "context",
+    "title": "Framing: from existential termination to an effective O(log(w/δ)) certificate",
+    "content": "The module docstring states the leaf's contribution. The parent entry proved only the existential Vincent termination statement `exists_level_isolates : ∃ k, …` — some bisection level $k$ makes every dyadic subinterval of width $w/2^k$ root-isolated. This file upgrades that to an explicit, computable witness of the correct $O(\\log(w/\\delta))$ order, turning the existence proof into a termination certificate for the Vincent–Akritas–Strzeboński (VAS) real-root isolation algorithm. The docstring highlights the one genuinely subtle point — the necessity of the `+1`: the natural witness $k = \\mathrm{clog}_2\\lceil w/\\delta\\rceil$ gives only the non-strict bound $w/2^k \\le \\delta$ (equality at exact powers of two, e.g. $w/\\delta = 4$), so the strict isolation bound needs one extra level, $k_0 = \\mathrm{clog}_2\\lceil w/\\delta\\rceil + 1$, matching the standard $\\log_2(w/\\delta)+1$ VAS depth. It enumerates the four results (threshold form, packaged explicit bound, effective isolation, per-interval version) and records the file as self-contained, 0-axiom, 0-sorry.",
+    "mathContext": "$k_0 = \\mathrm{clog}_2\\lceil w/\\delta\\rceil + 1 \\Rightarrow w/2^{k_0} < \\delta = \\mathrm{minGap}\\,S$. The $+1$ is forced: at $w/\\delta = 4$, $\\mathrm{clog}_2 4 = 2$ and $w/2^2 = \\delta$ (isolation fails by equality).",
+    "significance": "context",
+    "relatedConcepts": ["Vincent's theorem", "real root isolation", "VAS / bisection algorithm", "Nat.clog", "effective bounds", "minimum root gap"],
+    "prerequisites": ["Vincent bisection termination (parent entry)", "ceiling logarithm Nat.clog and Nat.le_pow_clog", "minimum gap of a finite root set"]
+  },
+  {
     "id": "ann-mingap-def",
     "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02",
     "range": { "startLine": 74, "endLine": 80 },


### PR DESCRIPTION
Enrichment pass (quality 94). Added one `context` annotation covering the module docstring (lines 1–64), previously uncovered — the first annotation began at line 74. It frames the leaf's contribution (upgrading the parent's existential Vincent termination to an explicit computable $O(\log(w/\delta))$ witness) and explains the necessity of the `+1` in $k_0 = \mathrm{clog}_2\lceil w/\delta\rceil + 1$ (exact powers of two force it, e.g. $w/\delta=4$). Header-coverage gap only; no deepening of an already-complete entry.