### PR TITLE
Fix invisible cross-references across the Cauchy-interlacing family

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01/meta.json
@@ -118,8 +118,9 @@
   },
   "crossReferences": [
     {
-      "slug": "cauchy-interlacing-theorem",
-      "relation": "Parent entry — proves the abstract interlacing theorem cauchy_interlacing in compression form (taking the Rayleigh-agreement hypothesis as input) and the Courant–Fischer max–min keystone. This entry discharges that hypothesis."
+      "targetId": "cauchy-interlacing-theorem",
+      "relationship": "parent",
+      "description": "Parent entry — proves the abstract interlacing theorem cauchy_interlacing in compression form (taking the Rayleigh-agreement hypothesis as input) and the Courant–Fischer max–min keystone. This entry discharges that hypothesis."
     }
   ],
   "references": [

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02/meta.json
@@ -124,12 +124,14 @@
   },
   "crossReferences": [
     {
-      "slug": "cauchy-interlacing-theorem-oq-02",
-      "relation": "Parent entry — proves the abstract Poincaré separation λ(k+m) ≤ μ(k) ≤ λ(k) for a symmetric operator and a codimension-m compression with agreeing Rayleigh quotient, and lists the principal-submatrix bridge as its second open question. This entry supplies that bridge by realising the compression as toEuclideanLin of a principal submatrix."
+      "targetId": "cauchy-interlacing-theorem-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry — proves the abstract Poincaré separation λ(k+m) ≤ μ(k) ≤ λ(k) for a symmetric operator and a codimension-m compression with agreeing Rayleigh quotient, and lists the principal-submatrix bridge as its second open question. This entry supplies that bridge by realising the compression as toEuclideanLin of a principal submatrix."
     },
     {
-      "slug": "cauchy-interlacing-theorem",
-      "relation": "Root entry — the codimension-one Cauchy interlacing theorem and the Courant–Fischer keystone on which the entire chain rests."
+      "targetId": "cauchy-interlacing-theorem",
+      "relationship": "ancestor",
+      "description": "Root entry — the codimension-one Cauchy interlacing theorem and the Courant–Fischer keystone on which the entire chain rests."
     }
   ],
   "references": [

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-02/meta.json
@@ -125,12 +125,14 @@
   },
   "crossReferences": [
     {
-      "slug": "cauchy-interlacing-theorem",
-      "relation": "Parent entry — proves the codimension-one interlacing λ(k.succ) ≤ μ(k) ≤ λ(k.castSucc) and the Courant–Fischer keystone. This entry generalises the inequality to arbitrary codimension (the parent's second open question) and recovers the codimension-one case as the m = 1 corollary."
+      "targetId": "cauchy-interlacing-theorem",
+      "relationship": "parent",
+      "description": "Parent entry — proves the codimension-one interlacing λ(k.succ) ≤ μ(k) ≤ λ(k.castSucc) and the Courant–Fischer keystone. This entry generalises the inequality to arbitrary codimension (the parent's second open question) and recovers the codimension-one case as the m = 1 corollary."
     },
     {
-      "slug": "cauchy-interlacing-theorem-oq-01",
-      "relation": "Sibling entry — discharges the Rayleigh-agreement hypothesis for the codimension-one compression by building the orthogonal projection compression explicitly. The same construction discharges it for arbitrary codimension, which would make this entry's inequality unconditional."
+      "targetId": "cauchy-interlacing-theorem-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling entry — discharges the Rayleigh-agreement hypothesis for the codimension-one compression by building the orthogonal projection compression explicitly. The same construction discharges it for arbitrary codimension, which would make this entry's inequality unconditional."
     }
   ],
   "references": [

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01-oq-02/meta.json
@@ -166,16 +166,19 @@
   },
   "crossReferences": [
     {
-      "slug": "cauchy-interlacing-theorem-oq-03-oq-01",
-      "relation": "Parent entry — proves Weyl's a-priori operator-norm stability bound |μ(k) − ν(k)| ≤ ‖T − U‖ and lists this residual / a-posteriori bound (Bauer–Fike for the Hermitian case) as its lead open question. This entry closes that question with the converse, a-posteriori direction."
+      "targetId": "cauchy-interlacing-theorem-oq-03-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry — proves Weyl's a-priori operator-norm stability bound |μ(k) − ν(k)| ≤ ‖T − U‖ and lists this residual / a-posteriori bound (Bauer–Fike for the Hermitian case) as its lead open question. This entry closes that question with the converse, a-posteriori direction."
     },
     {
-      "slug": "cauchy-interlacing-theorem-oq-03",
-      "relation": "Grandparent entry — proves Weyl monotonicity (weyl_monotone) and the additive inequality from the Courant–Fischer keystone, on which the parent's stability bound rests."
+      "targetId": "cauchy-interlacing-theorem-oq-03",
+      "relationship": "ancestor",
+      "description": "Grandparent entry — proves Weyl monotonicity (weyl_monotone) and the additive inequality from the Courant–Fischer keystone, on which the parent's stability bound rests."
     },
     {
-      "slug": "cauchy-interlacing-theorem",
-      "relation": "Root entry — proves the Courant–Fischer max–min keystone underlying the whole eigenvalue-perturbation family."
+      "targetId": "cauchy-interlacing-theorem",
+      "relationship": "ancestor",
+      "description": "Root entry — proves the Courant–Fischer max–min keystone underlying the whole eigenvalue-perturbation family."
     }
   ],
   "references": [

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
@@ -117,12 +117,14 @@
   },
   "crossReferences": [
     {
-      "slug": "cauchy-interlacing-theorem",
-      "relation": "Parent entry — proves the Courant–Fischer max–min keystone (eigenvalue_maxmin_lower / eigenvalue_maxmin_upper) and the codimension-one interlacing inequality. This entry reuses the keystone verbatim to derive Weyl's monotonicity and additive inequalities."
+      "targetId": "cauchy-interlacing-theorem",
+      "relationship": "parent",
+      "description": "Parent entry — proves the Courant–Fischer max–min keystone (eigenvalue_maxmin_lower / eigenvalue_maxmin_upper) and the codimension-one interlacing inequality. This entry reuses the keystone verbatim to derive Weyl's monotonicity and additive inequalities."
     },
     {
-      "slug": "cauchy-interlacing-theorem-oq-02",
-      "relation": "Sibling entry (Poincaré separation) — its conclusion explicitly names 'Weyl monotonicity, Lidskii' as reusable consequences of the keystone that 'likewise only need the dimension count to vary'. This entry realises that prediction for the Weyl inequalities."
+      "targetId": "cauchy-interlacing-theorem-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling entry (Poincaré separation) — its conclusion explicitly names 'Weyl monotonicity, Lidskii' as reusable consequences of the keystone that 'likewise only need the dimension count to vary'. This entry realises that prediction for the Weyl inequalities."
     }
   ],
   "references": [


### PR DESCRIPTION
## Problem

Five entries in the Cauchy-interlacing family encoded their `crossReferences` with `{slug, relation}` keys:

```json
{ "slug": "cauchy-interlacing-theorem", "relation": "Parent entry — proves …" }
```

But the gallery loader (`normalizeCrossReferences` in `src/data/proofs/index.ts`) and the `ProofOverview`/`ProofConclusion` components only understand the object form `{ proofId | targetId, relationship, description }` (plus bare strings). A ref keyed on `slug` resolves to `ref.proofId ?? ref.targetId === undefined` and is **filtered out entirely** — so these accurate, well-written links have never rendered on the site.

## Fix

Convert `slug` → `targetId` and split the `relation` prose into:
- a `relationship` enum (`parent`/`sibling`/`ancestor`), inferred from its "Parent/Sibling/Root/Grandparent entry" prefix, and
- `description` = the full prose, preserved verbatim.

All **10 links** across the 5 entries target existing gallery entries and now resolve/render. No prose was lost; the diff touches only the cross-reference objects.

## Entries fixed
| Entry | Links restored |
|---|---|
| `cauchy-interlacing-theorem-oq-01` | 1 (previously **zero** visible refs) |
| `cauchy-interlacing-theorem-oq-02` | 2 |
| `cauchy-interlacing-theorem-oq-02-oq-02` | 2 |
| `cauchy-interlacing-theorem-oq-03` | 2 |
| `cauchy-interlacing-theorem-oq-03-oq-01-oq-02` | 3 |

Each file remains valid JSON and within all size caps.