### PR TITLE
research(roth-theorem-k3-oq-03-oq-01): slotwise multilinearity of the k-AP counting operator Λ_k [VERIFIED]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -140,4 +140,75 @@ theorem kAPCount_eq_zero_of_zero {N : ℕ} [NeZero N] (k : ℕ)
         Finset.sum_congr rfl (fun d _ => hprod x d))]
   simp
 
+-- ============================================================
+-- Multilinearity in each slot
+--
+-- The k-AP counting operator is *multilinear*: linear separately in
+-- each of its `k` function arguments.  These are exactly the identities
+-- that drive the generalized von Neumann argument, where one slot is
+-- expanded as `1_A = δ·1 + (1_A − δ)` and the count is split by linearity
+-- in that slot.  We record linearity in an arbitrary slot `j` via
+-- `Function.update`.
+-- ============================================================
+
+/-- Factor out the `j`-th slot of the inner product: replacing `f j` by an
+    arbitrary function `g` (via `Function.update`) pulls the `j`-th factor
+    `g (x + j·d)` out in front of the product over the remaining slots. -/
+theorem prod_update_factor {N : ℕ} [NeZero N] (k : ℕ)
+    (f : Fin k → ZMod N → ℂ) (j : Fin k) (g : ZMod N → ℂ) (x d : ZMod N) :
+    (∏ i : Fin k, Function.update f j g i (x + i.val • d))
+      = g (x + j.val • d) *
+          ∏ i ∈ Finset.univ.erase j, f i (x + i.val • d) := by
+  rw [← Finset.mul_prod_erase Finset.univ
+        (fun i => Function.update f j g i (x + i.val • d)) (Finset.mem_univ j)]
+  congr 1
+  · simp
+  · apply Finset.prod_congr rfl
+    intro i hi
+    simp only [Finset.mem_erase] at hi
+    simp [hi.1]
+
+/-- Additivity in slot `j`: `Λ_k` is additive in each function argument.
+    Splitting the `j`-th slot as a sum `g₁ + g₂` splits the whole count.
+    This is the linear step that lets the generalized von Neumann argument
+    decompose `1_A = δ·1 + (1_A − δ)` inside a single AP-count slot. -/
+theorem kAPCount_update_add {N : ℕ} [NeZero N] (k : ℕ)
+    (f : Fin k → ZMod N → ℂ) (j : Fin k) (g₁ g₂ : ZMod N → ℂ) :
+    kAPCount k (Function.update f j (g₁ + g₂))
+      = kAPCount k (Function.update f j g₁)
+        + kAPCount k (Function.update f j g₂) := by
+  unfold kAPCount
+  rw [← mul_add]
+  congr 1
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro x _
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro d _
+  rw [prod_update_factor, prod_update_factor, prod_update_factor, Pi.add_apply]
+  ring
+
+/-- Scalar homogeneity in slot `j`: scaling one function argument by a
+    constant `c` scales the whole count by `c`.  Together with
+    `kAPCount_update_add` this establishes multilinearity of `Λ_k`. -/
+theorem kAPCount_update_smul {N : ℕ} [NeZero N] (k : ℕ)
+    (f : Fin k → ZMod N → ℂ) (j : Fin k) (c : ℂ) (g : ZMod N → ℂ) :
+    kAPCount k (Function.update f j (c • g))
+      = c * kAPCount k (Function.update f j g) := by
+  unfold kAPCount
+  have key : (∑ x : ZMod N, ∑ d : ZMod N,
+                ∏ i : Fin k, Function.update f j (c • g) i (x + i.val • d))
+      = c * ∑ x : ZMod N, ∑ d : ZMod N,
+                ∏ i : Fin k, Function.update f j g i (x + i.val • d) := by
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro x _
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro d _
+    rw [prod_update_factor, prod_update_factor, Pi.smul_apply, smul_eq_mul]
+    ring
+  rw [key]; ring
+
 end RothTheoremOQ03OQ01

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,9 +58,9 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 143,
+    "lineCount": 214,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 4
   },
   "overview": {
@@ -142,9 +142,9 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 143,
+    "lineCount": 214,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 4,
     "path": "Proofs/RothTheoremOQ03OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
@@ -4,7 +4,7 @@
   "parentId": "roth-theorem-k3-oq-03",
   "status": "in-progress",
   "knowledge": {
-    "score": 10,
+    "score": 13,
     "insights": [
       "The parent OQ-03 defines gowersNorm and kAPCount constructively but proves NO algebraic properties of them — this child fills that gap with the foundational degenerate/normalization identities.",
       "kAPCount on a constant tuple (c,…,c) equals c^k: the inner product is c^k and the normalized double average (N^-1)^2 * sum_{x,d} c^k = c^k cancels N^2 against the (N^-1)^2 prefactor. The all-ones case gives Λ_k(1,…,1)=1, the total normalized k-AP mass.",
@@ -12,7 +12,9 @@
       "gowersNorm of the zero function is 0: conjugateByWeight ω 0 = 0 in both branches (identity and conjugation), so every 2^s-fold hypercube product vanishes.",
       "These constant/zero base cases are exactly the start of the multilinear expansion 1_A = δ·1 + (1_A − δ) that opens the generalized von Neumann argument.",
       "Parent RothTheoremOQ03.lean has TOOLCHAIN DRIFT on the current Mathlib (Complex.abs removed; Fin.val rewrite patterns and a dangling /-- docstring no longer parse) — this child is therefore SELF-CONTAINED, re-declaring the operators with the modern norm ‖·‖ so it builds independently of the broken parent.",
-      "norm notation ‖ ... ‖ wrapping a ∑/∏ that extends to the right swallows the closing bar — wrap the inner expression in explicit parentheses ‖(...)‖ (the parent dodged this with Complex.abs (...))."
+      "norm notation ‖ ... ‖ wrapping a ∑/∏ that extends to the right swallows the closing bar — wrap the inner expression in explicit parentheses ‖(...)‖ (the parent dodged this with Complex.abs (...)).",
+      "Multilinearity of Λ_k is proved slotwise via Function.update: the j-th factor factors out of the product (Finset.mul_prod_erase + Function.update_apply), then additivity/homogeneity descend to the pointwise product and close by ring after Pi.add_apply / Pi.smul_apply+smul_eq_mul.",
+      "These two identities (additivity + homogeneity in each slot) are exactly the linear step of the generalized von Neumann argument: they license splitting one Λ_k slot as 1_A = δ·1 + (1_A − δ)."
     ],
     "builtItems": [
       "RothTheoremOQ03OQ01.lean: self-contained, 4 noncomputable defs (hypercubeShift, conjugateByWeight, gowersNorm, kAPCount) + 5 proved theorems, 0 axioms, 0 sorries.",
@@ -20,14 +22,17 @@
       "gowersNorm_zero: gowersNorm N s 0 = 0.",
       "kAPCount_const: kAPCount k (fun _ _ => c) = c^k.",
       "kAPCount_const_one: kAPCount k (fun _ _ => 1) = 1.",
-      "kAPCount_eq_zero_of_zero: f j = 0 ⟹ kAPCount k f = 0."
+      "kAPCount_eq_zero_of_zero: f j = 0 ⟹ kAPCount k f = 0.",
+      "prod_update_factor: factors the j-th slot of the inner product ∏ᵢ (update f j g) i (x+i·d) = g(x+j·d)·∏_{i≠j} fᵢ(x+i·d) — the workhorse for slotwise linearity.",
+      "kAPCount_update_add: additivity in slot j — Λ_k(update f j (g₁+g₂)) = Λ_k(update f j g₁) + Λ_k(update f j g₂).",
+      "kAPCount_update_smul: scalar homogeneity in slot j — Λ_k(update f j (c•g)) = c·Λ_k(update f j g)."
     ],
-    "progressSummary": "Child of roth-theorem-k3-oq-03. The parent constructs the Gowers U^s norm and the k-AP counting operator Λ_k but proves nothing about them. This entry supplies the foundational identities: gowersNorm_zero, kAPCount_const (Λ_k(c,…,c)=c^k), kAPCount_const_one (normalization Λ_k(1,…,1)=1), and kAPCount_eq_zero_of_zero (a zero slot annihilates the count). All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. Self-contained file using the current Mathlib norm ‖·‖ (the parent file uses the now-removed Complex.abs).",
+    "progressSummary": "PROGRESS: added slotwise multilinearity of the k-AP counting operator Λ_k (prod_update_factor, kAPCount_update_add, kAPCount_update_smul) — the linear engine of the generalized von Neumann argument. 0 axioms, 0 sorries. score 10→13.",
     "nextSteps": [
-      "Prove multilinearity of kAPCount in each slot (additivity and scalar homogeneity via Function.update), enabling the full 1_A = δ·1 + (1_A − δ) expansion.",
-      "Prove gowersNorm_nonneg and the U^1 mean identity once the parent's Complex.abs drift is repaired (or keep on the self-contained operators).",
+      "Iterate the slot-splitting: expand a chosen slot as δ·1 + (1_A − δ) and apply kAPCount_update_add/smul to get the von Neumann telescoping into 2^k terms.",
+      "Bound the non-major terms by the Gowers U^{k-1} norm (the generalized von Neumann inequality) — needs a Cauchy-Schwarz/Gowers-norm control lemma next.",
       "Connect kAPCount of an indicator function to the actual count of k-APs in a finset.",
-      "Repair the toolchain drift in the parent RothTheoremOQ03.lean (Complex.abs → ‖·‖, Fin.val rewrites, dangling docstring) so the two files can be merged."
+      "Repair the toolchain drift in the parent RothTheoremOQ03.lean (Complex.abs → ‖·‖) so the two files can be merged."
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Advances **roth-theorem-k3-oq-03-oq-01** (RICH, the child of OQ-03 supplying algebraic properties of the Gowers-norm / k-AP-counting operators). The parent constructs the k-AP counting operator Λ_k but proves no linearity; the prior state had only the constant/zero base cases. This PR supplies the **slotwise multilinearity** identities — the linear engine of the generalized von Neumann argument.

## What's added (`proofs/Proofs/RothTheoremOQ03OQ01.lean`)

- **`prod_update_factor`** — factors the `j`-th slot out of the inner product:
  `∏ᵢ (update f j g) i (x+i·d) = g(x+j·d) · ∏_{i≠j} fᵢ(x+i·d)` (via `Finset.mul_prod_erase` + `Function.update_apply`). The workhorse for slotwise linearity.
- **`kAPCount_update_add`** — additivity in slot `j`:
  `Λ_k(update f j (g₁+g₂)) = Λ_k(update f j g₁) + Λ_k(update f j g₂)`.
- **`kAPCount_update_smul`** — scalar homogeneity in slot `j`:
  `Λ_k(update f j (c•g)) = c · Λ_k(update f j g)`.

Together these establish that `Λ_k` is linear separately in each of its `k` function arguments — exactly the step that licenses splitting one count slot as `1_A = δ·1 + (1_A − δ)` in the generalized von Neumann telescoping.

## Verification

- Docker build **clean**: `⚠→✔ [7743/7743] Built Proofs.RothTheoremOQ03OQ01`.
- **0 sorries, 0 axioms**, no `native_decide` — only propext/Classical.choice/Quot.sound.
- meta/leanFile synced: `lineCount 143→214`, `theoremCount 5→8`.

## Status

Research in progress (not the full theorem). Remaining next steps: iterate the slot-split into the 2^k von Neumann telescoping, then bound non-major terms by the Gowers `U^{k-1}` norm (needs a Cauchy–Schwarz/Gowers control lemma). No axioms introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)