### PR TITLE
Enrich Cauchy interlacing eigenvalue corollary (OQ-01-01-02): annotate module header

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-cauchy-oq010102-header",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 62 },
+    "type": "concept",
+    "title": "The Open Question and the Coordinate-Isometry Bridge",
+    "content": "The module docstring frames this file as the answer to the parent entry's first open question. The parent (cauchy-interlacing-theorem-oq-01-oq-01) proves the geometric identification — the orthogonal compression of toEuclideanLin A to the coordinate hyperplane H = span {e_{j.succAbove i}} has, on that basis, sesquilinear form exactly the principal submatrix A' = A.submatrix j.succAbove j.succAbove — but leaves open the matrix-level eigenvalue corollary. This file supplies the missing bridge: the coordinate isometry coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H, e_i ↦ e_{j.succAbove i}, under which the compression literally IS toEuclideanLin A' (compress_intertwine). Pushing A''s spectral eigenbasis through coordEquiv yields an eigenbasis of the compression with the SAME antitone eigenvalues — so no eigenvalue-uniqueness lemma is needed — feeding the abstract cauchy_interlacing to give λ_{k+1} ≤ μ_k ≤ λ_k. Works over any RCLike field (ℝ and ℂ); absent from Mathlib.",
+    "mathContext": "$\\mathrm{compress}\\,(\\mathrm{toEuclideanLin}\\,A)\\,H\\,(\\mathrm{coordEquiv}\\,x) = \\mathrm{coordEquiv}\\,(\\mathrm{toEuclideanLin}\\,A'\\,x)$; hence the principal submatrix eigenvalues interlace: $\\lambda_{k+1} \\le \\mu_k \\le \\lambda_k$.",
+    "significance": "context",
+    "relatedConcepts": ["Cauchy interlacing", "principal submatrix", "linear isometry equivalence", "spectral theorem", "compression of an operator"],
+    "prerequisites": ["the parent geometric identification (compress_inner_eq_principalSubmatrix)", "the spectral theorem for symmetric operators", "orthonormal bases and isometries"]
+  },
+  {
     "id": "ann-eigenvalues-finrank-congr",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
     "range": {


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-01-oq-02` (the matrix-level eigenvalue corollary of Cauchy interlacing).

Strong existing entry (rich meta, 4 keyInsights, narrative sections, 4 cross-references, 3 references, 6 fully-populated annotations). Gap: annotations started at line 63, leaving the module docstring (lines 1–62) — which frames the parent's open question and the `coordEquiv` coordinate-isometry bridge that answers it — unannotated.

**Change:** added one `context` annotation covering lines 1–62. Non-bloating: annotations 6 → 7; meta.json untouched (16 KB). JSON validated.