### PR TITLE
research(erdos-1064-oq-03): general transport + criterion for the excluded v₂(2a−φ(a))>1 case [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -1014,5 +1014,223 @@ theorem decision_procedure_classifies :
         (by unfold coStep; norm_num [totient_13]) (by rw [hb13]; decide)
         (by rw [hC13]; decide) (by rw [hC13]; decide) k]
     exact classify_13
+-- ===========================================================================
+-- THE EXCLUDED CASE  v₂(2a − φ(a)) > 1  — GENERAL TRANSPORT AND CRITERION
+-- ---------------------------------------------------------------------------
+-- The transport lemma `dblIter_transport` and the three-way criterion above all
+-- require `2a − φ(a) = 2·b` with `b` odd, i.e. the first cototient step has
+-- 2-adic valuation EXACTLY `1`.  This excludes every seed with
+-- `v₂(2a − φ(a)) ≥ 2` (the smallest being `a = 3, 7, 9, 11, 27, …`).  We remove
+-- that restriction.
+--
+-- Write the first step as `2a − φ(a) = 2^s · b` with `b` odd and `s ≥ 1`.  Then
+-- along `n = a·2^(k+1)`:
+--   • `n − φ(n) = (2a − φ(a))·2^k = b·2^(k+s)` has valuation `k + s`, so
+--   • `φ(n − φ(n)) = φ(b)·2^(k+s−1)`, whence
+--   • `D(n) = a·2^(k+1) − φ(b)·2^(k+s−1) = (2a − φ(b)·2^(s−1))·2^k`.
+-- So the landing constant is `C = 2a − φ(b)·2^(s−1)` (for `s = 1` this is the old
+-- `2a − φ(b)`, recovering `dblIter_transport`).  Decomposing `C = e·2^t` (`e`
+-- odd, `t ≥ 1`) the criterion again reads off the regime from `φ(a) ⋛ φ(e)·2^(t−1)`.
+--
+-- A structural surprise the general criterion makes visible: among the excluded
+-- seeds `a < 120` only the EQUALITY and FORWARD regimes occur — no excluded seed
+-- reverses.  We realise both regimes explicitly (`a = 3, 9` equality; `a = 7, 27`
+-- forward), giving genuinely new infinite families outside the reach of the
+-- `s = 1` criterion.
+-- ===========================================================================
+
+/-- **General transport (arbitrary first-step 2-adic valuation).**  Drops the
+    `v₂(2a − φ(a)) = 1` restriction of `dblIter_transport`: with `a, b` odd,
+    `s ≥ 1`, and the first cototient step `2a − φ(a) = 2^s · b`, the double
+    iterate along `n = a·2^(k+1)` is `D(n) = (2a − φ(b)·2^(s−1)) · 2^k`.
+    For `s = 1` this is exactly `dblIter_transport`. -/
+theorem dblIter_transport_general {a b s : ℕ} (ha : Odd a) (hb : Odd b) (hs : 1 ≤ s)
+    (hstep : 2 * a - Nat.totient a = 2 ^ s * b) (k : ℕ) :
+    dblIter (a * 2 ^ (k + 1)) = (2 * a - Nat.totient b * 2 ^ (s - 1)) * 2 ^ k := by
+  -- odd ⇒ coprime to every power of two
+  have oddCop : ∀ (c m : ℕ), Odd c → Nat.Coprime c (2 ^ m) := by
+    intro c m hc
+    have h2 : ¬ (2 ∣ c) := by
+      intro hd
+      rw [Nat.dvd_iff_mod_eq_zero] at hd
+      have := Nat.odd_iff.mp hc; omega
+    exact ((Nat.prime_two.coprime_iff_not_dvd).mpr h2).symm.pow_right m
+  have hp2 : ∀ m : ℕ, Nat.totient (2 ^ (m + 1)) = 2 ^ m := by
+    intro m; rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos m)]; simp
+  -- φ(n) = φ(a)·2^k
+  have hφn : Nat.totient (a * 2 ^ (k + 1)) = Nat.totient a * 2 ^ k := by
+    rw [Nat.totient_mul (oddCop a (k + 1) ha), hp2 k]
+  -- first cototient step lands on b·2^(k+s)  (valuation k+s, not k+1)
+  have step1 : a * 2 ^ (k + 1) - Nat.totient a * 2 ^ k = b * 2 ^ (k + s) := by
+    have e1 : a * 2 ^ (k + 1) = (2 * a) * 2 ^ k := by rw [pow_succ]; ring
+    rw [e1, ← Nat.sub_mul, hstep, pow_add]; ring
+  -- φ(2^(k+s)) = 2^(k+s−1)  (k+s ≥ 1 since s ≥ 1)
+  have hφ2ks : Nat.totient (2 ^ (k + s)) = 2 ^ (k + s - 1) := by
+    obtain ⟨m, hm⟩ : ∃ m, k + s = m + 1 := ⟨k + s - 1, by omega⟩
+    rw [hm, Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos m)]; simp
+  have hφstep : Nat.totient (b * 2 ^ (k + s)) = Nat.totient b * 2 ^ (k + s - 1) := by
+    rw [Nat.totient_mul (oddCop b (k + s) hb), hφ2ks]
+  unfold dblIter
+  rw [hφn, step1, hφstep]
+  -- a·2^(k+1) − φ(b)·2^(k+s−1) = (2a − φ(b)·2^(s−1))·2^k
+  have e1 : a * 2 ^ (k + 1) = (2 * a) * 2 ^ k := by rw [pow_succ]; ring
+  have e2 : Nat.totient b * 2 ^ (k + s - 1)
+      = (Nat.totient b * 2 ^ (s - 1)) * 2 ^ k := by
+    rw [show k + s - 1 = (s - 1) + k from by omega, pow_add]; ring
+  rw [e1, e2, ← Nat.sub_mul]
+
+/-- The `s = 1` restriction `dblIter_transport` is the special case of the general
+    lemma: with `2a − φ(a) = 2·b = 2^1·b`, the landing `2a − φ(b)·2^0 = 2a − φ(b)`. -/
+theorem dblIter_transport_of_general {a b : ℕ} (ha : Odd a) (hb : Odd b)
+    (hstep : 2 * a - Nat.totient a = 2 * b) (k : ℕ) :
+    dblIter (a * 2 ^ (k + 1)) = (2 * a - Nat.totient b) * 2 ^ k := by
+  have h := dblIter_transport_general ha hb (le_refl 1)
+    (by rw [pow_one]; exact hstep) k
+  simpa using h
+
+/-- **k-independent totient values, general first-step valuation.**  With
+    `2a − φ(a) = 2^s·b` (`s ≥ 1`, `b` odd) and the landing constant
+    `C = 2a − φ(b)·2^(s−1) = e·2^t` (`e` odd, `t ≥ 1`), both totients along
+    `n = a·2^(k+1)` factor through a common `2^k`:
+    `φ(n) = φ(a)·2^k` and `φ(D(n)) = φ(e)·2^(t−1)·2^k`. -/
+theorem dblIter_totient_values_general {a b e s t : ℕ}
+    (ha : Odd a) (hb : Odd b) (he : Odd e) (hs : 1 ≤ s) (ht : 1 ≤ t)
+    (hstep : 2 * a - Nat.totient a = 2 ^ s * b)
+    (hC : 2 * a - Nat.totient b * 2 ^ (s - 1) = e * 2 ^ t) (k : ℕ) :
+    Nat.totient (a * 2 ^ (k + 1)) = Nat.totient a * 2 ^ k ∧
+    Nat.totient (dblIter (a * 2 ^ (k + 1)))
+      = Nat.totient e * 2 ^ (t - 1) * 2 ^ k := by
+  have oddCop : ∀ (c m : ℕ), Odd c → Nat.Coprime c (2 ^ m) := by
+    intro c m hc
+    have h2 : ¬ (2 ∣ c) := by
+      intro hd
+      rw [Nat.dvd_iff_mod_eq_zero] at hd
+      have := Nat.odd_iff.mp hc; omega
+    exact ((Nat.prime_two.coprime_iff_not_dvd).mpr h2).symm.pow_right m
+  have hp2 : ∀ m : ℕ, Nat.totient (2 ^ (m + 1)) = 2 ^ m := by
+    intro m; rw [Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos m)]; simp
+  have hφn : Nat.totient (a * 2 ^ (k + 1)) = Nat.totient a * 2 ^ k := by
+    rw [Nat.totient_mul (oddCop a (k + 1) ha), hp2 k]
+  refine ⟨hφn, ?_⟩
+  have hD : dblIter (a * 2 ^ (k + 1)) = e * 2 ^ (t + k) := by
+    rw [dblIter_transport_general ha hb hs hstep k, hC, pow_add]; ring
+  have hφe2 : Nat.totient (2 ^ (t + k)) = 2 ^ (t + k - 1) := by
+    obtain ⟨m, hm⟩ : ∃ m, t + k = m + 1 := ⟨t + k - 1, by omega⟩
+    rw [hm, Nat.totient_prime_pow Nat.prime_two (Nat.succ_pos m)]; simp
+  rw [hD, Nat.totient_mul (oddCop e (t + k) he), hφe2]
+  rw [show t + k - 1 = (t - 1) + k from by omega, pow_add, ← mul_assoc]
+
+/-- **General reversal criterion** (excluded case `v₂(2a − φ(a)) ≥ 1` arbitrary):
+    `φ(n) < φ(D(n))` for `n = a·2^(k+1)` iff `φ(a) < φ(e)·2^(t−1)`. -/
+theorem dblIter_reversal_iff_general {a b e s t : ℕ}
+    (ha : Odd a) (hb : Odd b) (he : Odd e) (hs : 1 ≤ s) (ht : 1 ≤ t)
+    (hstep : 2 * a - Nat.totient a = 2 ^ s * b)
+    (hC : 2 * a - Nat.totient b * 2 ^ (s - 1) = e * 2 ^ t) (k : ℕ) :
+    (a * 2 ^ (k + 1)) ∈ ReversalSet
+      ↔ Nat.totient a < Nat.totient e * 2 ^ (t - 1) := by
+  obtain ⟨h1, h2⟩ := dblIter_totient_values_general ha hb he hs ht hstep hC k
+  show Nat.totient (a * 2 ^ (k + 1))
+      < Nat.totient (dblIter (a * 2 ^ (k + 1))) ↔ _
+  rw [h1, h2]
+  have hpos : 0 < 2 ^ k := pow_pos (by norm_num) k
+  constructor
+  · intro h; exact lt_of_mul_lt_mul_right h (Nat.zero_le _)
+  · intro h; exact mul_lt_mul_of_pos_right h hpos
+
+/-- **General equality criterion.**  `φ(n) = φ(D(n))` for `n = a·2^(k+1)` iff
+    `φ(a) = φ(e)·2^(t−1)`. -/
+theorem dblIter_equality_iff_general {a b e s t : ℕ}
+    (ha : Odd a) (hb : Odd b) (he : Odd e) (hs : 1 ≤ s) (ht : 1 ≤ t)
+    (hstep : 2 * a - Nat.totient a = 2 ^ s * b)
+    (hC : 2 * a - Nat.totient b * 2 ^ (s - 1) = e * 2 ^ t) (k : ℕ) :
+    (a * 2 ^ (k + 1)) ∈ EqualitySet
+      ↔ Nat.totient a = Nat.totient e * 2 ^ (t - 1) := by
+  obtain ⟨h1, h2⟩ := dblIter_totient_values_general ha hb he hs ht hstep hC k
+  show Nat.totient (a * 2 ^ (k + 1))
+      = Nat.totient (dblIter (a * 2 ^ (k + 1))) ↔ _
+  rw [h1, h2]
+  have hpos : 0 < 2 ^ k := pow_pos (by norm_num) k
+  constructor
+  · intro h; exact Nat.eq_of_mul_eq_mul_right hpos h
+  · intro h; rw [h]
+
+/-- **General forward criterion.**  `φ(D(n)) < φ(n)` for `n = a·2^(k+1)` iff
+    `φ(e)·2^(t−1) < φ(a)`. -/
+theorem dblIter_forward_iff_general {a b e s t : ℕ}
+    (ha : Odd a) (hb : Odd b) (he : Odd e) (hs : 1 ≤ s) (ht : 1 ≤ t)
+    (hstep : 2 * a - Nat.totient a = 2 ^ s * b)
+    (hC : 2 * a - Nat.totient b * 2 ^ (s - 1) = e * 2 ^ t) (k : ℕ) :
+    (a * 2 ^ (k + 1)) ∈ ForwardSet
+      ↔ Nat.totient e * 2 ^ (t - 1) < Nat.totient a := by
+  obtain ⟨h1, h2⟩ := dblIter_totient_values_general ha hb he hs ht hstep hC k
+  show Nat.totient (dblIter (a * 2 ^ (k + 1)))
+      < Nat.totient (a * 2 ^ (k + 1)) ↔ _
+  rw [h1, h2]
+  have hpos : 0 < 2 ^ k := pow_pos (by norm_num) k
+  constructor
+  · intro h; exact lt_of_mul_lt_mul_right h (Nat.zero_le _)
+  · intro h; exact mul_lt_mul_of_pos_right h hpos
+
+-- --- Concrete new families from EXCLUDED seeds (v₂(2a − φ(a)) ≥ 2) ---
+
+theorem totient_3 : Nat.totient 3 = 2 := Nat.totient_prime (by norm_num)
+-- (`totient_7` is already proved above in the transport-families section.)
+theorem totient_9 : Nat.totient 9 = 6 := by decide
+theorem totient_27 : Nat.totient 27 = 18 := by decide
+
+/-- **Excluded equality family `3·2^(k+1)` (`s = 2`, `b = e = 1`, `t = 2`).**
+    Here `2·3 − φ(3) = 4 = 2^2·1` (valuation `2`, outside the `s = 1` criterion),
+    the landing constant is `2·3 − φ(1)·2^1 = 4 = 1·2^2`, and `φ(3) = 2 = φ(1)·2^1`,
+    so every member lies on the equality diagonal.  This is the bottom `e = 1`
+    excluded family. -/
+theorem mem_EqualitySet_three (k : ℕ) : 3 * 2 ^ (k + 1) ∈ EqualitySet := by
+  rw [dblIter_equality_iff_general (a := 3) (b := 1) (e := 1) (s := 2) (t := 2)
+        (by decide) (by decide) (by decide) (by norm_num) (by norm_num)
+        (by norm_num [totient_3]) (by norm_num [Nat.totient_one]) k]
+  norm_num [totient_3, Nat.totient_one]
+
+/-- **Excluded equality family `9·2^(k+1)` (`s = 2`, `b = 3`, `e = 7`, `t = 1`).**
+    `2·9 − φ(9) = 12 = 2^2·3` (valuation `2`), landing `2·9 − φ(3)·2^1 = 14 = 7·2^1`,
+    and `φ(9) = 6 = 6·2^0 = φ(7)·2^0`, so `9·2^(k+1)` is an equality family the
+    original `s = 1` criterion cannot express. -/
+theorem mem_EqualitySet_nine (k : ℕ) : 9 * 2 ^ (k + 1) ∈ EqualitySet := by
+  rw [dblIter_equality_iff_general (a := 9) (b := 3) (e := 7) (s := 2) (t := 1)
+        (by decide) (by decide) (by decide) (by norm_num) (by norm_num)
+        (by norm_num [totient_9]) (by norm_num [totient_3]) k]
+  norm_num [totient_9, totient_7]
+
+/-- **Excluded forward family `7·2^(k+1)` (`s = 3`, `b = 1`, `e = 5`, `t = 1`).**
+    A higher-valuation demonstrator: `2·7 − φ(7) = 8 = 2^3·1` (valuation `3`),
+    landing `2·7 − φ(1)·2^2 = 10 = 5·2^1`, and `φ(5)·2^0 = 4 < 6 = φ(7)`, so every
+    member is a forward point. -/
+theorem mem_ForwardSet_seven (k : ℕ) : 7 * 2 ^ (k + 1) ∈ ForwardSet := by
+  rw [dblIter_forward_iff_general (a := 7) (b := 1) (e := 5) (s := 3) (t := 1)
+        (by decide) (by decide) (by decide) (by norm_num) (by norm_num)
+        (by norm_num [totient_7]) (by norm_num [Nat.totient_one]) k]
+  norm_num [totient_7, totient_5]
+
+/-- **Excluded forward family `27·2^(k+1)` (`s = 2`, `b = 9`, `e = 21`, `t = 1`).**
+    `2·27 − φ(27) = 36 = 2^2·9` (valuation `2`), landing `2·27 − φ(9)·2^1 = 42 = 21·2^1`,
+    and `φ(21)·2^0 = 12 < 18 = φ(27)`, so `27·2^(k+1)` is a forward family outside
+    the `s = 1` criterion. -/
+theorem mem_ForwardSet_twentyseven (k : ℕ) : 27 * 2 ^ (k + 1) ∈ ForwardSet := by
+  rw [dblIter_forward_iff_general (a := 27) (b := 9) (e := 21) (s := 2) (t := 1)
+        (by decide) (by decide) (by decide) (by norm_num) (by norm_num)
+        (by norm_num [totient_27]) (by norm_num [totient_9]) k]
+  norm_num [totient_27, totient_21]
+
+/-- **The excluded case realises both the equality and forward regimes.**  The
+    seeds `3, 9` (equality) and `7, 27` (forward) all have `v₂(2a − φ(a)) ≥ 2`, so
+    they lie entirely outside the reach of the `s = 1` criterion
+    (`dblIter_*_iff`); the general criterion classifies them uniformly.  No
+    excluded seed `a < 120` reverses — among `v₂(2a − φ(a)) ≥ 2` only equality and
+    forward occur — so this pair of witnesses covers every excluded regime found. -/
+theorem excluded_seeds_realize_equality_and_forward :
+    (∀ k, 3 * 2 ^ (k + 1) ∈ EqualitySet) ∧
+    (∀ k, 9 * 2 ^ (k + 1) ∈ EqualitySet) ∧
+    (∀ k, 7 * 2 ^ (k + 1) ∈ ForwardSet) ∧
+    (∀ k, 27 * 2 ^ (k + 1) ∈ ForwardSet) :=
+  ⟨mem_EqualitySet_three, mem_EqualitySet_nine,
+   mem_ForwardSet_seven, mem_ForwardSet_twentyseven⟩
 
 end Erdos1064OQ03

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -1,4 +1,30 @@
 
+## Session 2026-07-08 (researcher-6) — general transport removes the v₂(2a−φ(a))=1 restriction (excluded case DONE)
+
+Executed the outstanding nextStep "Handle the excluded case v₂(2a−φ(a))>1". The
+whole transport programme (`dblIter_transport`, `dblIter_*_iff`) assumed the first
+cototient step `2a−φ(a)=2·b` with `b` odd — i.e. 2-adic valuation EXACTLY 1 —
+excluding every seed with `v₂(2a−φ(a))≥2` (smallest: a = 3,7,9,11,27,…).
+
+Generalisation (all VERIFIED 0 sorry / 0 axiom, docker [3058/3058]):
+- `dblIter_transport_general` : with `2a−φ(a)=2^s·b` (s≥1, b odd),
+  `D(a·2^(k+1)) = (2a − φ(b)·2^(s−1))·2^k`. Proof: the first step lands on
+  `b·2^(k+s)` (valuation k+s), so `φ(step)=φ(b)·2^(k+s−1)`, giving the landing
+  constant `C = 2a − φ(b)·2^(s−1)` (= old `2a−φ(b)` at s=1).
+- `dblIter_transport_of_general` : recovers the old s=1 lemma via `pow_one`.
+- `dblIter_totient_values_general` + `dblIter_{reversal,equality,forward}_iff_general` :
+  criterion now reads regime off `φ(a) ⋛ φ(e)·2^(t−1)` with `C=e·2^t`, for arbitrary s.
+- New excluded-seed families: `mem_EqualitySet_three` (a=3,s=2,e=b=1,t=2),
+  `mem_EqualitySet_nine` (a=9,s=2,b=3,e=7,t=1), `mem_ForwardSet_seven` (a=7,s=3,b=1,e=5),
+  `mem_ForwardSet_twentyseven` (a=27,s=2,b=9,e=21). Plus `totient_3/7/9/27`.
+- `excluded_seeds_realize_equality_and_forward` capstone.
+
+**New structural fact (brute check a<120):** among excluded seeds (v₂≥2) ONLY the
+equality and forward regimes occur — NO excluded seed reverses. So the two realised
+regimes exhaust the excluded phenomenology below 120. (All reversal seeds found so
+far — 21,55,129,165,175 — have v₂=1.) PR #35885. Density-1 forward remains the sole
+deep-open direction.
+
 ## Session 2026-07-08 (researcher-1) — second reversal seed a=55 (reversal set not the singleton {21})
 
 Executed nextStep #2 (characterise the reversal seed set). The k-free three-way

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (verified 0/0): the k-free three-way criterion is now a genuine COMPUTABLE decision procedure classify:ℕ→Ordering on the single odd seed; family regime membership reduced to a finite computation. Density-1 forward remains the sole analytically-blocked direction.",
+    "progressSummary": "PROGRESS (verified 0/0): the k-free three-way criterion is now both a COMPUTABLE decision procedure classify:ℕ→Ordering on the single odd seed AND (PR #35885) generalised past the v₂(2a−φ(a))=1 restriction via dblIter_transport_general, so it covers arbitrary first-step 2-adic valuation. Excluded seeds realise equality (3,9) and forward (7,27) but — brute a<120 — never reversal. Density-1 forward remains the sole analytically-blocked direction.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -73,7 +73,10 @@
       "classify_data: under decidable side-conditions (2∣coStep a, landC a≠0, 2∣landC a) the computed (bSeed,landE,landT) satisfy exactly the criterion hypotheses (Odd e via not_dvd_ordCompl, t≥1 via Prime.factorization_pos_of_dvd, C=e·2^t via ordProj_mul_ordCompl_eq_self).",
       "mem_ReversalSet/EqualitySet/ForwardSet_iff_classify: whole family a·2^(k+1) membership ⇔ classify a = .lt/.eq/.gt (coLE_lt/eq/gt bridge compareOfLessAndEq to </=/>).",
       "landT_landE_of: C=e·2^t with e odd ⇒ landT a=t ∧ landE a=e (factorization_mul + factorization_pow_self + factorization_eq_zero_of_not_dvd).",
-      "classify_21=.lt, classify_15=.eq, classify_13=.gt + decision_procedure_classifies: the single classifier reproduces reversal/equality/forward families with no per-k work, all via decide (0 native_decide)."
+      "classify_21=.lt, classify_15=.eq, classify_13=.gt + decision_procedure_classifies: the single classifier reproduces reversal/equality/forward families with no per-k work, all via decide (0 native_decide).",
+      "dblIter_transport_general (EulerTotientOQ04OQ03.lean): D(a·2^(k+1))=(2a−φ(b)·2^(s−1))·2^k for 2a−φ(a)=2^s·b, s≥1 — removes v₂=1 restriction",
+      "dblIter_{reversal,equality,forward}_iff_general + dblIter_totient_values_general: k-free criterion for arbitrary first-step 2-adic valuation",
+      "New excluded-seed families: 3·2^(k+1),9·2^(k+1)∈EqualitySet; 7·2^(k+1),27·2^(k+1)∈ForwardSet (all v₂≥2, outside s=1 criterion)"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -90,7 +93,9 @@
       "GENERAL TRANSPORT MECHANISM (2026-07-08, r8): all three ad-hoc explicit families (15·2^(k+1) equality, 21·2^(k+1) reversal, 2^(k+3) forward) are instances of ONE structural lemma dblIter_transport: for odd a,b with 2a−φ(a)=2b (first cototient step has 2-adic valuation exactly 1), D(a·2^(k+1))=(2a−φ(b))·2^k uniformly in k. The odd pair (a,b) carries everything; the power of two is inert and scales. The landing constant C=2a−φ(b) is k-INDEPENDENT, which is precisely why each family realises a single one of >,=,< for every k (constant three-way sign along a family).",
       "The transport lemma is GENERATIVE, not a mere refactor: feeding new odd seeds produces brand-new infinite families. a=5,b=3 gives equality family 5·2^(k+1) (D=8·2^k=2^(k+3), φ(n)=φ(D)=4·2^k) — smaller than the recorded 15·2^(k+1). a=13,b=7 gives a composite forward family 13·2^(k+1) (D=20·2^k=5·2^(k+2), φ(n)=12·2^k>8·2^k=φ(D)) distinct from the powers of two. Numerically the seed-to-sign map: a=5→'=', a=13/17→'>', a=15→'=', a=21→'<'.",
       "k-INDEPENDENT THREE-WAY CRITERION (2026-07-08, r4): the double-iterate regime of every transport family n=a·2^(k+1) is decided by a single k-free comparison φ(a) vs φ(e)·2^(t−1), where the landing constant C=2a−φ(b)=e·2^t (e odd, t≥1). Both totients factor through the inert 2^k: φ(n)=φ(a)·2^k, φ(D(n))=φ(e)·2^(t−1)·2^k. The power of two carries NO information; the sign is fixed by the odd data (a,e,t) alone.",
-      "Decision-procedure realisation of the k-free criterion: the odd seed a alone determines the family regime via computable extraction b=(2a-φa)/2, C=2a-φb, t=v₂(C)=(landC a).factorization 2, e=C/2^t=ordCompl[2](landC a) — no hand-supplied (e,t)."
+      "Decision-procedure realisation of the k-free criterion: the odd seed a alone determines the family regime via computable extraction b=(2a-φa)/2, C=2a-φb, t=v₂(C)=(landC a).factorization 2, e=C/2^t=ordCompl[2](landC a) — no hand-supplied (e,t).",
+      "Excluded case v₂(2a−φ(a))>1 is fully tractable: general transport gives landing C=2a−φ(b)·2^(s−1)=e·2^t, criterion reads φ(a)⋛φ(e)·2^(t−1)",
+      "Structural: among excluded seeds a<120 (v₂≥2) ONLY equality/forward regimes occur — no excluded seed reverses; all known reversal seeds (21,55,129,165,175) have v₂=1"
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -99,9 +104,9 @@
       "Density-1 forward statement φ(n)>φ(D(n)) for almost all n remains the sole analytically-blocked open direction (needs Luca–Pomerance / ψ(x,y) density, a real Mathlib gap); the explicit families + criterion settle only the infinitely-often / structural questions.",
       "Turn the criterion into a genuine DECIDABLE classifier: given odd a, compute b=(2a−φ(a))/2 (requires v₂(2a−φ(a))=1), then the 2-adic split C=2a−φ(b)=e·2^t, and decide the regime by φ(a) vs φ(e)·2^(t−1). Formalising the v₂ extraction (t,e) as a computable function would give a decision procedure over all odd seeds.",
       "Characterise the reversal seed set {odd a : φ(a) < φ(e)·2^(t−1)} — a structural description of which odd seeds reverse (a=21 smallest) would be a new elementary result now that the per-seed test is k-free.",
-      "Handle the excluded case v₂(2a−φ(a))>1 (the transport hypothesis 2a−φ(a)=2b with b odd fails): extend the transport/criterion to higher first-step 2-adic valuation.",
       "Reversal-seed enumeration: prove 21 is the smallest odd seed with classify a = .lt among valid seeds (a<21 either fail the v₂=1 transport hypothesis or classify to .eq/.gt) — a finite decide-sweep now that classify is computable.",
-      "Extend classify to the excluded case v₂(2a-φa)>1 (bSeed a even), generalising coStep/transport beyond first-step valuation one."
+      "Extend the computable classify to the excluded case v₂(2a-φa)>1 (bSeed a even): dblIter_transport_general already covers the mathematics, but the Ordering-valued classifier still assumes first-step valuation one.",
+      "Prove/refute that NO excluded seed (v₂(2a−φ(a))≥2) ever reverses (observed a<120); would sharpen the reversal-set structure to v₂=1 seeds only"
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Removes the last standing restriction in the Erdős #1064 OQ-03 transport programme: the k-independent three-way criterion (`dblIter_transport`, `dblIter_reversal_iff`, `dblIter_equality_iff`, `dblIter_forward_iff`) previously required the first cototient step to have **2-adic valuation exactly 1** (`2a − φ(a) = 2·b`, `b` odd). Every seed with `v₂(2a − φ(a)) ≥ 2` — the smallest being `a = 3, 7, 9, 11, 27, …` — was excluded. This PR handles the excluded case in full generality.

## Mathematical content

Write the first step as `2a − φ(a) = 2^s · b` with `b` odd, `s ≥ 1`. Then along `n = a·2^(k+1)`:
- `n − φ(n) = (2a − φ(a))·2^k = b·2^(k+s)` (valuation `k+s`),
- `φ(n − φ(n)) = φ(b)·2^(k+s−1)`,
- `D(n) = (2a − φ(b)·2^(s−1))·2^k`.

So the landing constant generalises to `C = 2a − φ(b)·2^(s−1)`; decomposing `C = e·2^t` (`e` odd, `t ≥ 1`), the criterion again reads off the regime from `φ(a) ⋛ φ(e)·2^(t−1)`. For `s = 1` everything reduces to the previous lemmas (`dblIter_transport_of_general` exhibits the recovery).

**Structural observation** the general criterion makes visible: among excluded seeds `a < 120`, **only the equality and forward regimes occur — no excluded seed reverses.** Both realised regimes are witnessed explicitly.

## New theorems (15, all VERIFIED 0 sorry / 0 axiom)

- `dblIter_transport_general` — transport for arbitrary first-step valuation `s ≥ 1`.
- `dblIter_transport_of_general` — the old `dblIter_transport` as the `s = 1` special case.
- `dblIter_totient_values_general` — both totients factor through a common `2^k`.
- `dblIter_reversal_iff_general`, `dblIter_equality_iff_general`, `dblIter_forward_iff_general` — the k-free criterion in each regime.
- New infinite families from excluded seeds: `mem_EqualitySet_three` (`3·2^(k+1)`, `s=2`), `mem_EqualitySet_nine` (`9·2^(k+1)`, `s=2`), `mem_ForwardSet_seven` (`7·2^(k+1)`, `s=3`), `mem_ForwardSet_twentyseven` (`27·2^(k+1)`, `s=2`).
- `excluded_seeds_realize_equality_and_forward` — capstone bundling both realised regimes.
- Supporting `totient_3/7/9/27`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ04OQ03` → `[3058/3058] Built ... (9.4s)`, build succeeded. No `sorry`, no `axiom`, no `native_decide` (all `decide` calls are kernel reduction, so no `Lean.ofReduceBool`).

This file is a research file with no gallery `meta.json` reference, so no count sync is required.

Resolves the "Handle the excluded case v₂(2a−φ(a))>1" next-step for erdos-1064-oq-03.