### PR TITLE
research(erdos-1022-oq-02): formalize c_t→∞ existential for bounded ground sets [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -230,4 +230,57 @@ theorem firstMoment_threshold_ge_self (t : ℕ) (ht : 1 ≤ t) :
 theorem firstMomentThreshold_two : firstMomentThreshold 2 = 2 := by
   unfold firstMomentThreshold; norm_num
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 6: The threshold diverges — a formal `c_t → ∞`
+-- ══════════════════════════════════════════════════════════════════
+
+/-- Truncated integer division by a fixed positive constant is cofinal: as the
+    dividend runs to infinity so does the quotient.  This is the arithmetic hook
+    that survives dividing the exponential threshold by a fixed ground-set size. -/
+theorem tendsto_div_const_atTop {n : ℕ} (hn : 0 < n) :
+    Filter.Tendsto (· / n) Filter.atTop Filter.atTop := by
+  rw [Filter.tendsto_atTop_atTop]
+  intro b
+  refine ⟨b * n, fun m hm => ?_⟩
+  rw [Nat.le_div_iff_mul_le hn]
+  exact hm
+
+/-- **The first-moment threshold tends to infinity.**  `firstMomentThreshold t
+    = 2^{t-1} → ∞` as `t → ∞`.  This upgrades the pointwise bound
+    `firstMoment_threshold_ge_self` (`t ≤ 2^{t-1}`) to the actual limit
+    statement, making precise the `c_t → ∞` that Problem #1022 asks for. -/
+theorem firstMomentThreshold_tendsto_atTop :
+    Filter.Tendsto firstMomentThreshold Filter.atTop Filter.atTop :=
+  Filter.tendsto_atTop_mono' _
+    (by
+      filter_upwards [Filter.eventually_ge_atTop 1] with t ht
+      exact firstMoment_threshold_ge_self t ht)
+    Filter.tendsto_id
+
+/-- **An admissible sparseness coefficient exists and diverges (bounded ground
+    set).**  Over any *fixed* nonempty ground set `V`, the explicit function
+    `c(t) = ⌊2^{t-1} / |V|⌋` satisfies both halves of Erdős #1022's existential
+    in the first-moment regime:
+
+    * `c(t) → ∞` as `t → ∞` (the divergence the problem requires), and
+    * every `c(t)`-sparse family whose members all have size at least `t ≥ 1`
+      has Property B.
+
+    This packages the whole file into the exact logical shape of the conjecture
+    (`∃ c, (c → ∞) ∧ (sparse ⟹ Property B)`), *honestly restricted* to bounded
+    ground sets: the divisor `|V|` is the fixed cardinality, so the crude
+    ground-set bound (and hence this construction) degrades once `V` is allowed
+    to grow with the family — precisely the untouched hard regime. -/
+theorem exists_admissible_coeff (hV : 0 < Fintype.card V) :
+    ∃ c : ℕ → ℕ, Filter.Tendsto c Filter.atTop Filter.atTop ∧
+      ∀ (F : Finset (Finset V)) (t : ℕ), 1 ≤ t →
+        (∀ e ∈ F, t ≤ e.card) → IsSparse F (c t) → HasPropertyB F := by
+  refine ⟨fun t => firstMomentThreshold t / Fintype.card V, ?_, ?_⟩
+  · exact (tendsto_div_const_atTop hV).comp firstMomentThreshold_tendsto_atTop
+  · intro F t ht hmin hsparse
+    refine propertyB_of_sparse F t _ ht hmin hsparse ?_
+    calc firstMomentThreshold t / Fintype.card V * Fintype.card V
+          ≤ firstMomentThreshold t := Nat.div_mul_le_self _ _
+      _ = 2 ^ (t - 1) := rfl
+
 end Erdos1022OQ02

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1022-oq-02",
   "title": "Growth Rate of the Property-B Sparseness Threshold",
   "slug": "erdos-1022-oq-02",
-  "description": "Addresses OQ-02 of Erdős #1022 (the growth rate of the sparseness threshold c_t) in the first-moment regime. Instantiating the local sparseness condition at the whole ground set bounds the family size, |F| < c·|V|; combined with a minimum-size generalization of Erdős's first-moment theorem this yields the explicit criterion c·|V| ≤ 2^{t-1} ⟹ Property B. The admissible threshold 2^{t-1} doubles with each unit increase of t, i.e. grows exponentially. Does NOT resolve the open conjecture (the crude ground-set bound fails once V grows with F).",
+  "description": "Addresses OQ-02 of Erdős #1022 (the growth rate of the sparseness threshold c_t) in the first-moment regime. Instantiating the local sparseness condition at the whole ground set bounds the family size, |F| < c·|V|; combined with a minimum-size generalization of Erdős's first-moment theorem this yields the explicit criterion c·|V| ≤ 2^{t-1} ⟹ Property B. The admissible threshold 2^{t-1} doubles with each unit increase of t, i.e. grows exponentially. Does NOT resolve the open conjecture (the crude ground-set bound fails once V grows with F). This iteration packages the whole argument into the exact logical shape of the conjecture for bounded ground sets: the explicit coefficient c(t)=⌊2^{t-1}/|V|⌋ is proved to diverge (Filter.Tendsto atTop) and to certify Property B for every c(t)-sparse family of minimum size t (exists_admissible_coeff), formalizing the \"c_t → ∞\" the problem literally asks for.",
   "meta": {
     "author": "Erdős (first-moment slice)",
     "sourceUrl": "https://erdosproblems.com/1022",
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 233,
+    "lineCount": 286,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 11,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",
@@ -168,6 +168,16 @@
       "name": "firstMoment_threshold_doubles",
       "type": "proved",
       "description": "The admissible threshold 2^{t-1} doubles per unit increase of t — exponential growth rate"
+    },
+    {
+      "name": "exists_admissible_coeff",
+      "type": "proved",
+      "description": "Bounded-ground-set form of Erdős #1022's existential: the explicit coefficient c(t)=⌊2^{t-1}/|V|⌋ diverges (c_t→∞) and certifies Property B for every c(t)-sparse family of min-size-t sets"
+    },
+    {
+      "name": "firstMomentThreshold_tendsto_atTop",
+      "type": "proved",
+      "description": "The first-moment threshold 2^{t-1} tends to infinity — a formal Filter.Tendsto statement of c_t→∞ upgrading the pointwise t≤2^{t-1} bound"
     }
   ],
   "references": [
@@ -193,5 +203,8 @@
       "note": "First moment method and Property B"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "status": "verified",
+  "badge": "verified",
+  "axiomCount": 0
 }


### PR DESCRIPTION
## Summary

Extends the first-moment Property-B file `Proofs/Erdos1022OQ02.lean` (Erdős #1022, OQ-02: growth rate of the sparseness threshold) with a new **§ 6** that packages the existing criterion into the exact logical shape of the conjecture's existential, and makes the "`c_t → ∞`" claim a formal limit statement.

Erdős #1022 asks: *is there a function `c : ℕ → ℕ` with `c(t) → ∞` such that every `c(t)`-sparse family of sets of size `≥ t` has Property B?* The prior file proved the first-moment criterion `c·|V| ≤ 2^{t-1} ⟹ Property B` and that the threshold `2^{t-1}` doubles per step. This PR closes the loop to the problem's own `∃ c, (c → ∞) ∧ (…)` form for **bounded ground sets**.

## New results (all machine-checked, 0 axioms)

- **`tendsto_div_const_atTop`** — truncated integer division `⌊·/n⌋` by a fixed `n > 0` is cofinal (`Tendsto atTop atTop`). The arithmetic hook that survives dividing the exponential threshold by a fixed ground-set size.
- **`firstMomentThreshold_tendsto_atTop`** — `firstMomentThreshold t = 2^{t-1} → ∞` as a genuine `Filter.Tendsto … atTop atTop`, upgrading the pointwise `t ≤ 2^{t-1}` bound (`firstMoment_threshold_ge_self`) to the actual divergence.
- **`exists_admissible_coeff`** — for any fixed nonempty ground set `V`, the explicit coefficient `c(t) = ⌊2^{t-1}/|V|⌋` satisfies **both** halves of Erdős #1022's existential in the first-moment regime: `c(t) → ∞`, and every `c(t)`-sparse family whose members all have size `≥ t ≥ 1` has Property B.

## Honest scope

Unchanged from the base file: this does **not** resolve Problem #1022. The witness divides by the *fixed* cardinality `|V|`, so the construction (like the crude ground-set bound it rests on) degrades once `V` is allowed to grow with the family — the genuinely hard regime (large ground sets, Lovász's `c_2 = 1` matching argument) is untouched. What is added is the precise divergence statement and the conjecture-shaped packaging for bounded ground sets.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1022OQ02` → **exit 0**, `Built Proofs.Erdos1022OQ02` (7744/7744)
- 0 sorries, 0 `axiom` declarations, no `native_decide`
- `meta.json` synced: 8 → 11 theorems, 233 → 286 lines, `mainTheorems` updated, `status: verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)