### PR TITLE
Enrich Jensen power-mean monotonicity (jensen-inequality-oq-01-oq-02): add leanType to mainTheorems

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-02/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-02/meta.json
@@ -135,12 +135,14 @@
     {
       "name": "powerMean_le_powerMean",
       "type": "theorem",
-      "description": "Weighted power-mean monotonicity: for nonnegative data z with nonnegative weights w summing to 1 and 0 < p ≤ q, the weighted power mean is nondecreasing in the exponent — (∑ᵢ wᵢ·zᵢ^p)^(1/p) ≤ (∑ᵢ wᵢ·zᵢ^q)^(1/q)."
+      "description": "Weighted power-mean monotonicity: for nonnegative data z with nonnegative weights w summing to 1 and 0 < p ≤ q, the weighted power mean is nondecreasing in the exponent — (∑ᵢ wᵢ·zᵢ^p)^(1/p) ≤ (∑ᵢ wᵢ·zᵢ^q)^(1/q).",
+      "leanType": "(∑ i ∈ s, w i * z i ^ p) ^ (1 / p) ≤ (∑ i ∈ s, w i * z i ^ q) ^ (1 / q)"
     },
     {
       "name": "weighted_am_le_qm",
       "type": "theorem",
-      "description": "Weighted arithmetic-mean ≤ quadratic-mean, the p=1, q=2 instance: ∑ᵢ wᵢ·zᵢ ≤ (∑ᵢ wᵢ·zᵢ²)^(1/2)."
+      "description": "Weighted arithmetic-mean ≤ quadratic-mean, the p=1, q=2 instance: ∑ᵢ wᵢ·zᵢ ≤ (∑ᵢ wᵢ·zᵢ²)^(1/2).",
+      "leanType": "∑ i ∈ s, w i * z i ≤ (∑ i ∈ s, w i * z i ^ (2 : ℝ)) ^ (1 / 2 : ℝ)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `jensen-inequality-oq-01-oq-02` (quality 94, passes 0).

This entry is already thoroughly enriched (11 KB meta, 6 richly-annotated sections covering all 87 Lean lines), so rather than inflate prose I filled a **structural gap**:

- Both `mainTheorems` entries (`powerMean_le_powerMean`, `weighted_am_le_qm`) had `name`/`type`/`description` but **no `leanType`** — the field that gives readers the exact formal Lean signature. The gallery convention (e.g. the sibling `herons-formula-oq-07`) includes it.
- Added the verbatim conclusion signatures from `Proofs/JensenInequalityOQ01OQ02.lean`.

meta.json grew 11387 → 11591 bytes, well under the 60 KB cap. JSON validates; gallery-data build stage passes (no errors reference this entry).