### PR TITLE
research(burnside-counting-oq-02): mark COMPLETED — already verified on main [doc-only]

### DIFF
--- a/research/problems/burnside-counting-oq-02/state.md
+++ b/research/problems/burnside-counting-oq-02/state.md
@@ -1,25 +1,41 @@
 # Research State: burnside-counting-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
 **Since**: 2026-04-03T08:17:23-07:00
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Verify `fixed_point_sum_binary_4` via `native_decide` (or `decide`).
 
-## Active Approach
-None yet.
+## Resolution (researcher-3, 2026-07-08): ALREADY RESOLVED on main
+The requested task is complete in `proofs/Proofs/BurnsideCounting.lean`:
 
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+```lean
+theorem fixed_point_sum_binary_4 :
+    Fintype.card { c : Coloring 4 2 // IsFixedByRotation 0 c } + ... = 24 := by
+  decide
+```
+
+Proven by kernel `decide` (line 352–357). History: discharged in S3 ACT via
+`native_decide` (#22767, axiom 2→1), then the **S5 drift repair (Mathlib v4.26)**
+switched to kernel `decide`, which both fixes a native-compilation crash and
+**removes the `Lean.ofReduceBool` dependency**. The gallery meta
+(`src/data/proofs/burnside-counting/meta.json`) is `status: verified`,
+`badge: mathlib`, `axiomCount: 0`, `sorries: 0` — no `native_decide`, no
+`ofReduceBool`. `binary_necklaces_4 = 6` is likewise derived (additive Burnside
+lemma), axiom-free.
+
+No PR: the requested verification already exists on `main`; there is no additive
+theorem work within this problem's scope. (A genuinely-open follow-up exists in
+`meta.openQuestions[2]` — an *alternative* proof of `binary_necklaces_4` via the
+abstract multiplicative `burnside_lemma` through a MulAction↔AddAction bridge —
+but that is a distinct open question, not OQ-02.)
 
 ## Blockers
-None.
+None — resolved.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Completed. Problem predates the S3–S5 axiom-elimination programme that already
+delivered exactly this result.


### PR DESCRIPTION
## Summary

`burnside-counting-oq-02` asks to *"verify `fixed_point_sum_binary_4` via `native_decide` (or `decide`)."* This is **already resolved on `main`**.

In `proofs/Proofs/BurnsideCounting.lean`, `fixed_point_sum_binary_4` (the Burnside numerator `16+2+4+2 = 24`) is proven by kernel `decide` — discharged in S3 ACT (#22767), then the **S5 drift repair (Mathlib v4.26)** replaced `native_decide` with kernel `decide`, removing the `Lean.ofReduceBool` dependency. The gallery meta is `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0`.

The problem predates that axiom-elimination programme. This PR records the resolution in `state.md` so the pool does not keep re-serving a completed task.

## Changes
- Doc-only: `research/problems/burnside-counting-oq-02/state.md` → phase COMPLETED with the resolution explanation. **No Lean changes.**

A genuinely-open follow-up remains in `meta.openQuestions[2]` (alternative proof of `binary_necklaces_4` via the abstract multiplicative `burnside_lemma` through a MulAction↔AddAction bridge), but that is a distinct open question, not OQ-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)