### PR TITLE
Enrich Hermite's floor identity: add mainTheorems

### DIFF
--- a/src/data/proofs/hermite-floor-identity/meta.json
+++ b/src/data/proofs/hermite-floor-identity/meta.json
@@ -125,5 +125,17 @@
     "path": "Proofs/HermiteFloorIdentity.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "hermite_floor_identity",
+      "type": "theorem",
+      "description": "Hermite's identity: for every real x and every integer n ≥ 1, ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋. Each real floor is collapsed to an integer Euclidean quotient via Int.floor_div_natCast and Int.floor_add_natCast, then the integer Hermite sum finishes."
+    },
+    {
+      "name": "int_hermite_sum",
+      "type": "theorem",
+      "description": "Integer Hermite sum (the arithmetic core): for n ≥ 1 and any integer a, the Euclidean quotients (a + k)/n over k = 0,…,n-1 sum to a. Proved by integer induction on a using a shift recurrence that increases the sum by exactly 1 when a ↦ a+1."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `hermite-floor-identity`.

## Gap
The entry had **no `mainTheorems` array** — the structured list the gallery uses to surface a proof's headline results was absent.

## Change (additive, single field)
Added `mainTheorems` with the two theorems from `Proofs/HermiteFloorIdentity.lean`, described from the Lean source:
- `hermite_floor_identity` — Hermite's identity ∑_{k=0}^{n-1}⌊x+k/n⌋ = ⌊n·x⌋ for real x, n≥1.
- `int_hermite_sum` — the integer core: ∑_{k=0}^{n-1}(a+k)/n = a (Euclidean division), by integer induction with a shift recurrence.

## Verification
- meta.json parses (13.5 KB, under cap); `leanFile.theoremCount` is 2, matching the two mainTheorems.
- No other fields touched.