### PR TITLE
feat(gallery): precomputed full-text search index for description recall

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "export NODE_OPTIONS=\"${NODE_OPTIONS:-} --max-old-space-size=8192\" && pnpm gallery:check-size && pnpm annotations:build && pnpm research:build && pnpm research:enrich && pnpm gallery:loading-facts && tsc -b && vite build && pnpm gallery:check-bundle-budget",
+    "build": "export NODE_OPTIONS=\"${NODE_OPTIONS:-} --max-old-space-size=8192\" && pnpm gallery:check-size && pnpm annotations:build && pnpm research:build && pnpm research:enrich && pnpm gallery:check-search-index && pnpm gallery:loading-facts && tsc -b && vite build && pnpm gallery:check-bundle-budget",
     "lint": "eslint .",
     "gallery:check-bundle-budget": "tsx scripts/gallery/check-bundle-budget.ts",
+    "gallery:check-search-index": "tsx scripts/gallery/check-search-index.ts",
     "gallery:check-size": "tsx scripts/gallery/check-meta-size.ts",
     "gallery:check-size:strict": "tsx scripts/gallery/check-meta-size.ts --strict",
     "gallery:size-report": "tsx scripts/gallery/check-meta-size.ts --report",

--- a/scripts/annotations/build.ts
+++ b/scripts/annotations/build.ts
@@ -368,6 +368,13 @@ function sha8(filePath: string): string {
 const LISTINGS_MANIFEST_KEY = '__listings__';
 
 /**
+ * Reserved data-manifest key carrying the content hash of the emitted public
+ * search-index file (issue #35117). Never collides with a proof slug
+ * (slugs are kebab-case directory names).
+ */
+const SEARCH_INDEX_MANIFEST_KEY = '__searchindex__';
+
+/**
  * Truncate a listing description to a card-length excerpt (issue #35117).
  * Card view clamps to a few lines anyway; the full description still lives in
  * the per-proof meta.json fetched on the detail page. Cuts at a word boundary
@@ -549,6 +556,15 @@ function emitDataManifest(proofs: ProofConfig[]): boolean {
     src: '',
   };
 
+  // Reserved entry: content hash of the public search-index file so the runtime
+  // getSearchIndex() fetch is cache-busted on any content change (issue #35117).
+  const publicSearchIndex = path.join(PUBLIC_PROOFS_DIR, 'search-index.json');
+  manifest[SEARCH_INDEX_MANIFEST_KEY] = {
+    meta: fs.existsSync(publicSearchIndex) ? sha8(publicSearchIndex) : '',
+    ann: '',
+    src: '',
+  };
+
   const manifestPath = path.join(PROOFS_DATA_DIR, 'data-manifest.json');
   const next = JSON.stringify(manifest, null, 2) + '\n';
 
@@ -660,6 +676,59 @@ function generateListings(
 }
 
 /**
+ * Generate a precomputed search index (issue #35117).
+ *
+ * The listings payload truncates each description to a 140-char card excerpt,
+ * which narrowed client-side search recall — 91.9% of proof descriptions
+ * exceed the excerpt, so queries matching only the description tail stopped
+ * returning cards. This index restores full-text description search WITHOUT
+ * reinflating the eager listings fetch: it is emitted only to `public/data/`
+ * (never bundled into the JS graph) and fetched lazily at runtime, only when
+ * the user actually searches (see `getSearchIndex()` in
+ * `src/data/proofs/index.ts`).
+ *
+ * Shape: `{ [slug]: <full description, lowercased> }`. Title and tags are
+ * omitted — they already ship in full in the listings payload, so search
+ * consults the listing for those and this index only for the description.
+ * Lowercasing at build time keeps the runtime match a plain `includes()` and
+ * shrinks the transferred bytes slightly (no per-query re-lowercasing of a
+ * multi-MB string blob).
+ *
+ * Off-graph guarantee: written ONLY under public/data/proofs/. The 600 KB
+ * bundle-budget guard (scripts/gallery/check-bundle-budget.ts) protects against
+ * any future accidental inlining.
+ */
+function generateSearchIndex(proofs: ProofConfig[]): void {
+  const index: Record<string, string> = {};
+
+  for (const proof of proofs) {
+    const metaPath = path.join(proof.dataDir, 'meta.json');
+    if (!fs.existsSync(metaPath)) continue;
+
+    const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+    const slug = meta.slug || proof.id;
+    const description: string = (meta.description || '').trim();
+    // Only index proofs whose full description carries text beyond what the
+    // card excerpt would show — otherwise the listing description already
+    // covers the whole string and an index entry would be redundant bytes.
+    // (Search still falls back to the listing description for every proof, so
+    // short-description proofs remain fully searchable without an index entry.)
+    if (description.length > LISTING_EXCERPT_MAX) {
+      index[slug] = description.toLowerCase();
+    }
+  }
+
+  fs.mkdirSync(PUBLIC_PROOFS_DIR, { recursive: true });
+  // public/ only — this asset is fetched lazily at runtime and must never be
+  // pulled into the vite/Rollup module graph. Compact serialization; these
+  // bytes go over the wire.
+  const publicPath = path.join(PUBLIC_PROOFS_DIR, 'search-index.json');
+  fs.writeFileSync(publicPath, JSON.stringify(index));
+
+  console.log(`🔎 Generated search-index.json (${Object.keys(index).length} proofs indexed, ${Math.round(fs.statSync(publicPath).size / 1024)}KB public)`);
+}
+
+/**
  * Compute a deterministic input-fingerprint for the annotation build.
  *
  * Inputs (per issue #22149 Strategy B):
@@ -744,6 +813,12 @@ function build(options: { strict: boolean; verbose: boolean }): boolean {
 
   // Generate lightweight listings for HomePage
   generateListings(proofs, touched);
+
+  // Generate the precomputed full-text search index (issue #35117). Emitted to
+  // public/ only and fetched lazily at runtime when the user searches, so it
+  // restores description search recall without reinflating the eager listings
+  // payload (which only carries 140-char excerpts).
+  generateSearchIndex(proofs);
 
   // Emit Lean source to the build-generated public asset tree (fetched by slug
   // at runtime instead of imported via `*.lean?raw`). See issue #20992. With

--- a/scripts/gallery/check-search-index.ts
+++ b/scripts/gallery/check-search-index.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env npx tsx
+/**
+ * Search-index smoke check (issue #35117).
+ *
+ * The gallery listings payload truncates descriptions to a 140-char card
+ * excerpt, which narrowed client-side search recall. The build emits a separate
+ * precomputed search index (public/data/proofs/search-index.json and
+ * public/data/research/research-search-index.json) carrying the FULL,
+ * untruncated descriptions so search over description tails still works.
+ *
+ * This check runs after the annotation + research builds and fails the build if
+ * the search index ever regresses back to the truncated excerpt (e.g. someone
+ * accidentally points it at the listings field). Concretely it verifies, for
+ * each index:
+ *   1. The index file exists and parses.
+ *   2. It has a non-trivial number of entries.
+ *   3. At least one entry is longer than the listing excerpt cap — proving the
+ *      index carries full text, not the truncated excerpt.
+ *   4. No index value ends with the truncation ellipsis '…' — the excerpt
+ *      marker must never appear in the full-text index.
+ *
+ * Usage: tsx scripts/gallery/check-search-index.ts
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.join(__dirname, '../..')
+
+// Must match the excerpt cap in scripts/annotations/build.ts and
+// scripts/research/build.ts. Kept in sync manually — the check is deliberately
+// tolerant (it only needs SOME entry to exceed this) so a future cap tweak
+// won't spuriously fail.
+const LISTING_EXCERPT_MAX = 140
+
+interface IndexSpec {
+  label: string
+  indexPath: string
+  minEntries: number
+}
+
+const SPECS: IndexSpec[] = [
+  {
+    label: 'proofs',
+    indexPath: path.join(REPO_ROOT, 'public/data/proofs/search-index.json'),
+    minEntries: 1,
+  },
+  {
+    label: 'research',
+    indexPath: path.join(REPO_ROOT, 'public/data/research/research-search-index.json'),
+    minEntries: 1,
+  },
+]
+
+let failed = false
+
+for (const spec of SPECS) {
+  if (!fs.existsSync(spec.indexPath)) {
+    console.error(`FAIL [${spec.label}]: search index not found at ${spec.indexPath} — run the gallery build first`)
+    failed = true
+    continue
+  }
+
+  let index: Record<string, string>
+  try {
+    index = JSON.parse(fs.readFileSync(spec.indexPath, 'utf-8'))
+  } catch (e) {
+    console.error(`FAIL [${spec.label}]: search index is not valid JSON: ${e instanceof Error ? e.message : e}`)
+    failed = true
+    continue
+  }
+
+  const entries = Object.entries(index)
+  if (entries.length < spec.minEntries) {
+    console.error(`FAIL [${spec.label}]: search index has ${entries.length} entries (< ${spec.minEntries})`)
+    failed = true
+    continue
+  }
+
+  // Every value must be a string.
+  const nonString = entries.find(([, v]) => typeof v !== 'string')
+  if (nonString) {
+    console.error(`FAIL [${spec.label}]: search index value for "${nonString[0]}" is not a string`)
+    failed = true
+    continue
+  }
+
+  // Full-text proof: at least one entry must exceed the excerpt cap. If the
+  // index were built from the truncated listing field instead of the full
+  // description, no value could exceed the cap.
+  const longest = entries.reduce((max, [, v]) => Math.max(max, v.length), 0)
+  if (longest <= LISTING_EXCERPT_MAX) {
+    console.error(
+      `FAIL [${spec.label}]: longest search-index entry is ${longest} chars (<= ${LISTING_EXCERPT_MAX}). ` +
+        `The index appears to carry truncated excerpts, not full descriptions — ` +
+        `verify it is built from the untruncated meta/problem description (issue #35117).`
+    )
+    failed = true
+    continue
+  }
+
+  // Detect the truncation-excerpt signature: the excerpt() builder cuts to at
+  // most LISTING_EXCERPT_MAX chars and appends '…', so a truncated excerpt ends
+  // with '…' AND has length <= cap + 1. A full description that legitimately
+  // ends in an author-written '…' (e.g. "3, 5, 7, 11, 13, 17, …") is far longer
+  // than the cap and must NOT trip this — only the truncated-excerpt signature
+  // should. Every index entry carries a description longer than the cap by
+  // construction, so a short entry ending in '…' means the index was wrongly
+  // pointed at the truncated listing field.
+  const truncated = entries.find(([, v]) => v.endsWith('…') && v.length <= LISTING_EXCERPT_MAX + 1)
+  if (truncated) {
+    console.error(
+      `FAIL [${spec.label}]: search-index entry "${truncated[0]}" looks like a truncated ` +
+        `excerpt (ends with '…', length ${truncated[1].length} <= ${LISTING_EXCERPT_MAX + 1}). ` +
+        `The full-text index must be built from untruncated descriptions (issue #35117).`
+    )
+    failed = true
+    continue
+  }
+
+  console.log(
+    `ok [${spec.label}]: ${entries.length} entries, longest ${longest} chars ` +
+      `(> ${LISTING_EXCERPT_MAX} excerpt cap — full descriptions confirmed)`
+  )
+}
+
+if (failed) {
+  process.exit(1)
+}
+
+console.log('Search index checks passed.\n')

--- a/scripts/research/build.ts
+++ b/scripts/research/build.ts
@@ -590,12 +590,20 @@ function excerpt(text: string, max: number = LISTING_EXCERPT_MAX): string {
   return (lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut).replace(/[\s,;:.]+$/, '') + '…'
 }
 
+/**
+ * Resolve the full (untruncated) listing description for a problem. Shared by
+ * `generateListing` (which truncates it to a card excerpt) and the search-index
+ * builder (which keeps it full). Applies the same status-placeholder fallback
+ * to the problem title so the search text matches what the card shows.
+ */
+function fullDescription(problem: ResearchProblem): string {
+  const rawDescription = problem.problemStatement?.plain || ''
+  return isDescriptionPlaceholder(rawDescription) ? problem.title : rawDescription
+}
+
 function generateListing(problem: ResearchProblem): ResearchListing {
   // Safety net: if problemStatement.plain is a status placeholder, fall back to title
-  const rawDescription = problem.problemStatement?.plain || ''
-  const description = isDescriptionPlaceholder(rawDescription)
-    ? problem.title
-    : rawDescription
+  const description = fullDescription(problem)
 
   return {
     slug: problem.slug,
@@ -759,6 +767,13 @@ function emitDataManifest(slugs: string[]): void {
     manifest['__listings__'] = sha8(publicListings)
   }
 
+  // Reserved entry: content hash of the public search-index file so the runtime
+  // getResearchSearchIndex() fetch is cache-busted on any change (issue #35117).
+  const publicSearchIndex = path.join(PUBLIC_RESEARCH_DIR, 'research-search-index.json')
+  if (fs.existsSync(publicSearchIndex)) {
+    manifest['__searchindex__'] = sha8(publicSearchIndex)
+  }
+
   const next = JSON.stringify(manifest, null, 2) + '\n'
 
   if (fs.existsSync(DATA_MANIFEST_PATH)) {
@@ -834,6 +849,20 @@ function build(): void {
   // Process each problem
   const problems: ResearchProblem[] = []
   const listings: ResearchListing[] = []
+  // Precomputed full-text search index (issue #35117): slug -> full lowercased
+  // description. Emitted to public/ only and fetched lazily at runtime when the
+  // user searches, restoring description search recall without reinflating the
+  // eager listings fetch (which only carries 140-char excerpts). Populated in
+  // lockstep with `listings` so stubs skipped from listings are also absent
+  // here. Only entries whose full text exceeds the excerpt get indexed; search
+  // still falls back to the listing description for the rest.
+  const searchIndex: Record<string, string> = {}
+  const indexSearch = (problem: ResearchProblem) => {
+    const desc = fullDescription(problem).trim()
+    if (desc.length > LISTING_EXCERPT_MAX) {
+      searchIndex[problem.slug] = desc.toLowerCase()
+    }
+  }
   // Track every slug whose JSON we emit to public/data/research/<slug>.json.
   // This includes preserved-from-committed-JSON entries (the common case) and
   // newly generated problems alike — both are reachable via deep-link at
@@ -866,6 +895,7 @@ function build(): void {
         stubSkippedSlugs.push(entry.slug)
       } else {
         listings.push(generateListing(problem))
+        indexSearch(problem)
       }
       preservedCount++
       // Phase 3 (issue #20994): also emit to public/ so the runtime fetch-by-slug
@@ -885,6 +915,7 @@ function build(): void {
           stubSkippedSlugs.push(entry.slug)
         } else {
           listings.push(generateListing(problem))
+          indexSearch(problem)
         }
         generatedCount++
 
@@ -911,6 +942,12 @@ function build(): void {
   fs.mkdirSync(PUBLIC_RESEARCH_DIR, { recursive: true })
   const publicListingsPath = path.join(PUBLIC_RESEARCH_DIR, 'research-listings.json')
   fs.writeFileSync(publicListingsPath, JSON.stringify(listings))
+
+  // Precomputed full-text search index (issue #35117). public/ only — fetched
+  // lazily at runtime when the user searches; never bundled into the JS graph.
+  const publicSearchIndexPath = path.join(PUBLIC_RESEARCH_DIR, 'research-search-index.json')
+  fs.writeFileSync(publicSearchIndexPath, JSON.stringify(searchIndex))
+  console.log(`Generated research-search-index.json (${Object.keys(searchIndex).length} problems indexed, ${Math.round(fs.statSync(publicSearchIndexPath).size / 1024)}KB)`)
 
   // Phase 3 (issue #20994): emit the hashed slug -> sha8 manifest consumed by
   // the runtime loader in `src/data/research/index.ts`. Must run after the

--- a/src/data/proofs/index.ts
+++ b/src/data/proofs/index.ts
@@ -59,7 +59,22 @@ const DATA_MANIFEST: Record<string, ManifestEntry> = dataManifest as Record<
  */
 const LISTINGS_MANIFEST_KEY = '__listings__'
 
+/**
+ * Reserved data-manifest key carrying the content hash of the emitted public
+ * search-index file (see scripts/annotations/build.ts). Not a proof slug.
+ */
+const SEARCH_INDEX_MANIFEST_KEY = '__searchindex__'
+
+/**
+ * Precomputed search index (issue #35117). Maps proof slug -> the FULL,
+ * untruncated description (lowercased) so client-side search can match text
+ * beyond the 140-char listings excerpt without reinflating the eager listings
+ * payload. Fetched lazily only when the user searches.
+ */
+export type ProofSearchIndex = Record<string, string>
+
 let listingsPromise: Promise<ProofListing[]> | null = null
+let searchIndexPromise: Promise<ProofSearchIndex> | null = null
 
 /**
  * Fetch the lightweight gallery listings (phase 3, issue #35117).
@@ -82,6 +97,36 @@ export function getListings(): Promise<ProofListing[]> {
       })
   }
   return listingsPromise
+}
+
+/**
+ * Fetch the precomputed search index (issue #35117).
+ *
+ * The listings payload delivered by `getListings()` carries only a 140-char
+ * description excerpt (issue #35117 item 2), which narrowed full-text search
+ * recall — 91.9% of proof descriptions exceed that excerpt. This index restores
+ * full-text description search by mapping slug -> full lowercased description,
+ * built at build time from the untruncated meta.json descriptions.
+ *
+ * The promise is cached module-level so the index is fetched at most once per
+ * session. A failed fetch clears the cache so a later call can retry. Callers
+ * should only invoke this when a search is actually active, so the eager first
+ * paint never downloads the index (see useLazyFetchedData).
+ */
+export function getSearchIndex(): Promise<ProofSearchIndex> {
+  if (!searchIndexPromise) {
+    const v = DATA_MANIFEST[SEARCH_INDEX_MANIFEST_KEY]?.meta ?? ''
+    searchIndexPromise = fetch(`/data/proofs/search-index.json?v=${v}`)
+      .then((resp) => {
+        if (!resp.ok) throw new Error(`Failed to load search index (HTTP ${resp.status})`)
+        return resp.json() as Promise<ProofSearchIndex>
+      })
+      .catch((e) => {
+        searchIndexPromise = null
+        throw e
+      })
+  }
+  return searchIndexPromise
 }
 
 /**

--- a/src/data/research/index.ts
+++ b/src/data/research/index.ts
@@ -42,7 +42,22 @@ const DATA_MANIFEST: Record<string, string> = dataManifest as Record<string, str
  */
 const LISTINGS_MANIFEST_KEY = '__listings__'
 
+/**
+ * Reserved data-manifest key carrying the content hash of the emitted public
+ * research search-index file (see scripts/research/build.ts). Not a slug.
+ */
+const SEARCH_INDEX_MANIFEST_KEY = '__searchindex__'
+
+/**
+ * Precomputed research search index (issue #35117). Maps problem slug -> the
+ * FULL, untruncated description (lowercased) so client-side search can match
+ * text beyond the 140-char listings excerpt without reinflating the eager
+ * listings payload. Fetched lazily only when the user searches.
+ */
+export type ResearchSearchIndex = Record<string, string>
+
 let listingsPromise: Promise<ResearchListing[]> | null = null
+let searchIndexPromise: Promise<ResearchSearchIndex> | null = null
 
 /**
  * Fetch the lightweight research listings for the gallery page.
@@ -67,6 +82,36 @@ export function getResearchListings(): Promise<ResearchListing[]> {
       })
   }
   return listingsPromise
+}
+
+/**
+ * Fetch the precomputed research search index (issue #35117).
+ *
+ * The listings payload from `getResearchListings()` carries only a 140-char
+ * description excerpt, which narrowed full-text search recall (47.4% of
+ * research descriptions exceed that excerpt). This index restores full-text
+ * description search by mapping slug -> full lowercased description, built at
+ * build time from the untruncated problem descriptions.
+ *
+ * The promise is cached module-level so the index is fetched at most once per
+ * session. A failed fetch clears the cache so a later call can retry. Callers
+ * should only invoke this when a search is actually active, so the eager first
+ * paint never downloads the index (see useLazyFetchedData).
+ */
+export function getResearchSearchIndex(): Promise<ResearchSearchIndex> {
+  if (!searchIndexPromise) {
+    const v = DATA_MANIFEST[SEARCH_INDEX_MANIFEST_KEY] ?? ''
+    searchIndexPromise = fetch(`/data/research/research-search-index.json?v=${v}`)
+      .then((resp) => {
+        if (!resp.ok) throw new Error(`Failed to load research search index (HTTP ${resp.status})`)
+        return resp.json() as Promise<ResearchSearchIndex>
+      })
+      .catch((e) => {
+        searchIndexPromise = null
+        throw e
+      })
+  }
+  return searchIndexPromise
 }
 
 /**

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useUrlState, useDebouncedUrlState, serializers } from './useUrlState'
 export { useFetchedData } from './useFetchedData'
+export { useLazyFetchedData } from './useLazyFetchedData'

--- a/src/hooks/useLazyFetchedData.ts
+++ b/src/hooks/useLazyFetchedData.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Lazily load async data the first time `enabled` becomes true (issue #35117).
+ *
+ * Unlike `useFetchedData`, which fetches on mount, this hook defers the fetch
+ * until `enabled` flips to true — then keeps the result cached for the rest of
+ * the session (the underlying `load` also caches its promise module-level, so
+ * repeated calls are free). Built for the search-index loaders
+ * (`getSearchIndex`, `getResearchSearchIndex`), which should only be fetched
+ * once the user actually searches, so the eager first paint never pays for the
+ * index download.
+ *
+ * `load` must be referentially stable (e.g. a module-level function); passing
+ * an inline closure would refire the effect on every render.
+ */
+export function useLazyFetchedData<T>(
+  load: () => Promise<T>,
+  enabled: boolean
+): {
+  data: T | null
+  error: boolean
+} {
+  const [data, setData] = useState<T | null>(null)
+  const [error, setError] = useState(false)
+  // Guards against re-firing the fetch on subsequent renders. A ref (not state)
+  // so flipping it doesn't itself trigger a render / setState-in-effect.
+  const startedRef = useRef(false)
+
+  useEffect(() => {
+    if (!enabled || startedRef.current) return
+    startedRef.current = true
+    let cancelled = false
+    load()
+      .then((d) => {
+        if (!cancelled) setData(d)
+      })
+      .catch(() => {
+        if (!cancelled) setError(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, load])
+
+  return { data, error }
+}

--- a/src/pages/ErdosPage.tsx
+++ b/src/pages/ErdosPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { getListings } from '@/data/proofs'
+import { getListings, getSearchIndex } from '@/data/proofs'
 import { useAuth } from '@/contexts/AuthContext'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { Footer } from '@/components/Footer'
@@ -8,7 +8,7 @@ import { LoadingScreen } from '@/components/LoadingScreen'
 import { ProofBadge, ErdosBadge, MathlibIndicator, BadgeFilter } from '@/components/ui/proof-badge'
 import { BADGE_INFO, ERDOS_BADGE_INFO } from '@/types/proof'
 import { ArrowRight, Clock, CheckCircle, AlertCircle, Plus, Filter, ArrowUpDown, Search, Github, Share2, ExternalLink, Calendar, Trophy } from 'lucide-react'
-import { useDebouncedUrlState, useUrlState, serializers, useFetchedData } from '@/hooks'
+import { useDebouncedUrlState, useUrlState, serializers, useFetchedData, useLazyFetchedData } from '@/hooks'
 import type { ProofBadge as ProofBadgeType, ProofListing } from '@/types/proof'
 
 type SortOption = 'problem-number' | 'newest' | 'updated' | 'alphabetical'
@@ -46,6 +46,12 @@ export function ErdosPage() {
 
   // URL-synced state
   const [searchQuery, setSearchQuery] = useDebouncedUrlState('q', '', serializers.string)
+
+  // Full-text search index (issue #35117): fetched lazily only once the user
+  // searches, so first paint never pays for it. Restores description search
+  // recall past the 140-char listings excerpt. Falls back to the truncated
+  // listing description while it loads or if the fetch fails.
+  const { data: searchIndex } = useLazyFetchedData(getSearchIndex, searchQuery.trim().length > 0)
   const [selectedBadges, setSelectedBadges] = useUrlState<ProofBadgeType[]>(
     'badges',
     [],
@@ -69,15 +75,21 @@ export function ErdosPage() {
     // Start with only Erdős problems
     let filtered: ProofListing[] = (listings ?? []).filter(l => l.erdosNumber !== undefined)
 
-    // Filter by search query
+    // Filter by search query. Description matching consults the full-text
+    // search index (issue #35117) when available so matches past the 140-char
+    // listing excerpt still surface; the truncated listing.description is the
+    // fallback while the index loads or for entries absent from it.
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase()
-      filtered = filtered.filter((listing) =>
-        listing.title.toLowerCase().includes(query) ||
-        listing.description.toLowerCase().includes(query) ||
-        listing.tags.some(tag => tag.toLowerCase().includes(query)) ||
-        (listing.erdosNumber && listing.erdosNumber.toString().includes(query))
-      )
+      filtered = filtered.filter((listing) => {
+        const fullDescription = searchIndex?.[listing.slug]
+        return (
+          listing.title.toLowerCase().includes(query) ||
+          (fullDescription ?? listing.description.toLowerCase()).includes(query) ||
+          listing.tags.some(tag => tag.toLowerCase().includes(query)) ||
+          (listing.erdosNumber && listing.erdosNumber.toString().includes(query))
+        )
+      })
     }
 
     // Filter by badge type
@@ -113,7 +125,7 @@ export function ErdosPage() {
           return 0
       }
     })
-  }, [listings, searchQuery, selectedBadges, sortBy, showAiSolvedOnly])
+  }, [listings, searchIndex, searchQuery, selectedBadges, sortBy, showAiSolvedOnly])
 
   // Compute statistics
   const stats = useMemo(() => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { getListings } from '@/data/proofs'
+import { getListings, getSearchIndex } from '@/data/proofs'
 import { useAuth } from '@/contexts/AuthContext'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { Footer } from '@/components/Footer'
@@ -8,7 +8,7 @@ import { LoadingScreen } from '@/components/LoadingScreen'
 import { ProofBadge, WiedijkBadge, ErdosBadge, BadgeFilter, MathlibIndicator } from '@/components/ui/proof-badge'
 import { WIEDIJK_BADGE_INFO, HILBERT_BADGE_INFO, MILLENNIUM_BADGE_INFO, ERDOS_BADGE_INFO } from '@/types/proof'
 import { BookOpen, ArrowRight, Clock, CheckCircle, AlertCircle, Plus, Filter, ArrowUpDown, Search, Github, Share2, Dices } from 'lucide-react'
-import { useDebouncedUrlState, useUrlState, serializers, useFetchedData } from '@/hooks'
+import { useDebouncedUrlState, useUrlState, serializers, useFetchedData, useLazyFetchedData } from '@/hooks'
 import type { ProofBadge as ProofBadgeType, ProofListing } from '@/types/proof'
 
 type SortOption = 'newest' | 'oldest' | 'alphabetical' | 'updated'
@@ -35,6 +35,12 @@ export function HomePage() {
 
   // URL-synced state
   const [searchQuery, setSearchQuery] = useDebouncedUrlState('q', '', serializers.string)
+
+  // Full-text search index (issue #35117): fetched lazily only once the user
+  // searches, so first paint never pays for it. Restores description search
+  // recall past the 140-char listings excerpt. Falls back to the truncated
+  // listing description while it loads or if the fetch fails.
+  const { data: searchIndex } = useLazyFetchedData(getSearchIndex, searchQuery.trim().length > 0)
   const [selectedBadges, setSelectedBadges] = useUrlState<ProofBadgeType[]>(
     'badges',
     [],
@@ -58,14 +64,20 @@ export function HomePage() {
   const proofs = useMemo(() => {
     let filtered: ProofListing[] = listings ?? []
 
-    // Filter by search query
+    // Filter by search query. Description matching consults the full-text
+    // search index (issue #35117) when available so matches past the 140-char
+    // listing excerpt still surface; the truncated listing.description is the
+    // fallback while the index loads or for entries absent from it.
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase()
-      filtered = filtered.filter((listing) =>
-        listing.title.toLowerCase().includes(query) ||
-        listing.description.toLowerCase().includes(query) ||
-        listing.tags.some(tag => tag.toLowerCase().includes(query))
-      )
+      filtered = filtered.filter((listing) => {
+        const fullDescription = searchIndex?.[listing.slug]
+        return (
+          listing.title.toLowerCase().includes(query) ||
+          (fullDescription ?? listing.description.toLowerCase()).includes(query) ||
+          listing.tags.some(tag => tag.toLowerCase().includes(query))
+        )
+      })
     }
 
     // Filter by badge type
@@ -124,7 +136,7 @@ export function HomePage() {
           return 0
       }
     })
-  }, [listings, searchQuery, selectedBadges, sortBy, showWiedijkOnly, showHilbertOnly, showMillenniumOnly, showErdosOnly])
+  }, [listings, searchIndex, searchQuery, selectedBadges, sortBy, showWiedijkOnly, showHilbertOnly, showMillenniumOnly, showErdosOnly])
 
   const handleBadgeToggle = (badge: ProofBadgeType) => {
     setSelectedBadges((prev) => {

--- a/src/pages/ResearchPage.tsx
+++ b/src/pages/ResearchPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { getResearchListings } from '@/data/research'
+import { getResearchListings, getResearchSearchIndex } from '@/data/research'
 // Auth context available if needed for future features
 // import { useAuth } from '@/contexts/AuthContext'
 import { UserMenu } from '@/components/auth/UserMenu'
@@ -8,7 +8,7 @@ import { Footer } from '@/components/Footer'
 import { LoadingScreen } from '@/components/LoadingScreen'
 import { ResearchCard, ContributeSection, RelatedToolsSection } from '@/components/research'
 import { PHASE_INFO, TIER_INFO } from '@/types/research'
-import { useDebouncedUrlState, useUrlState, serializers, useFetchedData } from '@/hooks'
+import { useDebouncedUrlState, useUrlState, serializers, useFetchedData, useLazyFetchedData } from '@/hooks'
 import type { ResearchPhase, ValueTier, ResearchStatus, ResearchListing } from '@/types/research'
 import {
   FlaskConical,
@@ -30,6 +30,12 @@ export function ResearchPage() {
 
   // URL-synced state
   const [searchQuery, setSearchQuery] = useDebouncedUrlState('q', '', serializers.string)
+
+  // Full-text search index (issue #35117): fetched lazily only once the user
+  // searches, so first paint never pays for it. Restores description search
+  // recall past the 140-char listings excerpt. Falls back to the truncated
+  // listing description while it loads or if the fetch fails.
+  const { data: searchIndex } = useLazyFetchedData(getResearchSearchIndex, searchQuery.trim().length > 0)
   const [selectedPhases, setSelectedPhases] = useUrlState<ResearchPhase[]>(
     'phases',
     [],
@@ -59,14 +65,20 @@ export function ResearchPage() {
   const problems = useMemo(() => {
     let filtered: ResearchListing[] = [...(researchListings ?? [])]
 
-    // Filter by search query
+    // Filter by search query. Description matching consults the full-text
+    // search index (issue #35117) when available so matches past the 140-char
+    // listing excerpt still surface; the truncated problem.description is the
+    // fallback while the index loads or for entries absent from it.
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase()
-      filtered = filtered.filter((problem) =>
-        problem.title.toLowerCase().includes(query) ||
-        problem.description.toLowerCase().includes(query) ||
-        (problem.tags ?? []).some(tag => tag.toLowerCase().includes(query))
-      )
+      filtered = filtered.filter((problem) => {
+        const fullDescription = searchIndex?.[problem.slug]
+        return (
+          problem.title.toLowerCase().includes(query) ||
+          (fullDescription ?? problem.description.toLowerCase()).includes(query) ||
+          (problem.tags ?? []).some(tag => tag.toLowerCase().includes(query))
+        )
+      })
     }
 
     // Filter by phase
@@ -108,7 +120,7 @@ export function ResearchPage() {
           return 0
       }
     })
-  }, [researchListings, searchQuery, selectedPhases, selectedTiers, selectedStatus, sortBy])
+  }, [researchListings, searchIndex, searchQuery, selectedPhases, selectedTiers, selectedStatus, sortBy])
 
   const handlePhaseToggle = (phase: ResearchPhase) => {
     setSelectedPhases((prev) =>


### PR DESCRIPTION
## Summary

Implements the remaining scope of issue #35117 (perf phase 3, item 4): a **precomputed client-side search index** built from the *full, untruncated* descriptions at build time, fetched lazily at runtime only when the user searches.

This fixes the search-recall regression the Judge flagged on PR #35139. Phase 3 item 2 truncated listing descriptions to a 140-char excerpt to shrink the eager payload, but **91.9% of proof descriptions and 47.4% of research descriptions exceed 140 chars**, so client-side search stopped matching text beyond the excerpt. The index restores full-text recall without reinflating the eager listings payload.

Tracks A/B items 1–3, the bundle-budget guard (#35139), and Track B (#35136) were already merged — this PR does not touch them. List virtualization and payload sharding remain out of scope (deferred follow-ups per the curator's recommendation).

## Changes

- **Build time** (`scripts/annotations/build.ts`, `scripts/research/build.ts`): emit `public/data/proofs/search-index.json` and `public/data/research/research-search-index.json` — `{ [slug]: <full lowercased description> }`, only for entries whose full description exceeds the 140-char excerpt cap. Content-hashed into each data-manifest under a reserved `__searchindex__` key (mirrors the existing `__listings__` pattern). Emitted to `public/data/` **only** — never imported into the JS graph.
- **Runtime loaders** (`src/data/proofs/index.ts`, `src/data/research/index.ts`): add `getSearchIndex()` / `getResearchSearchIndex()` — module-cached `fetch(...?v=<sha8>)`, retry-on-failure, same shape as `getListings()`.
- **Lazy hook** (`src/hooks/useLazyFetchedData.ts`): fetches only once `enabled` flips true, so the eager first paint never downloads the index. Guards re-fires with a ref (no setState-in-effect).
- **Search wiring** (`HomePage.tsx`, `ErdosPage.tsx`, `ResearchPage.tsx`): description matching now consults `searchIndex[slug]` when available, falling back to the truncated `listing.description` while the index loads or if the fetch fails. Title/tag/status/Erdős-number matching unchanged.
- **Build check** (`scripts/gallery/check-search-index.ts`, wired as `gallery:check-search-index`): fails the build if either index regresses to truncated excerpts (verifies at least one entry exceeds the excerpt cap and that no entry carries the truncation-ellipsis signature — full descriptions confirmed).

Note: the `data-manifest.json` / `research-data-manifest.json` and `public/data/**` search-index files are gitignored build artifacts (like the existing listings + manifests); the deploy pipeline regenerates them via `pnpm build`, which now writes the `__searchindex__` key.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Search index built from full (untruncated) descriptions | ✅ | Index built from `meta.description` / `problemStatement.plain` pre-truncation; proof index longest entry 602+ chars, research 1452 chars (both >> 140 cap) |
| Index shipped as separate runtime-fetched, content-hashed asset | ✅ | `public/data/.../search-index.json?v=<sha8>` via `__searchindex__` manifest key; confirmed in `dist/data/`, absent from every `dist/assets/*.js` |
| Fetched lazily only when the user searches | ✅ | `useLazyFetchedData(getSearchIndex, searchQuery.trim().length > 0)` — no fetch until a query is entered |
| Search/filter recall restored (matches past char 140) | ✅ | See demo below — `contrapositive` goes 4 → 31 results |
| 600 KB bundle-budget guard stays green | ✅ | `pnpm build` passes `gallery:check-bundle-budget`; largest chunk vendor-katex 568 KB, UserMenu 387.7 KB |
| Tag/status/title filtering unchanged | ✅ | Those filter branches untouched; only the description branch consults the index |
| Graceful degradation (fetch failure / not-yet-loaded) | ✅ | `searchIndex?.[slug] ?? listing.description.toLowerCase()` falls back to title/tag + truncated description; loader clears its cache to allow retry |

## Search-recall demonstration

Query `"contrapositive"` — the word appears only past char 140 of `abel-ruffini`'s full description (excerpt ends at "…the"), so the truncated-only search missed it:

```
query: "contrapositive"
BEFORE (truncated excerpt only): 4 results   (abel-ruffini NOT included)
AFTER  (full-text index):        31 results  (abel-ruffini included)
```

## Test Plan

- `pnpm build` passes end-to-end: `gallery:check-search-index` ✅, `vite build` ✅, `gallery:check-bundle-budget` ✅ (all 26 chunks within 600 KB).
- `npx tsc --noEmit` clean.
- `eslint` clean on all touched files (the 67 pre-existing repo-wide lint errors are unrelated and present on `origin/main`; this PR adds zero).
- Verified search-index assets land in `dist/data/` and are absent from every `dist/assets/*.js` (grep for a tail-only term returns no JS-chunk hit).
- Simulated the exact page filter logic before/after to confirm the recall improvement above.

Closes #35117

🤖 Generated with [Claude Code](https://claude.com/claude-code)