### PR TITLE
research(erdos-490): eliminate Chebyshev θ-gap axiom → theorem (axiomCount 2→1) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos490Chebyshev.lean
+++ b/proofs/Proofs/Erdos490Chebyshev.lean
@@ -202,5 +202,56 @@ theorem theta_gap_lower_bound (n : ℕ) (hn : 4 ≤ n) :
     Real.log_pow, Real.log_pow] at hlog
   linarith [hlog]
 
+open Real Filter Asymptotics in
+/-- **Analytic tail (0 axioms, 0 sorries).** The elementary lower bound supplied by
+`theta_gap_lower_bound` eventually dominates a positive multiple of `n`:
+`(n/3)·log 4 − log n − √(2n)·log(2n) ≥ (log 4 / 6)·n` for all large `n`, because both
+`log n` and `√(2n)·log(2n)` are `o(n)` (`Real.isLittleO_log_id_atTop` and
+`isLittleO_log_rpow_atTop` with exponent `1/2`).  This is the single remaining analytic
+input needed to turn the axiom `chebyshev_theta_upper_half_lower_bound` in
+`Erdos490Problem.lean` into a theorem.  Stated with the *real* `√` and `2n/3`; the nat
+floor `⌊2n/3⌋` and `Nat.sqrt (2n)` of `theta_gap_lower_bound` only make its RHS larger, so
+this real bound lower-bounds it directly. -/
+theorem erdos490_analytic_tail :
+    ∃ c : ℝ, 0 < c ∧ ∃ N₀ : ℕ, ∀ n : ℕ, N₀ ≤ n →
+      c * (n : ℝ) ≤ (n : ℝ) * Real.log 4 - (2 * (n : ℝ) / 3) * Real.log 4
+        - Real.log (n : ℝ) - Real.sqrt (2 * (n : ℝ)) * Real.log (2 * (n : ℝ)) := by
+  have hL : (0 : ℝ) < Real.log 4 := Real.log_pos (by norm_num)
+  -- `log n = o(n)`: eventually `log x ≤ (log 4 / 12)·x`.
+  have hE1 : ∀ᶠ x : ℝ in atTop, Real.log x ≤ (Real.log 4 / 12) * x := by
+    have h := (isLittleO_iff.mp Real.isLittleO_log_id_atTop)
+      (show (0 : ℝ) < Real.log 4 / 12 by positivity)
+    filter_upwards [h, Filter.eventually_ge_atTop (1 : ℝ)] with x hx hx1
+    have hlog : (0 : ℝ) ≤ Real.log x := Real.log_nonneg hx1
+    have hx0 : (0 : ℝ) ≤ x := by linarith
+    simpa [id_eq, Real.norm_of_nonneg hlog, Real.norm_of_nonneg hx0] using hx
+  -- `√x·log x = o(x)`: eventually `√x · log x ≤ (log 4 / 24)·x`.
+  have hE2 : ∀ᶠ x : ℝ in atTop, Real.sqrt x * Real.log x ≤ (Real.log 4 / 24) * x := by
+    have hlo : (Real.log) =o[atTop] (fun x : ℝ => x ^ (1 / 2 : ℝ)) :=
+      isLittleO_log_rpow_atTop (by norm_num)
+    have h := (isLittleO_iff.mp hlo) (show (0 : ℝ) < Real.log 4 / 24 by positivity)
+    filter_upwards [h, Filter.eventually_ge_atTop (1 : ℝ)] with x hx hx1
+    have hx0 : (0 : ℝ) ≤ x := by linarith
+    have hlog : (0 : ℝ) ≤ Real.log x := Real.log_nonneg hx1
+    have hrp : (0 : ℝ) ≤ x ^ (1 / 2 : ℝ) := Real.rpow_nonneg hx0 _
+    rw [Real.norm_of_nonneg hlog, Real.norm_of_nonneg hrp] at hx
+    have hsqrt : Real.sqrt x = x ^ (1 / 2 : ℝ) := Real.sqrt_eq_rpow x
+    calc Real.sqrt x * Real.log x
+        ≤ Real.sqrt x * ((Real.log 4 / 24) * x ^ (1 / 2 : ℝ)) :=
+          mul_le_mul_of_nonneg_left hx (Real.sqrt_nonneg x)
+      _ = (Real.log 4 / 24) * (Real.sqrt x * x ^ (1 / 2 : ℝ)) := by ring
+      _ = (Real.log 4 / 24) * x := by rw [← hsqrt, Real.mul_self_sqrt hx0]
+  obtain ⟨X1, hX1⟩ := Filter.eventually_atTop.mp hE1
+  obtain ⟨X2, hX2⟩ := Filter.eventually_atTop.mp hE2
+  refine ⟨Real.log 4 / 6, by positivity, ⌈max X1 X2⌉₊, ?_⟩
+  intro n hn
+  have hnR : max X1 X2 ≤ (n : ℝ) := le_trans (Nat.le_ceil _) (by exact_mod_cast hn)
+  have hn1 : X1 ≤ (n : ℝ) := le_trans (le_max_left _ _) hnR
+  have hn2 : X2 ≤ 2 * (n : ℝ) := by
+    have := le_trans (le_max_right _ _) hnR; linarith
+  have e1 := hX1 (n : ℝ) hn1
+  have e2 := hX2 (2 * (n : ℝ)) hn2
+  nlinarith [e1, e2, hL]
+
 end Erdos490Cheb
 

--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -34,6 +34,7 @@ import Mathlib.NumberTheory.Primorial
 import Mathlib.NumberTheory.PrimeCounting
 import Mathlib.NumberTheory.Bertrand
 import Mathlib.NumberTheory.Chebyshev
+import Proofs.Erdos490Chebyshev
 
 open Finset Real
 open scoped Classical
@@ -176,21 +177,14 @@ theorem optimalA_card (N : ℕ) : (optimalA N).card = N / 2 := by
       exact ⟨by omega, h1, h2⟩
   rw [hset, Nat.card_Icc]; omega
 
-/-- **Chebyshev θ-gap lower bound** (the one irreducible analytic input, now stated
-against Mathlib's `Chebyshev.theta`).  Here `θ x = ∑_{p ≤ x} log p` is the first
-Chebyshev function.  The half-open interval `(N/2, N]` contributes at least a positive
-constant fraction of `N` to `θ`: `θ(N) − θ(N/2) ≳ N`.  This is the classical
-Chebyshev-strength lower bound `θ(N) − θ(N/2) ≥ c·N`, whose elementary proof runs
-through the central binomial coefficient (Erdős's proof of Bertrand's postulate gives
-exactly this `(2n/3, 2n]` product estimate).  Mathlib's `Mathlib.NumberTheory.Chebyshev`
-currently supplies only the *upper* bounds `theta_le_log4_mul_x` and `psi_le_const_mul_self`
-— it has **no** lower bound on `θ`, `ψ`, or `Nat.primeCounting` — so we isolate exactly
-this Chebyshev θ-gap as the single explicit analytic axiom.  Everything downstream (the
-bespoke prime-counting bound `primes_upper_half_lower_bound`, and hence `bound_is_optimal`)
-is then *fully verified* from it via the `θ → π` bridge below. -/
-axiom chebyshev_theta_upper_half_lower_bound :
-    ∃ c : ℝ, c > 0 ∧ ∀ N : ℕ, N ≥ 4 →
-      c * N ≤ Chebyshev.theta (N : ℝ) - Chebyshev.theta ((N / 2 : ℕ) : ℝ)
+/- The Chebyshev θ-gap lower bound `θ(N) − θ(N/2) ≥ c·N` was formerly an axiom here.
+   It is now a **theorem** (`chebyshev_theta_upper_half_lower_bound`, 0 axioms), proved
+   below immediately after `theta_gap_eq_sum_optimalB`, by combining the elementary
+   central-binomial estimate `Erdos490Cheb.theta_gap_lower_bound` with the analytic-tail
+   lemma `Erdos490Cheb.erdos490_analytic_tail` (`log n`, `√(2n)·log(2n) = o(n)`), plus a
+   Bertrand-based positive lower bound `θ(N) − θ(N/2) ≥ log 2` for the finitely many small
+   `N`.  This eliminates the last analytic axiom of the *lower*-bound half of #490 (only
+   `szemeredi_theorem`, the deep `N²/log N` *upper* bound, remains axiomatized). -/
 
 /-- **θ-gap as a sum over the optimal `B` (0-axiom).** The primes counted by
 `Chebyshev.theta N − Chebyshev.theta (N/2)` are exactly the primes in `(N/2, N]`, i.e. the
@@ -224,6 +218,129 @@ theorem theta_gap_eq_sum_optimalB (N : ℕ) :
     · rintro ⟨_, hpr, hlt, hle⟩
       exact ⟨⟨⟨hpr.pos, hle⟩, hpr⟩, by rintro ⟨⟨_, h2⟩, _⟩; omega⟩
   rw [e1, e2, ← hset, Finset.sum_sdiff_eq_sub hsub]
+
+/-- **Qualitative lower bound (0-axiom, via Bertrand's postulate).** For every `N ≥ 2`
+the half-open interval `(N/2, N]` contains a prime, so the optimal `B` is nonempty.
+Proof: apply Bertrand's postulate `Nat.exists_prime_lt_and_le_two_mul` at `m = ⌊N/2⌋`
+(nonzero since `N ≥ 2`) to get a prime `p` with `N/2 < p ≤ 2·⌊N/2⌋ ≤ N`. -/
+theorem optimalB_nonempty {N : ℕ} (hN : 2 ≤ N) : (optimalB N).Nonempty := by
+  have hm : N / 2 ≠ 0 := by omega
+  obtain ⟨p, hp, hlt, hle⟩ := Nat.exists_prime_lt_and_le_two_mul (N / 2) hm
+  refine ⟨p, ?_⟩
+  have hpN : p ≤ N := by omega
+  simp only [optimalB, Finset.mem_filter, Finset.mem_range]
+  exact ⟨by omega, hp, hlt, hpN⟩
+
+/-- The optimal `B` has at least one element for `N ≥ 2` (0-axiom, via Bertrand). -/
+theorem optimalB_card_pos {N : ℕ} (hN : 2 ≤ N) : 0 < (optimalB N).card :=
+  Finset.card_pos.mpr (optimalB_nonempty hN)
+
+/-- **Chebyshev θ-gap lower bound (0 axioms, 0 sorries).** `∃ c > 0, ∀ N ≥ 4,
+`c·N ≤ θ(N) − θ(N/2)`.  This is the classical Chebyshev-strength lower bound, now fully
+verified — formerly the analytic axiom `chebyshev_theta_upper_half_lower_bound`.
+
+The proof assembles three verified ingredients:
+* `Erdos490Cheb.theta_gap_lower_bound`: the elementary central-binomial estimate
+  `n·log 4 − ⌊2n/3⌋·log 4 − log n − √(2n)·log(2n) ≤ θ(2n) − θ(n)` (Erdős's Bertrand proof);
+* `Erdos490Cheb.erdos490_analytic_tail`: `∃ c₀ > 0, ∃ N₀, ∀ n ≥ N₀`, the real form of that
+  RHS is `≥ c₀·n` (because `log n` and `√(2n)·log(2n)` are `o(n)`);
+* `optimalB_nonempty` (Bertrand): `θ(N) − θ(N/2) ≥ log 2 > 0` for every `N ≥ 2`, covering
+  the finitely many `N` below the asymptotic threshold `N₁ = 2·max(N₀, 4)`.
+
+Alignment `N ↦ n = ⌊N/2⌋` uses `Chebyshev.theta_mono` (`2⌊N/2⌋ ≤ N`) and `N ≤ 3⌊N/2⌋`. -/
+theorem chebyshev_theta_upper_half_lower_bound :
+    ∃ c : ℝ, c > 0 ∧ ∀ N : ℕ, N ≥ 4 →
+      c * N ≤ Chebyshev.theta (N : ℝ) - Chebyshev.theta ((N / 2 : ℕ) : ℝ) := by
+  obtain ⟨c₀, hc₀, N₀, htail⟩ := Erdos490Cheb.erdos490_analytic_tail
+  set M : ℕ := max N₀ 4 with hMdef
+  set N₁ : ℕ := 2 * M with hN₁def
+  have hM4 : 4 ≤ M := le_max_right N₀ 4
+  have hMN0 : N₀ ≤ M := le_max_left N₀ 4
+  have hMpos : 0 < M := by omega
+  have hN₁pos : 0 < N₁ := by omega
+  -- Uniform positive lower bound: `log 2 ≤ θ(N) − θ(N/2)` for `N ≥ 2`.
+  have hgap2 : ∀ N : ℕ, 2 ≤ N →
+      Real.log 2 ≤ Chebyshev.theta (N : ℝ) - Chebyshev.theta ((N / 2 : ℕ) : ℝ) := by
+    intro N hN
+    rw [theta_gap_eq_sum_optimalB N]
+    obtain ⟨p₀, hp₀⟩ := optimalB_nonempty hN
+    have hp₀mem := hp₀
+    simp only [optimalB, Finset.mem_filter, Finset.mem_range] at hp₀mem
+    have hp₀prime : Nat.Prime p₀ := hp₀mem.2.1
+    have hp₀2 : (2 : ℝ) ≤ (p₀ : ℝ) := by exact_mod_cast hp₀prime.two_le
+    have hp₀pos : (0 : ℝ) < (p₀ : ℝ) := by exact_mod_cast hp₀prime.pos
+    have hnn : ∀ p ∈ optimalB N, 0 ≤ Real.log (p : ℝ) := by
+      intro p hp
+      simp only [optimalB, Finset.mem_filter, Finset.mem_range] at hp
+      exact Real.log_nonneg (by exact_mod_cast hp.2.1.one_lt.le)
+    calc Real.log 2 ≤ Real.log (p₀ : ℝ) :=
+          (Real.log_le_log_iff (by norm_num) hp₀pos).mpr hp₀2
+      _ ≤ ∑ p ∈ optimalB N, Real.log (p : ℝ) := Finset.single_le_sum hnn hp₀
+  -- Large branch: for `n ≥ M`, `c₀·n ≤ θ(2n) − θ(n)`.
+  have hlarge : ∀ n : ℕ, M ≤ n →
+      c₀ * (n : ℝ) ≤ Chebyshev.theta ((2 * n : ℕ) : ℝ) - Chebyshev.theta ((n : ℕ) : ℝ) := by
+    intro n hnM
+    have hn4 : 4 ≤ n := le_trans hM4 hnM
+    have hnN0 : N₀ ≤ n := le_trans hMN0 hnM
+    have ht := Erdos490Cheb.theta_gap_lower_bound n hn4
+    have ha := htail n hnN0
+    have hL : (0 : ℝ) < Real.log 4 := Real.log_pos (by norm_num)
+    have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast (by omega : 1 ≤ n)
+    -- Nat floor / Nat.sqrt only make the elementary RHS larger than its real form.
+    have hfloor : ((2 * n / 3 : ℕ) : ℝ) ≤ 2 * (n : ℝ) / 3 := by
+      calc ((2 * n / 3 : ℕ) : ℝ) ≤ ((2 * n : ℕ) : ℝ) / ((3 : ℕ) : ℝ) := Nat.cast_div_le
+        _ = 2 * (n : ℝ) / 3 := by push_cast; ring
+    have hsqrt : (Nat.sqrt (2 * n) : ℝ) ≤ Real.sqrt (2 * (n : ℝ)) := by
+      rw [show (2 * (n : ℝ)) = ((2 * n : ℕ) : ℝ) by push_cast; ring]
+      exact Real.nat_sqrt_le_real_sqrt
+    have hlog2n : 0 ≤ Real.log (2 * (n : ℝ)) := Real.log_nonneg (by linarith)
+    have h1 : ((2 * n / 3 : ℕ) : ℝ) * Real.log 4 ≤ (2 * (n : ℝ) / 3) * Real.log 4 :=
+      mul_le_mul_of_nonneg_right hfloor hL.le
+    have h2 : (Nat.sqrt (2 * n) : ℝ) * Real.log (2 * (n : ℝ))
+        ≤ Real.sqrt (2 * (n : ℝ)) * Real.log (2 * (n : ℝ)) :=
+      mul_le_mul_of_nonneg_right hsqrt hlog2n
+    linarith [ha, ht, h1, h2]
+  refine ⟨min (c₀ / 3) (Real.log 2 / N₁), ?_, ?_⟩
+  · have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+    have hN₁R : (0 : ℝ) < (N₁ : ℝ) := by exact_mod_cast hN₁pos
+    exact lt_min (div_pos hc₀ (by norm_num)) (div_pos hlog2 hN₁R)
+  · intro N hN
+    rcases lt_or_ge N N₁ with hsmall | hbig
+    · -- Small `N` (`4 ≤ N < N₁`): the uniform gap `≥ log 2` and `c ≤ log 2 / N₁ ≤ log 2 / N`.
+      have hgap := hgap2 N (by omega)
+      have hNpos : (0 : ℝ) < (N : ℝ) := by exact_mod_cast (by omega : 0 < N)
+      have hNle : (N : ℝ) ≤ (N₁ : ℝ) := by exact_mod_cast hsmall.le
+      have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+      have hN₁R : (0 : ℝ) < (N₁ : ℝ) := by exact_mod_cast hN₁pos
+      have hcmin : min (c₀ / 3) (Real.log 2 / N₁) ≤ Real.log 2 / N₁ := min_le_right _ _
+      have hle : (Real.log 2 / N₁) * (N : ℝ) ≤ Real.log 2 := by
+        rw [div_mul_eq_mul_div, div_le_iff₀ hN₁R]
+        exact mul_le_mul_of_nonneg_left hNle hlog2.le
+      have hstep : min (c₀ / 3) (Real.log 2 / N₁) * (N : ℝ) ≤ Real.log 2 :=
+        le_trans (mul_le_mul_of_nonneg_right hcmin hNpos.le) hle
+      linarith [hgap, hstep]
+    · -- Large `N` (`N ≥ N₁ = 2M`): set `n = ⌊N/2⌋ ≥ M`, align via `θ` monotone.
+      have hnM : M ≤ N / 2 := by omega
+      have hbranch := hlarge (N / 2) hnM
+      have h2le : (2 * (N / 2) : ℕ) ≤ N := by omega
+      have hmono : Chebyshev.theta ((2 * (N / 2) : ℕ) : ℝ) ≤ Chebyshev.theta (N : ℝ) :=
+        Chebyshev.theta_mono (by exact_mod_cast h2le)
+      have hN3 : (N : ℝ) ≤ 3 * ((N / 2 : ℕ) : ℝ) := by
+        have : N ≤ 3 * (N / 2) := by omega
+        exact_mod_cast this
+      have hcmin : min (c₀ / 3) (Real.log 2 / N₁) ≤ c₀ / 3 := min_le_left _ _
+      have hcN : min (c₀ / 3) (Real.log 2 / N₁) * (N : ℝ) ≤ (c₀ / 3) * (N : ℝ) :=
+        mul_le_mul_of_nonneg_right hcmin (by positivity)
+      have hstep2 : (c₀ / 3) * (N : ℝ) ≤ c₀ * ((N / 2 : ℕ) : ℝ) := by
+        have hmul := mul_le_mul_of_nonneg_left hN3 (le_of_lt (div_pos hc₀ (by norm_num : (0:ℝ) < 3)))
+        calc (c₀ / 3) * (N : ℝ) ≤ (c₀ / 3) * (3 * ((N / 2 : ℕ) : ℝ)) := hmul
+          _ = c₀ * ((N / 2 : ℕ) : ℝ) := by ring
+      calc min (c₀ / 3) (Real.log 2 / N₁) * (N : ℝ)
+          ≤ (c₀ / 3) * (N : ℝ) := hcN
+        _ ≤ c₀ * ((N / 2 : ℕ) : ℝ) := hstep2
+        _ ≤ Chebyshev.theta ((2 * (N / 2) : ℕ) : ℝ) - Chebyshev.theta ((N / 2 : ℕ) : ℝ) :=
+            hbranch
+        _ ≤ Chebyshev.theta (N : ℝ) - Chebyshev.theta ((N / 2 : ℕ) : ℝ) := by linarith [hmono]
 
 /-- **θ → π bridge (0-axiom).** Since every prime `p` counted in the θ-gap satisfies
 `p ≤ N`, each `log p ≤ log N`, so the θ-gap is bounded by `|optimalB N| · log N`.  Dividing
@@ -296,25 +413,6 @@ theorem optimalB_card_eq_primeCounting (N : ℕ) :
   rw [Finset.filter_filter, Finset.filter_filter, ← hB, hlow] at hpart
   rw [hπ N, hπ (N / 2)]
   omega
-
-/-- **Qualitative lower bound (0-axiom, via Bertrand's postulate).** For every `N ≥ 2`
-the half-open interval `(N/2, N]` contains a prime, so the optimal `B` is nonempty.
-Proof: apply Bertrand's postulate `Nat.exists_prime_lt_and_le_two_mul` at `m = ⌊N/2⌋`
-(nonzero since `N ≥ 2`) to get a prime `p` with `N/2 < p ≤ 2·⌊N/2⌋ ≤ N`.
-This discharges the *qualitative* content of `primes_upper_half_lower_bound` (there is at
-least one prime in the upper half) from a genuine Mathlib theorem; what the axiom still
-asserts is purely the *quantitative growth rate* `c · N / log N`. -/
-theorem optimalB_nonempty {N : ℕ} (hN : 2 ≤ N) : (optimalB N).Nonempty := by
-  have hm : N / 2 ≠ 0 := by omega
-  obtain ⟨p, hp, hlt, hle⟩ := Nat.exists_prime_lt_and_le_two_mul (N / 2) hm
-  refine ⟨p, ?_⟩
-  have hpN : p ≤ N := by omega
-  simp only [optimalB, Finset.mem_filter, Finset.mem_range]
-  exact ⟨by omega, hp, hlt, hpN⟩
-
-/-- The optimal `B` has at least one element for `N ≥ 2` (0-axiom, via Bertrand). -/
-theorem optimalB_card_pos {N : ℕ} (hN : 2 ≤ N) : 0 < (optimalB N).card :=
-  Finset.card_pos.mpr (optimalB_nonempty hN)
 
 /-- **Strict prime-counting gap (0-axiom).** For `N ≥ 2`, `π(N/2) < π(N)`: the upper
 half `(N/2, N]` always contributes at least one new prime. This is the qualitative

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -420,3 +420,26 @@ the classical Erdős central-binomial argument (~150–300 LOC of analytic NT), 
 genuine multi-session formalization — not a quick axiom elimination. The author's
 in-file docstring correctly frames it as "the one irreducible analytic input."
 Left axiomatized; the problem's completion task (the 6 original sorries) is done.
+
+## Session 2026-07-08 (researcher-2) — AXIOM ELIMINATED (chebyshev θ-gap → theorem, 2→1 axioms)
+**Result**: `chebyshev_theta_upper_half_lower_bound` is now a **theorem** (0-axiom), not an axiom.
+`Erdos490Problem.lean` → 1 axiom (only `szemeredi_theorem`), 0 sorries. Docker build green (7744 jobs).
+
+**How** (the crux the prior sessions isolated, now verified):
+- New lemma `Erdos490Cheb.erdos490_analytic_tail` (added to `Erdos490Chebyshev.lean`, 0-axiom):
+  `∃c>0,∃N₀,∀n≥N₀: c·n ≤ (n/3)·log4 − log n − √(2n)·log(2n)`. Proof: `log n = o(n)` via
+  `Real.isLittleO_log_id_atTop`; `√(2n)·log(2n) = o(n)` via `isLittleO_log_rpow_atTop (r=1/2)` +
+  `Real.sqrt_eq_rpow` (log x ≤ ε√x ⟹ √x·log x ≤ ε·x); extract N₀ from `Filter.eventually_atTop`,
+  final `nlinarith`. Built green first try.
+- Wiring in `Erdos490Problem.lean`: chain `c₀·n ≤ realRHS ≤ natRHS ≤ θ(2n)−θ(n)` where the nat
+  floor `⌊2n/3⌋ ≤ 2n/3` (`Nat.cast_div_le`) and `Nat.sqrt(2n) ≤ √(2n)` (`Real.nat_sqrt_le_real_sqrt`)
+  only enlarge the elementary RHS. Alignment N↦n=⌊N/2⌋ via `Chebyshev.theta_mono` (2⌊N/2⌋≤N) and
+  N≤3⌊N/2⌋. Small N (4≤N<N₁=2·max(N₀,4)): uniform `θ(N)−θ(N/2) ≥ log 2 > 0` from `optimalB_nonempty`
+  (Bertrand) + `theta_gap_eq_sum_optimalB`, so `c_small = log2/N₁` works — NO finite-min needed.
+  Final `c = min (c₀/3) (log2/N₁)`.
+- **Reorg**: moved `optimalB_nonempty`/`optimalB_card_pos` above the new theorem (the axiom was
+  consumed at `primes_upper_half_lower_bound` before those lemmas were defined).
+
+**Still open**: `szemeredi_theorem` (N²/log N upper bound) — the deep result, stays axiomatized.
+**Infra**: exit-135 volume corruption (#35184) hit 5/7 builds; the Problem file needed ~5 retries to
+go green. Line-less 135 = infra, RETRY (crux + wiring both correct once a clean run landed).

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -63,14 +63,14 @@
       "optimal_works_because_primes: divisibility argument (proved)",
       "optimalA_card: |optimalA N| = ⌊N/2⌋ (0-axiom, proved)",
       "optimalB_card_eq_primeCounting: |optimalB N| = π(N) − π(N/2) via Mathlib's Nat.primeCounting (0-axiom, proved) — pins the Chebyshev axiom to Mathlib's prime-counting API",
-      "chebyshev_theta_upper_half_lower_bound axiom: the Chebyshev θ-gap lower bound θ(N)−θ(N/2) ≥ c·N, stated against Mathlib's Chebyshev.theta (the classical first Chebyshev function) — replaces the former bespoke primes_upper_half_lower_bound axiom",
+      "chebyshev_theta_upper_half_lower_bound: NOW A THEOREM (0 axioms, 0 sorries) — the classical Chebyshev θ-gap lower bound θ(N)−θ(N/2) ≥ c·N, formerly an axiom, is fully proved by combining the central-binomial estimate theta_gap_lower_bound with the analytic tail erdos490_analytic_tail (√n·log n = o(n)) and a Bertrand small-N base case. This eliminates the last analytic axiom of the lower-bound half of #490.",
       "primes_upper_half_lower_bound: NOW A THEOREM (0 new axioms) — the prime-counting lower bound π(N)−π(N/2) ≳ N/log N is DERIVED from the Chebyshev θ-gap axiom via the verified θ→π bridge",
       "theta_gap_eq_sum_optimalB: θ(N)−θ(N/2) = ∑_{p∈optimalB N} log p (0-axiom) — re-expresses Mathlib's Chebyshev θ-difference as a sum over the optimal example, via Finset.sum_sdiff_eq_sub on the prime-filtered Ioc intervals",
       "theta_gap_le_card_mul_log: θ(N)−θ(N/2) ≤ |optimalB N|·log N (0-axiom) — each prime p ≤ N has log p ≤ log N, so the θ-gap is bounded by the count times log N; dividing by log N is the θ→π bridge",
       "productRatio, LimitQuestion: open limit formalization",
       "IsMultiplicativeSidon: A = B special case",
       "multiplicativeEnergy: counting quadruples a₁b₁ = a₂b₂",
-      "bound_is_optimal: matching lower bound (proved from the 2 axioms, 0 sorries)",
+      "bound_is_optimal: matching lower bound (proved from the 1 remaining axiom (Szemerédi), 0 sorries)",
       "optimal_has_distinct_products: PROVED 0-axiom (formerly an axiom) — the optimal construction A=[1,N/2], B=primes in (N/2,N] has distinct products, derived from optimal_works_because_primes via the ProductMapInjective↔HasDistinctProducts bridge",
       "hasDistinctProducts_iff_injOn: HasDistinctProducts A B ↔ injectivity of (a,b)↦a·b on A×ˢB (via Finset.card_image_iff)",
       "productMapInjective_iff_hasDistinctProducts: the two distinctness notions agree",
@@ -78,12 +78,13 @@
       "optimalB_nonempty: for N ≥ 2 the interval (N/2,N] contains a prime (0-axiom, via Mathlib's Bertrand postulate Nat.exists_prime_lt_and_le_two_mul) — discharges the qualitative content of the Chebyshev axiom",
       "optimalB_card_pos: |optimalB N| ≥ 1 for N ≥ 2 (0-axiom, via Bertrand)",
       "primeCounting_half_lt: π(N/2) < π(N) for N ≥ 2 (0-axiom) — the strict prime-counting gap, combining optimalB_card_pos with optimalB_card_eq_primeCounting",
-      "Erdos490Chebyshev.lean (NEW, standalone, 0-axiom/0-sorry): verified central-binomial decomposition centralBinom_le_small_mul_large (centralBinom n ≤ (2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n}p, the combinatorial crux of Chebyshev's θ lower bound — Mathlib's own stated TODO), plus theta_gap_lower_bound reducing θ(2n)−θ(n) to the elementary explicit lower bound n·log4 − ⌊2n/3⌋·log4 − log n − √(2n)·log(2n). Reduces (does NOT yet eliminate) the axiom chebyshev_theta_upper_half_lower_bound to the analytic tail √n·log n = o(n) + small-n Bertrand reconciliation."
+      "Erdos490Chebyshev.lean (NEW, standalone, 0-axiom/0-sorry): verified central-binomial decomposition centralBinom_le_small_mul_large (centralBinom n ≤ (2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n}p, the combinatorial crux of Chebyshev's θ lower bound — Mathlib's own stated TODO), plus theta_gap_lower_bound reducing θ(2n)−θ(n) to the elementary explicit lower bound n·log4 − ⌊2n/3⌋·log4 − log n − √(2n)·log(2n). Reduces (does NOT yet eliminate) the axiom chebyshev_theta_upper_half_lower_bound to the analytic tail √n·log n = o(n) + small-n Bertrand reconciliation.",
+      "erdos490_analytic_tail (in Erdos490Chebyshev.lean, 0-axiom): ∃c>0,∃N₀,∀n≥N₀, the elementary θ-gap lower bound (n/3)·log4 − log n − √(2n)·log(2n) ≥ c·n, proved from Real.isLittleO_log_id_atTop and isLittleO_log_rpow_atTop (exponent 1/2). This is the single analytic input that converted the Chebyshev θ-gap axiom into a theorem."
     ],
-    "axiomCount": 2,
-    "lineCount": 660,
-    "assumptions": "2 axioms, 0 sorries. Axioms: szemeredi_theorem (Szemerédi 1976 upper bound, deep); chebyshev_theta_upper_half_lower_bound (the classical Chebyshev θ-gap lower bound θ(N)−θ(N/2) ≥ c·N, stated directly against Mathlib's Chebyshev.theta; Mathlib's Mathlib.NumberTheory.Chebyshev currently supplies only UPPER bounds theta_le_log4_mul_x / psi_le_const_mul_self and no lower bound on θ, ψ, or Nat.primeCounting, so this single θ-gap fact is isolated as the analytic axiom). The former bespoke axiom primes_upper_half_lower_bound is NOW A THEOREM (0 new axioms): it is derived from the Chebyshev θ-gap axiom through the fully-verified θ→π bridge theta_gap_eq_sum_optimalB (θ(N)−θ(N/2) = ∑_{p∈optimalB N} log p) and theta_gap_le_card_mul_log (θ(N)−θ(N/2) ≤ |optimalB N|·log N, since each prime p ≤ N has log p ≤ log N); dividing by log N yields π(N)−π(N/2) ≥ c·N/log N. The former axiom optimal_has_distinct_products was eliminated (proved 0-axiom via the ProductMapInjective↔HasDistinctProducts bridge). Progression: researcher-8 (2026-06-28) repaired the build against the current Mathlib pin and eliminated 4 sorries with 0-axiom proofs (optimal_works_because_primes, the two IsSubsetUpTo subgoals, primes_products_determine_pair). researcher-3 (2026-06-28) then proved distinct_minimal_energy (HasDistinctProducts ↔ multiplicative energy = |A||B|) 0-axiom via the diagonal-subset argument, and in a follow-up session eliminated the last sorry: proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound from the isolated Chebyshev axiom (note: the previously hardcoded constant 1/3 was false at small N, e.g. N=10 where the product ratio dips to ≈0.115, so the theorem is now in its honest ∃c>0 form). researcher-5 (2026-07-04) discharged the qualitative half of primes_upper_half_lower_bound: optimalB_nonempty / optimalB_card_pos prove (via Mathlib's Bertrand postulate) that (N/2,N] always contains a prime for N ≥ 2, and primeCounting_half_lt derives the strict gap π(N/2) < π(N); the axiom now asserts purely the quantitative growth rate c·N/log N. researcher-9 (2026-07-07) restated that quantitative axiom against Mathlib's Chebyshev.theta as chebyshev_theta_upper_half_lower_bound (θ(N)−θ(N/2) ≥ c·N) and DERIVED the former primes_upper_half_lower_bound axiom as a theorem via the verified θ→π bridge (theta_gap_eq_sum_optimalB + theta_gap_le_card_mul_log); axiom count unchanged at 2, but the remaining analytic axiom is now the single standard Chebyshev θ-gap fact rather than a bespoke prime-counting difference, and its eventual elimination is exactly the classical θ(N)−θ(N/2) ≥ c·N lower bound (Erdős's central-binomial argument).",
-    "theoremCount": 22,
+    "axiomCount": 1,
+    "lineCount": 758,
+    "assumptions": "1 axiom, 0 sorries. Axiom: szemeredi_theorem (Szemerédi 1976 N²/log N upper bound, deep — the hard analytic input of the problem). The former second axiom chebyshev_theta_upper_half_lower_bound (the classical Chebyshev θ-gap lower bound θ(N)−θ(N/2) ≥ c·N) is NOW A THEOREM (0-axiom), proved by combining the verified central-binomial estimate Erdos490Cheb.theta_gap_lower_bound with the analytic tail Erdos490Cheb.erdos490_analytic_tail (log n and √(2n)·log(2n) are o(n)) and a Bertrand-based θ(N)−θ(N/2) ≥ log 2 for the finitely many small N. Only the deep Szemerédi upper bound remains axiomatized; status stays 'axiomatized'.",
+    "theoremCount": 23,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
@@ -185,10 +186,10 @@
     {
       "id": "summary",
       "title": "Summary and Optimality",
-      "summary": "erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 2 axioms, 0 sorries)",
+      "summary": "erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 1 remaining axioms, 0 sorries)",
       "startLine": 228,
       "endLine": 282,
-      "mathContext": "Bound: erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 2 axioms, 0 sorries)"
+      "mathContext": "Bound: erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 1 remaining axiom (Szemerédi), 0 sorries)"
     }
   ],
   "conclusion": {
@@ -216,9 +217,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 660,
-    "axiomCount": 2,
-    "theoremCount": 22,
+    "lineCount": 758,
+    "axiomCount": 1,
+    "theoremCount": 23,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-490-incomplete-01.json
+++ b/src/data/research/problems/erdos-490-incomplete-01.json
@@ -8,7 +8,7 @@
   "significance": 5,
   "tractability": 6,
   "started": "2026-06-28T00:00:00.000Z",
-  "lastUpdate": "2026-06-30T00:00:00.000Z",
+  "lastUpdate": "2026-07-08T00:00:00Z",
   "tags": [
     "number-theory",
     "combinatorics",
@@ -26,8 +26,9 @@
     ]
   },
   "currentState": {
-    "summary": "DONE (build-repair + full sorry elimination + axiom reduction). File builds against Mathlib 4.26 with 0 sorries and 2 axioms (szemeredi_theorem, primes_upper_half_lower_bound). The former axiom optimal_has_distinct_products is now PROVED 0-axiom from optimal_works_because_primes via a ProductMapInjective↔HasDistinctProducts bridge. The two remaining axioms are the deep Szemerédi upper bound and the irreducible Chebyshev prime-counting lower bound absent from the current Mathlib pin.",
-    "outcome": "progress"
+    "summary": "AXIOM ELIMINATED (chebyshev_theta_upper_half_lower_bound → theorem). Erdos490Problem.lean now builds against Mathlib 4.26 with 0 sorries and 1 axiom (szemeredi_theorem, the deep N²/log N upper bound; correctly stays axiomatized). The Chebyshev θ-gap lower bound θ(N)−θ(N/2) ≥ c·N — the last analytic axiom of the lower-bound half — is now fully proved: new lemma Erdos490Cheb.erdos490_analytic_tail (log n, √(2n)·log(2n) = o(n) via Real.isLittleO_log_id_atTop / isLittleO_log_rpow_atTop) supplies the analytic tail; combined with the existing central-binomial estimate theta_gap_lower_bound, a nat↔real bridge, the N↦⌊N/2⌋ alignment (Chebyshev.theta_mono), and a Bertrand-based θ-gap ≥ log 2 small-N base case. Docker build verified green (7744 jobs). Files: Erdos490Problem.lean 660→758 lines, 2→1 axioms; Erdos490Chebyshev.lean 206→257 lines, +erdos490_analytic_tail.",
+    "outcome": "progress",
+    "nextAction": "None from the lower-bound side. The sole remaining axiom szemeredi_theorem (N²/log N upper bound) is the deep result of the problem — out of scope for elimination."
   },
   "knowledge": {
     "insights": [
@@ -93,9 +94,9 @@
     {
       "path": "Proofs/Erdos490Problem.lean",
       "filename": "Erdos490Problem.lean",
-      "lineCount": 557,
-      "theoremCount": 16,
-      "axiomCount": 2,
+      "lineCount": 758,
+      "theoremCount": 23,
+      "axiomCount": 1,
       "defCount": 15,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

Eliminates the analytic axiom **`chebyshev_theta_upper_half_lower_bound`** in `Erdos490Problem.lean` — the classical Chebyshev-strength lower bound `θ(N) − θ(N/2) ≥ c·N`, which was the last analytic input of the *lower-bound* half of Erdős #490. It is now a **fully verified theorem (0 axioms)**. Axiom count for the problem drops **2 → 1** (only the deep Szemerédi `N²/log N` upper bound remains).

This completes the crux that prior sessions isolated but could not build (Aristotle down, infra corrupt).

## What was proved

**New crux lemma** `Erdos490Cheb.erdos490_analytic_tail` (`Erdos490Chebyshev.lean`, 0-axiom):
for all large `n`,
```
(n/3)·log 4 − log n − √(2n)·log(2n) ≥ (log 4 / 6)·n
```
because both `log n` and `√(2n)·log(2n)` are `o(n)` — via `Real.isLittleO_log_id_atTop` and `isLittleO_log_rpow_atTop` (exponent `1/2`) + `Real.sqrt_eq_rpow`.

**Wiring** (`Erdos490Problem.lean`) turns the axiom into a theorem by the chain
```
c₀·n ≤ realRHS ≤ natRHS ≤ θ(2n) − θ(n)
```
where the nat floor `⌊2n/3⌋ ≤ 2n/3` (`Nat.cast_div_le`) and `Nat.sqrt(2n) ≤ √(2n)` (`Real.nat_sqrt_le_real_sqrt`) only enlarge the elementary central-binomial estimate `Erdos490Cheb.theta_gap_lower_bound`. Alignment `N ↦ n = ⌊N/2⌋` uses `Chebyshev.theta_mono` (`2⌊N/2⌋ ≤ N`) and `N ≤ 3⌊N/2⌋`. The finitely many small `N` (`4 ≤ N < 2·max(N₀,4)`) are covered by the uniform Bertrand bound `θ(N) − θ(N/2) ≥ log 2 > 0` (`optimalB_nonempty` + `theta_gap_eq_sum_optimalB`), so `c = min(c₀/3, log 2 / N₁)` works for all `N ≥ 4` with **no finite-min construction**.

## Verification

- `Erdos490Problem.lean`: 660 → 758 lines, **2 → 1 axioms**, 22 → 23 theorems, **0 sorries**.
- `Erdos490Chebyshev.lean`: 206 → 257 lines, +1 theorem, 0 axioms, 0 sorries.
- Docker build verified green: `✔ Built Proofs.Erdos490Problem` (7744 jobs), `✔ Built Proofs.Erdos490Chebyshev` (7743 jobs).
- Status stays `axiomatized` (Szemerédi upper bound remains an axiom); meta counts + assumptions reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)