### PR TITLE
research(erdos-18-oq-01): first structural theorem — every practical number ≥ 2 is even [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -13,7 +13,9 @@
     `one_representable`, `self_representable`);
   * a **decidable bridge** `practical_of_check` turning `IsPractical m` into a
     finite check over `(divisors m).powerset`, and the verified practical numbers
-    `4`, `6`, `8` (extending the parent's `1`, `2` along OEIS A005153).
+    `4`, `6`, `8` (extending the parent's `1`, `2` along OEIS A005153);
+  * the first **structural** constraint — `practical_even`: every practical number
+    `m ≥ 2` is even (Srinivasan 1948), since `2` must be a sum of distinct divisors.
 
   All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -66,5 +68,43 @@ theorem six_practical : IsPractical 6 :=
 /-- **8 is practical** (divisors `{1,2,4,8}`: `1, 2, 1+2, 4, 1+4, 2+4, 1+2+4`). -/
 theorem eight_practical : IsPractical 8 :=
   practical_of_check (by norm_num) (by decide)
+
+/-- **Every practical number `≥ 2` is even** (Srinivasan 1948).  The first
+    *structural* constraint on practical numbers, beyond the representability
+    algebra and the small verified examples above.
+
+    Proof: `2` must be a sum of distinct divisors of `m`.  For `m = 2` the claim is
+    immediate; for `m ≥ 3` the representing set `S ⊆ divisors m` has `S.sum id = 2`
+    with all elements positive, so every element is `≤ 2`.  If `2 ∉ S` every element
+    is exactly `1`, forcing `S ⊆ {1}` and `S.sum id ≤ 1 < 2` — contradiction.  Hence
+    `2 ∈ S ⊆ divisors m`, i.e. `2 ∣ m`. -/
+theorem practical_even {m : ℕ} (hm : 2 ≤ m) (hp : IsPractical m) : 2 ∣ m := by
+  rcases eq_or_lt_of_le hm with h2 | h3
+  · exact ⟨1, by omega⟩
+  · obtain ⟨S, hSsub, hSsum⟩ := hp.2 2 (by norm_num) h3
+    by_contra hnot
+    have h2S : 2 ∉ S := fun h2mem => hnot (Nat.dvd_of_mem_divisors (hSsub h2mem))
+    have hall1 : ∀ x ∈ S, x = 1 := by
+      intro x hx
+      have hx1 : 1 ≤ x := Nat.pos_of_mem_divisors (hSsub hx)
+      have hx2 : x ≤ 2 := by
+        calc x = id x := rfl
+          _ ≤ S.sum id := Finset.single_le_sum (fun i _ => Nat.zero_le _) hx
+          _ = 2 := hSsum
+      rcases (by omega : x = 1 ∨ x = 2) with h | h
+      · exact h
+      · exact absurd (h ▸ hx) h2S
+    have hsub1 : S ⊆ ({1} : Finset ℕ) := fun x hx => Finset.mem_singleton.mpr (hall1 x hx)
+    have hone : ({1} : Finset ℕ).sum id = 1 := by simp
+    have hchain : S.sum id ≤ 1 := by
+      have hle : S.sum id ≤ ({1} : Finset ℕ).sum id := Finset.sum_le_sum_of_subset hsub1
+      rwa [hone] at hle
+    rw [hSsum] at hchain
+    exact absurd hchain (by norm_num)
+
+/-- **Restatement of `practical_even` via `Even`.** -/
+theorem practical_even' {m : ℕ} (hm : 2 ≤ m) (hp : IsPractical m) : Even m := by
+  obtain ⟨c, hc⟩ := practical_even hm hp
+  exact ⟨c, by omega⟩
 
 end Erdos18OQ01

--- a/research/problems/erdos-18-oq-01/knowledge.md
+++ b/research/problems/erdos-18-oq-01/knowledge.md
@@ -1,0 +1,25 @@
+# Erdős #18 OQ-01 (practical numbers) — Knowledge Base
+
+## Session 2026-07-08 (researcher-1) — first STRUCTURAL theorem: practical ⇒ even
+
+The predecessor `Erdos18OQ01.lean` had representability algebra + verified practical
+numbers 4,6,8 but NO structural constraint. Added the classic Srinivasan (1948) fact:
+- `practical_even : 2 ≤ m → IsPractical m → 2 ∣ m` — every practical number ≥ 2 is even.
+- `practical_even' : … → Even m` — restatement.
+
+Proof: 2 must be a sum of distinct divisors of m. For m=2 immediate; for m≥3 the
+representing set S ⊆ divisors m has S.sum id = 2, all elements positive ⇒ each ≤ 2 (via
+`Finset.single_le_sum`). If 2 ∉ S, every element is exactly 1 ⇒ S ⊆ {1} ⇒ S.sum id ≤ 1 < 2
+(`Finset.sum_le_sum_of_subset`), contradiction. So 2 ∈ S ⊆ divisors m ⇒ 2 ∣ m.
+
+★Gotchas (v4.26):
+- `Nat.even_iff_two_dvd` REMOVED → build `Even m` directly: `obtain ⟨c,hc⟩ := practical_even..;
+  exact ⟨c, by omega⟩` (Even m = ∃r, m=r+r; from m=2*c).
+- `Finset.sum_le_sum_of_subset hsub` needs its TYPE PINNED (`have hle : S.sum id ≤
+  ({1}:Finset ℕ).sum id := …`) else "typeclass instance problem is stuck" (f is a metavar).
+- ★Do NOT `simp only [id_eq] at hle` to normalize `S.sum id` — it eta-expands to `∑ x∈S, x`
+  while `hSsum` keeps `S.sum id`, so omega sees two DISCONNECTED atoms and fails
+  ("a := ↑m/2, b := ↑(∑ x∈S,x)"). Keep both sides as `S.sum id` and `rw [hSsum]`.
+
+Verified 0 axioms / 0 sorries, no native_decide; built first try (7744 jobs). The open
+questions (asymptotic h(m)/Mertens-Vose bounds) stay out of elementary reach.

--- a/research/problems/erdos-18-oq-01/state.md
+++ b/research/problems/erdos-18-oq-01/state.md
@@ -1,0 +1,30 @@
+# Current State
+
+**Phase**: MAKING PROGRESS
+**Since**: 2026-07-08
+**Iteration**: 2
+
+## Current Focus
+
+Added the first structural theorem about practical numbers (practical ⇒ even) on top of
+the existing representability algebra + verified small examples.
+
+## Active Approach
+
+Elementary: representability of 2 forces 2 to be a divisor. No axioms.
+
+## Blockers
+
+Asymptotic size of h(m) (Mertens / Vose-type bounds) is out of elementary reach and needs
+analytic machinery absent from Mathlib.
+
+## Next Action
+
+Optional further structural facts (e.g. practical numbers are ≥ their largest prime gap
+condition; closure properties) — modest value. Asymptotics remain blocked.
+
+## Attempt Counts
+
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 2


### PR DESCRIPTION
## Summary

Erdős #18 ($250, OPEN) studies *practical numbers* (`m` is practical iff every `1 ≤ k < m` is a sum of distinct divisors of `m`). The existing `Erdos18OQ01.lean` provided the representability algebra and verified small practical numbers (4, 6, 8) but **no structural constraint**. This PR adds the first one.

## What's new (0 axioms / 0 sorries)

- `practical_even : 2 ≤ m → IsPractical m → 2 ∣ m` — **every practical number ≥ 2 is even** (Srinivasan 1948).
- `practical_even' : … → Even m` — restatement via `Even`.

**Proof.** `2` must be a sum of distinct divisors of `m`. For `m = 2` the claim is immediate; for `m ≥ 3` the representing set `S ⊆ divisors m` has `S.sum id = 2` with all elements positive, so each element is `≤ 2`. If `2 ∉ S`, every element is exactly `1`, forcing `S ⊆ {1}` and `S.sum id ≤ 1 < 2` — contradiction. Hence `2 ∈ S ⊆ divisors m`, i.e. `2 ∣ m`.

## Verification

Built clean via the Docker wrapper (`Proofs.Erdos18OQ01`, 7744 jobs). 0 sorries, 0 axiom declarations, no `native_decide`.

## Status

The headline open questions of #18 (asymptotic size of `h(m)`, Mertens/Vose-type bounds) remain out of elementary reach and are not attempted. This PR adds elementary structural theory only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)