### PR TITLE
Fix: sync stale meta/leanFile counts for grown shannon-awgn-oq-02-oq-02

### DIFF
--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 1082,
+    "lineCount": 1118,
     "axiomCount": 0,
-    "theoremCount": 44,
+    "theoremCount": 46,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 1082,
-    "theoremCount": 44,
+    "lineCount": 1118,
+    "theoremCount": 46,
     "definitionCount": 1,
     "badge": "mathlib",
     "originalContributions": [
@@ -183,6 +183,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 1082,
-  "theoremCount": 44
+  "lineCount": 1118,
+  "theoremCount": 46
 }


### PR DESCRIPTION
## Fix

Count-drift repair for `shannon-channel-coding-awgn-oq-02-oq-02`: the main Lean file grew but the metadata counts were left stale.

## Evidence

The Lean file `Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean` was grown by research PR #36080 (strict stddev triangle inequality) after the last count sync, adding two theorems (`stddev_add_lt_iff_correlation_lt_one`, `stddev_add_lt_iff_not_affine_pos`).

**Before**: all three count blocks (top-level, `meta`, `leanFile`) read `lineCount: 1082`, `theoremCount: 44`.
**After**: `lineCount: 1118`, `theoremCount: 46` — matching the actual file.

Verification:
- `wc -l` = 1118
- comment-stripped `theorem`/`lemma` count = 46
- `definitionCount` (1), `axiomCount` (0), `sorries` (0) unchanged and already correct.

Found via meta-agrees-with-leanFile-but-both-drifted-from-actual scan; no auditor issue tracks it. Metadata-only change; no Lean source touched.

---
Automated fix by lean-mechanic agent.