### PR TITLE
research(erdos-490-incomplete-01): unconditional upper bound for optimal example [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -755,4 +755,89 @@ theorem bound_is_optimal :
     rw [ge_iff_le]
     linarith [hprod, hsimp]
 
+/-- **Upper bound on the optimal `B` (0 new axioms).** For `N ≥ 4`, the primes in
+`(N/2, N]` satisfy `|optimalB N| · log(N/2) ≤ log 4 · N`.  Each `p ∈ optimalB N` has
+`p > N/2`, so `log(N/2) ≤ log p`; summing gives `|optimalB N| · log(N/2) ≤ ∑ log p =
+θ(N) − θ(N/2) ≤ θ(N) ≤ log 4 · N`, the last step being Mathlib's Chebyshev upper bound
+`Chebyshev.theta_le_log4_mul_x`.  This is the upper-bound companion to
+`primes_upper_half_lower_bound`. -/
+theorem optimalB_card_upper_bound {N : ℕ} (hN : 4 ≤ N) :
+    ((optimalB N).card : ℝ) * Real.log ((N : ℝ) / 2) ≤ Real.log 4 * N := by
+  have hNpos : (0 : ℝ) < (N : ℝ) := by exact_mod_cast (by omega : 0 < N)
+  have hhalf_pos : (0 : ℝ) < (N : ℝ) / 2 := by linarith
+  -- Every prime `p ∈ optimalB N` exceeds `N/2`, so `log(N/2) ≤ log p`.
+  have hlb : ∀ p ∈ optimalB N, Real.log ((N : ℝ) / 2) ≤ Real.log (p : ℝ) := by
+    intro p hp
+    simp only [optimalB, Finset.mem_filter, Finset.mem_range] at hp
+    obtain ⟨_, _, hlt, _⟩ := hp
+    have hNp : (N : ℝ) < 2 * (p : ℝ) := by
+      have : N < 2 * p := by omega
+      exact_mod_cast this
+    exact Real.log_le_log hhalf_pos (by linarith)
+  -- `|B| · log(N/2) ≤ ∑_{p ∈ B} log p` (constant lower bound on each term).
+  have hsum : ((optimalB N).card : ℝ) * Real.log ((N : ℝ) / 2)
+      ≤ ∑ p ∈ optimalB N, Real.log (p : ℝ) := by
+    calc ((optimalB N).card : ℝ) * Real.log ((N : ℝ) / 2)
+        = ∑ _p ∈ optimalB N, Real.log ((N : ℝ) / 2) := by
+          rw [Finset.sum_const, nsmul_eq_mul]
+      _ ≤ ∑ p ∈ optimalB N, Real.log (p : ℝ) := Finset.sum_le_sum hlb
+  -- The sum is `θ(N) − θ(N/2) ≤ θ(N) ≤ log 4 · N`.
+  have heq := theta_gap_eq_sum_optimalB N
+  have hθnn : 0 ≤ Chebyshev.theta ((N / 2 : ℕ) : ℝ) := Chebyshev.theta_nonneg _
+  have hθub : Chebyshev.theta (N : ℝ) ≤ Real.log 4 * N :=
+    Chebyshev.theta_le_log4_mul_x (by positivity)
+  calc ((optimalB N).card : ℝ) * Real.log ((N : ℝ) / 2)
+      ≤ ∑ p ∈ optimalB N, Real.log (p : ℝ) := hsum
+    _ = Chebyshev.theta (N : ℝ) - Chebyshev.theta ((N / 2 : ℕ) : ℝ) := heq.symm
+    _ ≤ Chebyshev.theta (N : ℝ) := by linarith
+    _ ≤ Real.log 4 * N := hθub
+
+/-- **The optimal example attains order `N²/log N` from above (0 new axioms).** For
+`N ≥ 4`, `|optimalA N| · |optimalB N| ≤ log 4 · N² / log N`.  Combined with
+`bound_is_optimal` (the matching `≥ c·N²/log N` lower bound) this shows the explicit
+extremal construction `A = [1, N/2]`, `B = {primes in (N/2, N]}` achieves
+`|A|·|B| = Θ(N²/log N)` — the full order of magnitude of Erdős #490 — *without* invoking
+the deep axiom `szemeredi_theorem` (only Mathlib's Chebyshev upper bound `θ(x) ≤ log 4·x`).
+
+Proof: `|optimalA N| = ⌊N/2⌋ ≤ N/2`, and `optimalB_card_upper_bound` gives
+`|optimalB N| ≤ log 4·N / log(N/2)`.  For `N ≥ 4`, `log(N/2) = log N − log 2 ≥ (1/2) log N`
+(because `log N ≥ log 4 = 2 log 2`), so the product is `≤ (N/2)·log 4·N / ((1/2) log N) =
+log 4·N² / log N`. -/
+theorem optimal_example_upper_bound (N : ℕ) (hN : 4 ≤ N) :
+    ((optimalA N).card * (optimalB N).card : ℝ) ≤ Real.log 4 * N ^ 2 / Real.log N := by
+  have hNR : (4 : ℝ) ≤ (N : ℝ) := by exact_mod_cast hN
+  have hNnn : (0 : ℝ) ≤ (N : ℝ) := by linarith
+  have hlogN : 0 < Real.log N := Real.log_pos (by linarith)
+  have hlog4nn : (0 : ℝ) ≤ Real.log 4 := Real.log_nonneg (by norm_num)
+  have hlogN4 : Real.log 4 ≤ Real.log N := Real.log_le_log (by norm_num) hNR
+  -- `log(N/2) = log N − log 2`, and `log 4 = 2 log 2`.
+  have hlogNhalf_eq : Real.log ((N : ℝ) / 2) = Real.log N - Real.log 2 :=
+    Real.log_div (by exact_mod_cast (by omega : N ≠ 0)) (by norm_num)
+  have hlog4 : Real.log 4 = 2 * Real.log 2 := by
+    rw [show (4 : ℝ) = 2 ^ 2 by norm_num, Real.log_pow]; norm_num
+  -- `log(N/2) ≥ (1/2) log N > 0`.
+  have hhalf_lb : Real.log N / 2 ≤ Real.log ((N : ℝ) / 2) := by
+    rw [hlogNhalf_eq]
+    have h2 : 2 * Real.log 2 ≤ Real.log N := by rw [← hlog4]; exact hlogN4
+    linarith
+  have hhalf_pos : 0 < Real.log ((N : ℝ) / 2) := by linarith
+  -- `|optimalA N| ≤ N/2`, and the two cardinalities are nonnegative.
+  have hAcard : (optimalA N).card = N / 2 := optimalA_card N
+  have hAR : ((optimalA N).card : ℝ) ≤ (N : ℝ) / 2 := by
+    rw [hAcard]
+    have hnat : (N / 2 : ℕ) * 2 ≤ N := by omega
+    have : ((N / 2 : ℕ) : ℝ) * 2 ≤ (N : ℝ) := by exact_mod_cast hnat
+    linarith
+  have hA0 : (0 : ℝ) ≤ ((optimalA N).card : ℝ) := by positivity
+  have hB0 : (0 : ℝ) ≤ ((optimalB N).card : ℝ) := by positivity
+  have hBub := optimalB_card_upper_bound hN
+  -- Clear the denominator and finish with the nonnegative-product chain.
+  rw [le_div_iff₀ hlogN]
+  nlinarith [hBub, hAR, hhalf_lb, hA0, hB0, hlogN.le, hlog4nn, hNnn,
+    mul_nonneg hA0 hB0,
+    mul_le_mul_of_nonneg_left hBub hA0,
+    mul_le_mul_of_nonneg_right hAR (mul_nonneg hlog4nn hNnn),
+    mul_le_mul_of_nonneg_left (show Real.log N ≤ 2 * Real.log ((N : ℝ) / 2) by linarith)
+      (mul_nonneg hA0 hB0)]
+
 end Erdos490

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -470,3 +470,43 @@ main's `IsSubsetUpTo`, and OQ01's `HasDistinctProducts'` = main's `ProductMapInj
 
 **Still open:** `szemeredi_upper` (= `szemeredi_theorem`, the deep N²/log N upper bound) stays
 axiomatized in both files — the genuinely hard result, not attackable.
+
+## Session 2026-07-08 (researcher-2) — optimal example upper bound (0 new axioms)
+
+**Mode**: ACT (SOLVED-side, look-outward). **Outcome**: progress — added the matching
+UPPER bound for the explicit optimal example, so it is now Θ(N²/log N) fully verified
+without the deep `szemeredi_theorem` axiom.
+
+### What I Did (verified, 0 new axioms)
+- `optimalB_card_upper_bound {N} (hN : 4 ≤ N) : |optimalB N|·log(N/2) ≤ log 4·N`.
+  Each prime `p ∈ (N/2, N]` has `p > N/2` ⇒ `log(N/2) ≤ log p` (`Real.log_le_log`), so
+  `|optimalB|·log(N/2) ≤ ∑_{p∈optimalB} log p = θ(N)−θ(N/2)` (existing
+  `theta_gap_eq_sum_optimalB`) `≤ θ(N)` (`Chebyshev.theta_nonneg`) `≤ log 4·N`
+  (**Mathlib `Chebyshev.theta_le_log4_mul_x`** — a theorem, not an axiom).
+- `optimal_example_upper_bound (N) (hN : 4 ≤ N) : |optimalA N|·|optimalB N| ≤ log 4·N²/log N`.
+  `|optimalA N| = ⌊N/2⌋ ≤ N/2`; `log(N/2) = log N − log 2 ≥ (1/2) log N` for `N ≥ 4`
+  (because `log N ≥ log 4 = 2 log 2`), giving `|optimalB| ≤ 2·log 4·N/log N`; multiply.
+  Denominator cleared with `le_div_iff₀ hlogN`, closed by `nlinarith` with the three
+  monotone-product hints (`mul_le_mul_of_nonneg_left/​right`).
+
+Together with the pre-existing `bound_is_optimal` (`≥ c·N²/log N`), the explicit extremal
+construction `A=[1,N/2]`, `B={primes in (N/2,N]}` achieves `|A||B| = Θ(N²/log N)` — the full
+order of magnitude of #490 — with **no** dependence on `szemeredi_theorem`.
+
+### Verification
+Docker `docker-build.sh Proofs.Erdos490Problem` → EXIT 0 (7744 jobs). `#print axioms` of both
+new theorems = `[propext, Classical.choice, Quot.sound]` (0 new axioms). File 758 → 843 lines,
+23 → 25 theorems, still 1 axiom (`szemeredi_theorem`). Gallery meta leanFile counts updated.
+
+### Gotchas / API
+- `Chebyshev.theta_le_log4_mul_x {x} (hx : 0 ≤ x) : θ x ≤ log 4 * x` (Mathlib, theorem).
+- `Real.log_div (hx : x≠0) (hy : y≠0) : log(x/y) = log x − log y`; `Real.log_pow` for
+  `log 4 = 2 log 2` (`rw [show (4:ℝ)=2^2 by norm_num, Real.log_pow]; norm_num`).
+- `Chebyshev.theta_nonneg` gives `θ(N/2) ≥ 0` to drop it from the θ-gap.
+- 3× SIGBUS exit-135 (no line number) on my file's compile + one corrupt `LocallyFullyFaithful.ir`
+  invalid-header (fixed via `docker-build.sh --repair-cache`); pure fleet memory pressure, not
+  code — retry-loop-of-3 went green. `#print axioms` build also needed a 135 retry.
+
+### Terminus
+Lower-bound side of #490 is complete. `szemeredi_theorem` (the deep N²/log N UPPER bound for
+arbitrary distinct-product sets, Szemerédi 1976) is out of scope; correctly axiomatized.

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -217,9 +217,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 758,
+    "lineCount": 843,
     "axiomCount": 1,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-490-incomplete-01.json
+++ b/src/data/research/problems/erdos-490-incomplete-01.json
@@ -26,9 +26,9 @@
     ]
   },
   "currentState": {
-    "summary": "AXIOM ELIMINATED (chebyshev_theta_upper_half_lower_bound → theorem). Erdos490Problem.lean now builds against Mathlib 4.26 with 0 sorries and 1 axiom (szemeredi_theorem, the deep N²/log N upper bound; correctly stays axiomatized). The Chebyshev θ-gap lower bound θ(N)−θ(N/2) ≥ c·N — the last analytic axiom of the lower-bound half — is now fully proved: new lemma Erdos490Cheb.erdos490_analytic_tail (log n, √(2n)·log(2n) = o(n) via Real.isLittleO_log_id_atTop / isLittleO_log_rpow_atTop) supplies the analytic tail; combined with the existing central-binomial estimate theta_gap_lower_bound, a nat↔real bridge, the N↦⌊N/2⌋ alignment (Chebyshev.theta_mono), and a Bertrand-based θ-gap ≥ log 2 small-N base case. Docker build verified green (7744 jobs). Files: Erdos490Problem.lean 660→758 lines, 2→1 axioms; Erdos490Chebyshev.lean 206→257 lines, +erdos490_analytic_tail.",
+    "summary": "OPTIMAL EXAMPLE NOW TWO-SIDED (0 new axioms). Added optimalB_card_upper_bound (|optimalB N|·log(N/2) ≤ log4·N, via Mathlib Chebyshev.theta_le_log4_mul_x) and optimal_example_upper_bound (|optimalA N|·|optimalB N| ≤ log4·N²/logN for N≥4). Together with the existing lower bound bound_is_optimal (≥ c·N²/logN) this establishes the explicit extremal construction A=[1,N/2], B={primes in (N/2,N]} achieves |A||B|=Θ(N²/logN) — the full order of magnitude of Erdős #490 — WITHOUT invoking the deep axiom szemeredi_theorem (only Mathlib's Chebyshev θ upper bound). Docker build green (7744 jobs); #print axioms = [propext, Classical.choice, Quot.sound] for both. Erdos490Problem.lean 758→843 lines, 23→25 theorems, still 1 axiom (szemeredi_theorem).",
     "outcome": "progress",
-    "nextAction": "None from the lower-bound side. The sole remaining axiom szemeredi_theorem (N²/log N upper bound) is the deep result of the problem — out of scope for elimination."
+    "nextAction": "None tractable. The sole remaining axiom szemeredi_theorem (the deep N²/logN UPPER bound for arbitrary distinct-product A,B) is Szemerédi 1976 — out of scope for elimination. Both the lower AND upper bound of the explicit optimal example are now fully verified (0 axioms beyond foundational)."
   },
   "knowledge": {
     "insights": [
@@ -43,7 +43,8 @@
       "θ→π bridge is elementary and now verified: θ(N)−θ(N/2)=∑_{N/2<p≤N} log p (= sum over optimalB via Finset.sum_sdiff_eq_sub on prime-filtered Ioc intervals), and each log p ≤ log N gives θ-gap ≤ |optimalB|·log N; dividing by log N turns any Chebyshev θ lower bound directly into the π(N)−π(N/2) ≳ N/log N bound.",
       "The Chebyshev θ-gap axiom θ(N)−θ(N/2)≥c·N has a known elementary proof via the central binomial coefficient (Erdős's Bertrand argument): primes n<p≤2n divide C(2n,n) exactly once, and small primes ≤2n/3 contribute at most (2n)^√(2n)·4^(2n/3). Mathlib's Bertrand internals (factorization_centralBinom_*, pow_factorization_choose_le, primorial_le_4_pow) are PUBLIC and suffice for the combinatorial half.",
       "Mathlib's Mathlib.NumberTheory.Chebyshev explicitly lists 'Prove Chebyshev's lower bound' as an open TODO — so a θ lower bound is genuinely NOT available and must be built.",
-      "Remaining to fully eliminate the axiom: (a) the analytic tail √(2n)·log(2n)=o(n) and log n=o(n) (Mathlib has Real.isLittleO_log_id_atTop); (b) small-n reconciliation via Bertrand (finite min); (c) alignment (2n,n)↦(N,N/2) via θ monotonicity."
+      "Remaining to fully eliminate the axiom: (a) the analytic tail √(2n)·log(2n)=o(n) and log n=o(n) (Mathlib has Real.isLittleO_log_id_atTop); (b) small-n reconciliation via Bertrand (finite min); (c) alignment (2n,n)↦(N,N/2) via θ monotonicity.",
+      "2026-07-08 (researcher-2): the optimal example's UPPER bound is unconditional (0 new axioms): |optimalB N| ≤ log4·N/log(N/2) because each prime p∈(N/2,N] has log p ≥ log(N/2), so |optimalB|·log(N/2) ≤ ∑log p = θ(N)−θ(N/2) ≤ θ(N) ≤ log4·N (Mathlib Chebyshev.theta_le_log4_mul_x). With log(N/2)=logN−log2 ≥ (1/2)logN for N≥4 (since logN≥log4=2log2), and |optimalA|=⌊N/2⌋≤N/2, get |A||B| ≤ log4·N²/logN. This is the matching upper bound to bound_is_optimal, so the optimal example is Θ(N²/logN) fully verified — no dependence on szemeredi_theorem."
     ],
     "builtItems": [
       "Build repair: Nat.card_Icc, open scoped Classical, orphan-comment fixes (Erdos490Problem.lean)",
@@ -61,7 +62,9 @@
       "Erdos490Chebyshev.lean:centralBinom_le_small_mul_large — centralBinom n ≤ (2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n}p (0-axiom, the combinatorial crux)",
       "Erdos490Chebyshev.lean:four_pow_lt_bound — 4^n < n·(2n)^√(2n)·4^(2n/3)·∏_{n<p≤2n}p (0-axiom)",
       "Erdos490Chebyshev.lean:theta_gap_eq_log_prod — θ(2n)−θ(n) = log ∏_{n<p≤2n}p (0-axiom)",
-      "Erdos490Chebyshev.lean:theta_gap_lower_bound — θ(2n)−θ(n) ≥ n·log4−⌊2n/3⌋·log4−log n−√(2n)·log(2n) (0-axiom; reduces axiom to analytic tail)"
+      "Erdos490Chebyshev.lean:theta_gap_lower_bound — θ(2n)−θ(n) ≥ n·log4−⌊2n/3⌋·log4−log n−√(2n)·log(2n) (0-axiom; reduces axiom to analytic tail)",
+      "optimalB_card_upper_bound (Erdos490Problem.lean) — |optimalB N|·log(N/2) ≤ log4·N, 0 new axioms",
+      "optimal_example_upper_bound (Erdos490Problem.lean) — |optimalA N|·|optimalB N| ≤ log4·N²/logN for N≥4, 0 new axioms; matches bound_is_optimal to give Θ(N²/logN) for the optimal example without szemeredi_theorem"
     ],
     "mathlibGaps": [
       "No prime-counting lower bound (π(N) − π(N/2)) readily available for the optimal-example lower bound.",


### PR DESCRIPTION
## Summary

Erdős #490 (distinct products, `|A||B| ≪ N²/log N`, Szemerédi 1976). The existing file already proved the **lower** bound for the explicit optimal example (`bound_is_optimal`, `≥ c·N²/log N`) fully (0 axioms). This PR adds the matching **upper** bound, so the extremal construction is now `Θ(N²/log N)` fully verified — *without* invoking the deep axiom `szemeredi_theorem`.

Two new theorems (both `[propext, Classical.choice, Quot.sound]` only):

- **`optimalB_card_upper_bound`** `(N ≥ 4)`: `|optimalB N| · log(N/2) ≤ log 4 · N`. Each prime `p ∈ (N/2, N]` has `p > N/2`, so `log(N/2) ≤ log p`; summing gives `|optimalB N| · log(N/2) ≤ ∑ log p = θ(N) − θ(N/2) ≤ θ(N) ≤ log 4 · N`, the last step being Mathlib's `Chebyshev.theta_le_log4_mul_x` (a theorem, not an axiom).
- **`optimal_example_upper_bound`** `(N ≥ 4)`: `|optimalA N| · |optimalB N| ≤ log 4 · N² / log N`. Uses `|optimalA N| = ⌊N/2⌋ ≤ N/2` and `log(N/2) = log N − log 2 ≥ (1/2) log N` for `N ≥ 4` (since `log N ≥ log 4 = 2 log 2`).

Together with `bound_is_optimal`, the explicit construction `A = [1, N/2]`, `B = {primes in (N/2, N]}` achieves `|A||B| = Θ(N²/log N)`.

## Verification

- `docker-build.sh Proofs.Erdos490Problem` → **EXIT 0** (7744 jobs).
- `#print axioms` of both new theorems = `[propext, Classical.choice, Quot.sound]` — **0 new axioms, 0 sorries**.
- `Erdos490Problem.lean` 758 → 843 lines, 23 → 25 theorems, still **1 axiom** (`szemeredi_theorem`, the deep `N²/log N` upper bound for arbitrary distinct-product sets — out of scope for elimination).

## Terminus note

The lower-bound side of #490 is now complete on both the abstract statement and the explicit example. The sole remaining axiom `szemeredi_theorem` is Szemerédi's 1976 theorem and is correctly axiomatized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)