### PR TITLE
Fix: leanFile.axiomCount to literal declaration count (p-vs-np, bsd, erdos-630)

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -722,7 +722,7 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 38,
+    "axiomCount": 17,
     "lineCount": 7435,
     "sorries": 0,
     "path": "Proofs/BirchSwinnertonDyer.lean",

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -214,7 +214,7 @@
     ],
     "namespace": "Erdos630",
     "lineCount": 246,
-    "axiomCount": 22,
+    "axiomCount": 11,
     "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Erdos630Problem.lean",

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -134,7 +134,7 @@
     "opens": [
       "ComplexityCore"
     ],
-    "axiomCount": 372,
+    "axiomCount": 121,
     "sorries": 0,
     "definitionCount": 154,
     "theoremCount": 302,


### PR DESCRIPTION
## Fix

Correct `leanFile.axiomCount` to the literal `axiom`-declaration count in the main `.lean` file for three gallery entries. Direct continuation of merged PR #35770, which fixed 17 entries of this identical class; these three were not in that batch.

## Evidence

Per CLAUDE.md Axiom Integrity Policy, `leanFile.axiomCount` counts only literal `axiom` declarations in the main file. `meta.axiomCount` (the authoritative total) folds in companion-chain / structure-encoded assumptions and is **left unchanged**, so no disclosure is lost.

| Entry | leanFile.axiomCount | meta.axiomCount (kept) | Notes |
|-------|--------------------:|-----------------------:|-------|
| p-vs-np | 372 → **121** | 372 | 372 = documented chain aggregate (PNPBarriersUnified 121 + ComplexityCore 5 + Legacy 88 + OQ01 28 + Sound 123 + PvsNP 7); main file has 121 literal axioms |
| birch-swinnerton-dyer | 38 → **17** | 38 | assumptions text: "17 axiom declarations"; 38 includes structural/stub assumptions |
| erdos-630 | 22 → **11** | 22 | 11 literal `axiom` declarations in Erdos630Problem.lean |

**Verification**: literal counts obtained with a nesting-aware Lean comment stripper that also catches `private`/`protected`/`noncomputable axiom`. `leanFile.lineCount` already matches each current file, confirming the snapshots are otherwise current (only the axiom field was inflated).

Three other scan candidates (erdos-218, erdos-1126-oq-01, erdos-1012-oq-03) were **false positives** — each carries a `private axiom` that an unqualified `^axiom` regex misses; their counts (3, 6, 1) are already correct and were left untouched.

---
Automated fix by lean-mechanic agent.