### PR TITLE
research(erdos-1064-oq-03): structural reversal criterion + composite-landing reversal family [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -108,4 +108,89 @@ theorem forward_not_universal :
     (∃ n : ℕ, Nat.totient n < Nat.totient (dblIter n)) :=
   ⟨fun _ hp hp3 => totient_dblIter_lt_of_prime hp hp3, ⟨39, reverse_at_39⟩⟩
 
+-- ----------------------------------------------------------------------------
+-- Structural mechanism of the reversal:  when `D(n)` lands on a prime `q`, the
+-- three-way comparison `φ(n)  vs  φ(D(n))` collapses to a single size test,
+-- because `φ(q) = q − 1`.  This *explains* the empirical clustering of reversals
+-- on prime landings — a structural theorem that subsumes the individual
+-- numerical witnesses rather than enumerating them.
+-- ----------------------------------------------------------------------------
+
+/-- **Reversal criterion on prime landings.**  Whenever the double iterate lands
+    on a prime, the reversal `φ(n) < φ(D(n))` is *equivalent* to the clean size
+    condition `φ(n) + 1 < D(n)`.  (Since `φ(D(n)) = D(n) − 1`.)  This is the
+    exact mechanism behind the reversal clustering: a prime landing makes
+    `φ(D(n))` as large as possible, so reversal is governed purely by how large
+    the landing value `D(n)` is relative to `φ(n)`. -/
+theorem reversal_iff_of_dblIter_prime {n : ℕ} (hq : (dblIter n).Prime) :
+    Nat.totient n < Nat.totient (dblIter n) ↔ Nat.totient n + 1 < dblIter n := by
+  rw [Nat.totient_prime hq]
+  have := hq.two_le
+  omega
+
+/-- **Sufficient condition for reversal.**  If `D(n)` is prime and exceeds
+    `φ(n) + 1`, then `n` is a reversal point.  A one-line consequence of
+    `reversal_iff_of_dblIter_prime` that packages the "prime landing + large
+    landing value" pattern into a directly usable form. -/
+theorem reverse_of_dblIter_prime {n : ℕ} (hq : (dblIter n).Prime)
+    (hsize : Nat.totient n + 1 < dblIter n) :
+    Nat.totient n < Nat.totient (dblIter n) :=
+  (reversal_iff_of_dblIter_prime hq).mpr hsize
+
+/-- The `n = 39` witness re-derived structurally: `D(39) = 31` is prime and
+    `φ(39) + 1 = 25 < 31`, so the criterion fires. -/
+theorem reverse_at_39' : Nat.totient 39 < Nat.totient (dblIter 39) :=
+  reverse_of_dblIter_prime (by rw [dblIter_39]; norm_num)
+    (by rw [totient_39, dblIter_39]; decide)
+
+-- ----------------------------------------------------------------------------
+-- A SECOND reversal family:  reversal is *not* confined to prime landings.
+-- At `n = 42` the double iterate lands on the **composite** value
+-- `D(42) = 34 = 2·17`, yet the reversal `φ(42) < φ(D(42))` still holds.
+-- This shows the reversal phenomenon extends beyond the `D(n) prime` family,
+-- refining the earlier empirical observation that reversals "cluster" on primes.
+-- ----------------------------------------------------------------------------
+
+/-- `φ(42) = 12`  (42 = 2·21, φ(21) = φ(3·7) = 12). -/
+theorem totient_42 : Nat.totient 42 = 12 := by
+  rw [show (42 : ℕ) = 2 * 21 from rfl, Nat.totient_mul (by decide),
+      show (21 : ℕ) = 3 * 7 from rfl, Nat.totient_mul (by decide),
+      Nat.totient_prime (by norm_num), Nat.totient_prime (by norm_num),
+      Nat.totient_prime (by norm_num)]
+
+/-- `φ(30) = 8`  (30 = 2·15, φ(15) = 8). -/
+theorem totient_30 : Nat.totient 30 = 8 := by
+  rw [show (30 : ℕ) = 2 * 15 from rfl, Nat.totient_mul (by decide),
+      Nat.totient_prime (by norm_num), totient_15]
+
+/-- `φ(34) = 16`  (34 = 2·17, distinct primes). -/
+theorem totient_34 : Nat.totient 34 = 16 := by
+  rw [show (34 : ℕ) = 2 * 17 from rfl, Nat.totient_mul (by decide),
+      Nat.totient_prime (by norm_num), Nat.totient_prime (by norm_num)]
+
+/-- The double iterate of 42 lands on the **composite** value 34:  `D(42) = 34`
+    with `34 = 2 · 17`. -/
+theorem dblIter_42 : dblIter 42 = 34 := by
+  unfold dblIter
+  rw [totient_42, show (42 : ℕ) - 12 = 30 from rfl, totient_30]
+
+/-- `D(42) = 34` is **not** prime — witnessing that the landing value need not be
+    prime for a reversal to occur. -/
+theorem dblIter_42_not_prime : ¬ (dblIter 42).Prime := by
+  rw [dblIter_42]; decide
+
+/-- **A composite-landing reversal.**  At `n = 42` the double iterate reverses
+    the expected direction, `φ(42) = 12 < 16 = φ(D(42))`, even though
+    `D(42) = 34` is composite.  So the reversal family is strictly larger than
+    the prime-landing family. -/
+theorem reverse_at_42 : Nat.totient 42 < Nat.totient (dblIter 42) := by
+  rw [dblIter_42, totient_42, totient_34]; decide
+
+/-- **The reversal phenomenon is not confined to prime landings.**  There is a
+    reversal point `n` whose double iterate `D(n)` is composite: concretely
+    `n = 42`, where `D(42) = 34 = 2·17` and `φ(42) < φ(34)`. -/
+theorem reversal_with_composite_landing :
+    ∃ n : ℕ, ¬ (dblIter n).Prime ∧ Nat.totient n < Nat.totient (dblIter n) :=
+  ⟨42, dblIter_42_not_prime, reverse_at_42⟩
+
 end Erdos1064OQ03

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS: established the forward inequality φ(n) > φ(D(n)) on the entire infinite family of odd primes (via the collapse D(p) = p − 1), pinned the sharp boundary at p = 2 (equality), and exhibited a concrete reversal at n = 39 (D(39) = 31 prime). Whether the reverse holds infinitely often, and the almost-all direction, remain OPEN. All results ofReduceBool-free (0 axioms, 0 sorries).",
+    "progressSummary": "PROGRESS: forward inequality on all odd primes; sharp boundary at p=2. This session added the STRUCTURAL reversal criterion (reversal ⟺ φ(n)+1<D(n) on prime landings, explaining the clustering) and showed reversal extends to COMPOSITE landings (n=42, D(42)=34=2·17). Infinitely-often direction remains OPEN. All results 0 axioms / 0 sorries.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -44,19 +44,25 @@
       "totient_39 / totient_15 / totient_31 — concrete totient values via factorisation (Nat.totient_mul on coprime prime factors), avoiding kernel gcd-reduction in decide.",
       "dblIter_39 — D(39) = 31: the double iterate lands on a prime.",
       "reverse_at_39 — REVERSAL witness: φ(39) = 24 < 30 = φ(31) = φ(D(39)); the smallest n where φ(n) < φ(D(n)).",
-      "forward_not_universal — packaging theorem: (∀ prime p≥3, φ(D(p))<φ(p)) ∧ (∃ n, φ(n)<φ(D(n))); shows both directions occur for the higher iterate, mirroring the single-step Erdős 1064."
+      "forward_not_universal — packaging theorem: (∀ prime p≥3, φ(D(p))<φ(p)) ∧ (∃ n, φ(n)<φ(D(n))); shows both directions occur for the higher iterate, mirroring the single-step Erdős 1064.",
+      "reversal_iff_of_dblIter_prime (structural reversal criterion, EulerTotientOQ04OQ03.lean:127)",
+      "reverse_of_dblIter_prime + reverse_at_39 re-derivation (EulerTotientOQ04OQ03.lean:137,143)",
+      "reversal_with_composite_landing: composite-landing reversal via n=42 witness (dblIter_42, dblIter_42_not_prime, reverse_at_42; EulerTotientOQ04OQ03.lean:187)"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
       "The reversal φ(n) < φ(D(n)) empirically clusters where D(n) is itself prime: the smallest cases n = 39,42,55,84,85,93,110,115,133,155,165,168 in [2,200) have D(n) ∈ {31,34,47,68,73,73,86,97,113,131,101,136}, many of them prime, making φ(D(n)) = D(n) − 1 large. This is the higher-iterate echo of the single-step reversal phenomenon.",
       "Equality φ(n) = φ(D(n)) is also common (35 of the n in [2,200), including all n where D(n) shares the totient value), so the higher-iterate comparison is genuinely three-way (>, =, <) rather than a clean dichotomy — a structural difference worth noting versus the single-step statement.",
-      "Computing concrete totient values through Nat.totient_mul on coprime prime factors is the robust route in Lean: plain `decide` on Nat.totient stalls because Nat.gcd is well-founded recursion that does not reduce well in the kernel; factorisation sidesteps this and keeps the file ofReduceBool-free."
+      "Computing concrete totient values through Nat.totient_mul on coprime prime factors is the robust route in Lean: plain `decide` on Nat.totient stalls because Nat.gcd is well-founded recursion that does not reduce well in the kernel; factorisation sidesteps this and keeps the file ofReduceBool-free.",
+      "Reversal criterion collapses on prime landings: when D(n) is prime, φ(n)<φ(D(n)) ⟺ φ(n)+1<D(n), since φ(D(n))=D(n)−1. This EXPLAINS the empirical clustering of reversals on prime landings — φ(D(n)) is maximal there, so reversal is governed purely by the landing value size.",
+      "Reversal is NOT confined to prime landings: at n=42, D(42)=34=2·17 is COMPOSITE yet φ(42)=12<16=φ(34). So the reversal family strictly contains the prime-landing family, refining the earlier clustering observation."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Attempt the reversal-infinitude direction via primes q with q+φ(q−1)-shaped preimages: characterise n with D(n) prime, since those are the reversal candidates; a Dirichlet/linnik-type input would be needed and is likely the OPEN crux.",
       "Prove a density-1 forward statement φ(n) > φ(D(n)) for almost all n by transporting the Luca–Pomerance single-step argument through one extra cototient step (assess whether the extra step preserves the density-1 set).",
-      "Formalise the three-way classification on a finite window (n ≤ N) as a decidable certificate to complement the qualitative theorems, and search for the second/third reversal families beyond 'D(n) prime'."
+      "Formalise the three-way classification on a finite window (n ≤ N) as a decidable certificate to complement the qualitative theorems, and search for the second/third reversal families beyond 'D(n) prime'.",
+      "Characterize composite landing values D(n) admitting reversal (2p with p prime? squarefree with few factors?) toward an infinitely-often construction not relying on prime landings"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Extends the verified Erdős 1064 OQ-03 file (`EulerTotientOQ04OQ03.lean`, from #35451) with two **structural** results that subsume the isolated numerical witnesses rather than enumerating them.

The problem studies the double cototient iterate `D(n) = n − φ(n − φ(n))`, comparing `φ(n)` against `φ(D(n))`. The forward inequality holds on all odd primes; the reverse ("reversal") occurs, e.g. at n=39.

### 1. Reversal criterion on prime landings

`reversal_iff_of_dblIter_prime`: when `D(n)` is prime,
```
φ(n) < φ(D(n))   ⟺   φ(n) + 1 < D(n)
```
because `φ(D(n)) = D(n) − 1`. This **explains** the empirical clustering of reversals on prime landings: a prime landing makes `φ(D(n))` maximal, so reversal is governed purely by how large the landing value `D(n)` is relative to `φ(n)`. `reverse_of_dblIter_prime` packages the sufficient direction; `reverse_at_39'` re-derives the n=39 witness structurally.

### 2. Reversal is not confined to prime landings

`reversal_with_composite_landing`: at **n=42**, `D(42) = 34 = 2·17` is **composite**, yet `φ(42) = 12 < 16 = φ(34)`. So the reversal family *strictly contains* the prime-landing family, refining the earlier empirical clustering observation.

## Verification

- Build: `./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ04OQ03` → succeeds (3058/3058)
- **0 axioms, 0 sorries** — fully machine-checked
- The infinitely-often direction remains the OPEN part of this question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)