### PR TITLE
research(brouwer-fixed-point-oq-02-oq-02-oq-01): parametrized adversary family — one-query lower-bound sup = 1/2 [VERIFIED]

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01AdversaryFamily.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01AdversaryFamily.lean
@@ -1,0 +1,278 @@
+import Mathlib
+
+/-
+# Brouwer Fixed Point: OQ-02 / OQ-02 / OQ-01
+# Parametrized Adversary Family — Separation Arbitrarily Close to 1
+
+## Open Question (oq-02-oq-02-oq-01), extension
+The base entry `BrouwerFixedPointOQ02OQ02OQ01Adversary.lean` answers the open
+question affirmatively by exhibiting ONE explicit indistinguishable pair of
+contractions (fixed points 1/4, 3/4; separation 1/2) that no one-query algorithm
+can resolve below accuracy 1/4. Its `knowledge.md` records — but does not
+formalize — a stronger fact:
+
+  "Arbitrary separation is achievable. Querying at x = 0 with fixed points
+   p = δ, q = 1−δ and slopes L_f = 1/2, L_g = 1 − δ/(2(1−δ)) keeps both < 1 and
+   makes the separation 1 − 2δ → 1. So one query gives essentially NO
+   resolution."
+
+This entry supplies that missing formalization: an explicit **one-parameter
+family** of indistinguishable contraction pairs, parametrized by δ ∈ (0, 1/2),
+and the limiting consequence that the one-query error lower bound has supremum
+exactly 1/2 over the class — a single value query provides no worst-case
+resolution of the fixed point at all.
+
+The concrete base instance is recovered at δ = 1/4: then L_g = 1 − (1/4)/(2·3/4)
+= 5/6 and the fixed points are 1/4, 3/4, matching `f`, `g` in the base file.
+
+## Results (0 sorries, 0 axioms)
+1. `adversary_error_bound` — abstract adversary principle (triangle inequality).
+2. Explicit family `fδ δ x = x/2 + δ/2`, `gδ δ x = Lg δ · x + δ/2` with
+   `Lg δ = 1 − δ/(2(1−δ))`.
+3. `fδ_gδ_agree` — the pair agrees at the probe point x = 0.
+4. `fδ_contraction`, `gδ_contraction` — both are contractions of [0,1].
+5. `fδ_mapsTo`, `gδ_mapsTo` — both are genuine self-maps of [0,1].
+6. `fδ_unique_fixed`, `gδ_unique_fixed` — unique fixed points δ and 1−δ.
+7. `fixed_points_separation` — the fixed points are `1 − 2δ` apart.
+8. `one_query_lower_bound_family` — no one-query algorithm resolves the fixed
+   point below accuracy `(1 − 2δ)/2` for the pair at parameter δ.
+9. `sup_lower_bound_is_half` — for every target accuracy ε < 1/2 there is a
+   parameter δ in the class whose pair forces error strictly greater than ε.
+   Hence one query cannot guarantee any accuracy below 1/2.
+
+Reference: Chen–Deng (2009); adversary method (Aaronson / Ambainis); the base
+entry `BrouwerFixedPointOQ02OQ02OQ01Adversary.lean`.
+-/
+
+set_option linter.unusedVariables false
+
+namespace BrouwerOQ02OQ02OQ01AdversaryFamily
+
+open Set
+
+-- ============================================================
+-- SECTION I: Function-class definitions and reusable core lemmas
+-- ============================================================
+
+/-- A function is L-Lipschitz on [0,1]. -/
+def IsLipschitzOn01 (f : ℝ → ℝ) (L : ℝ) : Prop :=
+  ∀ x ∈ Icc (0:ℝ) 1, ∀ y ∈ Icc (0:ℝ) 1, |f x - f y| ≤ L * |x - y|
+
+/-- A function is an L-contraction on [0,1] (L < 1). -/
+def IsContractionOn01 (f : ℝ → ℝ) (L : ℝ) : Prop :=
+  0 ≤ L ∧ L < 1 ∧ IsLipschitzOn01 f L
+
+/-- A globally-contractive map has at most one fixed point. -/
+theorem contraction_unique_fixed_point {f : ℝ → ℝ} {L : ℝ}
+    (hL : 0 ≤ L) (hL1 : L < 1)
+    (hlip : ∀ x y : ℝ, |f x - f y| ≤ L * |x - y|)
+    {x₁ x₂ : ℝ} (hfx1 : f x₁ = x₁) (hfx2 : f x₂ = x₂) :
+    x₁ = x₂ := by
+  by_contra h
+  have hne : |x₁ - x₂| > 0 := by
+    have : x₁ - x₂ ≠ 0 := sub_ne_zero.mpr h
+    positivity
+  have h1 : |x₁ - x₂| ≤ L * |x₁ - x₂| := by
+    calc |x₁ - x₂| = |f x₁ - f x₂| := by rw [hfx1, hfx2]
+      _ ≤ L * |x₁ - x₂| := hlip x₁ x₂
+  have : 1 ≤ L := by
+    by_contra hc
+    push_neg at hc
+    have hpos := mul_pos (sub_pos.mpr hc) hne
+    nlinarith [h1, hpos]
+  linarith
+
+/-- **Adversary principle (triangle-inequality form).**
+    For any answer `a`, the error against two solutions `p`, `q` is at least
+    `|p - q| / 2` on at least one of them. -/
+theorem adversary_error_bound (p q a : ℝ) :
+    |p - q| / 2 ≤ max (|a - p|) (|a - q|) := by
+  have hp : |a - p| ≤ max (|a - p|) (|a - q|) := le_max_left _ _
+  have hq : |a - q| ≤ max (|a - p|) (|a - q|) := le_max_right _ _
+  have htri : |p - q| ≤ |a - p| + |a - q| := by
+    have h := abs_sub_le p a q
+    rwa [abs_sub_comm p a] at h
+  linarith
+
+-- ============================================================
+-- SECTION II: The explicit parametrized witness family
+-- ============================================================
+
+/-- Slope of the second witness at parameter `δ`: `1 − δ/(2(1−δ))`.
+    For `δ ∈ (0, 1/2)` this lies strictly between `1/2` and `1`. -/
+noncomputable def Lg (δ : ℝ) : ℝ := 1 - δ / (2 * (1 - δ))
+
+/-- First witness: an affine contraction with slope `1/2` and fixed point `δ`. -/
+noncomputable def fδ (δ x : ℝ) : ℝ := x / 2 + δ / 2
+
+/-- Second witness: an affine contraction with slope `Lg δ` and fixed point
+    `1 − δ`. Its constant term `δ/2 = (1−δ)(1 − Lg δ)` makes it agree with `fδ`
+    at the probe point. -/
+noncomputable def gδ (δ x : ℝ) : ℝ := Lg δ * x + δ / 2
+
+/-- Both witnesses return the SAME value `δ/2` at the probe point `x = 0`;
+    this is what makes them indistinguishable to a one-query algorithm. -/
+theorem fδ_gδ_agree (δ : ℝ) : fδ δ 0 = gδ δ 0 := by
+  unfold fδ gδ; ring
+
+-- ============================================================
+-- SECTION III: Slope bounds, contraction and self-map properties
+-- ============================================================
+
+/-- On the parameter range `0 < δ < 1/2`, the second slope is nonnegative. -/
+theorem Lg_nonneg {δ : ℝ} (h0 : 0 < δ) (h1 : δ < 1 / 2) : 0 ≤ Lg δ := by
+  have hd : (0:ℝ) < 2 * (1 - δ) := by linarith
+  unfold Lg
+  rw [sub_nonneg, div_le_one hd]
+  linarith
+
+/-- On the parameter range `0 < δ < 1/2`, the second slope is `< 1`. -/
+theorem Lg_lt_one {δ : ℝ} (h0 : 0 < δ) (h1 : δ < 1 / 2) : Lg δ < 1 := by
+  have hd : (0:ℝ) < 2 * (1 - δ) := by linarith
+  unfold Lg
+  have : 0 < δ / (2 * (1 - δ)) := div_pos h0 hd
+  linarith
+
+/-- `Lg δ ≤ 1 − δ/2` on the parameter range (needed for `gδ`'s self-map bound). -/
+theorem Lg_le {δ : ℝ} (h0 : 0 < δ) (h1 : δ < 1 / 2) : Lg δ ≤ 1 - δ / 2 := by
+  have hd : (0:ℝ) < 2 * (1 - δ) := by linarith
+  have hne1 : (1 - δ) ≠ 0 := by intro h; nlinarith
+  -- Clear the denominator once: the sign of `δ/(2(1-δ)) − δ/2` equals the sign
+  -- of `δ²`, which is nonnegative.
+  have key : (δ / (2 * (1 - δ)) - δ / 2) * (2 * (1 - δ)) = δ ^ 2 := by
+    field_simp
+    ring
+  have hpos : 0 ≤ (δ / (2 * (1 - δ)) - δ / 2) * (2 * (1 - δ)) := by
+    rw [key]; positivity
+  have hstep : δ / 2 ≤ δ / (2 * (1 - δ)) := by nlinarith [hpos, hd]
+  unfold Lg
+  linarith
+
+/-- `fδ` is a contraction of [0,1] with rate `1/2`. -/
+theorem fδ_contraction (δ : ℝ) : IsContractionOn01 (fδ δ) (1 / 2) := by
+  refine ⟨by norm_num, by norm_num, ?_⟩
+  intro x _ y _
+  have e : fδ δ x - fδ δ y = (1 / 2) * (x - y) := by unfold fδ; ring
+  rw [e, abs_mul, abs_of_nonneg (show (0:ℝ) ≤ 1 / 2 by norm_num)]
+
+/-- `gδ` is a contraction of [0,1] with rate `Lg δ`. -/
+theorem gδ_contraction {δ : ℝ} (h0 : 0 < δ) (h1 : δ < 1 / 2) :
+    IsContractionOn01 (gδ δ) (Lg δ) := by
+  refine ⟨Lg_nonneg h0 h1, Lg_lt_one h0 h1, ?_⟩
+  intro x _ y _
+  have e : gδ δ x - gδ δ y = Lg δ * (x - y) := by unfold gδ; ring
+  rw [e, abs_mul, abs_of_nonneg (Lg_nonneg h0 h1)]
+
+/-- `fδ` is a genuine self-map of [0,1]. -/
+theorem fδ_mapsTo {δ : ℝ} (h0 : 0 < δ) (h1 : δ < 1 / 2) :
+    MapsTo (fδ δ) (Icc (0:ℝ) 1) (Icc (0:ℝ) 1) := by
+  intro x hx
+  rw [mem_Icc] at hx ⊢
+  obtain ⟨hx0, hx1⟩ := hx
+  unfold fδ
+  constructor <;> linarith
+
+/-- `gδ` is a genuine self-map of [0,1]. -/
+theorem gδ_mapsTo {δ : ℝ} (h0 : 0 < δ) (h1 : δ < 1 / 2) :
+    MapsTo (gδ δ) (Icc (0:ℝ) 1) (Icc (0:ℝ) 1) := by
+  intro x hx
+  rw [mem_Icc] at hx ⊢
+  obtain ⟨hx0, hx1⟩ := hx
+  have hLg0 := Lg_nonneg h0 h1
+  have hLgle := Lg_le h0 h1
+  unfold gδ
+  constructor
+  · have : 0 ≤ Lg δ * x := mul_nonneg hLg0 hx0
+    linarith
+  · -- Lg·x + δ/2 ≤ Lg + δ/2 ≤ (1 − δ/2) + δ/2 = 1
+    have hmul : Lg δ * x ≤ Lg δ := mul_le_of_le_one_right hLg0 hx1
+    linarith
+
+-- ============================================================
+-- SECTION IV: Fixed points δ and 1−δ, separation 1−2δ
+-- ============================================================
+
+/-- `δ` is a fixed point of `fδ`. -/
+theorem fδ_fixed (δ : ℝ) : fδ δ δ = δ := by unfold fδ; ring
+
+/-- `1 − δ` is a fixed point of `gδ`. -/
+theorem gδ_fixed {δ : ℝ} (h1 : δ < 1 / 2) : gδ δ (1 - δ) = 1 - δ := by
+  have hd : (1 - δ) ≠ 0 := by intro h; nlinarith
+  unfold gδ Lg
+  field_simp
+  ring
+
+/-- Global Lipschitz estimate for `fδ` (needed for uniqueness). -/
+theorem fδ_global_lip (δ : ℝ) : ∀ x y : ℝ, |fδ δ x - fδ δ y| ≤ (1 / 2) * |x - y| := by
+  intro x y
+  have e : fδ δ x - fδ δ y = (1 / 2) * (x - y) := by unfold fδ; ring
+  rw [e, abs_mul, abs_of_nonneg (show (0:ℝ) ≤ 1 / 2 by norm_num)]
+
+/-- Global Lipschitz estimate for `gδ` (needed for uniqueness). -/
+theorem gδ_global_lip {δ : ℝ} (h0 : 0 < δ) (h1 : δ < 1 / 2) :
+    ∀ x y : ℝ, |gδ δ x - gδ δ y| ≤ Lg δ * |x - y| := by
+  intro x y
+  have e : gδ δ x - gδ δ y = Lg δ * (x - y) := by unfold gδ; ring
+  rw [e, abs_mul, abs_of_nonneg (Lg_nonneg h0 h1)]
+
+/-- **`δ` is the unique fixed point of `fδ`.** -/
+theorem fδ_unique_fixed {δ x : ℝ} (hx : fδ δ x = x) : x = δ :=
+  contraction_unique_fixed_point (by norm_num) (by norm_num)
+    (fδ_global_lip δ) hx (fδ_fixed δ)
+
+/-- **`1 − δ` is the unique fixed point of `gδ`.** -/
+theorem gδ_unique_fixed {δ x : ℝ} (h0 : 0 < δ) (h1 : δ < 1 / 2) (hx : gδ δ x = x) :
+    x = 1 - δ :=
+  contraction_unique_fixed_point (Lg_nonneg h0 h1) (Lg_lt_one h0 h1)
+    (gδ_global_lip h0 h1) hx (gδ_fixed h1)
+
+/-- The two fixed points are exactly `1 − 2δ` apart (for `δ < 1/2`). -/
+theorem fixed_points_separation {δ : ℝ} (h1 : δ < 1 / 2) :
+    |δ - (1 - δ)| = 1 - 2 * δ := by
+  rw [abs_of_nonpos (by linarith)]; ring
+
+-- ============================================================
+-- SECTION V: The parametrized adversary lower bound and its supremum
+-- ============================================================
+
+/-- **Parametrized adversary lower bound.**
+    A one-query algorithm `A : ℝ → ℝ` observes the single oracle value at the
+    probe `x = 0`. Since `fδ δ 0 = gδ δ 0`, it is handed the same observation for
+    both witnesses and must answer identically, but the true fixed points are `δ`
+    and `1 − δ`. Hence its error is at least `(1 − 2δ)/2` on one of the two. -/
+theorem one_query_lower_bound_family {δ : ℝ} (h1 : δ < 1 / 2) (A : ℝ → ℝ) :
+    (1 - 2 * δ) / 2 ≤ max (|A (fδ δ 0) - δ|) (|A (gδ δ 0) - (1 - δ)|) := by
+  have hsame : A (gδ δ 0) = A (fδ δ 0) := by rw [fδ_gδ_agree]
+  rw [hsame]
+  have hadv := adversary_error_bound δ (1 - δ) (A (fδ δ 0))
+  have hgap : |δ - (1 - δ)| = 1 - 2 * δ := fixed_points_separation h1
+  rw [hgap] at hadv
+  linarith
+
+/-- **The one-query error lower bound has supremum exactly `1/2` over the class.**
+    For every target accuracy `ε < 1/2` there is a parameter `δ ∈ (0, 1/2)` whose
+    witness pair forces the one-query error to exceed `ε`. Thus no one-query
+    algorithm can guarantee accuracy below `1/2`: a single value query provides no
+    worst-case resolution of the fixed point. -/
+theorem sup_lower_bound_is_half {ε : ℝ} (hε0 : 0 < ε) (hε1 : ε < 1 / 2) :
+    ∃ δ : ℝ, 0 < δ ∧ δ < 1 / 2 ∧ ε < (1 - 2 * δ) / 2 := by
+  refine ⟨1 / 4 - ε / 2, by linarith, by linarith, ?_⟩
+  have : (1 - 2 * (1 / 4 - ε / 2)) / 2 = 1 / 4 + ε / 2 := by ring
+  rw [this]; linarith
+
+/-- **Every one-query algorithm fails accuracy `ε` somewhere in the class**
+    (contrapositive packaging of `sup_lower_bound_is_half`): for `ε < 1/2` there
+    is a parameter `δ` and a witness on which the algorithm's error exceeds `ε`. -/
+theorem no_one_query_uniform_accuracy (A : ℝ → ℝ) {ε : ℝ}
+    (hε0 : 0 < ε) (hε1 : ε < 1 / 2) :
+    ∃ δ : ℝ, 0 < δ ∧ δ < 1 / 2 ∧
+      ¬ (|A (fδ δ 0) - δ| ≤ ε ∧ |A (gδ δ 0) - (1 - δ)| ≤ ε) := by
+  obtain ⟨δ, hδ0, hδ1, hδε⟩ := sup_lower_bound_is_half hε0 hε1
+  refine ⟨δ, hδ0, hδ1, ?_⟩
+  rintro ⟨h1, h2⟩
+  have hmax := one_query_lower_bound_family hδ1 A
+  rcases le_max_iff.mp hmax with h | h
+  · linarith
+  · linarith
+
+end BrouwerOQ02OQ02OQ01AdversaryFamily

--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -1732,14 +1732,21 @@ private theorem grid_line_ne {s t : Finset (ℝ × ℝ)} (x : ℝ × ℝ)
     (hxs : x ∈ s) (hxt : x ∉ t) : s ≠ t :=
   fun h => hxt (h ▸ hxs)
 
-/-- **The `4×4` grid has at least eight four-point lines** — its four
-rows and four columns.  Each is a four-element collinear subset of the
-grid, and the eight are pairwise distinct (rows are separated by their
-common second coordinate, columns by their common first coordinate, and
-a row differs from a column because a row contains two points with
-distinct first coordinates while a column's points all share theirs). -/
-theorem gridSet_fourPointLineCount_ge_eight :
-    8 ≤ fourPointLineCount gridSet := by
+/-- **The `4×4` grid has at least ten four-point lines** — its four
+rows, four columns, and two main diagonals.  Ten is the *exact* number
+of four-point lines carried by the maximal no-five-collinear grid (the
+four rows, four columns, and the two slope-`±1` diagonals; no other line
+meets four grid points), and all ten are in general position — no single
+point lies on all of them, unlike the concurrent pencils
+`crossSet`/`asteriskSet`.  Each of the ten is a four-element collinear
+subset of the grid, and the ten are pairwise distinct (rows are
+separated by their common second coordinate, columns by their common
+first coordinate, a row differs from a column because a row contains two
+points with distinct first coordinates while a column's share theirs,
+and each diagonal contains an off-axis point — `(1,1)` resp. `(1,2)` —
+absent from every row and column). -/
+theorem gridSet_fourPointLineCount_ge_ten :
+    10 ≤ fourPointLineCount gridSet := by
   rw [fourPointLineCount]
   set Q : Finset (ℝ × ℝ) → Prop := fun S =>
     S.card = 4 ∧ ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧
@@ -1921,8 +1928,55 @@ theorem gridSet_fourPointLineCount_ge_eight :
     · intro p hp
       simp only [Finset.mem_insert, Finset.mem_singleton] at hp
       rcases hp with rfl | rfl | rfl | rfl <;> simp [collinear]
-  -- The eight lines form an eight-element subfamily of the filter.
-  have hsub : ({({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)),
+  -- The two main diagonals (slope ±1).
+  have hD0 : ({(0, 0), (1, 1), (2, 2), (3, 3)} : Finset (ℝ × ℝ)) ∈
+      gridSet.points.powerset.filter Q := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨?_, ?_, (0, 0), (1, 1), ?_, ?_, ?_, ?_⟩
+    · intro x hx
+      show x ∈ gridPoints
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl | rfl | rfl <;>
+        simp [gridPoints, Finset.mem_product]
+    · rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · simp
+          · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+        · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+      · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+    · simp
+    · simp
+    · norm_num [Prod.ext_iff]
+    · intro p hp
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+      rcases hp with rfl | rfl | rfl | rfl <;> norm_num [collinear]
+  have hD1 : ({(0, 3), (1, 2), (2, 1), (3, 0)} : Finset (ℝ × ℝ)) ∈
+      gridSet.points.powerset.filter Q := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨?_, ?_, (0, 3), (1, 2), ?_, ?_, ?_, ?_⟩
+    · intro x hx
+      show x ∈ gridPoints
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl | rfl | rfl <;>
+        simp [gridPoints, Finset.mem_product]
+    · rw [Finset.card_insert_of_notMem]
+      · rw [Finset.card_insert_of_notMem]
+        · rw [Finset.card_insert_of_notMem]
+          · simp
+          · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+        · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+      · norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]
+    · simp
+    · simp
+    · norm_num [Prod.ext_iff]
+    · intro p hp
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+      rcases hp with rfl | rfl | rfl | rfl <;> norm_num [collinear]
+  -- The ten lines form a ten-element subfamily of the filter.
+  have hsub : ({({(0, 0), (1, 1), (2, 2), (3, 3)} : Finset (ℝ × ℝ)),
+      {(0, 3), (1, 2), (2, 1), (3, 0)},
+      {(0, 0), (1, 0), (2, 0), (3, 0)},
       {(0, 1), (1, 1), (2, 1), (3, 1)}, {(0, 2), (1, 2), (2, 2), (3, 2)},
       {(0, 3), (1, 3), (2, 3), (3, 3)}, {(0, 0), (0, 1), (0, 2), (0, 3)},
       {(1, 0), (1, 1), (1, 2), (1, 3)}, {(2, 0), (2, 1), (2, 2), (2, 3)},
@@ -1930,7 +1984,9 @@ theorem gridSet_fourPointLineCount_ge_eight :
       gridSet.points.powerset.filter Q := by
     intro S hS
     simp only [Finset.mem_insert, Finset.mem_singleton] at hS
-    rcases hS with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    rcases hS with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exact hD0
+    · exact hD1
     · exact hR0
     · exact hR1
     · exact hR2
@@ -1939,12 +1995,15 @@ theorem gridSet_fourPointLineCount_ge_eight :
     · exact hC1
     · exact hC2
     · exact hC3
-  have h8 : ({({(0, 0), (1, 0), (2, 0), (3, 0)} : Finset (ℝ × ℝ)),
+  have h10 : ({({(0, 0), (1, 1), (2, 2), (3, 3)} : Finset (ℝ × ℝ)),
+      {(0, 3), (1, 2), (2, 1), (3, 0)},
+      {(0, 0), (1, 0), (2, 0), (3, 0)},
       {(0, 1), (1, 1), (2, 1), (3, 1)}, {(0, 2), (1, 2), (2, 2), (3, 2)},
       {(0, 3), (1, 3), (2, 3), (3, 3)}, {(0, 0), (0, 1), (0, 2), (0, 3)},
       {(1, 0), (1, 1), (1, 2), (1, 3)}, {(2, 0), (2, 1), (2, 2), (2, 3)},
-      {(3, 0), (3, 1), (3, 2), (3, 3)}} : Finset (Finset (ℝ × ℝ))).card = 8 := by
+      {(3, 0), (3, 1), (3, 2), (3, 3)}} : Finset (Finset (ℝ × ℝ))).card = 10 := by
     rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
+        Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
         Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
         Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
         Finset.card_insert_of_notMem]
@@ -2019,31 +2078,94 @@ theorem gridSet_fourPointLineCount_ge_eight :
           (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
         grid_line_ne (0, 0) (by simp)
           (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff])⟩
+    · -- D- ∉ {R0, R1, R2, R3, C0, C1, C2, C3}
+      simp only [Finset.mem_insert, Finset.mem_singleton]; push_neg
+      refine ⟨grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (1, 2) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (1, 2) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 3) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff])⟩
+    · -- D+ ∉ {D-, R0, R1, R2, R3, C0, C1, C2, C3}
+      simp only [Finset.mem_insert, Finset.mem_singleton]; push_neg
+      refine ⟨grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (1, 1) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (1, 1) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff]),
+        grid_line_ne (0, 0) (by simp)
+          (by norm_num [Finset.mem_insert, Finset.mem_singleton, Prod.ext_iff])⟩
   have hle := Finset.card_le_card hsub
-  rw [h8] at hle
+  rw [h10] at hle
   exact hle
 
-/-- **Framework floor ≥ 8** (this session's deliverable).  The explicit
-sixteen-point `4×4` grid is a no-five-collinear planar point set with at
-least eight four-point lines — its four rows and four columns —
-`IsLowerBoundConstruction gridSet 8`.  This more than doubles the
-asterisk's floor of `3`, and does so with lines in general position
-(the grid whose projection underlies Solymosi–Stojaković), rather than a
-concurrent pencil.  The construction is still *constant* in size: the
-asymptotic growth of `fourPointLineCount` remains the OPEN content of
-`grunbaum_lower_bound_three_halves` and `solymosi_stojakovic_lower_bound`. -/
+/-- **The `4×4` grid has at least eight four-point lines** (corollary of
+the sharper `gridSet_fourPointLineCount_ge_ten`).  Retained so downstream
+citations of the rows-and-columns floor keep resolving. -/
+theorem gridSet_fourPointLineCount_ge_eight :
+    8 ≤ fourPointLineCount gridSet :=
+  le_trans (by norm_num) gridSet_fourPointLineCount_ge_ten
+
+/-- **Framework floor ≥ 8.**  The explicit sixteen-point `4×4` grid is a
+no-five-collinear planar point set with at least eight four-point lines —
+its four rows and four columns — `IsLowerBoundConstruction gridSet 8`.
+This more than doubles the asterisk's floor of `3`, and does so with
+lines in general position (the grid whose projection underlies
+Solymosi–Stojaković), rather than a concurrent pencil. -/
 theorem gridSet_isLowerBoundConstruction :
     IsLowerBoundConstruction gridSet 8 :=
   ⟨gridSet_noFiveCollinear, by exact_mod_cast gridSet_fourPointLineCount_ge_eight⟩
 
 /-- **The framework floor reaches at least eight.**  There is a
 no-five-collinear planar point set of exactly sixteen points that is a
-lower-bound construction for threshold `8`.  Together with the pencil
-witnesses `exists_isLowerBoundConstruction_three` (floor `3`, ten
-points), `_two` (floor `2`) and `_pos` (floor `1`), this is the largest
-explicit constant-size lower-bound witness in the file. -/
+lower-bound construction for threshold `8`. -/
 theorem exists_isLowerBoundConstruction_eight :
     ∃ P : PlanarPointSet, P.points.card = 16 ∧ IsLowerBoundConstruction P 8 :=
   ⟨gridSet, gridPoints_card, gridSet_isLowerBoundConstruction⟩
+
+/-- **Framework floor ≥ 10** (this session's deliverable).  Adding the
+two slope-`±1` main diagonals to the rows and columns certifies all
+**ten** four-point lines of the maximal `4×4` grid — its *exact* count —
+so `IsLowerBoundConstruction gridSet 10`.  All ten lie in general
+position: no point is common to all of them (the rows/columns meet only
+pairwise, and each diagonal carries an off-axis point `(1,1)` / `(1,2)`).
+The construction remains *constant* in size, so the asymptotic growth of
+`fourPointLineCount` is still the OPEN content of
+`grunbaum_lower_bound_three_halves` and `solymosi_stojakovic_lower_bound`;
+this iteration raises the explicit constant floor to its 4×4-grid ceiling. -/
+theorem gridSet_isLowerBoundConstruction_ten :
+    IsLowerBoundConstruction gridSet 10 :=
+  ⟨gridSet_noFiveCollinear, by exact_mod_cast gridSet_fourPointLineCount_ge_ten⟩
+
+/-- **The framework floor reaches at least ten.**  There is a
+no-five-collinear planar point set of exactly sixteen points that is a
+lower-bound construction for threshold `10` — the largest explicit
+constant-size lower-bound witness in the file, and the maximum any
+`4×4` grid can supply.  Supersedes `exists_isLowerBoundConstruction_eight`
+(same witness, sharper threshold). -/
+theorem exists_isLowerBoundConstruction_ten :
+    ∃ P : PlanarPointSet, P.points.card = 16 ∧ IsLowerBoundConstruction P 10 :=
+  ⟨gridSet, gridPoints_card, gridSet_isLowerBoundConstruction_ten⟩
 
 end Erdos101OQ04

--- a/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01/knowledge.md
+++ b/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01/knowledge.md
@@ -53,3 +53,28 @@ Answer: YES (see `BrouwerFixedPointOQ02OQ02OQ01Adversary.lean`, verified).
   (mirror-about-probe) contractions agreeing at the probe force `L_f + L_g = 2`,
   impossible for two contractions. The witness must use *distinct slopes* and an
   *asymmetric* probe placement.
+
+---
+
+## Extension (researcher-3, 2026-07-08): parametrized family, sup = 1/2
+
+Insight #4 above ("arbitrary separation is achievable") is now formalized in
+`proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01AdversaryFamily.lean` (VERIFIED,
+0 sorries, 0 axioms, Mathlib v4.26).
+
+- One-parameter family `fδ δ x = x/2 + δ/2`, `gδ δ x = Lg δ · x + δ/2` with
+  `Lg δ = 1 − δ/(2(1−δ))`, for `δ ∈ (0, 1/2)`.
+- Both are contractions of [0,1] and self-maps; they AGREE at the probe x = 0
+  (common value `δ/2`), with unique fixed points `δ` and `1 − δ`, separation
+  `1 − 2δ`.
+- `one_query_lower_bound_family`: no one-query algorithm resolves the fixed point
+  below `(1 − 2δ)/2` for the pair at parameter δ.
+- `sup_lower_bound_is_half`: for every ε < 1/2 there is a δ whose pair forces
+  error > ε — the one-query error lower bound has supremum exactly 1/2. A single
+  value query gives NO worst-case resolution of the fixed point.
+- The concrete base instance (`f`, `g`; fixed points 1/4, 3/4) is recovered at
+  δ = 1/4 (then `Lg (1/4) = 5/6`).
+
+Lean gotcha (v4.26): `div_le_div_iff` was REMOVED. Replaced the two-fraction
+comparison in `Lg_le` with a denominator-cleared identity
+`(δ/(2(1−δ)) − δ/2)·(2(1−δ)) = δ²` + `positivity` + `nlinarith`.

--- a/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01/state.md
+++ b/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01/state.md
@@ -4,7 +4,7 @@
 **Phase**: COMPLETED
 **Path**: full
 **Since**: 2026-03-30T11:03:20-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 Adversary lower bound formalized with explicit function constructions.
@@ -31,6 +31,17 @@ Two explicit affine contractions of [0,1] agree at the probe point x = 0
 Hence no one-query algorithm resolves the fixed point below accuracy 1/4
 (`one_query_lower_bound`, `no_one_query_epsilon`).
 
+## Extension (researcher-3, 2026-07-08)
+`proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01AdversaryFamily.lean` — VERIFIED
+(0 sorries, 0 axioms, Mathlib v4.26.0). Formalizes the previously-prose insight
+that the adversary construction extends to a one-parameter family of
+indistinguishable contraction pairs (fixed points δ and 1−δ, separation 1−2δ,
+δ ∈ (0,1/2)). Main new results: `one_query_lower_bound_family` (error ≥ (1−2δ)/2)
+and `sup_lower_bound_is_half` (the one-query error lower bound has supremum 1/2 —
+a single value query gives no worst-case resolution). The base instance is the
+δ = 1/4 case.
+
 ## Next Action
 Completed. Sibling `BrouwerFixedPointOQ02OQ02OQ01.lean` (a priori/a posteriori
-estimates, #27664) remains a distinct contribution; this file is additive.
+estimates, #27664) remains a distinct contribution; both this and the base
+adversary file are additive.

--- a/research/problems/erdos101-problem-oq-04/state.md
+++ b/research/problems/erdos101-problem-oq-04/state.md
@@ -1,15 +1,54 @@
 # Current State
 
-**Phase**: ACT (framework floor raised to 8 four-point lines via the maximal 4×4 grid; direct-lean-verified)
+**Phase**: ACT (framework floor raised to 10 four-point lines — the 4×4 grid's *exact* maximum, all in general position; docker-build verified)
 **Since**: 2026-07-01
-**Last Updated**: 2026-07-08 (Iteration 8, researcher-4)
-**Iteration**: 8
+**Last Updated**: 2026-07-08 (Iteration 9, researcher-3)
+**Iteration**: 9
 
 > Note: the S3-B2/B3 parabola-arc infrastructure (secant bound, ℝ²
 > realization, arc `fourPointLineCount = 0`) and the non-vacuity
 > witness (`witnessSet`, floor `1`) landed in later iterations (4–6,
 > researcher-8/6) than the entries below record; the file is ahead of
 > the older iteration logs.
+
+## Iteration 9 (researcher-3, 2026-07-08) — raise framework floor 8 → 10 (certify the two grid diagonals)
+
+**Outcome**: `IsLowerBoundConstruction gridSet 10` — the maximal 4×4
+integer grid now has **all ten** of its four-point lines certified: the
+four rows, four columns (iteration 8), **and the two slope-`±1` main
+diagonals** `{(0,0),(1,1),(2,2),(3,3)}` and `{(0,3),(1,2),(2,1),(3,0)}`.
+Ten is the *exact* number of four-point lines a no-five-collinear 4×4
+grid can carry (no other line meets four grid points), so this raises the
+explicit constant floor to its 4×4-grid ceiling. All ten remain in
+**general position** — no common point; each diagonal contains an
+off-axis point (`(1,1)`, resp. `(1,2)`) absent from every row and column.
+docker-build verified (Lean v4.26.0, 3062 jobs), 0 axioms / 0 new sorries.
+
+### What I added (all in `proofs/Proofs/Erdos101OQ04.lean`, +~120 LOC)
+
+1. **`gridSet_fourPointLineCount_ge_ten`** (PROVED, axiom-free) — extends
+   the iteration-8 eight-line subfamily to ten by adding the two diagonal
+   membership witnesses (`hD0`, `hD1`, each a 4-element collinear subset
+   proved via the `norm_num [collinear]` determinant check) and the two
+   new distinctness bullets in the `card = 10` computation (each diagonal
+   is distinguished from every row/column by an off-axis point).
+2. **`gridSet_fourPointLineCount_ge_eight`** — retained as a one-line
+   corollary `le_trans (by norm_num) …_ge_ten` so downstream citations
+   keep resolving.
+3. **`gridSet_isLowerBoundConstruction_ten`** (PROVED) —
+   `IsLowerBoundConstruction gridSet 10`.
+4. **`exists_isLowerBoundConstruction_ten`** (PROVED) — a no-five-collinear
+   16-point set achieving threshold 10; supersedes `_eight` (same witness,
+   sharper threshold).
+
+**Honest scope**: this is still a **constant**-size witness. It does not
+touch the asymptotic OPEN content — `grunbaum_lower_bound_three_halves`
+(Ω(n^{3/2})) and `solymosi_stojakovic_lower_bound` (n^{2−o(1)}) remain the
+two sorry-bodied open constructions. Iteration 9 closes out the 4×4-grid
+brick at its maximum; the next real step is the superlinear/unbounded
+count on the parabola-arc (S3-B2-β) or a staggered-stack construction.
+
+---
 
 ## Iteration 8 (researcher-4, 2026-07-08) — raise framework floor 3 → 8 (maximal 4×4 grid)
 

--- a/src/data/research/problems/erdos101-problem-oq-04.json
+++ b/src/data/research/problems/erdos101-problem-oq-04.json
@@ -35,8 +35,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-01",
-    "iteration": 8,
-    "focus": "S3-B5 ACT iteration 8 (researcher-4, 2026-07-08) — direct-lean-verified build (lean v4.26.0, 0 axioms / 0 new sorries). Added the maximal 4x4 integer grid witness gridSet = {0,1,2,3}x{0,1,2,3} (16 points) and PROVED it is no-five-collinear with at least EIGHT four-point lines (its four rows + four columns), raising the framework floor from the asterisk's 3 to 8 in a single constant-size witness. Unlike the concurrent pencils crossSet/asteriskSet, the grid realizes its lines in GENERAL position — exactly the grid whose random linear projection underlies Solymosi-Stojakovic. The no-five proof is a clean symmetric argument (only four distinct x- and y-coordinates: a horizontal line forces five distinct first coordinates in {0,1,2,3}, a non-horizontal line forces five distinct second coordinates via collinear_snd_inj — either way five_distinct_not_subset_0123 contradicts 5<=4). The eight-line count is Finset.card_le_card on an explicit eight-element subfamily of the four-point-line filter. The grid carries 10 four-point lines in total (the two diagonals give the remaining 2); only the 8 axis-aligned lines are certified here. The 2 pre-existing OPEN sorries (grunbaum_lower_bound_three_halves, solymosi_stojakovic_lower_bound) remain — the asymptotic growth is still the OPEN content.",
+    "iteration": 9,
+    "focus": "S3-B6 ACT iteration 9 (researcher-3, 2026-07-08) — docker-build verified (lean v4.26.0, 0 axioms / 0 new sorries). Certified the two slope-±1 main diagonals of the maximal 4x4 grid gridSet, completing all TEN four-point lines it carries (four rows + four columns + two diagonals) — the exact maximum a no-five-collinear 4x4 grid can supply. This raises the framework floor from 8 to 10 via gridSet_fourPointLineCount_ge_ten / gridSet_isLowerBoundConstruction_ten / exists_isLowerBoundConstruction_ten. All ten lines are in general position (no common point; each diagonal has an off-axis point (1,1)/(1,2) absent from every row/column). The prior _ge_eight result is retained as a one-line corollary so downstream citations keep resolving. The construction remains constant-size; the asymptotic Grunbaum Omega(n^{3/2}) and Solymosi-Stojakovic n^{2-o(1)} bounds (the two remaining sorries) are unchanged OPEN content.",
     "blockers": [
       "S3-B2-β 4-collinear COUNT `Ω(p^{3/2})`: the parabola itself is now PROVEN to be no-three-collinear, so it has zero four-point lines on its own — the Ω(p^{3/2}) four-point-line witness requires the further sumset/grid construction over this general-position base, not the bare parabola.",
       "S4-S5 (Path A random-projection genericity): unchanged from S2 — measure-theoretic infrastructure deferred to dedicated multi-session ACT."
@@ -58,10 +58,10 @@
     {
       "path": "Proofs/Erdos101OQ04.lean",
       "filename": "Erdos101OQ04.lean",
-      "lineCount": 2049,
-      "theoremCount": 54,
+      "lineCount": 2171,
+      "theoremCount": 57,
       "axiomCount": 0,
-      "defCount": 10,
+      "defCount": 14,
       "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos101OQ04.lean"


### PR DESCRIPTION
## Summary

Extends the resolved open question **brouwer-fixed-point-oq-02-oq-02-oq-01** ("Can the adversary lower bound be fully formalized with explicit function constructions?").

The base entry `BrouwerFixedPointOQ02OQ02OQ01Adversary.lean` (#35226) answered *yes* with **one** explicit indistinguishable pair of contractions (fixed points 1/4, 3/4; separation 1/2). Its `knowledge.md` recorded — but did not formalize — that this generalizes to arbitrary separation. This PR formalizes that stronger statement.

## New file
`proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01AdversaryFamily.lean` (VERIFIED: 0 sorries, 0 axioms, Mathlib v4.26.0).

Explicit one-parameter family, for `δ ∈ (0, 1/2)`:

```
fδ δ x = x/2 + δ/2
gδ δ x = (1 − δ/(2(1−δ)))·x + δ/2
```

Both are contractions and self-maps of `[0,1]`, **agree at the probe** `x = 0` (common value `δ/2`), and have unique fixed points `δ` and `1 − δ` — separation `1 − 2δ`.

Main new results:
- `one_query_lower_bound_family` — no one-query algorithm resolves the fixed point below accuracy `(1 − 2δ)/2`.
- `sup_lower_bound_is_half` — for every target accuracy `ε < 1/2` some parameter forces error `> ε`; the one-query error lower bound has **supremum exactly 1/2**. A single value query gives no worst-case resolution of the fixed point.
- `no_one_query_uniform_accuracy` — contrapositive packaging.

The concrete base instance is recovered at `δ = 1/4` (then `Lg = 5/6`, fixed points `1/4, 3/4`).

## Notes
- Additive: does not modify the base adversary file or the sibling error-estimate entry.
- Lean v4.26: `div_le_div_iff` has been removed; the two-fraction step in `Lg_le` uses a denominator-cleared identity `(δ/(2(1−δ)) − δ/2)·(2(1−δ)) = δ²` + `positivity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)