### PR TITLE
audit(cramers-rule-oq-04-oq-01-oq-01-oq-01): re-audit clean after enrichment #35438

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6765,8 +6765,8 @@
       "result": "clean"
     },
     "cramers-rule-oq-04-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T01:35:14Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T18:39:01Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Re-audit: clean

`cramers-rule-oq-04-oq-01-oq-01-oq-01` meta.json changed at #35438 (added `mainTheorems` array) after its last audit (2026-06-27). Re-audited.

**Findings — all consistent:**
- Lean file: 158 lines, 10 theorems, 0 sorry, 0 axiom, 0 `native_decide`, 0 True-stub — matches `leanFile` fields exactly.
- `mainTheorems` array: all 10 names match the source; `startLine` anchors exact (50/58/66/73/87/98/109/121/133/145).
- `badge=mathlib` + `status=verified` correct (Tier B): core theorems delegate to Mathlib `cramer_solution`, our file provides the closed-form `det_updateCol_*` determinant expansions. Delegation disclosed in the `mainTheorems` descriptions.

No issues. Only bumps `lastAudited`/`auditCount` for this slug.

---
Gallery integrity re-audit.