### PR TITLE
Enrich Erdős #100 integer-distance bridge: fix section boundary

### DIFF
--- a/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
@@ -63,14 +63,14 @@
       "title": "Counting Positive Integers in a Bounded Range",
       "summary": "card_le_floor_of_pos_int_le and card_le_of_pos_int_le: a finite set of positive integers each <= D has at most floor(D) <= D elements.",
       "startLine": 1,
-      "endLine": 90,
+      "endLine": 83,
       "mathContext": "Inject each value's natural-number form into Finset.Icc 1 (floor D); InjOn since distinct integers have distinct floors; |Icc 1 m| = m."
     },
     {
       "id": "bridge",
       "title": "The Integer-Distance Bridge",
       "summary": "distinct_distances_le_diam: the distinct integer distances bounded by the diameter number at most the diameter — the link to Erdős #89 and the Guth-Katz bound.",
-      "startLine": 91,
+      "startLine": 85,
       "endLine": 118,
       "mathContext": "Direct corollary of card_le_of_pos_int_le applied to the finite set of distinct integer distances."
     }


### PR DESCRIPTION
Enrichment pass for `erdos-100-oq-01-incomplete-01` (quality 94, passes 0).

The entry is otherwise complete (5 fully-populated annotations, 5 keyInsights, 3 mainTheorems with accurate line anchors, conclusion with 3 openQuestions). One accuracy fix:

- The docstring of `distinct_distances_le_diam` (the integer-distance bridge, Lean lines 85–92) was split into section 1 ("Counting Positive Integers…", ended at line 90) instead of belonging to section 2 ("The Integer-Distance Bridge", started at line 91).
- Fixed: section 1 `endLine` 90→83 (ends at the last counting lemma `card_le_of_pos_int_le`), section 2 `startLine` 91→85 (starts at the bridge theorem's docstring).

No content added/removed; meta.json size unchanged (11.8 KB). Counts (lineCount 118, theoremCount 3, axiomCount 0, sorries 0) verified against source, unchanged. JSON validated.