### PR TITLE
research(shannon-entropy-oq-03): self-contained SSA inequality (cmiSum_nonneg + ssa_inequality) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonEntropySSAEq.lean
+++ b/proofs/Proofs/ShannonEntropySSAEq.lean
@@ -445,4 +445,126 @@ theorem strong_subadditivity_eq_iff {α β γ : Type*}
   · intro heq; linear_combination -hdef - heq
   · intro hcmi; linear_combination -hdef - hcmi
 
+-- ═══════════════════════════════════════════════════════════════
+-- PART IV: Strong subadditivity itself (the inequality), self-contained
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **The conditional mutual information is nonnegative: `0 ≤ cmiSum pXYZ`.**
+    Equivalently `I(X;Z|Y) ≥ 0`.  This is the SSA *inequality* in relative-entropy
+    form, and it needs only `pXYZ ≥ 0` — no normalization `∑ p = 1`.  The proof is the
+    Gibbs/KL bound termwise (`p log(p/q) ≥ p − q`) summed against the reference
+    kernel `q = p_{XY} p_{YZ} / p_Y`, whose per-`y` mass matches that of `p`
+    (`∑_{x,z} q = ∑_{x,z} p`), so the linear lower bound telescopes to `0`. -/
+theorem cmiSum_nonneg {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz) :
+    0 ≤ cmiSum pXYZ := by
+  set q := fun x y z => (∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z)) /
+    (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) with hq_def
+  have hq_nn : ∀ x y z, 0 ≤ q x y z := fun x y z => by
+    simp only [hq_def]
+    exact div_nonneg
+      (mul_nonneg (Finset.sum_nonneg fun z' _ => hp _) (Finset.sum_nonneg fun x' _ => hp _))
+      (Finset.sum_nonneg fun x' _ => Finset.sum_nonneg fun z' _ => hp _)
+  have hmarg_pos : ∀ x y z, pXYZ (x, y, z) ≠ 0 →
+      0 < (∑ z' : γ, pXYZ (x, y, z')) ∧ 0 < (∑ x' : α, pXYZ (x', y, z)) ∧
+      0 < (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) := by
+    intro x y z hne
+    have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hne)
+    have hpXY : 0 < ∑ z', pXYZ (x, y, z') :=
+      lt_of_lt_of_le hpos (Finset.single_le_sum (fun z' _ => hp (x, y, z')) (Finset.mem_univ z))
+    have hpYZ : 0 < ∑ x', pXYZ (x', y, z) :=
+      lt_of_lt_of_le hpos (Finset.single_le_sum (fun x' _ => hp (x', y, z)) (Finset.mem_univ x))
+    have hpY : 0 < ∑ x' : α, ∑ z' : γ, pXYZ (x', y, z') :=
+      lt_of_lt_of_le hpXY (Finset.single_le_sum
+        (fun x' _ => Finset.sum_nonneg fun z' _ => hp (x', y, z')) (Finset.mem_univ x))
+    exact ⟨hpXY, hpYZ, hpY⟩
+  have hq_pos_of : ∀ x y z, pXYZ (x, y, z) ≠ 0 → 0 < q x y z := by
+    intro x y z hne
+    obtain ⟨hpXY, hpYZ, hpY⟩ := hmarg_pos x y z hne
+    simp only [hq_def]; exact div_pos (mul_pos hpXY hpYZ) hpY
+  have hq_sum_y : ∀ y, ∑ x : α, ∑ z : γ, q x y z = ∑ x, ∑ z, pXYZ (x, y, z) := by
+    intro y
+    simp only [hq_def]
+    by_cases hpy : (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) = 0
+    · have hall : ∀ x z, pXYZ (x, y, z) = 0 := by
+        have h2 := (Finset.sum_eq_zero_iff_of_nonneg
+          (fun x _ => Finset.sum_nonneg fun z _ => hp (x, y, z))).mp hpy
+        intro x z
+        exact (Finset.sum_eq_zero_iff_of_nonneg
+          (fun z _ => hp (x, y, z))).mp (h2 x (Finset.mem_univ x)) z (Finset.mem_univ z)
+      simp [hall]
+    · have hD : (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) ≠ 0 := hpy
+      have step1 : ∀ x : α, (∑ z : γ,
+            (∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z))
+              / (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')))
+          = (∑ z' : γ, pXYZ (x, y, z')) * (∑ z : γ, ∑ x' : α, pXYZ (x', y, z))
+              / (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) := by
+        intro x
+        rw [← Finset.sum_div, ← Finset.mul_sum]
+      simp_rw [step1]
+      rw [← Finset.sum_div, ← Finset.sum_mul]
+      rw [show (∑ z : γ, ∑ x' : α, pXYZ (x', y, z)) = ∑ x' : α, ∑ z : γ, pXYZ (x', y, z) from
+        Finset.sum_comm]
+      rw [mul_div_assoc, div_self hD, mul_one]
+  -- Rewrite cmiSum's summand into relative-entropy `p · log(p / q)` form.
+  have hcmi_q : cmiSum pXYZ = ∑ x : α, ∑ y : β, ∑ z : γ,
+      (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+       else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x y z)) := by
+    unfold cmiSum
+    refine Finset.sum_congr rfl (fun x _ => Finset.sum_congr rfl
+      (fun y _ => Finset.sum_congr rfl (fun z _ => ?_)))
+    by_cases hpxyz : pXYZ (x, y, z) = 0
+    · simp [hpxyz]
+    · rw [if_neg hpxyz, if_neg hpxyz]
+      obtain ⟨hpXY, hpYZ, hpY⟩ := hmarg_pos x y z hpxyz
+      have hlog_eq : pXYZ (x, y, z) * (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) /
+          ((∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z))) =
+          pXYZ (x, y, z) / q x y z := by
+        simp only [hq_def]
+        field_simp
+      rw [hlog_eq]
+  rw [hcmi_q]
+  -- Termwise Gibbs bound `p − q ≤ p log(p/q)` (with the zero convention).
+  have hbound : ∀ x y z, pXYZ (x, y, z) - q x y z ≤
+      (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+       else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x y z)) := by
+    intro x y z
+    by_cases hpxyz : pXYZ (x, y, z) = 0
+    · rw [if_pos hpxyz]; have := hq_nn x y z; linarith
+    · rw [if_neg hpxyz]
+      have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hpxyz)
+      exact kl_lb hpos (hq_pos_of x y z hpxyz)
+  -- The reference kernel has the same total mass as `p`, so `∑ (p − q) = 0`.
+  have hq_eq_p : ∑ x : α, ∑ y : β, ∑ z : γ, q x y z
+      = ∑ x : α, ∑ y : β, ∑ z : γ, pXYZ (x, y, z) := by
+    rw [Finset.sum_comm]
+    conv_rhs => rw [Finset.sum_comm]
+    exact Finset.sum_congr rfl fun y _ => hq_sum_y y
+  have hsum_pq : ∑ x : α, ∑ y : β, ∑ z : γ, (pXYZ (x, y, z) - q x y z) = 0 := by
+    simp only [Finset.sum_sub_distrib]
+    linarith [hq_eq_p]
+  calc (0 : ℝ) = ∑ x : α, ∑ y : β, ∑ z : γ, (pXYZ (x, y, z) - q x y z) := hsum_pq.symm
+    _ ≤ ∑ x : α, ∑ y : β, ∑ z : γ,
+          (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+           else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x y z)) :=
+      Finset.sum_le_sum fun x _ => Finset.sum_le_sum fun y _ =>
+        Finset.sum_le_sum fun z _ => hbound x y z
+
+/-- **Strong subadditivity of Shannon entropy (the inequality), self-contained.**
+    `H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z)` for any nonnegative weight `pXYZ`.
+    Combines `ssa_deficit_eq_cmi` (deficit = `I(X;Z|Y)`) with `cmiSum_nonneg`.  Unlike
+    the version in the parent `ShannonEntropy.lean`, this needs no normalization and
+    lives in the same self-contained file as the equality characterization. -/
+theorem ssa_inequality {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz) :
+    shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ)
+      ≤ shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ) := by
+  have hdef := ssa_deficit_eq_cmi (pXYZ := pXYZ) hp
+  have hnn := cmiSum_nonneg (pXYZ := pXYZ) hp
+  linarith
+
 end InformationTheory

--- a/research/problems/shannon-entropy-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/shannon-entropy-oq-03-incomplete-01/knowledge.md
@@ -19,3 +19,25 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-08 (researcher-1) — SSA inequality now self-contained in the equality file
+
+The problem was already COMPLETE (the "remaining SSA sorry" premise was false; SSA is
+in ShannonEntropy.lean:875, and the equality condition shipped as ShannonEntropySSAEq.lean
+→ gallery shannon-entropy-oq-03-oq-01). Genuine outward increment: that self-contained
+file held only the SSA *equality* condition; the SSA *inequality* itself lived only in the
+conflicting parent. Added to ShannonEntropySSAEq.lean (gallery shannon-entropy-oq-03-oq-01):
+- `cmiSum_nonneg : 0 ≤ cmiSum pXYZ` — I(X;Z|Y) ≥ 0, the SSA inequality in relative-entropy
+  form. Needs ONLY pXYZ ≥ 0 (NO ∑p=1 normalization). Reuses the file's own KL machinery
+  (q, hq_nn, hmarg_pos, hq_pos_of, hq_sum_y, hcmi_q, hbound → all local haves in
+  ssa_cmi_eq_zero_iff). Proof: termwise Gibbs `p log(p/q) ≥ p−q` (kl_lb) summed against
+  reference kernel q = p_XY·p_YZ/p_Y; per-y mass ∑_{x,z}q = ∑_{x,z}p (hq_sum_y), so the
+  linear lower bound telescopes to 0. Key nesting-sum tricks: `Finset.sum_comm` twice to
+  reorder ∑_x∑_y∑_z q → ∑_y(...) to apply hq_sum_y; `Finset.sum_le_sum` nested ×3 for the
+  triple-sum monotonicity; `simp only [Finset.sum_sub_distrib]; linarith [hq_eq_p]`.
+- `ssa_inequality : H(X,Y,Z)+H(Y) ≤ H(X,Y)+H(Y,Z)` — headline SSA, now self-contained
+  (ssa_deficit_eq_cmi + cmiSum_nonneg, one linarith).
+Named `ssa_inequality` (NOT `strong_subadditivity`) to avoid the exact dup-decl clash that
+broke ShannonEntropySSA.lean. File: 5 defs + 9 theorems (was 7), 570 lines, 0 axioms/0 sorries.
+Host-verified (lake env lean, clean; #print axioms = propext/Classical.choice/Quot.sound).
+Synced gallery meta lineCount 448→570, theoremCount 7→9.

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
@@ -146,9 +146,9 @@
       "Finset"
     ],
     "namespace": "InformationTheory",
-    "lineCount": 448,
+    "lineCount": 570,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 5,
     "path": "Proofs/ShannonEntropySSAEq.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Makes the strong-subadditivity **inequality** self-contained in
`ShannonEntropySSAEq.lean` (gallery entry `shannon-entropy-oq-03-oq-01`).

Previously that file held only the SSA **equality** condition (the Markov-chain
characterization). The SSA inequality *itself* lived only in the parent
`ShannonEntropy.lean` — which cannot be safely imported here (it conflicts with the
broken `ShannonEntropySSA.lean` on a duplicate-declaration error). This PR closes that
gap, reusing the file's own KL machinery.

## New theorems (both `theorem`, additive-only, 0/0)

- **`cmiSum_nonneg : 0 ≤ cmiSum pXYZ`** — the conditional mutual information
  `I(X;Z|Y) ≥ 0`, i.e. SSA in relative-entropy form. Needs **only** `pXYZ ≥ 0`
  (no `∑ p = 1` normalization). Proof: the termwise Gibbs bound `p·log(p/q) ≥ p − q`
  (the file's `kl_lb`) summed against the reference kernel `q = p_XY·p_YZ/p_Y`, whose
  per-`y` mass matches `p` (`∑_{x,z} q = ∑_{x,z} p`), so the linear lower bound
  telescopes to `0`.
- **`ssa_inequality`** — the headline `H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z)`, now fully
  self-contained (`ssa_deficit_eq_cmi` + `cmiSum_nonneg`).

Named `ssa_inequality` (not `strong_subadditivity`) specifically to avoid the kind of
cross-file duplicate-declaration clash that broke `ShannonEntropySSA.lean`.

## Verification

- Host-verified via `lake env lean` (**0 errors, 0 warnings, 0 sorries**). Docker
  builds are currently unreliable due to shared-volume cache corruption (spurious
  line-less SIGBUS/SIGSEGV at olean-write); host single-file elaboration is clean.
- `#print axioms` for both new theorems = `{propext, Classical.choice, Quot.sound}`
  only (no `sorryAx`, no `Lean.ofReduceBool`). **0 axioms.**
- File: 5 defs + 9 theorems (was 7), 570 lines. Gallery meta `lineCount`/`theoremCount`
  synced (448→570, 7→9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)