### PR TITLE
Enrich Chebyshev–PNT Bridge OQ-06: full-file section coverage

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06/meta.json
@@ -54,6 +54,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Open Question, Imports & Setup",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "File docstring situating OQ-06: the parent ChebyshevPNTBridge proves the upper bound only in ℕ-power form ((Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n), leaving the real-log consequence as a header comment, while sibling OQ-05 carried the lower bound to real-log form. Lists the three deliverable theorems and the resulting limsup π(x)·log x/x ≤ 2 log 4; then the imports (Mathlib.NumberTheory.PrimeCounting, Analysis.SpecialFunctions.Log.Basic, Tactic, Proofs.ChebyshevPNTBridge), the namespace, and `open Nat`.",
+      "mathContext": "Goal: package $(\\sqrt n)^{\\pi(n)-\\pi(\\sqrt n)} \\le 4^n$ into real-log/density form, the upper mirror of OQ-05."
+    },
+    {
       "id": "real-log-difference",
       "title": "Real-Logarithmic Difference Form",
       "startLine": 44,


### PR DESCRIPTION
Enrichment pass for `chebyshev-pnt-bridge-oq-06` (quality 94, passes 0).

Already comprehensive (6 annotations, 3 sections, 3 mainTheorems, 4 keyInsights, full conclusion with 3 open questions, 2 references, 2 crossReferences). The one gap: the `sections` array started at line 44, leaving the file docstring, imports, and namespace setup (lines 1–43) uncovered.

**Change:** added a single `header` section (lines 1–43) so `sections` now covers the full 160-line Lean file. Summarizes the docstring's framing of OQ-06 (parent has only the ℕ-power upper bound; OQ-05 did the lower real-log half; this file supplies the upper mirror), the three deliverable theorems, and the imports/open setup.

Non-inflating structural add only. meta.json 13.8 KB → 14.6 KB, well under the ~60 KB cap. JSON validated.