### PR TITLE
research(shannon-awgn-oq-02-oq-02): sharp equality boundary of the stddev triangle inequality [VERIFIED 0 sorry/0 axiom]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -905,4 +905,83 @@ theorem correlation_affine_invariant_of_pos [IsProbabilityMeasure μ] {X Y : Ω 
     correlation (fun ω => a * X ω + b) (fun ω => c * Y ω + d) μ = correlation X Y μ := by
   rw [correlation_affine_invariant hX hY a b c d, Real.sign_of_pos (mul_pos ha hc), one_mul]
 
+/-!
+### Sharp equality boundary of the standard-deviation triangle inequality
+
+`stddev_add_le` states the L² triangle inequality `σ[X+Y] ≤ σ[X] + σ[Y]` for the aggregate
+standard deviation.  The results below pin down its **equality** boundary — the exact condition
+under which the ceiling is attained.  Squaring the (nonnegative) triangle inequality reduces the
+equality `σ[X+Y] = σ[X] + σ[Y]` to `cov[X,Y] = σ[X]·σ[Y]`, i.e. covariance attaining its
+Cauchy–Schwarz maximum, which for non-degenerate variables is exactly the perfect *positive*
+correlation `ρ = +1`.  This is the sharp companion of `variance_add_eq_iff_covariance_zero` (whose
+equality boundary is the *uncorrelated* case `cov = 0`), sitting at the opposite extreme of the
+Cauchy–Schwarz interval.
+-/
+
+/-- **Equality boundary of the standard-deviation triangle inequality (covariance form).**  For
+square-integrable `X, Y`, the L² triangle inequality `σ[X+Y] ≤ σ[X] + σ[Y]` of `stddev_add_le` is
+an *equality*
+
+        √Var[X + Y] = √Var[X] + √Var[Y]
+
+*if and only if* the covariance attains its Cauchy–Schwarz maximum `cov[X,Y] = √Var[X]·√Var[Y]`.
+No non-degeneracy hypothesis is needed: when e.g. `Y` is a.e. constant both sides read
+`σ[X] = σ[X]` and `cov = 0 = σ[X]·0`.  Squaring the nonnegative identity turns it into the linear
+comparison `Var[X]+Var[Y]+2cov = (√Var[X]+√Var[Y])²`, from which the covariance value is forced. -/
+theorem stddev_add_eq_iff_covariance_eq_sqrt [IsFiniteMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) :
+    Real.sqrt (Var[X + Y; μ]) = Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ]) ↔
+      cov[X, Y; μ] = Real.sqrt (Var[X; μ]) * Real.sqrt (Var[Y; μ]) := by
+  set a := Real.sqrt (Var[X; μ]) with ha_def
+  set b := Real.sqrt (Var[Y; μ]) with hb_def
+  have hsx : a ^ 2 = Var[X; μ] := Real.sq_sqrt (variance_nonneg _ _)
+  have hsy : b ^ 2 = Var[Y; μ] := Real.sq_sqrt (variance_nonneg _ _)
+  constructor
+  · intro h
+    have h2 : Var[X + Y; μ] = (a + b) ^ 2 := by
+      rw [← h, Real.sq_sqrt (variance_nonneg (X + Y) μ)]
+    nlinarith [h2, variance_add hX hY, hsx, hsy]
+  · intro h
+    have h2 : Var[X + Y; μ] = (a + b) ^ 2 := by
+      nlinarith [variance_add hX hY, hsx, hsy, h]
+    rw [h2, Real.sqrt_sq (by positivity)]
+
+/-- **Equality boundary of the standard-deviation triangle inequality (correlation form).**  For
+non-degenerate `X, Y` the triangle inequality `σ[X+Y] ≤ σ[X] + σ[Y]` is an equality *exactly* when
+the correlation coefficient attains its maximum:
+
+        √Var[X + Y] = √Var[X] + √Var[Y]  ↔  ρ[X, Y] = 1.
+
+The covariance-form condition `cov = √Var[X]·√Var[Y]` of
+`stddev_add_eq_iff_covariance_eq_sqrt`, normalised through the definition of `correlation`; the two
+non-degeneracy hypotheses make the normalising denominator `σ[X]·σ[Y]` nonzero. -/
+theorem stddev_add_eq_iff_correlation_eq_one [IsFiniteMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hXnd : Var[X; μ] ≠ 0) (hYnd : Var[Y; μ] ≠ 0) :
+    Real.sqrt (Var[X + Y; μ]) = Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ]) ↔
+      correlation X Y μ = 1 := by
+  have hax : Real.sqrt (Var[X; μ]) ≠ 0 :=
+    Real.sqrt_ne_zero'.mpr ((variance_nonneg X μ).lt_of_ne hXnd.symm)
+  have hay : Real.sqrt (Var[Y; μ]) ≠ 0 :=
+    Real.sqrt_ne_zero'.mpr ((variance_nonneg Y μ).lt_of_ne hYnd.symm)
+  rw [stddev_add_eq_iff_covariance_eq_sqrt hX hY, correlation,
+    div_eq_one_iff_eq (mul_ne_zero hax hay)]
+
+/-- **Equality boundary of the standard-deviation triangle inequality (perfect-positive-correlation
+capstone).**  For non-degenerate `X, Y` the L² triangle inequality `σ[X+Y] ≤ σ[X] + σ[Y]` is an
+equality *if and only if* `X` is almost everywhere an **increasing** affine function of `Y`:
+
+        √Var[X + Y] = √Var[X] + √Var[Y]  ↔  ∃ a b, 0 < a ∧ X =ᵐ a·Y + b.
+
+Chaining `stddev_add_eq_iff_correlation_eq_one` with `correlation_eq_one_iff_affine_pos`, this is
+the sharp structural boundary of `stddev_add_le`: the standard deviations of a sum add *precisely*
+in the perfectly-positively-correlated (fully-aligned) case, dual to
+`variance_add_eq_iff_covariance_zero` — whose boundary is the orthogonal `cov = 0` case — at the
+opposite endpoint of the Cauchy–Schwarz interval. -/
+theorem stddev_add_eq_iff_affine_pos [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hXnd : Var[X; μ] ≠ 0) (hYnd : Var[Y; μ] ≠ 0) :
+    Real.sqrt (Var[X + Y; μ]) = Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ]) ↔
+      ∃ a b : ℝ, 0 < a ∧ X =ᵐ[μ] fun ω => a * Y ω + b := by
+  rw [stddev_add_eq_iff_correlation_eq_one hX hY hXnd hYnd,
+    correlation_eq_one_iff_affine_pos hX hY hXnd hYnd]
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 908,
+    "lineCount": 987,
     "axiomCount": 0,
-    "theoremCount": 38,
+    "theoremCount": 41,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -183,6 +183,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 908,
-  "theoremCount": 38
+  "lineCount": 987,
+  "theoremCount": 41
 }

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: affine-invariance structural companion ρ[aX+b,cY+d]=sign(ac)·ρ[X,Y] VERIFIED 0/0 (+ orientation-preserving corollary); dual to signed ±1 boundary capstone",
+    "progressSummary": "PROGRESS: proved the sharp equality boundary of the standard-deviation triangle inequality (σ[X+Y]=σ[X]+σ[Y] ⟺ cov=√Var·√Var ⟺ ρ=+1 ⟺ increasing-affine), 3 theorems VERIFIED 0 sorry/0 axiom; dual endpoint to variance_add_eq_iff_covariance_zero.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -54,7 +54,10 @@
       "correlation_eq_one_iff_affine_pos + correlation_eq_neg_one_iff_affine_neg (signed capstones) in ShannonChannelCodingAWGNOQ02OQ02.lean",
       "correlation_affine_invariant (ShannonChannelCodingAWGNOQ02OQ02.lean:879): ρ[a·X+b,c·Y+d]=sign(a·c)·ρ[X,Y] VERIFIED 0/0 — affine invariance, unconditional (degenerate cases via div-by-zero convention)",
       "correlation_affine_invariant_of_pos (line 903): a,c>0 ⟹ ρ preserved exactly ρ[a·X+b,c·Y+d]=ρ[X,Y]",
-      "real_sign_eq_self_div_abs helper (line 861): Real.sign x = x/|x| ∀x incl 0"
+      "real_sign_eq_self_div_abs helper (line 861): Real.sign x = x/|x| ∀x incl 0",
+      "stddev_add_eq_iff_covariance_eq_sqrt (ShannonChannelCodingAWGNOQ02OQ02.lean): σ[X+Y]=σ[X]+σ[Y] ↔ cov[X,Y]=√Var[X]·√Var[Y], no non-degeneracy hyp; proof squares both sides (Real.sq_sqrt / Real.sqrt_sq) and closes with nlinarith on variance_add.",
+      "stddev_add_eq_iff_correlation_eq_one (same file): non-degenerate normalisation, σ[X+Y]=σ[X]+σ[Y] ↔ ρ[X,Y]=1 via div_eq_one_iff_eq.",
+      "stddev_add_eq_iff_affine_pos (same file): capstone σ[X+Y]=σ[X]+σ[Y] ↔ ∃a b, 0<a ∧ X=ᵐ a·Y+b (perfect positive correlation / increasing affine), chaining correlation_eq_one_iff_affine_pos."
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -68,7 +71,9 @@
       "The equality-boundary iff closes cleanly: forward (tightness⟹regression line) needs Var[Y]≠0, but converse (affine⟹tightness) is unconditional — a pure bilinear/variance-of-affine computation transported along =ᵐ via covariance_congr_left + variance_congr.",
       "Correlation-coefficient normalisation ρ=cov/(σX·σY) packages the whole second-order theory: |ρ|≤1 IS covariance Cauchy–Schwarz (no non-degeneracy needed — division-by-zero convention absorbs degenerate case), and |ρ|=1 ⟺ a.e. affine dependence IS the sharp equality boundary. Both non-degeneracy hypotheses genuinely needed for the |ρ|=1 iff since a degenerate variable gives ρ=0≠±1 while X=ᵐ0·Y+μ[X] still holds.",
       "Signed sharp boundary: ρ = sign(a) when X =ᵐ a·Y+b, so ρ=+1 ⟺ increasing affine (a>0), ρ=−1 ⟺ decreasing affine (a<0); splits |ρ|=1⟺affine into two distinct endpoints.",
-      "Affine-invariance proof reuses the exact machinery of the ±1 capstones: cov[aX+b,cY+d]=ac·cov via covariance_add_const_left/right + covariance_const_mul_left/right; σ[aX+b]=|a|·σ[X] via variance_eq_of_affine+sqrt_mul+sqrt_sq_eq_abs; sign packaged as x/|x| so a·c/(|a|·|c|)=sign(a·c) closes by ring (field inverse rearrangement, no nonzero hyps needed)."
+      "Affine-invariance proof reuses the exact machinery of the ±1 capstones: cov[aX+b,cY+d]=ac·cov via covariance_add_const_left/right + covariance_const_mul_left/right; σ[aX+b]=|a|·σ[X] via variance_eq_of_affine+sqrt_mul+sqrt_sq_eq_abs; sign packaged as x/|x| so a·c/(|a|·|c|)=sign(a·c) closes by ring (field inverse rearrangement, no nonzero hyps needed).",
+      "Sharp equality boundary of the stddev triangle inequality stddev_add_le: squaring the nonnegative identity σ[X+Y]=σ[X]+σ[Y] reduces it to the covariance attaining its Cauchy-Schwarz maximum cov[X,Y]=√Var[X]·√Var[Y]; NO non-degeneracy hypothesis needed (degenerate Y gives 0=σ[X]·0).",
+      "The triangle-equality boundary sits at the OPPOSITE Cauchy-Schwarz endpoint from variance_add_eq_iff_covariance_zero: variances add iff cov=0 (orthogonal), but standard deviations add iff cov=σ[X]σ[Y] (perfectly positively correlated, ρ=+1)."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -85,7 +90,9 @@
       "Correlation-coefficient triangle/monotonicity: state ρ under sign of covariance, or the two-variance stddev triangle equality condition (perfect positive correlation ρ=+1) as the dual of the off-diagonal-cancellation boundary.",
       "Consider affine-invariance of ρ: corr(aX+b, cY+d)=sign(ac)·corr(X,Y) as a structural companion.",
       "Affine-invariance of covariance itself (cov[aX+b,cY+d]=ac·cov[X,Y]) is now proved inline — consider extracting as a named reusable lemma if a further correlation result needs it.",
-      "Consider corr sign-flip corollary for a>0,c<0 (orientation-reversing): ρ[aX+b,cY+d]=−ρ[X,Y] as the negative companion of correlation_affine_invariant_of_pos."
+      "Consider corr sign-flip corollary for a>0,c<0 (orientation-reversing): ρ[aX+b,cY+d]=−ρ[X,Y] as the negative companion of correlation_affine_invariant_of_pos.",
+      "Dual equality for the finite-sum triangle inequality stddev_sum_le: σ[∑Wᵢ]=∑σ[Wᵢ] iff all pairs are perfectly positively correlated (all centered contributions a.e. nonneg-proportional to a common direction) — needs an induction handling the shared-direction propagation.",
+      "Consider the strict-inequality companion: σ[X+Y] < σ[X]+σ[Y] whenever ρ<1 (non-degenerate), the strict form of stddev_add_le."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds the **sharp equality boundary** of the standard-deviation triangle inequality `stddev_add_le` (`σ[X+Y] ≤ σ[X]+σ[Y]`) in `ShannonChannelCodingAWGNOQ02OQ02.lean`. This is the dual endpoint of the existing `variance_add_eq_iff_covariance_zero`: **variances** add exactly when `cov=0` (orthogonal), whereas **standard deviations** add exactly when correlation is maximal (`ρ=+1`, perfectly positively correlated).

Three new theorems (all VERIFIED, 0 sorry / 0 axiom — depend only on `propext`, `Classical.choice`, `Quot.sound`):

1. `stddev_add_eq_iff_covariance_eq_sqrt` — general (no non-degeneracy):
   `√Var[X+Y] = √Var[X]+√Var[Y]  ↔  cov[X,Y] = √Var[X]·√Var[Y]`.
   Squaring the nonnegative identity reduces it to covariance attaining its Cauchy–Schwarz maximum; the degenerate case is covered automatically (`Y` a.e. constant ⇒ both sides `σ[X]=σ[X]`, `cov=0=σ[X]·0`).
2. `stddev_add_eq_iff_correlation_eq_one` — non-degenerate normalisation: `… ↔ ρ[X,Y] = 1`.
3. `stddev_add_eq_iff_affine_pos` — capstone: `… ↔ ∃ a b, 0 < a ∧ X =ᵐ a·Y+b` (increasing affine / perfect positive correlation), chaining `correlation_eq_one_iff_affine_pos`.

## Verification

- Host elaboration (`lake env lean`) exits 0 with zero diagnostics (full-file type-check, no sorries).
- `#print axioms` on all three: only `[propext, Classical.choice, Quot.sound]`.
- Docker build blocked this session by a shared-cache `.ir` corruption race across the concurrent fleet (multiple `lean-build` containers decompressing into the symlinked mathlib `.lake`); correctness confirmed via host elaboration instead.

## Files

- `proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean` (+3 theorems)
- `src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json` (lineCount 908→987, theoremCount 38→41)
- `src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json` (knowledge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)