### PR TITLE
audit(abel-ruffini-oq-04-oq-07): correct theoremCount 14→12

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -43,7 +43,7 @@
       "abel-ruffini-oq-04",
       "abel-ruffini-oq-04-oq-03"
     ],
-    "theoremCount": 14,
+    "theoremCount": 12,
     "definitionCount": 4
   },
   "overview": {
@@ -220,7 +220,7 @@
     "namespace": "BringJerrardReduction",
     "lineCount": 377,
     "axiomCount": 2,
-    "theoremCount": 14,
+    "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: abel-ruffini-oq-04-oq-07 (Bring-Jerrard Reduction)
**Problem**: `theoremCount` overstated by 2.

## Evidence

`proofs/Proofs/AbelRuffiniOQ04OQ07.lean` contains:
- **12 theorems**: depressed_quintic_forward/backward/iff, quintic_to_bringJerrard, bringRad_strictMono, bringRad_exists, bringRadical_spec/unique/anti_mono/zero/neg, bringJerrard_summary
- **2 axioms**: bringJerrard_reduction, bringRadical_not_in_radicals
- **4 defs**, **0 sorries**

**meta.json claimed**: `theoremCount: 14` (in both `meta.meta` and `leanFile`) — apparently counting the 2 axioms as theorems.

Per gallery convention (sibling `abel-ruffini-oq-04-oq-03` lists `theoremCount: 8` for 8 theorems + 1 axiom, excluding the axiom), `theoremCount` counts theorems only.

## Fix

Both `theoremCount` occurrences 14 → 12.

## Not changed (all remain accurate)

`status: axiomatized`, `badge: axiom`, `axiomCount: 2`, `sorries: 0`, `definitionCount: 4`, `lineCount: 377`. Both axioms stay disclosed in `assumptions`. No verification claim is affected — this is a structural count correction only.

---
Discovered during gallery integrity audit. Severity: LOW.