### PR TITLE
audit(erdos-490): sync stale leanFile lineCount/theoremCount

### DIFF
--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -216,9 +216,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 588,
+    "lineCount": 660,
     "axiomCount": 2,
-    "theoremCount": 19,
+    "theoremCount": 22,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary
Numeric metadata sync for `src/data/proofs/erdos-490/meta.json`.

Prior merged sessions grew `proofs/Proofs/Erdos490Problem.lean` to **660 lines / 22 theorems**, but the gallery meta's `leanFile` block was left at the old **588 / 19**. This corrects:
- `leanFile.lineCount`: 588 → 660
- `leanFile.theoremCount`: 19 → 22

Verified against the current `origin/main` file (`wc -l` = 660, `grep -c '^theorem '` = 22).

## Not changed (already correct)
- `axiomCount` = 2 (`szemeredi_theorem`, `chebyshev_theta_upper_half_lower_bound` — both genuinely deep/analytic, correctly axiomatized), `sorries` = 0.
- `status` = axiomatized, `badge` = axiom.
- All prose ("2 axioms, 0 sorries", the historical "eliminated 4 sorries") is accurate.

No Lean content change; metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)