### PR TITLE
Fix: erdos-142 meta describes axioms/lemmas absent from Lean source

### DIFF
--- a/src/data/proofs/erdos-142/meta.json
+++ b/src/data/proofs/erdos-142/meta.json
@@ -5,7 +5,7 @@
   "description": "Prove an asymptotic formula for r_k(N), the maximum size of a subset of {1,...,N} with no non-trivial k-term AP. The gap between Behrend's lower bound and Kelley–Meka's upper bound remains enormous even for k=3. Open ($10,000).",
   "meta": {
     "erdosNumber": 142,
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos142Problem.lean",
     "badge": "wip",
     "erdosProblemStatus": "open",
@@ -30,7 +30,7 @@
     "axiomCount": 0,
     "lineCount": 54,
     "theoremCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
+    "assumptions": "Definitional scaffold only. The Lean file provides the definitions `arithProg`, `IsAPFree`, and `rk` (0 axioms, 0 theorems, 0 sorries); the theorems for Szemerédi/Roth/Behrend/Kelley–Meka and the main open question are not yet stated.",
     "mathlib_version": "4.26.0",
     "definitionCount": 3
   },
@@ -38,7 +38,7 @@
     "historicalContext": "Erdős Problem #142 is one of the most celebrated open problems in combinatorics, carrying Erdős's largest prize ($10,000) for a problem in the field. The story begins with van der Waerden's theorem (1927) guaranteeing monochromatic $k$-APs in any finite coloring of the integers, and Erdős and Turán's 1936 conjecture that $r_k(N) = o(N)$. Roth (1953) proved the $k = 3$ case using Fourier analysis on $\\mathbb{Z}/N\\mathbb{Z}$, introducing the circle method to combinatorics. Szemerédi's celebrated theorem (1975) settled the general case via a monumental combinatorial argument and the Szemerédi regularity lemma, earning him the Abel Prize. The quantitative frontier advanced through Furstenberg's ergodic proof (1977), Gowers's introduction of uniformity norms (2001), and a remarkable succession of improvements for $k = 3$: Heath-Brown–Szemerédi, Bourgain, Sanders, Bloom, Bloom–Sisask. The 2023 breakthrough by Kelley and Meka — proving $r_3(N) \\le N \\cdot \\exp(-c(\\log N)^{1/12})$ — was the first sub-polynomial density decay, yet the gap from Behrend's 1946 lower bound $N \\cdot \\exp(-C\\sqrt{\\log N})$ remains vast, illustrating how far we are from an asymptotic formula.",
     "problemStatement": "Prove an asymptotic formula for $r_k(N)$, the largest size of a subset of $\\{1,\\ldots,N\\}$ containing no non-trivial $k$-term arithmetic progression. Even the correct order of magnitude of $r_3(N)$ is unknown.",
     "text": "Prove an asymptotic formula for r_k(N), the maximum size of a subset of {1,...,N} with no non-trivial k-term AP. The gap between Behrend's lower bound and Kelley–Meka's upper bound remains enormous even for k=3. Open ($10,000).",
-    "proofStrategy": "We define AP-$k$-free sets and $r_k(N)$ using `Finset.powerset` and `Finset.sup`. Szemerédi's theorem and Roth's theorem are axiomatized as qualitative bounds ($r_k(N) = o(N)$). Behrend's lower bound ($\\exp(-C\\sqrt{\\log N})$) and Kelley–Meka's upper bound ($\\exp(-c(\\log N)^{1/12})$) are axiomatized with explicit constants. The main open question is stated as the existence of an asymptotic formula $f_k(N) \\sim r_k(N)$, and Erdős's $\\$5{,}000$ sub-question $r_k(N) = o(N/\\log N)$ is separately axiomatized.",
+    "proofStrategy": "This entry is a definitional scaffold. We define AP-$k$-free sets and $r_k(N)$ using `Finset.powerset` and `Finset.sup`. The remaining sections (Szemerédi, Roth, Behrend, Kelley–Meka, Green–Tao, and the main open question) are placeholder comment headers only — the corresponding statements have not yet been formalized as axioms or theorems.",
     "keyInsights": [
       "**Enormous gap persists for $k = 3$**: Behrend's lower bound $\\exp(-C\\sqrt{\\log N})$ and Kelley–Meka's upper bound $\\exp(-c(\\log N)^{1/12})$ differ by a power in the exponent — the correct answer lies somewhere between $N^{1-o(1)}$ and $N \\cdot e^{-c\\sqrt{\\log N}}$",
       "**Erdős's prize hierarchy**: $\\$10{,}000$ for the asymptotic formula, $\\$5{,}000$ for the weaker $r_k(N) = o(N/\\log N)$ (now known for $k \\le 4$ but open for $k \\ge 5$)",
@@ -80,20 +80,20 @@
       "title": "Szemerédi's Theorem",
       "startLine": 42,
       "endLine": 49,
-      "summary": "Axiomatizes $\\forall k \\ge 3, \\forall \\varepsilon > 0, \\exists N_0 : r_k(N) \\le \\varepsilon N$ for $N \\ge N_0$. The qualitative foundation: every dense set contains $k$-APs.",
-      "mathContext": "Axiomatized: Axiomatizes $\\forall k \\ge 3, \\forall \\varepsilon > 0, \\exists N_0 : r_k(N) \\le \\varepsilon N$ for $N \\ge N_0$. The qualitative foundation: every dense set contains $k$-APs."
+      "summary": "Placeholder comment header for Szemerédi's theorem ($\\forall k \\ge 3, \\forall \\varepsilon > 0, \\exists N_0 : r_k(N) \\le \\varepsilon N$ for $N \\ge N_0$). Not yet formalized — no declaration is present in the source.",
+      "mathContext": "Placeholder header only: Szemerédi's theorem ($r_k(N) = o(N)$) is described but not yet stated as an axiom or theorem in the Lean source."
     },
     {
       "id": "roth",
       "title": "Roth's Theorem ($k = 3$)",
       "startLine": 50,
       "endLine": 54,
-      "summary": "Axiomatizes $r_3(N) = o(N)$ separately, acknowledging the long chain of quantitative improvements from Roth (1953) through Kelley–Meka (2023).",
-      "mathContext": "Axiomatized: Axiomatizes $r_3(N) = o(N)$ separately, acknowledging the long chain of quantitative improvements from Roth (1953) through Kelley–Meka (2023)."
+      "summary": "Placeholder comment header for Roth's theorem ($r_3(N) = o(N)$) and the chain of quantitative improvements from Roth (1953) through Kelley–Meka (2023). Not yet formalized — no declaration is present in the source.",
+      "mathContext": "Placeholder header only: Roth's theorem ($r_3(N) = o(N)$) is described but not yet stated as an axiom or theorem in the Lean source."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #142 asks for an asymptotic formula for r_k(N), the maximum size of a k-AP-free subset of {1,...,N}. Despite extraordinary progress — Szemerédi's theorem (1975), Roth's Fourier method (1953), Kelley–Meka's breakthrough (2023) — even the correct order of magnitude of r_3(N) is unknown. The formalization axiomatizes the state of the art: Behrend's lower bound, Kelley–Meka's upper bound, Green–Tao for k=4, and the main open question with Erdős's $10,000 prize.",
+    "summary": "Erdős Problem #142 asks for an asymptotic formula for r_k(N), the maximum size of a k-AP-free subset of {1,...,N}. Despite extraordinary progress — Szemerédi's theorem (1975), Roth's Fourier method (1953), Kelley–Meka's breakthrough (2023) — even the correct order of magnitude of r_3(N) is unknown. This entry is a definitional scaffold: the Lean file formalizes the definitions of AP-k-free sets and r_k(N), while the state-of-the-art bounds (Behrend, Kelley–Meka, Green–Tao for k=4) and the main open question remain placeholder headers awaiting formalization.",
     "implications": "**Theoretical Significance**: An asymptotic formula for r_k(N) would represent a complete understanding of the density threshold for arithmetic progressions in the integers.\n\nIt would resolve a central question spanning additive combinatorics, harmonic analysis, ergodic theory, and theoretical computer science (connections to PCP and property testing). The techniques required would likely yield deep structural insights into the interplay between additive and multiplicative structure in the integers.",
     "openQuestions": [
       "What is the true order of magnitude of r_3(N)? Is the Behrend-type lower bound exp(-C√(log N)) or the Kelley–Meka-type upper bound exp(-c(log N)^{1/12}) closer to the truth?",


### PR DESCRIPTION
## Fix

Match `erdos-142` meta.json to its Lean source, which is a bare definitional scaffold, not an axiomatization.

## Evidence

**Before**: meta.json claimed the file *"axiomatizes the state of the art: Behrend's lower bound, Kelley–Meka's upper bound, Green–Tao for k=4, and the main open question"*, that Szemerédi/Roth are *"Axiomatized"*, and that *"supporting lemmas [are] fully verified"*. `status` was `axiomatized` with `axiomCount: 0` (internally contradictory).

**After**: `proofs/Proofs/Erdos142Problem.lean` actually contains only `def arithProg`, `def IsAPFree`, `noncomputable def rk` — **3 defs, 0 axioms, 0 theorems, 0 sorries**. The Szemerédi/Roth/Behrend/Kelley–Meka/Green–Tao/Main-Open sections are empty `/- ## ... -/` comment headers.

Changes (Direction A — match meta to scaffold reality):
- `status`: `axiomatized` → `formalized` (no axioms or structure-encoded assumptions exist)
- `assumptions`: drop the false "supporting lemmas fully verified"; describe the definitional scaffold
- `proofStrategy` & `conclusion.summary`: state the bounds are placeholder headers, not axiomatizations
- `szemeredi` & `roth` section summaries/mathContext: mark as placeholder headers with no declaration present

`badge` remains `wip`. No Lean source changes. JSON validated; gallery-data/enrichment/search-index build stages pass.

Closes #35957

---
Automated fix by lean-mechanic agent.