### PR TITLE
Fix: erdos-173 incomplete axiom disclosure ('and 1 more') + one masked axiom

### DIFF
--- a/src/data/proofs/erdos-173/meta.json
+++ b/src/data/proofs/erdos-173/meta.json
@@ -49,14 +49,14 @@
       "IsRamseyTriangle and AlmostAllTrianglesRamsey definitions",
       "shader_theorem axiom: right triangles are Ramsey",
       "right_345_ramsey: concrete example from shader_theorem",
-      "stripColoring construction and equilateral_not_monochromatic_strip",
+      "stripColoring construction and equilateral_not_monochromatic_strip axiom",
       "at_most_one_is_tight theorem from strip coloring",
       "Similar definition and similarity_preserves_ramsey axiom",
       "erdos_173_summary combining all results"
     ],
     "axiomCount": 4,
     "lineCount": 234,
-    "assumptions": "4 axioms: shader_theorem, equilateral_not_monochromatic_strip, erdos_173_conjecture, and 1 more. See Lean source for complete statements.",
+    "assumptions": "4 axioms: shader_theorem (right triangles are Ramsey — Shader 1976), equilateral_not_monochromatic_strip (strip coloring blocks a monochromatic equilateral triangle), erdos_173_conjecture (all but at most one triangle is Ramsey — the open conjecture), similarity_preserves_ramsey (Ramsey property is scale-invariant). See Lean source for complete statements.",
     "theoremCount": 3,
     "definitionCount": 12
   },


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-173 (Monochromatic Triangles — Shader)
**Severity**: LOW (disclosure completeness + language precision)

All counts verify against `proofs/Proofs/Erdos173Problem.lean`: 4 axioms, 3
theorems, 12 defs, 0 sorries, 234 lines. `status` `axiomatized` / `badge`
`axiom` correct. Theorems are honest — `right_345_ramsey` genuinely verifies
3²+4²=5² via `norm_num` before applying `shader_theorem`; `erdos_173_summary`
is a disclosed axiom conjunction.

## Problems

1. **Incomplete disclosure.** `assumptions` read *"4 axioms: shader_theorem,
   equilateral_not_monochromatic_strip, erdos_173_conjecture, **and 1 more**"* —
   the 4th axiom (`similarity_preserves_ramsey`) was never named.

2. **Masked axiom.** `equilateral_not_monochromatic_strip` (line 166, `axiom`)
   appears in an `originalContributions` bullet without the "axiom" label,
   while sibling axioms `shader_theorem` and `similarity_preserves_ramsey`
   *are* labeled.

## Fix

`meta.json` only: name all 4 axioms in `assumptions` (with one-line glosses)
and label `equilateral_not_monochromatic_strip` as an axiom in its bullet.
No count/status change.

Part of the Erdős axiom-labeling cleanup (cf. PRs #36027 erdos-147, #36031
erdos-144).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)