### PR TITLE
Enrich Hurwitz commutative sharpness: differentiate mainTheorem types (main vs supporting)

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/meta.json
@@ -15,27 +15,27 @@
   "mainTheorems": [
     {
       "name": "comm_bound_sharp",
-      "type": "theorem",
+      "type": "main",
       "description": "Sharpness of the commutative Hurwitz bound: the set of ℝ-dimensions of commutative real normed division algebras is exactly {1,2} — both endpoints are realized (ℝ→1, ℂ→2) and no other dimension occurs. The realizability direction the parent's one-sided bound lacks."
     },
     {
       "name": "finrank_normed_field_eq_one_or_two",
-      "type": "theorem",
+      "type": "supporting",
       "description": "Commutative Hurwitz upper bound: every normed field over ℝ has finrank ℝ F ∈ {1,2}, via NormedAlgebra.Real.nonempty_algEquiv_or (Gelfand–Mazur) — F is ℝ- or ℂ-isomorphic."
     },
     {
       "name": "finrank_normed_field_admissible",
-      "type": "theorem",
+      "type": "supporting",
       "description": "Restatement: finrank ℝ F lies in the admissibleDimensions set {1,2} for every normed field F over ℝ."
     },
     {
       "name": "finrank_real_self",
-      "type": "theorem",
+      "type": "supporting",
       "description": "Realizability of dimension 1: finrank ℝ ℝ = 1."
     },
     {
       "name": "finrank_complex",
-      "type": "theorem",
+      "type": "supporting",
       "description": "Realizability of dimension 2: finrank ℝ ℂ = 2."
     }
   ],


### PR DESCRIPTION
The entry's 5 `mainTheorems` all used the flat `"type": "theorem"`, so the gallery UI could not distinguish the headline result from its supporting lemmas. This marks:

- `comm_bound_sharp` → `main` (the sharpness result: realized dimension set is exactly {1,2})
- `finrank_normed_field_eq_one_or_two`, `finrank_normed_field_admissible` (Gelfand–Mazur upper bound) → `supporting`
- `finrank_real_self`, `finrank_complex` (realizability endpoints ℝ→1, ℂ→2) → `supporting`

Matches the `main`/`supporting` convention used across sibling gallery entries. No prose change; JSON validates, gallery-data build passes (my entry raises no annotation/validation errors).