### PR TITLE
Enrich Order of 1+p·a mod odd prime power (oq-01): add header section

### DIFF
--- a/src/data/proofs/order-one-add-mul-prime-oq-01/meta.json
+++ b/src/data/proofs/order-one-add-mul-prime-oq-01/meta.json
@@ -120,6 +120,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Imports `Mathlib` and opens `namespace OrderOneAddMulPrimeOQ01`. The docstring states the problem — for an odd prime p and p ∤ a, the element 1 + p·a is a unit of ZMod (p^(n+1)) with multiplicative order exactly p^n — and explains why it matters: the principal units 1 + p·ℤ form the cyclic p-group of order p^n that, combined with the order-(p−1) part from reduction mod p, makes (ZMod p^k)ˣ cyclic for odd prime powers. It records that Mathlib proves the order computation (ZMod.orderOf_one_add_mul_prime) but does not package the structural consequences this file assembles, all axiom-free and without native_decide.",
+      "mathContext": "$\\operatorname{ord}_{p^{n+1}}(1 + p a) = p^{n}$ for $p$ an odd prime, $p \\nmid a$; the principal units $1 + p\\mathbb{Z}$ form a cyclic $p$-group of order $p^{n}$."
+    },
+    {
       "id": "core",
       "title": "The Order Computation",
       "startLine": 38,


### PR DESCRIPTION
Enrichment pass for `order-one-add-mul-prime-oq-01`.

**Structural gap fixed:** the `sections` array began at line 38, leaving the header region (lines 1–37: `import Mathlib`, the module docstring, and the `namespace`) with no section coverage.

Changes:
- Added a **header section** (lines 1–37) summarizing the import, the docstring's problem statement (odd prime p, p ∤ a ⇒ orderOf (1 + p·a) = p^n in ZMod p^(n+1)), why it matters (principal units form the cyclic p-group behind cyclicity of (ZMod p^k)ˣ), and what Mathlib packages vs. what this file assembles.
- Sections now cover the full 102-line file (header, order computation, structural corollaries, concrete instances) with no uncovered head region.

meta.json is 12.6 KB, well under the 60 KB cap; no field exceeds its cap. Gallery data build passes with no warnings for this entry.