### PR TITLE
Enrich Knight's Tour Oblique OQ-03 (knights-tour-oblique-oq-03): add leanType to mainTheorems

### DIFF
--- a/src/data/proofs/knights-tour-oblique-oq-03/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-03/meta.json
@@ -99,22 +99,26 @@
     {
       "name": "reverseTour_applyD4Tour",
       "type": "theorem",
-      "description": "reverseTour (applyD4Tour g t) = applyD4Tour g (reverseTour t): time-reversal commutes with every element of the dihedral board group D₄."
+      "description": "reverseTour (applyD4Tour g t) = applyD4Tour g (reverseTour t): time-reversal commutes with every element of the dihedral board group D₄.",
+      "leanType": "(g : Bool × Fin 4) (t : ClosedTour) : reverseTour (applyD4Tour g t) = applyD4Tour g (reverseTour t)"
     },
     {
       "name": "d4_reverse_leftInverse",
       "type": "theorem",
-      "description": "reverseTour (applyD4Tour (d4Inv g) (reverseTour (applyD4Tour g t))) = t: the composite reversal-and-D₄ symmetry has an explicit two-sided-style inverse, from commutation + involutivity + the D₄ inverse."
+      "description": "reverseTour (applyD4Tour (d4Inv g) (reverseTour (applyD4Tour g t))) = t: the composite reversal-and-D₄ symmetry has an explicit two-sided-style inverse, from commutation + involutivity + the D₄ inverse.",
+      "leanType": "(g : Bool × Fin 4) (t : ClosedTour) : reverseTour (applyD4Tour (d4Inv g) (reverseTour (applyD4Tour g t))) = t"
     },
     {
       "name": "d4_reverse_injective",
       "type": "theorem",
-      "description": "Function.Injective (fun t => reverseTour (applyD4Tour g t)): each composite symmetry is injective, so D₄ together with reversal acts faithfully on ClosedTour (order-16 D₄ × ℤ/2)."
+      "description": "Function.Injective (fun t => reverseTour (applyD4Tour g t)): each composite symmetry is injective, so D₄ together with reversal acts faithfully on ClosedTour (order-16 D₄ × ℤ/2).",
+      "leanType": "(g : Bool × Fin 4) : Function.Injective (fun t => reverseTour (applyD4Tour g t))"
     },
     {
       "name": "reverseTour_applyD4Tour_orbit",
       "type": "theorem",
-      "description": "∃ h, reverseTour (applyD4Tour g t) = applyD4Tour h (reverseTour t): reversal maps the D₄-orbit of t onto the D₄-orbit of reverseTour t."
+      "description": "∃ h, reverseTour (applyD4Tour g t) = applyD4Tour h (reverseTour t): reversal maps the D₄-orbit of t onto the D₄-orbit of reverseTour t.",
+      "leanType": "(g : Bool × Fin 4) (t : ClosedTour) : ∃ h : Bool × Fin 4, reverseTour (applyD4Tour g t) = applyD4Tour h (reverseTour t)"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `knights-tour-oblique-oq-03` (quality 94, passes 0).

Filled a **structural gap**: all 4 `mainTheorems` entries had `name`/`type`/`description` but **no `leanType`** — the field giving readers the exact formal Lean signature (part of the gallery convention).

- Added verbatim signatures from `Proofs/KnightsTourObliqueOQ03.lean` for `reverseTour_applyD4Tour`, `d4_reverse_leftInverse`, `d4_reverse_injective`, and `reverseTour_applyD4Tour_orbit`.

meta.json 14289 → 14791 bytes, well under the 60 KB cap. JSON validates.