### PR TITLE
Fix: sync isoperimetric-theorem-oq-01-oq-01 meta counts to Lean source

### DIFF
--- a/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
@@ -22,8 +22,8 @@
     "definitionCount": 3,
     "theoremCount": 9
   },
-  "lineCount": 221,
-  "theoremCount": 7,
+  "lineCount": 272,
+  "theoremCount": 9,
   "axiomCount": 0,
   "assumptions": [],
   "meta": {
@@ -83,7 +83,7 @@
     "lineCount": 272,
     "mathlib_version": "4.26.0",
     "assumptions": "0 axioms and 0 sorries by construction over ℝ. BUILD-CONFIRMED: machine-checked with `lake env lean` against the prebuilt Mathlib 4.26.0 olean cache (Docker engine was down fleet-wide, so docker-build.sh could not be used; the single file imports only Mathlib and has no sibling-proof dependencies, so a standalone compile is a complete check). Exit 0, no errors; `#print axioms` on isoperimetric_fourier / wirtinger / equality_implies_circle / hurwitzTerm_eq_zero reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool. Status promoted to 'verified'. The proof uses only elementary ℝ-algebra tactics (ring, nlinarith, linarith, le_antisymm, Finset.sum_nonneg). The Parseval bridge from the L²-integrals ∮(x'²+y'²) and ∮x dy to the coefficient sums E and Ar is the standard textbook reduction (Stein–Shakarchi, Ch. 4); it is documented, not re-derived — the formalized objects are the Fourier coefficients and the coefficient-level inequality, which is the mathematical heart of the method.",
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 3
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync stale top-level `meta.lineCount`/`theoremCount` and `meta.meta.theoremCount` to match the actual Lean source (and the already-correct `leanFile` object).

## Evidence

`proofs/Proofs/IsoperimetricFourierOQ0101.lean`: `wc -l` = 272, 9 theorems, 3 defs (verified by comment-stripped decl scan).

The drift dates to #30471 (sharp equality locus), which added 2 theorems — `equality_iff_terms_vanish` and `fundamental_mode_circle_condition` — growing the file 221→272 lines and 7→9 theorems, but only the nested `leanFile` object was updated.

**Before**: `meta.lineCount=221`, `meta.theoremCount=7`, `meta.meta.theoremCount=7` (stale)
**After**: `272` / `9` / `9`, matching `leanFile.{lineCount:272, theoremCount:9, definitionCount:3}` and the actual source.

`axiomCount=0`, `sorries=0`, `status=verified` unchanged and consistent. Data-only change; JSON validated with `jq`.

---
Automated fix by lean-mechanic agent.