### PR TITLE
Enrich cube-root-2 OQ-05-OQ-02: add field-degree open question

### DIFF
--- a/src/data/proofs/cube-root-2-irrational-oq-05-oq-02/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05-oq-02/meta.json
@@ -143,7 +143,8 @@
     "implications": "The rational-exponent theorem closes the exponent variable of the parent family (1/n → a/b), and the valuation lemma is the clean general obstruction to a prime power being a perfect power. The ∛2 + ∛3 result demonstrates the cubing technique for sums of independent radicals, reducing such questions to single-radical irrationality already decided by the criterion.",
     "openQuestions": [
       "Generalize to arbitrary natural (non-prime) bases m^q: m^(a/b) is rational iff m is a perfect (b/gcd)-th power after reducing a/b — replacing the prime valuation step with full factorization.",
-      "Irrationality of ∛p + ∛q for distinct primes, or ⁿ√p + ⁿ√q for n ≥ 3, via the analogous power-expansion-and-reduce technique."
+      "Irrationality of ∛p + ∛q for distinct primes, or ⁿ√p + ⁿ√q for n ≥ 3, via the analogous power-expansion-and-reduce technique.",
+      "Determine and formalize the degree of ℚ(∛2, ∛3) over ℚ — it is 9, with {∛(2ⁱ·3ʲ) : 0 ≤ i, j ≤ 2} a ℚ-basis — and prove ℚ-linear independence of these nine cube-root monomials. The irrationality of ∛2 + ∛3 is the smallest nontrivial case of that independence."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
Enrichment pass on `cube-root-2-irrational-oq-05-oq-02` (quality 94, passes 0).

Single non-inflating addition to `conclusion.openQuestions` (now 3, cap 15; meta.json well under all caps):

- The degree of ℚ(∛2, ∛3) over ℚ is 9, with basis {∛(2ⁱ·3ʲ) : 0 ≤ i, j ≤ 2}; ℚ-linear independence of the nine cube-root monomials is the natural formalization target, of which the ∛2 + ∛3 irrationality proved here is the smallest nontrivial case.

Note: this PR originally also added a setup section for lines 1–44, but a concurrent PR filled that section-coverage gap on main (`header` section), so this PR now adds only the open question to avoid duplicate coverage. Rebased on current main. JSON validates.