### PR TITLE
Enrich Erdős 307: re-anchor 10 drifted annotations to current source

### DIFF
--- a/src/data/proofs/erdos-307/annotations.json
+++ b/src/data/proofs/erdos-307/annotations.json
@@ -47,7 +47,7 @@
     "id": "ann-307-reciprocal-sum",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 42,
+      "startLine": 43,
       "endLine": 45
     },
     "type": "definition",
@@ -70,7 +70,7 @@
     "id": "ann-307-reciprocal-product",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 47,
+      "startLine": 48,
       "endLine": 50
     },
     "type": "definition",
@@ -92,7 +92,7 @@
     "id": "ann-307-set-of-primes",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 52,
+      "startLine": 53,
       "endLine": 54
     },
     "type": "definition",
@@ -114,7 +114,7 @@
     "id": "ann-307-pairwise-coprime",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 56,
+      "startLine": 57,
       "endLine": 58
     },
     "type": "definition",
@@ -136,7 +136,7 @@
     "id": "ann-307-main-problem",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 62,
+      "startLine": 63,
       "endLine": 70
     },
     "type": "definition",
@@ -158,7 +158,7 @@
     "id": "ann-307-coprime-version",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 76,
+      "startLine": 77,
       "endLine": 81
     },
     "type": "definition",
@@ -180,7 +180,7 @@
     "id": "ann-307-cambie1-defs",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 83,
+      "startLine": 84,
       "endLine": 88
     },
     "type": "definition",
@@ -427,8 +427,8 @@
     "id": "ann-307-egyptian-def",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 221,
-      "endLine": 224
+      "startLine": 338,
+      "endLine": 341
     },
     "type": "definition",
     "title": "Egyptian Fraction of 1",
@@ -449,8 +449,8 @@
     "id": "ann-307-egyptian-example",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 227,
-      "endLine": 233
+      "startLine": 343,
+      "endLine": 348
     },
     "type": "concept",
     "title": "Egyptian Example: 1 = 1/2 + 1/3 + 1/6 (Proved)",
@@ -471,8 +471,8 @@
     "id": "ann-307-search-space",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 243,
-      "endLine": 253
+      "startLine": 354,
+      "endLine": 364
     },
     "type": "definition",
     "title": "Search Space Analysis",
@@ -606,8 +606,8 @@
     "id": "ann-307-summary",
     "proofId": "erdos-307",
     "range": {
-      "startLine": 336,
-      "endLine": 343
+      "startLine": 568,
+      "endLine": 578
     },
     "type": "concept",
     "title": "Summary Theorem (Proved)",


### PR DESCRIPTION
Enrichment pass for `erdos-307`.

**Gap addressed:** `pnpm annotations:build` flagged **10 annotation misalignments** after the Lean file was reorganized (28 annotations total). All **re-anchored cleanly (0 remaining, no overlaps introduced)**:

- **7 early definitions** were a uniform **+1 line shift** (the header block gained a line): `reciprocalSum`, `reciprocalProduct`, `IsSetOfPrimes`, `IsPairwiseCoprime`, `ErdosProblem307`, `ErdosProblem307Coprime`, `cambie1` defs → startLines bumped onto their docstrings (43/48/53/57/63/77/84).
- **Part VII (Egyptian fractions) moved ~117 lines down**; re-anchored to the real decls: `ann-307-egyptian-def` → `IsEgyptianOne` (338), `ann-307-egyptian-example` → `egyptian_example` (343), `ann-307-search-space` → `searchSpaceSize` (354) — the last two also cleared `type` mismatches by landing on the correct construct kinds.
- `ann-307-summary` was squatting on the Egyptian-def block (336–343); its content describes the `erdos_307_summary` theorem → **moved to 568**, which also frees 336–343 for the egyptian def.

Verified against the Lean source; all 28 annotations now pass the construct validator.