### PR TITLE
Enrich Erdős #12 local obstruction: add mainTheorem anchors + full section coverage

### DIFF
--- a/src/data/proofs/erdos-12-wip-01/meta.json
+++ b/src/data/proofs/erdos-12-wip-01/meta.json
@@ -66,9 +66,17 @@
   },
   "sections": [
     {
+      "id": "overview-setup",
+      "title": "Framing: A Local Obstruction for Erdős #12",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring framing Erdős Problem #12 and this WIP file: it isolates the local divisibility obstruction for a divisibility-free set A (no a ∣ b+c for distinct a<b, a<c in A), records the structural consequences, and exhibits a concrete witness. Imports Mathlib and opens the Erdos12WIP01 namespace.",
+      "mathContext": "A ⊆ ℕ is divisibility-free iff no distinct a<b, a<c in A have a ∣ (b+c); the file draws the multiple-uniqueness and residue consequences and checks {4,5,6}."
+    },
+    {
       "id": "definition",
       "title": "The Divisibility-Free Predicate",
-      "startLine": 39,
+      "startLine": 37,
       "endLine": 46,
       "summary": "IsDivisibilityFree A: no distinct a, b, c ∈ A with a < b, a < c and a ∣ (b + c). Matches the erdos-12 gallery definition.",
       "mathContext": "$A$ is divisibility-free iff $\\forall a,b,c \\in A$ distinct with $a < b, a < c$, $a \\nmid (b+c)$."
@@ -103,22 +111,30 @@
     {
       "name": "no_two_larger_multiples",
       "type": "core",
-      "description": "For a ∈ A in a divisibility-free set, no two distinct elements of A larger than a are both multiples of a."
+      "description": "For a ∈ A in a divisibility-free set, no two distinct elements of A larger than a are both multiples of a.",
+      "startLine": 51,
+      "endLine": 55
     },
     {
       "name": "unique_larger_multiple",
       "type": "core",
-      "description": "Each a ∈ A has at most one larger multiple in A (any two coincide)."
+      "description": "Each a ∈ A has at most one larger multiple in A (any two coincide).",
+      "startLine": 59,
+      "endLine": 63
     },
     {
       "name": "no_antipodal_pair",
       "type": "supporting",
-      "description": "No two distinct elements of A larger than a sum to 0 mod a — the residue-level form of the obstruction."
+      "description": "No two distinct elements of A larger than a sum to 0 mod a — the residue-level form of the obstruction.",
+      "startLine": 74,
+      "endLine": 79
     },
     {
       "name": "divFree_456",
       "type": "supporting",
-      "description": "The concrete set {4, 5, 6} is divisibility-free, witnessing non-vacuous satisfiability."
+      "description": "The concrete set {4, 5, 6} is divisibility-free, witnessing non-vacuous satisfiability.",
+      "startLine": 84,
+      "endLine": 88
     }
   ],
   "crossReferences": [
@@ -130,7 +146,9 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "opens": [],
     "namespace": "Erdos12WIP01",
     "lineCount": 90,


### PR DESCRIPTION
Enrichment pass for `erdos-12-wip-01` (quality 94, passes 0).

The entry's annotations (5, fully populated), keyInsights (4), conclusion, and counts (lineCount 90, theoremCount 6, definitionCount 1, axiomCount 0, sorries 0) are accurate. Fixes:

1. **mainTheorem line anchors (were missing).** All 4 `mainTheorems` had no `startLine`/`endLine`, so they didn't link to the source. Added, verified against the Lean file: `no_two_larger_multiples` 51–55, `unique_larger_multiple` 59–63, `no_antipodal_pair` 74–79, `divFree_456` 84–88.
2. **Section boundary.** 'The Divisibility-Free Predicate' section started at line 39, but the `def IsDivisibilityFree` it describes begins at line 37. Fixed startLine 39→37.
3. **Header coverage.** Added an `overview-setup` section (lines 1–36) covering the module docstring/framing; sections now span the full file.

No content removed; meta.json 8.7→9.6 KB. JSON validated.