### PR TITLE
Enrich two entries: Erdős #564 tower-growth + Lamé closed-form bound (structural section fixes)

### DIFF
--- a/src/data/proofs/erdos-564-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-564-incomplete-01/annotations.json
@@ -197,7 +197,11 @@
       "concrete evaluation",
       "tower function"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "iterated exponentials / Knuth up-arrow notation",
+      "Lean's decide tactic for closed decidable goals",
+      "the tower recursion tower (k+1) n = 2 ^ tower k n"
+    ]
   },
   {
     "id": "ann-ramsey-monotonicity",

--- a/src/data/proofs/erdos-564-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-564-incomplete-01/meta.json
@@ -64,28 +64,60 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Tower-Growth Theory for Erdős #564",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Docstring framing the file as the verified, 0-axiom growth theory of the tower function that makes the 'tower height' phrasing of Erdős #564 precise: the parent axiomatizes R and the EHR bounds 2^{cn²} < R₃(n) < 2^{2^n} and defines tower(k,n) but proves no growth theory. Enumerates the deliverables (height/base strict monotonicity, the linear and faithful-quadratic crux, the general height gap) and stresses that none of the open conjecture is resolved. Imports Mathlib and Proofs.Erdos564Problem, opens Erdos564, and enters namespace Erdos564.Incomplete01.",
+      "mathContext": "$2^{cn^2} < R_3(n) < 2^{2^n}$: the EHR bounds are one tower level apart; Erdős asks whether $R_3(n)$ reaches tower height 2."
+    },
+    {
       "id": "height-growth",
       "title": "Growth in Tower Height",
-      "startLine": 41,
-      "endLine": 70,
+      "startLine": 46,
+      "endLine": 68,
       "summary": "tower_succ records the recursion tower (k+1) n = 2 ^ tower k n. tower_lt_succ_height proves tower k n < tower (k+1) n from m < 2^m (Nat.lt_two_pow_self), with no positivity hypothesis. tower_strictMono_height upgrades this to strict monotonicity of k ↦ tower k n via strictMono_nat_of_lt_succ, and self_le_tower derives n ≤ tower k n from height-monotonicity at 0 ≤ k.",
       "mathContext": "$\\text{tower}(k,n) < \\text{tower}(k+1,n) = 2^{\\text{tower}(k,n)}$ since $m < 2^m$; hence $n = \\text{tower}(0,n) \\le \\text{tower}(k,n)$."
     },
     {
       "id": "base-growth",
       "title": "Growth in Tower Base and the Height-1-vs-2 Crux",
-      "startLine": 71,
-      "endLine": 98,
-      "summary": "tower_strictMono_base proves n ↦ tower k n is strictly monotone by induction on k (successor step composes the IH with strict monotonicity of 2^(·)); tower_mono_base is the non-strict corollary. tower_two_eq gives tower 2 n = 2^(2^n). The crux tower_one_lt_tower_two shows 2^n < 2^(2^n) for every n — the singly-exponential known lower bound is strictly below the doubly-exponential conjectured one.",
+      "startLine": 70,
+      "endLine": 109,
+      "summary": "tower_strictMono_base proves n ↦ tower k n is strictly monotone by induction on k (successor step composes the IH with strict monotonicity of 2^(·)); tower_mono_base is the non-strict corollary. tower_two_eq gives tower 2 n = 2^(2^n). The crux tower_one_lt_tower_two shows 2^n < 2^(2^n) for every n — the singly-exponential known lower bound is strictly below the doubly-exponential conjectured one — and tower_lt_of_height_lt names the general height gap tower j n < tower k n for j < k.",
       "mathContext": "$\\text{tower}(1,n) = 2^n < 2^{2^n} = \\text{tower}(2,n)$: the EHR lower bound is one tower level below the upper bound."
+    },
+    {
+      "id": "quadratic-crux",
+      "title": "The Faithful Quadratic Crux: 2^{n²} < tower 2 n",
+      "startLine": 111,
+      "endLine": 136,
+      "summary": "nsq_lt_two_pow_self proves n² < 2^n for n ≥ 5 (tight at n = 4, where 4² = 16 = 2⁴) by Nat.le_induction, the successor step clearing (m+1)² = m²+2m+1 < 2^m + 2^m = 2^{m+1} via nlinarith with 2m+1 ≤ m². ehr_lower_lt_tower_two then upgrades the linear crux to its faithful form: the genuine EHR lower bound has a QUADRATIC exponent, yet 2^{n²} is still a whole tower level below the conjectured 2^{2^n} = tower 2 n for every n ≥ 5.",
+      "mathContext": "$n^2 < 2^n\\ (n \\ge 5) \\Rightarrow 2^{n^2} < 2^{2^n} = \\text{tower}(2,n)$: the real quadratic-exponent lower bound is still one tower level short."
     },
     {
       "id": "examples",
       "title": "Concrete Sanity Checks",
-      "startLine": 99,
-      "endLine": 110,
-      "summary": "tower 2 3 = 256, tower 3 1 = 16 (both by decide), and 5 ≤ tower 4 5 instantiating self_le_tower.",
+      "startLine": 138,
+      "endLine": 147,
+      "summary": "tower 2 3 = 256 and tower 3 1 = 16 (both by decide), plus 5 ≤ tower 4 5 instantiating self_le_tower — small numeric anchors that pin the recursion down to concrete values.",
       "mathContext": "$\\text{tower}(2,3)=2^{2^3}=2^8=256$; $\\text{tower}(3,1)=2^{2^{2}}=2^4=16$."
+    },
+    {
+      "id": "ramsey-monotonicity",
+      "title": "Monotonicity of the Hypergraph Ramsey Property",
+      "startLine": 149,
+      "endLine": 190,
+      "summary": "The first theory of the property predicate HasHypergraphRamseyProperty itself, 0-axiom. hasHypergraphRamseyProperty_mono: more vertices preserve the property (restrict a colouring of Fin m' along Fin.castLEEmb, find the clique downstairs, push it back with Finset.map), so the set of good m is upward closed — what lets one speak of the least such m. hasHypergraphRamseyProperty_antitone_clique: a smaller target clique is easier (any n'-subset of a monochromatic n-clique is still monochromatic), so R k · is monotone in clique size.",
+      "mathContext": "$m \\le m' \\Rightarrow (\\text{prop } k\\,m\\,n \\to \\text{prop } k\\,m'\\,n)$ and $n' \\le n \\Rightarrow (\\text{prop } k\\,m\\,n \\to \\text{prop } k\\,m\\,n')$: threshold well-behavedness of $R_k(n)$."
+    },
+    {
+      "id": "triviality-boundary",
+      "title": "The Triviality Boundary: R_k(n) = n for n ≤ k",
+      "startLine": 192,
+      "endLine": 259,
+      "summary": "Pins down where the property starts. hasHypergraphRamseyProperty_clique_zero handles n = 0 (S = ∅). hasHypergraphRamseyProperty_clique_lt_uniformity: for n < k an n-clique has no k-subsets, so monochromaticity is vacuous. hasHypergraphRamseyProperty_diagonal_base: for n = k the unique k-subset is the clique itself, monochromatic for c S. The unified hasHypergraphRamseyProperty_of_clique_le_uniformity combines them: whenever n ≤ k (and n ≤ m) the property holds, i.e. R_k(n) = n on and below the diagonal — so the genuine content of R₃(n) lives strictly above it (n > 3). Ends with #print axioms confirming 0-axiom status.",
+      "mathContext": "$n \\le k \\Rightarrow \\text{HasHypergraphRamseyProperty } k\\,m\\,n$, i.e. $R_k(n) = n$ for $n \\le k$; substance appears only for $n > k = 3$."
     }
   ],
   "mainTheorems": [
@@ -160,6 +192,21 @@
       "proofId": "erdos-564",
       "relationship": "extends",
       "description": "Parent formalization of Erdős #564 (axiomatized R and EHR bounds, tower definition). This file supplies the verified growth theory of that tower and repairs six dangling /-- doc comments that made the parent fail to parse."
+    },
+    {
+      "proofId": "ramsey-r4k",
+      "relationship": "related",
+      "description": "The off-diagonal GRAPH (2-uniform) Ramsey number R(4,k): structural upper bound R(4,k) ≤ C(k+2,3) and cubic growth. Erdős #564 is the 3-uniform HYPERGRAPH analogue R₃(n); both entries are about pinning the growth rate of a Ramsey number between a known lower and upper bound, but one tower level higher in the hypergraph case."
+    },
+    {
+      "proofId": "ramsey-r4k-oq-01",
+      "relationship": "related",
+      "description": "Formalizes the AKS O(k³/log²k) upper bound and the Mattheus–Verstraëte (2024) lower bound for R(4,k) — the graph-Ramsey instance of exactly the phenomenon Erdős #564 asks about: closing the gap between the best known lower and upper bounds on a Ramsey number. The tower-height gap 2^n vs 2^{2^n} here is the hypergraph counterpart of the polynomial gap there."
+    },
+    {
+      "proofId": "lovasz-local-lemma",
+      "relationship": "related",
+      "description": "The probabilistic-method tool underlying Ramsey lower bounds: sparse dependence among unlikely 'bad monochromatic clique' events yields the existence of good colourings. Such probabilistic constructions are the standard route to the singly-exponential lower bound of Erdős #564 that this entry's tower_one_lt_tower_two / ehr_lower_lt_tower_two show still sits a full tower level below the conjecture."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-03-oq-01-oq-01/annotations.json
@@ -6,7 +6,7 @@
       "startLine": 71,
       "endLine": 92
     },
-    "type": "lemma",
+    "type": "theorem",
     "title": "Geometric Lower Bound φⁿ ≤ fib(n+2)",
     "content": "The bridge from the discrete Fibonacci bound to a logarithm. For every n, φⁿ ≤ fib(n+2), where φ = (1+√5)/2 is the golden ratio. The proof is a two-step induction: the base cases are φ⁰ = 1 ≤ fib 2 = 1 and φ¹ = φ ≤ fib 3 = 2, and the inductive step rewrites φ^(n+2) = φ^(n+1) + φⁿ (the defining identity φ² = φ + 1) and matches it term-by-term against the Fibonacci recurrence fib(n+4) = fib(n+3) + fib(n+2).",
     "mathContext": "$\\varphi^{n} \\le F_{n+2}$ for all $n$, since $\\varphi^{n+2} = \\varphi^{n+1} + \\varphi^{n}$ mirrors $F_{n+4} = F_{n+3} + F_{n+2}$.",
@@ -29,7 +29,7 @@
       "startLine": 99,
       "endLine": 110
     },
-    "type": "lemma",
+    "type": "theorem",
     "title": "φ-Power Bound on the Smaller Entry",
     "content": "Combines the geometric bound φⁿ ≤ fib(n+2) with the parent's minimality bound fib(n+1) ≤ b. If the Euclidean run on 0 < b < a takes n ≥ 1 steps then φ^(n-1) ≤ fib(n+1) ≤ b. This is the exponential lower bound on the smaller entry that, inverted, becomes the logarithmic upper bound on the step count.",
     "mathContext": "$\\operatorname{euclidSteps}(a,b) = n,\\ n \\ge 1 \\implies \\varphi^{\\,n-1} \\le b$.",

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-03-oq-01-oq-01/meta.json
@@ -68,13 +68,62 @@
     }
   ],
   "sections": [
-    "Module Overview and References",
-    "Elementary Golden-Ratio Bounds",
-    "Geometric Lower Bound φⁿ ≤ fib(n+2)",
-    "The φ-Power Lower Bound on the Smaller Entry",
-    "The Closed-Form Logarithmic Bound (Lamé)",
-    "Making the Lamé Constant Explicit",
-    "Sanity Checks"
+    {
+      "id": "overview",
+      "title": "Module Overview and References",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Docstring situating the file in the gcd-algorithm-oq-01-oq-03 lineage: the grandparent develops φ = (1+√5)/2 and Binet's formula, the parent proves Lamé minimality (fib(n+1) ≤ b when euclidSteps a b = n), and this file answers the parent's OQ-01 by turning the exact worst-case count into the closed-form logarithmic bound (n : ℝ) ≤ log_φ(b) + 1. States the five-step proof outline and cites Lamé (1844) and the two ancestor files. Imports Mathlib and the two ancestor proofs; opens the golden-ratio namespaces.",
+      "mathContext": "$\\text{euclidSteps}\\,a\\,b = n \\Rightarrow n \\le \\log_\\varphi(b) + 1$, the quantitative content of Lamé's 1844 analysis."
+    },
+    {
+      "id": "elementary-golden-ratio-bounds",
+      "title": "Elementary Golden-Ratio Bounds",
+      "startLine": 43,
+      "endLine": 60,
+      "summary": "PART I. Three basic estimates on φ used throughout: phi_gt_three_halves (3/2 < φ, from √5 > 2), one_lt_phi (1 < φ, needed for log-base positivity/monotonicity), and phi_lt_two (φ < 2, from √5 < 3). All discharged by unfolding goldenPhi and linarith/nlinarith against the √5 bounds.",
+      "mathContext": "$\\tfrac32 < \\varphi < 2$ and $1 < \\varphi$, from $2 < \\sqrt5 < 3$."
+    },
+    {
+      "id": "geometric-lower-bound",
+      "title": "Geometric Lower Bound φⁿ ≤ fib(n+2)",
+      "startLine": 62,
+      "endLine": 89,
+      "summary": "PART II. phi_pow_le_fib proves φⁿ ≤ fib(n+2) for all n by two-step (Nat.twoStepInduction) induction: base cases φ⁰ = 1 ≤ fib 2 and φ¹ = φ ≤ fib 3 = 2, and the step combines φ^(n+2) = φ^(n+1) + φⁿ (from φ² = φ+1) with fib(n+4) = fib(n+3) + fib(n+2) via add_le_add. This is the geometric engine linking φ-powers to Fibonacci growth.",
+      "mathContext": "$\\varphi^n \\le \\mathrm{fib}(n+2)$, proved by two-step induction on $\\varphi^2 = \\varphi + 1$."
+    },
+    {
+      "id": "phi-power-lower-bound",
+      "title": "The φ-Power Lower Bound on the Smaller Entry",
+      "startLine": 91,
+      "endLine": 106,
+      "summary": "PART III. phi_pow_le_smaller shows that if the Euclidean run on 0 < b < a takes n ≥ 1 steps then φ^(n-1) ≤ b, by combining the parent's minimality bound fib(n+1) ≤ b (fib_le_of_euclidSteps) with the geometric bound φⁿ ≤ fib(n+2). Rewriting n = m+1 turns the goal into φ^m ≤ fib(m+2) ≤ b.",
+      "mathContext": "$\\text{euclidSteps}\\,a\\,b = n \\ge 1 \\Rightarrow \\varphi^{\\,n-1} \\le b$."
+    },
+    {
+      "id": "closed-form-log-bound",
+      "title": "The Closed-Form Logarithmic Bound (Lamé)",
+      "startLine": 108,
+      "endLine": 132,
+      "summary": "PART IV. euclidSteps_le_logb is the headline: euclidSteps a b = n ⟹ (n : ℝ) ≤ log_φ(b) + 1. From φ^(n-1) ≤ b and monotonicity of log_φ (base φ > 1, Real.logb_le_logb_of_le), n-1 = log_φ(φ^(n-1)) ≤ log_φ(b); Real.logb_pow and Real.logb_self_eq_one collapse the left side and linarith finishes.",
+      "mathContext": "$n - 1 = \\log_\\varphi(\\varphi^{\\,n-1}) \\le \\log_\\varphi(b) \\Rightarrow n \\le \\log_\\varphi(b) + 1$."
+    },
+    {
+      "id": "lame-constant-explicit",
+      "title": "Making the Lamé Constant Explicit",
+      "startLine": 134,
+      "endLine": 181,
+      "summary": "PART V. Pins down the textbook constant. two_log_two_lt_three_log_phi proves 2·log 2 < 3·log φ (equivalently φ³ = 2φ+1 > 4). logb_two_phi_gt deduces log₂(φ) > 2/3, so 1/log₂(φ) < 3/2. euclidSteps_le_log2 converts the base-φ bound into bits: (n : ℝ) ≤ (3/2)·log₂(b) + 1 — the explicit (slightly loose) form of the classical ≈ 1.4404·log₂(b) Lamé bound.",
+      "mathContext": "$\\varphi^3 = 2\\varphi + 1 > 4 \\Rightarrow \\log_2\\varphi > \\tfrac23 \\Rightarrow n \\le \\tfrac32\\log_2 b + 1$."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Sanity Checks",
+      "startLine": 183,
+      "endLine": 199,
+      "summary": "PART VI. Two concrete instances anchoring the abstract bounds: φ³ ≤ fib 5 = 5 (an instance of phi_pow_le_fib), and 5 ≤ log_φ(fib 6) + 1 for the Fibonacci pair (fib 7, fib 6) = (13, 8), which takes exactly 5 Euclidean steps — the worst case, verified via the parent's euclidSteps_fib identity with no native_decide.",
+      "mathContext": "On $(\\mathrm{fib}\\,7, \\mathrm{fib}\\,6) = (13,8)$, $5$ steps and $5 \\le \\log_\\varphi(8) + 1$."
+    }
   ],
   "sorries": [],
   "overview": {


### PR DESCRIPTION
Enrichment pass bundling two quality-94 / passes-0 entries that had genuine **structural** defects (not shallow prose). Both verified against their Lean sources; `pnpm build` reports 0 errors for each.

### 1. `erdos-564-incomplete-01` (Erdős #564 tower-growth theory)
- **`sections` covered only lines 41–110, but the Lean file is 259 lines.** The file had grown (faithful-quadratic crux, Ramsey-property monotonicity, triviality-boundary blocks) without `sections` keeping up, and the old "examples" section even pointed at the wrong lines. Rewrote to 7 sections covering all 259 lines.
- **`crossReferences` 1 → 4:** added `ramsey-r4k`, `ramsey-r4k-oq-01` (off-diagonal Ramsey lower/upper-bound-gap analogues), `lovasz-local-lemma` (probabilistic-method route to Ramsey lower bounds).
- Filled an empty `prerequisites` array on one annotation.

### 2. `gcd-algorithm-oq-01-oq-03-oq-01-oq-01` (Lamé closed-form bound)
- **`sections` was an array of 7 bare title strings** — no line ranges or summaries, anchoring to nothing. Rebuilt all 7 as proper objects (id/title/startLine/endLine/summary/mathContext) mapped to the file's PART I–VI structure; now covers all 199 lines.
- Fixed two annotation type mismatches (`lemma` → `theorem`, matching the source), clearing this entry's two gallery build-validation errors.

No mathematical claims, status, badge, or axiomCount changed for either entry. Both files well under the 60 KB cap. Branch base is behind main by 13 commits, but none of those commits touch these 4 files (verified) so the merge is clean.