### PR TITLE
Enrich Erdős #504 OQ-03: add references array

### DIFF
--- a/src/data/proofs/erdos-504-oq-03/meta.json
+++ b/src/data/proofs/erdos-504-oq-03/meta.json
@@ -125,6 +125,26 @@
       "description": "Companion sub-question: OQ-01 formalises the higher-dimensional (ℝ^d, right-angle threshold) analogue via the hypercube, while OQ-03 concerns uniqueness of the planar minimax configuration."
     }
   ],
+  "references": [
+    {
+      "title": "Erdős Problem #504",
+      "url": "https://www.erdosproblems.com/504",
+      "note": "Blumenthal's maximum-angle problem and the sub-questions, including OQ-03 on uniqueness of the optimal configuration."
+    },
+    {
+      "title": "P. Erdős and G. Szekeres, On some extremum problems in elementary geometry, Ann. Univ. Sci. Budapest 3–4 (1960/61), 53–62",
+      "note": "Early treatment of the maximum-angle problem, resolving the powers-of-two cases."
+    },
+    {
+      "title": "B. Sendov, On a conjecture concerning the least angle in a set of points (1993)",
+      "note": "Complete determination of α_N, with the extremal formula changing at the threshold N = 5·2^{n−3} within each dyadic interval (2^{n−1}, 2^n]."
+    },
+    {
+      "title": "Mathlib4, Mathlib.Geometry.Euclidean.Triangle",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Geometry/Euclidean/Triangle.html",
+      "note": "Source of the triangle angle-sum identity, pons asinorum, and its converse used throughout the proof."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
Enrichment pass for `erdos-504-oq-03`.

## Scope (reworked)
A sibling enricher's annotations.json for this entry merged to `main` mid-session, so I dropped my (duplicate) annotations and this PR now contributes **only the additive `references` array** the entry was missing:
- Erdős problem #504 (erdosproblems.com/504)
- Erdős–Szekeres (1960)
- Sendov (1993)
- Mathlib `Geometry.Euclidean.Triangle` (docs)

## Verification
- meta.json parses cleanly (4 references).
- Single-file additive change; no conflict with the merged annotations.