### PR TITLE
research(euler-polyhedral-oq-02-oq-02): connected-sum construction for Chern-Gauss-Bonnet (Part X)

### DIFF
--- a/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
+++ b/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
@@ -352,6 +352,75 @@ theorem chi_determined (M N : CGBManifold)
   rw [hdim, hpf, hN] at hM
   exact_mod_cast hM.symm
 
+-- ============================================================================
+-- Part X: Connected sums (χ is additive up to the sphere correction)
+-- ============================================================================
+
+/-- The connected sum `M # N` of two Chern-Gauss-Bonnet manifolds of the *same*
+    dimension (`h : M.halfDim = N.halfDim`). Removing an open `2n`-disk from each
+    and gluing along the boundary spheres gives χ(M # N) = χ(M) + χ(N) − χ(S^{2n})
+    = χ(M) + χ(N) − 2, and correspondingly ∫Pf drops by the sphere's contribution
+    `2·(2π)^n`. This is consistent with Chern-Gauss-Bonnet because the same
+    normalization constant `cgbConst n` governs all three pieces. -/
+def connectedSumCGB (M N : CGBManifold) (h : M.halfDim = N.halfDim) : CGBManifold where
+  halfDim := M.halfDim
+  chi := M.chi + N.chi - 2
+  totalPfaffian := M.totalPfaffian + N.totalPfaffian - 2 * cgbConst M.halfDim
+  chern_gauss_bonnet := by
+    rw [M.chern_gauss_bonnet, N.chern_gauss_bonnet, h]
+    push_cast; ring
+
+/-- Connected sum preserves dimension: dim(M # N) = dim M. -/
+theorem connectedSumCGB_dim (M N : CGBManifold) (h : M.halfDim = N.halfDim) :
+    (connectedSumCGB M N h).dim = M.dim := rfl
+
+/-- **Euler characteristic of a connected sum**: χ(M # N) = χ(M) + χ(N) − 2. -/
+theorem connectedSumCGB_chi (M N : CGBManifold) (h : M.halfDim = N.halfDim) :
+    (connectedSumCGB M N h).chi = M.chi + N.chi - 2 := rfl
+
+/-- **Total Pfaffian of a connected sum**: it is additive minus the sphere's
+    `2·(2π)^n` (the curvature removed with the two glued disks). -/
+theorem connectedSumCGB_totalPfaffian (M N : CGBManifold) (h : M.halfDim = N.halfDim) :
+    (connectedSumCGB M N h).totalPfaffian
+      = M.totalPfaffian + N.totalPfaffian - 2 * cgbConst M.halfDim := rfl
+
+/-- **The sphere is the identity for connected sum** (on Euler characteristics):
+    χ(S^{2n} # N) = χ(N). Connected sum makes `2n`-manifolds a monoid with
+    identity `S^{2n}`, and χ − 2 is the induced additive homomorphism to ℤ. -/
+theorem connectedSum_sphere_chi (n : ℕ) (N : CGBManifold)
+    (h : (sphereCGB n).halfDim = N.halfDim) :
+    (connectedSumCGB (sphereCGB n) N h).chi = N.chi := by
+  rw [connectedSumCGB_chi]
+  show (2 : ℤ) + N.chi - 2 = N.chi
+  ring
+
+/-- The sphere is also neutral for the total Pfaffian: ∫Pf(S^{2n} # N) = ∫Pf(N),
+    since the `2·(2π)^n` removed with the two disks exactly cancels the sphere's own
+    total Pfaffian `2·(2π)^n`. -/
+theorem connectedSum_sphere_totalPfaffian (n : ℕ) (N : CGBManifold)
+    (h : (sphereCGB n).halfDim = N.halfDim) :
+    (connectedSumCGB (sphereCGB n) N h).totalPfaffian = N.totalPfaffian := by
+  rw [connectedSumCGB_totalPfaffian]
+  show 2 * cgbConst n + N.totalPfaffian - 2 * cgbConst n = N.totalPfaffian
+  ring
+
+/-- **Genus-2 surface from two tori.** The connected sum T² # T² is the genus-2
+    closed orientable surface, with χ = 0 + 0 − 2 = −2 — matching the classical
+    χ(Σ_g) = 2 − 2g at g = 2. -/
+theorem genus_two_surface_chi :
+    (connectedSumCGB (torusCGB 1) (torusCGB 1) rfl).chi = -2 := by
+  rw [connectedSumCGB_chi]
+  show (0 : ℤ) + 0 - 2 = -2
+  ring
+
+/-- The genus-2 surface has total Pfaffian ∫Pf = −4π (so ∫Pf/2π = −2 = χ),
+    consistent with Gauss-Bonnet: a hyperbolic Σ₂ has ∫K dA = 2π·χ = −4π. -/
+theorem genus_two_surface_totalPfaffian :
+    (connectedSumCGB (torusCGB 1) (torusCGB 1) rfl).totalPfaffian = -(4 * π) := by
+  rw [connectedSumCGB_totalPfaffian]
+  show (0 : ℝ) + 0 - 2 * cgbConst 1 = -(4 * π)
+  rw [cgbConst_one]; ring
+
 end ChernGaussBonnet
 
 end

--- a/research/problems/euler-polyhedral-formula-oq-02-oq-02/knowledge.md
+++ b/research/problems/euler-polyhedral-formula-oq-02-oq-02/knowledge.md
@@ -54,3 +54,44 @@ annotations resolve cleanly).
 - Attempting a fully `verified` (0-assumption) entry is impossible: the Pfaffian
   curvature integral and manifold χ are not in Mathlib. The honest status is
   `axiomatized` with the geometric identity as a single structure field.
+
+---
+
+## Session 2026-07-08 (researcher-6) — Part X: connected sums
+
+**Mode:** REVISIT (mature axiomatized entry; add within the structure framework)
+**Outcome:** progress (1 new construction + 7 theorems)
+
+### What I Did
+Added `connectedSumCGB` — the connected sum `M # N` of two same-dimensional CGB
+manifolds — as a new functorial construction beside `prodCGB`:
+- `connectedSumCGB M N (h : M.halfDim = N.halfDim)`: χ = M.chi + N.chi − 2 and
+  totalPfaffian = M.tp + N.tp − 2·cgbConst n (curvature removed with the two glued
+  disks). The `chern_gauss_bonnet` field is discharged from M's and N's identities
+  since one normalization constant governs all three pieces.
+- `connectedSumCGB_dim/chi/totalPfaffian` (rfl accessors).
+- `connectedSum_sphere_chi`, `connectedSum_sphere_totalPfaffian`: **S^{2n} is the
+  connected-sum identity** (both χ and ∫Pf neutral) — connected sum is a monoid,
+  χ − 2 the induced additive homomorphism to ℤ.
+- `genus_two_surface_chi` (= −2) and `genus_two_surface_totalPfaffian` (= −4π):
+  T² # T² is the genus-2 surface, matching χ(Σ_g) = 2 − 2g and ∫K dA = 2π·χ = −4π.
+
+### Verification
+Built clean: `Proofs.EulerPolyhedralOQ02OQ02` (7743 jobs). File now 426 lines,
+44 theorems, 9 defs, 2 structures, 0 sorries, 0 axiom declarations. Status stays
+**axiomatized** (the 2 structure-encoded assumptions CGBManifold.chern_gauss_bonnet
+and ClosedOddManifold.chi_zero are unchanged; the new construction adds no
+assumptions). Build hit the recurring shared-volume corruption (exit-135, line-less)
+×2 → cleared by `docker-build.sh --repair-cache` at load 0 then a clean rebuild.
+
+### Frontier
+Core still BLOCKED on Mathlib v4.26 gaps (no Pfaffian, no characteristic-form
+integration over manifolds, no manifold Euler characteristic). The connected-sum,
+product, and sphere/torus/odd constructions now give a fairly complete calculus of
+the *structure-encoded* Euler-characteristic invariant; further elementary progress
+is exhausted until Mathlib gains the differential-geometry machinery.
+
+### Files Modified
+- `proofs/Proofs/EulerPolyhedralOQ02OQ02.lean` (Part X, +~70 lines, verified)
+- `src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json` (counts + contribution)
+- `src/data/research/problems/euler-polyhedral-formula-oq-02-oq-02.json` (counts + knowledge)

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
@@ -37,15 +37,16 @@
       "Normalized Chern-Gauss-Bonnet ∫ Pf(Ω/2π) = χ and integrality of the Euler number from a transcendental curvature integral",
       "Recovery of the classical 2D Gauss-Bonnet ∫ Pf(Ω) = 2πχ at n=1, bridging entries OQ-02 (discrete) and OQ-02-OQ-01 (smooth)",
       "Functorial constructions: even spheres S^{2n}, products M×N with multiplicative χ(M×N)=χ(M)χ(N) and multiplicative total Pfaffian, flat tori with χ=0",
-      "Odd-dimensional vanishing: a ClosedOddManifold structure recording χ=0 (Poincaré duality), explaining why Chern-Gauss-Bonnet carries no information in odd dimension"
+      "Odd-dimensional vanishing: a ClosedOddManifold structure recording χ=0 (Poincaré duality), explaining why Chern-Gauss-Bonnet carries no information in odd dimension",
+      "Connected-sum construction connectedSumCGB (Part X): χ(M # N) = χ(M) + χ(N) − 2 and the additive-minus-sphere total Pfaffian, with the sphere S^{2n} as the connected-sum identity (χ and ∫Pf neutral) and the genus-2 surface T²#T² realised with χ = −2, ∫Pf = −4π"
     ],
     "historicalContext": "Gauss (1827) and Bonnet (1848) related Gaussian curvature to topology for surfaces: ∫K dA = 2πχ. Allendoerfer-Weil (1943) and then Chern (1944-45) generalized this to all closed oriented even-dimensional Riemannian manifolds, expressing the Euler characteristic as the integral of the Pfaffian of the curvature form: ∫_M Pf(Ω/2π) = χ(M). Chern's intrinsic proof, via the transgression of the Euler form, became a cornerstone of characteristic-class theory. For 2-manifolds (n=1) the Pfaffian of the 2×2 curvature is the Gaussian curvature times the area form, recovering classical Gauss-Bonnet; for polyhedral surfaces the curvature concentrates at vertices as angular deficiency, recovering the discrete theorem Σδ(v)=2πχ.",
     "axiomCount": 2,
-    "lineCount": 357,
+    "lineCount": 426,
     "assumptions": "0 sorries; 0 axiom declarations; 2 structure-encoded assumptions. (1) CGBManifold.chern_gauss_bonnet encodes the Chern-Gauss-Bonnet identity ∫_M Pf(Ω) = (2π)^n·χ(M); Mathlib v4.26.0 has no Pfaffian of a curvature form, no integration of characteristic forms over manifolds, and no manifold Euler characteristic, so the identity is taken as a field rather than derived. (2) ClosedOddManifold.chi_zero encodes the Poincaré-duality fact that closed odd-dimensional manifolds have χ=0. All 37 theorems are then derived; the sphere Euler characteristics, normalization-constant lemmas, and the 2×2 Pfaffian identity are independently verified (depend only on propext/Classical.choice/Quot.sound). #print axioms confirms no sorryAx and no Lean.ofReduceBool.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 37,
-    "definitionCount": 8
+    "theoremCount": 44,
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "Chern (1944-45) generalized the Gauss-Bonnet theorem to closed oriented even-dimensional Riemannian manifolds, expressing χ(M) as the integral of the Pfaffian of the curvature form. This entry connects that higher-dimensional theorem back to the discrete (OQ-02) and smooth 2D (OQ-02-OQ-01) Gauss-Bonnet theorems already in the gallery.",
@@ -152,10 +153,10 @@
       "Real"
     ],
     "namespace": "ChernGaussBonnet",
-    "lineCount": 357,
+    "lineCount": 426,
     "axiomCount": 0,
-    "theoremCount": 37,
-    "definitionCount": 8,
+    "theoremCount": 44,
+    "definitionCount": 9,
     "path": "Proofs/EulerPolyhedralOQ02OQ02.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-02.json
+++ b/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-02.json
@@ -33,7 +33,8 @@
     "builtItems": [
       "CGBManifold structure encoding the Chern-Gauss-Bonnet identity ∫_M Pf(Ω)=(2π)^n·χ(M) with derived even-dimensionality, normalized integral, χ=0⇒∫Pf=0, sign matching, and Euler-number integrality.",
       "Verified sphere Euler characteristics (sphereEulerChar), (2π)^n normalization lemmas (cgbConst), and the 2×2 Pfaffian/determinant identity (pf2_sq_eq_det2).",
-      "Functorial constructions sphereCGB / prodCGB / torusCGB and ClosedOddManifold, plus two_dim_gauss_bonnet recovering the n=1 classical case."
+      "Functorial constructions sphereCGB / prodCGB / torusCGB and ClosedOddManifold, plus two_dim_gauss_bonnet recovering the n=1 classical case.",
+      "connectedSumCGB (Part X) — connected-sum monoid on CGB manifolds: χ additive minus sphere (χ(M#N)=χM+χN−2), sphere = identity, T²#T² genus-2 surface has χ=−2 / ∫Pf=−4π (all 0-axiom-declaration, structure-encoded framework unchanged)."
     ],
     "insights": [
       "χ(S^m)=1+(-1)^m gives 2 in even and 0 in odd dimension — the parity that makes the Pfaffian (an even-dimensional invariant) the correct curvature integrand for Chern-Gauss-Bonnet.",
@@ -66,10 +67,10 @@
     {
       "path": "Proofs/EulerPolyhedralFormula.lean",
       "filename": "EulerPolyhedralFormula.lean",
-      "lineCount": 1093,
-      "theoremCount": 65,
+      "lineCount": 426,
+      "theoremCount": 44,
       "axiomCount": 1,
-      "defCount": 27,
+      "defCount": 9,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerPolyhedralFormula.lean"


### PR DESCRIPTION
## Euler / Chern-Gauss-Bonnet OQ-02-OQ-02 — connected sums

The `CGBManifold` framework already models the Chern-Gauss-Bonnet identity
`∫_M Pf(Ω) = (2π)^n·χ(M)` and its product calculus (`prodCGB`, χ multiplicative).
This PR adds the complementary **connected-sum** construction.

### Contribution (Part X)

- **`connectedSumCGB M N (h : M.halfDim = N.halfDim)`** — the connected sum of two
  same-dimensional CGB manifolds: `χ(M # N) = χ(M) + χ(N) − 2` and total Pfaffian
  `∫Pf(M) + ∫Pf(N) − 2·(2π)^n` (the curvature removed with the two glued disks).
  The CGB field follows from M's and N's since one normalization constant governs
  all three pieces.
- **`connectedSum_sphere_chi` / `connectedSum_sphere_totalPfaffian`** — the sphere
  `S^{2n}` is the **identity** for connected sum (both χ and ∫Pf neutral); connected
  sum is a monoid and `χ − 2` the induced additive homomorphism to ℤ.
- **`genus_two_surface_chi` / `genus_two_surface_totalPfaffian`** — `T² # T²` is the
  genus-2 surface with `χ = −2` and `∫Pf = −4π`, matching the classical
  `χ(Σ_g) = 2 − 2g` and `∫K dA = 2π·χ`.

### Status / assumptions
- **No new assumptions.** The construction is built entirely within the existing
  `CGBManifold` structure, so the entry stays **`axiomatized`** with the same two
  structure-encoded fields (`CGBManifold.chern_gauss_bonnet`,
  `ClosedOddManifold.chi_zero`). Core CGB remains blocked on Mathlib v4.26 (no
  Pfaffian / characteristic-form integration / manifold Euler characteristic).

### Verification
- Built clean: `Proofs.EulerPolyhedralOQ02OQ02` (7743 jobs), **0 sorry, 0 axiom declarations**.
- File: 426 lines, 44 theorems, 9 defs, 2 structures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)