### PR TITLE
research(erdos-101-oq-04): reusable four-point-line counting engine [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualityMaximal.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualityMaximal.lean
@@ -1,0 +1,240 @@
+import Mathlib
+import Proofs.CauchySchwarzIntegralLpDualityIngredients
+import Proofs.CauchySchwarzIntegralLpDualityConsistency
+import Proofs.CauchySchwarzIntegralLpDualityGluing
+import Proofs.CauchySchwarzIntegralLpDualityExtension
+
+open MeasureTheory ENNReal
+noncomputable section
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+namespace RieszLpDualityMaximal
+
+/-- **General-measure Riesz reduction (abstract form).**
+
+    Given, for a fixed functional `φ`, an abstract extension-by-zero family `ext`
+    with its coeFn characterisation, the σ-finite Riesz theorem *with the norm bound*
+    (`Hσ`), and the five already-verified Mathlib-only ingredient facts
+    (representer monotonicity `Hmono`, representer consistency `Hcons`, σ-finiteness of a
+    countable union `HsigU`, and the gluing/vanishing lemma `Hglue`), the arbitrary-measure
+    Riesz representation holds.  This is the Folland (2nd ed.) Theorem 6.16 maximising-hull
+    construction: form `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` over σ-finite-restricted sets, realise it on
+    a countable union hull `T`, and for each `f` glue on `U = T ∪ supp f`. -/
+theorem riesz_general
+    {p q : ℝ≥0∞} (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)]
+    (φ : Lp ℝ p μ →L[ℝ] ℝ)
+    (ext : ∀ (S : Set α), MeasurableSet S → (Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ))
+    (hext : ∀ (S : Set α) (hS : MeasurableSet S) (f : Lp ℝ p (μ.restrict S)),
+      (ext S hS f : α → ℝ) =ᵐ[μ] S.indicator (f : α → ℝ))
+    (Hσ : ∀ (S : Set α) (hS : MeasurableSet S), SigmaFinite (μ.restrict S) →
+      ∃ g : α → ℝ, MemLp g q (μ.restrict S) ∧
+        eLpNorm g q (μ.restrict S) ≤ ENNReal.ofReal ‖φ‖ ∧
+        ∀ f : Lp ℝ p (μ.restrict S),
+          φ (ext S hS f) = ∫ a, (f : α → ℝ) a * g a ∂(μ.restrict S))
+    (Hmono : ∀ {S S' : Set α} (hS : MeasurableSet S) (hS' : MeasurableSet S'), S ⊆ S' →
+      ∀ {gS gS' : α → ℝ}, MemLp gS q (μ.restrict S) → MemLp gS' q (μ.restrict S') →
+        (∀ f : Lp ℝ p (μ.restrict S), φ (ext S hS f) = ∫ a, (f : α → ℝ) a * gS a ∂(μ.restrict S)) →
+        (∀ f : Lp ℝ p (μ.restrict S'), φ (ext S' hS' f) = ∫ a, (f : α → ℝ) a * gS' a ∂(μ.restrict S')) →
+        eLpNorm gS q (μ.restrict S) ≤ eLpNorm gS' q (μ.restrict S'))
+    (Hcons : ∀ {S S' : Set α} (hS : MeasurableSet S) (hS' : MeasurableSet S'), S ⊆ S' →
+      ∀ {gS gS' : α → ℝ}, MemLp gS q (μ.restrict S) → MemLp gS' q (μ.restrict S') →
+        (∀ f : Lp ℝ p (μ.restrict S), φ (ext S hS f) = ∫ a, (f : α → ℝ) a * gS a ∂(μ.restrict S)) →
+        (∀ f : Lp ℝ p (μ.restrict S'), φ (ext S' hS' f) = ∫ a, (f : α → ℝ) a * gS' a ∂(μ.restrict S')) →
+        gS =ᵐ[μ.restrict S] gS')
+    (HsigU : ∀ (S : ℕ → Set α), (∀ n, MeasurableSet (S n)) →
+      (∀ n, SigmaFinite (μ.restrict (S n))) → SigmaFinite (μ.restrict (⋃ n, S n)))
+    (Hglue : ∀ {g : α → ℝ} {T U : Set α}, MeasurableSet T → MeasurableSet U → T ⊆ U →
+      q ≠ 0 → q ≠ ∞ → MemLp g q (μ.restrict U) →
+      eLpNorm g q (μ.restrict U) ≤ eLpNorm g q (μ.restrict T) →
+      g =ᵐ[μ.restrict (U \ T)] 0) :
+    ∃ g : α → ℝ, MemLp g q μ ∧
+      ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
+  have hp0 : p ≠ 0 := (lt_of_lt_of_le zero_lt_one hp1.le).ne'
+  have hqtr : (1:ℝ) < q.toReal := (Real.holderConjugate_iff.mp hpq.symm).1
+  have hq0 : q ≠ 0 := by rintro rfl; simp only [ENNReal.toReal_zero] at hqtr; linarith
+  have hqtop : q ≠ ∞ := by rintro rfl; simp only [ENNReal.toReal_top] at hqtr; linarith
+  set A : Set ℝ := {r | ∃ (S : Set α) (hS : MeasurableSet S), SigmaFinite (μ.restrict S) ∧
+      ∃ g : α → ℝ, MemLp g q (μ.restrict S) ∧
+        eLpNorm g q (μ.restrict S) ≤ ENNReal.ofReal ‖φ‖ ∧
+        (∀ f : Lp ℝ p (μ.restrict S), φ (ext S hS f) = ∫ a, (f : α → ℝ) a * g a ∂(μ.restrict S)) ∧
+        (eLpNorm g q (μ.restrict S)).toReal = r} with hA_def
+  have hAne : A.Nonempty := by
+    obtain ⟨g0, hg0, hg0b, hg0r⟩ := Hσ ∅ MeasurableSet.empty (by
+      rw [Measure.restrict_empty]; infer_instance)
+    exact ⟨_, ∅, MeasurableSet.empty, (by rw [Measure.restrict_empty]; infer_instance),
+      g0, hg0, hg0b, hg0r, rfl⟩
+  have hAbdd : BddAbove A := by
+    refine ⟨‖φ‖, ?_⟩
+    rintro r ⟨S, hS, hSσ, g, hg, hgb, hgr, rfl⟩
+    have hfin : eLpNorm g q (μ.restrict S) ≠ ⊤ :=
+      ne_top_of_le_ne_top ENNReal.ofReal_ne_top hgb
+    calc (eLpNorm g q (μ.restrict S)).toReal
+        ≤ (ENNReal.ofReal ‖φ‖).toReal := (ENNReal.toReal_le_toReal hfin ENNReal.ofReal_ne_top).mpr hgb
+      _ = ‖φ‖ := ENNReal.toReal_ofReal (norm_nonneg _)
+  set c : ℝ := sSup A with hc_def
+  have hstep : ∀ n : ℕ, ∃ (S : Set α) (hS : MeasurableSet S), SigmaFinite (μ.restrict S) ∧
+      ∃ g : α → ℝ, MemLp g q (μ.restrict S) ∧
+        eLpNorm g q (μ.restrict S) ≤ ENNReal.ofReal ‖φ‖ ∧
+        (∀ f : Lp ℝ p (μ.restrict S), φ (ext S hS f) = ∫ a, (f : α → ℝ) a * g a ∂(μ.restrict S)) ∧
+        c - 1 / (n + 1 : ℝ) < (eLpNorm g q (μ.restrict S)).toReal := by
+    intro n
+    have hlt : c - 1 / (n + 1 : ℝ) < c := by
+      have : (0:ℝ) < 1 / (n + 1 : ℝ) := by positivity
+      linarith
+    obtain ⟨a, haA, hca⟩ := exists_lt_of_lt_csSup hAne hlt
+    obtain ⟨S, hS, hSσ, g, hg, hgb, hgr, hgeq⟩ := haA
+    exact ⟨S, hS, hSσ, g, hg, hgb, hgr, by rw [hgeq]; exact hca⟩
+  choose Sq hSqm hSqσ gq hgqmem hgqb hgqrep hgqapx using hstep
+  set T : Set α := ⋃ n, Sq n with hT_def
+  have hTm : MeasurableSet T := MeasurableSet.iUnion hSqm
+  have hTσ : SigmaFinite (μ.restrict T) := HsigU Sq hSqm hSqσ
+  obtain ⟨gT, hgTmem, hgTb, hgTrep⟩ := Hσ T hTm hTσ
+  have hgT_fin : eLpNorm gT q (μ.restrict T) ≠ ⊤ :=
+    ne_top_of_le_ne_top ENNReal.ofReal_ne_top hgTb
+  have hgT_le_c : (eLpNorm gT q (μ.restrict T)).toReal ≤ c :=
+    le_csSup hAbdd ⟨T, hTm, hTσ, gT, hgTmem, hgTb, hgTrep, rfl⟩
+  have hc_le_gT : c ≤ (eLpNorm gT q (μ.restrict T)).toReal := by
+    apply le_of_forall_pos_lt_add
+    intro ε hε
+    obtain ⟨n, hn⟩ := exists_nat_one_div_lt hε
+    have hsub : Sq n ⊆ T := Set.subset_iUnion Sq n
+    have hmono : eLpNorm (gq n) q (μ.restrict (Sq n)) ≤ eLpNorm gT q (μ.restrict T) :=
+      Hmono (hSqm n) hTm hsub (hgqmem n) hgTmem (hgqrep n) hgTrep
+    have hgqfin : eLpNorm (gq n) q (μ.restrict (Sq n)) ≠ ⊤ :=
+      ne_top_of_le_ne_top ENNReal.ofReal_ne_top (hgqb n)
+    have hmono' : (eLpNorm (gq n) q (μ.restrict (Sq n))).toReal
+        ≤ (eLpNorm gT q (μ.restrict T)).toReal :=
+      (ENNReal.toReal_le_toReal hgqfin hgT_fin).mpr hmono
+    have hax := hgqapx n
+    linarith
+  have hNT : (eLpNorm gT q (μ.restrict T)).toReal = c := le_antisymm hgT_le_c hc_le_gT
+  refine ⟨T.indicator gT, (memLp_indicator_iff_restrict hTm).mpr hgTmem, ?_⟩
+  intro f
+  obtain ⟨Sf, hSfm, hf_ae, hSfσ⟩ :=
+    ((Lp.memLp f).aefinStronglyMeasurable hp0 hptop).exists_set_sigmaFinite
+  set U : Set α := T ∪ Sf with hU_def
+  have hUm : MeasurableSet U := hTm.union hSfm
+  haveI : SigmaFinite (μ.restrict T) := hTσ
+  haveI : SigmaFinite (μ.restrict Sf) := hSfσ
+  have hUσ : SigmaFinite (μ.restrict U) := inferInstance
+  obtain ⟨gU, hgUmem, hgUb, hgUrep⟩ := Hσ U hUm hUσ
+  have hgU_fin : eLpNorm gU q (μ.restrict U) ≠ ⊤ := ne_top_of_le_ne_top ENNReal.ofReal_ne_top hgUb
+  have hTU : T ⊆ U := Set.subset_union_left
+  have hcons : gT =ᵐ[μ.restrict T] gU := Hcons hTm hUm hTU hgTmem hgUmem hgTrep hgUrep
+  have hnormT : eLpNorm gU q (μ.restrict T) = eLpNorm gT q (μ.restrict T) :=
+    eLpNorm_congr_ae hcons.symm
+  have hgUT_fin : eLpNorm gU q (μ.restrict T) ≠ ⊤ := by rw [hnormT]; exact hgT_fin
+  have hgU_le_c : (eLpNorm gU q (μ.restrict U)).toReal ≤ c :=
+    le_csSup hAbdd ⟨U, hUm, hUσ, gU, hgUmem, hgUb, hgUrep, rfl⟩
+  have hle : eLpNorm gU q (μ.restrict U) ≤ eLpNorm gU q (μ.restrict T) := by
+    apply (ENNReal.toReal_le_toReal hgU_fin hgUT_fin).mp
+    rw [hnormT, hNT]; exact hgU_le_c
+  have hglue : gU =ᵐ[μ.restrict (U \ T)] 0 := Hglue hTm hUm hTU hq0 hqtop hgUmem hle
+  have hfU_mem : MemLp (f : α → ℝ) p (μ.restrict U) := (Lp.memLp f).restrict U
+  set fU : Lp ℝ p (μ.restrict U) := hfU_mem.toLp _ with hfU_def
+  have hfU_coe : (fU : α → ℝ) =ᵐ[μ.restrict U] (f : α → ℝ) := hfU_mem.coeFn_toLp
+  have hextU_eq : ext U hUm fU = f := by
+    apply Lp.ext
+    have h1 : (ext U hUm fU : α → ℝ) =ᵐ[μ] U.indicator (fU : α → ℝ) := hext U hUm fU
+    have h2 : U.indicator (fU : α → ℝ) =ᵐ[μ] U.indicator (f : α → ℝ) :=
+      (ae_eq_restrict_iff_indicator_ae_eq hUm).mp hfU_coe
+    have hf_aeU : (f : α → ℝ) =ᵐ[μ.restrict Uᶜ] 0 := by
+      have hsub : Uᶜ ⊆ Sfᶜ := Set.compl_subset_compl.mpr Set.subset_union_right
+      exact ae_mono (Measure.restrict_mono hsub le_rfl) hf_ae
+    have h3 : U.indicator (f : α → ℝ) =ᵐ[μ] (f : α → ℝ) :=
+      indicator_ae_eq_of_restrict_compl_ae_eq_zero hUm hf_aeU
+    exact (h1.trans h2).trans h3
+  have hrep : φ f = ∫ a, (fU : α → ℝ) a * gU a ∂(μ.restrict U) := by
+    rw [← hextU_eq]; exact hgUrep fU
+  have hrep2 : φ f = ∫ a, (f : α → ℝ) a * gU a ∂(μ.restrict U) := by
+    rw [hrep]; exact integral_congr_ae (hfU_coe.mono fun a ha => by simp only [ha])
+  haveI hHolder : ENNReal.HolderConjugate p q := by
+    rw [ENNReal.holderConjugate_iff]
+    have hpinv : p⁻¹ ≠ ⊤ := ENNReal.inv_ne_top.mpr hp0
+    have hqinv : q⁻¹ ≠ ⊤ := ENNReal.inv_ne_top.mpr hq0
+    have key : (p⁻¹ + q⁻¹).toReal = (1 : ℝ≥0∞).toReal := by
+      rw [ENNReal.toReal_add hpinv hqinv, ENNReal.toReal_inv, ENNReal.toReal_inv,
+          ENNReal.toReal_one]
+      exact hpq.inv_add_inv_eq_one
+    have hsum : p⁻¹ + q⁻¹ ≠ ⊤ := by finiteness
+    exact (ENNReal.toReal_eq_toReal_iff' hsum (by simp)).mp key
+  have hint : Integrable (fun a => (f : α → ℝ) a * gU a) (μ.restrict U) :=
+    hfU_mem.integrable_mul hgUmem
+  have hsplit := (integral_add_compl hTm hint).symm
+  have hcompl0 : ∫ a in Tᶜ, (f : α → ℝ) a * gU a ∂(μ.restrict U) = 0 := by
+    rw [Measure.restrict_restrict hTm.compl]
+    have hset : Tᶜ ∩ U = U \ T := by rw [Set.inter_comm, Set.diff_eq]
+    rw [hset]
+    apply integral_eq_zero_of_ae
+    filter_upwards [hglue] with a ha
+    simp [ha]
+  have hTint : ∫ a in T, (f : α → ℝ) a * gU a ∂(μ.restrict U)
+      = ∫ a, (f : α → ℝ) a * gT a ∂(μ.restrict T) := by
+    rw [Measure.restrict_restrict hTm, Set.inter_eq_left.mpr hTU]
+    apply integral_congr_ae
+    filter_upwards [hcons] with a ha
+    rw [ha]
+  rw [hrep2, hsplit, hcompl0, add_zero, hTint]
+  have hind : ∀ a, (f : α → ℝ) a * (T.indicator gT) a
+      = T.indicator (fun x => (f : α → ℝ) x * gT x) a := by
+    intro a; by_cases h : a ∈ T <;>
+      simp [Set.indicator_of_mem, Set.indicator_of_notMem, h]
+  simp_rw [hind]
+  exact (integral_indicator hTm).symm
+
+/-- **General-measure Riesz reduction (concrete form).**  Discharges the abstract
+    reduction using the concrete Mathlib-only ingredients (`extByZeroCLM`, representer
+    consistency/monotonicity, countable-union σ-finiteness, gluing).  Takes only the
+    σ-finite Riesz theorem *with the norm bound* (`Hσ`) as a hypothesis — exactly the
+    output of `RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set` (modulo the
+    extension-map used to state the pullback).  Wiring this to the σ-finite chain
+    discharges the `riesz_lp_surjective` axiom. -/
+theorem riesz_general_of_sigmaFinite
+    {p q : ℝ≥0∞} (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)]
+    (φ : Lp ℝ p μ →L[ℝ] ℝ)
+    (Hσ : ∀ (S : Set α) (hS : MeasurableSet S), SigmaFinite (μ.restrict S) →
+      ∃ g : α → ℝ, MemLp g q (μ.restrict S) ∧
+        eLpNorm g q (μ.restrict S) ≤ ENNReal.ofReal ‖φ‖ ∧
+        ∀ f : Lp ℝ p (μ.restrict S),
+          φ (RieszLpDualityExtension.extByZeroCLM hS
+              (lt_of_lt_of_le zero_lt_one hp1.le).ne' hptop f)
+            = ∫ a, (f : α → ℝ) a * g a ∂(μ.restrict S)) :
+    ∃ g : α → ℝ, MemLp g q μ ∧
+      ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
+  have hp0 : p ≠ 0 := (lt_of_lt_of_le zero_lt_one hp1.le).ne'
+  refine riesz_general hp1 hptop hpq φ
+    (fun S hS => RieszLpDualityExtension.extByZeroCLM hS hp0 hptop)
+    (fun S hS f => RieszLpDualityExtension.extByZeroCLM_coeFn hS hp0 hptop f)
+    Hσ ?_ ?_ ?_ ?_
+  · -- Hmono
+    intro S S' hS hS' hSS' gS gS' hgS hgS' hrepS hrepS'
+    exact RieszLpDualityConsistency.representer_eLpNorm_mono_of_subset hpq hS hS' hSS' φ
+      hgS hgS'
+      (RieszLpDualityExtension.extByZeroCLM hS hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM_coeFn hS hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM hS' hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM_coeFn hS' hp0 hptop)
+      hrepS hrepS'
+  · -- Hcons
+    intro S S' hS hS' hSS' gS gS' hgS hgS' hrepS hrepS'
+    exact RieszLpDualityConsistency.representer_ae_eq_of_subset hpq hS hS' hSS' φ
+      hgS hgS'
+      (RieszLpDualityExtension.extByZeroCLM hS hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM_coeFn hS hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM hS' hp0 hptop)
+      (RieszLpDualityExtension.extByZeroCLM_coeFn hS' hp0 hptop)
+      hrepS hrepS'
+  · -- HsigU
+    exact fun S hSm hSσ => RieszLpDualityIngredients.sigmaFinite_restrict_iUnion hSm hSσ
+  · -- Hglue
+    exact fun hT hU hTU hq0 hqtop hg hle =>
+      RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le hT hU hTU hq0 hqtop hg hle
+
+end RieszLpDualityMaximal
+
+end
+
+#print axioms RieszLpDualityMaximal.riesz_general
+#print axioms RieszLpDualityMaximal.riesz_general_of_sigmaFinite

--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -125,6 +125,76 @@ theorem exists_four_collinear_subset_of_count_pos (P : PlanarPointSet)
   obtain ⟨hS_pow, hcard, hwitness⟩ := hS
   exact ⟨S, Finset.mem_powerset.mp hS_pow, hcard, hwitness⟩
 
+/- ## Reusable counting engine (axiom-free)
+
+Every explicit lower-bound witness in this file — `crossSet` (≥ 2),
+`asteriskSet` (≥ 3), `gridSet` (≥ 10) — establishes its bound by the
+*same* two-step argument: exhibit a finite family of four-point
+collinear subsets of `P.points`, then compare cardinalities against
+the powerset-filter that *defines* `fourPointLineCount`.  The two
+lemmas below factor that comparison out once and for all, so a future
+construction only has to supply the geometry (the collinear quadruples
+and their distinctness) and never re-derive the `Finset.card_le_card`
+plumbing.  This separates the *easy* counting from the *hard* geometry
+that is the genuine open content of `grunbaum_lower_bound_three_halves`
+and `solymosi_stojakovic_lower_bound`. -/
+
+/-- **Counting lower bound from a family of four-point lines (set form).**
+If `T` is a finite collection of subsets of `P.points`, each of size
+`4` and each collinear (carrying two distinct anchors `a, b` with all
+of `S` collinear with `a, b`), then `T.card ≤ fourPointLineCount P`.
+
+This is the exact converse plumbing of
+`exists_four_collinear_subset_of_count_pos`: rather than *extract* one
+line from a positive count, it *aggregates* many certified lines into a
+lower bound.  Because `T` is a `Finset` of `Finset`s, its own
+`T.card` already accounts for distinctness — the caller proves the
+quadruples are pairwise distinct exactly once, when building `T`. -/
+theorem fourPointLineCount_ge_of_subset (P : PlanarPointSet)
+    (T : Finset (Finset (ℝ × ℝ)))
+    (hmem : ∀ S ∈ T, S ⊆ P.points)
+    (hcard : ∀ S ∈ T, S.card = 4)
+    (hcol : ∀ S ∈ T, ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧
+      ∀ p ∈ S, collinear a b p) :
+    T.card ≤ fourPointLineCount P := by
+  rw [fourPointLineCount]
+  apply Finset.card_le_card
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨hmem S hS, hcard S hS, hcol S hS⟩
+
+/-- **Counting lower bound from an injective family (indexed form).**
+If `L : Fin k → Finset (ℝ × ℝ)` is an injective family of four-point
+collinear subsets of `P.points`, then `k ≤ fourPointLineCount P`.  This
+is the shape a growing construction naturally produces — one four-point
+line per index — so injectivity of `L` (no two indices name the same
+line) is the *only* combinatorial obligation beyond the per-line
+geometry.  Derived from `fourPointLineCount_ge_of_subset` applied to
+`Finset.univ.image L`. -/
+theorem fourPointLineCount_ge_of_injOn_family (P : PlanarPointSet) (k : ℕ)
+    (L : Fin k → Finset (ℝ × ℝ))
+    (hmem : ∀ i, L i ⊆ P.points)
+    (hcard : ∀ i, (L i).card = 4)
+    (hcol : ∀ i, ∃ a b : ℝ × ℝ, a ∈ L i ∧ b ∈ L i ∧ a ≠ b ∧
+      ∀ p ∈ L i, collinear a b p)
+    (hinj : Function.Injective L) :
+    k ≤ fourPointLineCount P := by
+  have hsub := fourPointLineCount_ge_of_subset P (Finset.univ.image L)
+    (by
+      intro S hS
+      simp only [Finset.mem_image, Finset.mem_univ, true_and] at hS
+      obtain ⟨i, rfl⟩ := hS; exact hmem i)
+    (by
+      intro S hS
+      simp only [Finset.mem_image, Finset.mem_univ, true_and] at hS
+      obtain ⟨i, rfl⟩ := hS; exact hcard i)
+    (by
+      intro S hS
+      simp only [Finset.mem_image, Finset.mem_univ, true_and] at hS
+      obtain ⟨i, rfl⟩ := hS; exact hcol i)
+  rwa [Finset.card_image_of_injective _ hinj, Finset.card_univ,
+    Fintype.card_fin] at hsub
+
 /-- **Lower bound vacuous below size 4**: for `P` with fewer than 4
 points, no four-point line exists.  Restatement of
 `fourPointLineCount_lt_four` to fix the OQ-04 namespace conventions. -/

--- a/research/problems/erdos-101-oq-04/state.md
+++ b/research/problems/erdos-101-oq-04/state.md
@@ -1,27 +1,55 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-03-30T16:34:54.971Z
-**Iteration**: 1
+**Phase**: ACT
+**Since**: 2026-07-08T00:00:00Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Reusable counting infrastructure for lower-bound witnesses.
 
 ## Active Approach
 
-None yet.
+Path B (explicit constructions). This iteration factored out the counting
+engine shared by every witness (`crossSet`, `asteriskSet`, `gridSet`): the
+`subset-of-filter → Finset.card_le_card` argument that turns a family of
+certified four-point collinear quadruples into a lower bound on
+`fourPointLineCount`.
+
+## Progress This Iteration (VERIFIED, 0-axiom)
+
+Added two general lemmas to `Proofs/Erdos101OQ04.lean` (build-verified,
+3062 jobs, only the two pre-existing OPEN sorries remain):
+
+- `fourPointLineCount_ge_of_subset` — set form: any `Finset` `T` of
+  four-point collinear subsets of `P.points` gives `T.card ≤
+  fourPointLineCount P`.
+- `fourPointLineCount_ge_of_injOn_family` — indexed form: an injective
+  family `L : Fin k → Finset (ℝ×ℝ)` of four-point collinear subsets gives
+  `k ≤ fourPointLineCount P` (the natural shape a growing construction
+  produces — one line per index).
+
+These separate the *easy* counting from the *hard* geometry that is the
+genuine open content, so future construction PRs supply only the collinear
+quadruples and their distinctness/injectivity.
 
 ## Blockers
 
-None.
+The two OPEN construction sorries are unchanged and remain the frontier:
+- `grunbaum_lower_bound_three_halves` (Ω(n^{3/2}))
+- `solymosi_stojakovic_lower_bound` (n^{2−o(1)})
+A general-n growing witness still needs a clean "no five collinear" proof
+(ruling out accidental cross-gadget alignments for all n) — grids alone
+cap at 10 four-point lines under the no-five-collinear constraint.
 
 ## Next Action
 
-Begin problem exploration.
+Build a concrete growing family and discharge `k ≤ fourPointLineCount`
+through `fourPointLineCount_ge_of_injOn_family`; the remaining work is the
+per-family no-five-collinear certificate.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/research/problems/erdos-101-oq-04.json
+++ b/src/data/research/problems/erdos-101-oq-04.json
@@ -29,22 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED, 0-axiom): added a non-vacuous framework witness in Erdos101OQ04.lean. The file previously exhibited only the general-position arc (realParabolaSet, fourPointLineCount=0), inhabiting just IsLowerBoundConstruction _ 0. Added explicit 5-point set W={(0,0),(1,0),(2,0),(3,0),(0,1)} proving IsLowerBoundConstruction W 1, plus exists_isLowerBoundConstruction_pos (|W|=5>4 with positive threshold). Build-verified via direct lean compile (Docker containerd content-store still down host-wide with input/output error); #print axioms of the four new theorems shows only [propext, Classical.choice, Quot.sound] (no sorryAx, no ofReduceBool). The two OPEN sorries (grunbaum_lower_bound_three_halves Omega(n^3/2), solymosi_stojakovic_lower_bound n^{2-o(1)}) remain untouched genuine open constructions.",
+    "progressSummary": "PROGRESS (VERIFIED, 0-axiom): factored out the counting engine shared by every explicit witness in Erdos101OQ04.lean. Every lower-bound theorem (crossSet>=2, asteriskSet>=3, gridSet>=10) re-derived the same subset-of-filter -> Finset.card_le_card argument by hand. Added two reusable general lemmas: fourPointLineCount_ge_of_subset (any Finset T of four-point collinear subsets of P.points yields T.card <= fourPointLineCount P) and fourPointLineCount_ge_of_injOn_family (an injective family L : Fin k -> Finset(RxR) of four-point collinear subsets yields k <= fourPointLineCount P -- the shape a growing construction produces, one line per index). Build-verified via docker-build (3062 jobs); only the two pre-existing OPEN sorries (grunbaum_lower_bound_three_halves Omega(n^3/2), solymosi_stojakovic_lower_bound n^{2-o(1)}) remain, both untouched. The new lemmas use only standard Finset/Fintype API (card_le_card, mem_filter, mem_powerset, card_image_of_injective, card_univ, card_fin) -- no sorry, no native_decide; axioms are the ordinary trio only.",
     "builtItems": [
       "Erdos101OQ04.witnessPoints/witnessSet: explicit 5-point ppset {(0,0),(1,0),(2,0),(3,0),(0,1)} (VERIFIED)",
       "Erdos101OQ04.witnessSet_isLowerBoundConstruction: IsLowerBoundConstruction witnessSet 1, 0 axioms (VERIFIED)",
-      "Erdos101OQ04.exists_isLowerBoundConstruction_pos: framework floor > arc zero for a >4-point set (VERIFIED)"
+      "Erdos101OQ04.exists_isLowerBoundConstruction_pos: framework floor > arc zero for a >4-point set (VERIFIED)",
+      "Erdos101OQ04.fourPointLineCount_ge_of_subset: Finset T of four-point collinear subsets -> T.card <= fourPointLineCount P (VERIFIED, 0-axiom)",
+      "Erdos101OQ04.fourPointLineCount_ge_of_injOn_family: injective L : Fin k -> Finset four-point collinear subsets -> k <= fourPointLineCount P (VERIFIED, 0-axiom)"
     ],
     "insights": [
       "The realParabolaSet arc has fourPointLineCount=0, so the file only inhabited IsLowerBoundConstruction _ 0 before this session; the four collinear x-axis points of W give the first positive four-point-line count witness (>=1) with no five collinear.",
-      "Both remaining sorries are genuine OPEN constructions: Grunbaum Omega(n^3/2) needs a sumset/grid built ON TOP of the no-three-collinear parabola base (parabola alone has 0 four-point lines); Solymosi-Stojakovic n^{2-o(1)} needs ~600-1000 LOC of measure-theoretic random-projection infra (Path A)."
+      "Both remaining sorries are genuine OPEN constructions: Grunbaum Omega(n^3/2) needs a sumset/grid built ON TOP of the no-three-collinear parabola base (parabola alone has 0 four-point lines); Solymosi-Stojakovic n^{2-o(1)} needs ~600-1000 LOC of measure-theoretic random-projection infra (Path A).",
+      "The counting half of every witness lower bound is identical (subset of the defining powerset-filter, then Finset.card_le_card); factoring it out leaves future constructions to supply only geometry (the collinear quadruples) plus distinctness/injectivity.",
+      "The injective-family form is the natural interface for a GROWING construction: it produces one four-point line per index i : Fin k, and the only combinatorial obligation beyond per-line geometry is that distinct indices name distinct lines (Function.Injective L)."
     ],
     "mathlibGaps": [
       "No mathlib gap for the witness; the OPEN Path A (Solymosi-Stojakovic) needs a measure-zero certificate for algebraic varieties in projection-parameter space, not currently in Mathlib in usable form."
     ],
     "nextSteps": [
-      "Non-vacuity gap is now closed (witness verified 0-axiom); the frontier stays the two OPEN construction sorries.",
-      "Path B (Grunbaum): next brick is a concrete finite construction with a PROVABLE positive lower bound on fourPointLineCount that grows (e.g. k disjoint 4-point lines with no cross-collinearity) - the hard part is ruling out accidental alignments for all n."
+      "Build a concrete growing family L : Fin k -> Finset(RxR) of four-point collinear subsets and discharge k <= fourPointLineCount via fourPointLineCount_ge_of_injOn_family; the remaining hard work is the per-family no-five-collinear certificate (ruling out accidental cross-gadget alignments for all n).",
+      "Grids cap at 10 four-point lines under no-five-collinear (each line <= 4 points forces a <= 4x4 grid), so a growing witness must be non-grid (near-pencil / convex-position tiny clusters), where the frontier is the all-n no-five-collinear proof."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Erdős #101 OQ-04 (higher-dimensional / four-point-line lower bounds). This iteration adds the **reusable counting engine** that every explicit lower-bound witness in `Proofs/Erdos101OQ04.lean` was re-deriving by hand.

`crossSet` (≥2), `asteriskSet` (≥3), and `gridSet` (≥10) each prove their bound by the *same* two-step argument: exhibit a finite family of four-point collinear subsets of `P.points`, then compare cardinalities against the powerset-filter that *defines* `fourPointLineCount`. Two new general lemmas factor that comparison out once:

- **`fourPointLineCount_ge_of_subset`** — set form: any `Finset T` of four-point collinear subsets of `P.points` gives `T.card ≤ fourPointLineCount P`.
- **`fourPointLineCount_ge_of_injOn_family`** — indexed form: an injective family `L : Fin k → Finset (ℝ × ℝ)` of four-point collinear subsets gives `k ≤ fourPointLineCount P` — the natural shape a *growing* construction produces (one line per index), reducing the combinatorial obligation to `Function.Injective L`.

This separates the **easy counting** from the **hard geometry** that is the genuine open content.

## Verification

- Build-verified via `./proofs/scripts/docker-build.sh Proofs.Erdos101OQ04` (3062 jobs, success).
- New lemmas use only standard `Finset`/`Fintype` API (`card_le_card`, `mem_filter`, `mem_powerset`, `card_image_of_injective`, `card_univ`, `card_fin`) — **no `sorry`, no `native_decide`**; axioms are the ordinary trio (`propext`, `Classical.choice`, `Quot.sound`).
- The two pre-existing OPEN sorries (`grunbaum_lower_bound_three_halves` Ω(n^{3/2}), `solymosi_stojakovic_lower_bound` n^{2−o(1)}) are **untouched** and remain the frontier.

## Status

`axiomatized` overall (file still carries the two OPEN construction sorries); the two new lemmas are `verified` 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)