### PR TITLE
research(erdos-1093-oq-02): density bound (deficiency + #primes ≤ k) + sharpen open core to k≥10 [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -147,3 +147,80 @@ OQ-02 is automatic for `k ≤ 9`.
 theorem deficiency_le_nine_of_k_le_nine {n k : ℕ} (hk : k ≤ 9) :
     deficiency n k ≤ 9 :=
   (deficiency_le n k).trans hk
+
+/-
+## Section V: A density bound — high deficiency forces few primes in the window
+
+The trivial bound `deficiency n k ≤ k` treats every one of the `k` consecutive
+integers `n, n-1, …, n-k+1` as a potential smooth contributor.  But a *prime*
+value in that window can never contribute: for an admissible pair every value
+`n - i` (`i < k`, `n ≥ 2k`) exceeds `k`, and a `k`-smooth number `> k` cannot be
+prime (a prime is `k`-smooth iff it is `≤ k`).  Hence the deficiency is bounded
+by the number of *non-prime* values in the window, and — the sharper statement —
+`deficiency + (#primes in the window) ≤ k`.  A large deficiency therefore forces
+the length-`k` window of consecutive integers to contain few primes, exactly the
+density phenomenon the Erdős–Lacampagne–Selfridge bound exploits.
+-/
+
+/-- Every value `n - i` in the deficiency window exceeds `k` (needs `i < k`,
+`n ≥ 2k`). -/
+theorem window_value_gt_k {n k i : ℕ} (hi : i < k) (hn : 2 * k ≤ n) :
+    k < n - i := by omega
+
+/-- A smooth contributor to the deficiency is never prime: it exceeds `k`, and a
+`k`-smooth number `> k` cannot be prime (a prime `p` is `k`-smooth iff `p ≤ k`). -/
+theorem smooth_contributor_not_prime {n k i : ℕ} (hi : i < k) (hn : 2 * k ≤ n)
+    (hs : IsKSmooth k (n - i)) : ¬ (n - i).Prime := by
+  intro hp
+  have hle : n - i ≤ k := (isKSmooth_prime_iff hp).mp hs
+  have hgt : k < n - i := window_value_gt_k hi hn
+  omega
+
+/-- **Density bound (weak form).**  The deficiency is at most the number of
+non-prime values among the `k` consecutive integers `n, …, n-k+1`. -/
+theorem deficiency_le_nonprime_count {n k : ℕ} (hn : 2 * k ≤ n) :
+    deficiency n k ≤
+      ((Finset.range k).filter (fun i => ¬ (n - i).Prime)).card := by
+  unfold deficiency
+  apply Finset.card_le_card
+  intro i hi
+  rw [Finset.mem_filter] at hi ⊢
+  obtain ⟨hir, hsmooth⟩ := hi
+  exact ⟨hir, smooth_contributor_not_prime (Finset.mem_range.mp hir) hn hsmooth⟩
+
+/-- **Density bound (sharp form).**  The deficiency plus the number of primes in
+the length-`k` window `n, …, n-k+1` is at most `k`.  Equivalently, an admissible
+pair with deficiency `d` has at most `k - d` primes among its `k` consecutive
+integers, so a record-breaking deficiency forces an unusually prime-poor window. -/
+theorem deficiency_add_prime_count_le {n k : ℕ} (hn : 2 * k ≤ n) :
+    deficiency n k
+      + ((Finset.range k).filter (fun i => (n - i).Prime)).card ≤ k := by
+  have hpart :
+      ((Finset.range k).filter (fun i => (n - i).Prime)).card
+        + ((Finset.range k).filter (fun i => ¬ (n - i).Prime)).card = k := by
+    rw [Finset.filter_card_add_filter_neg_card_eq_card, Finset.card_range]
+  have hd := deficiency_le_nonprime_count (n := n) (k := k) hn
+  omega
+
+/-
+## Section VI: Sharpening the open core to `k ≥ 10`
+
+Combining the trivial bound with the existence half, the whole conjecture
+`MaximalDeficiencyIs 9` collapses to a universal statement quantified only over
+`k ≥ 10`: the cases `k ≤ 9` are automatic from `deficiency ≤ k`.
+-/
+
+/-- **Sharpened reduction.**  `MaximalDeficiencyIs 9` is equivalent to the open
+statement restricted to `k ≥ 10`; the small cases `k ≤ 9` are discharged by the
+trivial bound.  This is strictly sharper than
+`maximalDeficiencyIs_nine_iff_upperBound`. -/
+theorem maximalDeficiencyIs_nine_iff_kGe10 :
+    MaximalDeficiencyIs 9 ↔
+      ∀ n k, 10 ≤ k → ValidDeficiencyExample n k → deficiency n k ≤ 9 := by
+  rw [maximalDeficiencyIs_nine_iff_upperBound]
+  constructor
+  · intro h n k _ hv; exact h n k hv
+  · intro h n k hv
+    by_cases hk : k ≤ 9
+    · exact deficiency_le_nine_of_k_le_nine hk
+    · exact h n k (by omega) hv

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -14,6 +14,49 @@ or do higher values occur? (The universal upper-bound direction is open.)
 
 ---
 
+## Session 2026-07-08 (Session 2) — Density bound + sharpened reduction
+
+**Mode:** REVISIT (MODERATE knowledge tier, highest available)
+**Outcome:** progress
+
+### What I Did
+- Added the first **non-trivial upper bound** on the deficiency to the OQ-02
+  file (Section V), all `ofReduceBool`-free (no `native_decide`):
+  - `smooth_contributor_not_prime` — every smooth contributor `n−i` (`i<k`,
+    `n≥2k`) is composite: it exceeds `k`, and a `k`-smooth number `>k` cannot be
+    prime (`isKSmooth_prime_iff`).
+  - `deficiency_le_nonprime_count` — weak form: `deficiency ≤ #{i<k : ¬(n−i).Prime}`
+    (smooth filter ⊆ non-prime filter).
+  - `deficiency_add_prime_count_le` — **sharp density bound**:
+    `deficiency n k + #{i<k : (n−i).Prime} ≤ k`.
+- Added `maximalDeficiencyIs_nine_iff_kGe10` (Section VI): the conjecture is
+  equivalent to the open statement quantified only over `k ≥ 10` (small `k`
+  discharged by the trivial bound). Strictly sharper than
+  `maximalDeficiencyIs_nine_iff_upperBound`.
+- Built clean: `Proofs.Erdos1093ProblemOQ02` (3059 jobs), 0 sorry, 0 new axioms.
+
+### Key Findings
+- **Primes in the window contribute nothing.** The `k` consecutive integers
+  `n, …, n−k+1` all exceed `k` (admissible ⇒ `n ≥ 2k`), and a prime is
+  `k`-smooth iff `≤ k`. So the trivial `deficiency ≤ k` upgrades to
+  `deficiency ≤ k − (#primes in window)` — the first genuine upper bound here.
+- **Reframes the open core.** A hypothetical deficiency `> 9` at `k ≥ 10` needs a
+  length-`k` run of consecutive integers with `< k−9` primes: an exceptionally
+  prime-poor window. This is exactly the density input the ELS bound
+  (`els_upper_bound`, `n ≪ 2^k√k`) formalizes.
+
+### Files Modified
+- `proofs/Proofs/Erdos1093ProblemOQ02.lean` (Sections V–VI, +~75 lines, verified)
+- `src/data/research/problems/erdos-1093-oq-02.json` (knowledge)
+
+### Next Steps
+- Quantify: combine `deficiency + #primes ≤ k` with a prime-count lower bound on
+  `[n−k+1, n]` (Brun–Titchmarsh) to force `k`-dependent upper bounds for `k ≥ 10`.
+- Attempt `k = 10, 11, 12` slices via the composite-contributor structure plus
+  the `p ∤ C(n,k)` admissibility constraint.
+
+---
+
 ## Session 2026-07-08 (Session 1) — Record admissibility + reduction
 
 **Mode:** FRESH

--- a/src/data/research/problems/erdos-1093-oq-02.json
+++ b/src/data/research/problems/erdos-1093-oq-02.json
@@ -10,7 +10,11 @@
   "tier": "C",
   "significance": 5,
   "tractability": 3,
-  "tags": ["erdos", "smooth-numbers", "binomial-coefficients"],
+  "tags": [
+    "erdos",
+    "smooth-numbers",
+    "binomial-coefficients"
+  ],
   "problemStatement": {
     "plain": "The deficiency of C(n,k) (for n>=2k, when C(n,k) has no prime factor <= k) is the number of 0<=i<k with n-i being k-smooth. The current record is deficiency(C(284,28))=9. OQ-02 asks: is 9 the maximum possible deficiency over all admissible (n,k), or do higher values occur?",
     "formal": "MaximalDeficiencyIs 9 := (exists admissible (n,k) with deficiency n k = 9) and (forall admissible (n,k), deficiency n k <= 9)."
@@ -29,7 +33,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS: existence half of OQ-02 machine-verified; the full conjecture is reduced to a single open universal upper bound. Universal bound remains OPEN.",
+    "progressSummary": "PROGRESS: added first non-trivial upper bound (density bound deficiency + #primes ≤ k, ofReduceBool-free) and sharpened the reduction to k≥10. Universal bound remains OPEN.",
     "builtItems": [
       "noSmallPrimeFactors_iff (Erdos1093ProblemOQ02.lean) — decidable reduction of the admissibility side-condition (unbounded ∀ prime) to a bounded check over primes p ≤ k; ofReduceBool-free.",
       "noSmallPrimeFactors_284_28 — the record pair (284,28) is admissible: no prime ≤ 28 divides C(284,28) (parent verified only the count = 9, never admissibility).",
@@ -37,18 +41,26 @@
       "exists_deficiency_nine — existence half of OQ-02: an admissible example attains deficiency 9.",
       "maximalDeficiencyIs_nine_iff_upperBound — MaximalDeficiencyIs 9 ⇔ (no admissible pair has deficiency > 9); isolates the open content.",
       "deficiency_le_nine_of_k_le_nine — OQ-02 is automatic for k ≤ 9 (from the trivial bound deficiency ≤ k), confining the open part to k ≥ 10.",
-      "Repaired the parent Erdos1093Problem.lean (broken on main: omega at L173 in isKSmooth_one lacked p.Prime's two_le) — parent now builds (3058 jobs)."
+      "Repaired the parent Erdos1093Problem.lean (broken on main: omega at L173 in isKSmooth_one lacked p.Prime's two_le) — parent now builds (3058 jobs).",
+      "deficiency_add_prime_count_le (Erdos1093ProblemOQ02.lean) — DENSITY BOUND (ofReduceBool-free): deficiency n k + #{i<k : (n-i).Prime} ≤ k. Sharper than the trivial deficiency ≤ k; a record deficiency forces a prime-poor length-k window (the ELS density phenomenon).",
+      "deficiency_le_nonprime_count — weak form: deficiency ≤ #{i<k : ¬(n-i).Prime}; the smooth filter ⊆ the non-prime filter.",
+      "smooth_contributor_not_prime — every smooth contributor n-i (i<k, n≥2k) is composite: it exceeds k, and a k-smooth number > k cannot be prime (isKSmooth_prime_iff).",
+      "maximalDeficiencyIs_nine_iff_kGe10 — sharpened reduction: MaximalDeficiencyIs 9 ⇔ (∀ admissible with k≥10, deficiency ≤ 9). Strictly sharper than maximalDeficiencyIs_nine_iff_upperBound; discharges k≤9 via the trivial bound."
     ],
     "insights": [
       "The parent's deficiency_284_28 = 9 alone does NOT exhibit a valid deficiency example: the deficiency count is defined unconditionally, but the ELS problem requires C(n,k) to have no prime factor ≤ k. Checking admissibility only needs primes ≤ k (Kummer is unnecessary): C(284,28) is a ~110-bit bignum, so native_decide computes it and tests divisibility by primes ≤ 28 instantly.",
       "The maximality question splits cleanly: the existence half is a finite verification (attained at (284,28)); the universal half (no admissible pair exceeds 9) is the genuinely open content and cannot be enumerated (unbounded n, k).",
-      "Trivial bound deficiency ≤ k means any counterexample needs k ≥ 10; the ELS bound n ≪ 2^k·√k (parent axiom els_upper_bound) bounds n per fixed k but the number of k-values is still unbounded."
+      "Trivial bound deficiency ≤ k means any counterexample needs k ≥ 10; the ELS bound n ≪ 2^k·√k (parent axiom els_upper_bound) bounds n per fixed k but the number of k-values is still unbounded.",
+      "Primes in the k-consecutive-integer window contribute ZERO to the deficiency: for admissible pairs each n-i > k, and a prime is k-smooth iff ≤ k. This upgrades the trivial bound deficiency ≤ k to deficiency ≤ (#non-primes in window) = k − (#primes in window) — the first non-trivial upper bound in the file and a concrete step toward the open universal bound.",
+      "The density bound reframes the open core: a hypothetical deficiency > 9 at k ≥ 10 requires a length-k run of consecutive integers containing < k−9 primes, i.e. an exceptionally prime-poor window — precisely the input ELS bound the axiomatized els_upper_bound to n ≪ 2^k√k."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Attack the universal upper bound for small k ≥ 10: for each fixed k the ELS bound gives a finite search range n ≤ C·2^k·√k, but C is not effective in the parent axiom — obtaining an explicit constant would make each fixed-k slice a finite (if large) decidable check.",
       "Prove structural constraints: an admissible pair with deficiency d forces d of the k consecutive integers n,n-1,...,n-k+1 to be k-smooth, a strong density constraint (Erdős–Lacampagne–Selfridge exploit this for the ≥1 ⇒ n ≪ 2^k√k bound).",
-      "Consider whether Kummer's theorem (carry count in base p) gives a cleaner ofReduceBool-free proof of noSmallPrimeFactors_284_28."
+      "Consider whether Kummer's theorem (carry count in base p) gives a cleaner ofReduceBool-free proof of noSmallPrimeFactors_284_28.",
+      "Quantify the density bound: combine deficiency + #primes ≤ k with a lower bound on primes in [n-k+1,n] (a Brun–Titchmarsh / prime-counting input) to force k-dependent upper bounds on deficiency for k ≥ 10.",
+      "Attempt k=10,11,12 slices: show no length-k window of admissible integers has ≥ 10 smooth values, using the composite-contributor structure plus the p∤C(n,k) admissibility constraint."
     ]
   }
 }


### PR DESCRIPTION
## Erdős #1093 OQ-02 — Is d(284,28)=9 the maximal deficiency?

**Status:** OPEN (universal upper bound). This session adds the **first non-trivial upper bound** on the deficiency and sharpens the open core. All new results are `native_decide`-free (`ofReduceBool`-free).

### Mathematical content

The deficiency of `C(n,k)` (for `n ≥ 2k`, `C(n,k)` with no prime factor `≤ k`) counts `i < k` with `n − i` being `k`-smooth. The trivial bound is `deficiency ≤ k`. This PR improves it:

- **`smooth_contributor_not_prime`** — every smooth contributor `n − i` (`i < k`, `n ≥ 2k`) is composite: it exceeds `k`, and a prime is `k`-smooth iff `≤ k`.
- **`deficiency_le_nonprime_count`** — weak form: `deficiency ≤ #{i<k : ¬(n−i).Prime}`.
- **`deficiency_add_prime_count_le`** — **sharp density bound:** `deficiency n k + #{i<k : (n−i).Prime} ≤ k`.

Interpretation: a record-breaking deficiency forces a length-`k` run of consecutive integers with few primes — precisely the density phenomenon the Erdős–Lacampagne–Selfridge bound (`n ≪ 2^k√k`) exploits.

- **`maximalDeficiencyIs_nine_iff_kGe10`** — sharpened reduction: `MaximalDeficiencyIs 9 ↔ (∀ admissible pairs with k ≥ 10, deficiency ≤ 9)`. Strictly sharper than the existing `maximalDeficiencyIs_nine_iff_upperBound`; the cases `k ≤ 9` are discharged by the trivial bound.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos1093ProblemOQ02` → **3059 jobs, 0 sorry, 0 new axiom declarations.**
- New theorems use no `native_decide`, so they do **not** depend on `Lean.ofReduceBool`.

### Honesty note
This is genuine but incremental progress toward the open universal bound: it replaces the trivial `≤ k` with a prime-density bound and confines the remaining open content to `k ≥ 10`. The universal bound itself remains OPEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)