### PR TITLE
research(binary-gcd-oq-01-oq-04-oq-03): avgSteps_one_ge — rational Ω(log N) average lower bound (a=1) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
@@ -245,4 +245,45 @@ theorem totalSteps_one_ge (N : ℕ) :
     _ ≤ ∑ b ∈ Finset.Icc 1 N, Nat.log 2 b :=
         Finset.sum_le_sum_of_subset hsub
 
+/-- **Average-level Ω(log N) lower bound (a = 1 row).** Dividing the total lower
+    bound `totalSteps_one_ge` by `N` and using `N ≤ 2·(N − ⌊N/2⌋)` (i.e. the upper
+    half `(⌊N/2⌋, N]` is at least half of `[1, N]`) gives an average-case lower
+    bound with an `N`-independent coefficient:
+
+      (∑_{b=1}^{N} binaryGcdSteps 1 b) / N ≥ (log₂ N − 1) / 2.
+
+    This is the rational-form counterpart of the integer total bound
+    `totalSteps_one_ge`, matching the *rational* `O(log N)` ceiling `avgSteps_le`
+    (which at `a = 1` reads `≤ 2·log₂ N + 2`). Together they sandwich the `a = 1`
+    average between `(log₂ N − 1)/2` and `2·log₂ N + 2` — an explicit `Θ(log N)` at
+    the average level, matching the *order* of Brent's average-case result. The
+    sharp `0.7050` leading constant remains out of reach (see file header). -/
+theorem avgSteps_one_ge (N : ℕ) (hN : 0 < N) :
+    ((Nat.log 2 N : ℚ) - 1) / 2 ≤ (totalSteps 1 N : ℚ) / (N : ℚ) := by
+  have hNQ : (0 : ℚ) < (N : ℚ) := by exact_mod_cast hN
+  -- clear both denominators: goal becomes  (log₂ N − 1)·N ≤ (totalSteps 1 N)·2
+  rw [le_div_iff₀ hNQ, div_mul_eq_mul_div,
+    div_le_iff₀ (show (0 : ℚ) < 2 by norm_num)]
+  -- reduce to the ℕ inequality  N · (log₂ N − 1) ≤ 2 · totalSteps 1 N
+  have key : N * (Nat.log 2 N - 1) ≤ 2 * totalSteps 1 N := by
+    have h2 : N ≤ 2 * (N - N / 2) := by omega
+    have hge := totalSteps_one_ge N
+    calc N * (Nat.log 2 N - 1)
+        ≤ (2 * (N - N / 2)) * (Nat.log 2 N - 1) := mul_le_mul_right' h2 _
+      _ = 2 * ((N - N / 2) * (Nat.log 2 N - 1)) := by ring
+      _ ≤ 2 * totalSteps 1 N := by omega
+  have keyQ : (N : ℚ) * ((Nat.log 2 N - 1 : ℕ) : ℚ) ≤ 2 * (totalSteps 1 N : ℚ) := by
+    exact_mod_cast key
+  -- bridge the ℕ truncated subtraction `log₂ N − 1` up to the ℚ subtraction
+  have hle : (Nat.log 2 N : ℚ) - 1 ≤ ((Nat.log 2 N - 1 : ℕ) : ℚ) := by
+    rcases Nat.eq_zero_or_pos (Nat.log 2 N) with h0 | h1
+    · rw [h0]; norm_num
+    · rw [Nat.cast_sub h1]; norm_num
+  have hNnn : (0 : ℚ) ≤ (N : ℚ) := le_of_lt hNQ
+  calc ((Nat.log 2 N : ℚ) - 1) * (N : ℚ)
+      ≤ ((Nat.log 2 N - 1 : ℕ) : ℚ) * (N : ℚ) := mul_le_mul_of_nonneg_right hle hNnn
+    _ = (N : ℚ) * ((Nat.log 2 N - 1 : ℕ) : ℚ) := by ring
+    _ ≤ 2 * (totalSteps 1 N : ℚ) := keyQ
+    _ = (totalSteps 1 N : ℚ) * 2 := by ring
+
 end BinaryGcdOQ01OQ04OQ03


### PR DESCRIPTION
## Summary

Adds `avgSteps_one_ge` to `Proofs/BinaryGcdOQ01OQ04OQ03.lean`, completing the **a = 1 average-case sandwich** for the Stein binary-GCD step count.

The file already had:
- `avgSteps_le` — rational **ceiling** `O(log N)` (at a = 1: ≤ 2·log₂N + 2)
- `totalSteps_one_ge` — integer **floor** on the total `∑_{b=1}^N binaryGcdSteps 1 b`

This PR supplies the missing **rational floor**:
```
(log₂ N − 1)/2  ≤  (∑_{b=1}^N binaryGcdSteps 1 b) / N
```
Together these pin the a = 1 average at an explicit **Θ(log N)**, matching the *order* of Brent's average-case result.

## Proof

Divide `totalSteps_one_ge` by `N`, using `N ≤ 2·(N − ⌊N/2⌋)` (the upper half `(⌊N/2⌋, N]` is at least half of `[1, N]`) to get an `N`-independent coefficient, then bridge the ℕ truncated subtraction `log₂ N − 1` up to the ℚ subtraction.

## Verification

- Docker build green (7745 jobs), `Replayed Proofs.BinaryGcdOQ01OQ04OQ03`
- 0 `sorry`, 0 `axiom` — foundational-only (standard Mathlib order/cast lemmas)
- One harmless deprecation warning (`mul_le_mul_right'`); no gallery meta.json exists for this file, so no data sync needed.

The sharp 0.7050 leading constant (transfer-operator eigenvalue) remains out of reach — see file header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)