### PR TITLE
Enrich Fourier torus-character orthonormality: mainTheorems anchors

### DIFF
--- a/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/meta.json
@@ -126,18 +126,27 @@
   "mainTheorems": [
     {
       "name": "torusChar_orthonormal",
-      "type": "theorem",
-      "description": "Orthonormality of the n-dimensional Fourier characters: ∫_{Tⁿ} e_j(x)·conj(e_k(x)) dx = δ_{j,k}. The tensor character splits into a coordinate product, Fubini factors the integral into 1-D integrals (each char1d_integral), and the product of Kronecker deltas collapses to the multi-index delta."
+      "type": "core",
+      "description": "Orthonormality of the n-dimensional Fourier characters: ∫_{Tⁿ} e_j(x)·conj(e_k(x)) dx = δ_{j,k}. The tensor character splits into a coordinate product, Fubini factors the integral into 1-D integrals (each char1d_integral), and the product of Kronecker deltas collapses to the multi-index delta.",
+      "leanType": "{n : ℕ} (j k : MultiIndex n) : ∫ x : Torus n, torusChar j x * conj (torusChar k x) = if j = k then 1 else 0",
+      "startLine": 75,
+      "endLine": 96
     },
     {
       "name": "char1d_integral",
-      "type": "theorem",
-      "description": "One-dimensional orthogonality in concrete-integral form: ∫_{AddCircle 1} fourier a(x)·conj(fourier b(x)) dx = δ_{a,b}, making Mathlib's orthonormal_fourier explicit as an integral against volume (= Haar probability measure at T=1)."
+      "type": "key",
+      "description": "One-dimensional orthogonality in concrete-integral form: ∫_{AddCircle 1} fourier a(x)·conj(fourier b(x)) dx = δ_{a,b}, making Mathlib's orthonormal_fourier explicit as an integral against volume (= Haar probability measure at T=1).",
+      "leanType": "(a b : ℤ) : ∫ x : AddCircle (1 : ℝ), fourier a x * conj (fourier b x) = if a = b then 1 else 0",
+      "startLine": 54,
+      "endLine": 65
     },
     {
       "name": "fourierCoeffND_torusChar",
-      "type": "theorem",
-      "description": "Orthonormality restated via the parent's coefficient: the j-th Fourier coefficient of the character e_k is δ_{j,k} (fourierCoeffND (torusChar k) j = δ_{j,k}) — the characters are an orthonormal system read off by the Fourier transform."
+      "type": "key",
+      "description": "Orthonormality restated via the parent's coefficient: the j-th Fourier coefficient of the character e_k is δ_{j,k} (fourierCoeffND (torusChar k) j = δ_{j,k}) — the characters are an orthonormal system read off by the Fourier transform.",
+      "leanType": "{n : ℕ} (j k : MultiIndex n) : fourierCoeffND (torusChar k) j = if k = j then 1 else 0",
+      "startLine": 103,
+      "endLine": 106
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass on `fourier-series-oq-04-wip-01-oq-01`.

`mainTheorems` listed all three theorems but every entry lacked `startLine`/`endLine` (undefined), breaking jump-to-source. Added verified anchors + `leanType` signatures and core/key types:
- torusChar_orthonormal (75–96), char1d_integral (54–65), fourierCoeffND_torusChar (103–106).

Sections already tile the full file. Anchors verified against the Lean source; JSON validated; under the 60 KB cap.