### PR TITLE
research(law-of-cosines-oq-03-oq-03): equilateral-family side monotonicity (Part 8) [VERIFIED]

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -328,4 +328,46 @@ theorem equilateral_pi_four_cosh (t : HyperbolicTriangle)
   rw [div_eq_iff hpos.ne']
   linear_combination (1 / 2 : ℝ) * hs
 
+-- ============================================================
+-- PART 8: The equilateral family — the side strictly decreases in the common angle
+-- ============================================================
+
+/-- **The equilateral side strictly decreases in the common angle (cosh form).**
+    Two equilateral hyperbolic triangles with common angles `θ₁ < θ₂` satisfy
+    `cosh(side₂) < cosh(side₁)`. Together with `equilateral_cosh` this shows the closed
+    form `θ ↦ cos θ / (1 - cos θ)` is strictly decreasing across the admissible range
+    `(0, π/3)`: the side blows up as `θ → 0` (thin, large triangles) and shrinks to `0`
+    as `θ → π/3` (the Euclidean limit). Unlike PART 4b, which pins two angles and varies
+    the third, this varies all three angles together along the equilateral family. -/
+theorem equilateral_cosh_antitone (t₁ t₂ : HyperbolicTriangle)
+    (h₁ : t₁.A = t₁.B) (h₁' : t₁.B = t₁.C)
+    (h₂ : t₂.A = t₂.B) (h₂' : t₂.B = t₂.C)
+    (hlt : t₁.C < t₂.C) :
+    Real.cosh t₂.c < Real.cosh t₁.c := by
+  have hcos : Real.cos t₂.C < Real.cos t₁.C :=
+    Real.cos_lt_cos_of_nonneg_of_le_pi t₁.hC.le t₂.hC_lt.le hlt
+  -- `1 - cos θ > 0` for `0 < θ < π`, since `cos θ < cos 0 = 1`.
+  have hd₁ : 0 < 1 - Real.cos t₁.C := by
+    have h := Real.cos_lt_cos_of_nonneg_of_le_pi (le_refl (0 : ℝ)) t₁.hC_lt.le t₁.hC
+    rw [Real.cos_zero] at h; linarith
+  have hd₂ : 0 < 1 - Real.cos t₂.C := by
+    have h := Real.cos_lt_cos_of_nonneg_of_le_pi (le_refl (0 : ℝ)) t₂.hC_lt.le t₂.hC
+    rw [Real.cos_zero] at h; linarith
+  rw [equilateral_cosh t₁ h₁ h₁', equilateral_cosh t₂ h₂ h₂',
+      div_lt_div_iff₀ hd₂ hd₁]
+  nlinarith [hcos]
+
+/-- **The equilateral side strictly decreases in the common angle.** With common angles
+    `θ₁ < θ₂`, the second triangle has the strictly shorter side: `t₂.c < t₁.c`. This is
+    the monotone hyperbolic counterpart of the Euclidean fact that all equilateral
+    triangles are similar — here each admissible common angle pins down a *unique* size,
+    refining the AAA congruence of PART 4 into a strict monotonicity along the family. -/
+theorem equilateral_side_antitone (t₁ t₂ : HyperbolicTriangle)
+    (h₁ : t₁.A = t₁.B) (h₁' : t₁.B = t₁.C)
+    (h₂ : t₂.A = t₂.B) (h₂' : t₂.B = t₂.C)
+    (hlt : t₁.C < t₂.C) :
+    t₂.c < t₁.c :=
+  (Real.cosh_strictMonoOn.lt_iff_lt (mem_Ici.mpr t₂.hc.le) (mem_Ici.mpr t₁.hc.le)).mp
+    (equilateral_cosh_antitone t₁ t₂ h₁ h₁' h₂ h₂' hlt)
+
 end HyperbolicAAA

--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -1,0 +1,148 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: the finiteness engine of the strong
+  (Alon–Fischer–Krivelevich–Szegedy) regularity lemma.
+
+  The strong regularity lemma (AFKS 2000) is proved by *iterating* the classical
+  lemma with a decreasing tolerance: whenever the current partition fails the
+  "almost-all-pairs, arbitrary-precision" requirement one refines it, and each
+  such refinement increases the mean-square edge density (the partition
+  `energy`) by a fixed positive amount `δ`.  Because energy is trapped in the
+  interval `[0, 1]`, this can happen only finitely many times — that bounded
+  loop is exactly what makes the iteration terminate and gives the qualitative
+  strong regularity statement.
+
+  This file formalizes that finiteness engine, fully machine-checked, on top of
+  the gallery's own `partitionEnergy` and its bounds `partitionEnergy_nonneg`
+  (Core) and `partitionEnergy_le_one` (Regularity):
+
+  * `energy_steps_bounded`     — abstract telescoping bound: if `f n ∈ [0,1]`
+    and `f` jumps by at least `δ` at each of the first `N` steps then
+    `N • δ ≤ 1`.  This is the pigeonhole heart of AFKS, stated for an arbitrary
+    real (`ℚ`)-valued potential.
+  * `energy_iteration_count_le` — the `δ > 0` count form: `N ≤ 1 / δ`.
+  * `no_infinite_energy_increments` — termination: no `[0,1]`-valued potential
+    can increase by a fixed `δ > 0` at *every* step.
+  * `partitionEnergy_iteration_bound` — graph instantiation: a refinement chain
+    of covering, pairwise-disjoint partitions whose energy grows by `≥ δ` each
+    step has length at most `1 / δ`.
+  * `partitionEnergy_no_infinite_increments` — the graph termination corollary:
+    the AFKS energy-increment loop must halt.
+
+  The remaining content of OQ-04 — spelling out the two-level partition and the
+  exceptional-pair accounting of the full strong lemma statement — is the open
+  research goal; see `research/problems/szemeredi-regularity-oq-04`.  This file
+  supplies the reusable, verified iteration bound that any such proof consumes.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000); Komlós–Simonovits (1996).
+-/
+import Mathlib
+import Proofs.SzemerediRegularity
+
+namespace Szemeredi.RegularityOQ04
+
+open Szemeredi.Core Szemeredi.Regularity
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: ABSTRACT ENERGY-ITERATION TERMINATION
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Telescoping energy bound.**  Let `f : ℕ → ℚ` be a potential confined to
+    `[0, 1]` that increases by at least `δ` at each of the first `N` steps.  Then
+    `N • δ ≤ 1`.  This is the finiteness engine of the AFKS iteration: only
+    `⌊1/δ⌋` genuine energy-increment refinements are possible.
+
+    No sign hypothesis on `δ` is required for this form (for `δ ≤ 0` it is
+    vacuous / trivial). -/
+theorem energy_steps_bounded (f : ℕ → ℚ) (N : ℕ) (δ : ℚ)
+    (h0 : ∀ n, 0 ≤ f n) (h1 : ∀ n, f n ≤ 1)
+    (hstep : ∀ n, n < N → f n + δ ≤ f (n + 1)) :
+    (N : ℚ) * δ ≤ 1 := by
+  -- Telescoping: from `f 0` the potential has climbed by at least `m • δ` after
+  -- `m ≤ N` steps.
+  have key : ∀ m, m ≤ N → f 0 + (m : ℚ) * δ ≤ f m := by
+    intro m
+    induction m with
+    | zero => intro _; simp
+    | succ k ih =>
+        intro hk1
+        have hkN : k ≤ N := Nat.le_of_succ_le hk1
+        have hklt : k < N := hk1
+        have ihk := ih hkN
+        have hs := hstep k hklt
+        have hexp : ((k : ℚ) + 1) * δ = (k : ℚ) * δ + δ := by ring
+        push_cast
+        linarith [ihk, hs, hexp]
+  have hN := key N le_rfl
+  linarith [h0 0, h1 N, hN]
+
+/-- **Iteration-count bound.**  With a genuine positive increment `δ`, an
+    `[0,1]`-valued potential can perform at most `1 / δ` increment steps. -/
+theorem energy_iteration_count_le (f : ℕ → ℚ) (N : ℕ) (δ : ℚ) (hδ : 0 < δ)
+    (h0 : ∀ n, 0 ≤ f n) (h1 : ∀ n, f n ≤ 1)
+    (hstep : ∀ n, n < N → f n + δ ≤ f (n + 1)) :
+    (N : ℚ) ≤ 1 / δ := by
+  have hb : (N : ℚ) * δ ≤ 1 := energy_steps_bounded f N δ h0 h1 hstep
+  rw [le_div_iff₀ hδ]
+  exact hb
+
+/-- **Termination of the AFKS energy loop.**  No `[0,1]`-valued potential can
+    increase by a fixed positive `δ` at *every* step: the refinement iteration
+    that drives the strong regularity lemma must halt. -/
+theorem no_infinite_energy_increments (f : ℕ → ℚ) (δ : ℚ) (hδ : 0 < δ)
+    (h0 : ∀ n, 0 ≤ f n) (h1 : ∀ n, f n ≤ 1) :
+    ¬ (∀ n, f n + δ ≤ f (n + 1)) := by
+  intro hstep
+  obtain ⟨N, hN⟩ := exists_nat_gt (1 / δ)
+  have hb : (N : ℚ) * δ ≤ 1 :=
+    energy_steps_bounded f N δ h0 h1 (fun n _ => hstep n)
+  rw [div_lt_iff₀ hδ] at hN
+  linarith
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: INSTANTIATION ON PARTITION ENERGY
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Graph-theoretic iteration bound.**  Let `parts : ℕ → Finset (Finset V)` be
+    a sequence of partitions of `V` — each covering and pairwise disjoint — whose
+    `partitionEnergy` grows by at least `δ > 0` at each of the first `N` steps.
+    Then `N ≤ 1 / δ`.
+
+    This is the concrete finiteness bound the AFKS iteration relies on: the
+    energy bounds `partitionEnergy_nonneg` and `partitionEnergy_le_one` confine
+    the potential to `[0, 1]`, so only finitely many energy-increment refinements
+    can occur. -/
+theorem partitionEnergy_iteration_bound
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (δ : ℚ) (hδ : 0 < δ)
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hstep : ∀ n, n < N →
+      partitionEnergy G (parts n) + δ ≤ partitionEnergy G (parts (n + 1))) :
+    (N : ℚ) ≤ 1 / δ := by
+  refine energy_iteration_count_le
+    (fun n => partitionEnergy G (parts n)) N δ hδ ?_ ?_ hstep
+  · intro n; exact partitionEnergy_nonneg G (parts n)
+  · intro n; exact partitionEnergy_le_one G (parts n) (hcover n) (hdisjoint n)
+
+/-- **Termination of the graph energy loop.**  A refinement sequence of covering,
+    pairwise-disjoint partitions cannot increase `partitionEnergy` by a fixed
+    `δ > 0` at every step — the AFKS refinement iteration terminates. -/
+theorem partitionEnergy_no_infinite_increments
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (δ : ℚ) (hδ : 0 < δ)
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q) :
+    ¬ (∀ n,
+      partitionEnergy G (parts n) + δ ≤ partitionEnergy G (parts (n + 1))) := by
+  apply no_infinite_energy_increments (fun n => partitionEnergy G (parts n)) δ hδ
+  · intro n; exact partitionEnergy_nonneg G (parts n)
+  · intro n; exact partitionEnergy_le_one G (parts n) (hcover n) (hdisjoint n)
+
+end Szemeredi.RegularityOQ04

--- a/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
+++ b/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
@@ -1,4 +1,43 @@
 
+## Session 2026-07-08 (researcher-6) — Part 8: equilateral-family monotonicity
+
+**Mode:** REVISIT (mature axiomatized AAA-congruence entry)
+**Outcome:** progress (2 new theorems, 0 new assumptions)
+
+### What I Did
+Added Part 8: monotonicity of the side along the one-parameter *equilateral family*.
+- `equilateral_cosh_antitone` — for two equilateral hyperbolic triangles with common
+  angles `θ₁ < θ₂`, `cosh(side₂) < cosh(side₁)`. Shows the closed form
+  `θ ↦ cos θ / (1 - cos θ)` (from `equilateral_cosh`) is strictly decreasing across the
+  admissible range `(0, π/3)`: side → ∞ as `θ → 0`, side → 0 as `θ → π/3` (Euclidean limit).
+- `equilateral_side_antitone` — the same comparison on the sides themselves,
+  `t₂.c < t₁.c`, via `cosh` injectivity on `[0, ∞)`.
+
+Distinct from Part 4b (`side_antitone_in_angle`), which pins **two** angles and varies the
+third; here all three angles move together along the equilateral family. Sharpens AAA
+congruence (Part 4) into a strict order across the family — the hyperbolic counterpart of
+"all Euclidean equilateral triangles are similar", except each admissible angle pins a
+*unique* size.
+
+### Verification
+- **Docker build failed (exit 135, SIGBUS)** twice — line-less, at the final
+  `[3061/3061]` compile step *after* successful elaboration (build #1 had surfaced a
+  normal elaboration error), i.e. Docker-volume corruption, not a proof bug.
+- **Host-verified** instead: `lake exe cache get` + `lake env lean
+  Proofs/LawOfCosinesOQ03OQ03.lean` → exit 0, no output (0 errors, 0 sorries).
+- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only —
+  no `sorryAx`, no `Lean.ofReduceBool`. Zero new assumptions.
+
+File now 373 lines, 24 theorems. Status stays **axiomatized** (7 structure-encoded
+geometric assumptions unchanged). Key steps: `div_lt_div_iff₀` (NOT `div_lt_div_iff`,
+unknown in Mathlib v4.26) to clear denominators + `nlinarith [hcos]`; `1 - cos θ > 0`
+via `cos θ < cos 0 = 1` from `cos_lt_cos_of_nonneg_of_le_pi`.
+
+### Files Modified
+- `proofs/Proofs/LawOfCosinesOQ03OQ03.lean` (Part 8, +~48 lines, host-verified)
+- `src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json` (counts + contribution + 2 mainTheorems)
+- `research/problems/law-of-cosines-oq-03-oq-03/knowledge.md` (this note)
+
 ## Session 2026-07-08 (researcher-6) — Part 7: equilateral corollaries
 
 **Mode:** REVISIT (mature axiomatized AAA-congruence entry)

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -6,16 +6,44 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The strong (Alon–Fischer–Krivelevich–Szegedy, 2000) regularity lemma is the
+classical Szemerédi lemma applied *iteratively* with a decreasing tolerance. Its
+proof splits into two halves:
+
+1. **Energy-increment step (the analytic crux)**: if a partition is far from the
+   almost-all-pairs / arbitrary-precision requirement, a refinement raises the
+   partition energy (mean-square edge density) by a fixed positive amount `δ`.
+2. **Finiteness / termination**: partition energy lives in `[0,1]`, so the
+   `δ`-increment step can fire only `⌊1/δ⌋` times; the loop terminates.
+
+Half (2) is elementary (bounded monotone potential) and fully reusable; half (1)
+carries all the graph-theoretic content.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Finiteness is a standalone, abstract fact** (S1, researcher-6): the
+  termination half needs nothing about graphs — only a `ℚ`-valued potential
+  `f : ℕ → ℚ` confined to `[0,1]` that jumps by `≥ δ`. Formalized abstractly in
+  `SzemerediRegularityOQ04.lean` as `energy_steps_bounded` (`N·δ ≤ 1`),
+  `no_infinite_energy_increments` (termination), then instantiated on the
+  gallery's `partitionEnergy` via `partitionEnergy_nonneg` /
+  `partitionEnergy_le_one`. Doing it abstractly means the *same* lemma bounds
+  both the inner classical loop and the outer AFKS loop.
+- The gallery already supplies the `[0,1]` confinement for free:
+  `partitionEnergy_nonneg` (unconditional, Core) and `partitionEnergy_le_one`
+  (needs cover + pairwise-disjoint, Regularity). No new energy analysis is
+  required for the termination certificate.
+- `le_div_iff₀` / `div_lt_iff₀` are the current (v4.26) subscripted names; the
+  un-subscripted `le_div_iff` / `div_lt_iff` are deprecated.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- (None confirmed yet.) The energy-increment step (half 1) had a prior
+  `energy_increment_step` attempt in the parent file that was removed due to
+  Mathlib `simp`-normal-form drift on `Matrix`/`Finset.sum`; reconstructing it
+  (probably via the surviving `split_energy_excess_bound`) is the next concrete
+  task, not a dead end yet.

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -1,25 +1,74 @@
 # Research State: szemeredi-regularity-oq-04
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04T19:56:31-07:00
-**Iteration**: 1
+**Iteration**: 2
 
-## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+## Status (S1, researcher-6, 2026-07-08) — VERIFIED finiteness engine for the AFKS iteration
+
+Created `proofs/Proofs/SzemerediRegularityOQ04.lean` (0 sorry / 0 axiom;
+`docker-build Proofs.SzemerediRegularityOQ04` succeeded). Moves the problem from
+OBSERVE (no Lean) to ACT with real machine-checked content.
+
+The strong (Alon–Fischer–Krivelevich–Szegedy) regularity lemma is proved by
+*iterating* the classical lemma: whenever the partition fails the almost-all-pairs
+arbitrary-precision requirement one refines it, and each refinement raises the
+mean-square edge density (partition `energy`) by a fixed `δ > 0`. Since energy is
+trapped in `[0,1]`, the loop runs at most `⌊1/δ⌋` times. This session formalizes
+exactly that finiteness engine, built on the gallery's own `partitionEnergy` and
+its bounds `partitionEnergy_nonneg` (Core) / `partitionEnergy_le_one` (Regularity):
+
+- `energy_steps_bounded` — abstract telescoping bound: an `[0,1]`-valued potential
+  `f : ℕ → ℚ` that jumps by `≥ δ` at each of the first `N` steps satisfies
+  `N • δ ≤ 1`. Proof: induction gives `f 0 + m·δ ≤ f m` for `m ≤ N`, then combine
+  `0 ≤ f 0` and `f N ≤ 1`. No sign hypothesis on `δ` needed for this form.
+- `energy_iteration_count_le` — `δ > 0` count form `N ≤ 1/δ` (via `le_div_iff₀`).
+- `no_infinite_energy_increments` — termination: no `[0,1]`-valued potential can
+  increase by a fixed `δ > 0` at *every* step (Archimedean `exists_nat_gt`).
+- `partitionEnergy_iteration_bound` — graph instantiation: a refinement chain of
+  covering, pairwise-disjoint partitions whose `partitionEnergy` grows by `≥ δ`
+  each step has length `≤ 1/δ`.
+- `partitionEnergy_no_infinite_increments` — the AFKS energy-increment loop halts.
+
+This is the reusable, verified ingredient every proof of the qualitative strong
+lemma consumes. It is deliberately stated abstractly (over a `ℚ`-valued potential)
+so the same engine also bounds the *outer* AFKS loop once the energy-increment
+step (a bad `ε`-irregular pair forces `energy ↑ δ`) is supplied.
+
+## What remains open (the OQ-04 goal proper)
+
+1. **Energy-increment step**: quantify "if the fine partition has `≥ ε·C(ℓ,2)`
+   non-`E(k)`-regular pairs then a refinement raises `partitionEnergy` by a fixed
+   `δ = δ(ε)`." The parent `SzemerediRegularity.lean` has the split-energy
+   excess lemmas (`split_energy_excess_bound`) but an assembled
+   `energy_increment_step` was previously attempted and removed — this is the
+   substantive missing piece.
+2. **Two-level statement**: spell out the AFKS conclusion — a coarse
+   `ε`-regular partition `V₁..V_k` and a refinement `W₁..W_ℓ` with all but
+   `ε·C(ℓ,2)` pairs `E(k)`-regular — in Lean, with the dependent tolerance
+   `E : ℕ → (0,1]` threaded correctly (chosen *after* seeing `k`).
+3. **Assemble**: run the outer loop using `partitionEnergy_no_infinite_increments`
+   as the termination certificate.
 
 ## Active Approach
-None yet.
+Iterate the classical lemma with bounded energy (approach 1 from problem.md).
+The finiteness/termination half is now done and verified; the energy-increment
+step (item 1) is the next target and the true crux.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (bounded-energy iteration — finiteness half verified)
 
 ## Blockers
-None.
+None new. The energy-increment step needs the removed `energy_increment_step`
+reconstructed (Mathlib `simp`-normal-form drift on `Matrix`/`Finset.sum` was the
+original obstacle — see parent file NOTE near `split_energy_excess_bound`).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Reconstruct the single energy-increment step lemma:
+`ε`-irregular refinement ⟹ `partitionEnergy` increases by `≥ ε^5` (Komlós–
+Simonovits constant), using the gallery's `split_energy_excess_bound`. Then feed
+it and `partitionEnergy_no_infinite_increments` into the outer iteration.

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 7,
     "sorries": 0,
-    "lineCount": 331,
-    "theoremCount": 22,
+    "lineCount": 373,
+    "theoremCount": 24,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -282,6 +282,18 @@
       "type": "theorem",
       "statement": "For hyperbolic triangles t₁, t₂ with t₁.A = t₂.A, t₁.B = t₂.B and t₁.C < t₂.C, t₂.c < t₁.c.",
       "significance": "Hyperbolic angle-side comparison: with two angles pinned, the side is a strictly decreasing function of its opposite angle. Upgrades AAA congruence (equal angles ⟹ equal sides) to a strict order statement via cosh injectivity on [0,∞). The hyperbolic analogue of the Euclidean larger-angle/longer-side law, but reversed and quantitative."
+    },
+    {
+      "name": "equilateral_cosh_antitone",
+      "type": "theorem",
+      "statement": "For two equilateral hyperbolic triangles with common angles θ₁ < θ₂, cosh(side₂) < cosh(side₁).",
+      "significance": "The equilateral closed form cosh(side) = cos θ/(1 - cos θ) is strictly decreasing across the admissible range (0, π/3): the side blows up as θ → 0 (thin, large triangles) and shrinks to 0 as θ → π/3 (Euclidean limit). Unlike side_antitone_in_angle, which pins two angles, this varies all three angles together along the equilateral family."
+    },
+    {
+      "name": "equilateral_side_antitone",
+      "type": "theorem",
+      "statement": "For two equilateral hyperbolic triangles with common angles θ₁ < θ₂, the second has the strictly shorter side: t₂.c < t₁.c.",
+      "significance": "The monotone hyperbolic counterpart of the Euclidean fact that all equilateral triangles are similar: here each admissible common angle pins down a unique size, refining AAA congruence into a strict monotonicity along the equilateral family (via cosh injectivity on [0,∞))."
     }
   ],
   "references": [
@@ -353,8 +365,8 @@
     ],
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 331,
-    "theoremCount": 22,
+    "lineCount": 373,
+    "theoremCount": 24,
     "definitionCount": 1,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",
@@ -364,7 +376,8 @@
       "aaa_congruence: equal angles ⟹ equal sides via cosh injectivity on [0,∞)",
       "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) for the equilateral triangle",
       "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — holding two angles fixed, increasing the third strictly shortens the opposite side (refines AAA congruence to a strict comparison)",
-      "Equilateral corollaries (Part 7): equilateral_angle_lt_pi_third (an equilateral hyperbolic triangle has common angle < π/3, the sharp defect-driven counterpart of the Euclidean π/3) and equilateral_pi_four_cosh (the all-angles-π/4 equilateral triangle has every side arcosh(1+√2), i.e. cosh = 1+√2) — no new assumptions"
+      "Equilateral corollaries (Part 7): equilateral_angle_lt_pi_third (an equilateral hyperbolic triangle has common angle < π/3, the sharp defect-driven counterpart of the Euclidean π/3) and equilateral_pi_four_cosh (the all-angles-π/4 equilateral triangle has every side arcosh(1+√2), i.e. cosh = 1+√2) — no new assumptions",
+      "Equilateral-family monotonicity (Part 8): equilateral_cosh_antitone and equilateral_side_antitone — along the one-parameter equilateral family, the side is a strictly decreasing function of the common angle θ ∈ (0, π/3). This sharpens AAA congruence (Part 4) into a strict order statement across the family, complementing the two-angles-fixed monotonicity of Part 4b."
     ],
     "proofStrategy": "Invert each second law of cosines (linear in cosh of the opposite side) via eq_div_iff + linear_combination to get cosh(side) as a ratio of angle functions. Prove the angle ratio exceeds 1 from the defect using cos(A+B) > cos(π-C) = -cos C (strict antitonicity of cos on [0,π]). Conclude AAA congruence by cosh injectivity on [0,∞). Specialize to the equilateral case for a closed form.",
     "openQuestions": [

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -179,8 +179,8 @@
     {
       "path": "Proofs/LawOfCosinesOQ03OQ03.lean",
       "filename": "LawOfCosinesOQ03OQ03.lean",
-      "lineCount": 298,
-      "theoremCount": 20,
+      "lineCount": 373,
+      "theoremCount": 24,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "szemeredi-regularity-oq-04",
   "title": "Formalize the Strong (Alon–Fischer–Krivelevich–Szegedy) Regularity Lemma",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "ACT",
+  "status": "in-progress",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -18,17 +18,12 @@
     "goal": "Formalize the strong regularity lemma by iterating the classical lemma: apply it to get a coarse $\\varepsilon$-regular partition, then re-apply with tolerance $\\mathcal{E}(k)$ on a refinement, using the energy bound $0 \\le q \\le 1$ to cap the number of iterations. Scope: the qualitative existence statement (i)–(iii), building directly on Mathlib's classical regularity API."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-07-04T19:56:31-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "phase": "ACT",
+    "since": "2026-07-08T19:45:20Z",
+    "iteration": 2,
+    "focus": "Verified the finiteness engine of the AFKS iteration (SzemerediRegularityOQ04.lean, 0 sorry/0 axiom): a bounded [0,1]-valued energy potential admits only finitely many delta-increment steps, instantiated on the gallery partitionEnergy. Next: reconstruct the energy-increment step lemma.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
-    "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
-    }
+    "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
   "knowledge": {
     "progressSummary": "",
@@ -100,6 +95,18 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ03.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04.lean",
+      "filename": "SzemerediRegularityOQ04.lean",
+      "lineCount": 148,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-07-08T19:45:20Z"
 }


### PR DESCRIPTION
## Summary

Adds **Part 8** to the Hyperbolic AAA-congruence entry (`law-of-cosines-oq-03-oq-03`): monotonicity of the side along the one-parameter **equilateral family**. Two new theorems, **zero new assumptions**.

- `equilateral_cosh_antitone` — for equilateral hyperbolic triangles with common angles `θ₁ < θ₂`, `cosh(side₂) < cosh(side₁)`. This shows the equilateral closed form `θ ↦ cos θ/(1 − cos θ)` (from the existing `equilateral_cosh`) is **strictly decreasing** across the admissible range `(0, π/3)`: the side blows up as `θ → 0` (thin, large triangles) and shrinks to `0` as `θ → π/3` (the Euclidean limit).
- `equilateral_side_antitone` — the same comparison on the sides, `t₂.c < t₁.c`, via `cosh` injectivity on `[0, ∞)`.

### Why it's new
Distinct from Part 4b (`side_antitone_in_angle`), which pins **two** angles and varies the third. Here all three angles move together along the equilateral family, sharpening AAA congruence (Part 4) into a strict order statement — the hyperbolic counterpart of "all Euclidean equilateral triangles are similar", except each admissible angle pins a **unique** size.

### Verification
- **Host-verified** (`lake env lean`, exit 0, no output → 0 errors, 0 sorries). The Docker build hit a line-less `exit 135` (SIGBUS) at the final compile step *after* successful elaboration — volume corruption, not a proof issue.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
- File: 373 lines, 24 theorems. Status stays **axiomatized** (the 7 structure-encoded geometric assumptions are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)