### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02-wip-01): (-2/n) residue table + mod-8 periodicity

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -499,6 +499,39 @@ theorem kronecker_two_periodic (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
   have h8 : (n + 8) % 8 = n % 8 := by omega
   rw [h8]
 
+/-- **Combined supplementary law `(-2/n)` at odd moduli (residue table).**
+    For odd positive `n`, `(-2/n) = 1` if `n ≡ 1, 3 (mod 8)` and `-1` if
+    `n ≡ 5, 7 (mod 8)`. This is the explicit `if`-form of the `-2` supplementary
+    character, completing the residue tables of all three nontrivial characters
+    mod `8` (the `-1` and `2` tables are `kronecker_neg_one_odd`,
+    `kronecker_two_odd`). It follows from `kronecker_eq_jacobi` and Mathlib's
+    `jacobiSym.at_neg_two` (`J(-2 | n) = χ₈' n`), unfolded via
+    `ZMod.χ₈'_nat_eq_if_mod_eight`. The residue classes `{1,3}` where `(-2/·) = 1`
+    are exactly those where the primitive character `χ₈'` is `+1`, distinct from
+    the `{1,7}` classes of `(2/·)`; the two mod-8 characters split the odd
+    residues differently. `sorry`-free, axiom-free. -/
+theorem kronecker_neg_two_odd (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker (-2) n = if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1 := by
+  rw [kronecker_eq_jacobi (-2) n hn hno, jacobiSym.at_neg_two (Nat.odd_iff.mpr hno),
+    ZMod.χ₈'_nat_eq_if_mod_eight, if_neg (show ¬ n % 2 = 0 by omega)]
+
+/-- **The denominator character `(-2/·)` is periodic mod 8.**
+    For odd positive `n`, `(-2/(n+8)) = (-2/n)`. Together with `kronecker_mul_right`
+    this exhibits the combined supplementary character — the value `(-2/·)` as the
+    odd denominator varies — as a Dirichlet character modulo `8`, completing the
+    periodicity data for all three nontrivial characters (`(-1/·)` mod 4,
+    `(2/·)` mod 8, and now `(-2/·)` mod 8). Note the period is `8`, not `4`: unlike
+    `(-1/·)` the combined character carries the mod-8 part `χ₈`, so it is *not*
+    periodic mod 4. Immediate from `kronecker_neg_two_odd`, since `(n+8) % 8 = n % 8`.
+    `sorry`-free, axiom-free. -/
+theorem kronecker_neg_two_periodic (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker (-2) ((n : ℤ) + 8) = kronecker (-2) (n : ℤ) := by
+  have e : ((n : ℤ) + 8) = ((n + 8 : ℕ) : ℤ) := by push_cast; ring
+  rw [e, kronecker_neg_two_odd (n + 8) (by omega) (by omega),
+    kronecker_neg_two_odd n hn hno]
+  have h8 : (n + 8) % 8 = n % 8 := by omega
+  rw [h8]
+
 /-- **The numerator character `(·/n)` depends only on `a mod n`.**
     For odd positive `n`, `(a/n) = (a % n / n)`: the Kronecker symbol at a fixed
     odd modulus `n`, viewed as a function of the numerator, factors through

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -1426,3 +1426,30 @@ with zero loss of intervening legitimate work). Full Docker chain build re-run t
 happens to carry your file in its diff can silently roll it back with no build-break
 signal (math PRs bypass Lean CI). The parent gallery axiom `riesz_lp_surjective`
 (import-direction re-export) remains the open follow-on; unchanged this session.
+
+## Session 28 (2026-07-08, researcher-3) — SOLVED/BLOCKED confirmation, no PR
+
+**Mode:** ASSESS + clobber-guard (cf. Session 27). **Outcome:** no session-sized work;
+verified the hard-won discharge is intact and the sole remaining item stays blocked.
+
+- **Clobber guard PASSED.** On `origin/main`: `extByZeroCLM_coeFn` is present in
+  `…Incomplete01Infra.lean`, and `riesz_lp_surjective_general`'s proof body (Synthesis.lean
+  384–422) has NO `sorry` — all four `riesz_general` maximality holes (Hmono/Hcons/HsigU/
+  Hglue) are filled with real Consistency/Ingredients/Gluing lemmas. Session 27's restore of
+  #35566 held; no repeat of the #35578 stale-base revert. My worktree base is byte-identical
+  to `origin/main` for both files.
+- **Synthesis chain is SOLVED** (0 real axioms / 0 real sorries across all
+  `CauchySchwarzIntegralLpDuality*.lean`; the grep hits are docstring prose like
+  "axiom elimination." / historical "sorry" notes). `riesz_lp_surjective_general` — the
+  exact statement of the parent axiom — is discharged and kernel-verified foundational-only.
+- **Sole remaining item is architecturally BLOCKED, not session-sized.** The parent axiom
+  `riesz_lp_surjective` still lives at `CauchySchwarzIntegralOQ01OQ01OQ02.lean:118`. It
+  cannot be replaced by `riesz_lp_surjective_general` in place: the parent is UPSTREAM of the
+  entire synthesis chain, so importing the discharge creates a cycle. True elimination needs
+  a layering refactor (hoist the proof into the parent, or re-route the parent's downstream
+  uses) — >1000 lines, BLOCKED. This is the same import-direction follow-on flagged since
+  S25/S26; unchanged. No cosmetic additions made (honesty: the file is saturated).
+
+**Recommendation:** stop re-serving this synthesis entry for ACT work — it is complete. The
+open parent-axiom elimination belongs to the parent gallery entry
+`cauchy-schwarz-integral-…-oq01oq01oq02` as a dedicated architectural task, not here.

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
@@ -117,3 +117,31 @@ line 304 `done` does nothing — not mine, untouched.
   moduli, re-prove `kronecker_mul_right` for the refined def.
 - Target 2: generalized reciprocity for fundamental discriminants (Gauss sums).
 Key API: jacobiSym.trichotomy / eq_one_or_neg_one / eq_zero_iff_not_coprime[NeZero].
+
+## Session 2026-07-08 (researcher-3) — (-2/·) supplementary character completed
+
+The three nontrivial supplementary characters mod 8 had asymmetric coverage:
+`(-1/·)` and `(2/·)` each had an explicit residue-table `if`-form
+(`kronecker_neg_one_odd`, `kronecker_two_odd`) AND a periodicity lemma
+(`kronecker_neg_one_periodic` mod 4, `kronecker_two_periodic` mod 8), but the
+combined character `(-2/·)` had only the abstract bridges (`= χ₈'`, `= (-1/·)·(2/·)`).
+Filled the gap (2 thm, VERIFIED 0/0, leanFile 676→709 L / 44→46 thm):
+
+- `kronecker_neg_two_odd (n hn hno)`: `(-2/n) = if n%8=1∨n%8=3 then 1 else -1`.
+  One-liner mirroring `kronecker_two_odd`: `kronecker_eq_jacobi` +
+  `jacobiSym.at_neg_two` (`J(-2|n)=χ₈' n`) + `ZMod.χ₈'_nat_eq_if_mod_eight` +
+  `if_neg` on the even branch. Note the `+1` classes are `{1,3} mod 8` (where χ₈'
+  is +1), DISTINCT from the `{1,7}` classes of `(2/·)` — the two mod-8 characters
+  split the odd residues differently.
+- `kronecker_neg_two_periodic (n hn hno)`: `(-2/(n+8)) = (-2/n)`. Mirrors
+  `kronecker_two_periodic`; period is 8 (NOT 4) because the character carries the
+  mod-8 part χ₈, so unlike `(-1/·)` it is not periodic mod 4.
+
+Every one of the three supplementary characters now has: value-table + periodicity
++ canonical-χ bridge — the complete Dirichlet-character data the Gauss-sum route
+(Target 2) consumes. Still open (unchanged, NOT session-sized): (1) wire `kronecker2`
+into the def for the classical symbol at even moduli; (2) generalized reciprocity
+via Gauss sums.
+
+*Build:* green first try (3058 jobs, 2.7s) — no SIGBUS this cycle. Pre-existing
+line-304 `done`-does-nothing linter warning is not mine (untouched).


### PR DESCRIPTION
## Summary

Completes the `(-2/·)` supplementary quadratic character mod 8 in `ElementaryQuadraticReciprocityOQ03OQ02.lean`, filling a real asymmetry: `(-1/·)` and `(2/·)` already had both an explicit residue-table `if`-form and a periodicity lemma, but the combined character `(-2/·)` had only the abstract bridges (`= χ₈'`, `= (-1/·)·(2/·)`).

## New theorems (2, VERIFIED 0 sorries / 0 axioms)

- **`kronecker_neg_two_odd`** — for odd positive `n`, `(-2/n) = 1` iff `n ≡ 1, 3 (mod 8)`, else `-1`. One-liner mirroring `kronecker_two_odd`: `kronecker_eq_jacobi` + `jacobiSym.at_neg_two` (`J(-2|n) = χ₈' n`) + `ZMod.χ₈'_nat_eq_if_mod_eight`. The `+1` classes `{1,3}` are distinct from the `{1,7}` classes of `(2/·)` — the two mod-8 characters split the odd residues differently.
- **`kronecker_neg_two_periodic`** — for odd positive `n`, `(-2/(n+8)) = (-2/n)`. Period is **8, not 4**: unlike `(-1/·)` the combined character carries the mod-8 part `χ₈`.

All three supplementary characters now carry the complete Dirichlet-character data — value table + periodicity + canonical-χ bridge — that the Gauss-sum route to generalized reciprocity (Target 2) consumes.

## Verification

Docker build green: `3058 jobs, 0 sorries, 0 axioms` (Mathlib v4.26). `leanFile` counts 676→709 L / 44→46 thm. Pre-existing line-304 `done`-linter warning is untouched.

## Scope (unchanged, still open)

1. Wire `kronecker2` into the definition for the classical symbol at even moduli.
2. Generalized reciprocity for arbitrary fundamental discriminants (Gauss sums).

🤖 Generated with [Claude Code](https://claude.com/claude-code)