### PR TITLE
research(erdos-666-incomplete-01): extend Chung refutation to the interval ε ≤ 1/4 [VERIFIED, 0 new axioms]

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -215,6 +215,48 @@ Instantiating Erdős's conjecture at `ε = 1/4` would supply a threshold `N` mak
 theorem erdos_conjecture_false : ¬ErdosConjecture := fun hConj =>
   chung_no_threshold (hConj (1/4) (by norm_num))
 
+/-!
+### Part IV.5: The refutation holds on the whole interval `ε ≤ 1/4`
+
+Chung's axiom only names the single density `ε = 1/4`, but the counterexample it
+supplies refutes the conjecture for *every* smaller density as well: a graph that
+is `(1/4)`-dense and `C₆`-free is automatically `ε`-dense for any `ε ≤ 1/4`, so no
+threshold can work at any such `ε`.  Formally this is a monotonicity fact —
+`ConjectureAt` is monotone in `ε` — and it costs **no new axioms**, only the
+already-assumed `chung_no_threshold`.  The upshot: Erdős's conjecture fails not at
+an isolated bad density but robustly across the entire range `(0, 1/4]`.
+-/
+
+unseal EpsilonDenseSubgraph in
+/-- **`ε`-density is antitone in `ε`.**  A subgraph that is `ε`-dense is also
+`ε'`-dense for every `ε' ≤ ε`, since the required edge count `ε' · Eₙ ≤ ε · Eₙ`
+only decreases (the hypercube edge count `Eₙ = n·2ⁿ⁻¹` is nonnegative). -/
+theorem epsilonDense_antitone {n : ℕ} {ε ε' : ℝ} (hle : ε' ≤ ε)
+    {H : SimpleGraph (Fin (2^n))} (hH : EpsilonDenseSubgraph n ε H) :
+    EpsilonDenseSubgraph n ε' H :=
+  le_trans (mul_le_mul_of_nonneg_right hle (Nat.cast_nonneg _)) hH
+
+/-- **`DenseForcesC6` is monotone in `ε`.**  If every `ε'`-dense subgraph is forced
+to contain `C₆`, then so is every `ε`-dense subgraph for `ε ≥ ε'` (the `ε`-dense
+subgraphs form a subclass of the `ε'`-dense ones). -/
+theorem denseForcesC6_mono {n : ℕ} {ε ε' : ℝ} (hle : ε' ≤ ε)
+    (h : DenseForcesC6 n ε') : DenseForcesC6 n ε :=
+  fun H hH => h H (epsilonDense_antitone hle hH)
+
+/-- **`ConjectureAt` is monotone in `ε`.**  The same threshold `N` witnesses the
+conjecture at the larger density `ε` once it holds at `ε' ≤ ε`. -/
+theorem conjectureAt_mono {ε ε' : ℝ} (hle : ε' ≤ ε)
+    (h : ConjectureAt ε') : ConjectureAt ε :=
+  let ⟨N, hN⟩ := h
+  ⟨N, fun n hn => denseForcesC6_mono hle (hN n hn)⟩
+
+/-- **Chung's refutation extends to every `ε ≤ 1/4`.**  Were the conjecture to hold
+at some `ε ≤ 1/4`, monotonicity would push it up to `ε = 1/4`, contradicting
+`chung_no_threshold`.  So `ConjectureAt ε` fails for the whole interval `ε ≤ 1/4` —
+in particular for every positive density `0 < ε ≤ 1/4`. -/
+theorem chung_no_threshold_le {ε : ℝ} (hε : ε ≤ 1/4) : ¬ ConjectureAt ε :=
+  fun h => chung_no_threshold (conjectureAt_mono hε h)
+
 /-
 ## Part V: Chung's Result (1992)
 

--- a/research/problems/erdos-666-incomplete-01/knowledge.md
+++ b/research/problems/erdos-666-incomplete-01/knowledge.md
@@ -18,3 +18,32 @@ Initial knowledge for problem `erdos-666-incomplete-01`.
 
 - Gallery: `src/data/proofs/erdos-666/`
 - Lean source: `proofs/Proofs/` (check namespace `Erdos666`)
+
+## Session (researcher-2, 2026-07-08): interval refutation ε ≤ 1/4
+
+**Mode**: REVISIT (MODERATE) · **Outcome**: progress (4 theorems VERIFIED, 0 new axioms),
+branch research/erdos666-interval-refutation-r2
+
+**Contribution — Part IV.5: refutation on the whole interval ε ≤ 1/4.** The axiom
+`chung_no_threshold : ¬ConjectureAt (1/4)` only names the single density 1/4. Added
+a density-monotonicity chain that extends the refutation to every ε ≤ 1/4 without any
+new axiom:
+- `epsilonDense_antitone` (unseal EpsilonDenseSubgraph): ε'≤ε ⇒ (ε-dense H ⇒ ε'-dense H),
+  since `ε'·Eₙ ≤ ε·Eₙ ≤ #edges` (`Eₙ = n·2ⁿ⁻¹ ≥ 0`, `mul_le_mul_of_nonneg_right` +
+  `le_trans`). One-liner term proof.
+- `denseForcesC6_mono` / `conjectureAt_mono`: `DenseForcesC6` and `ConjectureAt` are
+  monotone in ε (ε-dense graphs are a subclass of ε'-dense ones; same threshold N).
+- `chung_no_threshold_le : ε ≤ 1/4 → ¬ConjectureAt ε` — the headline: monotonicity would
+  push a conjecture-at-ε up to 1/4, contradicting the axiom. So Erdős's conjecture fails
+  robustly across the whole range (0, 1/4], not at an isolated point.
+
+**File state:** 1 axiom (`chung_no_threshold`, genuinely deep — Chung's 4-partition, not
+in Mathlib, NOT eliminable), 0 sorries. 326→368 lines.
+
+**Gotcha:** a `/-- docstring -/` must come AFTER `unseal … in`, not before — a docstring
+cannot attach to the `unseal` command (`unexpected token 'unseal'; expected 'lemma'`).
+Match the existing `chung_c6free` order: `unseal … in` / `/-- … -/` / `theorem`.
+
+**Remaining (unchanged):** `conder_better_bound` keeps a `True` placeholder for the
+ε=1/3 density (needs Conder's 3-coloring = a new deep axiom); `GeneralizedConjecture`
+(C_{2k}) open. Build: green attempt 1.

--- a/src/data/research/problems/erdos-666-incomplete-01.json
+++ b/src/data/research/problems/erdos-666-incomplete-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-03T12:23:52.517Z",
-    "iteration": 1,
-    "focus": "De-axiomatized chung_c6free in the parent Erdos666Problem.lean (researcher-4, 2026-07-08): the existence axiom '∀ n≥3, ∃ H, ¬HasC6 H' carries no edge-count data, so the empty subgraph ⊥ (no edges ⇒ no cycle) proves it outright. Entry axiom count 2→1; the deep density content stays isolated in chung_no_threshold. docker-build verified.",
+    "iteration": 2,
+    "focus": "Strengthened Chung refutation from the single point ε=1/4 to the whole interval ε≤1/4 (researcher-2): density monotonicity (epsilonDense_antitone, denseForcesC6_mono, conjectureAt_mono) turns the axiom chung_no_threshold into chung_no_threshold_le : ε≤1/4 → ¬ConjectureAt ε. Zero new axioms. File 0 sorry, 1 axiom.",
     "blockers": [],
-    "nextAction": "The remaining axiom chung_no_threshold (a *dense* 1/4-density C6-free subgraph via Chung's explicit 4-partition of Qₙ) is the genuine deep content — de-axiomatizing it needs the combinatorial edge-partition construction, absent from Mathlib. Alternative: formalize hypercube edge/vertex-count lemmas (hypercubeEdges = n·2^(n-1)) as theorems.",
+    "nextAction": "Remaining structural gaps: (1) conder_better_bound still carries a True placeholder for the ε=1/3 density claim (needs Conder 3-coloring construction, a new deep axiom); (2) GeneralizedConjecture for C_{2k} remains open. The single axiom chung_no_threshold is genuinely deep (Chung 4-partition, not in Mathlib) — not eliminable.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +32,9 @@
     "progressSummary": "COMPLETED: Discharged the lone sorry in erdos_conjecture_false and repaired the file so it actually compiles (it previously had 24 errors: nonexistent Nat.popcount, missing Real/edgeFinset imports, orphaned docstrings, a buggy HasCycle mod_lt, and a malformed conder_better_bound tuple). The disproof now follows from a single well-formed axiom chung_1992 (density form). 0 sorries, 1 axiom; #print axioms shows only propext/Classical.choice/Quot.sound + chung_1992.",
     "builtItems": [
       "Proved Erdos666.erdos_conjecture_false from chung_1992 (Proofs/Erdos666Problem.lean)",
-      "Repaired Hypercube, HasCycle, DenseSubgraph defs and imports so the file compiles (282 lines, 0 errors)"
+      "Repaired Hypercube, HasCycle, DenseSubgraph defs and imports so the file compiles (282 lines, 0 errors)",
+      "epsilonDense_antitone / denseForcesC6_mono / conjectureAt_mono: ConjectureAt is monotone in ε (density antitone, forcing/conjecture monotone) [VERIFIED]",
+      "chung_no_threshold_le : ε ≤ 1/4 → ¬ConjectureAt ε — Chung refutation extended from the point 1/4 to the whole interval (0,1/4], 0 new axioms [VERIFIED]"
     ],
     "insights": [
       "The old chung_1992 axiom (bare 4-partition, only H1/H2 disjointness, no edge counts) was insufficient AND malformed: it could not justify erdos_conjecture_false because the disproof needs a density lower bound on one part.",
@@ -42,6 +44,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "Replace the True placeholder in conder_better_bound with a real ε=1/3 density statement (needs Conder 3-coloring = new deep axiom).",
       "Optional: formalize Chung's explicit 4-partition to eliminate the single remaining axiom (large, ~1000+ lines)."
     ]
   },
@@ -61,7 +64,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T12:23:52.517Z",
-  "lastUpdate": "2026-07-08",
+  "lastUpdate": "2026-07-08T00:00:00Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Erdős Problem #666 (C₆ in dense hypercube subgraphs) is **disproved** by Chung (1992), captured in `Erdos666Problem.lean` by the single axiom

```lean
axiom chung_no_threshold : ¬ ConjectureAt (1/4)
```

which names only the density `ε = 1/4`. This PR strengthens the refutation to the **whole interval `ε ≤ 1/4`** using nothing but density monotonicity — **no new axioms** (Part IV.5):

- **`epsilonDense_antitone`** — a subgraph that is `ε`-dense is also `ε'`-dense for every `ε' ≤ ε` (the required edge count `ε'·Eₙ ≤ ε·Eₙ ≤ #edges`, since `Eₙ = n·2ⁿ⁻¹ ≥ 0`).
- **`denseForcesC6_mono` / `conjectureAt_mono`** — `DenseForcesC6` and `ConjectureAt` are monotone in `ε` (the `ε`-dense subgraphs are a subclass of the `ε'`-dense ones, so the same threshold `N` works).
- **`chung_no_threshold_le : ε ≤ 1/4 → ¬ ConjectureAt ε`** — the headline: if the conjecture held at any `ε ≤ 1/4`, monotonicity would push it up to `ε = 1/4`, contradicting the axiom. So Erdős's conjecture fails **robustly across the entire range `(0, 1/4]`**, not at an isolated bad density.

## Axiom status

Unchanged: **1 axiom** (`chung_no_threshold`), **0 sorries**. The axiom is genuinely deep (Chung's explicit edge-partition of `Qₙ` into four `C₆`-free subgraphs, not available in Mathlib) and is not eliminable at the session level; the new content is derived entirely from it.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos666Problem` → **Build completed successfully (7743 jobs)**, 0 sorries, 1 (pre-existing) axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)