### PR TITLE
Enrich Erdős #11 WIP: add header section for module docstring

### DIFF
--- a/src/data/proofs/erdos-11-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-11-wip-01-oq-01/meta.json
@@ -63,6 +63,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring and Import",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "Docstring framing Erdős #11 (OPEN: is every odd n > 1 a squarefree number plus a power of two?) and this file's three contributions — the DecidablePred instance the parent only promised, the k = 0 sufficient family, and the n = 1 boundary. Imports the parent Erdos11WIP01 (which supplies isSquarefreePlusPow2_iff and squarefreePlusPow2_of_witness); namespace Erdos11WIP01, open Finset.",
+      "mathContext": "IsSquarefreePlusPow2 n ⟺ ∃ k ∈ range (n+1), 2^k ≤ n ∧ Squarefree (n − 2^k); the parent's bounded characterization this file builds on."
+    },
+    {
       "id": "decidable",
       "title": "The Decidability Instance",
       "startLine": 35,


### PR DESCRIPTION
Enrichment pass on `erdos-11-wip-01-oq-01`.

The `sections` array started at line 35, leaving the substantial module docstring (lines 1–27, which frames the open problem and the file's three contributions) and imports uncovered. Added a **Module Docstring and Import** header section (lines 1–34), matching the convention across the gallery and giving full-file section coverage (1–62).

No prose inflation; meta.json ~11.6 KB → ~12.3 KB, well under the 60 KB cap. JSON validated.