### PR TITLE
Enrich Sum of Squared Medians (law-of-cosines-oq-07-oq-02): add leanType to mainTheorems

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-02/meta.json
@@ -116,12 +116,14 @@
     {
       "name": "sum_sq_medians",
       "type": "theorem",
-      "description": "Sum of squared medians: 4·(m_a² + m_b² + m_c²) = 3·(a² + b² + c²), where m_x is the median from vertex x to the opposite midpoint. Proved by summing the parent's median_length identity over the three vertices and closing with linear_combination."
+      "description": "Sum of squared medians: 4·(m_a² + m_b² + m_c²) = 3·(a² + b² + c²), where m_x is the median from vertex x to the opposite midpoint. Proved by summing the parent's median_length identity over the three vertices and closing with linear_combination.",
+      "leanType": "(a b c : P) : 4 * (dist a (midpoint ℝ b c) ^ 2 + dist b (midpoint ℝ a c) ^ 2 + dist c (midpoint ℝ a b) ^ 2) = 3 * (dist a b ^ 2 + dist b c ^ 2 + dist c a ^ 2)"
     },
     {
       "name": "sum_sq_medians_three_quarters",
       "type": "theorem",
-      "description": "The ¾-ratio form: the sum of the squared medians equals three quarters of the sum of the squared sides — a direct rescaling of sum_sq_medians."
+      "description": "The ¾-ratio form: the sum of the squared medians equals three quarters of the sum of the squared sides — a direct rescaling of sum_sq_medians.",
+      "leanType": "(a b c : P) : dist a (midpoint ℝ b c) ^ 2 + dist b (midpoint ℝ a c) ^ 2 + dist c (midpoint ℝ a b) ^ 2 = 3 / 4 * (dist a b ^ 2 + dist b c ^ 2 + dist c a ^ 2)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass (quality 94, passes 0). Structural gap: both `mainTheorems` had no `leanType`. Added the verbatim coordinate-free Lean signatures from `Proofs/LawOfCosinesOQ07OQ02.lean`. JSON validates; well under size cap.