### PR TITLE
Enrich Erdős #100 integer-distance bridge (erdos-100-oq-01-incomplete-01): finer sections

### DIFF
--- a/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
@@ -60,20 +60,44 @@
   },
   "sections": [
     {
-      "id": "counting-core",
-      "title": "Counting Positive Integers in a Bounded Range",
-      "summary": "card_le_floor_of_pos_int_le and card_le_of_pos_int_le: a finite set of positive integers each <= D has at most floor(D) <= D elements.",
+      "id": "sec-header",
+      "title": "Problem Statement and the Bridge to Erdős #89",
+      "summary": "Docstring: Erdős #100 asks whether an n-point integer-distance set in ℝ² must have diameter ≫ n (best known: diam ≥ c·n/log n via Guth–Katz). This file formalizes the combinatorial bridge the OQ-01 scaffold documents — that integer distances confine the distinct distances to {1,…,⌊diam⌋} — leaving the scaffold's Piepmeyer 9-point witness sorry untouched.",
       "startLine": 1,
-      "endLine": 90,
-      "mathContext": "Inject each value's natural-number form into Finset.Icc 1 (floor D); InjOn since distinct integers have distinct floors; |Icc 1 m| = m."
+      "endLine": 38,
+      "mathContext": "Erdős #100 (OPEN): integer pairwise distances ⟹ diam ≫ n? Bridge: #distinct distances ≤ ⌊diam⌋."
     },
     {
-      "id": "bridge",
-      "title": "The Integer-Distance Bridge",
-      "summary": "distinct_distances_le_diam: the distinct integer distances, being positive integers bounded by the diameter, number at most the diameter — the link to Erdős #89 and the Guth-Katz bound.",
-      "startLine": 91,
+      "id": "sec-floor-core",
+      "title": "Combinatorial Core: |S| ≤ ⌊D⌋₊",
+      "summary": "card_le_floor_of_pos_int_le maps each value x ∈ S to its natural floor ⌊x⌋₊, showing (hmaps) it lands in Finset.Icc 1 ⌊D⌋₊ and (hinj) the map is injective on S (distinct positive integers have distinct floors). Finset.card_le_card_of_injOn then bounds |S| by |Icc 1 ⌊D⌋₊| = ⌊D⌋₊.",
+      "startLine": 40,
+      "endLine": 72,
+      "mathContext": "|S| ≤ |Icc 1 ⌊D⌋₊| = ⌊D⌋₊ via the injection x ↦ ⌊x⌋₊ ∈ {1,…,⌊D⌋₊}."
+    },
+    {
+      "id": "sec-direct-bound",
+      "title": "Restating the Bound Against D",
+      "summary": "card_le_of_pos_int_le upgrades the ⌊D⌋₊ bound to the real bound |S| ≤ D for D ≥ 0, using Nat.floor_le (⌊D⌋₊ ≤ D). This is the form directly usable against the diameter.",
+      "startLine": 74,
+      "endLine": 83,
+      "mathContext": "⌊D⌋₊ ≤ D for D ≥ 0, so |S| ≤ ⌊D⌋₊ ≤ D."
+    },
+    {
+      "id": "sec-bridge",
+      "title": "The Integer-Distance Bridge (Erdős #100 ↔ #89)",
+      "summary": "distinct_distances_le_diam is the named corollary: the distinct pairwise distances of an integer-distance configuration are positive integers bounded by the diameter D, so their count is ≤ D. Combined with the Guth–Katz distinct-distances lower bound #distinct ≥ c·n/log n, this yields diam ≥ c·n/log n.",
+      "startLine": 85,
+      "endLine": 98,
+      "mathContext": "#distinct distances ≤ D; with Guth–Katz #distinct ≥ c·n/log n ⟹ diam ≥ c·n/log n."
+    },
+    {
+      "id": "sec-significance",
+      "title": "Significance: From the Bridge to the Diameter Bound",
+      "summary": "Closing docstring explaining how this unconditional combinatorial fact is exactly the step that converts the Guth–Katz distinct-distances lower bound into the current best diameter bound for Erdős #100, and why it is independent of the still-open Piepmeyer explicit-witness construction.",
+      "startLine": 100,
       "endLine": 118,
-      "mathContext": "Direct corollary of card_le_of_pos_int_le applied to the finite set of distinct integer distances."
+      "mathContext": "The bridge is the load-bearing inequality turning distinct-distance lower bounds into diameter lower bounds."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `erdos-100-oq-01-incomplete-01`.

The scorer flagged one structural gap (quality 94): sections 4/10 — only 2 coarse sections for a 118-line, three-lemma file. Addressed by splitting into 5 sections aligned to the file's natural structure, each with its own summary + mathContext (meta.json 12.8 → 14.8 KB, well under the ~60 KB cap):

1. Problem statement & the bridge to Erdős #89
2. Combinatorial core: |S| ≤ ⌊D⌋₊ (the injection x ↦ ⌊x⌋₊ into Icc 1 ⌊D⌋₊)
3. Restating the bound against D (via Nat.floor_le)
4. The integer-distance bridge `distinct_distances_le_diam` (Erdős #100 ↔ #89)
5. Significance: from the bridge to the diameter bound

Line anchors verified against the Lean source; annotations, keyInsights, conclusion, crossReferences unchanged and already complete. Quality 94 → 100.