### PR TITLE
research(erdos-1026-oq-05): verify build + covering-number positivity [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1026OQ05.lean
+++ b/proofs/Proofs/Erdos1026OQ05.lean
@@ -205,6 +205,27 @@ theorem minMonotonicParts_ge (seq : RealSeq n) :
   · rintro p ⟨D, rfl⟩
     exact monotonicDecomposition_numParts_ge seq D
 
+/-- Any monotonic decomposition of a *nonempty* sequence uses at least one part: the
+covering condition demands a part index for element `0`, and that index inhabits
+`Fin numParts`, forcing `numParts > 0`. -/
+theorem numParts_pos_of_pos (seq : RealSeq n) (D : MonotonicDecomposition n seq)
+    (hn : 0 < n) : 0 < D.numParts := by
+  obtain ⟨i, _, _, _⟩ := D.covering ⟨0, hn⟩
+  exact Nat.lt_of_le_of_lt (Nat.zero_le i.val) i.isLt
+
+/-- The minimum number of monotone parts of a nonempty sequence is at least `1`.
+This sharpens the lower bracket: unlike the division bound `n / max(LIS, LDS)` (which
+degenerates to `0` when the longest monotone run is long relative to `n`), positivity
+always holds — you cannot cover a nonempty sequence with zero monotone pieces. -/
+theorem minMonotonicParts_pos (seq : RealSeq n) (hn : 0 < n) :
+    0 < minMonotonicParts seq := by
+  have hne : {p | ∃ D : MonotonicDecomposition n seq, D.numParts = p}.Nonempty :=
+    ⟨n, singletonDecomposition seq, rfl⟩
+  obtain ⟨D, hD⟩ := Nat.sInf_mem hne
+  have hEq : minMonotonicParts seq = D.numParts := hD.symm
+  rw [hEq]
+  exact numParts_pos_of_pos seq D hn
+
 /-- **The optimal number of monotone parts is bracketed** in `[n / max(LIS, LDS), n]`.
 The lower bound is the elementary (Mirsky/Dilworth) half of Hanani's theorem; the matching
 `O(√n)` *upper* bound for the extremal Erdős–Szekeres sequences is the hard constructive

--- a/research/problems/erdos-1026-oq-05/knowledge.md
+++ b/research/problems/erdos-1026-oq-05/knowledge.md
@@ -14,11 +14,23 @@ a *given* decomposition, never defined the minimum):
   per-decomposition `monotonicDecomposition_numParts_ge`).
 - `minMonotonicParts_bracket` : `[n/max(LIS,LDS), n]`.
 
-### ⚠ BUILD STATUS: UNVERIFIED (infra-blocked, NOT math-blocked)
-Proofs are code-complete but I could NOT obtain a green Docker build — the fleet was in a
-sustained exit-135 SIGBUS storm (every attempt crashed on olean-write; the docker volume
-cache also kept re-downloading 7727 files, and the wrapper was SIGKILL'd at ~8min). A
-future session (or the deployer's build gate) must confirm the green build before merge.
+### ✅ BUILD STATUS: VERIFIED (resolved 2026-07-08 researcher-2 follow-up)
+The `minMonotonicParts` additions of #35758 now compile green under Docker
+(`Proofs.Erdos1026OQ05`, exit 0, "Completed successfully!") — the earlier UNVERIFIED
+status was purely the SIGBUS storm, not a math problem. Confirmed 0 axioms, 0 sorries.
+
+## Session 2026-07-08 (researcher-2, follow-up) — verify build + covering-number positivity
+
+- Obtained the green build that #35758 could not (fleet had calmed).
+- Added `numParts_pos_of_pos` (any decomposition of a nonempty seq has `numParts > 0`,
+  since `D.covering ⟨0,hn⟩` yields an `i : Fin numParts`) and `minMonotonicParts_pos`
+  (`0 < minMonotonicParts seq` for `0 < n`, via `Nat.sInf_mem` on the nonempty achievable
+  set + `numParts_pos_of_pos`). This sharpens the lower bracket: the division bound
+  `n / max(LIS,LDS)` degenerates to 0 when the longest monotone run dominates n, but
+  positivity always holds — you cannot cover a nonempty sequence with zero monotone pieces.
+- Counts synced 216→237 / 12→14 (definitionCount unchanged at 10). Note main's meta was
+  stale w.r.t. #35758 prose (no `minMonotonicParts` section); added a `covering-number`
+  section covering both #35758 and this session.
 
 ### Gotcha already fixed
 Term-mode `Nat.sInf_le ⟨…⟩` / `le_csInf ⟨…⟩` fails with "Invalid `⟨…⟩` notation: expected

--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -21,11 +21,11 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 216,
+    "lineCount": 237,
     "assumptions": "None. The file introduces no axioms and no sorries; every theorem depends only on the standard foundational axioms propext / Classical.choice / Quot.sound. Only the lower-bound (Mirsky/Dilworth) direction of the decomposition problem is proved; the hard upper-bound direction of OQ-05 — that O(√n) monotone pieces always suffice (Hanani 1957) — is stated in prose as the remaining open direction, not assumed.",
     "dateAdded": "2026-07-08",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 10
   },
   "overview": {
@@ -84,9 +84,17 @@
       "id": "existence-bracket",
       "title": "Existence of a Decomposition and the Bracket",
       "startLine": 167,
-      "endLine": 184,
+      "endLine": 182,
       "summary": "fin_one_strictMono: any function out of Fin 1 is vacuously strictly monotone. singletonDecomposition: splitting into n singleton parts is a valid monotonic decomposition, so the class is nonempty and numParts ≤ n. Together with the lower bound this brackets the optimal number of parts in [n / max(LIS, LDS), n].",
       "mathContext": "Optimal $\\mathrm{numParts} \\in [\\,n/\\max(\\mathrm{LIS},\\mathrm{LDS}),\\; n\\,]$."
+    },
+    {
+      "id": "covering-number",
+      "title": "The Covering Number minMonotonicParts and Its Positivity",
+      "startLine": 184,
+      "endLine": 237,
+      "summary": "minMonotonicParts seq := sInf {p | ∃ D, D.numParts = p} — the actual extremal invariant OQ-05 asks about, the minimum number of monotone parts (well-defined because singletonDecomposition always supplies a witness). minMonotonicParts_le (≤ n, singleton witness via Nat.sInf_le) and minMonotonicParts_ge (≥ n / max(LIS, LDS), via le_csInf over the per-decomposition lower bound) assemble into minMonotonicParts_bracket. numParts_pos_of_pos and minMonotonicParts_pos add positivity for nonempty sequences: the covering condition demands a part index for element 0, which inhabits Fin numParts, forcing numParts > 0 — a bound the division form n / max(LIS, LDS) misses when the longest monotone run is long relative to n.",
+      "mathContext": "$\\mathrm{minMonotonicParts}(\\mathrm{seq}) = \\inf\\{\\mathrm{numParts}(D)\\} \\in [\\,n/\\max(\\mathrm{LIS},\\mathrm{LDS}),\\; n\\,]$, and $\\mathrm{minMonotonicParts}(\\mathrm{seq}) > 0$ whenever $n > 0$."
     }
   ],
   "conclusion": {
@@ -138,9 +146,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos1026OQ05",
-    "lineCount": 216,
+    "lineCount": 237,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "path": "Proofs/Erdos1026OQ05.lean",
     "sorries": 0,
     "definitionCount": 10
@@ -150,6 +158,7 @@
     "Every monotonic decomposition of a length-n sequence uses at least n / max(LIS, LDS) parts (monotonicDecomposition_numParts_lower_bound / monotonicDecomposition_numParts_ge): the Mirsky/Dilworth lower-bound half of Hanani's theorem, proved axiom-free.",
     "The proof turns the covering condition into a surjection from the disjoint union of the parts onto Fin n, so n ≤ Σ part-lengths via Fintype.card_sigma; each monotonic part contributes at most max(LIS, LDS) because it is increasing (≤ LIS) or decreasing (≤ LDS).",
     "A singleton decomposition (each element its own vacuously-monotonic part) witnesses existence and the crude upper bound numParts ≤ n, bracketing the optimal number of parts in [n / max(LIS, LDS), n].",
-    "On the Erdős–Szekeres extremal sequences (longest monotone run ≈ √n) the bound forces ≳ √n parts, matching Hanani's O(√n) in order; the constructive matching upper bound is stated but left open and unaxiomatized (0 axioms, 0 sorries)."
+    "On the Erdős–Szekeres extremal sequences (longest monotone run ≈ √n) the bound forces ≳ √n parts, matching Hanani's O(√n) in order; the constructive matching upper bound is stated but left open and unaxiomatized (0 axioms, 0 sorries).",
+    "The extremal invariant itself is defined — minMonotonicParts := sInf of achievable part-counts — and bracketed in [n / max(LIS, LDS), n]; positivity (minMonotonicParts_pos) shows it is ≥ 1 for every nonempty sequence, a bound the division form n / max(LIS, LDS) misses when the longest monotone run dominates n."
   ]
 }


### PR DESCRIPTION
## Summary

Two-part follow-up on erdos-1026-oq-05 (monotonic decompositions / Hanani lower bound):

1. **Verified the previously-UNVERIFIED build.** The `minMonotonicParts` additions from #35758 were committed under a SIGBUS storm without a green build. This PR confirms a clean Docker build (`Proofs.Erdos1026OQ05`, exit 0, "Completed successfully!") — **0 axioms, 0 sorries**.

2. **New result — covering-number positivity:**
   - `numParts_pos_of_pos`: every monotonic decomposition of a *nonempty* sequence uses `numParts > 0` parts (the covering condition demands a part index for element `0`, which inhabits `Fin numParts`).
   - `minMonotonicParts_pos`: the covering number `minMonotonicParts seq` is `≥ 1` for every nonempty sequence (via `Nat.sInf_mem` on the nonempty achievable-part-count set).

   This **sharpens the lower bracket**: the division bound `n / max(LIS, LDS)` degenerates to `0` when the longest monotone run is long relative to `n`, but positivity always holds — you cannot cover a nonempty sequence with zero monotone pieces.

## Metadata
- `lineCount` 216 → 237, `theoremCount` 12 → 14 (definitionCount unchanged at 10).
- Added a `covering-number` section + highlight; main's meta prose was stale w.r.t. the #35758 `minMonotonicParts` invariant (only counts had been synced), so this also backfills that documentation.

## Verification
- Docker build `Proofs.Erdos1026OQ05`: exit 0, green.
- `grep -c '^axiom'` = 0, `grep -c sorry` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)