### PR TITLE
Enrich Erdős #128 induced-subgraph monotonicities: add mainTheorems array

### DIFF
--- a/src/data/proofs/erdos-128-wip-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01/meta.json
@@ -137,5 +137,39 @@
       "venue": "CPP",
       "note": "Supplies Finset.filter / Finset.card_le_card and the graph/Finset API underlying edgeCount and its monotonicity."
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "triangleFree_induce",
+      "type": "core",
+      "description": "**Triangle-freeness is hereditary.** Every induced subgraph of a triangle-free graph is triangle-free — the contrapositive of hasTriangle_induce. This is the structural reason the extremal C₅-blow-up witnesses for Erdős #128 stay triangle-free.",
+      "leanType": "{n : ℕ} (G : Graph n) (S : Finset (Fin n)) (hG : G.triangleFree) : (G.induce S).triangleFree",
+      "startLine": 82,
+      "endLine": 84
+    },
+    {
+      "name": "edgeCount_induce_le",
+      "type": "core",
+      "description": "**The edge count is monotone under taking induced subgraphs.** (G.induce S).edgeCount ≤ G.edgeCount, since induction only deletes edges (Finset.card_le_card on the filtered edge set). This is the monotonicity underlying the density hypothesis in the conjecture.",
+      "leanType": "{n : ℕ} (G : Graph n) (S : Finset (Fin n)) : (G.induce S).edgeCount ≤ G.edgeCount",
+      "startLine": 88,
+      "endLine": 93
+    },
+    {
+      "name": "hasTriangle_induce",
+      "type": "key",
+      "description": "**Triangles lift to the ambient graph.** A triangle in an induced subgraph is a triangle of the ambient graph, because induced adjacency (G.induce S).adj u v entails ambient adjacency G.adj u v. The lemma triangleFree_induce is its contrapositive.",
+      "leanType": "{n : ℕ} (G : Graph n) (S : Finset (Fin n)) (h : (G.induce S).hasTriangle) : G.hasTriangle",
+      "startLine": 75,
+      "endLine": 78
+    },
+    {
+      "name": "triangleFree_of_no_edges",
+      "type": "supporting",
+      "description": "**The degenerate base case.** A graph whose adjacency is everywhere false has no triangle.",
+      "leanType": "{n : ℕ} (G : Graph n) (hG : ∀ u v, ¬ G.adj u v) : G.triangleFree",
+      "startLine": 97,
+      "endLine": 100
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-128-wip-01` (quality 94, passes 0).

The entry has accurate annotations (5, fully populated), 5 keyInsights, 5 references, 3 crossReferences, 3 openQuestions, and correct counts (lineCount 117, theoremCount 4, definitionCount 4, axiomCount 0, sorries 0). Sections already cover the full file. One gap:

- The `mainTheorems` array was **absent** on this mainTheorems-schema entry, so the four proved results had no highlighted/source-linked list. Added all four with descriptions (adapted from `originalContributions`), `leanType` signatures, and line anchors verified against the Lean source: `triangleFree_induce` 82–84, `edgeCount_induce_le` 88–93, `hasTriangle_induce` 75–78, `triangleFree_of_no_edges` 97–100.

No content removed; meta.json 11.4→13.2 KB. JSON validated.