### PR TITLE
audit: persist 5 clean audits (never-audited research entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29654,8 +29654,38 @@
       "issues": [
         "Stale theoremCount/lineCount reconciled to Lean source after research growth (re-audit)"
       ]
+    },
+    "beta-central-binomial-explicit-rate-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-07-09T00:17:20Z",
+      "result": "clean"
+    },
+    "algebraic-reals-meager-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-07-09T00:17:20Z",
+      "result": "clean"
+    },
+    "erdos-1026-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-07-09T00:17:20Z",
+      "result": "clean"
+    },
+    "erdos-1080-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-07-09T00:17:20Z",
+      "result": "clean"
+    },
+    "erdos-504-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-07-09T00:17:20Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-08T20:35:55Z"
+  "lastUpdated": "2026-07-09T00:17:20Z"
 }


### PR DESCRIPTION
## Summary

Static audit of the 5 never-audited gallery entries in the auditor queue. **All 5 are CLEAN** — meta.json fully consistent with Lean source (0 real sorries, 0 axiom declarations, no structure-encoded assumptions, no undisclosed `native_decide`, theorem statements match the stated claims).

| Entry | status/badge | Notes |
|---|---|---|
| beta-central-binomial-explicit-rate-oq-02 | verified/original | 17 thm; main theorems match `1/(6n²)` & `1/(72n³)` bounds; parent `correction`/`log_correction_eq` verified; parent dep clean |
| algebraic-reals-meager-oq-02-oq-01 | verified/mathlib | 0/0, no structures |
| erdos-1026-oq-05 | verified/verified | 2 structures are definitional data bundles (not assumption typeclasses) → axiomCount=0 correct; counts 216/12/10 match source; honestly scoped to lower-bound direction |
| erdos-1080-oq-03 | verified/mathlib | the lone `sorry` is prose in a comment referencing the parent file; 0 real sorries |
| erdos-504-oq-03 | verified/original | 0/0, no structures |

## Why

These entries were absent from the git-tracked `audit-tracker.json`, so `find-targets.ts` kept re-serving them as "never audited" and the auditor fleet re-audited them repeatedly. This tracker-only change records the completed clean audits so the queue drains.

Tracker-only change (no code/proof changes). Math-agent PR — deployer merges directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)