### PR TITLE
Enrich Erdős #128 OQ-01: mainTheorems anchors + full-file sections

### DIFF
--- a/src/data/proofs/erdos-128-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01/meta.json
@@ -18,28 +18,43 @@
   "mainTheorems": [
     {
       "name": "blowup_C5_triangleFree",
-      "type": "theorem",
-      "description": "Capstone: every blow-up of the 5-cycle C₅, at every size n and for every class assignment c : Fin n → Fin 5, is triangle-free — exactly the triangle-freeness of the extremal construction conjectured to witness Erdős #128's optimal constant 1/50."
+      "type": "core",
+      "description": "Capstone: every blow-up of the 5-cycle C₅, at every size n and for every class assignment c : Fin n → Fin 5, is triangle-free — exactly the triangle-freeness of the extremal construction conjectured to witness Erdős #128's optimal constant 1/50.",
+      "leanType": "{n : ℕ} (c : Fin n → Fin 5) : (blowup C5 c).triangleFree",
+      "startLine": 129,
+      "endLine": 131
     },
     {
       "name": "triangleFree_of_hom",
-      "type": "theorem",
-      "description": "Triangle-freeness is preserved by pullback along an arbitrary graph homomorphism: if f : G → H is a homomorphism and H is triangle-free, then G is triangle-free (the three image vertices forced distinct by H's irreflexivity). Induced subgraphs and blow-ups are both instances."
+      "type": "core",
+      "description": "Triangle-freeness is preserved by pullback along an arbitrary graph homomorphism: if f : G → H is a homomorphism and H is triangle-free, then G is triangle-free (the three image vertices forced distinct by H's irreflexivity). Induced subgraphs and blow-ups are both instances.",
+      "leanType": "{n k : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k) (hf : IsHom G H f) (hH : H.triangleFree) : G.triangleFree",
+      "startLine": 81,
+      "endLine": 91
     },
     {
       "name": "blowup_triangleFree",
-      "type": "theorem",
-      "description": "Every blow-up of a triangle-free base graph is triangle-free — triangleFree_of_hom applied to the class map."
+      "type": "key",
+      "description": "Every blow-up of a triangle-free base graph is triangle-free — triangleFree_of_hom applied to the class map.",
+      "leanType": "{n k : ℕ} (H : Graph k) (c : Fin n → Fin k) (hH : H.triangleFree) : (blowup H c).triangleFree",
+      "startLine": 107,
+      "endLine": 109
     },
     {
       "name": "blowup_isHom",
-      "type": "theorem",
-      "description": "The class map of a blow-up is a graph homomorphism blowup H c → H."
+      "type": "supporting",
+      "description": "The class map of a blow-up is a graph homomorphism blowup H c → H.",
+      "leanType": "{n k : ℕ} (H : Graph k) (c : Fin n → Fin k) : IsHom (blowup H c) H c",
+      "startLine": 102,
+      "endLine": 103
     },
     {
       "name": "C5_triangleFree",
-      "type": "theorem",
-      "description": "The concrete 5-cycle C₅ on Fin 5 is triangle-free, verified by the decision procedure over Fin 5 (not native_decide)."
+      "type": "key",
+      "description": "The concrete 5-cycle C₅ on Fin 5 is triangle-free, verified by the decision procedure over Fin 5 (not native_decide).",
+      "leanType": "C5.triangleFree",
+      "startLine": 120,
+      "endLine": 122
     }
   ],
   "description": "Identifies the structural reason the conjectured-optimal extremal witnesses for Erdős Problem #128 ($250, OPEN) are triangle-free. The parent entry erdos-128-wip-01 proved triangle-freeness is hereditary under induced subgraphs and the edge count is monotone. This entry proves the sharper fact those rest on: triangle-freeness is preserved under ARBITRARY graph homomorphisms, pulled back along the map (triangleFree_of_hom) -- if there is a homomorphism f : G -> H and H is triangle-free, then G is triangle-free, the three image vertices being forced distinct by H's irreflexivity. Induced subgraphs (identity inclusion) and blow-ups (class map) are both instances. The blow-up of a base graph H along a class map c is defined (blowup) and its class map is shown to be a homomorphism (blowup_isHom), giving blowup_triangleFree: every blow-up of a triangle-free graph is triangle-free. The concrete 5-cycle C5 on Fin 5 is shown triangle-free by the decision procedure (C5_triangleFree, not native_decide), and combining yields blowup_C5_triangleFree: every blow-up of C5, at every size n and for every class assignment c : Fin n -> Fin 5, is triangle-free -- exactly the triangle-freeness of the extremal construction conjectured to witness the optimal constant 1/50. 5 theorems, 5 definitions + 1 structure, 0 sorries, 0 axioms.",
@@ -86,6 +101,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring and Import",
+      "summary": "Imports Mathlib; module docstring framing Erdős #128 ($250, OPEN: does edge density on every large induced subgraph force a triangle?) and this OQ-01 file's sharper goal — triangle-freeness is preserved under arbitrary graph homomorphisms, of which the parent's induced-subgraph inclusion and the extremal C₅-blow-up class map are both instances. Namespace Erdos128WIP01OQ01.",
+      "startLine": 1,
+      "endLine": 54,
+      "mathContext": "Erdős #128 conjectured-optimal constant 1/50 is witnessed by C₅-blow-ups; this file proves those witnesses are triangle-free at every scale via homomorphism pullback."
+    },
+    {
       "id": "objects",
       "title": "Graphs, Triangles, and Homomorphisms (re-declared)",
       "summary": "Graph, hasTriangle, triangleFree, and the graph-homomorphism predicate IsHom.",
@@ -106,8 +129,16 @@
       "title": "Blow-ups and the C₅ witness",
       "summary": "blowup, blowup_isHom, blowup_triangleFree, C5_triangleFree, blowup_C5_triangleFree.",
       "startLine": 96,
-      "endLine": 133,
+      "endLine": 131,
       "mathContext": "A blow-up pulls adjacency back along a class map; C₅ is triangle-free, hence so is every blow-up of it."
+    },
+    {
+      "id": "significance",
+      "title": "Significance",
+      "summary": "Closing docstring: triangle-freeness under arbitrary homomorphisms unifies the parent's hereditary property with the extremal witnesses; C₅ and all its blow-ups are triangle-free, while the hard analytic content (density > 1/50, optimality) stays open.",
+      "startLine": 133,
+      "endLine": 148,
+      "mathContext": "The remaining open content: that C₅-blow-ups achieve induced density > 1/50 and that 1/50 is optimal."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass on `erdos-128-wip-01-oq-01`.

Two structural defects fixed:
- **mainTheorems had no line anchors** — all five entries were `undefined` (broken jump-to-source). Added verified anchors + `leanType` signatures and core/key/supporting types: triangleFree_of_hom (81–91), blowup_isHom (102–103), blowup_triangleFree (107–109), C5_triangleFree (120–122), blowup_C5_triangleFree (129–131).
- **sections did not tile the file** — they started at line 55 and ended at 133, leaving the module docstring (1–54) and closing Significance docstring (134–148) uncovered. Added a header section and a Significance section and trimmed the blow-up section boundary; sections now cover 1–148.

Anchors verified against the Lean source; JSON validated; under the 60 KB cap.