### PR TITLE
research(erdos-1064-oq-03): 21 is the smallest odd reversal seed [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -1233,4 +1233,82 @@ theorem excluded_seeds_realize_equality_and_forward :
   ⟨mem_EqualitySet_three, mem_EqualitySet_nine,
    mem_ForwardSet_seven, mem_ForwardSet_twentyseven⟩
 
+-- ===========================================================================
+-- THE SMALLEST ODD REVERSAL SEED IS 21
+-- ---------------------------------------------------------------------------
+-- Now that `classify` is a genuine computable function on the single odd seed,
+-- we can settle a structural question the per-`k` families left open: *which*
+-- odd seed is the smallest whose transport family `a·2^(k+1)` reverses.  A seed
+-- `a` is admissible for the classifier ("valid") exactly when the transport
+-- hypotheses hold: `a` odd, the first cototient step `2a−φ(a)` has 2-adic
+-- valuation one (`bSeed a` odd), and the landing constant is nonzero and even.
+-- Sweeping the odd valid seeds below 21 shows only `5, 13, 15, 17` are valid,
+-- and they classify as `eq, gt, eq, gt` — none reverse — whereas `classify 21`
+-- is `.lt`.  Hence 21 is the least odd reversal seed.  The whole sweep stays
+-- kernel-`decide`-only (no `native_decide`, no `factorization` reduction): the
+-- validity test uses only `φ`, and the four surviving seeds are evaluated
+-- through the `landT_landE_of` rewriting helper.
+-- ===========================================================================
+
+/-- A seed `a` is *valid* for the transport classifier when it is odd, its first
+    cototient step `2a − φ(a)` has 2-adic valuation exactly one (equivalently
+    `bSeed a` is odd), and its landing constant is nonzero and even.  These are
+    precisely the side-conditions under which `classify a` faithfully decides the
+    regime of the family `a·2^(k+1)`. -/
+def ValidSeed (a : ℕ) : Prop :=
+  Odd a ∧ 2 ∣ coStep a ∧ Odd (bSeed a) ∧ landC a ≠ 0 ∧ 2 ∣ landC a
+
+instance : DecidablePred ValidSeed := fun a => by unfold ValidSeed; infer_instance
+
+/-- `classify 5 = .eq`: `b = 3`, `C = 8 = 1·2^3`, `t = 3`, `e = 1`, and
+    `φ(5) = 4 = 1·2^2 = φ(1)·2^(t−1)`. -/
+theorem classify_5 : classify 5 = Ordering.eq := by
+  have hb : bSeed 5 = 3 := by unfold bSeed coStep; norm_num [totient_5]
+  have hC : landC 5 = 8 := by unfold landC; norm_num [hb, totient_3]
+  obtain ⟨hT, hE⟩ := landT_landE_of (a := 5) (e := 1) (t := 3)
+    (by decide) (by norm_num [hC])
+  unfold classify
+  rw [hE, hT, totient_5, Nat.totient_one]
+  decide
+
+/-- `classify 17 = .gt`: `b = 9`, `C = 28 = 7·2^2`, `t = 2`, `e = 7`, and
+    `φ(7)·2^(t−1) = 6·2 = 12 < 16 = φ(17)`. -/
+theorem classify_17 : classify 17 = Ordering.gt := by
+  have hb : bSeed 17 = 9 := by unfold bSeed coStep; norm_num [totient_17]
+  have hC : landC 17 = 28 := by unfold landC; norm_num [hb, totient_9]
+  obtain ⟨hT, hE⟩ := landT_landE_of (a := 17) (e := 7) (t := 2)
+    (by decide) (by norm_num [hC])
+  unfold classify
+  rw [hE, hT, totient_17, totient_7]
+  decide
+
+/-- **21 is the smallest odd reversal seed (classifier form).**  `classify 21`
+    is `.lt`, while every valid seed `a < 21` is classified `.eq` or `.gt`.  The
+    only valid seeds below 21 are `5, 13, 15, 17`; all invalid `a < 21` fail the
+    validity test decidably (the sweep only touches `φ`, never `factorization`). -/
+theorem twentyone_least_reversal_seed :
+    classify 21 = Ordering.lt ∧
+    ∀ a, a < 21 → ValidSeed a → classify a ≠ Ordering.lt := by
+  refine ⟨classify_21, fun a ha hv => ?_⟩
+  interval_cases a <;>
+    try (exact absurd hv (by decide))
+  · rw [classify_5]; decide
+  · rw [classify_13]; decide
+  · rw [classify_15]; decide
+  · rw [classify_17]; decide
+
+/-- **21 is the smallest odd reversal seed (family form).**  The family
+    `21·2^(k+1)` reverses for every `k`, while for every valid odd seed `a < 21`
+    and every `k` the family `a·2^(k+1)` does *not* reverse.  This is the
+    structural sharpening promised once the per-seed test became computable:
+    among transport-admissible odd seeds, 21 is the least whose family lands in
+    the reversal regime `φ(D(n)) > φ(n)`. -/
+theorem least_reversal_seed_families :
+    (∀ k, 21 * 2 ^ (k + 1) ∈ ReversalSet) ∧
+    ∀ a, a < 21 → ValidSeed a → ∀ k, a * 2 ^ (k + 1) ∉ ReversalSet := by
+  refine ⟨decision_procedure_classifies.1, fun a ha hv k => ?_⟩
+  obtain ⟨ha_odd, hstep, hb, hC0, hCe⟩ := hv
+  rw [mem_ReversalSet_iff_classify ha_odd hstep hb hC0 hCe k]
+  exact twentyone_least_reversal_seed.2 a ha ⟨ha_odd, hstep, hb, hC0, hCe⟩
+
 end Erdos1064OQ03

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (verified 0/0): the k-free three-way criterion is now both a COMPUTABLE decision procedure classify:ℕ→Ordering on the single odd seed AND (PR #35885) generalised past the v₂(2a−φ(a))=1 restriction via dblIter_transport_general, so it covers arbitrary first-step 2-adic valuation. Excluded seeds realise equality (3,9) and forward (7,27) but — brute a<120 — never reversal. Density-1 forward remains the sole analytically-blocked direction.",
+    "progressSummary": "PROGRESS (verified 0/0): the k-free three-way criterion is now both a COMPUTABLE decision procedure classify:ℕ→Ordering on the single odd seed AND (PR #35885) generalised past the v₂(2a−φ(a))=1 restriction via dblIter_transport_general, so it covers arbitrary first-step 2-adic valuation. NEW: 21 is proven the SMALLEST odd reversal seed via a kernel-decide sweep over the classifier — the only valid seeds <21 are 5,13,15,17 (eq/gt/eq/gt), so classify 21 = .lt is the least; both classifier-form (twentyone_least_reversal_seed) and set-form (least_reversal_seed_families) theorems, 0 native_decide. Excluded seeds realise equality (3,9) and forward (7,27) but — brute a<120 — never reversal. Density-1 forward remains the sole analytically-blocked direction.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -76,7 +76,11 @@
       "classify_21=.lt, classify_15=.eq, classify_13=.gt + decision_procedure_classifies: the single classifier reproduces reversal/equality/forward families with no per-k work, all via decide (0 native_decide).",
       "dblIter_transport_general (EulerTotientOQ04OQ03.lean): D(a·2^(k+1))=(2a−φ(b)·2^(s−1))·2^k for 2a−φ(a)=2^s·b, s≥1 — removes v₂=1 restriction",
       "dblIter_{reversal,equality,forward}_iff_general + dblIter_totient_values_general: k-free criterion for arbitrary first-step 2-adic valuation",
-      "New excluded-seed families: 3·2^(k+1),9·2^(k+1)∈EqualitySet; 7·2^(k+1),27·2^(k+1)∈ForwardSet (all v₂≥2, outside s=1 criterion)"
+      "New excluded-seed families: 3·2^(k+1),9·2^(k+1)∈EqualitySet; 7·2^(k+1),27·2^(k+1)∈ForwardSet (all v₂≥2, outside s=1 criterion)",
+      "ValidSeed predicate + DecidablePred instance (EulerTotientOQ04OQ03.lean): odd a, v2(2a-phi a)=1, landing constant nonzero&even — exactly the classifier side-conditions",
+      "classify_5 = .eq, classify_17 = .gt (EulerTotientOQ04OQ03.lean): concrete classifier evaluations via landT_landE_of rewriting (no native_decide)",
+      "twentyone_least_reversal_seed (EulerTotientOQ04OQ03.lean): classify 21 = .lt AND every valid seed a<21 classifies .eq/.gt — 21 is the least odd reversal seed",
+      "least_reversal_seed_families (EulerTotientOQ04OQ03.lean): set form — 21*2^(k+1) reverses for all k, no valid odd a<21 gives a reversal family"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -95,7 +99,9 @@
       "k-INDEPENDENT THREE-WAY CRITERION (2026-07-08, r4): the double-iterate regime of every transport family n=a·2^(k+1) is decided by a single k-free comparison φ(a) vs φ(e)·2^(t−1), where the landing constant C=2a−φ(b)=e·2^t (e odd, t≥1). Both totients factor through the inert 2^k: φ(n)=φ(a)·2^k, φ(D(n))=φ(e)·2^(t−1)·2^k. The power of two carries NO information; the sign is fixed by the odd data (a,e,t) alone.",
       "Decision-procedure realisation of the k-free criterion: the odd seed a alone determines the family regime via computable extraction b=(2a-φa)/2, C=2a-φb, t=v₂(C)=(landC a).factorization 2, e=C/2^t=ordCompl[2](landC a) — no hand-supplied (e,t).",
       "Excluded case v₂(2a−φ(a))>1 is fully tractable: general transport gives landing C=2a−φ(b)·2^(s−1)=e·2^t, criterion reads φ(a)⋛φ(e)·2^(t−1)",
-      "Structural: among excluded seeds a<120 (v₂≥2) ONLY equality/forward regimes occur — no excluded seed reverses; all known reversal seeds (21,55,129,165,175) have v₂=1"
+      "Structural: among excluded seeds a<120 (v₂≥2) ONLY equality/forward regimes occur — no excluded seed reverses; all known reversal seeds (21,55,129,165,175) have v₂=1",
+      "The valid odd seeds below 21 are exactly {5,13,15,17}, classifying eq/gt/eq/gt; all invalid a<21 fail decidably on v2(2a-phi a)=1 or bSeed-odd, using only phi (no factorization). Hence 21 is the smallest odd reversal seed.",
+      "The sub-21 sweep is kernel-decide-only: interval_cases + `try (exact absurd hv (by decide))` discharges the invalid seeds (validity touches only phi, not factorization), leaving 5,13,15,17 handled by the classify_* lemmas."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -104,7 +110,7 @@
       "Density-1 forward statement φ(n)>φ(D(n)) for almost all n remains the sole analytically-blocked open direction (needs Luca–Pomerance / ψ(x,y) density, a real Mathlib gap); the explicit families + criterion settle only the infinitely-often / structural questions.",
       "Turn the criterion into a genuine DECIDABLE classifier: given odd a, compute b=(2a−φ(a))/2 (requires v₂(2a−φ(a))=1), then the 2-adic split C=2a−φ(b)=e·2^t, and decide the regime by φ(a) vs φ(e)·2^(t−1). Formalising the v₂ extraction (t,e) as a computable function would give a decision procedure over all odd seeds.",
       "Characterise the reversal seed set {odd a : φ(a) < φ(e)·2^(t−1)} — a structural description of which odd seeds reverse (a=21 smallest) would be a new elementary result now that the per-seed test is k-free.",
-      "Reversal-seed enumeration: prove 21 is the smallest odd seed with classify a = .lt among valid seeds (a<21 either fail the v₂=1 transport hypothesis or classify to .eq/.gt) — a finite decide-sweep now that classify is computable.",
+      "RESOLVED (twentyone_least_reversal_seed / least_reversal_seed_families): 21 is the smallest odd seed with classify a = .lt among valid seeds — the valid seeds a<21 are exactly {5,13,15,17} classifying eq/gt/eq/gt, discharged by a finite kernel-decide sweep. Next: characterise the FULL reversal-seed set {odd valid a : classify a = .lt} beyond its least element (is it an arithmetic-progression / residue pattern suggested by 21,55,...? a phi-only finite computation per seed now that classify is computable).",
       "Extend the computable classify to the excluded case v₂(2a-φa)>1 (bSeed a even): dblIter_transport_general already covers the mathematics, but the Ordering-valued classifier still assumes first-step valuation one.",
       "Prove/refute that NO excluded seed (v₂(2a−φ(a))≥2) ever reverses (observed a<120); would sharpen the reversal-set structure to v₂=1 seeds only"
     ]


### PR DESCRIPTION
## Summary

Settles a structural question the per-`k` reversal families left open: **among transport-admissible odd seeds, 21 is the least whose double-cototient family `a·2^(k+1)` reverses** (`φ(D(n)) > φ(n)`). Enabled by the now-computable classifier `classify : ℕ → Ordering` already on `main`.

## New results (in `proofs/Proofs/EulerTotientOQ04OQ03.lean`)

- `ValidSeed` predicate (+ `DecidablePred` instance) — the classifier's side-conditions: `a` odd, `v₂(2a−φ(a)) = 1` (`bSeed a` odd), landing constant nonzero & even.
- `classify_5 = .eq`, `classify_17 = .gt` — concrete classifier evaluations via the `landT_landE_of` rewriting helper.
- `twentyone_least_reversal_seed` — classifier form: `classify 21 = .lt` **and** every valid seed `a < 21` classifies `.eq`/`.gt`.
- `least_reversal_seed_families` — set form: `21·2^(k+1)` reverses for all `k`, while no valid odd `a < 21` yields a reversal family.

The valid odd seeds below 21 are exactly **{5, 13, 15, 17}** (eq/gt/eq/gt). The whole sub-21 sweep is **kernel-`decide`-only** — no `native_decide`, no `factorization` reduction — since validity uses only `φ`.

## Verification

- Docker build: `=== Build succeeded ===` (3058 jobs)
- **0 sorries, 0 new axioms** (kernel `decide`, not `native_decide`)

## Notes

- Rebased cleanly onto current `main`; the prior branch was 48 commits stale-based and would have clobbered main's #35885 `dblIter_transport_general` work. This PR touches only the two erdos-1064-oq-03 files.
- Duplicate `totient_3`/`totient_9` (already on `main`) were dropped; knowledge JSON was merged additively with main's #35885 content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)