### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02): (·/2) is a real character — kronecker2_sq [VERIFIED build]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -249,6 +249,31 @@ theorem kronecker2_values (a : ℤ) :
   unfold kronecker2
   split_ifs <;> decide
 
+/-- **`kronecker2` is a real character:** its square is the principal character
+    mod `2`, i.e. `(a/2)² = 0` on even `a` and `= 1` on odd `a`.  Since `(·/2)`
+    takes values in `{−1, 0, 1}` (`kronecker2_values`) and is `0` exactly on the
+    even residues, squaring collapses the two unit classes `{1,7}` and `{3,5}`
+    onto `1`.  This is the order-≤2 statement completing the identification of
+    `(·/2)` (with `kronecker2_mul`, `_periodic`, `_neg`) as the even *real*
+    Dirichlet character mod `8`. -/
+theorem kronecker2_sq (a : ℤ) :
+    kronecker2 a * kronecker2 a = if a % 2 = 0 then 0 else 1 := by
+  by_cases h : a % 2 = 0
+  · rw [if_pos h]; unfold kronecker2; rw [if_pos h]; ring
+  · rw [if_neg h]
+    have hne : kronecker2 a ≠ 0 := by
+      unfold kronecker2; rw [if_neg h]; split_ifs <;> decide
+    rcases kronecker2_values a with h1 | h1 | h1
+    · rw [h1]; ring
+    · exact absurd h1 hne
+    · rw [h1]; ring
+
+/-- **`(a/2)² = 1` for odd `a`.**  The `(·/2)` symbol squares to `1` on every
+    unit mod `8` — the concrete order-2 form of `kronecker2_sq`. -/
+theorem kronecker2_sq_odd (a : ℤ) (ha : a % 2 = 1) :
+    kronecker2 a * kronecker2 a = 1 := by
+  rw [kronecker2_sq, if_neg (by omega)]
+
 /-- The Kronecker symbol is completely multiplicative in the first argument:
     (ab/n) = (a/n)(b/n), provided a*b ≠ 0.
 

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 510,
+    "lineCount": 535,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 30,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -46,7 +46,8 @@
       "kronecker0_mul (repaired)",
       "kronecker_eq_sign_jacobi",
       "kroneckerNeg1_sq (private)",
-      "kronecker_mul_right (full, all nonzero moduli)"
+      "kronecker_mul_right (full, all nonzero moduli)",
+      "kronecker2_sq / kronecker2_sq_odd (ElementaryQuadraticReciprocityOQ03OQ02.lean, VERIFIED 0/0): the (·/2) character is REAL — its square is the principal character mod 2 ((a/2)²=0 on evens, =1 on odds); completes the even-real-Dirichlet-character-mod-8 identification alongside kronecker2_mul/_periodic/_neg/_values."
     ],
     "insights": [
       "For odd positive moduli the Kronecker symbol IS the Jacobi symbol (kronecker_eq_jacobi), so mul-in-n and QR come for free from jacobiSym.mul_right' and jacobiSym.quadratic_reciprocity.",
@@ -88,7 +89,7 @@
     "mathlib": []
   },
   "started": "2026-04-05T08:58:43.841Z",
-  "lastUpdate": "2026-07-07",
+  "lastUpdate": "2026-07-08T00:00:00.000Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Adds two **verified** structural lemmas to the Kronecker-symbol file, completing the identification of the `(·/2)` symbol as the even **real** Dirichlet character mod 8.

## New theorems (0-axiom, 0-sorry)

| Theorem | Statement |
|---|---|
| `kronecker2_sq` | `(a/2)² = ` principal character mod 2 — `0` on even `a`, `1` on odd `a` |
| `kronecker2_sq_odd` | `(a/2)² = 1` for odd `a` (the concrete order-2 form) |

The file already establishes that `(·/2)` is multiplicative (`kronecker2_mul`), period-8 (`kronecker2_periodic`), even (`kronecker2_neg`), and `{−1,0,1}`-valued (`kronecker2_values`). The missing structural fact was that it is a **real** character — order ≤ 2 — which is exactly `kronecker2_sq`. This is the property the Gauss-sum route to generalized quadratic reciprocity (the entry's Target 2) rests on.

## Verification

```
./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02
Build completed successfully (3058 jobs).
```

0 sorries, 0 axioms (unchanged). Synced gallery meta counts (510→535 lines, 28→30 theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)