### PR TITLE
research(erdos-1110-oq-01): density-of-finite-set-is-zero + density uniqueness [VERIFIED 0/0-new]

### DIFF
--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -1166,6 +1166,50 @@ theorem hasDensity_empty : HasDensity (∅ : Set ℕ) 0 := by
     Nat.cast_zero, zero_div, sub_zero, abs_zero]
   exact hε
 
+/- **Every finite set of naturals has natural density `0`** (unconditional, 0-axiom).
+The general fact behind `hasDensity_singleton_zero` and `hasDensity_empty`: the
+counting numerator `|A ∩ {0,…,n}|` never exceeds the fixed cardinality `|A|`, so the
+ratio is at most `|A|/n → 0`. Combined with `finite_nonRepresentable_of_two_three`
+this gives the `{2,3}` density-zero results directly, without computing the set. -/
+open scoped Classical in
+theorem hasDensity_zero_of_finite {A : Set ℕ} (hA : A.Finite) : HasDensity A 0 := by
+  intro ε hε
+  obtain ⟨N, hN⟩ := exists_nat_gt ((hA.toFinset.card : ℝ) / ε)
+  refine ⟨N + 1, fun n hn => ?_⟩
+  have hn0 : (0 : ℝ) < n := by exact_mod_cast (by omega : 0 < n)
+  have hsub : Finset.filter (· ∈ A) (Finset.range (n + 1)) ⊆ hA.toFinset := by
+    intro k hk
+    exact hA.mem_toFinset.mpr (Finset.mem_filter.mp hk).2
+  have hcardR : ((Finset.filter (· ∈ A) (Finset.range (n + 1))).card : ℝ)
+      ≤ (hA.toFinset.card : ℝ) := by exact_mod_cast Finset.card_le_card hsub
+  rw [sub_zero, abs_of_nonneg (by positivity), div_lt_iff₀ hn0]
+  have hCεn : (hA.toFinset.card : ℝ) < ε * n := by
+    have hle : ((N : ℕ) : ℝ) ≤ (n : ℝ) := by exact_mod_cast (by omega : (N : ℕ) ≤ n)
+    have hNn : (hA.toFinset.card : ℝ) / ε < n := lt_of_lt_of_le hN hle
+    rw [div_lt_iff₀ hε] at hNn
+    linarith [mul_comm (n : ℝ) ε]
+  linarith [hcardR]
+
+/- **Natural density is unique** (unconditional, 0-axiom). If a set has natural
+density `d₁` and also `d₂`, then `d₁ = d₂`. So `HasDensity A ·` is a genuine partial
+function — "the density of `A`" is well-defined whenever it exists. Proof: if the two
+densities differed, the counting ratio at a large `n` would sit within `|d₁−d₂|/2` of
+both, forcing `|d₁−d₂| < |d₁−d₂|`. -/
+open scoped Classical in
+theorem hasDensity_unique {A : Set ℕ} {d₁ d₂ : ℝ}
+    (h₁ : HasDensity A d₁) (h₂ : HasDensity A d₂) : d₁ = d₂ := by
+  by_contra hne
+  have hδpos : 0 < |d₁ - d₂| := abs_pos.mpr (sub_ne_zero.mpr hne)
+  obtain ⟨N₁, hN₁⟩ := h₁ (|d₁ - d₂| / 2) (by linarith)
+  obtain ⟨N₂, hN₂⟩ := h₂ (|d₁ - d₂| / 2) (by linarith)
+  have e1 := hN₁ (max N₁ N₂ + 1) (by omega)
+  have e2 := hN₂ (max N₁ N₂ + 1) (by omega)
+  set r := ((Finset.filter (· ∈ A) (Finset.range (max N₁ N₂ + 1 + 1))).card : ℝ)
+    / ((max N₁ N₂ + 1 : ℕ) : ℝ) with hr
+  have key : |d₁ - d₂| ≤ |d₁ - r| + |r - d₂| := abs_sub_le d₁ r d₂
+  rw [abs_sub_comm d₁ r] at key
+  linarith [e1, e2, key]
+
 /-- **The `{2,3}` coprime non-representables are empty (unconditional, 0-axiom).**
 
 `CoprimeNonRepresentable` is the Yu-Chen object whose infinitude is asserted "for

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -265,9 +265,9 @@
       "Finset"
     ],
     "namespace": "Erdos1110",
-    "lineCount": 1459,
+    "lineCount": 1503,
     "axiomCount": 1,
-    "theoremCount": 69,
+    "theoremCount": 70,
     "definitionCount": 7,
     "path": "Proofs/Erdos1110Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Two fundamental structural lemmas about the `HasDensity` predicate in `Erdos1110Problem.lean` (Erdős #1110, density of non-representables for additive bases). Both machine-checked, **no new axioms or sorries** — the file's sole deep axiom `erdos_lewin_infinite` (Erdős–Lewin 1996 infinitude direction, not in Mathlib) is untouched.

- **`hasDensity_zero_of_finite`** — every finite set of naturals has natural density `0`. This is the *general* fact behind the file's two ad-hoc helpers `hasDensity_singleton_zero` and `hasDensity_empty`: the counting numerator `|A ∩ {0,…,n}|` never exceeds the fixed cardinality `|A|`, so the ratio is `≤ |A|/n → 0`. Together with the already-proved `finite_nonRepresentable_of_two_three` it delivers the `{2,3}` density-zero results structurally, without computing the set explicitly.
- **`hasDensity_unique`** — natural density is unique: `HasDensity A d₁ → HasDensity A d₂ → d₁ = d₂`. So "the density of `A`" is well-defined whenever it exists (`HasDensity A ·` is a genuine partial function). Proof: a large-`n` counting ratio lies within `|d₁−d₂|/2` of both candidate densities, forcing `|d₁−d₂| < |d₁−d₂|`.

These fill a real gap: the file proved density-zero for the singleton and empty set separately but never the general finite case, and never established that the density value is unique.

## Verification

```
Build completed successfully (7743 jobs).
```
Docker build clean; 0 sorries; axiom count unchanged (1, the pre-existing deep `erdos_lewin_infinite`). Meta counts synced (lineCount 1459→1503, theoremCount 69→70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)