### PR TITLE
Erdős #79 companion: reduce K₄'s subgraph axiom to a concrete finite check (6→1)

### DIFF
--- a/proofs/Proofs/Erdos79Incomplete01.lean
+++ b/proofs/Proofs/Erdos79Incomplete01.lean
@@ -126,4 +126,142 @@ theorem K4_is_minimal_of_edgeDeleted
     isMinimallyNonLinear (completeGraphN 4) :=
   ⟨hsuper, K4_subgraphs_linear_of_edgeDeleted hdiamond⟩
 
+/- ## Making the finite check literal: the six named edges -/
+
+/-- Unfolding lemma for the complete-graph adjacency (definitional, but convenient
+    for `simp`). -/
+theorem completeGraphN_adj (n u v : ℕ) :
+    (completeGraphN n).Adj u v ↔ u ≠ v ∧ u < n ∧ v < n := Iff.rfl
+
+/-- Deleting the edge `{p,q}` is symmetric in `p` and `q`: `K₄ − {p,q} = K₄ − {q,p}`.
+    (The deletion predicate `¬((u=p∧v=q)∨(u=q∧v=p))` is symmetric under swapping
+    `p` and `q`, so the two graphs are literally equal.) -/
+theorem K4MinusEdge_comm (p q : ℕ) : K4MinusEdge p q = K4MinusEdge q p := by
+  ext u v
+  simp only [K4MinusEdge_adj]
+  tauto
+
+/-- **The finite check, made literal.**  The edge-deleted hypothesis
+    `hdiamond` — quantified over the (infinitely many, but adjacency-constrained)
+    pairs `p q` — is equivalent to the *explicit* six-fold conjunction over the
+    six edges `{0,1}, {0,2}, {0,3}, {1,2}, {1,3}, {2,3}` of K₄.  This is the
+    concrete finite check in its sharpest closed form: no quantifier over
+    `SimpleGraph ℕ` and no quantifier over vertices remains. -/
+theorem hdiamond_iff_six :
+    (∀ p q, (completeGraphN 4).Adj p q → isRamseySizeLinear (K4MinusEdge p q)) ↔
+      isRamseySizeLinear (K4MinusEdge 0 1) ∧ isRamseySizeLinear (K4MinusEdge 0 2) ∧
+      isRamseySizeLinear (K4MinusEdge 0 3) ∧ isRamseySizeLinear (K4MinusEdge 1 2) ∧
+      isRamseySizeLinear (K4MinusEdge 1 3) ∧ isRamseySizeLinear (K4MinusEdge 2 3) := by
+  constructor
+  · intro h
+    exact ⟨h 0 1 ⟨by decide, by decide, by decide⟩, h 0 2 ⟨by decide, by decide, by decide⟩,
+           h 0 3 ⟨by decide, by decide, by decide⟩, h 1 2 ⟨by decide, by decide, by decide⟩,
+           h 1 3 ⟨by decide, by decide, by decide⟩, h 2 3 ⟨by decide, by decide, by decide⟩⟩
+  · rintro ⟨h01, h02, h03, h12, h13, h23⟩ p q ⟨hne, hp, hq⟩
+    interval_cases p <;> interval_cases q <;>
+      first
+        | exact absurd rfl hne
+        | assumption
+        | (rw [K4MinusEdge_comm]; assumption)
+
+/- ## The sharp reduction: six edges to one, via edge-transitivity of K₄ -/
+
+/-- **Relabelling isomorphism.**  Any permutation `σ` of `ℕ` that preserves the
+    predicate `· < 4` (equivalently, permutes the vertex set `{0,1,2,3}` of K₄
+    among itself and fixes the rest) carries `K₄ − {p,q}` isomorphically onto
+    `K₄ − {σ p, σ q}`.  This is the mechanism behind the edge-transitivity of K₄:
+    all six diamonds are graph-isomorphic. -/
+noncomputable def diamondEquiv (σ : ℕ ≃ ℕ) (hσ : ∀ u, σ u < 4 ↔ u < 4) (p q : ℕ) :
+    K4MinusEdge p q ≃g K4MinusEdge (σ p) (σ q) where
+  toEquiv := σ
+  map_rel_iff' := by
+    intro a b
+    simp only [K4MinusEdge_adj, completeGraphN_adj, ne_eq,
+      EmbeddingLike.apply_eq_iff_eq, hσ]
+
+/-- A transposition of two vertices below 4 preserves the predicate `· < 4`. -/
+theorem swap_lt_four {a b : ℕ} (ha : a < 4) (hb : b < 4) (u : ℕ) :
+    (Equiv.swap a b) u < 4 ↔ u < 4 := by
+  rcases eq_or_ne u a with rfl | hua
+  · rw [Equiv.swap_apply_left]; omega
+  · rcases eq_or_ne u b with rfl | hub
+    · rw [Equiv.swap_apply_right]; omega
+    · rw [Equiv.swap_apply_of_ne_of_ne hua hub]
+
+/-- The `· < 4`-preserving property is closed under composition of permutations. -/
+theorem comp_lt_four {σ τ : Equiv.Perm ℕ}
+    (hσ : ∀ u, σ u < 4 ↔ u < 4) (hτ : ∀ u, τ u < 4 ↔ u < 4) (u : ℕ) :
+    (σ * τ) u < 4 ↔ u < 4 := by
+  rw [Equiv.Perm.mul_apply, hσ, hτ]
+
+/-- Convenience: the `· < 4`-preservation hypothesis for a single transposition. -/
+private theorem swap4 {a b : ℕ} (ha : a < 4) (hb : b < 4) :
+    ∀ u, (Equiv.swap a b) u < 4 ↔ u < 4 := fun u => swap_lt_four ha hb u
+
+/- The five relabelling isomorphisms carrying the reference diamond `K₄ − {0,1}`
+   onto each of the other five diamonds.  Each permutation sends `0 ↦ p`, `1 ↦ q`
+   while permuting `{0,1,2,3}` among itself — an explicit witness to S₄'s transitive
+   action on the edges of K₄. -/
+
+/-- `K₄ − {0,1} ≃g K₄ − {0,2}` via the transposition `(1 2)`. -/
+noncomputable def diamond_iso_02 : K4MinusEdge 0 1 ≃g K4MinusEdge 0 2 := by
+  have iso := diamondEquiv (Equiv.swap 1 2) (swap4 (by omega) (by omega)) 0 1
+  simpa only [show (Equiv.swap 1 2) 0 = 0 from by decide,
+    show (Equiv.swap 1 2) 1 = 2 from by decide] using iso
+
+/-- `K₄ − {0,1} ≃g K₄ − {0,3}` via the transposition `(1 3)`. -/
+noncomputable def diamond_iso_03 : K4MinusEdge 0 1 ≃g K4MinusEdge 0 3 := by
+  have iso := diamondEquiv (Equiv.swap 1 3) (swap4 (by omega) (by omega)) 0 1
+  simpa only [show (Equiv.swap 1 3) 0 = 0 from by decide,
+    show (Equiv.swap 1 3) 1 = 3 from by decide] using iso
+
+/-- `K₄ − {0,1} ≃g K₄ − {1,2}` via `(0 1)(1 2)` (a 3-cycle on `{0,1,2}`). -/
+noncomputable def diamond_iso_12 : K4MinusEdge 0 1 ≃g K4MinusEdge 1 2 := by
+  have iso := diamondEquiv (Equiv.swap 0 1 * Equiv.swap 1 2)
+    (fun u => comp_lt_four (swap4 (by omega) (by omega)) (swap4 (by omega) (by omega)) u) 0 1
+  simpa only [show ((Equiv.swap 0 1 * Equiv.swap 1 2 : Equiv.Perm ℕ)) 0 = 1 from by decide,
+    show ((Equiv.swap 0 1 * Equiv.swap 1 2 : Equiv.Perm ℕ)) 1 = 2 from by decide] using iso
+
+/-- `K₄ − {0,1} ≃g K₄ − {1,3}` via `(0 1)(1 3)`. -/
+noncomputable def diamond_iso_13 : K4MinusEdge 0 1 ≃g K4MinusEdge 1 3 := by
+  have iso := diamondEquiv (Equiv.swap 0 1 * Equiv.swap 1 3)
+    (fun u => comp_lt_four (swap4 (by omega) (by omega)) (swap4 (by omega) (by omega)) u) 0 1
+  simpa only [show ((Equiv.swap 0 1 * Equiv.swap 1 3 : Equiv.Perm ℕ)) 0 = 1 from by decide,
+    show ((Equiv.swap 0 1 * Equiv.swap 1 3 : Equiv.Perm ℕ)) 1 = 3 from by decide] using iso
+
+/-- `K₄ − {0,1} ≃g K₄ − {2,3}` via `(0 2)(1 3)`. -/
+noncomputable def diamond_iso_23 : K4MinusEdge 0 1 ≃g K4MinusEdge 2 3 := by
+  have iso := diamondEquiv (Equiv.swap 0 2 * Equiv.swap 1 3)
+    (fun u => comp_lt_four (swap4 (by omega) (by omega)) (swap4 (by omega) (by omega)) u) 0 1
+  simpa only [show ((Equiv.swap 0 2 * Equiv.swap 1 3 : Equiv.Perm ℕ)) 0 = 2 from by decide,
+    show ((Equiv.swap 0 2 * Equiv.swap 1 3 : Equiv.Perm ℕ)) 1 = 3 from by decide] using iso
+
+/-- **The sharpest reduction: six edges to one.**  Granting only the natural
+    meta-principle that Ramsey size-linearity is invariant under graph isomorphism
+    (`hcongr` — *not* an axiom, but an explicit hypothesis: over the opaque
+    `ramseyNumber` it cannot be derived), the parent's sweeping subgraph axiom
+    `K4_subgraphs_linear` follows from size-linearity of a **single** diamond
+    `K₄ − {0,1}`.  This is because all six diamonds are graph-isomorphic
+    (`diamond_iso_02 … diamond_iso_23`): K₄ is edge-transitive. -/
+theorem K4_subgraphs_linear_of_single
+    (hcongr : ∀ G G' : SimpleGraph ℕ, (G ≃g G') → isRamseySizeLinear G → isRamseySizeLinear G')
+    (h01 : isRamseySizeLinear (K4MinusEdge 0 1)) :
+    ∀ H : SimpleGraph ℕ, isProperSubgraph H (completeGraphN 4) → isRamseySizeLinear H := by
+  apply K4_subgraphs_linear_of_edgeDeleted
+  rw [hdiamond_iff_six]
+  exact ⟨h01,
+    hcongr _ _ diamond_iso_02 h01, hcongr _ _ diamond_iso_03 h01,
+    hcongr _ _ diamond_iso_12 h01, hcongr _ _ diamond_iso_13 h01,
+    hcongr _ _ diamond_iso_23 h01⟩
+
+/-- K₄ is minimally non-Ramsey-size-linear from the **single-diamond** hypothesis:
+    it suffices that K₄ is superlinear, that size-linearity is iso-invariant, and
+    that the one diamond `K₄ − {0,1}` is size-linear. -/
+theorem K4_is_minimal_of_single
+    (hsuper : isRamseySizeSuperlinear (completeGraphN 4))
+    (hcongr : ∀ G G' : SimpleGraph ℕ, (G ≃g G') → isRamseySizeLinear G → isRamseySizeLinear G')
+    (h01 : isRamseySizeLinear (K4MinusEdge 0 1)) :
+    isMinimallyNonLinear (completeGraphN 4) :=
+  ⟨hsuper, K4_subgraphs_linear_of_single hcongr h01⟩
+
 end Erdos79Incomplete01

--- a/src/data/proofs/erdos-79-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-79-incomplete-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-79inc-header",
+    "proofId": "erdos-79-incomplete-01",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "Goal: reduce K₄'s sweeping subgraph axiom to a finite check",
+    "content": "The parent file `Proofs/Erdos79Problem.lean` keeps the Ramsey number `ramseyNumber` opaque and axiomatizes `K4_subgraphs_linear`: *every* proper subgraph of K₄ is Ramsey size-linear — a hypothesis quantified over the infinitely many `H : SimpleGraph ℕ` sitting below K₄.\n\nOver the opaque `ramseyNumber` no specific graph's size-linearity can ever be derived, so the only mathematics available is combinatorial: reducing the SHAPE of that quantifier. This companion does exactly that, in two provable steps — first to a literal six-fold conjunction, then (via K₄'s edge-transitivity) to a single graph.\n\n`K4MinusEdge p q` is the complete graph on {0,1,2,3} with the single unordered edge {p,q} deleted — the 'diamond' K₄⁻ when {p,q} is a genuine edge, a maximal proper subgraph of K₄.",
+    "mathContext": "$K_4 - e$ is the diamond: two triangles glued along an edge, the maximal proper subgraph of $K_4$. Every proper subgraph $H \\subsetneq K_4$ omits some edge, hence $H \\le K_4 - e$ for some edge $e$.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey size-linear graph", "complete graph K₄", "edge deletion", "proper subgraph", "opaque parameter"],
+    "prerequisites": ["graph theory", "Ramsey theory", "subgraph order"]
+  },
+  {
+    "id": "ann-79inc-missing-edge",
+    "proofId": "erdos-79-incomplete-01",
+    "range": { "startLine": 68, "endLine": 99 },
+    "type": "theorem",
+    "title": "Every proper subgraph embeds in an edge-deleted K₄",
+    "content": "`properSubgraph_missing_edge`: a proper subgraph H ⊊ K₄ must fail to contain some edge of K₄ — otherwise it would contain every edge and, being ≤ K₄, would equal K₄ (contradicting properness). `properSubgraph_le_K4MinusEdge` packages this: H then sits inside the edge-deleted graph K₄−e for the omitted edge e. `K4MinusEdge_properSubgraph` confirms each K₄−e is itself a proper subgraph of K₄ (it has lost the edge {p,q}).\n\nThis is the combinatorial heart of the first reduction: the infinite family of proper subgraphs is covered by the six edge-deleted graphs.",
+    "mathContext": "If $H \\le K_4$ contains all six edges of $K_4$ then $H = K_4$ by antisymmetry of $\\le$; contrapositive gives an omitted edge $\\{p,q\\}$, and $H \\le K_4 - \\{p,q\\}$.",
+    "significance": "critical",
+    "relatedConcepts": ["antisymmetry of subgraph order", "edge cover", "maximal proper subgraph"],
+    "prerequisites": ["partial order on graphs", "le_antisymm"]
+  },
+  {
+    "id": "ann-79inc-edgedeleted",
+    "proofId": "erdos-79-incomplete-01",
+    "range": { "startLine": 101, "endLine": 127 },
+    "type": "theorem",
+    "title": "First reduction: ∀ subgraphs ⟶ the six diamonds (uses heredity axiom)",
+    "content": "`K4_subgraphs_linear_of_edgeDeleted`: with the parent's heredity axiom `ramsey_linear_hereditary` (size-linearity passes to subgraphs), the sweeping ∀-over-all-proper-subgraphs axiom follows from size-linearity of just the six edge-deleted graphs K₄−e. Given H, take the diamond K₄−e containing it: if H equals that diamond use the hypothesis directly, else H is a proper subgraph of the diamond and heredity applies.\n\nThis is the first place an imported axiom is used — which is why the entry as a whole is marked *axiomatized* — but the reduction of the quantifier is itself fully constructive.",
+    "mathContext": "$\\forall H \\subsetneq K_4,\\ \\mathrm{lin}(H)$ follows from $\\bigwedge_{e} \\mathrm{lin}(K_4-e)$ together with heredity $\\mathrm{lin}(G) \\wedge H \\subsetneq G \\Rightarrow \\mathrm{lin}(H)$.",
+    "significance": "key",
+    "relatedConcepts": ["hereditary property", "ramsey_linear_hereditary", "case split", "imported axiom"],
+    "prerequisites": ["heredity of graph properties"]
+  },
+  {
+    "id": "ann-79inc-literal-six",
+    "proofId": "erdos-79-incomplete-01",
+    "range": { "startLine": 129, "endLine": 172 },
+    "type": "theorem",
+    "title": "The finite check, made literal: hdiamond_iff_six",
+    "content": "`K4MinusEdge_comm`: deleting {p,q} is symmetric in its endpoints, so `K4MinusEdge p q = K4MinusEdge q p` — a literal graph EQUALITY (the deletion predicate `¬((u=p∧v=q)∨(u=q∧v=p))` is symmetric), proved by `ext` + `tauto`.\n\n`hdiamond_iff_six`: the edge-deleted hypothesis — quantified over the adjacency-constrained pairs p,q — is equivalent to the EXPLICIT six-fold conjunction over the edges {0,1},{0,2},{0,3},{1,2},{1,3},{2,3}. Forward is instantiation, each adjacency discharged by `decide`. Backward runs `interval_cases p <;> interval_cases q`: the diagonal p=q contradicts the distinctness hypothesis, the six listed pairs match a conjunct directly, and the six reversed pairs are handled by rewriting with `K4MinusEdge_comm`. This is the 'concrete finite check' in closed form: no quantifier over graphs or vertices remains.",
+    "mathContext": "$\\big(\\forall p\\,q,\\ K_4.\\mathrm{Adj}\\,p\\,q \\to \\mathrm{lin}(K_4-\\{p,q\\})\\big) \\iff \\bigwedge_{\\{i,j\\}} \\mathrm{lin}(K_4-\\{i,j\\})$ over the six edges $\\{i,j\\} \\subseteq \\{0,1,2,3\\}$.",
+    "significance": "critical",
+    "relatedConcepts": ["interval_cases", "decide", "graph extensionality", "symmetry of edge deletion", "finite conjunction"],
+    "prerequisites": ["finite case analysis", "SimpleGraph.ext"]
+  },
+  {
+    "id": "ann-79inc-diamondEquiv",
+    "proofId": "erdos-79-incomplete-01",
+    "range": { "startLine": 174, "endLine": 205 },
+    "type": "definition",
+    "title": "The relabelling engine: permutations of ℕ that fix {0,1,2,3}",
+    "content": "`diamondEquiv σ hσ p q : K4MinusEdge p q ≃g K4MinusEdge (σ p) (σ q)`. Any permutation σ of ℕ that preserves the predicate `· < 4` (equivalently permutes the vertex set {0,1,2,3} of K₄ among itself, fixing the rest) induces a graph isomorphism between edge-deleted K₄'s. Adjacency is preserved because σ is injective (so σu ≠ σv ↔ u ≠ v and the deleted pair maps to the deleted pair) and respects `<4` by hypothesis; the whole `map_rel_iff'` obligation closes by a single `simp only`.\n\n`swap_lt_four` and `comp_lt_four` supply the `· < 4`-preservation: a transposition of two vertices <4 preserves it, and the property is closed under composition.",
+    "mathContext": "For $\\sigma \\in \\mathrm{Sym}(\\mathbb{N})$ with $\\sigma u < 4 \\iff u < 4$: $\\;(K_4 - \\{p,q\\}).\\mathrm{Adj}\\,u\\,v \\iff (K_4 - \\{\\sigma p, \\sigma q\\}).\\mathrm{Adj}\\,(\\sigma u)(\\sigma v)$, a graph isomorphism.",
+    "significance": "critical",
+    "relatedConcepts": ["graph isomorphism (≃g)", "Equiv.swap", "Equiv.Perm", "RelIso.map_rel_iff'", "vertex relabelling"],
+    "prerequisites": ["permutations", "graph isomorphisms", "injectivity"]
+  },
+  {
+    "id": "ann-79inc-edge-transitive",
+    "proofId": "erdos-79-incomplete-01",
+    "range": { "startLine": 206, "endLine": 244 },
+    "type": "theorem",
+    "title": "Edge-transitivity of K₄: five explicit relabelling isomorphisms",
+    "content": "The five isomorphisms `diamond_iso_02, diamond_iso_03, diamond_iso_12, diamond_iso_13, diamond_iso_23` carry the reference diamond K₄−{0,1} onto each of the other five diamonds, exhibiting S₄'s transitive action on the six edges of K₄. Each is `diamondEquiv` applied to an explicit permutation sending 0↦p, 1↦q: single transpositions (1 2), (1 3) for the edges sharing vertex 0, and products (0 1)(1 2), (0 1)(1 3), (0 2)(1 3) for the rest. The image vertices are computed by `decide`.\n\nThese are the witnesses that make the six-fold check collapse to a single diamond.",
+    "mathContext": "The automorphism group of $K_4$ is $S_4$, acting transitively on the $\\binom{4}{2}=6$ edges; hence all six diamonds $K_4 - e$ are pairwise graph-isomorphic. Each isomorphism is realised by an explicit $\\sigma \\in S_4$ with $\\sigma(\\{0,1\\}) = e$.",
+    "significance": "key",
+    "relatedConcepts": ["edge-transitive graph", "symmetric group S₄", "transitive group action", "transposition products"],
+    "prerequisites": ["group actions on graphs", "Equiv.swap arithmetic"]
+  },
+  {
+    "id": "ann-79inc-single",
+    "proofId": "erdos-79-incomplete-01",
+    "range": { "startLine": 246, "endLine": 267 },
+    "type": "theorem",
+    "title": "The sharp reduction: one diamond suffices",
+    "content": "`K4_subgraphs_linear_of_single`: granting only that Ramsey size-linearity is invariant under graph isomorphism — an EXPLICIT hypothesis `hcongr`, not an axiom, since over the opaque `ramseyNumber` it cannot be derived — the parent's entire subgraph axiom follows from size-linearity of the SINGLE diamond K₄−{0,1}. Proof: rewrite with `hdiamond_iff_six`, then transport size-linearity of K₄−{0,1} along the five isomorphisms via `hcongr`. `K4_is_minimal_of_single` packages K₄'s minimality from this single-diamond hypothesis (plus the superlinearity axiom).\n\nThe combinatorial content of K₄'s minimality is now fully isolated: what remains to assume is size-linearity of ONE graph and the natural meta-principle that size-linearity respects isomorphism.",
+    "mathContext": "Given $\\mathrm{lin}$ isomorphism-invariant and $\\mathrm{lin}(K_4 - \\{0,1\\})$, all six $\\mathrm{lin}(K_4-e)$ hold, hence (with heredity) $\\forall H \\subsetneq K_4,\\ \\mathrm{lin}(H)$.",
+    "significance": "critical",
+    "relatedConcepts": ["isomorphism invariance", "explicit hypothesis vs axiom", "minimally non-Ramsey-size-linear", "reduction to a representative"],
+    "prerequisites": ["graph isomorphism invariance", "the six-fold and heredity reductions above"]
+  }
+]

--- a/src/data/proofs/erdos-79-incomplete-01/index.ts
+++ b/src/data/proofs/erdos-79-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos79Incomplete01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos79Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos79Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos79Incomplete01Data: ProofData = {
+  proof: erdos79Incomplete01Proof,
+  annotations: erdos79Incomplete01Annotations,
+}

--- a/src/data/proofs/erdos-79-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-79-incomplete-01/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "erdos-79-incomplete-01",
+  "title": "Erdős #79 Companion: The Finite Check for K₄'s Minimality (Six Diamonds to One)",
+  "slug": "erdos-79-incomplete-01",
+  "description": "An axiom-free combinatorial companion to Erdős #79 that reduces the parent's sweeping subgraph hypothesis — 'every proper subgraph of K₄ is Ramsey size-linear', quantified over infinitely many graphs — first to a literal six-fold conjunction over K₄'s six edges, and then, using the proved edge-transitivity of K₄ (five explicit relabelling isomorphisms), to size-linearity of a SINGLE diamond K₄−e. The reduction to minimality invokes the parent's heredity axiom, and the six-to-one step is gated behind an explicit isomorphism-invariance hypothesis (not an axiom).",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/79",
+    "date": "2026-07-08",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos79Incomplete01.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "ramsey-size-linear",
+      "extremal-graph-theory",
+      "edge-transitivity",
+      "combinatorics"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 79,
+    "erdosUrl": "https://erdosproblems.com/79",
+    "erdosProblemStatus": "solved",
+    "axiomCount": 1,
+    "lineCount": 267,
+    "assumptions": "No `axiom` and no `sorry` are declared in this file (leanFile.axiomCount = 0, sorries = 0). The pure combinatorial results — `hdiamond_iff_six` (the literal six-fold reduction), the five relabelling isomorphisms `diamond_iso_02 … diamond_iso_23`, the relabelling engine `diamondEquiv`, `K4MinusEdge_comm`, `swap_lt_four`, `comp_lt_four` — are fully machine-checked and depend only on the foundational axioms propext / Classical.choice / Quot.sound. The reduction-to-minimality theorems (`K4_subgraphs_linear_of_edgeDeleted`, `K4_subgraphs_linear_of_single`, `K4_is_minimal_of_single`) additionally use the parent file's `ramsey_linear_hereditary` axiom (heredity of Ramsey size-linearity, imported from Erdos79Problem); this single imported assumption is why the entry is marked axiomatized. The six-to-one step is furthermore gated behind an EXPLICIT hypothesis `hcongr` (Ramsey size-linearity is invariant under graph isomorphism) — a stated hypothesis, not an axiom, which over the opaque `ramseyNumber` cannot be derived.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 14,
+    "definitionCount": 7,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #79 (Erdős–Faudree–Rousseau–Schelp) asks whether infinitely many graphs are minimally non-Ramsey-size-linear: not Ramsey size-linear themselves, yet all of whose proper subgraphs are. Wigderson (2024) proved infinitely many exist non-constructively; K₄ remains the only explicit example. The parent formalization `Proofs/Erdos79Problem.lean` keeps the Ramsey number `ramseyNumber` opaque and packages the two hard facts about K₄ as axioms: `K4_not_linear` (K₄ is superlinear) and the sweeping `K4_subgraphs_linear` (every proper subgraph of K₄ is size-linear, quantified over infinitely many `H : SimpleGraph ℕ`). This companion attacks the second axiom's SHAPE: over the opaque `ramseyNumber` no specific graph's size-linearity is derivable, but the combinatorial reduction of the quantifier structure is fully provable.",
+    "problemStatement": "The parent's sweeping hypothesis `∀ H, isProperSubgraph H (completeGraphN 4) → isRamseySizeLinear H` is equivalent (using heredity) to size-linearity of the six edge-deleted graphs K₄−e, which — by K₄'s edge-transitivity — reduces further to size-linearity of a single diamond K₄−{0,1}, granted only that size-linearity is invariant under graph isomorphism.",
+    "text": "Every proper subgraph of K₄ omits one of its six edges, hence embeds in an edge-deleted graph K₄−e ('the diamond'). With the parent's heredity axiom this collapses the ∀-over-all-subgraphs hypothesis to the six diamonds; the six diamonds are pairwise graph-isomorphic (K₄ is edge-transitive), so the check collapses to one. This companion supplies both collapses in Lean: the literal six-fold conjunction and the five explicit relabelling isomorphisms.",
+    "proofStrategy": "Two reductions. (1) `hdiamond_iff_six`: the edge-deleted hypothesis `∀ p q, (K₄).Adj p q → isRamseySizeLinear (K4MinusEdge p q)` is proved equivalent to the explicit conjunction over the six edges {0,1},{0,2},{0,3},{1,2},{1,3},{2,3}. Forward is instantiation (each adjacency by `decide`); backward is `interval_cases` over p,q<4, closing the diagonal by the distinctness hypothesis and the reversed pairs by `K4MinusEdge_comm` (the deletion predicate is symmetric in p,q, so K4MinusEdge p q = K4MinusEdge q p literally). (2) `K4_subgraphs_linear_of_single`: all six diamonds are graph-isomorphic. The engine `diamondEquiv σ hσ p q : K4MinusEdge p q ≃g K4MinusEdge (σ p) (σ q)` builds a graph isomorphism from any permutation σ of ℕ preserving the predicate `· < 4` (adjacency is preserved because σ is injective, respects `<4` by hypothesis, and the deleted pair maps to the deleted pair). The five relabellings from the reference diamond K₄−{0,1} to each other edge are exhibited explicitly as single transpositions (1 2), (1 3) and 3-cycle-type products (0 1)(1 2), (0 1)(1 3), (0 2)(1 3), with `· < 4`-preservation via `swap_lt_four` and `comp_lt_four`. Composing with the parent's heredity axiom and the literal six-fold form, the whole subgraph axiom follows from size-linearity of one diamond plus an isomorphism-invariance hypothesis `hcongr`.",
+    "keyInsights": [
+      "Over the opaque `ramseyNumber`, no specific graph's size-linearity is derivable — so the only mathematics available here is COMBINATORIAL: reducing the quantifier structure of the parent's sweeping axiom. This companion makes that reduction as sharp as possible.",
+      "The parent's ∀-over-infinitely-many-subgraphs hypothesis is equivalent to a LITERAL six-fold conjunction (`hdiamond_iff_six`): every proper subgraph omits an edge and hence embeds in one of exactly six edge-deleted graphs. This is the 'concrete finite check' in closed form — no quantifier over graphs or vertices remains.",
+      "K₄ is EDGE-TRANSITIVE: its automorphism group S₄ acts transitively on the six edges, so the six diamonds K₄−e are pairwise graph-isomorphic. This is proved here by five explicit relabelling isomorphisms, collapsing the six-fold check to a single diamond.",
+      "The relabelling engine `diamondEquiv` is reusable: ANY permutation of ℕ preserving `· < 4` induces a graph isomorphism between edge-deleted K₄'s — the mechanism behind edge-transitivity, isolated as a lemma.",
+      "The symmetry `K4MinusEdge p q = K4MinusEdge q p` is a literal graph EQUALITY (not merely an isomorphism), since the edge-deletion predicate is symmetric in its two endpoints — this is what lets `interval_cases` finish the backward direction without any isomorphism.",
+      "The six-to-one collapse is stated honestly: it is gated behind an EXPLICIT hypothesis that size-linearity is isomorphism-invariant, which over the opaque `ramseyNumber` is a genuine assumption, not a theorem — so no hidden axiom is smuggled in."
+    ],
+    "prerequisites": [
+      "Graph theory: simple graphs, subgraphs, complete graphs, graph isomorphisms",
+      "Permutations and transpositions (Equiv.swap, Equiv.Perm)",
+      "Ramsey size-linearity (as modelled in the parent Erdos79Problem file)",
+      "Finite case analysis (interval_cases, decide)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: K₄ with One Edge Removed",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Module docstring framing the goal: reduce the parent's sweeping `K4_subgraphs_linear` axiom to a concrete finite check. Defines K4MinusEdge p q — the complete graph on {0,1,2,3} with the single unordered edge {p,q} deleted (the 'diamond' when {p,q} is a real edge) — with its adjacency simp lemma and the containment K₄−e ≤ K₄."
+    },
+    {
+      "id": "missing-edge",
+      "title": "Every Proper Subgraph Omits an Edge",
+      "startLine": 68,
+      "endLine": 99,
+      "summary": "properSubgraph_missing_edge: a proper subgraph H ⊊ K₄ must fail to contain some edge of K₄ (else, being ≤ K₄, it would equal K₄). properSubgraph_le_K4MinusEdge: consequently H embeds in some edge-deleted K₄−e. K4MinusEdge_properSubgraph: each K₄−e is itself a proper subgraph of K₄."
+    },
+    {
+      "id": "edgedeleted-reduction",
+      "title": "First Reduction: ∀ H  ⟶  the Six Diamonds",
+      "startLine": 101,
+      "endLine": 127,
+      "summary": "K4_subgraphs_linear_of_edgeDeleted: using the parent's heredity axiom ramsey_linear_hereditary, the sweeping ∀-over-all-proper-subgraphs axiom follows from size-linearity of the six edge-deleted graphs. K4_is_minimal_of_edgeDeleted restates K₄'s minimality from this reduced hypothesis."
+    },
+    {
+      "id": "literal-six",
+      "title": "Making the Finite Check Literal",
+      "startLine": 129,
+      "endLine": 172,
+      "summary": "completeGraphN_adj (adjacency unfolding) and K4MinusEdge_comm (the deletion is symmetric in its endpoints, so K4MinusEdge p q = K4MinusEdge q p literally). hdiamond_iff_six: the edge-deleted hypothesis is equivalent to the explicit six-fold conjunction over the edges {0,1},{0,2},{0,3},{1,2},{1,3},{2,3} — the concrete finite check in closed form, proved by instantiation (forward) and interval_cases + K4MinusEdge_comm (backward)."
+    },
+    {
+      "id": "edge-transitivity",
+      "title": "Second Reduction: Six Diamonds to One (Edge-Transitivity)",
+      "startLine": 174,
+      "endLine": 244,
+      "summary": "diamondEquiv: any permutation of ℕ preserving `· < 4` induces a graph isomorphism K4MinusEdge p q ≃g K4MinusEdge (σ p) (σ q). swap_lt_four / comp_lt_four: transpositions of vertices <4 and their composites preserve `· < 4`. The five explicit relabelling isomorphisms diamond_iso_02 … diamond_iso_23 carry the reference diamond K₄−{0,1} onto each of the other five — witnessing S₄'s transitive action on the edges of K₄."
+    },
+    {
+      "id": "single-diamond",
+      "title": "The Sharp Reduction: One Diamond Suffices",
+      "startLine": 246,
+      "endLine": 267,
+      "summary": "K4_subgraphs_linear_of_single: granting only that Ramsey size-linearity is invariant under graph isomorphism (explicit hypothesis hcongr, not an axiom), the parent's subgraph axiom follows from size-linearity of the SINGLE diamond K₄−{0,1}, via the six-fold form and the five isomorphisms. K4_is_minimal_of_single packages K₄'s minimality from this single-diamond hypothesis."
+    }
+  ],
+  "conclusion": {
+    "summary": "This companion reduces the parent's sweeping subgraph hypothesis for Erdős #79 — 'every proper subgraph of K₄ is Ramsey size-linear', quantified over infinitely many graphs — to a concrete finite check, in two provable steps. First (`hdiamond_iff_six`), every proper subgraph omits one of K₄'s six edges and hence embeds in an edge-deleted graph K₄−e, collapsing the ∀-hypothesis (via the parent's heredity axiom) to a LITERAL six-fold conjunction. Second (`K4_subgraphs_linear_of_single`), the six diamonds K₄−e are pairwise graph-isomorphic — K₄ is edge-transitive — proved by five explicit relabelling isomorphisms built from a reusable engine `diamondEquiv`; granting an explicit isomorphism-invariance hypothesis this collapses the check to a SINGLE diamond.",
+    "implications": "The combinatorial content of the K₄ minimality claim is fully isolated from the (unformalizable, opaque) Ramsey-theoretic content: what remains to be assumed is size-linearity of ONE graph, K₄−{0,1}, plus the natural meta-principle that Ramsey size-linearity respects graph isomorphism. The relabelling engine `diamondEquiv` and the edge-transitivity witnesses are reusable for any edge-deletion argument on K₄, and the pattern (proper subgraph ⟶ finite family of maximal subgraphs ⟶ single representative up to symmetry) is the template for the analogous reduction on any vertex-/edge-transitive host graph, relevant to the search for further minimally non-Ramsey-size-linear graphs beyond K₄.",
+    "openQuestions": [
+      "Discharge the isomorphism-invariance hypothesis `hcongr` at the model level: prove that any reasonable constructive definition of `ramseyNumber` (replacing the opaque parameter) satisfies ramseyNumber (G) invariance under graph isomorphism, turning the six-to-one reduction into an unconditional theorem.",
+      "Extend the finite-check template to a candidate second example: for an edge-transitive graph G conjectured minimally non-Ramsey-size-linear, reduce 'all proper subgraphs size-linear' to a single maximal-subgraph representative.",
+      "Formalize a constructive lower bound witnessing K₄'s superlinearity (`K4_not_linear`) to complement this reduction of the subgraph half."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos79Problem"
+    ],
+    "opens": [
+      "SimpleGraph",
+      "Erdos79"
+    ],
+    "namespace": "Erdos79Incomplete01",
+    "lineCount": 267,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 7,
+    "path": "Proofs/Erdos79Incomplete01.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul; Faudree, Ralph; Rousseau, Cecil; Schelp, Richard",
+      "title": "Ramsey size linear graphs",
+      "year": "1993",
+      "venue": "Combinatorics, Probability and Computing, vol. 2, pp. 389–399",
+      "note": "Introduces Ramsey size-linear graphs and the minimality question underlying Erdős #79; K₄ is the motivating example."
+    },
+    {
+      "authors": "Wigderson, Yuval",
+      "title": "Ramsey size-linear graphs and related questions",
+      "year": "2024",
+      "venue": "preprint / erdosproblems.com/79",
+      "note": "Proves infinitely many minimally non-Ramsey-size-linear graphs exist (non-constructive). Axiomatized as `wigderson_theorem` in the parent file; not used here."
+    },
+    {
+      "authors": "Mathlib Community",
+      "title": "Mathlib.Combinatorics.SimpleGraph",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "note": "Provides SimpleGraph, graph isomorphisms (≃g), and the permutation machinery (Equiv.swap, Equiv.Perm) used to build the edge-transitivity relabellings."
+    }
+  ],
+  "sorries": 0,
+  "crossReferences": [
+    {
+      "targetId": "erdos-79",
+      "relationship": "extends",
+      "description": "Parent problem. This companion reduces the parent's sweeping `K4_subgraphs_linear` axiom (every proper subgraph of K₄ is Ramsey size-linear) to a concrete finite check — first a literal six-fold conjunction, then a single diamond via K₄'s edge-transitivity — using only the parent's heredity axiom and an explicit isomorphism-invariance hypothesis."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extends the `incomplete-01` companion for **Erdős Problem #79** (minimally non-Ramsey-size-linear graphs; only K₄ is explicitly known). The parent `Proofs/Erdos79Problem.lean` keeps `ramseyNumber` opaque and axiomatizes the sweeping `K4_subgraphs_linear`: *every* proper subgraph of K₄ is Ramsey size-linear — quantified over infinitely many `H : SimpleGraph ℕ`. Over the opaque parameter no specific graph's size-linearity is derivable, so the available mathematics is the **combinatorial reduction of that axiom's shape**. This PR sharpens it in two provable steps.

## What's new (`Proofs/Erdos79Incomplete01.lean`)

- **`hdiamond_iff_six`** — the edge-deleted hypothesis (`∀ p q, K₄.Adj p q → isRamseySizeLinear (K4MinusEdge p q)`) is equivalent to a **literal six-fold conjunction** over K₄'s six edges. This is the "concrete finite check" in closed form: no quantifier over graphs or vertices remains. Backward direction by `interval_cases` + `K4MinusEdge_comm` (edge deletion is symmetric in its endpoints, a literal graph equality).
- **`diamondEquiv`** — reusable engine: any permutation of ℕ preserving `· < 4` induces a graph isomorphism `K4MinusEdge p q ≃g K4MinusEdge (σ p) (σ q)`.
- **`diamond_iso_02 … diamond_iso_23`** — five explicit relabelling isomorphisms witnessing **S₄'s transitive action on K₄'s edges** (edge-transitivity): all six diamonds are pairwise graph-isomorphic.
- **`K4_subgraphs_linear_of_single`** / **`K4_is_minimal_of_single`** — the six-fold check collapses to **one diamond** `K₄−{0,1}`, granted an *explicit* isomorphism-invariance hypothesis `hcongr` (a stated hypothesis, **not** an axiom — over the opaque `ramseyNumber` it is genuinely underivable).

## Verification

- Built under Docker: `✔ [7744/7744] Built Proofs.Erdos79Incomplete01`, **0 sorries**.
- **Axiom status: `axiomatized`** (`axiomCount = 1`). The pure combinatorial lemmas (`hdiamond_iff_six`, `diamondEquiv`, the five isomorphisms, `K4MinusEdge_comm`, `swap_lt_four`, `comp_lt_four`) are **0-axiom** (foundational `propext`/`Classical.choice`/`Quot.sound` only; `decide`, not `native_decide`, so no `Lean.ofReduceBool`). The reduction-to-minimality theorems additionally use the parent's imported `ramsey_linear_hereditary` axiom — disclosed in `assumptions`. No `axiom`/`sorry` is declared in this file (`leanFile.axiomCount = 0`).

## Gallery

Adds `src/data/proofs/erdos-79-incomplete-01/` (meta, annotations, index) and updates the research knowledge base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)