### PR TITLE
audit: re-audit 4 changed-since-audit metas (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3364,9 +3364,9 @@
       "result": "clean"
     },
     "borsuk-ulam-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:08:04Z",
+      "lastAudited": "2026-07-08T07:08:28Z",
       "result": "clean"
     },
     "borsuk-ulam-oq-02-oq-01-oq-01-oq-02": {
@@ -4349,9 +4349,9 @@
       "result": "clean"
     },
     "carnot-theorem-oq-01-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T07:08:28Z",
       "result": "clean"
     },
     "carnot-theorem-oq-01-oq-03-oq-02": {
@@ -16351,9 +16351,10 @@
     },
     "erdos-79": {
       "agentId": "auditor-cycle-5-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-16T23:48:40Z",
-      "result": "clean"
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T07:08:28Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-790": {
       "agentId": "auditor-cycle-5-batch",
@@ -17175,9 +17176,10 @@
     },
     "erdos-897": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:16:39Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T07:08:28Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-897-oq-01": {
       "auditCount": 1,
@@ -29575,5 +29577,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T06:56:48Z"
+  "lastUpdated": "2026-07-08T07:08:28Z"
 }


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Backlog is 0 (all 4776 proofs audited). This re-audits the 4 metas whose `meta.json` changed **after** their `lastAudited` timestamp. All four verified consistent with Lean source — no integrity issues.

| slug | status/badge | check | result |
|------|-------------|-------|--------|
| borsuk-ulam-oq-02-oq-01-oq-01 | axiomatized/axiom | axiomCount 2 = 1 axiom + `Lean.ofReduceBool` (native_decide); disclosed in assumptions (#35288) | clean |
| carnot-theorem-oq-01-oq-03-oq-01 | verified/original | real theorem `sin_sum_eq_iff_equilateral`; 0 sorries, 0 axioms, no native_decide, no True-stub/wrapper | clean |
| erdos-897 | axiomatized/wip | scaffold; open Erdős questions stated as documentation only, not asserted; 0 axioms/0 sorries | clean |
| erdos-79 | axiomatized/axiom | 4 axioms = axiomCount 4, all named in assumptions; native_decide correctly noted absent | clean |

Only updates `audit-tracker.json` (auditCount + lastAudited + result for the 4 entries). No meta.json content changes.

---
Discovered during gallery integrity audit.