### PR TITLE
Fix: picks-theorem leanFile.axiomCount should be 0 (no literal axioms)

### DIFF
--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -243,7 +243,7 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 503,
     "sorries": 0,
     "path": "Proofs/PicksTheorem.lean",


### PR DESCRIPTION
## Fix

Correct `leanFile.axiomCount` for `picks-theorem` from `1` to `0`.

## Evidence

`proofs/Proofs/PicksTheorem.lean` contains **zero literal `axiom` declarations** (verified by grep for every declaration form, including `noncomputable axiom`). The lone assumption is **structure-encoded** in `SimpleLatticePolygon.pick_relation` (the Pick's-formula field, lines 113–120), and the main result `picks_theorem` is a genuine `theorem` proved from that field.

Per the Axiom Integrity Policy (CLAUDE.md):
> `leanFile.axiomCount` still counts only literal `axiom` declarations, so it may legitimately read 0 while `meta.axiomCount` is 1.

**Before**: `leanFile.axiomCount: 1` (no literal axiom exists in the file)
**After**: `leanFile.axiomCount: 0`

`meta.axiomCount` remains `1` (correctly counting the structure-encoded `pick_relation` assumption); `status: "axiomatized"` / `badge: "axiom"` are unchanged and correct.

---
Automated fix by lean-mechanic agent.