### PR TITLE
Enrich central-limit-theorem OQ-01-02-01-03: surface κ₂=σ² result in mainTheorems

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -137,6 +137,14 @@
       "endLine": 66
     },
     {
+      "name": "gaussianExponent_deriv2",
+      "type": "supporting",
+      "description": "ψ''(t) = −σ² (constant): the second cumulant is κ₂ = −ψ''(0) = σ².",
+      "leanType": "(μ σ_sq t : ℝ) → HasDerivAt (fun s : ℝ => (↑μ * Complex.I - ↑(σ_sq * s) : ℂ)) (-↑σ_sq) t",
+      "startLine": 87,
+      "endLine": 93
+    },
+    {
       "name": "gaussianExponent_deriv3",
       "type": "core",
       "description": "ψ''' ≡ 0: all cumulants of order ≥ 3 vanish.",


### PR DESCRIPTION
Enrichment pass on `central-limit-theorem-oq-01-oq-02-oq-01-oq-03` (quality 94, passes 0).

The entry is already at target (5 field-complete annotations, 4 key insights, 3 open questions, full-file section coverage, references) and every count/line-anchor checks out against `Proofs/CentralLimitTheoremOQ01OQ02OQ01OQ03.lean`.

Single non-inflating addition: the `mainTheorems` array surfaced `gaussianExponent_deriv3` (ψ'''≡0, κ_{≥3}=0) but omitted `gaussianExponent_deriv2` (ψ''=−σ², the **second-cumulant** result κ₂=σ² and a listed original contribution) — the more fundamental of the two. Added it as a supporting entry with verified line anchors (87–93).

JSON validates; `check-meta-size` passes (well under caps).