### PR TITLE
Enrich Erdős #100 integer-distance bridge: cross-reference erdos-89

### DIFF
--- a/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
@@ -120,6 +120,11 @@
       "targetId": "erdos-100",
       "relationship": "foundational",
       "description": "The base Erdős #100 framework (integer-distance planar point sets and their diameter). This entry supplies the combinatorial inequality behind the current best diameter lower bound."
+    },
+    {
+      "targetId": "erdos-89",
+      "relationship": "related",
+      "description": "Erdős #89, the distinct-distances problem (an n-point planar set determines ≫ n/√(log n) distinct distances, resolved up to log by Guth–Katz). It is the companion this bridge feeds: distinct_distances_le_diam (#distinct ≤ diam) converts #89's distinct-distances lower bound into the current best diameter lower bound for #100. The link #100 ↔ #89 documented throughout this entry is exactly the erdos-89 result."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for erdos-100-oq-01-incomplete-01.

The entry's central narrative is the **#100 ↔ #89 bridge** — integer distances confine distinct distances to {1,…,⌊diam⌋}, converting the Guth–Katz distinct-distances lower bound (Erdős #89) into the current best diameter bound for #100. Erdős #89 was referenced throughout prose and `references`, but `crossReferences` linked only to erdos-100 kin. Added a `related` cross-reference to the **erdos-89** gallery entry (Distinct Distances in the Plane), the companion result this bridge feeds.

- meta.json: 11.7 KB → 12.3 KB (well under caps)
- JSON validated; no other fields touched.