### PR TITLE
Enrich odd-cubes Nicomachus (nicomachus-sum-of-cubes-oq-03): full-file section coverage

### DIFF
--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-03/meta.json
@@ -43,25 +43,33 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Overview, imports, and the subtraction-free strategy",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Imports (Mathlib.Algebra.BigOperators.Intervals and Mathlib.Tactic) and the module docstring, which states the odd-cube analogue of Nicomachus's theorem (∑_{k<n} (2k+1)³ = n²(2n²−1)), checks the first three cases (n=1,2,3 → 1, 28, 153), and lays out the proof plan: because the closed form's −1 breaks `ring` over ℕ, prove the subtraction-free equivalent ∑(2k+1)³ + n² = 2n⁴ instead and recover the headline over ℤ. Opens the NicomachusOddCubes namespace and Finset.",
+      "mathContext": "$\\sum_{k<n}(2k+1)^3 = n^2(2n^2-1)$; strategy: prove $\\sum(2k+1)^3 + n^2 = 2n^4$ in $\\mathbb{N}$ (no truncated subtraction), then cast to $\\mathbb{Z}$."
+    },
+    {
       "id": "subtraction-free",
       "title": "Subtraction-free odd-cube identity",
-      "startLine": 56,
-      "endLine": 67,
+      "startLine": 48,
+      "endLine": 68,
       "summary": "The core lemma ∑_{k<n} (2k+1)³ + n² = 2n⁴, proved by induction. The base case is `rfl`. The step peels the top odd cube with sum_range_succ, then a single subtraction-free `ring` identity 2m⁴ + (2m+1)³ + (m+1)² = 2(m+1)⁴ + m² is combined with the inductive hypothesis by `omega` (which atomizes the power terms). No truncated ℕ subtraction ever appears."
     },
     {
       "id": "headline",
       "title": "Headline form over ℤ",
-      "startLine": 73,
-      "endLine": 82,
+      "startLine": 69,
+      "endLine": 83,
       "summary": "∑_{k<n} (2k+1)³ = n²(2n²−1). Casting the ℕ identity to ℤ with push_cast lets the closed form use honest subtraction; `linarith` isolates the sum as 2n⁴ − n² and a final `ring` recognizes n²(2n²−1) = 2n⁴ − n²."
     },
     {
       "id": "scaled-form",
       "title": "Scaled multiplicative form",
-      "startLine": 88,
-      "endLine": 91,
-      "summary": "4·∑(2k+1)³ + 4n² = 8n⁴, the subtraction-free core scaled by 4, derived in one `omega` step from the core lemma for callers who want a division-free product form."
+      "startLine": 84,
+      "endLine": 93,
+      "summary": "4·∑(2k+1)³ + 4n² = 8n⁴, the subtraction-free core scaled by 4, derived in one `omega` step from the core lemma for callers who want a division-free product form; closes the NicomachusOddCubes namespace."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `nicomachus-sum-of-cubes-oq-03` ("Sum of the First n Odd Cubes: ∑ (2k−1)³ = n²(2n²−1)").

The entry was already rich (3 mainTheorems with line ranges, 4 keyInsights, full conclusion, 4 cross-references, 3 references). The one genuine structural gap: **`sections` covered only lines 56-91**, so the first 55 lines — imports, the module docstring that lays out the whole subtraction-free proof strategy, and the namespace — plus the inter-theorem docstrings were invisible to the section view.

- Added a **preamble** section (lines 1-47) covering the imports and the strategy docstring (the ∑(2k+1)³ + n² = 2n⁴ repackaging that clears the ℕ subtraction).
- Extended the three existing sections to be **contiguous**, attaching each theorem's docstring to its section, so `sections` now span the full 93-line file (min startLine 1, max endLine 93 = lineCount).

No existing content removed; verified entry, 0 axioms, 0 sorries — status unchanged. JSON valid, meta.json 13.5 KB (well under the 60 KB cap).