### PR TITLE
feat(gallery): add lagrange-theorem-oq-02-oq-02-oq-03 (cardinal orbit-stabilizer)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-oq-context",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 60 },
+    "type": "concept",
+    "title": "OQ-03 Setup: Orbit–Stabilizer Is Finiteness-Free",
+    "content": "The parent orbit–stabilizer family, and the `Nat.card` sibling `lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01`, phrase orbit–stabilizer over `Nat.card`, which is defined to be `0` on infinite types. On an infinite group the product form `Nat.card (orbit) · Nat.card (stabilizer) = Nat.card G` degenerates to `0 = 0` and the identity `#(orbit) = #(G ⧸ stabilizer)` loses its content when the orbit is infinite. This file (OQ-03) gives the honest infinite-general formulation over `Cardinal.mk`, where every identity retains its content for infinite groups, orbits, and stabilizers. The conceptual point: what orbit–stabilizer really *is* is a bijection `orbit G x ≃ G ⧸ stabilizer G x`, and taking cardinalities of a bijection needs no finiteness at all.",
+    "mathContext": "**Nat.card shadow**: $\\mathrm{Nat.card}(\\mathrm{orbit}) \\cdot \\mathrm{Nat.card}(\\mathrm{Stab}) = \\mathrm{Nat.card}\\,G$ collapses to $0 = 0$ once any factor is infinite. **Cardinal formulation** (this file): $\\#(\\mathrm{orbit}\\,G\\,x) \\cdot \\#(\\mathrm{Stab}\\,G\\,x) = \\#G$, a genuine equality of possibly-infinite cardinals. Both descend from the same bijection $\\mathrm{orbit}\\,G\\,x \\simeq G / \\mathrm{Stab}\\,G\\,x$.",
+    "significance": "key",
+    "relatedConcepts": ["orbit–stabilizer theorem", "cardinal arithmetic", "Cardinal.mk vs Nat.card", "MulAction", "infinite groups"],
+    "prerequisites": ["group actions", "cosets and G ⧸ H", "cardinal arithmetic"]
+  },
+  {
+    "id": "ann-coset-characterization",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "range": { "startLine": 70, "endLine": 95 },
+    "type": "theorem",
+    "title": "The Coset Characterization of Equal Images",
+    "content": "`same_image_iff_mem_stabilizer` proves `g₁ • x = g₂ • x ↔ g₁⁻¹ * g₂ ∈ stabilizer G x` by unfolding `mem_stabilizer_iff` and `mul_smul` and cancelling with `inv_mul_cancel` / `mul_inv_cancel`. `same_image_iff_coset_eq` rewrites this through `QuotientGroup.eq` to get coset equality `↑g₁ = ↑g₂` in `G ⧸ stabilizer G x`. Together these are the well-definedness and injectivity of the map `g • x ↦ ↑g` — the pointwise, finiteness-free core of orbit–stabilizer. No cardinality, no finiteness: this is a fact about a single pair of group elements.",
+    "mathContext": "$g_1 \\cdot x = g_2 \\cdot x \\iff g_1^{-1} g_2 \\in \\mathrm{Stab}(x) \\iff \\overline{g_1} = \\overline{g_2}$ in $G / \\mathrm{Stab}(x)$. The forward direction: if $g_1 \\cdot x = g_2 \\cdot x$ then $g_1^{-1} g_2 \\cdot x = g_1^{-1} \\cdot (g_2 \\cdot x) = g_1^{-1} \\cdot (g_1 \\cdot x) = x$. The map $g \\cdot x \\mapsto \\overline{g}$ is thus well defined and injective.",
+    "significance": "key",
+    "relatedConcepts": ["stabilizer", "left coset", "QuotientGroup.eq", "well-definedness", "injectivity"],
+    "prerequisites": ["mem_stabilizer_iff", "mul_smul", "QuotientGroup.eq"]
+  },
+  {
+    "id": "ann-bijection-cardinal-identity",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "range": { "startLine": 96, "endLine": 112 },
+    "type": "theorem",
+    "title": "The Orbit–Stabilizer Bijection and Its Cardinal Identity",
+    "content": "`orbitEquivQuotient` (the file's single `noncomputable def`) restates Mathlib's `MulAction.orbitEquivQuotientStabilizer G x` as the central object: a genuine bijection `orbit G x ≃ G ⧸ stabilizer G x` valid for *any* group action, no finiteness hypothesis. `mk_orbit_eq_mk_quotient_stabilizer` applies `Cardinal.mk_congr` to this bijection to yield the cardinal identity `#(orbit G x) = #(G ⧸ stabilizer G x)`. Unlike the `Nat.card` version, this equality retains its content when the orbit is infinite — it is a genuine equality of (possibly infinite) cardinals.",
+    "mathContext": "$\\mathrm{orbit}\\,G\\,x \\simeq G / \\mathrm{Stab}\\,G\\,x$ (Mathlib's `orbitEquivQuotientStabilizer`), hence $\\#(\\mathrm{orbit}\\,G\\,x) = \\#(G / \\mathrm{Stab}\\,G\\,x)$. Taking $\\#(-)$ of a bijection is the functor `Cardinal.mk_congr`; the bijection carries no finiteness, so neither does the cardinal identity.",
+    "significance": "key",
+    "relatedConcepts": ["MulAction.orbitEquivQuotientStabilizer", "Cardinal.mk_congr", "orbit", "quotient group"],
+    "prerequisites": ["the orbit–stabilizer bijection", "Cardinal.mk_congr"]
+  },
+  {
+    "id": "ann-cardinal-lagrange-product",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "range": { "startLine": 113, "endLine": 134 },
+    "type": "theorem",
+    "title": "Cardinal Lagrange and the Cardinal Orbit–Stabilizer Product",
+    "content": "`mk_eq_mk_quotient_mul_mk` proves the cardinal form of Lagrange's theorem `#G = #(G ⧸ H) · #H` for an arbitrary subgroup H of an arbitrary group G, as the cardinal image of `Subgroup.groupEquivQuotientProdSubgroup : G ≃ (G ⧸ H) × H` via `mk_prod` and two `lift_id` (single universe u). `mk_orbit_mul_mk_stabilizer` then feeds the cardinal identity `#(orbit) = #(G ⧸ stabilizer)` into cardinal Lagrange (instantiated at H = stabilizer G x) to get `#(orbit G x) · #(stabilizer G x) = #G`. This is the infinite-general product form: it remains a true, non-degenerate statement when the group is infinite.",
+    "mathContext": "**Cardinal Lagrange**: $\\#G = \\#(G/H) \\cdot \\#H$, from $G \\simeq (G/H) \\times H$ and $\\#(\\alpha \\times \\beta) = \\#\\alpha \\cdot \\#\\beta$. **Cardinal orbit–stabilizer product**: substituting $\\#(\\mathrm{orbit}) = \\#(G/\\mathrm{Stab})$ gives $\\#(\\mathrm{orbit}\\,G\\,x) \\cdot \\#(\\mathrm{Stab}\\,G\\,x) = \\#G$. Where $\\mathrm{Nat.card}(\\mathrm{orbit}) \\cdot \\mathrm{Nat.card}(\\mathrm{Stab}) = \\mathrm{Nat.card}\\,G$ collapses to $0 = 0$ on infinite groups, this cardinal form stays informative.",
+    "significance": "key",
+    "relatedConcepts": ["Subgroup.groupEquivQuotientProdSubgroup", "Cardinal.mk_prod", "Cardinal.lift_id", "Lagrange's theorem"],
+    "prerequisites": ["cardinal Lagrange", "mk_orbit_eq_mk_quotient_stabilizer", "cardinal multiplication"]
+  },
+  {
+    "id": "ann-finite-specialization",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "range": { "startLine": 135, "endLine": 144 },
+    "type": "theorem",
+    "title": "Finite Specialization: Recovering the Classical Formula",
+    "content": "`card_orbit_mul_card_stabilizer` shows that for `[Finite G]` the cardinal product formula descends to the classical natural-number identity `Nat.card (orbit G x) · Nat.card (stabilizer G x) = Nat.card G`, via `Nat.card_prod` and `Nat.card_congr (orbitProdStabilizerEquivGroup G x)`. This confirms that the cardinal formulation strictly generalizes the classical orbit–stabilizer theorem: the familiar finite statement is recovered, not replaced.",
+    "mathContext": "For finite $G$: $\\mathrm{Nat.card}(\\mathrm{orbit}\\,G\\,x) \\cdot \\mathrm{Nat.card}(\\mathrm{Stab}\\,G\\,x) = \\mathrm{Nat.card}\\,G$, from the finite bijection $\\mathrm{orbit}\\,G\\,x \\times \\mathrm{Stab}\\,G\\,x \\simeq G$ (`orbitProdStabilizerEquivGroup`). On finite types $\\mathrm{Nat.card}$ and $\\#(-)$ agree, so this is the specialization of the cardinal product to the finite regime.",
+    "significance": "important",
+    "relatedConcepts": ["MulAction.orbitProdStabilizerEquivGroup", "Nat.card_congr", "Nat.card_prod", "finite specialization"],
+    "prerequisites": ["Finite typeclass", "Nat.card vs Cardinal.mk agreement on finite types"]
+  },
+  {
+    "id": "ann-transitive-corollary",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "range": { "startLine": 145, "endLine": 158 },
+    "type": "theorem",
+    "title": "The Transitive-Action Corollary",
+    "content": "`mk_eq_mk_quotient_stabilizer_of_pretransitive` proves that for `[MulAction.IsPretransitive G X]` the orbit of any point is all of `X` (established by `ext` plus `MulAction.exists_smul_eq`, giving `orbit G x = Set.univ`), so the cardinal identity reads `#X = #(G ⧸ stabilizer G x)` after rewriting with `mk_univ`. This is the homogeneous-space statement: the size of the space equals the index of any point stabilizer, with no finiteness assumption.",
+    "mathContext": "For a (pre)transitive action every point is reachable, so $\\mathrm{orbit}\\,G\\,x = X$ and $\\#X = \\#(G / \\mathrm{Stab}\\,G\\,x)$. This identifies the homogeneous space $X$ with the coset space $G / \\mathrm{Stab}(x)$ up to cardinality — the cardinal analogue of the classical bijection $X \\cong G / \\mathrm{Stab}(x)$ for transitive actions.",
+    "significance": "important",
+    "relatedConcepts": ["MulAction.IsPretransitive", "MulAction.exists_smul_eq", "Cardinal.mk_univ", "homogeneous space"],
+    "prerequisites": ["pretransitive actions", "mk_orbit_eq_mk_quotient_stabilizer"]
+  },
+  {
+    "id": "ann-axiom-cleanliness",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "range": { "startLine": 159, "endLine": 167 },
+    "type": "concept",
+    "title": "Verified Status and the #check Anchors",
+    "content": "The file closes with seven `#check @...` anchors, one per theorem, confirming the final type signature of each result before closing the `OrbitStabilizerCardinal` namespace. The file introduces no `axiom` declarations, no `sorry`, and no `native_decide`; the Mathlib API closure inherits only the standard foundational triple (`Classical.choice`, `propext`, `Quot.sound`), which the Axiom Integrity Policy does not count as assumptions. Status `verified` (0 sorries, 0 axioms, 0 structure-encoded assumptions) is justified.",
+    "mathContext": "**Standard Mathlib triple**: $\\{\\mathrm{Classical.choice}, \\mathrm{propext}, \\mathrm{Quot.sound}\\}$ — the foundational axioms of Mathlib's classical logic, propositional extensionality, and quotient construction, treated as primitive rather than user-introduced. No `Lean.ofReduceBool` (no `native_decide`), no `sorryAx`.",
+    "significance": "key",
+    "relatedConcepts": ["axiom-cleanliness", "Mathlib triple", "verified status", "type-signature anchors"],
+    "prerequisites": ["Lean 4 axiom discipline", "Axiom Integrity Policy"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-03/meta.json
@@ -1,0 +1,308 @@
+{
+  "id": "lagrange-theorem-oq-02-oq-02-oq-03",
+  "title": "Orbit–Stabilizer Without Finiteness: The Cardinal Bijection and Product",
+  "slug": "lagrange-theorem-oq-02-oq-02-oq-03",
+  "description": "Resolves OQ-03 of the orbit–stabilizer family `lagrange-theorem-oq-02`: the orbit–stabilizer theorem is fundamentally finiteness-free. The `Nat.card` sibling (`lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01`) states orbit–stabilizer over `Nat.card`, which collapses to `0 = 0` the moment anything in sight is infinite. This entry gives the honest infinite-general formulation over `Cardinal.mk`, where every identity retains its content for infinite groups, orbits, and stabilizers: the coset characterization of equal images, the orbit–stabilizer bijection `orbit G x ≃ G ⧸ stabilizer G x`, the cardinal identity `#(orbit G x) = #(G ⧸ stabilizer G x)`, the cardinal form of Lagrange `#G = #(G ⧸ H) · #H`, the cardinal orbit–stabilizer product `#(orbit G x) · #(stabilizer G x) = #G`, the finite `Nat.card` specialization recovering the classical formula, and the transitive corollary `#X = #(G ⧸ stabilizer G x)`. Seven theorems in 167 lines, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-07-08",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ03.lean",
+    "tags": [
+      "group-theory",
+      "orbit-stabilizer",
+      "lagrange-theorem",
+      "cardinal-arithmetic",
+      "mulaction",
+      "coset",
+      "infinite-groups",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 167,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "dateAdded": "2026-07-08",
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.orbitEquivQuotientStabilizer",
+        "description": "The orbit–stabilizer bijection `orbit G x ≃ G ⧸ stabilizer G x`, valid for any group action with no finiteness hypothesis. The central object restated by this file's `orbitEquivQuotient`.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "Subgroup.groupEquivQuotientProdSubgroup",
+        "description": "The bijection `G ≃ (G ⧸ H) × H` underlying the cardinal form of Lagrange's theorem `#G = #(G ⧸ H) · #H`.",
+        "module": "Mathlib.GroupTheory.Coset.Basic"
+      },
+      {
+        "theorem": "QuotientGroup.eq",
+        "description": "Coset equality criterion: `↑g₁ = ↑g₂ ↔ g₁⁻¹ * g₂ ∈ H` in `G ⧸ H`. Used to translate the stabilizer-membership characterization of equal images into a coset equality.",
+        "module": "Mathlib.GroupTheory.Coset.Basic"
+      },
+      {
+        "theorem": "MulAction.orbitProdStabilizerEquivGroup",
+        "description": "The bijection `orbit G x × stabilizer G x ≃ G` for a finite group, used in the finite `Nat.card` specialization via `Nat.card_congr`.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "Cardinal.mk_congr",
+        "description": "An equivalence `α ≃ β` yields `#α = #β`. The functor that turns each bijection above into a cardinal equality.",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Cardinal.mk_prod",
+        "description": "`#(α × β) = lift #α · lift #β`. Combined with `Cardinal.lift_id` (single universe) to give the cardinal product form of Lagrange.",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      }
+    ],
+    "originalContributions": [
+      "same_image_iff_mem_stabilizer: the finiteness-free pointwise fact that `g₁ • x = g₂ • x ↔ g₁⁻¹ * g₂ ∈ stabilizer G x`, the well-definedness/injectivity core of the orbit–stabilizer map.",
+      "same_image_iff_coset_eq: reformulates equal images as coset equality `↑g₁ = ↑g₂` in `G ⧸ stabilizer G x`, exhibiting `g • x ↦ ↑g` as a well-defined injection of the orbit into the coset space.",
+      "orbitEquivQuotient / mk_orbit_eq_mk_quotient_stabilizer: the orbit–stabilizer bijection restated as the central object, and the cardinal identity `#(orbit G x) = #(G ⧸ stabilizer G x)` — a genuine equality of possibly-infinite cardinals, unlike the `Nat.card` shadow.",
+      "mk_eq_mk_quotient_mul_mk: the cardinal form of Lagrange's theorem `#G = #(G ⧸ H) · #H` for an arbitrary subgroup of an arbitrary group, obtained from `Subgroup.groupEquivQuotientProdSubgroup`.",
+      "mk_orbit_mul_mk_stabilizer: the cardinal orbit–stabilizer product `#(orbit G x) · #(stabilizer G x) = #G`, the infinite-general product form that stays true and informative where the `Nat.card` product collapses to `0 = 0`.",
+      "card_orbit_mul_card_stabilizer: the finite specialization recovering the classical `Nat.card (orbit) · Nat.card (stabilizer) = Nat.card G`.",
+      "mk_eq_mk_quotient_stabilizer_of_pretransitive: the transitive-action corollary `#X = #(G ⧸ stabilizer G x)`, reading off the size of the space as the index of any point stabilizer with no finiteness assumption."
+    ],
+    "assumptions": "0 sorries. 0 axiom declarations. 0 structure-encoded assumptions. The Mathlib API closure inherits only the standard foundational triple (Classical.choice, propext, Quot.sound); no native_decide, no user axioms. Status `verified` is justified per the project's Axiom Integrity Policy."
+  },
+  "overview": {
+    "historicalContext": "The orbit–stabilizer theorem is one of the workhorses of finite group theory: for a group G acting on a set X, |G · x| · |Stab(x)| = |G|. It is the engine behind Lagrange's theorem, the class equation, Sylow theory, and Burnside's counting lemma. In the finite setting it is almost always stated over natural-number cardinalities. But the *content* of the theorem is a bijection — orbit G x ≃ G ⧸ stabilizer G x — and taking the cardinality of a bijection needs no finiteness at all. The finite product formula is a shadow of a bijection that exists in full generality.\n\nMathlib phrases the orbit–stabilizer product over `Nat.card`, which is defined to be `0` on infinite types. On an infinite group the product form `Nat.card (orbit) · Nat.card (stabilizer) = Nat.card G` degenerates to `0 = 0`, carrying no information, and the identity `#(orbit) = #(G ⧸ stabilizer)` loses its content when the orbit is infinite. This entry answers OQ-03 of the parent family: it gives the honest infinite-general formulation over `Cardinal.mk`, where every identity — bijection, cardinal equality, and product — retains its meaning for infinite groups, orbits, and stabilizers, and where the finite `Nat.card` statement is recovered as a specialization.",
+    "problemStatement": "**The Open Question (OQ-03)**: The parent orbit–stabilizer family, and the `Nat.card` sibling `lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01`, phrase orbit–stabilizer over `Nat.card`, which is `0` on infinite types. Can the orbit–stabilizer theorem be given a formulation that retains its full content for infinite groups, orbits, and stabilizers — one where the product form does not collapse to `0 = 0`?\n\n**Answer**: Yes. Working over `Cardinal.mk` rather than `Nat.card`, the orbit–stabilizer bijection `orbit G x ≃ G ⧸ stabilizer G x` (Mathlib's `orbitEquivQuotientStabilizer`, finiteness-free) yields the cardinal identity `#(orbit G x) = #(G ⧸ stabilizer G x)`. Feeding this into the cardinal form of Lagrange `#G = #(G ⧸ H) · #H` (from `Subgroup.groupEquivQuotientProdSubgroup`) gives the cardinal orbit–stabilizer product `#(orbit G x) · #(stabilizer G x) = #G`, which stays true and informative in the infinite setting. The finite `Nat.card` product formula is recovered as a specialization, and the transitive case reads `#X = #(G ⧸ stabilizer G x)`. Seven theorems in 167 lines, 0 sorries, 0 axioms. There is no separate `research/problems/` companion for this leaf; the OQ-03 framing is the file's own docstring.",
+    "text": "The heart of orbit–stabilizer is a pointwise fact with no finiteness anywhere: two group elements move x to the same place exactly when they lie in the same left coset of the stabilizer. Formally, g₁ • x = g₂ • x ↔ g₁⁻¹ g₂ ∈ Stab(x) ↔ ↑g₁ = ↑g₂ in G ⧸ Stab(x). This says the map g • x ↦ ↑g is well defined and injective — it is the orbit–stabilizer bijection. Taking cardinalities of the bijection gives #(orbit) = #(G ⧸ Stab), an equality of (possibly infinite) cardinals. Composing with the cardinal Lagrange identity #G = #(G ⧸ H) · #H gives the cardinal product #(orbit) · #(Stab) = #G. Over `Cardinal.mk` these identities survive into the infinite regime; over `Nat.card` the product degenerates. The finite case falls out by specialization.",
+    "proofStrategy": "The file is a short chain of one- to few-line Mathlib compositions:\n\n(1) `same_image_iff_mem_stabilizer`: `g₁ • x = g₂ • x ↔ g₁⁻¹ * g₂ ∈ stabilizer G x`, by unfolding `mem_stabilizer_iff`, `mul_smul` and cancelling with `inv_mul_cancel` / `mul_inv_cancel`.\n\n(2) `same_image_iff_coset_eq`: rewrite (1) through `QuotientGroup.eq` to get coset equality `↑g₁ = ↑g₂`.\n\n(3) `orbitEquivQuotient`: `noncomputable def` restating `orbitEquivQuotientStabilizer G x` as the central bijection; `mk_orbit_eq_mk_quotient_stabilizer` applies `Cardinal.mk_congr` to it.\n\n(4) `mk_eq_mk_quotient_mul_mk`: cardinal Lagrange, via `mk_congr (Subgroup.groupEquivQuotientProdSubgroup)`, `mk_prod`, and two `lift_id` (single universe u).\n\n(5) `mk_orbit_mul_mk_stabilizer`: rewrite the cardinal identity into cardinal Lagrange.\n\n(6) `card_orbit_mul_card_stabilizer`: the `[Finite G]` specialization via `Nat.card_prod` and `Nat.card_congr (orbitProdStabilizerEquivGroup G x)`.\n\n(7) `mk_eq_mk_quotient_stabilizer_of_pretransitive`: for a pretransitive action the orbit is `Set.univ` (from `MulAction.exists_smul_eq`), so the cardinal identity reads `#X = #(G ⧸ stabilizer G x)` via `mk_univ`.",
+    "keyInsights": [
+      "The orbit–stabilizer theorem is fundamentally a *bijection* `orbit G x ≃ G ⧸ stabilizer G x` — Mathlib's `orbitEquivQuotientStabilizer` — with no finiteness hypothesis. Finiteness enters only when one passes to `Nat.card`; the bijection itself is universal.",
+      "Cardinal arithmetic (`Cardinal.mk`) is the right home for orbit–stabilizer over infinite groups: `#(orbit) · #(stabilizer) = #G` retains its content where `Nat.card (orbit) · Nat.card (stabilizer) = Nat.card G` collapses to `0 = 0` as soon as any factor is infinite.",
+      "The coset characterization `g₁ • x = g₂ • x ↔ ↑g₁ = ↑g₂` in `G ⧸ stabilizer G x` is the well-definedness-and-injectivity core of the bijection, stated purely pointwise and finiteness-free.",
+      "Cardinal Lagrange `#G = #(G ⧸ H) · #H` is the cardinal image of `Subgroup.groupEquivQuotientProdSubgroup`; the single-universe `lift_id` cleanup is all that separates `Cardinal.mk_prod` from the clean product statement.",
+      "The finite `Nat.card` formula is not lost — it is recovered as `card_orbit_mul_card_stabilizer` under `[Finite G]`, so this entry strictly generalizes the classical statement rather than replacing it."
+    ],
+    "prerequisites": [
+      "**Group actions (MulAction) in Mathlib** — the typeclass `MulAction G X`, the action `g • x`, the orbit `MulAction.orbit G x`, and the point stabilizer `MulAction.stabilizer G x` as a subgroup of G.",
+      "**Cosets and the quotient group `G ⧸ H`** — left cosets, the coset space `G ⧸ H`, and `QuotientGroup.eq : ↑g₁ = ↑g₂ ↔ g₁⁻¹ * g₂ ∈ H`.",
+      "**The orbit–stabilizer bijection** — `MulAction.orbitEquivQuotientStabilizer : orbit G x ≃ G ⧸ stabilizer G x`, the finiteness-free content of the theorem.",
+      "**Cardinal arithmetic** — `Cardinal.mk`, `Cardinal.mk_congr` (bijection ⇒ cardinal equality), `Cardinal.mk_prod`, `Cardinal.lift_id`, and the fact that `Nat.card` is `0` on infinite types.",
+      "**Lagrange's theorem in bijective form** — `Subgroup.groupEquivQuotientProdSubgroup : G ≃ (G ⧸ H) × H`, whose cardinal image is `#G = #(G ⧸ H) · #H`.",
+      "**Pretransitive actions** — `MulAction.IsPretransitive` and `MulAction.exists_smul_eq`, giving `orbit G x = Set.univ` for the transitive corollary."
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/LagrangeTheoremOQ02OQ03.lean",
+    "namespace": "OrbitStabilizerCardinal",
+    "imports": [
+      "Mathlib.GroupTheory.GroupAction.Quotient",
+      "Mathlib.GroupTheory.Index",
+      "Mathlib.GroupTheory.Coset.Basic",
+      "Mathlib.SetTheory.Cardinal.Finite",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MulAction",
+      "Cardinal"
+    ],
+    "lineCount": 167,
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "references": [
+    {
+      "type": "textbook",
+      "citation": "Dummit, D.S., and Foote, R.M. (2004). \"Abstract Algebra,\" 3rd ed. Wiley. §4.1 (Group actions), Theorem 4.1.7 (Orbit–Stabilizer).",
+      "relevance": "Standard reference for the finite orbit–stabilizer theorem |G · x| · |Stab(x)| = |G|. This entry generalizes the statement to arbitrary (infinite) groups over cardinal arithmetic, recovering Theorem 4.1.7 as the finite specialization."
+    },
+    {
+      "type": "textbook",
+      "citation": "Rotman, J.J. (1995). \"An Introduction to the Theory of Groups,\" 4th ed. Springer GTM 148. §3 (The orbit–stabilizer theorem and Lagrange's theorem).",
+      "relevance": "Presents orbit–stabilizer as a consequence of Lagrange applied to the point stabilizer. The cardinal formulation here makes the underlying bijection explicit and finiteness-free."
+    },
+    {
+      "type": "textbook",
+      "citation": "Jech, T. (2003). \"Set Theory,\" 3rd millennium ed. Springer. Ch. 3 (Cardinal arithmetic).",
+      "relevance": "Reference for cardinal multiplication and the fact that cardinal products of infinite cardinals do not degenerate the way `Nat.card` products do. Justifies why `Cardinal.mk` is the correct home for the infinite-general orbit–stabilizer product."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.GroupTheory.GroupAction.Quotient\" — `MulAction.orbitEquivQuotientStabilizer`, `MulAction.orbitProdStabilizerEquivGroup`. (accessed 2026)",
+      "relevance": "The finiteness-free orbit–stabilizer bijection and its finite product companion. This file's `orbitEquivQuotient` restates the former; `card_orbit_mul_card_stabilizer` uses the latter."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.GroupTheory.Coset.Basic\" — `Subgroup.groupEquivQuotientProdSubgroup`, `QuotientGroup.eq`. (accessed 2026)",
+      "relevance": "The bijection `G ≃ (G ⧸ H) × H` giving cardinal Lagrange, and the coset-equality criterion used in the coset characterization of equal images."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.SetTheory.Cardinal.Finite\" and \"Mathlib.SetTheory.Cardinal.Basic\" — `Cardinal.mk_congr`, `Cardinal.mk_prod`, `Cardinal.lift_id`, `Cardinal.mk_univ`, `Nat.card_congr`. (accessed 2026)",
+      "relevance": "The cardinal-arithmetic toolkit: turning bijections into cardinal equalities, computing cardinal products, and specializing to `Nat.card` in the finite case."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Proofs.LagrangeTheoremOQ02OQ02\" — parent gallery entry (the class equation). (this repository, accessed 2026)",
+      "relevance": "Parent in the orbit–stabilizer family. The class equation proved there is one application of the orbit-decomposition identity; this entry provides the finiteness-free cardinal backbone from which such applications draw."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "question": "The cardinal product `#(orbit G x) · #(stabilizer G x) = #G` is stated for a single universe `u` (all of G, X live in `Type u`). Can it be lifted to a fully universe-polymorphic form using `Cardinal.lift`, so that G and X may inhabit different universes?",
+      "difficulty": "medium",
+      "tags": [
+        "lean4",
+        "universe-polymorphism",
+        "cardinal-lift"
+      ]
+    },
+    {
+      "id": "oq-02",
+      "question": "Cardinal Lagrange `#G = #(G ⧸ H) · #H` here uses `Subgroup.groupEquivQuotientProdSubgroup`. Is there a formulation of the cardinal orbit–stabilizer product that avoids the axiom of choice (the coset representative selection inside that equivalence), or is choice genuinely required for the bijection in the infinite setting?",
+      "difficulty": "hard",
+      "tags": [
+        "lean4",
+        "axiom-of-choice",
+        "constructivity"
+      ]
+    },
+    {
+      "id": "oq-03",
+      "question": "The transitive corollary gives `#X = #(G ⧸ stabilizer G x)`. Can this be packaged as a general 'homogeneous space' statement identifying `X` with a coset space up to bijection, and connected to Mathlib's `MulAction.IsPretransitive` API as a reusable lemma?",
+      "difficulty": "easy",
+      "tags": [
+        "lean4",
+        "homogeneous-space",
+        "pretransitive"
+      ]
+    }
+  ],
+  "relatedProofs": [
+    "lagrange-theorem-oq-02-oq-02",
+    "lagrange-theorem-oq-02-oq-02-oq-01",
+    "lagrange-theorem-oq-02"
+  ],
+  "sections": [
+    {
+      "id": "header-and-context",
+      "title": "Header: The Finiteness-Free Reformulation",
+      "startLine": 1,
+      "endLine": 68,
+      "summary": "File docstring stating OQ-03: the `Nat.card` orbit–stabilizer product collapses to `0 = 0` on infinite groups, so this file reformulates over `Cardinal.mk`, where the bijection, cardinal identity, and product all retain content. Imports, namespace `OrbitStabilizerCardinal`, `open MulAction Cardinal`, universe `u`, and the variables `{G} [Group G] {X} [MulAction G X]`.",
+      "mathContext": "The mathematical point: finiteness plays no role in orbit–stabilizer. What is really going on is a bijection $\\mathrm{orbit}\\,G\\,x \\simeq G / \\mathrm{stabilizer}\\,G\\,x$, and taking cardinalities of a bijection is finiteness-free. Working over $\\#(-)$ rather than $\\mathrm{Nat.card}$ is what makes that content survive into the infinite regime."
+    },
+    {
+      "id": "coset-characterization",
+      "title": "The Coset Characterization of Equal Images",
+      "startLine": 70,
+      "endLine": 95,
+      "summary": "`same_image_iff_mem_stabilizer`: `g₁ • x = g₂ • x ↔ g₁⁻¹ * g₂ ∈ stabilizer G x`. `same_image_iff_coset_eq`: reformulates as coset equality `↑g₁ = ↑g₂` in `G ⧸ stabilizer G x`. Together these are the well-definedness and injectivity of the map `g • x ↦ ↑g` — the pointwise, finiteness-free core of orbit–stabilizer.",
+      "mathContext": "$g_1 \\cdot x = g_2 \\cdot x \\iff g_1^{-1} g_2 \\in \\mathrm{Stab}(x) \\iff \\overline{g_1} = \\overline{g_2}$ in $G / \\mathrm{Stab}(x)$. This is precisely the statement that $g \\cdot x \\mapsto \\overline{g}$ is a well-defined injection of the orbit into the coset space."
+    },
+    {
+      "id": "bijection-and-cardinal-identity",
+      "title": "The Bijection and the Cardinal Identity",
+      "startLine": 96,
+      "endLine": 112,
+      "summary": "`orbitEquivQuotient` (noncomputable def): restates Mathlib's `orbitEquivQuotientStabilizer G x` as the central bijection `orbit G x ≃ G ⧸ stabilizer G x`, valid for any action. `mk_orbit_eq_mk_quotient_stabilizer`: applies `Cardinal.mk_congr` to give the cardinal identity `#(orbit G x) = #(G ⧸ stabilizer G x)`.",
+      "mathContext": "$\\#(\\mathrm{orbit}\\,G\\,x) = \\#(G / \\mathrm{Stab}\\,G\\,x)$ as an equality of (possibly infinite) cardinals. Unlike the $\\mathrm{Nat.card}$ version, this retains its content when the orbit is infinite."
+    },
+    {
+      "id": "cardinal-lagrange-and-product",
+      "title": "Cardinal Lagrange and the Cardinal Orbit–Stabilizer Product",
+      "startLine": 113,
+      "endLine": 134,
+      "summary": "`mk_eq_mk_quotient_mul_mk`: cardinal form of Lagrange `#G = #(G ⧸ H) · #H` for an arbitrary subgroup, via `Subgroup.groupEquivQuotientProdSubgroup`, `mk_prod`, and `lift_id`. `mk_orbit_mul_mk_stabilizer`: feeds the cardinal identity into cardinal Lagrange to get `#(orbit G x) · #(stabilizer G x) = #G`.",
+      "mathContext": "$\\#G = \\#(G/H) \\cdot \\#H$ (cardinal Lagrange), and hence $\\#(\\mathrm{orbit}\\,G\\,x) \\cdot \\#(\\mathrm{Stab}\\,G\\,x) = \\#G$. Unlike $\\mathrm{Nat.card}(\\mathrm{orbit}) \\cdot \\mathrm{Nat.card}(\\mathrm{Stab}) = \\mathrm{Nat.card}\\,G$, this remains a true, non-degenerate statement when the group is infinite."
+    },
+    {
+      "id": "finite-specialization",
+      "title": "Finite Specialization over Nat.card",
+      "startLine": 135,
+      "endLine": 144,
+      "summary": "`card_orbit_mul_card_stabilizer`: for `[Finite G]` the cardinal product formula descends to the classical natural-number identity `Nat.card (orbit) · Nat.card (stabilizer) = Nat.card G`, via `Nat.card_prod` and `Nat.card_congr (orbitProdStabilizerEquivGroup G x)`, recovering the parent gallery entry's statement.",
+      "mathContext": "$\\mathrm{Nat.card}(\\mathrm{orbit}\\,G\\,x) \\cdot \\mathrm{Nat.card}(\\mathrm{Stab}\\,G\\,x) = \\mathrm{Nat.card}\\,G$ for finite $G$. The classical orbit–stabilizer formula, recovered as a specialization of the cardinal statement."
+    },
+    {
+      "id": "transitive-corollary",
+      "title": "The Transitive-Action Corollary",
+      "startLine": 145,
+      "endLine": 158,
+      "summary": "`mk_eq_mk_quotient_stabilizer_of_pretransitive`: for `[MulAction.IsPretransitive G X]` the orbit of any point is all of `X` (via `MulAction.exists_smul_eq`), so the cardinal identity reads `#X = #(G ⧸ stabilizer G x)` — the size of the space equals the index of any point stabilizer, with no finiteness assumption.",
+      "mathContext": "For a (pre)transitive action, $\\mathrm{orbit}\\,G\\,x = X$, so $\\#X = \\#(G / \\mathrm{Stab}\\,G\\,x)$: the homogeneous-space identity identifying $X$ with a coset space up to cardinality."
+    },
+    {
+      "id": "check-anchors",
+      "title": "Type-Signature Anchors",
+      "startLine": 159,
+      "endLine": 167,
+      "summary": "Seven `#check @...` anchors, one per theorem, closing the `OrbitStabilizerCardinal` namespace. These confirm the final type signatures of every result in the file.",
+      "mathContext": "Kernel-level confirmation that each of the seven statements elaborates at the claimed type, serving as a compile-time regression guard on the theorem signatures."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "OrbitStabilizerCardinal.same_image_iff_mem_stabilizer",
+      "statement": "∀ {G : Type u} [Group G] {X : Type u} [MulAction G X] (x : X) (g₁ g₂ : G), g₁ • x = g₂ • x ↔ g₁⁻¹ * g₂ ∈ MulAction.stabilizer G x",
+      "description": "Two group elements send x to the same point iff g₁⁻¹ g₂ stabilizes x. The pointwise, finiteness-free core of the orbit–stabilizer map."
+    },
+    {
+      "name": "OrbitStabilizerCardinal.same_image_iff_coset_eq",
+      "statement": "∀ {G : Type u} [Group G] {X : Type u} [MulAction G X] (x : X) (g₁ g₂ : G), g₁ • x = g₂ • x ↔ (↑g₁ : G ⧸ MulAction.stabilizer G x) = ↑g₂",
+      "description": "Equal images characterized as coset equality in G ⧸ stabilizer G x — the well-definedness and injectivity of g • x ↦ ↑g."
+    },
+    {
+      "name": "OrbitStabilizerCardinal.mk_orbit_eq_mk_quotient_stabilizer",
+      "statement": "∀ {G : Type u} [Group G] {X : Type u} [MulAction G X] (x : X), #(MulAction.orbit G x) = #(G ⧸ MulAction.stabilizer G x)",
+      "description": "The cardinal orbit–stabilizer identity #(orbit G x) = #(G ⧸ stabilizer G x) as an equality of possibly-infinite cardinals, from Cardinal.mk_congr applied to the bijection."
+    },
+    {
+      "name": "OrbitStabilizerCardinal.mk_eq_mk_quotient_mul_mk",
+      "statement": "∀ {G : Type u} [Group G] (H : Subgroup G), #G = #(G ⧸ H) * #H",
+      "description": "The cardinal form of Lagrange's theorem for an arbitrary subgroup of an arbitrary group, from Subgroup.groupEquivQuotientProdSubgroup."
+    },
+    {
+      "name": "OrbitStabilizerCardinal.mk_orbit_mul_mk_stabilizer",
+      "statement": "∀ {G : Type u} [Group G] {X : Type u} [MulAction G X] (x : X), #(MulAction.orbit G x) * #(MulAction.stabilizer G x) = #G",
+      "description": "The cardinal orbit–stabilizer product #(orbit G x) · #(stabilizer G x) = #G, the infinite-general product form that stays informative where the Nat.card version collapses to 0 = 0."
+    },
+    {
+      "name": "OrbitStabilizerCardinal.card_orbit_mul_card_stabilizer",
+      "statement": "∀ {G : Type u} [Group G] {X : Type u} [MulAction G X] [Finite G] (x : X), Nat.card (MulAction.orbit G x) * Nat.card (MulAction.stabilizer G x) = Nat.card G",
+      "description": "The finite specialization: for a finite group the cardinal product descends to the classical Nat.card orbit–stabilizer formula, recovering the parent gallery entry's statement."
+    },
+    {
+      "name": "OrbitStabilizerCardinal.mk_eq_mk_quotient_stabilizer_of_pretransitive",
+      "statement": "∀ {G : Type u} [Group G] {X : Type u} [MulAction G X] [MulAction.IsPretransitive G X] (x : X), #X = #(G ⧸ MulAction.stabilizer G x)",
+      "description": "The transitive corollary: when the action is pretransitive the orbit is all of X, so #X = #(G ⧸ stabilizer G x) — the size of the space equals the index of any point stabilizer."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "lagrange-theorem-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Parent: the class equation for finite groups. This entry supplies the finiteness-free cardinal backbone (orbit–stabilizer bijection and cardinal Lagrange) underlying the parent's orbit-decomposition machinery."
+    },
+    {
+      "proofId": "lagrange-theorem-oq-02-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Sibling: Burnside's lemma from the class equation (OQ-01 of the same parent). Both draw on the same MulAction / orbit–stabilizer infrastructure; this entry provides the cardinal generalization while OQ-01 provides the orbit-counting application."
+    },
+    {
+      "proofId": "lagrange-theorem-oq-02",
+      "relationship": "related",
+      "description": "Grandparent: the orbit–stabilizer family root. This entry is the OQ-03 leaf giving the infinite-general Cardinal.mk formulation, contrasting with the Nat.card sibling that collapses on infinite groups."
+    }
+  ],
+  "conclusion": {
+    "summary": "OQ-03 of the orbit–stabilizer family is resolved affirmatively (status: verified, 0 sorries, 0 axioms). Over Cardinal.mk the orbit–stabilizer bijection orbit G x ≃ G ⧸ stabilizer G x gives the cardinal identity #(orbit) = #(G ⧸ stabilizer), which composed with cardinal Lagrange #G = #(G ⧸ H) · #H yields the cardinal orbit–stabilizer product #(orbit) · #(stabilizer) = #G — a statement that stays true and informative for infinite groups where the Nat.card version collapses to 0 = 0. The finite formula is recovered by specialization, and the transitive case reads #X = #(G ⧸ stabilizer G x). Seven theorems, one noncomputable def, 167 lines.",
+    "implications": "The entry demonstrates that finiteness is a red herring in orbit–stabilizer: the theorem is a bijection, and cardinal arithmetic is the natural setting that preserves its content into the infinite regime. This is a reusable lesson for the gallery — whenever a finite counting identity is 'really' a bijection, moving from Nat.card to Cardinal.mk recovers an infinite-general statement at no extra cost, with the finite version dropping out as a specialization. The cardinal Lagrange lemma mk_eq_mk_quotient_mul_mk is independently useful and importable for any downstream infinite-group index computation.",
+    "openQuestions": [
+      "Can the single-universe cardinal product #(orbit G x) · #(stabilizer G x) = #G be lifted to a universe-polymorphic form via Cardinal.lift, allowing G and X to inhabit different universes?",
+      "Is the axiom of choice genuinely required for the cardinal orbit–stabilizer bijection in the infinite setting (via the coset representative selection in Subgroup.groupEquivQuotientProdSubgroup), or can a choice-free formulation be given?",
+      "Can the transitive corollary #X = #(G ⧸ stabilizer G x) be packaged as a general homogeneous-space lemma connected to Mathlib's IsPretransitive API for reuse elsewhere in the gallery?"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds the gallery entry for the recovered, docker-verified proof `proofs/Proofs/LagrangeTheoremOQ02OQ03.lean` (merged in PR #35316, commit `7a01e96`). The proof gives the finiteness-free cardinal formulation of the orbit–stabilizer theorem — where the `Nat.card` product form collapses to `0 = 0` on infinite groups, the `Cardinal.mk` form `#(orbit) · #(stabilizer) = #G` retains its content. The Lean file existed on `main` without a gallery directory; this PR supplies `meta.json` + `annotations.json` only (no Lean rebuild needed — already verified).

## Changes

- `src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-03/meta.json` — new gallery metadata (7 mainTheorems, sections with verified 167-line ranges, cross-references to parent/siblings, references, open questions, conclusion)
- `src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-03/annotations.json` — 7 per-section annotations matching the source line ranges (header 1–60, coset characterization 70–95, bijection 96–112, cardinal Lagrange 113–134, finite specialization 135–144, transitive corollary 145–158, `#check` anchors 159–167)

Only the new gallery directory is committed. `pnpm build`'s incidental annotation-regen churn (~1788 unrelated `annotations.json` files) was reverted before staging.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Slug `lagrange-theorem-oq-02-oq-02-oq-03`, unclaimed | ✅ | New dir created; no collision |
| Stats: 167 lines, 7 theorems, 1 def, 0 sorries, 0 axioms | ✅ | Read source; both `meta.*` and `leanFile.*` blocks set accordingly |
| status `verified`, badge `mathlib` | ✅ | Per Axiom Integrity Policy (0 axioms, 0 native_decide, 0 structure assumptions) |
| Three sorry fields consistent (top-level, `meta.sorries`, `leanFile.sorries`) | ✅ | All `0`; asserted by JSON consistency script |
| Both stat blocks accurate (167 lines / 7 theorems / 1 def / 0 axioms) | ✅ | `meta.*` == `leanFile.*` asserted |
| annotations section ranges match curator-verified ranges | ✅ | 7 annotations at the specified ranges |
| `index.ts` not hand-edited | ✅ | Build-generated; untouched |
| `pnpm build` passes | ✅ | Built in ~10.5s, bundle budget OK |
| Only new gallery dir committed | ✅ | `git diff --cached --stat` shows exactly the two new files |

## Test Plan

- `python3 json.load` on both files — valid JSON (7 annotations)
- Consistency script: top-level `sorries` == `meta.sorries` == `leanFile.sorries` == 0; `meta.axiomCount` == `leanFile.axiomCount` == 0; lineCount 167; theoremCount 7; definitionCount 1; status verified / badge mathlib; 7 mainTheorems — all pass
- `pnpm build` — passes (gallery validation + bundle budget)
- Reverted all incidental build churn; `git diff --cached --stat` confirms only the two new files staged

Closes #35317

🤖 Generated with [Claude Code](https://claude.com/claude-code)