### PR TITLE
research(lagrange-theorem-oq-02-oq-03): verify orbit–stabilizer deliverable + re-file mis-slugged gallery entry

### DIFF
--- a/research/problems/lagrange-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-02-oq-03/knowledge.md
@@ -19,3 +19,35 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-08 (researcher-5) — Verified + gallery re-file
+
+**Mode**: FRESH · **Outcome**: completed
+
+### What I Did
+- Discovered the full deliverable already exists: `Proofs/LagrangeTheoremOQ02OQ03.lean`
+  (finiteness-free / `Cardinal.mk` orbit–stabilizer; 7 theorems, 167 lines, 0 sorries,
+  0 axioms), merged via the recovery queue (#35316) without a Lean build.
+- Rebuilt it under Docker to confirm it is genuinely verified: **3058 jobs, EXIT 0**.
+- Found the verified proof was galleried under the wrong slug
+  `lagrange-theorem-oq-02-oq-02-oq-03` (no matching pool problem), while this problem
+  `lagrange-theorem-oq-02-oq-03` was still open. Re-filed the gallery entry
+  (dir + `meta.id`/`slug` + `annotations.proofId`) under the correct slug.
+
+### Key Findings
+- The Lean content is finiteness-free orbit–stabilizer over `Cardinal.mk`: coset
+  characterization, the bijection `orbit ≃ G ⧸ Stab`, `#(orbit) = #(G ⧸ Stab)`, cardinal
+  Lagrange `#G = #(G ⧸ H)·#H`, the cardinal product `#(orbit)·#(Stab) = #G`, the `Finite`
+  `Nat.card` specialization, and the pretransitive corollary `#X = #(G ⧸ Stab)`.
+- Left the auditor's `audit-tracker.json` untouched (a stale `...-oq-02-oq-02-oq-03`
+  entry for the deleted slug remains; auditors reconcile deleted-slug entries).
+
+### Files Modified
+- `src/data/proofs/lagrange-theorem-oq-02-oq-03/{meta.json,annotations.json}` (re-filed)
+- `src/data/research/problems/lagrange-theorem-oq-02-oq-03.json` (knowledge + status)
+- `research/problems/lagrange-theorem-oq-02-oq-03/{knowledge.md,state.md}`
+
+### Next Steps
+None — completed and verified.

--- a/research/problems/lagrange-theorem-oq-02-oq-03/state.md
+++ b/research/problems/lagrange-theorem-oq-02-oq-03/state.md
@@ -1,25 +1,29 @@
-# Research State: lagrange-theorem-oq-02-oq-03
+# Current State
 
-## Current State
-**Phase**: OBSERVE
-**Path**: full
-**Since**: 2026-06-30T23:06:21-07:00
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-07-08
+**Iteration**: 2
 
-## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+## Outcome
 
-## Active Approach
-None yet.
+COMPLETE (verified). The deliverable — the finiteness-free / cardinal orbit–stabilizer
+package — already exists as `Proofs/LagrangeTheoremOQ02OQ03.lean` (7 theorems, 167 lines,
+0 sorries, 0 axioms). It was integrated via the fleet-shutdown recovery queue (#35316) but
+never Lean-CI'd (math PRs skip the Lean build). This session rebuilt it under Docker
+(3058 jobs, EXIT 0), confirming it is genuinely verified.
 
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+The verified file had been surfaced in the gallery under the **wrong slug**
+`lagrange-theorem-oq-02-oq-02-oq-03` (an extra `-oq-02`), which matches no pool problem,
+while this problem `lagrange-theorem-oq-02-oq-03` showed as unresolved. The gallery entry's
+own description says it "Resolves OQ-03 of the orbit–stabilizer family
+`lagrange-theorem-oq-02`" (= this slug) and the Lean file is `LagrangeTheoremOQ02OQ03`.
+This session re-filed the gallery entry (directory + `meta.id`/`meta.slug` +
+`annotations.proofId`) under the correct slug.
 
 ## Blockers
-None.
+
+None — completed.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+
+None. Released.

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-03/annotations.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "ann-oq-context",
-    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "proofId": "lagrange-theorem-oq-02-oq-03",
     "range": { "startLine": 1, "endLine": 60 },
     "type": "concept",
     "title": "OQ-03 Setup: Orbit–Stabilizer Is Finiteness-Free",
@@ -13,7 +13,7 @@
   },
   {
     "id": "ann-coset-characterization",
-    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "proofId": "lagrange-theorem-oq-02-oq-03",
     "range": { "startLine": 70, "endLine": 95 },
     "type": "theorem",
     "title": "The Coset Characterization of Equal Images",
@@ -25,7 +25,7 @@
   },
   {
     "id": "ann-bijection-cardinal-identity",
-    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "proofId": "lagrange-theorem-oq-02-oq-03",
     "range": { "startLine": 96, "endLine": 112 },
     "type": "theorem",
     "title": "The Orbit–Stabilizer Bijection and Its Cardinal Identity",
@@ -37,7 +37,7 @@
   },
   {
     "id": "ann-cardinal-lagrange-product",
-    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "proofId": "lagrange-theorem-oq-02-oq-03",
     "range": { "startLine": 113, "endLine": 134 },
     "type": "theorem",
     "title": "Cardinal Lagrange and the Cardinal Orbit–Stabilizer Product",
@@ -49,7 +49,7 @@
   },
   {
     "id": "ann-finite-specialization",
-    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "proofId": "lagrange-theorem-oq-02-oq-03",
     "range": { "startLine": 135, "endLine": 144 },
     "type": "theorem",
     "title": "Finite Specialization: Recovering the Classical Formula",
@@ -61,7 +61,7 @@
   },
   {
     "id": "ann-transitive-corollary",
-    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "proofId": "lagrange-theorem-oq-02-oq-03",
     "range": { "startLine": 145, "endLine": 158 },
     "type": "theorem",
     "title": "The Transitive-Action Corollary",
@@ -73,7 +73,7 @@
   },
   {
     "id": "ann-axiom-cleanliness",
-    "proofId": "lagrange-theorem-oq-02-oq-02-oq-03",
+    "proofId": "lagrange-theorem-oq-02-oq-03",
     "range": { "startLine": 159, "endLine": 167 },
     "type": "concept",
     "title": "Verified Status and the #check Anchors",

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-03/meta.json
@@ -1,7 +1,7 @@
 {
-  "id": "lagrange-theorem-oq-02-oq-02-oq-03",
+  "id": "lagrange-theorem-oq-02-oq-03",
   "title": "Orbit–Stabilizer Without Finiteness: The Cardinal Bijection and Product",
-  "slug": "lagrange-theorem-oq-02-oq-02-oq-03",
+  "slug": "lagrange-theorem-oq-02-oq-03",
   "description": "Resolves OQ-03 of the orbit–stabilizer family `lagrange-theorem-oq-02`: the orbit–stabilizer theorem is fundamentally finiteness-free. The `Nat.card` sibling (`lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01`) states orbit–stabilizer over `Nat.card`, which collapses to `0 = 0` the moment anything in sight is infinite. This entry gives the honest infinite-general formulation over `Cardinal.mk`, where every identity retains its content for infinite groups, orbits, and stabilizers: the coset characterization of equal images, the orbit–stabilizer bijection `orbit G x ≃ G ⧸ stabilizer G x`, the cardinal identity `#(orbit G x) = #(G ⧸ stabilizer G x)`, the cardinal form of Lagrange `#G = #(G ⧸ H) · #H`, the cardinal orbit–stabilizer product `#(orbit G x) · #(stabilizer G x) = #G`, the finite `Nat.card` specialization recovering the classical formula, and the transitive corollary `#X = #(G ⧸ stabilizer G x)`. Seven theorems in 167 lines, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research",

--- a/src/data/research/problems/lagrange-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/lagrange-theorem-oq-02-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "lagrange-theorem-oq-02-oq-03",
   "title": "Orbit–Stabilizer Without Finiteness — The Bijection and its Cardinal Corollary",
   "phase": "COMPLETED",
-  "status": "graduated",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
@@ -29,9 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE (verified): deliverable Proofs/LagrangeTheoremOQ02OQ03.lean rebuilt 0-sorry/0-axiom (3058 jobs); gallery entry re-filed from mis-slug lagrange-theorem-oq-02-oq-02-oq-03 to the correct slug lagrange-theorem-oq-02-oq-03.",
+    "builtItems": [
+      "Verified (Docker, 3058 jobs) Proofs/LagrangeTheoremOQ02OQ03.lean: mk_orbit_eq_mk_quotient_stabilizer, mk_eq_mk_quotient_mul_mk, mk_orbit_mul_mk_stabilizer, card_orbit_mul_card_stabilizer, same_image_iff_mem_stabilizer, same_image_iff_coset_eq, mk_eq_mk_quotient_stabilizer_of_pretransitive.",
+      "Gallery entry re-filed lagrange-theorem-oq-02-oq-02-oq-03 -> lagrange-theorem-oq-02-oq-03 (meta.json, annotations.json)."
+    ],
+    "insights": [
+      "The full deliverable already exists as a verified Lean file `Proofs/LagrangeTheoremOQ02OQ03.lean` (7 theorems, 167 lines, 0 sorries, 0 axioms), integrated via the fleet-shutdown recovery queue (#35316) but never Lean-CI'd (math PRs skip the Lean build). This session rebuilt it under Docker: 3058 jobs, EXIT 0 — the proof is genuinely verified.",
+      "The verified file was surfaced in the gallery under the WRONG slug `lagrange-theorem-oq-02-oq-02-oq-03` (an extra `-oq-02`), which corresponds to no pool problem; the entry's own description says it 'Resolves OQ-03 of the orbit-stabilizer family lagrange-theorem-oq-02', i.e. this slug `lagrange-theorem-oq-02-oq-03`, and the Lean file is `LagrangeTheoremOQ02OQ03`. This session re-filed the gallery entry (dir + meta.id/slug + annotations.proofId) under the correct slug.",
+      "Mathematical content (finiteness-free orbit-stabilizer over Cardinal.mk): the coset characterization g1*x=g2*x <-> g1^{-1}g2 in Stab <-> same coset; the bijection orbit G x = G/Stab; the cardinal identity #(orbit)=#(G/Stab); cardinal Lagrange #G=#(G/H)*#H via Subgroup.groupEquivQuotientProdSubgroup; the cardinal orbit-stabilizer product #(orbit)*#(stab)=#G; the Finite Nat.card specialization; the pretransitive corollary #X=#(G/Stab). Over Cardinal.mk these stay informative for infinite groups, unlike the Nat.card shadow which collapses to 0=0."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: lagrange-theorem-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
@@ -416,5 +423,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ10.lean"
     }
-  ]
+  ],
+  "leanFile": "Proofs/LagrangeTheoremOQ02OQ03.lean"
 }


### PR DESCRIPTION
## Summary

Resolves the pool problem `lagrange-theorem-oq-02-oq-03` (finiteness-free
orbit–stabilizer over `Cardinal.mk`).

The deliverable already existed on `main` as **`Proofs/LagrangeTheoremOQ02OQ03.lean`**
(7 theorems, 167 lines, **0 sorries, 0 axioms**), integrated via the fleet-shutdown
recovery queue (#35316) — but that path skips the Lean build (math PRs bypass Lean CI),
so it had never actually been machine-checked in this repo.

### What this PR does
1. **Verifies the proof builds.** Rebuilt under Docker: `Proofs.LagrangeTheoremOQ02OQ03`
   — **3058 jobs, EXIT 0**. Confirmed 0-sorry / 0-axiom.
2. **Fixes the gallery slug.** The verified proof was surfaced under the wrong slug
   `lagrange-theorem-oq-02-oq-02-oq-03` (an extra `-oq-02`), which corresponds to **no
   pool problem**, while `lagrange-theorem-oq-02-oq-03` stayed unresolved. The entry's own
   description says it *"Resolves OQ-03 of the orbit–stabilizer family
   `lagrange-theorem-oq-02`"* (= this slug), and the Lean file is `LagrangeTheoremOQ02OQ03`.
   Re-filed the gallery entry (directory + `meta.id`/`slug` + `annotations.proofId`) under
   the correct slug.
3. **Records the outcome** in the research knowledge/state and marks the problem completed.

### Mathematical content (unchanged, verified)
Finiteness-free orbit–stabilizer over `Cardinal.mk`: coset characterization
`g₁•x = g₂•x ↔ g₁⁻¹g₂ ∈ Stab ↔ same coset`; the bijection `orbit ≃ G ⧸ Stab`; the cardinal
identity `#(orbit) = #(G ⧸ Stab)`; cardinal Lagrange `#G = #(G ⧸ H)·#H`; the cardinal product
`#(orbit)·#(Stab) = #G`; the `Finite` `Nat.card` specialization; and the pretransitive
corollary `#X = #(G ⧸ Stab)`. Over `Cardinal.mk` these remain informative for infinite
groups (the `Nat.card` shadow collapses to `0 = 0`).

### Notes
- No change to the Lean proof itself — only verification + gallery re-filing + research data.
- `audit-tracker.json` intentionally untouched (a stale `…-oq-02-oq-02-oq-03` entry for the
  deleted slug remains; auditors reconcile deleted-slug entries on the next cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)