### PR TITLE
research(knights-tour-oblique-oq-02): reversal is fixed-point-free ⇒ 2 ∣ obliqueDistribution k unconditionally [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/KnightsTourObliqueOQ02Palindrome.lean
+++ b/proofs/Proofs/KnightsTourObliqueOQ02Palindrome.lean
@@ -1,0 +1,164 @@
+/-
+  Knight's Tour Oblique Angles: Reversal is Fixed-Point-Free, so the Reversal
+  Factor Contributes an Unconditional Factor of 2 (OQ-02, Target E)
+
+  The sibling files built the order-16 symmetry group `D4 × C2` acting on closed
+  knight's tours (`KnightsTourObliqueOQ02Order16.lean`), where the `C2` factor is
+  time reversal `reverseTour`. The `Order16` file's orbit-divisibility result
+  `fullOrbit_card_dvd_sixteen` shows every orbit has size dividing 16, but the
+  precise power of 2 dividing `obliqueDistribution k` was left conditional on a
+  fixed-point analysis (flagged as the next step in the OQ-02 knowledge trail:
+  *"Show closed knight tours are never palindromic … would give every reversal
+  orbit size 2, hence 2 ∣ levelSet card unconditionally"*).
+
+  This file closes that gap for the **reversal factor**:
+
+  ## What this file proves (verified, 0 sorries, 0 axioms)
+
+  * `reverseTour_ne_self` — **no closed tour is palindromic**: `reverseTour t ≠ t`.
+    A closed tour is a `Nodup` list of 64 distinct squares, and a `Nodup` list
+    of length `≥ 2` can never equal its own reverse (its first and last entries
+    would coincide). So reversal is a *fixed-point-free* involution on
+    `ClosedTour`.
+  * `reverseOrbit_card` — every pure reversal orbit `{t, reverseTour t}` has
+    cardinality exactly `2` (immediate from fixed-point-freeness).
+  * `even_card_levelSet` / `two_dvd_obliqueDistribution` — **the headline**:
+    because the fixed-point-free involution `reverseTour` maps every histogram
+    level set `levelSet k` bijectively onto itself
+    (`levelSet_image_reverseTour_eq`), each level set partitions into matched
+    two-element reversal orbits, so `2 ∣ obliqueDistribution k` for **every** `k`,
+    unconditionally. This is the reversal analogue of the (conditional) D4 orbit
+    count, and it holds with no self-symmetry hypothesis precisely because
+    reversal — unlike a board symmetry — can never fix a tour.
+
+  Parent: `KnightsTourOblique.lean`.
+  Siblings: `KnightsTourObliqueOQ02.lean`, `…OQ02Reverse.lean`,
+  `…OQ02ReverseCount.lean`, `…OQ02Order16.lean`.
+-/
+
+import Mathlib
+import Proofs.KnightsTourObliqueOQ02Order16
+
+namespace KnightsTourOblique
+
+open List
+
+/-! ## A `Nodup` list of length ≥ 2 cannot be a palindrome -/
+
+/-- A `Nodup` list that equals its own reverse has length at most one. If it had
+    length `≥ 2`, its entry at index `length - 1` would equal its entry at index
+    `0` (reversal swaps them), contradicting `Nodup`. -/
+private theorem nodup_reverse_eq_length_le_one {α : Type*} {l : List α}
+    (hnd : l.Nodup) (hrev : l.reverse = l) : l.length ≤ 1 := by
+  by_contra hlt
+  push_neg at hlt
+  -- `hlt : 1 < l.length`, so indices `0` and `l.length - 1` are valid and distinct.
+  -- The reversed list's entry at `0` is the original's entry at `l.length - 1 - 0`;
+  -- rewriting `l.reverse = l` identifies it with the entry at `0`.
+  have e : l[l.length - 1 - 0]'(by omega) = l[0]'(by omega) := by
+    rw [← List.getElem_reverse]
+    · simp only [hrev]
+    · rw [List.length_reverse]; omega
+  have hidx : l.length - 1 - 0 = 0 := (List.Nodup.getElem_inj_iff hnd).mp e
+  omega
+
+/-! ## Reversal is fixed-point-free -/
+
+/-- **No closed knight's tour is palindromic.** A `ClosedTour` is a `Nodup` list
+    of 64 squares, and a `Nodup` list of length `≥ 2` cannot equal its own
+    reverse, so `reverseTour t ≠ t`. Hence time reversal is a fixed-point-free
+    involution on `ClosedTour`. -/
+theorem reverseTour_ne_self (t : ClosedTour) : reverseTour t ≠ t := by
+  intro h
+  have hpal : t.squares.reverse = t.squares := by
+    have h' := (closedTour_eq_iff (reverseTour t) t).mp h
+    rwa [reverseTour_squares] at h'
+  have hle := nodup_reverse_eq_length_le_one t.nodup hpal
+  rw [t.length_eq] at hle
+  omega
+
+/-- Every pure reversal orbit `{t, reverseTour t}` has exactly two elements,
+    because reversal fixes no tour. -/
+theorem reverseOrbit_card (t : ClosedTour) :
+    ({t, reverseTour t} : Finset ClosedTour).card = 2 :=
+  Finset.card_pair (reverseTour_ne_self t).symm
+
+/-! ## A fixed-point-free involution forces even cardinality
+
+`even_card_of_fpf_involution` is a general helper (also used in
+`SzemerediRegularityOQ01.lean`); it is re-proved here so this file stays
+self-contained. -/
+
+/-- **A fixed-point-free involution forces even cardinality.** If `σ : α → α`
+    maps `S` to itself, is an involution on `S`, and has no fixed point on `S`,
+    then `S` splits into two-element orbits `{x, σ x}`, so `S.card` is even.
+    Proved by strong induction, removing one orbit at a time. -/
+private theorem even_card_of_fpf_involution {α : Type*} [DecidableEq α]
+    {S : Finset α} {σ : α → α}
+    (hσ_mem : ∀ x ∈ S, σ x ∈ S)
+    (hσ_inv : ∀ x ∈ S, σ (σ x) = x)
+    (hσ_ne : ∀ x ∈ S, σ x ≠ x) :
+    Even S.card := by
+  induction S using Finset.strongInduction with
+  | H S ih =>
+    by_cases hS : S = ∅
+    · subst hS; exact ⟨0, by simp⟩
+    · obtain ⟨a, ha⟩ := Finset.nonempty_of_ne_empty hS
+      have hσa_ne : σ a ≠ a := hσ_ne a ha
+      have hpair_sub : {a, σ a} ⊆ S := by
+        intro x hx
+        rcases Finset.mem_insert.mp hx with rfl | hx'
+        · exact ha
+        · rw [Finset.mem_singleton] at hx'; subst hx'; exact hσ_mem a ha
+      have hmem : ∀ x, x ∈ S \ {a, σ a} ↔ x ∈ S ∧ x ≠ a ∧ x ≠ σ a := fun x => by
+        rw [Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton, not_or]
+      have hT_mem : ∀ x ∈ S \ {a, σ a}, σ x ∈ S \ {a, σ a} := by
+        intro x hx
+        rw [hmem] at hx ⊢
+        refine ⟨hσ_mem x hx.1, ?_, ?_⟩
+        · intro heq; apply hx.2.2; rw [← hσ_inv x hx.1, heq]
+        · intro heq; apply hx.2.1; rw [← hσ_inv x hx.1, heq, hσ_inv a ha]
+      have hT_inv : ∀ x ∈ S \ {a, σ a}, σ (σ x) = x :=
+        fun x hx => hσ_inv x (Finset.mem_sdiff.mp hx).1
+      have hT_ne : ∀ x ∈ S \ {a, σ a}, σ x ≠ x :=
+        fun x hx => hσ_ne x (Finset.mem_sdiff.mp hx).1
+      have hsub : S \ {a, σ a} ⊆ S := Finset.sdiff_subset
+      have hT_lt : S \ {a, σ a} ⊂ S := by
+        rw [Finset.ssubset_iff_of_subset hsub]
+        exact ⟨a, ha, by simp⟩
+      obtain ⟨k, hk⟩ := ih (S \ {a, σ a}) hT_lt hT_mem hT_inv hT_ne
+      have hcard_pair : ({a, σ a} : Finset α).card = 2 :=
+        Finset.card_pair hσa_ne.symm
+      have h2 : 2 ≤ S.card := by
+        rw [← hcard_pair]; exact Finset.card_le_card hpair_sub
+      have hcard : (S \ {a, σ a}).card = S.card - 2 := by
+        rw [Finset.card_sdiff, Finset.inter_eq_left.mpr hpair_sub, hcard_pair]
+      rw [hcard] at hk
+      exact ⟨k + 1, by omega⟩
+
+/-! ## The reversal factor of 2 in the histogram, unconditionally -/
+
+/-- **Every histogram level set has even cardinality.** Time reversal is a
+    fixed-point-free involution (`reverseTour_ne_self`, `reverseTour_involutive`)
+    that maps `levelSet k` into itself (`levelSet_image_reverseTour_eq`), so the
+    level set splits into two-element reversal orbits and its cardinality is
+    even. -/
+theorem even_card_levelSet (k : ℕ) : Even (levelSet k).card := by
+  apply even_card_of_fpf_involution (σ := reverseTour)
+  · -- reversal maps `levelSet k` into itself
+    intro t ht
+    have : reverseTour t ∈ (levelSet k).image reverseTour :=
+      Finset.mem_image_of_mem _ ht
+    rwa [levelSet_image_reverseTour_eq] at this
+  · exact fun t _ => reverseTour_involutive t
+  · exact fun t _ => reverseTour_ne_self t
+
+/-- **The reversal factor of 2 in the oblique histogram (headline).** For every
+    `k`, `2 ∣ obliqueDistribution k` — unconditionally, with no self-symmetry
+    hypothesis. This holds because reversal, unlike a board symmetry, can never
+    fix a tour, so it pairs the tours in each level set two-by-two. -/
+theorem two_dvd_obliqueDistribution (k : ℕ) : 2 ∣ obliqueDistribution k := by
+  rw [obliqueDistribution_eq_levelSet_card]
+  exact (even_card_levelSet k).two_dvd
+
+end KnightsTourOblique

--- a/src/data/research/problems/knights-tour-oblique-oq-02.json
+++ b/src/data/research/problems/knights-tour-oblique-oq-02.json
@@ -67,7 +67,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S12, researcher-4, 2026-07-08): Built the full order-16 symmetry group D4×C2 acting on closed tours (Order16.lean, 0-sorry/0-axiom, Docker GREEN 7747 jobs). Proved the two symmetries commute (direct product), reversal is a level-set bijection, and every full orbit cardinality divides 16 (block sizes {1,2,4,8,16}). Enlarges the D4 orbit-divisibility picture by the independent reversal factor.",
+    "progressSummary": "PROGRESS (S13, researcher-10): reversal factor of the order-16 symmetry group fully resolved — reverseTour is fixed-point-free (no palindromic closed tour), hence 2 ∣ obliqueDistribution k UNCONDITIONALLY (VERIFIED 0/0, PR #36035). Remaining: the D4 board factor still needs the self-symmetric-tour count to sharpen mod-8/mod-16 congruences.",
     "builtItems": [
       "research/problems/knights-tour-oblique-oq-02/problem.md — problem description, tractability triage, parent linkage, references (Knuth 2025, Loebbing-Wegener 1996, McKay 1997)",
       "research/problems/knights-tour-oblique-oq-02/knowledge.md — parent infrastructure survey (`obliqueCount`, `tourMoves`, `turnAngle`, `tour_winding_zero`, `no_turn_angle_4_all`), feasibility table, sorries/axioms anticipated",
@@ -128,7 +128,8 @@
       "applyD4Tour_reverseTour_comm: D4 board action and time reversal COMMUTE (Order16.lean) — combined group is direct product D4×C2",
       "levelSet_image_reverseTour_eq: reversal is a bijection of each obliqueDistribution level set (reversal analogue of D4 level-set result)",
       "C2 group (Bool synonym under xor) + D4xC2:=D4×C2 order-16 MulAction on ClosedTour (Order16.lean)",
-      "fullOrbit_card_dvd_sixteen + fullOrbit_card_eq {1,2,4,8,16}: order-16 orbit divisibility, enlarges d4Orbit_card_dvd_eight (Order16.lean)"
+      "fullOrbit_card_dvd_sixteen + fullOrbit_card_eq {1,2,4,8,16}: order-16 orbit divisibility, enlarges d4Orbit_card_dvd_eight (Order16.lean)",
+      "KnightsTourObliqueOQ02Palindrome.lean (NEW, VERIFIED 0 sorry/0 axiom, Docker 7748 jobs, PR #36035): reverseTour_ne_self, reverseOrbit_card, even_card_levelSet, two_dvd_obliqueDistribution + private nodup_reverse_eq_length_le_one (Nodup palindrome ⇒ length ≤ 1 via List.Nodup.getElem_inj_iff + List.getElem_reverse) and local even_card_of_fpf_involution."
     ],
     "insights": [
       "The full histogram is unreachable in Lean (1.3 × 10^13 tours), but the *structural skeleton* of the distribution — support, D4 invariance, reversal symmetry, winding-parity — is reachable using only the parent's existing infrastructure.",
@@ -156,7 +157,9 @@
       "Three cyclic-count invariances proved generically: map-neg (uses isOblique_neg_neg, exact pair-list equality via zip_map), reverse (uses isOblique_comm + Prod.swap; perm via reverse_perm∘rotate_perm), rotate-1 (identity f; perm via rotate_perm). Index-level engine lemmas zip_rotate_one_comm and zip_reverse_comm proved by List.ext_getElem + simp[getElem_zip,getElem_rotate/reverse]; rotate_one_reverse_rotate_one ((L.rotate 1).reverse.rotate 1 = L.reverse) via reverse_rotate+rotate_rotate+rotate_mod.",
       "(R) index identity tourMoves (reverseTour t) = ((tourMoves t).map MoveVector.neg).reverse.rotate 1 proved STRUCTURALLY (no per-index getElem): map/reverse/rotate commutation (map_map, map_reverse, map_rotate, zip_swap) + getMoveVector_swap on adjacent pairs (neg∘g = g∘Prod.swap), with adjacency of every cyclic square pair from tourPairs_all_adj. The closing-edge offset is exactly the cyclic rotate 1.",
       "Reversal commutes with D4 because reversal permutes traversal order while D4 permutes squares; List.map_reverse gives both sides square list (t.squares.map (applyD4 g)).reverse. So the enlarged group is D4×C2 (DIRECT product, order 16), not semidirect.",
-      "Order-16 MulAction packaging mirrors the D4 pattern: C2 needs a Bool synonym (Bool already carries boolean-ring and/true, not xor/false); mul_smul reduces to applyD4Tour_mul + revBool_mul + applyD4Tour_revBool_comm."
+      "Order-16 MulAction packaging mirrors the D4 pattern: C2 needs a Bool synonym (Bool already carries boolean-ring and/true, not xor/false); mul_smul reduces to applyD4Tour_mul + revBool_mul + applyD4Tour_revBool_comm.",
+      "S13 (researcher-10, 2026-07-08): reversal is FIXED-POINT-FREE. reverseTour t ≠ t for every closed tour, because a ClosedTour is a Nodup list of 64 squares and a Nodup list of length ≥ 2 can never equal its own reverse (entries at indices 0 and length-1 would coincide). So the C2 reversal factor of the order-16 group acts freely, unlike a board symmetry which can fix a tour.",
+      "S13: consequently 2 ∣ obliqueDistribution k for EVERY k, UNCONDITIONALLY (no self-symmetry hypothesis) — the FPF involution reverseTour pairs the tours in each level set two-by-two. This is the unconditional counterpart of the conditional D4 orbit-count divisibility."
     ],
     "mathlibGaps": [
       "No `Fintype` instance for `ClosedTour` in the parent file. The parent uses `Classical.choice` for existential extraction; OQ-02 needs an explicit `Fintype` (or a parametric workaround).",
@@ -164,9 +167,9 @@
       "Mathlib's `IsCycle` / `Cycle` infrastructure may apply to `ClosedTour`'s cyclic permutation viewpoint; check before re-implementing reversal symmetry."
     ],
     "nextSteps": [
-      "Characterize tours fixed by the full order-16 group; a fixed-point-free reversal factor would upgrade orbit-divisibility to 16 | obliqueDistribution k in the generic (self-symmetry-free) regime.",
-      "Show closed knight tours are never palindromic (reverseTour t ≠ t): would give every reversal orbit size 2, hence 2 | levelSet card unconditionally.",
-      "Combine fullOrbit block-size {1,2,4,8,16} enumeration with the self-symmetric-tour count to state obliqueDistribution k ≡ s_k (mod 16)."
+      "The C2 reversal factor is now fully resolved (unconditional 2 |). Remaining open: the D4 (board) factor still needs the self-symmetric-tour count s_k to pin obliqueDistribution k mod 8; combine with reverseTour_ne_self to get obliqueDistribution k ≡ (joint self-symmetric count) mod 16.",
+      "Characterize tours fixed by the full order-16 group: a tour with nontrivial full-group stabilizer must be board-self-symmetric AND its reversal must coincide with a board symmetry (reverseTour t = applyD4Tour g t for some g ≠ id), since pure reversal is now known FPF.",
+      "Compute or bound s_k (self-D4-symmetric tour count per level) to convert the divisibility into an exact congruence."
     ],
     "proven": []
   },


### PR DESCRIPTION
## Summary

New verified sibling file `KnightsTourObliqueOQ02Palindrome.lean` (6 declarations, **0 sorry / 0 axiom**, Docker GREEN 7748 jobs) closing the open next step flagged in the `knights-tour-oblique-oq-02` knowledge trail:

> *Show closed knight tours are never palindromic (`reverseTour t ≠ t`) — would give every reversal orbit size 2, hence `2 ∣ levelSet card` unconditionally.*

## Results

- **`reverseTour_ne_self`** — no closed tour is palindromic. A `ClosedTour` is a `Nodup` list of 64 squares, and a `Nodup` list of length ≥ 2 can never equal its own reverse (its entries at indices `0` and `length-1` would coincide, contradicting `Nodup`). Hence time reversal is a **fixed-point-free involution** on `ClosedTour`.
- **`reverseOrbit_card`** — every pure reversal orbit `{t, reverseTour t}` has cardinality exactly 2.
- **`even_card_levelSet` / `two_dvd_obliqueDistribution`** (headline) — the FPF involution `reverseTour` maps every histogram level set bijectively onto itself (`levelSet_image_reverseTour_eq`, from the sibling Order16 file), pairing tours two-by-two, so **`2 ∣ obliqueDistribution k` for every `k`, unconditionally**.

## Significance

The sibling `Order16` file established that every orbit of the full `D4 × C2` symmetry group has size dividing 16, but the exact power of 2 dividing `obliqueDistribution k` was left conditional on a fixed-point analysis. This PR discharges the analysis for the **reversal factor**: reversal — unlike a board symmetry — can never fix a tour, so it contributes a factor of 2 to the histogram with **no self-symmetry hypothesis**. This is the unconditional counterpart of the (conditional) D4 orbit count.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.KnightsTourObliqueOQ02Palindrome` → exit 0, 7748 jobs, no errors/warnings on the new file.
- 0 `sorry`, 0 `axiom` declarations, no structure-encoded assumptions. Reuses only Mathlib lemmas + the already-verified reversal infrastructure; `even_card_of_fpf_involution` is re-proved locally to keep the file self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)