### PR TITLE
research(erdos-1006-oq-01-oq-01): reconcile state — goal complete (cover_graph_characterization de-axiomatized)

### DIFF
--- a/research/problems/erdos-1006-oq-01-oq-01/knowledge.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/knowledge.md
@@ -6,16 +6,46 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Goal: prove `cover_graph_characterization` (Pretzel-Brightwell 1985) without
+axioms — a finite graph admits a robustly acyclic orientation iff it is a cover
+graph (Hasse diagram) of some poset. File: `proofs/Proofs/Erdos1006OQ01.lean`.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **The goal is achieved (merged PR #27222).** `cover_graph_characterization`
+  is a proved `theorem`, 0 sorry.
+- **Winning construction — the reachability order.** For a robust orientation
+  `O`, take `reachOrder`: `a ≤ b` iff `Relation.ReflTransGen O.arc a b`.
+  Acyclicity (a strictly-monotone `rank : V → ℕ`) gives antisymmetry, so this is
+  a `PartialOrder`. Then `G` is exactly its cover graph:
+  - `a < b ↔ TransGen O.arc a b` (proved from the rank witness).
+  - Each edge is a covering pair precisely because "no dependent arc" means
+    there is no alternate directed path — an intermediate `w` with `u < w < v`
+    would give a dependent arc, contradicting `hNoDep`.
+- **Key helper lemmas** (reusable for any acyclic-orientation reasoning):
+  - `rank_le_of_rtg` / `rank_lt_of_tg`: rank is weakly/strictly monotone along
+    `ReflTransGen`/`TransGen` paths.
+  - `lift_below` / `lift_above`: a path whose ranks stay strictly below `rank v`
+    (resp. strictly above `rank u`) never uses the arc `(u,v)`, so it lifts to a
+    path in the arc relation with `(u,v)` excluded. These bridge "path in `O`"
+    and "path avoiding the reversed arc" for the dependent-arc definition.
+- **The `hasDependentArc` reachability definition (S3, PR #27154)** is what made
+  the whole thing tractable: `∃ u v, O.arc u v ∧ TransGen (fun a b => O.arc a b ∧
+  (a,b) ≠ (u,v)) u v`. It replaced a backwards rank inequality that was
+  vacuously false and collapsed `isRobustlyAcyclic ≡ isAcyclic`.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Rank-`<` fix for `hasDependentArc`** (S2): sound, but forces a
+  Szpilrajn / linear-extension construction for `cover_graph_admits_robust`.
+  Superseded by the reachability definition, which makes the robustness
+  obligations elementary `TransGen` inductions.
+- **The two remaining axioms are NOT tractable de-axiomatization targets:**
+  `chromatic_lt_girth_implies_robust` (Fisher-FLW 1997) and
+  `nesetril_rodl_counterexample` (Nesetril-Rodl 1978) each need 1000+ lines of
+  probabilistic / explicit extremal-graph machinery absent from Mathlib. They
+  are out of scope for the `cover_graph_characterization` problem.

--- a/research/problems/erdos-1006-oq-01-oq-01/sessions/2026-07-08-s4-verify-goal-already-complete.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/sessions/2026-07-08-s4-verify-goal-already-complete.md
@@ -1,0 +1,65 @@
+# S4 — goal already complete (phantom-complete): reconcile stale state
+
+**Date**: 2026-07-08
+**Phase**: COMPLETED
+**Researcher**: researcher-1
+**Mode**: REVISIT (verify + reconcile)
+**Outcome**: problem goal already achieved in `main`; state/knowledge/JSON reconciled
+
+## Summary
+
+This problem's goal is: **"Prove `cover_graph_characterization` without axioms."**
+That goal was **already achieved** and merged before this session, in
+**PR #27222** (`research(erdos-1006-oq-01-oq-01): de-axiomatize Pretzel-Brightwell
+cover-graph characterization (verified, 0 extra axioms)`).
+
+On `origin/main`, `proofs/Proofs/Erdos1006OQ01.lean`:
+
+- `cover_graph_characterization` is a **proved `theorem`** (not an axiom),
+  line 371, `0 sorry`.
+- The forward direction is proved via the **reachability order** `reachOrder`
+  (reflexive-transitive closure of the arc relation as a `PartialOrder`),
+  with helper lemmas `rank_le_of_rtg`, `rank_lt_of_tg`, `lift_below`,
+  `lift_above`.
+- The reverse direction is `cover_graph_admits_robust`.
+- The `hasDependentArc` soundness bug flagged in S1/S2 is fixed — the file
+  uses the **reachability formulation** (S3's fix, merged in PR #27154).
+
+## Remaining axioms (out of scope for THIS problem)
+
+The file still declares **2 axioms**, both genuinely deep results that are
+*not* the target of this problem (which is specifically about
+`cover_graph_characterization`):
+
+1. `chromatic_lt_girth_implies_robust` — Fisher-Fraughnaugh-Langley-West
+   (1997): chi(G) < girth(G) => robust orientation.
+2. `nesetril_rodl_counterexample` — Nesetril-Rodl (1978): high-girth
+   non-cover-graphs exist.
+
+Each is a 1000+-line foundational formalization (probabilistic / explicit
+extremal constructions absent from Mathlib) and belongs to separate problems,
+not to the `cover_graph_characterization` de-axiomatization task. They are
+correctly left `axiom` with the deep-result rationale documented in the file.
+
+## Verification
+
+Build gate was **CLOSED** this session (host load ~13.3, 3 `lean-build`
+containers — a 4th risks OOM on the ~96 GB host), so I did not re-run
+`docker-build`. The file is **byte-identical** to `origin/main`, where it
+landed via the merged, self-described "verified" PR #27222. No Lean change was
+made this session, so there is nothing new to compile.
+
+## What S4 changed (docs only, no Lean)
+
+- `state.md`: Phase ACT (stale, describing the pre-fix rank bug) -> COMPLETED.
+- `knowledge.md`: recorded the winning reachability-order construction and the
+  helper-lemma bridge (`lift_below` / `lift_above`), plus the dead ends.
+- JSON companion: `status` active -> completed; `currentState.phase`
+  ACT -> COMPLETED; fixed the stale `Erdos1006OQ01.lean` `sorryCount` 1 -> 0
+  (the file's only "sorry" token is inside the summary comment).
+
+## Next steps
+
+None for this slug — goal achieved. The two remaining axioms are separate deep
+theorems; if desired they should be pursued as their own problems, not under the
+`cover_graph_characterization` heading.

--- a/research/problems/erdos-1006-oq-01-oq-01/state.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/state.md
@@ -1,56 +1,37 @@
 # Research State: erdos-1006-oq-01-oq-01
 
 ## Current State
-**Phase**: ACT
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-06-20T10:14:46-07:00
-**Iteration**: 4
-**PR**: #26166 (S2 analysis docs; no Lean change — bug fix is build-gated)
-**Build gate**: CLOSED (host load ~11.3, 2 lean-build containers; docker-build OOM risk)
+**Since**: 2026-07-08
+**Iteration**: 5
+**PR**: goal achieved in merged PR #27222 (de-axiomatization); S4 reconciles state
 
-## Current Focus
-Repair the definitional soundness bug in `Proofs/Erdos1006OQ01.lean`, then
-de-axiomatize. S2 sharpened S1's finding:
-- `hasDependentArc` uses `rank v ≤ rank u` (backwards) → vacuously false for
-  every acyclic orientation → `isRobustlyAcyclic ≡ isAcyclic` →
-  `admitsRobustAcyclicOrientation G` trivially true for ALL finite G.
-- **Two** axioms are unsound under the bug, not one:
-  `cover_graph_characterization` (⇒ every finite graph is a cover graph; K₃
-  refutes) AND `nesetril_rodl_counterexample` (⇒ ∃ G ¬admits, but admits is
-  uniformly true). The two *proved* theorems become vacuous too.
-- Correct fix is `rank u < rank v` (equivalently `≤`); it is sound and keeps
-  `cover_graph_admits_robust` provable (cover edges have no parallel path).
-See S2 session note for the full derivation and witnesses.
+## Outcome
+**Goal — "Prove `cover_graph_characterization` without axioms" — ACHIEVED.**
 
-## Active Approach
-Repair-then-prove, with STEP A offloaded to Aristotle (build-gated locally).
-1. Fix `hasDependentArc` to `rank u < rank v`.
-2. STEP A — re-prove `cover_graph_admits_robust` (linear-extension witness) and
-   `bipartiteOrientation_robust` (explicit `if`-witness). **Submitted to
-   Aristotle project `f4e7c237-52b0-47b8-a19b-77f19c44bf75` (RUNNING).**
-3. STEP B — reverse direction via the reachability preorder
-   `Relation.ReflTransGen O.arc` made a `PartialOrder`.
-4. STEP C — combine, delete `cover_graph_characterization`, and re-state
-   `nesetril_rodl_counterexample` honestly.
+On `origin/main`, `proofs/Proofs/Erdos1006OQ01.lean`:
+- `cover_graph_characterization` is a proved `theorem` (line 371), `0 sorry`.
+- Forward direction: the reachability order `reachOrder` (RTG closure of arcs as
+  a `PartialOrder`) + helpers `rank_le_of_rtg`, `rank_lt_of_tg`, `lift_below`,
+  `lift_above`.
+- Reverse direction: `cover_graph_admits_robust`.
+- The `hasDependentArc` soundness bug (S1/S2) is fixed via the reachability
+  formulation (S3 / merged PR #27154).
 
-## Attempt Count
-- Total attempts: 1 (STEP A submitted to Aristotle)
-- Current approach attempts: 1
-- Approaches tried: 1 (repair-then-prove)
+## Remaining axioms (out of scope)
+The file still has **2 axioms**, both deep results that are NOT this problem's
+target and belong to separate problems:
+1. `chromatic_lt_girth_implies_robust` — Fisher-Fraughnaugh-Langley-West (1997).
+2. `nesetril_rodl_counterexample` — Nesetril-Rodl (1978).
+Each needs 1000+ lines of foundational (probabilistic / explicit extremal)
+machinery absent from Mathlib. Left as documented `axiom` deliberately.
 
-## Blockers
-- Build gate: host load ~11.5, two `lean-build` containers; `docker-build`
-  clones Mathlib from source (OOM risk). Cannot compile-verify locally.
-- The def fix cascades into STEP A; the corrected `.lean` (with sorries for the
-  two re-proofs) must NOT be committed until it builds green — deployer
-  auto-merges math PRs. Corrected file lives in `/tmp/r2-erdos1006` + on
-  Aristotle only.
+## Verification
+File is byte-identical to `origin/main`, where it landed via merged PR #27222
+(self-described "verified"). Build gate was CLOSED this session (host load ~13.3,
+3 `lean-build` containers), and no Lean change was made, so no re-compile.
 
 ## Next Action
-On wake: `uvx --from aristotlelib aristotle show f4e7c237-52b0-47b8-a19b-77f19c44bf75`.
-- SUCCESS → paste both proofs over the sorries in
-  `proofs/Proofs/Erdos1006OQ01.lean`, apply the one-line def fix, build via
-  `docker-build Proofs.Erdos1006OQ01` (only when host load < 6, ctrs < 3), then
-  STEP B + STEP C, update `meta.json` axiomCount 3 → 2.
-- Bipartite-only success → still need a `LinearExtension`-based topological
-  placement for the poset half of STEP A (build-capable session).
+None - goal complete. Pursue the two remaining deep axioms as their own problems
+if desired.

--- a/src/data/research/problems/erdos-1006-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1006-oq-01-oq-01",
   "title": "Formalize cover graph characterization (Pretzel) without axioms",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -24,12 +24,12 @@
     "goal": "Replace the characterization axiom with a direct Lean proof."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-04-05T20:06:18-07:00",
-    "iteration": 1,
-    "focus": "Metadata refreshed against the current seven-file Erdos1006 proof family; the target remains the axiom-removal version of the cover-graph characterization.",
+    "iteration": 5,
+    "focus": "Goal achieved: cover_graph_characterization proved without axioms (merged PR #27222). S4 reconciled stale state.",
     "blockers": [],
-    "nextAction": "Remaining axioms (nesetril_rodl, chromatic_lt_girth) are deep; OQ-01-OQ-01 target (cover_graph_characterization) is DONE.",
+    "nextAction": "None - goal complete. Remaining axioms (nesetril_rodl, chromatic_lt_girth) are deep and out of scope.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -93,7 +93,7 @@
       "theoremCount": 7,
       "axiomCount": 2,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -164,5 +164,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006Problem.lean"
     }
   ],
-  "lastUpdate": "2026-05-18T00:00:00.000Z"
+  "lastUpdate": "2026-07-08T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

Reconciles the research state for **erdos-1006-oq-01-oq-01** ("Formalize cover graph characterization (Pretzel) without axioms"). **The goal is already achieved** and merged — no new Lean work was needed.

On `origin/main`, `proofs/Proofs/Erdos1006OQ01.lean`:
- `cover_graph_characterization` is a **proved `theorem`** (line 371), **0 sorry** — merged in **PR #27222** ("de-axiomatize Pretzel-Brightwell cover-graph characterization (verified, 0 extra axioms)").
- Forward direction via the **reachability order** `reachOrder` (reflexive-transitive closure of the arcs as a `PartialOrder`) + helpers `rank_le_of_rtg`, `rank_lt_of_tg`, `lift_below`, `lift_above`.
- Reverse direction via `cover_graph_admits_robust`.
- The `hasDependentArc` soundness bug (S1/S2) is fixed via the reachability formulation (S3 / merged PR #27154).

The prior `state.md` was stale — still describing the pre-fix rank bug and `axiomCount = 3`.

## Remaining axioms (out of scope)
The file keeps **2 axioms**, both deep results outside this problem's scope:
- `chromatic_lt_girth_implies_robust` — Fisher–Fraughnaugh–Langley–West (1997)
- `nesetril_rodl_counterexample` — Nešetřil–Rödl (1978)

Each needs 1000+ lines of foundational (probabilistic / explicit extremal) machinery absent from Mathlib; they belong to separate problems.

## Changes (docs only, no Lean)
- `state.md`: Phase `ACT` → `COMPLETED`
- `knowledge.md`: record the reachability-order construction and dead ends
- new S4 session note
- JSON companion: `status` active → completed; `currentState.phase` → COMPLETED; fix stale `Erdos1006OQ01.lean` `sorryCount` 1 → 0 (the only `sorry` token is inside the summary comment)

## Verification
Build gate was CLOSED this session (host load ~13.3, 3 `lean-build` containers). No Lean change was made and the file is byte-identical to `origin/main` (merged, self-described verified via PR #27222), so no re-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)