### PR TITLE
Fix: erdos-151 contribution calls an axiom a 'Proof' + phantom K₄-free variant

### DIFF
--- a/src/data/proofs/erdos-151/meta.json
+++ b/src/data/proofs/erdos-151/meta.json
@@ -37,8 +37,9 @@
     "originalContributions": [
       "Formal axiomatization of clique transversal number τ(G)",
       "Triangle-free independence function H(n) with Ramsey lower bound",
-      "Proof that complement of independent set is a clique transversal",
-      "Formal statement of the Erdős-Gallai conjecture with K₄-free variant"
+      "Axiom that the complement of an independent set yields a clique transversal (complement_of_indep_is_transversal)",
+      "Machine-checked reductions: the triangle-free case (erdos_151_triangle_free), the conjecture-implies-easy-bound direction, and reformulations — all proved from the axioms",
+      "Formal statement of the Erdős-Gallai conjecture (ErdosProblem151); the K₄-free case is noted as open in commentary only"
     ],
     "dateAdded": "2026-02-15",
     "relatedProblems": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-151 (Clique Transversal and Triangle-Free Independence)
**Severity**: LOW–MEDIUM — misleading `originalContributions` (axiom-as-proof + phantom formal variant)

## Evidence

Source `proofs/Proofs/Erdos151Problem.lean` has exactly 11 axioms, 7 theorems, 2 defs, 0 sorries — matching `axiomCount: 11`, `theoremCount: 7`, `definitionCount: 2`. The `assumptions` field correctly discloses all 11 axioms. Only `originalContributions` overstated:

1. **Axiom-as-proof** — `"Proof that complement of independent set is a clique transversal"` maps to `axiom complement_of_indep_is_transversal` (line 108). It is **axiomatized, not proved**. (Same pattern as #35970.)
2. **Phantom formal variant** — `"Formal statement of the Erdős-Gallai conjecture with K₄-free variant"`: there is **no K₄-free declaration** in the source; the K₄-free case appears only in a prose comment (`-- Even the K₄-free restriction ... remains open`).

## Fix (meta-only)

- Relabel the axiom line as an axiom.
- Reword the K₄-free claim to "noted as open in commentary only".
- Add a contribution line for the genuine machine-checked reductions the file **does** prove (`erdos_151_triangle_free`, `conjecture_implies_easy_bound`, reformulations).

No change to `status` (axiomatized), `badge` (axiom), `sorries` (0), or any count — those were already accurate.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)