### PR TITLE
Enrich Euler totient gcd factorisation: add mainTheorems anchors

### DIFF
--- a/src/data/proofs/euler-totient-oq-07-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-01/meta.json
@@ -32,28 +32,43 @@
   "mainTheorems": [
     {
       "name": "gcd_totient_eq_two_mul_gcd_half",
-      "type": "theorem",
-      "description": "The exact factorisation (structural heart): for m, n ≥ 3 the shared factor 2 splits off cleanly, gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2), reducing every question about the factor 2 to the halved totients where the parity obstruction is gone."
+      "type": "core",
+      "description": "The exact factorisation (structural heart): for m, n ≥ 3 the shared factor 2 splits off cleanly, gcd(φ m, φ n) = 2 · gcd(φ m / 2, φ n / 2), reducing every question about the factor 2 to the halved totients where the parity obstruction is gone.",
+      "leanType": "{m n : ℕ} (hm : 3 ≤ m) (hn : 3 ≤ n) : Nat.gcd (φ m) (φ n) = 2 * Nat.gcd (φ m / 2) (φ n / 2)",
+      "startLine": 57,
+      "endLine": 64
     },
     {
       "name": "gcd_totient_eq_two_iff",
-      "type": "theorem",
-      "description": "Characterisation of equality gcd = 2: for m, n ≥ 3, gcd(φ m, φ n) = 2 iff the halved totients φ m / 2 and φ n / 2 are coprime — the correct dividing line for the sharp lower bound (not 'one totient equals 2')."
+      "type": "core",
+      "description": "Characterisation of equality gcd = 2: for m, n ≥ 3, gcd(φ m, φ n) = 2 iff the halved totients φ m / 2 and φ n / 2 are coprime — the correct dividing line for the sharp lower bound (not 'one totient equals 2').",
+      "leanType": "{m n : ℕ} (hm : 3 ≤ m) (hn : 3 ≤ n) : Nat.gcd (φ m) (φ n) = 2 ↔ Nat.gcd (φ m / 2) (φ n / 2) = 1",
+      "startLine": 76,
+      "endLine": 78
     },
     {
       "name": "four_le_gcd_totient_iff",
-      "type": "theorem",
-      "description": "Characterisation of gcd ≥ 4: for m, n ≥ 3 the gcd exceeds the universal bound 2 (reaching ≥ 4) iff the halved totients share a common factor ≥ 2."
+      "type": "key",
+      "description": "Characterisation of gcd ≥ 4: for m, n ≥ 3 the gcd exceeds the universal bound 2 (reaching ≥ 4) iff the halved totients share a common factor ≥ 2.",
+      "leanType": "{m n : ℕ} (hm : 3 ≤ m) (hn : 3 ≤ n) : 4 ≤ Nat.gcd (φ m) (φ n) ↔ 2 ≤ Nat.gcd (φ m / 2) (φ n / 2)",
+      "startLine": 83,
+      "endLine": 85
     },
     {
       "name": "exists_gcd_two_with_large_totients",
-      "type": "theorem",
-      "description": "Refutes the candidate conjecture that gcd(φ m, φ n) = 2 forces one totient to equal 2: the pair m = 5, n = 7 gives gcd(φ5, φ7) = gcd(4, 6) = 2 with both totients ≥ 4, since the halves 2 and 3 are coprime. Equality is controlled by coprimality of the halves, per gcd_totient_eq_two_iff."
+      "type": "key",
+      "description": "Refutes the candidate conjecture that gcd(φ m, φ n) = 2 forces one totient to equal 2: the pair m = 5, n = 7 gives gcd(φ5, φ7) = gcd(4, 6) = 2 with both totients ≥ 4, since the halves 2 and 3 are coprime. Equality is controlled by coprimality of the halves, per gcd_totient_eq_two_iff.",
+      "leanType": "∃ m n : ℕ, 3 ≤ m ∧ 3 ≤ n ∧ Nat.gcd (φ m) (φ n) = 2 ∧ 4 ≤ φ m ∧ 4 ≤ φ n",
+      "startLine": 93,
+      "endLine": 95
     },
     {
       "name": "gcd_totient_div_two",
-      "type": "theorem",
-      "description": "Dividing the gcd of the totients by 2 recovers the gcd of the halves exactly (no rounding): gcd(φ m, φ n) / 2 = gcd(φ m / 2, φ n / 2) for m, n ≥ 3."
+      "type": "supporting",
+      "description": "Dividing the gcd of the totients by 2 recovers the gcd of the halves exactly (no rounding): gcd(φ m, φ n) / 2 = gcd(φ m / 2, φ n / 2) for m, n ≥ 3.",
+      "leanType": "{m n : ℕ} (hm : 3 ≤ m) (hn : 3 ≤ n) : Nat.gcd (φ m) (φ n) / 2 = Nat.gcd (φ m / 2) (φ n / 2)",
+      "startLine": 68,
+      "endLine": 70
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass on `euler-totient-oq-07-oq-01`.

`mainTheorems` listed all five theorems but every entry lacked `startLine`/`endLine` (undefined), breaking the gallery's jump-to-source. Added verified anchors + `leanType` signatures and core/key/supporting types:
- gcd_totient_eq_two_mul_gcd_half (57–64), gcd_totient_eq_two_iff (76–78), four_le_gcd_totient_iff (83–85), exists_gcd_two_with_large_totients (93–95), gcd_totient_div_two (68–70).

Sections already tile the full file. Anchors verified against the Lean source; JSON validated; under the 60 KB cap.