### PR TITLE
Enrich Catalan linear recurrence (catalan-numbers-oq-01): fix section boundaries

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01/meta.json
@@ -82,22 +82,22 @@
       "id": "header",
       "title": "Module Header and Setup",
       "startLine": 1,
-      "endLine": 30,
+      "endLine": 25,
       "summary": "Module docstring stating the linear recurrence, explaining why Mathlib's convolution and closed-form lemmas are not the first-order recurrence, and outlining the central-binomial bridge; import of Mathlib.",
       "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$ versus the quadratic Segner convolution."
     },
     {
       "id": "linear-recurrence",
       "title": "The Linear Recurrence",
-      "startLine": 31,
-      "endLine": 53,
+      "startLine": 26,
+      "endLine": 48,
       "summary": "catalan_linear_recurrence: instantiates succ_mul_catalan_eq_centralBinom at n and n+1 and Nat.succ_mul_centralBinom_succ at n, multiplies the goal by n+1, runs the calc chain through the central binomials, and cancels n+1 with Nat.eq_of_mul_eq_mul_left.",
       "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$."
     },
     {
       "id": "division-form",
       "title": "Exact-Division Corollary and Numeric Check",
-      "startLine": 55,
+      "startLine": 50,
       "endLine": 63,
       "summary": "catalan_succ_eq_div: the recurrence solved for catalan (n+1) as an exact ℕ division via Nat.mul_div_cancel_left; followed by a worked example deriving catalan 4 = 14 from catalan 3 = 5 through the recurrence (axiom-free, no native_decide).",
       "mathContext": "$C_{n+1} = 2(2n+1)\\,C_n / (n+2)$."


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01` (the O(1) linear recurrence for Catalan numbers). The entry's prose, annotations, and cross-references were already excellent (quality 94, all 3 sibling cross-refs valid and reciprocal), so this pass fixes **section-boundary accuracy** against the Lean source:

The three `sections` ranges were misaligned with the 63-line file:
- `header` was 1–30, swallowing the `catalan_linear_recurrence` docstring (lines 26–30) → now **1–25** (import + module docstring).
- `linear-recurrence` was 31–53, which overran into `catalan_succ_eq_div` (theorem at 53, docstring 50–52) while omitting its own docstring → now **26–48** (docstring + theorem + proof, which ends at line 48).
- `division-form` was 55–63, excluding `catalan_succ_eq_div`'s docstring (50–52) and its theorem header (53–54) and starting mid-proof → now **50–63** (the exact-division corollary + numeric example).

Each theorem and its docstring now sits wholly within one section. Diff is +4/−4 to meta.json; no content removed. JSON validated via the gallery build; no annotation warnings for this entry.