### PR TITLE
audit: sync stale OQ06 companion record in abel-ruffini-oq-04-oq-02-oq-02 (now 0-sorry)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -72,7 +72,7 @@
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
     "lineCount": 220,
-    "assumptions": "0 assumptions. 0 `axiom` declarations, 0 sorries, and no `native_decide` in the presented file — fully kernel-checked. The A₄ case (previously discharged by `native_decide` on the derived series of S₄, which trusted `Lean.ofReduceBool`) is now a structural Klein-four argument: the commutator subgroup of A₄ lands in `V₄ = {g | g² = 1}`, which is abelian, so the second derived subgroup is trivial. The small cases use `inferInstance` (A₀, A₁), `isSolvable_of_comm` + `decide` (A₂, A₃), and the V₄ argument (A₄); the large cases use the exact-sequence reduction with Mathlib's `Equiv.Perm.not_solvable`. (The companion file `AbelRuffiniOQ04OQ02OQ02OQ06.lean` on the derived-length gap still carries 1 sorry; see `additionalFiles`.)",
+    "assumptions": "0 assumptions. 0 `axiom` declarations, 0 sorries, and no `native_decide` in the presented file — fully kernel-checked. The A₄ case (previously discharged by `native_decide` on the derived series of S₄, which trusted `Lean.ofReduceBool`) is now a structural Klein-four argument: the commutator subgroup of A₄ lands in `V₄ = {g | g² = 1}`, which is abelian, so the second derived subgroup is trivial. The small cases use `inferInstance` (A₀, A₁), `isSolvable_of_comm` + `decide` (A₂, A₃), and the V₄ argument (A₄); the large cases use the exact-sequence reduction with Mathlib's `Equiv.Perm.not_solvable`. (The companion file `AbelRuffiniOQ04OQ02OQ02OQ06.lean` on the derived-length gap is now fully proved with 0 sorries; see `additionalFiles`.)",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
     "definitionCount": 1,
@@ -267,12 +267,12 @@
     "additionalFiles": [
       {
         "path": "Proofs/AbelRuffiniOQ04OQ02OQ02OQ06.lean",
-        "lineCount": 244,
+        "lineCount": 232,
         "theorems": 11,
         "definitions": 0,
         "axioms": 0,
-        "sorries": 1,
-        "description": "OQ-04-OQ-02-OQ-02-OQ-06: Derived series length gap — A₄ has derived length exactly 2 (a4_derived1_ne_bot + a4_derived2_eq_bot) while A₅ is perfect and never reaches ⊥ (a5_perfect + a5_derived_never_bot). Quantifies the phase transition at n = 5 of the parent's solvability classification. Namespace AbelRuffiniOQ04OQ02OQ02OQ06; imports parent Proofs.AbelRuffiniOQ04OQ02OQ02. 1 remaining sorry in a4_derived2_eq_bot (commutator A4 is abelian)."
+        "sorries": 0,
+        "description": "OQ-04-OQ-02-OQ-02-OQ-06: Derived series length gap — A₄ has derived length exactly 2 (a4_derived1_ne_bot + a4_derived2_eq_bot) while A₅ is perfect and never reaches ⊥ (a5_perfect + a5_derived_never_bot). Quantifies the phase transition at n = 5 of the parent's solvability classification. Namespace AbelRuffiniOQ04OQ02OQ02OQ06; imports parent Proofs.AbelRuffiniOQ04OQ02OQ02. Fully proved (0 sorries) — the former a4_derived2_eq_bot sorry was discharged via the Klein-four argument in #29166."
       }
     ]
   },


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: abel-ruffini-oq-04-oq-02-oq-02 (Alternating Groups: Aₙ Solvable iff n ≤ 4)
**Severity**: LOW (underclaim — meta claimed *more* incompleteness than reality)

## Problem

The parent entry's `additionalFiles` sub-record and `assumptions` prose still
described the companion `AbelRuffiniOQ04OQ02OQ02OQ06.lean` (derived-length gap)
as carrying **1 sorry / 244 lines**.

That sorry (`a4_derived2_eq_bot`) was discharged via the Klein-four argument in
**#29166** (2026-06-24, "[verified, 0-axiom]"). The companion file is now **232
lines, 0 sorries**, verified/0-axiom. The companion's *own* gallery entry
(`abel-ruffini-oq-04-oq-02-oq-02-oq-06`) already reflects this — only the parent
was never re-synced.

## Evidence

| Field | meta claimed | actual source |
|-------|-------------|---------------|
| companion `sorries` | 1 | 0 (`grep -c sorry` = 0) |
| companion `lineCount` | 244 | 232 (`wc -l`) |
| assumptions prose | "still carries 1 sorry" | fully proved |

`#29166` diff shows `-  sorry` removed from `a4_derived2_eq_bot`.

## Fix

- `additionalFiles[0].sorries`: 1 → 0
- `additionalFiles[0].lineCount`: 244 → 232
- `additionalFiles[0].description` + `assumptions`: "1 remaining sorry" → fully proved

The parent's own presented file (`AbelRuffiniOQ04OQ02OQ02.lean`) was independently
re-verified this audit: 220 lines, 18 theorems (incl. 2 `private`), 1 def, 0 axioms,
0 sorries, and **0 `native_decide` in code** (the 2 raw occurrences are in comments).
Its `verified/mathlib` status is accurate.

---
Discovered during gallery integrity audit.