### PR TITLE
Enrich Erdős #897 OQ-01 (quality 53→): fix invisible conclusion/cross-ref + deepen annotations

### DIFF
--- a/src/data/proofs/erdos-897-oq-01/annotations.json
+++ b/src/data/proofs/erdos-897-oq-01/annotations.json
@@ -8,7 +8,20 @@
     },
     "type": "concept",
     "title": "Part I of Erdős #897 — what is proved and what is not",
-    "content": "**Part I (OPEN)** of Erdős #897 asks: if an additive `f` satisfies `limsup_{p,k} f(p^k)/log(p^k) = ∞`, must `limsup_n (f(n+1)−f(n))/log n = ∞`? This file does **not** assert Part I. It proves the verified surrounding theory: a non-vacuity witness, selectivity against the classical examples, plain unboundedness, and a strongly-additive reduction. All results are axiom-free with 0 sorries."
+    "content": "**Part I (OPEN)** of Erdős #897 asks: if an additive `f` satisfies `limsup_{p,k} f(p^k)/log(p^k) = ∞`, must `limsup_n (f(n+1)−f(n))/log n = ∞`? This file does **not** assert Part I. It proves the verified surrounding theory: a non-vacuity witness, selectivity against the classical examples, plain unboundedness, and a strongly-additive reduction. All results are axiom-free with 0 sorries.",
+    "mathContext": "$\\displaystyle\\limsup_{p,k}\\frac{f(p^k)}{\\log(p^k)}=\\infty \\;\\overset{?}{\\Longrightarrow}\\; \\limsup_{n}\\frac{f(n+1)-f(n)}{\\log n}=\\infty$ — Part I, OPEN and deliberately not asserted; only the four verified deliverables below are established.",
+    "significance": "context",
+    "relatedConcepts": [
+      "additive arithmetic functions",
+      "Erdős problems",
+      "limsup growth conditions",
+      "consecutive differences of arithmetic functions"
+    ],
+    "prerequisites": [
+      "additive and strongly additive functions",
+      "limsup of a sequence",
+      "prime powers"
+    ]
   },
   {
     "id": "ann-e897oq01-logsqweight",
@@ -19,7 +32,19 @@
     },
     "type": "definition",
     "title": "The witness `logSqWeight`",
-    "content": "`logSqWeight n = ∑_{p ∈ primeFactors n} (log p)²`. On a prime power `p^k` its value is `(log p)²` (independent of `k`), while `log(p^k) = k·log p`. This gap is what makes it grow faster than `log` on prime powers."
+    "content": "`logSqWeight n = ∑_{p ∈ primeFactors n} (log p)²`. On a prime power `p^k` its value is `(log p)²` (independent of `k`), while `log(p^k) = k·log p`. This gap is what makes it grow faster than `log` on prime powers.",
+    "mathContext": "$\\mathrm{logSqWeight}(n)=\\sum_{p\\mid n}(\\log p)^2$; on a prime power $\\mathrm{logSqWeight}(p^k)=(\\log p)^2$ is constant in $k$, whereas $\\log(p^k)=k\\log p$, so the ratio $(\\log p)^2/(k\\log p)=(\\log p)/k$ is unbounded over primes at $k=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "strongly additive functions",
+      "prime factorization",
+      "arithmetic weight functions"
+    ],
+    "prerequisites": [
+      "Nat.primeFactors",
+      "the real logarithm",
+      "Finset.sum"
+    ]
   },
   {
     "id": "ann-e897oq01-additive",
@@ -30,7 +55,18 @@
     },
     "type": "theorem",
     "title": "`logSqWeight` is (strongly) additive",
-    "content": "Additivity follows because coprime numbers have disjoint prime supports, so the defining sum splits over a coprime product. Strong additivity follows from `(p^k).primeFactors = p.primeFactors`, giving `logSqWeight(p^k) = logSqWeight(p) = (log p)²`."
+    "content": "Additivity follows because coprime numbers have disjoint prime supports, so the defining sum splits over a coprime product. Strong additivity follows from `(p^k).primeFactors = p.primeFactors`, giving `logSqWeight(p^k) = logSqWeight(p) = (log p)²`.",
+    "mathContext": "Additive: $f(ab)=f(a)+f(b)$ for $\\gcd(a,b)=1$; strongly additive additionally requires $f(p^k)=f(p)$. Here $\\{p:p\\mid ab\\}=\\{p:p\\mid a\\}\\sqcup\\{p:p\\mid b\\}$ for coprime $a,b$, and $(p^k).\\mathrm{primeFactors}=\\{p\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "additive vs strongly additive functions",
+      "coprimality and disjoint prime supports",
+      "Finset.sum_union"
+    ],
+    "prerequisites": [
+      "Nat.Coprime and primeFactors",
+      "sums over disjoint unions"
+    ]
   },
   {
     "id": "ann-e897oq01-nonvacuity",
@@ -41,7 +77,19 @@
     },
     "type": "theorem",
     "title": "Non-vacuity: the hypothesis is satisfiable",
-    "content": "`logSqWeight` satisfies `UnboundedOnPrimePowers`: at `k = 1`, `(log p)² > M·log p` whenever `log p > M`, and a prime past `exp M` (via `Nat.exists_infinite_primes`) achieves this. Hence `exists_additive_unboundedOnPrimePowers` — Part I is **not vacuously true**."
+    "content": "`logSqWeight` satisfies `UnboundedOnPrimePowers`: at `k = 1`, `(log p)² > M·log p` whenever `log p > M`, and a prime past `exp M` (via `Nat.exists_infinite_primes`) achieves this. Hence `exists_additive_unboundedOnPrimePowers` — Part I is **not vacuously true**.",
+    "mathContext": "For any $M$ pick a prime $p>e^{M}$, so $\\log p>M$ and $(\\log p)^2>M\\log p$; thus $\\mathrm{logSqWeight}(p^1)>M\\log(p^1)$, witnessing $\\mathrm{UnboundedOnPrimePowers}$ and hence $\\exists$ an additive function satisfying the #897 hypothesis.",
+    "significance": "key",
+    "relatedConcepts": [
+      "non-vacuous conditional hypotheses",
+      "explicit existence witness",
+      "infinitude of primes"
+    ],
+    "prerequisites": [
+      "Nat.exists_infinite_primes",
+      "unboundedness on prime powers",
+      "monotonicity of exp/log"
+    ]
   },
   {
     "id": "ann-e897oq01-selectivity-log",
@@ -52,7 +100,17 @@
     },
     "type": "theorem",
     "title": "Selectivity: `log` fails the hypothesis",
-    "content": "`logN(p^k) = log(p^k)` exactly, so it never strictly exceeds `1·log(p^k)`. The logarithm sits precisely at the boundary of the growth condition and does not satisfy it."
+    "content": "`logN(p^k) = log(p^k)` exactly, so it never strictly exceeds `1·log(p^k)`. The logarithm sits precisely at the boundary of the growth condition and does not satisfy it.",
+    "mathContext": "$\\log(p^k)/\\log(p^k)=1$ for every prime power, so with multiplier $M=1$ the strict inequality $\\log(p^k)>1\\cdot\\log(p^k)$ is impossible: $\\log$ sits exactly at the boundary, $\\neg\\,\\mathrm{UnboundedOnPrimePowers}(\\log)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "boundary growth case",
+      "completely additive logarithm",
+      "Real.log_pow"
+    ],
+    "prerequisites": [
+      "Real.log_pow ($\\log(p^k)=k\\log p$)"
+    ]
   },
   {
     "id": "ann-e897oq01-selectivity-omega",
@@ -63,7 +121,18 @@
     },
     "type": "theorem",
     "title": "Selectivity: `ω` fails the hypothesis",
-    "content": "`ω(p^k) = 1` is bounded on prime powers. With `M = 2/log 2` the required inequality `ω(p^k) > M·log(p^k)` would force `1 > 2`. So the hypothesis isolates functions growing strictly faster than `log`."
+    "content": "`ω(p^k) = 1` is bounded on prime powers. With `M = 2/log 2` the required inequality `ω(p^k) > M·log(p^k)` would force `1 > 2`. So the hypothesis isolates functions growing strictly faster than `log`.",
+    "mathContext": "$\\omega(p^k)=1$ (number of distinct prime factors) is bounded on prime powers; taking $M=2/\\log 2$ gives $M\\log(p^k)=2k\\ge 2$, so $\\omega(p^k)=1>2$ is impossible, hence $\\neg\\,\\mathrm{UnboundedOnPrimePowers}(\\omega)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "number of distinct prime factors ω",
+      "bounded arithmetic functions",
+      "strongly additive ω"
+    ],
+    "prerequisites": [
+      "ω(p^k)=1 (cardinality of primeFactors)",
+      "Real.log positivity"
+    ]
   },
   {
     "id": "ann-e897oq01-plain-unbounded",
@@ -74,7 +143,18 @@
     },
     "type": "theorem",
     "title": "The hypothesis forces plain unboundedness",
-    "content": "Because `log(p^k) ≥ log 2 > 0` uniformly, choosing `M = (|B|+1)/log 2` turns `f(p^k) > M·log(p^k)` into `f(p^k) > B`. So growth relative to `log` implies plain unboundedness on prime powers."
+    "content": "Because `log(p^k) ≥ log 2 > 0` uniformly, choosing `M = (|B|+1)/log 2` turns `f(p^k) > M·log(p^k)` into `f(p^k) > B`. So growth relative to `log` implies plain unboundedness on prime powers.",
+    "mathContext": "Every prime power satisfies $\\log(p^k)\\ge\\log 2>0$; taking $M=(|B|+1)/\\log 2\\ge 0$ yields $f(p^k)>M\\log(p^k)\\ge M\\log 2=|B|+1>B$, so $f$ is plainly unbounded on prime powers.",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniform positive lower bound",
+      "unboundedness on prime powers",
+      "growth relative to log"
+    ],
+    "prerequisites": [
+      "log monotonicity and $\\log 2>0$",
+      "prime powers are $\\ge 2$"
+    ]
   },
   {
     "id": "ann-e897oq01-reduction",
@@ -85,6 +165,17 @@
     },
     "type": "theorem",
     "title": "Strongly-additive reduction to the primes",
-    "content": "For strongly additive `f`, `f(p^k) = f(p)` is constant in `k`, so `UnboundedOnPrimePowers f ⇔ ∀ M, ∃ prime p, f(p) > M·log p`. Forward: for `M ≥ 0` drop the factor `k ≥ 1`; for `M < 0` invoke the hypothesis at `0` (then `f(p) > 0 ≥ M·log p`). Reverse: take `k = 1`. This is the strongly-additive counterpart of the parent's completely-additive reduction."
+    "content": "For strongly additive `f`, `f(p^k) = f(p)` is constant in `k`, so `UnboundedOnPrimePowers f ⇔ ∀ M, ∃ prime p, f(p) > M·log p`. Forward: for `M ≥ 0` drop the factor `k ≥ 1`; for `M < 0` invoke the hypothesis at `0` (then `f(p) > 0 ≥ M·log p`). Reverse: take `k = 1`. This is the strongly-additive counterpart of the parent's completely-additive reduction.",
+    "mathContext": "For strongly additive $f$ (so $f(p^k)=f(p)$): $\\mathrm{UnboundedOnPrimePowers}(f)\\iff \\forall M,\\ \\exists\\text{ prime }p,\\ f(p)>M\\log p$. The $M<0$ branch is closed by applying the hypothesis at $k=0$, giving $f(p)>0\\ge M\\log p$; the reverse specializes to $k=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reduction to prime values",
+      "completely-additive reduction (parent entry)",
+      "strong additivity"
+    ],
+    "prerequisites": [
+      "strong additivity $f(p^k)=f(p)$",
+      "the growth hypothesis UnboundedOnPrimePowers"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -111,7 +111,15 @@
       "summary": "For strongly additive f the hypothesis is equivalent to f(p)/log p unbounded over the primes."
     }
   ],
-  "conclusion": "This companion nails down the theory Part I of Erdős #897 rests on: the growth hypothesis is non-vacuous (logSqWeight witnesses it), selective (log and ω fail it), forces plain unboundedness, and — for strongly additive f — reduces to a statement about the primes alone. The forward implication of Part I itself remains OPEN and is not asserted. Verified, 0 axioms, 0 sorries.",
+  "conclusion": {
+    "summary": "This companion nails down the theory Part I of Erdős #897 rests on: the growth hypothesis limsup_{p,k} f(p^k)/log(p^k) = ∞ is non-vacuous (logSqWeight(n) = ∑_{p|n}(log p)² witnesses it), selective (the classical additive functions log and ω both fail it), forces f plainly unbounded on prime powers, and — for strongly additive f — reduces to a statement about the primes alone (f(p)/log p unbounded). The forward implication of Part I itself remains OPEN and is not asserted. Verified, 0 axioms, 0 sorries.",
+    "implications": "Establishes that Part I is a genuine, non-trivial conditional: its hypothesis is satisfiable yet excludes the standard additive functions, so any proof of Part I must use more than the defining growth condition alone. The strongly-additive reduction localizes the hypothesis entirely to prime values, mirroring the parent entry's completely-additive reduction and narrowing where the open difficulty lives (the interplay between prime-power growth and consecutive-integer differences).",
+    "openQuestions": [
+      "Part I itself (OPEN): does limsup_{p,k} f(p^k)/log(p^k) = ∞ for additive f force limsup_n (f(n+1)−f(n))/log n = ∞?",
+      "Does the strongly-additive reduction extend to a corresponding reduction of the Part I *conclusion* (consecutive differences) to prime-indexed data?",
+      "Is there an additive witness satisfying the hypothesis for which the consecutive-difference limsup can be computed or bounded explicitly, testing Part I on a concrete family beyond logSqWeight?"
+    ]
+  },
   "leanFile": {
     "path": "Proofs/Erdos897OQ01.lean",
     "imports": [
@@ -129,8 +137,32 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-897",
-      "reason": "Parent formalization: definitions of additive/strongly/completely additive, Wirsing's converse, and the completely-additive reduction this file mirrors."
+      "targetId": "erdos-897",
+      "relationship": "parent",
+      "description": "Parent formalization: definitions of additive / strongly additive / completely additive functions, Wirsing's 1970 converse, and the completely-additive reduction that this file's strongly-additive reduction (stronglyAdditive_unboundedOnPrimePowers_iff) mirrors."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "Erdős Problem #897",
+      "year": "1990s",
+      "venue": "erdosproblems.com/897",
+      "note": "The open problem on additive functions growing faster than log on prime powers and their consecutive differences."
+    },
+    {
+      "authors": "Wirsing, Eduard",
+      "title": "Das asymptotische Verhalten von Summen über multiplikative Funktionen II",
+      "year": "1967",
+      "venue": "Acta Mathematica Academiae Scientiarum Hungaricae 18",
+      "note": "Mean-value and growth theory for additive/multiplicative functions; source of the converse-direction context formalized in the parent entry."
+    },
+    {
+      "authors": "Elliott, Peter D. T. A.",
+      "title": "Probabilistic Number Theory I: Mean-Value Theorems",
+      "year": "1979",
+      "venue": "Grundlehren der mathematischen Wissenschaften 239, Springer",
+      "note": "Standard reference for additive arithmetic functions, the ω function, and growth conditions relative to log."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `erdos-897-oq-01` (Part I of Erdős #897 — verified surrounding theory for an OPEN problem). This was a low-quality entry (score 53) with **three invisible-content rendering bugs** plus shallow annotations:

- **`conclusion` was a bare string** — but `ProofConclusion.tsx` reads `conclusion.summary`/`.implications`/`.openQuestions`, so the whole conclusion block rendered **blank** on the site. Converted to a `{summary, implications, openQuestions}` object; since Part I is OPEN, added 3 genuine open questions (Part I itself, extending the reduction to the conclusion, and a concrete test family).
- **`crossReferences` used `{slug, reason}`** — filtered out entirely by `normalizeCrossReferences` (the exact class fixed in #35345), so the parent `erdos-897` link never rendered. Converted to `{targetId, relationship, description}`.
- **The 8 annotations had none of `mathContext`/`significance`/`relatedConcepts`/`prerequisites`** — the main quality gap. Added all four to every annotation: LaTeX math context (the growth ratios, the M<0 branch, the ω/log boundary cases), significance tiers, and concept/prereq links.
- Added a `references` array (Erdős #897, Wirsing 1967, Elliott 1979).

All 8 annotation ranges already land on their theorems; no content removed. meta.json 12.0 KB, annotations 8.4 KB (both well under caps). JSON validated via the gallery build; no warnings for this entry.

_(Pushed on a distinct branch to avoid clobbering my still-open PR #35351.)_