### PR TITLE
research(erdos-659-incomplete-01): mod-8 obstruction — necessity side of x²+2y² characterization [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -305,6 +305,51 @@ theorem representable_pow {m : ℕ} (hm : m ∈ representable_x2_2y2) (k : ℕ) 
 theorem two_pow_representable (k : ℕ) : 2 ^ k ∈ representable_x2_2y2 :=
   representable_pow two_representable k
 
+/-! ### The mod-8 obstruction (necessity side of the characterization)
+
+The lemmas above are all *positivity* results — they exhibit integers that **are**
+represented by `x² + 2y²`. The arithmetic characterization cited in the notes above
+("a number is representable iff every prime `≡ 5, 7 (mod 8)` divides it to an even
+power") also has a *necessity* side, and its cleanest concrete form is a congruence
+obstruction: **no integer `≡ 5` or `7 (mod 8)` is a value of `x² + 2y²`.** The reason
+is elementary — squares mod `8` lie in `{0, 1, 4}` and `2y²` mod `8` lies in `{0, 2}`,
+so `x² + 2y²` mod `8` never hits `5` or `7`. This is exactly the residue class of the
+primes that are *inert* in `ℤ[√-2]`, i.e. that do not occur as norms. The lemma below
+verifies this by a finite `decide` over `ZMod 8`; it is the first non-representability
+result in the file and is fully verified (no axioms, no sorries), independent of the
+deep analytic input `moreeOsburnWorks`. -/
+
+/-- **The mod-8 obstruction**: an integer congruent to `5` or `7` mod `8` is never
+    representable as `x² + 2y²`. This is the necessity direction of the arithmetic
+    characterization of the norm form of `ℤ[√-2]` (discriminant `-8`), and shows the
+    form is not universal. -/
+theorem not_representable_of_mod8 (n : ℕ) (h : n % 8 = 5 ∨ n % 8 = 7) :
+    n ∉ representable_x2_2y2 := by
+  rintro ⟨x, y, hxy⟩
+  -- Reduce the representation to `ZMod 8`.
+  have hz : (n : ZMod 8) = (x : ZMod 8) ^ 2 + 2 * (y : ZMod 8) ^ 2 := by
+    have hn : (n : ZMod 8) = ((n : ℤ) : ZMod 8) := by push_cast; ring
+    rw [hn, hxy]; push_cast; ring
+  -- No pair of residues mod 8 sums to 5 or 7 under the form `a² + 2b²`.
+  have key : ∀ a b : ZMod 8, a ^ 2 + 2 * b ^ 2 ≠ 5 ∧ a ^ 2 + 2 * b ^ 2 ≠ 7 := by decide
+  -- The hypothesis pins `(n : ZMod 8)` to 5 or 7.
+  have hn8 : (n : ZMod 8) = 5 ∨ (n : ZMod 8) = 7 := by
+    rcases h with h | h
+    · left;  rw [← ZMod.natCast_mod n 8, h]; decide
+    · right; rw [← ZMod.natCast_mod n 8, h]; decide
+  rcases hn8 with h5 | h7
+  · exact (key (x : ZMod 8) (y : ZMod 8)).1 (hz.symm.trans h5)
+  · exact (key (x : ZMod 8) (y : ZMod 8)).2 (hz.symm.trans h7)
+
+/-- `5 ≡ 5 (mod 8)` is **not** representable as `x² + 2y²` — the smallest witness of
+    the mod-8 obstruction (`5` is inert in `ℤ[√-2]`). -/
+theorem five_not_representable : 5 ∉ representable_x2_2y2 :=
+  not_representable_of_mod8 5 (Or.inl rfl)
+
+/-- `7 ≡ 7 (mod 8)` is **not** representable as `x² + 2y²` (`7` is inert in `ℤ[√-2]`). -/
+theorem seven_not_representable : 7 ∉ representable_x2_2y2 :=
+  not_representable_of_mod8 7 (Or.inr rfl)
+
 /-- The 4-point property follows from avoiding all six two-distance configurations,
     **together with** the geometric lower bound that no 4-point subset collapses to
     fewer than two distinct distances.

--- a/research/problems/erdos-659-incomplete-01/state.md
+++ b/research/problems/erdos-659-incomplete-01/state.md
@@ -49,3 +49,17 @@ Added 5 verified theorems on the multiplicative structure of the norm form
 — the norm-multiplicativity of `ℤ[√-2]` underlying the arithmetic characterization
 Landau's theorem relies on. No axiom/sorry change (still 1 axiom, 0 sorries);
 docker build EXIT 0. theoremCount 5→10, lineCount 280→322.
+
+## Session 2026-07-08 (researcher-1)
+
+Added the **necessity side** of the x²+2y² arithmetic characterization — the first
+non-representability results in the file. `not_representable_of_mod8`: no integer
+`≡ 5` or `7 (mod 8)` is a value of `x²+2y²` (finite `decide` over `ZMod 8`; squares
+mod 8 ∈ {0,1,4}, `2y²` mod 8 ∈ {0,2}, so the form never hits 5 or 7). Concrete
+corollaries `five_not_representable` / `seven_not_representable` (smallest inert
+witnesses in ℤ[√-2]). Complements the existing positivity/multiplicativity lemmas
+(`representable_mul`, `sq_representable`, `two_pow_representable`, …), which only
+exhibited representable integers. Docker build EXIT 0 (kernel `decide`, no
+`native_decide` → no new axiom). theoremCount 13→16, lineCount →387; still 0 sorries,
+1 axiom (`moreeOsburnWorks`, Landau's theorem, irreducible). Also synced stale gallery
+`meta.json` leanFile counts (were 322/10, actual now 387/16).

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -45,12 +45,13 @@
             "Resolved the former classification sorry: fourPointProperty_from_avoiding_configs is now a fully verified conditional, with the necessary geometric lower bound made explicit (the original statement was false under the product/Chebyshev metric — mutually-equidistant 4-point sets exist)",
             "Partial classification of 6 two-distance configurations: square, 60° rhombus, and pentagon subset formally characterized; isosceles trapezoid (2 types) and kite left as True placeholders",
             "Educational explanation of Moree-Osburn lattice construction",
-            "Verified multiplicative structure of the norm form x²+2y² (repr_mul_identity composition identity + representable_mul closure, plus representability of 1, 2, 3): the norm-multiplicativity of ℤ[√-2] underlying the arithmetic characterization used by Landau's theorem"
+            "Verified multiplicative structure of the norm form x²+2y² (repr_mul_identity composition identity + representable_mul closure, plus representability of 1, 2, 3): the norm-multiplicativity of ℤ[√-2] underlying the arithmetic characterization used by Landau's theorem",
+            "Verified the necessity side (mod-8 obstruction) of the arithmetic characterization: not_representable_of_mod8 proves no integer ≡ 5 or 7 (mod 8) is a value of x²+2y² (finite decide over ZMod 8), with five_not_representable / seven_not_representable as the smallest concrete witnesses — the first non-representability results in the file, showing the form is not universal (5, 7 are inert in ℤ[√-2])"
         ],
         "axiomCount": 1,
-        "lineCount": 322,
+        "lineCount": 387,
         "assumptions": "1 axiom: moreeOsburnWorks (encodes Landau's 1908 theorem on the count of integers representable as x²+2y², together with the full 4-point classification; not available in Mathlib 4.26). 0 sorries.",
-        "theoremCount": 10,
+        "theoremCount": 16,
         "definitionCount": 10
     },
     "overview": {
@@ -139,9 +140,9 @@
             "Real"
         ],
         "namespace": "Erdos659",
-        "lineCount": 322,
+        "lineCount": 387,
         "axiomCount": 1,
-        "theoremCount": 10,
+        "theoremCount": 16,
         "definitionCount": 10,
         "path": "Proofs/Erdos659Problem.lean",
         "sorries": 0


### PR DESCRIPTION
## Summary

Adds the **necessity side** of the arithmetic characterization of the norm form `x²+2y²` (discriminant −8, the norm form of `ℤ[√-2]`) to `Erdos659Problem.lean`. Until now the file only had *positivity* results (integers that **are** representable — `representable_mul`, `sq_representable`, `two_pow_representable`, …). This adds the complementary obstruction, which the file's own docstring cited but never proved.

## What's new (3 theorems, all axiom-free)

- **`not_representable_of_mod8`** — no integer `≡ 5` or `7 (mod 8)` is a value of `x²+2y²`. Proof: reduce the representation to `ZMod 8`; a finite `decide` shows `a²+2b²` over `ZMod 8` never equals 5 or 7 (squares mod 8 ∈ {0,1,4}, `2y²` mod 8 ∈ {0,2}). This is exactly the residue class of primes *inert* in `ℤ[√-2]`.
- **`five_not_representable`** / **`seven_not_representable`** — smallest concrete witnesses (first non-representability facts in the file), showing the form is not universal.

## Verification

- Docker build `Proofs.Erdos659Problem` → **EXIT 0**.
- Uses kernel `decide` (not `native_decide`) → **no new axiom** / no `ofReduceBool`.
- File: 0 sorries, 1 inherited axiom (`moreeOsburnWorks` = Landau 1908 + 4-point classification, irreducible / absent from Mathlib 4.26). theoremCount 13→16, lineCount →387.
- Synced stale gallery `meta.json` leanFile counts (were 322/10).

## Scope

The main axiom `moreeOsburnWorks` remains — eliminating it requires formalizing Landau's theorem for discriminant-−8 binary quadratic forms, a large analytic-number-theory project out of scope for a single cycle. This PR is additive verified content on the arithmetic substrate, not an axiom elimination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)