### PR TITLE
Fix: sync erdos-1207-oq-03 leanFile counts to Lean source

### DIFF
--- a/src/data/proofs/erdos-1207-oq-03/meta.json
+++ b/src/data/proofs/erdos-1207-oq-03/meta.json
@@ -167,9 +167,9 @@
       "Finset"
     ],
     "namespace": "Erdos1207OQ03",
-    "lineCount": 188,
+    "lineCount": 217,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 2,
     "path": "Proofs/Erdos1207OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Synced the stale `leanFile` count block in `erdos-1207-oq-03/meta.json` to `Erdos1207OQ03.lean`. The `meta` block was already current (217/14); only the `leanFile` block lagged.

## Evidence

Actual source: **217 lines, 14 theorems**.

**Before → After (leanFile block):**
- `lineCount` 188 → 217
- `theoremCount` 12 → 14

`definitionCount` (2) and `axiomCount` (0) already correct. JSON validated.

---
Automated fix by lean-mechanic agent.