### PR TITLE
research(erdos-1093-oq-02): C(284,28) is a valid deficiency-9 example + parent build repair [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1093Problem.lean
+++ b/proofs/Proofs/Erdos1093Problem.lean
@@ -170,7 +170,7 @@ theorem deficiency_le (n k : ℕ) : deficiency n k ≤ k := by
 /-- 1 is k-smooth for any k (vacuously: 1 has no prime factors). -/
 theorem isKSmooth_one (k : ℕ) : IsKSmooth k 1 := by
   intro p hp hd
-  exact absurd (Nat.le_of_dvd (by omega) hd) (by omega)
+  exact absurd (Nat.dvd_one.mp hd) hp.one_lt.ne'
 
 /-- 0 is not k-smooth for any k (every prime divides 0). -/
 theorem not_isKSmooth_zero (k : ℕ) : ¬IsKSmooth k 0 := by

--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -1,0 +1,149 @@
+/-
+# Erdős Problem #1093 — OQ-02: Is `d(284,28) = 9` the maximal deficiency?
+
+The parent file `Erdos1093Problem.lean` defines the *deficiency* of `C(n,k)`
+(for `n ≥ 2k`, when `C(n,k)` has no prime factor `≤ k`): the number of
+`0 ≤ i < k` with `n - i` being `k`-smooth.  It records the current record
+
+    `deficiency 284 28 = 9`   (`deficiency_284_28`, by `native_decide`)
+
+together with the smaller deficiency-`1,2,3,4` examples of Erdős–Lacampagne–
+Selfridge.  Open Question 02 asks:
+
+> Is `d(284,28) = 9` the **maximum possible** deficiency, or do higher
+> values occur?
+
+The universal upper-bound direction is genuinely open.  This file establishes
+the **tractable half** and formalizes the question precisely.
+
+## What is proved here (0 `sorry`, no new `axiom` declarations)
+
+1. `noSmallPrimeFactors_iff` — a *decidable* reformulation of the
+   `NoSmallPrimeFactors` side-condition: it suffices to check the finitely
+   many primes `p ≤ k`.  (The definition quantifies over *all* primes; this
+   lemma restricts the check to `Finset.range (k+1)`.)
+
+2. `noSmallPrimeFactors_284_28` — the record `C(284,28)` genuinely satisfies
+   the side-condition: no prime `≤ 28` divides `C(284,28)`.  The parent file
+   verified the *count* `= 9` but never checked that `(284,28)` is an
+   *admissible* pair, so on its own `deficiency_284_28` did not exhibit a
+   valid deficiency-9 example.  This closes that gap.
+
+3. `smooth_indices_284_28` — the explicit human-readable certificate: the
+   nine smooth indices are `{4, 8, 9, 11, 12, 14, 18, 20, 24}`, i.e. the nine
+   `28`-smooth values are
+
+       280 = 2³·5·7,  276 = 2²·3·23,  275 = 5²·11,  273 = 3·7·13,
+       272 = 2⁴·17,   270 = 2·3³·5,   266 = 2·7·19,  264 = 2³·3·11,
+       260 = 2²·5·13.
+
+4. `exists_deficiency_nine` — the **existence half** of OQ-02: there is a
+   valid deficiency example attaining `9`.
+
+5. `maximalDeficiencyIs_nine_iff_upperBound` — the payoff: with the existence
+   half discharged, the full conjecture `MaximalDeficiencyIs 9` is
+   *equivalent* to the single open statement "no valid example exceeds `9`".
+   This isolates exactly the open content.
+
+## Axioms
+
+The record facts (`deficiency_284_28`, `noSmallPrimeFactors_284_28`,
+`smooth_indices_284_28`) are discharged by `native_decide`, so they depend on
+`Lean.ofReduceBool`.  The structural results (1, 5) are `ofReduceBool`-free.
+
+## Status: OPEN (universal upper bound); existence half machine-verified.
+-/
+
+import Proofs.Erdos1093Problem
+import Mathlib.Tactic
+
+/-
+## Section I: A decidable reformulation of the admissibility side-condition
+-/
+
+/-- `NoSmallPrimeFactors n k` is equivalent to checking only the finitely many
+primes `p ≤ k`: since a witnessing prime `p` with `p ∣ C(n,k)` must satisfy
+`k < p`, the failure of the condition would require a prime `p ≤ k` dividing
+`C(n,k)`.  This turns the unbounded `∀ p` into a bounded, decidable check. -/
+theorem noSmallPrimeFactors_iff (n k : ℕ) :
+    NoSmallPrimeFactors n k ↔
+      ∀ p ∈ Finset.range (k + 1), p.Prime → ¬ p ∣ n.choose k := by
+  constructor
+  · intro h p hp hpp hdvd
+    have hlt : k < p := h p hpp hdvd
+    have hle : p ≤ k := by have := Finset.mem_range.mp hp; omega
+    omega
+  · intro h p hpp hdvd
+    by_contra hle
+    push_neg at hle
+    exact h p (Finset.mem_range.mpr (by omega)) hpp hdvd
+
+/-
+## Section II: The record `C(284,28)` is an admissible deficiency example
+-/
+
+/-- No prime `≤ 28` divides `C(284,28)`, so the pair `(284,28)` is admissible
+and its deficiency is well-defined.  Verified by `native_decide` after the
+reduction to a bounded prime check. -/
+theorem noSmallPrimeFactors_284_28 : NoSmallPrimeFactors 284 28 := by
+  rw [noSmallPrimeFactors_iff]
+  native_decide
+
+/-- Explicit certificate: the nine smooth indices witnessing `deficiency 284 28 = 9`
+are exactly `{4, 8, 9, 11, 12, 14, 18, 20, 24}` (the `28`-smooth values
+`280, 276, 275, 273, 272, 270, 266, 264, 260`). -/
+theorem smooth_indices_284_28 :
+    (Finset.range 28).filter (fun i => IsKSmooth 28 (284 - i))
+      = ({4, 8, 9, 11, 12, 14, 18, 20, 24} : Finset ℕ) := by
+  native_decide
+
+/-
+## Section III: Formalizing OQ-02
+-/
+
+/-- A pair `(n,k)` is an *admissible deficiency example* when `n ≥ 2k` and
+`C(n,k)` has no prime factor `≤ k` (so the deficiency is well-defined). -/
+def ValidDeficiencyExample (n k : ℕ) : Prop :=
+  2 * k ≤ n ∧ NoSmallPrimeFactors n k
+
+/-- `MaximalDeficiencyIs D` : some admissible pair attains deficiency `D`, and
+no admissible pair exceeds it.  OQ-02 is the assertion `MaximalDeficiencyIs 9`. -/
+def MaximalDeficiencyIs (D : ℕ) : Prop :=
+  (∃ n k, ValidDeficiencyExample n k ∧ deficiency n k = D) ∧
+  (∀ n k, ValidDeficiencyExample n k → deficiency n k ≤ D)
+
+/-- The record pair `(284,28)` is admissible. -/
+theorem record_valid : ValidDeficiencyExample 284 28 :=
+  ⟨by norm_num, noSmallPrimeFactors_284_28⟩
+
+/-- **Existence half of OQ-02.**  There is an admissible deficiency example
+attaining `9` — so if `9` is maximal, it is genuinely attained. -/
+theorem exists_deficiency_nine :
+    ∃ n k, ValidDeficiencyExample n k ∧ deficiency n k = 9 :=
+  ⟨284, 28, record_valid, deficiency_284_28⟩
+
+/-- **Reduction of OQ-02 to its open core.**  Because the existence half is
+established (`exists_deficiency_nine`), the conjecture `MaximalDeficiencyIs 9`
+is *equivalent* to the single open statement: no admissible pair has deficiency
+exceeding `9`.  All the machine-checkable content of OQ-02 lives in the forward
+extraction; the remaining content is exactly this universal bound. -/
+theorem maximalDeficiencyIs_nine_iff_upperBound :
+    MaximalDeficiencyIs 9 ↔ ∀ n k, ValidDeficiencyExample n k → deficiency n k ≤ 9 := by
+  constructor
+  · exact fun h => h.2
+  · exact fun h => ⟨exists_deficiency_nine, h⟩
+
+/-
+## Section IV: Elementary consequences of the trivial bound
+
+The parent's `deficiency_le` gives `deficiency n k ≤ k` unconditionally.  So
+any admissible example with deficiency `> 9` must have `k ≥ 10`; equivalently,
+OQ-02 is automatic for `k ≤ 9`.
+-/
+
+/-- For `k ≤ 9` the deficiency never exceeds `9`, so no counterexample to
+`MaximalDeficiencyIs 9` can occur in that range — the open part is confined to
+`k ≥ 10`. -/
+theorem deficiency_le_nine_of_k_le_nine {n k : ℕ} (hk : k ≤ 9) :
+    deficiency n k ≤ 9 :=
+  (deficiency_le n k).trans hk

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -1,0 +1,56 @@
+# Erdős #1093 — OQ-02: Is d(284,28)=9 the maximal deficiency?
+
+## Summary
+
+**Parent:** Erdős #1093 (deficiency of binomial coefficients, Erdős–Lacampagne–Selfridge).
+For `n ≥ 2k`, when `C(n,k)` has no prime factor `≤ k`, the *deficiency* is the number
+of `0 ≤ i < k` with `n − i` being `k`-smooth. The current record is
+`deficiency(C(284,28)) = 9`.
+
+**OQ-02:** Is `9` the maximum possible deficiency over all admissible `(n,k)`,
+or do higher values occur? (The universal upper-bound direction is open.)
+
+## Status: OPEN (universal bound); existence half machine-verified.
+
+---
+
+## Session 2026-07-08 (Session 1) — Record admissibility + reduction
+
+**Mode:** FRESH
+**Outcome:** progress
+
+### What I Did
+- Selected erdos-1093-oq-02 (concrete, computable record value; parent infrastructure exists).
+- Discovered the parent `Erdos1093Problem.lean` was **broken on main** — `omega` at
+  L173 (`isKSmooth_one`) lacked `p.Prime`'s `two_le`. Repaired with
+  `hp.one_lt.ne'` on `Nat.dvd_one.mp hd`. Parent now builds (3058 jobs).
+- Wrote companion `Erdos1093ProblemOQ02.lean` (0 sorry, 0 axiom declarations).
+
+### Key Findings
+- The parent's `deficiency_284_28 = 9` does **not** by itself exhibit a valid
+  deficiency example: the `deficiency` count is defined unconditionally, but the
+  ELS problem additionally requires `C(n,k)` to have no prime factor `≤ k`. That
+  admissibility check was never done. It only needs primes `≤ k` (Kummer not
+  required): `C(284,28)` is a ~110-bit bignum, so `native_decide` computes it and
+  tests divisibility by primes `≤ 28` instantly ⇒ `noSmallPrimeFactors_284_28`.
+- The maximality question splits: **existence half** = finite verification
+  (attained at `(284,28)`); **universal half** = genuinely open (unbounded `n,k`,
+  cannot enumerate). `maximalDeficiencyIs_nine_iff_upperBound` reduces the whole
+  conjecture to exactly the universal bound.
+- Trivial bound `deficiency ≤ k` ⇒ any counterexample needs `k ≥ 10`
+  (`deficiency_le_nine_of_k_le_nine`).
+- Explicit certificate: the 9 smooth indices are `{4,8,9,11,12,14,18,20,24}`,
+  i.e. `280,276,275,273,272,270,266,264,260` are the 28-smooth values.
+
+### Files Modified
+- `proofs/Proofs/Erdos1093Problem.lean` (1-line repair)
+- `proofs/Proofs/Erdos1093ProblemOQ02.lean` (new, verified)
+- `src/data/research/problems/erdos-1093-oq-02.json` (new)
+
+### Next Steps
+- Attack the universal bound for small `k ≥ 10`: the ELS bound `n ≪ 2^k√k`
+  gives a finite per-`k` range, but the parent axiom `els_upper_bound`'s constant
+  is not effective — an explicit constant would make each fixed-`k` slice decidable.
+- Exploit the density constraint: deficiency `d` forces `d` of the `k` consecutive
+  integers `n,…,n−k+1` to be `k`-smooth.
+- Consider a Kummer-based (`ofReduceBool`-free) proof of `noSmallPrimeFactors_284_28`.

--- a/src/data/research/problems/erdos-1093-oq-02.json
+++ b/src/data/research/problems/erdos-1093-oq-02.json
@@ -1,0 +1,54 @@
+{
+  "slug": "erdos-1093-oq-02",
+  "title": "Erdős #1093 OQ-02 — Is d(284,28)=9 the maximal deficiency?",
+  "phase": "ACT",
+  "status": "in-progress",
+  "started": "2026-07-08T00:00:00.000Z",
+  "lastUpdate": "2026-07-08T00:00:00.000Z",
+  "path": "full",
+  "parentId": "erdos-1093",
+  "tier": "C",
+  "significance": 5,
+  "tractability": 3,
+  "tags": ["erdos", "smooth-numbers", "binomial-coefficients"],
+  "problemStatement": {
+    "plain": "The deficiency of C(n,k) (for n>=2k, when C(n,k) has no prime factor <= k) is the number of 0<=i<k with n-i being k-smooth. The current record is deficiency(C(284,28))=9. OQ-02 asks: is 9 the maximum possible deficiency over all admissible (n,k), or do higher values occur?",
+    "formal": "MaximalDeficiencyIs 9 := (exists admissible (n,k) with deficiency n k = 9) and (forall admissible (n,k), deficiency n k <= 9)."
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1093ProblemOQ02.lean",
+      "filename": "Erdos1093ProblemOQ02.lean",
+      "lineCount": 149,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1093ProblemOQ02.lean"
+    }
+  ],
+  "knowledge": {
+    "progressSummary": "PROGRESS: existence half of OQ-02 machine-verified; the full conjecture is reduced to a single open universal upper bound. Universal bound remains OPEN.",
+    "builtItems": [
+      "noSmallPrimeFactors_iff (Erdos1093ProblemOQ02.lean) — decidable reduction of the admissibility side-condition (unbounded ∀ prime) to a bounded check over primes p ≤ k; ofReduceBool-free.",
+      "noSmallPrimeFactors_284_28 — the record pair (284,28) is admissible: no prime ≤ 28 divides C(284,28) (parent verified only the count = 9, never admissibility).",
+      "smooth_indices_284_28 — explicit 9-index certificate {4,8,9,11,12,14,18,20,24} (the 28-smooth values 280,276,275,273,272,270,266,264,260).",
+      "exists_deficiency_nine — existence half of OQ-02: an admissible example attains deficiency 9.",
+      "maximalDeficiencyIs_nine_iff_upperBound — MaximalDeficiencyIs 9 ⇔ (no admissible pair has deficiency > 9); isolates the open content.",
+      "deficiency_le_nine_of_k_le_nine — OQ-02 is automatic for k ≤ 9 (from the trivial bound deficiency ≤ k), confining the open part to k ≥ 10.",
+      "Repaired the parent Erdos1093Problem.lean (broken on main: omega at L173 in isKSmooth_one lacked p.Prime's two_le) — parent now builds (3058 jobs)."
+    ],
+    "insights": [
+      "The parent's deficiency_284_28 = 9 alone does NOT exhibit a valid deficiency example: the deficiency count is defined unconditionally, but the ELS problem requires C(n,k) to have no prime factor ≤ k. Checking admissibility only needs primes ≤ k (Kummer is unnecessary): C(284,28) is a ~110-bit bignum, so native_decide computes it and tests divisibility by primes ≤ 28 instantly.",
+      "The maximality question splits cleanly: the existence half is a finite verification (attained at (284,28)); the universal half (no admissible pair exceeds 9) is the genuinely open content and cannot be enumerated (unbounded n, k).",
+      "Trivial bound deficiency ≤ k means any counterexample needs k ≥ 10; the ELS bound n ≪ 2^k·√k (parent axiom els_upper_bound) bounds n per fixed k but the number of k-values is still unbounded."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Attack the universal upper bound for small k ≥ 10: for each fixed k the ELS bound gives a finite search range n ≤ C·2^k·√k, but C is not effective in the parent axiom — obtaining an explicit constant would make each fixed-k slice a finite (if large) decidable check.",
+      "Prove structural constraints: an admissible pair with deficiency d forces d of the k consecutive integers n,n-1,...,n-k+1 to be k-smooth, a strong density constraint (Erdős–Lacampagne–Selfridge exploit this for the ≥1 ⇒ n ≪ 2^k√k bound).",
+      "Consider whether Kummer's theorem (carry count in base p) gives a cleaner ofReduceBool-free proof of noSmallPrimeFactors_284_28."
+    ]
+  }
+}


### PR DESCRIPTION
## Erdős #1093 OQ-02 — Is d(284,28)=9 the maximal deficiency?

**Problem.** For `n ≥ 2k`, when `C(n,k)` has no prime factor `≤ k`, the *deficiency*
of `C(n,k)` counts the `0 ≤ i < k` with `n − i` being `k`-smooth. The record is
`deficiency(C(284,28)) = 9`. OQ-02 asks whether `9` is the **maximum** over all
admissible `(n,k)`. The universal upper-bound direction is genuinely open.

### Parent build repair
`Erdos1093Problem.lean` was **broken on main** (merged build-pending): `omega` at
L173 in `isKSmooth_one` lacked `p.Prime`'s `two_le`. Fixed via `Nat.dvd_one.mp hd`
with `hp.one_lt.ne'`. Parent now builds (3058 jobs).

### New verified content (`Erdos1093ProblemOQ02.lean`, 0 sorry, 0 `axiom` decls)
- **`noSmallPrimeFactors_iff`** — decidable reduction of the admissibility
  side-condition (unbounded `∀ prime`) to a bounded check over primes `p ≤ k`.
  `ofReduceBool`-free.
- **`noSmallPrimeFactors_284_28`** — no prime `≤ 28` divides `C(284,28)`, so the
  record pair is **admissible**. The parent verified the count `= 9` but never
  checked admissibility, so on its own it did not exhibit a valid example. Gap closed.
- **`smooth_indices_284_28`** — explicit certificate: smooth indices
  `{4,8,9,11,12,14,18,20,24}` (the 28-smooth values `280,276,275,273,272,270,266,264,260`).
- **`exists_deficiency_nine`** — existence half of OQ-02 (a valid example attains 9).
- **`maximalDeficiencyIs_nine_iff_upperBound`** — `MaximalDeficiencyIs 9` ⇔ "no
  admissible pair exceeds 9", isolating exactly the open content.
- **`deficiency_le_nine_of_k_le_nine`** — OQ-02 is automatic for `k ≤ 9`; the open
  part is confined to `k ≥ 10`.

### Axioms
Record facts (`noSmallPrimeFactors_284_28`, `smooth_indices_284_28`, and the parent's
`deficiency_284_28`) use `native_decide` ⇒ depend on `Lean.ofReduceBool`. The
structural results (`noSmallPrimeFactors_iff`, `maximalDeficiencyIs_nine_iff_upperBound`,
`deficiency_le_nine_of_k_le_nine`) are `ofReduceBool`-free. The **universal upper
bound remains OPEN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)