### PR TITLE
Enrich Schur majorization (Karamata form): link to the majorization cluster

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -165,6 +165,16 @@
       "targetId": "cauchy-interlacing-theorem",
       "relationship": "related",
       "description": "Root of the Cauchy interlacing family. The Schur–Horn theorem is the classical companion of interlacing in the theory of eigenvalue inequalities and majorization for Hermitian operators."
+    },
+    {
+      "targetId": "birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The same majorization machinery in a combinatorial setting: that entry proves Schur-convexity of the two-draw collision probability via the Hardy–Littlewood–Pólya form of majorization (p ≺ q iff p = Dq for a doubly stochastic D) — exactly the doubly-stochastic majorization diag(T) ≺ spec(T) established here as the forward Schur–Horn direction."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-02-oq-03",
+      "relationship": "related",
+      "description": "Muirhead's inequality is the archetypal application of the majorization order this entry produces: its atomic bunching (Robin-Hood) step is a single majorizing transfer, and Muirhead's symmetric-mean inequality follows by the same Karamata/convexity argument used here to turn diag(T) ≺ spec(T) into scalar inequalities."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01` (Schur's majorization theorem, forward direction of Schur–Horn, Karamata form).

Already high-quality (score 94); the gap was that its cross-references stayed inside the Cauchy-interlacing family, despite the entry being fundamentally a **majorization** result (Karamata mentioned ×13). Added 2 links to the broader majorization/convexity cluster:

- `birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01` — Schur-convexity of collision probability via the **Hardy–Littlewood–Pólya doubly-stochastic form of majorization** ($p \prec q \iff p = Dq$), the same $\mathrm{diag}(T) \prec \mathrm{spec}(T)$ machinery this entry establishes, applied combinatorially.
- `amgm-inequality-oq-02-oq-02-oq-03` — **Muirhead's inequality** bunching step, the archetypal application of the majorization order, proved by the same Karamata/convexity argument.

Both targets verified to exist; descriptions checked against their statements. meta.json valid JSON, within size caps (5 cross-refs, cap 20).