### PR TITLE
research(erdos-1080-oq-03): bridge IsBipartite ↔ Mathlib Colorable 2 [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1080OQ03.lean
+++ b/proofs/Proofs/Erdos1080OQ03.lean
@@ -43,6 +43,7 @@ References:
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Paths
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
+import Mathlib.Combinatorics.SimpleGraph.Coloring
 import Mathlib.Data.Set.Basic
 
 open SimpleGraph Set
@@ -261,5 +262,51 @@ theorem bipartite_C4C6_free_girth_ge_eight (hbip : IsBipartite G)
       rw [e]; exact h6
   have := bipartite_girth_ge_of_forbidden hbip hforb hcyc
   omega
+
+/-! ### Bridge to Mathlib's two-colourability
+
+`IsBipartite` (this file's ad-hoc predicate) coincides with Mathlib's
+`SimpleGraph.Colorable 2`.  This lets the even-cycle / girth results above be
+transported to any graph the wider gallery presents as `2`-colourable, and
+conversely lets Mathlib's colouring API act on graphs built here. -/
+
+/-- **`IsBipartite G ↔ G.Colorable 2`.**  A bipartition `(X, Y)` is exactly a
+proper `2`-colouring: colour `X` with `0` and `Y` with `1`; conversely the two
+colour classes of a `2`-colouring form a bipartition (edges are bichromatic, so
+they cross). -/
+theorem isBipartite_iff_colorable_two : IsBipartite G ↔ G.Colorable 2 := by
+  have fin2 : ∀ x : Fin 2, x = 0 ∨ x = 1 := by decide
+  constructor
+  · rintro ⟨X, Y, h⟩
+    classical
+    refine ⟨Coloring.mk (fun v => if v ∈ X then (0 : Fin 2) else 1) ?_⟩
+    intro u v huv
+    have hiff : u ∈ X ↔ v ∈ Y := h.2.2 huv
+    by_cases hu : u ∈ X
+    · have hvnotX : v ∉ X := fun hvx => (mem_left_iff_not_right h v).mp hvx (hiff.mp hu)
+      simp only [if_pos hu, if_neg hvnotX]; decide
+    · have hvX : v ∈ X := (mem_left_iff_not_right h v).mpr (fun hvy => hu (hiff.mpr hvy))
+      simp only [if_neg hu, if_pos hvX]; decide
+  · rintro ⟨c⟩
+    refine ⟨{v | c v = 0}, {v | c v = 1}, ?_, ?_, ?_⟩
+    · rw [Set.disjoint_left]
+      rintro v hv0 hv1
+      simp only [Set.mem_setOf_eq] at hv0 hv1
+      rw [hv0] at hv1; exact absurd hv1 (by decide)
+    · ext v
+      simp only [Set.mem_union, Set.mem_setOf_eq, Set.mem_univ, iff_true]
+      exact fin2 (c v)
+    · intro u v huv
+      have hne : c u ≠ c v := c.valid huv
+      simp only [Set.mem_setOf_eq]
+      constructor
+      · intro hu0
+        rcases fin2 (c v) with h0 | h1
+        · exact absurd (hu0.trans h0.symm) hne
+        · exact h1
+      · intro hv1
+        rcases fin2 (c u) with h0 | h1
+        · exact h0
+        · exact absurd (h1.trans hv1.symm) hne
 
 end Erdos1080OQ03

--- a/research/problems/erdos-1080-oq-03/knowledge.md
+++ b/research/problems/erdos-1080-oq-03/knowledge.md
@@ -96,3 +96,27 @@ asks to "extend to other cycle lengths (C₈, C₁₀, …)".
   length ≥ 4 IS realizable, giving "realizable lengths = exactly even ≥ 4".
 - Erdős's C₈ EXISTENCE in dense C₄,C₆-free bipartite graphs — degree/moment
   count, NOT elementary. Still the real open core.
+
+## Session 2026-07-08 (researcher-1) — bridge IsBipartite ↔ Mathlib Colorable 2
+
+Executed nextStep #2 (bridge this file's ad-hoc IsBipartite to Mathlib two-colourability).
+Added to Proofs/Erdos1080OQ03.lean (VERIFIED 0 axioms / 0 sorries, host lake env lean):
+- import Mathlib.Combinatorics.SimpleGraph.Coloring.
+- isBipartite_iff_colorable_two : IsBipartite G ↔ G.Colorable 2.
+  Forward: Coloring.mk (fun v => if v∈X then 0 else 1); adjacent u,v cross parts
+  (h.2.2 huv : u∈X↔v∈Y, plus mem_left_iff_not_right) so colours differ; close each
+  branch with `simp only [if_pos/if_neg]; decide`. Converse: rintro ⟨c⟩, take colour
+  classes {v|c v=0},{v|c v=1}; Disjoint via c v=0 & c v=1 contradiction (by decide);
+  cover via `fin2 : ∀ x:Fin 2, x=0∨x=1 := by decide`; edge iff via c.valid huv (c u≠c v)
+  + fin2 case split. Fin 2 facts all `by decide` (kernel).
+
+This connects the file's even-cycle/girth theorems (bipartite ⇒ only even cycles ≥4) to
+Mathlib's Colorable API for cross-gallery reuse. NO count fields in the gallery meta
+(erdos-1080-oq-03/meta.json has no leanFile object), so no sync. File 265→312 lines.
+
+REMAINING (not done): the C₈ extremal-existence core (Erdős's observation, genuinely
+hard, not elementary). The PARENT Erdos1080Problem.lean is BADLY BROKEN (many errors:
+type mismatches L77, synth-fail L153, multiple orphaned /-- doc-comments L158/170/176/
+181/192, token errors L211, plus c4_free_iff_no_K22 sorry L306 + erdos_c8_observation
+axiom) — a large multi-error repair job (Mechanic/Doctor), NOT a single doc-comment fix
+as the old nextStep #3 implied; separate gallery entry, left for a repair agent.


### PR DESCRIPTION
## Summary

Connects `Erdos1080OQ03.lean`'s ad-hoc `IsBipartite` predicate to Mathlib's
`SimpleGraph.Colorable 2` (nextStep #2 of the problem). The file already proves the
structural backbone — bipartite graphs contain only even cycles of length ≥ 4 — so
tying `IsBipartite` to the standard 2-colourability notion lets those results be reused
across the gallery's graph-theory entries (and lets Mathlib's colouring API act on
graphs built here).

## New theorem (`theorem`, additive-only, 0/0)

`isBipartite_iff_colorable_two : IsBipartite G ↔ G.Colorable 2`

- **Forward**: a bipartition `(X, Y)` gives the proper 2-colouring `v ↦ if v ∈ X then 0
  else 1`; adjacent vertices cross the parts (`Adj u v → (u ∈ X ↔ v ∈ Y)`), so they get
  different colours.
- **Converse**: the two colour classes `{v | c v = 0}`, `{v | c v = 1}` of a 2-colouring
  form a bipartition — disjoint, covering (every `Fin 2` value is `0` or `1`), and edges
  are bichromatic (`c.valid`), hence cross.

Adds `import Mathlib.Combinatorics.SimpleGraph.Coloring`.

## Verification

- Host-verified via `lake env lean` (**0 errors, 0 warnings, 0 sorries**). Docker builds
  are currently unreliable (shared-volume cache corruption → spurious SIGBUS/SIGSEGV);
  host single-file elaboration is clean.
- `#print axioms isBipartite_iff_colorable_two` = `{propext, Classical.choice, Quot.sound}`
  only. **0 axioms.**
- File `Erdos1080OQ03.lean`: 265 → 312 lines. Gallery meta has no count fields, so no sync.

## Note

The extremal C₈-existence core (Erdős's observation) remains genuinely hard/open. The
*parent* `Erdos1080Problem.lean` is separately badly broken (multiple compile errors +
a sorry + an axiom) — a larger multi-error repair left for a repair agent; it is a
different gallery entry from this slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)