### PR TITLE
research(cauchy-schwarz-integral-oq-04): Heisenberg variance form + reconcile stale docs [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -3,10 +3,11 @@
 
   The gallery entry `CauchySchwarzIntegral` proves the L²/inner-product Cauchy–Schwarz
   inequality `|⟪f,g⟫| ≤ ‖f‖·‖g‖`.  Its OQ-04 asks for the **Heisenberg uncertainty
-  principle**.  The full operator-theoretic statement
-  `Var_ψ(A)·Var_ψ(B) ≥ ¼|⟪ψ,[A,B]ψ⟫|²` needs self-adjoint operators and the
-  commutator, beyond a single file; but the *single inequality that drives it* is a
-  clean Cauchy–Schwarz corollary, and that is what we formalize.
+  principle**.  We formalize both the Cauchy–Schwarz core that drives it *and* the
+  full operator-theoretic statement `Var_ψ(A)·Var_ψ(B) ≥ ¼|⟪ψ,[A,B]ψ⟫|²` for
+  symmetric (self-adjoint) operators `A, B` over `ℝ` or `ℂ` (`robertson_uncertainty`),
+  together with its variance-form specialization at the expectation values
+  (`heisenberg_variance_form`).
 
   Writing `u = (A−⟨A⟩)ψ`, `v = (B−⟨B⟩)ψ`, the uncertainty product is
   `Var(A)·Var(B) = ‖u‖²·‖v‖²`, and the commutator term is `Im⟪u,v⟫`.  The
@@ -20,6 +21,8 @@
 
   * `abs_im_inner_le_norm_mul_norm` — `|Im⟪u,v⟫| ≤ ‖u‖·‖v‖`.
   * `im_inner_sq_le` — `(Im⟪u,v⟫)² ≤ ‖u‖²·‖v‖²`.
+  * `robertson_uncertainty` — `¼‖⟪ψ,[A,B]ψ⟫‖² ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²`.
+  * `heisenberg_variance_form` — the same at `a = ⟨A⟩`, `b = ⟨B⟩` (variance form).
 
   All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -113,5 +116,22 @@ theorem robertson_uncertainty {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
   have him := im_inner_sq_le (𝕜 := 𝕜) u v
   nlinarith [hnb, him, norm_nonneg (inner 𝕜 ψ (A (B ψ) - B (A ψ))),
     abs_nonneg (RCLike.im (inner 𝕜 u v)), sq_abs (RCLike.im (inner 𝕜 u v))]
+
+/-- **Heisenberg uncertainty principle (variance form).**  The physically standard
+statement: instantiating `robertson_uncertainty` at the expectation values
+`⟨A⟩ = Re⟪ψ,Aψ⟫`, `⟨B⟩ = Re⟪ψ,Bψ⟫` makes each factor on the right the variance
+`Var_ψ(A) = ‖(A−⟨A⟩)ψ‖²`, `Var_ψ(B) = ‖(B−⟨B⟩)ψ‖²`, so
+
+  `Var_ψ(A)·Var_ψ(B) ≥ ¼·‖⟪ψ, (AB−BA)ψ⟫‖²`.
+
+For a symmetric operator `⟪ψ,Aψ⟫` is real, so `Re⟪ψ,Aψ⟫` is the genuine
+expectation value `⟨A⟩` and the centred vector `(A−⟨A⟩)ψ` is the fluctuation. -/
+theorem heisenberg_variance_form {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) :
+    (1 / 4 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ ^ 2
+      ≤ ‖A ψ - ((RCLike.re (inner 𝕜 ψ (A ψ)) : ℝ) : 𝕜) • ψ‖ ^ 2
+        * ‖B ψ - ((RCLike.re (inner 𝕜 ψ (B ψ)) : ℝ) : 𝕜) • ψ‖ ^ 2 :=
+  robertson_uncertainty hA hB ψ (RCLike.re (inner 𝕜 ψ (A ψ)))
+    (RCLike.re (inner 𝕜 ψ (B ψ)))
 
 end CauchySchwarzIntegralOQ04

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -22,9 +22,9 @@
     "phase": "COMPLETED",
     "since": "2026-06-22T00:00:00-07:00",
     "iteration": 1,
-    "focus": "Formalized the Cauchy-Schwarz core of the uncertainty principle; the full operator-commutator statement is beyond a single file.",
+    "focus": "Formalized the full Robertson uncertainty relation robertson_uncertainty AND its variance-form specialization heisenberg_variance_form (at the expectation values), on top of the Cauchy-Schwarz core. All verified, 0 axioms/sorries.",
     "blockers": [],
-    "nextAction": "None for the core inequality. The full Var(A)Var(B) ≥ ¼|⟪[A,B]⟫|² needs self-adjoint operator + commutator infrastructure.",
+    "nextAction": "None — the operator-theoretic statement Var(A)Var(B) ≥ ¼|⟪[A,B]⟫|² is proved for symmetric operators (robertson_uncertainty) and stated in variance form (heisenberg_variance_form). A future extension would tie ⟨A⟩ to a bundled self-adjoint-operator/observable layer if Mathlib gains one.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -32,13 +32,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "RESOLVED (full Robertson relation). OQ-04 asked whether Heisenberg Δx·Δp ≥ ℏ/2 can be formalized as a Cauchy-Schwarz consequence. A prior session had only the CS core (abs_im_inner_le_norm_mul_norm, im_inner_sq_le). This session PROVES the full operator-theoretic Robertson uncertainty relation in CauchySchwarzIntegralOQ04.lean: robertson_uncertainty (¼·‖⟪ψ,(AB−BA)ψ⟫‖² ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²) for symmetric A,B on any RCLike inner product space, any state ψ, any real shifts a,b. Key lemma inner_commutator_eq_sub: ⟪ψ,(AB−BA)ψ⟫ = ⟪u,v⟫−⟪v,u⟫ for centred u=(A−a)ψ, v=(B−b)ψ — the shifts CANCEL by symmetry. Then ⟪v,u⟫=conj⟪u,v⟫ gives commutator = 2i·Im⟪u,v⟫ (RCLike.sub_conj), norm 2|Im⟪u,v⟫|, and im_inner_sq_le finishes. Setting a=⟨A⟩,b=⟨B⟩ makes RHS Var(A)·Var(B). Verified: 0 axioms (propext/Classical/Quot only), 0 sorries, no native_decide. File now 4 theorems.",
+    "progressSummary": "RESOLVED (full Robertson relation). OQ-04 asked whether Heisenberg Δx·Δp ≥ ℏ/2 can be formalized as a Cauchy-Schwarz consequence. A prior session had only the CS core (abs_im_inner_le_norm_mul_norm, im_inner_sq_le). This session PROVES the full operator-theoretic Robertson uncertainty relation in CauchySchwarzIntegralOQ04.lean: robertson_uncertainty (¼·‖⟪ψ,(AB−BA)ψ⟫‖² ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖²) for symmetric A,B on any RCLike inner product space, any state ψ, any real shifts a,b. Key lemma inner_commutator_eq_sub: ⟪ψ,(AB−BA)ψ⟫ = ⟪u,v⟫−⟪v,u⟫ for centred u=(A−a)ψ, v=(B−b)ψ — the shifts CANCEL by symmetry. Then ⟪v,u⟫=conj⟪u,v⟫ gives commutator = 2i·Im⟪u,v⟫ (RCLike.sub_conj), norm 2|Im⟪u,v⟫|, and im_inner_sq_le finishes. Setting a=⟨A⟩,b=⟨B⟩ makes RHS Var(A)·Var(B). Verified: 0 axioms (propext/Classical/Quot only), 0 sorries, no native_decide. File now 5 theorems (adds heisenberg_variance_form, the variance-form specialization at the expectation values).",
     "builtItems": [
-      "CauchySchwarzIntegralOQ04.lean: 2 theorems over a general RCLike inner product space, 0 axioms (propext/Classical.choice/Quot.sound), 0 sorries.",
+      "CauchySchwarzIntegralOQ04.lean: 5 theorems over a general RCLike inner product space, 0 axioms (propext/Classical.choice/Quot.sound), 0 sorries.",
       "abs_im_inner_le_norm_mul_norm: |RCLike.im (inner 𝕜 u v)| ≤ ‖u‖·‖v‖ (RCLike.abs_im_le_norm |im z| ≤ ‖z‖, then norm_inner_le_norm).",
       "im_inner_sq_le: (RCLike.im (inner 𝕜 u v))² ≤ ‖u‖²·‖v‖² (nlinarith from the core + sq_abs).",
       "robertson_uncertainty in CauchySchwarzIntegralOQ04.lean (¼‖⟪ψ,[A,B]ψ⟫‖² ≤ ‖(A−a)ψ‖²‖(B−b)ψ‖² — Heisenberg/Robertson, OQ-04 target)",
-      "inner_commutator_eq_sub in CauchySchwarzIntegralOQ04.lean (⟪ψ,(AB−BA)ψ⟫ = ⟪u,v⟫−⟪v,u⟫, shift-independent)"
+      "inner_commutator_eq_sub in CauchySchwarzIntegralOQ04.lean (⟪ψ,(AB−BA)ψ⟫ = ⟪u,v⟫−⟪v,u⟫, shift-independent)",
+      "heisenberg_variance_form in CauchySchwarzIntegralOQ04.lean: the physically standard variance form — instantiates robertson_uncertainty at a=Re⟪ψ,Aψ⟫, b=Re⟪ψ,Bψ⟫ so each RHS factor is Var_ψ(A)=‖(A−⟨A⟩)ψ‖², Var_ψ(B). Verified 0 extra axioms."
     ],
     "insights": [
       "The Heisenberg/Robertson uncertainty inequality's analytic core is Cauchy-Schwarz on the imaginary part: |Im⟪u,v⟫| ≤ |⟪u,v⟫| ≤ ‖u‖‖v‖. For real fields Im = 0 (trivial); the content is the ℂ case.",
@@ -395,8 +396,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ04.lean",
       "filename": "CauchySchwarzIntegralOQ04.lean",
-      "lineCount": 55,
-      "theoremCount": 2,
+      "lineCount": 137,
+      "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Two changes to `Proofs/CauchySchwarzIntegralOQ04.lean`:

1. **New verified theorem `heisenberg_variance_form`** — the physically standard *variance form* of the uncertainty principle. Instantiating the already-proved `robertson_uncertainty` at the expectation values `a = Re⟪ψ,Aψ⟫`, `b = Re⟪ψ,Bψ⟫` turns each right-hand factor into a genuine variance `Var_ψ(A) = ‖(A−⟨A⟩)ψ‖²`, giving `Var_ψ(A)·Var_ψ(B) ≥ ¼‖⟪ψ,[A,B]ψ⟫‖²`. For symmetric `A`, `⟪ψ,Aψ⟫` is real, so `Re⟪ψ,Aψ⟫` is the true expectation value.

2. **Documentation reconciliation.** The file header and the problem metadata (`currentState.focus`/`nextAction`, `builtItems`, and the `leanFile` counts) still described the entry as only having the *Cauchy–Schwarz core* with the full operator statement being "beyond a single file." But `robertson_uncertainty` (and now the variance form) are fully proved in the file. Updated the header prose and OQ04 `leanFile` counts (`lineCount` 55→137, `theoremCount` 2→5).

## Verification

- `heisenberg_variance_form` depends on axioms `[propext, Classical.choice, Quot.sound]` only — **0 extra axioms, 0 sorries**.
- Host-verified with `lake env lean` against Mathlib v4.26 (Docker hit reproducible line-less exit-135 volume corruption; host single-file elaboration clean, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)