### PR TITLE
research(erdos-18-oq-01): complement symmetry of the representable set [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -262,4 +262,45 @@ theorem practical_pred_le_sigma {m : ℕ} (hm : 2 ≤ m) (hp : IsPractical m) :
     m - 1 ≤ (divisors m).sum id :=
   representable_le_sigma (hp.2 (m - 1) (by omega) (by omega))
 
+/-! ## Complement symmetry of the representable set
+
+The representable values of `m` are symmetric about `σ(m)/2`: if `k` is a sum of
+distinct divisors of `m`, so is its complement `σ(m) - k` (take the divisors NOT
+used).  Together with `representable_le_sigma` (every representable value is `≤
+σ(m)`) this pins the representable set inside `[0, σ(m)]` and makes it invariant
+under `k ↦ σ(m) - k`.  A structural companion to the additive
+`representable_union` above. -/
+
+/-- **The full divisor sum `σ(m)` is representable** — by the set of *all*
+    divisors of `m`.  This is the top of the representable range `[0, σ(m)]`,
+    matching the upper bound `representable_le_sigma`. -/
+theorem sigma_representable (m : ℕ) : IsRepresentable ((divisors m).sum id) m :=
+  ⟨divisors m, Finset.Subset.refl _, rfl⟩
+
+/-- **Complement symmetry.**  If `k` is representable by divisors of `m`, then so
+    is `σ(m) - k`: the divisors left unused by a subset summing to `k` themselves
+    sum to `σ(m) - k`.  Hence the representable set is symmetric under
+    `k ↦ σ(m) - k`. -/
+theorem representable_compl {k m : ℕ} (h : IsRepresentable k m) :
+    IsRepresentable ((divisors m).sum id - k) m := by
+  obtain ⟨S, hS, hsum⟩ := h
+  refine ⟨divisors m \ S, Finset.sdiff_subset, ?_⟩
+  have hsd : (divisors m \ S).sum id + S.sum id = (divisors m).sum id :=
+    Finset.sum_sdiff hS
+  omega
+
+/-- **Practical numbers also represent their TOP segment `[σ(m) - m, σ(m)]`.**
+    `practical_represents_le` gives the bottom segment `[0, m]`; reflecting it
+    through the complement symmetry `representable_compl` yields the mirror-image
+    top segment.  So a practical number represents both ends of `[0, σ(m)]` in a
+    full width-`m` block. -/
+theorem practical_top_segment {m : ℕ} (hp : IsPractical m) {k : ℕ}
+    (hlo : (divisors m).sum id - m ≤ k) (hhi : k ≤ (divisors m).sum id) :
+    IsRepresentable k m := by
+  -- `σ(m) - k ≤ m`, so the bottom segment represents it; complement back to `k`.
+  have hk' : (divisors m).sum id - k ≤ m := by omega
+  have hrep := representable_compl (practical_represents_le hp hk')
+  have hcancel : (divisors m).sum id - ((divisors m).sum id - k) = k := by omega
+  rwa [hcancel] at hrep
+
 end Erdos18OQ01

--- a/src/data/research/problems/erdos-18-oq-01.json
+++ b/src/data/research/problems/erdos-18-oq-01.json
@@ -38,14 +38,16 @@
       "zero_representable (∅), mem_divisors_representable (singleton {d}), one_representable (1∣m), self_representable ({m}).",
       "practical_of_check: IsPractical m from ∀ k ∈ range m, 1≤k → ∃ S ∈ (divisors m).powerset, S.sum id = k (decidable via Finset.decidableBExists/BAll).",
       "four_practical, six_practical, eight_practical via practical_of_check + decide.",
-      "representability algebra (researcher-7, 2026-07-08): representable_union (closure under disjoint union of divisor subsets: a,b representable via disjoint sets ⟹ a+b representable), representable_le_sigma (every representable value ≤ σ(m) = sum of all divisors), and practical_pred_le_sigma (a practical m ≥ 2 satisfies m-1 ≤ σ(m)). 0 axioms, 0 sorries, builds clean 7744 jobs."
+      "representability algebra (researcher-7, 2026-07-08): representable_union (closure under disjoint union of divisor subsets: a,b representable via disjoint sets ⟹ a+b representable), representable_le_sigma (every representable value ≤ σ(m) = sum of all divisors), and practical_pred_le_sigma (a practical m ≥ 2 satisfies m-1 ≤ σ(m)). 0 axioms, 0 sorries, builds clean 7744 jobs.",
+      "sigma_representable, representable_compl, practical_top_segment (3 theorems, 0 axioms): complement symmetry k↦σ(m)−k of the representability algebra + its consequence for the top segment of a practical number."
     ],
     "insights": [
       "IsRepresentable k m = ∃ S ⊆ divisors m, S.sum id = k; the bounded form ∃ S ∈ (divisors m).powerset (via Finset.mem_powerset) is DECIDABLE, so IsPractical m reduces to a finite decidable check and small cases follow by `decide`.",
       "KERNEL `decide` (not native_decide) on the powerset check stays 0-axiom (propext/Classical.choice/Quot.sound only, no Lean.ofReduceBool) — verified via #print axioms; computing Nat.divisors m for small m is cheap enough for the kernel.",
       "Representability building blocks: 0 by ∅, d by {d} (Finset.sum_singleton), 1 by Nat.one_mem_divisors.mpr (m≠0), m by Nat.mem_divisors_self.",
       "The open content (h(m) < (log log m)^O(1) infinitely often; h(n!) bounds) is analytic and far from these elementary facts.",
-      "The representable range of m is exactly [0, σ(m)]: 0 is representable (empty set), σ(m) is the max (representable_le_sigma), and disjoint divisor subsets add (representable_union). This is the elementary closure structure underlying every practical-number argument."
+      "The representable range of m is exactly [0, σ(m)]: 0 is representable (empty set), σ(m) is the max (representable_le_sigma), and disjoint divisor subsets add (representable_union). This is the elementary closure structure underlying every practical-number argument.",
+      "Complement symmetry (researcher-4, 2026-07-08): the representable set of m is symmetric under k↦σ(m)−k. sigma_representable: σ(m) itself is representable (all divisors). representable_compl: if S⊆divisors m sums to k, the unused divisors divisors m\\S sum to σ(m)−k (Finset.sum_sdiff + omega), so σ(m)−k is representable. practical_top_segment: reflecting practical_represents_le ([0,m] representable) through this symmetry gives the TOP block [σ(m)−m, σ(m)] representable — a practical number represents both width-m ends of [0,σ(m)]. All elementary, 0 axioms."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -209,8 +211,8 @@
     {
       "path": "Proofs/Erdos18OQ01.lean",
       "filename": "Erdos18OQ01.lean",
-      "lineCount": 265,
-      "theoremCount": 20,
+      "lineCount": 306,
+      "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds the **complement symmetry** of the practical-number representability algebra: the set of values representable as sums of distinct divisors of `m` is symmetric under `k ↦ σ(m) − k`.

## New theorems (3, all 0-axiom)
- `sigma_representable` — `σ(m) = (divisors m).sum id` is itself representable (by the set of *all* divisors), matching the upper bound `representable_le_sigma`.
- `representable_compl` — if `k` is a sum of distinct divisors of `m`, so is `σ(m) − k`: the divisors left *unused* by a subset summing to `k` sum to `σ(m) − k` (`Finset.sum_sdiff` + `omega`). Hence the representable set is invariant under `k ↦ σ(m) − k`.
- `practical_top_segment` — reflecting the existing `practical_represents_le` (a practical number represents the bottom block `[0, m]`) through the complement symmetry yields the mirror-image **top block** `[σ(m) − m, σ(m)]`. So a practical number represents both width-`m` ends of `[0, σ(m)]`.

These are structural companions to the file's existing additive lemma `representable_union`, deepening the representability-algebra layer that supports the open asymptotic questions about `h(m)`.

## Verification
- Docker build succeeded (7744 jobs) against Mathlib v4.26.
- `#print axioms` for all three: `[propext, Classical.choice, Quot.sound]` — **0 axioms, 0 sorries, no native_decide**.
- File: 23 theorems (was 20), 306 lines (was 265).

🤖 Generated with [Claude Code](https://claude.com/claude-code)