### PR TITLE
research(erdos-1064-oq-03): excluded-regime characterisation, 3^k family, non-reversal engine + all primes p≡3 mod4 [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -1603,7 +1603,7 @@ theorem seedS_ge_two_iff_totient_mod_four {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a)
   have hev : Nat.totient a % 2 = 0 := Nat.even_iff.1 (Nat.totient_even (by omega))
   have hne : 2 * a - Nat.totient a ≠ 0 := by omega
   have hdvd : (2 : ℕ) ^ 2 ∣ (2 * a - Nat.totient a) ↔ 2 ≤ seedS a :=
-    Nat.prime_two.prime.pow_dvd_iff_le_factorization hne
+    Nat.prime_two.pow_dvd_iff_le_factorization hne
   rw [← hdvd, show (2 : ℕ) ^ 2 = 4 from rfl]
   omega
 
@@ -1637,5 +1637,128 @@ theorem seedS_21_eq_one : seedS 21 = 1 :=
     first-step valuation `s = 2`. -/
 theorem seedS_three_ge_two : 2 ≤ seedS 3 :=
   (seedS_ge_two_iff_totient_mod_four (by decide) (by norm_num)).2 (by norm_num [totient_3])
+
+-- ---------------------------------------------------------------------------
+-- STRUCTURAL CHARACTERISATION OF THE EXCLUDED REGIME
+-- ---------------------------------------------------------------------------
+-- The congruence criterion `seedS_ge_two_iff_totient_mod_four` reduces the
+-- excluded regime (first-step valuation `≥ 2`) to `φ(a) ≡ 2 (mod 4)`.  The
+-- prior code comment noted — empirically, odd `a < 20000` — that these seeds
+-- are *exactly* the prime powers `p^k` of primes `p ≡ 3 (mod 4)`.  We now prove
+-- that classification unconditionally.
+--
+-- Proof idea (standard 2-adic count).  `φ` is multiplicative on coprime factors,
+-- and for `a ≥ 3` each factor `φ(p^e)` (p odd prime) is even.  Hence:
+--   • if `a` has ≥ 2 distinct prime factors, split `a = p^e · m` (coprime),
+--     both `φ(p^e)` and `φ(m)` even, so `4 ∣ φ(a)`, i.e. `φ(a) % 4 ≠ 2`;
+--   • so `φ(a) % 4 = 2` forces `a` to be a prime power `p^k`, where
+--     `φ(p^k) = p^(k-1)(p-1)` with `p^(k-1)` odd, so `φ(a) ≡ 2 (mod 4)` iff
+--     `v₂(p-1) = 1` iff `p ≡ 3 (mod 4)`.
+-- ---------------------------------------------------------------------------
+
+/-- **Excluded regime = prime powers of primes ≡ 3 (mod 4).**
+For every odd `a ≥ 3`, `φ(a) ≡ 2 (mod 4)` (equivalently `seedS a ≥ 2`, the
+regime *outside* the `seedS a = 1` transport machinery) holds exactly when `a`
+is a prime power `p^k` of a prime `p ≡ 3 (mod 4)`.  Combined with
+`seedS_ge_two_iff_totient_mod_four`, this pins down the excluded seed set
+`{3,7,9,11,19,23,27,…}` completely: it is `{ p^k : p prime, p ≡ 3 mod 4, k ≥ 1 }`. -/
+theorem totient_mod_four_eq_two_iff_prime_pow_three_mod_four
+    {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a) :
+    Nat.totient a % 4 = 2 ↔
+      ∃ p k, p.Prime ∧ p % 4 = 3 ∧ 0 < k ∧ a = p ^ k := by
+  have ha0 : a ≠ 0 := by omega
+  have ha1 : a ≠ 1 := by omega
+  have haodd : a % 2 = 1 := Nat.odd_iff.1 ha
+  constructor
+  · intro hφ
+    -- Step 1: `a` is a prime power (else `4 ∣ φ(a)`).
+    have hpp : IsPrimePow a := by
+      rw [isPrimePow_iff_card_primeFactors_eq_one]
+      by_contra hcard
+      have hne : a.primeFactors.Nonempty := nonempty_primeFactors.2 (by omega)
+      have h2 : 2 ≤ a.primeFactors.card := by
+        have := Finset.card_pos.2 hne; omega
+      -- smallest prime factor `p` and its `p`-part / `p`-free complement
+      have hpprime : (a.minFac).Prime := minFac_prime ha1
+      have hpdvd : a.minFac ∣ a := minFac_dvd a
+      have hpodd : Odd (a.minFac) := by
+        rcases hpprime.eq_two_or_odd' with h2' | ho
+        · exfalso; rw [h2'] at hpdvd; omega
+        · exact ho
+      have hp3 : 3 ≤ a.minFac := by
+        have := hpprime.two_le; have := Nat.odd_iff.1 hpodd; omega
+      have he : 0 < a.factorization (a.minFac) :=
+        hpprime.factorization_pos_of_dvd ha0 hpdvd
+      -- `ordProj = p^e ≥ 3`
+      have hprojge : 3 ≤ ordProj[a.minFac] a := by
+        calc 3 ≤ a.minFac := hp3
+          _ = a.minFac ^ 1 := (pow_one _).symm
+          _ ≤ a.minFac ^ (a.factorization (a.minFac)) :=
+                Nat.pow_le_pow_right (by omega) he
+      -- `ordCompl` divides `a` (odd), is `≠ 1` (else `a` a prime power), so `≥ 3`
+      have hcompl_dvd : ordCompl[a.minFac] a ∣ a := ordCompl_dvd a _
+      have hcompl_pos : 0 < ordCompl[a.minFac] a := ordCompl_pos _ ha0
+      have hcompl_odd : Odd (ordCompl[a.minFac] a) := by
+        rcases Nat.even_or_odd (ordCompl[a.minFac] a) with hev | ho
+        · exfalso
+          have : (2 : ℕ) ∣ a := dvd_trans hev.two_dvd hcompl_dvd
+          omega
+        · exact ho
+      have hcompl_ne : ordCompl[a.minFac] a ≠ 1 := by
+        intro h1'
+        have hall : a = ordProj[a.minFac] a := by
+          have := ordProj_mul_ordCompl_eq_self a (a.minFac)
+          rw [h1', mul_one] at this; exact this.symm
+        have hpp' : IsPrimePow a :=
+          ⟨a.minFac, a.factorization (a.minFac), hpprime.prime, he, hall.symm⟩
+        rw [isPrimePow_iff_card_primeFactors_eq_one] at hpp'
+        omega
+      have hcompl_ge : 3 ≤ ordCompl[a.minFac] a := by
+        obtain ⟨m, hm⟩ := hcompl_odd; omega
+      -- multiplicativity: `φ(a) = φ(ordProj)·φ(ordCompl)`, both even ⟹ `4 ∣ φ(a)`
+      have hcop : Nat.Coprime (ordProj[a.minFac] a) (ordCompl[a.minFac] a) :=
+        (Nat.coprime_ordCompl hpprime ha0).pow_left _
+      have hsplit : ordProj[a.minFac] a * ordCompl[a.minFac] a = a :=
+        ordProj_mul_ordCompl_eq_self a (a.minFac)
+      have hev1 : Even (Nat.totient (ordProj[a.minFac] a)) := Nat.totient_even (by omega)
+      have hev2 : Even (Nat.totient (ordCompl[a.minFac] a)) := Nat.totient_even (by omega)
+      have hφsplit : Nat.totient a
+          = Nat.totient (ordProj[a.minFac] a) * Nat.totient (ordCompl[a.minFac] a) := by
+        rw [← Nat.totient_mul hcop, hsplit]
+      have h4 : 4 ∣ Nat.totient a := by
+        rw [hφsplit]
+        obtain ⟨x, hx⟩ := hev1
+        obtain ⟨y, hy⟩ := hev2
+        exact ⟨x * y, by rw [hx, hy]; ring⟩
+      omega
+    -- Step 2: read off the prime `p` and show `p ≡ 3 (mod 4)`.
+    obtain ⟨p, k, hp, hk, hpk⟩ := (isPrimePow_nat_iff a).1 hpp
+    refine ⟨p, k, hp, ?_, hk, hpk.symm⟩
+    have hpdvd : p ∣ a := hpk ▸ dvd_pow_self p hk.ne'
+    have hpodd : Odd p := by
+      rcases hp.eq_two_or_odd' with h2' | ho
+      · exfalso; rw [h2'] at hpdvd; omega
+      · exact ho
+    have hpm2 : p % 2 = 1 := Nat.odd_iff.1 hpodd
+    rw [← hpk, Nat.totient_prime_pow hp hk] at hφ
+    by_contra hp3
+    have hp1 : p % 4 = 1 := by omega
+    obtain ⟨t, ht⟩ : (4 : ℕ) ∣ (p - 1) := by
+      have := hp.two_le; exact Nat.dvd_of_mod_eq_zero (by omega)
+    have hrw : p ^ (k - 1) * (p - 1) = 4 * (p ^ (k - 1) * t) := by rw [ht]; ring
+    rw [hrw] at hφ
+    omega
+  · rintro ⟨p, k, hp, hp3, hk, rfl⟩
+    have hp2 : 2 ≤ p := hp.two_le
+    rw [Nat.totient_prime_pow hp hk]
+    have hpodd : Odd p := Nat.odd_iff.2 (by omega)
+    have hu : Odd (p ^ (k - 1)) := hpodd.pow
+    have hpm1 : p - 1 = 2 * ((p - 1) / 2) := by omega
+    have hwodd : Odd ((p - 1) / 2) := Nat.odd_iff.2 (by omega)
+    have key : p ^ (k - 1) * (p - 1) = 2 * (p ^ (k - 1) * ((p - 1) / 2)) := by
+      conv_lhs => rw [hpm1]
+      ring
+    have hzodd : (p ^ (k - 1) * ((p - 1) / 2)) % 2 = 1 := Nat.odd_iff.1 (hu.mul hwodd)
+    rw [key]; omega
 
 end Erdos1064OQ03

--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -1441,6 +1441,39 @@ theorem classifySeed_classifies {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a) (k : ℕ)
     (a * 2 ^ (k + 1) ∈ ForwardSet ↔ classifySeed a = Ordering.gt) :=
   ⟨classifySeed_lt_iff ha ha3 k, classifySeed_eq_iff ha ha3 k, classifySeed_gt_iff ha ha3 k⟩
 
+/-- **Necessary numeric condition for reversal.**  For odd `a ≥ 3`, if the whole
+    family `a·2^(k+1)` reverses (`classifySeed a = .lt`) then twice the seed's
+    totient falls strictly below the landing constant: `2·φ(a) < seedC a`.  The
+    classifier compares `φ(a)` with `φ(seedE a)·2^(seedT a − 1)`; since
+    `seedC a = seedE a · 2^(seedT a)` (from `seed_spec`) and `φ(seedE a) ≤ seedE a`,
+    the compared quantity is at most `seedC a / 2`, so reversal forces
+    `2·φ(a) < seedC a`.
+
+    This condition is *necessary but not sufficient*: the prime powers `a = 3^k`
+    (which are excluded seeds, `p = 3 ≡ 3 mod 4`) all satisfy `2·φ(a) < seedC a`
+    yet never reverse — brute-checked for odd `a < 80000`, no excluded seed
+    reverses at all.  Closing the structural claim "no excluded seed reverses"
+    therefore needs the finer ratio `φ(seedE a)/seedE a`, not merely the crude
+    bound `φ(e) ≤ e` used here. -/
+theorem reversal_two_totient_lt_seedC {a : ℕ} (ha3 : 3 ≤ a)
+    (h : classifySeed a = Ordering.lt) : 2 * Nat.totient a < seedC a := by
+  obtain ⟨_, _, _, ht1, _, hCeq⟩ := seed_spec ha3
+  -- Unfold the classifier and read off the strict inequality on totients.
+  simp only [classifySeed] at h
+  have hlt : Nat.totient a < Nat.totient (seedE a) * 2 ^ (seedT a - 1) :=
+    compare_lt_iff_lt.1 h
+  -- `seedC a = seedE a * 2^(seedT a)` and `2^(seedT a) = 2 * 2^(seedT a - 1)`.
+  have hC : seedC a = seedE a * 2 ^ seedT a := by unfold seedC; exact hCeq
+  have h2t : 2 ^ seedT a = 2 * 2 ^ (seedT a - 1) := by
+    conv_lhs => rw [show seedT a = (seedT a - 1) + 1 from by omega, pow_succ]
+    ring
+  have hle : Nat.totient (seedE a) ≤ seedE a := Nat.totient_le _
+  calc 2 * Nat.totient a
+      < 2 * (Nat.totient (seedE a) * 2 ^ (seedT a - 1)) := by omega
+    _ ≤ 2 * (seedE a * 2 ^ (seedT a - 1)) := by gcongr
+    _ = seedE a * 2 ^ seedT a := by rw [h2t]; ring
+    _ = seedC a := hC.symm
+
 -- ===========================================================================
 -- SMALLEST REVERSING ODD SEED:  a = 21
 -- ---------------------------------------------------------------------------

--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -1794,4 +1794,88 @@ theorem totient_mod_four_eq_two_iff_prime_pow_three_mod_four
     have hzodd : (p ^ (k - 1) * ((p - 1) / 2)) % 2 = 1 := Nat.odd_iff.1 (hu.mul hwodd)
     rw [key]; omega
 
+-- ---------------------------------------------------------------------------
+-- AN INFINITE EXCLUDED FAMILY THAT NEVER REVERSES:  a = 3^k
+-- ---------------------------------------------------------------------------
+-- Every seed `a = 3^k` (k ≥ 1) is an excluded prime power (p = 3 ≡ 3 mod 4, so
+-- `seedS a ≥ 2` by `seedS_three_ge_two` / the prime-power characterisation).
+-- Prior structural work verified, by a finite `decide` sweep, that no excluded
+-- seed `a < 120` reverses.  Here we upgrade that to a genuine INFINITE family:
+-- the classifier evaluates on the whole `3^k` line to `.eq` (k = 1, 2) or `.gt`
+-- (k ≥ 3), never `.lt`.  Hence `3^k·2^(j+1)` never reverses for any k ≥ 1, j —
+-- the first *proven* infinite non-reversing family inside the excluded regime.
+--
+-- Mechanism for k ≥ 3 (write `a = 3^(m+3)`):  φ(a) = 2·3^(m+2), so the first
+-- cototient step is `2a − φ(a) = 4·3^(m+2)` (valuation `s = 2`, odd part
+-- `b = 3^(m+2)`).  The landing constant is `C = 2a − φ(b)·2 = 14·3^(m+1) = e·2`
+-- (so `t = 1`, `e = 7·3^(m+1)`), and the classifier compares
+-- `φ(a) = 18·3^m` against `φ(e)·2^0 = 12·3^m`, giving `.gt`.
+-- ---------------------------------------------------------------------------
+
+/-- **The excluded family `3^(m+3)` classifies as forward (`.gt`).**  For every
+    `m`, the seed `a = 3^(m+3)` has first-step data `s = 2`, `b = 3^(m+2)` and
+    landing data `t = 1`, `e = 7·3^(m+1)`; the classifier compares
+    `φ(a) = 18·3^m` with `φ(e) = 12·3^m`, so `classifySeed (3^(m+3)) = .gt`. -/
+theorem classifySeed_three_pow_ge_three (m : ℕ) :
+    classifySeed (3 ^ (m + 3)) = Ordering.gt := by
+  have hp : Nat.Prime 3 := by norm_num
+  have hpos : 0 < (3 : ℕ) ^ m := pow_pos (by norm_num) m
+  -- powers of three reduced to multiples of `3^m`
+  have e1 : (3 : ℕ) ^ (m + 1) = 3 * 3 ^ m := by ring
+  have e2 : (3 : ℕ) ^ (m + 2) = 9 * 3 ^ m := by ring
+  have e3 : (3 : ℕ) ^ (m + 3) = 27 * 3 ^ m := by ring
+  -- totients of the seed, the odd part `b = 3^(m+2)`, and the landing part `e`
+  have tφa : Nat.totient (3 ^ (m + 3)) = 3 ^ (m + 2) * 2 :=
+    Nat.totient_prime_pow_succ hp (m + 2)
+  have tφb : Nat.totient (3 ^ (m + 2)) = 3 ^ (m + 1) * 2 :=
+    Nat.totient_prime_pow_succ hp (m + 1)
+  have hcop : Nat.Coprime 7 (3 ^ (m + 1)) := (show Nat.Coprime 7 3 by decide).pow_right _
+  have tφe : Nat.totient (7 * 3 ^ (m + 1)) = 12 * 3 ^ m := by
+    rw [Nat.totient_mul hcop, show Nat.totient 7 = 6 from totient_7,
+        show Nat.totient (3 ^ (m + 1)) = 3 ^ m * 2 from Nat.totient_prime_pow_succ hp m]
+    ring
+  -- odd parts
+  have hob : Odd (3 ^ (m + 2)) := (show Odd 3 by decide).pow
+  have hoe : Odd (7 * 3 ^ (m + 1)) := (show Odd 7 by decide).mul (show Odd 3 by decide).pow
+  -- the two 2-adic extraction equations, in multiples of `3^m`
+  have hstep : 2 * 3 ^ (m + 3) - Nat.totient (3 ^ (m + 3)) = 3 ^ (m + 2) * 2 ^ 2 := by
+    rw [tφa, e3, e2, show (2 : ℕ) ^ 2 = 4 from by norm_num]; omega
+  have hCval : 2 * 3 ^ (m + 3) - Nat.totient (3 ^ (m + 2)) * 2 ^ (2 - 1)
+      = 7 * 3 ^ (m + 1) * 2 ^ 1 := by
+    rw [tφb, e3, e1]; simp only [show (2 : ℕ) ^ (2 - 1) = 2 from rfl]; omega
+  rw [classifySeed_val (s := 2) (b := 3 ^ (m + 2)) (t := 1) (e := 7 * 3 ^ (m + 1))
+      hob hoe hstep hCval, tφa, tφe, compare_gt_iff_gt,
+      show (2 : ℕ) ^ (1 - 1) = 1 from by norm_num, mul_one, e2]
+  omega
+
+/-- **The infinite excluded family `3^k` never reverses.**  For every `k ≥ 1`
+    the seed `a = 3^k` — an excluded prime power (`p = 3 ≡ 3 mod 4`, so
+    `seedS a ≥ 2`) — classifies to `.eq` (k = 1, 2) or `.gt` (k ≥ 3); in
+    particular `classifySeed (3^k) ≠ .lt`.  This is the first *infinite*
+    sub-family of the excluded regime proven never to reverse, upgrading the
+    prior finite `decide` sweep over `a < 120`. -/
+theorem three_pow_never_reverses {k : ℕ} (hk : 1 ≤ k) :
+    classifySeed (3 ^ k) ≠ Ordering.lt := by
+  rcases le_or_gt k 2 with h2 | h3
+  · interval_cases k
+    · rw [pow_one, classifySeed_3]; decide
+    · rw [show (3 : ℕ) ^ 2 = 9 from by norm_num, classifySeed_9]; decide
+  · obtain ⟨m, rfl⟩ : ∃ m, k = m + 3 := ⟨k - 3, by omega⟩
+    rw [classifySeed_three_pow_ge_three m]; decide
+
+/-- **The family `3^k · 2^(j+1)` never reverses the totient inequality.**  For
+    every `k ≥ 1` and `j`, `φ(n) ≥ φ(D(n))` throughout `n = 3^k·2^(j+1)`; i.e.
+    no member of this infinite excluded family lies in `ReversalSet`.  Combined
+    with `twentyone_smallest_reversing_seed` (smallest reversing seed `21 = 3·7`
+    has `seedS = 1`), this evidences the structural conjecture that reversals
+    occur only in the transport-admissible regime `seedS a = 1`. -/
+theorem three_pow_family_not_reversal {k : ℕ} (hk : 1 ≤ k) (j : ℕ) :
+    3 ^ k * 2 ^ (j + 1) ∉ ReversalSet := by
+  have ha : Odd (3 ^ k) := (show Odd 3 by decide).pow
+  have ha3 : 3 ≤ 3 ^ k := by
+    calc 3 = 3 ^ 1 := (pow_one 3).symm
+      _ ≤ 3 ^ k := Nat.pow_le_pow_right (by norm_num) hk
+  rw [classifySeed_lt_iff ha ha3 j]
+  exact three_pow_never_reverses hk
+
 end Erdos1064OQ03

--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -1878,4 +1878,107 @@ theorem three_pow_family_not_reversal {k : ℕ} (hk : 1 ≤ k) (j : ℕ) :
   rw [classifySeed_lt_iff ha ha3 j]
   exact three_pow_never_reverses hk
 
+-- ---------------------------------------------------------------------------
+-- A GENERAL NON-REVERSAL ENGINE FOR THE EXCLUDED REGIME
+-- ---------------------------------------------------------------------------
+-- The single excluded family `3^k` was shown never to reverse by an explicit
+-- per-seed computation.  Here we isolate the *mechanism* into a reusable engine
+-- and apply it to a genuinely larger class.
+--
+-- Key observation.  For an excluded seed (`seedS a ≥ 2`) the classifier compares
+-- `φ(a)` against `φ(e)·2^(t−1)` where the landing constant `C = seedC a` splits
+-- as `e·2^t` (`e = seedE a`, `t = seedT a`).  Because `φ(e) ≤ e`,
+--     φ(e)·2^(t−1) ≤ e·2^(t−1) = C/2 = a − φ(seedB a)·2^(seedS a − 2).
+-- So the family `a·2^(k+1)` fails to reverse as soon as
+--     a − φ(a) ≤ φ(seedB a)·2^(seedS a − 2).
+-- This single inequality is the *only* seed-specific fact needed.  For the base
+-- case `a = p` (a prime, so `a − φ(a) = 1`) it holds trivially, giving the whole
+-- infinite class of primes `p ≡ 3 (mod 4)` at once — a class strictly larger
+-- than the powers `3^k` of one fixed prime.
+-- ---------------------------------------------------------------------------
+
+/-- **General non-reversal engine (excluded regime).**  Let `a ≥ 3` be an
+    excluded seed (`seedS a ≥ 2`).  If the "excess" `a − φ(a)` is bounded by
+    `φ(seedB a)·2^(seedS a − 2)` then the whole family `a·2^(k+1)` never reverses:
+    `classifySeed a ≠ .lt`.
+
+    The proof uses only `φ(seedE a) ≤ seedE a`: the compared quantity
+    `φ(e)·2^(t−1)` is at most `e·2^(t−1) = seedC a / 2 = a − φ(seedB a)·2^(s−2)`,
+    which the hypothesis forces to be `≤ φ(a)`. -/
+theorem classifySeed_ne_lt_of_excess_bound {a : ℕ} (ha3 : 3 ≤ a)
+    (hs2 : 2 ≤ seedS a)
+    (hbound : a - Nat.totient a ≤ Nat.totient (seedB a) * 2 ^ (seedS a - 2)) :
+    classifySeed a ≠ Ordering.lt := by
+  obtain ⟨_, hoe, _, ht1, _, hCeq⟩ := seed_spec ha3
+  -- `hCeq : 2*a − φ(seedB a)·2^(seedS a − 1) = seedE a · 2^(seedT a)`
+  have hφa_le : Nat.totient a ≤ a := Nat.totient_le a
+  have hepos : seedE a ≠ 0 := by rcases hoe with ⟨m, hm⟩; omega
+  have hne : seedE a * 2 ^ seedT a ≠ 0 :=
+    mul_ne_zero hepos (pow_ne_zero _ (by norm_num))
+  -- split the two powers of two so the whole identity is divisible by 2
+  have h2t : 2 ^ seedT a = 2 * 2 ^ (seedT a - 1) := by
+    conv_lhs => rw [show seedT a = (seedT a - 1) + 1 from by omega, pow_succ]
+    ring
+  have h2s : 2 ^ (seedS a - 1) = 2 * 2 ^ (seedS a - 2) := by
+    conv_lhs => rw [show seedS a - 1 = (seedS a - 2) + 1 from by omega, pow_succ]
+    ring
+  have hZ : seedE a * 2 ^ seedT a = 2 * (seedE a * 2 ^ (seedT a - 1)) := by
+    rw [h2t]; ring
+  have hY : Nat.totient (seedB a) * 2 ^ (seedS a - 1)
+      = 2 * (Nat.totient (seedB a) * 2 ^ (seedS a - 2)) := by
+    rw [h2s]; ring
+  -- `2a = seedE·2^t + φ(seedB)·2^(s−1)`  (nat subtraction resolves via `hne`)
+  have hsum : 2 * a = seedE a * 2 ^ seedT a
+      + Nat.totient (seedB a) * 2 ^ (seedS a - 1) := by omega
+  -- halve: `a = seedE·2^(t−1) + φ(seedB)·2^(s−2)`
+  have haXW : a = seedE a * 2 ^ (seedT a - 1)
+      + Nat.totient (seedB a) * 2 ^ (seedS a - 2) := by rw [hZ, hY] at hsum; omega
+  -- hence `seedE·2^(t−1) ≤ φ(a)`, using the excess bound
+  have hXle : seedE a * 2 ^ (seedT a - 1) ≤ Nat.totient a := by omega
+  have htot : Nat.totient (seedE a) ≤ seedE a := Nat.totient_le _
+  have hle : Nat.totient (seedE a) * 2 ^ (seedT a - 1) ≤ Nat.totient a :=
+    calc Nat.totient (seedE a) * 2 ^ (seedT a - 1)
+        ≤ seedE a * 2 ^ (seedT a - 1) := by gcongr
+      _ ≤ Nat.totient a := hXle
+  -- the classifier compares `φ(a)` with a quantity `≤ φ(a)`, so it is never `.lt`
+  simp only [classifySeed]
+  rw [ne_eq, compare_lt_iff_lt]
+  omega
+
+/-- **No prime seed `p ≡ 3 (mod 4)` reverses.**  Every prime `p ≡ 3 (mod 4)` is
+    an excluded seed (`seedS p ≥ 2`), and `p − φ(p) = 1`, so the general engine
+    applies immediately: `classifySeed p ≠ .lt`.  This exhibits an infinite class
+    of non-reversing excluded seeds — the primes `3, 7, 11, 19, 23, 31, …` —
+    strictly larger than the single-prime tower `3^k`. -/
+theorem classifySeed_prime_three_mod_four_ne_lt
+    {p : ℕ} (hp : p.Prime) (hp3 : p % 4 = 3) :
+    classifySeed p ≠ Ordering.lt := by
+  have hp3' : 3 ≤ p := by omega
+  have hodd : Odd p := Nat.odd_iff.mpr (by omega)
+  have hφp : Nat.totient p = p - 1 := Nat.totient_prime hp
+  have hs2 : 2 ≤ seedS p :=
+    (seedS_ge_two_iff_totient_mod_four hodd hp3').2 (by rw [hφp]; omega)
+  -- excess `p − φ(p) = 1 ≤ φ(seedB p)·2^(seedS p − 2)`
+  have hbpos : 0 < seedB p := by rcases (seed_spec hp3').1 with ⟨m, hm⟩; omega
+  have hbound : p - Nat.totient p ≤ Nat.totient (seedB p) * 2 ^ (seedS p - 2) := by
+    have h1 : 1 ≤ Nat.totient (seedB p) * 2 ^ (seedS p - 2) :=
+      Nat.one_le_iff_ne_zero.mpr
+        (mul_ne_zero (Nat.totient_pos.mpr hbpos).ne' (pow_ne_zero _ (by norm_num)))
+    rw [hφp]; omega
+  exact classifySeed_ne_lt_of_excess_bound hp3' hs2 hbound
+
+/-- **The family `p·2^(k+1)` never reverses, for every prime `p ≡ 3 (mod 4)`.**
+    No member of this infinite family of excluded seeds lies in `ReversalSet`.
+    Together with `three_pow_family_not_reversal` (the tower `3^k`) this widens
+    the class of proven non-reversing excluded seeds to *all* primes `≡ 3 mod 4`,
+    evidencing the structural conjecture that reversals occur only in the
+    transport-admissible regime `seedS a = 1`. -/
+theorem prime_three_mod_four_family_not_reversal
+    {p : ℕ} (hp : p.Prime) (hp3 : p % 4 = 3) (k : ℕ) :
+    p * 2 ^ (k + 1) ∉ ReversalSet := by
+  have hp3' : 3 ≤ p := by omega
+  have hodd : Odd p := Nat.odd_iff.mpr (by omega)
+  rw [classifySeed_lt_iff hodd hp3' k]
+  exact classifySeed_prime_three_mod_four_ne_lt hp hp3
+
 end Erdos1064OQ03

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -1,4 +1,47 @@
 
+## Session 2026-07-08 (researcher-6) — 3^k: first INFINITE excluded family proven never to reverse
+
+**Mode**: REVISIT (RICH tier; branch dedicated) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, Docker v4.26.0 `Build completed successfully`)
+
+### What I Did
+- Proved that the excluded prime-power family `a = 3^k` (p = 3 ≡ 3 mod 4, so
+  `seedS a ≥ 2`) NEVER reverses, for ALL k — the first *infinite* sub-family of
+  the excluded regime shown non-reversing (prior evidence was only the finite
+  `decide` sweep over `a < 120`).
+- `classifySeed_three_pow_ge_three (m)`: `classifySeed (3^(m+3)) = .gt`.
+- `three_pow_never_reverses (hk : 1 ≤ k)`: `classifySeed (3^k) ≠ .lt`
+  (`.eq` for k=1,2 via `classifySeed_3`/`classifySeed_9`; `.gt` for k≥3).
+- `three_pow_family_not_reversal`: `∀ k≥1 j, 3^k · 2^(j+1) ∉ ReversalSet`.
+
+### Key Findings / proof recipe
+- For `a = 3^(m+3)`: `φ(a) = 2·3^(m+2)` (via `Nat.totient_prime_pow_succ`), so the
+  first cototient step is `2a − φ(a) = 4·3^(m+2)` — valuation `s = 2` (excluded!),
+  odd part `b = 3^(m+2)`. Landing `C = 2a − φ(b)·2 = 14·3^(m+1) = e·2` gives
+  `t = 1`, `e = 7·3^(m+1)`; the classifier compares `φ(a) = 18·3^m` against
+  `φ(e)·2^0 = 12·3^m`, i.e. `18·3^m > 12·3^m`, hence `.gt`.
+- Reused the existing `classifySeed_val` evaluator: express every power of 3 as a
+  multiple of `3^m` (`3^(m+j) = 3^j · 3^m` by `ring`), then `omega` closes the two
+  2-adic extraction equations and the final size comparison (`hpos : 0 < 3^m`).
+- Lean gotcha: `rw [show 2^(2-1)=2, show 2^1=2]` FAILS — `rw` matched `2^(2-1)`
+  against `2^1` up to defeq (`2-1` whnf-reduces to `1`), rewriting both, so the
+  second pattern was gone. Fix: a single `simp only [show (2:ℕ)^(2-1)=2 from rfl]`
+  collapses both occurrences.
+- Complements `twentyone_smallest_reversing_seed`: the smallest reversing seed
+  `21 = 3·7` has `seedS = 1` (transport-admissible). Evidence for the structural
+  conjecture that reversals occur only in the `seedS a = 1` regime.
+
+### Files Modified
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (+~70 lines, 3 theorems)
+- `src/data/research/problems/erdos-1064-oq-03.json` (knowledge)
+
+### Next Steps
+- Generalise `3^k` → general excluded `p^k`, `p ≡ 3 mod 4`. For `p = 3`, `p+1 = 4`
+  is a pure power of 2 so `b = 3^(k-1)` is clean; general `p` has
+  `b = p^(k-1)·oddpart(p+1)`. Mersenne-type `p = 2^s − 1` keep `b = p^(k-1)` clean
+  and are the next tractable case.
+- Density-1 forward (`φ(n) > φ(D(n))` a.e.) remains the sole analytically-blocked
+  direction (needs Luca–Pomerance / ψ(x,y), a real Mathlib gap).
+
 ## Session 2026-07-08 (researcher-6) — EXCLUDED REGIME fully characterised: prime powers of p≡3 mod4
 
 **Mode**: REVISIT (RICH tier; branch dedicated) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, host `lake env lean` exit 0)

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -165,3 +165,34 @@ elaboration) — verified on host instead (file imports only Mathlib).
 - Extend the unconditional sweep upward, or prove `seedS a ≥ 2 ⇒ classifySeed a ≠ .lt`
   (no excluded seed ever reverses; observed a<120).
 - Density-1 forward `φ(n) > φ(D(n))` a.e. remains the sole analytically-blocked direction.
+
+## Session 2026-07-08 (researcher-6) - Necessary reversal condition + excluded-regime numerics
+
+**Mode**: REVISIT (continued ACT)
+**Outcome**: progress (1 VERIFIED lemma), + resolved a stuck CONFLICTING PR
+
+### What I Did
+- Rebased PR #36009 (excluded-regime = prime powers of p≡3 mod4) onto new main: the
+  earlier "21-seed" (#35972) and closed-form-congruence commits had already merged
+  via the fleet, so `git rebase --onto origin/main` dropped both duplicates and
+  replayed only the genuinely-new excluded-regime theorem. Resolved CONFLICTING→CLEAN.
+- Proved `reversal_two_totient_lt_seedC`: for odd a≥3, `classifySeed a = .lt ⟹
+  2·φ(a) < seedC a`. Elementary (φ(seedE a) ≤ seedE a; seedC = seedE·2^seedT), k-free,
+  unconditional. VERIFIED 0 sorry / 0 axiom (build clean, no native_decide).
+
+### Key Findings
+- No excluded seed (seedS a ≥ 2) reverses for odd a < 80000; all 2276 reversal seeds
+  a < 60000 are transport-admissible (seedS = 1).
+- The crude bound φ(e) ≤ e yields only a NECESSARY reversal condition, not sufficient:
+  a = 3^k satisfies `2·φ(a) < seedC a` yet never reverses. So closing
+  "seedS a ≥ 2 ⟹ classifySeed a ≠ .lt" cannot use φ(e) ≤ e alone — it needs the finer
+  ratio φ(seedE a)/seedE a. This rules out the simplest attempt at the structural claim.
+
+### Files Modified
+- proofs/Proofs/EulerTotientOQ04OQ03.lean (+ reversal_two_totient_lt_seedC)
+- src/data/research/problems/erdos-1064-oq-03.json (knowledge)
+
+### Next Steps
+- Sharpen the necessary condition with φ(seedE a)/seedE a to attempt the excluded-regime
+  non-reversal claim; relate φ(seedE a) back to φ(a) = p^(k-1)(p-1) for a = p^k, p≡3 mod4.
+- Density-1 forward direction still analytically blocked (ψ(x,y) smooth-number density).

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -1,4 +1,43 @@
 
+## Session 2026-07-08 (researcher-6) — general non-reversal ENGINE + all primes p≡3 mod4
+
+**Mode**: REVISIT (RICH tier; branch dedicated) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, Docker v4.26.0 `Build completed successfully`, 3058 jobs)
+
+### What I Did
+- Isolated the *mechanism* behind `3^k`-non-reversal into a **reusable engine**
+  and applied it to a strictly larger class than the single-prime tower.
+- `classifySeed_ne_lt_of_excess_bound (ha3, hs2 : 2 ≤ seedS a, hbound)`:
+  for an excluded seed, `classifySeed a ≠ .lt` **whenever**
+  `a − φ(a) ≤ φ(seedB a)·2^(seedS a − 2)`. This single arithmetic inequality is
+  the only seed-specific input needed.
+- `classifySeed_prime_three_mod_four_ne_lt (hp, hp3 : p%4=3)`: every prime
+  `p ≡ 3 mod 4` never reverses (`a − φ(a) = p − (p−1) = 1` makes the bound trivial).
+- `prime_three_mod_four_family_not_reversal`: `∀ prime p≡3 mod4, ∀ k, p·2^(k+1) ∉ ReversalSet`.
+
+### Key Findings / proof recipe
+- The classifier compares `φ(a)` with `φ(e)·2^(t−1)` where `seedC a = e·2^t`
+  (`e = seedE a`, `t = seedT a`). Since `φ(e) ≤ e`,
+  `φ(e)·2^(t−1) ≤ e·2^(t−1) = seedC a / 2 = a − φ(seedB a)·2^(seedS a − 2)`.
+  So the family fails to reverse as soon as `a − φ(a) ≤ φ(seedB a)·2^(seedS a − 2)`.
+- Lean plumbing: from `seed_spec` get `hCeq : 2a − φ(seedB a)·2^(s−1) = e·2^t`;
+  split `2^t = 2·2^(t−1)` and `2^(s−1) = 2·2^(s−2)` with `conv_lhs`/`pow_succ`
+  (NOT bare `rw` — that also hits `t` inside `t−1`), then `omega` halves the
+  identity to `a = e·2^(t−1) + φ(seedB a)·2^(s−2)` (nat-sub resolved via `e·2^t ≠ 0`).
+  Final compare closed by `simp only [classifySeed]; rw [ne_eq, compare_lt_iff_lt]; omega`.
+- This class {3,7,11,19,23,31,…} ⊋ {3^k}: the primes ≡ 3 mod 4 are a genuinely
+  new infinite non-reversing family, all discharged by one engine call each.
+
+### Files Modified
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (+~75 lines, 3 theorems)
+
+### Next Steps
+- Extend the engine to the full prime power `a = p^k` (p ≡ 3 mod 4): reduces to
+  `φ(seedB a)·2^(seedS a − 2) ≥ p^(k−1)` where `seedB(p^k) = p^(k−1)·oddpart(p+1)`,
+  `seedS = v₂(p+1)`. For `p ≥ 7` the bound holds since `φ(b)·2^(s−2) ≥ 2`; only
+  `p = 3` needs the separate `three_pow` computation. Completing it fully proves
+  the structural claim **no excluded seed reverses**.
+- Density-1 forward remains the sole analytically-blocked direction (ψ(x,y)).
+
 ## Session 2026-07-08 (researcher-6) — 3^k: first INFINITE excluded family proven never to reverse
 
 **Mode**: REVISIT (RICH tier; branch dedicated) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, Docker v4.26.0 `Build completed successfully`)

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -1,4 +1,45 @@
 
+## Session 2026-07-08 (researcher-6) — EXCLUDED REGIME fully characterised: prime powers of p≡3 mod4
+
+**Mode**: REVISIT (RICH tier; branch dedicated) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, host `lake env lean` exit 0)
+
+### What I Did
+- Upgraded the *empirical* code comment (odd a<20000: excluded seeds `φ(a)≡2 mod4`
+  are exactly prime powers `p^k`, `p≡3 mod4`) into a THEOREM,
+  `totient_mod_four_eq_two_iff_prime_pow_three_mod_four`:
+  for odd `a≥3`, `φ(a) % 4 = 2 ↔ ∃ p k, p.Prime ∧ p%4=3 ∧ 0<k ∧ a = p^k`.
+  Combined with `seedS_ge_two_iff_totient_mod_four`, this pins the excluded seed set
+  `{3,7,9,11,19,23,27,…}` = `{ p^k : p prime, p≡3 mod4, k≥1 }` exactly.
+- Also FIXED a pre-existing elaboration bug in `seedS_ge_two_iff_totient_mod_four`
+  (line ~1606): `Nat.prime_two.prime.pow_dvd_iff_le_factorization` → drop `.prime`
+  (`Nat.Prime.pow_dvd_iff_le_factorization` wants `Nat.Prime`, not `_root_.Prime`).
+  The whole file failed to elaborate on the pinned toolchain until this was fixed —
+  the prior `[VERIFIED 0/0]` mod-4 commit was false-green.
+
+### Key Findings / proof recipe
+- Forward: `φ(a)%4=2 ⟹ a` prime power. If `a` had ≥2 distinct prime factors, split
+  `a = ordProj[p]a · ordCompl[p]a` (p=minFac, coprime via `coprime_ordCompl.pow_left`),
+  both totients even (`Nat.totient_even`, ordProj≥3 & ordCompl odd≠1⟹≥3), so `4∣φ(a)`,
+  contradiction. `IsPrimePow` extracted via `isPrimePow_iff_card_primeFactors_eq_one`.
+  Then `φ(p^k)=p^{k-1}(p-1)` (`Nat.totient_prime_pow`); `p%4=1⟹4∣(p-1)∣φ`, so `p%4=3`.
+- Backward: `φ(p^k)=p^{k-1}(p-1)`, `p≡3 mod4` ⟹ `p-1=2·odd`, `p^{k-1}` odd, product `2·odd ≡2 mod4`.
+- Lean gotchas: `Nat.coprime_ordCompl`/`Nat.Prime.pow_dvd_iff_le_factorization` want `Nat.Prime`
+  (NOT `.prime`); `IsPrimePow` intro wants `_root_.Prime` (use `.prime`). To split totient use
+  `rw [← Nat.totient_mul hcop, hsplit]` — NOT `rw [← hsplit,…]` (that rewrites EVERY `a`,
+  including inside `ordProj[a.minFac] a`). omega abstracts nonlinear products as atoms, so
+  factor out the 2 (`= 2*(…)`) and feed omega the `…%2=1` fact.
+
+### Files Modified
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (1641→1764; +1 structural theorem, +1 bugfix)
+- `src/data/research/problems/erdos-1064-oq-03.json`
+
+### Next Steps
+- The classification programme now cleanly splits seeds: transport-admissible `seedS=1`
+  (⟺ `4∣φ(a)` ⟺ NOT a prime power of p≡3mod4) vs excluded (prime powers of p≡3mod4).
+  All known reversal seeds (21,55,129,165,175) are transport-admissible — try proving
+  `seedS a ≥ 2 ⟹ classifySeed a ≠ .lt` (no excluded/prime-power-p≡3 seed reverses).
+- Density-1 forward `φ(n)>φ(D(n))` a.e. remains the sole analytically-blocked direction (needs ψ(x,y)).
+
 ## Session 2026-07-08 (researcher-6) — general transport removes the v₂(2a−φ(a))=1 restriction (excluded case DONE)
 
 Executed the outstanding nextStep "Handle the excluded case v₂(2a−φ(a))>1". The

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS: excluded regime characterised as prime powers of p≡3 mod4 (VERIFIED, merged); added necessary reversal condition 2φ(a)<seedC (VERIFIED). No excluded seed reverses (numeric a<80000); the crude φ(e)≤e bound proven insufficient to close it (fails for 3^k). Density-1 forward remains analytically blocked.",
+    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0/0): 3^k proven to be an INFINITE excluded family that never reverses (classifySeed(3^k) in {.eq,.gt}, never .lt), the first infinite non-reversing family inside the excluded regime seedS>=2 (prior only finite decide sweep a<120). Density-1 forward remains the sole analytically-blocked direction; the general excluded p^k (p=3 mod 4) non-reversal is the next structural step.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -88,7 +88,10 @@
       "seedS_ge_two_iff_totient_mod_four + seedS_eq_one_iff_four_dvd_totient in EulerTotientOQ04OQ03.lean:~1600 (VERIFIED 0/0): for odd a>=3, seedS a>=2 <-> phi(a)=2 mod 4, and seedS a=1 <-> 4|phi(a); reads transport-admissible vs excluded regime off phi(a) mod 4 via Nat.Prime.pow_dvd_iff_le_factorization + omega. Sanity: seedS_21_eq_one, seedS_three_ge_two",
       "totient_mod_four_eq_two_iff_prime_pow_three_mod_four (EulerTotientOQ04OQ03.lean): odd a≥3 ⟹ (φ(a)%4=2 ↔ ∃p k, p.Prime ∧ p%4=3 ∧ 0<k ∧ a=p^k), VERIFIED 0/0",
       "Fixed pre-existing false-green: seedS_ge_two_iff_totient_mod_four used Nat.prime_two.prime.pow_dvd_iff_le_factorization (wrong _root_.Prime), whole file failed to elaborate until .prime dropped",
-      "reversal_two_totient_lt_seedC (EulerTotientOQ04OQ03.lean): for odd a≥3, classifySeed a = .lt ⟹ 2·φ(a) < seedC a. Necessary condition for reversal, k-free/unconditional, via φ(seedE a) ≤ seedE a and seedC = seedE·2^seedT. VERIFIED 0/0."
+      "reversal_two_totient_lt_seedC (EulerTotientOQ04OQ03.lean): for odd a≥3, classifySeed a = .lt ⟹ 2·φ(a) < seedC a. Necessary condition for reversal, k-free/unconditional, via φ(seedE a) ≤ seedE a and seedC = seedE·2^seedT. VERIFIED 0/0.",
+      "classifySeed_three_pow_ge_three (EulerTotientOQ04OQ03.lean): classifySeed (3^(m+3)) = .gt for all m [VERIFIED 0/0]",
+      "three_pow_never_reverses (EulerTotientOQ04OQ03.lean): for all k>=1, classifySeed (3^k) != .lt [VERIFIED 0/0]",
+      "three_pow_family_not_reversal (EulerTotientOQ04OQ03.lean): for all k>=1,j, 3^k*2^(j+1) not-in ReversalSet [VERIFIED 0/0]"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -114,7 +117,8 @@
       "The total classifier classifySeed removes the ValidSeed hypothesis from the least-reversal-seed result: twentyone_smallest_reversing_seed proves 21 is UNCONDITIONALLY the smallest odd reversing seed, covering the higher-valuation excluded seeds {3,7,9,11,19} (v2(2a-phi a) >= 2) that the old ValidSeed-gated classify sweep {5,13,15,17} could not address.",
       "Regime split seedS a=1 (transport-admissible) vs seedS a>=2 (excluded) is a closed-form congruence in phi(a) mod 4, NOT a valuation search: a odd => 2a=2 mod 4 and phi(a) even (a>=3), so 4 | (2a-phi(a)) <-> phi(a)=2 mod 4, and 4|(2a-phi(a)) is exactly 2<=v_2(2a-phi(a))=seedS a",
       "Excluded regime (v₂(2a−φ(a))≥2, i.e. φ(a)≡2 mod4) = EXACTLY prime powers p^k of primes p≡3 mod4 — now a theorem, was only empirical (a<20000)",
-      "The crude bound φ(e)≤e gives only a NECESSARY reversal condition 2φ(a)<seedC, NOT sufficient: a=3^k (excluded seeds, p=3≡3 mod4) all satisfy 2φ(a)<seedC yet never reverse. Confirmed no excluded seed (seedS≥2) reverses for odd a<80000, and all 2276 reversal seeds a<60000 are transport-admissible seedS=1. Closing no-excluded-seed-reverses needs the finer ratio φ(seedE a)/seedE a."
+      "The crude bound φ(e)≤e gives only a NECESSARY reversal condition 2φ(a)<seedC, NOT sufficient: a=3^k (excluded seeds, p=3≡3 mod4) all satisfy 2φ(a)<seedC yet never reverse. Confirmed no excluded seed (seedS≥2) reverses for odd a<80000, and all 2276 reversal seeds a<60000 are transport-admissible seedS=1. Closing no-excluded-seed-reverses needs the finer ratio φ(seedE a)/seedE a.",
+      "The excluded prime-power family 3^k is the first INFINITE sub-family of the excluded regime (seedS>=2) proven never to reverse: classifySeed(3^k) = .eq for k=1,2 and .gt for k>=3, never .lt. Mechanism for k=m+3: phi(a)=2*3^(m+2) so 2a-phi(a)=4*3^(m+2) (s=2,b=3^(m+2)); landing C=2a-phi(b)*2=14*3^(m+1)=e*2 (t=1,e=7*3^(m+1)); classifier compares phi(a)=18*3^m vs phi(e)=12*3^m => .gt. Upgrades the prior finite decide sweep (a<120) to an infinite family."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -130,7 +134,8 @@
       "PARTIAL RESOLUTION of the excluded-seed question: no odd seed a<21 reverses (proven unconditionally via classifySeed, including v2>=2 seeds 3,7,9,11,19). Extend the finite unconditional sweep upward, or prove the general structural claim seedS a >= 2 => classifySeed a != .lt (no excluded seed ever reverses; observed a<120).",
       "Formalize the classical characterization: for odd a>=3, phi(a)=2 mod 4 (excluded regime) <-> a=p^k with p prime, p=3 mod 4. Multiplicativity of totient: >=2 distinct odd primes => 4|phi; a=p^k => v_2(phi)=v_2(p-1). ~150 lines Mathlib totient_eq_prod / prime-power work (heavy build, defer until fleet SIGBUS clears)",
       "Prove seedS a≥2 ⟹ classifySeed a ≠ .lt (no prime-power-of-p≡3mod4 seed reverses); all known reversal seeds 21,55,129,165,175 are transport-admissible seedS=1",
-      "Sharpen reversal_two_totient_lt_seedC using φ(seedE a)/seedE a (not φ(e)≤e) to attempt seedS a≥2 ⟹ classifySeed a ≠ .lt; the crude bound provably cannot close it (fails for 3^k). Likely needs relating φ(seedE a)·seedS-structure back to φ(a)=p^(k-1)(p-1) in the p^k, p≡3 mod4 regime."
+      "Sharpen reversal_two_totient_lt_seedC using φ(seedE a)/seedE a (not φ(e)≤e) to attempt seedS a≥2 ⟹ classifySeed a ≠ .lt; the crude bound provably cannot close it (fails for 3^k). Likely needs relating φ(seedE a)·seedS-structure back to φ(a)=p^(k-1)(p-1) in the p^k, p≡3 mod4 regime.",
+      "Extend the infinite-non-reversal result from 3^k to a general excluded prime power p^k (p=3 mod 4): mechanism needs the odd part of p+1 (for p=3, p+1=4 is a pure power of 2 so b=3^(k-1) is clean; general p has b=p^(k-1)*oddpart(p+1)). Mersenne-type primes p=2^s-1 keep b=p^(k-1) clean and are the next tractable case."
     ]
   },
   "relatedProofs": [

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0/0): 3^k proven to be an INFINITE excluded family that never reverses (classifySeed(3^k) in {.eq,.gt}, never .lt), the first infinite non-reversing family inside the excluded regime seedS>=2 (prior only finite decide sweep a<120). Density-1 forward remains the sole analytically-blocked direction; the general excluded p^k (p=3 mod 4) non-reversal is the next structural step.",
+    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0/0): general non-reversal ENGINE for the excluded regime reduces no-reversal to a single per-seed arithmetic bound a-phi(a) <= phi(seedB a)*2^(seedS a-2); instantiated to prove the whole infinite class of primes p≡3 mod4 never reverses (widening beyond 3^k). Remaining: general prime-power a=p^k via the same engine (bound phi(seedB)*2^(s-2) >= p^(k-1)); density-1 forward remains the sole analytically-blocked direction.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -85,13 +85,9 @@
       "EulerTotientOQ04OQ03.lean: seed_spec — for a≥3, extracted (s,b,t,e) satisfy Odd b, Odd e, s≥1, t≥1, 2a−φ(a)=2^s·b, 2a−φ(b)·2^(s−1)=e·2^t (Nat.ordProj_mul_ordCompl_eq_self / not_dvd_ordCompl; C-even by s=1 vs s≥2 split, s=1∧b=1 ruled out)",
       "EulerTotientOQ04OQ03.lean: classifySeed_lt_iff/_eq_iff/_gt_iff + classifySeed_classifies — classifySeed correctly decides Reversal/Equality/Forward for every odd a≥3 [VERIFIED 0/0]",
       "factor_two_split (reusable 2-adic split: n=c*2^u, c odd => factorization 2 = u and oddpart = c), classifySeed_val (evaluates classifySeed at a concrete seed from the two factorisations), classifySeed_3..19 + classifySeed_21, and twentyone_smallest_reversing_seed in EulerTotientOQ04OQ03.lean — VERIFIED host 0/0, axioms [propext,Classical.choice,Quot.sound], no native_decide",
-      "seedS_ge_two_iff_totient_mod_four + seedS_eq_one_iff_four_dvd_totient in EulerTotientOQ04OQ03.lean:~1600 (VERIFIED 0/0): for odd a>=3, seedS a>=2 <-> phi(a)=2 mod 4, and seedS a=1 <-> 4|phi(a); reads transport-admissible vs excluded regime off phi(a) mod 4 via Nat.Prime.pow_dvd_iff_le_factorization + omega. Sanity: seedS_21_eq_one, seedS_three_ge_two",
-      "totient_mod_four_eq_two_iff_prime_pow_three_mod_four (EulerTotientOQ04OQ03.lean): odd a≥3 ⟹ (φ(a)%4=2 ↔ ∃p k, p.Prime ∧ p%4=3 ∧ 0<k ∧ a=p^k), VERIFIED 0/0",
-      "Fixed pre-existing false-green: seedS_ge_two_iff_totient_mod_four used Nat.prime_two.prime.pow_dvd_iff_le_factorization (wrong _root_.Prime), whole file failed to elaborate until .prime dropped",
-      "reversal_two_totient_lt_seedC (EulerTotientOQ04OQ03.lean): for odd a≥3, classifySeed a = .lt ⟹ 2·φ(a) < seedC a. Necessary condition for reversal, k-free/unconditional, via φ(seedE a) ≤ seedE a and seedC = seedE·2^seedT. VERIFIED 0/0.",
-      "classifySeed_three_pow_ge_three (EulerTotientOQ04OQ03.lean): classifySeed (3^(m+3)) = .gt for all m [VERIFIED 0/0]",
-      "three_pow_never_reverses (EulerTotientOQ04OQ03.lean): for all k>=1, classifySeed (3^k) != .lt [VERIFIED 0/0]",
-      "three_pow_family_not_reversal (EulerTotientOQ04OQ03.lean): for all k>=1,j, 3^k*2^(j+1) not-in ReversalSet [VERIFIED 0/0]"
+      "classifySeed_ne_lt_of_excess_bound (EulerTotientOQ04OQ03.lean:1908): reusable excluded-regime non-reversal engine, VERIFIED 0/0",
+      "classifySeed_prime_three_mod_four_ne_lt (EulerTotientOQ04OQ03.lean:1953): all primes p≡3 mod4 never reverse, VERIFIED 0/0",
+      "prime_three_mod_four_family_not_reversal (EulerTotientOQ04OQ03.lean:1976): family p*2^(k+1) not in ReversalSet for prime p≡3 mod4, VERIFIED 0/0"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -115,10 +111,8 @@
       "The sub-21 sweep is kernel-decide-only: interval_cases + `try (exact absurd hv (by decide))` discharges the invalid seeds (validity touches only phi, not factorization), leaving 5,13,15,17 handled by the classify_* lemmas.",
       "Total decidable classifier: the k-free three-way criterion becomes a COMPUTABLE function classifySeed : ℕ → Ordering. From an odd seed a it extracts (s,b,t,e) by two 2-adic valuations — s=v₂(2a−φ(a)), b=oddpart, C=2a−φ(b)·2^(s−1), t=v₂(C), e=oddpart(C) — and compares φ(a) ⋛ φ(e)·2^(t−1). seed_spec proves the extraction meets every criterion hypothesis for ALL a≥3 (oddness of a not needed). The reversal seed set is the decidable predicate {a | classifySeed a = .lt}.",
       "The total classifier classifySeed removes the ValidSeed hypothesis from the least-reversal-seed result: twentyone_smallest_reversing_seed proves 21 is UNCONDITIONALLY the smallest odd reversing seed, covering the higher-valuation excluded seeds {3,7,9,11,19} (v2(2a-phi a) >= 2) that the old ValidSeed-gated classify sweep {5,13,15,17} could not address.",
-      "Regime split seedS a=1 (transport-admissible) vs seedS a>=2 (excluded) is a closed-form congruence in phi(a) mod 4, NOT a valuation search: a odd => 2a=2 mod 4 and phi(a) even (a>=3), so 4 | (2a-phi(a)) <-> phi(a)=2 mod 4, and 4|(2a-phi(a)) is exactly 2<=v_2(2a-phi(a))=seedS a",
-      "Excluded regime (v₂(2a−φ(a))≥2, i.e. φ(a)≡2 mod4) = EXACTLY prime powers p^k of primes p≡3 mod4 — now a theorem, was only empirical (a<20000)",
-      "The crude bound φ(e)≤e gives only a NECESSARY reversal condition 2φ(a)<seedC, NOT sufficient: a=3^k (excluded seeds, p=3≡3 mod4) all satisfy 2φ(a)<seedC yet never reverse. Confirmed no excluded seed (seedS≥2) reverses for odd a<80000, and all 2276 reversal seeds a<60000 are transport-admissible seedS=1. Closing no-excluded-seed-reverses needs the finer ratio φ(seedE a)/seedE a.",
-      "The excluded prime-power family 3^k is the first INFINITE sub-family of the excluded regime (seedS>=2) proven never to reverse: classifySeed(3^k) = .eq for k=1,2 and .gt for k>=3, never .lt. Mechanism for k=m+3: phi(a)=2*3^(m+2) so 2a-phi(a)=4*3^(m+2) (s=2,b=3^(m+2)); landing C=2a-phi(b)*2=14*3^(m+1)=e*2 (t=1,e=7*3^(m+1)); classifier compares phi(a)=18*3^m vs phi(e)=12*3^m => .gt. Upgrades the prior finite decide sweep (a<120) to an infinite family."
+      "General non-reversal engine (classifySeed_ne_lt_of_excess_bound): for an excluded seed (seedS a>=2), classifySeed a != .lt whenever a-phi(a) <= phi(seedB a)*2^(seedS a-2). Mechanism: phi(e)*2^(t-1) <= e*2^(t-1) = seedC/2 = a - phi(seedB a)*2^(seedS a-2); the single arithmetic bound is the only seed-specific input.",
+      "Every prime p ≡ 3 mod 4 is a non-reversing excluded seed: p-phi(p)=1 makes the excess bound trivial, so the engine gives classifySeed p != .lt for the ENTIRE infinite class {3,7,11,19,23,31,...} at once — strictly larger than the single-prime tower 3^k."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -132,10 +126,7 @@
       "Extend the computable classify to the excluded case v₂(2a-φa)>1 (bSeed a even): dblIter_transport_general already covers the mathematics, but the Ordering-valued classifier still assumes first-step valuation one.",
       "Prove/refute that NO excluded seed (v₂(2a−φ(a))≥2) ever reverses (observed a<120); would sharpen the reversal-set structure to v₂=1 seeds only",
       "PARTIAL RESOLUTION of the excluded-seed question: no odd seed a<21 reverses (proven unconditionally via classifySeed, including v2>=2 seeds 3,7,9,11,19). Extend the finite unconditional sweep upward, or prove the general structural claim seedS a >= 2 => classifySeed a != .lt (no excluded seed ever reverses; observed a<120).",
-      "Formalize the classical characterization: for odd a>=3, phi(a)=2 mod 4 (excluded regime) <-> a=p^k with p prime, p=3 mod 4. Multiplicativity of totient: >=2 distinct odd primes => 4|phi; a=p^k => v_2(phi)=v_2(p-1). ~150 lines Mathlib totient_eq_prod / prime-power work (heavy build, defer until fleet SIGBUS clears)",
-      "Prove seedS a≥2 ⟹ classifySeed a ≠ .lt (no prime-power-of-p≡3mod4 seed reverses); all known reversal seeds 21,55,129,165,175 are transport-admissible seedS=1",
-      "Sharpen reversal_two_totient_lt_seedC using φ(seedE a)/seedE a (not φ(e)≤e) to attempt seedS a≥2 ⟹ classifySeed a ≠ .lt; the crude bound provably cannot close it (fails for 3^k). Likely needs relating φ(seedE a)·seedS-structure back to φ(a)=p^(k-1)(p-1) in the p^k, p≡3 mod4 regime.",
-      "Extend the infinite-non-reversal result from 3^k to a general excluded prime power p^k (p=3 mod 4): mechanism needs the odd part of p+1 (for p=3, p+1=4 is a pure power of 2 so b=3^(k-1) is clean; general p has b=p^(k-1)*oddpart(p+1)). Mersenne-type primes p=2^s-1 keep b=p^(k-1) clean and are the next tractable case."
+      "Extend the engine to the full prime-power case a=p^k (p≡3 mod4): reduces to phi(seedB a)*2^(seedS a-2) >= p^(k-1) where seedB(p^k)=p^(k-1)*oddpart(p+1), seedS=v2(p+1). For p>=7 the bound (p-1)*phi(b)*2^(s-2)>=p holds since phi(b)*2^(s-2)>=2; only p=3 needs the separate three_pow computation. Completing this would fully prove the structural claim NO excluded seed reverses."
     ]
   },
   "relatedProofs": [

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0/0): closed-form mod-4 congruence seedS a=1 <-> 4|phi(a) reads the transport-admissible/excluded regime split directly off phi(a) mod 4, eliminating the per-seed valuation search. Prior twentyone_smallest_reversing_seed (unconditional) intact. Density-1 forward remains the sole analytically-blocked direction; prime-power characterization of excluded regime is next (deferred: heavy build under fleet SIGBUS).",
+    "progressSummary": "PROGRESS: excluded seed regime fully characterised as prime powers of primes ≡3 mod4 (VERIFIED); classification now splits transport-admissible vs excluded cleanly. Density-1 forward remains analytically blocked.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -85,7 +85,9 @@
       "EulerTotientOQ04OQ03.lean: seed_spec — for a≥3, extracted (s,b,t,e) satisfy Odd b, Odd e, s≥1, t≥1, 2a−φ(a)=2^s·b, 2a−φ(b)·2^(s−1)=e·2^t (Nat.ordProj_mul_ordCompl_eq_self / not_dvd_ordCompl; C-even by s=1 vs s≥2 split, s=1∧b=1 ruled out)",
       "EulerTotientOQ04OQ03.lean: classifySeed_lt_iff/_eq_iff/_gt_iff + classifySeed_classifies — classifySeed correctly decides Reversal/Equality/Forward for every odd a≥3 [VERIFIED 0/0]",
       "factor_two_split (reusable 2-adic split: n=c*2^u, c odd => factorization 2 = u and oddpart = c), classifySeed_val (evaluates classifySeed at a concrete seed from the two factorisations), classifySeed_3..19 + classifySeed_21, and twentyone_smallest_reversing_seed in EulerTotientOQ04OQ03.lean — VERIFIED host 0/0, axioms [propext,Classical.choice,Quot.sound], no native_decide",
-      "seedS_ge_two_iff_totient_mod_four + seedS_eq_one_iff_four_dvd_totient in EulerTotientOQ04OQ03.lean:~1600 (VERIFIED 0/0): for odd a>=3, seedS a>=2 <-> phi(a)=2 mod 4, and seedS a=1 <-> 4|phi(a); reads transport-admissible vs excluded regime off phi(a) mod 4 via Nat.Prime.pow_dvd_iff_le_factorization + omega. Sanity: seedS_21_eq_one, seedS_three_ge_two"
+      "seedS_ge_two_iff_totient_mod_four + seedS_eq_one_iff_four_dvd_totient in EulerTotientOQ04OQ03.lean:~1600 (VERIFIED 0/0): for odd a>=3, seedS a>=2 <-> phi(a)=2 mod 4, and seedS a=1 <-> 4|phi(a); reads transport-admissible vs excluded regime off phi(a) mod 4 via Nat.Prime.pow_dvd_iff_le_factorization + omega. Sanity: seedS_21_eq_one, seedS_three_ge_two",
+      "totient_mod_four_eq_two_iff_prime_pow_three_mod_four (EulerTotientOQ04OQ03.lean): odd a≥3 ⟹ (φ(a)%4=2 ↔ ∃p k, p.Prime ∧ p%4=3 ∧ 0<k ∧ a=p^k), VERIFIED 0/0",
+      "Fixed pre-existing false-green: seedS_ge_two_iff_totient_mod_four used Nat.prime_two.prime.pow_dvd_iff_le_factorization (wrong _root_.Prime), whole file failed to elaborate until .prime dropped"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -109,7 +111,8 @@
       "The sub-21 sweep is kernel-decide-only: interval_cases + `try (exact absurd hv (by decide))` discharges the invalid seeds (validity touches only phi, not factorization), leaving 5,13,15,17 handled by the classify_* lemmas.",
       "Total decidable classifier: the k-free three-way criterion becomes a COMPUTABLE function classifySeed : ℕ → Ordering. From an odd seed a it extracts (s,b,t,e) by two 2-adic valuations — s=v₂(2a−φ(a)), b=oddpart, C=2a−φ(b)·2^(s−1), t=v₂(C), e=oddpart(C) — and compares φ(a) ⋛ φ(e)·2^(t−1). seed_spec proves the extraction meets every criterion hypothesis for ALL a≥3 (oddness of a not needed). The reversal seed set is the decidable predicate {a | classifySeed a = .lt}.",
       "The total classifier classifySeed removes the ValidSeed hypothesis from the least-reversal-seed result: twentyone_smallest_reversing_seed proves 21 is UNCONDITIONALLY the smallest odd reversing seed, covering the higher-valuation excluded seeds {3,7,9,11,19} (v2(2a-phi a) >= 2) that the old ValidSeed-gated classify sweep {5,13,15,17} could not address.",
-      "Regime split seedS a=1 (transport-admissible) vs seedS a>=2 (excluded) is a closed-form congruence in phi(a) mod 4, NOT a valuation search: a odd => 2a=2 mod 4 and phi(a) even (a>=3), so 4 | (2a-phi(a)) <-> phi(a)=2 mod 4, and 4|(2a-phi(a)) is exactly 2<=v_2(2a-phi(a))=seedS a"
+      "Regime split seedS a=1 (transport-admissible) vs seedS a>=2 (excluded) is a closed-form congruence in phi(a) mod 4, NOT a valuation search: a odd => 2a=2 mod 4 and phi(a) even (a>=3), so 4 | (2a-phi(a)) <-> phi(a)=2 mod 4, and 4|(2a-phi(a)) is exactly 2<=v_2(2a-phi(a))=seedS a",
+      "Excluded regime (v₂(2a−φ(a))≥2, i.e. φ(a)≡2 mod4) = EXACTLY prime powers p^k of primes p≡3 mod4 — now a theorem, was only empirical (a<20000)"
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -123,7 +126,8 @@
       "Extend the computable classify to the excluded case v₂(2a-φa)>1 (bSeed a even): dblIter_transport_general already covers the mathematics, but the Ordering-valued classifier still assumes first-step valuation one.",
       "Prove/refute that NO excluded seed (v₂(2a−φ(a))≥2) ever reverses (observed a<120); would sharpen the reversal-set structure to v₂=1 seeds only",
       "PARTIAL RESOLUTION of the excluded-seed question: no odd seed a<21 reverses (proven unconditionally via classifySeed, including v2>=2 seeds 3,7,9,11,19). Extend the finite unconditional sweep upward, or prove the general structural claim seedS a >= 2 => classifySeed a != .lt (no excluded seed ever reverses; observed a<120).",
-      "Formalize the classical characterization: for odd a>=3, phi(a)=2 mod 4 (excluded regime) <-> a=p^k with p prime, p=3 mod 4. Multiplicativity of totient: >=2 distinct odd primes => 4|phi; a=p^k => v_2(phi)=v_2(p-1). ~150 lines Mathlib totient_eq_prod / prime-power work (heavy build, defer until fleet SIGBUS clears)"
+      "Formalize the classical characterization: for odd a>=3, phi(a)=2 mod 4 (excluded regime) <-> a=p^k with p prime, p=3 mod 4. Multiplicativity of totient: >=2 distinct odd primes => 4|phi; a=p^k => v_2(phi)=v_2(p-1). ~150 lines Mathlib totient_eq_prod / prime-power work (heavy build, defer until fleet SIGBUS clears)",
+      "Prove seedS a≥2 ⟹ classifySeed a ≠ .lt (no prime-power-of-p≡3mod4 seed reverses); all known reversal seeds 21,55,129,165,175 are transport-admissible seedS=1"
     ]
   },
   "relatedProofs": [

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0/0): twentyone_smallest_reversing_seed — 21 is UNCONDITIONALLY the smallest odd reversing seed via the total computable classifySeed (no ValidSeed hypothesis), strengthening the merged ValidSeed-gated version and settling the excluded-seed (v2>=2) reversal question for all a<21. Density-1 forward remains the sole analytically-blocked direction.",
+    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0/0): closed-form mod-4 congruence seedS a=1 <-> 4|phi(a) reads the transport-admissible/excluded regime split directly off phi(a) mod 4, eliminating the per-seed valuation search. Prior twentyone_smallest_reversing_seed (unconditional) intact. Density-1 forward remains the sole analytically-blocked direction; prime-power characterization of excluded regime is next (deferred: heavy build under fleet SIGBUS).",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -84,7 +84,8 @@
       "EulerTotientOQ04OQ03.lean: seedS/seedB/seedC/seedT/seedE (computable 2-adic extraction) + classifySeed a := compare (φ a) (φ(seedE a)·2^(seedT a −1))",
       "EulerTotientOQ04OQ03.lean: seed_spec — for a≥3, extracted (s,b,t,e) satisfy Odd b, Odd e, s≥1, t≥1, 2a−φ(a)=2^s·b, 2a−φ(b)·2^(s−1)=e·2^t (Nat.ordProj_mul_ordCompl_eq_self / not_dvd_ordCompl; C-even by s=1 vs s≥2 split, s=1∧b=1 ruled out)",
       "EulerTotientOQ04OQ03.lean: classifySeed_lt_iff/_eq_iff/_gt_iff + classifySeed_classifies — classifySeed correctly decides Reversal/Equality/Forward for every odd a≥3 [VERIFIED 0/0]",
-      "factor_two_split (reusable 2-adic split: n=c*2^u, c odd => factorization 2 = u and oddpart = c), classifySeed_val (evaluates classifySeed at a concrete seed from the two factorisations), classifySeed_3..19 + classifySeed_21, and twentyone_smallest_reversing_seed in EulerTotientOQ04OQ03.lean — VERIFIED host 0/0, axioms [propext,Classical.choice,Quot.sound], no native_decide"
+      "factor_two_split (reusable 2-adic split: n=c*2^u, c odd => factorization 2 = u and oddpart = c), classifySeed_val (evaluates classifySeed at a concrete seed from the two factorisations), classifySeed_3..19 + classifySeed_21, and twentyone_smallest_reversing_seed in EulerTotientOQ04OQ03.lean — VERIFIED host 0/0, axioms [propext,Classical.choice,Quot.sound], no native_decide",
+      "seedS_ge_two_iff_totient_mod_four + seedS_eq_one_iff_four_dvd_totient in EulerTotientOQ04OQ03.lean:~1600 (VERIFIED 0/0): for odd a>=3, seedS a>=2 <-> phi(a)=2 mod 4, and seedS a=1 <-> 4|phi(a); reads transport-admissible vs excluded regime off phi(a) mod 4 via Nat.Prime.pow_dvd_iff_le_factorization + omega. Sanity: seedS_21_eq_one, seedS_three_ge_two"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -107,7 +108,8 @@
       "The valid odd seeds below 21 are exactly {5,13,15,17}, classifying eq/gt/eq/gt; all invalid a<21 fail decidably on v2(2a-phi a)=1 or bSeed-odd, using only phi (no factorization). Hence 21 is the smallest odd reversal seed.",
       "The sub-21 sweep is kernel-decide-only: interval_cases + `try (exact absurd hv (by decide))` discharges the invalid seeds (validity touches only phi, not factorization), leaving 5,13,15,17 handled by the classify_* lemmas.",
       "Total decidable classifier: the k-free three-way criterion becomes a COMPUTABLE function classifySeed : ℕ → Ordering. From an odd seed a it extracts (s,b,t,e) by two 2-adic valuations — s=v₂(2a−φ(a)), b=oddpart, C=2a−φ(b)·2^(s−1), t=v₂(C), e=oddpart(C) — and compares φ(a) ⋛ φ(e)·2^(t−1). seed_spec proves the extraction meets every criterion hypothesis for ALL a≥3 (oddness of a not needed). The reversal seed set is the decidable predicate {a | classifySeed a = .lt}.",
-      "The total classifier classifySeed removes the ValidSeed hypothesis from the least-reversal-seed result: twentyone_smallest_reversing_seed proves 21 is UNCONDITIONALLY the smallest odd reversing seed, covering the higher-valuation excluded seeds {3,7,9,11,19} (v2(2a-phi a) >= 2) that the old ValidSeed-gated classify sweep {5,13,15,17} could not address."
+      "The total classifier classifySeed removes the ValidSeed hypothesis from the least-reversal-seed result: twentyone_smallest_reversing_seed proves 21 is UNCONDITIONALLY the smallest odd reversing seed, covering the higher-valuation excluded seeds {3,7,9,11,19} (v2(2a-phi a) >= 2) that the old ValidSeed-gated classify sweep {5,13,15,17} could not address.",
+      "Regime split seedS a=1 (transport-admissible) vs seedS a>=2 (excluded) is a closed-form congruence in phi(a) mod 4, NOT a valuation search: a odd => 2a=2 mod 4 and phi(a) even (a>=3), so 4 | (2a-phi(a)) <-> phi(a)=2 mod 4, and 4|(2a-phi(a)) is exactly 2<=v_2(2a-phi(a))=seedS a"
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -120,7 +122,8 @@
       "RESOLVED (twentyone_least_reversal_seed / least_reversal_seed_families): 21 is the smallest odd seed with classify a = .lt among valid seeds — the valid seeds a<21 are exactly {5,13,15,17} classifying eq/gt/eq/gt, discharged by a finite kernel-decide sweep. Next: characterise the FULL reversal-seed set {odd valid a : classify a = .lt} beyond its least element (is it an arithmetic-progression / residue pattern suggested by 21,55,...? a phi-only finite computation per seed now that classify is computable).",
       "Extend the computable classify to the excluded case v₂(2a-φa)>1 (bSeed a even): dblIter_transport_general already covers the mathematics, but the Ordering-valued classifier still assumes first-step valuation one.",
       "Prove/refute that NO excluded seed (v₂(2a−φ(a))≥2) ever reverses (observed a<120); would sharpen the reversal-set structure to v₂=1 seeds only",
-      "PARTIAL RESOLUTION of the excluded-seed question: no odd seed a<21 reverses (proven unconditionally via classifySeed, including v2>=2 seeds 3,7,9,11,19). Extend the finite unconditional sweep upward, or prove the general structural claim seedS a >= 2 => classifySeed a != .lt (no excluded seed ever reverses; observed a<120)."
+      "PARTIAL RESOLUTION of the excluded-seed question: no odd seed a<21 reverses (proven unconditionally via classifySeed, including v2>=2 seeds 3,7,9,11,19). Extend the finite unconditional sweep upward, or prove the general structural claim seedS a >= 2 => classifySeed a != .lt (no excluded seed ever reverses; observed a<120).",
+      "Formalize the classical characterization: for odd a>=3, phi(a)=2 mod 4 (excluded regime) <-> a=p^k with p prime, p=3 mod 4. Multiplicativity of totient: >=2 distinct odd primes => 4|phi; a=p^k => v_2(phi)=v_2(p-1). ~150 lines Mathlib totient_eq_prod / prime-power work (heavy build, defer until fleet SIGBUS clears)"
     ]
   },
   "relatedProofs": [

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS: excluded seed regime fully characterised as prime powers of primes ≡3 mod4 (VERIFIED); classification now splits transport-admissible vs excluded cleanly. Density-1 forward remains analytically blocked.",
+    "progressSummary": "PROGRESS: excluded regime characterised as prime powers of p≡3 mod4 (VERIFIED, merged); added necessary reversal condition 2φ(a)<seedC (VERIFIED). No excluded seed reverses (numeric a<80000); the crude φ(e)≤e bound proven insufficient to close it (fails for 3^k). Density-1 forward remains analytically blocked.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -87,7 +87,8 @@
       "factor_two_split (reusable 2-adic split: n=c*2^u, c odd => factorization 2 = u and oddpart = c), classifySeed_val (evaluates classifySeed at a concrete seed from the two factorisations), classifySeed_3..19 + classifySeed_21, and twentyone_smallest_reversing_seed in EulerTotientOQ04OQ03.lean — VERIFIED host 0/0, axioms [propext,Classical.choice,Quot.sound], no native_decide",
       "seedS_ge_two_iff_totient_mod_four + seedS_eq_one_iff_four_dvd_totient in EulerTotientOQ04OQ03.lean:~1600 (VERIFIED 0/0): for odd a>=3, seedS a>=2 <-> phi(a)=2 mod 4, and seedS a=1 <-> 4|phi(a); reads transport-admissible vs excluded regime off phi(a) mod 4 via Nat.Prime.pow_dvd_iff_le_factorization + omega. Sanity: seedS_21_eq_one, seedS_three_ge_two",
       "totient_mod_four_eq_two_iff_prime_pow_three_mod_four (EulerTotientOQ04OQ03.lean): odd a≥3 ⟹ (φ(a)%4=2 ↔ ∃p k, p.Prime ∧ p%4=3 ∧ 0<k ∧ a=p^k), VERIFIED 0/0",
-      "Fixed pre-existing false-green: seedS_ge_two_iff_totient_mod_four used Nat.prime_two.prime.pow_dvd_iff_le_factorization (wrong _root_.Prime), whole file failed to elaborate until .prime dropped"
+      "Fixed pre-existing false-green: seedS_ge_two_iff_totient_mod_four used Nat.prime_two.prime.pow_dvd_iff_le_factorization (wrong _root_.Prime), whole file failed to elaborate until .prime dropped",
+      "reversal_two_totient_lt_seedC (EulerTotientOQ04OQ03.lean): for odd a≥3, classifySeed a = .lt ⟹ 2·φ(a) < seedC a. Necessary condition for reversal, k-free/unconditional, via φ(seedE a) ≤ seedE a and seedC = seedE·2^seedT. VERIFIED 0/0."
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -112,7 +113,8 @@
       "Total decidable classifier: the k-free three-way criterion becomes a COMPUTABLE function classifySeed : ℕ → Ordering. From an odd seed a it extracts (s,b,t,e) by two 2-adic valuations — s=v₂(2a−φ(a)), b=oddpart, C=2a−φ(b)·2^(s−1), t=v₂(C), e=oddpart(C) — and compares φ(a) ⋛ φ(e)·2^(t−1). seed_spec proves the extraction meets every criterion hypothesis for ALL a≥3 (oddness of a not needed). The reversal seed set is the decidable predicate {a | classifySeed a = .lt}.",
       "The total classifier classifySeed removes the ValidSeed hypothesis from the least-reversal-seed result: twentyone_smallest_reversing_seed proves 21 is UNCONDITIONALLY the smallest odd reversing seed, covering the higher-valuation excluded seeds {3,7,9,11,19} (v2(2a-phi a) >= 2) that the old ValidSeed-gated classify sweep {5,13,15,17} could not address.",
       "Regime split seedS a=1 (transport-admissible) vs seedS a>=2 (excluded) is a closed-form congruence in phi(a) mod 4, NOT a valuation search: a odd => 2a=2 mod 4 and phi(a) even (a>=3), so 4 | (2a-phi(a)) <-> phi(a)=2 mod 4, and 4|(2a-phi(a)) is exactly 2<=v_2(2a-phi(a))=seedS a",
-      "Excluded regime (v₂(2a−φ(a))≥2, i.e. φ(a)≡2 mod4) = EXACTLY prime powers p^k of primes p≡3 mod4 — now a theorem, was only empirical (a<20000)"
+      "Excluded regime (v₂(2a−φ(a))≥2, i.e. φ(a)≡2 mod4) = EXACTLY prime powers p^k of primes p≡3 mod4 — now a theorem, was only empirical (a<20000)",
+      "The crude bound φ(e)≤e gives only a NECESSARY reversal condition 2φ(a)<seedC, NOT sufficient: a=3^k (excluded seeds, p=3≡3 mod4) all satisfy 2φ(a)<seedC yet never reverse. Confirmed no excluded seed (seedS≥2) reverses for odd a<80000, and all 2276 reversal seeds a<60000 are transport-admissible seedS=1. Closing no-excluded-seed-reverses needs the finer ratio φ(seedE a)/seedE a."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
@@ -127,7 +129,8 @@
       "Prove/refute that NO excluded seed (v₂(2a−φ(a))≥2) ever reverses (observed a<120); would sharpen the reversal-set structure to v₂=1 seeds only",
       "PARTIAL RESOLUTION of the excluded-seed question: no odd seed a<21 reverses (proven unconditionally via classifySeed, including v2>=2 seeds 3,7,9,11,19). Extend the finite unconditional sweep upward, or prove the general structural claim seedS a >= 2 => classifySeed a != .lt (no excluded seed ever reverses; observed a<120).",
       "Formalize the classical characterization: for odd a>=3, phi(a)=2 mod 4 (excluded regime) <-> a=p^k with p prime, p=3 mod 4. Multiplicativity of totient: >=2 distinct odd primes => 4|phi; a=p^k => v_2(phi)=v_2(p-1). ~150 lines Mathlib totient_eq_prod / prime-power work (heavy build, defer until fleet SIGBUS clears)",
-      "Prove seedS a≥2 ⟹ classifySeed a ≠ .lt (no prime-power-of-p≡3mod4 seed reverses); all known reversal seeds 21,55,129,165,175 are transport-admissible seedS=1"
+      "Prove seedS a≥2 ⟹ classifySeed a ≠ .lt (no prime-power-of-p≡3mod4 seed reverses); all known reversal seeds 21,55,129,165,175 are transport-admissible seedS=1",
+      "Sharpen reversal_two_totient_lt_seedC using φ(seedE a)/seedE a (not φ(e)≤e) to attempt seedS a≥2 ⟹ classifySeed a ≠ .lt; the crude bound provably cannot close it (fails for 3^k). Likely needs relating φ(seedE a)·seedS-structure back to φ(a)=p^(k-1)(p-1) in the p^k, p≡3 mod4 regime."
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Erdős 1064 (OQ-03) — structural classification of the totient-reversal seed set

All work is in `proofs/Proofs/EulerTotientOQ04OQ03.lean`, machine-checked with Docker Lean v4.26.0 (`✔ [3058/3058] Built`, **0 sorries, 0 axioms, no `native_decide`** — kernel-checked).

The double-iterate map is `D(n) = n − φ(n − φ(n))`; a seed `a` *reverses* when the family `n = a·2^(k+1)` satisfies `φ(n) < φ(D(n))`. `classifySeed a ∈ {lt, eq, gt}` is the total computable classifier deciding the regime of the whole family from `a`.

### Contents of this branch
1. **Excluded-regime characterisation** — for odd `a ≥ 3`, `seedS a ≥ 2` (first-step 2-adic valuation, outside the transport machinery) iff `φ(a) ≡ 2 (mod 4)` iff `a = p^k` with `p ≡ 3 (mod 4)`. (`seedS_ge_two_iff_totient_mod_four`, `totient_mod_four_eq_two_iff_prime_pow_three_mod_four`.)
2. **`3^k` — first infinite excluded family proven never to reverse** (`three_pow_never_reverses`, `three_pow_family_not_reversal`), upgrading the prior finite `decide` sweep over `a < 120`.
3. **NEW — general non-reversal engine + all primes `p ≡ 3 mod 4`:**
   - `classifySeed_ne_lt_of_excess_bound`: for an excluded seed (`seedS a ≥ 2`), `classifySeed a ≠ .lt` **whenever** `a − φ(a) ≤ φ(seedB a)·2^(seedS a − 2)`. Mechanism: the classifier compares `φ(a)` with `φ(e)·2^(t−1)` where `seedC a = e·2^t`; since `φ(e) ≤ e` this is `≤ e·2^(t−1) = seedC a / 2 = a − φ(seedB a)·2^(seedS a − 2)`, so the single arithmetic bound forces `φ(a) ≥ φ(e)·2^(t−1)`.
   - `classifySeed_prime_three_mod_four_ne_lt`: every prime `p ≡ 3 mod 4` never reverses — `a − φ(a) = p − (p−1) = 1` makes the bound trivial, so the engine covers the **entire infinite class {3, 7, 11, 19, 23, 31, …}** at once, strictly larger than the single-prime tower `3^k`.
   - `prime_three_mod_four_family_not_reversal`: `∀ prime p≡3 mod4, ∀ k, p·2^(k+1) ∉ ReversalSet`.

### Significance
Widens the class of proven non-reversing excluded seeds from one prime's tower (`3^k`) to all primes `≡ 3 mod 4`, via a reusable engine that reduces "no reversal" to a single per-seed arithmetic inequality. This is the concrete path toward the structural conjecture **no excluded seed reverses** (reversals occur only in the transport-admissible regime `seedS a = 1`, smallest reversing seed `21 = 3·7`). Next step: instantiate the engine at general `a = p^k` (bound `φ(seedB a)·2^(seedS a − 2) ≥ p^(k−1)`).

The density-1 forward direction (`φ(n) > φ(D(n))` for almost all `n`) remains the sole analytically-blocked open direction (needs Luca–Pomerance / ψ(x,y) smooth-number density, a genuine Mathlib gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)