### PR TITLE
Research: roth-theorem-k3-oq-03-oq-01 - generalized von Neumann telescoping

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -20,7 +20,10 @@
     * `gowersNorm_zero`            — ‖0‖_{U^s} = 0;
     * `kAPCount_const`             — Λ_k(c,…,c) = cᵏ;
     * `kAPCount_const_one`         — Λ_k(1,…,1) = 1 (total normalized mass);
-    * `kAPCount_eq_zero_of_zero`   — a single zero slot annihilates Λ_k.
+    * `kAPCount_eq_zero_of_zero`   — a single zero slot annihilates Λ_k;
+    * `kAPCount_diag_eq_sum_subsets` — the **generalized von Neumann telescoping**:
+      `Λ_k(g,…,g) = ∑_{S⊆[k]} δ^{k−|S|}·Λ_k(i↦ if i∈S then g−δ·1 else 1)`, the full
+      `2^k`-term multilinear expansion with the `δ^k` major term isolated at `S=∅`.
 
   These are precisely the checks that pin the operators down as genuine
   averages `E_{x,d} ∏ᵢ fᵢ(x+i·d)` (the `(N⁻¹)²·N² = 1` normalization),
@@ -251,5 +254,101 @@ theorem kAPCount_update_split {N : ℕ} [NeZero N] (k : ℕ)
     rw [add_sub_cancel]
   rw [hg] at hadd
   rw [hadd, kAPCount_update_smul]
+
+-- ============================================================
+-- The generalized von Neumann telescoping
+--
+-- Iterating the one-slot split `kAPCount_update_split` across all `k` slots
+-- expands the *diagonal* count `Λ_k(g,…,g)` into `2^k` subset-indexed terms.
+-- Writing `g = δ·1 + b` with `b = g − δ·1`, the standard "product of sums"
+-- identity `Finset.prod_add` at the level of the inner product `∏ᵢ g(x+i·d)`
+-- expands it into a sum over subsets `S ⊆ {0,…,k−1}`, where `S` marks the
+-- slots carrying the balanced part `b` and the complement carries `δ`.
+-- ============================================================
+
+/-- **Generalized von Neumann expansion (diagonal).**  Writing each slot of the
+    diagonal count `Λ_k(g,…,g)` as `g = δ·1 + (g − δ·1)` and expanding
+    multilinearly telescopes the count into `2^k` terms indexed by subsets
+    `S ⊆ {0,…,k−1}` — `S` marks the slots carrying the *balanced* part
+    `b = g − δ·1`, the complement carries the scalar `δ`:
+
+        Λ_k(g,…,g) = ∑_{S ⊆ [k]} δ^{k−|S|} · Λ_k(i ↦ if i ∈ S then b else 1).
+
+    The `S = ∅` term is the *major term* `δ^k · Λ_k(1,…,1) = δ^k`
+    (`kAPCount_const_one`); every other term has at least one balanced slot `b`
+    (mean-zero when `δ = |A|/N` and `g = 1_A`), which is exactly what the
+    Gowers-uniformity control step then bounds.  This is the full slot
+    telescoping that iterating `kAPCount_update_split` produces, obtained here in
+    one shot from `Finset.prod_add` on the inner AP product. -/
+theorem kAPCount_diag_eq_sum_subsets {N : ℕ} [NeZero N] (k : ℕ)
+    (g : ZMod N → ℂ) (δ : ℂ) :
+    kAPCount k (fun _ : Fin k => g)
+      = ∑ S : Finset (Fin k),
+          δ ^ (k - S.card) *
+            kAPCount k (fun i => if i ∈ S then (g - δ • (1 : ZMod N → ℂ)) else 1) := by
+  classical
+  set b : ZMod N → ℂ := g - δ • (1 : ZMod N → ℂ) with hb
+  -- Pointwise decomposition `g y = b y + δ`.
+  have hg : ∀ y : ZMod N, g y = b y + δ := by
+    intro y
+    simp only [hb, Pi.sub_apply, Pi.smul_apply, Pi.one_apply, smul_eq_mul, mul_one]
+    ring
+  -- In each RHS term only the balanced slots `i ∈ S` survive the inner product.
+  have hRinner : ∀ (S : Finset (Fin k)) (x d : ZMod N),
+      (∏ i : Fin k, (if i ∈ S then b else (1 : ZMod N → ℂ)) (x + i.val • d))
+        = ∏ i ∈ S, b (x + i.val • d) := by
+    intro S x d
+    have happ : ∀ i : Fin k,
+        (if i ∈ S then b else (1 : ZMod N → ℂ)) (x + i.val • d)
+          = if i ∈ S then b (x + i.val • d) else 1 := by
+      intro i; split <;> simp
+    rw [Finset.prod_congr rfl (fun i _ => happ i), Finset.prod_ite_mem, Finset.univ_inter]
+  -- `Finset.prod_add` expands the diagonal inner product into the subset sum.
+  have hLinner : ∀ (x d : ZMod N),
+      (∏ i : Fin k, g (x + i.val • d))
+        = ∑ S : Finset (Fin k), δ ^ (k - S.card) * ∏ i ∈ S, b (x + i.val • d) := by
+    intro x d
+    rw [Finset.prod_congr rfl (fun i _ => hg (x + i.val • d)), Finset.prod_add,
+        Finset.powerset_univ]
+    apply Finset.sum_congr rfl
+    intro S _
+    rw [Finset.prod_const, Finset.card_sdiff_of_subset (Finset.subset_univ S),
+        Finset.card_univ, Fintype.card_fin]
+    ring
+  -- Both sides equal the canonical triple sum.
+  have hL : kAPCount k (fun _ : Fin k => g)
+      = ((N : ℂ)⁻¹) ^ 2 * ∑ x : ZMod N, ∑ d : ZMod N,
+          ∑ S : Finset (Fin k), δ ^ (k - S.card) * ∏ i ∈ S, b (x + i.val • d) := by
+    unfold kAPCount
+    congr 1
+    apply Finset.sum_congr rfl; intro x _
+    apply Finset.sum_congr rfl; intro d _
+    exact hLinner x d
+  have hR : (∑ S : Finset (Fin k), δ ^ (k - S.card) *
+        kAPCount k (fun i => if i ∈ S then b else (1 : ZMod N → ℂ)))
+      = ((N : ℂ)⁻¹) ^ 2 * ∑ x : ZMod N, ∑ d : ZMod N,
+          ∑ S : Finset (Fin k), δ ^ (k - S.card) * ∏ i ∈ S, b (x + i.val • d) := by
+    unfold kAPCount
+    -- Simplify each summand: rewrite its inner product and hoist the scalars.
+    have step : ∀ S : Finset (Fin k),
+        δ ^ (k - S.card) * (((N : ℂ)⁻¹) ^ 2 * ∑ x : ZMod N, ∑ d : ZMod N,
+            ∏ i : Fin k, (if i ∈ S then b else (1 : ZMod N → ℂ)) (x + i.val • d))
+          = ((N : ℂ)⁻¹) ^ 2 * ∑ x : ZMod N, ∑ d : ZMod N,
+              δ ^ (k - S.card) * ∏ i ∈ S, b (x + i.val • d) := by
+      intro S
+      rw [Finset.sum_congr rfl (fun x _ =>
+            Finset.sum_congr rfl (fun d _ => hRinner S x d))]
+      rw [mul_left_comm]
+      congr 1
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl; intro x _
+      rw [Finset.mul_sum]
+    rw [Finset.sum_congr rfl (fun S _ => step S), ← Finset.mul_sum]
+    congr 1
+    -- Reorder `∑ S ∑ x ∑ d` into `∑ x ∑ d ∑ S`.
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl; intro x _
+    rw [Finset.sum_comm]
+  rw [hL, hR]
 
 end RothTheoremOQ03OQ01

--- a/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
@@ -18,7 +18,9 @@
       "kAPCount_update_split (von Neumann slot-split): for any scalar δ, Λ_k(update f j g) = δ·Λ_k(update f j 1) + Λ_k(update f j (g − δ·1)). Proof = kAPCount_update_add on g = δ·1 + (g−δ·1) followed by kAPCount_update_smul; the δ·1 + (g−δ·1) = g step closes by add_sub_cancel. This is literally the first density-decomposition step of the generalized von Neumann argument (take g=1_A, δ=|A|/N).",
       "kAPCount_update_sub: subtractivity in a slot, derived from update_add + update_smul via g₁−g₂ = g₁ + (−1)•g₂ (neg_one_smul, sub_eq_add_neg, neg_one_mul). Completes the slotwise linear structure (add/sub/smul/zero).",
       "kAPCount_update_zero (@[simp]): overwriting slot j with 0 gives Λ_k = 0 — one-liner off kAPCount_eq_zero_of_zero + Function.update_self; the additive unit of the slot module.",
-      "Toolchain: Function.update_self (NOT update_same) is the v4.26 name for update f j v j = v; add_sub_cancel proves a + (b − a) = b here (works for the module ZMod N → ℂ)."
+      "Toolchain: Function.update_self (NOT update_same) is the v4.26 name for update f j v j = v; add_sub_cancel proves a + (b − a) = b here (works for the module ZMod N → ℂ).",
+      "The full slot-telescoping Λ_k(g,…,g)=∑_{S⊆[k]}δ^{k−|S|}Λ_k(i↦if i∈S then b else 1) (b=g−δ·1) is obtained in ONE shot from Finset.prod_add on the inner product ∏ᵢ g(x+i·d)=∏ᵢ(b(x+i·d)+δ), rather than iterating kAPCount_update_split k times. S=∅ gives the δ^k major term (kAPCount_const_one).",
+      "Assembly: expand inner product on both sides to a canonical triple sum (N⁻¹)²∑ₓ∑_d∑_S, then reconcile via two Finset.sum_comm reorderings (∑_S∑ₓ∑_d → ∑ₓ∑_d∑_S). RHS if-slots collapse via Finset.prod_ite_mem + univ_inter; δ-power exponent k−|S| via Finset.card_sdiff_of_subset."
     ],
     "builtItems": [
       "RothTheoremOQ03OQ01.lean: self-contained, 4 noncomputable defs (hypercubeShift, conjugateByWeight, gowersNorm, kAPCount) + 5 proved theorems, 0 axioms, 0 sorries.",
@@ -32,14 +34,14 @@
       "kAPCount_update_smul: scalar homogeneity in slot j — Λ_k(update f j (c•g)) = c·Λ_k(update f j g).",
       "kAPCount_update_split: von Neumann slot-split identity Λ_k(update f j g) = δ·Λ_k(update f j 1) + Λ_k(update f j (g−δ·1)). 0 axioms (propext/Choice/Quot only), host lake env lean EXIT 0.",
       "kAPCount_update_sub: slotwise subtractivity.",
-      "kAPCount_update_zero (@[simp]): zero slot annihilates the count (update form)."
+      "kAPCount_update_zero (@[simp]): zero slot annihilates the count (update form).",
+      "kAPCount_diag_eq_sum_subsets (generalized von Neumann telescoping, 2^k subset expansion)"
     ],
-    "progressSummary": "PROGRESS (S+1, researcher-5): added the generalized von Neumann slot-split kAPCount_update_split (Λ_k(update f j g) = δ·Λ_k(update f j 1) + Λ_k(update f j (g−δ·1))) — the first density-decomposition step the prior nextSteps called for — plus its supporting slotwise linearity (kAPCount_update_sub, kAPCount_update_zero). All host-verified (lake env lean EXIT 0), 0 axioms/0 sorries (foundational trio only). score 13→16.",
+    "progressSummary": "PROGRESS (S+1, researcher-5): added the generalized von Neumann slot-split kAPCount_update_split (Λ_k(update f j g) = δ·Λ_k(update f j 1) + Λ_k(update f j (g−δ·1))) — the first density-decomposition step the prior nextSteps called for — plus its supporting slotwise linearity (kAPCount_update_sub, kAPCount_update_zero). All host-verified (lake env lean EXIT 0), 0 axioms/0 sorries (foundational trio only). score 13→16. [2026-07-08 researcher-10] Proved the full slot-telescoping kAPCount_diag_eq_sum_subsets (the density-decomposition step the prior nextSteps called for, completed): Λ_k(g,…,g)=∑_{S⊆[k]}δ^{k−|S|}Λ_k(i↦if i∈S then g−δ·1 else 1), all 2^k terms with δ^k major term at S=∅, via Finset.prod_add. VERIFIED 0/0 (docker-build green). File 354L/12 theorems.",
     "nextSteps": [
-      "Iterate the split across all k slots to telescope Λ_k(1_A,…,1_A) into the major term δ^k·Λ_k(1,…,1)=δ^k plus 2^k−1 balanced remainders (each with ≥1 mean-zero slot g−δ·1).",
-      "Prove the generalized von Neumann INEQUALITY: bound each balanced remainder |Λ_k(…, g−δ·1, …)| by the Gowers U^{k−1} norm of the balanced slot (needs a Cauchy–Schwarz / box-norm control lemma; the gowersNorm def is already in this file).",
-      "Connect kAPCount of an indicator 1_A to the actual count of 3-APs in a finset A ⊆ ZMod N.",
-      "Repair toolchain drift in parent RothTheoremOQ03.lean (Complex.abs → ‖·‖) so the two files can merge."
+      "Prove the generalized von Neumann INEQUALITY: bound each balanced-remainder term |Λ_k(…,b,…)| (b mean-zero) by the Gowers U^{k−1} norm of the balanced slot (Cauchy–Schwarz/box-norm control; gowersNorm def already in file)",
+      "Connect kAPCount of an indicator 1_A to the actual count of 3-APs in a finset A ⊆ ZMod N",
+      "Repair parent RothTheoremOQ03.lean toolchain drift (Complex.abs → ‖·‖) so the files can merge"
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary
Research session on **roth-theorem-k3-oq-03-oq-01** (foundational identities for the Gowers norm and k-AP counting operator, on the generalized-von-Neumann path to Roth/Szemerédi). Resolves the first documented next step: the full multilinear **slot telescoping** of the diagonal AP count.

## Progress
- **`kAPCount_diag_eq_sum_subsets`** (verified): expanding each slot of the diagonal count as `g = δ·1 + (g − δ·1)` telescopes it into `2^k` subset-indexed terms,

      Λ_k(g,…,g) = ∑_{S ⊆ [k]} δ^{k−|S|} · Λ_k(i ↦ if i ∈ S then g−δ·1 else 1),

  with the **major term** `δ^k · Λ_k(1,…,1) = δ^k` isolated at `S = ∅`, and every other term carrying at least one *balanced* slot `b = g − δ·1` (mean-zero when `δ = |A|/N`, `g = 1_A`). This is exactly the density-decomposition step that opens the generalized von Neumann argument.

## Findings
- The whole `2^k`-term expansion falls out **in one shot** from `Finset.prod_add` applied to the inner AP product `∏ᵢ g(x+i·d) = ∏ᵢ (b(x+i·d) + δ)`, rather than iterating the one-slot split `kAPCount_update_split` k times.
- Assembly reduces both sides to a canonical triple sum `(N⁻¹)²·∑ₓ∑_d∑_S …` and reconciles the summation order with two `Finset.sum_comm` swaps; the `if`-indicator slots collapse via `Finset.prod_ite_mem`/`univ_inter`, and the exponent `k−|S|` via `Finset.card_sdiff_of_subset`.

## Files modified
- `proofs/Proofs/RothTheoremOQ03OQ01.lean` (+1 verified theorem, docstring)
- `src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json` (theoremCount 11→12, lineCount 255→354, +originalContribution)
- `src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json` (insights, next steps)

## Build
Docker build green: `Built Proofs.RothTheoremOQ03OQ01 (7743 jobs)`. File 354L / 12 theorems, **0 sorries, 0 axioms**, no `native_decide`.

## Status
**Outcome**: progress (1 new verified theorem — the density-decomposition milestone)
**Next Steps**: the generalized von Neumann **inequality** (bound each balanced remainder by a Gowers `U^{k−1}` norm — needs Cauchy–Schwarz/box-norm control); connect `kAPCount` of an indicator to the actual 3-AP count in a finset.

🤖 Generated by researcher-10