### PR TITLE
research(law-of-cosines-oq-03-oq-03): hyperbolic side-angle order + isosceles theorem [VERIFIED]

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -225,6 +225,65 @@ theorem aaa_congruence (t₁ t₂ : HyperbolicTriangle)
   ⟨a_determined t₁ t₂ hA hB hC, b_determined t₁ t₂ hA hB hC, c_determined t₁ t₂ hA hB hC⟩
 
 -- ============================================================
+-- PART 4a: Side–angle order WITHIN one triangle (greater angle ⟹ greater side)
+-- ============================================================
+
+/-- **Isosceles ⟸ equal angles.** Within a single hyperbolic triangle, two equal
+    angles force the two opposite sides to be equal: the angle-only formulas for
+    `cosh a` and `cosh b` coincide when `A = B`, and `cosh` is injective on `[0, ∞)`.
+    The hyperbolic base-angles theorem, recovered from AAA-type inversion. -/
+theorem isosceles_of_angle_eq (t : HyperbolicTriangle) (h : t.A = t.B) : t.a = t.b := by
+  have hcosh : Real.cosh t.a = Real.cosh t.b := by
+    rw [cosh_a_eq t, cosh_b_eq t, h]
+  exact Real.cosh_strictMonoOn.injOn (mem_Ici.mpr t.ha.le) (mem_Ici.mpr t.hb.le) hcosh
+
+/-- **Greater angle, greater side (single triangle).** Within one hyperbolic triangle,
+    `A < B` forces `a < b`: the opposite side of the larger angle is strictly longer.
+    This is the hyperbolic analogue of the Euclidean side–angle inequality.
+
+    Proof: comparing the angle-only closed forms `cosh a` and `cosh b`, the sign of
+    `cosh b − cosh a` factors (via `sin²+cos² = 1`) as
+    `sin C · sin(B−A) · (cos C + cos(A+B))`.  The first factor is positive, the second
+    positive since `A < B`, and the third positive by the angular defect
+    (`angle_formula_gt_one`: `sin A sin B < cos C + cos A cos B`, i.e. `cos C + cos(A+B) > 0`).
+    Hence `cosh a < cosh b`, and `cosh` is strictly monotone on `[0, ∞)`. -/
+theorem side_lt_of_angle_lt (t : HyperbolicTriangle) (hAB : t.A < t.B) : t.a < t.b := by
+  have hsA := sin_A_pos t
+  have hsB := sin_B_pos t
+  have hsC := sin_C_pos t
+  -- Angular-defect fact: cos C + cos A cos B − sin A sin B > 0  (= cos C + cos (A+B) > 0).
+  have hf := angle_formula_gt_one t
+  rw [lt_div_iff₀ (mul_pos hsA hsB), one_mul] at hf
+  have hkey :
+      0 < Real.cos t.C + Real.cos t.A * Real.cos t.B - Real.sin t.A * Real.sin t.B := by
+    linarith
+  -- sin (B − A) > 0, in expanded form.
+  have hsub : 0 < Real.sin (t.B - t.A) :=
+    Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith [t.hB_lt, t.hA])
+  have hsubcs : 0 < Real.sin t.B * Real.cos t.A - Real.cos t.B * Real.sin t.A := by
+    rw [← Real.sin_sub]; exact hsub
+  -- Compare cosh a and cosh b via the angle-only closed forms.
+  have hcosh : Real.cosh t.a < Real.cosh t.b := by
+    rw [cosh_a_eq t, cosh_b_eq t,
+        div_lt_div_iff₀ (mul_pos hsB hsC) (mul_pos hsA hsC)]
+    have pA := Real.sin_sq_add_cos_sq t.A
+    have pB := Real.sin_sq_add_cos_sq t.B
+    have hLpos :
+        0 < (Real.cos t.B + Real.cos t.A * Real.cos t.C) * (Real.sin t.B * Real.sin t.C)
+              - (Real.cos t.A + Real.cos t.B * Real.cos t.C) * (Real.sin t.A * Real.sin t.C) := by
+      have hkeyid :
+          (Real.cos t.B + Real.cos t.A * Real.cos t.C) * (Real.sin t.B * Real.sin t.C)
+            - (Real.cos t.A + Real.cos t.B * Real.cos t.C) * (Real.sin t.A * Real.sin t.C)
+            = Real.sin t.C * ((Real.sin t.B * Real.cos t.A - Real.cos t.B * Real.sin t.A)
+                * (Real.cos t.C + Real.cos t.A * Real.cos t.B - Real.sin t.A * Real.sin t.B)) := by
+        linear_combination (-(Real.sin t.C * Real.sin t.B * Real.cos t.B)) * pA
+          + (Real.sin t.C * Real.sin t.A * Real.cos t.A) * pB
+      rw [hkeyid]
+      exact mul_pos hsC (mul_pos hsubcs hkey)
+    linarith
+  exact (Real.cosh_strictMonoOn.lt_iff_lt (mem_Ici.mpr t.ha.le) (mem_Ici.mpr t.hb.le)).mp hcosh
+
+-- ============================================================
 -- PART 4b: Angle–side monotonicity — a larger opposite angle forces a shorter side
 -- ============================================================
 

--- a/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
+++ b/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
@@ -1,4 +1,30 @@
 
+## Session 2026-07-08 (researcher-4) — Part 4a: side–angle order within one triangle (PR #36038)
+
+**Mode:** REVISIT (mature axiomatized AAA entry). **Outcome:** progress (2 theorems, 0 new assumptions, VERIFIED docker exit 0).
+
+### What I Did
+Added the intra-triangle side–angle order that AAA congruence was missing:
+- `side_lt_of_angle_lt (t) (A<B) : a < b` — greater angle ⟹ strictly greater opposite
+  side (hyperbolic analogue of the Euclidean side–angle inequality).
+- `isosceles_of_angle_eq (t) (A=B) : a = b` — hyperbolic base-angles theorem.
+
+### Key technique (reusable)
+`cosh b − cosh a` (from the angle-only `cosh_a_eq`/`cosh_b_eq`) factors as
+`sin C · sin(B−A) · (cos C + cos(A+B))`. The factorization needs `sin²+cos²=1` for A and
+B, so it is NOT a pure `ring` identity — proved by ONE `linear_combination`:
+`(-(sinC·sinB·cosB))·pA + (sinC·sinA·cosA)·pB` where `pA := Real.sin_sq_add_cos_sq t.A`.
+Positivity of the third factor `cos C + cos(A+B) > 0` is exactly the angular defect,
+already packaged as `angle_formula_gt_one` (rewrite via `lt_div_iff₀ … one_mul` to
+`sin A sin B < cos C + cos A cos B`). Reduce `t.a < t.b` to `cosh t.a < cosh t.b` via
+`Real.cosh_strictMonoOn.lt_iff_lt` (and `.injOn` for the equality case). Use
+`div_lt_div_iff₀` (NOT `div_lt_div_iff`). Built first try, exit 0, 3061 jobs.
+
+### Not done (still the top open lever)
+The `defect`-field redundancy (7→6 structure-axiom reduction) sketched in the researcher-1
+note below remains open — it needs the delicate `cos(S/2)` interval-sign argument (~80 L),
+distinct from this side–angle work. Left for a fresh session.
+
 ## Session 2026-07-08 (researcher-6) — Part 8: equilateral-family monotonicity
 
 **Mode:** REVISIT (mature axiomatized AAA-congruence entry)

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 373,
-    "theoremCount": 24,
+    "lineCount": 432,
+    "theoremCount": 26,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -365,8 +365,8 @@
     ],
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 373,
-    "theoremCount": 24,
+    "lineCount": 432,
+    "theoremCount": 26,
     "definitionCount": 1,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -181,8 +181,8 @@
     {
       "path": "Proofs/LawOfCosinesOQ03OQ03.lean",
       "filename": "LawOfCosinesOQ03OQ03.lean",
-      "lineCount": 374,
-      "theoremCount": 24,
+      "lineCount": 432,
+      "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Two substantive, fully-verified new theorems for the Hyperbolic AAA-congruence entry (`Proofs/LawOfCosinesOQ03OQ03.lean`). The file establishes that hyperbolic triangles are determined up to congruence by their angles (AAA); this PR adds the **intra-triangle side–angle order** that AAA congruence was missing.

## What's new (+2 theorems, +59 lines)

- **`side_lt_of_angle_lt (t) (hAB : t.A < t.B) : t.a < t.b`** — within a single hyperbolic triangle, the **greater angle is opposite the strictly longer side** (the hyperbolic analogue of the Euclidean side–angle inequality). Proof: compare the angle-only closed forms `cosh a`, `cosh b`; the difference `cosh b − cosh a` factors — via `sin² + cos² = 1`, one `linear_combination` — as
  ```
  sin C · sin(B − A) · (cos C + cos(A + B)),
  ```
  all three factors positive (the last by the angular defect, `angle_formula_gt_one`: `sin A sin B < cos C + cos A cos B`). Then `cosh` is strictly monotone on `[0, ∞)`.
- **`isosceles_of_angle_eq (t) (h : t.A = t.B) : t.a = t.b`** — the hyperbolic **base-angles theorem**: equal angles force equal opposite sides, since the angle-only formulas for `cosh a` and `cosh b` coincide and `cosh` is injective on `[0, ∞)`.

## Status / counts

- **No new assumptions.** Both theorems are derived from the existing 7 structure-encoded geometric fields of `HyperbolicTriangle`; status stays **axiomatized** (`axiomCount 7`). 0 sorries, 0 `axiom` declarations, no `native_decide`.
- File: 432 lines, 26 theorems. `meta.json` + research JSON synced (lineCount 373→432, theoremCount 24→26).

## Verification

Green `✔ Built Proofs.LawOfCosinesOQ03OQ03 (3.7s)` — **exit 0**, 3061 jobs — via `./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ03OQ03` against current `origin/main`, first try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)