### PR TITLE
research(cauchy-interlacing-oq-02-oq-01): reconcile phantom-complete + record follow-up

### DIFF
--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (phantom): the exact deliverable already exists, verified 0-sorry/0-axiom.",
+    "progressSummary": "COMPLETE: deliverable poincare_separation_compression (unconditional codim-m Poincaré separation, no Rayleigh hypothesis) verified 0-sorry/0-axiom under sibling cauchy-interlacing-theorem-oq-01-oq-02 (#28084). Phantom recorded #35278; pool status reconciled to completed 2026-07-08.",
     "builtItems": [
       "poincare_separation_compression in CauchyInterlacingPoincareCompression.lean (#28084) — unconditional codimension-m Poincaré separation: given a symmetric T on V (dim n+m) and any subspace H (dim n), the descending eigenvalues of the explicit orthogonal compression compress T H interlace those of T as lam⟨k+m⟩ ≤ mu k ≤ lam⟨k⟩, with NO Rayleigh side hypothesis.",
       "compress / isSymmetric_compress / rayleigh_compress_eq in CauchyInterlacingCompression.lean (#27245) — define compress T H := P_H∘T∘ι_H, prove it symmetric, and discharge the Rayleigh-agreement identity for an arbitrary subspace via the orthogonal-projection adjoint identity.",
@@ -39,10 +39,13 @@
     ],
     "insights": [
       "This slug duplicates work already merged under sibling cauchy-interlacing-theorem-oq-01-oq-02 (#28084). The Rayleigh-agreement hypothesis of the abstract poincare_separation is discharged by rayleigh_compress_eq, which is stated for an ARBITRARY submodule H (nothing uses codim=1), so the abstract theorem and the explicit compression join for any codimension m with no new work.",
-      "Rayleigh discharge mechanism: for y∈H, ⟨compress T H y, y⟩_H = ⟨P_H(Ty), y⟩ = ⟨Ty, y⟩_V by the orthogonal-projection adjoint identity (P_H self-adjoint, P_H y = y); norms agree since the inclusion H↪V is a linear isometry."
+      "Rayleigh discharge mechanism: for y∈H, ⟨compress T H y, y⟩_H = ⟨P_H(Ty), y⟩ = ⟨Ty, y⟩_V by the orthogonal-projection adjoint identity (P_H self-adjoint, P_H y = y); norms agree since the inclusion H↪V is a linear isometry.",
+      "Re-verification 2026-07-08: poincare_separation_compression (CauchyInterlacingPoincareCompression.lean:73) is 0-sorry/0-axiom; sibling gallery entry cauchy-interlacing-theorem-oq-01-oq-02 is status=verified badge=mathlib axiomCount=0. The single grep sorry hit in CauchyInterlacingCompression.lean is inside a docstring (0-sorry/0-axiom self-reference), not a real sorry. Nothing left to prove."
     ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "STRONG FOLLOW-UP (theory-level, genuinely distinct): the extremal/equality (Fan-Pall) converse — characterize when interlacing is TIGHT, i.e. λ_{k+m}(A)=μ_k or μ_k=λ_k(A). Tightness should force the compression subspace to align with eigenspaces of A. This is a real converse, not a cosmetic variant, and would need eigenspace-intersection dimension counting not yet in the compression files."
+    ]
   },
   "tags": [
     "linear-algebra",


### PR DESCRIPTION
## Summary

`cauchy-interlacing-theorem-oq-02-oq-01` (*Unconditional codimension-m orthogonal compression corollary*) is a **phantom-complete**: its exact deliverable already exists, verified 0-sorry/0-axiom.

- **Deliverable**: `poincare_separation_compression` (`proofs/Proofs/CauchyInterlacingPoincareCompression.lean:73`) — for a symmetric `T` on `V` (dim `n+m`) and **any** subspace `H` (dim `n`), the descending eigenvalues of the explicit orthogonal compression interlace those of `T` as `λ_{k+m} ≤ μ_k ≤ λ_k`, with **no Rayleigh side-hypothesis**.
- The Rayleigh-agreement hypothesis is discharged internally by `rayleigh_compress_eq` (`CauchyInterlacingCompression.lean:91`), stated for an **arbitrary** submodule `H` (nothing uses codim = 1) via the orthogonal-projection adjoint identity — exactly what this OQ asked for.
- Lives under sibling gallery entry `cauchy-interlacing-theorem-oq-01-oq-02` (#28084): `status=verified`, `badge=mathlib`, `axiomCount=0`, `sorries=0`.

## Verification (2026-07-08)

- Main deliverable file is 0-sorry / 0-axiom.
- The single `grep sorry` hit in `CauchyInterlacingCompression.lean` is a docstring self-reference (`"0-sorry/0-axiom"`), not a real sorry.

## Changes

Knowledge-only (no Lean source change — nothing left to prove):
- Records the re-verification insight.
- Records one genuinely-distinct theory-level follow-up: the **Fan–Pall extremal/equality converse** (tightness of interlacing forces the compression subspace to align with eigenspaces of `T`).
- Local candidate-pool status reconciled `available → completed` (pool file is gitignored runtime state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)