### PR TITLE
research(kronecker-oq0302-wip01): denominator-side periodicity of (-1/·) mod 4 and (2/·) mod 8 [VERIFIED]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -427,6 +427,39 @@ theorem kronecker2_eq_kronecker_two (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
   · rw [if_pos h, if_pos (by omega)]
   · rw [if_neg h, if_neg (by omega)]
 
+/-- **The denominator character `(-1/·)` is periodic mod 4.**
+    For odd positive `n`, `(-1/(n+4)) = (-1/n)`. Together with multiplicativity
+    in the second argument (`kronecker_mul_right`) this exhibits the *sign*
+    supplementary character — the value `(-1/·)` as the odd denominator varies —
+    as a Dirichlet character modulo `4`. This is the denominator-side complement
+    of `kronecker2_periodic` (which shows the *numerator* character `(·/2)` is a
+    Dirichlet character mod 8); both are structural inputs to the Gauss-sum route
+    to generalized reciprocity (refinement 2). Immediate from `kronecker_neg_one_odd`,
+    since `(n+4) % 4 = n % 4`. `sorry`-free, axiom-free. -/
+theorem kronecker_neg_one_periodic (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker (-1) ((n : ℤ) + 4) = kronecker (-1) (n : ℤ) := by
+  have e : ((n : ℤ) + 4) = ((n + 4 : ℕ) : ℤ) := by push_cast; ring
+  rw [e, kronecker_neg_one_odd (n + 4) (by omega) (by omega),
+    kronecker_neg_one_odd n hn hno]
+  have h4 : (n + 4) % 4 = n % 4 := by omega
+  rw [h4]
+
+/-- **The denominator character `(2/·)` is periodic mod 8.**
+    For odd positive `n`, `(2/(n+8)) = (2/n)`. Together with `kronecker_mul_right`
+    this exhibits the fixed-numerator-`2` supplementary character — the value
+    `(2/·)` as the odd denominator varies — as a Dirichlet character modulo `8`.
+    It is the denominator-side complement of `kronecker2_periodic`; note the two
+    "2-characters" agree on the odd integers by `kronecker2_eq_kronecker_two`, so
+    both periodicities (numerator mod 8, denominator mod 8) hold. Immediate from
+    `kronecker_two_odd`, since `(n+8) % 8 = n % 8`. `sorry`-free, axiom-free. -/
+theorem kronecker_two_periodic (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker 2 ((n : ℤ) + 8) = kronecker 2 (n : ℤ) := by
+  have e : ((n : ℤ) + 8) = ((n + 8 : ℕ) : ℤ) := by push_cast; ring
+  rw [e, kronecker_two_odd (n + 8) (by omega) (by omega),
+    kronecker_two_odd n hn hno]
+  have h8 : (n + 8) % 8 = n % 8 := by omega
+  rw [h8]
+
 /-!
 ## Module note: what remains open
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
@@ -53,6 +53,30 @@ the proof is `kronecker_two_odd` + `unfold kronecker2` + a residue comparison by
 first fresh build after an edit (elaborates fully — `3058/3058` — then crashes on
 finalization). A plain retry builds green (environmental / shared-volume, not a
 proof error). Do NOT edit the proof in response to a line-less 135.
+*(Reproduced again 2026-07-08: fresh build `✖ 135` at `3058/3058`, plain retry
+`✔ Built`. Same behaviour, same fix.)*
+
+## Update (2026-07-08 #2) — denominator-side periodicity of the supplementary characters
+
+Two new theorems establish that the two *denominator-side* quadratic characters
+are periodic Dirichlet characters (theoremCount 26→28, lineCount 477→510,
+0 sorries / 0 axioms):
+- `kronecker_neg_one_periodic (n hn hno)` — for odd positive `n`,
+  `(-1/(n+4)) = (-1/n)`: the sign character `(-1/·)` is periodic mod 4.
+- `kronecker_two_periodic (n hn hno)` — for odd positive `n`,
+  `(2/(n+8)) = (2/n)`: the character `(2/·)` is periodic mod 8.
+
+Both are one-liners off the Section-8 supplementary laws: rewrite the numeral
+addition `(n:ℤ)+k = ((n+k:ℕ):ℤ)` (`push_cast; ring`), apply `kronecker_neg_one_odd`
+/`kronecker_two_odd` on both sides, then close with `(n+k)%k = n%k` by `omega`.
+
+**Why this matters (honest framing).** These are the *denominator-side* complement
+of `kronecker2_periodic` (which is the *numerator* character `(·/2)`). Combined
+with `kronecker_mul_right` (multiplicativity in the denominator), they exhibit the
+supplementary characters `(-1/·)` and `(2/·)` as Dirichlet characters mod 4 and mod
+8 — the periodicity + multiplicativity data the Gauss-sum route to generalized
+reciprocity (refinement 2) rests on. This is incremental structural progress, not
+the reciprocity core itself, which still needs the Gauss sum (open).
 
 ## Open work
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: COMPLETED
 **Since**: 2026-07-07
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
@@ -38,6 +38,14 @@ supplementary laws are done. Or refinement (1): redefine `kronecker` to use
 
 ## Attempt Counts
 
-- Total attempts: 2
+- Total attempts: 3
 - Current approach attempts: 1
 - Approaches tried: 1
+
+## Progress log
+
+- 2026-07-08 (iter 3): Added denominator-side periodicity of the supplementary
+  characters — `kronecker_neg_one_periodic` ((-1/·) periodic mod 4) and
+  `kronecker_two_periodic` ((2/·) periodic mod 8). Structural complement of
+  `kronecker2_periodic`; feeds the Gauss-sum route (refinement 2). The Gauss-sum
+  reciprocity core and refinement (1) definition rewiring both remain open.

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,11 +18,11 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 22,
+    "theoremCount": 28,
     "defCount": 4,
-    "lineCount": 365,
+    "lineCount": 510,
     "dateAdded": "2026-03-28",
-    "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized.",
+    "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
     "definitionCount": 4
   },
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 477,
+    "lineCount": 510,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 28,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Incremental structural progress on the Kronecker-symbol WIP (`elementary-quadratic-reciprocity-oq-03-oq-02-wip-01`), toward refinement (2) — generalized quadratic reciprocity via Gauss sums.

Two new theorems in `Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean` (0 sorries, 0 axioms; theoremCount 26→28, lineCount 477→510):

- `kronecker_neg_one_periodic` — for odd positive `n`, `(-1/(n+4)) = (-1/n)`: the sign supplementary character `(-1/·)` is periodic **mod 4**.
- `kronecker_two_periodic` — for odd positive `n`, `(2/(n+8)) = (2/n)`: the character `(2/·)` is periodic **mod 8**.

## Why this matters

These are the *denominator-side* complement of the existing `kronecker2_periodic` (which shows the *numerator* character `(·/2)` is a Dirichlet character mod 8). Combined with `kronecker_mul_right` (multiplicativity in the denominator), they supply the **periodicity + multiplicativity** data that exhibits the supplementary characters `(-1/·)` and `(2/·)` as Dirichlet characters mod 4 / mod 8 — a direct structural input to the Gauss-sum route to generalized reciprocity.

## Honesty note

This is incremental structural progress, **not** the reciprocity core: the Gauss-sum argument for generalized reciprocity (refinement 2) and the definition-rewiring for the classical even-modulus symbol (refinement 1) both remain open, as documented in the source module note. The problem was already COMPLETED (Target 1 done); this advances the open follow-up work.

## Verification

Built via `./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02` — `Built (3058 jobs)`, 0 errors, only a pre-existing unused-`done` linter warning. (Fresh build hit the file's documented environmental exit-135 SIGSEGV at 3058/3058; a plain retry built green — not a proof error.)

Proofs are one-liners off the Section-8 supplementary laws: rewrite `(n:ℤ)+k = ((n+k:ℕ):ℤ)`, apply `kronecker_neg_one_odd`/`kronecker_two_odd` on both sides, close with `(n+k)%k = n%k` by `omega`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)