### PR TITLE
research(szemeredi-regularity-oq-04): quantitative single-part energy-increment jump [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
@@ -145,4 +145,60 @@ theorem partitionEnergy_single_split_mono (G : SimpleGraph V) [DecidableRel G.Ad
     Finset.sum_add_distrib]
   linarith [h1, h2, h3]
 
+/-- **Quantitative refinement increment of the gallery energy (energy-increment
+    step).**  Suppose the refined part `A₁ ∪ A₂` has an irregular partner `B₀ ∈ R`:
+    the two halves see densities differing by at least `δ`, i.e.
+    `|d(A₁,B₀) − d(A₂,B₀)| ≥ δ`.  Then refining the partition by replacing
+    `A₁ ∪ A₂` with its pieces `A₁, A₂` raises `partitionEnergy` by a *definite*
+    positive amount:
+
+    `partitionEnergy G (insert (A₁ ∪ A₂) R) + gain ≤
+        partitionEnergy G (insert A₁ (insert A₂ R))`,
+
+    where `gain = (|A₁||A₂|/(|A₁|+|A₂|))·(|B₀|/n²)·δ²`.  Every block of the
+    ordered-pair sum still moves in the right direction by `pairEnergy` monotonicity;
+    the row block against `R` carries the strict Cauchy–Schwarz surplus at `B₀`
+    (`pairEnergy_row_split_gain`).  This is the analytic heart of the strong
+    (Alon–Fischer–Krivelevich–Szegedy) regularity lemma: paired with the abstract
+    `[0,1]`-potential termination bound of `SzemerediRegularityOQ04`, the fixed
+    `gain > 0` forces the refinement loop to halt after at most `⌊1/gain⌋` steps. -/
+theorem partitionEnergy_single_split_gain (G : SimpleGraph V) [DecidableRel G.Adj]
+    (R : Finset (Finset V)) (A₁ A₂ B₀ : Finset V) (hdisj : Disjoint A₁ A₂)
+    (hA₁R : A₁ ∉ R) (hA₂R : A₂ ∉ R) (hne : A₁ ≠ A₂) (hAR : A₁ ∪ A₂ ∉ R)
+    (hB₀ : B₀ ∈ R)
+    (hn₁ : 0 < (A₁.card : ℚ)) (hn₂ : 0 < (A₂.card : ℚ)) (hB : 0 < (B₀.card : ℚ))
+    (δ : ℚ) (hδ : 0 ≤ δ)
+    (hdev : |edgeDensity G A₁ B₀ - edgeDensity G A₂ B₀| ≥ δ) :
+    partitionEnergy G (insert (A₁ ∪ A₂) R) +
+        (A₁.card : ℚ) * A₂.card / ((A₁.card : ℚ) + A₂.card) *
+          ((B₀.card : ℚ) / (Fintype.card V : ℚ) ^ 2) * δ ^ 2 ≤
+      partitionEnergy G (insert A₁ (insert A₂ R)) := by
+  -- A₁ is not in the smaller inserted family either.
+  have hA₁ : A₁ ∉ insert A₂ R := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨hne, hA₁R⟩
+  -- Diagonal block: (A₁∪A₂,A₁∪A₂) ≤ the four sub-pairs (pure monotonicity).
+  have h1 : pairEnergy G (A₁ ∪ A₂) (A₁ ∪ A₂) ≤
+      pairEnergy G A₁ A₁ + pairEnergy G A₁ A₂ +
+        pairEnergy G A₂ A₁ + pairEnergy G A₂ A₂ := by
+    have a := pairEnergy_split_mono G A₁ A₂ (A₁ ∪ A₂) hdisj
+    have b := pairEnergy_split_mono_right G A₁ A₁ A₂ hdisj
+    have c := pairEnergy_split_mono_right G A₂ A₁ A₂ hdisj
+    linarith
+  -- Row block: the strict Cauchy–Schwarz surplus at the irregular partner B₀.
+  have h2 := pairEnergy_row_split_gain G A₁ A₂ hdisj R B₀ hB₀ hn₁ hn₂ hB δ hδ hdev
+  rw [Finset.sum_add_distrib] at h2
+  -- Column block: pure monotonicity again.
+  have h3 : R.sum (fun P => pairEnergy G P (A₁ ∪ A₂)) ≤
+      R.sum (fun P => pairEnergy G P A₁) + R.sum (fun P => pairEnergy G P A₂) := by
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_le_sum
+    intro P _
+    exact pairEnergy_split_mono_right G P A₁ A₂ hdisj
+  -- Expand both energies to their block decompositions and combine.
+  rw [partitionEnergy_eq_double_sum, partitionEnergy_eq_double_sum]
+  simp only [Finset.sum_insert hAR, Finset.sum_insert hA₁, Finset.sum_insert hA₂R,
+    Finset.sum_add_distrib]
+  linarith [h1, h2, h3]
+
 end Szemeredi.RegularityOQ04Bridge

--- a/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
@@ -1,0 +1,148 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: connecting the `pairEnergy` refinement
+  machinery to the gallery's `partitionEnergy`.
+
+  The companion file `SzemerediRegularityOQ04Energy` builds a normalized
+  per-ordered-pair energy `pairEnergy G A B = (|A||B|/n²)·d(A,B)²` and proves its
+  refinement behaviour (`pairEnergy_split_mono`, `pairEnergy_split_gain`,
+  `pairEnergy_row_split_mono`).  Its docstring asserts — but never proves — that
+  *summing* `pairEnergy` over all ordered pairs of parts reproduces
+  `partitionEnergy`.  Without that bridge the whole `pairEnergy` layer is
+  disconnected from the actual gallery energy, so none of its monotonicity
+  content transfers.
+
+  This file supplies the missing bridge and cashes it out, fully machine-checked:
+
+  * `partitionEnergy_eq_sum_pairEnergy` — the bridge: `partitionEnergy G parts`
+    is exactly `Σ_{(P,Q) ∈ parts ×ˢ parts} pairEnergy G P Q`, unconditionally
+    (the `n = 0` degenerate case is handled because every `pairEnergy` term
+    carries the same vanishing `1/n²` weight).
+  * `pairEnergy_comm` — symmetry `pairEnergy G A B = pairEnergy G B A`, via the
+    gallery's `edgeDensity_symm`.
+  * `pairEnergy_split_mono_right` — the second-argument (B-side) form of
+    `pairEnergy_split_mono`.
+  * `partitionEnergy_single_split_mono` — **genuine refinement monotonicity of
+    the gallery energy**: replacing a part `A₁ ∪ A₂` by its two disjoint pieces
+    never decreases `partitionEnergy`.  This is the "splitting a part never
+    decreases energy" fact stated in the `partitionEnergy` docstring but not
+    previously proved for the actual refinement operation (the existing
+    `partitionEnergy_mono` is only monotone under *set inclusion* of the family,
+    which does not model a refinement — a refinement removes `A₁ ∪ A₂` and adds
+    `A₁, A₂`).  The proof decomposes the ordered-pair sum into the diagonal, row,
+    and column blocks and applies the `pairEnergy` split lemmas to each.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000); Komlós–Simonovits (1996).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Energy
+import Proofs.SzemerediRegularityOQ01
+
+namespace Szemeredi.RegularityOQ04Bridge
+
+open Szemeredi.Core Szemeredi.Regularity Szemeredi.RegularityOQ04Energy
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: THE BRIDGE — partitionEnergy IS THE SUM OF pairEnergy
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Bridge lemma.**  The gallery's `partitionEnergy G parts` is exactly the sum
+    of the normalized `pairEnergy` contributions over all ordered pairs of parts.
+    This holds unconditionally: in the degenerate `n = |V| = 0` case both sides
+    vanish, since every `pairEnergy` term carries the common `1/n²` factor. -/
+theorem partitionEnergy_eq_sum_pairEnergy (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : Finset (Finset V)) :
+    partitionEnergy G parts =
+      (parts.product parts).sum (fun pq => pairEnergy G pq.1 pq.2) := by
+  unfold partitionEnergy pairEnergy
+  by_cases hn : (Fintype.card V : ℚ) = 0
+  · simp only [if_pos hn]
+    symm
+    apply Finset.sum_eq_zero
+    intro pq _
+    simp [hn]
+  · simp only [if_neg hn]
+
+/-- The bridge in nested-double-sum form, convenient for block decompositions. -/
+private theorem partitionEnergy_eq_double_sum (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : Finset (Finset V)) :
+    partitionEnergy G parts =
+      parts.sum (fun P => parts.sum (fun Q => pairEnergy G P Q)) := by
+  rw [partitionEnergy_eq_sum_pairEnergy,
+    show parts.product parts = parts ×ˢ parts from rfl, Finset.sum_product]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: SYMMETRY AND THE SECOND-ARGUMENT SPLIT
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Symmetry of pair energy.**  `pairEnergy G A B = pairEnergy G B A`, an
+    immediate consequence of `edgeDensity_comm` and `|A||B| = |B||A|`. -/
+theorem pairEnergy_comm (G : SimpleGraph V) [DecidableRel G.Adj] (A B : Finset V) :
+    pairEnergy G A B = pairEnergy G B A := by
+  unfold pairEnergy
+  rw [Szemeredi.Regularity.OQ01.edgeDensity_comm G A B]
+  ring
+
+/-- **Second-argument refinement monotonicity.**  Splitting the `B`-side of a pair
+    into disjoint `B₁, B₂` never decreases its normalized energy contribution.
+    This is `pairEnergy_split_mono` transported through `pairEnergy_comm`. -/
+theorem pairEnergy_split_mono_right (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B₁ B₂ : Finset V) (hB : Disjoint B₁ B₂) :
+    pairEnergy G A (B₁ ∪ B₂) ≤ pairEnergy G A B₁ + pairEnergy G A B₂ := by
+  rw [pairEnergy_comm G A (B₁ ∪ B₂), pairEnergy_comm G A B₁, pairEnergy_comm G A B₂]
+  exact pairEnergy_split_mono G B₁ B₂ A hB
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: REFINEMENT MONOTONICITY OF partitionEnergy
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Refinement monotonicity of the gallery energy.**  Let `R` be a family of
+    parts and let `A₁, A₂` be two disjoint sets, neither in `R`, whose union is
+    also not in `R`.  Then refining the partition by replacing the single part
+    `A₁ ∪ A₂` with its two pieces `A₁, A₂` never decreases `partitionEnergy`:
+
+    `partitionEnergy G (insert (A₁ ∪ A₂) R) ≤ partitionEnergy G (insert A₁ (insert A₂ R))`.
+
+    This is the exact "splitting a part never decreases energy" statement from the
+    `partitionEnergy` docstring, realized for the genuine refinement operation.
+    The ordered-pair sum splits into a diagonal block `(A,A)`, a row block
+    `(A, R)`, a column block `(R, A)`, and the untouched `R × R` block; the three
+    affected blocks are each controlled by the `pairEnergy` split lemmas. -/
+theorem partitionEnergy_single_split_mono (G : SimpleGraph V) [DecidableRel G.Adj]
+    (R : Finset (Finset V)) (A₁ A₂ : Finset V) (hdisj : Disjoint A₁ A₂)
+    (hA₁R : A₁ ∉ R) (hA₂R : A₂ ∉ R) (hne : A₁ ≠ A₂) (hAR : A₁ ∪ A₂ ∉ R) :
+    partitionEnergy G (insert (A₁ ∪ A₂) R) ≤
+      partitionEnergy G (insert A₁ (insert A₂ R)) := by
+  -- A₁ is not in the smaller inserted family either.
+  have hA₁ : A₁ ∉ insert A₂ R := by
+    simp only [Finset.mem_insert, not_or]
+    exact ⟨hne, hA₁R⟩
+  -- Diagonal block: (A₁∪A₂,A₁∪A₂) ≤ the four sub-pairs.
+  have h1 : pairEnergy G (A₁ ∪ A₂) (A₁ ∪ A₂) ≤
+      pairEnergy G A₁ A₁ + pairEnergy G A₁ A₂ +
+        pairEnergy G A₂ A₁ + pairEnergy G A₂ A₂ := by
+    have a := pairEnergy_split_mono G A₁ A₂ (A₁ ∪ A₂) hdisj
+    have b := pairEnergy_split_mono_right G A₁ A₁ A₂ hdisj
+    have c := pairEnergy_split_mono_right G A₂ A₁ A₂ hdisj
+    linarith
+  -- Row block: Σ_{Q∈R} pairEnergy (A₁∪A₂) Q ≤ Σ pairEnergy A₁ Q + Σ pairEnergy A₂ Q.
+  have h2 := pairEnergy_row_split_mono G A₁ A₂ hdisj R
+  rw [Finset.sum_add_distrib] at h2
+  -- Column block: Σ_{P∈R} pairEnergy P (A₁∪A₂) ≤ Σ pairEnergy P A₁ + Σ pairEnergy P A₂.
+  have h3 : R.sum (fun P => pairEnergy G P (A₁ ∪ A₂)) ≤
+      R.sum (fun P => pairEnergy G P A₁) + R.sum (fun P => pairEnergy G P A₂) := by
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_le_sum
+    intro P _
+    exact pairEnergy_split_mono_right G P A₁ A₂ hdisj
+  -- Expand both energies to their block decompositions and combine.
+  rw [partitionEnergy_eq_double_sum, partitionEnergy_eq_double_sum]
+  simp only [Finset.sum_insert hAR, Finset.sum_insert hA₁, Finset.sum_insert hA₂R,
+    Finset.sum_add_distrib]
+  linarith [h1, h2, h3]
+
+end Szemeredi.RegularityOQ04Bridge

--- a/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
@@ -228,4 +228,36 @@ theorem pairEnergy_row_split_mono (G : SimpleGraph V) [DecidableRel G.Adj]
   intro B _
   exact pairEnergy_split_mono G A₁ A₂ B hA
 
+/-- **Quantitative row form of the energy increment.**  If a distinguished part
+    `B₀ ∈ Bs` witnesses a density deviation `|d(A₁,B₀) − d(A₂,B₀)| ≥ δ` between the
+    two halves, then splitting the `A`-side and summing the energy contribution over
+    the whole row raises the total by at least the single-pair gain at `B₀`.  Every
+    other row term contributes a nonnegative increment (`pairEnergy_split_mono`), so
+    the definite gain at `B₀` survives to the summed statement.  This is the shape in
+    which one irregular partner drives the whole-partition energy jump. -/
+theorem pairEnergy_row_split_gain (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A₁ A₂ : Finset V) (hA : Disjoint A₁ A₂) (Bs : Finset (Finset V))
+    (B₀ : Finset V) (hB₀ : B₀ ∈ Bs)
+    (hn₁ : 0 < (A₁.card : ℚ)) (hn₂ : 0 < (A₂.card : ℚ)) (hB : 0 < (B₀.card : ℚ))
+    (δ : ℚ) (hδ : 0 ≤ δ)
+    (hdev : |edgeDensity G A₁ B₀ - edgeDensity G A₂ B₀| ≥ δ) :
+    (Bs.sum fun B => pairEnergy G (A₁ ∪ A₂) B) +
+        (A₁.card : ℚ) * A₂.card / ((A₁.card : ℚ) + A₂.card) *
+          ((B₀.card : ℚ) / (Fintype.card V : ℚ) ^ 2) * δ ^ 2 ≤
+      Bs.sum fun B => pairEnergy G A₁ B + pairEnergy G A₂ B := by
+  -- Work with the per-term surplus `g B = (pairEnergy A₁ B + pairEnergy A₂ B) − pairEnergy (A₁∪A₂) B`.
+  have hnn : ∀ B ∈ Bs, (0 : ℚ) ≤
+      (pairEnergy G A₁ B + pairEnergy G A₂ B) - pairEnergy G (A₁ ∪ A₂) B := by
+    intro B _
+    linarith [pairEnergy_split_mono G A₁ A₂ B hA]
+  -- At `B₀` the surplus is at least the Cauchy–Schwarz gain.
+  have hgain : (A₁.card : ℚ) * A₂.card / ((A₁.card : ℚ) + A₂.card) *
+        ((B₀.card : ℚ) / (Fintype.card V : ℚ) ^ 2) * δ ^ 2 ≤
+      (pairEnergy G A₁ B₀ + pairEnergy G A₂ B₀) - pairEnergy G (A₁ ∪ A₂) B₀ := by
+    linarith [pairEnergy_split_gain G A₁ A₂ B₀ hA hn₁ hn₂ hB δ hδ hdev]
+  -- One term of a sum of nonnegatives is bounded by the whole sum.
+  have hsingle := Finset.single_le_sum hnn hB₀
+  rw [Finset.sum_sub_distrib] at hsingle
+  linarith
+
 end Szemeredi.RegularityOQ04Energy

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -47,3 +47,36 @@ carries all the graph-theoretic content.
   Mathlib `simp`-normal-form drift on `Matrix`/`Finset.sum`; reconstructing it
   (probably via the surviving `split_energy_excess_bound`) is the next concrete
   task, not a dead end yet.
+
+---
+
+## Session 2026-07-08 (researcher-7) — Quantitative single-part energy increment
+
+**Mode**: REVISIT (continuing own thread) · **Outcome**: progress (VERIFIED 0/0)
+
+### What I Did
+- Proved `pairEnergy_row_split_gain` (Energy file): summing the split contribution
+  over a whole row of `B`-parts, one irregular partner `B₀` drives a definite gain
+  `(|A₁||A₂|/(|A₁|+|A₂|))·(|B₀|/n²)·δ²`; other row terms are nonneg by
+  `pairEnergy_split_mono`. Mechanism: `Finset.single_le_sum` on the per-term surplus
+  `g B = f'(B) − f(B)`, then `Finset.sum_sub_distrib` + `linarith`.
+- Proved `partitionEnergy_single_split_gain` (Bridge file): the actual quantitative
+  energy-increment for the gallery `partitionEnergy`. Refining `A₁∪A₂ → A₁,A₂` with
+  an irregular partner `B₀ ∈ R` raises `partitionEnergy` by the same δ² gain. Same
+  block decomposition as `partitionEnergy_single_split_mono`, but the row block now
+  carries the surplus; `linarith [h1, h2gain, h3]` assembles it.
+
+### Key Findings
+- The whole-partition jump localizes to **one** strengthened block. Diagonal and
+  column blocks stay pure-monotone; only the row block against `R` needs the gain.
+- The gain expression must be written syntactically identically in the row lemma and
+  the partition-level goal so `linarith` matches it as a single atom.
+
+### Files Modified
+- proofs/Proofs/SzemerediRegularityOQ04Energy.lean (+pairEnergy_row_split_gain)
+- proofs/Proofs/SzemerediRegularityOQ04Bridge.lean (+partitionEnergy_single_split_gain)
+
+### Next Steps
+- Bolt the δ² gain onto the `[0,1]`-potential termination engine
+  (`energy_steps_bounded` / `no_infinite_energy_increments`) to cap AFKS step count.
+- Wire `exists_irregular_witness` to produce `B₀` and `hdev` from an ε-irregular pair.

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -3,7 +3,7 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-04T19:56:31-07:00
+**Since**: 2026-07-08T17:43:50-07:00
 **Iteration**: 2
 
 ## Status (S1, researcher-6, 2026-07-08) — VERIFIED finiteness engine for the AFKS iteration

--- a/research/registry.json
+++ b/research/registry.json
@@ -35823,10 +35823,11 @@
     },
     {
       "slug": "szemeredi-regularity-oq-04",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-07-04T19:56:31-07:00",
-      "status": "active"
+      "status": "active",
+      "lastUpdate": "2026-07-08T17:43:50-07:00"
     },
     {
       "slug": "prob-method-applications-wip-01-oq-02",

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -26,22 +26,27 @@
     "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: built the verified energy-INCREMENT engine (0 sorry/0 axiom, host-verified) complementing the existing termination engine. partitionEnergy refinement monotonicity + quantitative Cauchy-Schwarz gain now proven; strong AFKS lemma statement still open.",
+    "progressSummary": "PROGRESS: quantitative single-part energy-increment proven (partitionEnergy_single_split_gain, VERIFIED 0/0). Irregular partner ⇒ definite δ² partitionEnergy jump. Termination engine + monotonicity + quantitative increment now all in hand; remaining: bolt increment to termination for the AFKS step-count, and wire the irregularity witness.",
     "builtItems": [
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
       "pairEnergy def + pairEnergy_split_mono — one-sided refinement never decreases the normalized pair energy (|A||B|/n^2)d^2; transports density_sq_convex to partitionEnergy units.",
       "pairEnergy_split_gain — quantitative energy increment: |d1-d2|>=delta gives gain >= (|A1||A2|/(|A1|+|A2|))(|B|/n^2)delta^2 (the AFKS Cauchy-Schwarz boost).",
-      "pairEnergy_row_split_mono — monotonicity summed over a row of B-parts (Finset.sum_le_sum)."
+      "pairEnergy_row_split_mono — monotonicity summed over a row of B-parts (Finset.sum_le_sum).",
+      "pairEnergy_row_split_gain (SzemerediRegularityOQ04Energy.lean): one irregular partner B₀∈Bs drives a definite row-sum energy gain; every other row term nonneg by split_mono, surplus at B₀ survives via Finset.single_le_sum + sum_sub_distrib",
+      "partitionEnergy_single_split_gain (SzemerediRegularityOQ04Bridge.lean): QUANTITATIVE energy-increment — refining A₁∪A₂ into A₁,A₂ with irregular partner B₀ (|d(A₁,B₀)-d(A₂,B₀)|≥δ) raises partitionEnergy by ≥ (|A₁||A₂|/(|A₁|+|A₂|))·(|B₀|/n²)·δ². Block decomposition: diag+col pure monotone, row carries the Cauchy-Schwarz surplus."
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
-      "The weighted-average d(A1cupA2,B)=(|A1|d1+|A2|d2)/(|A1|+|A2|) plus split_energy_identity/excess_bound give the increment purely; scaling by |B|/n^2>=0 lifts density_sq_convex into the normalized energy."
+      "The weighted-average d(A1cupA2,B)=(|A1|d1+|A2|d2)/(|A1|+|A2|) plus split_energy_identity/excess_bound give the increment purely; scaling by |B|/n^2>=0 lifts density_sq_convex into the normalized energy.",
+      "The whole-partition energy JUMP reduces to a SINGLE strengthened block: only the row block against R needs the gain; diagonal and column blocks contribute nonneg increments by monotonicity, so linarith[h1,h2gain,h3] assembles exactly as the mono proof plus the gain atom."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Assemble whole-partition refinement monotonicity: split one part A->A1|A2 across the full parts x parts product sum (2D: rows AND columns AND the diagonal (A,A) via double convexity).",
       "Combine pairEnergy_split_gain with exists_irregular_witness (2-sided A,B refinement) to get the eps^5 whole-partition energy jump, then feed energy_iteration_count_le for the AFKS bound.",
-      "State the strong-regularity conclusion: almost-all-pairs regular with arbitrary precision (Alon-Fischer-Krivelevich-Szegedy)."
+      "State the strong-regularity conclusion: almost-all-pairs regular with arbitrary precision (Alon-Fischer-Krivelevich-Szegedy).",
+      "Assemble the AFKS bound: instantiate energy_steps_bounded/no_infinite_energy_increments with gain = (|A₁||A₂|/(|A₁|+|A₂|))·(|B₀|/n²)·δ² to cap the number of refinement steps by ⌊1/gain⌋.",
+      "Connect exists_irregular_witness (SzemerediRegularityOQ01) to supply the B₀ and the density-deviation hypothesis hdev from an ε-irregular pair, closing the loop from irregularity to the δ²-gain."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Continues the OQ-04 energy-increment engine of the **strong (Alon–Fischer–Krivelevich–Szegedy) regularity lemma**. Prior sessions built the abstract `[0,1]`-potential *termination* half and the *qualitative* refinement monotonicity of the gallery `partitionEnergy` (`partitionEnergy_single_split_mono`). This PR supplies the missing **quantitative** piece: an irregular partner forces a *definite* energy jump.

## New theorems (both VERIFIED — 0 sorries, 0 axioms)

- **`pairEnergy_row_split_gain`** (`SzemerediRegularityOQ04Energy.lean`) — splitting the `A`-side and summing the pair-energy over a whole row of `B`-parts, one irregular partner `B₀` with `|d(A₁,B₀) − d(A₂,B₀)| ≥ δ` drives a definite gain `(|A₁||A₂|/(|A₁|+|A₂|))·(|B₀|/n²)·δ²`. Every other row term is nonnegative by `pairEnergy_split_mono`, so the surplus at `B₀` survives summation (`Finset.single_le_sum` + `Finset.sum_sub_distrib`).

- **`partitionEnergy_single_split_gain`** (`SzemerediRegularityOQ04Bridge.lean`) — the **analytic heart of AFKS**: refining a partition by replacing `A₁ ∪ A₂` with its disjoint pieces, when the pair has an irregular partner `B₀ ∈ R`, raises the gallery `partitionEnergy` by that same `δ²` gain. The ordered-pair sum decomposes into diagonal, row, and column blocks; diagonal and column stay pure-monotone while the row block carries the Cauchy–Schwarz surplus.

Together with the existing termination bound (`energy_steps_bounded` / `no_infinite_energy_increments`), the fixed `gain > 0` caps the refinement loop at `⌊1/gain⌋` steps.

## Verification

`./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04Bridge` → **Built successfully (7747 jobs)**. No new `sorry`/`axiom`; remaining warnings are pre-existing lints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)