### PR TITLE
research(e-transcendental-oq-02-oq-06): explicit irrational non-normal witness — sharpness of normal_imp_irrational [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -4,6 +4,7 @@ import Mathlib.Data.Complex.ExponentialBounds
 import Mathlib.Data.Real.Irrational
 import Mathlib.Topology.Algebra.Order.Floor
 import Mathlib.Order.Filter.Basic
+import Mathlib.NumberTheory.Transcendental.Liouville.LiouvilleNumber
 import Mathlib.Tactic
 import Proofs.eTranscendental
 
@@ -850,5 +851,171 @@ theorem e_normal_implies_uniform_decimal_digits
 /-- e is irrational — a necessary condition for normality (not sufficient). -/
 theorem e_irrational_necessary_for_normality : Irrational (Real.exp 1) :=
   e_irrational
+
+-- ============================================================
+-- PART VI: SHARPNESS — AN EXPLICIT IRRATIONAL NON-NORMAL NUMBER
+-- ============================================================
+
+/-!
+`normal_imp_irrational` shows normality ⇒ irrationality. Is the converse true?
+No: irrationality is strictly weaker than normality. We exhibit a concrete
+*verified* witness — the base-`b` Liouville constant
+`liouvilleNumber b = ∑_{i≥0} b^(-i!)` (Mathlib) — which is irrational (indeed
+transcendental) yet **not normal** in base `b` for every `b ≥ 3`: its base-`b`
+digits are all `0` or `1` (from position `n ≥ 2` on), so the digit `2` is
+eventually missing and the criterion `not_normal_of_eventually_missing_digit`
+applies. This closes the sharp boundary of `normal_imp_irrational`.
+-/
+
+open scoped Nat in
+/-- For every `n ≥ 1` there is a factorial "window" index `k` with
+`k ! ≤ n < (k+1)!` (the position of `n` in the factorial number system). -/
+theorem exists_factorial_window {n : ℕ} (hn : 1 ≤ n) :
+    ∃ k, k ! ≤ n ∧ n < (k + 1)! := by
+  have hex : ∃ m, n < (m + 1)! :=
+    ⟨n, lt_of_lt_of_le (Nat.lt_succ_self n) (Nat.self_le_factorial _)⟩
+  classical
+  refine ⟨Nat.find hex, ?_, Nat.find_spec hex⟩
+  set k := Nat.find hex with hk
+  rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+  · rw [hk0]; simpa using hn
+  · have hmin : ¬ n < (k - 1 + 1)! := Nat.find_min hex (Nat.sub_lt hkpos Nat.one_pos)
+    rw [Nat.sub_add_cancel hkpos] at hmin
+    exact Nat.not_lt.mp hmin
+
+open scoped Nat in
+/-- **Exact floor of `bⁿ · (base-b Liouville constant)`.**
+For `k ! ≤ n < (k+1)!` the value `bⁿ · liouvilleNumber b` has integer part
+`∑_{i=0}^{k} b^(n - i!)`: the partial sum contributes an integer (all exponents
+`n - i!` are non-negative) and the remainder tail is `< 1` (Mathlib's
+`remainder_lt'` gives `bⁿ · remainder < 2/b ≤ 2/3 < 1` when `b ≥ 3`). -/
+theorem liouvilleNumber_floor {b : ℕ} (hb : 3 ≤ b) {k n : ℕ}
+    (hk_le : k ! ≤ n) (hk_lt : n < (k + 1)!) :
+    ⌊(b : ℝ) ^ n * liouvilleNumber (b : ℝ)⌋
+      = ∑ i ∈ Finset.range (k + 1), (b : ℤ) ^ (n - i !) := by
+  have hb1 : (1 : ℝ) < (b : ℝ) := by exact_mod_cast (by omega : 1 < b)
+  have hb2R : (2 : ℝ) ≤ (b : ℝ) := by exact_mod_cast (by omega : 2 ≤ b)
+  have hbpos : (0 : ℝ) < (b : ℝ) := by linarith
+  set P : ℤ := ∑ i ∈ Finset.range (k + 1), (b : ℤ) ^ (n - i !) with hP
+  -- Claim 1: the partial sum scales to the integer P.
+  have hbne : (b : ℝ) ≠ 0 := by positivity
+  have hclaim1 : (b : ℝ) ^ n * LiouvilleNumber.partialSum (b : ℝ) k = (P : ℝ) := by
+    rw [LiouvilleNumber.partialSum, Finset.mul_sum, hP, Int.cast_sum]
+    apply Finset.sum_congr rfl
+    intro i hi
+    have hik : i ! ≤ n :=
+      le_trans (Nat.factorial_le (Nat.le_of_lt_succ (Finset.mem_range.mp hi))) hk_le
+    rw [Int.cast_pow, Int.cast_natCast, mul_one_div, div_eq_iff (pow_ne_zero _ hbne),
+      ← pow_add, Nat.sub_add_cancel hik]
+  -- The remainder tail is non-negative and < 1.
+  have hrem_nonneg : 0 ≤ (b : ℝ) ^ n * LiouvilleNumber.remainder (b : ℝ) k :=
+    mul_nonneg (by positivity) (le_of_lt (LiouvilleNumber.remainder_pos hb1 k))
+  have hrem_lt : (b : ℝ) ^ n * LiouvilleNumber.remainder (b : ℝ) k < 1 := by
+    have hR := LiouvilleNumber.remainder_lt' k hb1
+    have hbn : (0 : ℝ) ≤ (b : ℝ) ^ n := by positivity
+    -- Tail bound: remainder ≤ 2 / b^((k+1)!).
+    have hstep : LiouvilleNumber.remainder (b : ℝ) k ≤ 2 / (b : ℝ) ^ (k + 1)! := by
+      calc LiouvilleNumber.remainder (b : ℝ) k
+          ≤ (1 - 1 / (b : ℝ))⁻¹ * (1 / (b : ℝ) ^ (k + 1)!) := le_of_lt hR
+        _ ≤ 2 * (1 / (b : ℝ) ^ (k + 1)!) := by
+            gcongr; exact sub_one_div_inv_le_two hb2R
+        _ = 2 / (b : ℝ) ^ (k + 1)! := by rw [mul_one_div]
+    -- Polynomial gap: 2·bⁿ < b^((k+1)!) since (k+1)! ≥ n+1 and b ≥ 3.
+    have hexp : 2 * (b : ℝ) ^ n < (b : ℝ) ^ (k + 1)! := by
+      calc 2 * (b : ℝ) ^ n
+          < (b : ℝ) * (b : ℝ) ^ n := by
+            apply mul_lt_mul_of_pos_right _ (by positivity)
+            exact_mod_cast (by omega : (2 : ℕ) < b)
+        _ = (b : ℝ) ^ (n + 1) := by rw [pow_succ, mul_comm]
+        _ ≤ (b : ℝ) ^ (k + 1)! := pow_le_pow_right₀ hb1.le (by omega)
+    have key : (b : ℝ) ^ n * (2 / (b : ℝ) ^ (k + 1)!) < 1 := by
+      rw [← mul_div_assoc, div_lt_one (by positivity)]
+      linarith [hexp]
+    exact lt_of_le_of_lt (mul_le_mul_of_nonneg_left hstep hbn) key
+  -- Assemble: bⁿ·x = P + (small tail), so the floor is P.
+  have hsplit : (b : ℝ) ^ n * liouvilleNumber (b : ℝ)
+      = (P : ℝ) + (b : ℝ) ^ n * LiouvilleNumber.remainder (b : ℝ) k := by
+    rw [← LiouvilleNumber.partialSum_add_remainder hb1 k, mul_add, hclaim1]
+  rw [Int.floor_eq_iff]
+  refine ⟨?_, ?_⟩
+  · rw [hsplit]; exact le_add_of_nonneg_right hrem_nonneg
+  · rw [hsplit]; push_cast; linarith [hrem_lt]
+
+open scoped Nat in
+/-- **Every base-b digit of the Liouville constant (from position 2 on) is 0 or 1.**
+Consequently it is never equal to `2`. This is the digit obstruction that
+forbids normality. -/
+theorem liouvilleNumber_digit_le_one {b : ℕ} (hb : 3 ≤ b) {k n : ℕ}
+    (hk_le : k ! ≤ n) (hk_lt : n < (k + 1)!) (hn : 2 ≤ n) :
+    (⌊(b : ℝ) ^ n * liouvilleNumber (b : ℝ)⌋) % (b : ℤ) ≤ 1 := by
+  rw [liouvilleNumber_floor hb hk_le hk_lt, Finset.sum_range_succ]
+  -- Lower-index terms are all divisible by b (their exponents are ≥ 1).
+  have hdvd : (b : ℤ) ∣ ∑ i ∈ Finset.range k, (b : ℤ) ^ (n - i !) := by
+    apply Finset.dvd_sum
+    intro i hi
+    have hi_lt_k : i < k := Finset.mem_range.mp hi
+    have hik : i ! < n := by
+      rcases Nat.eq_zero_or_pos i with h0 | hp
+      · rw [h0, Nat.factorial_zero]; omega
+      · calc i ! < k ! := (Nat.factorial_lt hp).mpr hi_lt_k
+          _ ≤ n := hk_le
+    exact dvd_pow_self (b : ℤ) (by omega : n - i ! ≠ 0)
+  obtain ⟨c, hc⟩ := hdvd
+  rw [hc, add_comm, Int.add_mul_emod_self_left]
+  -- Remaining top term b^(n - k!) has residue 0 (if n > k!) or 1 (if n = k!).
+  rcases eq_or_lt_of_le hk_le with heq | hlt
+  · -- n = k! : b^0 = 1, and 1 % b = 1.
+    have hz : n - k ! = 0 := by omega
+    rw [hz, pow_zero]
+    have h1 : (1 : ℤ) % (b : ℤ) = 1 :=
+      Int.emod_eq_of_lt (by norm_num) (by exact_mod_cast (by omega : (1 : ℕ) < b))
+    omega
+  · -- k! < n : exponent ≥ 1, so b divides the term.
+    obtain ⟨d, hd⟩ := dvd_pow_self (b : ℤ) (by omega : n - k ! ≠ 0)
+    have h0 : (b : ℤ) ^ (n - k !) % (b : ℤ) = 0 := by rw [hd, Int.mul_emod_right]
+    omega
+
+open scoped Nat in
+/-- The base-`b` Liouville constant is irrational (in fact transcendental). -/
+theorem liouvilleNumber_irrational {b : ℕ} (hb : 2 ≤ b) :
+    Irrational (liouvilleNumber (b : ℝ)) :=
+  (liouville_liouvilleNumber hb).irrational
+
+open scoped Nat in
+/-- **The Liouville constant is not normal in base `b` (b ≥ 3).**
+Its base-`b` digit `2` is absent from position `2` onwards, so
+`not_normal_of_eventually_missing_digit` applies. -/
+theorem liouvilleNumber_not_normal {b : ℕ} (hb : 3 ≤ b) :
+    ¬ IsNormalInBase b (liouvilleNumber (b : ℝ)) := by
+  have hb2 : 2 ≤ b := by omega
+  have h2b : (2 : ℕ) < b := by omega
+  refine not_normal_of_eventually_missing_digit b hb2 (liouvilleNumber (b : ℝ))
+    (⟨2, h2b⟩ : Fin b) 2 ?_
+  intro n hn
+  obtain ⟨k, hk_le, hk_lt⟩ := exists_factorial_window (by omega : 1 ≤ n)
+  have hdig := liouvilleNumber_digit_le_one hb hk_le hk_lt (by omega : 2 ≤ n)
+  have hval : ((⟨2, h2b⟩ : Fin b) : ℤ) = 2 := by simp
+  rw [hval]
+  unfold nthDigit
+  omega
+
+open scoped Nat in
+/-- **Sharpness of `normal_imp_irrational`: an explicit irrational non-normal number.**
+For every base `b ≥ 3`, the Liouville constant is irrational yet not normal in
+base `b`. -/
+theorem exists_irrational_not_normal {b : ℕ} (hb : 3 ≤ b) :
+    ∃ x : ℝ, Irrational x ∧ ¬ IsNormalInBase b x :=
+  ⟨liouvilleNumber (b : ℝ), liouvilleNumber_irrational (by omega),
+    liouvilleNumber_not_normal hb⟩
+
+/-- **Irrationality does not imply normality.**
+The converse of `normal_imp_irrational` fails: there is an irrational real that
+is not normal in base `3`. Normality is therefore *strictly* stronger than
+irrationality (together with disjunctivity). -/
+theorem irrational_not_imp_normal :
+    ¬ ∀ (b : ℕ), 2 ≤ b → ∀ x : ℝ, Irrational x → IsNormalInBase b x := by
+  intro h
+  obtain ⟨x, hx_irr, hx_not⟩ := exists_irrational_not_normal (b := 3) (by norm_num)
+  exact hx_not (h 3 (by norm_num) x hx_irr)
 
 end ETranscendentalOQ02

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 54,
+    "theoremCount": 61,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -74,7 +74,7 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 854,
+    "lineCount": 1021,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
     "definitionCount": 5
@@ -207,9 +207,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 854,
+    "lineCount": 1021,
     "axiomCount": 1,
-    "theoremCount": 54,
+    "theoremCount": 61,
     "definitionCount": 5,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/e-transcendental-oq-02-oq-06.json
+++ b/src/data/research/problems/e-transcendental-oq-02-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (verified 0/0 new): added the non-normality criterion (missing k-tuple/digit ⇒ not normal), the exact converse of normal_imp_disjunctive and the sharp boundary showing normality > irrationality + disjunctivity; recovered normal_imp_irrational as a corollary. Open conjecture axiom e_absolutely_normal unchanged. Genuine irrational non-normal witness (Liouville digit computation) is the remaining sharpness step.",
+    "progressSummary": "SHARPNESS COMPLETE (verified 0/0 new): exhibited an explicit VERIFIED irrational non-normal number (base-b Liouville constant, b>=3) via a factorial-number-system digit computation, proving the converse of normal_imp_irrational fails (irrational_not_imp_normal). Open conjecture axiom e_absolutely_normal unchanged.",
     "builtItems": [
       "normal_ktuple_infinitely_often (Proofs/ETranscendentalOQ02.lean): {n | s occurs at n}.Infinite for x normal in base b. Verified 0 sorry; axioms [propext, Classical.choice, Quot.sound].",
       "normal_imp_disjunctive (same file): every finite digit string appears at least once (corollary via Set.Infinite.nonempty).",
@@ -39,24 +39,30 @@
       "match_count_le (ETranscendentalOQ02.lean:751, private): x-general count bound, generalizes rational_match_count_le off the concrete (q:ℝ).",
       "not_normal_of_eventually_missing_ktuple (ETranscendentalOQ02.lean:776): eventually-missing k-tuple ⇒ ¬IsNormalInBase b x. VERIFIED 0 sorry/0 new axiom.",
       "not_normal_of_eventually_missing_digit (ETranscendentalOQ02.lean:802): single eventually-missing digit ⇒ not normal (k=1 corollary).",
-      "normal_imp_irrational_of_criterion (ETranscendentalOQ02.lean:813): normal ⇒ irrational re-derived from the criterion via rational_has_missing_ktuple_intCast (non-vacuity)."
+      "normal_imp_irrational_of_criterion (ETranscendentalOQ02.lean:813): normal ⇒ irrational re-derived from the criterion via rational_has_missing_ktuple_intCast (non-vacuity).",
+      "exists_factorial_window (Nat.find): forall n>=1 exists k, k!<=n<(k+1)! — ETranscendentalOQ02.lean",
+      "liouvilleNumber_floor: exact integer part floor(b^n*liouvilleNumber b)=sum b^(n-i!) — ETranscendentalOQ02.lean",
+      "liouvilleNumber_digit_le_one: nthDigit <=1 for n>=2 — ETranscendentalOQ02.lean",
+      "liouvilleNumber_not_normal (b>=3), exists_irrational_not_normal, irrational_not_imp_normal — ETranscendentalOQ02.lean"
     ],
     "insights": [
       "The stated target normal_imp_irrational was ALREADY a complete 0-sorry theorem (Session 13); OQ-02-OQ-06 as literally phrased was resolved. Added genuinely new theory instead of reclaiming.",
       "Normal numbers are DISJUNCTIVE: every finite digit-string occurs, in fact at infinitely many positions. Positive companion to normal_imp_irrational (which uses a MISSING tuple to force frequency 0); here a bounded match-count would force frequency 0, contradicting the positive normal limit b^(-k).",
       "The file did NOT build on current Mathlib (never Lean-CI-d; math PRs skip the Lean build). Four latent breaks were repaired to reach a verified state.",
       "SHARP BOUNDARY (2026-07-08, r5): normality is strictly stronger than both irrationality and disjunctivity. The precise obstruction is a frequency-0 (eventually-missing) tuple/digit; formalized as not_normal_of_eventually_missing_ktuple, the exact contrapositive of normal_imp_disjunctive.",
-      "The count/Tendsto engine (match_count_le + tendsto_bounded_count_div_atTop_zero + tendsto_nhds_unique + zpow_pos) that discharged normal_imp_irrational is fully reusable for arbitrary x: only the missing-tuple hypothesis differs between the rational case and the general criterion."
+      "The count/Tendsto engine (match_count_le + tendsto_bounded_count_div_atTop_zero + tendsto_nhds_unique + zpow_pos) that discharged normal_imp_irrational is fully reusable for arbitrary x: only the missing-tuple hypothesis differs between the rational case and the general criterion.",
+      "SHARPNESS RESOLVED: the base-b Liouville constant liouvilleNumber b = sum_{i>=0} b^(-i!) (Mathlib) is an explicit VERIFIED irrational non-normal number for every b>=3 — irrational does NOT imply normal (converse of normal_imp_irrational fails).",
+      "Digit computation via the factorial number system: for k!<=n<(k+1)!, floor(b^n * liouvilleNumber b) = sum_{i=0}^{k} b^(n-i!); the tail b^n*remainder < 1 uses Mathlib remainder_lt prime and sub_one_div_inv_le_two giving < 2/b <= 2/3 (needs b>=3: the doubled 0!=1! leading term puts digit 2 at n=1 only).",
+      "Every base-b digit of liouvilleNumber b is 0 or 1 from position n>=2 on (residue b^(n-k!) % b in {0,1}: lower-index terms divisible by b, top term 1 iff n is a factorial), so digit 2 is eventually missing and not_normal_of_eventually_missing_digit applies."
     ],
     "mathlibGaps": [
       "omega does not discharge variable-divisor Euclidean identities (a/T*T + a%T = a with T variable, nonlinear); use Nat.mod_add_div'/Nat.div_add_mod explicitly.",
       "Genuine irrational-AND-non-normal WITNESS (true sharpness of 'irrational ⇏ normal') still needs the real→digit bridge for a specific transcendental: computing nthDigit b n x = ⌊bⁿx⌋%b for an explicit series (e.g. Liouville ∑ b^(-k!)) requires summing the tail to isolate the k-th digit — a real-analysis construction not present. The abstract criterion is the tool; only the witness digit-computation is missing."
     ],
     "nextSteps": [
-      "Sharpness: irrational does NOT imply normal. Construct an explicit irrational non-normal number (Liouville-type digit sequence with a frequency-0 digit) in the nthDigit framework, proving non-eventual-periodicity and a frequency-0 block.",
-      "Quantitative disjunctivity: bound first-occurrence position / gaps of a fixed k-tuple via the normality convergence rate (only qualitative infinitude proved so far).",
-      "Construct a concrete irrational non-normal witness: define x = ∑_{k≥1} b^(-k!) (Liouville, Mathlib has LiouvilleNumber/Liouville.irrational), prove digit d=2..b-1 is eventually absent (nthDigit = 0 or 1 only at factorial gaps), then apply not_normal_of_eventually_missing_digit to get a verified irrational non-normal number — completing the sharpness of normal_imp_irrational.",
-      "Frequency-mismatch criterion: strengthen not_normal_of_eventually_missing_digit to 'if digit-d frequency tends to a limit ≠ 1/b then not normal' (only the absence/0-frequency case is done)."
+      "Frequency-mismatch criterion: strengthen not_normal_of_eventually_missing_digit to digit-frequency != 1/b implies not normal (only the 0-frequency/absence case done).",
+      "Quantitative disjunctivity: bound first-occurrence position of a fixed k-tuple via the normality convergence rate (only qualitative infinitude proved).",
+      "The open axiom e_absolutely_normal is genuinely open — not eliminable; the sharpness of normal_imp_irrational is now complete."
     ],
     "markdown": "# Knowledge Base: e-transcendental-oq-02-oq-06\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Completes the **sharpness** of `normal_imp_irrational` for the e-normality entry: an explicit, fully machine-checked example showing **irrationality does not imply normality**.

The base-`b` Liouville constant `liouvilleNumber b = ∑_{i≥0} b^(-i!)` (from Mathlib) is:
- **irrational** — indeed transcendental — via `liouville_liouvilleNumber` + `Liouville.irrational`;
- **not normal in base `b`** for every `b ≥ 3` — its base-`b` digits are all `0` or `1` from position `n ≥ 2` onward, so the digit `2` is eventually absent and the existing criterion `not_normal_of_eventually_missing_digit` applies.

Together with `normal_imp_irrational` this shows normality is **strictly stronger** than irrationality (`irrational_not_imp_normal`).

## Key idea — factorial number system

For `k! ≤ n < (k+1)!`:
```
⌊bⁿ · liouvilleNumber b⌋ = ∑_{i=0}^{k} b^(n − i!)   (integer part)
```
The tail `bⁿ · remainder` is `< 1` via Mathlib's `remainder_lt'` and `sub_one_div_inv_le_two`, giving `< 2/b ≤ 2/3` (this is where `b ≥ 3` is needed: the doubled `0! = 1! = 1` leading term puts a digit `2` at position `n = 1`, hence the criterion starts from `n = 2`). The residue `b^(n−k!) % b ∈ {0,1}` is `1` exactly when `n` is a factorial, `0` otherwise.

## New theorems (7, all verified 0 sorries / 0 axioms)
- `exists_factorial_window` — factorial-window index (Nat.find)
- `liouvilleNumber_floor` — exact integer part
- `liouvilleNumber_digit_le_one` — every digit `≤ 1` for `n ≥ 2`
- `liouvilleNumber_irrational`, `liouvilleNumber_not_normal`, `exists_irrational_not_normal`, `irrational_not_imp_normal`

## Verification
- Docker build `Proofs.ETranscendentalOQ02`: **success**, 0 sorries.
- The open-conjecture axiom `e_absolutely_normal` (is `e` normal?) is **unchanged** — this PR does not touch it.

meta.json updated: lineCount 854→1021, theoremCount 54→61 (axiomCount stays 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)