### PR TITLE
research(algebraic-reals-meager-oq-02-oq-01): dual Oxtoby — a meagre set of full Lebesgue measure [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01.lean
@@ -1,0 +1,176 @@
+import Mathlib
+
+/-
+  The dual Oxtoby phenomenon: a *meagre* set of *full* Lebesgue measure
+  (algebraic-reals-meager — OQ-02 → OQ-01)
+
+  The parent entry OQ-02 ("Measure versus Category") records one half of the
+  Oxtoby measure/category contrast: there is a set that is **comeagre**
+  (topologically large) yet **null** (measure-theoretically small) — the
+  Liouville numbers `L = {x | Liouville x}`. Concretely `L ∈ residual ℝ`
+  (`liouville_residual`) while `volume L = 0` (`liouville_null`).
+
+  This file supplies the **dual** direction, completing the symmetric picture:
+  there is a set that is **meagre** (topologically small) yet **conull**
+  (measure-theoretically large, i.e. of full Lebesgue measure). No new
+  construction is needed — the witness is simply the *complement of the
+  Liouville numbers*, the **non-Liouville reals** `Lᶜ`:
+
+  - `Lᶜ` is **meagre** because its complement `L` is comeagre
+    (`isMeagre_compl_of_mem_residual`);
+  - `Lᶜ` is **conull** (`volume (Lᶜ)ᶜ = volume L = 0`) because `L` is null.
+
+  Together with the parent's result this yields the full **symmetric Oxtoby
+  decomposition** of the real line:
+
+      ℝ  =  L  ⊔  Lᶜ
+            └ comeagre & null      (topologically large, measure-small)
+                 └ meagre & conull (topologically small, measure-large)
+
+  i.e. `ℝ` splits into a comeagre null set and a meagre conull set. This is the
+  sharp statement that "topological largeness" and "measure largeness" are not
+  merely inequivalent (OQ-02) but *complementary*: the very same partition
+  witnesses both failures of implication at once.
+
+  ## Honesty / novelty
+
+  Every ingredient is standard Mathlib (`eventually_residual_liouville`,
+  `volume_setOf_liouville`, `IsMeagre`, `compl_compl`). The abstract duality
+  lemma `isMeagre_compl_of_mem_residual` (complement of a residual set is
+  meagre) is a two-line unfolding of the definition `IsMeagre s := sᶜ ∈
+  residual`. The mathematical content is the *synthesis*: turning the parent's
+  comeagre-null witness into a meagre-conull one by complementation, and
+  packaging the resulting symmetric decomposition of `ℝ`. There is no new
+  mathematics; the value is the explicit, machine-checked dual statement that
+  the parent (which only records the comeagre-null half) leaves implicit.
+
+  No new axioms (standard Mathlib triple inherited).
+
+  References:
+  - Oxtoby, J.C. (1980). "Measure and Category", Springer GTM 2.
+  - Mathlib: NumberTheory.Transcendental.Liouville.{Residual,Measure},
+             Topology.GDelta.Basic (`IsMeagre`).
+
+  Tags: measure-theory, baire-category, liouville-numbers, meagre, residual,
+        lebesgue-measure, sharp-boundary, oxtoby-duality
+-/
+
+set_option maxHeartbeats 400000
+
+namespace AlgebraicRealsMeagerOQ02OQ01
+
+open MeasureTheory Filter Set
+
+-- ============================================================================
+-- Part I: the abstract duality — the complement of a residual set is meagre
+-- ============================================================================
+
+/-- **Complement of a comeagre set is meagre.** By definition `IsMeagre s`
+    means `sᶜ ∈ residual`; for `s = Aᶜ` this is `Aᶜᶜ = A ∈ residual`. Thus any
+    comeagre (residual) set has a meagre complement. This is the structural
+    engine that converts the parent's comeagre-null witness into a
+    meagre-conull one. -/
+theorem isMeagre_compl_of_mem_residual {α : Type*} [TopologicalSpace α]
+    {A : Set α} (h : A ∈ residual α) : IsMeagre Aᶜ := by
+  rw [IsMeagre, compl_compl]
+  exact h
+
+-- ============================================================================
+-- Part II: the Liouville numbers (comeagre & null) — recalled from Mathlib
+-- ============================================================================
+
+/-- The Liouville numbers are comeagre (residual) in `ℝ`. -/
+theorem liouville_residual : {x : ℝ | Liouville x} ∈ residual ℝ :=
+  eventually_residual_liouville
+
+/-- The Liouville numbers are Lebesgue-null. -/
+theorem liouville_null : volume {x : ℝ | Liouville x} = 0 :=
+  volume_setOf_liouville
+
+-- ============================================================================
+-- Part III: the dual witness — the non-Liouville reals are meagre yet conull
+-- ============================================================================
+
+/-- **The non-Liouville reals are meagre.** Their complement is the comeagre
+    set of Liouville numbers, so `isMeagre_compl_of_mem_residual` applies. This
+    is the topological "smallness" half of the dual phenomenon. -/
+theorem nonLiouville_meagre : IsMeagre {x : ℝ | Liouville x}ᶜ :=
+  isMeagre_compl_of_mem_residual liouville_residual
+
+/-- **The non-Liouville reals are conull (of full Lebesgue measure).** Their
+    complement is the null set of Liouville numbers, so the complement carries
+    no Lebesgue mass. This is the measure-theoretic "largeness" half. -/
+theorem nonLiouville_conull : volume ({x : ℝ | Liouville x}ᶜ)ᶜ = 0 := by
+  rw [compl_compl]
+  exact liouville_null
+
+/-- **Dual Oxtoby (headline).** There exists a *meagre* subset of `ℝ` whose
+    complement is Lebesgue-null — a topologically small set of full Lebesgue
+    measure. This is the mirror image of the parent's comeagre null set, and
+    completes the OQ-02 measure/category contrast in both directions. -/
+theorem exists_meagre_conull :
+    ∃ S : Set ℝ, IsMeagre S ∧ volume Sᶜ = 0 :=
+  ⟨{x : ℝ | Liouville x}ᶜ, nonLiouville_meagre, nonLiouville_conull⟩
+
+-- ============================================================================
+-- Part IV: the symmetric Oxtoby decomposition of the real line
+-- ============================================================================
+
+/-- **The symmetric Oxtoby decomposition.** The real line partitions into two
+    pieces that witness the *complementary* failure of "topological size" and
+    "measure size" to coincide:
+
+    * `A = L` — the Liouville numbers: **comeagre** (`A ∈ residual ℝ`) and
+      **null** (`volume A = 0`); topologically large, measure-small;
+    * `B = Lᶜ` — the non-Liouville reals: **meagre** (`IsMeagre B`) and
+      **conull** (`volume Bᶜ = 0`); topologically small, measure-large.
+
+    with `A ∪ B = univ` and `Disjoint A B`. This is the sharp form of OQ-02:
+    the two notions of largeness are not merely inequivalent but exactly
+    complementary along a single partition of `ℝ`. -/
+theorem real_symmetric_oxtoby :
+    ∃ A B : Set ℝ,
+      A ∪ B = univ ∧ Disjoint A B ∧
+      (A ∈ residual ℝ ∧ volume A = 0) ∧
+      (IsMeagre B ∧ volume Bᶜ = 0) :=
+  ⟨{x : ℝ | Liouville x}, {x : ℝ | Liouville x}ᶜ,
+    union_compl_self _, disjoint_compl_right,
+    ⟨liouville_residual, liouville_null⟩,
+    ⟨nonLiouville_meagre, nonLiouville_conull⟩⟩
+
+/-- **OQ-01 resolution.** Packaging: the dual meagre-conull witness together
+    with the full symmetric decomposition of `ℝ`. -/
+theorem oq01_resolution :
+    (∃ S : Set ℝ, IsMeagre S ∧ volume Sᶜ = 0) ∧
+    (∃ A B : Set ℝ,
+      A ∪ B = univ ∧ Disjoint A B ∧
+      (A ∈ residual ℝ ∧ volume A = 0) ∧
+      (IsMeagre B ∧ volume Bᶜ = 0)) :=
+  ⟨exists_meagre_conull, real_symmetric_oxtoby⟩
+
+#check @isMeagre_compl_of_mem_residual
+#check @nonLiouville_meagre
+#check @nonLiouville_conull
+#check @exists_meagre_conull
+#check @real_symmetric_oxtoby
+#check @oq01_resolution
+
+/-
+  ## Results Summary
+
+  | Theorem | Statement | Status |
+  |---------|-----------|--------|
+  | `isMeagre_compl_of_mem_residual` | complement of a residual set is meagre | Proved |
+  | `liouville_residual` | Liouville numbers comeagre | Proved (Mathlib) |
+  | `liouville_null` | Liouville numbers Lebesgue-null | Proved (Mathlib) |
+  | `nonLiouville_meagre` | non-Liouville reals are meagre | Proved |
+  | `nonLiouville_conull` | non-Liouville reals are conull (full measure) | Proved |
+  | `exists_meagre_conull` | ∃ meagre set of full measure (dual Oxtoby) | Proved |
+  | `real_symmetric_oxtoby` | ℝ = comeagre-null ⊔ meagre-conull | Proved |
+  | `oq01_resolution` | dual witness + symmetric decomposition | Proved |
+
+  **Sorries**: 0
+  **Axioms**: 0 declared (Mathlib triple inherited)
+-/
+
+end AlgebraicRealsMeagerOQ02OQ01

--- a/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "algebraic-reals-meager-oq-02-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "The Dual Oxtoby Phenomenon",
+    "content": "The docstring frames the dual of the parent OQ-02. OQ-02 exhibits a *comeagre yet null* set (the Liouville numbers $L$): topologically large, measure-small. This file supplies the mirror image — a *meagre yet conull* set: topologically small, measure-large — with no new construction. The witness is simply $L^c$, the non-Liouville reals. Because $L$ is comeagre, $L^c$ is meagre; because $L$ is null, $L^c$ is conull (full Lebesgue measure). Packaged as the symmetric decomposition $\\mathbb{R} = L \\sqcup L^c$, this shows the two notions of largeness are not merely inequivalent but exactly complementary along one partition of $\\mathbb{R}$.",
+    "mathContext": "Meagre: complement comeagre (residual). Conull: complement Lebesgue-null. $L$ comeagre & null $\\Rightarrow$ $L^c$ meagre & conull.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Baire category",
+      "Lebesgue measure",
+      "Oxtoby duality",
+      "Liouville numbers",
+      "meagre sets"
+    ],
+    "prerequisites": [
+      "measure theory",
+      "Baire category",
+      "real analysis"
+    ]
+  },
+  {
+    "id": "ann-duality-lemma",
+    "proofId": "algebraic-reals-meager-oq-02-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 76
+    },
+    "type": "theorem",
+    "title": "Complement of a Comeagre Set is Meagre",
+    "content": "`isMeagre_compl_of_mem_residual`: the abstract engine of the whole file. In Mathlib `IsMeagre s` is *defined* as `sᶜ ∈ residual X`. So `IsMeagre Aᶜ` unfolds to `Aᶜᶜ ∈ residual X`, and `compl_compl` rewrites $A^{cc} = A$, reducing the goal to the hypothesis `A ∈ residual X`. The lemma is stated for an arbitrary topological space, making the point that converting a comeagre witness into a meagre one is a purely formal complementation — nothing measure-theoretic is used here.",
+    "mathContext": "$\\mathrm{IsMeagre}\\,s := s^c \\in \\mathrm{residual}$; hence $A \\in \\mathrm{residual} \\Rightarrow \\mathrm{IsMeagre}\\,A^c$ via $A^{cc}=A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsMeagre",
+      "residual filter",
+      "compl_compl",
+      "Baire category"
+    ],
+    "prerequisites": [
+      "definition of meagre / residual sets"
+    ]
+  },
+  {
+    "id": "ann-liouville-facts",
+    "proofId": "algebraic-reals-meager-oq-02-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "Liouville Numbers: Comeagre and Null",
+    "content": "`liouville_residual` and `liouville_null` recall the two Mathlib facts that make the Liouville numbers the canonical separating example: they are residual/comeagre (`eventually_residual_liouville`) and Lebesgue-null (`volume_setOf_liouville`). These are exactly the two properties of $L$ that the dual construction complements — comeagreness gives meagreness of $L^c$, nullity gives conullity of $L^c$.",
+    "mathContext": "$L = \\{x : \\mathbb{R} \\mid \\mathrm{Liouville}\\,x\\}$ satisfies $L \\in \\mathrm{residual}\\,\\mathbb{R}$ and $\\mathrm{volume}\\,L = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Liouville numbers",
+      "residual filter",
+      "Lebesgue measure"
+    ],
+    "prerequisites": [
+      "Liouville numbers"
+    ]
+  },
+  {
+    "id": "ann-dual-witness",
+    "proofId": "algebraic-reals-meager-oq-02-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "A Meagre Set of Full Lebesgue Measure",
+    "content": "The heart of the entry. `nonLiouville_meagre` applies the duality lemma to `liouville_residual` to conclude $L^c$ is meagre. `nonLiouville_conull` shows $\\mathrm{volume}\\,(L^c)^c = 0$ by rewriting $(L^c)^c = L$ (`compl_compl`) and invoking `liouville_null` — i.e. $L^c$ has full Lebesgue measure. `exists_meagre_conull` then packages the existential: there is a meagre subset of $\\mathbb{R}$ whose complement is null. This is the exact mirror of the parent's comeagre null set, completing the measure/category contrast in the dual direction.",
+    "mathContext": "$L^c$ meagre (complement $L$ comeagre) and conull ($\\mathrm{volume}\\,(L^c)^c = \\mathrm{volume}\\,L = 0$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "meagre sets",
+      "conull sets",
+      "Liouville numbers",
+      "full measure"
+    ],
+    "prerequisites": [
+      "meagre / residual sets",
+      "conull sets"
+    ]
+  },
+  {
+    "id": "ann-decomposition",
+    "proofId": "algebraic-reals-meager-oq-02-oq-01",
+    "range": {
+      "startLine": 119,
+      "endLine": 149
+    },
+    "type": "theorem",
+    "title": "The Symmetric Oxtoby Decomposition ℝ = L ⊔ Lᶜ",
+    "content": "`real_symmetric_oxtoby` packages the whole picture: $\\mathbb{R}$ partitions as $A \\cup B$ with $A = L$ and $B = L^c$, disjoint (`disjoint_compl_right`) and covering (`union_compl_self`), where $A$ is comeagre-and-null and $B$ is meagre-and-conull. This is the sharp form of OQ-02: the parent shows comeagre $\\not\\Rightarrow$ conull; here a *single* partition of $\\mathbb{R}$ simultaneously witnesses that one piece is topologically large but measure-small and the other topologically small but measure-large. `oq01_resolution` bundles the dual witness with the decomposition as the OQ-01 deliverable.",
+    "mathContext": "$\\mathbb{R} = L \\sqcup L^c$; $L$ comeagre & null, $L^c$ meagre & conull — the two largeness notions are complementary.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Oxtoby duality",
+      "measure versus category",
+      "partition of ℝ",
+      "sharp boundary"
+    ],
+    "prerequisites": [
+      "meagre / residual sets",
+      "conull sets",
+      "set complementation"
+    ]
+  }
+]

--- a/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/index.ts
+++ b/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const algebraicRealsMeagerOQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const algebraicRealsMeagerOQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const algebraicRealsMeagerOQ02OQ01Data: ProofData = {
+  proof: algebraicRealsMeagerOQ02OQ01Proof,
+  annotations: algebraicRealsMeagerOQ02OQ01Annotations,
+}

--- a/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "algebraic-reals-meager-oq-02-oq-01",
+  "title": "Dual Oxtoby: a meagre set of full Lebesgue measure",
+  "slug": "algebraic-reals-meager-oq-02-oq-01",
+  "description": "Completes the symmetric Oxtoby picture begun by the parent OQ-02. Where OQ-02 exhibits a comeagre (topologically large) yet null (measure-small) set — the Liouville numbers — this entry supplies the dual: a meagre (topologically small) yet conull (full Lebesgue measure) set, namely the non-Liouville reals Lᶜ. No new construction is needed: Lᶜ is meagre because its complement L is comeagre, and conull because L is null. Packaged as the symmetric decomposition ℝ = L ⊔ Lᶜ into a comeagre-null part and a meagre-conull part, showing topological and measure largeness are not merely inequivalent but exactly complementary along one partition of ℝ.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Meagre_set",
+    "date": "2026-07-08",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicRealsMeagerOQ02OQ01.lean",
+    "tags": [
+      "measure-theory",
+      "baire-category",
+      "liouville-numbers",
+      "meagre",
+      "residual",
+      "lebesgue-measure",
+      "real-analysis",
+      "sharp-boundary"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-08",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "eventually_residual_liouville",
+        "description": "The set of Liouville numbers is residual (comeagre)",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Residual"
+      },
+      {
+        "theorem": "volume_setOf_liouville",
+        "description": "The set of Liouville numbers has Lebesgue measure zero",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "IsMeagre",
+        "description": "IsMeagre s is defined as sᶜ ∈ residual X — a set is meagre iff its complement is comeagre",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      },
+      {
+        "theorem": "compl_compl",
+        "description": "Double complement: sᶜᶜ = s",
+        "module": "Mathlib.Order.SetNotation"
+      },
+      {
+        "theorem": "union_compl_self",
+        "description": "s ∪ sᶜ = univ",
+        "module": "Mathlib.Data.Set.Basic"
+      },
+      {
+        "theorem": "disjoint_compl_right",
+        "description": "Disjoint s sᶜ",
+        "module": "Mathlib.Order.BooleanAlgebra"
+      }
+    ],
+    "originalContributions": [
+      "isMeagre_compl_of_mem_residual: PROVED the abstract duality that the complement of any residual (comeagre) set is meagre — a two-line unfolding of IsMeagre s := sᶜ ∈ residual via compl_compl; the structural engine converting a comeagre-null witness into a meagre-conull one",
+      "nonLiouville_meagre: PROVED the non-Liouville reals Lᶜ are meagre (their complement, the Liouville numbers, is comeagre)",
+      "nonLiouville_conull: PROVED the non-Liouville reals are conull — volume (Lᶜ)ᶜ = volume L = 0 — i.e. of full Lebesgue measure",
+      "exists_meagre_conull: PROVED the headline dual Oxtoby statement — there exists a meagre subset of ℝ of full Lebesgue measure, the mirror of the parent's comeagre null set",
+      "real_symmetric_oxtoby: PROVED the symmetric decomposition ℝ = L ⊔ Lᶜ (disjoint, union = univ) with L comeagre-and-null and Lᶜ meagre-and-conull, the sharp form of OQ-02 exhibiting the two largeness notions as exactly complementary",
+      "Synthesis (no new mathematics): reuses Mathlib's Liouville residual/measure-zero facts and complementation to complete the OQ-02 measure/category contrast in the dual direction the parent leaves implicit"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Baire category: meagre / residual (comeagre) sets and the definition IsMeagre s := sᶜ ∈ residual",
+      "Lebesgue measure on ℝ; conull (full measure) = complement is null",
+      "Liouville numbers: residual (comeagre) and Lebesgue-null"
+    ],
+    "lineCount": 178,
+    "relatedProblems": [
+      {
+        "id": "algebraic-reals-meager-oq-02",
+        "relationship": "Parent: records the comeagre-null half of the Oxtoby contrast (comeagre ⇏ conull, witnessed by the Liouville numbers); this entry supplies the dual meagre-conull half and packages the symmetric decomposition of ℝ"
+      },
+      {
+        "id": "algebraic-reals-meager",
+        "relationship": "Grandparent: the Baire-category smallness (meagreness) of the algebraic reals, the origin of the measure/category theme"
+      }
+    ],
+    "assumptions": "0 axioms. Relies only on Mathlib's Baire-category infrastructure (IsMeagre, residual), the Liouville residual/measure-zero results, and elementary complement identities. The ordinary foundational triple (propext / Classical.choice / Quot.sound) is inherited from Mathlib and does not count as an assumption.",
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Baire (1899) and Lebesgue (1902) gave two independent notions of 'smallness' for subsets of ℝ: meagre (category-small, a countable union of nowhere-dense sets) and null (measure-small). Oxtoby's 'Measure and Category' (1980) systematically contrasts them, and a recurring theme is that although the two σ-ideals share many formal properties (a duality principle), they are genuinely different: ℝ can be split into a meagre set and a null set whose union is everything. The classic witness is the Liouville numbers, comeagre yet null. The parent entry OQ-02 formalized that half — a comeagre null set. This entry records the mirror image, a meagre set of full measure, and the resulting complementary partition of ℝ.",
+    "problemStatement": "Formalize the dual direction of the parent OQ-02: exhibit a meagre subset of ℝ of full Lebesgue measure (a meagre conull set), completing the symmetric Oxtoby picture in which ℝ decomposes into a comeagre null set and a meagre conull set.",
+    "text": "A 0-sorry, 0-axiom synthesis. The witness is the complement of the Liouville numbers, Lᶜ. By definition IsMeagre s ↔ sᶜ ∈ residual, so Lᶜ is meagre exactly because L is comeagre (isMeagre_compl_of_mem_residual applied to eventually_residual_liouville). And Lᶜ is conull because volume (Lᶜ)ᶜ = volume L = 0 (volume_setOf_liouville). Packaged as real_symmetric_oxtoby: ℝ = L ⊔ Lᶜ with L comeagre-and-null and Lᶜ meagre-and-conull.",
+    "proofStrategy": "The core is the abstract lemma isMeagre_compl_of_mem_residual: unfold IsMeagre Aᶜ to Aᶜᶜ ∈ residual and rewrite with compl_compl to reduce to A ∈ residual. Instantiating at the Liouville numbers gives meagreness of Lᶜ; conullity is compl_compl followed by volume_setOf_liouville. The decomposition uses union_compl_self and disjoint_compl_right for the partition, reusing liouville_residual and liouville_null for the properties of the comeagre-null side.",
+    "keyInsights": [
+      "**Duality by complementation**: the dual of a comeagre null set is a meagre conull set — its literal complement. No new construction is required; the Liouville numbers already encode both halves of the Oxtoby contrast.",
+      "**IsMeagre is complement-of-residual by definition**: isMeagre_compl_of_mem_residual is a two-line unfolding (IsMeagre s := sᶜ ∈ residual, then compl_compl), making the meagreness of Lᶜ immediate from the comeagreness of L.",
+      "**Full measure = complement null**: on ℝ (an infinite measure space) 'full Lebesgue measure' is stated as conullity, volume Sᶜ = 0; for S = Lᶜ this is volume L = 0.",
+      "**Complementary, not merely inequivalent**: the parent shows comeagre ⇏ conull; this entry sharpens it to a single partition ℝ = L ⊔ Lᶜ where one piece is topologically large / measure-small and the other topologically small / measure-large — the two notions of largeness fail to coincide in opposite directions simultaneously.",
+      "**Honest scope**: every ingredient is already in Mathlib; the contribution is the explicit, machine-checked dual statement and the packaged symmetric decomposition the parent leaves implicit."
+    ],
+    "prerequisites": [
+      "Baire category: meagre and residual (comeagre) sets",
+      "The definition IsMeagre s := sᶜ ∈ residual X",
+      "Lebesgue measure on ℝ and the notion of a conull (full-measure) set",
+      "Liouville numbers: residual and Lebesgue-null"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: the dual Oxtoby phenomenon",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "File docstring and imports. Recalls the parent's comeagre-null witness (the Liouville numbers) and frames the dual goal — a meagre set of full Lebesgue measure — with the witness being the complement Lᶜ. Previews the symmetric decomposition ℝ = L ⊔ Lᶜ and the honesty note that all ingredients are standard Mathlib.",
+      "mathContext": "A set is meagre if its complement is comeagre (residual); conull if its complement is Lebesgue-null. The Liouville numbers L are comeagre and null, so Lᶜ is meagre and conull."
+    },
+    {
+      "id": "duality",
+      "title": "Abstract duality: complement of a comeagre set is meagre",
+      "startLine": 64,
+      "endLine": 76,
+      "summary": "Proves isMeagre_compl_of_mem_residual: for any topological space, A ∈ residual ⟹ IsMeagre Aᶜ. Two-line proof unfolding IsMeagre and rewriting Aᶜᶜ = A via compl_compl.",
+      "mathContext": "IsMeagre s := sᶜ ∈ residual X; the complement of a residual set is therefore meagre by double-complement."
+    },
+    {
+      "id": "liouville",
+      "title": "The Liouville numbers: comeagre and null",
+      "startLine": 78,
+      "endLine": 88,
+      "summary": "Recalls from Mathlib the two facts used as the separating witness: the Liouville numbers are residual (eventually_residual_liouville) and Lebesgue-null (volume_setOf_liouville).",
+      "mathContext": "L = {x | Liouville x} ∈ residual ℝ and volume L = 0."
+    },
+    {
+      "id": "dual-witness",
+      "title": "The non-Liouville reals are meagre yet conull",
+      "startLine": 90,
+      "endLine": 113,
+      "summary": "Proves nonLiouville_meagre (Lᶜ is meagre, from the duality lemma), nonLiouville_conull (volume (Lᶜ)ᶜ = 0, from compl_compl + liouville_null), and the headline exists_meagre_conull — a meagre subset of ℝ of full Lebesgue measure.",
+      "mathContext": "Lᶜ is the dual witness: meagre because L is comeagre, conull because L is null."
+    },
+    {
+      "id": "decomposition",
+      "title": "The symmetric Oxtoby decomposition of ℝ",
+      "startLine": 115,
+      "endLine": 149,
+      "summary": "Proves real_symmetric_oxtoby: ℝ = L ⊔ Lᶜ (disjoint, union = univ) with L comeagre-and-null and Lᶜ meagre-and-conull, and oq01_resolution packaging the dual witness with the decomposition.",
+      "mathContext": "A single partition of ℝ witnesses both failures of implication: comeagre ⇏ conull (on L) and meagre ⇏ null (on Lᶜ)."
+    }
+  ]
+}

--- a/src/data/research/problems/algebraic-reals-meager-oq-02-oq-01.json
+++ b/src/data/research/problems/algebraic-reals-meager-oq-02-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "algebraic-reals-meager-oq-02-oq-01",
   "title": "Dual Oxtoby: a meagre set of full Lebesgue measure",
   "phase": "COMPLETED",
-  "status": "graduated",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -31,9 +31,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE (verified 0 sorries / 0 axioms, PR pending). Dual direction of parent OQ-02: a MEAGRE set of FULL Lebesgue measure (the non-Liouville reals Lᶜ), plus the symmetric decomposition ℝ = L ⊔ Lᶜ. Built on Proofs/AlgebraicRealsMeagerOQ02OQ01.lean, 8 theorems, Docker-verified (3.6s, 7743 jobs).",
+    "builtItems": [
+      "isMeagre_compl_of_mem_residual in AlgebraicRealsMeagerOQ02OQ01.lean:73 — abstract duality: A∈residual α ⟹ IsMeagre Aᶜ (any TopologicalSpace), via rw[IsMeagre, compl_compl].",
+      "nonLiouville_meagre:97 + nonLiouville_conull:103 — the non-Liouville reals Lᶜ are meagre and conull (volume (Lᶜ)ᶜ = 0).",
+      "exists_meagre_conull:111 — headline: ∃ meagre S ⊆ ℝ with volume Sᶜ = 0 (a meagre set of full Lebesgue measure).",
+      "real_symmetric_oxtoby:131 — ℝ = L ⊔ Lᶜ (union_compl_self + disjoint_compl_right), L comeagre-and-null, Lᶜ meagre-and-conull; oq01_resolution:143 packages it."
+    ],
+    "insights": [
+      "The dual of a comeagre null set is its literal complement: Lᶜ is meagre (because L is comeagre) and conull (because L is null). No new construction needed — the Liouville numbers already encode both halves of the Oxtoby contrast.",
+      "IsMeagre s is DEFINED as sᶜ ∈ residual X (Mathlib Topology/GDelta/Basic:218), so isMeagre_compl_of_mem_residual (A∈residual ⟹ IsMeagre Aᶜ) is a two-line unfold + compl_compl, valid over any topological space.",
+      "'Full Lebesgue measure' on ℝ (infinite measure space) is formalized as conullity: volume Sᶜ = 0. For S = Lᶜ this is volume L = 0 via compl_compl + volume_setOf_liouville.",
+      "Sharp form of OQ-02: the single partition ℝ = L ⊔ Lᶜ simultaneously witnesses comeagre⇏conull (on L) and meagre⇏null (on Lᶜ); the two largeness notions are exactly complementary, not merely inequivalent."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary

Resolves the seeker-selected open question **algebraic-reals-meager-oq-02-oq-01**: the *dual* direction of the parent OQ-02, completing the symmetric Oxtoby picture.

The parent OQ-02 exhibits a **comeagre yet null** set — the Liouville numbers `L` (topologically large, measure-small). This entry supplies the mirror image: a **meagre yet conull** set — the non-Liouville reals `Lᶜ` (topologically small, measure-large, i.e. **full Lebesgue measure**). No new construction is needed:

- `Lᶜ` is **meagre** because its complement `L` is comeagre (`IsMeagre s := sᶜ ∈ residual`);
- `Lᶜ` is **conull** because `volume (Lᶜ)ᶜ = volume L = 0`.

Packaged as the symmetric decomposition **ℝ = L ⊔ Lᶜ** into a comeagre-null part and a meagre-conull part — the sharp form of OQ-02 showing the two notions of largeness are not merely inequivalent but *exactly complementary* along one partition of ℝ.

## Theorems (`Proofs/AlgebraicRealsMeagerOQ02OQ01.lean`, 8 theorems, 178 lines)

| Theorem | Statement |
|---------|-----------|
| `isMeagre_compl_of_mem_residual` | complement of a residual set is meagre (abstract, any topological space) |
| `nonLiouville_meagre` | the non-Liouville reals are meagre |
| `nonLiouville_conull` | the non-Liouville reals are conull (full measure) |
| `exists_meagre_conull` | ∃ meagre set of full Lebesgue measure (dual Oxtoby headline) |
| `real_symmetric_oxtoby` | ℝ = L ⊔ Lᶜ, comeagre-null ⊔ meagre-conull |
| `oq01_resolution` | dual witness + symmetric decomposition |

## Verification

- **Docker build**: `Built Proofs.AlgebraicRealsMeagerOQ02OQ01 (3.6s)`, 7743 jobs, EXIT 0.
- **0 sorries, 0 axioms** — uses only standard Mathlib (`eventually_residual_liouville`, `volume_setOf_liouville`, `IsMeagre`, `compl_compl`, `union_compl_self`, `disjoint_compl_right`). Ordinary foundational triple inherited from Mathlib.

## Honesty / scope

No new mathematics — the value is the explicit, machine-checked dual statement (a meagre set of full measure) and the packaged symmetric decomposition of ℝ that the parent entry leaves implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)