### PR TITLE
research(cauchy-interlacing-oq-02-oq-01): spectrum containment on invariant subspace [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
@@ -254,4 +254,52 @@ theorem hasEigenvalue_compress_eigenvalue_of_invariant
     ⟨Module.End.mem_eigenspace_iff.mpr hcoe, hne⟩
   exact Module.End.hasEigenvalue_of_hasEigenvector hev
 
+/-- **Spectrum containment on an invariant subspace (attainment case).**
+
+If `H` is `T`-invariant, the whole spectrum of the orthogonal compression
+`compress T H` is contained in the spectrum of the ambient operator `T`:
+
+  `spectrum 𝕜 (compress T H) ⊆ spectrum 𝕜 T`.
+
+This is the set-level upgrade of the per-index
+`hasEigenvalue_compress_eigenvalue_of_invariant`.  On an invariant `H` the
+compression coincides with the honest restriction `T.restrict`
+(`compress_eq_restrict_of_invariant`), so it loses no spectral information: each
+eigenvalue it exhibits is realised in the ambient space by the *same*
+eigenvector, viewed in `V`.  No symmetry of `T` is required — this is a pure
+invariant-restriction fact, which is exactly why Poincaré interlacing
+`μ_k ≤ λ_k` degenerates to equality on such a block. -/
+theorem spectrum_compress_subset_of_invariant {T : V →ₗ[𝕜] V} (H : Submodule 𝕜 V)
+    (hinv : ∀ y ∈ H, T y ∈ H) :
+    spectrum 𝕜 (compress T H) ⊆ spectrum 𝕜 T := by
+  intro μ hμ
+  -- `μ ∈ spectrum` ⇒ eigenvalue of the (finite-dimensional) compression.
+  have hev : Module.End.HasEigenvalue (compress T H) μ :=
+    Module.End.hasEigenvalue_iff_mem_spectrum.mpr hμ
+  obtain ⟨y, hy⟩ := hev.exists_hasEigenvector
+  rw [Module.End.hasEigenvector_iff] at hy
+  obtain ⟨hy_mem, hy_ne⟩ := hy
+  rw [Module.End.mem_eigenspace_iff] at hy_mem
+  -- Transport the eigen-equation `compress T H y = μ • y` to `V` via invariance.
+  have hcoe : T (y : V) = μ • (y : V) := by
+    have e := coe_compress_of_invariant H hinv y
+    rw [hy_mem] at e
+    simpa using e.symm
+  have hyV : (y : V) ≠ 0 := by rw [Ne, Submodule.coe_eq_zero]; exact hy_ne
+  have hevV : Module.End.HasEigenvalue T μ :=
+    Module.End.hasEigenvalue_of_hasEigenvector
+      ⟨Module.End.mem_eigenspace_iff.mpr hcoe, hyV⟩
+  exact hevV.mem_spectrum
+
+/-- **The compression spectrum is the honest-restriction spectrum on an invariant
+block.**  Since `compress T H = T.restrict hinv` on an invariant subspace
+(`compress_eq_restrict_of_invariant`), the two operators share a spectrum; the
+containment `spectrum_compress_subset_of_invariant` is thus the classical fact
+that a restriction to an invariant subspace has spectrum inside the ambient one,
+routed through the explicit orthogonal compression. -/
+theorem spectrum_compress_eq_restrict_of_invariant {T : V →ₗ[𝕜] V}
+    (H : Submodule 𝕜 V) (hinv : ∀ y ∈ H, T y ∈ H) :
+    spectrum 𝕜 (compress T H) = spectrum 𝕜 (T.restrict hinv) := by
+  rw [compress_eq_restrict_of_invariant H hinv]
+
 end CauchyInterlacing.PoincareCompression

--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (phantom deliverable pre-existed, verified 0/0). Researcher-9 (2026-07-08) added the tightness/attainment companion: the compression onto a T-invariant subspace equals the honest restriction T.restrict, characterising the equality case of the interlacing bound.",
+    "progressSummary": "COMPLETE + spectrum-containment sharpening: on a T-invariant subspace, spectrum 𝕜 (compress T H) ⊆ spectrum 𝕜 T (set level) and equals spectrum of the honest restriction. Next-steps #2 (converse) and #3 (set-level spectrum inclusion) now both resolved; only the with-multiplicity sub-multiset form remains open.",
     "builtItems": [
       "poincare_separation_compression in CauchyInterlacingPoincareCompression.lean (#28084) — unconditional codimension-m Poincaré separation: given a symmetric T on V (dim n+m) and any subspace H (dim n), the descending eigenvalues of the explicit orthogonal compression compress T H interlace those of T as lam⟨k+m⟩ ≤ mu k ≤ lam⟨k⟩, with NO Rayleigh side hypothesis.",
       "compress / isSymmetric_compress / rayleigh_compress_eq in CauchyInterlacingCompression.lean (#27245) — define compress T H := P_H∘T∘ι_H, prove it symmetric, and discharge the Rayleigh-agreement identity for an arbitrary subspace via the orthogonal-projection adjoint identity.",
@@ -39,20 +39,25 @@
       "compress_eq_restrict_of_invariant + coe_compress_of_invariant (researcher-9, CauchyInterlacingPoincareCompression.lean) — if H is T-invariant (∀ y∈H, T y∈H) then compress T H = T.restrict hinv as operators H→ₗH; pointwise ↑(compress T H y)=T ↑y. Proof: compress_apply, then the orthogonal projection is inert on T ↑y∈H via coe_orthogonalProjection_apply + starProjection_eq_self_iff.mpr. This is the attainment/tightness case of Poincaré separation.",
       "invariant_iff_coe_compress_eq in CauchyInterlacingPoincareCompression.lean:195 — pointwise-coercion iff: ↑(compress T H y)=T↑y ∀y IFF H is T-invariant (VERIFIED 0/0)",
       "invariant_of_exists_lift in CauchyInterlacingPoincareCompression.lean:209 — existence of ANY pointwise lift S:H→ₗH of T forces H-invariance (VERIFIED 0/0)",
-      "hasEigenvalue_compress_eigenvalue_of_invariant in CauchyInterlacingPoincareCompression.lean: on a T-invariant subspace H, every eigenvalue μ_k of compress T H is a HasEigenvalue of the ambient symmetric T, via the included eigenvector ↑(bH k). VERIFIED 0 sorry / 0 new axioms (build 4.5s)."
+      "hasEigenvalue_compress_eigenvalue_of_invariant in CauchyInterlacingPoincareCompression.lean: on a T-invariant subspace H, every eigenvalue μ_k of compress T H is a HasEigenvalue of the ambient symmetric T, via the included eigenvector ↑(bH k). VERIFIED 0 sorry / 0 new axioms (build 4.5s).",
+      "spectrum_compress_subset_of_invariant (CauchyInterlacingPoincareCompression.lean) — set-level spectrum containment: H T-invariant ⟹ spectrum 𝕜 (compress T H) ⊆ spectrum 𝕜 T; upgrades per-index hasEigenvalue_compress_eigenvalue_of_invariant; no symmetry needed (VERIFIED 0/0, PR pending)",
+      "spectrum_compress_eq_restrict_of_invariant — compress T H = T.restrict on invariant block ⟹ shared spectrum, routes containment through honest-restriction picture (VERIFIED 0/0)"
     ],
     "insights": [
       "This slug duplicates work already merged under sibling cauchy-interlacing-theorem-oq-01-oq-02 (#28084). The Rayleigh-agreement hypothesis of the abstract poincare_separation is discharged by rayleigh_compress_eq, which is stated for an ARBITRARY submodule H (nothing uses codim=1), so the abstract theorem and the explicit compression join for any codimension m with no new work.",
       "Rayleigh discharge mechanism: for y∈H, ⟨compress T H y, y⟩_H = ⟨P_H(Ty), y⟩ = ⟨Ty, y⟩_V by the orthogonal-projection adjoint identity (P_H self-adjoint, P_H y = y); norms agree since the inclusion H↪V is a linear isometry.",
       "The interlacing μ_k ≤ λ_k is an equality on a block exactly when the corresponding invariant subspace is T-stable. compress T H loses information only through the orthogonal projection P_H(T ↑y); when T ↑y already lies in H the projection is the identity, so compress collapses to the restriction and no eigenvalue is lost — the extremal case of Poincaré separation.",
       "Converse of the compression-attainment picture: the compression's projection error vanishes on y∈H precisely when H is invariant; a lifting S exists iff the ambient image T↑y lands back in H (read off from Submodule.coe_mem of compress T H y).",
-      "Attainment/spectrum-inclusion case of Cauchy interlacing: on invariant H the compression = T.restrict (compress_eq_restrict_of_invariant), so its whole spectrum {μ_k} ⊆ spec(T) and the bound μ_k ≤ λ_k degenerates onto the ambient spectrum. The pointwise eigenvalue-inclusion is the natural companion to the already-merged operator identity."
+      "Attainment/spectrum-inclusion case of Cauchy interlacing: on invariant H the compression = T.restrict (compress_eq_restrict_of_invariant), so its whole spectrum {μ_k} ⊆ spec(T) and the bound μ_k ≤ λ_k degenerates onto the ambient spectrum. The pointwise eigenvalue-inclusion is the natural companion to the already-merged operator identity.",
+      "The spectrum containment does NOT require T symmetric — it is a pure invariant-restriction fact; symmetry only enters for the descending-eigenvalue interlacing μ_k ≤ λ_k, not for the set-level ⊆.",
+      "Dot notation (compress T H).HasEigenvalue resolves to LinearMap.HasEigenvalue (nonexistent) since the syntactic head is LinearMap not Module.End; must write Module.End.HasEigenvalue explicitly even though End 𝕜 H := H →ₗ[𝕜] H."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Formalise the spectral consequence: under H T-invariant, the descending eigenvalues of compress T H are a sub-multiset of those of T (equality is attained in the interlacing bound). Needs bridging equal operators to equal eigenvalue tuples across distinct IsSymmetric proofs — watch proof-irrelevance of the symmetry witness in hT.eigenvalues.",
       "Converse: if compress T H = T.restrict for some restriction then H is T-invariant (the projection error vanishes iff T ↑y∈H for all y).",
-      "Upgrade pointwise inclusion to a multiset/spectrum containment: (compress T H).spectrum ⊆ T.spectrum on invariant H (uses hasEigenvalue_compress_eigenvalue_of_invariant per index); or the equality-in-interlacing characterisation μ_k = λ_k on the invariant block."
+      "Upgrade pointwise inclusion to a multiset/spectrum containment: (compress T H).spectrum ⊆ T.spectrum on invariant H (uses hasEigenvalue_compress_eigenvalue_of_invariant per index); or the equality-in-interlacing characterisation μ_k = λ_k on the invariant block.",
+      "Multiset/with-multiplicity spectrum containment: descending eigenvalue tuple of compress T H is a sub-multiset of that of T on invariant H (harder — needs eigenvalue-tuple-as-multiset + multiplicity comparison across distinct IsSymmetric witnesses)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Resolves the open next-step for **cauchy-interlacing-theorem-oq-02-oq-01**: *upgrade the pointwise per-index eigenvalue inclusion to a set-level spectrum containment*. Adds two theorems to `CauchyInterlacingPoincareCompression.lean`.

### New theorems

- **`spectrum_compress_subset_of_invariant`** — on a `T`-invariant subspace `H`,
  ```
  spectrum 𝕜 (compress T H) ⊆ spectrum 𝕜 T
  ```
  The set-level upgrade of the existing per-index `hasEigenvalue_compress_eigenvalue_of_invariant`: each eigenvalue of the orthogonal compression is realised in the ambient space `V` by the *same* eigenvector (transported via `coe_compress_of_invariant`). Notably **no symmetry of `T` is required** — this is a pure invariant-restriction fact, which is exactly why Poincaré interlacing `μ_k ≤ λ_k` degenerates to equality on an invariant block.

- **`spectrum_compress_eq_restrict_of_invariant`** — since `compress T H = T.restrict hinv` on an invariant block (`compress_eq_restrict_of_invariant`), the compression and the honest restriction share a spectrum, routing the containment through the classical "restriction to an invariant subspace has spectrum inside the ambient one".

### Verification

- Host-verified clean: `lake env lean Proofs/CauchyInterlacingPoincareCompression.lean` exits 0 with no errors (Docker build repeatedly hit fleet-memory SIGBUS-135 at the olean-write stage *after* clean `[7747/7747]` elaboration; host elaboration confirms correctness).
- `#print axioms` for both theorems lists only `propext, Classical.choice, Quot.sound` — **0 sorries, 0 axioms**.

Also updates the problem's research knowledge JSON (next-steps #2 converse and #3 set-level spectrum inclusion now both resolved; only the with-multiplicity sub-multiset form remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)