### PR TITLE
Enrich Erdos R(k,k)>2^(k/2): link probabilistic-method engine (bidirectional)

### DIFF
--- a/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
@@ -198,6 +198,16 @@
       "targetId": "ramsey-r4k-oq-01",
       "relationship": "related",
       "description": "Sibling: off-diagonal R(4,k) = Θ(k³/(log k)^c) bounds (AKS upper, Mattheus-Verstraëte lower)"
+    },
+    {
+      "targetId": "prob-method-applications-wip-01",
+      "relationship": "related",
+      "description": "The abstract first-moment engine of which this R(k,k) > 2^{k/2} bound is the flagship instance: that entry proves the union-bound existence principle and a general Ramsey-style avoidance theorem (|cliques|·2^{|E|−m+1} < 2^{|E|} ⇒ a colouring with no monochromatic block exists), which specialises to exactly the counting argument formalized here."
+    },
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "related",
+      "description": "The first-moment / expectation principle underlying this proof: Erdős's 1947 bound is the founding application of the probabilistic method, obtained by showing the expected number of monochromatic K_k in a random 2-colouring is < 1 when n < 2^{k/2}."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Enrichment pass — ramsey-r4k-extensions-oq-01 (Erdős probabilistic lower bound R(k,k) > 2^(k/2))

This entry is 'the very first application of the probabilistic method' but linked only within the Ramsey family, not to the probabilistic-method entries. Added the missing (now bidirectional) links:

- **prob-method-applications-wip-01** — the abstract first-moment union-bound engine whose general Ramsey avoidance theorem ($|\mathrm{cliques}|\cdot 2^{|E|-m+1} < 2^{|E|}$) specialises to exactly this counting argument. (That entry already links here after PR #36089 — this closes the loop.)
- **prob-method-expectation** — the first-moment/expectation principle: $\mathbb{E}[\#\text{mono } K_k] < 1$ when $n < 2^{k/2}$.

Pure cross-reference enrichment. crossReferences 3 → 5 (cap 20). JSON validated; both targets verified on disk; gallery-data build passes. No status/badge/axiomCount change ('verified', 0 axioms).