### PR TITLE
Research: cauchy-schwarz-integral-oq-04 — full Robertson uncertainty relation [VERIFIED]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -105,8 +105,7 @@ theorem robertson_uncertainty {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
     rcases eq_or_ne (RCLike.I : 𝕜) 0 with h | h
     · rw [h, norm_zero]; norm_num
     · rw [RCLike.norm_I_of_ne_zero h]
-  have h2 : ‖(2 : 𝕜)‖ = 2 := by
-    rw [show (2 : 𝕜) = ((2 : ℝ) : 𝕜) by norm_num, RCLike.norm_ofReal]; norm_num
+  have h2 : ‖(2 : 𝕜)‖ = 2 := RCLike.norm_two
   -- ‖⟪ψ,[A,B]ψ⟫‖ ≤ 2·|Im⟪u,v⟫|
   have hnb : ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ ≤ 2 * |RCLike.im (inner 𝕜 u v)| := by
     rw [hid, hconj, RCLike.sub_conj, norm_mul, norm_mul, RCLike.norm_ofReal, h2]

--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -51,4 +51,68 @@ theorem im_inner_sq_le (u v : E) :
   nlinarith [h, abs_nonneg (RCLike.im (inner 𝕜 u v)),
     sq_abs (RCLike.im (inner 𝕜 u v)), norm_nonneg u, norm_nonneg v]
 
+/-! ## The full Robertson uncertainty relation
+
+The lemmas above are the Cauchy–Schwarz core.  Here we assemble them into the
+genuine operator-theoretic **Robertson uncertainty relation**
+
+  `‖(A−a)ψ‖²·‖(B−b)ψ‖² ≥ ¼·‖⟪ψ, (AB−BA)ψ⟫‖²`,
+
+for symmetric (self-adjoint) operators `A, B` on any inner product space over `ℝ`
+or `ℂ`, any state `ψ`, and *any* real shifts `a, b`.  Taking `a = ⟪ψ,Aψ⟫`,
+`b = ⟪ψ,Bψ⟫` (the expectation values) makes the left side `Var(A)·Var(B)`, so this
+is exactly Heisenberg's `Δx·Δp ≥ ℏ/2` with `[x,p] = iℏ`.
+
+The key algebraic fact is that the commutator expectation equals the antisymmetric
+part of `⟪u,v⟫` for the centred vectors `u = (A−a)ψ`, `v = (B−b)ψ` — and, crucially,
+is **independent of the shifts** `a, b` (they cancel by symmetry).  Combined with
+`⟪v,u⟫ = conj⟪u,v⟫`, this makes `⟪ψ,[A,B]ψ⟫ = ⟪u,v⟫ − conj⟪u,v⟫ = 2·i·Im⟪u,v⟫`,
+whose norm is `2·|Im⟪u,v⟫|`, and `im_inner_sq_le` finishes. -/
+
+/-- **Commutator = antisymmetric part of the centred inner product.**  For symmetric
+`A, B` and any real shifts `a, b`, with `u = (A−a)ψ`, `v = (B−b)ψ`,
+`⟪ψ, (AB−BA)ψ⟫ = ⟪u,v⟫ − ⟪v,u⟫`.  The shifts cancel, so the commutator expectation
+does not depend on the centring. -/
+theorem inner_commutator_eq_sub {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) (a b : ℝ) :
+    inner 𝕜 ψ (A (B ψ) - B (A ψ))
+      = inner 𝕜 (A ψ - (a : 𝕜) • ψ) (B ψ - (b : 𝕜) • ψ)
+        - inner 𝕜 (B ψ - (b : 𝕜) • ψ) (A ψ - (a : 𝕜) • ψ) := by
+  have e1 : inner 𝕜 (A ψ) (B ψ) = inner 𝕜 ψ (A (B ψ)) := hA ψ (B ψ)
+  have e2 : inner 𝕜 (B ψ) (A ψ) = inner 𝕜 ψ (B (A ψ)) := hB ψ (A ψ)
+  have e3 : inner 𝕜 (A ψ) ψ = inner 𝕜 ψ (A ψ) := hA ψ ψ
+  have e4 : inner 𝕜 (B ψ) ψ = inner 𝕜 ψ (B ψ) := hB ψ ψ
+  simp only [inner_sub_left, inner_sub_right, inner_smul_left, inner_smul_right,
+    RCLike.conj_ofReal]
+  rw [e1, e2, e3, e4]
+  ring
+
+/-- **Robertson uncertainty relation.**  For symmetric operators `A, B`, any state
+`ψ` and any real shifts `a, b`,
+`¼·‖⟪ψ, (AB−BA)ψ⟫‖² ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²`.  With `a = ⟪ψ,Aψ⟫`, `b = ⟪ψ,Bψ⟫` the
+right-hand side is the product of variances `Var(A)·Var(B)`, giving the Heisenberg
+uncertainty principle `Δx·Δp ≥ ℏ/2`. -/
+theorem robertson_uncertainty {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) (a b : ℝ) :
+    (1 / 4 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ ^ 2
+      ≤ ‖A ψ - (a : 𝕜) • ψ‖ ^ 2 * ‖B ψ - (b : 𝕜) • ψ‖ ^ 2 := by
+  set u := A ψ - (a : 𝕜) • ψ with hu
+  set v := B ψ - (b : 𝕜) • ψ with hv
+  have hid : inner 𝕜 ψ (A (B ψ) - B (A ψ)) = inner 𝕜 u v - inner 𝕜 v u :=
+    inner_commutator_eq_sub hA hB ψ a b
+  have hconj : inner 𝕜 v u = (starRingEnd 𝕜) (inner 𝕜 u v) := (inner_conj_symm v u).symm
+  have hInorm : ‖(RCLike.I : 𝕜)‖ ≤ 1 := by
+    rcases eq_or_ne (RCLike.I : 𝕜) 0 with h | h
+    · rw [h, norm_zero]; norm_num
+    · rw [RCLike.norm_I_of_ne_zero h]
+  have h2 : ‖(2 : 𝕜)‖ = 2 := by
+    rw [show (2 : 𝕜) = ((2 : ℝ) : 𝕜) by norm_num, RCLike.norm_ofReal]; norm_num
+  -- ‖⟪ψ,[A,B]ψ⟫‖ ≤ 2·|Im⟪u,v⟫|
+  have hnb : ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ ≤ 2 * |RCLike.im (inner 𝕜 u v)| := by
+    rw [hid, hconj, RCLike.sub_conj, norm_mul, norm_mul, RCLike.norm_ofReal, h2]
+    nlinarith [hInorm, abs_nonneg (RCLike.im (inner 𝕜 u v))]
+  have him := im_inner_sq_le (𝕜 := 𝕜) u v
+  nlinarith [hnb, him, norm_nonneg (inner 𝕜 ψ (A (B ψ) - B (A ψ))),
+    abs_nonneg (RCLike.im (inner 𝕜 u v)), sq_abs (RCLike.im (inner 𝕜 u v))]
+
 end CauchySchwarzIntegralOQ04

--- a/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
@@ -19,3 +19,26 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## RESOLVED — full Robertson relation (researcher-2, 2026-07-08)
+
+The prior state had only the **Cauchy-Schwarz core** (`abs_im_inner_le_norm_mul_norm`,
+`im_inner_sq_le`), deferring the operator statement. This session formalizes the full
+**Robertson uncertainty relation** in `CauchySchwarzIntegralOQ04.lean` (VERIFIED, 0
+axioms, 0 sorries, no `native_decide`):
+
+- `inner_commutator_eq_sub (hA hB : IsSymmetric) (ψ) (a b : ℝ)`:
+  `⟪ψ, (AB−BA)ψ⟫ = ⟪u,v⟫ − ⟪v,u⟫`  where `u=(A−a)ψ`, `v=(B−b)ψ`. The shifts `a,b` cancel.
+- `robertson_uncertainty (hA hB : IsSymmetric) (ψ) (a b : ℝ)`:
+  `¼·‖⟪ψ,(AB−BA)ψ⟫‖² ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²`.
+
+Setting `a=⟪ψ,Aψ⟫`, `b=⟪ψ,Bψ⟫` makes the RHS `Var(A)·Var(B)`, i.e. Heisenberg's
+`Δx·Δp ≥ ℏ/2` with `[x,p]=iℏ`. Valid over any `RCLike` field (ℝ trivial, ℂ the content).
+
+### Proof chain
+1. `inner_commutator_eq_sub`: expand both inner products (`inner_sub_left/right`,
+   `inner_smul_left/right`, `RCLike.conj_ofReal`), rewrite `⟪Aψ,ψ⟫=⟪ψ,Aψ⟫` etc. via
+   symmetry, `ring`. Shift terms cancel.
+2. `⟪v,u⟫ = conj⟪u,v⟫` (`inner_conj_symm`), so commutator `= ⟪u,v⟫−conj⟪u,v⟫
+   = 2·i·Im⟪u,v⟫` (`RCLike.sub_conj`); norm `≤ 2|Im⟪u,v⟫|` using `‖I‖≤1`.
+3. Square and apply the existing `im_inner_sq_le`.

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -32,16 +32,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (the Cauchy-Schwarz core). OQ-04 asks for the Heisenberg uncertainty principle. The full operator-theoretic statement Var_ψ(A)·Var_ψ(B) ≥ ¼|⟪ψ,[A,B]ψ⟫|² needs self-adjoint operators and the commutator (beyond a single file). The single inequality that drives it IS a Cauchy-Schwarz corollary, formalized here in any inner product space over ℝ or ℂ: abs_im_inner_le_norm_mul_norm (|Im⟪u,v⟫| ≤ ‖u‖·‖v‖) and im_inner_sq_le ((Im⟪u,v⟫)² ≤ ‖u‖²·‖v‖²). With u = (A−⟨A⟩)ψ, v = (B−⟨B⟩)ψ this is exactly √(Var A · Var B) ≥ |Im⟪u,v⟫|. CauchySchwarzIntegralOQ04.lean, 2 theorems, 0 axioms, 0 sorries, no native_decide.",
+    "progressSummary": "RESOLVED (full Robertson relation). OQ-04 asked whether Heisenberg Δx·Δp ≥ ℏ/2 can be formalized as a Cauchy-Schwarz consequence. A prior session had only the CS core (abs_im_inner_le_norm_mul_norm, im_inner_sq_le). This session PROVES the full operator-theoretic Robertson uncertainty relation in CauchySchwarzIntegralOQ04.lean: robertson_uncertainty (¼·‖⟪ψ,(AB−BA)ψ⟫‖² ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²) for symmetric A,B on any RCLike inner product space, any state ψ, any real shifts a,b. Key lemma inner_commutator_eq_sub: ⟪ψ,(AB−BA)ψ⟫ = ⟪u,v⟫−⟪v,u⟫ for centred u=(A−a)ψ, v=(B−b)ψ — the shifts CANCEL by symmetry. Then ⟪v,u⟫=conj⟪u,v⟫ gives commutator = 2i·Im⟪u,v⟫ (RCLike.sub_conj), norm 2|Im⟪u,v⟫|, and im_inner_sq_le finishes. Setting a=⟨A⟩,b=⟨B⟩ makes RHS Var(A)·Var(B). Verified: 0 axioms (propext/Classical/Quot only), 0 sorries, no native_decide. File now 4 theorems.",
     "builtItems": [
       "CauchySchwarzIntegralOQ04.lean: 2 theorems over a general RCLike inner product space, 0 axioms (propext/Classical.choice/Quot.sound), 0 sorries.",
       "abs_im_inner_le_norm_mul_norm: |RCLike.im (inner 𝕜 u v)| ≤ ‖u‖·‖v‖ (RCLike.abs_im_le_norm |im z| ≤ ‖z‖, then norm_inner_le_norm).",
-      "im_inner_sq_le: (RCLike.im (inner 𝕜 u v))² ≤ ‖u‖²·‖v‖² (nlinarith from the core + sq_abs)."
+      "im_inner_sq_le: (RCLike.im (inner 𝕜 u v))² ≤ ‖u‖²·‖v‖² (nlinarith from the core + sq_abs).",
+      "robertson_uncertainty in CauchySchwarzIntegralOQ04.lean (¼‖⟪ψ,[A,B]ψ⟫‖² ≤ ‖(A−a)ψ‖²‖(B−b)ψ‖² — Heisenberg/Robertson, OQ-04 target)",
+      "inner_commutator_eq_sub in CauchySchwarzIntegralOQ04.lean (⟪ψ,(AB−BA)ψ⟫ = ⟪u,v⟫−⟪v,u⟫, shift-independent)"
     ],
     "insights": [
       "The Heisenberg/Robertson uncertainty inequality's analytic core is Cauchy-Schwarz on the imaginary part: |Im⟪u,v⟫| ≤ |⟪u,v⟫| ≤ ‖u‖‖v‖. For real fields Im = 0 (trivial); the content is the ℂ case.",
       "Mathlib v4.26: `inner` now takes the field EXPLICITLY — `inner 𝕜 u v` (notation ⟪u,v⟫_𝕜), NOT `inner u v`. RCLike.abs_im_le_norm (z : K) : |im z| ≤ ‖z‖; norm_inner_le_norm (x y) : ‖⟪x,y⟫‖ ≤ ‖x‖‖y‖ (𝕜 implicit).",
-      "Substituting u = (A−⟨A⟩)ψ, v = (B−⟨B⟩)ψ converts this generic inequality into Heisenberg's bound: ‖u‖² = Var(A), ‖v‖² = Var(B), and 2·Im⟪u,v⟫ = ⟪ψ,(−i)[A,B]ψ⟫."
+      "Substituting u = (A−⟨A⟩)ψ, v = (B−⟨B⟩)ψ converts this generic inequality into Heisenberg's bound: ‖u‖² = Var(A), ‖v‖² = Var(B), and 2·Im⟪u,v⟫ = ⟪ψ,(−i)[A,B]ψ⟫.",
+      "Full Robertson uncertainty relation is a clean Cauchy-Schwarz corollary: the commutator expectation ⟪ψ,[A,B]ψ⟫ is the antisymmetric part ⟪u,v⟫−⟪v,u⟫ of the centred inner product, INDEPENDENT of the shift constants a,b (they cancel by symmetry of A,B).",
+      "⟪v,u⟫ = conj⟪u,v⟫ (inner_conj_symm) turns the commutator into 2i·Im⟪u,v⟫ (RCLike.sub_conj z: z−conj z = 2·im z·I); its norm is 2|Im⟪u,v⟫| using ‖I‖≤1 (RCLike.norm_I_of_ne_zero) — works uniformly for ℝ (I=0, trivial) and ℂ.",
+      "LinearMap.IsSymmetric T := ∀x y, ⟪Tx,y⟫=⟪x,Ty⟫; the a,b-shift cancellation needs only hA ψ ψ and hB ψ ψ plus RCLike.conj_ofReal (conj of a real coercion)."
     ],
     "mathlibGaps": [
       "The full operator-theoretic uncertainty principle (self-adjoint operators, variance of an observable in a state, the commutator [A,B]) is not packaged in Mathlib; only the underlying Cauchy-Schwarz inequality is in reach here."


### PR DESCRIPTION
## Summary
Extends **OQ-04** of `cauchy-schwarz-integral` (*"Can the Heisenberg uncertainty
principle be formalized as a Cauchy-Schwarz consequence?"*) from the previously-formalized
**Cauchy-Schwarz core** to the full operator-theoretic **Robertson uncertainty relation**.

Prior state of `CauchySchwarzIntegralOQ04.lean`: only `abs_im_inner_le_norm_mul_norm` and
`im_inner_sq_le` (the `(Im⟪u,v⟫)² ≤ ‖u‖²‖v‖²` step). The full statement with the
commutator was explicitly deferred as "beyond a single file". This PR proves it.

## Progress
New verified theorems (`proofs/Proofs/CauchySchwarzIntegralOQ04.lean`):

- `robertson_uncertainty (hA hB : IsSymmetric) (ψ : E) (a b : ℝ) :`
  `¼·‖⟪ψ, (AB−BA)ψ⟫‖² ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²`
- `inner_commutator_eq_sub (hA hB : IsSymmetric) (ψ : E) (a b : ℝ) :`
  `⟪ψ, (AB−BA)ψ⟫ = ⟪u,v⟫ − ⟪v,u⟫`  (centred `u=(A−a)ψ`, `v=(B−b)ψ`)

Valid for symmetric (self-adjoint) `A, B` on **any** inner product space over `ℝ` or `ℂ`,
any state `ψ`, and **any** real shifts `a, b`. Taking `a = ⟪ψ,Aψ⟫`, `b = ⟪ψ,Bψ⟫` makes the
right-hand side `Var(A)·Var(B)`, so this is exactly Heisenberg's `Δx·Δp ≥ ℏ/2` with
`[x,p] = iℏ`.

## Key idea
The commutator expectation is the **antisymmetric part** of the centred inner product and
is **independent of the shifts** `a, b` (they cancel by symmetry). With `⟪v,u⟫ = conj⟪u,v⟫`
this gives `⟪ψ,[A,B]ψ⟫ = ⟪u,v⟫ − conj⟪u,v⟫ = 2i·Im⟪u,v⟫`, whose norm is `2|Im⟪u,v⟫|`, and
the existing `im_inner_sq_le` closes it.

## Verification
- Docker build: **success** (7743 jobs; one unrelated transient shared-volume exit-135 on
  `Mathlib.RingTheory.MvPowerSeries.Inverse` cleared on retry).
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only —
  **0 `axiom` declarations, 0 sorries, no `native_decide`**.

## Status
**Outcome**: completed (full Robertson/Heisenberg relation now formalized)
**Next Steps**: optional — instantiate on concrete position/momentum operators on `L²(ℝ)`
once the derivative-as-momentum operator is available.

🤖 Generated by researcher-2