### PR TITLE
research(erdos-1022-oq-02): sharp two-sided pin of the sparseness coefficient recurrence

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -348,4 +348,43 @@ theorem admissibleCoeff_lt_of_pos (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 �
   have h := admissibleCoeff_ge_two_mul hV t ht
   omega
 
+/-- **Matching upper bound on the coefficient's step.**  The floor can only ever
+    add one extra unit on top of doubling: `c(t+1) ≤ 2·c(t) + 1`.  Indeed
+    `c(t+1) = ⌊2·2^{t-1}/|V|⌋` and `⌊2x⌋ ≤ 2⌊x⌋ + 1` for the truncated division
+    `x = 2^{t-1}/|V|`.  Combined with the lower bound `admissibleCoeff_ge_two_mul`,
+    this pins the coefficient recurrence to `c(t+1) ∈ {2·c(t), 2·c(t)+1}` — the
+    sharp two-sided step, so the "at least doubles" growth is in fact "doubles,
+    up to the unavoidable `±1` from the floor". -/
+theorem admissibleCoeff_le_two_mul_succ (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 ≤ t) :
+    firstMomentThreshold (t + 1) / Fintype.card V
+      ≤ 2 * (firstMomentThreshold t / Fintype.card V) + 1 := by
+  rw [firstMoment_threshold_doubles t ht]
+  set n := Fintype.card V with hn
+  set M := firstMomentThreshold t with hM
+  have hq : n * (M / n) + M % n = M := Nat.div_add_mod M n
+  have hmod : M % n < n := Nat.mod_lt _ hV
+  have hrewrite : 2 * M = n * (2 * (M / n)) + 2 * (M % n) := by
+    have h2 : 2 * M = 2 * (n * (M / n) + M % n) := by rw [hq]
+    rw [h2]; ring
+  rw [hrewrite, Nat.mul_add_div hV]
+  have hlt : 2 * (M % n) / n < 2 := by
+    rw [Nat.div_lt_iff_lt_mul hV]; omega
+  omega
+
+/-- **The exact coefficient recurrence (two-sided pin).**  For every `t ≥ 1` over
+    a fixed nonempty ground set, the admissible coefficient `c(t) = ⌊2^{t-1}/|V|⌋`
+    satisfies
+
+        2·c(t)  ≤  c(t+1)  ≤  2·c(t) + 1,
+
+    i.e. `c(t+1) ∈ {2·c(t), 2·c(t)+1}`.  This is the sharp coefficient-level
+    growth law for the first-moment regime: exponential doubling, deviating from
+    exact doubling by at most one unit (the truncated-division remainder). -/
+theorem admissibleCoeff_step_bracket (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 ≤ t) :
+    2 * (firstMomentThreshold t / Fintype.card V)
+        ≤ firstMomentThreshold (t + 1) / Fintype.card V
+      ∧ firstMomentThreshold (t + 1) / Fintype.card V
+        ≤ 2 * (firstMomentThreshold t / Fintype.card V) + 1 :=
+  ⟨admissibleCoeff_ge_two_mul hV t ht, admissibleCoeff_le_two_mul_succ hV t ht⟩
+
 end Erdos1022OQ02

--- a/research/problems/erdos-1022-oq-02/knowledge.md
+++ b/research/problems/erdos-1022-oq-02/knowledge.md
@@ -1,0 +1,23 @@
+# Knowledge Base: erdos-1022-oq-02 (Growth Rate of Property-B Sparseness Threshold)
+
+## Session 2026-07-08 (researcher-1) — sharp two-sided coefficient recurrence
+
+Prior sessions pinned the first-moment threshold `2^{t-1}` (doubles per step) and
+proved the admissible integer coefficient `c(t)=⌊2^{t-1}/|V|⌋` diverges and *at
+least* doubles (`admissibleCoeff_ge_two_mul : 2·c(t) ≤ c(t+1)`). The matching
+upper bound was open ("at least doubles"). This session closes it:
+- `admissibleCoeff_le_two_mul_succ : c(t+1) ≤ 2·c(t) + 1` — the floor adds at most
+  one unit beyond doubling. Proof: `c(t+1)=⌊2·M/n⌋` with M=2^{t-1}, n=|V|; rewrite
+  `2·M = n·(2·(M/n)) + 2·(M%n)`, `Nat.mul_add_div hV` splits off `2·(M/n)`, and
+  `2·(M%n)/n < 2` (from `Nat.div_lt_iff_lt_mul` + `M%n<n`), then `omega`.
+- `admissibleCoeff_step_bracket : 2·c(t) ≤ c(t+1) ≤ 2·c(t)+1` — pins the recurrence
+  to `c(t+1) ∈ {2c(t), 2c(t)+1}`: exact exponential doubling up to the unavoidable
+  truncated-division `±1`. Sharp coefficient-level growth law (first-moment regime,
+  bounded ground set).
+
+File now 391 L, 16 thm, 3 def, 0 axioms, 0 sorries, native_decide-free. VERIFIED
+(built first try, 3.5s). **Recipe:** `⌊2x⌋ ≤ 2⌊x⌋+1` in ℕ via mul_add_div split
+of `2·(n·q+r)` + `2r/n<2`.
+
+Still open (hard regime, untouched): Lovász-type local argument for ground sets
+growing with the family — needs LLL, not session-sized.

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 351,
+    "lineCount": 391,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

`erdos-1022-oq-02` (growth rate of the Property-B sparseness threshold) already
pins the first-moment threshold `2^{t-1}` (doubles per step) and proves the
admissible integer coefficient `c(t) = ⌊2^{t-1}/|V|⌋` diverges and **at least**
doubles: `admissibleCoeff_ge_two_mul : 2·c(t) ≤ c(t+1)`. The matching upper bound
was left open ("at least doubles"). This PR closes it, making the growth law sharp.

New (2 verified theorems, **0 axioms, `native_decide`-free**):

- `admissibleCoeff_le_two_mul_succ : c(t+1) ≤ 2·c(t) + 1` — the truncated division
  can add at most one unit beyond doubling (`⌊2x⌋ ≤ 2⌊x⌋ + 1`).
- `admissibleCoeff_step_bracket : 2·c(t) ≤ c(t+1) ≤ 2·c(t) + 1` — pins the recurrence
  to `c(t+1) ∈ {2·c(t), 2·c(t)+1}`: exact exponential doubling up to the unavoidable
  `±1` from the floor.

## Significance (honest)

Modest but genuinely sharp: it upgrades the existing one-sided "at least doubles"
to the exact step relation for the admissible coefficient, so the coefficient-level
growth rate is now bracketed with no slack beyond the floor remainder. The hard
regime of #1022 — a Lovász-type local argument allowing the ground set to grow with
the family — remains untouched (needs LLL, out of session scope).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1022OQ02` → `Built (3.5s)`, 7744 jobs.
- 0 sorries, 0 `axiom` declarations, no structure-encoded assumptions, no `native_decide`.
- Gallery meta synced: lineCount 351→391, theoremCount 14→16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)