### PR TITLE
Enrich Sum of Odd Cubes: add leanFile block + odd-squares companion cross-ref

### DIFF
--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-03/meta.json
@@ -3,6 +3,22 @@
   "title": "Sum of the First n Odd Cubes: ∑ (2k−1)³ = n²(2n²−1)",
   "slug": "nicomachus-sum-of-cubes-oq-03",
   "description": "A fully machine-checked, self-contained proof of the odd-cube analogue of Nicomachus's theorem: the sum of the first n odd cubes equals n²(2n²−1), i.e. ∑_{k<n} (2k+1)³ = n²(2n²−1). The closed form carries a subtraction (2n²−1), which is hostile to `ring` over ℕ, so the engine of the proof is the subtraction-free repackaging ∑(2k+1)³ + n² = 2n⁴, proved by induction with a single polynomial `ring` identity spliced into the hypothesis by `omega`. The headline n²(2n²−1) form is then recovered over ℤ via push_cast. Mathlib has neither identity.",
+  "leanFile": {
+    "path": "Proofs/NicomachusOddCubes.lean",
+    "namespace": "NicomachusOddCubes",
+    "imports": [
+      "Mathlib.Algebra.BigOperators.Intervals",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "lineCount": 93,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "sorries": 0
+  },
   "meta": {
     "author": "Classical (odd-cube companion to Nicomachus, c. 100 AD); formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Squared_triangular_number",
@@ -128,6 +144,11 @@
       "proofId": "nicomachus-sum-of-cubes-oq-02",
       "relationship": "Sibling Faulhaber power-sum",
       "description": "The Faulhaber p=4 closed form ∑ k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30. A companion entry sharing this one's exact 'clear the denominator/subtraction, then ring-and-omega induction' recipe."
+    },
+    {
+      "proofId": "odd-squares-sum-oq-01",
+      "relationship": "Odd-index power-sum companion (degree 2)",
+      "description": "The sum of the first n odd SQUARES, ∑_{k<n}(2k+1)² = n(2n−1)(2n+1)/3 — the degree-2 member of the same odd-index power-sum family as this degree-3 entry. Both dissolve the closed form's division/subtraction into a subtraction-free identity over ℕ (there 3∑+n = 4n³, here ∑+n² = 2n⁴) so the induction stays inside ℕ and closes by `ring`; together they trace the odd-index Faulhaber ladder from squares to cubes."
     },
     {
       "proofId": "arithmetic-series",


### PR DESCRIPTION
Enrichment pass for `nicomachus-sum-of-cubes-oq-03` (quality 94, passes 0).

## Changes (meta.json only)
- **Added the missing top-level `leanFile` object** (namespace NicomachusOddCubes, imports, opens Finset, lineCount 93, theoremCount 3, definitionCount 0, axiomCount 0, sorries 0) — all verified against `Proofs/NicomachusOddCubes.lean`. Schema-consistency with sibling entries.
- **Added a crossReference to `odd-squares-sum-oq-01`** — the degree-2 member of the same odd-index power-sum family as this degree-3 entry. Both dissolve the closed form's division/subtraction into a subtraction-free ℕ identity (there 3∑+n = 4n³, here ∑+n² = 2n⁴) so the induction stays in ℕ and closes by `ring`. This mutualizes the link (the odd-squares entry now points here to nicomachus-sum-of-cubes as well).

JSON validates; 13.6 KB, under all caps.