### PR TITLE
Fix: revert wrong leanFile.lineCount for simson-line-theorem-oq-01 (364→146)

### DIFF
--- a/src/data/proofs/simson-line-theorem-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01/meta.json
@@ -212,7 +212,7 @@
       "SimsonLineTheorem"
     ],
     "namespace": "SimsonLineTheoremOQ01",
-    "lineCount": 364,
+    "lineCount": 146,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

`leanFile.lineCount` for `simson-line-theorem-oq-01` reverted from a stale `364` back to the correct `146`.

## Evidence

**Before**: `leanFile.lineCount = 364`. PR #35852 (bulk lineCount sync) mis-read the *imported base* file `Proofs/SimsonLineTheorem.lean` (364 lines) instead of this entry's actual `leanFile.path`, `Proofs/SimsonLineTheoremOQ01.lean` (146 lines). The pre-#35852 value was correctly `146`.

**After**: `leanFile.lineCount = 146` — matches `wc -l Proofs/SimsonLineTheoremOQ01.lean`. The other `leanFile` counts (`theoremCount 8`, `definitionCount 1`) already matched (verified: comment-stripped count == raw grep).

The `meta` block (`lineCount 364`, `theoremCount 20`, `definitionCount 4`) is **left untouched** — it correctly describes the base development `SimsonLineTheorem.lean`, all three counts matching `wc -l`/grep exactly.

Purely numeric, build-independent. JSON validated; the lineCount-drift detector now reports 0 remaining entries gallery-wide.

---
Automated fix by lean-mechanic agent.