### PR TITLE
research(szemeredi-regularity-oq-04): variance atom bound — the AFKS energy-increment analytic core [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
@@ -260,4 +260,73 @@ theorem pairEnergy_row_split_gain (G : SimpleGraph V) [DecidableRel G.Adj]
   rw [Finset.sum_sub_distrib] at hsingle
   linarith
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: THE VARIANCE ATOM BOUND (n-cell energy excess)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Weighted-mean square identity (n cells).**  For nonnegative weights `w` on a
+    finite index set `s`, the size-weighted second moment about the weighted mean
+    `μ = (Σ wᵢxᵢ)/(Σ wᵢ)` splits as
+    `Σ wᵢ(xᵢ − μ)² = Σ wᵢxᵢ² − (Σ wᵢ)·μ²`.
+    This is the Finset generalization of `split_energy_identity` (the two-cell
+    case): the excess of the second moment over the mean-squared is exactly the
+    weighted variance.  The only hypothesis is `Σ wᵢ ≠ 0` (so `μ` is well defined). -/
+theorem weighted_variance_identity {ι : Type*} (s : Finset ι) (w x : ι → ℚ)
+    (hW : (∑ i ∈ s, w i) ≠ 0) :
+    (∑ i ∈ s, w i * (x i - (∑ j ∈ s, w j * x j) / (∑ j ∈ s, w j)) ^ 2) =
+      (∑ i ∈ s, w i * x i ^ 2) -
+        (∑ i ∈ s, w i) * ((∑ j ∈ s, w j * x j) / (∑ j ∈ s, w j)) ^ 2 := by
+  set μ : ℚ := (∑ j ∈ s, w j * x j) / (∑ j ∈ s, w j) with hμ_def
+  -- `μ` is the honest weighted mean: `(Σ wⱼ)·μ = Σ wⱼxⱼ`.
+  have hμ : (∑ i ∈ s, w i) * μ = ∑ i ∈ s, w i * x i := by
+    rw [hμ_def]; field_simp
+  -- Expand the variance sum termwise, then collect the three sub-sums.
+  have hexp : (∑ i ∈ s, w i * (x i - μ) ^ 2) =
+      (∑ i ∈ s, w i * x i ^ 2) - 2 * μ * (∑ i ∈ s, w i * x i) +
+        μ ^ 2 * (∑ i ∈ s, w i) := by
+    rw [Finset.mul_sum, Finset.mul_sum, ← Finset.sum_sub_distrib,
+        ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun i _ => by ring)
+  rw [hexp, ← hμ]; ring
+
+/-- **The variance atom bound.**  If a single cell `i₀` carries weight at least
+    `w₀ ≥ 0` and its value `x i₀` deviates from the weighted mean by at least
+    `d ≥ 0`, then the weighted second-moment excess dominates `w₀·d²`:
+    `Σ wᵢxᵢ² − (Σ wᵢ)·μ² ≥ w₀·d²`.
+
+    This is the analytic core of the AFKS energy increment beyond the two-cell
+    Cauchy–Schwarz `split_energy_excess_bound`.  When an ε-irregular pair is
+    refined *simultaneously* on both coordinates into a family of sub-cells, the
+    witness sub-cell is one atom of the resulting weighted distribution of
+    densities whose deviation from the mean is bounded below; this lemma converts
+    that single-atom deviation into a definite energy gain, with no reliance on
+    triangle inequalities through mixed densities. -/
+theorem variance_atom_bound {ι : Type*} (s : Finset ι) (w x : ι → ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hW : (∑ i ∈ s, w i) ≠ 0)
+    (i₀ : ι) (hi₀ : i₀ ∈ s) (w₀ d : ℚ) (hw₀ : 0 ≤ w₀) (hd : 0 ≤ d)
+    (hwlb : w₀ ≤ w i₀)
+    (hdev : d ≤ |x i₀ - (∑ j ∈ s, w j * x j) / (∑ j ∈ s, w j)|) :
+    w₀ * d ^ 2 ≤
+      (∑ i ∈ s, w i * x i ^ 2) -
+        (∑ i ∈ s, w i) * ((∑ j ∈ s, w j * x j) / (∑ j ∈ s, w j)) ^ 2 := by
+  set μ : ℚ := (∑ j ∈ s, w j * x j) / (∑ j ∈ s, w j) with hμ_def
+  -- Every variance term is nonnegative, so the whole sum dominates the `i₀` term.
+  have hnn : ∀ i ∈ s, (0 : ℚ) ≤ w i * (x i - μ) ^ 2 :=
+    fun i hi => mul_nonneg (hw i hi) (sq_nonneg _)
+  have hsingle : w i₀ * (x i₀ - μ) ^ 2 ≤ ∑ i ∈ s, w i * (x i - μ) ^ 2 :=
+    Finset.single_le_sum hnn hi₀
+  -- The `i₀` term itself dominates `w₀·d²`.
+  have hsq : d ^ 2 ≤ (x i₀ - μ) ^ 2 := by
+    calc d ^ 2 ≤ |x i₀ - μ| ^ 2 :=
+          sq_le_sq' (by linarith [abs_nonneg (x i₀ - μ)]) hdev
+      _ = (x i₀ - μ) ^ 2 := sq_abs _
+  have hatom : w₀ * d ^ 2 ≤ w i₀ * (x i₀ - μ) ^ 2 := by
+    calc w₀ * d ^ 2 ≤ w i₀ * d ^ 2 := mul_le_mul_of_nonneg_right hwlb (sq_nonneg d)
+      _ ≤ w i₀ * (x i₀ - μ) ^ 2 :=
+          mul_le_mul_of_nonneg_left hsq (le_trans hw₀ hwlb)
+  -- Combine with the variance identity.
+  have hvar := weighted_variance_identity s w x hW
+  rw [← hμ_def] at hvar
+  linarith [hsingle, hatom, hvar]
+
 end Szemeredi.RegularityOQ04Energy

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -240,3 +240,47 @@ carries all the graph-theoretic content.
   `Σ wᵢ xᵢ² − (Σwᵢ)μ² ≥ w₀·d²` (one atom of weight ≥ w₀ deviating ≥ d from mean),
   then instantiate over the 4 sub-cells to get the true ε⁴ energy increment.
 - Outer AFKS loop assembly feeding `afks_energy_iteration_count`.
+
+## Session 2026-07-08 (Session 6, researcher-7) - Variance atom bound (the analytic core)
+
+**Mode**: REVISIT (continuing branch szem-oq04-bside-s5)
+**Outcome**: progress (2 theorems VERIFIED 0/0)
+
+### What I Did
+- `weighted_variance_identity` (Energy file): the Finset generalization of the
+  two-cell `split_energy_identity`. For nonnegative weights `w` on a finite `s`,
+  with weighted mean `μ = (Σ wⱼxⱼ)/(Σ wⱼ)`:
+  `Σ wᵢ(xᵢ−μ)² = Σ wᵢxᵢ² − (Σ wᵢ)·μ²`. Sole hypothesis `Σ wᵢ ≠ 0`. Proof:
+  termwise `sub_sq` expansion → three sub-sums via `Finset.mul_sum` +
+  `sum_sub/add_distrib` → substitute `(Σw)·μ = Σwx` (`mul_div` cancel via
+  `field_simp`) → `ring`.
+- `variance_atom_bound` (Energy file): the analytic core session 5 flagged as the
+  genuine blocker. If one cell `i₀` has weight `≥ w₀ ≥ 0` and value deviating from
+  the mean by `≥ d ≥ 0`, then `Σ wᵢxᵢ² − (Σ wᵢ)μ² ≥ w₀·d²`. Proof: variance terms
+  all nonneg → `Finset.single_le_sum` isolates the `i₀` term → `sq_le_sq'`/`sq_abs`
+  give `(xᵢ₀−μ)² ≥ d²` → two `mul_le_mul` steps give `wᵢ₀(xᵢ₀−μ)² ≥ w₀d²` →
+  `linarith` with the identity.
+
+### Key Findings
+- This is the **variance ≥ single-atom-contribution** fact that dodges the
+  session-5 obstruction (the mixed second difference / defect that no single
+  triangle inequality kills). Instead of decomposing the two-sided witness
+  deviation through a mixed density, one refines BOTH coordinates simultaneously
+  into cells and treats the density distribution as a weighted point set; the
+  witness cell is a single atom whose deviation is bounded below, and its energy
+  contribution alone is ≥ w₀d² by this bound. No triangle detour, no defect term.
+- Abstract over an arbitrary index type `ι` (not tied to `V`), so it is reusable
+  as a clean standalone weighted-variance lower bound.
+
+### Files Modified
+- proofs/Proofs/SzemerediRegularityOQ04Energy.lean (+weighted_variance_identity,
+  +variance_atom_bound; +~90 lines)
+
+### Next Steps
+- Instantiate `variance_atom_bound` over the 4 (or general m×k) sub-cells of a
+  simultaneous two-coordinate refinement: weights `|Aᵢ||Bⱼ|/n²`, values
+  `d(Aᵢ,Bⱼ)`, mean `d(A,B)`, witness atom `(A',B')` with deviation `≥ ε/2` from
+  the block average → energy gain `≥ (|A'||B'|/n²)·(ε/2)²`. This closes the
+  genuine ε⁴ increment that the two whole-partner one-sided branches (S4/S5)
+  could only approximate.
+- Wire the resulting increment into `afks_energy_iteration_count`.

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -26,7 +26,7 @@
     "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0/0): supplied the missing witness->increment bridge (SzemerediRegularityOQ04Witness, 4 theorems). exists_irregular_witness now feeds a concrete between-halves density gap >eps/2 - exactly the hdev hypothesis pairEnergy_split_gain/partitionEnergy_single_split_gain_uniform require. Termination engine + quantitative increment + witness bridge now all in hand; remaining: promote the witness subset to a partition part (two-sided refinement) to close the loop into afks_energy_iteration_count.",
+    "progressSummary": "PROGRESS (VERIFIED 0/0): supplied the variance atom bound Σwᵢxᵢ²−(Σwᵢ)μ²≥w₀d² (+its identity), the abstract analytic core the S5 note flagged as the genuine blocker for full AFKS closure. Bypasses the mixed-second-difference defect via variance≥single-atom-contribution. Remaining: instantiate over the m×k sub-cells of a two-coordinate refinement and feed afks_energy_iteration_count.",
     "builtItems": [
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
       "pairEnergy def + pairEnergy_split_mono — one-sided refinement never decreases the normalized pair energy (|A||B|/n^2)d^2; transports density_sq_convex to partitionEnergy units.",
@@ -40,7 +40,9 @@
       "edgeDensity_whole_between (SzemerediRegularityOQ04Witness.lean): |d(A1,B)-d(A1 u A2,B)| <= |d(A1,B)-d(A2,B)| for disjoint A1,A2 (0<|B|, 0<|A1|+|A2|), via edgeDensity_union_mul + |B|-cancellation + abs of the weighted-mean identity. VERIFIED 0/0.",
       "edgeDensity_whole_between_right (SzemerediRegularityOQ04Witness.lean): second-argument form via edgeDensity_comm. VERIFIED 0/0.",
       "irregular_witness_split_gap (SzemerediRegularityOQ04Witness.lean): |d(A',B')-d(A\\A',B')| + |d(A,B')-d(A,B\\B')| > eps from a witness deviation >eps, via abs_sub_le through d(A,B') then two edgeDensity_whole_between collapses. VERIFIED 0/0.",
-      "irregular_witness_split_gap_disjunction (SzemerediRegularityOQ04Witness.lean): at least one coordinate carries a between-halves gap > eps/2 = exactly the hdev hypothesis of pairEnergy_split_gain (delta=eps/2). VERIFIED 0/0."
+      "irregular_witness_split_gap_disjunction (SzemerediRegularityOQ04Witness.lean): at least one coordinate carries a between-halves gap > eps/2 = exactly the hdev hypothesis of pairEnergy_split_gain (delta=eps/2). VERIFIED 0/0.",
+      "weighted_variance_identity (Energy): Finset generalization of split_energy_identity — Σwᵢ(xᵢ−μ)²=Σwᵢxᵢ²−(Σwᵢ)μ² for weighted mean μ, VERIFIED 0/0",
+      "variance_atom_bound (Energy): single-atom deviation ≥d (weight ≥w₀) ⟹ Σwᵢxᵢ²−(Σwᵢ)μ²≥w₀d² — the analytic core dodging the S5 defect obstruction, VERIFIED 0/0"
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
@@ -50,12 +52,13 @@
       "check-superseded.sh false-positives on PRs that only MODIFY (append to) existing proof files: it flags a branch when the file PATHS it touches exist on main, ignoring whether the specific theorems are new. PR #35809 (verified quantitative gain) was wrongly auto-closed this way; rebasing onto current main fixes it (files exist at merge-base ⇒ NOT_SUPERSEDED modifies-existing-only).",
       "Three consecutive line-less exit-135 SIGBUS crashes were MASKING a real elaboration error (No goals to be solved at gcongr). docker-build --repair-cache (fresh olean force-refresh) let elaboration complete and surface the genuine error at 4.7s — SIGBUS retries alone would never have revealed it.",
       "The AFKS energy-increment lemmas (pairEnergy_split_gain, partitionEnergy_single_split_gain) consume a between-halves density gap |d(A1,B0)-d(A2,B0)|>=delta, but exists_irregular_witness produces a whole-vs-pair deviation |d(A',B')-d(A,B)|>eps. Different shapes; the missing link is a triangle-inequality bridge, now supplied by SzemerediRegularityOQ04Witness.",
-      "Density convexity: d(A1 u A2,B) is the |A1|:|A2|-weighted mean of d(A1,B),d(A2,B), hence lies between them, so the whole is never farther from a half than the two halves are from each other (edgeDensity_whole_between). Upgrades a whole-vs-half gap into a half-vs-half gap of >= the same size."
+      "Density convexity: d(A1 u A2,B) is the |A1|:|A2|-weighted mean of d(A1,B),d(A2,B), hence lies between them, so the whole is never farther from a half than the two halves are from each other (edgeDensity_whole_between). Upgrades a whole-vs-half gap into a half-vs-half gap of >= the same size.",
+      "The S5 mixed-second-difference (defect) obstruction is bypassed by treating the two-coordinate refinement as a weighted point distribution: the witness cell is one atom, and variance≥single-atom-contribution gives the energy gain directly, with no triangle-through-mixed-density detour."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Assemble the full AFKS energy-increment step: from an eps-irregular pair (A,B) in partition P, use exists_irregular_witness -> irregular_witness_split_gap_disjunction to select the coordinate with the >eps/2 gap, refine that part so the witness subset becomes a partition part, and invoke partitionEnergy_single_split_gain_uniform for the eps^2/(2n^2) floor. Remaining subtlety: the B-side disjunct needs B' promoted to a part (two-sided refinement); wire this into afks_energy_iteration_count.",
-      "State the strong-regularity conclusion: almost-all-pairs regular with arbitrary precision (AFKS), now that termination + increment + witness-bridge are all in hand.",
+      "Instantiate variance_atom_bound over the m×k sub-cells of a simultaneous two-coordinate refinement (weights |Aᵢ||Bⱼ|/n², values d(Aᵢ,Bⱼ), mean d(A,B), witness atom (A′,B′) deviation ≥ε/2) → energy gain ≥ (|A′||B′|/n²)(ε/2)²; this is the true ε⁴ increment.",
+      "Wire that increment into afks_energy_iteration_count for the outer AFKS loop.",
       "Consider upstreaming edgeDensity_whole_between (density convexity) as a clean general fact."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary

Adds the **abstract variance atom bound** to `SzemerediRegularityOQ04Energy.lean` — the analytic core that session 5's knowledge flagged as the genuine blocker for full AFKS (strong regularity) closure. Two new theorems, fully machine-checked (0 sorries, 0 axioms):

- **`weighted_variance_identity`** — the Finset generalization of the existing two-cell `split_energy_identity`: for nonnegative weights `w` on a finite `s` with weighted mean `μ = (Σ wⱼxⱼ)/(Σ wⱼ)`,
  `Σ wᵢ(xᵢ−μ)² = Σ wᵢxᵢ² − (Σ wᵢ)·μ²`. Sole hypothesis `Σ wᵢ ≠ 0`.
- **`variance_atom_bound`** — if one cell `i₀` carries weight `≥ w₀ ≥ 0` and its value deviates from the mean by `≥ d ≥ 0`, then `Σ wᵢxᵢ² − (Σ wᵢ)μ² ≥ w₀·d²`.

## Why this matters

Sessions 4–5 discharged the two *whole-partner* one-sided energy branches, but full closure was blocked by the **mixed second difference** (the 4-cell defect `d(A',B')−d(A',B)−d(A,B')+d(A,B)`) — no single triangle inequality through a mixed density kills it. This bound dodges the obstruction: treat a simultaneous two-coordinate refinement as a weighted point distribution of densities; the irregular witness cell is a single atom whose deviation from the mean is bounded below, and *variance ≥ single-atom-contribution* delivers the energy gain directly, with no triangle detour and no defect term.

The lemma is abstract over an arbitrary index type, so it doubles as a clean standalone weighted-variance lower bound.

## Next step (not in this PR)

Instantiate over the `m×k` sub-cells of a two-coordinate refinement (weights `|Aᵢ||Bⱼ|/n²`, values `d(Aᵢ,Bⱼ)`, mean `d(A,B)`, witness atom `(A',B')`) to obtain the true ε⁴ increment, then wire it into `afks_energy_iteration_count`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04Energy` → **Build succeeded**, 0 sorries, 0 axioms.