### PR TITLE
Enrich harmonic regrouping / log 2 (harmonic-divergence-oq-03-oq-01): finer sections + insight

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-03-oq-01/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-03-oq-01/meta.json
@@ -80,7 +80,8 @@
       "**Conditional → absolute by pairing.** The parent series is not Summable (conditional only); grouping consecutive terms yields a positive O(1/k²) series that IS absolutely summable, with the same sum.",
       "**Pairing is a subsequence, not a rearrangement.** The N-th paired partial sum is exactly the 2N-th alternating partial sum, so convergence and value transfer for free — no re-derivation of log 2.",
       "**Monotone + bounded, no comparison series.** Positivity makes the paired partial sums monotone; Monotone.ge_of_tendsto bounds them by their own limit log 2, feeding summable_of_sum_range_le directly.",
-      "**An honest tsum for log 2.** Unlike the alternating form, the regrouped series has a genuine HasSum/tsum value, giving log 2 a positive-series representation ∑ 1/((2k+1)(2k+2))."
+      "**An honest tsum for log 2.** Unlike the alternating form, the regrouped series has a genuine HasSum/tsum value, giving log 2 a positive-series representation ∑ 1/((2k+1)(2k+2)).",
+    "**Grouping is legitimate exactly where rearrangement is not.** The alternating harmonic series is conditionally convergent, so by Riemann's rearrangement theorem its terms can be reordered to sum to any real value (or diverge) — rearrangement is unsafe here. Grouping (inserting parentheses without changing order), by contrast, preserves the sum of any convergent series because it only selects a subsequence of the partial sums. This entry rests entirely on that distinction: pairing consecutive terms is a grouping, so it keeps the value log 2 while upgrading conditional convergence to absolute — precisely the manipulation Riemann forbids for reordering but permits for parenthesising."
     ],
     "prerequisites": [
       "The alternating harmonic series = log 2 (parent)",
@@ -90,28 +91,44 @@
   },
   "sections": [
     {
-      "id": "pairing",
-      "title": "The paired term and the pairing identity",
-      "startLine": 38,
+      "id": "sec-header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Imports (Mathlib and the parent HarmonicDivergenceOQ03), docstring explaining the strategy — regroup the conditionally convergent alternating harmonic series ∑(−1)ⁿ⁺¹/n by pairing consecutive terms into a positive, absolutely convergent series with the same sum log 2 — and the namespace HarmonicAlt / opens (Filter, Finset, Topology).",
+      "mathContext": "Regroup $\\sum \\frac{(-1)^{n+1}}{n} = \\log 2$ (conditional) into a positive absolutely convergent series."
+    },
+    {
+      "id": "sec-pairing",
+      "title": "The Paired Term and the Pairing Identity",
+      "startLine": 37,
       "endLine": 56,
-      "summary": "pairTerm k := 1/((2k+1)(2k+2)) is nonnegative (pairTerm_nonneg). altTerm_pair proves the key algebraic collapse (−1)^{2k}/(2k+1) + (−1)^{2k+1}/(2k+2) = 1/(2k+1) − 1/(2k+2) = 1/((2k+1)(2k+2)), reducing two alternating terms to one positive term.",
-      "mathContext": "$\\varphi$-free: $\\frac{1}{2k+1}-\\frac{1}{2k+2}=\\frac{1}{(2k+1)(2k+2)}$."
+      "summary": "pairTerm k := 1/((2k+1)(2k+2)) with pairTerm_nonneg (0 ≤ pairTerm). altTerm_pair proves the key algebraic collapse altTerm(2k) + altTerm(2k+1) = 1/(2k+1) − 1/(2k+2) = 1/((2k+1)(2k+2)) = pairTerm k, reducing two consecutive alternating terms to one positive term.",
+      "mathContext": "$\\frac{1}{2k+1}-\\frac{1}{2k+2}=\\frac{1}{(2k+1)(2k+2)}$: two alternating terms collapse to one positive term."
     },
     {
-      "id": "partial-sums",
-      "title": "Paired partial sums = even alternating partial sums",
+      "id": "sec-partial-sums",
+      "title": "Paired Partial Sums = Even Alternating Partial Sums",
       "startLine": 57,
-      "endLine": 83,
-      "summary": "sum_pairTerm_eq: by induction (peeling two terms via Finset.sum_range_succ and altTerm_pair), ∑_{k<N} pairTerm k = altPartial (2N). tendsto_sum_pairTerm then composes the parent's altHarmonic_tendsto_log_two with N ↦ 2N → ∞ to conclude the paired partial sums tend to log 2.",
-      "mathContext": "$\\sum_{k<N}\\frac{1}{(2k+1)(2k+2)} = \\mathrm{altPartial}(2N) \\to \\log 2$."
+      "endLine": 82,
+      "summary": "sum_pairTerm_eq: by induction (peeling two terms via Finset.sum_range_succ and altTerm_pair), ∑_{k<N} pairTerm k = altPartial(2N). tendsto_sum_pairTerm then composes the parent's altHarmonic_tendsto_log_two with N ↦ 2N → ∞, so the paired partial sums are exactly the even alternating partial sums and tend to log 2.",
+      "mathContext": "$\\sum_{k<N}\\frac{1}{(2k+1)(2k+2)} = \\mathrm{altPartial}(2N) \\to \\log 2$: a subsequence, not a rearrangement."
     },
     {
-      "id": "summability-value",
-      "title": "Absolute summability and the value log 2",
-      "startLine": 84,
+      "id": "sec-summability",
+      "title": "Absolute Summability (Monotone + Bounded)",
+      "startLine": 83,
+      "endLine": 92,
+      "summary": "summable_pairTerm: since the terms are nonnegative the partial sums are monotone, and Monotone.ge_of_tendsto bounds them by their own limit log 2, so summable_of_sum_range_le yields Summable pairTerm — no external comparison series is needed, the sequence bounds itself.",
+      "mathContext": "Nonnegative ⟹ monotone partial sums ≤ log 2 ⟹ Summable, via summable_of_sum_range_le."
+    },
+    {
+      "id": "sec-value",
+      "title": "The Value log 2 (HasSum and tsum)",
+      "startLine": 93,
       "endLine": 103,
-      "summary": "summable_pairTerm: the paired partial sums are monotone (positive terms) and ≤ their limit log 2 (Monotone.ge_of_tendsto), so summable_of_sum_range_le gives Summable pairTerm. hasSum_pairTerm_log_two / tsum_pairTerm: HasSum.tendsto_sum_nat plus uniqueness of limits fix ∑' pairTerm = log 2 — an honest absolutely-convergent value, unlike the parent's conditional-only limit.",
-      "mathContext": "$\\sum_k \\frac{1}{(2k+1)(2k+2)} = \\log 2$ (absolutely convergent)."
+      "summary": "hasSum_pairTerm_log_two combines summability with HasSum.tendsto_sum_nat and uniqueness of limits to fix HasSum pairTerm (log 2); tsum_pairTerm records ∑' k, 1/((2k+1)(2k+2)) = log 2 — an honest absolutely-convergent value for log 2, unlike the parent's conditional-only alternating limit.",
+      "mathContext": "$\\sum_k \\frac{1}{(2k+1)(2k+2)} = \\log 2$ (absolutely convergent HasSum/tsum)."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `harmonic-divergence-oq-03-oq-01`.

The scorer flagged two structural gaps (quality 94): sections 6/10 and keyInsights 8/10. Both addressed without bloat; the split also fixes that the header (lines 1–36) was previously uncovered by any section.

**Sections 3 → 5** — split into 5 covering the whole file, each with summary + mathContext: header/setup, the pairing identity (pairTerm + altTerm_pair), paired partial sums = even alternating partial sums, absolute summability (monotone + bounded), and the value log 2 (HasSum/tsum).

**keyInsights 4 → 5** — added: grouping is legitimate exactly where rearrangement is not — by Riemann's rearrangement theorem the conditionally convergent alternating harmonic series can be reordered to any value, but pairing consecutive terms is a *grouping* (a subsequence of the partial sums), so it preserves the value log 2 while upgrading conditional to absolute convergence.

Line anchors verified against the Lean source; annotations, conclusion, crossReferences unchanged. Quality 94 → 100.