### PR TITLE
Fix invisible slug/relation cross-references across 37 gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -26,9 +26,9 @@
   },
   "crossReferences": [
     {
-      "slug": "abel-ruffini-oq-04-oq-01-oq-01",
-      "relation": "parent",
-      "note": "Parent shows complex conjugation is an even double transposition for x⁵ - x - 1 (one real root) and flags the Dedekind mod-2 route as the correct way to obtain a transposition; this entry formalizes that route for p = 2."
+      "targetId": "abel-ruffini-oq-04-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent shows complex conjugation is an even double transposition for x⁵ - x - 1 (one real root) and flags the Dedekind mod-2 route as the correct way to obtain a transposition; this entry formalizes that route for p = 2."
     }
   ],
   "overview": {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/meta.json
@@ -25,9 +25,9 @@
   },
   "crossReferences": [
     {
-      "slug": "abel-ruffini-oq-04-oq-01",
-      "relation": "parent",
-      "note": "Parent proves Gal(x⁵ - 4x + 2) ≅ S₅; this entry addresses its open question about the alternate witness x⁵ - x - 1."
+      "targetId": "abel-ruffini-oq-04-oq-01",
+      "relationship": "parent",
+      "description": "Parent proves Gal(x⁵ - 4x + 2) ≅ S₅; this entry addresses its open question about the alternate witness x⁵ - x - 1."
     }
   ],
   "overview": {

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/meta.json
@@ -91,12 +91,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "baire-category-theorem-oq-01-oq-01",
-      "relationship": "Sibling entry deriving the Uniform Boundedness Principle from the same gallery Baire theorem; this entry resolves its lead open question by supplying the other two pillars (open mapping and closed graph)."
+      "targetId": "baire-category-theorem-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling entry deriving the Uniform Boundedness Principle from the same gallery Baire theorem; this entry resolves its lead open question by supplying the other two pillars (open mapping and closed graph)."
     },
     {
-      "slug": "baire-category-theorem-oq-01",
-      "relationship": "Grandparent entry providing the Baire category theorem (baire_nonempty_interior) on which the single Baire step of this derivation rests."
+      "targetId": "baire-category-theorem-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent entry providing the Baire category theorem (baire_nonempty_interior) on which the single Baire step of this derivation rests."
     }
   ],
   "references": [

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-01/meta.json
@@ -89,8 +89,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "baire-category-theorem-oq-01",
-      "relationship": "Parent entry providing the Baire category theorem (baire_nonempty_interior) that this derivation is built on; this resolves its lead open question."
+      "targetId": "baire-category-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry providing the Baire category theorem (baire_nonempty_interior) that this derivation is built on; this resolves its lead open question."
     }
   ],
   "references": [

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-02-oq-02/meta.json
@@ -98,13 +98,13 @@
   ],
   "crossReferences": [
     {
-      "slug": "baire-category-theorem-oq-01-oq-02",
-      "relation": "parent",
+      "targetId": "baire-category-theorem-oq-01-oq-02",
+      "relationship": "parent",
       "description": "The parent bounds the cardinality of a perfect space (whole space with no isolated points) below by 𝔠 via the Cantor scheme. This child removes the 'perfect space' hypothesis: Cantor–Bendixson extracts a perfect kernel from any uncountable Polish space, proves it uncountable, and applies the parent's bound to it."
     },
     {
-      "slug": "baire-category-theorem-oq-01",
-      "relation": "ancestor",
+      "targetId": "baire-category-theorem-oq-01",
+      "relationship": "ancestor",
       "description": "The grandparent establishes bare uncountability of a complete metric space with no isolated points via Baire category; this entry reaches the Cantor–Bendixson form for arbitrary uncountable Polish spaces."
     }
   ],

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-02/meta.json
@@ -97,8 +97,8 @@
   ],
   "crossReferences": [
     {
-      "slug": "baire-category-theorem-oq-01",
-      "relation": "parent",
+      "targetId": "baire-category-theorem-oq-01",
+      "relationship": "parent",
       "description": "The parent entry derives the bare uncountability of a complete metric space with no isolated points (via meagreness); this child sharpens uncountability to the explicit cardinal floor 𝔠 ≤ #α."
     }
   ],

--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/meta.json
@@ -132,8 +132,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "banach-steinhaus-theorem-oq-01",
-      "relation": "Parent entry: states the uniform boundedness principle and the `resonance` contrapositive whose open question (comeagre resonance set) this entry answers."
+      "targetId": "banach-steinhaus-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry: states the uniform boundedness principle and the `resonance` contrapositive whose open question (comeagre resonance set) this entry answers."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/connected-space-oq-01-oq-01/meta.json
+++ b/src/data/proofs/connected-space-oq-01-oq-01/meta.json
@@ -139,8 +139,9 @@
   },
   "crossReferences": [
     {
-      "slug": "connected-space-oq-01",
-      "reason": "Parent entry: closure preserves connectedness; this entry answers its open question on path-connectedness."
+      "targetId": "connected-space-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry: closure preserves connectedness; this entry answers its open question on path-connectedness."
     }
   ],
   "references": [

--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-02/meta.json
@@ -137,9 +137,9 @@
   },
   "crossReferences": [
     {
-      "slug": "descartes-circle-theorem-oq-01",
-      "title": "Descartes Circle Theorem (Soddy Curvatures over ℝ)",
-      "relationship": "Parent entry. Establishes the real-valued curvature relation `descartesRel`, solves it as a quadratic to recover the two Soddy curvatures (a+b+c)±2√(ab+bc+ca), and records the Vieta relations that this leaf reuses over ℤ via the cast bridge."
+      "targetId": "descartes-circle-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry. Establishes the real-valued curvature relation `descartesRel`, solves it as a quadratic to recover the two Soddy curvatures (a+b+c)±2√(ab+bc+ca), and records the Vieta relations that this leaf reuses over ℤ via the cast bridge."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -116,24 +116,24 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01",
-      "relation": "parent",
-      "note": "The Zolotarev–Frobenius identity sign(x ↦ a·x on ℤ/n) = J(a|n) for every odd n; this entry answers that capstone's first follow-up question by specializing it (per residue line) to derive quadratic reciprocity via the shuffle permutation, and supplies the combinatorial transpose sign the whole family had delegated to Mathlib."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The Zolotarev–Frobenius identity sign(x ↦ a·x on ℤ/n) = J(a|n) for every odd n; this entry answers that capstone's first follow-up question by specializing it (per residue line) to derive quadratic reciprocity via the shuffle permutation, and supplies the combinatorial transpose sign the whole family had delegated to Mathlib."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
-      "relation": "ancestor",
-      "note": "Defines ZolotarevCRT.ringMulPerm and the per-residue multiplication-permutation machinery used here through the parent Frobenius identity for the per-line signs."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+      "relationship": "ancestor",
+      "description": "Defines ZolotarevCRT.ringMulPerm and the per-residue multiplication-permutation machinery used here through the parent Frobenius identity for the per-line signs."
     },
     {
-      "slug": "quadratic-reciprocity",
-      "relation": "related",
-      "note": "The same law (q/p)·(p/q) = (-1)^((p-1)/2·(q-1)/2) stated and proved as the gallery's canonical Law of Quadratic Reciprocity. This entry is a complementary, self-contained derivation via permutation signs (Zolotarev) that deliberately avoids Mathlib's legendreSym.quadratic_reciprocity."
+      "targetId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The same law (q/p)·(p/q) = (-1)^((p-1)/2·(q-1)/2) stated and proved as the gallery's canonical Law of Quadratic Reciprocity. This entry is a complementary, self-contained derivation via permutation signs (Zolotarev) that deliberately avoids Mathlib's legendreSym.quadratic_reciprocity."
     },
     {
-      "slug": "quadratic-gauss-sum-square",
-      "relation": "related",
-      "note": "An alternative analytic route to quadratic reciprocity through the quadratic Gauss sum g = Σ (a/p) ζ^a, whose square g² = (-1)^((p-1)/2) p underlies the Gauss-sum proof — contrast with the purely combinatorial sign/inversion-count argument used here."
+      "targetId": "quadratic-gauss-sum-square",
+      "relationship": "related",
+      "description": "An alternative analytic route to quadratic reciprocity through the quadratic Gauss sum g = Σ (a/p) ζ^a, whose square g² = (-1)^((p-1)/2) p underlies the Gauss-sum proof — contrast with the purely combinatorial sign/inversion-count argument used here."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -113,14 +113,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01",
-      "relation": "parent",
-      "note": "The full odd-modulus Zolotarev–Frobenius identity sign(x ↦ a·x on ℤ/n) = J(a | n); this entry specializes it to a = -1, answering the parent's open question #3 (recover the supplementary laws as values of the Zolotarev sign character)."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The full odd-modulus Zolotarev–Frobenius identity sign(x ↦ a·x on ℤ/n) = J(a | n); this entry specializes it to a = -1, answering the parent's open question #3 (recover the supplementary laws as values of the Zolotarev sign character)."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
-      "relation": "ancestor",
-      "note": "Defines ZolotarevCRT.ringMulPerm and its multiplicativity, the permutation whose a = -1 instance (negation) is the subject of this entry."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+      "relationship": "ancestor",
+      "description": "Defines ZolotarevCRT.ringMulPerm and its multiplicativity, the permutation whose a = -1 instance (negation) is the subject of this entry."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -114,19 +114,19 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02",
-      "relation": "parent",
-      "note": "The second supplement J(2 | n) = (-1)^((n²-1)/8) (sign of doubling x ↦ 2·x); this entry fuses it with the first supplement to obtain the combined supplement a = -2, and reuses its jacobiSym_two and the octic power formula it established."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "The second supplement J(2 | n) = (-1)^((n²-1)/8) (sign of doubling x ↦ 2·x); this entry fuses it with the first supplement to obtain the combined supplement a = -2, and reuses its jacobiSym_two and the octic power formula it established."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
-      "relation": "sibling",
-      "note": "The first supplement J(-1 | n) = (-1)^((n-1)/2) (sign of negation x ↦ -x); its jacobiSym_neg_one is the second factor fused here into the combined supplement."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "The first supplement J(-1 | n) = (-1)^((n-1)/2) (sign of negation x ↦ -x); its jacobiSym_neg_one is the second factor fused here into the combined supplement."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01",
-      "relation": "ancestor",
-      "note": "The full odd-modulus Zolotarev–Frobenius identity sign(x ↦ a·x on ℤ/n) = J(a | n); its specialization to the unit -2 reads the combined supplement off the permutation x ↦ -2·x."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "ancestor",
+      "description": "The full odd-modulus Zolotarev–Frobenius identity sign(x ↦ a·x on ℤ/n) = J(a | n); its specialization to the unit -2 reads the combined supplement off the permutation x ↦ -2·x."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -130,19 +130,19 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01",
-      "relation": "parent",
-      "note": "The full odd-modulus Zolotarev–Frobenius identity sign(x ↦ a·x on ℤ/n) = J(a | n); this entry specializes it to a = 2, answering the a = 2 half of the parent's open question #3 (recover the supplementary laws as values of the Zolotarev sign character)."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The full odd-modulus Zolotarev–Frobenius identity sign(x ↦ a·x on ℤ/n) = J(a | n); this entry specializes it to a = 2, answering the a = 2 half of the parent's open question #3 (recover the supplementary laws as values of the Zolotarev sign character)."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
-      "relation": "sibling",
-      "note": "The first supplement J(-1 | n) = (-1)^((n-1)/2), the a = -1 half of the same open question; its listed open question #1 ('prove the SECOND supplement by computing the sign of the doubling permutation') is exactly what this entry delivers."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "The first supplement J(-1 | n) = (-1)^((n-1)/2), the a = -1 half of the same open question; its listed open question #1 ('prove the SECOND supplement by computing the sign of the doubling permutation') is exactly what this entry delivers."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
-      "relation": "ancestor",
-      "note": "Defines ZolotarevCRT.ringMulPerm and its multiplicativity, the permutation whose a = 2 instance (doubling) is the subject of this entry."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+      "relationship": "ancestor",
+      "description": "Defines ZolotarevCRT.ringMulPerm and its multiplicativity, the permutation whose a = 2 instance (doubling) is the subject of this entry."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -113,19 +113,19 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01",
-      "relation": "parent",
-      "note": "The whole-ring prime-power identity sign(ringMulPerm a on ℤ/pⁿ) = J(a | pⁿ); this entry performs the every-odd-n assembly it explicitly flagged, using it as the prime-power case of the induction."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The whole-ring prime-power identity sign(ringMulPerm a on ℤ/pⁿ) = J(a | pⁿ); this entry performs the every-odd-n assembly it explicitly flagged, using it as the prime-power case of the induction."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
-      "relation": "ancestor",
-      "note": "Defines ZolotarevCRT.ringMulPerm and proves the CRT multiplicativity sign_ringMulPerm_mul_of_odd that supplies the coprime-product step of the induction."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+      "relationship": "ancestor",
+      "description": "Defines ZolotarevCRT.ringMulPerm and proves the CRT multiplicativity sign_ringMulPerm_mul_of_odd that supplies the coprime-product step of the induction."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01",
-      "relation": "ancestor",
-      "note": "The squarefree-odd Frobenius/Zolotarev identity; this entry strictly generalizes it from squarefree odd n to ALL odd n by adding the prime-power factors."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01",
+      "relationship": "ancestor",
+      "description": "The squarefree-odd Frobenius/Zolotarev identity; this entry strictly generalizes it from squarefree odd n to ALL odd n by adding the prime-power factors."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -113,14 +113,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01",
-      "relation": "parent",
-      "note": "The units-level prime-power lemma sign(x ↦ u·x on (ℤ/pⁿ)ˣ) = legendreSym p (u mod p); this entry performs the whole-ring assembly it explicitly left as a follow-up, reusing it as the units block via sign_mulLeft_eq_legendre."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The units-level prime-power lemma sign(x ↦ u·x on (ℤ/pⁿ)ˣ) = legendreSym p (u mod p); this entry performs the whole-ring assembly it explicitly left as a follow-up, reusing it as the units block via sign_mulLeft_eq_legendre."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
-      "relation": "ancestor",
-      "note": "Defines ZolotarevCRT.ringMulPerm (multiplication-by-a on the whole ring ℤ/n) and the CRT decomposition of its sign; this entry supplies the prime-power factor the CRT decomposition cannot split."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+      "relationship": "ancestor",
+      "description": "Defines ZolotarevCRT.ringMulPerm (multiplication-by-a on the whole ring ℤ/n) and the CRT decomposition of its sign; this entry supplies the prime-power factor the CRT decomposition cannot split."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -109,14 +109,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01",
-      "relation": "parent",
-      "note": "The full squarefree-odd Frobenius/Zolotarev lemma sign(ringMulPerm a on ℤ/n) = J(a | n); this entry performs the heart of its #1 follow-up (the genuinely new prime-power computation) at the level of the unit group, reusing its generator_not_isSquare and legendreSym_unit_eq."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The full squarefree-odd Frobenius/Zolotarev lemma sign(ringMulPerm a on ℤ/n) = J(a | n); this entry performs the heart of its #1 follow-up (the genuinely new prime-power computation) at the level of the unit group, reusing its generator_not_isSquare and legendreSym_unit_eq."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
-      "relation": "grandparent",
-      "note": "The prime base case sign(ringMulPerm a on ℤ/p) = legendreSym p a, of which this entry is the prime-power generalization at the unit level."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
+      "relationship": "grandparent",
+      "description": "The prime base case sign(ringMulPerm a on ℤ/p) = legendreSym p a, of which this entry is the prime-power generalization at the unit level."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01/meta.json
@@ -110,14 +110,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
-      "relation": "parent",
-      "note": "The prime base case sign(ringMulPerm a on ℤ/p) = legendreSym p a; this entry performs the factorization induction it left as a follow-up and reaches Mathlib's jacobiSym for all squarefree odd n."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
+      "relationship": "parent",
+      "description": "The prime base case sign(ringMulPerm a on ℤ/p) = legendreSym p a; this entry performs the factorization induction it left as a follow-up and reaches Mathlib's jacobiSym for all squarefree odd n."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
-      "relation": "grandparent",
-      "note": "CRT decomposition of the Zolotarev permutation; its sign_ringMulPerm_mul_of_odd is the multiplicativity used at every step of the induction."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+      "relationship": "grandparent",
+      "description": "CRT decomposition of the Zolotarev permutation; its sign_ringMulPerm_mul_of_odd is the multiplicativity used at every step of the induction."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01/meta.json
@@ -130,14 +130,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
-      "relation": "parent",
-      "note": "CRT decomposition of the Zolotarev permutation; this entry proves the base case it explicitly left open and combines it with the CRT multiplicativity to reach Jacobi values."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+      "relationship": "parent",
+      "description": "CRT decomposition of the Zolotarev permutation; this entry proves the base case it explicitly left open and combines it with the CRT multiplicativity to reach Jacobi values."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01",
-      "relation": "grandparent",
-      "note": "Zolotarev's lemma for the prime/units case; its units-level statement is re-established self-contained here because the file no longer compiles."
+      "targetId": "elementary-quadratic-reciprocity-oq-01",
+      "relationship": "grandparent",
+      "description": "Zolotarev's lemma for the prime/units case; its units-level statement is re-established self-contained here because the file no longer compiles."
     }
   ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
@@ -113,19 +113,19 @@
   ],
   "crossReferences": [
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01",
-      "relation": "parent",
-      "note": "Zolotarev's permutation proof for the prime case (units group); this entry answers its third open question."
+      "targetId": "elementary-quadratic-reciprocity-oq-01",
+      "relationship": "parent",
+      "description": "Zolotarev's permutation proof for the prime case (units group); this entry answers its third open question."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-01",
-      "relation": "sibling",
-      "note": "Gauss sum as a third QR pathway."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Gauss sum as a third QR pathway."
     },
     {
-      "slug": "elementary-quadratic-reciprocity-oq-01-oq-02",
-      "relation": "sibling",
-      "note": "Cubic and quartic characters as higher-reciprocity pathways."
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Cubic and quartic characters as higher-reciprocity pathways."
     }
   ]
 }

--- a/src/data/proofs/erdos-10-wip-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-02/meta.json
@@ -115,8 +115,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "erdos-10-wip-01",
-      "relationship": "Parent thread: proves the subadditive bound popcount(a+b) ≤ popcount(a)+popcount(b) whose equality case this entry characterizes."
+      "targetId": "erdos-10-wip-01",
+      "relationship": "parent",
+      "description": "Parent thread: proves the subadditive bound popcount(a+b) ≤ popcount(a)+popcount(b) whose equality case this entry characterizes."
     }
   ],
   "sorries": []

--- a/src/data/proofs/erdos-10-wip-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-03/meta.json
@@ -113,16 +113,19 @@
   ],
   "crossReferences": [
     {
-      "slug": "erdos-10-wip-01",
-      "relationship": "Parent thread: supplies the popcount characterization isPrimePlusKPowers_iff_popcount that this reduction re-indexes by the offset."
+      "targetId": "erdos-10-wip-01",
+      "relationship": "parent",
+      "description": "Parent thread: supplies the popcount characterization isPrimePlusKPowers_iff_popcount that this reduction re-indexes by the offset."
     },
     {
-      "slug": "erdos-10-wip-01-oq-01",
-      "relationship": "Sibling: proves the same offset refutation criterion for the kernel-decidable witness search (no native_decide); this entry aims it at the covering-congruence construction instead."
+      "targetId": "erdos-10-wip-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling: proves the same offset refutation criterion for the kernel-decidable witness search (no native_decide); this entry aims it at the covering-congruence construction instead."
     },
     {
-      "slug": "erdos-10-incomplete-01-oq-02",
-      "relationship": "Dependency: provides the six-prime covering primes' parity/size bounds and the explicit even progression family with family_props."
+      "targetId": "erdos-10-incomplete-01-oq-02",
+      "relationship": "related",
+      "description": "Dependency: provides the six-prime covering primes' parity/size bounds and the explicit even progression family with family_props."
     }
   ],
   "sorries": []

--- a/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
+++ b/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
@@ -143,19 +143,19 @@
   ],
   "crossReferences": [
     {
-      "slug": "amgm-inequality",
-      "title": "Arithmetic Mean - Geometric Mean Inequality",
-      "relationship": "The algebraic reduction core rests entirely on AM–GM: each pedal distance acquires a coefficient t + 1/t ≥ 2, and the factor 2 in the Erdős–Mordell bound is exactly this AM–GM constant."
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "The algebraic reduction core rests entirely on AM–GM: each pedal distance acquires a coefficient t + 1/t ≥ 2, and the factor 2 in the Erdős–Mordell bound is exactly this AM–GM constant."
     },
     {
-      "slug": "ptolemys-theorem",
-      "title": "Ptolemy's Theorem",
-      "relationship": "The geometric key inequalities arise from the concyclicity of the pedal feet with P and a vertex on a circle of diameter PA; the chord-projection bound is a Ptolemy-type inequality on that cyclic configuration."
+      "targetId": "ptolemys-theorem",
+      "relationship": "related",
+      "description": "The geometric key inequalities arise from the concyclicity of the pedal feet with P and a vertex on a circle of diameter PA; the chord-projection bound is a Ptolemy-type inequality on that cyclic configuration."
     },
     {
-      "slug": "triangle-inequality",
-      "title": "The Triangle Inequality",
-      "relationship": "Both are foundational distance inequalities in Euclidean geometry; Erdős–Mordell strengthens naive vertex-vs-side distance comparisons into a sharp weighted bound with an equality characterization."
+      "targetId": "triangle-inequality",
+      "relationship": "related",
+      "description": "Both are foundational distance inequalities in Euclidean geometry; Erdős–Mordell strengthens naive vertex-vs-side distance comparisons into a sharp weighted bound with an equality characterization."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/halls-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-01/meta.json
@@ -105,8 +105,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "halls-theorem-oq-01",
-      "relation": "Answers the first open question of this entry — the quantitative defect (deficiency) form of Hall's theorem — in the Finset / SDR formulation."
+      "targetId": "halls-theorem-oq-01",
+      "relationship": "related",
+      "description": "Answers the first open question of this entry — the quantitative defect (deficiency) form of Hall's theorem — in the Finset / SDR formulation."
     }
   ],
   "references": [

--- a/src/data/proofs/halls-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-02/meta.json
@@ -119,12 +119,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "halls-theorem-oq-01-oq-01",
-      "relation": "Answers this entry's stated open question — sharpening Ore's qualitative 'missing at most d' defect theorem to the exact min = max-deficiency equality — and reuses its defect_hall biconditional."
+      "targetId": "halls-theorem-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Answers this entry's stated open question — sharpening Ore's qualitative 'missing at most d' defect theorem to the exact min = max-deficiency equality — and reuses its defect_hall biconditional."
     },
     {
-      "slug": "halls-theorem-oq-01",
-      "relation": "The parent bipartite Hall biconditional; this entry supplies the exact deficiency / König duality in the Finset formulation of that family."
+      "targetId": "halls-theorem-oq-01",
+      "relationship": "related",
+      "description": "The parent bipartite Hall biconditional; this entry supplies the exact deficiency / König duality in the Finset formulation of that family."
     }
   ],
   "references": [

--- a/src/data/proofs/halls-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-03/meta.json
@@ -119,12 +119,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "halls-theorem-oq-01",
-      "relation": "Answers a follow-up open question of this entry — the regular application of Hall's theorem — at the indexed-Finset / SDR level, complementing the parent's conditional bipartite biconditional."
+      "targetId": "halls-theorem-oq-01",
+      "relationship": "related",
+      "description": "Answers a follow-up open question of this entry — the regular application of Hall's theorem — at the indexed-Finset / SDR level, complementing the parent's conditional bipartite biconditional."
     },
     {
-      "slug": "halls-theorem-oq-01-oq-01",
-      "relation": "Sibling Finset-level Hall result: that entry proves Ore's defect form; this one proves the regular case. Both build on Finset.all_card_le_biUnion_card_iff_exists_injective."
+      "targetId": "halls-theorem-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling Finset-level Hall result: that entry proves Ore's defect form; this one proves the regular case. Both build on Finset.all_card_le_biUnion_card_iff_exists_injective."
     }
   ],
   "references": [

--- a/src/data/proofs/hilbert-17-oq-03-oq-03/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-03/meta.json
@@ -177,12 +177,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "hilbert-17",
-      "relation": "Parent entry; this discharges its axiom robinson_not_sos_aux (axiom count 4 → 3)."
+      "targetId": "hilbert-17",
+      "relationship": "parent",
+      "description": "Parent entry; this discharges its axiom robinson_not_sos_aux (axiom count 4 → 3)."
     },
     {
-      "slug": "hilbert-17-oq-03-oq-02",
-      "relation": "Sibling: the analogous 0-axiom proof for the Motzkin polynomial."
+      "targetId": "hilbert-17-oq-03-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling: the analogous 0-axiom proof for the Motzkin polynomial."
     }
   ],
   "sections": [

--- a/src/data/proofs/hilbert-4-oq-04/meta.json
+++ b/src/data/proofs/hilbert-4-oq-04/meta.json
@@ -152,8 +152,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "hilbert-4",
-      "relation": "Parent entry: Hilbert's 4th problem, whose open question on the Hilbert metric / Birkhoff contraction / Perron–Frobenius power-iteration bridge this entry realizes for the 2×2 case."
+      "targetId": "hilbert-4",
+      "relationship": "parent",
+      "description": "Parent entry: Hilbert's 4th problem, whose open question on the Hilbert metric / Birkhoff contraction / Perron–Frobenius power-iteration bridge this entry realizes for the 2×2 case."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/lifting-the-exponent-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lifting-the-exponent-oq-01-oq-01/meta.json
@@ -119,8 +119,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "lifting-the-exponent-oq-01",
-      "reason": "Parent entry: the odd-prime LTE in padicValNat form, whose first open question (the p = 2 even-exponent companion) this entry answers."
+      "targetId": "lifting-the-exponent-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry: the odd-prime LTE in padicValNat form, whose first open question (the p = 2 even-exponent companion) this entry answers."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/mellin-power-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/mellin-power-convergence-oq-01-oq-01/meta.json
@@ -132,9 +132,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "mellin-power-convergence-oq-01",
-      "title": "The Mellin transform of the unit indicator: convergence strip and scaling law",
-      "relation": "Parent entry. Supplies the base pair mellin 𝟙_{(0,1]} s = 1/s, the sharp strip Re s > 0, and the dilation law mellin 𝟙_{(0,a]} s = a^s/s; this entry answers its first open question by extending to general intervals and power weights."
+      "targetId": "mellin-power-convergence-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry. Supplies the base pair mellin 𝟙_{(0,1]} s = 1/s, the sharp strip Re s > 0, and the dilation law mellin 𝟙_{(0,a]} s = a^s/s; this entry answers its first open question by extending to general intervals and power weights."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/prob-method-expectation-oq-02-oq-01/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-02-oq-01/meta.json
@@ -81,9 +81,21 @@
     { "title": "Exponential Growth and Concrete Witness", "description": "R(2j+1,2j+1) > 2^j for j ≥ 3, and the instance R(7,7) > 8." }
   ],
   "crossReferences": [
-    { "slug": "prob-method-expectation-oq-02", "relation": "parent", "description": "Answers open question #1 — derive the explicit growth from the first-moment criterion by estimating C(n,k) and choosing n optimally; reuses its first_moment_ramsey, Coloring and Mono." },
-    { "slug": "prob-method-expectation", "relation": "ancestor", "description": "Grandparent entry whose placeholder Ramsey lower bound the parent replaced and this entry now quantifies." },
-    { "slug": "prob-method-alteration", "relation": "related", "description": "The alteration method pushes the diagonal lower bound beyond the pure first-moment 2^(k/2) growth proved here." }
+    {
+      "targetId": "prob-method-expectation-oq-02",
+      "relationship": "parent",
+      "description": "Answers open question #1 — derive the explicit growth from the first-moment criterion by estimating C(n,k) and choosing n optimally; reuses its first_moment_ramsey, Coloring and Mono."
+    },
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "ancestor",
+      "description": "Grandparent entry whose placeholder Ramsey lower bound the parent replaced and this entry now quantifies."
+    },
+    {
+      "targetId": "prob-method-alteration",
+      "relationship": "related",
+      "description": "The alteration method pushes the diagonal lower bound beyond the pure first-moment 2^(k/2) growth proved here."
+    }
   ],
   "references": [
     { "label": "Erdős 1947", "citation": "P. Erdős, Some remarks on the theory of graphs, Bull. Amer. Math. Soc. 53 (1947), 292–294 (the 2^(k/2) diagonal Ramsey lower bound)." },

--- a/src/data/proofs/prob-method-expectation-oq-02-oq-02/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-02-oq-02/meta.json
@@ -95,18 +95,18 @@
   },
   "crossReferences": [
     {
-      "slug": "prob-method-expectation-oq-02",
-      "relation": "parent",
+      "targetId": "prob-method-expectation-oq-02",
+      "relationship": "parent",
       "description": "Answers open question #2 ('formalize the off-diagonal version giving lower bounds on R(s,t) for s ≠ t via the same union bound'); generalizes its diagonal first_moment_ramsey."
     },
     {
-      "slug": "prob-method-expectation",
-      "relation": "ancestor",
+      "targetId": "prob-method-expectation",
+      "relationship": "ancestor",
       "description": "Grandparent entry on the first-moment / expectation method whose Ramsey placeholder the parent and this entry replace with genuine content."
     },
     {
-      "slug": "prob-method-alteration",
-      "relation": "related",
+      "targetId": "prob-method-alteration",
+      "relationship": "related",
       "description": "The alteration / deletion method improves on the pure off-diagonal union bound proved here, especially for unbalanced s, t."
     }
   ],

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01-oq-03/meta.json
@@ -74,16 +74,19 @@
   },
   "crossReferences": [
     {
-      "slug": "ptolemys-theorem-oq-01-oq-01",
-      "relation": "Parent leaf — proves the Ptolemy-equality converse for four points on the unit circle, but seals its angular sign-analysis behind the axiom positive_ratio_implies_cyclic_order. This entry answers the same 'equality ⇔ cyclic' question in full Euclidean generality and 0-axiom, using inversion/betweenness in place of complex coordinates."
+      "targetId": "ptolemys-theorem-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent leaf — proves the Ptolemy-equality converse for four points on the unit circle, but seals its angular sign-analysis behind the axiom positive_ratio_implies_cyclic_order. This entry answers the same 'equality ⇔ cyclic' question in full Euclidean generality and 0-axiom, using inversion/betweenness in place of complex coordinates."
     },
     {
-      "slug": "ptolemys-theorem-oq-01",
-      "relation": "Grandparent leaf — 'Ptolemy Inequality with Concyclicity Characterization'; this entry sharpens the inequality to an exact equality criterion valid in any real inner-product space."
+      "targetId": "ptolemys-theorem-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent leaf — 'Ptolemy Inequality with Concyclicity Characterization'; this entry sharpens the inequality to an exact equality criterion valid in any real inner-product space."
     },
     {
-      "slug": "ptolemys-theorem",
-      "relation": "Root entry — Ptolemy's theorem for cyclic quadrilaterals; the present result is the metric-space equality case of the inequality form that generalises it."
+      "targetId": "ptolemys-theorem",
+      "relationship": "ancestor",
+      "description": "Root entry — Ptolemy's theorem for cyclic quadrilaterals; the present result is the metric-space equality case of the inequality form that generalises it."
     }
   ],
   "references": [

--- a/src/data/proofs/schroeder-bernstein-oq-02-oq-01/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-02-oq-01/meta.json
@@ -139,12 +139,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "schroeder-bernstein-oq-02",
-      "relation": "Parent entry: the Knaster–Tarski (least fixed point) proof whose open question — is gfp equally useful, and what is gfp ∖ lfp — this entry answers."
+      "targetId": "schroeder-bernstein-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry: the Knaster–Tarski (least fixed point) proof whose open question — is gfp equally useful, and what is gfp ∖ lfp — this entry answers."
     },
     {
-      "slug": "schroeder-bernstein",
-      "relation": "The base Schroeder–Bernstein gallery entry."
+      "targetId": "schroeder-bernstein",
+      "relationship": "related",
+      "description": "The base Schroeder–Bernstein gallery entry."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/second-isomorphism-theorem-modules-oq-01-oq-01/meta.json
+++ b/src/data/proofs/second-isomorphism-theorem-modules-oq-01-oq-01/meta.json
@@ -149,9 +149,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "second-isomorphism-theorem-modules-oq-01",
-      "relation": "parent",
-      "note": "Derives the two-submodule modular law from the diamond isomorphism; this entry answers its first open question on three submodules"
+      "targetId": "second-isomorphism-theorem-modules-oq-01",
+      "relationship": "parent",
+      "description": "Derives the two-submodule modular law from the diamond isomorphism; this entry answers its first open question on three submodules"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/sylow-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01-oq-01/meta.json
@@ -121,16 +121,19 @@
   },
   "crossReferences": [
     {
-      "slug": "sylow-theorem-oq-02-oq-01",
-      "relation": "Parent entry — characterizes nilpotency by normality (equivalently uniqueness, equivalently count one) of all Sylow subgroups. This entry sharpens 'normal' to 'characteristic', showing the two coincide for Sylow subgroups and inserting the characteristic tier into the equivalence chain."
+      "targetId": "sylow-theorem-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry — characterizes nilpotency by normality (equivalently uniqueness, equivalently count one) of all Sylow subgroups. This entry sharpens 'normal' to 'characteristic', showing the two coincide for Sylow subgroups and inserting the characteristic tier into the equivalence chain."
     },
     {
-      "slug": "sylow-theorem-oq-02",
-      "relation": "Grandparent entry — the per-prime orbit enumeration n_p = [G : N_G(P)] underlying both the parent's counting characterization and this entry's uniqueness-driven coincidence."
+      "targetId": "sylow-theorem-oq-02",
+      "relationship": "ancestor",
+      "description": "Grandparent entry — the per-prime orbit enumeration n_p = [G : N_G(P)] underlying both the parent's counting characterization and this entry's uniqueness-driven coincidence."
     },
     {
-      "slug": "sylow-theorem",
-      "relation": "Root entry — Sylow existence, conjugacy, and counting, the foundation for the whole strand."
+      "targetId": "sylow-theorem",
+      "relationship": "ancestor",
+      "description": "Root entry — Sylow existence, conjugacy, and counting, the foundation for the whole strand."
     }
   ],
   "references": [

--- a/src/data/proofs/sylow-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01/meta.json
@@ -127,12 +127,14 @@
   },
   "crossReferences": [
     {
-      "slug": "sylow-theorem-oq-02",
-      "relation": "Parent entry — enumerates the Sylow p-subgroups via the conjugation orbit, proving n_p = [G : N_G(P)] and the per-prime criterion n_p = 1 ⟺ P ◁ G. This entry quantifies that criterion over all primes and identifies the resulting class as the nilpotent groups, with normalizer_eq_top_of_nilpotent making the n_p = [G : N_G(P)] bridge explicit."
+      "targetId": "sylow-theorem-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry — enumerates the Sylow p-subgroups via the conjugation orbit, proving n_p = [G : N_G(P)] and the per-prime criterion n_p = 1 ⟺ P ◁ G. This entry quantifies that criterion over all primes and identifies the resulting class as the nilpotent groups, with normalizer_eq_top_of_nilpotent making the n_p = [G : N_G(P)] bridge explicit."
     },
     {
-      "slug": "sylow-theorem",
-      "relation": "Root entry — Sylow's existence, conjugacy, and counting theorems, the foundation on which both the parent enumeration and this nilpotency characterization rest."
+      "targetId": "sylow-theorem",
+      "relationship": "ancestor",
+      "description": "Root entry — Sylow's existence, conjugacy, and counting theorems, the foundation on which both the parent enumeration and this nilpotency characterization rest."
     }
   ],
   "references": [


### PR DESCRIPTION
## Problem

37 gallery entries encode `crossReferences` with legacy keys the loader doesn't understand — e.g. `{ slug, relation }`, `{ slug, relation:'parent', note }`, `{ slug, relationship:'<prose>' }`, `{ slug, reason }`.

`normalizeCrossReferences` (`src/data/proofs/index.ts`) and the `ProofOverview`/`ProofConclusion` components only read `{ proofId | targetId, relationship, description }` (plus bare strings). A ref keyed on `slug` yields `ref.proofId ?? ref.targetId === undefined` and is filtered out, so these accurate links have never rendered.

## Fix

For each legacy ref: `slug` → `targetId`; the short-enum field becomes `relationship` (inferred from the prose prefix when only prose was present); the prose (`note`/`description`/`reason`/long `relation`) becomes `description`. All target slugs exist (0 dropped); each file's diff is confined to its `crossReferences` block (surgical replacement — other fields byte-identical).

~85 previously-invisible links restored across 37 entries (Baire, Banach–Steinhaus, the Zolotarev/quadratic-reciprocity chain, Hall's theorem, Sylow, prob-method, Erdős–Mordell, Ptolemy, and more).

Follows #35345 (same defect, the 5 Cauchy-interlacing entries). All files valid JSON, within size caps.

## Note for maintainers
The durable fix is to teach `normalizeCrossReferences` to also coerce `{slug, relation}` (mirroring its bare-string coercion), covering future entries too — a small loader code change, out of scope for this data-only PR.