### PR TITLE
Enrich Fourier series OQ-04 WIP-01 OQ-01: add mainTheorems

### DIFF
--- a/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/meta.json
@@ -123,6 +123,23 @@
       "significance": "high"
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "torusChar_orthonormal",
+      "type": "theorem",
+      "description": "Orthonormality of the n-dimensional Fourier characters: ∫_{Tⁿ} e_j(x)·conj(e_k(x)) dx = δ_{j,k}. The tensor character splits into a coordinate product, Fubini factors the integral into 1-D integrals (each char1d_integral), and the product of Kronecker deltas collapses to the multi-index delta."
+    },
+    {
+      "name": "char1d_integral",
+      "type": "theorem",
+      "description": "One-dimensional orthogonality in concrete-integral form: ∫_{AddCircle 1} fourier a(x)·conj(fourier b(x)) dx = δ_{a,b}, making Mathlib's orthonormal_fourier explicit as an integral against volume (= Haar probability measure at T=1)."
+    },
+    {
+      "name": "fourierCoeffND_torusChar",
+      "type": "theorem",
+      "description": "Orthonormality restated via the parent's coefficient: the j-th Fourier coefficient of the character e_k is δ_{j,k} (fourierCoeffND (torusChar k) j = δ_{j,k}) — the characters are an orthonormal system read off by the Fourier transform."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "fourier-series-oq-04-wip-01",


### PR DESCRIPTION
Adds the absent `mainTheorems` array for `fourier-series-oq-04-wip-01-oq-01` from `Proofs/FourierSeriesOQ04WIP01OQ01.lean`: `torusChar_orthonormal` (n-dim character orthonormality), `char1d_integral` (1-D concrete-integral orthogonality), `fourierCoeffND_torusChar` (coefficient form). Additive single-field change; meta parses, under cap.