### PR TITLE
Restore mainTheorems on denumerability-rationals-oq-05/oq-06 (regression from #35532)

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-05/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-05/meta.json
@@ -115,6 +115,72 @@
       "mathContext": "$\\aleph_0^{\\aleph_0} = \\mathfrak{c} > \\aleph_0$, so $\\mathbb{N} \\to \\mathbb{Q}$ is uncountable."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "mk_seq_rat",
+      "type": "core",
+      "description": "**The boundary: #(ℕ → ℚ) = 𝔠.** Where every finite operation keeps ℚ at ℵ₀, the countable power of rational sequences already reaches the continuum: mk_arrow gives #ℚ ^ #ℕ = ℵ₀ ^ ℵ₀, collapsed by aleph0_power_aleph0 to 𝔠. The sharp companion to the rest of the file — ℕ → ℚ is equinumerous with ℝ.",
+      "leanType": "#(ℕ → ℚ) = 𝔠",
+      "startLine": 64,
+      "endLine": 65
+    },
+    {
+      "name": "not_countable_seq_rat",
+      "type": "key",
+      "description": "**ℕ → ℚ is uncountable.** Immediate from mk_seq_rat and aleph0_lt_continuum (ℵ₀ < 𝔠): rational sequences are strictly more numerous than the rationals themselves.",
+      "leanType": "¬ Countable (ℕ → ℚ)",
+      "startLine": 69,
+      "endLine": 71
+    },
+    {
+      "name": "mk_rat",
+      "type": "supporting",
+      "description": "**#ℚ = ℵ₀.** The rationals are denumerable — countable and infinite, hence exactly ℵ₀ (Cardinal.mk_eq_aleph0). The engine for every result in the file.",
+      "leanType": "#ℚ = ℵ₀",
+      "startLine": 32,
+      "endLine": 33
+    },
+    {
+      "name": "mk_rat_prod",
+      "type": "supporting",
+      "description": "**#(ℚ × ℚ) = ℵ₀.** Pairs of rationals are still denumerable: mk_prod gives #ℚ · #ℚ and aleph0_mul_aleph0 collapses ℵ₀ · ℵ₀ to ℵ₀ — the ℵ₀-analogue of the continuum's 𝔠 · 𝔠 = 𝔠.",
+      "leanType": "#(ℚ × ℚ) = ℵ₀",
+      "startLine": 38,
+      "endLine": 39
+    },
+    {
+      "name": "mk_rat_prod_eq_mk_rat",
+      "type": "supporting",
+      "description": "**#(ℚ × ℚ) = #ℚ.** The plane of rationals equals the line of rationals; both are ℵ₀.",
+      "leanType": "#(ℚ × ℚ) = #ℚ",
+      "startLine": 43,
+      "endLine": 44
+    },
+    {
+      "name": "nonempty_equiv_prod_rat",
+      "type": "supporting",
+      "description": "**An explicit bijection ℚ × ℚ ≃ ℚ exists** (Cardinal.eq applied to mk_rat_prod_eq_mk_rat).",
+      "leanType": "Nonempty (ℚ × ℚ ≃ ℚ)",
+      "startLine": 47,
+      "endLine": 48
+    },
+    {
+      "name": "mk_list_rat",
+      "type": "supporting",
+      "description": "**#(List ℚ) = ℵ₀.** Finite sequences of rationals are denumerable (mk_list_eq_aleph0, valid for any countable nonempty type).",
+      "leanType": "#(List ℚ) = ℵ₀",
+      "startLine": 52,
+      "endLine": 53
+    },
+    {
+      "name": "mk_finset_rat",
+      "type": "supporting",
+      "description": "**#(Finset ℚ) = ℵ₀.** Finite subsets of ℚ are denumerable: mk_finset_of_infinite gives #(Finset ℚ) = #ℚ, rewritten to ℵ₀ by mk_rat.",
+      "leanType": "#(Finset ℚ) = ℵ₀",
+      "startLine": 57,
+      "endLine": 58
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "denumerability-rationals",

--- a/src/data/proofs/denumerability-rationals-oq-06/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-06/meta.json
@@ -103,6 +103,48 @@
       "mathContext": "Since #ℕ = ℵ₀ = #(ℚ[X]), Cardinal.eq gives an equivalence ℕ ≃ ℚ[X], i.e. ℚ[X] is denumerable."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "cardinalMk_polynomial_rat",
+      "type": "core",
+      "description": "**#(ℚ[X]) = ℵ₀.** The rational polynomial ring is denumerable: Polynomial.cardinalMk_eq_max gives #(ℚ[X]) = max #ℚ ℵ₀, and #ℚ = ℵ₀ collapses the maximum to ℵ₀. So adjoining an indeterminate to ℚ does not increase cardinality.",
+      "leanType": "#(ℚ[X]) = ℵ₀",
+      "startLine": 36,
+      "endLine": 37
+    },
+    {
+      "name": "cardinalMk_polynomial_int",
+      "type": "key",
+      "description": "**#(ℤ[X]) = ℵ₀.** The same argument with #ℤ = ℵ₀ (Cardinal.mk_int): the integer polynomial ring is also denumerable.",
+      "leanType": "#(ℤ[X]) = ℵ₀",
+      "startLine": 40,
+      "endLine": 41
+    },
+    {
+      "name": "cardinalMk_polynomial_rat_eq_int",
+      "type": "supporting",
+      "description": "**#(ℚ[X]) = #(ℤ[X]).** The rational and integer polynomial rings have the same cardinality (both ℵ₀).",
+      "leanType": "#(ℚ[X]) = #(ℤ[X])",
+      "startLine": 44,
+      "endLine": 45
+    },
+    {
+      "name": "nonempty_nat_equiv_polynomial_rat",
+      "type": "key",
+      "description": "**ℚ[X] is denumerable.** Since #ℕ = #(ℚ[X]) (both ℵ₀), Cardinal.eq yields a bijection ℕ ≃ ℚ[X].",
+      "leanType": "Nonempty (ℕ ≃ ℚ[X])",
+      "startLine": 49,
+      "endLine": 50
+    },
+    {
+      "name": "mk_rat",
+      "type": "supporting",
+      "description": "**#ℚ = ℵ₀** (mk_eq_aleph0) — the engine lemma the polynomial-ring cardinalities reduce to.",
+      "leanType": "#ℚ = ℵ₀",
+      "startLine": 32,
+      "endLine": 32
+    }
+  ],
   "references": [
     {
       "authors": "Cantor, Georg",


### PR DESCRIPTION
## Regression repair

The erdos-214 research PR **#35532** (commit `6a0d1676d9d`) was based on stale `main` and, on merge, **accidentally deleted** the `mainTheorems` arrays that two enrichment PRs had just added:
- **#35520** → `denumerability-rationals-oq-05` (8-theorem array, 66 lines)
- **#35521** → `denumerability-rationals-oq-06` (5-theorem array, 42 lines)

Both entries currently render on `main` with `mainTheorems: []` despite having 8 and 5 theorems respectively.

## Fix
Restored both arrays verbatim from their enrichment commits (`e032c3e` for oq-05, `3e19624` for oq-06).

## Verification
- `git diff main` is **purely** the mainTheorems additions (66 + 42 insertions, 0 deletions, no other fields touched).
- Every restored anchor re-verified against the current Lean sources — all names map to the correct `startLine` (oq-05: 8/8 theorems at lines 32/38/43/47/52/57/64/69; oq-06: 5/5 at 32/36/40/44/49).
- Both JSON files validate; leanFile theoremCount matches the restored array length.

_(This is the kind of stale-base clobber that math PRs bypassing CI can introduce; flagging the pattern in the body.)_