### PR TITLE
research(shannon-channel-coding-awgn-oq-02-oq-02): orientation-reversing correlation dual + strict stddev triangle inequality

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -905,6 +905,18 @@ theorem correlation_affine_invariant_of_pos [IsProbabilityMeasure μ] {X Y : Ω 
     correlation (fun ω => a * X ω + b) (fun ω => c * Y ω + d) μ = correlation X Y μ := by
   rw [correlation_affine_invariant hX hY a b c d, Real.sign_of_pos (mul_pos ha hc), one_mul]
 
+/-- **Scale-and-shift sign flip (orientation-reversing case).**  Correlation flips sign under any
+pair of affine reparametrisations whose slopes have *opposite* orientation (`a·c < 0`):
+`ρ[a·X + b, c·Y + d] = -ρ[X, Y]`.  The orientation-reversing counterpart of
+`correlation_affine_invariant_of_pos`, specialising `correlation_affine_invariant` with
+`sign(a·c) = -1`.  Together the two lemmas exhaust the non-degenerate dichotomy: an affine change
+of units preserves the Pearson coefficient exactly when it is orientation-preserving and negates
+it exactly when it is orientation-reversing (e.g. `ρ[X, -Y] = -ρ[X, Y]`). -/
+theorem correlation_affine_invariant_of_neg [IsProbabilityMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) {a c : ℝ} (hac : a * c < 0) (b d : ℝ) :
+    correlation (fun ω => a * X ω + b) (fun ω => c * Y ω + d) μ = -correlation X Y μ := by
+  rw [correlation_affine_invariant hX hY a b c d, Real.sign_of_neg hac, neg_one_mul]
+
 /-!
 ### Sharp equality boundary of the standard-deviation triangle inequality
 
@@ -983,5 +995,25 @@ theorem stddev_add_eq_iff_affine_pos [IsProbabilityMeasure μ] {X Y : Ω → ℝ
       ∃ a b : ℝ, 0 < a ∧ X =ᵐ[μ] fun ω => a * Y ω + b := by
   rw [stddev_add_eq_iff_correlation_eq_one hX hY hXnd hYnd,
     correlation_eq_one_iff_affine_pos hX hY hXnd hYnd]
+
+/-- **Strict standard-deviation triangle inequality (non-degenerate, imperfect correlation).**
+For non-degenerate `X, Y` the L² triangle inequality `σ[X+Y] ≤ σ[X] + σ[Y]` of `stddev_add_le` is
+*strict*
+
+        √Var[X + Y] < √Var[X] + √Var[Y]
+
+whenever the correlation coefficient falls short of its maximum `ρ[X, Y] ≠ 1`.  The strict
+companion of `stddev_add_le`: since equality holds *exactly* at `ρ = 1`
+(`stddev_add_eq_iff_correlation_eq_one`), any imperfect (or negative) correlation forces a genuine
+gap — the standard deviations of a sum are *strictly* sub-additive off the fully-aligned diagonal.
+Combined with the equality characterisation this pins the two-term triangle inequality to a sharp
+dichotomy: equality iff `ρ = 1`, strict inequality otherwise. -/
+theorem stddev_add_lt_of_correlation_ne_one [IsFiniteMeasure μ] {X Y : Ω → ℝ}
+    (hX : MemLp X 2 μ) (hY : MemLp Y 2 μ) (hXnd : Var[X; μ] ≠ 0) (hYnd : Var[Y; μ] ≠ 0)
+    (hρ : correlation X Y μ ≠ 1) :
+    Real.sqrt (Var[X + Y; μ]) < Real.sqrt (Var[X; μ]) + Real.sqrt (Var[Y; μ]) := by
+  refine lt_of_le_of_ne (stddev_add_le hX hY) ?_
+  intro heq
+  exact hρ ((stddev_add_eq_iff_correlation_eq_one hX hY hXnd hYnd).mp heq)
 
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 987,
+    "lineCount": 1019,
     "axiomCount": 0,
-    "theoremCount": 41,
+    "theoremCount": 43,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 908,
-    "theoremCount": 38,
+    "lineCount": 940,
+    "theoremCount": 40,
     "definitionCount": 1,
     "badge": "mathlib",
     "originalContributions": [
@@ -183,6 +183,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 987,
-  "theoremCount": 41
+  "lineCount": 1019,
+  "theoremCount": 43
 }

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: proved the sharp equality boundary of the standard-deviation triangle inequality (σ[X+Y]=σ[X]+σ[Y] ⟺ cov=√Var·√Var ⟺ ρ=+1 ⟺ increasing-affine), 3 theorems VERIFIED 0 sorry/0 axiom; dual endpoint to variance_add_eq_iff_covariance_zero.",
+    "progressSummary": "PROGRESS: added orientation-reversing correlation dual (_of_neg) completing the affine sign dichotomy, and the strict two-term stddev triangle inequality (σ[X+Y]<σ[X]+σ[Y] for ρ≠1); both VERIFIED 0 sorry/0 axiom.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -57,7 +57,9 @@
       "real_sign_eq_self_div_abs helper (line 861): Real.sign x = x/|x| ∀x incl 0",
       "stddev_add_eq_iff_covariance_eq_sqrt (ShannonChannelCodingAWGNOQ02OQ02.lean): σ[X+Y]=σ[X]+σ[Y] ↔ cov[X,Y]=√Var[X]·√Var[Y], no non-degeneracy hyp; proof squares both sides (Real.sq_sqrt / Real.sqrt_sq) and closes with nlinarith on variance_add.",
       "stddev_add_eq_iff_correlation_eq_one (same file): non-degenerate normalisation, σ[X+Y]=σ[X]+σ[Y] ↔ ρ[X,Y]=1 via div_eq_one_iff_eq.",
-      "stddev_add_eq_iff_affine_pos (same file): capstone σ[X+Y]=σ[X]+σ[Y] ↔ ∃a b, 0<a ∧ X=ᵐ a·Y+b (perfect positive correlation / increasing affine), chaining correlation_eq_one_iff_affine_pos."
+      "stddev_add_eq_iff_affine_pos (same file): capstone σ[X+Y]=σ[X]+σ[Y] ↔ ∃a b, 0<a ∧ X=ᵐ a·Y+b (perfect positive correlation / increasing affine), chaining correlation_eq_one_iff_affine_pos.",
+      "correlation_affine_invariant_of_neg (ShannonChannelCodingAWGNOQ02OQ02.lean): a·c<0 ⟹ ρ[aX+b,cY+d] = -ρ[X,Y], VERIFIED 0/0",
+      "stddev_add_lt_of_correlation_ne_one (ShannonChannelCodingAWGNOQ02OQ02.lean): non-degenerate X,Y with ρ≠1 ⟹ √Var[X+Y] < √Var[X]+√Var[Y] (strict triangle inequality), VERIFIED 0/0"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -73,7 +75,9 @@
       "Signed sharp boundary: ρ = sign(a) when X =ᵐ a·Y+b, so ρ=+1 ⟺ increasing affine (a>0), ρ=−1 ⟺ decreasing affine (a<0); splits |ρ|=1⟺affine into two distinct endpoints.",
       "Affine-invariance proof reuses the exact machinery of the ±1 capstones: cov[aX+b,cY+d]=ac·cov via covariance_add_const_left/right + covariance_const_mul_left/right; σ[aX+b]=|a|·σ[X] via variance_eq_of_affine+sqrt_mul+sqrt_sq_eq_abs; sign packaged as x/|x| so a·c/(|a|·|c|)=sign(a·c) closes by ring (field inverse rearrangement, no nonzero hyps needed).",
       "Sharp equality boundary of the stddev triangle inequality stddev_add_le: squaring the nonnegative identity σ[X+Y]=σ[X]+σ[Y] reduces it to the covariance attaining its Cauchy-Schwarz maximum cov[X,Y]=√Var[X]·√Var[Y]; NO non-degeneracy hypothesis needed (degenerate Y gives 0=σ[X]·0).",
-      "The triangle-equality boundary sits at the OPPOSITE Cauchy-Schwarz endpoint from variance_add_eq_iff_covariance_zero: variances add iff cov=0 (orthogonal), but standard deviations add iff cov=σ[X]σ[Y] (perfectly positively correlated, ρ=+1)."
+      "The triangle-equality boundary sits at the OPPOSITE Cauchy-Schwarz endpoint from variance_add_eq_iff_covariance_zero: variances add iff cov=0 (orthogonal), but standard deviations add iff cov=σ[X]σ[Y] (perfectly positively correlated, ρ=+1).",
+      "The general correlation_affine_invariant (sign(a·c)·ρ) already subsumes both orientation cases; the orientation-reversing dual _of_neg is a 1-line specialization via Real.sign_of_neg, completing the a·c>0 / a·c<0 dichotomy alongside _of_pos.",
+      "Strict two-term stddev triangle inequality falls out of lt_of_le_of_ne applied to stddev_add_le together with the equality-iff-ρ=1 characterization: any ρ≠1 (non-degenerate) forces σ[X+Y] < σ[X]+σ[Y]. No new analysis needed."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -92,7 +96,8 @@
       "Affine-invariance of covariance itself (cov[aX+b,cY+d]=ac·cov[X,Y]) is now proved inline — consider extracting as a named reusable lemma if a further correlation result needs it.",
       "Consider corr sign-flip corollary for a>0,c<0 (orientation-reversing): ρ[aX+b,cY+d]=−ρ[X,Y] as the negative companion of correlation_affine_invariant_of_pos.",
       "Dual equality for the finite-sum triangle inequality stddev_sum_le: σ[∑Wᵢ]=∑σ[Wᵢ] iff all pairs are perfectly positively correlated (all centered contributions a.e. nonneg-proportional to a common direction) — needs an induction handling the shared-direction propagation.",
-      "Consider the strict-inequality companion: σ[X+Y] < σ[X]+σ[Y] whenever ρ<1 (non-degenerate), the strict form of stddev_add_le."
+      "Consider the strict-inequality companion: σ[X+Y] < σ[X]+σ[Y] whenever ρ<1 (non-degenerate), the strict form of stddev_add_le.",
+      "Finite-sum strict triangle inequality: if some pair (i,j) in s has ρ<1 then σ[∑Wᵢ] < ∑σ[Wᵢ]; requires shared-direction propagation through the stddev_sum_le induction (the still-open hard step)."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Two verified lemmas extending the correlation / standard-deviation triangle-inequality thread of `Proofs.ShannonChannelCodingAWGNOQ02OQ02`.

**`correlation_affine_invariant_of_neg`** — orientation-reversing companion of the existing `correlation_affine_invariant_of_pos`. For affine reparametrisations with opposite-orientation slopes (`a·c < 0`):

    ρ[a·X + b, c·Y + d] = -ρ[X, Y]

A 1-line specialization of the general `correlation_affine_invariant` (`sign(a·c)·ρ`) via `Real.sign_of_neg`. Together with `_of_pos` it exhausts the non-degenerate dichotomy of the Pearson coefficient under affine changes of units (e.g. `ρ[X, -Y] = -ρ[X, Y]`).

**`stddev_add_lt_of_correlation_ne_one`** — the **strict** form of `stddev_add_le`. For non-degenerate `X, Y` with `ρ[X,Y] ≠ 1`:

    √Var[X + Y] < √Var[X] + √Var[Y]

Obtained from `lt_of_le_of_ne` on `stddev_add_le` together with the equality characterization `stddev_add_eq_iff_correlation_eq_one` (equality holds *exactly* at `ρ = 1`). This pins the two-term L² triangle inequality to a sharp dichotomy: equality iff perfect positive correlation, strict inequality otherwise.

## Verification

- Both proofs build only on already-verified infrastructure in the same file.
- **0 sorries, 0 axioms** (no `native_decide`, pure term/tactic proofs).
- Docker build: `Built Proofs.ShannonChannelCodingAWGNOQ02OQ02 (6.1s)`.
- Metadata counts synced (lineCount 987→1019, theoremCount 41→43).

## Honest scope

`_of_neg` is a modest named dual (trivial given the general lemma) included for completeness of the orientation dichotomy; the strict triangle inequality is the substantive addition. The finite-sum strict form remains open (needs shared-direction propagation through the `stddev_sum_le` induction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)