### PR TITLE
research(abel-ruffini-oq-04-oq-01-oq-03): central Sylow ⟹ abelian upgrade + order-15 classification

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ01OQ03.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01OQ03.lean
@@ -795,4 +795,92 @@ example {G : Type*} [Group G] [Finite G] (c : G) (hc : orderOf c = 5)
     (hcard.trans (by norm_num)) (by norm_num)
     (huniq_of_lt (by norm_num) (by norm_num)) c hc (by norm_num)
 
+/-! ### From central Sylow to abelian: the `G ⧸ ⟨c⟩` cyclic upgrade
+
+The nilpotency result above places the group on the nilpotent side of the boundary, but in
+the *prime-index* subcase (`k = 1`) one can say strictly more: `G` is **abelian**.  Once the
+centrality criterion `mem_center_of_coprime_index` puts `c` in `Z(G)`, the classical theorem
+"`G ⧸ Z(G)` cyclic ⟹ `G` abelian" (`commutative_of_cyclic_center_quotient`) applies through
+the intermediate central subgroup `⟨c⟩`, provided the quotient `G ⧸ ⟨c⟩` is cyclic.  When the
+index is a *prime* `q`, that quotient has prime order and is automatically cyclic.  This is
+the exact mechanism behind "every group of order `15` is cyclic": `15 = 5·3`, `gcd(3, 4) = 1`
+centralises the order-`5` element, and the order-`3` quotient is cyclic — giving
+commutativity, a strict strengthening of the order-`15` nilpotency example above. -/
+
+/-- **A central element generates a normal subgroup.**  If `c ∈ Z(G)` then every element of
+`⟨c⟩` is central, hence fixed by conjugation, so `⟨c⟩ ⊴ G`.  This is exactly what makes the
+coset space `G ⧸ ⟨c⟩` a *group* (rather than a bare quotient), a prerequisite for even stating
+that it is cyclic below. -/
+theorem zpowers_normal_of_mem_center {G : Type*} [Group G] {c : G}
+    (hc : c ∈ Subgroup.center G) : (Subgroup.zpowers c).Normal := by
+  refine ⟨fun n hn g => ?_⟩
+  have hcen : n ∈ Subgroup.center G := Subgroup.zpowers_le.mpr hc hn
+  rw [Subgroup.mem_center_iff] at hcen
+  have hfix : g * n * g⁻¹ = n := by rw [hcen g]; group
+  rw [hfix]; exact hn
+
+/-- **Central element with cyclic quotient ⟹ abelian.**  If `c ∈ Z(G)` and the quotient
+`G ⧸ ⟨c⟩` is cyclic, then `G` is commutative.  This routes Mathlib's
+`commutative_of_cyclic_center_quotient` through the quotient map `G → G ⧸ ⟨c⟩`, whose kernel
+`⟨c⟩` lies in the centre exactly because `c` is central (`Subgroup.zpowers_le`).  The `Normal`
+instance — needed for `G ⧸ ⟨c⟩` to carry a group structure — follows from centrality via
+`zpowers_normal_of_mem_center`. -/
+theorem mul_comm_of_center_zpowers_cyclic_quotient {G : Type*} [Group G] (c : G)
+    (hc : c ∈ Subgroup.center G) [(Subgroup.zpowers c).Normal]
+    [IsCyclic (G ⧸ Subgroup.zpowers c)] (a b : G) :
+    a * b = b * a := by
+  refine commutative_of_cyclic_center_quotient (QuotientGroup.mk' (Subgroup.zpowers c)) ?_ a b
+  rw [QuotientGroup.ker_mk']
+  exact Subgroup.zpowers_le.mpr hc
+
+/-- **Prime index ⟹ cyclic quotient.**  If `⟨c⟩` has order `p` and `Nat.card G = p·q` with
+`q` prime, then `G ⧸ ⟨c⟩` has order `q`, hence is cyclic.  (Lagrange:
+`|G| = |G ⧸ ⟨c⟩| · |⟨c⟩|` with `|⟨c⟩| = orderOf c = p`, cancel the `p`.) -/
+theorem isCyclic_quotient_zpowers_of_prime_index {G : Type*} [Group G] [Finite G]
+    (c : G) [(Subgroup.zpowers c).Normal] {p q : ℕ} (hc : orderOf c = p) (hq : q.Prime)
+    (hcard : Nat.card G = p * q) :
+    IsCyclic (G ⧸ Subgroup.zpowers c) := by
+  haveI : Fact q.Prime := ⟨hq⟩
+  apply isCyclic_of_prime_card (p := q)
+  have hlag : Nat.card G
+      = Nat.card (G ⧸ Subgroup.zpowers c) * Nat.card (Subgroup.zpowers c) :=
+    Subgroup.card_eq_card_quotient_mul_card_subgroup _
+  rw [Nat.card_zpowers, hc, hcard,
+    mul_comm (Nat.card (G ⧸ Subgroup.zpowers c)) p] at hlag
+  exact (Nat.eq_of_mul_eq_mul_left (hc ▸ orderOf_pos c) hlag).symm
+
+/-- **Coprime prime index ⟹ abelian.**  Under the `zpowers_sylow_normal` hypotheses, if the
+index `q = [G : ⟨c⟩]` is a *prime* coprime to `p − 1`, then `G` is commutative: `c` is central
+by `mem_center_of_coprime_index`, and the prime-order quotient `G ⧸ ⟨c⟩` is cyclic, so
+`mul_comm_of_center_zpowers_cyclic_quotient` applies.  This upgrades the nilpotency conclusion
+`isNilpotent_of_sylow_central_primePow_index` (in its `k = 1` subcase) from nilpotent to
+abelian. -/
+theorem mul_comm_of_prime_index_coprime {G : Type*} [Group G] [Finite G] {p q : ℕ}
+    [hp : Fact p.Prime] (hq : q.Prime)
+    (hcard : Nat.card G = p * q) (hpq : ¬ (p ∣ q))
+    (huniq : ∀ d : ℕ, d ∣ q → d % p = 1 → d = 1)
+    (c : G) (hc : orderOf c = p) (hcop : Nat.Coprime q (p - 1)) (a b : G) :
+    a * b = b * a := by
+  have hcent : c ∈ Subgroup.center G :=
+    mem_center_of_coprime_index q hcard hpq huniq c hc hcop
+  haveI : (Subgroup.zpowers c).Normal := zpowers_normal_of_mem_center hcent
+  haveI : IsCyclic (G ⧸ Subgroup.zpowers c) :=
+    isCyclic_quotient_zpowers_of_prime_index c hc hq hcard
+  exact mul_comm_of_center_zpowers_cyclic_quotient c hcent a b
+
+/-- **Every group of order `15` is abelian.**  Cauchy provides an order-`5` element `c`; with
+`15 = 5·3`, `3` prime, `5 ∤ 3`, and `gcd(3, 4) = 1`, `mul_comm_of_prime_index_coprime` gives
+commutativity.  (A finite abelian group of squarefree order `15` is then cyclic — the
+classical classification of order-`15` groups, here obtained by upgrading the order-`15`
+nilpotency example above to full commutativity.) -/
+theorem mul_comm_of_card_fifteen {G : Type*} [Group G] [Finite G]
+    (hcard : Nat.card G = 15) (a b : G) : a * b = b * a := by
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  haveI : Fintype G := Fintype.ofFinite G
+  obtain ⟨c, hc⟩ : ∃ x : G, orderOf x = 5 :=
+    exists_prime_orderOf_dvd_card 5 (by rw [← Nat.card_eq_fintype_card, hcard]; norm_num)
+  exact mul_comm_of_prime_index_coprime (q := 3) (by norm_num)
+    (hcard.trans (by norm_num)) (by norm_num)
+    (huniq_of_lt (by norm_num) (by norm_num)) c hc (by norm_num) a b
+
 end AbelRuffiniSylowElim

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-03.json
@@ -34,7 +34,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: class-equation centrality criterion — conjClass size ∣ gcd(m,p-1) and coprime index ⇒ c central (5 theorems + order-15 example, VERIFIED 0 sorry / 0 axiom).",
+    "progressSummary": "PROGRESS: abelian upgrade (k=1 prime-index subcase) repaired + verified, order-15 classification capped (PR #35938, 0/0).",
     "builtItems": [
       "zpowers_sylow_normal in AbelRuffiniOQ04OQ01OQ03.lean — arbitrary-prime Sylow-elimination core: order p·m + p∤m + no-small-divisor ⇒ ⟨c⟩ (order-p) normal",
       "conj_mem_zpowers_sylow — every g normalizes ⟨c⟩ (general prime consequence)",
@@ -54,7 +54,9 @@
       "centralizer_index_dvd_index_zpowers ([G:C_G(c)] ∣ m via index_dvd_of_le + zpowers_index_eq)",
       "conjClass_card_dvd_gcd (|conjClass c| ∣ gcd(m,p-1) via Nat.dvd_gcd of the two bounds)",
       "mem_center_of_coprime_index (Coprime m (p-1) ⇒ c ∈ center G)",
-      "mem_center_order5_of_coprime_index + order-15 centrality example (all VERIFIED 0 sorry/0 axiom)"
+      "mem_center_order5_of_coprime_index + order-15 centrality example (all VERIFIED 0 sorry/0 axiom)",
+      "zpowers_normal_of_mem_center (AbelRuffiniOQ04OQ01OQ03.lean): c ∈ center G ⟹ (zpowers c).Normal, via conj_mem with mem_center_iff + group tactic — the instance that unblocks the abelian upgrade (PR #35938).",
+      "Repaired + host-verified the abelian upgrade: mul_comm_of_center_zpowers_cyclic_quotient / isCyclic_quotient_zpowers_of_prime_index / mul_comm_of_prime_index_coprime / mul_comm_of_card_fifteen (order-15 abelian), 0 sorry / 0 axiom, PR #35938."
     ],
     "insights": [
       "Generalizing the fixed prime 5 to a variable prime p is NOT a rename: the two number-theoretic steps change tactic. n_p ≡ 1 (mod p) ⇒ n_p = 1 needs Nat.mod_eq_of_lt hp.out.one_lt to evaluate 1 % p (omega cannot do variable-modulus mod); index cancellation [G:P]·p = p·m ⇒ [G:P] = m needs Nat.eq_of_mul_eq_mul_right (omega cannot cancel a variable multiplier).",
@@ -68,13 +70,15 @@
       "The sharp N/C refinement of the ±1 involution lemma: conjugation on a normal cyclic ⟨c⟩ of prime order p factors through Aut(⟨c⟩)≅(ℤ/p)ˣ of order p−1, so C_G(c) has index dividing p−1 (Noether first-iso + Lagrange). The involution lemma is the order-2 special case; this is the full automorphism-group constraint.",
       "Class-equation sharpening: the conjugacy-class size of an order-p element c divides gcd(m, p-1), not merely p-1 — because ⟨c⟩ ≤ C_G(c) forces [G:C_G(c)] ∣ [G:⟨c⟩]=m (lattice constraint), on top of the automorphism-group constraint [G:C_G(c)] ∣ p-1.",
       "Centrality criterion (class-equation punchline): if the index m=[G:⟨c⟩] is COPRIME to p-1, then gcd(m,p-1)=1, the conjugacy class of c is a singleton, C_G(c)=⊤, and c ∈ Z(G). This is the elementary transfer-theoretic core of Burnside normal-p-complement, specialised to one element. The Abel-Ruffini orders 20=5·4, 40=5·8 sit in the NON-coprime regime (gcd(4,4)=gcd(8,4)=4), which is exactly why non-central order-5 elements are possible there.",
-      "Smallest coprime instance p=5,m=3 (order 15): gcd(3,4)=1 ⇒ every order-5 element is central — the group-theoretic reason all order-15 groups are cyclic. Verified as an example."
+      "Smallest coprime instance p=5,m=3 (order 15): gcd(3,4)=1 ⇒ every order-5 element is central — the group-theoretic reason all order-15 groups are cyclic. Verified as an example.",
+      "The abelian-upgrade draft (mul_comm_of_center_zpowers_cyclic_quotient et al) did NOT compile as written: IsCyclic (G ⧸ Subgroup.zpowers c) requires a Normal instance on ⟨c⟩ for the quotient to have a group structure (else \"failed to synthesize Pow (G ⧸ zpowers c) ℤ\"). A central element does give a normal ⟨c⟩ but Lean has no automatic instance — it must be supplied."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Density-1 forward direction for the associated Galois obstruction remains analytically blocked (unchanged).",
       "Class equation is now essentially complete at the single-element level (size ∣ gcd(m,p-1), coprime ⇒ central). A genuine next step would be the GLOBAL class equation: sum over all conjugacy classes = |G|, deriving e.g. that the number of order-p elements is ≡ 0 mod something, or a normal-p-complement statement for the whole group — but that needs summing over class representatives (Mathlib ConjClasses.card_eq / class equation), a heavier packaging.",
-      "Alternative: state the contrapositive — a non-central order-p element forces gcd(m,p-1)>1, i.e. p-1 shares a prime factor with the index; specialise to conclude structural facts about which orders p·m admit nonabelian groups."
+      "Alternative: state the contrapositive — a non-central order-p element forces gcd(m,p-1)>1, i.e. p-1 shares a prime factor with the index; specialise to conclude structural facts about which orders p·m admit nonabelian groups.",
+      "Abelian regime is now complete through prime-index/order-15. A natural next follow-up: order 21 = 3·7 (nonabelian example exists) vs the coprime criterion — sharpness of the abelian conclusion when q ∤ (p-1) fails (e.g. 7 ≡ 1 mod 3 gives the nonabelian group of order 21)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Strengthens the coprime-regime nilpotency boundary result (merged in #35914, `isNilpotent_of_sylow_central_primePow_index`) in its `k = 1` (prime-index) subcase from **nilpotent** to **abelian**, and caps it with the classical order-15 classification.

### New theorems (pure addition, 5 lemmas)
- `zpowers_normal_of_mem_center` — a subgroup `⟨c⟩` generated by a central element is normal; this is the instance that gives the coset space `G ⧸ ⟨c⟩` its group structure.
- `mul_comm_of_center_zpowers_cyclic_quotient` — `c ∈ Z(G)` and `G ⧸ ⟨c⟩` cyclic ⟹ `G` abelian, routing Mathlib's `commutative_of_cyclic_center_quotient` through the central subgroup `⟨c⟩`.
- `isCyclic_quotient_zpowers_of_prime_index` — `|⟨c⟩| = p`, `|G| = p·q` with `q` prime ⟹ `G ⧸ ⟨c⟩` has order `q`, hence cyclic (Lagrange).
- `mul_comm_of_prime_index_coprime` — under the `zpowers_sylow_normal` hypotheses, a *prime* index `q` coprime to `p−1` forces `G` commutative.
- `mul_comm_of_card_fifteen` — **every finite group of order 15 is abelian** (`15 = 5·3`, `gcd(3,4)=1`, `3` prime): the classical order-15 classification, obtained by upgrading the earlier order-15 nilpotency example to full commutativity.

### Repair
The prior draft of these lemmas (unpushed `[UNVERIFIED]` work) did **not** compile: `IsCyclic (G ⧸ Subgroup.zpowers c)` requires a `Normal` instance on `⟨c⟩` for the quotient to carry a group structure at all, which was absent (`failed to synthesize Pow (G ⧸ zpowers c) ℤ`). This PR supplies it via `zpowers_normal_of_mem_center` and threads the instance through, making the whole block elaborate.

### Verification
Host-verified with `lake env lean` (exit 0): **0 errors, 0 sorries**. `#print axioms` on the new theorems shows only `propext / Classical.choice / Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Genuine 0-sorry / 0-axiom result. (Docker build hit repeated SIGBUS-135 at the olean-write stage under fleet memory pressure — after clean elaboration with zero type errors — so verification was done host-side.)

Counts: lineCount 798 → 886, theoremCount 27 → 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)