### PR TITLE
research(szemeredi-regularity-oq-04): 2×2 ε⁴ energy increment core [VERIFIED]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
@@ -438,4 +438,96 @@ theorem edgeDensity_prod_split (G : SimpleGraph V) [DecidableRel G.Adj]
       edgeDensity_union_mul_right G A₂ B₁ B₂ hB]
   ring
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART V: THE 2×2 SIMULTANEOUS-REFINEMENT ENERGY INCREMENT
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The genuine ε⁴ energy increment.**  Refining a pair `(A, B)` *simultaneously*
+    on both coordinates into a disjoint `2×2` grid `{A₁,A₂}×{B₁,B₂}` raises the
+    normalized energy by at least `(|A₁||B₁|/n²)·d²` whenever the corner sub-cell
+    `(A₁,B₁)` has density deviating from the whole density `d(A,B)` by at least `d`:
+
+      `pairEnergy G A B + (|A₁||B₁|/n²)·d²
+         ≤ Σ_{i,j} pairEnergy G Aᵢ Bⱼ`.
+
+    Unlike the two one-sided branches of sessions 4–5 (which could only exploit a
+    deviation against a *whole* partner and stumbled on the mixed second-difference
+    defect), this bound uses the witness cell's deviation from the coarse density
+    *directly*, via the variance atom bound over the four sub-cells.  The mean
+    identity is discharged by `edgeDensity_prod_split` (the law of total density),
+    so `d(A,B)` is the honest `|Aᵢ||Bⱼ|`-weighted centroid and the corner cell is a
+    genuine variance atom.  For an ε-irregular witness `|A₁| ≥ ε|A|`, `|B₁| ≥ ε|B|`,
+    `|d(A₁,B₁) − d(A,B)| > ε`, this yields an energy jump `≥ ε⁴·|A||B|/n²` — the
+    increment the AFKS iteration consumes, with no defect term. -/
+theorem pairEnergy_prod_refinement_gain (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A₁ A₂ B₁ B₂ : Finset V) (hA : Disjoint A₁ A₂) (hB : Disjoint B₁ B₂)
+    (d : ℚ) (hd : 0 ≤ d)
+    (hdev : d ≤ |edgeDensity G A₁ B₁ - edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)|) :
+    pairEnergy G (A₁ ∪ A₂) (B₁ ∪ B₂) +
+        (↑A₁.card : ℚ) * ↑B₁.card / (Fintype.card V : ℚ) ^ 2 * d ^ 2 ≤
+      pairEnergy G A₁ B₁ + pairEnergy G A₁ B₂ +
+        pairEnergy G A₂ B₁ + pairEnergy G A₂ B₂ := by
+  classical
+  -- Cell selectors over the 4-element index `Bool × Bool`.
+  set P : Bool → Finset V := fun b => cond b A₂ A₁ with hP
+  set Q : Bool → Finset V := fun b => cond b B₂ B₁ with hQ
+  set w : Bool × Bool → ℚ := fun p => ((P p.1).card : ℚ) * (Q p.2).card with hwdef
+  set x : Bool × Bool → ℚ := fun p => edgeDensity G (P p.1) (Q p.2) with hxdef
+  -- Sum-expansion helper over `Bool × Bool`.
+  have expand : ∀ f : Bool × Bool → ℚ,
+      (∑ p ∈ (Finset.univ : Finset (Bool × Bool)), f p)
+        = f (false, false) + f (false, true) + f (true, false) + f (true, true) := by
+    intro f
+    simp only [Fintype.sum_prod_type, Fintype.sum_bool]
+    ring
+  have hcardA : ((A₁ ∪ A₂).card : ℚ) = A₁.card + A₂.card := by
+    rw [Finset.card_union_of_disjoint hA]; push_cast; ring
+  have hcardB : ((B₁ ∪ B₂).card : ℚ) = B₁.card + B₂.card := by
+    rw [Finset.card_union_of_disjoint hB]; push_cast; ring
+  -- Total weight `Σw = |A₁∪A₂|·|B₁∪B₂|`.
+  have hW : (∑ p ∈ (Finset.univ : Finset (Bool × Bool)), w p)
+      = (↑(A₁ ∪ A₂).card : ℚ) * ↑(B₁ ∪ B₂).card := by
+    rw [expand w]
+    simp only [hwdef, hP, hQ, cond_true, cond_false]
+    rw [hcardA, hcardB]; ring
+  -- Mean identity `Σ w·x = (Σw)·d(A,B)` — the law of total density.
+  have hmean : (∑ p ∈ (Finset.univ : Finset (Bool × Bool)), w p * x p)
+      = (∑ p ∈ (Finset.univ : Finset (Bool × Bool)), w p) *
+          edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂) := by
+    rw [hW, expand (fun p => w p * x p)]
+    simp only [hwdef, hxdef, hP, hQ, cond_true, cond_false]
+    linear_combination -(edgeDensity_prod_split G A₁ A₂ B₁ B₂ hA hB)
+  have hwnn : ∀ p ∈ (Finset.univ : Finset (Bool × Bool)), 0 ≤ w p := by
+    intro p _; simp only [hwdef]; positivity
+  have hdev' : d ≤ |x (false, false) - edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)| := by
+    simp only [hxdef, hP, hQ, cond_false]; exact hdev
+  have hwlb : ((A₁.card : ℚ) * B₁.card) ≤ w (false, false) :=
+    le_of_eq (by simp [hwdef, hP, hQ])
+  have hw₀nn : (0 : ℚ) ≤ (A₁.card : ℚ) * B₁.card := by positivity
+  -- Apply the abstract atom gain over the four sub-cells.
+  have hgain := weighted_second_moment_atom_gain (Finset.univ : Finset (Bool × Bool))
+    w x hwnn (edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)) hmean (false, false)
+    (Finset.mem_univ _) ((A₁.card : ℚ) * B₁.card) d hw₀nn hd hwlb hdev'
+  rw [hW, expand (fun p => w p * x p ^ 2)] at hgain
+  simp only [hwdef, hxdef, hP, hQ, cond_true, cond_false] at hgain
+  -- Scale the raw excess by `1/n² ≥ 0` and identify the `pairEnergy` terms.
+  have hn2 : (0 : ℚ) ≤ 1 / (Fintype.card V : ℚ) ^ 2 := by positivity
+  have hscaled := mul_le_mul_of_nonneg_left hgain hn2
+  have hL : pairEnergy G (A₁ ∪ A₂) (B₁ ∪ B₂) +
+        (↑A₁.card : ℚ) * ↑B₁.card / (Fintype.card V : ℚ) ^ 2 * d ^ 2
+      = 1 / (Fintype.card V : ℚ) ^ 2 *
+        ((↑(A₁ ∪ A₂).card : ℚ) * ↑(B₁ ∪ B₂).card *
+            edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂) ^ 2 + ↑A₁.card * ↑B₁.card * d ^ 2) := by
+    unfold pairEnergy; ring
+  have hR : pairEnergy G A₁ B₁ + pairEnergy G A₁ B₂ +
+        pairEnergy G A₂ B₁ + pairEnergy G A₂ B₂
+      = 1 / (Fintype.card V : ℚ) ^ 2 *
+        ((↑A₁.card : ℚ) * ↑B₁.card * edgeDensity G A₁ B₁ ^ 2 +
+          ↑A₁.card * ↑B₂.card * edgeDensity G A₁ B₂ ^ 2 +
+          ↑A₂.card * ↑B₁.card * edgeDensity G A₂ B₁ ^ 2 +
+          ↑A₂.card * ↑B₂.card * edgeDensity G A₂ B₂ ^ 2) := by
+    unfold pairEnergy; ring
+  rw [hL, hR]
+  exact hscaled
+
 end Szemeredi.RegularityOQ04Energy

--- a/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
@@ -364,4 +364,78 @@ theorem weighted_second_moment_atom_gain {ι : Type*} (s : Finset ι) (w x : ι 
     rw [← hμ] at hkey
     linarith [hkey]
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART IV: THE LAW OF TOTAL DENSITY (2×2 SIMULTANEOUS REFINEMENT)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Helper: edge counts from `A` are additive over a disjoint split of the
+    `B`-side.  Mirror of `edge_count_union`, splitting the *second* coordinate. -/
+private theorem edge_count_union_right (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B₁ B₂ : Finset V) (hB : Disjoint B₁ B₂) :
+    ((A.product (B₁ ∪ B₂)).filter (fun p => G.Adj p.1 p.2)).card =
+    ((A.product B₁).filter (fun p => G.Adj p.1 p.2)).card +
+    ((A.product B₂).filter (fun p => G.Adj p.1 p.2)).card := by
+  have h_prod : A.product (B₁ ∪ B₂) = A.product B₁ ∪ A.product B₂ := by
+    ext ⟨a, b⟩
+    constructor
+    · intro h
+      have hab := Finset.mem_product.mp h
+      rcases Finset.mem_union.mp hab.2 with hb | hb
+      · exact Finset.mem_union.mpr (Or.inl (Finset.mem_product.mpr ⟨hab.1, hb⟩))
+      · exact Finset.mem_union.mpr (Or.inr (Finset.mem_product.mpr ⟨hab.1, hb⟩))
+    · intro h
+      rcases Finset.mem_union.mp h with hab | hab <;> {
+        have := Finset.mem_product.mp hab
+        exact Finset.mem_product.mpr ⟨this.1, Finset.mem_union.mpr (by tauto)⟩ }
+  rw [h_prod, Finset.filter_union]
+  apply Finset.card_union_of_disjoint
+  apply Finset.disjoint_filter_filter
+  rw [Finset.disjoint_left]
+  intro x h₁ h₂
+  exact absurd (Finset.mem_product.mp h₂).2
+    (Finset.disjoint_left.mp hB (Finset.mem_product.mp h₁).2)
+
+/-- **Weighted-average identity, second coordinate.**  Mirror of
+    `edgeDensity_union_mul`: for a disjoint split `B₁, B₂` of the `B`-side,
+    `|A|·|B₁∪B₂|·d(A,B₁∪B₂) = |A|·|B₁|·d(A,B₁) + |A|·|B₂|·d(A,B₂)`. -/
+theorem edgeDensity_union_mul_right (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B₁ B₂ : Finset V) (hB : Disjoint B₁ B₂) :
+    (↑A.card : ℚ) * ↑(B₁ ∪ B₂).card * edgeDensity G A (B₁ ∪ B₂) =
+    ↑A.card * ↑B₁.card * edgeDensity G A B₁ +
+    ↑A.card * ↑B₂.card * edgeDensity G A B₂ := by
+  have h₁ := card_mul_edgeDensity G A B₁
+  have h₂ := card_mul_edgeDensity G A B₂
+  have h₃ := card_mul_edgeDensity G A (B₁ ∪ B₂)
+  have he : (↑((A.product (B₁ ∪ B₂)).filter (fun p => G.Adj p.1 p.2)).card : ℚ) =
+      ↑((A.product B₁).filter (fun p => G.Adj p.1 p.2)).card +
+      ↑((A.product B₂).filter (fun p => G.Adj p.1 p.2)).card := by
+    exact_mod_cast edge_count_union_right G A B₁ B₂ hB
+  rw [h₃, h₁, h₂]; exact he
+
+/-- **Law of total density for a 2×2 simultaneous refinement.**  When a pair is
+    refined on *both* coordinates into a disjoint `2×2` grid of sub-cells, the
+    whole edge-count-weighted density is exactly the sum of the four sub-cell
+    edge-count-weighted densities:
+
+      `|A||B|·d(A,B) = Σ_{i,j∈{1,2}} |Aᵢ||Bⱼ|·d(Aᵢ,Bⱼ)`,
+
+    with `A = A₁∪A₂`, `B = B₁∪B₂`.  Equivalently, `d(A,B)` is the `|Aᵢ||Bⱼ|`-weighted
+    mean of the four sub-densities.  This is the *mean identity* that the variance
+    atom bound consumes: it certifies that the coarse density `d(A,B)` is the
+    honest weighted centroid of the refined density distribution, so a single
+    sub-cell whose density deviates from `d(A,B)` is a genuine variance atom.
+    Proved by splitting the `A`-side (`edgeDensity_union_mul`) and then each
+    resulting term on the `B`-side (`edgeDensity_union_mul_right`). -/
+theorem edgeDensity_prod_split (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A₁ A₂ B₁ B₂ : Finset V) (hA : Disjoint A₁ A₂) (hB : Disjoint B₁ B₂) :
+    (↑(A₁ ∪ A₂).card : ℚ) * ↑(B₁ ∪ B₂).card * edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂) =
+      ↑A₁.card * ↑B₁.card * edgeDensity G A₁ B₁ +
+      ↑A₁.card * ↑B₂.card * edgeDensity G A₁ B₂ +
+      ↑A₂.card * ↑B₁.card * edgeDensity G A₂ B₁ +
+      ↑A₂.card * ↑B₂.card * edgeDensity G A₂ B₂ := by
+  rw [edgeDensity_union_mul G A₁ A₂ (B₁ ∪ B₂) hA,
+      edgeDensity_union_mul_right G A₁ B₁ B₂ hB,
+      edgeDensity_union_mul_right G A₂ B₁ B₂ hB]
+  ring
+
 end Szemeredi.RegularityOQ04Energy

--- a/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Energy.lean
@@ -329,4 +329,39 @@ theorem variance_atom_bound {ι : Type*} (s : Finset ι) (w x : ι → ℚ)
   rw [← hμ_def] at hvar
   linarith [hsingle, hatom, hvar]
 
+/-- **Atom gain in mean-identity form.**  The directly consumable increment form of
+    `variance_atom_bound`: instead of the internal weighted mean `(Σwx)/(Σw)`, it
+    takes an *external* candidate mean `μ` together with the *mean identity*
+    `Σ wᵢxᵢ = (Σ wᵢ)·μ` as a hypothesis, and concludes
+
+      `(Σ wᵢ)·μ² + w₀·d² ≤ Σ wᵢxᵢ²`.
+
+    This is exactly the shape a block-refinement energy increment needs: the
+    coarse energy of a pair is `(Σ wᵢ)·μ²` with `μ = d(A,B)` the whole density and
+    `Σ wᵢ = |A||B|/n²`; the refined energy is `Σ wᵢxᵢ²` over the sub-cells; and the
+    mean identity is the *law of total density* `Σ|Aᵢ||Bⱼ|d(Aᵢ,Bⱼ) = |A||B|d(A,B)`.
+    Discharging that identity turns a single deviating sub-cell into a definite
+    energy gain `w₀·d²`, with no division and no reference to the internal mean. -/
+theorem weighted_second_moment_atom_gain {ι : Type*} (s : Finset ι) (w x : ι → ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i) (μ : ℚ)
+    (hmean : (∑ i ∈ s, w i * x i) = (∑ i ∈ s, w i) * μ)
+    (i₀ : ι) (hi₀ : i₀ ∈ s) (w₀ d : ℚ) (hw₀ : 0 ≤ w₀) (hd : 0 ≤ d)
+    (hwlb : w₀ ≤ w i₀) (hdev : d ≤ |x i₀ - μ|) :
+    (∑ i ∈ s, w i) * μ ^ 2 + w₀ * d ^ 2 ≤ ∑ i ∈ s, w i * x i ^ 2 := by
+  rcases eq_or_ne (∑ i ∈ s, w i) 0 with hW | hW
+  · -- Total weight zero ⇒ every weight vanishes; both sides collapse to `0`.
+    have hall : ∀ i ∈ s, w i = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg hw).mp hW
+    have hw0 : w₀ = 0 := le_antisymm (hall i₀ hi₀ ▸ hwlb) hw₀
+    have hrhs : (∑ i ∈ s, w i * x i ^ 2) = 0 :=
+      Finset.sum_eq_zero (fun i hi => by rw [hall i hi]; ring)
+    rw [hW, hw0, hrhs]; simp
+  · -- Nonzero total weight ⇒ `μ` is the honest weighted mean; apply the atom bound.
+    have hμ : μ = (∑ j ∈ s, w j * x j) / (∑ j ∈ s, w j) := by
+      rw [hmean, eq_div_iff hW]; ring
+    have hkey := variance_atom_bound s w x hw hW i₀ hi₀ w₀ d hw₀ hd hwlb
+      (hμ ▸ hdev)
+    rw [← hμ] at hkey
+    linarith [hkey]
+
 end Szemeredi.RegularityOQ04Energy

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -284,3 +284,82 @@ carries all the graph-theoretic content.
   genuine ε⁴ increment that the two whole-partner one-sided branches (S4/S5)
   could only approximate.
 - Wire the resulting increment into `afks_energy_iteration_count`.
+
+## Session 2026-07-08 (Session 7, researcher-7) - The 2×2 ε⁴ energy increment (closure of the increment core)
+
+**Mode**: REVISIT (continuing branch szem-oq04-bside-s5)
+**Outcome**: progress (5 theorems VERIFIED 0/0, capstone `pairEnergy_prod_refinement_gain`
+built green on retry attempt 4 after a sustained fleet SIGBUS/SIGSEGV write window)
+
+### What I Did
+- `weighted_second_moment_atom_gain` (Energy file, VERIFIED): the directly
+  consumable form of `variance_atom_bound`. Takes an *external* mean `μ` plus the
+  *mean identity* `Σ wᵢxᵢ = (Σwᵢ)·μ` and concludes `(Σwᵢ)·μ² + w₀·d² ≤ Σ wᵢxᵢ²`.
+  No internal division, no `(Σwx)/(Σw)`. Case-splits on `Σw = 0` (all weights
+  vanish, both sides collapse to 0) vs `≠ 0` (μ is the honest mean, apply the
+  atom bound). This is the exact shape the block-energy increment needs.
+- `edge_count_union_right` + `edgeDensity_union_mul_right` (Energy file, VERIFIED):
+  the second-coordinate mirrors of the existing A-side edge-count/weighted-average
+  identities. (`edgeDensity_comm` is in OQ01, which the Energy file does not import,
+  so the B-side split is proved directly from the raw product-filter, not via comm.)
+- `edgeDensity_prod_split` (Energy file, VERIFIED): **the law of total density for
+  a 2×2 refinement.** `|A||B|·d(A,B) = Σ_{i,j} |Aᵢ||Bⱼ|·d(Aᵢ,Bⱼ)` for `A=A₁∪A₂`,
+  `B=B₁∪B₂` disjoint. Proved by one A-side split then a B-side split of each
+  resulting term (`ring` closes the reassociation). This is precisely the *mean
+  identity* the variance atom bound consumes — it certifies `d(A,B)` is the honest
+  `|Aᵢ||Bⱼ|`-weighted centroid of the four sub-densities.
+- `pairEnergy_prod_refinement_gain` (Energy file, VERIFIED): **the genuine
+  ε⁴ energy increment.** Refining `(A,B)` simultaneously into the 2×2 grid raises
+  the normalized energy by ≥ `(|A₁||B₁|/n²)·d²` whenever the corner cell's density
+  deviates from `d(A,B)` by ≥ d. Assembled by instantiating
+  `weighted_second_moment_atom_gain` over the 4-element index `Bool × Bool`
+  (weights `|Pᵢ||Qⱼ|` unnormalized, densities `d(Pᵢ,Qⱼ)`, mean `d(A,B)`), with the
+  mean identity discharged by `edgeDensity_prod_split` and the final `1/n²` scaling
+  applied through `mul_le_mul_of_nonneg_left` + two `ring` identities.
+
+### Key Findings
+- **This closes the elementary-route obstruction of Sessions 4–5.** The witness
+  deviation from an ε-irregular pair is `|d(A',B') − d(A,B)| > ε` *directly against
+  the whole density* — which IS the coarse mean. So one does not need to decompose
+  it through a mixed density (the S5 defect / second-difference that no triangle
+  inequality kills). Refine BOTH coordinates at once; the witness cell A'×B' is a
+  single variance atom of the 4-cell density distribution whose deviation from the
+  centroid d(A,B) is bounded below, and `variance_atom_bound` converts that lone
+  atom into a definite energy gain. No defect term, no Cauchy–Schwarz on the
+  cross-terms. The variance-atom viewpoint (S6) was exactly the right dodge.
+- With `|A₁| ≥ ε|A|`, `|B₁| ≥ ε|B|`, `|d(A₁,B₁)−d(A,B)| > ε`: weight
+  `≥ ε²|A||B|`, deviation `> ε`, gain `≥ ε²·ε²·|A||B|/n² = ε⁴·|A||B|/n²`. The true
+  ε⁴ increment the AFKS iteration consumes.
+- `linear_combination` sign: expanding `Σ w·x` over `Bool × Bool` vs the
+  `edgeDensity_prod_split` RHS needs coefficient **−1** (default +1 leaves a `2×`
+  residual — the identity's orientation is `whole = Σcells`, opposite the goal).
+- `Fintype.sum_prod_type` + `Fintype.sum_bool` cleanly expand a `Bool × Bool` sum
+  to its four named terms; wrap in a local `expand` helper + `ring`.
+- Final `/n²` scaling: do NOT `convert ... using 2` (descends into the `+` tree and
+  mis-pairs one pairEnergy term with the whole scaled sum). Instead prove
+  `goalLHS = 1/n²·(rawLHS)` and `goalRHS = 1/n²·(rawRHS)` as explicit `ring`
+  identities (each `unfold pairEnergy; ring`), `rw` both, then `exact` the scaled
+  inequality — bulletproof against association mismatch.
+
+### Files Modified
+- proofs/Proofs/SzemerediRegularityOQ04Energy.lean
+  (+weighted_second_moment_atom_gain, +edge_count_union_right,
+   +edgeDensity_union_mul_right, +edgeDensity_prod_split,
+   +pairEnergy_prod_refinement_gain; +~150 lines)
+
+### Build note
+- The capstone repeatedly reached `[7745/7745] Building … (1.1s)` with **zero
+  elaboration errors** (only pre-existing unused-section-variable linter warnings)
+  and then exited 135/139 at the olean-write stage — the fleet-memory write
+  corruption, not a math error. Attempts 1–3 of a bounded retry-loop crashed at the
+  write; **attempt 4 landed clean exit-0** (`Build completed successfully (7745
+  jobs)`), confirming the whole file VERIFIED (0 sorry, 0 axiom). Lesson: a
+  `[N/N] … (1.1s)` line with zero type errors followed by 135/139 is purely a write
+  race — keep retrying, do NOT touch the proof.
+
+### Next Steps
+- Generalize the 2×2 grid to an m×k product refinement (`Finset (Finset V)` families
+  + `card_biUnion` disjoint + `edge_count` over a product partition via
+  `Finset.biUnion`); the abstract atom gain already covers arbitrary finite index.
+- Wire `pairEnergy_prod_refinement_gain` + `exists_irregular_witness` (Bridge) into
+  the whole-partition energy monotonicity feeding `afks_energy_iteration_count`.

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -26,7 +26,7 @@
     "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0/0): supplied the variance atom bound Σwᵢxᵢ²−(Σwᵢ)μ²≥w₀d² (+its identity), the abstract analytic core the S5 note flagged as the genuine blocker for full AFKS closure. Bypasses the mixed-second-difference defect via variance≥single-atom-contribution. Remaining: instantiate over the m×k sub-cells of a two-coordinate refinement and feed afks_energy_iteration_count.",
+    "progressSummary": "PROGRESS S7: closed the increment analytic core — 2×2 law-of-total-density + variance-atom gain assemble the genuine ε⁴ energy increment (5 theorems VERIFIED 0/0, capstone pairEnergy_prod_refinement_gain built green).",
     "builtItems": [
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
       "pairEnergy def + pairEnergy_split_mono — one-sided refinement never decreases the normalized pair energy (|A||B|/n^2)d^2; transports density_sq_convex to partitionEnergy units.",
@@ -42,7 +42,11 @@
       "irregular_witness_split_gap (SzemerediRegularityOQ04Witness.lean): |d(A',B')-d(A\\A',B')| + |d(A,B')-d(A,B\\B')| > eps from a witness deviation >eps, via abs_sub_le through d(A,B') then two edgeDensity_whole_between collapses. VERIFIED 0/0.",
       "irregular_witness_split_gap_disjunction (SzemerediRegularityOQ04Witness.lean): at least one coordinate carries a between-halves gap > eps/2 = exactly the hdev hypothesis of pairEnergy_split_gain (delta=eps/2). VERIFIED 0/0.",
       "weighted_variance_identity (Energy): Finset generalization of split_energy_identity — Σwᵢ(xᵢ−μ)²=Σwᵢxᵢ²−(Σwᵢ)μ² for weighted mean μ, VERIFIED 0/0",
-      "variance_atom_bound (Energy): single-atom deviation ≥d (weight ≥w₀) ⟹ Σwᵢxᵢ²−(Σwᵢ)μ²≥w₀d² — the analytic core dodging the S5 defect obstruction, VERIFIED 0/0"
+      "variance_atom_bound (Energy): single-atom deviation ≥d (weight ≥w₀) ⟹ Σwᵢxᵢ²−(Σwᵢ)μ²≥w₀d² — the analytic core dodging the S5 defect obstruction, VERIFIED 0/0",
+      "weighted_second_moment_atom_gain (SzemerediRegularityOQ04Energy.lean): atom gain in mean-identity form (Σwᵢ)μ²+w₀d²≤Σwᵢxᵢ² [VERIFIED]",
+      "edgeDensity_union_mul_right + edge_count_union_right: B-side (second-coordinate) weighted-average/edge-count identities [VERIFIED]",
+      "edgeDensity_prod_split: law of total density for a 2×2 refinement, |A||B|d(A,B)=Σ|Aᵢ||Bⱼ|d(Aᵢ,Bⱼ) [VERIFIED]",
+      "pairEnergy_prod_refinement_gain: the genuine ε⁴ 2×2 energy increment [VERIFIED — built green on retry attempt 4]"
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
@@ -53,13 +57,15 @@
       "Three consecutive line-less exit-135 SIGBUS crashes were MASKING a real elaboration error (No goals to be solved at gcongr). docker-build --repair-cache (fresh olean force-refresh) let elaboration complete and surface the genuine error at 4.7s — SIGBUS retries alone would never have revealed it.",
       "The AFKS energy-increment lemmas (pairEnergy_split_gain, partitionEnergy_single_split_gain) consume a between-halves density gap |d(A1,B0)-d(A2,B0)|>=delta, but exists_irregular_witness produces a whole-vs-pair deviation |d(A',B')-d(A,B)|>eps. Different shapes; the missing link is a triangle-inequality bridge, now supplied by SzemerediRegularityOQ04Witness.",
       "Density convexity: d(A1 u A2,B) is the |A1|:|A2|-weighted mean of d(A1,B),d(A2,B), hence lies between them, so the whole is never farther from a half than the two halves are from each other (edgeDensity_whole_between). Upgrades a whole-vs-half gap into a half-vs-half gap of >= the same size.",
-      "The S5 mixed-second-difference (defect) obstruction is bypassed by treating the two-coordinate refinement as a weighted point distribution: the witness cell is one atom, and variance≥single-atom-contribution gives the energy gain directly, with no triangle-through-mixed-density detour."
+      "The S5 mixed-second-difference (defect) obstruction is bypassed by treating the two-coordinate refinement as a weighted point distribution: the witness cell is one atom, and variance≥single-atom-contribution gives the energy gain directly, with no triangle-through-mixed-density detour.",
+      "The ε-irregular witness deviation |d(A,B)−d(A,B)| is DIRECTLY against the coarse mean, so refining both coords simultaneously makes the witness cell a single variance atom — dodging the S5 mixed-second-difference defect entirely (no Cauchy–Schwarz on cross terms).",
+      "Bool×Bool index + Fintype.sum_prod_type/sum_bool cleanly instantiates the abstract atom gain over 4 cells; linear_combination needs coeff −1 against edgeDensity_prod_split (whole=Σcells orientation).",
+      "Final /n² scaling: avoid convert (mis-pairs the + tree); prove goal=1/n²·raw via unfold+ring both sides then exact the scaled inequality."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Instantiate variance_atom_bound over the m×k sub-cells of a simultaneous two-coordinate refinement (weights |Aᵢ||Bⱼ|/n², values d(Aᵢ,Bⱼ), mean d(A,B), witness atom (A′,B′) deviation ≥ε/2) → energy gain ≥ (|A′||B′|/n²)(ε/2)²; this is the true ε⁴ increment.",
-      "Wire that increment into afks_energy_iteration_count for the outer AFKS loop.",
-      "Consider upstreaming edgeDensity_whole_between (density convexity) as a clean general fact."
+      "Generalize 2×2 → m×k product refinement via Finset(Finset V) families + card_biUnion + edge_count over a Finset.biUnion product partition.",
+      "Wire pairEnergy_prod_refinement_gain + exists_irregular_witness into whole-partition energy monotonicity feeding afks_energy_iteration_count."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Closes the analytic core of the AFKS energy-increment engine for the strong regularity lemma (OQ-04). All additions are in `proofs/Proofs/SzemerediRegularityOQ04Energy.lean`, fully machine-checked (**0 sorry, 0 axiom**, `Build completed successfully (7745 jobs)`).

## New theorems
- **`weighted_second_moment_atom_gain`** — the consumable form of session 6's `variance_atom_bound`: takes an external mean `μ` + the mean identity `Σwᵢxᵢ = (Σwᵢ)μ` and yields `(Σwᵢ)μ² + w₀d² ≤ Σwᵢxᵢ²` (no internal division).
- **`edge_count_union_right` / `edgeDensity_union_mul_right`** — second-coordinate mirrors of the existing A-side edge-count/weighted-average identities.
- **`edgeDensity_prod_split`** — the *law of total density* for a 2×2 refinement: `|A||B|·d(A,B) = Σᵢⱼ |Aᵢ||Bⱼ|·d(Aᵢ,Bⱼ)`. This is the mean identity certifying `d(A,B)` is the honest weighted centroid of the four sub-densities.
- **`pairEnergy_prod_refinement_gain`** — the genuine **ε⁴ energy increment**: a simultaneous 2×2 refinement raises the normalized energy by ≥ `(|A₁||B₁|/n²)·d²` when the corner cell's density deviates from `d(A,B)` by ≥ d.

## Why it matters
Sessions 4–5 could only exploit a witness deviation against a *whole* partner and stalled on the mixed second-difference (defect) that no triangle inequality kills. Because an ε-irregular witness deviates from the coarse density `d(A,B)` **directly**, refining both coordinates at once makes the witness cell a single variance atom of the 4-cell density distribution — `variance_atom_bound` converts that lone atom into a definite energy gain with no defect term. For `|A₁|≥ε|A|, |B₁|≥ε|B|, |d(A₁,B₁)−d(A,B)|>ε` this yields the ε⁴·|A||B|/n² increment the AFKS iteration consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)