### PR TITLE
Enrich Kronecker's Jugendtraum OQ-02 (kroneckers-jugendtraum-oq-02): add leanType + references

### DIFF
--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
@@ -59,12 +59,14 @@
     {
       "name": "regulator_eq_single_log_of_rank_eq_one",
       "type": "theorem",
-      "description": "The rank-one regulator is a single logarithm: when rank K = 1, the regulator collapses from a determinant of logarithms to one archimedean term mult(w)·|log(w ε)| for the fundamental (Stark) unit ε — the linear-algebra fact behind the rank-one abelian Stark conjecture's claim that L'(0,χ) is a rational multiple of one log|ε|."
+      "description": "The rank-one regulator is a single logarithm: when rank K = 1, the regulator collapses from a determinant of logarithms to one archimedean term mult(w)·|log(w ε)| for the fundamental (Stark) unit ε — the linear-algebra fact behind the rank-one abelian Stark conjecture's claim that L'(0,χ) is a rational multiple of one log|ε|.",
+      "leanType": "(K : Type*) [Field K] [NumberField K] (hrank : rank K = 1) : ∃ (w : InfinitePlace K) (ε : (𝓞 K)ˣ), regulator K = (mult w : ℝ) * |Real.log (w (ε : K))|"
     },
     {
       "name": "rank_eq_one_iff_card_infinitePlace_eq_two",
       "type": "theorem",
-      "description": "Rank one ⟺ two infinite places: by Dirichlet's unit theorem the unit rank of K is #(InfinitePlace K) − 1, so the rank-one Stark hypothesis rank K = 1 holds exactly when K has two infinite places."
+      "description": "Rank one ⟺ two infinite places: by Dirichlet's unit theorem the unit rank of K is #(InfinitePlace K) − 1, so the rank-one Stark hypothesis rank K = 1 holds exactly when K has two infinite places.",
+      "leanType": "(K : Type*) [Field K] [NumberField K] : rank K = 1 ↔ Fintype.card (InfinitePlace K) = 2"
     }
   ],
   "overview": {
@@ -121,6 +123,35 @@
       "targetId": "kroneckers-jugendtraum",
       "relationship": "extends",
       "description": "Parent Kronecker Jugendtraum / Stark entry; this treats the unit-rank-1 case where the regulator collapses from an r×r determinant to a single archimedean log of the fundamental (Stark) unit."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Harold M. Stark"
+      ],
+      "title": "L-functions at s = 1. IV. First derivatives at s = 0",
+      "year": 1980,
+      "venue": "Advances in Mathematics 35 (3), 197–235",
+      "note": "States the rank-one abelian Stark conjecture: L'(0, χ) is a rational multiple of a single logarithm log|ε| of a Stark unit ε — the L-function counterpart of the regulator collapse formalized here."
+    },
+    {
+      "authors": [
+        "John Tate"
+      ],
+      "title": "Les conjectures de Stark sur les fonctions L d'Artin en s = 0",
+      "year": 1984,
+      "venue": "Progress in Mathematics 47, Birkhäuser (notes by D. Bernardi and N. Schappacher)",
+      "note": "The standard reference reformulating and systematizing the Stark conjectures, including the rank-one case and its relation to units and regulators."
+    },
+    {
+      "authors": [
+        "David Hilbert"
+      ],
+      "title": "Mathematische Probleme",
+      "year": 1900,
+      "venue": "Göttinger Nachrichten, 253–297; Problem 12 (Kronecker's Jugendtraum)",
+      "note": "Hilbert's 12th problem: explicit generation of the abelian extensions of a number field, the arithmetic context the Stark units address."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `kroneckers-jugendtraum-oq-02` (quality 94, passes 0).

Two **structural gaps** filled:

1. Both `mainTheorems` (`regulator_eq_single_log_of_rank_eq_one`, `rank_eq_one_iff_card_infinitePlace_eq_two`) had no `leanType` — added verbatim signatures from `Proofs/KroneckersJugendtraumStarkRankOne.lean`.
2. `references` was **empty** — added the canonical Stark sources (Stark 1980 *L-functions at s=1 IV*, Tate 1984 *Les conjectures de Stark*) and Hilbert's 1900 problem list (Problem 12), all directly relevant to the rank-one abelian Stark setting.

meta.json 10082 → 12556 bytes, well under the 60 KB cap. JSON validates.