### PR TITLE
research(hilbert-17-oq-03): reconcile stale 'NEW' state to mature [notes only]

### DIFF
--- a/research/problems/hilbert-17-oq-03/state.md
+++ b/research/problems/hilbert-17-oq-03/state.md
@@ -1,27 +1,45 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-03T12:03:52.282Z
-**Iteration**: 1
+**Phase**: MATURE (substance delivered via child entries)
+**Since**: 2026-07-08
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+None. This slug ("Complexity of Deciding PSD Polynomial Sum-of-Squares") is a
+**complexity meta-question**, not a clean Lean theorem target. Its mathematical
+substance — the PSD ⊋ SOS separation and the PSD=SOS classification cases — has
+been fully delivered as verified, 0-axiom **child** gallery entries and wired into
+the parent `hilbert-17` (see knowledge.md for the multi-session log). No
+incremental Lean work remains on this node itself.
 
-## Active Approach
+## What was delivered (children of oq-03, all verified / 0-axiom)
 
-None yet.
+- `hilbert-17-oq-03-oq-02` — Motzkin polynomial is **not** SOS (`Hilbert17MotzkinNotSOS.lean`).
+- `hilbert-17-oq-03-oq-03` — Robinson polynomial is **not** SOS (`Hilbert17RobinsonNotSOS.lean`,
+  zero-set / 10-point det-128 linear-algebra route).
+- `hilbert-17-oq-03-oq-04` — univariate PSD ⇒ SOS (`Hilbert17UnivariatePSDSOS.lean`).
+- Quadratic PSD ⇒ SOS via the Gram/√M engine (`Hilbert17QuadraticGram.lean`).
+
+All four are imported into `Proofs/Hilbert17SumOfSquares.lean`, which drove the
+parent from **10 → 1 axioms**.
 
 ## Blockers
 
-None.
+The parent `hilbert-17` has exactly **one** axiom left: `pfister_bound_aux`
+(Pfister's 2ⁿ-square bound over formally real fields). This is genuinely deep with
+no short Mathlib path (confirmed across sessions) and is correctly left axiomatized.
+The complexity classification itself (SOS membership ≈ SDP feasibility) is a
+meta/complexity statement with no clear meaningful Lean formalization.
 
 ## Next Action
 
-Begin problem exploration.
+None for this slug. Future claimants should release without fabricating value.
+The only remaining hard target is `pfister_bound_aux` (multi-session, Pfister
+forms), tracked under the parent `hilbert-17`.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1


### PR DESCRIPTION
## Summary
Notes-only reconciliation of `research/problems/hilbert-17-oq-03/state.md`.

`hilbert-17-oq-03` ("Complexity of Deciding PSD Polynomial Sum-of-Squares") is a **complexity meta-question**, not a clean Lean theorem target. Its mathematical substance has been fully delivered as verified, 0-axiom **child** gallery entries and wired into the parent `hilbert-17`:

- `hilbert-17-oq-03-oq-02` — Motzkin ∉ SOS
- `hilbert-17-oq-03-oq-03` — Robinson ∉ SOS (zero-set / det-128 route)
- `hilbert-17-oq-03-oq-04` — univariate PSD ⇒ SOS
- quadratic PSD ⇒ SOS (Gram/√M engine)

These drove the parent `Hilbert17SumOfSquares.lean` from **10 → 1 axioms** (verified in the current `origin/main` file: 1 axiom, `pfister_bound_aux`).

But the oq-03 slug's own `state.md` still read **"Phase: NEW / 0 attempts / Begin problem exploration"**, which misleads future claimants into re-surveying already-completed work. This corrects it to **MATURE** with an accurate delivery log and the one honest remaining blocker: `pfister_bound_aux` (Pfister's 2ⁿ bound over formally real fields — genuinely deep, no short Mathlib path, correctly axiomatized).

## Scope
Notes only — no Lean, no gallery meta, no axiom/sorry change. Verified the parent file is at 1 axiom and all four child files exist/are imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)