### PR TITLE
research(e-transcendental-oq-02-oq-06): frequency-mismatch non-normality criteria [VERIFIED 0 sorry]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -819,6 +819,127 @@ theorem normal_imp_irrational_of_criterion (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
   exact not_normal_of_eventually_missing_ktuple b hb (q : ℝ) k N₀ s hmiss hn
 
 -- ============================================================
+-- PART IV.7: FREQUENCY-MISMATCH CRITERIA
+-- ============================================================
+
+/-!
+## Frequency-mismatch criteria for non-normality
+
+`not_normal_of_eventually_missing_ktuple` handles the *absence* obstruction
+(frequency `0 ≠ b^{-k}`). The criteria below cover the general
+frequency-mismatch phenomenon: a `k`-tuple whose empirical frequency
+converges to *any* wrong limit — or is merely *eventually* over- or
+under-represented — cannot occur in a normal number.
+
+The one-sided bounds (`_ge`, `_le`) are strictly more flexible than
+convergence: an *eventual* inequality suffices, and no limit need be
+identified in advance (over-representation, in particular, is invisible to the
+absence criterion). All follow from the single structural fact that normality
+pins the frequency limit to `b^{-k}` (`tendsto_tupleFreq_of_normal`), combined
+with uniqueness / order-closure of limits. The base is left free: these hold
+for every `b` (the normal regime being `b ≥ 2`).
+-/
+
+/-- Empirical frequency of the `k`-tuple `s` among the first `N` starting
+    positions of `x`'s base-`b` expansion — the quantity `IsNormalInBase`
+    constrains. -/
+noncomputable def tupleFreq (b : ℕ) (x : ℝ) (k : ℕ) (s : Fin k → Fin b) (N : ℕ) : ℝ :=
+  (((Finset.range N).filter
+    (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ) / (N : ℝ)
+
+/-- Unfolding lemma: in a number normal in base `b` the frequency of every
+    `k`-tuple converges to `b^{-k}`. This is `IsNormalInBase` restated through
+    `tupleFreq`, the shared hypothesis of all the criteria below. -/
+theorem tendsto_tupleFreq_of_normal (b : ℕ) (x : ℝ) (hn : IsNormalInBase b x)
+    (k : ℕ) (s : Fin k → Fin b) :
+    Tendsto (tupleFreq b x k s) atTop (nhds ((b : ℝ) ^ (-(k : ℤ)))) :=
+  hn k s
+
+/-- **Frequency-mismatch criterion.** If the frequency of some `k`-tuple `s`
+    converges to a limit `L ≠ b^{-k}`, then `x` is **not** normal in base `b`.
+    Strictly generalises `not_normal_of_eventually_missing_ktuple` (the `L = 0`
+    case): a wrong *positive* limiting frequency is just as fatal as absence.
+    Proof: normality forces the frequency to `b^{-k}`; uniqueness of limits then
+    equates `L` with `b^{-k}`, contradicting `hne`. -/
+theorem not_normal_of_freq_tendsto_ne (b : ℕ) (x : ℝ)
+    (k : ℕ) (s : Fin k → Fin b) (L : ℝ)
+    (hL : Tendsto (tupleFreq b x k s) atTop (nhds L))
+    (hne : L ≠ (b : ℝ) ^ (-(k : ℤ))) :
+    ¬ IsNormalInBase b x := fun hn =>
+  hne (tendsto_nhds_unique hL (tendsto_tupleFreq_of_normal b x hn k s))
+
+/-- **Over-representation criterion.** If the tuple `s` is *eventually*
+    represented with frequency at least `c`, and `c > b^{-k}`, then `x` is not
+    normal in base `b`. Only a one-sided *eventual* bound is required — no
+    convergence, and no exact limit. This obstruction (a tuple appearing *too
+    often*) is inaccessible to the absence criterion. Proof: order-closure of
+    limits pushes the eventual bound `c ≤ tupleFreq` through to `c ≤ b^{-k}`,
+    contradicting `hc`. -/
+theorem not_normal_of_eventually_freq_ge (b : ℕ) (x : ℝ)
+    (k : ℕ) (s : Fin k → Fin b) (c : ℝ)
+    (hev : ∀ᶠ N in atTop, c ≤ tupleFreq b x k s N)
+    (hc : (b : ℝ) ^ (-(k : ℤ)) < c) :
+    ¬ IsNormalInBase b x := by
+  intro hn
+  have hle : c ≤ (b : ℝ) ^ (-(k : ℤ)) :=
+    ge_of_tendsto (tendsto_tupleFreq_of_normal b x hn k s) hev
+  linarith
+
+/-- **Under-representation criterion.** If the tuple `s` is *eventually*
+    represented with frequency at most `c`, and `c < b^{-k}`, then `x` is not
+    normal in base `b`. The absence criterion is the extreme instance (`c → 0`).
+    Proof: order-closure of limits pushes `tupleFreq ≤ c` through to
+    `b^{-k} ≤ c`, contradicting `hc`. -/
+theorem not_normal_of_eventually_freq_le (b : ℕ) (x : ℝ)
+    (k : ℕ) (s : Fin k → Fin b) (c : ℝ)
+    (hev : ∀ᶠ N in atTop, tupleFreq b x k s N ≤ c)
+    (hc : c < (b : ℝ) ^ (-(k : ℤ))) :
+    ¬ IsNormalInBase b x := by
+  intro hn
+  have hge : (b : ℝ) ^ (-(k : ℤ)) ≤ c :=
+    le_of_tendsto (tendsto_tupleFreq_of_normal b x hn k s) hev
+  linarith
+
+/-- The single-digit matching count is the `k = 1` tuple count for the constant
+    tuple `fun _ => d`: the `Fin 1` quantifier collapses and `n + 0 = n`. -/
+private lemma tupleFreq_one_eq_digitFreq (b : ℕ) (x : ℝ) (d : Fin b) (N : ℕ) :
+    tupleFreq b x 1 (fun _ => d) N =
+      (((Finset.range N).filter (fun n => nthDigit b n x = (d : ℤ))).card : ℝ)
+        / (N : ℝ) := by
+  unfold tupleFreq
+  have hfilter :
+      ((Finset.range N).filter
+        (fun n => ∀ i : Fin 1, nthDigit b (n + i.val) x = ((fun _ => d) i : ℤ)))
+        = (Finset.range N).filter (fun n => nthDigit b n x = (d : ℤ)) := by
+    apply Finset.filter_congr
+    intro n _
+    rw [Fin.forall_fin_one]
+    simp
+  rw [hfilter]
+
+/-- **Single-digit frequency-mismatch criterion.** If a single digit `d` occurs
+    with frequency converging to `L ≠ 1/b`, then `x` is **not** normal in base
+    `b`. Strengthens `not_normal_of_eventually_missing_digit` (the `L = 0`
+    absence case) to *any* wrong limiting frequency — including a digit that is
+    strictly over-represented. The `k = 1` shadow of
+    `not_normal_of_freq_tendsto_ne`. -/
+theorem not_normal_of_digit_freq_ne (b : ℕ) (x : ℝ) (d : Fin b) (L : ℝ)
+    (hL : Tendsto
+      (fun N => (((Finset.range N).filter (fun n => nthDigit b n x = (d : ℤ))).card : ℝ)
+        / (N : ℝ)) atTop (nhds L))
+    (hne : L ≠ (b : ℝ)⁻¹) :
+    ¬ IsNormalInBase b x := by
+  apply not_normal_of_freq_tendsto_ne b x 1 (fun _ => d) L
+  · have heq : tupleFreq b x 1 (fun _ => d) =
+        (fun N => (((Finset.range N).filter
+          (fun n => nthDigit b n x = (d : ℤ))).card : ℝ) / (N : ℝ)) :=
+      funext (tupleFreq_one_eq_digitFreq b x d)
+    rw [heq]; exact hL
+  · have hb1 : (b : ℝ) ^ (-((1 : ℕ) : ℤ)) = (b : ℝ)⁻¹ := by
+      rw [Nat.cast_one, zpow_neg, zpow_one]
+    rw [hb1]; exact hne
+
+-- ============================================================
 -- PART V: OPEN QUESTION
 -- ============================================================
 

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -207,10 +207,10 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 1021,
+    "lineCount": 1142,
     "axiomCount": 1,
-    "theoremCount": 61,
-    "definitionCount": 5,
+    "theoremCount": 67,
+    "definitionCount": 6,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/e-transcendental-oq-02-oq-06.json
+++ b/src/data/research/problems/e-transcendental-oq-02-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SHARPNESS COMPLETE (verified 0/0 new): exhibited an explicit VERIFIED irrational non-normal number (base-b Liouville constant, b>=3) via a factorial-number-system digit computation, proving the converse of normal_imp_irrational fails (irrational_not_imp_normal). Open conjecture axiom e_absolutely_normal unchanged.",
+    "progressSummary": "FREQUENCY-MISMATCH CRITERIA COMPLETE (verified 0/0 new axioms): generalized the absence-only non-normality criterion to full frequency mismatch — wrong limit, and one-sided eventual over/under-representation (the over-representation direction was previously inaccessible). Single-digit corollary included. Only genuinely-open axiom e_absolutely_normal remains.",
     "builtItems": [
       "normal_ktuple_infinitely_often (Proofs/ETranscendentalOQ02.lean): {n | s occurs at n}.Infinite for x normal in base b. Verified 0 sorry; axioms [propext, Classical.choice, Quot.sound].",
       "normal_imp_disjunctive (same file): every finite digit string appears at least once (corollary via Set.Infinite.nonempty).",
@@ -43,7 +43,11 @@
       "exists_factorial_window (Nat.find): forall n>=1 exists k, k!<=n<(k+1)! — ETranscendentalOQ02.lean",
       "liouvilleNumber_floor: exact integer part floor(b^n*liouvilleNumber b)=sum b^(n-i!) — ETranscendentalOQ02.lean",
       "liouvilleNumber_digit_le_one: nthDigit <=1 for n>=2 — ETranscendentalOQ02.lean",
-      "liouvilleNumber_not_normal (b>=3), exists_irrational_not_normal, irrational_not_imp_normal — ETranscendentalOQ02.lean"
+      "liouvilleNumber_not_normal (b>=3), exists_irrational_not_normal, irrational_not_imp_normal — ETranscendentalOQ02.lean",
+      "tupleFreq def + tendsto_tupleFreq_of_normal (IsNormalInBase restated as freq->b^{-k}) in ETranscendentalOQ02.lean",
+      "not_normal_of_freq_tendsto_ne: converges to L != b^{-k} => not normal (tendsto_nhds_unique); generalizes not_normal_of_eventually_missing_ktuple (L=0 case)",
+      "not_normal_of_eventually_freq_ge / _le: one-sided EVENTUAL bound (>c>b^{-k} or <c<b^{-k}) => not normal via ge_of_tendsto/le_of_tendsto; no convergence needed, over-representation now covered",
+      "not_normal_of_digit_freq_ne: single-digit k=1 corollary via tupleFreq_one_eq_digitFreq (Fin.forall_fin_one collapse), zpow_neg/zpow_one for b^{-1}=1/b"
     ],
     "insights": [
       "The stated target normal_imp_irrational was ALREADY a complete 0-sorry theorem (Session 13); OQ-02-OQ-06 as literally phrased was resolved. Added genuinely new theory instead of reclaiming.",
@@ -53,16 +57,17 @@
       "The count/Tendsto engine (match_count_le + tendsto_bounded_count_div_atTop_zero + tendsto_nhds_unique + zpow_pos) that discharged normal_imp_irrational is fully reusable for arbitrary x: only the missing-tuple hypothesis differs between the rational case and the general criterion.",
       "SHARPNESS RESOLVED: the base-b Liouville constant liouvilleNumber b = sum_{i>=0} b^(-i!) (Mathlib) is an explicit VERIFIED irrational non-normal number for every b>=3 — irrational does NOT imply normal (converse of normal_imp_irrational fails).",
       "Digit computation via the factorial number system: for k!<=n<(k+1)!, floor(b^n * liouvilleNumber b) = sum_{i=0}^{k} b^(n-i!); the tail b^n*remainder < 1 uses Mathlib remainder_lt prime and sub_one_div_inv_le_two giving < 2/b <= 2/3 (needs b>=3: the doubled 0!=1! leading term puts digit 2 at n=1 only).",
-      "Every base-b digit of liouvilleNumber b is 0 or 1 from position n>=2 on (residue b^(n-k!) % b in {0,1}: lower-index terms divisible by b, top term 1 iff n is a factorial), so digit 2 is eventually missing and not_normal_of_eventually_missing_digit applies."
+      "Every base-b digit of liouvilleNumber b is 0 or 1 from position n>=2 on (residue b^(n-k!) % b in {0,1}: lower-index terms divisible by b, top term 1 iff n is a factorial), so digit 2 is eventually missing and not_normal_of_eventually_missing_digit applies.",
+      "Frequency-mismatch is the general non-normality obstruction: normality pins every k-tuple frequency to exactly b^{-k} (tendsto_tupleFreq_of_normal), so ANY wrong limiting frequency, or even a one-sided eventual over/under-representation, forbids normality. The absence (frequency-0) case is just the c->0 extreme of under-representation."
     ],
     "mathlibGaps": [
       "omega does not discharge variable-divisor Euclidean identities (a/T*T + a%T = a with T variable, nonlinear); use Nat.mod_add_div'/Nat.div_add_mod explicitly.",
       "Genuine irrational-AND-non-normal WITNESS (true sharpness of 'irrational ⇏ normal') still needs the real→digit bridge for a specific transcendental: computing nthDigit b n x = ⌊bⁿx⌋%b for an explicit series (e.g. Liouville ∑ b^(-k!)) requires summing the tail to isolate the k-th digit — a real-analysis construction not present. The abstract criterion is the tool; only the witness digit-computation is missing."
     ],
     "nextSteps": [
-      "Frequency-mismatch criterion: strengthen not_normal_of_eventually_missing_digit to digit-frequency != 1/b implies not normal (only the 0-frequency/absence case done).",
       "Quantitative disjunctivity: bound first-occurrence position of a fixed k-tuple via the normality convergence rate (only qualitative infinitude proved).",
-      "The open axiom e_absolutely_normal is genuinely open — not eliminable; the sharpness of normal_imp_irrational is now complete."
+      "Real->digit bridge for an explicit transcendental to exhibit an over-represented (freq>1/b) non-normal witness, now that the over-representation criterion exists (nthDigit b n x = floor(b^n x) % b tail-sum computation).",
+      "The open axiom e_absolutely_normal is genuinely open (not eliminable)."
     ],
     "markdown": "# Knowledge Base: e-transcendental-oq-02-oq-06\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Advances **e-transcendental-oq-02-oq-06** (nextStep #1) by generalizing the non-normality machinery in `proofs/Proofs/ETranscendentalOQ02.lean` from the *absence-only* case to the full **frequency-mismatch** obstruction.

Previously the file had `not_normal_of_eventually_missing_ktuple` / `not_normal_of_eventually_missing_digit`, which only detect a k-tuple/digit whose frequency is **0** (`0 ≠ b^{-k}`). This PR captures the general phenomenon: normality pins *every* k-tuple frequency to exactly `b^{-k}`, so any wrong limit — or even a one-sided eventual over/under-representation — forbids normality.

## New declarations (Part IV.7)

- `tupleFreq b x k s N` — empirical frequency of tuple `s` among the first `N` positions (the quantity `IsNormalInBase` constrains).
- `tendsto_tupleFreq_of_normal` — `IsNormalInBase b x → tupleFreq → b^{-k}`.
- `not_normal_of_freq_tendsto_ne` — frequency converges to `L ≠ b^{-k}` ⟹ **not normal**. Strictly generalizes `not_normal_of_eventually_missing_ktuple` (the `L = 0` case): a wrong *positive* frequency is just as fatal as absence. Proof: `tendsto_nhds_unique`.
- `not_normal_of_eventually_freq_ge` / `not_normal_of_eventually_freq_le` — a **one-sided eventual** bound `c` with `c > b^{-k}` (resp. `c < b^{-k}`) ⟹ not normal. Strictly more flexible than convergence: no limit need be identified, and **over-representation** (a tuple appearing too often) is invisible to the absence criterion. Proof: `ge_of_tendsto` / `le_of_tendsto` order-closure.
- `not_normal_of_digit_freq_ne` — single-digit `k=1` corollary: digit frequency `→ L ≠ 1/b` ⟹ not normal. Via `tupleFreq_one_eq_digitFreq` (the `Fin 1` quantifier collapse).

The base `b` is left free in the new criteria — they hold for every `b` (normal regime `b ≥ 2`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ETranscendentalOQ02` → **Build completed successfully (3085 jobs)**, 0 errors.
- **0 sorries**, **0 new axioms**. The only axiom remains `e_absolutely_normal` (whether *e* is absolutely normal is genuinely open).
- No new lint warnings from the added code.
- meta.json counts synced: lineCount 1021→1142, theoremCount 61→67, definitionCount 5→6 (axiomCount 1 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)