### PR TITLE
Enrich ℚ[X] countability (denumerability-rationals-oq-06)

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-06/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-06/meta.json
@@ -137,6 +137,14 @@
       "endLine": 50
     },
     {
+      "name": "natEquivPolynomialRat",
+      "type": "supporting",
+      "description": "**The extracted enumeration ℕ ≃ ℚ[X].** A concrete (noncomputable) bijection witnessing denumerability, obtained by choosing a witness from nonempty_nat_equiv_polynomial_rat — turning the existence statement into a usable equivalence object.",
+      "leanType": "ℕ ≃ ℚ[X]",
+      "startLine": 54,
+      "endLine": 55
+    },
+    {
       "name": "mk_rat",
       "type": "supporting",
       "description": "**#ℚ = ℵ₀** (mk_eq_aleph0) — the engine lemma the polynomial-ring cardinalities reduce to.",


### PR DESCRIPTION
Enrichment pass on a quality-94 entry (11 KB meta.json, under all size caps).

The `mainTheorems` navigation array highlighted the four cardinality theorems plus `mk_rat`, but omitted `natEquivPolynomialRat` — the file's single `def`, the concrete (noncomputable) bijection ℕ ≃ ℚ[X] extracted from the existence theorem. This PR adds it so navigation covers the constructive denumerability witness itself, not just its existence statement.

- Accurate leanType (ℕ ≃ ℚ[X]) and line anchors (54–55) verified against the Lean source.
- No prose inflation; single navigation entry added. JSON validated.