### PR TITLE
research(eqr-oq-03-oq-02): full Kronecker symbol is {−1,0,1}-valued (real quadratic character)

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -581,6 +581,51 @@ theorem χ₈'_eq_χ₄_mul_χ₈_of_odd (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1
     ← kronecker_two_eq_χ₈ n hn hno]
   exact kronecker_neg_two_eq_mul (n : ℤ)
 
+-- ============================================================
+-- Section 10: The symbol is {−1, 0, 1}-valued (a real character)
+-- ============================================================
+
+/-- **The Kronecker symbol is `{−1, 0, 1}`-valued.**  For every integer pair
+`(a, n)` the symbol `(a/n)` lands in `{−1, 0, 1}`: the special moduli `n = 0, −1`
+are `{0,1}`- and `{−1,1}`-valued by definition, `n = 1` gives `1`, and the general
+branch is `sign · J(a ∣ |n|)` with `sign ∈ {−1,1}` and the Jacobi symbol
+`{−1,0,1}`-valued (`jacobiSym.trichotomy`).  Taking `{−1,0,1}` values is the
+defining feature of a *real* (quadratic) Dirichlet character — exactly the object
+the Gauss-sum route consumes.  Previously known here only for `kronecker2`
+(`kronecker2_values`); this establishes it for the full symbol. -/
+theorem kronecker_trichotomy (a n : ℤ) :
+    kronecker a n = 0 ∨ kronecker a n = 1 ∨ kronecker a n = -1 := by
+  rcases eq_or_ne n 0 with rfl | hn0
+  · rw [show kronecker a 0 = kronecker0 a from by simp [kronecker], kronecker0]
+    split_ifs <;> tauto
+  · rw [kronecker_eq_sign_jacobi a n hn0]
+    have hs : (if n < 0 then kroneckerNeg1 a else 1) = 1 ∨
+        (if n < 0 then kroneckerNeg1 a else 1) = -1 := by
+      split_ifs with hlt
+      · rw [kroneckerNeg1]; split_ifs <;> tauto
+      · tauto
+    rcases jacobiSym.trichotomy a n.natAbs with hj | hj | hj
+    · left; rw [hj, mul_zero]
+    · rw [hj, mul_one]; tauto
+    · rw [hj]
+      rcases hs with h | h
+      · rw [h]; right; right; ring
+      · rw [h]; right; left; ring
+
+/-- **The symbol is bounded by `1` in absolute value.**  An immediate consequence
+of `kronecker_trichotomy`: `|(a/n)| ≤ 1` for all `a, n`.  The clean quantitative
+form of "the Kronecker symbol is a quadratic character". -/
+theorem kronecker_abs_le_one (a n : ℤ) : |kronecker a n| ≤ 1 := by
+  rcases kronecker_trichotomy a n with h | h | h <;> rw [h] <;> norm_num
+
+/-- **The symbol squares into `{0, 1}` (order-two character).**  From the
+trichotomy, `(a/n)² ∈ {0, 1}`: the value squared is `0` on non-coprime pairs and
+`1` otherwise, i.e. the Kronecker symbol has order dividing `2` wherever it is
+nonzero — the abstract statement that `(·/n)` is a *quadratic* character. -/
+theorem kronecker_sq_mem (a n : ℤ) :
+    kronecker a n ^ 2 = 0 ∨ kronecker a n ^ 2 = 1 := by
+  rcases kronecker_trichotomy a n with h | h | h <;> rw [h] <;> norm_num
+
 /-!
 ## Module note: what remains open
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
@@ -87,3 +87,33 @@ the reciprocity core itself, which still needs the Gauss sum (open).
 2. Target 2: generalized quadratic reciprocity for arbitrary fundamental
    discriminants — supplementary laws (done: `kronecker_neg_one_odd`,
    `kronecker_two_odd`) + Gauss sums (open).
+# Knowledge: elementary-quadratic-reciprocity-oq-03-oq-02-wip-01 (Kronecker Symbol WIP)
+
+Target file: proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean (gallery
+elementary-quadratic-reciprocity-oq-03-oq-02). File is otherwise COMPLETE (0 real
+sorries — the 9 grep hits are all "`sorry`-free" comments; 0 axioms; no
+native_decide). Full two-argument multiplicativity + supplementary-law/χ-character
+dictionary (χ₄, χ₈, χ₈') already present from prior sessions.
+
+## Session 2026-07-08 (researcher-1) — {−1,0,1}-valued (real quadratic character)
+
+The full `kronecker` symbol lacked the basic "real character" property (only
+`kronecker2` had `kronecker2_values`). Added it (3 thm, VERIFIED 0/0):
+- `kronecker_trichotomy (a n) : kronecker a n = 0 ∨ = 1 ∨ = -1`. Proof: n=0 →
+  `kronecker0` (if-split, tauto); n≠0 → `kronecker_eq_sign_jacobi` normal form,
+  sign ∈{-1,1} (split_ifs on kroneckerNeg1), `jacobiSym.trichotomy a n.natAbs`
+  gives J∈{0,1,-1}, product cases via ring.
+- `kronecker_abs_le_one : |kronecker a n| ≤ 1` — rcases trichotomy <;> norm_num.
+- `kronecker_sq_mem : kronecker a n ^ 2 = 0 ∨ = 1` (order-two character) — same.
+
+This is exactly the "real Dirichlet character" object the Gauss-sum route consumes.
+File 677 L, 44 thm, 0 axioms, 0 sorries. VERIFIED (TWO line-less exit-135 SIGBUS at
+olean-write [3058/3058] no elab errors → `--repair-cache` then rebuild green 2.7s;
+plain retry alone did NOT fix, repair-cache did). Pre-existing linter warning
+line 304 `done` does nothing — not mine, untouched.
+
+## Still open (NOT session-sized)
+- Wire `kronecker2` into the definition so it becomes the classical symbol at even
+  moduli, re-prove `kronecker_mul_right` for the refined def.
+- Target 2: generalized reciprocity for fundamental discriminants (Gauss sums).
+Key API: jacobiSym.trichotomy / eq_one_or_neg_one / eq_zero_iff_not_coprime[NeZero].

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 631,
+    "lineCount": 677,
     "axiomCount": 0,
-    "theoremCount": 38,
+    "theoremCount": 44,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The Kronecker-symbol WIP file (`ElementaryQuadraticReciprocityOQ03OQ02.lean`) already
establishes full two-argument multiplicativity and the supplementary-law/χ-character
dictionary (χ₄, χ₈, χ₈'). One basic structural property was missing for the **full**
symbol: that it is `{−1, 0, 1}`-valued — i.e. a *real* (quadratic) Dirichlet character.
This was previously known only for the special modulus `kronecker2` (`kronecker2_values`).

New (3 verified theorems, **0 axioms, `native_decide`-free**):

- `kronecker_trichotomy : kronecker a n = 0 ∨ kronecker a n = 1 ∨ kronecker a n = -1` —
  the defining feature of a real character, for every integer pair `(a, n)`. Proof uses
  the file's `kronecker_eq_sign_jacobi` normal form (`sign ∈ {−1,1}`) together with
  Mathlib's `jacobiSym.trichotomy`.
- `kronecker_abs_le_one : |kronecker a n| ≤ 1` — the quantitative form.
- `kronecker_sq_mem : kronecker a n ^ 2 = 0 ∨ kronecker a n ^ 2 = 1` — order-two
  character (square lands in `{0,1}`).

## Significance (honest)

Fills a genuine gap: the `{−1,0,1}`-valued property is exactly the "real Dirichlet
character" object the still-open Gauss-sum reciprocity route consumes, and it now holds
for the complete symbol, not just `kronecker2`. It does not close the two remaining open
targets (redefining via `kronecker2` at even moduli; generalized reciprocity via Gauss
sums), which are not session-sized.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02` →
  `Built (2.7s)`, 3058 jobs (after a cache repair for transient SIGBUS on olean write).
- 0 sorries, 0 `axiom` declarations, no structure-encoded assumptions, no `native_decide`.
- Gallery meta synced: lineCount 631→677, theoremCount 38→44.
- Pre-existing linter warning at line 304 (`done` tactic) is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)