### PR TITLE
Enrich Weyl inequalities keystone: surface its two child refinements

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
@@ -125,6 +125,16 @@
       "targetId": "cauchy-interlacing-theorem-oq-02",
       "relationship": "sibling",
       "description": "Sibling entry (Poincaré separation) — its conclusion explicitly names 'Weyl monotonicity, Lidskii' as reusable consequences of the keystone that 'likewise only need the dimension count to vary'. This entry realises that prediction for the Weyl inequalities."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-03-oq-01",
+      "relationship": "extended-by",
+      "description": "Child refinement — turns the additive Weyl inequalities proved here into the a-priori operator-norm stability bound |μ(k) − ν(k)| ≤ ‖T − U‖ for the k-th eigenvalue under a Hermitian perturbation."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-03-oq-02",
+      "relationship": "extended-by",
+      "description": "Child refinement — derives the dual Weyl inequality μ(i) + ν(j) ≤ ρ(k) by negation, the companion of the additive bound established here in the sub/super-additive pair."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-03` (Weyl's eigenvalue inequalities from the Courant–Fischer keystone).

This hub entry listed only its parent and sibling, though two child entries build directly on it and already link back as `child-of`. Added the reciprocal forward links so the keystone page surfaces its refinements:
- `cauchy-interlacing-theorem-oq-03-oq-01` — Weyl operator-norm stability bound $|\mu_k - \nu_k| \le \|T-U\|$
- `cauchy-interlacing-theorem-oq-03-oq-02` — the dual Weyl inequality by negation

Both targets exist; valid JSON, within caps (4 cross-refs).