### PR TITLE
audit: reconcile stale theoremCount/lineCount (elementary-quadratic-reciprocity, erdos-1022-oq-02, erdos-703)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4606,10 +4606,11 @@
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-02-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T01:23:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T19:05:17Z",
       "result": "clean",
-      "issues": []
+      "issues": [],
+      "agentId": "auditor-reaudit-20260708"
     },
     "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01": {
       "auditCount": 3,
@@ -5022,10 +5023,11 @@
       "issues": []
     },
     "cauchy-schwarz-oq-03-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-07-08T18:16:34Z",
-      "result": "clean"
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "clean",
+      "agentId": "auditor-reaudit-20260708"
     },
     "cauchy-schwarz-oq-04": {
       "auditCount": 6,
@@ -5526,10 +5528,11 @@
       "result": "clean"
     },
     "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-07-08T18:30:00Z",
-      "result": "clean"
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "clean",
+      "agentId": "auditor-reaudit-20260708"
     },
     "cayleys-theorem-oq-01-oq-01-oq-02-oq-02": {
       "auditCount": 1,
@@ -6631,10 +6634,11 @@
       "result": "clean"
     },
     "connected-space-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-07-08T17:39:58Z",
-      "result": "clean"
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "clean",
+      "agentId": "auditor-reaudit-20260708"
     },
     "connected-space-oq-01-oq-02": {
       "auditCount": 1,
@@ -8220,11 +8224,13 @@
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02": {
-      "auditCount": 8,
-      "issues": [],
-      "lastAudited": "2026-07-08T18:06:14Z",
-      "result": "clean",
-      "agentId": "lean-auditor-reaudit"
+      "auditCount": 9,
+      "issues": [
+        "Stale theoremCount/lineCount reconciled to Lean source (re-audit)"
+      ],
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "issues-fixed",
+      "agentId": "auditor-reaudit-20260708"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01": {
       "auditCount": 3,
@@ -9014,10 +9020,13 @@
       "result": "clean"
     },
     "erdos-1022-oq-02": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-07-08T05:29:02Z",
-      "result": "clean"
+      "auditCount": 3,
+      "issues": [
+        "Stale theoremCount/lineCount reconciled to Lean source (re-audit)"
+      ],
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "issues-fixed",
+      "agentId": "auditor-reaudit-20260708"
     },
     "erdos-1022-oq-04": {
       "auditCount": 1,
@@ -9489,10 +9498,11 @@
       "result": "clean"
     },
     "erdos-1059-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-07T01:34:18Z",
-      "result": "clean"
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "clean",
+      "agentId": "auditor-reaudit-20260708"
     },
     "erdos-1059-oq-02": {
       "auditCount": 2,
@@ -9825,10 +9835,10 @@
       "result": "clean"
     },
     "erdos-1093": {
-      "agentId": "auditor-agent-7",
-      "auditCount": 5,
-      "lastAudited": "2026-07-08T18:54:18Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-reaudit-20260708",
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "clean"
     },
     "erdos-1094": {
       "agentId": "auditor-cycle-20-batch",
@@ -11707,10 +11717,10 @@
       ]
     },
     "erdos-214": {
-      "agentId": "lean-auditor-reaudit",
-      "auditCount": 6,
-      "lastAudited": "2026-07-08T18:46:32Z",
-      "result": "issues-fixed",
+      "agentId": "auditor-reaudit-20260708",
+      "auditCount": 7,
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "clean",
       "issues": []
     },
     "erdos-214-incomplete-01-oq-01": {
@@ -15746,11 +15756,13 @@
       "result": "clean"
     },
     "erdos-703": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-07-08T17:39:58Z",
-      "result": "clean",
-      "issues": []
+      "agentId": "auditor-reaudit-20260708",
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "issues-fixed",
+      "issues": [
+        "Stale theoremCount/lineCount reconciled to Lean source (re-audit)"
+      ]
     },
     "erdos-704": {
       "agentId": "auditor-cycle-20-batch",
@@ -21397,10 +21409,11 @@
       "issues": []
     },
     "kepler-conjecture-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-07-08T18:16:34Z",
-      "result": "clean"
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "clean",
+      "agentId": "auditor-reaudit-20260708"
     },
     "knights-tour-oblique": {
       "auditCount": 4,
@@ -22376,12 +22389,13 @@
       "result": "clean"
     },
     "liouville-theorem-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-07-08T18:46:32Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T19:05:17Z",
+      "result": "clean",
       "issues": [
         "theoremCount stale (leanFile=21, meta=17; actual=19) \u2014 reconciled to 19"
-      ]
+      ],
+      "agentId": "auditor-reaudit-20260708"
     },
     "liouville-theorem-oq-04": {
       "auditCount": 3,
@@ -27749,9 +27763,9 @@
       "result": "clean"
     },
     "chebyshev-bounds-oq-06-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-07-08T18:30:19Z",
+      "lastAudited": "2026-07-08T19:05:17Z",
       "result": "clean",
       "agentId": "auditor-reaudit-20260708",
       "notes": "Re-audit CLEAN: 0 axioms/0 sorries. Substantial IsEquivalent algebra collapsing Stirling factors to prove C(2n,n) ~ 4^n/sqrt(pi n); derived from Mathlib Stirling.factorial_isEquivalent_stirling, honestly credited; docstring notes effective one-sided bound NOT achieved (Robbins absent). verified/verified accurate."

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 32,
     "defCount": 4,
-    "lineCount": 510,
+    "lineCount": 561,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 535,
+    "lineCount": 561,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 32,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 233,
+    "lineCount": 286,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 8,
+    "theoremCount": 11,
     "definitionCount": 3
   },
   "overview": {

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -49,10 +49,10 @@
       "largeSetsFamily / largeSetsFamily_avoids_1 / largeSetsFamily_card_le_T: Frankl's (1977) r=1 lower-bound construction — the family of sets larger than (n+1)/2 is a valid 1-avoiding family, giving a verified lower bound |largeSetsFamily n| ≤ T(n,1)"
     ],
     "axiomCount": 1,
-    "lineCount": 380,
+    "lineCount": 415,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 8
   },
   "crossReferences": [


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Re-audit sweep of 13 gallery entries whose Lean source or meta.json was committed after their last audit (post-merge batch of ~18 PRs). Sorry counts, axiom counts, `native_decide` disclosure, status, and badges all reconcile with the Lean source. Three entries had **stale meta-level counts** after their Lean files grew:

| Slug | Field | Was | Now | Cause |
|------|-------|-----|-----|-------|
| elementary-quadratic-reciprocity-oq-03-oq-02 | theoremCount | 28 / lf 30 | **32** | #35448 added `kronecker2_sq` |
| | lineCount | 510 / lf 535 | **561** | |
| erdos-1022-oq-02 | meta.theoremCount | 8 | **11** | #35463 grew file (leanFile.* already 11) |
| | meta.lineCount | 233 | **286** | |
| erdos-703 | meta.theoremCount | 9 | **11** | #35461 grew file (leanFile.* already 11) |
| | meta.lineCount | 380 | **415** | |

Truth verified via `grep -cE '^\s*(theorem|lemma) '` (excludes defs, per gallery convention) and `wc -l`. `definitionCount` fields confirmed correct (4 / 3 / 8). No prose count mismatches. No status/badge overclaims — all three remain honestly `verified`/`axiomatized` as appropriate.

The other 10 changed-since-audit candidates (erdos-1093, cayleys-theorem…, erdos-1059-oq-01-oq-01, cauchy-interlacing…, erdos-214, liouville-theorem-oq-03, chebyshev-bounds-oq-06-oq-01, kepler-conjecture-oq-04, connected-space-oq-01-oq-01, cauchy-schwarz-oq-03-oq-03) audited clean. Tracker updated in place.

---
Discovered during gallery integrity audit.