### PR TITLE
research(erdos-1064-oq-03): computable decision procedure for transport families [VERIFIED 0 sorry/0 axiom]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -871,11 +871,11 @@ theorem coLE_lt {x y : ℕ} : compareOfLessAndEq x y = Ordering.lt ↔ x < y :=
 
 /-- `compareOfLessAndEq` returns `.eq` exactly on equality. -/
 theorem coLE_eq {x y : ℕ} : compareOfLessAndEq x y = Ordering.eq ↔ x = y := by
-  unfold compareOfLessAndEq; split_ifs with h1 h2 <;> simp_all <;> omega
+  unfold compareOfLessAndEq; split_ifs with h1 h2 <;> (simp_all; try omega)
 
 /-- `compareOfLessAndEq` returns `.gt` exactly on the strict-greater relation. -/
 theorem coLE_gt {x y : ℕ} : compareOfLessAndEq x y = Ordering.gt ↔ y < x := by
-  unfold compareOfLessAndEq; split_ifs with h1 h2 <;> simp_all <;> omega
+  unfold compareOfLessAndEq; split_ifs with h1 h2 <;> (simp_all; try omega)
 
 /-- **Extraction is faithful.**  Under the decidable side-conditions on `a`
     (first cototient step even with odd quotient, landing constant nonzero and
@@ -889,7 +889,7 @@ theorem classify_data {a : ℕ} (hstep : 2 ∣ coStep a) (hC0 : landC a ≠ 0)
   refine ⟨?_, ?_, ?_, ?_⟩
   · -- `e = ordCompl[2] C` is odd: a prime never divides the complementary part
     exact Nat.odd_iff.2 (Nat.two_dvd_ne_zero.1
-      (Nat.not_dvd_ordCompl Nat.prime_two.prime hC0))
+      (Nat.not_dvd_ordCompl Nat.prime_two hC0))
   · -- `t = v₂(C) ≥ 1` since `2 ∣ C ≠ 0`
     exact Nat.prime_two.factorization_pos_of_dvd hC0 hCe
   · -- `2a − φ(a) = 2·bSeed a` because the step is even

--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -826,4 +826,193 @@ theorem two_distinct_reversal_families :
     (∀ k, (55 * 2 ^ (k + 1)) ∈ ReversalSet) ∧ (21 : ℕ) ≠ 55 :=
   ⟨reversal_via_criterion, reversal_via_criterion_55, by decide⟩
 
+-- ===========================================================================
+-- A COMPUTABLE DECISION PROCEDURE FOR TRANSPORT FAMILIES
+-- ---------------------------------------------------------------------------
+-- The `k`-free criterion above still asks the caller to *supply* the odd data
+-- `(b, e, t)` describing the family.  Here we make the extraction AUTOMATIC:
+-- from the single odd seed `a` we COMPUTE, by ordinary `Nat` arithmetic,
+--     b = (2a − φ(a))/2,   C = 2a − φ(b),   t = v₂(C),   e = C / 2^t,
+-- and package the entire three-way regime of the family `a·2^(k+1)` as one
+-- decidable `Ordering`-valued function
+--     classify a  =  compare  φ(a)  (φ(e)·2^(t−1)).
+-- The only inputs are decidable facts about `a` alone — that the first cototient
+-- step has 2-adic valuation exactly one (`Odd (bSeed a)`) and that the landing
+-- constant is nonzero and even.  Membership of the whole family in each regime is
+-- thereby reduced to a finite computation on `a`, with no per-`k` work and no
+-- hand-supplied `(e, t)`.  This is the decision procedure promised by the
+-- transport programme; the reversal seeds `21`, `55` are then read off by
+-- evaluating `classify`.
+-- ===========================================================================
+
+/-- Doubled first cototient step `2a − φ(a)` (equal to `2·bSeed a` on valid seeds). -/
+def coStep (a : ℕ) : ℕ := 2 * a - Nat.totient a
+
+/-- The intermediate odd seed `b = (2a − φ(a))/2`. -/
+def bSeed (a : ℕ) : ℕ := coStep a / 2
+
+/-- The landing constant `C = 2a − φ(b)`; transport gives `D(a·2^(k+1)) = C·2^k`. -/
+def landC (a : ℕ) : ℕ := 2 * a - Nat.totient (bSeed a)
+
+/-- 2-adic valuation `t` of the landing constant, writing `C = e·2^t` with `e` odd. -/
+def landT (a : ℕ) : ℕ := (landC a).factorization 2
+
+/-- Odd part `e` of the landing constant, `C = e·2^t`. -/
+def landE (a : ℕ) : ℕ := ordCompl[2] (landC a)
+
+/-- **The computable three-way classifier.**  Compares `φ(a)` with `φ(e)·2^(t−1)`
+    and returns `.lt` (reversal), `.eq` (equality) or `.gt` (forward). -/
+def classify (a : ℕ) : Ordering :=
+  compareOfLessAndEq (Nat.totient a) (Nat.totient (landE a) * 2 ^ (landT a - 1))
+
+/-- `compareOfLessAndEq` returns `.lt` exactly on the strict-less relation. -/
+theorem coLE_lt {x y : ℕ} : compareOfLessAndEq x y = Ordering.lt ↔ x < y :=
+  Batteries.compareOfLessAndEq_eq_lt
+
+/-- `compareOfLessAndEq` returns `.eq` exactly on equality. -/
+theorem coLE_eq {x y : ℕ} : compareOfLessAndEq x y = Ordering.eq ↔ x = y := by
+  unfold compareOfLessAndEq; split_ifs with h1 h2 <;> simp_all <;> omega
+
+/-- `compareOfLessAndEq` returns `.gt` exactly on the strict-greater relation. -/
+theorem coLE_gt {x y : ℕ} : compareOfLessAndEq x y = Ordering.gt ↔ y < x := by
+  unfold compareOfLessAndEq; split_ifs with h1 h2 <;> simp_all <;> omega
+
+/-- **Extraction is faithful.**  Under the decidable side-conditions on `a`
+    (first cototient step even with odd quotient, landing constant nonzero and
+    even) the computed data `(bSeed a, landE a, landT a)` satisfies exactly the
+    hypotheses required by the `k`-free transport criterion. -/
+theorem classify_data {a : ℕ} (hstep : 2 ∣ coStep a) (hC0 : landC a ≠ 0)
+    (hCe : 2 ∣ landC a) :
+    Odd (landE a) ∧ 1 ≤ landT a ∧
+      2 * a - Nat.totient a = 2 * bSeed a ∧
+      2 * a - Nat.totient (bSeed a) = landE a * 2 ^ landT a := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · -- `e = ordCompl[2] C` is odd: a prime never divides the complementary part
+    exact Nat.odd_iff.2 (Nat.two_dvd_ne_zero.1
+      (Nat.not_dvd_ordCompl Nat.prime_two.prime hC0))
+  · -- `t = v₂(C) ≥ 1` since `2 ∣ C ≠ 0`
+    exact Nat.prime_two.factorization_pos_of_dvd hC0 hCe
+  · -- `2a − φ(a) = 2·bSeed a` because the step is even
+    show 2 * a - Nat.totient a = 2 * bSeed a
+    have h2 : coStep a = 2 * bSeed a := by
+      simp only [bSeed]; exact (Nat.mul_div_cancel' hstep).symm
+    exact h2
+  · -- `C = e·2^t` is the ordProj/ordCompl split of the landing constant
+    show landC a = landE a * 2 ^ landT a
+    rw [mul_comm]
+    exact (Nat.ordProj_mul_ordCompl_eq_self (landC a) 2).symm
+
+/-- **Decision procedure — reversal branch.**  For any odd seed `a` whose first
+    cototient step has 2-adic valuation one and whose landing constant is nonzero
+    and even, the *whole* family `a·2^(k+1)` is a reversal family iff the
+    computable classifier returns `.lt`. -/
+theorem mem_ReversalSet_iff_classify {a : ℕ} (ha : Odd a) (hstep : 2 ∣ coStep a)
+    (hb : Odd (bSeed a)) (hC0 : landC a ≠ 0) (hCe : 2 ∣ landC a) (k : ℕ) :
+    a * 2 ^ (k + 1) ∈ ReversalSet ↔ classify a = Ordering.lt := by
+  obtain ⟨he, ht, hst, hC⟩ := classify_data hstep hC0 hCe
+  unfold classify
+  rw [coLE_lt]
+  exact dblIter_reversal_iff ha hb he ht hst hC k
+
+/-- **Decision procedure — equality branch.**  `a·2^(k+1)` lies on the equality
+    diagonal for all `k` iff `classify a = .eq`. -/
+theorem mem_EqualitySet_iff_classify {a : ℕ} (ha : Odd a) (hstep : 2 ∣ coStep a)
+    (hb : Odd (bSeed a)) (hC0 : landC a ≠ 0) (hCe : 2 ∣ landC a) (k : ℕ) :
+    a * 2 ^ (k + 1) ∈ EqualitySet ↔ classify a = Ordering.eq := by
+  obtain ⟨he, ht, hst, hC⟩ := classify_data hstep hC0 hCe
+  unfold classify
+  rw [coLE_eq]
+  exact dblIter_equality_iff ha hb he ht hst hC k
+
+/-- **Decision procedure — forward branch.**  `a·2^(k+1)` is a forward family for
+    all `k` iff `classify a = .gt`. -/
+theorem mem_ForwardSet_iff_classify {a : ℕ} (ha : Odd a) (hstep : 2 ∣ coStep a)
+    (hb : Odd (bSeed a)) (hC0 : landC a ≠ 0) (hCe : 2 ∣ landC a) (k : ℕ) :
+    a * 2 ^ (k + 1) ∈ ForwardSet ↔ classify a = Ordering.gt := by
+  obtain ⟨he, ht, hst, hC⟩ := classify_data hstep hC0 hCe
+  unfold classify
+  rw [coLE_gt]
+  exact dblIter_forward_iff ha hb he ht hst hC k
+
+-- --- Evaluating the classifier at concrete seeds (no `native_decide`) ---
+
+/-- Helper: if the landing constant factors as `C = e·2^t` with `e` odd and
+    `t ≥ 1`, then the computed valuation/odd-part are exactly `t` and `e`. -/
+theorem landT_landE_of {a e t : ℕ} (he : Odd e)
+    (h : landC a = e * 2 ^ t) : landT a = t ∧ landE a = e := by
+  have he0 : e ≠ 0 := by rintro rfl; exact absurd (Nat.odd_iff.1 he) (by decide)
+  have hT : landT a = t := by
+    unfold landT
+    rw [h, Nat.factorization_mul he0 (pow_ne_zero t (by norm_num)), Finsupp.add_apply,
+        Nat.factorization_eq_zero_of_not_dvd (Nat.two_dvd_ne_zero.2 (Nat.odd_iff.1 he)),
+        Nat.factorization_pow_self Nat.prime_two, zero_add]
+  refine ⟨hT, ?_⟩
+  show landC a / 2 ^ landT a = e
+  rw [hT, h, Nat.mul_div_assoc e (dvd_refl (2 ^ t)), Nat.div_self (pow_pos (by norm_num) t),
+      mul_one]
+
+theorem totient_11 : Nat.totient 11 = 10 := Nat.totient_prime (by norm_num)
+theorem totient_7 : Nat.totient 7 = 6 := Nat.totient_prime (by norm_num)
+
+/-- The classifier evaluated at `a = 21` returns `.lt` (reversal), computing
+    `b = 15`, `C = 34 = 17·2^1`, `t = 1`, `e = 17`, and `φ(21) = 12 < 16 = φ(17)`. -/
+theorem classify_21 : classify 21 = Ordering.lt := by
+  have hb : bSeed 21 = 15 := by unfold bSeed coStep; norm_num [totient_21]
+  have hC : landC 21 = 34 := by unfold landC; norm_num [hb, totient_15]
+  obtain ⟨hT, hE⟩ := landT_landE_of (a := 21) (e := 17) (t := 1)
+    (by decide) (by norm_num [hC])
+  unfold classify
+  rw [hE, hT, totient_21, totient_17]
+  decide
+
+/-- The classifier evaluated at `a = 15` returns `.eq` (equality diagonal):
+    `b = 11`, `C = 20 = 5·2^2`, `t = 2`, `e = 5`, and `φ(15) = 8 = 4·2 = φ(5)·2^1`. -/
+theorem classify_15 : classify 15 = Ordering.eq := by
+  have hb : bSeed 15 = 11 := by unfold bSeed coStep; norm_num [totient_15]
+  have hC : landC 15 = 20 := by unfold landC; norm_num [hb, totient_11]
+  obtain ⟨hT, hE⟩ := landT_landE_of (a := 15) (e := 5) (t := 2)
+    (by decide) (by norm_num [hC])
+  unfold classify
+  rw [hE, hT, totient_15, totient_5]
+  decide
+
+/-- The classifier evaluated at `a = 13` returns `.gt` (forward):
+    `b = 7`, `C = 20 = 5·2^2`, `t = 2`, `e = 5`, and `φ(5)·2^1 = 8 < 12 = φ(13)`. -/
+theorem classify_13 : classify 13 = Ordering.gt := by
+  have hb : bSeed 13 = 7 := by unfold bSeed coStep; norm_num [totient_13]
+  have hC : landC 13 = 20 := by unfold landC; norm_num [hb, totient_7]
+  obtain ⟨hT, hE⟩ := landT_landE_of (a := 13) (e := 5) (t := 2)
+    (by decide) (by norm_num [hC])
+  unfold classify
+  rw [hE, hT, totient_13, totient_5]
+  decide
+
+/-- **The decision procedure decides all three regimes.**  Running the single
+    computable classifier on the seeds `21`, `15`, `13` (with all side-conditions
+    discharged by `decide`) reproduces the reversal, equality and forward families
+    with no hand-supplied `(e, t)` data — the extraction is fully automatic. -/
+theorem decision_procedure_classifies :
+    (∀ k, (21 * 2 ^ (k + 1)) ∈ ReversalSet) ∧
+    (∀ k, (15 * 2 ^ (k + 1)) ∈ EqualitySet) ∧
+    (∀ k, (13 * 2 ^ (k + 1)) ∈ ForwardSet) := by
+  have hb21 : bSeed 21 = 15 := by unfold bSeed coStep; norm_num [totient_21]
+  have hb15 : bSeed 15 = 11 := by unfold bSeed coStep; norm_num [totient_15]
+  have hb13 : bSeed 13 = 7 := by unfold bSeed coStep; norm_num [totient_13]
+  have hC21 : landC 21 = 34 := by unfold landC; norm_num [hb21, totient_15]
+  have hC15 : landC 15 = 20 := by unfold landC; norm_num [hb15, totient_11]
+  have hC13 : landC 13 = 20 := by unfold landC; norm_num [hb13, totient_7]
+  refine ⟨fun k => ?_, fun k => ?_, fun k => ?_⟩
+  · rw [mem_ReversalSet_iff_classify (a := 21) (by decide)
+        (by unfold coStep; norm_num [totient_21]) (by rw [hb21]; decide)
+        (by rw [hC21]; decide) (by rw [hC21]; decide) k]
+    exact classify_21
+  · rw [mem_EqualitySet_iff_classify (a := 15) (by decide)
+        (by unfold coStep; norm_num [totient_15]) (by rw [hb15]; decide)
+        (by rw [hC15]; decide) (by rw [hC15]; decide) k]
+    exact classify_15
+  · rw [mem_ForwardSet_iff_classify (a := 13) (by decide)
+        (by unfold coStep; norm_num [totient_13]) (by rw [hb13]; decide)
+        (by rw [hC13]; decide) (by rw [hC13]; decide) k]
+    exact classify_13
+
 end Erdos1064OQ03

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "STRUCTURAL: k-independent three-way criterion (2026-07-08, r4) — the regime of every transport family n=a·2^(k+1) reduces to the k-free comparison φ(a) vs φ(e)·2^(t−1) via the 2-adic split of the landing constant C=e·2^t. 0 axioms / 0 sorries. All infinitely-often + structural questions settled; density-1 forward (almost-all n) remains the sole analytically-blocked open direction.",
+    "progressSummary": "PROGRESS (verified 0/0): the k-free three-way criterion is now a genuine COMPUTABLE decision procedure classify:ℕ→Ordering on the single odd seed; family regime membership reduced to a finite computation. Density-1 forward remains the sole analytically-blocked direction.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -68,7 +68,12 @@
       "dblIter_totient_values (EulerTotientOQ04OQ03.lean): φ(a·2^(k+1))=φ(a)·2^k ∧ φ(D(n))=φ(e)·2^(t−1)·2^k given odd a,b,e, t≥1, 2a−φ(a)=2b, 2a−φ(b)=e·2^t",
       "dblIter_reversal_iff / dblIter_equality_iff / dblIter_forward_iff: n∈{Reversal,Equality,Forward}Set ↔ the k-free comparison of φ(a) with φ(e)·2^(t−1) (< / = / >)",
       "reversal_via_criterion / equality_via_criterion / forward_via_criterion: the 21/15/13 families recovered from the sign inequality alone (a=21,e=17,t=1→12<16; a=15,e=5,t=2→8=8; a=13,e=5,t=2→8<12)",
-      "threeway_criterion_classifies: bundles all three regimes as one k-free classifier"
+      "threeway_criterion_classifies: bundles all three regimes as one k-free classifier",
+      "coStep/bSeed/landC/landT/landE/classify (EulerTotientOQ04OQ03.lean): computable Nat-arithmetic extraction of the transport data and Ordering-valued classifier classify a = compareOfLessAndEq φ(a) (φ(e)·2^(t-1)).",
+      "classify_data: under decidable side-conditions (2∣coStep a, landC a≠0, 2∣landC a) the computed (bSeed,landE,landT) satisfy exactly the criterion hypotheses (Odd e via not_dvd_ordCompl, t≥1 via Prime.factorization_pos_of_dvd, C=e·2^t via ordProj_mul_ordCompl_eq_self).",
+      "mem_ReversalSet/EqualitySet/ForwardSet_iff_classify: whole family a·2^(k+1) membership ⇔ classify a = .lt/.eq/.gt (coLE_lt/eq/gt bridge compareOfLessAndEq to </=/>).",
+      "landT_landE_of: C=e·2^t with e odd ⇒ landT a=t ∧ landE a=e (factorization_mul + factorization_pow_self + factorization_eq_zero_of_not_dvd).",
+      "classify_21=.lt, classify_15=.eq, classify_13=.gt + decision_procedure_classifies: the single classifier reproduces reversal/equality/forward families with no per-k work, all via decide (0 native_decide)."
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -84,7 +89,8 @@
       "The forward direction φ(n)>φ(D(n)) is NOT confined to primes: on n=2^(k+3) the double iterate collapses to 3·2^(k+1) and φ(D)=2^(k+1)<2^(k+2)=φ(n). This closes the earlier asymmetry where only reversal and equality had explicit composite infinite families while forward had only the odd-prime family. Now all three relations >,=,< are each realised on an infinite family of composite integers.",
       "GENERAL TRANSPORT MECHANISM (2026-07-08, r8): all three ad-hoc explicit families (15·2^(k+1) equality, 21·2^(k+1) reversal, 2^(k+3) forward) are instances of ONE structural lemma dblIter_transport: for odd a,b with 2a−φ(a)=2b (first cototient step has 2-adic valuation exactly 1), D(a·2^(k+1))=(2a−φ(b))·2^k uniformly in k. The odd pair (a,b) carries everything; the power of two is inert and scales. The landing constant C=2a−φ(b) is k-INDEPENDENT, which is precisely why each family realises a single one of >,=,< for every k (constant three-way sign along a family).",
       "The transport lemma is GENERATIVE, not a mere refactor: feeding new odd seeds produces brand-new infinite families. a=5,b=3 gives equality family 5·2^(k+1) (D=8·2^k=2^(k+3), φ(n)=φ(D)=4·2^k) — smaller than the recorded 15·2^(k+1). a=13,b=7 gives a composite forward family 13·2^(k+1) (D=20·2^k=5·2^(k+2), φ(n)=12·2^k>8·2^k=φ(D)) distinct from the powers of two. Numerically the seed-to-sign map: a=5→'=', a=13/17→'>', a=15→'=', a=21→'<'.",
-      "k-INDEPENDENT THREE-WAY CRITERION (2026-07-08, r4): the double-iterate regime of every transport family n=a·2^(k+1) is decided by a single k-free comparison φ(a) vs φ(e)·2^(t−1), where the landing constant C=2a−φ(b)=e·2^t (e odd, t≥1). Both totients factor through the inert 2^k: φ(n)=φ(a)·2^k, φ(D(n))=φ(e)·2^(t−1)·2^k. The power of two carries NO information; the sign is fixed by the odd data (a,e,t) alone."
+      "k-INDEPENDENT THREE-WAY CRITERION (2026-07-08, r4): the double-iterate regime of every transport family n=a·2^(k+1) is decided by a single k-free comparison φ(a) vs φ(e)·2^(t−1), where the landing constant C=2a−φ(b)=e·2^t (e odd, t≥1). Both totients factor through the inert 2^k: φ(n)=φ(a)·2^k, φ(D(n))=φ(e)·2^(t−1)·2^k. The power of two carries NO information; the sign is fixed by the odd data (a,e,t) alone.",
+      "Decision-procedure realisation of the k-free criterion: the odd seed a alone determines the family regime via computable extraction b=(2a-φa)/2, C=2a-φb, t=v₂(C)=(landC a).factorization 2, e=C/2^t=ordCompl[2](landC a) — no hand-supplied (e,t)."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -93,7 +99,9 @@
       "Density-1 forward statement φ(n)>φ(D(n)) for almost all n remains the sole analytically-blocked open direction (needs Luca–Pomerance / ψ(x,y) density, a real Mathlib gap); the explicit families + criterion settle only the infinitely-often / structural questions.",
       "Turn the criterion into a genuine DECIDABLE classifier: given odd a, compute b=(2a−φ(a))/2 (requires v₂(2a−φ(a))=1), then the 2-adic split C=2a−φ(b)=e·2^t, and decide the regime by φ(a) vs φ(e)·2^(t−1). Formalising the v₂ extraction (t,e) as a computable function would give a decision procedure over all odd seeds.",
       "Characterise the reversal seed set {odd a : φ(a) < φ(e)·2^(t−1)} — a structural description of which odd seeds reverse (a=21 smallest) would be a new elementary result now that the per-seed test is k-free.",
-      "Handle the excluded case v₂(2a−φ(a))>1 (the transport hypothesis 2a−φ(a)=2b with b odd fails): extend the transport/criterion to higher first-step 2-adic valuation."
+      "Handle the excluded case v₂(2a−φ(a))>1 (the transport hypothesis 2a−φ(a)=2b with b odd fails): extend the transport/criterion to higher first-step 2-adic valuation.",
+      "Reversal-seed enumeration: prove 21 is the smallest odd seed with classify a = .lt among valid seeds (a<21 either fail the v₂=1 transport hypothesis or classify to .eq/.gt) — a finite decide-sweep now that classify is computable.",
+      "Extend classify to the excluded case v₂(2a-φa)>1 (bSeed a even), generalising coStep/transport beyond first-step valuation one."
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Erdős 1064 OQ-03 studies the double cototient iterate `D(n) = n − φ(n − φ(n))` and the three-way sign of `φ(n) − φ(D(n))`. The existing file establishes a **k-independent three-way criterion**: along any transport family `n = a·2^(k+1)`, the regime is decided by the k-free comparison `φ(a) ⋛ φ(e)·2^(t−1)` on odd data `(a, e, t)` — but the caller must *supply* `(b, e, t)` by hand.

This PR turns that criterion into a **genuine computable decision procedure** on the single odd seed `a`:

- **Computable extraction** (`coStep`, `bSeed`, `landC`, `landT`, `landE`): from `a` alone, compute `b = (2a−φa)/2`, the landing constant `C = 2a−φb`, its 2-adic valuation `t = v₂(C) = (landC a).factorization 2`, and odd part `e = C/2^t = ordCompl[2](landC a)` — all by ordinary `Nat` arithmetic.
- **`classify : ℕ → Ordering`** `= compareOfLessAndEq φ(a) (φ(e)·2^(t−1))`.
- **`classify_data`**: under decidable side-conditions (`2 ∣ coStep a`, `landC a ≠ 0`, `2 ∣ landC a`) the extracted `(bSeed, landE, landT)` satisfy *exactly* the criterion hypotheses (`Odd e` via `not_dvd_ordCompl`, `t ≥ 1` via `Prime.factorization_pos_of_dvd`, `C = e·2^t` via `ordProj_mul_ordCompl_eq_self`).
- **Master theorems** `mem_ReversalSet/EqualitySet/ForwardSet_iff_classify`: membership of the *whole* family `a·2^(k+1)` in each regime ⇔ `classify a = .lt/.eq/.gt`, with no per-`k` work.
- **Concrete evaluations** `classify_21 = .lt`, `classify_15 = .eq`, `classify_13 = .gt`, assembled in `decision_procedure_classifies` — reproducing the reversal, equality and forward families with **no hand-supplied `(e, t)`**.

## Verification

- Docker build (`Proofs.EulerTotientOQ04OQ03`) succeeds, **0 sorries, 0 axioms, 0 `native_decide`** (concrete seeds discharged by `decide` + factorisation lemmas, never `native_decide`).

## Status

The infinitely-often / structural questions were already settled; the density-1 forward direction remains the sole analytically-blocked open part (needs Luca–Pomerance / ψ(x,y) density, a real Mathlib gap). This PR is a self-contained elementary advance on the structural side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)