### PR TITLE
Enrich Rationality Criterion for n-th Roots (cube-root-2-irrational-oq-05-oq-01): add mainTheorems array

### DIFF
--- a/src/data/proofs/cube-root-2-irrational-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05-oq-01/meta.json
@@ -110,6 +110,72 @@
       "mathContext": "$\\sqrt[3]{2},\\sqrt[3]{6} \\notin \\mathbb{Q}$ but $\\sqrt[3]{8} = 2 \\in \\mathbb{Q}$."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "rational_rpow_inv_iff",
+      "type": "core",
+      "description": "**The rationality criterion.** For m, n ≥ 1, the real n-th root m^(1/n) is rational (¬Irrational) iff m is a perfect n-th power (∃ k, kⁿ = m). The headline generalization over the parent's prime-only result: an exact characterization for every radicand. Forward direction forces an integer root via irrational_nrt_of_notint_nrt; reverse direction simplifies (kⁿ)^(1/n) to k.",
+      "leanType": "{m n : ℕ} (hn : 0 < n) : (¬ Irrational ((m : ℝ) ^ ((n : ℝ)⁻¹))) ↔ IsPerfectNthPow m n",
+      "startLine": 46,
+      "endLine": 74
+    },
+    {
+      "name": "irrational_rpow_inv_iff",
+      "type": "core",
+      "description": "**The irrationality criterion** (contrapositive form). m^(1/n) is irrational iff m is not a perfect n-th power — the directly usable statement, obtained from rational_rpow_inv_iff by not_iff_not.",
+      "leanType": "{m n : ℕ} (hn : 0 < n) : Irrational ((m : ℝ) ^ ((n : ℝ)⁻¹)) ↔ ¬ IsPerfectNthPow m n",
+      "startLine": 78,
+      "endLine": 81
+    },
+    {
+      "name": "rpow_inv_pow",
+      "type": "supporting",
+      "description": "**The defining root identity.** For n ≥ 1, (m^(1/n))^n = m over ℝ — the rpow composition (m ≥ 0) that lets the integer-root machinery apply to the real n-th root.",
+      "leanType": "{m n : ℕ} (hn : 0 < n) : ((m : ℝ) ^ ((n : ℝ)⁻¹)) ^ n = (m : ℝ)",
+      "startLine": 37,
+      "endLine": 42
+    },
+    {
+      "name": "not_isPerfectNthPow_prime",
+      "type": "supporting",
+      "description": "**A prime is never a perfect n-th power** for n ≥ 2 — the divisibility fact (k ∣ p forces k = 1 or p, and neither kⁿ equals p) that specializes the criterion to primes.",
+      "leanType": "{p n : ℕ} (hp : p.Prime) (hn : 2 ≤ n) : ¬ IsPerfectNthPow p n",
+      "startLine": 84,
+      "endLine": 95
+    },
+    {
+      "name": "irrational_rpow_inv_prime",
+      "type": "corollary",
+      "description": "**The n-th root of a prime is irrational** — the parent entry OQ-05 result recovered as a one-line corollary of the general criterion via not_isPerfectNthPow_prime.",
+      "leanType": "{p n : ℕ} (hp : p.Prime) (hn : 2 ≤ n) : Irrational ((p : ℝ) ^ ((n : ℝ)⁻¹))",
+      "startLine": 99,
+      "endLine": 101
+    },
+    {
+      "name": "irrational_cbrt_two",
+      "type": "corollary",
+      "description": "**∛2 is irrational** — the base gallery entry, recovered from the prime corollary at p = 2, n = 3.",
+      "leanType": "Irrational ((2 : ℝ) ^ ((3 : ℝ)⁻¹))",
+      "startLine": 104,
+      "endLine": 106
+    },
+    {
+      "name": "rational_cbrt_eight",
+      "type": "corollary",
+      "description": "**∛8 is rational** (= 2). Since 8 = 2³ is a perfect cube, the criterion's rational branch fires — the worked converse showing the characterization is genuinely two-sided.",
+      "leanType": "¬ Irrational ((8 : ℝ) ^ ((3 : ℝ)⁻¹))",
+      "startLine": 110,
+      "endLine": 112
+    },
+    {
+      "name": "irrational_cbrt_six",
+      "type": "corollary",
+      "description": "**∛6 is irrational**, although 6 is not prime — demonstrating the criterion reaches composite non-perfect-powers that the prime corollary cannot.",
+      "leanType": "Irrational ((6 : ℝ) ^ ((3 : ℝ)⁻¹))",
+      "startLine": 116,
+      "endLine": 124
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "cube-root-2-irrational-oq-05",


### PR DESCRIPTION
Enrichment pass for `cube-root-2-irrational-oq-05-oq-01` (quality 94, passes 0).

Well-enriched entry (5 annotations, full section coverage 1–126, 4 keyInsights, cross-references) but the `mainTheorems` array was **absent**.

**Change (non-inflating gap fill):** added a `mainTheorems` array covering all 8 theorems with `startLine`/`endLine` anchors and `leanType` signatures — the core two-sided criterion `rational_rpow_inv_iff` / `irrational_rpow_inv_iff` (m^(1/n) rational ⟺ m a perfect n-th power), supporting `rpow_inv_pow` and `not_isPerfectNthPow_prime`, and the corollaries/instances `irrational_rpow_inv_prime`, `irrational_cbrt_two`, `rational_cbrt_eight`, `irrational_cbrt_six`. Matches `meta.theoremCount = 8`.

JSON and size guardrail checks pass, well under the 60 KB cap.