### PR TITLE
research(erdos-1090-incomplete-01): ramseyNumber monotone in k [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -511,6 +511,27 @@ theorem ramsey_lower_bound (k : ℕ) (hk : k ≥ 3) : ramseyNumber k ≥ k := by
   rw [ge_iff_le, ← hcard]
   exact hasRamseyProperty_card_ge A k hA
 
+/--
+**Monotonicity of the Ramsey number in `k`:**
+The minimal Ramsey-witnessing size grows with the demand: for `3 ≤ k' ≤ k`,
+`R(k') ≤ R(k)`.  Requiring *more* monochromatic collinear points cannot make the
+threshold smaller.  Concretely the set defining `R(k)` is contained in the one
+defining `R(k')` (`hasRamseyProperty_antitone`), and `hunter_observation` makes the
+`k`-set nonempty, so its infimum is attained by a set `A` that — having the property
+for `k` — *a fortiori* has it for `k'`.  Hence `A.card = R(k)` lies in the
+`k'`-defining set and `R(k') = sInf ≤ R(k)`.
+-/
+theorem ramseyNumber_mono {k k' : ℕ} (hk' : 3 ≤ k') (hkk : k' ≤ k) :
+    ramseyNumber k' ≤ ramseyNumber k := by
+  have hk : 3 ≤ k := le_trans hk' hkk
+  have hne : {n : ℕ | ∃ A : Finset Point, A.card = n ∧ HasRamseyProperty A k}.Nonempty := by
+    obtain ⟨A, hA⟩ := hunter_observation k hk
+    exact ⟨A.card, A, rfl, hA⟩
+  obtain ⟨A, hcard, hA⟩ := Nat.sInf_mem hne
+  -- `A` attains `R(k)` and, by downward monotonicity in `k`, also witnesses `k'`.
+  refine Nat.sInf_le ⟨A, ?_, hasRamseyProperty_antitone hkk hA⟩
+  simpa [ramseyNumber] using hcard
+
 /-
 **R(3) is Small:**
 The k = 3 case can be achieved with a small set of points.

--- a/research/problems/erdos-1090-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1090-incomplete-01/knowledge.md
@@ -61,3 +61,20 @@ copy differs in the vector-space (`Point` vs `Fin d → ℝ`) and the nonzero-co
 - Quantitative `ramseyNumber k` upper bound (explicit |A|); only `ramsey_lower_bound (≥ k)` exists.
 - `ramseyNumber_mono` (k'≤k ⟹ ramseyNumber k' ≤ ramseyNumber k) is a clean easy follow-up via
   `hasRamseyProperty_antitone` + `Nat.sInf` subset monotonicity.
+
+## Session 2026-07-08 (researcher-3): ramseyNumber_mono
+
+Proved the flagged "clean easy follow-up": `ramseyNumber_mono {k k'} (3 ≤ k') (k' ≤ k) :
+ramseyNumber k' ≤ ramseyNumber k`. The set defining `R(k)` is contained in the one
+defining `R(k')` (`hasRamseyProperty_antitone`); `hunter_observation k` (k ≥ 3 via
+k ≥ k' ≥ 3) makes the `k`-set nonempty, so `Nat.sInf_mem` attains it with a set `A`
+that also witnesses `k'`, giving `A.card = R(k) ∈` the `k'`-set and `Nat.sInf_le`.
+Membership goal `A.card = ramseyNumber k` closed by `simpa [ramseyNumber] using hcard`
+(hcard is `A.card = Nat.sInf {…k}`, defeq to `ramseyNumber k`).
+
+Host `lake env lean` EXIT 0; `#print axioms ramseyNumber_mono =
+[propext, Classical.choice, Quot.sound]`. File 730→751 lines, 14→15 theorems (defs 18
+unchanged); gallery `erdos-1090/meta.json` line/thm synced in both leanFile & meta blocks.
+
+Remaining next-steps unchanged: SylvesterGallai/HellyProperty still DEFS; quantitative
+`ramseyNumber k` upper bound; projection-body dedup (3 verified copies, left as-is).

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -69,9 +69,9 @@
       "erdos1090_generalized_affirmative: proves the previously-unproved r-coloring version Erdos1090Generalized k r, by specializing ramsey_construction_general to C=Fin r (multicolor Hales–Jewett needs no extra hypothesis on r)"
     ],
     "axiomCount": 0,
-    "lineCount": 730,
+    "lineCount": 751,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 18
   },
   "overview": {
@@ -107,9 +107,9 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 730,
+    "lineCount": 751,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 18,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Proves the follow-up flagged in the problem knowledge as a "clean easy" next step:

\`\`\`lean
theorem ramseyNumber_mono {k k' : ℕ} (hk' : 3 ≤ k') (hkk : k' ≤ k) :
    ramseyNumber k' ≤ ramseyNumber k
\`\`\`

The minimal Ramsey-witnessing size grows with the demand `k`: requiring *more*
monochromatic collinear points cannot lower the threshold.

## Proof

The set defining `R(k)` is contained in the one defining `R(k')`
(`hasRamseyProperty_antitone`: a set with the property for `k` has it for any `k' ≤ k`).
`hunter_observation k` (with `k ≥ 3`, which follows from `k ≥ k' ≥ 3`) makes the
`k`-defining set nonempty, so `Nat.sInf_mem` attains its infimum by a set `A` with
`A.card = R(k)`. That `A` a fortiori witnesses `k'`, so `R(k) ∈` the `k'`-defining set,
and `Nat.sInf_le` gives `R(k') ≤ R(k)`. The `3 ≤ k'` hypothesis is necessary: without
nonemptiness of the `k`-set, `sInf ∅ = 0` would break the inequality.

## Verification

Host `lake env lean Proofs/Erdos1090Problem.lean` → **exit 0** (only pre-existing
warnings). Axiom audit:

\`\`\`
'Erdos1090.ramseyNumber_mono' depends on axioms: [propext, Classical.choice, Quot.sound]
\`\`\`

No `sorryAx`, no new axioms — the whole file remains 0-sorry / 0-axiom.

File 730→751 lines, 14→15 theorems (defs 18 unchanged); gallery
`src/data/proofs/erdos-1090/meta.json` line/theorem counts synced in both the
`leanFile` and `meta` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)