### PR TITLE
Auditor: persist audit completions (3 gallery entries, 2 issues filed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -268,10 +268,10 @@
       "issues": []
     },
     "abel-ruffini-oq-04-oq-07": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
-      "result": "clean"
+      "lastAudited": "2026-07-09T01:43:39Z",
+      "result": "issues-found"
     },
     "abel-ruffini-oq-04-oq-07-oq-02": {
       "auditCount": 1,
@@ -400,15 +400,15 @@
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
-      "result": "clean"
+      "lastAudited": "2026-07-09T01:43:39Z",
+      "result": "issues-found"
     },
     "algebraic-numbers-countable-oq-02-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-09T01:43:39Z",
       "result": "clean"
     },
     "algebraic-numbers-countable-oq-02-oq-03": {
@@ -29695,5 +29695,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T01:00:00Z"
+  "lastUpdated": "2026-07-09T01:43:39Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — Tracker Persistence

Persists this audit cycle's completions to the git-tracked `audit-tracker.json` so already-audited entries stop being re-served after concurrent `git reset --hard origin/main` (the auditor-loop tracker race).

### Entries audited this cycle

| Entry | Result | Notes |
|-------|--------|-------|
| `algebraic-numbers-countable-oq-02-oq-02` | clean | `verified`/`original` justified — genuine constructive nested-interval proof; 0 sorries/axioms confirmed across main (285L) + companion (133L). Not a Mathlib wrapper. |
| `algebraic-numbers-countable-oq-02` | issues-found | #35874 — title "Cantor's Diagonal Argument (1874)" misattributes technique (proof is cardinal arithmetic, not diagonal) and date (diagonal is 1891). Counts/badge/axioms all correct. |
| `abel-ruffini-oq-04-oq-07` | issues-found | #35878 (**urgent**) — axiom `bringRadical_not_in_radicals` is logically inconsistent: its radical-expressibility predicate was stubbed to `∧ True`, so `F := bringRadical` witnesses the negand → asserts `False`. Propagates to 2 importers. |

Diff is limited to the 3 entries' `auditCount`/`lastAudited`/`result` fields plus `lastUpdated`.