### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-02): Wirtinger inequality via Parseval [VERIFIED]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
@@ -114,4 +114,84 @@ theorem fourierCoeffOn_deriv_zero_periodic (f : ℝ → ℝ) (hf : ContDiff ℝ 
     exact intervalIntegral.integral_ofReal
   rw [hcomp, hz, hfp, sub_self, ofReal_zero, smul_zero]
 
+-- ============================================================
+-- SECTION III: Wirtinger's inequality (Fourier / Parseval form)
+-- ============================================================
+
+/-- A continuous `ℝ → ℂ` function is `L²` on the finite-measure interval `(0, 2π]`.
+    It is bounded there (continuous on the compact closure `[0, 2π]`), and the
+    restricted measure is finite, so `MemLp.of_bound` applies. -/
+private theorem memLp_two_of_continuous {g : ℝ → ℂ} (hg : Continuous g) :
+    MemLp g 2 (volume.restrict (Set.Ioc (0 : ℝ) (2 * π))) := by
+  obtain ⟨C, hC⟩ :=
+    (isCompact_Icc (a := (0 : ℝ)) (b := 2 * π)).exists_bound_of_continuousOn hg.continuousOn
+  exact MemLp.of_bound hg.aestronglyMeasurable C
+    (ae_restrict_of_forall_mem measurableSet_Ioc
+      (fun x hx => hC x (Set.Ioc_subset_Icc_self hx)))
+
+/-- **Wirtinger's inequality** (Fourier / Hurwitz form).  For a `C¹` function `f`
+    of period `2π` whose mean over one period vanishes,
+
+        ∫₀^{2π} f² ≤ ∫₀^{2π} (f')².
+
+    This is the analytic heart of the Fourier proof of the isoperimetric
+    inequality.  Via Parseval's identity (`hasSum_sq_fourierCoeffOn`) both sides
+    are `2π` times a sum of squared Fourier coefficients:
+
+        ∫₀^{2π} f²  = 2π · ∑ₙ |ĉₙ(f)|²,   ∫₀^{2π} (f')² = 2π · ∑ₙ |ĉₙ(f')|².
+
+    The first-order identity `ĉₙ(f') = i·n·ĉₙ(f)` (`fourierCoeffOn_deriv_periodic`)
+    gives `|ĉₙ(f')|² = n²·|ĉₙ(f)|²`, and for `n ≠ 0` the eigenvalue satisfies
+    `n² ≥ 1`.  The `n = 0` mode contributes nothing on either side: `ĉ₀(f') = 0`
+    (`fourierCoeffOn_deriv_zero_periodic`) and `ĉ₀(f) = 0` by the zero-mean
+    hypothesis.  Hence the sums compare termwise and the inequality follows,
+    with equality exactly when only the first harmonic survives — the circle. -/
+theorem wirtinger_inequality (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
+    (hperiod : ∀ t, f (t + 2 * π) = f t)
+    (hmean : ∫ x in (0 : ℝ)..(2 * π), f x = 0) :
+    ∫ x in (0 : ℝ)..(2 * π), (f x) ^ 2 ≤ ∫ x in (0 : ℝ)..(2 * π), (deriv f x) ^ 2 := by
+  have hab : (0 : ℝ) < 2 * π := by positivity
+  -- Continuity of `f` and its derivative, embedded into `ℂ`.
+  have hgc : Continuous (ofReal ∘ f) := Complex.continuous_ofReal.comp hf.continuous
+  have hg'c : Continuous (ofReal ∘ deriv f) :=
+    Complex.continuous_ofReal.comp (hf.continuous_deriv le_rfl)
+  -- Parseval on `(0, 2π]` for `f` and for `f'`.
+  have Pg := hasSum_sq_fourierCoeffOn hab (memLp_two_of_continuous hgc)
+  have Pg' := hasSum_sq_fourierCoeffOn hab (memLp_two_of_continuous hg'c)
+  -- `ĉ₀(f) = 0` (zero mean) and `ĉ₀(f') = 0` (the companion identity).
+  have hc0 : fourierCoeffOn hab (ofReal ∘ f) 0 = 0 := by
+    rw [fourierCoeffOn_eq_integral]
+    simp only [neg_zero, fourier_zero, one_smul]
+    have hcomp : (∫ x in (0 : ℝ)..(2 * π), (ofReal ∘ f) x)
+        = ((∫ x in (0 : ℝ)..(2 * π), f x : ℝ) : ℂ) := by
+      simp only [Function.comp]; exact intervalIntegral.integral_ofReal
+    rw [hcomp, hmean, ofReal_zero, smul_zero]
+  have hc0' : fourierCoeffOn hab (ofReal ∘ deriv f) 0 = 0 :=
+    fourierCoeffOn_deriv_zero_periodic f hf hperiod hab
+  -- Termwise: `|ĉₙ(f)|² ≤ |ĉₙ(f')|²`.
+  have key : ∀ n : ℤ,
+      ‖fourierCoeffOn hab (ofReal ∘ f) n‖ ^ 2
+        ≤ ‖fourierCoeffOn hab (ofReal ∘ deriv f) n‖ ^ 2 := by
+    intro n
+    rcases eq_or_ne n 0 with rfl | hn
+    · simp [hc0, hc0']
+    · rw [fourierCoeffOn_deriv_periodic f hf hperiod hab n hn,
+          norm_mul, norm_mul, Complex.norm_I, one_mul, mul_pow]
+      have hn1 : (1 : ℝ) ≤ ‖(n : ℂ)‖ ^ 2 := by
+        have h1 : (1 : ℝ) ≤ ‖(n : ℂ)‖ := by
+          rw [Complex.norm_intCast]; exact_mod_cast Int.one_le_abs hn
+        nlinarith [norm_nonneg ((n : ℂ))]
+      exact le_mul_of_one_le_left (sq_nonneg _) hn1
+  -- Compare the two Parseval sums termwise, then cancel the common `(2π)⁻¹`.
+  have hle := hasSum_le key Pg Pg'
+  simp only [smul_eq_mul, sub_zero] at hle
+  have hfin := le_of_mul_le_mul_left hle (by positivity : (0 : ℝ) < (2 * π)⁻¹)
+  -- Bridge the complex `L²` integrals back to the real squared integrals.
+  have hbridge : ∀ x : ℝ, ‖(ofReal ∘ f) x‖ ^ 2 = (f x) ^ 2 := fun x => by
+    simp only [Function.comp, Complex.norm_real, Real.norm_eq_abs, sq_abs]
+  have hbridge' : ∀ x : ℝ, ‖(ofReal ∘ deriv f) x‖ ^ 2 = (deriv f x) ^ 2 := fun x => by
+    simp only [Function.comp, Complex.norm_real, Real.norm_eq_abs, sq_abs]
+  simp_rw [hbridge, hbridge'] at hfin
+  exact hfin
+
 end IsoperimetricFourier

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
@@ -11,18 +11,24 @@
       "Mathlib does NOT package 'derivative of a periodic function is periodic' (no Function.Periodic.deriv on this toolchain). Proved here from deriv_comp_add_const: since (fun x ↦ f (x+T)) = f, their derivatives agree, giving f'(t+T) = f'(t).",
       "ContDiff ℝ 1 (deriv f) is extracted from ContDiff ℝ 2 f via contDiff_succ_iff_deriv (n := 1) |>.2.2 — note the current 3-way conjunction (Differentiable ∧ (n=ω→AnalyticOn) ∧ ContDiff n (deriv f)).",
       "(i·n)·(i·n) collapses to −n² via Complex.I_mul_I (I*I = -1) after a ring normalization that pulls out (I*I)·n².",
-      "The n=0 companion is governed by FTC, not the i·n divide-by-n identity: fourier 0 = 1 so c₀(f') is the period-average of f', and intervalIntegral.integral_deriv_eq_sub + periodicity forces it to 0. Together with the -n² eigenvalue (n≠0) this pins the full differentiation spectrum: 0 on constants, i·n on the n-th harmonic."
+      "The n=0 companion is governed by FTC, not the i·n divide-by-n identity: fourier 0 = 1 so c₀(f') is the period-average of f', and intervalIntegral.integral_deriv_eq_sub + periodicity forces it to 0. Together with the -n² eigenvalue (n≠0) this pins the full differentiation spectrum: 0 on constants, i·n on the n-th harmonic.",
+      "Wirtinger inequality ∫f²≤∫(f')² (mean-zero, period 2π) is a clean termwise hasSum_le on the two Parseval sums: |ĉₙ(f')|²=n²|ĉₙ(f)|² and n²≥1 for n≠0, with the n=0 mode killed on both sides (ĉ₀(f')=0 companion, ĉ₀(f)=0 zero-mean)."
     ],
     "builtItems": [
       "AreaOfCircleOQ01OQ02OQ02OQ02.lean: 3 theorems, 0 axioms, 0 sorries, imports and reuses the parent IBP identity. VERIFIED via docker build (Built [7744/7744]).",
       "deriv_periodic_of_periodic: the derivative of a T-periodic function is T-periodic.",
       "fourierCoeffOn_deriv2_periodic: cₙ(f'') = -n²·cₙ(f) for C² periodic f, n ≠ 0.",
-      "fourierCoeffOn_deriv_zero_periodic: c₀(f') = 0 for C¹ periodic f (zero mode), via FTC ∫ f' = f(2π)-f(0) = 0."
+      "fourierCoeffOn_deriv_zero_periodic: c₀(f') = 0 for C¹ periodic f (zero mode), via FTC ∫ f' = f(2π)-f(0) = 0.",
+      "wirtinger_inequality in AreaOfCircleOQ01OQ02OQ02OQ02.lean (VERIFIED 0/0): ∫₀^2π f² ≤ ∫₀^2π (f')² for C¹ period-2π mean-zero f",
+      "memLp_two_of_continuous helper: continuous ℝ→ℂ is L² on Ioc(0,2π) via MemLp.of_bound + IsCompact.exists_bound_of_continuousOn"
     ],
-    "progressSummary": "PROGRESS: n=0 companion c₀(f')=0 proved and VERIFIED (0/0), completing the spectral picture of d/dx on periodic functions (3 theorems total). Remaining: Wirtinger via Parseval, then isoperimetric assembly.",
+    "progressSummary": "PROGRESS: Wirtinger inequality proved and VERIFIED (0/0) — 4 theorems total. The analytic core of the Hurwitz/Fourier isoperimetric proof is done; remaining is the area/perimeter Fourier assembly.",
     "nextSteps": [
-      "Assemble Wirtinger inequality ∫|f'|² ≥ ∫|f|² (mean-zero f, period 2π) from the n²≥1 Fourier-mode bound and Parseval; requires fourierCoeffOn Parseval/completeness for periodic functions (assess Mathlib fourierCoeff L² isometry availability).",
-      "Combine with the area/perimeter Fourier expansions to close the isoperimetric inequality C² ≥ 4πA with the circle as the equality case."
+      "Assemble the full isoperimetric inequality C²≥4πA: express area A and perimeter C via Fourier coefficients of the (mean-adjusted) boundary parametrisation and apply wirtinger_inequality mode-by-mode; equality iff only n=±1 harmonics survive (circle). Requires Greens-theorem area formula A=½∮(x dy − y dx) in Fourier form.",
+      "Characterise the equality case of wirtinger_inequality: ∫f²=∫(f')² iff ĉₙ(f)=0 for all |n|≥2 (only the first harmonic), i.e. f(t)=a cos t + b sin t."
+    ],
+    "mathlibGaps": [
+      "Mathlib has Parseval on an interval (hasSum_sq_fourierCoeffOn / tsum_sq_fourierCoeffOn, AddCircle.lean) — no gap; the L² isometry is available directly, so Wirtinger did NOT need custom infrastructure."
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Adds **Wirtinger's inequality** (Fourier / Hurwitz form) to `AreaOfCircleOQ01OQ02OQ02OQ02.lean`, the analytic core of the Fourier proof of the isoperimetric inequality:

> For a `C¹` function `f` of period `2π` with zero mean over one period,
> **∫₀^{2π} f² ≤ ∫₀^{2π} (f')².**

This advances the `area-of-circle-oq-01-oq-02-oq-02-oq-02` research thread from the spectral identities (`ĉₙ(f')=i·n·ĉₙ(f)`, `ĉₙ(f'')=−n²·ĉₙ(f)`, `ĉ₀(f')=0`, all previously VERIFIED here) to the inequality they were built for.

## Proof strategy

- **Parseval on `(0,2π]`** — Mathlib's `hasSum_sq_fourierCoeffOn` expresses each side as `2π · ∑ₙ |ĉₙ(·)|²`. (No custom L² infrastructure needed — the Fourier `HilbertBasis` isometry is already in Mathlib.)
- **Eigenvalue bound** — the first-order identity `fourierCoeffOn_deriv_periodic` gives `|ĉₙ(f')|² = n²·|ĉₙ(f)|²`, and `n² ≥ 1` for `n ≠ 0` (`Int.one_le_abs`).
- **`n = 0` mode** — vanishes on both sides: `ĉ₀(f') = 0` (`fourierCoeffOn_deriv_zero_periodic`, the companion in this file) and `ĉ₀(f) = 0` by the zero-mean hypothesis.
- **Termwise comparison** — `hasSum_le` compares the two Parseval sums; cancelling the common positive `(2π)⁻¹` and bridging `‖(↑f):ℂ‖² = f²` closes the goal.

Also adds a small helper `memLp_two_of_continuous` (continuous `ℝ→ℂ` ⇒ `L²` on the finite-measure `Ioc(0,2π)`).

## Verification

- Docker build: `✔ [7744/7744] Built Proofs.AreaOfCircleOQ01OQ02OQ02OQ02 (4.0s)` — `Build completed successfully`.
- **0 sorries, 0 axioms** (no `native_decide`; only standard Mathlib lemmas). File now has 4 verified theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)