### PR TITLE
research(cauchy-interlacing-oq-02-oq-01): compression=restriction iff invariant [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
@@ -181,4 +181,25 @@ theorem compress_eq_restrict_of_invariant {T : V →ₗ[𝕜] V} (H : Submodule 
   -- `ext` already reduces to the coerced (ambient-`V`) equality of the images.
   exact (coe_compress_of_invariant H hinv y).trans (LinearMap.restrict_coe_apply T hinv y).symm
 
+/-- **The compression is a genuine restriction iff the subspace is invariant.**
+
+Converse of `coe_compress_of_invariant`.  The orthogonal compression `compress T H`
+acts as `T` itself on `H` — pointwise `↑(compress T H y) = T ↑y`, i.e. it incurs
+*no* projection error — **iff** `H` is `T`-invariant.
+
+The forward direction is `coe_compress_of_invariant`.  Conversely, `compress T H y`
+is by construction an element of `H`, so its coercion `↑(compress T H y)` always
+lies in `H`; if that coercion equals `T ↑y`, then `T ↑y ∈ H`, which is exactly
+invariance.  This pins down the attainment case of the interlacing bound: the
+compression stops losing spectral information *precisely* on invariant subspaces. -/
+theorem coe_compress_eq_iff_invariant {T : V →ₗ[𝕜] V} (H : Submodule 𝕜 V) :
+    (∀ y : H, ((compress T H y : H) : V) = T (y : V)) ↔ (∀ y ∈ H, T y ∈ H) := by
+  constructor
+  · intro h y hy
+    have key : T y = ((compress T H ⟨y, hy⟩ : H) : V) := (h ⟨y, hy⟩).symm
+    rw [key]
+    exact SetLike.coe_mem _
+  · intro hinv y
+    exact coe_compress_of_invariant H hinv y
+
 end CauchyInterlacing.PoincareCompression

--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
@@ -31,22 +31,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (phantom deliverable pre-existed, verified 0/0). Researcher-9 (2026-07-08) added the tightness/attainment companion: the compression onto a T-invariant subspace equals the honest restriction T.restrict, characterising the equality case of the interlacing bound.",
+    "progressSummary": "COMPLETE + attainment iff added (verified 0/0): coe_compress_eq_iff_invariant closes the converse (nextStep 2) — the compression is a genuine restriction iff H is T-invariant. Remaining open: the spectral sub-multiset consequence (nextStep 1).",
     "builtItems": [
       "poincare_separation_compression in CauchyInterlacingPoincareCompression.lean (#28084) — unconditional codimension-m Poincaré separation: given a symmetric T on V (dim n+m) and any subspace H (dim n), the descending eigenvalues of the explicit orthogonal compression compress T H interlace those of T as lam⟨k+m⟩ ≤ mu k ≤ lam⟨k⟩, with NO Rayleigh side hypothesis.",
       "compress / isSymmetric_compress / rayleigh_compress_eq in CauchyInterlacingCompression.lean (#27245) — define compress T H := P_H∘T∘ι_H, prove it symmetric, and discharge the Rayleigh-agreement identity for an arbitrary subspace via the orthogonal-projection adjoint identity.",
       "poincare_separation_compression_span — same result compressing onto span of an orthonormal frame; cauchy_interlacing_compression_of_poincare — the m=1 corollary.",
-      "compress_eq_restrict_of_invariant + coe_compress_of_invariant (researcher-9, CauchyInterlacingPoincareCompression.lean) — if H is T-invariant (∀ y∈H, T y∈H) then compress T H = T.restrict hinv as operators H→ₗH; pointwise ↑(compress T H y)=T ↑y. Proof: compress_apply, then the orthogonal projection is inert on T ↑y∈H via coe_orthogonalProjection_apply + starProjection_eq_self_iff.mpr. This is the attainment/tightness case of Poincaré separation."
+      "compress_eq_restrict_of_invariant + coe_compress_of_invariant (researcher-9, CauchyInterlacingPoincareCompression.lean) — if H is T-invariant (∀ y∈H, T y∈H) then compress T H = T.restrict hinv as operators H→ₗH; pointwise ↑(compress T H y)=T ↑y. Proof: compress_apply, then the orthogonal projection is inert on T ↑y∈H via coe_orthogonalProjection_apply + starProjection_eq_self_iff.mpr. This is the attainment/tightness case of Poincaré separation.",
+      "coe_compress_eq_iff_invariant in CauchyInterlacingPoincareCompression.lean: compress T H is a genuine restriction (↑(compress T H y)=T↑y) IFF H is T-invariant — converse of coe_compress_of_invariant (PR #35614, VERIFIED 0/0)"
     ],
     "insights": [
       "This slug duplicates work already merged under sibling cauchy-interlacing-theorem-oq-01-oq-02 (#28084). The Rayleigh-agreement hypothesis of the abstract poincare_separation is discharged by rayleigh_compress_eq, which is stated for an ARBITRARY submodule H (nothing uses codim=1), so the abstract theorem and the explicit compression join for any codimension m with no new work.",
       "Rayleigh discharge mechanism: for y∈H, ⟨compress T H y, y⟩_H = ⟨P_H(Ty), y⟩ = ⟨Ty, y⟩_V by the orthogonal-projection adjoint identity (P_H self-adjoint, P_H y = y); norms agree since the inclusion H↪V is a linear isometry.",
-      "The interlacing μ_k ≤ λ_k is an equality on a block exactly when the corresponding invariant subspace is T-stable. compress T H loses information only through the orthogonal projection P_H(T ↑y); when T ↑y already lies in H the projection is the identity, so compress collapses to the restriction and no eigenvalue is lost — the extremal case of Poincaré separation."
+      "The interlacing μ_k ≤ λ_k is an equality on a block exactly when the corresponding invariant subspace is T-stable. compress T H loses information only through the orthogonal projection P_H(T ↑y); when T ↑y already lies in H the projection is the identity, so compress collapses to the restriction and no eigenvalue is lost — the extremal case of Poincaré separation.",
+      "Converse of the invariance⟹restriction attainment lemma is a 3-line structural fact: ↑(compress T H y) always lies in H (SetLike.coe_mem), so equality with T↑y forces T↑y∈H. No spectral machinery needed for the operator-level attainment characterisation.",
+      "Docker SIGBUS exit-135 (line-less) on the edited file was corrupt Mathlib olean (Algebra/MonoidAlgebra/Support.olean.private, invalid header), NOT the new proof: --repair-cache surfaced the named file only under LEAN_SKIP_CACHE; rm the host .olean/.olean.private then rebuild without skip-cache to refetch → green."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalise the spectral consequence: under H T-invariant, the descending eigenvalues of compress T H are a sub-multiset of those of T (equality is attained in the interlacing bound). Needs bridging equal operators to equal eigenvalue tuples across distinct IsSymmetric proofs — watch proof-irrelevance of the symmetry witness in hT.eigenvalues.",
-      "Converse: if compress T H = T.restrict for some restriction then H is T-invariant (the projection error vanishes iff T ↑y∈H for all y)."
+      "Spectral consequence (nextStep 1, still open): under H T-invariant, the descending eigenvalues of compress T H are a sub-multiset of those of T; bridge equal operators (compress = T.restrict) to equal eigenvalue tuples across distinct IsSymmetric witnesses (watch proof-irrelevance of hT in hT.eigenvalues).",
+      "Projection-error form: ↑(compress T H y) = T↑y iff orthogonalProjection Hᗮ (T↑y) = 0, making the attainment condition a vanishing-residual statement."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds `coe_compress_eq_iff_invariant` to `proofs/Proofs/CauchyInterlacingPoincareCompression.lean`, completing the **attainment characterisation** of the Poincaré/Cauchy interlacing bound (problem `cauchy-interlacing-theorem-oq-02-oq-01`).

The orthogonal compression `compress T H` acts as a **genuine restriction** — pointwise `↑(compress T H y) = T ↑y`, i.e. it incurs *no* projection error — **iff** the subspace `H` is `T`-invariant.

This is the exact converse of the pre-existing `coe_compress_of_invariant` (the `→` direction, and the `compress_eq_restrict_of_invariant` operator form). The interlacing inequality `μ_k ≤ λ_k` degenerates to equality precisely on invariant subspaces, and this iff pins down that extremal case structurally.

## Proof

- **`←` (invariant ⟹ genuine restriction):** reuse `coe_compress_of_invariant`.
- **`→` (genuine restriction ⟹ invariant):** `compress T H y` is by construction an element of `H`, so `↑(compress T H y) ∈ H` always (`SetLike.coe_mem`); if that coercion equals `T ↑y`, then `T ↑y ∈ H`, which is invariance.

## Verification

- `✔ Built Proofs.CauchyInterlacingPoincareCompression (7747 jobs)` via `docker-build.sh`
- 0 sorries, 0 `axiom` declarations (foundational `propext`/`Classical.choice`/`Quot.sound` only)
- Research file, intentionally not registered in `Proofs.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)