### PR TITLE
Enrich ℚ[X] countability: close section line-coverage gaps

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-06/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-06/meta.json
@@ -82,7 +82,7 @@
       "id": "imports-helper",
       "title": "Imports and the Engine Lemma #ℚ = ℵ₀",
       "startLine": 1,
-      "endLine": 31,
+      "endLine": 32,
       "summary": "File docstring positioning ℚ[X] against the sibling cardinal results, imports Mathlib, opens Cardinal and Polynomial. mk_rat records #ℚ = ℵ₀ via Cardinal.mk_eq_aleph0 (ℚ countable and infinite).",
       "mathContext": "#ℚ = ℵ₀ because ℚ is both countable and infinite; this is the input the maximum collapses against."
     },
@@ -90,7 +90,7 @@
       "id": "polynomial-cardinality",
       "title": "Countability of ℚ[X] and ℤ[X]",
       "startLine": 33,
-      "endLine": 44,
+      "endLine": 45,
       "summary": "cardinalMk_polynomial_rat and cardinalMk_polynomial_int: each rewrites #(R[X]) via Polynomial.cardinalMk_eq_max to max #R ℵ₀, substitutes #R = ℵ₀, and finishes with max_self. cardinalMk_polynomial_rat_eq_int records #(ℚ[X]) = #(ℤ[X]).",
       "mathContext": "#(R[X]) = max #R ℵ₀ and #ℚ = #ℤ = ℵ₀, so #(ℚ[X]) = #(ℤ[X]) = max ℵ₀ ℵ₀ = ℵ₀."
     },


### PR DESCRIPTION
Enrichment pass for `denumerability-rationals-oq-06` (quality 94). The entry is already comprehensively enriched, so this is a curated accuracy fix, not prose accretion.

**Gap:** two `sections` entries under-covered the theorems they describe:
- `imports-helper` ended at line 31, but the `mk_rat` theorem it summarizes is at line **32** (orphaned).
- `polynomial-cardinality` ended at line 44, but `cardinalMk_polynomial_rat_eq_int` spans lines 43–**45** (line 45 orphaned).

**Fix:** extended the two `endLine` anchors (31→32, 44→45). Sections now cover lines 1–32, 33–45, 46–56 contiguously with no orphaned theorem lines.

- verified against `Proofs/DenumerabilityRationalsOQ06.lean`
- JSON validated; within size caps