### PR TITLE
Enrich Gibonacci Gelin–Cesàro Identity (fibonacci leaf): add mainTheorems

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-04-oq-03/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-03/meta.json
@@ -168,5 +168,22 @@
       "note": "Gelin–Cesàro identity, Lucas numbers, and Gibonacci product identities"
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "gib_gelin_cesaro",
+      "type": "theorem",
+      "description": "Gibonacci Gelin–Cesàro identity (flagship): for the general Horadam/gibonacci sequence G a b n = a·F n + b·F(n−1) with discriminant μ = a² − ab − b², G(n−2)·G(n−1)·G(n+1)·G(n+2) − G(n)⁴ = −μ². Proved by combining the gibonacci Cassini and Catalan (r = 2) identities recentred at n; the sign factor (−1)^|n| cancels in the difference of squares, giving the index-independent constant −μ²."
+    },
+    {
+      "name": "fib_gelin_cesaro",
+      "type": "theorem",
+      "description": "Fibonacci Gelin–Cesàro: the seed (a, b) = (1, 0) has μ = 1, so F(n−2)·F(n−1)·F(n+1)·F(n+2) − F(n)⁴ = −1. Recovered by specialising gib_gelin_cesaro."
+    },
+    {
+      "name": "lucas_gelin_cesaro",
+      "type": "theorem",
+      "description": "Lucas Gelin–Cesàro: the seed (a, b) = (1, 2) has discriminant μ = −5, so L(n−2)·L(n−1)·L(n+1)·L(n+2) − L(n)⁴ = −25. Recovered by specialising gib_gelin_cesaro."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment for `fibonacci-identities-oq-04-oq-03` (q94, passes 0). **Gap:** `mainTheorems[]` absent on `main`.

Added `mainTheorems` (accurate statement + strategy):
1. **gib_gelin_cesaro** — general Horadam/gibonacci identity G(n−2)G(n−1)G(n+1)G(n+2) − G(n)⁴ = −μ² (μ = a²−ab−b²), via Cassini + Catalan with the sign cancelling in the difference of squares.
2. **fib_gelin_cesaro** — Fibonacci case (μ=1): F… − F(n)⁴ = −1.
3. **lucas_gelin_cesaro** — Lucas case (μ=−5): L… − L(n)⁴ = −25.

JSON validates, under caps; descriptions checked against `Proofs/FibonacciIdentitiesOQ04OQ03.lean`. Only meta.json changed; verified, 0 axioms, 0 sorries.