### PR TITLE
Fix: sync erdos-340-greedy-sidon theoremCount to actual source (24)

### DIFF
--- a/src/data/proofs/erdos-340-greedy-sidon/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/meta.json
@@ -69,7 +69,7 @@
     ],
     "assumptions": "None. This file is fully axiom-free (0 axiom declarations, 0 structure-encoded assumptions, no native_decide; #print axioms reports only propext / Classical.choice / Quot.sound). Its previous sole axiom, the tight Erdos-Turan bound sidon_upper_bound (|A| <= sqrt(N) + sqrt(sqrt(N)) + 1), has been retired: every consumer now routes through the verified, axiom-free Erdos340.sidon_card_le_sqrt (the +2 form, proved in Erdos340SidonErdosTuran.lean by optimising the master window inequality). The greedy sequence and its values are genuine definitions/theorems, and Erdos's open growth conjecture N^(1/2-epsilon) appears only as commentary, never as an assumption.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 24,
     "definitionCount": 14
   },
   "overview": {
@@ -213,7 +213,7 @@
     "namespace": "Erdos340",
     "lineCount": 648,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 24,
     "definitionCount": 14,
     "path": "Proofs/Erdos340GreedySidon.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Reconcile the drifted `theoremCount` for `erdos-340-greedy-sidon` to the true comment-stripped source count.

## Evidence

`Erdos340GreedySidon.lean` (648 lines) has **24** `theorem`/`lemma` declarations.

- `meta.theoremCount` was **16** — stale (predates growth of the file).
- `leanFile.theoremCount` was **25** — raw-grep overcount: line 386 (`lemma \`sidon_exists_extension\`, proved here...`) is docstring prose inside a `/- -/` block opened at line 380, not a declaration.

**Before**: meta=16, leanFile=25 (disagree)
**After**: both = 24 (comment-stripped truth)

`lineCount` (648=648) and `definitionCount` (14=14, the 15th match being an `instance`) already agreed and are untouched. The stale `summary` prose at line 194 (describes a retired 21-axiom / 537-line version) is left for enrichment scope to avoid a substantive rewrite in a count-sync PR.

---
Automated fix by lean-mechanic agent.