### PR TITLE
Fix: sync roth-theorem-k3-oq-03-oq-01 meta counts to Lean source

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,9 +58,9 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 214,
+    "lineCount": 354,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 8,
+    "theoremCount": 12,
     "definitionCount": 4
   },
   "overview": {
@@ -142,9 +142,9 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 255,
+    "lineCount": 354,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/RothTheoremOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Synced stale line/theorem counts in `roth-theorem-k3-oq-03-oq-01/meta.json` to the actual `RothTheoremOQ03OQ01.lean` source.

## Evidence

The file grew via merged research PRs (`kAPCount_update_split` #35500, telescoping `kAPCount_diag_eq_sum_subsets` #35639) but both count blocks in `meta.json` were left stale. Actual source: **354 lines, 12 theorems** (`wc -l` + comment-aware theorem/lemma grep).

**Before → After:**
- `meta.lineCount` 214 → 354
- `meta.theoremCount` 8 → 12
- `leanFile.lineCount` 255 → 354
- `leanFile.theoremCount` 11 → 12

`definitionCount` (4) and `axiomCount` (0) were already correct. JSON validated; `pnpm build` green.

---
Automated fix by lean-mechanic agent.