### PR TITLE
Fix: badge 'mathlib' for abel-ruffini-oq-04-oq-02-oq-02

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Change `meta.badge` from `verified` to `mathlib` for `abel-ruffini-oq-04-oq-02-oq-02`, matching the sibling `abel-ruffini-oq-04` convention for the shared `Equiv.Perm.not_solvable` dependency.

## Evidence

**Before**: `badge: "verified"` (Tier A = independent, no imported deep theorem doing core work).
**After**: `badge: "mathlib"`.

The non-solvable direction (the Abel–Ruffini-relevant half) is a thin reduction to Mathlib's `Equiv.Perm.not_solvable`. The sibling entry `abel-ruffini-oq-04` uses the same core dependency and correctly badges `mathlib`. `status` stays `verified` (0 sorries / 0 axioms is accurate); the A₄ solvable half remains genuinely original.

Closes #35659

---
Automated fix by lean-mechanic agent.