### PR TITLE
Enrich sum of first n odd cubes (nicomachus-sum-of-cubes-oq-03): add mainTheorems + references

### DIFF
--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-03/meta.json
@@ -64,6 +64,32 @@
       "summary": "4·∑(2k+1)³ + 4n² = 8n⁴, the subtraction-free core scaled by 4, derived in one `omega` step from the core lemma for callers who want a division-free product form."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "sum_odd_cubes",
+      "type": "core",
+      "description": "**Sum of the first n odd cubes (headline, over ℤ).** ∑_{k<n} (2k+1)³ = n²(2n²−1). Stated over ℤ so the closed form can use honest subtraction: the ℕ core lemma is cast with push_cast, the sum isolated as 2n⁴ − n² by linarith, and ring recognizes n²(2n²−1) = 2n⁴ − n².",
+      "leanType": "(n : ℕ) : (∑ k ∈ range n, ((2 * (k : ℤ) + 1) ^ 3)) = (n : ℤ) ^ 2 * (2 * (n : ℤ) ^ 2 - 1)",
+      "startLine": 73,
+      "endLine": 82
+    },
+    {
+      "name": "sum_odd_cubes_add",
+      "type": "key",
+      "description": "**Subtraction-free odd-cube identity.** (∑_{k<n} (2k+1)³) + n² = 2n⁴ — the closed form with n² moved left so every term is a genuine natural number, keeping the whole induction in ℕ with no truncated subtraction. Proved by induction: sum_range_succ peels the top odd cube, a single polynomial identity closes by ring, and omega splices it with the hypothesis (atomizing the power terms).",
+      "leanType": "(n : ℕ) : (∑ k ∈ range n, (2 * k + 1) ^ 3) + n ^ 2 = 2 * n ^ 4",
+      "startLine": 56,
+      "endLine": 67
+    },
+    {
+      "name": "four_mul_sum_odd_cubes",
+      "type": "supporting",
+      "description": "**Scaled multiplicative form.** 4·(∑_{k<n} (2k+1)³) + 4n² = 8n⁴ — the subtraction-free core scaled by 4, division-free, for callers who want the 2n²−1 factor cleared into a product. One omega step from the core lemma.",
+      "leanType": "(n : ℕ) : 4 * (∑ k ∈ range n, (2 * k + 1) ^ 3) + 4 * n ^ 2 = 8 * n ^ 4",
+      "startLine": 88,
+      "endLine": 91
+    }
+  ],
   "overview": {
     "historicalContext": "**Odd cubes and the squared triangular number**\n\nNicomachus of Gerasa (c. 100 AD) observed that the sum of the *first n cubes* is the square of the $n$-th triangular number: $1^3 + 2^3 + \\cdots + n^3 = (1 + 2 + \\cdots + n)^2$. A natural companion restricts the sum to the **odd** cubes. Where the full sum telescopes to a perfect square, the odd-cube sum has its own crisp closed form,\n$$1^3 + 3^3 + 5^3 + \\cdots + (2n-1)^3 = n^2(2n^2 - 1),$$\na Faulhaber-type identity that Mathlib does not currently provide. This entry supplies it, as a follow-up to the parent Nicomachus formalization.",
     "problemStatement": "**Sum of the first n odd cubes**\n\nIndexing the $n$ odd numbers as $2k+1$ for $k = 0, \\ldots, n-1$ (so `range n` enumerates $1, 3, \\ldots, 2n-1$), prove that for every natural number $n$,\n$$\\sum_{k<n} (2k+1)^3 = n^2(2n^2 - 1).$$\nThe goal is a fully machine-checked proof with no axioms and no sorries.",
@@ -112,6 +138,26 @@
       "proofId": "newton-power-sum-identities-oq-01",
       "relationship": "General power-sum framework",
       "description": "Newton's identities for power sums pₖ = ∑ Xᵢᵏ, the symmetric-function context for fixed-degree power-sum formulas including odd-index variants."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introductio Arithmetica",
+      "year": 100,
+      "note": "The classical source of the sum-of-cubes theorem 1³+2³+⋯+n³ = (1+2+⋯+n)², of which this odd-index restriction ∑(2k+1)³ = n²(2n²−1) is a companion."
+    },
+    {
+      "authors": "Johann Faulhaber",
+      "title": "Academia Algebrae",
+      "year": 1631,
+      "note": "Faulhaber's closed forms for the power sums ∑ kᵖ; the odd-cube identity proved here is a Faulhaber-type formula, factoring over ℤ as n²(2n²−1) with no rational coefficients."
+    },
+    {
+      "authors": "Wikipedia contributors",
+      "title": "Squared triangular number",
+      "year": 2024,
+      "note": "en.wikipedia.org/wiki/Squared_triangular_number. Covers Nicomachus's sum-of-cubes identity and its variants, including the sum of the first n odd cubes n²(2n²−1)."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `nicomachus-sum-of-cubes-oq-03` — rich entry missing two structural fields (no `mainTheorems`, no `references`; no prior enricher PR).

## Changes
- **`mainTheorems`** (3): `sum_odd_cubes` (core), `sum_odd_cubes_add` (key), `four_mul_sum_odd_cubes` (supporting), with exact `leanType` signatures and line ranges verified against `proofs/Proofs/NicomachusOddCubes.lean`.
- **`references`** (3): Nicomachus's *Introductio Arithmetica*; Faulhaber's *Academia Algebrae* (1631); Wikipedia *Squared triangular number*.

## Validation
- `jq` valid JSON; `meta.json` 12.6 KB (under the 60 KB cap).
- Content-only change; axiom/status/badge fields untouched (verified, 0 axioms, badge original).