### PR TITLE
Fix erdos-143: bind malformed Conjecture_iii to actual reciprocal sum (#36060)

### DIFF
--- a/proofs/Proofs/Erdos143Problem.lean
+++ b/proofs/Proofs/Erdos143Problem.lean
@@ -68,11 +68,14 @@ def Conjecture_i (A : Set ℝ) : Prop :=
 def Conjecture_ii (A : Set ℝ) : Prop :=
   Summable fun (x : A) => 1 / ((x : ℝ) * Real.log x)
 
+/-- The partial reciprocal sum ∑_{x∈A, 1<x<n} 1/x. Uses `finsum`, which is `0`
+    when the support is not finite, so it is well-defined for any `A : Set ℝ`. -/
+noncomputable def reciprocalPartialSum (A : Set ℝ) (n : ℝ) : ℝ :=
+  ∑ᶠ x ∈ (A ∩ Set.Ioo 1 n), 1 / x
+
 /-- **Conjecture (iii)**: The partial reciprocal sum is o(log n). STATUS: SOLVED -/
 def Conjecture_iii (A : Set ℝ) : Prop :=
-  ∀ ε > 0, ∃ N₀ : ℝ, ∀ n ≥ N₀, ∀ (partialSum : ℝ),
-    -- partialSum represents ∑_{x∈A, x<n} 1/x
-    partialSum ≤ ε * Real.log n
+  ∀ ε > 0, ∃ N₀ : ℝ, ∀ n ≥ N₀, reciprocalPartialSum A n ≤ ε * Real.log n
 
 /- ## Main Results -/
 

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -46,10 +46,10 @@
       "Formalized the KLL 2025 partial resolution"
     ],
     "axiomCount": 3,
-    "lineCount": 119,
+    "lineCount": 122,
     "assumptions": "3 axiom(s): kll_theorem, well_separated_integers_primitive, erdos_1935_primitive. See Lean source for complete statements.",
     "theoremCount": 1,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Erdős Problem #143 belongs to a family of questions about how structural constraints on sets force sparseness. A set $A \\subset (1, \\infty)$ is *well-separated under integer dilation* if $|kx - y| \\geq 1$ for all distinct $x, y \\in A$ and positive integers $k$ — no element can be close to any integer multiple of another. This condition arises naturally in the study of primitive sets, lattice-free configurations, and Diophantine approximation.\n\nFor **integer sets**, well-separation implies primitivity: if $a \\mid b$ with $b = ka$, then $|ka - b| = 0 < 1$, violating the condition. Erdős initiated the study of primitive sets in 1935, proving that for any infinite primitive set $A \\subset \\mathbb{N}$, the series $\\sum_{a \\in A} 1/(a \\log a)$ converges — a result that quantifies how sparse primitive sets must be. Felix Behrend independently obtained the density estimate $\\sum_{a \\leq x, a \\in A} 1/a \\ll \\sqrt{\\log x / \\log \\log x}$ in the same year. The question of whether these density bounds extend from primitive integer sets to the broader class of real well-separated sets remained open for nearly 90 years.\n\nThe breakthrough came in 2025 when Dimitris Koukoulopoulos, Youness Lamzouri, and Jared Duker Lichtman proved that for any well-separated set $A$, the partial reciprocal sum $\\sum_{x < n, x \\in A} 1/x = o(\\log n)$ — resolving the weakest of Erdős's three conjectures. Their proof uses a novel graph-theoretic approach: they construct a GCD graph on elements of $A$ and use structural properties of this graph together with bounds from multiplicative number theory to control the reciprocal sum. The two stronger conjectures — (i) that the lower density $\\liminf |A \\cap [1,x]|/x = 0$, and (ii) that $\\sum_{x \\in A} 1/(x \\log x)$ converges — remain open, with the $500 prize still partially unclaimed.\n\nThe problem connects to several areas of modern number theory: the structure of multiplicative functions (Halász's theorem), sieve methods for controlling divisor sums, and the Hardy-Ramanujan theory of the number of prime factors.",
@@ -101,7 +101,7 @@
       "startLine": 61,
       "endLine": 85,
       "summary": "The KLL theorem and its application",
-      "mathContext": "KLL theorem (Klurman-Lunnon-Lewko): if $A$ is well-separated, then $A(x) = o(x/\\sqrt{\\log x})$ — a density bound slightly better than trivial."
+      "mathContext": "KLL theorem (Koukoulopoulos-Lamzouri-Lichtman): if $A$ is well-separated, then $\\sum_{x < n,\\, x \\in A} 1/x = o(\\log n)$ — the partial reciprocal sum grows strictly slower than the harmonic benchmark $\\log n$."
     },
     {
       "id": "primitive-sets",
@@ -221,10 +221,10 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 119,
+    "lineCount": 122,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "path": "Proofs/Erdos143Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

`Conjecture_iii` — the one conjecture erdos-143 claims to have resolved — was a malformed formalization: it universally quantified a bare `partialSum : ℝ` with no hypothesis relating it to `∑_{x∈A, x<n} 1/x`. As written it asserts *every* real `p ≤ ε·log n` (instantiate `p := ε·log n + 1` → false), so `kll_theorem` axiomatized a false proposition (latent inconsistency).

## Changes

- **Lean** (`proofs/Proofs/Erdos143Problem.lean`):
  - Add `noncomputable def reciprocalPartialSum (A) (n) := ∑ᶠ x ∈ (A ∩ Set.Ioo 1 n), 1 / x` (finsum → well-defined for any `A : Set ℝ`).
  - `Conjecture_iii` now reads `∀ ε > 0, ∃ N₀, ∀ n ≥ N₀, reciprocalPartialSum A n ≤ ε * Real.log n` — the genuine `o(log n)` statement. `kll_theorem` now axiomatizes the real KLL 2025 result.
- **meta.json**:
  - Fix "Main Results" `mathContext`: **KLL = Koukoulopoulos-Lamzouri-Lichtman** (was wrongly "Klurman-Lunnon-Lewko"); result is `∑_{x<n} 1/x = o(log n)` (was wrongly `A(x) = o(x/√log x)`).
  - Sync `definitionCount` 7→8, `lineCount` 119→122.

## Evidence

**Before**: `Conjecture_iii A` false for every `A`; `kll_theorem`/`erdos_143_partial` derive a false statement.
**After**: `Conjecture_iii A` faithfully encodes `∑_{1<x<n, x∈A} 1/x = o(log n)`.

Docker build: `✔ Built Proofs.Erdos143Problem (3.2s)`. Axiom count/disclosure unchanged (3 axioms, `status: axiomatized`, `badge: axiom`).

Closes #36060

---
Automated fix by lean-mechanic agent.