### PR TITLE
Enrich Erdős #1017 Turán additive structure (erdos-1017-oq-03-oq-01): mainTheorems + header section

### DIFF
--- a/src/data/proofs/erdos-1017-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-03-oq-01/meta.json
@@ -60,6 +60,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Header, Imports, and turanBound",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Module docstring on the additive/triangular structure of the Turán quarter-square bound T(n) = ⌊n²/4⌋ for Erdős #1017. Imports Mathlib, declares namespace Erdos1017OQ03OQ01, and re-declares turanBound n = n²/4 for self-containment.",
+      "mathContext": "$T(n) = \\lfloor n^2/4 \\rfloor$; this file develops its additive dynamics (one-/two-step increments, triangular and binomial bridges, accumulation sum)."
+    },
+    {
       "id": "increments",
       "title": "One-Step and Two-Step Increments",
       "summary": "turanBound_succ (T(n+1) = T(n) + floor((n+1)/2)), turanBound_two_step (T(n+2) = T(n) + (n+1), division-free), and turanBound_two_step_diff (T(n+2) − T(n) = n+1).",
@@ -82,6 +90,56 @@
       "startLine": 105,
       "endLine": 121,
       "mathContext": "Nat.choose_two_right + congr/ring for the binomial bridge; a one-line induction (Finset.sum_range_succ + turanBound_succ) for the accumulation formula."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "turanBound_add_succ_choose",
+      "type": "core",
+      "description": "**Quarter-square ↔ binomial bridge.** T(n) + T(n+1) = C(n+1, 2): the two extremal bipartite edge counts on n and n+1 vertices sum to the edge count of the complete graph K_{n+1} — every edge of K_{n+1} accounted for exactly once. The cleanest combinatorial reading of the quarter-square sequence.",
+      "leanType": "(n : ℕ) : turanBound n + turanBound (n + 1) = Nat.choose (n + 1) 2",
+      "startLine": 108,
+      "endLine": 112
+    },
+    {
+      "name": "turanBound_eq_sum",
+      "type": "core",
+      "description": "**Accumulation formula.** T(n) = ∑_{k<n} ⌊(k+1)/2⌋ — the Turán bound is the running sum of its one-step increments ⌈k/2⌉. Proved by a one-line induction on turanBound_succ.",
+      "leanType": "(n : ℕ) : turanBound n = ∑ k ∈ Finset.range n, (k + 1) / 2",
+      "startLine": 116,
+      "endLine": 121
+    },
+    {
+      "name": "turanBound_succ",
+      "type": "key",
+      "description": "**Additive one-step increment.** T(n+1) = T(n) + ⌊(n+1)/2⌋: adding one vertex to the balanced complete bipartite graph adds ⌈n/2⌉ edges. Proved by a parity case-split on the closed forms.",
+      "leanType": "(n : ℕ) : turanBound (n + 1) = turanBound n + (n + 1) / 2",
+      "startLine": 53,
+      "endLine": 66
+    },
+    {
+      "name": "turanBound_two_step",
+      "type": "key",
+      "description": "**Exact two-step increment (division-free).** T(n+2) = T(n) + (n+1): a symmetric ±1 shift about n+1 adds exactly n+1 edges regardless of parity, from (n+2)² = n² + 4(n+1) via Nat.add_mul_div_right.",
+      "leanType": "(n : ℕ) : turanBound (n + 2) = turanBound n + (n + 1)",
+      "startLine": 71,
+      "endLine": 73
+    },
+    {
+      "name": "turanBound_add_succ_triangular",
+      "type": "key",
+      "description": "**Triangular-number form.** T(n) + T(n+1) = n(n+1)/2, the n-th triangular number: the sum of the two consecutive extremal bipartite edge counts is exactly 1+2+⋯+n.",
+      "leanType": "(n : ℕ) : turanBound n + turanBound (n + 1) = n * (n + 1) / 2",
+      "startLine": 101,
+      "endLine": 103
+    },
+    {
+      "name": "turanBound_add_succ",
+      "type": "supporting",
+      "description": "**Exact division-free pair identity.** 2·(T(n) + T(n+1)) = n(n+1): two consecutive quarter-squares add to a triangular number in exact (÷2-free) form, the engine of the triangular and binomial bridges.",
+      "leanType": "(n : ℕ) : 2 * (turanBound n + turanBound (n + 1)) = n * (n + 1)",
+      "startLine": 83,
+      "endLine": 97
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-1017-oq-03-oq-01` (quality 94, passes 0). Two genuine gaps:

1. **No `mainTheorems` array** despite 7 named theorems (`theoremCount` = 7). Added a curated 6-theorem array with verified anchors/leanType: `turanBound_add_succ_choose` (binomial bridge) & `turanBound_eq_sum` (accumulation) as core, the increment/triangular keys, and the division-free pair identity.
2. **Sections started at line 51**, leaving imports, the docstring, and the `turanBound` definition (1–50) uncovered. Added a `setup` section.

Anchors checked against `Proofs/Erdos1017OQ03OQ01.lean`. Well under size cap.