### PR TITLE
research(puiseux-theorem-wip-01): Puiseux series form a Subring of HahnSeries ℚ K

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -616,6 +616,124 @@ theorem char_zero_required :
 end Connections
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
+PART VIII: THE PUISEUX SERIES FORM A SUBRING
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-!
+### Closure of the Puiseux condition under the ring operations
+
+The prose throughout this file asserts that the Puiseux series form a *field*
+`K⦃⦃x⦄⦄` sitting inside the Hahn series `HahnSeries ℚ K`. Up to here the file only
+establishes that individual `single`-term series (and the specific binomial roots
+of Part II) satisfy `IsPuiseuxSeries`. This section upgrades that pointwise fact to
+the genuine algebraic statement: `{f | IsPuiseuxSeries f}` is closed under
+`0`, `1`, `+`, `-`, and `*`, and therefore is a `Subring` of `HahnSeries ℚ K`.
+
+The whole argument is denominator arithmetic on the exponent supports:
+
+* `support (f + g) ⊆ support f ∪ support g`, so if `f` has exponents in `(1/n)ℤ`
+  and `g` in `(1/m)ℤ`, the common denominator `n·m` works for the sum
+  (`k/n = (k·m)/(n·m)`).
+* `support (f * g) ⊆ support f + support g` (Minkowski sum of supports), and
+  `k₁/n + k₂/m = (k₁·m + k₂·n)/(n·m)`, so `n·m` again works for the product.
+
+This is exactly the closure that makes `IsPuiseuxSeries` an honest algebraic
+substructure rather than a predicate that merely happens to hold on the examples
+constructed above.
+-/
+
+section Subring
+
+/-- The zero series is a Puiseux series — its support is empty, so the exponent
+condition holds vacuously (with ramification `1`). -/
+theorem isPuiseux_zero {K : Type*} [Zero K] :
+    IsPuiseuxSeries (0 : HahnSeries ℚ K) :=
+  ⟨1, fun q hq => by simp [HahnSeries.support_zero] at hq⟩
+
+/-- The unit series `1 = single 0 1` is a Puiseux series (its only exponent is the
+integer `0`). -/
+theorem isPuiseux_one {K : Type*} [Zero K] [One K] :
+    IsPuiseuxSeries (1 : HahnSeries ℚ K) := by
+  rw [← HahnSeries.single_zero_one]
+  exact isPuiseux_single 0 1
+
+/-- **Closure under addition.** If every exponent of `f` lies in `(1/n)ℤ` and every
+exponent of `g` lies in `(1/m)ℤ`, then every exponent of `f + g` lies in
+`(1/(n·m))ℤ`: the support of a sum is contained in the union of the supports, and
+`k/n = (k·m)/(n·m)`. -/
+theorem isPuiseux_add {K : Type*} [AddCommMonoid K] {f g : HahnSeries ℚ K}
+    (hf : IsPuiseuxSeries f) (hg : IsPuiseuxSeries g) :
+    IsPuiseuxSeries (f + g) := by
+  obtain ⟨n, hn⟩ := hf
+  obtain ⟨m, hm⟩ := hg
+  have hn0 : ((n : ℕ) : ℚ) ≠ 0 := by exact_mod_cast n.pos.ne'
+  have hm0 : ((m : ℕ) : ℚ) ≠ 0 := by exact_mod_cast m.pos.ne'
+  refine ⟨n * m, fun q hq => ?_⟩
+  rcases HahnSeries.support_add_subset hq with h | h
+  · obtain ⟨k, hk⟩ := hn q h
+    refine ⟨k * (m : ℤ), ?_⟩
+    rw [hk]; push_cast
+    rw [div_eq_div_iff hn0 (mul_ne_zero hn0 hm0)]; ring
+  · obtain ⟨k, hk⟩ := hm q h
+    refine ⟨k * (n : ℤ), ?_⟩
+    rw [hk]; push_cast
+    rw [div_eq_div_iff hm0 (mul_ne_zero hn0 hm0)]; ring
+
+/-- **Closure under negation.** Negation does not move exponents around
+(`support (-f) = support f`), so the ramification of `-f` is the same as that of
+`f`. -/
+theorem isPuiseux_neg {K : Type*} [AddGroup K] {f : HahnSeries ℚ K}
+    (hf : IsPuiseuxSeries f) : IsPuiseuxSeries (-f) := by
+  obtain ⟨n, hn⟩ := hf
+  refine ⟨n, fun q hq => ?_⟩
+  rw [HahnSeries.support_neg] at hq
+  exact hn q hq
+
+/-- **Closure under multiplication.** The support of a product is contained in the
+Minkowski sum `support f + support g`, so a typical exponent of `f · g` is
+`k₁/n + k₂/m = (k₁·m + k₂·n)/(n·m)`; the common denominator `n·m` witnesses that
+`f · g` is again a Puiseux series. -/
+theorem isPuiseux_mul {K : Type*} [NonUnitalNonAssocSemiring K] {f g : HahnSeries ℚ K}
+    (hf : IsPuiseuxSeries f) (hg : IsPuiseuxSeries g) :
+    IsPuiseuxSeries (f * g) := by
+  obtain ⟨n, hn⟩ := hf
+  obtain ⟨m, hm⟩ := hg
+  have hn0 : ((n : ℕ) : ℚ) ≠ 0 := by exact_mod_cast n.pos.ne'
+  have hm0 : ((m : ℕ) : ℚ) ≠ 0 := by exact_mod_cast m.pos.ne'
+  refine ⟨n * m, fun q hq => ?_⟩
+  obtain ⟨a, ha, b, hb, hab⟩ := Set.mem_add.mp (HahnSeries.support_mul_subset_add_support hq)
+  obtain ⟨k, hk⟩ := hn a ha
+  obtain ⟨l, hl⟩ := hm b hb
+  refine ⟨k * (m : ℤ) + l * (n : ℤ), ?_⟩
+  rw [← hab, hk, hl]; push_cast
+  rw [div_add_div _ _ hn0 hm0, div_eq_div_iff (mul_ne_zero hn0 hm0) (mul_ne_zero hn0 hm0)]
+  ring
+
+/-- **The Puiseux series form a subring of `HahnSeries ℚ K`.**
+
+Bundling the five closure facts above, `{f : HahnSeries ℚ K | IsPuiseuxSeries f}`
+is a `Subring`. This is the structural backbone of Puiseux's theorem: the objects
+the Newton–Puiseux algorithm produces live in an honest ring (in fact a field, when
+`K` is a field, since one further inverts the leading term), not merely in an
+ad-hoc collection of series. Membership `y ∈ puiseuxSubring K` is definitionally
+`IsPuiseuxSeries y`, so all the concrete roots constructed earlier in this file are
+elements of this subring. -/
+def puiseuxSubring (K : Type*) [Ring K] : Subring (HahnSeries ℚ K) where
+  carrier := {f | IsPuiseuxSeries f}
+  zero_mem' := isPuiseux_zero
+  one_mem' := isPuiseux_one
+  add_mem' := fun ha hb => isPuiseux_add ha hb
+  mul_mem' := fun ha hb => isPuiseux_mul ha hb
+  neg_mem' := fun ha => isPuiseux_neg ha
+
+/-- The concrete membership unfolding: `y ∈ puiseuxSubring K ↔ IsPuiseuxSeries y`.
+Confirms the subring's carrier is exactly the Puiseux condition. -/
+@[simp] theorem mem_puiseuxSubring {K : Type*} [Ring K] (y : HahnSeries ℚ K) :
+    y ∈ puiseuxSubring K ↔ IsPuiseuxSeries y := Iff.rfl
+
+end Subring
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
 SUMMARY
 ═══════════════════════════════════════════════════════════════════════════════ -/
 

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -47,3 +47,38 @@ File state at session start: 603 lines, 0 sorries, 0 axioms, 11 theorems.
 - Full algebraic closure (`IsAlgClosed (PuiseuxField K)`) is not attemptable
   without the Newton–Puiseux convergence machinery, which is absent from Mathlib
   v4.26 — this is a >1000-line foundational build, out of scope for a session.
+
+---
+
+## Session (researcher-3, 2026-07-08): Subring structure
+
+Problem was already SOLVED (0 sorry/0 axiom); worked outward on structure.
+
+**Contribution — Part VIII: the Puiseux series form a `Subring`.** The file
+previously proved only that individual `single`-term series and the specific
+binomial roots satisfy `IsPuiseuxSeries`. Added the five closure lemmas
+`isPuiseux_zero / one / add / neg / mul`, bundled into
+`puiseuxSubring (K) [Ring K] : Subring (HahnSeries ℚ K)`, plus the
+membership-unfolding `mem_puiseuxSubring` (`y ∈ puiseuxSubring K ↔ IsPuiseuxSeries y`,
+`Iff.rfl`). This makes the "Puiseux series form a field" prose a machine-checked
+substructure fact. Verified 0-sorry/0-axiom, docker-build (3069 jobs). 12→18
+theorems, 640→758 lines.
+
+**Technique (reusable — denominator arithmetic on Hahn supports):**
+- `HahnSeries.support_add_subset : (f+g).support ⊆ f.support ∪ g.support`
+- `HahnSeries.support_mul_subset_add_support : (f*g).support ⊆ f.support + g.support`
+  (RHS is the pointwise Minkowski sum; destructure with `Set.mem_add.mp` →
+  `⟨a, ha, b, hb, hab⟩` with `a + b = q`).
+- `HahnSeries.support_neg : (-f).support = f.support`.
+- `HahnSeries.single_zero_one : single 0 1 = 1` (rewrite `1` to a single term).
+- `HahnSeries.support_zero : (0).support = ∅` (vacuous, ramification 1).
+- Common denominator: if `q = k/n` (n : ℕ+) and `q' = l/m`, the sum/product exponent
+  has denominator `n*m`. Cast plumbing: `n.pos.ne'` for `(↑n:ℕ) ≠ 0`, then
+  `exact_mod_cast` to ℚ; `push_cast` flattens `↑(n*m:ℕ+)` to `↑n*↑m` (PNat.mul_coe
+  is norm_cast); finish with `div_eq_div_iff` / `div_add_div` + `ring`.
+- `Subring … where` accepts the flattened fields `carrier / zero_mem' / one_mem' /
+  add_mem' / mul_mem' / neg_mem'` directly (extends flattening); the membership
+  proofs unify with `IsPuiseuxSeries` since the carrier is `{f | IsPuiseuxSeries f}`.
+
+**Deferred (unchanged):** full algebraic closure `IsAlgClosed (PuiseuxField K)`
+still needs the Newton–Puiseux convergence machinery absent from Mathlib.

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -48,17 +48,18 @@
       "Binomial base case of algebraic closure proved (puiseux_binomial_root): over any algebraically closed K, every binomial Yⁿ = c·xᵐ has an honest Puiseux root c^(1/n)·x^(m/n)",
       "Genuine ramification witnessed (puiseux_binomial_ramification): the root of Yⁿ = c·x has orderTop exactly 1/n, so for n≥2 it lies strictly outside the Laurent field",
       "isPuiseux_single helper: every single-term Hahn series is a Puiseux series",
+      "Subring structure (puiseuxSubring): the IsPuiseuxSeries predicate is closed under 0, 1, +, - and * (isPuiseux_zero/one/add/neg/mul), so the Puiseux series form an honest Subring of HahnSeries ℚ K — the structural backbone the prose claimed, proved by denominator arithmetic on exponent supports (common denominator n·m for both sum and product)",
       "Galois group Gal(Puiseux/Laurent) ≅ Ẑ noted as an informal String descriptor (galois_group_is_profinite_integers), not formalized",
       "Characteristic-zero requirement noted as an informal String descriptor (char_zero_required, Artin-Schreier obstruction), not formalized",
       "Binomial root lifted to an honest Polynomial.IsRoot (puiseux_binomial_isRoot): the Puiseux series c^(1/n)·x^(m/n) is a genuine root of the polynomial Xⁿ - C(single m c) over the Hahn/Puiseux field, the polynomial-level form of a single Newton-polygon edge"
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 640,
+    "lineCount": 758,
     "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The two headline placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). Four narrative theorems remain as String-literal descriptors carrying no formal content (curve_branches_are_puiseux, newton_polygon_tropicalization, galois_group_is_profinite_integers, char_zero_required); each merely asserts ∃ desc : String, desc = \"…\" and marks an informal application/connection rather than a machine-checked result. This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
-    "definitionCount": 2
+    "theoremCount": 18,
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Newton discovered the algorithm for computing fractional power series roots of polynomials in 1676. Puiseux gave the first rigorous proof in 1850 that these series provide the algebraic closure of the Laurent series field, establishing that allowing fractional exponents suffices to solve all polynomial equations over formal power series (in characteristic 0). The study of algebraic curves via local parametrization goes back to Newton who introduced the Newton polygon method to compute the branches of an algebraic curve at a singular point. The formal algebraic closure result was refined in the 20th century by Hironaka and others in connection with resolution of singularities, and the characteristic-0 hypothesis is essential: in characteristic p, the Artin-Schreier phenomenon means p-th power extensions cannot be captured by Puiseux series.",
@@ -172,10 +173,10 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 640,
+    "lineCount": 758,
     "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 2,
+    "theoremCount": 18,
+    "definitionCount": 3,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

The `puiseux-theorem-wip-01` file (Wiedijk #41) was already at 0-sorry/0-axiom;
this session works **outward on structure**. Adds **Part VIII: the Puiseux series
form a `Subring`**.

Until now the file only proved that individual `single`-term series and the
specific binomial roots of Part II satisfy `IsPuiseuxSeries`. This PR upgrades
that pointwise fact to the genuine algebraic statement the surrounding prose
already claimed: `{f | IsPuiseuxSeries f}` is closed under `0, 1, +, -, *`, hence
is an honest `Subring` of the ambient Hahn series `HahnSeries ℚ K`.

## New declarations

- `isPuiseux_zero`, `isPuiseux_one` — the ring identities are Puiseux series
  (empty support / integer exponent `0` via `single_zero_one`).
- `isPuiseux_add` — closure under `+`: `support (f+g) ⊆ support f ∪ support g`,
  common denominator `n·m` (`k/n = (k·m)/(n·m)`).
- `isPuiseux_neg` — closure under `-`: `support (-f) = support f`.
- `isPuiseux_mul` — closure under `*`: `support (f·g) ⊆ support f + support g`
  (Minkowski sum), `k₁/n + k₂/m = (k₁·m + k₂·n)/(n·m)`.
- `puiseuxSubring (K) [Ring K] : Subring (HahnSeries ℚ K)` — bundles the five
  closure facts.
- `mem_puiseuxSubring` — `y ∈ puiseuxSubring K ↔ IsPuiseuxSeries y` (`Iff.rfl`),
  so every concrete root constructed earlier in the file is an element.

## Verification

- `docker-build.sh Proofs.PuiseuxTheorem` — **build succeeded (3069 jobs)**,
  0 sorries, 0 axioms. No new warnings (the two pre-existing linter notes at
  lines 352/379 are untouched code).
- meta.json counts synced: theoremCount 12→18, lineCount 640→758,
  definitionCount 2→3; added an `originalContributions` entry.

## Scope note

Full algebraic closure `IsAlgClosed (PuiseuxField K)` remains open — it needs the
Newton–Puiseux convergence machinery not present in Mathlib. This PR is a
structural addition, not a claim on the headline theorem; badge stays `wip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)