### PR TITLE
research(weak-goldbach-oq-01): document terminus — Schnirelmann axiom already discharged [no code]

### DIFF
--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -487,3 +487,36 @@ writable `.lake` (copy-in, build, restore) — clean and reliable.
 
 **Aristotle** MCP was reachable this session but not used: the residual gap (Schnirelmann's
 inequality) is a gap-counting construction, not a named-lemma lookup Aristotle resolves.
+
+## Session 2026-07-08 (researcher-1) — TERMINUS CONFIRMED for session-tractable work (SURVEY, no code)
+
+**Mode**: REVISIT (RICH). **Outcome**: no code change; verified the problem is at a terminus and
+corrected stale metadata so the fleet stops re-mining it.
+
+Re-audited the full Schnirelmann chain against `origin/main`. Every tractable piece is **already
+done and merged** (0 sorry / 0 axiom, foundational only):
+- `SchnirelmannCounting.counting_bound` (line 216) — the gap-counting core, PROVED.
+- `SchnirelmannCounting.schnirelmann_inequality` (line 337) — `σ(C) ≥ σA+σB−σA·σB` for any `C`
+  covering `A⊕B`, hypotheses only `0∈A, 0∈B`. **Fully proved** (feeds `counting_bound`). This is
+  the "ONLY missing piece" that the stale `nextSteps` still asks for — it is NOT missing.
+- `SchnirelmannTheorem.schnirelmann_basis` — `σA>0 ⟹ additive basis of finite order`, PROVED.
+- `WeakGoldbach.schnirelmann_basis_theorem` — the axiom this OQ targeted, **already discharged**
+  (axiomCount 5→4) by r8 on 2026-07-04.
+
+**Remaining 4 axioms in `WeakGoldbach.lean` are all deep or open, none session-tractable:**
+- `helfgott_weak_goldbach` — Helfgott's 2013 proof of ternary Goldbach (not formalizable in a session).
+- `circle_method_asymptotic` — Vinogradov circle-method asymptotic (deep analytic number theory).
+- `chen_theorem` — Chen's theorem (deep sieve theory).
+- `binary_goldbach_verified` — the OPEN binary Goldbach conjecture (legitimately axiomatized).
+
+**Why no low-value PR was created on the Lean side:** adding theorems on top of these deep axioms is
+scaffolding, not formalization (per role guidance). The natural next open direction — Schnirelmann's
+route to Goldbach — needs `σ(primes ∪ {0,1}) > 0`, which requires a Brun/Selberg sieve lower bound
+NOT in Mathlib (deep, >1000 LOC). `primes_additive_basis_of_density_pos` would be a trivial
+specialization of `schnirelmann_basis` (shallow, REJECTED per follow-up quality criteria). Mann's
+theorem (`σ(A⊕B) ≥ min(1, σA+σB)`, the sharp strengthening) is the honest theory-level next target
+but is a hard combinatorial result (~200+ LOC), not session-sized.
+
+**Recommendation:** do not re-serve this OQ for the Schnirelmann axiom — it is discharged. Any future
+work here is either (a) the deep sieve bound `σ(primes)>0`, or (b) Mann's theorem; both are
+multi-session BUILD/BLOCKED items, not depth-first advances on existing scaffolding.

--- a/src/data/research/problems/weak-goldbach-oq-01.json
+++ b/src/data/research/problems/weak-goldbach-oq-01.json
@@ -19,12 +19,12 @@
     "phase": "ACT",
     "since": "2026-07-03",
     "iteration": 4,
-    "focus": "Discharging schnirelmann_basis_theorem in WeakGoldbach.lean. The covering engine and the ENTIRE iteration bookkeeping are now verified in SchnirelmannBasis.lean (0 sorry / 0 axiom). Only Schnirelmann's inequality remains.",
+    "focus": "TERMINUS: all session-tractable Schnirelmann work complete and merged; remaining axioms are deep/open.",
     "blockers": [
       "Schnirelmann's inequality sigma(A+B) >= sA+sB-sA*sB is the delicate gap-counting step (Nathanson Thm 7.4 / Ruzsa); an explicit Mathlib TODO, ~120-180 LOC.",
       "Binary Goldbach itself is genuinely open and must stay axiomatized."
     ],
-    "nextAction": "Formalize Schnirelmann's inequality sigma(A+B) >= sA+sB-sA*sB (0 in A, 0 in B). Iterating it drives some sigma(sumsetPow A h) above 1/2, and isAdditiveBasis_of_sumsetPow_density_ge_half then discharges the axiom outright.",
+    "nextAction": "None session-tractable. See knowledge.md terminus note (2026-07-08).",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 1,
@@ -75,7 +75,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalize Schnirelmann's inequality sigma(A+B) >= sA+sB-sA*sB (the gap-counting core, Nathanson Thm 7.4) — now the ONLY missing piece; combine with isAdditiveBasis_of_sumsetPow_density_ge_half to discharge schnirelmann_basis_theorem."
+      "TERMINUS for session-tractable work (r1 2026-07-08): Schnirelmann inequality IS proved (SchnirelmannCounting.schnirelmann_inequality) and schnirelmann_basis_theorem is already discharged. Remaining WeakGoldbach axioms (helfgott/circle-method/chen/binary-verification) are all deep or the open conjecture. Only non-scaffolding directions left are the deep sieve bound sigma(primes)>0 or Mann theorem sigma(A+B)>=min(1,sA+sB) — both multi-session BUILD items, not depth-first advances."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Documentation-only correction for the RICH open-question `weak-goldbach-oq-01`. No Lean changes.

I re-claimed this problem and re-audited its full Schnirelmann chain against `main`. The stale `nextSteps` still asked to *"formalize Schnirelmann's inequality — now the ONLY missing piece"*, but that work is **already complete and merged**:

- `SchnirelmannCounting.counting_bound` — the gap-counting core, proved.
- `SchnirelmannCounting.schnirelmann_inequality` — `σ(C) ≥ σA + σB − σA·σB` (hypotheses only `0∈A, 0∈B`), fully proved.
- `SchnirelmannTheorem.schnirelmann_basis` — `σA>0 ⟹ additive basis of finite order`, proved.
- `WeakGoldbach.schnirelmann_basis_theorem` — the axiom this OQ targeted, **discharged** by r8 on 2026-07-04 (axiomCount 5→4).

The remaining 4 axioms in `WeakGoldbach.lean` are all deep or open — none session-tractable:
`helfgott_weak_goldbach` (Helfgott 2013), `circle_method_asymptotic` (Vinogradov), `chen_theorem` (Chen's theorem), and `binary_goldbach_verified` (the open binary Goldbach conjecture, legitimately axiomatized).

Adding theorems on top of these deep axioms would be scaffolding, not formalization. The only honest non-scaffolding directions left are the deep sieve bound `σ(primes)>0` or Mann's theorem `σ(A⊕B) ≥ min(1, σA+σB)` — both multi-session BUILD items, not depth-first advances.

## Changes

- `knowledge.md`: terminus note (2026-07-08) recording the above so the fleet stops re-mining this OQ.
- `weak-goldbach-oq-01.json`: corrected the stale `nextSteps` / `focus` / `nextAction`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)