### PR TITLE
Enrich Dual Weyl inequality: add header section for full file coverage

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/meta.json
@@ -82,6 +82,14 @@
   },
   "sections": [
     {
+      "id": "header-setup",
+      "title": "Module Header and the Negation Strategy",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Imports (Mathlib and the parent Proofs.CauchyInterlacingWeyl) and the module docstring laying out the two-sided Weyl bracket: the parent's subadditive weyl_add_le (i + j ≤ k → ρ k ≤ μ i + ν j) versus the superadditive weyl_add_ge (k + (n−1) ≤ i + j → μ i + ν j ≤ ρ k) proved here. Explains the negation trick — presenting −T by the reversed eigenbasis b∘Fin.rev and the antitone enumeration t ↦ −μ(Fin.rev t) — and how feeding −T, −U, −(T+U) into weyl_add_le at reversed indices converts hypothesis and conclusion into the dual bound. Opens InnerProductSpace scope and the CauchyInterlacing.Weyl namespace. Flagged as a research file, intentionally not registered in Proofs.lean.",
+      "mathContext": "Two-sided bracket λ_{i+1}(A) + λ_{j+1}(B) ≤ λ_{i+j+1−(n−1)}(A+B) ≤ λ_{i'+1}(A) + λ_{j'+1}(B); the lower half is the upper half read off −T, −U."
+    },
+    {
       "id": "negation-eigen",
       "title": "The Negation Eigen-Presentation",
       "startLine": 50,


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-03-oq-02` (quality 94, passes 0).

Already richly enriched — 7 annotations (all with mathContext/significance), 3 mainTheorems, 4 keyInsights, conclusion with implications and 3 open questions (Lidskii–Wielandt, interlacing specialization, Horn's problem). Per the size guardrails, the one genuine gap was **section coverage**: the `sections` array started at line 50, leaving lines 1–49 (imports, module docstring explaining the negation trick, `open scoped`, namespace) uncovered.

**Change:**
- Added a `header-setup` section (L1–49) — "Module Header and the Negation Strategy" — so the `sections` array now spans the full 127-line Lean file.

No prose inflation; meta.json 20.8 → 21.9 KB, well under the 60 KB cap.