### PR TITLE
research(erdos-490-oq-01): eliminate optimal_lower axiom → theorem (axiomCount 2→1) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos490OQ01.lean
+++ b/proofs/Proofs/Erdos490OQ01.lean
@@ -18,7 +18,11 @@
   5. Structural analysis: cardinality bounds, trivial bound (§6)
 
   Sorry count: 0
-  Axiom count: 2 (Szemerédi bound, optimal example lower bound). `maxProd_exists` is now
+  Axiom count: 1 (Szemerédi upper bound only). The optimal-example lower bound
+  `optimal_lower` is now a **proved theorem** (0-axiom), derived from the sibling file's
+  verified `Erdos490.bound_is_optimal` via `maxProd_is_upper` (the maximum dominates the
+  optimal example's product), with small cases `N ∈ {2,3}` handled by `maxProd_ge_self`.
+  `maxProd_exists` is likewise
   a proved theorem: the maximum ranges over subsets of the finite set {1,...,N}, so the
   achievable-value set is a nonempty finite set of naturals and we take its `Finset.max'`.
   (Also repaired Mathlib v4.26 API drift: div_le_iff→div_le_iff₀, le_div_iff→le_div_iff₀,
@@ -26,6 +30,7 @@
 -/
 
 import Mathlib
+import Proofs.Erdos490Problem
 
 open Finset Real Filter
 
@@ -125,9 +130,79 @@ theorem maxProd_is_achieved (N : ℕ) (hN : 2 ≤ N) :
 axiom szemeredi_upper : ∃ C : ℝ, 0 < C ∧
   ∀ N : ℕ, (hN : 2 ≤ N) → (maxProd N hN : ℝ) ≤ C * (N : ℝ)^2 / Real.log (N : ℝ)
 
-/-- **Optimal example bound (axiom)**: maxProd(N) ≥ c·N²/log N for some c > 0. -/
-axiom optimal_lower : ∃ c : ℝ, 0 < c ∧
-  ∀ N : ℕ, (hN : 2 ≤ N) → c * (N : ℝ)^2 / Real.log (N : ℝ) ≤ (maxProd N hN : ℝ)
+/-- **Crude lower bound** `maxProd N ≥ N` (0-axiom).  The pair `A = {1,…,N}`, `B = {1}`
+has distinct products (`a·1 = a`) and `|A|·|B| = N·1 = N`, so the maximum is at least `N`.
+This handles the small cases `N ∈ {2,3}` of `optimal_lower`, where the quantitative
+`N²/log N` machinery is not yet in force. -/
+theorem maxProd_ge_self (N : ℕ) (hN : 2 ≤ N) : (N : ℝ) ≤ (maxProd N hN : ℝ) := by
+  have hAsub : IsSubsetUpTo' (Finset.Icc 1 N) N := by
+    intro a ha; exact Finset.mem_Icc.mp ha
+  have hBsub : IsSubsetUpTo' ({1} : Finset ℕ) N := by
+    intro a ha
+    simp only [Finset.mem_singleton] at ha
+    subst ha; exact ⟨le_refl 1, by omega⟩
+  have hd : HasDistinctProducts' (Finset.Icc 1 N) ({1} : Finset ℕ) := by
+    intro a₁ a₂ b₁ b₂ _ _ hb₁ hb₂ heq
+    simp only [Finset.mem_singleton] at hb₁ hb₂
+    subst hb₁; subst hb₂
+    simp only [mul_one] at heq
+    exact ⟨heq, rfl⟩
+  have hup := maxProd_is_upper N hN (Finset.Icc 1 N) ({1} : Finset ℕ) hAsub hBsub hd
+  simp only [Nat.card_Icc, Finset.card_singleton, mul_one, Nat.add_sub_cancel] at hup
+  exact_mod_cast hup
+
+/-- **Optimal example bound (theorem, 0-axiom)**: `maxProd(N) ≥ c·N²/log N` for some
+`c > 0`.  Formerly an axiom; now derived from the sibling file's fully-proved
+`Erdos490.bound_is_optimal` (the optimal example `A = [1,N/2]`, `B = primes in (N/2,N]`
+achieves `|A||B| ≥ c₀·N²/log N` for `N ≥ 4`, using the verified Chebyshev θ-gap bound).
+Since `maxProd N` dominates the product of *any* valid pair (`maxProd_is_upper`), the
+lower bound transfers.  The small cases `N ∈ {2,3}` use `maxProd_ge_self` with the
+constant shrunk to `≤ log N / N`. -/
+theorem optimal_lower : ∃ c : ℝ, 0 < c ∧
+    ∀ N : ℕ, (hN : 2 ≤ N) → c * (N : ℝ)^2 / Real.log (N : ℝ) ≤ (maxProd N hN : ℝ) := by
+  obtain ⟨c₀, hc₀, hbig⟩ := Erdos490.bound_is_optimal
+  have hlog2 : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  have hlog3 : 0 < Real.log 3 := Real.log_pos (by norm_num)
+  refine ⟨min c₀ (min (Real.log 2 / 2) (Real.log 3 / 3)), ?_, ?_⟩
+  · exact lt_min hc₀ (lt_min (by positivity) (by positivity))
+  · intro N hN
+    set c := min c₀ (min (Real.log 2 / 2) (Real.log 3 / 3)) with hcdef
+    have hlogN : 0 < Real.log (N : ℝ) :=
+      Real.log_pos (by exact_mod_cast (show 1 < N by omega))
+    by_cases h4 : 4 ≤ N
+    · -- Large N: transfer the optimal-example bound.
+      obtain ⟨A, B, hA, hB, hd, hge⟩ := hbig N h4
+      have hA' : IsSubsetUpTo' A N := by intro a ha; exact hA a ha
+      have hB' : IsSubsetUpTo' B N := by intro b hb; exact hB b hb
+      have hd' : HasDistinctProducts' A B := by
+        have hpmi := (Erdos490.productMapInjective_iff_hasDistinctProducts A B).mpr hd
+        intro a₁ a₂ b₁ b₂ ha₁ ha₂ hb₁ hb₂ heq
+        exact hpmi a₁ a₂ b₁ b₂ ha₁ ha₂ hb₁ hb₂ heq
+      have hup : (A.card * B.card : ℝ) ≤ (maxProd N hN : ℝ) := by
+        exact_mod_cast maxProd_is_upper N hN A B hA' hB' hd'
+      have hmain : c₀ * (N : ℝ)^2 / Real.log N ≤ (maxProd N hN : ℝ) :=
+        le_trans hge hup
+      -- Scale the constant down from c₀ to c ≤ c₀.
+      have hX0 : (0 : ℝ) ≤ (N : ℝ)^2 / Real.log N := div_nonneg (by positivity) hlogN.le
+      have hmono : c * (N : ℝ)^2 / Real.log N ≤ c₀ * (N : ℝ)^2 / Real.log N := by
+        rw [mul_div_assoc, mul_div_assoc]
+        exact mul_le_mul_of_nonneg_right (min_le_left _ _) hX0
+      exact le_trans hmono hmain
+    · -- Small N (N = 2 or 3): use maxProd N ≥ N with c ≤ log N / N.
+      have hself : (N : ℝ) ≤ (maxProd N hN : ℝ) := maxProd_ge_self N hN
+      have hc2 : c ≤ Real.log 2 / 2 := le_trans (min_le_right _ _) (min_le_left _ _)
+      have hc3 : c ≤ Real.log 3 / 3 := le_trans (min_le_right _ _) (min_le_right _ _)
+      interval_cases N
+      · -- N = 2
+        have hbound : c * (2 : ℝ)^2 / Real.log 2 ≤ (2 : ℝ) := by
+          rw [div_le_iff₀ hlog2]; nlinarith [hc2, hlog2]
+        push_cast at hself ⊢
+        linarith [hbound, hself]
+      · -- N = 3
+        have hbound : c * (3 : ℝ)^2 / Real.log 3 ≤ (3 : ℝ) := by
+          rw [div_le_iff₀ hlog3]; nlinarith [hc3, hlog3]
+        push_cast at hself ⊢
+        linarith [hbound, hself]
 
 -- ============================================================================
 -- § 4. The Product Ratio Sequence

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -443,3 +443,30 @@ Left axiomatized; the problem's completion task (the 6 original sorries) is done
 **Still open**: `szemeredi_theorem` (N²/log N upper bound) — the deep result, stays axiomatized.
 **Infra**: exit-135 volume corruption (#35184) hit 5/7 builds; the Problem file needed ~5 retries to
 go green. Line-less 135 = infra, RETRY (crux + wiring both correct once a clean run landed).
+
+## Session 2026-07-08 (researcher-10) — AXIOM ELIMINATED in sibling OQ01 (2→1 axioms)
+
+**Mode**: ACT (family axiom-reduction). **Outcome**: progress — eliminated `optimal_lower`
+in `Erdos490OQ01.lean` (the open-question sibling file), axiom count **2 → 1**. The main
+completion file `Erdos490Problem.lean` was reconfirmed at its stable frontier (0 sorries,
+1 deep axiom `szemeredi_theorem`; meta.json in sync — no change).
+
+**What I did (verified 0-axiom, docker 7745 jobs green):** Converted `axiom optimal_lower`
+(`maxProd(N) ≥ c·N²/log N`) into a **theorem** by transferring the main file's now-verified
+`Erdos490.bound_is_optimal` (the optimal example's lower bound, itself the fruit of
+researcher-2's Chebyshev θ-gap work). Since `maxProd N` dominates any valid pair's product
+(`maxProd_is_upper`), the specific pair from `bound_is_optimal` (N ≥ 4) transfers the bound;
+small cases N ∈ {2,3} use a new helper `maxProd_ge_self` (pair `A=Icc 1 N`, `B={1}`,
+`|A||B|=N`) with constant `c = min c₀ (min (log2/2)(log3/3))` so `c ≤ logN/N`.
+`#print axioms optimal_lower = [propext, Classical.choice, Quot.sound]` (no sorryAx/ofReduceBool).
+
+**Key wiring:** the two files carry distinct-but-identical defs — OQ01's `IsSubsetUpTo'` =
+main's `IsSubsetUpTo`, and OQ01's `HasDistinctProducts'` = main's `ProductMapInjective` (bridge
+`Erdos490.productMapInjective_iff_hasDistinctProducts`); convert by `intro`+re-`exact`. Keep the
+ℕ→ℝ cast of `maxProd_is_upper` in the same `(A.card*B.card : ℝ)` shape as `bound_is_optimal`'s
+`≥` so `linarith` unifies the atom. Constant scaling avoids `gcongr`/`div_le_div_*` name-drift via
+`mul_div_assoc` + `mul_le_mul_of_nonneg_right`. Full detail in
+`sessions/2026-07-08-r10-oq01-optimal-lower-deaxiom.md`.
+
+**Still open:** `szemeredi_upper` (= `szemeredi_theorem`, the deep N²/log N upper bound) stays
+axiomatized in both files — the genuinely hard result, not attackable.

--- a/research/problems/erdos-490-incomplete-01/sessions/2026-07-08-r10-oq01-optimal-lower-deaxiom.md
+++ b/research/problems/erdos-490-incomplete-01/sessions/2026-07-08-r10-oq01-optimal-lower-deaxiom.md
@@ -1,0 +1,70 @@
+# Session 2026-07-08 (researcher-10) — AXIOM ELIMINATED: `optimal_lower` in Erdos490OQ01 (2→1 axioms)
+
+**Mode**: ACT (family axiom-reduction). **Outcome**: progress — eliminated the axiom
+`optimal_lower` in the sibling open-question file `Erdos490OQ01.lean`, proving it 0-axiom
+by reusing the main file's now-verified `Erdos490.bound_is_optimal`. `Erdos490OQ01.lean`
+axiom count **2 → 1** (only the deep `szemeredi_upper` remains). Docker build green
+(7745 jobs).
+
+## Context
+The base completion task `erdos-490-incomplete-01` (`Erdos490Problem.lean`) is at a stable
+frontier: **0 sorries, 1 axiom** (`szemeredi_theorem`, the deep Szemerédi 1976 *upper*
+bound). Its matching *lower* bound `bound_is_optimal` was fully proved 0-axiom in the
+07-08 (researcher-2) Chebyshev θ-gap session. Its gallery meta is in sync.
+
+The sibling file `Erdos490OQ01.lean` (open question: does `maxProd(N)·logN/N²` converge?)
+still carried **2 axioms**: `szemeredi_upper` (= Szemerédi, deep) and `optimal_lower`
+(`maxProd(N) ≥ c·N²/logN`). The latter duplicates content already proved in the main file.
+
+## What I did (verified, 0-axiom)
+Converted `axiom optimal_lower` into a **theorem** by transferring the main file's proved
+lower bound:
+- `maxProd N` is the max of `|A||B|` over valid distinct-product pairs, and dominates the
+  product of *any* single valid pair (`maxProd_is_upper`).
+- `Erdos490.bound_is_optimal` (0-axiom) hands a specific pair `(A,B)` = `([1,N/2], primes
+  in (N/2,N])` with `|A||B| ≥ c₀·N²/logN` for `N ≥ 4`. Its `Erdos490.IsSubsetUpTo` /
+  `Erdos490.HasDistinctProducts` witnesses convert to OQ01's primed `IsSubsetUpTo'` /
+  `HasDistinctProducts'` (identical bodies; `HasDistinctProducts'` = main's
+  `ProductMapInjective`, via `Erdos490.productMapInjective_iff_hasDistinctProducts`).
+  Feeding them to `maxProd_is_upper` gives `c₀·N²/logN ≤ |A||B| ≤ maxProd N` for `N ≥ 4`.
+- **Small cases `N ∈ {2,3}`** (below `bound_is_optimal`'s `N ≥ 4` floor): new helper
+  `maxProd_ge_self : (N:ℝ) ≤ maxProd N` (from the pair `A = Icc 1 N`, `B = {1}`,
+  `|A||B| = N`). Choosing the final constant `c = min c₀ (min (log2/2) (log3/3))` makes
+  `c ≤ logN/N` for `N ∈ {2,3}`, so `c·N²/logN ≤ N ≤ maxProd N`. No log *numerics* needed —
+  only symbolic `min_le` + `Real.log_pos`.
+
+Final constant `c = min c₀ (min (log 2/2) (log 3/3)) > 0`.
+
+## Gotchas / API
+- The two files use **distinct-but-identical** defs (`IsSubsetUpTo` vs `IsSubsetUpTo'`,
+  `ProductMapInjective` vs `HasDistinctProducts'`): convert by `intro`+re-`exact`, they are
+  not defeq by *name* but share bodies so the applied form typechecks.
+- `bound_is_optimal` states `(A.card*B.card : ℝ) ≥ c₀*N²/logN`; keep the ℕ→ℝ cast of
+  `maxProd_is_upper` in the **same** `(A.card * B.card : ℝ)` syntactic form so `linarith`
+  sees one atom (`exact_mod_cast` into that shape, then `linarith [hge, hup]`).
+- Constant scaling `c·N²/logN ≤ c₀·N²/logN` for `c ≤ c₀`: avoid `gcongr`/`div_le_div_*`
+  name-drift — `rw [mul_div_assoc, mul_div_assoc]` then
+  `mul_le_mul_of_nonneg_right (min_le_left _ _) (div_nonneg (by positivity) hlogN.le)`.
+  (`positivity` can't prove `0 ≤ N²/logN` alone since `log N` isn't obviously ≥ 0; supply
+  `hlogN.le` explicitly.)
+- Small N: after `interval_cases N`, `push_cast at hself ⊢` normalises `((2:ℕ):ℝ) → 2` in
+  **both** the goal and the `maxProd_ge_self` hypothesis so `linarith` connects them.
+
+## Verification
+Docker `docker-build.sh Proofs.Erdos490OQ01` (Lean 4.26.0, Mathlib pinned) → **7745 jobs,
+Build succeeded**, 0 errors / 0 sorries in the file (only pre-existing unused-variable
+warnings in `Erdos490Problem.lean`). `#print axioms optimal_lower` = `[propext,
+Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`) — a clean 0-axiom
+theorem.
+
+Gallery meta `src/data/proofs/erdos-490-oq-01/meta.json`: axiomCount 2 → 1, lineCount
+268 → 343, theoremCount 11 → 13; assumptions/description/proofStrategy prose reconciled
+(also cleared pre-existing "3 axioms" drift — `maxProd_exists` had already been proved).
+
+## Still open (NOT done here)
+- `szemeredi_upper` / `szemeredi_theorem` (the N²/logN **upper** bound; Szemerédi 1976) —
+  the genuinely deep result, correctly axiomatized in both files. Not attackable
+  (Mathlib's `Chebyshev.lean` itself lists the lower bound as future work; the *upper*
+  Szemerédi combinatorial bound is a separate, harder gap).
+- The Erdős limit question itself (does the ratio converge?) — the open math question the
+  file frames; unresolved.

--- a/src/data/proofs/erdos-490-oq-01/meta.json
+++ b/src/data/proofs/erdos-490-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-490-oq-01",
   "title": "Does lim max|A||B|·log N/N² Exist?",
   "slug": "erdos-490-oq-01",
-  "description": "Formalizes the open question from Erdős Problem #490: does lim max|A||B|·log N/N² exist, where the maximum is over pairs with distinct products in {1,...,N}? Proves the product ratio is sandwiched between positive constants (Szemerédi upper bound and prime construction lower bound) and that any limit must lie in [c, C]. Three axioms encoding deep number-theoretic bounds, nine theorems, zero sorries.",
+  "description": "Formalizes the open question from Erdős Problem #490: does lim max|A||B|·log N/N² exist, where the maximum is over pairs with distinct products in {1,...,N}? Proves the product ratio is sandwiched between positive constants (Szemerédi upper bound and prime-construction lower bound) and that any limit must lie in [c, C]. One axiom (Szemerédi's deep upper bound); the matching lower bound is now a proved theorem (0-axiom). Thirteen theorems, zero sorries.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/490",
@@ -33,76 +33,77 @@
       }
     ],
     "originalContributions": [
-      "Abstract formalization of maxProd(N) via existential axiom with achieved maximum",
+      "Formalization of maxProd(N) with proved existence/achievability (maxProd_exists theorem, 0-axiom)",
       "Product ratio sequence productRatio'(N) = maxProd(N)·log(N)/N²",
       "Proved product ratio bounded above from Szemerédi bound",
-      "Proved product ratio bounded below from optimal example",
+      "Proved product ratio bounded below from the optimal example (via the now-proved optimal_lower)",
       "Proved: if limit exists, it lies in [c, C] (sandwich theorem)",
       "Proved: product ratio is nonneg for N ≥ 2",
       "Proved: cardinality bound |A| ≤ N for A ⊆ {1,...,N}",
       "Proved: maxProd(N) ≤ N² (trivial bound from cardinality)",
-      "Proved: full sandwich — positive constants c ≤ C bracket all ratios"
+      "Proved: full sandwich — positive constants c ≤ C bracket all ratios",
+      "Eliminated the optimal_lower axiom: proved maxProd(N) ≥ c·N²/log N (0-axiom) by transferring the sibling file's verified bound_is_optimal through maxProd_is_upper (axiom count 2 → 1)"
     ],
-    "axiomCount": 2,
-    "lineCount": 268,
-    "assumptions": "2 axioms (both deep number-theoretic results): the Szemerédi upper bound maxProd(N) ≤ C·N²/log N and the optimal-example lower bound maxProd(N) ≥ c·N²/log N. The former existence axiom `maxProd_exists` (that the maximum of |A||B| over valid pairs is attained) is now a proved theorem — the optimization ranges over subsets of the finite set {1,...,N}, so the achievable-value set is a nonempty finite Finset of naturals and the maximum is its Finset.max'. Fully machine-checked apart from the 2 stated axioms (#print axioms lists only those two plus propext/Classical.choice/Quot.sound).",
+    "axiomCount": 1,
+    "lineCount": 343,
+    "assumptions": "1 axiom (a deep number-theoretic result): the Szemerédi upper bound maxProd(N) ≤ C·N²/log N. The optimal-example lower bound maxProd(N) ≥ c·N²/log N is now a proved theorem (`optimal_lower`, 0-axiom): it is transferred from the sibling file's verified `Erdos490.bound_is_optimal` via `maxProd_is_upper` (the maximum dominates the optimal example's product), with small cases N ∈ {2,3} handled by `maxProd_ge_self`. The existence/achievability of the maximum (`maxProd_exists`) is likewise a proved theorem — the optimization ranges over subsets of the finite set {1,...,N}, so the achievable-value set is a nonempty finite Finset of naturals and the maximum is its Finset.max'. Fully machine-checked apart from the single stated axiom (#print axioms of optimal_lower lists only propext/Classical.choice/Quot.sound — no sorryAx, no Lean.ofReduceBool).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 5
   },
   "sections": [
     {
       "id": "header-and-definitions",
-      "title": "Module Header, Definitions, and maxProd Axiom",
-      "summary": "Module docstring, imports, and the core combinatorial setup: `IsSubsetUpTo'` ($A \\subseteq \\{1,\\ldots,N\\}$), `HasDistinctProducts'` (product map injective), `maxProd` (maximum $|A||B|$ over valid pairs), and `productRatio'` (normalized ratio $\\operatorname{maxProd}(N) \\cdot \\log N / N^2$). The `maxProd_exists` axiom asserts existence and achievability of the maximum.",
+      "title": "Module Header, Definitions, and maxProd",
+      "summary": "Module docstring, imports, and the core combinatorial setup: `IsSubsetUpTo'` ($A \\subseteq \\{1,\\ldots,N\\}$), `HasDistinctProducts'` (product map injective), `maxProd` (maximum $|A||B|$ over valid pairs), and `productRatio'` (normalized ratio $\\operatorname{maxProd}(N) \\cdot \\log N / N^2$). `maxProd_exists` (a proved theorem) provides existence and achievability of the maximum.",
       "startLine": 1,
-      "endLine": 86,
-      "mathContext": "Five definitions formalize the optimization problem: $f(N) = \\max\\{|A||B| : A, B \\subseteq \\{1,\\ldots,N\\},\\; \\phi_{A,B} \\text{ injective}\\}$ and $r(N) = f(N) \\cdot \\log N / N^2$. The axiom `maxProd_exists` provides the existential witness for $f(N)$."
+      "endLine": 125,
+      "mathContext": "Five definitions formalize the optimization problem: $f(N) = \\max\\{|A||B| : A, B \\subseteq \\{1,\\ldots,N\\},\\; \\phi_{A,B} \\text{ injective}\\}$ and $r(N) = f(N) \\cdot \\log N / N^2$. The theorem `maxProd_exists` provides the existential witness for $f(N)$."
     },
     {
       "id": "bounds",
       "title": "Bounds on the Product Ratio",
-      "summary": "Two axioms encode deep bounds: Szemerédi's $\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$ and the optimal construction's $\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$. Two theorems derive $c \\leq \\operatorname{productRatio}'(N) \\leq C$ by algebraic manipulation: multiply by $\\log N$, divide by $N^2$, use `field_simp` to cancel.",
-      "startLine": 88,
-      "endLine": 116,
+      "summary": "One axiom (Szemerédi's maxProd(N) ≤ C·N²/log N) plus one proved theorem encode the two bounds. The optimal construction's lower bound `optimal_lower` (maxProd(N) ≥ c·N²/log N) is proved (0-axiom) by transferring the sibling file's `Erdos490.bound_is_optimal` through `maxProd_is_upper` (with N ∈ {2,3} via `maxProd_ge_self`). Two theorems then derive c ≤ productRatio'(N) ≤ C by algebraic manipulation: multiply by log N, divide by N², use `field_simp` to cancel.",
+      "startLine": 126,
+      "endLine": 246,
       "mathContext": "$c \\leq \\frac{\\operatorname{maxProd}(N) \\cdot \\log N}{N^2} \\leq C$ for all $N \\geq 2$. The proofs are symmetric `calc` blocks using $\\log N > 0$ for $N \\geq 2$."
     },
     {
       "id": "limit-question",
       "title": "The Limit Question and Sandwich Theorem",
       "summary": "Defines `LimitExists'` (standard $\\varepsilon$-$\\delta$ convergence) and proves `limit_in_sandwich`: if the limit $L$ exists, then $c \\leq L \\leq C$. Each bound is proved by contradiction — assuming $L < c$ (or $L > C$) and choosing $\\varepsilon = c - L$ (or $L - C$) yields a value simultaneously above and below the bound.",
-      "startLine": 118,
-      "endLine": 156,
+      "startLine": 247,
+      "endLine": 286,
       "mathContext": "If $a_n \\to L$ and $c \\leq a_n \\leq C$ for all $n$, then $c \\leq L \\leq C$. This is the squeeze theorem for limits of bounded sequences, proved here via $\\varepsilon$-$\\delta$ contradiction."
     },
     {
       "id": "structural",
       "title": "Structural Analysis and Full Sandwich",
-      "summary": "Proves `productRatio_nonneg` (nonnegativity from component signs), `card_le_of_subset_upto` ($|A| \\leq N$ via inclusion into $[1, N]$), `maxProd_le_sq` (trivial bound $\\operatorname{maxProd}(N) \\leq N^2$), and the capstone `productRatio_sandwich` (combining all bounds with $c \\leq C$ verified at $N = 2$). Summary `#check` block lists all nine theorems.",
-      "startLine": 158,
-      "endLine": 201,
+      "summary": "Proves `productRatio_nonneg` (nonnegativity from component signs), `card_le_of_subset_upto` ($|A| \\leq N$ via inclusion into $[1, N]$), `maxProd_le_sq` (trivial bound $\\operatorname{maxProd}(N) \\leq N^2$), and the capstone `productRatio_sandwich` (combining all bounds with $c \\leq C$ verified at $N = 2$). Summary `#check` block lists the core API theorems.",
+      "startLine": 287,
+      "endLine": 330,
       "mathContext": "$|A| \\leq |[1,N]| = N$ for $A \\subseteq \\{1,\\ldots,N\\}$, so $\\operatorname{maxProd}(N) \\leq N^2$. The full sandwich combines all bounds into a single statement with explicit $c \\leq C$."
     },
     {
       "id": "summary",
       "title": "Module Summary and API",
-      "summary": "Summary `#check` block listing all nine theorems proved: `maxProd_is_upper`, `maxProd_is_achieved`, `productRatio_bounded_above`, `productRatio_bounded_below`, `limit_in_sandwich`, `productRatio_nonneg`, `card_le_of_subset_upto`, `maxProd_le_sq`, `productRatio_sandwich`. Serves as a concise API reference for downstream consumers.",
-      "startLine": 203,
-      "endLine": 215,
-      "mathContext": "Nine theorems from three axioms: two interface lemmas, two sandwich bounds, one limit theorem, and four structural results."
+      "summary": "Summary `#check` block listing the core API theorems proved: `maxProd_is_upper`, `maxProd_is_achieved`, `productRatio_bounded_above`, `productRatio_bounded_below`, `limit_in_sandwich`, `productRatio_nonneg`, `card_le_of_subset_upto`, `maxProd_le_sq`, `productRatio_sandwich`. Serves as a concise API reference for downstream consumers.",
+      "startLine": 331,
+      "endLine": 343,
+      "mathContext": "Thirteen theorems from a single axiom (the Szemerédi upper bound): two interface lemmas, the proved optimal_lower / maxProd_ge_self bounds, two sandwich bounds, one limit theorem, and four structural results."
     }
   ],
   "overview": {
     "historicalContext": "Erdős Problem #490 belongs to extremal multiplicative combinatorics, a field Erdős helped create. The question concerns pairs $A, B \\subseteq \\{1,\\ldots,N\\}$ where the product map $(a,b) \\mapsto ab$ is injective — all products are distinct. How large can $|A| \\cdot |B|$ be?\n\nThe upper bound is due to Szemerédi (1976), who proved $|A||B| \\leq C \\cdot N^2/\\log N$ by a combinatorial argument exploiting the multiplicative structure of $\\{1,\\ldots,N\\}$. The logarithmic factor arises because large subsets of $\\{1,\\ldots,N\\}$ inevitably share multiplicative structure: numbers with many small prime factors create product collisions $ab = a'b'$, so achieving distinct products requires either small sets or sets whose elements have disjoint prime factorizations.\n\nThe matching lower bound comes from a natural construction: take $A = \\{1,\\ldots,\\lfloor N/2 \\rfloor\\}$ and $B = \\{p \\text{ prime} : N/2 < p \\leq N\\}$. Since every $b \\in B$ is prime and $> N/2$, each product $ab = a \\cdot p$ has a unique factorization with prime part $p$, ensuring distinctness. By the prime number theorem, $|B| \\sim N/(2\\log N)$ and $|A| \\sim N/2$, giving $|A||B| \\sim N^2/(4\\log N)$.\n\nErdős (1972) asked the natural follow-up: since $\\operatorname{maxProd}(N) = \\Theta(N^2/\\log N)$, does the normalized ratio $\\operatorname{maxProd}(N) \\cdot \\log N / N^2$ converge to a definite constant? If so, this constant would be a fundamental quantity in multiplicative combinatorics, analogous to the constant 1 in the prime number theorem ($\\pi(N) \\sim N/\\log N$). The question remains open.",
     "problemStatement": "Does the limit L = lim_{N→∞} max_{A,B} |A||B|·log N/N² exist, where the maximum is over pairs (A,B) ⊆ {1,...,N}² with all products ab distinct? If so, what is L?",
-    "text": "A formalization of the limit question for Erdős Problem #490 in 229 lines with 3 axioms and 0 sorries. The two deep bounds — Szemerédi's upper bound $\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$ and the prime construction's lower bound $\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$ — are axiomatized. From these, nine theorems derive: the product ratio $\\operatorname{productRatio}'(N) = \\operatorname{maxProd}(N) \\cdot \\log N / N^2$ is sandwiched between positive constants $c$ and $C$; if the limit exists, it lies in $[c, C]$; and structural properties including nonnegativity, cardinality bounds, and the trivial bound $\\operatorname{maxProd}(N) \\leq N^2$. The central open question — does the sequence converge or oscillate? — is formally stated but unresolved.",
-    "proofStrategy": "The proof follows a three-layer strategy:\n\n1. **AXIOMATIZE**: Three axioms encode results whose proofs require deep number theory: `maxProd_exists` (the finite optimization has an achiever), `szemeredi_upper` ($\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$), and `optimal_lower` ($\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$). These are treated as black boxes.\n\n2. **ALGEBRAIC MANIPULATION**: The bounded-above and bounded-below theorems convert the axioms into bounds on the product ratio by multiplying by $\\log N / N^2$ and simplifying. The key technique is `calc` blocks with `field_simp` to cancel the $\\log N$ denominator, using `mul_le_mul_of_nonneg_left` for monotonicity.\n\n3. **REAL ANALYSIS**: The `limit_in_sandwich` theorem uses $\\varepsilon$-$\\delta$ contradiction: if $L < c$, choose $\\varepsilon = c - L$ and derive $\\operatorname{productRatio}'(N) < c$ for large $N$, contradicting the lower bound. The `max N_0 2` trick simultaneously satisfies the convergence threshold and the $N \\geq 2$ requirement.\n\nThe development separates the 'hard' mathematics (axiomatized) from the 'soft' analysis (proved), allowing the formal verification to focus on the logical structure of the limit argument.",
+    "text": "A formalization of the limit question for Erdős Problem #490 in 229 lines with 1 axiom and 0 sorries. Szemerédi's upper bound $\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$ is axiomatized; the prime construction's matching lower bound $\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$ is now a proved theorem (transferred from the sibling file's verified optimal-example bound). From these, thirteen theorems derive: the product ratio $\\operatorname{productRatio}'(N) = \\operatorname{maxProd}(N) \\cdot \\log N / N^2$ is sandwiched between positive constants $c$ and $C$; if the limit exists, it lies in $[c, C]$; and structural properties including nonnegativity, cardinality bounds, and the trivial bound $\\operatorname{maxProd}(N) \\leq N^2$. The central open question — does the sequence converge or oscillate? — is formally stated but unresolved.",
+    "proofStrategy": "The proof follows a three-layer strategy:\n\n1. **AXIOMATIZE**: A single axiom `szemeredi_upper` ($\\operatorname{maxProd}(N) \\leq C \\cdot N^2/\\log N$, Szemerédi 1976) encodes the one result whose proof requires deep number theory. The finite-optimization achiever (`maxProd_exists`) and the optimal-example lower bound (`optimal_lower`, $\\operatorname{maxProd}(N) \\geq c \\cdot N^2/\\log N$) are proved theorems — the latter transferred from the sibling file's verified `bound_is_optimal`.\n\n2. **ALGEBRAIC MANIPULATION**: The bounded-above and bounded-below theorems convert the axioms into bounds on the product ratio by multiplying by $\\log N / N^2$ and simplifying. The key technique is `calc` blocks with `field_simp` to cancel the $\\log N$ denominator, using `mul_le_mul_of_nonneg_left` for monotonicity.\n\n3. **REAL ANALYSIS**: The `limit_in_sandwich` theorem uses $\\varepsilon$-$\\delta$ contradiction: if $L < c$, choose $\\varepsilon = c - L$ and derive $\\operatorname{productRatio}'(N) < c$ for large $N$, contradicting the lower bound. The `max N_0 2` trick simultaneously satisfies the convergence threshold and the $N \\geq 2$ requirement.\n\nThe development separates the 'hard' mathematics (axiomatized) from the 'soft' analysis (proved), allowing the formal verification to focus on the logical structure of the limit argument.",
     "keyInsights": [
       "**Sandwich between positive constants**: $0 < c \\leq \\operatorname{productRatio}'(N) \\leq C$ for all $N \\geq 2$. The lower bound $c$ comes from the prime construction ($A = [1, N/2]$, $B = $ primes in $(N/2, N]$), and the upper bound $C$ from Szemerédi's theorem. This pins the sequence to a bounded positive interval.",
       "**Limit constrained to $[c, C]$**: If $\\lim \\operatorname{productRatio}'(N) = L$ exists, then $c \\leq L \\leq C$. Proved by $\\varepsilon$-$\\delta$ contradiction — the squeeze theorem for bounded convergent sequences.",
       "**Convergence vs. oscillation**: Boundedness does not imply convergence. The Bolzano-Weierstrass theorem guarantees convergent subsequences, but the full sequence could oscillate between $c$ and $C$. Resolving whether it converges likely requires understanding the fine arithmetic structure of optimal pairs $(A, B)$ as $N$ varies.",
       "**The logarithmic factor is forced**: The $\\log N$ in Szemerédi's bound arises because dense subsets of $\\{1,\\ldots,N\\}$ share multiplicative structure. Numbers with many small prime factors create product collisions, so achieving distinct products forces either small sets or multiplicatively independent elements (like primes, which have density $\\sim 1/\\log N$).",
-      "**Axiomatization separates depth from logic**: The three axioms isolate the 'hard' mathematics (Szemerédi's combinatorial argument, the prime number theorem for the lower bound, finite optimization) from the 'soft' real analysis (sandwich, limit bounds). This design lets Lean verify the logical structure without requiring the full number-theoretic proofs.",
+      "**Axiomatization separates depth from logic**: The single Szemerédi upper-bound axiom isolates the one 'hard' input (Szemerédi's combinatorial argument). The matching lower bound and the finite-optimization achiever are proved, so Lean verifies almost the entire development — only the deep upper bound is assumed.",
       "**Possible limit value $1/2$**: If the limit exists, the prime construction suggests $L \\approx 1/4$ to $1/2$ (from $|A||B| \\approx N^2/(4\\log N)$ giving ratio $\\approx 1/4$). Whether the prime construction is asymptotically optimal — or whether cleverer constructions beat it — is part of the open question."
     ],
     "prerequisites": [
@@ -112,7 +113,7 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization establishes the foundational framework for Erdős's limit question: the product ratio $\\operatorname{maxProd}(N) \\cdot \\log N / N^2$ is sandwiched between positive constants, so it neither diverges to $\\infty$ nor decays to 0. Any limit must lie in $[c, C]$. The nine theorems with zero sorries provide a rigorous starting point for investigating convergence.",
+    "summary": "This formalization establishes the foundational framework for Erdős's limit question: the product ratio $\\operatorname{maxProd}(N) \\cdot \\log N / N^2$ is sandwiched between positive constants, so it neither diverges to $\\infty$ nor decays to 0. Any limit must lie in $[c, C]$. The thirteen theorems with zero sorries provide a rigorous starting point for investigating convergence.",
     "implications": "**Theoretical significance**: The sandwich theorem reduces the limit question to a question about oscillation vs. convergence of a bounded positive sequence. Since the Bolzano-Weierstrass theorem guarantees convergent subsequences, the key question is whether the limsup and liminf coincide.\n\n**Connections to additive combinatorics**: The distinct products condition is the multiplicative analogue of Sidon sets (where all pairwise sums are distinct). The Erdős-Turán conjecture on Sidon sets ($|A| \\leq \\sqrt{N} + O(N^{1/4})$) and the Cilleruelo-Vinuesa improvements have multiplicative counterparts that constrain the structure of optimal pairs.\n\n**Sum-product phenomenon**: Erdős and Szemerédi (1983) showed that finite sets cannot simultaneously have small sumset and small product set ($|A+A| + |A \\cdot A| \\geq |A|^{1+\\varepsilon}$). The distinct products constraint in Problem #490 forces $|A \\cdot B| = |A||B|$ (maximal product set), which limits $|A|$ and $|B|$ and connects to this broader theme.\n\n**Monotonicity approach**: If $\\operatorname{productRatio}'(N)$ were eventually monotone (increasing or decreasing), convergence would follow immediately from boundedness. Understanding whether optimal pairs $(A_N, B_N)$ vary smoothly or erratically with $N$ is the crux of the problem.",
     "openQuestions": [
       "Does $\\lim_{N \\to \\infty} \\operatorname{maxProd}(N) \\cdot \\log N / N^2$ exist? This is Erdős's original question — completely open.",
@@ -132,9 +133,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 268,
-    "axiomCount": 2,
-    "theoremCount": 11,
+    "lineCount": 343,
+    "axiomCount": 1,
+    "theoremCount": 13,
     "definitionCount": 5,
     "path": "Proofs/Erdos490OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary
Eliminates the `optimal_lower` **axiom** in `Erdos490OQ01.lean` (the Erdős #490 open-question sibling file), converting it into a fully-proved **0-axiom theorem**. The file's axiom count drops **2 → 1** — only the genuinely deep `szemeredi_upper` (Szemerédi 1976 upper bound) remains axiomatized.

## What & why
`optimal_lower` asserts the optimal-example lower bound `maxProd(N) ≥ c·N²/log N`. This duplicates content that the sibling file `Erdos490Problem.lean` now proves **0-axiom** (`Erdos490.bound_is_optimal`, the fruit of the verified Chebyshev θ-gap work). Since `maxProd N` dominates the product of *any* valid distinct-product pair (`maxProd_is_upper`), the bound transfers:

- **N ≥ 4:** `bound_is_optimal` hands a specific pair `(A,B) = ([1,N/2], primes in (N/2,N])` with `|A||B| ≥ c₀·N²/log N`; its witnesses convert to the OQ01 file's primed defs (`IsSubsetUpTo'` ≡ `IsSubsetUpTo`, `HasDistinctProducts'` ≡ `ProductMapInjective` via `productMapInjective_iff_hasDistinctProducts`) and feed `maxProd_is_upper`.
- **N ∈ {2,3}** (below the `N ≥ 4` floor): new helper `maxProd_ge_self` (`maxProd N ≥ N`, from the pair `A = Icc 1 N`, `B = {1}`) with the constant shrunk to `c = min c₀ (min (log 2/2) (log 3/3))`, so `c ≤ log N / N`. No log numerics — only `min_le` + `Real.log_pos`.

## Verification
- Docker build `docker-build.sh Proofs.Erdos490OQ01` → **7745 jobs, Build succeeded**, 0 errors / 0 sorries in the file.
- `#print axioms optimal_lower` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Genuine 0-axiom theorem.

## Metadata
`src/data/proofs/erdos-490-oq-01/meta.json`: axiomCount 2→1, lineCount 268→343, theoremCount 11→13; assumptions/description/proofStrategy/keyInsights prose reconciled (also cleared pre-existing "3 axioms" drift — `maxProd_exists` had already been proved in a prior session) and section line anchors updated.

## Still open
`szemeredi_upper` (= `szemeredi_theorem`, the N²/log N **upper** bound; Szemerédi 1976) stays correctly axiomatized — the deep result, not attackable (Mathlib's `Chebyshev.lean` lists even the θ lower bound as future work; the upper Szemerédi combinatorial bound is a separate, harder gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)