### PR TITLE
research(shannon-awgn-oq-02-oq-02): signed correlation capstone — ρ=±1 ⟺ increasing/decreasing affine slope

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -747,4 +747,96 @@ theorem abs_correlation_eq_one_iff_affine [IsProbabilityMeasure μ] {X Y : Ω �
   · intro h; rw [← sq_abs, h]; norm_num
   · intro h; rw [← Real.sqrt_sq_eq_abs, h, Real.sqrt_one]
 
+/-!
+### Signed capstone: distinguishing perfect positive from perfect negative correlation
+
+The capstone `abs_correlation_eq_one_iff_affine` locates the extremal case `|ρ| = 1` but is blind to
+the **sign** of the correlation.  The sharp refinement records that the sign of `ρ` is exactly the
+sign of the regression slope: when `X =ᵐ a·Y + b` with `a ≠ 0` and `Y` non-degenerate,
+
+    ρ[X, Y] = a / |a| = sign a,
+
+because `cov[X,Y] = a·Var[Y]`, `σ_X = |a|·σ_Y`, so the normalisation collapses to `a/|a|`.  Hence
+`ρ = +1` picks out the *increasing* affine relations (`a > 0`, perfect positive correlation) and
+`ρ = -1` the *decreasing* ones (`a < 0`, perfect negative correlation) — the two endpoints of the
+Cauchy–Schwarz interval `[-1, 1]` are structurally different, not merely `|ρ| = 1`.
+-/
+
+/-- **Variance under an a.e. affine change of variable.**  If `X =ᵐ a·Y + b` then
+`Var[X] = a²·Var[Y]`; the additive constant drops and the multiplicative slope scales the variance
+by `a²`.  Extracted from the equality-boundary computation so the signed capstones can reuse it. -/
+theorem variance_eq_of_affine [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hY : MemLp Y 2 μ) (a b : ℝ) (h : X =ᵐ[μ] fun ω => a * Y ω + b) :
+    Var[X; μ] = a ^ 2 * Var[Y; μ] := by
+  have hsmul : (fun ω => a * Y ω) = a • Y := by
+    funext ω; rw [Pi.smul_apply, smul_eq_mul]
+  rw [variance_congr h, variance_add_const (hY.aestronglyMeasurable.const_mul a) b, hsmul,
+    variance_smul]
+
+/-- **Correlation of an a.e. affine pair is the sign of the slope.**  For non-degenerate `Y` and a
+nonzero slope `a`, if `X =ᵐ a·Y + b` then `ρ[X, Y] = a / |a|` (i.e. `+1` when `a > 0` and `-1` when
+`a < 0`).  This is the signed sharpening of `covariance_sq_eq_of_affine`: normalising the covariance
+`a·Var[Y]` by `σ_X·σ_Y = |a|·Var[Y]` cancels the magnitude of the slope and leaves only its sign. -/
+theorem correlation_eq_of_affine [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hY : MemLp Y 2 μ) {a b : ℝ} (ha : a ≠ 0) (hYnd : Var[Y; μ] ≠ 0)
+    (h : X =ᵐ[μ] fun ω => a * Y ω + b) :
+    correlation X Y μ = a / |a| := by
+  have hYint : Integrable (fun ω => a * Y ω) μ := (hY.integrable one_le_two).const_mul a
+  have hcov : cov[X, Y; μ] = a * Var[Y; μ] := by
+    rw [covariance_congr_left h, covariance_add_const_left hYint b,
+      covariance_const_mul_left, covariance_self hY.aemeasurable]
+  have hsqrtX : Real.sqrt (Var[X; μ]) = |a| * Real.sqrt (Var[Y; μ]) := by
+    rw [variance_eq_of_affine hY a b h, Real.sqrt_mul (sq_nonneg a), Real.sqrt_sq_eq_abs]
+  have hs : Real.sqrt (Var[Y; μ]) * Real.sqrt (Var[Y; μ]) = Var[Y; μ] :=
+    Real.mul_self_sqrt (variance_nonneg _ _)
+  have haa : |a| ≠ 0 := abs_ne_zero.mpr ha
+  rw [correlation, hcov, hsqrtX, mul_assoc, hs]
+  field_simp
+
+/-- **ρ = 1 ⟺ a.e. increasing affine dependence (perfect positive correlation).**  For
+non-degenerate `X, Y` the correlation attains its maximum `+1` *exactly* when `X` is almost
+everywhere an affine function of `Y` with **positive** slope.  Refines
+`abs_correlation_eq_one_iff_affine`: it is the `+1` endpoint, distinguished from the `-1` endpoint by
+the sign of the regression slope. -/
+theorem correlation_eq_one_iff_affine_pos [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hXnd : Var[X; μ] ≠ 0) (hYnd : Var[Y; μ] ≠ 0) :
+    correlation X Y μ = 1 ↔ ∃ a b : ℝ, 0 < a ∧ X =ᵐ[μ] fun ω => a * Y ω + b := by
+  constructor
+  · intro h
+    have hsq : correlation X Y μ ^ 2 = 1 := by rw [h]; norm_num
+    obtain ⟨a, b, hab⟩ := (correlation_sq_eq_one_iff_affine hX hY hXnd hYnd).mp hsq
+    have ha : a ≠ 0 := by
+      rintro rfl
+      exact hXnd (by rw [variance_eq_of_affine hY 0 b hab]; ring)
+    have hval : correlation X Y μ = a / |a| := correlation_eq_of_affine hY ha hYnd hab
+    refine ⟨a, b, ?_, hab⟩
+    rcases ha.lt_or_gt with hneg | hpos
+    · rw [h, abs_of_neg hneg, div_neg, div_self ha] at hval; norm_num at hval
+    · exact hpos
+  · rintro ⟨a, b, ha, hab⟩
+    rw [correlation_eq_of_affine hY ha.ne' hYnd hab, abs_of_pos ha, div_self ha.ne']
+
+/-- **ρ = -1 ⟺ a.e. decreasing affine dependence (perfect negative correlation).**  For
+non-degenerate `X, Y` the correlation attains its minimum `-1` *exactly* when `X` is almost
+everywhere an affine function of `Y` with **negative** slope.  The `-1` endpoint companion of
+`correlation_eq_one_iff_affine_pos`; together they split `abs_correlation_eq_one_iff_affine` into its
+two structurally distinct extremes. -/
+theorem correlation_eq_neg_one_iff_affine_neg [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hXnd : Var[X; μ] ≠ 0) (hYnd : Var[Y; μ] ≠ 0) :
+    correlation X Y μ = -1 ↔ ∃ a b : ℝ, a < 0 ∧ X =ᵐ[μ] fun ω => a * Y ω + b := by
+  constructor
+  · intro h
+    have hsq : correlation X Y μ ^ 2 = 1 := by rw [h]; norm_num
+    obtain ⟨a, b, hab⟩ := (correlation_sq_eq_one_iff_affine hX hY hXnd hYnd).mp hsq
+    have ha : a ≠ 0 := by
+      rintro rfl
+      exact hXnd (by rw [variance_eq_of_affine hY 0 b hab]; ring)
+    have hval : correlation X Y μ = a / |a| := correlation_eq_of_affine hY ha hYnd hab
+    refine ⟨a, b, ?_, hab⟩
+    rcases ha.lt_or_gt with hneg | hpos
+    · exact hneg
+    · rw [h, abs_of_pos hpos, div_self ha] at hval; norm_num at hval
+  · rintro ⟨a, b, ha, hab⟩
+    rw [correlation_eq_of_affine hY ha.ne hYnd hab, abs_of_neg ha, div_neg, div_self ha.ne]
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 750,
+    "lineCount": 842,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 36,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -48,7 +48,8 @@
       "awgn_multisymbol_output_power: E[(∑_{i∈s} Wᵢ)²] = ∑_{i∈s} Pᵢ — the block-power restatement. Writing Pᵢ = E[Wᵢ²] for the power of the i-th contribution, the aggregate output power is the sum of the per-contribution powers: the n-symbol analogue of the parent's E[Y²] = P + N (which is the special case s = {signal, noise}).",
       "awgn_multisymbol_variance: Var[∑_{i∈s} Wᵢ] = ∑_{i∈s} Var[Wᵢ] for pairwise-independent Wᵢ — the Bienaymé identity recorded in channel notation (a direct application of IndepFun.variance_sum), making explicit that pairwise independence already annihilates every off-diagonal covariance in the expansion of the variance of a sum.",
       "sum_mean_zero: E[∑_{i∈s} Wᵢ] = 0 — the aggregate of zero-mean contributions is zero-mean, via linearity of the integral over a Finset (integral_finset_sum) on the square-integrable (hence integrable) parts. This is the lemma that lets the squared-mean term drop for the sum, not just for each summand.",
-      "second_moment_eq_variance: E[W²] = Var[W] for a zero-mean variable — the bridge identifying the engineering notion of 'power' with the probabilistic variance; the rewrite that turns the variance-of-a-sum law into a second-moment law once the means are zero."
+      "second_moment_eq_variance: E[W²] = Var[W] for a zero-mean variable — the bridge identifying the engineering notion of 'power' with the probabilistic variance; the rewrite that turns the variance-of-a-sum law into a second-moment law once the means are zero.",
+      "correlation_eq_one_iff_affine_pos / correlation_eq_neg_one_iff_affine_neg: the signed sharp boundary — ρ = +1 exactly when X is a.e. an increasing affine function of Y (positive slope, perfect positive correlation) and ρ = −1 exactly when the slope is negative (perfect negative correlation). Refines the capstone |ρ|=1 ⟺ affine dependence by splitting the two endpoints of the Cauchy–Schwarz interval [−1,1] according to the sign of the regression slope, via correlation_eq_of_affine (ρ = a/|a| = sign a when X =ᵐ a·Y+b) and variance_eq_of_affine (Var[X] = a²·Var[Y])."
     ],
     "prerequisites": [
       "Variance of a sum of pairwise-independent variables: ProbabilityTheory.IndepFun.variance_sum (Var[∑ Xᵢ] = ∑ Var[Xᵢ])",
@@ -181,6 +182,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 750,
-  "theoremCount": 32
+  "lineCount": 842,
+  "theoremCount": 36
 }

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: normalised capstone COMPLETE — Pearson correlation coefficient ρ=cov/(σX·σY) added (750 lines, 32 thm, 0 sorry/0 axiom). |ρ|≤1 = covariance Cauchy–Schwarz; |ρ|=1 ⟺ a.e. affine dependence = sharp equality boundary. Second-order theory now packaged in dimensionless form.",
+    "progressSummary": "PROGRESS: signed correlation capstone (ρ=±1 ⟺ increasing/decreasing affine) VERIFIED 0/0, PR #35904",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -48,7 +48,10 @@
       "correlation: def cov[X,Y]/(√Var[X]·√Var[Y]) (ShannonChannelCodingAWGNOQ02OQ02.lean)",
       "correlation_sq: ρ²=cov²/(Var[X]·Var[Y]) via div_pow/mul_pow + Real.sq_sqrt (ShannonChannelCodingAWGNOQ02OQ02.lean)",
       "abs_correlation_le_one: |ρ|≤1 with no non-degeneracy hyp; ρ²≤1 via eq_or_lt_of_le on Var·Var then div_le_one, then abs_le+nlinarith (ShannonChannelCodingAWGNOQ02OQ02.lean)",
-      "abs_correlation_eq_one_iff_affine: |ρ|=1 ⟺ ∃a b, X=ᵐa·Y+b — normalised capstone via correlation_sq_eq_one_iff_affine + Real.sqrt_sq_eq_abs (ShannonChannelCodingAWGNOQ02OQ02.lean)"
+      "abs_correlation_eq_one_iff_affine: |ρ|=1 ⟺ ∃a b, X=ᵐa·Y+b — normalised capstone via correlation_sq_eq_one_iff_affine + Real.sqrt_sq_eq_abs (ShannonChannelCodingAWGNOQ02OQ02.lean)",
+      "variance_eq_of_affine (Var[X]=a²Var[Y]) in ShannonChannelCodingAWGNOQ02OQ02.lean",
+      "correlation_eq_of_affine (ρ=a/|a|=sign a) in ShannonChannelCodingAWGNOQ02OQ02.lean",
+      "correlation_eq_one_iff_affine_pos + correlation_eq_neg_one_iff_affine_neg (signed capstones) in ShannonChannelCodingAWGNOQ02OQ02.lean"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -60,7 +63,8 @@
       "Cauchy–Schwarz for covariance (cov[X,Y]²≤Var[X]·Var[Y]) is ABSENT from Mathlib probability layer; proved via discrim_le_zero applied to the nonnegative quadratic t↦Var[X+t•Y]=Var[Y]·t²+2cov·t+Var[X]. This is the engine for the standard-deviation triangle inequality.",
       "Sharp EQUALITY case of covariance Cauchy–Schwarz (cov²=Var[X]·Var[Y]) is characterized by the regression-residual variance IDENTITY Var[Var[Y]·X − cov·Y] = Var[Y]·(Var[X]·Var[Y] − cov²): when Var[Y]≠0 the residual has zero variance (hence a.e. constant) exactly when C–S is tight. Dividing by Var[Y] exhibits X =ᵐ (cov/Var[Y])·Y + b — a.e. affine dependence with slope the regression coefficient. Classical equality-in-Cauchy–Schwarz ⟺ linear-dependence, specialised to the covariance inner product; sharp EQUALITY companion to the earlier stddev triangle INEQUALITY.",
       "The equality-boundary iff closes cleanly: forward (tightness⟹regression line) needs Var[Y]≠0, but converse (affine⟹tightness) is unconditional — a pure bilinear/variance-of-affine computation transported along =ᵐ via covariance_congr_left + variance_congr.",
-      "Correlation-coefficient normalisation ρ=cov/(σX·σY) packages the whole second-order theory: |ρ|≤1 IS covariance Cauchy–Schwarz (no non-degeneracy needed — division-by-zero convention absorbs degenerate case), and |ρ|=1 ⟺ a.e. affine dependence IS the sharp equality boundary. Both non-degeneracy hypotheses genuinely needed for the |ρ|=1 iff since a degenerate variable gives ρ=0≠±1 while X=ᵐ0·Y+μ[X] still holds."
+      "Correlation-coefficient normalisation ρ=cov/(σX·σY) packages the whole second-order theory: |ρ|≤1 IS covariance Cauchy–Schwarz (no non-degeneracy needed — division-by-zero convention absorbs degenerate case), and |ρ|=1 ⟺ a.e. affine dependence IS the sharp equality boundary. Both non-degeneracy hypotheses genuinely needed for the |ρ|=1 iff since a degenerate variable gives ρ=0≠±1 while X=ᵐ0·Y+μ[X] still holds.",
+      "Signed sharp boundary: ρ = sign(a) when X =ᵐ a·Y+b, so ρ=+1 ⟺ increasing affine (a>0), ρ=−1 ⟺ decreasing affine (a<0); splits |ρ|=1⟺affine into two distinct endpoints."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -74,7 +78,8 @@
       "Correlation coefficient ρ = cov/(σX·σY): |ρ| ≤ 1 immediate from covariance_sq_le_variance_mul_variance; state |ρ|=1 ⟺ a.e. affine dependence as normalised capstone.",
       "Converse affine⟹equality (X =ᵐ a·Y+b ⟹ cov²=Var·Var) for full iff — needs covariance_congr under a.e. equality (build from integral_congr_ae).",
       "Upstream covariance_congr_left to Mathlib (Probability/Moments/Covariance.lean) alongside variance_congr; would also give a covariance_congr_right by covariance_comm.",
-      "Correlation-coefficient triangle/monotonicity: state ρ under sign of covariance, or the two-variance stddev triangle equality condition (perfect positive correlation ρ=+1) as the dual of the off-diagonal-cancellation boundary."
+      "Correlation-coefficient triangle/monotonicity: state ρ under sign of covariance, or the two-variance stddev triangle equality condition (perfect positive correlation ρ=+1) as the dual of the off-diagonal-cancellation boundary.",
+      "Consider affine-invariance of ρ: corr(aX+b, cY+d)=sign(ac)·corr(X,Y) as a structural companion."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Sharp **signed** refinement of the correlation-coefficient capstone in `ShannonChannelCodingAWGNOQ02OQ02.lean`. The existing capstone `abs_correlation_eq_one_iff_affine` characterises `|ρ| = 1 ⟺ a.e. affine dependence` but is blind to the **sign** of the correlation. This PR splits the two endpoints of the Cauchy–Schwarz interval `[-1, 1]` by the sign of the regression slope.

## New theorems (all VERIFIED, 0 sorry / 0 axiom)

- `variance_eq_of_affine` — `X =ᵐ a·Y + b ⟹ Var[X] = a²·Var[Y]` (additive constant drops, slope scales variance by `a²`).
- `correlation_eq_of_affine` — for non-degenerate `Y` and nonzero slope, `X =ᵐ a·Y + b ⟹ ρ[X,Y] = a/|a| = sign a`. Normalising `cov = a·Var[Y]` by `σ_X·σ_Y = |a|·Var[Y]` cancels the slope magnitude, leaving only its sign.
- `correlation_eq_one_iff_affine_pos` — **ρ = +1 ⟺** `X` is a.e. an *increasing* affine function of `Y` (`a > 0`, perfect positive correlation).
- `correlation_eq_neg_one_iff_affine_neg` — **ρ = −1 ⟺** `X` is a.e. a *decreasing* affine function of `Y` (`a < 0`, perfect negative correlation).

Together the last two split `abs_correlation_eq_one_iff_affine` into its two structurally distinct extremes.

## Verification

`./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingAWGNOQ02OQ02` → `✔ Built (7743 jobs)`. Gallery `meta.json` line/theorem counts synced (842 / 36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)