### PR TITLE
Enrich Weitzenböck (herons-formula-oq-07): add weitzenbock_sq_eq_iff to mainTheorems

### DIFF
--- a/src/data/proofs/herons-formula-oq-07/meta.json
+++ b/src/data/proofs/herons-formula-oq-07/meta.json
@@ -42,6 +42,12 @@
       "leanType": "48 * heronProduct a b c ≤ (a^2 + b^2 + c^2)^2"
     },
     {
+      "name": "weitzenbock_sq_eq_iff",
+      "type": "supporting",
+      "description": "The square-free equality condition: (a²+b²+c²)² = 48·heronProduct holds iff a² = b² and b² = c². Reads the SOS identity backwards so each summand (a²-b²)², (b²-c²)², (c²-a²)² must vanish. This is the algebraic pivot that weitzenbock_eq_iff upgrades to the geometric equilateral case, separating the square-free algebra from the final positivity step.",
+      "leanType": "(a^2 + b^2 + c^2)^2 = 48 * heronProduct a b c ↔ a^2 = b^2 ∧ b^2 = c^2"
+    },
+    {
       "name": "weitzenbock",
       "type": "main",
       "description": "Weitzenböck's inequality: for any nondegenerate triangle, 4√3·Area ≤ a² + b² + c².",


### PR DESCRIPTION
Enrichment pass for `herons-formula-oq-07` (quality 94, passes 0).

This entry is already thoroughly enriched (11 KB meta, 6 richly-annotated sections), so rather than inflate prose I filled a genuine **structural gap**:

- `weitzenbock_sq_eq_iff` — the square-free equality condition `(a²+b²+c²)² = 48·heronProduct ↔ a² = b² ∧ b² = c²`, which is the algebraic pivot for the equality case and was given its own annotation in #35903 — was **missing from the `mainTheorems` array**. Only 4 of the file's key theorems were listed.
- Added it with its `leanType` and a description of its role (reads the SOS identity backwards; upgraded to the equilateral case by `weitzenbock_eq_iff`).

meta.json grew 11462 → 12029 bytes, well under the 60 KB cap. Gallery-data validation stages of `pnpm build` pass.