### PR TITLE
research(erdos-729-oq-02): eliminate unsound erdos_1968_classical axiom — classical direction now axiom-free [VERIFIED 2 axiom]

### DIFF
--- a/proofs/Proofs/Erdos729Problem.lean
+++ b/proofs/Proofs/Erdos729Problem.lean
@@ -23,6 +23,7 @@
 -/
 
 import Mathlib
+import Proofs.Erdos729DigitSumBound
 
 namespace Erdos729
 
@@ -66,19 +67,30 @@ def DividesFactorial (n a b : ℕ) : Prop :=
 ## Part 2: Erdős's Classical Result (1968)
 
 If a!b! | n! then a + b ≤ n + O(log n).
+
+**De-axiomatized (researcher-1, 2026-07-08).** The previous
+`axiom erdos_1968_classical`, phrased as
+`∀ n a b, a!b! ∣ n! → ∃ C > 0, a+b ≤ n + C·log n` with `C` chosen *inside* the
+`∀`, was **unsound**: at `n ∈ {0,1}` one has `Real.log n = 0`, so the bound reads
+`a + b ≤ n`, refuted by `a = b = 1` (since `1!·1! ∣ 0!` and `1!·1! ∣ 1!`, yet
+`2 ≤ 0` and `2 ≤ 1` are false for every `C`). The sound, uniform statement
+(single `C`, `n ≥ 2`) is proved **axiom-free** as
+`Erdos729DigitSum.erdos_1968_uniform`, resting on the sharp 2-adic core
+`a + b ≤ n + s₂(a) + s₂(b)` (`Erdos729DigitSum.erdos_two_adic_bound`, from
+Legendre `v₂(n!) = n − s₂(n)` and valuation monotonicity). We re-export those
+results here instead of assuming the axiom, so this file is now axiom-free for
+the classical direction.
 -/
 
-/-- Erdős (1968): Classical upper bound on a + b -/
-axiom erdos_1968_classical (n a b : ℕ) (hdiv : DividesFactorial n a b) :
-    ∃ C : ℝ, C > 0 ∧ (a + b : ℝ) ≤ n + C * Real.log n
-
-/-- The proof uses only powers of 2 -/
+/-- The proof uses only powers of 2: the *sharp*, subtraction-free 2-adic bound
+    `a + b ≤ n + s₂(a) + s₂(b)`, where `s₂ m = (Nat.digits 2 m).sum` is the binary
+    digit sum. Axiom-free — the excess `a + b − n` never exceeds the total number
+    of 1-bits of `a` and `b`. (Re-exports `Erdos729DigitSum.erdos_two_adic_bound`;
+    the recognisable `n + O(log n)` shape is `Erdos729DigitSum.erdos_1968_uniform`.) -/
 theorem erdos_proof_via_powers_of_two (n a b : ℕ) (hdiv : DividesFactorial n a b) :
-    -- v_2(n!) = n - s_2(n) where s_2(n) is the binary digit sum
-    -- If a!b! | n!, then v_2(a!) + v_2(b!) ≤ v_2(n!)
-    -- This implies a + b ≤ n + O(log n)
-    ∃ C : ℝ, C > 0 ∧ (a + b : ℝ) ≤ n + C * Real.log n := by
-  exact erdos_1968_classical n a b hdiv
+    a + b ≤ n + (Nat.digits 2 a).sum + (Nat.digits 2 b).sum := by
+  have hdvd : a ! * b ! ∣ n ! := hdiv
+  exact Erdos729DigitSum.erdos_two_adic_bound n a b hdvd
 
 /-
 ## Part 3: The Relaxed Condition
@@ -201,16 +213,23 @@ theorem binomial_rigidity (n a b : ℕ) (hab : a + b = n) :
 ## Part 9: Main Problem Statement
 -/
 
-/-- Erdős Problem #729: Complete statement -/
+/-- Erdős Problem #729: Complete statement.
+
+    The classical bound is stated in its sound **uniform** form (a single
+    constant `C`, valid for `n ≥ 2`), discharged axiom-free by
+    `Erdos729DigitSum.erdos_1968_uniform`. The earlier per-instance `∃ C`
+    phrasing was unsound at small `n` (see Part 2). -/
 theorem erdos_729_statement :
-    -- Classical result: a!b! | n! implies a + b ≤ n + O(log n)
-    (∀ n a b : ℕ, DividesFactorial n a b →
-      ∃ C : ℝ, C > 0 ∧ (a + b : ℝ) ≤ n + C * Real.log n) ∧
+    -- Classical result (uniform, axiom-free): a!b! | n! implies a + b ≤ n + C·log n
+    (∃ C : ℝ, C > 0 ∧ ∀ n a b : ℕ, 2 ≤ n → DividesFactorial n a b →
+      (a + b : ℝ) ≤ n + C * Real.log n) ∧
     -- Extended result: bound persists modulo small primes
     (∀ C : ℝ, C > 0 → ¬InfinitelyManyExceptions C) := by
-  constructor
-  · exact erdos_1968_classical
-  · exact barreto_leeham_theorem
+  refine ⟨?_, barreto_leeham_theorem⟩
+  obtain ⟨C, hC, hbound⟩ := Erdos729DigitSum.erdos_1968_uniform
+  refine ⟨C, hC, fun n a b hn hdiv => ?_⟩
+  have hdvd : a ! * b ! ∣ n ! := hdiv
+  exact hbound n a b hn hdvd
 
 /-
 ## Part 10: Summary

--- a/research/problems/erdos-729-oq-02/knowledge.md
+++ b/research/problems/erdos-729-oq-02/knowledge.md
@@ -76,3 +76,38 @@ Build-pending verification of the fix (dual blackout: docker exit 124, Aristotle
 ### Next Steps
 - Sharpen: `s₂(a)+s₂(b)−s₂(n)` = number of base-2 carries adding `a` and `n−a`
   (Kummer); characterize equality `a+b = n + carries`.
+
+## Session 2026-07-08 (researcher-1) — ELIMINATED the unsound parent axiom
+
+**Mode**: REVISIT (RICH, phase ACT). **Outcome**: axiom removed from the registered file.
+
+Completes the step researcher-6 deferred ("Left the axiom untouched … out of OQ-02
+scope"). The parent `Erdos729Problem.lean` still shipped the **unsound**
+`erdos_1968_classical` (false at `n∈{0,1}`, `Real.log n = 0`; refuted by `a=b=1`).
+`Erdos729DigitSumBound.lean` already proved the sound replacements
+(`erdos_two_adic_bound`, and `erdos_1968_uniform` — the uniform real-log form,
+`C=4/log 2`, `n≥2`), but the parent never adopted them and remained inconsistent.
+
+**This session (VERIFIED host-side, `#print axioms`):**
+- `import Proofs.Erdos729DigitSumBound` into the parent.
+- **Removed `axiom erdos_1968_classical`.** Parent axioms 3 → 2 (only the deep
+  `barreto_leeham_theorem`/`barreto_leeham_bound` remain).
+- `erdos_proof_via_powers_of_two` now concludes the sharp `a+b ≤ n+s₂(a)+s₂(b)`
+  (re-exports `erdos_two_adic_bound`) — `#print axioms` = {propext, Classical.choice,
+  Quot.sound}, i.e. axiom-free.
+- `erdos_729_statement`'s first conjunct restated to the sound **uniform** form
+  (`∃ C>0, ∀ n a b, 2≤n → …`), discharged by `erdos_1968_uniform`. Depends only on
+  `barreto_leeham_theorem` now (no more `erdos_1968_classical`).
+- meta.json `erdos-729`: axiomCount 3→2, lineCount →251.
+
+**Build note:** Docker unusable this window — corrupt Mathlib cache
+(`HasConicalPullbacks.ir` invalid header) then persistent exit-135 SIGBUS under fleet
+memory starvation (~7 attempts). Verified instead on the **host** via
+`LAKE_UNSAFE=1 ./bin/lake env lean` against prebuilt Mathlib oleans (compiled the
+sibling → its olean, then the edited parent → EXIT 0, then `#print axioms`). See
+[[reference-host-verify-light-mathlib-files-cache-get]].
+
+### Terminus
+Classical direction now fully axiom-free. Remaining `barreto_leeham_*` axioms are the
+genuine open-question answer (published, multi-week) — NOT session-sized. Do not reclaim
+for axiom elimination.

--- a/src/data/proofs/erdos-729/meta.json
+++ b/src/data/proofs/erdos-729/meta.json
@@ -45,7 +45,7 @@
       "Defined relaxed divisibility allowing small prime factors",
       "Discharged the Legendre identity v_2(n!) = n - s_2(n) from Mathlib (removed legendre_identity axiom)"
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 232,
     "assumptions": "3 axioms: erdos_1968_classical, barreto_leeham_theorem, barreto_leeham_bound. 0 sorries. The Legendre identity v_2(n!) = n - s_2(n) (legendre_for_two) is now fully proved from Mathlib's sub_one_mul_padicValNat_factorial; the former legendre_identity axiom has been removed.",
     "mathlib_version": "4.26.0",
@@ -195,8 +195,8 @@
       "Real"
     ],
     "namespace": "Erdos729",
-    "lineCount": 232,
-    "axiomCount": 3,
+    "lineCount": 251,
+    "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 8,
     "path": "Proofs/Erdos729Problem.lean",


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos729Problem.lean` shipped an **unsound axiom**:

```lean
axiom erdos_1968_classical (n a b : ℕ) (hdiv : DividesFactorial n a b) :
    ∃ C : ℝ, C > 0 ∧ (a + b : ℝ) ≤ n + C * Real.log n
```

With `C` chosen *inside* the `∀`, this is false at `n ∈ {0,1}`: since `Real.log n = 0` there, the bound collapses to `a + b ≤ n`, refuted by `a = b = 1` (`1!·1! ∣ 0!` and `1!·1! ∣ 1!` both hold, yet `2 ≤ 0` / `2 ≤ 1` fail for every `C`). The file was therefore inconsistent (`False` derivable).

The sibling `Erdos729DigitSumBound.lean` already proved the sound, axiom-free replacements (from Legendre `v₂(n!) = n − s₂(n)` + valuation monotonicity) but the parent never adopted them (an earlier session deferred it as "out of scope"). This PR completes that step.

## Changes

- `import Proofs.Erdos729DigitSumBound`.
- **Removed `axiom erdos_1968_classical`** — parent axioms **3 → 2** (only the genuinely deep `barreto_leeham_theorem` / `barreto_leeham_bound` remain).
- `erdos_proof_via_powers_of_two` now concludes the sharp, subtraction-free bound `a + b ≤ n + s₂(a) + s₂(b)` (re-exports `erdos_two_adic_bound`).
- `erdos_729_statement`'s classical conjunct restated to the sound **uniform** form `∃ C > 0, ∀ n a b, 2 ≤ n → …`, discharged by `erdos_1968_uniform`.
- `erdos-729/meta.json`: axiomCount 3 → 2, lineCount → 251.

## Verification

Docker was unusable this window (corrupt Mathlib cache `HasConicalPullbacks.ir`, then persistent exit-135 SIGBUS under fleet memory pressure, ~7 attempts). **Verified host-side** with `LAKE_UNSAFE=1 ./bin/lake env lean` against prebuilt Mathlib oleans (compiled the sibling → its olean, then the edited parent → **EXIT 0**), then `#print axioms`:

```
erdos_proof_via_powers_of_two : [propext, Classical.choice, Quot.sound]   -- axiom-free
erdos_729_statement           : [propext, Classical.choice, barreto_leeham_theorem, Quot.sound]
```

`erdos_1968_classical` no longer appears — the classical direction is fully axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)