### PR TITLE
audit(algebraic-numbers-countable-oq-02): badge original→mathlib (Tier B core via Mathlib)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
@@ -16,19 +16,19 @@
       "cantor",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 192,
-    "assumptions": "",
+    "assumptions": "0 sorries, 0 axiom declarations (fully machine-checked). The uncountability core is derived via a Mathlib bridge rather than independently formalized: ¬ Countable ℝ follows from Cardinal.mk_real (#ℝ = 𝔠) and Cardinal.aleph0_lt_continuum (ℵ₀ < 𝔠), and the diagonal gap ℵ₀ < 2^ℵ₀ is Cardinal.cantor. This file supplies the Countable-typeclass reductio, the non-enumerability reformulations, and the transcendentals corollary (composed with the sibling AlgebraicNumbersCountable proof). Badge 'mathlib'.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-04-04",
     "originalContributions": [
-      "reals_not_countable: ¬ Countable ℝ (main theorem)",
-      "no_surjection_nat_to_real: ¬∃ f : ℕ → ℝ, Function.Surjective f",
-      "exists_not_in_range: for any f : ℕ → ℝ, ∃ x, x ∉ Set.range f",
-      "transcendentalReals: definition of the transcendental reals",
-      "transcendentals_uncountable: ¬ Set.Countable transcendentalReals"
+      "reals_not_countable: ¬ Countable ℝ — the Countable-typeclass reductio bridging Mathlib's Cardinal.mk_real and Cardinal.aleph0_lt_continuum (the uncountability core itself is Mathlib's, not independently formalized here)",
+      "no_surjection_nat_to_real / exists_not_in_range: reformulations of uncountability as non-enumerability, derived from reals_not_countable",
+      "transcendentalReals: definition of the set of transcendental reals",
+      "transcendentals_uncountable: ¬ Set.Countable transcendentalReals, obtained by composing this file's ¬ Countable ℝ with the sibling AlgebraicNumbersCountable proof (countability of the algebraic reals)",
+      "§5 bridge theorems linking the abstract cardinal gap (Cardinal.cantor) to the concrete diagonal argument in CantorDiagonalization.lean"
     ],
     "prerequisites": [
       "AlgebraicNumbersCountable: algebraic reals are countable (parent proof)",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: \`algebraic-numbers-countable-oq-02\` — "ℝ is Uncountable: Cantor's Diagonal Argument (1874)"
**Severity**: MEDIUM (Mathlib wrapper claimed as \`original\`)
**Failure mode**: #5 — "0 sorries with hidden imports"

## Problem

The entry carried \`badge: "original"\`, but the core result — \`¬ Countable ℝ\` — is derived **entirely** from Mathlib, with no independent diagonal construction in the file:

| File theorem | Actually is |
|---|---|
| \`card_real_eq_continuum\` | \`Cardinal.mk_real\` (Mathlib, verbatim) |
| \`aleph0_lt_card_real\` | uses \`Cardinal.aleph0_lt_continuum\` (Mathlib) |
| \`reals_not_countable\` | \`Cardinal.mk_le_aleph0\` + the above (5-line reductio) |
| \`cantor_diagonal_gap\` | \`Cardinal.cantor ℵ₀\` (Mathlib, verbatim) |

Per the auditor guidance, a 0-sorry file that obtains its main result by calling a deep Mathlib theorem is **Tier B** and must use badge \`mathlib\`, not \`original\`.

## Fix

- \`badge\`: \`original\` → \`mathlib\`
- \`assumptions\`: now discloses the Mathlib bridge (previously empty)
- \`originalContributions\`: reframed to distinguish the Mathlib-derived core from the genuine file-local contributions (Countable-typeclass reductio, non-enumerability reformulations, transcendentals corollary composed with the sibling \`AlgebraicNumbersCountable\` proof, and the §5 diagonal bridge)
- \`status\`: **unchanged** — remains \`verified\` (the file is genuinely machine-checked: 0 sorries, 0 axiom declarations, no structure-encoded assumptions)

The body text (proofStrategy, mainTheorems, mathlibDependencies) was already transparent about the delegation; only the badge/assumptions/contributions framing overstated independence.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)