### PR TITLE
research(lp-duality): verified Folland-6.16 maximality assembly — arbitrary-measure Riesz reduction [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualityMaximal.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualityMaximal.lean
@@ -1,0 +1,240 @@
+import Mathlib
+import Proofs.CauchySchwarzIntegralLpDualityIngredients
+import Proofs.CauchySchwarzIntegralLpDualityConsistency
+import Proofs.CauchySchwarzIntegralLpDualityGluing
+import Proofs.CauchySchwarzIntegralLpDualityExtension
+
+open MeasureTheory ENNReal
+noncomputable section
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+namespace RieszLpDualityMaximal
+
+/-- **General-measure Riesz reduction (abstract form).**
+
+    Given, for a fixed functional `φ`, an abstract extension-by-zero family `ext`
+    with its coeFn characterisation, the σ-finite Riesz theorem *with the norm bound*
+    (`Hσ`), and the five already-verified Mathlib-only ingredient facts
+    (representer monotonicity `Hmono`, representer consistency `Hcons`, σ-finiteness of a
+    countable union `HsigU`, and the gluing/vanishing lemma `Hglue`), the arbitrary-measure
+    Riesz representation holds.  This is the Folland (2nd ed.) Theorem 6.16 maximising-hull
+    construction: form `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` over σ-finite-restricted sets, realise it on
+    a countable union hull `T`, and for each `f` glue on `U = T ∪ supp f`. -/
+theorem riesz_general
+    {p q : ℝ≥0∞} (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)]
+    (φ : Lp ℝ p μ →L[ℝ] ℝ)
+    (ext : ∀ (S : Set α), MeasurableSet S → (Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ))
+    (hext : ∀ (S : Set α) (hS : MeasurableSet S) (f : Lp ℝ p (μ.restrict S)),
+      (ext S hS f : α → ℝ) =ᵐ[μ] S.indicator (f : α → ℝ))
+    (Hσ : ∀ (S : Set α) (hS : MeasurableSet S), SigmaFinite (μ.restrict S) →
+      ∃ g : α → ℝ, MemLp g q (μ.restrict S) ∧
+        eLpNorm g q (μ.restrict S) ≤ ENNReal.ofReal ‖φ‖ ∧
+        ∀ f : Lp ℝ p (μ.restrict S),
+          φ (ext S hS f) = ∫ a, (f : α → ℝ) a * g a ∂(μ.restrict S))
+    (Hmono : ∀ {S S' : Set α} (hS : MeasurableSet S) (hS' : MeasurableSet S'), S ⊆ S' →
+      ∀ {gS gS' : α → ℝ}, MemLp gS q (μ.restrict S) → MemLp gS' q (μ.restrict S') →
+        (∀ f : Lp ℝ p (μ.restrict S), φ (ext S hS f) = ∫ a, (f : α → ℝ) a * gS a ∂(μ.restrict S)) →
+        (∀ f : Lp ℝ p (μ.restrict S'), φ (ext S' hS' f) = ∫ a, (f : α → ℝ) a * gS' a ∂(μ.restrict S')) →
+        eLpNorm gS q (μ.restrict S) ≤ eLpNorm gS' q (μ.restrict S'))
+    (Hcons : ∀ {S S' : Set α} (hS : MeasurableSet S) (hS' : MeasurableSet S'), S ⊆ S' →
+      ∀ {gS gS' : α → ℝ}, MemLp gS q (μ.restrict S) → MemLp gS' q (μ.restrict S') →
+        (∀ f : Lp ℝ p (μ.restrict S), φ (ext S hS f) = ∫ a, (f : α → ℝ) a * gS a ∂(μ.restrict S)) →
+        (∀ f : Lp ℝ p (μ.restrict S'), φ (ext S' hS' f) = ∫ a, (f : α → ℝ) a * gS' a ∂(μ.restrict S')) →
+        gS =ᵐ[μ.restrict S] gS')
+    (HsigU : ∀ (S : ℕ → Set α), (∀ n, MeasurableSet (S n)) →
+      (∀ n, SigmaFinite (μ.restrict (S n))) → SigmaFinite (μ.restrict (⋃ n, S n)))
+    (Hglue : ∀ {g : α → ℝ} {T U : Set α}, MeasurableSet T → MeasurableSet U → T ⊆ U →
+      q ≠ 0 → q ≠ ∞ → MemLp g q (μ.restrict U) →
+      eLpNorm g q (μ.restrict U) ≤ eLpNorm g q (μ.restrict T) →
+      g =ᵐ[μ.restrict (U \ T)] 0) :
+    ∃ g : α → ℝ, MemLp g q μ ∧
+      ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
+  have hp0 : p ≠ 0 := (lt_of_lt_of_le zero_lt_one hp1.le).ne'
+  have hqtr : (1:ℝ) < q.toReal := (Real.holderConjugate_iff.mp hpq.symm).1
+  have hq0 : q ≠ 0 := by rintro rfl; simp only [ENNReal.toReal_zero] at hqtr; linarith
+  have hqtop : q ≠ ∞ := by rintro rfl; simp only [ENNReal.toReal_top] at hqtr; linarith
+  set A : Set ℝ := {r | ∃ (S : Set α) (hS : MeasurableSet S), SigmaFinite (μ.restrict S) ∧
+      ∃ g : α → ℝ, MemLp g q (μ.restrict S) ∧
+        eLpNorm g q (μ.restrict S) ≤ ENNReal.ofReal ‖φ‖ ∧
+        (∀ f : Lp ℝ p (μ.restrict S), φ (ext S hS f) = ∫ a, (f : α → ℝ) a * g a ∂(μ.restrict S)) ∧
+        (eLpNorm g q (μ.restrict S)).toReal = r} with hA_def
+  have hAne : A.Nonempty := by
+    obtain ⟨g0, hg0, hg0b, hg0r⟩ := Hσ ∅ MeasurableSet.empty (by
+      rw [Measure.restrict_empty]; infer_instance)
+    exact ⟨_, ∅, MeasurableSet.empty, (by rw [Measure.restrict_empty]; infer_instance),
+      g0, hg0, hg0b, hg0r, rfl⟩
+  have hAbdd : BddAbove A := by
+    refine ⟨‖φ‖, ?_⟩
+    rintro r ⟨S, hS, hSσ, g, hg, hgb, hgr, rfl⟩
+    have hfin : eLpNorm g q (μ.restrict S) ≠ ⊤ :=
+      ne_top_of_le_ne_top ENNReal.ofReal_ne_top hgb
+    calc (eLpNorm g q (μ.restrict S)).toReal
+        ≤ (ENNReal.ofReal ‖φ‖).toReal := (ENNReal.toReal_le_toReal hfin ENNReal.ofReal_ne_top).mpr hgb
+      _ = ‖φ‖ := ENNReal.toReal_ofReal (norm_nonneg _)
+  set c : ℝ := sSup A with hc_def
+  have hstep : ∀ n : ℕ, ∃ (S : Set α) (hS : MeasurableSet S), SigmaFinite (μ.restrict S) ∧
+      ∃ g : α → ℝ, MemLp g q (μ.restrict S) ∧
+        eLpNorm g q (μ.restrict S) ≤ ENNReal.ofReal ‖φ‖ ∧
+        (∀ f : Lp ℝ p (μ.restrict S), φ (ext S hS f) = ∫ a, (f : α → ℝ) a * g a ∂(μ.restrict S)) ∧
+        c - 1 / (n + 1 : ℝ) < (eLpNorm g q (μ.restrict S)).toReal := by
+    intro n
+    have hlt : c - 1 / (n + 1 : ℝ) < c := by
+      have : (0:ℝ) < 1 / (n + 1 : ℝ) := by positivity
+      linarith
+    obtain ⟨a, haA, hca⟩ := exists_lt_of_lt_csSup hAne hlt
+    obtain ⟨S, hS, hSσ, g, hg, hgb, hgr, hgeq⟩ := haA
+    exact ⟨S, hS, hSσ, g, hg, hgb, hgr, by rw [hgeq]; exact hca⟩
+  choose Sq hSqm hSqσ gq hgqmem hgqb hgqrep hgqapx using hstep
+  set T : Set α := ⋃ n, Sq n with hT_def
+  have hTm : MeasurableSet T := MeasurableSet.iUnion hSqm
+  have hTσ : SigmaFinite (μ.restrict T) := HsigU Sq hSqm hSqσ
+  obtain ⟨gT, hgTmem, hgTb, hgTrep⟩ := Hσ T hTm hTσ
+  have hgT_fin : eLpNorm gT q (μ.restrict T) ≠ ⊤ :=
+    ne_top_of_le_ne_top ENNReal.ofReal_ne_top hgTb
+  have hgT_le_c : (eLpNorm gT q (μ.restrict T)).toReal ≤ c :=
+    le_csSup hAbdd ⟨T, hTm, hTσ, gT, hgTmem, hgTb, hgTrep, rfl⟩
+  have hc_le_gT : c ≤ (eLpNorm gT q (μ.restrict T)).toReal := by
+    apply le_of_forall_pos_lt_add
+    intro ε hε
+    obtain ⟨n, hn⟩ := exists_nat_one_div_lt hε
+    have hsub : Sq n ⊆ T := Set.subset_iUnion Sq n
+    have hmono : eLpNorm (gq n) q (μ.restrict (Sq n)) ≤ eLpNorm gT q (μ.restrict T) :=
+      Hmono (hSqm n) hTm hsub (hgqmem n) hgTmem (hgqrep n) hgTrep
+    have hgqfin : eLpNorm (gq n) q (μ.restrict (Sq n)) ≠ ⊤ :=
+      ne_top_of_le_ne_top ENNReal.ofReal_ne_top (hgqb n)
+    have hmono' : (eLpNorm (gq n) q (μ.restrict (Sq n))).toReal
+        ≤ (eLpNorm gT q (μ.restrict T)).toReal :=
+      (ENNReal.toReal_le_toReal hgqfin hgT_fin).mpr hmono
+    have hax := hgqapx n
+    linarith
+  have hNT : (eLpNorm gT q (μ.restrict T)).toReal = c := le_antisymm hgT_le_c hc_le_gT
+  refine ⟨T.indicator gT, (memLp_indicator_iff_restrict hTm).mpr hgTmem, ?_⟩
+  intro f
+  obtain ⟨Sf, hSfm, hf_ae, hSfσ⟩ :=
+    ((Lp.memLp f).aefinStronglyMeasurable hp0 hptop).exists_set_sigmaFinite
+  set U : Set α := T ∪ Sf with hU_def
+  have hUm : MeasurableSet U := hTm.union hSfm
+  haveI : SigmaFinite (μ.restrict T) := hTσ
+  haveI : SigmaFinite (μ.restrict Sf) := hSfσ
+  have hUσ : SigmaFinite (μ.restrict U) := inferInstance
+  obtain ⟨gU, hgUmem, hgUb, hgUrep⟩ := Hσ U hUm hUσ
+  have hgU_fin : eLpNorm gU q (μ.restrict U) ≠ ⊤ := ne_top_of_le_ne_top ENNReal.ofReal_ne_top hgUb
+  have hTU : T ⊆ U := Set.subset_union_left
+  have hcons : gT =ᵐ[μ.restrict T] gU := Hcons hTm hUm hTU hgTmem hgUmem hgTrep hgUrep
+  have hnormT : eLpNorm gU q (μ.restrict T) = eLpNorm gT q (μ.restrict T) :=
+    eLpNorm_congr_ae hcons.symm
+  have hgUT_fin : eLpNorm gU q (μ.restrict T) ≠ ⊤ := by rw [hnormT]; exact hgT_fin
+  have hgU_le_c : (eLpNorm gU q (μ.restrict U)).toReal ≤ c :=
+    le_csSup hAbdd ⟨U, hUm, hUσ, gU, hgUmem, hgUb, hgUrep, rfl⟩
+  have hle : eLpNorm gU q (μ.restrict U) ≤ eLpNorm gU q (μ.restrict T) := by
+    apply (ENNReal.toReal_le_toReal hgU_fin hgUT_fin).mp
+    rw [hnormT, hNT]; exact hgU_le_c
+  have hglue : gU =ᵐ[μ.restrict (U \ T)] 0 := Hglue hTm hUm hTU hq0 hqtop hgUmem hle
+  have hfU_mem : MemLp (f : α → ℝ) p (μ.restrict U) := (Lp.memLp f).restrict U
+  set fU : Lp ℝ p (μ.restrict U) := hfU_mem.toLp _ with hfU_def
+  have hfU_coe : (fU : α → ℝ) =ᵐ[μ.restrict U] (f : α → ℝ) := hfU_mem.coeFn_toLp
+  have hextU_eq : ext U hUm fU = f := by
+    apply Lp.ext
+    have h1 : (ext U hUm fU : α → ℝ) =ᵐ[μ] U.indicator (fU : α → ℝ) := hext U hUm fU
+    have h2 : U.indicator (fU : α → ℝ) =ᵐ[μ] U.indicator (f : α → ℝ) :=
+      (ae_eq_restrict_iff_indicator_ae_eq hUm).mp hfU_coe
+    have hf_aeU : (f : α → ℝ) =ᵐ[μ.restrict Uᶜ] 0 := by
+      have hsub : Uᶜ ⊆ Sfᶜ := Set.compl_subset_compl.mpr Set.subset_union_right
+      exact ae_mono (Measure.restrict_mono hsub le_rfl) hf_ae
+    have h3 : U.indicator (f : α → ℝ) =ᵐ[μ] (f : α → ℝ) :=
+      indicator_ae_eq_of_restrict_compl_ae_eq_zero hUm hf_aeU
+    exact (h1.trans h2).trans h3
+  have hrep : φ f = ∫ a, (fU : α → ℝ) a * gU a ∂(μ.restrict U) := by
+    rw [← hextU_eq]; exact hgUrep fU
+  have hrep2 : φ f = ∫ a, (f : α → ℝ) a * gU a ∂(μ.restrict U) := by
+    rw [hrep]; exact integral_congr_ae (hfU_coe.mono fun a ha => by simp only [ha])
+  haveI hHolder : ENNReal.HolderConjugate p q := by
+    rw [ENNReal.holderConjugate_iff]
+    have hpinv : p⁻¹ ≠ ⊤ := ENNReal.inv_ne_top.mpr hp0
+    have hqinv : q⁻¹ ≠ ⊤ := ENNReal.inv_ne_top.mpr hq0
+    have key : (p⁻¹ + q⁻¹).toReal = (1 : ℝ≥0∞).toReal := by
+      rw [ENNReal.toReal_add hpinv hqinv, ENNReal.toReal_inv, ENNReal.toReal_inv,
+          ENNReal.toReal_one]
+      exact hpq.inv_add_inv_eq_one
+    have hsum : p⁻¹ + q⁻¹ ≠ ⊤ := by finiteness
+    exact (ENNReal.toReal_eq_toReal_iff' hsum (by simp)).mp key
+  have hint : Integrable (fun a => (f : α → ℝ) a * gU a) (μ.restrict U) :=
+    hfU_mem.integrable_mul hgUmem
+  have hsplit := (integral_add_compl hTm hint).symm
+  have hcompl0 : ∫ a in Tᶜ, (f : α → ℝ) a * gU a ∂(μ.restrict U) = 0 := by
+    rw [Measure.restrict_restrict hTm.compl]
+    have hset : Tᶜ ∩ U = U \ T := by rw [Set.inter_comm, Set.diff_eq]
+    rw [hset]
+    apply integral_eq_zero_of_ae
+    filter_upwards [hglue] with a ha
+    simp [ha]
+  have hTint : ∫ a in T, (f : α → ℝ) a * gU a ∂(μ.restrict U)
+      = ∫ a, (f : α → ℝ) a * gT a ∂(μ.restrict T) := by
+    rw [Measure.restrict_restrict hTm, Set.inter_eq_left.mpr hTU]
+    apply integral_congr_ae
+    filter_upwards [hcons] with a ha
+    rw [ha]
+  rw [hrep2, hsplit, hcompl0, add_zero, hTint]
+  have hind : ∀ a, (f : α → ℝ) a * (T.indicator gT) a
+      = T.indicator (fun x => (f : α → ℝ) x * gT x) a := by
+    intro a; by_cases h : a ∈ T <;>
+      simp [Set.indicator_of_mem, Set.indicator_of_notMem, h]
+  simp_rw [hind]
+  exact (integral_indicator hTm).symm
+
+/-- **General-measure Riesz reduction (concrete form).**  Discharges the abstract
+    reduction using the concrete Mathlib-only ingredients (`extByZeroCLM`, representer
+    consistency/monotonicity, countable-union σ-finiteness, gluing).  Takes only the
+    σ-finite Riesz theorem *with the norm bound* (`Hσ`) as a hypothesis — exactly the
+    output of `RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set` (modulo the
+    extension-map used to state the pullback).  Wiring this to the σ-finite chain
+    discharges the `riesz_lp_surjective` axiom. -/
+theorem riesz_general_of_sigmaFinite
+    {p q : ℝ≥0∞} (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)]
+    (φ : Lp ℝ p μ →L[ℝ] ℝ)
+    (Hσ : ∀ (S : Set α) (hS : MeasurableSet S), SigmaFinite (μ.restrict S) →
+      ∃ g : α → ℝ, MemLp g q (μ.restrict S) ∧
+        eLpNorm g q (μ.restrict S) ≤ ENNReal.ofReal ‖φ‖ ∧
+        ∀ f : Lp ℝ p (μ.restrict S),
+          φ (RieszLpDualityExtension.extByZeroCLM hS
+              (lt_of_lt_of_le zero_lt_one hp1.le).ne' hptop f)
+            = ∫ a, (f : α → ℝ) a * g a ∂(μ.restrict S)) :
+    ∃ g : α → ℝ, MemLp g q μ ∧
+      ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
+  have hp0 : p ≠ 0 := (lt_of_lt_of_le zero_lt_one hp1.le).ne'
+  refine riesz_general hp1 hptop hpq φ
+    (fun S hS => RieszLpDualityExtension.extByZeroCLM hS hp0 hptop)
+    (fun S hS f => RieszLpDualityExtension.extByZeroCLM_coeFn hS hp0 hptop f)
+    Hσ ?_ ?_ ?_ ?_
+  · -- Hmono
+    intro S S' hS hS' hSS' gS gS' hgS hgS' hrepS hrepS'
+    exact RieszLpDualityConsistency.representer_eLpNorm_mono_of_subset hpq hS hS' hSS' φ
+      hgS hgS'
+      (RieszLpDualityExtension.extByZeroCLM hS hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM_coeFn hS hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM hS' hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM_coeFn hS' hp0 hptop)
+      hrepS hrepS'
+  · -- Hcons
+    intro S S' hS hS' hSS' gS gS' hgS hgS' hrepS hrepS'
+    exact RieszLpDualityConsistency.representer_ae_eq_of_subset hpq hS hS' hSS' φ
+      hgS hgS'
+      (RieszLpDualityExtension.extByZeroCLM hS hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM_coeFn hS hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM hS' hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM_coeFn hS' hp0 hptop)
+      hrepS hrepS'
+  · -- HsigU
+    exact fun S hSm hSσ => RieszLpDualityIngredients.sigmaFinite_restrict_iUnion hSm hSσ
+  · -- Hglue
+    exact fun hT hU hTU hq0 hqtop hg hle =>
+      RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le hT hU hTU hq0 hqtop hg hle
+
+end RieszLpDualityMaximal
+
+end
+
+#print axioms RieszLpDualityMaximal.riesz_general
+#print axioms RieszLpDualityMaximal.riesz_general_of_sigmaFinite

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -1297,3 +1297,63 @@ reduction eliminate the `riesz_lp_surjective` axiom in `CauchySchwarzIntegralOQ0
 pass is still the right tool there (each Docker verify is minutes). No axiom eliminated this
 session; no code committed (the sum-bound file builds up to the one gap above and was not
 shipped to avoid a non-building file).
+
+### 2026-07-08 (Session 25, researcher-4) — MAXIMALITY ASSEMBLY VERIFIED: the 200-line Folland-6.16 `sorry` is discharged as a standalone 0-axiom file (PR #35433)
+
+**Mode:** ACT. **Outcome:** the single remaining *analytic* content of the whole strand —
+the arbitrary-measure Riesz maximising-hull construction — is now written and VERIFIED,
+0-sorry/0-axiom, host `lake env lean`. This is the step every prior session (S5/S7/S10
+explicitly) deferred as the "write-it-blind trap." It is no longer a trap because a host
+verifier was available and the proof was built incrementally against it.
+
+**Key infra unlock (host verifier, no Docker):** `cd proofs && lake exe cache get` unpacks
+the 7727 local `~/.cache/mathlib/*.ltar` into the mathlib package build dir in ~26 s
+(unpack-only, NOT a from-source rebuild) → `LAKE_UNSAFE=1 ./bin/lake env lean <file>` then
+compiles any `import Mathlib` file in ~1–2 min. For files importing the Mathlib-only
+ingredient `Proofs.*` (Consistency/Gluing/Ingredients/Extension — all `import Mathlib` only,
+verified this session), build their oleans with
+`lake env bash -c 'LEAN_PATH="/tmp/ol:$LEAN_PATH" lean Proofs/X.lean -o /tmp/ol/Proofs/X.olean'`
+in dependency order (Ingredients→Gluing), then compile the new file with the same
+`LEAN_PATH` prepend. This gives FULL host verification of a concrete ingredient-importing
+file **without Docker** — the trick that unblocks all Mathlib-only strand work under memory
+pressure.
+
+**Shipped (PR #35433):** `proofs/Proofs/CauchySchwarzIntegralLpDualityMaximal.lean`
+(namespace `RieszLpDualityMaximal`, imports Mathlib + the 4 Mathlib-only ingredient files):
+- `riesz_general` (abstract, ext-agnostic): the full Folland Thm 6.16 argument. Real-valued
+  sup `A = {(eLpNorm g_S q (μ|S)).toReal | admissible S}`, `c = sSup A ≤ ‖φ‖`
+  (`exists_lt_of_lt_csSup` maximizing seq + `le_of_forall_pos_lt_add` +
+  `exists_nat_one_div_lt` to pin `‖g_T‖.toReal = c` on the hull `T = ⋃ₙ Sₙ`); per-`f`
+  gluing on `U = T ∪ supp f` via `integral_add_compl hTm` splitting `∫_{μ|U}` into T and Tᶜ,
+  the Tᶜ piece killed by the gluing lemma, the T piece rewritten by consistency, then
+  `integral_indicator` to land the global `g = T.indicator g_T`.
+- `riesz_general_of_sigmaFinite` (concrete): applies `riesz_general` with the real
+  ingredients; takes only the σ-finite Riesz-with-bound `Hσ` as hypothesis.
+Both `#print axioms` = {propext, Classical.choice, Quot.sound}.
+
+**Mathlib v4.26 API notes (this session):**
+- `MemLp.integrable_mul (hf)(hg) [HolderTriple p q 1] : Integrable (f*g)` — needs the
+  ℝ≥0∞ `HolderConjugate` instance. Build it from the *real* conjugate via
+  `ENNReal.holderConjugate_iff` (`↔ p⁻¹+q⁻¹=1`) + `toReal_add`/`toReal_inv` and
+  `hpq.inv_add_inv_eq_one`; get `1 < q.toReal` from `(Real.holderConjugate_iff.mp hpq.symm).1`.
+- `(memLp_indicator_iff_restrict hS).mpr : MemLp g q (μ|S) → MemLp (S.indicator g) q μ` —
+  the global-representer membership (pure Mathlib; no chain lemma needed).
+- `exists_set_sigmaFinite` = `((Lp.memLp f).aefinStronglyMeasurable hp0 hptop).exists_set_sigmaFinite`
+  gives the σ-finite support inline (no need to import SigmaFiniteSupport).
+- `ae_eq_restrict_iff_indicator_ae_eq hs` (lift `=ᵐ[μ|s]` to `s.indicator =ᵐ[μ]`);
+  `indicator_ae_eq_of_restrict_compl_ae_eq_zero hs` (`f=ᵐ0 off s ⟹ f =ᵐ s.indicator f`).
+- `integral_add_compl hs hint`; `setIntegral_union`; `Measure.restrict_restrict hs`
+  (`(μ|t)|s = μ|(s∩t)`); `ENNReal.toReal_eq_toReal_iff'` (replaces deprecated `toReal_eq_toReal`).
+- Beta-redex gotcha: after `EventuallyEq.mono`, the pointwise goal is unreduced
+  `(fun a=>…) a = (fun a=>…) a` → use `simp only [ha]` (beta-reduces) not `rw [ha]`.
+  Higher-order `rw [integral_indicator]` on the indicator RHS fails to match → use
+  `exact (integral_indicator hTm).symm`.
+
+**Axiom NOT yet eliminated (one Docker build away).** The final step is chain-ext wiring in
+the Synthesis file: `riesz_general` is ext-agnostic, so apply it with the CHAIN's
+`extByZeroCLM` (no ext-swap) + the ingredient lemmas + `riesz_representer_on_sigmaFinite_set`
+as `Hσ`, discharging `riesz_lp_surjective_general`'s `sorry`; then swap the parent axiom.
+Docker-gated because Synthesis imports the σ-finite chain. NOT attempted this session:
+swap free ~1.5 GB / RAM free ~1.7 GB / 2 concurrent lean-build = the S21/S22 SIGBUS
+signature; a 3rd heavy chain build would OOM. See state.md "Next Action" for the exact
+wiring recipe + the two-`extByZeroCLM`-arity caveat to resolve.

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/state.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/state.md
@@ -1,34 +1,81 @@
 # Research State: cauchy-schwarz-integral-lp-duality-synthesis
 
 ## Current State
-**Phase**: ACT (axiom-elimination reduction, one measure-theory gap from a new brick)
+**Phase**: ACT (maximality assembly VERIFIED — one chain-ext wiring build from axiom elimination)
 **Path**: full
-**Since**: 2026-07-07
-**Iteration**: 24
+**Since**: 2026-07-08
+**Iteration**: 25
 
 ## Current Focus
-Eliminate the `riesz_lp_surjective` axiom (`CauchySchwarzIntegralOQ01OQ01OQ02.lean`) via the
-σ-finite-support reduction. Per-function step done (`…LpSigmaFiniteSupport.lean`, 0/0). This
-session (researcher-2, S24) targeted step (2) COMMON CARRIER: a countable union of
-σ-finite-restricted sets is σ-finite.
+The **last analytic content** — the Folland-6.16 arbitrary-measure Riesz maximality
+assembly — is now VERIFIED and shipped (PR #35433, S25). What remains to eliminate the
+`riesz_lp_surjective` axiom is a single **chain-ext wiring** step in the Synthesis file
+(Docker-gated).
 
-## Progress this session
-The clean **sum-bound** proof of `sigmaFinite_restrict_iUnion` compiles end-to-end in v4.26
-**except one line**: `μ.restrict (⋃ n, s n) ≤ Measure.sum (fun n => μ.restrict (s n))` type-checks
-and `Measure.sigmaFinite_of_le` applies, but instance resolution cannot find
-`SigmaFinite (Measure.sum fun n => μ.restrict (s n))` — i.e. the single missing fact is
-"a countable `Measure.sum` of σ-finite measures is σ-finite". See knowledge.md (S24) for the
-exact compiling snippet and the three next-step options (inferInstance retry / direct
-`FiniteSpanningSetsIn` diagonal with `Nat.unpair` + `MeasurableSet (s n)` / Aristotle).
+## Progress this session (S25, researcher-4)
+Wrote and host-verified the complete maximising-hull construction that 24 prior sessions
+deferred as the "write-it-blind trap":
+`proofs/Proofs/CauchySchwarzIntegralLpDualityMaximal.lean` (namespace
+`RieszLpDualityMaximal`), **0-sorry / 0-axiom** (`#print axioms` =
+{propext, Classical.choice, Quot.sound}), host `lake env lean` EXIT 0.
+- `riesz_general` (abstract): the full Folland (2nd ed.) Thm 6.16 argument — sup
+  `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` over σ-finite-restricted measurable `S`, realised on a
+  countable-union hull `T = ⋃ₙ Sₙ`, glued per test function on `U = T ∪ supp f`
+  (representer agrees with `g_T` on `T` by consistency, vanishes off `T` by gluing).
+  Takes the σ-finite Riesz-with-bound and the five ingredient lemmas as abstract
+  hypotheses ⇒ ext-agnostic, Mathlib-only.
+- `riesz_general_of_sigmaFinite` (concrete): wires the real Mathlib-only ingredients
+  (`extByZeroCLM`, `representer_{ae_eq,eLpNorm_mono}_of_subset`,
+  `sigmaFinite_restrict_iUnion`, `eLpNorm_ae_zero_on_diff_of_le`), taking only the
+  σ-finite Riesz theorem WITH norm bound as hypothesis = exactly
+  `riesz_representer_on_sigmaFinite_set`'s output.
+
+The file imports only Mathlib + the 4 Mathlib-only ingredient files (NOT the σ-finite
+chain), so it is a light build. Host-verified by building the 4 ingredient oleans with
+`lake env lean -o` into a temp `LEAN_PATH` dir and compiling against them.
 
 ## Blockers
-- **One measure-theory fact**: `SigmaFinite (Measure.sum m)` for countable σ-finite `m` — not
-  an available instance; needs a lemma or a `FiniteSpanningSetsIn` diagonal (~short).
-- **Parallel**: the `gseq_norm_bound` rpow-drift chain in `…Incomplete01Norm.lean` (~16
-  mechanical errors, S19 note) — fast-iteration / Aristotle territory.
+- **Final wiring is Docker-gated.** Discharging the Synthesis `sorry`
+  (`riesz_lp_surjective_general`, Synthesis.lean:375) by applying `riesz_general`
+  requires the Synthesis file, which imports the σ-finite chain (Incomplete01, the
+  memory monster). Host `lake env lean` cannot build chain-dependent files.
+- **Infra this session**: swap free ~1.5 GB, RAM free ~1.7 GB, 2 concurrent
+  `lean-build` — the S21/S22 SIGBUS signature. A 3rd heavy chain build was correctly
+  NOT launched (would OOM and destabilise the other two agents).
 
-## Next Action
-Close `SigmaFinite (Measure.sum m)` (one of the three routes in knowledge.md S24) → lands
-`sigmaFinite_restrict_iUnion` → step (2) done → steps (3)–(4) eliminate the axiom. No code
-shipped this session (the sum-bound file builds up to the one gap and was not committed to
-avoid a non-building file).
+## Next Action (Docker session, quiet infra)
+Discharge the axiom in ONE Docker build:
+1. In `CauchySchwarzIntegralLpDualitySynthesis.lean`, `import
+   Proofs.CauchySchwarzIntegralLpDualityMaximal`, and replace the `sorry` in
+   `riesz_lp_surjective_general` with (sketch):
+   ```
+   intro φ
+   refine RieszLpDualityMaximal.riesz_general hp1 hptop hpq φ
+     (fun S hS => RieszSigmaFiniteComplete.extByZeroCLM hS (lt_of_lt_of_le zero_lt_one hp1.le).ne' hptop)
+     (fun S hS f => <chain extByZeroCLM_coeFn>)          -- resolve the chain's coeFn lemma/arity
+     (fun S hS hSσ => riesz_representer_on_sigmaFinite_set hp1 hptop hpq hS hSσ φ)
+     ?Hmono ?Hcons ?HsigU ?Hglue
+   ```
+   `riesz_general` is **ext-agnostic**, so pass the CHAIN's `extByZeroCLM` here — NO
+   ext-swap needed. Discharge `?Hmono`/`?Hcons` with
+   `RieszLpDualityConsistency.representer_{eLpNorm_mono,ae_eq}_of_subset` (feeding the
+   chain ext + its coeFn), `?HsigU` with
+   `RieszLpDualityIngredients.sigmaFinite_restrict_iUnion`, `?Hglue` with
+   `RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le`.
+   NOTE: there appear to be TWO chain `extByZeroCLM` decls (Incomplete01OQ01
+   `extByZeroCLM_coeFn` takes `hS g`, 2 args; Synthesis line ~325 uses `hS (…).ne' hptop`,
+   3 args) — resolve which `RieszSigmaFiniteComplete.extByZeroCLM`/coeFn matches
+   `riesz_representer_on_sigmaFinite_set` before building.
+2. Then swap `axiom riesz_lp_surjective` → `theorem … := riesz_lp_surjective_general …`
+   in `CauchySchwarzIntegralOQ01OQ01OQ02.lean`, and update
+   `src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json`
+   (`axiomCount 1→0`, status/badge) iff green.
+
+## Ingredient inventory (all VERIFIED on main / this PR)
+- Maximality assembly: `RieszLpDualityMaximal.riesz_general{,_of_sigmaFinite}` (PR #35433).
+- `RieszLpDualityConsistency.representer_{ae_eq,eLpNorm_mono}_of_subset`.
+- `RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le`.
+- `RieszLpDualityIngredients.{sigmaFinite_restrict_iUnion, eLpNorm_rpow_restrict_*}`.
+- `RieszLpDualityExtension.extByZeroCLM{,_coeFn}`.
+- σ-finite Riesz WITH bound: `RieszSigmaFiniteComplete.riesz_lp_surjective_sigma_finite`
+  surfaced through `RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set`.


### PR DESCRIPTION
## Summary

Discharges the **last analytic content** gating elimination of the `riesz_lp_surjective` axiom in the Cauchy–Schwarz / Lᵖ-duality strand: the general-measure Riesz reduction (Folland, *Real Analysis* 2nd ed., Thm 6.16).

For 24 sessions this problem was "one ~200-line maximality `sorry` away" (`RieszLpDualitySynthesis.riesz_lp_surjective_general`, Synthesis.lean:375). Every prior attempt to write it was declined as the documented "write-it-blind trap." This PR writes and **verifies** that assembly.

## What's new — `CauchySchwarzIntegralLpDualityMaximal.lean` (Mathlib-only)

- **`riesz_general`** (abstract form): the full maximising-hull construction. Forms `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` over σ-finite-restricted measurable sets, realises it on a countable-union hull `T = ⋃ₙ Sₙ`, and for each test function `f` glues on `U = T ∪ supp f` (representer agrees with `g_T` on `T` by consistency, vanishes off `T` by the gluing lemma). Reduces arbitrary-measure Riesz to the σ-finite case plus the five already-verified ingredient lemmas (passed as abstract hypotheses).
- **`riesz_general_of_sigmaFinite`** (concrete form): wires the real Mathlib-only ingredients — `RieszLpDualityExtension.extByZeroCLM`, `RieszLpDualityConsistency.representer_{ae_eq,eLpNorm_mono}_of_subset`, `RieszLpDualityIngredients.sigmaFinite_restrict_iUnion`, `RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le` — taking **only** the σ-finite Riesz theorem *with the norm bound* as a hypothesis. That hypothesis is exactly the output of `RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set`.

## Verification

Host `lake env lean` → **EXIT 0**. `#print axioms` on both theorems = `{propext, Classical.choice, Quot.sound}` (no `sorryAx`, no `Lean.ofReduceBool`). Genuinely axiom-free.

The file imports only `Mathlib` + the 4 **Mathlib-only** ingredient files (not the heavy σ-finite chain), so CI/Docker builds it lightly.

## Impact

Turns the long-standing maximality `sorry` into a **one-line application**. The only remaining step to eliminate the `riesz_lp_surjective` axiom is the chain-ext wiring in the Synthesis file (Docker-gated, since it imports the σ-finite chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)