### PR TITLE
research(erdos-1093-oq-02): de-native_decide the (28!)²<47! certificate [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -48,10 +48,14 @@ the **tractable half** and formalizes the question precisely.
 ## Axioms
 
 The record facts (`deficiency_284_28`, `noSmallPrimeFactors_284_28`,
-`smooth_indices_284_28`) and the single numeric certificate `(28!)² < 47!`
-inside `deficiency_record_le_18` (Section XII) are discharged by `native_decide`,
-so they depend on `Lean.ofReduceBool`.  The structural results (1, 5) and all of
-Sections IV–XI are `ofReduceBool`-free.
+`smooth_indices_284_28`) are discharged by `native_decide`, so they depend on
+`Lean.ofReduceBool`: they compute the bignum binomial `C(284,28)` (Pascal
+recursion, infeasible for the kernel) or factor values via `Nat.primeFactors`
+(well-founded recursion, which does not reduce under kernel `decide`).  The
+numeric certificate `(28!)² < 47!` inside `deficiency_record_le_18` (Section XII)
+is now discharged by kernel `decide` (`Nat.factorial` is structural recursion, so
+the kernel reduces it), hence it is `ofReduceBool`-free.  The structural results
+(1, 5) and all of Sections IV–XI are `ofReduceBool`-free.
 
 ## Status: OPEN (universal upper bound); existence half machine-verified.
 -/
@@ -678,7 +682,7 @@ theorem sharp_bound_frontier_exact (k : ℕ) :
 Section X's sharp closed form `(k + deficiency n k)! ≤ (k!)²`
 (`deficiency_add_factorial_le_sq`) is an abstract inequality; specialising it to
 the record modulus `k = 28` turns it into a concrete numeric ceiling on the
-deficiency.  Since `(28!)² < 47!` (a single bignum comparison, `native_decide`)
+deficiency.  Since `(28!)² < 47!` (a single bignum comparison, kernel `decide`)
 while `(28!)² ≥ 46! = (28 + 18)!`, the bound `(28 + d)! ≤ (28!)²` forces
 `d ≤ 18`.  So *every* admissible pair with `k = 28` — including the record
 `(284, 28)` itself — has deficiency at most `18`.
@@ -703,7 +707,10 @@ theorem deficiency_record_le_18 {n : ℕ} (hn : 56 ≤ n)
   have hsq := deficiency_add_factorial_le_sq (n := n) (k := 28) (by omega) h
   have hmono : Nat.factorial 47 ≤ Nat.factorial (28 + deficiency n 28) :=
     Nat.factorial_le (by omega)
-  have hnum : (Nat.factorial 28) ^ 2 < Nat.factorial 47 := by native_decide
+  -- `Nat.factorial` is structural recursion, so the kernel reduces it: this
+  -- bignum comparison is checked by `decide` (⇒ no `Lean.ofReduceBool`), matching
+  -- the `interval_cases k <;> decide` pattern used for the abstract bound above.
+  have hnum : (Nat.factorial 28) ^ 2 < Nat.factorial 47 := by decide
   exact absurd (hmono.trans hsq) (not_le.mpr hnum)
 
 /-

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -224,3 +224,38 @@ are not decidable.
 ### Files Modified
 - `proofs/Proofs/Erdos1093ProblemOQ02.lean` (Section XII, +~35 lines, verified)
 - `src/data/research/problems/erdos-1093-oq-02.json` (metadata + knowledge)
+
+## Session 2026-07-08 (researcher-2) — de-native_decide the (28!)²<47! certificate
+
+**Mode:** AXIOM-REDUCTION (elementary theory saturated; look at trust surface).
+**Outcome:** progress (1 native_decide → kernel `decide`).
+
+### What I Did
+Converted the numeric certificate `(Nat.factorial 28)^2 < Nat.factorial 47` inside
+`deficiency_record_le_18` (Section XIV) from `native_decide` to kernel `decide`.
+`Nat.factorial` is *structural* recursion, so the kernel reduces `47!`/`28!`
+(47/28 GMP-accelerated mults) and the `<` literal comparison — no `Lean.ofReduceBool`.
+This matches the pre-existing `interval_cases k <;> decide` pattern (Section on the
+abstract `(k!)² < (k+9)!` bound). So `deficiency_record_le_18` is now
+`ofReduceBool`-free.
+
+### Why the other two certs can't follow (documented in the file's ## Axioms block)
+- `noSmallPrimeFactors_284_28`: reduces (via `noSmallPrimeFactors_iff`) to testing
+  `p ∤ C(284,28)` for primes p≤28. Kernel `decide` would have to compute the bignum
+  binomial `C(284,28)` by Pascal recursion — infeasible. A genuine `ofReduceBool`-free
+  route is Kummer/Legendre (v_p(C(n,k))=0 ⟺ no base-p carries adding 28 and 256), a
+  per-prime finite carry check; not attempted here (≈100+ lines, 9 primes).
+- `smooth_indices_284_28`: `IsKSmooth` decidability goes through `Nat.primeFactors`,
+  which is **well-founded** recursion → does NOT reduce under kernel `decide` (only
+  `native_decide`). This is why `decide` cannot replace it even though the values are
+  ≤ 284.
+
+### Verification
+Built clean: `Proofs.Erdos1093ProblemOQ02` (3060 jobs, exit 0). File 714 lines,
+30 theorems, 0 sorry, 0 axiom declarations. Remaining native_decide: exactly the
+two binomial/factorization record certs above (+ parent's `deficiency_284_28`).
+
+### Frontier
+Unchanged: the universal upper bound (and closing 10≤d≤18 at k=28) is BLOCKED on
+effective analytic NT absent from Mathlib. The Kummer de-native_decide of
+`noSmallPrimeFactors_284_28` is the one remaining *bounded* trust-surface win.


### PR DESCRIPTION
## Summary

Trust-surface reduction on the (saturated) Erdős #1093 OQ-02 file: the numeric
certificate `(28!)² < 47!` inside `deficiency_record_le_18` (Section XIV) is
converted from `native_decide` to **kernel `decide`**, removing its
`Lean.ofReduceBool` dependency.

`Nat.factorial` is structural recursion, so the kernel reduces `28!`/`47!`
(GMP-accelerated multiplications) and checks the `<` literal comparison directly —
no compiler trust needed. This matches the file's existing
`interval_cases k <;> decide` proof of the abstract `(k!)² < (k+9)!` bound.

## Why the other two `native_decide` record certs cannot follow (now documented)

- `noSmallPrimeFactors_284_28` reduces to `p ∤ C(284,28)` for primes `p ≤ 28`;
  kernel `decide` would have to compute the bignum binomial `C(284,28)` by Pascal
  recursion (infeasible). An `ofReduceBool`-free route would be Kummer/Legendre
  (no base-`p` carries) — a bounded per-prime check, left as the one remaining
  trust-surface win.
- `smooth_indices_284_28` decidability goes through `Nat.primeFactors`
  (**well-founded** recursion), which does not reduce under kernel `decide`.

## Verification

VERIFIED: Docker build clean (3060 jobs, exit 0), 0 sorry, 0 axiom declarations.
Also reconciles stale `leanFiles` metadata (595→714 lines, 26→30 theorems from
prior unsynced sessions).

## Scope

No change to the open frontier: the universal upper bound (and closing `10 ≤ d ≤ 18`
at `k = 28`) remains BLOCKED on effective analytic number theory absent from
Mathlib 4.26. This PR is a pure honesty/trust-surface improvement.