### PR TITLE
audit(liouville-theorem-oq-03): reconcile stale theoremCount + re-audit 4 metas

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5022,9 +5022,9 @@
       "issues": []
     },
     "cauchy-schwarz-oq-03-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-07-01T17:43:53Z",
+      "lastAudited": "2026-07-08T18:16:34Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-04": {
@@ -5250,9 +5250,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:16:34Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-04-oq-01": {
@@ -21388,10 +21388,10 @@
       "issues": []
     },
     "kepler-conjecture-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-16T00:08:02Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-07-08T18:16:34Z",
+      "result": "clean"
     },
     "knights-tour-oblique": {
       "auditCount": 4,
@@ -22367,10 +22367,12 @@
       "result": "clean"
     },
     "liouville-theorem-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T19:24:49Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:16:34Z",
+      "result": "issues-fixed",
+      "issues": [
+        "theoremCount stale (leanFile=21, meta=17; actual=19) \u2014 reconciled to 19"
+      ]
     },
     "liouville-theorem-oq-04": {
       "auditCount": 3,

--- a/src/data/proofs/liouville-theorem-oq-03/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-03/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 1,
     "assumptions": "One axiom: `dimH_wellApprox` — the Jarník–Besicovitch dimension formula dimH(W τ) = ENNReal.ofReal(2/τ) for τ ≥ 2. This is the deep theorem of metric Diophantine approximation (Jarník 1931, Besicovitch 1934) and is not yet available in Mathlib (the upper bound requires a covering/Borel–Cantelli Hausdorff-measure estimate; the lower bound a mass-distribution principle / Frostman construction on a Cantor subset). `#print axioms` confirms: the structural lemmas (wellApprox_antitone, liouville_subset_wellApprox, dimH_liouville_le_wellApprox, and the jbDim exponent facts) depend on no axioms beyond the standard foundational trio; only the formula-dependent results (dimH_wellApprox_two, dimH_liouville_le, dimH_liouville_eq_zero, the summary) carry dimH_wellApprox.",
     "lineCount": 210,
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 2,
     "originalContributions": [
       "wellApprox τ := {x | LiouvilleWith τ x}: the τ-well-approximable sets, packaged on top of Mathlib's LiouvilleWith with the JB exponent in mind",
@@ -134,7 +134,7 @@
     "path": "Proofs/LiouvilleTheoremOQ03.lean",
     "sorries": 0,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 19,
     "definitionCount": 2,
     "lineCount": 268
   },


### PR DESCRIPTION
## Gallery Integrity Re-audit

Re-audit sweep of 4 metas whose commit date post-dated their last audit.

### Fixed
**liouville-theorem-oq-03** — three-way `theoremCount` disagreement:
- `leanFile.theoremCount` = 21
- `meta.theoremCount` = 17
- actual (`grep` of `theorem`/`lemma` decls) = **19**

Reconciled both fields to 19. Integrity-critical fields were all correct and unchanged: `status: axiomatized`, `badge: axiom`, 1 axiom (`dimH_wellApprox`, Jarník–Besicovitch, disclosed in `assumptions`), 0 sorries, 268 lines, 2 defs.

### Clean (no changes, tracker bumped)
- **kepler-conjecture-oq-04** — axiomatized, 2 axioms, 0 sorries, 570 lines ✓
- **cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01** — verified, 0 axioms/0 sorries, 86 lines, 4 theorems ✓
- **cauchy-schwarz-oq-03-oq-03** — verified, badge `mathlib` (Hölder via `NNReal.inner_le_Lp_mul_Lq`, dependency disclosed), 0/0, 114 lines, 2 theorems ✓

Tracker `lastAudited` updated for all 4.

---
Discovered during autonomous gallery integrity audit.