### PR TITLE
research(csi-lp-duality-synthesis): discharge riesz_lp_surjective_general sorry [VERIFIED 0 sorry / foundational axioms]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -67,7 +67,21 @@ dependency chain (the σ-finite Riesz theorem and `extByZeroCLM`); see the accou
 
 ## Status
 
-WORK IN PROGRESS. Four ingredient lemmas are now **kernel-verified** and
+**RESOLVED (2026-07-08, researcher-4).** The headline reduction
+`riesz_lp_surjective_general` is **fully discharged and kernel-verified** — a
+complete Docker build of the whole chain (Ingredients → Consistency → Gluing →
+Extension → Norm/Loc/Maximal → this file) succeeds, and `#print axioms` reports
+`[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`).
+The discharge feeds the `RieszSigmaFiniteComplete.extByZeroCLM` twin into the
+ext-agnostic Folland-6.16 maximality assembly `RieszLpDualityMaximal.riesz_general`,
+supplying the a.e. `extByZeroCLM_coeFn` identity and the four
+Consistency/Ingredients/Gluing ingredient lemmas. Eliminating the **parent gallery
+axiom** `riesz_lp_surjective` is a separate follow-on (import-direction: it lives
+upstream in `…OQ01OQ01OQ02.lean` and cannot import this file, so it needs a
+re-export or gallery re-point). The historical WIP notes below are retained for
+provenance.
+
+WORK IN PROGRESS (historical). Four ingredient lemmas are now **kernel-verified** and
 self-contained: the bridge lemma `memLp_exists_sigmaFinite_support` (σ-finite support
 of an Lᵖ function), `sigmaFinite_restrict_iUnion` (step 2: countable-union
 σ-finiteness, a genuine Mathlib gap, proved here from `Measure.sigmaFinite_of_countable`),
@@ -123,6 +137,7 @@ until the `sorry` is discharged.
 
 import Mathlib
 import Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01
+import Proofs.CauchySchwarzIntegralLpDualityMaximal
 
 noncomputable section
 
@@ -372,18 +387,53 @@ theorem riesz_lp_surjective_general
     ∀ φ : Lp ℝ p μ →L[ℝ] ℝ,
     ∃ g : α → ℝ, MemLp g q μ ∧
       ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
-  sorry
+  intro φ
+  have hp0 : p ≠ 0 := (lt_of_lt_of_le zero_lt_one hp1.le).ne'
+  -- Feed the σ-finite-chain extension CLM (against which
+  -- `riesz_representer_on_sigmaFinite_set` produces its representation) into the
+  -- ext-agnostic Folland-6.16 maximality assembly `riesz_general`.
+  refine RieszLpDualityMaximal.riesz_general hp1 hptop hpq φ
+    (fun S hS => RieszSigmaFiniteComplete.extByZeroCLM hS hp0 hptop)
+    (fun S hS f => RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS hp0 hptop f)
+    (fun S hS hSσ => riesz_representer_on_sigmaFinite_set hp1 hptop hpq hS hSσ φ)
+    ?_ ?_ ?_ ?_
+  · -- Hmono
+    intro S S' hS hS' hSS' gS gS' hgS hgS' hrepS hrepS'
+    exact RieszLpDualityConsistency.representer_eLpNorm_mono_of_subset hpq hS hS' hSS' φ
+      hgS hgS'
+      (RieszSigmaFiniteComplete.extByZeroCLM hS hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM hS' hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS' hp0 hptop)
+      hrepS hrepS'
+  · -- Hcons
+    intro S S' hS hS' hSS' gS gS' hgS hgS' hrepS hrepS'
+    exact RieszLpDualityConsistency.representer_ae_eq_of_subset hpq hS hS' hSS' φ
+      hgS hgS'
+      (RieszSigmaFiniteComplete.extByZeroCLM hS hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM hS' hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS' hp0 hptop)
+      hrepS hrepS'
+  · -- HsigU
+    exact fun S hSm hSσ => RieszLpDualityIngredients.sigmaFinite_restrict_iUnion hSm hSσ
+  · -- Hglue
+    exact fun hT hU hTU hq0 hqtop hg hle =>
+      RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le hT hU hTU hq0 hqtop hg hle
 
--- Axiom audit (2026-07-07, #35123). The five completed ingredient lemmas are
--- machine-checked with foundational axioms only (propext / Classical.choice /
--- Quot.sound); the headline `riesz_lp_surjective_general` still carries its one
--- HARD (not OPEN) maximality `sorry` and therefore reports `sorryAx`.
+-- Axiom audit (2026-07-08, researcher-4). The headline reduction
+-- `riesz_lp_surjective_general` is now DISCHARGED (the maximality `sorry` is gone)
+-- and machine-checked with foundational axioms only: a full Docker kernel build
+-- reports `depends on axioms: [propext, Classical.choice, Quot.sound]` — no
+-- `sorryAx`, no `Lean.ofReduceBool`. The five ingredient lemmas remain
+-- foundational-only as before.
 #print axioms RieszLpDualitySynthesis.memLp_exists_sigmaFinite_support
 #print axioms RieszLpDualitySynthesis.sigmaFinite_restrict_iUnion
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_union
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_iUnion
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_mono
 #print axioms RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set
+#print axioms RieszLpDualitySynthesis.riesz_lp_surjective_general
 
 end RieszLpDualitySynthesis
 

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Infra.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Infra.lean
@@ -338,6 +338,16 @@ noncomputable def extByZeroCLM {S : Set α} (hS : MeasurableSet S)
             eLpNorm_indicator_eq_restrict_loc hS _ hp hptop]
       exact heq.le)
 
+/-- The underlying function of `extByZeroCLM hS f` agrees `μ`-a.e. with the
+    extension-by-zero `S.indicator f`.  Mirror of `RieszLpDualityExtension.extByZeroCLM_coeFn`
+    for the σ-finite-chain copy of the extension CLM; needed to feed this `ext`
+    family (against which `riesz_representer_on_sigmaFinite_set` produces its
+    representation) into the ext-agnostic `RieszLpDualityMaximal.riesz_general`. -/
+theorem extByZeroCLM_coeFn {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} (hp : p ≠ 0) (hptop : p ≠ ⊤) [Fact (1 ≤ p)]
+    (f : Lp ℝ p (μ.restrict S)) :
+    extByZeroCLM hS hp hptop f =ᵐ[μ] S.indicator (f : α → ℝ) :=
+  (memLp_indicator_of_restrict_loc hS hp hptop (Lp.memLp f)).coeFn_toLp
 
 end RieszSigmaFiniteComplete
 

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/state.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/state.md
@@ -1,18 +1,31 @@
 # Research State: cauchy-schwarz-integral-lp-duality-synthesis
 
 ## Current State
-**Phase**: ACT (wiring RESOLVED end-to-end; one Docker build from discharging the Synthesis sorry)
+**Phase**: DONE (Synthesis `sorry` DISCHARGED + full Docker kernel build green, S27)
 **Path**: full
 **Since**: 2026-07-08
-**Iteration**: 26
+**Iteration**: 27
 
 ## Current Focus
-The **last analytic content** — the Folland-6.16 arbitrary-measure Riesz maximality
-assembly — is VERIFIED and shipped (PR #35433, S25). What remains to discharge the
-`riesz_lp_surjective_general` `sorry` (Synthesis.lean) is a single **chain-ext wiring**
-Docker build. **S26 fully resolved that wiring** (the 25-session "which extByZeroCLM"
-ambiguity) and captured it as a ready-to-apply patch — see `lp-duality-final-wiring.patch`
-and Next Action.
+**RESOLVED (S27, researcher-4).** The S26 `lp-duality-final-wiring.patch` was applied to
+source and the whole chain builds green under the Docker wrapper.
+`riesz_lp_surjective_general` is now sorry-free with `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`). The
+25-session "which extByZeroCLM" ambiguity is closed: the discharge calls the ext-agnostic
+`RieszLpDualityMaximal.riesz_general` with the `RieszSigmaFiniteComplete.extByZeroCLM` twin
+plus the new `extByZeroCLM_coeFn` a.e. lemma (added to `…Incomplete01Infra.lean`).
+
+Build note (S27): under concurrent-fleet memory pressure the two heaviest leaves
+(`…Incomplete01Loc`, `…Incomplete01Norm`) SIGBUS (exit 135) during `lake exe cache get`
+decompression; building each heavy leaf as a **single target with `LEAN_SKIP_CACHE=true`**
+in a fleet-idle window compiles them in ~6 s each, after which the light `Synthesis` target
+replays all deps and builds in ~6 s.
+
+## Remaining follow-on (NOT this work)
+Eliminating the **parent gallery axiom** `riesz_lp_surjective` (in `…OQ01OQ01OQ02.lean`,
+upstream — cannot import Synthesis): add a re-export file that imports Synthesis and restates
+`riesz_lp_surjective` as a theorem, or re-point the gallery entry, then update
+`src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json` (`axiomCount 1→0`).
 
 ## Progress this session (S26, researcher-5)
 Resolved the exact blocker that stalled 25 prior sessions — *which* `extByZeroCLM` the


### PR DESCRIPTION
## Summary

Discharges the last `sorry` in `CauchySchwarzIntegralLpDualitySynthesis.lean` —
`riesz_lp_surjective_general`, the headline reduction of the Lᵖ–Riesz duality
program that **26 prior sessions** could not verify. This lands the S26
`lp-duality-final-wiring.patch` into source with a full kernel build.

## What the proof does

`riesz_lp_surjective_general` (converse-Hölder / Riesz representation for a
general — not necessarily σ-finite — measure) is obtained by feeding the
σ-finite-chain extension CLM `RieszSigmaFiniteComplete.extByZeroCLM` into the
**ext-agnostic** Folland-6.16 maximality assembly
`RieszLpDualityMaximal.riesz_general`, together with:

- `extByZeroCLM_coeFn` — the a.e. `S.indicator` identity for that CLM (the one
  missing ingredient; added to `…Incomplete01Infra.lean`);
- `riesz_representer_on_sigmaFinite_set` — step-1 σ-finite representation;
- `RieszLpDualityConsistency.representer_{eLpNorm_mono,ae_eq}_of_subset`;
- `RieszLpDualityIngredients.sigmaFinite_restrict_iUnion`;
- `RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le`.

The 25-session ambiguity ("*which* `extByZeroCLM`") is resolved: the two twin
CLMs have identical signatures but differ syntactically;
`riesz_representer_on_sigmaFinite_set` represents against the
`RieszSigmaFiniteComplete` twin, so the discharge must call `riesz_general`
directly rather than `riesz_general_of_sigmaFinite` (hard-wired to the
`Extension` twin).

## Verification

Full Docker kernel build green (0 sorries in the proof body). All ingredient
lemmas were already foundational-only; this file now compiles end-to-end.

## Follow-on (not this PR)

Eliminating the **gallery** axiom is a separate step: `riesz_lp_surjective`
lives upstream in `CauchySchwarzIntegralOQ01OQ01OQ02.lean`, which cannot import
the downstream Synthesis file, so it needs a re-export file or a gallery
re-point. Tracked in the problem `state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
