### PR TITLE
research(erdos-1064-oq-03): forward inequality on an infinite composite family 2^(k+3) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -398,4 +398,97 @@ theorem oq03_three_way_infinite :
     {p : ℕ | p.Prime ∧ 3 ≤ p}.Infinite ∧ ReversalSet.Infinite ∧ EqualitySet.Infinite :=
   ⟨oq03_both_directions_infinite.1, reversal_infinitely_many, equality_infinitely_many⟩
 
+-- ===========================================================================
+-- FORWARD family on COMPOSITES:  φ(n) > φ(D(n)) on the powers of two n = 2^(k+3).
+--
+-- So far the forward direction `φ(n) > φ(D(n))` was exhibited only on the
+-- infinite family of odd PRIMES, whereas the reversal (`21·2^(k+1)`) and
+-- equality (`15·2^(k+1)`) directions each already run over an infinite
+-- COMPOSITE family.  This closes that asymmetry: the forward inequality is not
+-- confined to primes either — it holds throughout the infinite composite family
+-- of pure powers of two.  For n = 2^(k+3) the double iterate collapses to
+-- D(n) = 3·2^(k+1):
+--
+--   φ(2^(k+3)) = 2^(k+2);
+--   n − φ(n) = 2^(k+2),  φ(2^(k+2)) = 2^(k+1);
+--   D(n) = 2^(k+3) − 2^(k+1) = 3·2^(k+1);
+--   φ(3·2^(k+1)) = 2·2^k = 2^(k+1)  <  2^(k+2) = φ(n).
+--
+-- Thus each of the three relations `>`, `=`, `<` is now realised on an explicit
+-- infinite family of COMPOSITE integers, matching the structural picture.
+-- ===========================================================================
+
+/-- The forward locus `{n | φ(D(n)) < φ(n)}` for the double iterate. -/
+def ForwardSet : Set ℕ := {n : ℕ | Nat.totient (dblIter n) < Nat.totient n}
+
+/-- **The double iterate collapses the power-of-two family `2^(k+3)` onto
+    `3·2^(k+1)`.**  For every `k`, `D(2^(k+3)) = 3·2^(k+1)`.  (First cototient
+    step lands on `2^(k+2)`; the second subtracts `2^(k+1)`, leaving `3·2^(k+1)`.)
+    -/
+theorem dblIter_pow2 (k : ℕ) : dblIter (2 ^ (k + 3)) = 3 * 2 ^ (k + 1) := by
+  have e1 : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+  have e2 : (2 : ℕ) ^ (k + 2) = 4 * 2 ^ k := by rw [pow_succ, pow_succ]; ring
+  have e3 : (2 : ℕ) ^ (k + 3) = 8 * 2 ^ k := by rw [pow_succ, pow_succ, pow_succ]; ring
+  have hp3 : Nat.totient (2 ^ (k + 3)) = 2 ^ (k + 2) := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos (k + 2))]; simp
+  have hp2' : Nat.totient (2 ^ (k + 2)) = 2 ^ (k + 1) := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos (k + 1))]; simp
+  unfold dblIter
+  rw [hp3]
+  have hsub : 2 ^ (k + 3) - 2 ^ (k + 2) = 2 ^ (k + 2) := by omega
+  rw [hsub, hp2']
+  omega
+
+/-- **Forward inequality on the entire power-of-two family `2^(k+3)`.**  For every
+    `k`, `φ(D(2^(k+3))) = 2^(k+1) < 2^(k+2) = φ(2^(k+3))`, so each member lies in
+    the forward locus. -/
+theorem mem_ForwardSet_pow2 (k : ℕ) : 2 ^ (k + 3) ∈ ForwardSet := by
+  have e2 : (2 : ℕ) ^ (k + 2) = 4 * 2 ^ k := by rw [pow_succ, pow_succ]; ring
+  have hpos : 0 < (2 : ℕ) ^ k := pow_pos (by norm_num) k
+  have hp3 : Nat.totient (2 ^ (k + 3)) = 2 ^ (k + 2) := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos (k + 2))]; simp
+  have hp2 : Nat.totient (2 ^ (k + 1)) = 2 ^ k := by
+    rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos k)]; simp
+  have cop3 : Nat.Coprime 3 (2 ^ (k + 1)) :=
+    (show Nat.Coprime 3 2 by norm_num).pow_right (k + 1)
+  have hφD : Nat.totient (3 * 2 ^ (k + 1)) = 2 * 2 ^ k := by
+    rw [Nat.totient_mul cop3, Nat.totient_prime (by norm_num), hp2]
+  show Nat.totient (dblIter (2 ^ (k + 3))) < Nat.totient (2 ^ (k + 3))
+  rw [dblIter_pow2, hφD, hp3, e2]
+  omega
+
+/-- `2^(k+3)` is composite (divisible by 2 and at least 8). -/
+theorem not_prime_pow2 (k : ℕ) : ¬ (2 ^ (k + 3)).Prime := by
+  intro h
+  have hdvd : (2 : ℕ) ∣ 2 ^ (k + 3) := dvd_pow_self 2 (by omega)
+  rcases h.eq_one_or_self_of_dvd 2 hdvd with h1 | h1
+  · norm_num at h1
+  · have h8 : (8 : ℕ) ≤ 2 ^ (k + 3) := by
+      calc (8 : ℕ) = 2 ^ 3 := by norm_num
+        _ ≤ 2 ^ (k + 3) := Nat.pow_le_pow_right (by norm_num) (by omega)
+    omega
+
+/-- The map `k ↦ 2^(k+3)` is injective. -/
+theorem pow2_family_injective : Function.Injective (fun k : ℕ => 2 ^ (k + 3)) := by
+  intro a b hab
+  simp only at hab
+  have := Nat.pow_right_injective (le_refl 2) hab
+  omega
+
+/-- **The forward inequality `φ(n) > φ(D(n))` holds infinitely often.**  The
+    forward locus `{n | φ(D(n)) < φ(n)}` is infinite, exhibited by the explicit
+    injective power-of-two family `n = 2^(k+3)`. -/
+theorem forward_infinitely_many : ForwardSet.Infinite :=
+  Set.infinite_of_injective_forall_mem pow2_family_injective mem_ForwardSet_pow2
+
+/-- **The forward inequality is not confined to primes.**  There are infinitely
+    many *composite* `n` with `φ(n) > φ(D(n))`: the powers of two `n = 2^(k+3)`.
+    This mirrors `reversal_with_composite_landing` for the forward direction and
+    completes the symmetry — each of `>`, `=`, `<` now runs over an infinite
+    family of composite integers. -/
+theorem forward_not_confined_to_primes :
+    {n : ℕ | ¬ n.Prime ∧ n ∈ ForwardSet}.Infinite :=
+  Set.infinite_of_injective_forall_mem pow2_family_injective
+    (fun k => ⟨not_prime_pow2 k, mem_ForwardSet_pow2 k⟩)
+
 end Erdos1064OQ03

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -25,17 +25,17 @@
     {
       "path": "Proofs/EulerTotientOQ04OQ03.lean",
       "filename": "EulerTotientOQ04OQ03.lean",
-      "lineCount": 401,
-      "theoremCount": 29,
+      "lineCount": 494,
+      "theoremCount": 35,
       "axiomCount": 0,
-      "defCount": 3,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ04OQ03.lean"
     }
   ],
   "knowledge": {
-    "progressSummary": "RESOLVED (infinitely-often direction): the reversal φ(n) < φ(D(n)) now holds on an EXPLICIT INFINITE family n = 21·2^(k+1), for which D(n) = 17·2^(k+1) and φ(n) = 12·2^k < 16·2^k = φ(D(n)). This generalises the composite-landing witnesses n=42 (k=0), n=84 (k=1) into a full infinite family, so ReversalSet is infinite — no density input. Combined with the odd-prime forward family, BOTH directions of OQ-03 now hold infinitely often (oq03_both_directions_infinite). All 0 axioms / 0 sorries (only propext/Classical.choice/Quot.sound). THREE-WAY (2026-07-08, r7): equality φ(n)=φ(D(n)) now also holds on an EXPLICIT INFINITE family n=15·2^(k+1), for which D(n)=5·2^(k+2) and φ(n)=8·2^k=φ(D(n)) (both n and D(n) carry the same totient value). So all three cases >, =, < are realised infinitely often (oq03_three_way_infinite), upgrading the earlier empirical 'equality is common' observation into a proved infinite branch. Still 0 axioms / 0 sorries (only propext/Classical.choice/Quot.sound).",
+    "progressSummary": "RESOLVED (infinitely-often direction): the reversal φ(n) < φ(D(n)) now holds on an EXPLICIT INFINITE family n = 21·2^(k+1), for which D(n) = 17·2^(k+1) and φ(n) = 12·2^k < 16·2^k = φ(D(n)). This generalises the composite-landing witnesses n=42 (k=0), n=84 (k=1) into a full infinite family, so ReversalSet is infinite — no density input. Combined with the odd-prime forward family, BOTH directions of OQ-03 now hold infinitely often (oq03_both_directions_infinite). All 0 axioms / 0 sorries (only propext/Classical.choice/Quot.sound). THREE-WAY (2026-07-08, r7): equality φ(n)=φ(D(n)) now also holds on an EXPLICIT INFINITE family n=15·2^(k+1), for which D(n)=5·2^(k+2) and φ(n)=8·2^k=φ(D(n)) (both n and D(n) carry the same totient value). So all three cases >, =, < are realised infinitely often (oq03_three_way_infinite), upgrading the earlier empirical 'equality is common' observation into a proved infinite branch. Still 0 axioms / 0 sorries (only propext/Classical.choice/Quot.sound). FORWARD-COMPOSITE (2026-07-08, r4): the forward inequality φ(n)>φ(D(n)) now also holds on an EXPLICIT INFINITE COMPOSITE family n=2^(k+3), with D(n)=3·2^(k+1) and φ(D)=2^(k+1)<2^(k+2)=φ(n) (forward_not_confined_to_primes / forward_infinitely_many). This closes the structural asymmetry: each of >,=,< is realised infinitely often on composites. Still 0 axioms / 0 sorries. The density-1 forward statement (almost-all n) stays the only open direction.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -59,7 +59,11 @@
       "mem_EqualitySet_family — φ(15·2^(k+1)) = 8·2^k = φ(D(·)); each member lies exactly on the equality diagonal; recovers n=30 (k=0), n=60 (k=1).",
       "eq_family_injective — k ↦ 15·2^(k+1) injective.",
       "equality_infinitely_many — EqualitySet.Infinite: equality φ(n)=φ(D(n)) holds infinitely often (explicit family, no density).",
-      "oq03_three_way_infinite — the forward (odd primes), reversal (21·2^(k+1)), and equality (15·2^(k+1)) families are each infinite; OQ-03 realises >, =, < all infinitely often."
+      "oq03_three_way_infinite — the forward (odd primes), reversal (21·2^(k+1)), and equality (15·2^(k+1)) families are each infinite; OQ-03 realises >, =, < all infinitely often.",
+      "ForwardSet := {n | φ(D(n)) < φ(n)} (EulerTotientOQ04OQ03.lean) — the forward locus, added as the composite-family counterpart to ReversalSet/EqualitySet.",
+      "dblIter_pow2 — D(2^(k+3)) = 3·2^(k+1) for all k (first cototient step lands on 2^(k+2); second subtracts 2^(k+1)).",
+      "mem_ForwardSet_pow2 / forward_infinitely_many — φ(D(2^(k+3))) = 2^(k+1) < 2^(k+2) = φ(2^(k+3)); ForwardSet.Infinite via the injective power-of-two family.",
+      "not_prime_pow2 + forward_not_confined_to_primes — the forward inequality φ(n)>φ(D(n)) holds on infinitely many COMPOSITE n (the powers of two 2^(k+3)), the forward analogue of reversal_with_composite_landing."
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -71,13 +75,15 @@
       "The infinitely-often reversal direction (previously OPEN crux) is provable by an EXPLICIT family with NO density machinery: n = 21·2^(k+1) satisfies D(n)=17·2^(k+1) and φ(n)=12·2^k < 16·2^k=φ(D(n)) for every k. n=42,84,168,... are its members.",
       "The reversal family is obtained by prepending one cototient preimage step to the PARENT single-step family 15·2^(k+1): the first cototient step of 21·2^(k+1) lands exactly on 15·2^(k+1) (the parent family member), and the second step lifts the odd part 15↦17, pushing φ(D(n)) above φ(n). This is a clean 'one extra step' transport of the Grytczuk–Luca–Wójtowicz construction.",
       "Scaling caveat that guided the search: for n=a·2^(k+1) the totient scales as φ(a)·2^k on both n and D(n) only when the powers of 2 match; a=15 gives EQUALITY (both odd parts have φ=8), whereas a=21 gives strict reversal because the second step lifts 15↦17 raising φ from 8·2^k to 16·2^k.",
-      "Equality φ(n)=φ(D(n)) is not just empirically common but holds on an EXPLICIT infinite family n=15·2^(k+1): D collapses to 5·2^(k+2) and both n and D(n) share totient value 8·2^k. This is the a=15 case of the reversal-family scaling caveat — where a=21 lifted the odd part 15↦17 (breaking equality into reversal), a=15 keeps the second cototient step totient-preserving (15·2^(k+1) → 11·2^(k+1) → 5·2^(k+2), with φ(15)=φ(5·4)=8·2^k throughout). Together with the forward and reversal families this pins down the three-way (>,=,<) comparison as genuinely three-valued infinitely often, not a dichotomy."
+      "Equality φ(n)=φ(D(n)) is not just empirically common but holds on an EXPLICIT infinite family n=15·2^(k+1): D collapses to 5·2^(k+2) and both n and D(n) share totient value 8·2^k. This is the a=15 case of the reversal-family scaling caveat — where a=21 lifted the odd part 15↦17 (breaking equality into reversal), a=15 keeps the second cototient step totient-preserving (15·2^(k+1) → 11·2^(k+1) → 5·2^(k+2), with φ(15)=φ(5·4)=8·2^k throughout). Together with the forward and reversal families this pins down the three-way (>,=,<) comparison as genuinely three-valued infinitely often, not a dichotomy.",
+      "The forward direction φ(n)>φ(D(n)) is NOT confined to primes: on n=2^(k+3) the double iterate collapses to 3·2^(k+1) and φ(D)=2^(k+1)<2^(k+2)=φ(n). This closes the earlier asymmetry where only reversal and equality had explicit composite infinite families while forward had only the odd-prime family. Now all three relations >,=,< are each realised on an infinite family of composite integers."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Density-1 forward statement φ(n) > φ(D(n)) for almost all n by transporting Luca–Pomerance through one extra cototient step (assess whether the extra step preserves the density-1 set) — this remains the main open direction.",
       "Full DECIDABLE three-way (>,=,<) certificate on a finite window: the three explicit families (odd primes / 21·2^(k+1) / 15·2^(k+1)) now cover one infinite branch each, but a complete window classification is still open.",
-      "Prime-landing reversal infinitude (D(n) prime infinitely often) as a distinct Dirichlet-type direction complementing the elementary power-of-two families."
+      "Prime-landing reversal infinitude (D(n) prime infinitely often) as a distinct Dirichlet-type direction complementing the elementary power-of-two families.",
+      "Density-1 forward statement φ(n)>φ(D(n)) for almost all n remains the sole genuinely open direction (needs Luca–Pomerance / ψ(x,y) density, a real Mathlib gap); the explicit families settle only the infinitely-often questions."
     ]
   }
 }


### PR DESCRIPTION
## Summary

Erdős 1064 OQ-03 studies the **double cototient iterate** `D(n) = n − φ(n − φ(n))`, comparing `φ(n)` against `φ(D(n))`.

The existing file already proves all three relations `>`, `=`, `<` occur infinitely often, but with a structural asymmetry:

| relation | family | type |
|----------|--------|------|
| `>` forward | odd primes `p` | **prime** |
| `<` reversal | `21·2^(k+1)` | composite |
| `=` equality | `15·2^(k+1)` | composite |

The forward direction was the only one lacking an explicit **composite** family. This PR closes that gap.

## Contribution

For the pure powers of two `n = 2^(k+3)` the double iterate collapses cleanly:

```
φ(2^(k+3)) = 2^(k+2);
n − φ(n) = 2^(k+2),  φ(2^(k+2)) = 2^(k+1);
D(2^(k+3)) = 2^(k+3) − 2^(k+1) = 3·2^(k+1);
φ(3·2^(k+1)) = 2^(k+1)  <  2^(k+2) = φ(n).
```

So `φ(n) > φ(D(n))` holds throughout an infinite family of **composite** integers.

New declarations (all elementary, `Nat.totient` + `Nat.totient_prime_pow`/`Nat.totient_mul`):

- `ForwardSet := {n | φ(D(n)) < φ(n)}`
- `dblIter_pow2 : D(2^(k+3)) = 3·2^(k+1)`
- `mem_ForwardSet_pow2`, `forward_infinitely_many : ForwardSet.Infinite`
- `not_prime_pow2`, `pow2_family_injective`
- `forward_not_confined_to_primes` — the forward analogue of `reversal_with_composite_landing`; each of `>`, `=`, `<` now runs over an infinite composite family.

## Verification

- Docker build of `Proofs.EulerTotientOQ04OQ03` succeeds (exit 0), full compile from cold cache.
- **0 axioms, 0 sorries** (foundational trio only). File: 494 lines, 35 theorems, 4 defs.

The only remaining open direction is the *density-1* forward statement (almost all `n`), which needs Luca–Pomerance / `ψ(x,y)`-density input — a genuine Mathlib gap, unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)