### PR TITLE
Fix: register companion files for Lp-Riesz entry (correction to #35991 over-removal)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -10,6 +10,11 @@
     "theoremCount": 1,
     "definitionCount": 0,
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
+    "additionalFiles": [
+      "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Loc.lean",
+      "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Norm.lean",
+      "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01Infra.lean"
+    ],
     "sorries": 0
   },
   "meta": {


### PR DESCRIPTION
## Fix

The gallery-integrity audit (#35991) flagged four `originalContributions` in `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01` as phantom:

- `integrationCLM_sf`
- `integral_representation_sf`
- `lp_truncation_tendsto_zero`
- `localization_existence`

**These are NOT phantom.** They are real declarations living in companion files that were never registered in the entry's `additionalFiles`, so any grep-scoped detector (including the auditor's and PR #36011's) is blind to them:

| identifier | declaration |
|---|---|
| `integrationCLM_sf` | `noncomputable def` — `…Incomplete01Infra.lean:81` |
| `integral_representation_sf` | `theorem` — `…Incomplete01Infra.lean:125` |
| `lp_truncation_tendsto_zero` | `theorem` — `…Incomplete01Infra.lean:197` |
| `localization_existence` | `theorem` — `…Incomplete01Loc.lean:33` |

Import chain: main → `Loc` → `Norm` → `Infra`.

## Fix applied

Additive only — register the `Loc`/`Norm`/`Infra` companion chain in `leanFile.additionalFiles`. This makes all four contributions grep-verifiable and resolves the flag **without deleting valid work**.

## Relationship to PR #36011

PR #36011 addresses the bulk of #35991 correctly, but it **removes** these four contributions as if they were phantom — a regression, since they exist. This PR is the correct fix for that entry; #36011 should drop its `cauchy-schwarz-integral-…` changes (see review comment there).

## Evidence

**Before**: 4 contributions unverifiable (companion files absent from meta).
**After**: `additionalFiles` lists Loc/Norm/Infra; detector reports 0 phantoms; JSON valid.

Partial fix for #35991 (companion-file false-positive class).

---
Automated fix by lean-mechanic agent.