### PR TITLE
Enrich Composition Part-Count Generating Function (oq-01-oq-01-oq-01-oq-02): header section coverage

### DIFF
--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -80,6 +80,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Header, Imports, and Family Context",
+      "startLine": 1,
+      "endLine": 64,
+      "mathContext": "$\\sum_{c : \\mathrm{Composition}\\,n} t^{c.\\mathrm{length}} = t\\,(1+t)^{n-1}$ — the part-count generating function that packages every moment at once.",
+      "summary": "Imports the parent CompositionPartsChooseOQ01OQ01 (source of the gap bijection gapsEquiv and the bridge length_eq_card_gaps) and Mathlib.Tactic, then a module docstring situating this leaf within the composition-statistics family: the grandparent's 2^(n−1) count, the parent's graded C(n−1,k−1) count, and the first/second-moment parents, all of which fall out of the single generating-function identity proved here. Closes with the namespace declaration and open Finset CompositionPartsChooseOQ01OQ01."
+    },
+    {
       "id": "subset-generating-function",
       "title": "The Subset-Cardinality Generating Function",
       "startLine": 65,


### PR DESCRIPTION
Enrichment pass for `composition-parts-choose-oq-01-oq-01-oq-01-oq-02` (quality 94, passes 0).

The entry was already rich — 4 mainTheorems with verified startLine/endLine anchors, 5 fully-populated annotations, 4 keyInsights, and a complete conclusion. The one gap: the `sections` array started at line 65, leaving the module docstring, imports, and namespace setup (lines 1–64) uncovered.

## Change (factual, non-inflating)
- Added a `setup` section (lines 1–64) covering the imports (parent `CompositionPartsChooseOQ01OQ01` supplying `gapsEquiv`/`length_eq_card_gaps`, plus `Mathlib.Tactic`), the family-context docstring, and the `namespace`/`open` declarations.

`sections` now covers the full 123-line file. No prose inflated; meta.json ~20 KB, well under the 60 KB cap.