### PR TITLE
Enrich Odd Squares Sum: add leanFile block + Nicomachus cross-ref

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -3,6 +3,22 @@
   "title": "Sum of Squares of the First n Odd Numbers: ∑(2k−1)² = n(2n−1)(2n+1)/3",
   "slug": "odd-squares-sum-oq-01",
   "description": "A fully machine-checked, self-contained proof that the sum of the squares of the first n odd numbers has the closed form n(2n−1)(2n+1)/3: ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3. The result is established both as a division-free exact identity over ℕ — 3·∑(2k+1)² + n = 4n³, phrased additively so the inductive step has no truncated subtraction and closes by `ring` alone — and as the classical rational closed form over ℚ. This is the odd-indexed companion of the square-pyramidal identity ∑k² = n(n+1)(2n+1)/6, which Mathlib has; this variant it does not.",
+  "leanFile": {
+    "path": "Proofs/OddSquaresSum.lean",
+    "namespace": "OddSquaresSum",
+    "imports": [
+      "Mathlib.Algebra.BigOperators.Intervals",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "lineCount": 74,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "sorries": 0
+  },
   "meta": {
     "author": "Classical; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Square_pyramidal_number",
@@ -117,6 +133,11 @@
       "proofId": "triangular-reciprocals",
       "relationship": "related — elementary closed-form sum",
       "description": "A companion elementary identity for a sum over the first n naturals: ∑ 2/(n(n+1)) = 2 by telescoping. Both belong to the gallery's family of clean closed forms for figurate/polynomial sums proved by short, fully verified elementary arguments."
+    },
+    {
+      "proofId": "nicomachus-sum-of-cubes-oq-01",
+      "relationship": "related — figurate power-sum closed form",
+      "description": "Nicomachus's identity ∑_{k≤n} k³ = (∑_{k≤n} k)² is the sum-of-cubes member of the same family of clean closed forms for polynomial power sums. Both prove a figurate-number identity by short fully verified induction, complementing Mathlib's built-in power-sum lemmas."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `odd-squares-sum-oq-01` (quality 94, passes 0).

## Changes (meta.json only)
- **Added the missing top-level `leanFile` object** (namespace OddSquaresSum, imports, opens Finset, lineCount 74, theoremCount 2, definitionCount 0, axiomCount 0, sorries 0) — all fields verified directly against `Proofs/OddSquaresSum.lean`. Brings the entry into schema consistency with its siblings and supplies the `leanFile.*` fields drift/audit tooling expects.
- **Added a crossReference** to `nicomachus-sum-of-cubes-oq-01` (∑k³ = (∑k)²), a fellow clean figurate power-sum closed form — matching the entry's own "figurate/polynomial sums" framing.

Note: I verified the entry's existing `crossReferences` use of `proofId` (rather than `targetId`) is correct — the loader resolves `proofId ?? targetId` and `proofId` is the primary field name, so no change was needed there.

JSON validates; 10.8 KB, under all caps.