### PR TITLE
Enrich Chebyshev algebra-endomorphism (de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02): full section coverage

### DIFF
--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02/meta.json
@@ -82,6 +82,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module header, imports, and namespace",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring motivating the algebra-endomorphism upgrade of the parent's Chebyshev index homomorphism, the Mathlib.RingTheory.Polynomial.Chebyshev / Tactic imports, and the import of the parent file DeMoivreOQ01OQ03OQ01OQ01 (supplying the ancestor evaluation identity)."
+    },
+    {
       "id": "alg-end-hom",
       "title": "The algebra-endomorphism homomorphism",
       "startLine": 54,
@@ -99,8 +106,8 @@
       "id": "unit-circle",
       "title": "Unit-circle reparametrization by the power map",
       "startLine": 138,
-      "endLine": 161,
-      "summary": "eval_chebAlgEnd_unit: over a field, (chebAlgEnd n p).eval (z + z⁻¹) = p.eval (zⁿ + z⁻ⁿ), connecting the substitution action to the grandparent's evaluation identity."
+      "endLine": 175,
+      "summary": "eval_chebAlgEnd_unit: over a field, (chebAlgEnd n p).eval (z + z⁻¹) = p.eval (zⁿ + z⁻ⁿ), connecting the substitution action to the grandparent's evaluation identity. Followed by worked ℝ examples (index 1 = identity endomorphism; the concrete n = 3 reparametrization feeding z³ + z⁻³) and a #check verification block over the main declarations."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02` (quality 94, passes 0). Already a comprehensive entry — curation pass, no inflation (~13.8 KB).

## Changes
- **Header section** (lines 1–53): module docstring, imports, and parent import — previously the `sections` array started at line 54, leaving the header uncovered.
- **Extended the `unit-circle` section** from line 161 to 175 so `sections` cover the whole file: the tail holds worked ℝ examples (index 1 = identity endomorphism; the concrete n = 3 reparametrization feeding z³ + z⁻³) and a `#check` verification block, none of which were previously in any section.

## Verification
- meta re-checked against `DeMoivreOQ01OQ03OQ01OQ01OQ02.lean`: 175 lines, 8 theorems, 1 def, 0 sorries, 0 axioms — consistent. Sections now span 1–175 with no gaps.
- JSON validates; within all size caps.