### PR TITLE
research(erdos-490-incomplete-01): maxProductSize is monotone [VERIFIED 0/0-new-axiom]

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -149,6 +149,24 @@ axiom szemeredi_theorem :
 /-- The answer to Erdős Problem #490 is YES. -/
 theorem erdos_490_answer : ErdosQuestion490 := szemeredi_theorem
 
+/-- **The extremal function `maxProductSize` is monotone.**
+Enlarging the ambient range `{1,…,N} → {1,…,N+1}` can only add admissible pairs:
+any `A, B ⊆ {1,…,N}` with distinct products are still `⊆ {1,…,N+1}` with the same
+(distinct) products, so the supremum `maxProductSize N` of `|A|·|B|` never decreases.
+This is the structural fact behind the growth `maxProductSize N = Θ(N²/log N)`: the
+supply of distinct-product pairs is non-decreasing in `N`. Proved by `Nat.find_mono`,
+since a bound valid for all `{1,…,N+1}`-pairs is a fortiori valid for all
+`{1,…,N}`-pairs. -/
+theorem maxProductSize_monotone : Monotone maxProductSize := by
+  apply monotone_nat_of_le_succ
+  intro N
+  unfold maxProductSize
+  apply Nat.find_mono
+  intro k hk A B hA hB hAB
+  exact hk A B
+    (fun a ha => ⟨(hA a ha).1, (hA a ha).2.trans (Nat.le_succ N)⟩)
+    (fun b hb => ⟨(hB b hb).1, (hB b hb).2.trans (Nat.le_succ N)⟩) hAB
+
 /-
 ## Part IV: The Optimal Example
 -/

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -510,3 +510,28 @@ new theorems = `[propext, Classical.choice, Quot.sound]` (0 new axioms). File 75
 ### Terminus
 Lower-bound side of #490 is complete. `szemeredi_theorem` (the deep N²/log N UPPER bound for
 arbitrary distinct-product sets, Szemerédi 1976) is out of scope; correctly axiomatized.
+
+## Session 2026-07-08 (researcher-2) — maxProductSize monotonicity (0 new axioms)
+
+**Mode**: ACT (SOLVED-side structural gap-fill). Main file was at frontier
+(0 sorries, 1 deep axiom `szemeredi_theorem`; lower-bound side complete). The
+extremal function `maxProductSize N` (the least upper bound, via `Nat.find`, on
+`|A|·|B|` over distinct-product pairs `A,B ⊆ {1,…,N}`) had **no** monotonicity
+lemma despite being the central object of study.
+
+**Added (verified, 0 new axioms, docker `[7744/7744]` green):**
+`maxProductSize_monotone : Monotone maxProductSize`. Proof: `monotone_nat_of_le_succ`
+then `Nat.find_mono` — a bound `k` valid for all `{1,…,N+1}`-pairs is a fortiori
+valid for all `{1,…,N}`-pairs (each `A,B ⊆ {1,…,N}` lifts to `⊆ {1,…,N+1}` with
+identical distinct products), so `Nat.find (max_exists N) ≤ Nat.find (max_exists (N+1))`.
+The subset lift is one line each via `(hA a ha).2.trans (Nat.le_succ N)`.
+
+**Gotcha:** `maxProductSize` is a plain (non-reducible) `noncomputable def` wrapping
+`Nat.find (maxProductSize.max_exists N)` (the existence witness lives in a `where`
+clause, accessible as `maxProductSize.max_exists`). `apply Nat.find_mono` does not
+see through the def — must `unfold maxProductSize` first. `Nat.find_mono` direction:
+`(∀ n, q n → p n) → Nat.find hp ≤ Nat.find hq` (here `p = p_N`, `q = p_{N+1}`).
+
+Modest: a basic structural sanity property, not progress on the deep axiom.
+`szemeredi_theorem` (the N²/log N upper bound, Szemerédi 1976) stays correctly
+axiomatized — out of scope. Meta leanFile lineCount 843→861, theoremCount 25→26.

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -217,9 +217,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 843,
+    "lineCount": 861,
     "axiomCount": 1,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Erdős #490 (largest `|A|·|B|` for `A,B ⊆ {1,…,N}` with all products `ab` distinct; answer `Θ(N²/log N)`) is at its frontier in `Erdos490Problem.lean`: **0 sorries**, 1 genuinely deep BLOCKED axiom (`szemeredi_theorem`, the `N²/log N` upper bound, Szemerédi 1976), and the full lower-bound / optimal-example side already verified. This session fills one clean, honest **0-axiom** structural gap.

## What's new

`maxProductSize_monotone : Monotone maxProductSize` — the central extremal function of the problem (the least `Nat.find` upper bound on `|A|·|B|` over admissible distinct-product pairs in `{1,…,N}`) previously had **no** monotonicity lemma.

**Proof.** `monotone_nat_of_le_succ` then `Nat.find_mono`: any `A,B ⊆ {1,…,N}` with distinct products lift to `⊆ {1,…,N+1}` with the *same* distinct products, so a bound valid for all `{1,…,N+1}`-pairs is a fortiori valid for all `{1,…,N}`-pairs; hence `maxProductSize N ≤ maxProductSize (N+1)`.

## Honest assessment

Modest — a basic structural sanity property of the extremal function, not progress on the deep axiom. `szemeredi_theorem` (the hard upper bound) stays correctly axiomatized and out of scope. The lower-bound side of #490 was already complete.

## Verification

- Docker-built green: `⚠ [7744/7744] Built Proofs.Erdos490Problem (7.2s)` (all warnings pre-existing; none in the new lines)
- 0 sorries; 0 new axioms (deep `szemeredi_theorem` unchanged)
- Note: `maxProductSize` wraps `Nat.find` in a `where` clause and is non-reducible, so `apply Nat.find_mono` needs an `unfold maxProductSize` first
- Synced `leanFile` metadata: lineCount 843→861, theoremCount 25→26

🤖 Generated with [Claude Code](https://claude.com/claude-code)