### PR TITLE
audit(erdos-214): sync stale meta.lineCount 226→237 after axiom-elim

### DIFF
--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -78,7 +78,7 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 226,
+    "lineCount": 237,
     "assumptions": "1 axiom: juhasz_stronger (Juhász 1979 — a unit-distance-free set's complement contains a congruent copy of ANY 4-point configuration). The original Problem #214 statement (juhasz_1979 : Erdos214Statement) is no longer a separate axiom: it is DERIVED from juhasz_stronger via the proved reduction unit_square_from_stronger (a unit square is a special 4-point configuration, transported into the complement by Juhász's isometry). 0 sorries.",
     "theoremCount": 5,
     "definitionCount": 13,


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: erdos-214
**Problem**: `meta.lineCount` stale at 226 while `leanFile.lineCount` and the actual file are 237.

## Evidence

- De-axiom PR #35381 (`juhasz_1979` axiom 2→1) updated `leanFile.lineCount` 226→237 but left `meta.lineCount` at 226.
- `wc -l proofs/Proofs/Erdos214Problem.lean` = 237.
- Same independently-lagging-lineCount pattern as erdos-666 (#35376).

## Fix

- `meta.lineCount` 226 → 237.

## Also in this PR

Records re-audit of **cauchy-interlacing-theorem-oq-03-oq-01** — CLEAN (verified/original, 0 axioms, 0 sorries, 0 native_decide, no True stubs; prose consistent).

Numeric integrity of erdos-214 otherwise correct: axiomatized/axiom, 1 axiom (`juhasz_stronger`), 0 sorries — all match.

---
Discovered during gallery integrity re-audit sweep (changed-since-lastAudited).