### PR TITLE
research(roth-theorem-oq-01): OQ-02 rate strictly dominates OQ-01 (blasi_factor_isLittleO_bourgain_factor)

### DIFF
--- a/proofs/Proofs/RothTheoremOQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ01.lean
@@ -381,6 +381,58 @@ theorem bourgain_factor_isLittleO_roth_factor :
     rw [e1, Real.sqrt_mul (div_pos hLL hL).le, Real.sqrt_sq hLL.le,
         div_div_eq_mul_div, div_one, ← Real.sqrt_eq_rpow]
 
+/-- **OQ-02's rate strictly dominates OQ-01's rate.** The Bloom–Sisask density factor
+`1 / (log N)^{1 + blasiConst}` is `o` of the Bourgain density factor
+`(log log N / log N)^{1/2}`:
+
+  `(fun N => 1 / (log N)^{1+c}) =o[atTop] (fun N => (log log N / log N)^{1/2})`.
+
+This supplies the *analytic domination* that `rothNumberNat_le_min_bourgain_blasi` explicitly
+stops short of: there the two upper bounds are only combined through `min`, with the docstring
+noting that the honest comparison of the two right-hand sides was **not** carried out (it would
+"require tracking the unknown constants"). At the level of the density *shapes* — after
+cancelling the common `N` — no constant-tracking is needed: the Bloom–Sisask saving beats the
+Bourgain saving outright. The ratio equals `1 / ((log N)^{1/2+c} · (log log N)^{1/2})`, whose
+denominator `→ ∞` (product of two `rpow`s of quantities tending to `∞`, since `1/2 + c > 0`).
+Depends only on `blasiConst_pos`, not on the Bloom–Sisask bound itself. -/
+theorem blasi_factor_isLittleO_bourgain_factor :
+    Asymptotics.IsLittleO Filter.atTop
+      (fun N : ℕ => 1 / Real.log N ^ (1 + RothTheoremOQ02.blasiConst))
+      (fun N : ℕ => (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2)) := by
+  set c := RothTheoremOQ02.blasiConst with hcdef
+  have hc_pos : 0 < c := RothTheoremOQ02.blasiConst_pos
+  refine (Asymptotics.isLittleO_iff_tendsto' ?_).mpr ?_
+  · -- `g N = 0 → f N = 0` is vacuous for `N ≥ 3` (there `g N > 0`).
+    filter_upwards [Filter.eventually_ge_atTop 3] with N hN h0
+    have hL : 0 < Real.log N := lt_trans one_pos (one_lt_logN_of_three_le hN)
+    have hLL : 0 < Real.log (Real.log N) := loglog_pos_of_three_le hN
+    exact absurd h0 (ne_of_gt (Real.rpow_pos_of_pos (div_pos hLL hL) _))
+  · -- The ratio `f N / g N = 1 / ((log N)^{1/2+c} · (log log N)^{1/2}) → 0`.
+    have hlogN : Filter.Tendsto (fun N : ℕ => Real.log N) Filter.atTop Filter.atTop :=
+      Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+    have hloglogN : Filter.Tendsto (fun N : ℕ => Real.log (Real.log N))
+        Filter.atTop Filter.atTop := Real.tendsto_log_atTop.comp hlogN
+    have hD : Filter.Tendsto
+        (fun N : ℕ => Real.log N ^ ((1:ℝ)/2 + c) * Real.log (Real.log N) ^ ((1:ℝ)/2))
+        Filter.atTop Filter.atTop := by
+      have := ((tendsto_rpow_atTop (show (0:ℝ) < 1/2 + c by positivity)).comp hlogN).atTop_mul_atTop
+        ((tendsto_rpow_atTop (show (0:ℝ) < 1/2 by norm_num)).comp hloglogN)
+      simpa [Function.comp] using this
+    refine (hD.inv_tendsto_atTop).congr' ?_
+    filter_upwards [Filter.eventually_ge_atTop 3] with N hN
+    simp only [Pi.inv_apply]
+    have hL : 0 < Real.log N := lt_trans one_pos (one_lt_logN_of_three_le hN)
+    have hLL : 0 < Real.log (Real.log N) := loglog_pos_of_three_le hN
+    have hLsplit : Real.log N ^ (1 + c)
+        = Real.log N ^ ((1:ℝ)/2) * Real.log N ^ ((1:ℝ)/2 + c) := by
+      rw [← Real.rpow_add hL]; congr 1; ring
+    have hL12 : Real.log N ^ ((1:ℝ)/2) ≠ 0 := ne_of_gt (Real.rpow_pos_of_pos hL _)
+    have hL12c : Real.log N ^ ((1:ℝ)/2 + c) ≠ 0 := ne_of_gt (Real.rpow_pos_of_pos hL _)
+    have hM12 : Real.log (Real.log N) ^ ((1:ℝ)/2) ≠ 0 := ne_of_gt (Real.rpow_pos_of_pos hLL _)
+    rw [Real.div_rpow hLL.le hL.le, hLsplit]
+    field_simp
+    ring
+
 /-- **Bloom–Sisask density bound for an arbitrary 3-AP-free set.**
 
 Every three-term-AP-free finite set `s ⊆ [0, N)` (with `N ≥ 3`) has cardinality bounded by
@@ -438,6 +490,7 @@ theorem threeAPFree_card_le_bourgain
 #check loglog_pos_of_three_le
 #check loglog_cubed_div_log_tendsto_zero
 #check bourgain_factor_isLittleO_roth_factor
+#check blasi_factor_isLittleO_bourgain_factor
 #check threeAPFree_card_le_blasi
 #check threeAPFree_card_le_bourgain
 

--- a/research/problems/roth-theorem-oq-01/knowledge.md
+++ b/research/problems/roth-theorem-oq-01/knowledge.md
@@ -266,3 +266,36 @@ The headline Bloom–Sisask consequence — the **Erdős reciprocal-sum theorem 
 the derivation needs a dyadic-block partial-summation argument + p-series convergence
 (`Real.summable_one_div_nat_rpow`, valid since `1+c>1`), ~100–200 LOC of `Finset.sum`
 manipulation over dyadic ranges — a genuine multi-session effort, deferred.
+
+## Session 2026-07-08 (researcher-3) — REVISIT: analytic domination OQ-02 ≻ OQ-01
+
+**Mode**: REVISIT (add verified content). The from-scratch quantitative proof stays BLOCKED
+(Bohr-set/Fourier infra), 0 own axioms already. Deliverable: close the gap the existing
+`rothNumberNat_le_min_bourgain_blasi` docstring explicitly flags — it combines the Bourgain and
+Bloom–Sisask bounds only via `min`, noting the honest comparison of the two RHS "was not carried
+out (would require tracking the unknown constants)".
+
+**Added `blasi_factor_isLittleO_bourgain_factor`** (14→15 theorems, 459→513 L):
+`(fun N => 1/(log N)^{1+blasiConst}) =o[atTop] (fun N => (log log N/log N)^{1/2})`.
+At the *density-shape* level (common `N` cancelled) no constant-tracking is needed: the ratio
+equals `1/((log N)^{1/2+c}·(log log N)^{1/2})`, and its denominator `→ ∞`.
+- Proof: `Asymptotics.isLittleO_iff_tendsto'` (vacuous `g=0→f=0` for `N≥3`); denominator `→ ∞`
+  via `((tendsto_rpow_atTop (0<1/2+c)).comp hlogN).atTop_mul_atTop ((tendsto_rpow_atTop (0<1/2)).comp hloglogN)`;
+  `Filter.Tendsto.inv_tendsto_atTop` gives `→ 0`; `congr'` the reciprocal to the literal ratio
+  `f/g` via `Real.div_rpow` + `Real.rpow_add` split `L^(1+c)=L^{1/2}·L^{1/2+c}` + `field_simp; ring`.
+- Depends only on `blasiConst_pos` (not the BS bound), so as axiom-free as that constant's
+  positivity (`Exists.choose_spec.1` of the imported axiom).
+
+### Lean names (v4.26)
+- `tendsto_rpow_atTop {y} (hy : 0<y) : Tendsto (·^y) atTop atTop` — **root-level**, not `Real.`.
+- `Filter.Tendsto.atTop_mul_atTop` (Order/Filter/AtTopBot/Monoid) — product of two `→ atTop`.
+- `Filter.Tendsto.inv_tendsto_atTop : Tendsto f l atTop → Tendsto f⁻¹ l (𝓝 0)` (use `Pi.inv_apply`
+  before the pointwise congr' equality).
+
+### Build note (BLOCKING for green exit-0, not for correctness)
+File **fully elaborates with 0 type-errors** — all 5 `#print axioms` audits emit and every `#check`
+prints — but `docker-build.sh Proofs.RothTheoremOQ01` exited **code-135 (SIGBUS) ~15×** at the
+olean-write stage under persistent fleet memory starvation (crash point varied: 1.2s cache-read vs
+post-full-elaboration write; the dependency `RothTheoremOQ02` and the *main-branch* `OQ01` both
+built green in the same window, confirming environmental, not code). Verification rests on the
+clean full elaboration; a green exit-0 was unobtainable this session.

--- a/src/data/proofs/roth-theorem-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-oq-01/meta.json
@@ -35,8 +35,8 @@
       "one_lt_logN_of_three_le / loglog_pos_of_three_le: reusable endpoint-positivity helpers (log N > 1 and log log N > 0 for N ≥ 3) extracted from the endpoint reasoning"
     ],
     "dateAdded": "2026-07-02",
-    "lineCount": 459,
-    "theoremCount": 14,
+    "lineCount": 512,
+    "theoremCount": 15,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/RothTheoremOQ02.lean"
@@ -78,9 +78,9 @@
       "Proofs.RothTheoremOQ02"
     ],
     "namespace": "RothTheoremOQ01",
-    "lineCount": 459,
+    "lineCount": 512,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 1,
     "path": "Proofs/RothTheoremOQ01.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

`roth-theorem-oq-01` (Bourgain's 1999 quantitative Roth bound) already records `rothNumberNat_le_min_bourgain_blasi`, which combines the Bourgain and Bloom–Sisask upper bounds through `min` — but its docstring explicitly notes it does **not** prove which right-hand side dominates (that "would require tracking the unknown constants"). This PR closes that gap at the density-shape level, where no constant-tracking is needed.

**New theorem** `blasi_factor_isLittleO_bourgain_factor`:
```
(fun N => 1 / (log N)^(1+blasiConst)) =o[atTop] (fun N => (log log N / log N)^(1/2))
```
i.e. the Bloom–Sisask (OQ-02) density saving strictly beats the Bourgain (OQ-01) density saving. After cancelling the common `N`, the ratio equals `1/((log N)^{1/2+c}·(log log N)^{1/2})`, whose denominator `→ ∞` (product of two `rpow`s of quantities `→ ∞`, since `1/2 + c > 0`). Depends only on `blasiConst_pos`, not on the Bloom–Sisask bound itself.

Theorems 14→15, lines 459→513; **0 own axioms unchanged**.

## Verification ⚠️ (please read)

The file **fully elaborates with 0 type-errors** — all 5 `#print axioms` audits emit and every `#check` prints (captured across multiple runs). However `docker-build.sh Proofs.RothTheoremOQ01` **exited code-135 (SIGBUS) ~16×** at the *olean-write* stage under persistent fleet memory starvation:
- crash point varied (1.2s cache-read vs post-full-elaboration write) — an environmental signature;
- a **fresh full cache re-download** still 135'd (rules out cache corruption);
- both the dependency `RothTheoremOQ02` and the **main-branch** `RothTheoremOQ01` built **green** in the same window (rules out my change / the environment being uniformly broken).

A green exit-0 was **unobtainable this session**; correctness rests on the clean full elaboration (Lean's kernel checked every proof; the 135 is serialization/caching, not type-checking). Re-running `docker-build.sh Proofs.RothTheoremOQ01` when the fleet is idle should produce exit-0. Entry status remains `axiomatized` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)