### PR TITLE
research(szemeredi-regularity-oq-04): B-side energy increment mirror [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
@@ -486,4 +486,45 @@ theorem partitionEnergy_Aside_gain_of_irregular (G : SimpleGraph V)
     hdisj hA'R hcompR hne hAR' hB₀ hn₁ hn₂ hB (eps / 2) (by linarith) hdev'
   rwa [hunion] at hgain
 
+/-- **B-side irregularity ⇒ uniform energy jump** (second-coordinate mirror of
+    `partitionEnergy_Aside_gain_of_irregular`).  Symmetric to the A-side branch:
+    if a witness sub-part `B' ⊆ B` (with complement `B \ B'` inside `B`) deviates
+    from the whole part's density *measured against a fixed existing part*
+    `A₀ ∈ R` by at least `ε/2` — i.e. `|d(A₀, B') − d(A₀, B)| ≥ ε/2`, the datum the
+    `d(A, B')`-intermediate triangle decomposition of an irregular pair produces on
+    the `B`-coordinate — then refining `B` into `B'` and `B \ B'` raises
+    `partitionEnergy` by the uniform floor `(ε/2)² / (2n²) = ε² / (8n²)`.
+
+    Because `partitionEnergy_subpair_split_gain_uniform` splits the *first*
+    coordinate, the deviation is flipped onto that coordinate via the gallery's
+    `edgeDensity_comm` (`d(A₀, ·) = d(·, A₀)`); the split part `B` then plays the
+    role of `A₁ ∪ A₂` against the fixed partner `A₀`.  Together with
+    `partitionEnergy_Aside_gain_of_irregular` this closes *both* one-sided branches
+    of an irregular pair whose deviating coordinate is refined against a genuine
+    whole part of the partition. -/
+theorem partitionEnergy_Bside_gain_of_irregular (G : SimpleGraph V)
+    [DecidableRel G.Adj]
+    (R : Finset (Finset V)) (B A₀ B' : Finset V) (hB' : B' ⊆ B)
+    (hB'R : B' ∉ R) (hcompR : B \ B' ∉ R) (hne : B' ≠ B \ B') (hBR : B ∉ R)
+    (hA₀ : A₀ ∈ R)
+    (hn₁ : 1 ≤ (B'.card : ℚ)) (hn₂ : 1 ≤ ((B \ B').card : ℚ))
+    (hA : 1 ≤ (A₀.card : ℚ))
+    (eps : ℚ) (hε : 0 ≤ eps)
+    (hdev : |edgeDensity G A₀ B' - edgeDensity G A₀ B| ≥ eps / 2) :
+    partitionEnergy G (insert B R) +
+        (eps / 2) ^ 2 / (2 * (Fintype.card V : ℚ) ^ 2) ≤
+      partitionEnergy G (insert B' (insert (B \ B') R)) := by
+  have hunion : B' ∪ (B \ B') = B := Finset.union_sdiff_of_subset hB'
+  have hdisj : Disjoint B' (B \ B') := disjoint_sdiff_self_right
+  -- Flip the deviation onto the first coordinate (the one the split lemma refines)
+  -- via density symmetry, and present `B` as its disjoint two-piece union.
+  have hdev' : |edgeDensity G B' A₀ - edgeDensity G (B' ∪ (B \ B')) A₀| ≥ eps / 2 := by
+    rw [hunion, Szemeredi.Regularity.OQ01.edgeDensity_comm G B' A₀,
+      Szemeredi.Regularity.OQ01.edgeDensity_comm G B A₀]
+    exact hdev
+  have hBR' : B' ∪ (B \ B') ∉ R := by rwa [hunion]
+  have hgain := partitionEnergy_subpair_split_gain_uniform G R B' (B \ B') A₀
+    hdisj hB'R hcompR hne hBR' hA₀ hn₁ hn₂ hA (eps / 2) (by linarith) hdev'
+  rwa [hunion] at hgain
+
 end Szemeredi.RegularityOQ04Bridge

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -196,3 +196,47 @@ carries all the graph-theoretic content.
 - B-side branch via two-level refinement + 4-cell defect Cauchy–Schwarz.
 - Outer AFKS loop assembly feeding `afks_energy_iteration_count`.
 - Discharge `|A'|,|A\A'|≥1`, `∉R` side conditions from `|A'|≥ε|A|>0` + equipartition.
+
+## Session 2026-07-08 (Session 5) - B-side energy increment (whole-partner mirror)
+
+**Mode**: REVISIT (continuing branch szem-oq04-knowledge-s3)
+**Outcome**: progress (1 theorem VERIFIED 0/0)
+
+### What I Did
+- `partitionEnergy_Bside_gain_of_irregular`: the exact second-coordinate mirror of
+  `partitionEnergy_Aside_gain_of_irregular`. A witness sub-part `B' ⊆ B` whose
+  density against a fixed WHOLE part `A₀ ∈ R` deviates from the whole part's
+  density by `≥ ε/2` (`|d(A₀,B') − d(A₀,B)| ≥ ε/2`) realizes the uniform floor
+  `ε²/(8n²)` when `B` is refined into `B', B∖B'`.
+- Since `partitionEnergy_subpair_split_gain_uniform` splits the FIRST coordinate,
+  the deviation is flipped onto it with `edgeDensity_comm` (2 rewrites) so `B`
+  plays the `A₁∪A₂` role against partner `A₀`; then reuse the verified subpair
+  lemma verbatim. ~30 lines.
+
+### Key Findings
+- **The two whole-partner one-sided branches are now both discharged**
+  (A-side against whole B; B-side against whole A). This is the complete
+  "refine the deviating coordinate against a genuine whole part" toolkit.
+- **What still blocks full closure**: neither of the two single-triangle
+  decompositions of the witness deviation `|d(A',B')−d(A,B)|` gives *both* legs
+  against whole parts — each yields one whole-partner leg (GOOD) and one
+  sub-part-partner leg (BAD):
+    * through `d(A',B)`: A-leg `|d(A',B)−d(A,B)|` vs whole B (GOOD), B-leg
+      `|d(A',B')−d(A',B)|` vs sub-part A' (BAD).
+    * through `d(A,B')`: B-leg `|d(A,B')−d(A,B)|` vs whole A (GOOD), A-leg
+      `|d(A',B')−d(A,B')|` vs sub-part B' (BAD).
+  The obstruction is the mixed second difference (defect)
+  `d(A',B')−d(A',B)−d(A,B')+d(A,B)`; killing it is exactly the 4-cell defect
+  Cauchy–Schwarz. So full closure genuinely requires the simultaneous
+  refinement of BOTH coordinates (4 cells) + a variance/second-moment bound
+  `Σ wᵢ xᵢ² ≥ (Σwᵢ)μ² + w₀d²` — the hard analytic core, NOT reducible to
+  triangle inequalities. Confirmed dead-end for the elementary route.
+
+### Files Modified
+- proofs/Proofs/SzemerediRegularityOQ04Bridge.lean (+partitionEnergy_Bside_gain_of_irregular)
+
+### Next Steps
+- 4-cell simultaneous refinement: abstract variance atom bound
+  `Σ wᵢ xᵢ² − (Σwᵢ)μ² ≥ w₀·d²` (one atom of weight ≥ w₀ deviating ≥ d from mean),
+  then instantiate over the 4 sub-cells to get the true ε⁴ energy increment.
+- Outer AFKS loop assembly feeding `afks_energy_iteration_count`.

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -68,12 +68,15 @@ reconstructed (Mathlib `simp`-normal-form drift on `Matrix`/`Finset.sum` was the
 original obstacle — see parent file NOTE near `split_energy_excess_bound`).
 
 ## Next Action
-The quantitative energy-increment is now DONE and assembled (S3, researcher-7,
-PR #35839): one irregular-partner split realizes a uniform floor `δ²/(2n²)`
-(`partitionEnergy_single_split_gain_uniform`), which caps the AFKS refinement loop
-at an explicit `N ≤ 2n²/ε²` (`afks_energy_iteration_count`). Remaining:
-1. Wire `exists_irregular_pair` (SzemerediRegularity.lean:152) to auto-produce
-   `B₀ ∈ R` and `hdev` from an ε-irregular pair (currently hypotheses).
+Both whole-partner one-sided energy increments are now proved (S5, researcher-7):
+`partitionEnergy_Aside_gain_of_irregular` (refine A vs whole B) and its mirror
+`partitionEnergy_Bside_gain_of_irregular` (refine B vs whole A), each realizing the
+uniform floor `ε²/(8n²)`. Confirmed (S5) that no single-triangle decomposition of a
+witness deviation gives both legs against whole parts — the mixed second-difference
+(defect) obstructs it, so full closure needs the 4-cell simultaneous refinement +
+variance/second-moment bound (the hard analytic core). Remaining:
+1. Prove the abstract variance atom bound `Σ wᵢ xᵢ² − (Σwᵢ)μ² ≥ w₀·d²`, then
+   instantiate over the 4 sub-cells for the true ε⁴ energy increment.
 2. State the two-level AFKS conclusion (coarse ε-regular partition + refinement
    with all but `ε·C(ℓ,2)` pairs regular), dependent tolerance `E : ℕ → (0,1]`.
 3. Assemble the outer loop using `afks_energy_iteration_count` as the certificate.


### PR DESCRIPTION
## Summary

Adds `partitionEnergy_Bside_gain_of_irregular`, the second-coordinate mirror of the
already-merged `partitionEnergy_Aside_gain_of_irregular` (#35858). It completes the
"refine the deviating coordinate against a genuine whole part" toolkit for **both**
coordinates of an irregular pair in the AFKS energy-increment argument.

**Statement.** A witness sub-part `B' ⊆ B` whose density against a fixed *existing*
whole part `A₀ ∈ R` deviates from the whole part's density by `≥ ε/2`
(`|d(A₀,B') − d(A₀,B)| ≥ ε/2`) realizes the uniform energy floor `ε²/(8n²)` when `B`
is refined into `B', B∖B'`:

```
partitionEnergy G (insert B R) + (ε/2)²/(2n²) ≤ partitionEnergy G (insert B' (insert (B∖B') R))
```

**Proof.** Since `partitionEnergy_subpair_split_gain_uniform` splits the *first*
coordinate, the deviation is flipped onto it via the gallery's `edgeDensity_comm`
(2 rewrites); `B` then plays the `A₁∪A₂` role against the fixed partner `A₀`, and the
verified subpair lemma discharges the rest. ~30 lines, 0 sorry / 0 axiom.

## Verification

`docker-build Proofs.SzemerediRegularityOQ04Bridge`: green (7748 jobs). No new
`sorry`/`axiom`; chains only through previously-verified lemmas.

## Context / next

Confirmed this session that no single-triangle decomposition of the witness deviation
`|d(A',B')−d(A,B)|` yields *both* legs against whole parts — the mixed second
difference (defect) obstructs it. Full closure therefore needs the 4-cell
simultaneous refinement + a variance/second-moment bound (`Σ wᵢxᵢ² ≥ (Σwᵢ)μ² + w₀d²`),
the genuine analytic core; recorded in `knowledge.md` as the next target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)