### PR TITLE
research(erdos-1090-incomplete-01): ramseyNumber monotone in k [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -511,6 +511,25 @@ theorem ramsey_lower_bound (k : ℕ) (hk : k ≥ 3) : ramseyNumber k ≥ k := by
   rw [ge_iff_le, ← hcard]
   exact hasRamseyProperty_card_ge A k hA
 
+/--
+**Monotonicity of the Ramsey number in `k`:**
+For `3 ≤ k` and `k' ≤ k`, `ramseyNumber k' ≤ ramseyNumber k`. Requiring more
+monochromatic collinear points can only need a larger set: a size-minimal set
+witnessing the property for `k` also witnesses it for `k'` (by
+`hasRamseyProperty_antitone`), so the minimum size for `k'` is no larger. This
+makes `ramseyNumber` a genuine nondecreasing threshold, complementing the trivial
+lower bound `ramsey_lower_bound`.
+-/
+theorem ramseyNumber_le_of_le {k k' : ℕ} (hk : k' ≤ k) (hk3 : 3 ≤ k) :
+    ramseyNumber k' ≤ ramseyNumber k := by
+  have hne : {n : ℕ | ∃ A : Finset Point, A.card = n ∧ HasRamseyProperty A k}.Nonempty := by
+    obtain ⟨A, hA⟩ := hunter_observation k hk3
+    exact ⟨A.card, A, rfl, hA⟩
+  obtain ⟨A, hcard, hA⟩ := Nat.sInf_mem hne
+  calc ramseyNumber k'
+      ≤ A.card := Nat.sInf_le ⟨A, rfl, hasRamseyProperty_antitone hk hA⟩
+    _ = ramseyNumber k := hcard
+
 /-
 **R(3) is Small:**
 The k = 3 case can be achieved with a small set of points.

--- a/src/data/research/problems/erdos-1090-incomplete-01.json
+++ b/src/data/research/problems/erdos-1090-incomplete-01.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-1090-incomplete-01",
-  "title": "Complete proof of Erdős Problem #1090: Monochromatic Collinear Points",
+  "title": "Complete proof of Erd\u0151s Problem #1090: Monochromatic Collinear Points",
   "phase": "NEW",
   "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in geometry: Complete proof of Erdős Problem #1090: Monochromatic Collinear Points.",
+    "plain": "Formal investigation in geometry: Complete proof of Erd\u0151s Problem #1090: Monochromatic Collinear Points.",
     "whyMatters": []
   },
   "knownResults": {
@@ -29,21 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED & VERIFIED (0 axioms, 0 sorries): Eliminated BOTH axioms (graham_selfridge, hunter_observation) by proving erdos1090_construction from Mathlib's Hales-Jewett theorem (Combinatorics.Line.exists_mono_in_high_dimension) via an explicit linear projection of the combinatorial cube [k]^ι into ℝ². Also repaired the file's pre-existing non-compiling state (orphan /-- docstrings, invalid ∀ p q r ∈ A multi-binders, SylvesterGallai DecidablePred). #print axioms: [propext, Classical.choice, Quot.sound] only.",
+    "progressSummary": "COMPLETED & VERIFIED (0 axioms, 0 sorries): Eliminated BOTH axioms (graham_selfridge, hunter_observation) by proving erdos1090_construction from Mathlib's Hales-Jewett theorem (Combinatorics.Line.exists_mono_in_high_dimension) via an explicit linear projection of the combinatorial cube [k]^\u03b9 into \u211d\u00b2. Also repaired the file's pre-existing non-compiling state (orphan /-- docstrings, invalid \u2200 p q r \u2208 A multi-binders, SylvesterGallai DecidablePred). #print axioms: [propext, Classical.choice, Quot.sound] only.",
     "builtItems": [
-      "erdos1090_construction (Erdos1090Problem.lean:155): general k≥3 Ramsey set built from Hales-Jewett combinatorial line via linear projection φ p = ∑ j (p j:ℝ)•v j, v j=!₂[1,w j]; direction nonzero since first coord = |varying|≥1.",
+      "erdos1090_construction (Erdos1090Problem.lean:155): general k\u22653 Ramsey set built from Hales-Jewett combinatorial line via linear projection \u03c6 p = \u2211 j (p j:\u211d)\u2022v j, v j=!\u2082[1,w j]; direction nonzero since first coord = |varying|\u22651.",
       "graham_selfridge, hunter_observation: converted from axiom to theorem (both = instances of erdos1090_construction).",
-      "Repaired 7 orphan /-- docstrings → /- block comments; expanded 2 invalid multi-binders ∀ p q r ∈ A; added open Classical in before SylvesterGallai for filter DecidablePred."
+      "Repaired 7 orphan /-- docstrings \u2192 /- block comments; expanded 2 invalid multi-binders \u2200 p q r \u2208 A; added open Classical in before SylvesterGallai for filter DecidablePred.",
+      "ramseyNumber_le_of_le (NEW): for 3\u2264k, k'\u2264k \u27f9 ramseyNumber k' \u2264 ramseyNumber k \u2014 the min-set-size threshold is nondecreasing in k (from hasRamseyProperty_antitone + Nat.sInf_le). Complements ramsey_lower_bound."
     ],
     "insights": [
-      "Erdős #1090 general case is provable axiom-free in Lean: Mathlib's Hales-Jewett (Combinatorics.Line.exists_mono_in_high_dimension) + a linear 'generic projection' suffices. No genericity argument needed — taking the projection's first coordinate as the coordinate-SUM makes any combinatorial line's direction have first coord = |V| ≥ 1 > 0, so it is automatically nonzero and the k image points are distinct.",
-      "Affine identity φ(l a) = φ(l 0) + (a:ℝ)•dir proved at the module level (add_smul, mul_smul, Finset.sum_add_distrib, Finset.smul_sum) from the per-coordinate fact emb(l a j)=emb(l 0 j)+emb a*[varying]; nonzeroness pushed through WithLp.ofLp (linear) to a positive Finset sum.",
-      "The committed file at HEAD never compiled (last commit was 'UNVERIFIED — build host down'); a prior knowledge note claimed the build was fixed but that fix was not in the committed state."
+      "Erd\u0151s #1090 general case is provable axiom-free in Lean: Mathlib's Hales-Jewett (Combinatorics.Line.exists_mono_in_high_dimension) + a linear 'generic projection' suffices. No genericity argument needed \u2014 taking the projection's first coordinate as the coordinate-SUM makes any combinatorial line's direction have first coord = |V| \u2265 1 > 0, so it is automatically nonzero and the k image points are distinct.",
+      "Affine identity \u03c6(l a) = \u03c6(l 0) + (a:\u211d)\u2022dir proved at the module level (add_smul, mul_smul, Finset.sum_add_distrib, Finset.smul_sum) from the per-coordinate fact emb(l a j)=emb(l 0 j)+emb a*[varying]; nonzeroness pushed through WithLp.ofLp (linear) to a positive Finset sum.",
+      "The committed file at HEAD never compiled (last commit was 'UNVERIFIED \u2014 build host down'); a prior knowledge note claimed the build was fixed but that fix was not in the committed state."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Optional follow-up: prove a quantitative upper bound on ramseyNumber k (currently only ramsey_lower_bound ≥ k is proved).",
-      "Optional: prove Erdos1090Generalized (r-coloring) from the same Hales-Jewett projection (Mathlib HJ already allows arbitrary finite color type)."
+      "Quantitative upper bound on ramseyNumber k remains open: the Hales-Jewett construction gives a set of size \u2264 k^|\u03b9| but |\u03b9| (the HJ dimension) is non-explicit, so no clean closed-form upper bound is available without an explicit HJ number. Monotonicity (ramseyNumber_le_of_le), the lower bound (\u2265k), the r-coloring generalization, and the higher-dimensional analogue are all now proved."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Erdős #1090 (monochromatic collinear points) is fully solved and axiom-free in `Erdos1090Problem.lean`. The file defines `ramseyNumber k` (the minimum size of a finite set with the Ramsey property for `k`) and proves the trivial lower bound `ramseyNumber k ≥ k`. This adds the complementary **monotonicity** of the threshold.

## New theorem

```lean
theorem ramseyNumber_le_of_le {k k' : ℕ} (hk : k' ≤ k) (hk3 : 3 ≤ k) :
    ramseyNumber k' ≤ ramseyNumber k
```

For `3 ≤ k` and `k' ≤ k`, the minimum-set-size threshold is nondecreasing in `k`: a size-minimal set witnessing the Ramsey property for `k` also witnesses it for `k'` (via the existing `hasRamseyProperty_antitone`), so the minimum for `k'` is no larger. Proof: `Nat.sInf_mem` gives a minimal witness `A` for `k`; `A` witnesses `k'` too, so `ramseyNumber k' ≤ A.card = ramseyNumber k` by `Nat.sInf_le`.

This makes `ramseyNumber` a genuine nondecreasing threshold, complementing `ramsey_lower_bound`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1090Problem` — **succeeded** (2429 jobs, 2.7s). Warnings shown are all pre-existing (lines 65/423/551), not the new theorem.
- 0 sorries, 0 axioms; file remains axiom-free.

**State note.** The nextSteps' r-coloring generalization (`erdos1090_generalized_affirmative`) and higher-dimensional analogue (`erdos1090_higherDim_affirmative`) are already proved. A *quantitative upper bound* on `ramseyNumber k` remains open: the Hales–Jewett construction bounds the set size by `k^|ι|`, but the HJ dimension `|ι|` is non-explicit, so no clean closed-form upper bound is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)