### PR TITLE
Enrich Hermite floor identity OQ-01 (sawtooth): add mainTheorems

### DIFF
--- a/src/data/proofs/hermite-floor-identity-oq-01/meta.json
+++ b/src/data/proofs/hermite-floor-identity-oq-01/meta.json
@@ -114,5 +114,17 @@
     "path": "Proofs/HermiteFloorIdentityOQ01.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "hermite_fract_sum",
+      "type": "theorem",
+      "description": "Companion sawtooth identity — the fractional-part analogue of Hermite's floor identity: for every real x and every n ≥ 1, ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n-1)/2, where {·} = Int.fract. Proved by expanding each {·} as value − floor, evaluating the exact sum, and substituting Hermite's floor identity."
+    },
+    {
+      "name": "sum_div_eq",
+      "type": "theorem",
+      "description": "Supporting arithmetic-series lemma: ∑_{k=0}^{n-1} k/n = (n-1)/2 over ℝ, the exact (un-floored) contribution to the sawtooth sum; proved via Gauss's sum by induction to avoid ℕ-division under the cast."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `hermite-floor-identity-oq-01`.

## Gap
No `mainTheorems` array (absent).

## Change (additive, single field)
Added `mainTheorems` from `Proofs/HermiteFloorIdentityOQ01.lean`:
- `hermite_fract_sum` — the fractional-part (sawtooth) analogue of Hermite's identity: ∑_{k<n}{x+k/n} = {n·x} + (n-1)/2.
- `sum_div_eq` — supporting arithmetic-series lemma ∑_{k<n} k/n = (n-1)/2.

## Verification
meta.json parses (12.4 KB, under cap); no other fields touched.