### PR TITLE
Enrich Weitzenböck (herons-formula-oq-07): add heronProduct_nonneg to mainTheorems

### DIFF
--- a/src/data/proofs/herons-formula-oq-07/meta.json
+++ b/src/data/proofs/herons-formula-oq-07/meta.json
@@ -31,6 +31,12 @@
   },
   "mainTheorems": [
     {
+      "name": "heronProduct_nonneg",
+      "type": "supporting",
+      "description": "For a nondegenerate triangle, Heron's product s(s-a)(s-b)(s-c) is non-negative. The strict triangle inequalities a<b+c, b<a+c, c<a+b are exactly s-a>0, s-b>0, s-c>0, so all four factors are positive; proved by iterated mul_nonneg with each factor discharged by linarith. This is the sole place the triangle hypotheses enter — it guarantees Area = √(heronProduct) is real, making the squaring step reversible.",
+      "leanType": "0 ≤ heronProduct a b c"
+    },
+    {
       "name": "sq_sum_sub_heron",
       "type": "supporting",
       "description": "The Weitzenböck sum-of-squares identity: (a²+b²+c²)² - 48·heronProduct = 2((a²-b²)²+(b²-c²)²+(c²-a²)²), an identity for all reals.",


### PR DESCRIPTION
Structural coverage gap: the Lean file `HeronsFormulaOQ07.lean` has 6 named theorems (matching `leanFile.theoremCount: 6`) but `mainTheorems` listed only 5. The missing one, `heronProduct_nonneg`, is the foundational supporting lemma — the sole place the strict triangle inequalities enter the development, guaranteeing `Area = √(heronProduct)` is real so the squaring step is reversible.

Added it as a `supporting` mainTheorem with accurate `leanType` (`0 ≤ heronProduct a b c`) and a description of its proof (iterated `mul_nonneg` + `linarith`) and role.

No prose inflation; meta.json 12.9→13.4 KB, well under caps. Gallery-data build validation passes.