### PR TITLE
Enrich Euler Identity OQ-05: Four-Square Identity

### DIFF
--- a/src/data/proofs/euler-identity-oq-05/meta.json
+++ b/src/data/proofs/euler-identity-oq-05/meta.json
@@ -92,7 +92,8 @@
       "**Euler's identity is multiplicativity of a norm**: the four bilinear forms z₁,…,z₄ are exactly the components of the quaternion product, so the identity says N(q)N(q') = N(qq') for the quaternion norm N(x₁+x₂i+x₃j+x₄k) = x₁²+x₂²+x₃²+x₄² — the sign pattern is the quaternion multiplication table, not an accident",
       "**Closure is the real theorem, the ring equation is just its certificate**: Mathlib stops at the polynomial identity for four squares; the mathematically load-bearing statement is that sums of four squares form a multiplicative submonoid, which is what actually reduces Lagrange's theorem to the prime case",
       "**The four-square closure was the missing sibling of a two-square one**: Mathlib packages exactly this closure for two squares (sq_add_sq_mul) but never for four; IsSumFourSq.mul is the faithful four-square analogue, with witnesses produced mechanically rather than guessed",
-      "**Witness-explicit existence**: IsSumFourSq.mul does not merely assert a·b is a sum of four squares — it returns the representation, so e.g. 21 = 3·7 is certified as 0²+4²+2²+1² with no search, illustrating how Euler's reduction is constructive"
+      "**Witness-explicit existence**: IsSumFourSq.mul does not merely assert a·b is a sum of four squares — it returns the representation, so e.g. 21 = 3·7 is certified as 0²+4²+2²+1² with no search, illustrating how Euler's reduction is constructive",
+      "**Four is minimal — three squares are NOT closed**: the entry also proves the sharpness dual (not_isSumThreeSq_mul_closed): 3 = 1²+1²+1² and 5 = 0²+1²+2² are each sums of three squares, yet 15 = 3·5 ≡ 7 (mod 8) is not, because a square is 0/1/4 mod 8 and no triple of those sums to 7. So no Euler-style closure identity exists for three squares, matching Hurwitz's dimensions 1,2,4,8; the obstruction is verified self-containedly by a finite decide over ZMod 8 (kernel decide, not native_decide, so no ofReduceBool), independent of the full Legendre–Gauss three-square theorem"
     ],
     "prerequisites": [
       "Euler's four-square identity as a polynomial identity over a commutative ring (Mathlib's euler_four_squares / sum_four_sq_mul_sum_four_sq, discharged by ring)",
@@ -125,6 +126,72 @@
       "endLine": 143,
       "mathContext": "Two-square sums embed into four-square sums; $21 = 3\\cdot 7 = 0^2+4^2+2^2+1^2$ via the closure theorem.",
       "summary": "isSumFourSq_of_isSumTwoSq pads a two-square sum with two zeros. The examples certify 3 = 1²+1²+1²+0² and 7 = 2²+1²+1²+1², then obtain a four-square representation of 21 = 3·7 by applying IsSumFourSq.mul — witnesses are produced mechanically, not guessed — and a numeric check confirms the resulting forms (0,4,2,1) sum to 21."
+    },
+    {
+      "id": "sharpness-three-squares",
+      "title": "Sharpness: Three Squares Are Not Multiplicatively Closed",
+      "startLine": 146,
+      "endLine": 200,
+      "mathContext": "A square is $\\equiv 0,1,4 \\pmod 8$, so no sum of three squares is $\\equiv 7 \\pmod 8$; hence $15 = 3\\cdot 5$ (with $3,5$ each sums of three squares) is not, and three-square sums fail closure.",
+      "summary": "Establishes that four is the minimal number of squares for which Euler-style multiplicative closure holds. IsSumThreeSq is the three-square predicate; sq_zmod_eight (every square in ZMod 8 is 0/1/4) and sum_three_sq_ne_fifteen_zmod_eight (no triple of those sums to 15 ≡ 7) are discharged by a finite kernel decide over ZMod 8 — NOT native_decide, so no ofReduceBool is introduced. fifteen_not_isSumThreeSq lifts this mod-8 obstruction to ℤ, and not_isSumThreeSq_mul_closed exhibits 3 = 1²+1²+1² and 5 = 0²+1²+2² with 15 = 3·5 not a sum of three squares — the sharpness dual of IsSumFourSq.mul, independent of the full Legendre–Gauss three-square theorem."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "IsSumFourSq.mul",
+      "type": "core",
+      "description": "**Multiplicative closure (the gap Mathlib leaves).** The product of two sums of four squares is a sum of four squares, with witnesses read directly off Euler's identity — the four-square analogue of Mathlib's two-square sq_add_sq_mul, which has no four-square counterpart. This is the load-bearing structural statement that reduces Lagrange's four-square theorem to the prime case.",
+      "leanType": "{a b : R} (ha : IsSumFourSq a) (hb : IsSumFourSq b) : IsSumFourSq (a * b)",
+      "startLine": 86,
+      "endLine": 94
+    },
+    {
+      "name": "not_isSumThreeSq_mul_closed",
+      "type": "core",
+      "description": "**Sharpness of 'four'.** Sums of three squares are NOT closed under multiplication: 3 = 1²+1²+1² and 5 = 0²+1²+2² are each sums of three squares, yet 15 = 3·5 ≡ 7 (mod 8) is not — so four is the minimal count for which Euler-style closure can hold. Proved via a finite decide over ZMod 8, independent of the full three-square theorem.",
+      "leanType": "∃ a b : ℤ, IsSumThreeSq a ∧ IsSumThreeSq b ∧ ¬ IsSumThreeSq (a * b)",
+      "startLine": 194,
+      "endLine": 198
+    },
+    {
+      "name": "four_square_identity",
+      "type": "key",
+      "description": "**Euler's four-square identity.** Over an arbitrary commutative ring, the product of two sums of four squares equals a sum of four explicit bilinear squares (the components of the Hamilton quaternion product), discharged by ring. The certificate underlying every closure result in the file.",
+      "leanType": "(x₁ x₂ x₃ x₄ y₁ y₂ y₃ y₄ : R) : (x₁^2+x₂^2+x₃^2+x₄^2) * (y₁^2+y₂^2+y₃^2+y₄^2) = z₁^2 + z₂^2 + z₃^2 + z₄^2",
+      "startLine": 57,
+      "endLine": 63
+    },
+    {
+      "name": "isSumFourSq_prod",
+      "type": "supporting",
+      "description": "**Closure under finite products.** A finite product of sums of four squares is a sum of four squares, by Finset.induction (empty ↦ 1 via isSumFourSq_one, insert ↦ IsSumFourSq.mul).",
+      "leanType": "{ι : Type*} (s : Finset ι) (f : ι → R) (hf : ∀ i ∈ s, IsSumFourSq (f i)) : IsSumFourSq (∏ i ∈ s, f i)",
+      "startLine": 97,
+      "endLine": 105
+    },
+    {
+      "name": "IsSumFourSq.pow",
+      "type": "supporting",
+      "description": "**Closure under powers.** A power of a sum of four squares is a sum of four squares, by induction on the exponent.",
+      "leanType": "{a : R} (ha : IsSumFourSq a) (n : ℕ) : IsSumFourSq (a ^ n)",
+      "startLine": 108,
+      "endLine": 111
+    },
+    {
+      "name": "isSumFourSq_of_isSumTwoSq",
+      "type": "supporting",
+      "description": "**Two-square embedding.** Any sum of two squares is a sum of four squares (pad with two zeros) — the bridge realising the Brahmagupta–Fibonacci two-square structure inside the four-square monoid.",
+      "leanType": "{a : R} (h : ∃ x y : R, a = x^2 + y^2) : IsSumFourSq a",
+      "startLine": 116,
+      "endLine": 119
+    },
+    {
+      "name": "fifteen_not_isSumThreeSq",
+      "type": "supporting",
+      "description": "**The mod-8 obstruction, lifted to ℤ.** 15 is not a sum of three integer squares: reducing mod 8 would force the forbidden residue 7, which sum_three_sq_ne_fifteen_zmod_eight rules out. The concrete witness that three-square sums fail closure.",
+      "leanType": "¬ IsSumThreeSq (15 : ℤ)",
+      "startLine": 177,
+      "endLine": 182
     }
   ],
   "conclusion": {
@@ -137,6 +204,10 @@
     ]
   },
   "crossReferences": [
-    "euler-identity"
+    {
+      "targetId": "euler-identity",
+      "relationship": "related",
+      "description": "Parent family entry (the analytic Euler identity e^(iπ)+1=0). This OQ-05 concerns a different theorem also due to Euler — the four-square identity — and develops its algebraic payload: the sums of four squares form a multiplicative submonoid, the closure step behind Lagrange's four-square theorem."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `euler-identity-oq-05` (quality 94, passes 0). This entry had **real structural gaps** (not just shallow prose), all fixed here:

- **`mainTheorems` was absent** — added an array of 7 theorems (core: `IsSumFourSq.mul`, `not_isSumThreeSq_mul_closed`; key: `four_square_identity`; supporting: `isSumFourSq_prod`, `IsSumFourSq.pow`, `isSumFourSq_of_isSumTwoSq`, `fifteen_not_isSumThreeSq`) with Lean types and accurate line anchors.
- **`sections` stopped at line 143 but the file is 200 lines** — added a 4th section covering the sharpness proof (lines 146–200): the mod-8 obstruction showing sums of three squares are not multiplicatively closed. This whole block (7 declarations) was previously undocumented.
- **5th keyInsight — 'four is minimal'**: 3 and 5 are sums of three squares but 15 = 3·5 ≡ 7 (mod 8) is not, matching Hurwitz's dimensions 1,2,4,8. Notes the proof uses kernel `decide` (not `native_decide`), so no `ofReduceBool` — consistent with the entry's axiom-free claim.
- **`crossReferences` was a bare string** `["euler-identity"]` — normalized to the `{targetId, relationship, description}` object schema used everywhere else in the gallery (fixes a likely rendering gap).

All theorem names, types, and line numbers verified against `Proofs/EulerIdentityOQ05.lean`. meta.json well under the 60 KB cap; 5 keyInsights, 4 sections. JSON validated.