### PR TITLE
audit: re-audit 79 changed-since-audit gallery entries (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -93,8 +93,8 @@
       "result": "clean"
     },
     "abel-ruffini-obstruction-oq-06": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T21:23:43Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -244,8 +244,8 @@
       "issues": []
     },
     "abel-ruffini-oq-04-oq-02-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T10:45:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -280,8 +280,8 @@
       "issues": []
     },
     "abel-ruffini-oq-06": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T23:58:18Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -1225,9 +1225,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-06-19T00:00:00Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02": {
@@ -1243,15 +1243,15 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-02": {
@@ -1261,9 +1261,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-06-19T11:02:10Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-02": {
@@ -1273,15 +1273,15 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-02-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-06-19T10:59:05Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-20T00:00:00Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01": {
@@ -1297,15 +1297,15 @@
       "issues": []
     },
     "area-of-circle-oq-01-oq-02-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-19T10:53:13Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-07-08T18:30:00Z",
+      "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T07:49:58Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-03": {
@@ -1317,14 +1317,14 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-03-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-12T00:17:48Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-03-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-05T15:52:47Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -1335,9 +1335,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-02-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T07:49:35Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-02-oq-02": {
@@ -1353,9 +1353,9 @@
       "issues": []
     },
     "area-of-circle-oq-02-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-05T06:09:18Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-03": {
@@ -1365,9 +1365,10 @@
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-05-08T19:13:05Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T18:30:00Z",
+      "result": "clean",
+      "issues": []
     },
     "area-of-circle-oq-03-oq-02": {
       "auditCount": 7,
@@ -1382,15 +1383,15 @@
       "issues": []
     },
     "area-of-circle-oq-03-oq-02-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:46Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-02-oq-02-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-06T18:00:32Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-03": {
@@ -1414,39 +1415,39 @@
       "result": "clean"
     },
     "area-of-circle-oq-05-incomplete-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-06T12:45:59Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-01-incomplete-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T16:58:18Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-05-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-05T06:04:15Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-07-08T18:30:00Z",
+      "result": "clean"
     },
     "area-of-circle-oq-05-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-03-oq-02": {
@@ -1456,15 +1457,15 @@
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-03-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-03-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-03-oq-05": {
@@ -1474,8 +1475,8 @@
       "result": "clean"
     },
     "area-of-circle-oq-07": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T17:14:04Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -1492,14 +1493,14 @@
       "issues": []
     },
     "area-of-circle-oq-07-oq-02-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T15:49:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-07-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T17:16:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -1510,9 +1511,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-07-oq-03-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-07-oq-04": {
@@ -1528,15 +1529,15 @@
       "result": "clean"
     },
     "area-of-circle-oq-07-oq-04-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-07-oq-05": {
@@ -1546,27 +1547,27 @@
       "issues": []
     },
     "area-of-circle-oq-07-oq-05-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T15:49:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-07-oq-05-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T16:58:18Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-07-oq-05-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T17:06:44Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-07-oq-05-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-25T10:50:06Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "arithmetic-series": {
@@ -1618,8 +1619,8 @@
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T22:20:47Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -3769,9 +3770,10 @@
     },
     "buffons-needle": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-06-19T09:26:10Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T18:30:00Z",
+      "result": "clean",
+      "issues": []
     },
     "buffons-needle-oq-01": {
       "auditCount": 5,
@@ -3876,9 +3878,9 @@
       "result": "clean"
     },
     "buffons-needle-oq-02-oq-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:32Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "buffons-needle-oq-02-oq-02": {
@@ -4597,9 +4599,9 @@
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-02-oq-02": {
@@ -4639,8 +4641,8 @@
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-01T00:31:56Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -4846,15 +4848,15 @@
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-04T12:55:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
     "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-02": {
@@ -5190,8 +5192,8 @@
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-02-oq-02-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T17:19:59Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -5465,9 +5467,9 @@
       "result": "issues-fixed"
     },
     "cayley-hamilton-reduction-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:08:06Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-02-oq-01-wip-01": {
@@ -5519,9 +5521,9 @@
       "result": "clean"
     },
     "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "cayleys-theorem-oq-01-oq-01-oq-02-oq-02": {
@@ -5799,8 +5801,8 @@
       "result": "clean"
     },
     "cevas-theorem-oq-04-oq-04-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-25T15:54:06Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -5823,8 +5825,8 @@
       "result": "clean"
     },
     "chebyshev-bounds-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T21:23:52Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -6343,8 +6345,8 @@
       "issues": []
     },
     "combinations-formula-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-25T15:54:06Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -7181,9 +7183,9 @@
       "result": "clean"
     },
     "derangements-convergence-oq-03-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "derangements-convergence-oq-03-oq-02": {
@@ -7193,9 +7195,9 @@
       "issues": []
     },
     "derangements-convergence-oq-03-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "derangements-convergence-oq-04": {
@@ -7267,9 +7269,9 @@
       "result": "clean"
     },
     "derangements-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:28Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "derangements-oq-03-oq-01": {
@@ -7510,8 +7512,8 @@
       "result": "clean"
     },
     "dini-theorem-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -7653,9 +7655,9 @@
       "result": "clean"
     },
     "dissection-of-cubes-oq-01-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:48Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "dissection-of-cubes-oq-01-oq-01-oq-01": {
@@ -7678,9 +7680,9 @@
       "notes": "Re-audited 2026-05-04: 0 sorries, leanFile.axiomCount=0 (meta.axiomCount=2 from parent imports, by design). covers_unit_cube:=trivial is struct field fill not a True stub. Empty issues array was auditor artifact."
     },
     "dissection-of-cubes-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-16T10:00:13Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "dissection-of-cubes-oq-02-oq-02": {
@@ -7991,8 +7993,8 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "ehrhart-cube-proven-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-05-06T21:00:17Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -8064,14 +8066,14 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-06T06:15:20Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
     "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-24T22:10:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": [],
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
@@ -8419,14 +8421,15 @@
     },
     "erdos-1001": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:45:30Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T18:30:00Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-1001-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:46Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "erdos-1001-oq-02-oq-01": {
@@ -9537,8 +9540,8 @@
       "result": "clean"
     },
     "erdos-1062-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-19T15:45:01Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -9616,8 +9619,8 @@
       "result": "issues-fixed"
     },
     "erdos-107-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-19T11:23:46Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -12432,9 +12435,9 @@
       "issues": []
     },
     "erdos-307-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:08:22Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "erdos-307-oq-02-oq-01": {
@@ -13940,9 +13943,9 @@
     },
     "erdos-482": {
       "agentId": "auditor-cycle-2026-05-01",
-      "auditCount": 4,
-      "lastAudited": "2026-05-27T08:49:08Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T18:30:00Z",
+      "result": "clean",
       "issues": [
         "Phantom non-periodicity axiom in originalContributions; sections part-1/3/5 describe docstring-only content as axiomatized \u2014 issue #14343"
       ]
@@ -18779,8 +18782,8 @@
       "result": "clean"
     },
     "feuerbachs-theorem-oq-02-murakami": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-17T00:00:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -19166,9 +19169,9 @@
       "result": "clean"
     },
     "friendship-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-08T21:15:00Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "friendship-theorem-oq-01-oq-01": {
@@ -19657,9 +19660,9 @@
       "result": "clean"
     },
     "geometric-series-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "geometric-series-oq-01-oq-02": {
@@ -20430,9 +20433,9 @@
       "issues": []
     },
     "herons-formula-oq-06-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-25T07:27:00Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "herons-formula-oq-07": {
@@ -20918,9 +20921,9 @@
       "result": "clean"
     },
     "inclusion-exclusion-oq-04-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "infinitude-primes": {
@@ -20942,9 +20945,9 @@
       "issues": []
     },
     "infinitude-primes-4k1-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "infinitude-primes-4k1-oq-02-oq-01": {
@@ -21803,8 +21806,8 @@
       "issues": []
     },
     "lagrange-theorem-oq-02-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -22570,8 +22573,8 @@
       "result": "clean"
     },
     "markov-equation-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-28T13:50:04Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -23171,8 +23174,8 @@
       "result": "clean"
     },
     "nth-root-irrational-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-15T15:01:15Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean",
       "issues": []
     },
@@ -23868,9 +23871,10 @@
     },
     "product-of-segments-of-chords": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:22Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T18:30:00Z",
+      "result": "clean",
+      "issues": []
     },
     "product-of-segments-of-chords-oq-01": {
       "auditCount": 2,
@@ -24415,9 +24419,9 @@
       "issues": []
     },
     "rearrangement-inequality-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "repunit-oq-01": {
@@ -24554,9 +24558,9 @@
       "result": "issues-fixed"
     },
     "schauder-fixed-point-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-25T23:00:00Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "schroder-numbers-oq-01": {
@@ -24919,9 +24923,9 @@
       "result": "clean"
     },
     "solution-of-cubic-oq-01-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "solution-of-cubic-oq-03": {
@@ -25893,9 +25897,9 @@
       "issues": []
     },
     "sylvester-sequence-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "sylvester-sequence-oq-02": {
@@ -26357,9 +26361,9 @@
       "result": "clean"
     },
     "urysohns-lemma-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:30:00Z",
       "result": "clean"
     },
     "urysohns-lemma-oq-01-oq-01-oq-01-oq-01": {


### PR DESCRIPTION
## Auditor re-audit sweep — 2026-07-08

Backlog is 0 (4779/4779 audited). This sweep re-audits every gallery meta whose **git commit date postdates its tracked `lastAudited`** — the real re-audit signal (mtime/find-targets --next are noise once the backlog is empty).

### Scope
79 existing candidates (deleted-meta false positives filtered out). Dominated by the 2026-07-04 annotations-build regen cluster (area-of-circle family) plus today's cauchy-interlacing enrichment (#35351).

### Method
Comment-stripped mechanical check per entry: sorry / axiom / `native_decide` / True-stub counts vs `meta.json` numeric fields, plus whole-meta prose reconciliation (`N sorr` / `N axiom`).

### Result: all 79 clean
Five entries tripped the mechanical checker and were verified clean by hand:

| Entry | Flag | Resolution |
|---|---|---|
| cayley-hamilton-reduction-oq-02-oq-01 | 12 sorries in "verified" | Sorries live only in the Aristotle companion (disclosed); main file 0/0 |
| area-of-circle-oq-05-oq-01 | 2 hidden sorries | Companion scaffolds, disclosed; entry is `axiomatized` (conservative) |
| ehrhart-cube-proven-oq-02 | 8 native_decide | `axiomatized` + `Lean.ofReduceBool` disclosed |
| elementary-quadratic-reciprocity* | native_decide | Illustrative example/spot-check blocks; main proofs native_decide-free (accepted norm: 57/64 verified entries carry undisclosed example-native_decide) |
| area-of-circle-oq-01-oq-03-oq-02 | prose "15 sorr" | False match on "15 **sorry-free** results"; actual 2 axioms / 2 sorries, consistent |

Existing `issues[]` audit trails preserved (e.g. erdos-482).

🤖 Generated with [Claude Code](https://claude.com/claude-code)