### PR TITLE
Fix: erdos-14-unique-sums lists phantom biconditional contribution

### DIFF
--- a/src/data/proofs/erdos-14-unique-sums/meta.json
+++ b/src/data/proofs/erdos-14-unique-sums/meta.json
@@ -28,8 +28,7 @@
       "uniqueSums / uniqueSums': set of sums representable in exactly one way",
       "nonUniqueCount: U(N) = |{1,...,N} \\ B| count of non-uniquely representable integers",
       "IsSidon: predicate — a+b = c+d implies {a,b}={c,d} (all pairwise sums distinct)",
-      "sidon_all_unique: Sidon sets have all sums in uniqueSums",
-      "sidon_implies_unique_sumset: Sidon ↔ uniqueSums A = sumset A"
+      "sidon_all_unique: Sidon sets have all sums in uniqueSums (sumset A ⊆ uniqueSums A)"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-14-unique-sums
**Problem**: Phantom theorem in `originalContributions` + overclaim (biconditional vs one-direction inclusion)

## Evidence

**meta.json claimed** (originalContributions):
> `sidon_implies_unique_sumset: Sidon ↔ uniqueSums A = sumset A`

**Lean source shows** (`proofs/Proofs/Erdos14UniqueSums.lean`):
- No declaration named `sidon_implies_unique_sumset` exists anywhere (`grep` → not found).
- No theorem proves the biconditional/equality characterization `Sidon ↔ uniqueSums A = sumset A`.
- The only relevant result is `sidon_all_unique` (line 88), which proves the **forward inclusion only**: `sumset A ⊆ uniqueSums A`. That result is already the preceding contribution entry, so the phantom line is also redundant.

## Fix

- Remove the phantom/overclaiming `sidon_implies_unique_sumset` entry.
- Clarify the surviving `sidon_all_unique` entry to state the actual one-directional inclusion `sumset A ⊆ uniqueSums A`.

No count fields change (originalContributions is not counted in the axiom/theorem/definition/line metrics; those were verified accurate).

---
Discovered during gallery integrity audit (phantom-theorem contributions pattern).