### PR TITLE
Enrich Markov Vieta ascent growth: cross-link Vieta-neighbor, Hurwitz generalization, Pell chain

### DIFF
--- a/src/data/proofs/markov-equation-oq-06-oq-01/meta.json
+++ b/src/data/proofs/markov-equation-oq-06-oq-01/meta.json
@@ -41,6 +41,21 @@
       "targetId": "markov-equation",
       "relationship": "related",
       "description": "The grandparent development runs the Markov tree downward (descent decreases the coordinate sum); this entry quantifies the upward direction, showing the ascent grows the maximal coordinate geometrically."
+    },
+    {
+      "targetId": "markov-equation-oq-05",
+      "relationship": "related",
+      "description": "Supplies the structural fact behind the ascent step used here: with the first two coordinates fixed, the Vieta neighbor 3xy − z is the unique other solution. The successor top coordinate 3bc − a whose doubling this entry proves is exactly that neighbor, so the geometric growth is the quantitative shadow of the fiber-involution structure."
+    },
+    {
+      "targetId": "markov-equation-oq-03",
+      "relationship": "related",
+      "description": "Carries the same Vieta-jump machinery to the Markov–Hurwitz generalizations x²+y²+z² = kxyz; the doubling/geometric-growth argument here is the k = 3 quantitative instance of that broader jumping framework."
+    },
+    {
+      "targetId": "pell-equation-oq-06-oq-01",
+      "relationship": "related",
+      "description": "A cross-family instance of the same recursive-chain method: the negative Pell equation x² − 2y² = −1 is classified by an ascending Vieta-style chain, mirroring how the Markov ascent sequence generates all triples along one branch."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Enrichment pass — markov-equation-oq-06-oq-01 (geometric growth of the Vieta ascent)

The entry linked only its parent and grandparent. Added 3 mathematically load-bearing cross-references:

- **markov-equation-oq-05** — the Vieta neighbor $3xy-z$ is the unique alternative solution; the successor top coordinate $3bc-a$ whose doubling this entry proves *is* that neighbor, so the geometric growth is the quantitative shadow of the fiber-involution structure.
- **markov-equation-oq-03** — the Markov–Hurwitz $kxyz$ generalization of the same Vieta-jump machinery (this is the $k=3$ quantitative instance).
- **pell-equation-oq-06-oq-01** — a cross-family recursive-chain classification via Vieta jumping (negative Pell $x^2-2y^2=-1$), mirroring the single-branch ascent here.

Pure cross-reference enrichment. crossReferences 2 → 5 (cap 20). meta.json 12.9 KB → 14.0 KB (well under 60 KB). JSON validated; all 5 targets verified on disk; gallery-data build (enrichment + search-index) passes. No change to status/badge/axiomCount ('verified', 0 axioms).