### PR TITLE
Enrich 'The n-th Root of a Prime Is Irrational': valuation-vs-descent insight

### DIFF
--- a/src/data/proofs/cube-root-2-irrational-oq-05/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05/meta.json
@@ -73,7 +73,8 @@
       "**One counting argument, two parameters.** Irrationality of p^(1/n) is governed entirely by a single divisibility: n must divide the p-adic valuation of the radicand. Since a prime has valuation 1 at itself, and n ≥ 2 never divides 1, every such root is irrational.",
       "**Subsumes the base entry and Mathlib's square-root lemma.** ∛2 (p = 2, n = 3) is the base gallery entry; √p (n = 2) is `Nat.Prime.irrational_sqrt`. Both are single instances of irrational_rpow_inv_prime.",
       "**rpow makes the radical algebraic.** Writing the n-th root as the real power p^(n⁻¹) turns 'x^n = p' into the exponent identity n⁻¹·n = 1, so the only analytic input is the homomorphism law `Real.rpow_mul` for nonnegative base.",
-      "**Sharpness.** The hypothesis n ≥ 2 is necessary (n = 1 gives p, rational) and primality can be relaxed to 'p is not a perfect n-th power' — the multiplicity argument is exactly the obstruction."
+      "**Sharpness.** The hypothesis n ≥ 2 is necessary (n = 1 gives p, rational) and primality can be relaxed to 'p is not a perfect n-th power' — the multiplicity argument is exactly the obstruction.",
+      "**Valuation beats descent.** The classical √2 proof runs an even/odd infinite descent (2 ∣ a² ⟹ 2 ∣ a), which is awkward to iterate for cube and higher roots. Replacing parity by the full p-adic valuation vₚ turns the argument into a single divisibility count that is uniform in both p and n — this is precisely why one lemma (irrational_nrt_of_n_not_dvd_multiplicity) discharges the entire family rather than one root at a time."
     ],
     "prerequisites": [
       "p-adic multiplicity / valuation and unique factorization (multiplicity, multiplicity_self)",


### PR DESCRIPTION
Enrichment pass for `cube-root-2-irrational-oq-05` (quality 94, passes 0).

The entry was already comprehensive and accurate against the Lean file (5 rich annotations, full sections/mainTheorems/conclusion, 12 KB). One focused, non-inflating addition:

- **New keyInsight** (4→5, under the 12 cap): contrasts the classical even/odd infinite-descent proof of √2 (2∣a² ⟹ 2∣a, awkward to iterate for higher roots) with the p-adic valuation argument used here. Replacing parity by the full valuation vₚ makes the obstruction a single divisibility count uniform in both p and n, which is exactly why one Mathlib lemma (`irrational_nrt_of_n_not_dvd_multiplicity`) discharges the entire family instead of one root at a time. Reinforces the existing 'Cardinal-free p-adic multiplicity' framing in the description.

meta.json JSON validated; size 12.5 KB (within 60 KB cap, verified via check-meta-size.ts). No annotations changed.