### PR TITLE
research(erdos-1026-oq-05): monotonic-decomposition lower bound [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1026OQ05.lean
+++ b/proofs/Proofs/Erdos1026OQ05.lean
@@ -1,0 +1,184 @@
+import Mathlib
+
+/-
+# erdos-1026-oq-05: Lower bound on monotonic decompositions of a sequence
+
+Erdős Problem #1026 concerns monotonic subsequences: by Erdős–Szekeres, every sequence of
+`k² + 1` distinct reals contains a monotonic subsequence of length `k + 1`, and the
+optimization variant studies the maximum *sum* carried by such a subsequence.
+
+**OQ-05** asks to extend the picture from single monotonic subsequences to *decompositions*
+of the whole sequence into monotonic pieces (the object underlying Hanani's 1957 theorem,
+`MonotonicDecomposition` in `Erdos1026Problem.lean`). The parent file states the
+`MonotonicDecomposition` structure but proves *nothing* about how many parts such a
+decomposition must use — Hanani's `(√2 + o(1))√n` bound lives only in a comment.
+
+This file proves, axiom-free, the elementary but genuine **lower bound** direction
+(the Mirsky/Dilworth half): *every* monotonic decomposition of a sequence into pieces that
+are each increasing or decreasing must use enough parts to cover the sequence, namely
+
+    n ≤ numParts · max (LIS seq) (LDS seq)         (`monotonicDecomposition_numParts_lower_bound`)
+
+where `LIS`/`LDS` are the longest increasing / decreasing subsequence lengths. The proof is
+a clean counting argument: the parts' index maps assemble into a surjection from their
+disjoint union onto `Fin n`, so `n` is at most the sum of the part lengths; and each part,
+being monotonic, has length at most `LIS seq` (if increasing) or `LDS seq` (if decreasing),
+hence at most `max (LIS seq) (LDS seq)`.
+
+Two consequences are recorded:
+* the contrapositive `monotonicDecomposition_numParts_ge` — you cannot cover a length-`n`
+  sequence with `numParts` monotonic pieces once `numParts · max(LIS, LDS) < n`; and
+* the fact that a decomposition always exists (`singletonDecomposition`), so the bound is
+  about a nonempty class of objects and brackets `numParts` from below (the trivial
+  singleton decomposition gives the matching crude upper bound `numParts ≤ n`).
+
+For the extremal Erdős–Szekeres sequences, where the longest monotone run has length only
+`≈ √n`, the bound forces `numParts ≳ √n` monotone pieces — the lower-bound side of Hanani's
+theorem. The matching **upper** bound (that `O(√n)` pieces always *suffice*) is the hard
+constructive direction and is left open, stated but not axiomatized.
+
+The framework is self-contained: it re-states the minimal `Subsequence` / `LIS` / `LDS` /
+`MonotonicDecomposition` interface of `Erdos1026Problem.lean` rather than importing it, since
+that file depends on `Archive.Wiedijk100Theorems`. No axioms, no sorries.
+-/
+
+open Finset
+
+namespace Erdos1026OQ05
+
+/-- A sequence of `n` real numbers (mirrors `Erdos1026.RealSeq`). -/
+def RealSeq (n : ℕ) := Fin n → ℝ
+
+/-- A subsequence, given by a strictly increasing index map (mirrors
+`Erdos1026.Subsequence`). -/
+structure Subsequence (n m : ℕ) where
+  indices : Fin m → Fin n
+  strictMono : StrictMono indices
+
+variable {n m : ℕ}
+
+/-- A subsequence is (exactly) increasing: its values strictly increase. -/
+def IsIncreasing (seq : RealSeq n) (sub : Subsequence n m) : Prop :=
+  StrictMono (seq ∘ sub.indices)
+
+/-- A subsequence is (exactly) decreasing: its values strictly decrease. -/
+def IsDecreasing (seq : RealSeq n) (sub : Subsequence n m) : Prop :=
+  ∀ i j : Fin m, i < j → seq (sub.indices j) < seq (sub.indices i)
+
+/-- A subsequence is monotonic if it is increasing or decreasing. -/
+def IsMonotonic (seq : RealSeq n) (sub : Subsequence n m) : Prop :=
+  IsIncreasing seq sub ∨ IsDecreasing seq sub
+
+/-- A subsequence has length at most that of its parent sequence. -/
+lemma subsequence_length_le (sub : Subsequence n m) : m ≤ n := by
+  have := Fintype.card_le_of_injective sub.indices sub.strictMono.injective
+  simpa using this
+
+/-- The longest increasing subsequence length. -/
+noncomputable def LIS (seq : RealSeq n) : ℕ :=
+  sSup {m | ∃ sub : Subsequence n m, IsIncreasing seq sub}
+
+/-- The longest decreasing subsequence length. -/
+noncomputable def LDS (seq : RealSeq n) : ℕ :=
+  sSup {m | ∃ sub : Subsequence n m, IsDecreasing seq sub}
+
+/-- The set of achievable increasing subsequence lengths is bounded above by `n`. -/
+lemma lis_bddAbove (seq : RealSeq n) :
+    BddAbove {m | ∃ sub : Subsequence n m, IsIncreasing seq sub} :=
+  ⟨n, fun _ ⟨sub, _⟩ => subsequence_length_le sub⟩
+
+/-- The set of achievable decreasing subsequence lengths is bounded above by `n`. -/
+lemma lds_bddAbove (seq : RealSeq n) :
+    BddAbove {m | ∃ sub : Subsequence n m, IsDecreasing seq sub} :=
+  ⟨n, fun _ ⟨sub, _⟩ => subsequence_length_le sub⟩
+
+/-- An increasing subsequence has length at most `LIS`. -/
+lemma len_le_LIS_of_increasing {seq : RealSeq n} {sub : Subsequence n m}
+    (h : IsIncreasing seq sub) : m ≤ LIS seq :=
+  le_csSup (lis_bddAbove seq) ⟨sub, h⟩
+
+/-- A decreasing subsequence has length at most `LDS`. -/
+lemma len_le_LDS_of_decreasing {seq : RealSeq n} {sub : Subsequence n m}
+    (h : IsDecreasing seq sub) : m ≤ LDS seq :=
+  le_csSup (lds_bddAbove seq) ⟨sub, h⟩
+
+/-- A monotonic subsequence has length at most `max (LIS seq) (LDS seq)`. -/
+lemma len_le_max_of_monotonic {seq : RealSeq n} {sub : Subsequence n m}
+    (h : IsMonotonic seq sub) : m ≤ max (LIS seq) (LDS seq) := by
+  rcases h with hInc | hDec
+  · exact (len_le_LIS_of_increasing hInc).trans (le_max_left _ _)
+  · exact (len_le_LDS_of_decreasing hDec).trans (le_max_right _ _)
+
+/-- A decomposition of a sequence into monotonic subsequences whose images cover every
+index (mirrors `Erdos1026.MonotonicDecomposition`). -/
+structure MonotonicDecomposition (n : ℕ) (seq : RealSeq n) where
+  numParts : ℕ
+  parts : Fin numParts → Σ m, Subsequence n m
+  monotonic : ∀ i, IsMonotonic seq (parts i).2
+  disjoint : ∀ i j k₁ k₂, i ≠ j →
+    (parts i).2.indices k₁ ≠ (parts j).2.indices k₂
+  covering : ∀ k : Fin n, ∃ i m hm, (parts i).2.indices ⟨m, hm⟩ = k
+
+/-- **OQ-05 lower bound.** Every monotonic decomposition of a length-`n` sequence uses
+enough parts that `numParts · max(LIS, LDS) ≥ n`. Equivalently, you cannot cover the
+sequence with fewer than `n / max(LIS, LDS)` monotone pieces.
+
+Proof: the parts' index maps assemble into a surjection `g` from the disjoint union
+`Σ i, Fin (length of part i)` onto `Fin n` (this is exactly the covering condition), so
+`n = |Fin n| ≤ Σ i, (length of part i)`. Each part is monotonic, hence has length at most
+`max (LIS seq) (LDS seq)`, and summing the constant bound over the `numParts` parts gives the
+claim. -/
+theorem monotonicDecomposition_numParts_lower_bound
+    (seq : RealSeq n) (D : MonotonicDecomposition n seq) :
+    n ≤ D.numParts * max (LIS seq) (LDS seq) := by
+  classical
+  -- The parts' index maps, packaged as one map out of the disjoint union of the parts.
+  let g : (Σ i : Fin D.numParts, Fin (D.parts i).1) → Fin n :=
+    fun p => (D.parts p.1).2.indices p.2
+  -- Covering says this map is surjective.
+  have hsurj : Function.Surjective g := by
+    intro k
+    obtain ⟨i, m, hm, hk⟩ := D.covering k
+    exact ⟨⟨i, ⟨m, hm⟩⟩, hk⟩
+  -- Hence `n = |Fin n| ≤ |Σ i, Fin (part i length)| = Σ i, (part i length)`.
+  have hcard : Fintype.card (Fin n)
+      ≤ Fintype.card (Σ i : Fin D.numParts, Fin (D.parts i).1) :=
+    Fintype.card_le_of_surjective g hsurj
+  rw [Fintype.card_fin, Fintype.card_sigma] at hcard
+  simp only [Fintype.card_fin] at hcard
+  refine hcard.trans ?_
+  -- Each part is monotonic, so its length is at most `max (LIS seq) (LDS seq)`.
+  calc ∑ i, (D.parts i).1
+      ≤ ∑ _i : Fin D.numParts, max (LIS seq) (LDS seq) :=
+        Finset.sum_le_sum (fun i _ => len_le_max_of_monotonic (D.monotonic i))
+    _ = D.numParts * max (LIS seq) (LDS seq) := by
+        rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+
+/-- Division form: any monotonic decomposition uses at least `n / max(LIS, LDS)` parts.
+(For `max = 0` the sequence is empty and the bound `0 ≤ numParts` is trivial.) -/
+theorem monotonicDecomposition_numParts_ge
+    (seq : RealSeq n) (D : MonotonicDecomposition n seq) :
+    n / max (LIS seq) (LDS seq) ≤ D.numParts := by
+  apply Nat.div_le_of_le_mul
+  rw [Nat.mul_comm]
+  exact monotonicDecomposition_numParts_lower_bound seq D
+
+/-- Any function out of `Fin 1` is (vacuously) strictly monotone: there are no `a < b`. -/
+lemma fin_one_strictMono {α : Type*} [Preorder α] (f : Fin 1 → α) : StrictMono f := by
+  intro a b hab
+  exact absurd hab (by simp [Fin.lt_def])
+
+/-- Every sequence admits a monotonic decomposition: split it into `n` singleton parts.
+A single element is (vacuously) increasing, so each part is monotonic; the parts obviously
+cover and are pairwise disjoint. This shows `MonotonicDecomposition` is a nonempty class and
+gives the crude upper bound `numParts = n`, which together with
+`monotonicDecomposition_numParts_lower_bound` brackets the optimal number of parts in
+`[n / max(LIS, LDS), n]`. -/
+def singletonDecomposition (seq : RealSeq n) : MonotonicDecomposition n seq where
+  numParts := n
+  parts := fun i => ⟨1, ⟨fun _ => i, fin_one_strictMono _⟩⟩
+  monotonic := fun _ => Or.inl (fin_one_strictMono _)
+  disjoint := fun _ _ _ _ hij => hij
+  covering := fun k => ⟨k, 0, Nat.one_pos, rfl⟩
+
+end Erdos1026OQ05

--- a/src/data/proofs/erdos-1026-oq-05/annotations.json
+++ b/src/data/proofs/erdos-1026-oq-05/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "monotonic-interface",
+    "proofId": "erdos-1026-oq-05",
+    "range": {
+      "startLine": 55,
+      "endLine": 68
+    },
+    "type": "definition",
+    "title": "Monotonic Subsequences on a Self-Contained Interface",
+    "content": "A Subsequence n m is a strictly monotone index map Fin m → Fin n; IsIncreasing means seq ∘ indices is strictly increasing, IsDecreasing means it is strictly decreasing (values fall as indices rise), and IsMonotonic is their disjunction. These mirror Erdos1026Problem.lean but are re-stated locally so the file needs only `import Mathlib` and avoids the Archive dependency of the parent.",
+    "mathContext": "$$\\text{monotonic}(\\iota)\\iff \\mathrm{seq}\\circ\\iota \\text{ strictly monotone or strictly antitone}.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotonic subsequence",
+      "strictly monotone index maps",
+      "Erdős–Szekeres"
+    ],
+    "prerequisites": [
+      "order on ℝ",
+      "StrictMono"
+    ]
+  },
+  {
+    "id": "len-le-max",
+    "proofId": "erdos-1026-oq-05",
+    "range": {
+      "startLine": 96,
+      "endLine": 113
+    },
+    "type": "insight",
+    "title": "A Monotonic Part Is No Longer Than the Longest Monotone Run",
+    "content": "LIS and LDS are the suprema of achievable increasing / decreasing subsequence lengths, each bounded above by n (via subsequence_length_le, since an injective index map cannot exceed the parent length). len_le_max_of_monotonic then bounds any monotonic subsequence: if increasing its length is ≤ LIS, if decreasing ≤ LDS, so in all cases ≤ max(LIS, LDS). This single inequality is the only place monotonicity enters the decomposition bound, and it is what ties the number of parts to the longest-monotone-run parameter.",
+    "mathContext": "$$m \\le \\mathrm{LIS}\\ (\\text{inc}),\\quad m \\le \\mathrm{LDS}\\ (\\text{dec}) \\;\\Rightarrow\\; m \\le \\max(\\mathrm{LIS},\\mathrm{LDS}).$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "longest increasing subsequence",
+      "le_csSup",
+      "supremum of achievable lengths"
+    ],
+    "prerequisites": [
+      "sSup and BddAbove on ℕ",
+      "injective maps and cardinality"
+    ]
+  },
+  {
+    "id": "decomposition-lower-bound",
+    "proofId": "erdos-1026-oq-05",
+    "range": {
+      "startLine": 131,
+      "endLine": 157
+    },
+    "type": "theorem",
+    "title": "The Mirsky/Dilworth Lower Bound on Decomposition Size",
+    "content": "monotonicDecomposition_numParts_lower_bound proves n ≤ numParts · max(LIS, LDS) for every monotonic decomposition. The covering condition says the map g : (Σ i, Fin (part i length)) → Fin n, (i, j) ↦ (part i).indices j, is surjective; so Fintype.card_le_of_surjective gives n = |Fin n| ≤ |Σ i, Fin (part i length)|, which by Fintype.card_sigma equals the sum of the part lengths. Bounding each summand by max(LIS, LDS) (len_le_max_of_monotonic) and summing the constant over numParts parts finishes. This is exactly the Mirsky/Dilworth lower-bound half of Hanani's decomposition theorem.",
+    "mathContext": "$$n = |\\mathrm{Fin}\\,n| \\le \\sum_i |\\text{part}_i| \\le \\mathrm{numParts}\\cdot\\max(\\mathrm{LIS},\\mathrm{LDS}).$$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Dilworth's theorem",
+      "Mirsky's theorem",
+      "Fintype.card_sigma",
+      "surjection cardinality bound"
+    ],
+    "prerequisites": [
+      "cardinality of a sigma type",
+      "Finset.sum_le_sum and Finset.sum_const"
+    ]
+  },
+  {
+    "id": "division-form-and-bracket",
+    "proofId": "erdos-1026-oq-05",
+    "range": {
+      "startLine": 159,
+      "endLine": 184
+    },
+    "type": "insight",
+    "title": "Division Form, Existence, and the Bracket",
+    "content": "monotonicDecomposition_numParts_ge rephrases the bound as numParts ≥ n / max(LIS, LDS) via Nat.div_le_of_le_mul. The singleton decomposition — each element its own vacuously-monotonic part (fin_one_strictMono: any map out of Fin 1 is strictly monotone since there are no a < b) — shows MonotonicDecomposition is a nonempty class and gives the crude upper bound numParts ≤ n. Together the optimal number of parts is bracketed in [n / max(LIS, LDS), n]. On Erdős–Szekeres extremal sequences (max(LIS, LDS) ≈ √n) the lower bound forces ≳ √n parts, matching Hanani's O(√n) in order; the constructive upper bound is left open.",
+    "mathContext": "$$\\mathrm{numParts} \\in \\left[\\; \\lfloor n/\\max(\\mathrm{LIS},\\mathrm{LDS})\\rfloor,\\; n \\;\\right].$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hanani's theorem",
+      "vacuous strict monotonicity on Fin 1",
+      "Nat.div_le_of_le_mul"
+    ],
+    "prerequisites": [
+      "natural-number division inequalities",
+      "structures in Lean"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "erdos-1026-oq-05",
+  "title": "Erdős #1026 OQ-05: A Lower Bound on Monotonic Decompositions",
+  "slug": "erdos-1026-oq-05",
+  "description": "Open question OQ-05 of Erdős Problem #1026 (monotonic subsequence sum optimization) asks to extend the picture from single monotonic subsequences to decompositions of the whole sequence into monotonic pieces — the object underlying Hanani's 1957 theorem, formalized as MonotonicDecomposition in the parent file. That parent states the MonotonicDecomposition structure but proves nothing about how many parts such a decomposition must use; Hanani's (√2 + o(1))√n bound lives only in a comment. This entry proves, axiom-free, the elementary but genuine Mirsky/Dilworth lower-bound half: every monotonic decomposition of a length-n sequence satisfies n ≤ numParts · max(LIS, LDS) (monotonicDecomposition_numParts_lower_bound), equivalently numParts ≥ n / max(LIS, LDS) (monotonicDecomposition_numParts_ge). The proof is a clean counting argument: the parts' index maps assemble into a surjection from their disjoint union onto Fin n (exactly the covering condition), so n is at most the sum of the part lengths; and each part, being monotonic, has length at most the longest increasing subsequence LIS (if increasing) or longest decreasing subsequence LDS (if decreasing), hence at most their max. A trivial singleton decomposition is exhibited (singletonDecomposition), showing the class is nonempty and giving the matching crude upper bound numParts ≤ n, so the optimal number of parts is bracketed in [n / max(LIS, LDS), n]. For the extremal Erdős–Szekeres sequences, where the longest monotone run has length only ≈ √n, the bound forces numParts ≳ √n pieces — the lower-bound side of Hanani's theorem. The matching upper bound (that O(√n) pieces always suffice) is the hard constructive direction and is left open, stated but not axiomatized. No axioms, no sorries.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://www.erdosproblems.com/1026",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1026OQ05.lean",
+    "tags": [
+      "combinatorics",
+      "order-theory",
+      "erdos-szekeres",
+      "monotonic-subsequences",
+      "dilworth",
+      "decomposition",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 184,
+    "assumptions": "None. The file introduces no axioms and no sorries; every theorem depends only on the standard foundational axioms propext / Classical.choice / Quot.sound. Only the lower-bound (Mirsky/Dilworth) direction of the decomposition problem is proved; the hard upper-bound direction of OQ-05 — that O(√n) monotone pieces always suffice (Hanani 1957) — is stated in prose as the remaining open direction, not assumed.",
+    "dateAdded": "2026-07-08",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 9
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1026 concerns monotonic subsequences. The Erdős–Szekeres theorem (1935) guarantees that every sequence of k²+1 distinct reals contains a monotonic subsequence of length k+1. Dually, Hanani (1957) showed the whole sequence can be partitioned into few monotonic subsequences — at most (√2 + o(1))√n of them — and the optimization variant studies the sums such pieces carry. The parent gallery formalization records the MonotonicDecomposition structure but proves no quantitative bound on the number of parts. This entry supplies the elementary lower bound that any such decomposition must obey.",
+    "problemStatement": "**OQ-05**: Extend Erdős #1026 from single monotonic subsequences to k-monotonic decompositions of the whole sequence — partitions into pieces that are each increasing or decreasing. How many pieces are required?",
+    "text": "We re-state the minimal Subsequence / LIS / LDS / MonotonicDecomposition interface and prove the Mirsky/Dilworth lower bound: every monotonic decomposition of a length-n sequence uses at least n / max(LIS, LDS) parts. The bound is tight in order of magnitude against the Erdős–Szekeres extremal sequences (longest monotone run ≈ √n forces ≈ √n parts), pinning the lower-bound side of Hanani's theorem. The constructive upper bound is left open.",
+    "proofStrategy": "Self-contained over a minimal Subsequence n m (a strictly monotone index map Fin m → Fin n), re-stated rather than imported because the parent Erdos1026Problem.lean depends on Archive.Wiedijk100Theorems. LIS/LDS are the sSup of achievable increasing/decreasing subsequence lengths, each bounded above by n (lis_bddAbove / lds_bddAbove via subsequence_length_le). A monotonic subsequence has length ≤ max(LIS, LDS) (len_le_max_of_monotonic, from len_le_LIS_of_increasing / len_le_LDS_of_decreasing and le_csSup). For a decomposition D, the map g : (Σ i, Fin (part i length)) → Fin n sending (i, j) ↦ (part i).indices j is surjective by the covering condition, so Fintype.card_le_of_surjective gives n = |Fin n| ≤ |Σ i, Fin (part i length)| = Σ i, (part i length) (Fintype.card_sigma). Bounding each summand by max(LIS, LDS) and summing the constant over numParts parts (Finset.sum_const) yields n ≤ numParts · max(LIS, LDS); Nat.div_le_of_le_mul rephrases it as numParts ≥ n / max(LIS, LDS). The singleton decomposition (each element its own vacuously-monotonic part, fin_one_strictMono) shows the class is nonempty and gives numParts ≤ n.",
+    "keyInsights": [
+      "The covering condition of a monotonic decomposition is exactly the statement that the parts' index maps assemble into a surjection from their disjoint union onto the index set Fin n; this turns the counting bound into a one-line application of Fintype.card_le_of_surjective plus Fintype.card_sigma.",
+      "Each part contributes at most max(LIS, LDS) to the cover because a monotonic subsequence is either increasing (length ≤ LIS) or decreasing (length ≤ LDS); this is the only place monotonicity is used, and it is what ties the decomposition size to the longest-monotone-run parameter.",
+      "The resulting bound n ≤ numParts · max(LIS, LDS) is the Mirsky/Dilworth lower-bound half of Hanani's theorem: on the Erdős–Szekeres extremal sequences (max(LIS, LDS) ≈ √n) it forces numParts ≳ √n, matching Hanani's O(√n) upper bound in order.",
+      "The elementary lower bound is unconditional and axiom-free; the matching upper bound (a construction achieving O(√n) parts for every sequence) is the genuinely hard direction and is left open, stated but not axiomatized."
+    ],
+    "prerequisites": [
+      "The Erdős–Szekeres theorem and monotonic subsequences",
+      "Longest increasing / decreasing subsequence lengths (LIS, LDS) as suprema",
+      "Dilworth/Mirsky-style covering-versus-chain counting",
+      "Finite cardinality of a sigma type and surjection-cardinality bounds"
+    ]
+  },
+  "sections": [
+    {
+      "id": "subsequence-interface",
+      "title": "The Subsequence Interface and Monotonicity",
+      "startLine": 42,
+      "endLine": 68,
+      "summary": "RealSeq n := Fin n → ℝ; Subsequence n m is a strictly monotone index map Fin m → Fin n; IsIncreasing/IsDecreasing/IsMonotonic re-state the exact notions (matching Erdos1026Problem.lean) so the file is self-contained.",
+      "mathContext": "A subsequence is a strictly increasing $\\iota : \\mathrm{Fin}\\,m \\to \\mathrm{Fin}\\,n$; it is monotonic when $\\mathrm{seq}\\circ\\iota$ is strictly monotone or strictly antitone."
+    },
+    {
+      "id": "lis-lds",
+      "title": "Longest Monotone Runs and Length Bounds",
+      "startLine": 70,
+      "endLine": 128,
+      "summary": "subsequence_length_le: a subsequence is no longer than its parent. LIS/LDS are the suprema of achievable increasing/decreasing lengths, bounded above by n (lis_bddAbove/lds_bddAbove). len_le_LIS_of_increasing / len_le_LDS_of_decreasing / len_le_max_of_monotonic bound the length of a monotonic subsequence by max(LIS, LDS).",
+      "mathContext": "$m \\le \\mathrm{LIS}$ for increasing, $m \\le \\mathrm{LDS}$ for decreasing, hence $m \\le \\max(\\mathrm{LIS},\\mathrm{LDS})$ for monotonic."
+    },
+    {
+      "id": "decomposition-lower-bound",
+      "title": "The Monotonic-Decomposition Lower Bound",
+      "startLine": 130,
+      "endLine": 165,
+      "summary": "MonotonicDecomposition packages numParts monotonic parts that cover and are pairwise disjoint. monotonicDecomposition_numParts_lower_bound: n ≤ numParts · max(LIS, LDS), via a surjection from the disjoint union of parts onto Fin n and Fintype.card_sigma. monotonicDecomposition_numParts_ge: the division form numParts ≥ n / max(LIS, LDS).",
+      "mathContext": "$n = |\\mathrm{Fin}\\,n| \\le \\sum_i |\\text{part}_i| \\le \\mathrm{numParts}\\cdot\\max(\\mathrm{LIS},\\mathrm{LDS})$."
+    },
+    {
+      "id": "existence-bracket",
+      "title": "Existence of a Decomposition and the Bracket",
+      "startLine": 167,
+      "endLine": 187,
+      "summary": "fin_one_strictMono: any function out of Fin 1 is vacuously strictly monotone. singletonDecomposition: splitting into n singleton parts is a valid monotonic decomposition, so the class is nonempty and numParts ≤ n. Together with the lower bound this brackets the optimal number of parts in [n / max(LIS, LDS), n].",
+      "mathContext": "Optimal $\\mathrm{numParts} \\in [\\,n/\\max(\\mathrm{LIS},\\mathrm{LDS}),\\; n\\,]$."
+    }
+  ],
+  "conclusion": {
+    "summary": "OQ-05 of Erdős #1026 is given a precise formalization on the MonotonicDecomposition object, and its elementary lower-bound half is settled axiom-free: every monotonic decomposition of a length-n sequence uses at least n / max(LIS, LDS) parts (equivalently n ≤ numParts · max(LIS, LDS)), by a covering-surjection counting argument in which each monotonic part contributes at most max(LIS, LDS) to the cover. A singleton decomposition witnesses existence and the crude upper bound numParts ≤ n, bracketing the optimum. On the Erdős–Szekeres extremal sequences the bound forces ≳ √n parts, matching Hanani's O(√n) in order of magnitude.",
+    "implications": "The lower bound is the Mirsky/Dilworth-side certificate for Hanani's decomposition theorem and reduces the open content to a purely constructive question: does every sequence admit a monotonic decomposition into O(√n) parts, matching the bound? The parameter controlling the answer is max(LIS, LDS), the longest monotone run, exactly the quantity Erdős–Szekeres bounds below by √n.",
+    "openQuestions": [
+      "Does every length-n sequence admit a monotonic decomposition into O(√n) parts (Hanani's upper bound), matching the lower bound proved here up to constants?",
+      "What is the exact minimal number of monotonic parts as a function of the sequence, and is it always equal to max over an appropriate partition invariant (a Dilworth-type min-max identity)?",
+      "How does the maximum-sum optimization of Erdős #1026 interact with the decomposition: can one always find a monotonic part carrying an Ω(1/√n) share of the total sum inside an optimal decomposition?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1026",
+      "relationship": "extends",
+      "description": "Parent gallery proof: Erdős Problem #1026 (monotonic subsequence sum optimization), whose MonotonicDecomposition structure and Erdős–Szekeres LIS·LDS ≥ n bound this entry quantifies from below."
+    },
+    {
+      "targetId": "erdos-1026-oq-02",
+      "relationship": "related",
+      "description": "Sibling open question OQ-02 (approximate monotonicity) built on the same self-contained Subsequence interface."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, P. and Szekeres, G.",
+      "title": "A combinatorial problem in geometry",
+      "year": "1935",
+      "venue": "Compositio Mathematica 2, 463–470",
+      "note": "Every sequence of k²+1 distinct reals contains a monotonic subsequence of length k+1; the LIS·LDS ≥ n form underlies the √n scale of the bound."
+    },
+    {
+      "authors": "Hanani, H.",
+      "title": "On the number of monotonic subsequences",
+      "year": "1957",
+      "venue": "",
+      "note": "Every sequence of n elements decomposes into at most (√2 + o(1))√n monotonic subsequences — the upper bound whose lower-bound counterpart is proved here."
+    },
+    {
+      "authors": "Erdős problem database",
+      "title": "Erdős Problem #1026",
+      "year": "",
+      "venue": "erdosproblems.com/1026",
+      "note": "Source of the monotonic subsequence sum optimization problem and its open questions."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1026OQ05",
+    "lineCount": 184,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "path": "Proofs/Erdos1026OQ05.lean",
+    "sorries": 0,
+    "definitionCount": 9
+  },
+  "sorries": 0,
+  "highlights": [
+    "Every monotonic decomposition of a length-n sequence uses at least n / max(LIS, LDS) parts (monotonicDecomposition_numParts_lower_bound / monotonicDecomposition_numParts_ge): the Mirsky/Dilworth lower-bound half of Hanani's theorem, proved axiom-free.",
+    "The proof turns the covering condition into a surjection from the disjoint union of the parts onto Fin n, so n ≤ Σ part-lengths via Fintype.card_sigma; each monotonic part contributes at most max(LIS, LDS) because it is increasing (≤ LIS) or decreasing (≤ LDS).",
+    "A singleton decomposition (each element its own vacuously-monotonic part) witnesses existence and the crude upper bound numParts ≤ n, bracketing the optimal number of parts in [n / max(LIS, LDS), n].",
+    "On the Erdős–Szekeres extremal sequences (longest monotone run ≈ √n) the bound forces ≳ √n parts, matching Hanani's O(√n) in order; the constructive matching upper bound is stated but left open and unaxiomatized (0 axioms, 0 sorries)."
+  ]
+}

--- a/src/data/research/problems/erdos-1026-oq-05.json
+++ b/src/data/research/problems/erdos-1026-oq-05.json
@@ -1,0 +1,40 @@
+{
+  "slug": "erdos-1026-oq-05",
+  "title": "Erdős #1026 OQ-05: k-monotonic decompositions",
+  "tier": "B",
+  "significance": 5,
+  "tractability": 6,
+  "status": "active",
+  "phase": "ACT",
+  "path": "proofs/Proofs/Erdos1026OQ05.lean",
+  "started": "2026-07-08",
+  "lastUpdate": "2026-07-08",
+  "problemStatement": "Extend Erdős #1026 from single monotonic subsequences to decompositions of the whole sequence into monotonic pieces (Hanani 1957). How many monotonic parts must such a decomposition use?",
+  "currentState": "Elementary lower-bound half proved axiom-free: every monotonic decomposition uses at least n / max(LIS, LDS) parts. The constructive matching upper bound (O(√n) parts always suffice) is left open.",
+  "leanFiles": ["proofs/Proofs/Erdos1026OQ05.lean"],
+  "relatedProofs": ["erdos-1026", "erdos-1026-oq-02"],
+  "knowledge": {
+    "insights": [
+      "The covering condition of a MonotonicDecomposition is exactly a surjection from the disjoint union of the parts (Σ i, Fin (part i length)) onto Fin n; this converts the counting bound into Fintype.card_le_of_surjective + Fintype.card_sigma.",
+      "A monotonic part has length ≤ max(LIS, LDS): increasing parts are ≤ LIS, decreasing ≤ LDS (le_csSup against the sup-of-achievable-lengths definition). This is the only use of monotonicity in the bound.",
+      "The resulting n ≤ numParts · max(LIS, LDS) is the Mirsky/Dilworth lower-bound half of Hanani's decomposition theorem; on Erdős–Szekeres extremal sequences (max(LIS,LDS) ≈ √n) it forces ≳ √n parts."
+    ],
+    "builtItems": [
+      "monotonicDecomposition_numParts_lower_bound: n ≤ numParts · max(LIS, LDS) (Erdos1026OQ05.lean:131)",
+      "monotonicDecomposition_numParts_ge: numParts ≥ n / max(LIS, LDS) via Nat.div_le_of_le_mul (Erdos1026OQ05.lean:159)",
+      "len_le_max_of_monotonic + lis/lds_bddAbove + subsequence_length_le supporting lemmas",
+      "singletonDecomposition: existence witness giving numParts ≤ n; fin_one_strictMono (Erdos1026OQ05.lean:176)"
+    ],
+    "mathlibGaps": [
+      "No Hanani-style monotonic decomposition theorem in Mathlib; the parent file only states the structure. Dilworth is available for antichains but not directly wired to the LIS/LDS monotone-run decomposition.",
+      "The constructive O(√n) upper bound (Hanani 1957) is not formalized and would require a genuine partition construction, not just counting."
+    ],
+    "nextSteps": [
+      "Attempt the Hanani upper bound: construct a monotonic decomposition into O(√n) parts (e.g. greedy patience-sorting / RSK column count), which would close the bracket to Θ(√n) for extremal sequences.",
+      "Prove a Dilworth-type min-max identity for the minimal number of monotonic parts in terms of a partition invariant.",
+      "Connect to the sum-optimization of Erdős #1026: does an optimal decomposition contain a part carrying Ω(1/√n) of the total sum?"
+    ],
+    "progressSummary": "PROGRESS: Mirsky/Dilworth lower bound n ≤ numParts·max(LIS,LDS) proved VERIFIED 0/0; constructive upper bound remains open."
+  },
+  "tags": ["combinatorics", "erdos-szekeres", "monotonic-subsequences", "dilworth", "decomposition", "open-question"]
+}

--- a/src/data/research/problems/erdos-1026-oq-05.json
+++ b/src/data/research/problems/erdos-1026-oq-05.json
@@ -11,8 +11,13 @@
   "lastUpdate": "2026-07-08",
   "problemStatement": "Extend Erdős #1026 from single monotonic subsequences to decompositions of the whole sequence into monotonic pieces (Hanani 1957). How many monotonic parts must such a decomposition use?",
   "currentState": "Elementary lower-bound half proved axiom-free: every monotonic decomposition uses at least n / max(LIS, LDS) parts. The constructive matching upper bound (O(√n) parts always suffice) is left open.",
-  "leanFiles": ["proofs/Proofs/Erdos1026OQ05.lean"],
-  "relatedProofs": ["erdos-1026", "erdos-1026-oq-02"],
+  "leanFiles": [
+    "proofs/Proofs/Erdos1026OQ05.lean"
+  ],
+  "relatedProofs": [
+    "erdos-1026",
+    "erdos-1026-oq-02"
+  ],
   "knowledge": {
     "insights": [
       "The covering condition of a MonotonicDecomposition is exactly a surjection from the disjoint union of the parts (Σ i, Fin (part i length)) onto Fin n; this converts the counting bound into Fintype.card_le_of_surjective + Fintype.card_sigma.",
@@ -32,9 +37,17 @@
     "nextSteps": [
       "Attempt the Hanani upper bound: construct a monotonic decomposition into O(√n) parts (e.g. greedy patience-sorting / RSK column count), which would close the bracket to Θ(√n) for extremal sequences.",
       "Prove a Dilworth-type min-max identity for the minimal number of monotonic parts in terms of a partition invariant.",
-      "Connect to the sum-optimization of Erdős #1026: does an optimal decomposition contain a part carrying Ω(1/√n) of the total sum?"
+      "Connect to the sum-optimization of Erdős #1026: does an optimal decomposition contain a part carrying Ω(1/√n) of the total sum?",
+      "Upper bound O(√n): construct an explicit monotone-piece decomposition achieving ~√n parts. Likely needs a greedy patience-sorting / Dilworth-antichain-cover argument; Mathlib lacks Dilworth chain-decomposition for this setting — assess buildability before attempting."
     ],
-    "progressSummary": "PROGRESS: Mirsky/Dilworth lower bound n ≤ numParts·max(LIS,LDS) proved VERIFIED 0/0; constructive upper bound remains open."
+    "progressSummary": "VERIFIED (PR #35677): Mirsky/Dilworth lower bound n ≤ numParts·max(LIS,LDS) proved axiom-free 0/0 (surjection from parts disjoint union onto Fin n + per-part length ≤ max(LIS,LDS)); division form + singletonDecomposition bracket numParts in [n/max(LIS,LDS), n]. The elementary lower-bound direction is DONE. Remaining open: constructive O(√n) upper bound (Hanani 1957) — genuinely hard, not elementary."
   },
-  "tags": ["combinatorics", "erdos-szekeres", "monotonic-subsequences", "dilworth", "decomposition", "open-question"]
+  "tags": [
+    "combinatorics",
+    "erdos-szekeres",
+    "monotonic-subsequences",
+    "dilworth",
+    "decomposition",
+    "open-question"
+  ]
 }


### PR DESCRIPTION
## Erdős #1026 OQ-05 — Lower bound on monotonic decompositions

Proves the **Mirsky/Dilworth lower-bound direction** of OQ-05, filling a genuine gap: the parent `Erdos1026Problem.lean` states the `MonotonicDecomposition` structure but proves *nothing* about how many parts a decomposition must use (Hanani's `(√2+o(1))√n` bound lives only in a comment).

### Main result
```
monotonicDecomposition_numParts_lower_bound :
  n ≤ D.numParts * max (LIS seq) (LDS seq)
```
Proof: the parts' index maps assemble into a **surjection** from their disjoint union `Σ i, Fin (len part i)` onto `Fin n` (this is exactly the covering condition), so `n ≤ Σ len(part i)`; each part, being monotonic, has length `≤ max(LIS, LDS)`, and summing the constant bound over `numParts` parts closes the claim.

Two consequences:
- `monotonicDecomposition_numParts_ge` — division form `n / max(LIS,LDS) ≤ numParts`.
- `singletonDecomposition` — every sequence admits a decomposition (n singletons), so the class is nonempty and `numParts` is bracketed in `[n/max(LIS,LDS), n]`.

For the extremal Erdős–Szekeres sequences (longest monotone run `≈√n`), this forces `numParts ≳ √n` — the lower-bound side of Hanani's theorem. The matching `O(√n)` upper bound is the hard constructive direction, **stated in prose, not axiomatized**.

### Status
- **Axiom-free, 0 sorries.** Self-contained interface (re-states `Subsequence`/`LIS`/`LDS`/`MonotonicDecomposition`) to avoid the `Archive.Wiedijk100Theorems` dependency of the parent file.
- Docker-verified: `Built Proofs.Erdos1026OQ05 (8.8s)`, no warnings.
- 9 theorems/lemmas, 9 definitions, 184 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)