### PR TITLE
research(e-transcendental-oq-02): frequency-mismatch non-normality criterion

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -819,6 +819,99 @@ theorem normal_imp_irrational_of_criterion (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
   exact not_normal_of_eventually_missing_ktuple b hb (q : ℝ) k N₀ s hmiss hn
 
 -- ============================================================
+-- PART IV.7: FREQUENCY-MISMATCH CRITERION
+-- ============================================================
+
+/-!
+## From absence to frequency anomaly
+
+`not_normal_of_eventually_missing_ktuple` handles the extreme case of a tuple
+whose matching frequency is `0`. The results below generalise it to *any*
+frequency anomaly. If the matching frequency of a tuple `s` converges to a limit
+`L ≠ b^{-k}`, or merely stays *eventually bounded away* from `b^{-k}` on one
+side, then `x` cannot be normal in base `b`.
+
+The `tendsto`-form (`not_normal_of_match_freq_tendsto_ne`) is the exact converse
+of the definition, via uniqueness of limits. The one-sided `eventually` forms
+(`_eventually_le` / `_eventually_ge`) are strictly stronger: they never assume
+the frequency converges at all, only that it stays on the wrong side of a
+threshold separated from `b^{-k}` — capturing *under-* and *over-representation*,
+not just outright absence. The single-digit specialisation
+`not_normal_of_digit_freq_tendsto_ne` records the familiar statement "a digit
+occurring with density `≠ 1/b` forbids normality".
+-/
+
+/-- **Frequency-mismatch criterion (`k`-tuple form).** If the matching frequency
+    of the tuple `s` converges to a limit `L ≠ b^{-k}`, then `x` is not normal in
+    base `b`. Immediate from uniqueness of limits: normality forces the very same
+    frequency to converge to `b^{-k}`. Generalises
+    `not_normal_of_eventually_missing_ktuple`, which is the `L = 0` instance. -/
+theorem not_normal_of_match_freq_tendsto_ne (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (k : ℕ) (s : Fin k → Fin b) (L : ℝ)
+    (hlim : Tendsto
+        (fun N : ℕ =>
+          (((Finset.range N).filter
+            (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ)
+            / (N : ℝ))
+        atTop (nhds L))
+    (hne : L ≠ (b : ℝ) ^ (-(k : ℤ))) :
+    ¬ IsNormalInBase b x := by
+  intro hn
+  exact hne (tendsto_nhds_unique hlim (hn k s))
+
+/-- **Under-representation forbids normality.** If the matching frequency of `s`
+    is *eventually* at most some `c < b^{-k}`, then `x` is not normal — no
+    convergence of the frequency itself is assumed. Choosing `c` strictly between
+    `0` and `b^{-k}` recovers the eventually-missing obstruction. -/
+theorem not_normal_of_match_freq_eventually_le (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (k : ℕ) (s : Fin k → Fin b) (c : ℝ)
+    (hc : c < (b : ℝ) ^ (-(k : ℤ)))
+    (hbound : ∀ᶠ N in atTop,
+        (((Finset.range N).filter
+          (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ)
+          / (N : ℝ) ≤ c) :
+    ¬ IsNormalInBase b x := by
+  intro hn
+  have hle : (b : ℝ) ^ (-(k : ℤ)) ≤ c := le_of_tendsto (hn k s) hbound
+  linarith
+
+/-- **Over-representation forbids normality.** Dual of
+    `not_normal_of_match_freq_eventually_le`: if the matching frequency of `s` is
+    *eventually* at least some `c > b^{-k}`, then `x` is not normal. Again no
+    convergence of the frequency is assumed. -/
+theorem not_normal_of_match_freq_eventually_ge (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (k : ℕ) (s : Fin k → Fin b) (c : ℝ)
+    (hc : (b : ℝ) ^ (-(k : ℤ)) < c)
+    (hbound : ∀ᶠ N in atTop,
+        c ≤ (((Finset.range N).filter
+          (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ)
+          / (N : ℝ)) :
+    ¬ IsNormalInBase b x := by
+  intro hn
+  have hge : c ≤ (b : ℝ) ^ (-(k : ℤ)) := ge_of_tendsto (hn k s) hbound
+  linarith
+
+/-- **Single-digit frequency-mismatch criterion.** If a digit `d` occurs in the
+    base-`b` expansion of `x` with limiting frequency `L ≠ 1/b`, then `x` is not
+    normal in base `b`. The `k = 1` case of `not_normal_of_match_freq_tendsto_ne`,
+    recording the intuition that normality demands every digit at density `1/b`
+    (`b^{-1} = b⁻¹`). Generalises `not_normal_of_eventually_missing_digit`, which
+    is the `L = 0` instance. -/
+theorem not_normal_of_digit_freq_tendsto_ne (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (d : Fin b) (L : ℝ)
+    (hlim : Tendsto
+        (fun N : ℕ =>
+          (((Finset.range N).filter (fun n => nthDigit b n x = (d : ℤ))).card : ℝ)
+            / (N : ℝ))
+        atTop (nhds L))
+    (hne : L ≠ (b : ℝ)⁻¹) :
+    ¬ IsNormalInBase b x := by
+  refine not_normal_of_match_freq_tendsto_ne b hb x 1 (fun _ => d) L ?_ ?_
+  · simp only [Fin.forall_fin_one, Fin.val_zero, add_zero]
+    exact hlim
+  · rwa [Nat.cast_one, zpow_neg_one]
+
+-- ============================================================
 -- PART V: OPEN QUESTION
 -- ============================================================
 

--- a/research/problems/e-transcendental-oq-02-oq-06/knowledge.md
+++ b/research/problems/e-transcendental-oq-02-oq-06/knowledge.md
@@ -19,3 +19,45 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-08 (Researcher-8) — Frequency-mismatch criterion
+
+**Mode**: FRESH | **Outcome**: progress (VERIFIED, 0 sorry, 0 new axiom)
+
+### What I did
+Generalized the existing *absence* obstruction (`not_normal_of_eventually_missing_ktuple/_digit`,
+which handles matching-frequency `0`) to arbitrary frequency anomalies. Added to
+`proofs/Proofs/ETranscendentalOQ02.lean` (PART IV.7):
+
+- `not_normal_of_match_freq_tendsto_ne` — if a k-tuple's matching frequency
+  converges to `L ≠ b^(-k)`, then not normal. One line via `tendsto_nhds_unique`
+  against the definitional limit `hn k s`.
+- `not_normal_of_match_freq_eventually_le` / `_eventually_ge` — if the matching
+  frequency is *eventually* `≤ c < b^(-k)` (resp. `≥ c > b^(-k)`), then not
+  normal. Uses `le_of_tendsto` / `ge_of_tendsto`; **no convergence of the
+  frequency is assumed** — strictly stronger than the tendsto form. Captures
+  under- and over-representation.
+- `not_normal_of_digit_freq_tendsto_ne` — single digit with density `≠ 1/b`
+  forbids normality (k=1). Bridged `b^(-(1:ℤ)) = b⁻¹` via `Nat.cast_one` +
+  `zpow_neg_one`; collapsed the `∀ i : Fin 1` predicate with `Fin.forall_fin_one`.
+
+### Key findings
+- The absence case was the extreme (`L = 0`) instance; the general anomaly needs
+  nothing beyond uniqueness of limits (`tendsto_nhds_unique`) or one-sided limit
+  comparison (`le_of_tendsto` / `ge_of_tendsto`). The eventual-bound forms are the
+  real content: they conclude non-normality from a *single* frequency inequality
+  holding eventually, without the frequency converging.
+- The necessary-condition theory for normality is now complete: irrational ⇐
+  normal, disjunctive ⇐ normal, and full frequency-mismatch ⇐ ¬normal.
+
+### Status
+Core axiom `e_absolutely_normal` remains **genuinely open** (no base is proved
+normal for e as of 2026) — not eliminable. This session strengthens the sharp
+boundary, not the open core.
+
+### Files modified
+- `proofs/Proofs/ETranscendentalOQ02.lean` (+4 theorems, PART IV.7)
+- `src/data/proofs/e-transcendental-oq-02/meta.json` (lineCount 1021→1114, theoremCount 61→65)
+- `src/data/research/problems/e-transcendental-oq-02-oq-06.json` (knowledge)

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -207,9 +207,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 1021,
+    "lineCount": 1114,
     "axiomCount": 1,
-    "theoremCount": 61,
+    "theoremCount": 65,
     "definitionCount": 5,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/e-transcendental-oq-02-oq-06.json
+++ b/src/data/research/problems/e-transcendental-oq-02-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SHARPNESS COMPLETE (verified 0/0 new): exhibited an explicit VERIFIED irrational non-normal number (base-b Liouville constant, b>=3) via a factorial-number-system digit computation, proving the converse of normal_imp_irrational fails (irrational_not_imp_normal). Open conjecture axiom e_absolutely_normal unchanged.",
+    "progressSummary": "PROGRESS: frequency-mismatch non-normality criterion added (tendsto-ne + one-sided eventual bounds + single-digit density≠1/b); necessary-condition theory for normality now complete. Core axiom e_absolutely_normal remains genuinely open.",
     "builtItems": [
       "normal_ktuple_infinitely_often (Proofs/ETranscendentalOQ02.lean): {n | s occurs at n}.Infinite for x normal in base b. Verified 0 sorry; axioms [propext, Classical.choice, Quot.sound].",
       "normal_imp_disjunctive (same file): every finite digit string appears at least once (corollary via Set.Infinite.nonempty).",
@@ -43,7 +43,10 @@
       "exists_factorial_window (Nat.find): forall n>=1 exists k, k!<=n<(k+1)! — ETranscendentalOQ02.lean",
       "liouvilleNumber_floor: exact integer part floor(b^n*liouvilleNumber b)=sum b^(n-i!) — ETranscendentalOQ02.lean",
       "liouvilleNumber_digit_le_one: nthDigit <=1 for n>=2 — ETranscendentalOQ02.lean",
-      "liouvilleNumber_not_normal (b>=3), exists_irrational_not_normal, irrational_not_imp_normal — ETranscendentalOQ02.lean"
+      "liouvilleNumber_not_normal (b>=3), exists_irrational_not_normal, irrational_not_imp_normal — ETranscendentalOQ02.lean",
+      "not_normal_of_match_freq_tendsto_ne (ETranscendentalOQ02.lean): tuple matching-frequency → L ≠ b^(-k) ⇒ ¬normal, via tendsto_nhds_unique",
+      "not_normal_of_match_freq_eventually_le / _eventually_ge: eventual one-sided frequency bound strictly away from b^(-k) ⇒ ¬normal (no convergence assumed), via le_of_tendsto / ge_of_tendsto",
+      "not_normal_of_digit_freq_tendsto_ne: single-digit density ≠ 1/b ⇒ ¬normal (k=1 specialization; b^(-1)=b⁻¹ bridge via Nat.cast_one+zpow_neg_one)"
     ],
     "insights": [
       "The stated target normal_imp_irrational was ALREADY a complete 0-sorry theorem (Session 13); OQ-02-OQ-06 as literally phrased was resolved. Added genuinely new theory instead of reclaiming.",
@@ -53,16 +56,16 @@
       "The count/Tendsto engine (match_count_le + tendsto_bounded_count_div_atTop_zero + tendsto_nhds_unique + zpow_pos) that discharged normal_imp_irrational is fully reusable for arbitrary x: only the missing-tuple hypothesis differs between the rational case and the general criterion.",
       "SHARPNESS RESOLVED: the base-b Liouville constant liouvilleNumber b = sum_{i>=0} b^(-i!) (Mathlib) is an explicit VERIFIED irrational non-normal number for every b>=3 — irrational does NOT imply normal (converse of normal_imp_irrational fails).",
       "Digit computation via the factorial number system: for k!<=n<(k+1)!, floor(b^n * liouvilleNumber b) = sum_{i=0}^{k} b^(n-i!); the tail b^n*remainder < 1 uses Mathlib remainder_lt prime and sub_one_div_inv_le_two giving < 2/b <= 2/3 (needs b>=3: the doubled 0!=1! leading term puts digit 2 at n=1 only).",
-      "Every base-b digit of liouvilleNumber b is 0 or 1 from position n>=2 on (residue b^(n-k!) % b in {0,1}: lower-index terms divisible by b, top term 1 iff n is a factorial), so digit 2 is eventually missing and not_normal_of_eventually_missing_digit applies."
+      "Every base-b digit of liouvilleNumber b is 0 or 1 from position n>=2 on (residue b^(n-k!) % b in {0,1}: lower-index terms divisible by b, top term 1 iff n is a factorial), so digit 2 is eventually missing and not_normal_of_eventually_missing_digit applies.",
+      "Frequency-mismatch criterion completes the sharp-boundary theory: absence (freq 0) was the extreme case; under-/over-representation (freq eventually bounded away from b^(-k) on either side) equally forbids normality, and needs NO convergence hypothesis — only le_of_tendsto/ge_of_tendsto against the definitional limit."
     ],
     "mathlibGaps": [
       "omega does not discharge variable-divisor Euclidean identities (a/T*T + a%T = a with T variable, nonlinear); use Nat.mod_add_div'/Nat.div_add_mod explicitly.",
       "Genuine irrational-AND-non-normal WITNESS (true sharpness of 'irrational ⇏ normal') still needs the real→digit bridge for a specific transcendental: computing nthDigit b n x = ⌊bⁿx⌋%b for an explicit series (e.g. Liouville ∑ b^(-k!)) requires summing the tail to isolate the k-th digit — a real-analysis construction not present. The abstract criterion is the tool; only the witness digit-computation is missing."
     ],
     "nextSteps": [
-      "Frequency-mismatch criterion: strengthen not_normal_of_eventually_missing_digit to digit-frequency != 1/b implies not normal (only the 0-frequency/absence case done).",
       "Quantitative disjunctivity: bound first-occurrence position of a fixed k-tuple via the normality convergence rate (only qualitative infinitude proved).",
-      "The open axiom e_absolutely_normal is genuinely open — not eliminable; the sharpness of normal_imp_irrational is now complete."
+      "The open axiom e_absolutely_normal is genuinely open — not eliminable. The non-normality theory (irrationality, disjunctivity, absence, and now full frequency-mismatch) is complete on the necessary-condition side."
     ],
     "markdown": "# Knowledge Base: e-transcendental-oq-02-oq-06\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Strengthens the sharp-boundary theory for **e-transcendental-oq-02-oq-06** (normality ⇒ irrationality / disjunctivity). The existing obstruction `not_normal_of_eventually_missing_ktuple`/`_digit` only handled a tuple/digit with matching frequency **exactly 0** (absence). This PR generalizes it to **any frequency anomaly**.

Added to `proofs/Proofs/ETranscendentalOQ02.lean` (new PART IV.7):

- **`not_normal_of_match_freq_tendsto_ne`** — a k-tuple whose matching frequency converges to `L ≠ b^(-k)` forbids normality. Immediate from `tendsto_nhds_unique` against the definitional limit.
- **`not_normal_of_match_freq_eventually_le` / `_eventually_ge`** — the matching frequency being *eventually* `≤ c < b^(-k)` (resp. `≥ c > b^(-k)`) forbids normality, via `le_of_tendsto` / `ge_of_tendsto`. **No convergence of the frequency is assumed** — strictly stronger than the tendsto form; captures under-/over-representation, not just absence.
- **`not_normal_of_digit_freq_tendsto_ne`** — the familiar single-digit statement: a digit with density `≠ 1/b` forbids normality (k=1 case; `b^(-1)=b⁻¹`).

This completes the necessary-condition theory for normality: `normal ⇒ irrational`, `normal ⇒ disjunctive`, and now full frequency-mismatch `⇒ ¬normal`.

## Verification

- Docker build: **`Built Proofs.ETranscendentalOQ02` (3085 jobs, 0 errors)**.
- **0 sorries, 0 new axioms.** The open-question axiom `e_absolutely_normal` is unchanged and remains genuinely open (no base is proved normal for e as of 2026).
- Only new diagnostics are benign `unused variable hb` warnings — `hb` is kept for signature uniformity with the sibling `not_normal_of_*` criteria.

## Metadata
- `meta.json`: `leanFile.lineCount` 1021→1114, `theoremCount` 61→65.
- Problem knowledge + session note updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)