### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-03): general odd-degree non-2group obstruction [VERIFIED]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
@@ -16,6 +16,11 @@
   concrete degree-3 obstruction behind the 60° trisection (cos 20° has
   minimal degree 3, which is not a power of 2).
 
+  A general odd-degree obstruction (`odd_degree_gt_one_not_2group`) records
+  that *any* algebraic real whose minimal polynomial has odd degree `> 1` has
+  no 2-group Galois group — subsuming the degree-3 (cos 20°) case and covering
+  degrees `5, 7, 9, …`.
+
   Parent: AngleTrisectionOQ02OQ01.lean (natDegree_dvd_card_gal, reused here)
 -/
 
@@ -77,5 +82,27 @@ theorem degree_three_not_2group (α : ℝ) (hα : IsIntegral ℚ α)
           _ ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) hge
       omega
   exact h2k hk.symm
+
+/-- **The general odd-degree obstruction.**
+    Any algebraic real whose minimal polynomial has *odd* degree `> 1` has no
+    2-group Galois group: an odd number `> 1` is never a power of `2`
+    (`2^0 = 1`, and `2^k` is even for `k ≥ 1`).
+
+    This generalizes `degree_three_not_2group` from the single degree `3` to
+    every odd degree `3, 5, 7, 9, …`, and gives a clean sufficient condition
+    for non-constructibility: an algebraic real of odd degree `> 1` cannot be
+    constructed by straightedge and compass. -/
+theorem odd_degree_gt_one_not_2group (α : ℝ) (hα : IsIntegral ℚ α)
+    (hodd : Odd (minpoly ℚ α).natDegree) (hgt : 1 < (minpoly ℚ α).natDegree) :
+    ¬ IsPGroup 2 (minpoly ℚ α).Gal := by
+  refine not_pgroup_of_degree_ne_pow_p α hα Nat.prime_two (fun k hk => ?_)
+  rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+  · -- `k = 0`: `2^0 = 1`, contradicting `natDegree > 1`.
+    rw [hk0, pow_zero] at hk; omega
+  · -- `k ≥ 1`: `2^k` is even, contradicting the odd degree.
+    have heven : (2 ^ k) % 2 = 0 :=
+      Nat.even_iff.mp (Nat.even_pow.mpr ⟨even_two, by omega⟩)
+    rw [hk, Nat.odd_iff] at hodd
+    omega
 
 end AngleTrisectionOQ02OQ01OQ03

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-03.json
@@ -4,25 +4,27 @@
   "parentId": "angle-trisection-oq-02-oq-01",
   "status": "in-progress",
   "knowledge": {
-    "score": 10,
+    "score": 12,
     "insights": [
       "The parent OQ-02-OQ-01 proves, for the prime 2, that a 2-group Galois group forces the minimal-polynomial degree to be a power of 2 — the algebraic core of the impossibility of angle trisection. The argument never used anything special about 2: it rests only on natDegree ∣ |Gal| (natDegree_dvd_card_gal) plus IsPGroup.iff_card.",
       "This child lifts the result to an ARBITRARY prime p: Gal(minpoly ℚ α) a p-group ⟹ natDegree = p^k. Divisibility natDegree ∣ p^n is upgraded to equality via Nat.dvd_prime_pow.",
       "IsPGroup.iff_card requires [Fact p.Prime] [Finite G] — supplied via haveI : Fact p.Prime := ⟨hp⟩; the Gal group's Finite instance is automatic (separable polynomial over CharZero).",
       "Contrapositive non-constructibility criterion: if natDegree is not a power of p, Gal is not a p-group.",
-      "Concrete degree-3 obstruction: a real with minimal degree 3 has no 2-group Galois group (3 ≠ 2^k for all k), precisely why the 60° angle cannot be trisected (cos 20° has minimal degree 3)."
+      "Concrete degree-3 obstruction: a real with minimal degree 3 has no 2-group Galois group (3 ≠ 2^k for all k), precisely why the 60° angle cannot be trisected (cos 20° has minimal degree 3).",
+      "Odd-degree generalization: an algebraic real whose minimal polynomial has odd degree > 1 can never have a 2-group Galois group, because 2^0 = 1 and 2^k is even for k ≥ 1. This upgrades the concrete degree-3 (cos 20°) obstruction to a general sufficient condition for non-constructibility by straightedge and compass, covering every odd degree."
     ],
     "builtItems": [
-      "AngleTrisectionOQ02OQ01OQ03.lean: 4 theorems, 0 axioms, 0 sorries, reuses parent natDegree_dvd_card_gal.",
+      "AngleTrisectionOQ02OQ01OQ03.lean: 5 theorems, 0 axioms, 0 sorries, reuses parent natDegree_dvd_card_gal.",
       "galois_pgroup_implies_degree_pow_p: p-group Gal ⟹ natDegree ∣ p^n.",
       "galois_pgroup_implies_degree_is_pow_p: p-group Gal ⟹ natDegree = p^k.",
       "not_pgroup_of_degree_ne_pow_p: degree not a power of p ⟹ Gal not a p-group.",
-      "degree_three_not_2group: minimal degree 3 ⟹ not a 2-group (the trisection obstruction)."
+      "degree_three_not_2group: minimal degree 3 ⟹ not a 2-group (the trisection obstruction).",
+      "odd_degree_gt_one_not_2group: minimal degree ODD and > 1 ⟹ not a 2-group — general odd-degree non-constructibility obstruction subsuming degree 3 and covering 5, 7, 9, … (an odd number > 1 is never a power of 2)."
     ],
-    "progressSummary": "Child of angle-trisection-oq-02-oq-01 (Galois → degree criterion). The parent handles the prime 2; this entry generalizes to an arbitrary prime p — p-group Galois group ⟹ minimal-polynomial degree is a power of p — together with the contrapositive non-constructibility criterion and the concrete degree-3 (cos 20°) obstruction behind the impossibility of trisecting 60°. All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide.",
+    "progressSummary": "Child of angle-trisection-oq-02-oq-01 (Galois → degree criterion). The parent handles the prime 2; this entry generalizes to an arbitrary prime p — p-group Galois group ⟹ minimal-polynomial degree is a power of p — together with the contrapositive non-constructibility criterion, the concrete degree-3 (cos 20°) obstruction, and now a GENERAL odd-degree obstruction: odd minimal degree > 1 ⟹ not a 2-group, subsuming the degree-3 case and covering 5, 7, 9, …. All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. 5 theorems total.",
     "nextSteps": [
-      "Instantiate degree_three_not_2group at α = cos 20° using the cluster's cos20 minimal-polynomial degree result to obtain a fully concrete non-trisectability corollary.",
-      "Mirror the criterion at the field-degree / finrank level (not just minpoly natDegree) to align with IsConstructibleFromQ.",
+      "BLOCKED (infra): a fully concrete cos 20° corollary via AngleTrisectionCos20GalOQ01OQ02OQ02.cos_pi9_minpoly_degree is currently unreachable — that file transitively imports AngleTrisectionOQ02OQ03OQ01.lean, which does not build against Mathlib v4.26 (AlgHom.toAlgHom removed, ring failures). Repair that file first, then instantiate odd_degree_gt_one_not_2group / degree_three_not_2group at cos(π/9).",
+      "BLOCKED (elaborator): mirroring the criterion at the field-degree / finrank level via IntermediateField.adjoin.finrank currently segfaults the Lean 4.26 elaborator in this environment; revisit with a different formulation (e.g. minpoly.natDegree_eq_finrank or a splitting-field degree bound).",
       "Generalize to the converse direction (degree a power of p does not by itself force a p-group) to clarify the gap between necessary and sufficient conditions."
     ]
   },
@@ -375,8 +377,8 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ03.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ03.lean",
-      "lineCount": 82,
-      "theoremCount": 4,
+      "lineCount": 108,
+      "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends the merged **p-group Galois → power-of-p degree criterion** file (`AngleTrisectionOQ02OQ01OQ03.lean`) with a new, more general non-constructibility obstruction:

**`odd_degree_gt_one_not_2group`** — any algebraic real whose minimal polynomial has **odd degree > 1** has no 2-group Galois group.

Proof: an odd number > 1 is never a power of 2 (`2^0 = 1`; `2^k` is even for `k ≥ 1`). This generalizes the existing single-degree obstruction `degree_three_not_2group` (cos 20°, degree 3) to *every* odd degree — 3, 5, 7, 9, … — giving a clean sufficient condition for non-constructibility by straightedge and compass.

## Verification

- Builds clean against Mathlib v4.26 via `docker-build.sh` (7745 jobs).
- **0-axiom**: `propext` / `Classical.choice` / `Quot.sound` only. No `native_decide`.
- Uses only `omega` + standard `Nat` lemmas (`Nat.even_pow`, `Nat.even_iff`, `Nat.odd_iff`); introduces no new assumptions.
- File: 4 → 5 theorems, 82 → 108 lines. Metadata synced.

## Follow-ups documented (blocked)

Two originally-planned next steps are recorded as blocked in the knowledge metadata:
- **Concrete cos 20° corollary** via `cos_pi9_minpoly_degree`: blocked because that file transitively imports `AngleTrisectionOQ02OQ03OQ01.lean`, which no longer builds against Mathlib v4.26 (`AlgHom.toAlgHom` removed, `ring` failures).
- **Field-degree / finrank mirror** via `IntermediateField.adjoin.finrank`: currently segfaults the Lean 4.26 elaborator in this environment; needs a different formulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)