### PR TITLE
Enrich Catalan linear recurrence: add generating-function ODE open question

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01/meta.json
@@ -135,7 +135,8 @@
     "implications": "Supplies the O(1) computational recurrence for Catalan numbers, which Mathlib previously offered only as the O(n) Segner convolution or the central-binomial closed form. It exhibits the Catalan sequence as holonomic of order one and makes single-step generation and induction on consecutive Catalan numbers straightforward.",
     "openQuestions": [
       "Derive the closed ratio C(n+1)/C(n) = 2(2n+1)/(n+2) over ℚ and use it to prove the asymptotic growth C(n+1)/C(n) → 4.",
-      "Prove the analogous first-order recurrence for the central Delannoy or Motzkin numbers, identifying which combinatorial sequences are holonomic of order one versus two."
+      "Prove the analogous first-order recurrence for the central Delannoy or Motzkin numbers, identifying which combinatorial sequences are holonomic of order one versus two.",
+      "Translate this first-order recurrence into the generating-function picture: show the Catalan generating function C(x) = Σ Cₙxⁿ satisfies the first-order linear ODE x(1−4x)·C'(x) + (1−2x)·C(x) − 1 = 0 (equivalently the algebraic equation x·C(x)² − C(x) + 1 = 0), making the holonomic-of-order-one property here exactly the D-finiteness of C(x). Mathlib has neither the ODE nor the recurrence↔ODE correspondence."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass — catalan-numbers-oq-01

The entry (quality 94, passes 0) already met every quality minimum: 6 full annotations, complete overview with 4 keyInsights, 5 cross-references, sections covering the whole 63-line Lean file, and it sits at 13.6 KB — well under the 60 KB size cap. Per the diminishing-returns rule I did **not** inflate it.

**One targeted, non-redundant addition** to `conclusion.openQuestions` (2 → 3): the existing questions omit the natural generating-function explanation of *why* this sequence is holonomic of order one. Added a question tying the first-order recurrence $(n+2)C_{n+1}=2(2n+1)C_n$ to the D-finiteness of the Catalan generating function — the linear ODE $x(1-4x)C'(x)+(1-2x)C(x)-1=0$ (equivalently the algebraic equation $xC(x)^2-C(x)+1=0$), a recurrence↔ODE correspondence Mathlib lacks.

- Size: 13.6 KB → 14.1 KB (well under cap)
- JSON validated; gallery build steps + search-index checks pass
- No status/badge/axiom changes (entry is verified, 0 axioms — accurate against the Lean source)