### PR TITLE
Enrich Conjugacy Class Equation index form (conjugacy-class-equation-oq-01-oq-01): close section gap

### DIFF
--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/meta.json
@@ -94,10 +94,10 @@
   "sections": [
     {
       "id": "header",
-      "title": "Module Header and Setup",
+      "title": "Module Header, Setup, and the Per-Class Index Identity",
       "startLine": 1,
-      "endLine": 38,
-      "summary": "Module docstring explaining the assembly of the index form from Mathlib's cardinality-form class equation and the parent's per-class identity. Mathlib import, open MulAction Subgroup ConjAct, namespace, variable {G : Type*} [Group G], and the re-derived per-class bridge conjClass_card_eq_index_centralizer.",
+      "endLine": 46,
+      "summary": "Module docstring explaining the assembly of the index form from Mathlib's cardinality-form class equation and the parent's per-class identity. Mathlib import, open MulAction Subgroup ConjAct, namespace, variable {G : Type*} [Group G], and the re-derived per-class bridge conjClass_card_eq_index_centralizer (lines 40-46): |class(g)| = [G : C_G(g)], proved by rewriting the class carrier as the ConjAct orbit and identifying the stabilizer with the centralizer (MulAction.index_stabilizer).",
       "mathContext": "$|G| = |Z(G)| + \\sum_i [G : C_G(g_i)]$."
     },
     {


### PR DESCRIPTION
Enrichment pass for `conjugacy-class-equation-oq-01-oq-01` (quality 94, passes 0).

Already rich — 5 mainTheorems with verified anchors, 5 annotations, 4 keyInsights, complete conclusion with 2 cross-references. The one defect: a **section coverage gap**. The header section ended at line 38, but its own summary claimed it covered `conjClass_card_eq_index_centralizer` — which actually lives at lines 40–46, in the gap before the next section (line 48).

## Change (factual, non-inflating)
- Extended the header section `endLine` 38 → 46 so it genuinely covers the per-class index identity it already described, and expanded the summary to state the theorem's line span and proof (orbit/stabilizer = centralizer via `MulAction.index_stabilizer`).

Sections now span the theorem with no gap. No prose inflated; meta.json ~17 KB, well under the 60 KB cap.