### PR TITLE
research: integrate 4 verified proofs from fleet-shutdown recovery queue

### DIFF
--- a/proofs/Proofs/BurnsideCounting.lean
+++ b/proofs/Proofs/BurnsideCounting.lean
@@ -341,17 +341,20 @@ def ColoringEquiv {n k : ℕ} [NeZero n] (c₁ c₂ : Coloring n k) : Prop :=
     - |Fix(3)| = 2 (only constant colorings)
     Sum = 24.
 
-    Discharged in S3 (researcher-9, 2026-06-10) by `native_decide`:
+    Discharged by `decide` (S3 originally used `native_decide`; the S5 drift
+    repair for Mathlib v4.26 switched to the kernel tactic `decide`, which
+    both fixes a native-compilation crash and removes the `Lean.ofReduceBool`
+    dependency for this theorem):
     `Coloring 4 2 = Fin 4 → Fin 2` is finite; `IsFixedByRotation r` is
     decidable (instance above); hence
     `Fintype.card { c // IsFixedByRotation r c }` is computable and the
-    arithmetic identity is verified by evaluation of `decide`. -/
+    arithmetic identity is verified by kernel evaluation of `decide`. -/
 theorem fixed_point_sum_binary_4 :
     Fintype.card { c : Coloring 4 2 // IsFixedByRotation 0 c } +
     Fintype.card { c : Coloring 4 2 // IsFixedByRotation 1 c } +
     Fintype.card { c : Coloring 4 2 // IsFixedByRotation 2 c } +
     Fintype.card { c : Coloring 4 2 // IsFixedByRotation 3 c } = 24 := by
-  native_decide
+  decide
 
 /-- The equivalence relation on colorings by rotation.
     Derived from `AddAction.orbitRel` (replacing the prior axiom): two
@@ -381,24 +384,46 @@ def coloringQuotientFintype (n k : ℕ) [NeZero n] :
     There are exactly 6 distinct binary necklaces of length 4.
 
     Mathematically this is Burnside's lemma: `(16 + 2 + 4 + 2) / 4 = 6`.
-    Formally it is discharged directly: `coloringQuotientFintype 4 2` is a
-    *computable* `Fintype (Quotient (coloringSetoid 4 2))` — built from
-    `Quotient.fintype` over the finite carrier `Coloring 4 2 = Fin 4 → Fin 2`
-    and the decidable orbit relation `coloringSetoid_decidableRel`. So
-    `Fintype.card` of the orbit quotient is obtained by enumerating the 16
-    colorings, mapping each to its rotation orbit, and counting the 6
-    distinct classes. `native_decide` evaluates that chain at native speed.
 
-    Discharged in S4 (this PR): the last of the 5 original axioms in this
-    file; `BurnsideCounting.lean` is now axiom-free. -/
+    S4 originally discharged this by `native_decide` over the computable
+    `coloringQuotientFintype 4 2`, enumerating the orbit quotient directly.
+    The S5 drift repair replaces that with a genuine application of Mathlib's
+    additive Burnside lemma
+    `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup`:
+      `∑ a : ZMod 4, |Fix a| = |orbits| * |ZMod 4|`.
+    The fixed-point sum is `24` (`fixed_point_sum_binary_4`, whose subtypes
+    `{c // IsFixedByRotation a c}` are defeq to `fixedBy (Coloring 4 2) a`)
+    and `|ZMod 4| = 4`, so `|orbits| * 4 = 24`, giving `|orbits| = 6` by
+    arithmetic — no quotient enumeration required. This route is kernel-checked
+    (no `native_decide`, no `Lean.ofReduceBool`): it counts orbits from the
+    fixed-point data rather than by native evaluation of the quotient. -/
 theorem binary_necklaces_4 :
     @Fintype.card (Quotient (@coloringSetoid 4 2 _)) (coloringQuotientFintype 4 2) = 6 := by
-  native_decide
-
-#check burnside_lemma
-#check cyclicAddActionOnColorings
-#check binary_4_colorings_count
-#check constant_4_2
-#check period2_count
-
-end BurnsideCounting
+  -- Supply the orbit-quotient `Fintype` in BOTH the `coloringSetoid` form (used
+  -- by the goal / calc LHS) and the defeq `orbitRel` form (used by Burnside's
+  -- `hb` and the calc RHS), both as `coloringQuotientFintype 4 2`, so every
+  -- `Fintype.card` of the quotient resolves to the same instance.
+  letI : Fintype (Quotient (@coloringSetoid 4 2 _)) := coloringQuotientFintype 4 2
+  letI : Fintype (Quotient (AddAction.orbitRel (ZMod 4) (Coloring 4 2))) :=
+    coloringQuotientFintype 4 2
+  -- Additive Burnside: `∑ a, |Fix a| = |orbits| * |ZMod 4|`.
+  have hb := AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup
+    (ZMod 4) (Coloring 4 2)
+  -- `fixedBy (Coloring 4 2) a` and `{c // IsFixedByRotation a c}` are defeq.
+  have hbridge : ∀ a : ZMod 4,
+      Fintype.card (AddAction.fixedBy (Coloring 4 2) a) =
+        Fintype.card { c : Coloring 4 2 // IsFixedByRotation a c } := fun a =>
+    Fintype.card_congr (Equiv.subtypeEquivRight fun _ => Iff.rfl)
+  have hsum : (∑ a : ZMod 4, Fintype.card (AddAction.fixedBy (Coloring 4 2) a)) = 24 := by
+    simp only [hbridge]
+    decide
+  have hcard : Fintype.card (ZMod 4) = 4 := by decide
+  rw [hsum, hcard] at hb
+  -- hb : 24 = Fintype.card (Quotient (orbitRel (ZMod 4) (Coloring 4 2))) * 4.
+  -- Bridge the goal's quotient (`coloringSetoid` form + `coloringQuotientFintype`
+  -- instance) to Burnside's (`orbitRel` form) in term mode; a `rw` would force
+  -- the kernel to reduce `coloringQuotientFintype`, which is expensive.
+  calc @Fintype.card (Quotient (@coloringSetoid 4 2 _)) (coloringQuotientFintype 4 2)
+      = Fintype.card (Quotient (AddAction.orbitRel (ZMod 4) (Coloring 4 2))) :=
+        Fintype.card_congr (Equiv.refl _)
+    _ = 6 := by omega

--- a/proofs/Proofs/Erdos771Problem.lean
+++ b/proofs/Proofs/Erdos771Problem.lean
@@ -84,10 +84,123 @@ noncomputable def f (n : ℕ) : ℕ :=
 def f_property (n k : ℕ) : Prop :=
   ∀ m ≥ 1, ∃ S : Finset ℕ, S ⊆ Icc_n n ∧ S.card ≥ k ∧ AvoidSum S m
 
+/-- If every element of `S` is strictly larger than `m`, then `S` avoids `m`:
+    every nonempty subset sum is at least its (single) minimum element `> m`, and
+    the empty subset sums to `0`, which is filtered out of `subsetSums`. -/
+theorem avoid_of_forall_lt (S : Finset ℕ) (m : ℕ) (hlb : ∀ a ∈ S, m < a) :
+    AvoidSum S m := by
+  intro hmem
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+  obtain ⟨⟨A, hA, hAsum⟩, hpos⟩ := hmem
+  rw [Finset.mem_powerset] at hA
+  rcases A.eq_empty_or_nonempty with hA0 | hA1
+  · rw [hA0, Finset.sum_empty] at hAsum; omega
+  · obtain ⟨a₀, ha₀⟩ := hA1
+    have hle : a₀ ≤ ∑ a ∈ A, a := Finset.single_le_sum (fun i _ => Nat.zero_le i) ha₀
+    have hlt : m < a₀ := hlb a₀ (hA ha₀)
+    rw [hAsum] at hle
+    omega
+
+/-- A positive element of `S`, taken as the singleton `{a}`, is one of its subset
+    sums. Hence a set containing a positive `m` cannot avoid `m`. -/
+theorem self_mem_subsetSums (S : Finset ℕ) (a : ℕ) (ha : a ∈ S) (hpos : 0 < a) :
+    a ∈ subsetSums S := by
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image]
+  refine ⟨⟨{a}, ?_, ?_⟩, hpos⟩
+  · rw [Finset.mem_powerset]; simpa using ha
+  · simp
+
+/-- Every avoiding subset of `{1,…,n}` has size at most `n`. -/
+theorem maxAvoidingSize_le (n m : ℕ) : maxAvoidingSize n m ≤ n := by
+  classical
+  unfold maxAvoidingSize
+  apply Finset.sup_le
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS
+  have hcard : S.card ≤ (Icc_n n).card := Finset.card_le_card hS.1
+  rw [Icc_n, Nat.card_Icc] at hcard
+  omega
+
+/-- For `m > n²` the whole set `{1,…,n}` avoids `m`: every subset sum is at most
+    `|A|·n ≤ n·n < m`, so `m` is never realised. -/
+theorem avoid_full (n m : ℕ) (h : n * n < m) : AvoidSum (Icc_n n) m := by
+  intro hmem
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+  obtain ⟨⟨A, hA, hAsum⟩, _⟩ := hmem
+  rw [Finset.mem_powerset] at hA
+  have hbound : ∑ a ∈ A, a ≤ A.card * n := by
+    have hle := Finset.sum_le_card_nsmul A id n (fun a ha => by
+      have haI : a ∈ Icc_n n := hA ha
+      rw [Icc_n, Finset.mem_Icc] at haI; simpa using haI.2)
+    simpa [smul_eq_mul] using hle
+  have hcard : A.card ≤ n := by
+    have hc := Finset.card_le_card hA
+    rw [Icc_n, Nat.card_Icc] at hc; omega
+  have hfin : ∑ a ∈ A, a ≤ n * n :=
+    le_trans hbound (Nat.mul_le_mul hcard (le_refl n))
+  rw [hAsum] at hfin
+  omega
+
+/-- Key bridge: an avoiding subset of size ≥ k exists iff `maxAvoidingSize n m ≥ k`. -/
+theorem maxAvoidingSize_ge_iff (n m k : ℕ) :
+    (∃ S : Finset ℕ, S ⊆ Icc_n n ∧ S.card ≥ k ∧ AvoidSum S m)
+      ↔ k ≤ maxAvoidingSize n m := by
+  classical
+  constructor
+  · rintro ⟨S, hSsub, hScard, hSavoid⟩
+    have hmem : S ∈ (Finset.powerset (Icc_n n)).filter (fun S => AvoidSum S m) := by
+      rw [Finset.mem_filter, Finset.mem_powerset]; exact ⟨hSsub, hSavoid⟩
+    calc k ≤ S.card := hScard
+      _ ≤ maxAvoidingSize n m := by unfold maxAvoidingSize; exact Finset.le_sup hmem
+  · intro hk
+    rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+    · exact ⟨∅, Finset.empty_subset _, by rw [hk0]; exact Nat.zero_le _,
+        avoid_of_forall_lt ∅ m (fun a ha => absurd ha (Finset.notMem_empty a))⟩
+    · unfold maxAvoidingSize at hk
+      rw [Finset.le_sup_iff (show (⊥ : ℕ) < k from hkpos)] at hk
+      obtain ⟨S, hSmem, hScard⟩ := hk
+      rw [Finset.mem_filter, Finset.mem_powerset] at hSmem
+      exact ⟨S, hSmem.1, hScard, hSmem.2⟩
+
 /-- f(n) is the largest k satisfying f_property. -/
 theorem f_characterization (n : ℕ) (hn : n ≥ 1) :
     f_property n (f n) ∧ ∀ k > f n, ¬f_property n k := by
-  sorry
+  classical
+  have hn0 : n ≠ 0 := by omega
+  have H : (Finset.Icc 1 (n * n)).Nonempty :=
+    Finset.nonempty_Icc.mpr (Nat.one_le_iff_ne_zero.mpr (Nat.mul_ne_zero hn0 hn0))
+  have hf : f n = (Finset.Icc 1 (n * n)).inf' H (fun m => maxAvoidingSize n m) := by
+    unfold f; rw [dif_neg hn0]
+  have hfn_le : f n ≤ n := by
+    rw [hf]
+    calc (Finset.Icc 1 (n * n)).inf' H (fun m => maxAvoidingSize n m)
+        ≤ maxAvoidingSize n 1 :=
+          Finset.inf'_le _ (Finset.mem_Icc.mpr ⟨le_refl 1, by nlinarith [hn]⟩)
+      _ ≤ n := maxAvoidingSize_le n 1
+  refine ⟨?_, ?_⟩
+  · -- f_property n (f n)
+    intro m hm
+    rw [maxAvoidingSize_ge_iff]
+    rcases le_or_lt m (n * n) with hmle | hmgt
+    · rw [hf]; exact Finset.inf'_le _ (Finset.mem_Icc.mpr ⟨hm, hmle⟩)
+    · have hfull : n ≤ maxAvoidingSize n m := by
+        have hmemfull : Icc_n n ∈
+            (Finset.powerset (Icc_n n)).filter (fun S => AvoidSum S m) := by
+          rw [Finset.mem_filter, Finset.mem_powerset]
+          exact ⟨Finset.Subset.refl _, avoid_full n m hmgt⟩
+        calc n = (Icc_n n).card := by rw [Icc_n, Nat.card_Icc]; omega
+          _ ≤ maxAvoidingSize n m := by unfold maxAvoidingSize; exact Finset.le_sup hmemfull
+      omega
+  · -- maximality
+    intro k hk hprop
+    obtain ⟨m₀, hm₀mem, hm₀eq⟩ :=
+      Finset.exists_mem_eq_inf' H (fun m => maxAvoidingSize n m)
+    rw [Finset.mem_Icc] at hm₀mem
+    obtain ⟨S, hSsub, hScard, hSavoid⟩ := hprop m₀ hm₀mem.1
+    have hle : k ≤ maxAvoidingSize n m₀ :=
+      (maxAvoidingSize_ge_iff n m₀ k).mp ⟨S, hSsub, hScard, hSavoid⟩
+    have hfm0 : f n = maxAvoidingSize n m₀ := by rw [hf, hm₀eq]
+    omega
 
 /-
 ## Part III: The Erdős-Graham Conjecture
@@ -233,15 +346,53 @@ theorem leading_constant :
 ## Part VIII: Special Cases
 -/
 
-/-- For m = 1, we can't include 1 in S. -/
+/-- For m = 1, we can't include 1 in S, so the largest 1-avoiding subset of
+    `{1,…,n}` is `{2,…,n}`, of size `n − 1`. -/
 theorem m_eq_one_case (n : ℕ) (hn : n ≥ 1) :
     maxAvoidingSize n 1 = n - 1 := by
-  sorry
+  classical
+  unfold maxAvoidingSize
+  apply le_antisymm
+  · -- every 1-avoiding S omits 1, so |S| ≤ n − 1
+    apply Finset.sup_le
+    intro S hS
+    rw [Finset.mem_filter, Finset.mem_powerset] at hS
+    obtain ⟨hSsub, hSavoid⟩ := hS
+    have h1notin : 1 ∉ S := fun h1 => hSavoid (self_mem_subsetSums S 1 h1 one_pos)
+    have hsub2 : S ⊆ Finset.Icc 2 n := by
+      intro x hx
+      have hxI : x ∈ Icc_n n := hSsub hx
+      rw [Icc_n, Finset.mem_Icc] at hxI
+      rw [Finset.mem_Icc]
+      rcases Nat.lt_or_ge x 2 with hlt | hge
+      · interval_cases x
+        · omega
+        · exact absurd hx h1notin
+      · exact ⟨hge, hxI.2⟩
+    calc S.card ≤ (Finset.Icc 2 n).card := Finset.card_le_card hsub2
+      _ = n - 1 := by rw [Nat.card_Icc]; omega
+  · -- {2,…,n} is 1-avoiding with size n − 1
+    have hmem : Finset.Icc 2 n ∈
+        (Finset.powerset (Icc_n n)).filter (fun S => AvoidSum S 1) := by
+      rw [Finset.mem_filter, Finset.mem_powerset]
+      refine ⟨fun x hx => by rw [Finset.mem_Icc] at hx; rw [Icc_n, Finset.mem_Icc]; omega,
+        avoid_of_forall_lt _ 1 (fun a ha => by rw [Finset.mem_Icc] at ha; omega)⟩
+    calc n - 1 = (Finset.Icc 2 n).card := by rw [Nat.card_Icc]; omega
+      _ ≤ _ := Finset.le_sup hmem
 
-/-- For m = 2, we can't include 2 or have {1} alone. -/
+/-- For m = 2, the set `{3,…,n}` is 2-avoiding and has size `n − 2`, so the
+    largest 2-avoiding subset has size at least `n − 2`. -/
 theorem m_eq_two_case (n : ℕ) (hn : n ≥ 2) :
     maxAvoidingSize n 2 ≥ n - 2 := by
-  sorry
+  classical
+  unfold maxAvoidingSize
+  have hmem : Finset.Icc 3 n ∈
+      (Finset.powerset (Icc_n n)).filter (fun S => AvoidSum S 2) := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨fun x hx => by rw [Finset.mem_Icc] at hx; rw [Icc_n, Finset.mem_Icc]; omega,
+      avoid_of_forall_lt _ 2 (fun a ha => by rw [Finset.mem_Icc] at ha; omega)⟩
+  calc n - 2 = (Finset.Icc 3 n).card := by rw [Nat.card_Icc]; omega
+    _ ≤ _ := Finset.le_sup hmem
 
 /-- Small primes give good constructions. -/
 def smallPrimeConstruction (m n : ℕ) : Finset ℕ :=

--- a/proofs/Proofs/LagrangeTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ02OQ03.lean
@@ -1,0 +1,167 @@
+import Mathlib.GroupTheory.GroupAction.Quotient
+import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.Coset.Basic
+import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.Tactic
+
+/-!
+# Orbit–Stabilizer Without Finiteness — The Bijection and its Cardinal Corollary
+
+## What This Proves
+
+This file answers `oq-03` of the parent `lagrange-theorem-oq-02` (the
+orbit–stabilizer family).  The parent, and the `Nat.card` sibling
+`lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01`, phrase orbit–stabilizer
+over `Nat.card`, which is **`0` on infinite types**.  Over `Nat.card` the
+identity `#(orbit) = [G : stabilizer]` still holds unconditionally (the bijection
+is finiteness-free), but the *product* form `#(orbit) · #(stabilizer) = #G`
+degenerates to `0 = 0` as soon as anything in sight is infinite, and the
+statement `#(orbit) = #(G ⧸ stabilizer)` carries no information when the orbit is
+infinite.
+
+This file gives the **honest infinite-general** formulation over `Cardinal.mk`,
+where every identity retains its content for infinite groups, orbits, and
+stabilizers:
+
+* the orbit–stabilizer **bijection** `orbit G x ≃ G ⧸ stabilizer G x`, together
+  with the explicit coset characterization of when two group elements send `x` to
+  the same point (`g₁ • x = g₂ • x ↔ g₁⁻¹ g₂ ∈ stabilizer ↔ ↑g₁ = ↑g₂` in the
+  coset space);
+* the **cardinal** identity `#(orbit G x) = #(G ⧸ stabilizer G x)`, a genuine
+  equality of (possibly infinite) cardinals;
+* the **cardinal orbit–stabilizer product** `#(orbit G x) · #(stabilizer G x) = #G`
+  for an *arbitrary* group, obtained from the cardinal form of Lagrange's theorem
+  `#G = #(G ⧸ H) · #H` (`Subgroup.groupEquivQuotientProdSubgroup`), and which — unlike
+  its `Nat.card` shadow — stays true and informative in the infinite setting;
+* the **finite specialization**, recovering the classical product formula over
+  `Nat.card`;
+* the **transitive** case, where the orbit is everything and one reads off
+  `#X = #(G ⧸ stabilizer G x)`.
+
+The mathematical point: finiteness plays no role in orbit–stabilizer.  What is
+really going on is a bijection, and taking cardinalities of a bijection is
+finiteness-free.  Working over `Cardinal.mk` rather than `Nat.card` is what makes
+that content survive into the infinite regime.
+
+## Status
+- [x] Coset characterization of equal images (`same_image_iff_*`) — `0` sorries
+- [x] Cardinal orbit–stabilizer bijection and cardinal identity — `0` sorries
+- [x] Cardinal Lagrange `#G = #(G ⧸ H) · #H` and cardinal orbit–stabilizer product
+- [x] Finite `Nat.card` specialization
+- [x] Transitive-action corollary
+- 0 axioms beyond Mathlib's foundational `propext`/`Classical.choice`/`Quot.sound`.
+
+## Mathlib Dependencies
+- `Mathlib.GroupTheory.GroupAction.Quotient` : `MulAction.orbitEquivQuotientStabilizer`
+- `Mathlib.GroupTheory.Coset.Basic` : `Subgroup.groupEquivQuotientProdSubgroup`,
+  `QuotientGroup.eq`
+- `Mathlib.SetTheory.Cardinal.Finite` : `Cardinal.mk_congr`, `Cardinal.mk_prod`,
+  `Cardinal.lift_id`, `Nat.card_congr`
+-/
+
+namespace OrbitStabilizerCardinal
+
+open MulAction Cardinal
+
+universe u
+
+variable {G : Type u} [Group G] {X : Type u} [MulAction G X]
+
+/-! ### The coset characterization of the bijection
+
+The heart of orbit–stabilizer is a *pointwise* fact with no finiteness anywhere:
+two group elements move `x` to the same place exactly when they lie in the same
+left coset of the stabilizer.  This is the map `g • x ↦ g · stabilizer` being
+well defined and injective. -/
+
+/-- Two elements send `x` to the same point iff `g₁⁻¹ g₂` stabilizes `x`. -/
+theorem same_image_iff_mem_stabilizer (x : X) (g₁ g₂ : G) :
+    g₁ • x = g₂ • x ↔ g₁⁻¹ * g₂ ∈ stabilizer G x := by
+  rw [mem_stabilizer_iff, mul_smul]
+  constructor
+  · intro h
+    rw [← h, ← mul_smul, inv_mul_cancel, one_smul]
+  · intro h
+    calc g₁ • x = g₁ • (g₁⁻¹ • (g₂ • x)) := by rw [h]
+      _ = g₂ • x := by rw [← mul_smul, mul_inv_cancel, one_smul]
+
+/-- Two elements send `x` to the same point iff they represent the same coset in
+`G ⧸ stabilizer G x`.  This is precisely the statement that
+`g • x ↦ (g : G ⧸ stabilizer G x)` is a well-defined injection of the orbit into
+the coset space — the finiteness-free content of orbit–stabilizer. -/
+theorem same_image_iff_coset_eq (x : X) (g₁ g₂ : G) :
+    g₁ • x = g₂ • x ↔ (g₁ : G ⧸ stabilizer G x) = (g₂ : G ⧸ stabilizer G x) := by
+  rw [same_image_iff_mem_stabilizer, ← QuotientGroup.eq]
+
+/-! ### The bijection and the cardinal identity -/
+
+/-- **Orbit–stabilizer bijection, no finiteness hypothesis.**  This is Mathlib's
+`orbitEquivQuotientStabilizer`, restated here as the central object of this file:
+a genuine bijection between the orbit and the coset space, valid for *any* group
+action. -/
+noncomputable def orbitEquivQuotient (x : X) :
+    orbit G x ≃ G ⧸ stabilizer G x :=
+  orbitEquivQuotientStabilizer G x
+
+/-- **Cardinal orbit–stabilizer.**  `#(orbit G x) = #(G ⧸ stabilizer G x)` as an
+equality of cardinals, for an arbitrary (possibly infinite) group.  Unlike the
+`Nat.card` version, this retains its content when the orbit is infinite. -/
+theorem mk_orbit_eq_mk_quotient_stabilizer (x : X) :
+    #(orbit G x) = #(G ⧸ stabilizer G x) :=
+  mk_congr (orbitEquivQuotientStabilizer G x)
+
+/-! ### Cardinal Lagrange and the cardinal orbit–stabilizer product -/
+
+/-- **Cardinal form of Lagrange's theorem.**  `#G = #(G ⧸ H) · #H` for an
+arbitrary subgroup `H` of an arbitrary group `G`.  This is the cardinal image of
+the bijection `G ≃ (G ⧸ H) × H` (`Subgroup.groupEquivQuotientProdSubgroup`), and
+holds for infinite groups, where the `Nat.card` product formula collapses to
+`0 = 0`. -/
+theorem mk_eq_mk_quotient_mul_mk (H : Subgroup G) :
+    #G = #(G ⧸ H) * #H := by
+  rw [mk_congr (Subgroup.groupEquivQuotientProdSubgroup (s := H)), mk_prod,
+    lift_id, lift_id]
+
+/-- **Cardinal orbit–stabilizer product.**  `#(orbit G x) · #(stabilizer G x) = #G`
+for an arbitrary group action.  This is the infinite-general product form: it is
+obtained by feeding the cardinal identity `#(orbit) = #(G ⧸ stabilizer)` into the
+cardinal Lagrange identity, and — unlike `Nat.card (orbit) · Nat.card (stabilizer)
+= Nat.card G` — remains a true, non-degenerate statement when the group is
+infinite. -/
+theorem mk_orbit_mul_mk_stabilizer (x : X) :
+    #(orbit G x) * #(stabilizer G x) = #G := by
+  rw [mk_orbit_eq_mk_quotient_stabilizer, ← mk_eq_mk_quotient_mul_mk]
+
+/-! ### Finite specialization -/
+
+/-- **Finite specialization.**  For a finite group the cardinal product formula
+descends to the classical natural-number identity
+`#(orbit) · #(stabilizer) = #G` over `Nat.card`, recovering the statement of the
+parent gallery entry. -/
+theorem card_orbit_mul_card_stabilizer [Finite G] (x : X) :
+    Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G := by
+  rw [← Nat.card_prod, Nat.card_congr (orbitProdStabilizerEquivGroup G x)]
+
+/-! ### Transitive actions -/
+
+/-- **Transitive case.**  When the action is (pre)transitive the orbit of any
+point is all of `X`, so the cardinal identity reads
+`#X = #(G ⧸ stabilizer G x)`: the size of the space equals the index of any point
+stabilizer, with no finiteness assumption. -/
+theorem mk_eq_mk_quotient_stabilizer_of_pretransitive [MulAction.IsPretransitive G X]
+    (x : X) : #X = #(G ⧸ stabilizer G x) := by
+  have horbit : orbit G x = Set.univ := by
+    ext y
+    simp only [Set.mem_univ, iff_true, MulAction.mem_orbit_iff]
+    exact MulAction.exists_smul_eq G x y
+  rw [← mk_orbit_eq_mk_quotient_stabilizer, horbit, mk_univ]
+
+#check @same_image_iff_mem_stabilizer
+#check @same_image_iff_coset_eq
+#check @mk_orbit_eq_mk_quotient_stabilizer
+#check @mk_eq_mk_quotient_mul_mk
+#check @mk_orbit_mul_mk_stabilizer
+#check @card_orbit_mul_card_stabilizer
+#check @mk_eq_mk_quotient_stabilizer_of_pretransitive
+
+end OrbitStabilizerCardinal

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/annotations.json
@@ -14,7 +14,7 @@
   {
     "id": "bezout-irrednorm-ann-euclidean-instance",
     "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01",
-    "range": { "startLine": 40, "endLine": 45 },
+    "range": { "startLine": 42, "endLine": 45 },
     "type": "concept",
     "title": "The imported Euclidean structure: why irreducible ⟹ prime here",
     "content": "The whole necessity argument silently rests on one structural fact carried over from the parent import: for −2 ≤ d < 0, ℤ[√d] is norm-Euclidean, hence a PID, hence a unique factorization domain. That is exactly why `irreducible` can be traded for the far stronger `prime` — the step `UniqueFactorizationMonoid.irreducible_iff_prime` used at the top of the main theorem, activated by `letI := NormEuclideanZsqrtdFamily.euclideanDomain d hd hd2`. In a general integral domain irreducibles need not be prime, and neither the divides-a-rational-prime lemma (which uses `Prime.dvd_or_dvd`) nor the norm-comparison finish would go through. The bare `open Zsqrtd` / `variable {d : ℤ}` here is thus the seam where the earlier Euclidean-domain development is grafted onto this file; the hypotheses `hd : d < 0` and `hd2 : -2 ≤ d` threaded through every theorem are precisely the conditions under which that instance exists.",

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/meta.json
@@ -39,7 +39,8 @@
       "The norm turns a structural question about irreducibles into an elementary divisibility statement about integers: z prime divides N(z) = z·z̄, so it must divide a rational prime factor of |N(z)|.",
       "exists_prime_dvd_natCast is the crux — moving from 'z divides the image of a composite integer' to 'z divides the image of a rational prime' — and it is a clean strong induction that peels prime factors and uses Prime.dvd_or_dvd at each step.",
       "Once z ∣ ↑p is known, norm_intCast (N(↑p) = p²) forces |N(z)| ∣ p², and the only non-unit divisors of p² are p and p²; this is exactly the split/ramified (norm p) vs inert (norm p²) dichotomy.",
-      "This is the necessary direction complementing the parent's sufficient irreducible_of_prime_norm: prime norm ⟹ irreducible, and irreducible ⟹ norm p or p²."
+      "This is the necessary direction complementing the parent's sufficient irreducible_of_prime_norm: prime norm ⟹ irreducible, and irreducible ⟹ norm p or p².",
+      "The proof never case-splits on d: it invokes only d < 0 (to make the norm nonnegative, so ↑|N(z)| = N(z)) and −2 ≤ d < 0 (to summon the parent's EuclideanDomain/UFD instance). The p-vs-p² dichotomy is thus a formal consequence of 'UFD + nonnegative multiplicative norm', uniform across the whole family, and this is exactly why the leftover content — which rational primes are inert (norm p²) versus split (norm p) — is the genuinely d-dependent part, decided per-d by a congruence/Legendre-symbol condition rather than by the norm bound proved here."
     ],
     "prerequisites": [
       "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02: the parent PID/UFD entry with irreducible_of_prime_norm and the EuclideanDomain (ℤ√d) value for −2 ≤ d < 0",

--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "William Burnside (1897), Cauchy (1845), Frobenius (1887), formalized via Mathlib",
     "date": "1897",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BurnsideCounting.lean",
     "tags": [
       "combinatorics",
@@ -17,13 +17,13 @@
       "group-actions",
       "polya-enumeration"
     ],
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 1,
-    "assumptions": "Depends on the `Lean.ofReduceBool` axiom (1 assumption) introduced by `native_decide`; 0 literal `axiom` declarations, 0 sorries, no assumption-carrying structures. All 5 original axioms are discharged across S1–S4 of burnside-counting-oq-01: rotatedIndex_add (S1 / PR #21148, full Nat-modular proof); coloringSetoid + coloringQuotientFintype (S2, AddAction.orbitRel + Quotient.fintype with a decidable-orbit-relation instance); fixed_point_sum_binary_4 (S3, native_decide); binary_necklaces_4 (S4, native_decide on the computable orbit-quotient cardinality). NOTE: the two finite counts (fixed_point_sum_binary_4, binary_necklaces_4) close by `native_decide`, which trusts the Lean compiler (Lean.ofReduceBool) rather than performing kernel reduction; everything else is kernel-checked. burnside_lemma is a re-export of Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (a theorem, not an assumption).",
-    "lineCount": 404,
-    "theoremCount": 12,
+    "axiomCount": 0,
+    "assumptions": "None. The S5 drift repair (Mathlib v4.26) replaces every `native_decide` with kernel `decide` plus a genuine application of Mathlib's additive Burnside lemma `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup`, so the file no longer depends on `Lean.ofReduceBool`. `#print axioms fixed_point_sum_binary_4` and `#print axioms binary_necklaces_4` report only the foundational trio [propext, Classical.choice, Quot.sound]. 0 literal `axiom` declarations, 0 sorries, no assumption-carrying structures.",
+    "lineCount": 429,
+    "theoremCount": 9,
     "definitionCount": 9,
     "originalContributions": [
       "burnside_lemma: Burnside orbit-counting theorem from Mathlib (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
@@ -72,9 +72,9 @@
   },
   "leanFile": {
     "namespace": "BurnsideCounting",
-    "lineCount": 404,
+    "lineCount": 429,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 9,
     "definitionCount": 9,
     "path": "Proofs/BurnsideCounting.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 771,
     "erdosUrl": "https://erdosproblems.com/771",
     "erdosProblemStatus": "solved",
@@ -79,9 +79,9 @@
       "erdos_771, erdos_771_main, erdos_771_solved: main theorem statements"
     ],
     "axiomCount": 2,
-    "lineCount": 292,
-    "assumptions": "2 axioms: erdos_graham_lower_bound, alon_freiman_upper_bound. 7 sorries.",
-    "theoremCount": 11,
+    "lineCount": 443,
+    "assumptions": "2 axioms: erdos_graham_lower_bound, alon_freiman_upper_bound. 0 sorries.",
+    "theoremCount": 16,
     "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos771Aristotle.lean",
@@ -214,11 +214,11 @@
       "Nat"
     ],
     "namespace": "Erdos771",
-    "lineCount": 292,
+    "lineCount": 443,
     "axiomCount": 2,
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 16,
-    "sorries": 3,
+    "sorries": 0,
     "path": "Proofs/Erdos771Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos771Aristotle.lean",
@@ -243,5 +243,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, solved, subset-sums"
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }

--- a/src/data/proofs/pythagorean-theorem-oq-05/annotations.json
+++ b/src/data/proofs/pythagorean-theorem-oq-05/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-pt-oq05-shared-limit",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 270,
+      "endLine": 285
+    },
+    "type": "insight",
+    "title": "One Scaled Limit for Both Curvatures",
+    "content": "tendsto_cosh_mul_sub_one_div_sq proves (cosh(tx) − 1)/t² → x²/2 as t → 0⁺. Its spherical twin, tendsto_one_sub_cos_mul_div_sq (Part Va), proves (1 − cos(tx))/t² → the SAME x²/2. This shared second-order coefficient is the whole reason the spherical law cos c = cos a cos b and the hyperbolic law cosh c = cosh a cosh b both degenerate to the identical Euclidean form c² = a² + b². The flat limit is a statement about the germ of each curved law at t = 0, where both linearize to x ↦ x²/2.",
+    "mathContext": "$\\frac{\\cosh(tx)-1}{t^2} \\to \\frac{x^2}{2}$ and $\\frac{1-\\cos(tx)}{t^2} \\to \\frac{x^2}{2}$ as $t \\to 0^+$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "second-order Taylor germ",
+      "curvature degeneration",
+      "squeeze theorem",
+      "flat limit"
+    ],
+    "prerequisites": [
+      "limits in a filter",
+      "second-order behaviour of cos and cosh at 0"
+    ]
+  },
+  {
+    "id": "ann-pt-oq05-cosh-upper-bound",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 229,
+      "endLine": 250
+    },
+    "type": "tactic",
+    "title": "The Upper Bound by Two-Level Monotonicity",
+    "content": "cosh_sub_one_le_sq_mul_cosh (and its all-u extension cosh_sub_one_le_sq_mul_cosh_all just below) establishes 2(cosh u − 1) ≤ u²·cosh u — the upper half of the hyperbolic squeeze. The proof studies g(u) = u²·cosh u − 2(cosh u − 1): its second derivative g''(u) = u²·cosh u + 4u·sinh u is ≥ 0 for u ≥ 0, so g' is increasing from g'(0) = 0, hence g' ≥ 0, hence g is increasing from g(0) = 0, hence g ≥ 0. The all-u version follows because both sides are even in u. This turns a non-obvious inequality into two applications of the mean value theorem.",
+    "mathContext": "$2(\\cosh u - 1) \\le u^2 \\cosh u$, from $g''(u) = u^2\\cosh u + 4u\\sinh u \\ge 0$ for $u \\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "mean value theorem",
+      "second-derivative test",
+      "monotonicity from derivative sign",
+      "even functions"
+    ],
+    "prerequisites": [
+      "derivatives of cosh/sinh",
+      "monotonicity via MVT"
+    ]
+  },
+  {
+    "id": "ann-pt-oq05-sinc-route",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 350,
+      "endLine": 391
+    },
+    "type": "insight",
+    "title": "The Spherical Limit via sinc Continuity",
+    "content": "The spherical scaled limit avoids the monotonicity machinery of the hyperbolic case entirely. sin_eq_sinc_mul rewrites sin u = Real.sinc u · u; combined with the half-angle identity 1 − cos(tx) = 2 sin(tx/2)², the ratio (1 − cos(tx))/t² becomes exactly (x²/2)·sinc(tx/2)². Since Real.sinc is continuous with sinc 0 = 1, the limit as t → 0⁺ is (x²/2)·1² = x²/2. This is strictly cleaner than a squeeze: no bounds, no second derivatives — just continuity of a single Mathlib function at a point.",
+    "mathContext": "$\\frac{1-\\cos(tx)}{t^2} = \\frac{x^2}{2}\\,\\operatorname{sinc}\\!\\left(\\tfrac{tx}{2}\\right)^2 \\to \\frac{x^2}{2}$ since $\\operatorname{sinc}(0)=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.sinc",
+      "half-angle identity",
+      "continuity at a point",
+      "sin u = sinc u · u"
+    ],
+    "prerequisites": [
+      "Real.sinc and sinc 0 = 1",
+      "1 − cos θ = 2 sin²(θ/2)"
+    ]
+  },
+  {
+    "id": "ann-pt-oq05-telescope",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 300,
+      "endLine": 316
+    },
+    "type": "concept",
+    "title": "Linearizing the Product by Telescoping",
+    "content": "tendsto_cosh_prod_sub_one_div_sq handles the two-variable product side without any genuinely two-variable analysis. The factorization f·g − 1 = (f − 1)·g + (g − 1), applied with f = cosh(ta), g = cosh(tb), splits (cosh(ta)cosh(tb) − 1)/t² into (cosh(ta) − 1)/t² · cosh(tb) plus (cosh(tb) − 1)/t². The first factor tends to a²/2 times cosh(tb) → 1, the second to b²/2, so the sum tends to (a²+b²)/2. The spherical case uses the same identity with cos. This is how the multiplicative curved law becomes the additive Euclidean one.",
+    "mathContext": "$fg - 1 = (f-1)g + (g-1)$, so $\\frac{\\cosh(ta)\\cosh(tb)-1}{t^2} \\to \\frac{a^2}{2}\\cdot 1 + \\frac{b^2}{2} = \\frac{a^2+b^2}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping identity",
+      "product of limits",
+      "continuity of cosh/cos at 0",
+      "multiplicative to additive"
+    ],
+    "prerequisites": [
+      "algebra of limits",
+      "cosh(tx) → 1 and cos(tx) → 1 as t → 0"
+    ]
+  },
+  {
+    "id": "ann-pt-oq05-uniqueness",
+    "proofId": "pythagorean-theorem-oq-05",
+    "range": {
+      "startLine": 424,
+      "endLine": 443
+    },
+    "type": "tactic",
+    "title": "Uniqueness of Limits Closes Both Theorems",
+    "content": "spherical_flat_limit (and identically hyperbolic_flat_limit) finishes with tendsto_nhds_unique. The curved law cos(t·c) = cos(t·a)·cos(t·b) holds for every t > 0, so on the filter 𝓝[Ioi 0] 0 the two scaled functions (1 − cos(tc))/t² and (1 − cos(ta)cos(tb))/t² are eventually equal (eventually_nhdsWithin_of_forall). One tends to c²/2, the other to (a²+b²)/2; a convergent sequence has a unique limit, so c²/2 = (a²+b²)/2 and linarith gives c² = a² + b². No smallness or range restriction on a, b, c is used — the germ at t = 0 is all that matters.",
+    "mathContext": "$\\frac{c^2}{2} = \\frac{a^2+b^2}{2}$ by uniqueness of the $t \\to 0^+$ limit, hence $c^2 = a^2 + b^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "tendsto_nhds_unique",
+      "eventually equal on a filter",
+      "𝓝[Ioi 0] 0",
+      "Tendsto.congr'"
+    ],
+    "prerequisites": [
+      "uniqueness of limits in a Hausdorff space",
+      "filters and eventually"
+    ]
+  }
+]

--- a/src/data/proofs/pythagorean-theorem-oq-05/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-05/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "pythagorean-theorem-oq-05",
+  "title": "Pythagorean Theorem OQ-05: The Flat-Limit Reduction of the Spherical and Hyperbolic Laws",
+  "slug": "pythagorean-theorem-oq-05",
+  "description": "Both non-Euclidean Pythagorean theorems collapse to the Euclidean identity c² = a² + b² as curvature → 0. For a right-angled triangle the spherical law reads cos(c) = cos(a)·cos(b) and the hyperbolic law reads cosh(c) = cosh(a)·cosh(b); rescaling the sides by a parameter t (t = 1/R, the reciprocal curvature radius) and letting t → 0⁺ recovers Pythagoras exactly. The mechanism is a single second-order limit: (1 − cos(tx))/t² → x²/2 on the sphere and (cosh(tx) − 1)/t² → x²/2 in hyperbolic space, so the multiplicative curved laws linearize to the additive flat one. The spherical route reduces the limit to continuity of Real.sinc at 0; the hyperbolic route to a two-level monotonicity bound 2(cosh u − 1) ≤ u²·cosh u. 19 theorems, 0 axioms, 0 sorries, no range restriction on a, b, c.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-08",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTheoremOQ05.lean",
+    "tags": [
+      "geometry",
+      "non-euclidean",
+      "flat-limit",
+      "spherical-trigonometry",
+      "hyperbolic-geometry",
+      "taylor-approximation",
+      "squeeze-theorem"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-08",
+    "axiomCount": 0,
+    "assumptions": "None. Both main theorems take the right-angle curved law (as a scaled functional equation ∀ t > 0) as an explicit hypothesis and derive c² = a² + b² from it; they do not assume any spherical/hyperbolic-geometry infrastructure. Fully machine-checked, depending only on propext, Classical.choice, and Quot.sound.",
+    "lineCount": 443,
+    "theoremCount": 19,
+    "definitionCount": 0,
+    "originalContributions": [
+      "spherical_flat_limit: if cos(t·c) = cos(t·a)·cos(t·b) for all t > 0 then c² = a² + b² — the spherical right-triangle law degenerates to Pythagoras in the flat limit, with NO range restriction on a, b, c",
+      "hyperbolic_flat_limit: if cosh(t·c) = cosh(t·a)·cosh(t·b) for all t > 0 then c² = a² + b² — the hyperbolic right-triangle law degenerates to Pythagoras in the flat limit",
+      "tendsto_one_sub_cos_mul_div_sq: (1 − cos(tx))/t² → x²/2 as t → 0⁺, proved cleanly via the sinc identity sin u = sinc u · u and continuity of Real.sinc at 0 (sinc 0 = 1) — no monotonicity or second-derivative machinery",
+      "tendsto_cosh_mul_sub_one_div_sq: (cosh(tx) − 1)/t² → x²/2 as t → 0⁺, obtained by squeezing between the lower bound 1 + (tx)²/2 ≤ cosh(tx) and the upper bound 2(cosh u − 1) ≤ u²·cosh u",
+      "cosh_sub_one_le_sq_mul_cosh_all: 2(cosh u − 1) ≤ u²·cosh u for all real u, proved by a two-level monotonicity argument on u²·cosh u − 2(cosh u − 1) whose second derivative u²·cosh u + 4u·sinh u is nonnegative for u ≥ 0",
+      "sin_eq_sinc_mul: sin u = Real.sinc u · u, the identity that routes the spherical scaled limit through sinc continuity",
+      "tendsto_one_sub_cos_prod_div_sq / tendsto_cosh_prod_sub_one_div_sq: the product-side limits (1 − cos(ta)cos(tb))/t² → (a²+b²)/2 and (cosh(ta)cosh(tb) − 1)/t² → (a²+b²)/2, decomposed via the telescoping factorization f·g − 1 = (f − 1)·g + (g − 1) and continuity of cos/cosh at 0"
+    ]
+  },
+  "overview": {
+    "historicalContext": "In a space of constant curvature K the Pythagorean theorem for a right-angled triangle is not additive but multiplicative. On the unit sphere (K = +1) the law of cosines for a right angle collapses to cos c = cos a · cos b; in the hyperbolic plane (K = −1) it reads cosh c = cosh a · cosh b. These are classical: the spherical form is essentially Menelaus and appears in Regiomontanus' De triangulis (1464) and the Arabic astronomers before him; the hyperbolic form is due to Bolyai and Lobachevsky (1830s) and Taurinus' earlier 'logarithmic-spherical' geometry. It has long been understood informally that both reduce to a² + b² = c² 'in the small' — as the triangle shrinks relative to the radius of curvature, or equivalently as K → 0. This entry makes that flat limit fully precise and machine-checked, extracting the Euclidean identity as the exact second-order (t → 0⁺) content of the two curved laws simultaneously, through one shared analytic mechanism.",
+    "problemStatement": "Prove rigorously that the spherical and hyperbolic right-angle laws degenerate to the Euclidean Pythagorean theorem in the flat limit. Concretely: if cos(t·c) = cos(t·a)·cos(t·b) for all t > 0, then c² = a² + b²; and if cosh(t·c) = cosh(t·a)·cosh(t·b) for all t > 0, then c² = a² + b². The scaling parameter t plays the role of 1/R (reciprocal curvature radius); the flat limit is t → 0⁺.",
+    "text": "The heart of the matter is a single scaled limit taken in two curvatures. On the sphere, the quantity (1 − cos(tx))/t² converges to x²/2 as t → 0⁺; in hyperbolic space, (cosh(tx) − 1)/t² converges to the same x²/2. Given the curved right-angle law as a functional equation valid for all t > 0, the two sides agree identically on (0, ∞); taking the flat limit of each side and using uniqueness of limits forces c²/2 = (a² + b²)/2, hence c² = a² + b². The product side is handled by the telescoping factorization cos(ta)cos(tb) − 1 = (cos(ta) − 1)·cos(tb) + (cos(tb) − 1) (and its cosh analogue), so that the product limit splits into the two single-variable limits plus continuity of cos/cosh at 0. Crucially, no range restriction on a, b, c is needed: the flat limit reads off the germ at t = 0, where both curved laws linearize to the same quadratic form.",
+    "proofStrategy": "The spherical scaled limit tendsto_one_sub_cos_mul_div_sq is proved through the sinc identity: writing sin u = Real.sinc u · u and using the half-angle identity 1 − cos(tx) = 2 sin(tx/2)², the ratio (1 − cos(tx))/t² becomes (x²/2)·sinc(tx/2)², whose limit is x²/2 by continuity of Real.sinc at 0 (sinc 0 = 1). This avoids all monotonicity machinery. The hyperbolic scaled limit tendsto_cosh_mul_sub_one_div_sq is instead a squeeze: the lower bound cosh(tx) ≥ 1 + (tx)²/2 gives (cosh(tx) − 1)/t² ≥ x²/2, and the upper bound 2(cosh u − 1) ≤ u²·cosh u (cosh_sub_one_le_sq_mul_cosh_all, from a two-level monotonicity argument whose second derivative u²·cosh u + 4u·sinh u ≥ 0 for u ≥ 0) gives (cosh(tx) − 1)/t² ≤ x²·cosh(tx)/2 → x²/2. Both product limits telescope as f·g − 1 = (f − 1)·g + (g − 1). The two main theorems then apply the curved law pointwise on Ioi 0, conclude the two limit-functions agree eventually, and invoke tendsto_nhds_unique.",
+    "keyInsights": [
+      "The flat limit is a statement about germs at t = 0: both curved right-angle laws share the same second-order Taylor coefficient, so their t → 0⁺ limits coincide with the single Euclidean quadratic form x ↦ x²/2 — this is why sphere and hyperbolic plane give the SAME Pythagoras",
+      "One analytic quantity does all the work in both curvatures: (1 − cos(tx))/t² and (cosh(tx) − 1)/t² both tend to x²/2, so the spherical and hyperbolic reductions are literally the same limit computation with cos ↔ cosh",
+      "The sinc route is the clean way to the spherical limit: 1 − cos(tx) = 2 sin(tx/2)² and sin u = sinc u · u turn the ratio into (x²/2)·sinc(tx/2)², reducing everything to continuity of Real.sinc at 0 — strictly simpler than the hyperbolic squeeze it replaces",
+      "The multiplicative curved law linearizes to the additive flat one via telescoping: f·g − 1 = (f − 1)·g + (g − 1) converts the product cos(ta)cos(tb) (resp. cosh(ta)cosh(tb)) into a sum of single-variable limits, so no genuinely two-variable analysis is required",
+      "No range restriction on a, b, c is needed — the argument extracts the second-order behaviour at t → 0⁺ and never requires the sides to be small, unlike a naive 'small-triangle approximation' heuristic"
+    ],
+    "prerequisites": [
+      "Limits and the squeeze theorem in a filter (Filter.Tendsto, tendsto_nhds_unique)",
+      "Real hyperbolic functions: derivatives of cosh/sinh, cosh ≥ 1 + x²/2, and monotonicity via the mean value theorem",
+      "Real.sinc and its continuity at 0 (sinc 0 = 1), plus the half-angle identity 1 − cos θ = 2 sin²(θ/2)",
+      "The right-angle laws of cosines on the sphere (cos c = cos a cos b) and in hyperbolic space (cosh c = cosh a cosh b)"
+    ]
+  },
+  "conclusion": {
+    "summary": "A fully machine-verified, axiom-free proof that the spherical and hyperbolic Pythagorean theorems both degenerate to the Euclidean identity c² = a² + b² in the flat limit. The two reductions are unified by a single scaled second-order limit — (1 − cos(tx))/t² → x²/2 and (cosh(tx) − 1)/t² → x²/2 — with the spherical case routed through continuity of Real.sinc and the hyperbolic case through a squeeze bound. No range restriction on the side lengths is required. Zero axioms, zero sorries, 19 theorems.",
+    "implications": "The entry pins down, in checked form, the sense in which Euclidean geometry is the K → 0 limit of both curved constant-curvature geometries at once: the curved right-angle laws share a second-order germ, and that germ is Pythagoras. The scaled-limit lemmas (tendsto_one_sub_cos_mul_div_sq, tendsto_cosh_mul_sub_one_div_sq) and the monotonicity bound 2(cosh u − 1) ≤ u²·cosh u are reusable infrastructure for other flat-limit / curvature-degeneration arguments (e.g. deriving the Euclidean law of cosines from the spherical/hyperbolic law of cosines, or the flat metric from the round/hyperbolic metric). It complements the gallery's algebraic Pythagorean entries by giving the analytic, differential-geometric viewpoint.",
+    "openQuestions": [
+      "Derive the curved laws' hypotheses from an intrinsic model: prove cos c = cos a · cos b directly from spherical geometry (great-circle arcs on S²) and cosh c = cosh a · cosh b from the hyperboloid/Poincaré model, so the flat-limit theorems apply to genuine geometric triangles rather than to an assumed functional equation",
+      "Extend the flat limit to the full (non-right-angle) laws of cosines — cos c = cos a cos b + sin a sin b cos C and its hyperbolic analogue — and show they degenerate to the Euclidean law of cosines c² = a² + b² − 2ab cos C",
+      "Quantify the rate: give an explicit O(t²) error term for c² − (a² + b²) at finite curvature, turning the qualitative flat limit into a first-order curvature correction",
+      "Unify the two curvatures with a single signed-curvature parameter K and prove one theorem in which K = 0 is a removable degeneration, recovering both cases and the Euclidean case continuously"
+    ]
+  },
+  "leanFile": {
+    "namespace": "PythagoreanFlatLimit",
+    "lineCount": 443,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTheoremOQ05.lean",
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv",
+      "Mathlib.Analysis.SpecialFunctions.ExpDeriv",
+      "Mathlib.Analysis.Calculus.MeanValue",
+      "Mathlib.Topology.Algebra.Order.LiminfLimsup",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Sinc",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Set"
+    ],
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "extends",
+      "description": "The classical Euclidean theorem a² + b² = c². This entry shows that same identity is the flat limit (curvature → 0) of the spherical law cos c = cos a cos b and the hyperbolic law cosh c = cosh a cosh b, giving the analytic/geometric reason the Euclidean form is the K = 0 case."
+    },
+    {
+      "targetId": "pythagorean-theorem-oq-04",
+      "relationship": "related",
+      "description": "The Gaussian-integer (algebraic) recasting of the Pythagorean identity. Where OQ-04 reads a² + b² = c² as norm multiplicativity in ℤ[i], OQ-05 reads it as the degenerate second-order limit of the curved laws of cosines — the algebraic and differential-geometric viewpoints on the same theorem."
+    }
+  ],
+  "sections": [
+    {
+      "id": "derivatives",
+      "title": "Part I: Derivatives of cosh and sinh",
+      "startLine": 47,
+      "endLine": 74,
+      "summary": "hasDerivAt_cosh' and hasDerivAt_sinh' package the derivatives of Real.cosh and Real.sinh in the HasDerivAt form used by the later mean-value arguments."
+    },
+    {
+      "id": "basic-inequalities",
+      "title": "Part II: Basic hyperbolic inequalities",
+      "startLine": 75,
+      "endLine": 147,
+      "summary": "Elementary bounds cosh > 0, cosh ≥ 1, sinh x ≥ x for x ≥ 0, and the quadratic lower bound cosh x ≥ 1 + x²/2 (first for x ≥ 0, then all x by parity in cosh_ge_one_add_sq_div_two_all), each proved through the mean value theorem on the derivatives from Part I."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Part III: The upper bound 2(cosh u − 1) ≤ u²·cosh u",
+      "startLine": 148,
+      "endLine": 250,
+      "summary": "cosh_sub_one_le_sq_mul_cosh(_all) proves 2(cosh u − 1) ≤ u²·cosh u by a two-level monotonicity argument: the function u²·cosh u − 2(cosh u − 1) has second derivative u²·cosh u + 4u·sinh u ≥ 0 for u ≥ 0, so it and its derivative are increasing from 0. This is the upper half of the hyperbolic squeeze."
+    },
+    {
+      "id": "scaled-limit-hyperbolic",
+      "title": "Part IV: The hyperbolic scaled limit (cosh(tx) − 1)/t² → x²/2",
+      "startLine": 251,
+      "endLine": 285,
+      "summary": "cosh_mul_sub_one_div_sq_bounds sandwiches (cosh(tx) − 1)/t² between x²/2 and x²·cosh(tx)/2 using the Part II lower bound and the Part III upper bound; tendsto_cosh_mul_sub_one_div_sq then squeezes to x²/2 as t → 0⁺."
+    },
+    {
+      "id": "product-limit-hyperbolic",
+      "title": "Part V: The hyperbolic product limit → (a²+b²)/2",
+      "startLine": 286,
+      "endLine": 316,
+      "summary": "tendsto_cosh_prod_sub_one_div_sq computes (cosh(ta)·cosh(tb) − 1)/t² → (a²+b²)/2 via the telescoping factorization f·g − 1 = (f − 1)·g + (g − 1) together with tendsto_cosh_mul_one (cosh(tx) → 1) for continuity at 0."
+    },
+    {
+      "id": "hyperbolic-main",
+      "title": "Part VI: Hyperbolic flat limit",
+      "startLine": 317,
+      "endLine": 343,
+      "summary": "hyperbolic_flat_limit: from cosh(t·c) = cosh(t·a)·cosh(t·b) for all t > 0, the two scaled quantities agree on Ioi 0, so their limits c²/2 and (a²+b²)/2 coincide by tendsto_nhds_unique, giving c² = a² + b²."
+    },
+    {
+      "id": "scaled-limit-spherical",
+      "title": "Part Va: The spherical scaled limit via sinc",
+      "startLine": 344,
+      "endLine": 401,
+      "summary": "sin_eq_sinc_mul (sin u = sinc u · u) and the half-angle identity turn (1 − cos(tx))/t² into (x²/2)·sinc(tx/2)²; tendsto_one_sub_cos_mul_div_sq concludes the limit x²/2 from continuity of Real.sinc at 0, avoiding all monotonicity machinery."
+    },
+    {
+      "id": "product-and-spherical-main",
+      "title": "Part Vb–VI: Spherical product limit and spherical flat limit",
+      "startLine": 402,
+      "endLine": 443,
+      "summary": "tendsto_one_sub_cos_prod_div_sq telescopes the product side to (a²+b²)/2; spherical_flat_limit then mirrors the hyperbolic argument: cos(t·c) = cos(t·a)·cos(t·b) forces c²/2 = (a²+b²)/2 by uniqueness of limits, hence c² = a² + b² with no range restriction on a, b, c."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Consolidated recovery PR for issue #35315 (triage of 10 banked branches with unpushed research from the 2026-07-08 fleet shutdown). Follows the #35118 recovery-queue playbook: declaration-level supersession diffing, docker-verify-before-integration, and salvage-then-leave for incomplete rolling branches. All category-(a) proofs were individually docker-build verified (`./proofs/scripts/docker-build.sh Proofs.<Name>` — never bare `lake build`) with `#print axioms` audits before inclusion.

## Full disposition table (10 branches)

| # | Branch | Cat | Disposition |
|---|--------|-----|-------------|
| 1 | `research/lagrange-oq020203-orbit-stabilizer-cardinal` | **(a)** | INTEGRATED — new `LagrangeTheoremOQ02OQ03.lean`, 3058 jobs, 0 axiom |
| 2 | `research/erdos-771-special-cases` | **(a)** | INTEGRATED — 3 sorries discharged, 7743 jobs |
| 3 | `research/burnside-oq-02-drift-repair` | **(a)** | INTEGRATED — v4.26 drift repair, removes `Lean.ofReduceBool` |
| 4 | `research/pythagorean-oq-05-gallery` | **(a)** | INTEGRATED — missing gallery entry for on-main verified proof |
| 5 | `feature/enricher-2` | **(a)** | INTEGRATED — bezout d-uniformity enrichment (JSON) |
| 6 | `research/beta-cbin-oq02-second-order` | **(b)** | LEFT ON ORIGIN — build fails (algebra drift, lines 151/153/319) |
| 7 | `research/brouwer-oq020201-adversary` | **(c)** | SUPERSEDED — file identical to main (#35226) — **safe to delete** |
| 8 | `research/sylow-oq0403-weyl` | **(c)** | SUPERSEDED — file identical to main (#35236) — **safe to delete** |
| 9 | `research/erdos-3-bertrand-series-v2` | **(c)** | SUPERSEDED — main superset of `Erdos3LogHarmonic` — **safe to delete** |
| 10 | `research/erdos-490-incomplete-01-r3` | **(c)** | SUPERSEDED — main 0-sorry verified (#35266); branch has 1 sorry — **safe to delete** |

## Changes (category-(a) integrations)

- **`proofs/Proofs/LagrangeTheoremOQ02OQ03.lean`** (NEW, 167 lines): infinite-general orbit-stabilizer over `Cardinal.mk` — bijection, cardinal Lagrange `#G = #(G⧸H)·#H`, cardinal product form, finite specialization, transitive case. Docker: 3058 jobs, 0 sorries. `#print axioms mk_orbit_mul_mk_stabilizer` = `[propext, Classical.choice, Quot.sound]`.
- **`proofs/Proofs/Erdos771Problem.lean`**: discharges all 3 remaining sorries (`f_characterization`, `m_eq_one_case`, `m_eq_two_case`) via 5 new helper lemmas. Docker: 7743 jobs, 0 sorries (main had 3); 2 open-conjecture axioms remain. Gallery meta `src/data/proofs/erdos-771/meta.json` updated: sorries 3→0, lineCount 292→443, theoremCount 11→16 (both `meta.*` and `leanFile.*` blocks + top-level `sorries`).
- **`proofs/Proofs/BurnsideCounting.lean`**: Mathlib v4.26 drift repair replacing every `native_decide` with kernel `decide` + `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup`. `#print axioms fixed_point_sum_binary_4`/`binary_necklaces_4` = foundational trio only (removes `Lean.ofReduceBool`). Gallery meta `src/data/proofs/burnside-counting/meta.json`: status axiomatized→verified, badge axiom→mathlib, axiomCount 1→0 (both blocks).
- **`src/data/proofs/pythagorean-theorem-oq-05/`** (NEW meta.json + annotations.json): gallery entry for the already-on-main verified `PythagoreanTheoremOQ05.lean` (19 theorems, 0 axioms, 443 lines, namespace `PythagoreanFlatLimit`) whose gallery dir was missing on main. Meta verified against the actual on-main file (both stat blocks agree: axiomCount 0, theoremCount 19, sorries 0).
- **`src/data/proofs/bezout-identity-...-oq-02-oq-01/`**: d-uniformity keyInsight + annotation anchor fix (40→42) recovered from `feature/enricher-2`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All 10 branches recorded a/b/c disposition | ✅ | Table above + issue comment |
| Category (a) docker-build verified per file | ✅ | Lagrange 3058 jobs, Erdos771 7743 jobs, Burnside clean; Pythagorean = on-main file already verified; enricher-2 = JSON-only |
| One consolidated recovery PR, `research` + `loom:review-requested`, `Closes #35315` | ✅ | This PR |
| Gallery meta updated per Axiom Integrity Policy | ✅ | erdos-771 + burnside both stat blocks + top-level; pythagorean-oq-05 verified against source |
| Category (b) left un-deleted with notes | ✅ | beta-cbin: build gaps at lines 151/153/319 documented |
| Category (c) listed safe-to-delete, NOT deleted | ✅ | brouwer/sylow/erdos-3-bertrand/erdos-490-r3; not deleted here |
| No worktree removed; dirty files inspected | ✅ | lg-r7-oq05 (churn, not committed), lg-r6-wt (genuine WIP committed+pushed), lg-enricher2-bezout (churn, not committed) |
| `pnpm build`/annotations builds not run | ✅ | Not run |
| No force-push/rewrite of source branches | ✅ | Only category-b WIP appended to its own branch |

## Test Plan

- `./proofs/scripts/docker-build.sh Proofs.LagrangeTheoremOQ02OQ03` → 3058 jobs, success, 0 sorries, `#print axioms` = foundational trio.
- `./proofs/scripts/docker-build.sh Proofs.Erdos771Problem` → 7743 jobs, success, 0 sorries.
- `./proofs/scripts/docker-build.sh Proofs.BurnsideCounting` → success, `#print axioms` of both headline theorems = foundational trio (no `Lean.ofReduceBool`).
- Pythagorean-oq-05: gallery meta verified against on-main `PythagoreanTheoremOQ05.lean` (identical file, 0 axiom / 19 thm / 443 lines).
- All 6 touched JSON files validate with `json.load`.

Closes #35315

🤖 Generated with [Claude Code](https://claude.com/claude-code)