### PR TITLE
Enrich Gaussian CF ODE: add first-cumulant theorem (κ₁=μ) to mainTheorems

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -137,6 +137,14 @@
       "endLine": 66
     },
     {
+      "name": "gaussianExponent_deriv_zero",
+      "type": "core",
+      "description": "ψ'(0) = iμ: the first cumulant κ₁ = μ (the mean).",
+      "leanType": "(μ σ_sq : ℝ) → deriv (gaussianExponent μ σ_sq) 0 = ↑μ * Complex.I",
+      "startLine": 80,
+      "endLine": 83
+    },
+    {
       "name": "gaussianExponent_deriv2",
       "type": "core",
       "description": "ψ''(t) = −σ² (constant): the second cumulant κ₂ = σ² (the variance).",


### PR DESCRIPTION
Enrichment pass for `central-limit-theorem-oq-01-oq-02-oq-01-oq-03` (quality 94, passes 0).

The entry is already comprehensively enriched, so this is a single curated, non-inflating fix rather than prose accretion.

**Gap:** `mainTheorems` highlighted the second cumulant κ₂=σ² (`gaussianExponent_deriv2`) and the vanishing higher cumulants κ_{≥3}=0 (`gaussianExponent_deriv3`) but omitted the **first cumulant** theorem `gaussianExponent_deriv_zero` (ψ'(0)=iμ, so κ₁=μ). 

**Fix:** Added `gaussianExponent_deriv_zero` to `mainTheorems`, line-anchored to lines 80–83, completing the cumulant trio (κ₁, κ₂, κ_{≥3}=0) that the overview/annotations already narrate.

- meta.json 12.7 → 13.0 KB, well within the 60 KB cap
- verified against `Proofs/CentralLimitTheoremOQ01OQ02OQ01OQ03.lean` (theorem at line 80, deriv-form κ₁ statement)
- JSON validated; `pnpm build` data-generation steps pass