### PR TITLE
Enrich Hall's defect theorem: add mainTheorems anchors

### DIFF
--- a/src/data/proofs/halls-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-01/meta.json
@@ -143,13 +143,19 @@
   "mainTheorems": [
     {
       "name": "defect_hall",
-      "type": "theorem",
-      "description": "Hall's theorem with defect d (Ore's deficiency form): a finite family of finite sets t : ι → Finset α satisfies the relaxed Hall condition ∀ s, #s ≤ #(s.biUnion t) + d if and only if there is a partial system of distinct representatives leaving at most d indices unmatched — a set `rejected` with #rejected ≤ d and an assignment e that is injective off `rejected` with e i ∈ t i for every i ∉ rejected. Proved by adjoining d universal dummy elements (living in α ⊕ Fin d), applying ordinary Hall to the enlarged family, and counting how many indices are absorbed by dummies."
+      "type": "core",
+      "description": "Hall's theorem with defect d (Ore's deficiency form): a finite family of finite sets t : ι → Finset α satisfies the relaxed Hall condition ∀ s, #s ≤ #(s.biUnion t) + d if and only if there is a partial system of distinct representatives leaving at most d indices unmatched — a set `rejected` with #rejected ≤ d and an assignment e that is injective off `rejected` with e i ∈ t i for every i ∉ rejected. Proved by adjoining d universal dummy elements (living in α ⊕ Fin d), applying ordinary Hall to the enlarged family, and counting how many indices are absorbed by dummies.",
+      "leanType": "{ι α : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq α] [Nonempty α] (t : ι → Finset α) (d : ℕ) : (∀ s : Finset ι, #s ≤ #(s.biUnion t) + d) ↔ ∃ (e : ι → α) (rejected : Finset ι), #rejected ≤ d ∧ Set.InjOn e (↑rejectedᶜ) ∧ ∀ i ∉ rejected, e i ∈ t i",
+      "startLine": 62,
+      "endLine": 176
     },
     {
       "name": "defect_hall_zero",
-      "type": "theorem",
-      "description": "Marriage theorem (no defect): specialising defect_hall to d = 0 recovers the classical Hall statement — the Hall condition ∀ s, #s ≤ #(s.biUnion t) is equivalent to the existence of a full system of distinct representatives (an injective e with e i ∈ t i for all i). Follows because #rejected ≤ 0 forces `rejected = ∅`, collapsing the partial SDR to a total one."
+      "type": "key",
+      "description": "Marriage theorem (no defect): specialising defect_hall to d = 0 recovers the classical Hall statement — the Hall condition ∀ s, #s ≤ #(s.biUnion t) is equivalent to the existence of a full system of distinct representatives (an injective e with e i ∈ t i for all i). Follows because #rejected ≤ 0 forces `rejected = ∅`, collapsing the partial SDR to a total one.",
+      "leanType": "{ι α : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq α] [Nonempty α] (t : ι → Finset α) : (∀ s : Finset ι, #s ≤ #(s.biUnion t)) ↔ ∃ e : ι → α, Function.Injective e ∧ ∀ i, e i ∈ t i",
+      "startLine": 181,
+      "endLine": 196
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass on `halls-theorem-oq-01-oq-01`.

`mainTheorems` listed both theorems but each lacked `startLine`/`endLine` (undefined), breaking jump-to-source. Added verified anchors + `leanType` signatures and core/key types:
- defect_hall (62–176), defect_hall_zero (181–196).

Sections already tile the full file. Anchors verified against the Lean source; JSON validated; under the 60 KB cap.