### PR TITLE
research(dirichlets-oq-02-oq-03): exact primorial-vs-factorial tower comparison C k < B k (k≥1), C k = B k ↔ k=0 [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -407,65 +407,118 @@ tower: `4k + 3 ≤ p3 k ≤ C k`, a strictly tighter ceiling than `p3_bracketed`
 theorem p3_bracketed_primorial (k : ℕ) : 4 * k + 3 ≤ p3 k ∧ p3 k ≤ C k :=
   ⟨p3_ge_linear k, p3_le_primorialTower k⟩
 
-/-! ### The primorial tower never exceeds the factorial tower
+/-! ## Step 6: the primorial tower never exceeds the factorial tower (`C k ≤ B k`)
 
-The worked values suggested `C k` is dramatically smaller than `B k` (`C 1 = 11`
-vs `B 1 = 95`; `C 2 = 131` vs `B 2 = 4·96! − 1`).  We now upgrade this from the
-two verified instances `k = 1, 2` to a **theorem for all `k`**: `C k ≤ B k`.
+`primorial_tighter_than_factorial` established `C 1 < B 1` at the single index
+`k = 1`.  We now upgrade this to a *theorem for all `k`*: the primorial tower `C`
+is dominated by the iterated-factorial tower `B` everywhere, `C k ≤ B k`.
 
-The heart of the argument is the multiplicative gap between the two one-step maps.
-Writing `t = towerProd (k+1) = ∏_{i≤k} C i`, the primorial step gives
-`C (k+1) = 4·t − 1`, whereas the factorial step gives `B (k+1) = 4·(B k + 1)! − 1`.
-So `C (k+1) ≤ B (k+1)` reduces to the single inequality
+The engine is the reduction `C (k+1) ≤ B (k+1) ⇔ towerProd (k+1) ≤ (B k + 1)!`
+(both sides are `4·· − 1`), so it suffices to bound the running product
+`towerProd` by the factorial appearing in `B`.  That product bound is proved by
+induction: writing `F = (B k + 1)!`, the inductive hypothesis gives
+`towerProd (k+1) ≤ F`, and then
+`towerProd (k+2) = towerProd (k+1)·(4·towerProd (k+1) − 1) ≤ F·(4F − 1)
+   ≤ (4F)·(4F − 1) ≤ (4F)! = (B (k+1) + 1)!`,
+using only the elementary factorial lower bound `n·(n−1) ≤ n!`. -/
 
-    towerProd (k+1) ≤ (B k + 1)!.
+/-- Elementary factorial lower bound `n·(n−1) ≤ n!` (from `n! = n·(n−1)!` and
+`n−1 ≤ (n−1)!`).  Supplies the single non-arithmetic step in `C_le_B`. -/
+theorem factorial_ge_mul_pred : ∀ n : ℕ, n * (n - 1) ≤ n !
+  | 0 => by simp
+  | (m + 1) => by
+      rw [Nat.add_sub_cancel, Nat.factorial_succ]
+      exact Nat.mul_le_mul (le_refl (m + 1)) (Nat.self_le_factorial m)
 
-Inductively `towerProd (k+1) = towerProd k · (4·towerProd k − 1) ≤ 4·m²` with
-`m = (B (k−1) + 1)! ≥ towerProd k`, and `4·m² ≤ (4m)! = (B k + 1)!` because a
-factorial dominates the square of its argument (`sq_le_factorial`).  The factorial
-tower's extra `(·)!` at every level therefore swallows the primorial's squaring,
-keeping `C` below `B` uniformly. -/
-
-/-- A factorial dominates the square of its argument once `n ≥ 4`: `n·n ≤ n!`.
-(`4·4 = 16 ≤ 24 = 4!`, and the gap only widens.) -/
-theorem sq_le_factorial : ∀ n : ℕ, 4 ≤ n → n * n ≤ n ! := by
-  intro n hn
-  induction n, hn using Nat.le_induction with
-  | base => decide
-  | succ n hn ih =>
-    rw [Nat.factorial_succ]
-    have h1 : n + 1 ≤ n ! := le_trans (by nlinarith [hn]) ih
-    exact Nat.mul_le_mul (le_refl (n + 1)) h1
-
-/-- **The reduction inequality.**  `towerProd (k+1) = ∏_{i≤k} C i ≤ (B k + 1)!`.
-This is exactly what makes the primorial step stay below the factorial step:
-`C (k+1) = 4·towerProd (k+1) − 1 ≤ 4·(B k + 1)! − 1 = B (k+1)`.  Proved by
-induction; the step bounds `towerProd (k+2) ≤ 4·((B k + 1)!)² ≤ (4·(B k + 1)!)!
-= (B (k+1) + 1)!` via `sq_le_factorial`. -/
+/-- The running product is bounded by the factorial appearing in the next `B`
+step: `towerProd (k+1) ≤ (B k + 1)!`.  This is the crux of `C_le_B`. -/
 theorem towerProd_succ_le_factorial (k : ℕ) : towerProd (k + 1) ≤ (B k + 1)! := by
   induction k with
   | zero => decide
   | succ k ih =>
-    have hm1 : 1 ≤ (B k + 1)! := Nat.factorial_pos _
-    have hBsucc : B (k + 1) + 1 = 4 * (B k + 1)! := by rw [B_succ]; omega
-    have hsq := sq_le_factorial (4 * (B k + 1)!) (by omega)
-    calc towerProd (k + 1 + 1)
-          = towerProd (k + 1) * (4 * towerProd (k + 1) - 1) := towerProd_succ (k + 1)
-      _ ≤ (B k + 1)! * (4 * (B k + 1)!) := Nat.mul_le_mul ih (by omega)
-      _ ≤ (4 * (B k + 1)!) * (4 * (B k + 1)!) := Nat.mul_le_mul (by omega) (le_refl _)
-      _ ≤ (4 * (B k + 1)!)! := hsq
-      _ = (B (k + 1) + 1)! := by rw [hBsucc]
+    have hFpos := Nat.factorial_pos (B k + 1)
+    have hB1 : B (k + 1) + 1 = 4 * (B k + 1)! := by rw [B_succ]; omega
+    rw [towerProd_succ, hB1]
+    set F := (B k + 1)! with hF
+    set tp := towerProd (k + 1) with htp
+    calc tp * (4 * tp - 1)
+        ≤ F * (4 * F - 1) := Nat.mul_le_mul ih (by omega)
+      _ ≤ (4 * F) * (4 * F - 1) := Nat.mul_le_mul (by omega) (le_refl _)
+      _ ≤ (4 * F)! := factorial_ge_mul_pred (4 * F)
 
-/-- **The primorial tower never exceeds the factorial tower: `C k ≤ B k` for all `k`.**
-Upgrades the two verified instances (`primorial_tighter_than_factorial`, `k = 1`;
-`C_two_eq` vs `B 2`) to a uniform theorem.  Both towers certify the same bound
-`p3 k ≤ B k, C k`, but `C` — replacing the running factorial by the running
-primorial — is always the tighter certificate.  `native_decide`-free. -/
+/-- **The primorial tower never exceeds the factorial tower.** For every `k`,
+`C k ≤ B k`: the doubly-exponential primorial tower `C` is dominated everywhere
+by the iterated-factorial tower `B`.  Equality holds only at `k = 0`
+(`C 0 = B 0 = 3`); for `k ≥ 1` the domination is strict already at `k = 1`
+(`C 1 = 11 < 95 = B 1`, see `primorial_tighter_than_factorial`).  This makes the
+tightness of the primorial refinement a *theorem for all `k`* rather than a
+single-index observation. -/
 theorem C_le_B (k : ℕ) : C k ≤ B k := by
   cases k with
   | zero => decide
   | succ k =>
     have h := towerProd_succ_le_factorial k
     rw [C_eq, B_succ]; omega
+
+/-! ## Step 7: the domination is **strict** for every `k ≥ 1` (`C k < B k`)
+
+`C_le_B` gives `C k ≤ B k` everywhere, with equality at `k = 0`
+(`C 0 = B 0 = 3`).  We now upgrade the inequality to a *strict* one for all
+`k ≥ 1`, matching the single-index observation `C 1 = 11 < 95 = B 1` of
+`primorial_tighter_than_factorial`.  The slack is already present in the
+factorial step: the ceiling `n·(n−1) ≤ n!` used in `C_le_B` is in fact *strict*
+for `n ≥ 4` (`n! = n·(n−1)!` and `(n−1)! > (n−1)` once `n−1 ≥ 3`), and the
+argument `4·(B k + 1)! ≥ 4` always lands in that regime.  So the running-product
+bound `towerProd (k+1) ≤ (B k + 1)!` sharpens to a strict `<`, and the strictness
+transfers to `C (k+1) < B (k+1)` because both towers apply the same monotone
+`x ↦ 4·(x+1)! − 1` (resp. `x ↦ 4·x − 1`) map. -/
+
+/-- Strict elementary factorial bound `n·(n−1) < n!` for `n ≥ 4`.  From
+`n! = n·(n−1)!` together with `(n−1) < (n−1)!` (valid since `n − 1 ≥ 3`), i.e.
+`Nat.lt_factorial_self`.  This is the strict refinement of `factorial_ge_mul_pred`
+that supplies the strictness in `C_lt_B`. -/
+theorem factorial_gt_mul_pred {n : ℕ} (hn : 4 ≤ n) : n * (n - 1) < n ! := by
+  obtain ⟨p, rfl⟩ : ∃ p, n = p + 1 := ⟨n - 1, by omega⟩
+  have hp : 3 ≤ p := by omega
+  have hlt : p < p ! := Nat.lt_factorial_self hp
+  rw [Nat.add_sub_cancel, Nat.factorial_succ]
+  exact mul_lt_mul_of_pos_left hlt (by omega)
+
+/-- Strict running-product bound `towerProd (k+1) < (B k + 1)!`.  Identical to
+`towerProd_succ_le_factorial` except the final factorial step is strict via
+`factorial_gt_mul_pred` (its argument `4·(B k + 1)!` is always `≥ 4`). -/
+theorem towerProd_succ_lt_factorial (k : ℕ) : towerProd (k + 1) < (B k + 1)! := by
+  induction k with
+  | zero => decide
+  | succ k ih =>
+    have hFpos := Nat.factorial_pos (B k + 1)
+    have hB1 : B (k + 1) + 1 = 4 * (B k + 1)! := by rw [B_succ]; omega
+    rw [towerProd_succ, hB1]
+    set F := (B k + 1)! with hF
+    set tp := towerProd (k + 1) with htp
+    calc tp * (4 * tp - 1)
+        ≤ F * (4 * F - 1) := Nat.mul_le_mul (by omega) (by omega)
+      _ ≤ (4 * F) * (4 * F - 1) := Nat.mul_le_mul (by omega) (le_refl _)
+      _ < (4 * F)! := factorial_gt_mul_pred (by omega)
+
+/-- **The primorial tower is strictly below the factorial tower for every
+`k ≥ 1`.**  `C k < B k` whenever `k ≥ 1`, sharpening `C_le_B` (which allows
+equality) and promoting the single-index fact `C 1 = 11 < 95 = B 1` to a theorem
+for all `k ≥ 1`.  Equality holds *only* at `k = 0` (`C 0 = B 0 = 3`), so together
+with `C_le_B` this pins down the comparison exactly: `C k = B k ⇔ k = 0`. -/
+theorem C_lt_B {k : ℕ} (hk : 1 ≤ k) : C k < B k := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  have h := towerProd_succ_lt_factorial j
+  rw [C_eq, B_succ]; omega
+
+/-- **Exact comparison of the two towers.** `C k = B k` if and only if `k = 0`;
+for all `k ≥ 1` the primorial tower is strictly smaller.  Combines `C_le_B`,
+`C_lt_B`, and the base equality `C 0 = B 0 = 3`. -/
+theorem C_eq_B_iff (k : ℕ) : C k = B k ↔ k = 0 := by
+  constructor
+  · intro h
+    by_contra hk
+    exact absurd h (Nat.ne_of_lt (C_lt_B (by omega)))
+  · rintro rfl; decide
 
 end DirichletsTheoremOQ02OQ03

--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -407,4 +407,65 @@ tower: `4k + 3 ≤ p3 k ≤ C k`, a strictly tighter ceiling than `p3_bracketed`
 theorem p3_bracketed_primorial (k : ℕ) : 4 * k + 3 ≤ p3 k ∧ p3 k ≤ C k :=
   ⟨p3_ge_linear k, p3_le_primorialTower k⟩
 
+/-! ### The primorial tower never exceeds the factorial tower
+
+The worked values suggested `C k` is dramatically smaller than `B k` (`C 1 = 11`
+vs `B 1 = 95`; `C 2 = 131` vs `B 2 = 4·96! − 1`).  We now upgrade this from the
+two verified instances `k = 1, 2` to a **theorem for all `k`**: `C k ≤ B k`.
+
+The heart of the argument is the multiplicative gap between the two one-step maps.
+Writing `t = towerProd (k+1) = ∏_{i≤k} C i`, the primorial step gives
+`C (k+1) = 4·t − 1`, whereas the factorial step gives `B (k+1) = 4·(B k + 1)! − 1`.
+So `C (k+1) ≤ B (k+1)` reduces to the single inequality
+
+    towerProd (k+1) ≤ (B k + 1)!.
+
+Inductively `towerProd (k+1) = towerProd k · (4·towerProd k − 1) ≤ 4·m²` with
+`m = (B (k−1) + 1)! ≥ towerProd k`, and `4·m² ≤ (4m)! = (B k + 1)!` because a
+factorial dominates the square of its argument (`sq_le_factorial`).  The factorial
+tower's extra `(·)!` at every level therefore swallows the primorial's squaring,
+keeping `C` below `B` uniformly. -/
+
+/-- A factorial dominates the square of its argument once `n ≥ 4`: `n·n ≤ n!`.
+(`4·4 = 16 ≤ 24 = 4!`, and the gap only widens.) -/
+theorem sq_le_factorial : ∀ n : ℕ, 4 ≤ n → n * n ≤ n ! := by
+  intro n hn
+  induction n, hn using Nat.le_induction with
+  | base => decide
+  | succ n hn ih =>
+    rw [Nat.factorial_succ]
+    have h1 : n + 1 ≤ n ! := le_trans (by nlinarith [hn]) ih
+    exact Nat.mul_le_mul (le_refl (n + 1)) h1
+
+/-- **The reduction inequality.**  `towerProd (k+1) = ∏_{i≤k} C i ≤ (B k + 1)!`.
+This is exactly what makes the primorial step stay below the factorial step:
+`C (k+1) = 4·towerProd (k+1) − 1 ≤ 4·(B k + 1)! − 1 = B (k+1)`.  Proved by
+induction; the step bounds `towerProd (k+2) ≤ 4·((B k + 1)!)² ≤ (4·(B k + 1)!)!
+= (B (k+1) + 1)!` via `sq_le_factorial`. -/
+theorem towerProd_succ_le_factorial (k : ℕ) : towerProd (k + 1) ≤ (B k + 1)! := by
+  induction k with
+  | zero => decide
+  | succ k ih =>
+    have hm1 : 1 ≤ (B k + 1)! := Nat.factorial_pos _
+    have hBsucc : B (k + 1) + 1 = 4 * (B k + 1)! := by rw [B_succ]; omega
+    have hsq := sq_le_factorial (4 * (B k + 1)!) (by omega)
+    calc towerProd (k + 1 + 1)
+          = towerProd (k + 1) * (4 * towerProd (k + 1) - 1) := towerProd_succ (k + 1)
+      _ ≤ (B k + 1)! * (4 * (B k + 1)!) := Nat.mul_le_mul ih (by omega)
+      _ ≤ (4 * (B k + 1)!) * (4 * (B k + 1)!) := Nat.mul_le_mul (by omega) (le_refl _)
+      _ ≤ (4 * (B k + 1)!)! := hsq
+      _ = (B (k + 1) + 1)! := by rw [hBsucc]
+
+/-- **The primorial tower never exceeds the factorial tower: `C k ≤ B k` for all `k`.**
+Upgrades the two verified instances (`primorial_tighter_than_factorial`, `k = 1`;
+`C_two_eq` vs `B 2`) to a uniform theorem.  Both towers certify the same bound
+`p3 k ≤ B k, C k`, but `C` — replacing the running factorial by the running
+primorial — is always the tighter certificate.  `native_decide`-free. -/
+theorem C_le_B (k : ℕ) : C k ≤ B k := by
+  cases k with
+  | zero => decide
+  | succ k =>
+    have h := towerProd_succ_le_factorial k
+    rw [C_eq, B_succ]; omega
+
 end DirichletsTheoremOQ02OQ03

--- a/research/knowledge/technique-index.json
+++ b/research/knowledge/technique-index.json
@@ -94,6 +94,14 @@
       ],
       "outcome": "success",
       "date": "2026-07-04"
+    },
+    {
+      "name": "Strict inequality via Nat.lt_factorial_self",
+      "used_in_problems": [
+        "dirichlets-theorem-oq-02-oq-03"
+      ],
+      "outcome": "success",
+      "date": "2026-07-08"
     }
   ]
 }

--- a/research/problems/dirichlets-theorem-oq-02-oq-03/state.md
+++ b/research/problems/dirichlets-theorem-oq-02-oq-03/state.md
@@ -1,9 +1,9 @@
 # Research State: dirichlets-theorem-oq-02-oq-03
 
 ## Current State
-**Phase**: COMPLETED
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-08
+**Since**: 2026-07-08T14:15:19-07:00
 **Iteration**: 2
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -33910,11 +33910,11 @@
     },
     {
       "slug": "dirichlets-theorem-oq-02-oq-03",
-      "phase": "COMPLETED",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-07-02T05:53:08.467Z",
       "status": "graduated",
-      "lastUpdate": "2026-07-02T05:53:08.467Z",
+      "lastUpdate": "2026-07-08T14:15:19-07:00",
       "completed": "2026-07-02T05:53:08.467Z"
     },
     {

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): C_le_B now proves the primorial tower C k ≤ B k for ALL k (previously only the instances k=1,2 were checked), making the primorial certificate provably at least as tight as the factorial tower everywhere. Reduction lemma towerProd_succ_le_factorial + reusable n²≤n! (n≥4). 0 axioms, 0 sorries, native_decide-free (propext/Classical.choice/Quot.sound only).",
+    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): the primorial-vs-factorial comparison is now PINNED DOWN EXACTLY. C_le_B gives C k ≤ B k for all k, and the strict refinement C_lt_B gives C k < B k for every k ≥ 1, with equality only at k=0 (C_eq_B_iff: C k = B k ↔ k = 0). Engine: strict n·(n−1) < n! (n≥4) via Nat.lt_factorial_self, propagated through towerProd_succ_lt_factorial. native_decide-free, 0 axioms, 0 sorries.",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
@@ -41,7 +41,11 @@
       "C_one_eq=11, C_two_eq=131, primorial_tighter_than_factorial (7≤11=C1<95=B1), p3_bracketed_primorial (4k+3 ≤ p3 k ≤ C k). All 0 sorry / 0 axiom (foundational trio only), native_decide-free.",
       "C_le_B (DirichletsTheoremOQ02OQ03.lean §\"primorial tower never exceeds factorial tower\") — VERIFIED 0/0 (propext/Classical.choice/Quot.sound only): the primorial tower C k ≤ B k for ALL k, upgrading the two verified instances (k=1: 11≤95; k=2: 131 vs 4·96!−1) to a uniform theorem. Reduces to towerProd_succ_le_factorial via the one-step maps.",
       "towerProd_succ_le_factorial — the reduction inequality towerProd (k+1) = ∏_{i≤k} C i ≤ (B k + 1)!, which is exactly C (k+1) ≤ B (k+1). Proved by induction; step bounds towerProd (k+2) ≤ 4·((B k+1)!)² ≤ (4·(B k+1)!)! = (B (k+1)+1)!.",
-      "sq_le_factorial — reusable: n·n ≤ n! for n ≥ 4 (Nat.le_induction from 16≤24; step (n+1)² ≤ (n+1)·n! since n+1 ≤ n! ). This is the engine that lets the factorial tower swallow the primorial's squaring."
+      "sq_le_factorial — reusable: n·n ≤ n! for n ≥ 4 (Nat.le_induction from 16≤24; step (n+1)² ≤ (n+1)·n! since n+1 ≤ n! ). This is the engine that lets the factorial tower swallow the primorial's squaring.",
+      "factorial_gt_mul_pred (DirichletsTheoremOQ02OQ03.lean:480) — strict n·(n−1) < n! for n≥4 via n!=n·(n−1)! and Nat.lt_factorial_self ((n−1) < (n−1)! for n−1≥3). Strict refinement of factorial_ge_mul_pred; supplies the slack for C_lt_B.",
+      "towerProd_succ_lt_factorial (DirichletsTheoremOQ02OQ03.lean:490) — strict running-product bound towerProd (k+1) < (B k + 1)!, by induction with the strict factorial step; the arg 4·(B k+1)! is always ≥4 so factorial_gt_mul_pred applies.",
+      "C_lt_B (DirichletsTheoremOQ02OQ03.lean:509) — VERIFIED 0/0: the primorial tower is STRICTLY below the factorial tower, C k < B k for all k≥1, promoting the single-index C 1=11<95=B 1 to a theorem.",
+      "C_eq_B_iff (DirichletsTheoremOQ02OQ03.lean:517) — VERIFIED 0/0: exact comparison C k = B k ↔ k = 0; combines C_le_B, C_lt_B and the base equality C 0 = B 0 = 3."
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
@@ -51,13 +55,14 @@
       "The Euclid ≡3(mod4) construction only needs the PRODUCT of the primes found so far, not a factorial of the previous bound: N=4·(∏_{i<k}p3 i)−1 is ≡3 mod4, its ≡3-mod4 prime factor p cannot divide ∏p3 i (else p∣4·∏ and p∣N ⇒ p∣1), so p is new and p3 k ≤ p ≤ N. This gives the PRIMORIAL bound p3 k ≤ 4·∏_{i<k}p3 i − 1, dramatically tighter than the factorial tower.",
       "The primorial tower C(k)=4·(∏_{i<k}C i)−1 (C0=3,C1=11,C2=131,C3=17291) is doubly-exponential but incomparably smaller than the iterated-factorial tower B (B2=4·96!−1). p3 k ≤ C k follows by STRONG induction feeding p3_le_primorial the pointwise p3 i ≤ C i for i<k via Finset.prod_le_prod.",
       "Structural-recursion trick for a product-defined tower: define the running product towerProd k (towerProd 0=1, towerProd(k+1)=towerProd k·(4·towerProd k−1)) structurally, set C k := 4·towerProd k−1, then prove towerProd k = ∏_{i<k} C i by induction (prod_range_succ). Avoids non-structural self-reference of C.",
-      "The factorial tower B and primorial tower C differ only in their one-step map (4·(prev+1)!−1 vs 4·prev−1). C k ≤ B k holds uniformly because the extra factorial at every level dominates the squaring the primorial recursion introduces: towerProd(k+2) ≈ 4·towerProd(k+1)² while (B(k+1)+1)! = (4·(B k+1)!)! ≥ (4·(B k+1)!)² ≥ that. Formalised via the elementary lemma n² ≤ n! (n≥4)."
+      "The factorial tower B and primorial tower C differ only in their one-step map (4·(prev+1)!−1 vs 4·prev−1). C k ≤ B k holds uniformly because the extra factorial at every level dominates the squaring the primorial recursion introduces: towerProd(k+2) ≈ 4·towerProd(k+1)² while (B(k+1)+1)! = (4·(B k+1)!)! ≥ (4·(B k+1)!)² ≥ that. Formalised via the elementary lemma n² ≤ n! (n≥4).",
+      "The ≤-domination C k ≤ B k is in fact STRICT for every k≥1: the only inequality used (n·(n−1) ≤ n!) is itself strict once n≥4 (n! = n·(n−1)! and (n−1) < (n−1)! for n−1≥3), and the towers factorial argument 4·(B k+1)! is always ≥4, so the strictness propagates and equality survives ONLY at the base k=0 where both towers equal 3."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Attempt a genuinely elementary sub-exponential certified bound (or prove the primorial tower's doubly-exponential growth is intrinsic to Euclid-style iteration without an analytic input).",
+      "Attempt a genuinely elementary sub-exponential certified bound (or prove the primorial tower´s doubly-exponential growth is intrinsic to Euclid-style iteration without an analytic input).",
       "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1).",
-      "Strengthen C_le_B to strict C k < B k for k ≥ 1 (already have C 1 < B 1; the ≤-chain has slack at every step so a strict version should go through)."
+      "Quantify the gap growth: prove B k / C k → ∞ (or a lower bound like B k ≥ C k · (something growing), since each factorial step swaps a squaring for a full factorial)."
     ],
     "markdown": "# Knowledge Base: dirichlets-theorem-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): added the sharper PRIMORIAL certified bound p3 k ≤ 4·(∏_{i<k} p3 i) − 1 and its explicit tower C (C1=11 vs B1=95, C2=131 vs B2=4·96!−1), strictly tighter than the iterated-factorial tower while remaining honest against p_k∼2k·ln k. native_decide-free, 0 axioms, 0 sorries.",
+    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): C_le_B now proves the primorial tower C k ≤ B k for ALL k (previously only the instances k=1,2 were checked), making the primorial certificate provably at least as tight as the factorial tower everywhere. Reduction lemma towerProd_succ_le_factorial + reusable n²≤n! (n≥4). 0 axioms, 0 sorries, native_decide-free (propext/Classical.choice/Quot.sound only).",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
@@ -38,7 +38,10 @@
       "p3_one=7, B_one=95, tower_loose_at_one (DirichletsTheoremOQ02OQ03.lean:209–229) — worked values quantifying looseness. Verified 0 sorry / 0 axiom, 7743 jobs.",
       "p3_le_primorial (DirichletsTheoremOQ02OQ03.lean) — primorial bound p3 k ≤ 4·(∏_{i<k} p3 i) − 1, the certified content of the primorial Euclid construction.",
       "towerProd + C + towerProd_eq_prod + p3_le_primorialTower — explicit primorial tower C with p3 k ≤ C k (strong induction).",
-      "C_one_eq=11, C_two_eq=131, primorial_tighter_than_factorial (7≤11=C1<95=B1), p3_bracketed_primorial (4k+3 ≤ p3 k ≤ C k). All 0 sorry / 0 axiom (foundational trio only), native_decide-free."
+      "C_one_eq=11, C_two_eq=131, primorial_tighter_than_factorial (7≤11=C1<95=B1), p3_bracketed_primorial (4k+3 ≤ p3 k ≤ C k). All 0 sorry / 0 axiom (foundational trio only), native_decide-free.",
+      "C_le_B (DirichletsTheoremOQ02OQ03.lean §\"primorial tower never exceeds factorial tower\") — VERIFIED 0/0 (propext/Classical.choice/Quot.sound only): the primorial tower C k ≤ B k for ALL k, upgrading the two verified instances (k=1: 11≤95; k=2: 131 vs 4·96!−1) to a uniform theorem. Reduces to towerProd_succ_le_factorial via the one-step maps.",
+      "towerProd_succ_le_factorial — the reduction inequality towerProd (k+1) = ∏_{i≤k} C i ≤ (B k + 1)!, which is exactly C (k+1) ≤ B (k+1). Proved by induction; step bounds towerProd (k+2) ≤ 4·((B k+1)!)² ≤ (4·(B k+1)!)! = (B (k+1)+1)!.",
+      "sq_le_factorial — reusable: n·n ≤ n! for n ≥ 4 (Nat.le_induction from 16≤24; step (n+1)² ≤ (n+1)·n! since n+1 ≤ n! ). This is the engine that lets the factorial tower swallow the primorial's squaring."
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
@@ -47,13 +50,14 @@
       "The whole development is native_decide-free: the only numeric fact (B 1 = 95) is discharged by kernel decide, so axiomCount stays 0 (verified, not axiomatized).",
       "The Euclid ≡3(mod4) construction only needs the PRODUCT of the primes found so far, not a factorial of the previous bound: N=4·(∏_{i<k}p3 i)−1 is ≡3 mod4, its ≡3-mod4 prime factor p cannot divide ∏p3 i (else p∣4·∏ and p∣N ⇒ p∣1), so p is new and p3 k ≤ p ≤ N. This gives the PRIMORIAL bound p3 k ≤ 4·∏_{i<k}p3 i − 1, dramatically tighter than the factorial tower.",
       "The primorial tower C(k)=4·(∏_{i<k}C i)−1 (C0=3,C1=11,C2=131,C3=17291) is doubly-exponential but incomparably smaller than the iterated-factorial tower B (B2=4·96!−1). p3 k ≤ C k follows by STRONG induction feeding p3_le_primorial the pointwise p3 i ≤ C i for i<k via Finset.prod_le_prod.",
-      "Structural-recursion trick for a product-defined tower: define the running product towerProd k (towerProd 0=1, towerProd(k+1)=towerProd k·(4·towerProd k−1)) structurally, set C k := 4·towerProd k−1, then prove towerProd k = ∏_{i<k} C i by induction (prod_range_succ). Avoids non-structural self-reference of C."
+      "Structural-recursion trick for a product-defined tower: define the running product towerProd k (towerProd 0=1, towerProd(k+1)=towerProd k·(4·towerProd k−1)) structurally, set C k := 4·towerProd k−1, then prove towerProd k = ∏_{i<k} C i by induction (prod_range_succ). Avoids non-structural self-reference of C.",
+      "The factorial tower B and primorial tower C differ only in their one-step map (4·(prev+1)!−1 vs 4·prev−1). C k ≤ B k holds uniformly because the extra factorial at every level dominates the squaring the primorial recursion introduces: towerProd(k+2) ≈ 4·towerProd(k+1)² while (B(k+1)+1)! = (4·(B k+1)!)! ≥ (4·(B k+1)!)² ≥ that. Formalised via the elementary lemma n² ≤ n! (n≥4)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove the primorial tower never exceeds the factorial tower in general: C k ≤ B k (needs ∏_{i<k} C i ≤ (B(k-1)+1)!), making the tightness a theorem for all k rather than just k=1,2.",
       "Attempt a genuinely elementary sub-exponential certified bound (or prove the primorial tower's doubly-exponential growth is intrinsic to Euclid-style iteration without an analytic input).",
-      "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1)."
+      "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1).",
+      "Strengthen C_le_B to strict C k < B k for k ≥ 1 (already have C 1 < B 1; the ≤-chain has slack at every step so a strict version should go through)."
     ],
     "markdown": "# Knowledge Base: dirichlets-theorem-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Pins down the comparison between the **primorial certificate tower** `C` and the **iterated-factorial tower** `B` for the Euclid `≡3 (mod 4)` construction, exactly:

- `C_le_B` : `C k ≤ B k` for all `k` (previously only instances `k=1,2` were checked).
- `C_lt_B` : `C k < B k` for **every** `k ≥ 1` (strict domination).
- `C_eq_B_iff` : `C k = B k ↔ k = 0` (equality survives only at the base, where both equal 3).

## Method

The single inequality underlying the `≤`-tower, `n·(n−1) ≤ n!`, is in fact **strict** for `n ≥ 4` (`factorial_gt_mul_pred`, via `n! = n·(n−1)!` and `Nat.lt_factorial_self`). Since the towers' factorial argument `4·(B k + 1)!` is always `≥ 4`, the strictness propagates through `towerProd_succ_lt_factorial` and transfers to `C_lt_B`.

## Verification

- File: `proofs/Proofs/DirichletsTheoremOQ02OQ03.lean`
- Docker build: `Built Proofs.DirichletsTheoremOQ02OQ03` (7743 jobs), **0 sorries, 0 axioms, native_decide-free** (foundational `propext`/`Classical.choice`/`Quot.sound` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)