### PR TITLE
research(law-of-cosines-oq-03-oq-03): axiom-reduction sketch — the defect field is derivable (7→6)

### DIFF
--- a/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
+++ b/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
@@ -64,3 +64,34 @@ new theorems introduce none). Key steps: `linarith` on the defect; `linear_combi
 - `proofs/Proofs/LawOfCosinesOQ03OQ03.lean` (Part 7, +~35 lines, verified)
 - `src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json` (counts + contribution)
 - `src/data/research/problems/law-of-cosines-oq-03-oq-03.json` (counts + knowledge)
+
+## Session 2026-07-08 (researcher-1) — axiom-reduction assessment (no PR)
+
+Problem is COMPLETE (0 sorries, 20 theorems). Investigated nextStep #1 (reduce the 7
+structure-encoded axioms in `HyperbolicTriangle`). Findings:
+
+- The three second laws lawA/lawB/lawC each involve a DIFFERENT side (cosh a / cosh b /
+  cosh c), so they are mutually independent — deriving "three seconds from one first law"
+  requires ADDING the first law of cosines + sine rule apparatus (a large derivation, no
+  net axiom saving 3→3).
+
+- **BETTER target found: the `defect` field (A+B+C < π) is REDUNDANT** — derivable from
+  the other axioms, so removing it reduces 7→6. Concrete argument (verified on paper,
+  NOT yet formalized):
+  1. From ha/hb/hc (sides > 0) get cosh a,b,c > 1 via `Real.one_lt_cosh` (1<cosh x ↔ x≠0).
+  2. cosh_c_eq + cosh c > 1 ⟹ (cos C + cos A cos B)/(sin A sin B) > 1 ⟹ **cos C + cos(A+B)
+     > 0** (rearrange, sin A sin B>0; cos(A+B)=cosAcosB−sinAsinB). Similarly cos A+cos(B+C)
+     > 0 and cos B+cos(A+C) > 0 (need cosh_a_gt_one/cosh_b_gt_one — only cosh_c_gt_one
+     exists; add the two analogues, trivial from one_lt_cosh).
+  3. sum-to-product `Real.cos_add_cos`: each becomes 2·cos(S/2)·cos(δ/2) > 0 where
+     S=A+B+C. So cos(S/2) ≠ 0 and the three cos(δ/2) share its sign.
+  4. Suppose cos(S/2) < 0 (S/2 ∈ (π/2,3π/2)). Then all three cos(δ/2)<0; from the C-one,
+     cos((C−A−B)/2)<0 forces A+B−C>π (since C<π, A,B>0 bound the range); symmetrically
+     B+C−A>π. Add: 2B>2π ⟹ B>π, contradicting hB_lt. So cos(S/2)>0 ⟹ S/2<π/2 ⟹ **S<π**.
+  5. Replace `defect` field with theorem `defect_of_laws`, rewire angle_sum_lt_pi /
+     area_positive / equilateral_angle_lt_pi_third (currently use t.defect).
+
+  Est. 60–100 lines of delicate trig (cos sign/monotonicity on intervals) + refactor.
+  Genuine 7→6 structure-axiom reduction. Deferred (hard, needs fresh budget); left this
+  sketch so it's a clean next win. Other nextSteps (SAS/ASA congruence, area-defect
+  integral) are also substantial.


### PR DESCRIPTION
## Summary

Knowledge-only note (no Lean change) documenting a concrete **axiom-reduction** path for
`LawOfCosinesOQ03OQ03.lean`, which the problem is otherwise COMPLETE on (0 sorries, 20
theorems, 7 structure-encoded axioms).

## Finding

The nextStep "derive three second laws from one first law" gives no net saving (the three
second laws each involve a *different* side, so they're independent — reducing them needs
adding the first-law/sine-rule apparatus, 3→3).

**A cleaner target:** the `HyperbolicTriangle.defect` field (`A+B+C < π`) is **redundant**
— derivable from the other axioms, so removing it reduces the structure-encoded axiom
count 7→6. The paper argument (not yet formalized):

1. Sides `> 0` ⟹ `cosh a,b,c > 1` (`Real.one_lt_cosh`).
2. Each `cosh_·_eq` + `cosh · > 1` ⟹ `cos X + cos(Y+Z) > 0` for the three vertex
   permutations.
3. Sum-to-product (`Real.cos_add_cos`): each is `2·cos(S/2)·cos(δ/2) > 0`, `S = A+B+C`.
4. If `cos(S/2) < 0`, the three factors force `A+B−C > π` and `B+C−A > π`, adding to
   `B > π` — contradicting `hB_lt`. Hence `cos(S/2) > 0` ⟹ `S < π`.
5. Replace the field with a theorem and rewire `angle_sum_lt_pi` / `area_positive` /
   `equilateral_angle_lt_pi_third`.

Estimated ~60–100 lines of delicate trig plus a small refactor — a genuine 7→6 reduction,
deferred here as a clear next win with the full sketch recorded in the problem's
`knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)