### PR TITLE
Enrich shannon-channel-coding-awgn-oq-02-oq-02: annotations + keyInsights

### DIFF
--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-second-moment-eq-variance",
+    "proofId": "shannon-channel-coding-awgn-oq-02-oq-02",
+    "range": {
+      "startLine": 40,
+      "endLine": 48
+    },
+    "type": "theorem",
+    "title": "Power = Variance for a Zero-Mean Signal",
+    "content": "second_moment_eq_variance is the bridge between the engineering notion of signal power E[W²] and the probabilistic variance Var[W]. The one-line proof rewrites with variance_eq_sub (Var[W] = E[W²] − (E[W])²) and substitutes the zero-mean hypothesis μ[W] = 0, so the (E[W])² term collapses and ring finishes. Recorded self-contained (independent of the parent file) because it is reused twice below: once on the aggregate ∑ Wᵢ and once term-by-term on each Wᵢ.",
+    "mathContext": "$\\operatorname{Var}[W] = \\mathbb{E}[W^2] - (\\mathbb{E}[W])^2 \\;\\xrightarrow{\\;\\mathbb{E}[W]=0\\;}\\; \\mathbb{E}[W^2] = \\operatorname{Var}[W]$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "variance",
+      "second moment",
+      "signal power",
+      "mean-zero random variable"
+    ],
+    "prerequisites": [
+      "variance as second moment minus squared mean",
+      "expectation on a probability space"
+    ]
+  },
+  {
+    "id": "ann-multisymbol-variance",
+    "proofId": "shannon-channel-coding-awgn-oq-02-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "Bienaymé Identity: Variance of a Pairwise-Independent Sum",
+    "content": "awgn_multisymbol_variance records Mathlib's IndepFun.variance_sum directly in channel notation. The hypothesis Set.Pairwise ↑s (fun i j => W i ⟂ᵢ[μ] W j) demands only pairwise — not mutual — independence, and that is exactly what is needed: expanding Var[∑ Wᵢ] produces a double sum ∑ᵢ∑ⱼ Cov(Wᵢ, Wⱼ) whose off-diagonal covariances all vanish under pairwise independence, collapsing it to the diagonal ∑ᵢ Var[Wᵢ]. This is the substantive probabilistic input of the whole entry.",
+    "mathContext": "$\\operatorname{Var}\\!\\left[\\sum_{i\\in s} W_i\\right] = \\sum_{i,j\\in s}\\operatorname{Cov}(W_i,W_j) = \\sum_{i\\in s}\\operatorname{Var}[W_i]$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bienaymé's identity",
+      "pairwise independence",
+      "covariance",
+      "variance of a sum"
+    ],
+    "prerequisites": [
+      "covariance and its bilinearity",
+      "independence implies zero covariance",
+      "IndepFun.variance_sum"
+    ]
+  },
+  {
+    "id": "ann-sum-mean-zero",
+    "proofId": "shannon-channel-coding-awgn-oq-02-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 72
+    },
+    "type": "theorem",
+    "title": "The Aggregate Is Again Zero-Mean",
+    "content": "sum_mean_zero shows that a finite sum of zero-mean contributions is itself zero-mean. Square-integrability (MemLp 2) gives integrability of each part via MemLp.integrable with 1 ≤ 2, licensing linearity of the integral over a Finset (integral_finset_sum); the resulting ∑ᵢ E[Wᵢ] is then zero termwise. This lemma is precisely what lets the squared-mean term drop when second_moment_eq_variance is applied to the aggregate ∑ Wᵢ, not merely to each summand.",
+    "mathContext": "$\\mathbb{E}\\!\\left[\\sum_{i\\in s} W_i\\right] = \\sum_{i\\in s}\\mathbb{E}[W_i] = 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "linearity of expectation",
+      "integrability from L² membership",
+      "finite sums of integrable functions"
+    ],
+    "prerequisites": [
+      "integral_finset_sum",
+      "L² membership implies integrability on a finite measure"
+    ]
+  },
+  {
+    "id": "ann-multisymbol-power",
+    "proofId": "shannon-channel-coding-awgn-oq-02-oq-02",
+    "range": {
+      "startLine": 74,
+      "endLine": 93
+    },
+    "type": "theorem",
+    "title": "Multi-Symbol Output Power: The Core Identity",
+    "content": "awgn_multisymbol_power assembles the three preceding facts into the main result E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The aggregate is square-integrable (memLp_finset_sum') and zero-mean (sum_mean_zero), so second_moment_eq_variance rewrites its power as Var[∑ Wᵢ]; awgn_multisymbol_variance splits that into ∑ᵢ Var[Wᵢ]; and a termwise reverse application of second_moment_eq_variance turns each Var[Wᵢ] back into E[Wᵢ²]. Powers add across pairwise-independent, zero-mean contributions.",
+    "mathContext": "$\\mathbb{E}\\!\\left[\\left(\\sum_{i\\in s} W_i\\right)^2\\right] = \\operatorname{Var}\\!\\left[\\sum_{i\\in s} W_i\\right] = \\sum_{i\\in s}\\operatorname{Var}[W_i] = \\sum_{i\\in s}\\mathbb{E}[W_i^2]$",
+    "significance": "key",
+    "relatedConcepts": [
+      "additivity of power",
+      "second-moment identity",
+      "pairwise independence",
+      "AWGN channel"
+    ],
+    "prerequisites": [
+      "the Bienaymé identity",
+      "power = variance for zero-mean signals",
+      "square-integrability of a finite sum"
+    ]
+  },
+  {
+    "id": "ann-output-power-named",
+    "proofId": "shannon-channel-coding-awgn-oq-02-oq-02",
+    "range": {
+      "startLine": 95,
+      "endLine": 111
+    },
+    "type": "theorem",
+    "title": "Block Power Budget with Named Powers",
+    "content": "awgn_multisymbol_output_power restates the core identity with per-contribution powers Pᵢ = E[Wᵢ²]: the aggregate output power is ∑ᵢ Pᵢ. For a signal-plus-noise block this is the total-power budget P_total = ∑ signal powers + ∑ noise powers — the n-symbol analogue of the parent's single-symbol E[Y²] = P + N, recovered as the case s = {signal, noise}. The proof simply rewrites the named powers into awgn_multisymbol_power.",
+    "mathContext": "$\\mathbb{E}\\!\\left[\\left(\\sum_{i\\in s} W_i\\right)^2\\right] = \\sum_{i\\in s} P_i, \\qquad P_i := \\mathbb{E}[W_i^2]$",
+    "significance": "context",
+    "relatedConcepts": [
+      "power budget",
+      "AWGN channel capacity",
+      "signal-to-noise ratio",
+      "block coding"
+    ],
+    "prerequisites": [
+      "the core multi-symbol power identity"
+    ]
+  }
+]

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -93,7 +93,9 @@
     "keyInsights": [
       "Pairwise independence is enough. The block-power identity does not need mutual (full) independence of the contributions: the variance of a sum expands into a double sum of covariances, and only pairwise independence is required to make every off-diagonal covariance vanish. Mathlib packages this as IndepFun.variance_sum with a Set.Pairwise hypothesis.",
       "Zero mean is what turns 'variance' into 'power', and it must hold for the aggregate too. The engineering quantity E[W²] equals the probabilistic variance Var[W] only after the squared-mean term (E[W])² is dropped. The same reduction on the aggregate ∑ Wᵢ is legitimate because a finite sum of zero-mean contributions is again zero-mean (sum_mean_zero).",
-      "The two-term parent result is the special case |s| = 2. Instantiating s = {signal, noise} recovers E[(X+Z)²] = E[X²] + E[Z²]; the Finset formulation makes the n-symbol block-power budget a single identity rather than an induction the caller must run."
+      "The two-term parent result is the special case |s| = 2. Instantiating s = {signal, noise} recovers E[(X+Z)²] = E[X²] + E[Z²]; the Finset formulation makes the n-symbol block-power budget a single identity rather than an induction the caller must run.",
+      "The Finset indexing sidesteps induction entirely. Rather than adding one symbol at a time and re-verifying independence at each step, the argument works directly with an arbitrary finite index set s and its Set.Pairwise independence hypothesis, so IndepFun.variance_sum discharges the whole block in one application — the same proof shape as the two-term case, with a Finset in place of a two-element set.",
+      "Square-integrability is the minimal regularity that makes every step legitimate. MemLp 2 does double duty: memLp_finset_sum' keeps the aggregate ∑ Wᵢ in L² so variance_eq_sub applies to it, and MemLp.integrable (via 1 ≤ 2) supplies the integrability needed for linearity of expectation over the Finset — no boundedness or higher moments are assumed."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass on `shannon-channel-coding-awgn-oq-02-oq-02` (quality 36, passes 0 — previously had no annotations.json).

## Changes
- **Added `annotations.json`** (5 inline annotations, previously absent). Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, anchored to all five theorems:
  - `second_moment_eq_variance` — power = variance for zero-mean signals
  - `awgn_multisymbol_variance` — the Bienaymé identity in channel notation
  - `sum_mean_zero` — the aggregate is again zero-mean
  - `awgn_multisymbol_power` — the core identity E[(∑Wᵢ)²] = ∑E[Wᵢ²]
  - `awgn_multisymbol_output_power` — the named block-power budget ∑Pᵢ
- **Added 2 keyInsights** (3 → 5): the induction-free Finset formulation, and the double role of L² square-integrability.

## Verification
- meta.json 16.0 KB (well under the ~60 KB cap); JSON validated.
- `pnpm annotations:build` (DISABLE_BUILD_CACHE=1) resolves all 5 annotations against the Lean source with **0 errors for this entry**; annotation `type` fields match the Lean construct kinds (all `theorem`) and line ranges are in bounds.
- Gallery data validation and search-index checks pass under `pnpm build` (the final `tsc` step fails only because node_modules is not installed in this worktree — unrelated to content).