### PR TITLE
research(erdos-1090-incomplete-01): prove HellyProperty 2 from Mathlib Helly [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -26,6 +26,7 @@ References:
 
 import Mathlib.Analysis.InnerProductSpace.EuclideanDist
 import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Analysis.Convex.Radon
 import Mathlib.Combinatorics.HalesJewett
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Finset.Basic
@@ -564,6 +565,31 @@ def HellyProperty (d : ℕ) : Prop :=
     (∀ S ∈ F, Convex ℝ S) →
     (∀ G : Finset (Set Point), G ⊆ F → G.card = d + 1 → (⋂ S ∈ G, S).Nonempty) →
     (⋂ S ∈ F, S).Nonempty
+
+/-- **Helly's theorem in the plane — affirmative.**  `HellyProperty 2` holds for
+`Point = ℝ²`: any finite family `F` of at least `3` convex sets in the plane in which
+every `3`-element subfamily has a common point has a point common to *all* of `F`.
+
+This is exactly Mathlib's `Convex.helly_theorem_set` specialised to
+`Module.finrank ℝ ℝ² = 2`, so the placeholder threshold `d + 1 = 3` is the classical
+planar Helly number.  Note the ambient space is fixed to the plane, so `d = 2`
+(`= finrank ℝ Point`) is the *only* honest instance of the abstract `HellyProperty d`
+defined above: for `d < 2` pairwise/triple intersection is too weak to force a common
+point, and for `d > 2` the `(d+1)`-wise hypothesis is not what Helly consumes. -/
+theorem helly_planar : HellyProperty 2 := by
+  intro F hcard hconv hinter
+  have hfr : Module.finrank ℝ Point = 2 := by simp [Point]
+  -- Bridge the entry's `⋂ S ∈ F, S` notation to Mathlib's `⋂₀ (F : Set _)`.
+  have hbF : (⋂ S ∈ F, S) = ⋂₀ (F : Set (Set Point)) := by ext x; simp
+  rw [hbF]
+  refine Convex.helly_theorem_set (𝕜 := ℝ) ?_ hconv ?_
+  · -- `finrank + 1 ≤ #F` is exactly the `F.card ≥ 2 + 1` hypothesis.
+    rw [hfr]; exact hcard
+  · -- Every `(finrank + 1) = 3`-subfamily meets, from the entry-shaped `hinter`.
+    intro G hG hGcard
+    have hbG : (⋂₀ (G : Set (Set Point))) = ⋂ S ∈ G, S := by ext x; simp
+    rw [hbG]
+    exact hinter G hG (by rw [hfr] at hGcard; exact hGcard)
 
 /-
 ## Part X: Generalizations

--- a/research/problems/erdos-1090-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1090-incomplete-01/knowledge.md
@@ -78,3 +78,26 @@ unchanged); gallery `erdos-1090/meta.json` line/thm synced in both leanFile & me
 
 Remaining next-steps unchanged: SylvesterGallai/HellyProperty still DEFS; quantitative
 `ramseyNumber k` upper bound; projection-body dedup (3 verified copies, left as-is).
+
+## Session 2026-07-08 (researcher-1): helly_planar — proved the HellyProperty placeholder
+
+**Mode**: ACT (look-outward on SOLVED). **Outcome**: progress, 0-axiom. Converted one of the
+two never-proved DEF placeholders (`HellyProperty`) into an established theorem.
+- `helly_planar : HellyProperty 2`. `HellyProperty d` over the FIXED plane `Point = ℝ²` is
+  only honest at `d = finrank ℝ Point = 2` (classical planar Helly number `d+1 = 3`): every
+  finite family of ≥3 convex sets whose every 3-element subfamily meets has a common point.
+- Proof = specialize Mathlib `Convex.helly_theorem_set` (Analysis/Convex/Radon.lean) to
+  `finrank ℝ ℝ² = 2` (`finrank_euclideanSpace_fin`, discharged by `simp [Point]`). Only two
+  bridges needed: the entry writes `⋂ S ∈ F, S` where Mathlib writes `⋂₀ (F : Set _)` —
+  both directions close by `ext x; simp`. Added `import Mathlib.Analysis.Convex.Radon`.
+- Sylvester–Gallai is NOT in Mathlib (grep empty), so the `SylvesterGallai` def stays a
+  placeholder — proving it is a from-scratch multi-hundred-line undertaking, out of session scope.
+
+File 751→777 lines, 15→16 theorems (defs 18 unchanged), 0 sorry / 0 axiom. Host `lake env lean`
+EXIT 0; `#print axioms helly_planar = [propext, Classical.choice, Quot.sound]` (no sorryAx / no
+ofReduceBool). Gallery meta.json line/thm synced in both .meta and leanFile blocks; Radon import added.
+
+Remaining next-steps: `SylvesterGallai` still a placeholder DEF (needs a from-scratch Mathlib
+proof — not currently available); quantitative `ramseyNumber k` UPPER bound (only lower bound
+≥ k proved; the HJ construction gives |A| ≤ k^|ι| but ι from Mathlib HJ is non-explicit);
+projection-body dedup (3 verified copies, left as-is).

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -66,12 +66,13 @@
       "SylvesterGallai, HellyProperty, Erdos1090Generalized, Erdos1090HigherDim: related/generalized statements",
       "hasRamseyProperty_mono / hasRamseyProperty_antitone (0-axiom): the Ramsey property is upward-closed under superset (A ⊆ B) and downward-closed in k (k' ≤ k), the structural monotonicities that make ramseyNumber k a well-defined threshold",
       "ramsey_construction_general: the Hales–Jewett generic-projection construction over an ARBITRARY finite color type C (not just Bool) — for k≥3, a finite A⊂ℝ² with k monochromatic collinear points under any c:Point→C",
-      "erdos1090_generalized_affirmative: proves the previously-unproved r-coloring version Erdos1090Generalized k r, by specializing ramsey_construction_general to C=Fin r (multicolor Hales–Jewett needs no extra hypothesis on r)"
+      "erdos1090_generalized_affirmative: proves the previously-unproved r-coloring version Erdos1090Generalized k r, by specializing ramsey_construction_general to C=Fin r (multicolor Hales–Jewett needs no extra hypothesis on r)",
+      "helly_planar (0-axiom): proves the previously-unproved placeholder HellyProperty 2 for the plane by specializing Mathlib's Convex.helly_theorem_set to finrank ℝ ℝ² = 2 — every finite family of ≥3 planar convex sets whose 3-element subfamilies each intersect has a common point (classical planar Helly number d+1=3)"
     ],
     "axiomCount": 0,
-    "lineCount": 751,
+    "lineCount": 777,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 18
   },
   "overview": {
@@ -97,6 +98,7 @@
     "imports": [
       "Mathlib.Analysis.InnerProductSpace.EuclideanDist",
       "Mathlib.Analysis.InnerProductSpace.PiL2",
+      "Mathlib.Analysis.Convex.Radon",
       "Mathlib.Combinatorics.HalesJewett",
       "Mathlib.Data.Real.Basic",
       "Mathlib.Data.Finset.Basic",
@@ -107,9 +109,9 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 751,
+    "lineCount": 777,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 18,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #1090 (`erdos-1090-incomplete-01`) is a SOLVED gallery entry (0 sorry / 0 axiom). This look-outward session eliminates one of its two remaining never-proved DEF *placeholders*.

- **`helly_planar : HellyProperty 2`** — proves the classical Helly theorem in the plane, converting the previously-unproved `HellyProperty` def into an established theorem. Any finite family of ≥3 convex sets in ℝ² whose every 3-element subfamily has a common point has a point common to all of them.
- Proof specializes Mathlib's `Convex.helly_theorem_set` to `finrank ℝ ℝ² = 2` (so the placeholder threshold `d+1 = 3` is the classical planar Helly number). The ambient space is fixed to the plane, so `d = 2 = finrank ℝ Point` is the only honest instance of the abstract `HellyProperty d`.
- The only bridging work: the entry writes `⋂ S ∈ F, S` where Mathlib writes `⋂₀ (F : Set _)`; both directions close by `ext x; simp`.
- Added `import Mathlib.Analysis.Convex.Radon`.

The other placeholder, `SylvesterGallai`, is **not** in Mathlib (proving it is a from-scratch multi-hundred-line effort) and is left as a documented next-step.

## Verification

- Host `lake env lean Proofs/Erdos1090Problem.lean` → **EXIT 0** (only pre-existing warnings).
- `#print axioms Erdos1090.helly_planar` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
- File 751→777 lines, 15→16 theorems (18 defs unchanged); gallery `meta.json` line/theorem counts synced in both `.meta` and `leanFile` blocks, Radon import recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)