### PR TITLE
research(pythagorean-theorem-oq-05): gallery entry for verified flat-limit reduction [VERIFIED]

### DIFF
--- a/research/problems/pythagorean-theorem-oq-01/state.md
+++ b/research/problems/pythagorean-theorem-oq-01/state.md
@@ -1,25 +1,35 @@
 # Research State: pythagorean-theorem-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-04-05T23:12:43-07:00
-**Iteration**: 1
+**Since**: 2026-07-08T00:00:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Verified work surfaced to gallery; remaining target assessed as blocked.
 
 ## Active Approach
-None yet.
+The problem's verified content lives across sibling Lean files. This iteration
+surfaced the fully-verified flat-limit file `PythagoreanTheoremOQ05.lean` (0/0,
+3070 jobs) as gallery entry `pythagorean-theorem-oq-05` (meta + 5 annotations,
+PR #35314). The remaining open target is the primitive-triple density asymptotic
+in `PythagoreanTriplesOQ01.lean`.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+`PythagoreanTriplesOQ01.lean` rests on 3 load-bearing axioms, each requiring
+>1000 lines of infrastructure absent from Mathlib v4.26:
+- `sector_lattice_point_density` — Gauss circle problem (sector lattice points ~ πN/8)
+- `coprime_fraction_in_sector` — coprime density 6/π² via Möbius inversion
+- `bothOdd_fraction_in_coprime_sector` — parity equidistribution → 1/3
+Prior sessions already reduced 7 → 3 axioms; these 3 are the irreducible core.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+- Audit sibling pythagorean files (OQ03 etc.) for Mathlib drift.
+- Revisit the density axioms only once Mathlib gains lattice-point-counting /
+  Gauss-circle infrastructure (Landau–Ramanujan, leg-density likewise).

--- a/src/data/proofs/pythagorean-theorem-oq-05/annotations.json
+++ b/src/data/proofs/pythagorean-theorem-oq-05/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-pt-oq05-shared-limit",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 270,
+      "endLine": 285
+    },
+    "type": "insight",
+    "title": "One Scaled Limit for Both Curvatures",
+    "content": "tendsto_cosh_mul_sub_one_div_sq proves (cosh(tx) − 1)/t² → x²/2 as t → 0⁺. Its spherical twin, tendsto_one_sub_cos_mul_div_sq (Part Va), proves (1 − cos(tx))/t² → the SAME x²/2. This shared second-order coefficient is the whole reason the spherical law cos c = cos a cos b and the hyperbolic law cosh c = cosh a cosh b both degenerate to the identical Euclidean form c² = a² + b². The flat limit is a statement about the germ of each curved law at t = 0, where both linearize to x ↦ x²/2.",
+    "mathContext": "$\\frac{\\cosh(tx)-1}{t^2} \\to \\frac{x^2}{2}$ and $\\frac{1-\\cos(tx)}{t^2} \\to \\frac{x^2}{2}$ as $t \\to 0^+$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "second-order Taylor germ",
+      "curvature degeneration",
+      "squeeze theorem",
+      "flat limit"
+    ],
+    "prerequisites": [
+      "limits in a filter",
+      "second-order behaviour of cos and cosh at 0"
+    ]
+  },
+  {
+    "id": "ann-pt-oq05-cosh-upper-bound",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 229,
+      "endLine": 250
+    },
+    "type": "tactic",
+    "title": "The Upper Bound by Two-Level Monotonicity",
+    "content": "cosh_sub_one_le_sq_mul_cosh (and its all-u extension cosh_sub_one_le_sq_mul_cosh_all just below) establishes 2(cosh u − 1) ≤ u²·cosh u — the upper half of the hyperbolic squeeze. The proof studies g(u) = u²·cosh u − 2(cosh u − 1): its second derivative g''(u) = u²·cosh u + 4u·sinh u is ≥ 0 for u ≥ 0, so g' is increasing from g'(0) = 0, hence g' ≥ 0, hence g is increasing from g(0) = 0, hence g ≥ 0. The all-u version follows because both sides are even in u. This turns a non-obvious inequality into two applications of the mean value theorem.",
+    "mathContext": "$2(\\cosh u - 1) \\le u^2 \\cosh u$, from $g''(u) = u^2\\cosh u + 4u\\sinh u \\ge 0$ for $u \\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "mean value theorem",
+      "second-derivative test",
+      "monotonicity from derivative sign",
+      "even functions"
+    ],
+    "prerequisites": [
+      "derivatives of cosh/sinh",
+      "monotonicity via MVT"
+    ]
+  },
+  {
+    "id": "ann-pt-oq05-sinc-route",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 350,
+      "endLine": 391
+    },
+    "type": "insight",
+    "title": "The Spherical Limit via sinc Continuity",
+    "content": "The spherical scaled limit avoids the monotonicity machinery of the hyperbolic case entirely. sin_eq_sinc_mul rewrites sin u = Real.sinc u · u; combined with the half-angle identity 1 − cos(tx) = 2 sin(tx/2)², the ratio (1 − cos(tx))/t² becomes exactly (x²/2)·sinc(tx/2)². Since Real.sinc is continuous with sinc 0 = 1, the limit as t → 0⁺ is (x²/2)·1² = x²/2. This is strictly cleaner than a squeeze: no bounds, no second derivatives — just continuity of a single Mathlib function at a point.",
+    "mathContext": "$\\frac{1-\\cos(tx)}{t^2} = \\frac{x^2}{2}\\,\\operatorname{sinc}\\!\\left(\\tfrac{tx}{2}\\right)^2 \\to \\frac{x^2}{2}$ since $\\operatorname{sinc}(0)=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.sinc",
+      "half-angle identity",
+      "continuity at a point",
+      "sin u = sinc u · u"
+    ],
+    "prerequisites": [
+      "Real.sinc and sinc 0 = 1",
+      "1 − cos θ = 2 sin²(θ/2)"
+    ]
+  },
+  {
+    "id": "ann-pt-oq05-telescope",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 300,
+      "endLine": 316
+    },
+    "type": "concept",
+    "title": "Linearizing the Product by Telescoping",
+    "content": "tendsto_cosh_prod_sub_one_div_sq handles the two-variable product side without any genuinely two-variable analysis. The factorization f·g − 1 = (f − 1)·g + (g − 1), applied with f = cosh(ta), g = cosh(tb), splits (cosh(ta)cosh(tb) − 1)/t² into (cosh(ta) − 1)/t² · cosh(tb) plus (cosh(tb) − 1)/t². The first factor tends to a²/2 times cosh(tb) → 1, the second to b²/2, so the sum tends to (a²+b²)/2. The spherical case uses the same identity with cos. This is how the multiplicative curved law becomes the additive Euclidean one.",
+    "mathContext": "$fg - 1 = (f-1)g + (g-1)$, so $\\frac{\\cosh(ta)\\cosh(tb)-1}{t^2} \\to \\frac{a^2}{2}\\cdot 1 + \\frac{b^2}{2} = \\frac{a^2+b^2}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping identity",
+      "product of limits",
+      "continuity of cosh/cos at 0",
+      "multiplicative to additive"
+    ],
+    "prerequisites": [
+      "algebra of limits",
+      "cosh(tx) → 1 and cos(tx) → 1 as t → 0"
+    ]
+  },
+  {
+    "id": "ann-pt-oq05-uniqueness",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 424,
+      "endLine": 443
+    },
+    "type": "tactic",
+    "title": "Uniqueness of Limits Closes Both Theorems",
+    "content": "spherical_flat_limit (and identically hyperbolic_flat_limit) finishes with tendsto_nhds_unique. The curved law cos(t·c) = cos(t·a)·cos(t·b) holds for every t > 0, so on the filter 𝓝[Ioi 0] 0 the two scaled functions (1 − cos(tc))/t² and (1 − cos(ta)cos(tb))/t² are eventually equal (eventually_nhdsWithin_of_forall). One tends to c²/2, the other to (a²+b²)/2; a convergent sequence has a unique limit, so c²/2 = (a²+b²)/2 and linarith gives c² = a² + b². No smallness or range restriction on a, b, c is used — the germ at t = 0 is all that matters.",
+    "mathContext": "$\\frac{c^2}{2} = \\frac{a^2+b^2}{2}$ by uniqueness of the $t \\to 0^+$ limit, hence $c^2 = a^2 + b^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "tendsto_nhds_unique",
+      "eventually equal on a filter",
+      "𝓝[Ioi 0] 0",
+      "Tendsto.congr'"
+    ],
+    "prerequisites": [
+      "uniqueness of limits in a Hausdorff space",
+      "filters and eventually"
+    ]
+  }
+]

--- a/src/data/proofs/pythagorean-theorem-oq-05/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-05/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "pythagorean-theorem-oq-05",
+  "title": "Pythagorean Theorem OQ-05: The Flat-Limit Reduction of the Spherical and Hyperbolic Laws",
+  "slug": "pythagorean-theorem-oq-05",
+  "description": "Both non-Euclidean Pythagorean theorems collapse to the Euclidean identity c² = a² + b² as curvature → 0. For a right-angled triangle the spherical law reads cos(c) = cos(a)·cos(b) and the hyperbolic law reads cosh(c) = cosh(a)·cosh(b); rescaling the sides by a parameter t (t = 1/R, the reciprocal curvature radius) and letting t → 0⁺ recovers Pythagoras exactly. The mechanism is a single second-order limit: (1 − cos(tx))/t² → x²/2 on the sphere and (cosh(tx) − 1)/t² → x²/2 in hyperbolic space, so the multiplicative curved laws linearize to the additive flat one. The spherical route reduces the limit to continuity of Real.sinc at 0; the hyperbolic route to a two-level monotonicity bound 2(cosh u − 1) ≤ u²·cosh u. 19 theorems, 0 axioms, 0 sorries, no range restriction on a, b, c.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-08",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTheoremOQ05.lean",
+    "tags": [
+      "geometry",
+      "non-euclidean",
+      "flat-limit",
+      "spherical-trigonometry",
+      "hyperbolic-geometry",
+      "taylor-approximation",
+      "squeeze-theorem"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-08",
+    "axiomCount": 0,
+    "assumptions": "None. Both main theorems take the right-angle curved law (as a scaled functional equation ∀ t > 0) as an explicit hypothesis and derive c² = a² + b² from it; they do not assume any spherical/hyperbolic-geometry infrastructure. Fully machine-checked, depending only on propext, Classical.choice, and Quot.sound.",
+    "lineCount": 443,
+    "theoremCount": 19,
+    "definitionCount": 0,
+    "originalContributions": [
+      "spherical_flat_limit: if cos(t·c) = cos(t·a)·cos(t·b) for all t > 0 then c² = a² + b² — the spherical right-triangle law degenerates to Pythagoras in the flat limit, with NO range restriction on a, b, c",
+      "hyperbolic_flat_limit: if cosh(t·c) = cosh(t·a)·cosh(t·b) for all t > 0 then c² = a² + b² — the hyperbolic right-triangle law degenerates to Pythagoras in the flat limit",
+      "tendsto_one_sub_cos_mul_div_sq: (1 − cos(tx))/t² → x²/2 as t → 0⁺, proved cleanly via the sinc identity sin u = sinc u · u and continuity of Real.sinc at 0 (sinc 0 = 1) — no monotonicity or second-derivative machinery",
+      "tendsto_cosh_mul_sub_one_div_sq: (cosh(tx) − 1)/t² → x²/2 as t → 0⁺, obtained by squeezing between the lower bound 1 + (tx)²/2 ≤ cosh(tx) and the upper bound 2(cosh u − 1) ≤ u²·cosh u",
+      "cosh_sub_one_le_sq_mul_cosh_all: 2(cosh u − 1) ≤ u²·cosh u for all real u, proved by a two-level monotonicity argument on u²·cosh u − 2(cosh u − 1) whose second derivative u²·cosh u + 4u·sinh u is nonnegative for u ≥ 0",
+      "sin_eq_sinc_mul: sin u = Real.sinc u · u, the identity that routes the spherical scaled limit through sinc continuity",
+      "tendsto_one_sub_cos_prod_div_sq / tendsto_cosh_prod_sub_one_div_sq: the product-side limits (1 − cos(ta)cos(tb))/t² → (a²+b²)/2 and (cosh(ta)cosh(tb) − 1)/t² → (a²+b²)/2, decomposed via the telescoping factorization f·g − 1 = (f − 1)·g + (g − 1) and continuity of cos/cosh at 0"
+    ]
+  },
+  "overview": {
+    "historicalContext": "In a space of constant curvature K the Pythagorean theorem for a right-angled triangle is not additive but multiplicative. On the unit sphere (K = +1) the law of cosines for a right angle collapses to cos c = cos a · cos b; in the hyperbolic plane (K = −1) it reads cosh c = cosh a · cosh b. These are classical: the spherical form is essentially Menelaus and appears in Regiomontanus' De triangulis (1464) and the Arabic astronomers before him; the hyperbolic form is due to Bolyai and Lobachevsky (1830s) and Taurinus' earlier 'logarithmic-spherical' geometry. It has long been understood informally that both reduce to a² + b² = c² 'in the small' — as the triangle shrinks relative to the radius of curvature, or equivalently as K → 0. This entry makes that flat limit fully precise and machine-checked, extracting the Euclidean identity as the exact second-order (t → 0⁺) content of the two curved laws simultaneously, through one shared analytic mechanism.",
+    "problemStatement": "Prove rigorously that the spherical and hyperbolic right-angle laws degenerate to the Euclidean Pythagorean theorem in the flat limit. Concretely: if cos(t·c) = cos(t·a)·cos(t·b) for all t > 0, then c² = a² + b²; and if cosh(t·c) = cosh(t·a)·cosh(t·b) for all t > 0, then c² = a² + b². The scaling parameter t plays the role of 1/R (reciprocal curvature radius); the flat limit is t → 0⁺.",
+    "text": "The heart of the matter is a single scaled limit taken in two curvatures. On the sphere, the quantity (1 − cos(tx))/t² converges to x²/2 as t → 0⁺; in hyperbolic space, (cosh(tx) − 1)/t² converges to the same x²/2. Given the curved right-angle law as a functional equation valid for all t > 0, the two sides agree identically on (0, ∞); taking the flat limit of each side and using uniqueness of limits forces c²/2 = (a² + b²)/2, hence c² = a² + b². The product side is handled by the telescoping factorization cos(ta)cos(tb) − 1 = (cos(ta) − 1)·cos(tb) + (cos(tb) − 1) (and its cosh analogue), so that the product limit splits into the two single-variable limits plus continuity of cos/cosh at 0. Crucially, no range restriction on a, b, c is needed: the flat limit reads off the germ at t = 0, where both curved laws linearize to the same quadratic form.",
+    "proofStrategy": "The spherical scaled limit tendsto_one_sub_cos_mul_div_sq is proved through the sinc identity: writing sin u = Real.sinc u · u and using the half-angle identity 1 − cos(tx) = 2 sin(tx/2)², the ratio (1 − cos(tx))/t² becomes (x²/2)·sinc(tx/2)², whose limit is x²/2 by continuity of Real.sinc at 0 (sinc 0 = 1). This avoids all monotonicity machinery. The hyperbolic scaled limit tendsto_cosh_mul_sub_one_div_sq is instead a squeeze: the lower bound cosh(tx) ≥ 1 + (tx)²/2 gives (cosh(tx) − 1)/t² ≥ x²/2, and the upper bound 2(cosh u − 1) ≤ u²·cosh u (cosh_sub_one_le_sq_mul_cosh_all, from a two-level monotonicity argument whose second derivative u²·cosh u + 4u·sinh u ≥ 0 for u ≥ 0) gives (cosh(tx) − 1)/t² ≤ x²·cosh(tx)/2 → x²/2. Both product limits telescope as f·g − 1 = (f − 1)·g + (g − 1). The two main theorems then apply the curved law pointwise on Ioi 0, conclude the two limit-functions agree eventually, and invoke tendsto_nhds_unique.",
+    "keyInsights": [
+      "The flat limit is a statement about germs at t = 0: both curved right-angle laws share the same second-order Taylor coefficient, so their t → 0⁺ limits coincide with the single Euclidean quadratic form x ↦ x²/2 — this is why sphere and hyperbolic plane give the SAME Pythagoras",
+      "One analytic quantity does all the work in both curvatures: (1 − cos(tx))/t² and (cosh(tx) − 1)/t² both tend to x²/2, so the spherical and hyperbolic reductions are literally the same limit computation with cos ↔ cosh",
+      "The sinc route is the clean way to the spherical limit: 1 − cos(tx) = 2 sin(tx/2)² and sin u = sinc u · u turn the ratio into (x²/2)·sinc(tx/2)², reducing everything to continuity of Real.sinc at 0 — strictly simpler than the hyperbolic squeeze it replaces",
+      "The multiplicative curved law linearizes to the additive flat one via telescoping: f·g − 1 = (f − 1)·g + (g − 1) converts the product cos(ta)cos(tb) (resp. cosh(ta)cosh(tb)) into a sum of single-variable limits, so no genuinely two-variable analysis is required",
+      "No range restriction on a, b, c is needed — the argument extracts the second-order behaviour at t → 0⁺ and never requires the sides to be small, unlike a naive 'small-triangle approximation' heuristic"
+    ],
+    "prerequisites": [
+      "Limits and the squeeze theorem in a filter (Filter.Tendsto, tendsto_nhds_unique)",
+      "Real hyperbolic functions: derivatives of cosh/sinh, cosh ≥ 1 + x²/2, and monotonicity via the mean value theorem",
+      "Real.sinc and its continuity at 0 (sinc 0 = 1), plus the half-angle identity 1 − cos θ = 2 sin²(θ/2)",
+      "The right-angle laws of cosines on the sphere (cos c = cos a cos b) and in hyperbolic space (cosh c = cosh a cosh b)"
+    ]
+  },
+  "conclusion": {
+    "summary": "A fully machine-verified, axiom-free proof that the spherical and hyperbolic Pythagorean theorems both degenerate to the Euclidean identity c² = a² + b² in the flat limit. The two reductions are unified by a single scaled second-order limit — (1 − cos(tx))/t² → x²/2 and (cosh(tx) − 1)/t² → x²/2 — with the spherical case routed through continuity of Real.sinc and the hyperbolic case through a squeeze bound. No range restriction on the side lengths is required. Zero axioms, zero sorries, 19 theorems.",
+    "implications": "The entry pins down, in checked form, the sense in which Euclidean geometry is the K → 0 limit of both curved constant-curvature geometries at once: the curved right-angle laws share a second-order germ, and that germ is Pythagoras. The scaled-limit lemmas (tendsto_one_sub_cos_mul_div_sq, tendsto_cosh_mul_sub_one_div_sq) and the monotonicity bound 2(cosh u − 1) ≤ u²·cosh u are reusable infrastructure for other flat-limit / curvature-degeneration arguments (e.g. deriving the Euclidean law of cosines from the spherical/hyperbolic law of cosines, or the flat metric from the round/hyperbolic metric). It complements the gallery's algebraic Pythagorean entries by giving the analytic, differential-geometric viewpoint.",
+    "openQuestions": [
+      "Derive the curved laws' hypotheses from an intrinsic model: prove cos c = cos a · cos b directly from spherical geometry (great-circle arcs on S²) and cosh c = cosh a · cosh b from the hyperboloid/Poincaré model, so the flat-limit theorems apply to genuine geometric triangles rather than to an assumed functional equation",
+      "Extend the flat limit to the full (non-right-angle) laws of cosines — cos c = cos a cos b + sin a sin b cos C and its hyperbolic analogue — and show they degenerate to the Euclidean law of cosines c² = a² + b² − 2ab cos C",
+      "Quantify the rate: give an explicit O(t²) error term for c² − (a² + b²) at finite curvature, turning the qualitative flat limit into a first-order curvature correction",
+      "Unify the two curvatures with a single signed-curvature parameter K and prove one theorem in which K = 0 is a removable degeneration, recovering both cases and the Euclidean case continuously"
+    ]
+  },
+  "leanFile": {
+    "namespace": "PythagoreanFlatLimit",
+    "lineCount": 443,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTheoremOQ05.lean",
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv",
+      "Mathlib.Analysis.SpecialFunctions.ExpDeriv",
+      "Mathlib.Analysis.Calculus.MeanValue",
+      "Mathlib.Topology.Algebra.Order.LiminfLimsup",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Sinc",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Set"
+    ],
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "extends",
+      "description": "The classical Euclidean theorem a² + b² = c². This entry shows that same identity is the flat limit (curvature → 0) of the spherical law cos c = cos a cos b and the hyperbolic law cosh c = cosh a cosh b, giving the analytic/geometric reason the Euclidean form is the K = 0 case."
+    },
+    {
+      "targetId": "pythagorean-theorem-oq-04",
+      "relationship": "related",
+      "description": "The Gaussian-integer (algebraic) recasting of the Pythagorean identity. Where OQ-04 reads a² + b² = c² as norm multiplicativity in ℤ[i], OQ-05 reads it as the degenerate second-order limit of the curved laws of cosines — the algebraic and differential-geometric viewpoints on the same theorem."
+    }
+  ],
+  "sections": [
+    {
+      "id": "derivatives",
+      "title": "Part I: Derivatives of cosh and sinh",
+      "startLine": 47,
+      "endLine": 74,
+      "summary": "hasDerivAt_cosh' and hasDerivAt_sinh' package the derivatives of Real.cosh and Real.sinh in the HasDerivAt form used by the later mean-value arguments."
+    },
+    {
+      "id": "basic-inequalities",
+      "title": "Part II: Basic hyperbolic inequalities",
+      "startLine": 75,
+      "endLine": 147,
+      "summary": "Elementary bounds cosh > 0, cosh ≥ 1, sinh x ≥ x for x ≥ 0, and the quadratic lower bound cosh x ≥ 1 + x²/2 (first for x ≥ 0, then all x by parity in cosh_ge_one_add_sq_div_two_all), each proved through the mean value theorem on the derivatives from Part I."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Part III: The upper bound 2(cosh u − 1) ≤ u²·cosh u",
+      "startLine": 148,
+      "endLine": 250,
+      "summary": "cosh_sub_one_le_sq_mul_cosh(_all) proves 2(cosh u − 1) ≤ u²·cosh u by a two-level monotonicity argument: the function u²·cosh u − 2(cosh u − 1) has second derivative u²·cosh u + 4u·sinh u ≥ 0 for u ≥ 0, so it and its derivative are increasing from 0. This is the upper half of the hyperbolic squeeze."
+    },
+    {
+      "id": "scaled-limit-hyperbolic",
+      "title": "Part IV: The hyperbolic scaled limit (cosh(tx) − 1)/t² → x²/2",
+      "startLine": 251,
+      "endLine": 285,
+      "summary": "cosh_mul_sub_one_div_sq_bounds sandwiches (cosh(tx) − 1)/t² between x²/2 and x²·cosh(tx)/2 using the Part II lower bound and the Part III upper bound; tendsto_cosh_mul_sub_one_div_sq then squeezes to x²/2 as t → 0⁺."
+    },
+    {
+      "id": "product-limit-hyperbolic",
+      "title": "Part V: The hyperbolic product limit → (a²+b²)/2",
+      "startLine": 286,
+      "endLine": 316,
+      "summary": "tendsto_cosh_prod_sub_one_div_sq computes (cosh(ta)·cosh(tb) − 1)/t² → (a²+b²)/2 via the telescoping factorization f·g − 1 = (f − 1)·g + (g − 1) together with tendsto_cosh_mul_one (cosh(tx) → 1) for continuity at 0."
+    },
+    {
+      "id": "hyperbolic-main",
+      "title": "Part VI: Hyperbolic flat limit",
+      "startLine": 317,
+      "endLine": 343,
+      "summary": "hyperbolic_flat_limit: from cosh(t·c) = cosh(t·a)·cosh(t·b) for all t > 0, the two scaled quantities agree on Ioi 0, so their limits c²/2 and (a²+b²)/2 coincide by tendsto_nhds_unique, giving c² = a² + b²."
+    },
+    {
+      "id": "scaled-limit-spherical",
+      "title": "Part Va: The spherical scaled limit via sinc",
+      "startLine": 344,
+      "endLine": 401,
+      "summary": "sin_eq_sinc_mul (sin u = sinc u · u) and the half-angle identity turn (1 − cos(tx))/t² into (x²/2)·sinc(tx/2)²; tendsto_one_sub_cos_mul_div_sq concludes the limit x²/2 from continuity of Real.sinc at 0, avoiding all monotonicity machinery."
+    },
+    {
+      "id": "product-and-spherical-main",
+      "title": "Part Vb–VI: Spherical product limit and spherical flat limit",
+      "startLine": 402,
+      "endLine": 443,
+      "summary": "tendsto_one_sub_cos_prod_div_sq telescopes the product side to (a²+b²)/2; spherical_flat_limit then mirrors the hyperbolic argument: cos(t·c) = cos(t·a)·cos(t·b) forces c²/2 = (a²+b²)/2 by uniqueness of limits, hence c² = a² + b² with no range restriction on a, b, c."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/pythagorean-theorem-oq-01.json
+++ b/src/data/research/problems/pythagorean-theorem-oq-01.json
@@ -39,10 +39,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM REDUCTION: PythagoreanTriplesOQ01.lean 6→3 axioms. Removed 3 unused supplementary axioms (r2_average_order was additionally FALSE as stated — nonneg-pair average order is π/4 not π). Remaining 3 are the load-bearing Gauss-circle/Möbius/parity assumptions. Full docker verification memory-blocked (>90GB for fresh elaboration; change is compile-safe removal of unused decls).",
+    "progressSummary": "GALLERY: pythagorean-theorem-oq-05 entry created for the verified flat-limit result (spherical cos c=cos a cos b AND hyperbolic cosh c=cosh a cosh b both degenerate to c²=a²+b² as curvature→0; 0/0, 3070 jobs). PythagoreanTriplesOQ01.lean remains at 3 load-bearing Gauss-circle/Möbius/parity axioms — genuinely blocked (each needs >1000 lines of lattice-point-counting infrastructure absent from Mathlib v4.26).",
     "builtItems": [
       "sin_eq_sinc_mul, tendsto_one_sub_cos_mul_div_sq, tendsto_cos_mul_one, tendsto_one_sub_cos_prod_div_sq, spherical_flat_limit in Proofs/PythagoreanTheoremOQ05.lean (0 sorry, 0 axioms, verified via lake env lean 4.26.0)",
-      "Removed 3 unused axioms from Proofs/PythagoreanTriplesOQ01.lean (r2_average_order [false as stated], landau_two_squares, primitive_by_leg_density), reducing 6→3; content retained as documented targets. Updated meta.json axiomCount 6→3 in both stat blocks + assumptions/keyStatements/annotations."
+      "Removed 3 unused axioms from Proofs/PythagoreanTriplesOQ01.lean (r2_average_order [false as stated], landau_two_squares, primitive_by_leg_density), reducing 6→3; content retained as documented targets. Updated meta.json axiomCount 6→3 in both stat blocks + assumptions/keyStatements/annotations.",
+      "Created gallery entry src/data/proofs/pythagorean-theorem-oq-05/ (meta.json + 5 annotations) for the flat-limit file PythagoreanTheoremOQ05.lean — status verified, badge mathlib, 0 axioms / 0 sorries, docker-build confirmed 3070 jobs green"
     ],
     "insights": [
       "Spherical flat limit: from cos(tc)=cos(ta)cos(tb) ∀t>0, c²=a²+b² follows by the exact identity (1-cos(tx))/t² = (x²/2)·sinc(tx/2)², using half-angle 1-cos(tx)=2sin(tx/2)² and sin u = sinc u · u; sinc continuity (sinc 0 = 1) gives the limit. No range restriction on a,b,c needed.",
@@ -54,7 +55,6 @@
       "Mathlib cache drift broke the existing hyperbolic section: le_div_iff→le_div_iff₀, div_le_div_iff→div_le_div_iff₀, Filter.eventually_nhdsWithin_of_forall→eventually_nhdsWithin_of_forall, Tendsto.congr! argument order (eventuallyEq first), pointwise squeeze tendsto_of_tendsto_of_tendsto_of_le_of_le→eventually variant (prime), HasDerivAt.sub of a const now yields x-0 (needs simpa/convert), and let-bound f 0 = 0 no longer closes by bare simp (needs show)."
     ],
     "nextSteps": [
-      "Optionally create a gallery entry (src/data/proofs/pythagorean-theorem-oq-05) for the now-complete flat-limit file.",
       "Audit sibling pythagorean files (OQ03 etc.) for the same Mathlib drift.",
       "Future: prove the corrected quarter-disk average order (→π/4) once Mathlib gains lattice-point-counting / Gauss-circle infrastructure; likewise Landau–Ramanujan and leg-density."
     ],


### PR DESCRIPTION
## Summary

Surfaces the fully-verified `PythagoreanTheoremOQ05.lean` (already on main, 443 lines, 19 theorems, **0 axioms / 0 sorries**, docker-build **3070 jobs green**) as a gallery entry. Previously this verified file had no gallery presence — it was the top open next-step for the `pythagorean-theorem-oq-01` research problem.

## The result

Both non-Euclidean right-angle Pythagorean laws degenerate to the Euclidean identity `c² = a² + b²` in the flat limit (curvature → 0):

- **Spherical**: `cos(t·c) = cos(t·a)·cos(t·b)` for all t > 0  ⟹  `c² = a² + b²`
- **Hyperbolic**: `cosh(t·c) = cosh(t·a)·cosh(t·b)` for all t > 0  ⟹  `c² = a² + b²`

Both are unified by a single scaled second-order limit — `(1 − cos(tx))/t² → x²/2` and `(cosh(tx) − 1)/t² → x²/2` — where t = 1/R plays the role of reciprocal curvature radius. The spherical case is routed cleanly through continuity of `Real.sinc` at 0; the hyperbolic case through the squeeze bound `2(cosh u − 1) ≤ u²·cosh u`. No range restriction on a, b, c.

## Changes

- `src/data/proofs/pythagorean-theorem-oq-05/meta.json` — new gallery entry (status `verified`, badge `mathlib`, axiomCount 0)
- `src/data/proofs/pythagorean-theorem-oq-05/annotations.json` — 5 annotations (all anchor-validated against the Lean source)
- `src/data/research/problems/pythagorean-theorem-oq-01.json` — knowledge update

## Verification

- `PythagoreanTheoremOQ05.lean` docker-build: **3070 jobs, green**; `grep` confirms 0 `axiom` decls, 0 `sorry`, no `native_decide`.
- Gallery build (`scripts/annotations/build.ts`): entry discovered, **0 annotation errors** for this slug.

## Scope note

The parent problem's other file, `PythagoreanTriplesOQ01.lean`, remains **blocked** on 3 load-bearing axioms (Gauss-circle lattice-point density ~πN/8, coprime density 6/π², parity equidistribution 1/3) — each needs >1000 lines of lattice-point-counting infrastructure absent from Mathlib v4.26. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)