### PR TITLE
research(erdos-897-oq-01): Part I scaffolding — non-vacuity, selectivity, strongly-additive reduction [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -1,0 +1,214 @@
+/-
+  Erdős Problem #897 — OQ-01 (Part I): Non-Vacuity, Selectivity, and a
+  Strongly-Additive Reduction
+
+  Companion to `Erdos897Problem.lean`. Part I of Erdős #897 asks: if `f` is
+  additive with `limsup_{p,k} f(p^k)/log(p^k) = ∞`, must
+  `limsup_n (f(n+1)-f(n))/log n = ∞`?  The forward implication is OPEN and is
+  **not** asserted here. This file supplies the verified surrounding theory that
+  any analysis of Part I needs:
+
+  (1) **Non-vacuity.** The hypothesis `UnboundedOnPrimePowers` is satisfiable:
+      `logSqWeight n = ∑_{p ∣ n} (log p)²` is additive — in fact strongly
+      additive — and grows faster than `log` on prime powers. So Part I is not
+      vacuously true.
+  (2) **Selectivity.** The parent file's flagship additive functions `log` and
+      `ω` both FAIL the hypothesis (`log` sits exactly at the boundary,
+      `ω` is bounded on prime powers). The hypothesis therefore isolates functions
+      growing strictly faster than `log` on prime powers.
+  (3) The hypothesis forces plain unboundedness of `f` on prime powers.
+  (4) **Strongly-additive reduction.** For strongly additive `f` the hypothesis
+      collapses to `f(p)/log p` unbounded over primes — the counterpart of the
+      parent file's completely-additive reduction. The cancellation differs: the
+      value is constant in `k`, so the binding case is `k = 1`, and the `M < 0`
+      branch is handled by invoking the hypothesis at `0`.
+
+  Verified, 0 axioms, 0 sorries, no `native_decide`.
+-/
+
+import Proofs.Erdos897Problem
+
+namespace Erdos897
+
+open Finset
+
+/-
+## (1) Non-vacuity: an explicit witness satisfying the hypothesis
+
+`logSqWeight n = ∑_{p ∈ primeFactors n} (log p)²`. On a prime power `p^k` (k ≥ 1)
+its value is `(log p)²`, independent of `k`, while `log(p^k) = k·log p`. Choosing a
+large prime makes `(log p)² / log(p^k) = log p / k` as large as we like at `k = 1`,
+so the function is unbounded on prime powers relative to `log`.
+-/
+
+/-- The additive weight `logSqWeight n = ∑_{p ∣ n} (log p)²`, our witness that the
+Erdős #897 hypothesis `UnboundedOnPrimePowers` is non-vacuous. -/
+noncomputable def logSqWeight (n : ℕ) : ℝ :=
+  ∑ p ∈ n.primeFactors, (Real.log p) ^ 2
+
+/-- On a prime power the sum collapses to the single prime: `logSqWeight p = (log p)²`. -/
+theorem logSqWeight_prime {p : ℕ} (hp : p.Prime) :
+    logSqWeight p = (Real.log p) ^ 2 := by
+  simp only [logSqWeight, hp.primeFactors, Finset.sum_singleton]
+
+/-- `logSqWeight` is additive: prime supports of coprime numbers are disjoint, so the
+defining sum splits over a coprime product. -/
+theorem logSqWeight_additive : IsAdditive logSqWeight := by
+  intro a b ha hb hab
+  simp only [logSqWeight]
+  rw [Nat.primeFactors_mul ha.ne' hb.ne',
+      Finset.sum_union hab.disjoint_primeFactors]
+
+/-- `logSqWeight` is in fact **strongly additive**: `logSqWeight (p^k) = logSqWeight p`
+for every prime `p` and `k ≥ 1`, since `(p^k).primeFactors = p.primeFactors`. -/
+theorem logSqWeight_stronglyAdditive : IsStronglyAdditive logSqWeight := by
+  refine ⟨logSqWeight_additive, ?_⟩
+  intro p k hp hk
+  simp only [logSqWeight]
+  rw [Nat.primeFactors_pow p (by omega : k ≠ 0)]
+
+/-- `logSqWeight` satisfies the Erdős #897 hypothesis: it is unbounded on prime powers
+relative to `log`. At `k = 1` we have `logSqWeight p = (log p)²` versus `log p`, and a
+sufficiently large prime makes `(log p)² > M·log p` for any target `M`. -/
+theorem logSqWeight_unboundedOnPrimePowers : UnboundedOnPrimePowers logSqWeight := by
+  intro M
+  -- Pick a prime `p` with `log p > M` by going past `exp M`.
+  obtain ⟨p, hpN, hp⟩ := Nat.exists_infinite_primes (⌈Real.exp M⌉₊ + 1)
+  refine ⟨p, 1, hp, le_refl 1, ?_⟩
+  have hlogpos : 0 < Real.log p := Real.log_pos (by exact_mod_cast hp.one_lt)
+  have hlogM : M < Real.log p := by
+    have hexp_lt : Real.exp M < (p : ℝ) := by
+      have hceil : Real.exp M ≤ (⌈Real.exp M⌉₊ : ℝ) := Nat.le_ceil _
+      have hNp : ((⌈Real.exp M⌉₊ + 1 : ℕ) : ℝ) ≤ (p : ℝ) := by exact_mod_cast hpN
+      push_cast at hNp
+      linarith
+    have := Real.log_lt_log (Real.exp_pos M) hexp_lt
+    rwa [Real.log_exp] at this
+  simp only [pow_one]
+  rw [logSqWeight_prime hp]
+  -- goal: `(log p)² > M * log p`; both factors of `(log p)(log p - M)` are positive.
+  nlinarith [mul_pos hlogpos (sub_pos.mpr hlogM)]
+
+/-- **Non-vacuity (headline).** There exists an additive function satisfying the
+Erdős #897 hypothesis, so Part I is not vacuously true. Witness: `logSqWeight`. -/
+theorem exists_additive_unboundedOnPrimePowers :
+    ∃ f : ℕ → ℝ, IsAdditive f ∧ UnboundedOnPrimePowers f :=
+  ⟨logSqWeight, logSqWeight_additive, logSqWeight_unboundedOnPrimePowers⟩
+
+/-
+## (2) Selectivity: the classical examples fail the hypothesis
+
+`log` sits exactly at the boundary (`log(p^k)/log(p^k) = 1`) and `ω` is bounded on
+prime powers (`ω(p^k) = 1`). Neither is unbounded relative to `log`, so the
+hypothesis genuinely restricts to functions growing *strictly* faster than `log`.
+-/
+
+/-- **Selectivity for `log`.** The logarithm does not satisfy the hypothesis:
+`logN(p^k) = log(p^k)` exactly, so it never exceeds `1 · log(p^k)`. -/
+theorem not_unboundedOnPrimePowers_logN : ¬ UnboundedOnPrimePowers logN := by
+  intro h
+  obtain ⟨p, k, _hp, _hk, hlt⟩ := h 1
+  simp only [logN, one_mul, Nat.cast_pow] at hlt
+  exact lt_irrefl _ hlt
+
+/-- **Selectivity for `ω`.** The distinct-prime-factor count is bounded (`ω(p^k) = 1`)
+on prime powers, so it cannot outgrow `log`: with `M = 2/log 2` the required
+inequality `ω(p^k) > M·log(p^k)` would force `1 > 2`. -/
+theorem not_unboundedOnPrimePowers_omega : ¬ UnboundedOnPrimePowers omega := by
+  intro h
+  obtain ⟨p, k, hp, hk, hlt⟩ := h (2 / Real.log 2)
+  have homega : omega (p ^ k) = 1 := by
+    simp only [omega]
+    rw [Nat.primeFactors_pow p (by omega : k ≠ 0), hp.primeFactors, Finset.card_singleton]
+    norm_num
+  rw [homega] at hlt
+  have hlog2 : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  have hpk2 : (2 : ℝ) ≤ (p : ℝ) ^ k := by
+    have hle : 2 ≤ p ^ k := le_trans hp.two_le (Nat.le_self_pow (by omega) p)
+    calc (2 : ℝ) ≤ ((p ^ k : ℕ) : ℝ) := by exact_mod_cast hle
+      _ = (p : ℝ) ^ k := by push_cast; ring
+  have hloglb : Real.log 2 ≤ Real.log ((p : ℝ) ^ k) := Real.log_le_log (by norm_num) hpk2
+  have hcnn : (0 : ℝ) ≤ 2 / Real.log 2 := by positivity
+  have hmul : (2 / Real.log 2) * Real.log 2 ≤ (2 / Real.log 2) * Real.log ((p : ℝ) ^ k) :=
+    mul_le_mul_of_nonneg_left hloglb hcnn
+  have hval : (2 / Real.log 2) * Real.log 2 = 2 := by field_simp
+  linarith
+
+/-
+## (3) The hypothesis forces plain unboundedness on prime powers
+-/
+
+/-- If `f` is unbounded on prime powers relative to `log`, then `f` is plainly
+unbounded on prime powers: for every `B` some `f(p^k)` exceeds `B`. The uniform
+lower bound `log(p^k) ≥ log 2 > 0` lets us dial the multiplier against `B`. -/
+theorem unboundedOnPrimePowers_unbounded {f : ℕ → ℝ}
+    (hf : UnboundedOnPrimePowers f) :
+    ∀ B : ℝ, ∃ p k : ℕ, p.Prime ∧ 1 ≤ k ∧ f (p ^ k) > B := by
+  intro B
+  set M := (|B| + 1) / Real.log 2 with hMdef
+  obtain ⟨p, k, hp, hk, hpk⟩ := hf M
+  refine ⟨p, k, hp, hk, ?_⟩
+  have hlog2 : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  have hMnn : 0 ≤ M := by rw [hMdef]; positivity
+  have hpk2 : (2 : ℝ) ≤ (p : ℝ) ^ k := by
+    have hle : 2 ≤ p ^ k := le_trans hp.two_le (Nat.le_self_pow (by omega) p)
+    calc (2 : ℝ) ≤ ((p ^ k : ℕ) : ℝ) := by exact_mod_cast hle
+      _ = (p : ℝ) ^ k := by push_cast; ring
+  have hloglb : Real.log 2 ≤ Real.log ((p : ℝ) ^ k) := Real.log_le_log (by norm_num) hpk2
+  have hchain : M * Real.log 2 ≤ M * Real.log ((p : ℝ) ^ k) :=
+    mul_le_mul_of_nonneg_left hloglb hMnn
+  have hval : M * Real.log 2 = |B| + 1 := by rw [hMdef]; field_simp
+  have hBlt : B < |B| + 1 := by nlinarith [abs_nonneg B, le_abs_self B]
+  calc B < |B| + 1 := hBlt
+    _ = M * Real.log 2 := hval.symm
+    _ ≤ M * Real.log ((p : ℝ) ^ k) := hchain
+    _ < f (p ^ k) := hpk
+
+/-
+## (4) A strongly-additive reduction
+
+For strongly additive `f`, `f(p^k) = f(p)` is constant in `k`, so the prime-power
+hypothesis reduces to a statement about primes alone — the strongly-additive
+counterpart of `completelyAdditive_unboundedOnPrimePowers_iff`.
+-/
+
+/-- **Reduction theorem (strongly additive).** For strongly additive `f`, the Erdős
+#897 hypothesis is equivalent to `f(p)/log p` being unbounded over the primes.
+
+Forward: since `f(p^k) = f(p)` the multiplier `k` appears only through
+`log(p^k) = k·log p`; for `M ≥ 0` we drop the extra factor `k ≥ 1` (both `M` and
+`log p` are nonnegative), and for `M < 0` we instead invoke the hypothesis at `0`
+(then `f(p) > 0 ≥ M·log p`). Reverse: take `k = 1`. -/
+theorem stronglyAdditive_unboundedOnPrimePowers_iff {f : ℕ → ℝ}
+    (hf : IsStronglyAdditive f) :
+    UnboundedOnPrimePowers f ↔
+      ∀ M : ℝ, ∃ p : ℕ, p.Prime ∧ f p > M * Real.log p := by
+  constructor
+  · intro h M
+    by_cases hM : 0 ≤ M
+    · obtain ⟨p, k, hp, hk, hpk⟩ := h M
+      refine ⟨p, hp, ?_⟩
+      have hfp : f (p ^ k) = f p := hf.2 p k hp hk
+      have hlogp : 0 ≤ Real.log p := Real.log_nonneg (by exact_mod_cast hp.one_lt.le)
+      have hk1 : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk
+      rw [hfp, Real.log_pow] at hpk
+      -- hpk : f p > M * (↑k * log p); drop the factor k ≥ 1.
+      have hdrop : M * Real.log p ≤ M * ((k : ℝ) * Real.log p) := by
+        nlinarith [mul_nonneg (mul_nonneg hM (by linarith : (0 : ℝ) ≤ (k : ℝ) - 1)) hlogp]
+      linarith
+    · push_neg at hM
+      obtain ⟨p, k, hp, hk, hpk⟩ := h 0
+      refine ⟨p, hp, ?_⟩
+      have hfp : f (p ^ k) = f p := hf.2 p k hp hk
+      rw [hfp, zero_mul] at hpk
+      have hlogp : 0 < Real.log p := Real.log_pos (by exact_mod_cast hp.one_lt)
+      have hnp : M * Real.log p ≤ 0 := mul_nonpos_of_nonpos_of_nonneg hM.le hlogp.le
+      linarith
+  · intro h M
+    obtain ⟨p, hp, hpp⟩ := h M
+    refine ⟨p, 1, hp, le_refl 1, ?_⟩
+    have hfp : f (p ^ 1) = f p := hf.2 p 1 hp (le_refl 1)
+    rw [hfp, pow_one]
+    exact hpp
+
+end Erdos897

--- a/research/problems/erdos-897-oq-01/knowledge.md
+++ b/research/problems/erdos-897-oq-01/knowledge.md
@@ -1,0 +1,38 @@
+# Erdős #897 OQ-01 (Part I) — Knowledge Base
+
+## Session 2026-07-08 (researcher-1) — built the missing Part-I scaffolding
+
+**Discovery:** the research DB (`src/data/research/problems/erdos-897-oq-01.json`)
+and registry marked this slug COMPLETED/graduated with a Lean file
+`Erdos897OQ01.lean` and gallery entry `erdos-897-oq-01` — but NEITHER existed. Only
+the parent's completely-additive reduction had ever landed (into
+`Erdos897Problem.lean`, commits #28766/#35294). The specific Part-I deliverables the
+DB described (logSqWeight witness, selectivity, strongly-additive reduction) were
+never actually built. This session builds them for real.
+
+**Delivered** (`proofs/Proofs/Erdos897OQ01.lean`, 214 L, 9 thm / 1 def, 0 axioms,
+0 sorries, no native_decide):
+- `logSqWeight n = ∑_{p|n} (log p)²`, proved additive AND strongly additive.
+- `exists_additive_unboundedOnPrimePowers` — non-vacuity: the #897 hypothesis is
+  satisfiable, so Part I is not vacuously true. (At k=1, (log p)² > M·log p for a
+  prime p past exp M via `Nat.exists_infinite_primes`.)
+- `not_unboundedOnPrimePowers_logN` / `not_unboundedOnPrimePowers_omega` —
+  selectivity: log sits at the boundary (log(p^k)=log(p^k) exactly), ω is bounded
+  (ω(p^k)=1); with M=2/log2 the ω inequality would force 1>2.
+- `unboundedOnPrimePowers_unbounded` — hypothesis ⇒ plain unboundedness (M=(|B|+1)/log2).
+- `stronglyAdditive_unboundedOnPrimePowers_iff` — reduction to f(p)/log p over primes;
+  M≥0 drops the k≥1 factor, M<0 invokes the hypothesis at 0 (f(p)>0≥M·log p), reverse
+  takes k=1.
+
+**Gotchas:**
+- The def `UnboundedOnPrimePowers` renders `Real.log (p^k)` as `Real.log ((↑p)^k)`
+  (real power, since `Real.log_pow` applies) — so after `refine ⟨p,1,…⟩` use
+  `simp only [pow_one]` (NOT a single `rw [pow_one]`, which only hits the ℕ `p^1`
+  inside `f (p^1)` and leaves `Real.log (↑p ^ 1)` unsimplified → nlinarith fails).
+- `omega` the parent def coexists with the `omega` tactic fine (term vs tactic position).
+- `Real.log_le_log (0<x) (x≤y)`, `Real.log_lt_log`, `Real.log_nonneg`, `Real.log_pos`,
+  `Nat.le_self_pow (k≠0) p : p ≤ p^k`, `Nat.le_ceil`, `hp.primeFactors = {p}`,
+  `Nat.primeFactors_pow p (k≠0)` all current in v4.26.
+
+**Status:** gallery entry now `verified`/`original`. Part I forward implication stays
+OPEN (documented, not asserted).

--- a/research/problems/erdos-897-oq-01/state.md
+++ b/research/problems/erdos-897-oq-01/state.md
@@ -1,0 +1,30 @@
+# Current State
+
+**Phase**: COMPLETED
+**Since**: 2026-07-08
+**Iteration**: 1
+
+## Current Focus
+
+Verified Part-I surrounding theory for Erdős #897 delivered as companion file
+`proofs/Proofs/Erdos897OQ01.lean` + gallery entry `erdos-897-oq-01`.
+
+## Active Approach
+
+Done. Non-vacuity witness (logSqWeight), selectivity (log/ω fail), plain
+unboundedness, and a strongly-additive reduction — all verified, 0 axioms/0 sorries.
+
+## Blockers
+
+Part I itself (does prime-power growth force unbounded normalized consecutive
+differences?) remains OPEN — needs genuine analytic number theory, not asserted.
+
+## Next Action
+
+None for this slug. Part I forward implication is a research-frontier open problem.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/erdos-897-oq-01/annotations.json
+++ b/src/data/proofs/erdos-897-oq-01/annotations.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "ann-e897oq01-header",
+    "proofId": "erdos-897-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 29
+    },
+    "type": "concept",
+    "title": "Part I of Erdős #897 — what is proved and what is not",
+    "content": "**Part I (OPEN)** of Erdős #897 asks: if an additive `f` satisfies `limsup_{p,k} f(p^k)/log(p^k) = ∞`, must `limsup_n (f(n+1)−f(n))/log n = ∞`? This file does **not** assert Part I. It proves the verified surrounding theory: a non-vacuity witness, selectivity against the classical examples, plain unboundedness, and a strongly-additive reduction. All results are axiom-free with 0 sorries."
+  },
+  {
+    "id": "ann-e897oq01-logsqweight",
+    "proofId": "erdos-897-oq-01",
+    "range": {
+      "startLine": 46,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "The witness `logSqWeight`",
+    "content": "`logSqWeight n = ∑_{p ∈ primeFactors n} (log p)²`. On a prime power `p^k` its value is `(log p)²` (independent of `k`), while `log(p^k) = k·log p`. This gap is what makes it grow faster than `log` on prime powers."
+  },
+  {
+    "id": "ann-e897oq01-additive",
+    "proofId": "erdos-897-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 71
+    },
+    "type": "theorem",
+    "title": "`logSqWeight` is (strongly) additive",
+    "content": "Additivity follows because coprime numbers have disjoint prime supports, so the defining sum splits over a coprime product. Strong additivity follows from `(p^k).primeFactors = p.primeFactors`, giving `logSqWeight(p^k) = logSqWeight(p) = (log p)²`."
+  },
+  {
+    "id": "ann-e897oq01-nonvacuity",
+    "proofId": "erdos-897-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 96
+    },
+    "type": "theorem",
+    "title": "Non-vacuity: the hypothesis is satisfiable",
+    "content": "`logSqWeight` satisfies `UnboundedOnPrimePowers`: at `k = 1`, `(log p)² > M·log p` whenever `log p > M`, and a prime past `exp M` (via `Nat.exists_infinite_primes`) achieves this. Hence `exists_additive_unboundedOnPrimePowers` — Part I is **not vacuously true**."
+  },
+  {
+    "id": "ann-e897oq01-selectivity-log",
+    "proofId": "erdos-897-oq-01",
+    "range": {
+      "startLine": 108,
+      "endLine": 115
+    },
+    "type": "theorem",
+    "title": "Selectivity: `log` fails the hypothesis",
+    "content": "`logN(p^k) = log(p^k)` exactly, so it never strictly exceeds `1·log(p^k)`. The logarithm sits precisely at the boundary of the growth condition and does not satisfy it."
+  },
+  {
+    "id": "ann-e897oq01-selectivity-omega",
+    "proofId": "erdos-897-oq-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 135
+    },
+    "type": "theorem",
+    "title": "Selectivity: `ω` fails the hypothesis",
+    "content": "`ω(p^k) = 1` is bounded on prime powers. With `M = 2/log 2` the required inequality `ω(p^k) > M·log(p^k)` would force `1 > 2`. So the hypothesis isolates functions growing strictly faster than `log`."
+  },
+  {
+    "id": "ann-e897oq01-plain-unbounded",
+    "proofId": "erdos-897-oq-01",
+    "range": {
+      "startLine": 144,
+      "endLine": 165
+    },
+    "type": "theorem",
+    "title": "The hypothesis forces plain unboundedness",
+    "content": "Because `log(p^k) ≥ log 2 > 0` uniformly, choosing `M = (|B|+1)/log 2` turns `f(p^k) > M·log(p^k)` into `f(p^k) > B`. So growth relative to `log` implies plain unboundedness on prime powers."
+  },
+  {
+    "id": "ann-e897oq01-reduction",
+    "proofId": "erdos-897-oq-01",
+    "range": {
+      "startLine": 182,
+      "endLine": 214
+    },
+    "type": "theorem",
+    "title": "Strongly-additive reduction to the primes",
+    "content": "For strongly additive `f`, `f(p^k) = f(p)` is constant in `k`, so `UnboundedOnPrimePowers f ⇔ ∀ M, ∃ prime p, f(p) > M·log p`. Forward: for `M ≥ 0` drop the factor `k ≥ 1`; for `M < 0` invoke the hypothesis at `0` (then `f(p) > 0 ≥ M·log p`). Reverse: take `k = 1`. This is the strongly-additive counterpart of the parent's completely-additive reduction."
+  }
+]

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "erdos-897-oq-01",
+  "title": "Erdős #897 OQ-01 (Part I): Non-Vacuity, Selectivity, and a Strongly-Additive Reduction",
+  "slug": "erdos-897-oq-01",
+  "description": "Verified, axiom-free surrounding theory for Part I of Erdős #897 (OPEN): a witness making the growth hypothesis non-vacuous, proof that log and ω fail it, plain unboundedness, and a strongly-additive reduction to the primes.",
+  "meta": {
+    "author": "Research agent (Lean Genius)",
+    "sourceUrl": "https://erdosproblems.com/897",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos897OQ01.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "additive-functions",
+      "analytic-number-theory",
+      "arithmetic-functions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 897,
+    "erdosUrl": "https://erdosproblems.com/897",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-07-08",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.log",
+        "description": "The natural logarithm function",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Nat.primeFactors",
+        "description": "The set of prime factors of a natural number",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.exists_infinite_primes",
+        "description": "There are arbitrarily large primes",
+        "module": "Mathlib.Data.Nat.Prime.Infinite"
+      },
+      {
+        "theorem": "Real.log_pow",
+        "description": "log(x^n) = n·log x",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "logSqWeight n = ∑_{p|n} (log p)²: an explicit additive witness (in fact strongly additive) satisfying UnboundedOnPrimePowers, so Part I of Erdős #897 is NOT vacuously true (exists_additive_unboundedOnPrimePowers)",
+      "logSqWeight_additive / logSqWeight_stronglyAdditive: the witness is additive (disjoint prime supports of coprime numbers) and strongly additive (logSqWeight(p^k) = logSqWeight(p) = (log p)²), so the strongly-additive reduction below applies to it",
+      "not_unboundedOnPrimePowers_logN and not_unboundedOnPrimePowers_omega: SELECTIVITY — the parent file's flagship additive functions log and ω both FAIL the hypothesis. log sits exactly at the boundary (log(p^k)/log(p^k)=1); ω is bounded on prime powers (ω(p^k)=1). The hypothesis isolates functions growing strictly faster than log on prime powers",
+      "unboundedOnPrimePowers_unbounded: the hypothesis forces plain unboundedness of f on prime powers (for every B some f(p^k) > B), by dialing the multiplier against the uniform lower bound log(p^k) ≥ log 2 > 0",
+      "stronglyAdditive_unboundedOnPrimePowers_iff: a strongly-additive reduction collapsing UnboundedOnPrimePowers f to 'f(p)/log p unbounded over primes' — the strongly-additive counterpart of the parent's completely-additive reduction. Since f(p^k)=f(p) is constant in k, the binding case is k=1; the M<0 branch is handled by invoking the hypothesis at 0 (then f(p) > 0 ≥ M·log p)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 214,
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries; proofs use no native_decide (so #print axioms shows only propext/Classical.choice/Quot.sound). Part I of Erdős #897 — whether the prime-power growth hypothesis forces limsup_n (f(n+1)-f(n))/log n = ∞ — remains OPEN and is NOT asserted; this entry proves only the verified surrounding theory (non-vacuity, selectivity, plain unboundedness, and the strongly-additive reduction).",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Erdős #897 concerns additive arithmetic functions f (f(ab)=f(a)+f(b) for coprime a,b) that grow unboundedly fast on prime powers relative to log, i.e. limsup_{p,k} f(p^k)/log(p^k) = ∞. Part I asks whether this forces the normalized consecutive differences (f(n+1)-f(n))/log n to be unbounded as well. The parent gallery entry erdos-897 formalizes the definitions, Wirsing's 1970 converse, and a reduction for completely additive functions. This companion supplies the Part-I-specific surrounding theory: a witness proving the hypothesis is satisfiable, a demonstration that the classical functions log and ω do NOT satisfy it, and a strongly-additive analogue of the parent's reduction.",
+    "problemStatement": "Let $f$ be additive with $\\limsup_{p,k} \\frac{f(p^k)}{\\log(p^k)} = \\infty$.\n\n**Part I (OPEN)**: must $\\displaystyle\\limsup_n \\frac{f(n+1)-f(n)}{\\log n} = \\infty$?\n\nThis entry does **not** assert Part I. It proves the verified scaffolding: (1) the hypothesis is satisfiable by an explicit additive (indeed strongly additive) witness $\\mathrm{logSqWeight}(n)=\\sum_{p\\mid n}(\\log p)^2$; (2) the classical examples $\\log$ and $\\omega$ FAIL the hypothesis; (3) the hypothesis forces $f$ plainly unbounded on prime powers; (4) for strongly additive $f$ the hypothesis reduces to $f(p)/\\log p$ unbounded over primes.",
+    "text": "Verified, axiom-free surrounding theory for Part I of Erdős #897 (OPEN): non-vacuity of the growth hypothesis, selectivity against log and ω, plain unboundedness, and a strongly-additive reduction.",
+    "proofStrategy": "1. **Non-vacuity**: define logSqWeight(n)=∑_{p|n}(log p)². Additivity comes from the disjoint prime supports of coprime numbers; strong additivity from (p^k).primeFactors = p.primeFactors. It satisfies UnboundedOnPrimePowers because at k=1 its value (log p)² beats M·log p for a sufficiently large prime p (obtained past exp M via Nat.exists_infinite_primes).\n\n2. **Selectivity**: logN(p^k)=log(p^k) exactly, so it never strictly exceeds 1·log(p^k); ω(p^k)=1 is bounded, so with M=2/log 2 the required inequality 1 > 2 is impossible.\n\n3. **Plain unboundedness**: from f(p^k) > M·log(p^k) ≥ M·log 2 (M ≥ 0), choosing M = (|B|+1)/log 2 gives f(p^k) > B.\n\n4. **Strongly-additive reduction**: f(p^k)=f(p) is constant in k, so log(p^k)=k·log p is the only k-dependence. For M ≥ 0 drop the factor k ≥ 1; for M < 0 invoke the hypothesis at 0 so f(p) > 0 ≥ M·log p. The reverse takes k=1.",
+    "keyInsights": [
+      "**Non-vacuity matters**: an open conditional statement is only interesting if its hypothesis can actually hold. logSqWeight exhibits an additive function growing like (log p)² on prime powers — strictly faster than log — so Part I is not vacuously true.",
+      "**The hypothesis is a strict growth condition**: log itself sits exactly at the boundary and ω is bounded on prime powers, so both classical examples fail it. The hypothesis picks out functions super-logarithmic on prime powers.",
+      "**Strongly additive vs completely additive**: for completely additive f the multiplier k cancels in f(p^k)/log(p^k)=f(p)/log p; for strongly additive f the value is constant in k, so the reduction still holds but the binding case is k=1 and the negative-M branch needs the hypothesis at 0.",
+      "**A uniform floor drives the estimates**: log(p^k) ≥ log 2 > 0 on every prime power is what lets the multiplier be dialed to force both non-vacuity and plain unboundedness."
+    ],
+    "prerequisites": [
+      "Number theory (primes, divisibility)",
+      "Elementary real analysis (logarithm monotonicity)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Documentation",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Statement of Part I (OPEN, not asserted) and the four verified deliverables."
+    },
+    {
+      "id": "non-vacuity",
+      "title": "(1) Non-vacuity witness",
+      "startLine": 35,
+      "endLine": 96,
+      "summary": "logSqWeight(n)=∑_{p|n}(log p)² is additive, strongly additive, and unbounded on prime powers, so the #897 hypothesis is satisfiable."
+    },
+    {
+      "id": "selectivity",
+      "title": "(2) Selectivity",
+      "startLine": 98,
+      "endLine": 135,
+      "summary": "log and ω both fail the hypothesis, so it isolates strictly super-logarithmic growth on prime powers."
+    },
+    {
+      "id": "plain-unbounded",
+      "title": "(3) Plain unboundedness",
+      "startLine": 137,
+      "endLine": 165,
+      "summary": "The hypothesis forces f unbounded on prime powers (every B is exceeded)."
+    },
+    {
+      "id": "reduction",
+      "title": "(4) Strongly-additive reduction",
+      "startLine": 167,
+      "endLine": 214,
+      "summary": "For strongly additive f the hypothesis is equivalent to f(p)/log p unbounded over the primes."
+    }
+  ],
+  "conclusion": "This companion nails down the theory Part I of Erdős #897 rests on: the growth hypothesis is non-vacuous (logSqWeight witnesses it), selective (log and ω fail it), forces plain unboundedness, and — for strongly additive f — reduces to a statement about the primes alone. The forward implication of Part I itself remains OPEN and is not asserted. Verified, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "path": "Proofs/Erdos897OQ01.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos897",
+    "lineCount": 214,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 9
+  },
+  "crossReferences": [
+    {
+      "slug": "erdos-897",
+      "reason": "Parent formalization: definitions of additive/strongly/completely additive, Wirsing's converse, and the completely-additive reduction this file mirrors."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The research DB and registry marked `erdos-897-oq-01` as **completed/graduated** with a Lean file (`Erdos897OQ01.lean`) and gallery entry that **never actually existed** — only the parent's completely-additive reduction had ever landed (into `Erdos897Problem.lean`). This PR builds the missing Part-I deliverables for real, making the stale records true.

Part I of Erdős #897 (OPEN): if additive `f` has `limsup_{p,k} f(p^k)/log(p^k) = ∞`, must `limsup_n (f(n+1)−f(n))/log n = ∞`? **Not asserted.** This entry proves the verified surrounding theory.

## What's proved (new file `proofs/Proofs/Erdos897OQ01.lean`, 214 L, 9 thm / 1 def, 0 axioms / 0 sorries, no `native_decide`)

- **Non-vacuity** — `logSqWeight n = ∑_{p|n} (log p)²` is additive (indeed strongly additive) and satisfies `UnboundedOnPrimePowers`, so Part I is *not vacuously true* (`exists_additive_unboundedOnPrimePowers`). At `k=1`, `(log p)² > M·log p` for a prime past `exp M`.
- **Selectivity** — the parent's flagship functions `log` and `ω` both **fail** the hypothesis (`not_unboundedOnPrimePowers_logN` / `_omega`): `log` sits exactly at the boundary, `ω(p^k)=1` is bounded. So the hypothesis isolates strictly super-logarithmic growth on prime powers.
- **Plain unboundedness** — `unboundedOnPrimePowers_unbounded`: the hypothesis forces `f` unbounded on prime powers (uniform floor `log(p^k) ≥ log 2`).
- **Strongly-additive reduction** — `stronglyAdditive_unboundedOnPrimePowers_iff`: for strongly additive `f`, the hypothesis ⇔ `f(p)/log p` unbounded over primes. The counterpart of the parent's completely-additive reduction; the `M<0` branch is handled by invoking the hypothesis at `0`.

## Verification

Built clean via the Docker wrapper (`Proofs.Erdos897OQ01`, 7744 jobs). 0 sorries, 0 axiom declarations, no `native_decide`. New gallery entry `erdos-897-oq-01` (status `verified`/`original`) with annotations; gallery build enriches it with no errors.

## Status

Part I forward implication remains **OPEN** — documented, not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)