### PR TITLE
Research: prob-method-expectation-oq-04 — resolve OQ-04 (Erdős 1947 clique bound) [VERIFIED]

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ04.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ04.lean
@@ -126,4 +126,93 @@ theorem expectedMonoCliques_le (n k : ℕ) :
   have h := Nat.choose_le_pow_div k n (α := ℚ)
   simpa using h
 
+/-! ## The ℕ-power inequality behind Erdős 1947 (OQ-04 core)
+
+OQ-04 asks to strengthen `expected_mono_cliques` to `E(n,k) < 1` for `n < 2^(k/2)`.
+Via `expectedMonoCliques_lt_one_iff` this reduces to the pure `ℕ`-power inequality
+`2·C(n,k) < 2^{C(k,2)}`, and the half-integer hypothesis `n < 2^(k/2)` is equivalent
+(square both sides) to the clean `ℕ` statement `n² < 2^k`.  This section discharges
+that inequality outright (`erdos_1947_clique_bound`), so OQ-04's target
+`expectedMonoCliques n k < 1` now holds unconditionally on `n² < 2^k`, `k ≥ 3`
+(`expectedMonoCliques_lt_one_of_sq_lt`).  Mathematically this is the Erdős 1947
+diagonal Ramsey lower bound `R(k,k) > n` for every `n` with `n² < 2^k`.
+
+The proof compares squares to stay entirely in `ℕ`: from `C(n,k)·k! ≤ nᵏ`
+(`Nat.descFactorial_le_pow`) and `n² < 2^k` one gets
+`(2·C(n,k))²·(k!)² ≤ 4·n^{2k} < 4·2^{k²} = 2^{k²+2}`, while
+`(2^{C(k,2)})²·(k!)² ≥ 2^{2·C(k,2)}·2^{k+2} = 2^{k²+2}` using the factorial growth
+lemma `2^{k+2} ≤ (k!)²` and the identity `2·C(k,2)+k = k²`. -/
+
+/-- `2·C(k,2) + k = k²`, i.e. `2·C(k,2) = k(k−1)`.  Holds for every `k`. -/
+private lemma two_mul_choose_two_add (k : ℕ) : 2 * k.choose 2 + k = k * k := by
+  induction k with
+  | zero => rfl
+  | succ j ih =>
+    have h : (j + 1).choose 2 = j.choose 2 + j := by
+      rw [Nat.choose_succ_succ']
+      simp [Nat.choose_one_right, Nat.add_comm]
+    rw [h]; nlinarith [ih]
+
+/-- Factorial growth: `2^{k+2} ≤ (k!)²` for `k ≥ 3` (base `2⁵ = 32 ≤ 36 = (3!)²`). -/
+private lemma two_pow_add_two_le_factorial_sq {k : ℕ} (hk : 3 ≤ k) :
+    2 ^ (k + 2) ≤ (k.factorial) ^ 2 := by
+  induction k, hk using Nat.le_induction with
+  | base => decide
+  | succ k hk ih =>
+    calc 2 ^ (k + 1 + 2)
+        = 2 ^ (k + 2) * 2 := by rw [show k + 1 + 2 = (k + 2) + 1 from by ring, pow_succ]
+      _ ≤ (k.factorial) ^ 2 * 2 := by gcongr
+      _ ≤ (k.factorial) ^ 2 * (k + 1) ^ 2 := by gcongr; nlinarith [hk]
+      _ = ((k + 1).factorial) ^ 2 := by rw [Nat.factorial_succ]; ring
+
+/-- **Erdős 1947 clique bound (pure `ℕ` form).**  If `n² < 2^k` and `k ≥ 3`, then
+`2·C(n,k) < 2^{C(k,2)}`.  Combined with `expectedMonoCliques_lt_one_iff` this gives
+`E(n,k) < 1`, hence (strict first moment) a 2-colouring of `Kₙ` with no
+monochromatic `k`-clique — the diagonal Ramsey lower bound `R(k,k) > n`. -/
+theorem erdos_1947_clique_bound {n k : ℕ} (hk : 3 ≤ k) (hn : n ^ 2 < 2 ^ k) :
+    2 * n.choose k < 2 ^ (k.choose 2) := by
+  have hk0 : k ≠ 0 := by omega
+  -- `C(n,k)·k! ≤ nᵏ` via `descFactorial`.
+  have hCk : n.choose k * k.factorial ≤ n ^ k := by
+    have h := Nat.descFactorial_eq_factorial_mul_choose n k
+    have hle := Nat.descFactorial_le_pow n k
+    rw [h] at hle
+    calc n.choose k * k.factorial = k.factorial * n.choose k := by ring
+      _ ≤ n ^ k := hle
+  have hkey := two_mul_choose_two_add k
+  have hgrow := two_pow_add_two_le_factorial_sq hk
+  have hpow : (n ^ 2) ^ k < (2 ^ k) ^ k := Nat.pow_lt_pow_left hn hk0
+  -- Compare squares, multiplied through by `(k!)²`.
+  have hmul : (2 * n.choose k) ^ 2 * (k.factorial) ^ 2
+                < (2 ^ (k.choose 2)) ^ 2 * (k.factorial) ^ 2 := by
+    calc (2 * n.choose k) ^ 2 * (k.factorial) ^ 2
+        = 4 * (n.choose k * k.factorial) ^ 2 := by ring
+      _ ≤ 4 * (n ^ k) ^ 2 := by gcongr
+      _ = 4 * (n ^ 2) ^ k := by
+            have hnn : (n ^ k) ^ 2 = (n ^ 2) ^ k := by
+              rw [← pow_mul, ← pow_mul, Nat.mul_comm]
+            rw [hnn]
+      _ < 4 * (2 ^ k) ^ k := by gcongr
+      _ = 2 ^ (k * k + 2) := by
+            rw [← pow_mul, show (4 : ℕ) = 2 ^ 2 from rfl, ← pow_add, Nat.add_comm]
+      _ = 2 ^ (2 * k.choose 2 + k + 2) := by rw [← hkey]
+      _ = (2 ^ (k.choose 2)) ^ 2 * 2 ^ (k + 2) := by
+            rw [← pow_mul, ← pow_add]; congr 1; ring
+      _ ≤ (2 ^ (k.choose 2)) ^ 2 * (k.factorial) ^ 2 := by gcongr
+  have hsq : (2 * n.choose k) ^ 2 < (2 ^ (k.choose 2)) ^ 2 :=
+    lt_of_mul_lt_mul_right hmul (Nat.zero_le _)
+  exact lt_of_pow_lt_pow_left₀ 2 (Nat.zero_le _) hsq
+
+/-- **OQ-04 resolved.**  The expected number of monochromatic `k`-cliques is `< 1`
+whenever `n² < 2^k` (equivalently `n < 2^{k/2}`) and `k ≥ 3` — the strengthening of
+`expected_mono_cliques` the gallery entry asked for.  By the strict first moment
+principle this exhibits a 2-colouring of `Kₙ` with no monochromatic `k`-clique. -/
+theorem expectedMonoCliques_lt_one_of_sq_lt {n k : ℕ} (hk : 3 ≤ k) (hn : n ^ 2 < 2 ^ k) :
+    expectedMonoCliques n k < 1 := by
+  rw [expectedMonoCliques_lt_one_iff]
+  have h := erdos_1947_clique_bound hk hn
+  have hcast : ((2 * n.choose k : ℕ) : ℚ) < ((2 ^ k.choose 2 : ℕ) : ℚ) := by exact_mod_cast h
+  push_cast at hcast
+  linarith
+
 end ProbMethod.ExpectationOQ04

--- a/research/problems/prob-method-expectation-oq-04/knowledge.md
+++ b/research/problems/prob-method-expectation-oq-04/knowledge.md
@@ -48,3 +48,25 @@ entirely in ℕ.
 Attempted to queue this on Aristotle 2026-07-08; MCP tool loaded but backend down
 ("Resource not found"). Direct Lean proof deferred (infra had transient exit-135/SIGBUS
 cache corruption this session).
+
+## RESOLVED (researcher-2, 2026-07-08)
+
+The clean ℕ target set out above is now **proved** in
+`ProbMethodExpectationOQ04.lean` (VERIFIED, 0 axioms, 0 sorries, no `native_decide`):
+
+- `erdos_1947_clique_bound (hk : 3 ≤ k) (hn : n^2 < 2^k) : 2 * n.choose k < 2^(k.choose 2)`
+- `expectedMonoCliques_lt_one_of_sq_lt (hk : 3 ≤ k) (hn : n^2 < 2^k) : expectedMonoCliques n k < 1`
+
+This closes OQ-04: the expected number of monochromatic `k`-cliques is `< 1` whenever
+`n² < 2^k` (⟺ `n < 2^(k/2)`), which is the Erdős 1947 diagonal Ramsey lower bound
+`R(k,k) > n`.
+
+### Proof (square-comparison, all ℕ)
+1. `C(n,k)·k! ≤ nᵏ` via `Nat.descFactorial_eq_factorial_mul_choose` + `Nat.descFactorial_le_pow`.
+2. Growth lemma `2^(k+2) ≤ (k!)²` for `k ≥ 3` (`Nat.le_induction`, base `2⁵=32 ≤ 36=(3!)²`).
+3. Identity `2·C(k,2) + k = k²` (induction via `Nat.choose_succ_succ'`).
+4. Multiply the target square through by `(k!)²`: `(2·C(n,k))²·(k!)² = 4·(C·k!)² ≤ 4·n^{2k}
+   = 4·(n²)ᵏ < 4·(2ᵏ)ᵏ = 2^{k²+2} = 2^{2·C(k,2)}·2^{k+2} ≤ (2^{C(k,2)})²·(k!)²`, then
+   `lt_of_mul_lt_mul_right` and `lt_of_pow_lt_pow_left₀`.
+
+Build: first try, 7743 jobs, `#print axioms` = `[propext, Classical.choice, Quot.sound]` only.

--- a/src/data/research/problems/prob-method-expectation-oq-04.json
+++ b/src/data/research/problems/prob-method-expectation-oq-04.json
@@ -32,18 +32,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE. Child of prob-method-expectation (strict first moment principle over ℚ on finite sets). The parent's strict E[X] > t ⟹ ∃ X(ω) > t cannot conclude at the threshold E[X] = t. This entry adds the non-strict averaging lemmas: exists_ge_of_card_mul_le / exists_le_of_card_mul_ge (division-free practical forms t·|s| ≤ ∑f ⟹ ∃ f a ≥ t), exists_ge_average / exists_le_average (some element at least/at most the mean), first_moment_ge / first_moment_le (non-strict threshold). ProbMethodExpectationOQ04.lean, 6 theorems, 0 axioms, 0 sorries, no native_decide.",
+    "progressSummary": "RESOLVED. OQ-04 asked to strengthen expected_mono_cliques to E(n,k) < 1 for n < 2^(k/2). ProbMethodExpectationOQ04.lean now PROVES this: erdos_1947_clique_bound (n^2 < 2^k ∧ k≥3 ⟹ 2·C(n,k) < 2^C(k,2)) discharges the pure-ℕ power inequality the prior session had only reduced to, and expectedMonoCliques_lt_one_of_sq_lt combines it with expectedMonoCliques_lt_one_iff to give E(n,k) < 1 unconditionally on n^2 < 2^k. This is the Erdős 1947 diagonal Ramsey lower bound R(k,k) > n. Proof compares squares to stay in ℕ (descFactorial_le_pow + factorial growth 2^(k+2) ≤ (k!)^2 + identity 2·C(k,2)+k = k^2). Verified: 0 axioms (propext/Classical/Quot only), 0 sorries, no native_decide. Also retains the non-strict first-moment averaging lemmas.",
     "builtItems": [
       "ProbMethodExpectationOQ04.lean: 6 theorems, 0 axioms (propext/Classical.choice/Quot.sound), 0 sorries.",
       "exists_ge_of_card_mul_le / exists_le_of_card_mul_ge: division-free first moment via by_contra + Finset.sum_lt_sum_of_nonempty + sum_const/nsmul_eq_mul + linarith.",
       "exists_ge_average / exists_le_average: some element ≥/≤ the mean (∑f)/|s| (reduce to the division-free form via le_of_eq + field_simp).",
-      "first_moment_ge / first_moment_le: non-strict threshold (E[X] ≥ t ⟹ ∃ f a ≥ t) via the average lemma + le_trans."
+      "first_moment_ge / first_moment_le: non-strict threshold (E[X] ≥ t ⟹ ∃ f a ≥ t) via the average lemma + le_trans.",
+      "erdos_1947_clique_bound in ProbMethodExpectationOQ04.lean (n^2<2^k, k≥3 ⟹ 2·C(n,k) < 2^C(k,2))",
+      "expectedMonoCliques_lt_one_of_sq_lt in ProbMethodExpectationOQ04.lean (E(n,k) < 1 for n^2<2^k, k≥3 — OQ-04 target)",
+      "two_pow_add_two_le_factorial_sq and two_mul_choose_two_add helper lemmas"
     ],
     "insights": [
       "The division-free shapes (t·|s| ≤ ∑f ⟹ ∃ f a ≥ t) are the practical lower-bound forms of the first moment method — they avoid dividing by |s| and feed directly into existence arguments.",
       "Core proof: by_contra, push_neg gives ∀ a ∈ s, f a < t; Finset.sum_lt_sum_of_nonempty (strict, needs Nonempty) gives ∑ f < ∑ t = |s|·t; mul_comm + linarith contradicts the hypothesis.",
       "Average forms reduce to the division-free forms: the side goal (∑f/|s|)·|s| = ∑f (or its ≤) is closed by le_of_eq + field_simp with |s| ≠ 0 (from Nonempty.card_pos).",
-      "Non-strict completes strict: first_moment_principle (parent) handles E[X] > t; first_moment_ge handles E[X] ≥ t, the boundary the strict form misses."
+      "Non-strict completes strict: first_moment_principle (parent) handles E[X] > t; first_moment_ge handles E[X] ≥ t, the boundary the strict form misses.",
+      "OQ-04 fully resolved: the half-integer hypothesis n < 2^(k/2) is equivalent (squaring) to the clean ℕ statement n^2 < 2^k, sidestepping rpow entirely.",
+      "Square-comparison keeps the whole Erdős 1947 argument in ℕ: prove (2·C(n,k))^2 < (2^C(k,2))^2 via multiplying through by (k!)^2, then lt_of_pow_lt_pow_left₀.",
+      "Key sublemmas: Nat.descFactorial_le_pow gives C(n,k)·k! ≤ n^k; factorial growth 2^(k+2) ≤ (k!)^2 (induction, base 32 ≤ 36); and 2·C(k,2)+k = k^2 (induction via choose_succ_succ)."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Resolves the gallery open question **OQ-04** on `prob-method-expectation`: *"Can the
`expected_mono_cliques` result be strengthened to show the count is `< 1` for `n < 2^(k/2)`?"*

A prior session (in `ProbMethodExpectationOQ04.lean`) had reduced `E(n,k) < 1` to the pure
ℕ-power inequality `2·C(n,k) < 2^{C(k,2)}` but left it as an open target. This PR **proves**
that inequality outright, closing OQ-04.

## Progress
New verified theorems in `proofs/Proofs/ProbMethodExpectationOQ04.lean`:

- `erdos_1947_clique_bound {n k} (hk : 3 ≤ k) (hn : n^2 < 2^k) : 2 * n.choose k < 2^(k.choose 2)`
- `expectedMonoCliques_lt_one_of_sq_lt {n k} (hk : 3 ≤ k) (hn : n^2 < 2^k) : expectedMonoCliques n k < 1`

plus two supporting lemmas (`two_mul_choose_two_add`, `two_pow_add_two_le_factorial_sq`).

The half-integer hypothesis `n < 2^(k/2)` is equivalent (squaring) to the clean ℕ statement
`n² < 2^k`. Mathematically `expectedMonoCliques_lt_one_of_sq_lt` is the **Erdős 1947 diagonal
Ramsey lower bound** `R(k,k) > n`: `E < 1` plus the strict first moment principle exhibits a
2-colouring of `Kₙ` with no monochromatic `k`-clique.

## Proof
Square-comparison to stay entirely in ℕ:
1. `C(n,k)·k! ≤ nᵏ` (`Nat.descFactorial_eq_factorial_mul_choose` + `Nat.descFactorial_le_pow`).
2. Factorial growth `2^{k+2} ≤ (k!)²` for `k ≥ 3` (`Nat.le_induction`, base `2⁵=32 ≤ 36=(3!)²`).
3. Identity `2·C(k,2)+k = k²` (induction via `Nat.choose_succ_succ'`).
4. Multiply the target square by `(k!)²`:
   `(2·C(n,k))²·(k!)² = 4·(C·k!)² ≤ 4·n^{2k} = 4·(n²)ᵏ < 4·(2ᵏ)ᵏ = 2^{k²+2}
    = 2^{2·C(k,2)}·2^{k+2} ≤ (2^{C(k,2)})²·(k!)²`, then `lt_of_mul_lt_mul_right` and
   `lt_of_pow_lt_pow_left₀`.

## Verification
- Docker build: **success first try** (7743 jobs).
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only —
  **0 `axiom` declarations, 0 sorries, no `native_decide`**.

## Status
**Outcome**: completed (OQ-04 resolved)
**Next Steps**: optional — connect to a formal Mathlib `SimpleGraph` Ramsey-number definition
to state `R(k,k) > n` as a graph-theoretic corollary (would need Ramsey infra not yet in Mathlib).

🤖 Generated by researcher-2