### PR TITLE
audit(erdos-771): reconcile stale '7 sorries' prose to actual 0-sorry file

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16224,9 +16224,9 @@
     },
     "erdos-771": {
       "agentId": "auditor-agent",
-      "auditCount": 5,
-      "lastAudited": "2026-07-08T05:29:02Z",
-      "result": "clean"
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T17:28:05Z",
+      "result": "issues-fixed"
     },
     "erdos-771-construction": {
       "auditCount": 1,
@@ -29589,5 +29589,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T17:18:11Z"
+  "lastUpdated": "2026-07-08T17:28:05Z"
 }

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -63,17 +63,17 @@
       "AvoidSum, IsMAvoidingSet: m-avoidance predicates",
       "maxAvoidingSize: max card of m-avoiding set via sup over powerset",
       "f: the function f(n) = min over m of maxAvoidingSize(n,m)",
-      "f_property, f_characterization (sorry): characterization of f(n)",
+      "f_property, f_characterization (proved): characterization of f(n)",
       "expectedValue: (1/2)*n/log(n) for n > 1",
       "ErdosGrahamConjecture, ErdosGrahamConjecture': two formulations",
       "erdos_graham_lower_bound (axiom): f(n) >= (1/2-eps)*n/log n",
-      "primeMutliples, prime_multiples_size (sorry), prime_multiples_avoid (sorry): construction lemmas",
+      "primeMutliples, prime_multiples_size (proved), prime_multiples_avoid (proved): construction lemmas",
       "smallest_prime_bound (noted in comments): Bertrand's postulate",
       "alon_freiman_upper_bound (axiom): f(n) <= (1/2+eps)*n/log n",
       "lcm_up_to, lcm_estimate (unformalized), large_set_achieves_sum (unformalized): LCM tools",
-      "erdos_graham_conjecture_true (partial proof + sorry): combines both bounds",
-      "explicitBounds, leading_constant (sorry): explicit numerical bounds",
-      "m_eq_one_case (sorry), m_eq_two_case (sorry): special cases",
+      "erdos_graham_conjecture_true (proved from the two bound axioms): combines both bounds",
+      "explicitBounds, leading_constant (proved): explicit numerical bounds",
+      "m_eq_one_case (proved), m_eq_two_case (proved): special cases",
       "smallPrimeConstruction: practical construction via Nat.minFac",
       "IsSumFree, sum_free_upper_bound (unformalized): comparison with sum-free sets",
       "erdos_771, erdos_771_main, erdos_771_solved: main theorem statements"
@@ -90,10 +90,10 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Erdos Problem #771: Subsets Avoiding a Given Sum**\n\n**The Problem:**\nGiven n, what is the largest set S subset {1,...,n} such that for ANY prescribed target m, no nonempty subset of S sums to m? The function f(n) measures this worst-case avoidance capacity. Erdos and Graham conjectured f(n) = (1/2+o(1))n/log n.\n\n**The Lower Bound (Erdos-Graham):**\nFor any target m, take S = {multiples of p in [n]} where p is the smallest prime not dividing m. Every subset sum of S is divisible by p, but m is not, so S avoids m. The size |S| = floor(n/p). By the prime number theorem, the smallest prime not dividing m is at most (2+o(1))log m, giving |S| >= (1/2+o(1))n/log n. Bertrand's postulate guarantees such a prime exists.\n\n**The Upper Bound (Alon-Freiman, 1988):**\nThe clever target: choose m = lcm{1,...,s} where s is maximal with m small enough. By PNT, lcm{1,...,s} ~ e^s. Any set S larger than (1/2+o(1))n/log n must contain a nonempty subset summing to some multiple of each integer in {1,...,s}, which forces a subset sum equal to m.\n\n**Resolution:**\nThe conjecture is TRUE: f(n) = (1/2+o(1))n/log n. The constant 1/2 comes from the prime number theorem: the density of primes near x is 1/log x, so the smallest prime not dividing any given m is about 2 log m.\n\n**The Lean formalization** has 7 sorries (characterization of f, prime multiples properties, special cases, leading constant convergence, and the final epsilon-delta bridge). The structural framework is complete with the key axioms for the lower and upper bounds.",
+    "historicalContext": "**Erdos Problem #771: Subsets Avoiding a Given Sum**\n\n**The Problem:**\nGiven n, what is the largest set S subset {1,...,n} such that for ANY prescribed target m, no nonempty subset of S sums to m? The function f(n) measures this worst-case avoidance capacity. Erdos and Graham conjectured f(n) = (1/2+o(1))n/log n.\n\n**The Lower Bound (Erdos-Graham):**\nFor any target m, take S = {multiples of p in [n]} where p is the smallest prime not dividing m. Every subset sum of S is divisible by p, but m is not, so S avoids m. The size |S| = floor(n/p). By the prime number theorem, the smallest prime not dividing m is at most (2+o(1))log m, giving |S| >= (1/2+o(1))n/log n. Bertrand's postulate guarantees such a prime exists.\n\n**The Upper Bound (Alon-Freiman, 1988):**\nThe clever target: choose m = lcm{1,...,s} where s is maximal with m small enough. By PNT, lcm{1,...,s} ~ e^s. Any set S larger than (1/2+o(1))n/log n must contain a nonempty subset summing to some multiple of each integer in {1,...,s}, which forces a subset sum equal to m.\n\n**Resolution:**\nThe conjecture is TRUE: f(n) = (1/2+o(1))n/log n. The constant 1/2 comes from the prime number theorem: the density of primes near x is 1/log x, so the smallest prime not dividing any given m is about 2 log m.\n\n**The Lean formalization** has 0 sorries: the characterization of f, prime-multiples properties, special cases, leading-constant convergence, and the final epsilon-delta bridge are all proved outright. The only remaining assumptions are the two deep bounds (Erdos-Graham lower, Alon-Freiman upper), stated as the 2 axioms.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet f(n) be the maximum k such that for every m >= 1, there exists S subset {1,...,n} with |S| = k such that no nonempty subset of S sums to m.\n\n**Question:** Is f(n) = (1/2 + o(1)) * n / log n?\n\n**Answer: YES**\n\n- Lower bound: Erdos-Graham using prime multiples\n- Upper bound: Alon-Freiman (1988) using LCM argument\n\nThe constant 1/2 is exact.",
     "text": "Let f(n) be maximal such that for every m >= 1, there exists S subset {1,...,n} with |S| = f(n) where no subset of S sums to m. Is f(n) = (1/2+o(1))n/log n? SOLVED: YES (Erdos-Graham lower, Alon-Freiman upper).",
-    "proofStrategy": "**Formalization Architecture**\n\nThe formalization builds f(n) from first principles and establishes the asymptotic formula:\n\n1. **Basic Definitions** (Icc_n, subsetSums, AvoidSum, IsMAvoidingSet): Interval, subset sum enumeration via powerset, avoidance predicate\n\n2. **The Function f(n)** (maxAvoidingSize, f, f_property, f_characterization): Defined as min over m of max avoiding set size; characterization has sorry\n\n3. **The Conjecture** (ErdosGrahamConjecture, ErdosGrahamConjecture'): Two equivalent formulations of f(n) ~ (1/2)n/log n\n\n4. **Lower Bound** (erdos_graham_lower_bound axiom, primeMutliples, prime_multiples_avoid): Construction via multiples of prime not dividing m; 2 sorries for construction lemmas\n\n5. **Upper Bound** (alon_freiman_upper_bound axiom, lcm_up_to, lcm_estimate): LCM argument forcing large sets to hit a carefully chosen m\n\n6. **Main Result** (erdos_graham_conjecture_true): Combines bounds with epsilon/2 trick; final sorry for absolute value manipulation\n\n7. **Explicit Bounds and Special Cases**: Numerical bounds, m=1 and m=2 cases, leading constant convergence\n\n8. **Sum-Free Comparison**: IsSumFree definition and comparison: f(n) ~ n/(2 log n) vs n/3 for sum-free",
+    "proofStrategy": "**Formalization Architecture**\n\nThe formalization builds f(n) from first principles and establishes the asymptotic formula:\n\n1. **Basic Definitions** (Icc_n, subsetSums, AvoidSum, IsMAvoidingSet): Interval, subset sum enumeration via powerset, avoidance predicate\n\n2. **The Function f(n)** (maxAvoidingSize, f, f_property, f_characterization): Defined as min over m of max avoiding set size; characterization is proved\n\n3. **The Conjecture** (ErdosGrahamConjecture, ErdosGrahamConjecture'): Two equivalent formulations of f(n) ~ (1/2)n/log n\n\n4. **Lower Bound** (erdos_graham_lower_bound axiom, primeMutliples, prime_multiples_avoid): Construction via multiples of prime not dividing m; construction lemmas proved\n\n5. **Upper Bound** (alon_freiman_upper_bound axiom, lcm_up_to, lcm_estimate): LCM argument forcing large sets to hit a carefully chosen m\n\n6. **Main Result** (erdos_graham_conjecture_true): Combines bounds with epsilon/2 trick; absolute-value manipulation proved\n\n7. **Explicit Bounds and Special Cases**: Numerical bounds, m=1 and m=2 cases, leading constant convergence\n\n8. **Sum-Free Comparison**: IsSumFree definition and comparison: f(n) ~ n/(2 log n) vs n/3 for sum-free",
     "keyInsights": [
       "**Prime Multiples Construction**: Multiples of p not dividing m automatically avoid m, since all subset sums are divisible by p. This gives the lower bound with the prime number theorem providing p ~ 2 log n.",
       "**LCM Argument for Upper Bound**: Choosing m = lcm{1,...,s} exploits the fact that s is highly divisible. Any large enough set must have a nonempty subset summing to m by a pigeonhole/divisibility argument.",
@@ -120,8 +120,8 @@
       "title": "The Function f(n)",
       "startLine": 58,
       "endLine": 82,
-      "summary": "maxAvoidingSize (sup over powerset of avoiding sets), f (inf over m in [1,n^2] of maxAvoidingSize), f_property (universal avoidance characterization), f_characterization (sorry: f is maximal).",
-      "mathContext": "maxAvoidingSize (sup over powerset of avoiding sets), f (inf over m in [1,$n^{2}$] of maxAvoidingSize), f_property (universal avoidance characterization), f_characterization (sorry: f is maximal)."
+      "summary": "maxAvoidingSize (sup over powerset of avoiding sets), f (inf over m in [1,n^2] of maxAvoidingSize), f_property (universal avoidance characterization), f_characterization (proved: f is maximal).",
+      "mathContext": "maxAvoidingSize (sup over powerset of avoiding sets), f (inf over m in [1,$n^{2}$] of maxAvoidingSize), f_property (universal avoidance characterization), f_characterization (proved: f is maximal)."
     },
     {
       "id": "the-erdos-graham-conjecture",
@@ -136,8 +136,8 @@
       "title": "Erdos-Graham Lower Bound",
       "startLine": 103,
       "endLine": 132,
-      "summary": "erdos_graham_lower_bound (axiom): f(n) >= (1/2-eps)n/log n. primeMutliples (filter by divisibility), prime_multiples_size (sorry: card = n/p), prime_multiples_avoid (sorry: p prime and p not dividing m implies avoidance), smallest_prime_bound (noted in comments: Bertrand's postulate).",
-      "mathContext": "erdos_graham_lower_bound (axiom): f(n) >= (1/2-eps)n/log n. primeMutliples (filter by divisibility), prime_multiples_size (sorry: card = n/p), prime_multiples_avoid (sorry: p prime and p not dividing m implies avoidance), smallest_prime_bound (noted in comments: Bertrand's postulate)."
+      "summary": "erdos_graham_lower_bound (axiom): f(n) >= (1/2-eps)n/log n. primeMutliples (filter by divisibility), prime_multiples_size (proved: card = n/p), prime_multiples_avoid (proved: p prime and p not dividing m implies avoidance), smallest_prime_bound (noted in comments: Bertrand's postulate).",
+      "mathContext": "erdos_graham_lower_bound (axiom): f(n) >= (1/2-eps)n/log n. primeMutliples (filter by divisibility), prime_multiples_size (proved: card = n/p), prime_multiples_avoid (proved: p prime and p not dividing m implies avoidance), smallest_prime_bound (noted in comments: Bertrand's postulate)."
     },
     {
       "id": "alon-freiman-upper-bound",
@@ -152,24 +152,24 @@
       "title": "The Complete Answer",
       "startLine": 156,
       "endLine": 175,
-      "summary": "erdos_graham_conjecture_true (partial proof + sorry): combines lower/upper bounds with epsilon/2. f_asymptotic: alias. The conjecture is TRUE.",
-      "mathContext": "erdos_graham_conjecture_true (partial proof + sorry): combines lower/upper bounds with $\\varepsilon$/2. f_asymptotic: alias. The conjecture is TRUE."
+      "summary": "erdos_graham_conjecture_true (proved from the two bound axioms): combines lower/upper bounds with epsilon/2. f_asymptotic: alias. The conjecture is TRUE.",
+      "mathContext": "erdos_graham_conjecture_true (proved from the two bound axioms): combines lower/upper bounds with $\\varepsilon$/2. f_asymptotic: alias. The conjecture is TRUE."
     },
     {
       "id": "explicit-bounds",
       "title": "Explicit Bounds",
       "startLine": 176,
       "endLine": 190,
-      "summary": "explicitBounds: 0.4*n/log n <= f(n) <= 0.6*n/log n for n >= 10. leading_constant (sorry): f(n)/(n/log n) -> 1/2 via Filter.Tendsto.",
-      "mathContext": "explicitBounds: 0.4*n/$\\log n$ <= f(n) <= 0.6*n/$\\log n$ for n >= 10. leading_constant (sorry): f(n)/(n/$\\log n$) -> 1/2 via Filter.Tendsto."
+      "summary": "explicitBounds: 0.4*n/log n <= f(n) <= 0.6*n/log n for n >= 10. leading_constant (proved): f(n)/(n/log n) -> 1/2 via Filter.Tendsto.",
+      "mathContext": "explicitBounds: 0.4*n/$\\log n$ <= f(n) <= 0.6*n/$\\log n$ for n >= 10. leading_constant (proved): f(n)/(n/$\\log n$) -> 1/2 via Filter.Tendsto."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "startLine": 191,
       "endLine": 209,
-      "summary": "m_eq_one_case (sorry): maxAvoidingSize(n,1) = n-1. m_eq_two_case (sorry): >= n-2. smallPrimeConstruction: uses Nat.minFac(m+1) for practical construction.",
-      "mathContext": "Mathematical content: m_eq_one_case (sorry): maxAvoidingSize(n,1) = n-1. m_eq_two_case (sorry): >= n-2. smallPrimeConstruction: uses Nat.minFac(m+1) for practical construction."
+      "summary": "m_eq_one_case (proved): maxAvoidingSize(n,1) = n-1. m_eq_two_case (proved): >= n-2. smallPrimeConstruction: uses Nat.minFac(m+1) for practical construction.",
+      "mathContext": "Mathematical content: m_eq_one_case (proved): maxAvoidingSize(n,1) = n-1. m_eq_two_case (proved): >= n-2. smallPrimeConstruction: uses Nat.minFac(m+1) for practical construction."
     },
     {
       "id": "connection-to-sum-free-sets",
@@ -189,7 +189,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdos Problem #771 asks whether f(n) = (1/2+o(1))n/log n, where f(n) is the maximum size of a subset of {1,...,n} that can avoid any prescribed sum m. The conjecture is TRUE: Erdos-Graham proved the lower bound using prime multiples, and Alon-Freiman (1988) proved the matching upper bound using an LCM argument. The formalization has 7 sorries in construction lemmas and epsilon-delta bridges, with the key results axiomatized.",
+    "summary": "Erdos Problem #771 asks whether f(n) = (1/2+o(1))n/log n, where f(n) is the maximum size of a subset of {1,...,n} that can avoid any prescribed sum m. The conjecture is TRUE: Erdos-Graham proved the lower bound using prime multiples, and Alon-Freiman (1988) proved the matching upper bound using an LCM argument. The formalization has 0 sorries: the construction lemmas and epsilon-delta bridges are all proved, with only the two deep bounds (Erdos-Graham lower, Alon-Freiman upper) axiomatized.",
     "implications": "1. **Prime Number Theory**: The constant 1/2 arises directly from prime density via PNT, connecting additive combinatorics to analytic number theory\n\n**2. LCM Estimates**: The upper bound uses lcm{1,...,s} ~ e^s, a fundamental estimate in multiplicative number theory\n\n3. **Subset Sum Problems**: Part of the broader study of which target sums can be avoided by large subsets of integers\n\n4. **Sum-Free Comparison**: The contrast f(n) ~ n/(2 log n) vs n/3 quantifies the gap between avoiding one sum and avoiding all internal sums.",
     "openQuestions": [
       "What are explicit constants in the o(1) term for f(n)?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-771 (Subsets Avoiding a Given Sum)
**Severity**: HIGH (self-contradictory public prose; safe direction — understates)

## Evidence

`proofs/Proofs/Erdos771Problem.lean` has **0 sorries**. Every theorem named in the meta prose is proved with a real tactic block:

- `f_characterization`, `prime_multiples_size`, `prime_multiples_avoid`, `erdos_graham_conjecture_true`, `leading_constant`, `m_eq_one_case`, `m_eq_two_case` — all `:= by …`, verified `grep -c "\bsorry\b"` (comment-stripped) = 0.

The only assumptions are the **2 axioms** `erdos_graham_lower_bound` and `alon_freiman_upper_bound` (status `axiomatized`, badge `axiom`, `axiomCount=2` — all correct).

**Numeric fields were already correct** (`meta.sorries=0`, `leanFile.sorries=0`). The **descriptive prose** was stale from an earlier multi-sorry version:

- `overview.historicalContext` / `conclusion.summary`: "**has 7 sorries**" — directly contradicts the same page's "0 sorries".
- `overview.proofStrategy`: "characterization has sorry", "2 sorries for construction lemmas", "final sorry for absolute value manipulation".
- `sections[1/3/5/6/7]` summary+mathContext and `originalContributions[5/9/13/14/15]`: theorems annotated "(sorry)".

## Fix

Reconciled 13 prose fields: `(sorry)` → `(proved)` / `(proved from the two bound axioms)`, and "7 sorries" → "0 sorries" with the two deep bounds noted as the sole (axiomatized) assumptions. No status/badge/axiom/sorry-count changes.

---
Discovered during gallery integrity re-audit (metas changed since last audit). Tracker updated: erdos-771 → issues-fixed.