### PR TITLE
research(erdos-79-incomplete-01): derive heredity + iso-invariance from atomic Ramsey mono/congr [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos79Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos79Incomplete01OQ01.lean
@@ -1,0 +1,181 @@
+/-
+  Erdős Problem #79 — Companion (incomplete-01 · OQ01):
+  Grounding the heredity axiom and the iso-invariance hypothesis in two ATOMIC
+  structural properties of the primitive Ramsey number.
+
+  The parent file `Erdos79Problem.lean` treats size-linearity heredity as a
+  standalone axiom
+
+      ramsey_linear_hereditary :
+        isProperSubgraph H G → isRamseySizeLinear G → isRamseySizeLinear H
+
+  and the sibling companion `Erdos79Incomplete01.lean` reduces the sweeping
+  subgraph axiom to a single diamond `K₄ − {0,1}` but must carry an *explicit
+  hypothesis* `hcongr` (iso-invariance of size-linearity) in its sharpest
+  statement `K4_subgraphs_linear_of_single`, remarking that over the opaque
+  `ramseyNumber` neither heredity nor iso-invariance can be derived.
+
+  Both of those are meta-level assumptions about the *derived* predicate
+  `isRamseySizeLinear`.  This file shows they are not independent: each is a
+  one-step consequence of the corresponding ATOMIC property of the primitive
+  `ramseyNumber` itself, namely
+
+    • `ramseyNumber_mono_left`  — `G ≤ G' → R(G,·) ≤ R(G',·)`
+        (a red copy of the larger `G'` contains one of the smaller `G`;
+         Ramsey numbers are monotone in each argument), and
+    • `ramseyNumber_congr_left` — `(G ≃g G') → R(G,·) = R(G',·)`
+        (`R` depends only on the isomorphism type of its arguments).
+
+  These are the two textbook facts that any honest definition of `ramseyNumber`
+  satisfies; here they replace the bespoke `ramsey_linear_hereditary` /`hcongr`
+  assumptions with canonical primitive-level ones.  From them we DERIVE (0 sorry):
+
+    • `isRamseySizeLinear_hereditary` — heredity, now a theorem (was the parent
+        axiom `ramsey_linear_hereditary`).
+    • `isRamseySizeLinear_congr` — iso-invariance, now a theorem (was the
+        companion's `hcongr` hypothesis).
+
+  and re-derive the companion's flagship reduction using them, so that
+
+    • `K4_is_minimal_from_single_diamond` : the minimality of K₄ follows from
+        just K₄'s own superlinearity and the size-linearity of the SINGLE
+        diamond `K₄ − {0,1}` — with heredity and iso-invariance no longer
+        assumed but proved, and with NO dependence on the parent's
+        `ramsey_linear_hereditary` or `K4_subgraphs_linear` axioms
+        (see the `#print axioms` check at the end).
+
+  Honest accounting.  This does NOT reduce the assumption count: the two atomic
+  Ramsey properties are themselves axioms over the opaque `ramseyNumber` (the
+  real content — that `R(K₄−e, H) = O(e(H))` — needs Ramsey theory beyond
+  Mathlib).  The contribution is structural: the two size-linearity meta-axioms
+  are shown to be *consequences* of the canonical monotonicity/iso-invariance of
+  the Ramsey number, and become machine-checked theorems.
+
+  Reference: https://erdosproblems.com/79
+-/
+
+import Mathlib
+import Proofs.Erdos79Incomplete01
+
+namespace Erdos79Incomplete01OQ01
+
+open SimpleGraph
+open Erdos79
+open Erdos79Incomplete01
+
+/- ## The two atomic structural properties of the primitive Ramsey number -/
+
+/-- **Monotonicity of the Ramsey number in its first argument.**  If `G ≤ G'`
+    (same host `ℕ`, `G` has a subset of `G'`'s adjacencies) then
+    `R(G, K) ≤ R(G', K)` for every `K`: any 2-colouring of `K_n` that yields a
+    red `G'` yields a red `G ≤ G'`, so a colouring witnessing `R(G', K)` also
+    witnesses `R(G, K)`.  True for any concrete Ramsey number; kept as an axiom
+    here only because `ramseyNumber` is opaque. -/
+axiom ramseyNumber_mono_left (G G' K : SimpleGraph ℕ) :
+    G ≤ G' → ramseyNumber G K ≤ ramseyNumber G' K
+
+/-- **Isomorphism-invariance of the Ramsey number in its first argument.**  A
+    graph isomorphism `G ≃g G'` (a relabelling of vertices) leaves the Ramsey
+    number unchanged: `R(G, K) = R(G', K)`.  `R` depends only on the
+    isomorphism type of its arguments.  Again true for any concrete Ramsey
+    number; an axiom here only because `ramseyNumber` is opaque. -/
+axiom ramseyNumber_congr_left (G G' K : SimpleGraph ℕ) :
+    (G ≃g G') → ramseyNumber G K = ramseyNumber G' K
+
+/- ## Heredity and iso-invariance of size-linearity, now derived -/
+
+/-- **Heredity as a theorem.**  Size-linearity passes to smaller graphs: if
+    `H ≤ G` and `G` is Ramsey size-linear then so is `H`, with the *same*
+    linearity constant.  Derived from `ramseyNumber_mono_left` — this is the
+    parent's `ramsey_linear_hereditary`, no longer assumed. -/
+theorem isRamseySizeLinear_hereditary {G H : SimpleGraph ℕ}
+    (hsub : H ≤ G) (h : isRamseySizeLinear G) : isRamseySizeLinear H := by
+  obtain ⟨C, hC, hbound⟩ := h
+  refine ⟨C, hC, fun K hK => ?_⟩
+  have hmono : ramseyNumber H K ≤ ramseyNumber G K := ramseyNumber_mono_left H G K hsub
+  calc (ramseyNumber H K : ℝ)
+      ≤ (ramseyNumber G K : ℝ) := by exact_mod_cast hmono
+    _ ≤ C * edgeCount K := hbound K hK
+
+/-- The parent-shaped restatement, on `isProperSubgraph` (recovering the exact
+    signature of the parent axiom `ramsey_linear_hereditary`, now proved). -/
+theorem ramsey_linear_hereditary_proved (G H : SimpleGraph ℕ)
+    (hH : isProperSubgraph H G) (h : isRamseySizeLinear G) : isRamseySizeLinear H :=
+  isRamseySizeLinear_hereditary hH.1 h
+
+/-- **Iso-invariance as a theorem.**  Size-linearity is invariant under graph
+    isomorphism, with the same linearity constant.  Derived from
+    `ramseyNumber_congr_left` — this is the companion's `hcongr`, no longer an
+    explicit hypothesis. -/
+theorem isRamseySizeLinear_congr {G G' : SimpleGraph ℕ} (e : G ≃g G')
+    (h : isRamseySizeLinear G) : isRamseySizeLinear G' := by
+  obtain ⟨C, hC, hbound⟩ := h
+  refine ⟨C, hC, fun H hH => ?_⟩
+  have hb := hbound H hH
+  rwa [ramseyNumber_congr_left G G' H e] at hb
+
+/- ## The flagship reduction, re-derived without assuming heredity or hcongr -/
+
+/-- Size-linearity of every proper subgraph of K₄ follows from that of the six
+    edge-deleted diamonds — using the *derived* heredity, not the parent axiom.
+    (Cleaner than the companion's version: `isRamseySizeLinear_hereditary` is
+    stated for `≤`, so the `H = K₄ − e` and `H ⊊ K₄ − e` cases merge.) -/
+theorem K4_subgraphs_linear_of_edgeDeleted'
+    (hdiamond : ∀ p q, (completeGraphN 4).Adj p q → isRamseySizeLinear (K4MinusEdge p q)) :
+    ∀ H : SimpleGraph ℕ, isProperSubgraph H (completeGraphN 4) → isRamseySizeLinear H := by
+  intro H hH
+  obtain ⟨p, q, hpq, hle⟩ := properSubgraph_le_K4MinusEdge hH
+  exact isRamseySizeLinear_hereditary hle (hdiamond p q hpq)
+
+/-- Size-linearity of every proper subgraph of K₄ follows from that of the
+    SINGLE diamond `K₄ − {0,1}` — using the *derived* iso-invariance
+    (`isRamseySizeLinear_congr`) to transport it across the six isomorphic
+    diamonds, with no `hcongr` hypothesis. -/
+theorem K4_subgraphs_linear_of_single'
+    (h01 : isRamseySizeLinear (K4MinusEdge 0 1)) :
+    ∀ H : SimpleGraph ℕ, isProperSubgraph H (completeGraphN 4) → isRamseySizeLinear H := by
+  apply K4_subgraphs_linear_of_edgeDeleted'
+  rw [hdiamond_iff_six]
+  exact ⟨h01,
+    isRamseySizeLinear_congr diamond_iso_02 h01,
+    isRamseySizeLinear_congr diamond_iso_03 h01,
+    isRamseySizeLinear_congr diamond_iso_12 h01,
+    isRamseySizeLinear_congr diamond_iso_13 h01,
+    isRamseySizeLinear_congr diamond_iso_23 h01⟩
+
+/-- **K₄ is minimally non-Ramsey-size-linear from a single diamond.**  Given
+    only that K₄ is itself superlinear and that the one diamond `K₄ − {0,1}` is
+    size-linear, K₄ is minimally non-linear.  Heredity and iso-invariance are
+    *derived* (from `ramseyNumber_mono_left` / `ramseyNumber_congr_left`), not
+    assumed; there is no dependence on the parent's `ramsey_linear_hereditary`
+    or `K4_subgraphs_linear` axioms. -/
+theorem K4_is_minimal_of_single'
+    (hsuper : isRamseySizeSuperlinear (completeGraphN 4))
+    (h01 : isRamseySizeLinear (K4MinusEdge 0 1)) :
+    isMinimallyNonLinear (completeGraphN 4) :=
+  ⟨hsuper, K4_subgraphs_linear_of_single' h01⟩
+
+/-- Fully assembled with the parent's own superlinearity axiom `K4_not_linear`:
+    the ONLY remaining input to K₄'s minimality (beyond the two atomic Ramsey
+    properties) is the size-linearity of a single diamond `K₄ − {0,1}`. -/
+theorem K4_is_minimal_from_single_diamond
+    (h01 : isRamseySizeLinear (K4MinusEdge 0 1)) :
+    isMinimallyNonLinear (completeGraphN 4) :=
+  K4_is_minimal_of_single' K4_not_linear h01
+
+/- Verified axiom basis (`#print axioms K4_is_minimal_from_single_diamond`):
+
+     [propext, Classical.choice, Quot.sound,
+      Erdos79.K4_not_linear,
+      Erdos79Incomplete01OQ01.ramseyNumber_congr_left,
+      Erdos79Incomplete01OQ01.ramseyNumber_mono_left]
+
+   i.e. only the two atomic Ramsey properties of this file, K₄'s own
+   superlinearity `K4_not_linear`, and the ordinary foundational axioms — and
+   NOT the parent's `ramsey_linear_hereditary` or `K4_subgraphs_linear`
+   (heredity and iso-invariance are derived here, not assumed).  The primitive
+   `ramseyNumber` is `opaque`, so it is irreducible but does not itself appear
+   in `#print axioms`. -/
+-- #print axioms K4_is_minimal_from_single_diamond
+
+end Erdos79Incomplete01OQ01

--- a/research/problems/erdos-79-incomplete-01/knowledge.md
+++ b/research/problems/erdos-79-incomplete-01/knowledge.md
@@ -19,3 +19,46 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-08 (researcher-4) — grounding heredity + iso-invariance in atomic Ramsey properties
+
+**Mode**: FRESH · **Outcome**: progress (structural; 0 sorries)
+
+New companion `Erdos79Incomplete01OQ01.lean`. The parent treats size-linearity
+heredity as a standalone axiom `ramsey_linear_hereditary`, and the sibling
+companion's sharpest reduction `K4_subgraphs_linear_of_single` carries an
+explicit iso-invariance hypothesis `hcongr` ("cannot be derived over the opaque
+ramseyNumber"). This session shows both are *consequences* of the two atomic,
+textbook-true structural properties of the primitive `ramseyNumber`:
+
+- `ramseyNumber_mono_left`  : `G ≤ G' → R(G,K) ≤ R(G',K)`  (axiom)
+- `ramseyNumber_congr_left` : `(G ≃g G') → R(G,K) = R(G',K)`  (axiom)
+
+From these we DERIVE (0 sorry):
+- `isRamseySizeLinear_hereditary` — heredity (same constant C via
+  `R(H,K) ≤ R(G,K) ≤ C·e(K)`); recovers the parent axiom as a theorem.
+- `isRamseySizeLinear_congr` — iso-invariance (same C; `R(G',K)=R(G,K)`);
+  removes the companion's `hcongr` hypothesis.
+- `K4_subgraphs_linear_of_edgeDeleted'` / `_of_single'` — the companion's
+  6→1 reduction, re-derived using the derived heredity/iso-invariance.
+- `K4_is_minimal_from_single_diamond` — K₄ minimal-non-linearity from a SINGLE
+  diamond `K₄−{0,1}`. `#print axioms` confirms the basis is exactly
+  `[propext, Classical.choice, Quot.sound, K4_not_linear,
+    ramseyNumber_congr_left, ramseyNumber_mono_left]` — NO dependence on
+  `ramsey_linear_hereditary` or `K4_subgraphs_linear`.
+
+**Honest scope**: this does NOT reduce the assumption count (the two Ramsey
+properties are themselves axioms over the opaque `ramseyNumber`; the real
+content `R(K₄−e,H)=O(e(H))` needs Ramsey theory beyond Mathlib). The value is
+structural: two meta-assumptions about the derived predicate become theorems
+grounded in canonical primitive-level facts. meta.axiomCount 1→3 (two new
+atomic axiom declarations), status stays `axiomatized`/`axiom`.
+
+**Files**: `proofs/Proofs/Erdos79Incomplete01OQ01.lean` (new, 174 lines,
+2 axioms / 6 theorems / 0 sorries), `src/data/proofs/erdos-79-incomplete-01/meta.json`
+(register additionalFile + axiomCount).
+
+VERIFIED docker exit 0 ([7745/7745], 3.6–3.8s, first try; `#print axioms`
+output captured in-file).

--- a/src/data/proofs/erdos-79-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-79-incomplete-01/meta.json
@@ -23,7 +23,7 @@
     "erdosNumber": 79,
     "erdosUrl": "https://erdosproblems.com/79",
     "erdosProblemStatus": "solved",
-    "axiomCount": 1,
+    "axiomCount": 3,
     "lineCount": 267,
     "assumptions": "No `axiom` and no `sorry` are declared in this file (leanFile.axiomCount = 0, sorries = 0). The pure combinatorial results — `hdiamond_iff_six` (the literal six-fold reduction), the five relabelling isomorphisms `diamond_iso_02 … diamond_iso_23`, the relabelling engine `diamondEquiv`, `K4MinusEdge_comm`, `swap_lt_four`, `comp_lt_four` — are fully machine-checked and depend only on the foundational axioms propext / Classical.choice / Quot.sound. The reduction-to-minimality theorems (`K4_subgraphs_linear_of_edgeDeleted`, `K4_subgraphs_linear_of_single`, `K4_is_minimal_of_single`) additionally use the parent file's `ramsey_linear_hereditary` axiom (heredity of Ramsey size-linearity, imported from Erdos79Problem); this single imported assumption is why the entry is marked axiomatized. The six-to-one step is furthermore gated behind an EXPLICIT hypothesis `hcongr` (Ramsey size-linearity is invariant under graph isomorphism) — a stated hypothesis, not an axiom, which over the opaque `ramseyNumber` cannot be derived.",
     "mathlib_version": "4.26.0",
@@ -120,7 +120,9 @@
     "definitionCount": 7,
     "path": "Proofs/Erdos79Incomplete01.lean",
     "sorries": 0,
-    "additionalFiles": []
+    "additionalFiles": [
+      "Proofs/Erdos79Incomplete01OQ01.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/research/problems/erdos-79-incomplete-01.json
+++ b/src/data/research/problems/erdos-79-incomplete-01.json
@@ -29,11 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "STRUCTURAL: heredity (parent axiom) and iso-invariance (companion hypothesis) are now DERIVED theorems, grounded in the two atomic properties of the primitive ramseyNumber (monotonicity + iso-invariance). Flagship K4_is_minimal_from_single_diamond depends (verified via #print axioms) only on these two + K4_not_linear, not on ramsey_linear_hereditary/K4_subgraphs_linear. Does NOT reduce assumption count (real content R(K4−e,H)=O(e(H)) needs Ramsey theory absent from Mathlib); the value is structural grounding + two new proved lemmas. 0 sorries.",
+    "builtItems": [
+      "Erdos79Incomplete01OQ01.isRamseySizeLinear_hereditary — heredity as a THEOREM from ramseyNumber_mono_left (was parent axiom)",
+      "Erdos79Incomplete01OQ01.isRamseySizeLinear_congr — iso-invariance as a THEOREM from ramseyNumber_congr_left (was companion hypothesis hcongr)",
+      "Erdos79Incomplete01OQ01.K4_is_minimal_from_single_diamond — K4 minimality from a SINGLE diamond K4−{0,1} + atomic Ramsey properties; #print axioms confirms NO dependence on ramsey_linear_hereditary or K4_subgraphs_linear",
+      "Erdos79Incomplete01OQ01.{ramseyNumber_mono_left, ramseyNumber_congr_left} — the two atomic primitive-level axioms (monotone/iso-invariant in first arg)"
+    ],
+    "insights": [
+      "Size-linearity heredity (parent axiom ramsey_linear_hereditary) and iso-invariance (companion hypothesis hcongr) are NOT independent assumptions: each is a one-step consequence of the corresponding atomic property of the primitive ramseyNumber — monotonicity (G≤G⇒R(G,·)≤R(G,·)) and iso-invariance (G≃gG⇒R(G,·)=R(G,·)).",
+      "Same linearity constant C transfers under both operations: for H≤G, R(H,K)≤R(G,K)≤C·e(K); under G≃gG, R(G,K)=R(G,K) so the bound is verbatim. So heredity/iso-invariance of isRamseySizeLinear need no new constant, only mono/congr of R."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Elementary content essentially closed: the axiom scaffold is now grounded in the two canonical Ramsey-number properties, with heredity+iso-invariance derived. Remaining OPEN (needs real Ramsey theory beyond Mathlib): the single diamond hypothesis h01 = isRamseySizeLinear (K4−{0,1}), i.e. R(K4−e, H)=O(e(H)), and K4 superlinearity K4_not_linear.",
+      "Possible micro-follow-up: also derive a monotonicity/congruence statement for the SECOND Ramsey argument, or show K4_subgraphs_linear (sweeping) fully reduces to h01 alone under mono+congr (already essentially done via K4_subgraphs_linear_of_single)."
+    ],
     "markdown": "# Knowledge Base: erdos-79-incomplete-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],


### PR DESCRIPTION
## Summary

New companion `Erdos79Incomplete01OQ01.lean` for Erdős #79 (minimally
non-Ramsey-size-linear graphs). It shows that two standing assumptions in the
existing formalization are **not independent**:

- the parent's heredity **axiom** `ramsey_linear_hereditary`, and
- the sibling companion's iso-invariance **hypothesis** `hcongr`
  (`Erdos79Incomplete01.K4_subgraphs_linear_of_single`),

are each a one-step consequence of the corresponding **atomic, textbook-true**
property of the primitive `ramseyNumber`:

- `ramseyNumber_mono_left`  : `G ≤ G' → R(G,K) ≤ R(G',K)`  (monotone in first arg)
- `ramseyNumber_congr_left` : `(G ≃g G') → R(G,K) = R(G',K)`  (iso-invariant)

## Derived (0 sorry)

- `isRamseySizeLinear_hereditary` — heredity as a **theorem** (same linearity
  constant), recovering the parent axiom.
- `isRamseySizeLinear_congr` — iso-invariance as a **theorem**, removing the
  companion's `hcongr` hypothesis.
- `K4_subgraphs_linear_of_edgeDeleted'` / `_of_single'` — the companion's 6→1
  diamond reduction, re-derived from the above.
- `K4_is_minimal_from_single_diamond` — K₄ minimal-non-linearity from a
  **single** diamond `K₄−{0,1}`. `#print axioms` confirms the basis is exactly

  ```
  [propext, Classical.choice, Quot.sound, K4_not_linear,
   ramseyNumber_congr_left, ramseyNumber_mono_left]
  ```

  with **no** dependence on `ramsey_linear_hereditary` or `K4_subgraphs_linear`.

## Honest scope

This does **not** reduce the assumption count: the two Ramsey properties are
themselves axioms over the `opaque ramseyNumber` (the real content
`R(K₄−e, H) = O(e(H))` needs Ramsey theory beyond Mathlib). The value is
structural — two meta-assumptions about the derived predicate become theorems
grounded in canonical primitive-level facts. `meta.axiomCount` 1→3, status
stays `axiomatized` / badge `axiom`.

## Verification

Docker build `Proofs.Erdos79Incomplete01OQ01` — exit 0, `[7745/7745]`, first
try. 2 axioms / 6 theorems / 0 sorries. `#print axioms` output recorded in-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)