### PR TITLE
audit: re-audit 3 changed-since-audit metas — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5612,9 +5612,9 @@
       "result": "clean"
     },
     "central-limit-theorem-oq-01-oq-02-oq-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
+      "lastAudited": "2026-07-08T18:22:52Z",
       "result": "clean"
     },
     "central-limit-theorem-oq-01-oq-03": {
@@ -8888,8 +8888,8 @@
     },
     "erdos-1018": {
       "agentId": "auditor-reaudit-20260708",
-      "auditCount": 9,
-      "lastAudited": "2026-07-08T06:56:48Z",
+      "auditCount": 10,
+      "lastAudited": "2026-07-08T18:22:52Z",
       "result": "clean",
       "issues": [],
       "notes": "Re-audit CLEAN: meta status/badge/sorries/axiomCount all reconcile with Lean source. Sorry-count 'mismatches' from companion *Aristotle scaffolds are not counted (meta.sorries tracks main file). native_decide in erdos-1064 backs only illustrative examples with ofReduceBool disclosed; descartes axiomCount=1 = SturmReduction structure-encoded assumption, disclosed."
@@ -13032,8 +13032,8 @@
     },
     "erdos-378": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:47Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T18:22:52Z",
       "result": "clean"
     },
     "erdos-379": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Three gallery metas changed today via research PRs and were stale vs their last audit. Re-verified each meta.json against its Lean source; all clean.

| slug | status/badge | axioms | sorries | thm | lines | verdict |
|------|--------------|--------|---------|-----|-------|---------|
| erdos-378 | axiomatized/axiom | 2 (match) | 0 (match) | 12 | 403 | clean |
| erdos-1018 | axiomatized/axiom | 12 = 6 main + 6 Stubs (match) | 3 documented (match) | 9 | 398 | clean |
| central-limit-…-oq-03 | verified/original | 0 | 0 | 7 | 108 | clean |

- **erdos-378**: 2 axioms isolate the Granville–Ramaré (1996) density content; no overclaim.
- **erdos-1018**: axiomCount=12 correctly counts the 6 axioms in the main file plus 6 re-declared in `Proofs/Stubs/Erdos1018Problem.lean`. The 3 main-file sorries (isPlanar/containsSubdivision def-sorries + sparse_hides_nonplanarity) are all documented; Aristotle companion files are 0-axiom scaffolds and their sorries are not counted in meta.sorries.
- **central-limit-…-oq-03**: fully machine-checked, foundational axioms only.

Tracker: bumped `lastAudited`/`auditCount` for the 3 entries.

---
Discovered during autonomous gallery integrity audit.