### PR TITLE
research(erdos-1059-oq-01-oq-01): eliminate an axiom via Bertrand + repair latent build breaks [VERIFIED, axiomCount 2→1]

### DIFF
--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -448,7 +448,9 @@ theorem density_one_at_factorials (k : ℕ) : ∃ N : ℕ, ∀ n : ℕ, n ≥ N 
     Erdos1059OQ01.qualifyingPrimeCount (Nat.factorial n) * (k + 1) ≥
     Erdos1059OQ01.primeCount (Nat.factorial n) * k := by
   obtain ⟨N₀, hN₀⟩ := density_at_levels k
-  refine ⟨max N₀ 1, fun n hn => ?_⟩
+  -- Witness N₀ + 1: we apply the level-sum bound at n - 1 (range n = range ((n-1)+1)),
+  -- which needs n - 1 ≥ N₀, i.e. n ≥ N₀ + 1.
+  refine ⟨N₀ + 1, fun n hn => ?_⟩
   have hn1 : n ≥ 1 := by omega
   have hnN : n ≥ N₀ := by omega
   rw [qualifyingCount_decomposition n hn1, primeCount_decomposition n hn1]

--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -107,13 +107,30 @@ For a clean formalization: q(l)·(l+1) ≥ p(l)·l.
 axiom strong_selberg_density (l : ℕ) (hl : l ≥ 3) :
     qualifyingInLevel l * (l + 1) ≥ primesInLevel l * l
 
-/-- **Primes Growth in Levels**: For l ≥ 3, I(l) contains at least l primes.
+/-- **Positivity of the level prime count** (formerly the axiom
+    `primes_growth_in_levels`, now *proved* from Bertrand's postulate).
 
-    This is an extremely weak consequence of PNT: the interval (l!, (l+1)!]
-    has length l·l!, which for l ≥ 3 is far more than needed for l primes.
-    By PNT, the prime count is ≈ l!/log(l!), which vastly exceeds l. -/
-axiom primes_growth_in_levels (l : ℕ) (hl : l ≥ 3) :
-    primesInLevel l ≥ l
+    For `l ≥ 1` the primorial interval `I(l) = (l!, (l+1)!]` contains at least one
+    prime.  Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`) gives a
+    prime `p` with `l! < p ≤ 2·l!`, and `2·l! ≤ (l+1)!` for `l ≥ 1`, so
+    `p ∈ I(l)`.
+
+    This is all the growth the downstream results actually use: both
+    `qualifyingInLevel_pos` and `levelwise_strict_surplus` only need
+    `primesInLevel l ≥ 1` (the surplus argument turns on `p·(l−k) > 0`, i.e.
+    `p ≥ 1`, not the far stronger `p ≥ l`). Eliminating the old `p(l) ≥ l` axiom
+    leaves a single sieve axiom (`strong_selberg_density`). -/
+theorem primesInLevel_pos (l : ℕ) (hl : l ≥ 1) :
+    primesInLevel l ≥ 1 := by
+  unfold primesInLevel Erdos1059OQ02.PrimorialInterval
+  rw [Nat.one_le_iff_ne_zero, Finset.card_ne_zero]
+  obtain ⟨p, hp, hlt, hle⟩ :=
+    Nat.exists_prime_lt_and_le_two_mul (Nat.factorial l) (Nat.factorial_ne_zero l)
+  refine ⟨p, ?_⟩
+  rw [Finset.mem_filter, Finset.mem_Ioc]
+  have hstep : 2 * Nat.factorial l ≤ Nat.factorial (l + 1) := by
+    rw [Nat.factorial_succ]; gcongr; omega
+  exact ⟨⟨hlt, by omega⟩, hp⟩
 
 /-
 ## Part III: Strong Axiom Implies Weak Axiom
@@ -125,18 +142,18 @@ if q(l)·(l+1) ≥ p(l)·l ≥ l·l ≥ 9 > 0, then q(l) ≥ 1.
 /-- The strong axiom implies q(l) ≥ 1 for l ≥ 3. -/
 theorem qualifyingInLevel_pos (l : ℕ) (hl : l ≥ 3) :
     qualifyingInLevel l ≥ 1 := by
-  have hp := primes_growth_in_levels l hl
+  have hp := primesInLevel_pos l (by omega)
   have hs := strong_selberg_density l hl
-  -- q(l) * (l+1) ≥ p(l) * l ≥ l * l ≥ 9 > 0
+  -- q(l) * (l+1) ≥ p(l) * l ≥ 1 * 3 > 0
   -- Since l+1 > 0, q(l) ≥ 1
   by_contra hc
   push_neg at hc
   -- hc : qualifyingInLevel l < 1, i.e., = 0 in ℕ
   have hq : qualifyingInLevel l = 0 := by omega
   rw [hq, zero_mul] at hs
-  -- hs : 0 ≥ p(l) * l, so p(l) * l = 0
-  -- But p(l) ≥ l ≥ 3, so p(l) * l ≥ 9 > 0
-  nlinarith
+  -- hs : 0 ≥ p(l) * l, but p(l) ≥ 1 and l ≥ 3 give p(l) * l ≥ 3 > 0
+  have hpos : 1 * 3 ≤ primesInLevel l * l := Nat.mul_le_mul hp hl
+  omega
 
 /-- A qualifying prime exists in I(l) for l ≥ 3 (extraction from the count). -/
 theorem qualifyingPrime_exists (l : ℕ) (hl : l ≥ 3) :
@@ -198,59 +215,47 @@ theorem levelwise_density_bound (l k : ℕ) (hl : l ≥ 3) (hlk : l ≥ k) :
   -- But q*(l+1) ≥ p*l from axiom. Contradiction.
   linarith
 
-/-- **Strict surplus**: For l ≥ max(3, k+2) with the growth axiom,
-    q(l)·(k+1) ≥ p(l)·k + 1. That is, each high level contributes
-    at least 1 unit of surplus toward the density bound.
+/-- **Strict surplus**: For l ≥ max(3, k+2), each high level contributes
+    at least 1 unit of surplus toward the density bound:
+    q(l)·(k+1) ≥ p(l)·k + 1.
 
-    Proof: From q(l)·(l+1) ≥ p(l)·l and p(l) ≥ l ≥ k+2:
-      q·(k+1)·(l+1) ≥ p·l·(k+1) = p·k·(l+1) + p·(l-k)·(?)
-    The surplus p·(l-k) ≥ l·2 ≥ 2(l+1) > (l+1), so dividing gives ≥ 1. -/
+    Proof (uses only `p(l) ≥ 1`, via `primesInLevel_pos`): suppose instead
+    q·(k+1) ≤ p·k. Splitting `l+1 = (k+1)+(l-k)` and using `q ≤ p` gives
+    q·(l+1) ≤ p·l; the Selberg axiom gives the reverse, so all inequalities are
+    equalities. In particular q·(l-k) = p·(l-k) with `l-k > 0`, so `q = p`; then
+    q·(k+1) = p·k with `q = p` forces `p = 0`, contradicting `p ≥ 1`. -/
 theorem levelwise_strict_surplus (l k : ℕ) (hl : l ≥ 3) (hlk : l ≥ k + 2) :
     qualifyingInLevel l * (k + 1) ≥ primesInLevel l * k + 1 := by
   have hs := strong_selberg_density l hl
-  have hp := primes_growth_in_levels l hl
+  have hp := primesInLevel_pos l (by omega)
   have hqlp := qualifyingInLevel_le_primesInLevel l
-  -- Strategy: show q*(k+1) ≥ p*k + 1 via contradiction
-  -- If q*(k+1) ≤ p*k, then q*(l+1) = q*(k+1) + q*(l-k) ≤ p*k + p*(l-k) = p*l
-  -- But actually we need strict: q*(k+1) < p*k + 1, i.e., q*(k+1) ≤ p*k
-  -- q*(l+1) = q*(k+1) + q*(l-k) ≤ p*k + p*(l-k) = p*l
-  -- Axiom gives q*(l+1) ≥ p*l, so q*(l+1) = p*l.
-  -- Then q = p*l/(l+1). But we need q*(k+1) ≤ p*k < p*l/(l+1) * (k+1)...
-  -- Actually, for strict surplus we need the surplus from (l-k) ≥ 2 levels.
-  -- q*(l+1) = q*(k+1) + q*(l-k)
-  -- ≤ p*k + p*(l-k) = p*l [using q ≤ p]
-  -- But q*(l+1) ≥ p*l [axiom]
-  -- So equality: q*(k+1) = p*k AND q*(l-k) = p*(l-k) AND q*(l+1) = p*l
-  -- From q*(l-k) = p*(l-k) and l-k ≥ 2 > 0: q = p
-  -- From q*(k+1) = p*k and q = p: p*(k+1) = p*k, so p = 0
-  -- But p ≥ l ≥ 3. Contradiction.
   by_contra hc
   push_neg at hc
   -- hc : q*(k+1) < p*k + 1, i.e., q*(k+1) ≤ p*k
   have hle : qualifyingInLevel l * (k + 1) ≤ primesInLevel l * k := by omega
-  -- Step 1: q*(l+1) ≤ p*l (from hle, q ≤ p, and splitting l+1 = (k+1) + (l-k))
+  -- Split l+1 = (k+1) + (l-k) and k + (l-k) = l.
   have hsplit : qualifyingInLevel l * (l + 1) =
       qualifyingInLevel l * (k + 1) + qualifyingInLevel l * (l - k) := by
     rw [← Nat.mul_add]; congr 1; omega
+  have hqmul : qualifyingInLevel l * (l - k) ≤ primesInLevel l * (l - k) :=
+    Nat.mul_le_mul_right _ hqlp
+  have hcomb : primesInLevel l * k + primesInLevel l * (l - k) = primesInLevel l * l := by
+    rw [← Nat.mul_add]; congr 1; omega
+  -- q*(l+1) ≤ p*l, and the axiom gives ≥, so equality.
   have hub : qualifyingInLevel l * (l + 1) ≤ primesInLevel l * l := by
-    have hqmul : qualifyingInLevel l * (l - k) ≤ primesInLevel l * (l - k) :=
-      Nat.mul_le_mul_right _ hqlp
-    have hcomb : primesInLevel l * k + primesInLevel l * (l - k) = primesInLevel l * l := by
-      rw [← Nat.mul_add]; congr 1; omega
-    linarith
-  -- Step 2: Combined with axiom q*(l+1) ≥ p*l → equality q*(l+1) = p*l
-  have heq : qualifyingInLevel l * (l + 1) = primesInLevel l * l := by linarith
-  -- Step 3: From heq and hle, derive p*l*(k+1) ≤ p*k*(l+1)
-  -- which gives p*(l-k) ≤ 0, contradicting p ≥ l ≥ 3 and l-k ≥ 2
-  have h1 := Nat.mul_le_mul_right (l + 1) hle
-  -- h1 : q*(k+1)*(l+1) ≤ p*k*(l+1)
-  have h2 : qualifyingInLevel l * (k + 1) * (l + 1) =
-      qualifyingInLevel l * (l + 1) * (k + 1) := by ring
-  have h3 : qualifyingInLevel l * (l + 1) * (k + 1) =
-      primesInLevel l * l * (k + 1) := by rw [heq]
-  -- p*l*(k+1) = q*(k+1)*(l+1) ≤ p*k*(l+1), so p*(l-k) ≤ 0
-  -- But p ≥ l ≥ k+2, so p*(l-k) ≥ (k+2)*2 > 0
-  nlinarith
+    rw [hsplit]; omega
+  have heq : qualifyingInLevel l * (l + 1) = primesInLevel l * l := by omega
+  -- Equality of the total forces equality of the (l-k)-piece.
+  have hpiece : qualifyingInLevel l * (l - k) = primesInLevel l * (l - k) := by omega
+  -- l - k > 0, so cancel to get q = p.
+  have hlk0 : 0 < l - k := by omega
+  have hqp : qualifyingInLevel l = primesInLevel l :=
+    Nat.eq_of_mul_eq_mul_right hlk0 hpiece
+  -- Then q*(k+1) = p*k with q = p forces p = 0, contradicting p ≥ 1.
+  have hk1 : qualifyingInLevel l * (k + 1) = primesInLevel l * k := by omega
+  rw [hqp] at hk1
+  have hexp : primesInLevel l * (k + 1) = primesInLevel l * k + primesInLevel l := by ring
+  omega
 
 /-
 ## Part V: Gap Analysis — Why General x Fails

--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -42,6 +42,7 @@ Dependencies: Erdos1059OQ01 (counting functions), Erdos1059OQ02 (intervals, weak
 
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.NumberTheory.Bertrand
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Basic
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic

--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -126,13 +126,13 @@ axiom strong_selberg_density (l : ℕ) (hl : l ≥ 3) :
 theorem primesInLevel_pos (l : ℕ) (hl : l ≥ 1) :
     primesInLevel l ≥ 1 := by
   unfold primesInLevel Erdos1059OQ02.PrimorialInterval
-  rw [Nat.one_le_iff_ne_zero, Finset.card_ne_zero]
+  rw [ge_iff_le, Finset.one_le_card]
   obtain ⟨p, hp, hlt, hle⟩ :=
     Nat.exists_prime_lt_and_le_two_mul (Nat.factorial l) (Nat.factorial_ne_zero l)
-  refine ⟨p, ?_⟩
-  rw [Finset.mem_filter, Finset.mem_Ioc]
   have hstep : 2 * Nat.factorial l ≤ Nat.factorial (l + 1) := by
     rw [Nat.factorial_succ]; gcongr; omega
+  refine ⟨p, ?_⟩
+  rw [Finset.mem_filter, Finset.mem_Ioc]
   exact ⟨⟨hlt, by omega⟩, hp⟩
 
 /-
@@ -164,7 +164,7 @@ theorem qualifyingPrime_exists (l : ℕ) (hl : l ≥ 3) :
     p.Prime ∧ Erdos1059OQ01.AllFactorialSubtractionsComposite p := by
   have hpos := qualifyingInLevel_pos l hl
   unfold qualifyingInLevel at hpos
-  rw [Nat.one_le_iff_ne_zero, Finset.card_ne_zero] at hpos
+  rw [ge_iff_le, Finset.one_le_card] at hpos
   obtain ⟨p, hp⟩ := hpos
   simp only [Finset.mem_filter] at hp
   exact ⟨p, hp.1, hp.2.1, hp.2.2⟩
@@ -344,7 +344,7 @@ theorem density_at_levels (k : ℕ) : ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
     rw [Finset.mul_sum]
     apply Finset.sum_le_sum
     intro l _
-    ring_nf
+    exact le_of_eq (mul_comm (primesInLevel l) k)
   -- Low-level LHS contribution is ≥ 0
   have h_low_nonneg : 0 ≤ (Finset.range L₀).sum (fun l => qualifyingInLevel l * (k + 1)) :=
     Nat.zero_le _

--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -454,9 +454,11 @@ theorem density_one_at_factorials (k : ℕ) : ∃ N : ℕ, ∀ n : ℕ, n ≥ N 
   have hn1 : n ≥ 1 := by omega
   have hnN : n ≥ N₀ := by omega
   rw [qualifyingCount_decomposition n hn1, primeCount_decomposition n hn1]
-  -- Now apply density_at_levels with n-1 (since range n = range ((n-1)+1))
+  -- Now apply density_at_levels with n-1 (since range n = range ((n-1)+1)).
+  -- The decompositions give (Σ q_l)·(k+1); density_at_levels sums q_l·(k+1)
+  -- termwise, so bridge with Finset.sum_mul.
   have hnn : n = (n - 1) + 1 := by omega
-  rw [hnn]
+  rw [hnn, Finset.sum_mul, Finset.sum_mul]
   exact hN₀ (n - 1) (by omega)
 
 /-

--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -12,10 +12,12 @@ However, a STRONGER axiom capturing the Selberg sieve's quantitative prediction
 — that the qualifying fraction at level l is ≥ l/(l+1) — combined with a mild
 growth condition, DOES imply density at factorial evaluation points.
 
-**Key results** (0 sorries, 2 axioms):
+**Key results** (0 sorries, 1 axiom):
 1. `primesInLevel`, `qualifyingInLevel`: interval-level counting functions
 2. `strong_selberg_density`: axiom — q(l)*(l+1) ≥ p(l)*l for l ≥ 3
-3. `primes_growth_in_levels`: axiom — p(l) ≥ l for l ≥ 3 (very weak PNT)
+3. `primesInLevel_pos`: THEOREM (was an axiom) — p(l) ≥ 1 for l ≥ 1, proved from
+   Bertrand's postulate. The downstream results need only positivity, so the old
+   `p(l) ≥ l` axiom is eliminated.
 4. `qualifyingInLevel_le_primesInLevel`: q(l) ≤ p(l) always
 5. `strong_implies_weak`: strong axiom → selberg_density_axiom (≥1 per interval)
 6. `levelwise_density_bound`: for l ≥ k, q(l)*(k+1) ≥ p(l)*k
@@ -33,7 +35,8 @@ bounds (the sieve analysis is performed interval by interval). The aggregation
 from level-wise to cumulative density is the non-trivial step that requires
 understanding the interaction between different interval scales.
 
-Axioms: 2 (strong_selberg_density, primes_growth_in_levels)
+Axioms: 1 (strong_selberg_density) — the former primes_growth_in_levels axiom is
+now the proved theorem primesInLevel_pos (Bertrand's postulate)
 Dependencies: Erdos1059OQ01 (counting functions), Erdos1059OQ02 (intervals, weak axiom)
 -/
 
@@ -474,9 +477,12 @@ theorem density_one_at_factorials (k : ℕ) : ∃ N : ℕ, ∀ n : ℕ, n ≥ N 
 **This file is now sorry-free** — the previous two `sorry`s (the interval
 decompositions) are discharged by `count_decomp`.
 
-**Axioms** (2, both disclosed sieve inputs):
+**Axioms** (1, a single disclosed sieve input):
 - strong_selberg_density: captures Selberg sieve's quantitative prediction
-- primes_growth_in_levels: weak PNT (p(l) ≥ l for l ≥ 3)
+
+The former `primes_growth_in_levels` axiom (`p(l) ≥ l`) is now the proved theorem
+`primesInLevel_pos` (`p(l) ≥ 1`, via Bertrand's postulate); the downstream
+results only ever used positivity of the level prime count.
 
 **Open**: Extending from factorial points to all x requires within-interval
 density estimates, which is a deeper sieve-theoretic result.

--- a/src/data/proofs/erdos-1059-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/annotations.json
@@ -31,7 +31,7 @@
     },
     "type": "concept",
     "title": "The Strong Selberg Density Axiom",
-    "content": "The strong axiom states q(l)·(l+1) ≥ p(l)·l for l ≥ 3, meaning the qualifying fraction q(l)/p(l) is at least l/(l+1). This is motivated by the Selberg sieve: each of the l+1 'bad' conditions (p - k! composite for some k ≤ l) eliminates at most O(l!/log²(l!)) primes by Brun-Titchmarsh, while the total is ≈ l!/log(l!) by PNT, so the bad fraction is O((l+1)/log(l!)) → 0. The axiom captures the leading behavior with the clean threshold l/(l+1). The companion axiom primes_growth_in_levels (p(l) ≥ l for l ≥ 3) is an extremely weak consequence of PNT — the actual count is astronomically larger.",
+    "content": "The strong axiom states q(l)·(l+1) ≥ p(l)·l for l ≥ 3, meaning the qualifying fraction q(l)/p(l) is at least l/(l+1). This is motivated by the Selberg sieve: each of the l+1 'bad' conditions (p - k! composite for some k ≤ l) eliminates at most O(l!/log²(l!)) primes by Brun-Titchmarsh, while the total is ≈ l!/log(l!) by PNT, so the bad fraction is O((l+1)/log(l!)) → 0. The axiom captures the leading behavior with the clean threshold l/(l+1). It is now the SOLE axiom: the companion growth bound (formerly the axiom primes_growth_in_levels, p(l) ≥ l) is now the proved theorem primesInLevel_pos (p(l) ≥ 1, from Bertrand's postulate), since the downstream results only need positivity of the level prime count.",
     "mathContext": "Axiom: $q(l) \\cdot (l+1) \\geq p(l) \\cdot l$ for $l \\geq 3$, equivalently $\\frac{q(l)}{p(l)} \\geq \\frac{l}{l+1}$. From Brun-Titchmarsh: non-qualifying primes in $I(l)$ are $\\leq (l+1) \\cdot \\frac{2 \\cdot l!}{\\log^2(l!)}$, while $p(l) \\approx \\frac{l!}{\\log(l!)}$, giving bad fraction $\\leq \\frac{2(l+1)}{\\log(l!)} \\to 0$.",
     "significance": "key",
     "relatedConcepts": [
@@ -55,17 +55,17 @@
     },
     "type": "concept",
     "title": "Strong Axiom Recovers the Weak Selberg Axiom",
-    "content": "strong_implies_weak proves that the strong axiom gives q(l) ≥ 1 for l ≥ 3, recovering the weak selberg_density_axiom (at least one qualifying prime per interval). The chain: from the axioms, q(l)·(l+1) ≥ p(l)·l ≥ l² ≥ 9 > 0, so q(l) ≥ 1. From q(l) ≥ 1, extract a specific element via Finset.card_ne_zero → Finset.Nonempty → ∃ element. This confirms the strong axiom strictly generalizes the weak one.",
-    "mathContext": "$q(l)(l+1) \\geq p(l) \\cdot l \\geq l^2 \\geq 9 > 0 \\implies q(l) \\geq 1$. The extraction $q(l) \\geq 1 \\implies \\exists p \\in I(l), \\text{Prime}(p) \\wedge \\text{AFSC}(p)$ uses the correspondence between cardinality $\\geq 1$ and nonemptiness.",
+    "content": "strong_implies_weak proves that the strong axiom gives q(l) ≥ 1 for l ≥ 3, recovering the weak selberg_density_axiom (at least one qualifying prime per interval). The chain: from the strong axiom and primesInLevel_pos (p(l) ≥ 1), q(l)·(l+1) ≥ p(l)·l ≥ 1·3 = 3 > 0, so q(l) ≥ 1. From q(l) ≥ 1, extract a specific element via Finset.one_le_card → Finset.Nonempty → ∃ element. This confirms the strong axiom strictly generalizes the weak one.",
+    "mathContext": "$q(l)(l+1) \\geq p(l) \\cdot l \\geq 1 \\cdot 3 = 3 > 0 \\implies q(l) \\geq 1$. The extraction $q(l) \\geq 1 \\implies \\exists p \\in I(l), \\text{Prime}(p) \\wedge \\text{AFSC}(p)$ uses the correspondence between cardinality $\\geq 1$ and nonemptiness.",
     "significance": "supporting",
     "relatedConcepts": [
-      "Finset.card_ne_zero",
+      "Finset.one_le_card",
       "Finset.Nonempty",
       "selberg_density_axiom"
     ],
     "prerequisites": [
       "strong_selberg_density",
-      "primes_growth_in_levels"
+      "primesInLevel_pos"
     ]
   },
   {

--- a/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
@@ -54,22 +54,22 @@
     ],
     "originalContributions": [
       "primesInLevel, qualifyingInLevel: interval-level counting functions for primes and qualifying primes in each primorial interval",
-      "strong_selberg_density: axiom capturing Selberg sieve's quantitative prediction — qualifying fraction ≥ l/(l+1) at each level",
-      "primes_growth_in_levels: axiom — at least l primes per level (very weak PNT)",
-      "qualifyingInLevel_pos: PROVED q(l) ≥ 1 for l ≥ 3 from strong axiom + growth",
+      "strong_selberg_density: axiom capturing Selberg sieve's quantitative prediction — qualifying fraction ≥ l/(l+1) at each level (the sole remaining axiom)",
+      "primesInLevel_pos: PROVED p(l) ≥ 1 for l ≥ 1 from Bertrand's postulate (Nat.exists_prime_lt_and_le_two_mul) — was the axiom primes_growth_in_levels (p(l) ≥ l); downstream results need only positivity, so the axiom is eliminated (2 axioms → 1)",
+      "qualifyingInLevel_pos: PROVED q(l) ≥ 1 for l ≥ 3 from strong axiom + primesInLevel_pos",
       "strong_implies_weak: PROVED strong axiom recovers selberg_density_axiom",
       "levelwise_density_bound: PROVED l/(l+1) ≥ k/(k+1) monotonicity for interval counts",
       "levelwise_strict_surplus: PROVED per-level surplus ≥ 1 for l ≥ max(3, k+2)",
       "density_at_levels: PROVED (main theorem) — level-sum density bound via sum splitting and surplus accumulation",
       "Gap analysis: factorial growth of interval sizes prevents extending from factorial points to general x"
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "prerequisites": [
       "Elementary number theory: primes, factorials, compositeness",
       "Sieve theory: Selberg sieve, Brun-Titchmarsh inequality (motivational)",
       "Finset operations: filter, card, sum, sum splitting"
     ],
-    "lineCount": 480,
+    "lineCount": 496,
     "relatedProblems": [
       {
         "id": "erdos-1059-oq-01",
@@ -84,8 +84,8 @@
         "relationship": "Grandparent: main Erdős 1059 conjecture"
       }
     ],
-    "assumptions": "Two explicit sieve axioms: strong_selberg_density (the Selberg sieve's quantitative prediction q(l)·(l+1) ≥ p(l)·l for l ≥ 3) and primes_growth_in_levels (weak PNT: p(l) ≥ l for l ≥ 3). The file is now SORRY-FREE: the two interval-decomposition lemmas (π(n!) and C(n!) as sums over primorial levels), previously sorry, are proved via the generic count_decomp by induction. Hence density_one_at_factorials is fully derived modulo the two disclosed axioms.",
-    "theoremCount": 11,
+    "assumptions": "One explicit sieve axiom: strong_selberg_density (the Selberg sieve's quantitative prediction q(l)·(l+1) ≥ p(l)·l for l ≥ 3). The former second axiom primes_growth_in_levels (p(l) ≥ l) is now the PROVED theorem primesInLevel_pos (p(l) ≥ 1, via Bertrand's postulate); the downstream results only ever used positivity of the level prime count, so the axiom count drops from 2 to 1. The file is SORRY-FREE: the two interval-decomposition lemmas (π(n!) and C(n!) as sums over primorial levels) are proved via the generic count_decomp by induction. Hence density_one_at_factorials is fully derived modulo the single disclosed axiom.",
+    "theoremCount": 12,
     "definitionCount": 3
   },
   "overview": {
@@ -118,7 +118,7 @@
     {
       "id": "axioms",
       "title": "Part II: The Strong Selberg Density Axiom",
-      "summary": "States two axioms: (1) strong_selberg_density, the bound q(l)·(l+1) ≥ p(l)·l capturing the Selberg sieve prediction, and (2) primes_growth_in_levels, a weak growth bound p(l) ≥ l for l ≥ 3.",
+      "summary": "States the single axiom strong_selberg_density, the bound q(l)·(l+1) ≥ p(l)·l capturing the Selberg sieve prediction. The former growth axiom primes_growth_in_levels (p(l) ≥ l) is replaced by the proved theorem primesInLevel_pos (p(l) ≥ 1, via Bertrand's postulate), which is all the downstream results require.",
       "startLine": 77,
       "endLine": 116,
       "mathContext": "The sieve argument gives $q(l) \\geq p(l) \\cdot (1 - O((l+1)/\\log(l!)))$. The axiom $q(l)(l+1) \\geq p(l)l$ captures the leading term."
@@ -166,10 +166,10 @@
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Inventory of results: 7 theorems proved from first principles (through density_at_levels), 3 statements requiring sorry (the two decompositions plus density_one_at_factorials), and the 2 axioms (strong_selberg_density, primes_growth_in_levels). Notes the open extension to all x.",
+      "summary": "Inventory of results: all theorems proved from first principles including the interval decompositions and density_one_at_factorials (0 sorries), and the single axiom strong_selberg_density (the former primes_growth_in_levels is now the proved theorem primesInLevel_pos). Notes the open extension to all x.",
       "startLine": 409,
       "endLine": 434,
-      "mathContext": "2 axioms, 2 sorries; the factorial-point result is unconditional given the axioms, while the all-x extension remains open."
+      "mathContext": "1 axiom, 0 sorries; the factorial-point result is unconditional given the single Selberg axiom, while the all-x extension remains open."
     }
   ],
   "crossReferences": [
@@ -190,15 +190,15 @@
     }
   ],
   "leanFile": {
-    "lineCount": 480,
+    "lineCount": 496,
     "namespace": "Erdos1059OQ01OQ01",
     "opens": [
       "Nat"
     ],
     "structureCount": 0,
-    "axiomCount": 2,
-    "theoremCount": 11,
-    "substantiveTheoremCount": 7,
+    "axiomCount": 1,
+    "theoremCount": 12,
+    "substantiveTheoremCount": 8,
     "computationalVerifications": 0,
     "lemmaCount": 0,
     "imports": [

--- a/src/data/research/problems/erdos-1059-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1059-oq-01-oq-01.json
@@ -14,8 +14,8 @@
         "proven": [
             "primesInLevel, qualifyingInLevel: interval-level counting functions for primes and qualifying primes in each primorial interval",
             "strong_selberg_density: axiom capturing Selberg sieve's quantitative prediction — qualifying fraction ≥ l/(l+1) at each level",
-            "primes_growth_in_levels: axiom — at least l primes per level (very weak PNT)",
-            "qualifyingInLevel_pos: PROVED q(l) ≥ 1 for l ≥ 3 from strong axiom + growth",
+            "primesInLevel_pos: PROVED p(l) ≥ 1 for l ≥ 1 from Bertrand's postulate — was the axiom primes_growth_in_levels (p(l) ≥ l); axiom count reduced 2 → 1",
+            "qualifyingInLevel_pos: PROVED q(l) ≥ 1 for l ≥ 3 from strong axiom + primesInLevel_pos",
             "strong_implies_weak: PROVED strong axiom recovers selberg_density_axiom",
             "levelwise_density_bound: PROVED l/(l+1) ≥ k/(k+1) monotonicity for interval counts",
             "levelwise_strict_surplus: PROVED per-level surplus ≥ 1 for l ≥ max(3, k+2)",
@@ -30,16 +30,16 @@
     "currentState": {
         "phase": "COMPLETED",
         "since": "2026-04-12T00:00:00Z",
-        "iteration": 1,
-        "focus": "Verified deliverable already complete in main: proofs/Proofs/Erdos1059OQ01OQ01.lean and gallery entry erdos-1059-oq-01-oq-01 (status axiomatized)."
+        "iteration": 2,
+        "focus": "2026-07-08: eliminated the primes_growth_in_levels axiom (proved primesInLevel_pos p(l) >= 1 from Bertrand's postulate; downstream needs only positivity), reducing axiomCount 2 -> 1. Also repaired several latent build breaks that had been merged without Lean CI (density_one_at_factorials witness N0+1 and a sum_mul bridge; card>=1 rewrites via Finset.one_le_card; a ring_nf that left an unsolved <=). File now builds under Mathlib v4.26 (3068 jobs, 0 sorries, 1 axiom)."
     },
     "knowledge": {
-        "progressSummary": "COMPLETED (axiomatized) in main (480 lines, 11 theorems, 0 sorries, axiomCount 2, badge 'axiom'); the stated assumptions are isolated as named axioms per the axiom-integrity policy. Investigates whether density_one_conjecture can be derived from selberg_density_axiom. Shows the weak axiom is provably insufficient, introduces a strong Selberg density axiom (qualifying fraction ≥ l/(l+1) at each level), and proves it implies density at factorial evaluation points. Identifies the precise mathematical gap for general x: factorial growth of interval sizes prevents aggregation of level-wise bounds.",
+        "progressSummary": "COMPLETED (axiomatized) in main (496 lines, 12 theorems, 0 sorries, axiomCount 1, badge 'axiom'); the stated assumptions are isolated as named axioms per the axiom-integrity policy. Investigates whether density_one_conjecture can be derived from selberg_density_axiom. Shows the weak axiom is provably insufficient, introduces a strong Selberg density axiom (qualifying fraction ≥ l/(l+1) at each level), and proves it implies density at factorial evaluation points. Identifies the precise mathematical gap for general x: factorial growth of interval sizes prevents aggregation of level-wise bounds.",
         "builtItems": [
             "primesInLevel, qualifyingInLevel: interval-level counting functions for primes and qualifying primes in each primorial interval",
             "strong_selberg_density: axiom capturing Selberg sieve's quantitative prediction — qualifying fraction ≥ l/(l+1) at each level",
-            "primes_growth_in_levels: axiom — at least l primes per level (very weak PNT)",
-            "qualifyingInLevel_pos: PROVED q(l) ≥ 1 for l ≥ 3 from strong axiom + growth",
+            "primesInLevel_pos: PROVED p(l) ≥ 1 for l ≥ 1 from Bertrand's postulate — was the axiom primes_growth_in_levels (p(l) ≥ l); axiom count reduced 2 → 1",
+            "qualifyingInLevel_pos: PROVED q(l) ≥ 1 for l ≥ 3 from strong axiom + primesInLevel_pos",
             "strong_implies_weak: PROVED strong axiom recovers selberg_density_axiom",
             "levelwise_density_bound: PROVED l/(l+1) ≥ k/(k+1) monotonicity for interval counts",
             "levelwise_strict_surplus: PROVED per-level surplus ≥ 1 for l ≥ max(3, k+2)",


### PR DESCRIPTION
## Summary

De-axiomatizes `Proofs/Erdos1059OQ01OQ01.lean` and repairs several latent build failures. **axiomCount 2 → 1, 0 sorries**, builds under Mathlib v4.26.

### Axiom elimination (the headline)

The former axiom `primes_growth_in_levels` (`p(l) ≥ l`, "weak PNT") is replaced by the **proved theorem** `primesInLevel_pos`:

```lean
theorem primesInLevel_pos (l : ℕ) (hl : l ≥ 1) : primesInLevel l ≥ 1
```

proved from **Bertrand's postulate** (`Nat.exists_prime_lt_and_le_two_mul`): the interval `I(l) = (l!, (l+1)!]` contains a prime because Bertrand gives one in `(l!, 2·l!]` and `2·l! ≤ (l+1)!` for `l ≥ 1`.

Both downstream consumers (`qualifyingInLevel_pos`, `levelwise_strict_surplus`) only ever needed **positivity** of the level prime count — the surplus argument turns on `p·(l−k) > 0`, i.e. `p ≥ 1`, not the far stronger `p ≥ l`. So the growth axiom was never actually necessary. The sole remaining axiom is the genuinely deep `strong_selberg_density` (Selberg-sieve quantitative prediction).

### Latent build repairs

This file had been merged **without Lean CI** (math PRs bypass it) and did **not** build on `main` under Mathlib v4.26. Fixed:

- `density_one_at_factorials`: witness `max N₀ 1` → `N₀ + 1` (the level-sum bound is applied at `n-1`, needing `n-1 ≥ N₀`); plus a `Finset.sum_mul` bridge between `(∑ qₗ)·(k+1)` and `∑ (qₗ·(k+1))`.
- `primesInLevel_pos` / `qualifyingPrime_exists`: `card ≥ 1` via `ge_iff_le` + `Finset.one_le_card` (the previously-used `Nat.one_le_iff_ne_zero` does not exist).
- `h_low_deficit`: a `ring_nf` that left an unsolved `x ≤ x` → `le_of_eq (mul_comm _ _)`.
- added `import Mathlib.NumberTheory.Bertrand`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos1059OQ01OQ01` → `✔ Built (3068 jobs)`, 0 errors, **0 sorries, 1 axiom**. (Two pre-existing unused-`hn` linter warnings in the decomposition theorems remain; harmless.)

Gallery `meta.json`, `annotations.json`, and the research JSON are reconciled: axiomCount 2→1, theoremCount 11→12, lineCount 480→496, and all prose describing the former axiom updated to its new proved-theorem status.

## Honesty note

The remaining axiom `strong_selberg_density` is the real analytic content (Selberg sieve + Brun–Titchmarsh) and is **not** Mathlib-eliminable; the problem stays `axiomatized`. The all-`x` extension beyond factorial points remains open (documented in-file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)