### PR TITLE
Fix: erdos-149 originalContributions names 6 axioms absent from Lean source

### DIFF
--- a/src/data/proofs/erdos-149/meta.json
+++ b/src/data/proofs/erdos-149/meta.json
@@ -51,10 +51,9 @@
       "strongChromaticIndex G = sInf {k | ∃ coloring using < k colors}: χ'_s via infimum",
       "ErdosNesetrilConjecture: χ'_s(G) ≤ (5/4)Δ² universally quantified",
       "conjecture_is_tight axiom: (5/4)Δ² is achievable for every Δ ≥ 2",
-      "Timeline axioms: trivial_bound, molloy_reed_1997, bruhn_joos_2018, bonamy_perrett_postle_2022, hurley_joannis_kang_2022",
+      "hurley_joannis_kang_2022 axiom: current best upper bound χ'_s(G) ≤ 1.772Δ²",
       "current_gap: 1.772 - 5/4 = 0.522 proved by norm_num",
-      "mahdian_c4_free and bipartite_bound axioms for special graph classes",
-      "cliqueNumber_LineSquare axiom with sleszynska_nowak_2015 and faron_postle_2019 bounds",
+      "cliqueNumber_LineSquare axiom: clique number ω(L(G)²) of the line-graph square, with notation ω_L²",
       "StronglyIndependentEdges, IsInducedMatching, and partition characterization",
       "erdos_149_summary: conjunction of best bound and tightness"
     ],


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-149 (Strong Chromatic Index Conjecture)
**Severity**: MEDIUM — phantom contributions (declarations named in meta but absent from source)

## Evidence

`meta.json` `originalContributions` named axioms that do **not** exist in `proofs/Proofs/Erdos149Problem.lean`:

- `"Timeline axioms: trivial_bound, molloy_reed_1997, bruhn_joos_2018, bonamy_perrett_postle_2022, hurley_joannis_kang_2022"` — of these, **only `hurley_joannis_kang_2022` exists**. The other four are phantom.
- `"mahdian_c4_free and bipartite_bound axioms for special graph classes"` — Part 4 (Special Graph Classes) is a documentation-only section with **no declarations**. Both phantom.
- `"cliqueNumber_LineSquare axiom with sleszynska_nowak_2015 and faron_postle_2019 bounds"` — `cliqueNumber_LineSquare` exists, but `sleszynska_nowak_2015` and `faron_postle_2019` do **not**.

Verified via `grep`: all 8 named phantom declarations return 0 occurrences in the source.

The Lean file contains exactly **3 axioms** (`conjecture_is_tight`, `hurley_joannis_kang_2022`, `cliqueNumber_LineSquare`) and **2 theorems** (`current_gap`, `erdos_149_summary`). This matches `axiomCount: 3`, `theoremCount: 2`, and the `assumptions` field — those are correct. Only `originalContributions` overstated.

## Fix

Rewrote the three affected entries to reference only real declarations. No change to `status` (`axiomatized`), `badge` (`axiom`), `sorries` (0), `axiomCount` (3), or any count — those were already accurate.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)