### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-03): Fin 3 sign-change lemmas de-axiomatize quadratic examples

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -174,6 +174,75 @@ theorem countSignChanges_two {f : Fin 2 → ℝ} (h : f 0 * f 1 < 0) :
         | exact absurd hk0 (by decide)
         | exact absurd hk1 (by decide)
 
+/- ## § 2¾. Three-term coefficient sign-change counts (verified, axiom-free)
+
+Quadratics `a·X² + b·X + c` produce a length-3 coefficient sequence.  For the
+degree-2 examples the gallery's base file *axiomatised* (`example_x2_minus_1_sign_changes`,
+`example_x2_plus_1_sign_changes`) the middle coefficient of the coefficient sequence is
+`0`, so the count is governed entirely by the signs of the two outer entries:
+
+* opposite outer signs (`f 0 · f 2 < 0`) — exactly one sign change (across the zero);
+* equal or vanishing outer signs (`0 ≤ f 0 · f 2`) — no sign change at all.
+
+We prove both, extending `countSignChanges_two` from `Fin 2` to the `Fin 3`
+middle-zero pattern.  These discharge the base file's two quadratic sign-change
+axioms with fully machine-checked, axiom-free evaluations (see § 4). -/
+
+/-- **One sign change across a zero.**  If `f : Fin 3 → ℝ` has a zero middle entry
+(`f 1 = 0`) and outer entries of opposite sign (`f 0 · f 2 < 0`), then `f` has exactly
+one sign change — the pair `(0, 2)` jumping over the vanishing middle term.  Axiom-free. -/
+theorem countSignChanges_three_mid_zero_pos {f : Fin 3 → ℝ}
+    (hmid : f 1 = 0) (h : f 0 * f 2 < 0) :
+    DescartesRuleOfSigns.countSignChanges f = 1 := by
+  have h0 : f 0 ≠ 0 := fun he => by rw [he, zero_mul] at h; exact lt_irrefl 0 h
+  have h2 : f 2 ≠ 0 := fun he => by rw [he, mul_zero] at h; exact lt_irrefl 0 h
+  unfold DescartesRuleOfSigns.countSignChanges
+  rw [Finset.card_eq_one]
+  refine ⟨(0, 2), ?_⟩
+  ext ⟨i, j⟩
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_singleton,
+    decide_eq_true_eq, DescartesRuleOfSigns.SignChangeBetween,
+    DescartesRuleOfSigns.oppositeSign, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hij, hi0, hj0, -, -⟩
+    have hi1 : i ≠ 1 := by rintro rfl; exact hi0 hmid
+    have hj1 : j ≠ 1 := by rintro rfl; exact hj0 hmid
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact ⟨rfl, rfl⟩
+        | (exfalso; revert hij hi1 hj1; decide)
+  · rintro ⟨rfl, rfl⟩
+    refine ⟨by decide, h0, h2, ?_, h⟩
+    intro k hk0 hk2
+    fin_cases k <;>
+      first
+        | exact hmid
+        | exact absurd hk0 (by decide)
+        | exact absurd hk2 (by decide)
+
+/-- **No sign change with a zero middle and non-opposite outer entries.**  If `f 1 = 0`
+and the outer entries do not have strictly opposite signs (`0 ≤ f 0 · f 2` — covering
+equal signs *and* a vanishing outer entry), then `f` has no sign change.  Axiom-free. -/
+theorem countSignChanges_three_mid_zero_zero {f : Fin 3 → ℝ}
+    (hmid : f 1 = 0) (h : 0 ≤ f 0 * f 2) :
+    DescartesRuleOfSigns.countSignChanges f = 0 := by
+  unfold DescartesRuleOfSigns.countSignChanges
+  rw [Finset.card_eq_zero]
+  apply Finset.filter_eq_empty_iff.mpr
+  rintro ⟨i, j⟩ -
+  simp only [decide_eq_true_eq, DescartesRuleOfSigns.SignChangeBetween,
+    DescartesRuleOfSigns.oppositeSign]
+  rintro ⟨hij, hi0, hj0, -, hopp⟩
+  have hi1 : i ≠ 1 := by rintro rfl; exact hi0 hmid
+  have hj1 : j ≠ 1 := by rintro rfl; exact hj0 hmid
+  have hij02 : i = 0 ∧ j = 2 := by
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact ⟨rfl, rfl⟩
+        | (exfalso; revert hij hi1 hj1; decide)
+  obtain ⟨rfl, rfl⟩ := hij02
+  exact absurd hopp (not_lt.mpr h)
+
 /- ## § 3. Axiom-free validation of the Sturm half on linear polynomials
 
 For `p = X − c` with `c > 0`, the gallery already proves (axiom-free) that the
@@ -259,5 +328,59 @@ theorem linear_descartes_bound (hc : 0 < c) :
   descartes_upper_bound_via_sturm (linearReduction c hc)
 
 end Linear
+
+/- ## § 4. De-axiomatizing the base file's quadratic sign-change examples
+
+The gallery's base file `DescartesRuleOfSigns` states the two concrete counts
+`signChangesInCoeffs (X² − 1) = 1` and `signChangesInCoeffs (X² + 1) = 0` as `axiom`
+declarations (the classically-decided filter in `countSignChanges` does not reduce under
+`decide`).  With the `Fin 3` machinery of § 2¾ we now discharge both **axiom-free**,
+showing those base axioms are removable. -/
+
+section Quadratic
+
+/-- **`X² − 1` has exactly one coefficient sign change, computed axiom-free.**  The
+coefficient sequence is `[1, 0, −1]`: a zero middle with opposite outer signs, hence one
+sign change.  This is exactly the statement of the base file's `example_x2_minus_1_sign_changes`
+axiom, now proved. -/
+theorem x2_minus_1_signChanges :
+    signChangesInCoeffs (X ^ 2 - 1 : ℝ[X]) = 1 := by
+  have hne : (X ^ 2 - 1 : ℝ[X]) ≠ 0 := by
+    intro h
+    have : (X ^ 2 - 1 : ℝ[X]).coeff 2 = 0 := by rw [h]; simp
+    simp [coeff_sub, coeff_X_pow, coeff_one] at this
+  have hdeg : (X ^ 2 - 1 : ℝ[X]).natDegree = 2 := by compute_degree!
+  unfold signChangesInCoeffs
+  rw [dif_neg hne, hdeg]
+  apply countSignChanges_three_mid_zero_pos
+  · simp [DescartesRuleOfSigns.coeffSequence, coeff_sub, coeff_X_pow, coeff_one]
+  · have e0 : DescartesRuleOfSigns.coeffSequence (X ^ 2 - 1 : ℝ[X]) 2 0 = 1 := by
+      simp [DescartesRuleOfSigns.coeffSequence, coeff_sub, coeff_X_pow, coeff_one]
+    have e2 : DescartesRuleOfSigns.coeffSequence (X ^ 2 - 1 : ℝ[X]) 2 2 = -1 := by
+      simp [DescartesRuleOfSigns.coeffSequence, coeff_sub, coeff_X_pow, coeff_one]
+    rw [e0, e2]; norm_num
+
+/-- **`X² + 1` has no coefficient sign change, computed axiom-free.**  The coefficient
+sequence is `[1, 0, 1]`: a zero middle with equal outer signs, hence no sign change.  This
+is exactly the statement of the base file's `example_x2_plus_1_sign_changes` axiom, now
+proved. -/
+theorem x2_plus_1_signChanges :
+    signChangesInCoeffs (X ^ 2 + 1 : ℝ[X]) = 0 := by
+  have hne : (X ^ 2 + 1 : ℝ[X]) ≠ 0 := by
+    intro h
+    have : (X ^ 2 + 1 : ℝ[X]).coeff 2 = 0 := by rw [h]; simp
+    simp [coeff_add, coeff_X_pow, coeff_one] at this
+  have hdeg : (X ^ 2 + 1 : ℝ[X]).natDegree = 2 := by compute_degree!
+  unfold signChangesInCoeffs
+  rw [dif_neg hne, hdeg]
+  apply countSignChanges_three_mid_zero_zero
+  · simp [DescartesRuleOfSigns.coeffSequence, coeff_add, coeff_X_pow, coeff_one]
+  · have e0 : DescartesRuleOfSigns.coeffSequence (X ^ 2 + 1 : ℝ[X]) 2 0 = 1 := by
+      simp [DescartesRuleOfSigns.coeffSequence, coeff_add, coeff_X_pow, coeff_one]
+    have e2 : DescartesRuleOfSigns.coeffSequence (X ^ 2 + 1 : ℝ[X]) 2 2 = 1 := by
+      simp [DescartesRuleOfSigns.coeffSequence, coeff_add, coeff_X_pow, coeff_one]
+    rw [e0, e2]; norm_num
+
+end Quadratic
 
 end DescartesRuleOfSignsOQ01OQ03

--- a/research/problems/descartes-rule-of-signs-oq-01-oq-03/state.md
+++ b/research/problems/descartes-rule-of-signs-oq-01-oq-03/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: SOLVED
 **Since**: 2026-06-25T21:00:00.000Z
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
 
@@ -14,11 +14,13 @@ Reduction skeleton over ℕ (`upper_bound_core`, `parity_core`, both omega-close
 
 ## Result
 
-`proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean` — 10 theorems, 1 definition, 1 structure, 0 sorries, 0 `axiom` declarations. The general direction is conditional on the `SturmReduction` bridge data (counted as the entry's single standing assumption); the linear-polynomial validation is unconditional and axiom-free.
+`proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean` — 14 theorems, 1 definition, 1 structure, 0 sorries, 0 `axiom` declarations. The general direction is conditional on the `SturmReduction` bridge data (counted as the entry's single standing assumption); the linear-polynomial validation is unconditional and axiom-free.
 
 **Iteration 3 increment (2026-07-07):** made the linear branch *fully* unconditional. Previously `linearReduction`/`linear_descartes_bound` took `hV : signChangesInCoeffs (X − C c) = 1` as an unproved hypothesis. That coefficient count is now computed directly by a new axiom-free lemma `linear_signChanges`, built on a new general helper `countSignChanges_two` (a length-2 real sequence with opposite-sign entries has exactly one sign change — the base file had only ever *axiomatised* such concrete counts, e.g. `example_x2_minus_1_sign_changes`). So the `hV` hypothesis is discharged and the linear case carries no assumption beyond `c > 0`. Gallery entry: `descartes-rule-of-signs-oq-01-oq-03`.
 
 A prerequisite Mathlib-rot repair was made to the base file `Proofs/DescartesRuleOfSigns.lean` (renamed `Polynomial.card_roots_le_degree` → `Polynomial.card_roots'`, fixed `Fin.castSucc_lt_succ` application, and supplied the explicit multiset argument to `Multiset.countP_le_card`) so the dependency chain compiles against Mathlib 4.26.0.
+
+**Iteration 4 increment (2026-07-08):** carried out the iteration-3 "next intermediate step" — extended the axiom-free coefficient sign-change computation from `Fin 2` to the `Fin 3` middle-zero pattern. Two reusable lemmas, `countSignChanges_three_mid_zero_pos` (zero middle, opposite outer signs ⟹ one sign change, via the single pair `(0,2)`) and `countSignChanges_three_mid_zero_zero` (zero middle, non-opposite outer signs ⟹ no sign change, filter is empty), generalise `countSignChanges_two`. Using them, the base file's two *axiomatised* quadratic examples are now discharged **axiom-free** as theorems `x2_minus_1_signChanges : signChangesInCoeffs (X²−1) = 1` and `x2_plus_1_signChanges : signChangesInCoeffs (X²+1) = 0` (coefficient sequences `[1,0,−1]` and `[1,0,1]`; `natDegree = 2` via `compute_degree!`, coefficients via `simp [coeffSequence, coeff_sub/coeff_add, coeff_X_pow, coeff_one]`). This shows the base file's `example_x2_minus_1_sign_changes`/`example_x2_plus_1_sign_changes` axioms are removable. The entry stays `axiomatized` because the general-polynomial `SturmReduction` bridge remains a standing structural assumption.
 
 ## Blockers
 
@@ -26,7 +28,7 @@ None.
 
 ## Next Action
 
-Solved. Remaining open question: prove the three comparison facts (B1)-(B3) for *general* polynomials to make the general Sturm ⟹ Descartes implication unconditional. (For linear polynomials this is now done — the (B1)-(B3) facts are discharged axiom-free via `linear_signChanges`/`countSignChanges_two`.) A natural next intermediate step is extending the axiom-free coefficient sign-change computation from `Fin 2` to `Fin 3` (quadratics), which would let the base file's axiomatised examples `example_x2_minus_1_sign_changes`/`example_x2_plus_1_sign_changes` be de-axiomatised.
+Solved. The remaining open direction is unchanged: prove the three comparison facts (B1)-(B3) for *general* polynomials to make the general Sturm ⟹ Descartes implication unconditional. Follow-up mechanical step now enabled: replace the two `axiom` declarations in the base gallery file `Proofs/DescartesRuleOfSigns.lean` with theorems (the proofs now exist in this entry as `x2_minus_1_signChanges`/`x2_plus_1_signChanges`; a base-file edit would need the `Fin 3` helpers relocated into the base file, since it cannot import this descendant). A further generalisation is a fully general `Fin 3` sign-change count (arbitrary nonzero middle) to handle quadratics `aX²+bX+c` with `b ≠ 0`.
 
 ## Attempt Counts
 

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
@@ -49,9 +49,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 263,
+    "lineCount": 386,
     "assumptions": "The general direction (Sturm ⟹ Descartes for an arbitrary polynomial) is a reduction: it is conditional on a `SturmReduction p` bridge structure whose five fields package Sturm's exact positive-root count on (0, B] together with the three classical coefficient-comparison facts σ_p(0) ≤ V(p), Even(V(p) − σ_p(0)), and Even(σ_p(B)). Per the project's axiom-integrity policy these structure fields are mathematical assumptions (counted here as axiomCount 1; obtaining the data for a general p requires Sturm's theorem, axiomatized in the parent entry as sturm_exact_count_axiom, plus standard Sturm/Descartes comparison theory). No `axiom` declarations and no sorries appear in the file (leanFile.axiomCount = 0). The reduction theorems (upper_bound_core, parity_core, descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm) are fully machine-checked implications, and the Sturm half is validated UNCONDITIONALLY and axiom-free on linear polynomials X − c (c > 0), reusing the gallery's axiom-free Sturm computations. The linear-polynomial validation (X − c, c > 0) is now fully unconditional and axiom-free: the coefficient sign-change count V(X − c) = 1 is computed directly (linear_signChanges, via the new axiom-free countSignChanges_two), so the previously-assumed hypothesis hV has been discharged and linearReduction/linear_descartes_bound carry no standing assumption for the linear case.",
-    "theoremCount": 10,
+    "theoremCount": 14,
     "mathlib_version": "4.26.0",
     "definitionCount": 2
   },
@@ -122,9 +122,9 @@
       "Proofs.DescartesRuleOfSignsOQ02OQ01OQ02"
     ],
     "namespace": "DescartesRuleOfSignsOQ01OQ03",
-    "lineCount": 263,
+    "lineCount": 386,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 14,
     "definitionCount": 2,
     "path": "Proofs/DescartesRuleOfSignsOQ01OQ03.lean",
     "sorries": 0

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
@@ -26,8 +26,8 @@
   },
   "currentState": {
     "phase": "SOLVED",
-    "since": "2026-06-25T21:00:00.000Z",
-    "iteration": 2,
+    "since": "2026-07-08T00:00:00.000Z",
+    "iteration": 4,
     "focus": "Solved as a verified, axiom-free reduction with an unconditional linear-polynomial validation.",
     "blockers": [],
     "nextAction": "Prove (B1)-(B3) for general polynomials to upgrade the reduction to an unconditional result.",
@@ -43,21 +43,24 @@
       "upper_bound_core / parity_core: omega-closed reduction skeleton over N (axiom-free)",
       "SturmReduction structure bridging Sturm's variation count to Descartes' coefficient sign-change count",
       "descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm",
-      "linear_positiveRoots, linear_sturm_count, linearReduction, linear_descartes_bound (axiom-free linear validation)"
+      "linear_positiveRoots, linear_sturm_count, linearReduction, linear_descartes_bound (axiom-free linear validation)",
+      "countSignChanges_three_mid_zero_pos / _zero: Fin 3 middle-zero sign-change counts (axiom-free), generalising countSignChanges_two",
+      "x2_minus_1_signChanges, x2_plus_1_signChanges: axiom-free evaluations discharging the base file's two quadratic sign-change axioms"
     ],
     "insights": [
       "The entire 'exact count => bound + parity' content reduces to two omega lemmas once the count is written as a non-increasing difference hi - lo; the inequality and the parity fall out of upper_bound_core and parity_core respectively.",
       "Isolating Sturm's theorem and the classical comparison estimates as explicit hypotheses in a SturmReduction structure makes the general implication transparently conditional (a reduction), keeping the descent to Descartes pure combinatorics.",
       "The bridge structure is inhabitable: for linear factors X - c the three comparison facts trivialise to 1 <= 1, Even 0, Even 0, giving an end-to-end axiom-free instance via linearReduction.",
-      "Gallery base file DescartesRuleOfSigns.lean had rotted against Mathlib 4.26.0 (Polynomial.card_roots_le_degree removed; Fin.castSucc_lt_succ arg now implicit; Multiset.countP_le_card needs explicit multiset) and required repair before any dependent could build."
+      "Gallery base file DescartesRuleOfSigns.lean had rotted against Mathlib 4.26.0 (Polynomial.card_roots_le_degree removed; Fin.castSucc_lt_succ arg now implicit; Multiset.countP_le_card needs explicit multiset) and required repair before any dependent could build.",
+      "The base file's axiomatised concrete counts (example_x2_minus_1_sign_changes = 1, example_x2_plus_1_sign_changes = 0) are removable: with a Fin 3 middle-zero sign-change lemma the coefficient sequences [1,0,-1] and [1,0,1] are counted axiom-free (natDegree via compute_degree!, coefficients via simp on coeffSequence/coeff_X_pow/coeff_one)."
     ],
     "mathlibGaps": [
       "No packaged Sturm-sequence sign-variation theory in Mathlib connecting sigma_p to the coefficient sign-change count V(p); the comparison facts (B1)-(B3) must be supplied as assumptions."
     ],
     "nextSteps": [
-      "Prove (B1) sigma_p(0) <= V(p), (B2) Even(V(p) - sigma_p(0)), (B3) Even(sigma_p(B)) for general polynomials.",
-      "Extend the linear validation to split polynomials prod (X - c_i) with distinct positive roots.",
-      "Adapt the reduction skeleton to recover the Budan-Fourier theorem on arbitrary intervals [a, b]."
+      "Relocate the Fin 3 helpers into the base file DescartesRuleOfSigns.lean and replace its two example_x2_*_sign_changes axiom declarations with theorems (the proofs now exist in this entry).",
+      "Generalise to a full Fin 3 sign-change count (arbitrary nonzero middle term) for quadratics aX^2+bX+c with b != 0.",
+      "Prove (B1)-(B3) for general polynomials to make the general Sturm => Descartes implication unconditional."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Iteration-4 increment on `descartes-rule-of-signs-oq-01-oq-03`. Extends the entry's axiom-free coefficient sign-change computation from `Fin 2` (length-2 sequences) to the `Fin 3` middle-zero pattern, and uses it to **discharge axiom-free** the base gallery file's two *axiomatised* quadratic sign-change examples.

## What's new (`proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean`, +123 lines)

Two reusable helper lemmas generalising the existing `countSignChanges_two`:

- `countSignChanges_three_mid_zero_pos` — `f : Fin 3 → ℝ` with zero middle (`f 1 = 0`) and opposite outer signs (`f 0 · f 2 < 0`) ⟹ exactly one sign change (the pair `(0,2)` jumping the vanishing middle).
- `countSignChanges_three_mid_zero_zero` — zero middle and non-opposite outer signs (`0 ≤ f 0 · f 2`) ⟹ no sign change (the filter is empty).

Two concrete evaluations built on them, matching the base file's axioms:

- `x2_minus_1_signChanges : signChangesInCoeffs (X² − 1) = 1`  (coeff sequence `[1, 0, −1]`)
- `x2_plus_1_signChanges  : signChangesInCoeffs (X² + 1) = 0`  (coeff sequence `[1, 0, 1]`)

`natDegree = 2` via `compute_degree!`; coefficients via `simp` on `coeffSequence`/`coeff_X_pow`/`coeff_one`. This demonstrates the base file's `example_x2_minus_1_sign_changes` / `example_x2_plus_1_sign_changes` **axiom declarations are removable**.

## Status / counts

- File: 386 lines, 14 theorems, 2 definitions (`structure SturmReduction` + `def linearReduction`), 0 sorries, 0 `axiom` declarations.
- Entry remains `axiomatized` (`axiomCount 1`): the general-polynomial `SturmReduction` bridge is still the single standing structural assumption. This PR does not touch that assumption; it only de-axiomatizes the concrete quadratic sign-change facts.
- `meta.json` / research JSON / `state.md` synced (lineCount 263→386, theoremCount 10→14, leanFile definitionCount 2).

## Verification note

The new file **elaborates cleanly with zero type errors** — confirmed across 6 independent Docker builds against current `origin/main` (elaboration completing in 1.1–5.2 s each). Every run then died with **exit code 135 (SIGBUS) at the olean-write stage** under fleet memory contention (host at ~88 GB/96 GB, 5+ concurrent builds); this is a known environmental artifact, not a math/type error (a real error exits code 1 with an `error:` message). I also repaired a corrupted shared `aesop/RuleSet.ir` cache artifact encountered mid-way (`--repair-cache`) that was breaking fleet builds. Marked `[UNVERIFIED]` pending a green `exit 0` in a quieter window; the deployer can confirm on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)