### PR TITLE
research(erdos-1038-wip-01): formalize the supremum object + provable bound 2√2 ≤ sublevelSup [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos1038WIP01.lean
+++ b/proofs/Proofs/Erdos1038WIP01.lean
@@ -17,6 +17,8 @@
   * `mem_sublevelSet_quadratic`   — `x ∈ sublevelSet (x²−1) ↔ 0 < x² ∧ x² < 2`.
   * `sublevelSet_quadratic`       — `= Set.Ioo (−√2) √2 ∖ {0}`.
   * `sublevelMeasure_quadratic`   — `= ENNReal.ofReal (2√2)`.
+  * `sublevelSup`                 — the supremum of sublevel measures over admissible `f`.
+  * `le_sublevelSup`              — `2√2 ≤ sublevelSup` (the provable half of `= 2√2`).
 
   All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -96,5 +98,20 @@ theorem sublevelMeasure_quadratic :
   rw [sublevelSet_quadratic, measure_diff_null (by simp), Real.volume_Ioo]
   congr 1
   ring
+
+/-- The **supremum of sublevel-set measures** over all admissible monic polynomials
+    (monic, all roots real and in `[-1,1]`).  Erdős–Herzog–Piranian (1958) conjectured
+    and Tao (2025) proved this supremum equals `2√2`.  It is introduced here as a Lean
+    object so the extremal witness can be tied to it. -/
+noncomputable def sublevelSup : ℝ≥0∞ :=
+  ⨆ (f : Polynomial ℝ) (_ : MonicRealRootedIn01 f), sublevelMeasure f
+
+/-- **Supremum lower bound: `2√2 ≤ sublevelSup`.**  The admissible quadratic `x² − 1`
+    attains sublevel measure `2√2`, so the supremum is at least `2√2`.  This is the
+    machine-checkable half of the Erdős–Herzog–Piranian/Tao result `sublevelSup = 2√2`;
+    the matching *upper* bound needs logarithmic potential theory beyond Mathlib and is
+    not attempted here. -/
+theorem le_sublevelSup : ENNReal.ofReal (2 * Real.sqrt 2) ≤ sublevelSup :=
+  le_iSup_of_le q (le_iSup_of_le quadratic_admissible sublevelMeasure_quadratic.ge)
 
 end Erdos1038WIP01

--- a/research/problems/erdos-1038-wip-01/knowledge.md
+++ b/research/problems/erdos-1038-wip-01/knowledge.md
@@ -1,0 +1,26 @@
+# Erdős #1038 WIP-01 — Knowledge Base
+
+## Problem
+
+Supremum/infimum of |{x : |f(x)| < 1}| over non-constant monic polynomials with all
+roots real in [-1,1]. Sup = 2√2 (Erdős–Herzog–Piranian 1958 conjecture, Tao 2025 proof).
+The extremal witness is (the limit of polynomials approaching) x²−1.
+
+## Session 2026-07-08 (researcher-1) — formalize the supremum object + provable lower bound
+
+The predecessor file `Erdos1038WIP01.lean` proved the extremal quadratic's sublevel
+measure is exactly 2√2 but never connected it to "the supremum". Added:
+- `sublevelSup := ⨆ (f) (_ : MonicRealRootedIn01 f), sublevelMeasure f` — the extremal
+  quantity as a Lean object (first time it is defined).
+- `le_sublevelSup : ENNReal.ofReal (2√2) ≤ sublevelSup` — the machine-checkable HALF of
+  Tao's `sublevelSup = 2√2`. One-liner: `le_iSup_of_le q (le_iSup_of_le
+  quadratic_admissible sublevelMeasure_quadratic.ge)`. The matching UPPER bound
+  (= 2√2) needs logarithmic potential theory beyond Mathlib — documented, not attempted.
+
+Verified 0 axioms / 0 sorries; built via docker wrapper on retry 3 (shared-volume cache
+corruption: line-less exit-135 then `UniqueFactorizationDomain/Basic.olean.private invalid
+header`, healed across retries as the failure point advanced 1.3s→8.1s→green). Pre-existing
+linter note at L85 (`simpa using h0`) is in the original code, harmless.
+
+Status: the provable direction of the headline sup=2√2 is now formalized. Upper bound and
+the infimum exact value (2^(4/3)−1 ≤ inf ≤ 1.835) remain OPEN/blocked (potential theory).

--- a/research/problems/erdos-1038-wip-01/state.md
+++ b/research/problems/erdos-1038-wip-01/state.md
@@ -1,0 +1,30 @@
+# Current State
+
+**Phase**: MAKING PROGRESS
+**Since**: 2026-07-08
+**Iteration**: 2
+
+## Current Focus
+
+Formalized the supremum object `sublevelSup` and the provable half `2√2 ≤ sublevelSup`
+(Erdős–Herzog–Piranian/Tao) on top of the existing extremal-quadratic computation.
+
+## Active Approach
+
+Elementary/measure-theoretic: the admissible quadratic x²−1 attains 2√2, so `le_iSup_of_le`
+gives the supremum lower bound directly. No axioms.
+
+## Blockers
+
+Upper bound `sublevelSup ≤ 2√2` needs logarithmic potential theory (Tao 2025) absent from
+Mathlib. Infimum exact value open (2^(4/3)−1 ≤ inf ≤ 1.835).
+
+## Next Action
+
+None tractable without potential-theory infrastructure. The provable direction is done.
+
+## Attempt Counts
+
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 2

--- a/src/data/research/problems/erdos-1038-wip-01.json
+++ b/src/data/research/problems/erdos-1038-wip-01.json
@@ -14,7 +14,10 @@
     ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "sublevelSup: the supremum of sublevel-set measures over admissible monic polynomials, introduced as a Lean object (⨆ over MonicRealRootedIn01 f of sublevelMeasure f).",
+      "le_sublevelSup: 2√2 ≤ sublevelSup — the machine-checkable HALF of the Erdős–Herzog–Piranian (1958) / Tao (2025) result sublevelSup = 2√2. The extremal quadratic x²−1 attains 2√2, so the supremum is at least 2√2 (via le_iSup_of_le with the quadratic witness). The matching upper bound needs logarithmic potential theory beyond Mathlib and is not attempted."
+    ],
     "open": [],
     "goal": ""
   },


### PR DESCRIPTION
## Summary

The extremal-quadratic file for Erdős #1038 (`Erdos1038WIP01.lean`) computed `|{x : |x²−1| < 1}| = 2√2` but never connected it to *the supremum* of the problem. This PR introduces the supremum as a Lean object and proves the machine-checkable half of the headline result.

Erdős #1038: over non-constant monic polynomials with all roots real in `[-1,1]`, the supremum of `|{x : |f(x)| < 1}|` is `2√2` (Erdős–Herzog–Piranian 1958 conjecture; Tao 2025 proof).

## What's new (2 declarations, 0 axioms / 0 sorries)

- `sublevelSup := ⨆ (f) (_ : MonicRealRootedIn01 f), sublevelMeasure f` — the extremal quantity of #1038, defined in Lean for the first time.
- `le_sublevelSup : ENNReal.ofReal (2√2) ≤ sublevelSup` — the **provable half** of `sublevelSup = 2√2`. The admissible quadratic `x²−1` attains sublevel measure `2√2` (existing `sublevelMeasure_quadratic`), so the supremum is at least `2√2` via `le_iSup_of_le`. The matching **upper** bound needs logarithmic potential theory beyond Mathlib (Tao 2025) and is documented, not attempted.

## Verification

Built clean via the Docker wrapper (`Proofs.Erdos1038WIP01`, 7743 jobs) after transient shared-volume cache corruption healed across retries. 0 sorries, 0 axiom declarations, no `native_decide`.

## Status

The provable direction of the headline `sup = 2√2` is now formalized. The upper bound and the infimum's exact value (`2^(4/3)−1 ≤ inf ≤ 1.835`) remain **OPEN/blocked** (potential theory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)