### PR TITLE
Enrich CLT Gaussian cumulants: anchor mainTheorems to source lines

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -122,21 +122,27 @@
   "mainTheorems": [
     {
       "name": "gaussianCharFn_hasDerivAt",
-      "type": "theorem",
+      "type": "core",
       "description": "The Gaussian characteristic-function ODE φ'(t) = φ(t)·(iμ − σ²t).",
-      "leanType": "(μ σ_sq t : ℝ) → HasDerivAt (fun s => Complex.exp (gaussianExponent μ σ_sq s)) (Complex.exp (gaussianExponent μ σ_sq t) * (↑μ * Complex.I - ↑(σ_sq * t))) t"
+      "leanType": "(μ σ_sq t : ℝ) → HasDerivAt (fun s => Complex.exp (gaussianExponent μ σ_sq s)) (Complex.exp (gaussianExponent μ σ_sq t) * (↑μ * Complex.I - ↑(σ_sq * t))) t",
+      "startLine": 74,
+      "endLine": 78
     },
     {
       "name": "gaussianExponent_hasDerivAt",
-      "type": "theorem",
+      "type": "supporting",
       "description": "The exponent derivative ψ'(t) = iμ − σ²t.",
-      "leanType": "(μ σ_sq t : ℝ) → HasDerivAt (gaussianExponent μ σ_sq) (↑μ * Complex.I - ↑(σ_sq * t)) t"
+      "leanType": "(μ σ_sq t : ℝ) → HasDerivAt (gaussianExponent μ σ_sq) (↑μ * Complex.I - ↑(σ_sq * t)) t",
+      "startLine": 52,
+      "endLine": 66
     },
     {
       "name": "gaussianExponent_deriv3",
-      "type": "theorem",
+      "type": "core",
       "description": "ψ''' ≡ 0: all cumulants of order ≥ 3 vanish.",
-      "leanType": "(σ_sq t : ℝ) → HasDerivAt (fun _ : ℝ => (-↑σ_sq : ℂ)) 0 t"
+      "leanType": "(σ_sq t : ℝ) → HasDerivAt (fun _ : ℝ => (-↑σ_sq : ℂ)) 0 t",
+      "startLine": 104,
+      "endLine": 107
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `central-limit-theorem-oq-01-oq-02-oq-01-oq-03` (Gaussian characteristic-function ODE / vanishing higher cumulants).

The entry already had a `mainTheorems` array, but its 3 items carried **no line anchors** (`startLine`/`endLine` absent) and used the generic `"theorem"` type — so the navigable theorem list could not link back to the Lean source.

**Change (non-inflating, correctness/navigation fix):**
- Added `startLine`/`endLine` anchors to all 3 mainTheorems items, transcribed from the Lean source: `gaussianExponent_hasDerivAt` (L52), `gaussianCharFn_hasDerivAt` (L74), `gaussianExponent_deriv3` (L104).
- Upgraded the generic `theorem` type to semantic `core`/`supporting` labels (the char-fn ODE and the ψ'''≡0 vanishing-cumulants result are core; the exponent first derivative is supporting).

No prose deepened; no existing content changed. meta.json 12.2 KB -> 12.3 KB (well under the 60 KB cap; `check-meta-size.ts` passes). JSON validated.