### PR TITLE
research(erdos-703-incomplete-01): even-parity Frankl-Füredi family r-avoiding + T(n,r) bound [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -332,6 +332,58 @@ theorem franklFurediOdd_card_le_T (n r : ℕ) : (franklFurediOdd n r).card ≤ T
     exact ⟨Finset.mem_powerset.mpr (Finset.filter_subset _ _), franklFurediOdd_avoids_r n r⟩
   exact Finset.le_sup hmem
 
+/--
+**Two members of `franklFurediEven` avoid `r`-intersection (`n + r` even, `n ≥ 1`).**
+The even-parity companion of `franklFurediOdd_avoids_r`. Here the "large" condition
+is on the *centred* set `A₀ = A \ {0}` (`|A₀| ≥ (n+r)/2`), living in the
+`(n−1)`-element ground set `{1,…,n−1}`. For two large sets, inclusion–exclusion on
+the centred sets gives
+`|A ∩ B| ≥ |A₀ ∩ B₀| ≥ 2·⌊(n+r)/2⌋ − (n−1) = (n+r) − (n−1) = r+1 > r`,
+using `n + r` even so `2·⌊(n+r)/2⌋ = n+r`; if either set is small (`|·| < r`) then
+`|A ∩ B| ≤ min(|A|,|B|) < r`. In every case `|A ∩ B| ≠ r`. -/
+theorem franklFurediEven_avoids_r (n r : ℕ) (hn : 1 ≤ n) (hpar : (n + r) % 2 = 0) :
+    avoidsRIntersection r (franklFurediEven n r) := by
+  intro A B hA hB
+  rw [franklFurediEven, Finset.mem_filter, Finset.mem_powerset] at hA hB
+  obtain ⟨hAsub, hAcond⟩ := hA
+  obtain ⟨hBsub, hBcond⟩ := hB
+  set A0 := A.filter (· ≠ 0) with hA0
+  set B0 := B.filter (· ≠ 0) with hB0
+  have hA0subA : A0 ⊆ A := Finset.filter_subset _ _
+  have hB0subB : B0 ⊆ B := Finset.filter_subset _ _
+  -- The centred intersection sits inside the actual intersection.
+  have hcard_int : (A0 ∩ B0).card ≤ (A ∩ B).card :=
+    Finset.card_le_card (Finset.inter_subset_inter hA0subA hB0subB)
+  -- The centred sets live in `{1,…,n−1}`, which has `n−1` elements.
+  have hground : ((Finset.range n).filter (· ≠ 0)).card = n - 1 := by
+    rw [Finset.filter_ne', Finset.card_erase_of_mem (Finset.mem_range.mpr hn),
+      Finset.card_range]
+  have hA0sub : A0 ⊆ (Finset.range n).filter (· ≠ 0) :=
+    Finset.filter_subset_filter (· ≠ 0) hAsub
+  have hB0sub : B0 ⊆ (Finset.range n).filter (· ≠ 0) :=
+    Finset.filter_subset_filter (· ≠ 0) hBsub
+  have hunion0 : (A0 ∪ B0).card ≤ n - 1 := by
+    calc (A0 ∪ B0).card ≤ ((Finset.range n).filter (· ≠ 0)).card :=
+          Finset.card_le_card (Finset.union_subset hA0sub hB0sub)
+      _ = n - 1 := hground
+  have hie0 := Finset.card_union_add_card_inter A0 B0
+  have hiA : (A ∩ B).card ≤ A.card := Finset.card_le_card Finset.inter_subset_left
+  have hiB : (A ∩ B).card ≤ B.card := Finset.card_le_card Finset.inter_subset_right
+  rcases hAcond with hAlarge | hAsmall <;> rcases hBcond with hBlarge | hBsmall <;> omega
+
+/--
+**Lower bound on `T(n,r)` from the `franklFurediEven` construction (`n + r` even).**
+The even-parity analogue of `franklFurediOdd_card_le_T`: `franklFurediEven n r` is a
+valid `r`-avoiding subfamily of `2^{[n]}`, so its cardinality bounds `T(n,r)` below. -/
+theorem franklFurediEven_card_le_T (n r : ℕ) (hn : 1 ≤ n) (hpar : (n + r) % 2 = 0) :
+    (franklFurediEven n r).card ≤ T n r := by
+  have hmem : franklFurediEven n r ∈
+      ((Finset.range n).powerset.powerset).filter (avoidsRIntersection r) := by
+    rw [Finset.mem_filter]
+    exact ⟨Finset.mem_powerset.mpr (Finset.filter_subset _ _),
+      franklFurediEven_avoids_r n r hn hpar⟩
+  exact Finset.le_sup hmem
+
 /-
 ## Part V: The Main Question - Exponential Bound
 

--- a/src/data/research/problems/erdos-703-incomplete-01.json
+++ b/src/data/research/problems/erdos-703-incomplete-01.json
@@ -15,18 +15,21 @@
     "open": [],
     "goal": ""
   },
-  "currentState": "T(n,0) = 2^{n-1} is now fully machine-checked (0 sorries). The deep Frankl-Rodl exponential bound and the unit-distance chromatic number remain axiomatized (frankl_rodl_1987, chromaticNumber). Entry status: axiomatized, 2 axioms, 0 sorries.",
+  "currentState": "T(n,0)=2^{n-1} is fully machine-checked, and BOTH parities of the Frankl-Füredi extremal construction are now proved r-avoiding with matching T(n,r) lower bounds: franklFurediOdd_avoids_r / _card_le_T (all n,r) and the new even-parity companions franklFurediEven_avoids_r / _card_le_T (n+r even, n≥1). The deep Frankl-Rödl exponential bound (frankl_rodl_1987) remains the sole axiom. Entry status: axiomatized, 1 axiom, 0 sorries.",
   "knowledge": {
     "progressSummary": "PROGRESS: trivial case T(n,0)=2^{n-1} fully machine-checked (sorry eliminated); deep cases remain axiomatized | 2026-07-08 (researcher-3): advanced the r=1 case — assembled large_sets_avoid_1 into largeSetsFamily (Frankl 1977 lower-bound construction) and proved largeSetsFamily_card_le_T: |largeSetsFamily n| ≤ T(n,1). Verified, 0 new axioms.",
     "builtItems": [
       "card_le_of_avoids_zero (Erdos703Problem.lean:97): complement-pairing upper bound |F| <= 2^{n-1} for 0-avoiding families",
       "star_family_card (Erdos703Problem.lean:164): fixed-point star family has 2^{n-1} members (Finset.card_nbij' bijection)",
-      "T_n_0 (Erdos703Problem.lean:204): full machine-checked proof T(n,0) = 2^{n-1} via le_antisymm (replaced a sorry)"
+      "T_n_0 (Erdos703Problem.lean:204): full machine-checked proof T(n,0) = 2^{n-1} via le_antisymm (replaced a sorry)",
+      "franklFurediEven_avoids_r (Erdos703Problem.lean): the even-parity (n+r even, n≥1) companion of franklFurediOdd_avoids_r — the family {A⊆[n] : |A\\{0}|≥(n+r)/2 ∨ |A|<r} avoids r-intersection. Large-large case uses inclusion-exclusion on the centred sets A\\{0},B\\{0} in the (n-1)-element ground set {1,…,n-1}: |A∩B|≥2⌊(n+r)/2⌋-(n-1)=r+1. VERIFIED 0 extra axioms.",
+      "franklFurediEven_card_le_T (Erdos703Problem.lean): even-parity T(n,r) lower bound, mirroring franklFurediOdd_card_le_T via Finset.le_sup. VERIFIED 0 extra axioms."
     ],
     "insights": [
       "T(n,0) = 2^{n-1}: the 0-avoiding families are exactly the intersecting families; the complement map sending A to its complement in [n] injects any intersecting F into a disjoint copy, giving 2|F| <= 2^n, hence |F| <= 2^{n-1}.",
       "Sharpness is witnessed by the star family of all subsets of [n] containing 0, in bijection with the powerset of [n] minus {0} via A maps to A.erase 0, so it has exactly 2^{n-1} members.",
-      "The remaining open content (Frankl-Rodl 1987 main bound, exponential chromatic number) is genuinely deep and stays axiomatized; only the trivial base case was within reach of a from-scratch Lean proof."
+      "The remaining open content (Frankl-Rodl 1987 main bound, exponential chromatic number) is genuinely deep and stays axiomatized; only the trivial base case was within reach of a from-scratch Lean proof.",
+      "The even-parity Frankl-Füredi family needs the |A\\{0}| (centred) size condition, not |A|: removing the fixed element 0 shrinks the ground set to n-1, which exactly compensates for the non-strict ≥ so that 2⌊(n+r)/2⌋-(n-1)=r+1 when n+r is even. For n+r odd the same bound only gives r (not r+1), which is why franklFurediOdd (strict >) covers the odd parity instead."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Completes a symmetric gap in `Proofs/Erdos703Problem.lean`. The file defined both the odd- and even-parity Frankl–Füredi extremal families, but only `franklFurediOdd` had the theorems establishing it is `r`-avoiding and gives a `T(n,r)` lower bound. This PR adds the even-parity companions:

- **`franklFurediEven_avoids_r`** (`n+r` even, `n ≥ 1`): the family `{A ⊆ [n] : |A\{0}| ≥ (n+r)/2 ∨ |A| < r}` avoids `r`-intersection. The large–large case runs inclusion–exclusion on the *centred* sets `A\{0}`, `B\{0}` inside the `(n−1)`-element ground set `{1,…,n−1}`, giving `|A∩B| ≥ 2⌊(n+r)/2⌋ − (n−1) = (n+r) − (n−1) = r+1 > r` (the even parity makes `2⌊(n+r)/2⌋ = n+r`). Small cases: `|A∩B| ≤ min(|A|,|B|) < r`.
- **`franklFurediEven_card_le_T`**: the matching even-parity `T(n,r)` lower bound, mirroring `franklFurediOdd_card_le_T`.

### Why the centring, and why the parity hypothesis
Removing the fixed element `0` shrinks the ground set to `n−1`, which exactly compensates for the non-strict `≥` condition; for `n+r` **odd** the same bound only yields `r` (not `r+1`), which is precisely why the odd parity is covered by the strict-`>` `franklFurediOdd` family instead. So the two constructions partition by parity.

## Verification

- Both theorems depend on axioms `[propext, Classical.choice, Quot.sound]` only — **0 extra axioms, 0 sorries**. (The file's sole assumption remains the deep `frankl_rodl_1987` exponential bound, untouched.)
- Host-verified with `lake env lean` against Mathlib v4.26 (Docker hit reproducible line-less exit-135 volume corruption; host single-file elaboration clean, exit 0).
- Also corrected stale `currentState` metadata (1 axiom, not 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)