### PR TITLE
Enrich Knight's Tour Oblique OQ-03: cross-link uncited siblings (oq-04, oq-01-oq-02)

### DIFF
--- a/src/data/proofs/knights-tour-oblique-oq-03/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-03/meta.json
@@ -183,6 +183,16 @@
       "targetId": "knights-tour-oblique-oq-01",
       "relationship": "complementary",
       "description": "Sibling studying the n×n generalization of the oblique minimum."
+    },
+    {
+      "targetId": "knights-tour-oblique-oq-01-oq-02",
+      "relationship": "complementary",
+      "description": "Extends the oblique lower bound to rectangular m×n boards (m, n ≥ 5), showing it is a corner phenomenon; the D₄ board symmetry exploited here degenerates to the smaller rectangle group when m ≠ n."
+    },
+    {
+      "targetId": "knights-tour-oblique-oq-04",
+      "relationship": "complementary",
+      "description": "The dual extremal sibling: OQ-04 targets the MAXIMUM oblique-turn count and the 2-regular structure of the oblique-turn graph. The order-16 D₄ × ℤ/2 action established here acts on the level sets of that same oblique count, so it constrains both the minimum (base file) and maximum (OQ-04) extremes symmetrically."
     }
   ]
 }


### PR DESCRIPTION
## Enrichment pass — knights-tour-oblique-oq-03

Filled a genuine structural gap in the cross-reference graph. The knights-tour-oblique family has 6 gallery entries; this one previously linked only 3 (parent OQ-02, base file, OQ-01). Two relevant siblings were absent:

- **knights-tour-oblique-oq-04** — the dual extremal sibling (MAXIMUM oblique turns / 2-regular oblique-turn graph). The order-16 D₄ × ℤ/2 action proved in OQ-03 acts on the level sets of the very oblique count OQ-04 maximizes, so they belong together.
- **knights-tour-oblique-oq-01-oq-02** — the rectangular m×n generalization of the lower bound.

No prose inflation, no field deepening. crossReferences 3 → 5 (cap 20). meta.json 14.8 KB → 15.6 KB (well under the 60 KB cap). JSON validated; gallery-data build steps (enrichment summary, search-index, loading-facts) pass. Verified both target IDs exist on disk.

No changes to status/badge/axiomCount — the file remains correctly 'axiomatized' (lineage-inherited native_decide/enumeration axiom in the base file; this entry's own 4 theorems are assumption-free).