### PR TITLE
research(dirichlets-oq-02-oq-03): Tendsto packaging of B/C^p divergence [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ03.lean
@@ -1060,4 +1060,36 @@ theorem B_div_C_pow_diverges (p m : ℕ) : ∃ K, ∀ k, K ≤ k → m * (C k) ^
     _ = (C k) ^ (p + 1) := by rw [pow_succ]; ring
     _ ≤ B k := hK0 k hkK0
 
+/-- **Filter-level packaging: `B k / (C k)^p → ∞` for every fixed power `p`.**
+The division-free eventual bounds `C_pow_le_B_eventually` / `B_div_C_pow_diverges`
+say only that `m·(C k)^p ≤ B k` eventually, for each constant `m`.  Repackaged as a
+single `Filter.Tendsto … atTop atTop` statement, this is the honest analytic assertion
+that the factorial certificate `B` dominates *every* fixed polynomial power of the
+primorial certificate `C` — the real-valued ratio genuinely diverges to `+∞`.
+Proof: `Tendsto … atTop` unfolds to `∀ M, eventually M ≤ B k / (C k)^p`; take the
+constant `m = ⌈M⌉₊` in `B_div_C_pow_diverges`, then clear the (positive) denominator. -/
+theorem tendsto_B_div_C_pow_atTop (p : ℕ) :
+    Filter.Tendsto (fun k => (B k : ℝ) / (C k : ℝ) ^ p) Filter.atTop Filter.atTop := by
+  rw [Filter.tendsto_atTop]
+  intro M
+  obtain ⟨K, hK⟩ := B_div_C_pow_diverges p ⌈M⌉₊
+  filter_upwards [Filter.eventually_ge_atTop K] with k hk
+  have hCpos : (0 : ℝ) < (C k : ℝ) ^ p := by
+    have hC0 : 0 < C k := by have := C_ge_add k; omega
+    have : (0 : ℝ) < (C k : ℝ) := by exact_mod_cast hC0
+    positivity
+  have hcast : (⌈M⌉₊ : ℝ) * (C k : ℝ) ^ p ≤ (B k : ℝ) := by exact_mod_cast hK k hk
+  rw [le_div_iff₀ hCpos]
+  calc M * (C k : ℝ) ^ p
+      ≤ (⌈M⌉₊ : ℝ) * (C k : ℝ) ^ p :=
+        mul_le_mul_of_nonneg_right (Nat.le_ceil M) hCpos.le
+    _ ≤ (B k : ℝ) := hcast
+
+/-- **The classical ratio `B k / C k → ∞`** (the `p = 1` instance of
+`tendsto_B_div_C_pow_atTop`): the factorial certificate outgrows the primorial
+certificate itself, not merely additively but with unbounded ratio. -/
+theorem tendsto_B_div_C_atTop :
+    Filter.Tendsto (fun k => (B k : ℝ) / (C k : ℝ)) Filter.atTop Filter.atTop := by
+  simpa using tendsto_B_div_C_pow_atTop 1
+
 end DirichletsTheoremOQ02OQ03

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -172,12 +172,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 1063,
+    "lineCount": 1095,
     "axiomCount": 0,
     "path": "Proofs/DirichletsTheoremOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 7,
-    "theoremCount": 70
+    "theoremCount": 72
   },
   "sorries": 0,
   "status": "verified",

--- a/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Step 13, VERIFIED 0/0): B dominates every fixed POWER of C — C_pow_le_B_eventually ((C k)^p ≤ B k eventually, all p) and B_div_C_pow_diverges (m·(C k)^p ≤ B k eventually, all p,m), generalizing C_sq_le_B / B_div_C_diverges via the tetration lower bound 2↑↑k≤B k. Complements the counting-function side π(x;4,3)≥k+1 (#35706) and the value-side ratio divergence (#35694). Remaining: analytic terminus (2k·ln k truth) and a Tendsto-filter packaging.",
+    "progressSummary": "PROGRESS (Step 14, VERIFIED 0/0): packaged the p-th power domination as a Filter.Tendsto atTop statement — B k/(C k)^p → ∞ for every fixed p (tendsto_B_div_C_pow_atTop) with the classical ratio B/C→∞ corollary, resolving the \"Tendsto-filter packaging\" next-step. Analytic upper-bound terminus (2k·ln k) and ℝⁿ growth-rank hierarchy remain the only open directions.",
     "builtItems": [
       "exists_prime_three_mod_four_in_interval (DirichletsTheoremOQ02OQ03.lean:78) — certified interval form: ∀n ∃ prime p≡3 mod4, n<p≤4·(n+1)!−1.",
       "nextP3 + nextP3_le_of + nextP3_le_factorial (DirichletsTheoremOQ02OQ03.lean:113–134) — least prime ≡3 mod4 above n, its minimality, and the one-step factorial bound.",
@@ -59,7 +59,9 @@
       "primesCount3 + card_le_primesCount3 / primesCount3_mono / primesCount3_ge_of_doubly_exp / primesCount3_ge / primesCount3_unbounded in Proofs/DirichletsTheoremOQ02OQ03.lean Step 11 (5 thm, 0/0, PR #35706)",
       "two_pow_two_mul_le_tower2 (2^(2k+2) ≤ 2↑↑k for k≥5) in DirichletsTheoremOQ02OQ03.lean Step 13 — exponent-level tetration engine",
       "C_pow_le_B_eventually (∀p, ∃K, ∀k≥K, (C k)^p ≤ B k) in DirichletsTheoremOQ02OQ03.lean Step 13 — B dominates every fixed power of C, generalizing C_sq_le_B (p=2 case) via the tetration lower bound 2↑↑k≤B k",
-      "B_div_C_pow_diverges (∀p m, ∃K, ∀k≥K, m·(C k)^p ≤ B k) in DirichletsTheoremOQ02OQ03.lean Step 13 — B/C^p→∞ for all p, generalizing B_div_C_diverges (p=1 case)"
+      "B_div_C_pow_diverges (∀p m, ∃K, ∀k≥K, m·(C k)^p ≤ B k) in DirichletsTheoremOQ02OQ03.lean Step 13 — B/C^p→∞ for all p, generalizing B_div_C_diverges (p=1 case)",
+      "tendsto_B_div_C_pow_atTop (DirichletsTheoremOQ02OQ03.lean): Tendsto (fun k => (B k:ℝ)/(C k:ℝ)^p) atTop atTop for every fixed p — filter-level packaging of B_div_C_pow_diverges (0 axioms/0 sorries)",
+      "tendsto_B_div_C_atTop: classical ratio B k / C k → ∞ (p=1 instance)"
     ],
     "insights": [
       "The Euclid construction N=4·(n+1)!−1 certifies an INTERVAL, not just existence: a prime ≡3 (mod 4) always lies in (n, 4·(n+1)!−1]. The upper bound is p∣N⇒p≤N; the lower is the standard p∤(n+1)! coprimality twist.",
@@ -82,7 +84,8 @@
       "Counting-function side (π(x;4,3)) done: p3 k ≤ x ⟹ k+1 ≤ π(x;4,3) transfers the certified value bound p3 k ≤ 4^(2^k) into π(x;4,3) ≥ k+1 for x ≥ 4^(2^k) — an iterated-log lower bound, honestly isolating the analytic gap to the truth π(x;4,3) ∼ x/(2 ln x) (PR #35706).",
       "B/C ratio divergence (∀m ∃K ∀k≥K, m·C k ≤ B k) was completed on main by #35694 (C_succ_add_one, C_sq_le_B, B_div_C_diverges, quartic_le_two_pow) — do NOT rebuild; the exact quadratic recursion C(k+1)=(C k+1)·C k is there too.",
       "The Step-11 tetration lower bound 2↑↑k≤B k makes p-th power domination transparent: bound C side by (4^(2^k))^p=2^(2^(k+1)·p), B side below by 2^(2↑↑(k-1)), and reduce to the exponent comparison 2^(k+1)·p ≤ 2↑↑(k-1); the multiplier p is absorbed via p≤2^(k-1). No native_decide.",
-      "Arbitrary multiplier m folds in for free: m·(C k)^p ≤ (C k)^(p+1) once m≤C k (from C k≥k+3), so B_div_C_pow_diverges follows from C_pow_le_B_eventually(p+1) with no extra estimate."
+      "Arbitrary multiplier m folds in for free: m·(C k)^p ≤ (C k)^(p+1) once m≤C k (from C k≥k+3), so B_div_C_pow_diverges follows from C_pow_le_B_eventually(p+1) with no extra estimate.",
+      "The p-power domination upgrades cleanly from division-free ∀-∃ (m·(C k)^p ≤ B k eventually) to a first-class Filter.Tendsto atTop statement: unfold tendsto_atTop, take m=⌈M⌉₊, clear the positive denominator via le_div_iff₀. No analytic input needed — purely a repackaging of the certified eventual bounds."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Upgrades the division-free eventual bounds already in `DirichletsTheoremOQ02OQ03.lean`
(`C_pow_le_B_eventually` / `B_div_C_pow_diverges`: `m·(C k)^p ≤ B k` eventually) to a
**first-class filter statement**, resolving the recorded *"Tendsto-filter packaging"* next step:

```lean
theorem tendsto_B_div_C_pow_atTop (p : ℕ) :
    Tendsto (fun k => (B k : ℝ) / (C k : ℝ) ^ p) atTop atTop
```

for every fixed power `p`, plus the classical ratio corollary

```lean
theorem tendsto_B_div_C_atTop :
    Tendsto (fun k => (B k : ℝ) / (C k : ℝ)) atTop atTop   -- the p = 1 instance
```

Here `C` is the primorial-tower certificate and `B` the factorial certificate for the
`≡ 3 (mod 4)` progression. The statement is the honest analytic assertion that `B`
dominates *every fixed polynomial power* of `C` — the real ratio genuinely diverges to `+∞`,
not merely that additive/multiplicative constants are eventually beaten.

## Proof

`Tendsto … atTop` unfolds to `∀ M, eventually M ≤ B k / (C k)^p`; take the constant
`m = ⌈M⌉₊` in `B_div_C_pow_diverges`, then clear the positive denominator (`C k ≥ 3`)
via `le_div_iff₀`. No analytic input — purely a repackaging of the certified eventual bounds.

## Verification

- Docker build green: `Proofs.DirichletsTheoremOQ02OQ03` (7743 jobs).
- **0 axioms, 0 sorries**, no `native_decide`. Foundation-only.
- meta.json: `lineCount` 1063→1095, `theoremCount` 70→72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)