### PR TITLE
research(erdos-1012-oq-01-oq-02): connect n-recurrence to threshold_diff + Θ(n²) growth [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1012OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1012OQ01OQ02.lean
@@ -229,4 +229,79 @@ theorem edgeThreshold_le_succ_right (n k : ℕ) (h1 : k + 2 ≤ n) (h2 : n ≤ 2
   have hrec := edgeThreshold_succ_right n k h1
   omega
 
+/-! ## Connecting the `n`-recurrence to the parent's boundary difference
+
+The parent `Erdos1012OQ01.threshold_diff` records the jump across the Woodall boundary
+`n = 2k+2 → 2k+3` abstractly, as the binomial difference `C(k+2,2) − C(k+1,2)`.  The
+`n`-recurrence `edgeThreshold_succ_left` pins that single step down concretely: the
+boundary sits at `n = 2k+2`, where the discrete `n`-derivative `n − k − 1` evaluates to
+`k + 1`.  So the parent's boundary difference is *exactly* `k + 1`, and the two ways of
+computing it agree. -/
+
+/-- Pascal step for the second binomial coefficient: `C(k+2, 2) − C(k+1, 2) = k + 1`.
+    This is the parent's abstract `threshold_diff` right-hand side, evaluated. -/
+theorem choose_two_diff_succ (k : ℕ) :
+    (k + 2).choose 2 - (k + 1).choose 2 = k + 1 := by
+  have h : (k + 1 + 1).choose 2 = (k + 1).choose 2 + (k + 1) := choose_two_succ (k + 1)
+  rw [show k + 1 + 1 = k + 2 by omega] at h
+  omega
+
+/-- **The Woodall boundary step.**  Crossing the boundary `n = 2k+2 → 2k+3` raises the
+    threshold by exactly `k + 1` — the `n`-recurrence's discrete derivative `n − k − 1`
+    evaluated at `n = 2k+2`. -/
+theorem edgeThreshold_boundary_step (k : ℕ) :
+    edgeThreshold (2 * k + 3) k = edgeThreshold (2 * k + 2) k + (k + 1) := by
+  have h := edgeThreshold_succ_left (2 * k + 2) k (by omega)
+  rw [show 2 * k + 2 + 1 = 2 * k + 3 by omega] at h
+  omega
+
+/-- **The parent's boundary difference, evaluated concretely.**  The Woodall-boundary
+    jump `edgeThreshold (2k+3) k − edgeThreshold (2k+2) k` — which the parent
+    `threshold_diff` expresses as `C(k+2,2) − C(k+1,2)` — is exactly `k + 1`.  This closes
+    the loop between the abstract binomial difference and the `n`-recurrence: both routes
+    give `k + 1` (cf. `choose_two_diff_succ`). -/
+theorem threshold_diff_eq (k : ℕ) :
+    edgeThreshold (2 * k + 3) k - edgeThreshold (2 * k + 2) k = k + 1 := by
+  rw [edgeThreshold_boundary_step]; omega
+
+/-! ## Quadratic (Θ(n²)) growth of the threshold
+
+For fixed `k` the threshold grows quadratically in `n`.  Doubling it isolates the leading
+term `(n-k-1)(n-k-2)`, and it is sandwiched between that quadratic below and
+`n(n-1) = 2·C(n,2)` above — both degree-2 in `n` with leading coefficient 1.  So the
+threshold grows like `½n²`, the same rate as the complete graph. -/
+
+/-- Subtraction-free doubled form of the threshold for `n ≥ k+2`:
+    `2·edgeThreshold n k = (n-k-1)(n-k-2) + (k+2)(k+1) + 2`. -/
+theorem two_mul_edgeThreshold (n k : ℕ) (h : k + 2 ≤ n) :
+    2 * edgeThreshold n k = (n - k - 1) * (n - k - 2) + (k + 2) * (k + 1) + 2 := by
+  unfold edgeThreshold
+  have h1 : 2 * (n - k - 1).choose 2 = (n - k - 1) * (n - k - 2) := by
+    rw [two_mul_choose_two, show n - k - 1 - 1 = n - k - 2 by omega]
+  have h2 : 2 * (k + 2).choose 2 = (k + 2) * (k + 1) := by
+    rw [two_mul_choose_two, show k + 2 - 1 = k + 1 by omega]
+  omega
+
+/-- **Quadratic lower bound.**  For `n ≥ k+2`, the leading term already forces
+    `(n-k-1)(n-k-2) ≤ 2·edgeThreshold n k`. -/
+theorem edgeThreshold_quadratic_lower (n k : ℕ) (h : k + 2 ≤ n) :
+    (n - k - 1) * (n - k - 2) ≤ 2 * edgeThreshold n k := by
+  rw [two_mul_edgeThreshold n k h]; omega
+
+/-- **Θ(n²) growth sandwich.**  For fixed `k` and `n ≥ 2k+3`, the doubled threshold is
+    trapped between two quadratics in `n`:
+
+        (n-k-1)(n-k-2) ≤ 2·edgeThreshold n k ≤ n(n-1) = 2·C(n,2).
+
+    Both bounds are degree-2 in `n` with leading coefficient 1, so `edgeThreshold n k`
+    grows like `½n²` — the same asymptotic rate as the complete-graph edge count `C(n,2)`,
+    confirming the threshold is a genuinely quadratic (not vacuous, not linear) barrier. -/
+theorem edgeThreshold_quadratic_sandwich (n k : ℕ) (h : 2 * k + 3 ≤ n) :
+    (n - k - 1) * (n - k - 2) ≤ 2 * edgeThreshold n k ∧
+      2 * edgeThreshold n k ≤ n * (n - 1) := by
+  refine ⟨edgeThreshold_quadratic_lower n k (by omega), ?_⟩
+  have hle := edgeThreshold_le_choose_two n k h
+  have hd : 2 * n.choose 2 = n * (n - 1) := two_mul_choose_two n
+  omega
+
 end Erdos1012OQ01OQ02

--- a/research/problems/erdos-1012-oq-01-oq-02/knowledge.md
+++ b/research/problems/erdos-1012-oq-01-oq-02/knowledge.md
@@ -29,6 +29,27 @@ sign of 2k+4-n from the range hypothesis).
 
 VERIFIED 0 axioms (propext/Quot.sound only) / 0 sorries, no native_decide. First-try build.
 
-## Remaining next step
-- Connect the recurrences to the parent's `threshold_diff` (the boundary difference
-  C(k+2,2)-C(k+1,2) is the single step at n=2k+2); joint Θ(n²) growth rate.
+## threshold_diff connection + Θ(n²) growth (researcher-2, 2026-07-08, PR #36084)
+Closed the documented remaining next step. 6 new theorems, VERIFIED 0 axioms / 0 sorries,
+no native_decide (Docker green, 7744 jobs).
+
+Boundary-difference bridge (parent `threshold_diff` = `C(k+2,2)-C(k+1,2)`, evaluated):
+- `choose_two_diff_succ (k) : C(k+2,2) - C(k+1,2) = k+1` — the parent's abstract RHS,
+  computed. Gotcha: `choose_two_succ (k+1)` yields `(k+1+1).choose 2`, which omega
+  atomizes separately from `(k+2).choose 2`; `rw [show k+1+1 = k+2 by omega] at h` first.
+- `edgeThreshold_boundary_step (k) : edgeThreshold (2k+3) k = edgeThreshold (2k+2) k + (k+1)`
+  — the n-recurrence's derivative `n-k-1` evaluated at n=2k+2 (via `edgeThreshold_succ_left`).
+- `threshold_diff_eq (k) : edgeThreshold (2k+3) k - edgeThreshold (2k+2) k = k+1` — closes
+  the loop: the abstract binomial difference and the recurrence both give k+1.
+
+Θ(n²) growth (quadratic sandwich):
+- `two_mul_edgeThreshold (h : k+2 ≤ n) : 2·edgeThreshold n k = (n-k-1)(n-k-2)+(k+2)(k+1)+2`
+  — subtraction-free doubled closed form (reuses `two_mul_choose_two`).
+- `edgeThreshold_quadratic_lower (h : k+2 ≤ n) : (n-k-1)(n-k-2) ≤ 2·edgeThreshold n k`.
+- `edgeThreshold_quadratic_sandwich (h : 2k+3 ≤ n) : (n-k-1)(n-k-2) ≤ 2·edgeThreshold n k
+  ≤ n(n-1)` — two-sided quadratic bound (upper reuses `edgeThreshold_le_choose_two`),
+  so the threshold grows like ½n², the same rate as C(n,2).
+
+The next step is now COMPLETE; no obvious further elementary arithmetic remains for this
+child (the n- and k-recurrences, non-degeneracy, boundary connection, and growth rate are
+all recorded). Deeper work belongs to the parent (Woodall's f(k) axioms).

--- a/src/data/research/problems/erdos-1012-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1012-oq-01-oq-02.json
@@ -21,10 +21,10 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-06-22T00:00:00-07:00",
-    "iteration": 1,
-    "focus": "Formalized closed form, n-recurrence, and monotonicity of edgeThreshold.",
+    "iteration": 2,
+    "focus": "Connected n-recurrence to parent threshold_diff; established Theta(n^2) growth sandwich.",
     "blockers": [],
-    "nextAction": "None — complete.",
+    "nextAction": "None -- complete.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -43,7 +43,9 @@
       "edgeThreshold_le_choose_two: NON-DEGENERACY — for n≥2k+3, edgeThreshold n k ≤ C(n,2). The required edge count never exceeds the complete graph's, so the long-cycle hypothesis edgeCount G ≥ edgeThreshold n k is satisfiable rather than vacuous. Doubled gap 2(C(n,2)−edgeThreshold) = 2k(k+2)+2c(k+1)≥0 (c=n−(2k+3)), closed by nlinarith.",
       "edgeThreshold_add_surplus_eq_choose_two: exact surplus identity C(n,2) = edgeThreshold n k + (k(k+2) + (n-(2k+3))(k+1)) for n ≥ 2k+3 — upgrades the ≤ bound edgeThreshold_le_choose_two to an equality with an explicit nonnegative gap.",
       "edgeThreshold_lt_choose_two: strict non-degeneracy — edgeThreshold n k < C(n,2) for n ≥ 2k+3 except at the single degenerate point (k,n)=(0,3) where edgeThreshold 3 0 = C(3,2) = 3.",
-      "edgeThreshold_succ_right + edgeThreshold_succ_right_le + edgeThreshold_le_succ_right (researcher-1): recurrence and convexity in k. Subtraction-free identity edgeThreshold n (k+1) + n = edgeThreshold n k + (2k+4) (signed k-derivative 2k+4-n), giving the U-shape: threshold non-increasing in k while n≥2k+4, non-decreasing once n≤2k+4, minimized near k=(n-4)/2."
+      "edgeThreshold_succ_right + edgeThreshold_succ_right_le + edgeThreshold_le_succ_right (researcher-1): recurrence and convexity in k. Subtraction-free identity edgeThreshold n (k+1) + n = edgeThreshold n k + (2k+4) (signed k-derivative 2k+4-n), giving the U-shape: threshold non-increasing in k while n≥2k+4, non-decreasing once n≤2k+4, minimized near k=(n-4)/2.",
+      "edgeThreshold_boundary_step + threshold_diff_eq + choose_two_diff_succ (researcher-2, PR #36084): connect the n-recurrence to the parent's threshold_diff. The Woodall-boundary jump edgeThreshold(2k+3)k - edgeThreshold(2k+2)k, which threshold_diff expresses abstractly as C(k+2,2)-C(k+1,2), is exactly k+1 = the discrete n-derivative n-k-1 at n=2k+2.",
+      "two_mul_edgeThreshold + edgeThreshold_quadratic_lower + edgeThreshold_quadratic_sandwich (researcher-2, PR #36084): Theta(n^2) growth. Doubled closed form 2*edgeThreshold n k = (n-k-1)(n-k-2)+(k+2)(k+1)+2, and the two-sided quadratic sandwich (n-k-1)(n-k-2) <= 2*edgeThreshold n k <= n(n-1)=2*C(n,2) for n>=2k+3, so the threshold grows like n^2/2 -- the same asymptotic rate as the complete-graph edge count. VERIFIED 0 axioms / 0 sorries, no native_decide."
     ],
     "insights": [
       "The threshold's discrete derivative in n is exactly n-k-1: C((n-k-1)+1,2) - C(n-k-1,2) = n-k-1. This is the structural reason the edge requirement tightens with each added vertex and f(k) is a well-defined minimum.",
@@ -52,11 +54,12 @@
       "Weak monotonicity proved by `induction hnm with | refl | @step m h ih` on the ≤ proof (Nat.le.rec); the step case applies the n-recurrence and omega (treating edgeThreshold terms as atoms, n-k-1 ≥ 0).",
       "Non-degeneracy needs no division: double both sides via 2·C(m,2)=m·(m-1), substitute n=2k+3+c to eliminate all truncated subtraction, and the gap becomes the manifestly nonnegative polynomial 2k(k+2)+2c(k+1). nlinarith closes it; omega then divides the doubled inequality back by 2.",
       "The threshold-vs-complete-graph surplus is exactly k(k+2)+(n-(2k+3))(k+1); it vanishes only at (k,n)=(0,3), so away from that corner the long-cycle edge hypothesis has strict room above the threshold (not forced to K_n). Proven by halving the parent's doubled polynomial identity and cancelling 2 via Nat.eq_of_mul_eq_mul_left.",
-      "k-direction complements the n-direction: both binomials C(n-k-1,2) and C(k+2,2) move oppositely as k grows, so the discrete k-derivative 2k+4-n is signed (unlike the always-positive n-derivative n-k-1). Stating it additively (LHS+n = RHS+(2k+4)) keeps it subtraction-free in ℕ; the two monotonicity branches then follow by omega from the recurrence + the sign of 2k+4-n."
+      "k-direction complements the n-direction: both binomials C(n-k-1,2) and C(k+2,2) move oppositely as k grows, so the discrete k-derivative 2k+4-n is signed (unlike the always-positive n-derivative n-k-1). Stating it additively (LHS+n = RHS+(2k+4)) keeps it subtraction-free in ℕ; the two monotonicity branches then follow by omega from the recurrence + the sign of 2k+4-n.",
+      "choose_two_succ(k+1) produces (k+1+1).choose 2, which omega treats as a distinct atom from (k+2).choose 2; normalize with `rw [show k+1+1 = k+2 by omega] at h` before omega. Same k-successor atom gotcha as the parent's choose_two_succ note."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Connect the n-recurrence to the parent's threshold_diff (the boundary difference C(k+2,2)-C(k+1,2) is the single step at n=2k+2)."
+      "COMPLETE: n-recurrence, k-recurrence (convexity), non-degeneracy vs C(n,2), boundary connection to threshold_diff, and Theta(n^2) growth are all recorded. No obvious further elementary arithmetic remains for this child; deeper work belongs to the parent Erdos1012OQ01 (Woodall f(k) axioms)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Advances the documented next step for `erdos-1012-oq-01-oq-02` (Woodall edge threshold `edgeThreshold n k = C(n-k-1,2)+C(k+2,2)+1`): **connect the `n`-recurrence to the parent's `threshold_diff`** and **establish the joint Θ(n²) growth rate**. Adds 6 theorems to `proofs/Proofs/Erdos1012OQ01OQ02.lean`, reusing the parent's `edgeThreshold` definition.

### Connecting to the parent's boundary difference
The parent `Erdos1012OQ01.threshold_diff` records the Woodall-boundary jump abstractly as `C(k+2,2) − C(k+1,2)`. This PR pins it down concretely via the `n`-recurrence:
- `choose_two_diff_succ`: `C(k+2,2) − C(k+1,2) = k+1` (the parent's RHS, evaluated).
- `edgeThreshold_boundary_step`: crossing `n = 2k+2 → 2k+3` raises the threshold by exactly `k+1` — the discrete `n`-derivative `n−k−1` at `n = 2k+2`.
- `threshold_diff_eq`: the parent's boundary difference `edgeThreshold(2k+3) k − edgeThreshold(2k+2) k = k+1`, closing the loop between the abstract binomial difference and the recurrence.

### Θ(n²) growth
- `two_mul_edgeThreshold`: subtraction-free doubled closed form `2·edgeThreshold n k = (n-k-1)(n-k-2) + (k+2)(k+1) + 2` for `n ≥ k+2`.
- `edgeThreshold_quadratic_lower`: `(n-k-1)(n-k-2) ≤ 2·edgeThreshold n k`.
- `edgeThreshold_quadratic_sandwich`: for `n ≥ 2k+3`, `(n-k-1)(n-k-2) ≤ 2·edgeThreshold n k ≤ n(n-1) = 2·C(n,2)` — a two-sided quadratic sandwich, so the threshold grows like `½n²`, the same asymptotic rate as the complete-graph edge count.

## Verification
Docker build green (7744 jobs). **0 axioms, 0 sorries, no `native_decide`.** Only adds to one existing file (75 insertions, 0 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)