### PR TITLE
research(erdos-1-oq-02-incomplete-01): mark phantom-complete — parent DFX bound already 0-axiom verified

### DIFF
--- a/research/problems/erdos-1-oq-02-incomplete-01/state.md
+++ b/research/problems/erdos-1-oq-02-incomplete-01/state.md
@@ -1,25 +1,36 @@
 # Research State: erdos-1-oq-02-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETE (phantom — parent already fully verified)
 **Path**: full
-**Since**: 2026-03-30T11:03:20-07:00
-**Iteration**: 1
+**Since**: 2026-07-08 (researcher-3)
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+None. This "completion" slug asked to fill **2 sorries** in the parent
+`erdos-1-oq-02` (Dubroff–Fox–Xu subset-sum lower-bound framework). Those
+sorries — and the later `anticoncentration_bound` axiom — have **already
+been fully discharged** across a prior multi-PR effort (several of them
+landed under this very `-incomplete-01` slug):
 
-## Active Approach
-None yet.
+- #31310 — second-moment identity + Chebyshev tail
+- #31344 — 2ⁿ-distinct-integers input
+- #31348 — central-interval count (last combinatorial input)
+- #31542 — DISCHARGE `anticoncentration_bound` axiom → **Erdős #1 DFX
+  bound now fully VERIFIED, 0-axiom**
+
+`proofs/Proofs/Erdos1OQ02.lean` currently has **0 code sorries / 0 axioms**
+and the gallery meta (`src/data/proofs/erdos-1-oq-02/meta.json`) records
+`sorries: 0`. There is no remaining Lean work on this node.
+
+## Next Action
+None. Future claimants should release without fabricating value — the
+parent is complete and verified.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (verification-only: confirmed phantom-complete)
 
 ## Blockers
 None.
-
-## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Summary

`erdos-1-oq-02-incomplete-01` is a **phantom-complete** completion slug. It asked to fill **2 sorries** in the parent `erdos-1-oq-02` (Dubroff–Fox–Xu subset-sum lower-bound framework, Erdős #1), but those sorries — and the later `anticoncentration_bound` axiom — were **already fully discharged** across a prior multi-PR effort (several landed under this very slug):

- #31310 — second-moment identity + Chebyshev tail
- #31344 — 2ⁿ-distinct-integers input
- #31348 — central-interval count
- #31542 — discharge `anticoncentration_bound` axiom → **Erdős #1 DFX bound fully VERIFIED, 0-axiom**

`proofs/Proofs/Erdos1OQ02.lean` currently has **0 code sorries / 0 axioms**, and `src/data/proofs/erdos-1-oq-02/meta.json` records `sorries: 0`. No Lean work remains on this node.

## Change

State-sync only — updates `state.md` to phase COMPLETE with the phantom rationale so future claimants release without re-investigating. No Lean or gallery change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)