### PR TITLE
research(cauchy-schwarz-lp-duality): add q-power seminorm monotonicity under set inclusion (verified step-2 ingredient)

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -255,6 +255,36 @@ theorem eLpNorm_rpow_restrict_iUnion {g : α → ℝ} {S : ℕ → Set α}
     one_div_mul_cancel hqr, ENNReal.rpow_one]
   rw [Measure.restrict_iUnion hSd hSm, lintegral_sum_measure]
 
+/-- **Monotonicity of the `q`-power Lᵠ-seminorm under set inclusion** (step 2 ingredient).
+    For `0 < q < ∞` and measurable `A ⊆ B`, the `q`-th power of the Lᵠ-seminorm is
+    monotone in the restriction set:
+
+      `‖g‖_{q, A}^q ≤ ‖g‖_{q, B}^q`.
+
+    This is the order-theoretic content that makes the maximality *supremum*
+    `c = ⨆_S ‖g_S‖_q` well-behaved: enlarging the σ-finite support set can only increase
+    the representing function's norm, so a maximizing *sequence* can be replaced by its
+    increasing union without loss. It is an immediate corollary of the disjoint additivity
+    `eLpNorm_rpow_restrict_union` applied to the decomposition `B = A ∪ (B \ A)`: the
+    `(B \ A)`-contribution is a nonnegative `ℝ≥0∞`, so it only adds. Stated on the
+    `q`-power (not the seminorm itself) for the same reason as its additive companion —
+    the `q`-power splits exactly over disjoint supports while the seminorm is merely
+    subadditive. -/
+theorem eLpNorm_rpow_restrict_mono {g : α → ℝ} {A B : Set α}
+    (hA : MeasurableSet A) (hB : MeasurableSet B) (hAB : A ⊆ B)
+    {q : ℝ≥0∞} (hq0 : q ≠ 0) (hqtop : q ≠ ∞) :
+    eLpNorm g q (μ.restrict A) ^ q.toReal
+      ≤ eLpNorm g q (μ.restrict B) ^ q.toReal := by
+  have hdiff : MeasurableSet (B \ A) := hB.diff hA
+  have hdisj : Disjoint A (B \ A) :=
+    Set.disjoint_left.2 (fun x hxA hxD => hxD.2 hxA)
+  have hunion : A ∪ (B \ A) = B := Set.union_diff_cancel hAB
+  have key := eLpNorm_rpow_restrict_union (μ := μ) (g := g) (A := A) (B := B \ A)
+    hdiff hdisj hq0 hqtop
+  rw [hunion] at key
+  rw [key]
+  exact le_self_add
+
 /-- **Step 1 of the maximality reduction — per-σ-finite-set representer.**
     For any measurable set `S` whose restriction `μ.restrict S` is σ-finite, the
     functional `φ` on `Lp ℝ p μ`, pulled back along the extension-by-zero embedding
@@ -352,6 +382,7 @@ theorem riesz_lp_surjective_general
 #print axioms RieszLpDualitySynthesis.sigmaFinite_restrict_iUnion
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_union
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_iUnion
+#print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_mono
 #print axioms RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set
 
 end RieszLpDualitySynthesis

--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -67,7 +67,8 @@
       "Uniqueness needs no SigmaFinite μ hypothesis: a MemLp function at a finite exponent q<∞ is automatically AEFinStronglyMeasurable, and testing against finite-measure indicators gives ∫_s g=0 ∀s.",
       "S18: Incomplete01 fixed 65→63 (verified). Root structural bug: hg_eq_n was defined INSIDE the hg_lq_norm `have … := by` block but used at Step A5 outside that scope → `unknown identifier` + phantom cascade over lines 902-970. Hoisting it de-cascades the tail (exposes ~8 REAL drift errors).",
       "S18 CRITICAL: with ~15 more source-verified drift fixes applied, the build runs 40 FULL min of live `Building` ticks then Terminates without flushing errors — a resource blowup (>32GB/40min), NOT a hang or docker death. The fixes let elaboration proceed much further through the 600-line localization_existence, which then cannot complete under the 32GB envelope. Residual real errors are likely FEW but unmeasurable until the file fits.",
-      "S18: Lean flushes its error summary only at FILE COMPLETION; a build that times out mid-elaboration shows 0 errors in the log (not `clean`). Full-file compile time for Incomplete01 with errors is ~180s of Lean (post cache-get)."
+      "S18: Lean flushes its error summary only at FILE COMPLETION; a build that times out mid-elaboration shows 0 errors in the log (not `clean`). Full-file compile time for Incomplete01 with errors is ~180s of Lean (post cache-get).",
+      "q-power seminorm monotonicity under set inclusion is a free corollary of the disjoint additivity lemma already proved: eLpNorm g q (μ.restrict A)^q ≤ eLpNorm g q (μ.restrict B)^q since the (B\\A) contribution is a nonnegative ℝ≥0∞ (le_self_add). Justifies replacing a maximizing sequence by its increasing union."
     ],
     "builtItems": [
       "memLp_exists_sigmaFinite_support — bridge lemma: for 0<p<inf, every f in Lp(mu) is a.e. supported on a measurable S with mu.restrict S sigma-finite (proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean). High-confidence (uses only confirmed Mathlib API) but UNVERIFIED this session (no build).",
@@ -89,7 +90,8 @@
       "private rpow_iSup: (⨆f)^q=⨆fᵠ for q>0 via ENNReal.orderIsoRpow.map_iSup",
       "RieszLpDualityAnnihilator.lp_pairing_eq_zero_ae_zero in proofs/Proofs/CauchySchwarzIntegralLpDualityAnnihilator.lean — annihilator/uniqueness lemma: g∈Lᵠ, ∫f·g=0 ∀f∈Lᵖ ⟹ g=ᵐ0. Standalone, Mathlib-only, verified lake env lean EXIT 0, #print axioms = {propext,Classical.choice,Quot.sound}.",
       "S18 (committed, verified): hoisted hg_eq_n to localization_existence top level; AEStronglyMeasurable .congr_ae→.congr; eLpNorm one-norm via eLpNorm_one_eq_lintegral_enorm+enorm_eq_nnnorm. Rebuild-confirmed 63 errors.",
-      "S18 (staged, source-verified, unverified-by-build): research/problems/cauchy-schwarz-integral-lp-duality-synthesis/s18-batch3-drift-fixes.patch — git-apply-clean; fixes integrationCLM_sf map_add/map_smul (=ᵐ coeFn→integral_congr_ae), integral_norm direction, hg_norm rpow shape, Measure.ae_mono→ae_mono, Set.subset_univ _, (hind:α→ℝ)→E.indicator 1, EventuallyEq.mul_right drop-arg."
+      "S18 (staged, source-verified, unverified-by-build): research/problems/cauchy-schwarz-integral-lp-duality-synthesis/s18-batch3-drift-fixes.patch — git-apply-clean; fixes integrationCLM_sf map_add/map_smul (=ᵐ coeFn→integral_congr_ae), integral_norm direction, hg_norm rpow shape, Measure.ae_mono→ae_mono, Set.subset_univ _, (hind:α→ℝ)→E.indicator 1, EventuallyEq.mul_right drop-arg.",
+      "eLpNorm_rpow_restrict_mono (2026-07-08, researcher-3): monotonicity of the q-power Lᵠ-seminorm under measurable set inclusion A⊆B, from eLpNorm_rpow_restrict_union on B=A∪(B\\A) + le_self_add. Foundational-only axioms. The step-2 ingredient that makes the maximality supremum c=⨆_S‖g_S‖_q well-behaved (enlarging the support can only increase the norm)."
     ],
     "mathlibGaps": [
       "Mathlib has NO general Lp-Lq duality / Riesz surjectivity (no *Dual* Lp file under MeasureTheory/Function). This remains a genuine Mathlib gap that the gallery chain fills.",
@@ -112,8 +114,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean",
       "filename": "CauchySchwarzIntegralLpDualitySynthesis.lean",
-      "lineCount": 350,
-      "theoremCount": 6,
+      "lineCount": 390,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 13,
@@ -121,7 +123,7 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean"
     }
   ],
-  "lastUpdate": "2026-07-02",
+  "lastUpdate": "2026-07-08",
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-02",


### PR DESCRIPTION
## Summary

`CauchySchwarzIntegralLpDualitySynthesis.lean` (arbitrary-measure Riesz representation for Lᵖ, reduced to the σ-finite case) carries 5 fully-verified ingredient lemmas plus one **HARD, not open** `sorry` — the Folland 6.16 maximality construction (`riesz_lp_surjective_general`). This PR adds the remaining order-theoretic ingredient its maximality supremum needs, fully verified.

## New lemma

- **`eLpNorm_rpow_restrict_mono`** — for measurable `A ⊆ B` and `0 < q < ∞`,
  `‖g‖_{q,A}^q ≤ ‖g‖_{q,B}^q`.
  Immediate from the file's existing disjoint additivity `eLpNorm_rpow_restrict_union` applied to `B = A ∪ (B \ A)`: the `(B \ A)`-contribution is a nonnegative `ℝ≥0∞`, so it only adds (`le_self_add`).

This is exactly what makes the maximality supremum `c = ⨆_S ‖g_S‖_q` well-behaved: enlarging a σ-finite support set can only *increase* the representing function's norm, so a maximizing sequence can be replaced by its increasing union without loss. It advances the maximality bookkeeping **without touching the hard `sorry`**.

## Verification

- Builds clean: `✔ Built Proofs.CauchySchwarzIntegralLpDualitySynthesis (7748 jobs)`
- `#print axioms` confirms the new lemma is **foundational-only** (`propext / Classical.choice / Quot.sound`)
- The maximality `sorry` (and its `sorryAx`) is **unchanged** — it remains the documented crux
- Research JSON updated (`theoremCount` 6 → 7, `lineCount` 359 → 390)

Honest status: this is a genuine, self-contained building block for the still-open maximality argument, not a discharge of it. No gallery meta exists for this research-only entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)