### PR TITLE
research(erdos-1093-oq-02): Section X — sharp factorial bound (k+deficiency)! ≤ (k!)² [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -381,3 +381,128 @@ theorem deficiency_pow_succ_le_factorial {n k : ℕ} (hn : 2 * k ≤ n)
   calc (k + 1) ^ deficiency n k = (k + 1) ^ S.card := by rw [hcard]
     _ ≤ P := hlow
     _ ≤ Nat.factorial k := hle
+
+/-
+## Section X: The sharp factorial bound `(k + deficiency)! ≤ (k!)²`
+
+Section IX only used that each smooth window value exceeds `k`, giving the crude
+lower bound `P ≥ (k+1)^{deficiency}`.  But the smooth window values are *distinct*
+integers (the map `i ↦ n - i` is injective on `i < k ≤ n`), so `P` is a product of
+`deficiency` **distinct** integers each `≥ k+1`.  The smallest such product is
+`(k+1)(k+2)⋯(k+d) = (k+1).ascFactorial d`, hence
+
+    `(k+1).ascFactorial (deficiency n k) ≤ P ≤ k!`.
+
+Multiplying by `k!` and using `k! · (k+1).ascFactorial d = (k+d)!`
+(`Nat.factorial_mul_ascFactorial`) turns this into the memorable closed form
+
+    `(k + deficiency n k)! ≤ (k!)²`.
+
+This strictly improves Section IX (for `k = 28` it forces `deficiency ≤ 18` versus
+the `≤ 20` from `(k+1)^d ≤ k!`), and like everything since Section V it is
+`ofReduceBool`-free and independent of the axiomatized ELS bound.
+-/
+
+/-- **Product lower bound for distinct naturals bounded below.**  If every element
+of a finset `T ⊆ ℕ` is at least `m`, then `∏_{x∈T} x ≥ m(m+1)⋯(m+|T|-1)` — the
+product of the `|T|` smallest values the elements could possibly take.  Proved by
+induction on `T`, peeling off the maximum: the erased set lies in `[m, max)`, whose
+`max - m` slots bound its cardinality, forcing `max ≥ m + (|T|-1)`. -/
+theorem prod_range_add_le_prod_of_forall_ge {m : ℕ} :
+    ∀ (T : Finset ℕ), (∀ x ∈ T, m ≤ x) →
+      (∏ j ∈ Finset.range T.card, (m + j)) ≤ ∏ x ∈ T, x := by
+  intro T
+  induction T using Finset.strongInduction with
+  | _ T ih =>
+    intro hT
+    rcases T.eq_empty_or_nonempty with rfl | hne
+    · simp
+    · set M := T.max' hne with hM
+      have hMmem : M ∈ T := T.max'_mem hne
+      have hMge : m ≤ M := hT M hMmem
+      have hsub : T.erase M ⊆ Finset.Ico m M := by
+        intro x hx
+        have hxT : x ∈ T := Finset.mem_of_mem_erase hx
+        have hxne : x ≠ M := Finset.ne_of_mem_erase hx
+        have hxle : x ≤ M := T.le_max' x hxT
+        exact Finset.mem_Ico.mpr ⟨hT x hxT, lt_of_le_of_ne hxle hxne⟩
+      have hcardle : (T.erase M).card ≤ M - m := by
+        calc (T.erase M).card ≤ (Finset.Ico m M).card := Finset.card_le_card hsub
+          _ = M - m := Nat.card_Ico m M
+      have hMbound : m + (T.erase M).card ≤ M := by omega
+      have hcard : T.card = (T.erase M).card + 1 := by
+        have he := Finset.card_erase_of_mem hMmem
+        have hpos : 0 < T.card := Finset.card_pos.mpr hne
+        omega
+      have hIH : (∏ j ∈ Finset.range (T.erase M).card, (m + j)) ≤ ∏ x ∈ T.erase M, x :=
+        ih (T.erase M) (Finset.erase_ssubset hMmem)
+          (fun x hx => hT x (Finset.mem_of_mem_erase hx))
+      rw [hcard, Finset.prod_range_succ]
+      calc (∏ j ∈ Finset.range (T.erase M).card, (m + j)) * (m + (T.erase M).card)
+          ≤ (∏ x ∈ T.erase M, x) * M := Nat.mul_le_mul hIH hMbound
+        _ = ∏ x ∈ T, x := by
+              rw [mul_comm]; exact Finset.mul_prod_erase T (fun x => x) hMmem
+
+/-- **The smooth window product dominates `(k+1).ascFactorial (deficiency)`.**  The
+`deficiency n k` smooth values in the window are distinct integers each `> k`, so
+their product is at least the product `(k+1)(k+2)⋯(k+deficiency)` of the smallest
+possible distinct values above `k`. -/
+theorem ascFactorial_le_smooth_window_prod {n k : ℕ} (hn : 2 * k ≤ n) :
+    (k + 1).ascFactorial (deficiency n k) ≤
+      ∏ i ∈ (Finset.range k).filter (fun i => IsKSmooth k (n - i)), (n - i) := by
+  set S := (Finset.range k).filter (fun i => IsKSmooth k (n - i)) with hS
+  have hcard : deficiency n k = S.card := rfl
+  set T := S.image (fun i => n - i) with hT
+  have hinj : ∀ a ∈ S, ∀ b ∈ S, (fun i => n - i) a = (fun i => n - i) b → a = b := by
+    intro a ha b hb hab
+    simp only at hab
+    have hak : a < k := Finset.mem_range.mp (Finset.filter_subset _ _ ha)
+    have hbk : b < k := Finset.mem_range.mp (Finset.filter_subset _ _ hb)
+    omega
+  have hTcard : T.card = S.card := Finset.card_image_of_injOn (by
+    intro a ha b hb hab
+    exact hinj a (Finset.mem_coe.mp ha) b (Finset.mem_coe.mp hb) hab)
+  have hPeq : (∏ x ∈ T, x) = ∏ i ∈ S, (n - i) := Finset.prod_image hinj
+  have hTge : ∀ x ∈ T, k + 1 ≤ x := by
+    intro x hx
+    rw [hT, Finset.mem_image] at hx
+    obtain ⟨i, hiS, rfl⟩ := hx
+    have hik : i < k := Finset.mem_range.mp (Finset.filter_subset _ _ hiS)
+    have := window_value_gt_k hik hn
+    omega
+  calc (k + 1).ascFactorial (deficiency n k)
+      = (k + 1).ascFactorial T.card := by rw [hcard, hTcard]
+    _ = ∏ j ∈ Finset.range T.card, (k + 1 + j) := by rw [Nat.ascFactorial_eq_prod_range]
+    _ ≤ ∏ x ∈ T, x := prod_range_add_le_prod_of_forall_ge T hTge
+    _ = ∏ i ∈ S, (n - i) := hPeq
+
+/-- **Sharp ascending-factorial bound.**  For an admissible pair,
+
+    `(k+1).ascFactorial (deficiency n k) ≤ k!`,
+
+i.e. `(k+1)(k+2)⋯(k+deficiency) ≤ k!`.  This refines Section IX's
+`(k+1)^{deficiency} ≤ k!` because the smooth window values are distinct. -/
+theorem deficiency_ascFactorial_le_factorial {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k) :
+    (k + 1).ascFactorial (deficiency n k) ≤ Nat.factorial k := by
+  have hlow := ascFactorial_le_smooth_window_prod (n := n) (k := k) hn
+  have hdvd := smooth_window_prod_dvd_factorial h
+  exact hlow.trans (Nat.le_of_dvd (Nat.factorial_pos k) hdvd)
+
+/-- **Sharp factorial bound (closed form).**  For an admissible pair,
+
+    `(k + deficiency n k)! ≤ (k!)²`.
+
+This is the strongest elementary upper bound in the file: it improves Section IX
+(for `k = 28` it forces `deficiency ≤ 18`, versus `≤ 20`), is `ofReduceBool`-free,
+and does not use the axiomatized ELS bound.  It follows from
+`deficiency_ascFactorial_le_factorial` via `k! · (k+1).ascFactorial d = (k+d)!`. -/
+theorem deficiency_add_factorial_le_sq {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k) :
+    Nat.factorial (k + deficiency n k) ≤ (Nat.factorial k) ^ 2 := by
+  have hasc := deficiency_ascFactorial_le_factorial hn h
+  calc Nat.factorial (k + deficiency n k)
+      = Nat.factorial k * (k + 1).ascFactorial (deficiency n k) :=
+        (Nat.factorial_mul_ascFactorial k (deficiency n k)).symm
+    _ ≤ Nat.factorial k * Nat.factorial k := Nat.mul_le_mul (le_refl _) hasc
+    _ = (Nat.factorial k) ^ 2 := by rw [pow_two]

--- a/src/data/research/problems/erdos-1093-oq-02.json
+++ b/src/data/research/problems/erdos-1093-oq-02.json
@@ -33,7 +33,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS: added first non-trivial upper bound (density bound deficiency + #primes ≤ k, ofReduceBool-free) and sharpened the reduction to k≥10. Universal bound remains OPEN.",
+    "progressSummary": "PROGRESS: Section X sharpens the elementary upper bound from (k+1)^deficiency ≤ k! to (k+deficiency)! ≤ (k!)² via distinctness of smooth window values (k=28: deficiency ≤ 18 vs 20). Universal bound = 9 remains OPEN.",
     "builtItems": [
       "noSmallPrimeFactors_iff (Erdos1093ProblemOQ02.lean) — decidable reduction of the admissibility side-condition (unbounded ∀ prime) to a bounded check over primes p ≤ k; ofReduceBool-free.",
       "noSmallPrimeFactors_284_28 — the record pair (284,28) is admissible: no prime ≤ 28 divides C(284,28) (parent verified only the count = 9, never admissibility).",
@@ -45,22 +45,25 @@
       "deficiency_add_prime_count_le (Erdos1093ProblemOQ02.lean) — DENSITY BOUND (ofReduceBool-free): deficiency n k + #{i<k : (n-i).Prime} ≤ k. Sharper than the trivial deficiency ≤ k; a record deficiency forces a prime-poor length-k window (the ELS density phenomenon).",
       "deficiency_le_nonprime_count — weak form: deficiency ≤ #{i<k : ¬(n-i).Prime}; the smooth filter ⊆ the non-prime filter.",
       "smooth_contributor_not_prime — every smooth contributor n-i (i<k, n≥2k) is composite: it exceeds k, and a k-smooth number > k cannot be prime (isKSmooth_prime_iff).",
-      "maximalDeficiencyIs_nine_iff_kGe10 — sharpened reduction: MaximalDeficiencyIs 9 ⇔ (∀ admissible with k≥10, deficiency ≤ 9). Strictly sharper than maximalDeficiencyIs_nine_iff_upperBound; discharges k≤9 via the trivial bound."
+      "maximalDeficiencyIs_nine_iff_kGe10 — sharpened reduction: MaximalDeficiencyIs 9 ⇔ (∀ admissible with k≥10, deficiency ≤ 9). Strictly sharper than maximalDeficiencyIs_nine_iff_upperBound; discharges k≤9 via the trivial bound.",
+      "prod_range_add_le_prod_of_forall_ge (Erdos1093ProblemOQ02.lean) — reusable: a finset T⊆ℕ with all elements ≥ m has ∏T ≥ ∏_{j<|T|}(m+j); proved by strong induction peeling the max (erased set ⊆ Ico m max bounds card, forcing max ≥ m+|T|-1).",
+      "ascFactorial_le_smooth_window_prod — (k+1).ascFactorial(deficiency n k) ≤ ∏ smooth window values, via injective image onto distinct integers > k.",
+      "deficiency_ascFactorial_le_factorial — (k+1).ascFactorial(deficiency n k) ≤ k! (sharp refinement of Section IX (k+1)^d ≤ k!).",
+      "deficiency_add_factorial_le_sq — closed form (k+deficiency n k)! ≤ (k!)²; the strongest elementary upper bound in the file, ofReduceBool-free."
     ],
     "insights": [
       "The parent's deficiency_284_28 = 9 alone does NOT exhibit a valid deficiency example: the deficiency count is defined unconditionally, but the ELS problem requires C(n,k) to have no prime factor ≤ k. Checking admissibility only needs primes ≤ k (Kummer is unnecessary): C(284,28) is a ~110-bit bignum, so native_decide computes it and tests divisibility by primes ≤ 28 instantly.",
       "The maximality question splits cleanly: the existence half is a finite verification (attained at (284,28)); the universal half (no admissible pair exceeds 9) is the genuinely open content and cannot be enumerated (unbounded n, k).",
       "Trivial bound deficiency ≤ k means any counterexample needs k ≥ 10; the ELS bound n ≪ 2^k·√k (parent axiom els_upper_bound) bounds n per fixed k but the number of k-values is still unbounded.",
       "Primes in the k-consecutive-integer window contribute ZERO to the deficiency: for admissible pairs each n-i > k, and a prime is k-smooth iff ≤ k. This upgrades the trivial bound deficiency ≤ k to deficiency ≤ (#non-primes in window) = k − (#primes in window) — the first non-trivial upper bound in the file and a concrete step toward the open universal bound.",
-      "The density bound reframes the open core: a hypothetical deficiency > 9 at k ≥ 10 requires a length-k run of consecutive integers containing < k−9 primes, i.e. an exceptionally prime-poor window — precisely the input ELS bound the axiomatized els_upper_bound to n ≪ 2^k√k."
+      "The density bound reframes the open core: a hypothetical deficiency > 9 at k ≥ 10 requires a length-k run of consecutive integers containing < k−9 primes, i.e. an exceptionally prime-poor window — precisely the input ELS bound the axiomatized els_upper_bound to n ≪ 2^k√k.",
+      "Section X: the smooth window values are DISTINCT integers (i↦n-i injective on i<k≤n), so their product exceeds not just (k+1)^d but the ascending factorial (k+1)(k+2)···(k+d). This distinct-value refinement of Section IX yields (k+1).ascFactorial(deficiency) ≤ k!, i.e. (k+deficiency)! ≤ (k!)². For k=28 it forces deficiency ≤ 18 versus ≤ 20 from (k+1)^d ≤ k! — a strict elementary improvement, still ofReduceBool-free and independent of the axiomatized ELS bound."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Attack the universal upper bound for small k ≥ 10: for each fixed k the ELS bound gives a finite search range n ≤ C·2^k·√k, but C is not effective in the parent axiom — obtaining an explicit constant would make each fixed-k slice a finite (if large) decidable check.",
-      "Prove structural constraints: an admissible pair with deficiency d forces d of the k consecutive integers n,n-1,...,n-k+1 to be k-smooth, a strong density constraint (Erdős–Lacampagne–Selfridge exploit this for the ≥1 ⇒ n ≪ 2^k√k bound).",
-      "Consider whether Kummer's theorem (carry count in base p) gives a cleaner ofReduceBool-free proof of noSmallPrimeFactors_284_28.",
-      "Quantify the density bound: combine deficiency + #primes ≤ k with a lower bound on primes in [n-k+1,n] (a Brun–Titchmarsh / prime-counting input) to force k-dependent upper bounds on deficiency for k ≥ 10.",
-      "Attempt k=10,11,12 slices: show no length-k window of admissible integers has ≥ 10 smooth values, using the composite-contributor structure plus the p∤C(n,k) admissibility constraint."
+      "Push the sharp bound quantitatively: (k+d)! ≤ (k!)² is equivalent to C(k+d,d)·d! ≤ k!; combine with an ELS-style lower bound on smooth-count to see if it can reach deficiency ≤ 9 for large k.",
+      "Attempt k=10,11,12 slices: the sharp bound (k+d)! ≤ (k!)² gives a concrete deficiency ceiling per k (k=28→18); check whether admissibility (p∤C(n,k)) plus this bound closes small k.",
+      "Consider whether the descFactorial/ascFactorial packaging generalizes to bound the number of k-smooth values in ANY length-k window (independent of deficiency admissibility)."
     ]
   }
 }


### PR DESCRIPTION
## Summary

Extends the OQ-02 file (`Erdos1093ProblemOQ02.lean`) with **Section X**, sharpening the elementary upper bound on the binomial-coefficient deficiency.

Section IX established `(k+1)^{deficiency n k} ≤ k!` using only that each smooth window value exceeds `k`. But the `deficiency n k` smooth values in the window `n, n-1, …, n-k+1` are **distinct** integers (the map `i ↦ n-i` is injective on `i < k ≤ n`). So their product is at least the product of the *smallest possible* distinct values above `k`:

$$P \ge (k+1)(k+2)\cdots(k+d) = (k+1).\mathrm{ascFactorial}\,d.$$

Combined with `P ∣ k!` (`smooth_window_prod_dvd_factorial`, Section IX) this gives

- `deficiency_ascFactorial_le_factorial`: `(k+1).ascFactorial (deficiency n k) ≤ k!`
- `deficiency_add_factorial_le_sq`: **`(k + deficiency n k)! ≤ (k!)²`** (closed form)

For `k = 28` the new bound forces `deficiency ≤ 18`, versus `≤ 20` from Section IX — a strict improvement, and the record is `9`.

## New results

- `prod_range_add_le_prod_of_forall_ge` — reusable: a finset `T ⊆ ℕ` with all elements `≥ m` satisfies `∏_{x∈T} x ≥ ∏_{j<|T|}(m+j)`. Strong induction peeling the maximum.
- `ascFactorial_le_smooth_window_prod` — the smooth window product dominates `(k+1).ascFactorial (deficiency)`.
- `deficiency_ascFactorial_le_factorial`, `deficiency_add_factorial_le_sq`.

## Verification

- Builds clean: `./proofs/scripts/docker-build.sh Proofs.Erdos1093ProblemOQ02` (3060 jobs, 0 sorry, 0 new axioms).
- `ofReduceBool`-free (no `native_decide` in the new section) and independent of the axiomatized ELS bound.
- The universal upper bound `= 9` remains **OPEN**; this is a further elementary narrowing of the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)