### PR TITLE
research(erdos-1064-oq-03): total decidable classifier over all odd seeds [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -1310,5 +1310,135 @@ theorem least_reversal_seed_families :
   obtain ⟨ha_odd, hstep, hb, hC0, hCe⟩ := hv
   rw [mem_ReversalSet_iff_classify ha_odd hstep hb hC0 hCe k]
   exact twentyone_least_reversal_seed.2 a ha ⟨ha_odd, hstep, hb, hC0, hCe⟩
+-- ===========================================================================
+-- A TOTAL DECIDABLE CLASSIFIER FOR EVERY ODD SEED
+--
+-- The general criterion `dblIter_*_iff_general` decides the regime of the family
+-- `n = a·2^(k+1)` from data `(s, b, t, e)` that must be *supplied* by hand for
+-- each seed.  Here we make that data COMPUTABLE: `seedS/seedB/seedC/seedT/seedE`
+-- extract `(s, b, t, e)` from `a` by two 2-adic valuations, and `classifySeed a`
+-- reads off the regime.  `seed_spec` proves the extracted data satisfies every
+-- hypothesis of the general criterion for arbitrary odd `a ≥ 3`, so the three
+-- `classifySeed_*_iff` corollaries turn the whole trichotomy into a single
+-- decision procedure — the reversal seed set is `{a | classifySeed a = .lt}`.
+-- ===========================================================================
+
+/-- First-step 2-adic valuation `s = v₂(2a − φ(a))`. -/
+def seedS (a : ℕ) : ℕ := (2 * a - Nat.totient a).factorization 2
+
+/-- Odd part `b` of the first cototient step: `2a − φ(a) = 2^s · b`. -/
+def seedB (a : ℕ) : ℕ := (2 * a - Nat.totient a) / 2 ^ seedS a
+
+/-- Landing constant `C = 2a − φ(b)·2^(s−1)` (the double iterate `D(a·2^(k+1))`
+    equals `C·2^k`). -/
+def seedC (a : ℕ) : ℕ := 2 * a - Nat.totient (seedB a) * 2 ^ (seedS a - 1)
+
+/-- Second 2-adic valuation `t = v₂(C)`. -/
+def seedT (a : ℕ) : ℕ := (seedC a).factorization 2
+
+/-- Odd part `e` of the landing constant: `C = 2^t · e`. -/
+def seedE (a : ℕ) : ℕ := seedC a / 2 ^ seedT a
+
+/-- **Total classifier.**  Compares `φ(a)` with `φ(e)·2^(t−1)`; for every odd
+    `a ≥ 3` this decides which regime the whole family `n = a·2^(k+1)` lands in:
+    `lt` = reversal `φ(n) < φ(D(n))`, `eq` = equality, `gt` = forward. -/
+def classifySeed (a : ℕ) : Ordering :=
+  compare (Nat.totient a) (Nat.totient (seedE a) * 2 ^ (seedT a - 1))
+
+/-- **Correctness of the extraction.**  For odd `a ≥ 3` the computed data
+    `(seedS a, seedB a, seedT a, seedE a)` satisfies every hypothesis of the
+    general transport criterion: `b, e` are odd, `s, t ≥ 1`, and the two defining
+    2-adic factorisations hold.  (Oddness of `a` is not needed here — it enters
+    only through the family's coprimality in the criterion below.) -/
+theorem seed_spec {a : ℕ} (ha3 : 3 ≤ a) :
+    Odd (seedB a) ∧ Odd (seedE a) ∧ 1 ≤ seedS a ∧ 1 ≤ seedT a ∧
+    2 * a - Nat.totient a = 2 ^ seedS a * seedB a ∧
+    2 * a - Nat.totient (seedB a) * 2 ^ (seedS a - 1) = seedE a * 2 ^ seedT a := by
+  simp only [seedS, seedB, seedC, seedT, seedE]
+  have ha1 : 1 < a := by omega
+  have hφa_lt : Nat.totient a < a := Nat.totient_lt a ha1
+  obtain ⟨j, hj⟩ := Nat.totient_even (show 2 < a by omega)
+  have hφa_pos : 0 < Nat.totient a := Nat.totient_pos.mpr (by omega)
+  set m := 2 * a - Nat.totient a with hm
+  have hm_ne : m ≠ 0 := by omega
+  have hm_dvd : 2 ∣ m := ⟨a - j, by omega⟩
+  set s := m.factorization 2 with hs
+  set b := m / 2 ^ s with hb
+  have hs1 : 1 ≤ s := by
+    have h := Nat.prime_two.factorization_pos_of_dvd hm_ne hm_dvd
+    rw [← hs] at h; omega
+  -- 2^s · b = m  and  b odd, both from the 2-adic decomposition of m
+  have hsb : 2 ^ s * b = m := Nat.ordProj_mul_ordCompl_eq_self m 2
+  have hob : Odd b := by
+    have hnd : ¬ 2 ∣ b := Nat.not_dvd_ordCompl Nat.prime_two hm_ne
+    exact Nat.odd_iff.mpr (by omega)
+  -- 2^s = 2·2^(s−1) so b·2^(s−1) is exactly m/2
+  have h2s : 2 ^ s = 2 * 2 ^ (s - 1) := by
+    conv_lhs => rw [show s = (s - 1) + 1 from by omega, pow_succ]
+    ring
+  have hbpow : 2 * (b * 2 ^ (s - 1)) = m := by rw [← hsb, h2s]; ring
+  have hmul_le : Nat.totient b * 2 ^ (s - 1) ≤ b * 2 ^ (s - 1) := by
+    gcongr
+    exact Nat.totient_le b
+  have hterm_le : Nat.totient b * 2 ^ (s - 1) ≤ a - 1 := by omega
+  -- the landing term is even (hence C is even, with v₂ ≥ 1)
+  have hterm_dvd : 2 ∣ Nat.totient b * 2 ^ (s - 1) := by
+    rcases hs1.lt_or_eq with hs_gt | hs_eq
+    · exact (dvd_pow_self 2 (show s - 1 ≠ 0 by omega)).mul_left _
+    · -- s = 1: then b ≠ 1 (else m = 2 contradicts a ≥ 3), so b ≥ 3 and φ(b) is even
+      have hb_ne1 : b ≠ 1 := by
+        intro hb1
+        have hval : (2 : ℕ) ^ s * b = 2 := by rw [← hs_eq, hb1]; norm_num
+        rw [hsb] at hval; omega
+      have hb3 : 2 < b := by rcases hob with ⟨i, hi⟩; omega
+      rw [← hs_eq]
+      simpa using (Nat.totient_even hb3).two_dvd
+  set C := 2 * a - Nat.totient b * 2 ^ (s - 1) with hC
+  have hC_ne : C ≠ 0 := by omega
+  have hC_dvd : 2 ∣ C := by omega
+  set t := C.factorization 2 with ht
+  set e := C / 2 ^ t with he
+  have ht1 : 1 ≤ t := by
+    have h := Nat.prime_two.factorization_pos_of_dvd hC_ne hC_dvd
+    rw [← ht] at h; omega
+  have hst : 2 ^ t * e = C := Nat.ordProj_mul_ordCompl_eq_self C 2
+  have hoe : Odd e := by
+    have hnd : ¬ 2 ∣ e := Nat.not_dvd_ordCompl Nat.prime_two hC_ne
+    exact Nat.odd_iff.mpr (by omega)
+  have hCeq : C = e * 2 ^ t := by rw [← hst]; ring
+  exact ⟨hob, hoe, hs1, ht1, hsb.symm, hCeq⟩
+
+/-- **The classifier decides reversal.**  For odd `a ≥ 3`, `φ(n) < φ(D(n))` along
+    `n = a·2^(k+1)` iff `classifySeed a = .lt`. -/
+theorem classifySeed_lt_iff {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a) (k : ℕ) :
+    a * 2 ^ (k + 1) ∈ ReversalSet ↔ classifySeed a = Ordering.lt := by
+  obtain ⟨hob, hoe, hs1, ht1, hstep, hCeq⟩ := seed_spec ha3
+  rw [dblIter_reversal_iff_general ha hob hoe hs1 ht1 hstep hCeq k]
+  exact compare_lt_iff_lt.symm
+
+/-- **The classifier decides equality.** -/
+theorem classifySeed_eq_iff {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a) (k : ℕ) :
+    a * 2 ^ (k + 1) ∈ EqualitySet ↔ classifySeed a = Ordering.eq := by
+  obtain ⟨hob, hoe, hs1, ht1, hstep, hCeq⟩ := seed_spec ha3
+  rw [dblIter_equality_iff_general ha hob hoe hs1 ht1 hstep hCeq k]
+  exact compare_eq_iff_eq.symm
+
+/-- **The classifier decides the forward regime.** -/
+theorem classifySeed_gt_iff {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a) (k : ℕ) :
+    a * 2 ^ (k + 1) ∈ ForwardSet ↔ classifySeed a = Ordering.gt := by
+  obtain ⟨hob, hoe, hs1, ht1, hstep, hCeq⟩ := seed_spec ha3
+  rw [dblIter_forward_iff_general ha hob hoe hs1 ht1 hstep hCeq k]
+  exact compare_gt_iff_gt.symm
+
+/-- **Total trichotomy.**  For every odd `a ≥ 3` the computable `classifySeed a`
+    correctly decides the regime of the whole family `n = a·2^(k+1)` — a single
+    decision procedure covering all seeds, `k`-free and with no restriction on the
+    first-step 2-adic valuation.  In particular the reversal seed set is the
+    decidable predicate `{a | classifySeed a = Ordering.lt}`. -/
+theorem classifySeed_classifies {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a) (k : ℕ) :
+    (a * 2 ^ (k + 1) ∈ ReversalSet ↔ classifySeed a = Ordering.lt) ∧
+    (a * 2 ^ (k + 1) ∈ EqualitySet ↔ classifySeed a = Ordering.eq) ∧
+    (a * 2 ^ (k + 1) ∈ ForwardSet ↔ classifySeed a = Ordering.gt) :=
+  ⟨classifySeed_lt_iff ha ha3 k, classifySeed_eq_iff ha ha3 k, classifySeed_gt_iff ha ha3 k⟩
 
 end Erdos1064OQ03

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -48,3 +48,39 @@ File 794→829 lines, 56 theorems. NO gallery meta references EulerTotientOQ04OQ
 (research file), so no count sync. Density-1 forward remains the sole deep-open direction
 (needs ψ(x,y)). Further reversal seeds (129,165,175) and the excluded v₂(2a−φ(a))>1 case
 remain as future elementary increments.
+
+## Session 2026-07-08 (researcher-6) — Total decidable classifier
+
+**Mode**: REVISIT | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom)
+
+### What I Did
+- Turned the k-free three-way criterion into a COMPUTABLE total classifier in
+  `EulerTotientOQ04OQ03.lean`:
+  - `seedS/seedB/seedC/seedT/seedE`: from an odd seed `a`, extract `(s,b,t,e)`
+    by two 2-adic valuations — `s=v₂(2a−φ(a))`, `b`=odd part, landing
+    `C=2a−φ(b)·2^(s−1)`, `t=v₂(C)`, `e`=odd part of `C`.
+  - `classifySeed a := compare (φ a) (φ(seedE a)·2^(seedT a−1))`.
+- `seed_spec` (holds for all `a≥3`, oddness of `a` not required): the extracted
+  data meets every hypothesis of `dblIter_*_iff_general` — `Odd b`, `Odd e`,
+  `s,t≥1`, `2a−φ(a)=2^s·b`, `2a−φ(b)·2^(s−1)=e·2^t`.
+- `classifySeed_lt_iff/_eq_iff/_gt_iff` + `classifySeed_classifies`: for every
+  odd `a≥3`, `classifySeed a` correctly decides the regime of `a·2^(k+1)`.
+
+### Key Findings
+- The extraction is total: `C>0` always (φ(b)·2^(s−1) ≤ b·2^(s−1) = (2a−φ(a))/2
+  < 2a), and `C` is even for `a≥3` because the only obstruction `s=1 ∧ b=1`
+  forces `φ(a)=2a−2`, impossible for `a≥3` (φ(a)≤a−1). So `t≥1`.
+- Mathlib plumbing: `Nat.ordProj_mul_ordCompl_eq_self` gives `2^v·oddpart = n`
+  by defeq (no rewriting), `Nat.not_dvd_ordCompl` gives oddness; in this build
+  `not_dvd_ordCompl` wants `Nat.Prime` (not `Prime`), and `Nat.totient_lt` takes
+  `n` explicitly.
+- The reversal seed set is now the decidable predicate `{a | classifySeed a = .lt}`.
+
+### Files Modified
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (1048→1179; +6 defs, +5 theorems)
+- `src/data/research/problems/erdos-1064-oq-03.json`
+
+### Next Steps
+- Characterise `{odd a≥3 | classifySeed a = .lt}` structurally, or prove
+  `seedS a ≥ 2 ⇒ classifySeed a ≠ .lt` (no excluded seed reverses; observed a<120).
+- Density-1 forward stays analytically blocked (ψ(x,y)/Luca–Pomerance gap).

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (verified 0/0): the k-free three-way criterion is now both a COMPUTABLE decision procedure classify:ℕ→Ordering on the single odd seed AND (PR #35885) generalised past the v₂(2a−φ(a))=1 restriction via dblIter_transport_general, so it covers arbitrary first-step 2-adic valuation. NEW: 21 is proven the SMALLEST odd reversal seed via a kernel-decide sweep over the classifier — the only valid seeds <21 are 5,13,15,17 (eq/gt/eq/gt), so classify 21 = .lt is the least; both classifier-form (twentyone_least_reversal_seed) and set-form (least_reversal_seed_families) theorems, 0 native_decide. Excluded seeds realise equality (3,9) and forward (7,27) but — brute a<120 — never reversal. Density-1 forward remains the sole analytically-blocked direction.",
+    "progressSummary": "PROGRESS (verified 0/0): the k-free three-way criterion is now (a) a COMPUTABLE decision procedure classify:ℕ→Ordering on the single odd seed, generalised past the v₂(2a−φ(a))=1 restriction (PR #35885, dblIter_transport_general); (b) upgraded to a TOTAL decidable classifier classifySeed:ℕ→Ordering that reads the regime off ANY odd seed a≥3 via two 2-adic valuations (seed_spec proves the extraction meets every general-criterion hypothesis with no v₂ restriction) — the reversal seed set is the decidable predicate {a | classifySeed a = .lt}; and (c) used to prove 21 is the SMALLEST odd reversal seed via a kernel-decide sweep (the only valid seeds <21 are 5,13,15,17, classifying eq/gt/eq/gt), theorems twentyone_least_reversal_seed + least_reversal_seed_families, 0 native_decide. Excluded seeds realise equality (3,9) and forward (7,27) but — brute a<120 — never reversal. Density-1 forward remains the sole analytically-blocked direction.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -80,7 +80,10 @@
       "ValidSeed predicate + DecidablePred instance (EulerTotientOQ04OQ03.lean): odd a, v2(2a-phi a)=1, landing constant nonzero&even — exactly the classifier side-conditions",
       "classify_5 = .eq, classify_17 = .gt (EulerTotientOQ04OQ03.lean): concrete classifier evaluations via landT_landE_of rewriting (no native_decide)",
       "twentyone_least_reversal_seed (EulerTotientOQ04OQ03.lean): classify 21 = .lt AND every valid seed a<21 classifies .eq/.gt — 21 is the least odd reversal seed",
-      "least_reversal_seed_families (EulerTotientOQ04OQ03.lean): set form — 21*2^(k+1) reverses for all k, no valid odd a<21 gives a reversal family"
+      "least_reversal_seed_families (EulerTotientOQ04OQ03.lean): set form — 21*2^(k+1) reverses for all k, no valid odd a<21 gives a reversal family",
+      "EulerTotientOQ04OQ03.lean: seedS/seedB/seedC/seedT/seedE (computable 2-adic extraction) + classifySeed a := compare (φ a) (φ(seedE a)·2^(seedT a −1))",
+      "EulerTotientOQ04OQ03.lean: seed_spec — for a≥3, extracted (s,b,t,e) satisfy Odd b, Odd e, s≥1, t≥1, 2a−φ(a)=2^s·b, 2a−φ(b)·2^(s−1)=e·2^t (Nat.ordProj_mul_ordCompl_eq_self / not_dvd_ordCompl; C-even by s=1 vs s≥2 split, s=1∧b=1 ruled out)",
+      "EulerTotientOQ04OQ03.lean: classifySeed_lt_iff/_eq_iff/_gt_iff + classifySeed_classifies — classifySeed correctly decides Reversal/Equality/Forward for every odd a≥3 [VERIFIED 0/0]"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -101,12 +104,14 @@
       "Excluded case v₂(2a−φ(a))>1 is fully tractable: general transport gives landing C=2a−φ(b)·2^(s−1)=e·2^t, criterion reads φ(a)⋛φ(e)·2^(t−1)",
       "Structural: among excluded seeds a<120 (v₂≥2) ONLY equality/forward regimes occur — no excluded seed reverses; all known reversal seeds (21,55,129,165,175) have v₂=1",
       "The valid odd seeds below 21 are exactly {5,13,15,17}, classifying eq/gt/eq/gt; all invalid a<21 fail decidably on v2(2a-phi a)=1 or bSeed-odd, using only phi (no factorization). Hence 21 is the smallest odd reversal seed.",
-      "The sub-21 sweep is kernel-decide-only: interval_cases + `try (exact absurd hv (by decide))` discharges the invalid seeds (validity touches only phi, not factorization), leaving 5,13,15,17 handled by the classify_* lemmas."
+      "The sub-21 sweep is kernel-decide-only: interval_cases + `try (exact absurd hv (by decide))` discharges the invalid seeds (validity touches only phi, not factorization), leaving 5,13,15,17 handled by the classify_* lemmas.",
+      "Total decidable classifier: the k-free three-way criterion becomes a COMPUTABLE function classifySeed : ℕ → Ordering. From an odd seed a it extracts (s,b,t,e) by two 2-adic valuations — s=v₂(2a−φ(a)), b=oddpart, C=2a−φ(b)·2^(s−1), t=v₂(C), e=oddpart(C) — and compares φ(a) ⋛ φ(e)·2^(t−1). seed_spec proves the extraction meets every criterion hypothesis for ALL a≥3 (oddness of a not needed). The reversal seed set is the decidable predicate {a | classifySeed a = .lt}."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
     ],
     "nextSteps": [
+      "Characterise {odd a≥3 | classifySeed a = .lt} structurally, or prove seedS a ≥ 2 ⇒ classifySeed a ≠ .lt (no excluded seed reverses; observed a<120).",
       "Density-1 forward statement φ(n)>φ(D(n)) for almost all n remains the sole analytically-blocked open direction (needs Luca–Pomerance / ψ(x,y) density, a real Mathlib gap); the explicit families + criterion settle only the infinitely-often / structural questions.",
       "Turn the criterion into a genuine DECIDABLE classifier: given odd a, compute b=(2a−φ(a))/2 (requires v₂(2a−φ(a))=1), then the 2-adic split C=2a−φ(b)=e·2^t, and decide the regime by φ(a) vs φ(e)·2^(t−1). Formalising the v₂ extraction (t,e) as a computable function would give a decision procedure over all odd seeds.",
       "Characterise the reversal seed set {odd a : φ(a) < φ(e)·2^(t−1)} — a structural description of which odd seeds reverse (a=21 smallest) would be a new elementary result now that the per-seed test is k-free.",


### PR DESCRIPTION
## Summary
Follow-up to the merged general-transport work (#35885). Turns the `k`-free three-way criterion (`dblIter_*_iff_general`) into a **computable total classifier** `classifySeed : ℕ → Ordering` in `proofs/Proofs/EulerTotientOQ04OQ03.lean`.

From an odd seed `a`, the classifier extracts the transport data `(s,b,t,e)` by two 2-adic valuations:
- `s = v₂(2a − φ(a))`, `b` = odd part  (so `2a − φ(a) = 2^s·b`);
- landing constant `C = 2a − φ(b)·2^(s−1)`, `t = v₂(C)`, `e` = odd part of `C`  (so `C = 2^t·e`);
- then compares `φ(a)` with `φ(e)·2^(t−1)`.

## New declarations
- `seedS / seedB / seedC / seedT / seedE` — computable extraction
- `classifySeed` — the `Ordering`-valued decision function
- `seed_spec` — for **all** `a ≥ 3` (oddness of `a` not needed) the extracted data satisfies every hypothesis of the general criterion: `Odd b`, `Odd e`, `s,t ≥ 1`, `2a−φ(a)=2^s·b`, `2a−φ(b)·2^(s−1)=e·2^t`
- `classifySeed_lt_iff / _eq_iff / _gt_iff` + `classifySeed_classifies` — for every odd `a ≥ 3`, `classifySeed a` correctly decides which regime the whole family `n = a·2^(k+1)` lands in (reversal / equality / forward)

**Consequence:** the reversal seed set is now the *decidable* predicate `{a | classifySeed a = Ordering.lt}`.

## Totality
The extraction is total: `C > 0` always (`φ(b)·2^(s−1) ≤ b·2^(s−1) = (2a−φ(a))/2 < 2a`), and `C` is even for every `a ≥ 3` — the only obstruction `s=1 ∧ b=1` would force `φ(a)=2a−2`, impossible since `φ(a) ≤ a−1`. Built on `Nat.ordProj_mul_ordCompl_eq_self` / `Nat.not_dvd_ordCompl`.

## Verification
`docker-build Proofs.EulerTotientOQ04OQ03` → `[3058/3058]`, **0 sorries, 0 axioms**, no `native_decide` (all `omega`/`gcongr`/`ring`/`simp` — kernel-checked). File 1048→1179 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)