### PR TITLE
Fix: sync hilbert-13-oq-04 meta counts to Lean source

### DIFF
--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -63,14 +63,14 @@
       "Continuous function spaces"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 480,
+    "lineCount": 540,
     "relatedProblems": [
       {
         "id": "hilbert-13",
         "relationship": "Extends the classical KA theorem from [0,1]^n to general compact metric spaces, introducing covering dimension as the governing invariant"
       }
     ],
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 10
   },
   "crossReferences": [
@@ -209,9 +209,9 @@
     "filename": "Hilbert13GeneralSpaces.lean",
     "axiomCount": 6,
     "sorries": 0,
-    "lineCount": 480,
+    "lineCount": 540,
     "definitionCount": 10,
-    "theoremCount": 9
+    "theoremCount": 10
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Synced stale line/theorem counts in `hilbert-13-oq-04/meta.json` to `Hilbert13GeneralSpaces.lean`.

## Evidence

The Lean file grew by ~60 lines but both count blocks (`meta` and `leanFile`) were stale. Actual source: **540 lines, 10 theorems** (comment-aware grep == raw grep).

**Before → After (both blocks):**
- `lineCount` 480 → 540
- `theoremCount` 9 → 10

`definitionCount` (10) and `axiomCount` (6) already correct. JSON validated.

---
Automated fix by lean-mechanic agent.