### PR TITLE
research(erdos-1093-oq-02): sharpen OQ-02 open frontier k≥15 → k≥16 (Section XV) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -705,3 +705,112 @@ theorem deficiency_record_le_18 {n : ℕ} (hn : 56 ≤ n)
     Nat.factorial_le (by omega)
   have hnum : (Nat.factorial 28) ^ 2 < Nat.factorial 47 := by native_decide
   exact absurd (hmono.trans hsq) (not_le.mpr hnum)
+
+/-
+## Section XV: The correct OQ-02 frontier — the sharp bound closes `k ≤ 15`, open frontier is `k ≥ 16`
+
+Sections XII–XIII analysed the finite comparison `(k!)² < (k + 9)!`, whose reversal
+at `k = 15` confines the reach of the sharp bound *for detecting deficiency `9`* to
+`k ≤ 14`.  But OQ-02 (`MaximalDeficiencyIs 9`) is the statement that no admissible
+pair has deficiency **exceeding** `9`, i.e. it must rule out deficiency `≥ 10`.  The
+threshold `9` was therefore one too small: the exclusion of deficiency `≥ 10` is
+governed by the comparison `(k!)² < (k + 10)!`, whose reversal sits at `k = 16`, not
+`k = 15`.
+
+Concretely `(k!)² < (k + 10)!` holds for every `k ≤ 15` (at the frontier
+`25!/(15!)² ≈ 9.07 > 1`) and *reverses* at `k = 16` (`26!/(16!)² ≈ 0.92 < 1`).  Via
+the sharp factorial bound `(k + deficiency n k)! ≤ (k!)²`
+(`deficiency_add_factorial_le_sq`), the case `deficiency ≥ 10` forces
+`(k + 10)! ≤ (k!)²`, impossible for `k ≤ 15`.  Hence *every* admissible pair with
+`k ≤ 15` already has `deficiency ≤ 9`, and the open universal bound of OQ-02 is
+confined to `k ≥ 16` — a strict sharpening of `maximalDeficiencyIs_nine_iff_kGe15`
+(which left `k = 15` nominally open).  Like everything since Section V it is
+`ofReduceBool`-free (the finite comparisons are discharged by kernel `decide`).
+-/
+
+/-- **The deficiency-`10` frontier comparison.**  For every `k ≤ 15` one has
+`(k!)² < (k + 10)!`.  This is the analogue for the exclusion of deficiency `≥ 10`
+of the `(k!)² < (k + 9)!` comparison of Section XII, and it reverses one step
+later — at `k = 16` (see `sharp_bound_permits_deficiency_ten`). -/
+theorem factorial_sq_lt_add_ten_of_k_le_15 {k : ℕ} (hk : k ≤ 15) :
+    (Nat.factorial k) ^ 2 < Nat.factorial (k + 10) := by
+  interval_cases k <;> decide
+
+/-- **The sharp bound closes `k ≤ 15` for OQ-02.**  For an admissible pair with
+`k ≤ 15` the deficiency never exceeds `9`.  Indeed a deficiency `≥ 10` would give
+`(k + 10)! ≤ (k + deficiency n k)! ≤ (k!)²` via `deficiency_add_factorial_le_sq`,
+contradicting `(k!)² < (k + 10)!` (`factorial_sq_lt_add_ten_of_k_le_15`).  This is
+the sharp elementary resolution of OQ-02 in the range `k ≤ 15`: it rules out the
+record-breaking deficiency `≥ 10` uniformly in `n`, extending the
+`deficiency ≤ 8`-for-`k ≤ 14` bound of Section XII to cover `k = 15` as well
+(where the bound permits deficiency `9` but not `10`). -/
+theorem deficiency_le_nine_of_k_le_15 {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k) (hk : k ≤ 15) : deficiency n k ≤ 9 := by
+  by_contra hcon
+  push_neg at hcon
+  have hsharp := deficiency_add_factorial_le_sq hn h
+  have hle : Nat.factorial (k + 10) ≤ (Nat.factorial k) ^ 2 :=
+    (Nat.factorial_le (by omega)).trans hsharp
+  exact absurd hle (not_le.mpr (factorial_sq_lt_add_ten_of_k_le_15 hk))
+
+/-- **Sharpened reduction to `k ≥ 16`.**  `MaximalDeficiencyIs 9` is equivalent to
+the open universal bound restricted to `k ≥ 16`: the cases `k ≤ 14` are discharged
+by `deficiency_le_eight_of_k_le_14` and the case `k = 15` by the new
+`deficiency_le_nine_of_k_le_15`.  Strictly sharper than
+`maximalDeficiencyIs_nine_iff_kGe15`; the entire remaining open content of OQ-02
+lives at `k ≥ 16`.  (The earlier `k ≥ 15` reduction was not tight because it tracked
+the deficiency-`9` frontier `(k!)² < (k + 9)!` rather than the deficiency-`10`
+frontier `(k!)² < (k + 10)!` that actually governs the conjecture.) -/
+theorem maximalDeficiencyIs_nine_iff_kGe16 :
+    MaximalDeficiencyIs 9 ↔
+      ∀ n k, 16 ≤ k → ValidDeficiencyExample n k → deficiency n k ≤ 9 := by
+  rw [maximalDeficiencyIs_nine_iff_upperBound]
+  constructor
+  · intro h n k _ hv; exact h n k hv
+  · intro h n k hv
+    by_cases hk : k ≤ 15
+    · exact deficiency_le_nine_of_k_le_15 hv.1 hv.2 hk
+    · exact h n k (by omega) hv
+
+/-- **The sharp bound permits deficiency `10` for every `k ≥ 16`.**  For all
+`k ≥ 16` one has `(k + 10)! ≤ (k!)²`.  Hence the sharp factorial bound
+`deficiency_add_factorial_le_sq` is *consistent with* `deficiency = 10` at every
+`k ≥ 16`: it cannot exclude a record-breaking deficiency `≥ 10` there.  Paired with
+`factorial_sq_lt_add_ten_of_k_le_15` — whose comparison reverses exactly at
+`k = 16` — this shows the elementary sharp bound resolves OQ-02 for *precisely* the
+cases `k ≤ 15`, confirming the open frontier `k ≥ 16` is beyond its reach.
+
+Proof by induction from the base `26! ≤ (16!)²`; the inductive step multiplies the
+hypothesis `(k + 10)! ≤ (k!)²` by the factor `k + 11 ≤ (k + 1)²`. -/
+theorem sharp_bound_permits_deficiency_ten :
+    ∀ k, 16 ≤ k → Nat.factorial (k + 10) ≤ (Nat.factorial k) ^ 2 := by
+  intro k hk
+  induction k, hk using Nat.le_induction with
+  | base => decide
+  | succ k hk ih =>
+      have e1 : k + 1 + 10 = (k + 10) + 1 := by omega
+      have hstep :
+          (k + 11) * Nat.factorial (k + 10) ≤ (k + 1) ^ 2 * (Nat.factorial k) ^ 2 := by
+        have h1 : (k + 11) * Nat.factorial (k + 10) ≤ (k + 11) * (Nat.factorial k) ^ 2 :=
+          Nat.mul_le_mul le_rfl ih
+        have h2 :
+            (k + 11) * (Nat.factorial k) ^ 2 ≤ (k + 1) ^ 2 * (Nat.factorial k) ^ 2 :=
+          Nat.mul_le_mul (by nlinarith [hk]) le_rfl
+        exact h1.trans h2
+      calc Nat.factorial (k + 1 + 10)
+          = (k + 11) * Nat.factorial (k + 10) := by
+              rw [e1, Nat.factorial_succ]
+        _ ≤ (k + 1) ^ 2 * (Nat.factorial k) ^ 2 := hstep
+        _ = (Nat.factorial (k + 1)) ^ 2 := by rw [Nat.factorial_succ, mul_pow]
+
+/-- **The elementary sharp bound resolves OQ-02 for *exactly* `k ≤ 15`.**  Combining
+`deficiency_le_nine_of_k_le_15` (the sharp bound forces `deficiency ≤ 9` when
+`k ≤ 15`) with `sharp_bound_permits_deficiency_ten` (the bound is consistent with
+`deficiency = 10` once `k ≥ 16`): the `(k!)²` method closes the OQ-02 question for
+`k ≤ 15` and is provably powerless for `k ≥ 16`.  Stated as the sharp split of the
+finite comparison `(k!)² < (k + 10)!` at the frontier `k = 16`. -/
+theorem oq02_frontier_exact (k : ℕ) :
+    (k ≤ 15 → (Nat.factorial k) ^ 2 < Nat.factorial (k + 10)) ∧
+    (16 ≤ k → Nat.factorial (k + 10) ≤ (Nat.factorial k) ^ 2) :=
+  ⟨fun hk => factorial_sq_lt_add_ten_of_k_le_15 hk,
+   fun hk => sharp_bound_permits_deficiency_ten k hk⟩

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -10,7 +10,54 @@ of `0 ≤ i < k` with `n − i` being `k`-smooth. The current record is
 **OQ-02:** Is `9` the maximum possible deficiency over all admissible `(n,k)`,
 or do higher values occur? (The universal upper-bound direction is open.)
 
-## Status: OPEN (universal bound); existence half machine-verified.
+## Status: OPEN (universal bound, now confined to k≥16); existence half machine-verified.
+
+---
+
+## Session 2026-07-08 (Session 3) — Correct OQ-02 frontier: k≥15 → k≥16
+
+**Mode:** REVISIT (RICH knowledge tier, highest available)
+**Outcome:** progress (limitative + strict sharpening)
+
+### Key realization
+Sections XII–XIII tracked the **deficiency-9** comparison `(k!)² < (k+9)!`
+(reversing at `k=15`) and concluded "open frontier `k ≥ 15`". But OQ-02
+(`MaximalDeficiencyIs 9`) rules out deficiency **`≥ 10`**, whose exclusion is
+governed by `(k!)² < (k+10)!` — reversing one step **later**, at `k=16`. The
+threshold `9` was one too small. Exact arithmetic:
+- `25!/(15!)² ≈ 9.07 > 1` ⟹ deficiency `≥10` **excluded** at `k=15`
+- `26!/(16!)² ≈ 0.92 < 1` ⟹ deficiency `10` **permitted** at `k=16`
+
+So the elementary sharp bound `(k+deficiency)! ≤ (k!)²` (Section X) already
+**resolves OQ-02 for all `k ≤ 15`**; the tight open frontier is **`k ≥ 16`**.
+
+### What I Did — Section XV (VERIFIED, 0 sorry, 0 new axioms, ofReduceBool-free)
+- `factorial_sq_lt_add_ten_of_k_le_15` — `(k!)² < (k+10)!` for `k ≤ 15` (kernel `decide`).
+- `deficiency_le_nine_of_k_le_15` — admissible `k ≤ 15` ⟹ `deficiency ≤ 9`
+  (a deficiency `≥10` forces `(k+10)! ≤ (k!)²`, impossible for `k ≤ 15`).
+- `maximalDeficiencyIs_nine_iff_kGe16` — strict sharpening of `_kGe15`.
+- `sharp_bound_permits_deficiency_ten` — `(k+10)! ≤ (k!)²` for `k ≥ 16` (limitative:
+  induction from `26! ≤ (16!)²`, step factor `k+11 ≤ (k+1)²`).
+- `oq02_frontier_exact` — the split at the frontier `k = 16`.
+
+### Why the tail is genuinely blocked (new clarification)
+The parent axiom `els_upper_bound` (`n ≪ 2^k·√k` for deficiency `≥1`) is a
+**location** bound on `n`, provably insufficient to close the deficiency universal
+bound: it constrains *where* admissible pairs sit, not *how many* `k`-smooth values
+the length-`k` window holds. A conditional resolution needs a short-interval
+**smooth-count** bound; any faithful such hypothesis is `#{k-smooth in (n−k,n]} ≤ 9`
+`= deficiency n k ≤ 9`, i.e. circular. Hence the `k ≥ 16` tail is irreducibly
+analytic (ψ(x,y)/Dickman-ρ density) — BLOCKED pending Mathlib smooth-number density
+(>1000 lines, deep chains). This corrects the earlier "axiomatize ELS then prove a
+conditional resolution" next-step, which cannot work.
+
+### Verification
+`./proofs/scripts/docker-build.sh Proofs.Erdos1093ProblemOQ02` → `Built (3060 jobs)`,
+0 sorry, 0 `axiom` declarations. File now 816 lines, 35 theorems.
+
+### Files Modified
+- `proofs/Proofs/Erdos1093ProblemOQ02.lean` (Section XV, +~110 lines, verified)
+- `src/data/research/problems/erdos-1093-oq-02.json` (leanFiles counts + knowledge)
 
 ---
 

--- a/src/data/research/problems/erdos-1093-oq-02.json
+++ b/src/data/research/problems/erdos-1093-oq-02.json
@@ -23,8 +23,8 @@
     {
       "path": "Proofs/Erdos1093ProblemOQ02.lean",
       "filename": "Erdos1093ProblemOQ02.lean",
-      "lineCount": 595,
-      "theoremCount": 26,
+      "lineCount": 816,
+      "theoremCount": 35,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -33,7 +33,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (limitative): proved the elementary sharp bound (k+deficiency)! ≤ (k!)² resolves EXACTLY k ≤ 14 and is provably powerless for k ≥ 15 (sharp_bound_frontier_exact, sharp_bound_permits_deficiency_nine; (k+9)! ≤ (k!)² for all k ≥ 15). This rigorously establishes that OQ-02's open tail k ≥ 15 requires genuinely analytic ELS density input — no elementary factorial-product bound can close it. Section XIV additionally specialises the sharp bound to the record modulus k=28, yielding the explicit ceiling deficiency n 28 ≤ 18 for every admissible pair (via the bignum certificate (28!)² < 47!); the record there is 9, so the elementary theory still leaves 10 ≤ d ≤ 18 open. 0 axioms, 0 sorries added; universal bound = 9 remains OPEN.",
+    "progressSummary": "PROGRESS (limitative + sharpening): resolved OQ-02 elementarily for ALL k≤15 (was k≤14) by using the correct deficiency-≥10 threshold (k+10)!≤(k!)² instead of the deficiency-9 threshold; the tight open frontier is now k≥16 (strictly sharper than the recorded k≥15). Proved the (k!)² method is provably powerless for k≥16 (permits deficiency 10). Established that the existing ELS location axiom cannot yield a conditional resolution (needs a smooth-COUNT bound; any faithful form is circular) — the k≥16 tail is irreducibly analytic and BLOCKED pending Mathlib smooth-number density. 0 axioms, 0 sorries added; universal bound = 9 remains OPEN for k≥16.",
     "builtItems": [
       "noSmallPrimeFactors_iff (Erdos1093ProblemOQ02.lean) — decidable reduction of the admissibility side-condition (unbounded ∀ prime) to a bounded check over primes p ≤ k; ofReduceBool-free.",
       "noSmallPrimeFactors_284_28 — the record pair (284,28) is admissible: no prime ≤ 28 divides C(284,28) (parent verified only the count = 9, never admissibility).",
@@ -54,8 +54,8 @@
       "maximalDeficiencyIs_nine_iff_kGe15 — sharpened reduction: MaximalDeficiencyIs 9 ⇔ (∀ admissible with k≥15, deficiency ≤ 9). Strictly sharper than maximalDeficiencyIs_nine_iff_kGe10; discharges 10≤k≤14 via the sharp factorial bound.",
       "sharp_bound_permits_deficiency_nine (Erdos1093ProblemOQ02.lean, Section XIII): ∀ k ≥ 15, (k+9)! ≤ (k!)². ofReduceBool-free (kernel decide base + Nat.le_induction).",
       "sharp_bound_frontier_exact (Erdos1093ProblemOQ02.lean, Section XIII): the exact split — k ≤ 14 ⟹ (k!)² < (k+9)! and 15 ≤ k ⟹ (k+9)! ≤ (k!)², pinning the elementary method's reach to exactly k ≤ 14.",
-      "deficiency_record_le_18 (Erdos1093ProblemOQ02.lean, Section XIV) — EXPLICIT ceiling at the record modulus: every admissible (n,28) has deficiency n 28 ≤ 18. Specialises deficiency_add_factorial_le_sq ((28+d)! ≤ (28!)²) with the native_decide certificate (28!)² < 47!; a deficiency ≥ 19 gives 47! ≤ (28+d)! ≤ (28!)² < 47!. Quantifies the elementary-vs-record gap (record is 9)."
-
+      "deficiency_record_le_18 (Erdos1093ProblemOQ02.lean, Section XIV) — EXPLICIT ceiling at the record modulus: every admissible (n,28) has deficiency n 28 ≤ 18. Specialises deficiency_add_factorial_le_sq ((28+d)! ≤ (28!)²) with the native_decide certificate (28!)² < 47!; a deficiency ≥ 19 gives 47! ≤ (28+d)! ≤ (28!)² < 47!. Quantifies the elementary-vs-record gap (record is 9).",
+      "Section XV (Erdos1093ProblemOQ02.lean): factorial_sq_lt_add_ten_of_k_le_15, deficiency_le_nine_of_k_le_15, maximalDeficiencyIs_nine_iff_kGe16 (strict sharpening of _kGe15), sharp_bound_permits_deficiency_ten (k≥16 limitative), oq02_frontier_exact — VERIFIED 0 sorries / 0 new axioms, ofReduceBool-free (kernel decide)."
     ],
     "insights": [
       "The parent's deficiency_284_28 = 9 alone does NOT exhibit a valid deficiency example: the deficiency count is defined unconditionally, but the ELS problem requires C(n,k) to have no prime factor ≤ k. Checking admissibility only needs primes ≤ k (Kummer is unnecessary): C(284,28) is a ~110-bit bignum, so native_decide computes it and tests divisibility by primes ≤ 28 instantly.",
@@ -65,17 +65,18 @@
       "The density bound reframes the open core: a hypothetical deficiency > 9 at k ≥ 10 requires a length-k run of consecutive integers containing < k−9 primes, i.e. an exceptionally prime-poor window — precisely the input ELS bound the axiomatized els_upper_bound to n ≪ 2^k√k.",
       "Section X: the smooth window values are DISTINCT integers (i↦n-i injective on i<k≤n), so their product exceeds not just (k+1)^d but the ascending factorial (k+1)(k+2)···(k+d). This distinct-value refinement of Section IX yields (k+1).ascFactorial(deficiency) ≤ k!, i.e. (k+deficiency)! ≤ (k!)². For k=28 it forces deficiency ≤ 18 versus ≤ 20 from (k+1)^d ≤ k! — a strict elementary improvement, still ofReduceBool-free and independent of the axiomatized ELS bound.",
       "Section XII: the sharp bound (k+deficiency)! ≤ (k!)² is not just a per-k ceiling — for small k that ceiling drops below 9. A deficiency ≥ 9 forces (k+9)! ≤ (k!)², but (k!)² < (k+9)! for every k ≤ 14 (first fails at k=15, where (15!)² first exceeds 24!). So NO admissible pair with k ≤ 14 exceeds deficiency 8, pushing the open frontier of MaximalDeficiencyIs 9 from k≥10 to k≥15 — with no ELS/prime-distribution input and ofReduceBool-free (kernel decide, not native_decide).",
-      "LIMITATIVE RESULT (this session): the elementary sharp bound (k+deficiency)! ≤ (k!)² is EXACTLY tight — it resolves precisely k ≤ 14 and is provably powerless for k ≥ 15. Concretely (k+9)! ≤ (k!)² for ALL k ≥ 15 (proved by induction from base 24! ≤ (15!)², step multiplies IH by factor k+10 ≤ (k+1)²), so the bound is consistent with deficiency = 9 at every k ≥ 15 and can never by itself exclude it. The finite comparison (k!)² < (k+9)! powering deficiency_le_eight_of_k_le_14 reverses exactly at k=15. This rigorously confines OQ-02's open tail to genuinely analytic (ELS density) input — no push of the (k!)² method can close k ≥ 15."
+      "LIMITATIVE RESULT (this session): the elementary sharp bound (k+deficiency)! ≤ (k!)² is EXACTLY tight — it resolves precisely k ≤ 14 and is provably powerless for k ≥ 15. Concretely (k+9)! ≤ (k!)² for ALL k ≥ 15 (proved by induction from base 24! ≤ (15!)², step multiplies IH by factor k+10 ≤ (k+1)²), so the bound is consistent with deficiency = 9 at every k ≥ 15 and can never by itself exclude it. The finite comparison (k!)² < (k+9)! powering deficiency_le_eight_of_k_le_14 reverses exactly at k=15. This rigorously confines OQ-02's open tail to genuinely analytic (ELS density) input — no push of the (k!)² method can close k ≥ 15.",
+      "FRONTIER SHARPENED (this session, k≥15 → k≥16): the file's Section XII–XIII tracked the deficiency-9 comparison (k!)²<(k+9)! (reversing at k=15), but OQ-02 (MaximalDeficiencyIs 9) requires excluding deficiency ≥10, governed by (k!)²<(k+10)! — which reverses one step LATER, at k=16. Exact arithmetic: 25!/(15!)²≈9.07>1 (deficiency ≥10 EXCLUDED at k=15) but 26!/(16!)²≈0.92<1 (deficiency 10 PERMITTED at k=16). So the elementary sharp bound (k+d)!≤(k!)² closes OQ-02 for ALL k≤15, and the tight open frontier is k≥16. The prior maximalDeficiencyIs_nine_iff_kGe15 was NOT tight (it left k=15 nominally open).",
+      "The existing parent axiom els_upper_bound (n ≪ 2^k·√k for deficiency ≥1) is a LOCATION bound on n and is provably insufficient to close the deficiency universal bound: it constrains where admissible pairs sit, not how many smooth values the length-k window holds. Any conditional resolution therefore needs a short-interval smooth-COUNT bound, and any faithful such hypothesis is (# k-smooth values in (n-k,n]) ≤ 9 = deficiency n k ≤ 9, i.e. circular. This confirms the k≥16 tail is irreducibly analytic (ψ(x,y)/Dickman-ρ density), not reachable by axiomatizing the current ELS location bound."
     ],
     "mathlibGaps": [
       "No smooth-number density estimates (ψ(x,y) / Dickman ρ) in Mathlib v4.26 — the Erdős–Lacampagne–Selfridge analytic input needed for the k ≥ 15 tail of OQ-02 cannot yet be formalized without building this."
     ],
     "nextSteps": [
-      "The elementary (k!)² method is now PROVEN insufficient for k ≥ 15 (sharp_bound_frontier_exact). Any further progress on the universal bound MaximalDeficiencyIs 9 must supply the analytic Erdős–Lacampagne–Selfridge smooth-number density bound as an explicit (axiomatized) hypothesis and prove the conditional resolution; Mathlib lacks smooth-number density estimates, so this is a genuine infrastructure gap.",
       "Assess whether a hybrid bound (Section VII prime-count + an Erdős–Rankin prime-gap lower bound on primes in a length-k window) could beat (k!)² for k ≥ 15; likely still insufficient since the sharp ceiling grows ~linearly in k.",
       "Push the sharp bound quantitatively: (k+d)! ≤ (k!)² is equivalent to C(k+d,d)·d! ≤ k!; combine with an ELS-style lower bound on smooth-count to see if it can reach deficiency ≤ 9 for large k.",
-      "Consider whether the descFactorial/ascFactorial packaging generalizes to bound the number of k-smooth values in ANY length-k window (independent of deficiency admissibility)."
-
+      "Consider whether the descFactorial/ascFactorial packaging generalizes to bound the number of k-smooth values in ANY length-k window (independent of deficiency admissibility).",
+      "The k≥16 open tail is irreducibly analytic: the missing input is a short-interval k-smooth-count bound (ψ(x,x+k) type / Dickman ρ), which Mathlib lacks; a faithful hypothesis is equivalent to the conclusion (circular), so no elementary conditional reduction exists. Treat as BLOCKED pending smooth-number density infrastructure (>1000 lines, deep chains)."
     ]
   }
 }


### PR DESCRIPTION
## Summary

Erdős #1093 OQ-02 asks whether `d(284,28)=9` is the **maximal** deficiency of an admissible `C(n,k)` — i.e. whether **no** admissible pair has deficiency `≥ 10`.

The file previously (Sections XII–XIII) analysed the finite comparison `(k!)² < (k+9)!`, which reverses at `k=15`, and concluded the open frontier is `k ≥ 15` (`maximalDeficiencyIs_nine_iff_kGe15`). **But that threshold was one too small for the actual conjecture:** OQ-02 rules out deficiency `≥ 10`, whose exclusion is governed by `(k!)² < (k+10)!`, and that comparison reverses one step **later**, at `k = 16`.

Exact arithmetic:
- `25!/(15!)² ≈ 9.07 > 1` ⟹ deficiency `≥ 10` **excluded** at `k = 15`
- `26!/(16!)² ≈ 0.92 < 1` ⟹ deficiency `10` **permitted** at `k = 16`

So the elementary sharp bound `(k + deficiency)! ≤ (k!)²` (`deficiency_add_factorial_le_sq`, Section X) already **resolves OQ-02 for all `k ≤ 15`**, and the tight open frontier is **`k ≥ 16`** — a strict sharpening of the recorded `k ≥ 15`.

## Section XV (new, 0 sorries, 0 new axioms, `ofReduceBool`-free)
| Theorem | Statement |
|---|---|
| `factorial_sq_lt_add_ten_of_k_le_15` | `(k!)² < (k+10)!` for `k ≤ 15` (kernel `decide`) |
| `deficiency_le_nine_of_k_le_15` | admissible `k ≤ 15` ⟹ `deficiency n k ≤ 9` |
| `maximalDeficiencyIs_nine_iff_kGe16` | `MaximalDeficiencyIs 9 ↔ (∀ k ≥ 16 admissible, deficiency ≤ 9)` |
| `sharp_bound_permits_deficiency_ten` | `(k+10)! ≤ (k!)²` for `k ≥ 16` (limitative: bound can't exclude deficiency 10) |
| `oq02_frontier_exact` | the split at the frontier `k = 16` |

## Also
- Confirmed the parent axiom `els_upper_bound` (a **location** bound `n ≪ 2^k√k`) is provably insufficient for a conditional resolution: closing the tail needs a short-interval **smooth-count** bound, and any faithful such hypothesis equals `deficiency ≤ 9` (circular). The `k ≥ 16` tail is irreducibly analytic (ψ(x,y)/Dickman-ρ), currently **blocked** on Mathlib smooth-number density.
- Synced stale `leanFiles` counts (lineCount 595→816, theoremCount 26→35) and updated `knowledge`.

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos1093ProblemOQ02` → `Built (3060 jobs)`, 0 sorries, no new `axiom` declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)