### PR TITLE
Enrich Cramer's Rule 2×2/3×3 closed forms: cofactor/adjugate insight

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -80,7 +80,8 @@
       "The specialization is entirely mechanical once the right Mathlib primitives are named: det_fin_two/three give the determinant as a fixed polynomial, and updateCol_self/updateCol_ne classify each entry of the column-replaced matrix as coming from b or from A.",
       "Column replacement acts only on the second index. updateCol_self fires exactly on the entries whose column equals the replaced index i (these become b), and updateCol_ne on all others (these stay A) — so for a 2×2 the numerator picks up b in one column and A in the other, giving b₀a₁₁ − a₀₁b₁ for i = 0.",
       "Because det_fin_two and det_fin_three expand into a fixed monomial order, the proof needs no ring step: substituting the entries yields the closed form verbatim, which is why each theorem closes by rewriting alone.",
-      "The 3×3 numerators are the six Sarrus terms with exactly one factor in each replaced by the corresponding bᵢ; reading them off is the explicit content of Cramer's rule for three equations in three unknowns."
+      "The 3×3 numerators are the six Sarrus terms with exactly one factor in each replaced by the corresponding bᵢ; reading them off is the explicit content of Cramer's rule for three equations in three unknowns.",
+      "Each numerator det(Aᵢ), expanded along the replaced column i, is a signed combination of the bⱼ whose coefficients are exactly the (j,i) cofactors of A — so the closed forms are (adj(A)·b)ᵢ / det A. This makes the leaf the concrete face of the root entry cramers-rule (x = adj(A) b / det A): the alternating signs in b₀a₁₁ − a₀₁b₁ and in the six 3×3 terms are the cofactor signs (−1)^{i+j}, not an artifact of det_fin_two/three's term order."
     ],
     "prerequisites": [
       "The parent's cramer_solution: xᵢ = det(Aᵢ)/det A over a field with det A ≠ 0",


### PR DESCRIPTION
Enrichment pass for `cramers-rule-oq-04-oq-01-oq-01-oq-01` (quality 94, passes 0).

The entry was already comprehensive and accurate against the Lean file (5 rich annotations, full sections/mainTheorems/conclusion, 16.5 KB — well under caps). Made one focused, non-inflating addition:

- **New keyInsight** (4→5, still far under the 12 cap): each numerator `det(Aᵢ)`, expanded along the replaced column i, is a signed combination of the bⱼ whose coefficients are exactly the (j,i) cofactors of A — so the closed forms are `(adj(A)·b)ᵢ / det A`. This makes the leaf the concrete face of the root entry `cramers-rule` (x = adj(A) b / det A) and clarifies that the alternating signs are the cofactor signs (−1)^{i+j}, not an artifact of `det_fin_two/three`'s monomial order.

Reinforces the existing crossReference to the adjugate root. meta.json JSON validated; size 17 KB (within 60 KB cap, verified via check-meta-size.ts). No annotations changed.