### PR TITLE
Enrich Pythagorean triples sum-of-two-squares (pythagorean-triples-oq-04-oq-01): add mainTheorems + references

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-04-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-04-oq-01/meta.json
@@ -104,5 +104,52 @@
       "summary": "sq_add_sq_of_forall_prime_factor': an independent, non-constructive proof of the headline via Nat.eq_sq_add_sq_iff, whose parity condition is vacuous when no prime factor is ≡ 3 (mod 4); confirms the constructive and characterization-based statements agree."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "sq_add_sq_of_forall_prime_factor",
+      "type": "core",
+      "description": "**Constructive sufficiency of the two-square theorem.** If every prime factor of n is ≢ 3 (mod 4), then n is a sum of two squares. Proved by strong induction on n: peel off the least prime factor p = n.minFac (a sum of two squares by Fermat's prime case, since p ≢ 3), apply the induction hypothesis to the strictly smaller cofactor n/p (whose prime factors all divide n), and recombine via the Brahmagupta–Fibonacci identity Nat.sq_add_sq_mul. Lifts the parent's two-factor multiplicativity to arbitrarily many primes.",
+      "leanType": "∀ n : ℕ, (∀ p : ℕ, p.Prime → p ∣ n → p % 4 ≠ 3) → ∃ a b : ℕ, a ^ 2 + b ^ 2 = n",
+      "startLine": 61,
+      "endLine": 91
+    },
+    {
+      "name": "sq_add_sq_pow",
+      "type": "key",
+      "description": "**Prime powers.** Every power pᵏ of a prime p ≢ 3 (mod 4) is a sum of two squares — the only prime factor of pᵏ is p, so the headline's hypothesis holds. A direct corollary via Nat.Prime.dvd_of_dvd_pow and Nat.prime_dvd_prime_iff_eq.",
+      "leanType": "{p : ℕ} (hp : p.Prime) (hp3 : p % 4 ≠ 3) (k : ℕ) : ∃ a b : ℕ, a ^ 2 + b ^ 2 = p ^ k",
+      "startLine": 99,
+      "endLine": 105
+    },
+    {
+      "name": "sq_add_sq_of_forall_prime_factor'",
+      "type": "supporting",
+      "description": "**Independent cross-check.** The same sufficiency result derived instead from Mathlib's characterization Nat.eq_sq_add_sq_iff, whose parity condition over primes ≡ 3 (mod 4) is vacuously satisfied when none divide n. A second, non-constructive proof confirming the constructive and characterization-based statements agree.",
+      "leanType": "(n : ℕ) (h : ∀ p : ℕ, p.Prime → p ∣ n → p % 4 ≠ 3) : ∃ a b : ℕ, a ^ 2 + b ^ 2 = n",
+      "startLine": 116,
+      "endLine": 122
+    }
+  ],
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Demonstratio theorematis Fermatiani omnem numerum primum formae 4n+1 esse summam duorum quadratorum",
+      "year": 1760,
+      "venue": "Novi Commentarii academiae scientiarum Petropolitanae 5, 3–13",
+      "note": "The first published proof of Fermat's two-square theorem for primes (communicated to Goldbach from 1747), the base case supplied here through Mathlib's Nat.Prime.sq_add_sq."
+    },
+    {
+      "authors": "Brahmagupta",
+      "title": "Brāhmasphuṭasiddhānta",
+      "year": 628,
+      "note": "Origin of the two-square (Brahmagupta–Fibonacci) identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)², the multiplicative combiner that recombines the per-prime representations in the induction; also in Fibonacci's Liber Quadratorum (1225)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.Prime.sq_add_sq, Nat.sq_add_sq_mul, Nat.eq_sq_add_sq_iff (Mathlib.NumberTheory.SumTwoSquares)",
+      "year": 2024,
+      "note": "The prime case (via the Gaussian integers), the two-factor identity, and the full existence characterization used respectively as the base case, the inductive combiner, and the cross-check."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-04-oq-01` — rich entry missing two structural fields (no `mainTheorems`, no `references`; no prior enricher PR).

## Changes
- **`mainTheorems`** (3): `sq_add_sq_of_forall_prime_factor` (core), `sq_add_sq_pow` (key), `sq_add_sq_of_forall_prime_factor'` (supporting), with exact `leanType` signatures and line ranges verified against `proofs/Proofs/PythagoreanTriplesOQ04OQ01.lean`.
- **`references`** (3): Euler's proof of Fermat's two-square theorem for primes (1760); Brahmagupta's two-square identity (628); Mathlib's `SumTwoSquares`.

## Validation
- `jq` valid JSON; `meta.json` 14.7 KB (under the 60 KB cap).
- Content-only change; axiom/status/badge fields untouched (verified, 0 axioms).