### PR TITLE
Enrich Catalan linear recurrence: add navigable mainTheorems array

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01/meta.json
@@ -103,6 +103,22 @@
       "mathContext": "$C_{n+1} = 2(2n+1)\\,C_n / (n+2)$."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "catalan_linear_recurrence",
+      "type": "core",
+      "description": "The headline result: the first-order (holonomic) linear recurrence for the Catalan numbers, $(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, over ℕ. Absent from Mathlib, which states only the quadratic Segner convolution catalan_succ' and the closed form catalan_eq_centralBinom_div. Proved without induction by multiplying through by n+1, rewriting via the central-binomial bridge succ_mul_catalan_eq_centralBinom and the central-binomial recurrence Nat.succ_mul_centralBinom_succ, then cancelling n+1.",
+      "leanType": "(n : ℕ) → (n + 2) * catalan (n + 1) = 2 * (2 * n + 1) * catalan n",
+      "startLine": 31
+    },
+    {
+      "name": "catalan_succ_eq_div",
+      "type": "corollary",
+      "description": "The recurrence solved for the next term, exhibiting the exact O(1) division step $C_{n+1} = 2(2n+1)\\,C_n/(n+2)$ over ℕ. The truncating division is provably exact because n+2 divides the numerator (Nat.mul_div_cancel_left).",
+      "leanType": "(n : ℕ) → catalan (n + 1) = 2 * (2 * n + 1) * catalan n / (n + 2)",
+      "startLine": 53
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "catalan-numbers-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01` (quality 94, passes 0).

This entry was already comprehensively enriched — 6 annotations (all with mathContext/significance/relatedConcepts/prerequisites), full section coverage of the 63-line Lean file, 4 keyInsights, and a conclusion with 3 open questions. Per the size guardrails (bigger ≠ better), the only high-value, non-inflating improvement was adding a navigable `mainTheorems` array.

**Change:**
- Added `mainTheorems` with the two theorems verified against the Lean source:
  - `catalan_linear_recurrence` (core, L31): `(n+2)·catalan(n+1) = 2·(2n+1)·catalan n`
  - `catalan_succ_eq_div` (corollary, L53): the exact O(1) division step
- Each includes `leanType` signature and `startLine` anchor for page navigation.

meta.json grows 14.1 → 15.2 KB, well under the 60 KB cap. No prose inflation.