### PR TITLE
research(dirichlets-oq-02-oq-03): certified lower bound on the counting function π(x;4,3)

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -794,4 +794,58 @@ theorem B_div_C_diverges (m : ℕ) : ∃ K, ∀ k, K ≤ k → m * C k ≤ B k :
     _ = C k ^ 2 := (sq (C k)).symm
     _ ≤ B k := hsq
 
+/-! ## Certified lower bound on the prime-counting function `π(x; 4, 3)`
+
+Everything above bounds the *k-th* prime `≡ 3 (mod 4)` from the enumeration side.
+Dually, one can bound the **counting function**
+`π(x; 4, 3) = #{p ≤ x : p prime, p ≡ 3 (mod 4)}` from below.  Because `p3` is
+strictly increasing with `p3 k ≤ 4^(2^k)`, the `K + 1` primes `p3 0 < ⋯ < p3 K`
+all lie below `4^(2^K)`; so once `x` reaches that height, at least `K + 1` primes
+`≡ 3 (mod 4)` have appeared.
+
+Inverting the doubly-exponential threshold, the certificate is an **iterated
+logarithm**: `π(x; 4, 3)` exceeds roughly `log₂ log₄ x`.  The truth is
+`π(x; 4, 3) ∼ x / (2 ln x)` (PNT for arithmetic progressions), an analytic input
+the elementary Euclid construction cannot reach — but the counting bound below is
+fully certified and axiom-free. -/
+
+/-- `countP3 x` is the number of primes `p ≤ x` with `p ≡ 3 (mod 4)`. -/
+def countP3 (x : ℕ) : ℕ :=
+  ((Finset.range (x + 1)).filter (fun n => Nat.Prime n ∧ n % 4 = 3)).card
+
+/-- **Certified lower bound on the counting function.** Whenever `x` reaches the
+doubly-exponential height `4^(2^K)`, at least `K + 1` primes `≡ 3 (mod 4)` lie in
+`[0, x]`, i.e. `π(x; 4, 3) ≳ log₂ log₄ x`.  Proof: the `K + 1` values
+`p3 0 < ⋯ < p3 K` are distinct primes `≡ 3 (mod 4)`, each `≤ p3 K ≤ 4^(2^K) ≤ x`,
+so they inject into the counted set. -/
+theorem countP3_ge (K x : ℕ) (hx : 4 ^ (2 ^ K) ≤ x) : K + 1 ≤ countP3 x := by
+  have hsub : (Finset.range (K + 1)).image p3 ⊆
+      (Finset.range (x + 1)).filter (fun n => Nat.Prime n ∧ n % 4 = 3) := by
+    intro q hq
+    simp only [Finset.mem_image, Finset.mem_range] at hq
+    obtain ⟨k, hk, rfl⟩ := hq
+    rw [Finset.mem_filter, Finset.mem_range]
+    refine ⟨?_, p3_prime k, p3_mod k⟩
+    have h1 : p3 k ≤ p3 K := p3_strictMono.monotone (by omega)
+    have h2 : p3 K ≤ 4 ^ (2 ^ K) := p3_le_doubly_exp K
+    omega
+  have hcard : ((Finset.range (K + 1)).image p3).card = K + 1 := by
+    rw [Finset.card_image_of_injective _ p3_strictMono.injective, Finset.card_range]
+  calc K + 1 = ((Finset.range (K + 1)).image p3).card := hcard.symm
+    _ ≤ countP3 x := Finset.card_le_card hsub
+
+/-- The counting function is unbounded: for every `K` the threshold `x = 4^(2^K)`
+already gives at least `K` primes `≡ 3 (mod 4)` — a counting-function restatement
+of Dirichlet's infinitude for this progression, with a certified rate. -/
+theorem countP3_unbounded (K : ℕ) : ∃ x, K ≤ countP3 x :=
+  ⟨4 ^ (2 ^ K), le_trans (Nat.le_succ K) (countP3_ge K _ le_rfl)⟩
+
+/-- Concrete instance of `countP3_ge` at `K = 1`: past `x = 16 = 4^(2^1)` at least
+two primes `≡ 3 (mod 4)` have appeared. -/
+example : 2 ≤ countP3 16 := countP3_ge 1 16 (by norm_num)
+
+/-- The certified bound is loose: the true count at `x = 16` is `3` (the primes
+`3, 7, 11`), whereas `countP3_ge` only guarantees `2`. -/
+theorem countP3_sixteen : countP3 16 = 3 := by decide
+
 end DirichletsTheoremOQ02OQ03

--- a/research/problems/dirichlets-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/dirichlets-theorem-oq-02-oq-03/knowledge.md
@@ -76,3 +76,27 @@ k-th prime ≡ 3 (mod 4):
 File 250 L, 23 thm / 3 def, 0 axioms, 0 sorries. VERIFIED (rotating olean
 corruption: line-less 135 then named Cyclotomic/Discriminant.olean.private invalid
 header → rm + retry green).
+
+### Session 2026-07-08 (Session 3, researcher-1) — counting-function lower bound
+
+Advanced the "Next Steps" item from Session 1: bounded the **counting function**
+`π(x;4,3)` from below (dual to the k-th-prime bounds). 3 verified theorems + 1 def,
+0 axioms, `native_decide`-free.
+- `def countP3 x := #{n ≤ x : Nat.Prime n ∧ n % 4 = 3}` (Finset.range (x+1) filter).
+- `countP3_ge (K x) (hx : 4^(2^K) ≤ x) : K+1 ≤ countP3 x` — inject the K+1 distinct
+  primes `p3 0 < ⋯ < p3 K` (each `≤ p3 K ≤ 4^(2^K)` by `p3_le_doubly_exp`) into the
+  counted set via `Finset.range (K+1) |>.image p3 ⊆ filter …`, `card_image_of_injective`
+  with `p3_strictMono.injective`, then `Finset.card_le_card`. Certifies `π(x;4,3) ≳
+  log₂log₄x` (truth `∼ x/(2 ln x)`, needs analytic PNT-for-APs).
+- `countP3_unbounded K : ∃ x, K ≤ countP3 x` — take `x = 4^(2^K)`, one-liner.
+- `countP3_sixteen : countP3 16 = 3 := by decide` — kernel decide (NOT native_decide,
+  stays 0-axiom); shows the bound `≥2` from `countP3_ge 1` is loose (true = {3,7,11}).
+
+File now 851 L, 59 thm/lemma, 6 def, 0 axioms, 0 sorries. VERIFIED (first build
+line-less exit-135 SIGBUS after [7743/7743] 3.9s no elab errors = fleet volume
+corruption; retry at MEM=24576 built green in 9.0s, zero proof changes).
+
+**Recipe (reusable):** to turn a strict-mono enumeration bound `f k ≤ g k` into a
+counting-function lower bound, inject `(range (K+1)).image f` into the filtered
+Finset and count via `card_image_of_injective ∘ StrictMono.injective` + `card_le_card`;
+the membership proof only needs `f k ≤ f K ≤ g K ≤ x` (monotone + the height bound).

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -172,12 +172,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 797,
+    "lineCount": 851,
     "axiomCount": 0,
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 56
+    "theoremCount": 59
   },
   "sorries": 0,
   "status": "verified",


### PR DESCRIPTION
## Summary

`dirichlets-theorem-oq-02-oq-03` already certifies the growth *rate* of the k-th prime
`p ≡ 3 (mod 4)` from the elementary Euclid construction (interval bound, iterated-factorial
tower `B`, primorial tower `C`, doubly-exponential closed form `p3 k ≤ 4^(2^k)`, and the
divergence of the two towers). This PR adds the **dual, counting-function direction**, the
open "Next Steps" item flagged in Session 1.

New (3 verified theorems + 1 def, **0 axioms, `native_decide`-free**):

- `def countP3 x` — the number of primes `p ≤ x` with `p ≡ 3 (mod 4)`, i.e. `π(x;4,3)`.
- `countP3_ge (K x) (hx : 4^(2^K) ≤ x) : K + 1 ≤ countP3 x` — a **certified lower bound**:
  once `x` reaches the doubly-exponential height `4^(2^K)`, at least `K+1` such primes have
  appeared. Equivalently `π(x;4,3) ≳ log₂ log₄ x`. Proof injects the `K+1` distinct primes
  `p3 0 < ⋯ < p3 K` (each `≤ p3 K ≤ 4^(2^K) ≤ x` via `p3_le_doubly_exp` + `p3_strictMono`)
  into the counted Finset.
- `countP3_unbounded (K) : ∃ x, K ≤ countP3 x` — counting-function restatement of Dirichlet
  infinitude for this progression, with a certified threshold.
- `countP3_sixteen : countP3 16 = 3 := by decide` — kernel `decide` (keeps the file 0-axiom);
  witnesses that the `≥ 2` guaranteed by `countP3_ge 1` is loose (true count is `{3, 7, 11}`).

## Honest significance

The certified counting bound is an **iterated logarithm** — the true asymptotic is
`π(x;4,3) ∼ x/(2 ln x)` (PNT for arithmetic progressions), an analytic input the elementary
construction cannot reach. This PR makes precise *how far* the elementary certificate falls
short on the counting side, mirroring the existing sequence-side story. Modest but genuinely
new: it opens the counting-function axis of the entry, which was previously absent.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.DirichletsTheoremOQ02OQ03` → `Built (9.0s)`, 7743 jobs.
- 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions, no `native_decide`.
- Gallery meta synced: lineCount 797→851, theoremCount 56→59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)