### PR TITLE
Fix: sync stale erdos-3 metadata counts to actual Lean source

### DIFF
--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -63,7 +63,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 163,
+    "lineCount": 801,
     "prerequisites": [
       "Arithmetic progressions and their properties",
       "Series convergence and divergence (reciprocal sums)",
@@ -72,8 +72,8 @@
       "Extremal combinatorics (Ramsey-type reasoning)"
     ],
     "assumptions": "0 axioms. `euler_prime_sum_diverges` (Euler 1737, ∑ 1/p diverges) is now a proved theorem, discharged from Mathlib's `not_summable_one_div_on_primes`. 1 sorry remains in `required_bound_implies_conjecture` (the o(N/log N) threshold), which is threshold-critical: as hard as Erdős #3 itself. The strictly stronger (log N)^{1+δ} threshold reduction (`strong_required_bound_implies_conjecture`) is fully proved, sorry-free and axiom-free.",
-    "theoremCount": 3,
-    "definitionCount": 11
+    "theoremCount": 26,
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "**The Erdos-Turan Conjecture on Arithmetic Progressions**\n\nThis problem was first posed by Erdos and Turan in 1936, making it one of the oldest open problems in additive combinatorics. They conjectured that any subset $A \\subseteq \\mathbb{N}$ with $\\sum_{n \\in A} 1/n = \\infty$ must contain arbitrarily long arithmetic progressions.\n\n**Early History (1936--1975):**\nThe conjecture was motivated by the observation that 'large' sets (measured by reciprocal sum divergence) should be arithmetically rich. Roth made the first breakthrough in 1953, proving $r_3(N) = o(N)$ -- sets of positive density contain 3-term APs. This introduced Fourier analysis into combinatorics and contributed to Roth's Fields Medal. Twenty-two years later, Szemeredi (1975) proved the landmark theorem $r_k(N) = o(N)$ for all $k$, using his Regularity Lemma -- a purely combinatorial tour de force that won him the Abel Prize.\n\n**Multiple Proof Traditions (1977--2001):**\nFurstenberg (1977) gave a completely different proof of Szemeredi's theorem using ergodic theory, showing the equivalence with a multiple recurrence theorem. Gowers (2001) gave a third proof introducing the uniformity norms $\\|f\\|_{U^k}$ and higher-order Fourier analysis, obtaining the first quantitative bounds $r_k(N) \\ll N/(\\log \\log N)^{c_k}$. His Fields Medal recognized this achievement.\n\n**Modern Breakthroughs (2008--2024):**\nGreen and Tao (2008) proved primes contain arbitrarily long APs, confirming Erdos's intuition that the conjecture relates to primes. Kelley and Meka (2023) achieved a dramatic improvement for $k=3$: $r_3(N) \\ll N/\\exp((\\log N)^{1/11})$, nearly matching the Behrend lower bound. Leng, Sah, and Sawhney (2024) extended these methods to general $k$.\n\n**The Persistent Gap:**\nDespite 90 years of progress, the conjecture remains OPEN with Erdos's $5,000 prize unclaimed. Current bounds give $r_k(N) = o(N/\\exp((\\log \\log N)^c))$, but the conjecture requires $o(N/\\log N)$ -- an exponentially stronger statement. Neither a proof nor a counterexample appears within reach of current techniques.",
@@ -247,9 +247,9 @@
       "Finset"
     ],
     "namespace": "Erdos3",
-    "lineCount": 486,
+    "lineCount": 801,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 26,
     "definitionCount": 12,
     "path": "Proofs/Erdos3Problem.lean",
     "sorries": 1


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-3/meta.json` carried badly stale count fields for `Proofs/Erdos3Problem.lean`. The file grew (most recently via #35395 adding the Roth number `r₂(N)=1` content) without the metadata being resynced. Both the inner `meta` object and the `leanFile` object are corrected to match the current source.

## Evidence

Actual current `Proofs/Erdos3Problem.lean` (comment-stripped): **801 lines**, **26 theorems/lemmas**, **12 defs**, **1 sorry**, **0 axioms**.

| field | object | before | after |
|-------|--------|--------|-------|
| `lineCount` | `meta` | 163 | 801 |
| `theoremCount` | `meta` | 3 | 26 |
| `definitionCount` | `meta` | 11 | 12 |
| `lineCount` | `leanFile` | 486 | 801 |
| `theoremCount` | `leanFile` | 10 | 26 |

`sorries` (1) and `axiomCount` (0) were already correct and are unchanged. No Lean source touched; JSON validated.

Scope note: does not touch `Erdos3LogHarmonic.lean` (the file under open PR #35217) — only the primary `Erdos3Problem.lean` count metadata.

---
Automated fix by lean-mechanic agent.