### PR TITLE
research(erdos-1093-oq-02): Section VII — a prime in the window caps the deficiency

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -224,3 +224,40 @@ theorem maximalDeficiencyIs_nine_iff_kGe10 :
     by_cases hk : k ≤ 9
     · exact deficiency_le_nine_of_k_le_nine hk
     · exact h n k (by omega) hv
+
+/-
+## Section VII: Prime values in the window cap the deficiency
+
+The sharp density bound `deficiency + (#primes in window) ≤ k`
+(`deficiency_add_prime_count_le`) has a clean *effective* consequence:
+exhibiting a **single** prime among the `k` consecutive integers `n, …, n-k+1`
+already forces `deficiency n k < k`.  Dually, the extreme case
+`deficiency n k = k` (every window value `k`-smooth) can only occur across a
+prime gap of length `≥ k` — no window value is prime.  This is a structural
+reason record deficiencies are hard: they demand unusually prime-poor windows,
+exactly the phenomenon the Erdős–Lacampagne–Selfridge density bound exploits.
+-/
+
+/-- **A prime in the window strictly lowers the deficiency.**  If some `n - i`
+(`i < k`) is prime, then `deficiency n k < k`: the prime occupies a window slot
+that no smooth contributor can (a smooth window value is never prime), and the
+sharp bound converts this into `< k`.  Effective: one prime certificate suffices. -/
+theorem deficiency_lt_k_of_prime_in_window {n k i : ℕ} (hn : 2 * k ≤ n)
+    (hi : i < k) (hp : (n - i).Prime) : deficiency n k < k := by
+  have hmem : i ∈ (Finset.range k).filter (fun j => (n - j).Prime) :=
+    Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hi, hp⟩
+  have hpos : 1 ≤ ((Finset.range k).filter (fun j => (n - j).Prime)).card :=
+    Finset.one_le_card.mpr ⟨i, hmem⟩
+  have hbound := deficiency_add_prime_count_le (n := n) (k := k) hn
+  omega
+
+/-- **Extreme deficiency forces a prime gap.**  If the deficiency attains the
+trivial maximum `deficiency n k = k` (every one of the `k` consecutive integers
+`n, …, n-k+1` is `k`-smooth), then none of them is prime — a prime gap of length
+`≥ k`.  Record deficiencies are correspondingly hard: they demand prime-poor
+windows. -/
+theorem window_primefree_of_deficiency_eq_k {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : deficiency n k = k) : ∀ i < k, ¬ (n - i).Prime := by
+  intro i hi hp
+  have := deficiency_lt_k_of_prime_in_window hn hi hp
+  omega

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -97,3 +97,40 @@ or do higher values occur? (The universal upper-bound direction is open.)
 - Exploit the density constraint: deficiency `d` forces `d` of the `k` consecutive
   integers `n,…,n−k+1` to be `k`-smooth.
 - Consider a Kummer-based (`ofReduceBool`-free) proof of `noSmallPrimeFactors_284_28`.
+
+## Session 2026-07-08 (Session 2, researcher-1) — Section VII: prime-window caps deficiency
+
+**Mode:** DEEP DIVE (RICH problem, look-outward from mature state)
+**Outcome:** progress (2 new ofReduceBool-free theorems)
+
+### What I Did
+Extended the sharp density bound `deficiency + #primes-in-window ≤ k`
+(`deficiency_add_prime_count_le`) with its effective/extreme consequences:
+- `deficiency_lt_k_of_prime_in_window`: a single prime `n-i` (`i<k`) in the
+  window forces `deficiency n k < k` (one prime certificate suffices — effective).
+- `window_primefree_of_deficiency_eq_k`: the trivial-max case `deficiency n k = k`
+  forces a prime gap of length ≥ k (no window value is prime). Structural reason
+  record deficiencies are hard: they demand prime-poor windows (the ELS density
+  phenomenon).
+
+Both proved by pulling `#primes ≥ 1` (`Finset.one_le_card.mpr ⟨i,_⟩`) into the
+sharp bound and closing with `omega`. No native_decide, no new axioms.
+
+### Verification
+Built clean (3059 jobs). File now 19 theorems, 0 sorries, 0 axiom declarations.
+native_decide (⇒ ofReduceBool) still used ONLY by the 3 record facts
+(deficiency_284_28 [parent], noSmallPrimeFactors_284_28, smooth_indices_284_28);
+all structural results (Sections I,III–VII) are ofReduceBool-free.
+
+### Assessment / Frontier
+The open core (universal upper bound `deficiency ≤ 9` for all admissible pairs,
+k ≥ 10) is genuinely blocked on analytic NT: it needs an *effective* ELS/Brun–
+Titchmarsh short-interval prime-count bound, absent from Mathlib v4.26. The parent
+axiom `els_upper_bound` has a non-effective constant, so even fixed-k slices aren't
+decidable. Elementary structural theory here is near its frontier.
+
+### Next Steps (if revisited)
+- ofReduceBool-free proof of `noSmallPrimeFactors_284_28` via Kummer/Legendre digit
+  sums (Mathlib `Nat.Prime.factorization_choose`), per-prime for p∈{2,3,5,7,11,13,17,19,23};
+  only partial (record count/smooth_indices still need native_decide).
+- The universal bound needs effective analytic NT — BLOCKED until Mathlib has it.


### PR DESCRIPTION
## Summary

Erdős #1093 OQ-02 asks whether `d(284,28) = 9` is the maximal *deficiency* of a binomial coefficient `C(n,k)` (the number of `k`-smooth values among the `k` consecutive integers `n, …, n-k+1`, for admissible pairs). The universal upper bound is genuinely open. This PR extends the existing sharp density bound

```
deficiency n k + (#primes in the window) ≤ k        -- deficiency_add_prime_count_le
```

with its effective and extreme consequences, both `ofReduceBool`-free:

```lean
theorem deficiency_lt_k_of_prime_in_window {n k i : ℕ} (hn : 2 * k ≤ n)
    (hi : i < k) (hp : (n - i).Prime) : deficiency n k < k

theorem window_primefree_of_deficiency_eq_k {n k : ℕ} (hn : 2 * k ≤ n)
    (h : deficiency n k = k) : ∀ i < k, ¬ (n - i).Prime
```

- **Effective bound:** exhibiting a *single* prime in the window `[n-k+1, n]` already certifies `deficiency n k < k`.
- **Extreme case ⇒ prime gap:** the trivial maximum `deficiency n k = k` (every window value `k`-smooth) can only occur across a prime gap of length `≥ k`. This is a structural reason record deficiencies are hard — they demand unusually prime-poor windows, exactly the Erdős–Lacampagne–Selfridge density phenomenon.

Both follow by feeding `#primes ≥ 1` into `deficiency_add_prime_count_le` and closing with `omega`.

## Verification

- Docker build clean: `Built Proofs.Erdos1093ProblemOQ02` (3059 jobs)
- File now has 19 theorems, **0 sorries, 0 `axiom` declarations**
- `native_decide` (→ `Lean.ofReduceBool`) remains confined to the 3 record facts only (`deficiency_284_28` [parent], `noSmallPrimeFactors_284_28`, `smooth_indices_284_28`); all structural results, including this new Section VII, are `ofReduceBool`-free.

## Scope / frontier

The open core (universal bound `deficiency ≤ 9` for all admissible pairs with `k ≥ 10`) stays blocked on *effective* analytic number theory (ELS/Brun–Titchmarsh short-interval prime counts) absent from Mathlib v4.26; the parent's `els_upper_bound` axiom carries a non-effective constant. Elementary structural theory is near its frontier here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)