### PR TITLE
Enrich ∛3 non-constructibility (cube-root-3-irrational-oq-03-oq-01): header section + cross-ref

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03-oq-01/meta.json
@@ -98,6 +98,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module docstring framing the Delian problem and Wantzel's degree criterion, the Mathlib import and the import/open of the parent OQ-03 (supplying finrank_adjoin_cbrt3 : [ℚ(∛3):ℚ] = 3), and the IntermediateField open.",
+      "mathContext": "$[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] = 3$ is not a power of $2$, so $\\sqrt[3]{3}$ is not constructible."
+    },
+    {
       "id": "arithmetic",
       "title": "The Arithmetic Obstruction",
       "startLine": 36,
@@ -142,6 +150,11 @@
       "targetId": "cube-root-3-irrational",
       "relationship": "related",
       "description": "The base entry establishing the irrationality of ∛3; this descendant reaches the full degree-theoretic impossibility of doubling the cube."
+    },
+    {
+      "targetId": "fourth-root-2-irrational",
+      "relationship": "related",
+      "description": "A companion radical field-degree computation ([ℚ(⁴√2):ℚ] = 4 via Eisenstein irreducibility of X⁴ − 2); by contrast ⁴√2 has 2-power degree and so does not meet this entry's non-constructibility obstruction, sharpening what the degree-3 case rules out."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `cube-root-3-irrational-oq-03-oq-01` (quality 94, passes 0). Already a model entry (5 full annotations, 4 keyInsights, complete conclusion) — curation pass, no inflation (~11.8 KB).

## Changes
- **Header section**: `sections` previously started at line 36, leaving the module docstring / imports / parent-open (lines 1–35) uncovered. Added an accurate `header` section (sections 3 → 4), matching the coverage convention of sibling entries.
- **Cross-reference** to `fourth-root-2-irrational` (crossReferences 2 → 3): a companion radical field-degree computation. It sharpens the contrast — ⁴√2 has 2-power degree (4) and so is *not* excluded by this entry's 'degree not a power of 2' obstruction, whereas ∛3 (degree 3) is.

## Verification
- meta re-checked against `CubeRoot3IrrationalOQ03OQ01.lean`: 68 lines, 3 theorems, 0 defs, 0 sorries, 0 axioms — consistent. Target `fourth-root-2-irrational` verified to exist.
- JSON validates; within all size caps.