### PR TITLE
Enrich Cramer's Rule 2×2/3×3 closed forms: add Maclaurin (1748) reference

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -243,6 +243,11 @@
       "type": "book"
     },
     {
+      "key": "Maclaurin1748",
+      "citation": "Maclaurin, C., A Treatise of Algebra, in Three Parts, London (1748, posthumous). Gives the determinant-quotient solution of 2×2 and 3×3 linear systems two years before Cramer — the small-case closed forms this entry formalizes (an instance of Stigler's law of eponymy).",
+      "type": "book"
+    },
+    {
       "key": "Strang2016",
       "citation": "Strang, G., Introduction to Linear Algebra, 5th ed., Wellesley-Cambridge Press (2016), §5.3 (Cramer's Rule, Inverses, and Volumes).",
       "type": "book"


### PR DESCRIPTION
Enrichment pass for cramers-rule-oq-04-oq-01-oq-01-oq-01.

The entry is otherwise saturated (10 mainTheorems, sections cover the full 158-line file, object-form crossReferences). The one genuine gap: `historicalContext` explicitly credits *"Cramer (1750) and Maclaurin (1748) worked with small systems before the determinant calculus was abstracted"*, yet `references` listed only Cramer and Strang. Added **Maclaurin, A Treatise of Algebra (1748)** — which gave the determinant-quotient solution of 2×2/3×3 systems two years before Cramer (an instance of Stigler's law), exactly the small-case closed forms this entry formalizes.

- Purely additive (+5 lines, one references entry); JSON validated.