### PR TITLE
research(feuerbachs-theorem-oq-04): inner-product form of the tangency criteria [VERIFIED]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -259,6 +259,52 @@ theorem externallyTangent_comm (O₁ : E) (ρ₁ : ℝ) (O₂ : E) (ρ₂ : ℝ)
   unfold ExternallyTangent
   rw [sdist_comm, add_comm]
 
+/-! ## Inner-product form of the tangency criteria
+
+Tangency is defined as a *distance* equation (`sdist = ρ₁ + ρ₂` externally,
+`= |ρ₁ − ρ₂|` internally), but the quantity one actually computes from ambient
+coordinates is the inner product `scos O₁ O₂ = ⟪O₁, O₂⟫`.  Since
+`cos ∘ sdist = scos` (`cos_sdist`) and `cos` is injective on `[0, π]`, the
+distance equations are equivalent to the single inner-product equations
+
+  external:  `⟪O₁, O₂⟫ = cos (ρ₁ + ρ₂)`,   internal:  `⟪O₁, O₂⟫ = cos (ρ₁ − ρ₂)`,
+
+valid whenever the relevant radius combination lies in `[0, π]` (so that it is a
+legal spherical distance).  This is the bridge a coordinate-level Feuerbach
+tangency proof needs: reduce "the nine-point circle is tangent to the incircle"
+to one inner-product identity between their centres. -/
+
+/-- **External tangency ⇔ inner-product equation.**  For model centres `O₁, O₂`,
+external tangency `sdist O₁ O₂ = ρ₁ + ρ₂` is equivalent to
+`scos O₁ O₂ = cos (ρ₁ + ρ₂)`, provided `ρ₁ + ρ₂ ∈ [0, π]`.  Forward: apply `cos`
+and use `cos_sdist`.  Backward: `cos` is injective on `[0, π]`, and both
+`sdist O₁ O₂` and `ρ₁ + ρ₂` lie there. -/
+theorem externallyTangent_iff_scos {O₁ O₂ : E} (h₁ : OnSphere O₁) (h₂ : OnSphere O₂)
+    {ρ₁ ρ₂ : ℝ} (hlo : 0 ≤ ρ₁ + ρ₂) (hhi : ρ₁ + ρ₂ ≤ Real.pi) :
+    ExternallyTangent O₁ ρ₁ O₂ ρ₂ ↔ scos O₁ O₂ = Real.cos (ρ₁ + ρ₂) := by
+  unfold ExternallyTangent
+  rw [← cos_sdist O₁ O₂ h₁ h₂]
+  constructor
+  · intro h; rw [h]
+  · intro h
+    exact Real.injOn_cos (Set.mem_Icc.mpr ⟨sdist_nonneg O₁ O₂, sdist_le_pi O₁ O₂⟩)
+      (Set.mem_Icc.mpr ⟨hlo, hhi⟩) h
+
+/-- **Internal tangency ⇔ inner-product equation.**  For model centres `O₁, O₂`,
+internal tangency `sdist O₁ O₂ = |ρ₁ − ρ₂|` is equivalent to
+`scos O₁ O₂ = cos (ρ₁ − ρ₂)` (using `cos |ρ₁ − ρ₂| = cos (ρ₁ − ρ₂)`), provided
+`|ρ₁ − ρ₂| ≤ π`. -/
+theorem internallyTangent_iff_scos {O₁ O₂ : E} (h₁ : OnSphere O₁) (h₂ : OnSphere O₂)
+    {ρ₁ ρ₂ : ℝ} (hhi : |ρ₁ - ρ₂| ≤ Real.pi) :
+    InternallyTangent O₁ ρ₁ O₂ ρ₂ ↔ scos O₁ O₂ = Real.cos (ρ₁ - ρ₂) := by
+  unfold InternallyTangent
+  rw [← cos_sdist O₁ O₂ h₁ h₂, ← Real.cos_abs (ρ₁ - ρ₂)]
+  constructor
+  · intro h; rw [h]
+  · intro h
+    exact Real.injOn_cos (Set.mem_Icc.mpr ⟨sdist_nonneg O₁ O₂, sdist_le_pi O₁ O₂⟩)
+      (Set.mem_Icc.mpr ⟨abs_nonneg _, hhi⟩) h
+
 /-! ## The tangent point of two tangent circles
 
 The defining geometric content of tangency is that the two circles actually **meet** — at

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -680,3 +680,35 @@ refinement.
 REMAINING: (1) uniqueness / interior-incenter refinement; (2) spherical nine-point circle;
 (3) the Feuerbach tangency itself (nine-point circle tangent to the incircle). The hard
 existence-of-incenter obstacle is now cleared.
+
+## Session 2026-07-08 (researcher-2): inner-product form of the tangency criteria [VERIFIED — 0 sorry, 0 axiom]
+
+**Mode:** ACT (add a bounded, reusable ingredient toward the sole frontier item — the
+Feuerbach tangency capstone). The full tritangent family, incircle/excircle existence,
+nine-point circle, and abstract tangent-point specs are all in place; the missing bridge
+is turning the *distance* tangency predicates into the *inner-product* equations one
+actually computes from coordinates.
+
+**Added to `FeuerbachsTheoremOQ04.lean`** (2 theorems, +~46 L, docker `✔ [7743/7743]`,
+first try, 0 sorry / 0 axiom / 0 native_decide):
+- **`externallyTangent_iff_scos`** (`0 ≤ ρ₁+ρ₂ ≤ π`):
+  `ExternallyTangent O₁ ρ₁ O₂ ρ₂ ↔ scos O₁ O₂ = cos (ρ₁+ρ₂)`.
+- **`internallyTangent_iff_scos`** (`|ρ₁−ρ₂| ≤ π`):
+  `InternallyTangent O₁ ρ₁ O₂ ρ₂ ↔ scos O₁ O₂ = cos (ρ₁−ρ₂)`.
+
+Proof pattern (both): `unfold` the tangency def, `rw [← cos_sdist O₁ O₂ h₁ h₂]` to turn the
+RHS `scos` into `cos (sdist …)`; forward = `rw [h]`; backward = `Real.injOn_cos` on
+`Set.Icc 0 π` (memberships from `sdist_nonneg`/`sdist_le_pi` and the radius-range hyps).
+Internal case first rewrites `← Real.cos_abs (ρ₁−ρ₂)` so the target reads `cos |ρ₁−ρ₂|`,
+matching the `InternallyTangent` definition `sdist = |ρ₁−ρ₂|`.
+
+**Why this matters:** the final Feuerbach tangency ("nine-point circle internally tangent to
+the incircle") now reduces to a *single inner-product identity* `⟪O₉, O_in⟫ = cos(ρ₉ − ρ_in)`
+between the two explicit centres — exactly the coordinate-level target the remaining work
+must hit. This is the criterion, not the identity itself (still the hard capstone).
+
+**Metadata:** reconciled badly-stale `leanFiles` entry for this file (568→1310 lines,
+29→65 theorems; prior sessions grew it far past the recorded numbers).
+
+**Frontier unchanged:** the tangency identity between the concrete nine-point and incircle
+centres remains the sole hard open item.

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -407,8 +407,8 @@
     {
       "path": "Proofs/FeuerbachsTheoremOQ04.lean",
       "filename": "FeuerbachsTheoremOQ04.lean",
-      "lineCount": 568,
-      "theoremCount": 29,
+      "lineCount": 1310,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds the bridge lemmas that turn the **distance-based** spherical tangency predicates
(`sdist O₁ O₂ = ρ₁ + ρ₂` / `= |ρ₁ − ρ₂|`) into the **inner-product** equations a
coordinate-level Feuerbach proof actually computes:

- `externallyTangent_iff_scos` (`0 ≤ ρ₁+ρ₂ ≤ π`):
  `ExternallyTangent O₁ ρ₁ O₂ ρ₂ ↔ scos O₁ O₂ = cos (ρ₁+ρ₂)`
- `internallyTangent_iff_scos` (`|ρ₁−ρ₂| ≤ π`):
  `InternallyTangent O₁ ρ₁ O₂ ρ₂ ↔ scos O₁ O₂ = cos (ρ₁−ρ₂)`

Proof: `cos ∘ sdist = scos` (`cos_sdist`) plus injectivity of `cos` on `[0, π]`
(`Real.injOn_cos`, with memberships from `sdist_nonneg` / `sdist_le_pi`); the internal
case uses `Real.cos_abs`.

## Why this matters

The sole remaining frontier item — "the spherical nine-point circle is internally
tangent to the incircle" — now reduces to a **single inner-product identity**
`⟪O₉, O_in⟫ = cos(ρ₉ − ρ_in)` between the two explicit centres. This PR supplies the
*criterion*; the identity itself remains the hard capstone (not attempted here).

## Verification

VERIFIED: docker build clean (7743 jobs, exit 0), 0 sorry, 0 axiom, 0 `native_decide`.
Also reconciles a badly-stale `leanFiles` metadata entry for this file
(568→1310 lines, 29→65 theorems, from prior unsynced sessions).