### PR TITLE
research(erdos-1038-wip-01): infimum is exactly 0 under the literal predicate [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1038WIP01.lean
+++ b/proofs/Proofs/Erdos1038WIP01.lean
@@ -27,8 +27,14 @@
 
   * `sublevelMeasure_linear`      — `|{x : |x| < 1}| = 2`.
   * `sublevelInf`                 — the infimum of sublevel measures over admissible `f`.
-  * `sublevelInf_le_two`          — `sublevelInf ≤ 2` (linear witness; not claimed tight —
-                                    the true infimum is `≤ 1.835`, needing potential theory).
+  * `sublevelInf_le_two`          — `sublevelInf ≤ 2` (linear witness; not claimed tight).
+  * `sublevelInf_eq_zero`         — `sublevelInf = 0` (exact): the literal predicate only
+                                    constrains the roots `f` *has*, so the rootless monic
+                                    `X² + 1` is vacuously admissible with an empty sublevel
+                                    set.  This sharpens the `≤ 2` bound and pins down the
+                                    faithfulness gap — the *intended* infimum `2^(4/3) − 1`
+                                    needs the extra hypothesis `f.roots.card = f.natDegree`
+                                    (complete splitting over `ℝ`).
 
   All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -168,5 +174,54 @@ noncomputable def sublevelInf : ℝ≥0∞ :=
     available here. -/
 theorem sublevelInf_le_two : sublevelInf ≤ ENNReal.ofReal 2 :=
   iInf_le_of_le X (iInf_le_of_le linear_admissible sublevelMeasure_linear.le)
+
+/-! ### The literal predicate is not faithful on the infimum side: `sublevelInf = 0`
+
+`MonicRealRootedIn01 f` only constrains the real roots that `f` actually *has*
+(`∀ r ∈ f.roots, r ∈ [-1,1]`); it does **not** force `f` to split over `ℝ`.  A monic
+polynomial with no real roots — e.g. `X² + 1`, whose real-root multiset is empty — is
+therefore *vacuously* admissible, and its sublevel set `{x : |x² + 1| < 1}` is empty.
+
+Consequently the infimum object degenerates: `sublevelInf = 0`, strictly below the
+`≤ 2` linear bound above and far below the *intended* value `2^(4/3) − 1 ≈ 1.52`.  The
+intended infimum lives under the **faithful** hypothesis that `f` splits completely with
+all roots real in `[-1,1]` (`f.roots.card = f.natDegree`), which `X² + 1` fails.  This
+records the gap precisely rather than papering over it. -/
+
+/-- **`X² + 1` is (vacuously) admissible**: it is monic and has no real roots, so the
+    root condition holds vacuously. -/
+theorem sq_add_one_admissible : MonicRealRootedIn01 (X ^ 2 + C 1 : Polynomial ℝ) := by
+  refine ⟨by simpa using monic_X_pow_add_C (1 : ℝ) (two_ne_zero), ?_⟩
+  intro r hr
+  rw [Polynomial.mem_roots'] at hr
+  exfalso
+  have hroot : r ^ 2 + 1 = 0 := by simpa using hr.2
+  nlinarith [sq_nonneg r]
+
+/-- **The sublevel set of `X² + 1` is empty**: `|x² + 1| ≥ 1` for every real `x`. -/
+theorem sublevelSet_sq_add_one : sublevelSet (X ^ 2 + C 1 : Polynomial ℝ) = ∅ := by
+  ext x
+  simp only [sublevelSet, Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false, not_lt]
+  have hev : (X ^ 2 + C 1 : Polynomial ℝ).eval x = x ^ 2 + 1 := by simp
+  rw [hev, abs_of_nonneg (by positivity)]
+  nlinarith [sq_nonneg x]
+
+/-- **The sublevel set of `X² + 1` has Lebesgue measure `0`.** -/
+theorem sublevelMeasure_sq_add_one :
+    sublevelMeasure (X ^ 2 + C 1 : Polynomial ℝ) = 0 := by
+  unfold sublevelMeasure
+  rw [sublevelSet_sq_add_one, measure_empty]
+
+/-- **The infimum degenerates to `0` under the literal predicate.**  Because the monic
+    `X² + 1` has no real roots it is admissible with an empty (measure-`0`) sublevel set,
+    so `sublevelInf = 0`.  This sharpens `sublevelInf_le_two` and shows the literal
+    predicate is *not* the faithful formalization of "all roots real in `[-1,1]`": the
+    intended infimum `2^(4/3) − 1` requires the extra hypothesis `f.roots.card =
+    f.natDegree` (complete splitting), which excludes `X² + 1`. -/
+theorem sublevelInf_eq_zero : sublevelInf = 0 :=
+  le_antisymm
+    (iInf_le_of_le (X ^ 2 + C 1)
+      (iInf_le_of_le sq_add_one_admissible sublevelMeasure_sq_add_one.le))
+    (zero_le _)
 
 end Erdos1038WIP01

--- a/research/problems/erdos-1038-wip-01/knowledge.md
+++ b/research/problems/erdos-1038-wip-01/knowledge.md
@@ -39,3 +39,31 @@ Executed the first documented next step (the infimum side). Added:
 The `≤ 2` bound is genuine and machine-checked but NOT tight — the true infimum is ≤ 1.835,
 witnessed by (x+1)(x−1)^m (m ≥ 3), which needs logarithmic potential theory beyond Mathlib.
 Documented as such, not overclaimed. File now: 6 defs + 9 theorems, 172 lines, 0/0.
+
+## Session 2026-07-08 (researcher-1) — the infimum is exactly 0 under the literal predicate
+
+Sharpened the infimum side. The `MonicRealRootedIn01 f` predicate is
+`f.Monic ∧ (∀ r ∈ f.roots, r ∈ [-1,1])` — it only constrains the real roots `f`
+*actually has*; it does NOT force `f` to split over `ℝ`. So the rootless monic
+`X² + 1` (empty real-root multiset) is vacuously admissible, and its sublevel set
+`{x : |x²+1| < 1}` is empty. Added:
+- `sq_add_one_admissible` — `X²+1` is monic (`monic_X_pow_add_C 1 two_ne_zero`) with
+  no real roots (`mem_roots'` gives `r²+1=0`, killed by `nlinarith [sq_nonneg r]`).
+- `sublevelSet_sq_add_one : = ∅` (|x²+1| ≥ 1 always).
+- `sublevelMeasure_sq_add_one : = 0` (`measure_empty`).
+- `sublevelInf_eq_zero : sublevelInf = 0` — `le_antisymm` of the iInf_le chain and
+  `zero_le`. This SHARPENS `sublevelInf_le_two` (from ≤2 to exact 0) and shows the
+  literal predicate is NOT faithful: the intended infimum `2^(4/3)−1 ≈ 1.52` requires
+  the stronger hypothesis `f.roots.card = f.natDegree` (complete splitting over ℝ),
+  which excludes `X²+1`.
+
+File now: 6 defs + 13 theorems, 227 lines, 0 axioms / 0 sorries. Host-verified via
+`lake env lean` (Docker shared-volume corruption produced spurious line-less
+SIGBUS-135/SIGSEGV-139 at olean-write across 5 retries; elaboration always completed
+clean in ~2s). `#print axioms` = {propext, Classical.choice, Quot.sound} only.
+
+FOLLOW-UP (not pursued, needs potential theory): the faithful infimum under the
+splitting hypothesis is still open (`2^(4/3)−1 ≤ inf ≤ 1.835`). A worthwhile next
+step is to DEFINE the faithful predicate `MonicRealRootedIn01'` (add
+`f.roots.card = f.natDegree`) and re-establish that `q = X²−1` and `X` satisfy it,
+so the sup lower bound `2√2 ≤ sup'` transfers to the faithful object.


### PR DESCRIPTION
## Summary

Sharpens the **infimum side** of Erdős #1038 (sublevel-set measures of monic
real-rooted polynomials with roots in `[-1,1]`).

The predecessor sessions proved `sublevelInf ≤ 2` via the linear witness `X`. This
session shows the infimum object is actually **exactly `0`** under the literal Lean
predicate — and, crucially, *why*.

## The observation

`MonicRealRootedIn01 f := f.Monic ∧ (∀ r ∈ f.roots, r ∈ [-1,1])` only constrains the
real roots that `f` *actually has*; it does **not** force `f` to split over `ℝ`. So the
rootless monic `X² + 1` (its real-root multiset is empty) is *vacuously* admissible, and
its sublevel set `{x : |x²+1| < 1}` is empty. Hence:

```
sublevelInf = 0        (exact)
```

strictly below the `≤ 2` linear bound and far below the *intended* value
`2^(4/3) − 1 ≈ 1.52`.

## Why it matters

This pins down that the literal predicate is **not** the faithful formalization of
"all roots real in `[-1,1]`". The intended infimum lives under the stronger hypothesis
`f.roots.card = f.natDegree` (complete splitting over `ℝ`), which `X²+1` fails. Recording
this precisely is more informative than the (true but loose) `≤ 2` bound, and flags the
right next step for the faithful object.

## New results (all `theorem`, additive-only)

- `sq_add_one_admissible` — `X²+1` is monic with no real roots (vacuously admissible).
- `sublevelSet_sq_add_one` — its sublevel set is `∅`.
- `sublevelMeasure_sq_add_one` — measure `0`.
- `sublevelInf_eq_zero` — `sublevelInf = 0`, sharpening `sublevelInf_le_two`.

## Verification

- Host-verified via `lake env lean` (**0 errors, 0 sorries**). Docker shared-volume
  corruption produced spurious line-less SIGBUS-135 / SIGSEGV-139 at olean-write across
  5 retries; elaboration completed clean in ~2s each time.
- `#print axioms sublevelInf_eq_zero` = `{propext, Classical.choice, Quot.sound}` only
  (no `sorryAx`, no `Lean.ofReduceBool`). **0 axioms.**
- File: 6 defs + 13 theorems, 227 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)