### PR TITLE
Auditor: re-audit erdos-175, erdos-160 (both clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11260,9 +11260,9 @@
       "result": "issues-fixed"
     },
     "erdos-160": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:34Z",
+      "lastAudited": "2026-07-09T02:42:15Z",
       "result": "clean"
     },
     "erdos-160-incomplete-01": {
@@ -11376,9 +11376,9 @@
       "result": "clean"
     },
     "erdos-175": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:34Z",
+      "lastAudited": "2026-07-09T02:42:15Z",
       "result": "clean"
     },
     "erdos-176": {


### PR DESCRIPTION
## Auditor re-audit — tracker persistence

Re-audited the two oldest gallery entries by `lastAudited` (both previously clean, count=3, last audited 2026-05-03). Manual integrity review confirms both remain **clean**.

### erdos-175 — Central Binomial Coefficient Not Squarefree
- 4 literal `axiom` declarations match `axiomCount: 4`; all are substantive propositions (Granville–Ramaré, Sander ×2, Erdős–Kolesnik), none stubbed to `True`
- 0 sorries; `status: axiomatized` / `badge: axiom` correct
- Main theorem `erdos_175_statement` transparently derives from the disclosed axioms — no axiom masking; `assumptions` field fully discloses all 4
- `native_decide` appears only in `example` blocks (policy-OK, no bump)
- Old `open_for_all_n : True` placeholder is now a proper `def : Prop`

### erdos-160
- 3 substantive analytic-bound axioms match `axiomCount: 3`; 0 sorries; status/badge consistent
- `h_sublinear` is correctly guarded (`ε < 1/3`) with an honest NOTE documenting why the unguarded form would be false — no overclaim

No Lean source changes. Tracker `auditCount`/`lastAudited` bumps only (re-serialized with `ensure_ascii=True` to keep the diff minimal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)