### PR TITLE
audit: reconcile stale counts (erdos-214 theoremCount, liouville-theorem-oq-03 lineCount)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11707,9 +11707,9 @@
     },
     "erdos-214": {
       "agentId": "lean-auditor-reaudit",
-      "auditCount": 5,
-      "lastAudited": "2026-07-08T18:06:14Z",
-      "result": "clean",
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T18:46:32Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-214-incomplete-01-oq-01": {
@@ -22375,8 +22375,8 @@
       "result": "clean"
     },
     "liouville-theorem-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-07-08T18:16:34Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T18:46:32Z",
       "result": "issues-fixed",
       "issues": [
         "theoremCount stale (leanFile=21, meta=17; actual=19) \u2014 reconciled to 19"

--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -80,7 +80,7 @@
     "axiomCount": 1,
     "lineCount": 237,
     "assumptions": "1 axiom: juhasz_stronger (Juhász 1979 — a unit-distance-free set's complement contains a congruent copy of ANY 4-point configuration). The original Problem #214 statement (juhasz_1979 : Erdos214Statement) is no longer a separate axiom: it is DERIVED from juhasz_stronger via the proved reduction unit_square_from_stronger (a unit square is a special 4-point configuration, transported into the complement by Juhász's isometry). 0 sorries.",
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Erdos214ProblemAristotle.lean"
@@ -193,7 +193,7 @@
     "namespace": "Erdos214",
     "lineCount": 237,
     "axiomCount": 1,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 13,
     "path": "Proofs/Erdos214Problem.lean",
     "sorries": 0,

--- a/src/data/proofs/liouville-theorem-oq-03/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-03/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-06-24",
     "axiomCount": 1,
     "assumptions": "One axiom: `dimH_wellApprox` — the Jarník–Besicovitch dimension formula dimH(W τ) = ENNReal.ofReal(2/τ) for τ ≥ 2. This is the deep theorem of metric Diophantine approximation (Jarník 1931, Besicovitch 1934) and is not yet available in Mathlib (the upper bound requires a covering/Borel–Cantelli Hausdorff-measure estimate; the lower bound a mass-distribution principle / Frostman construction on a Cantor subset). `#print axioms` confirms: the structural lemmas (wellApprox_antitone, liouville_subset_wellApprox, dimH_liouville_le_wellApprox, and the jbDim exponent facts) depend on no axioms beyond the standard foundational trio; only the formula-dependent results (dimH_wellApprox_two, dimH_liouville_le, dimH_liouville_eq_zero, the summary) carry dimH_wellApprox.",
-    "lineCount": 210,
+    "lineCount": 268,
     "theoremCount": 19,
     "definitionCount": 2,
     "originalContributions": [


### PR DESCRIPTION
## Gallery Integrity Audit

Re-audit sweep of 4 changed-since-audit metas (commit date > tracker.lastAudited). Two carried genuine stale count fields; the other two (connected-space-oq-01-oq-01, cauchy-schwarz-oq-03-oq-03) were clean.

### erdos-214 — `theoremCount` 3-way mismatch
- **meta.meta.theoremCount**: 5
- **leanFile.theoremCount**: 6
- **actual**: 8 real theorems (L105,113,121,143,146,168,206,226) + 1 docstring false-match at L77
- **Fix**: both → 8. `definitionCount` (13), `lineCount` (237), `axiomCount` (1) already correct.

### liouville-theorem-oq-03 — stale `meta.meta.lineCount`
- **meta.meta.lineCount**: 210 (stale)
- **leanFile.lineCount / actual `wc -l`**: 268
- PR #35412 reconciled `theoremCount` but missed this second `lineCount` field (the two lineCount fields lag independently).
- **Fix**: meta.meta.lineCount → 268.

Both are LOW-severity cosmetic data mismatches. No `status`/`badge` overclaim — both remain accurate. Tracker updated (`issues-fixed`).

---
Discovered during autonomous gallery integrity audit.