### PR TITLE
Gallery integrity: erdos-148 lists phantom small-case theorems

### DIFF
--- a/src/data/proofs/erdos-148/meta.json
+++ b/src/data/proofs/erdos-148/meta.json
@@ -44,7 +44,7 @@
       "unitFractionSum definition: sum of unit fractions over a set",
       "isEgyptianDecomposition definition: set summing to 1",
       "F definition: count of k-decompositions",
-      "F_one, F_two, F_three theorems: small cases",
+      "Worked examples verifying the decompositions {1} (F(1)=1) and {2,3,6} (F(3)=1); F(2)=0 argued in commentary",
       "konyagin_lower_bound axiom: F(k) >= 2^{c*k/log k}",
       "elsholtz_planitzer_upper_bound axiom: F(k) <= c_0^{(1/5+o(1))*2^k}",
       "vardi_constant axiom: c_0 approx 1.26408"


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-148 (Erdős Problem #148: Unit Fraction Decompositions)
**Problem**: `originalContributions` lists three named theorems that do not exist in the Lean source.

## Evidence

**meta.json claimed**: `"F_one, F_two, F_three theorems: small cases"`

**Lean file shows** (`proofs/Proofs/Erdos148Problem.lean`): zero occurrences of `F_one`/`F_two`/`F_three` anywhere (grep is empty, even in comments). The only named theorem is `erdos_148_status`. The small cases are covered by **two anonymous `example` declarations** (verifying `{1}` and `{2,3,6}`); **F(2)=0 is only argued informally in a comment**, never formally stated.

## Fix

Replaced the phantom entry with an accurate description of what the file actually contains.

Numeric integrity fields were already correct and are **unchanged**:
- `theoremCount: 1` ✓ (matches the single `erdos_148_status`)
- `axiomCount: 3` ✓ (`konyagin_lower_bound`, `elsholtz_planitzer_upper_bound`, `vardi_constant`)
- `definitionCount: 5` ✓
- `sorries: 0` ✓
- `status: axiomatized` / `badge: axiom` ✓ (open problem, bounds axiomatized — correct)

Single-line, meta-only change; no Lean source touched.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)