### PR TITLE
research(erdos-1093-oq-02): de-native_decide noSmallPrimeFactors_284_28 via Kummer's theorem [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -47,21 +47,27 @@ the **tractable half** and formalizes the question precisely.
 
 ## Axioms
 
-The record facts (`deficiency_284_28`, `noSmallPrimeFactors_284_28`,
-`smooth_indices_284_28`) are discharged by `native_decide`, so they depend on
-`Lean.ofReduceBool`: they compute the bignum binomial `C(284,28)` (Pascal
-recursion, infeasible for the kernel) or factor values via `Nat.primeFactors`
-(well-founded recursion, which does not reduce under kernel `decide`).  The
-numeric certificate `(28!)² < 47!` inside `deficiency_record_le_18` (Section XII)
-is now discharged by kernel `decide` (`Nat.factorial` is structural recursion, so
-the kernel reduces it), hence it is `ofReduceBool`-free.  The structural results
-(1, 5) and all of Sections IV–XI are `ofReduceBool`-free.
+Two record facts remain discharged by `native_decide`, so they depend on
+`Lean.ofReduceBool`: the parent's `deficiency_284_28` computes the bignum
+binomial `C(284,28)` (Pascal recursion, infeasible for the kernel), and
+`smooth_indices_284_28` factors values via `Nat.primeFactors` (well-founded
+recursion, which does not reduce under kernel `decide`).  Two facts that
+previously used `native_decide` are now `ofReduceBool`-free:
+- the numeric certificate `(28!)² < 47!` inside `deficiency_record_le_18`
+  (Section XII), via kernel `decide` (`Nat.factorial` is structural recursion, so
+  the kernel reduces it);
+- `noSmallPrimeFactors_284_28`, via **Kummer's theorem** — instead of the bignum
+  divisibility test it reduces each prime `p ≤ 28` to a bounded base-`p` carry
+  count (`Nat.factorization_choose`) that the kernel discharges.
+
+The structural results (1, 5) and all of Sections IV–XI are `ofReduceBool`-free.
 
 ## Status: OPEN (universal upper bound); existence half machine-verified.
 -/
 
 import Proofs.Erdos1093Problem
 import Mathlib.Data.Nat.Prime.Factorial
+import Mathlib.Data.Nat.Choose.Factorization
 import Mathlib.Tactic
 
 /-
@@ -90,11 +96,44 @@ theorem noSmallPrimeFactors_iff (n k : ℕ) :
 -/
 
 /-- No prime `≤ 28` divides `C(284,28)`, so the pair `(284,28)` is admissible
-and its deficiency is well-defined.  Verified by `native_decide` after the
-reduction to a bounded prime check. -/
+and its deficiency is well-defined.
+
+**`ofReduceBool`-free (kernel `decide` only).**  Rather than compute the
+~50-digit bignum `C(284,28)` and test divisibility — which would force
+`native_decide`, since kernel `decide` cannot evaluate the exponential Pascal
+recursion for `Nat.choose 284 28` — we invoke **Kummer's theorem**
+(`Nat.factorization_choose`): the `p`-adic valuation of `C(n,k)` equals the
+number of carries when `k` and `n - k` are added in base `p`.  For each prime
+`p ≤ 28`, `p ∣ C(284,28)` would force a positive carry count over the finite
+window `Ico 1 9` (valid because `log p 284 ≤ log 2 284 = 8 < 9`), a purely
+bounded `%`/`≤` computation the kernel discharges.  Adding `28` and `256` has no
+carry in any base `p ≤ 28`, so the carry count is `0` and no such prime divides
+`C(284,28)`. -/
 theorem noSmallPrimeFactors_284_28 : NoSmallPrimeFactors 284 28 := by
   rw [noSmallPrimeFactors_iff]
-  native_decide
+  intro p hp hpp hdvd
+  have hp2 : 2 ≤ p := hpp.two_le
+  have hchoose_ne : Nat.choose 284 28 ≠ 0 := (Nat.choose_pos (by norm_num)).ne'
+  have hpos : 0 < (Nat.choose 284 28).factorization p :=
+    hpp.factorization_pos_of_dvd hchoose_ne hdvd
+  -- Kummer's carry bound needs any `b > log p 284`; `log p 284 ≤ log 2 284 = 8`.
+  have hb : Nat.log p 284 < 9 := by
+    apply Nat.log_lt_of_lt_pow (by norm_num)
+    calc (284 : ℕ) < 2 ^ 9 := by norm_num
+      _ ≤ p ^ 9 := Nat.pow_le_pow_left hp2 9
+  rw [Nat.factorization_choose hpp (by norm_num) hb] at hpos
+  -- `hpos : 0 < #{i ∈ Ico 1 9 | p ^ i ≤ 28 % p ^ i + (284 - 28) % p ^ i}`.
+  -- Case on the finitely many `p ≤ 28`: non-primes contradict `hpp`; for each
+  -- prime the carry set is empty, contradicting `hpos`.
+  have hp28 : p ≤ 28 := by have := Finset.mem_range.mp hp; omega
+  -- For each prime `p` the carry set is empty (`decide` closes `0 < card → False`);
+  -- composite `p` are ruled out by `hpp` (`norm_num` only ever sees non-primes here,
+  -- where `¬ p.Prime` holds — proving it against a *prime* would instead reduce the
+  -- side goal to `⊢ False` and stall, so `decide` must be tried first).
+  interval_cases p <;>
+    first
+      | (revert hpos; decide)
+      | exact absurd hpp (by norm_num)
 
 /-- Explicit certificate: the nine smooth indices witnessing `deficiency 284 28 = 9`
 are exactly `{4, 8, 9, 11, 12, 14, 18, 20, 24}` (the `28`-smooth values

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -259,3 +259,50 @@ two binomial/factorization record certs above (+ parent's `deficiency_284_28`).
 Unchanged: the universal upper bound (and closing 10≤d≤18 at k=28) is BLOCKED on
 effective analytic NT absent from Mathlib. The Kummer de-native_decide of
 `noSmallPrimeFactors_284_28` is the one remaining *bounded* trust-surface win.
+
+## Session 2026-07-08 (researcher-3) — de-native_decide `noSmallPrimeFactors_284_28` via Kummer
+
+**Mode:** AXIOM/TRUST-REDUCTION (elementary theory saturated; the "one remaining
+bounded trust-surface win" flagged by researcher-2's session was the Kummer route).
+**Outcome:** progress (1 native_decide → kernel `decide`). VERIFIED, 0 sorry / 0 axiom.
+
+### What I did
+Rewrote `noSmallPrimeFactors_284_28`. Old proof: `rw [noSmallPrimeFactors_iff]; native_decide`
+(computes the ~50-digit bignum `C(284,28)` and tests divisibility → `Lean.ofReduceBool`).
+New proof invokes **Kummer's theorem** `Nat.factorization_choose` (Mathlib
+`Mathlib/Data/Nat/Choose/Factorization.lean`): `(C n k).factorization p =
+#{i ∈ Ico 1 b | p^i ≤ k % p^i + (n-k) % p^i}` (carry count), for any `b > log p n`.
+For each prime `p ≤ 28`, `p ∣ C(284,28)` ⇒ `0 < factorization p` (`Prime.factorization_pos_of_dvd`)
+⇒ a positive carry count over `Ico 1 9`; adding `28`+`256` has no carry in any base
+`p ≤ 28`, so the count is 0 — contradiction. `interval_cases p` (2..28), primes closed by
+`decide` on the concrete carry set, composites by `norm_num` on `¬ p.Prime`.
+
+### Key gotchas (reusable)
+- **`log` doesn't reduce under kernel `decide`** (well-founded rec). Bound `log p 284 < 9`
+  via `Nat.log_lt_of_lt_pow (h : 284 < p^9)`, and `284 < p^9` generically from
+  `284 < 2^9 ≤ p^9` (`Nat.pow_le_pow_left hpp.two_le`). No `log` ever hits `decide`.
+- **`decide` DOES reduce the `Finset.Ico 1 9` filter-card** (confirmed by isolated probes —
+  `decide`, `rfl`, `simp+decide` all work standalone even for `p=23`, `23^8`). The bignum
+  `C(284,28)` is what `decide` can't do (exponential Pascal recursion), NOT the carry set.
+- **Branch-order trap in `interval_cases p <;> first | A | B`:** put the `decide` branch
+  FIRST. If `norm_num` (proving `¬ p.Prime`) is tried against a genuine *prime*, it reduces
+  the side goal to `⊢ False` and STALLS with "unsolved goals" — a hard error, not a clean
+  failure `first` can recover from. With `decide` first, primes are closed before `norm_num`
+  is reached, so `norm_num` only ever sees composites (where `¬ p.Prime` holds cleanly).
+
+### Build notes
+Documented exit-135/139 SIGBUS at `[3060/3060]` (elaborates fully in ~1-2s, 0 proof errors,
+then crashes on olean finalization under fleet memory contention) reproduced ~11× in a row;
+`LEAN_SKIP_CACHE=true` did NOT help (crash is post-decompress). Fix: `docker-build.sh
+--repair-cache` (force cache refresh; decompress dropped to 15s, a sign the fleet quieted),
+then the very next build went green `✔ [3060/3060] Built (2.4s)` exit 0. Real proof errors,
+by contrast, print explicit `.lean:LINE:COL: error` diagnostics (the branch-order bug printed
+9 of them) — their ABSENCE + reaching `[3060/3060]` is the tell for an environmental crash.
+
+### Frontier
+Unchanged: the universal upper bound (and closing `10 ≤ d ≤ 18` at `k=28`) is BLOCKED on
+effective analytic NT absent from Mathlib. Remaining native_decide in this file: exactly one
+— `smooth_indices_284_28` — which CANNOT be de-native_decided (`IsKSmooth` decidability routes
+through `Nat.primeFactors`, well-founded recursion, does not reduce under kernel `decide`). The
+parent's `deficiency_284_28` also remains native_decide. So the file is still `ofReduceBool`-
+dependent overall, but this session removed one of the two record-cert dependencies here.

--- a/src/data/research/problems/erdos-1093-oq-02.json
+++ b/src/data/research/problems/erdos-1093-oq-02.json
@@ -23,7 +23,7 @@
     {
       "path": "Proofs/Erdos1093ProblemOQ02.lean",
       "filename": "Erdos1093ProblemOQ02.lean",
-      "lineCount": 816,
+      "lineCount": 862,
       "theoremCount": 35,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Summary

Trust-surface reduction on Erdős #1093 OQ-02. Replaces the `native_decide` in
`noSmallPrimeFactors_284_28` — which computed the ~50-digit bignum `C(284,28)` and
tested divisibility, pulling in `Lean.ofReduceBool` — with an `ofReduceBool`-free,
kernel-`decide` proof via **Kummer's theorem**.

This was the *one remaining bounded trust-surface win* explicitly flagged by the
prior session (researcher-2, PR #35574 de-native_decided the sibling `(28!)²<47!`
certificate; this PR handles the binomial-divisibility certificate).

## The proof

`Nat.factorization_choose` (Mathlib's Kummer's theorem): the `p`-adic valuation of
`C(n,k)` is the number of carries when adding `k` and `n-k` in base `p`, over any
window `Ico 1 b` with `b > log p n`. For each prime `p ≤ 28`:
`p ∣ C(284,28)` ⇒ `0 < (C 284 28).factorization p` (`Prime.factorization_pos_of_dvd`)
⇒ a positive carry count. But adding `28` and `256` has **no** carry in any base
`p ≤ 28`, so the count is `0` — contradiction. `interval_cases p` over `2..28`
discharges each prime by `decide` on the concrete (small) carry set; composites are
ruled out by `¬ p.Prime`.

Two `log`-reduction / tactic gotchas documented in the file and knowledge notes:
- `Nat.log` is well-founded recursion and won't reduce under kernel `decide`; the
  window bound `log p 284 < 9` is proved via `Nat.log_lt_of_lt_pow` + `284 < 2^9 ≤ p^9`.
- In `interval_cases p <;> first | (revert hpos; decide) | exact absurd hpp (by norm_num)`
  the `decide` branch must come first: `norm_num` on `¬ p.Prime` against a genuine
  *prime* reduces to `⊢ False` and stalls (hard error), so it must only ever see composites.

## Verification

`✔ [3060/3060] Built Proofs.Erdos1093ProblemOQ02` (Docker, Mathlib v4.26), exit 0.
**0 sorry, 0 `axiom` declarations.** This file's `native_decide` sites drop from 2 to 1:
only `smooth_indices_284_28` remains (blocked — `IsKSmooth` decidability routes through
`Nat.primeFactors`, well-founded recursion). The file remains `ofReduceBool`-dependent
overall (that cert + the parent's `deficiency_284_28`), so the entry's `axiomatized`
status is unchanged; this is a genuine reduction of the trust surface, not a status change.

The open crux (universal upper bound / closing `10 ≤ d ≤ 18` at `k=28`) is unchanged and
remains blocked on effective analytic number theory absent from Mathlib.