### PR TITLE
research(erdos-117-oq-01): complete liminf/limsup bracket + pin convergent base to Pyber window (8→10 theorems, 0 axioms added)

### DIFF
--- a/proofs/Proofs/Erdos117OQ01.lean
+++ b/proofs/Proofs/Erdos117OQ01.lean
@@ -127,6 +127,37 @@ theorem limInf_ge_log_c1 :
   rw [ge_iff_le]
   exact Filter.le_liminf_of_le hcobdd hev
 
+/-- The limsup is at most log(c₂): the symmetric companion of `limInf_ge_log_c1`,
+    completing the two-sided bound `log c₁ ≤ liminf ≤ limsup ≤ log c₂` promised by
+    Part III. Even without knowing the limit exists, both extreme cluster values of
+    `log h(n)/n` are trapped inside Pyber's window. -/
+theorem limSup_le_log_c2 :
+    ∃ c₂ : ℝ, c₂ > 1 ∧ growthRateLimSup ≤ Real.log c₂ := by
+  obtain ⟨c₁, c₂, hc1, hc12, hbounds⟩ := pyber_bounds
+  have hc2 : c₂ > 1 := lt_trans hc1 hc12
+  refine ⟨c₂, hc2, ?_⟩
+  -- growthRate n ≤ log c₂ eventually
+  have hev : ∀ᶠ n : ℕ in atTop, growthRate n ≤ Real.log c₂ := by
+    apply Filter.eventually_atTop.mpr
+    refine ⟨1, fun n hn => ?_⟩
+    have hn_pos : (0 : ℝ) < n := by exact_mod_cast (show 0 < n from by omega)
+    unfold growthRate
+    rw [if_neg (show n ≠ 0 from by omega), div_le_iff₀ hn_pos]
+    have hhn : (1 : ℝ) ≤ (h n : ℝ) := by exact_mod_cast h_pos n hn
+    have hlog : Real.log (h n : ℝ) ≤ Real.log (c₂ ^ n) :=
+      Real.log_le_log (by linarith) (hbounds n hn).2
+    rw [Real.log_pow, mul_comm] at hlog
+    exact hlog
+  -- growthRate is cobounded above (its lower bound L witnesses the cobound)
+  have hcobdd : (atTop : Filter ℕ).IsCoboundedUnder (· ≤ ·) growthRate := by
+    obtain ⟨L, _, hL⟩ := growthRate_lower_bound
+    refine ⟨L, fun a ha => ?_⟩
+    rw [Filter.eventually_map] at ha
+    obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp ha
+    exact le_trans (hL (max N 1) (le_max_right _ _)) (hN (max N 1) (le_max_left _ _))
+  unfold growthRateLimSup
+  exact Filter.limsup_le_of_le hcobdd hev
+
 /-- liminf ≤ limsup (always true for bounded sequences) -/
 theorem limInf_le_limSup : growthRateLimInf ≤ growthRateLimSup := by
   unfold growthRateLimInf growthRateLimSup
@@ -162,6 +193,43 @@ theorem limit_determines_base (L : ℝ) (hL : L > 0)
     exponentialBaseExists := by
   refine ⟨Real.exp L, Real.one_lt_exp_iff.mpr hL, ?_⟩
   rwa [Real.log_exp]
+
+/-- **The exponential base lies in Pyber's window.** If the growth rate converges to `L`,
+    then `log c₁ ≤ L ≤ log c₂` for Pyber's constants — equivalently, the base `exp L`
+    satisfies `c₁ ≤ exp L ≤ c₂`. So even though the *existence* of the limit is the open
+    question, its *value* (should it exist) is already pinned to the interval Pyber
+    established. Proof: pass the eventual two-sided bounds on `growthRate` through
+    `ge_of_tendsto` / `le_of_tendsto`. -/
+theorem convergent_limit_in_pyber_window (L : ℝ)
+    (hconv : Filter.Tendsto growthRate atTop (nhds L)) :
+    ∃ c₁ c₂ : ℝ, 1 < c₁ ∧ c₁ < c₂ ∧ Real.log c₁ ≤ L ∧ L ≤ Real.log c₂ := by
+  obtain ⟨c₁, c₂, hc1, hc12, hbounds⟩ := pyber_bounds
+  refine ⟨c₁, c₂, hc1, hc12, ?_, ?_⟩
+  · -- log c₁ ≤ L, from the eventual lower bound log c₁ ≤ growthRate n
+    have hev : ∀ᶠ n : ℕ in atTop, Real.log c₁ ≤ growthRate n := by
+      apply Filter.eventually_atTop.mpr
+      refine ⟨1, fun n hn => ?_⟩
+      have hn_pos : (0 : ℝ) < n := by exact_mod_cast (show 0 < n from by omega)
+      unfold growthRate
+      rw [if_neg (show n ≠ 0 from by omega), le_div_iff₀ hn_pos]
+      have hlog : Real.log (c₁ ^ n) ≤ Real.log (h n : ℝ) :=
+        Real.log_le_log (by positivity) (hbounds n hn).1
+      rw [Real.log_pow, mul_comm] at hlog
+      exact hlog
+    exact ge_of_tendsto hconv hev
+  · -- L ≤ log c₂, from the eventual upper bound growthRate n ≤ log c₂
+    have hev : ∀ᶠ n : ℕ in atTop, growthRate n ≤ Real.log c₂ := by
+      apply Filter.eventually_atTop.mpr
+      refine ⟨1, fun n hn => ?_⟩
+      have hn_pos : (0 : ℝ) < n := by exact_mod_cast (show 0 < n from by omega)
+      unfold growthRate
+      rw [if_neg (show n ≠ 0 from by omega), div_le_iff₀ hn_pos]
+      have hhn : (1 : ℝ) ≤ (h n : ℝ) := by exact_mod_cast h_pos n hn
+      have hlog : Real.log (h n : ℝ) ≤ Real.log (c₂ ^ n) :=
+        Real.log_le_log (by linarith) (hbounds n hn).2
+      rw [Real.log_pow, mul_comm] at hlog
+      exact hlog
+    exact le_of_tendsto hconv hev
 
 /-- Convergence implies exponential behavior:
     for `ε ∈ (0, c)`, eventually `(c-ε)ⁿ ≤ h(n) ≤ (c+ε)ⁿ`.

--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -25,8 +25,8 @@
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",
-    "lineCount": 300,
-    "theoremCount": 8,
+    "lineCount": 368,
+    "theoremCount": 10,
     "definitionCount": 9,
     "additionalFiles": [
       "Proofs/Erdos117OQ01Aristotle.lean",
@@ -128,6 +128,18 @@
       "type": "supporting",
       "description": "Submultiplicativity of h → convergence (Fekete's lemma)",
       "leanType": "submultiplicative → growthRateConverges"
+    },
+    {
+      "name": "limSup_le_log_c2",
+      "type": "theorem",
+      "statement": "∃ c₂ > 1, growthRateLimSup ≤ log c₂.",
+      "significance": "Symmetric companion of limInf_ge_log_c1, completing the two-sided bound log c₁ ≤ liminf ≤ limsup ≤ log c₂ that Part III sets up. Both extreme cluster values of log h(n)/n are trapped inside Pyber's window even without knowing the limit exists. Proved via Filter.limsup_le_of_le with the lower bound as the cobound witness."
+    },
+    {
+      "name": "convergent_limit_in_pyber_window",
+      "type": "theorem",
+      "statement": "If growthRate → L then ∃ c₁ c₂, 1 < c₁ < c₂ ∧ log c₁ ≤ L ≤ log c₂.",
+      "significance": "Even though existence of the limit is the open question, its value (should it exist) is pinned to Pyber's interval: the exponential base exp L lies in [c₁, c₂]. Passes the eventual two-sided bounds on growthRate through ge_of_tendsto / le_of_tendsto."
     }
   ],
   "crossReferences": [
@@ -146,9 +158,9 @@
       "Filter"
     ],
     "namespace": "Erdos117OQ01",
-    "lineCount": 300,
+    "lineCount": 368,
     "axiomCount": 3,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "substantiveTheoremCount": 6,
     "sorryTheorems": 0,
     "definitionCount": 9,

--- a/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
+++ b/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Discharged the lone sorry in the parent gallery entry Erdos117OQ01.lean (base_implies_behavior) and restored the whole Erdős #117-OQ-01 file family to a fully machine-checked state on Lean 4.26. The sorry sat on a FALSE statement: ExponentialBehavior c was quantified over all ε > 0, but for ε ≥ c the lower base c−ε ≤ 0 and (c−ε)ⁿ at even n can exceed h(n). Corrected the definition to ε ∈ (0,c) and proved the convergence ⇒ exponential-behavior implication via Metric.tendsto_atTop + exp∘log monotonicity. Result: 0 sorries, only the 3 structural axioms (h, h_pos, pyber_bounds), no sorryAx, no Lean.ofReduceBool.",
+    "progressSummary": "Discharged the lone sorry in the parent gallery entry Erdos117OQ01.lean (base_implies_behavior) and restored the whole Erdős #117-OQ-01 file family to a fully machine-checked state on Lean 4.26. The sorry sat on a FALSE statement: ExponentialBehavior c was quantified over all ε > 0, but for ε ≥ c the lower base c−ε ≤ 0 and (c−ε)ⁿ at even n can exceed h(n). Corrected the definition to ε ∈ (0,c) and proved the convergence ⇒ exponential-behavior implication via Metric.tendsto_atTop + exp∘log monotonicity. Result: 0 sorries, only the 3 structural axioms (h, h_pos, pyber_bounds), no sorryAx, no Lean.ofReduceBool. | 2026-07-08 (researcher-3): completed Part III's two-sided bracket by adding limSup_le_log_c2, and added convergent_limit_in_pyber_window pinning any limit to [log c₁, log c₂]. Still 0 sorries, 3 structural axioms, 8→10 theorems.",
     "builtItems": [
       "Erdos117OQ01.base_implies_behavior — proved (was sorry): convergence to log c ⇒ ExponentialBehavior c for ε ∈ (0,c)",
       "Erdos117OQ01.ExponentialBehavior — corrected statement to ε ∈ (0,c) (unrestricted ∀ε>0 form is false)",
@@ -64,7 +64,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:10:05.551Z",
-  "lastUpdate": "2026-06-25",
+  "lastUpdate": "2026-07-08",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

`Erdos117OQ01.lean` (Erdős #117 — exponential growth rate of the abelian covering number `h(n)`) frames Part III around "liminf and limsup are well-defined and bounded", but only proved the **liminf** lower bound (`limInf_ge_log_c1`). This PR fills the two natural, fully-provable gaps.

## New theorems

- **`limSup_le_log_c2`** — `∃ c₂ > 1, growthRateLimSup ≤ log c₂`. The symmetric companion of `limInf_ge_log_c1`, completing the two-sided bracket
  `log c₁ ≤ liminf ≤ limsup ≤ log c₂`.
  Both extreme cluster values of `log h(n)/n` are trapped inside Pyber's window even without knowing the limit exists. Proved via `Filter.limsup_le_of_le` with the growth-rate lower bound supplying the `(· ≤ ·)` cobound witness.
- **`convergent_limit_in_pyber_window`** — if `growthRate → L` then `log c₁ ≤ L ≤ log c₂`, so the exponential base `exp L` (should the still-open limit exist) is pinned to `[c₁, c₂]`. Proved by passing the eventual two-sided bounds through `ge_of_tendsto` / `le_of_tendsto`.

## Verification

- Builds clean: `✔ Built Proofs.Erdos117OQ01 (7743 jobs)`
- 0 sorries; **0 new axioms** — still exactly the 3 structural axioms `h`, `h_pos`, `pyber_bounds`
- `theoremCount` 8 → 10, `lineCount` 300 → 368; meta.json + research JSON updated

Status remains `axiomatized`. The underlying convergence question for #117 (does `lim log h(n)/n` exist?) is unchanged and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)