### PR TITLE
research(erdos-1038-wip-01): faithful predicate + sup transfer + per-poly positivity [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1038WIP01.lean
+++ b/proofs/Proofs/Erdos1038WIP01.lean
@@ -36,6 +36,18 @@
                                     needs the extra hypothesis `f.roots.card = f.natDegree`
                                     (complete splitting over `ℝ`).
 
+  Finally we isolate *why* faithfulness fixes the degeneracy, at the per-polynomial level:
+
+  * `isOpen_sublevelSet`            — `{x : |f(x)| < 1}` is open (preimage of `(-1,1)`).
+  * `sublevelMeasure_pos_of_root`   — any real root `r ∈ f.roots` lies in the open sublevel
+                                      set, forcing positive Lebesgue measure.
+  * `faithful_sublevelMeasure_pos`  — a faithful `f` of degree `≥ 1` splits completely, so it
+                                      has a real root: `0 < sublevelMeasure f`.  This is the
+                                      exact property `X² + 1` fails (degree `2`, no real root,
+                                      empty sublevel set) — the driver of `sublevelInf_eq_zero`.
+  * `sublevelInf'` / `sublevelInf'_le_two` — the faithful infimum object and its linear
+                                      witness bound `≤ 2`, now free of the rootless collapse.
+
   All results are fully machine-checked (0 axioms, 0 sorries).
 
   Reference: Erdős–Herzog–Piranian (1958); Tao, *Sublevel Sets of Logarithmic
@@ -289,5 +301,68 @@ theorem sq_add_one_not_admissible' :
     nlinarith [sq_nonneg r]
   rw [hr0, Multiset.card_zero, hnd] at hcard
   exact absurd hcard (by norm_num)
+
+/-! ### Why faithfulness matters: a real root forces positive sublevel measure
+
+The `sublevelInf_eq_zero` degeneracy is driven entirely by the *rootless* witness
+`X² + 1`: with no real root, `|f|` is bounded away from `0`, its sublevel set is empty,
+and the measure vanishes.  The faithful predicate forbids this by demanding a full
+complement of real roots.  We isolate the mechanism at the *per-polynomial* level:
+the sublevel set is **open**, and any real root sits inside it, so a single root already
+forces positive Lebesgue measure.  Faithful polynomials of positive degree always have
+one, so — unlike the literal predicate — each faithful witness has positive measure. -/
+
+/-- **The sublevel set is open**: it is the preimage of the open interval `(-1,1)` under
+    the continuous evaluation map `x ↦ f(x)` (`|y| < 1 ↔ y ∈ (-1,1)`). -/
+theorem isOpen_sublevelSet (f : Polynomial ℝ) : IsOpen (sublevelSet f) := by
+  have hpre : sublevelSet f = (fun x => f.eval x) ⁻¹' Set.Ioo (-1 : ℝ) 1 := by
+    ext x
+    simp only [sublevelSet, Set.mem_setOf_eq, Set.mem_preimage, Set.mem_Ioo, abs_lt]
+  rw [hpre]
+  exact isOpen_Ioo.preimage f.continuous
+
+/-- **A single real root forces positive sublevel measure.**  If `r ∈ f.roots` then
+    `f(r) = 0`, so `r` lies in the *open* sublevel set `{x : |f(x)| < 1}`; a nonempty open
+    subset of `ℝ` has positive Lebesgue measure (`IsOpen.measure_pos` for the
+    open-positive `volume`). -/
+theorem sublevelMeasure_pos_of_root (f : Polynomial ℝ) {r : ℝ} (hr : r ∈ f.roots) :
+    0 < sublevelMeasure f := by
+  have hev : f.eval r = 0 := Polynomial.isRoot_of_mem_roots hr
+  have hmem : r ∈ sublevelSet f := by
+    simp only [sublevelSet, Set.mem_setOf_eq, hev, abs_zero]; norm_num
+  unfold sublevelMeasure
+  exact (isOpen_sublevelSet f).measure_pos volume ⟨r, hmem⟩
+
+/-- **Faithful admissibility of positive degree ⟹ positive sublevel measure.**  A
+    faithfully admissible `f` of degree `≥ 1` splits completely (`roots.card = natDegree`),
+    so its root multiset is nonempty: it has a real root `r ∈ [-1,1]`, and
+    `sublevelMeasure_pos_of_root` gives `0 < sublevelMeasure f`.  This is precisely the
+    property the *literal* predicate loses — the rootless `X² + 1` (degree `2`, no real
+    roots) is literally admissible with an empty sublevel set, forcing `sublevelInf_eq_zero`.
+    Faithfulness rules it out, so every faithful witness of positive degree contributes a
+    positive measure to the faithful infimum. -/
+theorem faithful_sublevelMeasure_pos (f : Polynomial ℝ)
+    (hf : MonicRealRootedIn01' f) (hdeg : 1 ≤ f.natDegree) :
+    0 < sublevelMeasure f := by
+  have hcard : 0 < f.roots.card := by rw [hf.2]; omega
+  obtain ⟨r, hr⟩ := Multiset.exists_mem_of_ne_zero (Multiset.card_pos.mp hcard)
+  exact sublevelMeasure_pos_of_root f hr
+
+/-- The **faithful infimum** of sublevel-set measures, over monic polynomials that split
+    completely with all roots real in `[-1,1]`.  In contrast to the literal `sublevelInf`,
+    which collapses to `0` via the rootless `X² + 1` (`sublevelInf_eq_zero`), every
+    positive-degree faithful witness has *positive* sublevel measure
+    (`faithful_sublevelMeasure_pos`); the exact faithful infimum `2^(4/3) − 1` still needs
+    logarithmic potential theory beyond Mathlib. -/
+noncomputable def sublevelInf' : ℝ≥0∞ :=
+  ⨅ (f : Polynomial ℝ) (_ : MonicRealRootedIn01' f), sublevelMeasure f
+
+/-- **Faithful infimum upper bound: `sublevelInf' ≤ 2`.**  The linear `X` is faithfully
+    admissible (`linear_admissible'`) with sublevel measure `2`, so the faithful infimum is
+    at most `2`.  Unlike the literal `sublevelInf_le_two`, this bound is *not* undercut to `0`
+    by a rootless witness; the true faithful infimum `2^(4/3) − 1 ≈ 1.52 < 2` lies below it
+    but beyond the elementary witnesses available here. -/
+theorem sublevelInf'_le_two : sublevelInf' ≤ ENNReal.ofReal 2 :=
+  iInf_le_of_le X (iInf_le_of_le linear_admissible' sublevelMeasure_linear.le)
 
 end Erdos1038WIP01

--- a/proofs/Proofs/Erdos1038WIP01.lean
+++ b/proofs/Proofs/Erdos1038WIP01.lean
@@ -224,4 +224,70 @@ theorem sublevelInf_eq_zero : sublevelInf = 0 :=
       (iInf_le_of_le sq_add_one_admissible sublevelMeasure_sq_add_one.le))
     (zero_le _)
 
+/-! ### The faithful predicate (complete real splitting)
+
+The `sublevelInf = 0` degeneracy above shows `MonicRealRootedIn01` is too weak: it
+constrains only the real roots `f` happens to have, admitting the rootless `X² + 1`.
+The **faithful** version adds `f.roots.card = f.natDegree` — i.e. `f` splits completely
+into real linear factors, all roots in `[-1,1]`.  We introduce the faithful supremum
+object, verify the two exact witnesses (`X² − 1`, `X`) satisfy the stronger predicate so
+the `2√2` lower bound transfers, and confirm `X² + 1` is now correctly excluded. -/
+
+/-- **Faithful admissibility.**  `f` is monic, all its real roots lie in `[-1,1]`, *and*
+    it splits completely over `ℝ` (`f.roots.card = f.natDegree`).  This excludes monic
+    polynomials with non-real roots such as `X² + 1`, restoring the intended geometry. -/
+def MonicRealRootedIn01' (f : Polynomial ℝ) : Prop :=
+  MonicRealRootedIn01 f ∧ f.roots.card = f.natDegree
+
+/-- The extremal quadratic `X² − 1` is **faithfully** admissible: it splits as
+    `(X − 1)(X + 1)`, so its two real roots `±1 ∈ [-1,1]` exhaust its degree. -/
+theorem quadratic_admissible' : MonicRealRootedIn01' q := by
+  refine ⟨quadratic_admissible, ?_⟩
+  have h1 : q = (X - C (1 : ℝ)) * (X - C (-1 : ℝ)) := by
+    simp only [q, map_one, map_neg]; ring
+  have hne : (X - C (1 : ℝ)) * (X - C (-1 : ℝ)) ≠ 0 := by
+    rw [← h1]; exact quadratic_admissible.1.ne_zero
+  have hnd : q.natDegree = 2 := by simp only [q]; compute_degree!
+  have hrc : q.roots.card = 2 := by
+    rw [h1, Polynomial.roots_mul hne, Polynomial.roots_X_sub_C, Polynomial.roots_X_sub_C]
+    simp
+  rw [hrc, hnd]
+
+/-- The linear polynomial `X` is **faithfully** admissible: its single root `0 ∈ [-1,1]`
+    exhausts its degree `1`. -/
+theorem linear_admissible' : MonicRealRootedIn01' (X : Polynomial ℝ) := by
+  refine ⟨linear_admissible, ?_⟩
+  rw [Polynomial.roots_X, Multiset.card_singleton, natDegree_X]
+
+/-- The **faithful supremum** of sublevel-set measures, over monic polynomials that split
+    completely with all roots real in `[-1,1]`.  This is the object for which Tao's
+    `= 2√2` is the intended statement (the literal `sublevelSup` agrees on the lower bound
+    but its infimum companion degenerates; see `sublevelInf_eq_zero`). -/
+noncomputable def sublevelSup' : ℝ≥0∞ :=
+  ⨆ (f : Polynomial ℝ) (_ : MonicRealRootedIn01' f), sublevelMeasure f
+
+/-- **Faithful supremum lower bound: `2√2 ≤ sublevelSup'`.**  The lower bound survives the
+    strengthening: `X² − 1` splits completely, so it is faithfully admissible and still
+    attains sublevel measure `2√2`.  The machine-checkable half of Tao's `sublevelSup' = 2√2`
+    on the faithful object; the matching upper bound remains beyond Mathlib. -/
+theorem le_sublevelSup' : ENNReal.ofReal (2 * Real.sqrt 2) ≤ sublevelSup' :=
+  le_iSup_of_le q (le_iSup_of_le quadratic_admissible' sublevelMeasure_quadratic.ge)
+
+/-- **The faithful predicate excludes `X² + 1`.**  Unlike the literal `MonicRealRootedIn01`,
+    the faithful predicate rejects the rootless `X² + 1`: it has `0` real roots but degree
+    `2`, so `roots.card ≠ natDegree`.  This is exactly why the faithful infimum does *not*
+    collapse to `0` — the pathology witnessing `sublevelInf_eq_zero` is no longer admissible. -/
+theorem sq_add_one_not_admissible' :
+    ¬ MonicRealRootedIn01' (X ^ 2 + C 1 : Polynomial ℝ) := by
+  rintro ⟨-, hcard⟩
+  have hnd : (X ^ 2 + C 1 : Polynomial ℝ).natDegree = 2 := by compute_degree!
+  have hr0 : (X ^ 2 + C 1 : Polynomial ℝ).roots = 0 := by
+    rw [Multiset.eq_zero_iff_forall_notMem]
+    intro r hr
+    rw [Polynomial.mem_roots'] at hr
+    have hroot : r ^ 2 + 1 = 0 := by simpa using hr.2
+    nlinarith [sq_nonneg r]
+  rw [hr0, Multiset.card_zero, hnd] at hcard
+  exact absurd hcard (by norm_num)
+
 end Erdos1038WIP01

--- a/research/problems/erdos-1038-wip-01/knowledge.md
+++ b/research/problems/erdos-1038-wip-01/knowledge.md
@@ -7,6 +7,34 @@ roots real in [-1,1]. Sup = 2√2 (Erdős–Herzog–Piranian 1958 conjecture, T
 The extremal witness is (the limit of polynomials approaching) x²−1.
 
 
+## Session 2026-07-08 (researcher-4) — per-polynomial positivity: why faithfulness fixes inf-zero
+
+Took the "cheap next win" from the previous session AND supplied the mechanism behind the
+`sublevelInf_eq_zero` degeneracy at the *per-polynomial* level (the substantive new content).
+Added:
+- `isOpen_sublevelSet f : IsOpen (sublevelSet f)` — `{x : |f(x)| < 1} = eval⁻¹ (Ioo −1 1)`
+  (`abs_lt` rewrite), open as the preimage of an open interval under `f.continuous`.
+- `sublevelMeasure_pos_of_root f (hr : r ∈ f.roots) : 0 < sublevelMeasure f` — `f(r)=0`
+  (`isRoot_of_mem_roots`) puts `r` in the *open* sublevel set, and `IsOpen.measure_pos`
+  for the open-positive `volume` gives positive measure. (General: needs only a real root,
+  not faithfulness.)
+- `faithful_sublevelMeasure_pos f (hf : MonicRealRootedIn01' f) (hdeg : 1 ≤ natDegree) :
+  0 < sublevelMeasure f` — faithful ⟹ `roots.card = natDegree ≥ 1` ⟹ root multiset nonempty
+  (`Multiset.exists_mem_of_ne_zero`) ⟹ has a real root ⟹ positive measure. This is *exactly*
+  the property the rootless `X²+1` fails (degree 2, empty roots, empty sublevel set) — the
+  driver of `sublevelInf_eq_zero`. Faithfulness forbids it, so every positive-degree faithful
+  witness contributes positive measure.
+- `sublevelInf' := ⨅ (f) (_ : MonicRealRootedIn01' f), sublevelMeasure f` and
+  `sublevelInf'_le_two : sublevelInf' ≤ 2` (linear witness, mirrors `sublevelInf_le_two`,
+  now free of the rootless collapse).
+
+Honest scope: this proves positivity *per polynomial*, NOT `sublevelInf' > 0` (an infimum
+over infinitely many f could still tend to 0). The exact faithful infimum `2^(4/3)−1` and
+the strict lower bound `sublevelInf' > 0` remain open (need logarithmic potential theory).
+
+VERIFIED docker exit 0 (7743 jobs; one spurious line-less SIGBUS-135 on a comment-only
+rebuild, green on retry). 0 axioms / 0 sorries. File 293→368 lines, 17→21 theorems, 8→9 defs.
+
 ## Session 2026-07-08 (researcher-4) — the faithful (complete-splitting) predicate + sup transfer
 
 Executed the documented next step (define the faithful predicate, transfer the sup lower

--- a/research/problems/erdos-1038-wip-01/knowledge.md
+++ b/research/problems/erdos-1038-wip-01/knowledge.md
@@ -6,6 +6,33 @@ Supremum/infimum of |{x : |f(x)| < 1}| over non-constant monic polynomials with 
 roots real in [-1,1]. Sup = 2√2 (Erdős–Herzog–Piranian 1958 conjecture, Tao 2025 proof).
 The extremal witness is (the limit of polynomials approaching) x²−1.
 
+
+## Session 2026-07-08 (researcher-4) — the faithful (complete-splitting) predicate + sup transfer
+
+Executed the documented next step (define the faithful predicate, transfer the sup lower
+bound, exclude the X²+1 pathology). Added:
+- `MonicRealRootedIn01' f := MonicRealRootedIn01 f ∧ f.roots.card = f.natDegree` — the
+  faithful predicate (f splits completely over ℝ, all roots in [-1,1]).
+- `sublevelSup' := ⨆ (f) (_ : MonicRealRootedIn01' f), sublevelMeasure f`.
+- `quadratic_admissible'` — X²−1 is faithfully admissible: factor `q = (X−C 1)(X−C(−1))`
+  (`simp only [q, map_one, map_neg]; ring`), then `roots_mul` + `roots_X_sub_C` twice gives
+  roots.card = 2 = natDegree (`compute_degree!`).
+- `linear_admissible'` — X is faithfully admissible: `roots_X` gives {0}, card 1 = natDegree 1.
+- `le_sublevelSup' : ofReal(2√2) ≤ sublevelSup'` — the 2√2 lower bound transfers verbatim
+  (one-liner mirroring `le_sublevelSup`), since X²−1 splits and stays admissible.
+- `sq_add_one_not_admissible' : ¬ MonicRealRootedIn01' (X²+1)` — X²+1 has 0 real roots but
+  natDegree 2 (`Multiset.eq_zero_iff_forall_notMem` + `nlinarith [sq_nonneg r]`), so it is
+  EXCLUDED. This is the point: the `sublevelInf_eq_zero` degeneracy needed X²+1's vacuous
+  admissibility, which the faithful predicate removes.
+
+VERIFIED docker exit 0 (7743 jobs, first try; cleaned 2 self-introduced lint warnings on a
+2nd build). 0 axioms / 0 sorries. File 227→293 lines, 13→17 theorems, 6→8 defs.
+
+STILL OPEN/blocked (potential theory beyond Mathlib): the faithful infimum exact value
+2^(4/3)−1 ≈ 1.52, and both matching upper bounds (sup'=2√2, the Tao 2025 side).
+Cheap next win: define `sublevelInf'` and mirror `linear_admissible'` for a faithful
+`sublevelInf' ≤ 2`.
+
 ## Session 2026-07-08 (researcher-1) — formalize the supremum object + provable lower bound
 
 The predecessor file `Erdos1038WIP01.lean` proved the extremal quadratic's sublevel

--- a/src/data/research/problems/erdos-1038-wip-01.json
+++ b/src/data/research/problems/erdos-1038-wip-01.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE. First theorems for Erdős #1038 (the gallery file Erdos1038Problem is a stub: definitions only, all 'theorems' commented as prose). Formalizes the concrete extremal computation: the quadratic q = X²−1 is admissible (monic, roots ±1 ∈ [-1,1]), its sublevel set {x : |x²−1| < 1} = Ioo(-√2,√2) \\ {0}, and its Lebesgue measure is exactly 2√2 — the supremum value (Erdős–Herzog–Piranian 1958, Tao 2025). Erdos1038WIP01.lean, 6 defs + 9 theorems (172 lines), 0 axioms, 0 sorries, no native_decide. Now covers BOTH extremal quantities: sublevelSup (2√2 ≤ sup, quadratic witness) and sublevelInf (inf ≤ 2, linear witness). The full supremum bound over all f, and the tight infimum, need logarithmic potential theory (not attempted).",
+    "progressSummary": "PROGRESS. Faithful predicate MonicRealRootedIn01' in place with sup transfer (2*sqrt(2) <= sublevelSup'); this session adds the per-polynomial positivity mechanism: sublevel set is open, any real root forces positive measure, so faithful+deg>=1 => positive measure — exactly the property rootless X^2+1 fails, explaining sublevelInf_eq_zero. Faithful infimum object sublevelInf' + <=2 bound added. File 368 lines, 9 defs + 21 theorems, 0 axioms / 0 sorries, no native_decide. Strict faithful lower bound sublevelInf'>0 and exact 2^(4/3)-1 remain open (potential theory).",
     "builtItems": [
       "Erdos1038WIP01.lean: q := X²−1, eval_q (simp), 4 theorems, 0 axioms (propext/Classical.choice/Quot.sound), 0 sorries. Self-contained re-decl of MonicRealRootedIn01/sublevelSet/sublevelMeasure (stub-independent).",
       "quadratic_admissible: q is monic (monic_X_pow_sub_C 1 (n:=2)) with roots in [-1,1] (mem_roots' → r²−1=0 → nlinarith).",
@@ -47,21 +47,27 @@
       "sublevelSup / le_sublevelSup: sublevelSup := ⨆ over admissible f of sublevelMeasure f; 2√2 ≤ sublevelSup via le_iSup_of_le q (le_iSup_of_le quadratic_admissible sublevelMeasure_quadratic.ge).",
       "linear_admissible / sublevelSet_linear / sublevelMeasure_linear: X is monic (monic_X) with root 0 ∈ [-1,1]; sublevelSet X = Ioo(-1,1) (abs_lt); measure = ENNReal.ofReal 2.",
       "sublevelInf / sublevelInf_le_two: sublevelInf := ⨅ over admissible f of sublevelMeasure f; sublevelInf ≤ 2 via iInf_le_of_le X (iInf_le_of_le linear_admissible sublevelMeasure_linear.le).",
-      "MonicRealRootedIn01' (faithful predicate = MonicRealRootedIn01 f ∧ f.roots.card = f.natDegree, i.e. complete real splitting) + sublevelSup' (⨆ over faithful f). quadratic_admissible'/linear_admissible' verify X²−1 (splits (X−1)(X+1) via roots_mul+roots_X_sub_C, card 2 = natDegree 2) and X (roots_X {0}, card 1 = natDegree 1) are faithfully admissible; le_sublevelSup' transfers the 2√2 lower bound to the faithful object. sq_add_one_not_admissible': X²+1 has 0 real roots but natDegree 2 → EXCLUDED, so the sublevelInf_eq_zero pathology is no longer admissible under the faithful predicate. All 0 axioms / 0 sorries, docker VERIFIED exit 0."
+      "MonicRealRootedIn01' (faithful predicate = MonicRealRootedIn01 f ∧ f.roots.card = f.natDegree, i.e. complete real splitting) + sublevelSup' (⨆ over faithful f). quadratic_admissible'/linear_admissible' verify X²−1 (splits (X−1)(X+1) via roots_mul+roots_X_sub_C, card 2 = natDegree 2) and X (roots_X {0}, card 1 = natDegree 1) are faithfully admissible; le_sublevelSup' transfers the 2√2 lower bound to the faithful object. sq_add_one_not_admissible': X²+1 has 0 real roots but natDegree 2 → EXCLUDED, so the sublevelInf_eq_zero pathology is no longer admissible under the faithful predicate. All 0 axioms / 0 sorries, docker VERIFIED exit 0.",
+      "isOpen_sublevelSet (Erdos1038WIP01.lean): sublevel set is open via isOpen_Ioo.preimage f.continuous",
+      "sublevelMeasure_pos_of_root (Erdos1038WIP01.lean): any real root => 0 < sublevelMeasure f (IsOpen.measure_pos on volume)",
+      "faithful_sublevelMeasure_pos (Erdos1038WIP01.lean): MonicRealRootedIn01' f AND deg>=1 => 0 < sublevelMeasure f",
+      "sublevelInf' def + sublevelInf'_le_two (Erdos1038WIP01.lean): faithful infimum object and linear-witness <=2 bound, free of rootless collapse"
     ],
     "insights": [
       "x²−1 is the explicit extremizer for the Erdős #1038 supremum: |x²−1| < 1 ⟺ 0 < x² < 2 ⟺ x ∈ (-√2,√2)\\{0}, measure 2√2.",
       "Lean: |x²−1| < 1 splits via abs_lt into −1 < x²−1 ∧ x²−1 < 1 = 0 < x² ∧ x² < 2; the elementary form (0 < x² < 2) is certain, the √2 interval form needs Real.sq_sqrt and nlinarith with sq_nonneg(x±√2) to convert x² < 2 ↔ |x| < √2.",
       "Removing the isolated zero of x² (the point x=0 where x²−1 = −1, |−1| = 1 not < 1) is exactly the \\{0}; measure_diff_null (volume {0} = 0 by simp) discards it for the measure.",
-      "monic_X_pow_sub_C (1) (n:=2) (by norm_num) gives Monic (X²−C 1); roots via Polynomial.mem_roots' (a ∈ roots ↔ p ≠ 0 ∧ IsRoot)."
+      "monic_X_pow_sub_C (1) (n:=2) (by norm_num) gives Monic (X²−C 1); roots via Polynomial.mem_roots' (a ∈ roots ↔ p ≠ 0 ∧ IsRoot).",
+      "Per-polynomial positivity: the sublevel set {x:|f(x)|<1} is OPEN (preimage of Ioo(-1,1) under continuous eval), so any real root r (f(r)=0) lies inside it and forces positive Lebesgue measure via IsOpen.measure_pos. This localizes WHY sublevelInf_eq_zero happens: it is driven entirely by the rootless X^2+1, and faithfulness (roots.card=natDegree) forbids rootlessness.",
+      "Honest scope boundary: per-polynomial positivity does NOT yield sublevelInf'>0 — an infimum over infinitely many faithful f could still tend to 0. The strict faithful lower bound (and exact value 2^(4/3)-1) needs logarithmic potential theory beyond Mathlib."
     ],
     "mathlibGaps": [
       "The supremum BOUND (every admissible f has sublevel measure ≤ 2√2) requires logarithmic potential theory (Tao 2025) not in Mathlib — only the extremal witness is formalized here."
     ],
     "nextSteps": [
-      "Tighten sublevelInf ≤ 2 toward the true ≤ 1.835: the polynomial (x+1)(x−1)^m for m ≥ 3 witnesses inf < 2; formalize its sublevel measure as a sharper upper bound on the (open) infimum.",
-      "Products: MonicRealRootedIn01 is preserved under multiplication (monic × monic, roots union), giving a closure structure on admissible polynomials.",
-      "The general upper bound 2√2 over all admissible f (the hard analytic core, Tao's logarithmic-potential argument)."
+      "OPEN (needs potential theory): prove sublevelInf' > 0 (strict), a uniform positive lower bound over all faithful f — the 2^(4/3)-1 direction.",
+      "OPEN (needs potential theory): matching upper bound sublevelSup' = 2*sqrt(2) (the Tao 2025 side).",
+      "Elementary candidate: search for a faithful witness of measure < 2 (degree >= 3, Chebyshev-like) to improve sublevelInf'_le_two below 2."
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-1038-wip-01.json
+++ b/src/data/research/problems/erdos-1038-wip-01.json
@@ -27,9 +27,9 @@
     "phase": "COMPLETED",
     "since": "2026-06-22T00:00:00-07:00",
     "iteration": 1,
-    "focus": "Added the infimum side: the sublevelInf object and a second exact witness (linear X, measure 2) bounding sublevelInf ≤ 2.",
+    "focus": "Added the faithful predicate MonicRealRootedIn01' (complete real splitting f.roots.card=f.natDegree) + sublevelSup'; transferred the 2√2 sup lower bound (le_sublevelSup') to the faithful object and proved X²+1 is excluded (sq_add_one_not_admissible'), so the literal-predicate sublevelInf_eq_zero degeneracy does not affect the faithful infimum.",
     "blockers": [],
-    "nextAction": "The two provable directions (2√2 ≤ sublevelSup, sublevelInf ≤ 2) are done. Tightening sublevelInf ≤ 2 toward the true ≤ 1.835 needs the polynomial (x+1)(x−1)^m and logarithmic potential theory beyond Mathlib.",
+    "nextAction": "The faithful sup lower bound 2√2 ≤ sublevelSup' is done. Remaining OPEN/blocked: the faithful infimum exact value 2^(4/3)−1 (needs logarithmic potential theory beyond Mathlib) and both matching upper bounds. A cheap next win: the linear witness X also gives sublevelInf' ≤ 2 under the faithful predicate (define sublevelInf', mirror linear_admissible').",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
@@ -46,7 +46,8 @@
       "sublevelMeasure_quadratic: = ENNReal.ofReal (2√2) (measure_diff_null removes {0}, Real.volume_Ioo, ring for √2−(−√2)=2√2).",
       "sublevelSup / le_sublevelSup: sublevelSup := ⨆ over admissible f of sublevelMeasure f; 2√2 ≤ sublevelSup via le_iSup_of_le q (le_iSup_of_le quadratic_admissible sublevelMeasure_quadratic.ge).",
       "linear_admissible / sublevelSet_linear / sublevelMeasure_linear: X is monic (monic_X) with root 0 ∈ [-1,1]; sublevelSet X = Ioo(-1,1) (abs_lt); measure = ENNReal.ofReal 2.",
-      "sublevelInf / sublevelInf_le_two: sublevelInf := ⨅ over admissible f of sublevelMeasure f; sublevelInf ≤ 2 via iInf_le_of_le X (iInf_le_of_le linear_admissible sublevelMeasure_linear.le)."
+      "sublevelInf / sublevelInf_le_two: sublevelInf := ⨅ over admissible f of sublevelMeasure f; sublevelInf ≤ 2 via iInf_le_of_le X (iInf_le_of_le linear_admissible sublevelMeasure_linear.le).",
+      "MonicRealRootedIn01' (faithful predicate = MonicRealRootedIn01 f ∧ f.roots.card = f.natDegree, i.e. complete real splitting) + sublevelSup' (⨆ over faithful f). quadratic_admissible'/linear_admissible' verify X²−1 (splits (X−1)(X+1) via roots_mul+roots_X_sub_C, card 2 = natDegree 2) and X (roots_X {0}, card 1 = natDegree 1) are faithfully admissible; le_sublevelSup' transfers the 2√2 lower bound to the faithful object. sq_add_one_not_admissible': X²+1 has 0 real roots but natDegree 2 → EXCLUDED, so the sublevelInf_eq_zero pathology is no longer admissible under the faithful predicate. All 0 axioms / 0 sorries, docker VERIFIED exit 0."
     ],
     "insights": [
       "x²−1 is the explicit extremizer for the Erdős #1038 supremum: |x²−1| < 1 ⟺ 0 < x² < 2 ⟺ x ∈ (-√2,√2)\\{0}, measure 2√2.",


### PR DESCRIPTION
## Erdős #1038 — WIP-01

Formalizes the sublevel-set extremal problem for monic real-rooted polynomials with roots in `[-1,1]`: study `|{x : |f(x)| < 1}|`. Sup = 2√2 (Erdős–Herzog–Piranian 1958, Tao 2025).

### This branch adds
**Faithful (complete-splitting) predicate** `MonicRealRootedIn01' f := Monic ∧ (roots ⊆ [-1,1]) ∧ roots.card = natDegree`, fixing the degeneracy that the literal predicate admits the rootless `X²+1`:
- `quadratic_admissible'`, `linear_admissible'` — the two exact witnesses split completely.
- `le_sublevelSup' : 2√2 ≤ sublevelSup'` — the sup lower bound transfers to the faithful object.
- `sq_add_one_not_admissible'` — `X²+1` is correctly excluded (0 real roots ≠ degree 2).

**Per-polynomial positivity (the mechanism behind `sublevelInf_eq_zero`):**
- `isOpen_sublevelSet` — `{x : |f(x)| < 1}` is open (preimage of `(-1,1)` under continuous eval).
- `sublevelMeasure_pos_of_root` — any real root lies in that open set ⟹ positive Lebesgue measure.
- `faithful_sublevelMeasure_pos` — faithful + degree ≥ 1 ⟹ has a real root ⟹ `0 < sublevelMeasure f`. This is exactly the property rootless `X²+1` fails, which drove `sublevelInf = 0` under the literal predicate.
- `sublevelInf'` + `sublevelInf'_le_two` — faithful infimum object and its linear-witness `≤ 2` bound, free of the rootless collapse.

### Honest scope
Proves positivity *per polynomial*, not `sublevelInf' > 0` (an infimum over infinitely many f could still tend to 0). The exact faithful infimum `2^(4/3)−1` and the matching sup upper bound `= 2√2` need logarithmic potential theory beyond Mathlib and are not attempted.

**Docker-verified, 0 axioms, 0 sorries, no native_decide.** File: 368 lines, 9 defs + 21 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)