### PR TITLE
audit: re-audit 55 metas changed since last audit — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -124,14 +124,14 @@
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-25T10:50:06Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T11:02:56Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -1857,15 +1857,15 @@
       "issues": []
     },
     "baire-category-theorem-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "baire-category-theorem-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-27T03:27:07Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "baire-category-theorem-oq-01-oq-01-oq-02": {
@@ -1875,15 +1875,15 @@
       "result": "clean"
     },
     "baire-category-theorem-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "baire-category-theorem-oq-01-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T18:00:00Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "baire-category-theorem-oq-01-oq-03": {
@@ -2131,9 +2131,9 @@
       "issues": []
     },
     "banach-steinhaus-theorem-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-25T02:12:18Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "basel-problem": {
@@ -3949,10 +3949,10 @@
       "issues": []
     },
     "burnside-counting": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-07-08T17:18:11Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-07-08T17:35:39Z",
+      "result": "clean"
     },
     "burnside-counting-oq-03": {
       "auditCount": 3,
@@ -4385,8 +4385,8 @@
       "issues": []
     },
     "catalan-numbers-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T20:35:47Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -4555,9 +4555,9 @@
       "issues": []
     },
     "cauchy-interlacing-theorem-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-21T03:54:08Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-01": {
@@ -4585,9 +4585,9 @@
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-02": {
@@ -4609,21 +4609,21 @@
       "issues": []
     },
     "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T03:41:26Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
     "cauchy-interlacing-theorem-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-21T03:54:08Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-20T00:00:00Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-03-oq-01": {
@@ -4633,9 +4633,9 @@
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-03-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T00:00:00Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-03-oq-02": {
@@ -6252,8 +6252,8 @@
       "result": "clean"
     },
     "collatz-structured-oq-02-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-27T09:42:14Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -6616,9 +6616,9 @@
       "result": "clean"
     },
     "connected-space-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "connected-space-oq-01-oq-02": {
@@ -7351,8 +7351,8 @@
       "issues": []
     },
     "descartes-circle-theorem-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T21:30:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -8110,63 +8110,63 @@
       ]
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-02": {
@@ -8205,9 +8205,9 @@
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-07-08T05:29:02Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01": {
@@ -10049,8 +10049,8 @@
     },
     "erdos-1110": {
       "agentId": "auditor-loop",
-      "auditCount": 5,
-      "lastAudited": "2026-07-08T06:56:48Z",
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "notes": "Re-audit CLEAN: meta status/badge/sorries/axiomCount all reconcile with Lean source. Sorry-count 'mismatches' from companion *Aristotle scaffolds are not counted (meta.sorries tracks main file). native_decide in erdos-1064 backs only illustrative examples with ofReduceBool disclosed; descartes axiomCount=1 = SturmReduction structure-encoded assumption, disclosed.",
       "issues": []
@@ -10569,9 +10569,9 @@
       "result": "clean"
     },
     "erdos-117-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:34Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "erdos-1170": {
@@ -15728,9 +15728,10 @@
     },
     "erdos-703": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:01Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T17:35:39Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-704": {
       "agentId": "auditor-cycle-20-batch",
@@ -16224,9 +16225,10 @@
     },
     "erdos-771": {
       "agentId": "auditor-agent",
-      "auditCount": 6,
-      "lastAudited": "2026-07-08T17:28:05Z",
-      "result": "issues-fixed"
+      "auditCount": 7,
+      "lastAudited": "2026-07-08T17:35:39Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-771-construction": {
       "auditCount": 1,
@@ -17182,8 +17184,8 @@
       "issues": []
     },
     "erdos-897-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T23:32:52Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -17207,9 +17209,10 @@
     },
     "erdos-90": {
       "agentId": "auditor-agent",
-      "auditCount": 5,
-      "lastAudited": "2026-07-08T16:57:03Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T17:35:39Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-900": {
       "agentId": "auditor-cycle-20-batch",
@@ -17990,8 +17993,8 @@
     },
     "erdos-mordell-inequality-oq-01": {
       "agentId": "auditor-agent",
-      "auditCount": 2,
-      "lastAudited": "2026-06-19T07:45:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -20228,15 +20231,15 @@
       "issues": []
     },
     "halls-theorem-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "halls-theorem-oq-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-25T23:56:46Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "halls-theorem-oq-02": {
@@ -20638,9 +20641,9 @@
       "issues": []
     },
     "hilbert-17-oq-03-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T14:45:41Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
+      "result": "clean",
       "issues": []
     },
     "hilbert-17-oq-03-oq-04": {
@@ -20754,8 +20757,8 @@
       "result": "clean"
     },
     "hilbert-4-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T04:00:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -21824,8 +21827,8 @@
       "issues": []
     },
     "lagrange-theorem-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-01T07:11:43Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -22328,8 +22331,8 @@
       "issues": []
     },
     "lifting-the-exponent-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T23:05:01Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -22765,9 +22768,9 @@
       "issues": []
     },
     "mellin-power-convergence-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-25T02:12:18Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "menelaus-theorem-oq-01": {
@@ -23798,14 +23801,14 @@
       "result": "clean"
     },
     "prob-method-expectation-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "prob-method-expectation-oq-02-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-01T00:31:57Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -23986,9 +23989,9 @@
       "result": "clean"
     },
     "ptolemys-theorem-oq-01-oq-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T00:00:00Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "ptolemys-theorem-oq-01-oq-01-oq-03-oq-01": {
@@ -24593,8 +24596,8 @@
       "result": "clean"
     },
     "schroeder-bernstein-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T02:32:09Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -24649,8 +24652,8 @@
       ]
     },
     "second-isomorphism-theorem-modules-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T23:05:02Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -25787,14 +25790,14 @@
       "result": "clean"
     },
     "sylow-theorem-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "sylow-theorem-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T21:43:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": []
     },
@@ -27618,9 +27621,9 @@
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-08T04:59:24Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-05-oq-02": {
@@ -28056,15 +28059,15 @@
       "result": "clean"
     },
     "erdos-10-wip-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-08T04:59:24Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "erdos-10-wip-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-08T04:59:24Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "erdos-1000-oq-02": {
@@ -28482,9 +28485,9 @@
       "result": "clean"
     },
     "halls-theorem-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-08T04:59:24Z",
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean"
     },
     "halls-theorem-oq-02-oq-01": {
@@ -29569,8 +29572,8 @@
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-07-08T06:56:48Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T17:35:39Z",
       "result": "clean",
       "issues": [],
       "notes": "Re-audit CLEAN: meta status/badge/sorries/axiomCount all reconcile with Lean source. Sorry-count 'mismatches' from companion *Aristotle scaffolds are not counted (meta.sorries tracks main file). native_decide in erdos-1064 backs only illustrative examples with ofReduceBool disclosed; descartes axiomCount=1 = SturmReduction structure-encoded assumption, disclosed."
@@ -29589,5 +29592,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T17:28:05Z"
+  "lastUpdated": "2026-07-08T17:35:39Z"
 }


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Backlog is at 0 (all 4779 proofs audited). This sweep re-audits the **55 gallery entries whose `meta.json` was committed *after* their tracker `lastAudited` timestamp** — mostly the recent enrichment/cross-reference batch (#35351, #35354, #35356, etc.).

## Method

Mechanical integrity check per slug: comment-strip the Lean sources (primary `leanFile` + all `additionalFiles`), count real `sorry` / `axiom` / `: True` occurrences, and compare against meta claims (`status`, `badge`, `sorries`, `axiomCount`).

## Result: all 55 clean

- **verified/original/mathlib** entries: 0 sorry, 0 axiom, 0 True-stub ✓
- **axiomatized** entries (`collatz-structured-oq-02-oq-03`, `erdos-1110`, `erdos-703`, `erdos-117-oq-01`, `erdos-771`, `erdos-90`): declared axiom counts match; sorries are either 0 in the primary file or confined to `*Aristotle.lean` scaffold companions (design-tolerated by `find-targets.ts`; `status=axiomatized` so no overclaim).
- `erdos-90`: `meta.sorries=1` correctly counts the single real sorry (the `OpenAI2026LowerBound` headline lower-bound theorem, honestly axiomatized).
- `erdos-771`: previously-stale "7 sorries" prose already reconciled upstream by #35354; current file is 0-sorry (primary) with 2 axioms.

No integrity issues found. Tracker entries bumped (`auditCount++`, `lastAudited`, `result=clean`).

---
Discovered during autonomous gallery integrity re-audit.