### PR TITLE
research(sylow-theorem-oq-04-oq-03): Weyl involution on U⁻, w²=−I, w⁴=1 [VERIFIED, 0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -370,6 +370,54 @@ theorem weylW_conj_unipotent (t : ZMod p) :
   fin_cases i <;> fin_cases j <;>
     simp [Matrix.mul_apply, Fin.sum_univ_two] <;> ring
 
+/-- **The Weyl element sends the lower unipotent subgroup back to the upper one.**
+The reverse of `weylW_conj_unipotent`: conjugation by `w` turns `[[1, 0], [t, 1]] ∈ U⁻`
+into `[[1, -t], [0, 1]] ∈ U`:
+
+    w · [[1, 0], [t, 1]] · w⁻¹ = [[1, -t], [0, 1]].
+
+Together with `weylW_conj_unipotent` this shows `w` interchanges the two opposite root
+groups `U ↔ U⁻`; in particular the subgroup `⟨U, U⁻⟩` is stable under conjugation by
+`w`, one of the closure facts behind `⟨U, U⁻⟩ = SL(2, p)`. -/
+theorem weylW_conj_lowerUnipotent (t : ZMod p) :
+    weylW * lowerUnipotent t * weylW⁻¹ = unipotentUpper (-t) := by
+  rw [weylW_inv]
+  apply Subtype.ext
+  show ((!![(0 : ZMod p), -1; 1, 0] * !![1, 0; t, 1]) * !![(0 : ZMod p), 1; -1, 0])
+      = !![1, -t; 0, 1]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two] <;> ring
+
+/-- **`w² = −1`.**  The square of the Weyl element is the central scalar `−1`:
+
+    w² = [[0, -1], [1, 0]]² = [[-1, 0], [0, -1]] = −I.
+
+Since `−I` is the non-trivial central element of `SL(2, p)` (for `p > 2`), `w` has
+order `4` in `SL(2, p)` and order `2` in `PSL(2, p)`.  This pins down the Weyl group
+`W = N(T)/T ≅ ℤ/2`, whose non-trivial element acts on the torus by the reflection
+`a ↦ a⁻¹` of `weylW_conj_torus`. -/
+theorem val_weylW_sq :
+    ((weylW * weylW : Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) :
+        Matrix (Fin 2) (Fin 2) (ZMod p)) = !![-1, 0; 0, -1] := by
+  show (!![(0 : ZMod p), -1; 1, 0] * !![(0 : ZMod p), -1; 1, 0]) = !![-1, 0; 0, -1]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two] <;> ring
+
+/-- **`w⁴ = 1`.**  A direct consequence of `w² = −1`: the Weyl element has order
+dividing `4` in `SL(2, p)`. -/
+theorem weylW_pow_four :
+    weylW * weylW * weylW * weylW = (1 : Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) := by
+  apply Subtype.ext
+  show (((!![(0 : ZMod p), -1; 1, 0] * !![(0 : ZMod p), -1; 1, 0])
+          * !![(0 : ZMod p), -1; 1, 0]) * !![(0 : ZMod p), -1; 1, 0])
+      = (1 : Matrix (Fin 2) (Fin 2) (ZMod p))
+  rw [Matrix.one_fin_two]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two]
+
 /-- **`U ∩ T = 1`.**  The only matrix that is simultaneously upper unipotent
 `[[1, t], [0, 1]]` and diagonal `[[a, 0], [0, a⁻¹]]` is the identity: `t = 0` and
 `a = 1`.  Combined with `card_unipotent_range` and `card_torus_range`, this makes

--- a/research/problems/sylow-theorem-oq-04-oq-03/state.md
+++ b/research/problems/sylow-theorem-oq-04-oq-03/state.md
@@ -4,15 +4,22 @@
 **Phase**: BUILD (infrastructure; deep theorem BLOCKED)
 **Path**: full
 **Since**: 2026-07-07
-**Iteration**: 4
+**Iteration**: 5
 
 ## Current Focus
 Iwasawa/Bruhat infrastructure for PSL(2,p) simplicity, built inside `SL(2, ZMod p)`.
-VERIFIED this session (researcher-2, 2026-07-07, docker-build green, 388L / 17 lemmas,
-0 sorry / 0 axiom): the Weyl element `weylW`, `weylW_conj_torus` (reflection a↦a⁻¹),
-`lowerUnipotent`/`weylW_conj_unipotent` (w·U·w⁻¹ = U⁻), and `unipotent_inter_torus_trivial`
-(U∩T=1 ⇒ Borel B = U⋊T). Recovered from an environmental exit-135 blackout draft with no
-proof change. Sits on the merged unipotent Sylow-p (#34623) and torus/normalizer split (#34648).
+VERIFIED this session (researcher-2, 2026-07-08, docker-build green 7743 jobs, 436L / 20
+theorems, 0 sorry / 0 axiom): three new Weyl-group ingredients completing the Bruhat
+symmetry —
+- `weylW_conj_lowerUnipotent`: `w·U⁻·w⁻¹ = U` (the reverse of last session's
+  `weylW_conj_unipotent`), so `w` interchanges the opposite root groups `U ↔ U⁻` and
+  `⟨U, U⁻⟩` is `w`-conjugation-stable.
+- `val_weylW_sq`: `w² = −I` (the central scalar), so `w` has order 4 in `SL(2,p)` and
+  order 2 in `PSL(2,p)` — pinning down the Weyl group `W = N(T)/T ≅ ℤ/2`.
+- `weylW_pow_four`: `w⁴ = 1`.
+Also synced the stale meta.json (leanFile 265→436L, 4→7 defs, 17→20 thms; added the six
+Weyl/Bruhat theorems from #35236 + this session to mainTheorems). Sits on the merged
+unipotent Sylow-p (#34623), torus/normalizer split (#34648), and Weyl element (#35236).
 
 ## Blockers
 - **Mathematical / Mathlib**: the deep simplicity theorem for the whole family p≥5 needs the

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -39,6 +39,42 @@
   },
   "mainTheorems": [
     {
+      "name": "weylW_pow_four",
+      "type": "supporting",
+      "description": "The Weyl element has order dividing 4 in SL(2,p): w⁴ = 1. Immediate from w² = -1 (val_weylW_sq); the four-fold matrix product is computed entrywise against the identity.",
+      "leanType": "weylW * weylW * weylW * weylW = (1 : Matrix.SpecialLinearGroup (Fin 2) (ZMod p))"
+    },
+    {
+      "name": "val_weylW_sq",
+      "type": "core",
+      "description": "The square of the Weyl element is the central scalar -1: w² = [[0,-1],[1,0]]² = [[-1,0],[0,-1]] = -I. Since -I is the non-trivial central element of SL(2,p) for p>2, w has order 4 in SL(2,p) and order 2 in PSL(2,p), pinning down the Weyl group W = N(T)/T ≅ ℤ/2 whose non-trivial element acts on the torus by the reflection a ↦ a⁻¹.",
+      "leanType": "((weylW * weylW : Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) : Matrix (Fin 2) (Fin 2) (ZMod p)) = !![-1, 0; 0, -1]"
+    },
+    {
+      "name": "weylW_conj_lowerUnipotent",
+      "type": "core",
+      "description": "The Weyl element conjugates the lower (opposite) unipotent subgroup U⁻ back to the upper one U: w·[[1,0],[t,1]]·w⁻¹ = [[1,-t],[0,1]]. Together with weylW_conj_unipotent (which sends U to U⁻) this shows w interchanges the two opposite root groups U ↔ U⁻, so ⟨U, U⁻⟩ is stable under conjugation by w — one of the closure facts behind ⟨U, U⁻⟩ = SL(2,p).",
+      "leanType": "(t : ZMod p) → weylW * lowerUnipotent t * weylW⁻¹ = unipotentUpper (-t)"
+    },
+    {
+      "name": "unipotent_inter_torus_trivial",
+      "type": "core",
+      "description": "U ∩ T = 1: the only matrix simultaneously upper-unipotent [[1,t],[0,1]] and diagonal [[a,0],[0,a⁻¹]] is the identity (t = 0 and a = 1). Combined with card_unipotent_range and card_torus_range this makes the Borel B = U ⋊ T a genuine internal semidirect product with |B| = p(p-1).",
+      "leanType": "(t : ZMod p) → (a : (ZMod p)ˣ) → unipotentUpper t = torusDiag a → t = 0 ∧ a = 1"
+    },
+    {
+      "name": "weylW_conj_unipotent",
+      "type": "core",
+      "description": "The Weyl element sends the upper unipotent subgroup to the lower one: w·[[1,t],[0,1]]·w⁻¹ = [[1,0],[-t,1]] ∈ U⁻. Because ⟨U, U⁻⟩ = SL(2,p), this exhibits U⁻ as a w-conjugate of U — the step that makes the conjugates of the abelian normal subgroup U generate the whole group, exactly the generation hypothesis of Iwasawa's simplicity criterion.",
+      "leanType": "(t : ZMod p) → weylW * unipotentUpper t * weylW⁻¹ = lowerUnipotent (-t)"
+    },
+    {
+      "name": "weylW_conj_torus",
+      "type": "core",
+      "description": "The Weyl element reflects the split torus: w·diag(a)·w⁻¹ = diag(a⁻¹). Hence w normalises T and realises the non-trivial element of the Weyl group W = N(T)/T ≅ ℤ/2, acting on T by the reflection a ↦ a⁻¹.",
+      "leanType": "(a : (ZMod p)ˣ) → weylW * torusDiag a * weylW⁻¹ = torusDiag a⁻¹"
+    },
+    {
       "name": "torusHom_conj_unipotent",
       "type": "core",
       "description": "The split torus normalizes the unipotent subgroup, acting by squares: diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ = [[1,a²t],[0,1]] for every unit a and every t. Rewriting (torusHom a)⁻¹ = torusHom a⁻¹ via map_inv exposes diag(a)⁻¹ = [[a⁻¹,0],[0,a]]; the triple matrix product is computed entrywise, the diagonal entries collapsing through a·a⁻¹ = 1 and the top-right entry being a·t·a = a²·t by ring. This is the U ⊴ B normality that makes the Borel B = U ⋊ T the point stabiliser Iwasawa's criterion requires.",
@@ -200,12 +236,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 265,
+    "lineCount": 436,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 4,
-    "theoremCount": 17
+    "definitionCount": 7,
+    "theoremCount": 20
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Extends the standalone Bruhat/Iwasawa infrastructure for the (blocked) simplicity of PSL(2,p), all built inside `SL(2, ZMod p)`. Three new Weyl-group ingredients, each **verified by direct entrywise matrix computation** (docker-build green, 7743 jobs, 0 sorry / 0 axiom):

- **`weylW_conj_lowerUnipotent`**: `w·[[1,0],[t,1]]·w⁻¹ = [[1,-t],[0,1]]` — the reverse of the previously-merged `weylW_conj_unipotent`. Together they show the Weyl element `w` **interchanges the opposite root groups** `U ↔ U⁻`, so `⟨U, U⁻⟩` is stable under conjugation by `w` (a closure fact behind `⟨U, U⁻⟩ = SL(2,p)`).
- **`val_weylW_sq`**: `w² = [[-1,0],[0,-1]] = −I`, the central scalar. Hence `w` has **order 4 in `SL(2,p)`** and order 2 in `PSL(2,p)`, pinning down the Weyl group `W = N(T)/T ≅ ℤ/2` whose non-trivial element acts on the torus by the reflection `a ↦ a⁻¹` (`weylW_conj_torus`).
- **`weylW_pow_four`**: `w⁴ = 1`.

## Bookkeeping
Reconciled the stale `meta.json` (it predated #35236): `leanFile` 265→436 lines, 4→7 defs, 17→20 theorems; added the six Weyl/Bruhat theorems (from #35236 and this session) to `mainTheorems`.

## Status
Still **BLOCKED / axiomatized-parent**: the deep simplicity theorem for the whole family `p ≥ 5` needs the PSL(2,p) action on P¹(𝔽_p), 2-transitivity, and the Iwasawa assembly — none of which exist in Mathlib (>1000 lines). This PR only advances the verified standalone substrate. Sits on #34623, #34648, #35236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)