### PR TITLE
Enrich Denumerability of ℚ closure (denumerability-rationals-oq-05): add base-robustness of 𝔠 insight

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-05/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-05/meta.json
@@ -81,7 +81,8 @@
       "**ℵ₀ absorbs finite operations but not countable powers.** ℵ₀ · ℵ₀ = ℵ₀ (products), #(List ℚ) = ℵ₀ (finite sequences), #(Finset ℚ) = ℵ₀ (finite subsets) — but ℵ₀ ^ ℵ₀ = 𝔠. Finiteness of the operation is exactly the dividing line.",
       "**The ℵ₀-shadow of the continuum results.** This entry is the level-down companion to 𝔠 · 𝔠 = 𝔠 and 𝔠 ^ ℵ₀ = 𝔠: the same absorption laws govern both the smallest infinite cardinal and the continuum, but the *power* operation lifts ℵ₀ strictly up to 𝔠.",
       "**Cantor's gap, made operational.** ℵ₀ < 𝔠 (oq-01) becomes concrete: the rationals are denumerable, yet the rational sequences ℕ → ℚ are not — an uncountable object built entirely from ℚ.",
-      "**Bijection from cardinal arithmetic.** #(ℚ × ℚ) = #ℚ unpacks via `Cardinal.eq` to ℚ × ℚ ≃ ℚ — a pairing of rationals, the ℵ₀ analogue of Cantor's line-plane bijection."
+      "**Bijection from cardinal arithmetic.** #(ℚ × ℚ) = #ℚ unpacks via `Cardinal.eq` to ℚ × ℚ ≃ ℚ — a pairing of rationals, the ℵ₀ analogue of Cantor's line-plane bijection.",
+      "**The boundary value 𝔠 is base-robust: ℚ is not special.** #(ℕ → ℚ) = 𝔠 not because the base is ℚ but because any base κ with 2 ≤ κ ≤ 𝔠 is squeezed by the Cantor–Bernstein sandwich 2^ℵ₀ ≤ κ^ℵ₀ ≤ (2^ℵ₀)^ℵ₀ = 2^(ℵ₀·ℵ₀) = 2^ℵ₀ = 𝔠. So ℕ → ℚ, ℕ → ℤ, ℕ → ℕ, and ℕ → {0,1} all have the same cardinality; `aleph0_power_aleph0` (ℵ₀^ℵ₀ = 𝔠) is one instance of this collapse. The escape from ℵ₀ is driven entirely by the *countably infinite exponent*, not the base."
     ],
     "prerequisites": [
       "Cardinal arithmetic in Mathlib (ℵ₀, 𝔠, multiplication, exponentiation)",


### PR DESCRIPTION
## Enrichment pass — denumerability-rationals-oq-05

This q94 entry is already saturated (5 fully-populated annotations, correct line anchors on all 8 mainTheorems, complete conclusion, accurate counts). Per the size-guardrail SKIP rule I did **not** inflate it — added exactly **one** sharp, mathematically-verifiable keyInsight that the existing four do not cover.

### What's added
A 5th keyInsight explaining why the boundary value `#(ℕ → ℚ) = 𝔠` is **base-robust**: it holds not because the base is ℚ but because any base κ with 2 ≤ κ ≤ 𝔠 is squeezed by the Cantor–Bernstein sandwich

487022^{\aleph_0} \le \kappa^{\aleph_0} \le (2^{\aleph_0})^{\aleph_0} = 2^{\aleph_0\cdot\aleph_0} = 2^{\aleph_0} = \mathfrak c.48702

So ℕ→ℚ, ℕ→ℤ, ℕ→ℕ, and ℕ→{0,1} all have cardinality 𝔠; `aleph0_power_aleph0` (ℵ₀^ℵ₀ = 𝔠) is one instance of this collapse. The escape from ℵ₀ is driven by the *countably infinite exponent*, not the base — which is precisely why the proof routes through `aleph0_power_aleph0`.

### Guardrails
- keyInsights 4 → 5 (cap 12)
- meta.json 14.2 KB → 14.8 KB (cap ~60 KB)
- JSON validated; no content deleted, additive only