### PR TITLE
research(shannon-channel-coding-awgn-oq-02-oq-02): multivariate stddev-triangle equality boundary [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -984,4 +984,99 @@ theorem stddev_add_eq_iff_affine_pos [IsProbabilityMeasure μ] {X Y : Ω → ℝ
   rw [stddev_add_eq_iff_correlation_eq_one hX hY hXnd hYnd,
     correlation_eq_one_iff_affine_pos hX hY hXnd hYnd]
 
+/-!
+### Multivariate sharp equality boundary of the standard-deviation triangle inequality
+
+The two-term equality boundary `stddev_add_eq_iff_covariance_eq_sqrt` pins down when
+`σ[X+Y] = σ[X] + σ[Y]`.  The results below lift it to the *finite-family* triangle inequality
+`stddev_sum_le` (`σ[∑Wᵢ] ≤ ∑σ[Wᵢ]`), identifying the exact condition under which the aggregate
+standard deviation attains its ceiling.
+
+The mechanism is uniform saturation of Cauchy–Schwarz.  Squaring the nonnegative identity
+`σ[∑Wᵢ] = ∑σ[Wᵢ]` gives `Var[∑Wᵢ] = (∑σ[Wᵢ])²`; expanding the left side by the double-sum
+`variance_sum'` and the right side by `Finset.sum_mul_sum` turns it into
+
+    ∑ᵢ∑ⱼ cov[Wᵢ, Wⱼ]  =  ∑ᵢ∑ⱼ σ[Wᵢ]·σ[Wⱼ].
+
+Every summand obeys the Cauchy–Schwarz bound `cov[Wᵢ, Wⱼ] ≤ σ[Wᵢ]·σ[Wⱼ]`
+(`abs_covariance_le_sqrt`), so the two double sums are equal *iff every term is* — a sum of
+nonnegative gaps vanishes iff each gap does (`Finset.sum_eq_sum_iff_of_le`).  Hence the aggregate
+standard deviations add precisely when *all pairs* saturate Cauchy–Schwarz, i.e. are perfectly
+positively correlated.  This is the multivariate dual, at the opposite Cauchy–Schwarz endpoint, of
+the vanishing-off-diagonal boundary `variance_sum_eq_iff_offDiag_covariance_zero`.
+-/
+
+/-- **Multivariate equality boundary of the standard-deviation triangle inequality (covariance
+form).**  For any finite family of square-integrable contributions the L² triangle inequality
+`σ[∑ᵢ Wᵢ] ≤ ∑ᵢ σ[Wᵢ]` of `stddev_sum_le` is an *equality*
+
+        √Var[∑ᵢ Wᵢ] = ∑ᵢ √Var[Wᵢ]
+
+*if and only if* every ordered pair saturates the covariance Cauchy–Schwarz bound,
+`cov[Wᵢ, Wⱼ] = √Var[Wᵢ]·√Var[Wⱼ]` for all `i, j ∈ s`.  No non-degeneracy hypothesis is needed
+(the diagonal condition `i = j` reads `Var[Wᵢ] = Var[Wᵢ]` and the Cauchy–Schwarz gap is tight
+there).  This is the finite-family lift of `stddev_add_eq_iff_covariance_eq_sqrt`, and the sharp
+dual — at the perfectly-correlated endpoint of the Cauchy–Schwarz interval — of the
+vanishing-off-diagonal boundary `variance_sum_eq_iff_offDiag_covariance_zero`. -/
+theorem stddev_sum_eq_iff_pairwise_covariance_eq_sqrt [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ) :
+    Real.sqrt (Var[∑ i ∈ s, W i; μ]) = ∑ i ∈ s, Real.sqrt (Var[W i; μ]) ↔
+      ∀ i ∈ s, ∀ j ∈ s,
+        cov[W i, W j; μ] = Real.sqrt (Var[W i; μ]) * Real.sqrt (Var[W j; μ]) := by
+  classical
+  have hsum_nonneg : 0 ≤ ∑ i ∈ s, Real.sqrt (Var[W i; μ]) :=
+    Finset.sum_nonneg fun i _ => Real.sqrt_nonneg _
+  -- Termwise Cauchy–Schwarz: every covariance is dominated by the product of standard deviations.
+  have hle_inner : ∀ i ∈ s, ∀ j ∈ s,
+      cov[W i, W j; μ] ≤ Real.sqrt (Var[W i; μ]) * Real.sqrt (Var[W j; μ]) := by
+    intro i hi j hj
+    calc cov[W i, W j; μ] ≤ |cov[W i, W j; μ]| := le_abs_self _
+      _ ≤ Real.sqrt (Var[W i; μ] * Var[W j; μ]) := abs_covariance_le_sqrt (hW i hi) (hW j hj)
+      _ = Real.sqrt (Var[W i; μ]) * Real.sqrt (Var[W j; μ]) :=
+          Real.sqrt_mul (variance_nonneg _ _) _
+  have hle_outer : ∀ i ∈ s, (∑ j ∈ s, cov[W i, W j; μ])
+      ≤ ∑ j ∈ s, Real.sqrt (Var[W i; μ]) * Real.sqrt (Var[W j; μ]) :=
+    fun i hi => Finset.sum_le_sum (fun j hj => hle_inner i hi j hj)
+  -- Reduce the (nonnegative) √-equality to the squared equality of the two double sums.
+  rw [show (Real.sqrt (Var[∑ i ∈ s, W i; μ]) = ∑ i ∈ s, Real.sqrt (Var[W i; μ]))
+        ↔ (Var[∑ i ∈ s, W i; μ] = (∑ i ∈ s, Real.sqrt (Var[W i; μ])) ^ 2) from
+      ⟨fun h => by rw [← h, Real.sq_sqrt (variance_nonneg _ _)],
+       fun h => by rw [h, Real.sqrt_sq hsum_nonneg]⟩,
+    variance_sum' hW, pow_two, Finset.sum_mul_sum,
+    Finset.sum_eq_sum_iff_of_le hle_outer]
+  -- Sum-of-nonnegative-gaps: the outer equality reduces to per-pair saturation.
+  constructor
+  · intro h i hi j hj
+    exact (Finset.sum_eq_sum_iff_of_le (fun j hj => hle_inner i hi j hj)).mp (h i hi) j hj
+  · intro h i hi
+    exact (Finset.sum_eq_sum_iff_of_le (fun j hj => hle_inner i hi j hj)).mpr
+      (fun j hj => h i hi j hj)
+
+/-- **Multivariate equality boundary of the standard-deviation triangle inequality (correlation
+form).**  For a finite family of *non-degenerate* square-integrable contributions
+(`Var[Wᵢ] ≠ 0` for all `i ∈ s`), the aggregate standard deviations add,
+
+        √Var[∑ᵢ Wᵢ] = ∑ᵢ √Var[Wᵢ],
+
+*if and only if* every pair is perfectly positively correlated, `ρ[Wᵢ, Wⱼ] = 1` for all
+`i, j ∈ s`.  This normalises `stddev_sum_eq_iff_pairwise_covariance_eq_sqrt` through the definition
+of the Pearson coefficient (each pair's covariance saturates Cauchy–Schwarz exactly when its
+correlation hits `+1`); the multivariate capstone of `stddev_add_eq_iff_correlation_eq_one`. -/
+theorem stddev_sum_eq_iff_pairwise_correlation_eq_one [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (hnd : ∀ i ∈ s, Var[W i; μ] ≠ 0) :
+    Real.sqrt (Var[∑ i ∈ s, W i; μ]) = ∑ i ∈ s, Real.sqrt (Var[W i; μ]) ↔
+      ∀ i ∈ s, ∀ j ∈ s, correlation (W i) (W j) μ = 1 := by
+  rw [stddev_sum_eq_iff_pairwise_covariance_eq_sqrt hW]
+  have hden : ∀ i ∈ s, ∀ j ∈ s,
+      Real.sqrt (Var[W i; μ]) * Real.sqrt (Var[W j; μ]) ≠ 0 := fun i hi j hj =>
+    mul_ne_zero
+      (Real.sqrt_ne_zero'.mpr ((variance_nonneg _ _).lt_of_ne (hnd i hi).symm))
+      (Real.sqrt_ne_zero'.mpr ((variance_nonneg _ _).lt_of_ne (hnd j hj).symm))
+  refine ⟨fun h i hi j hj => ?_, fun h i hi j hj => ?_⟩
+  · rw [correlation, h i hi j hj, div_self (hden i hi j hj)]
+  · have hcorr := h i hi j hj
+    rw [correlation] at hcorr
+    exact (div_eq_one_iff_eq (hden i hi j hj)).mp hcorr
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 987,
+    "lineCount": 1082,
     "axiomCount": 0,
-    "theoremCount": 41,
+    "theoremCount": 44,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 908,
-    "theoremCount": 38,
+    "lineCount": 1082,
+    "theoremCount": 44,
     "definitionCount": 1,
     "badge": "mathlib",
     "originalContributions": [
@@ -183,6 +183,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 987,
-  "theoremCount": 41
+  "lineCount": 1082,
+  "theoremCount": 44
 }

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: proved the sharp equality boundary of the standard-deviation triangle inequality (σ[X+Y]=σ[X]+σ[Y] ⟺ cov=√Var·√Var ⟺ ρ=+1 ⟺ increasing-affine), 3 theorems VERIFIED 0 sorry/0 axiom; dual endpoint to variance_add_eq_iff_covariance_zero.",
+    "progressSummary": "PROGRESS: multivariate sharp equality boundary of the stddev triangle inequality proved (covariance + correlation forms), VERIFIED 0 sorry/0 axiom — completes the finite-family analog of the 2-variable stddev_add_eq boundary.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -57,7 +57,9 @@
       "real_sign_eq_self_div_abs helper (line 861): Real.sign x = x/|x| ∀x incl 0",
       "stddev_add_eq_iff_covariance_eq_sqrt (ShannonChannelCodingAWGNOQ02OQ02.lean): σ[X+Y]=σ[X]+σ[Y] ↔ cov[X,Y]=√Var[X]·√Var[Y], no non-degeneracy hyp; proof squares both sides (Real.sq_sqrt / Real.sqrt_sq) and closes with nlinarith on variance_add.",
       "stddev_add_eq_iff_correlation_eq_one (same file): non-degenerate normalisation, σ[X+Y]=σ[X]+σ[Y] ↔ ρ[X,Y]=1 via div_eq_one_iff_eq.",
-      "stddev_add_eq_iff_affine_pos (same file): capstone σ[X+Y]=σ[X]+σ[Y] ↔ ∃a b, 0<a ∧ X=ᵐ a·Y+b (perfect positive correlation / increasing affine), chaining correlation_eq_one_iff_affine_pos."
+      "stddev_add_eq_iff_affine_pos (same file): capstone σ[X+Y]=σ[X]+σ[Y] ↔ ∃a b, 0<a ∧ X=ᵐ a·Y+b (perfect positive correlation / increasing affine), chaining correlation_eq_one_iff_affine_pos.",
+      "stddev_sum_eq_iff_pairwise_covariance_eq_sqrt (ShannonChannelCodingAWGNOQ02OQ02.lean): √Var[∑ᵢ∈s Wᵢ]=∑ᵢ√Var[Wᵢ] ↔ ∀i,j∈s cov[Wᵢ,Wⱼ]=√Var[Wᵢ]·√Var[Wⱼ]; no non-degeneracy hyp (diagonal tight). Multivariate lift of stddev_add_eq_iff_covariance_eq_sqrt, dual of variance_sum_eq_iff_offDiag_covariance_zero.",
+      "stddev_sum_eq_iff_pairwise_correlation_eq_one (same file): for non-degenerate family, √Var[∑]=∑σ ↔ ∀i,j∈s ρ[Wᵢ,Wⱼ]=1 (all pairs perfectly positively correlated); normalises the covariance form via correlation def + div_eq_one_iff_eq. Multivariate capstone of stddev_add_eq_iff_correlation_eq_one."
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -73,7 +75,8 @@
       "Signed sharp boundary: ρ = sign(a) when X =ᵐ a·Y+b, so ρ=+1 ⟺ increasing affine (a>0), ρ=−1 ⟺ decreasing affine (a<0); splits |ρ|=1⟺affine into two distinct endpoints.",
       "Affine-invariance proof reuses the exact machinery of the ±1 capstones: cov[aX+b,cY+d]=ac·cov via covariance_add_const_left/right + covariance_const_mul_left/right; σ[aX+b]=|a|·σ[X] via variance_eq_of_affine+sqrt_mul+sqrt_sq_eq_abs; sign packaged as x/|x| so a·c/(|a|·|c|)=sign(a·c) closes by ring (field inverse rearrangement, no nonzero hyps needed).",
       "Sharp equality boundary of the stddev triangle inequality stddev_add_le: squaring the nonnegative identity σ[X+Y]=σ[X]+σ[Y] reduces it to the covariance attaining its Cauchy-Schwarz maximum cov[X,Y]=√Var[X]·√Var[Y]; NO non-degeneracy hypothesis needed (degenerate Y gives 0=σ[X]·0).",
-      "The triangle-equality boundary sits at the OPPOSITE Cauchy-Schwarz endpoint from variance_add_eq_iff_covariance_zero: variances add iff cov=0 (orthogonal), but standard deviations add iff cov=σ[X]σ[Y] (perfectly positively correlated, ρ=+1)."
+      "The triangle-equality boundary sits at the OPPOSITE Cauchy-Schwarz endpoint from variance_add_eq_iff_covariance_zero: variances add iff cov=0 (orthogonal), but standard deviations add iff cov=σ[X]σ[Y] (perfectly positively correlated, ρ=+1).",
+      "Multivariate stddev-triangle equality (√Var[∑Wᵢ]=∑σ[Wᵢ]) reduces via square+variance_sum'+Finset.sum_mul_sum to ∑ᵢ∑ⱼcov=∑ᵢ∑ⱼσᵢσⱼ; each summand obeys Cauchy–Schwarz cov≤σᵢσⱼ, so the two double sums are equal iff every ordered pair saturates it — Finset.sum_eq_sum_iff_of_le twice (nested)."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -92,7 +95,8 @@
       "Affine-invariance of covariance itself (cov[aX+b,cY+d]=ac·cov[X,Y]) is now proved inline — consider extracting as a named reusable lemma if a further correlation result needs it.",
       "Consider corr sign-flip corollary for a>0,c<0 (orientation-reversing): ρ[aX+b,cY+d]=−ρ[X,Y] as the negative companion of correlation_affine_invariant_of_pos.",
       "Dual equality for the finite-sum triangle inequality stddev_sum_le: σ[∑Wᵢ]=∑σ[Wᵢ] iff all pairs are perfectly positively correlated (all centered contributions a.e. nonneg-proportional to a common direction) — needs an induction handling the shared-direction propagation.",
-      "Consider the strict-inequality companion: σ[X+Y] < σ[X]+σ[Y] whenever ρ<1 (non-degenerate), the strict form of stddev_add_le."
+      "Consider the strict-inequality companion: σ[X+Y] < σ[X]+σ[Y] whenever ρ<1 (non-degenerate), the strict form of stddev_add_le.",
+      "Affine form of the multivariate boundary: √Var[∑Wᵢ]=∑σ requires a COMMON increasing-affine template (all Wᵢ =ᵐ aᵢ·Y+bᵢ, aᵢ>0) — harder than pairwise, needs a shared regressor Y; the pairwise-correlation form is the clean stopping point."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds the **multivariate sharp equality boundary** of the standard-deviation triangle inequality `stddev_sum_le` (`σ[∑ᵢ Wᵢ] ≤ ∑ᵢ σ[Wᵢ]`) to `ShannonChannelCodingAWGNOQ02OQ02.lean`.

The file already had the 2-variable equality boundary (`stddev_add_eq_iff_covariance_eq_sqrt` / `_correlation_eq_one` / `_affine_pos`) and the multivariate *inequality* `stddev_sum_le`, but not the multivariate *equality* condition. These two theorems close that gap.

## New theorems (both VERIFIED, 0 sorry / 0 axiom)

- **`stddev_sum_eq_iff_pairwise_covariance_eq_sqrt`** — for any finite family of square-integrable `Wᵢ`,
  `√Var[∑ᵢ Wᵢ] = ∑ᵢ √Var[Wᵢ] ↔ ∀ i,j∈s, cov[Wᵢ,Wⱼ] = √Var[Wᵢ]·√Var[Wⱼ]`.
  No non-degeneracy hypothesis (the diagonal condition is automatically tight).
- **`stddev_sum_eq_iff_pairwise_correlation_eq_one`** — for a non-degenerate family (`Var[Wᵢ]≠0`),
  `√Var[∑ᵢ Wᵢ] = ∑ᵢ √Var[Wᵢ] ↔ ∀ i,j∈s, ρ[Wᵢ,Wⱼ] = 1` (all pairs perfectly positively correlated).

## Proof idea

Square the nonnegative identity → `Var[∑Wᵢ] = (∑σ[Wᵢ])²`. Expand LHS by `variance_sum'` (double sum of covariances) and RHS by `Finset.sum_mul_sum`, giving `∑ᵢ∑ⱼ cov[Wᵢ,Wⱼ] = ∑ᵢ∑ⱼ σᵢσⱼ`. Every summand satisfies the covariance Cauchy–Schwarz bound `cov[Wᵢ,Wⱼ] ≤ σᵢσⱼ` (`abs_covariance_le_sqrt`), so the two sums are equal iff every term is (`Finset.sum_eq_sum_iff_of_le`, applied to the nested sums). The correlation form normalises each pair through the Pearson definition.

This is the finite-family lift of the 2-variable boundary and the sharp dual — at the perfectly-correlated endpoint of the Cauchy–Schwarz interval — of `variance_sum_eq_iff_offDiag_covariance_zero` (whose boundary is the orthogonal `cov=0` case).

## Verification

`./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingAWGNOQ02OQ02` → `✔ [7743/7743] Built (5.6s)`, exit 0. 0 sorries, 0 axioms.

meta.json counts synced (theoremCount 41→44, lineCount →1082); research knowledge JSON updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)