### PR TITLE
Enrich Erdős #1023 growth brackets: cross-reference beta-central-binomial-asymptotic

### DIFF
--- a/src/data/proofs/erdos-1023-oq-04/meta.json
+++ b/src/data/proofs/erdos-1023-oq-04/meta.json
@@ -172,6 +172,11 @@
       "targetId": "erdos-1023-oq-02",
       "relationship": "sibling",
       "description": "Develops the intersection and difference analogues of the union-free problem: the complementation bijection A ↦ Aᶜ carries union-free families onto intersection-free families, giving F∩(n) = F(n), so the same central-binomial value and hence the same 2^n/(n+1) ≤ F ≤ 2^n brackets proved here transfer verbatim to the intersection-free maximum."
+    },
+    {
+      "targetId": "beta-central-binomial-asymptotic",
+      "relationship": "related",
+      "description": "Supplies the sharp central-binomial asymptotic this entry defers: it derives C(2n,n) ~ 4ⁿ/√(πn) from Mathlib's Stirling equivalent. Since the even subsequence here is exactly that quantity (unionFreeMax_two_mul: F(2n) = centralBinom n = C(2n,n)), that estimate turns the elementary bracket 2^n/(n+1) ≤ F(n) ≤ 2^n proved here into the true √n-order growth F(2n) ~ 4ⁿ/√(πn) — the Stirling-type refinement listed as this entry's first open question."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for erdos-1023-oq-04.

The entry is saturated and its lineage link graph is already complete (parent erdos-1023 + both siblings oq-02/oq-03; no child exists). The genuine gap was thematic: its **first open question** — the sharp √n-order central-binomial asymptotic that 'requires a Stirling-type estimate' — has a direct gallery answer in **beta-central-binomial-asymptotic**, which derives C(2n,n) ~ 4ⁿ/√(πn) from Mathlib's Stirling equivalent. Since the even subsequence here is exactly that quantity (unionFreeMax_two_mul: F(2n) = centralBinom n = C(2n,n)), added a `related` cross-reference connecting the elementary bracket 2ⁿ/(n+1) ≤ F(n) ≤ 2ⁿ to the sharp asymptotic that resolves the deferred open question.

- Purely additive (+5 lines, one crossReference); JSON validated.