### PR TITLE
Enrich Euler Totient Shared Power of Two (OQ-07-OQ-01): add mainTheorems

### DIFF
--- a/src/data/proofs/euler-totient-oq-07-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-01/meta.json
@@ -29,6 +29,33 @@
       "Iterate the splitting: peel off the full 2-adic valuation v₂(gcd(φ m, φ n)) = min(v₂ φ m, v₂ φ n) and relate it to the classification of n with φ(n) ≡ 2 (mod 4) (arguments 4, p^k, 2p^k with p ≡ 3 mod 4)."
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "gcd_totient_eq_two_mul_gcd_half",
+      "type": "theorem",
+      "description": "The exact factorisation (structural heart): for m, n ≥ 3 the shared factor 2 splits off cleanly, gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2), reducing every question about the factor 2 to the halved totients where the parity obstruction is gone."
+    },
+    {
+      "name": "gcd_totient_eq_two_iff",
+      "type": "theorem",
+      "description": "Characterisation of equality gcd = 2: for m, n ≥ 3, gcd(φ m, φ n) = 2 iff the halved totients φ m / 2 and φ n / 2 are coprime — the correct dividing line for the sharp lower bound (not 'one totient equals 2')."
+    },
+    {
+      "name": "four_le_gcd_totient_iff",
+      "type": "theorem",
+      "description": "Characterisation of gcd ≥ 4: for m, n ≥ 3 the gcd exceeds the universal bound 2 (reaching ≥ 4) iff the halved totients share a common factor ≥ 2."
+    },
+    {
+      "name": "exists_gcd_two_with_large_totients",
+      "type": "theorem",
+      "description": "Refutes the candidate conjecture that gcd(φ m, φ n) = 2 forces one totient to equal 2: the pair m = 5, n = 7 gives gcd(φ5, φ7) = gcd(4, 6) = 2 with both totients ≥ 4, since the halves 2 and 3 are coprime. Equality is controlled by coprimality of the halves, per gcd_totient_eq_two_iff."
+    },
+    {
+      "name": "gcd_totient_div_two",
+      "type": "theorem",
+      "description": "Dividing the gcd of the totients by 2 recovers the gcd of the halves exactly (no rounding): gcd(φ m, φ n) / 2 = gcd(φ m / 2, φ n / 2) for m, n ≥ 3."
+    }
+  ],
   "sorries": 0,
   "references": [
     {


### PR DESCRIPTION
Enrichment for `euler-totient-oq-07-oq-01` (q94, passes 0). **Gap:** `mainTheorems[]` absent on `main`.

Added `mainTheorems` with the 5 theorems (accurate statement + strategy):
1. **gcd_totient_eq_two_mul_gcd_half** — clean factorisation gcd(φm,φn) = 2·gcd(φm/2,φn/2) for m,n ≥ 3.
2. **gcd_totient_eq_two_iff** — gcd = 2 ⟺ halved totients coprime.
3. **four_le_gcd_totient_iff** — gcd ≥ 4 ⟺ halves share a factor ≥ 2.
4. **exists_gcd_two_with_large_totients** — m=5,n=7 refutes the 'one totient = 2' conjecture (gcd = 2, both totients ≥ 4).
5. **gcd_totient_div_two** — exact halving identity.

JSON validates, under caps; descriptions checked against `Proofs/EulerTotientOQ07OQ01.lean`. Only meta.json changed; verified, 0 axioms, 0 sorries.