### PR TITLE
audit: reconcile stale meta counts + disclose native_decide (8 entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1925,10 +1925,13 @@
       "issues": []
     },
     "ballot-problem-oq-01-oq-02": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-05-08T17:41:24Z",
-      "result": "clean"
+      "auditCount": 4,
+      "issues": [
+        "Stale lineCount 1047->1079 reconciled to Lean source"
+      ],
+      "lastAudited": "2026-07-08T19:38:03Z",
+      "result": "issues-fixed",
+      "agentId": "lean-auditor-reaudit"
     },
     "ballot-problem-oq-01-oq-02-oq-01": {
       "auditCount": 3,
@@ -8410,10 +8413,13 @@
       "issues": []
     },
     "erdos-1000": {
-      "auditCount": 4,
-      "issues": [],
-      "lastAudited": "2026-05-04T04:02:32Z",
-      "result": "clean"
+      "auditCount": 5,
+      "issues": [
+        "Stale lineCount 1149->1153 reconciled to Lean source"
+      ],
+      "lastAudited": "2026-07-08T19:38:03Z",
+      "result": "issues-fixed",
+      "agentId": "lean-auditor-reaudit"
     },
     "erdos-1000-oq-03": {
       "auditCount": 1,
@@ -9020,13 +9026,13 @@
       "result": "clean"
     },
     "erdos-1022-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
-        "Stale theoremCount/lineCount reconciled to Lean source (re-audit)"
+        "Stale lineCount 286->351 and theoremCount 11->14 reconciled to Lean source (re-audit)"
       ],
-      "lastAudited": "2026-07-08T19:12:11Z",
-      "result": "clean",
-      "agentId": "auditor-reaudit-20260708"
+      "lastAudited": "2026-07-08T19:38:03Z",
+      "result": "issues-fixed",
+      "agentId": "lean-auditor-reaudit"
     },
     "erdos-1022-oq-04": {
       "auditCount": 1,
@@ -12387,10 +12393,13 @@
       "result": "clean"
     },
     "erdos-299": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:33Z",
-      "result": "clean"
+      "agentId": "lean-auditor-reaudit",
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T19:38:03Z",
+      "result": "issues-fixed",
+      "issues": [
+        "native_decide on named theorems egyptian_236/egyptian_2_4_6_12 undisclosed; meta.axiomCount 1->2, Lean.ofReduceBool disclosed (leanFile.axiomCount stays literal 1)"
+      ]
     },
     "erdos-3": {
       "agentId": "auditor-agent-7",
@@ -15738,10 +15747,13 @@
       "result": "clean"
     },
     "erdos-700": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:40Z",
-      "result": "clean"
+      "agentId": "lean-auditor-reaudit",
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T19:38:03Z",
+      "result": "issues-fixed",
+      "issues": [
+        "native_decide on named theorem f_30 undisclosed; meta.axiomCount 2->3, Lean.ofReduceBool disclosed in assumptions (leanFile.axiomCount stays literal 2)"
+      ]
     },
     "erdos-701": {
       "agentId": "auditor-cycle-20-batch",
@@ -24491,18 +24503,22 @@
       "result": "issues-fixed"
     },
     "roth-theorem": {
-      "auditCount": 3,
-      "lastAudited": "2026-07-08T18:54:18Z",
-      "result": "clean",
-      "issues": [],
-      "agentId": "auditor-agent-7"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T19:38:03Z",
+      "result": "issues-fixed",
+      "issues": [
+        "Stale lineCount 1401->1554 reconciled to Lean source"
+      ],
+      "agentId": "lean-auditor-reaudit"
     },
     "roth-theorem-k3": {
-      "auditCount": 6,
-      "issues": [],
-      "lastAudited": "2026-07-08T18:54:18Z",
-      "result": "clean",
-      "agentId": "auditor-agent-7"
+      "auditCount": 7,
+      "issues": [
+        "Stale meta.lineCount 1401->1554 reconciled (leanFile already correct)"
+      ],
+      "lastAudited": "2026-07-08T19:38:03Z",
+      "result": "issues-fixed",
+      "agentId": "lean-auditor-reaudit"
     },
     "roth-theorem-k3-oq-01": {
       "auditCount": 5,
@@ -29633,12 +29649,14 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-03": {
-      "lastAudited": "2026-07-08T19:12:11Z",
-      "auditCount": 2,
-      "result": "clean",
-      "agentId": "auditor-reaudit-20260708",
+      "lastAudited": "2026-07-08T19:38:03Z",
+      "auditCount": 3,
+      "result": "issues-fixed",
+      "agentId": "lean-auditor-reaudit",
       "notes": "Audit CLEAN (first audit): 0 sorries/0 axioms/0 native_decide. Uses kernel `decide` (lines 219,224) NOT native_decide for B 1=95 numeric check; assumptions field correctly states ofReduceBool-free. Genuine Euclid-construction + iterated-factorial tower bound p3(k)<=B(k). verified/original accurate.",
-      "issues": []
+      "issues": [
+        "Stale meta.lineCount 230->292 and meta.theoremCount 21->26 reconciled (leanFile already correct)"
+      ]
     }
   },
   "version": 1,

--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "0 axioms in the parent file BallotProblemOQ01OQ02.lean (all axioms eliminated: fiber_card_uniform proved via fiberSwap bijection, uniformOn_fiber_transfer proved via cross-multiplication bijection showing |(MCS ∩ MSP)| · |CS| = |(CS ∩ SP)| · |MCS|). 2 axioms in the registered companion BallotProblemOQ01OQ02OQ02.lean (LGV path-ordering extension): three_candidate_ordering_formula and three_ordering_product_conjecture, both stating the 3-candidate ordering probability as the product of pairwise ballot ratios via the Lindström-Gessel-Viennot lemma (non-intersecting lattice path theory not in Mathlib). Chain axiom total: 2.",
-    "lineCount": 1047,
+    "lineCount": 1079,
     "theoremCount": 40,
     "definitionCount": 19,
     "additionalFiles": [
@@ -104,7 +104,7 @@
   },
   "leanFile": {
     "namespace": "MultiBallot",
-    "lineCount": 1047,
+    "lineCount": 1079,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 19,

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -61,10 +61,10 @@
     ],
     "dateAdded": "2026-07-08",
     "axiomCount": 0,
-    "lineCount": 230,
+    "lineCount": 292,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, no structure-encoded assumptions. Uses kernel `decide` (not `native_decide`) for the numeric check B 1 = 95, so it is `ofReduceBool`-free.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 21,
+    "theoremCount": 26,
     "definitionCount": 3
   },
   "overview": {

--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1000",
     "erdosProblemStatus": "solved",
     "axiomCount": 3,
-    "lineCount": 1149,
+    "lineCount": 1153,
     "assumptions": "Two deep mathematical axioms: erdos_dichotomy (liminf=0 implies limsup=1, via Euler product for φ(n)/n), haight_resolution (vanishing Cesàro average exists, via highly composite construction). Plus `Lean.ofReduceBool`: the theorems `naturalSeq_phiA_eq_totient` (k=0 base case) and the supporting lemma `card_Icc_filter_reducedDenom_eq` are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction (#print axioms lists `Lean.ofReduceBool`). erdos_no_zero_limit is now PROVED from erdos_dichotomy (convergence to 0 contradicts dichotomy via frequently-vs-eventually). cassels_liminf_zero is PROVED from haight_resolution. Infrastructure: complement formula, growth bounds, multiplicity bounds, double-counting vocabulary, growth constraints from low density, deficit counting bounds.",
     "mathlib_version": "4.26.0",
     "theoremCount": 61,
@@ -272,7 +272,7 @@
       "Topology"
     ],
     "namespace": "Erdos1000",
-    "lineCount": 1149,
+    "lineCount": 1153,
     "axiomCount": 2,
     "theoremCount": 61,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 286,
+    "lineCount": 351,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 3
   },
   "overview": {
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 286,
+    "lineCount": 351,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 14,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -53,9 +53,9 @@
       "Verified Egyptian fraction examples: {2,3,6} and {2,4,6,12}",
       "Proof that powers of 2 have unbounded gaps"
     ],
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 386,
-    "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries.",
+    "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries. Plus `Lean.ofReduceBool`: the theorems `egyptian_236` and `egyptian_2_4_6_12` (concrete unit-fraction identities) are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction (#print axioms lists `Lean.ofReduceBool`). Axiom total including ofReduceBool: 2.",
     "theoremCount": 10,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -19,11 +19,11 @@
     "sourceUrl": "https://erdosproblems.com/700",
     "erdosUrl": "https://erdosproblems.com/700",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 427,
     "theoremCount": 14,
     "definitionCount": 3,
-    "assumptions": "2 axioms: (1) erdos_700_question2 — there are infinitely many composite n with f(n) > √n (open; n=30 is a known example); (2) erdos_700_question3 — f(n) ≪_A n/(log n)^A for every A > 0 (open; connects to Hardy-Ramanujan). 14 theorems proved: bounds, f(pq)=p, f(30)=6, f(p²)≥p. 0 sorries.",
+    "assumptions": "2 axioms: (1) erdos_700_question2 — there are infinitely many composite n with f(n) > √n (open; n=30 is a known example); (2) erdos_700_question3 — f(n) ≪_A n/(log n)^A for every A > 0 (open; connects to Hardy-Ramanujan). 14 theorems proved: bounds, f(pq)=p, f(30)=6, f(p²)≥p. 0 sorries. Plus `Lean.ofReduceBool`: the theorem `f_30` (f(30)=6) is discharged by `native_decide` (interval_cases over 2≤k≤15 plus the k=5 witness), which trusts the Lean compiler's kernel reduction (#print axioms lists `Lean.ofReduceBool`). Axiom total including ofReduceBool: 3.",
     "mathlib_version": "4.26.0"
   },
   "sections": [

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -58,7 +58,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 1401,
+    "lineCount": 1554,
     "assumptions": "No axioms, no sorries. Fully verified. Main theorem roth_density_bound proved via Mathlib's corners-theorem chain (Regularity Lemma → Triangle Removal → Corners → Roth). Fourier-analytic density increment infrastructure (Parts I-V) independently verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 42,

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -34,7 +34,7 @@
       "roth_density_bound: main theorem via Mathlib roth_3ap_theorem_nat"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 1401,
+    "lineCount": 1554,
     "theoremCount": 42,
     "definitionCount": 6,
     "additionalFiles": [
@@ -89,7 +89,7 @@
       "Mathlib"
     ],
     "namespace": "Szemeredi.Roth",
-    "lineCount": 1401,
+    "lineCount": 1554,
     "axiomCount": 0,
     "theoremCount": 42,
     "definitionCount": 6,


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Swept gallery entries whose Lean source was committed **after** their `lastAudited` timestamp (timezone-correct comparison — a prior scan missed these due to `-04:00` vs `Z` offset). Found and fixed 8 entries.

### Stale numeric fields
`lineCount` follows the `wc -l` convention; `theoremCount` verified against source (incl. `private`/`@[attr]`-prefixed decls).

| Slug | Fix |
|------|-----|
| erdos-1022-oq-02 | lineCount 286→351, theoremCount 11→14 (leanFile + meta) |
| dirichlets-theorem-oq-02-oq-03 | meta.lineCount 230→292, meta.theoremCount 21→26 |
| erdos-1000 | lineCount 1149→1153 |
| roth-theorem | lineCount 1401→1554 |
| roth-theorem-k3 | meta.lineCount 1401→1554 |
| ballot-problem-oq-01-oq-02 | lineCount 1047→1079 |

### Undisclosed `native_decide` (axiom-integrity policy)
`native_decide` on a named main-file theorem depends on `Lean.ofReduceBool`; per policy `meta.axiomCount` must count it and `assumptions` must disclose it (`leanFile.axiomCount` stays literal). Sibling **erdos-1000** already follows this standard — these two were inconsistent:

- **erdos-700**: `f_30` (f(30)=6, an advertised proved theorem) discharged by `native_decide` → `meta.axiomCount` 2→3 + `ofReduceBool` disclosure.
- **erdos-299**: `egyptian_236` / `egyptian_2_4_6_12` discharged by `native_decide` → `meta.axiomCount` 1→2 + `ofReduceBool` disclosure.

No status/badge overclaims found; both native_decide entries were already `axiomatized`/`axiom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)