### PR TITLE
research(erdos-1022-oq-02): coefficient-level growth rate — integer c(t) at least doubles per step [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -283,4 +283,69 @@ theorem exists_admissible_coeff (hV : 0 < Fintype.card V) :
           ≤ firstMomentThreshold t := Nat.div_mul_le_self _ _
       _ = 2 ^ (t - 1) := rfl
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 7: Quantitative growth rate of the admissible *coefficient*
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+  § 5-6 pin the growth of the *threshold* `2^{t-1}` (it doubles per step,
+  `firstMoment_threshold_doubles`) and show the admissible coefficient
+  `c(t) = ⌊2^{t-1}/|V|⌋` diverges (`exists_admissible_coeff`).  What was left
+  *qualitative* is the growth rate of that integer coefficient itself.  This
+  section pins it: over a fixed ground set `c(t)` tracks the real density
+  `2^{t-1}/|V|` to within one vertex (the floor loses `< |V|`), and — despite
+  the floor — `c(t)` *at least doubles* with each unit increase of `t`.  So the
+  admissible coefficient, not merely the underlying threshold, grows at least
+  exponentially in the minimum set size `t`: the sharp coefficient-level answer
+  to OQ-02 in the first-moment regime for bounded ground sets.
+-/
+
+-- The `DecidableEq V` instance is unused in this final section (only `Fintype`
+-- and `Nat` arithmetic are needed); omit it for the remaining declarations.
+omit [DecidableEq V]
+
+/-- **The integer coefficient tracks the real density to within one vertex.**
+    `c(t) = ⌊2^{t-1}/|V|⌋` satisfies `2^{t-1} < (c(t)+1)·|V|`: the truncated
+    division discards strictly less than a full copy of `|V|`, so the integer
+    coefficient never falls more than one vertex-worth below the exact real
+    threshold `2^{t-1}/|V|`.  Together with `propertyB_of_sparse`'s lower bound
+    this brackets `c(t)` tightly around `2^{t-1}/|V|`. -/
+theorem threshold_lt_succ_coeff_mul (hV : 0 < Fintype.card V) (t : ℕ) :
+    firstMomentThreshold t
+      < (firstMomentThreshold t / Fintype.card V + 1) * Fintype.card V := by
+  have hdm := Nat.div_add_mod (firstMomentThreshold t) (Fintype.card V)
+  have hmod := Nat.mod_lt (firstMomentThreshold t) hV
+  rw [add_mul, one_mul,
+      Nat.mul_comm (firstMomentThreshold t / Fintype.card V) (Fintype.card V)]
+  omega
+
+/-- **The admissible coefficient at least doubles with each unit increase of
+    `t`.**  This lifts the threshold-level doubling
+    (`firstMoment_threshold_doubles`) to the *integer* coefficient
+    `c(t) = ⌊2^{t-1}/|V|⌋` itself, surviving the floor: `2·c(t) ≤ c(t+1)`.
+    Hence the admissible sparseness coefficient — the quantity Problem #1022
+    actually asks about, not merely the real threshold — grows at least
+    exponentially in the minimum set size `t`.  This is the sharp
+    coefficient-level growth rate for the first-moment regime over a bounded
+    ground set. -/
+theorem admissibleCoeff_ge_two_mul (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 ≤ t) :
+    2 * (firstMomentThreshold t / Fintype.card V)
+      ≤ firstMomentThreshold (t + 1) / Fintype.card V := by
+  rw [firstMoment_threshold_doubles t ht, Nat.le_div_iff_mul_le hV, mul_assoc]
+  have h : firstMomentThreshold t / Fintype.card V * Fintype.card V
+      ≤ firstMomentThreshold t := Nat.div_mul_le_self _ _
+  omega
+
+/-- **Strict growth of the admissible coefficient once it is positive.**  As
+    soon as the ground set is small enough for the threshold to admit a nonzero
+    coefficient (`0 < c(t)`, i.e. `|V| ≤ 2^{t-1}`), the coefficient strictly
+    increases at the next step: `c(t) < c(t+1)`.  Immediate from the doubling
+    bound `2·c(t) ≤ c(t+1)`. -/
+theorem admissibleCoeff_lt_of_pos (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 ≤ t)
+    (hpos : 0 < firstMomentThreshold t / Fintype.card V) :
+    firstMomentThreshold t / Fintype.card V
+      < firstMomentThreshold (t + 1) / Fintype.card V := by
+  have h := admissibleCoeff_ge_two_mul hV t ht
+  omega
+
 end Erdos1022OQ02

--- a/src/data/research/problems/erdos-1022-oq-02.json
+++ b/src/data/research/problems/erdos-1022-oq-02.json
@@ -28,19 +28,19 @@
   },
   "currentState": {
     "phase": "COMPLETED",
-    "since": "2026-06-23T00:00:00Z",
-    "iteration": 1,
-    "focus": "Created 233-line formalization: 8 theorems, 3 defs, 0 axioms, 0 sorries.",
+    "since": "2026-07-08T00:00:00Z",
+    "iteration": 2,
+    "focus": "Added §7 (coefficient-level growth rate): 3 theorems pinning that the integer admissible coefficient c(t)=⌊2^{t-1}/|V|⌋ at least doubles per step (2·c(t)≤c(t+1)), tracks the real density to within one vertex, and strictly increases once positive. File now 350 lines, 14 theorems, 3 defs, 0 axioms, 0 sorries. Docker build verified (7744 jobs).",
     "blockers": [],
-    "nextAction": "None.",
+    "nextAction": "None. First-moment regime is now exhausted at both threshold and coefficient level; the open hard regime (ground set growing with the family, Lovász-type) is out of scope.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 233-line formalization, 8 proved theorems, 0 axioms, 0 sorries. First-moment answer to OQ-02 (exponential growth of the threshold).",
+    "progressSummary": "[2026-07-08] Coefficient-level growth rate pinned: the integer admissible coefficient c(t)=⌊2^{t-1}/|V|⌋ at least doubles per step (2·c(t)≤c(t+1), admissibleCoeff_ge_two_mul) despite the floor, tracks the real density 2^{t-1}/|V| to within one vertex (threshold_lt_succ_coeff_mul), and is strictly increasing once positive. This upgrades the earlier qualitative c_t→∞ to a quantitative exponential rate for the coefficient itself. COMPLETE: 233-line formalization, 8 proved theorems, 0 axioms, 0 sorries. First-moment answer to OQ-02 (exponential growth of the threshold).",
     "builtItems": [
       "Created Proofs/Erdos1022OQ02.lean (233 lines, 8 theorems, 3 defs, 0 axioms)",
       "Created gallery entry src/data/proofs/erdos-1022-oq-02/",
@@ -84,7 +84,7 @@
     "mathlib": []
   },
   "started": "2026-06-23T00:00:00Z",
-  "lastUpdate": "2026-06-23T00:00:00Z",
+  "lastUpdate": "2026-07-08T00:00:00Z",
   "significance": 5,
   "tractability": 5,
   "leanFiles": [
@@ -102,8 +102,8 @@
     {
       "path": "Proofs/Erdos1022OQ02.lean",
       "filename": "Erdos1022OQ02.lean",
-      "lineCount": 234,
-      "theoremCount": 8,
+      "lineCount": 351,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds **§7** to `Erdos1022OQ02.lean` pinning the growth rate of the *integer* admissible coefficient `c(t) = ⌊2^{t-1}/|V|⌋` **itself**, closing OQ-02's "what is its growth rate" question at the coefficient level for bounded ground sets.

Prior work (this file, incl. #35463) established:
- the *real threshold* `2^{t-1}` doubles per step (`firstMoment_threshold_doubles`), and
- the coefficient diverges qualitatively, `c(t) → ∞` (`exists_admissible_coeff`).

What was left open was the *quantitative* growth rate of the integer coefficient after the floor. This PR pins it:

| Theorem | Statement | Content |
|---|---|---|
| `threshold_lt_succ_coeff_mul` | `2^{t-1} < (c(t)+1)·|V|` | the floor discards strictly less than one vertex-worth, so `c(t)` tracks the real density `2^{t-1}/|V|` to within one vertex |
| `admissibleCoeff_ge_two_mul` | `2·c(t) ≤ c(t+1)` | the integer coefficient **at least doubles per step** despite truncation (`⌊2a/n⌋ ≥ 2⌊a/n⌋`), hence grows at least exponentially in `t` |
| `admissibleCoeff_lt_of_pos` | `c(t) < c(t+1)` when `c(t) > 0` | strict monotonicity once the coefficient is positive |

## Honest scope

Unchanged from the file's standing disclaimer: this is the **first-moment / bounded-ground-set** regime only. The genuinely hard regime of Erdős #1022 (ground set growing with the family, Lovász-type `c_2 = 1` matching) is untouched. The result is a sharp lower bound on any admissible `c_t` for bounded `V`.

## Verification

- File: 286 → 351 lines, 11 → 14 theorems, **0 axioms, 0 sorries**.
- Docker build verified: `✔ [7744/7744] Built Proofs.Erdos1022OQ02`, 7744 jobs green, **no warnings**.
- Metadata (`meta.json`, research JSON) synced to truth (also reconciled a pre-existing stale `meta.lineCount`/`theoremCount` from #35463).

🤖 Generated with [Claude Code](https://claude.com/claude-code)