### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02): bridge kronecker2 to Mathlib χ₈ [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -274,6 +274,20 @@ theorem kronecker2_sq_odd (a : ℤ) (ha : a % 2 = 1) :
     kronecker2 a * kronecker2 a = 1 := by
   rw [kronecker2_sq, if_neg (by omega)]
 
+/-- **The local `(·/2)` symbol is Mathlib's canonical quadratic character mod 8.**
+    `kronecker2 a = χ₈ a` for every integer `a`. The extra `a % 8 = -1` disjunct in
+    the local definition is vacuous (`Int.emod` by `8` lands in `[0,8)`), so the two
+    branch conditions agree. This bridge exports all of Mathlib's `χ₈`/`jacobiSym`
+    theory (e.g. `jacobiSym.at_two`, the second supplementary law) to the local
+    development, and conversely certifies the hand-rolled definition against the
+    library — the natural entry point for the Gauss-sum route to generalized
+    reciprocity (Target 2). -/
+theorem kronecker2_eq_χ₈ (a : ℤ) : kronecker2 a = ZMod.χ₈ (a : ZMod 8) := by
+  rw [ZMod.χ₈_int_eq_if_mod_eight]
+  unfold kronecker2
+  have h8 : 0 ≤ a % 8 := Int.emod_nonneg a (by norm_num)
+  split_ifs <;> omega
+
 /-- The Kronecker symbol is completely multiplicative in the first argument:
     (ab/n) = (a/n)(b/n), provided a*b ≠ 0.
 

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 561,
+    "lineCount": 575,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 36,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -36,7 +36,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Target 1 (full second-argument multiplicativity) proven and machine-verified; file builds 0 sorries / 0 axioms under Mathlib v4.26. This session (researcher-3) adds the missing companion to kroneckerNeg1_mul/kronecker0_mul: kronecker2_mul — the (·/2) mod-8 character is completely multiplicative, (ab/2)=(a/2)(b/2), UNCONDITIONALLY (a zero factor makes both sides 0). Proved by reducing kronecker2 to a function of x%8 (Int.emod_emod_of_dvd) and Int.mul_emod, then a 64-case interval_cases/decide over the residue pairs. This is exactly the 2-adic building block nextStep 1 needs to refine kronecker to route even moduli through kronecker2 (classical symbol) rather than jacobiSym|n|. [2026-07-08 researcher-2] Added kronecker2 structural lemmas to ElementaryQuadraticReciprocityOQ03OQ02.lean: kronecker2_neg (the (·/2) symbol is an EVEN Dirichlet character mod 8, (−a/2)=(a/2)) and kronecker2_values (∈{−1,0,1}). Both build-verified (3058 jobs, 0 sorry/0 axiom). Complements kronecker2_mul + kronecker2_periodic toward the Gauss-sum identification of (·/2) as the even real character mod 8.",
+    "progressSummary": "PROGRESS (WIP, still open): (·/2) mod-8 character now certified equal to Mathlib's ZMod.χ₈ (kronecker2_eq_χ₈, 0/0). Character theory complete AND library-bridged; remaining open work is Target 2 (generalized reciprocity for fundamental discriminants via Gauss sums) and the even-modulus refinement of the full kronecker symbol.",
     "builtItems": [
       "kronecker2_periodic (ElementaryQuadraticReciprocityOQ03OQ02.lean): (a+8/2)=(a/2), period-8 of the (·/2) character; with kronecker2_mul this makes kronecker2 a Dirichlet character mod 8 (foundation for the Gauss-sum route to Target 2).",
       "kronecker2_mul (ElementaryQuadraticReciprocityOQ03OQ02.lean): (ab/2)=(a/2)(b/2) unconditional multiplicativity of the (·/2) mod-8 character, via x%8 reduction + 64-case decide.",
@@ -47,7 +47,8 @@
       "kronecker_eq_sign_jacobi",
       "kroneckerNeg1_sq (private)",
       "kronecker_mul_right (full, all nonzero moduli)",
-      "kronecker2_sq / kronecker2_sq_odd (ElementaryQuadraticReciprocityOQ03OQ02.lean, VERIFIED 0/0): the (·/2) character is REAL — its square is the principal character mod 2 ((a/2)²=0 on evens, =1 on odds); completes the even-real-Dirichlet-character-mod-8 identification alongside kronecker2_mul/_periodic/_neg/_values."
+      "kronecker2_sq / kronecker2_sq_odd (ElementaryQuadraticReciprocityOQ03OQ02.lean, VERIFIED 0/0): the (·/2) character is REAL — its square is the principal character mod 2 ((a/2)²=0 on evens, =1 on odds); completes the even-real-Dirichlet-character-mod-8 identification alongside kronecker2_mul/_periodic/_neg/_values.",
+      "kronecker2_eq_χ₈ (ElementaryQuadraticReciprocityOQ03OQ02.lean, VERIFIED 0/0): the local (·/2) mod-8 character equals Mathlib's canonical ZMod.χ₈. Proof: rw [ZMod.χ₈_int_eq_if_mod_eight]; unfold kronecker2; split_ifs <;> omega — the local def's extra 'a%8=-1' disjunct is vacuous since Int.emod by 8 is nonnegative."
     ],
     "insights": [
       "For odd positive moduli the Kronecker symbol IS the Jacobi symbol (kronecker_eq_jacobi), so mul-in-n and QR come for free from jacobiSym.mul_right' and jacobiSym.quadratic_reciprocity.",
@@ -60,13 +61,15 @@
       "Normal-form trick: with three DIFFERENT moduli (m*n, m, n) a direct split_ifs on the kronecker branches explodes; collapse each to sign(n)*J(a||n|) via kronecker_eq_sign_jacobi first, then remaining case work is purely about signs.",
       "Sign multiplicativity across a nonzero product: only the m<0,n<0 case is nontrivial (m*n>0), where the two sign chars cancel via kroneckerNeg1_sq (a value in {+-1} squares to 1).",
       "SCOPE/HONESTY: at even moduli this file's kronecker equals Jacobi's value at 2, NOT the classical mod-8 kronecker2 (defined but never wired into kronecker). So kronecker_mul_right is multiplicativity of the symbol AS DEFINED (matches the classical Kronecker symbol at all odd moduli and at n=+-1). Kept status wip.",
-      "BUILD: local Docker build SIGSEGVs (exit 135/139) on the #print axioms commands (stack overflow); origin/main replays its cached olean so the crash only surfaces after editing. Commented the block out; file then builds in ~2s."
+      "BUILD: local Docker build SIGSEGVs (exit 135/139) on the #print axioms commands (stack overflow); origin/main replays its cached olean so the crash only surfaces after editing. Commented the block out; file then builds in ~2s.",
+      "Session 2026-07-08 (researcher-4): Mathlib ALREADY has the (·/2) character as ZMod.χ₈ with a matching if-then-else value lemma χ₈_int_eq_if_mod_eight and the bridge jacobiSym.at_two : J(2|b)=χ₈ b (odd b). So the local kronecker2 character theory (mul/periodic/neg/values/sq) is now certified equal to χ₈, and Target-2 Gauss-sum work can lean on Mathlib's χ₈/jacobiSym API instead of re-deriving it."
     ],
     "mathlibGaps": [
       "No Kronecker symbol in Mathlib (only jacobiSym for odd positive denominators).",
       "No supplementary-law lemmas connecting (2/n)/(-1/n) to the odd part for a generalized reciprocity."
     ],
     "nextSteps": [
+      "Use kronecker2_eq_χ₈ + jacobiSym.at_two to re-express kronecker at even moduli through χ₈ (the 2-adic refinement of nextStep 'route even moduli through kronecker2'), then re-prove kronecker_mul_right for the refined definition without re-deriving χ₈ multiplicativity.",
       "Refine kronecker to use kronecker2 for the 2-adic part (classical symbol at even moduli), then re-prove kronecker_mul_right for the refined definition.",
       "Target 2: generalized quadratic reciprocity for arbitrary fundamental discriminants (supplementary laws + Gauss sums)."
     ]


### PR DESCRIPTION
## Summary

Adds a single verified lemma to the Kronecker-symbol WIP that **certifies the hand-rolled `(·/2)` character against Mathlib** and unlocks the library's quadratic-character API for the remaining Gauss-sum work.

### New result
`kronecker2_eq_χ₈ (a : ℤ) : kronecker2 a = ZMod.χ₈ (a : ZMod 8)`

The local `kronecker2` is defined by `if a%8 = 1 ∨ a%8 = -1 ∨ a%8 = 7 then 1 else -1` (for odd `a`); Mathlib's `ZMod.χ₈_int_eq_if_mod_eight` gives the same table with `a%8 = 1 ∨ a%8 = 7`. Since `Int.emod` by `8` is nonnegative, the extra `a%8 = -1` disjunct is vacuous and the two agree. Proof:
```lean
rw [ZMod.χ₈_int_eq_if_mod_eight]; unfold kronecker2
have h8 : 0 ≤ a % 8 := Int.emod_nonneg a (by norm_num)
split_ifs <;> omega
```

### Why it matters
The entry had already established `kronecker2` as an even real Dirichlet character mod 8 (`_mul`, `_periodic`, `_neg`, `_values`, `_sq`). This identifies it with the canonical `χ₈`, so all of Mathlib's `χ₈`/`jacobiSym` theory (notably `jacobiSym.at_two : J(2 | b) = χ₈ b` for odd `b`, the second supplementary law) becomes directly available — the natural entry point for the Gauss-sum route to generalized reciprocity (the entry's Target 2, still open).

### Verification
Host-verified with `lake env lean` against pinned Mathlib. 0 sorry / 0 axiom. File `ElementaryQuadraticReciprocityOQ03OQ02.lean` 561 → 575 lines. Problem remains an in-progress WIP (Target 2 open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)