### PR TITLE
research(erdos-659-incomplete-01): closure of x²+2y² representable set under squares/powers [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -285,6 +285,26 @@ theorem two_representable : 2 ∈ representable_x2_2y2 := ⟨0, 1, by norm_num�
 /-- `3 = 1² + 2·1²` is representable (`3 ≡ 3 (mod 8)` splits in `ℤ[√-2]`). -/
 theorem three_representable : 3 ∈ representable_x2_2y2 := ⟨1, 1, by norm_num⟩
 
+/-- **Every perfect square is representable** (`n² = n² + 2·0²`, the norm of a
+    rational integer). -/
+theorem sq_representable (n : ℕ) : n ^ 2 ∈ representable_x2_2y2 :=
+  ⟨(n : ℤ), 0, by push_cast; ring⟩
+
+/-- **Powers of a representable integer are representable.**  Immediate induction
+    from `representable_mul` and `one_representable` (`m⁰ = 1`).  This makes precise
+    the claim in the `representable_mul` docstring that "every power of `2` is
+    representable". -/
+theorem representable_pow {m : ℕ} (hm : m ∈ representable_x2_2y2) (k : ℕ) :
+    m ^ k ∈ representable_x2_2y2 := by
+  induction k with
+  | zero => simpa using one_representable
+  | succ k ih => rw [pow_succ]; exact representable_mul ih hm
+
+/-- **Every power of `2` is representable** (`2ᵏ = Norm((√-2)ᵏ)`), the special case
+    of `representable_pow` promised by the `representable_mul` docstring. -/
+theorem two_pow_representable (k : ℕ) : 2 ^ k ∈ representable_x2_2y2 :=
+  representable_pow two_representable k
+
 /-- The 4-point property follows from avoiding all six two-distance configurations,
     **together with** the geometric lower bound that no 4-point subset collapses to
     fewer than two distinct distances.

--- a/src/data/research/problems/erdos-659-incomplete-01.json
+++ b/src/data/research/problems/erdos-659-incomplete-01.json
@@ -29,10 +29,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETION: dangling sorry resolved (file now 0-sorry, 1-axiom, compiles clean after fixing 5 floating doc-comments). Added verified positive-definiteness lemmas for x²+2y². Main result erdos_659 remains axiomatized on moreeOsburnWorks (Landau theorem, not in Mathlib).",
+    "progressSummary": "UPDATE (researcher-5, 2026-07-08): extended the multiplicative-structure section of the norm form x²+2y² with three verified closure lemmas: sq_representable (every perfect square n²=n²+2·0² is representable), representable_pow (powers mᵏ of a representable m stay representable — induction from representable_mul + one_representable), and two_pow_representable (every 2ᵏ is representable). The last makes precise the claim already asserted in the representable_mul docstring ('every power of 2 is representable') but not previously proved. All 0-axiom / 0-sorry, docker-build verified (3058 jobs, Mathlib v4.26.0). The Landau axiom moreeOsburnWorks and the isConfiguration True-placeholders are untouched (out of scope). COMPLETION: dangling sorry resolved (file now 0-sorry, 1-axiom, compiles clean after fixing 5 floating doc-comments). Added verified positive-definiteness lemmas for x²+2y². Main result erdos_659 remains axiomatized on moreeOsburnWorks (Landau theorem, not in Mathlib).",
     "builtItems": [
       "latticeDistSq_symm / latticeDistSq_nonneg / latticeDistSq_eq_zero_iff in Erdos659Problem.lean (positive-definiteness of x²+2y²)",
-      "Verified fourPointProperty_from_avoiding_configs (0 sorries) with explicit lower-bound hypothesis"
+      "Verified fourPointProperty_from_avoiding_configs (0 sorries) with explicit lower-bound hypothesis",
+      "sq_representable / representable_pow / two_pow_representable: closure of the x²+2y² representable set under squares and powers; completes the 'every power of 2 is representable' claim from the representable_mul docstring."
     ],
     "insights": [
       "The original fourPointProperty_from_avoiding_configs was false under the product/Chebyshev metric on ℝ×ℝ: unit-square corners (0,0),(1,0),(0,1),(1,1) are mutually equidistant (sup-distance 1), so distinctDistances=1 while avoiding every named 2-distance config. A geometric lower bound (2 ≤ distinctDistances on 4-subsets) is required and now explicit.",
@@ -62,7 +63,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T12:23:52.516Z",
-  "lastUpdate": "2026-04-03T12:23:52.516Z",
+  "lastUpdate": "2026-07-08",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Extends the multiplicative-structure section of the norm form `x²+2y²` (which already had `repr_mul_identity`, `representable_mul`, `one/two/three_representable`) with three verified closure lemmas:

```lean
theorem sq_representable (n : ℕ) : n ^ 2 ∈ representable_x2_2y2          -- n² = n² + 2·0²
theorem representable_pow {m} (hm : m ∈ representable_x2_2y2) (k) : m ^ k ∈ representable_x2_2y2
theorem two_pow_representable (k : ℕ) : 2 ^ k ∈ representable_x2_2y2
```

- `representable_pow` is an immediate induction from the existing `representable_mul` and `one_representable` (`m⁰ = 1`).
- `two_pow_representable` makes precise the claim **already asserted** in the `representable_mul` docstring — *"every power of 2 is representable"* — but not previously proved.
- `sq_representable` records that every rational-integer square is a norm of `ℤ[√-2]`.

## Verification

- File: **13 theorems** (was 10), **0 axioms added**, **0 sorries added**.
- `docker-build` verified: **3058 jobs**, Mathlib v4.26.0.
- The Landau axiom `moreeOsburnWorks` and the `isConfiguration` placeholders are out of scope and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)