### PR TITLE
Fix: central-limit-theorem-oq-02-oq-04 leanFile.theoremCount overcount (38→37)

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
@@ -25,7 +25,7 @@
     "namespace": "CentralLimitTheoremOQ02OQ04",
     "lineCount": 1984,
     "axiomCount": 0,
-    "theoremCount": 38,
+    "theoremCount": 37,
     "definitionCount": 3,
     "path": "Proofs/CentralLimitTheoremOQ02OQ04.lean",
     "sorries": 2


### PR DESCRIPTION
## Fix

`leanFile.theoremCount` in `central-limit-theorem-oq-02-oq-04/meta.json` was **38**, but the true count is **37**.

## Evidence

**Before**: `leanFile.theoremCount = 38`, disagreeing with `meta.theoremCount = 37`.
**After**: both `= 37`.

The raw-grep count sync miscounted line 236 of `CentralLimitTheoremOQ02OQ04.lean`:

> `lemma is omitted due to nested \`ciSup\` elaboration complexity, so the numerical`

This is **docstring prose**, not a declaration. A comment-stripped, `private`-inclusive scan of the file finds exactly 37 real `theorem`/`lemma` declarations — matching the `meta.theoremCount` the author already recorded. This edit mirrors the stale `leanFile` block to that truth.

No Lean source changes; metadata-only.

---
Automated fix by lean-mechanic agent.