### PR TITLE
research(puiseux-theorem-wip-01): Puiseux series form a K-subalgebra + single-inverse closure [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -1,5 +1,6 @@
 import Mathlib.RingTheory.HahnSeries.Basic
 import Mathlib.RingTheory.HahnSeries.Multiplication
+import Mathlib.RingTheory.HahnSeries.Summable
 import Mathlib.RingTheory.PowerSeries.Basic
 import Mathlib.FieldTheory.IsAlgClosed.Basic
 import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
@@ -732,6 +733,58 @@ Confirms the subring's carrier is exactly the Puiseux condition. -/
     y ∈ puiseuxSubring K ↔ IsPuiseuxSeries y := Iff.rfl
 
 end Subring
+
+/-! ### Part IX: The Puiseux series form a `K`-subalgebra
+
+Part VIII bundled the closure lemmas into a `Subring` of `HahnSeries ℚ K`.  When
+the coefficient ring `K` is commutative the ambient `HahnSeries ℚ K` is a
+`K`-algebra (with `algebraMap K (HahnSeries ℚ K) = C = single 0`), and the Puiseux
+series form a `K`-**subalgebra**: they additionally contain every scalar `C c` and
+are closed under the `K`-action.  This is the honest statement that the objects the
+Newton–Puiseux algorithm manipulates form a `K`-algebra, not merely a ring — the
+scalar field `K` embeds into them as the constant series.
+-/
+
+section Subalgebra
+
+/-- The image `algebraMap K (HahnSeries ℚ K) c = C c = single 0 c` of a scalar is a
+Puiseux series (a single term at exponent `0`, ramification `1`). -/
+theorem isPuiseux_algebraMap {K : Type*} [CommRing K] (c : K) :
+    IsPuiseuxSeries (algebraMap K (HahnSeries ℚ K) c) := by
+  rw [← HahnSeries.C_eq_algebraMap, HahnSeries.C_apply]
+  exact isPuiseux_single 0 c
+
+/-- **The Puiseux series form a `K`-subalgebra of `HahnSeries ℚ K`.**
+
+Extends `puiseuxSubring` (Part VIII) with the scalar closure `algebraMap_mem'`: the
+constant series `C c = single 0 c` is Puiseux for every `c : K` (`isPuiseux_algebraMap`),
+and closure under `+`, `*` is inherited from `isPuiseux_add` / `isPuiseux_mul`.  The
+carrier is again exactly the Puiseux condition, so every concrete root constructed in
+this file is an element of this subalgebra. -/
+def puiseuxSubalgebra (K : Type*) [CommRing K] : Subalgebra K (HahnSeries ℚ K) where
+  carrier := {f | IsPuiseuxSeries f}
+  mul_mem' := fun ha hb => isPuiseux_mul ha hb
+  add_mem' := fun ha hb => isPuiseux_add ha hb
+  algebraMap_mem' := isPuiseux_algebraMap
+
+/-- Membership in the Puiseux subalgebra is definitionally the Puiseux condition. -/
+@[simp] theorem mem_puiseuxSubalgebra {K : Type*} [CommRing K] (y : HahnSeries ℚ K) :
+    y ∈ puiseuxSubalgebra K ↔ IsPuiseuxSeries y := Iff.rfl
+
+/-- **First inverse-closure fact: the inverse of a single-term series is Puiseux.**
+
+Over a field `K`, `(single m a)⁻¹ = single (-m) a⁻¹` (`HahnSeries.inv_single`), which is
+again a single term, hence a Puiseux series.  This is the base case of the (still open)
+full inverse-closure `IsPuiseuxSeries f → IsPuiseuxSeries f⁻¹` that would upgrade the
+subring/subalgebra to a subfield.  The general case needs a "series supported on the
+subgroup `(1/n)ℤ` form a subfield" reconstruction (via `HahnSeries.embDomainRingHom`
+from `ℤ ↪o ℚ`), which is not yet available in Mathlib. -/
+theorem isPuiseux_inv_single {K : Type*} [Field K] (m : ℚ) (a : K) :
+    IsPuiseuxSeries (HahnSeries.single m a)⁻¹ := by
+  rw [HahnSeries.inv_single]
+  exact isPuiseux_single (-m) a⁻¹
+
+end Subalgebra
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 SUMMARY

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -82,3 +82,45 @@ theorems, 640→758 lines.
 
 **Deferred (unchanged):** full algebraic closure `IsAlgClosed (PuiseuxField K)`
 still needs the Newton–Puiseux convergence machinery absent from Mathlib.
+
+## Session (researcher-2, 2026-07-08): K-Subalgebra + single-inverse closure
+
+**Mode**: REVISIT (MODERATE) · **Outcome**: progress (3 theorems/1 def VERIFIED 0/0),
+branch research/puiseux-wip01-subalgebra-r2
+
+**Contribution — Part IX: the Puiseux series form a `K`-subalgebra.** researcher-3
+gave the `Subring`; this upgrades it to `puiseuxSubalgebra (K) [CommRing K] :
+Subalgebra K (HahnSeries ℚ K)`. The only new ingredient is scalar closure
+`isPuiseux_algebraMap`: `algebraMap K (HahnSeries ℚ K) c = C c = single 0 c`
+(`HahnSeries.C_eq_algebraMap` (rfl) + `HahnSeries.C_apply`, `C` is `@[simps]` with
+`toFun := single 0`), which is `isPuiseux_single 0 c`. `mul_mem'/add_mem'` reuse the
+existing closure lemmas. `mem_puiseuxSubalgebra` is `Iff.rfl`.
+
+**Contribution — first inverse-closure fact.** `isPuiseux_inv_single [Field K]`:
+`(single m a)⁻¹ = single (-m) a⁻¹` (`HahnSeries.inv_single`) is again a single term,
+hence Puiseux. Base case of the full inverse-closure that would give a subfield.
+
+**Gotchas:**
+- `HahnSeries.inv_single` and the `Field (HahnSeries ℚ K)` instance live in
+  `Mathlib.RingTheory.HahnSeries.Summable`, which the file did NOT import (only
+  Basic/Multiplication/PowerSeries). Added the import. Without it: `inv_single`
+  reads as an unknown constant.
+- Build: clean elaboration `[3070/3070] (0.4–1.8s)` with zero type errors, then
+  exit-135 SIGBUS at olean write on attempts 1–3; **attempt 4 landed clean**
+  (`Build completed successfully`). The file's own knowledge already flagged code-135
+  as an intermittent write crash here, not a logic error — keep retrying.
+
+**Why full inverse-closure is blocked (the real next step).** For `f` supported on
+`(1/n)ℤ`, `f⁻¹` is too: the series supported on the subgroup `(1/n)ℤ ≅ ℤ` form a
+subFIELD of `HahnSeries ℚ K` (via `HahnSeries.embDomainRingHom` from the order
+embedding `ℤ ↪o ℚ`, `k ↦ k/n`, which is a field hom `HahnSeries ℤ K →+* HahnSeries ℚ K`;
+its range is inv-closed and `map_inv₀` transports the inverse). The one missing plumbing
+lemma is the *preimage reconstruction*: `support f ⊆ Set.range (emb) ⇒ ∃ g, embDomain emb g = f`.
+Mathlib has `support_embDomain_subset` and `embDomain_injective` but no surjectivity-onto-
+range / `comapDomain`, so `g` must be built by hand (coeff `g k = f.coeff (k/n)`, PWO via
+`IsPWO.image_of_monotone` through the order-iso). ~60–100 lines of Hahn surgery, high
+SIGBUS risk — deferred, not attempted this session.
+
+**Files Modified:** proofs/Proofs/PuiseuxTheorem.lean (+import Summable; +Part IX:
+isPuiseux_algebraMap, puiseuxSubalgebra, mem_puiseuxSubalgebra, isPuiseux_inv_single;
+758→811 lines, 18→19 numbered theorems + def).

--- a/src/data/research/problems/puiseux-theorem-wip-01.json
+++ b/src/data/research/problems/puiseux-theorem-wip-01.json
@@ -31,12 +31,12 @@
     "goal": "Replace all 5 True-stubs with actual Lean proofs or sorry for Aristotle"
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-21T16:44:08+02:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Structural rounding-out: upgraded the Puiseux Subring (researcher-3) to a K-Subalgebra (puiseuxSubalgebra, algebraMap/C c = single 0 c is Puiseux) and proved the base case of inverse-closure (isPuiseux_inv_single). Full field/subfield inverse-closure remains open (needs subgroup-supported HahnSeries reconstruction absent from Mathlib).",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Full inverse-closure IsPuiseuxSeries f -> IsPuiseuxSeries f-inverse via HahnSeries.embDomainRingHom (Z -> Q, k/n): series supported on (1/n)Z form a subfield. Needs a preimage-reconstruction lemma (support subset range(emb) => in range of embDomain) not yet in Mathlib.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -46,7 +46,9 @@
   "knowledge": {
     "progressSummary": "COMPLETE (verified fragment). All 5 original True-stubs are gone: square_root_puiseux/cusp_parameterization are computed Hahn-series proofs, newton_puiseux_terminates is now prose, and the two main placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were already replaced on main by puiseux_binomial_root + puiseux_binomial_ramification. This session added puiseux_binomial_isRoot lifting the binomial power-equation yⁿ=single m c to a genuine Polynomial.IsRoot of Xⁿ-C(single m c) — the polynomial-level single Newton-edge. File is 0-sorry/0-axiom (only propext/Classical.choice/Quot.sound). Full Newton–Puiseux (arbitrary polynomials + char-0 convergence) is NOT in Mathlib and remains unformalized; it is the genuine open remainder.",
     "builtItems": [
-      "puiseux_binomial_isRoot in proofs/Proofs/PuiseuxTheorem.lean (binomial Puiseux root as Polynomial.IsRoot of Xⁿ-C(single m c); verified, 0 substantive axioms)"
+      "puiseux_binomial_isRoot in proofs/Proofs/PuiseuxTheorem.lean (binomial Puiseux root as Polynomial.IsRoot of Xⁿ-C(single m c); verified, 0 substantive axioms)",
+      "puiseuxSubalgebra (K:CommRing): the Puiseux series form a K-subalgebra of HahnSeries Q K, upgrading the Subring; algebraMap_mem via isPuiseux_algebraMap (algebraMap = C = single 0) [VERIFIED]",
+      "isPuiseux_inv_single (K:Field): (single m a)-inverse = single (-m) a-inverse is Puiseux — base case of inverse closure toward the subfield statement [VERIFIED]"
     ],
     "insights": [
       "The binomial/single-Newton-edge case is the entire algebraic content available without convergence machinery: y=single(m/n)a with aⁿ=c gives yⁿ=single m c via HahnSeries.single_pow; IsAlgClosed only supplies the n-th root a of c (char 0 NOT needed for this fragment).",
@@ -56,6 +58,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "Full inverse-closure -> puiseuxSubfield via HahnSeries.embDomainRingHom (Z ↪o Q, k↦k/n): series supported on the subgroup (1/n)Z form a subfield closed under inverse; blocked on a preimage-reconstruction lemma (support ⊆ range(emb) ⇒ ∈ range embDomain) absent from Mathlib v4.26.",
       "Full Newton–Puiseux for arbitrary polynomials requires: (1) Puiseux subfield as a Subfield of HahnSeries ℚ K, (2) Newton polygon / lower-hull construction, (3) term-by-term iteration with char-0 convergence. None are in Mathlib — large (>1000L) foundational build; leave as documented open remainder."
     ],
     "markdown": "# Knowledge Base: puiseux-theorem-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary

Rounds out the algebraic structure of the Puiseux series in `PuiseuxTheorem.lean` (Wiedijk #41). Predecessor work established that `{f | IsPuiseuxSeries f}` is a **`Subring`** of `HahnSeries ℚ K` (Part VIII). This PR upgrades that to a **`K`-subalgebra** and lands the base case of inverse-closure.

New declarations (Part IX):

- **`isPuiseux_algebraMap`** — `algebraMap K (HahnSeries ℚ K) c = C c = single 0 c` is a Puiseux series (single term at exponent `0`), via `HahnSeries.C_eq_algebraMap` + `C_apply`.
- **`puiseuxSubalgebra (K) [CommRing K] : Subalgebra K (HahnSeries ℚ K)`** — bundles scalar closure with the existing `isPuiseux_add` / `isPuiseux_mul`. `mem_puiseuxSubalgebra` is `Iff.rfl`. This is the honest statement that the Newton–Puiseux algorithm's objects form a `K`-algebra (the scalar field embeds as the constant series), not merely a ring.
- **`isPuiseux_inv_single [Field K]`** — `(single m a)⁻¹ = single (-m) a⁻¹` (`HahnSeries.inv_single`) is again a single term, hence Puiseux. The base case of the full inverse-closure that would give a subfield.

Also adds `import Mathlib.RingTheory.HahnSeries.Summable` (home of `inv_single` and the `HahnSeries` `Field` instance).

## Scope / what remains

Full inverse-closure `IsPuiseuxSeries f → IsPuiseuxSeries f⁻¹` (which would upgrade the subring/subalgebra to a **subfield**) is documented as the next step but **not** attempted: it reduces to "series supported on the subgroup `(1/n)ℤ ≅ ℤ` form a subfield" via `HahnSeries.embDomainRingHom` (`ℤ ↪o ℚ`, `k ↦ k/n`), whose only missing ingredient is a preimage-reconstruction lemma (`support f ⊆ range(emb) ⇒ ∃ g, embDomain emb g = f`) absent from Mathlib v4.26. Full algebraic closure remains blocked on Newton–Puiseux convergence (unchanged, out of scope).

## Verification

`./proofs/scripts/docker-build.sh Proofs.PuiseuxTheorem` → **Build completed successfully (3070 jobs)**, 0 sorry, 0 axioms. (Clean `[3070/3070]` elaboration with zero type errors; the intermittent exit-135 is the known olean-write SIGBUS documented in this file's notes — succeeded on retry.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)