### PR TITLE
audit: reconcile stale line/theorem counts on 7 re-audited entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4594,10 +4594,13 @@
       "result": "clean"
     },
     "cauchy-interlacing-theorem-oq-01-oq-02": {
-      "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-06-24T12:27:19Z",
-      "result": "clean"
+      "auditCount": 2,
+      "issues": [
+        "Stale theoremCount/lineCount reconciled to Lean source after research growth (re-audit)"
+      ],
+      "lastAudited": "2026-07-08T20:35:55Z",
+      "result": "issues-fixed",
+      "agentId": "auditor-reaudit-20260708"
     },
     "cauchy-interlacing-theorem-oq-01-oq-02-oq-01": {
       "auditCount": 2,
@@ -8587,9 +8590,13 @@
       "result": "clean"
     },
     "erdos-1006-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-06-20T17:37:55Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-08T20:35:55Z",
+      "result": "issues-fixed",
+      "agentId": "auditor-reaudit-20260708",
+      "issues": [
+        "Stale theoremCount/lineCount reconciled to Lean source after research growth (re-audit)"
+      ]
     },
     "erdos-1006-oq-01-oq-02": {
       "auditCount": 2,
@@ -9020,12 +9027,13 @@
       "result": "clean"
     },
     "erdos-1022-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
-        "Stale theoremCount/lineCount reconciled to Lean source (re-audit)"
+        "Stale theoremCount/lineCount reconciled to Lean source (re-audit)",
+        "Stale theoremCount/lineCount reconciled to Lean source after research growth (re-audit)"
       ],
-      "lastAudited": "2026-07-08T19:12:11Z",
-      "result": "clean",
+      "lastAudited": "2026-07-08T20:35:55Z",
+      "result": "issues-fixed",
       "agentId": "auditor-reaudit-20260708"
     },
     "erdos-1022-oq-04": {
@@ -15757,11 +15765,12 @@
     },
     "erdos-703": {
       "agentId": "auditor-reaudit-20260708",
-      "auditCount": 6,
-      "lastAudited": "2026-07-08T19:12:11Z",
-      "result": "clean",
+      "auditCount": 7,
+      "lastAudited": "2026-07-08T20:35:55Z",
+      "result": "issues-fixed",
       "issues": [
-        "Stale theoremCount/lineCount reconciled to Lean source (re-audit)"
+        "Stale theoremCount/lineCount reconciled to Lean source (re-audit)",
+        "Stale theoremCount/lineCount reconciled to Lean source after research growth (re-audit)"
       ]
     },
     "erdos-704": {
@@ -24491,18 +24500,22 @@
       "result": "issues-fixed"
     },
     "roth-theorem": {
-      "auditCount": 3,
-      "lastAudited": "2026-07-08T18:54:18Z",
-      "result": "clean",
-      "issues": [],
-      "agentId": "auditor-agent-7"
+      "auditCount": 4,
+      "lastAudited": "2026-07-08T20:35:55Z",
+      "result": "issues-fixed",
+      "issues": [
+        "Stale theoremCount/lineCount reconciled to Lean source after research growth (re-audit)"
+      ],
+      "agentId": "auditor-reaudit-20260708"
     },
     "roth-theorem-k3": {
-      "auditCount": 6,
-      "issues": [],
-      "lastAudited": "2026-07-08T18:54:18Z",
-      "result": "clean",
-      "agentId": "auditor-agent-7"
+      "auditCount": 7,
+      "issues": [
+        "Stale theoremCount/lineCount reconciled to Lean source after research growth (re-audit)"
+      ],
+      "lastAudited": "2026-07-08T20:35:55Z",
+      "result": "issues-fixed",
+      "agentId": "auditor-reaudit-20260708"
     },
     "roth-theorem-k3-oq-01": {
       "auditCount": 5,
@@ -29633,14 +29646,16 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-03": {
-      "lastAudited": "2026-07-08T19:12:11Z",
-      "auditCount": 2,
-      "result": "clean",
+      "lastAudited": "2026-07-08T20:35:55Z",
+      "auditCount": 3,
+      "result": "issues-fixed",
       "agentId": "auditor-reaudit-20260708",
       "notes": "Audit CLEAN (first audit): 0 sorries/0 axioms/0 native_decide. Uses kernel `decide` (lines 219,224) NOT native_decide for B 1=95 numeric check; assumptions field correctly states ofReduceBool-free. Genuine Euclid-construction + iterated-factorial tower bound p3(k)<=B(k). verified/original accurate.",
-      "issues": []
+      "issues": [
+        "Stale theoremCount/lineCount reconciled to Lean source after research growth (re-audit)"
+      ]
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T19:12:11Z"
+  "lastUpdated": "2026-07-08T20:35:55Z"
 }

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -12,8 +12,8 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
-    "lineCount": 148,
-    "theoremCount": 3,
+    "lineCount": 184,
+    "theoremCount": 5,
     "definitionCount": 0,
     "difficulty": "advanced",
     "category": "linear-algebra",
@@ -62,9 +62,9 @@
       "CauchyInterlacing.Poincare"
     ],
     "namespace": "CauchyInterlacing.PoincareCompression",
-    "lineCount": 148,
+    "lineCount": 184,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/CauchyInterlacingPoincareCompression.lean",
     "sorries": 0

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -61,10 +61,10 @@
     ],
     "dateAdded": "2026-07-08",
     "axiomCount": 0,
-    "lineCount": 230,
+    "lineCount": 410,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, no structure-encoded assumptions. Uses kernel `decide` (not `native_decide`) for the numeric check B 1 = 95, so it is `ofReduceBool`-free.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 21,
+    "theoremCount": 37,
     "definitionCount": 3
   },
   "overview": {
@@ -177,7 +177,7 @@
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 31
+    "theoremCount": 37
   },
   "sorries": 0,
   "status": "verified",

--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -21,8 +21,8 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "2 axioms: chromatic_lt_girth_implies_robust (Fisher-Fraughnaugh-Langley-West 1997: χ(G) < girth(G) → G has robust orientation), nesetril_rodl_counterexample (Nešetřil-Rödl 1978: for every girth g≥3, there exists a graph with girth g that does NOT have a robust orientation). The Pretzel-Brightwell characterization (cover_graph_characterization) is now a proved theorem, not an axiom.",
-    "lineCount": 467,
-    "theoremCount": 11,
+    "lineCount": 534,
+    "theoremCount": 12,
     "definitionCount": 13,
     "originalContributions": [
       "admitsRobustAcyclicOrientation: predicate — G has an orientation that stays acyclic under any single edge reversal",

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 286,
+    "lineCount": 351,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 3
   },
   "overview": {
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 286,
+    "lineCount": 351,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 14,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -49,10 +49,10 @@
       "largeSetsFamily / largeSetsFamily_avoids_1 / largeSetsFamily_card_le_T: Frankl's (1977) r=1 lower-bound construction — the family of sets larger than (n+1)/2 is a valid 1-avoiding family, giving a verified lower bound |largeSetsFamily n| ≤ T(n,1)"
     ],
     "axiomCount": 1,
-    "lineCount": 415,
+    "lineCount": 467,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 8
   },
   "crossReferences": [
@@ -186,9 +186,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 415,
+    "lineCount": 467,
     "axiomCount": 1,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -58,10 +58,10 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 1401,
+    "lineCount": 1554,
     "assumptions": "No axioms, no sorries. Fully verified. Main theorem roth_density_bound proved via Mathlib's corners-theorem chain (Regularity Lemma → Triangle Removal → Corners → Roth). Fourier-analytic density increment infrastructure (Parts I-V) independently verified.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 42,
+    "theoremCount": 49,
     "definitionCount": 6,
     "additionalFiles": [
       "Proofs/RothTheoremAristotle.lean"
@@ -223,7 +223,7 @@
     "namespace": "Szemeredi.Roth",
     "lineCount": 1554,
     "axiomCount": 0,
-    "theoremCount": 43,
+    "theoremCount": 49,
     "definitionCount": 6,
     "path": "Proofs/RothTheorem.lean",
     "sorries": 0,

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -21,7 +21,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 2,
-    "assumptions": "Main file Proofs/RothTheorem.lean: 0 axioms, 0 sorries. All 42 theorems verified; the main theorem `roth_density_bound` invokes Mathlib's `roth_3ap_theorem_nat` (itself verified via the corners theorem chain: Regularity → Triangle Removal → Corners → Roth), and the Fourier-analytic infrastructure (Parts I–V, including `fourier_large_coefficient`) is independently verified. Chain total: 2 axioms from the OQ-02 companion Proofs/RothTheoremOQ02.lean — `rothNumberNat_bloom_sisask` (Bloom–Sisask 2020 logarithmic-barrier bound, arXiv:2007.03528) and `rothNumberNat_kelley_meka` (Kelley–Meka 2023 polynomial bound). The companion axiomatizes state-of-the-art quantitative refinements that require Bohr-set / density-increment infrastructure not yet in Mathlib v4.26.0; the qualitative Roth result itself remains fully verified.",
+    "assumptions": "Main file Proofs/RothTheorem.lean: 0 axioms, 0 sorries. All 49 theorems verified; the main theorem `roth_density_bound` invokes Mathlib's `roth_3ap_theorem_nat` (itself verified via the corners theorem chain: Regularity → Triangle Removal → Corners → Roth), and the Fourier-analytic infrastructure (Parts I–V, including `fourier_large_coefficient`) is independently verified. Chain total: 2 axioms from the OQ-02 companion Proofs/RothTheoremOQ02.lean — `rothNumberNat_bloom_sisask` (Bloom–Sisask 2020 logarithmic-barrier bound, arXiv:2007.03528) and `rothNumberNat_kelley_meka` (Kelley–Meka 2023 polynomial bound). The companion axiomatizes state-of-the-art quantitative refinements that require Bohr-set / density-increment infrastructure not yet in Mathlib v4.26.0; the qualitative Roth result itself remains fully verified.",
     "originalContributions": [
       "APFree definition and basic properties (apFree_empty, apFree_singleton, apFree_subset) on ZMod N",
       "tripleCount: exact count of 3-APs; apFree_iff_tripleCount_zero equivalence",
@@ -34,8 +34,8 @@
       "roth_density_bound: main theorem via Mathlib roth_3ap_theorem_nat"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 1401,
-    "theoremCount": 42,
+    "lineCount": 1554,
+    "theoremCount": 49,
     "definitionCount": 6,
     "additionalFiles": [
       "Proofs/RothTheoremAristotle.lean",
@@ -46,7 +46,7 @@
   "overview": {
     "historicalContext": "Roth's theorem (1953) was a landmark in additive combinatorics: every subset of integers with positive upper density contains a 3-term arithmetic progression. The original proof used Fourier analysis (the density increment strategy). The k=3 case was later subsumed by Szemerédi's theorem (1975) for general k-APs, but Roth's Fourier method remains fundamental.\n\nThe Fourier-analytic proof proceeds by density increment: if A ⊆ Z/NZ has density δ but no 3-AP, then A's Fourier transform has a large coefficient at some frequency r≠0 (the key analytic lemma). This large coefficient means A looks 'structured' — concentrated in a coset of a subgroup. Restricting to that coset increases the density to δ + δ²/4. Iterating O(1/δ²) times reaches density 1, giving a 3-AP by the pigeonhole principle.\n\nModern proofs achieve better quantitative bounds: Bourgain (1999) gave N/(log log N)^{1/2} and Bloom-Sisask (2020) gave N/log^{1+c} N. The qualitative result here suffices for Roth's original theorem.",
     "problemStatement": "**Roth's Theorem**: For every δ > 0, there exists N₀ such that for all N ≥ N₀, every subset A ⊆ Z/NZ with |A| ≥ δN contains a 3-term arithmetic progression {a, a+d, a+2d} with d ≠ 0.",
-    "text": "A 1401-line formalization developing the full Fourier-analytic proof of Roth's theorem from first principles on Z/NZ. Parts I–V (Fourier analysis, AP counting, large coefficient, density increment) are fully self-contained; Part VI wraps via Mathlib's `roth_3ap_theorem_nat`. The key standalone result is `fourier_large_coefficient` — a complete, independently verified proof of the crucial analytic step.",
+    "text": "A 1554-line formalization developing the full Fourier-analytic proof of Roth's theorem from first principles on Z/NZ. Parts I–V (Fourier analysis, AP counting, large coefficient, density increment) are fully self-contained; Part VI wraps via Mathlib's `roth_3ap_theorem_nat`. The key standalone result is `fourier_large_coefficient` — a complete, independently verified proof of the crucial analytic step.",
     "proofStrategy": "**Part I (AP-free basics)**: Define `APFree A` on `ZMod N`; prove empty/singleton cases; monotonicity under subset. Cardinality bound `card_le_nat` via `ZMod.card N`.\n\n**Part II (AP counting)**: `tripleCount A` counts nontrivial 3-APs via filter on `ZMod N × ZMod N`. Prove `apFree_iff_tripleCount_zero` using Finset.card_eq_zero.\n\n**Part III (Fourier analysis)**: `fourierCoeff A r = Σ_{x∈A} exp(2πi val(r·x)/N)`. Additive character `ψ`: prove `psi_add`, `psi_zero`, `psi_ne_one`, `psi_norm`, `conj_psi`. Prove `char_orthogonality`: `Σ_r ψ(rc) = N·δ(c,0)` via shift argument. Use to prove `parseval_on_zmod` and `triple_count_fourier`.\n\n**Part IV (Large coefficient)**: `fourier_large_coefficient` — two cases: (1) δ²N < 2: Parseval gives max ≥ 1 > δ²N/2; (2) δ²N ≥ 2: contradiction via Fourier identity + AM-GM bound on sum over T₁ ∪ T₂ splitting by kernel of ×2.\n\n**Part V (Density increment)**: `cosetRestrict A g hg hgN j hj` restricts A to the j-th coset in ZMod(N/g). Prove `apFree_coset_restrict` (AP-free preserved) and `density_increment_lemma` (some coset achieves density δ + δ²/4).\n\n**Part VI (Main theorem)**: `roth_density_bound` maps A to ℕ via `ZMod.val`, verifies `apFree_imp_threeAPFree_val`, then invokes `roth_3ap_theorem_nat`.",
     "keyInsights": [
       "**Character Orthogonality as Foundation**: The entire Fourier-analytic approach rests on `char_orthogonality` — the sum of ψ(rc) over all r vanishes when c≠0. This is proved via a shift argument: multiplication by ψ(c)≠1 is a bijection on the sum, forcing it to zero. All subsequent results build on this.",
@@ -89,9 +89,9 @@
       "Mathlib"
     ],
     "namespace": "Szemeredi.Roth",
-    "lineCount": 1401,
+    "lineCount": 1554,
     "axiomCount": 0,
-    "theoremCount": 42,
+    "theoremCount": 49,
     "definitionCount": 6,
     "path": "Proofs/RothTheorem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Changed-since-audit sweep (Lean commit date > tracker `lastAudited`) surfaced 11 candidates whose Lean source changed since last audit. 7 had stale `lineCount`/`theoremCount` after research growth; 4 were clean.

### Fixed (stale counts, LOW severity)
| slug | old → new (line/thm) |
|------|------|
| cauchy-interlacing-theorem-oq-01-oq-02 | 148/3 → 184/5 |
| dirichlets-theorem-oq-02-oq-03 | meta 230/21, leanFile-thm 31 → 410/37 |
| erdos-1006-oq-01 | meta 467/11 → 534/12 |
| erdos-1022-oq-02 | 286/11 → 351/14 |
| erdos-703 | 415/11 → 467/13 |
| roth-theorem | 1401/42 → 1554/49 (+ prose "42 theorems"/"1401-line") |
| roth-theorem-k3 | meta 1401/42, leanFile-thm 43 → 1554/49 |

Theorem counts are comment-stripped `theorem`/`lemma` declarations (the honest count; raw grep over-counts docstrings).

### Verified clean (no change)
- **erdos-1090, erdos-214, erdos-490** — all counts already synced.
- **law-of-cosines-oq-03-oq-03** — `axiomCount=7` = structure-encoded assumptions (not literal axioms); correct per Axiom Integrity Policy.

### Integrity notes (no overclaim)
- `roth-theorem` `axiomCount=2` retained — it is the **chain** count (2 axioms in the OQ-02 companion `RothTheoremOQ02.lean`), documented in `assumptions`; main file is 0/0.
- No sorry/axiom/status/badge changes. All affected entries remain accurately `verified`/`mathlib`.

Cosmetic count reconciliation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)