### PR TITLE
Fix: sync erdos-165 meta counts to Lean source

### DIFF
--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -56,11 +56,11 @@
       "Repaired latent Mathlib-drift breakage in erdos_165 (linarith could not widen 5/4 to 2 without k²/log k ≥ 0)"
     ],
     "axiomCount": 10,
-    "lineCount": 323,
+    "lineCount": 363,
     "assumptions": "10 axioms (unchanged): ramseyNumber, ramseyNumber_symm, ramseyNumber_recurrence, R3_small_values, aks_upper_bound, shearer_upper_bound, kim_lower_bound, bk_pgm_bound, cjms_bound, hhkp_bound. 0 sorries. New theorems add no axioms; asymptotic_constant_le is fully axiom-free; pgm_conjecture_refuted depends only on the existing hhkp_bound.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 5,
-    "definitionCount": 3,
+    "theoremCount": 7,
+    "definitionCount": 4,
     "additionalFiles": [
       "Proofs/Stubs/Erdos165Aristotle.lean"
     ]
@@ -166,10 +166,10 @@
       "Real"
     ],
     "namespace": "Erdos165",
-    "lineCount": 323,
+    "lineCount": 363,
     "axiomCount": 10,
-    "theoremCount": 5,
-    "definitionCount": 3,
+    "theoremCount": 7,
+    "definitionCount": 4,
     "path": "Proofs/Erdos165Problem.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Synced stale line/theorem/definition counts in `erdos-165/meta.json` to `Erdos165Problem.lean`.

## Evidence

The Lean file grew but both count blocks (`meta` and `leanFile`) were stale. Actual source: **363 lines, 7 theorems, 4 definitions** (comment-aware count — the previously-claimed 8th theorem was a docstring prose line `lemma \`asymptotic_constant_le\`, which handles...`, not a declaration).

**Before → After (both blocks):**
- `lineCount` 323 → 363
- `theoremCount` 5 → 7
- `definitionCount` 3 → 4

`axiomCount` (10) already correct. JSON validated.

---
Automated fix by lean-mechanic agent.