### PR TITLE
research(algebraic-reals-meager-oq-02-oq-01): both halves of the Oxtoby decomposition are dense [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01Dense.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01Dense.lean
@@ -1,0 +1,171 @@
+import Mathlib
+
+/-
+  Both halves of the symmetric Oxtoby decomposition are *dense*
+  (algebraic-reals-meager — OQ-02 → OQ-01, structural follow-up)
+
+  The sibling file `AlgebraicRealsMeagerOQ02OQ01` records the **symmetric
+  Oxtoby decomposition** of the real line
+
+      ℝ  =  L  ⊔  Lᶜ
+            └ comeagre & null      (topologically large, measure-small)
+                 └ meagre & conull (topologically small, measure-large)
+
+  where `L = {x | Liouville x}`. That statement contrasts the two notions of
+  largeness but says nothing about how the two pieces sit *topologically*
+  inside `ℝ`. This file supplies the sharpening: **both** pieces are **dense**.
+
+  * `L` is dense because it is comeagre and `ℝ` is a Baire space
+    (`dense_of_mem_residual`). This half is routine.
+  * `Lᶜ` is dense — the genuinely informative half — *despite being meagre*.
+    A meagre set is topologically "small", yet here it meets every nonempty
+    open interval, because it is **conull**: any nonempty open set carries
+    positive Lebesgue measure (`volume` is an open-positive measure), so a set
+    whose complement is null can have no interior and is therefore dense.
+
+  Consequently `ℝ` is partitioned into **two disjoint dense sets**, one
+  comeagre-and-null and one meagre-and-conull. The measure/category pathology
+  is not confined to a nowhere-dense corner: both anomalous classes are
+  topologically ubiquitous.
+
+  The reusable engine is the abstract lemma `dense_of_conull`: in any space
+  whose measure gives nonempty opens positive mass (`IsOpenPosMeasure`), a
+  conull set is dense. It is proved from Mathlib's
+  `interior_eq_empty_of_null` (a null set has empty interior) via the standard
+  `closure = (interior ·ᶜ)ᶜ` identity.
+
+  ## Honesty / novelty
+
+  No new mathematics: `dense_of_conull` is a three-line rearrangement of
+  `interior_eq_empty_of_null`, mirroring Mathlib's own `dense_of_ae`, and
+  `dense_liouville` is a one-line appeal to `dense_of_mem_residual`. The value
+  is the explicit, machine-checked observation that the Oxtoby decomposition is
+  a partition of `ℝ` into two dense sets, which the sibling file leaves
+  unstated. Presented as a modest structural sharpening, not a new result.
+
+  No new axioms (standard Mathlib triple inherited).
+
+  References:
+  - Oxtoby, J.C. (1980). "Measure and Category", Springer GTM 2.
+  - Mathlib: MeasureTheory.Measure.OpenPos (`interior_eq_empty_of_null`,
+             `IsOpenPosMeasure`), Topology.Baire.Lemmas
+             (`dense_of_mem_residual`),
+             NumberTheory.Transcendental.Liouville.{Residual,Measure}.
+
+  Tags: measure-theory, baire-category, liouville-numbers, dense, meagre,
+        residual, lebesgue-measure, sharp-boundary, oxtoby-duality
+-/
+
+set_option maxHeartbeats 400000
+
+namespace AlgebraicRealsMeagerOQ02OQ01Dense
+
+open MeasureTheory Filter Set
+
+-- ============================================================================
+-- Part I: the abstract engine — a conull set is dense
+-- ============================================================================
+
+/-- **A conull set is dense** (in a space whose measure gives every nonempty
+    open set positive mass). If `μ sᶜ = 0` then `s` has dense complement of its
+    complement: `interior sᶜ = ∅` (a null set has empty interior), so
+    `closure s = (interior sᶜ)ᶜ = univ`. This is the measure-theoretic mirror
+    of `dense_of_mem_residual` and the engine that makes the *meagre* half of
+    the Oxtoby decomposition dense. -/
+theorem dense_of_conull {X : Type*} [TopologicalSpace X] [MeasurableSpace X]
+    {μ : Measure X} [μ.IsOpenPosMeasure] {s : Set X} (hs : μ sᶜ = 0) :
+    Dense s := by
+  rw [dense_iff_closure_eq, closure_eq_compl_interior_compl, compl_univ_iff]
+  exact μ.interior_eq_empty_of_null hs
+
+-- ============================================================================
+-- Part II: the Liouville numbers — comeagre, null, meagre complement (recalled)
+-- ============================================================================
+
+/-- The Liouville numbers are comeagre (residual) in `ℝ`. -/
+theorem liouville_residual : {x : ℝ | Liouville x} ∈ residual ℝ :=
+  eventually_residual_liouville
+
+/-- The Liouville numbers are Lebesgue-null. -/
+theorem liouville_null : volume {x : ℝ | Liouville x} = 0 :=
+  volume_setOf_liouville
+
+/-- The non-Liouville reals are meagre (their complement `L` is comeagre). -/
+theorem nonLiouville_meagre : IsMeagre {x : ℝ | Liouville x}ᶜ := by
+  rw [IsMeagre, compl_compl]
+  exact liouville_residual
+
+-- ============================================================================
+-- Part III: both pieces are dense
+-- ============================================================================
+
+/-- **The Liouville numbers are dense.** They are comeagre and `ℝ` is a Baire
+    space, so `dense_of_mem_residual` applies. -/
+theorem dense_liouville : Dense {x : ℝ | Liouville x} :=
+  dense_of_mem_residual liouville_residual
+
+/-- **The non-Liouville reals are dense — despite being meagre.** They are
+    conull (`volume Lᶜᶜ = volume L = 0`), and a conull set in `ℝ` is dense by
+    `dense_of_conull`. This is the sharp topological content: the *small*
+    (meagre) half of the Oxtoby decomposition still meets every open interval. -/
+theorem dense_nonLiouville : Dense {x : ℝ | Liouville x}ᶜ :=
+  dense_of_conull (μ := volume) (by rw [compl_compl]; exact liouville_null)
+
+-- ============================================================================
+-- Part IV: ℝ as a union of two disjoint dense sets, one meagre one comeagre
+-- ============================================================================
+
+/-- **A meagre, dense set of full Lebesgue measure.** Sharpening of the
+    sibling's `exists_meagre_conull`: the witness `Lᶜ` is not only meagre and
+    conull but also dense. -/
+theorem exists_meagre_dense_conull :
+    ∃ S : Set ℝ, IsMeagre S ∧ Dense S ∧ volume Sᶜ = 0 :=
+  ⟨{x : ℝ | Liouville x}ᶜ, nonLiouville_meagre, dense_nonLiouville, by
+    rw [compl_compl]; exact liouville_null⟩
+
+/-- **The dense symmetric Oxtoby decomposition.** `ℝ` partitions into two
+    disjoint **dense** sets:
+
+    * `A = L` — comeagre, null, and dense;
+    * `B = Lᶜ` — meagre, conull, and dense.
+
+    Both notions of largeness fail along this single partition (as in the
+    sibling `real_symmetric_oxtoby`), and additionally *neither* failure is
+    confined to a nowhere-dense set: both classes are topologically dense in
+    `ℝ`. -/
+theorem real_symmetric_oxtoby_dense :
+    ∃ A B : Set ℝ,
+      A ∪ B = univ ∧ Disjoint A B ∧ Dense A ∧ Dense B ∧
+      (A ∈ residual ℝ ∧ volume A = 0) ∧
+      (IsMeagre B ∧ volume Bᶜ = 0) :=
+  ⟨{x : ℝ | Liouville x}, {x : ℝ | Liouville x}ᶜ,
+    union_compl_self _, disjoint_compl_right,
+    dense_liouville, dense_nonLiouville,
+    ⟨liouville_residual, liouville_null⟩,
+    ⟨nonLiouville_meagre, by rw [compl_compl]; exact liouville_null⟩⟩
+
+#check @dense_of_conull
+#check @dense_liouville
+#check @dense_nonLiouville
+#check @exists_meagre_dense_conull
+#check @real_symmetric_oxtoby_dense
+
+/-
+  ## Results Summary
+
+  | Theorem | Statement | Status |
+  |---------|-----------|--------|
+  | `dense_of_conull` | conull set is dense (IsOpenPosMeasure) | Proved |
+  | `liouville_residual` | Liouville numbers comeagre | Proved (Mathlib) |
+  | `liouville_null` | Liouville numbers Lebesgue-null | Proved (Mathlib) |
+  | `nonLiouville_meagre` | non-Liouville reals meagre | Proved |
+  | `dense_liouville` | Liouville numbers dense | Proved |
+  | `dense_nonLiouville` | non-Liouville reals dense (though meagre) | Proved |
+  | `exists_meagre_dense_conull` | ∃ meagre dense conull set | Proved |
+  | `real_symmetric_oxtoby_dense` | ℝ = two disjoint dense sets | Proved |
+
+  **Sorries**: 0
+  **Axioms**: 0 declared (Mathlib triple inherited)
+-/
+
+end AlgebraicRealsMeagerOQ02OQ01Dense

--- a/src/data/research/problems/algebraic-reals-meager-oq-02-oq-01.json
+++ b/src/data/research/problems/algebraic-reals-meager-oq-02-oq-01.json
@@ -31,21 +31,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (verified 0 sorries / 0 axioms, PR pending). Dual direction of parent OQ-02: a MEAGRE set of FULL Lebesgue measure (the non-Liouville reals Lᶜ), plus the symmetric decomposition ℝ = L ⊔ Lᶜ. Built on Proofs/AlgebraicRealsMeagerOQ02OQ01.lean, 8 theorems, Docker-verified (3.6s, 7743 jobs).",
+    "progressSummary": "COMPLETE + sharpened (PR #35731 pending): both halves of ℝ = L ⊔ Lᶜ shown dense via new reusable dense_of_conull. Two follow-up open questions logged (ℚ-equivariance; ℝⁿ transfer).",
     "builtItems": [
       "isMeagre_compl_of_mem_residual in AlgebraicRealsMeagerOQ02OQ01.lean:73 — abstract duality: A∈residual α ⟹ IsMeagre Aᶜ (any TopologicalSpace), via rw[IsMeagre, compl_compl].",
       "nonLiouville_meagre:97 + nonLiouville_conull:103 — the non-Liouville reals Lᶜ are meagre and conull (volume (Lᶜ)ᶜ = 0).",
       "exists_meagre_conull:111 — headline: ∃ meagre S ⊆ ℝ with volume Sᶜ = 0 (a meagre set of full Lebesgue measure).",
-      "real_symmetric_oxtoby:131 — ℝ = L ⊔ Lᶜ (union_compl_self + disjoint_compl_right), L comeagre-and-null, Lᶜ meagre-and-conull; oq01_resolution:143 packages it."
+      "real_symmetric_oxtoby:131 — ℝ = L ⊔ Lᶜ (union_compl_self + disjoint_compl_right), L comeagre-and-null, Lᶜ meagre-and-conull; oq01_resolution:143 packages it.",
+      "dense_of_conull in AlgebraicRealsMeagerOQ02OQ01Dense.lean:72 — conull ⟹ Dense (IsOpenPosMeasure); μ implicit and absent from conclusion so callers must pass (μ := volume).",
+      "dense_liouville / dense_nonLiouville:96,106 — both Oxtoby pieces dense; real_symmetric_oxtoby_dense:129 packages ℝ as two disjoint dense sets (comeagre-null + meagre-conull). PR #35731, verified 0/0."
     ],
     "insights": [
       "The dual of a comeagre null set is its literal complement: Lᶜ is meagre (because L is comeagre) and conull (because L is null). No new construction needed — the Liouville numbers already encode both halves of the Oxtoby contrast.",
       "IsMeagre s is DEFINED as sᶜ ∈ residual X (Mathlib Topology/GDelta/Basic:218), so isMeagre_compl_of_mem_residual (A∈residual ⟹ IsMeagre Aᶜ) is a two-line unfold + compl_compl, valid over any topological space.",
       "'Full Lebesgue measure' on ℝ (infinite measure space) is formalized as conullity: volume Sᶜ = 0. For S = Lᶜ this is volume L = 0 via compl_compl + volume_setOf_liouville.",
-      "Sharp form of OQ-02: the single partition ℝ = L ⊔ Lᶜ simultaneously witnesses comeagre⇏conull (on L) and meagre⇏null (on Lᶜ); the two largeness notions are exactly complementary, not merely inequivalent."
+      "Sharp form of OQ-02: the single partition ℝ = L ⊔ Lᶜ simultaneously witnesses comeagre⇏conull (on L) and meagre⇏null (on Lᶜ); the two largeness notions are exactly complementary, not merely inequivalent.",
+      "A conull set in any IsOpenPosMeasure space is dense: interior sᶜ = ∅ (null sets have empty interior, interior_eq_empty_of_null) so closure s = (interior sᶜ)ᶜ = univ. This is the measure-side mirror of dense_of_mem_residual.",
+      "Both halves of the symmetric Oxtoby decomposition ℝ = L ⊔ Lᶜ are dense: L by comeagreness (Baire), Lᶜ despite being MEAGRE by conullity. So the measure/category pathology is topologically ubiquitous, not confined to a nowhere-dense set."
     ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Follow-up (open): are L and Lᶜ each preserved as comeagre-null / meagre-conull under the ℚ-translation and nonzero-ℚ-scaling action on ℝ? Liouville x ⟺ Liouville (x+q) ⟺ Liouville (qx) for q∈ℚˣ would give a group-equivariant Oxtoby decomposition.",
+      "Follow-up (open): does the dense-two-piece decomposition transfer to ℝⁿ (product Liouville set) — a meagre, dense, conull subset of ℝⁿ?"
+    ]
   },
   "tags": [
     "descriptive-set-theory",


### PR DESCRIPTION
## Summary

Structural follow-up to the merged **symmetric Oxtoby decomposition** (PR #35672 / `AlgebraicRealsMeagerOQ02OQ01.lean`), which established

    ℝ = L ⊔ Lᶜ,   L = {x | Liouville x}
        └ comeagre & null
             └ meagre & conull

That statement contrasts the two notions of largeness but says nothing about how the pieces sit topologically. This PR sharpens it: **both pieces are dense.**

- `dense_of_conull` — reusable engine: in any `IsOpenPosMeasure` space, a conull set is dense (from Mathlib's `interior_eq_empty_of_null`, mirroring `dense_of_ae`).
- `dense_liouville` — the comeagre half is dense (Baire, `dense_of_mem_residual`). Routine.
- `dense_nonLiouville` — the **meagre** half is *nonetheless dense*, because it is conull. This is the informative content: the topologically "small" piece still meets every open interval.
- `exists_meagre_dense_conull` — a meagre, dense set of full Lebesgue measure.
- `real_symmetric_oxtoby_dense` — ℝ is partitioned into two disjoint **dense** sets, one comeagre-null and one meagre-conull.

Consequence: the measure/category pathology is not confined to a nowhere-dense corner — both anomalous classes are topologically ubiquitous.

## Honesty / novelty

No new mathematics. `dense_of_conull` is a three-line rearrangement of `interior_eq_empty_of_null`; `dense_liouville` is a one-liner. The value is the explicit, machine-checked statement that the Oxtoby decomposition partitions ℝ into two dense sets — left unstated by the sibling file. Presented as a modest structural sharpening.

## Verification

- 8 theorems, 0 sorries, 0 `axiom` declarations, no `native_decide`.
- Verified via host `lake env lean` (single file, full Mathlib oleans): exit 0, 0 errors.
- `#print axioms real_symmetric_oxtoby_dense` = `{propext, Classical.choice, Quot.sound}` (standard triple only — no `sorryAx`, no `Lean.ofReduceBool`).
- `status: verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)