### PR TITLE
Enrich Triangular 8n+1 Test: cross-link Pell equation and Fermat two-squares

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02/meta.json
@@ -161,6 +161,16 @@
       "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-02",
       "relationship": "relatedTo",
       "description": "The two-summand sibling (two triangular ⟺ 4n+1 a sum of two squares). Together with Gauss Eureka these three entries give the full d=1,2,3 triangular-rank hierarchy: 8n+1 square, 4n+1 two squares, always."
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "relatedTo",
+      "description": "The square-triangular open question of this entry reduces, via the 8n+1 test, to the Pell equation x²−2y²=1 (x=2k+1, y=2m): the n that are simultaneously triangular and square are in bijection with Pell solutions, giving the recurrence 0, 1, 36, 1225, …. This entry supplies the 8n+1 characterization; Pell's equation supplies the solution structure."
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "relatedTo",
+      "description": "The rank-2 tier of the triangular-rank hierarchy (two triangular ⟺ 4n+1 a sum of two squares) is governed by the sum-of-two-squares theory Fermat's theorem initiates — a prime is a sum of two squares iff p=2 or p≡1 (mod 4). The 4n+1 condition classifying rank-2 triangularity is exactly a sum-of-two-squares condition."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass — lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02 (Triangular 8n+1 Test)

The entry cross-linked its two triangular-hierarchy siblings but omitted the two theories its own open questions and rank tiers depend on. Added:

- **pell-equation** — the entry's own open question 'square triangular numbers' reduces, via the 8n+1 test, to the Pell equation $x^2-2y^2=1$ ($x=2k+1,\ y=2m$); square-triangular numbers biject with Pell solutions, giving the recurrence 0, 1, 36, 1225, ….
- **fermat-two-squares** — the rank-2 tier (two triangular ⟺ 4n+1 a sum of two squares) is governed by the Fermat/Zagier sum-of-two-squares theory.

Pure cross-reference enrichment — no prose inflation. crossReferences 2 → 4 (cap 20). meta.json 14.2 KB → 15.1 KB (well under 60 KB). JSON validated; all 4 targets verified on disk; gallery-data build (enrichment + search-index) passes. No change to status/badge/axiomCount (remains 'verified', 0 axioms).