### PR TITLE
research(dirichlets-theorem-oq-02-oq-03): certified linear lower bound brackets the k-th prime ≡ 3 (mod 4) [VERIFIED]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -242,6 +242,26 @@ theorem p3_le_tower (k : ℕ) : p3 k ≤ B k := by
       _ ≤ 4 * (B k + 1)! - 1 := step_mono ih
       _ = B (k + 1) := by simp
 
+/-- **Certified linear lower bound.** The values `p3 k` are strictly increasing and all
+`≡ 3 (mod 4)`, so consecutive ones differ by at least `4`; hence `p3 k ≥ 4k + 3`. This
+is elementary (no primality input beyond the mod-4 residue) and complements the tower
+upper bound. -/
+theorem p3_ge_linear (k : ℕ) : 4 * k + 3 ≤ p3 k := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have hlt := p3_lt_succ k
+    have hmk := p3_mod k
+    have hmk1 := p3_mod (k + 1)
+    omega
+
+/-- **Bracketing the k-th prime `≡ 3 (mod 4)`.** Combining the two certified bounds,
+`4k + 3 ≤ p3 k ≤ B k`: the k-th such prime is pinned between an explicit linear lower
+bound and the iterated-factorial tower `B`. (The true growth is `p_k ∼ 2k·ln k`, which
+sits between them.) -/
+theorem p3_bracketed (k : ℕ) : 4 * k + 3 ≤ p3 k ∧ p3 k ≤ B k :=
+  ⟨p3_ge_linear k, p3_le_tower k⟩
+
 /-! ## Step 4: sanity checks and the honest contrast
 
 Small values of both sides, confirming the bound holds and quantifying its

--- a/research/problems/dirichlets-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/dirichlets-theorem-oq-02-oq-03/knowledge.md
@@ -63,3 +63,16 @@ yields, and how it compares with the genuine `p_k ∼ 2k·ln k`.
 
 - Tying `p3` to `Nat.nth` was avoidable: the direct `Nat.find`-based enumeration with a
   minimality lemma is cleaner and fully certifies "k-th prime" without the `Nat.nth` API.
+
+### Session 2026-07-08 (Session 2, researcher-1) — certified linear lower bound
+
+Re-served the already-completed slug. Added two verified theorems bracketing the
+k-th prime ≡ 3 (mod 4):
+- `p3_ge_linear : 4*k + 3 ≤ p3 k` — since the `p3` values are strictly increasing
+  and all ≡ 3 (mod 4), consecutive ones differ by ≥ 4. One-line induction: feed
+  `p3_lt_succ`, `p3_mod k`, `p3_mod (k+1)` to `omega` (omega reasons mod-4).
+- `p3_bracketed : 4*k + 3 ≤ p3 k ∧ p3 k ≤ B k` — combines the new lower bound with
+  the existing tower upper bound; the true value `∼ 2k·ln k` sits between them.
+File 250 L, 23 thm / 3 def, 0 axioms, 0 sorries. VERIFIED (rotating olean
+corruption: line-less 135 then named Cyclotomic/Discriminant.olean.private invalid
+header → rm + retry green).

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -172,12 +172,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 272,
+    "lineCount": 292,
     "axiomCount": 0,
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 24
+    "theoremCount": 26
   },
   "sorries": 0,
   "status": "verified",


### PR DESCRIPTION
## Summary

Dirichlet's theorem OQ-02-OQ-03, companion file `DirichletsTheoremOQ02OQ03.lean`.
The file certifies an iterated-factorial tower **upper** bound `p3 k ≤ B k` on the
k-th prime `≡ 3 (mod 4)` (where `p3` is the increasing enumeration, `p3 0 = 3`).
This PR adds the matching elementary **lower** bound, bracketing the k-th such prime.

## Added theorems (both VERIFIED, 0 axioms / 0 sorries)

- **`p3_ge_linear`** — `4k + 3 ≤ p3 k`. The `p3` values are strictly increasing and
  all `≡ 3 (mod 4)`, so consecutive ones differ by at least `4`. One-line induction
  feeding `p3_lt_succ`, `p3_mod k`, `p3_mod (k+1)` to `omega` (mod-4 reasoning). No
  primality input beyond the residue.
- **`p3_bracketed`** — `4k + 3 ≤ p3 k ∧ p3 k ≤ B k`. The k-th prime `≡ 3 (mod 4)` is
  pinned between the explicit linear lower bound and the factorial tower `B`; the true
  value `p_k ∼ 2k·ln k` sits between them.

## Notes

Rebased onto the current `main` version of the file (which had added the
`p3_surjective` / `mem_range_p3_iff` completeness theorems since my worktree's base);
my additions are disjoint and non-conflicting.

## Verification

`./proofs/scripts/docker-build.sh Proofs.DirichletsTheoremOQ02OQ03` → **7743 jobs,
0 errors, 0 sorries, 0 axioms**. Synced `meta.json` `leanFile` (`lineCount` 272→292,
`theoremCount` 24→26).