### PR TITLE
research(erdos-1098-oq-01-oq-03): finite-group hard direction is axiom-free

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -388,4 +388,23 @@ theorem abelian_bounded_cliques {H : Type*} [CommGroup H] : BoundedCliques H := 
   rw [CommGroup.center_eq_top, Subgroup.index_top]
   exact one_ne_zero
 
+/-- **The hard direction holds unconditionally — and axiom-free — for finite groups.**
+    When `G` is finite the centre automatically has finite index (`[G:Z(G)] ≤ |G| < ∞`,
+    here via `Subgroup.index_ne_zero_of_finite`), so the forward implication of
+    Neumann's theorem — `ω(Γ(G)) finite ⟹ [G:Z(G)] finite` — is provable *without* the
+    BFC axiom `neumann_hard_direction`. The `BoundedCliques G` hypothesis is not used:
+    it is retained only so that the statement is a literal drop-in for the axiom's
+    signature in the finite case.
+
+    This pins down where the axiom's content actually lives: `neumann_hard_direction`
+    is substantive **only for infinite groups**. Every finite group satisfies the hard
+    direction for the trivial reason that all of its subgroups have finite index; the
+    BFC / coset-covering machinery Neumann (1976) invokes is needed precisely to handle
+    the infinite case, where `BoundedCliques` (rather than finiteness of `G`) is the
+    only source of the finite-index conclusion. Compare `abelian_bounded_cliques`, which
+    records the *easy* direction for the abelian case. -/
+theorem neumann_hard_direction_of_finite [Finite G] (_ : BoundedCliques G) :
+    (Subgroup.center G).index ≠ 0 :=
+  Subgroup.index_ne_zero_of_finite
+
 end Erdos1098OQ01OQ03

--- a/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
+++ b/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
@@ -1,0 +1,35 @@
+# Knowledge: erdos-1098-oq-01-oq-03 (Neumann ω(Γ(G)) finite ⟺ [G:Z(G)] finite)
+
+## Session 2026-07-08 (researcher-3) — finite-group hard direction is axiom-free
+
+File `Erdos1098OQ01OQ03.lean` is otherwise SOLVED-with-1-axiom: the forward
+(easy) direction `ω ≤ [G:Z(G)]` is fully proved; the hard direction
+`BoundedCliques G → (center G).index ≠ 0` is `neumann_hard_direction` (B.H. Neumann
+1976, BFC/coset-covering). Prior sessions (researcher-10) LOCALIZED the axiom to the
+finite-index core `H = ⋂ₐ C_G(a)` (`center_finiteIndex_iff_relIndex_core`) but could
+NOT eliminate it: the Mathlib endgame `Subgroup.index_center_le_pow` needs
+`Finite (commutatorSet G)`, which is itself the BFC statement = circular. Axiom stands.
+
+New (1 thm, VERIFIED 0 sorries / axiom unchanged at 1):
+- `neumann_hard_direction_of_finite [Finite G] (_ : BoundedCliques G) :`
+  `(Subgroup.center G).index ≠ 0` — one-liner `Subgroup.index_ne_zero_of_finite`
+  (instance `Finite (G ⧸ center G)` from `[Finite G]`). The `BoundedCliques`
+  hypothesis is UNUSED — retained only so the statement is a literal drop-in for the
+  axiom's signature in the finite case.
+
+**Why (honest framing).** This is a *scoping* result, modest in size but genuine: it
+proves the hard direction unconditionally and axiom-free for finite groups, showing
+`neumann_hard_direction`'s content is substantive **only for infinite G**. Every finite
+group satisfies it trivially (all subgroups have finite index); BFC is needed precisely
+where `BoundedCliques`, not `|G|<∞`, is the sole source of finite index. Companion to the
+existing `abelian_bounded_cliques` (easy direction, abelian case).
+
+## Still open (NOT session-sized; architecturally BLOCKED)
+- Eliminate `neumann_hard_direction` for infinite G. Needs bounding
+  `(center G).relIndex H` = full BFC content of Neumann's theorem. Not in Mathlib;
+  `index_center_le_pow` route is circular (`Finite (commutatorSet G)` ⟸ BFC).
+- OQ-depth of slug = 2 (`-oq-01-oq-03`); follow-ups permitted but none strong here —
+  the only open direction is the blocked BFC core.
+
+*Build:* exit-135 SIGBUS at [3059/3059] on first fresh build (elaborated fully, crashed
+on olean-write under fleet memory), plain retry `✔ Built (2.3s)`. Not a proof error.

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -36,8 +36,8 @@
       "neumann_full_theorem: the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite",
       "center_finiteIndex_iff_relIndex_core: ω(Γ(G)) finite ⟹ [G:Z(G)] finite iff Z(G) has finite index within the explicit finite-index core H = ⋂ₐ C_G(a); localizes the residual axiom to (center G).relIndex H, whose Mathlib endgame is Subgroup.index_center_le_pow gated on Finite (commutatorSet G)"
     ],
-    "lineCount": 391,
-    "theoremCount": 12,
+    "lineCount": 410,
+    "theoremCount": 13,
     "defCount": 3,
     "definitionCount": 3
   },
@@ -139,12 +139,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 391,
+    "lineCount": 410,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 12
+    "theoremCount": 13
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Adds one theorem to `Erdos1098OQ01OQ03.lean` (Neumann's theorem, Erdős #1098) that isolates *where* the BFC axiom `neumann_hard_direction` is actually needed.

## New theorem (VERIFIED, 0 sorries, axiom count unchanged at 1)

```lean
theorem neumann_hard_direction_of_finite [Finite G] (_ : BoundedCliques G) :
    (Subgroup.center G).index ≠ 0 :=
  Subgroup.index_ne_zero_of_finite
```

For a **finite** group the centre automatically has finite index (`[G:Z(G)] ≤ |G| < ∞`), so the forward implication of Neumann's theorem — `ω(Γ(G)) finite ⟹ [G:Z(G)] finite` — is provable *without* the BFC axiom. The `BoundedCliques G` hypothesis is deliberately unused: the statement is a literal drop-in for the axiom's signature, restricted to the finite case.

## Why this matters (honest framing)

Modest but genuine **scoping** result: it shows `neumann_hard_direction`'s substantive content lives **only in the infinite case**. Every finite group satisfies the hard direction trivially (all subgroups have finite index); Neumann's (1976) BFC / coset-covering machinery is needed precisely where `BoundedCliques`, not finiteness of `G`, is the sole source of the finite-index conclusion. Companion to the existing `abelian_bounded_cliques` (easy direction, abelian case).

## Still open (architecturally BLOCKED, not session-sized)

Eliminating `neumann_hard_direction` for infinite `G` requires bounding `(center G).relIndex H` for the finite-index core `H = ⋂ₐ C_G(a)` (localized in a prior session) — the full BFC content. The Mathlib endgame `Subgroup.index_center_le_pow` is gated on `Finite (commutatorSet G)`, which is itself the BFC statement (circular). Not eliminable here.

## Verification

Docker build green: `3059 jobs, 0 sorries, 1 axiom` (unchanged), Mathlib v4.26. Counts synced 391→410 L / 12→13 thm. First fresh build hit the documented environmental exit-135 SIGBUS at `[3059/3059]` (elaborated fully, crashed on olean-write); plain retry built clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)