### PR TITLE
research(erdos-703-incomplete-01): Frankl-Füredi franklFurediOdd is r-avoiding + T(n,r) lower bound [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -297,6 +297,41 @@ def franklFurediEven (n r : ℕ) : Finset (Finset ℕ) :=
   (Finset.range n).powerset.filter
     (fun A => (A.filter (· ≠ 0)).card ≥ (n + r) / 2 ∨ A.card < r)
 
+/--
+**Two members of `franklFurediOdd` avoid `r`-intersection.**
+Generalizes `large_sets_avoid_1` (the `r = 1` case) to all `r`. Three cases:
+* both sets large (`|A|, |B| > (n+r)/2`): inclusion–exclusion gives
+  `|A ∩ B| ≥ |A| + |B| - n ≥ 2⌊(n+r)/2⌋ + 2 - n ≥ r + 1 > r` (both parities);
+* either set small (`|·| < r`): `|A ∩ B| ≤ min(|A|,|B|) < r`.
+In every case `|A ∩ B| ≠ r`.
+-/
+theorem franklFurediOdd_avoids_r (n r : ℕ) : avoidsRIntersection r (franklFurediOdd n r) := by
+  intro A B hA hB
+  rw [franklFurediOdd, Finset.mem_filter, Finset.mem_powerset] at hA hB
+  obtain ⟨hAsub, hAcond⟩ := hA
+  obtain ⟨hBsub, hBcond⟩ := hB
+  have hie := Finset.card_union_add_card_inter A B
+  have hunion : (A ∪ B).card ≤ n := by
+    calc (A ∪ B).card ≤ (Finset.range n).card :=
+          Finset.card_le_card (Finset.union_subset hAsub hBsub)
+      _ = n := Finset.card_range n
+  have hiA : (A ∩ B).card ≤ A.card := Finset.card_le_card Finset.inter_subset_left
+  have hiB : (A ∩ B).card ≤ B.card := Finset.card_le_card Finset.inter_subset_right
+  rcases hAcond with hAlarge | hAsmall <;> rcases hBcond with hBlarge | hBsmall <;> omega
+
+/--
+**Lower bound on `T(n,r)` from the Frankl–Füredi `franklFurediOdd` construction.**
+Since `franklFurediOdd n r` is a valid `r`-avoiding subfamily of `2^{[n]}`, its
+cardinality bounds `T(n,r)` below. This is the general-`r` analogue of
+`largeSetsFamily_card_le_T`.
+-/
+theorem franklFurediOdd_card_le_T (n r : ℕ) : (franklFurediOdd n r).card ≤ T n r := by
+  have hmem : franklFurediOdd n r ∈
+      ((Finset.range n).powerset.powerset).filter (avoidsRIntersection r) := by
+    rw [Finset.mem_filter]
+    exact ⟨Finset.mem_powerset.mpr (Finset.filter_subset _ _), franklFurediOdd_avoids_r n r⟩
+  exact Finset.le_sup hmem
+
 /-
 ## Part V: The Main Question - Exponential Bound
 

--- a/research/problems/erdos-703-incomplete-01/state.md
+++ b/research/problems/erdos-703-incomplete-01/state.md
@@ -1,26 +1,37 @@
 # State: erdos-703-incomplete-01
 
-## Current Phase: OBSERVE
+## Current Phase: ACT (progress)
 
-**Phase**: OBSERVE  
-**Status**: Active  
-**Started**: 2026-04-03T05:22:49  
-**Last Updated**: 2026-04-03T05:22:49
+**Phase**: ACT
+**Status**: Active
+**Last Updated**: 2026-07-08
 
 ## Progress Summary
 
-Initial workspace created by Seeker. Ready for Researcher to begin OBSERVE phase.
+The gallery file `Erdos703Problem.lean` has **0 real sorries** (the only `sorry`
+token is inside a docstring) and **1 deep axiom** (`frankl_rodl_1987`, the
+Frankl–Rödl 1987 exponential bound — genuinely open-literature, not
+Mathlib-eliminable). The stale "1 sorry / 2 axioms" in the seed metadata was
+incorrect.
 
-## Current Focus
+This session added verified content around the previously **defined-but-unused**
+Frankl–Füredi families:
 
-Read gallery proof and understand the sorry statement(s) that need completion.
+- `franklFurediOdd_avoids_r (n r)` : the family `{A ⊆ [n] : |A| > (n+r)/2 ∨ |A| < r}`
+  is a valid `r`-avoiding family, for **all** `r` (both parities of `n+r`).
+  Generalizes the existing `r = 1` result `large_sets_avoid_1`.
+- `franklFurediOdd_card_le_T (n r)` : consequently `|franklFurediOdd n r| ≤ T(n,r)`,
+  the general-`r` analogue of `largeSetsFamily_card_le_T`.
+
+Build: `docker-build.sh Proofs.Erdos703Problem` → 7743 jobs, 0 errors, 0 sorries.
 
 ## Blockers
 
-None currently identified.
+The main question (`mainQuestion` / `frankl_rodl_1987`) is a deep 1987 theorem
+with no Mathlib pathway; it remains an axiom. Not eliminable this session.
 
 ## Next Action
 
-1. Read `problem.md` thoroughly
-2. Examine the gallery Lean source at `src/data/proofs/erdos-703/`
-3. Identify what the sorry statement(s) require
+Optional: prove `franklFurediEven` avoids `r`-intersection under `Even (n + r)`
+(the parity-matched optimal family), and/or a Frankl–Füredi exactness statement
+for fixed `r` and large `n`.

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -186,9 +186,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 380,
+    "lineCount": 415,
     "axiomCount": 1,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #703 (Forbidden r-Intersection Families). The gallery file
`Erdos703Problem.lean` has **0 real sorries** (the seed metadata's "1 sorry / 2
axioms" was stale — the lone `sorry` token is inside a docstring) and **1 deep
axiom** `frankl_rodl_1987` (the Frankl–Rödl 1987 exponential bound, genuinely
open-literature and not Mathlib-eliminable).

The `franklFurediOdd` / `franklFurediEven` families were **defined but carried no
verified properties**. This PR proves the odd family is a genuine lower-bound
construction for all `r`, generalizing the existing `r = 1` result (#35358).

## Added theorems (both VERIFIED)

- **`franklFurediOdd_avoids_r (n r)`** — the family `{A ⊆ [n] : |A| > (n+r)/2 ∨ |A| < r}`
  avoids `r`-intersection for **all** `r` and both parities of `n+r`.
  Proof by inclusion–exclusion: two large sets give `|A ∩ B| ≥ 2⌊(n+r)/2⌋ + 2 − n ≥ r + 1`;
  if either set is small then `|A ∩ B| ≤ min(|A|,|B|) < r`. Generalizes `large_sets_avoid_1`.
- **`franklFurediOdd_card_le_T (n r)`** — hence `|franklFurediOdd n r| ≤ T(n,r)`,
  the general-`r` analogue of `largeSetsFamily_card_le_T`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos703Problem` → **7743 jobs, 0 errors,
0 sorries, 1 axiom** (`frankl_rodl_1987`, unchanged).

Synced `meta.json` `leanFile` counts (`lineCount` 380→415, `theoremCount` 9→11).

## Status

The main question (`mainQuestion`, answered by the deep Frankl–Rödl axiom) is not
eliminable and remains axiomatized. This PR adds machine-checked structural
content around the extremal constructions; it does not close the open axiom.