### PR TITLE
chore: gitignore .loom/sweep-checkpoint/ (sweep resume state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ package-lock.json
 aristotle-results/
 .loom/signals/
 .loom/state/
+.loom/sweep-checkpoint/
 .loom/tokens
 .loom/tokens/
 .loom-in-use


### PR DESCRIPTION
The `/loom:sweep` skill's checkpoint/resume design (#3373) documents `.loom/sweep-checkpoint/` as gitignored, but the pattern was never added — checkpoint files show up as untracked churn on every sweep host. Adds the one-line pattern next to the other `.loom/` state dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)