### PR TITLE
research(erdos-1090): prove higher-dimensional analogue (replace True placeholder) [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -571,16 +571,132 @@ theorem erdos1090_generalized_affirmative (k r : ℕ) : Erdos1090Generalized k r
   exact ⟨S, hSA, hScol, fun p hp q hq => hmono p q hp hq⟩
 
 /--
-**Higher Dimensions:**
-Does the analogue hold in ℝ³ with planes instead of lines?
+**Collinearity in `ℝ^d`.**  A finite set `S ⊆ (Fin d → ℝ)` is collinear when all
+of its points lie on one affine line `{p₀ + t • dir | t ∈ ℝ}` with a nonzero
+direction `dir`.  This is the genuine higher-dimensional analogue of the planar
+`IsKCollinear`: `k` collinear points span an affine line (a `1`-flat), which is a
+fortiori contained in a common hyperplane, so it is the *strongest* faithful
+reading of "the analogue in `ℝ^d`". -/
+def CollinearInDim {d : ℕ} (S : Finset (Fin d → ℝ)) : Prop :=
+  ∃ p₀ dir : Fin d → ℝ, dir ≠ 0 ∧ ∀ s ∈ S, ∃ t : ℝ, s = p₀ + t • dir
+
+/--
+**Higher Dimensions.**  Does the monochromatic-collinear analogue hold in `ℝ^d`?
+For `d ≥ 2` and `k ≥ 3` we ask for a finite `A ⊂ ℝ^d` such that every `2`-coloring
+of `A` contains `k` monochromatic points lying on a common affine line.  (Points on
+a line lie on a common hyperplane, so this affirms the planes/hyperplanes reading of
+the classical question in every dimension.)
 -/
 def Erdos1090HigherDim (d k : ℕ) : Prop :=
-  d ≥ 2 → k ≥ d + 1 →
+  2 ≤ d → 3 ≤ k →
   ∃ A : Finset (Fin d → ℝ), ∀ c : (Fin d → ℝ) → Bool,
-    ∃ S : Finset (Fin d → ℝ), S ⊆ A ∧ S.card ≥ k ∧
-      -- All points in S lie on a (d-1)-dimensional hyperplane
-      -- and all have the same color
-      True
+    ∃ S : Finset (Fin d → ℝ), S ⊆ A ∧ k ≤ S.card ∧ CollinearInDim S ∧
+      ∀ p ∈ S, ∀ q ∈ S, c p = c q
+
+/-- **Erdős #1090 — higher-dimensional analogue, affirmative.**  For every `d ≥ 2`
+and `k ≥ 3` there is a finite `A ⊂ ℝ^d` such that every `2`-coloring of `A` contains
+`k` monochromatic collinear points.  Proved by the same Hales–Jewett generic-projection
+construction as the planar case, projecting the combinatorial cube `[k]^ι` directly into
+`ℝ^d` via `φ p = ∑ j, (p j) • v j` with `v j = e₀ + (w j) • e₁` (first coordinate `1`,
+second coordinate `w j`, the rest `0`).  A monochromatic combinatorial line maps to `k`
+distinct collinear points of one color; the image direction has first coordinate
+`|varying set| ≥ 1 > 0`, hence is nonzero. -/
+theorem erdos1090_higherDim_affirmative (d k : ℕ) : Erdos1090HigherDim d k := by
+  classical
+  intro hd hk
+  haveI : NeZero k := ⟨by omega⟩
+  -- The first coordinate index, available since `d ≥ 2`; used to witness `dir ≠ 0`.
+  set e0 : Fin d := ⟨0, by omega⟩ with he0
+  -- Hales–Jewett: a finite index type `ι` controlling every `2`-coloring of `[k]^ι`.
+  obtain ⟨ι, ιfin, hHJ⟩ :=
+    Combinatorics.Line.exists_mono_in_high_dimension (Fin k) Bool
+  haveI : Fintype ι := ιfin
+  set emb : Fin k → ℝ := fun a => (a.val : ℝ) with hemb
+  set w : ι → ℝ := fun j => ((Fintype.equivFin ι j).val : ℝ) with hw
+  -- Per-coordinate image vectors in `ℝ^d`: `v j = (1, w j, 0, …, 0)`.
+  set v : ι → (Fin d → ℝ) :=
+    fun j i => if (i : ℕ) = 0 then 1 else if (i : ℕ) = 1 then w j else 0 with hv
+  -- Linear "generic projection" `φ : [k]^ι → ℝ^d`.
+  set φ : (ι → Fin k) → (Fin d → ℝ) := fun p => ∑ j, emb (p j) • v j with hφ
+  refine ⟨Finset.image φ Finset.univ, ?_⟩
+  intro c
+  obtain ⟨l, col, hcol⟩ := hHJ (fun p => c (φ p))
+  have hcol' : ∀ a : Fin k, c (φ (l a)) = col := fun a => hcol a
+  set dir : (Fin d → ℝ) := ∑ j, (if l.idxFun j = none then (1 : ℝ) else 0) • v j with hdir
+  have key : ∀ (a : Fin k) (j : ι),
+      emb (l a j) = emb (l 0 j) + emb a * (if l.idxFun j = none then (1 : ℝ) else 0) := by
+    intro a j
+    by_cases h : l.idxFun j = none
+    · rw [l.apply_none a j h, l.apply_none 0 j h, if_pos h]
+      simp [hemb]
+    · obtain ⟨b, hb⟩ := Option.ne_none_iff_exists'.mp h
+      simp only [l.apply_some hb, if_neg h]
+      simp [hemb]
+  have hline : ∀ a : Fin k, φ (l a) = φ (l 0) + emb a • dir := by
+    intro a
+    simp only [hφ, hdir, Finset.smul_sum]
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [key a j, add_smul, mul_smul]
+  -- The image direction is nonzero: its `e0`-coordinate equals `|varying set| ≥ 1`.
+  have heval : dir e0 = ∑ j, (if l.idxFun j = none then (1 : ℝ) else 0) := by
+    rw [hdir, Finset.sum_apply]
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [Pi.smul_apply, smul_eq_mul]
+    have hv0 : v j e0 = 1 := by simp [hv, he0]
+    rw [hv0, mul_one]
+  have hdir_ne : dir ≠ 0 := by
+    intro h0
+    have hpos : (0 : ℝ) < dir e0 := by
+      rw [heval]
+      obtain ⟨j0, hj0⟩ := l.proper
+      calc (0 : ℝ) < 1 := one_pos
+        _ = (if l.idxFun j0 = none then (1 : ℝ) else 0) := (if_pos hj0).symm
+        _ ≤ ∑ j, (if l.idxFun j = none then (1 : ℝ) else 0) :=
+            Finset.single_le_sum
+              (f := fun j => if l.idxFun j = none then (1 : ℝ) else 0)
+              (fun j _ => by
+                show (0 : ℝ) ≤ if l.idxFun j = none then (1 : ℝ) else 0
+                split_ifs <;> norm_num)
+              (Finset.mem_univ j0)
+    rw [h0] at hpos
+    simp at hpos
+  refine ⟨Finset.image (fun a : Fin k => φ (l a)) Finset.univ, ?_, ?_, ?_, ?_⟩
+  · -- `S ⊆ A`
+    intro x hx
+    simp only [Finset.mem_image, Finset.mem_univ, true_and] at hx ⊢
+    obtain ⟨a, ha⟩ := hx
+    exact ⟨l a, ha⟩
+  · -- `k ≤ S.card`
+    have hinj : Function.Injective (fun a : Fin k => φ (l a)) := by
+      intro a a' haa'
+      simp only at haa'
+      rw [hline a, hline a'] at haa'
+      have hsm : emb a • dir = emb a' • dir := add_left_cancel haa'
+      have hee : emb a = emb a' := by
+        by_contra hne
+        have h2 : (emb a - emb a') • dir = 0 := by rw [sub_smul, hsm, sub_self]
+        rcases smul_eq_zero.mp h2 with h | h
+        · exact hne (sub_eq_zero.mp h)
+        · exact hdir_ne h
+      have : a.val = a'.val := by
+        have := hee; simp only [hemb] at this; exact Nat.cast_injective this
+      exact Fin.ext this
+    rw [Finset.card_image_of_injective _ hinj, Finset.card_univ, Fintype.card_fin]
+  · -- `CollinearInDim S`
+    refine ⟨φ (l 0), dir, hdir_ne, ?_⟩
+    intro p hp
+    simp only [Finset.mem_image, Finset.mem_univ, true_and] at hp
+    obtain ⟨a, ha⟩ := hp
+    exact ⟨emb a, by rw [← ha, hline a]⟩
+  · -- Monochromatic.
+    intro p hp q hq
+    simp only [Finset.mem_image, Finset.mem_univ, true_and] at hp hq
+    obtain ⟨a, ha⟩ := hp
+    obtain ⟨a', ha'⟩ := hq
+    rw [← ha, ← ha', hcol' a, hcol' a']
 
 /-
 ## Part XI: Main Results Summary

--- a/research/problems/erdos-1090-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1090-incomplete-01/knowledge.md
@@ -28,7 +28,36 @@ construction body are duplicated between `erdos1090_construction` (Bool) and
 `ramsey_construction_general Bool` corollary (defeq), but I left the verified Bool proof
 untouched to avoid risk.
 
+## Session 2026-07-08 (researcher-7) — higher-dimensional analogue (proved the placeholder def)
+
+**Mode**: ACT (look-outward on a SOLVED entry). **Outcome**: progress, 0-axiom.
+`Erdos1090HigherDim d k` *existed* as a def but its body carried a vacuous `True` placeholder
+(the "S lies on a hyperplane" condition was never stated) — so it was trivially satisfiable and
+meaningless. Replaced it with a genuine statement and PROVED it:
+- `CollinearInDim {d} (S : Finset (Fin d → ℝ))`: new predicate = all points of `S` lie on one
+  affine line `p₀ + t • dir` with `dir ≠ 0` (a shared affine 1-flat). This is the strongest
+  faithful ℝ^d reading — `k` collinear points span a line, a fortiori contained in a common
+  hyperplane, so it affirms the planes/hyperplanes question in every dimension.
+- `Erdos1090HigherDim d k` rewritten: `2 ≤ d → 3 ≤ k → ∃ A, ∀ c:(Fin d→ℝ)→Bool, ∃ S⊆A,
+  k ≤ S.card ∧ CollinearInDim S ∧ monochromatic`.
+- `erdos1090_higherDim_affirmative (d k) : Erdos1090HigherDim d k`: same Hales–Jewett
+  generic-projection proof as the planar case, but projecting `[k]^ι` into ℝ^d via
+  `v j i = if i=0 then 1 else if i=1 then w j else 0` (first coord 1, second `w j`, rest 0).
+  Nonzeroness of `dir` read off coordinate `e0 := ⟨0, by omega⟩` (available since `d ≥ 2`):
+  `dir e0 = ∑ (varying indicator) ≥ 1 > 0` via `Finset.single_le_sum` on `l.proper`.
+  Injectivity/collinearity/mono transport verbatim from the ℝ² proof.
+
+File 614→730 lines, 13→14 theorems, 17→18 defs, 0 sorry / 0 axiom. Host `lake env lean` EXIT 0;
+`#print axioms erdos1090_higherDim_affirmative` = [propext, Classical.choice, Quot.sound] only.
+NOTE the ℝ^d proof again duplicates ~90 lines of the projection body (key/hline/hdir_ne/
+injectivity) — third copy now (Bool, general-C, ℝ^d); a future factor-out is possible but each
+copy differs in the vector-space (`Point` vs `Fin d → ℝ`) and the nonzero-coordinate extraction
+(`WithLp.ofLp … 0` vs `dir e0`), so I left the three verified copies untouched.
+
 ## Still open / next
-- Dedup: make `erdos1090_construction` a corollary of `ramsey_construction_general Bool`.
-- `Erdos1090HigherDim` (ℝᵈ, hyperplanes), `SylvesterGallai`, `HellyProperty` remain DEFS, unproved.
+- Dedup: factor the shared generic-projection body across `erdos1090_construction` (Bool),
+  `ramsey_construction_general` (general C), and `erdos1090_higherDim_affirmative` (ℝ^d).
+- `SylvesterGallai`, `HellyProperty` remain DEFS, unproved.
 - Quantitative `ramseyNumber k` upper bound (explicit |A|); only `ramsey_lower_bound (≥ k)` exists.
+- `ramseyNumber_mono` (k'≤k ⟹ ramseyNumber k' ≤ ramseyNumber k) is a clean easy follow-up via
+  `hasRamseyProperty_antitone` + `Nat.sInf` subset monotonicity.

--- a/research/problems/erdos-1090-incomplete-01/state.md
+++ b/research/problems/erdos-1090-incomplete-01/state.md
@@ -1,16 +1,16 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-03T08:10:05.551Z
-**Iteration**: 1
+**Phase**: PROGRESS (look-outward on a SOLVED entry)
+**Since**: 2026-07-08
+**Iteration**: 3
 
 ## Current Focus
 
-Initial exploration of the problem.
+Higher-dimensional analogue of Erdős #1090, proved.
 
 ## Active Approach
 
-None yet.
+Hales–Jewett generic projection, now targeting ℝ^d instead of ℝ².
 
 ## Blockers
 
@@ -18,10 +18,12 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+Remaining follow-ups: dedup erdos1090_construction as a corollary of
+ramsey_construction_general Bool; quantitative ramseyNumber upper bound;
+SylvesterGallai / HellyProperty still DEFS.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 3
+- Current approach attempts: 1
+- Approaches tried: 2 (r-coloring generalization; higher-dimensional analogue)

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -56,6 +56,8 @@
       "Key geometric lemma: a combinatorial line maps to the affine line t ↦ φ(l 0) + t • dir, where the direction dir has first coordinate equal to the number of varying coordinates |V| ≥ 1, hence dir ≠ 0 — giving k genuinely distinct collinear points of one color.",
       "Nonzeroness handled cleanly via WithLp.ofLp (the linear coordinate map), reducing to a positive Finset sum (single_le_sum on the proper-coordinate witness).",
       "graham_selfridge: now an honest theorem, the k=3 instance of erdos1090_construction (formerly an axiom).",
+      "erdos1090_higherDim_affirmative: the higher-dimensional analogue, now an honest theorem. The former Erdos1090HigherDim def carried a vacuous 'True' placeholder; it is replaced by a genuine statement (CollinearInDim S: all points of S lie on one affine line p0 + t*dir with dir != 0) and PROVED for every d >= 2, k >= 3 by the same Hales-Jewett generic projection, now targeting R^d via v j = e0 + (w j)*e1 (first coord 1, second w j, rest 0). k monochromatic points on a common line lie a fortiori on a common hyperplane, affirming the planes/hyperplanes reading in all dimensions.",
+      "CollinearInDim: new predicate giving the faithful R^d notion of collinearity (points on a shared affine 1-flat), the honest replacement for the previous placeholder condition.",
       "hunter_observation: now an honest theorem = erdos1090_construction (formerly an axiom).",
       "Point abbrev, TwoColoring, Collinear, PointsOnLine, Line structure, OnLine predicate",
       "IsMonochromatic, IsKCollinear, MonochromaticKCollinear, HasRamseyProperty, Erdos1090Question statements",
@@ -67,10 +69,10 @@
       "erdos1090_generalized_affirmative: proves the previously-unproved r-coloring version Erdos1090Generalized k r, by specializing ramsey_construction_general to C=Fin r (multicolor Hales–Jewett needs no extra hypothesis on r)"
     ],
     "axiomCount": 0,
-    "lineCount": 614,
+    "lineCount": 730,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 13,
-    "definitionCount": 17
+    "theoremCount": 14,
+    "definitionCount": 18
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1090: Monochromatic Collinear Points**\n\nThis problem is a Ramsey-type question in Euclidean geometry: given a 2-coloring of a finite point set, must there exist monochromatic collinear points?\n\n**Key History:**\n- Erdős (1975): Posed the problem in [Er75f] \"On some problems of elementary and combinatorial geometry\"\n- Graham-Selfridge: Proved the k=3 case with an explicit construction\n- Hunter: Observed that generic projections of [k]ⁿ work via Hales-Jewett\n\n**Mathematical Setting:**\nThe Hales-Jewett theorem (1963) guarantees monochromatic combinatorial lines in [k]ⁿ for sufficiently large n. A generic (algebraically independent) projection to ℝ² preserves the collinear structure, solving the problem for all k. The solution exemplifies the transfer principle: combinatorial Ramsey results in high-dimensional grids project to geometric Ramsey results in the plane.",
@@ -105,10 +107,10 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 614,
+    "lineCount": 730,
     "axiomCount": 0,
-    "theoremCount": 11,
-    "definitionCount": 17,
+    "theoremCount": 14,
+    "definitionCount": 18,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Erdős Problem #1090 (monochromatic collinear points) is already solved in ℝ² (`erdos1090_construction`, 0-axiom via Hales–Jewett) and generalized to r-colorings. This PR fills a genuine remaining gap: the **higher-dimensional analogue**.

The `Erdos1090HigherDim d k` definition existed but carried a **vacuous `True` placeholder** — the intended "S lies on a hyperplane" condition was never stated, making the def trivially satisfiable and mathematically meaningless.

## What changed

- **`CollinearInDim {d} (S : Finset (Fin d → ℝ))`** — new predicate: all points of `S` lie on one affine line `p₀ + t • dir` with `dir ≠ 0` (a shared affine 1-flat). This is the strongest faithful ℝ^d reading of the classical question: `k` collinear points span a line, a fortiori contained in a common hyperplane.
- **`Erdos1090HigherDim d k`** rewritten with the genuine monochromatic-collinear condition (was `True`).
- **`erdos1090_higherDim_affirmative (d k) : Erdos1090HigherDim d k`** — proved for every `d ≥ 2`, `k ≥ 3` by the same Hales–Jewett generic-projection construction, now projecting the combinatorial cube `[k]^ι` directly into ℝ^d via `v j = (1, w j, 0, …, 0)`. Nonzeroness of the image direction is read off coordinate `0` (available since `d ≥ 2`): it equals `|varying set| ≥ 1 > 0`.

## Verification

- Host `lake env lean Proofs/Erdos1090Problem.lean` → **EXIT 0** (only pre-existing warnings).
- `#print axioms erdos1090_higherDim_affirmative` → `[propext, Classical.choice, Quot.sound]` only — **0 sorry / 0 axiom**.
- File 614→730 lines, 13→14 theorems, 17→18 defs. meta.json `leanFile`/`meta` counts synced (leanFile.theoremCount was also stale at 11).

Status remains `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)