### PR TITLE
research(shannon-awgn-oq-02-oq-02): correlation-coefficient capstone — |ρ|≤1 and |ρ|=1 ⟺ a.e. affine dependence

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -676,4 +676,75 @@ theorem covariance_sq_eq_variance_mul_variance_iff_affine [IsProbabilityMeasure 
   · rintro ⟨a, b, hab⟩
     exact covariance_sq_eq_of_affine hY a b hab
 
+/-!
+### Normalised capstone: the Pearson correlation coefficient ρ = cov/(σ_X·σ_Y)
+
+The equality boundary above is most cleanly expressed through the **correlation coefficient**
+
+    ρ[X, Y] = cov[X, Y] / (σ_X · σ_Y),        σ_X = √Var[X],  σ_Y = √Var[Y],
+
+the dimensionless normalisation of the covariance.  The covariance Cauchy–Schwarz inequality
+becomes the sharp statement `|ρ| ≤ 1` (needing *no* non-degeneracy hypothesis — the
+division-by-zero convention absorbs the degenerate case), and the equality boundary
+`covariance_sq_eq_variance_mul_variance_iff_affine` becomes its normalised capstone:
+`|ρ| = 1` holds **exactly** when `X` and `Y` are a.e. affinely dependent.  This is the standard
+correlation-coefficient packaging of the second-order theory built above.
+-/
+
+/-- **Pearson correlation coefficient.**  The covariance normalised by the product of the
+standard deviations, `ρ[X, Y] = cov[X, Y] / (√Var[X] · √Var[Y])`.  With the Lean
+division-by-zero convention `ρ = 0` whenever either variable is degenerate. -/
+noncomputable def correlation (X Y : Ω → ℝ) (μ : Measure Ω) : ℝ :=
+  cov[X, Y; μ] / (Real.sqrt (Var[X; μ]) * Real.sqrt (Var[Y; μ]))
+
+/-- **Correlation squared is the Cauchy–Schwarz ratio.**  `ρ² = cov² / (Var[X]·Var[Y])`, obtained
+by squaring the defining quotient and collapsing `(√Var)² = Var`.  This is the algebraic bridge
+between the normalised coefficient and the covariance Cauchy–Schwarz inequality. -/
+theorem correlation_sq (X Y : Ω → ℝ) (μ : Measure Ω) :
+    correlation X Y μ ^ 2 = cov[X, Y; μ] ^ 2 / (Var[X; μ] * Var[Y; μ]) := by
+  rw [correlation, div_pow, mul_pow, Real.sq_sqrt (variance_nonneg _ _),
+    Real.sq_sqrt (variance_nonneg _ _)]
+
+/-- **|ρ| ≤ 1 — covariance Cauchy–Schwarz, normalised.**  The correlation coefficient always lies
+in `[-1, 1]`, needing *no* non-degeneracy hypothesis: when either variable is degenerate the
+quotient is `0` by the division-by-zero convention, and otherwise `ρ² ≤ 1` follows from
+`covariance_sq_le_variance_mul_variance`. -/
+theorem abs_correlation_le_one [IsFiniteMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) :
+    |correlation X Y μ| ≤ 1 := by
+  have h2 : correlation X Y μ ^ 2 ≤ 1 := by
+    rw [correlation_sq]
+    rcases eq_or_lt_of_le (mul_nonneg (variance_nonneg X μ) (variance_nonneg Y μ)) with hz | hpos
+    · rw [← hz, div_zero]; norm_num
+    · rw [div_le_one hpos]; exact covariance_sq_le_variance_mul_variance hX hY
+  rw [abs_le]
+  constructor <;>
+    nlinarith [h2, sq_nonneg (correlation X Y μ - 1), sq_nonneg (correlation X Y μ + 1)]
+
+/-- **ρ² = 1 ⟺ a.e. affine dependence (normalised equality boundary).**  For non-degenerate
+`X, Y` (`Var[X] ≠ 0`, `Var[Y] ≠ 0`) the correlation coefficient is extremal — `ρ² = 1` — *exactly*
+when `X` is almost everywhere an affine function of `Y`.  This is
+`covariance_sq_eq_variance_mul_variance_iff_affine` normalised through `correlation_sq`; both
+non-degeneracy hypotheses are genuinely needed, since a degenerate variable makes `ρ = 0 ≠ ±1`
+while the affine relation `X =ᵐ 0·Y + μ[X]` still holds. -/
+theorem correlation_sq_eq_one_iff_affine [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hXnd : Var[X; μ] ≠ 0) (hYnd : Var[Y; μ] ≠ 0) :
+    correlation X Y μ ^ 2 = 1 ↔ ∃ a b : ℝ, X =ᵐ[μ] fun ω => a * Y ω + b := by
+  rw [correlation_sq, div_eq_one_iff_eq (mul_ne_zero hXnd hYnd)]
+  exact covariance_sq_eq_variance_mul_variance_iff_affine hX hY hYnd
+
+/-- **|ρ| = 1 ⟺ a.e. affine dependence — the normalised capstone.**  For non-degenerate `X, Y`
+the correlation coefficient attains its extreme value `|ρ| = 1` *exactly* when `X` and `Y` are
+almost everywhere affinely dependent (perfect ±correlation).  This is the dimensionless
+restatement of the sharp Cauchy–Schwarz equality boundary
+`covariance_sq_eq_variance_mul_variance_iff_affine`, obtained from `correlation_sq_eq_one_iff_affine`
+via `|ρ| = 1 ↔ ρ² = 1`. -/
+theorem abs_correlation_eq_one_iff_affine [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hXnd : Var[X; μ] ≠ 0) (hYnd : Var[Y; μ] ≠ 0) :
+    |correlation X Y μ| = 1 ↔ ∃ a b : ℝ, X =ᵐ[μ] fun ω => a * Y ω + b := by
+  rw [← correlation_sq_eq_one_iff_affine hX hY hXnd hYnd]
+  constructor
+  · intro h; rw [← sq_abs, h]; norm_num
+  · intro h; rw [← Real.sqrt_sq_eq_abs, h, Real.sqrt_one]
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,10 +12,10 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 679,
+    "lineCount": 750,
     "axiomCount": 0,
-    "theoremCount": 28,
-    "definitionCount": 0,
+    "theoremCount": 32,
+    "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
   },
@@ -181,6 +181,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 679,
-  "theoremCount": 28
+  "lineCount": 750,
+  "theoremCount": 32
 }

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: sharp Cauchy–Schwarz equality boundary now a FULL IFF (tightness ⟺ a.e. affine dependence). Added converse covariance_sq_eq_of_affine + missing covariance_congr_left. 679 lines, 28 thm, 0/0.",
+    "progressSummary": "PROGRESS: normalised capstone COMPLETE — Pearson correlation coefficient ρ=cov/(σX·σY) added (750 lines, 32 thm, 0 sorry/0 axiom). |ρ|≤1 = covariance Cauchy–Schwarz; |ρ|=1 ⟺ a.e. affine dependence = sharp equality boundary. Second-order theory now packaged in dimensionless form.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -44,7 +44,11 @@
       "exists_affine_of_covariance_sq_eq: tight C–S ⟹ X =ᵐ (cov/Var[Y])·Y + b (regression line)",
       "covariance_congr_left (ShannonChannelCodingAWGNOQ02OQ02.lean): cov a.e.-congruent in left arg — covariance analogue of Mathlib variance_congr (not in Mathlib), proved from defining integral via integral_congr_ae",
       "covariance_sq_eq_of_affine: CONVERSE of exists_affine_of_covariance_sq_eq — X =ᵐ a·Y+b ⟹ cov²=Var·Var, no non-degeneracy needed (bilinear cov=a·Var[Y], Var=a²·Var[Y])",
-      "covariance_sq_eq_variance_mul_variance_iff_affine: FULL IFF capstone — Cauchy–Schwarz tight ⟺ X,Y a.e. affinely dependent (629→679 lines, 25→28 thm, 0 sorry/0 axiom)"
+      "covariance_sq_eq_variance_mul_variance_iff_affine: FULL IFF capstone — Cauchy–Schwarz tight ⟺ X,Y a.e. affinely dependent (629→679 lines, 25→28 thm, 0 sorry/0 axiom)",
+      "correlation: def cov[X,Y]/(√Var[X]·√Var[Y]) (ShannonChannelCodingAWGNOQ02OQ02.lean)",
+      "correlation_sq: ρ²=cov²/(Var[X]·Var[Y]) via div_pow/mul_pow + Real.sq_sqrt (ShannonChannelCodingAWGNOQ02OQ02.lean)",
+      "abs_correlation_le_one: |ρ|≤1 with no non-degeneracy hyp; ρ²≤1 via eq_or_lt_of_le on Var·Var then div_le_one, then abs_le+nlinarith (ShannonChannelCodingAWGNOQ02OQ02.lean)",
+      "abs_correlation_eq_one_iff_affine: |ρ|=1 ⟺ ∃a b, X=ᵐa·Y+b — normalised capstone via correlation_sq_eq_one_iff_affine + Real.sqrt_sq_eq_abs (ShannonChannelCodingAWGNOQ02OQ02.lean)"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -55,7 +59,8 @@
       "Canonical variance-of-sum defect equals exactly 2 times the strict-lower-triangle pairwise covariance sum; the factor 2 is covariance_comm symmetry between the two ordered copies of each unordered pair. Sharpens the qualitative offDiag-vanishing iff to a closed-form defect and halves the covariance terms to control.",
       "Cauchy–Schwarz for covariance (cov[X,Y]²≤Var[X]·Var[Y]) is ABSENT from Mathlib probability layer; proved via discrim_le_zero applied to the nonnegative quadratic t↦Var[X+t•Y]=Var[Y]·t²+2cov·t+Var[X]. This is the engine for the standard-deviation triangle inequality.",
       "Sharp EQUALITY case of covariance Cauchy–Schwarz (cov²=Var[X]·Var[Y]) is characterized by the regression-residual variance IDENTITY Var[Var[Y]·X − cov·Y] = Var[Y]·(Var[X]·Var[Y] − cov²): when Var[Y]≠0 the residual has zero variance (hence a.e. constant) exactly when C–S is tight. Dividing by Var[Y] exhibits X =ᵐ (cov/Var[Y])·Y + b — a.e. affine dependence with slope the regression coefficient. Classical equality-in-Cauchy–Schwarz ⟺ linear-dependence, specialised to the covariance inner product; sharp EQUALITY companion to the earlier stddev triangle INEQUALITY.",
-      "The equality-boundary iff closes cleanly: forward (tightness⟹regression line) needs Var[Y]≠0, but converse (affine⟹tightness) is unconditional — a pure bilinear/variance-of-affine computation transported along =ᵐ via covariance_congr_left + variance_congr."
+      "The equality-boundary iff closes cleanly: forward (tightness⟹regression line) needs Var[Y]≠0, but converse (affine⟹tightness) is unconditional — a pure bilinear/variance-of-affine computation transported along =ᵐ via covariance_congr_left + variance_congr.",
+      "Correlation-coefficient normalisation ρ=cov/(σX·σY) packages the whole second-order theory: |ρ|≤1 IS covariance Cauchy–Schwarz (no non-degeneracy needed — division-by-zero convention absorbs degenerate case), and |ρ|=1 ⟺ a.e. affine dependence IS the sharp equality boundary. Both non-degeneracy hypotheses genuinely needed for the |ρ|=1 iff since a degenerate variable gives ρ=0≠±1 while X=ᵐ0·Y+μ[X] still holds."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -68,7 +73,8 @@
       "Equality condition for the std-deviation triangle inequality: √Var[∑Wᵢ]=∑√Var[Wᵢ] iff the centered contributions are a.e. nonneg-proportional (perfect positive correlation) — the sharp boundary of stddev_sum_le, dual to the off-diagonal-cancellation equality condition already proven.",
       "Correlation coefficient ρ = cov/(σX·σY): |ρ| ≤ 1 immediate from covariance_sq_le_variance_mul_variance; state |ρ|=1 ⟺ a.e. affine dependence as normalised capstone.",
       "Converse affine⟹equality (X =ᵐ a·Y+b ⟹ cov²=Var·Var) for full iff — needs covariance_congr under a.e. equality (build from integral_congr_ae).",
-      "Upstream covariance_congr_left to Mathlib (Probability/Moments/Covariance.lean) alongside variance_congr; would also give a covariance_congr_right by covariance_comm."
+      "Upstream covariance_congr_left to Mathlib (Probability/Moments/Covariance.lean) alongside variance_congr; would also give a covariance_congr_right by covariance_comm.",
+      "Correlation-coefficient triangle/monotonicity: state ρ under sign of covariance, or the two-variance stddev triangle equality condition (perfect positive correlation ρ=+1) as the dual of the off-diagonal-cancellation boundary."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Normalised capstone for the multi-symbol AWGN second-order theory (`shannon-channel-coding-awgn-oq-02-oq-02`): packages the covariance Cauchy–Schwarz inequality and its sharp equality boundary through the **Pearson correlation coefficient**

    ρ[X, Y] = cov[X, Y] / (σ_X · σ_Y),   σ_X = √Var[X], σ_Y = √Var[Y].

Builds directly on the previously-proven full IFF `covariance_sq_eq_variance_mul_variance_iff_affine`.

## New results (4 theorems + 1 def, all VERIFIED 0 sorry / 0 axiom)

- `correlation` — def `cov[X,Y] / (√Var[X]·√Var[Y])`.
- `correlation_sq` — `ρ² = cov² / (Var[X]·Var[Y])` (algebraic bridge, `div_pow`/`mul_pow`/`Real.sq_sqrt`).
- `abs_correlation_le_one` — `|ρ| ≤ 1`, the covariance Cauchy–Schwarz inequality in normalised form. **No non-degeneracy hypothesis needed**: the division-by-zero convention absorbs the degenerate case; otherwise `ρ² ≤ 1` via `div_le_one` and `covariance_sq_le_variance_mul_variance`.
- `correlation_sq_eq_one_iff_affine` — `ρ² = 1 ⟺ ∃ a b, X =ᵐ a·Y + b` for non-degenerate `X, Y`.
- `abs_correlation_eq_one_iff_affine` — **the capstone**: `|ρ| = 1 ⟺` a.e. affine dependence (perfect ±correlation), the dimensionless restatement of the sharp Cauchy–Schwarz equality boundary.

Both non-degeneracy hypotheses are genuinely required for the `|ρ|=1` iff: a degenerate variable gives `ρ = 0 ≠ ±1` while the affine relation `X =ᵐ 0·Y + μ[X]` still holds.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingAWGNOQ02OQ02` — green (7743 jobs, 11s).
- 0 `sorry`, 0 `axiom`, no `native_decide`.
- File 679 → 750 lines; 28 → 32 theorems; meta counts updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)