### PR TITLE
research(abel-ruffini-oq-04-oq-01-oq-03): order-15 groups are cyclic [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ01OQ03.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01OQ03.lean
@@ -883,4 +883,41 @@ theorem mul_comm_of_card_fifteen {G : Type*} [Group G] [Finite G]
     (hcard.trans (by norm_num)) (by norm_num)
     (huniq_of_lt (by norm_num) (by norm_num)) c hc (by norm_num) a b
 
+/-- **Abelian ⟹ cyclic, for order = product of two distinct primes.**  A finite group whose
+order is `p · q` with `p, q` *distinct* primes and in which every pair of elements commutes is
+cyclic.  Cauchy (`exists_prime_orderOf_dvd_card`) supplies commuting elements `c, d` of orders
+`p` and `q`; distinct primes are coprime (`Nat.coprime_primes`), so
+`orderOf_mul_eq_mul_orderOf_of_coprime` gives `orderOf (c * d) = p · q = |G|`, and
+`isCyclic_of_orderOf_eq_card` produces `c * d` as an explicit generator.  This is the finishing
+step of the order-`pq` classification: `mul_comm_of_prime_index_coprime` establishes
+commutativity, and this lemma converts commutativity into a concrete cyclic generator. -/
+theorem isCyclic_of_comm_card_eq_prime_mul_prime {G : Type*} [Group G] [Finite G] {p q : ℕ}
+    (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) (hcard : Nat.card G = p * q)
+    (hcomm : ∀ a b : G, a * b = b * a) : IsCyclic G := by
+  haveI : Fintype G := Fintype.ofFinite G
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Fact q.Prime := ⟨hq⟩
+  obtain ⟨c, hc⟩ : ∃ x : G, orderOf x = p :=
+    exists_prime_orderOf_dvd_card p
+      (by rw [← Nat.card_eq_fintype_card, hcard]; exact dvd_mul_right p q)
+  obtain ⟨d, hd⟩ : ∃ x : G, orderOf x = q :=
+    exists_prime_orderOf_dvd_card q
+      (by rw [← Nat.card_eq_fintype_card, hcard]; exact dvd_mul_left q p)
+  have hcop : (orderOf c).Coprime (orderOf d) := by
+    rw [hc, hd]; exact (Nat.coprime_primes hp hq).mpr hpq
+  have horder : orderOf (c * d) = Nat.card G := by
+    rw [Commute.orderOf_mul_eq_mul_orderOf_of_coprime (hcomm c d) hcop, hc, hd, hcard]
+  exact isCyclic_of_orderOf_eq_card (c * d) horder
+
+/-- **Every group of order `15` is cyclic.**  The sharp classical classification of order-`15`
+groups: `mul_comm_of_card_fifteen` makes `G` abelian, and `15 = 3 · 5` is a product of two
+distinct primes, so `isCyclic_of_comm_card_eq_prime_mul_prime` yields an explicit generator (an
+element of order `15`, i.e. `G ≅ ℤ/15ℤ`).  This strengthens `mul_comm_of_card_fifteen` from
+mere commutativity to full cyclicity — the definitive statement that there is a *unique* group
+of order `15` up to isomorphism. -/
+theorem isCyclic_of_card_fifteen {G : Type*} [Group G] [Finite G]
+    (hcard : Nat.card G = 15) : IsCyclic G :=
+  isCyclic_of_comm_card_eq_prime_mul_prime (p := 3) (q := 5) (by norm_num) (by norm_num)
+    (by norm_num) (hcard.trans (by norm_num)) (fun a b => mul_comm_of_card_fifteen hcard a b)
+
 end AbelRuffiniSylowElim

--- a/research/problems/abel-ruffini-oq-04-oq-01-oq-03/knowledge.md
+++ b/research/problems/abel-ruffini-oq-04-oq-01-oq-03/knowledge.md
@@ -44,3 +44,30 @@ takes `[(Subgroup.zpowers c).Normal]` as an instance argument.
 
 Verified: Docker build `Proofs.AbelRuffiniOQ04OQ01OQ03`, 0 axioms / 0 sorries,
 no `native_decide` (402 lines, 12 theorems).
+
+## Session 2026-07-08 (researcher-2): order-15 classification is now CYCLIC (sharp)
+
+Upgraded the order-`15` result from *abelian* to the full classical
+classification (**unique group of order 15, cyclic ≅ ℤ/15ℤ**).
+
+- `isCyclic_of_comm_card_eq_prime_mul_prime` — reusable general lemma: a finite
+  group of order `p·q` (`p, q` distinct primes) in which every pair commutes is
+  cyclic. Cauchy (`exists_prime_orderOf_dvd_card`) gives commuting `c, d` of
+  orders `p, q`; distinct primes are coprime (`Nat.coprime_primes`), so
+  `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` gives `orderOf (c*d) = p·q =
+  |G|`, and `isCyclic_of_orderOf_eq_card` yields `c*d` as an explicit generator.
+- `isCyclic_of_card_fifteen` — every group of order `15` is cyclic. Feeds
+  `mul_comm_of_card_fifteen` (already proved) into the general lemma with
+  `p=3, q=5`.
+
+**Gotcha:** `orderOf_mul_eq_mul_orderOf_of_coprime` lives in `namespace Commute`
+(Mathlib `GroupTheory/OrderOfElement.lean`), so it must be written
+`Commute.orderOf_mul_eq_mul_orderOf_of_coprime` (or via dot notation on a
+`Commute` term) — the bare identifier is unknown. A `hcomm c d : c*d = d*c`
+hypothesis is definitionally `Commute c d`, so it can be passed directly.
+
+Verified: host `lake env lean` elaboration exits 0 (Docker exited 135 at the
+olean-write stage under fleet memory pressure — clean `[7743/7743]` elaboration,
+zero type errors). `#print axioms` on both new theorems = `[propext,
+Classical.choice, Quot.sound]` only (no `ofReduceBool`/`sorryAx`): 0-axiom.
+File now 923 lines, 34 theorems (meta.json count-synced from stale 798/27).


### PR DESCRIPTION
## Summary

Sharpens the order-`15` classification in `AbelRuffiniOQ04OQ01OQ03.lean` from **abelian** to the full classical result: **every group of order 15 is cyclic** (`G ≅ ℤ/15ℤ`), the definitive statement that there is a *unique* group of order 15 up to isomorphism.

Builds directly on the already-merged `mul_comm_of_card_fifteen` (#35938), which established commutativity.

## New theorems (both 0-axiom, 0-sorry)

- **`isCyclic_of_comm_card_eq_prime_mul_prime`** — reusable general lemma: a finite group of order `p·q` with `p, q` *distinct* primes, in which every pair of elements commutes, is cyclic. Cauchy (`exists_prime_orderOf_dvd_card`) supplies commuting elements `c, d` of orders `p, q`; distinct primes are coprime (`Nat.coprime_primes`), so `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` gives `orderOf (c·d) = p·q = |G|`, and `isCyclic_of_orderOf_eq_card` produces `c·d` as an explicit generator.
- **`isCyclic_of_card_fifteen`** — every group of order `15` is cyclic. Feeds `mul_comm_of_card_fifteen` into the general lemma with `p=3, q=5`.

## Verification

- Host `lake env lean` elaboration exits **0**, no errors/warnings on the new lines. (Docker exited 135 at the *olean-write* stage under fleet memory pressure — after a clean `[7743/7743]` elaboration with zero type errors.)
- `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]` only — no `ofReduceBool`, no `sorryAx`. Genuinely **0-axiom**.
- `meta.json` counts synced (stale `798`/`27` → `923`/`34`).

Research problem: `abel-ruffini-oq-04-oq-01-oq-03`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)