### PR TITLE
research(erdos-748-incomplete-01): f is strictly monotone (StrictMono f) [VERIFIED 0/0-new-axiom]

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -209,6 +209,41 @@ theorem f_monotone : Monotone f :=
   monotone_nat_of_le_succ fun n =>
     Finset.card_le_card (sumFreeSubsets_subset_succ n)
 
+/--
+**The counting function `f` is strictly monotone.**
+Passing from `{1,…,n}` to `{1,…,n+1}` keeps every existing sum-free subset
+(`sumFreeSubsets_subset_succ`) and adds at least one genuinely new one: the
+singleton `{n+1}`, which is sum-free (`n+1 ≠ (n+1)+(n+1)`) but cannot fit inside
+`{1,…,n}`. Hence the inclusion of families is *strict*, so the count grows by at
+least one at every step (`f n < f (n+1)`). This sharpens `f_monotone`, which now
+follows as `f_strictMono.monotone`.
+-/
+theorem f_strictMono : StrictMono f := by
+  apply strictMono_nat_of_lt_succ
+  intro n
+  show (sumFreeSubsets n).card < (sumFreeSubsets (n + 1)).card
+  apply Finset.card_lt_card
+  rw [Finset.ssubset_iff_of_subset (sumFreeSubsets_subset_succ n)]
+  refine ⟨{n + 1}, ?_, ?_⟩
+  · -- `{n+1}` is a sum-free subset of `{1,…,n+1}`.
+    rw [sumFreeSubsets, Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨?_, ?_⟩
+    · intro x hx
+      rw [Finset.mem_singleton] at hx
+      subst hx
+      rw [Finset.mem_Icc]
+      omega
+    · -- `{n+1}` is sum-free: `n+1 ≠ (n+1) + (n+1)` (inlined `singleton_sumFree`).
+      intro a b c ha hb hc
+      rw [Finset.mem_singleton] at ha hb hc
+      omega
+  · -- `{n+1} ⊄ {1,…,n}`, so it is not counted by `sumFreeSubsets n`.
+    rw [sumFreeSubsets, Finset.mem_filter, Finset.mem_powerset]
+    rintro ⟨hsub, -⟩
+    have hmem : (n + 1) ∈ Finset.Icc 1 n := hsub (Finset.mem_singleton_self _)
+    rw [Finset.mem_Icc] at hmem
+    omega
+
 /-
 ## Part IV: The Cameron-Erdős Conjecture
 -/

--- a/research/problems/erdos-748-incomplete-01/knowledge.md
+++ b/research/problems/erdos-748-incomplete-01/knowledge.md
@@ -66,3 +66,19 @@ No change to the substantive status: 2 deep axioms remain (Green 2004 /
 Sapozhenko 2003), entry stays `axiomatized` / axiomCount 2. The two axioms are
 genuine >1000-line literature results (BLOCKED). Follow-up "largest sum-free
 subset has size ⌈n/2⌉" owned by PR #30202. Nothing else routine to do here.
+
+### Strict monotonicity of f (2026-07-08, researcher-2)
+
+Added `f_strictMono : StrictMono f` (0 axioms, Docker-built green [1857/1857]).
+This sharpens the existing `f_monotone`. Proof: `sumFreeSubsets n ⊊ sumFreeSubsets
+(n+1)` because the singleton `{n+1}` is sum-free (`n+1 ≠ (n+1)+(n+1)`) and lies in
+`{1,…,n+1}` but NOT in `{1,…,n}` (since `n+1 ∉ Icc 1 n`). Hence `f n < f (n+1)`
+via `Finset.card_lt_card` + `Finset.ssubset_iff_of_subset`. So the count grows by
+at least one at every step; `f_monotone = f_strictMono.monotone`. The
+`singleton_sumFree` lemma is defined later in the file, so its one-line argument
+is inlined at the use site.
+
+Substantive status unchanged: 2 deep axioms remain (Green 2004 upper bound /
+Sapozhenko 2003 precise asymptotic), both >1000-line literature results (BLOCKED).
+Entry stays `axiomatized`, axiomCount 2. Follow-up "largest sum-free subset has
+size ⌈n/2⌉" still owned by PR #30202 — not duplicated.

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -180,9 +180,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 424,
+    "lineCount": 459,
     "axiomCount": 2,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Erdős #748 (Cameron–Erdős conjecture on sum-free sets) is already essentially complete in `Erdos748Problem.lean`: **0 sorries**, 2 genuinely deep BLOCKED axioms (Green 2004 upper bound `f(n) ≪ 2^{n/2}` and Sapozhenko 2003 precise asymptotic). This session adds one clean, genuinely-new structural theorem at **0 new axioms**.

## What's new

`f_strictMono : StrictMono f` — the counting function `f(n)` (number of sum-free subsets of `{1,…,n}`) is **strictly** monotone, sharpening the existing `f_monotone`.

**Proof.** Passing from `{1,…,n}` to `{1,…,n+1}` keeps every existing sum-free subset (`sumFreeSubsets_subset_succ`) and adds a genuinely new one: the singleton `{n+1}`, which is sum-free (`n+1 ≠ (n+1)+(n+1)`) but cannot fit inside `{1,…,n}` (since `n+1 ∉ Icc 1 n`). Hence `sumFreeSubsets n ⊊ sumFreeSubsets (n+1)`, and `Finset.card_lt_card` gives `f n < f (n+1)`. Now `f_monotone = f_strictMono.monotone`.

## Honest assessment

Modest. This is a small structural strengthening, not a breakthrough — the substantive content of #748 (the upper bound / asymptotic) remains the two deep BLOCKED axioms. It is the natural remaining 0-axiom structural fact about `f` (the main follow-up "largest sum-free subset has size ⌈n/2⌉" is owned by PR #30202 and is not touched here).

## Verification

- Docker-built green: `✔ [1857/1857] Built Proofs.Erdos748Problem (3.5s)`
- 0 sorries; 0 new axioms (2 pre-existing deep axioms unchanged → entry stays `axiomatized`, axiomCount 2)
- `singleton_sumFree` is defined later in the file, so its one-line argument is inlined at the use site
- Synced `leanFile` metadata: lineCount 424→459, theoremCount 15→16

🤖 Generated with [Claude Code](https://claude.com/claude-code)