### PR TITLE
research(erdos-897-oq-01): master domination lemma + cone of witnesses [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -269,4 +269,37 @@ theorem unbounded_not_implies_unboundedOnPrimePowers :
   ⟨bigOmega, bigOmega_completelyAdditive.1, bigOmega_unbounded_on_primePowers,
     not_unboundedOnPrimePowers_bigOmega⟩
 
+/-
+## (6) The master domination lemma and a cone of witnesses
+
+`UnboundedOnPrimePowers` is a *largeness* condition, hence upward closed: if `f`
+satisfies it and `g` dominates `f` on prime powers (`g(p^k) ≥ f(p^k)`), then `g`
+satisfies it too — the same witnesses `(p,k)` work verbatim, since the comparison
+value `M·log(p^k)` does not depend on the function. This single lemma is the
+common source of the various closure properties of the class (positive scaling,
+adding a prime-power-nonnegative function); it also turns the single witness
+`logSqWeight` of (1) into an entire *cone* of witnesses: any `g ≥ logSqWeight` on
+prime powers is a satisfier.
+-/
+
+/-- **Domination lemma.** If `f` is unbounded on prime powers relative to `log` and
+`g(p^k) ≥ f(p^k)` for every prime power, then `g` is unbounded on prime powers too.
+The comparison value `M·log(p^k)` is independent of the function, so the same
+witness `(p,k)` transfers. -/
+theorem unboundedOnPrimePowers_of_ge {f g : ℕ → ℝ}
+    (hf : UnboundedOnPrimePowers f)
+    (hdom : ∀ p k : ℕ, p.Prime → 1 ≤ k → f (p ^ k) ≤ g (p ^ k)) :
+    UnboundedOnPrimePowers g := by
+  intro M
+  obtain ⟨p, k, hp, hk, hpk⟩ := hf M
+  exact ⟨p, k, hp, hk, lt_of_lt_of_le hpk (hdom p k hp hk)⟩
+
+/-- **A cone of witnesses.** Any function dominating `logSqWeight` on prime powers
+satisfies the Erdős #897 hypothesis. So non-vacuity (1) is not an isolated accident:
+the hypothesis holds for a whole family of functions, not just `logSqWeight`. -/
+theorem unboundedOnPrimePowers_of_ge_logSqWeight {g : ℕ → ℝ}
+    (hg : ∀ p k : ℕ, p.Prime → 1 ≤ k → logSqWeight (p ^ k) ≤ g (p ^ k)) :
+    UnboundedOnPrimePowers g :=
+  unboundedOnPrimePowers_of_ge logSqWeight_unboundedOnPrimePowers hg
+
 end Erdos897

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -129,11 +129,11 @@
       "Finset"
     ],
     "namespace": "Erdos897",
-    "lineCount": 272,
+    "lineCount": 305,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 13
+    "theoremCount": 15
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Adds Section (6) to `Erdos897OQ01.lean` — the **master domination lemma** for the Erdős #897 hypothesis `UnboundedOnPrimePowers`, plus its cone-of-witnesses corollary. 2 theorems, machine-checked, **0 axioms, 0 sorries, no native_decide**.

- **`unboundedOnPrimePowers_of_ge`** — if `f` satisfies the hypothesis and `g(p^k) ≥ f(p^k)` on every prime power, then `g` satisfies it too. The comparison value `M·log(p^k)` is function-independent, so the same witness `(p,k)` transfers verbatim.
- **`unboundedOnPrimePowers_of_ge_logSqWeight`** — any `g` dominating `logSqWeight` on prime powers is a satisfier, so the single non-vacuity witness of Section (1) becomes an entire cone.

## Relation to in-flight work (checked before shipping)

Two open PRs (#35963, #35892) add the *positive-cone* closure results — closure under positive scaling (`g = c·f`, `c > 0`) and under adding a prime-power-nonnegative function (`g = f + h`, `h ≥ 0`). Both are **exactly the special cases** of the single domination lemma in this PR. To stay distinct and avoid duplicate theorem-name (add/add) conflicts, I deliberately dropped my own `_smul`/`_add_nonneg` copies and kept only the general statement they specialize. This PR is additive to either of those merging.

## Verification

```
✔ [7744/7744] Built Proofs.Erdos897OQ01 (3.0s)
```
Meta counts synced (lineCount 272→305, theoremCount 13→15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)