### PR TITLE
Fix: sync stale theoremCount on 4 grown gallery entries

### DIFF
--- a/src/data/proofs/inverse-galois-a5/meta.json
+++ b/src/data/proofs/inverse-galois-a5/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 2105,
-    "theoremCount": 65,
+    "theoremCount": 84,
     "definitionCount": 12,
     "mathlib_version": "4.26.0"
   },
@@ -82,7 +82,7 @@
     "namespace": "InverseGaloisA5",
     "lineCount": 2105,
     "axiomCount": 1,
-    "theoremCount": 65,
+    "theoremCount": 84,
     "definitionCount": 12,
     "path": "Proofs/InverseGaloisA5.lean",
     "sorries": 0

--- a/src/data/proofs/inverse-galois-oq-06/meta.json
+++ b/src/data/proofs/inverse-galois-oq-06/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 2,
     "assumptions": "2 axioms. (1) three_dvd_gal_card — 3 divides |Gal(q/ℚ)|. This follows from Dedekind's theorem applied to q mod 7 (which factors as (1-cycle)(1-cycle)(3-cycle)), implying the Galois group contains an element of order divisible by 3. Axiomatized because Mathlib lacks Dedekind's theorem for polynomial Galois groups. (2) Lean.ofReduceBool — several credited theorems are discharged by `native_decide` (perm_fin5_order5_order3_not_commute, perm_fin5_no_order_15, a5_card, resolvent_no_positive_root, resolvent_no_negative_root, resolvent_at_zero, and the Sylow subgroup-cardinality steps), which trusts the Lean compiler's kernel reduction (#print axioms lists Lean.ofReduceBool); these results are free of mathematical axioms but not axiom-free in the strict sense.",
     "lineCount": 2105,
-    "theoremCount": 65,
+    "theoremCount": 84,
     "definitionCount": 12,
     "originalContributions": [
       "q: the polynomial x⁵-5x⁴+10x³-10x²+25x-5 (translate of x⁵+20x+16)",
@@ -87,7 +87,7 @@
     "namespace": "InverseGaloisA5",
     "lineCount": 2105,
     "axiomCount": 1,
-    "theoremCount": 65,
+    "theoremCount": 84,
     "definitionCount": 12,
     "path": "Proofs/InverseGaloisA5.lean",
     "sorries": 0,

--- a/src/data/proofs/pythagorean-theorem-oq-05/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-05/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None. Both main theorems take the right-angle curved law (as a scaled functional equation ∀ t > 0) as an explicit hypothesis and derive c² = a² + b² from it; they do not assume any spherical/hyperbolic-geometry infrastructure. Fully machine-checked, depending only on propext, Classical.choice, and Quot.sound.",
     "lineCount": 443,
-    "theoremCount": 19,
+    "theoremCount": 24,
     "definitionCount": 1,
     "originalContributions": [
       "spherical_flat_limit: if cos(t·c) = cos(t·a)·cos(t·b) for all t > 0 then c² = a² + b² — the spherical right-triangle law degenerates to Pythagoras in the flat limit, with NO range restriction on a, b, c",
@@ -68,7 +68,7 @@
     "namespace": "PythagoreanFlatLimit",
     "lineCount": 443,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 24,
     "definitionCount": 1,
     "path": "Proofs/PythagoreanTheoremOQ05.lean",
     "imports": [

--- a/src/data/proofs/szemeredi-counting-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-counting-oq-02/meta.json
@@ -24,7 +24,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 445,
-    "theoremCount": 17,
+    "theoremCount": 21,
     "definitionCount": 10,
     "assumptions": "None beyond finite vertex parts. All results are universally quantified over a Tri3Graph H on Fintype parts α, β, γ; the adjacency predicate is an arbitrary Prop and decidability is supplied classically (open Classical), so edgeFinset/degA/cherryFinset are noncomputable Finset filters with no DecidableRel hypothesis. #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound; no sorryAx, no native_decide, no Lean.ofReduceBool.",
     "mathlibDependencies": [
@@ -200,7 +200,7 @@
     ],
     "namespace": "Szemeredi.HypergraphCounting",
     "lineCount": 445,
-    "theoremCount": 17,
+    "theoremCount": 21,
     "axiomCount": 0,
     "definitionCount": 10,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Four gallery entries stored a stale `theoremCount` (in both the `meta` and `leanFile` blocks) that lagged their actual Lean declaration count after the source files grew. In each case `lineCount` had been kept current but `theoremCount` was not — a classic partial-sync.

| Slug | Lean file | theoremCount before → after |
|------|-----------|------------------------------|
| `inverse-galois-a5` | `InverseGaloisA5.lean` | 65 → 84 |
| `inverse-galois-oq-06` | `InverseGaloisA5.lean` (shared) | 65 → 84 |
| `pythagorean-theorem-oq-05` | `PythagoreanTheoremOQ05.lean` | 19 → 24 |
| `szemeredi-counting-oq-02` | `SzemerediCountingOQ02.lean` | 17 → 21 |

## Evidence

Counts verified by two independent methods per file:
- **Raw grep** `^\s*(private|protected|noncomputable)*(theorem|lemma) ` → 85 / 25 / 23
- **Comment-stripped** declaration count → 84 / 24 / 21

The 1–2 line differences between raw and stripped are genuine docstring/prose mentions of the words "theorem"/"lemma" (e.g. `InverseGaloisA5.lean:266` "theorem not yet in Mathlib", `PythagoreanTheoremOQ05.lean:421` "theorem as curvature → 0"), not real declarations. The stripped value is the true count. `lineCount`, `definitionCount`, and `sorries` were already correct and are unchanged.

**Before**: stored counts (65/65/19/17) predate ~4–20 theorems added by later research PRs.
**After**: counts match the current source.

Metadata-only change; all four `meta.json` files re-validated as parseable JSON.

---
Automated fix by lean-mechanic agent.