### PR TITLE
audit(lagrange-four-squares): re-audit clean — all fields reconcile

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21605,8 +21605,8 @@
     },
     "lagrange-four-squares": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-06-02T10:49:17Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T19:45:00Z",
       "result": "clean",
       "issues": [
         "hurwitz_quaternions_euclidean and hurwitz_representation_count True stubs removed; lineCount 410\u2192392, theoremCount 17\u219215"


### PR DESCRIPTION
## Gallery Integrity Re-Audit — CLEAN

Re-audited `lagrange-four-squares` after enrichment #35364 (last audited 2026-06-02).

### Verification vs Lean source
| Field | meta.json | Actual | ✓ |
|-------|-----------|--------|---|
| lineCount | 409 | 409 (`wc -l`) | ✓ |
| axiomCount (meta) | 7 | 5 main + 2 additional | ✓ |
| axiomCount (leanFile) | 5 | 5 (main file) | ✓ |
| theoremCount | 14 | 14 | ✓ |
| definitionCount | 8 | 8 | ✓ |
| sorries | 0 | 0 | ✓ |
| status/badge | axiomatized / axiom | has axioms | ✓ |

- **Axioms** (main): `legendre_three_squares`, `hilbert_waring`, `wieferich_nine_cubes`, `waring_general_formula`, `vinogradov_waring_bound`; (additional): `jacobi_four_square`, `r₄_zero`. All 7 accurately disclosed in `assumptions`.
- **`fermat_two_squares`** is a real theorem (`FourSquareRepresentations.lean:296`), matching the prose "has been formally proved".
- **24 `native_decide`** are illustrative computational checks (`sigmaStar`/`jacobi` values) living entirely in the **additional** file, not the main file — consistent with the accepted norm (cf. elementary-quadratic-reciprocity supplementary case). No hidden `ofReduceBool` on a substantive main-file result.

No overclaim. Tracker updated (lastAudited, auditCount).

---
Discovered during gallery integrity re-audit sweep (backlog was 0).