### PR TITLE
Enrich Connected Space closure dichotomy (connected-space-oq-01-oq-01): header section coverage

### DIFF
--- a/src/data/proofs/connected-space-oq-01-oq-01/meta.json
+++ b/src/data/proofs/connected-space-oq-01-oq-01/meta.json
@@ -93,6 +93,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Header, Imports, and the Negative/Positive Dichotomy",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Imports Mathlib's path-connectedness and local-path-connectedness topology (Topology.Connected.PathConnected, Topology.Connected.LocPathConnected) plus Tactic, then a module docstring framing the parent's open question: how closure behaves for path-connectedness versus connectedness. Lays out the two halves — the negative half (only connectedness survives closure, witnessed by the topologist's sine curve) and the positive half (local path-connectedness makes path components clopen, restoring rigidity) — and lists the Mathlib facts used. Closes with the namespace, open Set Topology, and the variable {α} [TopologicalSpace α] setup.",
+      "mathContext": "The topologist's sine curve $\\{(x,\\sin(1/x)) : x>0\\}$ is path-connected but its closure (adding $\\{0\\}\\times[-1,1]$) is connected yet not path-connected — the counterexample driving the whole dichotomy."
+    },
+    {
       "id": "negative-half",
       "title": "Section I: Closure Only Preserves Connectedness",
       "startLine": 59,


### PR DESCRIPTION
Enrichment pass for `connected-space-oq-01-oq-01` (quality 94, passes 0).

Already rich — 8 mainTheorems with verified anchors, 10 fully-populated annotations, 5 keyInsights, complete conclusion. The one gap: `sections` started at line 59, leaving the imports, module docstring (the negative/positive dichotomy framing), and namespace/open/variable setup (lines 1–58) uncovered.

## Change (factual, non-inflating)
- Added a `setup` section (lines 1–58) covering the imports, the docstring that frames the topologist's-sine-curve dichotomy, and the ambient topological-space setup.

`sections` now covers the full 126-line file. No prose inflated; meta.json ~15 KB, well under the 60 KB cap.