### PR TITLE
Enrich Effective Bisection Depth (descartes leaf): foundational cross-reference to root

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -248,6 +248,11 @@
       "targetId": "descartes-rule-of-signs-oq-02",
       "relationship": "related",
       "description": "Supplies the budanCount sign-variation infrastructure whose 0-or-1 value on the isolated intervals produced at the explicit level would complete the certified isolation pipeline."
+    },
+    {
+      "targetId": "descartes-rule-of-signs",
+      "relationship": "foundational",
+      "description": "The root of the whole lineage: Descartes' rule of signs, bounding the positive real roots of a polynomial by the sign changes in its coefficient sequence. Vincent/Budan root isolation (this leaf's subject) is the algorithmic descendant that turns that global sign-variation count into an interval-by-interval isolation procedure; the explicit bisection depth k₀ = ⌈log₂(w/δ)⌉+1 proved here bounds how deep that subdivision must go."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for descartes-rule-of-signs-oq-02-oq-01-oq-03-oq-02.

The entry is otherwise saturated (7 mainTheorems, sections cover the full 186-line file, 4 keyInsights, 3 references). Its `crossReferences` linked up to the parent and two ancestors (oq-02-oq-01, oq-02) but not to the lineage **root** `descartes-rule-of-signs` — the foundational theorem the whole Vincent/Budan root-isolation chain descends from. Gallery convention links leaves to their root (cf. the cramers-rule leaf → cramers-rule). Added a `foundational` cross-reference framing Vincent bisection as the algorithmic descendant of the sign-variation rule.

- Purely additive (+5 lines, one crossReference); JSON validated.