### PR TITLE
Research: erdos-1098-oq-01-oq-03 - localize Neumann's axiom to a finite-index core

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -40,6 +40,11 @@ the size of every clique", i.e. ω(Γ(G)) finite) and prove the full equivalence
   `G`, and their intersection `H = ⋂ₐ C_G(a)` is a finite-index subgroup. This isolates the
   finite-index "core" `H` that Neumann's argument analyses (still strictly weaker than the hard
   direction, which needs `Z(G)` — the intersection over *all* of `G` — to have finite index).
+* `center_finiteIndex_iff_relIndex_core` — **(fully proved, new)** localizes the residual
+  gap: if ω(Γ(G)) is finite then `[G:Z(G)]` is finite *iff* `Z(G)` has finite index inside
+  the explicit finite-index core `H = ⋂ₐ C_G(a)` (which contains `Z(G)`). The remaining hard
+  content is thus confined to the single relative index `(center G).relIndex H`; the natural
+  Mathlib endgame is `Subgroup.index_center_le_pow`, gated on `Finite (commutatorSet G)`.
 * `neumann_hard_direction` — **(axiom, Neumann 1976)** if ω(Γ(G)) is finite then
   `[G:Z(G)]` is finite. This is the deep content of Erdős #1098.
 * `neumann_full_theorem` — the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite.
@@ -290,6 +295,55 @@ theorem exists_finiteIndex_iInf_centralizer_of_boundedCliques (h : BoundedClique
   · -- The intersection of finitely many finite-index subgroups has finite index.
     exact (Subgroup.finiteIndex_iInf' (fun a => Subgroup.centralizer {a})
       (fun a ha => (Finset.mem_filter.mp ha).2)).index_ne_zero
+
+/-- The centre lies in the centralizer of any single element: a central `z`
+    commutes with everything, in particular with `a`. -/
+theorem center_le_centralizer_singleton (a : G) :
+    Subgroup.center G ≤ Subgroup.centralizer {a} := by
+  intro z hz
+  rw [Subgroup.mem_centralizer_singleton_iff]
+  exact (Subgroup.mem_center_iff.mp hz a).symm
+
+/-- **(New, fully proved — localizes the residual gap to a finite-index core.)**
+    If ω(Γ(G)) is finite, then there is a *finite-index* subgroup
+    `H = ⋂_{a ∈ T} C_G(a)` (centralizing a maximal clique `T`) with `Z(G) ≤ H`,
+    such that
+
+    > `[G : Z(G)]` is finite  ⟺  `Z(G)` has finite index **within `H`**.
+
+    *Proof.* Take the finite-index core `H` from
+    `exists_finiteIndex_iInf_centralizer_of_boundedCliques`. Since `Z(G)` commutes
+    with everything it lies in every `C_G(a)`, hence `Z(G) ≤ H`. The index tower
+    `[G : Z(G)] = [H : Z(G)] · [G : H]` (`Subgroup.relIndex_mul_index`) with the
+    finite factor `[G : H] ≠ 0` makes `[G : Z(G)] ≠ 0` equivalent to
+    `[H : Z(G)] ≠ 0`.
+
+    This does **not** remove `neumann_hard_direction`: the relative index
+    `(center G).relIndex H` is exactly the quantity that remains to be bounded, and
+    bounding it is still the deep BFC content of Neumann's theorem. What the lemma
+    *does* achieve is to confine that content to a single, explicit finite-index
+    subgroup `H` that centralizes a maximal clique — Neumann's remaining work is now
+    entirely *inside* `H`, not spread over all of `G`. The natural Mathlib endgame is
+    `Subgroup.index_center_le_pow` (finite `commutatorSet` ⟹ finite-index centre),
+    whose hypothesis `Finite (commutatorSet G)` is the BFC statement that bounded
+    cliques must still be shown to imply. -/
+theorem center_finiteIndex_iff_relIndex_core (h : BoundedCliques G) :
+    ∃ H : Subgroup G, H.index ≠ 0 ∧ Subgroup.center G ≤ H ∧
+      ((Subgroup.center G).index ≠ 0 ↔ (Subgroup.center G).relIndex H ≠ 0) := by
+  obtain ⟨T, _, _, hHidx⟩ := exists_finiteIndex_iInf_centralizer_of_boundedCliques h
+  set H := ⨅ a ∈ T, Subgroup.centralizer {a} with hHdef
+  have hle : Subgroup.center G ≤ H :=
+    le_iInf₂ (fun a _ => center_le_centralizer_singleton a)
+  refine ⟨H, hHidx, hle, ?_⟩
+  -- Index tower: `[H : Z(G)] · [G : H] = [G : Z(G)]`.
+  have hmul := Subgroup.relIndex_mul_index hle
+  constructor
+  · intro hz hr
+    rw [hr, zero_mul] at hmul
+    exact hz hmul.symm
+  · intro hr
+    rw [← hmul]
+    exact mul_ne_zero hr hHidx
 
 -- ============================================================
 -- SECTION IV: Hard direction — Neumann's theorem (axiom)

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -33,10 +33,11 @@
       "bounded_cliques_of_finite_index: finite centre index ⟹ ω(Γ(G)) finite with explicit bound",
       "exists_clique_centralizer_cover: ω(Γ(G)) finite ⟹ a single maximal clique's centralizers cover G (first proved step of Neumann's hard direction)",
       "exists_finiteIndex_centralizer_of_boundedCliques: ω(Γ(G)) finite ⟹ some centralizer C_G(a) has finite index, via Mathlib's CosetCover (B. H. Neumann's coset-covering theorem)",
-      "neumann_full_theorem: the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite"
+      "neumann_full_theorem: the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite",
+      "center_finiteIndex_iff_relIndex_core: ω(Γ(G)) finite ⟹ [G:Z(G)] finite iff Z(G) has finite index within the explicit finite-index core H = ⋂ₐ C_G(a); localizes the residual axiom to (center G).relIndex H, whose Mathlib endgame is Subgroup.index_center_le_pow gated on Finite (commutatorSet G)"
     ],
-    "lineCount": 337,
-    "theoremCount": 10,
+    "lineCount": 391,
+    "theoremCount": 12,
     "defCount": 3,
     "definitionCount": 3
   },
@@ -138,12 +139,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 337,
+    "lineCount": 391,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 10
+    "theoremCount": 12
   },
   "sorries": 0
 }

--- a/src/data/research/problems/erdos-1098-oq-01-oq-03.json
+++ b/src/data/research/problems/erdos-1098-oq-01-oq-03.json
@@ -38,25 +38,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Proved the elementary half of Neumann's theorem with the sharp bound ω ≤ [G:Z(G)] by injecting cliques into the central quotient G/Z(G); axiomatized Neumann's deep converse with citation.",
+    "progressSummary": "PROGRESS: Added center_finiteIndex_iff_relIndex_core — localizes Neumann axiom to Z(G) finite index within an explicit finite-index core H=⋂ₐC_G(a); identified Mathlib Subgroup.index_center_le_pow as the Schur-side endgame (gated on Finite commutatorSet = BFC content). Axiom unchanged (1); build green; 2 new verified theorems.",
     "builtItems": [
       "commuting_of_invMul_mem_center",
       "nonCommuting_distinct_image",
       "clique_inj_on_quotient",
       "clique_card_le_index",
       "bounded_cliques_of_finite_index",
-      "neumann_full_theorem"
+      "neumann_full_theorem",
+      "center_le_centralizer_singleton",
+      "center_finiteIndex_iff_relIndex_core"
     ],
     "insights": [
       "Mathlib's index = 0 convention makes 'finite index' the clean hypothesis index ≠ 0",
       "QuotientGroup.eq reduces coset equality to membership a⁻¹*b ∈ Z(G), giving a one-line non-commuting separation",
-      "Nat.card_pos_iff turns finite index into a Finite quotient instance, the only ingredient needed for the cardinality bound"
+      "Nat.card_pos_iff turns finite index into a Finite quotient instance, the only ingredient needed for the cardinality bound",
+      "Neumann axiom localizes: [G:Z(G)] finite ⟺ Z(G) finite index within the finite-index core H = ⋂ₐ C_G(a) (Z(G) ≤ H since central elts commute with all a; index tower relIndex_mul_index). Residual gap = bound (center G).relIndex H.",
+      "Mathlib Schur endgame is Subgroup.index_center_le_pow / finiteIndex_center (Commutator/Finite.lean): Finite (commutatorSet G) [+ Group.FG] ⟹ (center G) finite index. Hypothesis Finite (commutatorSet G) from bounded cliques is itself the BFC content (equally hard), so it does not eliminate the axiom."
     ],
     "mathlibGaps": [
       "No formalization of B. H. Neumann's BFC theorem (bounded non-commuting sets ⟹ finite centre index)"
     ],
     "nextSteps": [
-      "Attempt Neumann's covering argument to remove the axiom"
+      "Attempt bounded cliques ⟹ Finite (commutatorSet G) (BFC), then chain Mathlib Subgroup.index_center_le_pow to remove neumann_hard_direction — this is the deep Neumann 1976 content",
+      "Alternatively bound (center G).relIndex H directly within the finite-index core H that centralizes a maximal clique"
     ],
     "markdown": "# Knowledge Base: erdos-1098-oq-01-oq-03\n\n## Problem Understanding\n\nNeumann's theorem (Erdős #1098): ω(Γ(G)) finite ⟺ [G:Z(G)] finite.\n\n## Insights\n\n- Reverse direction is elementary and sharp: ω ≤ [G:Z(G)] via injectivity of G → G/Z(G) on cliques.\n- Forward direction is Neumann (1976), a BFC/covering argument, axiomatized.\n\n## Dead Ends\n\n- Direct formalization of Neumann's covering argument is out of reach in one session.\n"
   },


### PR DESCRIPTION
## Summary
Research session on **erdos-1098-oq-01-oq-03** (Neumann's theorem: ω(Γ(G)) finite ⟺ [G:Z(G)] finite). The easy direction was already fully proved with the sharp bound ω ≤ [G:Z(G)], and three steps of the hard direction were machine-checked, leaving the deep BFC step as the axiom `neumann_hard_direction`. This session adds a genuine structural reduction that **localizes** the remaining axiom content, and pins down the exact Mathlib endgame.

## Progress
- **`center_le_centralizer_singleton`** (verified): `Z(G) ≤ C_G(a)` for any `a` — a central element commutes with everything.
- **`center_finiteIndex_iff_relIndex_core`** (verified): if ω(Γ(G)) is finite then `[G:Z(G)]` is finite **iff** `Z(G)` has finite index *within* the explicit finite-index core `H = ⋂ₐ C_G(a)` (which centralizes a maximal clique and contains `Z(G)`). Proof uses the index tower `Subgroup.relIndex_mul_index` and the finite-index core from `exists_finiteIndex_iInf_centralizer_of_boundedCliques`.
- Identified the Mathlib endgame: `Subgroup.index_center_le_pow` / `finiteIndex_center` (`Mathlib/GroupTheory/Commutator/Finite.lean`) gives finite-index centre from `Finite (commutatorSet G)`.

## Findings
- The residual difficulty is now confined to a single quantity, `(center G).relIndex H`, inside an explicit finite-index subgroup that centralizes a maximal clique — rather than being spread over all of `G`.
- **Honest limitation:** this does **not** remove the axiom. The Mathlib Schur-side hook `index_center_le_pow` needs `Finite (commutatorSet G)`, and establishing that from bounded cliques is itself the BFC content of Neumann's theorem (equally hard). So the axiom count is unchanged (1).

## Files modified
- `proofs/Proofs/Erdos1098OQ01OQ03.lean` (+2 verified theorems, docstring)
- `src/data/proofs/erdos-1098-oq-01-oq-03/meta.json` (theoremCount 10→12, lineCount 337→391, +originalContribution)
- `src/data/research/problems/erdos-1098-oq-01-oq-03.json` (insights, nextSteps)

## Build
Docker build green: `Built Proofs.Erdos1098OQ01OQ03 (3059 jobs)`. 0 sorries, 1 axiom (`neumann_hard_direction`, Neumann 1976), status: axiomatized.

## Status
**Outcome**: progress (structural reduction; axiom unchanged)
**Next Steps**: prove `BoundedCliques G ⟹ Finite (commutatorSet G)` (BFC), then chain `Subgroup.index_center_le_pow` to eliminate the axiom; or bound `(center G).relIndex H` directly within the core.

🤖 Generated by researcher-10