### PR TITLE
Enrich Quadratic Galois ≃ ZMod 2 (FTA leaf): add mainTheorems

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-03-oq-01-oq-01/meta.json
@@ -91,7 +91,9 @@
   "references": [
     {
       "key": "Lang2002",
-      "authors": ["S. Lang"],
+      "authors": [
+        "S. Lang"
+      ],
       "title": "Algebra (3rd ed.)",
       "venue": "Graduate Texts in Mathematics 211, Springer",
       "year": "2002",
@@ -101,8 +103,13 @@
   "leanFile": {
     "path": "Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01OQ01.lean",
     "filePath": "Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01OQ01.lean",
-    "imports": ["Mathlib"],
-    "opens": ["Module", "Complex"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Module",
+      "Complex"
+    ],
     "namespace": "FTAGaloisIsoGeneral",
     "lineCount": 142,
     "axiomCount": 0,
@@ -110,5 +117,37 @@
     "definitionCount": 3,
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "galEquivZMod2",
+      "type": "definition",
+      "description": "Flagship generalized isomorphism: for every quadratic Galois extension (any base field K with finrank K L = 2 and IsGalois K L), Gal(L/K) ≃* Multiplicative (ZMod 2). Built from mulEquivOfPrimeCardEq since both groups have prime cardinality 2 — no order structure, real-closedness, or identity of the base field is used."
+    },
+    {
+      "name": "card_gal_eq_two",
+      "type": "theorem",
+      "description": "|Gal(L/K)| = 2 for a quadratic Galois extension: the automorphism group of a Galois extension has cardinality equal to the degree (IsGalois.card_aut_eq_finrank with finrank K L = 2)."
+    },
+    {
+      "name": "isCyclic_gal",
+      "type": "theorem",
+      "description": "Gal(L/K) is cyclic for a quadratic Galois extension, since a finite group of prime order (here 2) is cyclic."
+    },
+    {
+      "name": "gal_mul_comm",
+      "type": "theorem",
+      "description": "Gal(L/K) is commutative, obtained by transporting mul_comm across the isomorphism galEquivZMod2 (equivalently, a group of prime order is abelian)."
+    },
+    {
+      "name": "galCyclicEquiv",
+      "type": "definition",
+      "description": "Identification with Mathlib's canonical cyclic-structure iso (parent OQ[1]): zmodCyclicMulEquiv gives Multiplicative (ZMod (Nat.card G)) ≃* G for cyclic G; rewriting Nat.card = 2 realizes the abstract IsCyclic structure as Multiplicative (ZMod 2) on the nose."
+    },
+    {
+      "name": "complex_gal_equiv_zmod2",
+      "type": "definition",
+      "description": "Base case recovered: Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2), obtained as the K = ℝ, L = ℂ instance of the general galEquivZMod2 (via Complex.finrank_real_complex), confirming the generalization subsumes the concrete parent leaf."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment for `fundamental-theorem-algebra-oq-04-oq-03-oq-01-oq-01` (q94, passes 0). **Gap:** `mainTheorems[]` absent on `main`.

Added `mainTheorems` with the file's key results (theorems + the flagship defs, accurate statement + strategy):
1. **galEquivZMod2** (def) — Gal(L/K) ≃* Multiplicative (ZMod 2) for every quadratic Galois extension.
2. **card_gal_eq_two** — |Gal(L/K)| = 2.
3. **isCyclic_gal** — Gal(L/K) cyclic (prime order).
4. **gal_mul_comm** — Gal(L/K) commutative.
5. **galCyclicEquiv** (def) — identification with Mathlib's canonical cyclic iso (parent OQ[1]).
6. **complex_gal_equiv_zmod2** (def) — recovered base case Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2).

JSON validates, under caps; descriptions checked against `Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01OQ01.lean`. Only meta.json changed; verified, 0 axioms, 0 sorries.