### PR TITLE
research(shannon-channel-coding-awgn-oq-02-oq-02): multi-symbol output power E[(∑Wᵢ)²]=∑E[Wᵢ²] [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -1,0 +1,113 @@
+/-
+  Multi-symbol AWGN output power:  E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]
+
+  Open question (shannon-channel-coding-awgn-oq-02-oq-02):
+  "Variance of a Sum of Pairwise-Independent Contributions (Multi-Symbol AWGN
+   Output Power)."
+
+  The parent file `ShannonChannelCodingAWGNOQ02.lean` discharges the *two-term*
+  output-power relation `E[(X + Z)²] = E[X²] + E[Z²]` for a single-symbol additive
+  channel `Y = X + Z`, using `ProbabilityTheory.IndepFun.variance_add`.
+
+  A block of `n` transmitted symbols produces an aggregate output that is a *finite
+  sum* of contributions `∑_{i ∈ s} Wᵢ` (per-symbol signal + noise terms). When the
+  contributions are **pairwise independent** and **zero-mean**, the aggregate output
+  power is the sum of the individual powers:
+
+        E[(∑_{i ∈ s} Wᵢ)²] = ∑_{i ∈ s} E[Wᵢ²].
+
+  The mathematical content is the *variance-of-a-sum* fact for pairwise-independent
+  families — `ProbabilityTheory.IndepFun.variance_sum`, where the vanishing pairwise
+  covariances collapse the double sum to the diagonal — specialised to zero mean via
+  `E[W²] = Var[W]` (`ProbabilityTheory.variance_eq_sub`).  Note that *pairwise*
+  independence (not full/mutual independence) already suffices, exactly as for the
+  classical Bienaymé identity.
+
+  This generalises the parent's two-term result (`s = {X, Z}`) to arbitrary finite
+  blocks.  Everything is assembled from Mathlib's probability layer; the file is
+  axiom-free and sorry-free.
+-/
+
+import Mathlib
+
+open MeasureTheory ProbabilityTheory
+open scoped MeasureTheory ProbabilityTheory ENNReal
+
+namespace ShannonAWGNMultiSymbolPower
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- For a zero-mean square-integrable random variable the **second moment equals the
+variance**: `E[W²] = Var[W]`.  This is the bridge that turns the "power" of a
+zero-mean signal into its variance.  (Same statement as in the parent file, recorded
+here so the multi-symbol results are self-contained.) -/
+theorem second_moment_eq_variance [IsProbabilityMeasure μ] {W : Ω → ℝ}
+    (hW : MemLp W 2 μ) (hW0 : μ[W] = 0) :
+    μ[W ^ 2] = Var[W; μ] := by
+  rw [variance_eq_sub hW, hW0]
+  ring
+
+/-- **Multi-symbol output variance (Bienaymé identity).**  The variance of a finite
+sum of *pairwise-independent* square-integrable contributions is the sum of the
+variances:
+
+        Var[∑_{i ∈ s} Wᵢ] = ∑_{i ∈ s} Var[Wᵢ].
+
+This is `IndepFun.variance_sum`, recorded in the channel notation.  Pairwise
+independence suffices — the off-diagonal covariances vanish. -/
+theorem awgn_multisymbol_variance {ι : Type*} {W : ι → Ω → ℝ} {s : Finset ι}
+    (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (hindep : Set.Pairwise ↑s fun i j => W i ⟂ᵢ[μ] W j) :
+    Var[∑ i ∈ s, W i; μ] = ∑ i ∈ s, Var[W i; μ] :=
+  IndepFun.variance_sum hW hindep
+
+/-- The aggregate of a family of zero-mean contributions is again zero-mean:
+`E[∑_{i ∈ s} Wᵢ] = 0`. -/
+theorem sum_mean_zero [IsFiniteMeasure μ] {ι : Type*} {W : ι → Ω → ℝ} {s : Finset ι}
+    (hW : ∀ i ∈ s, MemLp (W i) 2 μ) (hmean : ∀ i ∈ s, μ[W i] = 0) :
+    μ[∑ i ∈ s, W i] = 0 := by
+  have hint : ∀ i ∈ s, Integrable (W i) μ := fun i hi => (hW i hi).integrable one_le_two
+  simp only [Finset.sum_apply]
+  rw [integral_finset_sum s hint]
+  exact Finset.sum_eq_zero hmean
+
+/-- **Multi-symbol AWGN output power.**  If the aggregate channel output is the finite
+sum `∑_{i ∈ s} Wᵢ` of *pairwise-independent*, zero-mean, square-integrable
+contributions, then the output second moment (power) is the sum of the individual
+second moments:
+
+        E[(∑_{i ∈ s} Wᵢ)²] = ∑_{i ∈ s} E[Wᵢ²].
+
+This is the variance-of-a-sum fact reduced to second moments via the zero-mean
+hypotheses, generalising the parent's two-term identity `E[(X + Z)²] = E[X²] + E[Z²]`
+to an arbitrary finite block of symbols. -/
+theorem awgn_multisymbol_power [IsProbabilityMeasure μ] {ι : Type*} {W : ι → Ω → ℝ}
+    {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (hindep : Set.Pairwise ↑s fun i j => W i ⟂ᵢ[μ] W j)
+    (hmean : ∀ i ∈ s, μ[W i] = 0) :
+    μ[(∑ i ∈ s, W i) ^ 2] = ∑ i ∈ s, μ[(W i) ^ 2] := by
+  have hSum : MemLp (∑ i ∈ s, W i) 2 μ := memLp_finset_sum' s hW
+  have hSum0 : μ[∑ i ∈ s, W i] = 0 := sum_mean_zero hW hmean
+  rw [second_moment_eq_variance hSum hSum0, awgn_multisymbol_variance hW hindep]
+  refine Finset.sum_congr rfl fun i hi => ?_
+  exact (second_moment_eq_variance (hW i hi) (hmean i hi)).symm
+
+/-- **Multi-symbol AWGN output power, named powers.**  Writing `Pᵢ = E[Wᵢ²]` for the
+power of the `i`-th contribution, the aggregate output power is the sum of the
+per-contribution powers:
+
+        E[(∑_{i ∈ s} Wᵢ)²] = ∑_{i ∈ s} Pᵢ.
+
+For a signal-plus-noise block (`Wᵢ` ranging over both the per-symbol signal and noise
+terms) this is the total-power budget `P_total = ∑ signal powers + ∑ noise powers`,
+the `n`-symbol analogue of the parent's `E[Y²] = P + N`. -/
+theorem awgn_multisymbol_output_power [IsProbabilityMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (hindep : Set.Pairwise ↑s fun i j => W i ⟂ᵢ[μ] W j)
+    (hmean : ∀ i ∈ s, μ[W i] = 0) {P : ι → ℝ}
+    (hP : ∀ i ∈ s, μ[(W i) ^ 2] = P i) :
+    μ[(∑ i ∈ s, W i) ^ 2] = ∑ i ∈ s, P i := by
+  rw [awgn_multisymbol_power hW hindep hmean]
+  exact Finset.sum_congr rfl hP
+
+end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -1,0 +1,182 @@
+{
+  "id": "shannon-channel-coding-awgn-oq-02-oq-02",
+  "slug": "shannon-channel-coding-awgn-oq-02-oq-02",
+  "title": "Multi-Symbol AWGN Output Power E[(∑Wᵢ)²] = ∑E[Wᵢ²] from the Variance of a Pairwise-Independent Sum",
+  "description": "Generalizes the parent two-term AWGN output-power identity E[(X+Z)²] = E[X²] + E[Z²] to a finite block of symbols: for pairwise-independent, zero-mean, square-integrable contributions Wᵢ (i ∈ s), the aggregate output power adds, E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The proof is the variance-of-a-sum (Bienaymé) identity for pairwise-independent families — ProbabilityTheory.IndepFun.variance_sum, where the vanishing pairwise covariances collapse the double sum to the diagonal — specialized to zero mean via E[W²] = Var[W] (ProbabilityTheory.variance_eq_sub). Pairwise (not mutual) independence already suffices. 113 lines, 5 theorems, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory"
+    ],
+    "namespace": "ShannonAWGNMultiSymbolPower",
+    "lineCount": 113,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
+    "tags": [
+      "probability",
+      "information-theory",
+      "variance",
+      "independence",
+      "pairwise-independence",
+      "second-moment",
+      "bienayme",
+      "awgn",
+      "shannon",
+      "channel-capacity",
+      "measure-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 113,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "awgn_multisymbol_power: E[(∑_{i∈s} Wᵢ)²] = ∑_{i∈s} E[Wᵢ²] — the heart of the entry. For a finite family of pairwise-independent, zero-mean, square-integrable contributions the aggregate second moment (output power) splits as the sum of the individual second moments. The proof combines the pairwise-independent variance-of-a-sum law (IndepFun.variance_sum) with the fact that the aggregate ∑ Wᵢ is again zero-mean (integral_finset_sum on the integrable parts), so every squared-mean term in Var[W] = E[W²] − (E[W])² vanishes and the variance identity collapses onto second moments — both for the sum and, term by term, for each Wᵢ.",
+      "awgn_multisymbol_output_power: E[(∑_{i∈s} Wᵢ)²] = ∑_{i∈s} Pᵢ — the block-power restatement. Writing Pᵢ = E[Wᵢ²] for the power of the i-th contribution, the aggregate output power is the sum of the per-contribution powers: the n-symbol analogue of the parent's E[Y²] = P + N (which is the special case s = {signal, noise}).",
+      "awgn_multisymbol_variance: Var[∑_{i∈s} Wᵢ] = ∑_{i∈s} Var[Wᵢ] for pairwise-independent Wᵢ — the Bienaymé identity recorded in channel notation (a direct application of IndepFun.variance_sum), making explicit that pairwise independence already annihilates every off-diagonal covariance in the expansion of the variance of a sum.",
+      "sum_mean_zero: E[∑_{i∈s} Wᵢ] = 0 — the aggregate of zero-mean contributions is zero-mean, via linearity of the integral over a Finset (integral_finset_sum) on the square-integrable (hence integrable) parts. This is the lemma that lets the squared-mean term drop for the sum, not just for each summand.",
+      "second_moment_eq_variance: E[W²] = Var[W] for a zero-mean variable — the bridge identifying the engineering notion of 'power' with the probabilistic variance; the rewrite that turns the variance-of-a-sum law into a second-moment law once the means are zero."
+    ],
+    "prerequisites": [
+      "Variance of a sum of pairwise-independent variables: ProbabilityTheory.IndepFun.variance_sum (Var[∑ Xᵢ] = ∑ Var[Xᵢ])",
+      "Variance as second moment minus squared mean: ProbabilityTheory.variance_eq_sub (Var[X] = E[X²] − (E[X])²)",
+      "Square-integrability of a Finset sum: MeasureTheory.memLp_finset_sum'",
+      "Linearity of the expectation over a Finset: MeasureTheory.integral_finset_sum",
+      "Square-integrability gives integrability on a probability space: MeasureTheory.MemLp.integrable with 1 ≤ 2",
+      "Parent: shannon-channel-coding-awgn-oq-02 (the two-term output-power identity E[(X+Z)²] = E[X²] + E[Z²])"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "ProbabilityTheory.IndepFun.variance_sum",
+        "description": "For a finite family that is pairwise independent (Set.Pairwise on the Finset) and square-integrable, the variance of the sum equals the sum of the variances: Var[∑ Xᵢ] = ∑ Var[Xᵢ]. This is the substantive probabilistic input; pairwise independence is exactly what makes every off-diagonal covariance vanish.",
+        "module": "Mathlib.Probability.Moments.Variance"
+      },
+      {
+        "theorem": "ProbabilityTheory.variance_eq_sub",
+        "description": "On a probability measure, Var[X] = E[X²] − (E[X])² for X ∈ L². Applied to each Wᵢ and to the aggregate ∑ Wᵢ it reduces the variance law to a second-moment law once the means are zero.",
+        "module": "Mathlib.Probability.Moments.Variance"
+      },
+      {
+        "theorem": "MeasureTheory.integral_finset_sum",
+        "description": "Linearity of the integral over a Finset: E[∑_{i∈s} Wᵢ] = ∑_{i∈s} E[Wᵢ], used to show the aggregate of zero-mean contributions is again zero-mean.",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.memLp_finset_sum'",
+        "description": "A finite sum of L² functions is again L², supplying square-integrability of the aggregate ∑ Wᵢ needed to apply variance_eq_sub to it.",
+        "module": "Mathlib.MeasureTheory.Function.LpSpace.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.MemLp.integrable",
+        "description": "On a finite measure, L² membership implies integrability (1 ≤ 2), supplying the integrability hypotheses for integral_finset_sum.",
+        "module": "Mathlib.MeasureTheory.Function.LpSpace.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Shannon's AWGN capacity C = ½ log(1 + P/N) rests on the output power adding across independent contributions. For a single symbol the output Y = X + Z has power E[Y²] = P + N; for a transmitted block of n symbols the aggregate output is a finite sum ∑ᵢ Wᵢ of per-symbol signal and noise terms, and the block power is the sum of the individual powers. The underlying probabilistic fact is the Bienaymé identity: the variance of a sum of pairwise-independent random variables is the sum of the variances, because pairwise independence annihilates every covariance cross-term. The parent entry (shannon-channel-coding-awgn-oq-02) established the two-term case; this entry lifts it to arbitrary finite blocks.",
+    "problemStatement": "For a finite index set s and contributions Wᵢ (i ∈ s) that are pairwise independent, zero-mean and square-integrable, derive the aggregate output-power identity E[(∑_{i∈s} Wᵢ)²] = ∑_{i∈s} E[Wᵢ²]. Recover the parent's two-term identity E[(X+Z)²] = E[X²] + E[Z²] as the special case s = {X, Z}.",
+    "proofStrategy": "Two facts compose, exactly as in the two-term case but with the Finset generalizations. (1) Pairwise-independent variance additivity: IndepFun.variance_sum gives Var[∑ Wᵢ] = ∑ Var[Wᵢ], the step where pairwise independence kills all off-diagonal covariances. (2) Power = variance for zero-mean signals: variance_eq_sub gives Var[W] = E[W²] − (E[W])², so for any zero-mean W the second moment equals the variance. The aggregate ∑ Wᵢ is itself zero-mean (E[∑ Wᵢ] = ∑ E[Wᵢ] = 0 by linearity of expectation over the Finset, using square-integrability ⟹ integrability), so applying variance_eq_sub to the sum and to each Wᵢ and dropping the vanishing squared-mean terms yields E[(∑ Wᵢ)²] = ∑ E[Wᵢ²]. Naming Pᵢ = E[Wᵢ²] gives the block output power ∑ Pᵢ (awgn_multisymbol_output_power).",
+    "keyInsights": [
+      "Pairwise independence is enough. The block-power identity does not need mutual (full) independence of the contributions: the variance of a sum expands into a double sum of covariances, and only pairwise independence is required to make every off-diagonal covariance vanish. Mathlib packages this as IndepFun.variance_sum with a Set.Pairwise hypothesis.",
+      "Zero mean is what turns 'variance' into 'power', and it must hold for the aggregate too. The engineering quantity E[W²] equals the probabilistic variance Var[W] only after the squared-mean term (E[W])² is dropped. The same reduction on the aggregate ∑ Wᵢ is legitimate because a finite sum of zero-mean contributions is again zero-mean (sum_mean_zero).",
+      "The two-term parent result is the special case |s| = 2. Instantiating s = {signal, noise} recovers E[(X+Z)²] = E[X²] + E[Z²]; the Finset formulation makes the n-symbol block-power budget a single identity rather than an induction the caller must run."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Open Question and Strategy",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "States the open question — the multi-symbol (finite-block) generalization of the parent's two-term output-power identity — and outlines the answer: the pairwise-independent variance-of-a-sum law (Bienaymé) combined with the zero-mean identification E[W²] = Var[W]. Notes that pairwise independence suffices and that the file is axiom-free and sorry-free.",
+      "mathContext": "$\\mathbb{E}\\left[\\left(\\sum_{i\\in s} W_i\\right)^2\\right] = \\sum_{i\\in s} \\mathbb{E}[W_i^2]$"
+    },
+    {
+      "id": "second-moment-eq-variance",
+      "title": "Power = Variance for Zero-Mean Signals",
+      "startLine": 40,
+      "endLine": 48,
+      "summary": "second_moment_eq_variance: for a zero-mean square-integrable W, E[W²] = Var[W], via variance_eq_sub with the mean substituted to zero. This is the bridge identifying signal power with variance, reused for both the aggregate and each summand.",
+      "mathContext": "$\\mathbb{E}[W] = 0 \\implies \\mathbb{E}[W^2] = \\operatorname{Var}[W]$"
+    },
+    {
+      "id": "multisymbol-variance",
+      "title": "Bienaymé Identity in Channel Notation",
+      "startLine": 50,
+      "endLine": 62,
+      "summary": "awgn_multisymbol_variance: Var[∑_{i∈s} Wᵢ] = ∑_{i∈s} Var[Wᵢ] for pairwise-independent square-integrable Wᵢ, recorded directly from IndepFun.variance_sum. Makes explicit the step where pairwise independence eliminates every off-diagonal covariance.",
+      "mathContext": "$\\operatorname{Var}\\left[\\sum_{i\\in s} W_i\\right] = \\sum_{i\\in s} \\operatorname{Var}[W_i]$"
+    },
+    {
+      "id": "sum-mean-zero",
+      "title": "The Aggregate Is Again Zero-Mean",
+      "startLine": 64,
+      "endLine": 72,
+      "summary": "sum_mean_zero: E[∑_{i∈s} Wᵢ] = 0 for zero-mean contributions, via linearity of the integral over a Finset (integral_finset_sum) on the integrable parts. This lets the squared-mean term drop for the aggregate, not just for each summand.",
+      "mathContext": "$\\mathbb{E}\\left[\\sum_{i\\in s} W_i\\right] = \\sum_{i\\in s} \\mathbb{E}[W_i] = 0$"
+    },
+    {
+      "id": "multisymbol-power",
+      "title": "Multi-Symbol Output Power",
+      "startLine": 74,
+      "endLine": 93,
+      "summary": "awgn_multisymbol_power: the core identity E[(∑_{i∈s} Wᵢ)²] = ∑_{i∈s} E[Wᵢ²]. Combines second_moment_eq_variance on the (zero-mean, L²) aggregate, awgn_multisymbol_variance, and a term-by-term application of second_moment_eq_variance to each Wᵢ.",
+      "mathContext": "$\\mathbb{E}\\left[\\left(\\sum_{i\\in s} W_i\\right)^2\\right] = \\sum_{i\\in s} \\mathbb{E}[W_i^2]$"
+    },
+    {
+      "id": "multisymbol-output-power",
+      "title": "Block Power Budget (Named Powers)",
+      "startLine": 95,
+      "endLine": 113,
+      "summary": "awgn_multisymbol_output_power: writing Pᵢ = E[Wᵢ²], the aggregate output power is ∑_{i∈s} Pᵢ — the n-symbol analogue of the parent's E[Y²] = P + N, obtained by rewriting the powers into the core identity.",
+      "mathContext": "$\\mathbb{E}\\left[\\left(\\sum_{i\\in s} W_i\\right)^2\\right] = \\sum_{i\\in s} P_i$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The multi-symbol AWGN output-power identity E[(∑_{i∈s} Wᵢ)²] = ∑_{i∈s} E[Wᵢ²] is derived for arbitrary finite blocks of pairwise-independent, zero-mean, square-integrable contributions. The Bienaymé variance-of-a-sum law (IndepFun.variance_sum) gives Var[∑ Wᵢ] = ∑ Var[Wᵢ]; the aggregate is again zero-mean (sum_mean_zero via integral_finset_sum), so for zero-mean signals the second moment equals the variance (variance_eq_sub), yielding the block identity (awgn_multisymbol_power) and its named-power form ∑ Pᵢ (awgn_multisymbol_output_power). 113 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This lifts the parent's two-term output-power identity to n-symbol blocks, exposing that (a) pairwise — not mutual — independence already suffices for powers to add, and (b) the zero-mean assumption is what identifies power with variance, applied uniformly to the aggregate and each summand. The Finset formulation delivers the block-power budget as a single reusable identity for multi-symbol AWGN power constraints."
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-awgn-oq-02",
+      "relationship": "extends",
+      "description": "Parent. Establishes the two-term output-power identity E[(X+Z)²] = E[X²] + E[Z²] via IndepFun.variance_add; this entry generalizes it to a finite block ∑_{i∈s} Wᵢ via the pairwise-independent IndepFun.variance_sum, recovering the parent as the case |s| = 2."
+    },
+    {
+      "targetId": "shannon-channel-coding-awgn",
+      "relationship": "related",
+      "description": "Grandparent. The AWGN capacity C = ½ log(1 + P/N) rests on the output power adding across independent contributions; this entry supplies the block-power version of that additivity."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Probability.Moments.Variance",
+      "author": "Mathlib Community",
+      "year": "2026",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of IndepFun.variance_sum (variance of a sum of pairwise-independent variables) and variance_eq_sub (Var[X] = E[X²] − (E[X])²), the two lemmas this entry composes."
+    },
+    {
+      "title": "Elements of Information Theory",
+      "author": "Thomas M. Cover and Joy A. Thomas",
+      "year": "2006",
+      "venue": "Wiley-Interscience",
+      "description": "Standard reference for AWGN channel capacity and the additive output-power relation for independent contributions."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers **OQ-02** of `shannon-channel-coding-awgn-oq-02` — *"Variance of a Sum of Pairwise-Independent Contributions (Multi-Symbol AWGN Output Power)"*.

The parent entry discharges the **two-term** AWGN output-power identity `E[(X+Z)²] = E[X²] + E[Z²]` via `IndepFun.variance_add`. A transmitted **block of n symbols** produces an aggregate output that is a finite sum `∑_{i∈s} Wᵢ`; this PR proves the block-power identity

```
E[(∑_{i∈s} Wᵢ)²] = ∑_{i∈s} E[Wᵢ²]
```

for **pairwise-independent**, zero-mean, square-integrable contributions, recovering the parent as the case `|s| = 2`.

## New results (all machine-checked, Lean v4.26.0, green in Docker)

- **`awgn_multisymbol_power`** — the core identity `E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]`. Combines the Bienaymé variance-of-a-sum law (`IndepFun.variance_sum`) with the zero-mean bridge `E[W²] = Var[W]`, applied to both the aggregate and each summand.
- **`awgn_multisymbol_output_power`** — named-power form `E[(∑ᵢ Wᵢ)²] = ∑ᵢ Pᵢ`, the n-symbol block-power budget (analogue of the parent's `E[Y²] = P + N`).
- **`awgn_multisymbol_variance`** — `Var[∑ᵢ Wᵢ] = ∑ᵢ Var[Wᵢ]` (Bienaymé, channel notation).
- **`sum_mean_zero`** — the aggregate of zero-mean contributions is zero-mean (`integral_finset_sum`).
- **`second_moment_eq_variance`** — `E[W²] = Var[W]` for zero-mean `W`.

**Key point:** *pairwise* (not mutual/full) independence already suffices for the powers to add — exactly the classical Bienaymé identity.

## Verification

- 5 theorems, 0 definitions, **0 axioms, 0 sorries, 0 native_decide**.
- Builds green in Docker (`Proofs.ShannonChannelCodingAWGNOQ02OQ02`).
- Depends only on `propext`, `Classical.choice`, `Quot.sound`.

## Files

- `proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean` (new, 113 lines)
- `src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)