### PR TITLE
Fix: sync meta.json counts for 6 research-updated gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -43,7 +43,7 @@
       "abel-ruffini-oq-04",
       "abel-ruffini-oq-04-oq-03"
     ],
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 4
   },
   "overview": {
@@ -220,7 +220,7 @@
     "namespace": "BringJerrardReduction",
     "lineCount": 376,
     "axiomCount": 1,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 4,
     "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
     "sorries": 0

--- a/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 192,
+    "lineCount": 205,
     "assumptions": "0 sorries, 0 axiom declarations (fully machine-checked). The uncountability core is derived via a Mathlib bridge rather than independently formalized: ¬ Countable ℝ follows from Cardinal.mk_real (#ℝ = 𝔠) and Cardinal.aleph0_lt_continuum (ℵ₀ < 𝔠), and the diagonal gap ℵ₀ < 2^ℵ₀ is Cardinal.cantor. This file supplies the Countable-typeclass reductio, the non-enumerability reformulations, and the transcendentals corollary (composed with the sibling AlgebraicNumbersCountable proof). Badge 'mathlib'.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-04-04",
@@ -411,7 +411,7 @@
       "Cardinal"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02",
-    "lineCount": 192,
+    "lineCount": 205,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 61,
+    "theoremCount": 74,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -74,10 +74,10 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 1218,
+    "lineCount": 1454,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "In 1909, Émile Borel introduced the concept of a **normal number** and proved that almost every real number (in the sense of Lebesgue measure) is absolutely normal. His theorem is a remarkable fact: though normality is the 'generic' property, proving any specific constant is normal has proved extraordinarily difficult.\n\nFor Euler's constant e = 2.71828182845904523536..., we know:\n- e is irrational (Euler, 1737) — proved via continued fractions and factorial series\n- e is transcendental (Hermite, 1873) — not a root of any polynomial with integer coefficients\n- e has a regular continued fraction [2; 1, 2, 1, 1, 4, 1, 1, 6, 1, 1, 8, ...] with a transparent pattern\n- The first 5 × 10¹³ decimal digits of e have been computed; statistical tests detect no anomalies\n\nYet despite all this, we cannot prove e is normal in base 10, base 2, or ANY base. Indeed, no specific real number has ever been proved normal. Borel's theorem proves normality is generic without identifying a single example.\n\nThe irrationality measure of e is exactly 2 (the minimum possible for any irrational) — see e-transcendental-oq-03. This excellent rational approximability property comes from the predictable continued fraction, but paradoxically does not help prove normality.",
@@ -207,10 +207,10 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 1218,
+    "lineCount": 1454,
     "axiomCount": 1,
-    "theoremCount": 69,
-    "definitionCount": 5,
+    "theoremCount": 74,
+    "definitionCount": 6,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 46,
     "defCount": 4,
-    "lineCount": 676,
+    "lineCount": 709,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 676,
+    "lineCount": 709,
     "axiomCount": 0,
-    "theoremCount": 44,
+    "theoremCount": 46,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -51,8 +51,8 @@
     "axiomCount": 1,
     "lineCount": 421,
     "assumptions": "1 axiom: moreeOsburnWorks (the two deep geometric facts about the box-truncated lattice — the 4-point property and the Landau/x²+2y² distinct-distance bound m/√(log m); not available in Mathlib 4.26). The cardinality (2k+1)² is now a verified theorem (moreeOsburnLattice_card), not an assumption. 0 sorries.",
-    "theoremCount": 16,
-    "definitionCount": 10
+    "theoremCount": 18,
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "This problem explores the interplay between local constraints (every 4 points determine many distances) and global behavior (few total distances). It belongs to the rich tradition of Erdős distance problems, initiated by Erdős himself in 1946 when he asked for the minimum number of distinct distances determined by $n$ points in the plane — a question that drove combinatorial geometry for decades and was finally resolved by Guth and Katz (2015) who proved the $\\Omega(n/\\log n)$ lower bound using algebraic methods.\n\nErdős believed configurations satisfying the 4-point property with few distances should exist, and that their study would illuminate the structure of extremal distance sets. The solution came from an unexpected direction: algebraic number theory. Moree and Osburn (2006) discovered that points on a 'stretched' integer lattice $\\{(a, b\\sqrt{2}) : a,b \\in \\mathbb{Z}\\}$ have the remarkable property of avoiding regular geometric configurations while having few distinct distances. The key insight is that squared distances in this lattice are integers of the form $x^2 + 2y^2$ — a positive definite binary quadratic form of discriminant $-8$.\n\nBy Landau's theorem (1908), the count of positive integers $\\leq N$ representable as $x^2 + Dy^2$ is asymptotic to $C_D \\cdot N/\\sqrt{\\log N}$, where $C_D$ depends on the class number of $\\mathbb{Q}(\\sqrt{-D})$. For $D = 2$, the class number of $\\mathbb{Q}(\\sqrt{-2})$ is 1, and $C_2 = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3,5 \\pmod{8}} (1 - p^{-2})^{-1/2}$. This controls the distinct distance count.\n\nLund and Sheffer independently found this construction. The 4-point property was verified by classifying all six configurations of 4 points with exactly 2 distances (the square, two types of rhombus, two isosceles trapezoids, and a pentagon subset) and showing the $\\sqrt{2}$-stretching eliminates each. Grayzel later completed the proof by ruling out the pentagon configuration using computer-assisted verification.",
@@ -143,7 +143,7 @@
     "lineCount": 421,
     "axiomCount": 1,
     "theoremCount": 18,
-    "definitionCount": 10,
+    "definitionCount": 9,
     "path": "Proofs/Erdos659Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -25,8 +25,8 @@
     "axiomCount": 0,
     "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, 0 structure-encoded hypotheses, no `native_decide` (so no `Lean.ofReduceBool`). `#print axioms` for `torusHom_conj_unipotent` and `card_torus_range` reports only the ordinary foundational axioms `propext`, `Classical.choice`, `Quot.sound`. Every result is machine-checked from Mathlib. The parent simplicity theorem for PSL(2, p) remains open; this entry proves only the verified unipotent-subgroup and split-torus infrastructure and makes no claim about the open question itself.",
     "lineCount": 544,
-    "theoremCount": 18,
-    "definitionCount": 4,
+    "theoremCount": 33,
+    "definitionCount": 7,
     "originalContributions": [
       "unipotentUpper: the matrix [[1,t],[0,1]] packaged as a determinant-1 element of SL(2, ZMod p)",
       "unipotentUpper_mul: additivity [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]], giving an abelian one-parameter subgroup",
@@ -259,7 +259,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 7,
-    "theoremCount": 24
+    "theoremCount": 33
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Six gallery entries had stale `lineCount` / `theoremCount` / `definitionCount` in their `meta.json` after recent research PRs grew the underlying Lean files. Both the `leanFile.*` and the `meta.*` count blocks had drifted (the `meta.*` block was staler in several cases).

## Evidence

Counts recomputed from a comment-stripped scan of each `proofs/Proofs/*.lean` source (nested `/- -/`, line `--`, and backtick spans removed). For every entry `strip == raw`, so there are no docstring false-positives. `lineCount` matches `wc -l`. `axiomCount` was already accurate and is left untouched.

| entry | drift fixed |
|---|---|
| abel-ruffini-oq-04-oq-07 | thm 12→14 |
| algebraic-numbers-countable-oq-02 | line 192→205 |
| e-transcendental-oq-02 | line 1218→1454, thm 69/61→74, def 5→6 |
| elementary-quadratic-reciprocity-oq-03-oq-02 | line 676→709, thm 44/32→46 |
| erdos-659 | thm 16→18, def 10→9 |
| sylow-theorem-oq-04-oq-03 | thm 24/18→33, def 4→7 |

Pure metadata; numeric-only diff (20 insertions / 20 deletions), all JSON validated. Build-independent.

---
Automated fix by lean-mechanic agent.