### PR TITLE
research(erdos-18-oq-01): first infinite family — every power of two is practical

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -15,7 +15,12 @@
     finite check over `(divisors m).powerset`, and the verified practical numbers
     `4`, `6`, `8` (extending the parent's `1`, `2` along OEIS A005153);
   * the first **structural** constraint — `practical_even`: every practical number
-    `m ≥ 2` is even (Srinivasan 1948), since `2` must be a sum of distinct divisors.
+    `m ≥ 2` is even (Srinivasan 1948), since `2` must be a sum of distinct divisors,
+    and its classification corollary `odd_practical_eq_one` (`1` is the only odd
+    practical number);
+  * the first **infinite family** — `two_pow_practical`: every power of two `2^k`
+    is practical, via `two_pow_representable` (the binary expansion of any
+    `n < 2^k` selects distinct divisors of `2^k` summing to `n`).
 
   All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -106,5 +111,58 @@ theorem practical_even {m : ℕ} (hm : 2 ≤ m) (hp : IsPractical m) : 2 ∣ m :
 theorem practical_even' {m : ℕ} (hm : 2 ≤ m) (hp : IsPractical m) : Even m := by
   obtain ⟨c, hc⟩ := practical_even hm hp
   exact ⟨c, by omega⟩
+
+/-- **1 is the only odd practical number.**  Combines `practical_even` (every
+    practical `m ≥ 2` is even) with the base case `m = 1`; there is no odd
+    practical number beyond `1`. -/
+theorem odd_practical_eq_one {m : ℕ} (hp : IsPractical m) (ho : Odd m) : m = 1 := by
+  rcases Nat.lt_or_ge m 2 with h | h
+  · have := hp.1; omega
+  · obtain ⟨d, hd⟩ := practical_even h hp
+    obtain ⟨e, he⟩ := ho
+    omega
+
+/-- **Every `n < 2^k` is a sum of distinct divisors of `2^k`.**  The binary
+    expansion of `n` selects distinct powers of two below `2^k`, each a divisor
+    of `2^k`.  Proved by induction on `k`: when `2^k ≤ n < 2^{k+1}` the high bit
+    `2^k` is peeled off and the remainder `n - 2^k < 2^k` is handled by the
+    inductive hypothesis (and `2^k` is fresh, since every element of the
+    remainder's representing set is `≤ n - 2^k < 2^k`). -/
+theorem two_pow_representable (k : ℕ) {n : ℕ} (hn : n < 2 ^ k) :
+    IsRepresentable n (2 ^ k) := by
+  induction k generalizing n with
+  | zero =>
+    have hn0 : n = 0 := by omega
+    subst hn0; exact zero_representable _
+  | succ k ih =>
+    have hpow : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by ring
+    have hdvd : (2 : ℕ) ^ k ∣ 2 ^ (k + 1) := pow_dvd_pow 2 (Nat.le_succ k)
+    have hsub : divisors (2 ^ k) ⊆ divisors (2 ^ (k + 1)) :=
+      Nat.divisors_subset_of_dvd (by positivity) hdvd
+    rcases lt_or_ge n (2 ^ k) with hlt | hge
+    · obtain ⟨S, hSsub, hSsum⟩ := ih hlt
+      exact ⟨S, hSsub.trans hsub, hSsum⟩
+    · have hlt2 : n - 2 ^ k < 2 ^ k := by omega
+      obtain ⟨S, hSsub, hSsum⟩ := ih hlt2
+      have hnotmem : (2 : ℕ) ^ k ∉ S := by
+        intro hmem
+        have hle : (2 : ℕ) ^ k ≤ S.sum id :=
+          Finset.single_le_sum (fun i _ => Nat.zero_le _) hmem
+        rw [hSsum] at hle
+        omega
+      refine ⟨insert (2 ^ k) S, ?_, ?_⟩
+      · rw [Finset.insert_subset_iff]
+        exact ⟨Nat.mem_divisors.mpr ⟨hdvd, by positivity⟩, hSsub.trans hsub⟩
+      · rw [Finset.sum_insert hnotmem, hSsum]
+        simp only [id_eq]
+        omega
+
+/-- **Every power of two is practical** — the first *infinite* family of
+    practical numbers in this file (the parent and the small examples `4,6,8`
+    above cover only finitely many).  The divisors of `2^k` are exactly
+    `1,2,4,…,2^k`, so the binary expansion of any `1 ≤ n < 2^k` exhibits it as a
+    sum of distinct divisors (`two_pow_representable`). -/
+theorem two_pow_practical (k : ℕ) : IsPractical (2 ^ k) :=
+  ⟨Nat.one_le_pow k 2 (by norm_num), fun _ _ hn => two_pow_representable k hn⟩
 
 end Erdos18OQ01

--- a/research/problems/erdos-18-oq-01/knowledge.md
+++ b/research/problems/erdos-18-oq-01/knowledge.md
@@ -23,3 +23,27 @@ representing set S ⊆ divisors m has S.sum id = 2, all elements positive ⇒ ea
 
 Verified 0 axioms / 0 sorries, no native_decide; built first try (7744 jobs). The open
 questions (asymptotic h(m)/Mertens-Vose bounds) stay out of elementary reach.
+
+## Session 2026-07-08 (researcher-1) — first INFINITE family + odd classification
+
+SOLVED-state look-outward. The file previously had only finite practical examples
+(1,2,4,6,8) and one structural fact (practical ⇒ even). Added:
+
+- `two_pow_representable (k) : n < 2^k → IsRepresentable n (2^k)` — binary-expansion
+  lemma. Proof by induction on k: when 2^k ≤ n < 2^{k+1}, peel the high bit 2^k
+  (fresh because every element of the remainder's representing set is ≤ n-2^k < 2^k)
+  and recurse on n - 2^k < 2^k. Uses `Nat.divisors_subset_of_dvd`, `pow_dvd_pow`,
+  `Finset.single_le_sum`, `Finset.sum_insert`, `Finset.insert_subset_iff`.
+- `two_pow_practical (k) : IsPractical (2^k)` — the FIRST infinite family in the file
+  (covers infinitely many practical numbers, not just examples).
+- `odd_practical_eq_one : IsPractical m → Odd m → m = 1` — classification corollary of
+  practical_even (1 is the only odd practical number).
+
+★Gotchas (v4.26, all worked first try):
+- `Nat.one_le_pow k 2 (by norm_num)` for `1 ≤ 2^k` (avoids guessing `Nat.one_le_two_pow`).
+- fresh-bit `omega`: keep both `2^k` and `n - 2^k` as atoms; `hpow : 2^(k+1)=2*2^k`
+  as a linear fact lets omega derive `n - 2^k < 2^k` from `n < 2^(k+1)`.
+- `Finset.sum_insert hnotmem` then `simp only [id_eq]` then `omega` (with hge : n ≥ 2^k).
+
+Verified 0 axioms / 0 sorries, no native_decide; built clean (7744 jobs). 13 theorems.
+Remaining OQ (asymptotic h(m)/Mertens-Vose density) still out of elementary reach.

--- a/research/problems/erdos-18-oq-01/state.md
+++ b/research/problems/erdos-18-oq-01/state.md
@@ -1,30 +1,6 @@
-# Current State
+# State: erdos-18-oq-01
 
-**Phase**: MAKING PROGRESS
-**Since**: 2026-07-08
-**Iteration**: 2
-
-## Current Focus
-
-Added the first structural theorem about practical numbers (practical ⇒ even) on top of
-the existing representability algebra + verified small examples.
-
-## Active Approach
-
-Elementary: representability of 2 forces 2 to be a divisor. No axioms.
-
-## Blockers
-
-Asymptotic size of h(m) (Mertens / Vose-type bounds) is out of elementary reach and needs
-analytic machinery absent from Mathlib.
-
-## Next Action
-
-Optional further structural facts (e.g. practical numbers are ≥ their largest prime gap
-condition; closure properties) — modest value. Asymptotics remain blocked.
-
-## Attempt Counts
-
-- Total attempts: 2
-- Current approach attempts: 1
-- Approaches tried: 2
+**Phase**: ACT
+**Since**: 2026-07-08T00:00:00Z
+**Attempts**: 2
+**Status**: available


### PR DESCRIPTION
## Summary

Erdős Problem #18 studies *practical numbers* (`m` such that every `1 ≤ k < m` is a sum of distinct divisors of `m`). This OQ-01 file previously covered only **finitely many** practical numbers (the examples `1,2,4,6,8`) plus one structural fact (`practical_even`: every practical `m ≥ 2` is even). This PR adds the **first infinite family**:

```lean
theorem two_pow_representable (k : ℕ) {n : ℕ} (hn : n < 2 ^ k) : IsRepresentable n (2 ^ k)
theorem two_pow_practical (k : ℕ) : IsPractical (2 ^ k)
```

- `two_pow_representable` is the binary-expansion lemma, proved by induction on `k`. When `2^k ≤ n < 2^{k+1}`, the high bit `2^k` is peeled off (it is fresh, since every element of the remainder's representing set is `≤ n - 2^k < 2^k`) and the remainder `n - 2^k < 2^k` is handled by the inductive hypothesis.
- `two_pow_practical` covers infinitely many practical numbers directly.

Also adds a classification corollary:

```lean
theorem odd_practical_eq_one {m : ℕ} (hp : IsPractical m) (ho : Odd m) : m = 1
```

**1 is the only odd practical number** — combining `practical_even` with the `m = 1` base case.

## Verification

- Docker build clean: `Built Proofs.Erdos18OQ01` (7744 jobs)
- **0 axioms, 0 sorries, no `native_decide`** — 13 theorems total
- The genuinely open questions (asymptotic size of `h(m)`, Mertens/Vose density bounds) remain out of elementary reach and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)