### PR TITLE
Enrich Fibonacci Identities OQ-06 (linear sums): split sections, add additive-in-ℕ keyInsight

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-06/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06/meta.json
@@ -63,7 +63,8 @@
       "**The partial sum is pure telescoping.** Each Fᵢ equals Fᵢ₊₂ − Fᵢ₊₁, so the partial sum collapses to Fₙ₊₂ − F₁ = Fₙ₊₂ − 1. Phrased additively as (∑ Fᵢ) + 1 = Fₙ₊₂ the whole argument stays in ℕ and the inductive step is discharged by omega once the recurrence is in scope.",
       "**The weighted sum is genuinely new, not a sibling specialization.** Every other Fibonacci sum in the gallery has a summand depending only on Fibonacci values (Fᵢ, Fᵢ², Fᵢ·Fᵢ₊₁). Here the summand i·Fᵢ carries the running index as a coefficient, so the closed form acquires the linear-in-n term n·Fₙ₊₂ — the Fibonacci counterpart of ∑ i·rⁱ = (n·rⁿ⁺¹ − …)/(r−1)².",
       "**zify + linear_combination quarantines the nonlinearity.** The weighted-sum step contains the nonlinear term k·Fₖ₊₂. After reducing all shifted Fibonacci values to the atoms Fₖ₊₁, Fₖ₊₂, the goal differs from the induction hypothesis by an exact ring identity, so casting to ℤ and feeding the hypothesis to linear_combination closes it without any case analysis or hand-rolled arithmetic.",
-      "**Both identities are absent from Mathlib.** Mathlib's Nat.fib API is rich in pointwise identities (recurrence, addition formula, doubling, Cassini over Int.fib, gcd) but records none of the classical linear partial sums — these are supplied here from the recurrence alone."
+      "**Both identities are absent from Mathlib.** Mathlib's Nat.fib API is rich in pointwise identities (recurrence, addition formula, doubling, Cassini over Int.fib, gcd) but records none of the classical linear partial sums — these are supplied here from the recurrence alone.",
+      "**Additive phrasing keeps the proofs in ℕ.** Both closed forms are naturally written with subtraction (Fₙ₊₂ − 1 and n·Fₙ₊₂ − Fₙ₊₃ + 2), where truncated ℕ-subtraction would misbehave. Moving the subtracted term to the left — (∑Fᵢ)+1 = Fₙ₊₂ and (∑ i·Fᵢ)+Fₙ₊₃ = n·Fₙ₊₂+2 — makes every quantity a genuine natural, so the partial sum closes by omega with no casting at all; only the weighted sum, which still carries the nonlinear k·Fₖ₊₂, needs a single zify to reach ℤ."
     ],
     "prerequisites": [
       "The Fibonacci recurrence Nat.fib_add_two",
@@ -73,12 +74,20 @@
   },
   "sections": [
     {
-      "id": "header",
-      "title": "Module Header and Setup",
+      "id": "overview",
+      "title": "Module Overview: the Missing Linear Sums",
       "startLine": 1,
-      "endLine": 31,
-      "summary": "Module docstring framing the two linear summation identities as the degree-zero/one companions to the parent file's degree-two sum of squares, noting both are absent from Mathlib and its open-question descendants, plus the import and namespace setup (open Finset).",
+      "endLine": 27,
+      "summary": "Module docstring: frames the two linear (degree-one) summation identities as the elementary companions to the parent file's quadratic sum of squares, and notes that despite the parent and its open-question descendants covering Cassini/Vajda/d'Ocagne, gcd, and bilinear product sums, these two most basic linear sums are absent from both Mathlib and the gallery. Each is a short Finset.sum_range_succ induction whose only Fibonacci input is the defining recurrence Nat.fib_add_two.",
       "mathContext": "$\\sum_{i=0}^{n} F_i = F_{n+2}-1$ and $\\sum_{i=0}^{n} i\\,F_i = n F_{n+2} - F_{n+3} + 2$."
+    },
+    {
+      "id": "setup",
+      "title": "Imports and Namespace",
+      "startLine": 29,
+      "endLine": 31,
+      "summary": "import Mathlib, the FibonacciIdentitiesOQ06 namespace, and open Finset (so range and sum notation resolve). No Fibonacci-specific setup beyond Mathlib's Nat.fib API.",
+      "mathContext": "Working over ℕ with Nat.fib and Finset.range sums; the sole Fibonacci lemma used downstream is Nat.fib_add_two."
     },
     {
       "id": "fib_sum",
@@ -89,12 +98,20 @@
       "mathContext": "$F_0 + F_1 + \\cdots + F_n = F_{n+2} - 1$, additively $(\\sum F_i) + 1 = F_{n+2}$."
     },
     {
-      "id": "fib_weighted_sum",
-      "title": "The Index-Weighted Sum (First Moment)",
+      "id": "fib_weighted_sum-statement",
+      "title": "The Index-Weighted Sum: Statement and Base Case",
       "startLine": 46,
-      "endLine": 68,
-      "summary": "fib_weighted_sum: (∑_{i≤n} i·Fᵢ) + Fₙ₊₃ = n·Fₙ₊₂ + 2 by induction. The step peels (k+1)·Fₖ₊₁ with Finset.sum_range_succ, rewrites the shifted Fibonacci values at k+3, (k+1)+2, (k+1)+3 down to the atoms Fₖ₊₁, Fₖ₊₂ via Nat.fib_add_two (including inside the hypothesis), then casts to ℤ with zify and closes by linear_combination on the induction hypothesis.",
+      "endLine": 54,
+      "summary": "fib_weighted_sum states the discrete first moment (∑_{i≤n} i·Fᵢ) + Fₙ₊₃ = n·Fₙ₊₂ + 2, phrased additively to stay in ℕ. The n = 0 base case reduces the singleton sum (Finset.sum_range_one) and evaluates the resulting concrete Fibonacci equation by decide.",
       "mathContext": "$0\\cdot F_0 + 1\\cdot F_1 + \\cdots + n\\cdot F_n = n F_{n+2} - F_{n+3} + 2$, additively $(\\sum i F_i) + F_{n+3} = n F_{n+2} + 2$."
+    },
+    {
+      "id": "fib_weighted_sum-induction",
+      "title": "The Index-Weighted Sum: Inductive Step",
+      "startLine": 55,
+      "endLine": 68,
+      "summary": "The inductive step peels (k+1)·Fₖ₊₁ with Finset.sum_range_succ and rewrites the three shifted Fibonacci values at k+3, (k+1)+2, (k+1)+3 down to the atoms Fₖ₊₁, Fₖ₊₂ via Nat.fib_add_two (e2, e3, e4) — including inside the induction hypothesis. Casting to ℤ with zify then leaves an exact ring identity that linear_combination on the hypothesis closes, with no case analysis.",
+      "mathContext": "Reduce all shifted $F$-values to $F_{k+1}, F_{k+2}$; the goal minus the hypothesis is a ring identity in ℤ closed by linear_combination."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-06`.

Quality **94 → 100** by closing two structural gaps:

- **sections 3 → 5**: split into overview docstring / imports-namespace / `fib_sum` / weighted-sum statement+base case / weighted-sum inductive step. The last split is the meaningful one — the weighted sum's inductive step (unfolding three instances of `Nat.fib_add_two` then `zify` + `linear_combination`) is the substantive work, distinct from its statement. Line ranges verified against the 70-line source.
- **keyInsights 4 → 5**: added the *additive-in-ℕ* design point — both closed forms are naturally subtractive (Fₙ₊₂ − 1, n·Fₙ₊₂ − Fₙ₊₃ + 2), so stating them additively keeps every quantity a genuine natural; the partial sum then closes by `omega` with no cast, and only the weighted sum (carrying the nonlinear k·Fₖ₊₂) needs a single `zify`.

No prose accretion; meta.json well under the cap. `jq` validation passes; recomputed quality = 100.