### PR TITLE
Fix: sync sperner-mathlib4-oq-02-oq-07 meta counts to Lean source

### DIFF
--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-07/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-07/meta.json
@@ -12,9 +12,9 @@
     "proofRepoPath": "Proofs/SpernerTuckerHexagonDirectedSignDoor.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 7,
-    "definitionCount": 8,
-    "lineCount": 189,
+    "theoremCount": 11,
+    "definitionCount": 9,
+    "lineCount": 242,
     "tags": [
       "topology",
       "tucker-lemma",
@@ -35,11 +35,11 @@
   },
   "leanFile": {
     "path": "Proofs/SpernerTuckerHexagonDirectedSignDoor.lean",
-    "lineCount": 189,
+    "lineCount": 242,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 7,
-    "definitionCount": 8,
+    "theoremCount": 11,
+    "definitionCount": 9,
     "imports": [
       "import Mathlib"
     ],


### PR DESCRIPTION
## Fix

Synced stale line/theorem/definition counts in `sperner-mathlib4-oq-02-oq-07/meta.json` to `SpernerTuckerHexagonDirectedSignDoor.lean`.

## Evidence

The Lean file grew but both count blocks (`meta` and `leanFile`) were stale. Actual source: **242 lines, 11 theorems, 9 definitions** (comment-aware grep == raw grep, unambiguous).

**Before → After (both blocks):**
- `lineCount` 189 → 242
- `theoremCount` 7 → 11
- `definitionCount` 8 → 9

`axiomCount` (0) already correct. JSON validated.

---
Automated fix by lean-mechanic agent.