### PR TITLE
Enrich: Positivity and Spectral Range of Orthogonal Compressions — line-anchored full-file sections

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/meta.json
@@ -105,16 +105,40 @@
   },
   "sections": [
     {
-      "title": "Positivity of Compressions (Operator Form)",
-      "content": "compress_isPositive proves that for a positive operator T (Mathlib's LinearMap.IsPositive: symmetric with re ⟪T x, x⟫ ≥ 0 for all x) and any subspace H, the orthogonal compression compress T H is again positive. Symmetry comes from isSymmetric_compress applied to hT.isSymmetric. For the Rayleigh nonnegativity, the inner product ⟪compress T H y, y⟫_H rewrites to ⟪T ↑y, ↑y⟫_V via compress_apply and the orthogonal-projection adjoint identity Submodule.inner_orthogonalProjection_eq_of_mem_right, so 0 ≤ re ⟪T ↑y, ↑y⟫ (from hT) finishes. No eigenvalues, no spectral theorem, and the subspace H is arbitrary."
+      "title": "Header and Setup",
+      "startLine": 1,
+      "endLine": 49,
+      "content": "The header docstring frames the two textbook corollaries the file delivers — positivity of compressions (operator form) and the Schur–Horn (majorization) direction's eigenvalue consequences — and explicitly disclaims full equality-majorization of the zero-padded length-(n+m) spectrum as a dimension mismatch. The imports pull in the gallery's own Poincaré separation (Proofs.CauchyInterlacingPoincare) and explicit orthogonal compression (Proofs.CauchyInterlacingCompression) files, so no new spectral theory is introduced. The opens (InnerProductSpace, BigOperators, CauchyInterlacing.Poincare) and the enclosing namespace CauchyInterlacing.MajorizationPositivity are established here."
     },
     {
-      "title": "Nonnegative Eigenvalues and Trace",
-      "content": "compress_eigenvalues_nonneg reads the eigenvalue form of positivity off the Poincaré lower bound: if every eigenvalue λ i of T is nonnegative, then for each k the chain 0 ≤ λ_{k+m} ≤ μ_k gives 0 ≤ μ_k. trace_compress_nonneg then lifts this through Finset.sum_nonneg to conclude the trace ∑_k μ_k of a PSD compression is nonnegative — the eigenvalue-side companion of trace nonnegativity for positive operators."
+      "title": "Positivity of Compressions (Operator Form)",
+      "startLine": 51,
+      "endLine": 76,
+      "content": "compress_isPositive proves that for a positive operator T (Mathlib's LinearMap.IsPositive: symmetric with re ⟪T x, x⟫ ≥ 0 for all x) and any subspace H, the orthogonal compression compress T H is again positive. Symmetry comes from isSymmetric_compress applied to hT.isSymmetric. For the Rayleigh nonnegativity, the inner product ⟪compress T H y, y⟫_H rewrites to ⟪T ↑y, ↑y⟫_V via compress_apply and the orthogonal-projection adjoint identity Submodule.inner_orthogonalProjection_eq_of_mem_right, so 0 ≤ re ⟪T ↑y, ↑y⟫ (from hT) finishes. No eigenvalues, no spectral theorem, and the subspace H is arbitrary. This section is self-contained (its own `section Positivity` with only the finite-dimensional inner-product-space variables) and does not touch the Poincaré hypothesis bundle."
+    },
+    {
+      "title": "Shared Poincaré Hypothesis Bundle",
+      "startLine": 78,
+      "endLine": 92,
+      "content": "The three eigenvalue corollaries all consume the same elaborate Poincaré setup, so it is factored into a single section variable block: the operator T with eigenbasis b and descending spectrum lam (hT, hlam), an n-dimensional subspace H (hHdim), the compression TH with eigenbasis bH and descending spectrum mu (hTH, hmu), and the Rayleigh-agreement hypothesis hRayleigh linking the two quotients. Because Lean 4 auto-includes only variables appearing in a theorem's statement, the explicit include forces the whole package — consumed solely inside the proof bodies via poincare_separation — into every theorem in the section. hRayleigh is the only link between compression and full operator the corollaries need, so the file never re-opens the spectral theorem."
+    },
+    {
+      "title": "Nonnegative Compression Eigenvalues",
+      "startLine": 94,
+      "endLine": 101,
+      "content": "compress_eigenvalues_nonneg reads the eigenvalue form of positivity off the Poincaré lower bound: if every eigenvalue λ i of T is nonnegative, then for each k the chain 0 ≤ λ_{k+m} ≤ μ_k gives 0 ≤ μ_k, discharged by a single le_trans (hpos _) (poincare_separation …).1. This is the eigenvalue-side companion of the operator-form compress_isPositive."
     },
     {
       "title": "Spectral-Range Containment",
-      "content": "compress_eigenvalue_mem_Icc sandwiches every compression eigenvalue inside the spectral range of T: μ_k ∈ [λ_{n+m-1}, λ_0] = [λ_min, λ_max]. The lower endpoint comes from λ_{n+m-1} ≤ λ_{k+m} ≤ μ_k and the upper from μ_k ≤ λ_k ≤ λ_0, each endpoint comparison supplied by antitonicity of λ on the Fin indices and the matching Poincaré bound. This is the uniform two-sided statement that the compression spectrum never escapes the full spectrum's range."
+      "startLine": 103,
+      "endLine": 121,
+      "content": "compress_eigenvalue_mem_Icc sandwiches every compression eigenvalue inside the spectral range of T: μ_k ∈ [λ_{n+m-1}, λ_0] = [λ_min, λ_max]. The lower endpoint comes from λ_{n+m-1} ≤ λ_{k+m} ≤ μ_k and the upper from μ_k ≤ λ_k ≤ λ_0, each endpoint comparison supplied by antitonicity of λ on the Fin indices (reduced to Fin.le_def plus omega) and the matching Poincaré bound. This is the uniform two-sided statement that the compression spectrum never escapes the full spectrum's range."
+    },
+    {
+      "title": "Nonnegative Trace of a PSD Compression",
+      "startLine": 123,
+      "endLine": 130,
+      "content": "trace_compress_nonneg lifts eigenvalue nonnegativity through Finset.sum_nonneg to conclude the trace ∑_k μ_k of a PSD compression is nonnegative, since each summand μ_k ≥ 0 by compress_eigenvalues_nonneg. It is the eigenvalue-side companion of trace nonnegativity for positive operators."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-02-oq-02` (quality 94, passes 0).

This entry was already deep and well under all size caps (meta 16.9 KB → 19.3 KB, cap ~60 KB). The one genuine gap was the `sections` array: it had 3 thematic sections with **no** `startLine`/`endLine` anchors and did not cover the header docstring or the shared Poincaré hypothesis `include` block.

Changes (meta.json only):
- Added `startLine`/`endLine` anchors to every section for in-page navigation.
- Added a **Header and Setup** section (docstring + imports/opens/namespace, lines 1–49).
- Added a **Shared Poincaré Hypothesis Bundle** section (the `variable`/`include` block, lines 78–92) — previously only surfaced in annotations.
- Split the merged eigenvalue/trace section into file-order **Nonnegative Compression Eigenvalues** and **Nonnegative Trace** sections so the array now covers the full 130-line Lean file contiguously.

No content deleted; no collection near its cap. JSON validated; size guardrail passes (all entries ≤ 60 KB).