### PR TITLE
Enrich Kronecker's Jugendtraum OQ-02: add mainTheorems

### DIFF
--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
@@ -55,6 +55,18 @@
     "theoremCount": 2,
     "definitionCount": 0
   },
+  "mainTheorems": [
+    {
+      "name": "regulator_eq_single_log_of_rank_eq_one",
+      "type": "theorem",
+      "description": "The rank-one regulator is a single logarithm: when rank K = 1, the regulator collapses from a determinant of logarithms to one archimedean term mult(w)·|log(w ε)| for the fundamental (Stark) unit ε — the linear-algebra fact behind the rank-one abelian Stark conjecture's claim that L'(0,χ) is a rational multiple of one log|ε|."
+    },
+    {
+      "name": "rank_eq_one_iff_card_infinitePlace_eq_two",
+      "type": "theorem",
+      "description": "Rank one ⟺ two infinite places: by Dirichlet's unit theorem the unit rank of K is #(InfinitePlace K) − 1, so the rank-one Stark hypothesis rank K = 1 holds exactly when K has two infinite places."
+    }
+  ],
   "overview": {
     "historicalContext": "Hilbert's 12th problem (Kronecker's Jugendtraum) asks for explicit generators of the abelian extensions of a number field K. Solved for K = ℚ (Kronecker–Weber: roots of unity) and for imaginary quadratic K (complex multiplication: j-invariants and CM torsion), it is open in general. The modern conjectural framework is provided by the **Stark conjectures** (Stark 1971–1980, Tate 1984): special values and derivatives of Artin L-functions at s = 0 should be algebraic combinations of logarithms of units, the **Stark units**, which conjecturally generate abelian extensions. The simplest and most-tested case is the *rank-one abelian Stark conjecture*, which applies precisely when the relevant unit rank is 1 and predicts that L'(0, χ) is a rational multiple of a single logarithm log|ε| of one Stark unit ε.",
     "problemStatement": "**Problem (parent oq-02):** Stark Units — effective computation for specific number fields.\n\n**This entry** isolates and machine-checks the structural fact underpinning the rank-one case: when the unit rank of K is 1, the regulator — which in general is an (r×r) determinant of logarithms of a fundamental system of units — collapses to a single archimedean logarithm of the fundamental (Stark) unit.",


### PR DESCRIPTION
Adds the absent `mainTheorems` array for `kroneckers-jugendtraum-oq-02` from `Proofs/KroneckersJugendtraumStarkRankOne.lean`: `regulator_eq_single_log_of_rank_eq_one` (rank-one regulator collapses to a single logarithm) and `rank_eq_one_iff_card_infinitePlace_eq_two` (rank one ⟺ two infinite places, via Dirichlet's unit theorem). Additive single-field change; meta parses, under cap.