### PR TITLE
Enrich denumerability-rationals-oq-05: link to child oq-05-oq-01

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-05/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-05/meta.json
@@ -196,6 +196,11 @@
       "targetId": "cantor-diagonalization-oq-07",
       "relationship": "related",
       "description": "The ℵ₀-level shadow of the continuum-stability results: 𝔠 · 𝔠 = 𝔠 and 𝔠 ^ ℵ₀ = 𝔠 mirror ℵ₀ · ℵ₀ = ℵ₀, but the power lifts ℵ₀ strictly to 𝔠"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "child",
+      "description": "Direct child answering this entry's first open question: it shows the ℵ₀/𝔠 boundary is structural, not special to ℚ. For ANY countably infinite commutative ring R, the polynomial ring stays denumerable (#(R[X]) = ℵ₀) while the countable power jumps to the continuum (#(ℕ → R) = 𝔠) — generalizing #(Finset ℚ)=ℵ₀ vs #(ℕ → ℚ)=𝔠 proved here to the ring level."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for denumerability-rationals-oq-05.

The entry is saturated (8 mainTheorems, sections cover the full 73-line file, 4 keyInsights). Its `crossReferences` linked the parent, the oq-01 sibling, and a Cantor-diagonalization entry — but not its own **direct child oq-05-oq-01**, which generalizes the ℵ₀/𝔠 boundary from ℚ to any countably infinite commutative ring (#(R[X]) = ℵ₀ vs #(ℕ → R) = 𝔠). That is exactly this entry's **first open question**. Added the downward `child` cross-reference, closing the link and pointing readers to the resolution of the deferred question.

- Purely additive (+5 lines, one crossReference); JSON validated.