### PR TITLE
research(erdos-771): fill 6 companion-file sorries with verified proofs [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos771Aristotle.lean
+++ b/proofs/Proofs/Erdos771Aristotle.lean
@@ -36,9 +36,13 @@ def primeMutliples (p n : ℕ) : Finset ℕ :=
 
 /-- The number of multiples of p in {1, ..., n} equals floor(n/p).
     This is a standard counting result: multiples of p in [1,n] are p, 2p, ..., floor(n/p)*p. -/
-theorem prime_multiples_size (p n : ℕ) (hp : p > 0) :
+theorem prime_multiples_size (p n : ℕ) (_hp : p > 0) :
     (primeMutliples p n).card = n / p := by
-  sorry
+  have hIcc : Icc_n n = Finset.Ioc 0 n := by
+    unfold Icc_n; ext k; simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+  unfold primeMutliples
+  rw [hIcc]
+  exact Nat.Ioc_filter_dvd_card_eq_div n p
 
 -- ===================================================================
 -- Section 2: Prime multiples avoid non-multiples
@@ -60,22 +64,38 @@ theorem primeMutliples_subset_sum_dvd (p n : ℕ) (A : Finset ℕ)
 
 /-- For prime p not dividing m, multiples of p avoid sum m.
     Any subset sum of multiples of p is a multiple of p, but m is not. -/
-theorem prime_multiples_avoid (p m n : ℕ) (hp : Nat.Prime p) (hpm : ¬p ∣ m) :
+theorem prime_multiples_avoid (p m n : ℕ) (_hp : Nat.Prime p) (hpm : ¬p ∣ m) :
     AvoidSum (primeMutliples p n) m := by
-  sorry
+  intro hmem
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+  obtain ⟨⟨A, hA, hAsum⟩, _⟩ := hmem
+  rw [Finset.mem_powerset] at hA
+  have hdvd := primeMutliples_subset_sum_dvd p n A hA
+  rw [hAsum] at hdvd
+  exact hpm hdvd
 
 -- ===================================================================
 -- Section 3: Avoiding sum 1
 -- ===================================================================
 
 /-- The set {2, ..., n} is a 1-avoiding set of size n-1 for n >= 2. -/
-theorem Icc_2_n_avoids_one (n : ℕ) (hn : n ≥ 2) :
+theorem Icc_2_n_avoids_one (n : ℕ) (_hn : n ≥ 2) :
     AvoidSum (Finset.Icc 2 n) 1 := by
-  sorry
+  intro hmem
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+  obtain ⟨⟨A, hA, hAsum⟩, _⟩ := hmem
+  rw [Finset.mem_powerset] at hA
+  -- Every element of A is ≥ 2, so a nonempty sum is ≥ 2 and the empty sum is 0 — never 1.
+  rcases A.eq_empty_or_nonempty with rfl | hne
+  · simp at hAsum
+  · obtain ⟨x, hx⟩ := hne
+    have hx2 : 2 ≤ x := by have := hA hx; rw [Finset.mem_Icc] at this; omega
+    have hle : x ≤ ∑ a ∈ A, a := Finset.single_le_sum (fun i _ => Nat.zero_le i) hx
+    omega
 
 /-- The set {2, ..., n} has card n - 1. -/
-theorem Icc_2_n_card (n : ℕ) (hn : n ≥ 2) :
+theorem Icc_2_n_card (n : ℕ) (_hn : n ≥ 2) :
     (Finset.Icc 2 n).card = n - 1 := by
-  sorry
+  rw [Nat.card_Icc]; omega
 
 end Erdos771Aristotle

--- a/proofs/Proofs/Erdos771ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos771ProblemAristotle.lean
@@ -26,9 +26,13 @@ def primeMutliples (p n : ℕ) : Finset ℕ :=
 
 -- Routine: Count of multiples of p in {1,...,n} equals ⌊n/p⌋.
 -- Uses Finset.Nat.card_multiples or Icc filter card formula.
-theorem prime_multiples_size (p n : ℕ) (hp : p > 0) :
+theorem prime_multiples_size (p n : ℕ) (_hp : p > 0) :
     (primeMutliples p n).card = n / p := by
-  sorry
+  have hIcc : Icc_n n = Finset.Ioc 0 n := by
+    unfold Icc_n; ext k; simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+  unfold primeMutliples
+  rw [hIcc]
+  exact Nat.Ioc_filter_dvd_card_eq_div n p
 
 -- Routine: The set of all subset sums of S.
 noncomputable def subsetSums (S : Finset ℕ) : Finset ℕ :=
@@ -42,8 +46,18 @@ def AvoidSum (S : Finset ℕ) (m : ℕ) : Prop :=
 -- Every element of primeMutliples p n is divisible by p; any
 -- nonempty subset sum is also divisible by p; since p ∤ m, m cannot
 -- be achieved as a subset sum.
-theorem prime_multiples_avoid (p m n : ℕ) (hp : Nat.Prime p) (hpm : ¬p ∣ m) :
+theorem prime_multiples_avoid (p m n : ℕ) (_hp : Nat.Prime p) (hpm : ¬p ∣ m) :
     AvoidSum (primeMutliples p n) m := by
-  sorry
+  intro hmem
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+  obtain ⟨⟨A, hA, hAsum⟩, _⟩ := hmem
+  rw [Finset.mem_powerset] at hA
+  have hdvd : p ∣ ∑ a ∈ A, a := by
+    refine Finset.dvd_sum (fun a ha => ?_)
+    have ha' : a ∈ primeMutliples p n := hA ha
+    rw [primeMutliples, Finset.mem_filter] at ha'
+    exact ha'.2
+  rw [hAsum] at hdvd
+  exact hpm hdvd
 
 end Erdos771ProblemAristotle


### PR DESCRIPTION
## Summary

Discharges all **6 remaining sorries** in the two Erdős #771 Aristotle companion files with fully verified proofs. These lemmas were already proven in the verified `Erdos771Construction.lean` / `Erdos771Problem.lean`; filling them here removes the sorries and stops the Aristotle proof-search agent from spending solver budget re-deriving already-solved lemmas.

## Changes

**`Erdos771Aristotle.lean`** (4 sorries → 0):
- `prime_multiples_size` — `|{multiples of p in {1,…,n}}| = ⌊n/p⌋` via `Nat.Ioc_filter_dvd_card_eq_div`.
- `prime_multiples_avoid` — multiples of `p` avoid sum `m` when `p ∤ m` (via the file's existing `primeMutliples_subset_sum_dvd` helper).
- `Icc_2_n_avoids_one` — `{2,…,n}` avoids sum 1 (every nonempty subset sum is ≥ 2; empty sum is 0).
- `Icc_2_n_card` — `|{2,…,n}| = n−1` via `Nat.card_Icc`.

**`Erdos771ProblemAristotle.lean`** (2 sorries → 0):
- `prime_multiples_size`, `prime_multiples_avoid` — same two lemmas (this file has no local helpers, so `prime_multiples_avoid` inlines the `Finset.dvd_sum` argument).

## Verification

- Docker build `Proofs.Erdos771Aristotle` → **EXIT 0**, and `Proofs.Erdos771ProblemAristotle` → **EXIT 0** (built separately; the build script only takes one target).
- 0 sorries, 0 axioms, **0 lint warnings** (unused statement hypotheses underscored to match `Construction.lean` style).
- No `native_decide`; no new axioms.

## Scope

Companion-file cleanup only — no change to the gallery entry or the main `Erdos771Problem.lean` (which is complete: 0 sorries, 2 irreducible external axioms = the Erdős–Graham / Alon–Freiman asymptotic bounds, absent from Mathlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)