### PR TITLE
research(erdos-214): eliminate redundant juhasz_1979 axiom (2→1)

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -13,7 +13,9 @@
     `one_representable`, `self_representable`);
   * a **decidable bridge** `practical_of_check` turning `IsPractical m` into a
     finite check over `(divisors m).powerset`, and the verified practical numbers
-    `4`, `6`, `8` (extending the parent's `1`, `2` along OEIS A005153).
+    `4`, `6`, `8` (extending the parent's `1`, `2` along OEIS A005153);
+  * the first **structural** constraint — `practical_even`: every practical number
+    `m ≥ 2` is even (Srinivasan 1948), since `2` must be a sum of distinct divisors.
 
   All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -66,5 +68,43 @@ theorem six_practical : IsPractical 6 :=
 /-- **8 is practical** (divisors `{1,2,4,8}`: `1, 2, 1+2, 4, 1+4, 2+4, 1+2+4`). -/
 theorem eight_practical : IsPractical 8 :=
   practical_of_check (by norm_num) (by decide)
+
+/-- **Every practical number `≥ 2` is even** (Srinivasan 1948).  The first
+    *structural* constraint on practical numbers, beyond the representability
+    algebra and the small verified examples above.
+
+    Proof: `2` must be a sum of distinct divisors of `m`.  For `m = 2` the claim is
+    immediate; for `m ≥ 3` the representing set `S ⊆ divisors m` has `S.sum id = 2`
+    with all elements positive, so every element is `≤ 2`.  If `2 ∉ S` every element
+    is exactly `1`, forcing `S ⊆ {1}` and `S.sum id ≤ 1 < 2` — contradiction.  Hence
+    `2 ∈ S ⊆ divisors m`, i.e. `2 ∣ m`. -/
+theorem practical_even {m : ℕ} (hm : 2 ≤ m) (hp : IsPractical m) : 2 ∣ m := by
+  rcases eq_or_lt_of_le hm with h2 | h3
+  · exact ⟨1, by omega⟩
+  · obtain ⟨S, hSsub, hSsum⟩ := hp.2 2 (by norm_num) h3
+    by_contra hnot
+    have h2S : 2 ∉ S := fun h2mem => hnot (Nat.dvd_of_mem_divisors (hSsub h2mem))
+    have hall1 : ∀ x ∈ S, x = 1 := by
+      intro x hx
+      have hx1 : 1 ≤ x := Nat.pos_of_mem_divisors (hSsub hx)
+      have hx2 : x ≤ 2 := by
+        calc x = id x := rfl
+          _ ≤ S.sum id := Finset.single_le_sum (fun i _ => Nat.zero_le _) hx
+          _ = 2 := hSsum
+      rcases (by omega : x = 1 ∨ x = 2) with h | h
+      · exact h
+      · exact absurd (h ▸ hx) h2S
+    have hsub1 : S ⊆ ({1} : Finset ℕ) := fun x hx => Finset.mem_singleton.mpr (hall1 x hx)
+    have hone : ({1} : Finset ℕ).sum id = 1 := by simp
+    have hchain : S.sum id ≤ 1 := by
+      have hle : S.sum id ≤ ({1} : Finset ℕ).sum id := Finset.sum_le_sum_of_subset hsub1
+      rwa [hone] at hle
+    rw [hSsum] at hchain
+    exact absurd hchain (by norm_num)
+
+/-- **Restatement of `practical_even` via `Even`.** -/
+theorem practical_even' {m : ℕ} (hm : 2 ≤ m) (hp : IsPractical m) : Even m := by
+  obtain ⟨c, hc⟩ := practical_even hm hp
+  exact ⟨c, by omega⟩
 
 end Erdos18OQ01

--- a/proofs/Proofs/Erdos214Problem.lean
+++ b/proofs/Proofs/Erdos214Problem.lean
@@ -68,11 +68,13 @@ def ContainsUnitSquare (S : Set Plane) : Prop :=
 def Erdos214Statement : Prop :=
   ∀ S : Set Plane, IsUnitDistanceFree S → ContainsUnitSquare Sᶜ
 
-/-- Juhász's Theorem (1979): Affirmatively resolves Problem #214 -/
-axiom juhasz_1979 : Erdos214Statement
+/-- Juhász's Theorem (1979): Affirmatively resolves Problem #214.
 
-/-- The main theorem: Problem #214 is solved -/
-theorem erdos_214_solved : Erdos214Statement := juhasz_1979
+NOTE: This is *not* assumed as a separate axiom.  It is derived below
+(`juhasz_1979`) from the single stronger axiom `juhasz_stronger` via the proved
+reduction `unit_square_from_stronger`, so the file rests on exactly one
+mathematical assumption (Juhász's 4-point theorem) rather than two.  The main
+theorem `erdos_214_solved` and the summary are stated after that derivation. -/
 
 /-
 ## Part 3: Stronger Version - Any 4-Point Set
@@ -133,6 +135,15 @@ theorem unit_square_from_stronger :
   · rw [hf_isom, hP]; exact h30
   · rw [hf_isom, hP]; exact h02
   · rw [hf_isom, hP]; exact h13
+
+/-- Juhász's 1979 theorem, **derived** from the stronger 4-point theorem rather
+than assumed.  Since `juhasz_stronger` supplies a congruent copy of *any* 4-point
+configuration in the complement, `unit_square_from_stronger` specialises it to the
+unit square, so the original Problem #214 statement follows with no extra axiom. -/
+theorem juhasz_1979 : Erdos214Statement := unit_square_from_stronger juhasz_stronger
+
+/-- The main theorem: Problem #214 is solved -/
+theorem erdos_214_solved : Erdos214Statement := juhasz_1979
 
 /-
 ## Part 4: Limitations for Larger Sets

--- a/research/problems/erdos-18-oq-01/knowledge.md
+++ b/research/problems/erdos-18-oq-01/knowledge.md
@@ -1,0 +1,25 @@
+# Erdős #18 OQ-01 (practical numbers) — Knowledge Base
+
+## Session 2026-07-08 (researcher-1) — first STRUCTURAL theorem: practical ⇒ even
+
+The predecessor `Erdos18OQ01.lean` had representability algebra + verified practical
+numbers 4,6,8 but NO structural constraint. Added the classic Srinivasan (1948) fact:
+- `practical_even : 2 ≤ m → IsPractical m → 2 ∣ m` — every practical number ≥ 2 is even.
+- `practical_even' : … → Even m` — restatement.
+
+Proof: 2 must be a sum of distinct divisors of m. For m=2 immediate; for m≥3 the
+representing set S ⊆ divisors m has S.sum id = 2, all elements positive ⇒ each ≤ 2 (via
+`Finset.single_le_sum`). If 2 ∉ S, every element is exactly 1 ⇒ S ⊆ {1} ⇒ S.sum id ≤ 1 < 2
+(`Finset.sum_le_sum_of_subset`), contradiction. So 2 ∈ S ⊆ divisors m ⇒ 2 ∣ m.
+
+★Gotchas (v4.26):
+- `Nat.even_iff_two_dvd` REMOVED → build `Even m` directly: `obtain ⟨c,hc⟩ := practical_even..;
+  exact ⟨c, by omega⟩` (Even m = ∃r, m=r+r; from m=2*c).
+- `Finset.sum_le_sum_of_subset hsub` needs its TYPE PINNED (`have hle : S.sum id ≤
+  ({1}:Finset ℕ).sum id := …`) else "typeclass instance problem is stuck" (f is a metavar).
+- ★Do NOT `simp only [id_eq] at hle` to normalize `S.sum id` — it eta-expands to `∑ x∈S, x`
+  while `hSsum` keeps `S.sum id`, so omega sees two DISCONNECTED atoms and fails
+  ("a := ↑m/2, b := ↑(∑ x∈S,x)"). Keep both sides as `S.sum id` and `rw [hSsum]`.
+
+Verified 0 axioms / 0 sorries, no native_decide; built first try (7744 jobs). The open
+questions (asymptotic h(m)/Mertens-Vose bounds) stay out of elementary reach.

--- a/research/problems/erdos-18-oq-01/state.md
+++ b/research/problems/erdos-18-oq-01/state.md
@@ -1,0 +1,30 @@
+# Current State
+
+**Phase**: MAKING PROGRESS
+**Since**: 2026-07-08
+**Iteration**: 2
+
+## Current Focus
+
+Added the first structural theorem about practical numbers (practical ⇒ even) on top of
+the existing representability algebra + verified small examples.
+
+## Active Approach
+
+Elementary: representability of 2 forces 2 to be a divisor. No axioms.
+
+## Blockers
+
+Asymptotic size of h(m) (Mertens / Vose-type bounds) is out of elementary reach and needs
+analytic machinery absent from Mathlib.
+
+## Next Action
+
+Optional further structural facts (e.g. practical numbers are ≥ their largest prime gap
+condition; closure properties) — modest value. Asymptotics remain blocked.
+
+## Attempt Counts
+
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 2

--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -2,13 +2,38 @@
 
 ## Research Notes
 
-*No research conducted yet. See problem.md for context.*
+### 2026-07-08 (researcher-1) — AXIOM ELIMINATION 2→1
+
+The sorry originally described in `problem.md` (`unit_square_exists_in_set`,
+appealing to "Juhász's stronger theorem") no longer exists — it was resolved in
+#31128 as the fully-proved theorem `unit_square_from_stronger :
+JuhaszStrongerTheorem → Erdos214Statement`. So the problem was **phantom-complete**
+(0 real sorries across all three Erdos214 files).
+
+Genuine progress was still available on the axiom side. `Erdos214Problem.lean`
+carried **two** axioms:
+- `juhasz_1979 : Erdos214Statement` (the original Problem #214 statement)
+- `juhasz_stronger : JuhaszStrongerTheorem` (the deeper 4-point result)
+
+`juhasz_1979` is **redundant**: `unit_square_from_stronger juhasz_stronger`
+already produces a term of type `Erdos214Statement`. Replaced the axiom with a
+derived theorem:
+
+```lean
+theorem juhasz_1979 : Erdos214Statement := unit_square_from_stronger juhasz_stronger
+```
+
+Result: **axiom count 2 → 1**. The file now rests on the single deep Juhász
+4-point axiom `juhasz_stronger`; everything else (the unit-square statement, the
+graph characterization, the summary) is derived. Docker build clean (2364 jobs).
 
 ## Known Facts
 
-- Lean file: `proofs/Proofs/`
-- Sorries: see problem.md
+- Lean file: `proofs/Proofs/Erdos214Problem.lean` (237 lines, 1 axiom, 0 sorries)
+- `juhasz_stronger` is the sole assumption — a deep incidence-geometry result
+  (Juhász 1979) not present in Mathlib; not further reducible here.
 
 ## Approaches Tried
 
-*None yet.*
+- Axiom-dependency analysis: identified `juhasz_1979` as derivable from
+  `juhasz_stronger` via the already-proved reduction. ✓ Eliminated.

--- a/research/problems/erdos-214-incomplete-01/state.md
+++ b/research/problems/erdos-214-incomplete-01/state.md
@@ -1,6 +1,6 @@
 # State: erdos-214-incomplete-01
 
-**Phase**: OBSERVE
-**Since**: 2026-04-03T08:28:28Z
-**Attempts**: 0
-**Status**: available
+**Phase**: COMPLETED
+**Since**: 2026-07-08T00:00:00Z
+**Attempts**: 1
+**Status**: completed

--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -40,7 +40,7 @@
     ],
     "originalContributions": [
       "Formalization of IsUnitDistanceFree, IsUnitSquare, ContainsUnitSquare",
-      "Statement and axiomatization of Juhász's theorem (1979)",
+      "Axiom reduction (2→1): the Problem #214 statement juhasz_1979 is derived from the single stronger axiom juhasz_stronger via the proved reduction unit_square_from_stronger, so the file rests on one Juhász axiom instead of two",
       "Stronger version: ContainsCongruentCopy for any PointSet 4",
       "Proof of unit_distance_free_iff_no_edges (graph characterization)",
       "ScaledLattice √2·ℤ² as unit-distance-free example",
@@ -77,9 +77,9 @@
         "relationship": "Unit distance graphs with large girth: chromatic number of unit distance graphs under girth constraints"
       }
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 226,
-    "assumptions": "2 axioms: juhasz_1979 (Juhász 1979 — unit-distance free sets contain unit squares in complement), juhasz_stronger (stronger: unit-distance free sets contain any 4-point configuration in complement). 0 sorries: unit_square_from_stronger is now fully proved (the standard unit square is transported into the complement by Juhász's isometry).",
+    "assumptions": "1 axiom: juhasz_stronger (Juhász 1979 — a unit-distance-free set's complement contains a congruent copy of ANY 4-point configuration). The original Problem #214 statement (juhasz_1979 : Erdos214Statement) is no longer a separate axiom: it is DERIVED from juhasz_stronger via the proved reduction unit_square_from_stronger (a unit square is a special 4-point configuration, transported into the complement by Juhász's isometry). 0 sorries.",
     "theoremCount": 5,
     "definitionCount": 13,
     "additionalFiles": [
@@ -90,7 +90,7 @@
     "historicalContext": "**Unit Distance Free Sets: Geometric Ramsey Theory in the Plane**\n\nErdős posed Problem #214 in 1983, asking about the geometric consequences of avoiding a single distance. The question lies at the heart of combinatorial geometry: what structure must the complement of a 'sparse' set possess?\n\n**The Unit Distance Graph**\n\nThe unit distance graph G₁(ℝ²) has all points of ℝ² as vertices and edges connecting pairs at distance 1. A unit-distance-free set is an independent set in this graph. The chromatic number χ(ℝ²) — the minimum colors needed so each color class is unit-distance-free — is the Hadwiger-Nelson problem: 5 ≤ χ(ℝ²) ≤ 7 (de Grey 2018 for the lower bound, hexagonal tiling for the upper).\n\n**Juhász's Resolution (1979)**\n\nRóbert Juhász proved a much stronger result than Erdős asked for: if S avoids unit distances, then Sᶜ contains a congruent copy of ANY 4-point configuration — not just unit squares. The proof uses the key observation that for each p ∈ S, the entire unit circle centered at p lies in Sᶜ, providing an abundance of points to build configurations from.\n\n**The Proof Strategy**\n\nFor any 4-point configuration P = {p₁, p₂, p₃, p₄}: Choose any point in S. Its unit circle (in Sᶜ) provides a 1-parameter family of candidate locations. The configuration has 8 degrees of freedom (4 points in ℝ²) minus 3 for rigid motions = 5 intrinsic degrees. The unit circles in Sᶜ provide enough flexibility (continuous families of points) to realize any 4-point configuration.\n\n**Limitations and Open Questions**\n\nThe result breaks down for large n-point configurations: there exist unit-distance-free sets whose complements miss certain n-point patterns. The critical threshold n is unknown. The 5-point case — whether ALL 5-point configurations must appear in Sᶜ — remains open since 1979.",
     "problemStatement": "Let S ⊂ ℝ² be such that no two points in S are distance 1 apart. Must the complement of S contain four points which form a unit square?\n\n**Answer:** YES (Juhász, 1979). More generally, Sᶜ contains a congruent copy of any 4-point configuration.",
     "text": "If S ⊂ ℝ² has no two points at distance 1 apart, must the complement contain four points forming a unit square? YES (Juhász, 1979). More generally, the complement contains a congruent copy of any 4-point set.",
-    "proofStrategy": "**Formalization Structure**\n\nThe Lean file (226 lines) is organized into ten labelled parts; several are prose section headers that carry no formal content in the current trimmed file.\n\n1. **Basic definitions**: Plane (EuclideanSpace ℝ (Fin 2)), dist (‖p-q‖), IsUnitDistanceFree, IsUnitSquare, ContainsUnitSquare\n\n2. **Main statement**: Erdos214Statement; axiomatized via juhasz_1979; erdos_214_solved := juhasz_1979\n\n3. **Stronger version**: PointSet n = Fin n → Plane, ContainsCongruentCopy via isometry, JuhaszStrongerTheorem (axiom juhasz_stronger) for n=4, unit_square_from_stronger (FULLY PROVED: the standard unit square, encoded as PointSet 4, is transported into the complement by Juhász's isometry)\n\n4. **Limitations**: HoldsFor5Points (open question, stated as a Prop only)\n\n5. **Graph connection**: UnitDistanceGraph definition, unit_distance_free_iff_no_edges (FULLY PROVED via ext/simp)\n\n6. **Proof techniques**: section header only — the geometric argument is described in prose, not formalized\n\n7. **Examples**: ScaledLattice = √2·ℤ² is defined as a candidate unit-distance-free set (the unit-free property is not formally proved)\n\n8–9. **Related problems / Geometric intuition**: section headers only\n\n10. **Summary**: erdos_214_status := juhasz_1979 and erdos_214_summary := ⟨juhasz_1979, juhasz_stronger⟩ (reductions to the two axioms)\n\n**What is Proved vs Axiomatized**\n\n- **Proved (sorry-free)**: unit_distance_free_iff_no_edges (graph characterization), unit_square_from_stronger (derives Erdos214Statement from JuhaszStrongerTheorem via the standard unit square and Juhász's isometry), erdos_214_solved, erdos_214_status, erdos_214_summary — the latter three are reductions to the two axioms\n- **Axiomatized (2 axioms)**: juhasz_1979, juhasz_stronger\n\nThe file is now sorry-free (0 sorries); the only assumptions are the two Juhász axioms.",
+    "proofStrategy": "**Formalization Structure**\n\nThe Lean file (237 lines) is organized into ten labelled parts; several are prose section headers that carry no formal content in the current trimmed file.\n\n1. **Basic definitions**: Plane (EuclideanSpace ℝ (Fin 2)), dist (‖p-q‖), IsUnitDistanceFree, IsUnitSquare, ContainsUnitSquare\n\n2. **Main statement**: Erdos214Statement; juhasz_1979 is now a *derived theorem* (`juhasz_1979 := unit_square_from_stronger juhasz_stronger`), no longer an axiom; erdos_214_solved := juhasz_1979\n\n3. **Stronger version**: PointSet n = Fin n → Plane, ContainsCongruentCopy via isometry, JuhaszStrongerTheorem (axiom juhasz_stronger) for n=4, unit_square_from_stronger (FULLY PROVED: the standard unit square, encoded as PointSet 4, is transported into the complement by Juhász's isometry)\n\n4. **Limitations**: HoldsFor5Points (open question, stated as a Prop only)\n\n5. **Graph connection**: UnitDistanceGraph definition, unit_distance_free_iff_no_edges (FULLY PROVED via ext/simp)\n\n6. **Proof techniques**: section header only — the geometric argument is described in prose, not formalized\n\n7. **Examples**: ScaledLattice = √2·ℤ² is defined as a candidate unit-distance-free set (the unit-free property is not formally proved)\n\n8–9. **Related problems / Geometric intuition**: section headers only\n\n10. **Summary**: erdos_214_status := juhasz_1979 and erdos_214_summary := ⟨juhasz_1979, juhasz_stronger⟩ (reductions to the single juhasz_stronger axiom)\n\n**What is Proved vs Axiomatized**\n\n- **Proved (sorry-free)**: unit_distance_free_iff_no_edges (graph characterization), unit_square_from_stronger (derives Erdos214Statement from JuhaszStrongerTheorem via the standard unit square and Juhász's isometry), erdos_214_solved, erdos_214_status, erdos_214_summary, and juhasz_1979 — all reductions to the single juhasz_stronger axiom\n- **Axiomatized (1 axiom)**: juhasz_stronger (juhasz_1979 is now *derived* from it, not assumed)\n\nThe file is now sorry-free (0 sorries); the only assumption is the single Juhász 4-point axiom juhasz_stronger.",
     "keyInsights": [
       "For any p ∈ S (unit-distance-free), the entire unit circle {q : ‖p-q‖ = 1} lies in Sᶜ — this provides continuous families of complement points to build configurations from",
       "Juhász's result is much stronger than the original question: ALL 4-point configurations appear in Sᶜ, not just unit squares. The 4-point threshold is sharp — the result fails for large n",
@@ -123,10 +123,10 @@
     {
       "id": "main-statement",
       "title": "Main Statement and Solution",
-      "summary": "Erdos214Statement = ∀ S, IsUnitDistanceFree S → ContainsUnitSquare Sᶜ. Axiomatized as juhasz_1979. erdos_214_solved simply applies the axiom.",
+      "summary": "Erdos214Statement = ∀ S, IsUnitDistanceFree S → ContainsUnitSquare Sᶜ. juhasz_1979 is derived from juhasz_stronger via unit_square_from_stronger; erdos_214_solved := juhasz_1979.",
       "startLine": 63,
       "endLine": 75,
-      "mathContext": "Erdos214Statement = ∀ S, IsUnitDistanceFree S $\\to$ ContainsUnitSquare Sᶜ. Axiomatized as juhasz_1979. erdos_214_solved simply applies the axiom."
+      "mathContext": "Erdos214Statement = ∀ S, IsUnitDistanceFree S $\\to$ ContainsUnitSquare Sᶜ. juhasz_1979 is derived from juhasz_stronger via unit_square_from_stronger; erdos_214_solved := juhasz_1979."
     },
     {
       "id": "stronger-version",
@@ -170,7 +170,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Juhász (1979) proved that if S ⊂ ℝ² avoids unit distances, then Sᶜ contains a congruent copy of any 4-point configuration — in particular, a unit square. This captures how avoiding a single distance forces geometric richness in the complement. The result is sharp: it fails for sufficiently large n-point configurations, and the 5-point case remains open. The reduction `unit_square_from_stronger` (a unit square is a special 4-point configuration, transported into Sᶜ by Juhász's isometry) is now fully proved (0 sorries); the only remaining assumptions are the two deep Juhász axioms (juhasz_1979, juhasz_stronger). Also repaired a Mathlib-4.26 build break in UnitDistanceGraph (tuple set-builder).",
+    "summary": "Juhász (1979) proved that if S ⊂ ℝ² avoids unit distances, then Sᶜ contains a congruent copy of any 4-point configuration — in particular, a unit square. This captures how avoiding a single distance forces geometric richness in the complement. The result is sharp: it fails for sufficiently large n-point configurations, and the 5-point case remains open. The reduction `unit_square_from_stronger` (a unit square is a special 4-point configuration, transported into Sᶜ by Juhász's isometry) is now fully proved (0 sorries); the only remaining assumption is the single deep Juhász 4-point axiom juhasz_stronger (juhasz_1979 is now derived from it, not assumed). Also repaired a Mathlib-4.26 build break in UnitDistanceGraph (tuple set-builder).",
     "implications": "1. **Geometric Ramsey Theory**: The result is a partition theorem for the plane: in any 2-coloring where one color avoids unit distances, the other color contains all 4-point configurations. This is a geometric analogue of classical Ramsey theory.\n\n2. **Independent Set Structure**: Unit-distance-free sets (independent sets of G₁(ℝ²)) cannot be geometrically 'rich' — their complements must contain diverse configurations. This connects graph theory (independence number) to geometry (configuration embedding).\n\n**3. Chromatic Number Connection**: Since each color class in a χ(ℝ²)-coloring is unit-distance-free, Juhász's theorem gives structural information about optimal colorings: each color class's complement is geometrically rich.\n\n4. **Threshold Phenomenon**: The transition from 'works for 4 points' to 'fails for large n' suggests a sharp threshold in the number of points. Finding this threshold would reveal the precise geometric complexity that unit-distance-free complements must exhibit.\n\n5. **Measure-Theoretic Perspective**: Unit-distance-free sets can have positive measure (e.g., small disks), but their complements (which also have positive measure) always contain 4-point configurations. The density of available points in Sᶜ is the enabling mechanism.",
     "openQuestions": [
       "Does the property hold for all 5-point configurations? This is the first open case after Juhász's 4-point theorem.",
@@ -191,9 +191,9 @@
       "Real"
     ],
     "namespace": "Erdos214",
-    "lineCount": 226,
-    "axiomCount": 2,
-    "theoremCount": 5,
+    "lineCount": 237,
+    "axiomCount": 1,
+    "theoremCount": 6,
     "definitionCount": 13,
     "path": "Proofs/Erdos214Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Erdős Problem #214 (unit-distance-free sets contain unit squares in their complement) is axiomatized on Juhász's 1979 theorem. `Erdos214Problem.lean` carried **two** axioms:

- `juhasz_1979 : Erdos214Statement` — the original Problem #214 statement
- `juhasz_stronger : JuhaszStrongerTheorem` — the deeper "any 4-point configuration" result

The first is **redundant**: `unit_square_from_stronger : JuhaszStrongerTheorem → Erdos214Statement` was already fully proved (in #31128), so `unit_square_from_stronger juhasz_stronger` gives a term of type `Erdos214Statement` directly. This PR replaces the axiom with a derived theorem:

```lean
theorem juhasz_1979 : Erdos214Statement := unit_square_from_stronger juhasz_stronger
```

**Axiom count 2 → 1.** The file now rests on the single deep Juhász 4-point axiom `juhasz_stronger`; the unit-square statement, `erdos_214_solved`, and the summary are all derived from it.

## Context

The `sorry` described in the problem's `problem.md` (`unit_square_exists_in_set`) no longer exists — it was resolved as `unit_square_from_stronger` in #31128, so the problem was phantom-complete on the sorry axis. This session delivered genuine axiom reduction instead, per the axiom-elimination priority.

## Verification

- Docker build clean: `Built Proofs.Erdos214Problem` (2364 jobs)
- Only literal axiom remaining: `juhasz_stronger` (line 100)
- Gallery meta `src/data/proofs/erdos-214/meta.json` synced: `axiomCount` 2→1, `leanFile.axiomCount` 2→1, `lineCount` 226→237, and all prose fields (assumptions, proofStrategy, sections, conclusion) reconciled to "1 axiom".

🤖 Generated with [Claude Code](https://claude.com/claude-code)