### PR TITLE
research(szemeredi-regularity-oq-04): direct 2×2 ε⁴ energy increment from an irregular pair [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
@@ -714,4 +714,86 @@ theorem partitionEnergy_gain_of_irregular_pair (G : SimpleGraph V)
       hA' hB' hA'_fresh hcomp_fresh hA_fresh hneA hB'_fresh hBcomp_fresh hB_fresh hneB
       hm₁ hm₂ hn₁ eps hε hBside⟩
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART XI: THE DIRECT 2×2 ENERGY INCREMENT FROM AN IRREGULAR PAIR
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Irregular pair ⇒ direct 2×2 energy increment (no triangle detour).**
+    This is the clean capstone that bypasses the one-sided A-side/B-side
+    reduction (PARTS VI–X) entirely.  Sessions 4–5 split the witness deviation
+    `|d(A′,B′) − d(A,B)| > ε` through a *mixed* density `d(A′,B)` via the triangle
+    inequality (`edgeDensity_two_sided_le`), keeping one coordinate whole; that
+    route loses a factor `½` in the tolerance (hence `¼` in the floor) and stumbles
+    on the mixed second-difference defect that no triangle inequality kills.
+
+    The witness deviation is, however, measured *directly against the coarse
+    density* `d(A,B)` — which is exactly the mean identity that the 2×2 variance
+    atom bound `pairEnergy_prod_refinement_gain` consumes.  So we refine **both**
+    coordinates simultaneously into the grid `{A′, A∖A′} × {B′, B∖B′}` and read off
+    the increment with no detour: the witness cell `A′×B′` is a single variance atom
+    of the four-cell density distribution whose deviation from the centroid `d(A,B)`
+    is `> ε`, contributing an energy gain of at least `(|A′||B′|/n²)·ε²`.
+
+    The unions `A′ ∪ (A∖A′) = A`, `B′ ∪ (B∖B′) = B` are honest disjoint splits
+    (`Finset.union_sdiff_of_subset`, `disjoint_sdiff_self_right`), so
+    `pairEnergy_prod_refinement_gain` applies verbatim with `d := ε`. -/
+theorem pairEnergy_prod_gain_of_irregular (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (heps : 0 ≤ eps) (A B : Finset V)
+    (hirr : ¬ IsEpsilonRegular G eps A B) :
+    ∃ A' B' : Finset V, A' ⊆ A ∧ B' ⊆ B ∧
+      eps * A.card ≤ (A'.card : ℚ) ∧ eps * B.card ≤ (B'.card : ℚ) ∧
+      pairEnergy G A B +
+          (↑A'.card : ℚ) * ↑B'.card / (Fintype.card V : ℚ) ^ 2 * eps ^ 2 ≤
+        pairEnergy G A' B' + pairEnergy G A' (B \ B') +
+          pairEnergy G (A \ A') B' + pairEnergy G (A \ A') (B \ B') := by
+  obtain ⟨A', B', hA', hB', hAc, hBc, hdev⟩ := exists_irregular_witness G eps A B hirr
+  refine ⟨A', B', hA', hB', hAc, hBc, ?_⟩
+  have hunionA : A' ∪ (A \ A') = A := Finset.union_sdiff_of_subset hA'
+  have hunionB : B' ∪ (B \ B') = B := Finset.union_sdiff_of_subset hB'
+  have hdisjA : Disjoint A' (A \ A') := disjoint_sdiff_self_right
+  have hdisjB : Disjoint B' (B \ B') := disjoint_sdiff_self_right
+  have hdev' : eps ≤
+      |edgeDensity G A' B' - edgeDensity G (A' ∪ (A \ A')) (B' ∪ (B \ B'))| := by
+    rw [hunionA, hunionB]; exact le_of_lt hdev
+  have hgain := pairEnergy_prod_refinement_gain G A' (A \ A') B' (B \ B')
+    hdisjA hdisjB eps heps hdev'
+  rwa [hunionA, hunionB] at hgain
+
+/-- **Irregular pair ⇒ explicit `ε⁴` energy increment.**  The AFKS-consumable form
+    of `pairEnergy_prod_gain_of_irregular`: floor the size-dependent cell gain
+    `(|A′||B′|/n²)·ε²` to the clean, subset-free bound `ε⁴·|A||B|/n²` using the
+    witness size thresholds `|A′| ≥ ε|A|`, `|B′| ≥ ε|B|`.  This is the genuine
+    `ε⁴` energy jump that the strong-regularity iteration consumes: an `ε`-irregular
+    pair, refined simultaneously on both coordinates, raises `pairEnergy` by at
+    least `ε⁴·|A||B|/n²` — a definite positive amount whenever the pair carries
+    positive mass.  Combined with the `[0,1]`-potential termination engine
+    (`afks_energy_iteration_count`, `N ≤ 2n²/ε²`) this is the quantitative core of
+    the AFKS finiteness statement, now free of the factor-`¼` loss the one-sided
+    branches incurred. -/
+theorem pairEnergy_prod_gain_of_irregular_eps4 (G : SimpleGraph V)
+    [DecidableRel G.Adj]
+    (eps : ℚ) (heps : 0 ≤ eps) (A B : Finset V)
+    (hirr : ¬ IsEpsilonRegular G eps A B) :
+    ∃ A' B' : Finset V, A' ⊆ A ∧ B' ⊆ B ∧
+      pairEnergy G A B +
+          eps ^ 4 * (↑A.card * ↑B.card) / (Fintype.card V : ℚ) ^ 2 ≤
+        pairEnergy G A' B' + pairEnergy G A' (B \ B') +
+          pairEnergy G (A \ A') B' + pairEnergy G (A \ A') (B \ B') := by
+  obtain ⟨A', B', hA', hB', hAc, hBc, hgain⟩ :=
+    pairEnergy_prod_gain_of_irregular G eps heps A B hirr
+  refine ⟨A', B', hA', hB', ?_⟩
+  -- Floor the exact cell gain `(|A′||B′|/n²)·ε²` by `ε⁴·|A||B|/n²`, then chain.
+  have hcard : (eps * A.card) * (eps * B.card) ≤ (↑A'.card : ℚ) * ↑B'.card :=
+    mul_le_mul hAc hBc (by positivity) (by positivity)
+  have he2 : (0 : ℚ) ≤ eps ^ 2 / (Fintype.card V : ℚ) ^ 2 := by positivity
+  have hfloor : eps ^ 4 * (↑A.card * ↑B.card) / (Fintype.card V : ℚ) ^ 2
+      ≤ (↑A'.card : ℚ) * ↑B'.card / (Fintype.card V : ℚ) ^ 2 * eps ^ 2 :=
+    calc eps ^ 4 * (↑A.card * ↑B.card) / (Fintype.card V : ℚ) ^ 2
+        = (eps * A.card) * (eps * B.card) * (eps ^ 2 / (Fintype.card V : ℚ) ^ 2) := by
+          ring
+      _ ≤ (↑A'.card : ℚ) * ↑B'.card * (eps ^ 2 / (Fintype.card V : ℚ) ^ 2) :=
+          mul_le_mul_of_nonneg_right hcard he2
+      _ = (↑A'.card : ℚ) * ↑B'.card / (Fintype.card V : ℚ) ^ 2 * eps ^ 2 := by ring
+  linarith [hgain, hfloor]
+
 end Szemeredi.RegularityOQ04Bridge

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -447,3 +447,54 @@ built green on retry attempt 4 after a sustained fleet SIGBUS/SIGSEGV write wind
   `Finset.biUnion`); the abstract atom gain already covers arbitrary finite index.
 - Wire `pairEnergy_prod_refinement_gain` + `exists_irregular_witness` (Bridge) into
   the whole-partition energy monotonicity feeding `afks_energy_iteration_count`.
+
+## Session 2026-07-08 (researcher-2) — Direct 2×2 ε⁴ increment from an irregular pair (no triangle detour)
+
+**Mode**: REVISIT (RICH) · **Outcome**: progress (2 theorems VERIFIED 0/0),
+branch research/szemeredi-oq04-prod-gain-r2
+
+### What I Did
+- `pairEnergy_prod_gain_of_irregular` (Bridge, PART XI): the clean capstone that
+  bypasses the entire one-sided A/B-side reduction (PARTS VI–X). The witness of
+  `exists_irregular_witness` gives `|d(A′,B′) − d(A,B)| > ε` measured **directly
+  against the coarse density** `d(A,B)` — which is exactly the mean identity the
+  2×2 variance-atom bound consumes. So refine BOTH coordinates at once into
+  `{A′,A∖A′}×{B′,B∖B′}` and feed `pairEnergy_prod_refinement_gain` verbatim
+  (`d := ε`), reading off the cell gain `(|A′||B′|/n²)·ε²`. No triangle detour, no
+  factor-½ tolerance loss, no mixed second-difference defect.
+- `pairEnergy_prod_gain_of_irregular_eps4` (Bridge, PART XI): floors the exact
+  cell gain to the AFKS-consumable `ε⁴·|A||B|/n²` via the witness size thresholds
+  `|A′|≥ε|A|`, `|B′|≥ε|B|` (`mul_le_mul` on the two size bounds, then scale by
+  `ε²/n² ≥ 0` through a 3-step `calc`/`ring`). This is the genuine ε⁴ energy jump
+  the strong-regularity iteration consumes — with none of the factor-¼ loss the
+  one-sided branches (S4/S5) incurred.
+
+### Key Findings
+- The one-sided machinery (S4–S10) was always a *detour*: it split the witness
+  deviation through a mixed density `d(A′,B)` because the increment lemmas then
+  available only consumed a whole-partner deviation. Once S7's
+  `pairEnergy_prod_refinement_gain` existed (consuming a deviation against the
+  whole *coarse* density), the witness plugs in with **zero** massaging — the
+  witness deviation IS a coarse-density deviation by definition of
+  `¬IsEpsilonRegular`. The two theorems are ~25 and ~20 lines.
+- `Finset.union_sdiff_of_subset hA' : A′ ∪ (A∖A′) = A` + `disjoint_sdiff_self_right`
+  turn the subset witness into an honest disjoint 2-split on each coordinate; the
+  gain lemma's hypothesis unions rewrite straight back to `A`,`B`.
+- Build: same `[7748/7748] … (1.2s)` zero-error elaboration then exit-135 SIGBUS at
+  the olean write; **succeeded on retry attempt 1** (`Build completed successfully
+  (7748 jobs)`). Purely the fleet-memory write race, not math.
+- **Worktree eaten again**: the sanctioned `.loom/worktrees/researcher-2-2` was
+  reclaimed by the janitor between claim and first write (clean + no persistent
+  process). Recreated off origin/main and committed a WIP stub immediately to make
+  it dirty/protected before doing real work.
+
+### Files Modified
+- proofs/Proofs/SzemerediRegularityOQ04Bridge.lean (+pairEnergy_prod_gain_of_irregular,
+  +pairEnergy_prod_gain_of_irregular_eps4; 19→21 theorems, 717→799 lines)
+- src/data/research/problems/szemeredi-regularity-oq-04.json (synced stale
+  Bridge/Energy leanFile counts: Bridge 301→799/8→21, Energy 264→533/5→11,def 0→1)
+
+### Next Steps
+- Sum the per-pair ε⁴ jump over all refined parts to get whole-partition energy
+  monotonicity, then feed `afks_energy_iteration_count` (N ≤ 2n²/ε²).
+- Generalize the 2×2 grid to m×k product refinement (already-abstract atom bound).

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -20,8 +20,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-08T19:45:20Z",
-    "iteration": 2,
-    "focus": "Verified the finiteness engine of the AFKS iteration (SzemerediRegularityOQ04.lean, 0 sorry/0 axiom): a bounded [0,1]-valued energy potential admits only finitely many delta-increment steps, instantiated on the gallery partitionEnergy. Next: reconstruct the energy-increment step lemma.",
+    "iteration": 3,
+    "focus": "Direct 2x2 ε⁴ energy increment from an irregular pair, bypassing the one-sided A/B-side triangle reduction: pairEnergy_prod_gain_of_irregular(_eps4) turn ¬IsEpsilonRegular into a definite pairEnergy jump ≥ ε⁴|A||B|/n² with no factor-¼ loss (VERIFIED 0/0). Next: sum over refined parts to feed afks_energy_iteration_count.",
     "blockers": [],
     "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
@@ -51,7 +51,9 @@
       "weighted_second_moment_atom_gain (SzemerediRegularityOQ04Energy.lean): atom gain in mean-identity form (Σwᵢ)μ²+w₀d²≤Σwᵢxᵢ² [VERIFIED]",
       "edgeDensity_union_mul_right + edge_count_union_right: B-side (second-coordinate) weighted-average/edge-count identities [VERIFIED]",
       "edgeDensity_prod_split: law of total density for a 2×2 refinement, |A||B|d(A,B)=Σ|Aᵢ||Bⱼ|d(Aᵢ,Bⱼ) [VERIFIED]",
-      "pairEnergy_prod_refinement_gain: the genuine ε⁴ 2×2 energy increment [VERIFIED — built green on retry attempt 4]"
+      "pairEnergy_prod_refinement_gain: the genuine ε⁴ 2×2 energy increment [VERIFIED — built green on retry attempt 4]",
+      "pairEnergy_prod_gain_of_irregular: direct 2x2 energy increment from an irregular pair (no triangle detour) — refine both coordinates via the witness (A′,A\\A′,B′,B\\B′), gain (|A′||B′|/n²)·ε² [VERIFIED]",
+      "pairEnergy_prod_gain_of_irregular_eps4: explicit ε⁴·|A||B|/n² energy jump from ¬IsEpsilonRegular, the AFKS-consumable floor (no factor-¼ loss of the one-sided branches) [VERIFIED]"
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
@@ -74,11 +76,11 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "Wire pairEnergy_prod_gain_of_irregular_eps4 into whole-partition energy monotonicity (sum the per-pair ε⁴ jump over refined parts) feeding afks_energy_iteration_count (N≤2n²/ε²).",
       "Full existential capstone from ¬IsEpsilonRegular directly: needs freshness of the INTERNALLY-chosen witness A′,B′, which the insert-model cannot guarantee — either work with the common refinement abstractly (dropping per-part ∉R conditions) or thread freshness as hypotheses",
       "Assemble the outer AFKS loop: feed partitionEnergy_gain_of_irregular_pair as the hstep of afks_energy_iteration_count to bound refinements by 2n²/ε²",
       "State two-level AFKS conclusion with dependent tolerance E:ℕ→(0,1]",
-      "Generalize 2×2 → m×k product refinement via Finset(Finset V) families + card_biUnion + edge_count over a Finset.biUnion product partition.",
-      "Wire pairEnergy_prod_refinement_gain + exists_irregular_witness into whole-partition energy monotonicity feeding afks_energy_iteration_count."
+      "Generalize 2×2 → m×k product refinement via Finset(Finset V) families + card_biUnion + edge_count over a Finset.biUnion product partition."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -171,8 +173,8 @@
     {
       "path": "Proofs/SzemerediRegularityOQ04Bridge.lean",
       "filename": "SzemerediRegularityOQ04Bridge.lean",
-      "lineCount": 301,
-      "theoremCount": 8,
+      "lineCount": 799,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -182,8 +184,8 @@
     {
       "path": "Proofs/SzemerediRegularityOQ04Energy.lean",
       "filename": "SzemerediRegularityOQ04Energy.lean",
-      "lineCount": 264,
-      "theoremCount": 5,
+      "lineCount": 533,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -191,5 +193,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04Energy.lean"
     }
   ],
-  "lastUpdate": "2026-07-08T19:45:20Z"
+  "lastUpdate": "2026-07-08T00:00:00Z"
 }


### PR DESCRIPTION
## Summary

Adds the clean capstone linking **ε-irregularity directly to a definite energy jump** for the strong (AFKS) regularity lemma, bypassing the entire one-sided A-side/B-side triangle reduction (PARTS VI–X) that earlier sessions built.

Two new theorems in `SzemerediRegularityOQ04Bridge.lean` (PART XI):

- **`pairEnergy_prod_gain_of_irregular`** — from `¬IsEpsilonRegular G ε A B`, extract the witness `(A′,B′)` and refine **both** coordinates at once into the grid `{A′,A∖A′}×{B′,B∖B′}`, yielding
  `pairEnergy G A B + (|A′||B′|/n²)·ε² ≤ Σ pairEnergy over the 4 cells`.
- **`pairEnergy_prod_gain_of_irregular_eps4`** — the AFKS-consumable floor: using the witness size thresholds `|A′|≥ε|A|`, `|B′|≥ε|B|`, the gain is at least
  `ε⁴·|A||B|/n²`.

## Why this is the right move

The witness deviation `|d(A′,B′) − d(A,B)| > ε` is measured **directly against the coarse density** `d(A,B)` — which is exactly the mean identity that Session 7's `pairEnergy_prod_refinement_gain` (the 2×2 variance-atom increment) consumes. So the witness plugs in verbatim: no decomposition through a mixed density `d(A′,B)`, no factor-½ tolerance loss (hence no factor-¼ loss in the floor), and no mixed second-difference defect. This is the direct realization of the ε⁴ increment that the earlier one-sided branches could only approximate at `ε²/(8n²)`.

The unions `A′∪(A∖A′)=A`, `B′∪(B∖B′)=B` are honest disjoint splits (`Finset.union_sdiff_of_subset`, `disjoint_sdiff_self_right`), so the gain lemma applies with `d := ε` after two rewrites.

## Verification

`./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04Bridge` → **Build completed successfully (7748 jobs)**, 0 sorry, 0 axioms. (First attempts hit the known exit-135 olean-write SIGBUS after a zero-error `[7748/7748] (1.2s)` elaboration; succeeded on retry — a fleet-memory write race, not a math error.)

Also syncs stale `leanFile` counts in the research JSON (Bridge 301→799 lines / 8→21 thm, Energy 264→533 lines / 5→11 thm / 0→1 def).

🤖 Generated with [Claude Code](https://claude.com/claude-code)