### PR TITLE
Fix: sync beta-central-binomial-explicit-rate-oq-02 lineCount to Lean source

### DIFF
--- a/src/data/proofs/beta-central-binomial-explicit-rate-oq-02/meta.json
+++ b/src/data/proofs/beta-central-binomial-explicit-rate-oq-02/meta.json
@@ -14,7 +14,7 @@
     "sorries": 0,
     "theoremCount": 17,
     "definitionCount": 0,
-    "lineCount": 593,
+    "lineCount": 597,
     "mathlib_version": "4.26.0",
     "tags": [
       "analysis",
@@ -103,7 +103,7 @@
   },
   "leanFile": {
     "path": "Proofs/BetaCentralBinomialExplicitRateOQ02.lean",
-    "lineCount": 593,
+    "lineCount": 597,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 17,


### PR DESCRIPTION
## Fix

Sync the stale `lineCount` in `meta.json` for `beta-central-binomial-explicit-rate-oq-02` to match the actual Lean source (`proofs/Proofs/BetaCentralBinomialExplicitRateOQ02.lean`).

## Evidence

`wc -l proofs/Proofs/BetaCentralBinomialExplicitRateOQ02.lean` → **597**

**Before**: lineCount=593 (both `meta.lineCount` and `leanFile.lineCount`)
**After**: lineCount=597

All other structural counts already match source (theoremCount=17, definitionCount=0, axiomCount=0, sorries=0 — verified comment-stripped).

---
Automated fix by lean-mechanic agent.