### PR TITLE
Enrich Hurwitz commutative sharpness: three-rung classification ladder

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/meta.json
@@ -113,25 +113,41 @@
       "id": "header",
       "title": "Module Header and Context",
       "startLine": 1,
-      "endLine": 41,
+      "endLine": 35,
       "summary": "Explains that the parent proves only the commutative UPPER bound finrank ℝ F ∈ {1,2} via Gelfand-Mazur and leaves the non-commutative case as a sorry; this file adds the realizability/sharpness direction so the commutative bound becomes exact.",
       "mathContext": "Hurwitz: real normed division algebras have dimension in $\\{1,2,4,8\\}$. Commutative case: Gelfand-Mazur $\\Rightarrow \\dim \\in \\{1,2\\}$."
     },
     {
+      "id": "admissible-def",
+      "title": "The admissible dimension set {1,2,4,8}",
+      "startLine": 36,
+      "endLine": 41,
+      "summary": "def admissibleDimensions : Set ℕ := {1,2,4,8}, defined identically to HurwitzOnlyIf.admissibleDimensions in the parent so the two files' statements align literally. Reproducing it (rather than importing the parent) keeps this companion self-contained.",
+      "mathContext": "$\\{1,2,4,8\\}$ — the dimensions of $\\mathbb R,\\mathbb C,\\mathbb H,\\mathbb O$, the target set of the Hurwitz classification."
+    },
+    {
       "id": "upper-bound",
       "title": "The Gelfand–Mazur Upper Bound",
-      "startLine": 43,
-      "endLine": 64,
-      "summary": "admissibleDimensions := {1,2,4,8}. finrank_normed_field_eq_one_or_two reproduces the parent's Gelfand-Mazur argument (F ≅ ℝ or ℂ ⇒ finrank 1 or 2); finrank_normed_field_admissible packages it into {1,2,4,8}.",
+      "startLine": 42,
+      "endLine": 56,
+      "summary": "finrank_normed_field_eq_one_or_two reproduces the parent's Gelfand-Mazur argument: NormedAlgebra.Real.nonempty_algEquiv_or gives F ≅ ℝ or ℂ, so transporting finrank across the linear equivalence yields 1 or 2. finrank_normed_field_admissible then packages this into the admissible set via omega.",
       "mathContext": "$F$ normed field over $\\mathbb{R} \\Rightarrow \\operatorname{finrank}_{\\mathbb R} F \\in \\{1,2\\} \\subseteq \\{1,2,4,8\\}$."
     },
     {
+      "id": "realizability",
+      "title": "Realizability of the endpoints ℝ and ℂ",
+      "startLine": 57,
+      "endLine": 64,
+      "summary": "finrank_real_self (finrank ℝ ℝ = 1, from CommSemiring.finrank_self) and finrank_complex (finrank ℝ ℂ = 2, from Complex.finrank_real_complex) are the concrete witnesses that dimensions 1 and 2 are actually attained by commutative real normed division algebras — the lower/realizability direction the parent's bound lacks.",
+      "mathContext": "$\\operatorname{finrank}_{\\mathbb R}\\mathbb R = 1$, $\\operatorname{finrank}_{\\mathbb R}\\mathbb C = 2$: both endpoints attained."
+    },
+    {
       "id": "sharpness",
-      "title": "Realizability and Sharpness",
-      "startLine": 66,
+      "title": "Sharpness: realized set is exactly {1,2}",
+      "startLine": 65,
       "endLine": 79,
-      "summary": "finrank_real_self (finrank ℝ ℝ = 1) and finrank_complex (finrank ℝ ℂ = 2) exhibit the endpoint algebras; comm_bound_sharp combines them with the upper bound to conclude the set of realized dimensions is exactly {1,2}.",
-      "mathContext": "$\\operatorname{finrank}_{\\mathbb R}\\mathbb R = 1$, $\\operatorname{finrank}_{\\mathbb R}\\mathbb C = 2$; both attained, none other $\\Rightarrow$ realized set $= \\{1,2\\}$."
+      "summary": "comm_bound_sharp bundles the two endpoint witnesses with the Gelfand-Mazur upper bound into a single statement, concluding the set of ℝ-dimensions of commutative real normed division algebras is exactly {1,2} — upgrading the parent's one-sided bound to a complete characterization of the commutative case.",
+      "mathContext": "Both endpoints attained and no other value occurs $\\Rightarrow$ realized set $= \\{1,2\\}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `hurwitz-theorem-oq-03-oq-01-incomplete-01` (quality 94, passes 0). The entry was already richly annotated (5 full annotations, complete sections/conclusion/mainTheorems, meta 12 KB — well under the 60 KB cap), so this is a single sharp, curation-quality addition rather than accretion.

## What changed
- **New keyInsight (5th of 12 cap):** frames the commutative case as the bottom rung of a three-rung ladder of division-algebra classifications over ℝ — Gelfand–Mazur (commutative: ℝ, ℂ; dims 1,2 — this entry) → Frobenius, 1878 (associative: ℝ, ℂ, ℍ; dims 1,2,4) → Hurwitz (general normed: ℝ, ℂ, ℍ, 𝕆; dims 1,2,4,8). This explains the **Frobenius theorem** that was already cited in the annotations' `relatedConcepts` but never described, and locates the parent's open non-commutative `sorry` as exactly the climb off the bottom rung.
- **New reference:** Frobenius (1878, Crelle 84) — the associative-division-algebra classification.

## Verification
- meta.json valid JSON, 12.4 KB (under 60 KB cap), keyInsights = 5 (≤ 12), all collections within caps (`check-meta-size.ts` passes).
- `pnpm build` gallery-data stages (enrichment, search-index, loading-facts) all pass; final `tsc` step fails only because this fresh worktree has no `node_modules` (environmental, not a data error).
- Accuracy: status/badge/axiomCount unchanged and still correct (0 axioms, 0 sorries, verified).