### PR TITLE
Enrich Weitzenböck's Inequality (herons-formula-oq-07)

### DIFF
--- a/src/data/proofs/herons-formula-oq-07/meta.json
+++ b/src/data/proofs/herons-formula-oq-07/meta.json
@@ -19,7 +19,8 @@
       "Squaring reduces the √3- and Area-containing statement to a pure polynomial inequality in a, b, c, avoiding all analysis except one Real.sqrt monotonicity step.",
       "The certificate (a²+b²+c²)² - 48·heronProduct = 2((a²-b²)²+(b²-c²)²+(c²-a²)²) is an identity in the squared side lengths, closed by ring, and simultaneously proves the inequality and its equality case.",
       "The squared inequality (a²+b²+c²)² ≥ 48·heronProduct needs no triangle hypothesis; nondegeneracy enters only to keep Area real.",
-      "Equality holds iff each summand vanishes, i.e. a² = b² = c², which for positive sides means the triangle is equilateral — so one SOS identity proves both the inequality and its sharpness."
+      "Equality holds iff each summand vanishes, i.e. a² = b² = c², which for positive sides means the triangle is equilateral — so one SOS identity proves both the inequality and its sharpness.",
+      "Dually, the inequality says the equilateral triangle maximizes area among all triangles with a fixed sum of squared sides a²+b²+c²: since 4√3·Area ≤ a²+b²+c² with equality only when equilateral, fixing the right-hand side caps the area, and the cap is attained exactly at the equilateral configuration — an extremal (isoperimetric-type) reading of the same certificate."
     ],
     "prerequisites": [
       "Heron's formula Area² = s(s-a)(s-b)(s-c)",
@@ -96,6 +97,11 @@
       "targetId": "herons-formula-oq-06",
       "relationship": "related",
       "description": "A sibling triangle inequality from Heron's formula (Euler's R ≥ 2r); both reduce a geometric inequality to a symmetric polynomial inequality with an explicit sum-of-squares certificate and full equality characterization."
+    },
+    {
+      "targetId": "herons-formula-oq-06-oq-02",
+      "relationship": "related",
+      "description": "Gerretsen's inequality s² ≤ 4R² + 4Rr + 3r² is another symmetric triangle inequality with the equilateral triangle as its unique equality case; like Weitzenböck it is settled algebraically and its sharpness is read off the equality condition, illustrating the same SOS-to-equilateral pattern in the (R, r, s) variables rather than the side lengths."
     }
   ],
   "references": [


### PR DESCRIPTION
Focused enrichment pass for `herons-formula-oq-07` (quality 94, already near-saturated — curation, not accretion).

## Changes
- **keyInsight (+1, now 5)**: added the dual/extremal reading — Weitzenböck says the equilateral triangle maximizes area among triangles with a fixed sum of squared sides, an isoperimetric-type interpretation of the same SOS certificate, distinct from the existing mechanics-focused insights.
- **crossReference (+1, now 3)**: linked to `herons-formula-oq-06-oq-02` (Gerretsen's inequality), a sibling symmetric triangle inequality with the equilateral equality case, illustrating the same SOS-to-equilateral pattern in the (R, r, s) variables.

## Verification
- meta counts confirmed against Lean source: lineCount 188, theoremCount 6, definitionCount 3, axiomCount 0 — all accurate, no drift.
- JSON valid; meta.json 12.9 KB (well under caps).
- Gallery-data build stages (enrichment + search index) pass.