### PR TITLE
research(shannon-awgn-oq-02-oq-02): converse affine⟹tightness + full iff Cauchy–Schwarz equality boundary

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -626,4 +626,54 @@ theorem exists_affine_of_covariance_sq_eq [IsFiniteMeasure μ] {X Y : Ω → ℝ
   field_simp
   linear_combination hω
 
+/-- **Covariance is preserved under a.e. equality of the left argument.**  If `X =ᵐ X'` then their
+covariances against any common `Y` agree.  This is the covariance companion of
+`ProbabilityTheory.variance_congr` (which Mathlib provides but has no covariance analogue); it is
+proved directly from the defining integral via `integral_congr_ae`, and is exactly what lets the
+affine-dependence *converse* below accept an arbitrary a.e. representative of `X`. -/
+theorem covariance_congr_left {X X' Y : Ω → ℝ} (h : X =ᵐ[μ] X') :
+    cov[X, Y; μ] = cov[X', Y; μ] := by
+  have hmean : μ[X] = μ[X'] := integral_congr_ae h
+  simp only [covariance]
+  refine integral_congr_ae ?_
+  filter_upwards [h] with ω hω
+  rw [hω, hmean]
+
+/-- **Affine dependence ⟹ Cauchy–Schwarz is tight — converse of `exists_affine_of_covariance_sq_eq`.**
+If `X` is almost everywhere an affine function of `Y`, `X =ᵐ a·Y + b`, then the covariance
+Cauchy–Schwarz inequality is an *equality*: `cov[X,Y]² = Var[X]·Var[Y]`.  Unlike the forward
+direction this needs **no** non-degeneracy hypothesis on `Y` — it is a direct bilinear computation
+(`cov[X,Y] = a·Var[Y]` and `Var[X] = a²·Var[Y]`) transported along the a.e. identity via
+`covariance_congr_left` and `variance_congr`. -/
+theorem covariance_sq_eq_of_affine [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hY : MemLp Y 2 μ) (a b : ℝ) (h : X =ᵐ[μ] fun ω => a * Y ω + b) :
+    cov[X, Y; μ] ^ 2 = Var[X; μ] * Var[Y; μ] := by
+  have hYint : Integrable (fun ω => a * Y ω) μ := (hY.integrable one_le_two).const_mul a
+  have hcov : cov[X, Y; μ] = a * Var[Y; μ] := by
+    rw [covariance_congr_left h, covariance_add_const_left hYint b,
+      covariance_const_mul_left, covariance_self hY.aemeasurable]
+  have hvar : Var[X; μ] = a ^ 2 * Var[Y; μ] := by
+    have hsmul : (fun ω => a * Y ω) = a • Y := by
+      funext ω; rw [Pi.smul_apply, smul_eq_mul]
+    rw [variance_congr h, variance_add_const (hY.aestronglyMeasurable.const_mul a) b, hsmul,
+      variance_smul]
+  rw [hcov, hvar]; ring
+
+/-- **Sharp equality boundary of covariance Cauchy–Schwarz — full iff form.**  For square-integrable
+`X, Y` with `Y` non-degenerate (`Var[Y] ≠ 0`), `cov[X,Y]² = Var[X]·Var[Y]` holds *exactly* when `X`
+is almost everywhere an affine function of `Y`.  Combines the forward direction
+`exists_affine_of_covariance_sq_eq` (tightness ⟹ regression line) with the converse
+`covariance_sq_eq_of_affine` (affine ⟹ tightness), giving the complete structural characterisation
+of the equality case: **Cauchy–Schwarz is tight iff `X` and `Y` are a.e. affinely dependent.** -/
+theorem covariance_sq_eq_variance_mul_variance_iff_affine [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hYnd : Var[Y; μ] ≠ 0) :
+    cov[X, Y; μ] ^ 2 = Var[X; μ] * Var[Y; μ] ↔
+      ∃ a b : ℝ, X =ᵐ[μ] fun ω => a * Y ω + b := by
+  constructor
+  · intro h
+    obtain ⟨b, hb⟩ := exists_affine_of_covariance_sq_eq hX hY hYnd h
+    exact ⟨cov[X, Y; μ] / Var[Y; μ], b, hb⟩
+  · rintro ⟨a, b, hab⟩
+    exact covariance_sq_eq_of_affine hY a b hab
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 629,
+    "lineCount": 679,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 28,
     "definitionCount": 0,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -181,6 +181,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 629,
-  "theoremCount": 25
+  "lineCount": 679,
+  "theoremCount": 28
 }

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: sharp EQUALITY boundary of covariance Cauchy–Schwarz VERIFIED (629 lines, 25 thm, 0/0) — tightness ⟺ a.e. affine dependence (regression line). Second-order picture complete: uncorrelatedness ⟹ powers add; monotone under covariance sign; affine dependence ⟹ C–S tight.",
+    "progressSummary": "PROGRESS: sharp Cauchy–Schwarz equality boundary now a FULL IFF (tightness ⟺ a.e. affine dependence). Added converse covariance_sq_eq_of_affine + missing covariance_congr_left. 679 lines, 28 thm, 0/0.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -41,7 +41,10 @@
       "variance_eq_zero_iff (real-valued Var=0 ⟺ a.e. constant, from Mathlib evariance_eq_zero_iff via ENNReal.toReal_eq_zero_iff + MemLp.evariance_ne_top)",
       "variance_regression_residual identity Var[Var[Y]·X − cov·Y] = Var[Y]·(Var[X]·Var[Y] − cov²) via variance_sub/variance_smul/covariance_smul + ring",
       "covariance_sq_eq_variance_mul_variance_iff (Var[Y]≠0): cov²=Var[X]·Var[Y] ⟺ residual a.e. constant — sharp equality boundary of C–S",
-      "exists_affine_of_covariance_sq_eq: tight C–S ⟹ X =ᵐ (cov/Var[Y])·Y + b (regression line)"
+      "exists_affine_of_covariance_sq_eq: tight C–S ⟹ X =ᵐ (cov/Var[Y])·Y + b (regression line)",
+      "covariance_congr_left (ShannonChannelCodingAWGNOQ02OQ02.lean): cov a.e.-congruent in left arg — covariance analogue of Mathlib variance_congr (not in Mathlib), proved from defining integral via integral_congr_ae",
+      "covariance_sq_eq_of_affine: CONVERSE of exists_affine_of_covariance_sq_eq — X =ᵐ a·Y+b ⟹ cov²=Var·Var, no non-degeneracy needed (bilinear cov=a·Var[Y], Var=a²·Var[Y])",
+      "covariance_sq_eq_variance_mul_variance_iff_affine: FULL IFF capstone — Cauchy–Schwarz tight ⟺ X,Y a.e. affinely dependent (629→679 lines, 25→28 thm, 0 sorry/0 axiom)"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -51,7 +54,8 @@
       "VERIFIED (0 sorry/0 axiom, Docker build clean): variance-of-sum additivity holds iff total off-diagonal covariance ∑ᵢ∑_{j∈s.erase i} cov[Wᵢ,Wⱼ]=0 — strictly weaker than pairwise-uncorrelatedness (covariances may cancel in aggregate). For n=2 the single off-diagonal term cannot cancel, so uncorrelatedness is exactly necessary and sufficient there.",
       "Canonical variance-of-sum defect equals exactly 2 times the strict-lower-triangle pairwise covariance sum; the factor 2 is covariance_comm symmetry between the two ordered copies of each unordered pair. Sharpens the qualitative offDiag-vanishing iff to a closed-form defect and halves the covariance terms to control.",
       "Cauchy–Schwarz for covariance (cov[X,Y]²≤Var[X]·Var[Y]) is ABSENT from Mathlib probability layer; proved via discrim_le_zero applied to the nonnegative quadratic t↦Var[X+t•Y]=Var[Y]·t²+2cov·t+Var[X]. This is the engine for the standard-deviation triangle inequality.",
-      "Sharp EQUALITY case of covariance Cauchy–Schwarz (cov²=Var[X]·Var[Y]) is characterized by the regression-residual variance IDENTITY Var[Var[Y]·X − cov·Y] = Var[Y]·(Var[X]·Var[Y] − cov²): when Var[Y]≠0 the residual has zero variance (hence a.e. constant) exactly when C–S is tight. Dividing by Var[Y] exhibits X =ᵐ (cov/Var[Y])·Y + b — a.e. affine dependence with slope the regression coefficient. Classical equality-in-Cauchy–Schwarz ⟺ linear-dependence, specialised to the covariance inner product; sharp EQUALITY companion to the earlier stddev triangle INEQUALITY."
+      "Sharp EQUALITY case of covariance Cauchy–Schwarz (cov²=Var[X]·Var[Y]) is characterized by the regression-residual variance IDENTITY Var[Var[Y]·X − cov·Y] = Var[Y]·(Var[X]·Var[Y] − cov²): when Var[Y]≠0 the residual has zero variance (hence a.e. constant) exactly when C–S is tight. Dividing by Var[Y] exhibits X =ᵐ (cov/Var[Y])·Y + b — a.e. affine dependence with slope the regression coefficient. Classical equality-in-Cauchy–Schwarz ⟺ linear-dependence, specialised to the covariance inner product; sharp EQUALITY companion to the earlier stddev triangle INEQUALITY.",
+      "The equality-boundary iff closes cleanly: forward (tightness⟹regression line) needs Var[Y]≠0, but converse (affine⟹tightness) is unconditional — a pure bilinear/variance-of-affine computation transported along =ᵐ via covariance_congr_left + variance_congr."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -63,7 +67,8 @@
       "Further sharp boundary: does the identity extend to L² limits / countable pairwise-uncorrelated families (Var of a series)? Would need dominated-convergence for covariance.",
       "Equality condition for the std-deviation triangle inequality: √Var[∑Wᵢ]=∑√Var[Wᵢ] iff the centered contributions are a.e. nonneg-proportional (perfect positive correlation) — the sharp boundary of stddev_sum_le, dual to the off-diagonal-cancellation equality condition already proven.",
       "Correlation coefficient ρ = cov/(σX·σY): |ρ| ≤ 1 immediate from covariance_sq_le_variance_mul_variance; state |ρ|=1 ⟺ a.e. affine dependence as normalised capstone.",
-      "Converse affine⟹equality (X =ᵐ a·Y+b ⟹ cov²=Var·Var) for full iff — needs covariance_congr under a.e. equality (build from integral_congr_ae)."
+      "Converse affine⟹equality (X =ᵐ a·Y+b ⟹ cov²=Var·Var) for full iff — needs covariance_congr under a.e. equality (build from integral_congr_ae).",
+      "Upstream covariance_congr_left to Mathlib (Probability/Moments/Covariance.lean) alongside variance_congr; would also give a covariance_congr_right by covariance_comm."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Completes the **sharp equality boundary** of the covariance Cauchy–Schwarz inequality for `shannon-channel-coding-awgn-oq-02-oq-02` into a **full iff**:

> `cov[X,Y]² = Var[X]·Var[Y]`  ⟺  `X` is almost everywhere an affine function of `Y`.

The base file already had the **forward** direction (`exists_affine_of_covariance_sq_eq`: tightness ⟹ regression line). This PR adds the missing **converse** and the combined iff.

## New theorems (3)

- **`covariance_congr_left`** — covariance analogue of Mathlib's `variance_congr` (a.e. congruence in the left argument). Proved directly from the defining integral via `integral_congr_ae`. Not currently in Mathlib; flagged for upstreaming.
- **`covariance_sq_eq_of_affine`** — the converse: `X =ᵐ a·Y + b ⟹ cov[X,Y]² = Var[X]·Var[Y]`. Needs **no** non-degeneracy hypothesis on `Y`; a direct bilinear computation (`cov[X,Y] = a·Var[Y]`, `Var[X] = a²·Var[Y]`) transported along the a.e. identity.
- **`covariance_sq_eq_variance_mul_variance_iff_affine`** — the full iff capstone (combines forward + converse).

## Verification

- Docker-built green: `✔ [7743/7743] Built Proofs.ShannonChannelCodingAWGNOQ02OQ02`
- 629 → 679 lines, 25 → 28 theorems
- **0 sorry / 0 axiom** (standard foundational axioms only)

meta.json counts and problem knowledge updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)