### PR TITLE
Enrich descartes-rule-of-signs OQ-02-01-03-02: complete mainTheorems coverage

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -173,6 +173,22 @@
       "leanType": "(S : Finset ℝ) : 0 < minGap S",
       "startLine": 83,
       "endLine": 96
+    },
+    {
+      "name": "minGap",
+      "type": "supporting",
+      "description": "**The minimum-gap object.** The smallest distance between two distinct points of a finite set S (via S.offDiag), with a harmless default of 1 when S has fewer than two points. This noncomputable definition is the quantity the entire effective-bisection bound is stated against — the isolation width scale δ = minGap S.",
+      "leanType": "(S : Finset ℝ) : ℝ",
+      "startLine": 77,
+      "endLine": 80
+    },
+    {
+      "name": "minGap_le",
+      "type": "supporting",
+      "description": "**Gap lower-bounds every distinct-pair distance (reproduced).** minGap S ≤ |x − y| for any two distinct x, y ∈ S — the defining property making δ = minGap S a genuine separation radius, used to turn a sub-δ width into isolation.",
+      "leanType": "{S : Finset ℝ} {x y : ℝ} (hx : x ∈ S) (hy : y ∈ S) (hxy : x ≠ y) : minGap S ≤ |x - y|",
+      "startLine": 98,
+      "endLine": 106
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass on `descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02` (quality 94, passes 0).

The entry was already strong (9 field-complete annotations, full section coverage, 4 insights, 3 open questions, 3 refs) and every count/anchor checks out against `Proofs/DescartesRuleOfSignsOQ02OQ01OQ03OQ02.lean`.

Single non-inflating addition: `mainTheorems` surfaced 6 of the file's named declarations but omitted two that the prose already leans on — the foundational **`minGap`** definition (the δ = minGap S scale the entire effective-bisection bound is stated against) and **`minGap_le`** (the distinct-pair distance lower bound). Added both with verified line anchors (77–80, 98–106), bringing `mainTheorems` to 8 = all 7 theorems + 1 def.

JSON validates; `check-meta-size` passes (well under caps).