### PR TITLE
research(beta-central-binomial-explicit-rate-oq-02): second- & third-order Beta correction terms, c₁=1/8, c₂=0 [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/BetaCentralBinomialExplicitRateOQ02.lean
+++ b/proofs/Proofs/BetaCentralBinomialExplicitRateOQ02.lean
@@ -32,6 +32,18 @@ This entry supplies the first nontrivial coefficient with an effective remainder
 * **`correction_log_isBigO_second_order`** (clean Landau form):
     `(fun n => log (q n) - 1/(8n)) =O[atTop] (fun n => 1/n²)`.
 
+Part 4 pushes this one order further.  Sharpening the *lower* Stirling bracket from
+`1/(12j) - 1/(12j²)` to the cubic `1/(12j) - 1/(144 j³)` (matching the exact upper
+bound `1/(12j)` to order `1/j³`) yields:
+
+* **`correction_log_third_order`** (the `c₂ = 0` answer): for `n ≥ 1`,
+    `|log (q n) - 1/(8n)| ≤ 1/(6 n²)` is upgraded to `≤ 1/(72 n³)`.
+  So the asymptotic expansion `q n = 1 + c₁/n + c₂/n² + ⋯` has **`c₂ = 0`** — no
+  genuine `1/n²` term — and the first correction beyond `1/(8n)` lives at order `1/n³`.
+
+* **`correction_log_isBigO_third_order`**:
+    `(fun n => log (q n) - 1/(8n)) =O[atTop] (fun n => 1/n³)`.
+
 ## The Engine
 
 The exact second-order coefficient is unlocked by Mathlib's **exact per-step
@@ -386,5 +398,196 @@ theorem correction_log_isBigO_second_order :
     abs_of_pos (by positivity : (0 : ℝ) < 1 / (n : ℝ) ^ 2)]
   calc |Real.log (correction n) - 1 / (8 * (n : ℝ))| ≤ 1 / (6 * (n : ℝ) ^ 2) := hb
     _ = 1 / 6 * (1 / (n : ℝ) ^ 2) := by ring
+
+/-! ### Part 4 — The `1/n²` coefficient vanishes: `q n = 1 + 1/(8n) + O(1/n³)`
+
+The second-order result above brackets `log (q n) - 1/(8n)` by `O(1/n²)`.  Does the
+expansion *continue* — is there a genuine `c₂/n²` term?  The true Stirling deviation
+`S(j) = log stirlingSeq(j) - log√π = 1/(12j) - 1/(360 j³) + ⋯` carries **no** `1/j²`
+term, so `c₂ = 0` and the next correction sits at `1/n³`.
+
+We prove this by *sharpening the lower bracket*.  The per-step deficit of the exact
+upper model from the leading series term is
+  `1/(12 i(i+1)) - 1/(3(2i+1)²) = 1/(12 i(i+1)(2i+1)²)`,
+which is dominated by the telescoping cubic model `(1/144)(1/i³ - 1/(i+1)³)` — the
+inequality collapses to `0 ≤ 7·i(i+1) + 1`.  Telescoping this `O(1/i⁴)` deficit gives
+the cubic lower bracket `S(j) ≥ 1/(12j) - 1/(144 j³)`, matching the exact upper bound
+`S(j) ≤ 1/(12j)` to order `1/j³`.  Feeding `log (q n) = 2·S(n) - S(2n)` collapses the
+`1/n²` contributions to exactly `0`. -/
+
+/-- **Sharpened lower per-step bound (new).**  For every `m`, the per-step drop exceeds
+the exact upper model corrected by a *cubic* telescoping term:
+`step ≥ (1/(12(m+1)) - 1/(12(m+2))) - (1/144)(1/(m+1)³ - 1/(m+2)³)`.
+
+The correction majorant telescopes to an `O(1/j³)` tail — one order sharper than
+`diff_lower`.  The pointwise inequality reduces to `0 ≤ 7·t(t+1) + 1`. -/
+lemma diff_lower_cubic (m : ℕ) :
+    (1 / (12 * ((m : ℝ) + 1)) - 1 / (12 * ((m : ℝ) + 2)))
+        - (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3 - 1 / ((m : ℝ) + 2) ^ 3)
+      ≤ Real.log (Stirling.stirlingSeq (m + 1)) - Real.log (Stirling.stirlingSeq (m + 2)) := by
+  have hlead := diff_lower_leading m
+  set t : ℝ := (m : ℝ) + 1 with ht
+  have ht0 : (0 : ℝ) < t := by rw [ht]; positivity
+  have ht1p : (0 : ℝ) < t + 1 := by linarith
+  have hden : (0 : ℝ) < 2 * t + 1 := by linarith
+  have ht2 : (m : ℝ) + 2 = t + 1 := by rw [ht]; ring
+  rw [ht2]
+  have hne0 : t ≠ 0 := ht0.ne'
+  have hne1 : t + 1 ≠ 0 := ht1p.ne'
+  have hne2 : 2 * t + 1 ≠ 0 := hden.ne'
+  have halg :
+      (1 / (12 * t) - 1 / (12 * (t + 1))) - (1 / 144) * (1 / t ^ 3 - 1 / (t + 1) ^ 3)
+        ≤ 1 / (3 * (2 * t + 1) ^ 2) := by
+    rw [← sub_nonneg]
+    have hEq : 1 / (3 * (2 * t + 1) ^ 2)
+          - ((1 / (12 * t) - 1 / (12 * (t + 1)))
+              - (1 / 144) * (1 / t ^ 3 - 1 / (t + 1) ^ 3))
+        = (7 * (t * (t + 1)) + 1)
+            / (144 * t ^ 3 * (t + 1) ^ 3 * (2 * t + 1) ^ 2) := by
+      field_simp; ring
+    rw [hEq]
+    apply div_nonneg
+    · nlinarith [ht0, mul_pos ht0 ht1p]
+    · positivity
+  linarith [hlead, halg]
+
+/-- Telescoping sum of the cubic correction model. -/
+private lemma tel_cubic (m N : ℕ) :
+    (∑ j ∈ Finset.range N,
+        ((1 / 144) * (1 / ((m : ℝ) + j + 1) ^ 3 - 1 / ((m : ℝ) + j + 2) ^ 3)))
+      = (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3 - 1 / ((m : ℝ) + N + 1) ^ 3) := by
+  induction N with
+  | zero => simp
+  | succ k ih => rw [Finset.sum_range_succ, ih]; push_cast; ring
+
+/-- **Cubic lower bound of the deviation (new).**  For every `m`,
+`1/(12(m+1)) - (1/144)/(m+1)³ ≤ log stirlingSeq(m+1) - log√π`. -/
+lemma stirlingLogDev_lower_cubic (m : ℕ) :
+    1 / (12 * ((m : ℝ) + 1)) - (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3)
+      ≤ Real.log (Stirling.stirlingSeq (m + 1)) - Real.log (Real.sqrt π) := by
+  set g : ℕ → ℝ := fun j => Real.log (Stirling.stirlingSeq (m + j + 1)) with hg
+  have hsum : ∀ N : ℕ, (∑ j ∈ Finset.range N, (g j - g (j + 1)))
+      = Real.log (Stirling.stirlingSeq (m + 1)) - Real.log (Stirling.stirlingSeq (m + N + 1)) := by
+    intro N; rw [Finset.sum_range_sub' g N]
+  have hbound : ∀ N : ℕ,
+      (1 / (12 * ((m : ℝ) + 1)) - 1 / (12 * ((m : ℝ) + N + 1)))
+          - (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3)
+        ≤ (∑ j ∈ Finset.range N, (g j - g (j + 1))) := by
+    intro N
+    have hle : (∑ j ∈ Finset.range N,
+          ((1 / (12 * ((m : ℝ) + j + 1)) - 1 / (12 * ((m : ℝ) + j + 2)))
+            - (1 / 144) * (1 / ((m : ℝ) + j + 1) ^ 3 - 1 / ((m : ℝ) + j + 2) ^ 3)))
+        ≤ (∑ j ∈ Finset.range N, (g j - g (j + 1))) := by
+      apply Finset.sum_le_sum
+      intro j _
+      have h := diff_lower_cubic (m + j)
+      have hc1 : ((m + j : ℕ) : ℝ) + 1 = (m : ℝ) + j + 1 := by push_cast; ring
+      have hc2 : ((m + j : ℕ) : ℝ) + 2 = (m : ℝ) + j + 2 := by push_cast; ring
+      rw [hc1, hc2] at h
+      simpa only [hg] using h
+    rw [Finset.sum_sub_distrib, tel_upper m N, tel_cubic m N] at hle
+    have hmono : (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3 - 1 / ((m : ℝ) + N + 1) ^ 3)
+        ≤ (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3) := by
+      have : (0 : ℝ) ≤ 1 / ((m : ℝ) + N + 1) ^ 3 := by positivity
+      nlinarith [this]
+    linarith
+  have hπ : (0 : ℝ) < Real.sqrt π := Real.sqrt_pos.mpr Real.pi_pos
+  have htend_arg : Tendsto (fun N : ℕ => m + N + 1) atTop atTop :=
+    tendsto_atTop_atTop.2 (fun b => ⟨b, fun a ha => by omega⟩)
+  have htend_s : Tendsto (fun N : ℕ => Stirling.stirlingSeq (m + N + 1)) atTop (𝓝 (Real.sqrt π)) :=
+    Stirling.tendsto_stirlingSeq_sqrt_pi.comp htend_arg
+  have htend_log : Tendsto (fun N : ℕ => Real.log (Stirling.stirlingSeq (m + N + 1))) atTop
+      (𝓝 (Real.log (Real.sqrt π))) :=
+    (Real.continuousAt_log hπ.ne').tendsto.comp htend_s
+  have htend : Tendsto (fun N : ℕ => ∑ j ∈ Finset.range N, (g j - g (j + 1))) atTop
+      (𝓝 (Real.log (Stirling.stirlingSeq (m + 1)) - Real.log (Real.sqrt π))) := by
+    have := (tendsto_const_nhds (x := Real.log (Stirling.stirlingSeq (m + 1)))).sub htend_log
+    refine this.congr ?_
+    intro N; rw [hsum N]
+  have htendM : Tendsto (fun N : ℕ =>
+      1 / (12 * ((m : ℝ) + 1)) - 1 / (12 * ((m : ℝ) + N + 1))) atTop
+      (𝓝 (1 / (12 * ((m : ℝ) + 1)) - 0)) :=
+    tendsto_const_nhds.sub (tendsto_tail_zero m)
+  have htend_lb : Tendsto (fun N : ℕ =>
+      (1 / (12 * ((m : ℝ) + 1)) - 1 / (12 * ((m : ℝ) + N + 1)))
+        - (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3)) atTop
+      (𝓝 ((1 / (12 * ((m : ℝ) + 1)) - 0) - (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3))) :=
+    htendM.sub_const _
+  have hfinal := le_of_tendsto_of_tendsto' htend_lb htend hbound
+  have hsimp : (1 / (12 * ((m : ℝ) + 1)) - 0) - (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3)
+      = 1 / (12 * ((m : ℝ) + 1)) - (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3) := by
+    rw [sub_zero]
+  rw [hsimp] at hfinal
+  exact hfinal
+
+/-- **Cubic Stirling deviation bracket (new).**  For `j ≥ 1`,
+`1/(12j) - 1/(144 j³) ≤ log stirlingSeq(j) - log√π ≤ 1/(12j)`.
+
+This is one order sharper on the lower side than `stirlingLogDev_bracket`: the slack
+drops from `1/(12j²)` to `1/(144 j³)`, pinning `S(j) = 1/(12j) + O(1/j³)`. -/
+theorem stirlingLogDev_bracket_cubic (j : ℕ) (hj : 1 ≤ j) :
+    1 / (12 * (j : ℝ)) - 1 / (144 * (j : ℝ) ^ 3)
+        ≤ Real.log (Stirling.stirlingSeq j) - Real.log (Real.sqrt π) ∧
+    Real.log (Stirling.stirlingSeq j) - Real.log (Real.sqrt π) ≤ 1 / (12 * (j : ℝ)) := by
+  obtain ⟨m, rfl⟩ : ∃ m, j = m + 1 := ⟨j - 1, by omega⟩
+  have hc : ((m + 1 : ℕ) : ℝ) = (m : ℝ) + 1 := by push_cast; ring
+  refine ⟨?_, ?_⟩
+  · have h := stirlingLogDev_lower_cubic m
+    rw [hc]
+    have hconv : (1 / 144) * (1 / ((m : ℝ) + 1) ^ 3) = 1 / (144 * ((m : ℝ) + 1) ^ 3) := by
+      rw [div_mul_div_comm, one_mul]
+    rw [hconv] at h
+    exact h
+  · have h := stirlingLogDev_upper m; rw [hc]; exact h
+
+/-- **Main result (OQ-02, third order): the `1/n²` coefficient of `log (q n)` vanishes.**
+For `n ≥ 1`,
+`|log (q n) - 1/(8n)| ≤ 1/(72 n³)`.
+
+Upgrading the second-order `O(1/n²)` bound to `O(1/n³)` shows the asymptotic expansion
+`q n = 1 + c₁/n + c₂/n² + ⋯` has `c₂ = 0`: the multiplicative diagonal Beta correction
+has no genuine `1/n²` term, and the first correction beyond `1/(8n)` sits at order
+`1/n³`. -/
+theorem correction_log_third_order (n : ℕ) (hn : 1 ≤ n) :
+    |Real.log (correction n) - 1 / (8 * (n : ℝ))| ≤ 1 / (72 * (n : ℝ) ^ 3) := by
+  have hn0 : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  have hnz : (n : ℝ) ≠ 0 := hn0.ne'
+  obtain ⟨hSn_lo, hSn_hi⟩ := stirlingLogDev_bracket_cubic n hn
+  obtain ⟨hS2n_lo, hS2n_hi⟩ := stirlingLogDev_bracket_cubic (2 * n) (by omega)
+  have hcast2n : ((2 * n : ℕ) : ℝ) = 2 * (n : ℝ) := by push_cast; ring
+  rw [hcast2n] at hS2n_lo hS2n_hi
+  rw [log_correction_eq n hn]
+  set Sn : ℝ := Real.log (Stirling.stirlingSeq n) - Real.log (Real.sqrt π) with hSn
+  set S2n : ℝ := Real.log (Stirling.stirlingSeq (2 * n)) - Real.log (Real.sqrt π) with hS2n
+  rw [abs_le]
+  refine ⟨?_, ?_⟩
+  · -- lower
+    have e1 : (2 : ℝ) * (1 / (12 * (n : ℝ)) - 1 / (144 * (n : ℝ) ^ 3))
+        - 1 / (12 * (2 * (n : ℝ))) - 1 / (8 * (n : ℝ)) = -(1 / (72 * (n : ℝ) ^ 3)) := by
+      field_simp; ring
+    linarith [hSn_lo, hS2n_hi, e1]
+  · -- upper
+    have e2 : (2 : ℝ) * (1 / (12 * (n : ℝ)))
+        - (1 / (12 * (2 * (n : ℝ))) - 1 / (144 * (2 * (n : ℝ)) ^ 3))
+        - 1 / (8 * (n : ℝ)) = 1 / (1152 * (n : ℝ) ^ 3) := by
+      field_simp; ring
+    have h1152le72 : (1 : ℝ) / (1152 * (n : ℝ) ^ 3) ≤ 1 / (72 * (n : ℝ) ^ 3) := by
+      apply one_div_le_one_div_of_le (by positivity)
+      nlinarith [hn0, pow_pos hn0 3]
+    linarith [hSn_hi, hS2n_lo, e2, h1152le72]
+
+/-- **Clean Landau form (third order).**  `log (q n) - 1/(8n) = O(1/n³)`. -/
+theorem correction_log_isBigO_third_order :
+    (fun n : ℕ => Real.log (correction n) - 1 / (8 * (n : ℝ))) =O[atTop]
+      (fun n : ℕ => 1 / (n : ℝ) ^ 3) := by
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨1 / 72, ?_⟩
+  filter_upwards [eventually_ge_atTop 1] with n hn
+  have hn0 : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  have hb := correction_log_third_order n hn
+  rw [Real.norm_eq_abs, Real.norm_eq_abs,
+    abs_of_pos (by positivity : (0 : ℝ) < 1 / (n : ℝ) ^ 3)]
+  calc |Real.log (correction n) - 1 / (8 * (n : ℝ))| ≤ 1 / (72 * (n : ℝ) ^ 3) := hb
+    _ = 1 / 72 * (1 / (n : ℝ) ^ 3) := by ring
 
 end BetaDiagSecondOrder

--- a/src/data/proofs/beta-central-binomial-explicit-rate-oq-02/meta.json
+++ b/src/data/proofs/beta-central-binomial-explicit-rate-oq-02/meta.json
@@ -1,0 +1,99 @@
+{
+  "id": "beta-central-binomial-explicit-rate-oq-02",
+  "title": "The Second- and Third-Order Terms of the Diagonal Beta Correction: q n = 1 + 1/(8n) + O(1/n³)",
+  "slug": "beta-central-binomial-explicit-rate-oq-02",
+  "description": "Answers open question OQ-02 of the parent entry (beta-central-binomial-explicit-rate): does the telescoping tail-bound technique extend to a genuine asymptotic expansion q n = 1 + c₁/n + c₂/n² + ⋯ with effective, machine-checked remainders? It does. Sharpening Mathlib's crude 1/(4j) Stirling tail to the true leading bracket 1/(12j) − 1/(12j²) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j) identifies the first coefficient c₁ = 1/8 with an effective O(1/n²) remainder (correction_log_second_order: |log q n − 1/(8n)| ≤ 1/(6n²)). Pushing the lower bracket one order further to the cubic 1/(12j) − 1/(144 j³) then shows the 1/n² coefficient vanishes — c₂ = 0 — upgrading the remainder to O(1/n³) (correction_log_third_order: |log q n − 1/(8n)| ≤ 1/(72 n³)). 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "dateAdded": "2026-07-08",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/BetaCentralBinomialExplicitRateOQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 17,
+    "definitionCount": 0,
+    "lineCount": 593,
+    "mathlib_version": "4.26.0",
+    "tags": [
+      "analysis",
+      "asymptotics",
+      "beta-function",
+      "stirling",
+      "central-binomial",
+      "landau-notation",
+      "asymptotic-expansion",
+      "research"
+    ],
+    "assumptions": [],
+    "imports": [
+      "Mathlib",
+      "Proofs.BetaCentralBinomialExplicitRate"
+    ]
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The parent entry established an effective 1 + O(1/n) rate for the diagonal Beta value B(n+1,n+1) relative to its Wallis/Stirling leading term, reducing the whole problem to the deviation of Mathlib's Stirling sequence stirlingSeq(k) → √π. Its second open question asked whether the telescoping tail-bound device could be pushed past the leading order into a genuine asymptotic expansion with effective remainders. The relevant classical fact is the Stirling series for log Γ, log stirlingSeq(j) − log√π = 1/(12j) − 1/(360 j³) + ⋯ (the Binet / Stirling asymptotic expansion, whose coefficients are the Bernoulli numbers B₂ₖ/(2k(2k−1))). Crucially this expansion has no 1/j² term, a fact usually read off the analytic continuation of ζ or the Euler–Maclaurin formula. Here it is recovered constructively and effectively: Mathlib's exact per-step series Stirling.log_stirlingSeq_diff_hasSum supplies convergent two-sided bounds that telescope into rational envelopes, and feeding log q n = 2·S(n) − S(2n) makes the 1/n² contributions cancel identically, exhibiting c₂ = 0 with a machine-checked O(1/n³) error bar.",
+    "problemStatement": "With q(n) = stirlingSeq(n)²/(√π·stirlingSeq(2n)) the multiplicative correction of the parent entry, prove effective bounds on log q(n) beyond leading order: (i) identify the first coefficient, |log q(n) − 1/(8n)| ≤ 1/(6 n²) for n ≥ 1, so c₁ = 1/8; and (ii) show the 1/n² coefficient vanishes, |log q(n) − 1/(8n)| ≤ 1/(72 n³) for n ≥ 1, so c₂ = 0 and the first correction beyond 1/(8n) sits at order 1/n³. Package both as Landau statements =O[atTop](1/n²) and =O[atTop](1/n³).",
+    "proofStrategy": "The engine is Mathlib's exact per-step series log stirlingSeq(m+1) − log stirlingSeq(m+2) = Σ_{k≥0} (1/(2k+3))·x^{2k+2} with x = 1/(2m+3), a positive convergent series. Bounding it two-sidedly gives sharp per-step envelopes: the geometric majorant 1/(2k+3) ≤ 1/3 yields the exact upper per-step drop (x²/3)/(1−x²) = 1/(12(m+1)(m+2)), which telescopes exactly to 1/(12j); the single leading term x²/3 gives a lower per-step drop whose deficit from the upper model is dominated first by a quadratic telescoping term (1/12)(1/i² − 1/(i+1)²), then — one order sharper — by a cubic telescoping term (1/144)(1/i³ − 1/(i+1)³), the sharper inequality collapsing to 0 ≤ 7·i(i+1)+1. Telescoping and passing to the limit stirlingSeq → √π produces the deviation brackets 1/(12j) − 1/(12j²) ≤ S(j) ≤ 1/(12j) and its cubic refinement 1/(12j) − 1/(144 j³) ≤ S(j) ≤ 1/(12j). Feeding these into log q(n) = 2·S(n) − S(2n) (the parent's log_correction_eq), the leading 1/(12·) contributions collapse to exactly 1/(8n); the quadratic bracket leaves an O(1/n²) remainder (c₁ = 1/8), and the cubic bracket makes the 1/n² pieces cancel identically, leaving O(1/n³) (c₂ = 0).",
+    "keyInsights": [
+      "The exact second-order coefficient is unlocked by Mathlib's exact per-step series log_stirlingSeq_diff_hasSum, not by the crude per-step estimate the parent used: the geometric majorant sums to the exact upper envelope 1/(12(m+1)(m+2)), whose telescope 1/(12j) is sharp to leading order — replacing the parent's off-by-a-factor-of-3 bound 1/(4j) and pinning the true coefficient 1/12.",
+      "A one-sided sharpening suffices at each order because the upper envelope is already exact: only the lower bracket needs refinement. The leading series term x²/3 undershoots the exact upper model by a per-step deficit 1/(12 i(i+1)) − 1/(3(2i+1)²) = 1/(12 i(i+1)(2i+1)²) = O(1/i⁴), which telescopes to an O(1/j²) — then, matched against a cubic model, an O(1/j³) — slack.",
+      "The vanishing of c₂ is a cancellation, not an estimate: log q(n) = 2·S(n) − S(2n) evaluates the same deviation at n and 2n, and the exact 1/(12·) leading terms combine to 2/(12n) − 1/(12·2n) = 1/(8n) while the next candidate 1/n² pieces from the two indices cancel identically — the cubic bracket certifies the residual lives at 1/n³.",
+      "Effectivity is preserved end to end exactly as in the parent: every bracket exponent is an explicit rational function of the index, the qualitative limit stirlingSeq → √π is used only to pass telescoped partial sums to their limit, and the final Landau constants (1/6 at second order, 1/72 at third) are honest explicit values, not existence claims.",
+      "The result answers the parent's OQ-02 in the affirmative and quantitatively: the expansion q(n) = 1 + c₁/n + c₂/n² + ⋯ begins c₁ = 1/8, c₂ = 0, with the first genuine correction beyond 1/(8n) at order 1/n³ — matching the Bernoulli-number structure of the classical Stirling series while being derived by elementary telescoping."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sharp-per-step-bounds",
+      "title": "Sharp Per-Step Bounds from the Exact Stirling Series",
+      "startLine": 76,
+      "endLine": 208,
+      "summary": "diff_upper derives the exact upper per-step bound log stirlingSeq(m+1) − log stirlingSeq(m+2) ≤ 1/(12(m+1)) − 1/(12(m+2)) by dominating Mathlib's per-step series termwise with a geometric majorant (1/(2k+3) ≤ 1/3) and summing (x²/3)/(1−x²) = 1/(12(m+1)(m+2)). diff_lower_leading records the matching lower bound from the single leading series term x²/3, and diff_lower packages the lower per-step drop in telescoping form with a quadratic correction majorant."
+    },
+    {
+      "id": "sharp-deviation-bracket",
+      "title": "Telescoping to the Sharp Stirling Deviation Bracket",
+      "startLine": 209,
+      "endLine": 350,
+      "summary": "tel_upper and tel_corr telescope the upper and quadratic-correction models; stirlingLogDev_upper sums the exact upper per-step bound to the sharp tail 1/(12(m+1)) (a factor 3 better than the parent's 1/(4·)), and stirlingLogDev_lower sums the corrected lower bound. The capstone stirlingLogDev_bracket states the sharp two-sided deviation bracket 1/(12j) − 1/(12j²) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j) for j ≥ 1, identifying the true 1/12 leading coefficient."
+    },
+    {
+      "id": "second-order-term",
+      "title": "The Second-Order Correction: c₁ = 1/8",
+      "startLine": 351,
+      "endLine": 401,
+      "summary": "Feeding the sharp bracket into log q(n) = 2·S(n) − S(2n), correction_log_second_order proves |log q(n) − 1/(8n)| ≤ 1/(6 n²) for n ≥ 1 — the OQ-02 answer, identifying the leading coefficient c₁ = 1/8 with an effective O(1/n²) remainder. correction_log_isBigO_second_order records the clean Landau form (log q n − 1/(8n)) =O[atTop](1/n²) with explicit constant 1/6."
+    },
+    {
+      "id": "third-order-vanishing",
+      "title": "The 1/n² Coefficient Vanishes: c₂ = 0",
+      "startLine": 402,
+      "endLine": 593,
+      "summary": "diff_lower_cubic sharpens the lower per-step bound with a cubic telescoping correction (the inequality collapsing to 0 ≤ 7·t(t+1)+1); tel_cubic telescopes it; stirlingLogDev_lower_cubic and stirlingLogDev_bracket_cubic yield the cubic deviation bracket 1/(12j) − 1/(144 j³) ≤ S(j) ≤ 1/(12j), one order sharper on the lower side. correction_log_third_order then proves |log q(n) − 1/(8n)| ≤ 1/(72 n³): the 1/n² contributions cancel, so c₂ = 0. correction_log_isBigO_third_order gives the Landau form =O[atTop](1/n³) with constant 1/72."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry answers open question OQ-02 of the parent beta-central-binomial-explicit-rate in the affirmative and quantitatively. The telescoping tail-bound technique does extend into a genuine effective asymptotic expansion of the multiplicative correction q(n) = stirlingSeq(n)²/(√π·stirlingSeq(2n)). Its technical core is a pair of sharp, machine-checked Stirling deviation brackets built from Mathlib's exact per-step series log_stirlingSeq_diff_hasSum: the leading bracket 1/(12j) − 1/(12j²) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j) (a factor-of-three improvement over the parent's crude 1/(4j)) and its cubic refinement 1/(12j) − 1/(144 j³) ≤ S(j) ≤ 1/(12j). Feeding log q(n) = 2·S(n) − S(2n) collapses the leading contributions to exactly 1/(8n), giving the first coefficient c₁ = 1/8 with an effective O(1/n²) remainder (|log q(n) − 1/(8n)| ≤ 1/(6 n²)); the cubic bracket then makes the 1/n² pieces cancel identically, upgrading the remainder to O(1/n³) (|log q(n) − 1/(8n)| ≤ 1/(72 n³)) and exhibiting c₂ = 0. Nothing is assumed: 0 axioms, 0 sorries.",
+    "implications": "The result recovers, by elementary telescoping and with fully explicit constants, the first two coefficients of the classical Stirling (Binet) series structure — c₁ = 1/8 and c₂ = 0 — for the diagonal Beta correction, confirming that the absence of a 1/n² term is a genuine feature (a cancellation certified by the cubic bracket) rather than an artifact of a lossy estimate. The sharp deviation bracket 1/(12j) − O(1/j³) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j) is itself reusable infrastructure: it upgrades any factorial-ratio asymptotic driven by Mathlib's Stirling sequence from leading order to second and third order with effective remainders, and pins the true 1/12 leading coefficient that the qualitative Mathlib development and the parent's 1/(4·) telescope both leave unidentified.",
+    "openQuestions": [
+      "Does the same per-step series admit a uniform inductive scheme producing the full Stirling tail S(j) = Σ_{k≥1} B_{2k}/(2k(2k−1) j^{2k−1}) with effective remainders at every order, rather than being pushed one order at a time?",
+      "What is the exact third-order coefficient c₃ of q(n) = 1 + 1/(8n) + c₃/n³ + ⋯? The cubic bracket bounds |log q(n) − 1/(8n)| ≤ 1/(72 n³) but does not yet pin the leading 1/n³ term to an exact rational value.",
+      "Can the sharp bracket 1/(12j) − 1/(144 j³) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j) be upstreamed to Mathlib's Stirling file, giving effective second-order versions of the many results that currently use only stirlingSeq → √π?"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/BetaCentralBinomialExplicitRateOQ02.lean",
+    "lineCount": 593,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 17,
+    "definitionCount": 0,
+    "imports": [
+      "import Mathlib",
+      "import Proofs.BetaCentralBinomialExplicitRate"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers **OQ-02** of the parent gallery entry `beta-central-binomial-explicit-rate`:

> *Does the telescoping tail-bound technique extend to a full asymptotic expansion q n = 1 + c₁/n + c₂/n² + ⋯ with effective, machine-checked remainder terms?*

**It does.** For the multiplicative diagonal Beta correction `q n = stirlingSeq(n)²/(√π·stirlingSeq(2n))`:

| Result | Statement (n ≥ 1) | Meaning |
|---|---|---|
| `correction_log_second_order` | `\|log q n − 1/(8n)\| ≤ 1/(6 n²)` | **c₁ = 1/8**, effective O(1/n²) remainder |
| `correction_log_third_order` | `\|log q n − 1/(8n)\| ≤ 1/(72 n³)` | **c₂ = 0**, first correction beyond 1/(8n) at order 1/n³ |

## The engine

Built from Mathlib's **exact** per-step series `Stirling.log_stirlingSeq_diff_hasSum`. Two new sharp deviation brackets:

- `stirlingLogDev_bracket`: `1/(12j) − 1/(12j²) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j)` — a factor-3 improvement over the parent's crude `1/(4j)`, pinning the true `1/12` leading coefficient (geometric majorant gives the exact upper envelope `1/(12(m+1)(m+2))`).
- `stirlingLogDev_bracket_cubic`: cubic lower refinement `1/(12j) − 1/(144 j³) ≤ S(j) ≤ 1/(12j)`; the sharpening inequality collapses to `0 ≤ 7·t(t+1)+1`.

Feeding `log q n = 2·S(n) − S(2n)` collapses the leading contributions to exactly `1/(8n)`; the cubic bracket makes the `1/n²` pieces cancel identically.

## Verification

- `proofs/Proofs/BetaCentralBinomialExplicitRateOQ02.lean`: 593 lines, 17 theorems/lemmas, **0 defs, 0 axioms, 0 sorries, 0 native_decide**.
- Builds green in Docker (`✔ Built Proofs.BetaCentralBinomialExplicitRateOQ02`, 7744 jobs, real build). The initial exit-135 was a SIGBUS artifact under fleet memory pressure; retry went green.
- Adds gallery entry `src/data/proofs/beta-central-binomial-explicit-rate-oq-02/meta.json` (status `verified`, badge `original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)