### PR TITLE
Enrich Erdős #1026 OQ-05: cover file docstring, fix section endLine

### DIFF
--- a/src/data/proofs/erdos-1026-oq-05/annotations.json
+++ b/src/data/proofs/erdos-1026-oq-05/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "erdos-1026-oq-05",
+    "range": {
+      "startLine": 3,
+      "endLine": 41
+    },
+    "type": "context",
+    "title": "From single monotonic subsequences to monotonic decompositions",
+    "content": "Erdős–Szekeres guarantees a single long monotonic subsequence; OQ-05 asks instead how many monotonic pieces are needed to cover the whole sequence — a monotonic decomposition, the object of Hanani's 1957 theorem. The parent Erdos1026Problem.lean only states the MonotonicDecomposition structure; Hanani's (√2 + o(1))√n bound lives in a comment. This file settles the elementary lower-bound (Mirsky/Dilworth) half axiom-free: any decomposition into monotonic parts satisfies n ≤ numParts · max(LIS, LDS). Because the longest monotone run is only ≈ √n on the extremal Erdős–Szekeres sequences, this forces numParts ≳ √n. The matching constructive O(√n) upper bound is stated but left open. The interface is re-stated locally rather than imported, since the parent depends on Archive.Wiedijk100Theorems.",
+    "mathContext": "$n \\le \\mathrm{numParts}\\cdot\\max(\\mathrm{LIS}(\\mathrm{seq}),\\mathrm{LDS}(\\mathrm{seq}))$; on extremal sequences $\\max(\\mathrm{LIS},\\mathrm{LDS})\\approx\\sqrt n$ forces $\\mathrm{numParts}\\gtrsim\\sqrt n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "monotonic decomposition",
+      "Erdős–Szekeres theorem",
+      "Hanani's theorem",
+      "Mirsky/Dilworth duality"
+    ],
+    "prerequisites": [
+      "monotonic subsequences",
+      "longest increasing/decreasing subsequence"
+    ]
+  },
+  {
     "id": "monotonic-interface",
     "proofId": "erdos-1026-oq-05",
     "range": {

--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -48,6 +48,14 @@
   },
   "sections": [
     {
+      "id": "overview-docstring",
+      "title": "Problem framing and imports",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "File docstring: Erdős #1026 and OQ-05's extension from single monotonic subsequences to monotonic decompositions (Hanani 1957). States the goal — the Mirsky/Dilworth lower-bound half n ≤ numParts · max(LIS, LDS) — and explains why the Subsequence/LIS/LDS/MonotonicDecomposition interface is re-stated rather than imported (the parent Erdos1026Problem.lean depends on Archive.Wiedijk100Theorems). Single `import Mathlib`.",
+      "mathContext": "Goal: $n \\le \\mathrm{numParts}\\cdot\\max(\\mathrm{LIS},\\mathrm{LDS})$, the lower-bound side of Hanani's $(\\sqrt2+o(1))\\sqrt n$ decomposition theorem."
+    },
+    {
       "id": "subsequence-interface",
       "title": "The Subsequence Interface and Monotonicity",
       "startLine": 42,
@@ -75,7 +83,7 @@
       "id": "existence-bracket",
       "title": "Existence of a Decomposition and the Bracket",
       "startLine": 167,
-      "endLine": 187,
+      "endLine": 184,
       "summary": "fin_one_strictMono: any function out of Fin 1 is vacuously strictly monotone. singletonDecomposition: splitting into n singleton parts is a valid monotonic decomposition, so the class is nonempty and numParts ≤ n. Together with the lower bound this brackets the optimal number of parts in [n / max(LIS, LDS), n].",
       "mathContext": "Optimal $\\mathrm{numParts} \\in [\\,n/\\max(\\mathrm{LIS},\\mathrm{LDS}),\\; n\\,]$."
     }


### PR DESCRIPTION
## Enrichment pass — erdos-1026-oq-05

**Gaps fixed:**
1. **Uncovered file head.** Every `section` and every annotation began at line 42+, leaving the substantial file docstring (lines 1–41) — which frames the Erdős–Szekeres → monotonic-decomposition extension, Hanani's theorem, and the Mirsky/Dilworth lower bound `n ≤ numParts · max(LIS, LDS)` — with no coverage. Added a `Problem framing and imports` section (1–41) and a matching `ann-overview` annotation (type `context`, with `mathContext`).
2. **Data-accuracy bug.** The final section's `endLine` was 187 on a 184-line file; corrected to 184.

Now 5 sections / 5 annotations covering the whole file. meta.json 14.8 KB (well under caps); no content deleted. Validated by the gallery enrichment build step (no errors reported for this entry).