### PR TITLE
Enrich Leibniz-Lagrange Identity: cross-link n-point generalisation and Jordan-von Neumann

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07-oq-02-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-02-oq-01/meta.json
@@ -90,6 +90,16 @@
       "targetId": "law-of-cosines-oq-07",
       "relationship": "related",
       "description": "The grandparent single-median Apollonius identity; the Leibniz identity here is the affine generalisation centred at the centroid."
+    },
+    {
+      "targetId": "british-flag-theorem-oq-01-oq-03",
+      "relationship": "related",
+      "description": "The n-point generalisation this entry's open question asks for: ∑ᵢ‖P−Aᵢ‖² = ∑ᵢ‖G−Aᵢ‖² + n‖P−G‖² for the barycentre G of n points, proved by the same polarisation. This triangle (n=3) case is its specialisation; that entry is the complementary (symmetric-sum) branch of the British-flag alternating-sum family."
+    },
+    {
+      "targetId": "law-of-cosines-oq-07-oq-01",
+      "relationship": "related",
+      "description": "The Jordan–von Neumann theorem: the parallelogram law ‖x+y‖²+‖x−y‖²=2(‖x‖²+‖y‖²) characterises exactly the norms coming from an inner product. It is the identity that makes the polarisation used here legitimate — the Leibniz identity holds precisely in the inner-product spaces that theorem singles out."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass — law-of-cosines-oq-07-oq-02-oq-01 (Leibniz–Lagrange identity for a triangle)

Two mathematically precise cross-references were missing — one of which the entry's own open question explicitly reaches for:

- **british-flag-theorem-oq-01-oq-03** — 'Leibniz Parallel-Axis Identity: $\sum_i\|P-A_i\|^2 = \sum_i\|G-A_i\|^2 + n\|P-G\|^2$'. This is exactly the n-point generalisation this entry's openQuestion #1 asks whether the same polarisation delivers; the triangle result here is its n=3 case.
- **law-of-cosines-oq-07-oq-01** — the Jordan–von Neumann theorem: the parallelogram law characterises inner-product norms. It is the identity that legitimises the polarisation-about-the-centroid technique used in this proof.

Pure cross-reference enrichment. crossReferences 2 → 4 (cap 20). meta.json 11.7 KB → 12.6 KB (well under 60 KB). JSON validated; all 4 targets verified on disk; gallery-data build (enrichment + search-index) passes. No change to status/badge/axiomCount.