### PR TITLE
Enrich Hexagrammum S6 census: link projective-dual sibling Brianchon

### DIFF
--- a/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
@@ -139,6 +139,11 @@
       "targetId": "pascals-hexagon",
       "relationship": "ancestor",
       "description": "Parent entry establishing Pascal's Hexagon Theorem (Wiedijk #28), whose third open question asks whether the 60-Pascal-line configuration with Steiner and Kirkman counts can be formalized."
+    },
+    {
+      "targetId": "pascals-hexagon-oq-02",
+      "relationship": "related",
+      "description": "The projective-dual sibling: Brianchon's theorem (diagonals of a hexagon circumscribed about a conic are concurrent) is the point↔line dual of Pascal's theorem. The same S₆ symmetry that organizes the 60 Pascal lines catalogued here acts, dually, on the Brianchon configuration — the two are companion faces of the Hexagrammum Mysticum's combinatorics."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Enrichment pass — pascals-hexagon-oq-03-incomplete-01 (S₆ cycle-type census)

The entry linked only up (parent OQ-03 + base Pascal), not sideways. Added the family sibling:

- **pascals-hexagon-oq-02** — Brianchon's theorem, the point↔line projective dual of Pascal. The S₆ symmetry organizing the 60 Pascal lines catalogued in this census acts dually on the Brianchon configuration; the two are companion faces of the Hexagrammum Mysticum combinatorics.

Pure cross-reference enrichment. crossReferences 2 → 3 (cap 20). JSON validated; target verified on disk; gallery-data build passes. No status/badge/axiomCount change (remains 'axiomatized').