### PR TITLE
research(erdos-1006-oq-01-oq-01): triangle K₃ admits no robust orientation — concrete girth-3 Nešetřil-Rödl witness [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1006OQ01.lean
+++ b/proofs/Proofs/Erdos1006OQ01.lean
@@ -431,6 +431,71 @@ theorem cover_graph_characterization [Fintype V] :
     letI : DecidableLT V := fun a b => Classical.propDecidable _
     exact cover_graph_admits_robust hP
 
+/-- **Concrete girth-3 non-example** (proved, no axiom): the triangle `K₃`
+    (the complete graph on `Fin 3`) admits *no* robustly acyclic orientation.
+
+    This is the smallest witness of the Nešetřil-Rödl phenomenon
+    (`nesetril_rodl_counterexample` below, at `g = 3`): a triangle is not a
+    cover graph because *every* acyclic orientation of it is transitive.
+    Concretely, the three vertices get pairwise-distinct ranks (adjacent
+    vertices cannot share a rank), so they line up as a source `a`, middle `b`
+    and sink `c` with arcs `a → b`, `b → c`, `a → c`. The arc `a → c` is then
+    *dependent*: the alternate directed path `a → b → c` already connects its
+    endpoints, so reversing `a → c` closes the cycle `c → a → b → c`. Hence no
+    orientation is robust.
+
+    Via `cover_graph_characterization` this reproves directly that the triangle
+    is not the Hasse diagram of any poset. -/
+theorem triangle_not_robust :
+    ¬ admitsRobustAcyclicOrientation (⊤ : SimpleGraph (Fin 3)) := by
+  rintro ⟨O, ⟨rank, hrank⟩, hdep⟩
+  -- Distinct vertices of `Fin 3` are adjacent in the complete graph.
+  have adj : ∀ u v : Fin 3, u ≠ v → (⊤ : SimpleGraph (Fin 3)).Adj u v := by
+    intro u v h; simpa using h
+  -- Each edge is oriented toward the higher rank.
+  have arc_of_lt : ∀ u v : Fin 3, u ≠ v → rank u < rank v → O.arc u v := by
+    intro u v hne hlt
+    rcases O.covers u v (adj u v hne) with h | h
+    · exact h
+    · exact absurd (hrank _ _ h) (by omega)
+  -- Adjacent (hence distinct) vertices get distinct ranks.
+  have rank_ne : ∀ u v : Fin 3, u ≠ v → rank u ≠ rank v := by
+    intro u v hne heq
+    rcases O.covers u v (adj u v hne) with h | h <;>
+      exact absurd (hrank _ _ h) (by omega)
+  -- A transitive triangle `rank a < rank b < rank c` has a dependent arc `a → c`:
+  -- the path `a → b → c` avoids `(a, c)`, so reversing `a → c` closes a cycle.
+  have triangle_dep : ∀ a b c : Fin 3, a ≠ b → b ≠ c → a ≠ c →
+      rank a < rank b → rank b < rank c → O.hasDependentArc := by
+    intro a b c hab hbc hac h1 h2
+    refine ⟨a, c, arc_of_lt a c hac (h1.trans h2), ?_⟩
+    refine Relation.TransGen.tail
+      (Relation.TransGen.single ⟨arc_of_lt a b hab h1, ?_⟩)
+      ⟨arc_of_lt b c hbc h2, ?_⟩
+    · intro h; rw [Prod.mk.injEq] at h; exact hbc h.2
+    · intro h; rw [Prod.mk.injEq] at h; exact hab h.1.symm
+  -- The three ranks are pairwise distinct, so they linearly order the vertices;
+  -- in every ordering we exhibit a transitive triangle and contradict robustness.
+  have d01 := rank_ne 0 1 (by decide)
+  have d02 := rank_ne 0 2 (by decide)
+  have d12 := rank_ne 1 2 (by decide)
+  rcases lt_trichotomy (rank 0) (rank 1) with h01 | h01 | h01
+  · rcases lt_trichotomy (rank 1) (rank 2) with h12 | h12 | h12
+    · exact hdep (triangle_dep 0 1 2 (by decide) (by decide) (by decide) h01 h12)
+    · exact absurd h12 d12
+    · rcases lt_trichotomy (rank 0) (rank 2) with h02 | h02 | h02
+      · exact hdep (triangle_dep 0 2 1 (by decide) (by decide) (by decide) h02 h12)
+      · exact absurd h02 d02
+      · exact hdep (triangle_dep 2 0 1 (by decide) (by decide) (by decide) h02 h01)
+  · exact absurd h01 d01
+  · rcases lt_trichotomy (rank 1) (rank 2) with h12 | h12 | h12
+    · rcases lt_trichotomy (rank 0) (rank 2) with h02 | h02 | h02
+      · exact hdep (triangle_dep 1 0 2 (by decide) (by decide) (by decide) h01 h02)
+      · exact absurd h02 d02
+      · exact hdep (triangle_dep 1 2 0 (by decide) (by decide) (by decide) h12 h02)
+    · exact absurd h12 d12
+    · exact hdep (triangle_dep 2 1 0 (by decide) (by decide) (by decide) h12 h01)
+
 /-- Fisher-Fraughnaugh-Langley-West (1997): If the chromatic number of G
     is less than its girth, then G admits a robustly acyclic orientation. -/
 axiom chromatic_lt_girth_implies_robust [Fintype V]
@@ -460,8 +525,10 @@ axiom nesetril_rodl_counterexample (g : ℕ) (hg : g ≥ 3) :
 7. `cover_graph_characterization` - Robust orientation ↔ cover graph
    (de-axiomatized: forward via the reachability order `reachOrder`,
     reverse via `cover_graph_admits_robust`)
+8. `triangle_not_robust` - The triangle K₃ admits no robustly acyclic
+   orientation (concrete girth-3 witness of Nešetřil-Rödl, no axiom)
 
 ### Axiomatized (deep results):
-8. `chromatic_lt_girth_implies_robust` - χ(G) < girth(G) suffices
-9. `nesetril_rodl_counterexample` - Counterexamples for all girths ≥ 3
+9. `chromatic_lt_girth_implies_robust` - χ(G) < girth(G) suffices
+10. `nesetril_rodl_counterexample` - Counterexamples for all girths ≥ 3
 -/

--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -114,9 +114,9 @@
   },
   "leanFile": {
     "namespace": "Erdos1006OQ01",
-    "lineCount": 467,
+    "lineCount": 534,
     "axiomCount": 2,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 13,
     "path": "Proofs/Erdos1006OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1006-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-01-oq-01.json
@@ -44,14 +44,16 @@
       "reachOrder (Proofs/Erdos1006OQ01.lean): reflexive-transitive closure of an acyclic orientation's arcs as a PartialOrder; antisymmetry from rank-strict-monotonicity.",
       "rank_lt_of_tg / rank_le_of_rtg: rank is strictly/weakly monotone along TransGen/ReflTransGen paths.",
       "lift_below / lift_above: a directed path whose endpoint is rank-below v (resp. start rank-above u) never uses the arc (u,v), so it lifts to the (u,v)-excluded relation — the technical core of 'each arc is a covering pair'.",
-      "cover_graph_characterization is now a theorem (Proofs/Erdos1006OQ01.lean:371): admits robust orientation ↔ isCoverGraph, verified 0 extra axioms."
+      "cover_graph_characterization is now a theorem (Proofs/Erdos1006OQ01.lean:371): admits robust orientation ↔ isCoverGraph, verified 0 extra axioms.",
+      "triangle_not_robust (Proofs/Erdos1006OQ01.lean): the triangle K3 (complete graph on Fin 3) admits no robustly acyclic orientation — concrete girth-3 witness of Nesetril-Rodl, VERIFIED 0 extra axioms. Any acyclic orientation of a triangle is transitive (source->middle->sink), so the source->sink arc is dependent via the middle vertex."
     ],
     "insights": [
       "The slug broad-matches the whole Erdos1006* proof family because the stripped base prefix is Erdos1006.",
       "The main characterization is still represented by an explicit axiom in Erdos1006OQ01.lean.",
       "S1/S2 found a soundness bug: hasDependentArc had its rank inequality backwards (rank v ≤ rank u), making it vacuously false for every acyclic orientation. This collapsed isRobustlyAcyclic to isAcyclic and rendered the cover_graph_characterization and nesetril_rodl_counterexample axioms UNSOUND (false statements).",
       "S3 fix: redefine hasDependentArc via reachability — an arc (u,v) is dependent iff Relation.TransGen of the arc relation (with (u,v) excluded) connects u to v. Reversing the arc then closes a directed cycle v→u⇝v. This is faithful to the textbook meaning and makes all three robustness obligations elementary TransGen inductions (no Szpilrajn/linear-extension machinery).",
-      "With the reachability definition of hasDependentArc, BOTH directions of Pretzel-Brightwell are elementary: forward = take transitive-closure poset, 'no dependent arc' ⇔ 'every arc is a covering pair'; reverse = cover_graph_admits_robust. The literature's 'depth' is in the definition/recognition, not the equivalence under this model."
+      "With the reachability definition of hasDependentArc, BOTH directions of Pretzel-Brightwell are elementary: forward = take transitive-closure poset, 'no dependent arc' ⇔ 'every arc is a covering pair'; reverse = cover_graph_admits_robust. The literature's 'depth' is in the definition/recognition, not the equivalence under this model.",
+      "The g=3 base case of nesetril_rodl_counterexample is elementary and now proved concretely (triangle_not_robust): a triangle is the smallest non-cover-graph. The abstract axiom remains for the deep all-girths construction, but the smallest witness is grounded."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -89,8 +91,8 @@
     {
       "path": "Proofs/Erdos1006OQ01.lean",
       "filename": "Erdos1006OQ01.lean",
-      "lineCount": 468,
-      "theoremCount": 7,
+      "lineCount": 534,
+      "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 13,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds `triangle_not_robust` to `Proofs/Erdos1006OQ01.lean`: **the triangle K₃ (complete graph on `Fin 3`) admits no robustly acyclic orientation** — the smallest concrete, machine-checked witness of the Nešetřil-Rödl phenomenon (girth 3).

The file's two remaining axioms are the *deep* results `chromatic_lt_girth_implies_robust` (FFLW) and `nesetril_rodl_counterexample` (high-girth counterexamples for **all** g ≥ 3). This theorem does not remove those axioms but supplies the elementary **g = 3 base case** as a fully-proved, self-contained non-example, grounding the abstract existence axiom in a checkable object.

## Proof idea

Any acyclic orientation of a triangle is *transitive*: the three vertices receive pairwise-distinct ranks (adjacent vertices can't share a rank), so they line up as source `a` → middle `b` → sink `c` with arcs `a→b`, `b→c`, `a→c`. The arc `a→c` is then **dependent** — the alternate directed path `a→b→c` already connects its endpoints, so reversing `a→c` closes the cycle `c→a→b→c`. Hence no orientation is robust. Via `cover_graph_characterization` this reproves directly that the triangle is not the Hasse diagram of any poset.

Entirely within the existing reachability model (`hasDependentArc` via `Relation.TransGen`); no new definitions.

## Verification

- `triangle_not_robust` depends on axioms `[propext, Classical.choice, Quot.sound]` only — **0 extra axioms, 0 sorries**.
- Host-verified with `lake env lean` against Mathlib v4.26 (Docker builds hit reproducible line-less exit-135 volume corruption; host single-file elaboration is clean, exit 0).
- Gallery meta `erdos-1006-oq-01` `leanFile` counts refreshed (lineCount 467→534, theoremCount 11→12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)