### PR TITLE
research(eqr-oq-03-oq-02-wip-01): denominator-side χ₄/χ₈ supplementary-character bridges [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -444,6 +444,34 @@ theorem kronecker_two_odd (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
   rw [kronecker_eq_jacobi 2 n hn hno, jacobiSym.at_two (Nat.odd_iff.mpr hno),
     ZMod.χ₈_nat_eq_if_mod_eight, if_neg (show ¬ n % 2 = 0 by omega)]
 
+/-- **The first supplementary character is Mathlib's `χ₄`.**
+    For odd positive `n`, the denominator-side symbol `(-1/n)` equals the canonical
+    quadratic Dirichlet character modulo `4`: `kronecker (-1) n = χ₄ n`. This is the
+    `χ`-form of `kronecker_neg_one_odd` — the *denominator-side* analogue of the
+    numerator bridge `kronecker2_eq_χ₈` (which identifies the `(·/2)` character with
+    `χ₈`). It exports the sign supplementary law to Mathlib's `χ₄`, so the Gauss sum
+    of `(-1/·)` (Target 2) can be taken directly against the library character.
+    Immediate from `kronecker_eq_jacobi` and `jacobiSym.at_neg_one`.
+    `sorry`-free, axiom-free. -/
+theorem kronecker_neg_one_eq_χ₄ (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker (-1) (n : ℤ) = ZMod.χ₄ (n : ZMod 4) := by
+  rw [kronecker_eq_jacobi (-1) n hn hno]
+  exact jacobiSym.at_neg_one (Nat.odd_iff.mpr hno)
+
+/-- **The second supplementary character is Mathlib's `χ₈`.**
+    For odd positive `n`, the denominator-side symbol `(2/n)` equals the canonical
+    quadratic Dirichlet character modulo `8`: `kronecker 2 n = χ₈ n`. This is the
+    `χ`-form of `kronecker_two_odd`. Combined with `kronecker_neg_one_eq_χ₄`, *both*
+    supplementary laws are now identified with the Mathlib characters `χ₄`, `χ₈` on
+    the denominator side — the mirror of the numerator-side identification
+    `kronecker2_eq_χ₈`, and the entry point for the Gauss-sum route to generalized
+    reciprocity (Target 2). Immediate from `kronecker_eq_jacobi` and
+    `jacobiSym.at_two`. `sorry`-free, axiom-free. -/
+theorem kronecker_two_eq_χ₈ (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker 2 (n : ℤ) = ZMod.χ₈ (n : ZMod 8) := by
+  rw [kronecker_eq_jacobi 2 n hn hno]
+  exact jacobiSym.at_two (Nat.odd_iff.mpr hno)
+
 /-- **Self-reciprocity of the prime 2.** For odd positive `n`, the value of the
     `(·/2)` character `kronecker2` at `n` equals the fixed-numerator symbol
     `(2/n) = kronecker 2 n`:

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -36,10 +36,10 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (WIP, still open): (·/2) mod-8 character now certified equal to Mathlib's ZMod.χ₈ (kronecker2_eq_χ₈, 0/0). Character theory complete AND library-bridged; remaining open work is Target 2 (generalized reciprocity for fundamental discriminants via Gauss sums) and the even-modulus refinement of the full kronecker symbol.",
+    "progressSummary": "PROGRESS (WIP, still open): (\u00b7/2) mod-8 character now certified equal to Mathlib's ZMod.\u03c7\u2088 (kronecker2_eq_\u03c7\u2088, 0/0). Character theory complete AND library-bridged; remaining open work is Target 2 (generalized reciprocity for fundamental discriminants via Gauss sums) and the even-modulus refinement of the full kronecker symbol.",
     "builtItems": [
-      "kronecker2_periodic (ElementaryQuadraticReciprocityOQ03OQ02.lean): (a+8/2)=(a/2), period-8 of the (·/2) character; with kronecker2_mul this makes kronecker2 a Dirichlet character mod 8 (foundation for the Gauss-sum route to Target 2).",
-      "kronecker2_mul (ElementaryQuadraticReciprocityOQ03OQ02.lean): (ab/2)=(a/2)(b/2) unconditional multiplicativity of the (·/2) mod-8 character, via x%8 reduction + 64-case decide.",
+      "kronecker2_periodic (ElementaryQuadraticReciprocityOQ03OQ02.lean): (a+8/2)=(a/2), period-8 of the (\u00b7/2) character; with kronecker2_mul this makes kronecker2 a Dirichlet character mod 8 (foundation for the Gauss-sum route to Target 2).",
+      "kronecker2_mul (ElementaryQuadraticReciprocityOQ03OQ02.lean): (ab/2)=(a/2)(b/2) unconditional multiplicativity of the (\u00b7/2) mod-8 character, via x%8 reduction + 64-case decide.",
       "kronecker_mul_right_odd",
       "kronecker_quadratic_reciprocity",
       "kronecker_reciprocity_one_mod_four",
@@ -47,8 +47,10 @@
       "kronecker_eq_sign_jacobi",
       "kroneckerNeg1_sq (private)",
       "kronecker_mul_right (full, all nonzero moduli)",
-      "kronecker2_sq / kronecker2_sq_odd (ElementaryQuadraticReciprocityOQ03OQ02.lean, VERIFIED 0/0): the (·/2) character is REAL — its square is the principal character mod 2 ((a/2)²=0 on evens, =1 on odds); completes the even-real-Dirichlet-character-mod-8 identification alongside kronecker2_mul/_periodic/_neg/_values.",
-      "kronecker2_eq_χ₈ (ElementaryQuadraticReciprocityOQ03OQ02.lean, VERIFIED 0/0): the local (·/2) mod-8 character equals Mathlib's canonical ZMod.χ₈. Proof: rw [ZMod.χ₈_int_eq_if_mod_eight]; unfold kronecker2; split_ifs <;> omega — the local def's extra 'a%8=-1' disjunct is vacuous since Int.emod by 8 is nonnegative."
+      "kronecker2_sq / kronecker2_sq_odd (ElementaryQuadraticReciprocityOQ03OQ02.lean, VERIFIED 0/0): the (\u00b7/2) character is REAL \u2014 its square is the principal character mod 2 ((a/2)\u00b2=0 on evens, =1 on odds); completes the even-real-Dirichlet-character-mod-8 identification alongside kronecker2_mul/_periodic/_neg/_values.",
+      "kronecker2_eq_\u03c7\u2088 (ElementaryQuadraticReciprocityOQ03OQ02.lean, VERIFIED 0/0): the local (\u00b7/2) mod-8 character equals Mathlib's canonical ZMod.\u03c7\u2088. Proof: rw [ZMod.\u03c7\u2088_int_eq_if_mod_eight]; unfold kronecker2; split_ifs <;> omega \u2014 the local def's extra 'a%8=-1' disjunct is vacuous since Int.emod by 8 is nonnegative.",
+      "kronecker_neg_one_eq_\u03c7\u2084 (NEW): for odd positive n, kronecker (-1) n = ZMod.\u03c7\u2084 n \u2014 \u03c7-form of kronecker_neg_one_odd (first supplementary law as Mathlib \u03c7\u2084).",
+      "kronecker_two_eq_\u03c7\u2088 (NEW): for odd positive n, kronecker 2 n = ZMod.\u03c7\u2088 n \u2014 \u03c7-form of kronecker_two_odd (second supplementary law as Mathlib \u03c7\u2088)."
     ],
     "insights": [
       "For odd positive moduli the Kronecker symbol IS the Jacobi symbol (kronecker_eq_jacobi), so mul-in-n and QR come for free from jacobiSym.mul_right' and jacobiSym.quadratic_reciprocity.",
@@ -62,14 +64,15 @@
       "Sign multiplicativity across a nonzero product: only the m<0,n<0 case is nontrivial (m*n>0), where the two sign chars cancel via kroneckerNeg1_sq (a value in {+-1} squares to 1).",
       "SCOPE/HONESTY: at even moduli this file's kronecker equals Jacobi's value at 2, NOT the classical mod-8 kronecker2 (defined but never wired into kronecker). So kronecker_mul_right is multiplicativity of the symbol AS DEFINED (matches the classical Kronecker symbol at all odd moduli and at n=+-1). Kept status wip.",
       "BUILD: local Docker build SIGSEGVs (exit 135/139) on the #print axioms commands (stack overflow); origin/main replays its cached olean so the crash only surfaces after editing. Commented the block out; file then builds in ~2s.",
-      "Session 2026-07-08 (researcher-4): Mathlib ALREADY has the (·/2) character as ZMod.χ₈ with a matching if-then-else value lemma χ₈_int_eq_if_mod_eight and the bridge jacobiSym.at_two : J(2|b)=χ₈ b (odd b). So the local kronecker2 character theory (mul/periodic/neg/values/sq) is now certified equal to χ₈, and Target-2 Gauss-sum work can lean on Mathlib's χ₈/jacobiSym API instead of re-deriving it."
+      "Session 2026-07-08 (researcher-4): Mathlib ALREADY has the (\u00b7/2) character as ZMod.\u03c7\u2088 with a matching if-then-else value lemma \u03c7\u2088_int_eq_if_mod_eight and the bridge jacobiSym.at_two : J(2|b)=\u03c7\u2088 b (odd b). So the local kronecker2 character theory (mul/periodic/neg/values/sq) is now certified equal to \u03c7\u2088, and Target-2 Gauss-sum work can lean on Mathlib's \u03c7\u2088/jacobiSym API instead of re-deriving it.",
+      "Denominator-side \u03c7-bridges complete the library identification: both supplementary laws (-1/\u00b7) and (2/\u00b7) at odd moduli are now Mathlib's canonical \u03c7\u2084, \u03c7\u2088 (2-line consequences of kronecker_eq_jacobi + jacobiSym.at_neg_one / at_two), mirroring the numerator bridge kronecker2_eq_\u03c7\u2088. This is the entry point for the Gauss-sum route (Target 2): the Gauss sums can be taken directly against library characters."
     ],
     "mathlibGaps": [
       "No Kronecker symbol in Mathlib (only jacobiSym for odd positive denominators).",
       "No supplementary-law lemmas connecting (2/n)/(-1/n) to the odd part for a generalized reciprocity."
     ],
     "nextSteps": [
-      "Use kronecker2_eq_χ₈ + jacobiSym.at_two to re-express kronecker at even moduli through χ₈ (the 2-adic refinement of nextStep 'route even moduli through kronecker2'), then re-prove kronecker_mul_right for the refined definition without re-deriving χ₈ multiplicativity.",
+      "Use kronecker2_eq_\u03c7\u2088 + jacobiSym.at_two to re-express kronecker at even moduli through \u03c7\u2088 (the 2-adic refinement of nextStep 'route even moduli through kronecker2'), then re-prove kronecker_mul_right for the refined definition without re-deriving \u03c7\u2088 multiplicativity.",
       "Refine kronecker to use kronecker2 for the 2-adic part (classical symbol at even moduli), then re-prove kronecker_mul_right for the refined definition.",
       "Target 2: generalized quadratic reciprocity for arbitrary fundamental discriminants (supplementary laws + Gauss sums)."
     ]


### PR DESCRIPTION
## Summary

`ElementaryQuadraticReciprocityOQ03OQ02.lean` develops the Kronecker symbol and its character theory (0 sorries, 0 axioms). The file already bridges the **numerator** character `(·/2)` to Mathlib's canonical `χ₈` (`kronecker2_eq_χ₈`); the open work (Target 2) is the Gauss-sum route to generalized reciprocity, which rests on identifying the supplementary characters with the library's `χ₄`/`χ₈`. This adds the symmetric **denominator-side** bridges.

## New theorems (2)

```lean
theorem kronecker_neg_one_eq_χ₄ (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
    kronecker (-1) (n : ℤ) = ZMod.χ₄ (n : ZMod 4)

theorem kronecker_two_eq_χ₈ (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
    kronecker 2 (n : ℤ) = ZMod.χ₈ (n : ZMod 8)
```

These are the `χ`-forms of the existing arithmetic supplementary laws `kronecker_neg_one_odd` (`(-1/n)`) and `kronecker_two_odd` (`(2/n)`). With them, **both** supplementary laws are now identified with the canonical Dirichlet characters `χ₄`, `χ₈` on the denominator side — mirroring `kronecker2_eq_χ₈` on the numerator side. Each is a 2-line consequence of `kronecker_eq_jacobi` composed with Mathlib's `jacobiSym.at_neg_one` / `jacobiSym.at_two`. This lets the Gauss sums of `(-1/·)` and `(2/·)` (Target 2) be taken directly against library characters.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02` — **succeeded** (3058 jobs, 4.5s build). Only a pre-existing unrelated linter warning at L304.
- 0 sorries, 0 axioms added; the file's axiom basis is unchanged (standard `propext`/`Classical.choice`/`Quot.sound`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)