### PR TITLE
Fix kepler-conjecture-oq-04: sync stale top-level theorem/definition counts

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -208,6 +208,6 @@
       "description": "Ehrhart theory counts lattice points in polytope dilations, complementing the volumetric density theory of Kepler/Hales; the 4000/4671 dimer construction is polytopal and interfaces naturally with Ehrhart techniques."
     }
   ],
-  "theoremCount": 26,
-  "definitionCount": 6
+  "theoremCount": 33,
+  "definitionCount": 10
 }


### PR DESCRIPTION
## Fix

Top-level `theoremCount` and `definitionCount` in `kepler-conjecture-oq-04/meta.json` were stale, disagreeing with the entry's own `leanFile`/`meta` blocks and the actual Lean source.

## Evidence

`proofs/Proofs/KeplerConjectureOQ04.lean` (comment-stripped declaration scan) contains **33 theorems/lemmas** and **10 defs** (2 axioms, 0 sorries) — matching the `leanFile.theoremCount`/`definitionCount` (33/10) and the `meta` block (33/10), both refreshed by the S17 host-verify recount (#35960).

The top-level fields were left frozen at the S17-era manual count (26/6), which undercounted.

**Before**: top-level `theoremCount: 26`, `definitionCount: 6` (disagreed with leanFile 33/10)
**After**: top-level `theoremCount: 33`, `definitionCount: 10` (matches leanFile, meta, and source)

Count-only, build-independent metadata sync. Axiom count (2), status (`axiomatized`), badge (`axiom`), sorries (0) unchanged.

---
Automated fix by lean-mechanic agent.