### PR TITLE
research(erdos-1064-oq-03): excluded regime never reverses — structural dichotomy proven [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -1981,4 +1981,203 @@ theorem prime_three_mod_four_family_not_reversal
   rw [classifySeed_lt_iff hodd hp3' k]
   exact classifySeed_prime_three_mod_four_ne_lt hp hp3
 
+-- ---------------------------------------------------------------------------
+-- THE FULL EXCLUDED PRIME-POWER FAMILY:  a = p^k,  p ≡ 3 (mod 4)
+-- ---------------------------------------------------------------------------
+-- The engine `classifySeed_ne_lt_of_excess_bound` reduced non-reversal of an
+-- excluded seed to the single bound  a − φ(a) ≤ φ(seedB a)·2^(seedS a − 2).
+-- Two special cases were already discharged with it: the tower `3^k` (one fixed
+-- prime, all exponents) and the primes `p ≡ 3 mod 4` (all such primes, exponent
+-- one).  Here we cover their common generalisation — EVERY prime power `p^k`
+-- with `p ≡ 3 (mod 4)` — closing the excluded prime-power case in full.
+--
+-- Arithmetic.  For `a = p^k` (`k = m+1`):  φ(a) = p^m·(p−1), so
+--   a − φ(a) = p^m,      2a − φ(a) = p^m·(p+1).
+-- Writing `p + 1 = w·2^S` with `w` odd and `S = v₂(p+1) ≥ 2` (as `p ≡ 3 mod 4`),
+-- the first cototient step factorises as `2a − φ(a) = (p^m·w)·2^S`, so
+--   seedS a = S,   seedB a = p^m·w   (with `p^m` and `w` coprime, `w ∣ p+1`).
+-- Hence the required bound is  p^m ≤ φ(p^m)·φ(w)·2^(S−2).  It follows from the
+-- two elementary facts  p^m ≤ 2·φ(p^m)  (true for any prime `p`) and
+-- `2 ≤ φ(w)·2^(S−2)` (true precisely because `p > 3`: the excluded value
+-- `S = 2 ∧ w = 1` forces `p + 1 = 4`, i.e. `p = 3`, which is handled separately
+-- by the `3^k` tower).  So the engine applies to every `p^k`, `p ≡ 3 mod 4`.
+-- ---------------------------------------------------------------------------
+
+/-- **For any prime `p`, `p^m ≤ 2·φ(p^m)`.**  (For `m ≥ 1`, `φ(p^m) = p^{m-1}(p-1)`
+    and `2(p-1) ≥ p`; for `m = 0` both sides are trivial.)  This is the seed-shape
+    ingredient in the prime-power non-reversal bound. -/
+theorem prime_pow_le_two_totient {p : ℕ} (hp : p.Prime) (m : ℕ) :
+    p ^ m ≤ 2 * Nat.totient (p ^ m) := by
+  rcases Nat.eq_zero_or_pos m with hm0 | hm1
+  · subst hm0; simp only [pow_zero, Nat.totient_one]; omega
+  · obtain ⟨m', rfl⟩ : ∃ m', m = m' + 1 := ⟨m - 1, by omega⟩
+    rw [Nat.totient_prime_pow_succ hp m', pow_succ]
+    have hpp : p ≤ 2 * (p - 1) := by have := hp.two_le; omega
+    calc p ^ m' * p ≤ p ^ m' * (2 * (p - 1)) := mul_le_mul_left' hpp (p ^ m')
+      _ = 2 * (p ^ m' * (p - 1)) := by ring
+
+/-- **No excluded prime power `p^k` with `p ≡ 3 (mod 4)` reverses.**  For every
+    prime `p ≡ 3 (mod 4)` and every `k ≥ 1` the seed `a = p^k` classifies away
+    from `.lt`, so the whole family `p^k·2^(j+1)` never reverses the totient
+    inequality.  This unifies and strictly extends both previously proven
+    infinite non-reversing sub-families — the tower `3^k`
+    (`three_pow_never_reverses`) and the primes themselves
+    (`classifySeed_prime_three_mod_four_ne_lt`, the `k = 1` slice). -/
+theorem classifySeed_prime_pow_three_mod_four_ne_lt {p k : ℕ}
+    (hp : p.Prime) (hp3 : p % 4 = 3) (hk : 1 ≤ k) :
+    classifySeed (p ^ k) ≠ Ordering.lt := by
+  by_cases hp3' : p = 3
+  · subst hp3'; exact three_pow_never_reverses hk
+  · -- `p ≡ 3 mod 4`, `p ≠ 3`  ⟹  `p ≥ 7`
+    have hp7 : 7 ≤ p := by
+      have h2 := hp.two_le
+      by_contra h7
+      push_neg at h7
+      interval_cases p <;> first
+        | exact absurd hp (by decide)
+        | omega
+    obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by omega⟩
+    have hodd_p : Odd p := Nat.odd_iff.mpr (by omega)
+    -- first cototient step:  2a − φ(a) = p^m·(p+1),  and  a − φ(a) = p^m
+    have hφ : Nat.totient (p ^ (m + 1)) = p ^ m * (p - 1) :=
+      Nat.totient_prime_pow_succ hp m
+    have hsum : Nat.totient (p ^ (m + 1)) + p ^ m = p ^ (m + 1) := by
+      rw [hφ, pow_succ]
+      have h1 : p ^ m * (p - 1) + p ^ m = p ^ m * ((p - 1) + 1) := by ring
+      rw [h1, show (p - 1) + 1 = p from by omega]
+    have hexcess : p ^ (m + 1) - Nat.totient (p ^ (m + 1)) = p ^ m := by omega
+    have hstep_sum : p ^ m * (p + 1) + Nat.totient (p ^ (m + 1)) = 2 * p ^ (m + 1) := by
+      rw [hφ]
+      have h2 : p ^ m * (p + 1) + p ^ m * (p - 1) = p ^ m * ((p + 1) + (p - 1)) := by ring
+      rw [h2, show (p + 1) + (p - 1) = 2 * p from by omega, pow_succ]; ring
+    have hstep_eq : 2 * p ^ (m + 1) - Nat.totient (p ^ (m + 1)) = p ^ m * (p + 1) := by omega
+    -- 2-adic decomposition of `p + 1`:  `p + 1 = w·2^S`, `w` odd, `S ≥ 2`
+    obtain ⟨S, w, hwodd, hS2, hpw⟩ :
+        ∃ S w, Odd w ∧ 2 ≤ S ∧ p + 1 = w * 2 ^ S := by
+      have hp1ne : p + 1 ≠ 0 := by omega
+      refine ⟨(p + 1).factorization 2, (p + 1) / 2 ^ ((p + 1).factorization 2), ?_, ?_, ?_⟩
+      · have hnd : ¬ (2 : ℕ) ∣ (p + 1) / 2 ^ ((p + 1).factorization 2) :=
+          Nat.not_dvd_ordCompl Nat.prime_two hp1ne
+        exact Nat.odd_iff.mpr (by omega)
+      · have h4 : (2 : ℕ) ^ 2 ∣ p + 1 := by
+          rw [show (2 : ℕ) ^ 2 = 4 from by norm_num]; omega
+        exact (Nat.Prime.pow_dvd_iff_le_factorization Nat.prime_two hp1ne).mp h4
+      · rw [mul_comm]; exact (Nat.ordProj_mul_ordCompl_eq_self (p + 1) 2).symm
+    -- factorised first step  ⟹  seedS a = S,  seedB a = p^m·w
+    have hbodd : Odd (p ^ m * w) := (hodd_p.pow).mul hwodd
+    have hEq : 2 * p ^ (m + 1) - Nat.totient (p ^ (m + 1)) = (p ^ m * w) * 2 ^ S := by
+      rw [hstep_eq, hpw]; ring
+    have hSval : seedS (p ^ (m + 1)) = S := by
+      unfold seedS; exact (factor_two_split hbodd hEq).1
+    have hBval : seedB (p ^ (m + 1)) = p ^ m * w := by
+      unfold seedB seedS; exact (factor_two_split hbodd hEq).2
+    -- totient of the odd part splits (p^m and w are coprime, since w ∣ p+1)
+    have hcps : Nat.Coprime p (p + 1) :=
+      Nat.coprime_self_add_right.mpr (Nat.coprime_one_right p)
+    have hwdvd : w ∣ p + 1 := ⟨2 ^ S, hpw⟩
+    have hcop_pw : Nat.Coprime (p ^ m) w :=
+      Nat.Coprime.pow_left m (Nat.Coprime.coprime_dvd_right hwdvd hcps)
+    have hφpw : Nat.totient (p ^ m * w) = Nat.totient (p ^ m) * Nat.totient w :=
+      Nat.totient_mul hcop_pw
+    -- fact 2:  2 ≤ φ(w)·2^(S−2)   (uses `p ≥ 7`, i.e. ¬(S = 2 ∧ w = 1))
+    have hQ2 : 2 ≤ Nat.totient w * 2 ^ (S - 2) := by
+      rcases Nat.lt_or_ge S 3 with hS3 | hS3
+      · have hSeq : S = 2 := by omega
+        have hw3 : 3 ≤ w := by
+          have h4w : p + 1 = w * 4 := by rw [hpw, hSeq]; norm_num
+          rcases hwodd with ⟨i, hi⟩; omega
+        have hev : Even (Nat.totient w) := Nat.totient_even (by omega)
+        have hpos : 0 < Nat.totient w := Nat.totient_pos.mpr (by omega)
+        obtain ⟨j, hj⟩ := hev
+        rw [hSeq]; simp only [show (2 : ℕ) - 2 = 0 from rfl, pow_zero, mul_one]; omega
+      · have h2pow : (2 : ℕ) ≤ 2 ^ (S - 2) := by
+          calc (2 : ℕ) = 2 ^ 1 := (pow_one 2).symm
+            _ ≤ 2 ^ (S - 2) := Nat.pow_le_pow_right (by norm_num) (by omega)
+        have hwpos : 0 < Nat.totient w :=
+          Nat.totient_pos.mpr (by rcases hwodd with ⟨i, hi⟩; omega)
+        have hw1 : 1 ≤ Nat.totient w := hwpos
+        calc (2 : ℕ) ≤ 2 ^ (S - 2) := h2pow
+          _ = 1 * 2 ^ (S - 2) := (one_mul _).symm
+          _ ≤ Nat.totient w * 2 ^ (S - 2) := mul_le_mul_right' hw1 (2 ^ (S - 2))
+    -- assemble the engine's excess bound  p^m ≤ φ(p^m)·φ(w)·2^(S−2)  and conclude
+    have hbound : p ^ (m + 1) - Nat.totient (p ^ (m + 1)) ≤
+        Nat.totient (seedB (p ^ (m + 1))) * 2 ^ (seedS (p ^ (m + 1)) - 2) := by
+      rw [hexcess, hBval, hSval, hφpw]
+      calc p ^ m ≤ 2 * Nat.totient (p ^ m) := prime_pow_le_two_totient hp m
+        _ = Nat.totient (p ^ m) * 2 := by ring
+        _ ≤ Nat.totient (p ^ m) * (Nat.totient w * 2 ^ (S - 2)) :=
+              mul_le_mul_left' hQ2 (Nat.totient (p ^ m))
+        _ = Nat.totient (p ^ m) * Nat.totient w * 2 ^ (S - 2) := by ring
+    have hpge : p ≤ p ^ (m + 1) := by
+      calc p = p ^ 1 := (pow_one p).symm
+        _ ≤ p ^ (m + 1) := Nat.pow_le_pow_right (by omega) (by omega)
+    have ha3 : 3 ≤ p ^ (m + 1) := le_trans (by omega) hpge
+    have hs2 : 2 ≤ seedS (p ^ (m + 1)) := by rw [hSval]; exact hS2
+    exact classifySeed_ne_lt_of_excess_bound ha3 hs2 hbound
+
+/-- **The family `p^k·2^(j+1)` never reverses, for every prime `p ≡ 3 (mod 4)`
+    and `k ≥ 1`.**  No member of this infinite two-parameter family of excluded
+    seeds lies in `ReversalSet`.  This is the full excluded prime-power case: it
+    contains both `three_pow_family_not_reversal` (`p = 3`) and
+    `prime_three_mod_four_family_not_reversal` (`k = 1`) as slices, giving further
+    evidence for the structural conjecture that reversals occur only in the
+    transport-admissible regime `seedS a = 1`. -/
+theorem prime_pow_three_mod_four_family_not_reversal {p k : ℕ}
+    (hp : p.Prime) (hp3 : p % 4 = 3) (hk : 1 ≤ k) (j : ℕ) :
+    p ^ k * 2 ^ (j + 1) ∉ ReversalSet := by
+  have hodd : Odd (p ^ k) := (Nat.odd_iff.mpr (show p % 2 = 1 by omega)).pow
+  have hpge : p ≤ p ^ k := by
+    calc p = p ^ 1 := (pow_one p).symm
+      _ ≤ p ^ k := Nat.pow_le_pow_right (by have := hp.two_le; omega) hk
+  have ha3 : 3 ≤ p ^ k := le_trans (by omega) hpge
+  rw [classifySeed_lt_iff hodd ha3 j]
+  exact classifySeed_prime_pow_three_mod_four_ne_lt hp hp3 hk
+
+-- ---------------------------------------------------------------------------
+-- CAPSTONE:  THE EXCLUDED REGIME NEVER REVERSES  (structural conjecture proven)
+-- ---------------------------------------------------------------------------
+-- The excluded seeds are *exactly* the prime powers `p^k` with `p ≡ 3 (mod 4)`:
+--   `seedS a ≥ 2  ⟺  φ(a) ≡ 2 (mod 4)`   (`seedS_ge_two_iff_totient_mod_four`)
+--   `φ(a) ≡ 2 (mod 4)  ⟺  a = p^k, p ≡ 3 mod 4`
+--                                (`totient_mod_four_eq_two_iff_prime_pow_three_mod_four`).
+-- Having just shown that *every* such prime power never reverses, we obtain the
+-- full structural dichotomy that all prior sessions were circling: no excluded
+-- seed reverses, equivalently every reversing seed is transport-admissible
+-- (`seedS a = 1`).  This turns the long-standing structural CONJECTURE into a
+-- THEOREM (the analytically-hard density-1 forward direction is the only part of
+-- Erdős 1064 OQ-03 that stays open).
+-- ---------------------------------------------------------------------------
+
+/-- **No excluded seed reverses.**  Every odd `a ≥ 3` with `seedS a ≥ 2` (the
+    excluded regime, where the first cototient step has 2-adic valuation `≥ 2`)
+    classifies away from `.lt`.  Proof: such `a` is a prime power `p^k` with
+    `p ≡ 3 (mod 4)` (`seedS_ge_two_iff_totient_mod_four` composed with
+    `totient_mod_four_eq_two_iff_prime_pow_three_mod_four`), and every such power
+    never reverses (`classifySeed_prime_pow_three_mod_four_ne_lt`). -/
+theorem excluded_seed_never_reverses {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a)
+    (hexcl : 2 ≤ seedS a) : classifySeed a ≠ Ordering.lt := by
+  have hφ4 : Nat.totient a % 4 = 2 := (seedS_ge_two_iff_totient_mod_four ha ha3).1 hexcl
+  obtain ⟨p, k, hp, hp3, hk, rfl⟩ :=
+    (totient_mod_four_eq_two_iff_prime_pow_three_mod_four ha ha3).1 hφ4
+  exact classifySeed_prime_pow_three_mod_four_ne_lt hp hp3 hk
+
+/-- **Every reversing seed is transport-admissible (`seedS a = 1`).**  The
+    contrapositive of `excluded_seed_never_reverses`: if the family `a·2^(k+1)`
+    reverses (`classifySeed a = .lt`) then the first cototient step of `a` has
+    2-adic valuation exactly one.  This is the previously-conjectural structural
+    characterisation of the reversal regime, now proven. -/
+theorem reversal_seed_transport_admissible {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a)
+    (h : classifySeed a = Ordering.lt) : seedS a = 1 := by
+  have hs1 : 1 ≤ seedS a := (seed_spec ha3).2.2.1
+  by_contra hne
+  exact excluded_seed_never_reverses ha ha3 (by omega) h
+
+/-- **`ReversalSet` form of the structural dichotomy.**  Any member
+    `n = a·2^(k+1)` of `ReversalSet` (odd seed `a ≥ 3`) has `seedS a = 1`: every
+    actual totient-inequality reversal occurs strictly inside the
+    transport-admissible regime. -/
+theorem reversal_mem_implies_transport_regime {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a)
+    (k : ℕ) (h : a * 2 ^ (k + 1) ∈ ReversalSet) : seedS a = 1 :=
+  reversal_seed_transport_admissible ha ha3 ((classifySeed_lt_iff ha ha3 k).1 h)
+
 end Erdos1064OQ03

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -1,4 +1,51 @@
 
+## Session 2026-07-08 (researcher-6) — MILESTONE: excluded regime fully closed (structural conjecture proven)
+
+**Mode**: REVISIT (RICH tier; branch dedicated) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, Docker `Built (5.6s)`, 3058 jobs; axioms propext/Classical.choice/Quot.sound; no native_decide)
+
+### What I Did
+- Extended the general non-reversal engine `classifySeed_ne_lt_of_excess_bound`
+  from its two prior special applications (the tower `3^k`; the primes `p≡3 mod4`
+  at `k=1`) to their **common generalisation — every prime power `p^k` with
+  `p≡3 mod4`, `k≥1`** (`classifySeed_prime_pow_three_mod_four_ne_lt`,
+  `prime_pow_three_mod_four_family_not_reversal`).
+- Recognised (via the file's existing `seedS_ge_two_iff_totient_mod_four` and
+  `totient_mod_four_eq_two_iff_prime_pow_three_mod_four`) that the excluded seeds
+  are **exactly** those prime powers, so the extension **closes the entire
+  excluded regime**. Added the capstone theorems.
+
+### Key Findings
+- `a=p^(m+1)`: `a−φ(a)=p^m`, `2a−φ(a)=p^m·(p+1)`. Writing `p+1=w·2^S` (w odd,
+  `S=v₂(p+1)≥2` since `p≡3 mod4`) gives `seedS a=S`, `seedB a=p^m·w` (p^m ⟂ w
+  because `w∣p+1`). The engine bound becomes `p^m ≤ φ(p^m)·φ(w)·2^(S−2)`.
+- Split into two elementary facts: `p^m ≤ 2·φ(p^m)` (any prime; `2(p−1)≥p`) and
+  `2 ≤ φ(w)·2^(S−2)`. The latter holds **iff `p>3`**: `S=2 ∧ w=1 ⟺ p+1=4 ⟺ p=3`,
+  so `p≥7` forces `S≥3` (2^(S−2)≥2) or `w≥3` odd (φ(w)≥2). `p=3` → `3^k` tower.
+- **Structural dichotomy now a THEOREM**: `excluded_seed_never_reverses`
+  (`seedS a≥2 ⟹ classifySeed a≠.lt`), hence `reversal_seed_transport_admissible`
+  (`classifySeed a=.lt ⟹ seedS a=1`) and `reversal_mem_implies_transport_regime`
+  (`a·2^(k+1)∈ReversalSet ⟹ seedS a=1`). Every reversal lives strictly inside the
+  transport-admissible regime `seedS a=1` — the conjecture prior sessions circled.
+
+### New declarations (all VERIFIED 0/0)
+- `prime_pow_le_two_totient` — `p^m ≤ 2·φ(p^m)` for any prime `p` (reusable)
+- `classifySeed_prime_pow_three_mod_four_ne_lt`
+- `prime_pow_three_mod_four_family_not_reversal`
+- `excluded_seed_never_reverses`
+- `reversal_seed_transport_admissible`
+- `reversal_mem_implies_transport_regime`
+
+### Files Modified
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (+~180)
+- `src/data/research/problems/erdos-1064-oq-03.json`
+
+### Next Steps
+- The elementary/structural side of OQ-03 is COMPLETE. The only open direction is
+  the analytically-hard density-1 forward statement (ψ(x,y) smooth-number
+  density / Luca–Pomerance) — a genuine Mathlib gap, not session-sized.
+- Optional elementary follow-up: characterise WHICH transport-admissible seeds
+  (`seedS a=1`) reverse, beyond the least element `a=21`.
+
 ## Session 2026-07-08 (researcher-6) — general non-reversal ENGINE + all primes p≡3 mod4
 
 **Mode**: REVISIT (RICH tier; branch dedicated) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, Docker v4.26.0 `Build completed successfully`, 3058 jobs)

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-6, VERIFIED 0/0): general non-reversal ENGINE for the excluded regime reduces no-reversal to a single per-seed arithmetic bound a-phi(a) <= phi(seedB a)*2^(seedS a-2); instantiated to prove the whole infinite class of primes p≡3 mod4 never reverses (widening beyond 3^k). Remaining: general prime-power a=p^k via the same engine (bound phi(seedB)*2^(s-2) >= p^(k-1)); density-1 forward remains the sole analytically-blocked direction.",
+    "progressSummary": "MILESTONE (researcher-6, VERIFIED 0/0): the STRUCTURAL side of Erdős 1064 OQ-03 is now COMPLETE. Proved that NO excluded seed (seedS≥2, = prime powers p≡3 mod4) ever reverses, hence every totient-inequality reversal occurs strictly in the transport-admissible regime seedS=1 (reversal_seed_transport_admissible / reversal_mem_implies_transport_regime). This converts the long-standing structural conjecture into a theorem. The ONLY remaining open part is the analytically-hard density-1 forward direction (ψ(x,y) smooth-number density), a genuine Mathlib gap.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -87,7 +87,13 @@
       "factor_two_split (reusable 2-adic split: n=c*2^u, c odd => factorization 2 = u and oddpart = c), classifySeed_val (evaluates classifySeed at a concrete seed from the two factorisations), classifySeed_3..19 + classifySeed_21, and twentyone_smallest_reversing_seed in EulerTotientOQ04OQ03.lean — VERIFIED host 0/0, axioms [propext,Classical.choice,Quot.sound], no native_decide",
       "classifySeed_ne_lt_of_excess_bound (EulerTotientOQ04OQ03.lean:1908): reusable excluded-regime non-reversal engine, VERIFIED 0/0",
       "classifySeed_prime_three_mod_four_ne_lt (EulerTotientOQ04OQ03.lean:1953): all primes p≡3 mod4 never reverse, VERIFIED 0/0",
-      "prime_three_mod_four_family_not_reversal (EulerTotientOQ04OQ03.lean:1976): family p*2^(k+1) not in ReversalSet for prime p≡3 mod4, VERIFIED 0/0"
+      "prime_three_mod_four_family_not_reversal (EulerTotientOQ04OQ03.lean:1976): family p*2^(k+1) not in ReversalSet for prime p≡3 mod4, VERIFIED 0/0",
+      "prime_pow_le_two_totient (EulerTotientOQ04OQ03.lean): for any prime p, p^m≤2·φ(p^m) — reusable seed-shape ingredient. VERIFIED 0/0",
+      "classifySeed_prime_pow_three_mod_four_ne_lt (EulerTotientOQ04OQ03.lean): classifySeed(p^k)≠.lt for all prime p≡3 mod4, k≥1. VERIFIED 0/0",
+      "prime_pow_three_mod_four_family_not_reversal (EulerTotientOQ04OQ03.lean): p^k·2^(j+1)∉ReversalSet for all prime p≡3 mod4, k≥1, j. VERIFIED 0/0",
+      "excluded_seed_never_reverses (EulerTotientOQ04OQ03.lean): seedS a≥2 ⟹ classifySeed a≠.lt for odd a≥3. VERIFIED 0/0",
+      "reversal_seed_transport_admissible (EulerTotientOQ04OQ03.lean): classifySeed a=.lt ⟹ seedS a=1. VERIFIED 0/0",
+      "reversal_mem_implies_transport_regime (EulerTotientOQ04OQ03.lean): a·2^(k+1)∈ReversalSet ⟹ seedS a=1. VERIFIED 0/0"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -112,21 +118,19 @@
       "Total decidable classifier: the k-free three-way criterion becomes a COMPUTABLE function classifySeed : ℕ → Ordering. From an odd seed a it extracts (s,b,t,e) by two 2-adic valuations — s=v₂(2a−φ(a)), b=oddpart, C=2a−φ(b)·2^(s−1), t=v₂(C), e=oddpart(C) — and compares φ(a) ⋛ φ(e)·2^(t−1). seed_spec proves the extraction meets every criterion hypothesis for ALL a≥3 (oddness of a not needed). The reversal seed set is the decidable predicate {a | classifySeed a = .lt}.",
       "The total classifier classifySeed removes the ValidSeed hypothesis from the least-reversal-seed result: twentyone_smallest_reversing_seed proves 21 is UNCONDITIONALLY the smallest odd reversing seed, covering the higher-valuation excluded seeds {3,7,9,11,19} (v2(2a-phi a) >= 2) that the old ValidSeed-gated classify sweep {5,13,15,17} could not address.",
       "General non-reversal engine (classifySeed_ne_lt_of_excess_bound): for an excluded seed (seedS a>=2), classifySeed a != .lt whenever a-phi(a) <= phi(seedB a)*2^(seedS a-2). Mechanism: phi(e)*2^(t-1) <= e*2^(t-1) = seedC/2 = a - phi(seedB a)*2^(seedS a-2); the single arithmetic bound is the only seed-specific input.",
-      "Every prime p ≡ 3 mod 4 is a non-reversing excluded seed: p-phi(p)=1 makes the excess bound trivial, so the engine gives classifySeed p != .lt for the ENTIRE infinite class {3,7,11,19,23,31,...} at once — strictly larger than the single-prime tower 3^k."
+      "Every prime p ≡ 3 mod 4 is a non-reversing excluded seed: p-phi(p)=1 makes the excess bound trivial, so the engine gives classifySeed p != .lt for the ENTIRE infinite class {3,7,11,19,23,31,...} at once — strictly larger than the single-prime tower 3^k.",
+      "The full excluded prime-power case is now closed: EVERY prime power a=p^k with p≡3 mod4 (k≥1) never reverses. This subsumes both prior infinite families (3^k tower AND primes p≡3 mod4, k=1) as special slices.",
+      "Uniform prime-power arithmetic: a=p^(m+1) gives a−φ(a)=p^m and 2a−φ(a)=p^m·(p+1); factoring p+1=w·2^S (w odd, S=v2(p+1)≥2) yields seedS=S, seedB=p^m·w. The engine bound becomes p^m≤φ(p^m)·φ(w)·2^(S−2).",
+      "The bound splits into two elementary facts: p^m≤2·φ(p^m) (any prime p, via φ(p^m)=p^(m-1)(p-1) and 2(p-1)≥p) and 2≤φ(w)·2^(S−2). The latter holds precisely when p>3: S=2∧w=1 forces p+1=4 ⟹ p=3, so p≥7 gives either S≥3 (2^(S-2)≥2) or w≥3 odd (φ(w)≥2). p=3 is dispatched by the 3^k tower.",
+      "CAPSTONE (structural conjecture now proven): the excluded seeds (seedS a≥2) are EXACTLY prime powers p^k with p≡3 mod4 (seedS_ge_two_iff_totient_mod_four composed with totient_mod_four_eq_two_iff_prime_pow_three_mod_four, both already in the file). Since all such powers never reverse, NO excluded seed reverses — equivalently every reversing seed has seedS a=1 (transport-admissible). The long-conjectured structural dichotomy is a theorem."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."
     ],
     "nextSteps": [
-      "Characterise {odd a≥3 | classifySeed a = .lt} structurally, or prove seedS a ≥ 2 ⇒ classifySeed a ≠ .lt (no excluded seed reverses; observed a<120).",
-      "Density-1 forward statement φ(n)>φ(D(n)) for almost all n remains the sole analytically-blocked open direction (needs Luca–Pomerance / ψ(x,y) density, a real Mathlib gap); the explicit families + criterion settle only the infinitely-often / structural questions.",
-      "Turn the criterion into a genuine DECIDABLE classifier: given odd a, compute b=(2a−φ(a))/2 (requires v₂(2a−φ(a))=1), then the 2-adic split C=2a−φ(b)=e·2^t, and decide the regime by φ(a) vs φ(e)·2^(t−1). Formalising the v₂ extraction (t,e) as a computable function would give a decision procedure over all odd seeds.",
-      "Characterise the reversal seed set {odd a : φ(a) < φ(e)·2^(t−1)} — a structural description of which odd seeds reverse (a=21 smallest) would be a new elementary result now that the per-seed test is k-free.",
-      "RESOLVED (twentyone_least_reversal_seed / least_reversal_seed_families): 21 is the smallest odd seed with classify a = .lt among valid seeds — the valid seeds a<21 are exactly {5,13,15,17} classifying eq/gt/eq/gt, discharged by a finite kernel-decide sweep. Next: characterise the FULL reversal-seed set {odd valid a : classify a = .lt} beyond its least element (is it an arithmetic-progression / residue pattern suggested by 21,55,...? a phi-only finite computation per seed now that classify is computable).",
-      "Extend the computable classify to the excluded case v₂(2a-φa)>1 (bSeed a even): dblIter_transport_general already covers the mathematics, but the Ordering-valued classifier still assumes first-step valuation one.",
-      "Prove/refute that NO excluded seed (v₂(2a−φ(a))≥2) ever reverses (observed a<120); would sharpen the reversal-set structure to v₂=1 seeds only",
-      "PARTIAL RESOLUTION of the excluded-seed question: no odd seed a<21 reverses (proven unconditionally via classifySeed, including v2>=2 seeds 3,7,9,11,19). Extend the finite unconditional sweep upward, or prove the general structural claim seedS a >= 2 => classifySeed a != .lt (no excluded seed ever reverses; observed a<120).",
-      "Extend the engine to the full prime-power case a=p^k (p≡3 mod4): reduces to phi(seedB a)*2^(seedS a-2) >= p^(k-1) where seedB(p^k)=p^(k-1)*oddpart(p+1), seedS=v2(p+1). For p>=7 the bound (p-1)*phi(b)*2^(s-2)>=p holds since phi(b)*2^(s-2)>=2; only p=3 needs the separate three_pow computation. Completing this would fully prove the structural claim NO excluded seed reverses."
+      "ONLY remaining open direction of Erdős 1064 OQ-03: the density-1 forward statement φ(n)>φ(D(n)) for almost all n. Needs ψ(x,y) smooth-number density / Luca–Pomerance analytic input — a real Mathlib gap, not session-sized, not Aristotle-suitable. The elementary structural side (which seeds reverse, and that reversals live only in the seedS=1 regime) is now COMPLETE.",
+      "Possible follow-up (elementary): characterise WHICH transport-admissible seeds (seedS a=1) reverse — i.e. describe {odd a : seedS a=1 ∧ classifySeed a=.lt} beyond its least element a=21. This is the natural next structural question now that the excluded regime is fully closed.",
+      "Possible follow-up: is the reversal-seed set (seedS=1, classify=.lt) infinite with positive density among transport-admissible seeds? (21·2^(k+1) family already gives infinitely-often.)"
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Closes the **entire excluded regime** of Erdős 1064 OQ-03, turning the long-standing structural **conjecture** — *totient-inequality reversals occur only in the transport-admissible regime `seedS a = 1`* — into a **theorem**.

## What was proven

Building on the general non-reversal engine `classifySeed_ne_lt_of_excess_bound` (merged in #36009), this PR:

1. Extends non-reversal to **every prime power** `a = p^k` with `p ≡ 3 (mod 4)`, `k ≥ 1` — unifying and strictly generalizing the two prior infinite sub-families (the tower `3^k` and the primes-only `k=1` slice).
2. Combines with the file's existing characterisation (`seedS_ge_two_iff_totient_mod_four` ∘ `totient_mod_four_eq_two_iff_prime_pow_three_mod_four`) that the excluded seeds (`seedS a ≥ 2`) are **exactly** those prime powers — hence the extension closes the whole excluded regime.

### New declarations (all VERIFIED, 0 sorry / 0 axiom)
| Theorem | Statement |
|---|---|
| `prime_pow_le_two_totient` | `p^m ≤ 2·φ(p^m)` for any prime `p` (reusable) |
| `classifySeed_prime_pow_three_mod_four_ne_lt` | `classifySeed (p^k) ≠ .lt` for prime `p≡3 mod4`, `k≥1` |
| `prime_pow_three_mod_four_family_not_reversal` | `p^k·2^(j+1) ∉ ReversalSet` |
| `excluded_seed_never_reverses` | `seedS a ≥ 2 ⟹ classifySeed a ≠ .lt` |
| `reversal_seed_transport_admissible` | `classifySeed a = .lt ⟹ seedS a = 1` |
| `reversal_mem_implies_transport_regime` | `a·2^(k+1) ∈ ReversalSet ⟹ seedS a = 1` |

## Proof sketch (prime-power case)

For `a = p^(m+1)`: `a − φ(a) = p^m` and `2a − φ(a) = p^m·(p+1)`. Writing `p+1 = w·2^S` (`w` odd, `S = v₂(p+1) ≥ 2`) gives `seedS a = S`, `seedB a = p^m·w`, reducing the engine bound to `p^m ≤ φ(p^m)·φ(w)·2^(S−2)`. This follows from `p^m ≤ 2·φ(p^m)` (any prime) and `2 ≤ φ(w)·2^(S−2)` — the latter holds precisely when `p > 3` (`S=2 ∧ w=1 ⟺ p=3`, dispatched by the `3^k` tower).

## Verification

Docker build clean: `Built Proofs.EulerTotientOQ04OQ03 (5.6s)`, 3058 jobs, 0 sorry, no `native_decide`; axioms `propext`/`Classical.choice`/`Quot.sound` only. Purely additive (199 insertions, 0 deletions in the Lean file).

## Remaining open

The analytically-hard **density-1 forward direction** (`φ(n) > φ(D(n))` for almost all `n`, needs ψ(x,y) smooth-number density / Luca–Pomerance) is the sole remaining open part — a genuine Mathlib gap.