### PR TITLE
Enrich Erdős #286 small-k Egyptian fractions: add absent mainTheorems array

### DIFF
--- a/src/data/proofs/erdos-286-oq-01/meta.json
+++ b/src/data/proofs/erdos-286-oq-01/meta.json
@@ -116,6 +116,40 @@
       "mathContext": "For $a < b < c$: $\\tfrac1a + \\tfrac1b + \\tfrac1c = 1 \\iff (a,b,c) = (2,3,6)$; and $\\tfrac12 + \\tfrac13 + \\tfrac16 = 1$."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "three_distinct_unit_fractions_eq_one",
+      "type": "core",
+      "description": "**k = 3 uniqueness.** The only strictly increasing triple of positive integers a < b < c with 1/a + 1/b + 1/c = 1 is (2,3,6). Proved by an ordered squeeze: 1 < 3/a forces a < 3 and a ≠ 1 gives a = 2; then 1/b + 1/c = 1/2 with 1/c < 1/b forces b < 4 and b > 2 so b = 3; finally 1/c = 1/6 and inv_inj give c = 6.",
+      "leanType": "(a b c : ℕ) (ha : 0 < a) (hab : a < b) (hbc : b < c) (h : (1 : ℚ) / a + 1 / b + 1 / c = 1) : a = 2 ∧ b = 3 ∧ c = 6",
+      "startLine": 77,
+      "endLine": 123
+    },
+    {
+      "name": "three_distinct_iff",
+      "type": "core",
+      "description": "**k = 3 characterisation (ordered).** For strictly increasing positive integers, 1/a + 1/b + 1/c = 1 holds iff (a,b,c) = (2,3,6) — packaging existence (repr_236) and uniqueness into a single iff.",
+      "leanType": "(a b c : ℕ) (ha : 0 < a) (hab : a < b) (hbc : b < c) : (1 : ℚ) / a + 1 / b + 1 / c = 1 ↔ a = 2 ∧ b = 3 ∧ c = 6",
+      "startLine": 127,
+      "endLine": 131
+    },
+    {
+      "name": "no_two_distinct_unit_fractions",
+      "type": "key",
+      "description": "**k = 2 impossibility.** No two distinct positive integers a < b satisfy 1/a + 1/b = 1: a = 1 forces the second term to vanish, and a ≥ 2 forces b ≥ 3 so 1/a + 1/b ≤ 1/2 + 1/3 = 5/6 < 1. Certifies the parent's 'needs k ≥ 3'.",
+      "leanType": "(a b : ℕ) (ha : 0 < a) (hab : a < b) (h : (1 : ℚ) / a + 1 / b = 1) : False",
+      "startLine": 45,
+      "endLine": 61
+    },
+    {
+      "name": "repr_236",
+      "type": "supporting",
+      "description": "**k = 3 existence witness.** 1/2 + 1/3 + 1/6 = 1, discharged by norm_num — the unique realizer at the threshold.",
+      "leanType": "(1 : ℚ) / 2 + 1 / 3 + 1 / 6 = 1",
+      "startLine": 68,
+      "endLine": 68
+    }
+  ],
   "references": [
     {
       "text": "P. Erdős, Problem #286 — unit fractions in short intervals (Erdős Problems database).",


### PR DESCRIPTION
Enrichment pass for erdos-286-oq-01.

The `mainTheorems` array was **absent** despite commit #35621 claiming to add it (a regression, mirroring the denumerability oq-05/oq-06 case restored in #35553). Added all 4 theorems with accurate `leanType` signatures and line anchors read from the Lean source:
- **three_distinct_unit_fractions_eq_one** (core) — k=3 uniqueness: only (2,3,6);
- **three_distinct_iff** (core) — the ordered iff characterisation;
- **no_two_distinct_unit_fractions** (key) — k=2 impossibility;
- **repr_236** (supporting) — the 1/2+1/3+1/6=1 existence witness.

- meta.json 13.9 KB → 15.8 KB (well under caps); JSON validated; single file.