### PR TITLE
Enrich Stark rank-one regulator (kroneckers-jugendtraum-oq-02): link real-quadratic sibling

### DIFF
--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
@@ -123,6 +123,11 @@
       "targetId": "kroneckers-jugendtraum",
       "relationship": "extends",
       "description": "Parent Kronecker Jugendtraum / Stark entry; this treats the unit-rank-1 case where the regulator collapses from an r×r determinant to a single archimedean log of the fundamental (Stark) unit."
+    },
+    {
+      "targetId": "kroneckers-jugendtraum-oq-01",
+      "relationship": "sibling-open-question",
+      "description": "The concrete real-quadratic instance of this entry's abstract rank-one collapse (and exactly the specialization named in this entry's second open question): real quadratic fields are precisely the totally real degree-2 fields, they have unit rank 1, and their regulator is a single bare logarithm of the classical fundamental unit — the (2,0)-signature member of the two-infinite-place family where the r×r regulator determinant here degenerates to one 1×1 entry."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `kroneckers-jugendtraum-oq-02`.

**Gap addressed:** Structurally complete entry (quality 94) whose `crossReferences` linked only the parent, omitting its sibling `kroneckers-jugendtraum-oq-01`.

**Change (cross-reference only):** Added `kroneckers-jugendtraum-oq-01` (relationship `sibling-open-question`). The link is doubly warranted — oq-01 (real quadratic fields, unit-rank-one) is the concrete (2,0)-signature instance of this entry's abstract rank-one regulator collapse, and it is exactly the 'specialize to real quadratic fields' specialization named in this entry's own second open question.

meta.json 12.6 KB → 13.2 KB (well under cap). No status/badge/axiom changes. Gallery-data validation passes.