### PR TITLE
research(erdos-1012-oq-01-oq-02): k-variation structure of Woodall edge threshold [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1012OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1012OQ01OQ02.lean
@@ -25,6 +25,21 @@
   * `edgeThreshold_lt_choose_two` — **strict** non-degeneracy: `edgeThreshold n k < C(n,2)`
     on `n ≥ 2k+3` away from the single degenerate corner `(k,n) = (0,3)`.
 
+  It also records the complementary variation in the *cycle-length parameter `k`* (with
+  `n` fixed), which the parent likewise omits:
+
+  * `edgeThreshold_succ_right`   — the **recurrence in `k`** (for `n ≥ k+2`):
+    `edgeThreshold n (k+1) + (n-k-2) = edgeThreshold n k + (k+2)`; the discrete
+    derivative in `k` is `2k+4-n`, negative for small `k` and positive for large `k`.
+  * `edgeThreshold_succ_right_le` / `edgeThreshold_succ_right_ge` — the threshold
+    **decreases** in `k` on `n ≥ 2k+4` and **increases** on `k+2 ≤ n ≤ 2k+4`.
+  * `edgeThreshold_second_diff`  — **convexity**: the second difference in `k` is the
+    constant `+2` (`edgeThreshold n k + edgeThreshold n (k+2) = 2·edgeThreshold n (k+1)+2`),
+    so `k ↦ edgeThreshold n k` is U-shaped.
+  * `edgeThreshold_reflect`      — **reflection symmetry** `edgeThreshold n k =
+    edgeThreshold n (n-k-3)` (the involution `k ↦ n-k-3` swaps the two binomials),
+    which with convexity pins the minimum to the axis `k = (n-3)/2`.
+
   All results are fully machine-checked (0 axioms, 0 sorries), reusing the parent's
   `edgeThreshold` definition.
 
@@ -93,6 +108,83 @@ theorem edgeThreshold_mono (k : ℕ) {n m : ℕ} (hn : k + 1 ≤ n) (hnm : n ≤
     have hkm : k + 1 ≤ m := le_trans hn h
     rw [edgeThreshold_succ_left m k hkm]
     omega
+
+/-!
+### Variation in `k` (fixed `n`)
+
+The results above track how `edgeThreshold n k` moves as the vertex count `n` grows.
+The complementary direction — how it moves as the cycle-length parameter `k` grows with
+`n` held fixed — is governed by the *other* binomial coefficient.  Writing
+`edgeThreshold n k = C(n-k-1, 2) + C(k+2, 2) + 1`, increasing `k` by one *shrinks* the
+first coefficient (its argument `n-k-1` drops) while it *grows* the second (`k+2` rises),
+so the threshold is a sum of a decreasing and an increasing term.  The net discrete
+derivative in `k` is `(k+2) - (n-k-2) = 2k+4-n`: negative for small `k`, positive for
+large `k`.  Hence `k ↦ edgeThreshold n k` is **convex (U-shaped)** in `k`, with constant
+second difference `2` and a reflection symmetry about the axis `k = (n-3)/2`.
+-/
+
+/-- **Recurrence in `k`.**  For `n ≥ k+2` (so `n-k-1 ≥ 1`), the subtraction-free form of
+    the discrete derivative in `k`:
+
+        edgeThreshold n (k+1) + (n - k - 2) = edgeThreshold n k + (k + 2).
+
+    Equivalently `edgeThreshold n (k+1) − edgeThreshold n k = (k+2) − (n-k-2) = 2k+4-n`.
+    Raising `k` shrinks the leading coefficient by `n-k-2 = C(n-k-1,2)-C(n-k-2,2)` and
+    grows the trailing one by `k+2 = C(k+3,2)-C(k+2,2)`. -/
+theorem edgeThreshold_succ_right (n k : ℕ) (h : k + 2 ≤ n) :
+    edgeThreshold n (k + 1) + (n - k - 2) = edgeThreshold n k + (k + 2) := by
+  unfold edgeThreshold
+  have e1 : n - (k + 1) - 1 = n - k - 2 := by omega
+  have e2 : k + 1 + 2 = (k + 2) + 1 := by omega
+  have e3 : n - k - 1 = (n - k - 2) + 1 := by omega
+  rw [e1, e2, choose_two_succ (k + 2), e3, choose_two_succ (n - k - 2)]
+  omega
+
+/-- **Threshold decreases in `k` on the pre-axis range `n ≥ 2k+4`.**  When `2k+4 ≤ n`
+    the step from `k` to `k+1` lands on the decreasing (negative-derivative) branch. -/
+theorem edgeThreshold_succ_right_le (n k : ℕ) (h : 2 * k + 4 ≤ n) :
+    edgeThreshold n (k + 1) ≤ edgeThreshold n k := by
+  have hr := edgeThreshold_succ_right n k (by omega)
+  omega
+
+/-- **Threshold increases in `k` on the post-axis range `k+2 ≤ n ≤ 2k+4`.**  When
+    `n ≤ 2k+4` (and `n ≥ k+2` so the recurrence applies) the step from `k` to `k+1`
+    lands on the increasing (nonnegative-derivative) branch. -/
+theorem edgeThreshold_succ_right_ge (n k : ℕ) (hlo : k + 2 ≤ n) (hhi : n ≤ 2 * k + 4) :
+    edgeThreshold n k ≤ edgeThreshold n (k + 1) := by
+  have hr := edgeThreshold_succ_right n k hlo
+  omega
+
+/-- **Convexity in `k`: constant second difference.**  For `n ≥ k+3`,
+
+        edgeThreshold n k + edgeThreshold n (k+2) = 2 · edgeThreshold n (k+1) + 2.
+
+    The second discrete difference is the constant `+2`, so `k ↦ edgeThreshold n k` is
+    (discretely) convex — a genuine U-shape rather than a monotone curve.  This is the
+    structural reason the two single-step directions above have opposite signs. -/
+theorem edgeThreshold_second_diff (n k : ℕ) (h : k + 3 ≤ n) :
+    edgeThreshold n k + edgeThreshold n (k + 2)
+      = 2 * edgeThreshold n (k + 1) + 2 := by
+  have hA := edgeThreshold_succ_right n k (by omega)
+  have hB := edgeThreshold_succ_right n (k + 1) (by omega)
+  rw [show k + 1 + 1 = k + 2 from rfl] at hB
+  omega
+
+/-- **Reflection symmetry in `k`.**  For `n ≥ k+3`,
+
+        edgeThreshold n k = edgeThreshold n (n - k - 3).
+
+    The involution `k ↦ n-k-3` swaps the two binomial coefficients
+    (`n-k-1 ↔ (n-k-3)+2` and `k+2 ↔ n-(n-k-3)-1`), so the threshold is symmetric about
+    the axis `k = (n-3)/2`.  Together with `edgeThreshold_second_diff` (convexity) this
+    pins the minimum of `k ↦ edgeThreshold n k` to that axis. -/
+theorem edgeThreshold_reflect (n k : ℕ) (h : k + 3 ≤ n) :
+    edgeThreshold n k = edgeThreshold n (n - k - 3) := by
+  unfold edgeThreshold
+  have e1 : n - (n - k - 3) - 1 = k + 2 := by omega
+  have e2 : (n - k - 3) + 2 = n - k - 1 := by omega
+  rw [e1, e2]
+  ring
 
 /-- **Non-degeneracy of the edge threshold.**  On the Woodall range `n ≥ 2k+3` the
     threshold never exceeds the total number of edges of the complete graph `Kₙ`:

--- a/src/data/research/problems/erdos-1012-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1012-oq-01-oq-02.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE. Child of erdos-1012-oq-01 (Woodall function f(k) and edge threshold). The parent evaluates edgeThreshold n k = C(n-k-1,2)+C(k+2,2)+1 only at the boundary points n=2k+2, 2k+3. This entry supplies the variation in n: edgeThreshold_eq (explicit polynomial form), edgeThreshold_succ_left (recurrence: adding a vertex raises the threshold by exactly n-k-1, for n≥k+1), edgeThreshold_lt_succ (strict monotonicity for n≥k+2), edgeThreshold_mono (weak monotonicity for k+1≤n≤m). Erdos1012OQ01OQ02.lean, 2 helpers + 5 theorems (incl. non-degeneracy edgeThreshold≤C(n,2)), 0 axioms, 0 sorries, no native_decide.",
+    "progressSummary": "COMPLETE. Child of erdos-1012-oq-01 (Woodall function f(k) and edge threshold). The parent evaluates edgeThreshold n k = C(n-k-1,2)+C(k+2,2)+1 only at the boundary points n=2k+2, 2k+3. This entry supplies the variation in n: edgeThreshold_eq (explicit polynomial form), edgeThreshold_succ_left (recurrence: adding a vertex raises the threshold by exactly n-k-1, for n≥k+1), edgeThreshold_lt_succ (strict monotonicity for n≥k+2), edgeThreshold_mono (weak monotonicity for k+1≤n≤m). Erdos1012OQ01OQ02.lean, 2 helpers + 5 n-theorems + 5 k-theorems (incl. non-degeneracy edgeThreshold≤C(n,2)), 0 axioms, 0 sorries, no native_decide.",
     "builtItems": [
       "Erdos1012OQ01OQ02.lean: 7 theorems, 0 axioms (propext/Quot.sound only — no Classical.choice), 0 sorries. Imports Proofs.Erdos1012OQ01 for the edgeThreshold definition.",
       "choose_two_succ: Pascal discrete-derivative C(m+1,2) = C(m,2) + m (via Nat.choose_succ_succ + Nat.choose_one_right).",
@@ -42,7 +42,11 @@
       "two_mul_choose_two: 2·C(m,2) = m·(m-1) (subtraction-free doubling helper, elementary induction reusing choose_two_succ).",
       "edgeThreshold_le_choose_two: NON-DEGENERACY — for n≥2k+3, edgeThreshold n k ≤ C(n,2). The required edge count never exceeds the complete graph's, so the long-cycle hypothesis edgeCount G ≥ edgeThreshold n k is satisfiable rather than vacuous. Doubled gap 2(C(n,2)−edgeThreshold) = 2k(k+2)+2c(k+1)≥0 (c=n−(2k+3)), closed by nlinarith.",
       "edgeThreshold_add_surplus_eq_choose_two: exact surplus identity C(n,2) = edgeThreshold n k + (k(k+2) + (n-(2k+3))(k+1)) for n ≥ 2k+3 — upgrades the ≤ bound edgeThreshold_le_choose_two to an equality with an explicit nonnegative gap.",
-      "edgeThreshold_lt_choose_two: strict non-degeneracy — edgeThreshold n k < C(n,2) for n ≥ 2k+3 except at the single degenerate point (k,n)=(0,3) where edgeThreshold 3 0 = C(3,2) = 3."
+      "edgeThreshold_lt_choose_two: strict non-degeneracy — edgeThreshold n k < C(n,2) for n ≥ 2k+3 except at the single degenerate point (k,n)=(0,3) where edgeThreshold 3 0 = C(3,2) = 3.",
+      "edgeThreshold_succ_right: k-recurrence (n fixed) edgeThreshold n (k+1)+(n-k-2)=edgeThreshold n k+(k+2) for n>=k+2; discrete derivative in k is 2k+4-n. Proof: unfold + choose_two_succ on both binomials (n-k-1 and k+3) then omega.",
+      "edgeThreshold_succ_right_le / edgeThreshold_succ_right_ge: threshold decreases in k on n>=2k+4 and increases on k+2<=n<=2k+4 (opposite signs of the derivative 2k+4-n). One-line omega from the k-recurrence.",
+      "edgeThreshold_second_diff: convexity in k -- constant second difference edgeThreshold n k + edgeThreshold n (k+2) = 2*edgeThreshold n (k+1) + 2 for n>=k+3. Two applications of the k-recurrence + omega (rw k+1+1=k+2 to unify the atom).",
+      "edgeThreshold_reflect: reflection symmetry edgeThreshold n k = edgeThreshold n (n-k-3) for n>=k+3; the involution k<->n-k-3 swaps the two binomials (n-k-1<->(n-k-3)+2, k+2<->n-(n-k-3)-1). unfold + two omega subtraction identities + ring. With convexity this pins the minimizer to k=(n-3)/2."
     ],
     "insights": [
       "The threshold's discrete derivative in n is exactly n-k-1: C((n-k-1)+1,2) - C(n-k-1,2) = n-k-1. This is the structural reason the edge requirement tightens with each added vertex and f(k) is a well-defined minimum.",
@@ -50,7 +54,9 @@
       "edgeThreshold_eq cannot be finished by omega alone (the m*(m-1) product is nonlinear); use Nat.choose_two_right and only the linear subtraction identities (n-k-1-1 = n-k-2, k+2-1 = k+1) under omega.",
       "Weak monotonicity proved by `induction hnm with | refl | @step m h ih` on the ≤ proof (Nat.le.rec); the step case applies the n-recurrence and omega (treating edgeThreshold terms as atoms, n-k-1 ≥ 0).",
       "Non-degeneracy needs no division: double both sides via 2·C(m,2)=m·(m-1), substitute n=2k+3+c to eliminate all truncated subtraction, and the gap becomes the manifestly nonnegative polynomial 2k(k+2)+2c(k+1). nlinarith closes it; omega then divides the doubled inequality back by 2.",
-      "The threshold-vs-complete-graph surplus is exactly k(k+2)+(n-(2k+3))(k+1); it vanishes only at (k,n)=(0,3), so away from that corner the long-cycle edge hypothesis has strict room above the threshold (not forced to K_n). Proven by halving the parent's doubled polynomial identity and cancelling 2 via Nat.eq_of_mul_eq_mul_left."
+      "The threshold-vs-complete-graph surplus is exactly k(k+2)+(n-(2k+3))(k+1); it vanishes only at (k,n)=(0,3), so away from that corner the long-cycle edge hypothesis has strict room above the threshold (not forced to K_n). Proven by halving the parent's doubled polynomial identity and cancelling 2 via Nat.eq_of_mul_eq_mul_left.",
+      "Variation in k (n fixed) is a sum of a decreasing binomial C(n-k-1,2) and an increasing one C(k+2,2); the net discrete derivative is exactly (k+2)-(n-k-2)=2k+4-n, so k->edgeThreshold n k is convex (constant 2nd difference +2) with a reflection symmetry about k=(n-3)/2 -- the complementary structure to the file's original n-monotonicity results.",
+      "Lean: to combine two edgeThreshold_succ_right instances in the second-difference proof, the (k+1)-instance yields the atom `edgeThreshold n (k+1+1)`; omega treats it as distinct from `edgeThreshold n (k+2)`, so `rw [show k+1+1=k+2 from rfl]` first to unify the atoms before omega."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -87,8 +93,8 @@
     {
       "path": "Proofs/Erdos1012OQ01OQ02.lean",
       "filename": "Erdos1012OQ01OQ02.lean",
-      "lineCount": 185,
-      "theoremCount": 9,
+      "lineCount": 277,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends the **completed** entry `erdos-1012-oq-01-oq-02` (structural arithmetic of the Woodall edge threshold `edgeThreshold n k = C(n-k-1,2) + C(k+2,2) + 1`) with its behavior in the **cycle-length parameter `k`** (with `n` fixed) — the complement of the file's existing `n`-variation results, and a documented next-step.

Raising `k` shrinks the leading binomial `C(n-k-1,2)` and grows the trailing `C(k+2,2)`, so the net discrete derivative in `k` is exactly `(k+2) - (n-k-2) = 2k+4-n`: negative for small `k`, positive for large `k`. Hence `k ↦ edgeThreshold n k` is convex (U-shaped) with a reflection symmetry.

## New theorems (all 0 axioms / 0 sorries)

| Theorem | Statement |
|---|---|
| `edgeThreshold_succ_right` | `edgeThreshold n (k+1) + (n-k-2) = edgeThreshold n k + (k+2)` for `n ≥ k+2` (subtraction-free derivative) |
| `edgeThreshold_succ_right_le` | decreasing in `k` on `n ≥ 2k+4` |
| `edgeThreshold_succ_right_ge` | increasing in `k` on `k+2 ≤ n ≤ 2k+4` |
| `edgeThreshold_second_diff` | `edgeThreshold n k + edgeThreshold n (k+2) = 2·edgeThreshold n (k+1) + 2` (constant 2nd difference ⇒ convex) |
| `edgeThreshold_reflect` | `edgeThreshold n k = edgeThreshold n (n-k-3)` for `n ≥ k+3` (involution `k ↦ n-k-3` swaps the two binomials) |

Together, convexity + reflection symmetry pin the minimizer of `k ↦ edgeThreshold n k` to the axis `k = (n-3)/2`.

## Verification

- `#print axioms` on the new theorems: `[propext, Quot.sound]` only — no `Classical.choice`, `Lean.ofReduceBool`, or `sorryAx`.
- Verified via host `lake env lean` (empty output). The Docker VM was under fleet memory pressure and produced line-less `exit-135`/`exit-139` crashes (SIGBUS/SIGSEGV, sub-second elaboration before crash — infrastructure, not a proof error); confirmed by cache repair + successful host elaboration of both the dependency and this file.

File: `proofs/Proofs/Erdos1012OQ01OQ02.lean` (9 → 14 theorems, 185 → 277 lines). Research metadata synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)