### PR TITLE
Enrich Hall's Theorem with Defect (OQ-01-OQ-01): add mainTheorems

### DIFF
--- a/src/data/proofs/halls-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-01/meta.json
@@ -140,5 +140,17 @@
     "theoremCount": 2,
     "definitionCount": 0
   },
+  "mainTheorems": [
+    {
+      "name": "defect_hall",
+      "type": "theorem",
+      "description": "Hall's theorem with defect d (Ore's deficiency form): a finite family of finite sets t : ι → Finset α satisfies the relaxed Hall condition ∀ s, #s ≤ #(s.biUnion t) + d if and only if there is a partial system of distinct representatives leaving at most d indices unmatched — a set `rejected` with #rejected ≤ d and an assignment e that is injective off `rejected` with e i ∈ t i for every i ∉ rejected. Proved by adjoining d universal dummy elements (living in α ⊕ Fin d), applying ordinary Hall to the enlarged family, and counting how many indices are absorbed by dummies."
+    },
+    {
+      "name": "defect_hall_zero",
+      "type": "theorem",
+      "description": "Marriage theorem (no defect): specialising defect_hall to d = 0 recovers the classical Hall statement — the Hall condition ∀ s, #s ≤ #(s.biUnion t) is equivalent to the existence of a full system of distinct representatives (an injective e with e i ∈ t i for all i). Follows because #rejected ≤ 0 forces `rejected = ∅`, collapsing the partial SDR to a total one."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `halls-theorem-oq-01-oq-01` (quality 94, passes 0).

## Gap addressed
The entry had rich prose and annotations but **no `mainTheorems[]`** — the gallery renders this as a distinct section, and it was absent (confirmed on `main`). This is a structural gap, not a prose-depth one.

## Change
Added `mainTheorems` with the file's two theorems, each with an accurate statement + proof-strategy description:

1. **defect_hall** — Hall's theorem with defect *d* (Ore's deficiency form): the relaxed Hall condition `∀ s, #s ≤ #(s.biUnion t) + d` ⟺ a partial SDR leaving ≤ *d* indices unmatched. Proof adjoins *d* universal dummies in `α ⊕ Fin d`, applies ordinary Hall to the enlarged family, and counts dummy-absorbed indices.
2. **defect_hall_zero** — the *d* = 0 corollary recovering the classical marriage theorem (Hall's condition ⟺ full SDR).

## Verification
- JSON validates (parses clean); meta.json 13.4 KB, well under the ~60 KB cap.
- Descriptions checked against the actual Lean theorem signatures and docstrings in `Proofs/HallsTheoremOQ01OQ01.lean`.
- Only `meta.json` changed; no axiom/status/sorries changes (entry remains verified, 0 axioms, 0 sorries).