### PR TITLE
Enrich Vajda's Identity (cassini-identity-oq-01-oq-01-oq-01): fix annotation ranges + section coverage

### DIFF
--- a/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
@@ -2,21 +2,33 @@
   {
     "id": "ann-vajda-header",
     "proofId": "cassini-identity-oq-01-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 49 },
+    "range": {
+      "startLine": 1,
+      "endLine": 49
+    },
     "type": "concept",
     "title": "Vajda's Identity: the master identity above Cassini, Catalan, and d'Ocagne",
     "content": "The header positions the entry as the apex of the Fibonacci bilinear family. Vajda's identity F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} = (−1)ⁿ·Fᵢ·Fⱼ specializes to all three classical laws: Cassini (i = j = 1), Catalan (i = j = r, the parent file's catalan_aux), and the d'Ocagne shift form (j = 1). Its defining formal advantage is that the offsets enter only additively (n+i, n+j, n+i+j), so — unlike the signed Catalan/d'Ocagne statements — no truncated ℕ subtraction ever appears, keeping the whole proof friction-free over ℕ. The docstring also flags that this is an *independent* derivation: the gallery already proves the same identity in the fibonacci-identities lineage (fib_vajda_gap) by a two-step induction on j off d'Ocagne, whereas this Cassini-lineage proof uses no induction beyond the one already inside the imported Cassini core — a single addition-formula expansion collapsing against cassini_sub.",
     "mathContext": "$F_{n+i}F_{n+j} - F_n F_{n+i+j} = (-1)^n F_i F_j$; specializations: Cassini $(i{=}j{=}1)$, Catalan $(i{=}j{=}r)$, d'Ocagne $(j{=}1)$. Fully additive indices $\\Rightarrow$ no $\\mathbb{N}$-subtraction.",
     "significance": "context",
-    "relatedConcepts": ["Vajda's identity", "Cassini / Catalan / d'Ocagne family", "master identity", "additive index form"],
-    "prerequisites": ["Fibonacci numbers", "the parent Catalan/Cassini entries", "the Fibonacci addition formula Nat.fib_add"]
+    "relatedConcepts": [
+      "Vajda's identity",
+      "Cassini / Catalan / d'Ocagne family",
+      "master identity",
+      "additive index form"
+    ],
+    "prerequisites": [
+      "Fibonacci numbers",
+      "the parent Catalan/Cassini entries",
+      "the Fibonacci addition formula Nat.fib_add"
+    ]
   },
   {
     "id": "ann-vajda-master",
     "proofId": "cassini-identity-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 54,
-      "endLine": 98
+      "startLine": 51,
+      "endLine": 106
     },
     "type": "theorem",
     "title": "Vajda's identity, the bilinear master identity",
@@ -39,8 +51,8 @@
     "id": "ann-vajda-catalan",
     "proofId": "cassini-identity-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 114,
-      "endLine": 122
+      "startLine": 119,
+      "endLine": 128
     },
     "type": "theorem",
     "title": "Catalan recovered as the diagonal i = j = r",
@@ -62,8 +74,8 @@
     "id": "ann-vajda-docagne",
     "proofId": "cassini-identity-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 124,
-      "endLine": 129
+      "startLine": 130,
+      "endLine": 137
     },
     "type": "theorem",
     "title": "d'Ocagne shift identity as the j = 1 slice",
@@ -85,8 +97,8 @@
     "id": "ann-vajda-cassini",
     "proofId": "cassini-identity-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 103,
-      "endLine": 111
+      "startLine": 110,
+      "endLine": 117
     },
     "type": "theorem",
     "title": "Cassini recovered as i = j = 1",
@@ -108,8 +120,8 @@
     "id": "ann-vajda-sanity",
     "proofId": "cassini-identity-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 138,
-      "endLine": 153
+      "startLine": 139,
+      "endLine": 154
     },
     "type": "theorem",
     "title": "Numerical sanity checks against the master identity",

--- a/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/meta.json
@@ -82,24 +82,31 @@
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Module header and the imported Cassini core",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "The docstring frames Vajda as the master identity above Cassini, Catalan, and d'Ocagne and states the single-bilinear-expansion strategy. The setup lines are the linchpin of the whole approach: `import Proofs.CassiniIdentityOQ01OQ01` and `open CassiniIdentityOQ01OQ01 (cassini_sub)` pull in the parent file's normalized Cassini core F_{n+1}² − F_n·F_{n+1} − F_n² = (−1)^n, so this file contributes no induction of its own — the sole induction in the development already lives inside the imported cassini_sub."
+    },
+    {
       "id": "vajda-master",
       "title": "Vajda's identity (the bilinear master identity)",
-      "startLine": 54,
-      "endLine": 98,
+      "startLine": 51,
+      "endLine": 106,
       "summary": "vajda proves F_{n+i}·F_{n+j} − F_n·F_{n+i+j} = (−1)^n·F_i·F_j. After the i=0 and j=0 vanishing cases, the i=s+1, j=t+1 case expands all three compound Fibonacci values (and the inner F_{s+t+1}, F_{s+t+2}) with Nat.fib_add, then a single linear_combination against the Cassini core cassini_sub collapses every cross term."
     },
     {
       "id": "vajda-specializations",
       "title": "Specializations: Cassini, Catalan, d'Ocagne",
-      "startLine": 100,
-      "endLine": 129,
+      "startLine": 108,
+      "endLine": 137,
       "summary": "vajda_cassini (i=j=1), vajda_catalan (i=j=r, recovering the parent's catalan_aux), and vajda_docagne (j=1) each follow from vajda by a one-line linear_combination, exhibiting the three classical bilinear identities as instances of the master identity."
     },
     {
       "id": "vajda-sanity",
       "title": "Numerical sanity checks",
-      "startLine": 131,
-      "endLine": 147,
+      "startLine": 139,
+      "endLine": 154,
       "summary": "vajda_2_1_3 (F₃F₅ − F₂F₆ = 2) and vajda_3_2_2 (F₅² − F₃F₇ = −1, the Catalan instance) check concrete numerical instances of the master identity."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `cassini-identity-oq-01-oq-01-oq-01` (Vajda's Identity). The entry's prose was already excellent (quality 94), so this pass targets **accuracy and coverage**, not accretion:

**Annotation-range corrections (accuracy).** Several annotations pointed into the *wrong* theorem's proof body:
- `ann-vajda-docagne` range 124–129 sat inside `vajda_catalan`'s proof; corrected to 130–137 (the actual `vajda_docagne`).
- `ann-vajda-cassini` 103–111 and `ann-vajda-catalan` 114–122 were similarly shifted; corrected to 110–117 and 119–128.
- `ann-vajda-sanity` startLine 138 was an orphaned blank line — this was the source of the gallery build's `No Lean construct found at line 138` warning. Corrected to 139–154. **Build error count drops 3452→3451 and this entry no longer appears in the warning list.**

**Section coverage.** Added a `Module header and the imported Cassini core` section (lines 1–49) so `sections` cover the full 156-line file, documenting the `import Proofs.CassiniIdentityOQ01OQ01` / `open ... (cassini_sub)` that lets this proof reuse the parent's single induction. Realigned the three existing sections to the true theorem boundaries (they had drifted, e.g. specializations ended at 129, cutting off `vajda_docagne` at 132–137).

meta.json 15.6 KB (cap ~60 KB); no content removed. JSON validated via the gallery build.