### PR TITLE
audit: re-audit abel-ruffini-oq-04 family (8 entries, all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7,9 +7,9 @@
       "result": "clean"
     },
     "abel-ruffini-galois-extensions": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-09T02:34:50Z",
       "result": "clean"
     },
     "abel-ruffini-galois-extensions-oq-01": {
@@ -37,9 +37,9 @@
       "issues": []
     },
     "abel-ruffini-galois-extensions-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-09T02:34:50Z",
       "result": "clean"
     },
     "abel-ruffini-galois-extensions-oq-04-oq-01": {
@@ -112,15 +112,15 @@
       "issues": []
     },
     "abel-ruffini-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-09T02:34:50Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-09T02:34:50Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-01-oq-01": {
@@ -154,9 +154,9 @@
       "issues": []
     },
     "abel-ruffini-oq-04-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-09T02:34:50Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-02-oq-01": {
@@ -166,9 +166,9 @@
       "issues": []
     },
     "abel-ruffini-oq-04-oq-02-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-09T02:34:49Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-02-oq-02-oq-06": {
@@ -232,9 +232,9 @@
       "issues": []
     },
     "abel-ruffini-oq-04-oq-02-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-09T02:34:49Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-02-oq-03-oq-01": {
@@ -256,9 +256,9 @@
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-07-09T02:31:55Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-04": {


### PR DESCRIPTION
## Gallery Integrity Audit

Staleness re-audit of the **abel-ruffini-oq-04** cluster (previously audited 2026-05-03). Verified proof-claim integrity against the Lean source.

### Results — all 8 CLEAN

| Entry | Status/Badge | Verification |
|-------|-------------|-------------|
| abel-ruffini-oq-04-oq-03 | axiomatized/axiom | 1 substantive reverse-direction axiom (`solvableGal_implies_solvableByRad`), honest title; forward direction genuinely via Mathlib's `solvableByRad.isSolvable'` |
| abel-ruffini-oq-04-oq-02-oq-03 | axiomatized/axiom | axiomCount=1 = `Lean.ofReduceBool` (native_decide on `primes_below_60`), disclosed |
| abel-ruffini-oq-04-oq-02-oq-02 | verified/mathlib | 0 axioms, 0 sorries; A₄ case refactored from native_decide → kernel `decide` (companion "native_decide" hits are line-comments only) |
| abel-ruffini-oq-04-oq-02 | axiomatized/axiom | `Lean.ofReduceBool` via native_decide, disclosed |
| abel-ruffini-oq-04-oq-01 | axiomatized/axiom | `Lean.ofReduceBool` via native_decide, disclosed |
| abel-ruffini-oq-04 | verified/mathlib | 0 axioms/sorries/native_decide confirmed |
| abel-ruffini-galois-extensions-oq-04 | verified/mathlib | 0 axioms/sorries/native_decide confirmed |
| abel-ruffini-galois-extensions | axiomatized/axiom | `Lean.ofReduceBool` via native_decide, disclosed |

**No integrity issues found.** All axiom counts, sorry counts, badges, and disclosures match the Lean source. This PR only advances `lastAudited` timestamps in `audit-tracker.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)