### PR TITLE
research(dirichlets-theorem-oq-02-oq-03): primorial tower C k ≤ B k for all k [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -407,4 +407,65 @@ tower: `4k + 3 ≤ p3 k ≤ C k`, a strictly tighter ceiling than `p3_bracketed`
 theorem p3_bracketed_primorial (k : ℕ) : 4 * k + 3 ≤ p3 k ∧ p3 k ≤ C k :=
   ⟨p3_ge_linear k, p3_le_primorialTower k⟩
 
+/-! ### The primorial tower never exceeds the factorial tower
+
+The worked values suggested `C k` is dramatically smaller than `B k` (`C 1 = 11`
+vs `B 1 = 95`; `C 2 = 131` vs `B 2 = 4·96! − 1`).  We now upgrade this from the
+two verified instances `k = 1, 2` to a **theorem for all `k`**: `C k ≤ B k`.
+
+The heart of the argument is the multiplicative gap between the two one-step maps.
+Writing `t = towerProd (k+1) = ∏_{i≤k} C i`, the primorial step gives
+`C (k+1) = 4·t − 1`, whereas the factorial step gives `B (k+1) = 4·(B k + 1)! − 1`.
+So `C (k+1) ≤ B (k+1)` reduces to the single inequality
+
+    towerProd (k+1) ≤ (B k + 1)!.
+
+Inductively `towerProd (k+1) = towerProd k · (4·towerProd k − 1) ≤ 4·m²` with
+`m = (B (k−1) + 1)! ≥ towerProd k`, and `4·m² ≤ (4m)! = (B k + 1)!` because a
+factorial dominates the square of its argument (`sq_le_factorial`).  The factorial
+tower's extra `(·)!` at every level therefore swallows the primorial's squaring,
+keeping `C` below `B` uniformly. -/
+
+/-- A factorial dominates the square of its argument once `n ≥ 4`: `n·n ≤ n!`.
+(`4·4 = 16 ≤ 24 = 4!`, and the gap only widens.) -/
+theorem sq_le_factorial : ∀ n : ℕ, 4 ≤ n → n * n ≤ n ! := by
+  intro n hn
+  induction n, hn using Nat.le_induction with
+  | base => decide
+  | succ n hn ih =>
+    rw [Nat.factorial_succ]
+    have h1 : n + 1 ≤ n ! := le_trans (by nlinarith [hn]) ih
+    exact Nat.mul_le_mul (le_refl (n + 1)) h1
+
+/-- **The reduction inequality.**  `towerProd (k+1) = ∏_{i≤k} C i ≤ (B k + 1)!`.
+This is exactly what makes the primorial step stay below the factorial step:
+`C (k+1) = 4·towerProd (k+1) − 1 ≤ 4·(B k + 1)! − 1 = B (k+1)`.  Proved by
+induction; the step bounds `towerProd (k+2) ≤ 4·((B k + 1)!)² ≤ (4·(B k + 1)!)!
+= (B (k+1) + 1)!` via `sq_le_factorial`. -/
+theorem towerProd_succ_le_factorial (k : ℕ) : towerProd (k + 1) ≤ (B k + 1)! := by
+  induction k with
+  | zero => decide
+  | succ k ih =>
+    have hm1 : 1 ≤ (B k + 1)! := Nat.factorial_pos _
+    have hBsucc : B (k + 1) + 1 = 4 * (B k + 1)! := by rw [B_succ]; omega
+    have hsq := sq_le_factorial (4 * (B k + 1)!) (by omega)
+    calc towerProd (k + 1 + 1)
+          = towerProd (k + 1) * (4 * towerProd (k + 1) - 1) := towerProd_succ (k + 1)
+      _ ≤ (B k + 1)! * (4 * (B k + 1)!) := Nat.mul_le_mul ih (by omega)
+      _ ≤ (4 * (B k + 1)!) * (4 * (B k + 1)!) := Nat.mul_le_mul (by omega) (le_refl _)
+      _ ≤ (4 * (B k + 1)!)! := hsq
+      _ = (B (k + 1) + 1)! := by rw [hBsucc]
+
+/-- **The primorial tower never exceeds the factorial tower: `C k ≤ B k` for all `k`.**
+Upgrades the two verified instances (`primorial_tighter_than_factorial`, `k = 1`;
+`C_two_eq` vs `B 2`) to a uniform theorem.  Both towers certify the same bound
+`p3 k ≤ B k, C k`, but `C` — replacing the running factorial by the running
+primorial — is always the tighter certificate.  `native_decide`-free. -/
+theorem C_le_B (k : ℕ) : C k ≤ B k := by
+  cases k with
+  | zero => decide
+  | succ k =>
+    have h := towerProd_succ_le_factorial k
+    rw [C_eq, B_succ]; omega
+
 end DirichletsTheoremOQ02OQ03

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): added the sharper PRIMORIAL certified bound p3 k ≤ 4·(∏_{i<k} p3 i) − 1 and its explicit tower C (C1=11 vs B1=95, C2=131 vs B2=4·96!−1), strictly tighter than the iterated-factorial tower while remaining honest against p_k∼2k·ln k. native_decide-free, 0 axioms, 0 sorries.",
+    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): C_le_B now proves the primorial tower C k ≤ B k for ALL k (previously only the instances k=1,2 were checked), making the primorial certificate provably at least as tight as the factorial tower everywhere. Reduction lemma towerProd_succ_le_factorial + reusable n²≤n! (n≥4). 0 axioms, 0 sorries, native_decide-free (propext/Classical.choice/Quot.sound only).",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
@@ -38,7 +38,10 @@
       "p3_one=7, B_one=95, tower_loose_at_one (DirichletsTheoremOQ02OQ03.lean:209–229) — worked values quantifying looseness. Verified 0 sorry / 0 axiom, 7743 jobs.",
       "p3_le_primorial (DirichletsTheoremOQ02OQ03.lean) — primorial bound p3 k ≤ 4·(∏_{i<k} p3 i) − 1, the certified content of the primorial Euclid construction.",
       "towerProd + C + towerProd_eq_prod + p3_le_primorialTower — explicit primorial tower C with p3 k ≤ C k (strong induction).",
-      "C_one_eq=11, C_two_eq=131, primorial_tighter_than_factorial (7≤11=C1<95=B1), p3_bracketed_primorial (4k+3 ≤ p3 k ≤ C k). All 0 sorry / 0 axiom (foundational trio only), native_decide-free."
+      "C_one_eq=11, C_two_eq=131, primorial_tighter_than_factorial (7≤11=C1<95=B1), p3_bracketed_primorial (4k+3 ≤ p3 k ≤ C k). All 0 sorry / 0 axiom (foundational trio only), native_decide-free.",
+      "C_le_B (DirichletsTheoremOQ02OQ03.lean §\"primorial tower never exceeds factorial tower\") — VERIFIED 0/0 (propext/Classical.choice/Quot.sound only): the primorial tower C k ≤ B k for ALL k, upgrading the two verified instances (k=1: 11≤95; k=2: 131 vs 4·96!−1) to a uniform theorem. Reduces to towerProd_succ_le_factorial via the one-step maps.",
+      "towerProd_succ_le_factorial — the reduction inequality towerProd (k+1) = ∏_{i≤k} C i ≤ (B k + 1)!, which is exactly C (k+1) ≤ B (k+1). Proved by induction; step bounds towerProd (k+2) ≤ 4·((B k+1)!)² ≤ (4·(B k+1)!)! = (B (k+1)+1)!.",
+      "sq_le_factorial — reusable: n·n ≤ n! for n ≥ 4 (Nat.le_induction from 16≤24; step (n+1)² ≤ (n+1)·n! since n+1 ≤ n! ). This is the engine that lets the factorial tower swallow the primorial's squaring."
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
@@ -47,13 +50,14 @@
       "The whole development is native_decide-free: the only numeric fact (B 1 = 95) is discharged by kernel decide, so axiomCount stays 0 (verified, not axiomatized).",
       "The Euclid ≡3(mod4) construction only needs the PRODUCT of the primes found so far, not a factorial of the previous bound: N=4·(∏_{i<k}p3 i)−1 is ≡3 mod4, its ≡3-mod4 prime factor p cannot divide ∏p3 i (else p∣4·∏ and p∣N ⇒ p∣1), so p is new and p3 k ≤ p ≤ N. This gives the PRIMORIAL bound p3 k ≤ 4·∏_{i<k}p3 i − 1, dramatically tighter than the factorial tower.",
       "The primorial tower C(k)=4·(∏_{i<k}C i)−1 (C0=3,C1=11,C2=131,C3=17291) is doubly-exponential but incomparably smaller than the iterated-factorial tower B (B2=4·96!−1). p3 k ≤ C k follows by STRONG induction feeding p3_le_primorial the pointwise p3 i ≤ C i for i<k via Finset.prod_le_prod.",
-      "Structural-recursion trick for a product-defined tower: define the running product towerProd k (towerProd 0=1, towerProd(k+1)=towerProd k·(4·towerProd k−1)) structurally, set C k := 4·towerProd k−1, then prove towerProd k = ∏_{i<k} C i by induction (prod_range_succ). Avoids non-structural self-reference of C."
+      "Structural-recursion trick for a product-defined tower: define the running product towerProd k (towerProd 0=1, towerProd(k+1)=towerProd k·(4·towerProd k−1)) structurally, set C k := 4·towerProd k−1, then prove towerProd k = ∏_{i<k} C i by induction (prod_range_succ). Avoids non-structural self-reference of C.",
+      "The factorial tower B and primorial tower C differ only in their one-step map (4·(prev+1)!−1 vs 4·prev−1). C k ≤ B k holds uniformly because the extra factorial at every level dominates the squaring the primorial recursion introduces: towerProd(k+2) ≈ 4·towerProd(k+1)² while (B(k+1)+1)! = (4·(B k+1)!)! ≥ (4·(B k+1)!)² ≥ that. Formalised via the elementary lemma n² ≤ n! (n≥4)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove the primorial tower never exceeds the factorial tower in general: C k ≤ B k (needs ∏_{i<k} C i ≤ (B(k-1)+1)!), making the tightness a theorem for all k rather than just k=1,2.",
       "Attempt a genuinely elementary sub-exponential certified bound (or prove the primorial tower's doubly-exponential growth is intrinsic to Euclid-style iteration without an analytic input).",
-      "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1)."
+      "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1).",
+      "Strengthen C_le_B to strict C k < B k for k ≥ 1 (already have C 1 < B 1; the ≤-chain has slack at every step so a strict version should go through)."
     ],
     "markdown": "# Knowledge Base: dirichlets-theorem-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Upgrades the primorial-tower tightness in `DirichletsTheoremOQ02OQ03.lean` from the two previously-verified numeric instances (`k=1`: `C 1 = 11 ≤ 95 = B 1`; `k=2`: `C 2 = 131` vs `B 2 = 4·96!−1`) to a **uniform theorem for all k**:

```lean
theorem C_le_B (k : ℕ) : C k ≤ B k
```

So the primorial certificate `C` for the growth of the `k`-th prime `≡ 3 (mod 4)` is provably at least as tight as the iterated-factorial tower `B` **at every level**, not just the two checked cases. This closes the file's first listed next-step.

## How

The two towers differ only in their one-step map (`4·(prev+1)!−1` for `B` vs `4·prev−1` for the running primorial `C`). `C (k+1) ≤ B (k+1)` reduces to a single inequality on the running product:

- **`towerProd_succ_le_factorial`** : `towerProd (k+1) = ∏_{i≤k} C i ≤ (B k + 1)!`. Induction; the step bounds `towerProd (k+2) ≤ 4·((B k+1)!)² ≤ (4·(B k+1)!)! = (B (k+1)+1)!`.
- **`sq_le_factorial`** (reusable) : `n·n ≤ n!` for `n ≥ 4`. This is the engine — the factorial tower's extra `(·)!` at every level swallows the squaring the primorial recursion introduces.

## Verification

- Host-built with `lake env lean`: **0 errors, 0 sorries**.
- `#print axioms C_le_B` → `[propext, Classical.choice, Quot.sound]` — foundational-only, **native_decide-free** (no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)