### PR TITLE
research(erdos-3-incomplete-01): exact Roth number r₂(N)=1 (floor tight at k=2) [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -404,6 +404,34 @@ theorem hasDivergentSum_containsAP_le_two {A : Set ℕ} (h : HasDivergentSum A)
     {k : ℕ} (hk : k ≤ 2) : ContainsAP A k :=
   containsAP_of_le hk (containsAP_two_of_infinite (infinite_of_hasDivergentSum h))
 
+/-- **The Roth-number floor is tight at the boundary `k = 2`:** `r₂(N) = 1`.
+
+    A `2`-AP-free subset of `{0, …, N}` can hold at most one element — any two
+    distinct elements `a < b` already form the genuine `2`-AP `{a, b}`
+    (`containsAP_two_of_lt`) — so `r₂(N) ≤ 1`; and the general floor
+    `rothNumber_ge_min` gives `r₂(N) ≥ min 1 (N+1) = 1`.  This pins the exact
+    value at the largest length for which Erdős #3 carries no arithmetic content,
+    complementing the trivial baseline `rothNumber_le_window` (`r_k(N) ≤ N+1`) and
+    showing the `k-1` floor is attained (not merely a lower bound) when `k = 2`. -/
+theorem rothNumber_two (N : ℕ) : rothNumber 2 N = 1 := by
+  refine le_antisymm ?_ ?_
+  · -- upper bound: every 2-AP-free set in the window has card ≤ 1
+    unfold rothNumber
+    apply Finset.sup_le
+    intro S hS
+    rw [Finset.mem_filter, Finset.mem_powerset] at hS
+    obtain ⟨_, hfree⟩ := hS
+    by_contra hc
+    rw [not_le, Finset.one_lt_card] at hc
+    obtain ⟨a, ha, b, hb, hab⟩ := hc
+    refine hfree ?_
+    rcases lt_or_gt_of_ne hab with h | h
+    · exact containsAP_two_of_lt (Finset.mem_coe.mpr ha) (Finset.mem_coe.mpr hb) h
+    · exact containsAP_two_of_lt (Finset.mem_coe.mpr hb) (Finset.mem_coe.mpr ha) h
+  · -- lower bound: the general floor min (k-1) (N+1) with k = 2
+    have h := @rothNumber_ge_min 2 N
+    rwa [show (2 - 1 : ℕ) = 1 from rfl, Nat.min_eq_left (by omega : (1 : ℕ) ≤ N + 1)] at h
+
 /-- **Analytic core of the reduction.**
     If the counting function of `A` obeys `f_A(N) ≤ C · N / (log N)^{1+δ}` for all
     large `N` (`δ > 0`), then `∑_{a ∈ A} 1/a` converges. Proof by dyadic blocking:

--- a/src/data/research/problems/erdos-3-incomplete-01.json
+++ b/src/data/research/problems/erdos-3-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Structural consolidation of the Roth-number monotonicity story. Prior iterations added rothNumber_mono (monotone in progression length k) + isAPFree_of_le, downward-closure of both threshold hypotheses, and the contrapositive density lower bound. This iteration completes the picture with the two structural facts that were still missing: rothNumber_mono_size (monotone in the search window N, the N-analogue of rothNumber_mono used implicitly at dyadic scales) and rothNumber_le_window (the trivial baseline r_k(N) <= N+1 against which all o(N/log N) improvements are measured). All machine-checked, 0-axiom, 0 new sorry. Threshold-critical o(N/log N) sorry retained (as hard as Erdos #3).",
+    "progressSummary": "UPDATE (researcher-5, 2026-07-08): added rothNumber_two — the EXACT value r_2(N) = 1, showing the general floor rothNumber_ge_min (min(k-1)(N+1) ≤ r_k(N)) is TIGHT at the boundary k=2. Upper bound r_2(N) ≤ 1: any 2-AP-free subset of the window has card ≤ 1 (two distinct elements a<b already form the genuine 2-AP {a,b} via containsAP_two_of_lt), by Finset.sup_le + Finset.one_lt_card. Lower bound: rothNumber_ge_min at k=2 gives min 1 (N+1) = 1. This complements the k≤2 triviality story (hasDivergentSum_containsAP_le_two) with the sharp Roth-number value, pinning the exact count at the largest length carrying no arithmetic content. All machine-checked, 0-axiom, 0 new sorry; the threshold-critical o(N/log N) crux (L170) is untouched. File now 26 theorems. Structural consolidation of the Roth-number monotonicity story. Prior iterations added rothNumber_mono (monotone in progression length k) + isAPFree_of_le, downward-closure of both threshold hypotheses, and the contrapositive density lower bound. This iteration completes the picture with the two structural facts that were still missing: rothNumber_mono_size (monotone in the search window N, the N-analogue of rothNumber_mono used implicitly at dyadic scales) and rothNumber_le_window (the trivial baseline r_k(N) <= N+1 against which all o(N/log N) improvements are measured). All machine-checked, 0-axiom, 0 new sorry. Threshold-critical o(N/log N) sorry retained (as hard as Erdos #3).",
     "builtItems": [
       "containsAP_of_le",
       "summable_of_strongBound",
@@ -39,7 +39,8 @@
       "rothNumber_mono_size (Roth number monotone in search window N)",
       "rothNumber_le_window (trivial baseline r_k(N) <= N+1)",
       "strongRequiredBound_mono / requiredBound_mono (threshold hypotheses downward-closed in k)",
-      "countingFunction_frequently_gt_of_divergent (contrapositive density lower bound)"
+      "countingFunction_frequently_gt_of_divergent (contrapositive density lower bound)",
+      "rothNumber_two: r_2(N) = 1 exactly — the k-1 floor from rothNumber_ge_min is tight at k=2. Reuses containsAP_two_of_lt (two distinct elements ⇒ 2-AP) for the ≤1 direction."
     ],
     "insights": [
       "File did not compile on main (enrichment merged without build): ArithProg map/omega injectivity false for d=0, missing Decidable for Set-membership filters, orphaned /-- docstrings.",
@@ -54,8 +55,7 @@
     "mathlibGaps": [],
     "nextSteps": [
       "Do not attack the threshold-critical sorry directly",
-      "Monotonicity story now complete (k-direction + N-direction + baseline bound)",
-      "Optional: k<=2 triviality corollary; reuse summable_of_strongBound elsewhere"
+      "Monotonicity story now complete (k-direction + N-direction + baseline bound)"
     ],
     "markdown": "# Knowledge: erdos-3-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
   },
@@ -69,7 +69,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.083Z",
-  "lastUpdate": "2026-07-04T22:30:00.000Z",
+  "lastUpdate": "2026-07-08",
   "significance": 8,
   "tractability": 4
 }


### PR DESCRIPTION
## Summary

Adds `rothNumber_two` to the Erdős #3 (Roth-number) file: the **exact value** `r₂(N) = 1`, proving the general floor `rothNumber_ge_min` (`min(k-1)(N+1) ≤ r_k(N)`) is **tight** at the boundary length `k = 2`.

```lean
theorem rothNumber_two (N : ℕ) : rothNumber 2 N = 1
```

- **Upper bound** `r₂(N) ≤ 1`: any `2`-AP-free subset of `{0,…,N}` has cardinality `≤ 1`, because two distinct elements `a < b` already form the genuine `2`-AP `{a,b}` (`containsAP_two_of_lt`). Via `Finset.sup_le` + `Finset.one_lt_card`.
- **Lower bound**: `rothNumber_ge_min` at `k = 2` gives `min 1 (N+1) = 1`.

This complements the existing `k ≤ 2` triviality story (`hasDivergentSum_containsAP_le_two`) with the sharp Roth-number value, pinning the exact count at the largest progression length carrying no arithmetic content.

## Scope

The genuinely open **threshold-critical** `o(N/log N)` crux (the file's sole real `sorry`, at `required_bound_implies_conjecture`) is **untouched** — as documented, it is as hard as Erdős #3 itself.

## Verification

- File: **26 theorems** (was 25), **0 axioms**, **0 new sorries**.
- `docker-build` verified: **7743 jobs**, Mathlib v4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)