### PR TITLE
audit(erdos-666): sync stale meta.lineCount 310→326

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15453,9 +15453,9 @@
     },
     "erdos-666": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
-      "lastAudited": "2026-07-08T05:49:40Z",
-      "result": "clean",
+      "auditCount": 7,
+      "lastAudited": "2026-07-08T18:00:00Z",
+      "result": "issues-fixed",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14107",
       "issues": []
     },

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -55,7 +55,7 @@
       "GeneralizedConjecture: open question for C_{2k}"
     ],
     "axiomCount": 1,
-    "lineCount": 310,
+    "lineCount": 326,
     "assumptions": "1 axiom (Chung 1992): chung_no_threshold — no threshold N makes every (1/4)-dense subgraph of Qₙ contain C₆; a consequence of Chung's edge-partition of Qₙ into four C₆-free subgraphs, not available in Mathlib. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) was previously axiomatized but is now PROVED outright — it carries no edge-count data, so the empty subgraph ⊥ (no edges, hence no cycle) is an honest witness. The deep density content stays isolated in the single axiom chung_no_threshold.",
     "theoremCount": 4,
     "definitionCount": 13


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: erdos-666 (Erdős #666: C₆ in Hypercube Subgraphs)

Re-audit triggered because the meta was committed (#35368, de-axiomatize `chung_c6free`) after its last audit timestamp.

### Finding (LOW severity)
- `meta.lineCount` = **310** (stale) but the actual Lean file is **326** lines. The de-axiomatization added ~16 lines and updated `leanFile.lineCount` (326) but left `meta.lineCount` at the pre-change value.

### Verified correct (no change needed)
- `axiomCount` = 1 everywhere; file has exactly 1 `axiom` (`chung_no_threshold`); only structure `DenseSubgraph` carries no extra assumptions.
- `sorries` = 0 (0 in source), `status` = axiomatized, `badge` = axiom.
- `assumptions` prose accurately describes `chung_c6free` as de-axiomatized and the count dropping 2→1.
- No True stubs, no `native_decide`.

### Fix
- `meta.lineCount`: 310 → 326.
- Tracker entry bumped (result: issues-fixed).

---
Discovered during gallery integrity audit.