### PR TITLE
Fix stale theoremCount on descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02 (4 → 7)

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -32,7 +32,7 @@
         "relationship": "Upgrades the parent's existential exists_width_lt / exists_level_isolates to an explicit O(log) computable witness"
       }
     ],
-    "theoremCount": 4,
+    "theoremCount": 7,
     "definitionCount": 1
   },
   "overview": {
@@ -50,7 +50,7 @@
     "namespace": "VincentBisection",
     "lineCount": 186,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 7,
     "sorries": 0,
     "mainTheorems": [
       {


### PR DESCRIPTION
Accuracy fix for `descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02` (quality 94, passes 0).

Both `meta.theoremCount` and `leanFile.theoremCount` reported **4**, but `DescartesRuleOfSignsOQ02OQ01OQ03OQ02.lean` actually has **7** theorems:
`minGap_pos`, `minGap_le`, `subsingleton_of_width_lt_minGap`, `width_lt_minGap_of_clog_lt`, `level_isolates_explicit_bound`, `level_isolates_explicit`, `level_isolates_explicit_each` (+ 1 def `minGap`).

- No private or attributed (`@[...]`) theorems that a `^theorem ` scan would miss; count is exact.
- `definitionCount` (1) and `lineCount` (186) were already correct; the mainTheorems array, sections (full 1–186 coverage), and cross-references are all accurate, so no other changes.
- Diff is exactly the two count lines (2 ins / 2 del).