### PR TITLE
Enrich Law of Cosines OQ-07 OQ-02 OQ-01 (Leibniz/centroid): add mainTheorems

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07-oq-02-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-02-oq-01/meta.json
@@ -112,5 +112,27 @@
     "path": "Proofs/LawOfCosinesOQ07OQ02OQ01.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "leibniz_centroid",
+      "type": "theorem",
+      "description": "Leibniz identity at the centroid: for any point p, dist(p,a)² + dist(p,b)² + dist(p,c)² = 3·dist(p,g)² + (dist(g,a)² + dist(g,b)² + dist(g,c)²), where g is the triangle centroid. The centroid minimises the sum of squared distances to the vertices."
+    },
+    {
+      "name": "leibniz_identity",
+      "type": "theorem",
+      "description": "General Leibniz/Lagrange identity: for any base point g satisfying the balance ∑(vertex −ᵥ g) = 0, ∑ dist(p,vertex)² = 3·dist(p,g)² + ∑ dist(g,vertex)²."
+    },
+    {
+      "name": "centroid_sum_sq",
+      "type": "theorem",
+      "description": "Sum of squared distances from the centroid to the vertices, the p = g specialisation of the Leibniz identity."
+    },
+    {
+      "name": "centroid₃_balance",
+      "type": "theorem",
+      "description": "Balance condition: the three displacement vectors from the vertices to the centroid sum to zero, (a −ᵥ g) + (b −ᵥ g) + (c −ᵥ g) = 0."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Adds the absent `mainTheorems` array for `law-of-cosines-oq-07-oq-02-oq-01` from `Proofs/LawOfCosinesOQ07OQ02OQ01.lean`: `leibniz_centroid` (Leibniz identity at the centroid), `leibniz_identity` (general balanced form), `centroid_sum_sq`, and `centroid₃_balance`. Additive single-field change; meta parses, under cap.