### PR TITLE
research(dirichlets-theorem-oq-02-oq-03): Step 13 — B dominates every fixed power of C [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -974,4 +974,90 @@ infinitely many primes `≡ 3 (mod 4)`", now with an explicit certified threshol
 theorem primesCount3_unbounded (m : ℕ) : ∃ x, m ≤ primesCount3 x :=
   ⟨4 ^ (2 ^ m), le_trans (Nat.le_succ m) (primesCount3_ge_of_doubly_exp m)⟩
 
+/-! ## Step 13: `B` dominates **every fixed power** of `C` — `(C k)^p ≤ B k`
+
+Step 10 proved the factorial tower `B` eventually dominates the *square* of the
+primorial tower, `(C k)² ≤ B k`, hence `B / C → ∞`.  The tetration lower bound
+`2 ↑↑ k ≤ B k` (Step 11) makes a far stronger statement transparent: `B`
+eventually dominates **any fixed power** `(C k)^p`, and even `m·(C k)^p` for any
+fixed multiplier `m`.  So `B / C^p → ∞` for *every* exponent `p`, i.e. `B`
+outgrows every polynomial in the primorial certificate `C`.
+
+The mechanism is the closed-form sandwich: on the `C` side
+`(C k)^p ≤ (4^(2^k))^p = 2^(2^(k+1)·p)` (`C_le_doubly_exp`), while on the `B` side
+`B k ≥ 2 ↑↑ k = 2^(2 ↑↑ (k−1))` (`tower2_le_B`).  It therefore suffices to
+compare the *exponents*: `2^(k+1)·p ≤ 2 ↑↑ (k−1)`, and the tetration term
+eventually dwarfs the doubly-exponential one.  Certified, `native_decide`-free —
+the only quantitative inputs are `n < 2^n` and the linear tetration bound
+`2^(k+2) ≤ 2 ↑↑ k` of Step 11. -/
+
+/-- Tetration beats a fixed doubly-exponential with a doubled exponent:
+`2^(2k+2) ≤ 2 ↑↑ k` for `k ≥ 5`.  Writing `k = i+1`, the claim
+`2^(2i+4) ≤ 2^(2 ↑↑ i)` reduces to `2i+4 ≤ 2 ↑↑ i`, which follows from
+`2^(i+2) ≤ 2 ↑↑ i` (`two_pow_le_tower2`, `i ≥ 4`) together with the elementary
+`2·(i+2) ≤ 2^(i+2)` (from `i+1 < 2^(i+1)`).  This is the exponent-level engine
+behind the power-domination result. -/
+theorem two_pow_two_mul_le_tower2 {j : ℕ} (hj : 5 ≤ j) : 2 ^ (2 * j + 2) ≤ tower2 j := by
+  obtain ⟨i, rfl⟩ : ∃ i, j = i + 1 := ⟨j - 1, by omega⟩
+  rw [tower2_succ]
+  apply Nat.pow_le_pow_right (by norm_num)
+  have hi4 : 4 ≤ i := by omega
+  have h := two_pow_le_tower2 hi4
+  have hb : i + 1 < 2 ^ (i + 1) := lt_two_pow_aux (i + 1)
+  have heq : (2 : ℕ) ^ (i + 2) = 2 * 2 ^ (i + 1) := by rw [pow_succ]; ring
+  omega
+
+/-- **`B` dominates every fixed power of `C`:** for each `p` there is a threshold
+`K` (here `K = p + 6`) with `(C k)^p ≤ B k` for all `k ≥ K`.  Generalises
+`C_sq_le_B` (the `p = 2` case) to arbitrary exponents, using the tetration lower
+bound on `B` rather than the ad-hoc quartic estimate.  Proof: bound the `C` side
+by `2^(2^(k+1)·p)` via `C_le_doubly_exp`, bound `B` below by
+`2^(2 ↑↑ (k−1)) = 2 ↑↑ k` via `tower2_le_B`, and compare exponents through
+`2^(k+1)·p ≤ 2^(2k')·… ≤ 2 ↑↑ (k−1)` (`two_pow_two_mul_le_tower2`, absorbing the
+multiplier `p ≤ 2^{k−1}`). Certified, `native_decide`-free. -/
+theorem C_pow_le_B_eventually (p : ℕ) : ∃ K, ∀ k, K ≤ k → (C k) ^ p ≤ B k := by
+  refine ⟨p + 6, fun k hk => ?_⟩
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  have hj5 : 5 ≤ j := by omega
+  have hjp : p ≤ j := by omega
+  -- `C` side: `(C (j+1))^p ≤ 2^(2^(j+2)·p)`.
+  have hC2 : (C (j + 1)) ^ p ≤ 2 ^ (2 ^ (j + 2) * p) := by
+    calc (C (j + 1)) ^ p ≤ (4 ^ (2 ^ (j + 1))) ^ p :=
+          Nat.pow_le_pow_left (C_le_doubly_exp (j + 1)) p
+      _ = 2 ^ (2 ^ (j + 2) * p) := by
+          rw [← pow_mul, show (4 : ℕ) = 2 ^ 2 by norm_num, ← pow_mul]
+          congr 1
+          have h42 : (2 : ℕ) ^ (j + 2) = 2 * 2 ^ (j + 1) := by rw [pow_succ]; ring
+          rw [h42]; ring
+  -- exponent comparison: `2^(j+2)·p ≤ 2 ↑↑ j`.
+  have hp2 : p ≤ 2 ^ j :=
+    le_trans (le_of_lt (lt_two_pow_aux p)) (Nat.pow_le_pow_right (by norm_num) hjp)
+  have hexp : 2 ^ (j + 2) * p ≤ tower2 j := by
+    calc 2 ^ (j + 2) * p ≤ 2 ^ (j + 2) * 2 ^ j := Nat.mul_le_mul (le_refl _) hp2
+      _ = 2 ^ (2 * j + 2) := by rw [← pow_add]; congr 1; ring
+      _ ≤ tower2 j := two_pow_two_mul_le_tower2 hj5
+  -- `B` side: `2^(2^(j+2)·p) ≤ 2^(2 ↑↑ j) = 2 ↑↑ (j+1) ≤ B (j+1)`.
+  have hB2 : 2 ^ (2 ^ (j + 2) * p) ≤ B (j + 1) := by
+    calc 2 ^ (2 ^ (j + 2) * p) ≤ 2 ^ tower2 j := Nat.pow_le_pow_right (by norm_num) hexp
+      _ = tower2 (j + 1) := (tower2_succ j).symm
+      _ ≤ B (j + 1) := tower2_le_B (j + 1)
+  exact le_trans hC2 hB2
+
+/-- **`B / C^p → ∞` for every fixed `p` (division-free form):**
+`∀ p m, ∃ K, ∀ k ≥ K, m·(C k)^p ≤ B k`.  Generalises `B_div_C_diverges` (the
+`p = 1` case) to arbitrary powers: the factorial certificate `B` outgrows every
+fixed *polynomial* in the primorial certificate `C`, with any constant.  Proof:
+absorb the multiplier as an extra factor, `m·(C k)^p ≤ (C k)^(p+1)` once
+`m ≤ C k` (true for `k ≥ m` since `C k ≥ k+3`), then apply
+`C_pow_le_B_eventually (p+1)`. -/
+theorem B_div_C_pow_diverges (p m : ℕ) : ∃ K, ∀ k, K ≤ k → m * (C k) ^ p ≤ B k := by
+  obtain ⟨K0, hK0⟩ := C_pow_le_B_eventually (p + 1)
+  refine ⟨max K0 m, fun k hk => ?_⟩
+  have hkK0 : K0 ≤ k := le_trans (le_max_left _ _) hk
+  have hkm : m ≤ k := le_trans (le_max_right _ _) hk
+  have hmC : m ≤ C k := le_trans hkm (by have := C_ge_add k; omega)
+  calc m * (C k) ^ p ≤ C k * (C k) ^ p := Nat.mul_le_mul_right _ hmC
+    _ = (C k) ^ (p + 1) := by rw [pow_succ]; ring
+    _ ≤ B k := hK0 k hkK0
+
 end DirichletsTheoremOQ02OQ03

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -172,12 +172,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 977,
+    "lineCount": 1063,
     "axiomCount": 0,
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 7,
-    "theoremCount": 67
+    "theoremCount": 70
   },
   "sorries": 0,
   "status": "verified",

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (verified 0/0, PR #35706): counting-function side added — certified π(x;4,3) ≥ k+1 for x ≥ 4^(2^k) (iterated-log growth). Value-side B/C divergence already done on main (#35694). Remaining: low-novelty modulus port; analytic terminus for sharpening toward the truth.",
+    "progressSummary": "PROGRESS (Step 13, VERIFIED 0/0): B dominates every fixed POWER of C — C_pow_le_B_eventually ((C k)^p ≤ B k eventually, all p) and B_div_C_pow_diverges (m·(C k)^p ≤ B k eventually, all p,m), generalizing C_sq_le_B / B_div_C_diverges via the tetration lower bound 2↑↑k≤B k. Complements the counting-function side π(x;4,3)≥k+1 (#35706) and the value-side ratio divergence (#35694). Remaining: analytic terminus (2k·ln k truth) and a Tendsto-filter packaging.",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
@@ -56,7 +56,10 @@
       "B_div_C_diverges (:787) — VERIFIED 0/0: division-free ratio divergence ∀m ∃K ∀k≥K, m·C k ≤ B k. From C k→∞ pick k≥max 3 m so m≤C k, then m·C k ≤ (C k)² ≤ B k. PR #TBD.",
       "tower2 (base-2 tetration def) + tower2_le_B: 2↑↑k ≤ B k (DirichletsTheoremOQ02OQ03.lean Step 11)",
       "two_pow_le_tower2 (2^(k+2)≤2↑↑k for k≥4), doubly_exp_le_tower2 (4^(2^k)≤2↑↑k for k≥5), growth_class_separation (C k≤4^(2^k)≤2↑↑k≤B k for k≥5), tower2_lt_doubly_exp_at_four (sharp threshold), lt_two_pow_aux",
-      "primesCount3 + card_le_primesCount3 / primesCount3_mono / primesCount3_ge_of_doubly_exp / primesCount3_ge / primesCount3_unbounded in Proofs/DirichletsTheoremOQ02OQ03.lean Step 11 (5 thm, 0/0, PR #35706)"
+      "primesCount3 + card_le_primesCount3 / primesCount3_mono / primesCount3_ge_of_doubly_exp / primesCount3_ge / primesCount3_unbounded in Proofs/DirichletsTheoremOQ02OQ03.lean Step 11 (5 thm, 0/0, PR #35706)",
+      "two_pow_two_mul_le_tower2 (2^(2k+2) ≤ 2↑↑k for k≥5) in DirichletsTheoremOQ02OQ03.lean Step 13 — exponent-level tetration engine",
+      "C_pow_le_B_eventually (∀p, ∃K, ∀k≥K, (C k)^p ≤ B k) in DirichletsTheoremOQ02OQ03.lean Step 13 — B dominates every fixed power of C, generalizing C_sq_le_B (p=2 case) via the tetration lower bound 2↑↑k≤B k",
+      "B_div_C_pow_diverges (∀p m, ∃K, ∀k≥K, m·(C k)^p ≤ B k) in DirichletsTheoremOQ02OQ03.lean Step 13 — B/C^p→∞ for all p, generalizing B_div_C_diverges (p=1 case)"
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
@@ -77,12 +80,16 @@
       "Tetration/tower-exponential lower bound: the factorial certificate B satisfies 2↑↑k ≤ B k (closed-form, via B_succ_ge_two_pow + monotonicity of 2^·). This is the closed-form counterpart of the recursive step 2^(B k)≤B(k+1) and places B strictly above C´s doubly-exponential growth class.",
       "Growth-class SEPARATION is sharp: for k≥5, C k ≤ 4^(2^k) ≤ 2↑↑k ≤ B k — the doubly-exponential UPPER bound on the primorial tower C is dominated by the tetration LOWER bound on B. Threshold k=5 is sharp (at k=4, 2↑↑4=65536 < 4^(2^4)=4294967296).",
       "Counting-function side (π(x;4,3)) done: p3 k ≤ x ⟹ k+1 ≤ π(x;4,3) transfers the certified value bound p3 k ≤ 4^(2^k) into π(x;4,3) ≥ k+1 for x ≥ 4^(2^k) — an iterated-log lower bound, honestly isolating the analytic gap to the truth π(x;4,3) ∼ x/(2 ln x) (PR #35706).",
-      "B/C ratio divergence (∀m ∃K ∀k≥K, m·C k ≤ B k) was completed on main by #35694 (C_succ_add_one, C_sq_le_B, B_div_C_diverges, quartic_le_two_pow) — do NOT rebuild; the exact quadratic recursion C(k+1)=(C k+1)·C k is there too."
+      "B/C ratio divergence (∀m ∃K ∀k≥K, m·C k ≤ B k) was completed on main by #35694 (C_succ_add_one, C_sq_le_B, B_div_C_diverges, quartic_le_two_pow) — do NOT rebuild; the exact quadratic recursion C(k+1)=(C k+1)·C k is there too.",
+      "The Step-11 tetration lower bound 2↑↑k≤B k makes p-th power domination transparent: bound C side by (4^(2^k))^p=2^(2^(k+1)·p), B side below by 2^(2↑↑(k-1)), and reduce to the exponent comparison 2^(k+1)·p ≤ 2↑↑(k-1); the multiplier p is absorbed via p≤2^(k-1). No native_decide.",
+      "Arbitrary multiplier m folds in for free: m·(C k)^p ≤ (C k)^(p+1) once m≤C k (from C k≥k+3), so B_div_C_pow_diverges follows from C_pow_le_B_eventually(p+1) with no extra estimate."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Port the primorial-tower framework to other elementary progressions (≡5 mod 6 via N=6·∏−1) — low novelty, mechanical.",
-      "Upper-bound side (certified analytic-free 2k·ln k) remains a genuine terminus: Step 8 proved the tower is intrinsically doubly-exponential, so no re-evaluation of THIS certificate yields sub-exponential; needs ψ(x,y)/analytic input Mathlib lacks."
+      "Upper-bound side (certified analytic-free 2k·ln k) remains a genuine terminus: Step 8 proved the tower is intrinsically doubly-exponential, so no re-evaluation of THIS certificate yields sub-exponential; needs ψ(x,y)/analytic input Mathlib lacks.",
+      "Package the p-th power domination as a single Mathlib-filter statement B k / (C k)^p → ∞ (Tendsto atTop); currently division-free ∀-∃ form only.",
+      "State the growth-class separation as a formal ordering of C and B in an iterated-exponential hierarchy (define a growth-rank and prove rank C < rank B)."
     ],
     "markdown": "# Knowledge Base: dirichlets-theorem-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the value-side growth results for the Dirichlet ≡3 (mod 4) certificate. The prior ratio-divergence work (#35694) showed the factorial tower `B` eventually dominates the **square** of the primorial tower `C`. This PR generalizes that from the square to **every fixed power**:

- **`two_pow_two_mul_le_tower2`** — `2^(2k+2) ≤ 2↑↑k` for `k ≥ 5` (exponent-level tetration engine).
- **`C_pow_le_B_eventually`** — `∀ p, ∃ K, ∀ k ≥ K, (C k)^p ≤ B k`. `B` eventually dominates every fixed power of `C`. Uses the Step-11 tetration lower bound `2↑↑k ≤ B k` (instead of the ad-hoc quartic estimate for the `p=2` case): bound the `C` side by `(4^(2^k))^p = 2^(2^(k+1)·p)`, bound `B` below by `2^(2↑↑(k−1)) = 2↑↑k`, and compare exponents through `2^(k+1)·p ≤ 2↑↑(k−1)` (the multiplier `p` is absorbed via `p ≤ 2^{k−1}`).
- **`B_div_C_pow_diverges`** — `∀ p m, ∃ K, ∀ k ≥ K, m·(C k)^p ≤ B k`, i.e. `B / C^p → ∞` for every exponent `p` and every constant `m`. The multiplier folds in for free: `m·(C k)^p ≤ (C k)^(p+1)` once `m ≤ C k`.

**Upshot:** the factorial certificate `B` outgrows every fixed *polynomial* in the primorial certificate `C` — a strengthening of `B/C → ∞` to `B/C^p → ∞`.

## Verification

- Docker-built: `✔ [7743/7743] Built Proofs.DirichletsTheoremOQ02OQ03 (5.0s)`
- **0 sorries, 0 axioms, `native_decide`/`ofReduceBool`-free** (kernel `decide` only where used).
- `leanFile` counts refreshed: lineCount 1063, theoremCount 70, definitionCount 7.

## Notes

Rebased onto current `main` so it coexists with the concurrently-merged counting-function section (Step 12, #35706); this contribution was renumbered to **Step 13**. Purely additive — appends a new section, touches no existing declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)