### PR TITLE
Fix: sync algebraic-reals-meager-oq-02-oq-01 lineCount to Lean source

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
@@ -69,7 +69,7 @@
       "Lebesgue measure on ℝ; conull (full measure) = complement is null",
       "Liouville numbers: residual (comeagre) and Lebesgue-null"
     ],
-    "lineCount": 178,
+    "lineCount": 176,
     "relatedProblems": [
       {
         "id": "algebraic-reals-meager-oq-02",


### PR DESCRIPTION
## Fix

Sync the stale `lineCount` in `meta.json` for `algebraic-reals-meager-oq-02-oq-01` to match the actual Lean source (`proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01.lean`).

## Evidence

`wc -l proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01.lean` → **176**

**Before**: lineCount=178
**After**: lineCount=176

All other structural counts already match source (theoremCount=8, axiomCount=0, sorries=0 — verified comment-stripped).

---
Automated fix by lean-mechanic agent.