### PR TITLE
research(e-transcendental-oq-02-oq-06): normal numbers are disjunctive + latent build repair [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -43,6 +43,8 @@ No specific constant has been proved normal, though almost all reals are (Borel,
 - [x] Normality defined rigorously (digit frequency version)
 - [x] Decimal digits 1–6 of e proved from exp_one bounds
 - [x] `normal_imp_irrational`: normality implies irrationality
+- [x] `normal_ktuple_infinitely_often` / `normal_imp_disjunctive`: normal ⇒ every
+      finite digit-string occurs (infinitely often)
 - [x] e is irrational (necessary condition for normality)
 - [ ] Whether e is normal in base 10, base 2, or any base (OPEN — axiomatized)
 -/
@@ -81,11 +83,11 @@ def IsAbsolutelyNormal (x : ℝ) : Prop :=
 
 /-- e is irrational (Euler, 1737 — proved via transcendence). -/
 theorem e_irrational : Irrational (Real.exp 1) :=
-  ETranscendental.e_irrational
+  _root_.e_irrational
 
 /-- e is transcendental over ℤ (Hermite, 1873). -/
 theorem e_transcendental : Transcendental ℤ (Real.exp 1) :=
-  ETranscendental.e_transcendental
+  _root_.e_transcendental
 
 /-- Tight bounds on e from Mathlib. -/
 theorem e_bounds : 2.718281828 < Real.exp 1 ∧ Real.exp 1 < 2.7182818286 :=
@@ -475,7 +477,9 @@ theorem periodic_has_missing_ktuple (b T k : ℕ) (hb : 2 ≤ b) (hT : 0 < T)
             hperiod _ (by omega), ih]
     -- f(n + i) = f(N₀ + (n-N₀)%T + i) for all i (by reducing mod T)
     have hfn_eq : ∀ i : Fin k, f (n + i.val) = f (N₀ + (n - N₀) % T + i.val) := fun i => by
-      rw [show n + i.val = N₀ + (n - N₀) % T + (n - N₀) / T * T + i.val from by omega]
+      have key : N₀ + (n - N₀) % T + (n - N₀) / T * T = n := by
+        rw [Nat.add_assoc, Nat.mod_add_div', Nat.add_sub_cancel' hn]
+      rw [show n + i.val = N₀ + (n - N₀) % T + (n - N₀) / T * T + i.val from by rw [key]]
       exact hperiod_rep ((n - N₀) / T) i.val
     -- So (fun i => f(N₀+(n-N₀)%T+i)) = s, meaning s ∈ orbit: contradiction
     exact hs (Finset.mem_image.mpr ⟨(n - N₀) % T, Finset.mem_range.mpr (Nat.mod_lt _ hT),
@@ -676,6 +680,51 @@ theorem normal_imp_irrational (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
   have hpos : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := zpow_pos hbR _
   linarith
 
+/-- **Normal numbers are disjunctive (this session).**
+    In a number normal in base `b`, every `k`-tuple of digits `s` occurs at
+    *infinitely many* starting positions. Proof (the positive companion to
+    `normal_imp_irrational`, which instead exhibits a *missing* tuple): if only
+    finitely many positions matched `s`, the matching count would be bounded, so
+    `tendsto_bounded_count_div_atTop_zero` would force its frequency to tend to
+    `0`; but normality forces that same frequency to tend to `b^(-k) > 0`, and
+    the uniqueness of limits yields the contradiction `b^(-k) = 0`. -/
+theorem normal_ktuple_infinitely_often (b k : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (hn : IsNormalInBase b x) (s : Fin k → Fin b) :
+    {n : ℕ | ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ)}.Infinite := by
+  by_contra hfin
+  rw [Set.not_infinite] at hfin
+  have h_count_le : ∀ N,
+      ((Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card
+        ≤ hfin.toFinset.card := by
+    intro N
+    refine Finset.card_le_card ?_
+    intro n hnmem
+    rw [Finset.mem_filter] at hnmem
+    exact hfin.mem_toFinset.mpr hnmem.2
+  have h_zero :
+      Tendsto
+        (fun N : ℕ =>
+          (((Finset.range N).filter
+            (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ)
+            / (N : ℝ))
+        atTop (nhds 0) :=
+    tendsto_bounded_count_div_atTop_zero hfin.toFinset.card _ h_count_le
+  have h_normal := hn k s
+  have heq : (0 : ℝ) = (b : ℝ) ^ (-(k : ℤ)) :=
+    tendsto_nhds_unique h_zero h_normal
+  have hbR : (0 : ℝ) < (b : ℝ) := by exact_mod_cast (by omega : 0 < b)
+  have hpos : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := zpow_pos hbR _
+  linarith
+
+/-- **Every finite string appears (disjunctivity corollary).**
+    A number normal in base `b` contains every `k`-tuple of base-`b` digits at
+    some starting position — immediate from the infinitude of matches. -/
+theorem normal_imp_disjunctive (b k : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (hn : IsNormalInBase b x) (s : Fin k → Fin b) :
+    ∃ n : ℕ, ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ) :=
+  (normal_ktuple_infinitely_often b k hb x hn s).nonempty
+
 -- ============================================================
 -- PART V: OPEN QUESTION
 -- ============================================================
@@ -705,8 +754,6 @@ theorem e_normal_implies_uniform_decimal_digits
   have h := hn 1 (fun _ => d)
   simp [nthDigit] at h ⊢
   convert h using 2
-  · congr 1; ext N; congr 1; ext n; simp
-  · norm_num
 
 /-- e is irrational — a necessary condition for normality (not sufficient). -/
 theorem e_irrational_necessary_for_normality : Irrational (Real.exp 1) :=

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -198,9 +198,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 715,
+    "lineCount": 762,
     "axiomCount": 1,
-    "theoremCount": 48,
+    "theoremCount": 50,
     "definitionCount": 5,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/e-transcendental-oq-02-oq-06.json
+++ b/src/data/research/problems/e-transcendental-oq-02-oq-06.json
@@ -1,7 +1,7 @@
 {
   "slug": "e-transcendental-oq-02-oq-06",
   "title": "Complete `normal_imp_irrational` in Lean 4, eliminating the axiom",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -29,11 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS (verified 0/0 for new results): normal_imp_irrational was already complete, so added normal_ktuple_infinitely_often + normal_imp_disjunctive (normal numbers are disjunctive) and repaired 4 pre-existing latent build breaks so the whole file compiles under current Mathlib. Only remaining axiom e_absolutely_normal is the genuine open conjecture (e is normal).",
+    "builtItems": [
+      "normal_ktuple_infinitely_often (Proofs/ETranscendentalOQ02.lean): {n | s occurs at n}.Infinite for x normal in base b. Verified 0 sorry; axioms [propext, Classical.choice, Quot.sound].",
+      "normal_imp_disjunctive (same file): every finite digit string appears at least once (corollary via Set.Infinite.nonempty).",
+      "Repair: eTranscendental.lean lost its namespace -> ETranscendental.e_irrational/e_transcendental became _root_.e_irrational/_root_.e_transcendental.",
+      "Repair: periodic_has_missing_ktuple L480 omega replaced by Nat.mod_add_div' + Nat.add_sub_cancel' (variable-divisor div/mod is nonlinear for omega).",
+      "Repair: e_normal_implies_uniform_decimal_digits convert now closes the goal outright; dropped stale post-convert bullets."
+    ],
+    "insights": [
+      "The stated target normal_imp_irrational was ALREADY a complete 0-sorry theorem (Session 13); OQ-02-OQ-06 as literally phrased was resolved. Added genuinely new theory instead of reclaiming.",
+      "Normal numbers are DISJUNCTIVE: every finite digit-string occurs, in fact at infinitely many positions. Positive companion to normal_imp_irrational (which uses a MISSING tuple to force frequency 0); here a bounded match-count would force frequency 0, contradicting the positive normal limit b^(-k).",
+      "The file did NOT build on current Mathlib (never Lean-CI-d; math PRs skip the Lean build). Four latent breaks were repaired to reach a verified state."
+    ],
+    "mathlibGaps": [
+      "omega does not discharge variable-divisor Euclidean identities (a/T*T + a%T = a with T variable, nonlinear); use Nat.mod_add_div'/Nat.div_add_mod explicitly."
+    ],
+    "nextSteps": [
+      "Sharpness: irrational does NOT imply normal. Construct an explicit irrational non-normal number (Liouville-type digit sequence with a frequency-0 digit) in the nthDigit framework, proving non-eventual-periodicity and a frequency-0 block.",
+      "Quantitative disjunctivity: bound first-occurrence position / gaps of a fixed k-tuple via the normality convergence rate (only qualitative infinitude proved so far)."
+    ],
     "markdown": "# Knowledge Base: e-transcendental-oq-02-oq-06\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -57,7 +72,7 @@
     "mathlib": []
   },
   "started": "2026-07-04T19:52:25.455Z",
-  "lastUpdate": "2026-07-04T19:52:25.491Z",
+  "lastUpdate": "2026-07-08",
   "leanFiles": [
     {
       "path": "Proofs/ETranscendentalOQ01.lean",


### PR DESCRIPTION
## Summary

Problem **e-transcendental-oq-02-oq-06** asks to *complete `normal_imp_irrational`, eliminating the axiom*. That theorem was already complete (0 sorry, no dedicated axiom) — the only axiom in the file, `e_absolutely_normal`, is the genuine open conjecture that *e* is normal, which must stay axiomatized. Rather than reclaim a done result, this PR adds genuinely new theory and repairs the file so it actually builds.

### New theory (both VERIFIED, axioms `[propext, Classical.choice, Quot.sound]`)
- **`normal_ktuple_infinitely_often`** — in a number normal in base `b`, every `k`-tuple of digits occurs at *infinitely many* starting positions (`{n | s occurs at n}.Infinite`). This is the positive companion to `normal_imp_irrational`: the latter derives a contradiction from a *missing* tuple (frequency → 0), while here a *bounded* match-count would force frequency → 0, contradicting the positive normal limit `b^(-k)`.
- **`normal_imp_disjunctive`** — every finite digit string appears at least once (corollary via `Set.Infinite.nonempty`). I.e. normal numbers are *disjunctive*.

### Latent build repair
The file was never Lean-CI'd (math PRs skip the Lean build) and no longer compiled on current Mathlib. Fixed 4 pre-existing breaks:
- `L86/L90`: dependency `eTranscendental.lean` lost its `namespace ETranscendental`, so `ETranscendental.e_irrational/e_transcendental` → `_root_.e_irrational/_root_.e_transcendental`.
- `L480`: `omega` cannot discharge the variable-divisor Euclidean identity `N₀ + (n−N₀)%T + (n−N₀)/T*T = n` (nonlinear) → replaced with `Nat.mod_add_div'` + `Nat.add_sub_cancel'`.
- `L755`: `convert h using 2` now closes the goal outright → dropped the stale post-`convert` bullets.

### Verification
`./proofs/scripts/docker-build.sh Proofs.ETranscendentalOQ02` → `=== Build succeeded ===`, 0 errors, 0 sorries. `#print axioms` confirms both new theorems use only the three foundational axioms.

meta.json updated: `leanFile.lineCount` 715→762, `theoremCount` 48→50, `axiomCount` unchanged (1 = `e_absolutely_normal`).