### PR TITLE
Fix: drop dangling companion ref from binomial-theorem-oq-02-oq-01-oq-01 manifest

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -194,9 +194,7 @@
     "definitionCount": 4,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
     "sorries": 0,
-    "additionalFiles": [
-      "Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean"
-    ]
+    "additionalFiles": []
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

The `verified` entry `binomial-theorem-oq-02-oq-01-oq-01` advertised a companion Lean file in `leanFile.additionalFiles` that no longer exists on disk.

## Evidence

**Before**: `leanFile.additionalFiles` = `["Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean"]` — but `git cat-file -e HEAD:...Aristotle.lean` → *absent*. The file was created in #10367 and **deleted in #27408** ("multinomial PMF fully verified") once the entry became sorry-clean; the manifest reference was left dangling. The main proof file does not import it. A gallery-wide scan confirmed this was the **only** missing-file `additionalFiles` reference across all entries.

**After**: `leanFile.additionalFiles` = `[]`. Entry remains `verified`, `sorries: 0`. No sorry-carrying or missing companion references remain (both detectors clean).

Related manifest-hygiene theme: #35854 (sorry-carrying companions; those 21 entries verified still clean here).

---
Automated fix by lean-mechanic agent.