### PR TITLE
Enrich Catalan O(1) Linear Recurrence (catalan-numbers-oq-01): mainTheorem endLine anchors

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01/meta.json
@@ -109,14 +109,16 @@
       "type": "core",
       "description": "The headline result: the first-order (holonomic) linear recurrence for the Catalan numbers, $(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, over ℕ. Absent from Mathlib, which states only the quadratic Segner convolution catalan_succ' and the closed form catalan_eq_centralBinom_div. Proved without induction by multiplying through by n+1, rewriting via the central-binomial bridge succ_mul_catalan_eq_centralBinom and the central-binomial recurrence Nat.succ_mul_centralBinom_succ, then cancelling n+1.",
       "leanType": "(n : ℕ) → (n + 2) * catalan (n + 1) = 2 * (2 * n + 1) * catalan n",
-      "startLine": 31
+      "startLine": 31,
+      "endLine": 48
     },
     {
       "name": "catalan_succ_eq_div",
       "type": "corollary",
       "description": "The recurrence solved for the next term, exhibiting the exact O(1) division step $C_{n+1} = 2(2n+1)\\,C_n/(n+2)$ over ℕ. The truncating division is provably exact because n+2 divides the numerator (Nat.mul_div_cancel_left).",
       "leanType": "(n : ℕ) → catalan (n + 1) = 2 * (2 * n + 1) * catalan n / (n + 2)",
-      "startLine": 53
+      "startLine": 53,
+      "endLine": 56
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01` (quality 94, passes 0).

The entry was already thorough — 3 full-coverage sections, 6 annotations (all with mathContext/significance/relatedConcepts), 4 keyInsights, and a complete conclusion. The one genuine gap: both `mainTheorems` carried only `startLine` and no `endLine`, leaving the theorem spans open-ended.

## Change (factual, non-inflating)
- `catalan_linear_recurrence`: added `endLine: 48` (theorem spans 31–48).
- `catalan_succ_eq_div`: added `endLine: 56` (theorem spans 53–56).

Both anchors verified against `Proofs/CatalanNumbersOQ01.lean`. No prose changed; meta.json stays ~15 KB, well under the 60 KB cap.