### PR TITLE
Enrich Brianchon's Theorem: re-anchor stale annotation set to current source

### DIFF
--- a/src/data/proofs/brianchon-theorem-oq-01/annotations.json
+++ b/src/data/proofs/brianchon-theorem-oq-01/annotations.json
@@ -3,247 +3,161 @@
     "id": "ann-intro",
     "proofId": "brianchon-theorem-oq-01",
     "range": {
-      "startLine": 7,
-      "endLine": 60
+      "startLine": 4,
+      "endLine": 59
     },
     "type": "concept",
     "title": "Brianchon's Theorem as the Dual of Pascal",
-    "content": "**Brianchon's Theorem (1806)**: If a hexagon is *circumscribed* about a conic — each of its six sides tangent to the conic — then the three main diagonals joining opposite vertices are **concurrent** (they pass through a single point, the *Brianchon point*). This is the exact projective dual of **Pascal's hexagon theorem (1639)**, which concerns a hexagon *inscribed* in a conic and concludes that the three intersections of opposite sides are *collinear*. Duality swaps 'point' with 'line', 'inscribed' with 'circumscribed', and 'collinear' with 'concurrent'. The single deep geometric input (six points on a conic ⟹ Pascal collinearity) is taken as the axiom `conic_implies_pascal`, identical to the one the `pascals-hexagon` gallery entry assumes; no new axiom is introduced.",
-    "mathContext": "The strategy avoids re-deriving the conic theory by transporting Pascal across the polarity $P \\mapsto C \\cdot P$. The new, axiom-free content is the bridge $\\text{Pascal collinear} \\Rightarrow \\text{Brianchon concurrent}$, proved by pure linear algebra over $\\mathbb{R}^3$. Historically Brianchon's result was one of the first dramatic demonstrations of the duality principle, predating its systematic development by Poncelet and Gergonne.",
+    "content": "**Brianchon's Theorem (1806)**: if a hexagon is *circumscribed* about a conic — each of its six sides tangent to the conic — then the three main diagonals joining opposite vertices are **concurrent** (the *Brianchon point*). This is the exact projective dual of **Pascal's hexagon theorem (1639)**, where a hexagon *inscribed* in a conic yields three *collinear* intersection points. The module docstring lays out the strategy: reuse the homogeneous-coordinate model of `PascalsHexagon.lean` verbatim, in which points and lines are both nonzero vectors in ℝ³, `lineThrough = lineIntersection = crossProduct` is a single operation, and `collinear`/`concurrent` are both the vanishing of a 3×3 determinant. Under this model the point↔line duality is literally the identity on `Fin 3 → ℝ`, so Brianchon reduces to Pascal with no new axiom.",
+    "mathContext": "Duality swaps point $\\leftrightarrow$ line, inscribed $\\leftrightarrow$ circumscribed, collinear $\\leftrightarrow$ concurrent. Historically Brianchon's result was among the first dramatic demonstrations of the projective duality principle, predating its systematic development by Poncelet and Gergonne.",
     "significance": "key",
     "relatedConcepts": [
-      "projective-duality",
-      "conic-sections",
-      "pole-polar",
-      "incidence-theorem"
+      "projective duality",
+      "conic sections",
+      "pole-polar polarity",
+      "incidence theorem"
     ],
     "prerequisites": [
-      "projective-plane",
-      "principle-of-duality"
+      "projective plane",
+      "principle of duality"
     ]
   },
   {
-    "id": "ann-projective-model",
+    "id": "ann-dual-conic",
     "proofId": "brianchon-theorem-oq-01",
     "range": {
-      "startLine": 72,
-      "endLine": 114
+      "startLine": 65,
+      "endLine": 74
     },
     "type": "definition",
-    "title": "Homogeneous Coordinate Model in ℝ³",
-    "content": "Points and lines of the projective plane are both modeled as nonzero vectors in $\\mathbb{R}^3$. The **join** of two points and the **meet** of two lines are *both* the cross product (`lineThrough` and `lineIntersection`). Three points are `collinear`, and dually three lines `concurrent`, iff the $3\\times3$ matrix of their coordinate vectors has vanishing determinant. A conic is a symmetric $3\\times3$ matrix $C$, with $p$ on the conic iff $p^{\\mathsf T} C p = 0$.",
-    "mathContext": "In $\\mathbb{RP}^2$ a point is a class $[x:y:z]$ of nonzero vectors up to scaling. The identity $\\det(p,q,r) = (p \\times q)\\cdot r$ makes the determinant the universal incidence test. Crucially, `collinear` and `concurrent` are *the same function* — 'the determinant vanishes' — so the point/line duality is literally the relabelling of a vector as a point or as a line. The quadratic form $\\sum_{i,j} C_{ij}\\,p_i\\,p_j$ encodes the conic.",
-    "significance": "key",
-    "relatedConcepts": [
-      "homogeneous-coordinates",
-      "cross-product",
-      "matrix-determinant",
-      "self-dual-coordinates"
-    ],
-    "prerequisites": [
-      "Fin 3 → ℝ",
-      "scalar-triple-product"
-    ]
-  },
-  {
-    "id": "ann-cofactor-identity",
-    "proofId": "brianchon-theorem-oq-01",
-    "range": {
-      "startLine": 121,
-      "endLine": 133
-    },
-    "type": "theorem",
-    "title": "The Cofactor Cross-Product Identity",
-    "content": "`crossProduct_mulMatrix`: $(M\\cdot u)\\times(M\\cdot v) = (\\operatorname{adj} M)^{\\mathsf T}\\cdot(u\\times v)$. This single degree-3 polynomial identity is the algebraic heart of pole–polar duality: the join/meet operation intertwines the **point map** $M$ with the **line map** $(\\operatorname{adj} M)^{\\mathsf T}$ (the cofactor matrix). It is discharged entirely by `ring` after expanding both sides with `Matrix.adjugate_fin_three`.",
-    "mathContext": "For a linear map $M$ on $\\mathbb{R}^3$, applying $M$ to points pushes lines forward by the inverse-transpose up to scale; over a ring without inverting, the cofactor matrix $\\operatorname{adj} M = \\det(M)\\,M^{-1}$ supplies that map polynomially. The identity is a $3\\times3$ instance of the Binet–Cauchy formula relating exterior powers: $\\Lambda^2 M$ acting on bivectors corresponds, under the Hodge star $u\\wedge v \\leftrightarrow u\\times v$, to $(\\operatorname{adj} M)^{\\mathsf T}$.",
+    "title": "The Dual Conic as the Adjugate Matrix",
+    "content": "PART 1. `dualConic C := Matrix.adjugate C` represents the conic whose *points* are the lines tangent to `C`. For nondegenerate `C` the adjugate equals `det C • C⁻¹`, so `adjugate C` and `C⁻¹` describe the same projective conic — but the adjugate is chosen because it is defined for *every* matrix, degenerate or not, keeping the construction total. `lineTangentToConic l C` is then defined as `pointOnConic l (dualConic C)`: a line is tangent to `C` exactly when it is a point on the dual conic. This single definitional move — tangency to `C` ≡ incidence with `dualConic C` — is what turns the whole duality into bookkeeping.",
+    "mathContext": "$\\text{dualConic}(C) = \\operatorname{adj}(C)$; for invertible $C$, $\\operatorname{adj}(C) = \\det(C)\\,C^{-1}$. Tangency: $\\ell^{\\mathsf T}\\,\\operatorname{adj}(C)\\,\\ell = 0$.",
     "significance": "critical",
     "relatedConcepts": [
-      "adjugate-matrix",
-      "Binet-Cauchy",
-      "exterior-algebra",
-      "pole-polar"
+      "adjugate matrix",
+      "dual conic",
+      "projective tangency",
+      "matrix inverse up to scalar"
     ],
     "prerequisites": [
-      "cofactor-matrix",
-      "cross-product"
+      "adjugate / classical adjoint of a matrix",
+      "conic as a symmetric bilinear form"
     ]
   },
   {
-    "id": "ann-det-transport",
+    "id": "ann-circumscribed-hexagon",
     "proofId": "brianchon-theorem-oq-01",
     "range": {
-      "startLine": 135,
-      "endLine": 149
-    },
-    "type": "theorem",
-    "title": "Determinant Transport Under a Fixed Matrix",
-    "content": "`det_threeVectorMatrix_mulMatrix`: $\\det(M\\cdot u,\\,M\\cdot v,\\,M\\cdot w) = \\det M \\cdot \\det(u,v,w)$. Applying a fixed matrix to all three rows multiplies the triple determinant by $\\det M$. The proof factors the row-stacked matrix as $\\text{(rows }u,v,w)\\cdot M^{\\mathsf T}$ and applies `det_mul` with `det_transpose`.",
-    "mathContext": "Because $\\det M \\cdot 0 = 0$, this lemma is exactly what propagates a *vanishing* source determinant to a vanishing target determinant — and it does so **without any nondegeneracy hypothesis** on $M$. This is why the duality bridge needs no assumption $\\det C \\neq 0$: collinearity (a zero determinant) is forced to concurrency regardless of whether $C$ is invertible.",
-    "significance": "key",
-    "relatedConcepts": [
-      "determinant-multiplicativity",
-      "matrix-determinant",
-      "incidence-preservation"
-    ],
-    "prerequisites": [
-      "Matrix.det_mul",
-      "Matrix.det_transpose"
-    ]
-  },
-  {
-    "id": "ann-dual-matrix",
-    "proofId": "brianchon-theorem-oq-01",
-    "range": {
-      "startLine": 155,
-      "endLine": 170
-    },
-    "type": "lemma",
-    "title": "Iterated Cofactor Collapses to det C · C",
-    "content": "For a symmetric $3\\times3$ conic, `dual_matrix_eq` shows the iterated cofactor matrix $\\big((\\operatorname{adj} C)^{\\mathsf T}\\big)^{\\!\\operatorname{adj}\\,\\mathsf T}$ collapses to the *single* linear map $\\det C \\cdot C$. Symmetry feeds two facts: a symmetric matrix equals its transpose (`transpose_of_symmetric`), and the adjugate of a symmetric matrix is symmetric (`adjugate_symmetric`).",
-    "mathContext": "The general fact is $\\operatorname{adj}(\\operatorname{adj} A) = (\\det A)^{n-2}\\,A$; for $n=3$ the exponent is $1$, so $\\operatorname{adj}(\\operatorname{adj} C) = \\det C \\cdot C$. Applying the cofactor identity twice (once with $M=C$, once with $M=\\operatorname{adj} C$) therefore replaces a double polarity by one fixed scaling map. This is the structural reason Brianchon collapses cleanly onto Pascal in dimension 3 specifically.",
-    "significance": "key",
-    "relatedConcepts": [
-      "adjugate-adjugate",
-      "symmetric-matrix",
-      "pole-polar"
-    ],
-    "prerequisites": [
-      "Matrix.adjugate_adjugate",
-      "Matrix.adjugate_transpose"
-    ]
-  },
-  {
-    "id": "ann-circumscribed",
-    "proofId": "brianchon-theorem-oq-01",
-    "range": {
-      "startLine": 176,
-      "endLine": 183
+      "startLine": 80,
+      "endLine": 104
     },
     "type": "definition",
-    "title": "The Circumscribed Hexagon by Polarity",
-    "content": "The tangent line to conic $C$ at a contact point $P$ is the **polar** $C \\cdot P$ (`tangentLine`). A vertex of the circumscribed hexagon (`circVertex`) is the meet of the tangent lines at two adjacent contact points — i.e. the intersection of two adjacent sides. So the entire circumscribed hexagon is the projective dual of the inscribed hexagon of contact points $A,\\dots,F$.",
-    "mathContext": "Pole–polar duality with respect to $C$ sends a point $P$ on the conic to its tangent line $\\ell = C P$, and conversely a tangent line back to its contact point via $\\operatorname{adj} C$. The contact hexagon's sides are the polars $CA, CB, \\dots, CF$; its vertices $CA \\times CB$ etc. are exactly where the cofactor identity will be applied.",
+    "title": "Hexagon Circumscribed About a Conic",
+    "content": "PART 2. `CircumscribedHexagon C` is the projective dual of `InscribedHexagon`: six lines `a b c d e f`, each carrying a proof `lineTangentToConic · C` that the side is tangent to `C`, plus six `ProjLine.valid` witnesses that each line is a nonzero vector (a genuine projective line). Where the inscribed hexagon stores six *points* on the conic, the circumscribed hexagon stores six *lines* tangent to it — the structure-level manifestation of the point↔line duality. The vertices of the hexagon will be the intersections of consecutive sides.",
+    "mathContext": "Six sides $a,\\dots,f$ with $\\ell^{\\mathsf T}\\operatorname{adj}(C)\\,\\ell = 0$ for each; vertices are consecutive meets $a\\cap b,\\ b\\cap c,\\dots$",
     "significance": "supporting",
     "relatedConcepts": [
-      "tangent-line",
-      "pole-polar",
-      "dual-hexagon"
+      "circumscribed polygon",
+      "tangent lines",
+      "projective line validity",
+      "structure as bundled data"
     ],
     "prerequisites": [
-      "conic-polarity"
+      "tangency condition (dual conic)",
+      "homogeneous coordinates for lines"
     ]
   },
   {
-    "id": "ann-diag-eq",
+    "id": "ann-vertices-diagonals",
     "proofId": "brianchon-theorem-oq-01",
     "range": {
-      "startLine": 189,
-      "endLine": 199
+      "startLine": 106,
+      "endLine": 140
     },
-    "type": "lemma",
-    "title": "Each Diagonal Is the Dual Image of a Pascal Point",
-    "content": "**Key reduction.** `diag_eq` shows a circumscribed-hexagon diagonal `lineThrough (circVertex C P Q) (circVertex C R S)` equals the fixed linear map $\\det C \\cdot C$ applied to the corresponding **Pascal point** `lineIntersection (lineThrough P Q) (lineThrough R S)`. The proof unfolds the definitions, applies the cofactor identity bottom-up (inner meets first, then the outer join), and rewrites with `dual_matrix_eq`.",
-    "mathContext": "Each diagonal is a triple cross product $\\big((CP\\times CQ)\\times(CR\\times CS)\\big)$. The cofactor identity peels $C$ off the inner meets producing $(\\operatorname{adj} C)^{\\mathsf T}$ factors, and the outer join introduces a further cofactor; `dual_matrix_eq` then fuses the iterated cofactors into $\\det C \\cdot C$ acting on the Pascal point $\\big((P\\times Q)\\times(R\\times S)\\big)$. This is the precise sense in which Brianchon's configuration is the polar image of Pascal's.",
-    "significance": "critical",
-    "relatedConcepts": [
-      "Pascal-point",
-      "pole-polar",
-      "dual-configuration"
-    ],
-    "prerequisites": [
-      "cofactor-identity",
-      "adjugate-adjugate"
-    ]
-  },
-  {
-    "id": "ann-bridge",
-    "proofId": "brianchon-theorem-oq-01",
-    "range": {
-      "startLine": 205,
-      "endLine": 229
-    },
-    "type": "theorem",
-    "title": "The Axiom-Free Duality Bridge",
-    "content": "`concurrent_brianchon_of_collinear_pascal` is the central deliverable: for a symmetric conic with six contact points, **if** the three Pascal points are collinear, **then** the three Brianchon diagonals are concurrent. It is proved with **no axioms and no `sorry`** — `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`. The proof rewrites each diagonal via `diag_eq`, transports the determinant by `det_threeVectorMatrix_mulMatrix`, and uses Pascal's vanishing determinant with `mul_zero`.",
-    "mathContext": "This makes the Pascal/Brianchon duality completely explicit and reusable: $\\det(\\text{diagonals}) = \\det(\\det C\\cdot C)\\cdot\\det(\\text{Pascal points}) = (\\det C)^4 \\cdot 0 = 0$. Because the final step multiplies by $0$, no nondegeneracy on $C$ is required. The same template — cofactor cross-product identity plus determinant transport — dualizes other incidence theorems (e.g. the dual of Pappus, Desargues self-duality).",
-    "significance": "critical",
-    "relatedConcepts": [
-      "projective-duality",
-      "Pascal-theorem",
-      "axiom-free",
-      "incidence-theorem"
-    ],
-    "prerequisites": [
-      "det-transport",
-      "diag-eq"
-    ]
-  },
-  {
-    "id": "ann-pascal-axiom",
-    "proofId": "brianchon-theorem-oq-01",
-    "range": {
-      "startLine": 235,
-      "endLine": 260
-    },
-    "type": "concept",
-    "title": "Contact Hexagon and the Shared Pascal Axiom",
-    "content": "`ContactHexagon C` bundles six points $A,B,C',D,E,F$ together with proofs that each lies on the conic $C$. The lone axiom `conic_implies_pascal` states that these six concyclic points make the three opposite-side intersections collinear — exactly the deep fact `pascals-hexagon` axiomatizes as `conic_implies_pascal_constraint`, restated here in collinearity form and reused unchanged. **No new axiom is introduced** by this entry.",
-    "mathContext": "Pascal's theorem is itself a consequence of the Cayley–Bacharach theorem (a cubic through 8 of 9 base points passes through the 9th) or of the Sylvester reduction to the standard conic $xy=z^2$. Axiomatizing it isolates that single geometric input; everything Brianchon-specific in this file is then verified, so the assumption count for Brianchon equals that for Pascal: exactly one.",
+    "type": "definition",
+    "title": "Vertices and the Three Main Diagonals",
+    "content": "The six vertices `vertexAB … vertexFA` are the intersections of consecutive sides, each computed as `lineIntersection` (the cross product) of two sides. The three **main diagonals** join opposite vertices: `mainDiagonal1 = lineThrough (a∩b) (d∩e)`, `mainDiagonal2 = lineThrough (b∩c) (e∩f)`, `mainDiagonal3 = lineThrough (c∩d) (f∩a)`. Because `lineThrough` and `lineIntersection` are the *same* cross-product operation, each diagonal is a nested cross product `crossProduct (crossProduct a b) (crossProduct d e)` — which is precisely the algebraic form of a Pascal point of the six lines viewed as points. This is where the duality becomes computational.",
+    "mathContext": "$\\text{mainDiagonal1} = (a\\times b)\\times(d\\times e)$, matching Pascal's point $AB\\cap DE$ with $A,B,D,E := a,b,d,e$.",
     "significance": "key",
     "relatedConcepts": [
-      "Cayley-Bacharach",
-      "Pascal-theorem",
-      "axiom-integrity",
-      "conic-locus"
+      "cross product join/meet",
+      "opposite vertices",
+      "Pascal point",
+      "nested cross products"
     ],
     "prerequisites": [
-      "structure-fields",
-      "pointOnConic"
+      "cross product as join and meet",
+      "hexagon vertex labeling"
+    ]
+  },
+  {
+    "id": "ann-inscribed-dual",
+    "proofId": "brianchon-theorem-oq-01",
+    "range": {
+      "startLine": 146,
+      "endLine": 168
+    },
+    "type": "technique",
+    "title": "Circumscribed Hexagon = Inscribed Hexagon in the Dual Conic",
+    "content": "PART 3, the duality bridge. `toInscribedDual` exhibits a `CircumscribedHexagon C` as an `InscribedHexagon (dualConic C)` by simply relabeling the data: the six tangent lines `a…f` become the six inscribed points `A…F`, and each tangency proof `hex.ha : lineTangentToConic a C` is *definitionally* an incidence proof `pointOnConic a (dualConic C)` — so the same term type-checks in both roles with no rewriting. This is the point↔line duality made concrete: the two hexagon structures carry identical underlying data.",
+    "mathContext": "Tangency to $C$ is, by the definition of `lineTangentToConic`, incidence with $\\text{dualConic}(C)$; so a circumscribed hexagon *is* an inscribed hexagon in the dual conic, definitionally.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "duality as data relabeling",
+      "definitional equality",
+      "inscribed vs circumscribed",
+      "dual conic incidence"
+    ],
+    "prerequisites": [
+      "structure field projection",
+      "definitional unfolding in Lean"
+    ]
+  },
+  {
+    "id": "ann-duality-identity",
+    "proofId": "brianchon-theorem-oq-01",
+    "range": {
+      "startLine": 170,
+      "endLine": 179
+    },
+    "type": "theorem",
+    "title": "The Duality Identity: Concurrency ≡ Pascal Constraint (Iff.rfl)",
+    "content": "`concurrent_diagonals_eq_pascalConstraint` is the formal heart of 'Brianchon is the dual of Pascal': the concurrency determinant of the three main diagonals is *identically* Pascal's collinearity determinant `pascalConstraint a b c d e f` for the six tangent lines. Both sides are the determinant of the same three cross-product vectors — because `lineThrough = lineIntersection = crossProduct` — so the equivalence is proved by `Iff.rfl`, definitional equality with no computation. The same algebraic expression reads as a *concurrence of lines* or a *collinearity of points* depending only on interpretation.",
+    "mathContext": "$\\det[\\,d_1\\ d_2\\ d_3\\,] = \\text{pascalConstraint}(a,b,c,d,e,f)$ as literally the same expression; hence `concurrent ⟺ pascalConstraint` is `Iff.rfl`.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "definitional equality (Iff.rfl)",
+      "determinant of cross products",
+      "concurrency vs collinearity",
+      "self-dual algebraic form"
+    ],
+    "prerequisites": [
+      "3×3 determinant as concurrency/collinearity test",
+      "reflexivity of Iff"
     ]
   },
   {
     "id": "ann-brianchon-theorem",
     "proofId": "brianchon-theorem-oq-01",
     "range": {
-      "startLine": 266,
-      "endLine": 291
+      "startLine": 185,
+      "endLine": 201
     },
-    "type": "theorem",
-    "title": "Brianchon's Theorem (Concurrency)",
-    "content": "`brianchon_theorem`: for a symmetric conic $C$ and any contact hexagon, the three main diagonals `brianchonDiag1/2/3` are concurrent. The proof is a one-liner: feed Pascal's axiom `conic_implies_pascal C hex` into the axiom-free bridge `concurrent_brianchon_of_collinear_pascal`. It therefore uses **no axiom beyond** `conic_implies_pascal`.",
-    "mathContext": "Here concurrency is recorded as the vanishing of the diagonals' coefficient determinant $\\det(\\text{diag}_1,\\text{diag}_2,\\text{diag}_3) = 0$. This is the standard projective statement of Brianchon's theorem, dual to Pascal's $\\det(\\text{Pascal points}) = 0$. The next part strengthens this determinant condition to a genuine common point.",
+    "type": "insight",
+    "title": "Brianchon's Theorem via One Rewrite Plus Pascal",
+    "content": "PART 4, the payoff. `brianchon_theorem` states that the three main diagonals of any hexagon circumscribed about `C` are concurrent. The proof is two steps: rewrite the goal along `concurrent_diagonals_eq_pascalConstraint` to turn concurrency into the Pascal constraint, then discharge it with `conic_implies_pascal_constraint (dualConic C) (toInscribedDual hex)` — Pascal's theorem applied to the six sides viewed as points inscribed in the dual conic. All the genuinely deep geometry (Cayley–Bacharach / Bézout, inherited as the sole axiom from `pascals-hexagon`) lives in Pascal; Brianchon adds only the axiom-free, fully machine-checked duality reduction.",
+    "mathContext": "`rw [concurrent_diagonals_eq_pascalConstraint]` then `exact conic_implies_pascal_constraint (dualConic C) (toInscribedDual hex)`. No `axiom`/`sorry`/`native_decide` in this file.",
     "significance": "key",
     "relatedConcepts": [
-      "concurrency",
-      "main-diagonals",
-      "projective-duality"
+      "theorem reduction by rewriting",
+      "Cayley–Bacharach theorem",
+      "axiom reuse across entries",
+      "Brianchon point"
     ],
     "prerequisites": [
-      "duality-bridge",
-      "Pascal-axiom"
-    ]
-  },
-  {
-    "id": "ann-brianchon-point",
-    "proofId": "brianchon-theorem-oq-01",
-    "range": {
-      "startLine": 297,
-      "endLine": 370
-    },
-    "type": "theorem",
-    "title": "The Genuine Brianchon Point",
-    "content": "The bare determinant condition is also satisfied degenerately (e.g. two coincident diagonals). `brianchon_point` recovers Brianchon's classical claim of a *single* common point: under the natural nondegeneracy hypothesis that the first two diagonals actually meet in a well-defined point (`lineIntersection (brianchonDiag1 hex) (brianchonDiag2 hex) ≠ 0`), all three diagonals pass through one explicit projective point. The witness is that meet; the first two incidences are the self-incidence identities `dotProduct_self_crossProduct` / `dotProduct_crossProduct_self`, and the third is exactly the concurrency from `brianchon_theorem`, re-expressed via the scalar-triple-product identity `det(a,b,c) = c·(a×b)`.",
-    "mathContext": "Incidence is $\\ell \\cdot X = 0$ (`onLine`). The meet $X = \\text{diag}_1 \\times \\text{diag}_2$ automatically satisfies $\\text{diag}_1\\cdot X = 0$ and $\\text{diag}_2\\cdot X = 0$ since $u\\cdot(u\\times v) = v\\cdot(u\\times v) = 0$. The third incidence $\\text{diag}_3 \\cdot X = 0$ is the concurrency determinant under the identification $\\det(\\text{diag}_1,\\text{diag}_2,\\text{diag}_3) = \\text{diag}_3 \\cdot(\\text{diag}_1\\times\\text{diag}_2)$. This upgrade is pure linear algebra: no axiom beyond `conic_implies_pascal`.",
-    "significance": "key",
-    "relatedConcepts": [
-      "Brianchon-point",
-      "scalar-triple-product",
-      "nondegeneracy",
-      "concurrency"
-    ],
-    "prerequisites": [
-      "meet-incidence",
-      "scalar-triple-product"
+      "Pascal's hexagon theorem (parent entry)",
+      "rewriting with a definitional equivalence"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `brianchon-theorem-oq-01`.

**Gap addressed (real defect):** the 11 annotations were written for an earlier ~370-line, matrix-cofactor-heavy version of the proof and had **fully detached from the current 201-line source**:
- 4 annotations pointed to lines **205–370** (the file has 201 lines) — flagged `out of bounds` by `annotations:build`;
- the other 7 referenced constructs that **do not exist** in the current file (cofactor cross-product identity, determinant transport under a fixed matrix, iterated-cofactor collapse to `det C · C`).

The current proof instead uses `Matrix.adjugate` as a black box and reduces Brianchon to Pascal **definitionally** (`Iff.rfl`).

**Fix:** replaced the set with **7 accurate annotations**, each verified to land on a real declaration (all pass the `annotations:build` construct validator — 0 misaligned, was 11):

| Lines | Construct | Annotation |
|-------|-----------|-----------|
| 4–59 | module docstring | Brianchon as the projective dual of Pascal |
| 65–74 | `dualConic`, `lineTangentToConic` | dual conic = adjugate; tangency ≡ dual-conic incidence |
| 80–104 | `CircumscribedHexagon` | six tangent lines (dual of six inscribed points) |
| 106–140 | `vertexAB…FA`, `mainDiagonal1/2/3` | diagonals as nested cross products = Pascal points |
| 146–168 | `toInscribedDual` | circumscribed = inscribed-in-dual, definitionally |
| 170–179 | `concurrent_diagonals_eq_pascalConstraint` | the `Iff.rfl` duality identity |
| 181–201 | `brianchon_theorem` | `rw` + `conic_implies_pascal_constraint` |

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. meta.json unchanged (sections already had valid ranges). Verified against the Lean source; no axiom-integrity changes.