### PR TITLE
Fix: erdos-147 contributions mask two axioms and overstate erdos_147 theorem

### DIFF
--- a/src/data/proofs/erdos-147/meta.json
+++ b/src/data/proofs/erdos-147/meta.json
@@ -48,11 +48,11 @@
       }
     ],
     "originalContributions": [
-      "turanNumber: axiomatized extremal graph function ex(n; H)",
-      "minDegree: minimum vertex degree δ(G) via Finset.inf'",
-      "janzer_disproof: Janzer's counterexample for even r ≥ 4",
-      "probabilistic_lower_bound: ex(n; H) ≥ c·n^{2-2/r+ε}",
-      "erdos_147: main theorem closing the problem at r = 4"
+      "turanNumber axiom: extremal graph function ex(n; H)",
+      "minDegree definition: minimum vertex degree δ(G) via Finset.inf'",
+      "janzer_disproof axiom: Janzer's counterexample for even r ≥ 4",
+      "probabilistic_lower_bound axiom: ex(n; H) ≥ c·n^{2-2/r+ε}",
+      "erdos_147 theorem: specializes the janzer_disproof axiom to r = 4 (statement only; the disproof itself is the axiom)"
     ],
     "axiomCount": 3,
     "lineCount": 101,


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-147 (Turán Numbers for Bipartite Graphs — Janzer disproof)
**Severity**: LOW (language precision; no status/count change)

Counts all verify against `proofs/Proofs/Erdos147Problem.lean`: 3 axioms
(`turanNumber`, `janzer_disproof`, `probabilistic_lower_bound`), 1 def
(`minDegree`), 1 theorem (`erdos_147`), 0 sorries, 101 lines. `status`
`axiomatized` / `badge` `axiom` are correct. Axioms are substantive (not
`True`-stubbed) and genuinely present (no phantom contributions).

## Problem

Two precision gaps in `originalContributions` (user-facing):

1. **Axiom masking.** `janzer_disproof` and `probabilistic_lower_bound` are
   `axiom` declarations, but their bullets omitted the "axiom" label — while
   `turanNumber`'s bullet said "axiomatized". The inconsistency makes the two
   unlabeled axioms read like proved results.

2. **Overstated theorem.** `erdos_147` was billed as *"main theorem closing
   the problem at r = 4."* Its proof is literally:
   ```lean
   theorem erdos_147 : ... := by
     use 4; constructor; · omega
     exact janzer_disproof 4 (by omega) ⟨2, rfl⟩
   ```
   i.e. a one-line specialization of the `janzer_disproof` axiom. The theorem
   closes nothing — the axiom asserts Janzer's disproof; `erdos_147` just plugs
   in r = 4.

## Fix

`meta.json` `originalContributions` only — label all three axioms consistently
and reword the `erdos_147` bullet to say it specializes the axiom (statement
only). The `assumptions` field already disclosed all 3 axioms, so no public
claim changes; this aligns the bullets with the axiom-labeling style already
used in the clean erdos-148 entry.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)