### PR TITLE
Enrich Kronecker density (dirichlet-approximation-theorem-oq-04): add sibling cross-ref to oq-02

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04/meta.json
@@ -157,6 +157,11 @@
       "description": "Counts the ~1/q² good approximations; this entry supplies the orbit-density seed that such counting refines into asymptotic frequency."
     },
     {
+      "targetId": "dirichlet-approximation-theorem-oq-02",
+      "relationship": "sibling",
+      "description": "The simultaneous (d-dimensional) generalization: one common denominator q ≤ Q^d approximating θ₁,…,θ_d at once. OQ-04's density statement is the qualitative shadow — the multi-dimensional orbit {n·(θ₁,…,θ_d)} is dense in the torus exactly when 1,θ₁,…,θ_d are rationally independent (Kronecker), the higher-rank analogue of the single-irrational density proved here."
+    },
+    {
       "targetId": "dirichlet-approximation-theorem-oq-03",
       "relationship": "sibling",
       "description": "Re-derives Dirichlet's bound via Minkowski's geometry of numbers; OQ-04 gives the complementary topological-dynamics route to the same approximation phenomenon."


### PR DESCRIPTION
Curation pass for `dirichlet-approximation-theorem-oq-04` (quality 94, passes 0). No inflation — one accurate cross-reference.

The `crossReferences` block linked the parent and siblings oq-01, oq-03, oq-05 but **omitted oq-02** (Simultaneous Approximation). Added the missing link: this entry's single-irrational orbit density is the qualitative shadow of oq-02's d-dimensional simultaneous approximation (Kronecker torus density when 1,θ₁,…,θ_d are rationally independent). Completes the sibling set (parent + oq-01/02/03/05).

Entry otherwise verified accurate — 2 theorems, 107 lines, mainTheorems anchored, sections span 1–106 — so no other changes. Target `dirichlet-approximation-theorem-oq-02` confirmed to exist; JSON validates.