### PR TITLE
Enrich Weyl inequalities (cauchy-interlacing-theorem-oq-03): header section + marker alignment

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
@@ -83,25 +83,33 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview and Setup",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "The module docstring derives the two classical Weyl spectral inequalities — monotonicity and the subadditive (additive) inequality — for symmetric operators as pure corollaries of the bound-form Courant–Fischer max–min keystone (CauchyInterlacingKeystone.lean). No new spectral theory is introduced: an operator T is presented by its orthonormal eigenbasis b and descending eigenvalue enumeration μ (Antitone μ, T(b i)=μ i • b i), and every result follows from the variational halves plus the eigenspan Rayleigh bound and the Grassmann dimension formula. Imports, opens, and the CauchyInterlacing.Weyl namespace.",
+      "mathContext": "$T\\preceq U \\Rightarrow \\mu_k\\le\\nu_k$ (monotonicity); $i+j\\le k \\Rightarrow \\rho_k\\le\\mu_i+\\nu_j$ (Weyl's inequality)."
+    },
+    {
       "id": "infrastructure",
       "title": "Grassmann and Eigenspan Bounds",
-      "startLine": 53,
-      "endLine": 91,
+      "startLine": 49,
+      "endLine": 80,
       "summary": "finrank_inf_lb: the intersection dimension bound finrank(P ⊓ Q) ≥ finrank P + finrank Q − finrank E from the Grassmann formula. rayleigh_le_on_upper_eigenspan: for antitone μ, every nonzero vector in span{b i,…} has Rayleigh quotient ≤ μ(i), the upper-tail dual of the keystone's lower eigenspan bound.",
       "mathContext": "The two reusable lemmas feeding the additive inequality: a dimension count and an eigenspan Rayleigh ceiling."
     },
     {
       "id": "monotone",
       "title": "Weyl Monotonicity",
-      "startLine": 92,
-      "endLine": 127,
+      "startLine": 81,
+      "endLine": 113,
       "summary": "weyl_monotone: re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ for all x ⟹ μ(k) ≤ ν(k). The optimal (k+1)-dimensional subspace for T (lower half) feeds the upper half for U; the witness vector satisfies μ(k) ≤ R_T(x) ≤ R_U(x) ≤ ν(k).",
       "mathContext": "Eigenvalues are monotone in the Loewner order — the simplest Courant–Fischer corollary."
     },
     {
       "id": "additive",
       "title": "Weyl's Additive Inequality",
-      "startLine": 128,
+      "startLine": 114,
       "endLine": 187,
       "summary": "weyl_add_le: for i + j ≤ k, ρ(k) ≤ μ(i) + ν(j). The optimal (k+1)-dim subspace for T+U meets the upper-tail eigenspans of T and U; two Grassmann counts leave a common nonzero vector, on which Rayleigh additivity gives ρ(k) ≤ R_T(x) + R_U(x) ≤ μ(i) + ν(j).",
       "mathContext": "The classical λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B) in 0-based descending form — the foundational eigenvalue perturbation bound."


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-03` (Weyl monotonicity + additive inequality from the Courant–Fischer keystone). Schema was already healthy (conclusion object w/ open questions, 4 valid cross-refs, 6 annotations w/ mathContext, no build warnings). This pass tightens **section coverage/accuracy**:

- **Added a header section** (`header`, 1–48) — sections previously started at line 53, leaving the module docstring/imports/`CauchyInterlacing.Weyl` setup with no section.
- **Aligned to the author's `/-! ## -/` markers.** `infrastructure` (53–91) had swallowed the Weyl-monotonicity marker (line 81) and `weyl_monotone`'s docstring; `monotone` (92–127) swallowed the additive marker (114). Re-snapped to infrastructure 49–80, monotone 81–113, additive 114–187 — each Weyl inequality's marker + docstring + theorem now sit together and the 187-line file is fully covered.

No content removed; JSON validated via the gallery build (no warnings).