### PR TITLE
research(dirichlets-theorem-oq-02-oq-03): tetration lower bound 2↑↑k≤B + sharp growth-class separation [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -794,4 +794,110 @@ theorem B_div_C_diverges (m : ℕ) : ∃ K, ∀ k, K ≤ k → m * C k ≤ B k :
     _ = C k ^ 2 := (sq (C k)).symm
     _ ≤ B k := hsq
 
+/-! ## Step 11: the factorial tower `B` is **tetrational** (`2 ↑↑ k ≤ B k`), and
+the growth-class separation from `C` is sharp
+
+Step 9 established the recursive exponential step `2^(B k) ≤ B (k+1)`
+(`B_succ_ge_two_pow`), and Step 10 turned it into the ratio divergence
+`B / C → ∞`.  What was still missing is a *closed-form* placement of `B` in the
+tetration (iterated-exponential) growth class.  We supply it: writing `2 ↑↑ k`
+for the tower of `k` twos (`tower2`), we prove `2 ↑↑ k ≤ B k`.
+
+Combined with the doubly-exponential *upper* bound `C k ≤ 4^(2^k)`
+(`C_le_doubly_exp`, Step 8), this separates the two certified towers by growth
+class in the sharpest possible sense: tetration eventually dominates any fixed
+doubly-exponential, so for `k ≥ 5` the closed-form lower bound on `B` already
+exceeds the closed-form upper bound on `C`,
+
+    C k ≤ 4^(2^k) ≤ 2 ↑↑ k ≤ B k.
+
+The threshold `k = 5` is sharp: at `k = 4` one still has
+`2 ↑↑ 4 = 65536 < 4^(2^4)` (`tower2_lt_doubly_exp_at_four`). -/
+
+/-- Base-2 tetration `tower2 k = 2 ↑↑ k`, the tower of `k` twos:
+`tower2 0 = 1`, `tower2 (k+1) = 2 ^ tower2 k`.  Values `1, 2, 4, 16, 65536,
+2^65536, …` — an iterated exponential, a strictly larger growth class than any
+doubly-exponential. -/
+def tower2 : ℕ → ℕ
+  | 0 => 1
+  | (k + 1) => 2 ^ tower2 k
+
+@[simp] theorem tower2_zero : tower2 0 = 1 := rfl
+@[simp] theorem tower2_succ (k : ℕ) : tower2 (k + 1) = 2 ^ tower2 k := rfl
+
+/-- Self-contained `n < 2^n` (used to convert the exponential lower bound on
+`tower2` into a linear one). -/
+theorem lt_two_pow_aux (n : ℕ) : n < 2 ^ n := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+    have h1 : 1 ≤ 2 ^ n := Nat.one_le_pow _ _ (by norm_num)
+    have h2 : 2 ^ (n + 1) = 2 ^ n + 2 ^ n := by rw [pow_succ]; ring
+    omega
+
+/-- **The factorial tower is tetrational: `2 ↑↑ k ≤ B k`.**  Each factorial step
+of `B` base-2 exponentiates the previous value (`B_succ_ge_two_pow`), so `B`
+dominates the tower of twos of the same height.  This closed-form
+iterated-exponential lower bound complements the doubly-exponential *upper* bound
+`C k ≤ 4^(2^k)`: the factorial certificate `B` lives in the tetration growth
+class, strictly above the primorial certificate `C`. -/
+theorem tower2_le_B (k : ℕ) : tower2 k ≤ B k := by
+  induction k with
+  | zero => decide
+  | succ k ih =>
+    calc tower2 (k + 1) = 2 ^ tower2 k := rfl
+      _ ≤ 2 ^ B k := Nat.pow_le_pow_right (by norm_num) ih
+      _ ≤ B (k + 1) := B_succ_ge_two_pow k
+
+/-- Linear-in-exponent lower bound on tetration: `2^(k+2) ≤ 2 ↑↑ k` for `k ≥ 4`.
+The engine converting the tetration recursion into the doubly-exponential
+comparison below.  Inductive step: `2 ↑↑ (k+1) = 2^(2 ↑↑ k) ≥ 2^(k+3)` because
+`2 ↑↑ k ≥ 2^(k+2) ≥ k+3` (the second gap from `n < 2^n`). -/
+theorem two_pow_le_tower2 {k : ℕ} (hk : 4 ≤ k) : 2 ^ (k + 2) ≤ tower2 k := by
+  induction k, hk using Nat.le_induction with
+  | base => decide
+  | succ k hk ih =>
+    rw [tower2_succ]
+    have hklin : k + 1 + 2 ≤ tower2 k := by
+      have h1 : k + 2 < 2 ^ (k + 2) := lt_two_pow_aux (k + 2)
+      omega
+    exact Nat.pow_le_pow_right (by norm_num) hklin
+
+/-- **Tetration overtakes the doubly-exponential ceiling of `C`:**
+`4^(2^k) ≤ 2 ↑↑ k` for `k ≥ 5`.  Writing `k = j+1`, one has
+`4^(2^(j+1)) = 2^(2·2^(j+1)) = 2^(2^(j+2))` and `2 ↑↑ (j+1) = 2^(2 ↑↑ j)`, so the
+claim reduces to `2^(j+2) ≤ 2 ↑↑ j` (`two_pow_le_tower2`, valid for `j ≥ 4`). -/
+theorem doubly_exp_le_tower2 {k : ℕ} (hk : 5 ≤ k) : 4 ^ (2 ^ k) ≤ tower2 k := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  have hj : 4 ≤ j := by omega
+  have hexp : 2 ^ (j + 2) ≤ tower2 j := two_pow_le_tower2 hj
+  have hpow : (2 : ℕ) ^ (j + 2) = 2 * 2 ^ (j + 1) := by
+    have hjj : j + 2 = (j + 1) + 1 := by omega
+    rw [hjj, pow_succ]; ring
+  have key : (4 : ℕ) ^ (2 ^ (j + 1)) = 2 ^ (2 ^ (j + 2)) := by
+    rw [show (4 : ℕ) = 2 ^ 2 by norm_num, ← pow_mul, hpow]
+  rw [key, tower2_succ]
+  exact Nat.pow_le_pow_right (by norm_num) hexp
+
+/-- The separation threshold `k = 5` is sharp: at `k = 4` the tetration lower
+bound is still below the doubly-exponential, `2 ↑↑ 4 = 65536 < 4294967296 =
+4^(2^4)`.  So `doubly_exp_le_tower2` genuinely requires `k ≥ 5`. -/
+theorem tower2_lt_doubly_exp_at_four : tower2 4 < 4 ^ (2 ^ 4) := by decide
+
+/-- **Sharp growth-class separation of the two certified towers.**  For every
+`k ≥ 5`,
+
+    C k ≤ 4^(2^k) ≤ 2 ↑↑ k ≤ B k,
+
+so the doubly-exponential *upper* bound on the primorial tower `C` is dominated
+by the tetration *lower* bound on the factorial tower `B`.  This upgrades the
+qualitative "different growth classes" picture (Steps 8–9) and the ratio
+divergence (Step 10) to an explicit sandwich in which a closed-form
+iterated-exponential on the `B` side overtakes a closed-form doubly-exponential
+on the `C` side.  The `k = 5` threshold is sharp
+(`tower2_lt_doubly_exp_at_four`). -/
+theorem growth_class_separation {k : ℕ} (hk : 5 ≤ k) :
+    C k ≤ 4 ^ (2 ^ k) ∧ 4 ^ (2 ^ k) ≤ tower2 k ∧ tower2 k ≤ B k :=
+  ⟨C_le_doubly_exp k, doubly_exp_le_tower2 hk, tower2_le_B k⟩
+
 end DirichletsTheoremOQ02OQ03

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -172,12 +172,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 797,
+    "lineCount": 903,
     "axiomCount": 0,
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 56
+    "theoremCount": 62
   },
   "sorries": 0,
   "status": "verified",

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: ratio B/C diverges as a theorem (VERIFIED 0/0). C_sq_le_B: (C k)²≤B k for k≥3; B_div_C_diverges: ∀m ∃K ∀k≥K, m·C k≤B k. Fills next-step 2 (division-free divergence). Upper-bound side of the original open question still at elementary terminus (needs analytic 2k·ln k).",
+    "progressSummary": "PROGRESS (Step 11, VERIFIED 0/0): closed-form tetration lower bound 2↑↑k ≤ B k (tower2_le_B) + SHARP growth-class separation C k≤4^(2^k)≤2↑↑k≤B k for k≥5 (growth_class_separation), threshold k=5 proven sharp. Upgrades the qualitative Steps 8-9 / ratio-divergence Step 10 to an explicit closed-form sandwich where B´s lower certificate overtakes C´s upper certificate. Upper-bound side of the original OQ still at elementary terminus (needs analytic 2k·ln k).",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
@@ -53,7 +53,9 @@
       "C_ge_add (:738) — linear lower bound k+3 ≤ C k (⇒ C unbounded), by induction with nlinarith on the multiplicative recursion.",
       "quartic_le_two_pow (:749) — (n+1)^4 ≤ 2^n for n≥17 (exponential beats fixed power). Nat.le_induction from 18^4≤2^17; step (n+2)^4 ≤ 2·(n+1)^4 needs nlinarith with degree-4 hints 289≤n·n and 289·n²≤n⁴.",
       "C_sq_le_B (:766) — VERIFIED 0/0: the factorial tower dominates the SQUARE of the primorial tower, (C k)² ≤ B k for k≥3. Chain: B(j+1)≥2^(C j), C(j+1)²≤(C j+1)^4≤2^(C j) (quartic, C j≥17 since C 2=131 & monotone).",
-      "B_div_C_diverges (:787) — VERIFIED 0/0: division-free ratio divergence ∀m ∃K ∀k≥K, m·C k ≤ B k. From C k→∞ pick k≥max 3 m so m≤C k, then m·C k ≤ (C k)² ≤ B k. PR #TBD."
+      "B_div_C_diverges (:787) — VERIFIED 0/0: division-free ratio divergence ∀m ∃K ∀k≥K, m·C k ≤ B k. From C k→∞ pick k≥max 3 m so m≤C k, then m·C k ≤ (C k)² ≤ B k. PR #TBD.",
+      "tower2 (base-2 tetration def) + tower2_le_B: 2↑↑k ≤ B k (DirichletsTheoremOQ02OQ03.lean Step 11)",
+      "two_pow_le_tower2 (2^(k+2)≤2↑↑k for k≥4), doubly_exp_le_tower2 (4^(2^k)≤2↑↑k for k≥5), growth_class_separation (C k≤4^(2^k)≤2↑↑k≤B k for k≥5), tower2_lt_doubly_exp_at_four (sharp threshold), lt_two_pow_aux"
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
@@ -70,7 +72,9 @@
       "Key mechanism: one factorial step turns the WHOLE previous primorial value into an exponent — 2^(C k)≤B(k+1) — via C_le_B chained with the exponential step. Certified/native_decide-free.",
       "Ratio divergence needs only a FIXED-base exponential-vs-power lemma, not an m-dependent one: proving (C k)²≤B k (via the quartic (n+1)^4≤2^n, n≥17) is both STRONGER than and EASIER than the m-parametrised m·C k≤B k, because the square absorbs the multiplier once C k≥m (C k→∞). Prove the square bound first, derive the ∀m form as a one-line corollary.",
       "The primorial recursion linearises for ring via set d := 4·towerProd k − 1: C(k+1)+1 = (C k+1)·C k has a clean closed form once the nat-subtraction sub-term is abstracted to an atom, sidestepping ring´s inability to normalise ℕ subtraction.",
-      "quartic step (n+2)^4 ≤ 2·(n+1)^4 is degree-4; nlinarith needs the products handed in (289≤n·n and 289·n²≤n·n·n·n) — bare nlinarith [hn] fails to synthesise the n⁴ monomial."
+      "quartic step (n+2)^4 ≤ 2·(n+1)^4 is degree-4; nlinarith needs the products handed in (289≤n·n and 289·n²≤n·n·n·n) — bare nlinarith [hn] fails to synthesise the n⁴ monomial.",
+      "Tetration/tower-exponential lower bound: the factorial certificate B satisfies 2↑↑k ≤ B k (closed-form, via B_succ_ge_two_pow + monotonicity of 2^·). This is the closed-form counterpart of the recursive step 2^(B k)≤B(k+1) and places B strictly above C´s doubly-exponential growth class.",
+      "Growth-class SEPARATION is sharp: for k≥5, C k ≤ 4^(2^k) ≤ 2↑↑k ≤ B k — the doubly-exponential UPPER bound on the primorial tower C is dominated by the tetration LOWER bound on B. Threshold k=5 is sharp (at k=4, 2↑↑4=65536 < 4^(2^4)=4294967296)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -79,7 +83,8 @@
       "Port the primorial-tower framework to other elementary progressions (e.g. the ≡5 mod 6 primes via N=6·∏−1).",
       "Quantify the gap growth: prove B k / C k → ∞ (or a lower bound like B k ≥ C k · (something growing), since each factorial step swaps a squaring for a full factorial).",
       "Sharpen (C k)²≤B k to (C k)^p ≤ B k for every fixed p (same route with (n+1)^(2p)≤2^n), or to B k ≥ 2^(C (k-1)) exhibiting the true tower gap.",
-      "Formalise C k ↑↑-style: B k ≥ 2 ↑↑ k vs C k ≤ 4^(2^k) to state the growth-class separation as an iterated-exponential lower bound on B."
+      "Formalise C k ↑↑-style: B k ≥ 2 ↑↑ k vs C k ≤ 4^(2^k) to state the growth-class separation as an iterated-exponential lower bound on B.",
+      "Generalize C_sq_le_B to (C k)^p ≤ B k for every fixed p (same quartic→2^n route with (n+1)^(2p)≤2^n), giving B/(C^p)→∞ for all p — the tetration lower bound now makes this transparent."
     ],
     "markdown": "# Knowledge Base: dirichlets-theorem-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the certified growth-bound analysis for the $k$-th prime $\equiv 3 \pmod 4$ (`DirichletsTheoremOQ02OQ03.lean`) with **Step 11**: a closed-form *tetration* (iterated-exponential) lower bound on the factorial certificate `B`, and the resulting **sharp growth-class separation** from the primorial certificate `C`.

### Context
The file certifies two Euclid-style upper towers on $p_k$ (the $k$-th prime $\equiv 3 \bmod 4$):
- factorial tower `B` ($B_{k+1}=4(B_k+1)!-1$), and
- primorial tower `C` (doubly-exponential, bracketed $4\cdot3^{2^k-1}-1 \le C_k \le 4^{2^k}$).

Prior steps separated them *qualitatively* (Steps 8–9) and via ratio divergence $B/C\to\infty$ (Step 10), but placed `B` in the tetration class only *recursively* (`B_succ_ge_two_pow`: $2^{B_k}\le B_{k+1}$).

### New results (6 theorems, 0 sorry / 0 axiom, `native_decide`-free)
- `tower2` — base-2 tetration $2\uparrow\uparrow k$.
- **`tower2_le_B`**: $2\uparrow\uparrow k \le B_k$ — closed-form iterated-exponential lower bound; `B` lives in the tetration growth class.
- `two_pow_le_tower2`: $2^{k+2}\le 2\uparrow\uparrow k$ ($k\ge4$).
- **`doubly_exp_le_tower2`**: $4^{2^k}\le 2\uparrow\uparrow k$ ($k\ge5$) — tetration overtakes `C`'s doubly-exponential ceiling.
- **`growth_class_separation`**: for $k\ge5$, $\;C_k \le 4^{2^k} \le 2\uparrow\uparrow k \le B_k$ — the doubly-exponential *upper* bound on `C` is dominated by the tetration *lower* bound on `B`.
- `tower2_lt_doubly_exp_at_four`: the $k=5$ threshold is **sharp** ($2\uparrow\uparrow4=65536 < 4^{2^4}=4294967296$).

This upgrades the growth-class separation to an explicit closed-form sandwich in which `B`'s certified lower bound overtakes `C`'s certified upper bound.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.DirichletsTheoremOQ02OQ03` → `Built ... (6.2s)`, 0 errors.
- 0 `sorry`, 0 `axiom`, no `native_decide` (kernel `decide` on small numerals only → foundational axioms only).
- meta.json counts synced: lineCount 797→903, theoremCount 56→62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)