### PR TITLE
feat(build): add in-place Mathlib olean cache repair for exit-135/SIGBUS

### DIFF
--- a/proofs/scripts/DOCKER-BUILD-RUNBOOK.md
+++ b/proofs/scripts/DOCKER-BUILD-RUNBOOK.md
@@ -1,0 +1,114 @@
+# Docker Build Cache Corruption Runbook
+
+Operational runbook for the recurring **exit-135 / SIGBUS** Mathlib olean
+corruption class in the Lean build tooling.
+
+## Symptom
+
+A `docker-build.sh` run fails with **exit code 135** (SIGBUS), typically with a
+message like:
+
+```
+... unexpected end of input
+offset 0: unexpected end of input
+```
+
+The failure often appears on a target that **previously built green** and whose
+own source did not change. It may also surface as `invalid header` when
+`LEAN_SKIP_CACHE=true` is set.
+
+## Root cause
+
+`docker-build.sh` mounts two **persistent, fleet-shared** named Docker volumes
+across every concurrent build container:
+
+| Volume | Mount | Contents |
+|--------|-------|----------|
+| `lean-mathlib-cache` | `/workspace/proofs/.lake/build` | compiled `.olean`/`.trace` |
+| `lean-mathlib-packages` | `/workspace/proofs/.lake/packages` | Mathlib source checkout |
+
+When a build container is **OOM-killed** (hits the `--memory` cgroup limit)
+mid-write to an `.olean`/`.trace` file, the volume can retain a **truncated**
+(often zero-byte) file. Any *subsequent* build — even an unrelated, previously
+green target — that imports the truncated module hits **SIGBUS** when Lean
+`mmap`s it. Because the volumes are shared fleet-wide, one OOM'd build can poison
+every concurrent/future build until the corrupt file(s) are repaired or the
+volume reset.
+
+The host OOMs at ~4 concurrent 32 GB builds, so this is triggered by
+concurrent-fleet memory pressure.
+
+## First-line recovery — Option B (in-place, no volume deletion)
+
+`lake exe cache get!` — the **bang** variant force-restores/overwrites individual
+corrupt/truncated oleans from the upstream Mathlib cache **without deleting the
+volume**. Corrupt files are clobbered with good copies; non-corrupt files are
+left alone. This is the recovery that repeatedly cleared exit-135/SIGBUS across
+the research fleet without any `docker volume rm`.
+
+```bash
+# Preferred: via docker-build.sh flag
+./proofs/scripts/docker-build.sh --repair-cache
+
+# Equivalent: standalone script
+./proofs/scripts/docker-repair-cache.sh
+```
+
+Properties:
+
+- **Safe under concurrent load** — per-file overwrite, so other agents may keep
+  building. No maintenance window required.
+- Retries up to 2 attempts automatically.
+- After it succeeds, re-run the failing build to confirm exit 0:
+  ```bash
+  ./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02
+  ```
+
+If `lake exe cache get!` does **not** converge after 2 attempts, the volume may
+have filesystem/metadata-level corruption (rare) rather than just individual bad
+oleans — fall back to Option A.
+
+## Fallback recovery — Option A (full volume reset)
+
+`docker volume rm` both volumes for a guaranteed clean slate. The next build
+recreates both volumes and does a full `lake exe cache get && lake build` from
+empty — a large one-time cost (full ~7700-module Mathlib re-download + rebuild
+of anything not covered by the upstream cache).
+
+```bash
+./proofs/scripts/docker-build.sh --repair-cache --nuke
+# or:
+./proofs/scripts/docker-repair-cache.sh --nuke
+```
+
+### SAFETY PRECONDITION (hard-enforced)
+
+`--nuke` **refuses to proceed** unless `docker ps -a --filter name=lean-build`
+shows **zero** containers (running or stopped). Deleting a shared volume while a
+build is in flight could strand or poison it. The script performs this check and
+exits non-zero with guidance if any `lean-build-*` container exists.
+
+Verify manually before invoking:
+
+```bash
+docker ps -a --filter name=lean-build   # must be empty
+```
+
+## Prevention notes
+
+- Prefer keeping concurrent 32 GB builds **below 4** on the shared host
+  (`docker ps | grep -c lean-build`) to avoid the OOM that seeds corruption.
+- The corruption is a **shared-volume** phenomenon: fixing it once (Option B)
+  clears it for every agent, but a fresh OOM can re-seed it — so this is an
+  operational recovery, not a permanent code fix.
+- This runbook does **not** change the normal (non-repair) build path. Everyday
+  `docker-build.sh Proofs.Foo` invocations are unaffected.
+
+## Related
+
+- Issue #35184 — this runbook / repair tooling.
+- PR #35159 — same failure class (`RothTheorem.olean` SIGBUS for downstream
+  importers).
+- PRs #35296, #35295 — "repair masked broken build" landings that demonstrated
+  the toolchain compiles cleanly again after the acute 2026-07-08 episode
+  self-healed.

--- a/proofs/scripts/docker-build.sh
+++ b/proofs/scripts/docker-build.sh
@@ -5,17 +5,35 @@
 #
 # Usage:
 #   ./proofs/scripts/docker-build.sh [target]
+#   ./proofs/scripts/docker-build.sh --repair-cache   # repair corrupt oleans, then exit
 #
 # Environment variables:
 #   LEAN_MEMORY_LIMIT  - Memory limit in MB (default: 32768 = 32GB)
 #   LEAN_BUILD_TIMEOUT - Build timeout (default: 60m)
 #   LEAN_SKIP_CACHE    - Skip Mathlib cache download (default: false)
 #
+# Recovering from exit-135 / SIGBUS ("unexpected end of input") corruption:
+#   The shared Mathlib volumes can retain truncated oleans after an OOM-killed
+#   build, poisoning every subsequent build that imports the module. Run the
+#   first-line, in-place repair (Option B, `lake exe cache get!`):
+#       ./proofs/scripts/docker-build.sh --repair-cache
+#   which delegates to proofs/scripts/docker-repair-cache.sh. See that script
+#   and proofs/scripts/DOCKER-BUILD-RUNBOOK.md for the fallback volume reset.
+#
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROOFS_DIR="$(dirname "$SCRIPT_DIR")"
 REPO_ROOT="$(dirname "$PROOFS_DIR")"
+
+# --repair-cache: delegate to the standalone repair script (first-line Option B,
+# in-place `lake exe cache get!` force-refresh) and exit. Does NOT touch the
+# normal build path. Any extra args (e.g. --nuke) are forwarded to the repair
+# script, so `--repair-cache --nuke` runs the guarded full volume reset.
+if [[ "${1:-}" == "--repair-cache" ]]; then
+    shift
+    exec "${SCRIPT_DIR}/docker-repair-cache.sh" "$@"
+fi
 
 # Configuration
 MEMORY_LIMIT="${LEAN_MEMORY_LIMIT:-32768}"  # 32GB default

--- a/proofs/scripts/docker-repair-cache.sh
+++ b/proofs/scripts/docker-repair-cache.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+#
+# Repair the shared Mathlib Docker volumes after olean corruption.
+#
+# WHY THIS EXISTS
+# ---------------
+# docker-build.sh mounts two PERSISTENT named volumes shared across every
+# concurrent build container:
+#   - lean-mathlib-cache    -> /workspace/proofs/.lake/build
+#   - lean-mathlib-packages -> /workspace/proofs/.lake/packages
+# When a build container is OOM-killed (hits the --memory cgroup limit) mid-write
+# to an .olean/.trace file, the volume can retain a TRUNCATED (often zero-byte)
+# file. Any subsequent build — even an unrelated, previously-green target — that
+# imports the truncated module then fails with SIGBUS (exit 135) when Lean mmaps
+# it, with the telltale "offset 0: unexpected end of input". Because the volumes
+# are shared fleet-wide, one OOM'd build poisons every concurrent/future build
+# until the specific corrupt file(s) are repaired or the volume is reset.
+#
+# RECOVERY STRATEGY
+# -----------------
+# Option B (default, first-line): `lake exe cache get!` — the bang variant
+#   force-restores/overwrites individual corrupt/truncated oleans from the
+#   upstream Mathlib cache WITHOUT deleting the volume. Each corrupt file is
+#   clobbered with a good copy; non-corrupt files are left alone. This is the
+#   recovery that repeatedly cleared exit-135/SIGBUS and "invalid header" errors
+#   for the research fleet across 2026-07-07/08 without any `docker volume rm`.
+#   Cheap, no maintenance window, degrades gracefully under concurrent load.
+#
+# Option A (fallback, --nuke): `docker volume rm` both volumes for a guaranteed
+#   clean slate. Only appropriate when Option B does not converge (rare
+#   volume-level metadata corruption, not just individual olean files). This
+#   forces a full re-download for the NEXT build (minutes-to-tens-of-minutes),
+#   so it MUST run in a true zero-container window — this script hard-guards it.
+#
+# USAGE
+#   ./proofs/scripts/docker-repair-cache.sh            # Option B (force cache get!)
+#   ./proofs/scripts/docker-repair-cache.sh --nuke     # Option A (delete volumes)
+#   ./proofs/scripts/docker-repair-cache.sh --help
+#
+# SAFETY PRECONDITION for --nuke:
+#   `docker ps -a --filter name=lean-build` must show ZERO containers. A build
+#   container starting between the check and the `rm` could be poisoned or lose
+#   its volume out from under it, so --nuke refuses to proceed if ANY
+#   lean-build-* container (running or stopped) exists.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROOFS_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$PROOFS_DIR")"
+
+# Must match docker-build.sh
+IMAGE="lean4-arm64:v4.26.0"
+CACHE_VOLUME="lean-mathlib-cache"
+PACKAGES_VOLUME="lean-mathlib-packages"
+
+MODE="cache-get"  # default: Option B
+
+usage() {
+    sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --nuke|--volume-rm|--reset)
+            MODE="nuke"
+            ;;
+        -h|--help)
+            usage 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            usage 1
+            ;;
+    esac
+    shift
+done
+
+# ---------------------------------------------------------------------------
+# Preflight: Docker available
+# ---------------------------------------------------------------------------
+if ! command -v docker &>/dev/null; then
+    echo "ERROR: Docker is not installed" >&2
+    exit 1
+fi
+if ! docker info &>/dev/null; then
+    echo "ERROR: Docker daemon is not running. Please start Docker Desktop." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Count in-flight build containers (running or stopped) for safety gating.
+# ---------------------------------------------------------------------------
+build_container_count() {
+    docker ps -a --filter name=lean-build --format '{{.Names}}' 2>/dev/null \
+        | grep -c . || true
+}
+
+CONTAINER_COUNT="$(build_container_count)"
+
+echo "=== Mathlib Docker Volume Repair ==="
+echo "Mode:                 ${MODE}"
+echo "Cache volume:         ${CACHE_VOLUME}"
+echo "Packages volume:      ${PACKAGES_VOLUME}"
+echo "lean-build containers: ${CONTAINER_COUNT}"
+echo ""
+
+if [[ "$MODE" == "nuke" ]]; then
+    # -----------------------------------------------------------------------
+    # Option A: docker volume rm (guaranteed clean slate).
+    # HARD SAFETY GATE: zero lean-build-* containers must exist.
+    # -----------------------------------------------------------------------
+    if [[ "$CONTAINER_COUNT" -ne 0 ]]; then
+        echo "REFUSING to delete shared volumes: ${CONTAINER_COUNT} lean-build container(s) present." >&2
+        echo "Deleting volumes now could poison or strand an in-flight build." >&2
+        echo "" >&2
+        echo "Wait for a true zero-container window, verify with:" >&2
+        echo "  docker ps -a --filter name=lean-build" >&2
+        echo "then re-run: $0 --nuke" >&2
+        exit 2
+    fi
+
+    echo "Zero build containers confirmed. Deleting shared Mathlib volumes..."
+    echo "(The next docker-build.sh run will recreate both volumes and do a full"
+    echo " 'lake exe cache get && lake build' from empty — a large one-time cost.)"
+    echo ""
+    # Volumes may legitimately not exist yet; don't fail the whole script on that.
+    docker volume rm "$CACHE_VOLUME" 2>/dev/null \
+        && echo "  removed ${CACHE_VOLUME}" \
+        || echo "  ${CACHE_VOLUME} not present (nothing to remove)"
+    docker volume rm "$PACKAGES_VOLUME" 2>/dev/null \
+        && echo "  removed ${PACKAGES_VOLUME}" \
+        || echo "  ${PACKAGES_VOLUME} not present (nothing to remove)"
+    echo ""
+    echo "=== Volumes reset. Next build will repopulate them from empty. ==="
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Option B (default): lake exe cache get! — in-place force-refresh.
+#
+# Safe to run even while other agents build: each corrupt file is overwritten
+# with a good copy, non-corrupt files are left alone. No volume deletion.
+# ---------------------------------------------------------------------------
+if [[ "$CONTAINER_COUNT" -ne 0 ]]; then
+    echo "NOTE: ${CONTAINER_COUNT} lean-build container(s) are running."
+    echo "      'lake exe cache get!' is safe to run concurrently (per-file overwrite),"
+    echo "      so proceeding. (Use --nuke only in a zero-container window.)"
+    echo ""
+fi
+
+# Ensure the image exists (mirror docker-build.sh behavior).
+if ! docker image inspect "$IMAGE" &>/dev/null; then
+    echo "Building Lean Docker image (first time only)..."
+    docker build -t "$IMAGE" "$PROOFS_DIR"
+    echo ""
+fi
+
+# Ensure volumes exist so the mount targets are valid.
+docker volume inspect "$CACHE_VOLUME"    &>/dev/null || docker volume create "$CACHE_VOLUME"    >/dev/null
+docker volume inspect "$PACKAGES_VOLUME" &>/dev/null || docker volume create "$PACKAGES_VOLUME" >/dev/null
+
+CONTAINER_NAME="lean-repair-$$"
+
+run_cache_get() {
+    docker run --rm \
+        -v "${REPO_ROOT}:/workspace:delegated" \
+        -v "${CACHE_VOLUME}:/workspace/proofs/.lake/build:delegated" \
+        -v "${PACKAGES_VOLUME}:/workspace/proofs/.lake/packages:delegated" \
+        -w /workspace/proofs \
+        --name "$CONTAINER_NAME" \
+        "$IMAGE" \
+        /bin/bash -c "lake exe cache get!"
+}
+
+# Try up to 2 attempts before recommending Option A fallback.
+ATTEMPT=0
+MAX_ATTEMPTS=2
+while :; do
+    ATTEMPT=$((ATTEMPT + 1))
+    echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: 'lake exe cache get!' (force-overwrite corrupt oleans)..."
+    if run_cache_get; then
+        echo ""
+        echo "=== Cache force-refresh succeeded. Re-run your build to confirm exit 0: ==="
+        echo "    ./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02"
+        exit 0
+    fi
+
+    echo ""
+    echo "Attempt ${ATTEMPT} did not succeed."
+    if [[ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]]; then
+        echo ""
+        echo "=== 'lake exe cache get!' did not converge after ${MAX_ATTEMPTS} attempts. ===" >&2
+        echo "This can indicate volume-level (not just per-file) corruption." >&2
+        echo "Fall back to Option A (full volume reset) in a ZERO-container window:" >&2
+        echo "  docker ps -a --filter name=lean-build   # must be empty" >&2
+        echo "  $0 --nuke" >&2
+        exit 3
+    fi
+    echo "Retrying..."
+    echo ""
+done


### PR DESCRIPTION
## Summary

Infra/runbook fix for the recurring **exit-135 / SIGBUS** Mathlib olean
corruption class in the Lean build tooling (issue #35184). Per the curator's
enhancement, the acute corruption episode reported at filing (04:44Z) had
already self-healed; the deliverable is the **preventive/recovery tooling**, not
an active-incident fix.

**Diagnostic build result (first acceptance criterion):** re-ran the exact
failing target on a zero-container host — **GREEN**:

```
⚠ [3058/3058] Replayed Proofs.ElementaryQuadraticReciprocityOQ03OQ02
Build completed successfully (3058 jobs).
=== Build succeeded ===
```

(`lake exe cache get` fetched 7727/7727 files, unpacked, and replayed the target
cleanly — the volume is healthy.) Confirms the acute symptom is cleared, so this
PR lands the runbook + repair tooling for the next recurrence.

## Changes

- **`proofs/scripts/docker-repair-cache.sh`** (new) — first-line **Option B**
  recovery: `lake exe cache get!` (bang) force-overwrites individual corrupt/
  truncated oleans in the shared volumes **without deleting them**, safe under
  concurrent load, auto-retries up to 2×. Guarded **Option A** fallback via
  `--nuke`: `docker volume rm` of both volumes, **refused unless
  `docker ps -a --filter name=lean-build` shows zero containers** (fails loudly,
  non-zero exit). Uses the same image/volume names as `docker-build.sh`.
- **`proofs/scripts/docker-build.sh`** — adds a `--repair-cache` flag that
  `exec`s the repair script (forwarding extra args like `--nuke`) and a usage
  comment block. **No change to the normal build path.**
- **`proofs/scripts/DOCKER-BUILD-RUNBOOK.md`** (new) — symptom, root cause,
  Option B / Option A procedures, the safety precondition, and prevention notes.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Re-run exact failing build, document status | ✅ | `docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02` → exit 0, `[3058/3058]`, "Build succeeded" (0 lean-build containers before build) |
| If still reproducing, apply recovery + re-run | ✅ (N/A) | Diagnostic was green; no live corruption to repair |
| Add repair script/runbook implementing Option B first-line | ✅ | `docker-repair-cache.sh` defaults to `lake exe cache get!`; Option A documented as fallback |
| Document safety precondition in script/runbook | ✅ | `--nuke` hard-gates on zero `lean-build-*` containers; documented in script header and runbook |
| No change to normal (non-repair) build path | ✅ | `--repair-cache` short-circuits before any build logic; only added a guarded early `exec` + comments |

## Test Plan

- `bash -n` syntax check: both scripts pass.
- `shellcheck -S warning proofs/scripts/docker-repair-cache.sh`: clean.
- `docker-repair-cache.sh --help`: prints the header runbook.
- Diagnostic docker build (above): exit 0, full `[3058/3058]` replay.
- Design note: the `--nuke` safety gate was written to fail-closed (non-zero
  exit) when any `lean-build-*` container exists; verified logically (host had 0
  containers, so a live destructive test was intentionally not run).

Closes #35184

🤖 Generated with [Claude Code](https://claude.com/claude-code)