### PR TITLE
research(erdos-1-oq-02-oq-01): powers-of-two extremal construction [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos1OQ02OQ01.lean
@@ -115,4 +115,95 @@ theorem geomSum_two_succ (n : ℕ) : (∑ i ∈ range n, 2 ^ i) + 1 = 2 ^ n := b
     rw [sum_range_succ, pow_succ]
     omega
 
+/-!
+## Section 4: the powers-of-two extremal set
+
+Section 2 gives the counting *lower* bound `2^{|A|} ≤ Σ A + 1`; Section 3 turns it
+into `max A ≥ (2^{|A|} − 1)/|A|`. This section supplies the matching
+*construction*: the geometric set `{2⁰, 2¹, …, 2^{n-1}}` is a genuine
+distinct-subset-sums set of cardinality `n`, it attains **equality** in the
+counting bound (`Σ A = 2ⁿ − 1`), and its largest element is only `2^{n-1} = 2ⁿ/2`.
+
+Writing `M(n)` for the Erdős extremal maximum
+
+> `M(n) := min { max A : |A| = n, A has distinct subset sums }`,
+
+Section 3 and this construction pin it between the two elementary walls
+
+> `(2ⁿ − 1)/n ≤ M(n) ≤ 2^{n-1}`.
+
+In particular the conjectural constant `c` in Erdős's `max A ≥ c·2^{|A|}` cannot
+exceed `1/2`: the whole difficulty of Erdős #1 lies in closing the `√n`-and-more
+gap between the counting lower bound and this doubling construction (the analytic
+second-moment bound of the parent entry `erdos-1-oq-02` narrows, but does not
+close, that gap). Distinctness reuses Mathlib's `Finset.geomSum_injective`
+(injectivity of `I ↦ ∑_{i∈I} 2^i`, the uniqueness of binary expansions).
+-/
+
+/-- The doubling map `i ↦ 2ⁱ` is injective. -/
+theorem twoPow_injective : Function.Injective (fun i : ℕ => 2 ^ i) :=
+  Nat.pow_right_injective (le_refl 2)
+
+/-- The geometric set `{2⁰, 2¹, …, 2^{n-1}}`. -/
+def geomSet (n : ℕ) : Finset ℕ := (range n).image (fun i => 2 ^ i)
+
+/-- Membership in the geometric set: `x` is a power `2ⁱ` with `i < n`. -/
+theorem mem_geomSet {n x : ℕ} : x ∈ geomSet n ↔ ∃ i < n, 2 ^ i = x := by
+  simp only [geomSet, mem_image, mem_range]
+
+/-- The geometric set has exactly `n` elements. -/
+theorem card_geomSet (n : ℕ) : (geomSet n).card = n := by
+  rw [geomSet, card_image_of_injective _ twoPow_injective, card_range]
+
+/-- A subset sum over an image of powers of two collapses to a geometric sum of
+    the chosen indices. -/
+theorem sum_image_twoPow (I : Finset ℕ) :
+    (I.image (fun i => 2 ^ i)).sum id = ∑ i ∈ I, 2 ^ i := by
+  simp only [sum_image twoPow_injective.injOn, id_eq]
+
+/-- **The geometric set has distinct subset sums.** Any subset of `{2⁰,…,2^{n-1}}`
+    is the image of an index set `I ⊆ range n`, and `I ↦ ∑_{i∈I} 2ⁱ` is injective
+    (`Finset.geomSum_injective`), so equal subset sums force equal subsets. -/
+theorem geomSet_hasDistinctSubsetSums (n : ℕ) :
+    HasDistinctSubsetSums (geomSet n) := by
+  intro S T hS hT hST
+  rw [geomSet] at hS hT
+  obtain ⟨I, _, rfl⟩ := subset_image_iff.1 hS
+  obtain ⟨J, _, rfl⟩ := subset_image_iff.1 hT
+  simp only [sum_image_twoPow] at hST
+  rw [geomSum_injective (le_refl 2) hST]
+
+/-- The geometric set attains **equality** in the counting bound: `Σ A = 2ⁿ − 1`. -/
+theorem sum_geomSet (n : ℕ) : (geomSet n).sum id = 2 ^ n - 1 := by
+  rw [geomSet, sum_image_twoPow]
+  have := geomSum_two_succ n
+  omega
+
+/-- The largest element of the geometric set is `2^{n-1}` (for `n ≥ 1`). -/
+theorem max'_geomSet {n : ℕ} (hn : 1 ≤ n) (hne : (geomSet n).Nonempty) :
+    (geomSet n).max' hne = 2 ^ (n - 1) := by
+  apply le_antisymm
+  · apply max'_le
+    intro y hy
+    rw [mem_geomSet] at hy
+    obtain ⟨i, hi, rfl⟩ := hy
+    exact Nat.pow_le_pow_right (by norm_num) (by omega)
+  · apply le_max'
+    rw [mem_geomSet]
+    exact ⟨n - 1, by omega, rfl⟩
+
+/-- **Two-sided wall on the Erdős extremal max.** For every `n ≥ 1` there is a
+    distinct-subset-sums set `A` of cardinality `n` whose largest element is
+    exactly `2^{n-1}`. Combined with `two_pow_card_le_card_mul_max` (giving
+    `max A ≥ (2ⁿ − 1)/|A|`) this pins the extremal maximum `M(n)` into
+    `(2ⁿ − 1)/n ≤ M(n) ≤ 2^{n-1}`, so the conjectural constant `c` in
+    `max A ≥ c·2^{|A|}` satisfies `c ≤ 1/2`. -/
+theorem exists_extremal_geomSet (n : ℕ) (hn : 1 ≤ n) :
+    ∃ A : Finset ℕ, A.card = n ∧ HasDistinctSubsetSums A ∧
+      ∃ hne : A.Nonempty, A.max' hne = 2 ^ (n - 1) := by
+  have hne : (geomSet n).Nonempty := by
+    rw [← card_pos, card_geomSet]; omega
+  exact ⟨geomSet n, card_geomSet n, geomSet_hasDistinctSubsetSums n,
+    hne, max'_geomSet hn hne⟩
+
 end Erdos1OQ02OQ01

--- a/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
@@ -11,11 +11,11 @@
       "Finset"
     ],
     "namespace": "Erdos1OQ02OQ01",
-    "lineCount": 118,
+    "lineCount": 209,
     "axiomCount": 0,
-    "theoremCount": 7,
-    "substantiveTheoremCount": 6,
-    "definitionCount": 1,
+    "theoremCount": 15,
+    "substantiveTheoremCount": 11,
+    "definitionCount": 2,
     "path": "Proofs/Erdos1OQ02OQ01.lean",
     "sorries": 0
   },
@@ -124,9 +124,17 @@
       "id": "maxbound",
       "title": "The Erdős–Moser Max Bound",
       "startLine": 92,
-      "endLine": 118,
+      "endLine": 116,
       "summary": "two_pow_card_le_card_mul_max combines the counting bound with ΣA ≤ |A|·max A to get 2^|A| ≤ |A|·max A + 1; geomSum_two_succ certifies tightness for the powers of two.",
       "mathContext": "$2^{|A|} \\le |A|\\cdot\\max A + 1$, i.e. $\\max A \\ge (2^{|A|}-1)/|A|$; equality $\\sum_{i<n}2^i + 1 = 2^n$ for the powers of two."
+    },
+    {
+      "id": "extremal",
+      "title": "The Powers-of-Two Extremal Set",
+      "startLine": 118,
+      "endLine": 209,
+      "summary": "The matching construction: geomSet n = {2^0,…,2^{n-1}} is a genuine distinct-subset-sums set (geomSet_hasDistinctSubsetSums, via Mathlib Finset.geomSum_injective + subset_image_iff), has card n, attains equality ΣA = 2^n − 1 (sum_geomSet), and has max element 2^{n-1} (max'_geomSet). exists_extremal_geomSet packages these into a two-sided wall (2^n−1)/n ≤ M(n) ≤ 2^{n-1} on the Erdős extremal maximum, so the conjectural constant c ≤ 1/2.",
+      "mathContext": "Extremal max $M(n)$ obeys $(2^n-1)/n \\le M(n) \\le 2^{n-1}$; the constant $c$ in $\\max A \\ge c\\cdot 2^{|A|}$ satisfies $c \\le 1/2$."
     }
   ],
   "mainTheorems": [
@@ -185,6 +193,46 @@
       "leanType": "{A B : Finset ℕ} (hBA : B ⊆ A) (h : HasDistinctSubsetSums A) : HasDistinctSubsetSums B",
       "startLine": 59,
       "endLine": 61
+    },
+    {
+      "name": "geomSet",
+      "type": "key",
+      "description": "**The geometric set.** geomSet n = {2^0, 2^1, …, 2^{n−1}} = (range n).image (2^·), the canonical distinct-subset-sums set used to bound the Erdős extremal maximum from above.",
+      "leanType": "(n : ℕ) : Finset ℕ",
+      "startLine": 148,
+      "endLine": 148
+    },
+    {
+      "name": "geomSet_hasDistinctSubsetSums",
+      "type": "core",
+      "description": "**The powers of two have distinct subset sums.** Every subset of {2^0,…,2^{n−1}} is the image of an index set I ⊆ range n (subset_image_iff), and I ↦ ∑_{i∈I} 2^i is injective (Mathlib Finset.geomSum_injective, uniqueness of binary expansions), so equal subset sums force equal subsets.",
+      "leanType": "(n : ℕ) : HasDistinctSubsetSums (geomSet n)",
+      "startLine": 167,
+      "endLine": 174
+    },
+    {
+      "name": "sum_geomSet",
+      "type": "key",
+      "description": "**Equality in the counting bound.** Σ(geomSet n) = 2^n − 1, so the geometric set attains equality 2^|A| = ΣA + 1 in two_pow_card_le_sum_succ.",
+      "leanType": "(n : ℕ) : (geomSet n).sum id = 2 ^ n - 1",
+      "startLine": 177,
+      "endLine": 180
+    },
+    {
+      "name": "max'_geomSet",
+      "type": "key",
+      "description": "**Largest element is 2^{n−1}.** For n ≥ 1 the maximum of geomSet n is exactly 2^{n−1} = 2^n/2, the small-max side of the extremal wall.",
+      "leanType": "{n : ℕ} (hn : 1 ≤ n) (hne : (geomSet n).Nonempty) : (geomSet n).max' hne = 2 ^ (n - 1)",
+      "startLine": 183,
+      "endLine": 193
+    },
+    {
+      "name": "exists_extremal_geomSet",
+      "type": "core",
+      "description": "**Two-sided wall on the Erdős extremal max.** For every n ≥ 1 there is a distinct-subset-sums set of cardinality n whose max is exactly 2^{n−1}; combined with two_pow_card_le_card_mul_max this pins M(n) into (2^n−1)/n ≤ M(n) ≤ 2^{n−1}, so the conjectural constant c in max A ≥ c·2^|A| satisfies c ≤ 1/2.",
+      "leanType": "(n : ℕ) (hn : 1 ≤ n) : ∃ A : Finset ℕ, A.card = n ∧ HasDistinctSubsetSums A ∧ ∃ hne : A.Nonempty, A.max' hne = 2 ^ (n - 1)",
+      "startLine": 201,
+      "endLine": 208
     }
   ],
   "references": [
@@ -210,12 +258,12 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize the elementary counting lower bound for Erdős's distinct-subset-sums problem: a distinct-subset-sums set A satisfies 2^|A| ≤ ΣA + 1 (its subset sums are 2^|A| distinct integers in {0,…,ΣA}), and hence the Erdős–Moser bound 2^|A| ≤ |A|·max A + 1, i.e. max A ≥ (2^|A|−1)/|A|. The powers of two attain equality in the counting bound. Fully machine-checked, 0 sorries, 0 axioms.",
-    "implications": "**Frames where the difficulty lives.** The counting bound is tight for the powers of two, so distinctness alone yields only max A ≥ (2^|A|−1)/|A| — a factor of |A| short of Erdős's conjectural c·2^|A|. Closing that gap is exactly what the parent's second-moment bound and deeper Fourier-analytic methods attack.\n\n**A clean, reusable elementary core.** The injective-image counting argument (2^|A| distinct sums in an interval of length ΣA) is the reusable combinatorial skeleton beneath every sharper anticoncentration estimate for subset sums.",
+    "summary": "We formalize the elementary counting lower bound for Erdős's distinct-subset-sums problem: a distinct-subset-sums set A satisfies 2^|A| ≤ ΣA + 1 (its subset sums are 2^|A| distinct integers in {0,…,ΣA}), and hence the Erdős–Moser bound 2^|A| ≤ |A|·max A + 1, i.e. max A ≥ (2^|A|−1)/|A|. We also supply the matching construction: the powers of two {2^0,…,2^{n−1}} are proven to have distinct subset sums (via Mathlib's Finset.geomSum_injective), attain equality ΣA = 2^n − 1 in the counting bound, and have max element 2^{n−1}, pinning the extremal maximum M(n) into (2^n−1)/n ≤ M(n) ≤ 2^{n−1} (so the conjectural constant c ≤ 1/2). Fully machine-checked, 0 sorries, 0 axioms.",
+    "implications": "**Frames where the difficulty lives.** The counting bound is tight for the powers of two, so distinctness alone yields only max A ≥ (2^|A|−1)/|A| — a factor of |A| short of Erdős's conjectural c·2^|A|. Closing that gap is exactly what the parent's second-moment bound and deeper Fourier-analytic methods attack.\n\n**A clean, reusable elementary core.** The injective-image counting argument (2^|A| distinct sums in an interval of length ΣA) is the reusable combinatorial skeleton beneath every sharper anticoncentration estimate for subset sums.\n\n**A concrete two-sided wall.** exists_extremal_geomSet turns the tightness identity into an actual distinct-subset-sums set of every cardinality n with max 2^{n−1}, so the elementary lower bound (2^n−1)/n and this doubling upper bound 2^{n−1} bracket the true extremal maximum; the conjectural constant c cannot exceed 1/2 by elementary means.",
     "openQuestions": [
-      "Formalize that the powers of two {1,2,…,2^{n−1}} actually have distinct subset sums (binary uniqueness), turning geomSum_two_succ's equality into a genuine extremal example inside HasDistinctSubsetSums.",
       "Combine this counting bound with the parent's second-moment bound to formalize the current best known constant in max A ≥ c·2^|A|/√|A|-type improvements.",
-      "Extend the counting argument to distinct sums over ℤ (signed subset sums) and compare the resulting interval-length constraint."
+      "Extend the counting argument to distinct sums over ℤ (signed subset sums) and compare the resulting interval-length constraint.",
+      "Improve the doubling upper bound 2^{n−1} via the Conway–Guy / Atkinson–Negro–Santoro constructions, which give distinct-subset-sums sets with max A < 0.23·2^n, sharpening the upper wall on c from 1/2 toward the conjectured optimum."
     ]
   }
 }

--- a/src/data/research/problems/erdos-1-oq-02-incomplete-01.json
+++ b/src/data/research/problems/erdos-1-oq-02-incomplete-01.json
@@ -29,11 +29,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: fixed a FALSE axiom (logical unsoundness) and repaired 4 Mathlib-4.26 build breakages in Erdos1OQ02.lean. File now compiles cleanly (verified via host lake env lean against pinned Mathlib 2df2f015/v4.26.0) with exactly 1 (true) axiom and 0 sorries; #print axioms shows no sorryAx.",
+    "progressSummary": "COMPLETED (both parent oq-02 and child oq-01 verified 0-axiom). Session 2026-07-08 added the matching powers-of-two extremal construction to oq-01, resolving its top open question (c ≤ 1/2 two-sided wall). Erdős #1 conjecture (constant-factor c·2^n) itself remains open.",
     "builtItems": [
       "Corrected axiom anticoncentration_bound (Chebyshev form) in Erdos1OQ02.lean",
       "Re-proved dfx_lower_bound: 2ⁿ ≤ 3·√n·N+2 (0 sorries) in Erdos1OQ02.lean",
-      "Repaired Mathlib-4.26 build breakages in sum_sq_le_card_mul_max_sq, sum_sq_cauchy_schwarz, improvement_factor"
+      "Repaired Mathlib-4.26 build breakages in sum_sq_le_card_mul_max_sq, sum_sq_cauchy_schwarz, improvement_factor",
+      "Erdos1OQ02OQ01.lean Section 4: geomSet, twoPow_injective, card_geomSet, mem_geomSet, sum_image_twoPow, geomSet_hasDistinctSubsetSums, sum_geomSet, max'_geomSet, exists_extremal_geomSet (8 thm + 1 def, host-verified 0-axiom/0-sorry)."
     ],
     "insights": [
       "The 'incomplete-01' snapshot (2 sorries, dated 2026-03-30) is obsolete: those sorries were filled long ago. The live file Erdos1OQ02.lean had 0 sorries but a FALSE axiom.",
@@ -41,12 +42,14 @@
       "Replaced with the rigorous Chebyshev anticoncentration bound `2ⁿ ≤ 3·√(Σaᵢ²)+2`, verified true on all test sets incl. the asymptotic extremal (powers of two: 256 ≤ 445).",
       "The file had ALSO broken on the Mathlib 4.26 bump (toolchain v4.26.0): div_le_iff→div_le_iff₀, a simp recursion in sum_sq_le_card_mul_max_sq (Finset.card_eq_sum_ones loop), an nlinarith cast-atom mismatch in sum_sq_cauchy_schwarz (ih not push_cast'd), and omega on the nonlinear n<n*n.",
       "dfx_lower_bound re-derived via Σaᵢ²≤n·N² (sum_sq_le_card_mul_max_sq) → √Q≤√n·N → 2ⁿ≤3·√n·N+2; dropped the now-unnecessary hN/hA_pos hypotheses (the +2 slack covers small n).",
-      "Session 2026-06-30 (researcher-2): AXIOM DISCHARGED. The anticoncentration_bound axiom (2^n ≤ 3√Q+2) is now a proved theorem in Erdos1OQ02.lean (0 axioms / 0 sorries, docker-verified [7744]); gallery entry erdos-1-oq-02 flipped axiomatized→verified. Combine of the prior ingredients: V = 2^n distinct same-parity doubled deviations with ΣV v²=2^n Q; split at ⌈2√Q⌉ — central-interval parity count ≤ L+1, discrete Chebyshev tail (new ℤ-indexed card_mul_le_sum_of_nonneg) ≤ 2^n/4 — gives (3/4)2^n ≤ 2√Q+1 ⇒ 2^n ≤ 3√Q+2. Q≥1 from distinct-subset-sums forcing 0∉A."
+      "Session 2026-06-30 (researcher-2): AXIOM DISCHARGED. The anticoncentration_bound axiom (2^n ≤ 3√Q+2) is now a proved theorem in Erdos1OQ02.lean (0 axioms / 0 sorries, docker-verified [7744]); gallery entry erdos-1-oq-02 flipped axiomatized→verified. Combine of the prior ingredients: V = 2^n distinct same-parity doubled deviations with ΣV v²=2^n Q; split at ⌈2√Q⌉ — central-interval parity count ≤ L+1, discrete Chebyshev tail (new ℤ-indexed card_mul_le_sum_of_nonneg) ≤ 2^n/4 — gives (3/4)2^n ≤ 2√Q+1 ⇒ 2^n ≤ 3√Q+2. Q≥1 from distinct-subset-sums forcing 0∉A.",
+      "Session 2026-07-08 (researcher-4): the claimed problem was phantom-complete (parent erdos-1-oq-02 fully VERIFIED 0-axiom since #31542, child oq-01 since #33160). Looked outward and resolved the child's top open question: the powers-of-two set is now PROVEN to have distinct subset sums, not just an arithmetic tightness identity.",
+      "Distinctness of {2^0,…,2^{n-1}} follows cleanly from Mathlib Finset.geomSum_injective (Colex.lean: I↦∑_{i∈I}n^i injective for n≥2, uniqueness of n-ary expansions) + Finset.subset_image_iff (every subset of an image is an image of an index subset). No from-scratch max-element induction needed."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Discharge anticoncentration_bound via the discrete second-moment route (NO probability theory): (1) prove the identity ∑_{T∈A.powerset}(2·T.sum id − S)² = 2^|A|·Σaᵢ² via off-diagonal membership-toggle cancellation; (2) prove ∑(v_j−c)² ≥ (M³−M)/12 for M distinct integers; combine. See knowledge.md 2026-06-28 (researcher-3) for the full plan.",
-      "Land step (1), the second-moment identity, first as a standalone 0-axiom lemma — it is the crux and self-contained."
+      "The elementary entry oq-01 is now complete both directions (lower counting wall + upper doubling construction). To sharpen the UPPER wall on the constant c below 1/2, formalize a Conway–Guy / Atkinson–Negro–Santoro construction (max A < 0.23·2^n) — this is a genuinely harder, non-elementary construction.",
+      "Cross-problem: exists_extremal_geomSet / geomSet_hasDistinctSubsetSums are reusable witnesses for any other distinct-subset-sums research entry needing an explicit extremal example."
     ],
     "markdown": "# Knowledge Base: erdos-1-oq-02-incomplete-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the elementary distinct-subset-sums entry **erdos-1-oq-02-oq-01** with the matching *upper-bound construction* it was previously missing. The entry already proved the counting **lower** bounds (`2^{|A|} ≤ ΣA + 1` and the Erdős–Moser `max A ≥ (2^{|A|}−1)/|A|`) but only witnessed tightness via an arithmetic identity (`geomSum_two_succ`). This PR proves that the powers-of-two set is a **genuine distinct-subset-sums set**, closing the entry's top open question.

### New results (Section 4, all 0-axiom / 0-sorry)
- `geomSet n := {2^0, …, 2^{n-1}}` — the canonical extremal set
- `geomSet_hasDistinctSubsetSums` — it has distinct subset sums, via Mathlib's `Finset.geomSum_injective` (uniqueness of binary expansions) + `Finset.subset_image_iff`
- `card_geomSet` — `|geomSet n| = n`
- `sum_geomSet` — `Σ = 2^n − 1` (attains **equality** in the counting bound)
- `max'_geomSet` — largest element is exactly `2^{n-1}`
- `exists_extremal_geomSet` — packages these into a **two-sided wall**
  `(2^n − 1)/n ≤ M(n) ≤ 2^{n-1}` on the Erdős extremal maximum, so the
  conjectural constant `c` in `max A ≥ c·2^{|A|}` satisfies `c ≤ 1/2`.

### Verification
Host-verified with `lake env lean` against the pinned Mathlib. `#print axioms exists_extremal_geomSet` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).

File: `proofs/Proofs/Erdos1OQ02OQ01.lean` (118 → 209 lines, 7 → 15 theorems, 1 → 2 defs). Gallery meta + problem knowledge synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)