### PR TITLE
Fix: reconcile stale leanFile/meta counts on 2 grown research files (erdos-703, roth-k3-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -49,10 +49,10 @@
       "largeSetsFamily / largeSetsFamily_avoids_1 / largeSetsFamily_card_le_T: Frankl's (1977) r=1 lower-bound construction — the family of sets larger than (n+1)/2 is a valid 1-avoiding family, giving a verified lower bound |largeSetsFamily n| ≤ T(n,1)"
     ],
     "axiomCount": 1,
-    "lineCount": 467,
+    "lineCount": 542,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 17,
     "definitionCount": 8
   },
   "crossReferences": [
@@ -186,9 +186,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 467,
+    "lineCount": 542,
     "axiomCount": 1,
-    "theoremCount": 13,
+    "theoremCount": 17,
     "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,9 +58,9 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 354,
+    "lineCount": 384,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 4
   },
   "overview": {
@@ -142,9 +142,9 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 354,
+    "lineCount": 384,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 4,
     "path": "Proofs/RothTheoremOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Two gallery entries whose Lean source grew via merged research PRs but whose `leanFile` and `meta` count fields were never synced. Pure metadata reconciliation; no Lean code touched.

## Evidence

Counts verified by comment-stripped named-declaration enumeration (`theorem`/`lemma` and `def`/`abbrev`/`structure`), with `lineCount` matched to exact `wc -l`.

**erdos-703** (`Proofs/Erdos703Problem.lean`)
- lineCount 467 → **542**, theoremCount 13 → **17** (definitionCount 8 unchanged)
- Grown by #35358, #35461, #35559 (Frankl–Füredi odd/even r-avoiding families + T(n,r) lower bounds). New theorems: `franklFurediEven_avoids_r`, `franklFurediEven_card_le_T`, `T_mono_ground`, `largeSetsFamily_subset_franklFurediOdd_one`, etc.

**roth-theorem-k3-oq-03-oq-01** (`Proofs/RothTheoremOQ03OQ01.lean`)
- lineCount 354 → **384**, theoremCount 12 → **13** (definitionCount 4 unchanged)
- Grown by #35639, #35954 (von Neumann telescoping, major-term δ^k isolation). New theorem: `kAPCount_diag_eq_major_add_remainder`.

Both `leanFile.*` and `meta.*` blocks (which were stale together) are updated consistently. `axiomCount` / `sorries` unchanged (build-independent count sync).

---
Automated fix by lean-mechanic agent.