### PR TITLE
research(erdos-1064-oq-03): infinite equality family 15·2^(k+1) → three-way classification [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -304,4 +304,98 @@ theorem oq03_both_directions_infinite :
   rw [this]
   exact Nat.infinite_setOf_prime.diff (Set.finite_singleton 2)
 
+-- ===========================================================================
+-- EQUALITY family:  φ(n) = φ(D(n)) holds infinitely often, via  n = 15·2^(k+1).
+--
+-- The higher-iterate comparison is genuinely THREE-WAY (>, =, <), not a clean
+-- dichotomy: alongside the forward (odd-prime) and reversal (21·2^(k+1))
+-- families, the diagonal `φ(n) = φ(D(n))` is realised on its own explicit
+-- infinite family.  For n = 15·2^(k+1) the double iterate collapses to
+-- D(n) = 5·2^(k+2), and both n and D(n) carry the SAME totient value 8·2^k:
+--
+--   φ(15·2^(k+1)) = 8·2^k;                       (15 = 3·5, φ(15) = 8)
+--   n − φ(n) = 11·2^(k+1),  φ(11·2^(k+1)) = 10·2^k;
+--   D(n) = 15·2^(k+1) − 10·2^k = 20·2^k = 5·2^(k+2);
+--   φ(5·2^(k+2)) = 4·2^(k+1) = 8·2^k = φ(n).
+--
+-- This turns the earlier empirical observation ("equality is common, 35 of the
+-- n in [2,200)") into a proved infinite branch, and — with the two inequality
+-- families — pins down all three cases as occurring infinitely often.
+-- ===========================================================================
+
+/-- The equality locus `{n | φ(n) = φ(D(n))}` for the double iterate. -/
+def EqualitySet : Set ℕ := {n : ℕ | Nat.totient n = Nat.totient (dblIter n)}
+
+/-- **The double iterate collapses the family `15·2^(k+1)` onto `5·2^(k+2)`.**
+    For every `k`, `D(15·2^(k+1)) = 5·2^(k+2)`.  (First cototient step lands on
+    `11·2^(k+1)`; the second step recombines to the pure power-of-two–times-`5`
+    form `20·2^k`.) -/
+theorem dblIter_eq_family (k : ℕ) : dblIter (15 * 2 ^ (k + 1)) = 5 * 2 ^ (k + 2) := by
+  have hp2 : Nat.totient (2 ^ (k + 1)) = 2 ^ k := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos k)]; simp
+  have cop15 : Nat.Coprime 15 (2 ^ (k + 1)) :=
+    (show Nat.Coprime 15 2 by norm_num).pow_right (k + 1)
+  have cop11 : Nat.Coprime 11 (2 ^ (k + 1)) :=
+    (show Nat.Coprime 11 2 by norm_num).pow_right (k + 1)
+  -- φ(n) = 8·2^k
+  have hφn : Nat.totient (15 * 2 ^ (k + 1)) = 8 * 2 ^ k := by
+    rw [Nat.totient_mul cop15, totient_15, hp2]
+  -- n − φ(n) = 11·2^(k+1)
+  have hsub1 : 15 * 2 ^ (k + 1) - 8 * 2 ^ k = 11 * 2 ^ (k + 1) := by
+    have h2 : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+    rw [h2]; omega
+  -- φ(11·2^(k+1)) = 10·2^k
+  have hφsub : Nat.totient (11 * 2 ^ (k + 1)) = 10 * 2 ^ k := by
+    rw [Nat.totient_mul cop11, Nat.totient_prime (by norm_num), hp2]
+  -- D(n) = n − φ(n − φ(n)) = 5·2^(k+2)
+  unfold dblIter
+  rw [hφn, hsub1, hφsub]
+  have h2 : (2 : ℕ) ^ (k + 2) = 4 * 2 ^ k := by rw [pow_succ, pow_succ]; ring
+  have h2' : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+  rw [h2, h2']; omega
+
+/-- **Equality on the entire family `15·2^(k+1)`.**  For every `k`,
+    `φ(15·2^(k+1)) = 8·2^k = φ(D(15·2^(k+1)))`, so each member sits exactly on
+    the diagonal `φ(n) = φ(D(n))`. -/
+theorem mem_EqualitySet_family (k : ℕ) : 15 * 2 ^ (k + 1) ∈ EqualitySet := by
+  have hp2 : Nat.totient (2 ^ (k + 1)) = 2 ^ k := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos k)]; simp
+  have hp2' : Nat.totient (2 ^ (k + 2)) = 2 ^ (k + 1) := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos (k + 1))]; simp
+  have cop15 : Nat.Coprime 15 (2 ^ (k + 1)) :=
+    (show Nat.Coprime 15 2 by norm_num).pow_right (k + 1)
+  have cop5 : Nat.Coprime 5 (2 ^ (k + 2)) :=
+    (show Nat.Coprime 5 2 by norm_num).pow_right (k + 2)
+  have hφn : Nat.totient (15 * 2 ^ (k + 1)) = 8 * 2 ^ k := by
+    rw [Nat.totient_mul cop15, totient_15, hp2]
+  have hφD : Nat.totient (5 * 2 ^ (k + 2)) = 4 * 2 ^ (k + 1) := by
+    rw [Nat.totient_mul cop5, Nat.totient_prime (by norm_num), hp2']
+  show Nat.totient (15 * 2 ^ (k + 1)) = Nat.totient (dblIter (15 * 2 ^ (k + 1)))
+  rw [dblIter_eq_family, hφn, hφD]
+  have h2 : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+  rw [h2]; ring
+
+/-- The map `k ↦ 15·2^(k+1)` is injective. -/
+theorem eq_family_injective : Function.Injective (fun k : ℕ => 15 * 2 ^ (k + 1)) := by
+  intro a b hab
+  simp only at hab
+  have h2 : (2 : ℕ) ^ (a + 1) = 2 ^ (b + 1) := Nat.eq_of_mul_eq_mul_left (by norm_num) hab
+  have := Nat.pow_right_injective (le_refl 2) h2
+  omega
+
+/-- **Equality `φ(n) = φ(D(n))` holds infinitely often.**  The diagonal locus
+    `{n | φ(n) = φ(D(n))}` is infinite, exhibited by the explicit injective
+    family `n = 15·2^(k+1)`.  No density machinery is required. -/
+theorem equality_infinitely_many : EqualitySet.Infinite :=
+  Set.infinite_of_injective_forall_mem eq_family_injective mem_EqualitySet_family
+
+/-- **Summary (OQ-03, all three cases realised infinitely).**  The higher-iterate
+    comparison `φ(n)` vs `φ(D(n))` is genuinely three-way: the strict forward
+    inequality (odd primes), the strict reversal (`21·2^(k+1)`), and exact
+    equality (`15·2^(k+1)`) each hold on an explicit infinite family.  So, unlike
+    a clean dichotomy, all of `>`, `=`, `<` occur infinitely often. -/
+theorem oq03_three_way_infinite :
+    {p : ℕ | p.Prime ∧ 3 ≤ p}.Infinite ∧ ReversalSet.Infinite ∧ EqualitySet.Infinite :=
+  ⟨oq03_both_directions_infinite.1, reversal_infinitely_many, equality_infinitely_many⟩
+
 end Erdos1064OQ03

--- a/research/problems/erdos-1064-oq-03/sessions/2026-07-08-r7-equality-family.md
+++ b/research/problems/erdos-1064-oq-03/sessions/2026-07-08-r7-equality-family.md
@@ -1,0 +1,50 @@
+# erdos-1064-oq-03 — Session (researcher-7, 2026-07-08)
+
+## Result: EQUALITY direction realised infinitely often (0 axioms / 0 sorries)
+
+**Context going in:** the infinitely-often *reversal* `φ(n) < φ(D(n))` was already
+resolved (researcher-3, family `21·2^(k+1)`), and the *forward* inequality
+`φ(n) > φ(D(n))` holds on the odd primes. The prior insights noted that
+`φ(n) = φ(D(n))` is *empirically* common (35 of the n in `[2,200)`) and that the
+higher-iterate comparison is genuinely three-way, but no proved infinite
+equality family existed.
+
+**What was proved:** an explicit infinite EQUALITY family
+
+    n = 15·2^(k+1),   k = 0,1,2,…
+
+For every k:
+- φ(15·2^(k+1)) = 8·2^k;                       (15 = 3·5, φ(15) = 8)
+- first cototient step: 15·2^(k+1) − φ(·) = 11·2^(k+1);
+- φ(11·2^(k+1)) = 10·2^k, so D(n) = 15·2^(k+1) − 10·2^k = 20·2^k = 5·2^(k+2);
+- φ(D(n)) = φ(5·2^(k+2)) = 4·2^(k+1) = 8·2^k = φ(n).
+
+Hence every member lies exactly on the diagonal `φ(n) = φ(D(n))`; the map
+`k ↦ 15·2^(k+1)` is injective, so `EqualitySet := {n | φ(n) = φ(D(n))}` is
+**infinite** (`equality_infinitely_many`).
+
+`oq03_three_way_infinite` packages all three cases: the strict-forward (odd
+primes), strict-reversal (`21·2^(k+1)`), and equality (`15·2^(k+1)`) families are
+each infinite. So the higher-iterate comparison provably realises `>`, `=`, and
+`<` infinitely often — not a dichotomy.
+
+## Method
+Same "totient scales on `a·2^(k+1)`" mechanism as the reversal family, tuned so
+the second cototient step preserves the totient value. The odd part 15 is the
+`a = 15` case flagged in the prior session's scaling caveat: there both `n` and
+`D(n)` end with `φ`-value `8·2^k`, giving equality (whereas `a = 21` lifted
+`15 ↦ 17` and broke it into reversal). Totient values via `Nat.totient_mul` on
+coprime factors + `Nat.totient_prime` / `Nat.totient_prime_pow` (kernel `decide`
+coprimality only — no `native_decide`, so `ofReduceBool`-free).
+
+## Verification
+Docker `docker-build.sh Proofs.EulerTotientOQ04OQ03` → Built, 0 errors.
+`#print axioms equality_infinitely_many` / `oq03_three_way_infinite`
+→ [propext, Classical.choice, Quot.sound] only. 0 axioms / 0 sorries.
+
+## Remaining open
+- Density-1 forward statement `φ(n) > φ(D(n))` for almost all n (transport
+  Luca–Pomerance through one extra cototient step) — still the main open
+  direction; needs density machinery.
+- Full decidable three-way certificate on a finite window; prime-landing
+  reversal infinitude (Dirichlet-type). Unchanged.

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -25,17 +25,17 @@
     {
       "path": "Proofs/EulerTotientOQ04OQ03.lean",
       "filename": "EulerTotientOQ04OQ03.lean",
-      "lineCount": 307,
-      "theoremCount": 24,
+      "lineCount": 401,
+      "theoremCount": 29,
       "axiomCount": 0,
-      "defCount": 2,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ04OQ03.lean"
     }
   ],
   "knowledge": {
-    "progressSummary": "RESOLVED (infinitely-often direction): the reversal φ(n) < φ(D(n)) now holds on an EXPLICIT INFINITE family n = 21·2^(k+1), for which D(n) = 17·2^(k+1) and φ(n) = 12·2^k < 16·2^k = φ(D(n)). This generalises the composite-landing witnesses n=42 (k=0), n=84 (k=1) into a full infinite family, so ReversalSet is infinite — no density input. Combined with the odd-prime forward family, BOTH directions of OQ-03 now hold infinitely often (oq03_both_directions_infinite). All 0 axioms / 0 sorries (only propext/Classical.choice/Quot.sound).",
+    "progressSummary": "RESOLVED (infinitely-often direction): the reversal φ(n) < φ(D(n)) now holds on an EXPLICIT INFINITE family n = 21·2^(k+1), for which D(n) = 17·2^(k+1) and φ(n) = 12·2^k < 16·2^k = φ(D(n)). This generalises the composite-landing witnesses n=42 (k=0), n=84 (k=1) into a full infinite family, so ReversalSet is infinite — no density input. Combined with the odd-prime forward family, BOTH directions of OQ-03 now hold infinitely often (oq03_both_directions_infinite). All 0 axioms / 0 sorries (only propext/Classical.choice/Quot.sound). THREE-WAY (2026-07-08, r7): equality φ(n)=φ(D(n)) now also holds on an EXPLICIT INFINITE family n=15·2^(k+1), for which D(n)=5·2^(k+2) and φ(n)=8·2^k=φ(D(n)) (both n and D(n) carry the same totient value). So all three cases >, =, < are realised infinitely often (oq03_three_way_infinite), upgrading the earlier empirical 'equality is common' observation into a proved infinite branch. Still 0 axioms / 0 sorries (only propext/Classical.choice/Quot.sound).",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -53,7 +53,13 @@
       "mem_ReversalSet_family — φ(21·2^(k+1)) = 12·2^k < 16·2^k = φ(D(·)); reversal on the whole family; recovers n=42 (k=0), n=84 (k=1).",
       "family_injective — k ↦ 21·2^(k+1) injective.",
       "reversal_infinitely_many — ReversalSet.Infinite: RESOLVES the open infinitely-often reversal direction (no density).",
-      "oq03_both_directions_infinite — both odd-prime forward family and 21·2^(k+1) reversal family are infinite; OQ-03 goes both ways infinitely often."
+      "oq03_both_directions_infinite — both odd-prime forward family and 21·2^(k+1) reversal family are infinite; OQ-03 goes both ways infinitely often.",
+      "EqualitySet := {n | φ(n) = φ(D(n))} (EulerTotientOQ04OQ03.lean) — the diagonal locus of the double iterate.",
+      "dblIter_eq_family — D(15·2^(k+1)) = 5·2^(k+2) for all k (first cototient step lands on 11·2^(k+1); second recombines to 20·2^k).",
+      "mem_EqualitySet_family — φ(15·2^(k+1)) = 8·2^k = φ(D(·)); each member lies exactly on the equality diagonal; recovers n=30 (k=0), n=60 (k=1).",
+      "eq_family_injective — k ↦ 15·2^(k+1) injective.",
+      "equality_infinitely_many — EqualitySet.Infinite: equality φ(n)=φ(D(n)) holds infinitely often (explicit family, no density).",
+      "oq03_three_way_infinite — the forward (odd primes), reversal (21·2^(k+1)), and equality (15·2^(k+1)) families are each infinite; OQ-03 realises >, =, < all infinitely often."
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -64,13 +70,14 @@
       "Reversal is NOT confined to prime landings: at n=42, D(42)=34=2·17 is COMPOSITE yet φ(42)=12<16=φ(34). So the reversal family strictly contains the prime-landing family, refining the earlier clustering observation.",
       "The infinitely-often reversal direction (previously OPEN crux) is provable by an EXPLICIT family with NO density machinery: n = 21·2^(k+1) satisfies D(n)=17·2^(k+1) and φ(n)=12·2^k < 16·2^k=φ(D(n)) for every k. n=42,84,168,... are its members.",
       "The reversal family is obtained by prepending one cototient preimage step to the PARENT single-step family 15·2^(k+1): the first cototient step of 21·2^(k+1) lands exactly on 15·2^(k+1) (the parent family member), and the second step lifts the odd part 15↦17, pushing φ(D(n)) above φ(n). This is a clean 'one extra step' transport of the Grytczuk–Luca–Wójtowicz construction.",
-      "Scaling caveat that guided the search: for n=a·2^(k+1) the totient scales as φ(a)·2^k on both n and D(n) only when the powers of 2 match; a=15 gives EQUALITY (both odd parts have φ=8), whereas a=21 gives strict reversal because the second step lifts 15↦17 raising φ from 8·2^k to 16·2^k."
+      "Scaling caveat that guided the search: for n=a·2^(k+1) the totient scales as φ(a)·2^k on both n and D(n) only when the powers of 2 match; a=15 gives EQUALITY (both odd parts have φ=8), whereas a=21 gives strict reversal because the second step lifts 15↦17 raising φ from 8·2^k to 16·2^k.",
+      "Equality φ(n)=φ(D(n)) is not just empirically common but holds on an EXPLICIT infinite family n=15·2^(k+1): D collapses to 5·2^(k+2) and both n and D(n) share totient value 8·2^k. This is the a=15 case of the reversal-family scaling caveat — where a=21 lifted the odd part 15↦17 (breaking equality into reversal), a=15 keeps the second cototient step totient-preserving (15·2^(k+1) → 11·2^(k+1) → 5·2^(k+2), with φ(15)=φ(5·4)=8·2^k throughout). Together with the forward and reversal families this pins down the three-way (>,=,<) comparison as genuinely three-valued infinitely often, not a dichotomy."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Density-1 forward statement φ(n) > φ(D(n)) for almost all n by transporting Luca–Pomerance through one extra cototient step (assess whether the extra step preserves the density-1 set) — this is now the main remaining open direction.",
-      "Characterise ALL reversal points (three-way >,=,< classification) on a finite window as a decidable certificate; the 21·2^(k+1) family covers only one infinite branch.",
-      "Prime-landing reversal infinitude (D(n) prime infinitely often) as a distinct, Dirichlet-type harder direction complementing the elementary 21·2^(k+1) family."
+      "Density-1 forward statement φ(n) > φ(D(n)) for almost all n by transporting Luca–Pomerance through one extra cototient step (assess whether the extra step preserves the density-1 set) — this remains the main open direction.",
+      "Full DECIDABLE three-way (>,=,<) certificate on a finite window: the three explicit families (odd primes / 21·2^(k+1) / 15·2^(k+1)) now cover one infinite branch each, but a complete window classification is still open.",
+      "Prime-landing reversal infinitude (D(n) prime infinitely often) as a distinct Dirichlet-type direction complementing the elementary power-of-two families."
     ]
   }
 }


### PR DESCRIPTION
## Summary

Erdős #1064 OQ-03 studies the double cototient iterate `D(n) = n − φ(n − φ(n))` and how `φ(n)` compares with `φ(D(n))`. Prior sessions resolved the **reversal** direction (`φ(n) < φ(D(n))` infinitely often, family `21·2^(k+1)`) and the **forward** direction (odd primes). This session adds the missing third case.

**New result — an explicit infinite EQUALITY family `n = 15·2^(k+1)`:**

For every `k`:
- `φ(15·2^(k+1)) = 8·2^k`  (15 = 3·5, φ(15) = 8)
- first cototient step: `15·2^(k+1) − φ(·) = 11·2^(k+1)`
- `φ(11·2^(k+1)) = 10·2^k`, so `D(n) = 15·2^(k+1) − 10·2^k = 20·2^k = 5·2^(k+2)`
- `φ(5·2^(k+2)) = 4·2^(k+1) = 8·2^k = φ(n)` — exact equality.

The map `k ↦ 15·2^(k+1)` is injective, so `EqualitySet := {n | φ(n) = φ(D(n))}` is infinite (`equality_infinitely_many`). This turns the earlier *empirical* observation ("equality is common, 35 of the n in [2,200)") into a proved infinite branch.

`oq03_three_way_infinite` packages all three families (forward odd primes / reversal `21·2^(k+1)` / equality `15·2^(k+1)`) as each infinite: the higher-iterate comparison provably realises `>`, `=`, and `<` **infinitely often** — not a dichotomy.

## Method

The `a = 15` case of the reversal-family scaling caveat. Where `a = 21` lifted the odd part `15 ↦ 17` (breaking equality into reversal), `a = 15` keeps the second cototient step totient-preserving. Totient values via `Nat.totient_mul` on coprime factors + `Nat.totient_prime` / `Nat.totient_prime_pow` (kernel `decide` coprimality only — no `native_decide`).

## Verification

- `docker-build.sh Proofs.EulerTotientOQ04OQ03` → **Built**, 0 errors (3058 jobs).
- `#print axioms oq03_three_way_infinite` / `equality_infinitely_many` → `[propext, Classical.choice, Quot.sound]` only.
- **0 axioms / 0 sorries**, `ofReduceBool`-free.
- leanFile: 307→401 lines, 24→29 theorems, 2→3 defs.

## Remaining open

- Density-1 forward statement `φ(n) > φ(D(n))` for almost all `n` (transport Luca–Pomerance through one extra step) — the main open direction.
- Full decidable three-way certificate on a finite window; prime-landing reversal infinitude (Dirichlet-type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)