### PR TITLE
research(erdos-165-oq-05): symmetric Shearer obstruction — refute any R(3,k) constant >1 [VERIFIED, 0 new axioms]

### DIFF
--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -303,6 +303,46 @@ theorem pgm_conjecture_refuted : ¬ pgmConjecture := by
   have : (1:ℝ)/2 ≤ 1/4 := R3_upper_constant_ge_half (1/4) hupper
   norm_num at this
 
+/-- **No asymptotic lower constant above `1`.**  The mirror of
+    `R3_upper_constant_ge_half`: if `R(3,k) ≥ (a - ε)·k²/log k` holds eventually for
+    *every* `ε > 0`, then `a ≤ 1`.  This is Shearer's upper bound (`c ≤ 1`) phrased as an
+    obstruction — any *valid* first-order lower constant for `R(3,k)` is at most `1`.  The
+    only Ramsey input is `shearer_upper_bound`; the rest is the axiom-free
+    `asymptotic_constant_le`. -/
+theorem R3_lower_constant_le_one (a : ℝ)
+    (ha : ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
+        (a - ε) * k^2 / log k ≤ (R3 k : ℝ)) :
+    a ≤ 1 := by
+  refine asymptotic_constant_le (fun k => (R3 k : ℝ)) a 1 ha ?_
+  intro ε hε
+  obtain ⟨k₀, hk₀⟩ := shearer_upper_bound ε hε
+  exact ⟨k₀, fun k hk => hk₀ k hk⟩
+
+/-- A conjectured exact asymptotic constant `c` for `R(3,k)`, i.e. `R(3,k) ~ c·k²/log k`:
+    `(c-ε)·k²/log k ≤ R(3,k) ≤ (c+ε)·k²/log k` eventually for every `ε > 0`.  This is the
+    common shape of `mainConjecture` (`c = 1/2`) and `pgmConjecture` (`c = 1/4`). -/
+def constantConjecture (c : ℝ) : Prop :=
+    ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
+      (c - ε) * k^2 / log k ≤ R3 k ∧ (R3 k : ℝ) ≤ (c + ε) * k^2 / log k
+
+/-- **Any conjectured constant `> 1` is refuted by Shearer's upper bound.**  The symmetric
+    companion to `pgm_conjecture_refuted`: whereas the PGM constant `1/4` is ruled out from
+    *below* (HHKP forces the constant `≥ 1/2`), any constant exceeding `1` is ruled out from
+    *above* — its lower half would assert a valid lower constant `> 1`, contradicting
+    `R3_lower_constant_le_one`.  Together with `pgm_conjecture_refuted` this pins the exact
+    constant to the interval `[1/2, 1]`: no conjecture with constant `< 1/2` or `> 1` can
+    hold.  The only Ramsey input is `shearer_upper_bound`. -/
+theorem constantConjecture_refuted_of_one_lt (c : ℝ) (hc : 1 < c) :
+    ¬ constantConjecture c := by
+  intro h
+  have hlower : ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
+      (c - ε) * k^2 / log k ≤ (R3 k : ℝ) := by
+    intro ε hε
+    obtain ⟨k₀, hk₀⟩ := h ε hε
+    exact ⟨k₀, fun k hk => (hk₀ k hk).1⟩
+  have : c ≤ 1 := R3_lower_constant_le_one c hlower
+  linarith
+
 /- ## Part VII: Related Problems -/
 
 /-

--- a/research/problems/erdos-165-oq-05/knowledge.md
+++ b/research/problems/erdos-165-oq-05/knowledge.md
@@ -44,3 +44,23 @@ none provable from Mathlib.
 
 - Axiom elimination is infeasible here: all 10 axioms are deep Ramsey-theory
   theorems (Kim 1995, Shearer 1983, HHKP 2025, AKS 1980) with no Mathlib proof.
+
+---
+
+## Follow-up: symmetric Shearer obstruction (researcher-1, 2026-07-08)
+
+The prior session refuted PGM (c=1/4) from *below* via HHKP (`R3_upper_constant_ge_half`).
+Added the *above* mirror using Shearer (upper constant 1):
+
+- `R3_lower_constant_le_one (a) (ha : ∀ε>0 eventually (a-ε)k²/log k ≤ R3 k) : a ≤ 1` —
+  any valid first-order LOWER constant is ≤ 1. Reuses the axiom-free `asymptotic_constant_le`
+  with (lower = ha, upper = shearer_upper_bound, b = 1).
+- `constantConjecture c` (general def, the common shape of mainConjecture c=1/2 and
+  pgmConjecture c=1/4).
+- `constantConjecture_refuted_of_one_lt (c) (1<c) : ¬ constantConjecture c` — its lower
+  half would assert a valid lower constant > 1, contradicting `R3_lower_constant_le_one`.
+
+**Net structural payoff**: `asymptotic_constant_le` is two-sided infrastructure. HHKP pins
+the constant ≥ 1/2 from below; Shearer pins it ≤ 1 from above. Together they bracket the
+(open) exact constant to **[1/2, 1]** using only the two Ramsey axioms. 0 new axioms;
+still 10 deep-Ramsey axioms (Kim/Shearer/HHKP/AKS), none Mathlib-eliminable. VERIFIED build.

--- a/src/data/research/problems/erdos-165-oq-05.json
+++ b/src/data/research/problems/erdos-165-oq-05.json
@@ -29,23 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Proved pgm_conjecture_refuted : not pgmConjecture, backed by the axiom-free incompatibility lemma asymptotic_constant_le and the general obstruction R3_upper_constant_ge_half. Added 0 new axioms. Also repaired a pre-existing Mathlib-drift build failure in erdos_165 (line 161): linarith could not widen 5/4 to 2 without k^2/log k >= 0; fixed by threading log-positivity via max k0 2 and mul_div_assoc.",
+    "progressSummary": "COMPLETED: Proved pgm_conjecture_refuted : not pgmConjecture, backed by the axiom-free incompatibility lemma asymptotic_constant_le and the general obstruction R3_upper_constant_ge_half. Added 0 new axioms. Also repaired a pre-existing Mathlib-drift build failure in erdos_165 (line 161): linarith could not widen 5/4 to 2 without k^2/log k >= 0; fixed by threading log-positivity via max k0 2 and mul_div_assoc. Follow-up (researcher-1, 2026-07-08): added the symmetric obstruction R3_lower_constant_le_one (Shearer's c≤1 ⟹ any valid lower constant ≤1) and the general constantConjecture def + constantConjecture_refuted_of_one_lt (any exact constant >1 refuted). With pgm_conjecture_refuted this brackets the true constant to [1/2,1]. 0 new axioms; still 10 deep-Ramsey axioms, none Mathlib-eliminable.",
     "builtItems": [
       "asymptotic_constant_le in Erdos165Problem.lean (axiom-free incompatibility lemma)",
       "R3_upper_constant_ge_half in Erdos165Problem.lean (HHKP obstruction)",
       "pgm_conjecture_refuted in Erdos165Problem.lean (not pgmConjecture)",
-      "Repaired erdos_165 proof (Mathlib-drift fix)"
+      "Repaired erdos_165 proof (Mathlib-drift fix)",
+      "R3_lower_constant_le_one (researcher-1): Shearer's upper bound (c≤1) as an obstruction — any valid first-order LOWER constant for R(3,k) is ≤ 1. Mirror of R3_upper_constant_ge_half; reuses axiom-free asymptotic_constant_le.",
+      "constantConjecture c (general def) + constantConjecture_refuted_of_one_lt: any conjectured exact constant c>1 is refuted from above by Shearer. With pgm_conjecture_refuted (c<1/2 refuted from below) this pins the true constant to [1/2,1]. 0 new axioms."
     ],
     "insights": [
       "The erdos-165 file on origin/main did NOT compile (linarith failure in erdos_165) despite meta claiming 0 sorries / axiomatized -- latent Mathlib drift.",
       "linarith treats c*k^2/log k as opaque unless mul_div_assoc factors out k^2/log k as a single atom; supplying 0 <= k^2/log k then lets it scale constants.",
       "The mathematical core of conjectured-constant-refuted-by-a-better-bound is a pure real-analysis fact (asymptotic_constant_le), fully axiom-free; only hhkp_bound is Ramsey input.",
-      "oq-05 (complete sorry in R3_asymptotic_order) was stale: no such sorry exists in the current file."
+      "oq-05 (complete sorry in R3_asymptotic_order) was stale: no such sorry exists in the current file.",
+      "asymptotic_constant_le is two-sided infrastructure: instantiated with (lower=HHKP, b=variable) it gives upper-constant≥1/2; with (lower=variable, upper=Shearer, b=1) it gives lower-constant≤1. The two obstructions bracket the exact constant to [1/2,1] using only the two Ramsey axioms hhkp_bound and shearer_upper_bound."
     ],
     "mathlibGaps": [],
-    "nextSteps": [
-      "Consider an analogous obstruction ruling out any conjectured constant > 1 against shearer_upper_bound."
-    ],
+    "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-165-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -69,8 +70,8 @@
     {
       "path": "Proofs/Erdos165Problem.lean",
       "filename": "Erdos165Problem.lean",
-      "lineCount": 324,
-      "theoremCount": 6,
+      "lineCount": 363,
+      "theoremCount": 8,
       "axiomCount": 10,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The file already refutes the PGM conjecture (constant `1/4`) **from below** via HHKP (`pgm_conjecture_refuted` ← `R3_upper_constant_ge_half`). The file's own `nextSteps` asked for the symmetric obstruction from Shearer's *upper* bound (constant `1`). This PR adds it:

```lean
theorem R3_lower_constant_le_one (a : ℝ)
    (ha : ∀ ε > 0, ∃ k₀, ∀ k ≥ k₀, (a - ε) * k^2 / log k ≤ (R3 k : ℝ)) : a ≤ 1
def constantConjecture (c : ℝ) : Prop := ...   -- common shape of mainConjecture / pgmConjecture
theorem constantConjecture_refuted_of_one_lt (c : ℝ) (hc : 1 < c) : ¬ constantConjecture c
```

**Structural payoff.** `asymptotic_constant_le` (the existing axiom-free two-sided lemma) is instantiated in both directions:
- `(lower = HHKP, b = variable)` ⟹ any valid **upper** constant is `≥ 1/2` (existing).
- `(lower = variable, upper = Shearer, b = 1)` ⟹ any valid **lower** constant is `≤ 1` (new).

Together these bracket the (still open) exact constant of `R(3,k) ~ c·k²/log k` to the interval **`[1/2, 1]`**: no conjecture with `c < 1/2` or `c > 1` can hold, using only the two Ramsey axioms `hhkp_bound` and `shearer_upper_bound`.

## Verification

- Docker-built `Proofs.Erdos165Problem`: **succeeded**.
- **0 new axioms.** The file retains its 10 deep-Ramsey axioms (Kim 1995 / Shearer 1983 / HHKP 2025 / AKS 1980), none provable from Mathlib — status stays `axiomatized`. The additions use only the existing `shearer_upper_bound` axiom plus the axiom-free `asymptotic_constant_le`.
- Meta synced (`theoremCount` 6→8, `lineCount` 324→363; `axiomCount` unchanged at 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)