### PR TITLE
research(erdos-666-incomplete-01): Qₙ n-regularity + edge count [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -105,8 +105,8 @@ theorem hypercube_degree (n : ℕ) (x : Fin (2 ^ n)) :
   -- the `i`-th neighbour, `x` with bit `i` flipped
   have hlt2 : ∀ i : Fin n, x.val ^^^ 2 ^ (i : ℕ) < 2 ^ n := fun i =>
     Nat.xor_lt_two_pow x.2 (Nat.pow_lt_pow_right (by norm_num) i.2)
-  set f : Fin n → Fin (2 ^ n) := fun i => ⟨x.val ^^^ 2 ^ (i : ℕ), hlt2 i⟩ with hf
-  have hfinj : Function.Injective f := by
+  have hfinj : Function.Injective
+      (fun i : Fin n => (⟨x.val ^^^ 2 ^ (i : ℕ), hlt2 i⟩ : Fin (2 ^ n))) := by
     intro a b hab
     have hv : x.val ^^^ 2 ^ (a : ℕ) = x.val ^^^ 2 ^ (b : ℕ) := congrArg Fin.val hab
     have h2 : (2 : ℕ) ^ (a : ℕ) = 2 ^ (b : ℕ) := by
@@ -115,10 +115,12 @@ theorem hypercube_degree (n : ℕ) (x : Fin (2 ^ n)) :
       rwa [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor,
         ← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor] at e
     exact Fin.ext (Nat.pow_right_injective (le_refl 2) h2)
-  have hnb : (Hypercube n).neighborFinset x = Finset.univ.image f := by
+  have hnb : (Hypercube n).neighborFinset x
+      = Finset.univ.image
+        (fun i : Fin n => (⟨x.val ^^^ 2 ^ (i : ℕ), hlt2 i⟩ : Fin (2 ^ n))) := by
     ext y
     simp only [SimpleGraph.mem_neighborFinset, Finset.mem_image, Finset.mem_univ,
-      true_and, hf]
+      true_and]
     constructor
     · intro hadj
       obtain ⟨i, hi⟩ := hadj

--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -75,8 +75,92 @@ def hypercubeVertices (n : ℕ) : ℕ := 2^n
 def hypercubeEdges (n : ℕ) : ℕ := n * 2^(n-1)
 
 /-
-**Degree in Qₙ:** every vertex has degree n.
+## Part I′: Structural invariants of Qₙ (regularity and edge count)
+
+The definitions `hypercubeVertices` and `hypercubeEdges` above are bare numeric
+formulas. Here we *prove* that they agree with the actual graph `Hypercube n`:
+`Qₙ` is `n`-regular and therefore, by the handshake lemma, has exactly
+`n · 2ⁿ⁻¹` edges. This connects the numeric definitions to the honest graph and
+is independent of the (irreducible) cycle machinery, so it does not interact
+with the `Nat.card · .edgeSet` / `HasCycle` co-unfolding described in the header.
 -/
+
+/-- Adjacency in `Qₙ` is decidable (classically). Needed only so that `degree`
+and `edgeFinset` are meaningful; it introduces no assumption beyond the ambient
+`Classical.choice`. -/
+noncomputable instance instDecidableHypercubeAdj (n : ℕ) :
+    DecidableRel (Hypercube n).Adj :=
+  fun _ _ => Classical.propDecidable _
+
+/--
+**`Qₙ` is `n`-regular:** every vertex has exactly `n` neighbours.
+
+The neighbours of `x` are precisely the `n` vertices `x ⊕ 2ⁱ` for `i < n`
+(flipping one of the `n` coordinate bits). The map `i ↦ x ⊕ 2ⁱ` from `Fin n`
+is injective (powers of two are distinct and `xor` is left-cancellative), and
+its image is exactly `neighborFinset x`.
+-/
+theorem hypercube_degree (n : ℕ) (x : Fin (2 ^ n)) :
+    (Hypercube n).degree x = n := by
+  -- the `i`-th neighbour, `x` with bit `i` flipped
+  have hlt2 : ∀ i : Fin n, x.val ^^^ 2 ^ (i : ℕ) < 2 ^ n := fun i =>
+    Nat.xor_lt_two_pow x.2 (Nat.pow_lt_pow_right (by norm_num) i.2)
+  set f : Fin n → Fin (2 ^ n) := fun i => ⟨x.val ^^^ 2 ^ (i : ℕ), hlt2 i⟩ with hf
+  have hfinj : Function.Injective f := by
+    intro a b hab
+    have hv : x.val ^^^ 2 ^ (a : ℕ) = x.val ^^^ 2 ^ (b : ℕ) := congrArg Fin.val hab
+    have h2 : (2 : ℕ) ^ (a : ℕ) = 2 ^ (b : ℕ) := by
+      have e : x.val ^^^ (x.val ^^^ 2 ^ (a : ℕ))
+          = x.val ^^^ (x.val ^^^ 2 ^ (b : ℕ)) := by rw [hv]
+      rwa [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor,
+        ← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor] at e
+    exact Fin.ext (Nat.pow_right_injective (le_refl 2) h2)
+  have hnb : (Hypercube n).neighborFinset x = Finset.univ.image f := by
+    ext y
+    simp only [SimpleGraph.mem_neighborFinset, Finset.mem_image, Finset.mem_univ,
+      true_and, hf]
+    constructor
+    · intro hadj
+      obtain ⟨i, hi⟩ := hadj
+      have hlt : (2 : ℕ) ^ i < 2 ^ n := hi ▸ Nat.xor_lt_two_pow x.2 y.2
+      have hin : i < n := (Nat.pow_lt_pow_iff_right (by norm_num)).mp hlt
+      refine ⟨⟨i, hin⟩, ?_⟩
+      apply Fin.ext
+      have h2 : x.val ^^^ (x.val ^^^ y.val) = x.val ^^^ 2 ^ i := by rw [hi]
+      rw [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor] at h2
+      exact h2.symm
+    · rintro ⟨i, rfl⟩
+      refine ⟨(i : ℕ), ?_⟩
+      show x.val ^^^ (x.val ^^^ 2 ^ (i : ℕ)) = 2 ^ (i : ℕ)
+      rw [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor]
+  rw [← SimpleGraph.card_neighborFinset_eq_degree, hnb,
+    Finset.card_image_of_injective _ hfinj, Finset.card_univ, Fintype.card_fin]
+
+/-- **`Qₙ` is `n`-regular** (packaged form). -/
+theorem hypercube_isRegular (n : ℕ) : (Hypercube n).IsRegularOfDegree n :=
+  fun x => hypercube_degree n x
+
+/--
+**Edge count of `Qₙ`:** the number of edges of `Hypercube n` is exactly
+`hypercubeEdges n = n · 2ⁿ⁻¹`.
+
+Proof: `Qₙ` is `n`-regular, so the degree sum is `n · 2ⁿ`; the handshake lemma
+equates that with `2 · |E|`, and `n · 2ⁿ = 2 · (n · 2ⁿ⁻¹)`.
+-/
+theorem hypercube_card_edges (n : ℕ) :
+    (Hypercube n).edgeFinset.card = hypercubeEdges n := by
+  have hsum : ∑ x : Fin (2 ^ n), (Hypercube n).degree x
+      = 2 * (Hypercube n).edgeFinset.card :=
+    (Hypercube n).sum_degrees_eq_twice_card_edges
+  rw [Finset.sum_congr rfl (fun x _ => hypercube_degree n x)] at hsum
+  simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul] at hsum
+  -- hsum : 2 ^ n * n = 2 * (edge count)
+  have key : 2 ^ n * n = 2 * hypercubeEdges n := by
+    simp only [hypercubeEdges]
+    cases n with
+    | zero => simp
+    | succ m => rw [Nat.succ_sub_one, pow_succ]; ring
+  omega
 
 /-
 ## Part II: Cycles in Graphs

--- a/research/problems/erdos-666-incomplete-01/knowledge.md
+++ b/research/problems/erdos-666-incomplete-01/knowledge.md
@@ -2,19 +2,52 @@
 
 ## Overview
 
-Initial knowledge for problem `erdos-666-incomplete-01`.
+Gallery entry `erdos-666` (Erdős #666: C₆ in hypercube subgraphs). The conjecture
+"every ε-dense subgraph of Qₙ contains C₆" is FALSE (Chung 1992; Brouwer–Dejter–
+Thomassen 1993; Conder 1993). The Lean entry is complete (0 sorries) apart from a
+single deep axiom.
 
 ## Gallery Proof Summary
 
-- Gallery: `erdos-666` — Erdős Problem #666: C₆ in Hypercube Subgraphs
-- Sorries: 1, Axioms: 1
-- Tags: erdos, graph-theory, hypercube, cycles, extremal-graph-theory, disproved
+- Sorries: 0. Axioms: 1 (`chung_no_threshold`).
+- Tags: erdos, graph-theory, hypercube, cycles, extremal-graph-theory, disproved.
 
-## Known Results
+## Known Results / Structure
 
-(To be populated during OBSERVE phase)
+- `Hypercube n : SimpleGraph (Fin (2^n))`, `Adj x y := ∃ i, x.val ^^^ y.val = 2^i`
+  (differ in exactly one bit ⇔ xor is a power of two; note the ∃ i is over all ℕ,
+  the bound i<n is automatic since x⊕y < 2ⁿ).
+- **Structural invariants (proved, researcher-3 2026-07-08):**
+  - Qₙ is n-regular: `hypercube_degree`, `hypercube_isRegular`.
+  - Edge count: `hypercube_card_edges : edgeFinset.card = hypercubeEdges n = n·2ⁿ⁻¹`.
+  - Method: neighbours of x are exactly `{x ⊕ 2ⁱ : i<n}`; explicit injection
+    `Fin n ↪ neighborFinset x`, then handshake lemma for the edge count.
+- `chung_no_threshold : ¬ ConjectureAt (1/4)` — the ONE remaining axiom. Chung
+  edge-partitions Qₙ (n≥3) into four C₆-free subgraphs; pigeonhole gives a
+  (1/4)-dense C₆-free subgraph for every candidate threshold. Stated in negation
+  form because the `∃ H, dense H ∧ ¬HasC6 H` form triggers a Mathlib v4.26
+  elaborator stack overflow (see file header).
+
+## Techniques that worked
+
+- `Nat.xor_lt_two_pow (h1 : x<2ⁿ)(h2 : y<2ⁿ) : x^^^y < 2ⁿ` — well-definedness of bit-flip.
+- xor left-cancellation without the deprecated `Nat.xor_cancel_left`: rewrite with
+  `← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor`.
+- `2ⁱ < 2ⁿ → i < n` via `(Nat.pow_lt_pow_iff_right (by norm_num)).mp`.
+- `Nat.pow_right_injective (le_refl 2)` for `2ⁱ = 2ʲ → i = j`.
+- `SimpleGraph.card_neighborFinset_eq_degree` (rfl), `Finset.card_image_of_injective`,
+  `sum_degrees_eq_twice_card_edges` (handshake).
+- Adjacency decidability supplied classically (`Classical.propDecidable`) — needed
+  only so `degree`/`edgeFinset` are meaningful; counts as Classical.choice, not a
+  new axiom.
+
+## Blockers
+
+- `chung_no_threshold`: needs Chung's explicit 4-partition construction (constant
+  density for all n) — not in Mathlib, >1000 lines. BLOCKED.
 
 ## Key References
 
 - Gallery: `src/data/proofs/erdos-666/`
-- Lean source: `proofs/Proofs/` (check namespace `Erdos666`)
+- Lean source: `proofs/Proofs/Erdos666Problem.lean` (namespace `Erdos666`)
+- Chung (1992) "Subgraphs of a hypercube containing no small even cycles"

--- a/research/problems/erdos-666-incomplete-01/state.md
+++ b/research/problems/erdos-666-incomplete-01/state.md
@@ -2,25 +2,49 @@
 
 ## Current Phase: ACT
 
-**Phase**: ACT  
-**Status**: Active  
-**Started**: 2026-04-03T05:22:49  
-**Last Updated**: 2026-07-08 (researcher-4)
+**Phase**: ACT
+**Status**: Active
+**Started**: 2026-04-03T05:22:49
+**Last Updated**: 2026-07-08 (researcher-3)
 
 ## Progress Summary
 
-De-axiomatized `chung_c6free` in the parent `Erdos666Problem.lean` (researcher-4, 2026-07-08): the existence axiom `∀ n≥3, ∃ H, ¬HasC6 H` carries no edge-count data, so the empty subgraph `⊥` (no edges ⇒ no cycle) proves it outright. Entry axiom count 2→1; the deep density content stays isolated in the single axiom `chung_no_threshold`. docker-build verified, Lean v4.26.0.
+Added and VERIFIED the hypercube's structural invariants (researcher-3, 2026-07-08),
+grounding the previously-bare numeric definitions in the actual graph `Hypercube n`:
+
+- `hypercube_degree`: Qₙ is n-regular — every vertex has exactly `n` neighbours
+  (the n bit-flips `x ⊕ 2ⁱ`, i<n). Proved via an explicit injection
+  `Fin n ↪ neighborFinset x`, using `Nat.xor_lt_two_pow` for well-definedness,
+  xor left-cancellation (`xor_assoc`/`xor_self`/`zero_xor`), and injectivity of
+  `i ↦ 2ⁱ` (`Nat.pow_right_injective`).
+- `hypercube_isRegular`: packaged `IsRegularOfDegree n` form.
+- `hypercube_card_edges`: `(Hypercube n).edgeFinset.card = hypercubeEdges n = n·2ⁿ⁻¹`,
+  derived from n-regularity via the handshake lemma
+  `sum_degrees_eq_twice_card_edges`.
+
+These carry no assumptions beyond the ambient `Classical.choice` (used only for
+adjacency decidability). The entry's single deep axiom `chung_no_threshold`
+(Chung's 4-partition of Qₙ into C₆-free subgraphs) is unchanged: eliminating it
+requires the explicit combinatorial construction, which is not in Mathlib
+(>1000 lines — BLOCKED). docker-build verified (Lean v4.26.0); the first attempt
+hit a transient exit-135 volume corruption, clean on retry.
+
+Entry file: 326 → 412 lines, theoremCount 5 → 8, axiomCount 1 (unchanged), 0 sorries.
 
 ## Current Focus
 
-Read gallery proof and understand the sorry statement(s) that need completion.
+The formalization is complete apart from the deep `chung_no_threshold` axiom.
+Remaining work is either (a) the full Chung edge-partition construction
+(BLOCKED — large combinatorial build) or (b) further structural lemmas
+(e.g. bipartiteness, C₄-freeness of 2-direction subgraphs).
 
 ## Blockers
 
-None currently identified.
+`chung_no_threshold`: requires Chung's explicit 4-partition of Qₙ into C₆-free
+subgraphs (constant-fraction density for all n). No Mathlib support; >1000 lines.
 
 ## Next Action
 
-1. Read `problem.md` thoroughly
-2. Examine the gallery Lean source at `src/data/proofs/erdos-666/`
-3. Identify what the sorry statement(s) require
+Optional follow-ups (not required — entry is otherwise complete):
+1. Prove Qₙ is bipartite (2-colour by bit-parity), explaining absence of odd cycles.
+2. Formalize a concrete C₆-free 2-direction subgraph (edges in 2 fixed coordinates).

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -39,6 +39,11 @@
         "theorem": "Real",
         "description": "Real numbers for the ε-density threshold",
         "module": "Mathlib.Data.Real.Basic"
+      },
+      {
+        "theorem": "SimpleGraph.sum_degrees_eq_twice_card_edges",
+        "description": "Handshake lemma: ∑ degrees = 2·|E|, used to derive the hypercube edge count from n-regularity",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
       }
     ],
     "originalContributions": [
@@ -52,12 +57,15 @@
       "erdos_conjecture_false: disproof theorem, fully proved from chung_no_threshold (instantiate ε = 1/4; the assumption that some threshold N forces C₆ in every (1/4)-dense subgraph directly contradicts Chung's counterexamples)",
       "chung_no_threshold axiom: for ε = 1/4 there is no threshold N beyond which every (1/4)-dense subgraph of Qₙ contains C₆ (pigeonhole consequence of Chung's 4-partition)",
       "chung_c6free theorem (de-axiomatized): for n ≥ 3, Qₙ has a C₆-free subgraph — proved via the empty subgraph ⊥ (no edges ⇒ no C₆), since the bare existence form carries no edge-count data; feeds the ε = 1/4 and ε = 1/3 corollaries. Drops the entry's axiom count from 2 to 1.",
-      "GeneralizedConjecture: open question for C_{2k}"
+      "GeneralizedConjecture: open question for C_{2k}",
+      "hypercube_degree theorem: Qₙ is n-regular — every vertex has exactly n neighbours (the n bit-flips x⊕2ⁱ, i<n). Proved via an explicit injection Fin n ↪ neighborFinset using Nat.xor_lt_two_pow, xor left-cancellation, and injectivity of i↦2ⁱ.",
+      "hypercube_isRegular theorem: packaged IsRegularOfDegree n form of the regularity result.",
+      "hypercube_card_edges theorem: the actual edge count of Hypercube n equals the numeric definition hypercubeEdges n = n·2ⁿ⁻¹, derived from n-regularity via the handshake lemma sum_degrees_eq_twice_card_edges. This grounds the previously-bare hypercubeEdges definition in the real graph."
     ],
     "axiomCount": 1,
-    "lineCount": 326,
-    "assumptions": "1 axiom (Chung 1992): chung_no_threshold — no threshold N makes every (1/4)-dense subgraph of Qₙ contain C₆; a consequence of Chung's edge-partition of Qₙ into four C₆-free subgraphs, not available in Mathlib. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) was previously axiomatized but is now PROVED outright — it carries no edge-count data, so the empty subgraph ⊥ (no edges, hence no cycle) is an honest witness. The deep density content stays isolated in the single axiom chung_no_threshold.",
-    "theoremCount": 4,
+    "lineCount": 412,
+    "assumptions": "1 axiom (Chung 1992): chung_no_threshold — no threshold N makes every (1/4)-dense subgraph of Qₙ contain C₆; a consequence of Chung's edge-partition of Qₙ into four C₆-free subgraphs, not available in Mathlib. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) was previously axiomatized but is now PROVED outright — it carries no edge-count data, so the empty subgraph ⊥ (no edges, hence no cycle) is an honest witness. The deep density content stays isolated in the single axiom chung_no_threshold. Separately, the structural invariants of the hypercube (n-regularity and the exact edge count n·2ⁿ⁻¹) are now fully proved (hypercube_degree, hypercube_card_edges), grounding the numeric vertex/edge definitions in the actual graph; these carry no assumptions beyond the ambient Classical.choice used for adjacency decidability.",
+    "theoremCount": 8,
     "definitionCount": 13
   },
   "overview": {
@@ -84,72 +92,80 @@
       "id": "hypercube",
       "title": "Hypercube Graph",
       "summary": "Definition of Qₙ via XOR, vertices, edges, regularity",
-      "startLine": 36,
-      "endLine": 68,
+      "startLine": 45,
+      "endLine": 76,
       "mathContext": "Formal definition: Definition of Qₙ via XOR, vertices, edges, regularity"
+    },
+    {
+      "id": "structure",
+      "title": "Structural Invariants of Qₙ (Regularity & Edge Count)",
+      "summary": "Proves that the bare numeric definitions agree with the actual graph: Qₙ is n-regular (`hypercube_degree`, `hypercube_isRegular`) and therefore, by the handshake lemma, has exactly n·2ⁿ⁻¹ edges (`hypercube_card_edges` = `hypercubeEdges n`). The neighbours of a vertex x are exactly the n vertices x⊕2ⁱ (i<n); the map i↦x⊕2ⁱ is injective (distinct powers of two, xor left-cancellative) with image the whole neighbourhood.",
+      "startLine": 77,
+      "endLine": 166,
+      "mathContext": "Connects hypercubeVertices/hypercubeEdges to Hypercube n via SimpleGraph.degree, IsRegularOfDegree, and the handshake lemma sum_degrees_eq_twice_card_edges. Independent of the irreducible cycle machinery, so it avoids the Nat.card·edgeSet / HasCycle co-unfolding crash."
     },
     {
       "id": "cycles",
       "title": "Cycles in Graphs",
       "summary": "HasCycle, HasC4, HasC6, HasC2k definitions",
-      "startLine": 69,
-      "endLine": 97,
+      "startLine": 167,
+      "endLine": 201,
       "mathContext": "Formal definition: HasCycle, HasC4, HasC6, HasC2k definitions"
     },
     {
       "id": "density",
       "title": "Subgraphs and Density",
       "summary": "DenseSubgraph, EpsilonDenseSubgraph",
-      "startLine": 98,
-      "endLine": 118,
+      "startLine": 202,
+      "endLine": 226,
       "mathContext": "Mathematical content: DenseSubgraph, EpsilonDenseSubgraph"
     },
     {
       "id": "conjecture",
       "title": "Erdős's Conjecture (Disproved)",
       "summary": "ErdosConjecture, erdos_conjecture_false",
-      "startLine": 119,
-      "endLine": 141,
+      "startLine": 227,
+      "endLine": 303,
       "mathContext": "Mathematical content: ErdosConjecture, erdos_conjecture_false"
     },
     {
       "id": "chung",
       "title": "Chung's Result (1992)",
       "summary": "4-partition into C₆-free subgraphs",
-      "startLine": 142,
-      "endLine": 175,
+      "startLine": 304,
+      "endLine": 321,
       "mathContext": "Mathematical content: 4-partition into C₆-free subgraphs"
     },
     {
       "id": "bdt",
       "title": "Brouwer-Dejter-Thomassen (1993)",
       "summary": "Informal commentary on BDT independent 4-coloring result (no formal declarations in file)",
-      "startLine": 176,
-      "endLine": 178,
+      "startLine": 322,
+      "endLine": 328,
       "mathContext": "Informal commentary: BDT independent 4-coloring result (no formal declarations)"
     },
     {
       "id": "conder",
       "title": "Conder's Improvement (1993)",
       "summary": "conder_better_bound: ε = 1/3 counterexample theorem derived from chung_c6free",
-      "startLine": 179,
-      "endLine": 201,
+      "startLine": 329,
+      "endLine": 352,
       "mathContext": "Mathematical content: conder_better_bound theorem (3-coloring, ε = 1/3 counterexample)"
     },
     {
       "id": "generalized",
       "title": "Generalized Conjecture",
       "summary": "GeneralizedConjecture: open question for C_{2k} in dense hypercube subgraphs",
-      "startLine": 203,
-      "endLine": 218,
+      "startLine": 353,
+      "endLine": 380,
       "mathContext": "Mathematical content: GeneralizedConjecture definition (open question for C_{2k})"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_666_summary: combined theorem stating conjecture is false and C₆-free subgraphs exist",
-      "startLine": 232,
-      "endLine": 261,
+      "startLine": 381,
+      "endLine": 412,
       "mathContext": "Mathematical content: erdos_666_summary theorem"
     }
   ],
@@ -171,9 +187,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 326,
+    "lineCount": 412,
     "axiomCount": 1,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 13,
     "path": "Proofs/Erdos666Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-666-incomplete-01.json
+++ b/src/data/research/problems/erdos-666-incomplete-01.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-03T12:23:52.517Z",
-    "iteration": 1,
-    "focus": "De-axiomatized chung_c6free in the parent Erdos666Problem.lean (researcher-4, 2026-07-08): the existence axiom '∀ n≥3, ∃ H, ¬HasC6 H' carries no edge-count data, so the empty subgraph ⊥ (no edges ⇒ no cycle) proves it outright. Entry axiom count 2→1; the deep density content stays isolated in chung_no_threshold. docker-build verified.",
+    "iteration": 2,
+    "focus": "Added & VERIFIED hypercube structural invariants (researcher-3, 2026-07-08): hypercube_degree (Qₙ is n-regular), hypercube_isRegular, and hypercube_card_edges (edgeFinset.card = hypercubeEdges n = n·2ⁿ⁻¹ via the handshake lemma). These ground the bare numeric vertex/edge definitions in the actual graph, with no assumptions beyond Classical.choice. The single deep axiom chung_no_threshold (Chung's 4-partition) is unchanged and BLOCKED (needs >1000-line construction absent from Mathlib). File 326→412 lines, theoremCount 5→8, 0 sorries, 1 axiom.",
     "blockers": [],
     "nextAction": "The remaining axiom chung_no_threshold (a *dense* 1/4-density C6-free subgraph via Chung's explicit 4-partition of Qₙ) is the genuine deep content — de-axiomatizing it needs the combinatorial edge-partition construction, absent from Mathlib. Alternative: formalize hypercube edge/vertex-count lemmas (hypercubeEdges = n·2^(n-1)) as theorems.",
     "attemptCounts": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Discharged the lone sorry in erdos_conjecture_false and repaired the file so it actually compiles (it previously had 24 errors: nonexistent Nat.popcount, missing Real/edgeFinset imports, orphaned docstrings, a buggy HasCycle mod_lt, and a malformed conder_better_bound tuple). The disproof now follows from a single well-formed axiom chung_1992 (density form). 0 sorries, 1 axiom; #print axioms shows only propext/Classical.choice/Quot.sound + chung_1992.",
+    "progressSummary": "Entry complete (0 sorries) apart from the deep axiom chung_no_threshold. researcher-3 (2026-07-08) added the hypercube's structural invariants: n-regularity (hypercube_degree/hypercube_isRegular) and the exact edge count n·2ⁿ⁻¹ (hypercube_card_edges, via the handshake lemma), grounding the numeric definitions in the real graph. VERIFIED, Lean v4.26.0. COMPLETED: Discharged the lone sorry in erdos_conjecture_false and repaired the file so it actually compiles (it previously had 24 errors: nonexistent Nat.popcount, missing Real/edgeFinset imports, orphaned docstrings, a buggy HasCycle mod_lt, and a malformed conder_better_bound tuple). The disproof now follows from a single well-formed axiom chung_1992 (density form). 0 sorries, 1 axiom; #print axioms shows only propext/Classical.choice/Quot.sound + chung_1992.",
     "builtItems": [
       "Proved Erdos666.erdos_conjecture_false from chung_1992 (Proofs/Erdos666Problem.lean)",
       "Repaired Hypercube, HasCycle, DenseSubgraph defs and imports so the file compiles (282 lines, 0 errors)"


### PR DESCRIPTION
## Summary

Erdős #666 (C₆ in hypercube subgraphs) is a **completion** problem whose gallery entry was already at 0 sorries / 1 axiom. The lone remaining axiom `chung_no_threshold` (Chung's explicit 4-partition of Qₙ into C₆-free subgraphs) is genuinely deep and absent from Mathlib — eliminating it needs a >1000-line combinatorial construction (BLOCKED).

This PR adds the highest-value **verified** content available: the hypercube's structural invariants, grounding the previously-bare numeric definitions `hypercubeVertices`/`hypercubeEdges` in the actual graph `Hypercube n`.

## New theorems (all VERIFIED, 0 sorries)

- **`hypercube_degree`** — Qₙ is `n`-regular: every vertex has exactly `n` neighbours (the `n` bit-flips `x ⊕ 2ⁱ`, `i<n`). Explicit injection `Fin n ↪ neighborFinset x`: well-definedness from `Nat.xor_lt_two_pow`, injectivity from xor left-cancellation + injectivity of `i ↦ 2ⁱ`, surjectivity from the adjacency characterisation.
- **`hypercube_isRegular`** — packaged `IsRegularOfDegree n` form.
- **`hypercube_card_edges`** — `(Hypercube n).edgeFinset.card = hypercubeEdges n = n·2ⁿ⁻¹`, from `n`-regularity via the handshake lemma `sum_degrees_eq_twice_card_edges`.

These carry no assumptions beyond the ambient `Classical.choice` (adjacency `DecidableRel`), and are independent of the irreducible cycle machinery, so they avoid the `Nat.card·edgeSet` / `HasCycle` co-unfolding crash documented in the file header.

## Axiom status (unchanged)

Still exactly **1 axiom**: `chung_no_threshold`. No new counted axioms.

## Build

`docker-build.sh Proofs.Erdos666Problem` — **succeeded** (Lean v4.26.0; first attempt hit a transient exit-135 volume corruption, clean on retry).

File 326 → 412 lines, `theoremCount` 5 → 8, 0 sorries, 1 axiom. Gallery `meta.json` counts/sections/contributions updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)