### PR TITLE
Enrich Sylow/Schur–Zassenhaus (sylow-theorem-oq-03): full-file section coverage

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-03/meta.json
@@ -96,10 +96,18 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Overview: from Sylow theory to group extensions",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Imports (SchurZassenhaus, Sylow, Complement, tactics) and the module docstring, which quotes the parent entry's open question — can Schur–Zassenhaus (coprime order/index ⟹ complemented) be formalized as an extension of Sylow theory? — and states the answer: Mathlib supplies the existence half (Subgroup.exists_right_complement'_of_coprime), and this file packages it in gallery form and derives the Sylow bridge — a normal Sylow p-subgroup is always complemented by a Hall p′-subgroup, so G splits as an internal semidirect product P ⋊ K. Opens Subgroup and fixes the ambient finite group G.",
+      "mathContext": "$\\gcd(|N|,[G:N])=1,\\ N\\trianglelefteq G \\Rightarrow G = N\\rtimes K$; specialised to a normal Sylow $p$-subgroup $P$, whose Hall property makes coprimality automatic."
+    },
+    {
       "id": "schur-zassenhaus",
       "title": "Section I: Schur–Zassenhaus Existence and Structure",
       "startLine": 44,
-      "endLine": 79,
+      "endLine": 80,
       "summary": "schurZassenhaus restates Mathlib's existence theorem; isComplement'_card_eq_index proves |K| = [G:N]; schurZassenhaus_structure bundles disjointness (N ⊓ K = ⊥), generation (N ⊔ K = ⊤), and the order; complement_of_coprime_orders gives the |G| = m·n factorization phrasing.",
       "mathContext": "A coprime normal subgroup splits off: G is the internal semidirect product N ⋊ K with K of order exactly [G:N]."
     },
@@ -107,7 +115,7 @@
       "id": "sylow-extension",
       "title": "Section II: The Sylow Extension — Normal Sylow Subgroups Split",
       "startLine": 81,
-      "endLine": 119,
+      "endLine": 121,
       "summary": "normalSylow_isComplemented: a normal Sylow p-subgroup is complemented (coprimality from Sylow.card_coprime_index). normalSylow_complement_card / _not_dvd / _coprime: the complement has order [G:P], is a Hall p′-subgroup (p ∤ |K|), and has order coprime to |P|.",
       "mathContext": "When a Sylow subgroup is normal, the Hall property makes Schur–Zassenhaus apply automatically, yielding a p-complement and the splitting G = P ⋊ K."
     }


### PR DESCRIPTION
Enrichment pass for `sylow-theorem-oq-03` ("The Schur–Zassenhaus splitting theorem and its Sylow corollary").

The entry was already rich (8 mainTheorems, 5 keyInsights, full conclusion, 4 references). The one genuine structural gap: **`sections` started at line 44**, so lines 1-43 — the imports and the module docstring that quotes the parent entry's open question and frames the whole Sylow-extension bridge (a normal Sylow p-subgroup is complemented by a Hall p′-subgroup, giving G = P ⋊ K) — were invisible to the section view.

- Added a **preamble** section (lines 1-43) covering imports and the framing docstring.
- Extended the two existing sections to be **contiguous**, so `sections` now span the full 121-line file (min startLine 1, max endLine 121 = lineCount).

No existing content removed; verified entry, 0 axioms, 0 sorries — status unchanged. JSON valid, meta.json 17 KB (well under the 60 KB cap).