### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-02-oq-02): Hurwitz isoperimetric area bound from Wirtinger [VERIFIED]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02OQ02.lean
@@ -1,0 +1,110 @@
+/-
+  Isoperimetric Inequality: the Hurwitz area bound from Wirtinger
+  Open Question: area-of-circle-oq-01-oq-02-oq-02-oq-02-oq-02
+
+  The sibling file `AreaOfCircleOQ01OQ02OQ02OQ02` proves the analytic
+  Wirtinger inequality for a `C¹` periodic mean-zero function `f`,
+
+      ∫₀^{2π} f²  ≤  ∫₀^{2π} (f')².
+
+  This file assembles it into the analytic heart of Hurwitz's Fourier proof of
+  the isoperimetric inequality.  Parametrise a closed curve `γ(t) = (x(t), y(t))`
+  by (constant-speed / arc-length) with period `2π`, so that its length is
+  `L = ∫₀^{2π} √(x'² + y'²) = 2π`, equivalently — in the arc-length
+  normalisation — `∫₀^{2π} (x'² + y'²) = 2π`.  Center the curve so that the
+  first coordinate has zero mean, `∫₀^{2π} x = 0`.  By Green's theorem the
+  enclosed (signed) area is
+
+      A = ∮ x dy = ∫₀^{2π} x · y'.
+
+  The theorem below shows `A ≤ π`, i.e. `A ≤ L² / (4π)` in this normalisation —
+  the isoperimetric inequality, with the circle the unique extremiser.
+
+  Hurwitz's one-line computation: expanding the nonnegative integral of the
+  square `(y' − x)² ≥ 0` gives
+
+      0 ≤ ∫ (y' − x)²  =  ∫ y'²  − 2 ∫ x y'  + ∫ x²,
+
+  hence `2A = 2∫ x y' ≤ ∫ y'² + ∫ x²`.  Wirtinger replaces `∫ x²` by the larger
+  `∫ x'²`, and the arc-length normalisation collapses `∫ x'² + ∫ y'² = 2π`, so
+  `2A ≤ 2π`.  Equality forces `y' = x` and (Wirtinger's equality case) only the
+  first harmonic to survive — the circle.
+
+  References:
+  - Hurwitz (1901): Fourier proof of the isoperimetric inequality
+  - AreaOfCircleOQ01OQ02OQ02OQ02.lean (the Wirtinger inequality, reused here)
+-/
+
+import Mathlib
+import Proofs.AreaOfCircleOQ01OQ02OQ02OQ02
+
+open Real Filter Topology Complex MeasureTheory IsoperimetricFourier
+
+noncomputable section
+
+namespace IsoperimetricFourier
+
+-- ============================================================
+-- SECTION IV: Hurwitz's isoperimetric area bound
+-- ============================================================
+
+/-- **Hurwitz's isoperimetric bound** (arc-length normalised form).  Let a closed
+    curve `γ(t) = (x(t), y(t))` be `C¹` and `2π`-periodic in its first coordinate,
+    centered so that `∫₀^{2π} x = 0`, and normalised to length `2π` in the sense
+    that `∫₀^{2π} (x'² + y'²) = 2π` (which holds for any arc-length / constant-speed
+    parametrisation of a curve of length `2π`).  Then the enclosed signed area
+    `A = ∫₀^{2π} x · y'` satisfies
+
+        A ≤ π   ( = L² / (4π) with L = 2π).
+
+    This is the isoperimetric inequality in normalised coordinates; the general
+    scale-invariant form `L² ≥ 4πA` follows by rescaling.  The proof is Hurwitz's:
+    `∫ (y' − x)² ≥ 0` bounds `2A` by `∫ y'² + ∫ x²`, Wirtinger
+    (`wirtinger_inequality`) upgrades `∫ x²` to `∫ x'²`, and the length
+    normalisation turns `∫ x'² + ∫ y'²` into `2π`. -/
+theorem hurwitz_area_bound (x y : ℝ → ℝ)
+    (hx : ContDiff ℝ 1 x) (hy : ContDiff ℝ 1 y)
+    (hxper : ∀ t, x (t + 2 * π) = x t)
+    (hmean : ∫ t in (0 : ℝ)..(2 * π), x t = 0)
+    (harc : ∫ t in (0 : ℝ)..(2 * π), ((deriv x t) ^ 2 + (deriv y t) ^ 2) = 2 * π) :
+    ∫ t in (0 : ℝ)..(2 * π), x t * deriv y t ≤ π := by
+  -- Continuity of the three building blocks.
+  have hxc : Continuous x := hx.continuous
+  have hdxc : Continuous (deriv x) := hx.continuous_deriv le_rfl
+  have hdyc : Continuous (deriv y) := hy.continuous_deriv le_rfl
+  -- Interval-integrability of every integrand that appears.
+  have iX2 : IntervalIntegrable (fun t => (x t) ^ 2) volume 0 (2 * π) :=
+    (hxc.pow 2).intervalIntegrable 0 (2 * π)
+  have iDX2 : IntervalIntegrable (fun t => (deriv x t) ^ 2) volume 0 (2 * π) :=
+    (hdxc.pow 2).intervalIntegrable 0 (2 * π)
+  have iDY2 : IntervalIntegrable (fun t => (deriv y t) ^ 2) volume 0 (2 * π) :=
+    (hdyc.pow 2).intervalIntegrable 0 (2 * π)
+  have iXY2 : IntervalIntegrable (fun t => 2 * (x t * deriv y t)) volume 0 (2 * π) :=
+    ((continuous_const.mul (hxc.mul hdyc))).intervalIntegrable 0 (2 * π)
+  -- Split the length normalisation into the two squared-derivative integrals.
+  have harc' : (∫ t in (0 : ℝ)..(2 * π), (deriv x t) ^ 2)
+      + (∫ t in (0 : ℝ)..(2 * π), (deriv y t) ^ 2) = 2 * π := by
+    rw [← intervalIntegral.integral_add iDX2 iDY2]; exact harc
+  -- The nonnegative square `(y' − x)²` expands by linearity of the integral.
+  have hexp : (fun t => (deriv y t - x t) ^ 2)
+      = (fun t => (deriv y t) ^ 2 - 2 * (x t * deriv y t) + (x t) ^ 2) := by
+    funext t; ring
+  have hval : (∫ t in (0 : ℝ)..(2 * π), (deriv y t - x t) ^ 2)
+      = (∫ t in (0 : ℝ)..(2 * π), (deriv y t) ^ 2)
+        - 2 * (∫ t in (0 : ℝ)..(2 * π), x t * deriv y t)
+        + (∫ t in (0 : ℝ)..(2 * π), (x t) ^ 2) := by
+    rw [hexp,
+        intervalIntegral.integral_add (iDY2.sub iXY2) iX2,
+        intervalIntegral.integral_sub iDY2 iXY2,
+        intervalIntegral.integral_const_mul]
+  -- The integral of a square is nonnegative.
+  have hnn : 0 ≤ ∫ t in (0 : ℝ)..(2 * π), (deriv y t - x t) ^ 2 := by
+    apply intervalIntegral.integral_nonneg (by positivity)
+    intro t _; positivity
+  rw [hval] at hnn
+  -- Wirtinger: `∫ x² ≤ ∫ x'²`.
+  have hw := wirtinger_inequality x hx hxper hmean
+  -- Assemble: `2A ≤ ∫ y'² + ∫ x² ≤ ∫ y'² + ∫ x'² = 2π`, so `A ≤ π`.
+  linarith [hnn, hw, harc']
+
+end IsoperimetricFourier

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
@@ -10,18 +10,29 @@
       "The −n² eigenvalue is exactly what drives Wirtinger's inequality: every Fourier mode of f'' contributes a factor n² ≥ 1, with equality only on the first harmonic — the circle, the equality case of C² ≥ 4πA.",
       "Mathlib does NOT package 'derivative of a periodic function is periodic' (no Function.Periodic.deriv on this toolchain). Proved here from deriv_comp_add_const: since (fun x ↦ f (x+T)) = f, their derivatives agree, giving f'(t+T) = f'(t).",
       "ContDiff ℝ 1 (deriv f) is extracted from ContDiff ℝ 2 f via contDiff_succ_iff_deriv (n := 1) |>.2.2 — note the current 3-way conjunction (Differentiable ∧ (n=ω→AnalyticOn) ∧ ContDiff n (deriv f)).",
-      "(i·n)·(i·n) collapses to −n² via Complex.I_mul_I (I*I = -1) after a ring normalization that pulls out (I*I)·n²."
+      "(i·n)·(i·n) collapses to −n² via Complex.I_mul_I (I*I = -1) after a ring normalization that pulls out (I*I)·n².",
+      "The n=0 companion is governed by FTC, not the i·n divide-by-n identity: fourier 0 = 1 so c₀(f') is the period-average of f', and intervalIntegral.integral_deriv_eq_sub + periodicity forces it to 0. Together with the -n² eigenvalue (n≠0) this pins the full differentiation spectrum: 0 on constants, i·n on the n-th harmonic.",
+      "Wirtinger inequality ∫f²≤∫(f')² (mean-zero, period 2π) is a clean termwise hasSum_le on the two Parseval sums: |ĉₙ(f')|²=n²|ĉₙ(f)|² and n²≥1 for n≠0, with the n=0 mode killed on both sides (ĉ₀(f')=0 companion, ĉ₀(f)=0 zero-mean).",
+      "Hurwitz assembly: the analytic Wirtinger inequality (∫f² ≤ ∫(f′)²) yields the isoperimetric area bound A ≤ π in one line via 0 ≤ ∫(y′−x)², which expands to 2A ≤ ∫(y′)²+∫x²; Wirtinger upgrades ∫x² to ∫(x′)² and the arc-length normalisation ∫((x′)²+(y′)²)=2π collapses the RHS to 2π."
     ],
     "builtItems": [
       "AreaOfCircleOQ01OQ02OQ02OQ02.lean: 2 theorems, 0 axioms, 0 sorries, imports and reuses the parent IBP identity.",
       "deriv_periodic_of_periodic: the derivative of a T-periodic function is T-periodic.",
-      "fourierCoeffOn_deriv2_periodic: ĉₙ(f'') = −n²·ĉₙ(f) for C² periodic f, n ≠ 0."
+      "fourierCoeffOn_deriv2_periodic: cₙ(f'') = -n²·cₙ(f) for C² periodic f, n ≠ 0.",
+      "fourierCoeffOn_deriv_zero_periodic: c₀(f') = 0 for C¹ periodic f (zero mode), via FTC ∫ f' = f(2π)-f(0) = 0.",
+      "wirtinger_inequality in AreaOfCircleOQ01OQ02OQ02OQ02.lean (VERIFIED 0/0): ∫₀^2π f² ≤ ∫₀^2π (f')² for C¹ period-2π mean-zero f",
+      "memLp_two_of_continuous helper: continuous ℝ→ℂ is L² on Ioc(0,2π) via MemLp.of_bound + IsCompact.exists_bound_of_continuousOn",
+      "hurwitz_area_bound in AreaOfCircleOQ01OQ02OQ02OQ02OQ02.lean: for C¹ (x,y) with period-2π mean-zero x and ∫((x′)²+(y′)²)=2π, ∫ x·y′ ≤ π (VERIFIED 0/0, Docker-built)"
     ],
-    "progressSummary": "Child of area-of-circle-oq-01-oq-02-oq-02 (Isoperimetric Inequality via Fourier analysis). The parent gives the first-order IBP identity ĉₙ(f')=i·n·ĉₙ(f); this entry iterates it to the second-order identity ĉₙ(f'')=−n²·ĉₙ(f), the −n² eigenvalue underlying Wirtinger's inequality and the equality case (the circle). Also supplies the missing lemma that the derivative of a periodic function is periodic. Both 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide.",
+    "progressSummary": "PROGRESS: analytic Wirtinger inequality assembled into Hurwitz isoperimetric area bound A ≤ π (arc-length normalised). Follow-ups: equality→circle, general L²≥4πA by Cauchy–Schwarz.",
     "nextSteps": [
-      "Assemble Wirtinger's inequality ∫|f'|² ≥ ∫|f|² (mean-zero f, period 2π) from the n²≥1 Fourier-mode bound and Parseval.",
-      "Prove the n=0 companion ĉ₀(f') = 0 (derivative of a periodic function has zero mean) to complete the spectral picture.",
-      "Combine with the area/perimeter Fourier expansions to close the isoperimetric inequality C² ≥ 4πA with the circle as the equality case."
+      "Assemble the full isoperimetric inequality C²≥4πA: express area A and perimeter C via Fourier coefficients of the (mean-adjusted) boundary parametrisation and apply wirtinger_inequality mode-by-mode; equality iff only n=±1 harmonics survive (circle). Requires Greens-theorem area formula A=½∮(x dy − y dx) in Fourier form.",
+      "Characterise the equality case of wirtinger_inequality: ∫f²=∫(f')² iff ĉₙ(f)=0 for all |n|≥2 (only the first harmonic), i.e. f(t)=a cos t + b sin t.",
+      "Equality/circle characterisation: A = π forces y′ = x pointwise (from ∫(y′−x)²=0) and Wirtinger equality (only the first harmonic survives) → the curve is a circle.",
+      "General scale-invariant form L² ≥ 4πA: drop the arc-length normalisation and relate L² to 2π·∫((x′)²+(y′)²) via Cauchy–Schwarz."
+    ],
+    "mathlibGaps": [
+      "Mathlib has Parseval on an interval (hasSum_sq_fourierCoeffOn / tsum_sq_fourierCoeffOn, AddCircle.lean) — no gap; the L² isometry is available directly, so Wirtinger did NOT need custom infrastructure."
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Assembles the analytic **Wirtinger inequality** (merged in #35632) into **Hurwitz's Fourier proof of the isoperimetric inequality**.

For a `C¹` closed curve `γ(t) = (x(t), y(t))` with period-`2π` mean-zero first coordinate (`∫₀^{2π} x = 0`), arc-length normalised so `∫₀^{2π} (x'² + y'²) = 2π` (length `L = 2π`), the enclosed signed area

    A = ∮ x dy = ∫₀^{2π} x · y'

satisfies

    A ≤ π   ( = L² / (4π) ).

This is the isoperimetric inequality in normalised coordinates; the scale-invariant `L² ≥ 4πA` follows by rescaling. The circle is the unique extremiser.

## Proof (Hurwitz's one line)

- `0 ≤ ∫ (y' − x)²` expands by linearity to `2A ≤ ∫ y'² + ∫ x²`.
- Wirtinger (`wirtinger_inequality`) upgrades `∫ x²` to the larger `∫ x'²`.
- The length normalisation collapses `∫ x'² + ∫ y'² = 2π`.
- Hence `2A ≤ 2π`, i.e. `A ≤ π`.

## Verification

- `theorem hurwitz_area_bound` — **0 sorry, 0 axiom**.
- Docker-verified: `Built Proofs.AreaOfCircleOQ01OQ02OQ02OQ02OQ02 (3.0s)`.
- Reuses only the merged Wirtinger inequality plus standard Mathlib (`intervalIntegral` linearity, `integral_nonneg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)