### PR TITLE
Enrich sum-of-divisors OQ-04 (sum-of-divisors-oq-04): add mainTheorems array

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-04/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04/meta.json
@@ -117,6 +117,48 @@
       "mathContext": "$\\sigma(pq) = (p+1)(q+1)$ and $\\mathrm{Perfect}(n) \\iff \\sigma(n) = 2n$."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "sigma_one_prime",
+      "type": "core",
+      "description": "**σ(p) = p + 1 for every prime p.** The general law behind the base entry's per-prime checks: a prime's only divisors are 1 and p. Extracted from sigma_one_apply_prime_pow at exponent 1.",
+      "leanType": "{p : ℕ} (hp : p.Prime) : sigma 1 p = p + 1",
+      "startLine": 33,
+      "endLine": 37
+    },
+    {
+      "name": "sigma_zero_prime",
+      "type": "supporting",
+      "description": "**τ(p) = σ₀(p) = 2 for every prime p.** A prime has exactly two divisors (1 and itself); the number-of-divisors function σ₀ evaluates to 2.",
+      "leanType": "{p : ℕ} (hp : p.Prime) : sigma 0 p = 2",
+      "startLine": 40,
+      "endLine": 43
+    },
+    {
+      "name": "sigma_one_prime_pow_mul",
+      "type": "core",
+      "description": "**Closed geometric form on prime powers:** σ(pⁱ)·(p−1) = pⁱ⁺¹−1 over ℤ, equivalently σ(pⁱ) = (pⁱ⁺¹−1)/(p−1). sigma_one_apply_prime_pow writes σ(pⁱ) as the open sum ∑_{k<i+1} pᵏ; geom_sum_mul collapses it. The multiplication-form avoids ℕ truncated division.",
+      "leanType": "{p : ℕ} (hp : p.Prime) (i : ℕ) : (sigma 1 (p ^ i) : ℤ) * ((p : ℤ) - 1) = (p : ℤ) ^ (i + 1) - 1",
+      "startLine": 48,
+      "endLine": 52
+    },
+    {
+      "name": "sigma_one_two_primes",
+      "type": "core",
+      "description": "**Multiplicativity on two distinct primes:** σ(p·q) = (p+1)(q+1). Distinct primes are coprime (coprime_primes), so σ factors via isMultiplicative_sigma.map_mul_of_coprime, and each factor is sigma_one_prime.",
+      "leanType": "{p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) : sigma 1 (p * q) = (p + 1) * (q + 1)",
+      "startLine": 57,
+      "endLine": 60
+    },
+    {
+      "name": "perfect_iff_sigma_one",
+      "type": "core",
+      "description": "**Perfection in σ-form:** for n > 0, n is perfect iff σ(n) = 2n. Ties the divisor-sum function to the base entry's perfect numbers (σ(6)=12=2·6, σ(28)=56=2·28), via Nat.perfect_iff_sum_divisors_eq_two_mul and sigma_one_apply.",
+      "leanType": "{n : ℕ} (hn : 0 < n) : Nat.Perfect n ↔ sigma 1 n = 2 * n",
+      "startLine": 65,
+      "endLine": 67
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "sum-of-divisors",


### PR DESCRIPTION
Enrichment pass for `sum-of-divisors-oq-04` ("Structural Identities for σₖ: Primes, Prime Powers, and Multiplicativity").

The entry had **no `mainTheorems` array** despite the Lean file proving 5 named structural identities for the divisor-sum function — so the gallery's theorem-list view was empty. Added a well-formed `mainTheorems` entry for each, with `leanType` and source line ranges:

- `sigma_one_prime` — σ(p) = p + 1 for every prime
- `sigma_zero_prime` — τ(p) = 2 for every prime
- `sigma_one_prime_pow_mul` — σ(pⁱ)·(p−1) = pⁱ⁺¹−1 (closed geometric form)
- `sigma_one_two_primes` — σ(pq) = (p+1)(q+1) (multiplicativity)
- `perfect_iff_sigma_one` — Perfect n ↔ σ(n) = 2n

Types and line ranges verified against the source; sections already cover the full 69-line file. No existing content removed; verified entry, 0 axioms, 0 sorries — status unchanged. JSON valid, meta.json 12.8 KB (well under the 60 KB cap).