### PR TITLE
research(erdos-729-oq-02): silence 4 unused-var warnings in reducedDenominator [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos729Problem.lean
+++ b/proofs/Proofs/Erdos729Problem.lean
@@ -91,7 +91,7 @@ def SmallPrimes (C : ℝ) : Set ℕ :=
   { p | Nat.Prime p ∧ (p : ℝ) ≤ C }
 
 /-- The "reduced" quotient: n!/(a!b!) with small primes removed from denominator -/
-noncomputable def reducedDenominator (n a b : ℕ) (C : ℝ) : ℕ :=
+noncomputable def reducedDenominator (_n _a _b : ℕ) (_C : ℝ) : ℕ :=
   -- The denominator of n!/(a!b!) with factors from small primes removed
   Classical.choose (⟨1, Nat.one_pos⟩ : ∃ d : ℕ, d > 0)
 

--- a/research/problems/erdos-729-oq-02/state.md
+++ b/research/problems/erdos-729-oq-02/state.md
@@ -1,10 +1,19 @@
 # Research State: erdos-729-oq-02
 
 ## Current State
-**Phase**: ACT
+**Phase**: DONE
 **Path**: full
 **Since**: 2026-06-15
-**Iteration**: 2
+**Iteration**: 3
+
+## Session 2026-07-08 (researcher-6) — fresh re-verification + lint cleanup
+Re-confirmed OQ-02 is fully resolved. `Erdos729Problem.lean` rebuilt clean this
+session (`✔ Built Proofs.Erdos729Problem`, 7743 jobs, 0 sorries, 3 out-of-scope
+axioms). Silenced 4 `unused variable` linter warnings in the `reducedDenominator`
+placeholder def (parent-problem scaffold) by underscore-prefixing its unused
+binders `n a b C → _n _a _b _C`; rebuilt warning-free. The general-`p` Legendre
+identity is proven in `Erdos729LegendreGeneral.lean` and the multinomial Kummer
+form in `Erdos729LegendreMultinomial.lean`. Marking OQ-02 complete.
 
 ## Current Focus
 OQ-02 resolved and now BUILD-VERIFIED: `legendre_for_two` ($v_2(n!) = n - s_2(n)$)


### PR DESCRIPTION
## Summary

OQ-02 — Legendre's formula $v_2(n!) = n - s_2(n)$ (`legendre_for_two`) — is **fully resolved** and re-verified this session. This PR is a zero-risk lint cleanup on top of the confirmed-green build.

## What changed
- `Erdos729Problem.lean`: underscore-prefix the 4 unused binders of the `reducedDenominator` placeholder def (`n a b C` → `_n _a _b _C`), removing 4 `unused variable` linter warnings. The def is a deliberate parent-problem (#729) scaffold; its semantics are unchanged.
- `state.md`: record fresh verification + mark OQ-02 DONE.

## Verification
Rebuilt clean via docker wrapper: `✔ Built Proofs.Erdos729Problem` (7743 jobs), **0 sorries, 3 out-of-scope axioms** (`erdos_1968_classical`, `barreto_leeham_theorem`, `barreto_leeham_bound` — the deep open math of Erdős #729 itself). Warning-free after the edit.

## Status
OQ-02 resolved: `legendre_for_two` proven axiom-free from Mathlib's `sub_one_mul_padicValNat_factorial`; the general-$p$ identity $v_p(n!)=(n-s_p(n))/(p-1)$ is proven in `Erdos729LegendreGeneral.lean` and the multinomial Kummer form in `Erdos729LegendreMultinomial.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)