### PR TITLE
research(shannon-channel-coding-awgn-oq-02-oq-02): stddev triangle-inequality equality boundary [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -905,4 +905,73 @@ theorem correlation_affine_invariant_of_pos [IsProbabilityMeasure μ] {X Y : Ω 
     correlation (fun ω => a * X ω + b) (fun ω => c * Y ω + d) μ = correlation X Y μ := by
   rw [correlation_affine_invariant hX hY a b c d, Real.sign_of_pos (mul_pos ha hc), one_mul]
 
+/-!
+### Sharp *equality* boundary of the standard-deviation triangle inequality
+
+`stddev_add_le` shows the aggregate amplitude never exceeds the sum of the individual RMS
+amplitudes, `√Var[X+Y] ≤ √Var[X] + √Var[Y]`.  When is this ceiling *attained*?  Expanding both
+sides through `variance_add`, equality holds **iff the single off-diagonal covariance attains its
+positive Cauchy–Schwarz extreme** `cov[X,Y] = √Var[X]·√Var[Y]` — equivalently (non-degenerate case)
+`ρ[X,Y] = 1`, i.e. `X` and `Y` are almost-everywhere affinely dependent with *positive* slope
+(perfect positive correlation).  This is the sharp *equality* companion of `stddev_add_le`, and the
+exact dual of the vanishing off-diagonal covariance that makes the *variances* add
+(`variance_add_eq_iff_covariance_zero`): there the powers add when the contributions are
+uncorrelated; here the *amplitudes* add precisely when they are perfectly positively correlated.
+-/
+
+/-- **Equality in the standard-deviation triangle inequality.**  For square-integrable `X, Y` the
+subadditivity `stddev_add_le` is an *equality*
+
+        √Var[X + Y] = √Var[X] + √Var[Y]
+
+if and only if the covariance attains its positive Cauchy–Schwarz extreme
+`cov[X,Y] = √Var[X]·√Var[Y]`.  Proved by squaring both nonnegative sides (`Real.sqrt_sq` /
+`Real.sq_sqrt`) and expanding `Var[X+Y]` via `variance_add`, so that the equality collapses to the
+single covariance condition.  No non-degeneracy hypothesis is needed. -/
+theorem stddev_add_eq_iff_covariance_eq_sqrt [IsFiniteMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) :
+    Real.sqrt (Var[X + Y; μ]) = Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ])
+      ↔ cov[X, Y; μ] = Real.sqrt (Var[X; μ]) * Real.sqrt (Var[Y; μ]) := by
+  have hsX : Real.sqrt (Var[X; μ]) ^ 2 = Var[X; μ] := Real.sq_sqrt (variance_nonneg _ _)
+  have hsY : Real.sqrt (Var[Y; μ]) ^ 2 = Var[Y; μ] := Real.sq_sqrt (variance_nonneg _ _)
+  have hcnn : (0 : ℝ) ≤ Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ]) := by positivity
+  have hkey : Real.sqrt (Var[X + Y; μ])
+        = Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ])
+      ↔ Var[X + Y; μ] = (Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ])) ^ 2 := by
+    constructor
+    · intro h; rw [← h, Real.sq_sqrt (variance_nonneg _ _)]
+    · intro h; rw [h, Real.sqrt_sq hcnn]
+  rw [hkey, variance_add hX hY]
+  constructor <;> intro h <;> nlinarith [hsX, hsY, h]
+
+/-- **Equality in the standard-deviation triangle inequality ⟺ ρ = 1 (non-degenerate).**  For
+non-degenerate `X, Y` the RMS amplitudes add, `√Var[X+Y] = √Var[X] + √Var[Y]`, exactly when the
+Pearson correlation is maximal, `ρ[X,Y] = 1`.  Normalises `stddev_add_eq_iff_covariance_eq_sqrt`
+through the definition of `correlation`, the positive Cauchy–Schwarz extreme `cov = σ_X·σ_Y` being
+`ρ = 1` after division by `σ_X·σ_Y ≠ 0`. -/
+theorem stddev_add_eq_iff_correlation_eq_one [IsFiniteMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hXnd : Var[X; μ] ≠ 0) (hYnd : Var[Y; μ] ≠ 0) :
+    Real.sqrt (Var[X + Y; μ]) = Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ])
+      ↔ correlation X Y μ = 1 := by
+  have hsX : Real.sqrt (Var[X; μ]) ≠ 0 :=
+    Real.sqrt_ne_zero'.mpr (lt_of_le_of_ne (variance_nonneg _ _) (Ne.symm hXnd))
+  have hsY : Real.sqrt (Var[Y; μ]) ≠ 0 :=
+    Real.sqrt_ne_zero'.mpr (lt_of_le_of_ne (variance_nonneg _ _) (Ne.symm hYnd))
+  rw [stddev_add_eq_iff_covariance_eq_sqrt hX hY, correlation,
+    div_eq_one_iff_eq (mul_ne_zero hsX hsY)]
+
+/-- **RMS amplitudes add ⟺ perfect positive correlation (a.e. increasing affine dependence).**  For
+non-degenerate `X, Y`, the standard-deviation triangle inequality is an equality
+`√Var[X+Y] = √Var[X] + √Var[Y]` exactly when `X` is almost everywhere an *increasing* affine function
+of `Y`, `X =ᵐ a·Y + b` with `a > 0`.  Chains `stddev_add_eq_iff_correlation_eq_one` with the signed
+capstone `correlation_eq_one_iff_affine_pos`: the aggregate RMS amplitude attains the subadditive
+ceiling `∑σ` precisely in the perfectly positively correlated case — the sharp equality dual of the
+uncorrelated case (`awgn_two_symbol_power_eq_iff_covariance_zero`) that makes the *powers* add. -/
+theorem stddev_add_eq_iff_affine_pos [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hXnd : Var[X; μ] ≠ 0) (hYnd : Var[Y; μ] ≠ 0) :
+    Real.sqrt (Var[X + Y; μ]) = Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ])
+      ↔ ∃ a b : ℝ, 0 < a ∧ X =ᵐ[μ] fun ω => a * Y ω + b := by
+  rw [stddev_add_eq_iff_correlation_eq_one hX hY hXnd hYnd,
+    correlation_eq_one_iff_affine_pos hX hY hXnd hYnd]
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 908,
+    "lineCount": 977,
     "axiomCount": 0,
-    "theoremCount": 38,
+    "theoremCount": 42,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -50,7 +50,8 @@
       "sum_mean_zero: E[∑_{i∈s} Wᵢ] = 0 — the aggregate of zero-mean contributions is zero-mean, via linearity of the integral over a Finset (integral_finset_sum) on the square-integrable (hence integrable) parts. This is the lemma that lets the squared-mean term drop for the sum, not just for each summand.",
       "second_moment_eq_variance: E[W²] = Var[W] for a zero-mean variable — the bridge identifying the engineering notion of 'power' with the probabilistic variance; the rewrite that turns the variance-of-a-sum law into a second-moment law once the means are zero.",
       "correlation_eq_one_iff_affine_pos / correlation_eq_neg_one_iff_affine_neg: the signed sharp boundary — ρ = +1 exactly when X is a.e. an increasing affine function of Y (positive slope, perfect positive correlation) and ρ = −1 exactly when the slope is negative (perfect negative correlation). Refines the capstone |ρ|=1 ⟺ affine dependence by splitting the two endpoints of the Cauchy–Schwarz interval [−1,1] according to the sign of the regression slope, via correlation_eq_of_affine (ρ = a/|a| = sign a when X =ᵐ a·Y+b) and variance_eq_of_affine (Var[X] = a²·Var[Y]).",
-      "correlation_affine_invariant: the dimensionless-invariance structural companion — ρ[a·X+b, c·Y+d] = sign(a·c)·ρ[X,Y] for arbitrary scales a,c and shifts b,d, holding unconditionally (even degenerate) via the division-by-zero convention. Additive shifts cancel (translation-invariance of covariance/variance), multiplicative scales cancel in magnitude against σ[a·X+b]=|a|·σ[X], leaving only the sign of the slope product; the orientation-preserving specialisation correlation_affine_invariant_of_pos (a,c>0) gives exact invariance ρ[a·X+b,c·Y+d]=ρ[X,Y]. This is the defining property that makes Pearson's ρ a scale-free measure of linear association — dual to the signed ±1 boundary theorems."
+      "correlation_affine_invariant: the dimensionless-invariance structural companion — ρ[a·X+b, c·Y+d] = sign(a·c)·ρ[X,Y] for arbitrary scales a,c and shifts b,d, holding unconditionally (even degenerate) via the division-by-zero convention. Additive shifts cancel (translation-invariance of covariance/variance), multiplicative scales cancel in magnitude against σ[a·X+b]=|a|·σ[X], leaving only the sign of the slope product; the orientation-preserving specialisation correlation_affine_invariant_of_pos (a,c>0) gives exact invariance ρ[a·X+b,c·Y+d]=ρ[X,Y]. This is the defining property that makes Pearson's ρ a scale-free measure of linear association — dual to the signed ±1 boundary theorems.",
+      "stddev_add_eq_iff_covariance_eq_sqrt / stddev_add_eq_iff_correlation_eq_one / stddev_add_eq_iff_affine_pos: the sharp EQUALITY boundary of the standard-deviation (Minkowski/L²) triangle inequality stddev_add_le. The subadditive ceiling √Var[X+Y] ≤ √Var[X]+√Var[Y] is attained — √Var[X+Y] = √Var[X]+√Var[Y] — exactly when the single off-diagonal covariance hits its positive Cauchy–Schwarz extreme cov[X,Y]=σ_X·σ_Y, equivalently ρ[X,Y]=1 (non-degenerate), equivalently X is a.e. an INCREASING affine function of Y (X =ᵐ a·Y+b with a>0, perfect positive correlation). This is the exact dual of the vanishing-covariance boundary that makes the POWERS add (awgn_two_symbol_power_eq_iff_covariance_zero): powers add when contributions are uncorrelated, amplitudes add when they are perfectly positively correlated. Proved by squaring both nonnegative sides (Real.sqrt_sq/Real.sq_sqrt) and expanding via variance_add, then chaining the correlation definition and the signed capstone correlation_eq_one_iff_affine_pos."
     ],
     "prerequisites": [
       "Variance of a sum of pairwise-independent variables: ProbabilityTheory.IndepFun.variance_sum (Var[∑ Xᵢ] = ∑ Var[Xᵢ])",
@@ -183,6 +184,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 908,
-  "theoremCount": 38
+  "lineCount": 977,
+  "theoremCount": 42
 }

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: affine-invariance structural companion ρ[aX+b,cY+d]=sign(ac)·ρ[X,Y] VERIFIED 0/0 (+ orientation-preserving corollary); dual to signed ±1 boundary capstone",
+    "progressSummary": "PROGRESS (VERIFIED 0/0): closed the equality-case gap of the standard-deviation triangle inequality — √Var[X+Y]=√Var[X]+√Var[Y] ⟺ cov=σ_Xσ_Y ⟺ ρ=1 ⟺ increasing a.e. affine dependence (3 theorems). The two-term sharp boundary of stddev_add_le is now complete; remaining directions (finite-sum equality iff, L²-limit series) are heavier and untouched.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -54,7 +54,10 @@
       "correlation_eq_one_iff_affine_pos + correlation_eq_neg_one_iff_affine_neg (signed capstones) in ShannonChannelCodingAWGNOQ02OQ02.lean",
       "correlation_affine_invariant (ShannonChannelCodingAWGNOQ02OQ02.lean:879): ρ[a·X+b,c·Y+d]=sign(a·c)·ρ[X,Y] VERIFIED 0/0 — affine invariance, unconditional (degenerate cases via div-by-zero convention)",
       "correlation_affine_invariant_of_pos (line 903): a,c>0 ⟹ ρ preserved exactly ρ[a·X+b,c·Y+d]=ρ[X,Y]",
-      "real_sign_eq_self_div_abs helper (line 861): Real.sign x = x/|x| ∀x incl 0"
+      "real_sign_eq_self_div_abs helper (line 861): Real.sign x = x/|x| ∀x incl 0",
+      "stddev_add_eq_iff_covariance_eq_sqrt (ShannonChannelCodingAWGNOQ02OQ02.lean): √Var[X+Y]=√Var[X]+√Var[Y] ↔ cov[X,Y]=√Var[X]·√Var[Y], no non-degeneracy needed (square both nonneg sides + variance_add + nlinarith).",
+      "stddev_add_eq_iff_correlation_eq_one: same equality ↔ ρ[X,Y]=1 for non-degenerate X,Y (normalise via div_eq_one_iff_eq).",
+      "stddev_add_eq_iff_affine_pos: same equality ↔ ∃a>0,b, X=ᵐ a·Y+b (chains correlation_eq_one_iff_affine_pos). VERIFIED 0 sorry/0 axiom (propext,Classical.choice,Quot.sound only)."
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -68,7 +71,8 @@
       "The equality-boundary iff closes cleanly: forward (tightness⟹regression line) needs Var[Y]≠0, but converse (affine⟹tightness) is unconditional — a pure bilinear/variance-of-affine computation transported along =ᵐ via covariance_congr_left + variance_congr.",
       "Correlation-coefficient normalisation ρ=cov/(σX·σY) packages the whole second-order theory: |ρ|≤1 IS covariance Cauchy–Schwarz (no non-degeneracy needed — division-by-zero convention absorbs degenerate case), and |ρ|=1 ⟺ a.e. affine dependence IS the sharp equality boundary. Both non-degeneracy hypotheses genuinely needed for the |ρ|=1 iff since a degenerate variable gives ρ=0≠±1 while X=ᵐ0·Y+μ[X] still holds.",
       "Signed sharp boundary: ρ = sign(a) when X =ᵐ a·Y+b, so ρ=+1 ⟺ increasing affine (a>0), ρ=−1 ⟺ decreasing affine (a<0); splits |ρ|=1⟺affine into two distinct endpoints.",
-      "Affine-invariance proof reuses the exact machinery of the ±1 capstones: cov[aX+b,cY+d]=ac·cov via covariance_add_const_left/right + covariance_const_mul_left/right; σ[aX+b]=|a|·σ[X] via variance_eq_of_affine+sqrt_mul+sqrt_sq_eq_abs; sign packaged as x/|x| so a·c/(|a|·|c|)=sign(a·c) closes by ring (field inverse rearrangement, no nonzero hyps needed)."
+      "Affine-invariance proof reuses the exact machinery of the ±1 capstones: cov[aX+b,cY+d]=ac·cov via covariance_add_const_left/right + covariance_const_mul_left/right; σ[aX+b]=|a|·σ[X] via variance_eq_of_affine+sqrt_mul+sqrt_sq_eq_abs; sign packaged as x/|x| so a·c/(|a|·|c|)=sign(a·c) closes by ring (field inverse rearrangement, no nonzero hyps needed).",
+      "Sharp EQUALITY boundary of the std-deviation (Minkowski/L²) triangle inequality stddev_add_le: √Var[X+Y]=√Var[X]+√Var[Y] ⟺ cov=σ_Xσ_Y ⟺ ρ=1 ⟺ X a.e. increasing-affine in Y (a>0). Exact dual of the uncorrelated-⟹-powers-add boundary: amplitudes add iff perfectly positively correlated."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -85,7 +89,9 @@
       "Correlation-coefficient triangle/monotonicity: state ρ under sign of covariance, or the two-variance stddev triangle equality condition (perfect positive correlation ρ=+1) as the dual of the off-diagonal-cancellation boundary.",
       "Consider affine-invariance of ρ: corr(aX+b, cY+d)=sign(ac)·corr(X,Y) as a structural companion.",
       "Affine-invariance of covariance itself (cov[aX+b,cY+d]=ac·cov[X,Y]) is now proved inline — consider extracting as a named reusable lemma if a further correlation result needs it.",
-      "Consider corr sign-flip corollary for a>0,c<0 (orientation-reversing): ρ[aX+b,cY+d]=−ρ[X,Y] as the negative companion of correlation_affine_invariant_of_pos."
+      "Consider corr sign-flip corollary for a>0,c<0 (orientation-reversing): ρ[aX+b,cY+d]=−ρ[X,Y] as the negative companion of correlation_affine_invariant_of_pos.",
+      "Finite-sum equality √Var[∑Wᵢ]=∑√Var[Wᵢ]: harder induction requiring all centered contributions a.e. nonneg-proportional (pairwise perfect positive correlation); equality propagation through stddev_sum_le is the open packaging.",
+      "L²/countable extension of variance additivity (Var of a series) still needs dominated-convergence for covariance — heavier."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Closes the **equality-case gap** of the standard-deviation (Minkowski/L²) triangle inequality `stddev_add_le` in `ShannonChannelCodingAWGNOQ02OQ02.lean`. The file already proved the subadditive ceiling `√Var[X+Y] ≤ √Var[X] + √Var[Y]` but had no characterization of when it is *attained*. This PR supplies the sharp boundary — the RMS amplitudes add exactly at **perfect positive correlation**:

- **`stddev_add_eq_iff_covariance_eq_sqrt`** — `√Var[X+Y] = √Var[X] + √Var[Y]  ↔  cov[X,Y] = √Var[X]·√Var[Y]` (the positive Cauchy–Schwarz extreme). No non-degeneracy hypothesis; proved by squaring both nonnegative sides (`Real.sqrt_sq`/`Real.sq_sqrt`) and expanding `Var[X+Y]` via `variance_add`, collapsing to the single covariance condition.
- **`stddev_add_eq_iff_correlation_eq_one`** — the same equality `↔ ρ[X,Y] = 1` (non-degenerate), normalising through the `correlation` definition.
- **`stddev_add_eq_iff_affine_pos`** — the same equality `↔ ∃ a>0, b,  X =ᵐ a·Y + b`, i.e. `X` is a.e. an **increasing** affine function of `Y`. Chains `correlation_eq_one_iff_affine_pos`.

## Why this matters

This is the exact **dual** of the vanishing-covariance boundary `awgn_two_symbol_power_eq_iff_covariance_zero` already in the file: the *powers* add when the contributions are uncorrelated, whereas the *amplitudes* add precisely when they are perfectly positively correlated. It completes the second-order picture around `stddev_add_le` — the sharp-boundary next-step flagged in the problem's knowledge base.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` on all three theorems lists only `[propext, Classical.choice, Quot.sound]`.
- File elaborates clean via `lake env lean` (host, ~70s). The Docker wrapper hit fleet **SIGBUS exit-135** at the olean-write stage after a clean 1.4s elaboration with zero type errors (memory pressure, not a math error).
- meta.json: `lineCount` 908→977, `theoremCount` 38→42 (the pre-existing count also undercounted one `private theorem` by 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)