### PR TITLE
Enrich Erdős #1007 graph dimension basics (erdos-1007-oq-05-oq-01): mainTheorem anchors + header section

### DIFF
--- a/src/data/proofs/erdos-1007-oq-05-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05-oq-01/meta.json
@@ -60,6 +60,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Header, Imports, and the Embedding Structure",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring on the graph-dimension problem (Erdős #1007 OQ-05) — the least n for which a graph has a unit-distance embedding in ℝⁿ — and why the structure is reproduced locally rather than imported. Imports Mathlib, namespace Erdos1007OQ05OQ01, open Finset, then the UnitDistanceEmbedding structure and the hasUnitEmbedding predicate (Nonempty of an embedding).",
+      "mathContext": "$\\mathrm{hasUnitEmbedding}\\,V\\,\\mathrm{adj}\\,n$ = a map $V \\to \\mathbb{R}^n$ realizing every edge as a unit distance; the graph dimension is the least such $n$."
+    },
+    {
       "id": "monotonicity",
       "title": "Monotonicity of Embeddability",
       "startLine": 44,
@@ -136,20 +144,26 @@
     {
       "name": "hasUnitEmbedding_mono",
       "type": "core",
-      "description": "Monotonicity of unit-embeddability in the ambient dimension",
-      "leanType": "{V : Type*} → {adj : V → V → Prop} → {n m : ℕ} → n ≤ m → hasUnitEmbedding V adj n → hasUnitEmbedding V adj m"
+      "description": "Monotonicity of unit-embeddability in the ambient dimension: an embedding in ℝⁿ lifts to ℝᵐ for m ≥ n, so the admissible dimensions form an up-set.",
+      "leanType": "{V : Type*} → {adj : V → V → Prop} → {n m : ℕ} → n ≤ m → hasUnitEmbedding V adj n → hasUnitEmbedding V adj m",
+      "startLine": 72,
+      "endLine": 74
     },
     {
       "name": "hasUnitEmbedding_zero_iff_edgeless",
       "type": "key",
-      "description": "Dimension-0 base case: embeds in ℝ⁰ iff edgeless",
-      "leanType": "{V : Type*} → {adj : V → V → Prop} → (hasUnitEmbedding V adj 0 ↔ ∀ u v, ¬ adj u v)"
+      "description": "Dimension-0 base case: a graph embeds in ℝ⁰ iff it is edgeless (an edge would force distance 1 in a 0-dimensional space, where every distance is 0).",
+      "leanType": "{V : Type*} → {adj : V → V → Prop} → (hasUnitEmbedding V adj 0 ↔ ∀ u v, ¬ adj u v)",
+      "startLine": 92,
+      "endLine": 94
     },
     {
       "name": "embedding_mono",
       "type": "key",
-      "description": "Coordinate-padding extends an embedding to higher dimension",
-      "leanType": "{V : Type*} → {adj : V → V → Prop} → {n m : ℕ} → n ≤ m → UnitDistanceEmbedding V adj n → UnitDistanceEmbedding V adj m"
+      "description": "Coordinate-padding extends a unit-distance embedding to higher dimension: pad the new coordinates with 0, leaving all edge distances unchanged. The construction underlying hasUnitEmbedding_mono.",
+      "leanType": "{V : Type*} → {adj : V → V → Prop} → {n m : ℕ} → n ≤ m → UnitDistanceEmbedding V adj n → UnitDistanceEmbedding V adj m",
+      "startLine": 47,
+      "endLine": 69
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `erdos-1007-oq-05-oq-01` (quality 94, passes 0). Two genuine gaps:

1. **All 3 top-level `mainTheorems` had `null` line anchors.** Filled with verified spans: `hasUnitEmbedding_mono` (72–74), `hasUnitEmbedding_zero_iff_edgeless` (92–94), `embedding_mono` (47–69); descriptions enriched.
2. **Sections started at line 44**, leaving imports, the graph-dimension docstring, and the `UnitDistanceEmbedding` structure + `hasUnitEmbedding` predicate (1–43) uncovered. Added a `setup` section.

Anchors checked against `Proofs/Erdos1007OQ05OQ01.lean`. Well under size cap.