### PR TITLE
research(e-transcendental-oq-02-oq-06): quantitative disjunctivity [VERIFIED 0 sorry]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -912,6 +912,110 @@ theorem not_normal_of_digit_freq_tendsto_ne (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
   · rwa [Nat.cast_one, zpow_neg_one]
 
 -- ============================================================
+-- PART IV.8: QUANTITATIVE DISJUNCTIVITY
+-- ============================================================
+
+/-!
+## From "infinitely often" to a positive density
+
+`normal_ktuple_infinitely_often` shows a normal number contains every tuple at
+*infinitely many* positions, and `normal_imp_disjunctive` extracts a single
+occurrence *somewhere*. Both are purely qualitative. The results below sharpen
+them using the fact that normality pins the matching frequency to the strictly
+positive value `b^{-k}`:
+
+* `exists_match_lt_of_count_pos` is the pure-`Finset` bridge: a positive matching
+  count over `range N` yields an explicit occurrence *below* `N`.
+* `eventually_exists_match_lt_of_normal` upgrades disjunctivity to an
+  effective-flavoured form — for a normal `x`, the tuple `s` occurs *before every
+  sufficiently large window* `N`, not merely somewhere. (The bare definition of
+  normality carries no convergence *rate*, so the position of the first
+  occurrence cannot be bounded by an explicit function of `k`; but "occurs before
+  every large `N`" is the strongest unconditional statement, and it pins the
+  first occurrence below any effective threshold at which the count is known
+  positive.)
+* `match_count_ge_linear_of_normal` is the density statement: the number of
+  occurrences of `s` below `N` is eventually at least `(b^{-k}/2)·N`, so the
+  occurrence set has positive lower density (in fact density exactly `b^{-k}`).
+  This strictly strengthens `normal_ktuple_infinitely_often`.
+-/
+
+/-- **Occurrence-extraction core.** If the count of tuple-`s` matches over
+    `Finset.range N` is positive, an explicit matching position `< N` exists.
+    The pure-`Finset` bridge underlying the quantitative statements below;
+    carries no normality hypothesis. -/
+theorem exists_match_lt_of_count_pos (b : ℕ) (x : ℝ) (k : ℕ) (s : Fin k → Fin b)
+    (N : ℕ)
+    (hpos : 0 < ((Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card) :
+    ∃ n < N, ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ) := by
+  obtain ⟨n, hn⟩ := Finset.card_pos.mp hpos
+  rw [Finset.mem_filter, Finset.mem_range] at hn
+  exact ⟨n, hn.1, hn.2⟩
+
+/-- **The matching count is eventually positive.** For a number normal in base
+    `b`, the number of positions below `N` at which the tuple `s` matches is
+    positive for all sufficiently large `N`. Proof: normality forces the
+    frequency `count/N → b^{-k} > 0`, so eventually `count/N > 0`, whence
+    (using `N ≥ 1`) `count > 0`. -/
+theorem eventually_match_count_pos_of_normal (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (hn : IsNormalInBase b x) (k : ℕ) (s : Fin k → Fin b) :
+    ∀ᶠ N in atTop, 0 < ((Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card := by
+  have hbR : (0 : ℝ) < (b : ℝ) := by exact_mod_cast (by omega : 0 < b)
+  have hposk : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := zpow_pos hbR _
+  have hev : ∀ᶠ N in atTop, (0 : ℝ) <
+      (((Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ)
+        / (N : ℝ) :=
+    (hn k s).eventually_const_lt hposk
+  filter_upwards [hev, eventually_ge_atTop 1] with N hN _
+  set c := ((Finset.range N).filter
+      (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card with hc
+  rcases Nat.eq_zero_or_pos c with h0 | hpos
+  · exfalso; rw [h0] at hN; simp at hN
+  · exact hpos
+
+/-- **Effective disjunctivity.** For a number normal in base `b`, the tuple `s`
+    occurs at some position *below* `N` for every sufficiently large `N`. This
+    strengthens `normal_imp_disjunctive` (one occurrence somewhere) to a bound
+    relative to every large window. Immediate from
+    `eventually_match_count_pos_of_normal` and the occurrence-extraction core. -/
+theorem eventually_exists_match_lt_of_normal (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (hn : IsNormalInBase b x) (k : ℕ) (s : Fin k → Fin b) :
+    ∀ᶠ N in atTop,
+      ∃ n < N, ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ) := by
+  filter_upwards [eventually_match_count_pos_of_normal b hb x hn k s] with N hN
+  exact exists_match_lt_of_count_pos b x k s N hN
+
+/-- **Positive lower density of occurrences.** For a number normal in base `b`,
+    the number of positions below `N` at which the tuple `s` matches is eventually
+    at least `(b^{-k}/2)·N`. Hence the occurrence set has positive lower density
+    (in fact density exactly `b^{-k}`), strictly strengthening the qualitative
+    `normal_ktuple_infinitely_often`. Proof: normality gives `count/N → b^{-k}`,
+    so eventually `count/N > b^{-k}/2`; clearing the (positive) denominator yields
+    the linear bound. -/
+theorem match_count_ge_linear_of_normal (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (hn : IsNormalInBase b x) (k : ℕ) (s : Fin k → Fin b) :
+    ∀ᶠ N : ℕ in atTop,
+      ((b : ℝ) ^ (-(k : ℤ)) / 2) * (N : ℝ) ≤
+        (((Finset.range N).filter
+          (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ) := by
+  have hbR : (0 : ℝ) < (b : ℝ) := by exact_mod_cast (by omega : 0 < b)
+  have hposk : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := zpow_pos hbR _
+  have hhalf : (b : ℝ) ^ (-(k : ℤ)) / 2 < (b : ℝ) ^ (-(k : ℤ)) := by linarith
+  have hev : ∀ᶠ N in atTop, (b : ℝ) ^ (-(k : ℤ)) / 2 <
+      (((Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ)
+        / (N : ℝ) :=
+    (hn k s).eventually_const_lt hhalf
+  filter_upwards [hev, eventually_gt_atTop 0] with N hN hN0
+  have hNR : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN0
+  have hmul := mul_lt_mul_of_pos_right hN hNR
+  rw [div_mul_cancel₀ _ hNR.ne'] at hmul
+  exact le_of_lt hmul
+
+-- ============================================================
 -- PART V: OPEN QUESTION
 -- ============================================================
 

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -207,9 +207,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 1114,
+    "lineCount": 1218,
     "axiomCount": 1,
-    "theoremCount": 65,
+    "theoremCount": 69,
     "definitionCount": 5,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/e-transcendental-oq-02-oq-06.json
+++ b/src/data/research/problems/e-transcendental-oq-02-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: frequency-mismatch non-normality criterion added (tendsto-ne + one-sided eventual bounds + single-digit density≠1/b); necessary-condition theory for normality now complete. Core axiom e_absolutely_normal remains genuinely open.",
+    "progressSummary": "PROGRESS: quantitative disjunctivity added (VERIFIED 0 sorry / axiom unchanged) — occurrence count grows at least linearly ((b^{-k}/2)*N), upgrading infinitely-often to positive lower density, plus an effective before-every-window occurrence statement. Frequency-mismatch criterion (nextStep #1) was completed by merged #35802; the duplicate #35800 was closed. Open axiom e_absolutely_normal genuinely open.",
     "builtItems": [
       "normal_ktuple_infinitely_often (Proofs/ETranscendentalOQ02.lean): {n | s occurs at n}.Infinite for x normal in base b. Verified 0 sorry; axioms [propext, Classical.choice, Quot.sound].",
       "normal_imp_disjunctive (same file): every finite digit string appears at least once (corollary via Set.Infinite.nonempty).",
@@ -46,7 +46,11 @@
       "liouvilleNumber_not_normal (b>=3), exists_irrational_not_normal, irrational_not_imp_normal — ETranscendentalOQ02.lean",
       "not_normal_of_match_freq_tendsto_ne (ETranscendentalOQ02.lean): tuple matching-frequency → L ≠ b^(-k) ⇒ ¬normal, via tendsto_nhds_unique",
       "not_normal_of_match_freq_eventually_le / _eventually_ge: eventual one-sided frequency bound strictly away from b^(-k) ⇒ ¬normal (no convergence assumed), via le_of_tendsto / ge_of_tendsto",
-      "not_normal_of_digit_freq_tendsto_ne: single-digit density ≠ 1/b ⇒ ¬normal (k=1 specialization; b^(-1)=b⁻¹ bridge via Nat.cast_one+zpow_neg_one)"
+      "not_normal_of_digit_freq_tendsto_ne: single-digit density ≠ 1/b ⇒ ¬normal (k=1 specialization; b^(-1)=b⁻¹ bridge via Nat.cast_one+zpow_neg_one)",
+      "exists_match_lt_of_count_pos (ETranscendentalOQ02.lean:947): pure-Finset bridge, positive match count over range N yields an explicit occurrence < N",
+      "eventually_match_count_pos_of_normal (ETranscendentalOQ02.lean:961): match count eventually positive for a normal number",
+      "eventually_exists_match_lt_of_normal (ETranscendentalOQ02.lean:984): effective disjunctivity — tuple occurs before every large window N (strengthens normal_imp_disjunctive)",
+      "match_count_ge_linear_of_normal (ETranscendentalOQ02.lean:998): occurrence count eventually >= (b^{-k}/2)*N, i.e. positive lower density (strengthens normal_ktuple_infinitely_often)"
     ],
     "insights": [
       "The stated target normal_imp_irrational was ALREADY a complete 0-sorry theorem (Session 13); OQ-02-OQ-06 as literally phrased was resolved. Added genuinely new theory instead of reclaiming.",
@@ -57,15 +61,17 @@
       "SHARPNESS RESOLVED: the base-b Liouville constant liouvilleNumber b = sum_{i>=0} b^(-i!) (Mathlib) is an explicit VERIFIED irrational non-normal number for every b>=3 — irrational does NOT imply normal (converse of normal_imp_irrational fails).",
       "Digit computation via the factorial number system: for k!<=n<(k+1)!, floor(b^n * liouvilleNumber b) = sum_{i=0}^{k} b^(n-i!); the tail b^n*remainder < 1 uses Mathlib remainder_lt prime and sub_one_div_inv_le_two giving < 2/b <= 2/3 (needs b>=3: the doubled 0!=1! leading term puts digit 2 at n=1 only).",
       "Every base-b digit of liouvilleNumber b is 0 or 1 from position n>=2 on (residue b^(n-k!) % b in {0,1}: lower-index terms divisible by b, top term 1 iff n is a factorial), so digit 2 is eventually missing and not_normal_of_eventually_missing_digit applies.",
-      "Frequency-mismatch criterion completes the sharp-boundary theory: absence (freq 0) was the extreme case; under-/over-representation (freq eventually bounded away from b^(-k) on either side) equally forbids normality, and needs NO convergence hypothesis — only le_of_tendsto/ge_of_tendsto against the definitional limit."
+      "Frequency-mismatch criterion completes the sharp-boundary theory: absence (freq 0) was the extreme case; under-/over-representation (freq eventually bounded away from b^(-k) on either side) equally forbids normality, and needs NO convergence hypothesis — only le_of_tendsto/ge_of_tendsto against the definitional limit.",
+      "Quantitative disjunctivity (nextStep #2): normality pins the tuple frequency to b^{-k} > 0, which upgrades the qualitative normal_ktuple_infinitely_often (Set.Infinite) to a positive LOWER DENSITY — the occurrence count below N is eventually >= (b^{-k}/2)*N. The bare Tendsto definition carries no convergence RATE, so the position of the first occurrence cannot be bounded by an explicit function of k; the strongest unconditional statement is that s occurs before every sufficiently large window N.",
+      "Filter.Tendsto.eventually_const_lt (hv : u < v) (h : Tendsto f l (nhds v)) : eventually u < f — the clean way to turn a Tendsto-to-positive-limit into an eventual strict positivity; eventually_gt_of_tendsto_gt does NOT exist in Mathlib v4.26."
     ],
     "mathlibGaps": [
       "omega does not discharge variable-divisor Euclidean identities (a/T*T + a%T = a with T variable, nonlinear); use Nat.mod_add_div'/Nat.div_add_mod explicitly.",
       "Genuine irrational-AND-non-normal WITNESS (true sharpness of 'irrational ⇏ normal') still needs the real→digit bridge for a specific transcendental: computing nthDigit b n x = ⌊bⁿx⌋%b for an explicit series (e.g. Liouville ∑ b^(-k!)) requires summing the tail to isolate the k-th digit — a real-analysis construction not present. The abstract criterion is the tool; only the witness digit-computation is missing."
     ],
     "nextSteps": [
-      "Quantitative disjunctivity: bound first-occurrence position of a fixed k-tuple via the normality convergence rate (only qualitative infinitude proved).",
-      "The open axiom e_absolutely_normal is genuinely open — not eliminable. The non-normality theory (irrationality, disjunctivity, absence, and now full frequency-mismatch) is complete on the necessary-condition side."
+      "Effective/rate-based first-occurrence bounds require ADDING an explicit normality-modulus hypothesis (the definition has no rate); consider defining EffectivelyNormalWithModulus and proving a first-occurrence bound M(k,s).",
+      "The open axiom e_absolutely_normal is genuinely open — not eliminable. Sharpness of normal_imp_irrational (Liouville witness) and the frequency-mismatch + quantitative-disjunctivity theory are now complete."
     ],
     "markdown": "# Knowledge Base: e-transcendental-oq-02-oq-06\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -117,8 +123,8 @@
     {
       "path": "Proofs/ETranscendentalOQ02.lean",
       "filename": "ETranscendentalOQ02.lean",
-      "lineCount": 1022,
-      "theoremCount": 42,
+      "lineCount": 1115,
+      "theoremCount": 46,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Realizes the documented **quantitative disjunctivity** next-step for the *Is e normal?* entry (`e-transcendental-oq-02-oq-06`). The existing occurrence theory was purely qualitative — `normal_ktuple_infinitely_often` gives only `Set.Infinite`, and `normal_imp_disjunctive` gives only one occurrence *somewhere*. This PR adds a new section (PART IV.8) sharpening both, using the fact that normality pins the matching frequency to the strictly positive value `b^{-k}`.

## New theorems (all VERIFIED, 0 sorry)

- **`exists_match_lt_of_count_pos`** — pure-`Finset` bridge: a positive matching count over `range N` yields an explicit occurrence position `< N` (no normality hypothesis; generally reusable).
- **`eventually_match_count_pos_of_normal`** — for a normal number the matching count is eventually positive (frequency → `b^{-k} > 0`).
- **`eventually_exists_match_lt_of_normal`** — *effective disjunctivity*: the tuple occurs *before every sufficiently large window* `N`, strengthening `normal_imp_disjunctive`.
- **`match_count_ge_linear_of_normal`** — *positive lower density*: the occurrence count below `N` is eventually `≥ (b^{-k}/2)·N`, strengthening `normal_ktuple_infinitely_often` from "infinitely often" to a linear-growth (density `b^{-k}`) statement.

## Honesty notes

- The bare definition of `IsNormalInBase` is a `Tendsto` with **no convergence rate**, so the position of a tuple's *first* occurrence cannot be bounded by an explicit function of `k`. "Occurs before every large `N`" is the strongest unconditional statement; a rate-based first-occurrence bound would require adding an explicit normality-modulus hypothesis (left as a documented next step).
- The open axiom `e_absolutely_normal` is **unchanged** and genuinely open. This PR adds no axioms and no sorries.
- The earlier frequency-mismatch next-step was completed by the already-merged #35802; the duplicate PR #35800 (this session's stale branch) has been closed.

## Verification

`./proofs/scripts/docker-build.sh Proofs.ETranscendentalOQ02` → **Build succeeded** (0 sorry). `meta.json` counts synced (lineCount 1114→1218, theoremCount 65→69, axiomCount 1 unchanged).