### PR TITLE
research(shannon-awgn-oq-02-oq-02): sharp Bienaymé — pairwise uncorrelated suffices for AWGN output power [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -110,4 +110,65 @@ theorem awgn_multisymbol_output_power [IsProbabilityMeasure μ] {ι : Type*}
   rw [awgn_multisymbol_power hW hindep hmean]
   exact Finset.sum_congr rfl hP
 
+/-!
+### Sharp form: pairwise *uncorrelatedness* already suffices
+
+The results above assume **pairwise independence** of the contributions, following
+`ProbabilityTheory.IndepFun.variance_sum`.  But the Bienaymé identity only ever uses
+that the *pairwise covariances vanish* — the off-diagonal terms of the double sum
+`Var[∑ Wᵢ] = ∑ᵢ ∑ⱼ cov[Wᵢ, Wⱼ]` (`ProbabilityTheory.variance_sum'`) drop out.  Pairwise
+independence is a strictly stronger hypothesis than pairwise uncorrelatedness (there
+exist uncorrelated but dependent random variables), so the identity holds under the
+weaker, and in fact *exactly sufficient*, second-order hypothesis `cov[Wᵢ, Wⱼ] = 0` for
+`i ≠ j`.  For the AWGN power budget this is the sharp statement: **uncorrelated** signal
+and noise contributions — not necessarily independent — still add in power.
+-/
+
+/-- **Sharp Bienaymé identity.**  The variance of a finite sum of *pairwise
+uncorrelated* square-integrable random variables is the sum of the variances.  Only the
+vanishing of the pairwise covariances is required; this is strictly weaker than the
+pairwise-independence hypothesis of `ProbabilityTheory.IndepFun.variance_sum`, and it is
+the exact second-order condition that makes the off-diagonal covariances of
+`variance_sum'` disappear. -/
+theorem variance_sum_of_pairwise_uncorrelated [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (huncor : Set.Pairwise ↑s fun i j => cov[W i, W j; μ] = 0) :
+    Var[∑ i ∈ s, W i; μ] = ∑ i ∈ s, Var[W i; μ] := by
+  rw [variance_sum' hW]
+  refine Finset.sum_congr rfl fun i hi => ?_
+  rw [Finset.sum_eq_single_of_mem i hi fun j hj hji => huncor hi hj hji.symm]
+  exact covariance_self (hW i hi).aemeasurable
+
+/-- Pairwise independence is a special case of pairwise uncorrelatedness, so the
+independence-based `awgn_multisymbol_variance` factors through the sharp identity:
+`IndepFun.covariance_eq_zero` turns each pairwise-independence witness into a vanishing
+covariance. -/
+theorem variance_sum_of_pairwise_indep [IsFiniteMeasure μ] {ι : Type*} {W : ι → Ω → ℝ}
+    {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (hindep : Set.Pairwise ↑s fun i j => W i ⟂ᵢ[μ] W j) :
+    Var[∑ i ∈ s, W i; μ] = ∑ i ∈ s, Var[W i; μ] :=
+  variance_sum_of_pairwise_uncorrelated hW fun i hi j hj hij =>
+    (hindep hi hj hij).covariance_eq_zero (hW i hi) (hW j hj)
+
+/-- **Multi-symbol AWGN output power under mere uncorrelatedness (sharp).**  If the
+aggregate channel output is the finite sum `∑_{i ∈ s} Wᵢ` of *pairwise-uncorrelated*,
+zero-mean, square-integrable contributions, then the output second moment (power) is the
+sum of the individual second moments:
+
+        E[(∑_{i ∈ s} Wᵢ)²] = ∑_{i ∈ s} E[Wᵢ²].
+
+This strengthens `awgn_multisymbol_power` by replacing pairwise independence with the
+weaker (and exactly sufficient) hypothesis of vanishing pairwise covariances. -/
+theorem awgn_multisymbol_power_of_uncorrelated [IsProbabilityMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (huncor : Set.Pairwise ↑s fun i j => cov[W i, W j; μ] = 0)
+    (hmean : ∀ i ∈ s, μ[W i] = 0) :
+    μ[(∑ i ∈ s, W i) ^ 2] = ∑ i ∈ s, μ[(W i) ^ 2] := by
+  have hSum : MemLp (∑ i ∈ s, W i) 2 μ := memLp_finset_sum' s hW
+  have hSum0 : μ[∑ i ∈ s, W i] = 0 := sum_mean_zero hW hmean
+  rw [second_moment_eq_variance hSum hSum0,
+    variance_sum_of_pairwise_uncorrelated hW huncor]
+  refine Finset.sum_congr rfl fun i hi => ?_
+  exact (second_moment_eq_variance (hW i hi) (hmean i hi)).symm
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 113,
+    "lineCount": 174,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,11 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "COMPLETE + SHARPENED (VERIFIED 0 sorry/0 axiom, 3.7s Docker, 7743 jobs): the multi-symbol AWGN output-power identity now holds under pairwise UNCORRELATEDNESS (vanishing pairwise covariances), strictly weaker than the pairwise independence of the original theorems and of Mathlib IndepFun.variance_sum. Identifies the exact second-order hypothesis behind Bienaymé.",
+    "builtItems": [
+      "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
+      "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
+      "awgn_multisymbol_power_of_uncorrelated (:165): E[(∑Wi)²]=∑E[Wi²] under pairwise-uncorrelated + zero-mean, strengthening awgn_multisymbol_power."
+    ],
+    "insights": [
+      "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
+      "Mathlib gap: no Uncorrelated concept and no pairwise-uncorrelated variance-sum lemma — only variance_sum´ (always true, double sum) and IndepFun.variance_sum (independence). The uncorrelated version sits strictly between them and was missing.",
+      "Proof recipe mirrors Mathlib IndepFun.variance_sum: rw[variance_sum´ hW]; Finset.sum_congr; collapse inner ∑j via Finset.sum_eq_single_of_mem i hi (fun j hj hji => huncor hi hj hji.symm); finish with covariance_self (hW i hi).aemeasurable. Replaces independence-derived covariance_eq_zero with the direct hypothesis.",
+      "For AWGN engineering: uncorrelated (not necessarily independent) signal+noise contributions still add in POWER — E[(∑Wi)²]=∑E[Wi²] for zero-mean pairwise-uncorrelated square-integrable terms."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0)."
+    ],
+    "nextSteps": [
+      "Consider upstreaming variance_sum_of_pairwise_uncorrelated to Mathlib (Probability/Moments/Variance.lean), from which IndepFun.variance_sum becomes a one-line corollary.",
+      "Further sharp boundary: does the identity extend to L² limits / countable pairwise-uncorrelated families (Var of a series)? Would need dominated-convergence for covariance."
+    ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Sharp-boundary follow-up to the (already complete) multi-symbol AWGN output-power entry `shannon-channel-coding-awgn-oq-02-oq-02`.

The existing theorems (and Mathlib's `ProbabilityTheory.IndepFun.variance_sum`) prove the variance-of-a-sum / output-power identity under **pairwise independence**. But Bienaymé's identity only ever uses that the **pairwise covariances vanish** — the off-diagonal terms of `Var[∑ Wᵢ] = ∑ᵢ∑ⱼ cov[Wᵢ,Wⱼ]` (Mathlib `variance_sum'`). Pairwise independence is strictly stronger than pairwise uncorrelatedness (uncorrelated-but-dependent variables exist), so the identity holds under the weaker — and exactly sufficient — second-order hypothesis.

This is the sharp form: **uncorrelated** (not necessarily independent) signal + noise contributions still add in *power*.

## New theorems (all 0 sorry / 0 axiom)

- `variance_sum_of_pairwise_uncorrelated` — `Var[∑ i∈s, Wᵢ] = ∑ Var[Wᵢ]` from `Set.Pairwise (cov[Wᵢ,Wⱼ]=0)` + `MemLp`.
- `variance_sum_of_pairwise_indep` — independence ⟹ uncorrelated ⟹ identity (via `IndepFun.covariance_eq_zero`); shows the sharp version subsumes `IndepFun.variance_sum`.
- `awgn_multisymbol_power_of_uncorrelated` — `E[(∑Wᵢ)²] = ∑ E[Wᵢ²]` under pairwise-uncorrelated + zero-mean, strengthening the existing `awgn_multisymbol_power`.

## Mathlib gap

Mathlib has `variance_sum'` (always-true double sum) and `IndepFun.variance_sum` (independence) but **no pairwise-uncorrelated variance-sum lemma** — the intermediate that these results fill. Candidate for upstreaming, from which `IndepFun.variance_sum` becomes a one-line corollary.

## Verification

`./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingAWGNOQ02OQ02` → `✔ [7743/7743] Built (3.7s)`, 0 sorries, 0 axioms. File: 5 → 8 theorems, 174 lines. Meta + research knowledge updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)