### PR TITLE
research(erdos-882-oq-03): the maximum subset sum equals the total ∑A [VERIFIED, 0-sorry, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos882ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos882ProblemOQ03.lean
@@ -203,4 +203,48 @@ theorem subsetSums_card_bounds (A : Finset ℕ) :
     A.card ≤ (subsetSums A).card ∧ (subsetSums A).card ≤ 2 ^ A.card - 1 :=
   ⟨subsetSums_card_ge A, subsetSums_card_le A⟩
 
+/-- **The total sum is a subset sum.**  The whole set `A` is one of its own
+    non-empty subsets (when `A` is non-empty), so its total `∑ A` occurs as a
+    subset sum. -/
+theorem sum_mem_subsetSums {A : Finset ℕ} (hA : A.Nonempty) :
+    A.sum id ∈ subsetSums A := by
+  unfold subsetSums nonemptySubsets
+  rw [Finset.mem_image]
+  refine ⟨A, ?_, rfl⟩
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨Finset.Subset.refl A, Finset.nonempty_iff_ne_empty.mp hA⟩
+
+/-- **The total sum dominates every subset sum.**  Every non-empty subset sum is
+    at most the total `∑ A`, since a subset's sum never exceeds the whole set's
+    sum (all summands are non-negative). -/
+theorem subsetSums_le_sum {A : Finset ℕ} :
+    ∀ s ∈ subsetSums A, s ≤ A.sum id := by
+  intro s hs
+  unfold subsetSums nonemptySubsets at hs
+  rw [Finset.mem_image] at hs
+  obtain ⟨S, hS, rfl⟩ := hs
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS
+  exact Finset.sum_le_sum_of_subset hS.1
+
+/-- **Sharp membership range.**  For a set of positive integers every non-empty
+    subset sum lies in `{1,…,∑ A}`.  This refines `subsetSums_subset_Icc`
+    (`{1,…,n·|A|}`): since each element is `≤ n`, `∑ A ≤ n·|A|`, so this interval
+    is contained in the coarser one, and by `sum_mem_subsetSums` its right endpoint
+    is attained. -/
+theorem subsetSums_subset_Icc_sum {A : Finset ℕ}
+    (hlo : ∀ a ∈ A, 1 ≤ a) :
+    subsetSums A ⊆ Finset.Icc 1 (A.sum id) := by
+  intro s hs
+  rw [Finset.mem_Icc]
+  exact ⟨subsetSums_pos hlo s hs, subsetSums_le_sum s hs⟩
+
+/-- **The maximum subset sum is the total.**  For a non-empty set the largest of
+    its non-empty subset sums is exactly `∑ A`: it is attained (by the full subset,
+    `sum_mem_subsetSums`) and dominates all others (`subsetSums_le_sum`). -/
+theorem max'_subsetSums_eq_sum {A : Finset ℕ} (hA : A.Nonempty) :
+    (subsetSums A).max' (subsetSums_nonempty hA) = A.sum id :=
+  le_antisymm
+    (Finset.max'_le _ _ _ (fun s hs => subsetSums_le_sum s hs))
+    (Finset.le_max' _ _ (sum_mem_subsetSums hA))
+
 end Erdos882OQ03

--- a/src/data/research/problems/erdos-882-oq-03.json
+++ b/src/data/research/problems/erdos-882-oq-03.json
@@ -12,15 +12,17 @@
       "subsetSums_nonempty (a non-empty set has a non-empty subset sum via a singleton) and subsetSums_pos (positive sets have positive subset sums, via Finset.single_le_sum) pin down basic positivity/non-triviality.",
       "The parent Erdos882Problem.lean is BIT-ROTTED on the current toolchain (Finset.sum_le_sum unknown, Algebra.id.smul_eq_mul unknown, maxValidSize Nat.find Decidable synthesis fails) — so this child re-declares the four predicates self-contained with the modern Finset API.",
       "Counting anchor: |subsetSums A| ≤ 2^|A| − 1 (subsetSums_card_le) follows from Finset.card_image_le composed with nonemptySubsets_card (|A.powerset.filter (·≠∅)| = 2^|A| − 1, via Finset.filter_ne' + card_erase_of_mem + card_powerset). The sum map can only collapse the 2^|A|−1 non-empty subsets, never create values — this is the information-theoretic side of the (1+o(1))log₂ n upper bound.",
-      "Membership range: for A with elements in [1,n], every subset sum lies in {1,…,n·|A|} (subsetSums_subset_Icc), proved from subsetSums_pos (lower) and subsetSums_le (upper, via Finset.sum_le_sum bounding each summand by n then Nat.mul_le_mul on card_le_card). Combined with subsetSums_card_le (≤2^|A|−1 distinct sums) this pins BOTH sides of the information-theoretic (1+o(1))log₂n upper bound: few sums, all confined to a short interval."
+      "Membership range: for A with elements in [1,n], every subset sum lies in {1,…,n·|A|} (subsetSums_subset_Icc), proved from subsetSums_pos (lower) and subsetSums_le (upper, via Finset.sum_le_sum bounding each summand by n then Nat.mul_le_mul on card_le_card). Combined with subsetSums_card_le (≤2^|A|−1 distinct sums) this pins BOTH sides of the information-theoretic (1+o(1))log₂n upper bound: few sums, all confined to a short interval.",
+      "Extremal value: the MAXIMUM non-empty subset sum is exactly the total ∑A (max'_subsetSums_eq_sum). It is attained by the full subset A itself (sum_mem_subsetSums) and dominates every other subset sum (subsetSums_le_sum, via Finset.sum_le_sum_of_subset since all summands are non-negative). This sharpens the membership range to the tight interval subsetSums A ⊆ {1,…,∑A} (subsetSums_subset_Icc_sum), whose right endpoint — unlike the coarse n·|A| — is realized; note ∑A ≤ n·|A| so this refines subsetSums_subset_Icc."
     ],
     "builtItems": [
-      "Erdos882ProblemOQ03.lean: 4 defs + 8 theorems, 0 axioms, 0 sorries, self-contained.",
+      "Erdos882ProblemOQ03.lean: 4 defs + 17 theorems, 0 axioms, 0 sorries, self-contained.",
       "subsetSums_mono, DivisibilityFree.mono, validSubset_subset (downward closure), subsetSums_nonempty, subsetSums_pos.",
       "nonemptySubsets_card (|nonemptySubsets A| = 2^|A| − 1), subsetSums_card_le (|subsetSums A| ≤ 2^|A| − 1 — the information-theoretic counting anchor), subsetSums_singleton (subsetSums {a} = {a}).",
-      "subsetSums_le (every non-empty subset sum ≤ n·|A|) and subsetSums_subset_Icc (subsetSums A ⊆ Icc 1 (n·|A|)) — the MEMBERSHIP-range side of the counting bound, complementing subsetSums_card_le's cardinality side. All 0-axiom verified (7743 jobs)."
+      "subsetSums_le (every non-empty subset sum ≤ n·|A|) and subsetSums_subset_Icc (subsetSums A ⊆ Icc 1 (n·|A|)) — the MEMBERSHIP-range side of the counting bound, complementing subsetSums_card_le's cardinality side. All 0-axiom verified (7743 jobs).",
+      "sum_mem_subsetSums (∑A is a subset sum, realized by the full subset), subsetSums_le_sum (every subset sum ≤ ∑A), subsetSums_subset_Icc_sum (sharp range subsetSums A ⊆ Icc 1 (∑A)), and max'_subsetSums_eq_sum (the maximum subset sum equals ∑A) — the extremal-value layer. All 0-axiom verified (7743 jobs)."
     ],
-    "progressSummary": "Child of erdos-882 (Subset Sums Without Divisibility). The parent states the analytic bounds as axioms but proves no structural facts; this entry supplies the structural layer: subset-sum and divisibility-free monotonicity, the downward closure of ValidSubset (WLOG sub-configuration tool), basic non-emptiness/positivity, the exact non-empty-subset count 2^|A|−1, the cardinality bound |subsetSums A| ≤ 2^|A|−1 anchoring the information-theoretic side of the (1+o(1))log₂ n upper bound, and the singleton sum set. All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. Self-contained re-declaration of the four predicates (parent file no longer builds on the current Mathlib).",
+    "progressSummary": "Child of erdos-882 (Subset Sums Without Divisibility). The parent states the analytic bounds as axioms but proves no structural facts; this entry supplies the structural layer: subset-sum and divisibility-free monotonicity, the downward closure of ValidSubset (WLOG sub-configuration tool), basic non-emptiness/positivity, the exact non-empty-subset count 2^|A|−1, the cardinality bound |subsetSums A| ≤ 2^|A|−1 anchoring the information-theoretic side of the (1+o(1))log₂ n upper bound, the singleton sum set, and the extremal characterization that the maximum subset sum is exactly the total ∑A (attained by the full subset, sharpening the range to {1,…,∑A}). All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. Self-contained re-declaration of the four predicates (parent file no longer builds on the current Mathlib).",
     "nextSteps": [
       "Prove subsetSums of an insert (subsetSums (insert a A) in terms of subsetSums A) to compute sum sets of explicit constructions.",
       "Formalize 'distinct subset sums' as a consequence of, or relation to, divisibility-free sums (the parent's DistinctSubsetSums is defined but unconnected).",
@@ -47,8 +49,8 @@
     {
       "path": "Proofs/Erdos882ProblemOQ03.lean",
       "filename": "Erdos882ProblemOQ03.lean",
-      "lineCount": 180,
-      "theoremCount": 10,
+      "lineCount": 250,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends the subset-sum structural theory for Erdős #882 (`erdos-882-oq-03`). The existing file develops monotonicity, downward closure, the cardinality bound `|subsetSums A| ≤ 2^|A|−1`, and the membership range `subsetSums A ⊆ {1,…,n·|A|}` (#35274). This PR adds the **extremal-value** layer: the largest non-empty subset sum is exactly the total `∑A`.

## New theorems (all 0-axiom verified)

- **`sum_mem_subsetSums`** — `∑A ∈ subsetSums A` for non-empty `A`: the whole set is one of its own non-empty subsets, so its total is attained as a subset sum.
- **`subsetSums_le_sum`** — every non-empty subset sum is `≤ ∑A` (a subset's sum never exceeds the whole set's, `Finset.sum_le_sum_of_subset`).
- **`subsetSums_subset_Icc_sum`** — sharp membership range `subsetSums A ⊆ {1,…,∑A}`. This refines the earlier `subsetSums_subset_Icc` (`{1,…,n·|A|}`): since each element is `≤ n`, `∑A ≤ n·|A|`, and unlike `n·|A|` the endpoint `∑A` is actually realized.
- **`max'_subsetSums_eq_sum`** — the capstone: `(subsetSums A).max' _ = ∑A`. The maximum subset sum is exactly the total, by `le_antisymm` of the two facts above (`Finset.max'_le` + `Finset.le_max'`).

## Status

- **Verified**: builds green (`7743 jobs`, `docker-build.sh Proofs.Erdos882ProblemOQ03`), 0 sorries, 0 `axiom` declarations, `#print axioms` = `propext / Classical.choice / Quot.sound` only.
- Research listing JSON synced: added insights/builtItems for the extremal layer; corrected the `Erdos882ProblemOQ03.lean` `leanFiles` counts to the actual `theoremCount 17` (the prior `10` was a longstanding undercount) and `lineCount 250`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)