### PR TITLE
Enrich No Greatest Cardinal (cantors-theorem-oq-05)

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-05/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-05/meta.json
@@ -70,7 +70,8 @@
       "**The diagonal argument's payoff is global, not local.** OQ-03 produces the diagonal witnesses that prove a < 2^a; this entry shows what that single inequality buys: the entire cardinal order is unbounded, with an explicit witnessing tower over every point.",
       "**Monotonicity of the tower is NOT monotonicity of exponentiation.** Whether a < b implies 2^a < 2^b is the GCH-adjacent question, independent of ZFC. The tower climbs only because Cantor's inequality is re-applied at each rung — `strictMono_nat_of_lt_succ` needs exactly the consecutive comparisons, never the general one.",
       "**No maximum, constructively witnessed.** ¬ IsMax a is not an abstract non-existence: powTower hands you infinitely many explicit, pairwise-distinct cardinals 2^a, 2^(2^a), … all strictly above a.",
-      "**The beth ladder in miniature.** powTower 0 is exactly the finite-index beth sequence ℶ₀, ℶ₁, ℶ₂, … starting from a; the result is the well-foundedness-free fact that this ladder never stops rising."
+      "**The beth ladder in miniature.** powTower 0 is exactly the finite-index beth sequence ℶ₀, ℶ₁, ℶ₂, … starting from a; the result is the well-foundedness-free fact that this ladder never stops rising.",
+      "**This is the resolution of Cantor's paradox, not a victim of it.** The naive 'cardinal of the set of all cardinals' is contradictory precisely because ¬ IsMax a forbids a top: any purported universal cardinal would be exceeded by its own powerset. The lesson ZFC draws is that the cardinals form a proper class (not a set), which is exactly the unformalized direction flagged in the open questions — the diagonal argument that powers this entry is the same one that dissolves the paradox."
     ],
     "prerequisites": [
       "Cantor's theorem in cardinal form (Cardinal.cantor)",


### PR DESCRIPTION
Enrichment pass for `cantors-theorem-oq-05` ("No Greatest Cardinal: The Powerset Tower").

The entry was already comprehensively enriched (quality 94: 8 annotations with full mathContext/significance/relatedConcepts, substantial historicalContext, complete conclusion, accurate sections matching the Lean source). Per the size guardrails I did **not** inflate it — this is a single, genuinely additive fix:

- **Surfaced Cantor's paradox as a key insight.** It was previously only glancingly referenced in one annotation's relatedConcepts, despite being the canonical structural consequence of `¬ IsMax a`: the naive 'cardinal of all cardinals' is contradictory precisely because no cardinal is maximal, and ZFC's resolution — cardinals form a proper class, not a set — is exactly the unformalized direction flagged in the entry's open questions.

meta.json remains 10.9 KB (cap ~60 KB); keyInsights now 5 (within 4–12). JSON structure validated via the gallery build's enrichment + search-index steps.