### PR TITLE
Enrich prime^rational-power & ∛2+∛3 (cube-root-2-irrational-oq-05-oq-02): header section + cross-ref

### DIFF
--- a/src/data/proofs/cube-root-2-irrational-oq-05-oq-02/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05-oq-02/meta.json
@@ -84,6 +84,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring stating the two extensions (rational-exponent prime powers and ∛2 + ∛3), the Mathlib import, and the import/open of the sibling entry OQ-05-OQ-01, from which IsPerfectNthPow, irrational_rpow_inv_iff, rpow_inv_pow, and irrational_cbrt_six are reused.",
+      "mathContext": "$p^{a/b} \\notin \\mathbb{Q}$ (non-integer $a/b$) and $\\sqrt[3]{2}+\\sqrt[3]{3} \\notin \\mathbb{Q}$."
+    },
+    {
       "id": "perfect-power-obstruction",
       "title": "Prime Powers and Perfect b-th Powers",
       "startLine": 45,
@@ -123,6 +131,11 @@
       "targetId": "cube-root-2-irrational",
       "relationship": "related",
       "description": "∛2, the base entry, appears here both as a base of a rational-exponent power and as a summand of the irrational ∛2 + ∛3"
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "related",
+      "description": "The general 'not a perfect n-th power ⇒ irrational' criterion underpinning Part 1: after Real.rpow_mul reduces p^(a/b) to (p^a)^(1/b), irrationality is exactly the failure of p^a to be a perfect b-th power"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `cube-root-2-irrational-oq-05-oq-02` (quality 94, passes 0). Already a strong entry — curation pass, no inflation (~12.6 KB, far under the 60 KB cap).

## Changes
- **Header section**: the `sections` array previously started at line 45, leaving the module docstring, Mathlib import, and the sibling import/open (lines 1–44) uncovered. Added an accurate `header` section closing the coverage gap (sections 3 → 4).
- **Cross-reference** to `nth-root-irrational` (crossReferences 3 → 4): the general 'not a perfect n-th power ⇒ irrational' criterion underpinning Part 1's reduction of p^(a/b) to (p^a)^(1/b).

## Verification
- meta.json re-checked against `CubeRoot2IrrationalOQ05OQ02.lean`: 143 lines, 5 theorems, 0 defs, 0 sorries, 0 axioms — all fields consistent.
- JSON validates; within all size caps.