### PR TITLE
research(e-transcendental-oq-02-oq-06): Liouville constant is not normal in base 2 [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -1429,26 +1429,180 @@ theorem liouvilleNumber_base_two_one_iff {n : ℕ} (hn : 2 ≤ n) :
         omega
     rw [if_pos (by rw [hkj, hj])]
 
+-- ============================================================
+-- PART VIII: BASE-2 SHARPNESS — THE LIOUVILLE CONSTANT IS NOT
+--            NORMAL IN BASE 2 (FIRST GENUINE USE OF THE
+--            FREQUENCY CRITERION)
+-- ============================================================
+
 /-!
-### Remaining step for base-2 sharpness
+The `b ≥ 3` witness (`liouvilleNumber_not_normal`) ruled out normality through a
+*missing* digit. That obstruction is provably unavailable in base `2`: an
+irrational base-`2` real omits no digit, so `not_normal_of_eventually_missing_*`
+cannot apply. Base-`2` non-normality is therefore the **first genuine
+application** of the frequency criterion `not_normal_of_digit_freq_tendsto_ne`:
+the digit `1` of `liouvilleNumber 2` *does* occur, but with asymptotic density
+`0`, not `1/2`.
 
-`liouvilleNumber_base_two_one_iff` reduces base-`2` non-normality of the
-Liouville constant to a single analytic fact: the factorial positions
-`{n : ∃ k, k ! = n}` have **natural density `0`**, i.e.
+The structural input is `liouvilleNumber_base_two_one_iff` (digit `1` sits
+exactly at the factorial positions). The remaining content — carried out here —
+is the analytic fact that the factorial positions have natural density `0`:
 
-  `Tendsto (fun N => (#{n < N | nthDigit 2 n L = 1} : ℝ) / N) atTop (𝓝 0)`.
-
-Given that, `not_normal_of_digit_freq_tendsto_ne 2 (by norm_num) L 1 0 …`
-(frequency `0 ≠ 2⁻¹`) yields `¬ IsNormalInBase 2 L`, completing
-`exists_irrational_not_normal` down to base `2` and giving the frequency
-criterion its first genuine application (the absence criterion is provably
-powerless here, since an irrational base-2 number omits no digit).
-
-The density fact is elementary but not free in Lean: the `1`-positions inject
-into `{k | k ! < N}`, whose cardinality is `≤ Nat.log 2 N + O(1)` (as
-`k ! ≥ 2^(k-1)`), and `Nat.log 2 N / N → 0`. Formalising `Nat.log 2 N / N → 0`
-(≈ `Real.log`-is-`o(id)` transported through `Nat.pow_log_le_self`) is the next
-session's target.
+* `two_pow_le_factorial_succ` : `2 ^ m ≤ (m+1)!` (exponential growth of `!`).
+* `liouvilleNumber_two_one_count_le` : the `1`-positions below `N` number at
+  most `Nat.log 2 N + 4` (they inject into the factorials `k! < N`, of which
+  there are `≤ Nat.log 2 N + O(1)` since `2^(k-1) ≤ k!`).
+* `tendsto_natLog_two_div_atTop_zero` : `Nat.log 2 N / N → 0` (from
+  `Real.log =o[atTop] id` transported through `Nat.pow_log_le_self`).
+* `liouvilleNumber_two_one_density_zero` : the digit-`1` density is `0`.
+* `liouvilleNumber_not_normal_base_two` : the payoff, `¬ IsNormalInBase 2 L`.
 -/
+
+open scoped Nat in
+/-- Exponential lower bound for the factorial: `2 ^ m ≤ (m + 1)!`. Elementary
+    induction: `(k+2)! = (k+2)·(k+1)! ≥ 2·2^k = 2^(k+1)`. -/
+private lemma two_pow_le_factorial_succ (m : ℕ) : 2 ^ m ≤ (m + 1)! := by
+  induction m with
+  | zero => simp
+  | succ k ih =>
+    have hstep : 2 * 2 ^ k ≤ (k + 1 + 1) * (k + 1)! := Nat.mul_le_mul (by omega) ih
+    calc 2 ^ (k + 1) = 2 * 2 ^ k := by ring
+      _ ≤ (k + 1 + 1) * (k + 1)! := hstep
+      _ = (k + 1 + 1)! := (Nat.factorial_succ (k + 1)).symm
+
+open scoped Nat in
+/-- **Count bound for digit-`1` positions of `liouvilleNumber 2`.** The number of
+    positions `n < N` at which the base-`2` digit is `1` is at most
+    `Nat.log 2 N + 4`. Proof: every such `n` is either `0`, `1`, or (by
+    `liouvilleNumber_base_two_one_iff`) a factorial `k! = n`; from
+    `2^(k-1) ≤ k! = n < N` and `Nat.le_log_iff_pow_le` the index `k` is bounded
+    by `Nat.log 2 N + 1`, so the `1`-positions inject into a set of size
+    `≤ Nat.log 2 N + 4`. -/
+private lemma liouvilleNumber_two_one_count_le (N : ℕ) :
+    ((Finset.range N).filter
+      (fun n => nthDigit 2 n (liouvilleNumber (2 : ℝ)) = 1)).card
+      ≤ Nat.log 2 N + 4 := by
+  classical
+  have hsub : (Finset.range N).filter
+      (fun n => nthDigit 2 n (liouvilleNumber (2 : ℝ)) = 1)
+      ⊆ insert 0 (insert 1
+        ((Finset.range (Nat.log 2 N + 2)).image Nat.factorial)) := by
+    intro n hn
+    rw [Finset.mem_filter, Finset.mem_range] at hn
+    obtain ⟨hnN, hdig⟩ := hn
+    rcases Nat.lt_or_ge n 2 with h2 | h2
+    · interval_cases n
+      · exact Finset.mem_insert_self _ _
+      · exact Finset.mem_insert_of_mem (Finset.mem_insert_self _ _)
+    · obtain ⟨k, hk⟩ := (liouvilleNumber_base_two_one_iff h2).mp hdig
+      have hk_pos : 1 ≤ k := by
+        rcases Nat.eq_zero_or_pos k with h0 | hp
+        · rw [h0, Nat.factorial_zero] at hk; omega
+        · exact hp
+      have hpow : 2 ^ (k - 1) ≤ n := by
+        have h := two_pow_le_factorial_succ (k - 1)
+        rw [Nat.sub_add_cancel hk_pos, hk] at h
+        exact h
+      have hn0 : n ≠ 0 := by omega
+      have hklog : k - 1 ≤ Nat.log 2 n :=
+        (Nat.le_log_iff_pow_le (by norm_num) hn0).mpr hpow
+      have hk_lt : k < Nat.log 2 N + 2 := by
+        have hmono : Nat.log 2 n ≤ Nat.log 2 N := Nat.log_mono_right hnN.le
+        omega
+      exact Finset.mem_insert_of_mem (Finset.mem_insert_of_mem
+        (Finset.mem_image.mpr ⟨k, Finset.mem_range.mpr hk_lt, hk⟩))
+  have c1 : ((Finset.range (Nat.log 2 N + 2)).image Nat.factorial).card
+      ≤ Nat.log 2 N + 2 :=
+    Finset.card_image_le.trans (by rw [Finset.card_range])
+  have c2 := Finset.card_insert_le 1
+    ((Finset.range (Nat.log 2 N + 2)).image Nat.factorial)
+  have c3 := Finset.card_insert_le 0
+    (insert 1 ((Finset.range (Nat.log 2 N + 2)).image Nat.factorial))
+  exact (Finset.card_le_card hsub).trans (by omega)
+
+/-- **`Nat.log 2 N / N → 0`.** The base-`2` integer logarithm is `o(N)`. Proof:
+    `Nat.pow_log_le_self` gives `2 ^ Nat.log 2 N ≤ N`, hence
+    `Nat.log 2 N ≤ Real.log N / Real.log 2`; squeeze against
+    `Real.log N / N → 0` (`Real.isLittleO_log_id_atTop`). -/
+private lemma tendsto_natLog_two_div_atTop_zero :
+    Tendsto (fun N : ℕ => (Nat.log 2 N : ℝ) / (N : ℝ)) atTop (nhds 0) := by
+  have hlogid : Tendsto (fun x : ℝ => Real.log x / x) atTop (nhds 0) := by
+    have h := Real.isLittleO_log_id_atTop
+    rw [Asymptotics.isLittleO_iff_tendsto
+      (fun x hx => by simp only [id_eq] at hx; simp [hx])] at h
+    simpa [id_eq] using h
+  have hnat : Tendsto (fun N : ℕ => Real.log (N : ℝ) / (N : ℝ)) atTop (nhds 0) := by
+    simpa using hlogid.comp tendsto_natCast_atTop_atTop
+  have hupper : Tendsto
+      (fun N : ℕ => Real.log (N : ℝ) / (N : ℝ) * (Real.log 2)⁻¹) atTop (nhds 0) := by
+    simpa using hnat.mul_const (Real.log 2)⁻¹
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds hupper
+    (Filter.Eventually.of_forall fun N => by positivity) ?_
+  filter_upwards [eventually_gt_atTop 0] with N hN
+  have hNpos : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN
+  have hlog2pos : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  have hkey : (Nat.log 2 N : ℝ) ≤ Real.log (N : ℝ) / Real.log 2 := by
+    have hpow : (2 : ℕ) ^ Nat.log 2 N ≤ N := Nat.pow_log_le_self 2 hN.ne'
+    have hpowR : (2 : ℝ) ^ Nat.log 2 N ≤ (N : ℝ) := by exact_mod_cast hpow
+    have hlogle : Real.log ((2 : ℝ) ^ Nat.log 2 N) ≤ Real.log (N : ℝ) :=
+      (Real.log_le_log_iff (by positivity) hNpos).mpr hpowR
+    rw [Real.log_pow] at hlogle
+    rw [le_div_iff₀ hlog2pos]
+    exact hlogle
+  calc (Nat.log 2 N : ℝ) / (N : ℝ)
+      ≤ (Real.log (N : ℝ) / Real.log 2) / (N : ℝ) := by gcongr
+    _ = Real.log (N : ℝ) / (N : ℝ) * (Real.log 2)⁻¹ := by ring
+
+/-- **The digit `1` of `liouvilleNumber 2` has density `0`.** The matching
+    frequency of digit `1` over `Finset.range N` tends to `0`, squeezed between
+    `0` and `(Nat.log 2 N + 4)/N` via `liouvilleNumber_two_one_count_le`. This is
+    the decisive frequency anomaly: normality would demand density `1/2`. -/
+theorem liouvilleNumber_two_one_density_zero :
+    Tendsto (fun N : ℕ =>
+      (((Finset.range N).filter
+        (fun n => nthDigit 2 n (liouvilleNumber (2 : ℝ)) = 1)).card : ℝ) / (N : ℝ))
+      atTop (nhds 0) := by
+  have h4 : Tendsto (fun N : ℕ => (4 : ℝ) / (N : ℝ)) atTop (nhds 0) :=
+    tendsto_const_nhds.div_atTop tendsto_natCast_atTop_atTop
+  have hg : Tendsto
+      (fun N : ℕ => (Nat.log 2 N : ℝ) / (N : ℝ) + (4 : ℝ) / (N : ℝ))
+      atTop (nhds 0) := by
+    simpa using tendsto_natLog_two_div_atTop_zero.add h4
+  refine squeeze_zero (fun N => by positivity) (fun N => ?_) hg
+  rcases Nat.eq_zero_or_pos N with hN | hN
+  · simp [hN]
+  · have hNpos : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN
+    rw [← add_div]
+    gcongr
+    exact_mod_cast liouvilleNumber_two_one_count_le N
+
+/-- **The Liouville constant is not normal in base `2`.** The digit `1` occurs
+    with density `0 ≠ 1/2` (`liouvilleNumber_two_one_density_zero`), so the
+    single-digit frequency criterion `not_normal_of_digit_freq_tendsto_ne`
+    forbids normality. This is the first application of the frequency criterion
+    to a number whose non-normality is *invisible* to the absence criterion (no
+    digit is eventually missing in base `2`), completing
+    `exists_irrational_not_normal` down to base `2`. -/
+theorem liouvilleNumber_not_normal_base_two :
+    ¬ IsNormalInBase 2 (liouvilleNumber (2 : ℝ)) := by
+  have hval : ((1 : Fin 2) : ℤ) = 1 := by decide
+  refine not_normal_of_digit_freq_tendsto_ne 2 (by norm_num)
+    (liouvilleNumber (2 : ℝ)) (1 : Fin 2) 0 ?_ (by norm_num)
+  simp only [hval]
+  exact liouvilleNumber_two_one_density_zero
+
+/-- **Sharpness of `normal_imp_irrational`, extended to base `2`.** For *every*
+    base `b ≥ 2` there is an irrational real that is not normal in base `b`:
+    the Liouville constant `liouvilleNumber b` (base `b ≥ 3`, via a missing
+    digit) or `liouvilleNumber 2` (base `2`, via the digit-`1` density anomaly).
+    Strengthens `exists_irrational_not_normal`, which required `b ≥ 3`. -/
+theorem exists_irrational_not_normal_of_two_le {b : ℕ} (hb : 2 ≤ b) :
+    ∃ x : ℝ, Irrational x ∧ ¬ IsNormalInBase b x := by
+  rcases Nat.lt_or_ge b 3 with h3 | h3
+  · have hb2 : b = 2 := by omega
+    subst hb2
+    exact ⟨liouvilleNumber (2 : ℝ), liouvilleNumber_irrational (by norm_num),
+      liouvilleNumber_not_normal_base_two⟩
+  · exact exists_irrational_not_normal h3
 
 end ETranscendentalOQ02

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 74,
+    "theoremCount": 80,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -70,11 +70,15 @@
       "Lemma match_count_le (this session, private): the x-general form of rational_match_count_le — if a k-tuple s is eventually missing past N₀, matching positions in Finset.range N number at most N₀ (Finset.card_le_card into Finset.range N₀).",
       "Theorem not_normal_of_eventually_missing_ktuple (this session): the sharp-boundary converse of normal_imp_disjunctive — if some k-tuple is eventually absent from x's base-b expansion, x is NOT normal in base b (frequency → 0 via match_count_le + tendsto_bounded_count_div_atTop_zero contradicts normality's frequency → b^(-k) > 0). Establishes normality is strictly stronger than disjunctivity.",
       "Theorem not_normal_of_eventually_missing_digit (this session): the k=1 corollary — a single eventually-absent digit forbids normality (the cleanest obstruction: a frequency-0 digit).",
-      "Theorem normal_imp_irrational_of_criterion (this session): re-derives normal ⇒ irrational from the non-normality criterion via rational_has_missing_ktuple_intCast, confirming the criterion is non-vacuous and subsumes the rational case."
+      "Theorem normal_imp_irrational_of_criterion (this session): re-derives normal ⇒ irrational from the non-normality criterion via rational_has_missing_ktuple_intCast, confirming the criterion is non-vacuous and subsumes the rational case.",
+      "Theorem liouvilleNumber_not_normal_base_two (this session): the Liouville constant is NOT normal in base 2 — the first application of the frequency criterion to a number whose non-normality is invisible to the missing-digit criterion (an irrational base-2 real omits no digit).",
+      "Theorem liouvilleNumber_two_one_density_zero (this session): the base-2 digit 1 of the Liouville constant has asymptotic density 0, not 1/2 — the decisive frequency anomaly, since digit 1 occurs exactly at the density-0 factorial positions.",
+      "Theorem exists_irrational_not_normal_of_two_le (this session): extends the sharpness of normal ⇒ irrational to all bases b ≥ 2 (base 2 via the digit-1 density anomaly, b ≥ 3 via a missing digit), strengthening exists_irrational_not_normal from b ≥ 3.",
+      "Lemmas two_pow_le_factorial_succ / liouvilleNumber_two_one_count_le / tendsto_natLog_two_div_atTop_zero (this session): the analytic core — 2^(k-1) ≤ k! forces the 1-positions below N to number ≤ Nat.log 2 N + 4, and Nat.log 2 N / N → 0 (via Real.log =o[atTop] id)."
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 1454,
+    "lineCount": 1608,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
     "definitionCount": 6
@@ -207,9 +211,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 1454,
+    "lineCount": 1608,
     "axiomCount": 1,
-    "theoremCount": 74,
+    "theoremCount": 80,
     "definitionCount": 6,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Closes the **base-2 sharpness** gap for `normal ⇒ irrational` in `ETranscendentalOQ02.lean`, giving the entry's *frequency criterion* its **first genuine application**.

In base `b ≥ 3` the Liouville constant `L = ∑ b^{-k!}` is non-normal because the digit `2` is eventually *missing* (`liouvilleNumber_not_normal`). That missing-digit obstruction is **provably powerless in base 2**: an irrational base-2 real omits no digit. Base-2 non-normality therefore genuinely requires the *frequency* route — and this PR completes it.

**Key fact:** the base-2 digit `1` of `L` occurs *exactly* at the factorial positions `{k!}` (`liouvilleNumber_base_two_one_iff`, already in the file), and the factorial positions have **natural density 0**. So digit `1` has density `0 ≠ 1/2`, and `not_normal_of_digit_freq_tendsto_ne` forbids normality.

## New declarations (all VERIFIED 0 sorry / 0 new axiom)

| Declaration | Statement |
|---|---|
| `two_pow_le_factorial_succ` | `2^m ≤ (m+1)!` (exponential growth of `!`) |
| `liouvilleNumber_two_one_count_le` | `#{1-positions < N} ≤ Nat.log 2 N + 4` (inject into factorials `k! < N`, `≤ log₂N + O(1)` since `2^(k-1) ≤ k!`) |
| `tendsto_natLog_two_div_atTop_zero` | `Nat.log 2 N / N → 0` (from `Real.log =o[atTop] id`, transported via `Nat.pow_log_le_self`) |
| `liouvilleNumber_two_one_density_zero` | the digit-`1` density is `0` |
| `liouvilleNumber_not_normal_base_two` | `¬ IsNormalInBase 2 (liouvilleNumber 2)` |
| `exists_irrational_not_normal_of_two_le` | sharpness of `normal ⇒ irrational` for **all** `b ≥ 2` |

## Verification

`./proofs/scripts/docker-build.sh Proofs.ETranscendentalOQ02` — **Build completed successfully (3085 jobs)**, no errors.

`#print axioms` on both headline theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `ofReduceBool`, and **not** dependent on the open `e_absolutely_normal` axiom.

## Scope

The entry remains `axiomatized` (status unchanged): the open axiom `e_absolutely_normal` (absolute normality of `e`) is genuinely open and untouched. This PR strengthens the *surrounding sharpness theory*, not the open conjecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)