### PR TITLE
Enrich Kronecker density (dirichlet-approximation-theorem-oq-04)

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04/annotations.json
@@ -43,7 +43,7 @@
       "minimal dynamical system",
       "equidistribution"
     ],
-    "significance": "supporting"
+    "significance": "key"
   },
   {
     "id": "ann-homogeneous-approximation",
@@ -66,7 +66,7 @@
       "distance to the nearest integer",
       "fractional parts accumulating at 0"
     ],
-    "significance": "supporting"
+    "significance": "key"
   },
   {
     "id": "ann-small-circle-point",


### PR DESCRIPTION
Enrichment pass on a quality-94 entry (19 KB meta.json, 6 rich annotations — all under size caps).

The entry is already thorough. The one accuracy gap: all 6 annotations were tagged `significance: "supporting"`, including the two that cover the entry's named theorems — `denseRange_iff_irrational` (Kronecker's density theorem, the topological engine) and `exists_pos_nat_mul_sub_round_lt` (the homogeneous Dirichlet corollary, tagged `core` in mainTheorems). This PR reclassifies those two to `"key"` so the UI signal matches the entry's own theorem hierarchy; the four context/tactic-substep annotations correctly stay `"supporting"`.

- Line anchors verified against the Lean source (theorems at 49–52 and 58–106).
- No content added; significance labels only. JSON validated (6 annotations, 2 now key).