### PR TITLE
research(law-of-cosines-oq-03-oq-03): hyperbolic angle-side monotonicity (18→20 theorems, 0 axioms added)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -225,6 +225,37 @@ theorem aaa_congruence (t₁ t₂ : HyperbolicTriangle)
   ⟨a_determined t₁ t₂ hA hB hC, b_determined t₁ t₂ hA hB hC, c_determined t₁ t₂ hA hB hC⟩
 
 -- ============================================================
+-- PART 4b: Angle–side monotonicity — a larger opposite angle forces a shorter side
+-- ============================================================
+
+/-- **Monotonicity of `cosh c` in the opposite angle `C`.** For two hyperbolic triangles
+    sharing the angles `A` and `B` but with `t₁.C < t₂.C`, we have
+    `cosh t₂.c < cosh t₁.c`. This is immediate from the inversion
+    `cosh c = (cos C + cos A cos B)/(sin A sin B)`: the numerator is strictly antitone in
+    `C` (since `cos` is antitone on `[0, π]`) while the positive denominator is unchanged. -/
+theorem cosh_c_antitone_in_C (t₁ t₂ : HyperbolicTriangle)
+    (hA : t₁.A = t₂.A) (hB : t₁.B = t₂.B) (hC : t₁.C < t₂.C) :
+    Real.cosh t₂.c < Real.cosh t₁.c := by
+  have hden : 0 < Real.sin t₂.A * Real.sin t₂.B := mul_pos (sin_A_pos t₂) (sin_B_pos t₂)
+  have hcos : Real.cos t₂.C < Real.cos t₁.C :=
+    Real.cos_lt_cos_of_nonneg_of_le_pi t₁.hC.le t₂.hC_lt.le hC
+  rw [cosh_c_eq t₁, cosh_c_eq t₂, hA, hB, div_lt_div_iff_of_pos_right hden]
+  linarith [hcos]
+
+/-- **Hyperbolic angle–side comparison.** Holding two angles fixed, increasing the third
+    angle strictly *shortens* the opposite side: if `t₁.A = t₂.A`, `t₁.B = t₂.B` and
+    `t₁.C < t₂.C`, then `t₂.c < t₁.c`. This refines AAA congruence into a strict
+    monotonicity statement and is the hyperbolic analogue of the Euclidean "larger angle
+    opposite longer side" — but here the correspondence is *reversed and quantitative*,
+    because in hyperbolic geometry the side is a decreasing function of its opposite angle
+    once the other two angles are pinned. -/
+theorem side_antitone_in_angle (t₁ t₂ : HyperbolicTriangle)
+    (hA : t₁.A = t₂.A) (hB : t₁.B = t₂.B) (hC : t₁.C < t₂.C) :
+    t₂.c < t₁.c :=
+  (Real.cosh_strictMonoOn.lt_iff_lt (mem_Ici.mpr t₂.hc.le) (mem_Ici.mpr t₁.hc.le)).mp
+    (cosh_c_antitone_in_C t₁ t₂ hA hB hC)
+
+-- ============================================================
 -- PART 5: Equilateral closed form
 -- ============================================================
 

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 7,
     "sorries": 0,
-    "lineCount": 267,
-    "theoremCount": 18,
+    "lineCount": 298,
+    "theoremCount": 20,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -270,6 +270,18 @@
       "statement": "0 < π − (t.A + t.B + t.C).",
       "significance": "The angular defect — equal to the hyperbolic area by the Gauss-Bonnet theorem — is strictly positive, the quantitative meaning of 'the angle sum falls short of π'.",
       "description": "linarith from the defect field."
+    },
+    {
+      "name": "cosh_c_antitone_in_C",
+      "type": "theorem",
+      "statement": "For hyperbolic triangles t₁, t₂ with t₁.A = t₂.A, t₁.B = t₂.B and t₁.C < t₂.C, cosh t₂.c < cosh t₁.c.",
+      "significance": "Reads off strict monotonicity directly from the inversion cosh c = (cos C + cos A cos B)/(sin A sin B): the numerator is antitone in C (cos antitone on [0,π]) over a fixed positive denominator, so a larger opposite angle yields a smaller cosh of the side."
+    },
+    {
+      "name": "side_antitone_in_angle",
+      "type": "theorem",
+      "statement": "For hyperbolic triangles t₁, t₂ with t₁.A = t₂.A, t₁.B = t₂.B and t₁.C < t₂.C, t₂.c < t₁.c.",
+      "significance": "Hyperbolic angle-side comparison: with two angles pinned, the side is a strictly decreasing function of its opposite angle. Upgrades AAA congruence (equal angles ⟹ equal sides) to a strict order statement via cosh injectivity on [0,∞). The hyperbolic analogue of the Euclidean larger-angle/longer-side law, but reversed and quantitative."
     }
   ],
   "references": [
@@ -341,8 +353,8 @@
     ],
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 267,
-    "theoremCount": 18,
+    "lineCount": 298,
+    "theoremCount": 20,
     "definitionCount": 1,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",
@@ -350,7 +362,8 @@
       "angle_formula_gt_one: the angular defect is exactly what makes the angle formula exceed 1",
       "cosh_c_gt_one: cosh c > 1 derived from the angles alone",
       "aaa_congruence: equal angles ⟹ equal sides via cosh injectivity on [0,∞)",
-      "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) for the equilateral triangle"
+      "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) for the equilateral triangle",
+      "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — holding two angles fixed, increasing the third strictly shortens the opposite side (refines AAA congruence to a strict comparison)"
     ],
     "proofStrategy": "Invert each second law of cosines (linear in cosh of the opposite side) via eq_div_iff + linear_combination to get cosh(side) as a ratio of angle functions. Prove the angle ratio exceeds 1 from the defect using cos(A+B) > cos(π-C) = -cos C (strict antitonicity of cos on [0,π]). Conclude AAA congruence by cosh injectivity on [0,∞). Specialize to the equilateral case for a closed form.",
     "openQuestions": [

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -8,12 +8,12 @@
   "tractability": "high",
   "path": "Proofs/LawOfCosinesOQ03OQ03.lean",
   "started": "2026-06-22",
-  "lastUpdate": "2026-06-22",
+  "lastUpdate": "2026-07-08",
   "problemStatement": "In hyperbolic geometry, do the three angles of a triangle determine its size (AAA congruence), or are there similar non-congruent triangles as in Euclidean geometry? Invert the second hyperbolic law of cosines and decide.",
   "significance": "AAA congruence is one of the sharpest qualitative differences between hyperbolic and Euclidean geometry, and underlies the rigidity of hyperbolic structures (Thurston). Completes the basic congruence theory alongside the parent law of cosines and sibling law of sines.",
   "currentState": "COMPLETED. Proved AAA congruence: the second law of cosines inverts to cosh c = (cos C + cos A cos B)/(sin A sin B), a function of the angles alone; injectivity of cosh on [0,∞) turns equal angles into equal sides. Also proved internal consistency (the defect A+B+C<π is exactly what makes the formula exceed 1) and the equilateral closed form cosh(side)=cos θ/(1-cos θ).",
   "knowledge": {
-    "progressSummary": "COMPLETE: hyperbolic AAA congruence formalized (18 theorems, 1 structure, 7 structure-encoded axioms, 0 sorries; verified 0-axiom — only propext/Classical/Quot, no native_decide). PR #27561.",
+    "progressSummary": "COMPLETE: hyperbolic AAA congruence formalized (20 theorems, 1 structure, 7 structure-encoded axioms, 0 sorries; verified 0-axiom — only propext/Classical/Quot, no native_decide). Extended 2026-07-08 with strict angle-side monotonicity. PR #27561.",
     "builtItems": [
       "LawOfCosinesOQ03OQ03.lean: hyperbolic AAA congruence (0 sorries, 7 structure-encoded axioms)",
       "HyperbolicTriangle: structure with sides a,b,c, angles A,B,C, side positivity, angle bounds, defect, and three second laws of cosines lawA/lawB/lawC",
@@ -21,14 +21,16 @@
       "angle_formula_gt_one: angle ratio > 1 from the defect alone, via cos(A+B) > cos(π-C) = -cos C (Real.cos_lt_cos_of_nonneg_of_le_pi + Real.cos_pi_sub + Real.cos_add)",
       "cosh_c_gt_one: cosh c > 1 derived purely from the angles",
       "aaa_congruence: equal angles ⟹ equal sides via Real.cosh_strictMonoOn.injOn",
-      "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) using sin²θ=(1-cosθ)(1+cosθ) + div_eq_div_iff"
+      "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) using sin²θ=(1-cosθ)(1+cosθ) + div_eq_div_iff",
+      "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — with two angles fixed, increasing the third strictly shortens the opposite side (cosh_c_eq numerator antitone in C + cosh injectivity)"
     ],
     "insights": [
       "The second law of cosines is linear in cosh of the opposite side, so it inverts algebraically — no Euclidean analogue, since the Euclidean law relates a side to the other two sides, not purely to angles.",
       "The angular defect A+B+C<π is equivalent to the angle formula exceeding 1: numerator-minus-denominator = cos C + cos(A+B), and the defect gives A+B<π-C, so by strict antitonicity of cos on [0,π], cos(A+B)>-cos C. Existence of a valid hyperbolic side ⟺ positive defect.",
       "cosh injectivity on [0,∞) (Real.cosh_strictMonoOn.injOn) upgrades equal cosh-sides to equal sides; side positivity (ha/hb/hc) places sides in the domain.",
       "lt_div_iff was renamed to lt_div_iff₀ in current Mathlib (4.26.0).",
-      "Equilateral case collapses to cos θ/(1-cos θ): the (1+cos θ) factors cancel between sin²θ and the numerator cos θ(1+cos θ)."
+      "Equilateral case collapses to cos θ/(1-cos θ): the (1+cos θ) factors cancel between sin²θ and the numerator cos θ(1+cos θ).",
+      "Angle-side monotonicity is a free corollary of the inversion: cosh c = (cos C + cos A cos B)/(sin A sin B) is strictly antitone in C over a fixed positive denominator, so a larger opposite angle forces a strictly shorter side — the reverse of the Euclidean larger-angle/longer-side law, and quantitative because the side is a definite function of the angles."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -176,8 +178,8 @@
     {
       "path": "Proofs/LawOfCosinesOQ03OQ03.lean",
       "filename": "LawOfCosinesOQ03OQ03.lean",
-      "lineCount": 268,
-      "theoremCount": 18,
+      "lineCount": 298,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends the already-complete **Hyperbolic AAA Congruence** entry (`law-of-cosines-oq-03-oq-03`) with a genuine new result: strict **angle-side monotonicity**. It falls directly out of the inversion already proved in the file,

    cosh c = (cos C + cos A·cos B) / (sin A·sin B),

so it required no new axioms and no new machinery.

## New theorems

- **`cosh_c_antitone_in_C`** — For triangles `t₁, t₂` with `t₁.A = t₂.A`, `t₁.B = t₂.B`, `t₁.C < t₂.C`, we get `cosh t₂.c < cosh t₁.c`. The numerator is strictly antitone in `C` (`cos` antitone on `[0, π]`) over a fixed positive denominator.
- **`side_antitone_in_angle`** — Therefore `t₂.c < t₁.c`: holding two angles fixed, increasing the third strictly **shortens** the opposite side. Via `Real.cosh_strictMonoOn` injectivity on `[0, ∞)`.

This refines AAA congruence (equal angles ⟹ equal sides) into a strict order statement — the hyperbolic analogue of the Euclidean "larger angle opposite the longer side" law, but **reversed and quantitative**: once the other two angles are pinned the side is a definite decreasing function of its opposite angle.

## Verification

- Builds clean: `✔ Built Proofs.LawOfCosinesOQ03OQ03 (3061 jobs)`
- 0 sorries; **0 new axioms** (still the 7 structure-encoded geometric assumptions)
- `theoremCount` 18 → 20, `lineCount` 267 → 298; meta.json + research JSON updated

Status remains `axiomatized` (structure-encoded second-law and defect assumptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)