### PR TITLE
research(erdos-897-oq-01): converse of (3) is false — Ω separates plain unboundedness from the #897 hypothesis [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -211,4 +211,62 @@ theorem stronglyAdditive_unboundedOnPrimePowers_iff {f : ℕ → ℝ}
     rw [hfp, pow_one]
     exact hpp
 
+/-
+## (5) The converse of (3) fails: `Ω` separates "plainly unbounded" from the hypothesis
+
+Theorem (3) shows the Erdős #897 hypothesis forces plain unboundedness on prime powers.
+The converse is **false**, and `Ω` (`bigOmega`) is the witness. `Ω` is completely
+additive with `Ω(p^k) = k`, so `Ω(2^k) = k → ∞` — it is plainly unbounded on prime
+powers. Yet it FAILS the normalized hypothesis: `Ω(p) = 1` for every prime while
+`log p ≥ log 2`, so via the completely-additive reduction the hypothesis would demand
+`1 > M·log p` at every `M`, which fails already at `M = 1/log 2`. Hence "unbounded on
+prime powers" is strictly weaker than the #897 hypothesis "unbounded relative to `log`".
+-/
+
+/-- `Ω(p) = 1` for a prime `p`: its factor list with multiplicity is `[p]`. -/
+theorem bigOmega_prime {p : ℕ} (hp : p.Prime) : bigOmega p = 1 := by
+  simp [bigOmega, Nat.primeFactorsList_prime hp]
+
+/-- **Selectivity for `Ω`.** The total-prime-factor count fails the hypothesis. Via the
+completely-additive reduction it would require some prime with `Ω(p) = 1 > M·log p` for
+every `M`; at `M = 1/log 2` this forces `log p < log 2`, impossible for a prime `p ≥ 2`. -/
+theorem not_unboundedOnPrimePowers_bigOmega : ¬ UnboundedOnPrimePowers bigOmega := by
+  rw [completelyAdditive_unboundedOnPrimePowers_iff bigOmega bigOmega_completelyAdditive]
+  push_neg
+  refine ⟨1 / Real.log 2, ?_⟩
+  intro p hp
+  rw [bigOmega_prime hp]
+  have hlog2 : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  have hlogp : Real.log 2 ≤ Real.log p :=
+    Real.log_le_log (by norm_num) (by exact_mod_cast hp.two_le)
+  have hnn : (0 : ℝ) ≤ 1 / Real.log 2 := by positivity
+  have hmul : (1 / Real.log 2) * Real.log 2 ≤ (1 / Real.log 2) * Real.log p :=
+    mul_le_mul_of_nonneg_left hlogp hnn
+  have hinv : (1 / Real.log 2) * Real.log 2 = 1 := by field_simp
+  linarith
+
+/-- `Ω` is nonetheless **plainly** unbounded on prime powers: `Ω(2^k) = k` exceeds any
+bound. Sharp complement to `not_unboundedOnPrimePowers_bigOmega`. -/
+theorem bigOmega_unbounded_on_primePowers :
+    ∀ B : ℝ, ∃ p k : ℕ, p.Prime ∧ 1 ≤ k ∧ bigOmega (p ^ k) > B := by
+  intro B
+  refine ⟨2, ⌈B⌉₊ + 1, Nat.prime_two, by omega, ?_⟩
+  have hval : bigOmega (2 ^ (⌈B⌉₊ + 1)) = ((⌈B⌉₊ + 1 : ℕ) : ℝ) := by
+    rw [bigOmega_completelyAdditive.2 2 (⌈B⌉₊ + 1) Nat.prime_two, bigOmega_prime Nat.prime_two]
+    ring
+  rw [hval]
+  have hceil : B ≤ (⌈B⌉₊ : ℝ) := Nat.le_ceil B
+  push_cast
+  linarith
+
+/-- **The converse of (3) is false (headline).** There is an additive function that is
+plainly unbounded on prime powers yet fails the Erdős #897 hypothesis, so the two
+notions of unboundedness are genuinely distinct. Witness: `Ω = bigOmega`. -/
+theorem unbounded_not_implies_unboundedOnPrimePowers :
+    ∃ f : ℕ → ℝ, IsAdditive f ∧
+      (∀ B : ℝ, ∃ p k : ℕ, p.Prime ∧ 1 ≤ k ∧ f (p ^ k) > B) ∧
+      ¬ UnboundedOnPrimePowers f :=
+  ⟨bigOmega, bigOmega_completelyAdditive.1, bigOmega_unbounded_on_primePowers,
+    not_unboundedOnPrimePowers_bigOmega⟩
+
 end Erdos897

--- a/research/problems/erdos-897-oq-01/knowledge.md
+++ b/research/problems/erdos-897-oq-01/knowledge.md
@@ -36,3 +36,21 @@ never actually built. This session builds them for real.
 
 **Status:** gallery entry now `verified`/`original`. Part I forward implication stays
 OPEN (documented, not asserted).
+
+## Session 2026-07-08b (researcher-1) — converse of (3) is false: Ω separates the notions
+
+Re-served an already-completed slug (file/gallery existed, verified). Added a
+**genuinely new** section (5) to `Erdos897OQ01.lean` sharpening theorem (3):
+
+- `bigOmega_prime` : Ω(p)=1 for prime p (factor list [p]).
+- `not_unboundedOnPrimePowers_bigOmega` : Ω FAILS the #897 hypothesis — via the
+  parent's completely-additive reduction, would need Ω(p)=1 > M·log p ∀M; at
+  M=1/log2 forces log p < log2, impossible for prime p≥2.
+- `bigOmega_unbounded_on_primePowers` : yet Ω(2^k)=k is plainly unbounded.
+- `unbounded_not_implies_unboundedOnPrimePowers` (headline) : ∃ additive f plainly
+  unbounded on prime powers but failing the hypothesis ⟹ the converse of theorem
+  (3) is FALSE; "unbounded on prime powers" ⊊ "unbounded relative to log".
+
+File now 272 L, 13 thm / 1 def, 0 axioms, 0 sorries, no native_decide. VERIFIED
+(exit-135 line-less crash on 1st build = infra, passed on retry).
+Reused parent's `bigOmega_completelyAdditive` + `completelyAdditive_..._iff`.

--- a/research/problems/erdos-897-oq-01/state.md
+++ b/research/problems/erdos-897-oq-01/state.md
@@ -21,7 +21,9 @@ differences?) remains OPEN — needs genuine analytic number theory, not asserte
 
 ## Next Action
 
-None for this slug. Part I forward implication is a research-frontier open problem.
+Part I forward implication remains a research-frontier open problem. Session
+2026-07-08b added the converse-of-(3) separation (Ω plainly unbounded but fails the
+normalized hypothesis). Further additive-function theory possible but frontier is analytic.
 
 ## Attempt Counts
 

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -129,11 +129,11 @@
       "Finset"
     ],
     "namespace": "Erdos897",
-    "lineCount": 214,
+    "lineCount": 272,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 9
+    "theoremCount": 13
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Erdős #897 OQ-01, companion file `Erdos897OQ01.lean`. The file's theorem (3)
(`unboundedOnPrimePowers_unbounded`) shows the #897 hypothesis
`UnboundedOnPrimePowers f` (`f` unbounded *relative to* `log` on prime powers)
forces **plain** unboundedness on prime powers. This PR adds section (5) proving
the **converse is false**, so the two notions are genuinely distinct.

Witness: `Ω = bigOmega` (total prime factors with multiplicity), which the parent
file already proves completely additive with `Ω(p^k) = k`.

## Added theorems (all VERIFIED, 0 axioms / 0 sorries)

- **`bigOmega_prime`** — `Ω(p) = 1` for a prime `p`.
- **`not_unboundedOnPrimePowers_bigOmega`** — `Ω` fails the #897 hypothesis. Via the
  parent's `completelyAdditive_unboundedOnPrimePowers_iff`, satisfying it would
  require `Ω(p) = 1 > M·log p` for a prime at *every* `M`; at `M = 1/log 2` this
  forces `log p < log 2`, impossible for a prime `p ≥ 2`.
- **`bigOmega_unbounded_on_primePowers`** — yet `Ω(2^k) = k` is plainly unbounded.
- **`unbounded_not_implies_unboundedOnPrimePowers`** (headline) — `∃` additive `f`
  plainly unbounded on prime powers but failing the hypothesis. Hence "unbounded on
  prime powers" is strictly weaker than the #897 hypothesis "unbounded relative to
  `log`".

This complements the existing selectivity results (`log` and `ω` fail because they
are *bounded* relative to `log`) with a function that is *unbounded* on prime powers
and still fails — pinning down exactly what the normalization buys.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos897OQ01` → **7744 jobs, 0 errors, 0
sorries, 0 axioms, no `native_decide`**. Synced `meta.json` `leanFile`
(`lineCount` 214→272, `theoremCount` 9→13).

## Status

Part I's forward implication (does prime-power growth relative to `log` force
unbounded normalized consecutive differences?) remains a genuine open analytic-NT
problem and is **not** asserted. This PR only sharpens the verified surrounding
theory.