### PR TITLE
Enrich beta-central-binomial-explicit-rate-oq-02: annotations + cross-references

### DIFF
--- a/src/data/proofs/beta-central-binomial-explicit-rate-oq-02/annotations.json
+++ b/src/data/proofs/beta-central-binomial-explicit-rate-oq-02/annotations.json
@@ -1,0 +1,140 @@
+[
+  {
+    "id": "ann-diff-upper",
+    "proofId": "beta-central-binomial-explicit-rate-oq-02",
+    "range": {
+      "startLine": 83,
+      "endLine": 144
+    },
+    "type": "technique",
+    "title": "Exact Upper Per-Step Bound via Geometric Majorant",
+    "content": "diff_upper is the sharp replacement for the parent entry's crude per-step estimate. Mathlib's exact per-step series Stirling.log_stirlingSeq_diff_hasSum expresses the drop log stirlingSeq(m+1) − log stirlingSeq(m+2) as a positive series Σ_{k≥0} (1/(2k+3))·y^{k+1} with y = x² = 1/(2m+3)². Dominating each coefficient 1/(2k+3) by its k=0 value 1/3 turns the tail into a geometric series (1/3)·y·Σ y^k = (y/3)/(1−y), which evaluates in closed form to exactly 1/(12(m+1)(m+2)). Because that closed form telescopes, the per-step bound is written as the difference 1/(12(m+1)) − 1/(12(m+2)) — the form that later sums to the sharp 1/(12j) envelope.",
+    "mathContext": "$\\log s_{m+1}-\\log s_{m+2}=\\sum_{k\\ge0}\\frac{1}{2k+3}\\,y^{k+1}\\le \\frac{y/3}{1-y}=\\frac{1}{12(m+1)(m+2)}=\\frac{1}{12(m+1)}-\\frac{1}{12(m+2)},\\quad y=\\tfrac{1}{(2m+3)^2}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Stirling asymptotic series",
+      "geometric series majorant",
+      "telescoping sums",
+      "closed-form geometric summation"
+    ],
+    "prerequisites": [
+      "convergent power series",
+      "geometric series",
+      "log of the Stirling sequence"
+    ]
+  },
+  {
+    "id": "ann-diff-lower",
+    "proofId": "beta-central-binomial-explicit-rate-oq-02",
+    "range": {
+      "startLine": 145,
+      "endLine": 208
+    },
+    "type": "technique",
+    "title": "Lower Per-Step Bound: Leading Term Plus Quadratic Deficit",
+    "content": "diff_lower_leading keeps only the single leading term x²/3 = 1/(3(2m+3)²) of the exact series, which is a valid lower bound since every dropped term is positive. diff_lower then repackages this lower drop in telescoping form: it undershoots the exact upper model 1/(12 i(i+1)) by a per-step deficit 1/(12 i(i+1)) − 1/(3(2i+1)²) = 1/(12 i(i+1)(2i+1)²) = O(1/i⁴). Bounding that deficit by the quadratic telescoping term (1/12)(1/i² − 1/(i+1)²) gives a lower per-step bound in a form that will sum to an O(1/j²) correction — enough to pin the second-order coefficient but not yet the vanishing of c₂.",
+    "mathContext": "$\\log s_{m+1}-\\log s_{m+2}\\ge \\frac{x^2}{3}=\\frac{1}{3(2m+3)^2},\\qquad \\frac{1}{12\\,i(i+1)}-\\frac{1}{3(2i+1)^2}=\\frac{1}{12\\,i(i+1)(2i+1)^2}=O(i^{-4})$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "truncated power series lower bound",
+      "telescoping majorant",
+      "per-step deficit estimate"
+    ],
+    "prerequisites": [
+      "positive-term series bounds",
+      "partial fractions"
+    ]
+  },
+  {
+    "id": "ann-devbracket",
+    "proofId": "beta-central-binomial-explicit-rate-oq-02",
+    "range": {
+      "startLine": 241,
+      "endLine": 359
+    },
+    "type": "theorem",
+    "title": "The Sharp Stirling Deviation Bracket",
+    "content": "stirlingLogDev_upper and stirlingLogDev_lower telescope the per-step bounds over m ≥ j and pass to the limit stirlingSeq → √π (the qualitative Mathlib fact, used only to close the telescoped partial sums). The capstone stirlingLogDev_bracket assembles them into the two-sided envelope 1/(12j) − 1/(12j²) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j) for j ≥ 1. The upper side is exact to leading order and identifies the true leading coefficient 1/12 — a factor-of-three improvement over Mathlib's and the parent entry's 1/(4j), which is the crux that makes an exact asymptotic coefficient extractable.",
+    "mathContext": "$\\frac{1}{12j}-\\frac{1}{12j^2}\\ \\le\\ \\log s_j-\\log\\sqrt{\\pi}\\ \\le\\ \\frac{1}{12j}\\qquad(j\\ge1)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Stirling's approximation",
+      "Binet series for log Gamma",
+      "telescoping to a limit",
+      "effective error bounds"
+    ],
+    "prerequisites": [
+      "convergence of stirlingSeq to sqrt(pi)",
+      "telescoping series",
+      "limits of monotone bounds"
+    ]
+  },
+  {
+    "id": "ann-second-order",
+    "proofId": "beta-central-binomial-explicit-rate-oq-02",
+    "range": {
+      "startLine": 360,
+      "endLine": 401
+    },
+    "type": "theorem",
+    "title": "The Second-Order Correction: c₁ = 1/8",
+    "content": "correction_log_second_order is the direct OQ-02 answer. Substituting the sharp bracket into the parent's identity log q(n) = 2·S(n) − S(2n) (with S(j) = log stirlingSeq(j) − log√π), the two exact 1/(12·) leading terms combine to 2/(12n) − 1/(24n) = 1/(8n), and the remaining quadratic slack is controlled by the bracket to give |log q(n) − 1/(8n)| ≤ 1/(6 n²) for n ≥ 1. This identifies the first expansion coefficient c₁ = 1/8 with an honest, explicit O(1/n²) remainder. correction_log_isBigO_second_order restates it in Landau form with the explicit constant 1/6.",
+    "mathContext": "$\\log q(n)=2S(n)-S(2n),\\quad \\frac{2}{12n}-\\frac{1}{24n}=\\frac{1}{8n},\\quad \\bigl|\\log q(n)-\\tfrac{1}{8n}\\bigr|\\le\\frac{1}{6n^2}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "asymptotic expansion coefficients",
+      "Landau big-O notation",
+      "diagonal Beta correction",
+      "central binomial asymptotics"
+    ],
+    "prerequisites": [
+      "big-O notation",
+      "the parent identity log q = 2S(n) - S(2n)"
+    ]
+  },
+  {
+    "id": "ann-cubic-lower",
+    "proofId": "beta-central-binomial-explicit-rate-oq-02",
+    "range": {
+      "startLine": 424,
+      "endLine": 527
+    },
+    "type": "technique",
+    "title": "Cubic Refinement of the Lower Bracket",
+    "content": "To reach the vanishing of c₂ the lower side of the bracket must match the exact upper 1/(12j) to one order deeper. diff_lower_cubic sharpens the lower per-step bound with a cubic telescoping correction (1/144)(1/i³ − 1/(i+1)³) in place of the quadratic one; the required inequality reduces, after clearing denominators, to the manifestly true 0 ≤ 7·t(t+1) + 1. tel_cubic telescopes it and stirlingLogDev_lower_cubic / stirlingLogDev_bracket_cubic produce the refined deviation bracket 1/(12j) − 1/(144 j³) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j), now sharp to order 1/j³ on both sides.",
+    "mathContext": "$\\frac{1}{12j}-\\frac{1}{144\\,j^3}\\ \\le\\ \\log s_j-\\log\\sqrt{\\pi}\\ \\le\\ \\frac{1}{12j};\\qquad\\text{key inequality }0\\le 7t(t+1)+1$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cubic telescoping correction",
+      "higher-order Stirling remainder",
+      "polynomial positivity certificate"
+    ],
+    "prerequisites": [
+      "telescoping series",
+      "the leading deviation bracket"
+    ]
+  },
+  {
+    "id": "ann-third-order",
+    "proofId": "beta-central-binomial-explicit-rate-oq-02",
+    "range": {
+      "startLine": 551,
+      "endLine": 593
+    },
+    "type": "theorem",
+    "title": "The 1/n² Coefficient Vanishes: c₂ = 0",
+    "content": "correction_log_third_order feeds the cubic bracket into log q(n) = 2·S(n) − S(2n). The candidate 1/n² contributions from the index n and from 2n cancel identically — this is a genuine cancellation certified by the sharpened bracket, not a lossy estimate — leaving |log q(n) − 1/(8n)| ≤ 1/(72 n³) for n ≥ 1. Hence the asymptotic expansion q(n) = 1 + c₁/n + c₂/n² + ⋯ has c₂ = 0, and the first correction beyond 1/(8n) sits at order 1/n³. correction_log_isBigO_third_order records the Landau form =O[atTop](1/n³) with constant 1/72, matching the odd-power (Bernoulli) structure of the classical Stirling/Binet series.",
+    "mathContext": "$\\bigl|\\log q(n)-\\tfrac{1}{8n}\\bigr|\\le\\frac{1}{72\\,n^3}\\ \\Rightarrow\\ q(n)=1+\\frac{1}{8n}+0\\cdot\\frac{1}{n^2}+O\\!\\left(\\frac{1}{n^3}\\right)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bernoulli numbers",
+      "Stirling series odd powers",
+      "exact cancellation of coefficients",
+      "effective asymptotic remainder"
+    ],
+    "prerequisites": [
+      "big-O notation",
+      "the cubic deviation bracket"
+    ]
+  }
+]

--- a/src/data/proofs/beta-central-binomial-explicit-rate-oq-02/meta.json
+++ b/src/data/proofs/beta-central-binomial-explicit-rate-oq-02/meta.json
@@ -75,6 +75,23 @@
       "summary": "diff_lower_cubic sharpens the lower per-step bound with a cubic telescoping correction (the inequality collapsing to 0 ≤ 7·t(t+1)+1); tel_cubic telescopes it; stirlingLogDev_lower_cubic and stirlingLogDev_bracket_cubic yield the cubic deviation bracket 1/(12j) − 1/(144 j³) ≤ S(j) ≤ 1/(12j), one order sharper on the lower side. correction_log_third_order then proves |log q(n) − 1/(8n)| ≤ 1/(72 n³): the 1/n² contributions cancel, so c₂ = 0. correction_log_isBigO_third_order gives the Landau form =O[atTop](1/n³) with constant 1/72."
     }
   ],
+  "crossReferences": [
+    {
+      "slug": "beta-central-binomial-explicit-rate",
+      "relationship": "parent",
+      "description": "The parent entry, whose open question OQ-02 this entry answers. It establishes the first-order rate q(n) = 1 + O(1/n) and the identity log q(n) = 2·S(n) − S(2n) that this entry feeds its sharp brackets into, and uses only the crude 1/(4j) telescoping bound that this entry sharpens to 1/(12j)."
+    },
+    {
+      "slug": "beta-central-binomial-asymptotic",
+      "relationship": "related",
+      "description": "The originating asymptotic study of the diagonal Beta value B(n+1,n+1) relative to its Wallis/Stirling leading term, of which the explicit-rate line (parent) and this second/third-order refinement are the effective continuation."
+    },
+    {
+      "slug": "stirling-formula",
+      "relationship": "foundation",
+      "description": "Supplies the Stirling sequence stirlingSeq(k) → √π and Mathlib's exact per-step series log_stirlingSeq_diff_hasSum — the engine that unlocks the true 1/12 leading coefficient of the log-deviation used throughout this entry."
+    }
+  ],
   "conclusion": {
     "summary": "The entry answers open question OQ-02 of the parent beta-central-binomial-explicit-rate in the affirmative and quantitatively. The telescoping tail-bound technique does extend into a genuine effective asymptotic expansion of the multiplicative correction q(n) = stirlingSeq(n)²/(√π·stirlingSeq(2n)). Its technical core is a pair of sharp, machine-checked Stirling deviation brackets built from Mathlib's exact per-step series log_stirlingSeq_diff_hasSum: the leading bracket 1/(12j) − 1/(12j²) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j) (a factor-of-three improvement over the parent's crude 1/(4j)) and its cubic refinement 1/(12j) − 1/(144 j³) ≤ S(j) ≤ 1/(12j). Feeding log q(n) = 2·S(n) − S(2n) collapses the leading contributions to exactly 1/(8n), giving the first coefficient c₁ = 1/8 with an effective O(1/n²) remainder (|log q(n) − 1/(8n)| ≤ 1/(6 n²)); the cubic bracket then makes the 1/n² pieces cancel identically, upgrading the remainder to O(1/n³) (|log q(n) − 1/(8n)| ≤ 1/(72 n³)) and exhibiting c₂ = 0. Nothing is assumed: 0 axioms, 0 sorries.",
     "implications": "The result recovers, by elementary telescoping and with fully explicit constants, the first two coefficients of the classical Stirling (Binet) series structure — c₁ = 1/8 and c₂ = 0 — for the diagonal Beta correction, confirming that the absence of a 1/n² term is a genuine feature (a cancellation certified by the cubic bracket) rather than an artifact of a lossy estimate. The sharp deviation bracket 1/(12j) − O(1/j³) ≤ log stirlingSeq(j) − log√π ≤ 1/(12j) is itself reusable infrastructure: it upgrades any factorial-ratio asymptotic driven by Mathlib's Stirling sequence from leading order to second and third order with effective remainders, and pins the true 1/12 leading coefficient that the qualitative Mathlib development and the parent's 1/(4·) telescope both leave unidentified.",


### PR DESCRIPTION
Enrichment pass on `beta-central-binomial-explicit-rate-oq-02` (quality 43, passes 0 — previously had no annotations.json).

## Changes
- **Added `annotations.json`** (6 inline annotations, previously absent). Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, anchored to the four proof sections:
  - Exact upper per-step bound via geometric majorant (`diff_upper`)
  - Lower per-step bound: leading term + quadratic deficit (`diff_lower`)
  - The sharp Stirling deviation bracket (`stirlingLogDev_bracket`)
  - The second-order correction c₁ = 1/8 (`correction_log_second_order`)
  - Cubic refinement of the lower bracket (`diff_lower_cubic`)
  - The vanishing 1/n² coefficient c₂ = 0 (`correction_log_third_order`)
- **Added `crossReferences`** to meta.json linking the parent entry, the originating asymptotic study, and the Stirling formula foundation.

## Verification
- meta.json 13.4 KB (well under the ~60 KB cap); JSON validated.
- Gallery data validation and search-index checks pass under `pnpm build` (the final `tsc` step fails only because node_modules is not installed in this worktree — unrelated to content).
- Content is line-anchored to the Lean source and mathematically faithful to the proof.