### PR TITLE
research(erdos-378): even-row parity — count odd iff central binomial squarefree [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -193,7 +193,7 @@ theorem squarefreeCount_odd_iff_central_squarefree {n : ℕ}
   set C : Finset ℕ := S.filter (fun k => n < 2 * k) with hC
   set F : Finset ℕ := S.filter (fun k => 2 * k = n) with hF
   have memS : ∀ k, k ∈ S ↔ (k < n ∧ 1 ≤ k ∧ Squarefree (n.choose k)) := by
-    intro k; simp only [hS, mem_filter, mem_range]; tauto
+    intro k; simp only [hS, mem_filter, mem_range]; try tauto
   have klt : ∀ k ∈ S, k < n := fun k hk => ((memS k).1 hk).1
   have mapsS : ∀ k ∈ S, (n - k) ∈ S := by
     intro k hk
@@ -249,9 +249,9 @@ theorem squarefreeCount_odd_iff_central_squarefree {n : ℕ}
   have hFodd : Odd F.card ↔ (n / 2) ∈ S := by
     by_cases h : (n / 2) ∈ S
     · have hFs : F = {n / 2} := by rw [eFc, filter_eq', if_pos h]
-      rw [hFs, Finset.card_singleton]; simp [h, Nat.odd_iff]
+      rw [hFs, Finset.card_singleton]; exact iff_of_true (by decide) h
     · have hFe : F = ∅ := by rw [eFc, filter_eq', if_neg h]
-      rw [hFe, Finset.card_empty]; simp [h, Nat.odd_iff]
+      rw [hFe, Finset.card_empty]; exact iff_of_false (by decide) h
   -- Assemble: squarefreeCount n = 2·|C| + |F|, so its parity is that of |F|.
   have key : squarefreeCount n = 2 * C.card + F.card := by
     have hsc : squarefreeCount n = S.card := by rw [hS]; rfl

--- a/proofs/Proofs/Erdos378Problem.lean
+++ b/proofs/Proofs/Erdos378Problem.lean
@@ -171,6 +171,98 @@ theorem squarefreeCount_even_of_odd {n : ℕ} (hn : Odd n) :
   rw [hsc, splitS, cardAB]
   exact ⟨B.card, rfl⟩
 
+/-- **Parity theorem, even rows.** For even `n ≥ 2`, the number of squarefree
+interior binomials in row `n` is *odd* exactly when the central binomial
+coefficient `C(n, n/2)` is squarefree.
+
+This complements `squarefreeCount_even_of_odd` and completes the parity theory of
+row counts: for odd `n` the count is always even (the involution `k ↦ n − k` is
+fixed-point free), while for even `n` the involution has the single fixed point
+`k = n/2`, so `squarefreeCount n = 2·|A| + |F|` where `|F| ∈ {0,1}` records
+whether the central index is itself squarefree. Hence the count is odd iff
+`C(n, n/2)` is squarefree. In particular an odd count forces `n` even — the
+Granville–Ramaré count `2m + 2` is even, matching the odd-`n` theorem. -/
+theorem squarefreeCount_odd_iff_central_squarefree {n : ℕ}
+    (hn : Even n) (hn2 : 2 ≤ n) :
+    Odd (squarefreeCount n) ↔ Squarefree (n.choose (n / 2)) := by
+  classical
+  obtain ⟨j, hj⟩ := hn
+  set S : Finset ℕ := (range n).filter (fun k => 1 ≤ k ∧ Squarefree (n.choose k))
+    with hS
+  set A : Finset ℕ := S.filter (fun k => 2 * k < n) with hA
+  set C : Finset ℕ := S.filter (fun k => n < 2 * k) with hC
+  set F : Finset ℕ := S.filter (fun k => 2 * k = n) with hF
+  have memS : ∀ k, k ∈ S ↔ (k < n ∧ 1 ≤ k ∧ Squarefree (n.choose k)) := by
+    intro k; simp only [hS, mem_filter, mem_range]; tauto
+  have klt : ∀ k ∈ S, k < n := fun k hk => ((memS k).1 hk).1
+  have mapsS : ∀ k ∈ S, (n - k) ∈ S := by
+    intro k hk
+    obtain ⟨hkn, hk1, hsq⟩ := (memS k).1 hk
+    rw [memS]
+    refine ⟨by omega, by omega, ?_⟩
+    rw [Nat.choose_symm hkn.le]; exact hsq
+  have invol : ∀ k ∈ S, n - (n - k) = k := by
+    intro k hk; have := klt k hk; omega
+  -- Split S on (2k < n): S = A ⊔ D.
+  set D : Finset ℕ := S.filter (fun k => ¬ 2 * k < n) with hD
+  have splitAD : S.card = A.card + D.card := by
+    rw [hA, hD]; exact (filter_card_add_filter_neg_card_eq_card _).symm
+  -- Within D (2k ≥ n), split on (n < 2k): the strict part is C, the equality part F.
+  have hCeq : C = D.filter (fun k => n < 2 * k) := by
+    ext k; simp only [hC, hD, mem_filter]
+    constructor
+    · rintro ⟨hkS, h2⟩; exact ⟨⟨hkS, by omega⟩, h2⟩
+    · rintro ⟨⟨hkS, _⟩, h2⟩; exact ⟨hkS, h2⟩
+  have hFeq : F = D.filter (fun k => ¬ n < 2 * k) := by
+    ext k; simp only [hF, hD, mem_filter]
+    constructor
+    · rintro ⟨hkS, h2⟩; exact ⟨⟨hkS, by omega⟩, by omega⟩
+    · rintro ⟨⟨hkS, hnlt⟩, h2⟩; exact ⟨hkS, by omega⟩
+  have splitDCF : D.card = C.card + F.card := by
+    rw [hCeq, hFeq]
+    exact (filter_card_add_filter_neg_card_eq_card (fun k => n < 2 * k)).symm
+  -- ι := (n - ·) maps A bijectively onto C.
+  have cardAC : A.card = C.card := by
+    refine card_nbij' (fun k => n - k) (fun k => n - k) ?_ ?_ ?_ ?_
+    · intro k hk
+      simp only [Finset.mem_coe, hA, hC, mem_filter] at hk ⊢
+      obtain ⟨hkS, h2k⟩ := hk
+      have hkn := klt k hkS
+      exact ⟨mapsS k hkS, by omega⟩
+    · intro k hk
+      simp only [Finset.mem_coe, hC, hA, mem_filter] at hk ⊢
+      obtain ⟨hkS, h2k⟩ := hk
+      have hkn := klt k hkS
+      exact ⟨mapsS k hkS, by omega⟩
+    · intro k hk
+      simp only [Finset.mem_coe, hA, mem_filter] at hk
+      exact invol k hk.1
+    · intro k hk
+      simp only [Finset.mem_coe, hC, mem_filter] at hk
+      exact invol k hk.1
+  -- The fixed-point set F is the singleton {n/2} when squarefree, else empty.
+  have eFc : F = S.filter (fun k => k = n / 2) := by
+    ext k; simp only [hF, mem_filter]
+    constructor
+    · rintro ⟨hkS, h2⟩; exact ⟨hkS, by omega⟩
+    · rintro ⟨hkS, h2⟩; exact ⟨hkS, by omega⟩
+  have hFodd : Odd F.card ↔ (n / 2) ∈ S := by
+    by_cases h : (n / 2) ∈ S
+    · have hFs : F = {n / 2} := by rw [eFc, filter_eq', if_pos h]
+      rw [hFs, Finset.card_singleton]; simp [h, Nat.odd_iff]
+    · have hFe : F = ∅ := by rw [eFc, filter_eq', if_neg h]
+      rw [hFe, Finset.card_empty]; simp [h, Nat.odd_iff]
+  -- Assemble: squarefreeCount n = 2·|C| + |F|, so its parity is that of |F|.
+  have key : squarefreeCount n = 2 * C.card + F.card := by
+    have hsc : squarefreeCount n = S.card := by rw [hS]; rfl
+    omega
+  have hparity : Odd (2 * C.card + F.card) ↔ Odd F.card := by
+    rw [Nat.odd_iff, Nat.odd_iff]; omega
+  have hlt : n / 2 < n := by omega
+  have hge : 1 ≤ n / 2 := by omega
+  rw [key, hparity, hFodd, memS (n / 2)]
+  tauto
+
 /-
 ## Part IV: Natural density
 -/

--- a/research/problems/erdos-378/knowledge.md
+++ b/research/problems/erdos-378/knowledge.md
@@ -1,0 +1,71 @@
+# Knowledge: Erdős #378 — Density of squarefree binomial coefficients
+
+## Status
+
+**SOLVED** (Granville–Ramaré 1996; observed by Aggarwal–Cambie). Formalized as
+`axiomatized` in `Proofs/Erdos378Problem.lean`: 0 sorries, exactly 2 axioms
+isolating the deep analytic Granville–Ramaré inputs.
+
+## The two axioms (deep, NOT Mathlib-eliminable)
+
+1. `granville_ramare_density_exists` — for every `m`, the density `η_m` of
+   `{n | squarefreeCount n = 2m+2}` exists. (Granville–Ramaré exponential-sum
+   input; no Mathlib analogue.)
+2. `complement_density` — `{n | squarefreeCount n < r}` has density
+   `Σ_{0≤m≤(r-1)/2} η_m`, and that density is `< 1`. The `< 1` clause is the
+   positivity content of the resolution.
+
+Both are honestly documented as the *only* assumptions; everything downstream
+(`erdos_378_density_exists`, `_positive`, `erdos_378`, `erdos_378_answer`) is
+machine-checked by a complementation argument (`natDensity_compl`).
+
+Do NOT attempt to prove these from Mathlib — they are the genuine analytic core.
+
+## Verified axiom-independent structure (the parity theory)
+
+The involution `k ↦ n − k` on the counted set drives everything:
+- `binomialSquarefree_symm`: squarefreeness of `C(n,k)` is symmetric.
+- `squarefreeCount_even_of_odd`: for **odd** `n`, the count is even (involution
+  fixed-point-free).
+- `squarefreeCount_odd_iff_central_squarefree` (**2026-07-08, this session**):
+  for **even** `n ≥ 2`, the count is *odd iff* `C(n, n/2)` is squarefree. The
+  involution now has the single fixed point `k = n/2`, so
+  `squarefreeCount n = 2·|A| + |F|` with `|F| ∈ {0,1}` recording whether the
+  central index is squarefree. This **completes the parity theory** of row
+  counts and explains structurally why Granville–Ramaré only see even counts
+  `2m+2` (an odd count would force an even `n` with squarefree central binomial;
+  the counted set `2m+2` is even).
+
+### Proof recipe for the even case (reusable)
+
+Mirror `squarefreeCount_even_of_odd` but split `S` three ways by the sign of
+`2k − n`:
+- `A = S.filter (2k<n)`, `C = S.filter (n<2k)`, `F = S.filter (2k=n)`.
+- `S.card = A.card + D.card` (D = filter ¬2k<n) via
+  `filter_card_add_filter_neg_card_eq_card`; then `D.card = C.card + F.card` by
+  proving `C = D.filter (n<2k)` and `F = D.filter (¬n<2k)` by `ext`+`omega` and
+  reusing the same additivity lemma on `D`.
+- `A.card = C.card` via `card_nbij'` with `k ↦ n−k` (identical to the odd proof,
+  inequality direction flipped; `omega` discharges `n < 2*(n-k)` etc.).
+- `F = S.filter (·= n/2)` (`ext`+`omega` using `n = j+j`), then `filter_eq'`
+  makes `F` the singleton `{n/2}` or `∅`; `Odd F.card ↔ n/2 ∈ S` by
+  `iff_of_true (by decide) h` / `iff_of_false (by decide) h`.
+- Assemble `squarefreeCount n = 2*C.card + F.card` by `omega`; parity via
+  `rw [Nat.odd_iff, Nat.odd_iff]; omega`; finish with `memS (n/2)` + `tauto`
+  (`n/2 < n`, `1 ≤ n/2` from `omega` on `n = j+j`, `2 ≤ n`).
+
+Gotcha: `simp only [hS, mem_filter, mem_range]` fully closes `memS`, so follow
+with `try tauto`, not bare `tauto` (else "No goals").
+
+## Build
+
+Builds clean under Mathlib v4.26 (`docker-build.sh Proofs.Erdos378Problem`,
+7743 jobs, `Built`, 0 errors/warnings). No exit-135 flakiness observed here.
+theoremCount 11→12, lineCount 311→403.
+
+## Open directions (if re-served)
+
+- No further axiom-free structural lemma is obviously high-value; the parity
+  theory is now complete.
+- The two Granville–Ramaré axioms are the frontier; formalizing either needs the
+  full exponential-sum machinery (>>1000 lines, BLOCKED).

--- a/research/problems/erdos-378/state.md
+++ b/research/problems/erdos-378/state.md
@@ -1,0 +1,33 @@
+# Current State
+
+**Phase**: COMPLETED
+**Since**: 2026-07-08
+**Iteration**: 1
+
+## Current Focus
+
+Erdős #378 is SOLVED and axiomatized honestly (2 deep Granville–Ramaré axioms,
+0 sorries). The axiom-independent parity theory of row counts is now complete.
+
+## Active Approach
+
+Involution `k ↦ n − k` on the squarefree-index set. Odd rows: fixed-point-free →
+even count (`squarefreeCount_even_of_odd`). Even rows: single fixed point `n/2` →
+count odd iff `C(n,n/2)` squarefree (`squarefreeCount_odd_iff_central_squarefree`,
+added 2026-07-08).
+
+## Blockers
+
+The two axioms (density existence `η_m`; complement density `< 1`) are the deep
+analytic Granville–Ramaré 1996 content — not eliminable from Mathlib without the
+full exponential-sum machinery (>>1000 lines). BLOCKED for de-axiomatization.
+
+## Next Action
+
+None high-value. Parity theory complete; density core is the analytic frontier
+(out of scope). If re-served, treat as complete.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Approaches tried: 1 (involution parity extension)

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -55,6 +55,7 @@
       "BinomialSquarefree, squarefreeCount, hasAtLeastSquarefree: definitions over Mathlib's Squarefree",
       "binomialSquarefree_symm theorem (verified, 0-axiom): squarefreeness of C(n,k) is symmetric under k ↦ n−k",
       "squarefreeCount_even_of_odd theorem (verified, 0-axiom): for odd n the count of squarefree interior binomials is even — the elementary structural reason Granville-Ramaré only ever count even numbers 2m+2 (involution k ↦ n−k has no fixed point for odd n)",
+      "squarefreeCount_odd_iff_central_squarefree theorem (verified, 0-axiom): for even n ≥ 2 the count is odd iff the central binomial C(n,n/2) is squarefree — the involution k ↦ n−k now has the single fixed point k = n/2, so squarefreeCount n = 2·|A| + |F| with |F| ∈ {0,1}; completes the parity theory of row counts alongside squarefreeCount_even_of_odd",
       "NaturalDensity, HasDensity: decidability-free density definitions via Set.ncard",
       "natDensity_compl theorem (verified, 0-axiom): the complement of a set of density d has density 1−d",
       "granville_ramare_density_exists axiom: Granville-Ramaré (1996) Input 1 — density η_m of exactlySquarefree m exists",
@@ -63,9 +64,9 @@
       "erdos_378, erdos_378_answer (no sorries): combined resolution of both questions"
     ],
     "axiomCount": 2,
-    "lineCount": 311,
-    "assumptions": "2 axioms, both isolating the deep analytic content of Granville-Ramaré (1996): granville_ramare_density_exists (the density η_m of n with exactly 2m+2 squarefree binomials exists) and complement_density (the set of n with fewer than r squarefree binomials has density Σ_{0≤m≤(r-1)/2} η_m, which is < 1). 0 sorries. All other results, including the resolution of both questions and the parity theorem squarefreeCount_even_of_odd, are fully machine-checked (depend only on propext/Classical.choice/Quot.sound).",
-    "theoremCount": 11,
+    "lineCount": 403,
+    "assumptions": "2 axioms, both isolating the deep analytic content of Granville-Ramaré (1996): granville_ramare_density_exists (the density η_m of n with exactly 2m+2 squarefree binomials exists) and complement_density (the set of n with fewer than r squarefree binomials has density Σ_{0≤m≤(r-1)/2} η_m, which is < 1). 0 sorries. All other results, including the resolution of both questions and the parity theorems squarefreeCount_even_of_odd (odd rows have an even count) and squarefreeCount_odd_iff_central_squarefree (an even row has an odd count iff its central binomial C(n,n/2) is squarefree), are fully machine-checked (depend only on propext/Classical.choice/Quot.sound).",
+    "theoremCount": 12,
     "definitionCount": 8,
     "additionalFiles": [
       "Proofs/Erdos378Aristotle.lean"
@@ -161,9 +162,9 @@
       "Finset"
     ],
     "namespace": "Erdos378",
-    "lineCount": 311,
+    "lineCount": 403,
     "axiomCount": 2,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 8,
     "path": "Proofs/Erdos378Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds one axiom-independent, machine-verified structural theorem to `Proofs/Erdos378Problem.lean`, **completing the parity theory** of squarefree-binomial row counts (Erdős #378). theoremCount 11→12, lineCount 311→403; **0 sorries, the 2 deep Granville–Ramaré axioms are unchanged**.

```lean
theorem squarefreeCount_odd_iff_central_squarefree {n : ℕ} (hn : Even n) (hn2 : 2 ≤ n) :
    Odd (squarefreeCount n) ↔ Squarefree (n.choose (n / 2))
```

## Context

The file already had `squarefreeCount_even_of_odd`: for **odd** `n`, the count of squarefree interior binomials is even, because the involution `k ↦ n − k` is fixed-point free. This PR handles the **even** case: the involution then has the *single* fixed point `k = n/2`, so

`squarefreeCount n = 2·|A| + |F|`,  `|F| ∈ {0,1}`,

where `|F|` records whether the central index `n/2` is itself squarefree. Hence the count is **odd iff `C(n, n/2)` is squarefree**.

Together the two theorems give the complete parity picture and explain structurally why Granville–Ramaré only ever observe *even* counts `2m + 2`.

## Proof

Splits the counted set three ways by the sign of `2k − n` (`A: 2k<n`, `C: n<2k`, `F: 2k=n`); `A ≃ C` via `k ↦ n−k` (`card_nbij'`); `F` collapses to a singleton/∅ via `filter_eq'`; parity assembled by `omega`. No new axioms, no `sorry`, no `native_decide`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos378Problem` → `✔ Built (7743 jobs)`, 0 errors, 0 warnings, Mathlib v4.26.

## Honesty note

This is axiom-independent structural work; it does **not** touch the two Granville–Ramaré density axioms, which are the genuine analytic core of the resolution and remain outside Mathlib's reach. Problem stays `axiomatized` (2 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)