### PR TITLE
research(erdos101-problem-oq-04): certify grid diagonals — four-point-line floor 8 → 10 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -1732,14 +1732,21 @@ private theorem grid_line_ne {s t : Finset (ℝ × ℝ)} (x : ℝ × ℝ)
     (hxs : x ∈ s) (hxt : x ∉ t) : s ≠ t :=
   fun h => hxt (h ▸ hxs)
 
-/-- **The `4×4` grid has at least eight four-point lines** — its four
-rows and four columns.  Each is a four-element collinear subset of the
-grid, and the eight are pairwise distinct (rows are separated by their
-common second coordinate, columns by their common first coordinate, and
-a row differs from a column because a row contains two points with
-distinct first coordinates while a column's points all share theirs). -/
-theorem gridSet_fourPointLineCount_ge_eight :
-    8 ≤ fourPointLineCount gridSet := by
+/-- **The `4×4` grid has at least ten four-point lines** — its four
+rows, four columns, and two main diagonals.  Ten is the *exact* number
+of four-point lines carried by the maximal no-five-collinear grid (the
+four rows, four columns, and the two slope-`±1` diagonals; no other line
+meets four grid points), and all ten are in general position — no single
+point lies on all of them, unlike the concurrent pencils
+`crossSet`/`asteriskSet`.  Each of the ten is a four-element collinear
+subset of the grid, and the ten are pairwise distinct (rows are
+separated by their common second coordinate, columns by their common
+first coordinate, a row differs from a column because a row contains two
+points with distinct first coordinates while a column's share theirs,
+and each diagonal contains an off-axis point — `(1,1)` resp. `(1,2)` —
+absent from every row and column). -/
+theorem gridSet_fourPointLineCount_ge_ten :
+    10 ≤ fourPointLineCount gridSet := by
   rw [fourPointLineCount]
   set Q : Finset (ℝ × ℝ) → Prop := fun S =>
     S.card = 4 ∧ ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧
@@ -1921,8 +1928,55 @@ theorem gridSet_fourPointLineCount_ge_eight :
     · intro p hp
       simp only [Finset.mem_insert, Finset.mem_singleton] at hp
       rcases hp with rfl | rfl | rfl | rfl <;> simp [collinear]
-  -- The eight lines form an eight-element subfamily of the filter.
-  have hsub : ({({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)),
+  -- The two main diagonals (slope ±1).
+  have hD0 : ({(0, 0), (1, 1), (2, 2), (3, 3)} : Finset (ℝ × ℝ)) ∈
+      gridSet.points.powerset.filter Q := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨?_, ?_, (0, 0), (1, 1), ?_, ?_, ?_, ?_⟩
+    · intro x hx
+      show x ∈ gridPoints
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl | rfl | rfl <;>
+        simp [gridPoints, Finset.mem_product]
+    · rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · simp
+          · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+        · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+      · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+    · simp
+    · simp
+    · norm_num [Prod.ext_iff]
+    · intro p hp
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+      rcases hp with rfl | rfl | rfl | rfl <;> norm_num [collinear]
+  have hD1 : ({(0, 3), (1, 2), (2, 1), (3, 0)} : Finset (ℝ × ℝ)) ∈
+      gridSet.points.powerset.filter Q := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨?_, ?_, (0, 3), (1, 2), ?_, ?_, ?_, ?_⟩
+    · intro x hx
+      show x ∈ gridPoints
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl | rfl | rfl <;>
+        simp [gridPoints, Finset.mem_product]
+    · rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · simp
+          · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+        · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+      · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+    · simp
+    · simp
+    · norm_num [Prod.ext_iff]
+    · intro p hp
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+      rcases hp with rfl | rfl | rfl | rfl <;> norm_num [collinear]
+  -- The ten lines form a ten-element subfamily of the filter.
+  have hsub : ({({(0, 0), (1, 1), (2, 2), (3, 3)} : Finset (ℝ × ℝ)),
+      {(0, 3), (1, 2), (2, 1), (3, 0)},
+      {(0, 0), (1, 0), (2, 0), (3, 0)},
       {(0, 1), (1, 1), (2, 1), (3, 1)}, {(0, 2), (1, 2), (2, 2), (3, 2)},
       {(0, 3), (1, 3), (2, 3), (3, 3)}, {(0, 0), (0, 1), (0, 2), (0, 3)},
       {(1, 0), (1, 1), (1, 2), (1, 3)}, {(2, 0), (2, 1), (2, 2), (2, 3)},
@@ -1930,7 +1984,9 @@ theorem gridSet_fourPointLineCount_ge_eight :
       gridSet.points.powerset.filter Q := by
     intro S hS
     simp only [Finset.mem_insert, Finset.mem_singleton] at hS
-    rcases hS with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases hS with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exact hD0
+    · exact hD1
     · exact hR0
     · exact hR1
     · exact hR2
@@ -1939,12 +1995,15 @@ theorem gridSet_fourPointLineCount_ge_eight :
     · exact hC1
     · exact hC2
     · exact hC3
-  have h8 : ({({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)),
+  have h10 : ({({(0, 0), (1, 1), (2, 2), (3, 3)} : Finset (ℝ × ℝ)),
+      {(0, 3), (1, 2), (2, 1), (3, 0)},
+      {(0, 0), (1, 0), (2, 0), (3, 0)},
       {(0, 1), (1, 1), (2, 1), (3, 1)}, {(0, 2), (1, 2), (2, 2), (3, 2)},
       {(0, 3), (1, 3), (2, 3), (3, 3)}, {(0, 0), (0, 1), (0, 2), (0, 3)},
       {(1, 0), (1, 1), (1, 2), (1, 3)}, {(2, 0), (2, 1), (2, 2), (2, 3)},
-      {(3, 0), (3, 1), (3, 2), (3, 3)}} : Finset (Finset (ℝ × ℝ))).card = 8 := by
+      {(3, 0), (3, 1), (3, 2), (3, 3)}} : Finset (Finset (ℝ × ℝ))).card = 10 := by
     rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
+        Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
         Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
         Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
         Finset.card_insert_of_notMem]
@@ -2019,31 +2078,94 @@ theorem gridSet_fourPointLineCount_ge_eight :
           (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
         grid_line_ne (0, 0) (by simp)
           (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff])⟩
+    · -- D- ∉ {R0, R1, R2, R3, C0, C1, C2, C3}
+      simp only [Finset.mem_insert, Finset.mem_singleton]; push_neg
+      refine ⟨grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (1, 2) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (1, 2) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff])⟩
+    · -- D+ ∉ {D-, R0, R1, R2, R3, C0, C1, C2, C3}
+      simp only [Finset.mem_insert, Finset.mem_singleton]; push_neg
+      refine ⟨grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (1, 1) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (1, 1) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff])⟩
   have hle := Finset.card_le_card hsub
-  rw [h8] at hle
+  rw [h10] at hle
   exact hle
 
-/-- **Framework floor ≥ 8** (this session's deliverable).  The explicit
-sixteen-point `4×4` grid is a no-five-collinear planar point set with at
-least eight four-point lines — its four rows and four columns —
-`IsLowerBoundConstruction gridSet 8`.  This more than doubles the
-asterisk's floor of `3`, and does so with lines in general position
-(the grid whose projection underlies Solymosi–Stojaković), rather than a
-concurrent pencil.  The construction is still *constant* in size: the
-asymptotic growth of `fourPointLineCount` remains the OPEN content of
-`grunbaum_lower_bound_three_halves` and `solymosi_stojakovic_lower_bound`. -/
+/-- **The `4×4` grid has at least eight four-point lines** (corollary of
+the sharper `gridSet_fourPointLineCount_ge_ten`).  Retained so downstream
+citations of the rows-and-columns floor keep resolving. -/
+theorem gridSet_fourPointLineCount_ge_eight :
+    8 ≤ fourPointLineCount gridSet :=
+  le_trans (by norm_num) gridSet_fourPointLineCount_ge_ten
+
+/-- **Framework floor ≥ 8.**  The explicit sixteen-point `4×4` grid is a
+no-five-collinear planar point set with at least eight four-point lines —
+its four rows and four columns — `IsLowerBoundConstruction gridSet 8`.
+This more than doubles the asterisk's floor of `3`, and does so with
+lines in general position (the grid whose projection underlies
+Solymosi–Stojaković), rather than a concurrent pencil. -/
 theorem gridSet_isLowerBoundConstruction :
     IsLowerBoundConstruction gridSet 8 :=
   ⟨gridSet_noFiveCollinear, by exact_mod_cast gridSet_fourPointLineCount_ge_eight⟩
 
 /-- **The framework floor reaches at least eight.**  There is a
 no-five-collinear planar point set of exactly sixteen points that is a
-lower-bound construction for threshold `8`.  Together with the pencil
-witnesses `exists_isLowerBoundConstruction_three` (floor `3`, ten
-points), `_two` (floor `2`) and `_pos` (floor `1`), this is the largest
-explicit constant-size lower-bound witness in the file. -/
+lower-bound construction for threshold `8`. -/
 theorem exists_isLowerBoundConstruction_eight :
     ∃ P : PlanarPointSet, P.points.card = 16 ∧ IsLowerBoundConstruction P 8 :=
   ⟨gridSet, gridPoints_card, gridSet_isLowerBoundConstruction⟩
+
+/-- **Framework floor ≥ 10** (this session's deliverable).  Adding the
+two slope-`±1` main diagonals to the rows and columns certifies all
+**ten** four-point lines of the maximal `4×4` grid — its *exact* count —
+so `IsLowerBoundConstruction gridSet 10`.  All ten lie in general
+position: no point is common to all of them (the rows/columns meet only
+pairwise, and each diagonal carries an off-axis point `(1,1)` / `(1,2)`).
+The construction remains *constant* in size, so the asymptotic growth of
+`fourPointLineCount` is still the OPEN content of
+`grunbaum_lower_bound_three_halves` and `solymosi_stojakovic_lower_bound`;
+this iteration raises the explicit constant floor to its 4×4-grid ceiling. -/
+theorem gridSet_isLowerBoundConstruction_ten :
+    IsLowerBoundConstruction gridSet 10 :=
+  ⟨gridSet_noFiveCollinear, by exact_mod_cast gridSet_fourPointLineCount_ge_ten⟩
+
+/-- **The framework floor reaches at least ten.**  There is a
+no-five-collinear planar point set of exactly sixteen points that is a
+lower-bound construction for threshold `10` — the largest explicit
+constant-size lower-bound witness in the file, and the maximum any
+`4×4` grid can supply.  Supersedes `exists_isLowerBoundConstruction_eight`
+(same witness, sharper threshold). -/
+theorem exists_isLowerBoundConstruction_ten :
+    ∃ P : PlanarPointSet, P.points.card = 16 ∧ IsLowerBoundConstruction P 10 :=
+  ⟨gridSet, gridPoints_card, gridSet_isLowerBoundConstruction_ten⟩
 
 end Erdos101OQ04

--- a/research/problems/erdos101-problem-oq-04/state.md
+++ b/research/problems/erdos101-problem-oq-04/state.md
@@ -1,15 +1,54 @@
 # Current State
 
-**Phase**: ACT (framework floor raised to 8 four-point lines via the maximal 4×4 grid; direct-lean-verified)
+**Phase**: ACT (framework floor raised to 10 four-point lines — the 4×4 grid's *exact* maximum, all in general position; docker-build verified)
 **Since**: 2026-07-01
-**Last Updated**: 2026-07-08 (Iteration 8, researcher-4)
-**Iteration**: 8
+**Last Updated**: 2026-07-08 (Iteration 9, researcher-3)
+**Iteration**: 9
 
 > Note: the S3-B2/B3 parabola-arc infrastructure (secant bound, ℝ²
 > realization, arc `fourPointLineCount = 0`) and the non-vacuity
 > witness (`witnessSet`, floor `1`) landed in later iterations (4–6,
 > researcher-8/6) than the entries below record; the file is ahead of
 > the older iteration logs.
+
+## Iteration 9 (researcher-3, 2026-07-08) — raise framework floor 8 → 10 (certify the two grid diagonals)
+
+**Outcome**: `IsLowerBoundConstruction gridSet 10` — the maximal 4×4
+integer grid now has **all ten** of its four-point lines certified: the
+four rows, four columns (iteration 8), **and the two slope-`±1` main
+diagonals** `{(0,0),(1,1),(2,2),(3,3)}` and `{(0,3),(1,2),(2,1),(3,0)}`.
+Ten is the *exact* number of four-point lines a no-five-collinear 4×4
+grid can carry (no other line meets four grid points), so this raises the
+explicit constant floor to its 4×4-grid ceiling. All ten remain in
+**general position** — no common point; each diagonal contains an
+off-axis point (`(1,1)`, resp. `(1,2)`) absent from every row and column.
+docker-build verified (Lean v4.26.0, 3062 jobs), 0 axioms / 0 new sorries.
+
+### What I added (all in `proofs/Proofs/Erdos101OQ04.lean`, +~120 LOC)
+
+1. **`gridSet_fourPointLineCount_ge_ten`** (PROVED, axiom-free) — extends
+   the iteration-8 eight-line subfamily to ten by adding the two diagonal
+   membership witnesses (`hD0`, `hD1`, each a 4-element collinear subset
+   proved via the `norm_num [collinear]` determinant check) and the two
+   new distinctness bullets in the `card = 10` computation (each diagonal
+   is distinguished from every row/column by an off-axis point).
+2. **`gridSet_fourPointLineCount_ge_eight`** — retained as a one-line
+   corollary `le_trans (by norm_num) …_ge_ten` so downstream citations
+   keep resolving.
+3. **`gridSet_isLowerBoundConstruction_ten`** (PROVED) —
+   `IsLowerBoundConstruction gridSet 10`.
+4. **`exists_isLowerBoundConstruction_ten`** (PROVED) — a no-five-collinear
+   16-point set achieving threshold 10; supersedes `_eight` (same witness,
+   sharper threshold).
+
+**Honest scope**: this is still a **constant**-size witness. It does not
+touch the asymptotic OPEN content — `grunbaum_lower_bound_three_halves`
+(Ω(n^{3/2})) and `solymosi_stojakovic_lower_bound` (n^{2−o(1)}) remain the
+two sorry-bodied open constructions. Iteration 9 closes out the 4×4-grid
+brick at its maximum; the next real step is the superlinear/unbounded
+count on the parabola-arc (S3-B2-β) or a staggered-stack construction.
+
+---
 
 ## Iteration 8 (researcher-4, 2026-07-08) — raise framework floor 3 → 8 (maximal 4×4 grid)
 

--- a/src/data/research/problems/erdos101-problem-oq-04.json
+++ b/src/data/research/problems/erdos101-problem-oq-04.json
@@ -35,8 +35,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-01",
-    "iteration": 8,
-    "focus": "S3-B5 ACT iteration 8 (researcher-4, 2026-07-08) — direct-lean-verified build (lean v4.26.0, 0 axioms / 0 new sorries). Added the maximal 4x4 integer grid witness gridSet = {0,1,2,3}x{0,1,2,3} (16 points) and PROVED it is no-five-collinear with at least EIGHT four-point lines (its four rows + four columns), raising the framework floor from the asterisk's 3 to 8 in a single constant-size witness. Unlike the concurrent pencils crossSet/asteriskSet, the grid realizes its lines in GENERAL position — exactly the grid whose random linear projection underlies Solymosi-Stojakovic. The no-five proof is a clean symmetric argument (only four distinct x- and y-coordinates: a horizontal line forces five distinct first coordinates in {0,1,2,3}, a non-horizontal line forces five distinct second coordinates via collinear_snd_inj — either way five_distinct_not_subset_0123 contradicts 5<=4). The eight-line count is Finset.card_le_card on an explicit eight-element subfamily of the four-point-line filter. The grid carries 10 four-point lines in total (the two diagonals give the remaining 2); only the 8 axis-aligned lines are certified here. The 2 pre-existing OPEN sorries (grunbaum_lower_bound_three_halves, solymosi_stojakovic_lower_bound) remain — the asymptotic growth is still the OPEN content.",
+    "iteration": 9,
+    "focus": "S3-B6 ACT iteration 9 (researcher-3, 2026-07-08) — docker-build verified (lean v4.26.0, 0 axioms / 0 new sorries). Certified the two slope-±1 main diagonals of the maximal 4x4 grid gridSet, completing all TEN four-point lines it carries (four rows + four columns + two diagonals) — the exact maximum a no-five-collinear 4x4 grid can supply. This raises the framework floor from 8 to 10 via gridSet_fourPointLineCount_ge_ten / gridSet_isLowerBoundConstruction_ten / exists_isLowerBoundConstruction_ten. All ten lines are in general position (no common point; each diagonal has an off-axis point (1,1)/(1,2) absent from every row/column). The prior _ge_eight result is retained as a one-line corollary so downstream citations keep resolving. The construction remains constant-size; the asymptotic Grunbaum Omega(n^{3/2}) and Solymosi-Stojakovic n^{2-o(1)} bounds (the two remaining sorries) are unchanged OPEN content.",
     "blockers": [
       "S3-B2-β 4-collinear COUNT `Ω(p^{3/2})`: the parabola itself is now PROVEN to be no-three-collinear, so it has zero four-point lines on its own — the Ω(p^{3/2}) four-point-line witness requires the further sumset/grid construction over this general-position base, not the bare parabola.",
       "S4-S5 (Path A random-projection genericity): unchanged from S2 — measure-theoretic infrastructure deferred to dedicated multi-session ACT."
@@ -58,10 +58,10 @@
     {
       "path": "Proofs/Erdos101OQ04.lean",
       "filename": "Erdos101OQ04.lean",
-      "lineCount": 2049,
-      "theoremCount": 54,
+      "lineCount": 2171,
+      "theoremCount": 57,
       "axiomCount": 0,
-      "defCount": 10,
+      "defCount": 14,
       "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos101OQ04.lean"


### PR DESCRIPTION
## Summary

Raises the explicit four-point-line lower-bound floor for **Erdős #101** (OQ-04, Solymosi–Stojaković lower-bound formalization) from **8 to 10** by certifying the two main diagonals of the maximal 4×4 integer grid `gridSet`.

The 4×4 grid `{0,1,2,3}²` (16 points, no five collinear) carries exactly **ten** four-point lines: its four rows, four columns, and the two slope-`±1` diagonals `{(0,0),(1,1),(2,2),(3,3)}` and `{(0,3),(1,2),(2,1),(3,0)}`. Iteration 8 (#35352) certified the eight axis-aligned lines; this PR adds the two diagonals, completing the grid to its **exact maximum**. No other line meets four grid points, so 10 is the ceiling any 4×4 grid can supply. All ten lines are in **general position** — no common point; each diagonal contains an off-axis point (`(1,1)`, `(1,2)`) absent from every row and column.

## What's new (`proofs/Proofs/Erdos101OQ04.lean`, +~120 LOC)

- `gridSet_fourPointLineCount_ge_ten` — extends the eight-line subfamily with the two diagonal membership witnesses (`hD0`/`hD1`, collinearity via the `norm_num [collinear]` determinant check) and two new distinctness bullets in the `card = 10` computation.
- `gridSet_isLowerBoundConstruction_ten : IsLowerBoundConstruction gridSet 10`.
- `exists_isLowerBoundConstruction_ten` — a 16-point no-five-collinear witness at threshold 10; supersedes `_eight` (same witness, sharper threshold).
- `gridSet_fourPointLineCount_ge_eight` retained as a one-line corollary so downstream citations keep resolving.

## Verification

- **docker-build verified** (Lean v4.26.0, 3062 jobs, `./proofs/scripts/docker-build.sh Proofs.Erdos101OQ04`).
- **0 axioms**, **0 new sorries**. Proof uses only `Finset` lemmas + `norm_num`/`simp`/`push_neg` (no `native_decide`/`decide`) → standard `propext`/`Classical.choice`/`Quot.sound` trio.
- The two pre-existing sorries (`grunbaum_lower_bound_three_halves`, `solymosi_stojakovic_lower_bound`) are unchanged.

## Honest scope

This is a **constant-size** witness — it closes out the 4×4-grid brick at its maximum but does **not** touch the asymptotic OPEN content. The Grünbaum Ω(n^{3/2}) and Solymosi–Stojaković n^{2−o(1)} lower bounds remain the two sorry-bodied open constructions; the next real step is the superlinear count on the parabola arc or a staggered-stack construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)