### PR TITLE
Enrich Probabilistic Method first-moment engine: link second-moment, LLL, Ramsey

### DIFF
--- a/src/data/proofs/prob-method-applications-wip-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01/meta.json
@@ -162,6 +162,21 @@
       "targetId": "prob-method-expectation",
       "relationship": "related",
       "description": "Provides the counting (cardinality) form of the first moment existence principle"
+    },
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "related",
+      "description": "The complementary pillar: the first-moment method proved here establishes mere existence (some object avoids the bad event), while the second-moment method upgrades this to concentration / almost-sure existence via Var/𝔼² bounds. Together they are the two basic moment tools of the probabilistic method."
+    },
+    {
+      "targetId": "prob-method-lovasz-local",
+      "relationship": "related",
+      "description": "The sharper existence tool: where the first-moment union bound needs the expected number of bad events < 1, the Lovász Local Lemma yields existence under only bounded local dependence even when many bad events are expected — the refinement of the crude counting bound used here."
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "The application domain: this entry's Ramsey-style avoidance theorem is an instance of the probabilistic method's flagship result — Erdős's lower bound R(k,k) > 2^{k/2}, obtained by exactly this first-moment union bound over random 2-colourings avoiding a monochromatic clique."
     }
   ]
 }


### PR DESCRIPTION
## Enrichment pass — prob-method-applications-wip-01 (First-Moment Existence Engine)

The entry linked only its own module + expectation form. Added the three natural relatives that place it in the probabilistic-method landscape:

- **prob-method-second-moment** — the complementary pillar: first moment gives existence, second moment gives concentration.
- **prob-method-lovasz-local** — the sharper existence tool (bounded local dependence vs the crude union bound).
- **ramseys-theorem** — the flagship application: Erdős's $R(k,k) > 2^{k/2}$ is exactly this first-moment union bound over random 2-colourings; this entry's Ramsey-style avoidance theorem is an instance.

Pure cross-reference enrichment. crossReferences 2 → 5 (cap 20). meta.json 10.6 KB → 11.8 KB. JSON validated; all 3 targets verified on disk; gallery-data build passes. No status/badge/axiomCount change (remains 'verified').