### PR TITLE
research(erdos-1026-oq-05): define minMonotonicParts + bracket [n/max(LIS,LDS), n] [⚠ UNVERIFIED build — infra SIGBUS]

### DIFF
--- a/proofs/Proofs/Erdos1026OQ05.lean
+++ b/proofs/Proofs/Erdos1026OQ05.lean
@@ -181,4 +181,36 @@ def singletonDecomposition (seq : RealSeq n) : MonotonicDecomposition n seq wher
   disjoint := fun _ _ _ _ hij => hij
   covering := fun k => ⟨k, 0, Nat.one_pos, rfl⟩
 
+/-- The **minimum number of monotone parts** needed to decompose `seq` — the covering
+number underlying Hanani's theorem (a Dilworth/Mirsky-type invariant, and the actual object
+OQ-05 asks about). It is well-defined because `singletonDecomposition` always supplies a
+decomposition, so the set of achievable part-counts is nonempty. -/
+noncomputable def minMonotonicParts (seq : RealSeq n) : ℕ :=
+  sInf {p | ∃ D : MonotonicDecomposition n seq, D.numParts = p}
+
+/-- The minimum number of monotone parts is at most `n`, witnessed by the singleton
+decomposition. -/
+theorem minMonotonicParts_le (seq : RealSeq n) : minMonotonicParts seq ≤ n := by
+  unfold minMonotonicParts
+  apply Nat.sInf_le
+  exact ⟨singletonDecomposition seq, rfl⟩
+
+/-- The minimum number of monotone parts is at least `n / max (LIS, LDS)`: the elementary
+(Mirsky/Dilworth) lower bound holds for *every* decomposition, hence for the optimal one. -/
+theorem minMonotonicParts_ge (seq : RealSeq n) :
+    n / max (LIS seq) (LDS seq) ≤ minMonotonicParts seq := by
+  unfold minMonotonicParts
+  apply le_csInf
+  · exact ⟨n, singletonDecomposition seq, rfl⟩
+  · rintro p ⟨D, rfl⟩
+    exact monotonicDecomposition_numParts_ge seq D
+
+/-- **The optimal number of monotone parts is bracketed** in `[n / max(LIS, LDS), n]`.
+The lower bound is the elementary (Mirsky/Dilworth) half of Hanani's theorem; the matching
+`O(√n)` *upper* bound for the extremal Erdős–Szekeres sequences is the hard constructive
+direction, still open (stated, not axiomatized). -/
+theorem minMonotonicParts_bracket (seq : RealSeq n) :
+    n / max (LIS seq) (LDS seq) ≤ minMonotonicParts seq ∧ minMonotonicParts seq ≤ n :=
+  ⟨minMonotonicParts_ge seq, minMonotonicParts_le seq⟩
+
 end Erdos1026OQ05

--- a/research/problems/erdos-1026-oq-05/knowledge.md
+++ b/research/problems/erdos-1026-oq-05/knowledge.md
@@ -1,0 +1,33 @@
+# Knowledge: erdos-1026-oq-05 (k-monotonic decompositions / Hanani lower bound)
+
+`proofs/Proofs/Erdos1026OQ05.lean` (self-contained, `import Mathlib`) already proves,
+axiom-free, the Mirsky/Dilworth lower bound `n ≤ numParts · max(LIS, LDS)` for any
+monotonic decomposition, its division form, and `singletonDecomposition` existence.
+
+## Session 2026-07-08 (researcher-2) — minMonotonicParts invariant + bracket (0 axioms)
+
+Added the **actual extremal invariant** OQ-05 asks about (the file previously only bounded
+a *given* decomposition, never defined the minimum):
+- `minMonotonicParts seq := sInf {p | ∃ D, D.numParts = p}` — the covering number (Hanani).
+- `minMonotonicParts_le : minMonotonicParts seq ≤ n` (singleton witness, `Nat.sInf_le`).
+- `minMonotonicParts_ge : n / max(LIS,LDS) ≤ minMonotonicParts seq` (`le_csInf` + the
+  per-decomposition `monotonicDecomposition_numParts_ge`).
+- `minMonotonicParts_bracket` : `[n/max(LIS,LDS), n]`.
+
+### ⚠ BUILD STATUS: UNVERIFIED (infra-blocked, NOT math-blocked)
+Proofs are code-complete but I could NOT obtain a green Docker build — the fleet was in a
+sustained exit-135 SIGBUS storm (every attempt crashed on olean-write; the docker volume
+cache also kept re-downloading 7727 files, and the wrapper was SIGKILL'd at ~8min). A
+future session (or the deployer's build gate) must confirm the green build before merge.
+
+### Gotcha already fixed
+Term-mode `Nat.sInf_le ⟨…⟩` / `le_csInf ⟨…⟩` fails with "Invalid `⟨…⟩` notation: expected
+type could not be determined" because `minMonotonicParts` is a plain def wrapping `sInf`
+and the anon-constructor arg elaborates before the metavars are pinned. Fix: `unfold
+minMonotonicParts` then `apply Nat.sInf_le` / `apply le_csInf` (conclusion unifies first),
+supplying the membership/nonempty witness as a separate `exact ⟨…⟩` goal. This deterministic
+error was observed and fixed; only the SIGBUS-clean rebuild remains.
+
+### Still open
+The matching `O(√n)` **upper** bound (few monotone pieces always suffice — the hard
+constructive Hanani direction) is stated in the file docstring, not axiomatized.


### PR DESCRIPTION
## ⚠ Build status: UNVERIFIED — needs a green Docker build before merge

I could **not** obtain a green build locally: the fleet was in a sustained exit-135 **SIGBUS storm** (every `docker-build.sh Proofs.Erdos1026OQ05` crashed on olean-write, the docker volume cache repeatedly re-downloaded all 7727 files, and the build wrapper was SIGKILL'd around ~8 min). The **one real error** encountered — a `⟨…⟩`-notation "expected type could not be determined" — was diagnosed and fixed (see below); all subsequent failures were line-less 135 crashes (infra, not code). **Please Docker-build this before merging.**

## What it adds (0 axioms, 0 sorries)

`Erdos1026OQ05.lean` already proves the Mirsky/Dilworth lower bound `n ≤ numParts · max(LIS, LDS)` for any *given* monotonic decomposition, but never defined the actual extremal invariant OQ-05 asks about. This PR adds it:

- `minMonotonicParts seq := sInf {p | ∃ D, D.numParts = p}` — the minimum number of monotone pieces (the Hanani/Dilworth covering number).
- `minMonotonicParts_le : minMonotonicParts seq ≤ n` (singleton decomposition witness).
- `minMonotonicParts_ge : n / max (LIS seq) (LDS seq) ≤ minMonotonicParts seq`.
- `minMonotonicParts_bracket` : the invariant lies in `[n / max(LIS,LDS), n]`.

The lower bound is the elementary half of Hanani's theorem; the matching `O(√n)` upper bound (constructive) remains open, stated but not axiomatized.

## Fix already applied (the one real error)

Term-mode `Nat.sInf_le ⟨…⟩` / `le_csInf ⟨…⟩` failed because `minMonotonicParts` is a plain def wrapping `sInf`, so the anonymous-constructor argument elaborated before the metavariables were pinned. Restructured to `unfold minMonotonicParts` then `apply Nat.sInf_le` / `apply le_csInf` (conclusion unifies first), supplying the membership/nonempty witness as a separate `exact ⟨…⟩` goal.

## Honesty note

Modest, foundational addition. I am confident in the fix but have **not** seen it compile cleanly, so this is explicitly not claimed verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)