### PR TITLE
Enrich Blichfeldt generalization: add missing top-level leanFile block

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem-oq-03/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-03/meta.json
@@ -3,6 +3,26 @@
   "title": "Blichfeldt's Generalization of Minkowski's Fundamental Theorem",
   "slug": "minkowski-fundamental-theorem-oq-03",
   "description": "The general-multiplicity form of Blichfeldt's principle over Mathlib's abstract fundamental-domain API. If a null-measurable set s has volume exceeding k times the covolume μF of a countable subgroup L, then some point z is covered by more than k translates of s by L: there is a finite T ⊆ L with k < #T and z ∈ l +ᵥ s for every l ∈ T. Equivalently, s contains more than k points that are pairwise congruent modulo L. At k = 1 this is exactly Mathlib's exists_pair_mem_lattice_not_disjoint_vadd (Blichfeldt's two-point principle); Mathlib has no general-k version. This is the honest Blichfeldt theorem — an arbitrary bounded measurable set and no 2ⁿ factor — as opposed to the parent entry's blichfeldt_statement, which is really van der Corput's convex-body counting theorem.",
+  "leanFile": {
+    "path": "Proofs/MinkowskiFundamentalTheoremOQ03.lean",
+    "namespace": "Blichfeldt",
+    "imports": [
+      "Mathlib.MeasureTheory.Group.GeometryOfNumbers",
+      "Mathlib.MeasureTheory.Integral.Lebesgue.Add",
+      "Mathlib.MeasureTheory.Integral.Lebesgue.Basic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ENNReal",
+      "Set",
+      "Filter"
+    ],
+    "lineCount": 136,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "sorries": 0
+  },
   "meta": {
     "status": "verified",
     "proofRepoPath": "Proofs/MinkowskiFundamentalTheoremOQ03.lean",


### PR DESCRIPTION
Enrichment pass for `minkowski-fundamental-theorem-oq-03` (quality 94, passes 0).

## Change (structural, meta.json only)
This entry was missing the top-level `leanFile` object that sibling gallery entries carry (the counts lived only under `meta`). Added it with all fields verified directly against `Proofs/MinkowskiFundamentalTheoremOQ03.lean`:
- `namespace`: Blichfeldt
- `imports`: the three MeasureTheory modules
- `opens`: MeasureTheory, ENNReal, Set, Filter
- `lineCount`: 136 (wc -l), `theoremCount`: 2 (exists_finset_card_lt_of_lt_tsum, exists_finset_lattice_common_vadd), `definitionCount`: 0, `axiomCount`: 0, `sorries`: 0

Brings the entry into schema consistency with its siblings and gives the drift/audit tooling the `leanFile.*` fields it expects. JSON validates; 15.3 KB, under all caps.