### PR TITLE
Enrich Sylvester Reduction (Pascal): link base theorem and sufficiency counterpart

### DIFF
--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/meta.json
@@ -110,6 +110,16 @@
       "targetId": "pascals-hexagon-incomplete-01-oq-03",
       "relationship": "related",
       "description": "Sibling OQ-03 proves the definite half of the Sylvester dichotomy (positive-definite conics are never equivalent to stdConic). This entry removes the symmetry hypothesis; together they isolate the remaining work to the indefinite-symmetric Sylvester direction."
+    },
+    {
+      "targetId": "pascals-hexagon",
+      "relationship": "related",
+      "description": "The theorem this whole lineage targets: a hexagon inscribed in a conic has its three pairs of opposite sides meeting at collinear points. The Sylvester reduction refined here — normalizing an arbitrary non-degenerate conic to stdConic = diag(1,1,−1) — is the projective-normal-form step by which the general Pascal statement is reduced to the standard conic."
+    },
+    {
+      "targetId": "pascals-hexagon-incomplete-01-oq-03-oq-01",
+      "relationship": "related",
+      "description": "The sufficiency counterpart completing the projective-equivalence dichotomy: while this entry (with OQ-03) supplies the necessity side (definite conics are never equivalent to stdConic), OQ-03-OQ-01 proves indefinite diagonal conics ARE projectively equivalent to stdConic — closing the indefinite-symmetric Sylvester direction these entries isolate."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass — pascals-hexagon-incomplete-01-oq-01 (Sylvester Reduction: Removing the Symmetry Hypothesis)

Two cross-references added to place this entry in its lineage:

- **pascals-hexagon** — the base theorem this entire Sylvester-reduction chain targets (hexagon inscribed in a conic ⇒ opposite sides meet collinearly). The reduction to stdConic = diag(1,1,−1) refined here is the projective-normal-form step of that program.
- **pascals-hexagon-incomplete-01-oq-03-oq-01** — the sufficiency counterpart: indefinite diagonal conics *are* projectively equivalent to stdConic, completing the necessity (this entry + OQ-03) / sufficiency dichotomy for equivalence to stdConic.

Pure cross-reference enrichment. crossReferences 2 → 4 (cap 20). meta.json 14.4 KB → 15.4 KB. JSON validated; both targets verified on disk; gallery-data build passes. No status/badge/axiomCount change (remains 'verified', 0 axioms).