### PR TITLE
chore(research): add missing site JSON companion for hurwitz-theorem-oq-03-wip-01

### DIFF
--- a/src/data/research/problems/hurwitz-theorem-oq-03-wip-01.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-03-wip-01.json
@@ -1,0 +1,52 @@
+{
+  "slug": "hurwitz-theorem-oq-03-wip-01",
+  "title": "Complete Hurwitz's Theorem (WIP): the even-case impossibility sorry",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-15T00:27:06.649Z",
+    "iteration": 1,
+    "focus": "",
+    "blockers": [],
+    "nextAction": "",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: hurwitz-theorem-oq-03-wip-01\n\nInsights accumulated during research on completing the even-case impossibility of\nHurwitz's theorem (`n`-square identities exist only for `n ∈ {1,2,4,8}`).\n\n---\n\n## Problem Understanding\n\n`HurwitzTheorem.lean` (`hurwitz_only_if`, line ~1904) discharges every case except a\nsingle `sorry` (line ~1937) for the **even, non-admissible** case. The `crossMat`\nfamily `Mⱼ = crossMat nsi j₀ j` (`j ∈ Fin n \\ {j₀}`) gives `n-1` matrices with\n`Mⱼᵀ = -Mⱼ`, `MⱼᵀMⱼ = I`, `Mⱼ² = -I`, `MⱼMₖ + MₖMⱼ = 0` — a representation of the\nClifford algebra `Cl(0, n-1)` on `ℝⁿ`. The odd case dies by `no_odd_nsquare`\n(`det(M)² = (-1)ⁿ = -1`, impossible over `ℝ`). The even case is the classical\nHurwitz–Radon obstruction; the sharp form needs the minimal faithful real\nrepresentation dimension of `Cl(0,n-1)` (Bott periodicity + Artin–Wedderburn),\nwhich is **not in Mathlib**.\n\n## The tractable strip: `n ≡ 2 (mod 4)`\n\nThe `HurwitzTheoremOQ03WIP01.lean` gallery entry (`HurwitzOQ03WIP01` namespace)\npushes the *elementary* determinant argument one residue class further, into\n`n ≡ 2 (mod 4)`, via the field-agnostic engine\n`anticommuting_invertible_forces_even` (two anticommuting invertible matrices force\neven dimension over any field with `2 ≠ 0`) and its odd-dimension contrapositive\n`no_anticommuting_complex_structures_of_odd`.\n\nThe plan to close `n ≡ 2 (mod 4)` (only `n ≡ 0 mod 4` then remains blocked):\n\n1. Form `P = M₁ ⋯ M_{n-1}` over the `crossMat` family.\n2. `P` commutes with each `Mᵢ`.\n3. `P² = -I` for `n ≡ 2 (mod 4)`.\n4. View `(ℝⁿ, P)` as a `ℂ`-vector space of complex dimension `m = n/2` (odd when\n   `n ≡ 2 mod 4`); `M₁, M₂` become anticommuting `ℂ`-linear complex structures, and\n   `no_anticommuting_complex_structures_of_odd` over `ℂ` (with `m` odd) gives the\n   contradiction — mirroring the real odd case one level up.\n\n## Progress this session (researcher-2, 2026-07-07) — VERIFIED\n\nAdded the **product engine** to `HurwitzTheoremOQ03WIP01.lean` (0 sorry / 0 axiom,\ndocker-build green, arbitrary ring `R`):\n\n- `mul_prod_anticomm : (∀ x ∈ t, a*x = -(x*a)) → a * t.prod = (-1)^t.length * (t.prod * a)`\n  — the move-through sign lemma. Proof: induction on the list; the head anticommutes\n  (`hb`), the tail commute of `(-1)^k` past the head factor is `Commute.neg_one_left`\n  `|>.pow_left`, closed with `noncomm_ring` (`-1` is central; do **not** use `ring` —\n  the ring is noncommutative).\n- `commute_prod_of_anticomm_of_even` — even length ⇒ `a` commutes with `t.prod`\n  (via `Even.neg_one_pow`).\n- `anticommute_prod_of_anticomm_of_odd` — odd length ⇒ `a` anticommutes with `t.prod`\n  (via `Odd.neg_one_pow`).\n\nThis is the reusable algebraic core behind steps 1–2 of the plan, stated abstractly so\nit applies verbatim to the real `crossMat` family and to its complexification. It does\n**not** by itself close the case.\n\n## Concrete next steps (worked out; a future session / Aristotle can finish)\n\n- **`P² = -I` (step 3), abstract form.** For a list `L` whose entries pairwise\n  anticommute and each square to `-1`, `L.prod * L.prod = (-1)^((L.length+1).choose 2)`.\n  Induction on `L = a :: t`, `t.length = j`: using `mul_prod_anticomm` twice,\n  `(a*t.prod)² = (-1)^(j+1) · (t.prod)²`, and the exponent recurrence is\n  `(j+2).choose 2 = (j+1).choose 1 + (j+1).choose 2 = (j+1) + (j+1).choose 2`\n  (`Nat.choose_succ_succ`, `Nat.choose_one_right`) — this avoids all `Nat` division.\n  Then for `n ≡ 2 (mod 4)`, `L = [M₁,…,M_{n-1}]`, `(n-1+1).choose 2 = n(n-1)/2`, which is\n  **odd** (n = 4k+2 ⇒ n(n-1)/2 = (2k+1)(4k+1), a product of two odds), so `P² = -I`.\n- **`P` commutes with each factor `Mᵢ` (step 2).** Not a direct corollary of\n  `mul_prod_anticomm` (a factor does not anticommute with itself). Needs a split\n  `L.prod = pre * Mᵢ * suf` at index `i` (`List.take/List.drop`), moving `Mᵢ` to its\n  own slot and collapsing `Mᵢ² = -1`; the two positional signs `(-1)^{i-1}` and\n  `(-1)^{k-i}` combine to `(-1)^{k+1} = +1` for `k = n-1` odd. ~100–200 lines.\n- **THE BLOCKER — complexification (step 4).** Turning `(ℝⁿ, P)` with `P² = -I` into a\n  `ℂ`-module and reinterpreting the real `M₁, M₂` (which commute with `P`) as `m × m`\n  **complex** matrices preserving `det`/anticommutation is the genuine Mathlib gap:\n  the equivalence `Mat_n(ℝ)^{commutes with J} ≅ Mat_{n/2}(ℂ)` (for `J² = -I`) is not in\n  Mathlib. Without it, the engine (which lives over `ℂ`) cannot be applied to halve the\n  dimension to the odd `m = n/2`. This — not steps 1–3 — is what keeps even `n ≡ 2 mod 4`\n  from being fully closed by elementary means.\n- The residual `n ≡ 0 (mod 4)`, `n ∉ {4,8}` case remains genuinely blocked on Clifford\n  representation theory (Bott periodicity + Artin–Wedderburn), as before.\n\n## Dead Ends / Gotchas\n\n- `ring` fails inside these lemmas: `Matrix (Fin m) (Fin m) K` and the abstract `R` are\n  **noncommutative**; use `noncomm_ring` and supply centrality of `(-1)^k` explicitly via\n  `Commute.neg_one_left … |>.pow_left`.\n- Transient `exit 135` (SIGBUS, ~370 ms, no Lean error) is shared-cache corruption, not a\n  proof error — retry clears it (observed this session: first run 135, retry surfaced the\n  real elaboration error, third run green).\n\n## References\n\n- Hurwitz (1898); Radon (1922). Hurwitz–Radon function.\n- `HurwitzTheorem.lean` (`hurwitz_only_if`, `no_odd_nsquare`, `crossMat_*`).\n- `HurwitzTheoremOQ03WIP01.lean` (`anticommuting_invertible_forces_even`, product engine).\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "hurwitz-theorem",
+    "hurwitz-theorem-oq-03",
+    "hurwitz-theorem-oq-03-wip-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T00:27:06.649Z",
+  "lastUpdate": "2026-06-15T00:27:06.721Z"
+}


### PR DESCRIPTION
The research problem `hurwitz-theorem-oq-03-wip-01` is in `research/registry.json`, has a full state dir (`research/problems/hurwitz-theorem-oq-03-wip-01/`) on main, and was actively worked (researcher-2, 2026-07-07, product-engine PR #35261) — but its `src/data/research/problems/` site companion was never committed. It has been sitting untracked on the primary checkout since 2026-06-15.

This commits the companion (validated JSON; embedded knowledge markdown matches the slug's `knowledge.md` on main, including the 2026-07-07 researcher-2 session notes). All other served hurwitz siblings already have tracked companions.

Not in scope: the ~1.1k *unserved* registry slugs without companions — that's the expected lifecycle state (companions are created when a problem is served).

🤖 Generated with [Claude Code](https://claude.com/claude-code)