### PR TITLE
research(dirichlets-theorem-oq-02-oq-03): primorial tower ≤ factorial tower for all k [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -407,4 +407,57 @@ tower: `4k + 3 ≤ p3 k ≤ C k`, a strictly tighter ceiling than `p3_bracketed`
 theorem p3_bracketed_primorial (k : ℕ) : 4 * k + 3 ≤ p3 k ∧ p3 k ≤ C k :=
   ⟨p3_ge_linear k, p3_le_primorialTower k⟩
 
+/-! ## Step 6: the primorial tower never exceeds the factorial tower (`C k ≤ B k`)
+
+`primorial_tighter_than_factorial` established `C 1 < B 1` at the single index
+`k = 1`.  We now upgrade this to a *theorem for all `k`*: the primorial tower `C`
+is dominated by the iterated-factorial tower `B` everywhere, `C k ≤ B k`.
+
+The engine is the reduction `C (k+1) ≤ B (k+1) ⇔ towerProd (k+1) ≤ (B k + 1)!`
+(both sides are `4·· − 1`), so it suffices to bound the running product
+`towerProd` by the factorial appearing in `B`.  That product bound is proved by
+induction: writing `F = (B k + 1)!`, the inductive hypothesis gives
+`towerProd (k+1) ≤ F`, and then
+`towerProd (k+2) = towerProd (k+1)·(4·towerProd (k+1) − 1) ≤ F·(4F − 1)
+   ≤ (4F)·(4F − 1) ≤ (4F)! = (B (k+1) + 1)!`,
+using only the elementary factorial lower bound `n·(n−1) ≤ n!`. -/
+
+/-- Elementary factorial lower bound `n·(n−1) ≤ n!` (from `n! = n·(n−1)!` and
+`n−1 ≤ (n−1)!`).  Supplies the single non-arithmetic step in `C_le_B`. -/
+theorem factorial_ge_mul_pred : ∀ n : ℕ, n * (n - 1) ≤ n !
+  | 0 => by simp
+  | (m + 1) => by
+      rw [Nat.add_sub_cancel, Nat.factorial_succ]
+      exact Nat.mul_le_mul (le_refl (m + 1)) (Nat.self_le_factorial m)
+
+/-- The running product is bounded by the factorial appearing in the next `B`
+step: `towerProd (k+1) ≤ (B k + 1)!`.  This is the crux of `C_le_B`. -/
+theorem towerProd_succ_le_factorial (k : ℕ) : towerProd (k + 1) ≤ (B k + 1)! := by
+  induction k with
+  | zero => decide
+  | succ k ih =>
+    have hFpos := Nat.factorial_pos (B k + 1)
+    have hB1 : B (k + 1) + 1 = 4 * (B k + 1)! := by rw [B_succ]; omega
+    rw [towerProd_succ, hB1]
+    set F := (B k + 1)! with hF
+    set tp := towerProd (k + 1) with htp
+    calc tp * (4 * tp - 1)
+        ≤ F * (4 * F - 1) := Nat.mul_le_mul ih (by omega)
+      _ ≤ (4 * F) * (4 * F - 1) := Nat.mul_le_mul (by omega) (le_refl _)
+      _ ≤ (4 * F)! := factorial_ge_mul_pred (4 * F)
+
+/-- **The primorial tower never exceeds the factorial tower.** For every `k`,
+`C k ≤ B k`: the doubly-exponential primorial tower `C` is dominated everywhere
+by the iterated-factorial tower `B`.  Equality holds only at `k = 0`
+(`C 0 = B 0 = 3`); for `k ≥ 1` the domination is strict already at `k = 1`
+(`C 1 = 11 < 95 = B 1`, see `primorial_tighter_than_factorial`).  This makes the
+tightness of the primorial refinement a *theorem for all `k`* rather than a
+single-index observation. -/
+theorem C_le_B (k : ℕ) : C k ≤ B k := by
+  cases k with
+  | zero => decide
+  | succ k =>
+    have h := towerProd_succ_le_factorial k
+    rw [C_eq, B_succ]; omega
+
 end DirichletsTheoremOQ02OQ03

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): added the sharper PRIMORIAL certified bound p3 k ≤ 4·(∏_{i<k} p3 i) − 1 and its explicit tower C (C1=11 vs B1=95, C2=131 vs B2=4·96!−1), strictly tighter than the iterated-factorial tower while remaining honest against p_k∼2k·ln k. native_decide-free, 0 axioms, 0 sorries.",
+    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): the primorial-vs-factorial tightness is now a THEOREM for all k — C_le_B: C k ≤ B k universally (was only checked at k=1,2), via towerProd_succ_le_factorial and the elementary n·(n−1)≤n!. native_decide-free, 0 axioms, 0 sorries.",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
@@ -38,7 +38,10 @@
       "p3_one=7, B_one=95, tower_loose_at_one (DirichletsTheoremOQ02OQ03.lean:209–229) — worked values quantifying looseness. Verified 0 sorry / 0 axiom, 7743 jobs.",
       "p3_le_primorial (DirichletsTheoremOQ02OQ03.lean) — primorial bound p3 k ≤ 4·(∏_{i<k} p3 i) − 1, the certified content of the primorial Euclid construction.",
       "towerProd + C + towerProd_eq_prod + p3_le_primorialTower — explicit primorial tower C with p3 k ≤ C k (strong induction).",
-      "C_one_eq=11, C_two_eq=131, primorial_tighter_than_factorial (7≤11=C1<95=B1), p3_bracketed_primorial (4k+3 ≤ p3 k ≤ C k). All 0 sorry / 0 axiom (foundational trio only), native_decide-free."
+      "C_one_eq=11, C_two_eq=131, primorial_tighter_than_factorial (7≤11=C1<95=B1), p3_bracketed_primorial (4k+3 ≤ p3 k ≤ C k). All 0 sorry / 0 axiom (foundational trio only), native_decide-free.",
+      "factorial_ge_mul_pred (DirichletsTheoremOQ02OQ03.lean) — elementary n·(n−1) ≤ n! from n!=n·(n−1)! and self_le_factorial.",
+      "towerProd_succ_le_factorial — towerProd(k+1) ≤ (B k+1)!, the running-product-vs-factorial crux.",
+      "C_le_B — primorial tower ≤ factorial tower for ALL k (VERIFIED 0/0, propext+Quot.sound only); upgrades primorial_tighter_than_factorial from k=1 to universal."
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
@@ -47,10 +50,12 @@
       "The whole development is native_decide-free: the only numeric fact (B 1 = 95) is discharged by kernel decide, so axiomCount stays 0 (verified, not axiomatized).",
       "The Euclid ≡3(mod4) construction only needs the PRODUCT of the primes found so far, not a factorial of the previous bound: N=4·(∏_{i<k}p3 i)−1 is ≡3 mod4, its ≡3-mod4 prime factor p cannot divide ∏p3 i (else p∣4·∏ and p∣N ⇒ p∣1), so p is new and p3 k ≤ p ≤ N. This gives the PRIMORIAL bound p3 k ≤ 4·∏_{i<k}p3 i − 1, dramatically tighter than the factorial tower.",
       "The primorial tower C(k)=4·(∏_{i<k}C i)−1 (C0=3,C1=11,C2=131,C3=17291) is doubly-exponential but incomparably smaller than the iterated-factorial tower B (B2=4·96!−1). p3 k ≤ C k follows by STRONG induction feeding p3_le_primorial the pointwise p3 i ≤ C i for i<k via Finset.prod_le_prod.",
-      "Structural-recursion trick for a product-defined tower: define the running product towerProd k (towerProd 0=1, towerProd(k+1)=towerProd k·(4·towerProd k−1)) structurally, set C k := 4·towerProd k−1, then prove towerProd k = ∏_{i<k} C i by induction (prod_range_succ). Avoids non-structural self-reference of C."
+      "Structural-recursion trick for a product-defined tower: define the running product towerProd k (towerProd 0=1, towerProd(k+1)=towerProd k·(4·towerProd k−1)) structurally, set C k := 4·towerProd k−1, then prove towerProd k = ∏_{i<k} C i by induction (prod_range_succ). Avoids non-structural self-reference of C.",
+      "The primorial tower C is dominated by the factorial tower B EVERYWHERE: C k ≤ B k for all k, not just k=1,2. Proof reduces (both towers are 4·x−1) to towerProd(k+1) ≤ (B k+1)!, an induction whose step uses towerProd(k+2)=towerProd(k+1)·(4·towerProd(k+1)−1) ≤ F·(4F−1) ≤ (4F)·(4F−1) ≤ (4F)! with F=(B k+1)!, needing only the elementary n·(n−1)≤n!. Equality holds solely at k=0 (both = 3)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "Prove the strict domination C k < B k for all k ≥ 1 (equality only at k=0): the slack towerProd(k+1) < (B k+1)! is present already at k=1 and should propagate, giving a clean strict theorem.",
       "Prove the primorial tower never exceeds the factorial tower in general: C k ≤ B k (needs ∏_{i<k} C i ≤ (B(k-1)+1)!), making the tightness a theorem for all k rather than just k=1,2.",
       "Attempt a genuinely elementary sub-exponential certified bound (or prove the primorial tower's doubly-exponential growth is intrinsic to Euclid-style iteration without an analytic input).",
       "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1)."


### PR DESCRIPTION
## Summary

Extends the SOLVED problem **dirichlets-theorem-oq-02-oq-03** (Certified Growth Bound for the k-th Prime ≡ 3 mod 4) with the follow-up flagged in its knowledge base: prove that the tighter **primorial tower** `C` never exceeds the **iterated-factorial tower** `B`.

Previously the file only established `C 1 = 11 < 95 = B 1` at a single index (`primorial_tighter_than_factorial`). This PR upgrades that to a **universal theorem**:

```lean
theorem C_le_B (k : ℕ) : C k ≤ B k
```

## Proof

Both towers have the shape `4·x − 1`, so `C (k+1) ≤ B (k+1) ⇔ towerProd (k+1) ≤ (B k + 1)!`. The running-product bound is proved by induction (`towerProd_succ_le_factorial`): with `F = (B k + 1)!` and IH `towerProd (k+1) ≤ F`,

```
towerProd (k+2) = towerProd (k+1)·(4·towerProd (k+1) − 1)
                ≤ F·(4F − 1) ≤ (4F)·(4F − 1) ≤ (4F)! = (B (k+1) + 1)!
```

The only non-arithmetic ingredient is the elementary factorial lower bound `factorial_ge_mul_pred : n·(n−1) ≤ n!` (from `n! = n·(n−1)!` and `n−1 ≤ (n−1)!`). Equality holds only at `k = 0` (`C 0 = B 0 = 3`).

## Verification

- Host-built with `lake env lean` (exit 0).
- `#print axioms C_le_B` → `[propext, Quot.sound]` only — **native_decide-free, 0 sorry, 0 axiom**.
- 3 new theorems (`factorial_ge_mul_pred`, `towerProd_succ_le_factorial`, `C_le_B`); meta.json `leanFile` counts synced (410→463 lines, 31→34 theorems) and `originalContributions` + research knowledge updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)