### PR TITLE
research(dirichlets-theorem-oq-02-oq-03): closed-form p3 k ≤ 4^(2^k) doubly-exponential bound

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -460,4 +460,111 @@ theorem C_le_B (k : ℕ) : C k ≤ B k := by
     have h := towerProd_succ_le_factorial k
     rw [C_eq, B_succ]; omega
 
+/-! ## Step 7: the domination is **strict** for every `k ≥ 1` (`C k < B k`)
+
+`C_le_B` gives `C k ≤ B k` everywhere, with equality at `k = 0`
+(`C 0 = B 0 = 3`).  We now upgrade the inequality to a *strict* one for all
+`k ≥ 1`, matching the single-index observation `C 1 = 11 < 95 = B 1` of
+`primorial_tighter_than_factorial`.  The slack is already present in the
+factorial step: the ceiling `n·(n−1) ≤ n!` used in `C_le_B` is in fact *strict*
+for `n ≥ 4` (`n! = n·(n−1)!` and `(n−1)! > (n−1)` once `n−1 ≥ 3`), and the
+argument `4·(B k + 1)! ≥ 4` always lands in that regime.  So the running-product
+bound `towerProd (k+1) ≤ (B k + 1)!` sharpens to a strict `<`, and the strictness
+transfers to `C (k+1) < B (k+1)` because both towers apply the same monotone
+`x ↦ 4·(x+1)! − 1` (resp. `x ↦ 4·x − 1`) map. -/
+
+/-- Strict elementary factorial bound `n·(n−1) < n!` for `n ≥ 4`.  From
+`n! = n·(n−1)!` together with `(n−1) < (n−1)!` (valid since `n − 1 ≥ 3`), i.e.
+`Nat.lt_factorial_self`.  This is the strict refinement of `factorial_ge_mul_pred`
+that supplies the strictness in `C_lt_B`. -/
+theorem factorial_gt_mul_pred {n : ℕ} (hn : 4 ≤ n) : n * (n - 1) < n ! := by
+  obtain ⟨p, rfl⟩ : ∃ p, n = p + 1 := ⟨n - 1, by omega⟩
+  have hp : 3 ≤ p := by omega
+  have hlt : p < p ! := Nat.lt_factorial_self hp
+  rw [Nat.add_sub_cancel, Nat.factorial_succ]
+  exact mul_lt_mul_of_pos_left hlt (by omega)
+
+/-- Strict running-product bound `towerProd (k+1) < (B k + 1)!`.  Identical to
+`towerProd_succ_le_factorial` except the final factorial step is strict via
+`factorial_gt_mul_pred` (its argument `4·(B k + 1)!` is always `≥ 4`). -/
+theorem towerProd_succ_lt_factorial (k : ℕ) : towerProd (k + 1) < (B k + 1)! := by
+  induction k with
+  | zero => decide
+  | succ k ih =>
+    have hFpos := Nat.factorial_pos (B k + 1)
+    have hB1 : B (k + 1) + 1 = 4 * (B k + 1)! := by rw [B_succ]; omega
+    rw [towerProd_succ, hB1]
+    set F := (B k + 1)! with hF
+    set tp := towerProd (k + 1) with htp
+    calc tp * (4 * tp - 1)
+        ≤ F * (4 * F - 1) := Nat.mul_le_mul (by omega) (by omega)
+      _ ≤ (4 * F) * (4 * F - 1) := Nat.mul_le_mul (by omega) (le_refl _)
+      _ < (4 * F)! := factorial_gt_mul_pred (by omega)
+
+/-- **The primorial tower is strictly below the factorial tower for every
+`k ≥ 1`.**  `C k < B k` whenever `k ≥ 1`, sharpening `C_le_B` (which allows
+equality) and promoting the single-index fact `C 1 = 11 < 95 = B 1` to a theorem
+for all `k ≥ 1`.  Equality holds *only* at `k = 0` (`C 0 = B 0 = 3`), so together
+with `C_le_B` this pins down the comparison exactly: `C k = B k ⇔ k = 0`. -/
+theorem C_lt_B {k : ℕ} (hk : 1 ≤ k) : C k < B k := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  have h := towerProd_succ_lt_factorial j
+  rw [C_eq, B_succ]; omega
+
+/-- **Exact comparison of the two towers.** `C k = B k` if and only if `k = 0`;
+for all `k ≥ 1` the primorial tower is strictly smaller.  Combines `C_le_B`,
+`C_lt_B`, and the base equality `C 0 = B 0 = 3`. -/
+theorem C_eq_B_iff (k : ℕ) : C k = B k ↔ k = 0 := by
+  constructor
+  · intro h
+    by_contra hk
+    exact absurd h (Nat.ne_of_lt (C_lt_B (by omega)))
+  · rintro rfl; decide
+
+/-! ### An explicit (non-recursive) closed-form certified bound
+
+The bounds `p3 k ≤ B k` and `p3 k ≤ C k` are both *recursive*: to evaluate them
+one must unfold the tower.  Here we collapse the primorial recursion into a single
+explicit closed form, `p3 k ≤ 4^(2^k)`, which makes the *doubly-exponential* growth
+of the certified bound literally visible in the exponent `2^k`.  The proof is a clean
+squaring induction: `4·towerProd (k+1) = (4·towerProd k)·(4·towerProd k − 1) ≤
+(4·towerProd k)^2`, and squaring the inductive bound `4·towerProd k ≤ 4^(2^k)` gives
+`(4^(2^k))^2 = 4^(2^(k+1))`. -/
+
+/-- Squaring induction: `4·towerProd k ≤ 4^(2^k)`.  This is the engine converting the
+recursive primorial tower into a closed-form bound; the leading factor `4` is carried so
+that `C k = 4·towerProd k − 1` inherits the bound with no residual arithmetic. -/
+theorem four_mul_towerProd_le (k : ℕ) : 4 * towerProd k ≤ 4 ^ (2 ^ k) := by
+  induction k with
+  | zero => decide
+  | succ n ih =>
+    have h1 : 4 * towerProd (n + 1) ≤ (4 * towerProd n) * (4 * towerProd n) := by
+      rw [towerProd_succ]
+      calc 4 * (towerProd n * (4 * towerProd n - 1))
+            = (4 * towerProd n) * (4 * towerProd n - 1) := by ring
+        _ ≤ (4 * towerProd n) * (4 * towerProd n) :=
+            Nat.mul_le_mul_left _ (Nat.sub_le _ _)
+    have h3 : 4 ^ (2 ^ n) * 4 ^ (2 ^ n) = 4 ^ (2 ^ (n + 1)) := by
+      rw [← pow_add, pow_succ, Nat.mul_two]
+    calc 4 * towerProd (n + 1) ≤ (4 * towerProd n) * (4 * towerProd n) := h1
+      _ ≤ 4 ^ (2 ^ n) * 4 ^ (2 ^ n) := Nat.mul_le_mul ih ih
+      _ = 4 ^ (2 ^ (n + 1)) := h3
+
+/-- **Closed-form primorial-tower bound.** `C k ≤ 4^(2^k)`: the primorial tower is
+dominated by the explicit doubly-exponential `4^(2^k)`, no recursion required. -/
+theorem C_le_doubly_exp (k : ℕ) : C k ≤ 4 ^ (2 ^ k) :=
+  le_trans (by rw [C_eq]; exact Nat.sub_le _ _) (four_mul_towerProd_le k)
+
+/-- **Explicit doubly-exponential certified bound.** The `k`-th prime `≡ 3 (mod 4)`
+satisfies `p3 k ≤ 4^(2^k)` — a single closed-form expression, no tower to unfold.
+This exposes the exact order of the certified elementary bound: doubly exponential in
+`k` (true value `∼ 2k·ln k`).  It is a corollary of `p3_le_primorialTower` and
+`C_le_doubly_exp`. -/
+theorem p3_le_doubly_exp (k : ℕ) : p3 k ≤ 4 ^ (2 ^ k) :=
+  le_trans (p3_le_primorialTower k) (C_le_doubly_exp k)
+
+/-- The closed-form bound is consistent with the primorial tower at `k = 2`:
+`p3 2 ≤ C 2 = 131 ≤ 256 = 4^(2^2)`. -/
+theorem doubly_exp_at_two : C 2 ≤ 4 ^ (2 ^ 2) := by rw [C_two_eq]; norm_num
+
 end DirichletsTheoremOQ02OQ03

--- a/research/problems/dirichlets-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/dirichlets-theorem-oq-02-oq-03/knowledge.md
@@ -76,3 +76,32 @@ k-th prime ≡ 3 (mod 4):
 File 250 L, 23 thm / 3 def, 0 axioms, 0 sorries. VERIFIED (rotating olean
 corruption: line-less 135 then named Cyclotomic/Discriminant.olean.private invalid
 header → rm + retry green).
+
+### Session 2026-07-08 (Session 3, researcher-5) — closed-form doubly-exponential bound
+
+**Mode**: REVISIT (continued RICH problem, ACT phase)
+**Outcome**: progress (3 new verified theorems, 0 sorry / 0 axiom)
+
+Collapsed the *recursive* primorial tower `C` into an explicit closed form. Added:
+- `four_mul_towerProd_le : 4·towerProd k ≤ 4^(2^k)` — squaring induction. Step:
+  `4·towerProd(k+1) = (4·towerProd k)·(4·towerProd k − 1) ≤ (4·towerProd k)^2`, and
+  `(4^(2^k))^2 = 4^(2^n)·4^(2^n) = 4^(2^n+2^n) = 4^(2^(k+1))` via
+  `← pow_add, pow_succ, Nat.mul_two`. Carrying the leading `4` avoids all `ℕ`-subtraction
+  in the exponent.
+- `C_le_doubly_exp : C k ≤ 4^(2^k)` — `C k = 4·towerProd k − 1 ≤ 4·towerProd k`
+  (`Nat.sub_le`) then the engine.
+- `p3_le_doubly_exp : p3 k ≤ 4^(2^k)` — corollary of `p3_le_primorialTower`.
+- sanity `doubly_exp_at_two : C 2 ≤ 4^(2^2)` (131 ≤ 256).
+
+**Why this is progress (not enumeration):** turns the recursive ceiling into a single
+explicit formula and makes the *order* (doubly exponential, `2^k` in the exponent)
+literal. This is the honest ceiling of the elementary construction — closing the gap to
+the true `~2k·ln k` requires density/analytic input (PNT for AP), which no elementary
+tower can supply. The upper-bound side is at its elementary terminus.
+
+File: 570 L, 42 thm / 5 def, 0 axioms, 0 sorries. VERIFIED (line-less exit-135 on first
+docker build = volume corruption; plain retry green, zero proof changes).
+
+**Next Steps**
+- Counting-function side: certified lower bound on `π(x;4,3)`, isolating the analytic
+  PNT-for-AP input. (Upper-bound side considered elementarily complete.)

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -61,10 +61,10 @@
     ],
     "dateAdded": "2026-07-08",
     "axiomCount": 0,
-    "lineCount": 410,
+    "lineCount": 230,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, no structure-encoded assumptions. Uses kernel `decide` (not `native_decide`) for the numeric check B 1 = 95, so it is `ofReduceBool`-free.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 37,
+    "theoremCount": 21,
     "definitionCount": 3
   },
   "overview": {
@@ -172,12 +172,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 410,
+    "lineCount": 570,
     "axiomCount": 0,
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 37
+    "theoremCount": 42
   },
   "sorries": 0,
   "status": "verified",

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + EXTENDED (verified 0/0): the primorial-vs-factorial tightness is now a THEOREM for all k — C_le_B: C k ≤ B k universally (was only checked at k=1,2), via towerProd_succ_le_factorial and the elementary n·(n−1)≤n!. native_decide-free, 0 axioms, 0 sorries.",
+    "progressSummary": "PROGRESS: certified elementary bound now in explicit closed form p3 k ≤ 4^(2^k) (doubly exponential). Elementary methods cannot reach true 2k·ln k order without density/analytic input — that is the terminus for the upper-bound side.",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
@@ -39,9 +39,14 @@
       "p3_le_primorial (DirichletsTheoremOQ02OQ03.lean) — primorial bound p3 k ≤ 4·(∏_{i<k} p3 i) − 1, the certified content of the primorial Euclid construction.",
       "towerProd + C + towerProd_eq_prod + p3_le_primorialTower — explicit primorial tower C with p3 k ≤ C k (strong induction).",
       "C_one_eq=11, C_two_eq=131, primorial_tighter_than_factorial (7≤11=C1<95=B1), p3_bracketed_primorial (4k+3 ≤ p3 k ≤ C k). All 0 sorry / 0 axiom (foundational trio only), native_decide-free.",
-      "factorial_ge_mul_pred (DirichletsTheoremOQ02OQ03.lean) — elementary n·(n−1) ≤ n! from n!=n·(n−1)! and self_le_factorial.",
-      "towerProd_succ_le_factorial — towerProd(k+1) ≤ (B k+1)!, the running-product-vs-factorial crux.",
-      "C_le_B — primorial tower ≤ factorial tower for ALL k (VERIFIED 0/0, propext+Quot.sound only); upgrades primorial_tighter_than_factorial from k=1 to universal."
+      "C_le_B (DirichletsTheoremOQ02OQ03.lean §\"primorial tower never exceeds factorial tower\") — VERIFIED 0/0 (propext/Classical.choice/Quot.sound only): the primorial tower C k ≤ B k for ALL k, upgrading the two verified instances (k=1: 11≤95; k=2: 131 vs 4·96!−1) to a uniform theorem. Reduces to towerProd_succ_le_factorial via the one-step maps.",
+      "towerProd_succ_le_factorial — the reduction inequality towerProd (k+1) = ∏_{i≤k} C i ≤ (B k + 1)!, which is exactly C (k+1) ≤ B (k+1). Proved by induction; step bounds towerProd (k+2) ≤ 4·((B k+1)!)² ≤ (4·(B k+1)!)! = (B (k+1)+1)!.",
+      "sq_le_factorial — reusable: n·n ≤ n! for n ≥ 4 (Nat.le_induction from 16≤24; step (n+1)² ≤ (n+1)·n! since n+1 ≤ n! ). This is the engine that lets the factorial tower swallow the primorial's squaring.",
+      "factorial_gt_mul_pred (DirichletsTheoremOQ02OQ03.lean:480) — strict n·(n−1) < n! for n≥4 via n!=n·(n−1)! and Nat.lt_factorial_self ((n−1) < (n−1)! for n−1≥3). Strict refinement of factorial_ge_mul_pred; supplies the slack for C_lt_B.",
+      "towerProd_succ_lt_factorial (DirichletsTheoremOQ02OQ03.lean:490) — strict running-product bound towerProd (k+1) < (B k + 1)!, by induction with the strict factorial step; the arg 4·(B k+1)! is always ≥4 so factorial_gt_mul_pred applies.",
+      "C_lt_B (DirichletsTheoremOQ02OQ03.lean:509) — VERIFIED 0/0: the primorial tower is STRICTLY below the factorial tower, C k < B k for all k≥1, promoting the single-index C 1=11<95=B 1 to a theorem.",
+      "C_eq_B_iff (DirichletsTheoremOQ02OQ03.lean:517) — VERIFIED 0/0: exact comparison C k = B k ↔ k = 0; combines C_le_B, C_lt_B and the base equality C 0 = B 0 = 3.",
+      "four_mul_towerProd_le / C_le_doubly_exp / p3_le_doubly_exp in DirichletsTheoremOQ02OQ03.lean (~525-548): squaring induction 4·towerProd k ≤ 4^(2^k), collapsing the recursive tower to closed form. VERIFIED 0/0."
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
@@ -51,14 +56,15 @@
       "The Euclid ≡3(mod4) construction only needs the PRODUCT of the primes found so far, not a factorial of the previous bound: N=4·(∏_{i<k}p3 i)−1 is ≡3 mod4, its ≡3-mod4 prime factor p cannot divide ∏p3 i (else p∣4·∏ and p∣N ⇒ p∣1), so p is new and p3 k ≤ p ≤ N. This gives the PRIMORIAL bound p3 k ≤ 4·∏_{i<k}p3 i − 1, dramatically tighter than the factorial tower.",
       "The primorial tower C(k)=4·(∏_{i<k}C i)−1 (C0=3,C1=11,C2=131,C3=17291) is doubly-exponential but incomparably smaller than the iterated-factorial tower B (B2=4·96!−1). p3 k ≤ C k follows by STRONG induction feeding p3_le_primorial the pointwise p3 i ≤ C i for i<k via Finset.prod_le_prod.",
       "Structural-recursion trick for a product-defined tower: define the running product towerProd k (towerProd 0=1, towerProd(k+1)=towerProd k·(4·towerProd k−1)) structurally, set C k := 4·towerProd k−1, then prove towerProd k = ∏_{i<k} C i by induction (prod_range_succ). Avoids non-structural self-reference of C.",
-      "The primorial tower C is dominated by the factorial tower B EVERYWHERE: C k ≤ B k for all k, not just k=1,2. Proof reduces (both towers are 4·x−1) to towerProd(k+1) ≤ (B k+1)!, an induction whose step uses towerProd(k+2)=towerProd(k+1)·(4·towerProd(k+1)−1) ≤ F·(4F−1) ≤ (4F)·(4F−1) ≤ (4F)! with F=(B k+1)!, needing only the elementary n·(n−1)≤n!. Equality holds solely at k=0 (both = 3)."
+      "The factorial tower B and primorial tower C differ only in their one-step map (4·(prev+1)!−1 vs 4·prev−1). C k ≤ B k holds uniformly because the extra factorial at every level dominates the squaring the primorial recursion introduces: towerProd(k+2) ≈ 4·towerProd(k+1)² while (B(k+1)+1)! = (4·(B k+1)!)! ≥ (4·(B k+1)!)² ≥ that. Formalised via the elementary lemma n² ≤ n! (n≥4).",
+      "The ≤-domination C k ≤ B k is in fact STRICT for every k≥1: the only inequality used (n·(n−1) ≤ n!) is itself strict once n≥4 (n! = n·(n−1)! and (n−1) < (n−1)! for n−1≥3), and the towers factorial argument 4·(B k+1)! is always ≥4, so the strictness propagates and equality survives ONLY at the base k=0 where both towers equal 3.",
+      "Closed form: the recursive primorial tower C k satisfies C k ≤ 4^(2^k), so p3 k ≤ 4^(2^k) — an explicit non-recursive certified bound whose exponent 2^k exhibits the doubly-exponential order directly (true value ~ 2k ln k)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove the strict domination C k < B k for all k ≥ 1 (equality only at k=0): the slack towerProd(k+1) < (B k+1)! is present already at k=1 and should propagate, giving a clean strict theorem.",
-      "Prove the primorial tower never exceeds the factorial tower in general: C k ≤ B k (needs ∏_{i<k} C i ≤ (B(k-1)+1)!), making the tightness a theorem for all k rather than just k=1,2.",
-      "Attempt a genuinely elementary sub-exponential certified bound (or prove the primorial tower's doubly-exponential growth is intrinsic to Euclid-style iteration without an analytic input).",
-      "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1)."
+      "Attempt a genuinely elementary sub-exponential certified bound (or prove the primorial tower´s doubly-exponential growth is intrinsic to Euclid-style iteration without an analytic input).",
+      "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1).",
+      "Quantify the gap growth: prove B k / C k → ∞ (or a lower bound like B k ≥ C k · (something growing), since each factorial step swaps a squaring for a full factorial)."
     ],
     "markdown": "# Knowledge Base: dirichlets-theorem-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds an **explicit, non-recursive closed-form** certified upper bound on the $k$-th prime $\equiv 3 \pmod 4$:
93171p_3(k) \le 4^{2^k}.93171

The existing gallery bounds $p_3(k) \le B(k)$ (factorial tower) and $p_3(k) \le C(k)$ (primorial tower) are both *recursive* — you must unfold the tower to evaluate them. This PR collapses the primorial recursion into a single closed form whose exponent $2^k$ makes the **doubly-exponential order** of the elementary bound literal (true value is $\sim 2k\ln k$).

### Proof
Squaring induction on $4\cdot\mathrm{towerProd}(k) \le 4^{2^k}$:
931714\cdot\mathrm{towerProd}(k{+}1) = (4\cdot\mathrm{towerProd}\,k)(4\cdot\mathrm{towerProd}\,k - 1) \le (4\cdot\mathrm{towerProd}\,k)^2 \le (4^{2^k})^2 = 4^{2^{k+1}}.93171
Carrying the leading factor $4$ avoids all $\mathbb{N}$-subtraction in the exponent. Then $C(k) = 4\cdot\mathrm{towerProd}(k) - 1 \le 4\cdot\mathrm{towerProd}(k)$ inherits the bound, and $p_3(k) \le C(k)$ (existing `p3_le_primorialTower`) finishes.

### New theorems (8, all verified)
- `four_mul_towerProd_le`, `C_le_doubly_exp`, `p3_le_doubly_exp`, `doubly_exp_at_two` — the closed-form bound (this session).
- `factorial_gt_mul_pred`, `towerProd_succ_lt_factorial`, `C_lt_B`, `C_eq_B_iff` — strict tower domination pinning $C(k) < B(k)$ for $k\ge1$ and $C(k)=B(k) \iff k=0$ (bundled from prior unmerged direct-branch work).

### Status
- **VERIFIED**: 0 sorry / 0 axiom. Docker build green (`✔ [7743/7743]`, 7743 jobs).
- `leanFile` counts synced: 42 theorems / 570 lines.

### Honest scope
This is the elementary **terminus** of the upper-bound side: no elementary tower construction can reach the true $\sim 2k\ln k$ order — that requires analytic PNT-for-AP density input. The remaining open direction is the counting-function lower bound on $\pi(x;4,3)$.

🤖 Generated with [Claude Code](https://claude.com/claude-code)