### PR TITLE
research(kronecker-symbol): self-reciprocity of the prime 2, (n/2)=(2/n)

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -405,6 +405,28 @@ theorem kronecker_two_odd (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
   rw [kronecker_eq_jacobi 2 n hn hno, jacobiSym.at_two (Nat.odd_iff.mpr hno),
     ZMod.χ₈_nat_eq_if_mod_eight, if_neg (show ¬ n % 2 = 0 by omega)]
 
+/-- **Self-reciprocity of the prime 2.** For odd positive `n`, the value of the
+    `(·/2)` character `kronecker2` at `n` equals the fixed-numerator symbol
+    `(2/n) = kronecker 2 n`:
+
+    `(n/2) = (2/n)`.
+
+    This is the reciprocity law for the prime `2`: the two a-priori distinct
+    "2-characters" in this file — `kronecker2` (a function of the *numerator*,
+    the even real Dirichlet character mod 8 established in Section 6) and
+    `kronecker 2 ·` (a function of the *denominator*, evaluated in Section 8) —
+    agree on the odd integers. Both equal `+1` on residues `±1 (mod 8)` and `−1`
+    on residues `±3 (mod 8)`, so the identity reduces to a residue comparison
+    after `kronecker_two_odd`. `sorry`-free, axiom-free. -/
+theorem kronecker2_eq_kronecker_two (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker2 (n : ℤ) = kronecker 2 n := by
+  rw [kronecker_two_odd n hn hno]
+  unfold kronecker2
+  rw [if_neg (show ¬ (n : ℤ) % 2 = 0 by omega)]
+  by_cases h : n % 8 = 1 ∨ n % 8 = 7
+  · rw [if_pos h, if_pos (by omega)]
+  · rw [if_neg h, if_neg (by omega)]
+
 /-!
 ## Module note: what remains open
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
@@ -37,9 +37,29 @@ New declarations:
   *replays* its cached olean so the crash only appears once the file is edited.
   Commented the `#print axioms` block out; the file otherwise builds in ~2s.
 
+## Update (2026-07-08) — self-reciprocity of the prime 2
+
+New theorem `kronecker2_eq_kronecker_two (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1)`:
+`kronecker2 (n : ℤ) = kronecker 2 n`, i.e. `(n/2) = (2/n)` for odd positive `n`.
+This bridges the two a-priori distinct "2-characters" that coexist in the file:
+- `kronecker2` — a function of the *numerator*, the even real Dirichlet character
+  mod 8 (Section 6: `kronecker2_mul` / `_periodic` / `_neg` / `_values`), and
+- `kronecker 2 ·` — a function of the *denominator* (Section 8: `kronecker_two_odd`).
+They agree on the odd integers (both `+1` on `±1 mod 8`, `−1` on `±3 mod 8`), so
+the proof is `kronecker_two_odd` + `unfold kronecker2` + a residue comparison by
+`omega`. Build-verified (3058 jobs, 0 sorries, 0 axioms). `theoremCount` 25→26.
+
+*Build note:* the file still exhibits the documented exit-135 SIGSEGV on the
+first fresh build after an edit (elaborates fully — `3058/3058` — then crashes on
+finalization). A plain retry builds green (environmental / shared-volume, not a
+proof error). Do NOT edit the proof in response to a line-less 135.
+
 ## Open work
 
 1. Refine `kronecker` to use `kronecker2` at the 2-adic part (→ classical symbol
    at even moduli), then re-prove `kronecker_mul_right` for the refined def.
+   (`kronecker2_eq_kronecker_two` is a step toward this: it shows the refined and
+   current defs would agree at odd moduli, so only the even branch changes.)
 2. Target 2: generalized quadratic reciprocity for arbitrary fundamental
-   discriminants — supplementary laws + Gauss sums.
+   discriminants — supplementary laws (done: `kronecker_neg_one_odd`,
+   `kronecker_two_odd`) + Gauss sums (open).

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 455,
+    "lineCount": 477,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Advances `elementary-quadratic-reciprocity-oq-03-oq-02-wip-01` (RICH, previously COMPLETED for Target 1) with one new build-verified theorem.

**`kronecker2_eq_kronecker_two`** — for odd positive `n`:
```lean
kronecker2 (n : ℤ) = kronecker 2 n    -- i.e. (n/2) = (2/n)
```

This is the **self-reciprocity law for the prime 2**. The file carries two a-priori distinct "2-characters":
- `kronecker2` — a function of the *numerator*, established in Section 6 as the even real Dirichlet character mod 8 (`kronecker2_mul`/`_periodic`/`_neg`/`_values`);
- `kronecker 2 ·` — a function of the *denominator*, evaluated in Section 8 (`kronecker_two_odd`).

The theorem shows they **agree on the odd integers** (both `+1` on residues `±1 (mod 8)`, `−1` on `±3 (mod 8)`). The proof reduces to `kronecker_two_odd` + `unfold kronecker2` + a residue comparison discharged by `omega`.

This is also a concrete step toward open refinement (1) (wiring `kronecker2` into `kronecker`'s 2-adic branch): it confirms the refined and current definitions would coincide at all odd moduli, isolating the change to the even branch.

## Verification
- Build: `Proofs.ElementaryQuadraticReciprocityOQ03OQ02`, **3058 jobs green**, 0 sorries, 0 axioms.
- `leanFile` counts synced: `theoremCount` 25→26, `lineCount` 455→477.

## Honesty note
Modest increment on a mature file. Target 1 (full second-argument multiplicativity) was already complete; this adds a clean bridging identity, not a resolution of the remaining Gauss-sum reciprocity core (Target 2), which stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)