### PR TITLE
research(dirichlets-theorem-oq-02-oq-03): sharper primorial certified bound on the k-th prime ≡3 (mod 4) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -289,4 +289,122 @@ theorem B_one : B 1 = 95 := by decide
 theorem tower_loose_at_one : p3 1 < B 1 := by
   rw [p3_one, B_one]; norm_num
 
+/-! ## Step 5: the tighter **primorial** bound
+
+The iterated-factorial tower `B` is astronomically loose because each step takes
+a *factorial of the whole previous bound*.  The classical Euclid argument for
+`≡ 3 (mod 4)` in fact only needs the *product of the primes found so far*, not a
+factorial: given the first `k` primes `p3 0, …, p3 (k−1) ≡ 3 (mod 4)`, the number
+
+    N = 4·(p3 0 · p3 1 ⋯ p3 (k−1)) − 1
+
+is `≡ 3 (mod 4)`, so it has a prime factor `p ≡ 3 (mod 4)`; and `p` cannot be any
+of `p3 0, …, p3 (k−1)` (each of those divides the product, hence `4·product`,
+while `p ∣ N = 4·product − 1`, forcing `p ∣ 1`).  So `p` is a *new* prime
+`≡ 3 (mod 4)`, giving `p3 k ≤ p ≤ N`.  This is the **primorial bound**
+
+    p3 k ≤ 4·(∏_{i<k} p3 i) − 1,
+
+replacing the factorial by a product.  It is enormously tighter: e.g.
+`p3 1 ≤ 4·3 − 1 = 11` versus the factorial tower's `B 1 = 95`. -/
+
+/-- **Primorial bound (actual-prime form).** The `k`-th prime `≡ 3 (mod 4)` is
+bounded by four times the product of the previous ones, minus one:
+`p3 k ≤ 4·(∏_{i<k} p3 i) − 1`.  This is the certified content of the *primorial*
+Euclid construction and is far tighter than the factorial tower `B`. -/
+theorem p3_le_primorial (k : ℕ) :
+    p3 k ≤ 4 * (∏ i ∈ range k, p3 i) - 1 := by
+  set M := ∏ i ∈ range k, p3 i with hM_def
+  have hM_pos : 0 < M := Finset.prod_pos (fun i _ => (p3_prime i).pos)
+  set N := 4 * M - 1 with hN_def
+  have hN_gt_one : 1 < N := by omega
+  have hN_mod : N % 4 = 3 := by omega
+  obtain ⟨p, hp, hpN, hpmod⟩ := exists_prime_factor_three_mod_four N hN_gt_one hN_mod
+  have hp_le_N : p ≤ N := Nat.le_of_dvd (by omega) hpN
+  -- `p` is a prime `≡ 3 (mod 4)`, hence appears in the enumeration: `p = p3 m`.
+  obtain ⟨m, hm⟩ := p3_surjective hp hpmod
+  -- `p` is NOT among the first `k` primes: else it divides the product and `N`.
+  have hp_new : k ≤ m := by
+    by_contra hlt
+    push_neg at hlt
+    have hdvd_M : p ∣ M := by
+      rw [hM_def, ← hm]; exact Finset.dvd_prod_of_mem p3 (Finset.mem_range.mpr hlt)
+    have hdvd_4M : p ∣ 4 * M := hdvd_M.mul_left 4
+    have hNp1 : N + 1 = 4 * M := by omega
+    rw [← hNp1] at hdvd_4M
+    -- `p ∣ N` and `p ∣ N + 1` force `p ∣ 1`.
+    have h1 : p ∣ 1 := (Nat.dvd_add_right hpN).mp hdvd_4M
+    have hp1 := hp.one_lt
+    have := Nat.le_of_dvd one_pos h1
+    omega
+  calc p3 k ≤ p3 m := p3_strictMono.monotone hp_new
+    _ = p := hm
+    _ ≤ N := hp_le_N
+
+/-! ### The explicit primorial tower `C`
+
+`C k = 4·(∏_{i<k} C i) − 1`, computed via the running product `towerProd`.
+Unrolling: `C 0 = 3`, `C 1 = 11`, `C 2 = 131`, `C 3 = 17291`, … — doubly
+exponential, but incomparably smaller than the factorial tower `B` (`B 2 = 4·96!−1`).
+We prove `p3 k ≤ C k` by strong induction, feeding `p3_le_primorial` the pointwise
+bound `p3 i ≤ C i` for `i < k`. -/
+
+/-- Running product `towerProd k = ∏_{i<k} C i`, defined structurally so that the
+primorial tower `C` is a genuine recursion. -/
+def towerProd : ℕ → ℕ
+  | 0 => 1
+  | (k + 1) => towerProd k * (4 * towerProd k - 1)
+
+/-- The explicit primorial tower `C k = 4·(∏_{i<k} C i) − 1`. -/
+def C (k : ℕ) : ℕ := 4 * towerProd k - 1
+
+theorem C_eq (k : ℕ) : C k = 4 * towerProd k - 1 := rfl
+
+@[simp] theorem towerProd_zero : towerProd 0 = 1 := rfl
+@[simp] theorem towerProd_succ (k : ℕ) :
+    towerProd (k + 1) = towerProd k * (4 * towerProd k - 1) := rfl
+
+/-- `towerProd k` is the product `∏_{i<k} C i`, so `C` really is the primorial tower. -/
+theorem towerProd_eq_prod (k : ℕ) : towerProd k = ∏ i ∈ range k, C i := by
+  induction k with
+  | zero => simp
+  | succ k ih => rw [Finset.prod_range_succ, ← ih, C_eq, towerProd_succ]
+
+/-- **Main tighter bound.** The `k`-th prime `≡ 3 (mod 4)` is bounded by the
+explicit primorial tower: `p3 k ≤ C k`.  Compared with the factorial tower
+`p3 k ≤ B k`, this replaces a tower of factorials by a doubly-exponential
+primorial tower — still not tight (`p_k ∼ 2k·ln k`), but vastly closer. -/
+theorem p3_le_primorialTower (k : ℕ) : p3 k ≤ C k := by
+  induction k using Nat.strong_induction_on with
+  | _ k ih =>
+    have hle : (∏ i ∈ range k, p3 i) ≤ ∏ i ∈ range k, C i :=
+      Finset.prod_le_prod (fun i _ => Nat.zero_le _) (fun i hi => ih i (Finset.mem_range.mp hi))
+    have hstep := p3_le_primorial k
+    rw [C_eq, towerProd_eq_prod]
+    omega
+
+/-! ### Worked values and the honest contrast with the factorial tower -/
+
+/-- `C 0 = 3`. -/
+theorem C_zero_eq : C 0 = 3 := rfl
+
+/-- `C 1 = 11`: the primorial bound on the 2nd prime `≡ 3 (mod 4)` is `11`
+(true value `7`), versus the factorial tower's `B 1 = 95`. -/
+theorem C_one_eq : C 1 = 11 := by decide
+
+/-- `C 2 = 131`: the primorial bound on the 3rd prime `≡ 3 (mod 4)` is `131`,
+versus `B 2 = 4·96! − 1`. -/
+theorem C_two_eq : C 2 = 131 := by decide
+
+/-- **The primorial tower is strictly tighter than the factorial tower** already
+at `k = 1`, while remaining a valid upper bound:
+`p3 1 = 7 ≤ 11 = C 1 < 95 = B 1`. -/
+theorem primorial_tighter_than_factorial : p3 1 ≤ C 1 ∧ C 1 < B 1 := by
+  rw [p3_one, C_one_eq, B_one]; exact ⟨by norm_num, by norm_num⟩
+
+/-- **Sharper bracketing.** Combining the linear lower bound with the primorial
+tower: `4k + 3 ≤ p3 k ≤ C k`, a strictly tighter ceiling than `p3_bracketed`. -/
+theorem p3_bracketed_primorial (k : ℕ) : 4 * k + 3 ≤ p3 k ∧ p3 k ≤ C k :=
+  ⟨p3_ge_linear k, p3_le_primorialTower k⟩
+
 end DirichletsTheoremOQ02OQ03

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "dirichlets-theorem-oq-02-oq-03",
   "title": "Certified Growth Bound for the k-th Prime ≡ 3 (mod 4)",
   "slug": "dirichlets-theorem-oq-02-oq-03",
-  "description": "The parent's Euclid-style proof of infinitely many primes ≡ 3 (mod 4) certifies more than infinitude: it bounds how fast such primes grow. We extract the interval bound (a prime ≡ 3 mod 4 always lies in (n, 4·(n+1)! − 1]), build the increasing enumeration p₃(0) < p₃(1) < … of these primes, and prove the explicit iterated-factorial tower bound p₃(k) ≤ B(k) with B(0)=3, B(k+1)=4·(B(k)+1)!−1. We contrast this astronomically loose certified bound with the true asymptotic p_k ∼ 2k·ln k from the PNT for arithmetic progressions. Fully machine-checked (0 sorry, 0 axiom, native_decide-free). This iteration adds the completeness half: p3 enumerates *exactly* the primes ≡3 (mod 4) (mem_range_p3_iff / p3_surjective, via minimality of nextP3), so with strict monotonicity 'p3 k = the k-th such prime' is now rigorous and the tower bound provably bounds every one of them.",
+  "description": "The parent's Euclid-style proof of infinitely many primes ≡ 3 (mod 4) certifies more than infinitude: it bounds how fast such primes grow. We extract the interval bound (a prime ≡ 3 mod 4 always lies in (n, 4·(n+1)! − 1]), build the increasing enumeration p₃(0) < p₃(1) < … of these primes, and prove the explicit iterated-factorial tower bound p₃(k) ≤ B(k) with B(0)=3, B(k+1)=4·(B(k)+1)!−1. We contrast this astronomically loose certified bound with the true asymptotic p_k ∼ 2k·ln k from the PNT for arithmetic progressions. Fully machine-checked (0 sorry, 0 axiom, native_decide-free). This iteration adds the completeness half: p3 enumerates *exactly* the primes ≡3 (mod 4) (mem_range_p3_iff / p3_surjective, via minimality of nextP3), so with strict monotonicity 'p3 k = the k-th such prime' is now rigorous and the tower bound provably bounds every one of them. This iteration adds the sharper **primorial bound** p₃(k) ≤ 4·(∏_{i<k} p₃(i)) − 1, replacing the factorial by the product of the primes found so far, and packages it as an explicit doubly-exponential tower C with C(0)=3, C(1)=11, C(2)=131, C(3)=17291 satisfying p₃(k) ≤ C(k). It is strictly tighter than the factorial tower already at k=1 (7 ≤ 11 = C(1) < 95 = B(1)) and incomparably tighter for k≥2 (C(2)=131 vs B(2)=4·96!−1), while still honestly far from the truth p_k ∼ 2k·ln k. All new results are 0 sorry / 0 axiom, native_decide-free (kernel decide only).",
   "meta": {
     "author": "Lean Genius Researcher (extends elementary Euclid argument, Euclid c. 300 BC; asymptotic: PNT for APs, de la Vallée Poussin 1896)",
     "sourceUrl": "https://www.erdosproblems.com/",
@@ -172,12 +172,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 292,
+    "lineCount": 410,
     "axiomCount": 0,
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 26
+    "theoremCount": 31
   },
   "sorries": 0,
   "status": "verified",

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,25 +29,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (verified 0/0): certified iterated-factorial tower B(k) upper-bounds the k-th prime ≡3 (mod 4); B(1)=95 vs true p_1=7, honest contrast with p_k∼2k·ln k. Deliverable Proofs/DirichletsTheoremOQ02OQ03.lean (7743 jobs, native_decide-free).",
+    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): added the sharper PRIMORIAL certified bound p3 k ≤ 4·(∏_{i<k} p3 i) − 1 and its explicit tower C (C1=11 vs B1=95, C2=131 vs B2=4·96!−1), strictly tighter than the iterated-factorial tower while remaining honest against p_k∼2k·ln k. native_decide-free, 0 axioms, 0 sorries.",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
       "p3 enumeration with p3_prime/p3_mod/p3_strictMono (DirichletsTheoremOQ02OQ03.lean:144–168).",
       "B tower + p3_le_tower (DirichletsTheoremOQ02OQ03.lean:176–201) — MAIN: p3 k ≤ B k, the certified iterated-factorial bound on the k-th prime ≡3 mod4.",
-      "p3_one=7, B_one=95, tower_loose_at_one (DirichletsTheoremOQ02OQ03.lean:209–229) — worked values quantifying looseness. Verified 0 sorry / 0 axiom, 7743 jobs."
+      "p3_one=7, B_one=95, tower_loose_at_one (DirichletsTheoremOQ02OQ03.lean:209–229) — worked values quantifying looseness. Verified 0 sorry / 0 axiom, 7743 jobs.",
+      "p3_le_primorial (DirichletsTheoremOQ02OQ03.lean) — primorial bound p3 k ≤ 4·(∏_{i<k} p3 i) − 1, the certified content of the primorial Euclid construction.",
+      "towerProd + C + towerProd_eq_prod + p3_le_primorialTower — explicit primorial tower C with p3 k ≤ C k (strong induction).",
+      "C_one_eq=11, C_two_eq=131, primorial_tighter_than_factorial (7≤11=C1<95=B1), p3_bracketed_primorial (4k+3 ≤ p3 k ≤ C k). All 0 sorry / 0 axiom (foundational trio only), native_decide-free."
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
       "Iterating the one-step factorial bound gives an explicit iterated-factorial TOWER B(0)=3, B(k+1)=4·(B(k)+1)!−1 as a certified upper bound on the k-th prime ≡3 (mod 4). B(1)=95 vs true p_1=7; B(2)=4·96!−1 — astronomically loose against the true p_k∼2k·ln k.",
       "Nat.find plus its minimality lemma (Nat.find_min) lets one define the increasing enumeration p3 of primes ≡3 (mod 4) and certify it skips none — so p3 k is genuinely the k-th such prime WITHOUT invoking Mathlib’s Nat.nth API (which is fiddly).",
-      "The whole development is native_decide-free: the only numeric fact (B 1 = 95) is discharged by kernel decide, so axiomCount stays 0 (verified, not axiomatized)."
+      "The whole development is native_decide-free: the only numeric fact (B 1 = 95) is discharged by kernel decide, so axiomCount stays 0 (verified, not axiomatized).",
+      "The Euclid ≡3(mod4) construction only needs the PRODUCT of the primes found so far, not a factorial of the previous bound: N=4·(∏_{i<k}p3 i)−1 is ≡3 mod4, its ≡3-mod4 prime factor p cannot divide ∏p3 i (else p∣4·∏ and p∣N ⇒ p∣1), so p is new and p3 k ≤ p ≤ N. This gives the PRIMORIAL bound p3 k ≤ 4·∏_{i<k}p3 i − 1, dramatically tighter than the factorial tower.",
+      "The primorial tower C(k)=4·(∏_{i<k}C i)−1 (C0=3,C1=11,C2=131,C3=17291) is doubly-exponential but incomparably smaller than the iterated-factorial tower B (B2=4·96!−1). p3 k ≤ C k follows by STRONG induction feeding p3_le_primorial the pointwise p3 i ≤ C i for i<k via Finset.prod_le_prod.",
+      "Structural-recursion trick for a product-defined tower: define the running product towerProd k (towerProd 0=1, towerProd(k+1)=towerProd k·(4·towerProd k−1)) structurally, set C k := 4·towerProd k−1, then prove towerProd k = ∏_{i<k} C i by induction (prod_range_succ). Avoids non-structural self-reference of C."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalize the counting-function side: turn the certified upper bound on p_k into a certified LOWER bound on π(x;4,3), isolating precisely where analytic PNT input becomes unavoidable.",
-      "Try to lower the certified tower from iterated-factorial toward exponential while staying elementary (e.g. via the primorial variant N=4·∏(known primes)−1), or argue the tower is intrinsic to Euclid-style iteration.",
-      "Port the certified-tower framework to other elementary progressions (5 mod 6, etc.)."
+      "Prove the primorial tower never exceeds the factorial tower in general: C k ≤ B k (needs ∏_{i<k} C i ≤ (B(k-1)+1)!), making the tightness a theorem for all k rather than just k=1,2.",
+      "Attempt a genuinely elementary sub-exponential certified bound (or prove the primorial tower's doubly-exponential growth is intrinsic to Euclid-style iteration without an analytic input).",
+      "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1)."
     ],
     "markdown": "# Knowledge Base: dirichlets-theorem-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the already-complete **Dirichlet OQ-03** entry (which certified the *iterated-factorial* tower bound `p3 k ≤ B k`, `B(k+1)=4·(B k+1)!−1`, on the k-th prime `≡ 3 (mod 4)`) with the **primorial variant** — a dramatically tighter certified elementary bound.

**Key insight.** The Euclid `≡ 3 (mod 4)` construction only needs the *product of the primes found so far*, not a factorial of the previous bound: for `N = 4·(∏_{i<k} p3 i) − 1 ≡ 3 (mod 4)`, its `≡ 3`-mod-4 prime factor `p` cannot divide `∏ p3 i` (else `p ∣ 4·∏` and `p ∣ N` force `p ∣ 1`), so `p` is a *new* such prime and `p3 k ≤ p ≤ N`.

## New theorems (all 0 sorry / 0 axiom, foundational trio only, `native_decide`-free)

- `p3_le_primorial` : `p3 k ≤ 4·(∏_{i<k} p3 i) − 1` — the primorial bound.
- `towerProd` / `C` / `towerProd_eq_prod` : the explicit primorial tower `C(0)=3, C(1)=11, C(2)=131, C(3)=17291` with `towerProd k = ∏_{i<k} C i`.
- `p3_le_primorialTower` : `p3 k ≤ C k` (strong induction feeding the pointwise `p3 i ≤ C i` through `Finset.prod_le_prod`).
- `primorial_tighter_than_factorial` : `p3 1 = 7 ≤ 11 = C 1 < 95 = B 1`.
- `p3_bracketed_primorial` : `4k + 3 ≤ p3 k ≤ C k`, a strictly tighter ceiling than the prior `p3_bracketed`.

## Honesty

The primorial tower is doubly-exponential — strictly tighter than the factorial tower already at `k = 1` and incomparably tighter for `k ≥ 2` (`C 2 = 131` vs `B 2 = 4·96! − 1`), but still honestly far from the true asymptotic `p_k ∼ 2k·ln k` (PNT for arithmetic progressions). This is an *improved elementary certified upper bound*, not a tight one.

## Verification

Host-verified with `lake env lean` against the prebuilt Mathlib cache (fleet Docker saturated). `#print axioms` on the three headline theorems reports only `[propext, Classical.choice, Quot.sound]` — no `ofReduceBool`, no `sorryAx`. The two numeric facts (`C 1 = 11`, `C 2 = 131`) use kernel `decide`.