### PR TITLE
Fix: sync 4 stale meta theoremCount fields to true declaration counts

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
@@ -40,7 +40,7 @@
     "assumptions": "0 axioms, 0 sorries. Builds on Mathlib's Gaussian Fourier transform infrastructure (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I — the vertical-strip shift of the real Gaussian integral). HONEST SCOPE: CentralLimitTheorem.lean states its gaussian_fourier_identity against an abstract stdGaussian measure introduced by `axiom`; this file proves the full mathematical content as a concrete Lebesgue integral, but discharging that particular CLT axiom additionally requires replacing the abstract measure by ProbabilityTheory.gaussianReal 0 1, a separate bridge not attempted here.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-21",
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
@@ -336,7 +336,7 @@
     "namespace": "BorsukUlamOQ03OQ01",
     "lineCount": 1163,
     "axiomCount": 1,
-    "theoremCount": 40,
+    "theoremCount": 46,
     "definitionCount": 4,
     "path": "Proofs/BorsukUlamOQ03OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/hilbert-17/meta.json
+++ b/src/data/proofs/hilbert-17/meta.json
@@ -50,7 +50,7 @@
       "pfister_bound_aux: At most 2^n rational function squares needed for n-variable PSD polynomials (Pfister forms)"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 8,
     "description": "Axiom-reduction history: three axioms were redundant restatements of deeper ones and are now derived theorems (artin_hilbert17 and cassels_bound_bivariate from pfister_bound_aux; artin_univariate from univariate_psd_is_sos_aux), and four more have been fully discharged by elementary 0-axiom child proofs — motzkin_not_sos_polynomial_aux (Hilbert17MotzkinNotSOS.lean), robinson_not_sos_aux (Hilbert17RobinsonNotSOS.lean), univariate_psd_is_sos_aux (Hilbert17UnivariatePSDSOS.lean), and quadratic_psd_is_sos_aux (Hilbert17QuadraticGram.lean: the homogeneous Gram/Cholesky core plus affine homogenisation by one extra coordinate). The single remaining independent axiom is pfister_bound_aux (Pfister's 2ⁿ bound)."
   },

--- a/src/data/proofs/mantel-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-03-oq-01/meta.json
@@ -196,7 +196,7 @@
     "namespace": "MantelTuranSharp",
     "lineCount": 146,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/MantelTheoremOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Four gallery entries carry a stale `theoremCount`. In each case the correct value is confirmed by **two independent sources**: the sibling count block within the same meta.json (`meta.*` vs `leanFile.*`), and a fresh comment-stripped recount of the main Lean file.

## Evidence

| entry | field fixed | before -> after | corroborating field |
|---|---|---|---|
| area-of-circle-oq-05-oq-03 | meta.theoremCount | 6 -> 8 | leanFile.theoremCount = 8 |
| hilbert-17 | meta.theoremCount | 11 -> 16 | leanFile.theoremCount = 16 |
| borsuk-ulam-oq-03-oq-01 | leanFile.theoremCount | 40 -> 46 | meta.theoremCount = 46 |
| mantel-theorem-oq-03-oq-01 | leanFile.theoremCount | 7 -> 9 | 9 real decls (line 141 `theorem (...) -/` is a docstring FP) |

Pure metadata: 4 insertions / 4 deletions across 4 files. `definitionCount` and `lineCount` were already correct in every case and left untouched.

---
Automated fix by lean-mechanic agent.