### PR TITLE
Enrich Erdős #11 decidability: add header/framing section

### DIFF
--- a/src/data/proofs/erdos-11-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-11-wip-01-oq-01/meta.json
@@ -63,6 +63,14 @@
   },
   "sections": [
     {
+      "id": "overview-setup",
+      "title": "Framing: Completing the Parent's Decidability Claim",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "Module docstring framing Erdős #11 (OPEN: is every odd n > 1 the sum of a squarefree number and a power of two?) and the specific gap this file fills — the parent erdos-11-wip-01 proved the bounded characterization isSquarefreePlusPow2_iff and called it a 'decidable characterization' but never registered the Decidable instance. Lists the three results (the instance, the k = 0 sufficient family, the n = 1 boundary). Imports the verified parent (Proofs.Erdos11WIP01) and opens Finset.",
+      "mathContext": "Parent: IsSquarefreePlusPow2 n ↔ ∃ k ∈ range (n+1), 2^k ≤ n ∧ Squarefree (n − 2^k); this file registers the instance from that equivalence and derives its first structural consequences."
+    },
+    {
       "id": "decidable",
       "title": "The Decidability Instance",
       "startLine": 35,


### PR DESCRIPTION
Enrichment pass for `erdos-11-wip-01-oq-01` (quality 94, passes 0).

Entry uses the openQuestion schema (highlights/implications, no mainTheorems array — correct for this schema). Annotations (5, all fully populated), keyInsights (4), conclusion, and counts (lineCount 68, theoremCount 2, definitionCount 0, axiomCount 0, sorries 0, verified against source) are all accurate. One coverage gap:

- The `sections` array began at line 35 (the decidability instance), leaving the module docstring and framing (lines 1–34) with no section. A reader stepping through sections never saw the problem statement or the parent-gap this file fills.
- Added an `overview-setup` section spanning lines 1–34.

No content removed; meta.json 10.1→11.0 KB. JSON validated.