### PR TITLE
audit: reconcile stale line/theorem counts on 6 changed entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -18,7 +18,7 @@
     ]
   },
   "conclusion": {
-    "summary": "For all real x, y the entry proves x*y <= ((x+y)/2)^2 — Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — obtained as the nonnegative discriminant of the real-rooted polynomial (X - x)(X - y). The reusable atom 'real-rooted quadratic => nonnegative discriminant' is proved through Mathlib's discrim_eq_sq_of_quadratic_eq_zero and phrased via the Polynomial.roots API. The file then discharges the FULL n = 3 case for arbitrary signed reals: both log-concavity steps e_1^2 >= 3 e_2 and e_2^2 >= 3 e_1 e_3 (and their normalized p-form), each realized as the nonnegative discriminant of a derivative quadratic and certified by an explicit sum-of-squares. Finally, Part III proves the FIRST Newton inequality k = 1 for arbitrary n and signed reals — 2 n e_2 <= (n-1) e_1^2 — from the square-of-sum identity e_1^2 = p_2 + 2 e_2 (sq_sum_eq, a clean induction) together with the QM-AM bound e_1^2 <= n p_2 (Mathlib's sq_sum_le_card_mul_sum_sq), needing no Rolle-iteration lemma. Part IV then discharges ALL THREE Newton steps at n = 4 for signed reals — 8 e_2 <= 3 e_1^2, 9 e_1 e_3 <= 4 e_2^2, and 8 e_2 e_4 <= 3 e_3^2 — via explicit sum-of-squares certificates, reaching the middle (k = 2) and top (k = 3) steps that the general k = 1 route does not cover. All 20 theorems are machine-checked with 0 sorries and 0 axioms (foundational axioms only).",
+    "summary": "For all real x, y the entry proves x*y <= ((x+y)/2)^2 — Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — obtained as the nonnegative discriminant of the real-rooted polynomial (X - x)(X - y). The reusable atom 'real-rooted quadratic => nonnegative discriminant' is proved through Mathlib's discrim_eq_sq_of_quadratic_eq_zero and phrased via the Polynomial.roots API. The file then discharges the FULL n = 3 case for arbitrary signed reals: both log-concavity steps e_1^2 >= 3 e_2 and e_2^2 >= 3 e_1 e_3 (and their normalized p-form), each realized as the nonnegative discriminant of a derivative quadratic and certified by an explicit sum-of-squares. Finally, Part III proves the FIRST Newton inequality k = 1 for arbitrary n and signed reals — 2 n e_2 <= (n-1) e_1^2 — from the square-of-sum identity e_1^2 = p_2 + 2 e_2 (sq_sum_eq, a clean induction) together with the QM-AM bound e_1^2 <= n p_2 (Mathlib's sq_sum_le_card_mul_sum_sq), needing no Rolle-iteration lemma. Part IV then discharges ALL THREE Newton steps at n = 4 for signed reals — 8 e_2 <= 3 e_1^2, 9 e_1 e_3 <= 4 e_2^2, and 8 e_2 e_4 <= 3 e_3^2 — via explicit sum-of-squares certificates, reaching the middle (k = 2) and top (k = 3) steps that the general k = 1 route does not cover. All 37 theorems are machine-checked with 0 sorries and 0 axioms (foundational axioms only).",
     "implications": [
       "Provides a reusable, signed-input building block — 'a real-rooted quadratic has nonnegative discriminant' — that any log-concavity/Newton-inequality development can differentiate down onto, decoupling the arithmetic atom from the (harder) real-rootedness-preservation step.",
       "Demonstrates that the n = 2 and n = 3 Newton inequalities need no positivity hypothesis at all: they are facts about real roots, not about positive numbers, and hence strictly generalize the AM-GM-style statements that assume x_i >= 0.",
@@ -132,8 +132,8 @@
       "Mathlib"
     ],
     "additionalFiles": [],
-    "lineCount": 535,
-    "theoremCount": 26,
+    "lineCount": 960,
+    "theoremCount": 37,
     "definitionCount": 0,
     "axiomCount": 0,
     "sorries": 0
@@ -157,7 +157,7 @@
     "additionalFiles": [],
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 26 theorems verified with 0 sorries and 0 axioms; #print axioms lists only propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Imports Mathlib only.",
+    "assumptions": "None. All 37 theorems verified with 0 sorries and 0 axioms; #print axioms lists only propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Imports Mathlib only.",
     "originalContributions": [
       "discrim_nonneg_of_root: a real quadratic a*x^2 + b*x + c with a real root has 0 <= discrim a b c — the reusable per-derivative 'real-rooted => log-concave coefficients' atom of the Rolle program",
       "monic_quadratic_discrim_nonneg: the same via Polynomial.IsRoot for the monic quadratic X^2 + C b * X + C c",
@@ -180,8 +180,8 @@
       "newton_first_general_normalized: the arbitrary-n first Newton inequality in genuine normalized p-form p_0 * p_2 <= p_1^2 with p_1 = e_1/n and p_2 = e_2/binom(n,2) = e_2/(n(n-1)/2), for every n >= 2 and all signed reals — newton_first_general divided down by the actual Maclaurin binomial normalizations"
     ],
     "dateAdded": "2026-07-04",
-    "lineCount": 535,
-    "theoremCount": 26,
+    "lineCount": 960,
+    "theoremCount": 37,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   }

--- a/src/data/proofs/binary-gcd-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "binary-gcd-oq-01-oq-01-oq-01",
   "title": "Binary GCD: A Matching Ω((log N)²) Total-Cost Lower Bound",
   "slug": "binary-gcd-oq-01-oq-01-oq-01",
-  "description": "Open question OQ-01 of binary-gcd-oq-01-oq-01. The parent supplied the honest total bit-operation cost model binaryGcdCost (each reduction step on the pair (a, b) costs Nat.size a + Nat.size b) and proved the classical O((log N)^2) upper bound; it left open whether that quadratic bound is tight or merely a loose over-estimate. This entry answers it affirmatively in the sharpest possible form: on the diagonal power-of-two family a = b = 2^k the cost is not just bounded below by a quadratic, it is exactly a quadratic — binaryGcdCost (2^k) (2^k) = (k+1)(k+2). Since (2^k, 2^k) is even/even, one step halves both operands at cost 2·size(2^k) = 2(k+1), and iterating over (2^k,2^k), (2^{k-1},2^{k-1}), …, (1,1) pays Σ_{j=0}^{k} 2(j+1) = (k+1)(k+2). As log₂(2^k) = k this gives the matching lower bound (log₂ N)^2 ≤ binaryGcdCost N N for N = 2^k, and combined with the parent's upper bound squeezes the cost on this family into Θ((log N)^2). 6 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "description": "Open question OQ-01 of binary-gcd-oq-01-oq-01. The parent supplied the honest total bit-operation cost model binaryGcdCost (each reduction step on the pair (a, b) costs Nat.size a + Nat.size b) and proved the classical O((log N)^2) upper bound; it left open whether that quadratic bound is tight or merely a loose over-estimate. This entry answers it affirmatively in the sharpest possible form: on the diagonal power-of-two family a = b = 2^k the cost is not just bounded below by a quadratic, it is exactly a quadratic — binaryGcdCost (2^k) (2^k) = (k+1)(k+2). Since (2^k, 2^k) is even/even, one step halves both operands at cost 2·size(2^k) = 2(k+1), and iterating over (2^k,2^k), (2^{k-1},2^{k-1}), …, (1,1) pays Σ_{j=0}^{k} 2(j+1) = (k+1)(k+2). As log₂(2^k) = k this gives the matching lower bound (log₂ N)^2 ≤ binaryGcdCost N N for N = 2^k, and combined with the parent's upper bound squeezes the cost on this family into Θ((log N)^2). 13 theorems, 0 sorries, 0 axioms, no native_decide.",
   "meta": {
     "author": "researcher-5",
     "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
@@ -141,7 +141,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Closes the tightness question left open by binary-gcd-oq-01-oq-01: on the diagonal power-of-two family a = b = 2^k the total bit-operation cost of Stein's Binary GCD is exactly (k+1)(k+2). Since log₂(2^k) = k, this gives the matching lower bound (log₂ N)^2 ≤ binaryGcdCost N N for N = 2^k, and combined with the parent's O((log N)^2) upper bound squeezes the cost into Θ((log N)^2). 6 theorems, 0 axioms, 0 sorries, no native_decide. Part 2 (recovered from draft PR #32737) strengthens the tightness certificate to a coprime family: N = 2^(k+1)-1 against 1 forces the subtract-and-halve branch every step and costs exactly (k+1)(k+4)/2 bit operations, so the quadratic bound is tight for gcd-1 inputs too, not only on the halving diagonal.",
+    "summary": "Closes the tightness question left open by binary-gcd-oq-01-oq-01: on the diagonal power-of-two family a = b = 2^k the total bit-operation cost of Stein's Binary GCD is exactly (k+1)(k+2). Since log₂(2^k) = k, this gives the matching lower bound (log₂ N)^2 ≤ binaryGcdCost N N for N = 2^k, and combined with the parent's O((log N)^2) upper bound squeezes the cost into Θ((log N)^2). 13 theorems, 0 axioms, 0 sorries, no native_decide. Part 2 (recovered from draft PR #32737) strengthens the tightness certificate to a coprime family: N = 2^(k+1)-1 against 1 forces the subtract-and-halve branch every step and costs exactly (k+1)(k+4)/2 bit operations, so the quadratic bound is tight for gcd-1 inputs too, not only on the halving diagonal.",
     "implications": "The parent's quadratic total-cost bound is asymptotically tight, not a loose over-estimate — there is a concrete, natural input family (equal powers of two) on which the O((log N)^2) estimate is achieved to within a constant factor, and in fact realised as an exact quadratic. The single-step-plus-induction pattern (isolate one reduction step as a cost recurrence, then telescope) is reusable for exact cost formulas on any structured input family of a bit-charged recursion.",
     "openQuestions": [
       "The exact leading constant of the worst case over all inputs of a given bit-length, not just the diagonal power-of-two family: is a = b = 2^k the true maximiser of binaryGcdCost among N-bit inputs?",
@@ -161,9 +161,9 @@
       "BinaryGcdOQ01OQ01"
     ],
     "namespace": "BinaryGcdOQ01OQ01OQ01",
-    "lineCount": 157,
+    "lineCount": 289,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 13,
     "substantiveTheoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/BinaryGcdOQ01OQ01OQ01.lean",

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/meta.json
@@ -23,9 +23,9 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 42,
     "definitionCount": 0,
-    "lineCount": 689,
+    "lineCount": 2076,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_range_by_parts",
@@ -90,9 +90,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "LawsOfLargeNumbers.MZ",
-    "lineCount": 689,
+    "lineCount": 2076,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 42,
     "definitionCount": 0,
     "path": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/newton-inductive-step/meta.json
+++ b/src/data/proofs/newton-inductive-step/meta.json
@@ -41,7 +41,7 @@
     ],
     "dateAdded": "2026-03-22",
     "axiomCount": 0,
-    "lineCount": 152,
+    "lineCount": 487,
     "prerequisites": [
       "Binomial coefficients and their properties (absorption identities)",
       "Real arithmetic and polynomial inequalities",
@@ -49,7 +49,7 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 2,
+    "theoremCount": 5,
     "definitionCount": 0
   },
   "overview": {
@@ -156,7 +156,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This module provides a fully verified proof (152 lines, 2 theorems, 0 axioms, 0 sorries) of the key binomial inequality for Newton's log-concavity. The absorption identity technique converts the problem into a clean polynomial identity, verified by linear_combination. It serves as infrastructure for 2 downstream proofs.",
+    "summary": "This module provides a fully verified proof (487 lines, 5 theorems, 0 axioms, 0 sorries) of the key binomial inequality for Newton's log-concavity. The absorption identity technique converts the problem into a clean polynomial identity, verified by linear_combination. It serves as infrastructure for 2 downstream proofs.",
     "implications": "Newton's inequalities and log-concavity of binomial coefficients have deep connections to combinatorics, algebra, and probability. The technique of using absorption identities to reduce binomial coefficient inequalities to polynomial identities is broadly applicable: any inequality involving a fixed number of consecutive binomial coefficients can be handled this way, making it a powerful paradigm for formal verification.",
     "openQuestions": [
       "Formalize the full Newton's inequality e_k^2 >= e_{k-1} * e_{k+1} for elementary symmetric polynomials",
@@ -170,9 +170,9 @@
     ],
     "opens": [],
     "namespace": "",
-    "lineCount": 152,
+    "lineCount": 487,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/NewtonInductiveStep.lean",
     "additionalFiles": [

--- a/src/data/proofs/shannon-channel-coding-bec/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec/meta.json
@@ -41,7 +41,7 @@
     "assumptions": "2 axioms inherited in scope from ShannonChannelCoding.lean: channel_coding_achievability, channel_coding_converse. (The parent's fano_inequality was discharged to a proven theorem via ShannonChannelCodingOQ02OQ01.fano_inequality_proved, and its former bsc_capacity_eq axiom was removed -- the BSC capacity bounds now follow from general capacity theorems and the exact value is proved in ShannonChannelCodingOQ02.) 0 sorries. The BEC capacity result itself is proved from first principles and does not invoke any of these axioms; they are carried in scope because the file imports the parent (and the BSC development in ShannonChannelCodingOQ02). Unlike the BSC, the BEC is not weakly symmetric (its erasure column sums to 2p, the others to 1 - p), so the parent's symmetric-channel machinery does not apply -- the H(X|Y) = p · H(X) identity is the engine instead.",
     "dateAdded": "2026-06-18",
     "axiomCount": 2,
-    "lineCount": 243,
+    "lineCount": 317,
     "prerequisites": [
       "Shannon entropy and mutual information (ShannonEntropy.lean)",
       "Discrete memoryless channels and channel capacity (ShannonChannelCoding.lean)",
@@ -49,7 +49,7 @@
       "Binary entropy function h(p) (ShannonChannelCodingOQ04.lean)"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 1
   },
   "overview": {
@@ -178,11 +178,11 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 243,
+    "lineCount": 317,
     "path": "Proofs/ShannonChannelCodingBEC.lean",
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 12
+    "theoremCount": 14
   },
   "sorries": 0,
   "references": [

--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -2,7 +2,7 @@
   "id": "strong-goldbach-symmetric",
   "title": "Strong Goldbach: Symmetric (Midpoint) Reformulation",
   "slug": "strong-goldbach-symmetric",
-  "description": "A fully verified, axiom-free structural reformulation of the (open) Strong/Binary Goldbach Conjecture. Proves that an even number 2m is a sum of two primes if and only if there is an offset k < m with both m−k and m+k prime — i.e. every Goldbach partition is a pair of primes symmetric about the midpoint n/2. Lifts this to a conjecture-level equivalence StrongGoldbachConjecture ↔ SymmetricGoldbachConjecture, and supplies a decidable instance so any concrete case is machine-checkable by `decide`. Also defines the Goldbach comet counting function (the number of symmetric prime pairs), proves existence ⟺ positive count and recasts the conjecture as a comet-positivity statement, and proves the structural fact that for 2m > 4 both Goldbach summands are odd. Bounds the comet height two complementary ways: a prime-side identity equating it to the number of primes j ∈ [m, 2m) whose complement 2m−j is also prime, and an offset-side ceiling — for m > 2 only offsets k of opposite parity to m contribute, capping the count at ≈ m/2 with no density input. The conjecture itself is NOT proved; only the equivalences, structural facts, and bounds are. 12 theorems, 5 definitions, 1 decidable instance, 0 axioms, 0 sorries.",
+  "description": "A fully verified, axiom-free structural reformulation of the (open) Strong/Binary Goldbach Conjecture. Proves that an even number 2m is a sum of two primes if and only if there is an offset k < m with both m−k and m+k prime — i.e. every Goldbach partition is a pair of primes symmetric about the midpoint n/2. Lifts this to a conjecture-level equivalence StrongGoldbachConjecture ↔ SymmetricGoldbachConjecture, and supplies a decidable instance so any concrete case is machine-checkable by `decide`. Also defines the Goldbach comet counting function (the number of symmetric prime pairs), proves existence ⟺ positive count and recasts the conjecture as a comet-positivity statement, and proves the structural fact that for 2m > 4 both Goldbach summands are odd. Bounds the comet height two complementary ways: a prime-side identity equating it to the number of primes j ∈ [m, 2m) whose complement 2m−j is also prime, and an offset-side ceiling — for m > 2 only offsets k of opposite parity to m contribute, capping the count at ≈ m/2 with no density input. The conjecture itself is NOT proved; only the equivalences, structural facts, and bounds are. 28 theorems, 5 definitions, 1 decidable instance, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-07-02",
@@ -20,8 +20,8 @@
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "assumptions": "None. The file is axiom-free (only the ordinary foundational axioms of Lean/Mathlib are used; `#print axioms` shows no `sorryAx`, no `Lean.ofReduceBool`). All examples use kernel `decide`, not `native_decide`. Note: this file does NOT prove the Strong Goldbach Conjecture, which remains open; it proves only that the conjecture is equivalent to its symmetric-prime-pair form.",
-    "lineCount": 351,
-    "theoremCount": 12,
+    "lineCount": 825,
+    "theoremCount": 28,
     "definitionCount": 5,
     "originalContributions": [
       "sumTwoPrimes_iff_symmetric: for every m, IsSumOfTwoPrimes (2m) ↔ ∃ k < m, Prime (m−k) ∧ Prime (m+k) — the midpoint-symmetry equivalence, valid without any lower bound on m",
@@ -119,9 +119,9 @@
   },
   "leanFile": {
     "namespace": "StrongGoldbach",
-    "lineCount": 351,
+    "lineCount": 825,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 28,
     "definitionCount": 5,
     "path": "Proofs/StrongGoldbachSymmetric.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Reconcile stale `lineCount`/`theoremCount` metadata on 6 gallery entries whose Lean source files grew after their metadata was cached. Follows the convention established by #35568/#35576: **truth = comment-stripped theorem/lemma count + `wc -l` line count**.

## Evidence

Gallery-wide scan (comment-stripping counter, validated exact against known-clean entries erdos-1122 = 208/7/3 and erdos-331 = 234/5/3) found these six with substantial drift. For each, both the `leanFile.*` and top-level `meta.*` count fields plus any count-prose were reconciled to the true source counts:

| Entry | lineCount | theoremCount |
|-------|-----------|--------------|
| laws-of-large-numbers-oq-01-oq-02-oq-01 | 689 → 2076 | 12 → 42 |
| strong-goldbach-symmetric | 351 → 825 | 12 → 28 |
| amgm-inequality-oq-02-oq-02-oq-05 | 535 → 960 | 26 → 37 |
| newton-inductive-step | 152 → 487 | 2 → 5 |
| binary-gcd-oq-01-oq-01-oq-01 | 157 → 289 | 6 → 13 |
| shannon-channel-coding-bec | 243 → 317 | 12 → 14 |

Notes:
- **amgm**: raw `grep` counts 38 but one `theorem` sits inside a docstring; comment-stripped truth is **37** (same over-count class as kepler in #35568). Prose claims of "20 theorems" and "26 theorems" both corrected to 37.
- **shannon**: `axiomCount` left untouched — `meta.axiomCount=2` (structure-scoped assumptions) vs `leanFile.axiomCount=0` (literal `axiom` decls) are both correct per the axiom-integrity policy.
- No `status`/`badge`/`sorry` fields changed. No overclaims found.

## Validation

- All 6 `meta.json` parse as valid JSON.
- `pnpm gallery:check-size` passes (4780 entries within caps).

---
Automated fix by lean-mechanic agent.