### PR TITLE
research(erdos-1204): A(k) minimal admissible-tuple diameter is monotone [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -285,6 +285,27 @@ theorem A_le {k : ℕ} {a : Finset ℕ} (hcard : a.card = k) (ha : Admissible a)
     A k ≤ a.sup id :=
   Nat.sInf_le ⟨a, hcard, ha, rfl⟩
 
+/-- **One-step monotonicity.** `A(k) ≤ A(k+1)`: deleting one element from an optimal
+admissible `(k+1)`-set leaves an admissible `k`-set (admissibility passes to subsets,
+`Admissible.subset`) whose largest element is no larger (`Finset.sup_mono`), so its
+diameter — which is `≥ A(k)` — bounds `A(k+1)` from above. -/
+theorem A_le_A_succ (k : ℕ) : A k ≤ A (k + 1) := by
+  obtain ⟨a, hcard, ha, hsup⟩ := A_mem (k + 1)
+  have hne : a.Nonempty := by rw [← Finset.card_pos, hcard]; omega
+  obtain ⟨x, hx⟩ := hne
+  have hsub : a.erase x ⊆ a := fun y hy => Finset.mem_of_mem_erase hy
+  have hcard' : (a.erase x).card = k := by rw [Finset.card_erase_of_mem hx, hcard]
+  have ha' : Admissible (a.erase x) := ha.subset hsub
+  calc A k ≤ (a.erase x).sup id := A_le hcard' ha'
+    _ ≤ a.sup id := Finset.sup_mono hsub
+    _ = A (k + 1) := hsup
+
+/-- **`A` is monotone.** The minimal-diameter function `A(k)` is non-decreasing in `k`:
+a larger admissible tuple can only need a larger diameter. Immediate from the one-step
+bound `A_le_A_succ`. -/
+theorem A_monotone : Monotone A :=
+  monotone_nat_of_le_succ A_le_A_succ
+
 /-- **Trivial lower bound.** `A(k) ≥ k - 1`, since any `k` distinct naturals have maximum
 at least `k - 1`. -/
 theorem sub_one_le_A (k : ℕ) : k - 1 ≤ A k := by


### PR DESCRIPTION
## Summary

Adds the basic **monotonicity** of the minimal admissible-tuple diameter `A(k)` to `Erdos1204Problem.lean`. The file defines `A(k)` and proves pointwise lower bounds (`k-1 ≤ A(k)`, `2(k-1) ≤ A(k)`) and exact small values (`A(2)=2, A(3)=6`, with `A(4..7)` in sibling files), but never that `A` is non-decreasing.

- **`A_le_A_succ`**: `A(k) ≤ A(k+1)`. Delete one element from an optimal admissible `(k+1)`-set — admissibility passes to subsets (`Admissible.subset`), the largest element is no larger (`Finset.sup_mono`), and the resulting admissible `k`-set has diameter `≥ A(k)`.
- **`A_monotone`**: `Monotone A`, via `monotone_nat_of_le_succ`.

A clean general structural fact (a larger admissible tuple can only need a larger diameter) that complements the existing pointwise bounds.

## Verification
- Docker build `Proofs.Erdos1204Problem`: green (two exit-0 runs, zero errors; warm-cache olean confirmed valid).
- `grep -c '^axiom'` = 0, `grep -c sorry` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)