### PR TITLE
Enrich golden-ratio badly-approximable (dirichlet-approximation-theorem-oq-05)

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-05/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-05/meta.json
@@ -133,9 +133,26 @@
     ]
   },
   "crossReferences": [
-    "dirichlet-approximation-theorem",
-    "dirichlet-approximation-theorem-oq-01",
-    "dirichlet-approximation-theorem-oq-03"
+    {
+      "targetId": "dirichlet-approximation-theorem",
+      "relationship": "extends",
+      "description": "Parent entry: proves the EXISTENCE of good approximations |qα − p| < 1/N (1 ≤ q ≤ N) by pigeonhole. This OQ-05 proves the dual SHARPNESS statement — that for the golden ratio the exponent cannot be improved — pinning the approximation rate of φ from both sides."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling entry: counts the ~1/q² good approximations (upper-bound side). OQ-05 supplies the complementary lower bound, showing those approximations cannot be too good for φ."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling entry: the Minkowski geometry-of-numbers re-derivation of the upper bound. OQ-03 produces good approximations; OQ-05 shows they cannot be too good for φ — both refine the parent beyond elementary pigeonhole."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-04",
+      "relationship": "sibling",
+      "description": "Sibling entry (Kronecker density): every irrational's multiples come arbitrarily close to integers. OQ-04 and OQ-05 bound the irrational rotation's orbit from opposite sides — OQ-04 shows φ's multiples get arbitrarily close, OQ-05 shows they cannot come too close too fast (the badly-approximable dual)."
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
Enrichment pass on a quality-94 entry (16.5 KB meta.json, under all size caps).

**Schema fix + missing reciprocal cross-reference.** This entry's `crossReferences` was a bare string array (`["dirichlet-approximation-theorem", ...]`), inconsistent with every sibling in the family (and the rest of the gallery), which use `{targetId, relationship, description}` objects. This PR:

- Converts the three existing cross-references to the standard object schema with relationship + description.
- Adds the **missing reciprocal link to oq-04** (Kronecker density), which is this entry's explicit dual — oq-04 already links back here describing oq-05 as "the dual SHARPNESS lower bound." The two entries bound the irrational rotation's orbit from opposite sides.

No prose inflation of existing fields; descriptions drawn from the entry's own `relatedProblems` and the sibling's reciprocal text. JSON validated (4 cross-refs, all objects).