### PR TITLE
research(erdos-1064-oq-03): second reversal family 55·2^(k+1) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -791,4 +791,39 @@ theorem threeway_criterion_classifies :
     (∀ k, (13 * 2 ^ (k + 1)) ∈ ForwardSet) :=
   ⟨reversal_via_criterion, equality_via_criterion, forward_via_criterion⟩
 
+-- ===========================================================================
+-- A SECOND REVERSAL SEED: the reversal seed set is not the singleton `{21}`
+-- ---------------------------------------------------------------------------
+-- The criterion makes the per-seed reversal test `φ(a) < φ(e)·2^(t−1)` a finite
+-- computation on odd data, so we can hunt for reversal seeds beyond `a = 21`.
+-- The next one is `a = 55`: `2·55 − φ(55) = 70 = 2·35` (so `b = 35`), the landing
+-- constant `2·55 − φ(35) = 86 = 43·2^1` (so `e = 43`, `t = 1`), and
+-- `φ(55) = 40 < 42 = φ(43)·2^0`.  Hence `55·2^(k+1)` is a SECOND infinite reversal
+-- family, disjoint from `21·2^(k+1)` — the reversal phenomenon is not tied to a
+-- single seed.
+-- ===========================================================================
+
+theorem totient_55 : Nat.totient 55 = 40 := by decide
+theorem totient_35 : Nat.totient 35 = 24 := by decide
+theorem totient_43 : Nat.totient 43 = 42 := Nat.totient_prime (by norm_num)
+
+/-- **Second reversal family `55·2^(k+1)`:** odd data `a = 55, b = 35, e = 43, t = 1`,
+    and `φ(55) = 40 < 42 = φ(43)·2^0`, so the criterion returns "reversal" for all `k`.
+    This is a genuinely new infinite reversal family, distinct from `21·2^(k+1)`. -/
+theorem reversal_via_criterion_55 (k : ℕ) : (55 * 2 ^ (k + 1)) ∈ ReversalSet := by
+  rw [dblIter_reversal_iff (a := 55) (b := 35) (e := 43) (t := 1)
+        (by decide) (by decide) (by decide) (by norm_num)
+        (by norm_num [totient_55]) (by norm_num [totient_35]) k]
+  norm_num [totient_55, totient_43]
+
+/-- **The reversal seed set contains at least two distinct odd seeds.**  Both
+    `21·2^(k+1)` and `55·2^(k+1)` reverse for every `k`, and the seeds `21 ≠ 55`
+    are distinct odd numbers.  So `ReversalSet` is not exhausted by the single
+    Researcher-3 family `21·2^(k+1)`; reversal seeds form a genuinely larger set,
+    the smallest two being `21` and `55`. -/
+theorem two_distinct_reversal_families :
+    (∀ k, (21 * 2 ^ (k + 1)) ∈ ReversalSet) ∧
+    (∀ k, (55 * 2 ^ (k + 1)) ∈ ReversalSet) ∧ (21 : ℕ) ≠ 55 :=
+  ⟨reversal_via_criterion, reversal_via_criterion_55, by decide⟩
+
 end Erdos1064OQ03

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -1,0 +1,24 @@
+
+## Session 2026-07-08 (researcher-1) — second reversal seed a=55 (reversal set not the singleton {21})
+
+Executed nextStep #2 (characterise the reversal seed set). The k-free three-way
+criterion (dblIter_reversal_iff, in Proofs/EulerTotientOQ04OQ03.lean) makes the
+per-seed reversal test φ(a) < φ(e)·2^(t−1) a finite computation on odd data. Brute
+search over odd seeds a<200 (φ via the criterion arithmetic) gives reversal seeds
+21, 55, 129, 165, 175, … — so 21 is smallest and 55 is the SECOND.
+
+Added (all VERIFIED 0 axioms / 0 sorries, host lake env lean):
+- totient_55 = 40, totient_35 = 24 (by decide, kernel — NOT native_decide, no ofReduceBool),
+  totient_43 = 42 (Nat.totient_prime).
+- reversal_via_criterion_55 (k) : 55·2^(k+1) ∈ ReversalSet. Criterion data a=55, b=35,
+  e=43, t=1: 2·55−φ(55)=70=2·35 (b odd, v₂=1 OK), 2·55−φ(35)=86=43·2^1, φ(55)=40<42=φ(43)·2^0.
+  Same proof shape as reversal_via_criterion (21): rw dblIter_reversal_iff (by decide ×3,
+  norm_num for ht/hstep/hC) then norm_num [totient_55, totient_43].
+- two_distinct_reversal_families : both 21·2^(k+1) and 55·2^(k+1) reverse ∀k, and 21≠55.
+  (Kept the distinctness statement to seed-inequality 21≠55; a full ∀j,k family-disjointness
+  proof hit exponent-arithmetic pitfalls — dropped as low-value/high-risk.)
+
+File 794→829 lines, 56 theorems. NO gallery meta references EulerTotientOQ04OQ03.lean
+(research file), so no count sync. Density-1 forward remains the sole deep-open direction
+(needs ψ(x,y)). Further reversal seeds (129,165,175) and the excluded v₂(2a−φ(a))>1 case
+remain as future elementary increments.


### PR DESCRIPTION
## Summary

Extends the reversal-seed analysis of Erdős #1064 OQ-03 (`φ(n)` vs `φ(D(n))` under
double-totient iteration `D`) in `Proofs/EulerTotientOQ04OQ03.lean`.

The prior k-free three-way criterion (`dblIter_reversal_iff`) reduces the sign of
`φ(n) − φ(D(n))` for a whole family `n = a·2^(k+1)` to a finite inequality
`φ(a) < φ(e)·2^(t−1)` on odd data `(a, e, t)`. That makes the reversal phenomenon
*searchable* — and the previously-known reversal seed `a = 21` is **not** the only one.

## Result: a second reversal family

The next reversal seed is **`a = 55`**:
- `2·55 − φ(55) = 70 = 2·35`, so `b = 35` (odd, `v₂ = 1` — transport applies);
- landing constant `2·55 − φ(35) = 86 = 43·2^1`, so `e = 43`, `t = 1`;
- `φ(55) = 40 < 42 = φ(43)·2^0` — **reversal**.

Hence `55·2^(k+1)` is a genuinely new infinite reversal family, disjoint from the
known `21·2^(k+1)`.

## New theorems (all `theorem`, additive-only, 0/0)

- `totient_55 = 40`, `totient_35 = 24` (`decide`, kernel), `totient_43 = 42`
  (`Nat.totient_prime`).
- `reversal_via_criterion_55 (k) : 55·2^(k+1) ∈ ReversalSet` — the new family, read off
  the k-free criterion exactly like the existing `reversal_via_criterion` for `21`.
- `two_distinct_reversal_families` — both `21·2^(k+1)` and `55·2^(k+1)` reverse for all
  `k`, and `21 ≠ 55`: the reversal seed set is not the singleton `{21}` (smallest two
  seeds are `21`, `55`; a search finds `21, 55, 129, 165, 175, …`).

## Verification

- Host-verified via `lake env lean` (**0 errors, 0 warnings, 0 sorries**). Docker builds
  are currently unreliable (shared-volume cache corruption → spurious SIGBUS/SIGSEGV at
  olean-write); host single-file elaboration is clean.
- `#print axioms` for both new families = `{propext, Classical.choice, Quot.sound}` only.
  The `decide` calls use **kernel** evaluation (not `native_decide`), so **no
  `Lean.ofReduceBool`**. **0 axioms.**
- File `EulerTotientOQ04OQ03.lean`: 794 → 829 lines. No gallery meta references this
  research file, so no count sync.

The density-1 forward direction (almost-all `n`) remains the sole analytically-blocked
open direction (needs Luca–Pomerance / `ψ(x,y)` density, a real Mathlib gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)