### PR TITLE
research(roth-theorem-k3-oq-03-oq-01): isolate δ^k major term in von Neumann expansion [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -24,6 +24,9 @@
     * `kAPCount_diag_eq_sum_subsets` — the **generalized von Neumann telescoping**:
       `Λ_k(g,…,g) = ∑_{S⊆[k]} δ^{k−|S|}·Λ_k(i↦ if i∈S then g−δ·1 else 1)`, the full
       `2^k`-term multilinear expansion with the `δ^k` major term isolated at `S=∅`.
+    * `kAPCount_diag_eq_major_add_remainder` — the same expansion with the `S=∅`
+      summand evaluated: `Λ_k(g,…,g) = δ^k + ∑_{∅≠S⊆[k]} δ^{k−|S|}·Λ_k(…)`, the
+      "main `k`-AP count `δ^k` plus a balanced (Gowers-controlled) remainder" form.
 
   These are precisely the checks that pin the operators down as genuine
   averages `E_{x,d} ∏ᵢ fᵢ(x+i·d)` (the `(N⁻¹)²·N² = 1` normalization),
@@ -350,5 +353,32 @@ theorem kAPCount_diag_eq_sum_subsets {N : ℕ} [NeZero N] (k : ℕ)
     apply Finset.sum_congr rfl; intro x _
     rw [Finset.sum_comm]
   rw [hL, hR]
+
+/-- **Major term + balanced remainder.**  Separating the `S = ∅` summand of the von
+    Neumann expansion `kAPCount_diag_eq_sum_subsets` isolates the *major term* `δ^k`
+    from the *balanced remainder*.  The `S = ∅` term carries the scalar `δ` in every
+    slot, so it equals `δ^k · Λ_k(1,…,1) = δ^k` (`kAPCount_const_one`); every remaining
+    term is indexed by a *nonempty* `S`, hence has at least one mean-zero slot
+    `b = g − δ·1`.  With `g = 1_A` and `δ = |A|/N` this is exactly the
+    "main `k`-AP count plus a Gowers-controlled error" split that the density-increment
+    argument feeds into the generalized von Neumann inequality:
+
+        Λ_k(g,…,g) = δ^k + ∑_{∅ ≠ S ⊆ [k]} δ^{k−|S|} · Λ_k(i ↦ if i ∈ S then b else 1). -/
+theorem kAPCount_diag_eq_major_add_remainder {N : ℕ} [NeZero N] (k : ℕ)
+    (g : ZMod N → ℂ) (δ : ℂ) :
+    kAPCount k (fun _ : Fin k => g)
+      = δ ^ k
+        + ∑ S ∈ (Finset.univ.erase (∅ : Finset (Fin k))),
+            δ ^ (k - S.card) *
+              kAPCount k (fun i => if i ∈ S then (g - δ • (1 : ZMod N → ℂ)) else 1) := by
+  classical
+  rw [kAPCount_diag_eq_sum_subsets k g δ,
+      ← Finset.add_sum_erase Finset.univ _ (Finset.mem_univ (∅ : Finset (Fin k)))]
+  congr 1
+  -- The `S = ∅` term collapses to `δ ^ k`: no balanced slots, so all slots carry `1`.
+  have hfun : (fun i => if i ∈ (∅ : Finset (Fin k)) then (g - δ • (1 : ZMod N → ℂ))
+        else (1 : ZMod N → ℂ)) = (fun (_ : Fin k) (_ : ZMod N) => (1 : ℂ)) := by
+    funext i y; simp
+  rw [Finset.card_empty, Nat.sub_zero, hfun, kAPCount_const_one, mul_one]
 
 end RothTheoremOQ03OQ01

--- a/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
@@ -20,7 +20,8 @@
       "kAPCount_update_zero (@[simp]): overwriting slot j with 0 gives Λ_k = 0 — one-liner off kAPCount_eq_zero_of_zero + Function.update_self; the additive unit of the slot module.",
       "Toolchain: Function.update_self (NOT update_same) is the v4.26 name for update f j v j = v; add_sub_cancel proves a + (b − a) = b here (works for the module ZMod N → ℂ).",
       "The full slot-telescoping Λ_k(g,…,g)=∑_{S⊆[k]}δ^{k−|S|}Λ_k(i↦if i∈S then b else 1) (b=g−δ·1) is obtained in ONE shot from Finset.prod_add on the inner product ∏ᵢ g(x+i·d)=∏ᵢ(b(x+i·d)+δ), rather than iterating kAPCount_update_split k times. S=∅ gives the δ^k major term (kAPCount_const_one).",
-      "Assembly: expand inner product on both sides to a canonical triple sum (N⁻¹)²∑ₓ∑_d∑_S, then reconcile via two Finset.sum_comm reorderings (∑_S∑ₓ∑_d → ∑ₓ∑_d∑_S). RHS if-slots collapse via Finset.prod_ite_mem + univ_inter; δ-power exponent k−|S| via Finset.card_sdiff_of_subset."
+      "Assembly: expand inner product on both sides to a canonical triple sum (N⁻¹)²∑ₓ∑_d∑_S, then reconcile via two Finset.sum_comm reorderings (∑_S∑ₓ∑_d → ∑ₓ∑_d∑_S). RHS if-slots collapse via Finset.prod_ite_mem + univ_inter; δ-power exponent k−|S| via Finset.card_sdiff_of_subset.",
+      "To peel the S=∅ major term off Finset.univ sum over subsets: rw [← Finset.add_sum_erase Finset.univ _ (Finset.mem_univ ∅)] turns ∑_{S:Finset (Fin k)} into F ∅ + ∑_{S∈univ.erase ∅}; then the empty-slot tuple (fun i => if i∈∅ then b else 1) equals the const-1 tuple by funext i y; simp, so kAPCount_const_one evaluates it to 1 and the term is δ^k."
     ],
     "builtItems": [
       "RothTheoremOQ03OQ01.lean: self-contained, 4 noncomputable defs (hypercubeShift, conjugateByWeight, gowersNorm, kAPCount) + 5 proved theorems, 0 axioms, 0 sorries.",
@@ -35,7 +36,8 @@
       "kAPCount_update_split: von Neumann slot-split identity Λ_k(update f j g) = δ·Λ_k(update f j 1) + Λ_k(update f j (g−δ·1)). 0 axioms (propext/Choice/Quot only), host lake env lean EXIT 0.",
       "kAPCount_update_sub: slotwise subtractivity.",
       "kAPCount_update_zero (@[simp]): zero slot annihilates the count (update form).",
-      "kAPCount_diag_eq_sum_subsets (generalized von Neumann telescoping, 2^k subset expansion)"
+      "kAPCount_diag_eq_sum_subsets (generalized von Neumann telescoping, 2^k subset expansion)",
+      "kAPCount_diag_eq_major_add_remainder: isolates the S=∅ major term of the von Neumann expansion — Λ_k(g,…,g) = δ^k + ∑_{∅≠S⊆[k]} δ^{k−|S|}·Λ_k(i↦ if i∈S then g−δ·1 else 1). S=∅ term collapses via kAPCount_const_one; proved with Finset.add_sum_erase + funext/simp. The \"main count δ^k + balanced (Gowers-controlled) remainder\" form. VERIFIED 0/0."
     ],
     "progressSummary": "PROGRESS (S+1, researcher-5): added the generalized von Neumann slot-split kAPCount_update_split (Λ_k(update f j g) = δ·Λ_k(update f j 1) + Λ_k(update f j (g−δ·1))) — the first density-decomposition step the prior nextSteps called for — plus its supporting slotwise linearity (kAPCount_update_sub, kAPCount_update_zero). All host-verified (lake env lean EXIT 0), 0 axioms/0 sorries (foundational trio only). score 13→16. [2026-07-08 researcher-10] Proved the full slot-telescoping kAPCount_diag_eq_sum_subsets (the density-decomposition step the prior nextSteps called for, completed): Λ_k(g,…,g)=∑_{S⊆[k]}δ^{k−|S|}Λ_k(i↦if i∈S then g−δ·1 else 1), all 2^k terms with δ^k major term at S=∅, via Finset.prod_add. VERIFIED 0/0 (docker-build green). File 354L/12 theorems.",
     "nextSteps": [


### PR DESCRIPTION
## Summary

Extends the generalized von Neumann telescoping in `RothTheoremOQ03OQ01.lean` by evaluating the `S = ∅` summand of `kAPCount_diag_eq_sum_subsets`, isolating the **main term** from the **balanced remainder**:

```
Λ_k(g,…,g) = δ^k + ∑_{∅ ≠ S ⊆ [k]} δ^{k−|S|} · Λ_k(i ↦ if i ∈ S then g−δ·1 else 1)
```

- **`kAPCount_diag_eq_major_add_remainder`**: the `S = ∅` term carries the scalar `δ` in every slot, so it collapses to `δ^k · Λ_k(1,…,1) = δ^k` (via `kAPCount_const_one`); every remaining term is indexed by a nonempty `S`, hence has at least one mean-zero balanced slot `b = g − δ·1`.

This is the standard **"main k-AP count `δ^k` plus a Gowers-controlled error"** form — the exact setup the density-increment argument feeds into the generalized von Neumann *inequality* (the file's stated next step). Proof peels the empty subset with `Finset.add_sum_erase` and reduces the empty-slot tuple to the constant-1 tuple.

## Verification
- Docker build `Proofs.RothTheoremOQ03OQ01`: green ("Completed successfully!", cold full rebuild).
- `grep -c '^axiom'` = 0, `grep -c sorry` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)