### PR TITLE
research(erdos-771): connect verified construction to maxAvoidingSize lower bounds [VERIFIED 0/2]

### DIFF
--- a/proofs/Proofs/Erdos771Problem.lean
+++ b/proofs/Proofs/Erdos771Problem.lean
@@ -394,6 +394,53 @@ theorem m_eq_two_case (n : ℕ) (hn : n ≥ 2) :
   calc n - 2 = (Finset.Icc 3 n).card := by rw [Nat.card_Icc]; omega
     _ ≤ _ := Finset.le_sup hmem
 
+/-- **General interval lower bound.** The interval `{m+1,…,n}` avoids `m` (all of
+    its elements exceed `m`, so no nonempty subset sum can equal `m`) and has
+    `n - m` elements, hence `maxAvoidingSize n m ≥ n - m`. This unifies the `m = 1`
+    and `m = 2` special cases (they are the instances `m = 1, 2`). -/
+theorem interval_avoiding_lower (n m : ℕ) : maxAvoidingSize n m ≥ n - m := by
+  classical
+  unfold maxAvoidingSize
+  have hmem : Finset.Icc (m + 1) n ∈
+      (Finset.powerset (Icc_n n)).filter (fun S => AvoidSum S m) := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨fun x hx => by rw [Finset.mem_Icc] at hx; rw [Icc_n, Finset.mem_Icc]; omega,
+      avoid_of_forall_lt _ m (fun a ha => by rw [Finset.mem_Icc] at ha; omega)⟩
+  calc n - m = (Finset.Icc (m + 1) n).card := by rw [Nat.card_Icc]; omega
+    _ ≤ _ := Finset.le_sup hmem
+
+/-- **Prime-multiples lower bound.** For any prime `p ∤ m`, the multiples of `p`
+    in `{1,…,n}` form an `m`-avoiding subset of size `⌊n/p⌋` (every subset sum is
+    a multiple of `p`, but `m` is not), hence `maxAvoidingSize n m ≥ ⌊n/p⌋`. This
+    feeds the verified construction lemmas `prime_multiples_avoid` /
+    `prime_multiples_size` directly into a lower bound on the `f`-defining
+    function `maxAvoidingSize`. -/
+theorem primeMultiples_avoiding_lower (p m n : ℕ) (hp : Nat.Prime p) (hpm : ¬p ∣ m) :
+    maxAvoidingSize n m ≥ n / p := by
+  classical
+  unfold maxAvoidingSize
+  have hsub : primeMutliples p n ⊆ Icc_n n := by
+    intro x hx; rw [primeMutliples, Finset.mem_filter] at hx; exact hx.1
+  have hmem : primeMutliples p n ∈
+      (Finset.powerset (Icc_n n)).filter (fun S => AvoidSum S m) := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    exact ⟨hsub, prime_multiples_avoid p m n hp hpm⟩
+  calc n / p = (primeMutliples p n).card := (prime_multiples_size p n hp.pos).symm
+    _ ≤ _ := Finset.le_sup hmem
+
+/-- **Bertrand-quantitative lower bound.** For every `m ≥ 1` there is a prime
+    `m < p ≤ 2m` (Bertrand's postulate); it cannot divide `m` (a divisor of a
+    positive `m` is at most `m`), so the prime-multiples bound and Nat-division
+    antitonicity give `maxAvoidingSize n m ≥ ⌊n/(2m)⌋`. Unlike the interval bound,
+    this stays useful as `m` grows relative to `n`. -/
+theorem maxAvoidingSize_ge_div_two_mul (n m : ℕ) (hm : 1 ≤ m) :
+    maxAvoidingSize n m ≥ n / (2 * m) := by
+  obtain ⟨p, hp, hmp, hp2m⟩ := Nat.exists_prime_lt_and_le_two_mul m (by omega)
+  have hpm : ¬p ∣ m := fun hdvd => by
+    have := Nat.le_of_dvd (by omega) hdvd; omega
+  calc n / (2 * m) ≤ n / p := Nat.div_le_div_left hp2m hp.pos
+    _ ≤ maxAvoidingSize n m := primeMultiples_avoiding_lower p m n hp hpm
+
 /-- Small primes give good constructions. -/
 def smallPrimeConstruction (m n : ℕ) : Finset ℕ :=
   let p := Nat.minFac (m + 1)  -- A prime not dividing m

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -214,9 +214,9 @@
       "Nat"
     ],
     "namespace": "Erdos771",
-    "lineCount": 443,
+    "lineCount": 490,
     "axiomCount": 2,
-    "theoremCount": 16,
+    "theoremCount": 19,
     "definitionCount": 16,
     "sorries": 0,
     "path": "Proofs/Erdos771Problem.lean",


### PR DESCRIPTION
## Summary

Erdős #771 (`f(n) = (1/2 + o(1))·n/log n` for sum-avoiding sets). The gallery file
`Erdos771Problem.lean` already verified the elementary construction lemmas
(`prime_multiples_avoid`, `prime_multiples_size`) and the two special cases
(`m_eq_one_case`, `m_eq_two_case`), but those construction lemmas were **isolated** —
never fed into an actual lower bound on `maxAvoidingSize` (the function that *defines*
`f n`). This session closes that gap with three verified lower-bound theorems.

## New theorems (all machine-checked, 0 sorries)

- **`interval_avoiding_lower`**: `maxAvoidingSize n m ≥ n - m`, via the interval
  `{m+1,…,n}` (every element exceeds `m`, so no nonempty subset sum hits `m`).
  Generalizes and unifies the `m = 1` and `m = 2` special cases.
- **`primeMultiples_avoiding_lower`**: for any prime `p ∤ m`,
  `maxAvoidingSize n m ≥ ⌊n/p⌋` — plugs the verified `prime_multiples_avoid` /
  `prime_multiples_size` directly into a `maxAvoidingSize` bound.
- **`maxAvoidingSize_ge_div_two_mul`**: via Bertrand's postulate (a prime
  `m < p ≤ 2m`, which cannot divide `m`), `maxAvoidingSize n m ≥ ⌊n/(2m)⌋` for
  `m ≥ 1`. Unlike the interval bound, this stays useful as `m` grows relative to `n`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos771Problem` → **Built successfully**,
  0 errors, 0 sorries.
- Axioms unchanged: the 2 pre-existing deep external results
  (`erdos_graham_lower_bound`, `alon_freiman_upper_bound`) remain; status stays
  `axiomatized`. My additions are axiom-free (built on verified construction lemmas).
- meta.json `leanFile` counts synced: theoremCount 16→19, lineCount 443→490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)