### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-03): two-prime-factor obstruction kills all p-groups + degree-6 capstone [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
@@ -195,4 +195,39 @@ theorem pgroup_distinct_primes_degree_one (α : ℝ) (hα : IsIntegral ℚ α)
         _ ≤ p ^ k := Nat.le_self_pow (by omega) p
     exact hne (pgroup_prime_unique α hα hp hp' hgt hP hP')
 
+/-- **Two distinct prime factors kill every p-group structure.**
+    If the minimal-polynomial degree of `α` has two *distinct* prime divisors
+    `q₁ ≠ q₂`, then `Gal(minpoly ℚ α)` is not a `p`-group for **any** prime `p`.
+
+    This is qualitatively stronger than the earlier obstructions, which each rule
+    out a p-group for one specific prime: a p-group forces the degree to be a
+    prime power `p^k` (a single prime factor), so whatever prime `p` one picks, at
+    least one of `q₁, q₂` differs from `p` and divides the degree, tripping the
+    master criterion `not_pgroup_of_prime_dvd_degree_ne`.  Equivalently, the Galois
+    group of such an `α` is not nilpotent of prime-power order for any prime. -/
+theorem no_pgroup_of_two_prime_factors (α : ℝ) (hα : IsIntegral ℚ α)
+    {q₁ q₂ : ℕ} (hq₁ : q₁.Prime) (hq₂ : q₂.Prime) (hne : q₁ ≠ q₂)
+    (h₁ : q₁ ∣ (minpoly ℚ α).natDegree) (h₂ : q₂ ∣ (minpoly ℚ α).natDegree)
+    {p : ℕ} (hp : p.Prime) :
+    ¬ IsPGroup p (minpoly ℚ α).Gal := by
+  rcases eq_or_ne q₁ p with h1p | h1p
+  · -- `q₁ = p`, so `q₂ ≠ p`; use `q₂` as the offending prime factor.
+    have hq2p : q₂ ≠ p := h1p ▸ hne.symm
+    exact not_pgroup_of_prime_dvd_degree_ne α hα hp hq₂ hq2p h₂
+  · -- `q₁ ≠ p`; use `q₁` directly.
+    exact not_pgroup_of_prime_dvd_degree_ne α hα hp hq₁ h1p h₁
+
+/-- **A concrete capstone at degree 6.**
+    Since `6 = 2 · 3` carries two distinct prime factors, an algebraic real whose
+    minimal polynomial has degree `6` has a Galois group that is not a `p`-group
+    for *any* prime `p` — no straightedge-and-compass tower (a chain of `2`-power
+    steps) can reach it, and neither can any single-prime radical tower. -/
+theorem degree_six_no_pgroup (α : ℝ) (hα : IsIntegral ℚ α)
+    (h6 : (minpoly ℚ α).natDegree = 6) {p : ℕ} (hp : p.Prime) :
+    ¬ IsPGroup p (minpoly ℚ α).Gal := by
+  refine no_pgroup_of_two_prime_factors α hα Nat.prime_two Nat.prime_three
+    (by norm_num) ?_ ?_ hp
+  · rw [h6]; decide
+  · rw [h6]; decide
+
 end AngleTrisectionOQ02OQ01OQ03

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-03/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-03/knowledge.md
@@ -1,0 +1,23 @@
+# Knowledge: angle-trisection-oq-02-oq-01-oq-03 — p-group Galois ⟹ degree = p^k
+
+## Session 2026-07-08 (researcher-1): two-prime-factor obstruction (depth-3, no new OQ)
+
+File was already complete (10 thm, 0 axiom, 0 sorry). Depth 3 ⟹ no OQ children.
+Added a theory-level strengthening on the same file:
+
+- `no_pgroup_of_two_prime_factors`: two distinct prime divisors q₁≠q₂ of natDegree ⟹
+  Gal is not a p-group for ANY prime p. Proof: case on q₁ = p; whichever branch,
+  a prime ≠ p divides the degree ⟹ master criterion `not_pgroup_of_prime_dvd_degree_ne`.
+- `degree_six_no_pgroup`: degree 6 = 2·3 ⟹ no p-group Galois for any prime (concrete).
+
+This is qualitatively stronger than the prior single-prime obstructions (which each
+rule out one fixed p): a p-group forces degree = p^k (a single prime factor), so a
+degree with ≥2 distinct prime factors is ruled out for *every* prime simultaneously.
+
+Docker VERIFIED (needed `--repair-cache` — persistent line-less exit-135 SIGBUS on the
+target survived two plain retries; cache force-refresh cleared it, real build = 6.3s).
+12 thm, 0 axiom, 0 sorry. #print axioms unchanged (propext/Classical.choice/Quot.sound).
+
+Remaining OPEN (unchanged): converse gap (degree = p^k does NOT force a p-group,
+e.g. S₄ quartic deg 4=2² |Gal|=24) needs a concrete Galois-group computation;
+blocked infra for the concrete cos 20° corollary (v4.26 AlgHom drift in a ~740-line dep).

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-03.json
@@ -1,38 +1,41 @@
 {
   "id": "angle-trisection-oq-02-oq-01-oq-03",
-  "name": "p-group Galois → power-of-p degree criterion (general prime)",
+  "name": "p-group Galois \u2192 power-of-p degree criterion (general prime)",
   "parentId": "angle-trisection-oq-02-oq-01",
   "status": "in-progress",
   "knowledge": {
     "score": 16,
     "insights": [
-      "The parent OQ-02-OQ-01 proves, for the prime 2, that a 2-group Galois group forces the minimal-polynomial degree to be a power of 2 — the algebraic core of the impossibility of angle trisection. The argument never used anything special about 2: it rests only on natDegree ∣ |Gal| (natDegree_dvd_card_gal) plus IsPGroup.iff_card.",
-      "This child lifts the result to an ARBITRARY prime p: Gal(minpoly ℚ α) a p-group ⟹ natDegree = p^k. Divisibility natDegree ∣ p^n is upgraded to equality via Nat.dvd_prime_pow.",
-      "IsPGroup.iff_card requires [Fact p.Prime] [Finite G] — supplied via haveI : Fact p.Prime := ⟨hp⟩; the Gal group's Finite instance is automatic (separable polynomial over CharZero).",
+      "The parent OQ-02-OQ-01 proves, for the prime 2, that a 2-group Galois group forces the minimal-polynomial degree to be a power of 2 \u2014 the algebraic core of the impossibility of angle trisection. The argument never used anything special about 2: it rests only on natDegree \u2223 |Gal| (natDegree_dvd_card_gal) plus IsPGroup.iff_card.",
+      "This child lifts the result to an ARBITRARY prime p: Gal(minpoly \u211a \u03b1) a p-group \u27f9 natDegree = p^k. Divisibility natDegree \u2223 p^n is upgraded to equality via Nat.dvd_prime_pow.",
+      "IsPGroup.iff_card requires [Fact p.Prime] [Finite G] \u2014 supplied via haveI : Fact p.Prime := \u27e8hp\u27e9; the Gal group's Finite instance is automatic (separable polynomial over CharZero).",
       "Contrapositive non-constructibility criterion: if natDegree is not a power of p, Gal is not a p-group.",
-      "Concrete degree-3 obstruction: a real with minimal degree 3 has no 2-group Galois group (3 ≠ 2^k for all k), precisely why the 60° angle cannot be trisected (cos 20° has minimal degree 3).",
-      "Odd-degree generalization: an algebraic real whose minimal polynomial has odd degree > 1 can never have a 2-group Galois group, because 2^0 = 1 and 2^k is even for k ≥ 1. This upgrades the concrete degree-3 (cos 20°) obstruction to a general sufficient condition for non-constructibility by straightedge and compass, covering every odd degree.",
-      "Master prime-factor obstruction: if ANY prime q≠p divides natDegree(minpoly ℚ α), then Gal is not a p-group — a p-group forces the degree to be p^k whose only prime factor is p (via Nat.Prime.dvd_of_dvd_pow + Nat.prime_dvd_prime_iff_eq). This single statement subsumes both the degree-3 obstruction (p=2,q=3) and the odd-degree obstruction (odd degree >1 has an odd prime factor q≠2), and — targeting an arbitrary prime p — also yields obstructions for other primes (e.g. even degree ⟹ not a 3-group).",
-      "Prime rigidity: on any extension of degree >1, Gal(minpoly ℚ α) can be a p-group for AT MOST ONE prime p. Since a p-group forces natDegree = p^k, two primes p,p' both giving p-group structure make the degree simultaneously a power of p and of p'; for a number >1 this forces p=p' (p ∣ p'^j with p prime ⟹ p=p' via Nat.Prime.dvd_of_dvd_pow + Nat.prime_dvd_prime_iff_eq). Thus the prime in the criterion is not a free parameter but an invariant read off from the unique prime divisor of the degree."
+      "Concrete degree-3 obstruction: a real with minimal degree 3 has no 2-group Galois group (3 \u2260 2^k for all k), precisely why the 60\u00b0 angle cannot be trisected (cos 20\u00b0 has minimal degree 3).",
+      "Odd-degree generalization: an algebraic real whose minimal polynomial has odd degree > 1 can never have a 2-group Galois group, because 2^0 = 1 and 2^k is even for k \u2265 1. This upgrades the concrete degree-3 (cos 20\u00b0) obstruction to a general sufficient condition for non-constructibility by straightedge and compass, covering every odd degree.",
+      "Master prime-factor obstruction: if ANY prime q\u2260p divides natDegree(minpoly \u211a \u03b1), then Gal is not a p-group \u2014 a p-group forces the degree to be p^k whose only prime factor is p (via Nat.Prime.dvd_of_dvd_pow + Nat.prime_dvd_prime_iff_eq). This single statement subsumes both the degree-3 obstruction (p=2,q=3) and the odd-degree obstruction (odd degree >1 has an odd prime factor q\u22602), and \u2014 targeting an arbitrary prime p \u2014 also yields obstructions for other primes (e.g. even degree \u27f9 not a 3-group).",
+      "Prime rigidity: on any extension of degree >1, Gal(minpoly \u211a \u03b1) can be a p-group for AT MOST ONE prime p. Since a p-group forces natDegree = p^k, two primes p,p' both giving p-group structure make the degree simultaneously a power of p and of p'; for a number >1 this forces p=p' (p \u2223 p'^j with p prime \u27f9 p=p' via Nat.Prime.dvd_of_dvd_pow + Nat.prime_dvd_prime_iff_eq). Thus the prime in the criterion is not a free parameter but an invariant read off from the unique prime divisor of the degree.",
+      "Two-prime-factor rigidity: a p-group Galois group forces natDegree = p^k (a PRIME POWER, single prime factor), so any degree with >=2 distinct prime factors admits no p-group structure for any prime p at all - a qualitatively stronger 'no prime works' conclusion than the earlier obstructions that each ruled out one fixed prime. Degree 6 is the smallest concrete witness (2*3)."
     ],
     "builtItems": [
       "AngleTrisectionOQ02OQ01OQ03.lean: 10 theorems, 0 axioms, 0 sorries, 0 native_decide, reuses parent natDegree_dvd_card_gal. #print axioms = propext/Classical.choice/Quot.sound only.",
-      "galois_pgroup_implies_degree_pow_p: p-group Gal ⟹ natDegree ∣ p^n.",
-      "galois_pgroup_implies_degree_is_pow_p: p-group Gal ⟹ natDegree = p^k.",
-      "not_pgroup_of_degree_ne_pow_p: degree not a power of p ⟹ Gal not a p-group.",
-      "degree_three_not_2group: minimal degree 3 ⟹ not a 2-group (the trisection obstruction).",
-      "odd_degree_gt_one_not_2group: minimal degree ODD and > 1 ⟹ not a 2-group.",
-      "not_pgroup_of_prime_dvd_degree_ne (NEW master criterion): any prime q≠p dividing natDegree ⟹ Gal not a p-group; subsumes degree_three and odd_degree obstructions and covers arbitrary target primes.",
+      "galois_pgroup_implies_degree_pow_p: p-group Gal \u27f9 natDegree \u2223 p^n.",
+      "galois_pgroup_implies_degree_is_pow_p: p-group Gal \u27f9 natDegree = p^k.",
+      "not_pgroup_of_degree_ne_pow_p: degree not a power of p \u27f9 Gal not a p-group.",
+      "degree_three_not_2group: minimal degree 3 \u27f9 not a 2-group (the trisection obstruction).",
+      "odd_degree_gt_one_not_2group: minimal degree ODD and > 1 \u27f9 not a 2-group.",
+      "not_pgroup_of_prime_dvd_degree_ne (NEW master criterion): any prime q\u2260p dividing natDegree \u27f9 Gal not a p-group; subsumes degree_three and odd_degree obstructions and covers arbitrary target primes.",
       "odd_degree_gt_one_not_2group' (NEW): the odd-degree obstruction re-derived from the master criterion by extracting an odd prime divisor (Nat.exists_prime_and_dvd), exhibiting it as a special case.",
-      "even_degree_not_3group (NEW): concrete p=3 instance — an even minimal degree ⟹ not a 3-group (2≠3 divides the degree), demonstrating the general-prime reach.",
-      "pgroup_prime_unique (NEW): for 1 < natDegree, IsPGroup p Gal ∧ IsPGroup p' Gal ⟹ p = p'. The p-group prime is an invariant of a nontrivial extension.",
-      "pgroup_distinct_primes_degree_one (NEW): distinct primes p≠p' both giving p-group Galois ⟹ natDegree = 1 (extension trivial / α rational). Contrapositive companion of pgroup_prime_unique."
+      "even_degree_not_3group (NEW): concrete p=3 instance \u2014 an even minimal degree \u27f9 not a 3-group (2\u22603 divides the degree), demonstrating the general-prime reach.",
+      "pgroup_prime_unique (NEW): for 1 < natDegree, IsPGroup p Gal \u2227 IsPGroup p' Gal \u27f9 p = p'. The p-group prime is an invariant of a nontrivial extension.",
+      "pgroup_distinct_primes_degree_one (NEW): distinct primes p\u2260p' both giving p-group Galois \u27f9 natDegree = 1 (extension trivial / \u03b1 rational). Contrapositive companion of pgroup_prime_unique.",
+      "no_pgroup_of_two_prime_factors (NEW): two distinct prime divisors q1!=q2 of natDegree => Gal is not a p-group for ANY prime p; strengthens the single-prime obstructions (a p-group forces a single prime factor p^k).",
+      "degree_six_no_pgroup (NEW): concrete capstone, degree 6 = 2*3 admits no p-group Galois structure for any prime."
     ],
-    "progressSummary": "Child of angle-trisection-oq-02-oq-01 (Galois → degree criterion). The parent handles the prime 2; this entry generalizes to an arbitrary prime p — p-group Galois group ⟹ minimal-polynomial degree is a power of p — with the contrapositive non-constructibility criterion, the concrete degree-3 (cos 20°) obstruction, the general odd-degree obstruction, and now a MASTER prime-factor obstruction: any prime q≠p dividing the degree rules out a p-group. The master criterion subsumes both the degree-3 and odd-degree obstructions (the latter re-derived as odd_degree_gt_one_not_2group') and, targeting arbitrary p, yields obstructions for other primes (even_degree_not_3group). All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. 8 theorems total. This session adds a PRIME RIGIDITY layer: pgroup_prime_unique shows that on any degree-(>1) extension the prime p for which Gal can be a p-group is unique — an invariant determined by the (single) prime factor of the degree, not a free choice — with contrapositive pgroup_distinct_primes_degree_one (two distinct primes ⟹ trivial degree 1). 10 theorems total, all 0-axiom verified.",
+    "progressSummary": "Child of angle-trisection-oq-02-oq-01 (Galois \u2192 degree criterion). The parent handles the prime 2; this entry generalizes to an arbitrary prime p \u2014 p-group Galois group \u27f9 minimal-polynomial degree is a power of p \u2014 with the contrapositive non-constructibility criterion, the concrete degree-3 (cos 20\u00b0) obstruction, the general odd-degree obstruction, and now a MASTER prime-factor obstruction: any prime q\u2260p dividing the degree rules out a p-group. The master criterion subsumes both the degree-3 and odd-degree obstructions (the latter re-derived as odd_degree_gt_one_not_2group') and, targeting arbitrary p, yields obstructions for other primes (even_degree_not_3group). All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. 8 theorems total. This session adds a PRIME RIGIDITY layer: pgroup_prime_unique shows that on any degree-(>1) extension the prime p for which Gal can be a p-group is unique \u2014 an invariant determined by the (single) prime factor of the degree, not a free choice \u2014 with contrapositive pgroup_distinct_primes_degree_one (two distinct primes \u27f9 trivial degree 1). 10 theorems total, all 0-axiom verified.",
     "nextSteps": [
-      "BLOCKED (infra): concrete cos 20° corollary via cos_pi9_minpoly_degree (AngleTrisectionCos20GalOQ01OQ02OQ02) remains unreachable — that file transitively imports AngleTrisectionOQ02OQ03OQ01.lean, which uses AlgHom API removed in Mathlib v4.26 (.toAlgHom on AlgEquiv, ring failures). Repair that ~740-line file first, then instantiate degree_three_not_2group at cos(π/9).",
+      "BLOCKED (infra): concrete cos 20\u00b0 corollary via cos_pi9_minpoly_degree (AngleTrisectionCos20GalOQ01OQ02OQ02) remains unreachable \u2014 that file transitively imports AngleTrisectionOQ02OQ03OQ01.lean, which uses AlgHom API removed in Mathlib v4.26 (.toAlgHom on AlgEquiv, ring failures). Repair that ~740-line file first, then instantiate degree_three_not_2group at cos(\u03c0/9).",
       "BLOCKED (elaborator): field-degree / finrank formulation via IntermediateField.adjoin.finrank segfaults the Lean 4.26 elaborator here; revisit via minpoly.natDegree_eq_finrank.",
-      "OPEN (converse gap): the necessary condition (p-group ⟹ degree = p^k) is not sufficient — degree = p^k does NOT force a p-group Galois group (e.g. an S_4 quartic has degree 4 = 2^2 but |Gal| = 24). Formalizing a concrete counterexample would sharpen the necessary-vs-sufficient boundary but requires computing a specific Galois group."
+      "OPEN (converse gap): the necessary condition (p-group \u27f9 degree = p^k) is not sufficient \u2014 degree = p^k does NOT force a p-group Galois group (e.g. an S_4 quartic has degree 4 = 2^2 but |Gal| = 24). Formalizing a concrete counterexample would sharpen the necessary-vs-sufficient boundary but requires computing a specific Galois group."
     ]
   },
   "relatedProofs": [
@@ -384,8 +387,8 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ03.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ03.lean",
-      "lineCount": 152,
-      "theoremCount": 8,
+      "lineCount": 233,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

`AngleTrisectionOQ02OQ01OQ03.lean` proves the general-prime p-group degree criterion (`Gal(minpoly ℚ α)` a p-group ⟹ `natDegree = p^k`) plus a chain of non-constructibility obstructions. The file was already complete (10 theorems, 0 axioms, 0 sorries) and sits at OQ-depth 3, so no new OQ children are spawned — instead this adds a **theory-level strengthening** on the same file.

## New theorems (2)

```lean
theorem no_pgroup_of_two_prime_factors (α : ℝ) (hα : IsIntegral ℚ α)
    {q₁ q₂ : ℕ} (hq₁ : q₁.Prime) (hq₂ : q₂.Prime) (hne : q₁ ≠ q₂)
    (h₁ : q₁ ∣ (minpoly ℚ α).natDegree) (h₂ : q₂ ∣ (minpoly ℚ α).natDegree)
    {p : ℕ} (hp : p.Prime) :
    ¬ IsPGroup p (minpoly ℚ α).Gal
```

If the minimal-polynomial degree has **two distinct prime factors**, then `Gal` is not a p-group for **any** prime `p`. This is qualitatively stronger than the earlier obstructions (`degree_three_not_2group`, `odd_degree_gt_one_not_2group`, …), which each rule out a p-group for one *fixed* prime: a p-group forces the degree to be a prime power `p^k` (a single prime factor), so whichever `p` is picked, one of `q₁, q₂` differs from `p` and divides the degree, tripping the master criterion `not_pgroup_of_prime_dvd_degree_ne`.

```lean
theorem degree_six_no_pgroup (α : ℝ) (hα : IsIntegral ℚ α)
    (h6 : (minpoly ℚ α).natDegree = 6) {p : ℕ} (hp : p.Prime) :
    ¬ IsPGroup p (minpoly ℚ α).Gal
```

Concrete capstone: `6 = 2·3` has two distinct prime factors, so a degree-6 algebraic real has a Galois group that is not a p-group for any prime — no single-prime radical/constructibility tower can reach it.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AngleTrisectionOQ02OQ01OQ03` — **succeeded** (7745 jobs, real build 6.3s after a `--repair-cache` cleared a persistent line-less exit-135 SIGBUS).
- 0 sorries, 0 axioms; `#print axioms` unchanged (`propext / Classical.choice / Quot.sound`).
- Research JSON leanFile counts synced (8→12 theorems, 152→233 lines) + knowledge notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)