### PR TITLE
Enrich Catalan's Identity (cassini-identity-oq-01-oq-01): add module-header section

### DIFF
--- a/src/data/proofs/cassini-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01/meta.json
@@ -82,9 +82,16 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module header and setup",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "The docstring states Catalan's identity F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r² as the r-step generalization of Cassini, notes that Mathlib carries only the r = 1 integer-indexed Cassini specialization, and lays out the three-lemma plan (cassini_sub → catalan_aux → catalan) that needs only one induction. Followed by the Mathlib import and namespace."
+    },
+    {
       "id": "cassini-core",
       "title": "The Cassini core (normalized form)",
-      "startLine": 40,
+      "startLine": 37,
       "endLine": 54,
       "summary": "cassini_sub proves F_{m+1}² − F_m·F_{m+1} − F_m² = (−1)^m by induction off Nat.fib_add_two. This is the r = 1 engine that the general identity scales by F_r²."
     },


### PR DESCRIPTION
Enrichment pass for `cassini-identity-oq-01-oq-01` (Catalan's Identity).

**Rebased onto current main to avoid regression.** While I was working, PR #35332 merged concurrently and already added the `extended-by` Vajda-child link, two Fibonacci-cluster cross-references (Gelin–Cesàro, Vajda-lineage), and the reframed Vajda open question — all improvements I had independently made. To avoid regressing those, this PR was rebased and reduced to the single contribution main still lacks:

- **Module-header section.** Added a 'Module header and setup' section (lines 1–35) so `sections` cover the full 114-line Lean file (previously started at line 40, omitting the docstring/import/namespace), and nudged the `cassini-core` section start to 37 to include its docstring.

Diff is +8/−1; all 4 existing cross-references and both open questions are preserved. JSON validated via the gallery build.