### PR TITLE
audit(shannon-awgn-oq-02-oq-02): sync stale meta counts to source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24727,10 +24727,12 @@
       "issues": []
     },
     "shannon-channel-coding-awgn-oq-02-oq-02": {
-      "auditCount": 3,
-      "issues": [],
-      "result": "clean",
-      "lastAudited": "2026-07-01T12:19:41Z"
+      "auditCount": 4,
+      "issues": [
+        "meta.lineCount 113\u2192291, theoremCount 5\u219212, description \"234 lines/10 theorems\"\u2192291/12 (leanFile block already correct; meta block + description stale after file grew across #35740/#35760/#35765). Core integrity verified/0 sorries/0 axioms confirmed against source."
+      ],
+      "lastAudited": "2026-07-09T01:00:00Z",
+      "result": "issues-fixed"
     },
     "shannon-channel-coding-awgn-oq-03": {
       "auditCount": 2,
@@ -29687,5 +29689,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T00:17:20Z"
+  "lastUpdated": "2026-07-09T01:00:00Z"
 }

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "shannon-channel-coding-awgn-oq-02-oq-02",
   "slug": "shannon-channel-coding-awgn-oq-02-oq-02",
   "title": "Multi-Symbol AWGN Output Power E[(∑Wᵢ)²] = ∑E[Wᵢ²] from the Variance of a Pairwise-Independent Sum",
-  "description": "Generalizes the parent two-term AWGN output-power identity E[(X+Z)²] = E[X²] + E[Z²] to a finite block of symbols: for pairwise-independent, zero-mean, square-integrable contributions Wᵢ (i ∈ s), the aggregate output power adds, E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The proof is the variance-of-a-sum (Bienaymé) identity for pairwise-independent families — ProbabilityTheory.IndepFun.variance_sum, where the vanishing pairwise covariances collapse the double sum to the diagonal — specialized to zero mean via E[W²] = Var[W] (ProbabilityTheory.variance_eq_sub). Pairwise (not mutual) independence already suffices. 234 lines, 10 theorems, 0 axioms, 0 sorries.",
+  "description": "Generalizes the parent two-term AWGN output-power identity E[(X+Z)²] = E[X²] + E[Z²] to a finite block of symbols: for pairwise-independent, zero-mean, square-integrable contributions Wᵢ (i ∈ s), the aggregate output power adds, E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The proof is the variance-of-a-sum (Bienaymé) identity for pairwise-independent families — ProbabilityTheory.IndepFun.variance_sum, where the vanishing pairwise covariances collapse the double sum to the diagonal — specialized to zero mean via E[W²] = Var[W] (ProbabilityTheory.variance_eq_sub). Pairwise (not mutual) independence already suffices. 291 lines, 12 theorems, 0 axioms, 0 sorries.",
   "leanFile": {
     "imports": [
       "Mathlib"
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 113,
-    "theoremCount": 5,
+    "lineCount": 291,
+    "theoremCount": 12,
     "definitionCount": 0,
     "badge": "mathlib",
     "originalContributions": [


### PR DESCRIPTION
## Audit finding: stale descriptive metadata

**Entry:** `shannon-channel-coding-awgn-oq-02-oq-02` ("Multi-Symbol AWGN Output Power…")

The Lean source `Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean` grew across three PRs (#35740 → #35760 → #35765) but the `meta` block and top-level `description` kept their original counts. The `leanFile` block was already correct (291/12).

| Field | Was | Now | Source truth |
|-------|-----|-----|--------------|
| `meta.lineCount` | 113 | 291 | `wc -l` = 291 |
| `meta.theoremCount` | 5 | 12 | 12 `theorem`/`lemma` decls |
| description | "234 lines, 10 theorems" | "291 lines, 12 theorems" | — |

**Integrity claims verified correct against source** (no change needed): `status: verified`, `badge: mathlib`, `sorries: 0`, `axiomCount: 0`, no `native_decide`. This PR only corrects descriptive count fields.

Tracker entry updated to `issues-fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)