### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-02): n=0 companion ĉ₀(f')=0 [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
@@ -79,4 +79,39 @@ theorem fourierCoeffOn_deriv2_periodic (f : ℝ → ℝ) (hf : ContDiff ℝ 2 f)
       I_mul_I]
   ring
 
+/-- **The `n = 0` companion**: the derivative of a periodic function has zero
+    mean, i.e. its zeroth Fourier coefficient vanishes,
+
+        ĉ₀(f') = 0.
+
+    Whereas `fourierCoeffOn_deriv_periodic` needs `n ≠ 0` (it divides by `n`), the
+    zero mode is governed by the fundamental theorem of calculus: for a `C¹`
+    periodic `f` the character `fourier 0` is constant `1`, so `ĉ₀(f')` is the
+    average of `f'` over one period, and `∫₀^{2π} f' = f(2π) − f(0) = 0` by
+    periodicity.  Together with the `−n²` eigenvalue for `n ≠ 0` this pins down
+    the full spectrum of the differentiation operator on periodic functions:
+    `0` on constants, `i·n` on the `n`-th harmonic. -/
+theorem fourierCoeffOn_deriv_zero_periodic (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
+    (hperiod : ∀ t, f (t + 2 * π) = f t) (hab : (0 : ℝ) < 2 * π) :
+    fourierCoeffOn hab (ofReal ∘ deriv f) 0 = 0 := by
+  rw [fourierCoeffOn_eq_integral]
+  -- The zero character is constant `1`, so the integrand is just `f'`.
+  simp only [neg_zero, fourier_zero, one_smul]
+  -- `f` is differentiable and `f'` is interval-integrable (it is continuous).
+  have hderiv : ∀ x ∈ Set.uIcc (0 : ℝ) (2 * π), DifferentiableAt ℝ f x :=
+    fun x _ => hf.differentiable le_rfl x
+  have hint : IntervalIntegrable (deriv f) MeasureTheory.volume 0 (2 * π) :=
+    (hf.continuous_deriv le_rfl).intervalIntegrable 0 (2 * π)
+  -- FTC: the integral of the derivative over a period is the boundary difference.
+  have hz : ∫ x in (0 : ℝ)..(2 * π), deriv f x = f (2 * π) - f 0 :=
+    intervalIntegral.integral_deriv_eq_sub hderiv hint
+  -- Periodicity makes that boundary difference vanish.
+  have hfp : f (2 * π) = f 0 := by have h := hperiod 0; rwa [zero_add] at h
+  -- Push `ofReal` through the (real) integral, then apply the two facts above.
+  have hcomp : (∫ x in (0 : ℝ)..(2 * π), (ofReal ∘ deriv f) x)
+      = ((∫ x in (0 : ℝ)..(2 * π), deriv f x : ℝ) : ℂ) := by
+    simp only [Function.comp]
+    exact intervalIntegral.integral_ofReal
+  rw [hcomp, hz, hfp, sub_self, ofReal_zero, smul_zero]
+
 end IsoperimetricFourier

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
@@ -10,17 +10,18 @@
       "The −n² eigenvalue is exactly what drives Wirtinger's inequality: every Fourier mode of f'' contributes a factor n² ≥ 1, with equality only on the first harmonic — the circle, the equality case of C² ≥ 4πA.",
       "Mathlib does NOT package 'derivative of a periodic function is periodic' (no Function.Periodic.deriv on this toolchain). Proved here from deriv_comp_add_const: since (fun x ↦ f (x+T)) = f, their derivatives agree, giving f'(t+T) = f'(t).",
       "ContDiff ℝ 1 (deriv f) is extracted from ContDiff ℝ 2 f via contDiff_succ_iff_deriv (n := 1) |>.2.2 — note the current 3-way conjunction (Differentiable ∧ (n=ω→AnalyticOn) ∧ ContDiff n (deriv f)).",
-      "(i·n)·(i·n) collapses to −n² via Complex.I_mul_I (I*I = -1) after a ring normalization that pulls out (I*I)·n²."
+      "(i·n)·(i·n) collapses to −n² via Complex.I_mul_I (I*I = -1) after a ring normalization that pulls out (I*I)·n².",
+      "The n=0 companion is governed by FTC, not the i·n divide-by-n identity: fourier 0 = 1 so c₀(f') is the period-average of f', and intervalIntegral.integral_deriv_eq_sub + periodicity forces it to 0. Together with the -n² eigenvalue (n≠0) this pins the full differentiation spectrum: 0 on constants, i·n on the n-th harmonic."
     ],
     "builtItems": [
-      "AreaOfCircleOQ01OQ02OQ02OQ02.lean: 2 theorems, 0 axioms, 0 sorries, imports and reuses the parent IBP identity.",
+      "AreaOfCircleOQ01OQ02OQ02OQ02.lean: 3 theorems, 0 axioms, 0 sorries, imports and reuses the parent IBP identity. VERIFIED via docker build (Built [7744/7744]).",
       "deriv_periodic_of_periodic: the derivative of a T-periodic function is T-periodic.",
-      "fourierCoeffOn_deriv2_periodic: ĉₙ(f'') = −n²·ĉₙ(f) for C² periodic f, n ≠ 0."
+      "fourierCoeffOn_deriv2_periodic: cₙ(f'') = -n²·cₙ(f) for C² periodic f, n ≠ 0.",
+      "fourierCoeffOn_deriv_zero_periodic: c₀(f') = 0 for C¹ periodic f (zero mode), via FTC ∫ f' = f(2π)-f(0) = 0."
     ],
-    "progressSummary": "Child of area-of-circle-oq-01-oq-02-oq-02 (Isoperimetric Inequality via Fourier analysis). The parent gives the first-order IBP identity ĉₙ(f')=i·n·ĉₙ(f); this entry iterates it to the second-order identity ĉₙ(f'')=−n²·ĉₙ(f), the −n² eigenvalue underlying Wirtinger's inequality and the equality case (the circle). Also supplies the missing lemma that the derivative of a periodic function is periodic. Both 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide.",
+    "progressSummary": "PROGRESS: n=0 companion c₀(f')=0 proved and VERIFIED (0/0), completing the spectral picture of d/dx on periodic functions (3 theorems total). Remaining: Wirtinger via Parseval, then isoperimetric assembly.",
     "nextSteps": [
-      "Assemble Wirtinger's inequality ∫|f'|² ≥ ∫|f|² (mean-zero f, period 2π) from the n²≥1 Fourier-mode bound and Parseval.",
-      "Prove the n=0 companion ĉ₀(f') = 0 (derivative of a periodic function has zero mean) to complete the spectral picture.",
+      "Assemble Wirtinger inequality ∫|f'|² ≥ ∫|f|² (mean-zero f, period 2π) from the n²≥1 Fourier-mode bound and Parseval; requires fourierCoeffOn Parseval/completeness for periodic functions (assess Mathlib fourierCoeff L² isometry availability).",
       "Combine with the area/perimeter Fourier expansions to close the isoperimetric inequality C² ≥ 4πA with the circle as the equality case."
     ]
   },


### PR DESCRIPTION
## Summary

Adds the **n = 0 companion** to the second-derivative Fourier identity for the isoperimetric-inequality program, in `Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean`:

```
fourierCoeffOn_deriv_zero_periodic :  ĉ₀(f') = 0   (C¹ periodic f)
```

Whereas the parent's `fourierCoeffOn_deriv_periodic` needs `n ≠ 0` (it divides by `n`), the zero mode is governed by the **fundamental theorem of calculus**: `fourier 0 ≡ 1`, so `ĉ₀(f')` is the period-average of `f'`, and `∫₀^{2π} f' = f(2π) − f(0) = 0` by periodicity.

Together with the existing `−n²` eigenvalue (for `n ≠ 0`), this pins down the **full spectrum** of the differentiation operator on `2π`-periodic functions: `0` on constants, `i·n` on the `n`-th harmonic. It completes a documented `nextStep` toward Wirtinger's inequality and the Fourier (Hurwitz) proof of the isoperimetric inequality `C² ≥ 4πA`.

## Status

- File: **3 theorems, 0 axioms, 0 sorries**
- Docker-build **verified green** (`Built [7744/7744]`). First attempt hit a line-less exit-135 SIGBUS from cold-cache decompression volume corruption; green on retry (byte-identical source).
- `#print axioms` foundation only (`propext`/`Classical.choice`/`Quot.sound`), no `native_decide`.

## Files
- `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean` — new theorem
- `src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json` — knowledge update

🤖 Generated with [Claude Code](https://claude.com/claude-code)