### PR TITLE
Enrich Blichfeldt/Minkowski covolume threshold: link sharpness sibling + Dirichlet application

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-02/meta.json
@@ -152,6 +152,16 @@
       "targetId": "minkowski-theorem-oq-02",
       "relationship": "related",
       "description": "Sibling Minkowski OQ (Dirichlet approximation); a consumer of covolume-parametric Minkowski for lattices other than ℤⁿ."
+    },
+    {
+      "targetId": "minkowski-theorem-oq-04-oq-03",
+      "relationship": "related",
+      "description": "The sharpness complement: this entry proves the Blichfeldt covolume threshold is SUFFICIENT (vol S > k·covol(Λ) ⇒ k+1 congruent points), while oq-04-oq-03 shows it is TIGHT — for every k there is a set of volume exactly k·covol with no k+1 congruent points, so the strict inequality cannot be weakened to ≥."
+    },
+    {
+      "targetId": "minkowski-theorem-oq-02-oq-01",
+      "relationship": "related",
+      "description": "A flagship application of the convex-body form proved here: Dirichlet's simultaneous approximation theorem falls out of Minkowski's theorem applied to a symmetric box against ℤⁿ, an axiom-free instance of the covolume-threshold machinery."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass — minkowski-theorem-oq-04-oq-02 (Blichfeldt & Minkowski for an arbitrary lattice)

Two precise cross-references added to complete the local graph:

- **minkowski-theorem-oq-04-oq-03** — the sharpness complement: this entry proves the Blichfeldt covolume threshold is *sufficient* ($\operatorname{vol}(S) > k\cdot\operatorname{covol}(\Lambda) \Rightarrow k+1$ congruent points), while oq-04-oq-03 shows it is *tight* (volume exactly $k\cdot\operatorname{covol}$ need not force it), so the strict inequality cannot be weakened.
- **minkowski-theorem-oq-02-oq-01** — Dirichlet's simultaneous approximation theorem, a flagship application of the convex-body form proved here.

Pure cross-reference enrichment. crossReferences 3 → 5 (cap 20). meta.json 24.2 KB → 25.0 KB (under 60 KB cap). JSON validated; both targets verified on disk; gallery-data build (enrichment + search-index) passes. No change to status/badge/axiomCount.