### PR TITLE
research(dirichlets-theorem-oq-02-oq-03): ratio B/C diverges — (C k)²≤B k [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -682,4 +682,116 @@ exponentiation `C k ↦ 2^(C k)` of the primorial value, at every level. -/
 theorem two_pow_C_le_B_succ (k : ℕ) : 2 ^ C k ≤ B (k + 1) :=
   le_trans (Nat.pow_le_pow_right (by norm_num) (C_le_B k)) (B_succ_ge_two_pow k)
 
+/-! ## Step 10: the ratio `B / C` diverges — `B k ≥ (C k)²` and `∀ m, m·C k ≤ B k`
+
+Steps 8–9 separated the two towers by *growth class* (primorial `C` is
+doubly-exponential, factorial `B` is tower-exponential).  Here we turn that
+qualitative separation into a quantitative statement about the ratio: the
+factorial tower eventually dominates the **square** of the primorial tower,
+`(C k)² ≤ B k`, and consequently `B k / C k → ∞` in the division-free form
+`∀ m, ∃ K, ∀ k ≥ K, m·C k ≤ B k`.
+
+The mechanism is the exponential step `2^(C k) ≤ B (k+1)`
+(`two_pow_C_le_B_succ`): one factorial step raises `2` to the whole primorial
+value, and a base-2 exponential of `C k` dwarfs any fixed power of `C (k+1)`
+(which is only `≈ (C k)²`).  The single analytic-free input is the elementary
+`(n+1)^4 ≤ 2^n` for `n ≥ 17`. -/
+
+/-- Closed multiplicative form of the primorial recursion:
+`C (k+1) + 1 = (C k + 1)·C k`.  Equivalently `C (k+1) = (C k)² + C k − 1`, so
+each step squares the previous value up to lower-order terms — the source of the
+doubly-exponential growth of `C`. -/
+theorem C_succ_add_one (k : ℕ) : C (k + 1) + 1 = (C k + 1) * C k := by
+  have ht : 1 ≤ towerProd k :=
+    le_trans (Nat.one_le_pow _ _ (by norm_num)) (towerProd_ge k)
+  have ht1 : 1 ≤ towerProd (k + 1) :=
+    le_trans (Nat.one_le_pow _ _ (by norm_num)) (towerProd_ge (k + 1))
+  have hCk : C k + 1 = 4 * towerProd k := by rw [C_eq]; omega
+  have hCk1 : C (k + 1) + 1 = 4 * towerProd (k + 1) := by rw [C_eq]; omega
+  rw [hCk1, towerProd_succ, hCk, C_eq]
+  set d := 4 * towerProd k - 1
+  ring
+
+/-- Each primorial step is bounded by the square of the successor:
+`C (k+1) ≤ (C k + 1)²`.  Immediate from `C_succ_add_one`. -/
+theorem C_succ_le_sq (k : ℕ) : C (k + 1) ≤ (C k + 1) ^ 2 := by
+  have h := C_succ_add_one k
+  have hle : (C k + 1) * C k ≤ (C k + 1) ^ 2 := by
+    rw [sq]; exact Nat.mul_le_mul_left _ (Nat.le_succ _)
+  omega
+
+/-- The primorial tower is monotone: `C k ≤ C (k+1)`.  Since
+`C (k+1) + 1 = (C k + 1)·C k ≥ C k + 1` (as `C k ≥ 1`). -/
+theorem C_le_succ (k : ℕ) : C k ≤ C (k + 1) := by
+  have h := C_succ_add_one k
+  have hpos : 1 ≤ C k := by
+    have := towerProd_ge k
+    have h1 : 1 ≤ towerProd k := le_trans (Nat.one_le_pow _ _ (by norm_num)) this
+    rw [C_eq]; omega
+  nlinarith [h, hpos]
+
+/-- Monotonicity of the primorial tower. -/
+theorem C_mono : Monotone C := monotone_nat_of_le_succ C_le_succ
+
+/-- Linear lower bound `k + 3 ≤ C k`: in particular `C` is unbounded, so it
+eventually exceeds any fixed multiplier. -/
+theorem C_ge_add (k : ℕ) : k + 3 ≤ C k := by
+  induction k with
+  | zero => rw [C_zero_eq]
+  | succ n ih =>
+    have h := C_succ_add_one n
+    nlinarith [ih, h]
+
+/-- **Exponential beats a fixed power:** `(n+1)^4 ≤ 2^n` for `n ≥ 17`.  The one
+elementary, `native_decide`-free input to the ratio-divergence result.  Proved by
+induction from the base `18^4 = 104976 ≤ 131072 = 2^17`, with the multiplicative
+step `(n+2)^4 ≤ 2·(n+1)^4` (valid for `n ≥ 5`). -/
+theorem quartic_le_two_pow (n : ℕ) (hn : 17 ≤ n) : (n + 1) ^ 4 ≤ 2 ^ n := by
+  induction n, hn using Nat.le_induction with
+  | base => norm_num
+  | succ n hn ih =>
+    have h1 : 289 ≤ n * n := by nlinarith [hn]
+    have h2 : 289 * (n * n) ≤ (n * n) * (n * n) := by nlinarith [h1]
+    have hstep : (n + 2) ^ 4 ≤ 2 * (n + 1) ^ 4 := by nlinarith [hn, h1, h2]
+    calc (n + 1 + 1) ^ 4 = (n + 2) ^ 4 := by ring
+      _ ≤ 2 * (n + 1) ^ 4 := hstep
+      _ ≤ 2 * 2 ^ n := by omega
+      _ = 2 ^ (n + 1) := by rw [pow_succ]; ring
+
+/-- **The factorial tower dominates the square of the primorial tower:**
+`(C k)² ≤ B k` for all `k ≥ 3`.  Writing `k = j+1`, the exponential step gives
+`B (j+1) ≥ 2^(C j)`, while `C (j+1) ≤ (C j + 1)²` so `C (j+1)² ≤ (C j + 1)^4`,
+and `(C j + 1)^4 ≤ 2^(C j)` once `C j ≥ 17` (true for `j ≥ 2`, since `C 2 = 131`
+and `C` is monotone).  Certified, `native_decide`-free. -/
+theorem C_sq_le_B {k : ℕ} (hk : 3 ≤ k) : C k ^ 2 ≤ B k := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  have hj2 : 2 ≤ j := by omega
+  have hCj : 17 ≤ C j := by
+    have hmono := C_mono hj2
+    rw [C_two_eq] at hmono
+    omega
+  have hquartic : (C j + 1) ^ 4 ≤ 2 ^ C j := quartic_le_two_pow (C j) hCj
+  have hsucc : C (j + 1) ^ 2 ≤ (C j + 1) ^ 4 := by
+    calc C (j + 1) ^ 2 ≤ ((C j + 1) ^ 2) ^ 2 := Nat.pow_le_pow_left (C_succ_le_sq j) 2
+      _ = (C j + 1) ^ 4 := by ring
+  calc C (j + 1) ^ 2 ≤ (C j + 1) ^ 4 := hsucc
+    _ ≤ 2 ^ C j := hquartic
+    _ ≤ B (j + 1) := two_pow_C_le_B_succ j
+
+/-- **The ratio `B / C` diverges (division-free form):**
+`∀ m, ∃ K, ∀ k ≥ K, m·C k ≤ B k`.  Since `C k → ∞` (`C_ge_add`), taking
+`k ≥ max 3 m` gives `m ≤ C k`, and then `m·C k ≤ (C k)² ≤ B k` by `C_sq_le_B`.
+This is the precise quantitative statement that the elementary factorial
+certificate `B` outgrows the primorial certificate `C` without bound — a
+certified counterpart to `p_k / C_k → ∞` for the two Euclid-style towers. -/
+theorem B_div_C_diverges (m : ℕ) : ∃ K, ∀ k, K ≤ k → m * C k ≤ B k := by
+  refine ⟨max 3 m, fun k hk => ?_⟩
+  have hk3 : 3 ≤ k := le_trans (le_max_left _ _) hk
+  have hkm : m ≤ k := le_trans (le_max_right _ _) hk
+  have hCk : m ≤ C k := by have := C_ge_add k; omega
+  have hsq : C k ^ 2 ≤ B k := C_sq_le_B hk3
+  calc m * C k ≤ C k * C k := Nat.mul_le_mul_right _ hCk
+    _ = C k ^ 2 := (sq (C k)).symm
+    _ ≤ B k := hsq
+
 end DirichletsTheoremOQ02OQ03

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -172,12 +172,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 410,
+    "lineCount": 797,
     "axiomCount": 0,
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 37
+    "theoremCount": 56
   },
   "sorries": 0,
   "status": "verified",

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: gap-growth quantified (next-step 3). The primorial tower C is doubly-exponential (Step 8 two-sided bracket); the factorial tower B is tower-exponential (Step 9: 2^(B k)≤B(k+1), 2^(C k)≤B(k+1)). Upper-bound side remains at elementary terminus (true 2k·ln k needs analytic input).",
+    "progressSummary": "PROGRESS: ratio B/C diverges as a theorem (VERIFIED 0/0). C_sq_le_B: (C k)²≤B k for k≥3; B_div_C_diverges: ∀m ∃K ∀k≥K, m·C k≤B k. Fills next-step 2 (division-free divergence). Upper-bound side of the original open question still at elementary terminus (needs analytic 2k·ln k).",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
@@ -47,7 +47,13 @@
       "C_lt_B (DirichletsTheoremOQ02OQ03.lean:509) — VERIFIED 0/0: the primorial tower is STRICTLY below the factorial tower, C k < B k for all k≥1, promoting the single-index C 1=11<95=B 1 to a theorem.",
       "C_eq_B_iff (DirichletsTheoremOQ02OQ03.lean:517) — VERIFIED 0/0: exact comparison C k = B k ↔ k = 0; combines C_le_B, C_lt_B and the base equality C 0 = B 0 = 3.",
       "four_mul_towerProd_le / C_le_doubly_exp / p3_le_doubly_exp in DirichletsTheoremOQ02OQ03.lean (~525-548): squaring induction 4·towerProd k ≤ 4^(2^k), collapsing the recursive tower to closed form. VERIFIED 0/0.",
-      "two_pow_le_succ_factorial (2^n≤(n+1)!), B_succ_ge_two_pow (2^(B k)≤B(k+1)), two_pow_C_le_B_succ (2^(C k)≤B(k+1)) in DirichletsTheoremOQ02OQ03.lean Step 9 [VERIFIED 0/0, PR #35652]"
+      "two_pow_le_succ_factorial (2^n≤(n+1)!), B_succ_ge_two_pow (2^(B k)≤B(k+1)), two_pow_C_le_B_succ (2^(C k)≤B(k+1)) in DirichletsTheoremOQ02OQ03.lean Step 9 [VERIFIED 0/0, PR #35652]",
+      "C_succ_add_one (DirichletsTheoremOQ02OQ03.lean:704) — closed multiplicative form of the primorial recursion: C(k+1)+1 = (C k+1)·C k. Proved by set-d over the nat-subtraction atom then ring. Basis for monotonicity and the square bound.",
+      "C_succ_le_sq (:717), C_le_succ (:725), C_mono (:734) — C(k+1) ≤ (C k+1)², and Monotone C via monotone_nat_of_le_succ.",
+      "C_ge_add (:738) — linear lower bound k+3 ≤ C k (⇒ C unbounded), by induction with nlinarith on the multiplicative recursion.",
+      "quartic_le_two_pow (:749) — (n+1)^4 ≤ 2^n for n≥17 (exponential beats fixed power). Nat.le_induction from 18^4≤2^17; step (n+2)^4 ≤ 2·(n+1)^4 needs nlinarith with degree-4 hints 289≤n·n and 289·n²≤n⁴.",
+      "C_sq_le_B (:766) — VERIFIED 0/0: the factorial tower dominates the SQUARE of the primorial tower, (C k)² ≤ B k for k≥3. Chain: B(j+1)≥2^(C j), C(j+1)²≤(C j+1)^4≤2^(C j) (quartic, C j≥17 since C 2=131 & monotone).",
+      "B_div_C_diverges (:787) — VERIFIED 0/0: division-free ratio divergence ∀m ∃K ∀k≥K, m·C k ≤ B k. From C k→∞ pick k≥max 3 m so m≤C k, then m·C k ≤ (C k)² ≤ B k. PR #TBD."
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
@@ -61,14 +67,19 @@
       "The ≤-domination C k ≤ B k is in fact STRICT for every k≥1: the only inequality used (n·(n−1) ≤ n!) is itself strict once n≥4 (n! = n·(n−1)! and (n−1) < (n−1)! for n−1≥3), and the towers factorial argument 4·(B k+1)! is always ≥4, so the strictness propagates and equality survives ONLY at the base k=0 where both towers equal 3.",
       "Closed form: the recursive primorial tower C k satisfies C k ≤ 4^(2^k), so p3 k ≤ 4^(2^k) — an explicit non-recursive certified bound whose exponent 2^k exhibits the doubly-exponential order directly (true value ~ 2k ln k).",
       "Growth-class separation of the two certified towers: the primorial tower C squares each step (C(k+1)≈C k², doubly-exponential, Step 8 bracket) while the factorial tower B exponentiates (2^(B k)≤B(k+1)), so B is tower-exponential (B k≥2↑↑k). The gap B/C diverges as a theorem, not just at k=1.",
-      "Key mechanism: one factorial step turns the WHOLE previous primorial value into an exponent — 2^(C k)≤B(k+1) — via C_le_B chained with the exponential step. Certified/native_decide-free."
+      "Key mechanism: one factorial step turns the WHOLE previous primorial value into an exponent — 2^(C k)≤B(k+1) — via C_le_B chained with the exponential step. Certified/native_decide-free.",
+      "Ratio divergence needs only a FIXED-base exponential-vs-power lemma, not an m-dependent one: proving (C k)²≤B k (via the quartic (n+1)^4≤2^n, n≥17) is both STRONGER than and EASIER than the m-parametrised m·C k≤B k, because the square absorbs the multiplier once C k≥m (C k→∞). Prove the square bound first, derive the ∀m form as a one-line corollary.",
+      "The primorial recursion linearises for ring via set d := 4·towerProd k − 1: C(k+1)+1 = (C k+1)·C k has a clean closed form once the nat-subtraction sub-term is abstracted to an atom, sidestepping ring´s inability to normalise ℕ subtraction.",
+      "quartic step (n+2)^4 ≤ 2·(n+1)^4 is degree-4; nlinarith needs the products handed in (289≤n·n and 289·n²≤n·n·n·n) — bare nlinarith [hn] fails to synthesise the n⁴ monomial."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Attempt a genuinely elementary sub-exponential certified bound (or prove the primorial tower´s doubly-exponential growth is intrinsic to Euclid-style iteration without an analytic input).",
       "Formalize B/C→∞ as ∀m, ∃K, ∀k≥K, m·C k≤B k (division-free divergence), building on 2^(C k)≤B(k+1) and the doubly-exp bracket for C.",
       "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1).",
-      "Quantify the gap growth: prove B k / C k → ∞ (or a lower bound like B k ≥ C k · (something growing), since each factorial step swaps a squaring for a full factorial)."
+      "Quantify the gap growth: prove B k / C k → ∞ (or a lower bound like B k ≥ C k · (something growing), since each factorial step swaps a squaring for a full factorial).",
+      "Sharpen (C k)²≤B k to (C k)^p ≤ B k for every fixed p (same route with (n+1)^(2p)≤2^n), or to B k ≥ 2^(C (k-1)) exhibiting the true tower gap.",
+      "Formalise C k ↑↑-style: B k ≥ 2 ↑↑ k vs C k ≤ 4^(2^k) to state the growth-class separation as an iterated-exponential lower bound on B."
     ],
     "markdown": "# Knowledge Base: dirichlets-theorem-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the certified-tower analysis of the Euclid-style bound for the *k*-th prime ≡ 3 (mod 4) with **Step 10: the ratio B/C diverges**, turning the qualitative growth-class separation of Steps 8–9 into a quantitative statement.

Two certified towers bound the prime: the **primorial tower** `C` (doubly-exponential) and the **factorial tower** `B` (tower-exponential). Previous work established `C k ≤ B k`, strict comparison, the doubly-exponential bracket for `C`, and the exponential step `2^(C k) ≤ B(k+1)`. This PR proves the factorial tower dominates the **square** of the primorial tower, hence `B/C → ∞`.

## New theorems (all VERIFIED, 0 sorry / 0 axiom, `native_decide`-free)

- **`C_sq_le_B`** — `(C k)² ≤ B k` for `k ≥ 3`. Chain: `B(j+1) ≥ 2^(C j)`, and `C(j+1)² ≤ (C j+1)^4 ≤ 2^(C j)` once `C j ≥ 17` (true for `j ≥ 2` since `C 2 = 131` and `C` is monotone).
- **`B_div_C_diverges`** — `∀ m, ∃ K, ∀ k ≥ K, m · C k ≤ B k` (division-free ratio divergence). Since `C k → ∞`, take `k ≥ max 3 m` so `m ≤ C k`, then `m·C k ≤ (C k)² ≤ B k`.

Supporting lemmas: `C_succ_add_one` (closed multiplicative form `C(k+1)+1 = (C k+1)·C k`), `C_succ_le_sq`, `C_le_succ`/`C_mono`, `C_ge_add` (linear lower bound `k+3 ≤ C k`), and `quartic_le_two_pow` (`(n+1)^4 ≤ 2^n` for `n ≥ 17`).

## Verification

`./proofs/scripts/docker-build.sh Proofs.DirichletsTheoremOQ02OQ03` → `✔ Built Proofs.DirichletsTheoremOQ02OQ03`, "Build completed successfully". No `sorry`, no `axiom`, no `native_decide`.

Also refreshes stale `meta.leanFile` counts (lineCount 410→797, theoremCount 37→56) to reflect the current file after recent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)