### PR TITLE
research(roth-theorem-oq-01): Bourgain saving is o(Roth 1953 saving) — axiom-free rate comparison [VERIFIED]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ01.lean
@@ -307,6 +307,80 @@ theorem rothNumberNat_isLittleO_of_bourgain :
           (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2)) * (N : ℝ) := by ring
     _ ≤ ε * (N : ℝ) := mul_le_mul_of_nonneg_right hbound.le (Nat.cast_nonneg N)
 
+/-- **Endpoint positivity.** For `N ≥ 3`, `log N > 1` (since `N ≥ 3 > e`). A small
+reusable helper extracted from the endpoint reasoning in `rothNumberNat_bourgain`. -/
+theorem one_lt_logN_of_three_le {N : ℕ} (hN : 3 ≤ N) : (1 : ℝ) < Real.log N := by
+  have h3R : (0 : ℝ) < 3 := by norm_num
+  have hNR : (3 : ℝ) ≤ (N : ℝ) := by exact_mod_cast hN
+  have h_e_lt_3 : Real.exp 1 < 3 :=
+    Real.exp_one_lt_d9.trans (by norm_num : (2.7182818286 : ℝ) < 3)
+  have h_one_lt_log3 : (1 : ℝ) < Real.log 3 := by
+    have h := (Real.log_lt_log_iff (Real.exp_pos 1) h3R).mpr h_e_lt_3
+    rwa [Real.log_exp] at h
+  exact lt_of_lt_of_le h_one_lt_log3 (Real.log_le_log h3R hNR)
+
+/-- **Double-log positivity.** For `N ≥ 3`, `log (log N) > 0`, since `log N > 1`. -/
+theorem loglog_pos_of_three_le {N : ℕ} (hN : 3 ≤ N) :
+    0 < Real.log (Real.log N) :=
+  Real.log_pos (one_lt_logN_of_three_le hN)
+
+/-- **Polylog decay engine (axiom-free).** `(log log N)³ / log N → 0`.  This is the
+quantitative core distinguishing Bourgain's `(log log N / log N)^{1/2}` saving from
+Roth's original `1 / log log N` saving: setting `u = log N → ∞`, Mathlib's
+`Real.tendsto_pow_log_div_mul_add_atTop` gives `(log u)³ / u → 0`, and `log N → ∞`
+carries the limit through the composition.  Uses only Mathlib's log-growth API — no
+axioms, no dependence on the Bloom–Sisask assumption. -/
+theorem loglog_cubed_div_log_tendsto_zero :
+    Filter.Tendsto
+      (fun N : ℕ => Real.log (Real.log N) ^ 3 / Real.log N)
+      Filter.atTop (nhds 0) := by
+  -- `(log u)³ / u → 0` as `u → ∞`.
+  have hpoly : Filter.Tendsto (fun u : ℝ => Real.log u ^ 3 / u) Filter.atTop (nhds 0) := by
+    simpa using Real.tendsto_pow_log_div_mul_add_atTop 1 0 3 one_ne_zero
+  -- `log N → ∞` as `N → ∞` (over ℕ).
+  have hlogN : Filter.Tendsto (fun N : ℕ => Real.log N) Filter.atTop Filter.atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  -- compose: `(log (log N))³ / log N → 0`.
+  simpa [Function.comp] using hpoly.comp hlogN
+
+/-- **Bourgain's saving is asymptotically strictly stronger than Roth's 1953 saving.**
+
+The Bourgain 1999 density factor `(log log N / log N)^{1/2}` is `o` of Roth's original
+1953 density factor `1 / log log N`:
+
+  `(fun N => (log log N / log N)^{1/2}) =o[atTop] (fun N => 1 / log log N)`.
+
+This formalizes the qualitative point emphasized throughout this file and its
+references — that Bourgain's improvement is a *power-of-log* saving, genuinely
+better than Roth's mere `log log` saving, not a rephrasing of it.  The ratio
+squares to `(log log N)³ / log N → 0` (`loglog_cubed_div_log_tendsto_zero`), so the
+ratio itself is `√((log log N)³ / log N) → 0`.  **Axiom-free** — this is a pure
+statement about the two rate *shapes* and does not touch the Bloom–Sisask
+assumption. -/
+theorem bourgain_factor_isLittleO_roth_factor :
+    Asymptotics.IsLittleO Filter.atTop
+      (fun N : ℕ => (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2))
+      (fun N : ℕ => 1 / Real.log (Real.log N)) := by
+  refine (Asymptotics.isLittleO_iff_tendsto' ?_).mpr ?_
+  · -- `g N = 0 → f N = 0` holds vacuously for `N ≥ 3` (there `1 / log log N ≠ 0`).
+    filter_upwards [Filter.eventually_ge_atTop 3] with N hN h0
+    exact absurd h0 (one_div_ne_zero (ne_of_gt (loglog_pos_of_three_le hN)))
+  · -- the ratio `f N / g N = √((log log N)³ / log N) → 0`.
+    have hratio : Filter.Tendsto
+        (fun N : ℕ => Real.sqrt (Real.log (Real.log N) ^ 3 / Real.log N))
+        Filter.atTop (nhds 0) := by
+      have := (Real.continuous_sqrt.tendsto 0).comp loglog_cubed_div_log_tendsto_zero
+      simpa [Real.sqrt_zero] using this
+    refine hratio.congr' ?_
+    filter_upwards [Filter.eventually_ge_atTop 3] with N hN
+    have hLL : 0 < Real.log (Real.log N) := loglog_pos_of_three_le hN
+    have hL : 0 < Real.log N := lt_trans one_pos (one_lt_logN_of_three_le hN)
+    -- `(log log N)³ / log N = (log log N / log N) · (log log N)²` (field identity).
+    have e1 : Real.log (Real.log N) ^ 3 / Real.log N
+        = Real.log (Real.log N) / Real.log N * Real.log (Real.log N) ^ 2 := by ring
+    rw [e1, Real.sqrt_mul (div_pos hLL hL).le, Real.sqrt_sq hLL.le,
+        div_div_eq_mul_div, div_one, ← Real.sqrt_eq_rpow]
+
 #check rothNumberNat_bourgain
 #check bourgainConst
 #check bourgainConst_pos
@@ -316,10 +390,19 @@ theorem rothNumberNat_isLittleO_of_bourgain :
 #check rothNumberNat_le_min_bourgain_blasi
 #check bourgain_factor_tendsto_zero
 #check rothNumberNat_isLittleO_of_bourgain
+#check one_lt_logN_of_three_le
+#check loglog_pos_of_three_le
+#check loglog_cubed_div_log_tendsto_zero
+#check bourgain_factor_isLittleO_roth_factor
 
 -- Axiom audit: `rothNumberNat_bourgain` is now a THEOREM.  Its only non-foundational
 -- dependency is the imported `RothTheoremOQ02.rothNumberNat_bloom_sisask` — there is NO
 -- separate Bourgain axiom, and no `sorryAx` / `Lean.ofReduceBool`.
 #print axioms rothNumberNat_bourgain
+
+-- The rate-shape comparison and its polylog engine are fully AXIOM-FREE (they depend on
+-- neither the Bourgain nor the Bloom–Sisask assumption — only Mathlib's log-growth API).
+#print axioms loglog_cubed_div_log_tendsto_zero
+#print axioms bourgain_factor_isLittleO_roth_factor
 
 end RothTheoremOQ01

--- a/src/data/proofs/roth-theorem-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "assumptions": "This entry bundles two files and ships two axioms total. Main file Proofs/RothTheoremOQ01.lean declares 0 axioms of its own and 0 sorries; every one of its 9 theorems is machine-checked (including the axiom-free `bourgain_factor_tendsto_zero`). Its presented result `rothNumberNat_bourgain` rests on exactly one assumption: `RothTheoremOQ02.rothNumberNat_bloom_sisask` (Bloom–Sisask 2020 logarithmic-barrier bound rothNumberNat N ≤ N/(log N)^(1+c), arXiv:2007.03528), imported from the companion file Proofs/RothTheoremOQ02.lean and used to derive the weaker Bourgain bound by rpow monotonicity. The companion file additionally declares a second axiom `rothNumberNat_kelley_meka` (Kelley–Meka 2023, quasi-polynomial bound); it is NOT in the dependency chain of the main Bourgain result, but it IS used by the companion's own theorems `rothNumberNat_le_kelley_meka`, `kelley_meka_consistent_with_Behrend`, and `rothNumberNat_le_min_blasi_kelley_meka`, so it counts as an assumption the entry carries. Both axioms encode state-of-the-art quantitative refinements requiring Bohr-set / density-increment infrastructure not yet in Mathlib v4.26.0. The former standalone `axiom rothNumberNat_bourgain` has been eliminated: Bourgain is now a derived theorem.",
+    "assumptions": "This entry bundles two files and ships two axioms total. Main file Proofs/RothTheoremOQ01.lean declares 0 axioms of its own and 0 sorries; every one of its 13 theorems is machine-checked (including the axiom-free `bourgain_factor_tendsto_zero` and the new rate-shape comparison `bourgain_factor_isLittleO_roth_factor`). Its presented result `rothNumberNat_bourgain` rests on exactly one assumption: `RothTheoremOQ02.rothNumberNat_bloom_sisask` (Bloom–Sisask 2020 logarithmic-barrier bound rothNumberNat N ≤ N/(log N)^(1+c), arXiv:2007.03528), imported from the companion file Proofs/RothTheoremOQ02.lean and used to derive the weaker Bourgain bound by rpow monotonicity. The companion file additionally declares a second axiom `rothNumberNat_kelley_meka` (Kelley–Meka 2023, quasi-polynomial bound); it is NOT in the dependency chain of the main Bourgain result, but it IS used by the companion's own theorems `rothNumberNat_le_kelley_meka`, `kelley_meka_consistent_with_Behrend`, and `rothNumberNat_le_min_blasi_kelley_meka`, so it counts as an assumption the entry carries. Both axioms encode state-of-the-art quantitative refinements requiring Bohr-set / density-increment infrastructure not yet in Mathlib v4.26.0. The former standalone `axiom rothNumberNat_bourgain` has been eliminated: Bourgain is now a derived theorem.",
     "originalContributions": [
       "rothNumberNat_bourgain: Bourgain's 1999 bound ∃ C > 0, ∀ N ≥ 3, rothNumberNat N ≤ C·N·(log log N/log N)^(1/2), derived (not axiomatized) from the imported Bloom–Sisask bound",
       "Explicit analytic reduction Bloom–Sisask ⟹ Bourgain: cancel N, split L^(1+c) = L^(1/2)·L^(1/2+c) via Real.rpow_add and (LL/L)^(1/2) = LL^(1/2)/L^(1/2) via Real.div_rpow, then close by base-monotonicity (Real.rpow_le_rpow) reading the constant C = 1/(B·E) off the N = 3 endpoint",
@@ -29,11 +29,14 @@
       "bourgain_consistent_with_Behrend: the Bourgain upper bound dominates Behrend's unconditional lower bound N·exp(-4√(log N)), verified transitively",
       "rothNumberNat_le_min_bourgain_blasi: the formal record that OQ-02 ⟹ OQ-01 — rothNumberNat N is bounded by the min of the Bourgain and Bloom–Sisask right-hand sides",
       "bourgain_factor_tendsto_zero: the density factor (log log N/log N)^(1/2) → 0 as N → ∞ — axiom-free, from Real.isLittleO_log_id_atTop (log u/u → 0 at u = log N → ∞) and continuity of √· = ·^(1/2)",
-      "rothNumberNat_isLittleO_of_bourgain: rothNumberNat N = o(N) DERIVED from the explicit Bourgain bound (not re-exported from Mathlib) — certifies the quantitative rate is genuinely strong enough to recover the qualitative Roth theorem"
+      "rothNumberNat_isLittleO_of_bourgain: rothNumberNat N = o(N) DERIVED from the explicit Bourgain bound (not re-exported from Mathlib) — certifies the quantitative rate is genuinely strong enough to recover the qualitative Roth theorem",
+      "bourgain_factor_isLittleO_roth_factor: Bourgain's 1999 density saving (log log N/log N)^(1/2) is o() of Roth's 1953 saving 1/log log N — a formal proof that Bourgain's improvement is a genuine power-of-log gain over Roth, not a rephrasing. Axiom-free (depends on neither the Bourgain nor Bloom–Sisask assumption).",
+      "loglog_cubed_div_log_tendsto_zero: axiom-free polylog decay engine (log log N)^3/log N → 0, the quantitative core behind the Bourgain-vs-Roth rate comparison, via Real.tendsto_pow_log_div_mul_add_atTop composed with log N → ∞",
+      "one_lt_logN_of_three_le / loglog_pos_of_three_le: reusable endpoint-positivity helpers (log N > 1 and log log N > 0 for N ≥ 3) extracted from the endpoint reasoning"
     ],
     "dateAdded": "2026-07-02",
-    "lineCount": 325,
-    "theoremCount": 9,
+    "lineCount": 408,
+    "theoremCount": 13,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/RothTheoremOQ02.lean"
@@ -75,9 +78,9 @@
       "Proofs.RothTheoremOQ02"
     ],
     "namespace": "RothTheoremOQ01",
-    "lineCount": 325,
+    "lineCount": 408,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 13,
     "definitionCount": 1,
     "path": "Proofs/RothTheoremOQ01.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds **4 machine-checked, axiom-free theorems** to \`RothTheoremOQ01.lean\` (main file 9 → 13 theorems), formalizing the qualitative point emphasized throughout the entry's "quantitative landscape" table: **Bourgain's 1999 saving is genuinely stronger than Roth's 1953 saving**, not a rephrasing of it.

### New theorems
- **\`bourgain_factor_isLittleO_roth_factor\`** — the marquee result: the Bourgain density factor \`(log log N / log N)^(1/2)\` is \`o[atTop]\` of Roth's 1953 factor \`1 / log log N\`. The ratio squares to \`(log log N)³ / log N → 0\`, so the ratio itself is \`√(...) → 0\`.
- **\`loglog_cubed_div_log_tendsto_zero\`** — axiom-free polylog decay engine \`(log log N)³ / log N → 0\`, via \`Real.tendsto_pow_log_div_mul_add_atTop\` composed with \`log N → ∞\`. This is the quantitative core distinguishing Bourgain's power-of-log saving from Roth's mere \`log log\` saving.
- **\`one_lt_logN_of_three_le\`**, **\`loglog_pos_of_three_le\`** — reusable endpoint-positivity helpers (\`log N > 1\`, \`log log N > 0\` for \`N ≥ 3\`).

### Axiom status
\`#print axioms\` confirms both new marquee theorems depend **only** on the foundational trio (\`propext\`, \`Classical.choice\`, \`Quot.sound\`) — no \`sorryAx\`, no \`Lean.ofReduceBool\`, and **independent of both the Bourgain and Bloom–Sisask assumptions**. The entry's total axiom count is **unchanged at 2** (these results add no assumptions).

### Verification
- Build: `./proofs/scripts/docker-build.sh Proofs.RothTheoremOQ01` → **2506 jobs, exit 0**.
- Meta synced: \`lineCount\` 325 → 408, \`theoremCount\` 9 → 13 (both \`meta\` and \`leanFile\`); assumptions prose and originalContributions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)