### PR TITLE
Enrich Erdős #1017 Turán bound: fix section boundary

### DIFF
--- a/src/data/proofs/erdos-1017-oq-02/meta.json
+++ b/src/data/proofs/erdos-1017-oq-02/meta.json
@@ -71,14 +71,14 @@
       "title": "Integer AM-GM Kernel",
       "summary": "four_mul_mul_le_add_sq (4ab <= (a+b)^2) and its strict form four_mul_mul_lt_add_sq (a != b).",
       "startLine": 63,
-      "endLine": 90,
+      "endLine": 83,
       "mathContext": "The square gap (a-b)^2 is exposed by case-splitting a <= b / b <= a and writing the larger as smaller + d, reducing to 0 <= d^2 (resp. 1 <= d^2)."
     },
     {
       "id": "extremality",
       "title": "Upper Bound, Equality at Balance, and Uniqueness",
       "summary": "mul_compl_le_turanBound (a*(n-a) <= T(n)), balanced_mul_compl_eq_turanBound (equality at floor(n/2)), exists_balanced_max (T(n) is the maximum), even_unbalanced_lt (unique maximiser for even n).",
-      "startLine": 91,
+      "startLine": 84,
       "endLine": 149,
       "mathContext": "Nat.le_div_iff_mul_le converts the floor bound to the kernel; parity split plus the closed forms give equality at balance; Nat.lt_of_mul_lt_mul_left cancels the factor 4 for strict uniqueness."
     }


### PR DESCRIPTION
Enrichment pass for `erdos-1017-oq-02` (quality 94, passes 0).

Entry is otherwise complete (6 fully-populated annotations, 4 keyInsights, 6 mainTheorems with accurate line anchors, 3 openQuestions). One accuracy fix:

- `mul_compl_le_turanBound` (docstring Lean lines 84–86, theorem 87–95) was split across the two sections: the 'Integer AM-GM Kernel' section ran to line 90, absorbing this theorem's docstring and head, even though section 3 ('Upper Bound, Equality at Balance, and Uniqueness') lists `mul_compl_le_turanBound` in its own summary.
- Fixed: section 2 `endLine` 90→83 (ends after the AM-GM lemma `four_mul_mul_lt_add_sq`, line 82), section 3 `startLine` 91→84 (starts at the upper-bound theorem's docstring).

No content added/removed. Counts (lineCount 149, theoremCount 8, definitionCount 1, axiomCount 0, sorries 0) verified against source, unchanged. JSON validated.