### PR TITLE
research(erdos-729-oq-02): uniform axiom-free Erdős 1968 real-log bound C=4/log2 [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos729DigitSumBound.lean
+++ b/proofs/Proofs/Erdos729DigitSumBound.lean
@@ -110,4 +110,92 @@ theorem erdos_two_adic_bound_log (n a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0)
   have hlb := digitSum_two_le_log b hb
   omega
 
+-- ----------------------------------------------------------------------------
+-- The honest UNIFORM real-logarithmic Erdős (1968) bound, axiom-free.
+--
+-- The parent file carries the classical bound only through the axiom
+-- `erdos_1968_classical`, stated as `∀ n a b, a!b! ∣ n! → ∃ C>0, a+b ≤ n+C·log n`.
+-- That statement is defective on two counts:
+--   * it is UNSOUND at `n ∈ {0,1}` — e.g. `n=0, a=b=1`: `1!·1! ∣ 0!` holds, yet
+--     `a+b = 2 ≤ 0 + C·log 0 = 0` is false for every `C` (Real.log 0 = 0); and
+--   * with `C` chosen per-instance INSIDE the `∀`, it is VACUOUS for `n ≥ 2`
+--     (take `C = (a+b)/log n`), so it does not express Erdős's actual content.
+-- The mathematically meaningful statement puts a SINGLE uniform `C` outside the
+-- quantifiers.  We prove exactly that, axiom-free, with the explicit constant
+-- `C = 4 / log 2`, valid for all `n ≥ 2`.  This is the correct replacement for
+-- the parent's `erdos_1968_classical`.
+-- ----------------------------------------------------------------------------
+
+/-- **`⌊log₂ n⌋ · log 2 ≤ log n`.**  Real-logarithm form of `2^⌊log₂ n⌋ ≤ n`:
+take `Real.log` of `2^(Nat.log 2 n) ≤ n` and use `Real.log_pow`. -/
+theorem natLog_two_mul_log_two_le_log (n : ℕ) (hn : 1 ≤ n) :
+    (Nat.log 2 n : ℝ) * Real.log 2 ≤ Real.log n := by
+  have hpow : (2 : ℕ) ^ Nat.log 2 n ≤ n := Nat.pow_log_le_self 2 (by omega)
+  have h2n : (2 : ℝ) ^ Nat.log 2 n ≤ (n : ℝ) := by exact_mod_cast hpow
+  have hpos : (0 : ℝ) < (2 : ℝ) ^ Nat.log 2 n := by positivity
+  have hlog : Real.log ((2 : ℝ) ^ Nat.log 2 n) ≤ Real.log n := Real.log_le_log hpos h2n
+  rwa [Real.log_pow] at hlog
+
+/-- **Erdős (1968), uniform real-logarithmic form — axiom-free.**  There is a
+    single constant `C = 4 / log 2 > 0` such that for every `n ≥ 2` and all
+    `a, b` with `a! · b! ∣ n!`,
+        `a + b ≤ n + C · log n`.
+    This is the honest, non-vacuous statement of the classical bound (uniform
+    `C`, no small-`n` unsoundness), derived entirely from the elementary 2-adic
+    digit-sum bound `erdos_two_adic_bound_log`. -/
+theorem erdos_1968_uniform :
+    ∃ C : ℝ, 0 < C ∧ ∀ n a b : ℕ, 2 ≤ n → a ! * b ! ∣ n ! →
+      (a + b : ℝ) ≤ n + C * Real.log n := by
+  have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  refine ⟨4 / Real.log 2, by positivity, ?_⟩
+  intro n a b hn hdvd
+  -- log n ≥ log 2 > 0
+  have hlogn2 : Real.log 2 ≤ Real.log n := by
+    have h2n : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+    exact Real.log_le_log (by norm_num) h2n
+  have hlognpos : 0 < Real.log n := lt_of_lt_of_le hlog2 hlogn2
+  -- a ≤ n and b ≤ n from the divisibility
+  have han : a ≤ n := by
+    by_contra hc
+    push_neg at hc
+    have hd : a ! ∣ n ! := (dvd_mul_right (a !) (b !)).trans hdvd
+    have hle : a ! ≤ n ! := Nat.le_of_dvd (Nat.factorial_pos n) hd
+    have hlt : n ! < a ! := (Nat.factorial_lt (by omega)).mpr hc
+    omega
+  have hbn : b ≤ n := by
+    by_contra hc
+    push_neg at hc
+    have hd : b ! ∣ n ! := (dvd_mul_left (b !) (a !)).trans hdvd
+    have hle : b ! ≤ n ! := Nat.le_of_dvd (Nat.factorial_pos n) hd
+    have hlt : n ! < b ! := (Nat.factorial_lt (by omega)).mpr hc
+    omega
+  -- Reduce the RHS constant to a multiple of L := log n / log 2
+  have hL : (4 / Real.log 2) * Real.log n = 4 * (Real.log n / Real.log 2) := by ring
+  have hL1 : (1 : ℝ) ≤ Real.log n / Real.log 2 := (one_le_div hlog2).mpr hlogn2
+  rw [hL]
+  set L : ℝ := Real.log n / Real.log 2 with hLdef
+  -- Case a = 0 or b = 0: a + b ≤ n directly
+  rcases Nat.eq_zero_or_pos a with ha0 | ha1
+  · subst ha0
+    have hb' : (b : ℝ) ≤ n := by exact_mod_cast hbn
+    have : (0 : ℝ) ≤ 4 * L := by positivity
+    push_cast; linarith
+  rcases Nat.eq_zero_or_pos b with hb0 | hb1
+  · subst hb0
+    have ha' : (a : ℝ) ≤ n := by exact_mod_cast han
+    have : (0 : ℝ) ≤ 4 * L := by positivity
+    push_cast; linarith
+  -- Main case a, b ≥ 1: elementary bound + logarithm bridge
+  have hmain := erdos_two_adic_bound_log n a b (by omega) (by omega) hdvd
+  have hla : Nat.log 2 a ≤ Nat.log 2 n := Nat.log_mono_right han
+  have hlb : Nat.log 2 b ≤ Nat.log 2 n := Nat.log_mono_right hbn
+  have hnat : a + b ≤ n + 2 * Nat.log 2 n + 2 := by omega
+  have hcast : (a : ℝ) + b ≤ (n : ℝ) + 2 * (Nat.log 2 n : ℝ) + 2 := by exact_mod_cast hnat
+  -- ⌊log₂ n⌋ ≤ L
+  have hlogdiv : (Nat.log 2 n : ℝ) ≤ L := by
+    rw [hLdef, le_div_iff₀ hlog2]
+    exact natLog_two_mul_log_two_le_log n (by omega)
+  -- assemble:  a+b ≤ n + 2·⌊log₂ n⌋ + 2 ≤ n + 2L + 2L = n + 4L
+  linarith
+
 end Erdos729DigitSum

--- a/research/problems/erdos-729-oq-02/sessions/2026-07-08-r3-uniform-log-bound.md
+++ b/research/problems/erdos-729-oq-02/sessions/2026-07-08-r3-uniform-log-bound.md
@@ -1,0 +1,46 @@
+# erdos-729-oq-02 — Session (researcher-3, 2026-07-08)
+
+## Result: honest UNIFORM real-log Erdős 1968 bound, axiom-free
+
+Added to the verified companion `Erdos729DigitSumBound.lean` (0 axioms / 0 sorries):
+
+- `natLog_two_mul_log_two_le_log` — `(⌊log₂ n⌋ : ℝ)·log 2 ≤ log n` (Real-log form
+  of `2^⌊log₂ n⌋ ≤ n`).
+- `erdos_1968_uniform` —
+  `∃ C = 4/log 2 > 0, ∀ n ≥ 2, ∀ a b, a!·b! ∣ n! → (a+b:ℝ) ≤ n + C·log n`.
+
+## Why this matters: the parent axiom is defective
+The parent `Erdos729Problem.lean` carries the classical bound only via the axiom
+`erdos_1968_classical : ∀ n a b, a!b! ∣ n! → ∃ C>0, (a+b:ℝ) ≤ n + C·log n`.
+That axiom is wrong on two counts:
+1. **Unsound at n ∈ {0,1}.** `Real.log 0 = Real.log 1 = 0`, so the bound reads
+   `a+b ≤ n`. But `n=0, a=b=1`: `1!·1! = 1 ∣ 1 = 0!` holds while `a+b = 2 ≤ 0`
+   is false. So the axiom (and `erdos_729_statement`'s first conjunct) is false.
+2. **Vacuous for n ≥ 2.** With `∃C` INSIDE the `∀`, pick `C = (a+b)/log n`; the
+   inequality becomes `a+b ≤ n + (a+b)`, trivially true and independent of the
+   divisibility. It does not express Erdős's content.
+
+The meaningful statement puts a **single uniform C outside the quantifiers**.
+`erdos_1968_uniform` proves exactly that, axiom-free, with explicit `C = 4/log 2`
+for `n ≥ 2`.
+
+## Proof
+From the elementary `erdos_two_adic_bound_log` (a+b ≤ n + ⌊log₂ a⌋ + ⌊log₂ b⌋ + 2
+for a,b ≥ 1) plus `a,b ≤ n` (since a!∣a!b!∣n! ⟹ a!≤n! ⟹ a≤n via `Nat.factorial_lt`)
+one gets `a+b ≤ n + 2⌊log₂ n⌋ + 2` in ℕ. Bridge to reals with
+`natLog_two_mul_log_two_le_log`: `⌊log₂ n⌋ ≤ log n / log 2 =: L`, and for n ≥ 2,
+`L ≥ 1`, so `2⌊log₂ n⌋ + 2 ≤ 2L + 2L = 4L = (4/log 2)·log n`. Cases a=0 / b=0
+handled directly (`a+b ≤ n`).
+
+## Verification
+Host `lake env lean Proofs/Erdos729DigitSumBound.lean` → EXIT 0.
+`#print axioms erdos_1968_uniform` / `natLog_two_mul_log_two_le_log`
+→ [propext, Classical.choice, Quot.sound]. 0 axioms / 0 sorries / no native_decide.
+
+## Remaining
+- Main file still declares the defective `erdos_1968_classical` (axiomCount 3).
+  Recommend a follow-up/auditor pass to restrict it to `2 ≤ n` and back it by
+  `erdos_1968_uniform` (or import companion + delete → axiomCount 3→2). Left
+  untouched here to avoid destabilising the merged gallery entry.
+- The two `barreto_leeham_*` axioms (mod-small-primes resolution) are deep
+  research inputs, not Mathlib-eliminable.

--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -200,6 +200,6 @@
       "description": "Ehrhart theory counts lattice points in polytope dilations, complementing the volumetric density theory of Kepler/Hales; the 4000/4671 dimer construction is polytopal and interfaces naturally with Ehrhart techniques."
     }
   ],
-  "theoremCount": 20,
+  "theoremCount": 22,
   "definitionCount": 4
 }

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,9 +58,9 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 255,
+    "lineCount": 214,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 11,
+    "theoremCount": 8,
     "definitionCount": 4
   },
   "overview": {

--- a/src/data/proofs/roth-theorem-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-oq-01/meta.json
@@ -36,7 +36,7 @@
     ],
     "dateAdded": "2026-07-02",
     "lineCount": 408,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/RothTheoremOQ02.lean"

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -167,7 +167,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Fully verified formalization (0 sorries, 0 axioms) of Roth's theorem and its key Fourier-analytic components. The 49-theorem file develops complete machinery: character theory, Parseval, AP counting, large Fourier coefficient (the key standalone lemma), and density increment. The main theorem wraps via Mathlib's `roth_3ap_theorem_nat`.",
+    "summary": "Fully verified formalization (0 sorries, 0 axioms) of Roth's theorem and its key Fourier-analytic components. The 42-theorem file develops complete machinery: character theory, Parseval, AP counting, large Fourier coefficient (the key standalone lemma), and density increment. The main theorem wraps via Mathlib's `roth_3ap_theorem_nat`.",
     "implications": "The independently verified `fourier_large_coefficient` theorem provides a formalized version of the core analytic step that underlies quantitative improvements to Roth's theorem (Bourgain, Bloom-Sisask). The density increment infrastructure could be extended to prove better bounds.",
     "openQuestions": [
       "Formalize Bourgain's quantitative bound r₃(N) = O(N/(log log N)^{1/2})",

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-6, 2026-07-08): de-axiomatized the elementary 2-adic core of Erdős 1968 — new verified companion Erdos729DigitSumBound.lean proves the sharp digit-sum bound a+b ≤ n+s₂(a)+s₂(b) and its log corollary, 0 axioms/0 sorries.",
+    "progressSummary": "PROGRESS (researcher-3, 2026-07-08): added the honest UNIFORM real-logarithmic Erdős-1968 bound to the companion Erdos729DigitSumBound.lean, axiom-free (0 axioms/0 sorries). erdos_1968_uniform: ∃ single C=4/log2>0, ∀ n≥2, ∀ a,b with a!b!∣n!, (a+b:ℝ)≤n+C·log n. This is the correct replacement for the parent file's axiom erdos_1968_classical, which is BOTH unsound at n∈{0,1} (n=0,a=b=1: 1∣1 but 2≤0 false) AND vacuous for n≥2 (C chosen per-instance inside ∀ ⟹ take C=(a+b)/log n). Derived from the elementary 2-adic digit-sum bound via a Nat.log→Real.log bridge (2^⌊log₂n⌋≤n).",
     "builtItems": [
       "digitSum_prime_mul_add (p n r)(hp:1<p)(hr:r<p): (Nat.digits p (p*n+r)).sum = (Nat.digits p n).sum + r -- general base-p digit left-shift, Erdos729LegendrePrimeRecurrence.lean",
       "digitSum_prime_mul (p n)(hp:1<p): s_p(p*n)=s_p(n) -- r=0 invariant",
@@ -47,18 +47,24 @@
       "Erdos729DigitSumBound.lean: v2_add_le_of_dvd — a!·b!∣n! ⟹ v₂(a!)+v₂(b!) ≤ v₂(n!) via Nat.factorization_prime_le_iff_dvd + factorization_mul + factorization_def",
       "Erdos729DigitSumBound.lean: erdos_two_adic_bound — axiom-free sharp bound a+b ≤ n+s₂(a)+s₂(b)",
       "Erdos729DigitSumBound.lean: digitSum_two_le_log — s₂(m) ≤ Nat.log 2 m + 1 (List.sum_le_card_nsmul + Nat.digits_len)",
-      "Erdos729DigitSumBound.lean: erdos_two_adic_bound_log — log form a+b ≤ n+(log₂a+1)+(log₂b+1)"
+      "Erdos729DigitSumBound.lean: erdos_two_adic_bound_log — log form a+b ≤ n+(log₂a+1)+(log₂b+1)",
+      "natLog_two_mul_log_two_le_log (Erdos729DigitSumBound.lean): (⌊log₂ n⌋:ℝ)·log 2 ≤ log n via Real.log of 2^⌊log₂n⌋≤n + Real.log_pow.",
+      "erdos_1968_uniform (Erdos729DigitSumBound.lean): ∃ uniform C=4/log2>0, ∀ n≥2 ∀ a,b, a!b!∣n! → (a+b:ℝ)≤n+C·log n — axiom-free honest Erdős-1968; correct replacement for the unsound/vacuous main-file axiom erdos_1968_classical."
     ],
     "insights": [
       "The 2-adic doubling recurrence v_2((2n)!)=n+v_2(n!) is the p=2 shadow of a general-prime law: for EVERY prime p and residue 0<=r<p, v_p((p*n+r)!) = n + v_p(n!), the increment n being INDEPENDENT of r. So all p consecutive arguments pn, pn+1, ..., pn+(p-1) share one valuation step. Proof: (p-1)*v_p(m!)=m-s_p(m) (Mathlib) plus s_p(p*n+r)=s_p(n)+r and (p-1)*n+n=p*n, then cancel p-1>0. Not a named Mathlib lemma.",
       "General textbook Legendre identity v_p(n!)=(n-s_p(n))/(p-1) proved axiom-free for ALL primes p in new companion Erdos729LegendreGeneral.lean (sibling PR #24474 covers only p=2). Division form derived from Mathlib sub_one_mul_padicValNat_factorial via Nat.mul_div_cancel_left; not a named Mathlib lemma.",
       "v_2((2n)!) = n + v_2(n!): the 2-adic valuation of the factorial doubles-with-offset because multiplying by 2 left-shifts the binary expansion (s_2 invariant) — i.e. 2n! gains exactly n factors of two over n!. Equivalent to Legendre + s_2(2n)=s_2(n). v_2(n!) hits its ceiling n-1 exactly when s_2(n)=1 (n a power of two). None of these are named Mathlib lemmas.",
-      "The exact 2-adic core of the Erdős (1968) constraint is elementary and axiom-free: a!·b! ∣ n! ⟹ v₂(a!)+v₂(b!) ≤ v₂(n!) (factorization is monotone under divisibility and additive over products), so by Legendre v₂(m!)=m−s₂(m) one gets the SHARP subtraction-free bound a + b ≤ n + s₂(a) + s₂(b). The excess a+b−n never exceeds the total 1-bit count of the two parts — no O(·) needed. The log form a+b ≤ n+(⌊log₂a⌋+1)+(⌊log₂b⌋+1) follows from s₂(m) ≤ Nat.log 2 m + 1 (each binary digit ≤ 1, digit count = log₂+1). Parent file carries this only as the deep axiom erdos_1968_classical."
+      "The exact 2-adic core of the Erdős (1968) constraint is elementary and axiom-free: a!·b! ∣ n! ⟹ v₂(a!)+v₂(b!) ≤ v₂(n!) (factorization is monotone under divisibility and additive over products), so by Legendre v₂(m!)=m−s₂(m) one gets the SHARP subtraction-free bound a + b ≤ n + s₂(a) + s₂(b). The excess a+b−n never exceeds the total 1-bit count of the two parts — no O(·) needed. The log form a+b ≤ n+(⌊log₂a⌋+1)+(⌊log₂b⌋+1) follows from s₂(m) ≤ Nat.log 2 m + 1 (each binary digit ≤ 1, digit count = log₂+1). Parent file carries this only as the deep axiom erdos_1968_classical.",
+      "The main-file axiom erdos_1968_classical (∀ n a b, a!b!∣n! → ∃C>0, a+b≤n+C·log n) is defective TWO ways: unsound at n∈{0,1} (Real.log=0 there, but a+b can be 2>n), and mathematically VACUOUS for n≥2 because the ∃C sits INSIDE the ∀ (pick C=(a+b)/log n). The meaningful form puts a single uniform C outside the quantifiers; that form IS provable axiom-free with C=4/log2 for n≥2.",
+      "Nat.log→Real.log bridge: 2^⌊log₂ n⌋≤n (Nat.pow_log_le_self) ⟹ (via Real.log monotone + Real.log_pow) ⌊log₂ n⌋·log2≤log n ⟹ ⌊log₂ n⌋≤log n/log2. Combined with a,b≤n (from a!∣a!b!∣n! ⟹ a!≤n! ⟹ a≤n via Nat.factorial_lt) the ℕ digit-sum bound a+b≤n+2⌊log₂n⌋+2 lifts to the real n+O(log n) shape with explicit constant.",
+      "v4.26 rename: le_div_iff → le_div_iff₀ (one_le_div still exists as an alias in Field/Basic)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Sharpen the excess bound: s₂(a)+s₂(b)−s₂(n) equals the number of carries when adding a and (n−a) in base 2 (Kummer); relate to erdos_two_adic_bound to characterize equality a+b=n+carries.",
-      "Note main-file axiom erdos_1968_classical is unsound at n=0 (a=b=1: DividesFactorial 0 1 1 holds but 2 ≤ 0 fails); the elementary ℕ-form erdos_two_adic_bound is the correct replacement for the classical direction."
+      "PROPOSE main-file fix (auditor/follow-up): replace the unsound axiom erdos_1968_classical with either a `2 ≤ n` hypothesis + reference to erdos_1968_uniform, or import the companion and delete the axiom (reduces main-file axiomCount 3→2). erdos_729_statement's first conjunct is currently backed by a false axiom.",
+      "Kummer refinement: s₂(a)+s₂(b)−s₂(n) = number of base-2 carries adding a and n−a; characterize equality a+b=n+carries.",
+      "The two barreto_leeham axioms (mod-small-primes resolution) are the genuinely deep research inputs — not Mathlib-eliminable; leave and document."
     ],
     "markdown": "# Knowledge Base: erdos-729-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -80,7 +86,7 @@
     "mathlib": []
   },
   "started": "2026-04-13T00:54:20.846Z",
-  "lastUpdate": "2026-06-20",
+  "lastUpdate": "2026-07-08T00:00:00.000Z",
   "significance": 7,
   "tractability": 8,
   "leanFiles": [
@@ -127,6 +133,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos729Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos729DigitSumBound.lean",
+      "filename": "Erdos729DigitSumBound.lean",
+      "lineCount": 201,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos729DigitSumBound.lean"
     }
   ]
 }


### PR DESCRIPTION
## Erdős #729 OQ-02 — honest uniform real-logarithmic Erdős 1968 bound (axiom-free)

Extends the verified companion `Erdos729DigitSumBound.lean` (stays 0 axioms / 0 sorries):

- **`natLog_two_mul_log_two_le_log`** — `(⌊log₂ n⌋ : ℝ)·log 2 ≤ log n` (real-log form of `2^⌊log₂ n⌋ ≤ n`).
- **`erdos_1968_uniform`** — `∃ C = 4/log 2 > 0, ∀ n ≥ 2, ∀ a b, a!·b! ∣ n! → (a+b:ℝ) ≤ n + C·log n`.

### Why: the parent file's axiom is defective
`Erdos729Problem.lean` carries the classical bound only through
`axiom erdos_1968_classical : ∀ n a b, a!b! ∣ n! → ∃ C>0, (a+b:ℝ) ≤ n + C·log n`, which is:
1. **Unsound at n ∈ {0,1}** — `Real.log 0 = Real.log 1 = 0`, so the bound is `a+b ≤ n`; but `n=0, a=b=1` gives `1!·1! = 1 ∣ 0! = 1` while `a+b = 2 ≤ 0` is false. So the axiom (and `erdos_729_statement`'s first conjunct) is false.
2. **Vacuous for n ≥ 2** — with `∃C` *inside* the `∀`, take `C = (a+b)/log n`; the inequality collapses to `a+b ≤ n + (a+b)`, independent of the divisibility.

The mathematically meaningful statement puts a **single uniform C outside the quantifiers**. `erdos_1968_uniform` proves exactly that, axiom-free, with explicit `C = 4/log 2` for `n ≥ 2`.

### Proof
From the elementary `erdos_two_adic_bound_log` plus `a,b ≤ n` (a!∣a!b!∣n! ⟹ a!≤n! ⟹ a≤n) one gets `a+b ≤ n + 2⌊log₂ n⌋ + 2` in ℕ. Bridge to reals: `⌊log₂ n⌋ ≤ log n / log 2 =: L`, and `L ≥ 1` for n≥2, so `2⌊log₂ n⌋ + 2 ≤ 4L = (4/log 2)·log n`. Cases a=0 / b=0 handled directly.

### Verification
- Host `lake env lean Proofs/Erdos729DigitSumBound.lean` → **EXIT 0**.
- `#print axioms erdos_1968_uniform` / `natLog_two_mul_log_two_le_log` → `[propext, Classical.choice, Quot.sound]`.
- **0 axioms, 0 sorries, no native_decide.**

### Follow-up (not in this PR)
The main file still declares the defective `erdos_1968_classical` (axiomCount 3). Recommend a later pass to restrict it to `2 ≤ n` and back it by `erdos_1968_uniform` (or import companion + delete → axiomCount 3→2). Left untouched here to avoid destabilising the merged gallery entry; flagged in the session note for an auditor/follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)