### PR TITLE
research(erdos-1022-oq-02): sync stale top-level phase ACT → COMPLETED

### DIFF
--- a/src/data/research/problems/erdos-1022-oq-02.json
+++ b/src/data/research/problems/erdos-1022-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1022-oq-02",
   "title": "Growth Rate of the Property-B Sparseness Threshold",
-  "phase": "ACT",
+  "phase": "COMPLETED",
   "status": "completed",
   "tier": "B",
   "path": "full",


### PR DESCRIPTION
## Summary
Metadata reconciliation for **erdos-1022-oq-02** ("Growth Rate of the Property-B Sparseness Threshold").

`Erdos1022OQ02.lean` is **0-axiom, 0-sorry** (8 theorems, 233 lines) and the JSON companion `status` is already `completed` with `currentState.phase = COMPLETED`, but the top-level `phase` field lagged at `ACT`. Synced it.

Pure metadata; no Lean change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)