### PR TITLE
research(algebraic-reals-meager-oq-02-oq-01): Aff(ℚ)-equivariant Oxtoby decomposition [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01Equivariant.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01Equivariant.lean
@@ -1,0 +1,206 @@
+import Mathlib.NumberTheory.Transcendental.Liouville.Measure
+
+/-
+  The symmetric Oxtoby decomposition is ℚ-affine equivariant
+  (algebraic-reals-meager — OQ-02 → OQ-01, structural follow-up)
+
+  The sibling files record the **symmetric Oxtoby decomposition** of ℝ
+
+      ℝ  =  L  ⊔  Lᶜ
+            └ comeagre & null      (topologically large, measure-small)
+                 └ meagre & conull (topologically small, measure-large)
+
+  with `L = {x | Liouville x}`, and sharpen it by showing both pieces are
+  *dense*. This file adds the missing **symmetry group**: the entire
+  decomposition is invariant under the natural action of the rational affine
+  group
+
+      Aff(ℚ)  ↷  ℝ,      x ↦ q·x + r     (q ∈ ℚˣ, r ∈ ℚ).
+
+  Every such map is a homeomorphism of `ℝ` that also preserves Lebesgue measure
+  up to a positive scalar, so *a priori* it could permute the two Oxtoby pieces
+  or blur the measure/category contrast. It does neither: it fixes `L` and `Lᶜ`
+  **setwise**. Hence the Oxtoby pathology is not an artifact of a particular
+  base point or scale — it is a genuinely `Aff(ℚ)`-equivariant partition of the
+  line.
+
+  ## The mechanism
+
+  The classical predicate `Liouville` is `LiouvilleWith p` for *every* exponent
+  `p` (`forall_liouvilleWith_iff`). Mathlib already proves each `LiouvilleWith p`
+  is invariant under adding a rational (`add_rat_iff`) and multiplying by a
+  nonzero rational (`mul_rat_iff`), and under negation (`neg_iff`). Quantifying
+  those `iff`s over `p` transports them verbatim to `Liouville`, giving the
+  pointwise equivariance
+
+      Liouville (q·x + r) ↔ Liouville x        (q ≠ 0, q,r ∈ ℚ).
+
+  Set-theoretically this says `f ⁻¹' L = L` for every rational affine `f`; since
+  each such `f` is a bijection with a rational affine inverse, also `f '' L = L`.
+  Complementation gives the same for `Lᶜ`, so the whole decomposition is fixed.
+
+  ## Honesty / novelty
+
+  No new mathematics: Part I is `forall_congr'` over Mathlib's existing
+  `LiouvilleWith` transfer lemmas; Parts II–III are `Set.ext` / bijection
+  bookkeeping. The value is the explicit, machine-checked statement that the
+  measure/category anomaly is `Aff(ℚ)`-equivariant — a structural fact the
+  sibling files leave unstated. Presented as a modest structural follow-up, not
+  a new result.
+
+  No new axioms (standard Mathlib triple inherited).
+
+  References:
+  - Oxtoby, J.C. (1980). "Measure and Category", Springer GTM 2.
+  - Mathlib: NumberTheory.Transcendental.Liouville.{LiouvilleWith,Residual,
+             Measure} (`forall_liouvilleWith_iff`, `LiouvilleWith.add_rat_iff`,
+             `mul_rat_iff`, `neg_iff`, `eventually_residual_liouville`,
+             `volume_setOf_liouville`).
+
+  Tags: liouville-numbers, measure-theory, baire-category, group-action,
+        affine-group, equivariance, oxtoby-duality, sharp-boundary
+-/
+
+set_option maxHeartbeats 400000
+
+namespace AlgebraicRealsMeagerOQ02OQ01Equivariant
+
+open MeasureTheory Filter Set
+
+-- ============================================================================
+-- Part I: pointwise ℚ-affine equivariance of the `Liouville` predicate
+-- ============================================================================
+
+/-- **Rational translation invariance.** `Liouville (x + r) ↔ Liouville x` for
+    `r : ℚ`. Obtained by quantifying Mathlib's `LiouvilleWith.add_rat_iff` over
+    the exponent `p` through `forall_liouvilleWith_iff`. -/
+theorem liouville_add_rat_iff (x : ℝ) (r : ℚ) :
+    Liouville (x + r) ↔ Liouville x := by
+  rw [← forall_liouvilleWith_iff, ← forall_liouvilleWith_iff]
+  exact forall_congr' fun _ => LiouvilleWith.add_rat_iff
+
+/-- **Rational translation invariance (left form).** `Liouville (r + x) ↔
+    Liouville x` for `r : ℚ`. -/
+theorem liouville_rat_add_iff (r : ℚ) (x : ℝ) :
+    Liouville (r + x) ↔ Liouville x := by
+  rw [add_comm]; exact liouville_add_rat_iff x r
+
+/-- **Reflection invariance.** `Liouville (-x) ↔ Liouville x`. -/
+theorem liouville_neg_iff (x : ℝ) : Liouville (-x) ↔ Liouville x := by
+  rw [← forall_liouvilleWith_iff, ← forall_liouvilleWith_iff]
+  exact forall_congr' fun _ => LiouvilleWith.neg_iff
+
+/-- **Nonzero rational scaling invariance.** `Liouville (x * r) ↔ Liouville x`
+    for `r : ℚ`, `r ≠ 0`. -/
+theorem liouville_mul_rat_iff {r : ℚ} (hr : r ≠ 0) (x : ℝ) :
+    Liouville (x * r) ↔ Liouville x := by
+  rw [← forall_liouvilleWith_iff, ← forall_liouvilleWith_iff]
+  exact forall_congr' fun _ => LiouvilleWith.mul_rat_iff hr
+
+/-- **Nonzero rational scaling invariance (left form).** `Liouville (r * x) ↔
+    Liouville x` for `r : ℚ`, `r ≠ 0`. -/
+theorem liouville_rat_mul_iff {r : ℚ} (hr : r ≠ 0) (x : ℝ) :
+    Liouville (r * x) ↔ Liouville x := by
+  rw [mul_comm]; exact liouville_mul_rat_iff hr x
+
+/-- **Full rational affine equivariance.** For `q, r : ℚ` with `q ≠ 0`,
+    `Liouville (q·x + r) ↔ Liouville x`. This is the pointwise invariance of the
+    Liouville numbers under the action of the rational affine group `Aff(ℚ)`. -/
+theorem liouville_rat_affine_iff {q : ℚ} (hq : q ≠ 0) (r : ℚ) (x : ℝ) :
+    Liouville ((q : ℝ) * x + r) ↔ Liouville x := by
+  rw [liouville_add_rat_iff, liouville_rat_mul_iff hq]
+
+-- ============================================================================
+-- Part II: set-level invariance of `L` and `Lᶜ`
+-- ============================================================================
+
+/-- **`L` is invariant under rational affine preimages.** For every
+    `f : x ↦ q·x + r` with `q ≠ 0` (`q, r ∈ ℚ`), `f ⁻¹' L = L`. -/
+theorem setOf_liouville_rat_affine_preimage {q : ℚ} (hq : q ≠ 0) (r : ℚ) :
+    (fun x : ℝ => (q : ℝ) * x + r) ⁻¹' {x : ℝ | Liouville x}
+      = {x : ℝ | Liouville x} := by
+  ext x
+  simp only [mem_preimage, mem_setOf_eq]
+  exact liouville_rat_affine_iff hq r x
+
+/-- **`Lᶜ` is invariant under rational affine preimages.** Complementation of
+    the previous lemma: the *non*-Liouville reals are also `Aff(ℚ)`-invariant. -/
+theorem setOf_liouville_compl_rat_affine_preimage {q : ℚ} (hq : q ≠ 0) (r : ℚ) :
+    (fun x : ℝ => (q : ℝ) * x + r) ⁻¹' {x : ℝ | Liouville x}ᶜ
+      = {x : ℝ | Liouville x}ᶜ := by
+  rw [preimage_compl, setOf_liouville_rat_affine_preimage hq r]
+
+/-- **`L` is invariant under rational affine images.** Each `f : x ↦ q·x + r`
+    (`q ≠ 0`, `q, r ∈ ℚ`) is a bijection whose inverse `y ↦ q⁻¹·y - q⁻¹·r` is
+    again rational affine, so `f '' L = L` follows from preimage invariance for
+    the inverse map. -/
+theorem setOf_liouville_rat_affine_image {q : ℚ} (hq : q ≠ 0) (r : ℚ) :
+    (fun x : ℝ => (q : ℝ) * x + r) '' {x : ℝ | Liouville x}
+      = {x : ℝ | Liouville x} := by
+  have hqR : (q : ℝ) ≠ 0 := by exact_mod_cast hq
+  rw [Set.image_eq_preimage_of_inverse
+        (g := fun y : ℝ => ((q⁻¹ : ℚ) : ℝ) * y + ((-(q⁻¹ * r) : ℚ) : ℝ))
+        (fun x => by push_cast; field_simp; ring)
+        (fun y => by push_cast; field_simp; ring)]
+  exact setOf_liouville_rat_affine_preimage (inv_ne_zero hq) (-(q⁻¹ * r))
+
+-- ============================================================================
+-- Part III: the equivariant symmetric Oxtoby decomposition
+-- ============================================================================
+
+/-- **The symmetric Oxtoby decomposition is `Aff(ℚ)`-equivariant.** For every
+    rational affine map `f : x ↦ q·x + r` (`q ≠ 0`, `q, r ∈ ℚ`):
+
+    * `f` fixes both pieces setwise (preimage and image), for `L` and for `Lᶜ`;
+    * the invariant facts persist — `L` is comeagre and null, `Lᶜ` is meagre and
+      conull.
+
+    Thus the measure/category pathology `ℝ = L ⊔ Lᶜ` is not tied to any base
+    point or scale: the whole rational affine group acts on `ℝ` preserving the
+    decomposition. -/
+theorem oxtoby_rat_affine_equivariant {q : ℚ} (hq : q ≠ 0) (r : ℚ) :
+    (fun x : ℝ => (q : ℝ) * x + r) ⁻¹' {x : ℝ | Liouville x}
+        = {x : ℝ | Liouville x} ∧
+    (fun x : ℝ => (q : ℝ) * x + r) '' {x : ℝ | Liouville x}
+        = {x : ℝ | Liouville x} ∧
+    (fun x : ℝ => (q : ℝ) * x + r) ⁻¹' {x : ℝ | Liouville x}ᶜ
+        = {x : ℝ | Liouville x}ᶜ ∧
+    {x : ℝ | Liouville x} ∈ residual ℝ ∧
+    volume {x : ℝ | Liouville x} = 0 ∧
+    IsMeagre {x : ℝ | Liouville x}ᶜ ∧
+    volume ({x : ℝ | Liouville x}ᶜ)ᶜ = 0 :=
+  ⟨setOf_liouville_rat_affine_preimage hq r,
+   setOf_liouville_rat_affine_image hq r,
+   setOf_liouville_compl_rat_affine_preimage hq r,
+   eventually_residual_liouville,
+   volume_setOf_liouville,
+   by rw [IsMeagre, compl_compl]; exact eventually_residual_liouville,
+   by rw [compl_compl]; exact volume_setOf_liouville⟩
+
+#check @liouville_rat_affine_iff
+#check @setOf_liouville_rat_affine_preimage
+#check @setOf_liouville_rat_affine_image
+#check @setOf_liouville_compl_rat_affine_preimage
+#check @oxtoby_rat_affine_equivariant
+
+/-
+  ## Results Summary
+
+  | Theorem | Statement | Status |
+  |---------|-----------|--------|
+  | `liouville_add_rat_iff` | `Liouville (x+r) ↔ Liouville x` | Proved |
+  | `liouville_rat_add_iff` | `Liouville (r+x) ↔ Liouville x` | Proved |
+  | `liouville_neg_iff` | `Liouville (-x) ↔ Liouville x` | Proved |
+  | `liouville_mul_rat_iff` | `Liouville (x*r) ↔ Liouville x` (r≠0) | Proved |
+  | `liouville_rat_mul_iff` | `Liouville (r*x) ↔ Liouville x` (r≠0) | Proved |
+  | `liouville_rat_affine_iff` | `Liouville (q*x+r) ↔ Liouville x` (q≠0) | Proved |
+  | `setOf_liouville_rat_affine_preimage` | `f ⁻¹' L = L` | Proved |
+  | `setOf_liouville_compl_rat_affine_preimage` | `f ⁻¹' Lᶜ = Lᶜ` | Proved |
+  | `setOf_liouville_rat_affine_image` | `f '' L = L` | Proved |
+  | `oxtoby_rat_affine_equivariant` | full equivariant decomposition | Proved |
+
+  **Sorries**: 0
+  **Axioms**: 0 declared (Mathlib triple inherited)
+-/
+
+end AlgebraicRealsMeagerOQ02OQ01Equivariant

--- a/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
@@ -83,7 +83,9 @@
     "assumptions": "0 axioms. Relies only on Mathlib's Baire-category infrastructure (IsMeagre, residual), the Liouville residual/measure-zero results, and elementary complement identities. The ordinary foundational triple (propext / Classical.choice / Quot.sound) is inherited from Mathlib and does not count as an assumption.",
     "theoremCount": 8,
     "definitionCount": 0,
-    "additionalFiles": []
+    "additionalFiles": [
+      "Proofs/AlgebraicRealsMeagerOQ02OQ01Equivariant.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Baire (1899) and Lebesgue (1902) gave two independent notions of 'smallness' for subsets of ℝ: meagre (category-small, a countable union of nowhere-dense sets) and null (measure-small). Oxtoby's 'Measure and Category' (1980) systematically contrasts them, and a recurring theme is that although the two σ-ideals share many formal properties (a duality principle), they are genuinely different: ℝ can be split into a meagre set and a null set whose union is everything. The classic witness is the Liouville numbers, comeagre yet null. The parent entry OQ-02 formalized that half — a comeagre null set. This entry records the mirror image, a meagre set of full measure, and the resulting complementary partition of ℝ.",

--- a/src/data/research/problems/algebraic-reals-meager-oq-02-oq-01.json
+++ b/src/data/research/problems/algebraic-reals-meager-oq-02-oq-01.json
@@ -31,14 +31,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + sharpened (PR #35731 pending): both halves of ℝ = L ⊔ Lᶜ shown dense via new reusable dense_of_conull. Two follow-up open questions logged (ℚ-equivariance; ℝⁿ transfer).",
+    "progressSummary": "COMPLETE + two structural sharpenings: (1) both Oxtoby pieces dense (PR #35731); (2) the decomposition is Aff(ℚ)-equivariant (this session). One follow-up (ℝⁿ transfer) still open.",
     "builtItems": [
       "isMeagre_compl_of_mem_residual in AlgebraicRealsMeagerOQ02OQ01.lean:73 — abstract duality: A∈residual α ⟹ IsMeagre Aᶜ (any TopologicalSpace), via rw[IsMeagre, compl_compl].",
       "nonLiouville_meagre:97 + nonLiouville_conull:103 — the non-Liouville reals Lᶜ are meagre and conull (volume (Lᶜ)ᶜ = 0).",
       "exists_meagre_conull:111 — headline: ∃ meagre S ⊆ ℝ with volume Sᶜ = 0 (a meagre set of full Lebesgue measure).",
       "real_symmetric_oxtoby:131 — ℝ = L ⊔ Lᶜ (union_compl_self + disjoint_compl_right), L comeagre-and-null, Lᶜ meagre-and-conull; oq01_resolution:143 packages it.",
       "dense_of_conull in AlgebraicRealsMeagerOQ02OQ01Dense.lean:72 — conull ⟹ Dense (IsOpenPosMeasure); μ implicit and absent from conclusion so callers must pass (μ := volume).",
-      "dense_liouville / dense_nonLiouville:96,106 — both Oxtoby pieces dense; real_symmetric_oxtoby_dense:129 packages ℝ as two disjoint dense sets (comeagre-null + meagre-conull). PR #35731, verified 0/0."
+      "dense_liouville / dense_nonLiouville:96,106 — both Oxtoby pieces dense; real_symmetric_oxtoby_dense:129 packages ℝ as two disjoint dense sets (comeagre-null + meagre-conull). PR #35731, verified 0/0.",
+      "liouville_add_rat_iff / liouville_rat_add_iff / liouville_neg_iff / liouville_mul_rat_iff / liouville_rat_mul_iff / liouville_rat_affine_iff in AlgebraicRealsMeagerOQ02OQ01Equivariant.lean — pointwise Aff(ℚ)-equivariance of Liouville, each a forall_congr' over the matching LiouvilleWith iff.",
+      "setOf_liouville_rat_affine_preimage / _compl_rat_affine_preimage / _rat_affine_image:130+ — set invariance of L and Lᶜ under rational affine maps.",
+      "oxtoby_rat_affine_equivariant — headline: every rational affine f fixes both Oxtoby pieces setwise, with the residual/null (L) and meagre/conull (Lᶜ) facts retained. VERIFIED 0 sorries, standard-triple axioms only (host lake env lean, EXIT 0)."
     ],
     "insights": [
       "The dual of a comeagre null set is its literal complement: Lᶜ is meagre (because L is comeagre) and conull (because L is null). No new construction needed — the Liouville numbers already encode both halves of the Oxtoby contrast.",
@@ -46,12 +49,14 @@
       "'Full Lebesgue measure' on ℝ (infinite measure space) is formalized as conullity: volume Sᶜ = 0. For S = Lᶜ this is volume L = 0 via compl_compl + volume_setOf_liouville.",
       "Sharp form of OQ-02: the single partition ℝ = L ⊔ Lᶜ simultaneously witnesses comeagre⇏conull (on L) and meagre⇏null (on Lᶜ); the two largeness notions are exactly complementary, not merely inequivalent.",
       "A conull set in any IsOpenPosMeasure space is dense: interior sᶜ = ∅ (null sets have empty interior, interior_eq_empty_of_null) so closure s = (interior sᶜ)ᶜ = univ. This is the measure-side mirror of dense_of_mem_residual.",
-      "Both halves of the symmetric Oxtoby decomposition ℝ = L ⊔ Lᶜ are dense: L by comeagreness (Baire), Lᶜ despite being MEAGRE by conullity. So the measure/category pathology is topologically ubiquitous, not confined to a nowhere-dense set."
+      "Both halves of the symmetric Oxtoby decomposition ℝ = L ⊔ Lᶜ are dense: L by comeagreness (Baire), Lᶜ despite being MEAGRE by conullity. So the measure/category pathology is topologically ubiquitous, not confined to a nowhere-dense set.",
+      "ℚ-equivariance follow-up RESOLVED: the classic predicate Liouville is Aff(ℚ)-invariant — Liouville (q·x+r) ↔ Liouville x for q,r∈ℚ, q≠0. Mechanism: Liouville x ↔ ∀p, LiouvilleWith p x (forall_liouvilleWith_iff), and each LiouvilleWith p already has add_rat_iff/mul_rat_iff/neg_iff in Mathlib; forall_congr'ing over p transports them verbatim to Liouville.",
+      "Set-level: f⁻¹'L = L for every rational affine f; since each such f is a bijection with rational affine inverse y↦q⁻¹y−q⁻¹r, also f''L=L (via Set.image_eq_preimage_of_inverse). Complementation gives the same for Lᶜ. So the whole Oxtoby decomposition ℝ=L⊔Lᶜ is a genuinely Aff(ℚ)-equivariant partition — the measure/category pathology is not tied to any base point or scale."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Follow-up (open): are L and Lᶜ each preserved as comeagre-null / meagre-conull under the ℚ-translation and nonzero-ℚ-scaling action on ℝ? Liouville x ⟺ Liouville (x+q) ⟺ Liouville (qx) for q∈ℚˣ would give a group-equivariant Oxtoby decomposition.",
-      "Follow-up (open): does the dense-two-piece decomposition transfer to ℝⁿ (product Liouville set) — a meagre, dense, conull subset of ℝⁿ?"
+      "Remaining follow-up (open): does the dense-two-piece decomposition transfer to ℝⁿ (product Liouville set) — a meagre, dense, conull subset of ℝⁿ?",
+      "Possible: package Aff(ℚ) as an actual MulAction / AddAction on ℝ and state the invariance as a group-action stabilizer, rather than a per-map iff."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Structural follow-up to the **symmetric Oxtoby decomposition** `ℝ = L ⊔ Lᶜ`
(with `L = {x | Liouville x}`, comeagre-&-null vs meagre-&-conull). This PR
identifies the decomposition's **symmetry group**: the whole partition is
invariant under the rational affine group `Aff(ℚ)` acting on `ℝ` by
`x ↦ q·x + r` (`q ∈ ℚˣ`, `r ∈ ℚ`).

So the measure/category pathology is not an artifact of a particular base point
or scale — it is a genuinely `Aff(ℚ)`-equivariant partition of the line.

## Mechanism

`Liouville x ↔ ∀ p, LiouvilleWith p x` (`forall_liouvilleWith_iff`), and each
`LiouvilleWith p` already carries `add_rat_iff` / `mul_rat_iff` / `neg_iff` in
Mathlib. Quantifying those `iff`s over the exponent `p` (`forall_congr'`)
transports them verbatim to `Liouville`, giving

    Liouville (q·x + r) ↔ Liouville x        (q ≠ 0, q,r ∈ ℚ).

Set-theoretically `f ⁻¹' L = L`; since each `f` is a bijection with rational
affine inverse `y ↦ q⁻¹·y − q⁻¹·r`, also `f '' L = L`
(`Set.image_eq_preimage_of_inverse`). Complementation gives the same for `Lᶜ`.

## Contents (`Proofs/AlgebraicRealsMeagerOQ02OQ01Equivariant.lean`)

- Part I: `liouville_add_rat_iff`, `liouville_rat_add_iff`, `liouville_neg_iff`,
  `liouville_mul_rat_iff`, `liouville_rat_mul_iff`, `liouville_rat_affine_iff`
- Part II: `setOf_liouville_rat_affine_preimage`,
  `setOf_liouville_compl_rat_affine_preimage`, `setOf_liouville_rat_affine_image`
- Part III: `oxtoby_rat_affine_equivariant` — every rational affine map fixes
  both Oxtoby pieces setwise, with the residual/null (`L`) and meagre/conull
  (`Lᶜ`) facts retained.

## Verification

- **10 theorems, 0 sorries.**
- `#print axioms oxtoby_rat_affine_equivariant` → `[propext, Classical.choice, Quot.sound]` (standard triple only; no new axioms).
- Host-verified: `lake env lean Proofs/AlgebraicRealsMeagerOQ02OQ01Equivariant.lean` exits 0.
- Narrow import (`Mathlib.NumberTheory.Transcendental.Liouville.Measure`).

## Honesty / novelty

No new mathematics: Part I is `forall_congr'` over Mathlib's existing
`LiouvilleWith` transfer lemmas; Parts II–III are `Set.ext` / bijection
bookkeeping. The value is the explicit, machine-checked statement that the
Oxtoby anomaly is `Aff(ℚ)`-equivariant. Presented as a modest structural
follow-up, not a new result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)