### PR TITLE
research(law-of-cosines-oq-03-oq-03): equilateral side strictly antitone in common angle [VERIFIED]

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -328,4 +328,46 @@ theorem equilateral_pi_four_cosh (t : HyperbolicTriangle)
   rw [div_eq_iff hpos.ne']
   linear_combination (1 / 2 : ℝ) * hs
 
+-- ============================================================
+-- PART 8: Monotonicity across the equilateral family
+-- ============================================================
+
+/-- For any hyperbolic triangle the common denominator `1 - cos C` of the inverted
+    second law is strictly positive, since `0 < C < π` forces `cos C < 1`. -/
+theorem one_sub_cos_C_pos (t : HyperbolicTriangle) : 0 < 1 - Real.cos t.C := by
+  nlinarith [Real.sin_sq_add_cos_sq t.C, sin_C_pos t, Real.neg_one_le_cos t.C]
+
+/-- **The equilateral hyperbolic side is strictly decreasing in the common angle.**
+    Compare two *equilateral* hyperbolic triangles (each with all three angles equal).
+    If the common angle of `t₁` is strictly smaller than that of `t₂` (`t₁.C < t₂.C`),
+    then `t₁` has the strictly larger side: `cosh t₂.c < cosh t₁.c`.
+
+    This is immediate from the equilateral closed form `cosh side = cos θ / (1 - cos θ)`:
+    the map `θ ↦ cos θ / (1 - cos θ)` is strictly decreasing on `(0, π)`, because `cos`
+    is antitone there and `x ↦ x / (1 - x)` is increasing for `x < 1`. Thin equilateral
+    triangles (small angle, large defect) are the large ones — the hyperbolic reversal of
+    Euclidean similarity, where all equilateral triangles have angle exactly `π/3`. -/
+theorem equilateral_cosh_antitone_in_angle (t₁ t₂ : HyperbolicTriangle)
+    (h₁ : t₁.A = t₁.B) (h₁' : t₁.B = t₁.C)
+    (h₂ : t₂.A = t₂.B) (h₂' : t₂.B = t₂.C)
+    (hlt : t₁.C < t₂.C) : Real.cosh t₂.c < Real.cosh t₁.c := by
+  have hcos : Real.cos t₂.C < Real.cos t₁.C :=
+    Real.cos_lt_cos_of_nonneg_of_le_pi t₁.hC.le t₂.hC_lt.le hlt
+  rw [equilateral_cosh t₁ h₁ h₁', equilateral_cosh t₂ h₂ h₂',
+    div_lt_div_iff₀ (one_sub_cos_C_pos t₂) (one_sub_cos_C_pos t₁)]
+  nlinarith [hcos, one_sub_cos_C_pos t₁, one_sub_cos_C_pos t₂]
+
+/-- **Larger equilateral triangle ⟺ smaller angle.** The side-length form of
+    `equilateral_cosh_antitone_in_angle`: among equilateral hyperbolic triangles, a
+    strictly smaller common angle yields a strictly longer side, `t₂.c < t₁.c` whenever
+    `t₁.C < t₂.C`. Combined with `equilateral_angle_lt_pi_third` (angle `< π/3`) this
+    pins down the whole one-parameter equilateral family: as `θ ↗ π/3` the triangle
+    shrinks toward the Euclidean point-limit, and as `θ ↘ 0` it grows without bound. -/
+theorem equilateral_side_antitone_in_angle (t₁ t₂ : HyperbolicTriangle)
+    (h₁ : t₁.A = t₁.B) (h₁' : t₁.B = t₁.C)
+    (h₂ : t₂.A = t₂.B) (h₂' : t₂.B = t₂.C)
+    (hlt : t₁.C < t₂.C) : t₂.c < t₁.c :=
+  (Real.cosh_strictMonoOn.lt_iff_lt (mem_Ici.mpr t₂.hc.le) (mem_Ici.mpr t₁.hc.le)).mp
+    (equilateral_cosh_antitone_in_angle t₁ t₂ h₁ h₁' h₂ h₂' hlt)
+
 end HyperbolicAAA

--- a/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
+++ b/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
@@ -25,3 +25,35 @@ new theorems introduce none). Key steps: `linarith` on the defect; `linear_combi
 - `proofs/Proofs/LawOfCosinesOQ03OQ03.lean` (Part 7, +~35 lines, verified)
 - `src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json` (counts + contribution)
 - `src/data/research/problems/law-of-cosines-oq-03-oq-03.json` (counts + knowledge)
+
+## Session 2026-07-08 (researcher-7) — Part 8: equilateral monotonicity
+
+**Mode:** REVISIT (mature axiomatized AAA-congruence entry). **Outcome:** progress
+(3 new theorems, 0 new assumptions).
+
+### What I Did
+Added monotonicity of the equilateral family across the common angle, complementing the
+existing `equilateral_cosh` (closed form) and `equilateral_angle_lt_pi_third` (angle < π/3):
+- `one_sub_cos_C_pos (t) : 0 < 1 - cos t.C` — the inverted-second-law denominator is
+  positive; `nlinarith [sin_sq_add_cos_sq, sin_C_pos, neg_one_le_cos]` (0<C<π ⟹ cos C<1).
+- `equilateral_cosh_antitone_in_angle (t₁ t₂) (both equilateral) (t₁.C < t₂.C) :
+  cosh t₂.c < cosh t₁.c`. From `equilateral_cosh` both sides = cos θ/(1-cos θ); clear
+  denominators with `div_lt_div_iff₀ (pos) (pos)` then `nlinarith [hcos]` (cross terms cancel
+  to cos C₂ < cos C₁, which is `Real.cos_lt_cos_of_nonneg_of_le_pi` on the angle order).
+- `equilateral_side_antitone_in_angle` : `t₂.c < t₁.c` — side form via
+  `Real.cosh_strictMonoOn.lt_iff_lt` (same pattern as `side_antitone_in_angle`).
+Reading: smaller angle ⟹ larger triangle; θ ↗ π/3 shrinks to the Euclidean limit, θ ↘ 0
+grows unboundedly — the hyperbolic reversal of Euclidean similarity (all equilateral = π/3).
+
+### Verification
+Host `lake env lean Proofs/LawOfCosinesOQ03OQ03.lean` EXIT 0 (no warnings);
+`#print axioms equilateral_side_antitone_in_angle` = [propext, Classical.choice, Quot.sound].
+File 331→373 lines, 22→25 theorems. Status stays **axiomatized** (7 structure-encoded
+assumptions unchanged; new theorems add none). ★v4.26 gotcha: the positive-denominator
+`a/b < c/d ↔ a*d < c*b` lemma is `div_lt_div_iff₀` (NOT `div_lt_div_iff`, which is now the
+group version `div_lt_div_iff'`).
+
+### Files Modified
+- `proofs/Proofs/LawOfCosinesOQ03OQ03.lean` (Part 8, +~45 lines, verified)
+- `src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json` (counts + contribution)
+- `src/data/research/problems/law-of-cosines-oq-03-oq-03.json` (leanFiles counts)

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 7,
     "sorries": 0,
-    "lineCount": 331,
-    "theoremCount": 22,
+    "lineCount": 373,
+    "theoremCount": 25,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -353,8 +353,8 @@
     ],
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 331,
-    "theoremCount": 22,
+    "lineCount": 373,
+    "theoremCount": 25,
     "definitionCount": 1,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",
@@ -364,7 +364,8 @@
       "aaa_congruence: equal angles ⟹ equal sides via cosh injectivity on [0,∞)",
       "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) for the equilateral triangle",
       "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — holding two angles fixed, increasing the third strictly shortens the opposite side (refines AAA congruence to a strict comparison)",
-      "Equilateral corollaries (Part 7): equilateral_angle_lt_pi_third (an equilateral hyperbolic triangle has common angle < π/3, the sharp defect-driven counterpart of the Euclidean π/3) and equilateral_pi_four_cosh (the all-angles-π/4 equilateral triangle has every side arcosh(1+√2), i.e. cosh = 1+√2) — no new assumptions"
+      "Equilateral corollaries (Part 7): equilateral_angle_lt_pi_third (an equilateral hyperbolic triangle has common angle < π/3, the sharp defect-driven counterpart of the Euclidean π/3) and equilateral_pi_four_cosh (the all-angles-π/4 equilateral triangle has every side arcosh(1+√2), i.e. cosh = 1+√2) — no new assumptions",
+      "equilateral_cosh_antitone_in_angle / equilateral_side_antitone_in_angle: monotonicity across the equilateral family. Among equilateral hyperbolic triangles a strictly smaller common angle yields a strictly longer side (cosh side = cos θ/(1-cos θ) is strictly decreasing on (0,π)). With equilateral_angle_lt_pi_third this pins down the one-parameter family: θ ↗ π/3 shrinks to the Euclidean limit, θ ↘ 0 grows without bound. Supporting lemma one_sub_cos_C_pos (0 < 1 - cos C from 0 < C < π). No new assumptions; entry stays axiomatized."
     ],
     "proofStrategy": "Invert each second law of cosines (linear in cosh of the opposite side) via eq_div_iff + linear_combination to get cosh(side) as a ratio of angle functions. Prove the angle ratio exceeds 1 from the defect using cos(A+B) > cos(π-C) = -cos C (strict antitonicity of cos on [0,π]). Conclude AAA congruence by cosh injectivity on [0,∞). Specialize to the equilateral case for a closed form.",
     "openQuestions": [

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -179,8 +179,8 @@
     {
       "path": "Proofs/LawOfCosinesOQ03OQ03.lean",
       "filename": "LawOfCosinesOQ03OQ03.lean",
-      "lineCount": 298,
-      "theoremCount": 20,
+      "lineCount": 373,
+      "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The hyperbolic law-of-cosines / AAA-congruence entry (`LawOfCosinesOQ03OQ03.lean`) already establishes AAA congruence, the angle→side inversion `cosh side = (cos C + cos A cos B)/(sin A sin B)`, angle–side monotonicity, and the equilateral closed form `cosh side = cos θ/(1 - cos θ)`. This PR adds the missing **monotonicity across the equilateral family**.

## New theorems

- **`one_sub_cos_C_pos`** — `0 < 1 - cos C`, the inverted-second-law denominator is positive (from `0 < C < π ⟹ cos C < 1`).
- **`equilateral_cosh_antitone_in_angle`** — two *equilateral* triangles with `t₁.C < t₂.C` satisfy `cosh t₂.c < cosh t₁.c`. The map `θ ↦ cos θ/(1 - cos θ)` is strictly decreasing on `(0, π)`.
- **`equilateral_side_antitone_in_angle`** — the side-length form: `t₂.c < t₁.c`. A strictly smaller common angle yields a strictly **longer** side.

Together with `equilateral_angle_lt_pi_third` (angle `< π/3`) this pins down the whole one-parameter equilateral family: as `θ ↗ π/3` the triangle shrinks toward the Euclidean point-limit; as `θ ↘ 0` it grows without bound — the hyperbolic reversal of Euclidean similarity, where every equilateral triangle has angle exactly `π/3`.

## Verification

- Host `lake env lean Proofs/LawOfCosinesOQ03OQ03.lean` → **EXIT 0** (no warnings).
- `#print axioms equilateral_side_antitone_in_angle` → `[propext, Classical.choice, Quot.sound]` only.
- File 331→373 lines, 22→25 theorems. Counts synced in meta.json and research JSON.
- Status remains **axiomatized**: the 7 structure-encoded geometric assumptions are unchanged; the new theorems introduce none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)