### PR TITLE
Fix: sync stale theoremCount across 27 gallery entries

### DIFF
--- a/src/data/proofs/abundant-number-oq-01-oq-02/meta.json
+++ b/src/data/proofs/abundant-number-oq-01-oq-02/meta.json
@@ -148,7 +148,7 @@
     "namespace": "AbundantNumberOQ0102",
     "lineCount": 103,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "substantiveTheoremCount": 3,
     "definitionCount": 1,
     "path": "Proofs/AbundantNumberOQ0102.lean",

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-05/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "0 axioms, 0 sorries (depends only on propext, Classical.choice, Quot.sound). Builds on Mathlib's Gaussian Fourier transform (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I), the parametric differentiation-under-the-integral lemma (hasDerivAt_integral_of_dominated_loc_of_deriv_le), and the Gaussian integrability lemmas integrable_exp_neg_mul_sq / integrable_mul_exp_neg_mul_sq.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-22",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 0
   },
   "overview": {
@@ -127,7 +127,7 @@
     "namespace": "GaussianHermiteFourier",
     "lineCount": 301,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/buffons-needle-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-01-oq-01/meta.json
@@ -65,7 +65,7 @@
     "lineCount": 188,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Depends only on Mathlib's Gamma-function API.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 10,
     "definitionCount": 1
   },
   "overview": {
@@ -165,7 +165,7 @@
     "namespace": "BuffonsNeedleOQ02OQ01OQ01",
     "lineCount": 188,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 10,
     "definitionCount": 1,
     "path": "Proofs/BuffonsNeedleOQ02OQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
@@ -36,7 +36,7 @@
     "namespace": "CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02",
     "lineCount": 165,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/meta.json
@@ -46,7 +46,7 @@
     "namespace": "CauchyGroupTheoremOQ01OQ01OQ01",
     "lineCount": 160,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
@@ -43,7 +43,7 @@
     "namespace": "CauchyGroupTheoremOQ01OQ01",
     "lineCount": 151,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/CauchyGroupTheoremOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-04/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-04/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "None — fully verified (depends only on propext, Classical.choice, Quot.sound). Builds on CubeRoot2IrrationalOQ03 for the sqfree-factor Eisenstein template.",
     "lineCount": 228,
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 0,
     "originalContributions": [
       "squarefree_has_eisenstein_prime: every squarefree m ≥ 2 possesses a prime p with p∣m and p²∤m — squarefreeness makes the Eisenstein hypothesis automatically discharge-able",
@@ -153,7 +153,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 12
+    "theoremCount": 15
   },
   "references": [
     {

--- a/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03-oq-03/meta.json
@@ -29,7 +29,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 6,
     "additionalFiles": []
   },
   "sorries": 0,
@@ -54,7 +54,7 @@
     "axiomCount": 0,
     "assumptions": "None beyond Lean/Mathlib's foundational propext / Classical.choice / Quot.sound (0 axiom declarations, 0 sorries, no native_decide). Verified via #print axioms on not_normal_adjoin_cbrt3 and not_isGalois_adjoin_cbrt3. Builds on CubeRoot3IrrationalOQ03 (minpoly_cbrt3 : minpoly ℚ ∛3 = X³ − 3, cbrt3_pow_three : ∛3³ = 3), which is itself 0-axiom. Uses Mathlib's Normal.splits, IntermediateField.minpoly_gen, Polynomial.splits_of_algHom, Polynomial.splits_iff_card_roots, Polynomial.separable_X_pow_sub_C, Polynomial.nodup_roots, and Odd.strictMono_pow.",
     "lineCount": 116,
-    "theoremCount": 4,
+    "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
       "not_normal_adjoin_cbrt3: ℚ(∛3)/ℚ is not a normal extension — the headline result and standard first example of a finite non-normal field extension.",

--- a/src/data/proofs/erdos-11-oq-03/meta.json
+++ b/src/data/proofs/erdos-11-oq-03/meta.json
@@ -15,7 +15,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 181,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 3
   },
   "openQuestion": {
@@ -202,7 +202,7 @@
     "axiomCount": 0,
     "lineCount": 181,
     "assumptions": "0 axioms. Re-declares the sibling API self-contained (IsSquarefreePlusPow2, isSquarefreePlusPow2_iff, SquarefreeCheck, squarefree_iff_check) and uses standard Mathlib lemmas (Nat.le_log_iff_pow_le, Nat.lt_two_pow_self, Finset.card_le_card, Finset.filter_nonempty_iff). The verified range uses kernel decide only; #print axioms shows just propext / Classical.choice / Quot.sound — no Lean.ofReduceBool.",
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 3
   },
   "sorries": 0

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
     "lineCount": 162,
     "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 0
   },
   "overview": {
@@ -104,7 +104,7 @@
     "namespace": "Erdos396OQ01OQ01OQ01",
     "lineCount": 162,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/Erdos396OQ04OQ01OQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-729-oq-04/meta.json
+++ b/src/data/proofs/erdos-729-oq-04/meta.json
@@ -92,7 +92,7 @@
     "lineCount": 156,
     "assumptions": "0 axioms, 0 sorries. #print axioms reports only [propext, Classical.choice, Quot.sound] for sub_one_mul_padicValNat_multinomial, padicValNat_multinomial_eq_div, prime_dvd_multinomial_iff, and sub_one_mul_padicValNat_multinomial_fin — no sorryAx and no Lean.ofReduceBool. The identity holds for every prime p and an arbitrary finite index set (any k). Verified with Lean toolchain 4.26.0 against the pinned Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -161,7 +161,7 @@
     "namespace": "Erdos729Multinomial",
     "lineCount": 156,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/Erdos729LegendreMultinomial.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-866-wip-01/meta.json
+++ b/src/data/proofs/erdos-866-wip-01/meta.json
@@ -13,7 +13,7 @@
     "namespace": "Erdos866Wip01",
     "lineCount": 113,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 1,
     "path": "Proofs/Erdos866Wip01.lean",
     "sorries": 0
@@ -72,7 +72,7 @@
       "Guarantees N k g: a clean Prop capturing the threshold semantics of g_k(N) — every A of size ≥ N+g forces a configuration — making the lower bound expressible without choosing a specific minimal-threshold encoding.",
       "not_guarantees_zero and g_k_ge_one: the threshold reformulation g_k(N) ≥ 1 for all k ≥ 3 — a guarantee threshold of 0 is refuted by the odd-numbers witness, so any valid threshold is at least 1."
     ],
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 1
   },
   "overview": {

--- a/src/data/proofs/euler-identity-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-02-oq-01/meta.json
@@ -55,7 +55,7 @@
     "axiomCount": 0,
     "lineCount": 130,
     "assumptions": "None. All theorems fully proved with 0 axioms and 0 sorries (no native_decide). #print axioms on euler_formula, hasSum_euler, and euler_identity reports only [propext, Classical.choice, Quot.sound]. The core derivation (hasSum_euler, euler_formula) uses only the exponential series and even/odd resummation; Complex.cos/sin are invoked solely in the closing identification lemmas, Pythagoras, and Euler's identity.",
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 2,
     "prerequisites": [
       "The complex exponential and its power series e^w = Σ wⁿ/n!",
@@ -145,7 +145,7 @@
     "namespace": "EulerIdentityOQ01OQ02OQ01",
     "lineCount": 130,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 2,
     "path": "Proofs/EulerIdentityOQ01OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -11,7 +11,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 110,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "assumptions": "None. All identities hold for every n : ℕ and are fully machine-checked over ℤ. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric sanity checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
     "tags": [
@@ -66,7 +66,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 110,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/proofs/fibonacci-identities-oq-04-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-02/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 138,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 1
   },
   "overview": {
@@ -154,7 +154,7 @@
     "namespace": "FibonacciIdentitiesOQ04OQ02",
     "lineCount": 138,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/FibonacciIdentitiesOQ04OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/fibonacci-identities-oq-05-oq-03/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-03/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 144,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -168,7 +168,7 @@
     "namespace": "FibonacciIdentitiesOQ05OQ03",
     "lineCount": 144,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/FibonacciIdentitiesOQ05OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/fibonacci-identities-oq-05/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05/meta.json
@@ -54,7 +54,7 @@
     "lineCount": 114,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -152,7 +152,7 @@
     "namespace": "FibonacciIdentitiesOQ05",
     "lineCount": 114,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/FibonacciIdentitiesOQ05.lean",
     "sorries": 0

--- a/src/data/proofs/mathematical-induction-oq-01-oq-04/meta.json
+++ b/src/data/proofs/mathematical-induction-oq-01-oq-04/meta.json
@@ -68,7 +68,7 @@
     ],
     "assumptions": "0 axioms, 0 sorries. #print axioms reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) for all six theorems; none counts under the project's axiom policy, and no sorryAx or Lean.ofReduceBool appears. All results are built on top of Mathlib's von Neumann hierarchy without introducing new assumptions.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -136,7 +136,7 @@
     "namespace": "MathematicalInductionOQ01OQ04",
     "lineCount": 169,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "path": "Proofs/MathematicalInductionOQ01OQ04.lean",
     "sorries": 0,
     "definitionCount": 0

--- a/src/data/proofs/nesbitt-inequality-oq-01-oq-01/meta.json
+++ b/src/data/proofs/nesbitt-inequality-oq-01-oq-01/meta.json
@@ -57,7 +57,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
     "lineCount": 152,
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 0
   },
   "overview": {
@@ -167,7 +167,7 @@
     "namespace": "NesbittInequalityOQ01OQ01",
     "lineCount": 152,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/NesbittInequalityOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/pell-equation-oq-06-oq-03-oq-03/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-03-oq-03/meta.json
@@ -30,7 +30,7 @@
       "rec_unique: the recurrence uₙ₊₂ = c·uₙ₊₁ − uₙ with two initial values determines an integer sequence uniquely, for any coefficient c — the abstract form of the parent's coordinate-specific uniqueness lemmas"
     ],
     "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide (the concrete d = 2 sanity checks use kernel `decide` on ℤ√2 arithmetic, not `native_decide`). Imports only Mathlib, using its Zsqrtd (ℤ√d) API: re_mul, im_mul, norm_def, norm_mul.",
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "crossReferences": [
@@ -129,7 +129,7 @@
     "path": "Proofs/PellEquationOQ06OQ03OQ03.lean",
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "imports": [
       "Mathlib"
     ]

--- a/src/data/proofs/prime-gap-bounds-oq-03/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-03/meta.json
@@ -77,7 +77,7 @@
     "lineCount": 152,
     "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. Depends on the parent entry PrimeGapBounds, itself verified at 0 axioms.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 0
   },
   "overview": {
@@ -169,7 +169,7 @@
     "namespace": "PrimeGapBoundsOQ03",
     "lineCount": 152,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/PrimeGapBoundsOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/product-of-segments-of-chords-oq-04/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-04/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-06-24",
     "axiomCount": 0,
     "lineCount": 219,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 1,
     "assumptions": "None. Only the standard foundational axioms (propext, Classical.choice, Quot.sound) appear in #print axioms; no sorryAx and no Lean.ofReduceBool.",
     "originalContributions": [
@@ -105,7 +105,7 @@
     "namespace": "ProductOfSegmentsOfChordsOQ04",
     "lineCount": 219,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 1,
     "path": "Proofs/ProductOfSegmentsOfChordsOQ04.lean",
     "sorries": 0

--- a/src/data/proofs/property-b-first-moment-oq-03-oq-04/meta.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-04/meta.json
@@ -54,7 +54,7 @@
     "lineCount": 179,
     "assumptions": "None. All 7 theorems fully proved with 0 axioms and 0 sorries (no native_decide; the proofs are real analysis via Real.add_one_le_exp, exp/log algebra, pow-monotonicity, and nlinarith). #print axioms on the main results reports only [propext, Classical.choice, Quot.sound]. Probabilities are modeled as real-valued functions (the standard first-moment idiom of the sibling entries), not via a measure space. The loss term is modeled linearly as c·k·p with c a positive constant; deriving the genuine loss coefficient from the conditional model, the union bound over m edges, and the final √(k/log k) asymptotic remain open (see open questions).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 3,
     "dateAdded": "2026-06-30",
     "relatedProblems": [
@@ -177,7 +177,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 7
+    "theoremCount": 8
   },
   "references": [
     {

--- a/src/data/proofs/ramseys-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ramseys-theorem-oq-04-oq-01/meta.json
@@ -57,7 +57,7 @@
     "axiomCount": 0,
     "lineCount": 169,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used (topDiff_comm uses just propext / Quot.sound). No native_decide — the only decide calls are over Bool.",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 2
   },
   "overview": {
@@ -138,7 +138,7 @@
     "namespace": "RamseyStepUp",
     "lineCount": 169,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 2,
     "path": "Proofs/RamseysTheoremOQ04OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-03/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-03/meta.json
@@ -12,7 +12,7 @@
     "proofRepoPath": "Proofs/SpernerTuckerFixedPointParity.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0,
     "lineCount": 253,
     "tags": [
@@ -119,7 +119,7 @@
     "lineCount": 253,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0,
     "imports": [
       "import Mathlib",

--- a/src/data/proofs/stirling-second-kind-oq-01-oq-02/meta.json
+++ b/src/data/proofs/stirling-second-kind-oq-01-oq-02/meta.json
@@ -62,7 +62,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified: 0 axioms, 0 sorries. factorial_mul_stirlingSecond and stirlingSecond_two depend only on propext, Classical.choice, Quot.sound (no native_decide, hence no Lean.ofReduceBool). Kernel-verified on Mathlib 4.26.0.",
     "lineCount": 211,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 1
   },
   "overview": {
@@ -180,7 +180,7 @@
     "namespace": "StirlingSecondKindOQ01OQ02",
     "lineCount": 211,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/StirlingSecondKindOQ01OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/wilsons-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-04-oq-02-oq-01/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified (depends only on propext, Classical.choice, Quot.sound).",
     "lineCount": 133,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 0,
     "originalContributions": [
       "abelianization_prod_enum: for any enumeration l of a finite group G, Abelianization.of l.prod = ∏ x : G, Abelianization.of x — the ordered product is well-defined modulo commutators and order-independent",
@@ -116,7 +116,7 @@
     "namespace": "WilsonsTheoremOQ04OQ02OQ01",
     "lineCount": 133,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/WilsonsTheoremOQ04OQ02OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `theoremCount` metadata across 27 gallery entries whose Lean sources have grown (research PRs added theorems) without the counts being updated.

## Evidence

For each entry the corrected count was derived by:
1. Comment-stripping the Lean source (nested `/- -/` + `--`), then counting `theorem`/`lemma` declarations.
2. Cross-checking the stripped count against a raw indented grep — they agree for every entry (no comment-embedded false positives).
3. Excluding entries where `theoremCount + lemmaCount` already reconciles to the actual total (e.g. erdos-1004-oq-02), matching the peer-reviewer's combined convention.
4. Only writing files whose JSON round-trips byte-identically, so diffs are pure value changes (2 entries with divergent formatting were skipped).

Representative corrections (old → new): abundant-number-oq-01-oq-02 6→7, cube-root-3-irrational-oq-02-oq-04 12→15, ramseys-theorem-oq-04-oq-01 9→11, wilsons-theorem-oq-04-oq-02-oq-01 5→7.

**Before**: `theoremCount` understated actual theorem/lemma count.
**After**: matches the Lean source. 50 insertions / 50 deletions, all `theoremCount` values; JSON validated with `jq`. No status/axiom/sorry changes.

---
Automated fix by lean-mechanic agent.