### PR TITLE
Enrich ψ/θ Same Main Term: full-file section coverage

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-02/meta.json
@@ -73,6 +73,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Open Question, Imports & Setup",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "File docstring framing the parent chebyshev-bounds-oq-02's open question (compare ψ with θ and quantify their difference), a roadmap of the gallery-facing statements and the Mathlib bridge; then `import Proofs.ChebyshevBoundsOQ02` (the parent's self-contained ℕ-indexed ψ) and `import Mathlib`, with `open Finset ArithmeticFunction` and the two nested namespaces.",
+      "mathContext": "Goal: ψ(n) − θ(n) is supported on the proper prime powers p^k (k ≥ 2) and is O(√n·log n)."
+    },
+    {
       "id": "theta-def",
       "title": "The First Chebyshev Function θ",
       "startLine": 54,


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-02-oq-02` (quality 94, passes 0).

The entry was already comprehensive (5 annotations with mathContext/significance/relatedConcepts/prerequisites, 9 mainTheorems, 4 keyInsights, full conclusion with 3 open questions, 3 references). The one genuine gap: the `sections` array started at line 54, leaving the file's docstring, imports, and namespace setup (lines 1–53) uncovered.

**Change:** added a single `header` section (lines 1–53) so `sections` now covers the full 146-line Lean file. It summarizes the docstring's framing of the parent's open question, the roadmap of gallery-facing statements + Mathlib bridge, and the import/open/namespace setup.

Non-inflating structural add only — no field deepened. meta.json 17.7 KB → 18.3 KB, well under the ~60 KB cap. JSON validated.