### PR TITLE
research(shannon-awgn-oq-02-oq-02): affine invariance of correlation ρ[aX+b,cY+d]=sign(ac)·ρ[X,Y] [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -839,4 +839,70 @@ theorem correlation_eq_neg_one_iff_affine_neg [IsProbabilityMeasure μ] {X Y : �
   · rintro ⟨a, b, ha, hab⟩
     rw [correlation_eq_of_affine hY ha.ne hYnd hab, abs_of_neg ha, div_neg, div_self ha.ne]
 
+/-!
+### Structural companion: affine invariance of the correlation coefficient
+
+The signed capstones locate `ρ = ±1` at the increasing/decreasing affine extremes.  The dual
+structural fact is that `ρ` is a *dimensionless* invariant: it is unchanged by any pair of
+orientation-preserving affine changes of units and merely flips sign under orientation-reversing
+ones.  Concretely, for arbitrary scales `a, c` and shifts `b, d`,
+
+    ρ[a·X + b, c·Y + d] = sign(a·c) · ρ[X, Y],
+
+because the additive shifts cancel (covariance and variance are translation-invariant) and the
+multiplicative scales cancel in magnitude against the standard deviations `σ[a·X+b] = |a|·σ[X]`,
+leaving only the sign of the slope product `a·c`.  This is the defining property that makes the
+Pearson coefficient a scale-free measure of linear association.
+-/
+
+/-- **Sign as a normalised quotient.**  `Real.sign x = x / |x|` for every real `x`, including
+`x = 0`, where both sides are `0` under the division-by-zero convention.  The scalar bridge used to
+package the affine-invariance normalisation. -/
+private theorem real_sign_eq_self_div_abs (x : ℝ) : Real.sign x = x / |x| := by
+  rcases lt_trichotomy x 0 with h | h | h
+  · rw [Real.sign_of_neg h, abs_of_neg h, div_neg, div_self h.ne]
+  · rw [h, Real.sign_zero, zero_div]
+  · rw [Real.sign_of_pos h, abs_of_pos h, div_self h.ne']
+
+/-- **Affine invariance of the correlation coefficient (up to the sign of the slopes).**
+For square-integrable `X, Y` and any affine reparametrisations `X' = a·X + b`, `Y' = c·Y + d`,
+
+    ρ[a·X + b, c·Y + d] = sign(a·c) · ρ[X, Y].
+
+The additive shifts `b, d` drop out because covariance and variance are translation-invariant, and
+the multiplicative scales `a, c` cancel in magnitude against the standard deviations
+`σ[a·X+b] = |a|·σ[X]`, leaving only the sign of the product `a·c`.  This is the defining
+*dimensionless* property of the Pearson coefficient: it is unchanged by orientation-preserving
+affine changes of units (`a·c > 0`) and merely flips sign under orientation-reversing ones
+(`a·c < 0`).  No non-degeneracy hypothesis is needed — the identity also holds in the degenerate
+cases via the division-by-zero convention. -/
+theorem correlation_affine_invariant [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (a b c d : ℝ) :
+    correlation (fun ω => a * X ω + b) (fun ω => c * Y ω + d) μ
+      = Real.sign (a * c) * correlation X Y μ := by
+  have hIaX : Integrable (fun ω => a * X ω) μ := (hX.integrable one_le_two).const_mul a
+  have hIcY : Integrable (fun ω => c * Y ω) μ := (hY.integrable one_le_two).const_mul c
+  have hcov : cov[fun ω => a * X ω + b, fun ω => c * Y ω + d; μ] = a * c * cov[X, Y; μ] := by
+    rw [covariance_add_const_left hIaX b, covariance_const_mul_left,
+      covariance_add_const_right hIcY d, covariance_const_mul_right]; ring
+  have hpX : Real.sqrt (Var[fun ω => a * X ω + b; μ]) = |a| * Real.sqrt (Var[X; μ]) := by
+    rw [variance_eq_of_affine hX a b (Filter.EventuallyEq.refl _ _), Real.sqrt_mul (sq_nonneg a),
+      Real.sqrt_sq_eq_abs]
+  have hpY : Real.sqrt (Var[fun ω => c * Y ω + d; μ]) = |c| * Real.sqrt (Var[Y; μ]) := by
+    rw [variance_eq_of_affine hY c d (Filter.EventuallyEq.refl _ _), Real.sqrt_mul (sq_nonneg c),
+      Real.sqrt_sq_eq_abs]
+  simp only [correlation]
+  rw [hcov, hpX, hpY, real_sign_eq_self_div_abs, abs_mul]
+  ring
+
+/-- **Scale-and-shift invariance (orientation-preserving case).**  Correlation is *exactly*
+preserved by any pair of increasing affine reparametrisations (`a, c > 0`):
+`ρ[a·X + b, c·Y + d] = ρ[X, Y]`.  The dimensionless-invariance specialisation of
+`correlation_affine_invariant` with `sign(a·c) = 1` — the precise sense in which the Pearson
+coefficient is independent of the choice of units and origin. -/
+theorem correlation_affine_invariant_of_pos [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) {a c : ℝ} (ha : 0 < a) (hc : 0 < c) (b d : ℝ) :
+    correlation (fun ω => a * X ω + b) (fun ω => c * Y ω + d) μ = correlation X Y μ := by
+  rw [correlation_affine_invariant hX hY a b c d, Real.sign_of_pos (mul_pos ha hc), one_mul]
+
 end ShannonAWGNMultiSymbolPower

--- a/research/problems/shannon-channel-coding-awgn-oq-02-oq-02/knowledge.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-02-oq-02/knowledge.md
@@ -48,3 +48,30 @@ Lean file: `proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean`
 
 - `μ[W₀ + W₁]` uses `Pi.add`, so the integrand prints as `(W₀ + W₁) x`, not `W₀ x + W₁ x`;
   `rw [integral_add ...]` fails to match until you `simp only [Pi.add_apply]` first.
+
+## Session 2026-07-08 (FRESH continuation) - Affine invariance of ρ
+
+**Mode**: FRESH (continued rich-knowledge problem, depth-over-breadth)
+**Outcome**: progress (2 theorems + 1 helper, VERIFIED 0 sorry / 0 axiom)
+
+### What I Did
+- Added `correlation_affine_invariant`: ρ[a·X+b, c·Y+d] = sign(a·c)·ρ[X,Y] for arbitrary a,b,c,d.
+- Added `correlation_affine_invariant_of_pos`: a,c>0 ⟹ ρ preserved exactly (scale-free property).
+- Added private helper `real_sign_eq_self_div_abs`: Real.sign x = x/|x| ∀x (incl 0 via 0/0=0).
+
+### Key Findings
+- The identity is UNCONDITIONAL — no non-degeneracy needed. Degenerate cases (Var=0) collapse to
+  0 = sign(ac)·0 automatically through the Lean division-by-zero convention.
+- Reuses the ±1-capstone machinery: cov[aX+b,cY+d]=ac·cov via covariance_add_const_left/right +
+  covariance_const_mul_left/right; σ[aX+b]=|a|·σ[X] via variance_eq_of_affine.
+- Packaging sign as x/|x| lets the final normalisation a·c/(|a|·|c|)=sign(ac) close by `ring`
+  (field inverse rearrangement) with zero nonzero-hypotheses — clean.
+
+### Files Modified
+- proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean (842→908 lines, 36→38 theorems)
+- src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json (counts + contribution)
+- src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json (knowledge)
+
+### Next Steps
+- Orientation-reversing corollary (a>0, c<0 ⟹ ρ ↦ −ρ) if a further result needs it.
+- Extract cov[aX+b,cY+d]=ac·cov as a named reusable covariance-bilinearity lemma if reused.

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 842,
+    "lineCount": 908,
     "axiomCount": 0,
-    "theoremCount": 36,
+    "theoremCount": 38,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -49,7 +49,8 @@
       "awgn_multisymbol_variance: Var[∑_{i∈s} Wᵢ] = ∑_{i∈s} Var[Wᵢ] for pairwise-independent Wᵢ — the Bienaymé identity recorded in channel notation (a direct application of IndepFun.variance_sum), making explicit that pairwise independence already annihilates every off-diagonal covariance in the expansion of the variance of a sum.",
       "sum_mean_zero: E[∑_{i∈s} Wᵢ] = 0 — the aggregate of zero-mean contributions is zero-mean, via linearity of the integral over a Finset (integral_finset_sum) on the square-integrable (hence integrable) parts. This is the lemma that lets the squared-mean term drop for the sum, not just for each summand.",
       "second_moment_eq_variance: E[W²] = Var[W] for a zero-mean variable — the bridge identifying the engineering notion of 'power' with the probabilistic variance; the rewrite that turns the variance-of-a-sum law into a second-moment law once the means are zero.",
-      "correlation_eq_one_iff_affine_pos / correlation_eq_neg_one_iff_affine_neg: the signed sharp boundary — ρ = +1 exactly when X is a.e. an increasing affine function of Y (positive slope, perfect positive correlation) and ρ = −1 exactly when the slope is negative (perfect negative correlation). Refines the capstone |ρ|=1 ⟺ affine dependence by splitting the two endpoints of the Cauchy–Schwarz interval [−1,1] according to the sign of the regression slope, via correlation_eq_of_affine (ρ = a/|a| = sign a when X =ᵐ a·Y+b) and variance_eq_of_affine (Var[X] = a²·Var[Y])."
+      "correlation_eq_one_iff_affine_pos / correlation_eq_neg_one_iff_affine_neg: the signed sharp boundary — ρ = +1 exactly when X is a.e. an increasing affine function of Y (positive slope, perfect positive correlation) and ρ = −1 exactly when the slope is negative (perfect negative correlation). Refines the capstone |ρ|=1 ⟺ affine dependence by splitting the two endpoints of the Cauchy–Schwarz interval [−1,1] according to the sign of the regression slope, via correlation_eq_of_affine (ρ = a/|a| = sign a when X =ᵐ a·Y+b) and variance_eq_of_affine (Var[X] = a²·Var[Y]).",
+      "correlation_affine_invariant: the dimensionless-invariance structural companion — ρ[a·X+b, c·Y+d] = sign(a·c)·ρ[X,Y] for arbitrary scales a,c and shifts b,d, holding unconditionally (even degenerate) via the division-by-zero convention. Additive shifts cancel (translation-invariance of covariance/variance), multiplicative scales cancel in magnitude against σ[a·X+b]=|a|·σ[X], leaving only the sign of the slope product; the orientation-preserving specialisation correlation_affine_invariant_of_pos (a,c>0) gives exact invariance ρ[a·X+b,c·Y+d]=ρ[X,Y]. This is the defining property that makes Pearson's ρ a scale-free measure of linear association — dual to the signed ±1 boundary theorems."
     ],
     "prerequisites": [
       "Variance of a sum of pairwise-independent variables: ProbabilityTheory.IndepFun.variance_sum (Var[∑ Xᵢ] = ∑ Var[Xᵢ])",
@@ -182,6 +183,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 842,
-  "theoremCount": 36
+  "lineCount": 908,
+  "theoremCount": 38
 }

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: signed correlation capstone (ρ=±1 ⟺ increasing/decreasing affine) VERIFIED 0/0, PR #35904",
+    "progressSummary": "PROGRESS: affine-invariance structural companion ρ[aX+b,cY+d]=sign(ac)·ρ[X,Y] VERIFIED 0/0 (+ orientation-preserving corollary); dual to signed ±1 boundary capstone",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -51,7 +51,10 @@
       "abs_correlation_eq_one_iff_affine: |ρ|=1 ⟺ ∃a b, X=ᵐa·Y+b — normalised capstone via correlation_sq_eq_one_iff_affine + Real.sqrt_sq_eq_abs (ShannonChannelCodingAWGNOQ02OQ02.lean)",
       "variance_eq_of_affine (Var[X]=a²Var[Y]) in ShannonChannelCodingAWGNOQ02OQ02.lean",
       "correlation_eq_of_affine (ρ=a/|a|=sign a) in ShannonChannelCodingAWGNOQ02OQ02.lean",
-      "correlation_eq_one_iff_affine_pos + correlation_eq_neg_one_iff_affine_neg (signed capstones) in ShannonChannelCodingAWGNOQ02OQ02.lean"
+      "correlation_eq_one_iff_affine_pos + correlation_eq_neg_one_iff_affine_neg (signed capstones) in ShannonChannelCodingAWGNOQ02OQ02.lean",
+      "correlation_affine_invariant (ShannonChannelCodingAWGNOQ02OQ02.lean:879): ρ[a·X+b,c·Y+d]=sign(a·c)·ρ[X,Y] VERIFIED 0/0 — affine invariance, unconditional (degenerate cases via div-by-zero convention)",
+      "correlation_affine_invariant_of_pos (line 903): a,c>0 ⟹ ρ preserved exactly ρ[a·X+b,c·Y+d]=ρ[X,Y]",
+      "real_sign_eq_self_div_abs helper (line 861): Real.sign x = x/|x| ∀x incl 0"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -64,7 +67,8 @@
       "Sharp EQUALITY case of covariance Cauchy–Schwarz (cov²=Var[X]·Var[Y]) is characterized by the regression-residual variance IDENTITY Var[Var[Y]·X − cov·Y] = Var[Y]·(Var[X]·Var[Y] − cov²): when Var[Y]≠0 the residual has zero variance (hence a.e. constant) exactly when C–S is tight. Dividing by Var[Y] exhibits X =ᵐ (cov/Var[Y])·Y + b — a.e. affine dependence with slope the regression coefficient. Classical equality-in-Cauchy–Schwarz ⟺ linear-dependence, specialised to the covariance inner product; sharp EQUALITY companion to the earlier stddev triangle INEQUALITY.",
       "The equality-boundary iff closes cleanly: forward (tightness⟹regression line) needs Var[Y]≠0, but converse (affine⟹tightness) is unconditional — a pure bilinear/variance-of-affine computation transported along =ᵐ via covariance_congr_left + variance_congr.",
       "Correlation-coefficient normalisation ρ=cov/(σX·σY) packages the whole second-order theory: |ρ|≤1 IS covariance Cauchy–Schwarz (no non-degeneracy needed — division-by-zero convention absorbs degenerate case), and |ρ|=1 ⟺ a.e. affine dependence IS the sharp equality boundary. Both non-degeneracy hypotheses genuinely needed for the |ρ|=1 iff since a degenerate variable gives ρ=0≠±1 while X=ᵐ0·Y+μ[X] still holds.",
-      "Signed sharp boundary: ρ = sign(a) when X =ᵐ a·Y+b, so ρ=+1 ⟺ increasing affine (a>0), ρ=−1 ⟺ decreasing affine (a<0); splits |ρ|=1⟺affine into two distinct endpoints."
+      "Signed sharp boundary: ρ = sign(a) when X =ᵐ a·Y+b, so ρ=+1 ⟺ increasing affine (a>0), ρ=−1 ⟺ decreasing affine (a<0); splits |ρ|=1⟺affine into two distinct endpoints.",
+      "Affine-invariance proof reuses the exact machinery of the ±1 capstones: cov[aX+b,cY+d]=ac·cov via covariance_add_const_left/right + covariance_const_mul_left/right; σ[aX+b]=|a|·σ[X] via variance_eq_of_affine+sqrt_mul+sqrt_sq_eq_abs; sign packaged as x/|x| so a·c/(|a|·|c|)=sign(a·c) closes by ring (field inverse rearrangement, no nonzero hyps needed)."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -79,7 +83,9 @@
       "Converse affine⟹equality (X =ᵐ a·Y+b ⟹ cov²=Var·Var) for full iff — needs covariance_congr under a.e. equality (build from integral_congr_ae).",
       "Upstream covariance_congr_left to Mathlib (Probability/Moments/Covariance.lean) alongside variance_congr; would also give a covariance_congr_right by covariance_comm.",
       "Correlation-coefficient triangle/monotonicity: state ρ under sign of covariance, or the two-variance stddev triangle equality condition (perfect positive correlation ρ=+1) as the dual of the off-diagonal-cancellation boundary.",
-      "Consider affine-invariance of ρ: corr(aX+b, cY+d)=sign(ac)·corr(X,Y) as a structural companion."
+      "Consider affine-invariance of ρ: corr(aX+b, cY+d)=sign(ac)·corr(X,Y) as a structural companion.",
+      "Affine-invariance of covariance itself (cov[aX+b,cY+d]=ac·cov[X,Y]) is now proved inline — consider extracting as a named reusable lemma if a further correlation result needs it.",
+      "Consider corr sign-flip corollary for a>0,c<0 (orientation-reversing): ρ[aX+b,cY+d]=−ρ[X,Y] as the negative companion of correlation_affine_invariant_of_pos."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Structural companion to the merged signed ±1 boundary capstone (#35904): the **dimensionless-invariance** property of the Pearson correlation coefficient, in `proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean`.

For square-integrable `X, Y` and arbitrary affine reparametrisations `X' = a·X + b`, `Y' = c·Y + d`:

```
ρ[a·X + b, c·Y + d] = sign(a·c) · ρ[X, Y]
```

The additive shifts `b, d` drop out (covariance and variance are translation-invariant); the multiplicative scales `a, c` cancel in magnitude against the standard deviations `σ[a·X+b] = |a|·σ[X]`, leaving only the **sign of the slope product** `a·c`. This is the defining property that makes `ρ` a scale-free measure of linear association — unchanged by orientation-preserving affine changes of units, sign-flipped under orientation-reversing ones. It is the dual of the signed ±1 boundary theorems already in the file.

## New results (all VERIFIED, 0 sorry / 0 axiom)

- `correlation_affine_invariant` — `ρ[a·X+b, c·Y+d] = sign(a·c)·ρ[X,Y]`. Holds **unconditionally** (no non-degeneracy hypothesis): degenerate cases collapse to `0 = sign(ac)·0` via the division-by-zero convention.
- `correlation_affine_invariant_of_pos` — for `a, c > 0`, exact invariance `ρ[a·X+b, c·Y+d] = ρ[X,Y]` (the "correlation is unit-free" statement).
- `real_sign_eq_self_div_abs` (private helper) — `Real.sign x = x / |x|` for all `x` (including `0`).

## Proof notes

Reuses the ±1-capstone machinery: `cov[aX+b,cY+d] = ac·cov[X,Y]` via `covariance_add_const_left/right` + `covariance_const_mul_left/right`; `σ[aX+b] = |a|·σ[X]` via `variance_eq_of_affine` + `Real.sqrt_mul` + `Real.sqrt_sq_eq_abs`. Packaging the sign as `x/|x|` lets the final normalisation `a·c/(|a|·|c|) = sign(a·c)` close by `ring` with zero nonzero-hypotheses.

## Verification

- Docker build green: `✔ [7743/7743] Built Proofs.ShannonChannelCodingAWGNOQ02OQ02`
- 0 `sorry`, 0 `axiom` declarations, 0 structure-encoded assumptions.
- File 842→908 lines, 36→38 theorems; gallery `meta.json` counts + contribution synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)