### PR TITLE
research(roth-theorem-oq-01): Erdős k=3 conjecture in explicit-AP form [VERIFIED 0/1-inherited]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ01Reciprocal.lean
+++ b/proofs/Proofs/RothTheoremOQ01Reciprocal.lean
@@ -202,6 +202,42 @@ theorem threeAPFree_summable_reciprocal
     simp only [Finset.mem_filter]; rintro ⟨_, h0⟩; exact hA0 h0
   exact finite_recip_sum_le _ hTAP hT0
 
+/-- **Erdős `k = 3` conjecture, contrapositive form.**  Any set `A ⊆ ℕ` (with `0 ∉ A`)
+whose reciprocal sum *diverges* is not 3-AP-free.  This is the direct contrapositive of
+`threeAPFree_summable_reciprocal`, and the form in which the Erdős conjecture is usually
+quoted ("a divergent reciprocal sum forces an arithmetic progression"). -/
+theorem not_threeAPFree_of_not_summable_reciprocal
+    {A : Set ℕ} (hA0 : 0 ∉ A) (hdiv : ¬ Summable (fun a : A => (1 : ℝ) / a)) :
+    ¬ ThreeAPFree A :=
+  fun hAP => hdiv (threeAPFree_summable_reciprocal hAP hA0)
+
+/-- **Erdős `k = 3` conjecture, explicit-progression form.**  Any set `A ⊆ ℕ` (with
+`0 ∉ A`) whose reciprocal sum diverges contains a *nontrivial* three-term arithmetic
+progression `a, a + d, a + 2d` with common difference `d > 0`.  This unpacks the abstract
+`¬ ThreeAPFree A` into concrete AP witnesses — the statement of the conjecture as it is
+usually phrased.  Rests on the single imported Bloom–Sisask assumption; no new axiom. -/
+theorem exists_nontrivial_threeAP_of_not_summable_reciprocal
+    {A : Set ℕ} (hA0 : 0 ∉ A) (hdiv : ¬ Summable (fun a : A => (1 : ℝ) / a)) :
+    ∃ a d : ℕ, 0 < d ∧ a ∈ A ∧ a + d ∈ A ∧ a + 2 * d ∈ A := by
+  have hnot : ¬ ThreeAPFree A := not_threeAPFree_of_not_summable_reciprocal hA0 hdiv
+  unfold ThreeAPFree at hnot
+  push_neg at hnot
+  obtain ⟨a, ha, b, hb, c, hc, hsum, hne⟩ := hnot
+  -- `hsum : a + c = b + b`, `hne : a ≠ c`; the middle term `b` is the average.
+  rcases lt_or_gt_of_ne hne with hlt | hgt
+  · -- `a < c`: progression starts at `a` with difference `b - a`.
+    refine ⟨a, b - a, by omega, ha, ?_, ?_⟩
+    · have h : a + (b - a) = b := by omega
+      rw [h]; exact hb
+    · have h : a + 2 * (b - a) = c := by omega
+      rw [h]; exact hc
+  · -- `c < a`: progression starts at `c` with difference `b - c`.
+    refine ⟨c, b - c, by omega, hc, ?_, ?_⟩
+    · have h : c + (b - c) = b := by omega
+      rw [h]; exact hb
+    · have h : c + 2 * (b - c) = a := by omega
+      rw [h]; exact ha
+
 #check @threeAPFree_summable_reciprocal
 #check @finite_recip_sum_le
 #check @fiber_sum_le
@@ -211,5 +247,6 @@ theorem threeAPFree_summable_reciprocal
 -- assumption `RothTheoremOQ02.rothNumberNat_bloom_sisask` — no new axiom, no `sorryAx`.
 #print axioms threeAPFree_summable_reciprocal
 #print axioms summable_recipMajorant
+#print axioms exists_nontrivial_threeAP_of_not_summable_reciprocal
 
 end RothTheoremOQ01Reciprocal


### PR DESCRIPTION
## Summary

The Bloom–Sisask reciprocal-sum consequence `threeAPFree_summable_reciprocal` (in `RothTheoremOQ01Reciprocal.lean`) proves *summability* of the reciprocal sum of a 3-AP-free set, but the file never stated the Erdős k=3 conjecture in the form it is universally quoted — *a set with divergent reciprocal sum contains a nontrivial 3-term AP*. The docstring mentioned this contrapositive but did not formalize it. This PR adds it, with explicit progression witnesses.

### New theorems (2)
- `not_threeAPFree_of_not_summable_reciprocal` — direct contrapositive: `0 ∉ A → ¬ Summable (fun a : A => 1/a) → ¬ ThreeAPFree A`.
- `exists_nontrivial_threeAP_of_not_summable_reciprocal` — explicit-AP form: `0 ∉ A → ¬ Summable (1/·) → ∃ a d, 0 < d ∧ a ∈ A ∧ a + d ∈ A ∧ a + 2d ∈ A`. Unpacks the abstract `¬ ThreeAPFree A` (`unfold`/`push_neg` → `a + c = b + b ∧ a ≠ c`) into a concrete progression: the middle term `b` is the average, common difference `b − a`; the arithmetic identities are discharged by `omega`.

### Verification
- Docker build green: `Built Proofs.RothTheoremOQ01Reciprocal (4.8s)` (2511 jobs), first try.
- `#print axioms` on the new theorem: `[propext, Classical.choice, Quot.sound, RothTheoremOQ02.rothNumberNat_bloom_sisask]` — **no new axiom**, no `sorryAx`/`ofReduceBool`. Status remains `axiomatized` on the single inherited Bloom–Sisask assumption.

### Scope
This is an interface/restatement addition — it converts the technical `¬ ThreeAPFree` predicate into the concrete AP-witness form actually quoted for the conjecture; it proves no mathematical content beyond the existing summability theorem. The genuine open work (the Bloom–Sisask bound from scratch, >1000 LOC of Bohr-set/Fourier infrastructure absent from Mathlib) remains blocked and out of session scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)