### PR TITLE
Enrich n-th-root rationality criterion (cube-root-2-irrational-oq-05-oq-01): cross-references

### DIFF
--- a/src/data/proofs/cube-root-2-irrational-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05-oq-01/meta.json
@@ -186,6 +186,21 @@
       "targetId": "cube-root-2-irrational",
       "relationship": "related",
       "description": "∛2 irrational (the base entry) is recovered here as irrational_cbrt_two, an instance of the prime corollary"
+    },
+    {
+      "targetId": "cube-root-2-irrational-oq-05-oq-02",
+      "relationship": "related",
+      "description": "Sibling child of OQ-05 taking the orthogonal direction: instead of characterizing which integer radicands give rational roots, it varies the exponent — p^q irrational for non-integer rational q — and proves ∛2 + ∛3 ∉ ℚ"
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "related",
+      "description": "States the same irrationality direction (m not a perfect n-th power ⇒ m^(1/n) irrational) as a standalone theorem; this entry sharpens it to a full iff by adding the converse (perfect power ⇒ rational) via integral closedness"
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "The n = 2 slice of this criterion: √m is rational iff m is a perfect square, the archetypal case from which the general perfect-n-th-power characterization descends"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `cube-root-2-irrational-oq-05-oq-01` (quality 94, passes 0). Already a rich, accurate entry (15 KB, all quality minimums met) — this is a curation pass, no inflation (15.1 → 16.1 KB, well under the 60 KB cap).

## Changes
- **3 accurate cross-references** (crossReferences 2 → 5, cap 20), all targets verified to exist:
  - `cube-root-2-irrational-oq-05-oq-02` — the sibling child of OQ-05 taking the orthogonal direction (varies the *exponent*: p^q for non-integer rational q, and ∛2 + ∛3 ∉ ℚ).
  - `nth-root-irrational` — states the same irrationality direction standalone; this entry sharpens it to a full iff by adding the converse (perfect power ⇒ rational) via integral closedness.
  - `sqrt2-irrational` — the n = 2 slice (√m rational iff m a perfect square).

## Verification
- meta.json re-checked against the Lean source `CubeRoot2IrrationalOQ05OQ01.lean`: 126 lines, 8 theorems, 1 def, 0 sorries, 0 axioms — all fields consistent.
- JSON validates; `check-meta-size.ts` within caps.