### PR TITLE
research(erdos-504-oq-03): N=3 base case — equilateral is the unique max-angle optimum [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos504OQ03.lean
+++ b/proofs/Proofs/Erdos504OQ03.lean
@@ -1,0 +1,150 @@
+/-
+Erdős Problem #504 — OQ-03: Uniqueness of optimal configurations for the
+maximum-angle problem, the N = 3 base case.
+
+Parent problem (Erdős #504, Blumenthal's problem, solved by Sendov 1993):
+let α_N be the smallest achievable value of the largest angle determined by N
+points in the plane,
+
+    α_N = min_{|P| = N} max_{a,b,c ∈ P} ∠ a b c.
+
+Equivalently α_N is the largest angle that is *always forced*: every N-point
+set contains three points spanning an angle ≥ α_N.  Sub-question OQ-03 asks for
+which N the optimal (angle-minimising) configuration is unique up to similarity.
+
+This file settles the smallest genuine case, N = 3.  For three pairwise-distinct
+points the largest of the three interior angles is always ≥ π/3, and equality
+holds *exactly* for the equilateral triangle.  Hence α₃ = π/3 and the extremal
+3-point configuration is the equilateral triangle, unique up to similarity — the
+base case of the uniqueness question.
+
+Everything is elementary and axiom-free, built on Mathlib's triangle angle-sum
+`angle_add_angle_add_angle_eq_pi`, the isosceles-triangle theorem (pons asinorum)
+`angle_eq_angle_of_dist_eq`, and its converse
+`dist_eq_of_angle_eq_angle_of_angle_ne_pi`.
+
+Main results:
+  * `exists_angle_ge_pi_div_three` — some interior angle of any (non-degenerate)
+    triangle is ≥ π/3.
+  * `maxAngle_ge_pi_div_three` — the maximum interior angle is ≥ π/3, i.e.
+    α₃ ≥ π/3.
+  * `all_angles_eq_pi_div_three_iff_equilateral` — all three interior angles
+    equal π/3 iff the three side lengths are equal.
+  * `maxAngle_eq_pi_div_three_iff_equilateral` — the maximum angle equals π/3
+    iff the triangle is equilateral.
+  * `alpha_three_optimal_iff_equilateral` — capstone: α₃ = π/3 is attained
+    exactly by the equilateral triangle (N = 3 uniqueness).
+-/
+
+import Mathlib
+
+open Real
+open scoped EuclideanGeometry RealInnerProductSpace
+
+namespace Erdos504OQ03
+
+open EuclideanGeometry
+
+variable {V P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+  [MetricSpace P] [NormedAddTorsor V P]
+
+/-- **Some angle of a triangle is at least π/3.**  The three interior angles of a
+(non-degenerate) triangle sum to `π`, so at least one of them is ≥ `π/3`. -/
+theorem exists_angle_ge_pi_div_three (A B C : P) (h : B ≠ A) :
+    π / 3 ≤ ∠ A B C ∨ π / 3 ≤ ∠ B C A ∨ π / 3 ≤ ∠ C A B := by
+  have hsum : ∠ A B C + ∠ B C A + ∠ C A B = π :=
+    angle_add_angle_add_angle_eq_pi C h
+  by_contra hcon
+  push_neg at hcon
+  obtain ⟨h1, h2, h3⟩ := hcon
+  linarith
+
+/-- The largest interior angle determined by the three points `A B C`. -/
+noncomputable def maxAngle (A B C : P) : ℝ :=
+  max (∠ A B C) (max (∠ B C A) (∠ C A B))
+
+/-- **α₃ ≥ π/3.**  The maximum interior angle of any (non-degenerate) triangle is
+at least `π/3`: three points always span an angle ≥ `π/3`. -/
+theorem maxAngle_ge_pi_div_three (A B C : P) (h : B ≠ A) :
+    π / 3 ≤ maxAngle A B C := by
+  unfold maxAngle
+  rcases exists_angle_ge_pi_div_three A B C h with h1 | h2 | h3
+  · exact le_max_of_le_left h1
+  · exact le_max_of_le_right (le_max_of_le_left h2)
+  · exact le_max_of_le_right (le_max_of_le_right h3)
+
+/-- **All three interior angles equal π/3 iff the triangle is equilateral.**
+The forward direction is the converse of pons asinorum (equal base angles force
+equal sides); the reverse direction is pons asinorum together with the angle
+sum. -/
+theorem all_angles_eq_pi_div_three_iff_equilateral (A B C : P) (h : B ≠ A) :
+    (∠ A B C = π / 3 ∧ ∠ B C A = π / 3 ∧ ∠ C A B = π / 3) ↔
+      (dist A B = dist B C ∧ dist B C = dist C A) := by
+  have hne : (π / 3 : ℝ) ≠ π := by
+    have := Real.pi_pos; intro hpi; linarith
+  constructor
+  · -- angles all π/3 ⟹ equilateral (converse pons asinorum)
+    rintro ⟨hB, hC, hA⟩
+    -- dist A B = dist A C
+    have e1 : dist A B = dist A C := by
+      apply dist_eq_of_angle_eq_angle_of_angle_ne_pi
+      · rw [angle_comm A C B, hB, hC]
+      · rw [angle_comm B A C, hA]; exact hne
+    -- dist B A = dist B C
+    have e2 : dist B A = dist B C := by
+      apply dist_eq_of_angle_eq_angle_of_angle_ne_pi
+      · rw [angle_comm B A C, hA, hC]
+      · rw [hB]; exact hne
+    refine ⟨?_, ?_⟩
+    · rw [dist_comm A B]; exact e2
+    · -- dist B C = dist C A
+      have hz : dist A B = dist C A := by rw [dist_comm C A]; exact e1
+      have hx : dist A B = dist B C := by rw [dist_comm A B]; exact e2
+      exact hx.symm.trans hz
+  · -- equilateral ⟹ all angles π/3 (pons asinorum + angle sum)
+    rintro ⟨q1, q2⟩
+    have hsum : ∠ A B C + ∠ B C A + ∠ C A B = π :=
+      angle_add_angle_add_angle_eq_pi C h
+    have hAC : dist A B = dist A C := by rw [dist_comm A C, ← q2, ← q1]
+    have p1 : ∠ A B C = ∠ A C B := angle_eq_angle_of_dist_eq hAC
+    have hBC_eq : ∠ A B C = ∠ B C A := by rw [p1, angle_comm A C B]
+    have hBA : dist B A = dist B C := by rw [dist_comm B A]; exact q1
+    have p2 : ∠ B A C = ∠ B C A := angle_eq_angle_of_dist_eq hBA
+    have hCA_eq : ∠ C A B = ∠ B C A := by rw [← angle_comm B A C]; exact p2
+    exact ⟨by linarith, by linarith, by linarith⟩
+
+/-- **N = 3 uniqueness (angle form).**  The maximum interior angle equals its
+minimum possible value `π/3` iff the three points form an equilateral triangle. -/
+theorem maxAngle_eq_pi_div_three_iff_equilateral (A B C : P) (h : B ≠ A) :
+    maxAngle A B C = π / 3 ↔ (dist A B = dist B C ∧ dist B C = dist C A) := by
+  constructor
+  · intro hmax
+    have hsum : ∠ A B C + ∠ B C A + ∠ C A B = π :=
+      angle_add_angle_add_angle_eq_pi C h
+    have h1 : ∠ A B C ≤ π / 3 := by
+      rw [← hmax]; exact le_max_left _ _
+    have h2 : ∠ B C A ≤ π / 3 := by
+      rw [← hmax]
+      exact le_trans (le_max_left _ _) (le_max_right _ _)
+    have h3 : ∠ C A B ≤ π / 3 := by
+      rw [← hmax]
+      exact le_trans (le_max_right _ _) (le_max_right _ _)
+    refine (all_angles_eq_pi_div_three_iff_equilateral A B C h).mp ⟨?_, ?_, ?_⟩
+    · linarith
+    · linarith
+    · linarith
+  · intro heq
+    obtain ⟨ha1, ha2, ha3⟩ :=
+      (all_angles_eq_pi_div_three_iff_equilateral A B C h).mpr heq
+    simp only [maxAngle, ha1, ha2, ha3, max_self]
+
+/-- **N = 3 base case of Erdős #504 OQ-03.**  For any three pairwise-distinct
+points the largest determined angle is ≥ `π/3`, and this minimum value `π/3` is
+attained *exactly* by the equilateral triangle.  Hence `α₃ = π/3` and the
+optimal 3-point configuration is unique up to similarity. -/
+theorem alpha_three_optimal_iff_equilateral (A B C : P) (h : B ≠ A) :
+    π / 3 ≤ maxAngle A B C ∧
+      (maxAngle A B C = π / 3 ↔ (dist A B = dist B C ∧ dist B C = dist C A)) :=
+  ⟨maxAngle_ge_pi_div_three A B C h, maxAngle_eq_pi_div_three_iff_equilateral A B C h⟩
+
+end Erdos504OQ03

--- a/src/data/proofs/erdos-504-oq-03/meta.json
+++ b/src/data/proofs/erdos-504-oq-03/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "erdos-504-oq-03",
+  "title": "Erdős #504 OQ-03: The Equilateral Triangle Is the Unique 3-Point Maximum-Angle Optimum",
+  "slug": "erdos-504-oq-03",
+  "description": "For Erdős #504 (Blumenthal's maximum-angle problem, solved by Sendov 1993), OQ-03 asks for which N the angle-minimising configuration is unique up to similarity. This entry settles the base case N = 3: among any three pairwise-distinct points the largest interior angle is ≥ π/3, with equality exactly for the equilateral triangle. Hence α₃ = π/3 and the optimal 3-point configuration is the equilateral triangle, unique up to similarity. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Researcher (Lean Genius)",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "erdos-problems",
+      "discrete-geometry",
+      "combinatorial-geometry",
+      "angles",
+      "euclidean-geometry",
+      "triangle",
+      "extremal-configuration",
+      "uniqueness",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanGeometry.angle_add_angle_add_angle_eq_pi",
+        "description": "The sum of the three interior angles of a (possibly degenerate) triangle equals π, given two vertices are distinct — the source of the ≥ π/3 lower bound.",
+        "module": "Mathlib.Geometry.Euclidean.Triangle"
+      },
+      {
+        "theorem": "EuclideanGeometry.angle_eq_angle_of_dist_eq",
+        "description": "Pons asinorum (isosceles triangle theorem, angle-at-point form): equal sides force equal base angles — used for the equilateral ⟹ equiangular direction.",
+        "module": "Mathlib.Geometry.Euclidean.Triangle"
+      },
+      {
+        "theorem": "EuclideanGeometry.dist_eq_of_angle_eq_angle_of_angle_ne_pi",
+        "description": "Converse of pons asinorum: equal base angles (with the apex angle ≠ π) force equal sides — used for the equiangular ⟹ equilateral direction.",
+        "module": "Mathlib.Geometry.Euclidean.Triangle"
+      },
+      {
+        "theorem": "EuclideanGeometry.angle_comm",
+        "description": "∠ p₁ p₂ p₃ = ∠ p₃ p₂ p₁ — the unoriented angle at a vertex is symmetric in its two rays.",
+        "module": "Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine"
+      }
+    ],
+    "originalContributions": [
+      "Proved exists_angle_ge_pi_div_three: in any non-degenerate triangle at least one interior angle is ≥ π/3, from the triangle angle sum π together with the pigeonhole that three numbers averaging π/3 cannot all be strictly below π/3.",
+      "Proved maxAngle_ge_pi_div_three: the maximum of the three interior angles is ≥ π/3, i.e. α₃ ≥ π/3 — three points always determine an angle of at least 60°.",
+      "Proved all_angles_eq_pi_div_three_iff_equilateral: the three interior angles all equal π/3 if and only if the three side lengths are equal, combining pons asinorum and its converse with the angle sum.",
+      "Proved maxAngle_eq_pi_div_three_iff_equilateral: the largest interior angle attains its minimum possible value π/3 exactly for the equilateral triangle — the N = 3 uniqueness statement.",
+      "Proved alpha_three_optimal_iff_equilateral: capstone combining the bound and the equality case: α₃ = π/3 is attained precisely by the equilateral triangle, so the optimal 3-point configuration is unique up to similarity."
+    ],
+    "dateAdded": "2026-07-08",
+    "erdosNumber": 504,
+    "proofRepoPath": "Proofs/Erdos504OQ03.lean",
+    "axiomCount": 0,
+    "lineCount": 150,
+    "assumptions": "None. 0 axioms (only the standard propext / Classical.choice / Quot.sound foundational axioms, which do not count), 0 sorries, no native_decide. The results are stated for an arbitrary real Euclidean affine space (NormedAddTorsor over a real inner product space), with the single genuine hypothesis that two of the three points are distinct. Fully machine-checked.",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: Euclidean Affine Space and Interior Angles",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Works in an arbitrary real Euclidean affine space: V a real inner product space and P a NormedAddTorsor over V, with the EuclideanGeometry angle-at-a-point notation ∠ a b c. The header recalls Erdős #504 (Blumenthal's problem): α_N is the smallest achievable value of the largest angle among N planar points, and OQ-03 asks for which N the extremal configuration is unique up to similarity.",
+      "mathContext": "Erdős #504, solved by Sendov (1993), determines α_N, the minimax angle among N points. OQ-03 concerns uniqueness of the optimal configuration; this file settles N = 3, where the optimum is the equilateral triangle."
+    },
+    {
+      "id": "lower-bound",
+      "title": "α₃ ≥ π/3: Some Angle Is at Least 60°",
+      "startLine": 52,
+      "endLine": 78,
+      "summary": "exists_angle_ge_pi_div_three: the three interior angles sum to π (angle_add_angle_add_angle_eq_pi, needing only B ≠ A), so by contradiction they cannot all be < π/3. maxAngle is defined as the maximum of the three interior angles, and maxAngle_ge_pi_div_three lifts the disjunction to the stated lower bound α₃ ≥ π/3.",
+      "mathContext": "This is the forced-angle direction of Erdős #504 at N = 3: every 3-point set contains an angle ≥ π/3. It is exact — the equilateral triangle makes all three angles equal to π/3."
+    },
+    {
+      "id": "equilateral-iff",
+      "title": "Equiangular ⟺ Equilateral",
+      "startLine": 79,
+      "endLine": 117,
+      "summary": "all_angles_eq_pi_div_three_iff_equilateral: all three interior angles equal π/3 iff the three side lengths are equal. The equiangular ⟹ equilateral direction uses the converse of pons asinorum (dist_eq_of_angle_eq_angle_of_angle_ne_pi, valid since π/3 ≠ π); the equilateral ⟹ equiangular direction uses pons asinorum (angle_eq_angle_of_dist_eq) with the angle sum forcing each common angle to be π/3.",
+      "mathContext": "The classical characterisation of the equilateral triangle by its angles, formalised via the isosceles-triangle theorem and its converse — the crux of the uniqueness of the minimiser."
+    },
+    {
+      "id": "uniqueness",
+      "title": "N = 3 Uniqueness: The Equilateral Triangle Is the Unique Optimum",
+      "startLine": 118,
+      "endLine": 150,
+      "summary": "maxAngle_eq_pi_div_three_iff_equilateral: the maximum interior angle equals its minimum possible value π/3 iff the triangle is equilateral — if maxAngle = π/3 then all three angles are ≤ π/3 yet sum to π, so each equals π/3. alpha_three_optimal_iff_equilateral packages the bound and the equality case: α₃ = π/3 is attained exactly by the equilateral triangle.",
+      "mathContext": "This is the OQ-03 answer for N = 3: the angle-minimising 3-point configuration exists (equilateral triangle) and is unique up to similarity (rotation, translation, scaling, reflection), since the equality case pins the side lengths equal."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Erdős #504 is Blumenthal's problem: for N points in the plane, minimise the largest angle determined by three of them; equivalently, find the largest angle α_N that is always forced. Erdős and Szekeres (1960) treated the powers of two, and Sendov (1993) gave the complete answer, with the formula changing at the threshold N = 5·2^{n−3} inside each dyadic interval (2^{n−1}, 2^n]. Sub-question OQ-03 asks for which N the optimal configuration is unique up to similarity. The smallest genuine case is N = 3, where the answer is the equilateral triangle.",
+    "problemStatement": "For which N is the extremal configuration attaining α_N = min_{|P|=N} max_{a,b,c ∈ P} ∠(a,b,c) unique up to similarity? This entry proves the N = 3 case: α₃ = π/3, uniquely attained by the equilateral triangle.",
+    "text": "The three interior angles of a triangle sum to π, so the largest is at least π/3, and any three points span an angle of at least 60°. Equality throughout forces all three angles to equal π/3, and by the isosceles-triangle theorem and its converse this happens exactly when all three sides are equal — the equilateral triangle. Hence α₃ = π/3 and the minimiser is unique up to similarity.",
+    "proofStrategy": "For the lower bound, use Mathlib's triangle angle sum (∠ A B C + ∠ B C A + ∠ C A B = π) and a one-line contradiction: three reals summing to π cannot all be below π/3. For the equality case, characterise the equilateral triangle by its angles — pons asinorum (equal sides ⟹ equal base angles) and its converse (equal base angles with apex ≠ π ⟹ equal sides) — and observe that maxAngle = π/3 forces every angle to π/3 because each is ≤ the max yet the three sum to π.",
+    "keyInsights": [
+      "α₃ ≥ π/3 is purely the triangle angle sum plus pigeonhole: three angles averaging π/3 cannot all be strictly smaller, so the maximum is at least π/3 — the exact minimax value.",
+      "The equality case is the classical fact 'equiangular ⟺ equilateral', which in Lean is exactly pons asinorum (angle_eq_angle_of_dist_eq) together with its converse (dist_eq_of_angle_eq_angle_of_angle_ne_pi); the apex-angle hypothesis of the converse is automatic since π/3 ≠ π.",
+      "maxAngle = π/3 collapses to equiangularity without any extra optimisation: each of the three angles is ≤ the maximum π/3, but they sum to π = 3·(π/3), so all three are forced equal.",
+      "The whole argument is dimension- and field-agnostic: it holds in any real Euclidean affine space and needs only that two of the three points are distinct, so it is genuinely about the geometry of three points rather than a coordinate computation.",
+      "Only the base case N = 3 is settled here; for larger N Sendov's threshold formula makes the extremal configuration change type, and uniqueness there requires the full minimax analysis, which is not attempted."
+    ]
+  },
+  "conclusion": {
+    "summary": "Settles the N = 3 base case of Erdős #504 OQ-03: among any three pairwise-distinct points the largest interior angle is ≥ π/3, with equality exactly for the equilateral triangle. Hence α₃ = π/3 and the angle-minimising 3-point configuration is the equilateral triangle, unique up to similarity. Fully verified with 0 axioms and no native_decide.",
+    "implications": "Establishes the smallest instance of the OQ-03 uniqueness phenomenon and packages a reusable equiangular ⟺ equilateral characterisation and a maxAngle lower bound for three points in an arbitrary real Euclidean affine space. These give a clean template for attacking the next cases (N = 4, and the dyadic thresholds of Sendov's formula).",
+    "openQuestions": [
+      "N = 4: identify the angle-minimising 4-point configuration (the square gives max angle π/2) and decide whether it is unique up to similarity, or whether a one-parameter family of optima appears.",
+      "General N: for which N in each dyadic interval (2^{n−1}, 2^n] — and in particular at the Sendov threshold N = 5·2^{n−3} — is the optimum unique, and where does a genuine (discrete or continuous) family of optima exist?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "extends",
+      "targetId": "erdos-504",
+      "description": "Answers the OQ-03 uniqueness sub-question of Erdős #504 (Blumenthal's maximum-angle problem) for N = 3 by proving the equilateral triangle is the unique angle-minimising 3-point configuration up to similarity."
+    },
+    {
+      "relationship": "relatedTo",
+      "targetId": "erdos-504-oq-01",
+      "description": "Companion sub-question: OQ-01 formalises the higher-dimensional (ℝ^d, right-angle threshold) analogue via the hypercube, while OQ-03 concerns uniqueness of the planar minimax configuration."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "EuclideanGeometry",
+      "RealInnerProductSpace"
+    ],
+    "namespace": "Erdos504OQ03",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos504OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "alpha_three_optimal_iff_equilateral",
+      "type": "theorem",
+      "description": "Capstone (N = 3 base case of Erdős #504 OQ-03): for any three pairwise-distinct points the largest determined angle is ≥ π/3, and this minimum value π/3 is attained exactly by the equilateral triangle — so the optimal 3-point configuration is unique up to similarity."
+    },
+    {
+      "name": "maxAngle_eq_pi_div_three_iff_equilateral",
+      "type": "theorem",
+      "description": "The maximum interior angle equals its minimum possible value π/3 if and only if the three points form an equilateral triangle."
+    },
+    {
+      "name": "all_angles_eq_pi_div_three_iff_equilateral",
+      "type": "theorem",
+      "description": "All three interior angles equal π/3 if and only if the three side lengths are equal, via pons asinorum and its converse together with the triangle angle sum."
+    },
+    {
+      "name": "maxAngle_ge_pi_div_three",
+      "type": "theorem",
+      "description": "The maximum interior angle of any non-degenerate triangle is at least π/3, i.e. α₃ ≥ π/3: three points always span an angle of at least 60°."
+    },
+    {
+      "name": "exists_angle_ge_pi_div_three",
+      "type": "theorem",
+      "description": "At least one interior angle of a non-degenerate triangle is ≥ π/3, since the three angles sum to π and cannot all be strictly below π/3."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Erdős Problem #504 (Blumenthal's maximum-angle problem, solved by Sendov 1993) determines α_N = min over N-point sets of the largest angle determined by three of the points. Sub-question **OQ-03** asks: for which N is the optimal (angle-minimising) configuration unique up to similarity?

This PR settles the smallest genuine case, **N = 3**. For three pairwise-distinct points:
- the largest interior angle is always ≥ π/3, and
- equality holds **exactly** for the equilateral triangle.

Hence α₃ = π/3 and the optimal 3-point configuration is the equilateral triangle, unique up to similarity.

## Results (`proofs/Proofs/Erdos504OQ03.lean`, namespace `Erdos504OQ03`)

- `exists_angle_ge_pi_div_three` — some interior angle of a non-degenerate triangle is ≥ π/3 (triangle angle sum + pigeonhole).
- `maxAngle_ge_pi_div_three` — the maximum interior angle is ≥ π/3 (α₃ ≥ π/3).
- `all_angles_eq_pi_div_three_iff_equilateral` — equiangular ⟺ equilateral, via pons asinorum and its converse.
- `maxAngle_eq_pi_div_three_iff_equilateral` — the maximum angle equals π/3 iff the triangle is equilateral (N = 3 uniqueness).
- `alpha_three_optimal_iff_equilateral` — capstone: α₃ = π/3 attained exactly by the equilateral triangle.

## Verification

- Docker-built `[7743/7743]`, **0 axioms / 0 sorries / no native_decide**.
- Stated in an arbitrary real Euclidean affine space (`NormedAddTorsor` over a real inner product space); the only hypothesis is that two of the three points are distinct.
- Built entirely on existing Mathlib: `angle_add_angle_add_angle_eq_pi`, `angle_eq_angle_of_dist_eq`, `dist_eq_of_angle_eq_angle_of_angle_ne_pi`, `angle_comm`.

Gallery entry added at `src/data/proofs/erdos-504-oq-03/meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)