### PR TITLE
audit: reconcile stale line/theorem counts (6 re-audited entries)

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -200,6 +200,6 @@
       "description": "Ehrhart theory counts lattice points in polytope dilations, complementing the volumetric density theory of Kepler/Hales; the 4000/4671 dimer construction is polytopal and interfaces naturally with Ehrhart techniques."
     }
   ],
-  "theoremCount": 22,
+  "theoremCount": 20,
   "definitionCount": 4
 }

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,9 +58,9 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 214,
+    "lineCount": 255,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 8,
+    "theoremCount": 11,
     "definitionCount": 4
   },
   "overview": {

--- a/src/data/proofs/roth-theorem-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-oq-01/meta.json
@@ -36,7 +36,7 @@
     ],
     "dateAdded": "2026-07-02",
     "lineCount": 408,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/RothTheoremOQ02.lean"

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -167,7 +167,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Fully verified formalization (0 sorries, 0 axioms) of Roth's theorem and its key Fourier-analytic components. The 42-theorem file develops complete machinery: character theory, Parseval, AP counting, large Fourier coefficient (the key standalone lemma), and density increment. The main theorem wraps via Mathlib's `roth_3ap_theorem_nat`.",
+    "summary": "Fully verified formalization (0 sorries, 0 axioms) of Roth's theorem and its key Fourier-analytic components. The 49-theorem file develops complete machinery: character theory, Parseval, AP counting, large Fourier coefficient (the key standalone lemma), and density increment. The main theorem wraps via Mathlib's `roth_3ap_theorem_nat`.",
     "implications": "The independently verified `fourier_large_coefficient` theorem provides a formalized version of the core analytic step that underlies quantitative improvements to Roth's theorem (Bourgain, Bloom-Sisask). The density increment infrastructure could be extended to prove better bounds.",
     "openQuestions": [
       "Formalize Bourgain's quantitative bound r₃(N) = O(N/(log log N)^{1/2})",


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Backlog was 0 (all 4780 audited), so ran a **changed-since-audit** scan: gallery entries whose primary Lean source was committed *after* their last audit (timezone-normalized to UTC). 13 candidates surfaced; **7 clean, 6 fixed**.

Truth basis: comment-stripped `theorem`/`lemma` declaration count and `wc -l` line count — docstring/comment mentions of "theorem" do not count.

### Fixes (LOW severity — count drift after research commits re-grew files)

| slug | field | was → now |
|------|-------|-----------|
| roth-theorem | leanFile+meta lineCount | 1401 → 1554 |
| roth-theorem | leanFile+meta theoremCount | 42 → 49 (+prose) |
| roth-theorem-k3 | meta lineCount | 1401 → 1554 |
| roth-theorem-k3 | meta/leanFile theoremCount | 42/43 → 49 |
| roth-theorem-k3-oq-03-oq-01 | lineCount | 214 → 255 |
| roth-theorem-k3-oq-03-oq-01 | theoremCount | 8 → 11 |
| roth-theorem-oq-01 | theoremCount | 13 → 12 (+prose) |
| kepler-conjecture-oq-04 | leanFile+top-level theoremCount | 22 → 20 |
| erdos-1022-oq-02 | lineCount / theoremCount | 286→351 / 11→14 |

kepler's `.meta` sub-snapshot (570/11) is a documented intermediate state that understates (not an overclaim) — left as-is.

### Clean (re-audited, no change)
dirichlets-theorem-oq-02-oq-03, erdos-214, erdos-490, erdos-659, erdos-666, euler-polyhedral-formula-oq-02-oq-02, law-of-cosines-oq-03-oq-03

No status/badge/sorry/axiom overclaims detected. Audit tracker updated (6 issues-fixed, 7 clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)