### PR TITLE
Fix: sync erdos-1026-oq-05 meta counts to Lean source

### DIFF
--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -21,12 +21,12 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 184,
+    "lineCount": 216,
     "assumptions": "None. The file introduces no axioms and no sorries; every theorem depends only on the standard foundational axioms propext / Classical.choice / Quot.sound. Only the lower-bound (Mirsky/Dilworth) direction of the decomposition problem is proved; the hard upper-bound direction of OQ-05 — that O(√n) monotone pieces always suffice (Hanani 1957) — is stated in prose as the remaining open direction, not assumed.",
     "dateAdded": "2026-07-08",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
-    "definitionCount": 9
+    "theoremCount": 12,
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Erdős Problem #1026 concerns monotonic subsequences. The Erdős–Szekeres theorem (1935) guarantees that every sequence of k²+1 distinct reals contains a monotonic subsequence of length k+1. Dually, Hanani (1957) showed the whole sequence can be partitioned into few monotonic subsequences — at most (√2 + o(1))√n of them — and the optimization variant studies the sums such pieces carry. The parent gallery formalization records the MonotonicDecomposition structure but proves no quantitative bound on the number of parts. This entry supplies the elementary lower bound that any such decomposition must obey.",
@@ -138,12 +138,12 @@
       "Mathlib"
     ],
     "namespace": "Erdos1026OQ05",
-    "lineCount": 184,
+    "lineCount": 216,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 12,
     "path": "Proofs/Erdos1026OQ05.lean",
     "sorries": 0,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "sorries": 0,
   "highlights": [


### PR DESCRIPTION
## Fix

Sync `meta.json` structural counts for `erdos-1026-oq-05` to match the actual Lean source (`proofs/Proofs/Erdos1026OQ05.lean`). Research PR #35758 added the `minMonotonicParts` definition plus 3 theorems (`minMonotonicParts_le`, `minMonotonicParts_ge`, `minMonotonicParts_bracket`) but did not re-sync the meta counts (it was shipped `[⚠ UNVERIFIED build — infra SIGBUS]`).

## Evidence

Actual source (`wc -l` + comment-stripped declaration count):
- lineCount: **216** (`wc -l`)
- theoremCount: **12** (theorem/lemma decls at lines 73,86,91,96,101,106,131,159,167,193,200,212 — line 37 is docstring prose, excluded)
- definitionCount: **10** (8 `def` + 2 `structure`; convention confirmed against last-verified commit a6b88c where 7 def + 2 struct → 9)

**Before**: lineCount=184, theoremCount=9, definitionCount=9 (stale, from pre-#35758 state)
**After**: lineCount=216, theoremCount=12, definitionCount=10

Both the `meta` block and the `leanFile` block were updated to stay consistent. `axiomCount`/`sorries` (0/0) already matched. Gallery data build + search-index checks pass.

---
Automated fix by lean-mechanic agent.