### PR TITLE
research(szemeredi-regularity-oq-01): edgeDensity complement transfer + Icc packaging [VERIFIED, 0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ01.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ01.lean
@@ -22,6 +22,11 @@
   * `irregularPairs_swap_mem` — the set of ordered irregular pairs underlying
     `IsRegularPartition` is closed under swapping coordinates: irregularity is a
     symmetric relation on parts.
+  * `edgeDensity_compl` — **complement transfer**: for disjoint nonempty `A, B`,
+    `d_{Gᶜ}(A, B) = 1 − d_G(A, B)`, via Mathlib's
+    `SimpleGraph.edgeDensity_add_edgeDensity_compl` and the gallery bridge.
+  * `edgeDensity_mem_Icc` — the range is packaged as a single membership
+    `d(A, B) ∈ Set.Icc 0 1` for downstream positivity/interval reasoning.
 
   All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -82,5 +87,29 @@ theorem irregularPairs_swap_mem (G : SimpleGraph V) [DecidableRel G.Adj]
   refine ⟨fun h => hpair.1 h.symm, ?_⟩
   rw [isEpsilonRegular_comm]
   exact hpair.2
+
+/-- **Complement transfer of edge density.**  For *disjoint*, nonempty vertex sets
+    `A` and `B`, every cross pair is either a `G`-edge or a `Gᶜ`-edge (disjointness
+    rules out the diagonal `a = b`), so the two densities are complementary:
+
+        d_{Gᶜ}(A, B) = 1 − d_G(A, B).
+
+    Proved by transporting both gallery densities to Mathlib via `edgeDensity_eq_mathlib`
+    and invoking `SimpleGraph.edgeDensity_add_edgeDensity_compl`.  This is the density
+    half of "regularity passes to the complement graph": the density *gap* on any
+    disjoint sub-pair is preserved (`|d_{Gᶜ} − d_{Gᶜ}| = |d_G − d_G|`). -/
+theorem edgeDensity_compl (G : SimpleGraph V) [DecidableRel G.Adj]
+    {A B : Finset V} (hA : A.Nonempty) (hB : B.Nonempty) (h : Disjoint A B) :
+    edgeDensity Gᶜ A B = 1 - edgeDensity G A B := by
+  have hsum := G.edgeDensity_add_edgeDensity_compl hA hB h
+  rw [edgeDensity_eq_mathlib, edgeDensity_eq_mathlib]
+  linarith [hsum]
+
+/-- **Edge density lies in `[0, 1]`.**  Packages `edgeDensity_nonneg` and
+    `edgeDensity_le_one` into a single interval membership, convenient for
+    downstream positivity and `Set.Icc` reasoning. -/
+theorem edgeDensity_mem_Icc (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) : edgeDensity G A B ∈ Set.Icc (0 : ℚ) 1 :=
+  ⟨edgeDensity_nonneg G A B, edgeDensity_le_one G A B⟩
 
 end Szemeredi.Regularity.OQ01

--- a/src/data/research/problems/szemeredi-regularity-oq-01.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-01.json
@@ -16,11 +16,10 @@
       "SzemerediRegularityOQ01.lean: 5 theorems, 0 axioms (propext/Classical.choice/Quot.sound only), 0 sorries. Imports Proofs.SzemerediRegularity (reuses edgeDensity_eq_mathlib bridge + Core defs).",
       "edgeDensity_comm (headline symmetry), isEpsilonRegular_comm (regularity symmetry), edgeDensity_empty_left, edgeDensity_empty_right, irregularPairs_swap_mem (irregularity is symmetric on parts)."
     ],
-    "progressSummary": "COMPLETE. First child of the (Mathlib-bridged, complete) szemeredi-regularity gallery entry. Fills a structural gap: the gallery's edgeDensity and IsEpsilonRegular were never shown symmetric in their two arguments, yet regularity is conventionally an unordered-pair notion. edgeDensity_comm (d(A,B)=d(B,A)) via the existing Mathlib bridge + SimpleGraph.edgeDensity_comm; isEpsilonRegular_comm (the iff) via witness-swap; irregularPairs_swap_mem (irregular-pair set closed under swap). All 0-axiom verified, no native_decide.",
+    "progressSummary": "COMPLETE. First child of the (Mathlib-bridged, complete) szemeredi-regularity gallery entry. Fills a structural gap: the gallery's edgeDensity and IsEpsilonRegular were never shown symmetric in their two arguments, yet regularity is conventionally an unordered-pair notion. edgeDensity_comm (d(A,B)=d(B,A)) via the existing Mathlib bridge + SimpleGraph.edgeDensity_comm; isEpsilonRegular_comm (the iff) via witness-swap; irregularPairs_swap_mem (irregular-pair set closed under swap). All 0-axiom verified, no native_decide. [2026-07-08 researcher-2] Extended with edgeDensity_compl (d_{Gᶜ}(A,B)=1−d_G(A,B) for disjoint nonempty A,B, via SimpleGraph.edgeDensity_add_edgeDensity_compl + gallery bridge) and edgeDensity_mem_Icc (range packaged as Set.Icc 0 1). File now 115L / 7 theorems, 0 sorry / 0 axiom (docker-build green, 7745 jobs).",
     "nextSteps": [
-      "Complement transfer: for disjoint A,B (so every cross pair is non-adjacent-or-not), d_{Gᶜ}(A,B) = 1 − d_G(A,B), hence IsEpsilonRegular Gᶜ ε A B ↔ IsEpsilonRegular G ε A B — regularity passes to the complement graph.",
       "Use isEpsilonRegular_comm to halve the irregular-pair count bookkeeping: the IsRegularPartition threshold counts ordered pairs, but symmetry means the underlying unordered irregular pairs are half as many.",
-      "edgeDensity range packaged: edgeDensity G A B ∈ Set.Icc 0 1 (combine edgeDensity_nonneg + edgeDensity_le_one) as a single membership lemma for downstream positivity/interval reasoning."
+      "Full complement regularity transfer IsEpsilonRegular Gᶜ ε A B ↔ IsEpsilonRegular G ε A B: edgeDensity_compl gives the density identity on disjoint nonempty sub-pairs, but the ε-regularity witnesses A'⊆A, B'⊆B can be empty (edgeDensity=0 on both G and Gᶜ, breaking the 1−d identity), so the transfer needs a degenerate-witness case split — left as a follow-up."
     ]
   },
   "relatedProofs": [
@@ -43,8 +42,8 @@
     {
       "path": "Proofs/SzemerediRegularityOQ01.lean",
       "filename": "SzemerediRegularityOQ01.lean",
-      "lineCount": 87,
-      "theoremCount": 5,
+      "lineCount": 115,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Two additive lemmas extending the completed **symmetry of edge density** entry (`SzemerediRegularityOQ01.lean`), realizing two of the entry's own listed next-steps. Both **fully verified** (docker-build green, 7745 jobs, 0 sorry / 0 axiom):

- **`edgeDensity_compl`** — complement transfer: for *disjoint*, nonempty `A, B`,
  `d_{Gᶜ}(A, B) = 1 − d_G(A, B)`. Disjointness rules out the diagonal, so every cross pair is either a `G`-edge or a `Gᶜ`-edge; proved by transporting both gallery densities to Mathlib via the entry's `edgeDensity_eq_mathlib` bridge and invoking `SimpleGraph.edgeDensity_add_edgeDensity_compl`. This is the density half of "regularity passes to the complement graph."
- **`edgeDensity_mem_Icc`** — packages `edgeDensity_nonneg` + `edgeDensity_le_one` into a single interval membership `d(A, B) ∈ Set.Icc 0 1`.

## Scope / honesty
The *full* complement regularity transfer `IsEpsilonRegular Gᶜ ↔ IsEpsilonRegular G` is **not** claimed here: the ε-regularity witnesses `A' ⊆ A, B' ⊆ B` can be empty, where `edgeDensity = 0` on both `G` and `Gᶜ` and the `1 − d` identity breaks — so it needs a degenerate-witness case split, left as a documented next-step. This PR only adds the two verified density facts.

File: 87→115 lines, 5→7 theorems. Parent entry was already `completed`; this is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)