### PR TITLE
research(erdos-1012-oq-01-oq-02): exact edge-threshold surplus + strict non-degeneracy [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1012OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1012OQ01OQ02.lean
@@ -19,6 +19,11 @@
     the threshold by exactly `n-k-1` (the discrete derivative `C(m+1,2)-C(m,2)=m`).
   * `edgeThreshold_lt_succ` / `edgeThreshold_mono` — strict and weak monotonicity
     in `n` on the meaningful range `n ≥ k+2` / `n ≥ k+1`.
+  * `edgeThreshold_add_surplus_eq_choose_two` — the **exact surplus** below the complete
+    graph: `C(n,2) = edgeThreshold n k + (k(k+2) + (n-(2k+3))(k+1))` for `n ≥ 2k+3`,
+    upgrading `edgeThreshold_le_choose_two` from an inequality to an equality.
+  * `edgeThreshold_lt_choose_two` — **strict** non-degeneracy: `edgeThreshold n k < C(n,2)`
+    on `n ≥ 2k+3` away from the single degenerate corner `(k,n) = (0,3)`.
 
   All results are fully machine-checked (0 axioms, 0 sorries), reusing the parent's
   `edgeThreshold` definition.
@@ -120,6 +125,61 @@ theorem edgeThreshold_le_choose_two (n k : ℕ) (h : 2 * k + 3 ≤ n) :
   have hle : 2 * edgeThreshold (2 * k + 3 + c) k ≤ 2 * (2 * k + 3 + c).choose 2 := by
     rw [d1, d2]; nlinarith [Nat.zero_le k, Nat.zero_le c, Nat.zero_le (k * c),
       Nat.zero_le (k * k)]
+  omega
+
+/-- **Exact surplus of the edge threshold below the complete graph.**  On the Woodall
+    range `n ≥ 2k+3` the slack between the threshold and the total number of edges of
+    `Kₙ` is the explicit closed form
+
+        C(n, 2) = edgeThreshold n k + (k·(k+2) + (n − (2k+3))·(k+1)).
+
+    This upgrades the inequality `edgeThreshold_le_choose_two` to an equality: the
+    surplus `k(k+2) + (n−(2k+3))(k+1)` is a manifestly nonnegative polynomial that
+    vanishes iff `k = 0` and `n = 2k+3` — the single degenerate point `edgeThreshold 3 0
+    = C(3,2) = 3`.  Writing `c = n − (2k+3)`, halving the parent's doubled identity
+    `2·edgeThreshold = (k+2+c)(k+1+c) + (k+2)(k+1) + 2` against `2·C(n,2) =
+    (2k+3+c)(2k+2+c)` gives exactly this gap. -/
+theorem edgeThreshold_add_surplus_eq_choose_two (n k : ℕ) (h : 2 * k + 3 ≤ n) :
+    edgeThreshold n k + (k * (k + 2) + (n - (2 * k + 3)) * (k + 1)) = n.choose 2 := by
+  obtain ⟨c, rfl⟩ : ∃ c, n = 2 * k + 3 + c := ⟨n - (2 * k + 3), by omega⟩
+  have hc : 2 * k + 3 + c - (2 * k + 3) = c := by omega
+  rw [hc]
+  -- Double both sides: 2·edgeThreshold = (k+2+c)(k+1+c) + (k+2)(k+1) + 2.
+  have d1 : 2 * edgeThreshold (2 * k + 3 + c) k
+      = (k + 2 + c) * (k + 1 + c) + (k + 2) * (k + 1) + 2 := by
+    unfold edgeThreshold
+    have h1 : 2 * (2 * k + 3 + c - k - 1).choose 2 = (k + 2 + c) * (k + 1 + c) := by
+      rw [show 2 * k + 3 + c - k - 1 = k + 2 + c by omega, two_mul_choose_two,
+          show k + 2 + c - 1 = k + 1 + c by omega]
+    have h2 : 2 * (k + 2).choose 2 = (k + 2) * (k + 1) := by
+      rw [two_mul_choose_two, show k + 2 - 1 = k + 1 by omega]
+    omega
+  have d2 : 2 * (2 * k + 3 + c).choose 2 = (2 * k + 3 + c) * (2 * k + 2 + c) := by
+    rw [two_mul_choose_two, show 2 * k + 3 + c - 1 = 2 * k + 2 + c by omega]
+  -- The doubled identity is a polynomial equality; cancel the factor of 2.
+  have key : 2 * (edgeThreshold (2 * k + 3 + c) k
+      + (k * (k + 2) + c * (k + 1))) = 2 * (2 * k + 3 + c).choose 2 := by
+    rw [Nat.mul_add, d1, d2]; ring
+  exact Nat.eq_of_mul_eq_mul_left (by norm_num) key
+
+/-- **Strict non-degeneracy of the edge threshold.**  Away from the single degenerate
+    point `(k, n) = (0, 3)`, the threshold is *strictly* below the complete-graph edge
+    count: for `n ≥ 2k+3` with either `k ≥ 1` or `n > 2k+3`,
+
+        edgeThreshold n k < C(n, 2).
+
+    Hence there is genuine room above the threshold — the long-cycle hypothesis
+    `edgeCount G ≥ edgeThreshold n k` is satisfied by strictly denser graphs than the
+    threshold graph, and in particular is not forced to be the complete graph. -/
+theorem edgeThreshold_lt_choose_two (n k : ℕ) (h : 2 * k + 3 ≤ n)
+    (hnt : 1 ≤ k ∨ 2 * k + 3 < n) : edgeThreshold n k < n.choose 2 := by
+  have hid := edgeThreshold_add_surplus_eq_choose_two n k h
+  have hpos : 0 < k * (k + 2) + (n - (2 * k + 3)) * (k + 1) := by
+    rcases hnt with hk | hn
+    · have : 0 < k * (k + 2) := Nat.mul_pos hk (by omega)
+      omega
+    · have : 0 < (n - (2 * k + 3)) * (k + 1) := Nat.mul_pos (by omega) (by omega)
+      omega
   omega
 
 end Erdos1012OQ01OQ02

--- a/src/data/research/problems/erdos-1012-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1012-oq-01-oq-02.json
@@ -40,14 +40,17 @@
       "edgeThreshold_succ_left: edgeThreshold (n+1) k = edgeThreshold n k + (n-k-1) for n≥k+1 (the C(m+1,2)-C(m,2)=m recurrence with m=n-k-1).",
       "edgeThreshold_lt_succ (strict mono, n≥k+2), edgeThreshold_mono (weak mono via induction on the ≤ proof).",
       "two_mul_choose_two: 2·C(m,2) = m·(m-1) (subtraction-free doubling helper, elementary induction reusing choose_two_succ).",
-      "edgeThreshold_le_choose_two: NON-DEGENERACY — for n≥2k+3, edgeThreshold n k ≤ C(n,2). The required edge count never exceeds the complete graph's, so the long-cycle hypothesis edgeCount G ≥ edgeThreshold n k is satisfiable rather than vacuous. Doubled gap 2(C(n,2)−edgeThreshold) = 2k(k+2)+2c(k+1)≥0 (c=n−(2k+3)), closed by nlinarith."
+      "edgeThreshold_le_choose_two: NON-DEGENERACY — for n≥2k+3, edgeThreshold n k ≤ C(n,2). The required edge count never exceeds the complete graph's, so the long-cycle hypothesis edgeCount G ≥ edgeThreshold n k is satisfiable rather than vacuous. Doubled gap 2(C(n,2)−edgeThreshold) = 2k(k+2)+2c(k+1)≥0 (c=n−(2k+3)), closed by nlinarith.",
+      "edgeThreshold_add_surplus_eq_choose_two: exact surplus identity C(n,2) = edgeThreshold n k + (k(k+2) + (n-(2k+3))(k+1)) for n ≥ 2k+3 — upgrades the ≤ bound edgeThreshold_le_choose_two to an equality with an explicit nonnegative gap.",
+      "edgeThreshold_lt_choose_two: strict non-degeneracy — edgeThreshold n k < C(n,2) for n ≥ 2k+3 except at the single degenerate point (k,n)=(0,3) where edgeThreshold 3 0 = C(3,2) = 3."
     ],
     "insights": [
       "The threshold's discrete derivative in n is exactly n-k-1: C((n-k-1)+1,2) - C(n-k-1,2) = n-k-1. This is the structural reason the edge requirement tightens with each added vertex and f(k) is a well-defined minimum.",
       "Lean gotcha: Nat.choose_succ_succ m 1 produces m.choose (1+1) (NOT m.choose 2); omega treats those as distinct atoms. Force the defeq with `show m + m.choose 2 = ...` before omega.",
       "edgeThreshold_eq cannot be finished by omega alone (the m*(m-1) product is nonlinear); use Nat.choose_two_right and only the linear subtraction identities (n-k-1-1 = n-k-2, k+2-1 = k+1) under omega.",
       "Weak monotonicity proved by `induction hnm with | refl | @step m h ih` on the ≤ proof (Nat.le.rec); the step case applies the n-recurrence and omega (treating edgeThreshold terms as atoms, n-k-1 ≥ 0).",
-      "Non-degeneracy needs no division: double both sides via 2·C(m,2)=m·(m-1), substitute n=2k+3+c to eliminate all truncated subtraction, and the gap becomes the manifestly nonnegative polynomial 2k(k+2)+2c(k+1). nlinarith closes it; omega then divides the doubled inequality back by 2."
+      "Non-degeneracy needs no division: double both sides via 2·C(m,2)=m·(m-1), substitute n=2k+3+c to eliminate all truncated subtraction, and the gap becomes the manifestly nonnegative polynomial 2k(k+2)+2c(k+1). nlinarith closes it; omega then divides the doubled inequality back by 2.",
+      "The threshold-vs-complete-graph surplus is exactly k(k+2)+(n-(2k+3))(k+1); it vanishes only at (k,n)=(0,3), so away from that corner the long-cycle edge hypothesis has strict room above the threshold (not forced to K_n). Proven by halving the parent's doubled polynomial identity and cancelling 2 via Nat.eq_of_mul_eq_mul_left."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -84,8 +87,8 @@
     {
       "path": "Proofs/Erdos1012OQ01OQ02.lean",
       "filename": "Erdos1012OQ01OQ02.lean",
-      "lineCount": 125,
-      "theoremCount": 7,
+      "lineCount": 185,
+      "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Supplementary edge-threshold arithmetic for Woodall's function `f(k)` (Erdős #1012, long cycles). `Erdos1012OQ01OQ02.lean` already established the explicit form, the recurrence in `n`, monotonicity, and the bound `edgeThreshold n k ≤ C(n,2)` on the Woodall range `n ≥ 2k+3`. This PR upgrades that inequality to an **exact identity** and derives its **strict** form.

## New theorems

- **`edgeThreshold_add_surplus_eq_choose_two`** — the exact surplus below the complete graph:
  ```
  C(n,2) = edgeThreshold n k + (k·(k+2) + (n − (2k+3))·(k+1))     for n ≥ 2k+3.
  ```
  The surplus is a manifestly nonnegative polynomial. Proof halves the doubled identity `2·edgeThreshold = (k+2+c)(k+1+c) + (k+2)(k+1) + 2` against `2·C(n,2) = (2k+3+c)(2k+2+c)` (with `c = n − (2k+3)`) and cancels the factor `2` via `Nat.eq_of_mul_eq_mul_left`.
- **`edgeThreshold_lt_choose_two`** — strict non-degeneracy: `edgeThreshold n k < C(n,2)` for `n ≥ 2k+3` **except** at the single degenerate corner `(k,n) = (0,3)`, where `edgeThreshold 3 0 = C(3,2) = 3`. So the long-cycle edge hypothesis `edgeCount G ≥ edgeThreshold n k` has strict room above the threshold and is not forced to be the complete graph.

## Verification

- Docker build `Proofs.Erdos1012OQ01OQ02` → **succeeded (7744 jobs)**.
- The new theorems reference only `edgeThreshold` (a definition) and `ℕ` arithmetic — **0 axioms, 0 sorries**. The Woodall axioms live in the parent `Erdos1012OQ01`, which is untouched.
- File 125→185 lines, 7→9 theorems; research JSON `leanFiles` counts synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)