### PR TITLE
research(sylow-oq-04-oq-03): lower unipotents are commutators for p≥5 — both root groups in the derived subgroup [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -517,4 +517,28 @@ theorem exists_unipotent_isCommutator (hp : 5 ≤ p) (s : ZMod p) :
     exact isUnit_iff_ne_zero.mpr h3
   exact unipotent_isCommutator_of_isUnit haU s
 
+/-- **For every prime `p ≥ 5`, every *lower* unipotent element is also a commutator.**
+Conjugating the upper-unipotent identity by the Weyl element `w` transports it to the
+opposite root group: since `w` sends `u(−s) ∈ U` to `lowerUnipotent s ∈ U⁻`
+(`weylW_conj_unipotent`) and conjugation carries a commutator `g·h·g⁻¹·h⁻¹` to the
+commutator of the conjugates, `lowerUnipotent s` is the commutator of
+`w·diag(a)·w⁻¹` and `w·u(t)·w⁻¹`.  Together with `exists_unipotent_isCommutator` this
+places **both** root groups `U` and `U⁻` inside the derived subgroup
+`[SL(2,p), SL(2,p)]` — the two halves of the perfectness input to Iwasawa's criterion
+(recall `⟨U, U⁻⟩ = SL(2,p)`). -/
+theorem exists_lowerUnipotent_isCommutator (hp : 5 ≤ p) (s : ZMod p) :
+    ∃ g h : Matrix.SpecialLinearGroup (Fin 2) (ZMod p),
+      g * h * g⁻¹ * h⁻¹ = lowerUnipotent s := by
+  obtain ⟨a, t, hc⟩ := exists_unipotent_isCommutator hp (-s)
+  refine ⟨weylW * torusHom a * weylW⁻¹, weylW * unipotentUpper t * weylW⁻¹, ?_⟩
+  -- Conjugation by `w` is a homomorphism, so it distributes over the commutator word;
+  -- the interior collapses to the upper-unipotent commutator identity `hc`.
+  have key : (weylW * torusHom a * weylW⁻¹) * (weylW * unipotentUpper t * weylW⁻¹)
+        * (weylW * torusHom a * weylW⁻¹)⁻¹ * (weylW * unipotentUpper t * weylW⁻¹)⁻¹
+      = weylW *
+          (torusHom a * unipotentUpper t * (torusHom a)⁻¹ * (unipotentUpper t)⁻¹)
+          * weylW⁻¹ := by
+    group
+  rw [key, hc, weylW_conj_unipotent, neg_neg]
+
 end SylowOQ04OQ03

--- a/research/problems/sylow-theorem-oq-04-oq-03/state.md
+++ b/research/problems/sylow-theorem-oq-04-oq-03/state.md
@@ -31,3 +31,20 @@ unipotent Sylow-p (#34623), torus/normalizer split (#34648), and Weyl element (#
 Continue the standalone BUILD: (a) generation ⟨U, U⁻⟩ = SL(2,p) from the Weyl conjugation,
 (b) |SL(2,𝔽_p)| = p(p²−1), (c) the P¹(𝔽_p) action + 2-transitivity. Keep the entry BLOCKED
 for the simplicity theorem itself until that action infrastructure exists.
+
+
+## Session 2026-07-08 (researcher-3) — BUILD: lower unipotents are commutators for p≥5 [VERIFIED 0/0]
+Added `exists_lowerUnipotent_isCommutator (hp : 5 ≤ p) (s)`: every lower unipotent
+`lowerUnipotent s` is a commutator `g*h*g⁻¹*h⁻¹`. Proof conjugates the existing
+`exists_unipotent_isCommutator` (upper case) by the Weyl element `w`: since
+`weylW_conj_unipotent` sends `u(-s)∈U` to `lowerUnipotent s∈U⁻`, and conjugation carries a
+commutator to the commutator of the conjugates (the `group` tactic discharges the
+distribution `k(ghg⁻¹h⁻¹)k⁻¹`), the lower unipotent is the commutator of `w·diag(a)·w⁻¹`
+and `w·u(t)·w⁻¹`. **Both** root groups U and U⁻ now lie in the derived subgroup — the two
+halves of the perfectness input to Iwasawa. Docker green (7743 jobs); 520→544 L / 0 sorry /
+0 axiom; meta synced (leanFile.lineCount 520→544, meta.lineCount 265→544 stale-reconcile,
+meta.theoremCount 17→18 + mainTheorems entry). PR pending.
+
+**Still BLOCKED** (deep theorem): full perfectness needs ⟨U,U⁻⟩=SL(2,p) generation; the
+simplicity theorem needs the P¹(𝔽_p) action + 2-transitivity + Iwasawa assembly (>1000 L,
+absent from Mathlib). Next tractable BUILD: generation ⟨U,U⁻⟩=SL(2,p) via Bruhat/Gauss.

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -24,8 +24,8 @@
     "dateAdded": "2026-07-04",
     "axiomCount": 0,
     "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, 0 structure-encoded hypotheses, no `native_decide` (so no `Lean.ofReduceBool`). `#print axioms` for `torusHom_conj_unipotent` and `card_torus_range` reports only the ordinary foundational axioms `propext`, `Classical.choice`, `Quot.sound`. Every result is machine-checked from Mathlib. The parent simplicity theorem for PSL(2, p) remains open; this entry proves only the verified unipotent-subgroup and split-torus infrastructure and makes no claim about the open question itself.",
-    "lineCount": 265,
-    "theoremCount": 17,
+    "lineCount": 544,
+    "theoremCount": 18,
     "definitionCount": 4,
     "originalContributions": [
       "unipotentUpper: the matrix [[1,t],[0,1]] packaged as a determinant-1 element of SL(2, ZMod p)",
@@ -38,6 +38,12 @@
     ]
   },
   "mainTheorems": [
+    {
+      "name": "exists_lowerUnipotent_isCommutator",
+      "type": "theorem",
+      "description": "For every prime p ≥ 5, every lower unipotent lowerUnipotent s is a commutator g·h·g⁻¹·h⁻¹. Conjugating exists_unipotent_isCommutator by the Weyl element w (which sends U to U⁻ via weylW_conj_unipotent) transports the upper-root-group commutator identity to the opposite root group. Together with the upper case this places BOTH root groups U and U⁻ inside the derived subgroup [SL(2,p), SL(2,p)] — the two halves of the perfectness input to Iwasawa's simplicity criterion (recall ⟨U, U⁻⟩ = SL(2,p)).",
+      "leanType": "(hp : 5 ≤ p) → (s : ZMod p) → ∃ g h : Matrix.SpecialLinearGroup (Fin 2) (ZMod p), g * h * g⁻¹ * h⁻¹ = lowerUnipotent s"
+    },
     {
       "name": "exists_unipotent_isCommutator",
       "type": "main",
@@ -248,7 +254,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 520,
+    "lineCount": 544,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds one verified theorem to `SylowTheoremOQ04OQ03.lean` (PSL(2,p) simplicity infrastructure via Iwasawa's criterion):

```lean
theorem exists_lowerUnipotent_isCommutator (hp : 5 ≤ p) (s : ZMod p) :
    ∃ g h : Matrix.SpecialLinearGroup (Fin 2) (ZMod p),
      g * h * g⁻¹ * h⁻¹ = lowerUnipotent s
```

The existing `exists_unipotent_isCommutator` shows every **upper** unipotent `u(s)` is a commutator `[diag(a), u(t)]`. This session completes the symmetry for the **opposite** root group: conjugating that identity by the Weyl element `w` transports it to the lower unipotents.

## Proof
- `weylW_conj_unipotent (-s)`: `w · u(-s) · w⁻¹ = lowerUnipotent s` (the Weyl element sends `U → U⁻`).
- Conjugation is a homomorphism, so it distributes over the commutator word: `(kgk⁻¹)(khk⁻¹)(kgk⁻¹)⁻¹(khk⁻¹)⁻¹ = k·(ghg⁻¹h⁻¹)·k⁻¹` — discharged by the `group` tactic.
- The interior `ghg⁻¹h⁻¹` (with `g = diag(a)`, `h = u(t)`) collapses to `u(-s)` by the reused `exists_unipotent_isCommutator`.

So `lowerUnipotent s = [w·diag(a)·w⁻¹, w·u(t)·w⁻¹]`. Together with the upper case, **both** root groups `U` and `U⁻` now lie in the derived subgroup `[SL(2,p), SL(2,p)]` — the two halves of the perfectness input to Iwasawa's simplicity criterion (recall `⟨U, U⁻⟩ = SL(2,p)`).

## Verification
`./proofs/scripts/docker-build.sh Proofs.SylowTheoremOQ04OQ03` → **Build succeeded (7743 jobs)**, 0 sorry / 0 axiom. (The two pre-existing `unusedSimpArgs` warnings at lines 431–432 are in `unipotent_inter_torus_trivial`, untouched by this change.)

meta.json synced: `leanFile.lineCount 520→544`; stale `meta.lineCount 265→544`; `meta.theoremCount 17→18` with a new `mainTheorems` entry. Entry stays `verified`; the deep simplicity theorem (P¹ action, 2-transitivity, Iwasawa assembly) remains open/BLOCKED as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)