### PR TITLE
Enrich Excenters/Nagel/Gergonne mass points: add header section

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-04-oq-04-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-04-oq-02/meta.json
@@ -68,6 +68,14 @@
   },
   "sections": [
     {
+      "id": "header-setup",
+      "title": "Module Header, Ravi Coordinates and Setup",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "The module docstring states the open question (mass-point treatment of the excenters, Nagel and Gergonne points) and introduces tangent-length (Ravi) coordinates x = s−a, y = s−b, z = s−c, in which the triangle inequalities collapse to x,y,z > 0 and the classical barycentrics become polynomial: incenter (y+z:z+x:x+y), A-excenter (−(y+z):z+x:x+y) (signed mass), Nagel (x:y:z), Gergonne (yz:zx:xy). Cites Coxeter–Greitzer and Kimberling's ETC. Imports Mathlib, enters the MassPointCeva.Excenters namespace, and fixes the ambient real module {V : Type*} [AddCommGroup V] [Module ℝ V].",
+      "mathContext": "Ravi map (x,y,z) ↦ (a,b,c) = (y+z, z+x, x+y) with x,y,z>0 parametrises all nondegenerate triangles; s = x+y+z."
+    },
+    {
       "id": "centres",
       "title": "Triangle centres in tangent-length barycentric coordinates",
       "startLine": 62,


### PR DESCRIPTION
Enrichment pass for `cevas-theorem-oq-04-oq-04-oq-02` (quality 94, passes 0).

Already fully enriched — 4 keyInsights, a 7-entry anchored `mainTheorems` array, 3 sections. The gap: `sections` started at line 62, leaving lines 1–61 uncovered: the module docstring stating the open question, the tangent-length (Ravi) coordinate exposition (the key device that makes the barycentrics polynomial), references, imports and namespace.

**Change:**
- Added a `header-setup` section (L1–61) — "Module Header, Ravi Coordinates and Setup" — so `sections` now spans the full 223-line Lean file.

No prose inflation; meta.json 17.8 → 18.7 KB, well under the 60 KB cap.