### PR TITLE
research(algebraic-reals-meager-oq-02-oq-01): transfer symmetric Oxtoby decomposition to ℝⁿ [VERIFIED 0 sorry 0 axiom]

### DIFF
--- a/proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01Product.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01Product.lean
@@ -1,0 +1,200 @@
+import Mathlib
+
+/-
+  The symmetric Oxtoby decomposition transfers to `ℝⁿ`
+  (algebraic-reals-meager — OQ-02 → OQ-01, structural follow-up)
+
+  The sibling files record the **symmetric Oxtoby decomposition** of the real
+  line
+
+      ℝ  =  L  ⊔  Lᶜ
+            └ comeagre & null      (topologically large, measure-small)
+                 └ meagre & conull (topologically small, measure-large)
+
+  with `L = {x | Liouville x}`, and sharpen it by showing both pieces are
+  *dense* (`…Dense.lean`) and `Aff(ℚ)`-equivariant (`…Equivariant.lean`). The
+  one follow-up left open there was whether the whole phenomenon transfers to
+  finite-dimensional real space `ℝⁿ = (ι → ℝ)`. This file settles it.
+
+  ## The product Liouville set
+
+  Define the **product Liouville set**
+
+      Lⁿ  :=  {x : ι → ℝ | ∀ i, Liouville (xᵢ)}  =  ⋂ i, (eval i)⁻¹' L,
+
+  the points *all* of whose coordinates are Liouville. It is the honest
+  `n`-dimensional analogue of `L`, and it inherits *both* Oxtoby anomalies:
+
+  * **comeagre** — each coordinate slot `(eval i)⁻¹' L` is residual, because
+    `eval i` is a continuous *open* surjection and the preimage of a residual
+    set under such a map is residual (`tendsto_residual_of_isOpenMap`); a finite
+    intersection of residual sets is residual (`Filter.iInter_mem`).
+  * **null** — `Lⁿ ⊆ (eval i)⁻¹' L` for any single coordinate `i`, and that
+    coordinate cylinder is Lebesgue-null in the product measure
+    (`Measure.pi_eval_preimage_null`, since `L` is null on the line).
+
+  Complementation gives the dual piece `(Lⁿ)ᶜ = {x | ∃ i, ¬ Liouville xᵢ}`,
+  which is therefore **meagre** and **conull**. As on the line, *both* pieces
+  are **dense**: `Lⁿ` because it is comeagre (`dense_of_mem_residual`), and
+  `(Lⁿ)ᶜ` — the meagre half — because it is conull and the product volume gives
+  every nonempty open set positive mass (`dense_of_conull`, reused from the
+  sibling; the instance `pi.isOpenPosMeasure` supplies the hypothesis).
+
+  So the entire measure/category pathology of the line survives verbatim into
+  every finite dimension:
+
+      ℝⁿ  =  Lⁿ  ⊔  (Lⁿ)ᶜ,     both dense,
+             └ comeagre & null
+                  └ meagre & conull.
+
+  ## Honesty / novelty
+
+  No new mathematics: every step is a one- or two-line appeal to existing
+  Mathlib product-space plumbing (`isOpenMap_eval`, `continuous_apply`,
+  `tendsto_residual_of_isOpenMap`, `Measure.pi_eval_preimage_null`,
+  `pi.isOpenPosMeasure`) composed with the line-level facts already recorded in
+  the sibling files. The value is the explicit, machine-checked statement that
+  the Oxtoby decomposition is *not* a one-dimensional accident — it is a genuine
+  finite-dimensional partition of `ℝⁿ` into two dense sets, one comeagre-and-null
+  and one meagre-and-conull. Presented as a modest structural generalization.
+
+  No new axioms (standard Mathlib triple inherited).
+
+  References:
+  - Oxtoby, J.C. (1980). "Measure and Category", Springer GTM 2.
+  - Mathlib: NumberTheory.Transcendental.Liouville.{Residual,Measure},
+             Topology.Baire.BaireMeasurable (`tendsto_residual_of_isOpenMap`),
+             MeasureTheory.Constructions.Pi (`Measure.pi_eval_preimage_null`,
+             `pi.isOpenPosMeasure`).
+
+  Tags: measure-theory, baire-category, liouville-numbers, meagre, residual,
+        product-measure, oxtoby-duality, dense, higher-dimensional
+-/
+
+set_option maxHeartbeats 400000
+
+namespace AlgebraicRealsMeagerOQ02OQ01Product
+
+open MeasureTheory Filter Set Function
+
+-- ============================================================================
+-- Part I: line-level facts and the abstract conull ⟹ dense engine (recalled)
+-- ============================================================================
+
+/-- The Liouville numbers are comeagre (residual) in `ℝ`. -/
+theorem liouville_residual : {x : ℝ | Liouville x} ∈ residual ℝ :=
+  eventually_residual_liouville
+
+/-- The Liouville numbers are Lebesgue-null on the line. -/
+theorem liouville_null : volume {x : ℝ | Liouville x} = 0 :=
+  volume_setOf_liouville
+
+/-- **A conull set is dense** (in a space whose measure gives every nonempty
+    open set positive mass). Mirror of `dense_of_mem_residual`; the engine that
+    makes the *meagre* half of the Oxtoby decomposition dense. Restated from the
+    sibling `…Dense.lean` so this file is self-contained. -/
+theorem dense_of_conull {X : Type*} [TopologicalSpace X] [MeasurableSpace X]
+    {μ : Measure X} [μ.IsOpenPosMeasure] {s : Set X} (hs : μ sᶜ = 0) :
+    Dense s := by
+  rw [dense_iff_closure_eq, closure_eq_compl_interior_compl, compl_univ_iff]
+  exact μ.interior_eq_empty_of_null hs
+
+-- ============================================================================
+-- Part II: the product Liouville set `Lⁿ` in `ℝⁿ = (ι → ℝ)`
+-- ============================================================================
+
+variable {ι : Type*} [Fintype ι]
+
+/-- The **product Liouville set**: points of `ℝⁿ` *all* of whose coordinates are
+    Liouville numbers, written as the intersection of the coordinate cylinders
+    `(eval i)⁻¹' L`. -/
+def productLiouville (ι : Type*) : Set (ι → ℝ) :=
+  ⋂ i, eval i ⁻¹' {x : ℝ | Liouville x}
+
+omit [Fintype ι] in
+/-- Membership characterization: `x ∈ Lⁿ ↔ every coordinate of `x` is
+    Liouville`. -/
+theorem mem_productLiouville {x : ι → ℝ} :
+    x ∈ productLiouville ι ↔ ∀ i, Liouville (x i) := by
+  simp [productLiouville]
+
+/-- **`Lⁿ` is comeagre.** Each coordinate cylinder `(eval i)⁻¹' L` is residual
+    (preimage of the residual set `L` under the continuous open map `eval i`),
+    and a finite intersection of residual sets is residual. -/
+theorem productLiouville_residual : productLiouville ι ∈ residual (ι → ℝ) := by
+  rw [productLiouville, Filter.iInter_mem]
+  exact fun i =>
+    tendsto_residual_of_isOpenMap (continuous_apply i) (isOpenMap_eval i) liouville_residual
+
+/-- **`Lⁿ` is Lebesgue-null.** It sits inside a single coordinate cylinder
+    `(eval i)⁻¹' L`, which is null in the product measure because `L` is null on
+    the line (`Measure.pi_eval_preimage_null`). -/
+theorem productLiouville_null [Nonempty ι] : volume (productLiouville ι) = 0 := by
+  obtain ⟨i⟩ := (inferInstance : Nonempty ι)
+  rw [productLiouville]
+  refine measure_mono_null (iInter_subset (fun i => eval i ⁻¹' {x : ℝ | Liouville x}) i) ?_
+  rw [volume_pi]
+  exact Measure.pi_eval_preimage_null (fun _ => volume) liouville_null
+
+/-- **`Lⁿ` is dense** (it is comeagre and `ℝⁿ` is a Baire space). -/
+theorem dense_productLiouville : Dense (productLiouville ι) :=
+  dense_of_mem_residual productLiouville_residual
+
+-- ============================================================================
+-- Part III: the dual piece `(Lⁿ)ᶜ` — meagre, conull, yet dense
+-- ============================================================================
+
+/-- **The dual set `(Lⁿ)ᶜ = {x | ∃ i, ¬ Liouville xᵢ}` is meagre.** Its
+    complement `Lⁿ` is comeagre, so it is meagre by definition of `IsMeagre`. -/
+theorem productLiouville_compl_meagre : IsMeagre (productLiouville ι)ᶜ := by
+  rw [IsMeagre, compl_compl]
+  exact productLiouville_residual
+
+/-- **`(Lⁿ)ᶜ` is conull (full Lebesgue measure).** Its complement `Lⁿ` is
+    null. -/
+theorem productLiouville_compl_conull [Nonempty ι] :
+    volume ((productLiouville ι)ᶜ)ᶜ = 0 := by
+  rw [compl_compl]
+  exact productLiouville_null
+
+/-- **`(Lⁿ)ᶜ` is dense — despite being meagre.** It is conull, and the product
+    volume is an open-positive measure, so `dense_of_conull` applies. This is
+    the sharp content: the topologically *small* half of the Oxtoby
+    decomposition still meets every nonempty open box in `ℝⁿ`. -/
+theorem dense_productLiouville_compl [Nonempty ι] : Dense (productLiouville ι)ᶜ :=
+  dense_of_conull (μ := volume) (by rw [compl_compl]; exact productLiouville_null)
+
+-- ============================================================================
+-- Part IV: the `n`-dimensional symmetric Oxtoby decomposition
+-- ============================================================================
+
+/-- **Headline.** For every nonempty finite index set `ι`, `ℝ^ι` contains a
+    set that is simultaneously **meagre**, **dense**, and of **full Lebesgue
+    measure** — namely `(Lⁿ)ᶜ`. The one-dimensional Oxtoby pathology is not a
+    low-dimensional accident. -/
+theorem exists_meagre_dense_conull [Nonempty ι] :
+    ∃ S : Set (ι → ℝ), IsMeagre S ∧ Dense S ∧ volume Sᶜ = 0 :=
+  ⟨(productLiouville ι)ᶜ, productLiouville_compl_meagre, dense_productLiouville_compl,
+    productLiouville_compl_conull⟩
+
+/-- **The symmetric Oxtoby decomposition of `ℝⁿ`.** The disjoint partition
+    `ℝ^ι = Lⁿ ⊔ (Lⁿ)ᶜ` has:
+
+    * `Lⁿ` — **comeagre** (`∈ residual`) and **null**;
+    * `(Lⁿ)ᶜ` — **meagre** and **conull**;
+
+    with *both* pieces **dense**. This is the verbatim `n`-dimensional analogue
+    of the line-level `real_symmetric_oxtoby_dense`. -/
+theorem product_symmetric_oxtoby [Nonempty ι] :
+    productLiouville ι ∪ (productLiouville ι)ᶜ = univ ∧
+      Disjoint (productLiouville ι) (productLiouville ι)ᶜ ∧
+      (productLiouville ι ∈ residual (ι → ℝ) ∧
+        volume (productLiouville ι) = 0 ∧ Dense (productLiouville ι)) ∧
+      (IsMeagre (productLiouville ι)ᶜ ∧
+        volume ((productLiouville ι)ᶜ)ᶜ = 0 ∧ Dense (productLiouville ι)ᶜ) :=
+  ⟨union_compl_self _, disjoint_compl_right,
+    ⟨productLiouville_residual, productLiouville_null, dense_productLiouville⟩,
+    ⟨productLiouville_compl_meagre, productLiouville_compl_conull,
+      dense_productLiouville_compl⟩⟩
+
+end AlgebraicRealsMeagerOQ02OQ01Product

--- a/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
@@ -10,13 +10,15 @@
     "status": "verified",
     "proofRepoPath": "Proofs/AlgebraicRealsMeagerOQ02OQ01.lean",
     "tags": [
-      "measure-theory",
       "baire-category",
+      "higher-dimensional",
+      "lebesgue-measure",
       "liouville-numbers",
       "meagre",
-      "residual",
-      "lebesgue-measure",
+      "measure-theory",
+      "product-measure",
       "real-analysis",
+      "residual",
       "sharp-boundary"
     ],
     "badge": "mathlib",
@@ -61,7 +63,8 @@
       "nonLiouville_conull: PROVED the non-Liouville reals are conull — volume (Lᶜ)ᶜ = volume L = 0 — i.e. of full Lebesgue measure",
       "exists_meagre_conull: PROVED the headline dual Oxtoby statement — there exists a meagre subset of ℝ of full Lebesgue measure, the mirror of the parent's comeagre null set",
       "real_symmetric_oxtoby: PROVED the symmetric decomposition ℝ = L ⊔ Lᶜ (disjoint, union = univ) with L comeagre-and-null and Lᶜ meagre-and-conull, the sharp form of OQ-02 exhibiting the two largeness notions as exactly complementary",
-      "Synthesis (no new mathematics): reuses Mathlib's Liouville residual/measure-zero facts and complementation to complete the OQ-02 measure/category contrast in the dual direction the parent leaves implicit"
+      "Synthesis (no new mathematics): reuses Mathlib's Liouville residual/measure-zero facts and complementation to complete the OQ-02 measure/category contrast in the dual direction the parent leaves implicit",
+      "productLiouville / product_symmetric_oxtoby (ℝⁿ transfer): PROVED the symmetric Oxtoby decomposition transfers verbatim to finite-dimensional real space ℝ^ι. The product Liouville set Lⁿ = {x : ι → ℝ | ∀ i, Liouville (xᵢ)} = ⋂ i, (eval i)⁻¹ L is comeagre (each coordinate cylinder is residual via tendsto_residual_of_isOpenMap on the open surjection eval i; finite intersection of residual is residual) and Lebesgue-null (Lⁿ ⊆ (eval i)⁻¹ L, null by Measure.pi_eval_preimage_null), its complement (Lⁿ)ᶜ meagre and conull, and — via dense_of_conull and the pi.isOpenPosMeasure instance — BOTH pieces dense. Resolves the sole open follow-up (ℝⁿ transfer) left by the equivariance session"
     ],
     "axiomCount": 0,
     "prerequisites": [
@@ -84,7 +87,8 @@
     "theoremCount": 8,
     "definitionCount": 0,
     "additionalFiles": [
-      "Proofs/AlgebraicRealsMeagerOQ02OQ01Equivariant.lean"
+      "Proofs/AlgebraicRealsMeagerOQ02OQ01Equivariant.lean",
+      "Proofs/AlgebraicRealsMeagerOQ02OQ01Product.lean"
     ]
   },
   "overview": {

--- a/src/data/research/problems/algebraic-reals-meager-oq-02-oq-01.json
+++ b/src/data/research/problems/algebraic-reals-meager-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + two structural sharpenings: (1) both Oxtoby pieces dense (PR #35731); (2) the decomposition is Aff(ℚ)-equivariant (this session). One follow-up (ℝⁿ transfer) still open.",
+    "progressSummary": "COMPLETE + THREE structural sharpenings: (1) both Oxtoby pieces dense (PR #35731); (2) Aff(ℚ)-equivariant decomposition; (3) full ℝⁿ transfer via product Liouville set (this session). All originally-open follow-ups resolved.",
     "builtItems": [
       "isMeagre_compl_of_mem_residual in AlgebraicRealsMeagerOQ02OQ01.lean:73 — abstract duality: A∈residual α ⟹ IsMeagre Aᶜ (any TopologicalSpace), via rw[IsMeagre, compl_compl].",
       "nonLiouville_meagre:97 + nonLiouville_conull:103 — the non-Liouville reals Lᶜ are meagre and conull (volume (Lᶜ)ᶜ = 0).",
@@ -41,7 +41,8 @@
       "dense_liouville / dense_nonLiouville:96,106 — both Oxtoby pieces dense; real_symmetric_oxtoby_dense:129 packages ℝ as two disjoint dense sets (comeagre-null + meagre-conull). PR #35731, verified 0/0.",
       "liouville_add_rat_iff / liouville_rat_add_iff / liouville_neg_iff / liouville_mul_rat_iff / liouville_rat_mul_iff / liouville_rat_affine_iff in AlgebraicRealsMeagerOQ02OQ01Equivariant.lean — pointwise Aff(ℚ)-equivariance of Liouville, each a forall_congr' over the matching LiouvilleWith iff.",
       "setOf_liouville_rat_affine_preimage / _compl_rat_affine_preimage / _rat_affine_image:130+ — set invariance of L and Lᶜ under rational affine maps.",
-      "oxtoby_rat_affine_equivariant — headline: every rational affine f fixes both Oxtoby pieces setwise, with the residual/null (L) and meagre/conull (Lᶜ) facts retained. VERIFIED 0 sorries, standard-triple axioms only (host lake env lean, EXIT 0)."
+      "oxtoby_rat_affine_equivariant — headline: every rational affine f fixes both Oxtoby pieces setwise, with the residual/null (L) and meagre/conull (Lᶜ) facts retained. VERIFIED 0 sorries, standard-triple axioms only (host lake env lean, EXIT 0).",
+      "AlgebraicRealsMeagerOQ02OQ01Product.lean — productLiouville (def), mem_productLiouville, productLiouville_residual/_null, dense_productLiouville, productLiouville_compl_meagre/_conull, dense_productLiouville_compl, exists_meagre_dense_conull (headline: ∃ meagre+dense+conull S⊆ℝ^ι), product_symmetric_oxtoby (full n-dim decomposition). 12 theorems + 1 def, VERIFIED 0 sorries, axioms [propext,Classical.choice,Quot.sound] only (host lake env lean EXIT 0)."
     ],
     "insights": [
       "The dual of a comeagre null set is its literal complement: Lᶜ is meagre (because L is comeagre) and conull (because L is null). No new construction needed — the Liouville numbers already encode both halves of the Oxtoby contrast.",
@@ -51,12 +52,13 @@
       "A conull set in any IsOpenPosMeasure space is dense: interior sᶜ = ∅ (null sets have empty interior, interior_eq_empty_of_null) so closure s = (interior sᶜ)ᶜ = univ. This is the measure-side mirror of dense_of_mem_residual.",
       "Both halves of the symmetric Oxtoby decomposition ℝ = L ⊔ Lᶜ are dense: L by comeagreness (Baire), Lᶜ despite being MEAGRE by conullity. So the measure/category pathology is topologically ubiquitous, not confined to a nowhere-dense set.",
       "ℚ-equivariance follow-up RESOLVED: the classic predicate Liouville is Aff(ℚ)-invariant — Liouville (q·x+r) ↔ Liouville x for q,r∈ℚ, q≠0. Mechanism: Liouville x ↔ ∀p, LiouvilleWith p x (forall_liouvilleWith_iff), and each LiouvilleWith p already has add_rat_iff/mul_rat_iff/neg_iff in Mathlib; forall_congr'ing over p transports them verbatim to Liouville.",
-      "Set-level: f⁻¹'L = L for every rational affine f; since each such f is a bijection with rational affine inverse y↦q⁻¹y−q⁻¹r, also f''L=L (via Set.image_eq_preimage_of_inverse). Complementation gives the same for Lᶜ. So the whole Oxtoby decomposition ℝ=L⊔Lᶜ is a genuinely Aff(ℚ)-equivariant partition — the measure/category pathology is not tied to any base point or scale."
+      "Set-level: f⁻¹'L = L for every rational affine f; since each such f is a bijection with rational affine inverse y↦q⁻¹y−q⁻¹r, also f''L=L (via Set.image_eq_preimage_of_inverse). Complementation gives the same for Lᶜ. So the whole Oxtoby decomposition ℝ=L⊔Lᶜ is a genuinely Aff(ℚ)-equivariant partition — the measure/category pathology is not tied to any base point or scale.",
+      "ℝⁿ transfer RESOLVED: the symmetric Oxtoby decomposition ℝ=L⊔Lᶜ lifts verbatim to ℝ^ι=(ι→ℝ). Define the product Liouville set Lⁿ=⋂ᵢ(eval i)⁻¹L={x|∀i,Liouville(xᵢ)}. It is comeagre — each coordinate cylinder (eval i)⁻¹L is residual because eval i is a continuous OPEN map and preimages of residual sets under open continuous maps are residual (tendsto_residual_of_isOpenMap), and a finite (Fintype) intersection of residual sets is residual (Filter.iInter_mem). It is null because Lⁿ⊆(eval i)⁻¹L and that single cylinder is null in the product measure (Measure.pi_eval_preimage_null, from L null on the line + volume_pi). Complement is meagre+conull; both pieces dense (Lⁿ via dense_of_mem_residual, (Lⁿ)ᶜ via dense_of_conull + pi.isOpenPosMeasure).",
+      "Key reusable Mathlib plumbing for product-space category/measure pathology: isOpenMap_eval (Topology/Bases), continuous_apply, tendsto_residual_of_isOpenMap + IsMeagre.preimage_of_isOpenMap (Topology/Baire/BaireMeasurable), Measure.pi_eval_preimage_null + pi.isOpenPosMeasure + volume_pi (MeasureTheory/Constructions/Pi), Filter.iInter_mem (finite index). The whole n-dim result is one- and two-line compositions of these with the line-level Liouville facts."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Remaining follow-up (open): does the dense-two-piece decomposition transfer to ℝⁿ (product Liouville set) — a meagre, dense, conull subset of ℝⁿ?",
-      "Possible: package Aff(ℚ) as an actual MulAction / AddAction on ℝ and state the invariance as a group-action stabilizer, rather than a per-map iff."
+      "Likely TERMINUS for the meagre/conull theme: the line result and its ℝⁿ transfer, density sharpening, and Aff(ℚ)-equivariance are all done. A remaining genuinely-distinct direction would be to phrase Lⁿ-invariance under the product action of Aff(ℚ)^ι (or GL-type rational affine maps of ℝⁿ), but this is a routine product of the 1-D equivariance and adds little theory-level content."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Resolves the sole open follow-up of `algebraic-reals-meager-oq-02-oq-01` (the ℝⁿ transfer). Adds `proofs/Proofs/AlgebraicRealsMeagerOQ02OQ01Product.lean`: the **symmetric Oxtoby decomposition transfers verbatim to finite-dimensional real space** `ℝ^ι = (ι → ℝ)`.

Define the **product Liouville set**

```
Lⁿ := {x : ι → ℝ | ∀ i, Liouville (xᵢ)} = ⋂ i, (eval i)⁻¹' L
```

the points all of whose coordinates are Liouville. It inherits **both** Oxtoby anomalies, and complementation gives the dual:

```
ℝ^ι  =  Lⁿ  ⊔  (Lⁿ)ᶜ          (disjoint, union = univ),  both dense
        └ comeagre & null
             └ meagre & conull
```

## Mechanism (all existing Mathlib product-space plumbing)

- **comeagre** — each coordinate cylinder `(eval i)⁻¹' L` is residual (`eval i` is a continuous *open* surjection, `tendsto_residual_of_isOpenMap`); a finite intersection of residual sets is residual (`Filter.iInter_mem`, from `Fintype ι`).
- **null** — `Lⁿ ⊆ (eval i)⁻¹' L`, a single coordinate cylinder null in the product measure (`Measure.pi_eval_preimage_null` + `volume_pi`, since `L` is null on the line).
- **both dense** — `Lⁿ` by `dense_of_mem_residual`; the meagre half `(Lⁿ)ᶜ` by `dense_of_conull` + the `pi.isOpenPosMeasure` instance (conull ⟹ dense, despite meagreness).

## Contents (12 theorems + 1 def)

Headlines: `exists_meagre_dense_conull` (∃ a meagre, dense, conull `S ⊆ ℝ^ι`) and `product_symmetric_oxtoby` (the full n-dimensional decomposition with all six properties).

## Verification

- **0 sorries, 0 axioms.** Host-verified (`lake env lean`, exit 0, no errors/warnings).
- `#print axioms` on both headline theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
- Docker build reaches the target and elaborates; the shared build cache currently has several corrupt `.ir` files (olean-header in `.ir`) causing transient SIGBUS/`invalid header` during the codegen step — an environmental cache-corruption artifact, not a proof issue (elaboration/kernel-check passes cleanly on host).

## Honesty

No new mathematics — every step is a one/two-line composition of existing Mathlib lemmas with the line-level Liouville facts from the sibling files. Value: the explicit, machine-checked statement that the Oxtoby measure/category pathology is genuinely finite-dimensional, not a one-dimensional accident. Presented as a modest structural generalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)