### PR TITLE
research(erdos-101-oq-04): height-certificate reduction for NoFiveCollinear [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -206,6 +206,144 @@ theorem isLowerBoundConstruction_threshold_eq_zero_of_small
   rw [fourPointLineCount_lt_four P h]
   norm_num
 
+/- ## Frontier reduction: NoFiveCollinear from a 3-point height certificate
+
+The genuine open content of `grunbaum_lower_bound_three_halves` and
+`solymosi_stojakovic_lower_bound` is producing a *growing* family of
+four-point lines that is simultaneously **no five collinear**.  The
+counting side is already discharged by
+`fourPointLineCount_ge_of_injOn_family`; what remains is the five-point
+`NoFiveCollinear` predicate, whose quantifier over five distinct points is
+awkward to establish directly for a parametric construction (the crux
+flagged in `state.md`: "a general-n growing witness still needs a clean
+no-five-collinear proof, ruling out accidental cross-gadget alignments for
+all n").
+
+The lemma below collapses that five-point obligation into two much simpler
+hypotheses, tailored to *row-structured* constructions (a union of
+horizontal four-point segments — the shape of `crossSet`, `asteriskSet`,
+`gridSet`, and every growing witness the frontier needs):
+
+* `H1` — **height fibres are small**: every horizontal line `y = c`
+  contains at most four points of `P`.  For a row construction this is
+  immediate (one row per height, four points per row).
+* `H2` — **no three points with pairwise-distinct heights are
+  collinear**: the *only* nontrivial arithmetic obligation, and precisely
+  the "no accidental cross-row alignment" certificate.
+
+Given `H1` and `H2`, `P` is automatically no-five-collinear.  So a future
+construction PR need only supply `H2` (plus the trivial `H1`) and the
+four-point lines — never the full five-point case analysis. -/
+
+/-- **NoFiveCollinear from a 3-point height certificate.**  If every
+horizontal line meets `P` in at most four points (`H1`) and no three
+points of `P` with pairwise-distinct second coordinates are collinear
+(`H2`), then `P` has no five collinear points.
+
+This reduces the five-point `NoFiveCollinear` predicate to a three-point
+condition, isolating the genuine open arithmetic (`H2`) from the
+five-point plumbing for any row-structured lower-bound witness. -/
+theorem noFiveCollinear_of_height_certificate (P : PlanarPointSet)
+    (H1 : ∀ c : ℝ, (P.points.filter (fun p => p.2 = c)).card ≤ 4)
+    (H2 : ∀ a b d : ℝ × ℝ, a ∈ P.points → b ∈ P.points → d ∈ P.points →
+      a.2 ≠ b.2 → a.2 ≠ d.2 → b.2 ≠ d.2 → ¬ collinear a b d) :
+    NoFiveCollinear P := by
+  intro a b c d e ha hb hc hd he hab hac had hae hbc hbd hbe hcd hce hde
+  rintro ⟨hcol_c, hcol_d, hcol_e⟩
+  by_cases hheight : a.2 = b.2
+  · -- Horizontal anchor: all five points share height `a.2`, but the
+    -- height fibre at `a.2` holds at most four points (`H1`) — contradiction.
+    have hx : b.1 - a.1 ≠ 0 := by
+      rw [sub_ne_zero]
+      intro h
+      exact hab (Prod.ext h.symm hheight)
+    have hb2 : b.2 - a.2 = 0 := sub_eq_zero.mpr hheight.symm
+    -- Every point collinear with `a, b` inherits height `a.2`.
+    have hforce : ∀ p : ℝ × ℝ, collinear a b p → p.2 = a.2 := by
+      intro p hp
+      unfold collinear at hp
+      rw [hb2, mul_zero] at hp
+      rcases mul_eq_zero.mp hp with h | h
+      · exact absurd h hx
+      · linarith
+    -- The five distinct points sit in the height-`a.2` fibre.
+    have hne_a : a ∉ ({b, c, d, e} : Finset (ℝ × ℝ)) := by
+      simp only [Finset.mem_insert, Finset.mem_singleton]; push_neg
+      exact ⟨hab, hac, had, hae⟩
+    have hne_b : b ∉ ({c, d, e} : Finset (ℝ × ℝ)) := by
+      simp only [Finset.mem_insert, Finset.mem_singleton]; push_neg
+      exact ⟨hbc, hbd, hbe⟩
+    have hne_c : c ∉ ({d, e} : Finset (ℝ × ℝ)) := by
+      simp only [Finset.mem_insert, Finset.mem_singleton]; push_neg
+      exact ⟨hcd, hce⟩
+    have hne_d : d ∉ ({e} : Finset (ℝ × ℝ)) := by
+      simp only [Finset.mem_singleton]; exact hde
+    have hcard : ({a, b, c, d, e} : Finset (ℝ × ℝ)).card = 5 := by
+      rw [Finset.card_insert_of_not_mem hne_a, Finset.card_insert_of_not_mem hne_b,
+        Finset.card_insert_of_not_mem hne_c, Finset.card_insert_of_not_mem hne_d,
+        Finset.card_singleton]
+    have hsub : ({a, b, c, d, e} : Finset (ℝ × ℝ)) ⊆
+        P.points.filter (fun p => p.2 = a.2) := by
+      intro p hp
+      rw [Finset.mem_filter]
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+      rcases hp with rfl | rfl | rfl | rfl | rfl
+      · exact ⟨ha, rfl⟩
+      · exact ⟨hb, hheight.symm⟩
+      · exact ⟨hc, hforce c hcol_c⟩
+      · exact ⟨hd, hforce d hcol_d⟩
+      · exact ⟨he, hforce e hcol_e⟩
+    have hle := Finset.card_le_card hsub
+    rw [hcard] at hle
+    exact absurd (le_trans hle (H1 a.2)) (by norm_num)
+  · -- Non-horizontal anchor: `a, b, c` then have pairwise-distinct heights,
+    -- so `H2` refutes `collinear a b c` directly.
+    have hab2 : a.2 ≠ b.2 := hheight
+    have hbne : b.2 - a.2 ≠ 0 := sub_ne_zero.mpr (Ne.symm hab2)
+    have hca2 : c.2 ≠ a.2 := by
+      intro h
+      unfold collinear at hcol_c
+      rw [h, sub_self, mul_zero] at hcol_c
+      have hc1 : c.1 - a.1 = 0 := by
+        rcases mul_eq_zero.mp hcol_c.symm with h1 | h1
+        · exact h1
+        · exact absurd h1 hbne
+      exact hac (Prod.ext (by linarith) h).symm
+    have hcb2 : c.2 ≠ b.2 := by
+      intro h
+      unfold collinear at hcol_c
+      rw [h] at hcol_c
+      have hcancel : b.1 - a.1 = c.1 - a.1 := mul_right_cancel₀ hbne hcol_c
+      exact hbc (Prod.ext (by linarith) h.symm)
+    exact H2 a b c ha hb hc hab2 (Ne.symm hca2) (Ne.symm hcb2) hcol_c
+
+/-- **Row-family lower-bound construction (frontier template).**  Combine
+the counting engine (`fourPointLineCount_ge_of_injOn_family`) with the
+height reduction (`noFiveCollinear_of_height_certificate`): an injective
+family of `k` four-point collinear subsets of `P`, together with the
+height certificate (`H1`, `H2`), makes `P` an
+`IsLowerBoundConstruction P k`.
+
+This is the exact interface a growing construction targets — supply the
+four-point lines and the 3-point height certificate `H2`, and both halves
+of `IsLowerBoundConstruction` (no-five-collinear *and* the count bound)
+follow.  It reduces `grunbaum_lower_bound_three_halves` /
+`solymosi_stojakovic_lower_bound` to producing, for each `n`, a family of
+size `≥ threshold(n)` satisfying `H2`. -/
+theorem isLowerBoundConstruction_of_rows (P : PlanarPointSet) (k : ℕ)
+    (L : Fin k → Finset (ℝ × ℝ))
+    (hmem : ∀ i, L i ⊆ P.points) (hcard : ∀ i, (L i).card = 4)
+    (hcol : ∀ i, ∃ a b : ℝ × ℝ, a ∈ L i ∧ b ∈ L i ∧ a ≠ b ∧
+      ∀ p ∈ L i, collinear a b p)
+    (hinj : Function.Injective L)
+    (H1 : ∀ c : ℝ, (P.points.filter (fun p => p.2 = c)).card ≤ 4)
+    (H2 : ∀ a b d : ℝ × ℝ, a ∈ P.points → b ∈ P.points → d ∈ P.points →
+      a.2 ≠ b.2 → a.2 ≠ d.2 → b.2 ≠ d.2 → ¬ collinear a b d) :
+    IsLowerBoundConstruction P (k : ℝ) := by
+  refine ⟨noFiveCollinear_of_height_certificate P H1 H2, ?_⟩
+  have hk := fourPointLineCount_ge_of_injOn_family P k L hmem hcard hcol hinj
+  exact_mod_cast hk
+
 /- ## Grünbaum's Ω(n^{3/2}) lower bound (recorded as deferred proof)
 
 The pre-Solymosi–Stojaković state of the art: Grünbaum (1972)

--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -287,7 +287,7 @@ theorem noFiveCollinear_of_height_certificate (P : PlanarPointSet)
       intro p hp
       rw [Finset.mem_filter]
       simp only [Finset.mem_insert, Finset.mem_singleton] at hp
-      rcases hp with rfl | rfl | rfl | rfl | rfl
+      rcases hp with h | h | h | h | h <;> rw [h]
       · exact ⟨ha, rfl⟩
       · exact ⟨hb, hheight.symm⟩
       · exact ⟨hc, hforce c hcol_c⟩

--- a/research/problems/erdos-101-oq-04/state.md
+++ b/research/problems/erdos-101-oq-04/state.md
@@ -2,54 +2,70 @@
 
 **Phase**: ACT
 **Since**: 2026-07-08T00:00:00Z
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
-Reusable counting infrastructure for lower-bound witnesses.
+Reducing the `NoFiveCollinear` obligation for growing constructions to a
+clean 3-point height certificate.
 
 ## Active Approach
 
-Path B (explicit constructions). This iteration factored out the counting
-engine shared by every witness (`crossSet`, `asteriskSet`, `gridSet`): the
-`subset-of-filter → Finset.card_le_card` argument that turns a family of
-certified four-point collinear quadruples into a lower bound on
-`fourPointLineCount`.
+Path B (explicit constructions). The frontier obstruction identified last
+iteration was: a general-n growing witness needs a clean "no five
+collinear" proof, but `NoFiveCollinear` quantifies over five distinct
+points, which is awkward to discharge for a parametric family. This
+iteration removes that obstruction.
 
 ## Progress This Iteration (VERIFIED, 0-axiom)
 
-Added two general lemmas to `Proofs/Erdos101OQ04.lean` (build-verified,
-3062 jobs, only the two pre-existing OPEN sorries remain):
+Added two general theorems to `Proofs/Erdos101OQ04.lean` (build-verified,
+3062 jobs; only the two pre-existing OPEN construction sorries remain):
 
-- `fourPointLineCount_ge_of_subset` — set form: any `Finset` `T` of
-  four-point collinear subsets of `P.points` gives `T.card ≤
-  fourPointLineCount P`.
-- `fourPointLineCount_ge_of_injOn_family` — indexed form: an injective
-  family `L : Fin k → Finset (ℝ×ℝ)` of four-point collinear subsets gives
-  `k ≤ fourPointLineCount P` (the natural shape a growing construction
-  produces — one line per index).
+- `noFiveCollinear_of_height_certificate` — **NoFiveCollinear from a
+  3-point height certificate.** If (H1) every horizontal line `y = c`
+  meets `P` in at most four points, and (H2) no three points of `P` with
+  pairwise-distinct second coordinates are collinear, then `P` is
+  no-five-collinear. Proof: a horizontal anchor forces all five points
+  into the height fibre at `a.2`, contradicting H1 (≤4); a non-horizontal
+  anchor gives `a, b, c` pairwise-distinct heights, so H2 refutes
+  `collinear a b c` directly.
 
-These separate the *easy* counting from the *hard* geometry that is the
-genuine open content, so future construction PRs supply only the collinear
-quadruples and their distinctness/injectivity.
+- `isLowerBoundConstruction_of_rows` — **frontier template.** Combines the
+  counting engine (`fourPointLineCount_ge_of_injOn_family`) with the
+  height reduction: an injective family of `k` four-point collinear
+  subsets of `P`, plus (H1, H2), yields `IsLowerBoundConstruction P k`.
+
+Together these collapse the entire five-point `NoFiveCollinear` case
+analysis into a single 3-point arithmetic hypothesis H2 (H1 is immediate
+for any row construction). A future growing-witness PR now only has to
+supply the four-point lines and prove H2 — never re-derive the five-point
+plumbing.
 
 ## Blockers
 
 The two OPEN construction sorries are unchanged and remain the frontier:
 - `grunbaum_lower_bound_three_halves` (Ω(n^{3/2}))
 - `solymosi_stojakovic_lower_bound` (n^{2−o(1)})
-A general-n growing witness still needs a clean "no five collinear" proof
-(ruling out accidental cross-gadget alignments for all n) — grids alone
-cap at 10 four-point lines under the no-five-collinear constraint.
+
+The remaining obligation for a general-n growing witness is now isolated
+to hypothesis **H2** of `isLowerBoundConstruction_of_rows`: "no three
+points with pairwise-distinct heights are collinear" — the arithmetic
+"no accidental cross-row alignment" certificate. For a super-increasing
+offset family this is a Vandermonde-type non-vanishing that grows with the
+row count; formalising it for all `n` is the next hard step.
 
 ## Next Action
 
-Build a concrete growing family and discharge `k ≤ fourPointLineCount`
-through `fourPointLineCount_ge_of_injOn_family`; the remaining work is the
-per-family no-five-collinear certificate.
+Instantiate `isLowerBoundConstruction_of_rows` with a concrete growing row
+family (k horizontal 4-point segments at distinct heights with
+super-increasing x-offsets). Supply the `k` four-point lines via the
+family `L`, and discharge H2 through the offset non-vanishing argument.
+This would turn the constant floor (currently 10, from `gridSet`) into a
+growing Ω(k) lower bound.
 
 ## Attempt Counts
 
-- Total attempts: 1
-- Current approach attempts: 1
+- Total attempts: 2
+- Current approach attempts: 2
 - Approaches tried: 1

--- a/src/data/research/problems/erdos-101-oq-04.json
+++ b/src/data/research/problems/erdos-101-oq-04.json
@@ -16,16 +16,20 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-30T16:34:54.971Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ACT",
+    "since": "2026-07-08T00:00:00Z",
+    "iteration": 3,
+    "focus": "Height-certificate reduction: collapse NoFiveCollinear to a 3-point condition for row constructions.",
+    "blockers": [
+      "grunbaum_lower_bound_three_halves (Omega(n^{3/2})) remains OPEN",
+      "solymosi_stojakovic_lower_bound (n^{2-o(1)}) remains OPEN",
+      "the 3-point height certificate H2 (no accidental cross-row alignment) is now the sole remaining obligation for a growing witness"
+    ],
+    "nextAction": "Instantiate isLowerBoundConstruction_of_rows with a concrete growing row family: supply the k four-point lines and discharge the H2 arithmetic (no three points with distinct heights collinear).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 2,
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -96,7 +100,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T16:34:54.971Z",
-  "lastUpdate": "2026-03-30T16:34:54.971Z",
+  "lastUpdate": "2026-07-08T00:00:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
@@ -477,11 +481,11 @@
     {
       "path": "Proofs/Erdos101OQ04.lean",
       "filename": "Erdos101OQ04.lean",
-      "lineCount": 674,
-      "theoremCount": 20,
+      "lineCount": 2379,
+      "theoremCount": 57,
       "axiomCount": 0,
-      "defCount": 6,
-      "sorryCount": 7,
+      "defCount": 14,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos101OQ04.lean"
     },


### PR DESCRIPTION
## Summary

Advances the OQ-04 frontier (max four-point-line count of a no-five-collinear planar point set) by removing the key obstruction to a **growing** lower-bound witness.

The previous `state.md` identified the crux: a general-$n$ growing construction needs a clean `NoFiveCollinear` proof, but that predicate quantifies over **five** distinct points — awkward to discharge for a parametric family. This PR collapses it to a **3-point** condition.

## New verified theorems (0-axiom, no new sorries)

- **`noFiveCollinear_of_height_certificate`** — If (H1) every horizontal line `y = c` meets `P` in at most four points, and (H2) no three points of `P` with pairwise-distinct second coordinates are collinear, then `P` is no-five-collinear.
  - *Horizontal anchor* (`a.2 = b.2`): all five collinear points share height `a.2`, so they sit in the height fibre at `a.2`, contradicting H1 (≤ 4).
  - *Non-horizontal anchor*: `a, b, c` then have pairwise-distinct heights, so H2 refutes `collinear a b c` directly.

- **`isLowerBoundConstruction_of_rows`** — frontier template. Combines the existing counting engine (`fourPointLineCount_ge_of_injOn_family`) with the height reduction: an injective family of `k` four-point collinear subsets plus (H1, H2) yields `IsLowerBoundConstruction P k`.

Together these isolate the entire five-point case analysis into a single 3-point arithmetic hypothesis H2 (H1 is immediate for any row-structured construction). A future growing-witness PR need only supply the four-point lines and prove H2 (the "no accidental cross-row alignment" certificate) — never re-derive the five-point plumbing.

## Status

- Build: **3062 jobs, exit 0**, 0 axioms.
- The two OPEN construction sorries (`grunbaum_lower_bound_three_halves`, `solymosi_stojakovic_lower_bound`) are **unchanged** and remain the genuine open frontier. This PR is honest support infrastructure, not a claim to close them.
- Synced badly-stale `leanFiles` counts for this file (674→2379 lines, 7→2 sorries, 20→57 theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)