### PR TITLE
Enrich Gaussian CF ODE / cumulants (central-limit-theorem-oq-01-oq-02-oq-01-oq-03)

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -137,6 +137,14 @@
       "endLine": 66
     },
     {
+      "name": "gaussianExponent_deriv2",
+      "type": "core",
+      "description": "ψ''(t) = −σ² (constant): the second cumulant κ₂ = σ² (the variance).",
+      "leanType": "(μ σ_sq t : ℝ) → HasDerivAt (fun s : ℝ => (↑μ * Complex.I - ↑(σ_sq * s) : ℂ)) (-↑σ_sq) t",
+      "startLine": 87,
+      "endLine": 93
+    },
+    {
       "name": "gaussianExponent_deriv3",
       "type": "core",
       "description": "ψ''' ≡ 0: all cumulants of order ≥ 3 vanish.",


### PR DESCRIPTION
Enrichment pass on a quality-94 entry (12.7 KB meta.json, well under all size caps).

The `mainTheorems` navigation array highlighted the first-derivative ODE (`gaussianCharFn_hasDerivAt`), the exponent derivative (`gaussianExponent_hasDerivAt`), and the vanishing of κ≥3 (`gaussianExponent_deriv3`), but omitted the **second cumulant** result — one of the entry's central original contributions. This PR adds `gaussianExponent_deriv2` (ψ''(t) = −σ², i.e. κ₂ = σ², the variance), completing the highlighted cumulant story κ₁ → κ₂ → κ≥3.

- Accurate leanType and line anchors (87–93) verified against the Lean source.
- No prose inflation; single navigation entry added. JSON validated.