### PR TITLE
Enrich Erdős #1017 extremality: complete mainTheorems to 8/8

### DIFF
--- a/src/data/proofs/erdos-1017-oq-02/meta.json
+++ b/src/data/proofs/erdos-1017-oq-02/meta.json
@@ -131,6 +131,22 @@
       "leanType": "(a b : ℕ) (h : a ≠ b) : 4 * (a * b) < (a + b) ^ 2",
       "startLine": 75,
       "endLine": 82
+    },
+    {
+      "name": "turanBound_two_mul",
+      "type": "supporting",
+      "description": "**Even closed form.** T(2m) = m². The parity closed form of the Turán bound reused to prove equality at the balanced split for even n.",
+      "leanType": "(m : ℕ) : turanBound (2 * m) = m ^ 2",
+      "startLine": 53,
+      "endLine": 55
+    },
+    {
+      "name": "turanBound_two_mul_add_one",
+      "type": "supporting",
+      "description": "**Odd closed form.** T(2m+1) = m(m+1). The parity closed form reused to prove equality at the balanced split for odd n.",
+      "leanType": "(m : ℕ) : turanBound (2 * m + 1) = m * (m + 1)",
+      "startLine": 58,
+      "endLine": 61
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass on `erdos-1017-oq-02`.

`mainTheorems` indexed 6 of the file's 8 theorems. This adds the two parity closed-form theorems that the equality-at-balance proof reuses:
- **turanBound_two_mul**: T(2m) = m² (lines 53–55)
- **turanBound_two_mul_add_one**: T(2m+1) = m(m+1) (lines 58–61)

Line anchors verified against the Lean source. No prose inflation; meta.json 14.6 KB → 15.2 KB, well under the 60 KB cap. JSON validated.