### PR TITLE
Enrich Triangular 8n+1 perfect-square test: add mainTheorems

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02/meta.json
@@ -14,6 +14,33 @@
     "path": "Proofs/TriangularSingleEightMulAddOneSquare.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "isTriangular_iff_isSquare",
+      "type": "theorem",
+      "description": "The 8n+1 perfect-square test: a natural number n is a triangular number T(k) = k(k+1)/2 if and only if 8n+1 is a perfect square. The headline characterization, proved unconditionally via the identity (2k+1)² = 8·T(k)+1."
+    },
+    {
+      "name": "eq_tri_of_eight_mul_add_one",
+      "type": "theorem",
+      "description": "Exact recovery of the triangular index: if 8n+1 = (2k+1)² then n = T(k) — the index is determined uniquely."
+    },
+    {
+      "name": "sq_two_mul_add_one",
+      "type": "lemma",
+      "description": "Defining identity: the odd square (2k+1)² equals 8·T(k) + 1."
+    },
+    {
+      "name": "tri_strictMono",
+      "type": "lemma",
+      "description": "T is strictly monotone, so the triangular index is unique when it exists."
+    },
+    {
+      "name": "two_mul_tri",
+      "type": "lemma",
+      "description": "Twice a triangular number is k(k+1) — the halving in T(k) = k(k+1)/2 is exact over ℕ."
+    }
+  ],
   "title": "Triangular Numbers and the 8n+1 Perfect-Square Test",
   "description": "The one-summand base case of the triangular-rank hierarchy. For every natural number n, n is itself a triangular number T(k)=k(k+1)/2 if and only if 8n+1 is a perfect square — proved unconditionally and axiom-free via the single defining identity (2k+1)² = 8·T(k)+1. The triangular index is recovered exactly and is unique (T is strictly monotone), and since 'is a perfect square' is decidable the characterization upgrades the triangular-number predicate to a DecidablePred, a constant-cost membership test.",
   "overview": {


### PR DESCRIPTION
Adds the absent `mainTheorems` array for `lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02` from `Proofs/TriangularSingleEightMulAddOneSquare.lean`: `isTriangular_iff_isSquare` (n triangular ⟺ 8n+1 a perfect square), `eq_tri_of_eight_mul_add_one` (exact index recovery), plus supporting lemmas `sq_two_mul_add_one`, `tri_strictMono`, `two_mul_tri`. Additive single-field change; meta parses, under cap.