### PR TITLE
research(erdos-1022-oq-02): iterated exponential growth bracket for the sparseness coefficient

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -387,4 +387,51 @@ theorem admissibleCoeff_step_bracket (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1
         ≤ 2 * (firstMomentThreshold t / Fintype.card V) + 1 :=
   ⟨admissibleCoeff_ge_two_mul hV t ht, admissibleCoeff_le_two_mul_succ hV t ht⟩
 
+/-- **Iterated exponential lower bound (the growth rate over many steps).**
+    Iterating the one-step doubling `admissibleCoeff_ge_two_mul` `k` times gives the
+    genuine exponential growth law for the admissible coefficient:
+
+        `2^k · c(t)  ≤  c(t + k)`      (`c(s) = ⌊2^{s-1}/|V|⌋`).
+
+    Where `admissibleCoeff_ge_two_mul` only asserts "at least doubles per step", this
+    accumulates the doublings: after `k` steps the coefficient has grown by a factor of
+    at least `2^k`. Proof by induction on `k`, chaining the one-step bound at index
+    `t + k` (which is `≥ 1` since `t ≥ 1`) with the `2·`-monotonicity of the IH. -/
+theorem admissibleCoeff_two_pow_mul_le (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 ≤ t)
+    (k : ℕ) :
+    2 ^ k * (firstMomentThreshold t / Fintype.card V)
+      ≤ firstMomentThreshold (t + k) / Fintype.card V := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      have hstep := admissibleCoeff_ge_two_mul hV (t + k) (by omega)
+      rw [show t + (k + 1) = (t + k) + 1 from by ring, pow_succ', mul_assoc]
+      exact le_trans (Nat.mul_le_mul (le_refl 2) ih) hstep
+
+/-- **Iterated exponential upper bound (the growth rate over many steps).**
+    The matching iterate of the one-step ceiling `admissibleCoeff_le_two_mul_succ`.
+    Carrying the `+1` through the recurrence to absorb the per-step floor remainders,
+
+        `c(t + k) + 1  ≤  2^k · (c(t) + 1)`,
+
+    equivalently `c(t + k) ≤ 2^k · c(t) + (2^k − 1)`: over `k` steps the coefficient
+    exceeds pure `2^k`-doubling by at most `2^k − 1`, the geometric sum of the `k`
+    truncated-division `±1` errors. Together with `admissibleCoeff_two_pow_mul_le` this
+    brackets `c(t + k)` between `2^k · c(t)` and `2^k · (c(t) + 1) − 1`, pinning the
+    multi-step growth to exact exponential rate `2^k` up to a bounded relative error.
+    Proof by induction on `k`, chaining the one-step ceiling at index `t + k` with the
+    `2·`-monotonicity of the IH. -/
+theorem admissibleCoeff_succ_le_two_pow_mul (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 ≤ t)
+    (k : ℕ) :
+    firstMomentThreshold (t + k) / Fintype.card V + 1
+      ≤ 2 ^ k * (firstMomentThreshold t / Fintype.card V + 1) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      have hstep := admissibleCoeff_le_two_mul_succ hV (t + k) (by omega)
+      rw [show t + (k + 1) = (t + k) + 1 from by ring, pow_succ', mul_assoc]
+      have h2 : firstMomentThreshold ((t + k) + 1) / Fintype.card V + 1
+          ≤ 2 * (firstMomentThreshold (t + k) / Fintype.card V + 1) := by omega
+      exact le_trans h2 (Nat.mul_le_mul (le_refl 2) ih)
+
 end Erdos1022OQ02

--- a/research/problems/erdos-1022-oq-02/knowledge.md
+++ b/research/problems/erdos-1022-oq-02/knowledge.md
@@ -21,3 +21,24 @@ of `2·(n·q+r)` + `2r/n<2`.
 
 Still open (hard regime, untouched): Lovász-type local argument for ground sets
 growing with the family — needs LLL, not session-sized.
+
+## Session 2026-07-08 (researcher-3) — iterated exponential growth bracket (multi-step rate)
+
+Prior session pinned the ONE-step recurrence `c(t+1) ∈ {2c(t), 2c(t)+1}`
+(`admissibleCoeff_step_bracket`, c(s)=⌊2^{s-1}/|V|⌋). Lifted it to the genuine
+MULTI-step growth rate (2 thm, VERIFIED 0/0, leanFile 390→437 L / 16→18 thm):
+- `admissibleCoeff_two_pow_mul_le : 2^k · c(t) ≤ c(t+k)` — iterate of the one-step
+  lower bound; after k steps the coefficient grows by ≥ 2^k.
+- `admissibleCoeff_succ_le_two_pow_mul : c(t+k) + 1 ≤ 2^k · (c(t)+1)` — iterate of the
+  one-step ceiling (carry the `+1` to absorb the k floor remainders); equivalently
+  `c(t+k) ≤ 2^k c(t) + (2^k−1)`. Together they bracket c(t+k) ∈ [2^k c(t), 2^k(c(t)+1)−1]:
+  exact exponential rate 2^k up to bounded relative error.
+**Recipe** (ℕ, induction on k, one-step lemma at index t+k with 1≤t+k from ht):
+`rw [show t+(k+1)=(t+k)+1 from by ring, pow_succ', mul_assoc]` then
+`le_trans (Nat.mul_le_mul (le_refl 2) ih) hstep` (lower) / `omega`-derived `h2` +
+`le_trans h2 (Nat.mul_le_mul (le_refl 2) ih)` (upper). `pow_succ'` gives 2^(k+1)=2·2^k,
+`Nat.mul_le_mul (le_refl 2) ih` is version-robust for 2·-monotonicity. zero case `simp`.
+Build GREEN first try (7744 jobs, 3.7s — heavy import chain, no SIGBUS this time).
+
+Still open (unchanged): Lovász-type LLL for ground sets growing with the family — not
+session-sized.

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 390,
+    "lineCount": 437,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 3
   },
   "overview": {
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 390,
+    "lineCount": 437,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

Erdős #1022 OQ-02 asks about the *growth rate* of the admissible Property-B sparseness coefficient `c(t) = ⌊2^{t-1}/|V|⌋`. A prior session pinned the **one-step** recurrence `c(t+1) ∈ {2·c(t), 2·c(t)+1}` (`admissibleCoeff_step_bracket`). This PR lifts it to the genuine **multi-step** exponential growth law.

## New theorems (2, VERIFIED 0 sorries / 0 axioms)

```lean
admissibleCoeff_two_pow_mul_le      : 2 ^ k * c t ≤ c (t + k)
admissibleCoeff_succ_le_two_pow_mul : c (t + k) + 1 ≤ 2 ^ k * (c t + 1)
```

Together they bracket
```
2^k · c(t)  ≤  c(t + k)  ≤  2^k · (c(t) + 1) − 1,
```
i.e. over `k` steps the coefficient grows at exactly exponential rate `2^k`, exceeding pure `2^k`-doubling by at most `2^k − 1` — the geometric sum of the `k` per-step truncated-division `±1` remainders. This is the accumulated form of the one-step "doubles up to ±1" law, and the direct statement of the coefficient's exponential growth rate.

## Proof

Each is a short induction on `k` chaining the corresponding one-step lemma (`admissibleCoeff_ge_two_mul` / `admissibleCoeff_le_two_mul_succ`) at index `t + k` (which is `≥ 1` since `t ≥ 1`) with the `2·`-monotonicity of the induction hypothesis. The upper bound carries a `+1` through the recurrence so the floor remainders absorb cleanly with no ℕ-subtraction.

## Verification

Docker build green: `7744 jobs, 0 sorries, 0 axioms` (Mathlib v4.26). Counts synced 390→437 L / 16→18 thm.

## Still open (unchanged)

The hard regime — a Lovász Local Lemma argument for ground sets growing with the family — remains open and is not session-sized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)