### PR TITLE
research(minpoly-charpoly-oq-02): counterexample — diagonalizable M,N with non-diagonalizable product [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
@@ -329,4 +329,52 @@ theorem commute_of_commonDiagonalizer {M N P : Matrix n n K}
     _ = P * (P⁻¹ * (N * M) * P) * P⁻¹ := by rw [hconj]
     _ = N * M := hcancel _
 
+/-! ### Necessity of the common-diagonalizer hypothesis
+
+`mul_of_commonDiagonalizer` requires `M` and `N` to share a single diagonalizer `P`;
+mere diagonalizability of each is not enough.  Explicit witnesses over `ℚ`: the swap
+`M = !![0,1;1,0]` (diagonalizable, eigenvalues `±1`) and the diagonal `N = !![1,0;0,-1]`.
+They do not commute, so by `commute_of_commonDiagonalizer` they share no diagonalizer —
+and indeed their product `M*N = !![0,-1;1,0]` is a rational `90°` rotation with
+eigenvalues `±i ∉ ℚ`, hence not diagonalizable over `ℚ`.  (The proof needs no eigenvalue
+theory: trace and determinant are similarity invariants, so a diagonal conjugate `D` of
+`M*N` would satisfy `D₀₀ + D₁₁ = 0` and `D₀₀·D₁₁ = 1`, forcing `D₀₀² = -1`, impossible
+over an ordered field.) -/
+theorem exists_diagonalizable_mul_not_diagonalizable :
+    ∃ M N : Matrix (Fin 2) (Fin 2) ℚ,
+      M.IsDiagonalizable ∧ N.IsDiagonalizable ∧ ¬ (M * N).IsDiagonalizable := by
+  refine ⟨!![0, 1; 1, 0], !![1, 0; 0, -1], ?_, ?_, ?_⟩
+  · -- `M` (the swap) is diagonalized by `P = !![1,1;1,-1]`.
+    refine ⟨!![1, 1; 1, -1], ?_, ?_⟩
+    · rw [Matrix.isUnit_iff_isUnit_det, Matrix.det_fin_two_of]; norm_num
+    · have hinv : (!![1, 1; 1, -1] : Matrix (Fin 2) (Fin 2) ℚ)⁻¹ = !![1/2, 1/2; 1/2, -1/2] :=
+        Matrix.inv_eq_right_inv (by rw [Matrix.one_fin_two]; norm_num [Matrix.mul_fin_two])
+      rw [hinv, show
+        (!![1/2, 1/2; 1/2, -1/2] : Matrix (Fin 2) (Fin 2) ℚ) * !![0, 1; 1, 0] * !![1, 1; 1, -1]
+          = !![1, 0; 0, -1] by norm_num [Matrix.mul_fin_two]]
+      intro i j hij
+      fin_cases i <;> fin_cases j <;> simp_all
+  · -- `N` is diagonal, hence diagonalizable.
+    refine Matrix.IsDiagonalizable.of_isDiag ?_
+    intro i j hij
+    fin_cases i <;> fin_cases j <;> simp_all
+  · -- `M*N = !![0,-1;1,0]` is not diagonalizable over `ℚ`.
+    rintro ⟨P, hP, hdiag⟩
+    have hMN : (!![0, 1; 1, 0] : Matrix (Fin 2) (Fin 2) ℚ) * !![1, 0; 0, -1] = !![0, -1; 1, 0] := by
+      norm_num [Matrix.mul_fin_two]
+    rw [hMN] at hdiag
+    set D := P⁻¹ * (!![0, -1; 1, 0] : Matrix (Fin 2) (Fin 2) ℚ) * P with hDdef
+    have htr : Matrix.trace D = 0 := by
+      rw [hDdef, Matrix.trace_conj' hP]; norm_num [Matrix.trace_fin_two_of]
+    have hdet : Matrix.det D = 1 := by
+      rw [hDdef, Matrix.det_conj' hP]; norm_num [Matrix.det_fin_two_of]
+    have h01 : D 0 1 = 0 := hdiag (by decide)
+    have h10 : D 1 0 = 0 := hdiag (by decide)
+    rw [Matrix.trace_fin_two] at htr
+    have hprod : D 0 0 * D 1 1 = 1 := by
+      rw [Matrix.det_fin_two, h01, h10] at hdet; simpa using hdet
+    have hD11 : D 1 1 = -D 0 0 := by linarith
+    rw [hD11] at hprod
+    nlinarith [sq_nonneg (D 0 0), hprod]
+
 end MinpolyCharpolyOQ02Incomplete01

--- a/research/problems/minpoly-charpoly-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/minpoly-charpoly-oq-02-incomplete-01/knowledge.md
@@ -1,0 +1,28 @@
+
+## Session 2026-07-08 (researcher-1) — counterexample: diagonalizable M,N, non-diagonalizable product
+
+Executed nextStep #2 (necessity of the common-diagonalizer hypothesis in
+mul_of_commonDiagonalizer). Added to Proofs/MinpolyCharpolyOQ02Incomplete01.lean
+(VERIFIED 0 axioms / 0 sorries, host lake env lean):
+- exists_diagonalizable_mul_not_diagonalizable : ∃ M N : Matrix (Fin 2)(Fin 2) ℚ,
+  M.IsDiagonalizable ∧ N.IsDiagonalizable ∧ ¬(M*N).IsDiagonalizable.
+  Witnesses: M=!![0,1;1,0] (swap, eigenvalues ±1, diagonalized by P=!![1,1;1,-1],
+  P⁻¹=!![1/2,1/2;1/2,-1/2]), N=!![1,0;0,-1] (diagonal → of_isDiag). M*N=!![0,-1;1,0]
+  (90° rotation, eigenvalues ±i∉ℚ) not diagonalizable. First NEGATIVE result in this
+  all-positive-closure-law file.
+  Non-diag proof (no eigenvalue theory): rintro ⟨P,hP,hdiag⟩; trace/det similarity-
+  invariant via Matrix.trace_conj'/det_conj' (h:IsUnit M)(N):tr/det(M⁻¹NM)=tr/det N;
+  D:=P⁻¹(MN)P diagonal ⟹ trace_fin_two D=D00+D11=0, det_fin_two D=D00·D11=1 (off-diag
+  h01/h10 via hdiag(by decide)); D11=-D00 ⟹ D00·(-D00)=1 ⟹ D00²=-1, nlinarith[sq_nonneg].
+
+★Lean recipe for concrete 2×2 ℚ matrix proofs: `Matrix.isUnit_iff_isUnit_det`+
+`Matrix.det_fin_two_of`+norm_num for IsUnit; `Matrix.inv_eq_right_inv (by rw[Matrix.
+one_fin_two];norm_num[Matrix.mul_fin_two])` to pin P⁻¹ (rw one_fin_two FIRST — norm_num
+won't rewrite RHS `1`); product equalities `norm_num [Matrix.mul_fin_two]`; IsDiag goals
+`intro i j hij; fin_cases i <;> fin_cases j <;> simp_all`; trace/det_fin_two(_of).
+★Host-verify needs local deps built first: `lake env lean -o .lake/build/lib/lean/Proofs/
+MinpolyCharpoly.olean Proofs/MinpolyCharpoly.lean` then OQ02 then the file (imports local
+Proofs.* not just Mathlib). No gallery meta on this research file. File 332→380, 18 thms.
+
+REMAINING: nextStep #1 (HARD half: commuting diagonalizable ⟹ common diagonalizer, needs
+eigenspace decomposition) genuinely hard, not session-sized.


### PR DESCRIPTION
## Summary

Adds the **necessity** companion (nextStep #2) to `MinpolyCharpolyOQ02Incomplete01.lean`'s
diagonalizability closure laws: `mul_of_commonDiagonalizer` needs `M`, `N` to share a
single diagonalizer — mere diagonalizability of each is **not** enough.

## Result

`exists_diagonalizable_mul_not_diagonalizable`:
```
∃ M N : Matrix (Fin 2) (Fin 2) ℚ,
  M.IsDiagonalizable ∧ N.IsDiagonalizable ∧ ¬ (M * N).IsDiagonalizable
```
Witnesses over `ℚ`:
- `M = !![0,1;1,0]` — the swap, eigenvalues `±1`, diagonalized by `P = !![1,1;1,-1]`.
- `N = !![1,0;0,-1]` — diagonal, hence diagonalizable.
- `M*N = !![0,-1;1,0]` — a `90°` rotation with eigenvalues `±i ∉ ℚ`, **not** diagonalizable
  over `ℚ`. (`M`, `N` don't commute, so `commute_of_commonDiagonalizer` already says they
  share no diagonalizer.)

This is the file's first **negative** (non-diagonalizability) result, complementing its
positive closure laws (`conj`/`smul`/`neg`/`transpose`/`inv`/`pow`/`aeval`/…).

## Proof note

Non-diagonalizability needs **no** eigenvalue theory. Trace and determinant are
similarity invariants (`Matrix.trace_conj'`, `Matrix.det_conj'`), so a hypothetical
diagonal conjugate `D` of `M*N` would satisfy `D₀₀ + D₁₁ = 0` and `D₀₀·D₁₁ = 1`, forcing
`D₀₀² = -1` — impossible over the ordered field `ℚ` (`nlinarith` + `sq_nonneg`).

## Verification

- Host-verified via `lake env lean` (built the local `MinpolyCharpoly` / `…OQ02`
  dependency oleans first). **0 errors, 0 sorries.** Docker builds are currently
  unreliable (shared-volume corruption).
- `#print axioms exists_diagonalizable_mul_not_diagonalizable` =
  `{propext, Classical.choice, Quot.sound}` only. **0 axioms.**
- File: 332 → 380 lines. No gallery meta references this research file, so no sync.

The remaining nextStep #1 (the *hard* half of simultaneous diagonalization: commuting
diagonalizable matrices admit a common diagonalizer, via eigenspace decomposition)
remains genuinely hard and out of session scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)