### PR TITLE
research(binary-gcd-oq-01-oq-04-oq-03): explicit ℚ two-sided Θ(log N) average (a=1 row) [VERIFIED]

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
@@ -245,4 +245,63 @@ theorem totalSteps_one_ge (N : ℕ) :
     _ ≤ ∑ b ∈ Finset.Icc 1 N, Nat.log 2 b :=
         Finset.sum_le_sum_of_subset hsub
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VI: EXPLICIT TWO-SIDED Θ(log N) AVERAGE IN ℚ  (a = 1 row)
+-- ═══════════════════════════════════════════════════════════════════
+--
+-- `totalSteps_one_ge` is a ℕ lower bound and `avgSteps_le` a ℚ upper bound, so
+-- the a = 1 average was pinned at Θ(log N) only across two different number
+-- systems. Dividing the ℕ lower bound by `N` and using
+-- `N − ⌊N/2⌋ = ⌈N/2⌉ ≥ N/2` turns it into an explicit ℚ lower bound on the
+-- *average* itself, so both bounds now live in ℚ and bracket the a = 1 average
+-- between `(log₂ N − 1)/2` and `2·log₂ N + 2` — a fully explicit Θ(log N)
+-- stated in a single normalised quantity (the average step count).
+
+/-- **Explicit ℚ average lower bound (a = 1 row).** The average step count over
+    `b ∈ [1, N]` on the `a = 1` row is at least `(log₂ N − 1) / 2`. This is the
+    ℚ-normalised companion of the ℕ bound `totalSteps_one_ge`: dividing by `N`
+    and using `N − ⌊N/2⌋ ≥ N/2` yields the clean `Ω(log N)` average, so the
+    lower bound now lives in the same normalised quantity as the `avgSteps_le`
+    ceiling. -/
+theorem avgSteps_one_ge (N : ℕ) (hN : 0 < N) :
+    ((Nat.log 2 N : ℚ) - 1) / 2 ≤ (totalSteps 1 N : ℚ) / (N : ℚ) := by
+  have hNQ : (0 : ℚ) < (N : ℚ) := by exact_mod_cast hN
+  rcases Nat.eq_zero_or_pos (Nat.log 2 N) with hlog | hlog
+  · -- log₂ N = 0 : LHS = −1/2 ≤ 0 ≤ RHS
+    have hpos : (0 : ℚ) ≤ (totalSteps 1 N : ℚ) / (N : ℚ) :=
+      div_nonneg (Nat.cast_nonneg _) hNQ.le
+    rw [hlog]; push_cast; linarith
+  · -- log₂ N ≥ 1 : divide the ℕ bound by N, using N − ⌊N/2⌋ ≥ N/2
+    have h1 : (1 : ℕ) ≤ Nat.log 2 N := hlog
+    set m : ℕ := N / 2 with hm
+    have hge : ((N : ℚ) - (m : ℚ)) * ((Nat.log 2 N : ℚ) - 1) ≤ (totalSteps 1 N : ℚ) := by
+      have hraw : ((N - m : ℕ) : ℚ) * ((Nat.log 2 N - 1 : ℕ) : ℚ) ≤ (totalSteps 1 N : ℚ) := by
+        exact_mod_cast totalSteps_one_ge N
+      rwa [Nat.cast_sub (Nat.div_le_self N 2), Nat.cast_sub h1, Nat.cast_one] at hraw
+    have hm2 : (2 : ℚ) * (m : ℚ) ≤ (N : ℚ) := by
+      have : 2 * m ≤ N := by rw [hm]; omega
+      exact_mod_cast this
+    have hlogQ : (1 : ℚ) ≤ (Nat.log 2 N : ℚ) := by exact_mod_cast h1
+    rw [div_le_iff₀ (by norm_num : (0 : ℚ) < 2), div_mul_eq_mul_div, le_div_iff₀ hNQ]
+    nlinarith [hge, mul_nonneg (by linarith : (0 : ℚ) ≤ (Nat.log 2 N : ℚ) - 1)
+                                (by linarith : (0 : ℚ) ≤ (N : ℚ) - 2 * (m : ℚ))]
+
+/-- **Explicit two-sided Θ(log N) average (a = 1 row).** Combining the ℚ lower
+    bound `avgSteps_one_ge` with the `avgSteps_le` ceiling at `a = 1`, the
+    average step count over `b ∈ [1, N]` satisfies
+
+        (log₂ N − 1) / 2  ≤  (∑_{b=1}^N binaryGcdSteps 1 b) / N  ≤  2·log₂ N + 2.
+
+    Both bounds are `Θ(log N)`, so the a = 1 average step count is a genuine
+    `Θ(log N)` — the *order* of Brent's average-case result — now witnessed by a
+    single normalised (ℚ) quantity. The sharp `0.7050` leading constant still
+    requires the transfer-operator analysis and remains out of reach here. -/
+theorem avgSteps_one_theta (N : ℕ) (hN : 0 < N) :
+    ((Nat.log 2 N : ℚ) - 1) / 2 ≤ (totalSteps 1 N : ℚ) / (N : ℚ) ∧
+      (totalSteps 1 N : ℚ) / (N : ℚ) ≤ 2 * (Nat.log 2 N : ℚ) + 2 := by
+  refine ⟨avgSteps_one_ge N hN, ?_⟩
+  have h := avgSteps_le 1 N Nat.one_pos hN
+  have hlog1 : (Nat.log 2 1 : ℚ) = 0 := by simp [Nat.log_one_right]
+  linarith [h, hlog1]
+
 end BinaryGcdOQ01OQ04OQ03

--- a/research/problems/binary-gcd-oq-01-oq-04-oq-03/knowledge.md
+++ b/research/problems/binary-gcd-oq-01-oq-04-oq-03/knowledge.md
@@ -100,3 +100,26 @@ leaves open. All Lean steps are **Docker-gated** and deferred until the build in
 - *A rigorous version of R. P. Brent's model for the binary Euclidean algorithm*,
   arXiv:1409.0729 (Adv. Math. 2015).
 - Knuth, *TAOCP* Vol. 2 (open questions on binary GCD averages).
+
+## Increment (researcher-2, 2026-07-08 session 2)
+
+Added the missing **ℚ average lower bound** so the a=1 Θ(log N) is now stated in a
+single normalised quantity (previously the ceiling `avgSteps_le` was in ℚ but the
+matching lower bound `totalSteps_one_ge` was in ℕ). New (VERIFIED, 0 sorry/0 axiom,
+no native_decide; build 7745 jobs, exit 0 on retry after one environmental exit-135):
+
+- `avgSteps_one_ge (hN : 0 < N) : (log₂ N − 1)/2 ≤ (totalSteps 1 N)/N`
+  — divide `totalSteps_one_ge` by N, using `N − ⌊N/2⌋ = ⌈N/2⌉ ≥ N/2` (i.e.
+  `2·⌊N/2⌋ ≤ N`). Two cases: `log₂N = 0` (LHS = −1/2 ≤ 0 ≤ RHS), else clear
+  denominators via `div_le_iff₀`/`le_div_iff₀` and close with `nlinarith` given the
+  product hint `0 ≤ (log₂N−1)·(N−2⌊N/2⌋)`.
+- `avgSteps_one_theta (hN : 0 < N) : (log₂ N − 1)/2 ≤ avg ∧ avg ≤ 2·log₂ N + 2`
+  — packages both ℚ bounds; upper half = `avgSteps_le 1 N` with `Nat.log 2 1 = 0`.
+
+This is the honest capstone of the ORDER result; the sharp 0.7050 constant stays
+BLOCKED-scale (transfer-operator spectral theory absent from Mathlib). At OQ depth 3
+→ no follow-up questions generated (depth guard).
+
+Gotchas confirmed: `Nat.cast_sub` needs the `≤` side proof for each truncated ℕ
+subtraction (`N/2 ≤ N`, `1 ≤ log₂N`); the current-name divide-lemmas are the `₀`
+variants (`div_le_iff₀`, `le_div_iff₀`), not the deprecated non-`₀` forms.

--- a/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-03.json
@@ -128,8 +128,8 @@
     },
     {
       "path": "Proofs/BinaryGcdOQ01OQ04OQ03.lean",
-      "lineCount": 248,
-      "theoremCount": 9,
+      "lineCount": 307,
+      "theoremCount": 11,
       "sorryCount": 0,
       "axiomCount": 0,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean"


### PR DESCRIPTION
## Summary

Adds the missing **ℚ-normalised average lower bound** for the binary-GCD average-case
`a = 1` row, so the Θ(log N) result now lives in a single normalised quantity. Previously
the ceiling `avgSteps_le` was stated in ℚ but the matching lower bound
`totalSteps_one_ge` was only in ℕ, so the two-sided Θ was split across number systems.

New theorems in `proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean`:

- `avgSteps_one_ge (hN : 0 < N) : (log₂ N − 1)/2 ≤ (totalSteps 1 N)/N`
  — divide `totalSteps_one_ge` by `N`, using `N − ⌊N/2⌋ = ⌈N/2⌉ ≥ N/2`.
- `avgSteps_one_theta (hN : 0 < N) : (log₂ N − 1)/2 ≤ avg ≤ 2·log₂ N + 2`
  — packages both ℚ bounds into an explicit two-sided Θ(log N).

## Verification

VERIFIED: 0 sorry, 0 axiom, no `native_decide`. Docker build succeeded (7745 jobs, exit 0).

## Scope

This is the honest capstone of the *order* result (the order that Brent's `≈ 0.7050 · log₂`
sharpens). The sharp **0.7050 leading constant** remains BLOCKED-scale — it needs
transfer-operator / dynamical-systems spectral theory that is absent from Mathlib 4.26.

At OQ depth 3, no follow-up questions are generated (depth guard).