### PR TITLE
Enrich Erdős #128 WIP-01: add mainTheorems

### DIFF
--- a/src/data/proofs/erdos-128-wip-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01/meta.json
@@ -17,6 +17,28 @@
     "path": "Proofs/Erdos128WIP01.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "hasTriangle_induce",
+      "type": "theorem",
+      "description": "A triangle in an induced subgraph is a triangle of the ambient graph: (G.induce S).hasTriangle → G.hasTriangle, since induced adjacency entails ambient adjacency."
+    },
+    {
+      "name": "triangleFree_induce",
+      "type": "theorem",
+      "description": "Triangle-freeness is hereditary: every induced subgraph of a triangle-free graph is triangle-free — the contrapositive of hasTriangle_induce, and why the C5-blow-up extremal witnesses stay triangle-free."
+    },
+    {
+      "name": "edgeCount_induce_le",
+      "type": "theorem",
+      "description": "The edge count is monotone under taking induced subgraphs: (G.induce S).edgeCount ≤ G.edgeCount, since inducing only deletes edges."
+    },
+    {
+      "name": "triangleFree_of_no_edges",
+      "type": "theorem",
+      "description": "Degenerate base case: a graph whose adjacency is everywhere false is triangle-free."
+    }
+  ],
   "description": "Supplies the first theorems for Erdős Problem #128 ($250, OPEN: if every induced subgraph on >= floor(n/2) vertices has more than n^2/50 edges, must G contain a triangle?). The scaffold Erdos128Problem.lean sets up the objects (Graph, edgeCount, induce, hasTriangle, triangleFree, denseSubgraphs) and records the known partial results (EFRS 1/16, Krivelevich, Razborov 27/1024, Norin-Yepremyan) as prose but proves no theorems, and currently fails to build (a missing DecidablePred instance for the edge-count filter and trailing docstrings). This entry, self-contained (re-declaring the objects with classical decidability), proves the two monotonicity properties of the induced-subgraph operation that any analysis uses: a triangle in an induced subgraph is a triangle of the ambient graph (hasTriangle_induce); hence triangle-freeness is hereditary (triangleFree_induce) -- exactly why the extremal C5-blow-up witnesses are triangle-free; the edge count is monotone, an induced subgraph has no more edges than the whole graph (edgeCount_induce_le); and a graph with no edges is triangle-free (triangleFree_of_no_edges). 4 theorems, 4 definitions + 1 structure, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",


### PR DESCRIPTION
Adds the absent `mainTheorems` array for `erdos-128-wip-01` from `Proofs/Erdos128WIP01.lean`: `hasTriangle_induce`, `triangleFree_induce` (hereditary triangle-freeness), `edgeCount_induce_le` (edge-count monotonicity), and `triangleFree_of_no_edges`. Additive single-field change; meta parses, under cap.