### PR TITLE
audit: erdos-90 sorry-FP fix + 2 clean (lagrange-oq02020203, pythagorean-oq05)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17206,10 +17206,10 @@
       "result": "clean"
     },
     "erdos-90": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:44Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T16:57:03Z",
+      "result": "issues-fixed"
     },
     "erdos-900": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -67,6 +67,12 @@
     ],
     "axiomCount": 21,
     "lineCount": 81,
+    "additionalFiles": [
+      "Proofs/Erdos90/ClassFieldTower.lean",
+      "Proofs/Erdos90/GolodShafarevich.lean",
+      "Proofs/Erdos90/ClassGroupLRank.lean",
+      "Proofs/Erdos90/OpenAI2026LowerBound.lean"
+    ],
     "companionFiles": [
       {
         "path": "Proofs/Erdos90/ClassFieldTower.lean",


### PR DESCRIPTION
## Gallery integrity audit — 3 entries

### 1. erdos-90 (Erdős Problem #90: Unit Distance) — false positive fixed
`find-targets.ts` reported `sorry mismatch: claims 1, actual 0`. The checker only followed the primary file `Proofs/Erdos90Problem.lean` (0 sorries); the single real `sorry` is the headline theorem in companion `Proofs/Erdos90/OpenAI2026LowerBound.lean` (sub-issue (d) of #20576).

Verified counts (comment-stripped) across the four `Erdos90/` companions:

| file | real sorries | axiom decls | struct fields |
|------|--------------|-------------|---------------|
| ClassFieldTower.lean | 0 | 0 | 13 |
| GolodShafarevich.lean | 0 | 3 | 0 |
| ClassGroupLRank.lean | 0 | 0 | 0 |
| OpenAI2026LowerBound.lean | **1** | 2 | 3 |

Totals: **sorries = 1** ✓, **axiomCount = 13+3+0+(2+3) = 21** ✓ — both match `meta.sorries` / `meta.axiomCount` and the existing `companionFiles` metadata. Status `axiomatized` / badge `axiom` correct (open Erdős problem, peer-review-gated headline sorry). No overclaim.

**Fix:** mirror the four `Erdos90/` companion paths into `meta.additionalFiles` so the checker follows them → chain-sorry = 1 matches claim. After the change `find-targets.ts --issues` reports **0 issues**. Metadata bookkeeping only, no content/claim changes.

### 2 & 3. lagrange-theorem-oq-02-oq-02-oq-03 and pythagorean-theorem-oq-05 — clean
Both previously-unaudited, `verified`/`mathlib`. Primary Lean files verified: 0 sorries, 0 axiom declarations, 0 `native_decide`, 0 `True` stubs, 0 `admit`. Status/badge consistent with Mathlib-bridge derivations. No overclaim.

Tracker updated for all three (erdos-90 → issues-fixed; other two → clean).

---
Discovered during gallery integrity audit.