### PR TITLE
research(erdos-18-oq-01): practical numbers closed under multiplication [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -359,4 +359,86 @@ theorem practical_two_pow_mul {m : ℕ} (hp : IsPractical m) (k : ℕ) :
     rw [hrw]
     exact practical_two_mul ih
 
+/-! ## Multiplicative closure under products
+
+The set of practical numbers is closed under multiplication: if `m` and `n` are
+both practical, so is `m · n`.  This is the full multiplicative-closure property
+(the Stewart–Sierpiński theory specialises it to prime factors); it strictly
+generalises `practical_two_mul` (the case `n = 2`, since `2` is practical) and,
+via `two_pow_practical`, the whole `2^k · m` generator `practical_two_pow_mul`. -/
+
+/-- **Scaling a representation.**  If `k` is a sum of distinct divisors of `m`,
+    then `c · k` is a sum of distinct divisors of `c · m` (scale each divisor used
+    by the factor `c ≥ 1`).  The scaled divisors `c · d` divide `c · m` and remain
+    distinct because multiplication by `c ≥ 1` is injective. -/
+theorem representable_scale (c : ℕ) (hc : 1 ≤ c) {k m : ℕ}
+    (h : IsRepresentable k m) : IsRepresentable (c * k) (c * m) := by
+  obtain ⟨S, hS, hsum⟩ := h
+  have hinj : ∀ a ∈ S, ∀ b ∈ S, c * a = c * b → a = b :=
+    fun a _ b _ hab => Nat.eq_of_mul_eq_mul_left (by omega) hab
+  refine ⟨S.image (c * ·), ?_, ?_⟩
+  · intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨d, hdS, rfl⟩ := hx
+    have hdvd : d ∣ m := Nat.dvd_of_mem_divisors (hS hdS)
+    have hm0 : m ≠ 0 := (Nat.mem_divisors.mp (hS hdS)).2
+    exact Nat.mem_divisors.mpr ⟨Nat.mul_dvd_mul_left c hdvd, Nat.mul_ne_zero (by omega) hm0⟩
+  · rw [Finset.sum_image hinj]
+    calc ∑ d ∈ S, id (c * d) = c * ∑ d ∈ S, d := by simp only [id_eq]; rw [Finset.mul_sum]
+      _ = c * S.sum id := rfl
+      _ = c * k := by rw [hsum]
+
+/-- **Practical numbers are closed under multiplication.**  If `m` and `n` are both
+    practical, so is `m · n`.  For a target `1 ≤ k < m·n`, write `k = m·q + r` with
+    `r = k % m < m` and `q = k / m < n`.  Represent the quotient `q` by divisors of
+    `n` and scale that representation by `m` (`representable_scale`) to get a sum of
+    distinct divisors of `m·n` equal to `m·q`, each `≥ m`; represent the remainder
+    `r` by divisors of `m ∣ m·n`, each `≤ r < m`.  The two divisor sets are disjoint
+    (multiples of `m` vs. values `< m`), so their union represents `m·q + r = k`. -/
+theorem practical_mul {m n : ℕ} (hpm : IsPractical m) (hpn : IsPractical n) :
+    IsPractical (m * n) := by
+  have hm1 : 1 ≤ m := hpm.1
+  have hn1 : 1 ≤ n := hpn.1
+  refine ⟨Nat.mul_pos hpm.1 hpn.1, fun k hk1 hkmn => ?_⟩
+  have hmn0 : m * n ≠ 0 := Nat.mul_ne_zero (by omega) (by omega)
+  have hrm : k % m < m := Nat.mod_lt k (by omega)
+  have hqn : k / m < n := (Nat.div_lt_iff_lt_mul (by omega)).mpr (by rw [Nat.mul_comm]; exact hkmn)
+  have hdecomp : m * (k / m) + k % m = k := Nat.div_add_mod k m
+  -- represent quotient `q = k/m` by divisors of `n`, remainder `r = k%m` by divisors of `m`.
+  obtain ⟨Sq, hSq, hSqsum⟩ := practical_represents_le hpn (le_of_lt hqn)
+  obtain ⟨Sr, hSr, hSrsum⟩ := practical_represents_le hpm (le_of_lt hrm)
+  -- scaled quotient set: `A = m · Sq ⊆ divisors (m·n)`, sums to `m·q`, elements `≥ m`.
+  have hminj : ∀ a ∈ Sq, ∀ b ∈ Sq, m * a = m * b → a = b :=
+    fun a _ b _ hab => Nat.eq_of_mul_eq_mul_left (by omega) hab
+  set A := Sq.image (m * ·) with hAdef
+  have hAsub : A ⊆ divisors (m * n) := by
+    intro x hx
+    rw [hAdef, Finset.mem_image] at hx
+    obtain ⟨d, hdSq, rfl⟩ := hx
+    have hdvd : d ∣ n := Nat.dvd_of_mem_divisors (hSq hdSq)
+    exact Nat.mem_divisors.mpr ⟨Nat.mul_dvd_mul_left m hdvd, hmn0⟩
+  have hAsum : A.sum id = m * (k / m) := by
+    rw [hAdef, Finset.sum_image hminj]
+    calc ∑ d ∈ Sq, id (m * d) = m * ∑ d ∈ Sq, d := by simp only [id_eq]; rw [Finset.mul_sum]
+      _ = m * Sq.sum id := rfl
+      _ = m * (k / m) := by rw [hSqsum]
+  -- remainder set embeds into divisors of `m·n` since `m ∣ m·n`.
+  have hBsub : Sr ⊆ divisors (m * n) :=
+    hSr.trans (Nat.divisors_subset_of_dvd hmn0 ⟨n, rfl⟩)
+  -- disjointness: `A`-elements are `≥ m`, `Sr`-elements are `≤ r < m`.
+  have hdisj : Disjoint A Sr := by
+    rw [Finset.disjoint_left]
+    intro a haA haSr
+    rw [hAdef, Finset.mem_image] at haA
+    obtain ⟨d, hdSq, rfl⟩ := haA
+    have hd1 : 1 ≤ d := Nat.pos_of_mem_divisors (hSq hdSq)
+    have hage : m ≤ m * d := le_mul_of_one_le_right (by omega) hd1
+    have hle : m * d ≤ Sr.sum id :=
+      Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le _) haSr
+    rw [hSrsum] at hle
+    omega
+  have hunion := representable_union hAsub hBsub hdisj
+  rw [hAsum, hSrsum, hdecomp] at hunion
+  exact hunion
+
 end Erdos18OQ01

--- a/research/problems/erdos-18-oq-01/knowledge.md
+++ b/research/problems/erdos-18-oq-01/knowledge.md
@@ -47,3 +47,37 @@ SOLVED-state look-outward. The file previously had only finite practical example
 
 Verified 0 axioms / 0 sorries, no native_decide; built clean (7744 jobs). 13 theorems.
 Remaining OQ (asymptotic h(m)/Mertens-Vose density) still out of elementary reach.
+
+## Session 2026-07-08 (researcher-9) — multiplicative closure: product of practicals
+
+SOLVED-state look-outward. The file already had the doubling closure `practical_two_mul`
+and its `2^k · m` generator `practical_two_pow_mul`. Added the **full multiplicative
+closure**: the set of practical numbers is closed under products.
+
+- `representable_scale (c) (hc : 1 ≤ c) : IsRepresentable k m → IsRepresentable (c*k) (c*m)`
+  — scale every divisor used by `c`; `c·d ∣ c·m` and `c ≥ 1` keeps the scaled divisors
+  distinct (`Finset.sum_image` with `Nat.eq_of_mul_eq_mul_left`).
+- `practical_mul : IsPractical m → IsPractical n → IsPractical (m*n)` — for `1 ≤ k < m·n`
+  write `k = m·q + r` (`q = k/m < n`, `r = k%m < m`); represent `q` by divisors of `n`,
+  scale by `m` to a sum of distinct divisors of `m·n` all `≥ m`; represent `r` by divisors
+  of `m ∣ m·n` all `< m`; the two sets are disjoint (multiples of `m` vs values `< m`), so
+  `representable_union` gives `m·q + r = k`. Strictly generalises `practical_two_mul`
+  (`n = 2`) and `practical_two_pow_mul`.
+
+Verified 0 axioms / 0 sorries, no native_decide; theoremCount 25→27, lineCount 362→444
+(`docker-build.sh Proofs.Erdos18OQ01` → `✔ Built (3.6s)`).
+
+★Gotchas (v4.26):
+- The parent `Erdos18Problem.lean` defines a LOCAL wrapper `def divisors (n) : Finset ℕ :=
+  n.divisors`. So `rw [Nat.mem_divisors]` FAILS (pattern `Nat.divisors ?` ≠ syntactic
+  `divisors m`). Use term-mode instead — it unfolds `divisors` up to defeq:
+  `Nat.dvd_of_mem_divisors h`, `Nat.pos_of_mem_divisors h`, `(Nat.mem_divisors.mp h).2`
+  (for `m ≠ 0`), and construct membership with `Nat.mem_divisors.mpr ⟨hdvd, hne0⟩`.
+- `Nat.pos_of_mem_divisors` wants membership in `divisors n`, NOT in the representing set
+  `Sq`: feed it `hSq hdSq`, not `hdSq`.
+- `Nat.div_lt_iff_lt_mul (0<m) : k/m < n ↔ k < n*m` — note `n*m` (commuted); close the mpr
+  with `by rw [Nat.mul_comm]; exact hkmn`.
+- `k = m*(k/m) + k%m` is `Nat.div_add_mod k m`; `k%m < m` is `Nat.mod_lt k (0<m)`.
+
+Remaining open (unchanged): the asymptotic `h(m)` / Mertens–Vose density bounds — analytic,
+out of elementary reach.

--- a/research/problems/erdos-18-oq-01/state.md
+++ b/research/problems/erdos-18-oq-01/state.md
@@ -2,5 +2,21 @@
 
 **Phase**: ACT
 **Since**: 2026-07-08T00:00:00Z
-**Attempts**: 2
+**Attempts**: 3
 **Status**: available
+
+## Current Focus
+Practical-number structural theory in `Proofs/Erdos18OQ01.lean` (27 theorems, 0 axioms,
+0 sorries). Session 2026-07-08 (researcher-9) added the full **multiplicative closure**:
+`practical_mul` (product of two practicals is practical) and its helper `representable_scale`,
+generalising the existing doubling closure `practical_two_mul` / `practical_two_pow_mul`.
+
+## Blockers
+- The asymptotic density of practical numbers (`h(m)`, Vose / Mertens-type bounds) needs
+  analytic number theory beyond elementary reach — out of single-session scope.
+
+## Next Action
+Toward the Stewart–Sierpiński criterion: an odd-prime step `IsPractical m → p ≤ σ(m)+1 →
+IsPractical (p*m)` (the general multiplicative criterion; `representable_scale` + the
+`[0,σ(m)]`-coverage lemmas `practical_represents_le` / `practical_top_segment` are the
+ingredients). Or leave as-is — the closure results are a natural stopping point.


### PR DESCRIPTION
## Summary

Adds the **full multiplicative-closure property** to the practical-numbers development in `Proofs/Erdos18OQ01.lean` (Erdős #18, OQ-01): the set of practical numbers is closed under products. This strictly generalises the file's existing doubling closure `practical_two_mul` (the `n = 2` case) and its `2^k·m` generator `practical_two_pow_mul`.

## New theorems (25 → 27)

- **`representable_scale (c) (hc : 1 ≤ c) : IsRepresentable k m → IsRepresentable (c*k) (c*m)`** — scale every divisor used in a representation by `c`; the scaled divisors `c·d` divide `c·m` and stay distinct because `(c·)` is injective for `c ≥ 1`.
- **`practical_mul : IsPractical m → IsPractical n → IsPractical (m*n)`** — for a target `1 ≤ k < m·n`, write `k = m·q + r` with `q = k/m < n` and `r = k%m < m`. Represent the quotient `q` by divisors of `n` and scale by `m` (a sum of distinct divisors of `m·n`, each `≥ m`); represent the remainder `r` by divisors of `m ∣ m·n` (each `≤ r < m`). The two divisor sets are disjoint (multiples of `m` vs. values `< m`), so `representable_union` represents `m·q + r = k`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos18OQ01` → **`✔ Built (7744 jobs)`**
- Still **0 axioms, 0 sorries, no `native_decide`**. 362 → 444 lines.

## Scope

`practical_mul` is the general multiplicative closure; the Stewart–Sierpiński theory refines it to prime factors (`p ≤ σ(m)+1`), a natural follow-up noted in `state.md`. The asymptotic density of practical numbers (`h(m)`, Vose / Mertens-type bounds) remains open — analytic, out of elementary reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)