### PR TITLE
chore(build): usage() help text tracks header block dynamically in docker-repair-cache.sh

### DIFF
--- a/proofs/scripts/docker-repair-cache.sh
+++ b/proofs/scripts/docker-repair-cache.sh
@@ -57,7 +57,9 @@ PACKAGES_VOLUME="lean-mathlib-packages"
 MODE="cache-get"  # default: Option B
 
 usage() {
-    sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    # Print the header comment block (line 2 through the first non-comment
+    # line), so the help text tracks header edits without a fixed line range.
+    awk 'NR > 1 && !/^#/ { exit } NR > 1 { sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
     exit "${1:-0}"
 }
 


### PR DESCRIPTION
Follow-up to the non-blocking Judge note on PR #35321: `usage()` rendered help via a hardcoded `sed -n '2,45p'` line range, which would silently drift if the header comment grew or shrank.

Now an `awk` prints from line 2 until the first non-comment line — no line-number coupling.

**Verification**: new output diffed byte-identical to the old sed range on current HEAD; `bash -n` and `shellcheck -S warning` clean; `--help` renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)