### PR TITLE
research(szemeredi-regularity-oq-04): irregularity-witness → between-halves density-gap bridge [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Witness.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Witness.lean
@@ -1,0 +1,196 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: wiring the irregularity witness to the
+  energy-increment hypothesis of the strong (AFKS) regularity lemma.
+
+  The companion files supply the two structural halves of the AFKS iteration:
+
+  * `SzemerediRegularityOQ04Energy` proves the *quantitative energy increment*
+    `pairEnergy_split_gain` — refining a part into two halves whose densities to a
+    fixed set `B` differ by at least `δ` raises the normalized energy by at least
+    `(|A₁||A₂|/(|A₁|+|A₂|))·(|B|/n²)·δ²`.
+  * `SzemerediRegularityOQ04Bridge` cashes that out to `partitionEnergy` and to the
+    explicit `N ≤ 2n²/ε²` iteration count.
+
+  Both consume a hypothesis of the shape `|d(A₁,B₀) − d(A₂,B₀)| ≥ δ`: a density
+  gap *between the two halves of a split part*, measured against a common third
+  set.  What the classical iteration actually produces (`exists_irregular_witness`,
+  `SzemerediRegularity`) is different: subsets `A' ⊆ A`, `B' ⊆ B` whose *own*
+  density `d(A',B')` deviates from the *pair* density `d(A,B)` by more than `ε`.
+  Nothing previously connected the two shapes — the increment machinery sat
+  disconnected from the only source of irregularity.
+
+  This file supplies that missing bridge, fully machine-checked:
+
+  * `edgeDensity_whole_between` — the convexity fact that `d(A₁∪A₂,B)` is the
+    `|A₁|:|A₂|`-weighted mean of `d(A₁,B)` and `d(A₂,B)`, hence lies between them:
+    `|d(A₁,B) − d(A₁∪A₂,B)| ≤ |d(A₁,B) − d(A₂,B)|`.  The whole is never farther
+    from a half than the two halves are from each other.
+  * `irregular_witness_split_gap` — the bridge: a witness deviation
+    `|d(A',B') − d(A,B)| > ε` is dominated by the sum of two genuine
+    *between-halves* gaps, one on each coordinate:
+    `|d(A',B') − d(A∖A',B')| + |d(A,B') − d(A,B∖B')| > ε`.
+  * `irregular_witness_split_gap_disjunction` — the consumable corollary: at least
+    one coordinate carries a between-halves gap `> ε/2`, i.e. exactly the `hdev`
+    hypothesis of `pairEnergy_split_gain`, on either the `A`-split (against `B'`)
+    or the `B`-split (against `A`).
+
+  The proof is a triangle inequality `|d(A',B')−d(A,B)| ≤ |d(A',B')−d(A,B')| +
+  |d(A,B')−d(A,B)|` with each term collapsed onto a between-halves gap by
+  `edgeDensity_whole_between` (the intermediate `d(A,B')` is the whole against a
+  fixed side, hence sandwiched between the two halves' densities).
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000); Szemerédi (1978); Komlós–Simonovits (1996).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Energy
+import Proofs.SzemerediRegularityOQ01
+
+namespace Szemeredi.RegularityOQ04Witness
+
+open Szemeredi.Core Szemeredi.Regularity Szemeredi.RegularityOQ04Energy
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: THE WHOLE LIES BETWEEN THE HALVES (DENSITY CONVEXITY)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The union density is a weighted mean of the halves.**  For a disjoint split
+    `A₁, A₂` of the first argument, against a fixed nonempty `B`, the whole density
+    `d(A₁∪A₂,B)` is the `|A₁|:|A₂|`-weighted average of `d(A₁,B)` and `d(A₂,B)`,
+    hence never farther from a half than the two halves are from each other:
+
+    `|d(A₁,B) − d(A₁∪A₂,B)| ≤ |d(A₁,B) − d(A₂,B)|`.
+
+    This is what upgrades a *whole-vs-half* density gap into a *half-vs-half* gap of
+    at least the same size — the shape the energy-increment lemma consumes. -/
+theorem edgeDensity_whole_between (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A₁ A₂ B : Finset V) (hdisj : Disjoint A₁ A₂)
+    (hB : 0 < (B.card : ℚ)) (hsum : 0 < (A₁.card : ℚ) + A₂.card) :
+    |edgeDensity G A₁ B - edgeDensity G (A₁ ∪ A₂) B| ≤
+      |edgeDensity G A₁ B - edgeDensity G A₂ B| := by
+  have hBne : (B.card : ℚ) ≠ 0 := ne_of_gt hB
+  -- Weighted-average identity, with the `|B|` factor cancelled.
+  have hmul := edgeDensity_union_mul G A₁ A₂ B hdisj
+  have hcard : ((A₁ ∪ A₂).card : ℚ) = (A₁.card : ℚ) + A₂.card := by
+    rw [Finset.card_union_of_disjoint hdisj]; push_cast; ring
+  rw [hcard] at hmul
+  have hcan : ((A₁.card : ℚ) + A₂.card) * edgeDensity G (A₁ ∪ A₂) B =
+      (A₁.card : ℚ) * edgeDensity G A₁ B + (A₂.card : ℚ) * edgeDensity G A₂ B :=
+    mul_left_cancel₀ hBne (by linear_combination hmul)
+  -- Solve for the whole-vs-half discrepancy: `(a₁+a₂)(g₁-gu) = a₂(g₁-g₂)`.
+  have hcancel : ((A₁.card : ℚ) + A₂.card) *
+        (edgeDensity G A₁ B - edgeDensity G (A₁ ∪ A₂) B) =
+      (A₂.card : ℚ) * (edgeDensity G A₁ B - edgeDensity G A₂ B) := by
+    linear_combination -hcan
+  have ha₁ : 0 ≤ (A₁.card : ℚ) := by positivity
+  have ha₂ : 0 ≤ (A₂.card : ℚ) := by positivity
+  -- Abbreviate; `set` now folds the goal, `hcancel`, `hsum`, `ha₁`, `ha₂`.
+  set g₁ := edgeDensity G A₁ B
+  set g₂ := edgeDensity G A₂ B
+  set gu := edgeDensity G (A₁ ∪ A₂) B
+  set a₁ := (A₁.card : ℚ)
+  set a₂ := (A₂.card : ℚ)
+  -- Take absolute values: `(a₁+a₂)·|g₁-gu| = a₂·|g₁-g₂|`.
+  have h1 : (a₁ + a₂) * |g₁ - gu| = a₂ * |g₁ - g₂| := by
+    have hcong := congrArg abs hcancel
+    rwa [abs_mul, abs_mul, abs_of_pos hsum, abs_of_nonneg ha₂] at hcong
+  -- Since `a₂ ≤ a₁ + a₂`, the right side is `≤ (a₁+a₂)·|g₁-g₂|`.
+  have h2 : a₂ * |g₁ - g₂| ≤ (a₁ + a₂) * |g₁ - g₂| :=
+    mul_le_mul_of_nonneg_right (by linarith) (abs_nonneg _)
+  have h3 : (a₁ + a₂) * |g₁ - gu| ≤ (a₁ + a₂) * |g₁ - g₂| := by rw [h1]; exact h2
+  exact le_of_mul_le_mul_left h3 hsum
+
+/-- Second-argument form: the whole `d(A, B₁∪B₂)` lies between the two halves
+    `d(A,B₁)` and `d(A,B₂)`.  Obtained from `edgeDensity_whole_between` by symmetry
+    of `edgeDensity`. -/
+theorem edgeDensity_whole_between_right (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B₁ B₂ : Finset V) (hdisj : Disjoint B₁ B₂)
+    (hA : 0 < (A.card : ℚ)) (hsum : 0 < (B₁.card : ℚ) + B₂.card) :
+    |edgeDensity G A B₁ - edgeDensity G A (B₁ ∪ B₂)| ≤
+      |edgeDensity G A B₁ - edgeDensity G A B₂| := by
+  have h := edgeDensity_whole_between G B₁ B₂ A hdisj hA hsum
+  rwa [Szemeredi.Regularity.OQ01.edgeDensity_comm G B₁ A,
+    Szemeredi.Regularity.OQ01.edgeDensity_comm G (B₁ ∪ B₂) A,
+    Szemeredi.Regularity.OQ01.edgeDensity_comm G B₂ A] at h
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE BRIDGE — WITNESS DEVIATION ⟹ BETWEEN-HALVES GAPS
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The irregularity-witness bridge.**  Let `A' ⊆ A`, `B' ⊆ B` be an
+    irregularity witness: their density `d(A',B')` deviates from the pair density
+    `d(A,B)` by more than `ε`.  Then that deviation is dominated by the sum of two
+    genuine *between-halves* density gaps — one from splitting `A` into `A', A∖A'`
+    (measured against the fixed set `B'`), one from splitting `B` into `B', B∖B'`
+    (measured against the fixed set `A`):
+
+    `|d(A',B') − d(A∖A',B')| + |d(A,B') − d(A,B∖B')| > ε`.
+
+    Proof: triangle-inequality through the intermediate density `d(A,B')`, then
+    collapse each leg with `edgeDensity_whole_between` — `d(A,B') = d(A'∪(A∖A'),B')`
+    is sandwiched between `d(A',B')` and `d(A∖A',B')`, and `d(A,B) =
+    d(A,B'∪(B∖B'))` between `d(A,B')` and `d(A,B∖B')`.  This turns the abstract
+    witness of `exists_irregular_witness` into the concrete half-vs-half gap that
+    `pairEnergy_split_gain` requires. -/
+theorem irregular_witness_split_gap (G : SimpleGraph V) [DecidableRel G.Adj]
+    (ε : ℚ) (A B A' B' : Finset V) (hA' : A' ⊆ A) (hB' : B' ⊆ B)
+    (hA : 0 < (A.card : ℚ)) (hB : 0 < (B.card : ℚ)) (hB'pos : 0 < (B'.card : ℚ))
+    (hdev : |edgeDensity G A' B' - edgeDensity G A B| > ε) :
+    |edgeDensity G A' B' - edgeDensity G (A \ A') B'| +
+        |edgeDensity G A B' - edgeDensity G A (B \ B')| > ε := by
+  -- `A' ⊔ (A ∖ A') = A` and `B' ⊔ (B ∖ B') = B`.
+  have hAunion : A' ∪ (A \ A') = A := Finset.union_sdiff_of_subset hA'
+  have hBunion : B' ∪ (B \ B') = B := Finset.union_sdiff_of_subset hB'
+  have hAdisj : Disjoint A' (A \ A') := Finset.disjoint_sdiff
+  have hBdisj : Disjoint B' (B \ B') := Finset.disjoint_sdiff
+  -- Size of the `A`-side halves sums to `|A| > 0`; likewise on the `B`-side.
+  have hAsum : 0 < (A'.card : ℚ) + (A \ A').card := by
+    have : (A'.card : ℚ) + ((A \ A').card : ℚ) = (A.card : ℚ) := by
+      rw [add_comm]; exact_mod_cast Finset.card_sdiff_add_card_eq_card hA'
+    rw [this]; exact hA
+  have hBsum : 0 < (B'.card : ℚ) + (B \ B').card := by
+    have : (B'.card : ℚ) + ((B \ B').card : ℚ) = (B.card : ℚ) := by
+      rw [add_comm]; exact_mod_cast Finset.card_sdiff_add_card_eq_card hB'
+    rw [this]; exact hB
+  -- A-leg: `|d(A',B') − d(A,B')| ≤ |d(A',B') − d(A∖A',B')|`.
+  have hAleg : |edgeDensity G A' B' - edgeDensity G A B'| ≤
+      |edgeDensity G A' B' - edgeDensity G (A \ A') B'| := by
+    have h := edgeDensity_whole_between G A' (A \ A') B' hAdisj hB'pos hAsum
+    rwa [hAunion] at h
+  -- B-leg: `|d(A,B') − d(A,B)| ≤ |d(A,B') − d(A,B∖B')|`.
+  have hBleg : |edgeDensity G A B' - edgeDensity G A B| ≤
+      |edgeDensity G A B' - edgeDensity G A (B \ B')| := by
+    have h := edgeDensity_whole_between_right G A B' (B \ B') hBdisj hA hBsum
+    rwa [hBunion] at h
+  -- Triangle inequality through the intermediate density `d(A, B')`.
+  have htri : |edgeDensity G A' B' - edgeDensity G A B| ≤
+      |edgeDensity G A' B' - edgeDensity G A B'| +
+        |edgeDensity G A B' - edgeDensity G A B| := by
+    have := abs_sub_le (edgeDensity G A' B') (edgeDensity G A B') (edgeDensity G A B)
+    linarith
+  linarith
+
+/-- **Consumable disjunction.**  From the witness deviation `> ε`, at least one
+    coordinate carries a between-halves density gap `> ε/2`: either splitting the
+    `A`-side against the fixed set `B'`, or splitting the `B`-side against the fixed
+    set `A`.  Each disjunct is *exactly* the `hdev` hypothesis of
+    `pairEnergy_split_gain` (with `δ = ε/2`), so this closes the loop from
+    `exists_irregular_witness` to a definite `partitionEnergy` increment. -/
+theorem irregular_witness_split_gap_disjunction (G : SimpleGraph V)
+    [DecidableRel G.Adj]
+    (ε : ℚ) (A B A' B' : Finset V) (hA' : A' ⊆ A) (hB' : B' ⊆ B)
+    (hA : 0 < (A.card : ℚ)) (hB : 0 < (B.card : ℚ)) (hB'pos : 0 < (B'.card : ℚ))
+    (hdev : |edgeDensity G A' B' - edgeDensity G A B| > ε) :
+    |edgeDensity G A' B' - edgeDensity G (A \ A') B'| > ε / 2 ∨
+      |edgeDensity G A B' - edgeDensity G A (B \ B')| > ε / 2 := by
+  have hsum := irregular_witness_split_gap G ε A B A' B' hA' hB' hA hB hB'pos hdev
+  by_contra hcon
+  push_neg at hcon
+  obtain ⟨h1, h2⟩ := hcon
+  linarith
+
+end Szemeredi.RegularityOQ04Witness

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -3,7 +3,7 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-08T17:43:50-07:00
+**Since**: 2026-07-08T18:27:58-07:00
 **Iteration**: 2
 
 ## Status (S1, researcher-6, 2026-07-08) — VERIFIED finiteness engine for the AFKS iteration

--- a/research/registry.json
+++ b/research/registry.json
@@ -35827,7 +35827,7 @@
       "path": "full",
       "started": "2026-07-04T19:56:31-07:00",
       "status": "active",
-      "lastUpdate": "2026-07-08T17:43:50-07:00"
+      "lastUpdate": "2026-07-08T18:27:58-07:00"
     },
     {
       "slug": "prob-method-applications-wip-01-oq-02",

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -26,7 +26,7 @@
     "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: quantitative energy-increment fully assembled — one irregular-partner split realizes a uniform floor δ²/(2n²) (partitionEnergy_single_split_gain_uniform) which caps the AFKS refinement loop at an explicit N≤2n²/ε² steps (afks_energy_iteration_count). Remaining: wire the irregular-pair witness and state/assemble the two-level conclusion.",
+    "progressSummary": "PROGRESS (VERIFIED 0/0): supplied the missing witness->increment bridge (SzemerediRegularityOQ04Witness, 4 theorems). exists_irregular_witness now feeds a concrete between-halves density gap >eps/2 - exactly the hdev hypothesis pairEnergy_split_gain/partitionEnergy_single_split_gain_uniform require. Termination engine + quantitative increment + witness bridge now all in hand; remaining: promote the witness subset to a partition part (two-sided refinement) to close the loop into afks_energy_iteration_count.",
     "builtItems": [
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
       "pairEnergy def + pairEnergy_split_mono — one-sided refinement never decreases the normalized pair energy (|A||B|/n^2)d^2; transports density_sq_convex to partitionEnergy units.",
@@ -36,7 +36,11 @@
       "partitionEnergy_single_split_gain (SzemerediRegularityOQ04Bridge.lean): QUANTITATIVE energy-increment — refining A₁∪A₂ into A₁,A₂ with irregular partner B₀ (|d(A₁,B₀)-d(A₂,B₀)|≥δ) raises partitionEnergy by ≥ (|A₁||A₂|/(|A₁|+|A₂|))·(|B₀|/n²)·δ². Block decomposition: diag+col pure monotone, row carries the Cauchy-Schwarz surplus.",
       "parallel_resistance_ge_half (Bridge:217): x·y/(x+y)≥1/2 for x,y≥1, via nlinarith on (x-1)(y-1)≥0",
       "partitionEnergy_single_split_gain_uniform (Bridge:240): floors exact δ² gain to δ²/(2n²) — the fixed-δ energy increment",
-      "afks_energy_iteration_count (Bridge:284): refinement chain climbing by ε²/(2n²) has length N≤2n²/ε², via partitionEnergy_iteration_bound + one_div_div"
+      "afks_energy_iteration_count (Bridge:284): refinement chain climbing by ε²/(2n²) has length N≤2n²/ε², via partitionEnergy_iteration_bound + one_div_div",
+      "edgeDensity_whole_between (SzemerediRegularityOQ04Witness.lean): |d(A1,B)-d(A1 u A2,B)| <= |d(A1,B)-d(A2,B)| for disjoint A1,A2 (0<|B|, 0<|A1|+|A2|), via edgeDensity_union_mul + |B|-cancellation + abs of the weighted-mean identity. VERIFIED 0/0.",
+      "edgeDensity_whole_between_right (SzemerediRegularityOQ04Witness.lean): second-argument form via edgeDensity_comm. VERIFIED 0/0.",
+      "irregular_witness_split_gap (SzemerediRegularityOQ04Witness.lean): |d(A',B')-d(A\\A',B')| + |d(A,B')-d(A,B\\B')| > eps from a witness deviation >eps, via abs_sub_le through d(A,B') then two edgeDensity_whole_between collapses. VERIFIED 0/0.",
+      "irregular_witness_split_gap_disjunction (SzemerediRegularityOQ04Witness.lean): at least one coordinate carries a between-halves gap > eps/2 = exactly the hdev hypothesis of pairEnergy_split_gain (delta=eps/2). VERIFIED 0/0."
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
@@ -44,13 +48,15 @@
       "The whole-partition energy JUMP reduces to a SINGLE strengthened block: only the row block against R needs the gain; diagonal and column blocks contribute nonneg increments by monotonicity, so linarith[h1,h2gain,h3] assembles exactly as the mono proof plus the gain atom.",
       "Uniform (size-independent) floor: the AFKS gain (|A₁||A₂|/(|A₁|+|A₂|))·(|B₀|/n²)·δ² floors to δ²/(2n²) via parallel_resistance_ge_half (x·y/(x+y)≥1/2 for x,y≥1) and |B₀|≥1. This gives a fixed δ=ε²/(2n²) at every step regardless of part sizes — exactly the shape the abstract [0,1]-potential termination engine consumes.",
       "check-superseded.sh false-positives on PRs that only MODIFY (append to) existing proof files: it flags a branch when the file PATHS it touches exist on main, ignoring whether the specific theorems are new. PR #35809 (verified quantitative gain) was wrongly auto-closed this way; rebasing onto current main fixes it (files exist at merge-base ⇒ NOT_SUPERSEDED modifies-existing-only).",
-      "Three consecutive line-less exit-135 SIGBUS crashes were MASKING a real elaboration error (No goals to be solved at gcongr). docker-build --repair-cache (fresh olean force-refresh) let elaboration complete and surface the genuine error at 4.7s — SIGBUS retries alone would never have revealed it."
+      "Three consecutive line-less exit-135 SIGBUS crashes were MASKING a real elaboration error (No goals to be solved at gcongr). docker-build --repair-cache (fresh olean force-refresh) let elaboration complete and surface the genuine error at 4.7s — SIGBUS retries alone would never have revealed it.",
+      "The AFKS energy-increment lemmas (pairEnergy_split_gain, partitionEnergy_single_split_gain) consume a between-halves density gap |d(A1,B0)-d(A2,B0)|>=delta, but exists_irregular_witness produces a whole-vs-pair deviation |d(A',B')-d(A,B)|>eps. Different shapes; the missing link is a triangle-inequality bridge, now supplied by SzemerediRegularityOQ04Witness.",
+      "Density convexity: d(A1 u A2,B) is the |A1|:|A2|-weighted mean of d(A1,B),d(A2,B), hence lies between them, so the whole is never farther from a half than the two halves are from each other (edgeDensity_whole_between). Upgrades a whole-vs-half gap into a half-vs-half gap of >= the same size."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Wire exists_irregular_pair (SzemerediRegularity.lean:152) to produce B₀∈R and hdev from an ε-irregular pair, feeding partitionEnergy_single_split_gain_uniform automatically (currently B₀/hdev are hypotheses).",
-      "State the two-level AFKS conclusion: coarse ε-regular partition + refinement with all but ε·C(ℓ,2) pairs regular, dependent tolerance E:ℕ→(0,1] threaded post-k.",
-      "Assemble the outer loop: run refinements using afks_energy_iteration_count as the explicit termination certificate (2n²/ε² bound)."
+      "Assemble the full AFKS energy-increment step: from an eps-irregular pair (A,B) in partition P, use exists_irregular_witness -> irregular_witness_split_gap_disjunction to select the coordinate with the >eps/2 gap, refine that part so the witness subset becomes a partition part, and invoke partitionEnergy_single_split_gain_uniform for the eps^2/(2n^2) floor. Remaining subtlety: the B-side disjunct needs B' promoted to a part (two-sided refinement); wire this into afks_energy_iteration_count.",
+      "State the strong-regularity conclusion: almost-all-pairs regular with arbitrary precision (AFKS), now that termination + increment + witness-bridge are all in hand.",
+      "Consider upstreaming edgeDensity_whole_between (density convexity) as a clean general fact."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Supplies the identified **missing link** in the strong (Alon–Fischer–Krivelevich–Szegedy) regularity lemma formalization: the bridge from `exists_irregular_witness` (`SzemerediRegularity`) to the `hdev` density-gap hypothesis that the AFKS energy-increment machinery (`SzemerediRegularityOQ04Energy` / `Bridge`) consumes.

The increment lemmas (`pairEnergy_split_gain`, `partitionEnergy_single_split_gain`) need a **between-halves** gap `|d(A₁,B₀) − d(A₂,B₀)| ≥ δ`. The irregularity witness only produces a **whole-vs-pair** deviation `|d(A′,B′) − d(A,B)| > ε`. These are different shapes; nothing previously connected them.

## New file: `SzemerediRegularityOQ04Witness.lean` (4 theorems, Docker-built, 0 sorry / 0 axiom)

- **`edgeDensity_whole_between`** — density convexity: `d(A₁∪A₂,B)` is the `|A₁|:|A₂|`-weighted mean of `d(A₁,B)`, `d(A₂,B)`, hence lies between them, giving `|d(A₁,B) − d(A₁∪A₂,B)| ≤ |d(A₁,B) − d(A₂,B)|`. The whole is never farther from a half than the two halves are from each other.
- **`edgeDensity_whole_between_right`** — second-argument form via `edgeDensity_comm`.
- **`irregular_witness_split_gap`** — the bridge: `|d(A′,B′) − d(A∖A′,B′)| + |d(A,B′) − d(A,B∖B′)| > ε`, obtained from the witness deviation by `abs_sub_le` through the intermediate density `d(A,B′)` and two convexity collapses.
- **`irregular_witness_split_gap_disjunction`** — the consumable corollary: at least one coordinate carries a between-halves gap `> ε/2`, i.e. exactly the `hdev` hypothesis of `pairEnergy_split_gain` with `δ = ε/2`.

## Status

Termination engine + quantitative energy increment + this witness bridge are now all in hand. The remaining open step is promoting the witness subset to an actual partition part (two-sided refinement) to close the loop into `afks_energy_iteration_count`.

Verified via `./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04Witness` — `Built (3.5s)`, 0 errors, 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)