### PR TITLE
Enrich L^p interpolation inequality: add header section for full file coverage

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-03/meta.json
@@ -89,6 +89,14 @@
   },
   "sections": [
     {
+      "id": "header-setup",
+      "title": "Module Header and Proof Outline",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "The module docstring frames the L^p interpolation (log-convexity) inequality ‖f‖_r ≤ ‖f‖_p^θ·‖f‖_q^(1-θ) for 1/r = θ/p + (1-θ)/q, θ ∈ (0,1), as the step beyond the parent's Hölder inequality (cauchy-schwarz-oq-03), and explains the single-Hölder proof: build the conjugate pair a = p/(rθ), b = q/(r(1-θ)) (so 1/a + 1/b = 1) from Real.HolderConjugate, apply NNReal.inner_le_Lp_mul_Lq to the split f_i^r = f_i^(rθ)·f_i^(r(1-θ)), then raise to 1/r. Imports Mathlib, opens Finset/NNReal, and enters the CauchySchwarzOQ03OQ03 namespace.",
+      "mathContext": "Cauchy–Schwarz/Hölder is the θ = 1/2 midpoint face of the log-convexity of $t \\mapsto \\log\\|f\\|_{1/t}$."
+    },
+    {
       "id": "lp-interpolation",
       "title": "L^p Interpolation Inequality",
       "summary": "The main result: ‖f‖_r ≤ ‖f‖_p^θ·‖f‖_q^(1-θ) for 1/r = θ/p + (1-θ)/q, θ ∈ (0,1). Built from Hölder with the conjugate pair a = p/(rθ), b = q/(r(1-θ)) applied to the split f_i^r = f_i^(rθ)·f_i^(r(1-θ)).",


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-03-oq-03` (quality 94, passes 0).

Prose (5 keyInsights) and a `mainTheorems` array (both theorems) were already present. The one gap: the `sections` array started at line 42, leaving lines 1–41 (module docstring stating the interpolation/log-convexity inequality and outlining the single-Hölder proof, imports, namespace) uncovered.

**Change:**
- Added a `header-setup` section (L1–41) — "Module Header and Proof Outline" — so `sections` now spans the full 114-line Lean file.

No prose inflation; meta.json 16.9 → 17.7 KB, well under the 60 KB cap.