### PR TITLE
research(erdos-703): T(n,1) lower bound from Frankl's large-set family (7→9 theorems, 0 axioms added)

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -246,6 +246,38 @@ theorem large_sets_avoid_1 (n : ℕ) (A B : Finset ℕ)
       _ = n := Finset.card_range n
   omega
 
+/--
+**The family of large sets (Frankl's `r = 1` lower-bound construction).**
+`F = {A ⊆ [n] : |A| > (n+1)/2}`. Every pair of members — including a set with
+itself — has intersection size `≠ 1`, so this is a valid `1`-avoiding family.
+-/
+def largeSetsFamily (n : ℕ) : Finset (Finset ℕ) :=
+  (Finset.range n).powerset.filter (fun A => A.card > (n + 1) / 2)
+
+/--
+**The large-set family avoids `1`-intersections.**
+Immediate from `large_sets_avoid_1`: any two sets both larger than `(n+1)/2`
+cannot meet in exactly one point.
+-/
+theorem largeSetsFamily_avoids_1 (n : ℕ) : avoidsRIntersection 1 (largeSetsFamily n) := by
+  intro A B hA hB
+  rw [largeSetsFamily, Finset.mem_filter, Finset.mem_powerset] at hA hB
+  exact large_sets_avoid_1 n A B hA.1 hB.1 hA.2 hB.2
+
+/--
+**Lower bound on `T(n,1)` from the large-set construction.**
+Since the large-set family is a valid `1`-avoiding subfamily of `2^{[n]}`, its
+cardinality is a lower bound for `T(n,1)`. This is Frankl's (1977) lower-bound
+construction: the extremal `1`-avoiding families are (essentially) the large
+sets together with a small-set tail.
+-/
+theorem largeSetsFamily_card_le_T (n : ℕ) : (largeSetsFamily n).card ≤ T n 1 := by
+  have hmem : largeSetsFamily n ∈
+      ((Finset.range n).powerset.powerset).filter (avoidsRIntersection 1) := by
+    rw [Finset.mem_filter]
+    exact ⟨Finset.mem_powerset.mpr (Finset.filter_subset _ _), largeSetsFamily_avoids_1 n⟩
+  exact Finset.le_sup hmem
+
 /-
 ## Part IV: Frankl-Füredi Optimal Families
 -/

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -45,14 +45,15 @@
       "erdos_703_solved: combined resolution theorem",
       "card_le_of_avoids_zero: complement-pairing upper bound |F| ≤ 2^{n-1} for 0-avoiding (intersecting) families",
       "star_family_card: the fixed-point star family has exactly 2^{n-1} members (sharpness witness)",
-      "T_n_0: fully machine-checked proof that T(n,0) = 2^{n-1} (previously a sorry)"
+      "T_n_0: fully machine-checked proof that T(n,0) = 2^{n-1} (previously a sorry)",
+      "largeSetsFamily / largeSetsFamily_avoids_1 / largeSetsFamily_card_le_T: Frankl's (1977) r=1 lower-bound construction — the family of sets larger than (n+1)/2 is a valid 1-avoiding family, giving a verified lower bound |largeSetsFamily n| ≤ T(n,1)"
     ],
     "axiomCount": 1,
-    "lineCount": 348,
+    "lineCount": 380,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
-    "definitionCount": 7
+    "theoremCount": 9,
+    "definitionCount": 8
   },
   "crossReferences": [
     {
@@ -185,10 +186,10 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 348,
+    "lineCount": 380,
     "axiomCount": 1,
-    "theoremCount": 7,
-    "definitionCount": 7,
+    "theoremCount": 9,
+    "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-703-incomplete-01.json
+++ b/src/data/research/problems/erdos-703-incomplete-01.json
@@ -17,7 +17,7 @@
   },
   "currentState": "T(n,0) = 2^{n-1} is now fully machine-checked (0 sorries). The deep Frankl-Rodl exponential bound and the unit-distance chromatic number remain axiomatized (frankl_rodl_1987, chromaticNumber). Entry status: axiomatized, 2 axioms, 0 sorries.",
   "knowledge": {
-    "progressSummary": "PROGRESS: trivial case T(n,0)=2^{n-1} fully machine-checked (sorry eliminated); deep cases remain axiomatized",
+    "progressSummary": "PROGRESS: trivial case T(n,0)=2^{n-1} fully machine-checked (sorry eliminated); deep cases remain axiomatized | 2026-07-08 (researcher-3): advanced the r=1 case — assembled large_sets_avoid_1 into largeSetsFamily (Frankl 1977 lower-bound construction) and proved largeSetsFamily_card_le_T: |largeSetsFamily n| ≤ T(n,1). Verified, 0 new axioms.",
     "builtItems": [
       "card_le_of_avoids_zero (Erdos703Problem.lean:97): complement-pairing upper bound |F| <= 2^{n-1} for 0-avoiding families",
       "star_family_card (Erdos703Problem.lean:164): fixed-point star family has 2^{n-1} members (Finset.card_nbij' bijection)",
@@ -50,7 +50,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T12:23:52.517Z",
-  "lastUpdate": "2026-06-19",
+  "lastUpdate": "2026-07-08",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Erdős #703 (forbidden r-intersection families). The file already proves `T(n,0) = 2^{n-1}` and, for `r = 1`, the pairwise lemma `large_sets_avoid_1` (two sets both larger than `(n+1)/2` cannot meet in exactly one point, by inclusion–exclusion). This PR assembles that lemma into **Frankl's (1977) lower-bound construction** — the flagged next step for the `r = 1` case.

## New declarations

- **`largeSetsFamily n`** := `{A ⊆ [n] : |A| > (n+1)/2}`.
- **`largeSetsFamily_avoids_1`** — it is a valid `1`-avoiding family, directly from `large_sets_avoid_1` (the existing lemma already covers the `A = B` diagonal).
- **`largeSetsFamily_card_le_T`** — `|largeSetsFamily n| ≤ T(n,1)`, a verified lower bound on `T(n,1)` via `Finset.le_sup` on the family defining `T`.

This is the first concrete progress on the `r = 1` case beyond the pairwise lemma: the large-set family is exactly the core of Frankl's extremal construction.

## Verification

- Builds clean: `✔ Built Proofs.Erdos703Problem (7743 jobs)`
- 0 sorries; still **exactly 1 axiom** (`frankl_rodl_1987`, the deep Frankl–Rödl 1987 exponential bound — untouched)
- `theoremCount` 7 → 9, `lineCount` 348 → 380; gallery meta + research JSON updated

Status remains `axiomatized` (the single deep `frankl_rodl_1987` axiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)