### PR TITLE
Enrich n-th root of a prime (cube-root-2-irrational-oq-05): cross-refs + honest open questions

### DIFF
--- a/src/data/proofs/cube-root-2-irrational-oq-05/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05/meta.json
@@ -86,22 +86,22 @@
       "id": "header",
       "title": "Module Header and Setup",
       "startLine": 1,
-      "endLine": 36,
+      "endLine": 29,
       "summary": "Module docstring describing the two-parameter generalization of ∛2, the Mathlib import, namespace, and Real open.",
       "mathContext": "$p^{1/n} \\notin \\mathbb{Q}$ for prime $p$ and $n \\geq 2$."
     },
     {
       "id": "main",
       "title": "The n-th Root of a Prime",
-      "startLine": 38,
-      "endLine": 60,
+      "startLine": 31,
+      "endLine": 53,
       "summary": "irrational_rpow_inv_prime: for prime p and n ≥ 2, p^(1/n) is irrational — x^n = p via rpow composition, multiplicity (p:ℤ)(p:ℤ) = 1 not divisible by n.",
       "mathContext": "$\\left(p^{1/n}\\right)^n = p$ and $n \\nmid v_p(p) = 1$."
     },
     {
       "id": "specializations",
       "title": "Cube Roots and Roots of Two",
-      "startLine": 62,
+      "startLine": 55,
       "endLine": 78,
       "summary": "irrational_cbrt_prime (∛p for all primes), irrational_cbrt_two and irrational_cbrt_three (∛2, ∛3), and irrational_rpow_inv_two (every n-th root of 2).",
       "mathContext": "$\\sqrt[3]{p}, \\sqrt[3]{2}, \\sqrt[3]{3}, \\sqrt[n]{2} \\notin \\mathbb{Q}$."
@@ -159,14 +159,40 @@
       "targetId": "cube-root-3-irrational",
       "relationship": "related",
       "description": "∛3 irrational is recovered here as irrational_cbrt_three, an instance of irrational_cbrt_prime"
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "related",
+      "description": "The general 'm not a perfect n-th power ⇒ m^(1/n) irrational' theorem; the prime case proved here is its cleanest witness, since a prime is never a perfect n-th power for n ≥ 2"
+    },
+    {
+      "targetId": "cube-root-2-irrational-oq-05-oq-01",
+      "relationship": "extended-by",
+      "description": "Settles the full two-way criterion m^(1/n) ∈ ℚ ⟺ m is a perfect n-th power, resolving this entry's first open question and completing the rationality direction the prime case only hints at"
+    },
+    {
+      "targetId": "cube-root-2-irrational-oq-05-oq-02",
+      "relationship": "extended-by",
+      "description": "Extends the prime-root family to non-integer rational exponents (p^q irrational for q.den ≥ 2) and proves ∛2 + ∛3 ∉ ℚ, resolving this entry's second open question"
+    },
+    {
+      "targetId": "fourth-root-2-irrational",
+      "relationship": "related",
+      "description": "Sharpens the p = 2, n = 4 instance (an irrational_rpow_inv_two case) from mere irrationality to the exact field degree [ℚ(⁴√2):ℚ] = 4 via Eisenstein irreducibility of X⁴ − 2"
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "The n = 2 archetype: √n irrational for non-square n. The general theorem here reproduces Nat.Prime.irrational_sqrt at n = 2, so √2 is the base-case slice of this two-parameter family"
     }
   ],
   "conclusion": {
     "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization that p^(1/n) is irrational for every prime p and every n ≥ 2, unifying ∛2, ∛p, every n-th root of 2, and (at n = 2) Mathlib's Nat.Prime.irrational_sqrt under a single p-adic-multiplicity argument.",
     "implications": "Closes the natural generalization of the base ∛2 entry. The same multiplicity obstruction shows m^(1/n) is irrational whenever m is not a perfect n-th power, of which the prime case is the cleanest witness.",
     "openQuestions": [
-      "State and prove the full criterion: m^(1/n) is rational iff m is a perfect n-th power (for m, n ≥ 1).",
-      "Extend to sums such as ∛2 + ∛3 and to irrationality of p^(q) for rational non-integer exponents q."
+      "Quantify the irrationality: establish effective Liouville-type lower bounds |p^(1/n) − a/b| ≥ C(p,n)·b^(−n) and determine the exact irrationality measure (Roth predicts 2 for these algebraic numbers).",
+      "Multi-radical independence and degree: are 1, p₁^(1/n), …, p_k^(1/n) linearly independent over ℚ for distinct primes, and is [ℚ(p₁^(1/n), …, p_k^(1/n)) : ℚ] = n^k? (The two-radical case ∛2 + ∛3 ∉ ℚ is settled in oq-05-oq-02.)",
+      "Note: the full rationality criterion (m^(1/n) ∈ ℚ ⟺ m a perfect n-th power) is proved in child entry oq-05-oq-01, and the non-integer rational-exponent case p^q in oq-05-oq-02 — both formerly open here, now resolved in the gallery."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `cube-root-2-irrational-oq-05` (quality 94, passes 0). This entry was already rich (12 KB, all quality minimums met), so this is a curation pass — no inflation. File grew 12.0 → 14.0 KB, well under the 60 KB cap.

## Changes
- **5 accurate cross-references** to genuinely-related gallery entries (crossReferences 2 → 7, cap 20):
  - `nth-root-irrational` — the general 'm not a perfect n-th power ⇒ irrational' theorem; the prime case here is its cleanest witness.
  - `cube-root-2-irrational-oq-05-oq-01` — child entry that **resolves this entry's first open question** (full iff criterion m^(1/n) ∈ ℚ ⟺ perfect n-th power).
  - `cube-root-2-irrational-oq-05-oq-02` — child entry that **resolves the second** (non-integer rational exponents; ∛2 + ∛3 ∉ ℚ).
  - `fourth-root-2-irrational` — sharpens the p=2, n=4 instance to the exact field degree via Eisenstein.
  - `sqrt2-irrational` — the n=2 archetype / Nat.Prime.irrational_sqrt slice.
- **Honest open questions**: the prior two `openQuestions` were *already settled* by the child entries above, so leaving them phrased as open was inaccurate. Replaced with genuinely-open directions (irrationality measure / Liouville–Roth bounds; multi-radical independence and degree) plus an explicit pointer to the in-gallery resolutions.
- **Tightened section line ranges** to align with theorem boundaries (header 1–29, main 31–53, specializations 55–78; previously spilled across docstrings).

## Verification
- JSON validates; `check-meta-size.ts` passes (all within caps).
- `pnpm build` data pipeline (gallery enrichment, search index, loading facts) passes; only the final `tsc` step fails because node_modules is absent in the fresh worktree (known limitation, not a data issue).
- meta.json accuracy re-checked against the Lean source: 0 sorries, 0 axioms, 5 theorems, 78 lines — all consistent.