### PR TITLE
Enrich Catalan Numbers (linear recurrence): link into the Catalan/ballot cluster

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01/meta.json
@@ -118,6 +118,16 @@
       "targetId": "catalan-numbers-oq-01-oq-03",
       "relationship": "related",
       "description": "Sibling: large Schröder numbers — another holonomic combinatorial sequence, relevant to the open question of which sequences (Motzkin, Delannoy, Schröder) are holonomic of order one versus two."
+    },
+    {
+      "targetId": "ballot-problem-oq-03-oq-01-oq-04",
+      "relationship": "complementary",
+      "description": "The complementary recurrence: this entry gives the first-order linear recurrence (n+2)·C(n+1) = 2(2n+1)·C(n), while that entry proves the quadratic Segner convolution C(n+1) = Σ Cₖ·C(n−k) combinatorially, via the ballot theorem. Together they realise both of the Catalan number's classical recursions — the O(1) analytic one here and the O(n) combinatorial one there."
+    },
+    {
+      "targetId": "catalan-numbers-oq-01-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Deepens the arithmetic of the same sequence: the p-adic valuation of Cₙ at an arbitrary prime, (p−1)(v_p(Cₙ)+v_p(n+1)) + s_p(2n) = 2·s_p(n), generalising the 2-adic result of the sibling entry oq-01-oq-02. Where this entry gives the recurrence that generates the Cₙ, that entry dissects their prime factorisation."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01` (the first-order O(1) linear recurrence $(n+2)C_{n+1}=2(2n+1)C_n$).

Already high-quality (score 94); its main gap was cross-linking. It cited 3 direct siblings but not two strongly-related entries elsewhere in the gallery.

## Changes
- **+2 cross-references** (3 → 5, well under the 20 cap):
  - `ballot-problem-oq-03-oq-01-oq-04` (`complementary`) — proves the **quadratic Segner convolution** $C_{n+1}=\sum C_k C_{n-k}$ combinatorially via the ballot theorem. This is exactly the O(n) recursion this entry contrasts its O(1) linear recurrence against; the two together realise both classical Catalan recursions.
  - `catalan-numbers-oq-01-oq-02-oq-01` (`related`) — the **p-adic valuation** of $C_n$ at an arbitrary prime, deepening the sequence's arithmetic beyond the 2-adic sibling already linked.

Both descriptions were verified against the target entries' actual statements. Uses the entry's existing `targetId` key convention. meta.json remains valid JSON, within all size caps; gallery data build passes.