### PR TITLE
research(collatz-structured-oq-02-oq-03): orbit minimum bounds & is monotone along the full trajectory [VERIFIED]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1022,6 +1022,25 @@ theorem colMin_le_collatz (n : ℕ) : colMin n ≤ colMin (collatz n) := by
   obtain ⟨k, hk⟩ := colMin_mem_orbit (collatz n)
   exact Nat.sInf_le ⟨k + 1, by rw [Function.iterate_succ_apply]; exact hk⟩
 
+/-- The orbit minimum bounds **every** value on the orbit, not just the start:
+`colMin n ≤ collatz^[k] n` for all `k`.  The `k`-th iterate lies in the orbit set,
+so the infimum is `≤` it (`Nat.sInf_le`).  Generalises `colMin_le_self` (`k = 0`). -/
+theorem colMin_le_iterate (n k : ℕ) : colMin n ≤ collatz^[k] n :=
+  Nat.sInf_le ⟨k, rfl⟩
+
+/-- The orbit minimum is **non-increasing along the whole trajectory**:
+`colMin n ≤ colMin (collatz^[k] n)` for all `k`.  Each further step passes to a
+sub-orbit whose infimum can only grow (`colMin_le_collatz`), and iterating this gives
+the bound for every `k`.  Generalises `colMin_le_collatz` (`k = 1`); combined with
+`colMin_le_iterate` it shows the orbit minimum of any iterate is sandwiched:
+`colMin n ≤ colMin (collatz^[k] n) ≤ collatz^[k] n`. -/
+theorem colMin_le_colMin_iterate (n k : ℕ) : colMin n ≤ colMin (collatz^[k] n) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rw [Function.iterate_succ_apply']
+    exact le_trans ih (colMin_le_collatz _)
+
 /-- **The orbit-minimum recursion** (the Bellman/dynamic-programming identity for
 `Col_min`): `colMin n = min n (colMin (collatz n))`.  The minimum over the orbit of
 `n` is either attained at `n` itself (step `0`) or somewhere in the orbit of its

--- a/research/problems/collatz-structured-oq-02-oq-03/state.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/state.md
@@ -4,7 +4,21 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-08T00:00:00Z
-**Iteration**: 8
+**Iteration**: 9
+
+## Iteration 9 (researcher-4, 2026-07-08, VERIFIED via docker-build, PR #36029)
+Added two decide-FREE Part III structural lemmas for the orbit minimum, each the
+full-trajectory generalization of an existing `k ≤ 1` fact:
+- `colMin_le_iterate (n k) : colMin n ≤ collatz^[k] n` — the orbit minimum bounds
+  EVERY orbit value (not just the start `n`); one line `Nat.sInf_le ⟨k, rfl⟩`,
+  generalizes `colMin_le_self` (k=0).
+- `colMin_le_colMin_iterate (n k) : colMin n ≤ colMin (collatz^[k] n)` — the orbit
+  minimum is non-increasing along the whole trajectory; induction on k via
+  `colMin_le_collatz`, generalizes `colMin_le_collatz` (k=1).
+Together: `colMin n ≤ colMin (collatz^[k] n) ≤ collatz^[k] n`. File 1801→1820 lines,
+0 sorries, 1 axiom (`tao_2019`) unchanged; NO `decide`/`native_decide`, so first-try
+green docker-build (7743 jobs, exit 0) — no exit-135 risk (contrast iter 8's decide
+crashes). meta.json synced (theoremCount 64→66).
 
 ## Iteration 8 (researcher-9, 2026-07-08, VERIFIED via docker-build)
 Added `autoDropCert_colMin_lt`: the general bridge from the Part VII turnkey certificate

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,11 +20,11 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1801,
+    "lineCount": 1820,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 64,
+    "theoremCount": 66,
     "definitionCount": 13,
     "originalContributions": [
       "attainsBelow_density_of_autoDropCert: fuses the general density lemma attainsBelow_density_of_residues with the turnkey autoDropCert engine, so the drop-below density floor at any 2^b level is (#auto-certified residues)·(N-1) with ZERO per-residue proof — the residue count is a decide, every drop hypothesis is autoDropCert_attainsBelow (axiom-free, no native_decide)"
@@ -137,9 +137,9 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1801,
+    "lineCount": 1820,
     "axiomCount": 1,
-    "theoremCount": 64,
+    "theoremCount": 66,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 13


### PR DESCRIPTION
## Summary

Incremental, fully-verified addition to the Erdős/Collatz OQ-03 file (`Proofs/CollatzStructuredOQ02OQ03.lean`, Part III: the orbit minimum `colMin`). Adds the two full-trajectory generalizations of the existing `k ≤ 1` orbit-minimum facts — both **`decide`-free**, so they carry no kernel-memory (exit-135/SIGBUS) risk that the certificate/`autoDropCert` layer is prone to.

## What's new (+2 theorems, +19 lines)

- **`colMin_le_iterate (n k) : colMin n ≤ collatz^[k] n`** — the orbit minimum bounds *every* value on the orbit, not just the start. One line: the `k`-th iterate is in the orbit set, so `Nat.sInf_le ⟨k, rfl⟩`. Generalizes `colMin_le_self` (the `k = 0` case).
- **`colMin_le_colMin_iterate (n k) : colMin n ≤ colMin (collatz^[k] n)`** — the orbit minimum is **non-increasing along the whole trajectory**: each further Collatz step passes to a sub-orbit whose infimum can only grow (`colMin_le_collatz`), iterated. Induction on `k`. Generalizes `colMin_le_collatz` (the `k = 1` case).

Together they sandwich the orbit minimum of any iterate: `colMin n ≤ colMin (collatz^[k] n) ≤ collatz^[k] n`.

## Status / counts

- File: 1820 lines, 66 theorems, 13 definitions, **0 sorries**, **1 axiom** (`tao_2019`, the deep Tao-2019 log-density-1 result — untouched by this PR). No `native_decide`; the new lemmas use only `Nat.sInf_le` and induction.
- `meta.json` synced: lineCount 1801→1820, theoremCount 64→66 (both `meta.*` and `leanFile.*`).

## Verification

Green `✔ Built Proofs.CollatzStructuredOQ02OQ03 (10s)` — **exit 0**, 7743 jobs — via `./proofs/scripts/docker-build.sh Proofs.CollatzStructuredOQ02OQ03` against current `origin/main`, first try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)