### PR TITLE
research(e-transcendental-oq-02-oq-06): effective normality modulus + first-occurrence bound [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -1016,6 +1016,124 @@ theorem match_count_ge_linear_of_normal (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
   exact le_of_lt hmul
 
 -- ============================================================
+-- PART IV.9: EFFECTIVE NORMALITY WITH AN EXPLICIT MODULUS
+-- ============================================================
+
+/-!
+## Effective first-occurrence bounds via a modulus of convergence
+
+`IsNormalInBase` is a bare `Tendsto` statement: it carries no *rate* of
+convergence, so — as flagged in `eventually_exists_match_lt_of_normal` — the
+position of the first occurrence of a tuple cannot be bounded by an explicit
+function of `k`. To obtain genuinely effective bounds one must *supply* a
+modulus of convergence.
+
+`EffectivelyNormalWithModulus b x M` asks for an explicit function
+`M : ℕ → ℝ → ℕ` such that, for every tuple length `k`, every tuple `s`, and every
+tolerance `ε > 0`, the matching frequency of `s` is within `ε` of `b^{-k}` for
+all windows `N ≥ M k ε`. This is exactly the `ε`–`N` form of the `Tendsto` in
+normality, so it *implies* `IsNormalInBase` (`isNormal_of_effectivelyNormal`);
+but it additionally *exposes* the threshold, which upgrades every "eventually"
+statement of PART IV.8 to an effective one:
+
+* `first_occurrence_lt_of_modulus` — the tuple `s` occurs at an *explicit*
+  position `< max (M k (b^{-k}/2)) 1`, a concrete function of the modulus and `k`.
+  This is the effective form of the (non-constructive)
+  `eventually_exists_match_lt_of_normal`.
+* `match_count_ge_linear_of_modulus` — for every `N ≥ max (M k (b^{-k}/2)) 1` the
+  occurrence count is at least `(b^{-k}/2)·N`, the effective (explicit-threshold)
+  form of `match_count_ge_linear_of_normal`.
+-/
+
+/-- **Effective normality with an explicit modulus of convergence.** A witness
+    that `x` is normal in base `b` *together with a rate*: for every tuple `s` of
+    length `k` and every tolerance `ε > 0`, the matching frequency of `s` lies
+    within `ε` of `b^{-k}` for all windows `N ≥ M k ε`. -/
+def EffectivelyNormalWithModulus (b : ℕ) (x : ℝ) (M : ℕ → ℝ → ℕ) : Prop :=
+  ∀ (k : ℕ) (s : Fin k → Fin b) (ε : ℝ), 0 < ε → ∀ N : ℕ, M k ε ≤ N →
+    |(((Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ)
+        / (N : ℝ) - (b : ℝ) ^ (-(k : ℤ))| < ε
+
+/-- **Effective normality implies normality.** The modulus form is precisely the
+    `ε`–`N` (`Metric.tendsto_atTop`) characterisation of the `Tendsto` defining
+    `IsNormalInBase`, so any number admitting a modulus of convergence is normal.
+    Records that `EffectivelyNormalWithModulus` is a genuine strengthening, not a
+    vacuous or incomparable notion. -/
+theorem isNormal_of_effectivelyNormal (b : ℕ) (x : ℝ) (M : ℕ → ℝ → ℕ)
+    (hM : EffectivelyNormalWithModulus b x M) : IsNormalInBase b x := by
+  intro k s
+  rw [Metric.tendsto_atTop]
+  intro ε hε
+  refine ⟨M k ε, fun N hN => ?_⟩
+  rw [Real.dist_eq]
+  exact hM k s ε hε N hN
+
+/-- **Effective first occurrence.** Given a modulus of normality, every tuple `s`
+    of length `k` occurs at an *explicit* position below `max (M k (b^{-k}/2)) 1`
+    — a concrete function of the modulus and `k`. This is the effective
+    strengthening of `eventually_exists_match_lt_of_normal`, whose window bound
+    was non-constructive (only "for all sufficiently large `N`"). Proof: at the
+    tolerance `ε = b^{-k}/2` the frequency at `N₁ := max (M k ε) 1` is within `ε`
+    of `b^{-k}`, hence `> b^{-k}/2 > 0`, so the matching count is positive and the
+    occurrence-extraction core produces a witness `< N₁`. -/
+theorem first_occurrence_lt_of_modulus (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (M : ℕ → ℝ → ℕ) (hM : EffectivelyNormalWithModulus b x M)
+    (k : ℕ) (s : Fin k → Fin b) :
+    ∃ n < max (M k ((b : ℝ) ^ (-(k : ℤ)) / 2)) 1,
+      ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ) := by
+  have hbR : (0 : ℝ) < (b : ℝ) := by exact_mod_cast (by omega : 0 < b)
+  have hposk : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := zpow_pos hbR _
+  set δ : ℝ := (b : ℝ) ^ (-(k : ℤ)) / 2 with hδdef
+  have hδpos : 0 < δ := by rw [hδdef]; exact div_pos hposk two_pos
+  set N₁ := max (M k δ) 1 with hN1def
+  have hN1pos : 0 < N₁ := lt_of_lt_of_le one_pos (le_max_right _ _)
+  have hN1R : (0 : ℝ) < (N₁ : ℝ) := by exact_mod_cast hN1pos
+  have hbound := hM k s δ hδpos N₁ (le_max_left _ _)
+  set c := ((Finset.range N₁).filter
+      (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card with hc
+  have habs := abs_lt.mp hbound
+  have heq : (b : ℝ) ^ (-(k : ℤ)) - δ = δ := by rw [hδdef]; ring
+  have hcpos_real : 0 < (c : ℝ) / (N₁ : ℝ) := by
+    have hlow : (b : ℝ) ^ (-(k : ℤ)) - δ < (c : ℝ) / (N₁ : ℝ) := by linarith [habs.1]
+    rw [heq] at hlow; linarith
+  have hcR : (0 : ℝ) < (c : ℝ) := by
+    have := mul_pos hcpos_real hN1R
+    rwa [div_mul_cancel₀ _ hN1R.ne'] at this
+  have hcpos : 0 < c := by exact_mod_cast hcR
+  exact exists_match_lt_of_count_pos b x k s N₁ (hc ▸ hcpos)
+
+/-- **Effective density lower bound.** Given a modulus of normality, for *every*
+    window `N ≥ max (M k (b^{-k}/2)) 1` the occurrence count of the tuple `s` is
+    at least `(b^{-k}/2)·N`. This is the effective (explicit-threshold) form of
+    `match_count_ge_linear_of_normal`, which only held "eventually". -/
+theorem match_count_ge_linear_of_modulus (b : ℕ) (hb : 2 ≤ b) (x : ℝ)
+    (M : ℕ → ℝ → ℕ) (hM : EffectivelyNormalWithModulus b x M)
+    (k : ℕ) (s : Fin k → Fin b) (N : ℕ)
+    (hN : max (M k ((b : ℝ) ^ (-(k : ℤ)) / 2)) 1 ≤ N) :
+    ((b : ℝ) ^ (-(k : ℤ)) / 2) * (N : ℝ) ≤
+      (((Finset.range N).filter
+        (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card : ℝ) := by
+  have hbR : (0 : ℝ) < (b : ℝ) := by exact_mod_cast (by omega : 0 < b)
+  have hposk : (0 : ℝ) < (b : ℝ) ^ (-(k : ℤ)) := zpow_pos hbR _
+  set δ : ℝ := (b : ℝ) ^ (-(k : ℤ)) / 2 with hδdef
+  have hδpos : 0 < δ := by rw [hδdef]; exact div_pos hposk two_pos
+  have hMN : M k δ ≤ N := le_trans (le_max_left _ _) hN
+  have hN0 : 0 < N := lt_of_lt_of_le one_pos (le_trans (le_max_right _ _) hN)
+  have hNR : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN0
+  have hbound := hM k s δ hδpos N hMN
+  set c := ((Finset.range N).filter
+      (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card with hc
+  have habs := abs_lt.mp hbound
+  have heq : (b : ℝ) ^ (-(k : ℤ)) - δ = δ := by rw [hδdef]; ring
+  have hlow : δ < (c : ℝ) / (N : ℝ) := by
+    have h : (b : ℝ) ^ (-(k : ℤ)) - δ < (c : ℝ) / (N : ℝ) := by linarith [habs.1]
+    rwa [heq] at h
+  have hmul := mul_lt_mul_of_pos_right hlow hNR
+  rw [div_mul_cancel₀ _ hNR.ne'] at hmul
+  exact le_of_lt hmul
+
+-- ============================================================
 -- PART V: OPEN QUESTION
 -- ============================================================
 

--- a/src/data/research/problems/e-transcendental-oq-02-oq-06.json
+++ b/src/data/research/problems/e-transcendental-oq-02-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: quantitative disjunctivity added (VERIFIED 0 sorry / axiom unchanged) — occurrence count grows at least linearly ((b^{-k}/2)*N), upgrading infinitely-often to positive lower density, plus an effective before-every-window occurrence statement. Frequency-mismatch criterion (nextStep #1) was completed by merged #35802; the duplicate #35800 was closed. Open axiom e_absolutely_normal genuinely open.",
+    "progressSummary": "PROGRESS (VERIFIED 0 sorry / axiom unchanged): added the effective-modulus layer — EffectivelyNormalWithModulus (normality + explicit convergence rate) implying IsNormalInBase, plus first_occurrence_lt_of_modulus (explicit first-occurrence position < max(M k (b^{-k}/2)) 1) and match_count_ge_linear_of_modulus (explicit-threshold linear density). Resolves the effective/rate-based first-occurrence next-step. Open axiom e_absolutely_normal remains genuinely open.",
     "builtItems": [
       "normal_ktuple_infinitely_often (Proofs/ETranscendentalOQ02.lean): {n | s occurs at n}.Infinite for x normal in base b. Verified 0 sorry; axioms [propext, Classical.choice, Quot.sound].",
       "normal_imp_disjunctive (same file): every finite digit string appears at least once (corollary via Set.Infinite.nonempty).",
@@ -50,7 +50,10 @@
       "exists_match_lt_of_count_pos (ETranscendentalOQ02.lean:947): pure-Finset bridge, positive match count over range N yields an explicit occurrence < N",
       "eventually_match_count_pos_of_normal (ETranscendentalOQ02.lean:961): match count eventually positive for a normal number",
       "eventually_exists_match_lt_of_normal (ETranscendentalOQ02.lean:984): effective disjunctivity — tuple occurs before every large window N (strengthens normal_imp_disjunctive)",
-      "match_count_ge_linear_of_normal (ETranscendentalOQ02.lean:998): occurrence count eventually >= (b^{-k}/2)*N, i.e. positive lower density (strengthens normal_ktuple_infinitely_often)"
+      "match_count_ge_linear_of_normal (ETranscendentalOQ02.lean:998): occurrence count eventually >= (b^{-k}/2)*N, i.e. positive lower density (strengthens normal_ktuple_infinitely_often)",
+      "EffectivelyNormalWithModulus (def) + isNormal_of_effectivelyNormal (ETranscendentalOQ02.lean PART IV.9): modulus form ⇒ IsNormalInBase, VERIFIED 0 sorry",
+      "first_occurrence_lt_of_modulus (ETranscendentalOQ02.lean): explicit first-occurrence bound < max(M k (b^{-k}/2)) 1 — effective form of the non-constructive eventually_exists_match_lt_of_normal",
+      "match_count_ge_linear_of_modulus (ETranscendentalOQ02.lean): explicit-threshold linear density lower bound (b^{-k}/2)·N for every N≥max(M k (b^{-k}/2)) 1 — effective form of match_count_ge_linear_of_normal"
     ],
     "insights": [
       "The stated target normal_imp_irrational was ALREADY a complete 0-sorry theorem (Session 13); OQ-02-OQ-06 as literally phrased was resolved. Added genuinely new theory instead of reclaiming.",
@@ -63,15 +66,17 @@
       "Every base-b digit of liouvilleNumber b is 0 or 1 from position n>=2 on (residue b^(n-k!) % b in {0,1}: lower-index terms divisible by b, top term 1 iff n is a factorial), so digit 2 is eventually missing and not_normal_of_eventually_missing_digit applies.",
       "Frequency-mismatch criterion completes the sharp-boundary theory: absence (freq 0) was the extreme case; under-/over-representation (freq eventually bounded away from b^(-k) on either side) equally forbids normality, and needs NO convergence hypothesis — only le_of_tendsto/ge_of_tendsto against the definitional limit.",
       "Quantitative disjunctivity (nextStep #2): normality pins the tuple frequency to b^{-k} > 0, which upgrades the qualitative normal_ktuple_infinitely_often (Set.Infinite) to a positive LOWER DENSITY — the occurrence count below N is eventually >= (b^{-k}/2)*N. The bare Tendsto definition carries no convergence RATE, so the position of the first occurrence cannot be bounded by an explicit function of k; the strongest unconditional statement is that s occurs before every sufficiently large window N.",
-      "Filter.Tendsto.eventually_const_lt (hv : u < v) (h : Tendsto f l (nhds v)) : eventually u < f — the clean way to turn a Tendsto-to-positive-limit into an eventual strict positivity; eventually_gt_of_tendsto_gt does NOT exist in Mathlib v4.26."
+      "Filter.Tendsto.eventually_const_lt (hv : u < v) (h : Tendsto f l (nhds v)) : eventually u < f — the clean way to turn a Tendsto-to-positive-limit into an eventual strict positivity; eventually_gt_of_tendsto_gt does NOT exist in Mathlib v4.26.",
+      "Effective normality needs an EXPLICIT modulus: IsNormalInBase is a bare Tendsto with no rate, so first-occurrence positions cannot be bounded by k alone. Adding a modulus M:ℕ→ℝ→ℕ (the ε–N / Metric.tendsto_atTop form) recovers effective bounds while STILL implying IsNormalInBase (isNormal_of_effectivelyNormal via Real.dist_eq).",
+      "First-occurrence recipe from a modulus: at tolerance ε=b^{-k}/2, the frequency at N₁=max(M k ε) 1 is within ε of b^{-k} (abs_lt), hence >b^{-k}/2>0 using the identity b^{-k}-δ=δ; so the matching count is positive and exists_match_lt_of_count_pos yields a witness <N₁, an EXPLICIT function of M and k."
     ],
     "mathlibGaps": [
       "omega does not discharge variable-divisor Euclidean identities (a/T*T + a%T = a with T variable, nonlinear); use Nat.mod_add_div'/Nat.div_add_mod explicitly.",
       "Genuine irrational-AND-non-normal WITNESS (true sharpness of 'irrational ⇏ normal') still needs the real→digit bridge for a specific transcendental: computing nthDigit b n x = ⌊bⁿx⌋%b for an explicit series (e.g. Liouville ∑ b^(-k!)) requires summing the tail to isolate the k-th digit — a real-analysis construction not present. The abstract criterion is the tool; only the witness digit-computation is missing."
     ],
     "nextSteps": [
-      "Effective/rate-based first-occurrence bounds require ADDING an explicit normality-modulus hypothesis (the definition has no rate); consider defining EffectivelyNormalWithModulus and proving a first-occurrence bound M(k,s).",
-      "The open axiom e_absolutely_normal is genuinely open — not eliminable. Sharpness of normal_imp_irrational (Liouville witness) and the frequency-mismatch + quantitative-disjunctivity theory are now complete."
+      "The open axiom e_absolutely_normal is genuinely open — not eliminable. The effective-modulus layer (EffectivelyNormalWithModulus + first_occurrence_lt_of_modulus + match_count_ge_linear_of_modulus), the frequency-mismatch criterion, quantitative disjunctivity, and the Liouville sharpness witness now form a complete effective normality theory around the bare definition.",
+      "Optional low-novelty: instantiate EffectivelyNormalWithModulus for an explicitly-constructed normal number (e.g. a Champernowne-style constant) to exhibit a concrete modulus — requires a digit-frequency rate Mathlib does not currently provide."
     ],
     "markdown": "# Knowledge Base: e-transcendental-oq-02-oq-06\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds an **effective-normality layer** to `ETranscendentalOQ02.lean`, resolving the problem's open next-step: *effective/rate-based first-occurrence bounds require adding an explicit normality-modulus hypothesis*.

`IsNormalInBase` is a bare `Tendsto` with no convergence rate, so (as flagged in `eventually_exists_match_lt_of_normal`) the first-occurrence position of a digit-tuple cannot be bounded by any explicit function of `k`. This PR supplies the missing rate.

### New declarations (PART IV.9)

- **`EffectivelyNormalWithModulus b x M`** — normality *with* an explicit modulus `M : ℕ → ℝ → ℕ`: for every tuple `s` of length `k` and tolerance `ε > 0`, the matching frequency is within `ε` of `b^{-k}` for all windows `N ≥ M k ε`.
- **`isNormal_of_effectivelyNormal`** — the modulus form is exactly the `ε`–`N` (`Metric.tendsto_atTop`) characterisation, so it *implies* `IsNormalInBase`. Confirms the notion is a genuine strengthening, not vacuous.
- **`first_occurrence_lt_of_modulus`** — every tuple `s` occurs at an **explicit** position `< max (M k (b^{-k}/2)) 1`, a concrete function of the modulus and `k`. Effective form of the non-constructive `eventually_exists_match_lt_of_normal`.
- **`match_count_ge_linear_of_modulus`** — for **every** `N ≥ max (M k (b^{-k}/2)) 1` the occurrence count is `≥ (b^{-k}/2)·N`. Explicit-threshold form of `match_count_ge_linear_of_normal` (which only held eventually).

### Proof sketch

Instantiate the modulus at tolerance `ε = b^{-k}/2`; at `N₁ = max (M k ε) 1` the frequency is within `ε` of `b^{-k}`, hence `> b^{-k}/2 > 0` (via `abs_lt` and the identity `b^{-k} − δ = δ`). A positive count feeds the existing occurrence-extraction core `exists_match_lt_of_count_pos`.

## Verification

- Docker build `Proofs.ETranscendentalOQ02`: **succeeded** (real elaboration, 4.1s).
- **0 sorries**, **no `native_decide`**, axiom count **unchanged** (the single open `e_absolutely_normal` is untouched and remains genuinely open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)