### PR TITLE
Enrich Ky Fan interlacing (oq-01-oq-02-oq-01): fix section schema so summaries render

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
@@ -89,16 +89,32 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview and Compression Setup",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "The module docstring states the Ky Fan interlacing package built on the parent Poincaré separation theorem: for a symmetric operator T on an (n+m)-dimensional space and its compression TH to an n-dimensional subspace H, the compression eigenvalues μ are trapped between the top and bottom n eigenvalues λ of T. The setup fixes the operators, eigenbases, eigenvalue lists (hlam/hmu antitone), the dimension hypotheses, and the Rayleigh-agreement hypothesis, then `include`s them into every theorem below."
+    },
+    {
+      "id": "ky-fan-sum-bounds",
       "title": "The Ky Fan Sum Bounds over an Arbitrary Index Set",
-      "content": "sum_mu_le_sum_top_lam and sum_bot_lam_le_sum_mu apply Finset.sum_le_sum to the two halves of the parent's Poincaré separation theorem. For any s : Finset (Fin n), the upper half μ_k ≤ λ_⟨k⟩ sums to ∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_⟨k⟩, and the lower half λ_⟨k+m⟩ ≤ μ_k sums to ∑_{k∈s} λ_⟨k+m⟩ ≤ ∑_{k∈s} μ_k. Leaving s free is the design choice that makes every later corollary a specialisation."
+      "startLine": 63,
+      "endLine": 77,
+      "summary": "sum_mu_le_sum_top_lam and sum_bot_lam_le_sum_mu apply Finset.sum_le_sum to the two halves of the parent's Poincaré separation theorem. For any s : Finset (Fin n), the upper half μ_k ≤ λ_⟨k⟩ sums to ∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_⟨k⟩, and the lower half λ_⟨k+m⟩ ≤ μ_k sums to ∑_{k∈s} λ_⟨k+m⟩ ≤ ∑_{k∈s} μ_k. Leaving s free is the design choice that makes every later corollary a specialisation."
     },
     {
+      "id": "weak-majorization",
       "title": "Weak Majorization: Top-j Partial Sums",
-      "content": "partial_sum_mu_le_partial_sum_lam specialises s to the initial segment {k : Fin n | (k : ℕ) < j}, giving ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k for every j : ℕ. This is the Ky Fan weak-majorization statement: the descending spectrum of the compression is weakly majorized by the largest eigenvalues of the full operator."
+      "startLine": 78,
+      "endLine": 92,
+      "summary": "partial_sum_mu_le_partial_sum_lam specialises s to the initial segment {k : Fin n | (k : ℕ) < j}, giving ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k for every j : ℕ. This is the Ky Fan weak-majorization statement: the descending spectrum of the compression is weakly majorized by the largest eigenvalues of the full operator."
     },
     {
+      "id": "trace-trapping",
       "title": "Trace Trapping",
-      "content": "trace_compress_le and trace_compress_ge specialise s to Finset.univ: the trace of the compression (the sum of all n of its eigenvalues) is at most the sum of the n largest eigenvalues of T and at least the sum of the n smallest (those with index m … n+m-1). trace_interlacing bundles the two as ∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j."
+      "startLine": 93,
+      "endLine": 116,
+      "summary": "trace_compress_le and trace_compress_ge specialise s to Finset.univ: the trace of the compression (the sum of all n of its eigenvalues) is at most the sum of the n largest eigenvalues of T and at least the sum of the n smallest (those with index m … n+m-1). trace_interlacing bundles the two as ∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-02-oq-01` (Ky Fan sum bounds / weak majorization / trace trapping). Prose, annotations (6, all with mathContext/significance), cross-references (3, valid `targetId` form), keyInsights, and references were already good (quality 94). This pass fixes the same **invisible-sections rendering bug** I fixed for the sibling entry in #35351:

**Problem.** The 3 sections were `{title, content}`, but `ProofSection` requires `{id, title, startLine, endLine, summary}` and `TableOfContents.tsx` renders `section.summary` / keys on `section.id`. So on the live site these sections showed a title with a **blank description**, no line anchoring, and the `content` prose was silently dropped.

**Fix.** Converted to **4 file-order sections** — `header` (1–62), `ky-fan-sum-bounds` (63–77), `weak-majorization` (78–92), `trace-trapping` (93–116) — each with an `id`, contiguous line range covering the full 116-line file, and the prose moved into `summary`. Added a header section (the original had none). No content lost.

_(Note: two pre-existing annotation-anchor lint warnings remain — `ann-compression-hypotheses` and `ann-include-directive` anchor to the `variable`/`include` setup block, which isn't a Lean *construct*; these don't affect rendering and are out of scope for this section fix.)_

meta.json 16.5 KB (cap ~60 KB). JSON validated via the gallery build. Distinct branch to avoid clobbering my open PRs.