### PR TITLE
Auditor: re-audit erdos-163/164/165/169 (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11286,21 +11286,21 @@
       "result": "issues-fixed"
     },
     "erdos-163": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:48Z",
+      "lastAudited": "2026-07-09T02:57:06Z",
       "result": "clean"
     },
     "erdos-164": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:34Z",
+      "lastAudited": "2026-07-09T02:57:06Z",
       "result": "clean"
     },
     "erdos-165": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:34Z",
+      "lastAudited": "2026-07-09T02:57:06Z",
       "result": "clean"
     },
     "erdos-166": {
@@ -11330,9 +11330,9 @@
       ]
     },
     "erdos-169": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:48Z",
+      "lastAudited": "2026-07-09T02:57:06Z",
       "result": "clean"
     },
     "erdos-17": {


### PR DESCRIPTION
## Gallery Integrity Audit — batch re-audit (all clean)

Re-audited four axiomatized Erdős entries (oldest `lastAudited`, not covered by open PR #35929). Every integrity dimension was cross-checked against the Lean source; **no issues found**.

| Slug | Axioms (meta = source) | sorries | Counts (thm/def/lines) | Verdict |
|------|------------------------|---------|------------------------|---------|
| erdos-163 (Burr-Erdős) | 1 = 1 (`lee_theorem`) | 0 | 3/8/198 ✓ | clean |
| erdos-164 (primitive sets) | 4 = 4 | 0 | 5/6/153 ✓ | clean |
| erdos-165 (R(3,k)) | 10 = 10 | 0 | 7/4/363 ✓ | clean |
| erdos-169 (AP-free sets) | 2 = 2 | 0 | 2/7/279 ✓ | clean |

### Checks performed
- **Axiom count**: `axiomCount` in meta matches literal `axiom` declarations in each Lean file; all axioms carry substantive propositions (no `True`/`trivial` stubs).
- **Status/badge**: all four correctly `axiomatized` / `axiom`; `assumptions` field discloses the axioms by name.
- **Sorries**: 0 in both meta and source.
- **native_decide**: none on substantive presented results.
- **Counts**: theorem/definition/line counts in meta agree with source.

Only tracker timestamps/counts change. Persisted via PR because the audit loop's `git reset --hard origin/main` clobbers local tracker writes.

---
Discovered during periodic gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)