### PR TITLE
audit: reconcile stale leanFile counts (collatz-structured-oq-02-oq-03, beta-integral-recurrence)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2456,9 +2456,9 @@
       "issues": []
     },
     "beta-integral-recurrence-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-25T16:58:19Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-07-08T19:12:11Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "beta-integral-recurrence-oq-01-oq-02": {
@@ -4606,8 +4606,8 @@
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-07-08T19:05:17Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T19:12:11Z",
       "result": "clean",
       "issues": [],
       "agentId": "auditor-reaudit-20260708"
@@ -5528,9 +5528,9 @@
       "result": "clean"
     },
     "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-07-08T19:05:17Z",
+      "lastAudited": "2026-07-08T19:12:11Z",
       "result": "clean",
       "agentId": "auditor-reaudit-20260708"
     },
@@ -6268,9 +6268,9 @@
       "result": "clean"
     },
     "collatz-structured-oq-02-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-07-08T17:39:58Z",
-      "result": "clean",
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T19:12:11Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "collatz-structured-oq-03": {
@@ -8224,12 +8224,12 @@
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02": {
-      "auditCount": 9,
+      "auditCount": 10,
       "issues": [
         "Stale theoremCount/lineCount reconciled to Lean source (re-audit)"
       ],
-      "lastAudited": "2026-07-08T19:05:17Z",
-      "result": "issues-fixed",
+      "lastAudited": "2026-07-08T19:12:11Z",
+      "result": "clean",
       "agentId": "auditor-reaudit-20260708"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01": {
@@ -8706,9 +8706,9 @@
       "issues": []
     },
     "erdos-101": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-06-19T10:28:22Z",
+      "lastAudited": "2026-07-08T19:12:11Z",
       "result": "clean"
     },
     "erdos-101-oq-01": {
@@ -9020,12 +9020,12 @@
       "result": "clean"
     },
     "erdos-1022-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "Stale theoremCount/lineCount reconciled to Lean source (re-audit)"
       ],
-      "lastAudited": "2026-07-08T19:05:17Z",
-      "result": "issues-fixed",
+      "lastAudited": "2026-07-08T19:12:11Z",
+      "result": "clean",
       "agentId": "auditor-reaudit-20260708"
     },
     "erdos-1022-oq-04": {
@@ -12080,8 +12080,8 @@
     },
     "erdos-26": {
       "agentId": "auditor-1777696958",
-      "auditCount": 6,
-      "lastAudited": "2026-05-30T09:06:03Z",
+      "auditCount": 7,
+      "lastAudited": "2026-07-08T19:12:11Z",
       "result": "clean",
       "issues": [
         "Section line drift in 5 of 8 sections (davenport-erdos +5, conjecture +5, counterexamples +5, tenenbaum-variant +2, supporting-lemmas +2). Filed #14568."
@@ -15757,9 +15757,9 @@
     },
     "erdos-703": {
       "agentId": "auditor-reaudit-20260708",
-      "auditCount": 5,
-      "lastAudited": "2026-07-08T19:05:17Z",
-      "result": "issues-fixed",
+      "auditCount": 6,
+      "lastAudited": "2026-07-08T19:12:11Z",
+      "result": "clean",
       "issues": [
         "Stale theoremCount/lineCount reconciled to Lean source (re-audit)"
       ]
@@ -17215,8 +17215,8 @@
       "issues": []
     },
     "erdos-897-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-07-08T17:39:58Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T19:12:11Z",
       "result": "clean",
       "issues": []
     },
@@ -22941,8 +22941,8 @@
       "issues": []
     },
     "minpoly-charpoly": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-05T19:53:45Z",
+      "auditCount": 3,
+      "lastAudited": "2026-07-08T19:12:11Z",
       "result": "clean",
       "issues": []
     },
@@ -29633,8 +29633,8 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-03": {
-      "lastAudited": "2026-07-08T18:33:17Z",
-      "auditCount": 1,
+      "lastAudited": "2026-07-08T19:12:11Z",
+      "auditCount": 2,
       "result": "clean",
       "agentId": "auditor-reaudit-20260708",
       "notes": "Audit CLEAN (first audit): 0 sorries/0 axioms/0 native_decide. Uses kernel `decide` (lines 219,224) NOT native_decide for B 1=95 numeric check; assumptions field correctly states ofReduceBool-free. Genuine Euclid-construction + iterated-factorial tower bound p3(k)<=B(k). verified/original accurate.",
@@ -29642,5 +29642,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T18:54:18Z"
+  "lastUpdated": "2026-07-08T19:12:11Z"
 }

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-01-oq-01/meta.json
@@ -123,7 +123,7 @@
       "Asymptotics"
     ],
     "namespace": "BetaDiagAsymptotic",
-    "lineCount": 146,
+    "lineCount": 147,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 1,
@@ -146,7 +146,7 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 146,
+    "lineCount": 147,
     "theoremCount": 5,
     "definitionCount": 1,
     "badge": "original",

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,11 +20,11 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1783,
+    "lineCount": 1801,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 63,
+    "theoremCount": 64,
     "definitionCount": 13,
     "originalContributions": [
       "attainsBelow_density_of_autoDropCert: fuses the general density lemma attainsBelow_density_of_residues with the turnkey autoDropCert engine, so the drop-below density floor at any 2^b level is (#auto-certified residues)·(N-1) with ZERO per-residue proof — the residue count is a decide, every drop hypothesis is autoDropCert_attainsBelow (axiom-free, no native_decide)"
@@ -137,9 +137,9 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1783,
+    "lineCount": 1801,
     "axiomCount": 1,
-    "theoremCount": 63,
+    "theoremCount": 64,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 13


### PR DESCRIPTION
## Gallery Integrity Audit

Re-audit sweep of changed-since-lastAudited entries. Two entries had stale `leanFile`/`meta` count fields after recent Lean-source commits; both are cosmetic count-drift with **no overclaim** (status/badge/axiomCount/sorries all correct and verified against source).

### collatz-structured-oq-02-oq-03
- `lineCount` 1783 → **1801**, `theoremCount` 63 → **64** (both `leanFile` and `meta` objects)
- Cause: #35466 (auto-engine → orbit-minimum bridge) added a lemma + lines after the meta was last synced by #35350.
- Verified: `wc -l` = 1801, prefix-aware theorem/lemma count = 64, def count 13 unchanged, axiomCount 1 correct.

### beta-integral-recurrence-oq-01-oq-01-oq-01
- `lineCount` 146 → **147** (both `leanFile` and `meta` objects)
- Cause: #35071 (v4.26 drift repair) grew the file by one line after the meta was last synced by #30085.
- Verified: `wc -l` = 147, theoremCount 5 correct.

### Tracker
Bumped `lastAudited` for 12 changed-since-audit slugs: 2 `issues-fixed` (above), 10 `clean` (cauchy-interlacing-oq-01-oq-02-oq-02, erdos-897-oq-01, cayleys-…, dirichlets-oq-02-oq-03, elementary-quadratic-reciprocity-oq-03-oq-02, erdos-1022-oq-02, erdos-703, erdos-101, minpoly-charpoly, erdos-26). The Cayley/Dirichlet apparent theorem-count deltas were false positives from attribute-prefixed declarations, confirmed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)