### PR TITLE
Fix: honest-frame ErdosSzekeres docstring (axiomatized, not proved)

### DIFF
--- a/proofs/Proofs/ErdosSzekeres.lean
+++ b/proofs/Proofs/ErdosSzekeres.lean
@@ -8,9 +8,12 @@ import Mathlib.Tactic
 # Erdős–Szekeres Theorem
 
 ## What This Proves
-We prove the Erdős–Szekeres Theorem: any sequence of at least (r-1)(s-1) + 1 distinct
-real numbers contains either an increasing subsequence of length r, or a decreasing
-subsequence of length s. This is Wiedijk's 100 Theorems #73.
+We formalize and axiomatize the Erdős–Szekeres Theorem: any sequence of at least
+(r-1)(s-1) + 1 distinct real numbers contains either an increasing subsequence of
+length r, or a decreasing subsequence of length s. This is Wiedijk's 100 Theorems #73.
+The core existence and tightness results are stated as axioms (see
+`erdos_szekeres_existence_axiom` and `erdos_szekeres_tight_axiom`); the pigeonhole
+proof described below is the intended approach but is not yet carried out in Lean.
 
 ## Historical Context
 Paul Erdős and George Szekeres proved this theorem in 1935 in their paper "A combinatorial
@@ -33,15 +36,15 @@ The proof uses an elegant pigeonhole argument:
 
 ## Approach
 - **Foundation:** We formalize increasing/decreasing subsequences using StrictMono/StrictAnti
-- **Original Contributions:** Direct proof of the pigeonhole argument using Finset cardinality
-- **Proof Techniques:** Pigeonhole principle, subsequence enumeration, order theory
+- **Original Contributions:** Type-safe subsequence definitions and the proved 2-element base case
+- **Proof Techniques:** Pigeonhole principle (axiomatized), subsequence enumeration, order theory
 
 ## Status
 - [ ] Complete proof
 - [x] Uses Mathlib for foundations
 - [x] Proves extensions/corollaries
 - [x] Pedagogical example
-- [x] Incomplete (has sorries)
+- [x] Incomplete (core theorem axiomatized; 0 sorries)
 
 ## Mathlib Dependencies
 - `Finset.card_le_card` : Cardinality is monotone


### PR DESCRIPTION
## Fix

Correct three false statements in the `ErdosSzekeres.lean` header docstring: the core theorem is **axiomatized**, not proved.

## Evidence

The file's core results are `axiom` declarations:
- `erdos_szekeres_existence_axiom` (line 200)
- `erdos_szekeres_tight_axiom` (line 235)

**Before** (docstring claimed a proof the file does not carry out):
- "We prove the Erdős–Szekeres Theorem…"
- Original Contributions: "Direct proof of the pigeonhole argument using Finset cardinality"
- Status: "[x] Incomplete (has sorries)" — but the file has **0 sorries** (it uses axioms)

**After**:
- "We formalize and axiomatize the Erdős–Szekeres Theorem…" with an explicit note that the pigeonhole proof is the intended-but-unimplemented approach
- Original Contributions: "Type-safe subsequence definitions and the proved 2-element base case"
- Status: "[x] Incomplete (core theorem axiomatized; 0 sorries)"

Comment-only change (all edits are inside the file's `/- … -/` header block, lines 7–55), so it is compilation-inert — no Lean rebuild required.

Addresses peer-review findings deferred out of enricher scope (`src/data/proofs/erdos-szekeres/review.json`, action items ai-3/ai-6, Lean-docstring portion).

---
Automated fix by lean-mechanic agent.