### PR TITLE
Fix: sync stale meta counts to Lean source (4 gallery entries)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 192,
+    "lineCount": 205,
     "assumptions": "0 sorries, 0 axiom declarations (fully machine-checked). The uncountability core is derived via a Mathlib bridge rather than independently formalized: ¬ Countable ℝ follows from Cardinal.mk_real (#ℝ = 𝔠) and Cardinal.aleph0_lt_continuum (ℵ₀ < 𝔠), and the diagonal gap ℵ₀ < 2^ℵ₀ is Cardinal.cantor. This file supplies the Countable-typeclass reductio, the non-enumerability reformulations, and the transcendentals corollary (composed with the sibling AlgebraicNumbersCountable proof). Badge 'mathlib'.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-04-04",
@@ -411,7 +411,7 @@
       "Cardinal"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02",
-    "lineCount": 192,
+    "lineCount": 205,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 61,
+    "theoremCount": 74,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -74,10 +74,10 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 1218,
+    "lineCount": 1454,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "In 1909, Émile Borel introduced the concept of a **normal number** and proved that almost every real number (in the sense of Lebesgue measure) is absolutely normal. His theorem is a remarkable fact: though normality is the 'generic' property, proving any specific constant is normal has proved extraordinarily difficult.\n\nFor Euler's constant e = 2.71828182845904523536..., we know:\n- e is irrational (Euler, 1737) — proved via continued fractions and factorial series\n- e is transcendental (Hermite, 1873) — not a root of any polynomial with integer coefficients\n- e has a regular continued fraction [2; 1, 2, 1, 1, 4, 1, 1, 6, 1, 1, 8, ...] with a transparent pattern\n- The first 5 × 10¹³ decimal digits of e have been computed; statistical tests detect no anomalies\n\nYet despite all this, we cannot prove e is normal in base 10, base 2, or ANY base. Indeed, no specific real number has ever been proved normal. Borel's theorem proves normality is generic without identifying a single example.\n\nThe irrationality measure of e is exactly 2 (the minimum possible for any irrational) — see e-transcendental-oq-03. This excellent rational approximability property comes from the predictable continued fraction, but paradoxically does not help prove normality.",
@@ -207,10 +207,10 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 1218,
+    "lineCount": 1454,
     "axiomCount": 1,
-    "theoremCount": 69,
-    "definitionCount": 5,
+    "theoremCount": 74,
+    "definitionCount": 6,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 32,
+    "theoremCount": 46,
     "defCount": 4,
-    "lineCount": 676,
+    "lineCount": 709,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 676,
+    "lineCount": 709,
     "axiomCount": 0,
-    "theoremCount": 44,
+    "theoremCount": 46,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/simson-line-theorem-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01/meta.json
@@ -93,11 +93,11 @@
     ],
     "dateAdded": "2026-06-16",
     "axiomCount": 0,
-    "lineCount": 364,
+    "lineCount": 146,
     "assumptions": "0 axioms. 0 sorries. Fully verified. Circumcircle normalised to the unit circle (Complex.normSq = 1) without loss of generality; on that normalisation the orthocenter is A+B+C.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
-    "definitionCount": 4
+    "theoremCount": 8,
+    "definitionCount": 1
   },
   "sections": [
     {
@@ -212,7 +212,7 @@
       "SimsonLineTheorem"
     ],
     "namespace": "SimsonLineTheoremOQ01",
-    "lineCount": 364,
+    "lineCount": 146,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,


### PR DESCRIPTION
## Summary

Repairs count-metadata drift found by a gallery-wide scan. Four entries had `lineCount`/`theoremCount`/`definitionCount` that no longer matched their Lean source (files grew or shrank via later research PRs). Several also had **internal disagreements** between the `.meta` and `.leanFile` count blocks — this PR reconciles both blocks to the true file counts.

| Entry | lineCount | theoremCount | definitionCount |
|---|---|---|---|
| algebraic-numbers-countable-oq-02 | 192 → **205** | 11 | 1 |
| e-transcendental-oq-02 | 1218 → **1454** | 61/69 → **74** | 5 → **6** |
| elementary-quadratic-reciprocity-oq-03-oq-02 | 676 → **709** | 32/44 → **46** | 4 |
| simson-line-theorem-oq-01 | 364 → **146** | 20 → **8** | 4 → **1** |

## Verification

- `lineCount` = `wc -l` (newline count) of the main Lean file.
- `theoremCount`/`definitionCount` from a block/line-comment-stripped declaration scan that correctly handles `private`/attributed lemmas (e.g. simson's 4 `private lemma`s + 4 `theorem`s = 8).
- Confirmed none of the four files contain string-literal comment markers, so the stripper is exact — no under-count risk.
- Diff is count-fields-only; no formatting churn.

Build-independent metadata repair; no Lean source changed.