### PR TITLE
research(dirichlets-theorem-oq-02-oq-03): completeness — p3 enumerates exactly the primes ≡3 (mod 4) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -167,6 +167,48 @@ theorem p3_lt_succ (k : ℕ) : p3 k < p3 (k + 1) := by
 theorem p3_strictMono : StrictMono p3 :=
   strictMono_nat_of_lt_succ p3_lt_succ
 
+/-! ### `p3` enumerates *exactly* the primes ≡ 3 (mod 4)
+
+Strict monotonicity says `p3` lists primes `≡ 3 (mod 4)` in increasing order
+without repetition; what makes "`p3 k` is *the* k-th such prime" rigorous is the
+*completeness* statement — no prime `≡ 3 (mod 4)` is skipped.  This follows from
+the minimality of `nextP3` (`nextP3_le_of`): the values of `p3` are gapless. -/
+
+/-- `p3` grows at least as fast as the index (a strictly increasing `ℕ → ℕ`
+sequence dominates the identity).  Used to locate any target below some `p3 k`. -/
+theorem p3_le_self (k : ℕ) : k ≤ p3 k := by
+  induction k with
+  | zero => simp
+  | succ k ih => have := p3_lt_succ k; omega
+
+/-- **Completeness of the enumeration.**  Every prime `q ≡ 3 (mod 4)` occurs as
+`p3 k` for some `k`; combined with `p3_strictMono` this certifies that `p3` is
+the increasing enumeration of *all* primes `≡ 3 (mod 4)`, so `p3 k` really is the
+`k`-th such prime and the tower bound `p3_le_tower` bounds every one of them. -/
+theorem p3_surjective {q : ℕ} (hq : Nat.Prime q) (hmod : q % 4 = 3) :
+    ∃ k, p3 k = q := by
+  have hex : ∃ k, q ≤ p3 k := ⟨q, p3_le_self q⟩
+  have hk : q ≤ p3 (Nat.find hex) := Nat.find_spec hex
+  refine ⟨Nat.find hex, le_antisymm ?_ hk⟩
+  rcases Nat.eq_zero_or_pos (Nat.find hex) with h0 | hpos
+  · -- q ≤ p3 0 = 3, and a prime ≡ 3 (mod 4) is ≥ 3, so q = 3
+    rw [h0]; have hq2 := hq.two_le; simp only [p3]; omega
+  · -- the predecessor is below q, so minimality of nextP3 pins p3 (Nat.find hex) ≤ q
+    obtain ⟨j, hj⟩ := Nat.exists_eq_succ_of_ne_zero hpos.ne'
+    have hmin : p3 j < q :=
+      not_le.mp (Nat.find_min hex (show j < Nat.find hex by omega))
+    rw [hj, p3_succ]
+    exact nextP3_le_of hmin hq hmod
+
+/-- **`p3` characterizes the primes `≡ 3 (mod 4)`.**  A number is a value of the
+enumeration iff it is a prime `≡ 3 (mod 4)`: `p3` is onto that set, and (by
+`p3_prime`/`p3_mod`) lands only in it. -/
+theorem mem_range_p3_iff (q : ℕ) :
+    (∃ k, p3 k = q) ↔ (Nat.Prime q ∧ q % 4 = 3) := by
+  constructor
+  · rintro ⟨k, rfl⟩; exact ⟨p3_prime k, p3_mod k⟩
+  · rintro ⟨hq, hmod⟩; exact p3_surjective hq hmod
+
 /-! ## Step 3: the certified iterated-factorial tower bound
 
 `B 0 = 3` and `B (k+1) = 4·(B k + 1)! − 1`.  We prove `p3 k ≤ B k`: the k-th

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "dirichlets-theorem-oq-02-oq-03",
   "title": "Certified Growth Bound for the k-th Prime ≡ 3 (mod 4)",
   "slug": "dirichlets-theorem-oq-02-oq-03",
-  "description": "The parent's Euclid-style proof of infinitely many primes ≡ 3 (mod 4) certifies more than infinitude: it bounds how fast such primes grow. We extract the interval bound (a prime ≡ 3 mod 4 always lies in (n, 4·(n+1)! − 1]), build the increasing enumeration p₃(0) < p₃(1) < … of these primes, and prove the explicit iterated-factorial tower bound p₃(k) ≤ B(k) with B(0)=3, B(k+1)=4·(B(k)+1)!−1. We contrast this astronomically loose certified bound with the true asymptotic p_k ∼ 2k·ln k from the PNT for arithmetic progressions. Fully machine-checked (0 sorry, 0 axiom, native_decide-free).",
+  "description": "The parent's Euclid-style proof of infinitely many primes ≡ 3 (mod 4) certifies more than infinitude: it bounds how fast such primes grow. We extract the interval bound (a prime ≡ 3 mod 4 always lies in (n, 4·(n+1)! − 1]), build the increasing enumeration p₃(0) < p₃(1) < … of these primes, and prove the explicit iterated-factorial tower bound p₃(k) ≤ B(k) with B(0)=3, B(k+1)=4·(B(k)+1)!−1. We contrast this astronomically loose certified bound with the true asymptotic p_k ∼ 2k·ln k from the PNT for arithmetic progressions. Fully machine-checked (0 sorry, 0 axiom, native_decide-free). This iteration adds the completeness half: p3 enumerates *exactly* the primes ≡3 (mod 4) (mem_range_p3_iff / p3_surjective, via minimality of nextP3), so with strict monotonicity 'p3 k = the k-th such prime' is now rigorous and the tower bound provably bounds every one of them.",
   "meta": {
     "author": "Lean Genius Researcher (extends elementary Euclid argument, Euclid c. 300 BC; asymptotic: PNT for APs, de la Vallée Poussin 1896)",
     "sourceUrl": "https://www.erdosproblems.com/",
@@ -172,12 +172,15 @@
     }
   ],
   "leanFile": {
-    "lineCount": 230,
+    "lineCount": 272,
     "axiomCount": 0,
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 21
+    "theoremCount": 24
   },
-  "sorries": 0
+  "sorries": 0,
+  "status": "verified",
+  "badge": "verified",
+  "axiomCount": 0
 }


### PR DESCRIPTION
## Summary

Extends `Proofs/DirichletsTheoremOQ02OQ03.lean` (certified growth bound for the k-th prime ≡ 3 mod 4) with the **completeness** half of the enumeration argument.

The base file builds `p3 : ℕ → ℕ`, the increasing enumeration of primes ≡ 3 (mod 4) starting at `p3 0 = 3`, and proves it is strictly increasing (`p3_strictMono`), always prime (`p3_prime`), and always ≡ 3 mod 4 (`p3_mod`). What was missing — and what makes the phrase "*the* k-th such prime" rigorous — is that `p3` **skips no such prime**. This PR supplies exactly that.

## New results (all machine-checked, 0 axioms, native_decide-free)

- **`p3_le_self`** — `k ≤ p3 k` (a strictly increasing `ℕ → ℕ` sequence dominates the identity); locates any target below some `p3 k`.
- **`p3_surjective`** — every prime `q ≡ 3 (mod 4)` occurs as `p3 k` for some `k`. Proof: take the least `k` with `q ≤ p3 k`; the predecessor lies strictly below `q`, so the minimality of `nextP3` (`nextP3_le_of`) forces `p3 k ≤ q`, giving equality. No prime ≡ 3 (mod 4) is skipped.
- **`mem_range_p3_iff`** — `(∃ k, p3 k = q) ↔ (Nat.Prime q ∧ q % 4 = 3)`: `p3` maps onto **and** only into the primes ≡ 3 (mod 4). Combined with `p3_strictMono`, this certifies `p3` is *the* increasing enumeration of all such primes, so `p3 k` really is the k-th one and `p3_le_tower` bounds every one of them.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.DirichletsTheoremOQ02OQ03` → **exit 0**, `Built Proofs.DirichletsTheoremOQ02OQ03` (7743/7743)
- 0 sorries, 0 `axiom` declarations, no `native_decide`
- `meta.json` synced: 21 → 24 theorems, 230 → 272 lines, `status: verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)