### PR TITLE
Gallery integrity: fix verified shannon-entropy-oq-03 manifest (drop sorry-carrying Aristotle scaffold)

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -45,9 +45,6 @@
     "lineCount": 92,
     "theoremCount": 3,
     "definitionCount": 0,
-    "additionalFiles": [
-      "Proofs/ShannonEntropySSAAristotle.lean"
-    ],
     "mathlib_version": "4.26.0",
     "verifiedAt": "2026-07-07"
   },
@@ -170,10 +167,7 @@
     "theoremCount": 3,
     "definitionCount": 0,
     "path": "Proofs/ShannonEntropySSA.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/ShannonEntropySSAAristotle.lean"
-    ]
+    "sorries": 0
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Integrity Issue

**Proof**: shannon-entropy-oq-03 (Strong Subadditivity of Shannon Entropy)
**Severity**: HIGH — a `verified` entry carried 3 sorries in a listed companion file.

## Evidence

- **meta.json claims**: `status: verified`, `badge: verified`, `sorries: 0`, and lists `Proofs/ShannonEntropySSAAristotle.lean` in `additionalFiles` (both `meta.additionalFiles` and `leanFile.additionalFiles`).
- **Lean source shows**: the main file `Proofs/ShannonEntropySSA.lean` has **0 sorries** and delegates its 3 theorems to the parent `Proofs/ShannonEntropy.lean`, where `strong_subadditivity` is genuinely proved (0 sorries, 0 axioms — confirmed by grep). The listed companion `ShannonEntropySSAAristotle.lean` is a **redundant Aristotle proof-search scaffold** in a disconnected `shannonEntropy'` (primed) namespace carrying **3 `sorry` stubs**. It is not imported by the presented proof and contributes nothing to the verified result.

A fleet-wide scan of all 4780 gallery entries found this was the **only** `verified` entry listing a sorry-carrying companion in its manifest — every other verified entry keeps a clean file set.

## Fix

Remove `Proofs/ShannonEntropySSAAristotle.lean` from both `additionalFiles` arrays so the manifest matches what is actually presented and verified. The headline `verified` status is correct and preserved; the scaffold `.lean` file stays on disk as an active Aristotle target.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)