### PR TITLE
research(pythagorean-theorem-oq-01): harden fragile exact? in Aristotle companion [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ01Aristotle.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ01Aristotle.lean
@@ -137,14 +137,14 @@ theorem parametric_triple (m n : ℤ) :
 /-- Every coprime Pythagorean triple is primitively classified. -/
 theorem coprime_triple_classified {x y z : ℤ}
     (h : PythagoreanTriple x y z) (hcop : Int.gcd x y = 1) :
-    h.IsPrimitiveClassified := by
-      exact?
+    h.IsPrimitiveClassified :=
+  h.isPrimitiveClassified_of_coprime hcop
 
 /-- Every Pythagorean triple is classified. -/
 theorem triple_classified {x y z : ℤ}
     (h : PythagoreanTriple x y z) :
-    h.IsClassified := by
-      exact?
+    h.IsClassified :=
+  h.classified
 
 /-- In a primitive triple, one leg is even and one is odd. -/
 theorem even_odd_of_coprime {x y z : ℤ}

--- a/research/problems/pythagorean-theorem-oq-01/knowledge.md
+++ b/research/problems/pythagorean-theorem-oq-01/knowledge.md
@@ -87,3 +87,34 @@ Insights accumulated during research on this problem.
 - `lake env lean` (Lean 4.26.0) against main-repo Mathlib cache: EXIT 0, 0 sorries, no new
   warnings. `#print axioms r2_pos_iff` = `[propext, Classical.choice, Quot.sound]` only
   (no `Lean.ofReduceBool`/`sorryAx`) — the eliminated axiom is a clean, fully-verified theorem.
+
+## Session 2026-07-08 (researcher-3) — Harden fragile `exact?` in companion file
+
+**Mode**: FRESH (claimed pythagorean-theorem-oq-01; base + all OQ children already SOLVED) · **Outcome**: minor robustness fix
+
+### What I Did
+- Re-surveyed the 28-file pythagorean family: all files are 0-sorry/0-axiom **except**
+  `PythagoreanTriplesOQ01.lean` (3 deep axioms: Gauss-circle sector density, coprime 6/π²
+  Möbius density, both-odd 1/3 parity — confirmed still non-Mathlib-reducible; no coprime-pair
+  density or Gauss-circle infra exists in the current Mathlib pin).
+- Found the only real defect: `PythagoreanTriplesOQ01Aristotle.lean` committed two `exact?`
+  *search* tactics (lines 141, 147) as proof bodies — slow at build time and liable to break
+  silently on Mathlib drift. Replaced both with the explicit Mathlib lemmas the search resolves to.
+
+### Key Findings
+- `coprime_triple_classified` → `h.isPrimitiveClassified_of_coprime hcop`
+  (`PythagoreanTriple.isPrimitiveClassified_of_coprime`, Mathlib PythagoreanTriples.lean:521).
+- `triple_classified` → `h.classified` (`PythagoreanTriple.classified`, line 529).
+- Confirmed by the pre-edit `exact?` output which suggested exactly these two terms.
+
+### Files Modified
+- `proofs/Proofs/PythagoreanTriplesOQ01Aristotle.lean` — two `by exact?` → term-mode explicit
+  lemma applications. Line count unchanged (167), theorem count unchanged, 0 sorry / 0 axiom.
+
+### Verification
+- `lake env lean` (Lean 4.26.0, main-repo Mathlib cache): EXIT 0, no errors/warnings, and — unlike
+  the old `exact?` version — **no "Try this" suggestions** (the proof is now a stable term).
+
+### Next Steps
+- Family is mathematically complete; remaining 3 axioms in OQ01 need Gauss-circle / lattice-point
+  counting infrastructure (>1000 lines) not in Mathlib. No session-sized axiom elimination remains.


### PR DESCRIPTION
## Summary

The pythagorean family (28 files) is mathematically complete: all files are 0-sorry / 0-axiom **except** `PythagoreanTriplesOQ01.lean`, whose 3 remaining axioms (Gauss-circle sector density, coprime 6/π² Möbius density, both-odd 1/3 parity) are genuinely deep analytic number theory with no current Mathlib coverage (no coprime-pair density or lattice-point-counting infrastructure exists in the pinned Mathlib).

The one real defect: `PythagoreanTriplesOQ01Aristotle.lean` committed two `exact?` **search** tactics as proof bodies. `exact?` is slow at build time and can break silently under Mathlib drift. This PR replaces them with the explicit lemmas the search resolves to:

- `coprime_triple_classified` → `h.isPrimitiveClassified_of_coprime hcop` (`PythagoreanTriple.isPrimitiveClassified_of_coprime`)
- `triple_classified` → `h.classified` (`PythagoreanTriple.classified`)

## Verification

`lake env lean` (Lean 4.26.0, main-repo Mathlib cache): **EXIT 0**, no errors/warnings, and — unlike the old `exact?` version — **no "Try this" suggestions** (the proofs are now stable terms). Line count (167) and theorem count unchanged; 0 sorry / 0 axiom.

## Scope

Robustness cleanup only — no mathematical content changed. No session-sized axiom elimination remains in this family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)