### PR TITLE
Enrich Odd Squares Sum: complete the odd-index Faulhaber ladder cross-links

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -138,6 +138,16 @@
       "proofId": "nicomachus-sum-of-cubes-oq-01",
       "relationship": "related — figurate power-sum closed form",
       "description": "Nicomachus's identity ∑_{k≤n} k³ = (∑_{k≤n} k)² is the sum-of-cubes member of the same family of clean closed forms for polynomial power sums. Both prove a figurate-number identity by short fully verified induction, complementing Mathlib's built-in power-sum lemmas."
+    },
+    {
+      "proofId": "nicomachus-sum-of-cubes-oq-03",
+      "relationship": "odd-index power-sum companion (degree 3)",
+      "description": "The degree-3 rung of the same odd-index Faulhaber ladder: ∑_{k<n} (2k+1)³ = n²(2n²−1). It uses the identical 'clear the subtraction into a subtraction-free ℕ identity, then ring-and-induction' recipe (there ∑+n² = 2n⁴, here 3∑+n = 4n³) and already cross-references this degree-2 entry as its companion — this makes the link bidirectional."
+    },
+    {
+      "proofId": "arithmetic-series",
+      "relationship": "odd-index power-sum companion (degree 1)",
+      "description": "The degree-1 base of the ladder: the sum of the first n odd numbers ∑_{k<n}(2k+1) = n² is a perfect square. Degrees 1, 2 (this entry), and 3 (odd cubes) together trace the elementary odd-index power-sum family from squares up."
     }
   ]
 }


### PR DESCRIPTION
## Enrichment pass — odd-squares-sum-oq-01 (∑(2k−1)² = n(2n−1)(2n+1)/3)

This is the degree-2 rung of the odd-index power-sum ladder, but two neighbours were unlinked. Added:

- **nicomachus-sum-of-cubes-oq-03** — the degree-3 odd-cube sibling (∑(2k+1)³ = n²(2n²−1)) using the identical 'clear the subtraction, ring-and-induct over ℕ' recipe. It already links *here*; this makes the relation bidirectional.
- **arithmetic-series** — the degree-1 base (∑ odd numbers = n²).

Degrees 1, 2 (this entry), 3 now trace the full elementary odd-index power-sum family. Pure cross-reference enrichment; uses the entry's existing `proofId` schema. crossReferences 3 → 5 (cap 20). meta.json 10.8 KB → 11.7 KB. JSON validated; both targets verified on disk; gallery-data build passes. No status/badge/axiomCount change.