### PR TITLE
Fix: correct technique/date misattribution (algebraic-numbers-countable-oq-02)

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02.lean
@@ -8,11 +8,18 @@ import Proofs.CantorDiagonalization
 import Proofs.AlgebraicNumbersCountable
 
 /-
-# ℝ is Uncountable: Cantor's Diagonal Argument (1874)
+# ℝ is Uncountable: Cantor's Cardinality Argument (ℵ₀ < 2^ℵ₀ = 𝔠)
 
 ## Open Question (algebraic-numbers-countable-oq-02)
 
-Prove in Lean 4 that ℝ is uncountable (Cantor's diagonal argument, completing the 1874 paper).
+Prove in Lean 4 that ℝ is uncountable via cardinal arithmetic (#ℝ = 𝔠 = 2^ℵ₀ > ℵ₀).
+
+Note on technique/history: this file proves ¬Countable ℝ by *cardinal arithmetic*,
+not by a diagonal digit construction. Cantor's original 1874 paper established the
+uncountability of ℝ via the *nested-interval* method (see sibling entry
+algebraic-numbers-countable-oq-02-oq-02); the *diagonal* digit argument came later,
+in 1891 (see sibling CantorDiagonalization.lean). The only "diagonal" content here is
+the abstract cardinal gap ℵ₀ < 2^ℵ₀ (Cantor's theorem, `Cardinal.cantor`).
 
 ## What This Proves
 
@@ -24,9 +31,10 @@ Prove in Lean 4 that ℝ is uncountable (Cantor's diagonal argument, completing 
 
 ## Proof Strategy
 
-**Cantor's diagonal argument** proves ℵ₀ < 2^ℵ₀ (no surjection from a set to its power set).
-Since #ℝ = 𝔠 = 2^ℵ₀ (Cardinal.mk_real) and 𝔠 > ℵ₀ (Cardinal.aleph0_lt_continuum),
-no injection ℝ → ℕ exists, i.e., ℝ is uncountable.
+**Cardinal arithmetic** (not a diagonal digit construction). Since #ℝ = 𝔠 = 2^ℵ₀
+(Cardinal.mk_real) and 𝔠 > ℵ₀ (Cardinal.aleph0_lt_continuum), no injection ℝ → ℕ
+exists, i.e., ℝ is uncountable. The strict gap ℵ₀ < 2^ℵ₀ is **Cantor's theorem**
+(the abstract form of the diagonal argument: no surjection from a set to its power set).
 
 **Connection to CantorDiagonalization**: The abstract gap ℵ₀ < 2^ℵ₀ (Cardinal.cantor ℵ₀)
 is the same theorem as no surjection ℕ → BinarySeq exists (CantorDiagonalization.lean).
@@ -40,9 +48,13 @@ real numbers are transcendental.
 ## Historical Note
 
 Cantor's 1874 paper "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen"
-proved two results:
+proved two results (using the *nested-interval* method, not the later diagonal argument):
 - The algebraic numbers are countable
 - The real numbers are uncountable
+
+The famous *diagonal* digit argument is from Cantor's 1891 paper. This formalization
+takes a third route — pure cardinal arithmetic via Mathlib's continuum bridge — which is
+logically equivalent to both but mechanically shortest.
 
 This established that there are "more" transcendental numbers than algebraic ones in a precise
 cardinality sense, even though transcendental numbers were historically much harder to identify
@@ -105,8 +117,9 @@ theorem reals_uncountable : ¬ Countable ℝ := reals_not_countable
 
 /-- **No surjection ℕ → ℝ exists.**
 
-    This is the direct statement of Cantor's diagonal argument:
-    no enumeration of real numbers can be complete.
+    This is the classical conclusion of Cantor's uncountability theorem:
+    no enumeration of real numbers can be complete. (Here it is obtained from
+    the cardinality bound above, not from a diagonal digit construction.)
 
     Proof: A surjection f : ℕ → ℝ would make ℝ countable (since ℕ is countable
     and the image of a countable set under a surjection is countable). But ℝ is

--- a/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "algebraic-numbers-countable-oq-02",
-  "title": "ℝ is Uncountable: Cantor's Diagonal Argument (1874)",
+  "title": "ℝ is Uncountable: Cantor's Cardinality Argument (ℵ₀ < 2^ℵ₀ = 𝔠)",
   "slug": "algebraic-numbers-countable-oq-02",
-  "description": "Proves that ℝ is uncountable via Cantor's diagonal argument, completing the 1874 paper. The main result ¬Countable ℝ follows from #ℝ = 𝔠 = 2^ℵ₀ > ℵ₀. Derives that: (1) no surjection ℕ → ℝ exists, (2) transcendental reals are uncountable. 0 sorries, 0 axioms.",
+  "description": "Proves ¬Countable ℝ via cardinal arithmetic: #ℝ = 𝔠 = 2^ℵ₀ > ℵ₀ (Mathlib bridge Cardinal.mk_real / Cardinal.aleph0_lt_continuum). Derives that (1) no surjection ℕ → ℝ exists, and (2) the transcendental reals are uncountable. The abstract diagonal content is Cantor's theorem ℵ₀ < 2^ℵ₀ (Cardinal.cantor). Cantor's 1874 paper established uncountability via nested intervals (see sibling oq-02-oq-02); the 1891 diagonal digit construction is the sibling CantorDiagonalization entry. 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cantor%27s_diagonal_argument",


### PR DESCRIPTION
## Fix

The entry `algebraic-numbers-countable-oq-02` was titled **"ℝ is Uncountable: Cantor's Diagonal Argument (1874)"**, misattributing both the technique and the date.

## Evidence

**Wrong technique**: the headline `reals_not_countable : ¬ Countable ℝ` is proved by **cardinal arithmetic** (`Cardinal.mk_real`, `Cardinal.aleph0_lt_continuum`, `Cardinal.mk_le_aleph0`), not by a diagonal digit construction. The only "diagonal" content is §5's `cantor_diagonal_gap := Cardinal.cantor ℵ₀` (the abstract ℵ₀ < 2^ℵ₀).

**Wrong date**: Cantor's diagonal argument is **1891**. The **1874** paper used the **nested-interval** method — as the sibling entry `algebraic-numbers-countable-oq-02-oq-02` correctly states. The old framing directly contradicted that sibling.

## Changes (metadata + docstrings only)

**Before**: title `"ℝ is Uncountable: Cantor's Diagonal Argument (1874)"`; description `"...via Cantor's diagonal argument, completing the 1874 paper..."`; Lean docstring header repeating the same.

**After**: title `"ℝ is Uncountable: Cantor's Cardinality Argument (ℵ₀ < 2^ℵ₀ = 𝔠)"`; description and Lean docstring reframed around the actual cardinal-arithmetic mechanism, with the correct 1874 (nested intervals) / 1891 (diagonal) history and pointers to the two sibling entries.

No status/badge/count changes: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0` remain accurate.

## Validation

- `meta.json` — valid JSON.
- Lean edit is **comment-only** (`git diff` confirms only docstring prose changed), so compilation is unaffected. (Docker build in this cycle hit the recurring SIGBUS/exit-135 memory-starvation transient in the *untouched* dependency files `CantorDiagonalization`/`AlgebraicNumbersCountable`, unrelated to this change.)

Closes #35874

---
Automated fix by lean-mechanic agent.