### PR TITLE
research(law-of-cosines-oq-03-oq-03): equilateral corollaries — θ<π/3 and cosh=1+√2 (Part 7)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -295,4 +295,37 @@ theorem area_positive (t : HyperbolicTriangle) :
     0 < Real.pi - (t.A + t.B + t.C) := by
   linarith [t.defect]
 
+-- ============================================================
+-- PART 7: The equilateral triangle — angle bound and a concrete value
+-- ============================================================
+
+/-- **Equilateral angle bound.** An equilateral hyperbolic triangle (all three angles
+    equal) has common angle strictly below `π/3`. This is the sharp hyperbolic
+    counterpart of the Euclidean equilateral angle `π/3`: the angular defect
+    `A + B + C < π` forces `3θ < π`, i.e. `θ < π/3`, and the closer `θ` is to `π/3`
+    the smaller (more Euclidean) the triangle. -/
+theorem equilateral_angle_lt_pi_third (t : HyperbolicTriangle)
+    (hAB : t.A = t.B) (hBC : t.B = t.C) : t.C < Real.pi / 3 := by
+  have h := t.defect
+  rw [hAB, hBC] at h
+  linarith
+
+/-- **A concrete equilateral triangle.** The hyperbolic equilateral triangle whose
+    three angles are all `π/4` has every side of length `arcosh (1 + √2)`:
+
+      cosh(side) = cos(π/4) / (1 - cos(π/4)) = 1 + √2.
+
+    (Since `π/4 < π/3`, this angle is admissible, and `1 + √2 > 1` confirms a genuine
+    hyperbolic side.) A clean closed value obtained from `equilateral_cosh`. -/
+theorem equilateral_pi_four_cosh (t : HyperbolicTriangle)
+    (hAB : t.A = t.B) (hBC : t.B = t.C) (hC4 : t.C = Real.pi / 4) :
+    Real.cosh t.c = 1 + Real.sqrt 2 := by
+  rw [equilateral_cosh t hAB hBC, hC4, Real.cos_pi_div_four]
+  have hs : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have hs0 : 0 ≤ Real.sqrt 2 := Real.sqrt_nonneg 2
+  have hlt : Real.sqrt 2 < 2 := by nlinarith [hs, hs0]
+  have hpos : (0 : ℝ) < 1 - Real.sqrt 2 / 2 := by linarith [hlt]
+  rw [div_eq_iff hpos.ne']
+  linear_combination (1 / 2 : ℝ) * hs
+
 end HyperbolicAAA

--- a/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
+++ b/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
@@ -1,0 +1,27 @@
+
+## Session 2026-07-08 (researcher-6) — Part 7: equilateral corollaries
+
+**Mode:** REVISIT (mature axiomatized AAA-congruence entry)
+**Outcome:** progress (2 new theorems, 0 new assumptions)
+
+### What I Did
+Added two clean corollaries around the equilateral hyperbolic triangle:
+- `equilateral_angle_lt_pi_third` — an equilateral triangle (all angles equal) has
+  common angle `< π/3`. Direct from the angular defect `A+B+C < π` (`3θ < π`); the
+  sharp hyperbolic counterpart of the Euclidean equilateral angle `π/3`.
+- `equilateral_pi_four_cosh` — the equilateral triangle with all angles `π/4` has
+  every side `arcosh(1+√2)`: `cosh side = cos(π/4)/(1-cos(π/4)) = 1+√2`. A concrete
+  closed value off the existing `equilateral_cosh`; `π/4 < π/3` confirms admissibility
+  and `1+√2 > 1` a genuine side.
+
+### Verification
+Built clean: `Proofs.LawOfCosinesOQ03OQ03` (3061 jobs), 0 sorries, 0 axiom
+declarations. File now 331 lines, 22 theorems, 2 structures. Status stays
+**axiomatized** (the 7 structure-encoded geometric assumptions are unchanged; the
+new theorems introduce none). Key steps: `linarith` on the defect; `linear_combination
+(1/2)·(√2²=2)` after `div_eq_iff`, with `√2 < 2` via `nlinarith`.
+
+### Files Modified
+- `proofs/Proofs/LawOfCosinesOQ03OQ03.lean` (Part 7, +~35 lines, verified)
+- `src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json` (counts + contribution)
+- `src/data/research/problems/law-of-cosines-oq-03-oq-03.json` (counts + knowledge)

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 7,
     "sorries": 0,
-    "lineCount": 298,
-    "theoremCount": 20,
+    "lineCount": 331,
+    "theoremCount": 22,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -353,8 +353,8 @@
     ],
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 298,
-    "theoremCount": 20,
+    "lineCount": 331,
+    "theoremCount": 22,
     "definitionCount": 1,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",
@@ -363,7 +363,8 @@
       "cosh_c_gt_one: cosh c > 1 derived from the angles alone",
       "aaa_congruence: equal angles ⟹ equal sides via cosh injectivity on [0,∞)",
       "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) for the equilateral triangle",
-      "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — holding two angles fixed, increasing the third strictly shortens the opposite side (refines AAA congruence to a strict comparison)"
+      "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — holding two angles fixed, increasing the third strictly shortens the opposite side (refines AAA congruence to a strict comparison)",
+      "Equilateral corollaries (Part 7): equilateral_angle_lt_pi_third (an equilateral hyperbolic triangle has common angle < π/3, the sharp defect-driven counterpart of the Euclidean π/3) and equilateral_pi_four_cosh (the all-angles-π/4 equilateral triangle has every side arcosh(1+√2), i.e. cosh = 1+√2) — no new assumptions"
     ],
     "proofStrategy": "Invert each second law of cosines (linear in cosh of the opposite side) via eq_div_iff + linear_combination to get cosh(side) as a ratio of angle functions. Prove the angle ratio exceeds 1 from the defect using cos(A+B) > cos(π-C) = -cos C (strict antitonicity of cos on [0,π]). Conclude AAA congruence by cosh injectivity on [0,∞). Specialize to the equilateral case for a closed form.",
     "openQuestions": [

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -22,7 +22,8 @@
       "cosh_c_gt_one: cosh c > 1 derived purely from the angles",
       "aaa_congruence: equal angles ⟹ equal sides via Real.cosh_strictMonoOn.injOn",
       "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) using sin²θ=(1-cosθ)(1+cosθ) + div_eq_div_iff",
-      "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — with two angles fixed, increasing the third strictly shortens the opposite side (cosh_c_eq numerator antitone in C + cosh injectivity)"
+      "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — with two angles fixed, increasing the third strictly shortens the opposite side (cosh_c_eq numerator antitone in C + cosh injectivity)",
+      "Part 7 equilateral corollaries: equilateral_angle_lt_pi_third (θ<π/3 from the defect) and equilateral_pi_four_cosh (all angles π/4 ⟹ cosh side = 1+√2). Concrete/structural additions to the AAA-congruence file; no new assumptions, status stays axiomatized."
     ],
     "insights": [
       "The second law of cosines is linear in cosh of the opposite side, so it inverts algebraically — no Euclidean analogue, since the Euclidean law relates a side to the other two sides, not purely to angles.",
@@ -79,8 +80,8 @@
     {
       "path": "Proofs/LawOfCosines.lean",
       "filename": "LawOfCosines.lean",
-      "lineCount": 281,
-      "theoremCount": 14,
+      "lineCount": 331,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Hyperbolic AAA congruence (OQ-03-OQ-03) — equilateral corollaries

The file establishes hyperbolic AAA congruence (angles determine the triangle) with
the side-inversion `cosh c = (cos C + cos A cos B)/(sin A sin B)`, defect consistency,
angle–side monotonicity, and the equilateral closed form `cosh(side) = cosθ/(1−cosθ)`.
This PR adds two clean corollaries around the equilateral case.

### Contribution (Part 7)

- **`equilateral_angle_lt_pi_third`** — an equilateral hyperbolic triangle (all three
  angles equal) has common angle `< π/3`. Immediate from the angular defect
  `A+B+C < π` (`3θ < π`); the sharp hyperbolic counterpart of the Euclidean
  equilateral angle `π/3`.
- **`equilateral_pi_four_cosh`** — the equilateral triangle with all angles `π/4` has
  every side `arcosh(1+√2)`: `cosh(side) = cos(π/4)/(1−cos(π/4)) = 1+√2`. A concrete
  closed value from the existing `equilateral_cosh` (`π/4 < π/3` admissible, `1+√2 > 1`
  a genuine hyperbolic side).

### Status / assumptions
- **No new assumptions.** Both theorems are derived from the existing
  `HyperbolicTriangle` structure, so the entry stays **`axiomatized`** with the same
  structure-encoded geometric fields.

### Verification
- Built clean: `Proofs.LawOfCosinesOQ03OQ03` (3061 jobs), **0 sorry, 0 axiom declarations**.
- File: 331 lines, 22 theorems, 2 structures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)