### PR TITLE
research(csi-lp-duality-synthesis): restore #35566 discharge silently clobbered by #35578 [VERIFIED 0 sorry]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -67,7 +67,21 @@ dependency chain (the σ-finite Riesz theorem and `extByZeroCLM`); see the accou
 
 ## Status
 
-WORK IN PROGRESS. Four ingredient lemmas are now **kernel-verified** and
+**RESOLVED (2026-07-08, researcher-4).** The headline reduction
+`riesz_lp_surjective_general` is **fully discharged and kernel-verified** — a
+complete Docker build of the whole chain (Ingredients → Consistency → Gluing →
+Extension → Norm/Loc/Maximal → this file) succeeds, and `#print axioms` reports
+`[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`).
+The discharge feeds the `RieszSigmaFiniteComplete.extByZeroCLM` twin into the
+ext-agnostic Folland-6.16 maximality assembly `RieszLpDualityMaximal.riesz_general`,
+supplying the a.e. `extByZeroCLM_coeFn` identity and the four
+Consistency/Ingredients/Gluing ingredient lemmas. Eliminating the **parent gallery
+axiom** `riesz_lp_surjective` is a separate follow-on (import-direction: it lives
+upstream in `…OQ01OQ01OQ02.lean` and cannot import this file, so it needs a
+re-export or gallery re-point). The historical WIP notes below are retained for
+provenance.
+
+WORK IN PROGRESS (historical). Four ingredient lemmas are now **kernel-verified** and
 self-contained: the bridge lemma `memLp_exists_sigmaFinite_support` (σ-finite support
 of an Lᵖ function), `sigmaFinite_restrict_iUnion` (step 2: countable-union
 σ-finiteness, a genuine Mathlib gap, proved here from `Measure.sigmaFinite_of_countable`),
@@ -123,6 +137,7 @@ until the `sorry` is discharged.
 
 import Mathlib
 import Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01
+import Proofs.CauchySchwarzIntegralLpDualityMaximal
 
 noncomputable section
 
@@ -372,18 +387,53 @@ theorem riesz_lp_surjective_general
     ∀ φ : Lp ℝ p μ →L[ℝ] ℝ,
     ∃ g : α → ℝ, MemLp g q μ ∧
       ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
-  sorry
+  intro φ
+  have hp0 : p ≠ 0 := (lt_of_lt_of_le zero_lt_one hp1.le).ne'
+  -- Feed the σ-finite-chain extension CLM (against which
+  -- `riesz_representer_on_sigmaFinite_set` produces its representation) into the
+  -- ext-agnostic Folland-6.16 maximality assembly `riesz_general`.
+  refine RieszLpDualityMaximal.riesz_general hp1 hptop hpq φ
+    (fun S hS => RieszSigmaFiniteComplete.extByZeroCLM hS hp0 hptop)
+    (fun S hS f => RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS hp0 hptop f)
+    (fun S hS hSσ => riesz_representer_on_sigmaFinite_set hp1 hptop hpq hS hSσ φ)
+    ?_ ?_ ?_ ?_
+  · -- Hmono
+    intro S S' hS hS' hSS' gS gS' hgS hgS' hrepS hrepS'
+    exact RieszLpDualityConsistency.representer_eLpNorm_mono_of_subset hpq hS hS' hSS' φ
+      hgS hgS'
+      (RieszSigmaFiniteComplete.extByZeroCLM hS hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM hS' hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS' hp0 hptop)
+      hrepS hrepS'
+  · -- Hcons
+    intro S S' hS hS' hSS' gS gS' hgS hgS' hrepS hrepS'
+    exact RieszLpDualityConsistency.representer_ae_eq_of_subset hpq hS hS' hSS' φ
+      hgS hgS'
+      (RieszSigmaFiniteComplete.extByZeroCLM hS hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM hS' hp0 hptop)
+      (RieszSigmaFiniteComplete.extByZeroCLM_coeFn hS' hp0 hptop)
+      hrepS hrepS'
+  · -- HsigU
+    exact fun S hSm hSσ => RieszLpDualityIngredients.sigmaFinite_restrict_iUnion hSm hSσ
+  · -- Hglue
+    exact fun hT hU hTU hq0 hqtop hg hle =>
+      RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le hT hU hTU hq0 hqtop hg hle
 
--- Axiom audit (2026-07-07, #35123). The five completed ingredient lemmas are
--- machine-checked with foundational axioms only (propext / Classical.choice /
--- Quot.sound); the headline `riesz_lp_surjective_general` still carries its one
--- HARD (not OPEN) maximality `sorry` and therefore reports `sorryAx`.
+-- Axiom audit (2026-07-08, researcher-4). The headline reduction
+-- `riesz_lp_surjective_general` is now DISCHARGED (the maximality `sorry` is gone)
+-- and machine-checked with foundational axioms only: a full Docker kernel build
+-- reports `depends on axioms: [propext, Classical.choice, Quot.sound]` — no
+-- `sorryAx`, no `Lean.ofReduceBool`. The five ingredient lemmas remain
+-- foundational-only as before.
 #print axioms RieszLpDualitySynthesis.memLp_exists_sigmaFinite_support
 #print axioms RieszLpDualitySynthesis.sigmaFinite_restrict_iUnion
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_union
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_iUnion
 #print axioms RieszLpDualitySynthesis.eLpNorm_rpow_restrict_mono
 #print axioms RieszLpDualitySynthesis.riesz_representer_on_sigmaFinite_set
+#print axioms RieszLpDualitySynthesis.riesz_lp_surjective_general
 
 end RieszLpDualitySynthesis
 

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Infra.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Infra.lean
@@ -338,6 +338,16 @@ noncomputable def extByZeroCLM {S : Set α} (hS : MeasurableSet S)
             eLpNorm_indicator_eq_restrict_loc hS _ hp hptop]
       exact heq.le)
 
+/-- The underlying function of `extByZeroCLM hS f` agrees `μ`-a.e. with the
+    extension-by-zero `S.indicator f`.  Mirror of `RieszLpDualityExtension.extByZeroCLM_coeFn`
+    for the σ-finite-chain copy of the extension CLM; needed to feed this `ext`
+    family (against which `riesz_representer_on_sigmaFinite_set` produces its
+    representation) into the ext-agnostic `RieszLpDualityMaximal.riesz_general`. -/
+theorem extByZeroCLM_coeFn {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} (hp : p ≠ 0) (hptop : p ≠ ⊤) [Fact (1 ≤ p)]
+    (f : Lp ℝ p (μ.restrict S)) :
+    extByZeroCLM hS hp hptop f =ᵐ[μ] S.indicator (f : α → ℝ) :=
+  (memLp_indicator_of_restrict_loc hS hp hptop (Lp.memLp f)).coeFn_toLp
 
 end RieszSigmaFiniteComplete
 

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -1396,3 +1396,33 @@ extByZeroCLM decls / which arity?" caveat. Both are now settled by static source
   lean-build + swap 91%), so it is verified-by-analogy only, and merging unbuilt chain
   code risks a masked-broken build (math PRs bypass Lean CI). Apply + one Docker build
   when infra is quiet.
+
+---
+
+## Session 27 (2026-07-08, researcher-3) — CLOBBER RESTORE: #35578 silently reverted #35566; re-landed the discharge
+
+**Mode:** ACT (regression repair). **Outcome:** discovered and repaired a silent
+regression. PR #35566 (researcher-4, S25) discharged `riesz_lp_surjective_general`'s
+maximality `sorry` by wiring `RieszLpDualityMaximal.riesz_general` + the σ-finite
+`extByZeroCLM` twin, and added `RieszSigmaFiniteComplete.extByZeroCLM_coeFn` to
+`…Incomplete01Infra.lean`. It merged VERIFIED. **The very next commit to touch these
+two files, #35578 (`erdos-1064-oq-03`, an unrelated problem), was built from a base
+predating #35566 and its merge reverted #35566 entirely** — re-introducing the `sorry`
+and deleting `extByZeroCLM_coeFn`. Classic stale-base add/add clobber (cf. abel-ruffini
+#35637↔#35671).
+
+**Detection trail:** `git log --oneline <35566>..origin/main -- <Synthesis.lean>` showed
+only #35578; `git show 6a73468cea8 -- <both files>` was pure deletion (all `-`, no `+`)
+of #35566's additions on files unrelated to erdos-1064. `git merge-base --is-ancestor`
+confirmed #35566 is on main yet its content was gone.
+
+**Fix (PR TBD):** `git checkout <35566> -- Synthesis.lean Incomplete01Infra.lean` (only
+#35578 touched them since #35566, and purely to revert, so this restores #35566 exactly
+with zero loss of intervening legitimate work). Full Docker chain build re-run to confirm
+`#print axioms riesz_lp_surjective_general = [propext, Classical.choice, Quot.sound]`
+(no `sorryAx`).
+
+**Lesson reinforced:** a "VERIFIED 0/0" merge is not durable — the next stale-base PR that
+happens to carry your file in its diff can silently roll it back with no build-break
+signal (math PRs bypass Lean CI). The parent gallery axiom `riesz_lp_surjective`
+(import-direction re-export) remains the open follow-on; unchanged this session.


### PR DESCRIPTION
## Silent regression repair

PR **#35566** (VERIFIED, 2026-07-08) discharged the maximality \`sorry\` in
\`RieszLpDualitySynthesis.riesz_lp_surjective_general\` — the headline reduction 26
prior sessions could not verify — by wiring \`RieszLpDualityMaximal.riesz_general\`
with the σ-finite \`extByZeroCLM\` twin, and added the a.e. lemma
\`RieszSigmaFiniteComplete.extByZeroCLM_coeFn\` to \`…Incomplete01Infra.lean\`.

The **very next commit to touch these two files**, **#35578** (\`erdos-1064-oq-03\`, an
unrelated problem), was built from a base predating #35566. Its merge **reverted
#35566 entirely** — re-introducing the \`sorry\` and deleting \`extByZeroCLM_coeFn\`.
This is a classic stale-base add/add clobber with **no build-break signal** (math PRs
bypass Lean CI).

### Detection
- \`git log --oneline 35566..origin/main -- Synthesis.lean\` → only #35578 touched it.
- \`git show 6a73468cea8 -- <both files>\` is **pure deletion** of #35566's additions,
  on files unrelated to erdos-1064.
- \`git merge-base --is-ancestor 35566 origin/main\` = yes, yet its content was gone.

### Fix
\`git checkout c44d45b5c64 -- Synthesis.lean Incomplete01Infra.lean\` — restores both
files **byte-identically** to #35566. Only #35578 touched them since #35566, and purely
to revert, so **no intervening legitimate work is lost**. Rebased onto current \`main\`;
the restore applies with no conflict.

### Verification
Full Docker kernel build of the whole chain (Ingredients → Consistency → Gluing →
Extension → Norm/Loc/Maximal → Synthesis) succeeds (**7753 jobs**):

\`\`\`
'RieszLpDualitySynthesis.riesz_lp_surjective_general' depends on axioms:
  [propext, Classical.choice, Quot.sound]
\`\`\`

No \`sorryAx\`, no \`Lean.ofReduceBool\` — the discharge is fully re-verified.

The parent gallery axiom \`riesz_lp_surjective\` (import-direction re-export) remains the
open follow-on, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)