### PR TITLE
research(shannon-awgn-oq-02-oq-02): VERIFIED sharp necessity of variance additivity

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -171,4 +171,64 @@ theorem awgn_multisymbol_power_of_uncorrelated [IsProbabilityMeasure μ] {ι : T
   refine Finset.sum_congr rfl fun i hi => ?_
   exact (second_moment_eq_variance (hW i hi) (hmean i hi)).symm
 
+/-!
+### Sharp necessity: what is the *exact* condition for power to add?
+
+The results above show that vanishing pairwise covariances are **sufficient** for the
+variance (equivalently, zero-mean power) to add.  Are they also **necessary**?  The
+Bienaymé expansion `Var[∑ Wᵢ] = ∑ᵢ ∑ⱼ cov[Wᵢ, Wⱼ]` (`variance_sum'`) answers this
+exactly: peeling off the diagonal `cov[Wᵢ, Wᵢ] = Var[Wᵢ]` leaves
+
+    Var[∑_{i ∈ s} Wᵢ] = ∑_{i ∈ s} Var[Wᵢ]  +  ∑_{i ∈ s} ∑_{j ∈ s, j ≠ i} cov[Wᵢ, Wⱼ],
+
+so additivity of variance holds **iff the total off-diagonal covariance vanishes** — a
+condition strictly weaker than pairwise uncorrelatedness (the individual covariances may
+cancel in aggregate without each being zero).  Thus, for a block of `n ≥ 3` contributions,
+pairwise uncorrelatedness is sufficient but *not* necessary for the powers to add; only
+the aggregate off-diagonal cancellation is.  For the two-symbol case the off-diagonal sum
+is `2·cov[W₀, W₁]`, so there additivity holds **iff** the single covariance is zero —
+uncorrelatedness is then exactly necessary and sufficient.
+-/
+
+/-- **Exact condition for variance additivity (sharp necessity).**  For any finite family
+of square-integrable random variables, the variance of the sum equals the sum of the
+variances *if and only if* the total off-diagonal covariance vanishes:
+
+    Var[∑_{i ∈ s} Wᵢ] = ∑_{i ∈ s} Var[Wᵢ]  ↔  ∑_{i ∈ s} ∑_{j ∈ s.erase i} cov[Wᵢ, Wⱼ] = 0.
+
+This is the sharp converse to `variance_sum_of_pairwise_uncorrelated`: pairwise
+uncorrelatedness (`cov[Wᵢ, Wⱼ] = 0` for all `i ≠ j`) forces the double sum to be zero and
+so is *sufficient*, but the identity holds under the strictly weaker hypothesis that the
+off-diagonal covariances merely *cancel in aggregate*. -/
+theorem variance_sum_eq_iff_offDiag_covariance_zero [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ) :
+    Var[∑ i ∈ s, W i; μ] = ∑ i ∈ s, Var[W i; μ] ↔
+      ∑ i ∈ s, ∑ j ∈ s.erase i, cov[W i, W j; μ] = 0 := by
+  have hsplit : ∀ i ∈ s, ∑ j ∈ s, cov[W i, W j; μ]
+      = Var[W i; μ] + ∑ j ∈ s.erase i, cov[W i, W j; μ] := by
+    intro i hi
+    rw [← Finset.add_sum_erase s (fun j => cov[W i, W j; μ]) hi,
+      covariance_self (hW i hi).aemeasurable]
+  have key : ∑ i ∈ s, ∑ j ∈ s, cov[W i, W j; μ]
+      = (∑ i ∈ s, Var[W i; μ]) + ∑ i ∈ s, ∑ j ∈ s.erase i, cov[W i, W j; μ] := by
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl hsplit
+  rw [variance_sum' hW, key]
+  constructor <;> intro h <;> linarith
+
+/-- **Two-symbol sharp boundary.**  For a *pair* of square-integrable contributions the
+output powers add if and only if the two are uncorrelated:
+
+    Var[W₀ + W₁] = Var[W₀] + Var[W₁]  ↔  cov[W₀, W₁] = 0.
+
+Here uncorrelatedness is genuinely *necessary* (not merely sufficient), because the single
+off-diagonal covariance cannot cancel against anything.  This is the exact second-order
+condition behind the two-term AWGN identity `E[(X + Z)²] = E[X²] + E[Z²]` of the parent
+file. -/
+theorem variance_add_eq_iff_covariance_zero [IsFiniteMeasure μ] {W₀ W₁ : Ω → ℝ}
+    (h₀ : MemLp W₀ 2 μ) (h₁ : MemLp W₁ 2 μ) :
+    Var[W₀ + W₁; μ] = Var[W₀; μ] + Var[W₁; μ] ↔ cov[W₀, W₁; μ] = 0 := by
+  rw [variance_add h₀ h₁]
+  constructor <;> intro h <;> linarith
+
 end ShannonAWGNMultiSymbolPower

--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -201,7 +201,7 @@ uncorrelatedness (`cov[Wᵢ, Wⱼ] = 0` for all `i ≠ j`) forces the double sum
 so is *sufficient*, but the identity holds under the strictly weaker hypothesis that the
 off-diagonal covariances merely *cancel in aggregate*. -/
 theorem variance_sum_eq_iff_offDiag_covariance_zero [IsFiniteMeasure μ] {ι : Type*}
-    {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ) :
+    [DecidableEq ι] {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ) :
     Var[∑ i ∈ s, W i; μ] = ∑ i ∈ s, Var[W i; μ] ↔
       ∑ i ∈ s, ∑ j ∈ s.erase i, cov[W i, W j; μ] = 0 := by
   have hsplit : ∀ i ∈ s, ∑ j ∈ s, cov[W i, W j; μ]

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "shannon-channel-coding-awgn-oq-02-oq-02",
   "slug": "shannon-channel-coding-awgn-oq-02-oq-02",
   "title": "Multi-Symbol AWGN Output Power E[(∑Wᵢ)²] = ∑E[Wᵢ²] from the Variance of a Pairwise-Independent Sum",
-  "description": "Generalizes the parent two-term AWGN output-power identity E[(X+Z)²] = E[X²] + E[Z²] to a finite block of symbols: for pairwise-independent, zero-mean, square-integrable contributions Wᵢ (i ∈ s), the aggregate output power adds, E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The proof is the variance-of-a-sum (Bienaymé) identity for pairwise-independent families — ProbabilityTheory.IndepFun.variance_sum, where the vanishing pairwise covariances collapse the double sum to the diagonal — specialized to zero mean via E[W²] = Var[W] (ProbabilityTheory.variance_eq_sub). Pairwise (not mutual) independence already suffices. 113 lines, 5 theorems, 0 axioms, 0 sorries.",
+  "description": "Generalizes the parent two-term AWGN output-power identity E[(X+Z)²] = E[X²] + E[Z²] to a finite block of symbols: for pairwise-independent, zero-mean, square-integrable contributions Wᵢ (i ∈ s), the aggregate output power adds, E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The proof is the variance-of-a-sum (Bienaymé) identity for pairwise-independent families — ProbabilityTheory.IndepFun.variance_sum, where the vanishing pairwise covariances collapse the double sum to the diagonal — specialized to zero mean via E[W²] = Var[W] (ProbabilityTheory.variance_eq_sub). Pairwise (not mutual) independence already suffices. 234 lines, 10 theorems, 0 axioms, 0 sorries.",
   "leanFile": {
     "imports": [
       "Mathlib"
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 174,
+    "lineCount": 234,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -149,7 +149,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The multi-symbol AWGN output-power identity E[(∑_{i∈s} Wᵢ)²] = ∑_{i∈s} E[Wᵢ²] is derived for arbitrary finite blocks of pairwise-independent, zero-mean, square-integrable contributions. The Bienaymé variance-of-a-sum law (IndepFun.variance_sum) gives Var[∑ Wᵢ] = ∑ Var[Wᵢ]; the aggregate is again zero-mean (sum_mean_zero via integral_finset_sum), so for zero-mean signals the second moment equals the variance (variance_eq_sub), yielding the block identity (awgn_multisymbol_power) and its named-power form ∑ Pᵢ (awgn_multisymbol_output_power). 113 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "summary": "The multi-symbol AWGN output-power identity E[(∑_{i∈s} Wᵢ)²] = ∑_{i∈s} E[Wᵢ²] is derived for arbitrary finite blocks of pairwise-independent, zero-mean, square-integrable contributions. The Bienaymé variance-of-a-sum law (IndepFun.variance_sum) gives Var[∑ Wᵢ] = ∑ Var[Wᵢ]; the aggregate is again zero-mean (sum_mean_zero via integral_finset_sum), so for zero-mean signals the second moment equals the variance (variance_eq_sub), yielding the block identity (awgn_multisymbol_power) and its named-power form ∑ Pᵢ (awgn_multisymbol_output_power). 234 lines, 10 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
     "implications": "This lifts the parent's two-term output-power identity to n-symbol blocks, exposing that (a) pairwise — not mutual — independence already suffices for powers to add, and (b) the zero-mean assumption is what identifies power with variance, applied uniformly to the aggregate and each summand. The Finset formulation delivers the block-power budget as a single reusable identity for multi-symbol AWGN power constraints."
   },
   "crossReferences": [
@@ -180,5 +180,7 @@
       "description": "Standard reference for AWGN channel capacity and the additive output-power relation for independent contributions."
     }
   ],
-  "sorries": []
+  "sorries": [],
+  "lineCount": 234,
+  "theoremCount": 10
 }

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,17 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + SHARPENED (VERIFIED 0 sorry/0 axiom, 3.7s Docker, 7743 jobs): the multi-symbol AWGN output-power identity now holds under pairwise UNCORRELATEDNESS (vanishing pairwise covariances), strictly weaker than the pairwise independence of the original theorems and of Mathlib IndepFun.variance_sum. Identifies the exact second-order hypothesis behind Bienaymé.",
+    "progressSummary": "PROGRESS: sharp necessity of variance additivity VERIFIED (10 thm, 0/0). Necessity direction (off-diagonal cancellation) now formalized alongside sufficiency.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
-      "awgn_multisymbol_power_of_uncorrelated (:165): E[(∑Wi)²]=∑E[Wi²] under pairwise-uncorrelated + zero-mean, strengthening awgn_multisymbol_power."
+      "awgn_multisymbol_power_of_uncorrelated (:165): E[(∑Wi)²]=∑E[Wi²] under pairwise-uncorrelated + zero-mean, strengthening awgn_multisymbol_power.",
+      "variance_sum_eq_iff_offDiag_covariance_zero (needs [DecidableEq ι] for s.erase): peel diagonal off Bienaymé via Finset.add_sum_erase + covariance_self, then Finset.sum_add_distrib to regroup; iff closed by linarith. ShannonChannelCodingAWGNOQ02OQ02.lean:203",
+      "variance_add_eq_iff_covariance_zero: two-symbol sharp boundary via Mathlib variance_add (Var[X+Y]=Var X+2cov+Var Y) + linarith. ShannonChannelCodingAWGNOQ02OQ02.lean:225"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
       "Mathlib gap: no Uncorrelated concept and no pairwise-uncorrelated variance-sum lemma — only variance_sum´ (always true, double sum) and IndepFun.variance_sum (independence). The uncorrelated version sits strictly between them and was missing.",
       "Proof recipe mirrors Mathlib IndepFun.variance_sum: rw[variance_sum´ hW]; Finset.sum_congr; collapse inner ∑j via Finset.sum_eq_single_of_mem i hi (fun j hj hji => huncor hi hj hji.symm); finish with covariance_self (hW i hi).aemeasurable. Replaces independence-derived covariance_eq_zero with the direct hypothesis.",
-      "For AWGN engineering: uncorrelated (not necessarily independent) signal+noise contributions still add in POWER — E[(∑Wi)²]=∑E[Wi²] for zero-mean pairwise-uncorrelated square-integrable terms."
+      "For AWGN engineering: uncorrelated (not necessarily independent) signal+noise contributions still add in POWER — E[(∑Wi)²]=∑E[Wi²] for zero-mean pairwise-uncorrelated square-integrable terms.",
+      "VERIFIED (0 sorry/0 axiom, Docker build clean): variance-of-sum additivity holds iff total off-diagonal covariance ∑ᵢ∑_{j∈s.erase i} cov[Wᵢ,Wⱼ]=0 — strictly weaker than pairwise-uncorrelatedness (covariances may cancel in aggregate). For n=2 the single off-diagonal term cannot cancel, so uncorrelatedness is exactly necessary and sufficient there."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0)."


### PR DESCRIPTION
## Summary

Verifies and completes the **sharp necessity** direction for the multi-symbol AWGN output-power problem (`shannon-channel-coding-awgn-oq-02-oq-02`). The prior session had committed these two theorems as `[UNVERIFIED]`; this PR fixes a missing typeclass binder, confirms a clean Docker build (0 sorry / 0 axiom), and reconciles stale meta counts.

## Mathematical content

Earlier work in this file proved that vanishing pairwise covariances are **sufficient** for variance (zero-mean power) to add. This PR pins down the exact condition:

- `variance_sum_eq_iff_offDiag_covariance_zero` — for any finite family of L² random variables,
  `Var[∑ᵢ Wᵢ] = ∑ᵢ Var[Wᵢ] ↔ ∑ᵢ ∑_{j∈s.erase i} cov[Wᵢ,Wⱼ] = 0`.
  Additivity holds **iff the total off-diagonal covariance vanishes** — strictly weaker than pairwise uncorrelatedness (individual covariances may cancel in aggregate).
- `variance_add_eq_iff_covariance_zero` — two-symbol sharp boundary: `Var[W₀+W₁] = Var[W₀]+Var[W₁] ↔ cov[W₀,W₁] = 0`. Here the single off-diagonal term cannot cancel against anything, so uncorrelatedness is genuinely necessary and sufficient.

Proof route: peel the diagonal off the Bienaymé expansion (`variance_sum'`) via `Finset.add_sum_erase` + `covariance_self`, regroup with `Finset.sum_add_distrib`, close the iff by `linarith`; two-symbol case uses Mathlib `variance_add`.

## Fix

`variance_sum_eq_iff_offDiag_covariance_zero` uses `s.erase i` and so requires `[DecidableEq ι]`, which was missing in the `[UNVERIFIED]` commit (`failed to synthesize DecidableEq ι`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingAWGNOQ02OQ02` → EXIT=0 (7743 jobs)
- 0 sorries, 0 `axiom` declarations, no `native_decide`
- Axioms: `propext`, `Classical.choice`, `Quot.sound` only
- meta reconciled to actual: 234 lines, 10 theorems (both `leanFile` and top-level blocks + prose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)