### PR TITLE
research(roth-theorem-k3-oq-03-oq-01): kAPCount(1_A)=(N⁻¹)²·#{k-APs in A} indicator→count bridge [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -80,6 +80,14 @@ noncomputable def kAPCount {N : ℕ} [NeZero N] (k : ℕ)
   ((N : ℂ)⁻¹) ^ 2 * ∑ x : ZMod N, ∑ d : ZMod N,
     ∏ i : Fin k, f i (x + i.val • d)
 
+/-- The complex indicator `1_A : ZMod N → ℂ` of a finite set `A ⊆ ZMod N`:
+    `1` on `A`, `0` off it.  Feeding `1_A` into every slot of `kAPCount`
+    turns the analytic operator `Λ_k` into a genuine combinatorial count
+    of arithmetic progressions lying inside `A`
+    (`kAPCount_indicator_eq_count`). -/
+noncomputable def indicatorZMod {N : ℕ} (A : Finset (ZMod N)) : ZMod N → ℂ :=
+  fun x => if x ∈ A then 1 else 0
+
 -- ============================================================
 -- Foundational identities
 -- ============================================================
@@ -380,5 +388,61 @@ theorem kAPCount_diag_eq_major_add_remainder {N : ℕ} [NeZero N] (k : ℕ)
         else (1 : ZMod N → ℂ)) = (fun (_ : Fin k) (_ : ZMod N) => (1 : ℂ)) := by
     funext i y; simp
   rw [Finset.card_empty, Nat.sub_zero, hfun, kAPCount_const_one, mul_one]
+
+-- ============================================================
+-- Bridge to combinatorics: `kAPCount` of an indicator counts APs
+--
+-- All the identities above are analytic facts about the *operator*
+-- `Λ_k`.  This block ties `Λ_k` back to the combinatorial object it is
+-- designed to measure: feeding the indicator `1_A` into every slot,
+-- `Λ_k(1_A,…,1_A)` becomes exactly `(N⁻¹)²` times the number of pairs
+-- `(x,d)` whose length-`k` progression `x, x+d, …, x+(k−1)d` lies wholly
+-- inside `A`.  This is the concrete meaning of "the normalized `k`-AP
+-- count of `A`" that Roth's theorem (`k = 3`) is a statement about.
+-- ============================================================
+
+/-- The indicator of the whole group is the constant `1` function. -/
+@[simp] theorem indicatorZMod_univ {N : ℕ} [NeZero N] :
+    indicatorZMod (Finset.univ : Finset (ZMod N)) = fun _ => (1 : ℂ) := by
+  funext x
+  simp [indicatorZMod]
+
+/-- **Combinatorial bridge.**  The analytic count of the diagonal indicator
+    tuple is `(N⁻¹)²` times the number of `(x, d)` pairs for which the entire
+    length-`k` progression `x + i·d` (`0 ≤ i < k`) lies inside `A`:
+
+        Λ_k(1_A,…,1_A) = (N⁻¹)² · #{(x,d) : ∀ i, x + i·d ∈ A}.
+
+    Each inner product `∏ᵢ 1_A(x + i·d)` is `1` exactly when every term of the
+    progression hits `A` and `0` otherwise (`Finset.prod_boole`); summing these
+    indicators over all pairs `(x,d)` counts the progressions (`Finset.sum_boole`).
+    This is what makes `kAPCount` the *normalized `k`-AP density* of `A`: the
+    quantity Roth's theorem forces to be positive once `A` is dense. -/
+theorem kAPCount_indicator_eq_count {N : ℕ} [NeZero N] (k : ℕ)
+    (A : Finset (ZMod N)) :
+    kAPCount k (fun _ : Fin k => indicatorZMod A)
+      = ((N : ℂ)⁻¹) ^ 2 *
+          ((Finset.univ.filter
+              (fun p : ZMod N × ZMod N =>
+                ∀ i : Fin k, p.1 + i.val • p.2 ∈ A)).card : ℂ) := by
+  classical
+  simp only [kAPCount, indicatorZMod]
+  congr 1
+  -- Collapse the double sum into a single sum over pairs.
+  rw [← Finset.sum_product', Finset.univ_product_univ]
+  -- Each inner product of indicators is the indicator of "all terms hit `A`"
+  -- (`prod_boole`); summing those indicators over all pairs counts the
+  -- progressions lying inside `A` (`sum_boole`), and `∀ i ∈ univ` collapses to
+  -- the plain `∀ i` on the counted set.
+  simp [Finset.prod_boole, Finset.sum_boole]
+
+/-- Consistency check: the normalized `k`-AP count of the whole group is `1`,
+    recovering `kAPCount_const_one` through the combinatorial definition
+    (every pair `(x,d)` gives a progression inside `univ`). -/
+theorem kAPCount_indicator_univ {N : ℕ} [NeZero N] (k : ℕ) :
+    kAPCount k (fun _ : Fin k => indicatorZMod (Finset.univ : Finset (ZMod N)))
+      = 1 := by
+  simp only [indicatorZMod_univ]
+  exact kAPCount_const_one k
 
 end RothTheoremOQ03OQ01

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -142,10 +142,10 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 384,
+    "lineCount": 448,
     "axiomCount": 0,
-    "theoremCount": 13,
-    "definitionCount": 4,
+    "theoremCount": 16,
+    "definitionCount": 5,
     "path": "Proofs/RothTheoremOQ03OQ01.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
@@ -4,7 +4,7 @@
   "parentId": "roth-theorem-k3-oq-03",
   "status": "in-progress",
   "knowledge": {
-    "score": 16,
+    "score": 19,
     "insights": [
       "The parent OQ-03 defines gowersNorm and kAPCount constructively but proves NO algebraic properties of them — this child fills that gap with the foundational degenerate/normalization identities.",
       "kAPCount on a constant tuple (c,…,c) equals c^k: the inner product is c^k and the normalized double average (N^-1)^2 * sum_{x,d} c^k = c^k cancels N^2 against the (N^-1)^2 prefactor. The all-ones case gives Λ_k(1,…,1)=1, the total normalized k-AP mass.",
@@ -21,7 +21,10 @@
       "Toolchain: Function.update_self (NOT update_same) is the v4.26 name for update f j v j = v; add_sub_cancel proves a + (b − a) = b here (works for the module ZMod N → ℂ).",
       "The full slot-telescoping Λ_k(g,…,g)=∑_{S⊆[k]}δ^{k−|S|}Λ_k(i↦if i∈S then b else 1) (b=g−δ·1) is obtained in ONE shot from Finset.prod_add on the inner product ∏ᵢ g(x+i·d)=∏ᵢ(b(x+i·d)+δ), rather than iterating kAPCount_update_split k times. S=∅ gives the δ^k major term (kAPCount_const_one).",
       "Assembly: expand inner product on both sides to a canonical triple sum (N⁻¹)²∑ₓ∑_d∑_S, then reconcile via two Finset.sum_comm reorderings (∑_S∑ₓ∑_d → ∑ₓ∑_d∑_S). RHS if-slots collapse via Finset.prod_ite_mem + univ_inter; δ-power exponent k−|S| via Finset.card_sdiff_of_subset.",
-      "To peel the S=∅ major term off Finset.univ sum over subsets: rw [← Finset.add_sum_erase Finset.univ _ (Finset.mem_univ ∅)] turns ∑_{S:Finset (Fin k)} into F ∅ + ∑_{S∈univ.erase ∅}; then the empty-slot tuple (fun i => if i∈∅ then b else 1) equals the const-1 tuple by funext i y; simp, so kAPCount_const_one evaluates it to 1 and the term is δ^k."
+      "To peel the S=∅ major term off Finset.univ sum over subsets: rw [← Finset.add_sum_erase Finset.univ _ (Finset.mem_univ ∅)] turns ∑_{S:Finset (Fin k)} into F ∅ + ∑_{S∈univ.erase ∅}; then the empty-slot tuple (fun i => if i∈∅ then b else 1) equals the const-1 tuple by funext i y; simp, so kAPCount_const_one evaluates it to 1 and the term is δ^k.",
+      "Combinatorial bridge (kAPCount_indicator_eq_count): feeding the complex indicator 1_A into every slot turns the analytic operator into a genuine count — Λ_k(1_A,…,1_A) = (N⁻¹)²·#{(x,d) : ∀ i, x+i·d ∈ A}, i.e. (N⁻¹)² times the number of length-k progressions x,x+d,…,x+(k−1)d lying wholly inside A. This is the concrete meaning of 'normalized k-AP density of A' that Roth's theorem (k=3) forces positive for dense A.",
+      "Proof recipe for indicator→count: simp only [kAPCount, indicatorZMod]; congr 1 (strip (N⁻¹)² prefactor); collapse the double average ∑_x∑_d to a single pair sum via `rw [← Finset.sum_product', Finset.univ_product_univ]` (sum_product' matches ∑x∈s∑y∈t f x y, avoids the (x,y).1 reconstruction that breaks Fintype.sum_prod_type); then `simp [Finset.prod_boole, Finset.sum_boole]` finishes (∏ of 0/1 indicators = indicator of ∀-condition, ∑ of that = card of the filtered pair set).",
+      "GOTCHA: `rw [Finset.sum_boole]` (and `rw`-ing any if-then-1-else-0 identity) FAILS 'did not find pattern' when the ite's Decidable instance is a concrete `decidableDforallFinset` (produced by prod_boole's bounded ∀ i∈univ) — rw won't unify the instance arg. Use `simp [Finset.sum_boole]` instead: simp is instance-robust AND simultaneously normalizes `∀ i ∈ univ` → `∀ i` so the counted filter predicate matches a plain-`∀ i` statement. Likewise hand-writing `if (∀ i ∈ univ, …) then 1 else 0` in a `have` fixes a DIFFERENT instance than prod_boole → later rw/exact mismatches; never restate the ite, let simp/library lemmas carry the instance."
     ],
     "builtItems": [
       "RothTheoremOQ03OQ01.lean: self-contained, 4 noncomputable defs (hypercubeShift, conjugateByWeight, gowersNorm, kAPCount) + 5 proved theorems, 0 axioms, 0 sorries.",
@@ -37,13 +40,16 @@
       "kAPCount_update_sub: slotwise subtractivity.",
       "kAPCount_update_zero (@[simp]): zero slot annihilates the count (update form).",
       "kAPCount_diag_eq_sum_subsets (generalized von Neumann telescoping, 2^k subset expansion)",
-      "kAPCount_diag_eq_major_add_remainder: isolates the S=∅ major term of the von Neumann expansion — Λ_k(g,…,g) = δ^k + ∑_{∅≠S⊆[k]} δ^{k−|S|}·Λ_k(i↦ if i∈S then g−δ·1 else 1). S=∅ term collapses via kAPCount_const_one; proved with Finset.add_sum_erase + funext/simp. The \"main count δ^k + balanced (Gowers-controlled) remainder\" form. VERIFIED 0/0."
+      "kAPCount_diag_eq_major_add_remainder: isolates the S=∅ major term of the von Neumann expansion — Λ_k(g,…,g) = δ^k + ∑_{∅≠S⊆[k]} δ^{k−|S|}·Λ_k(i↦ if i∈S then g−δ·1 else 1). S=∅ term collapses via kAPCount_const_one; proved with Finset.add_sum_erase + funext/simp. The \"main count δ^k + balanced (Gowers-controlled) remainder\" form. VERIFIED 0/0.",
+      "indicatorZMod: the complex indicator 1_A : ZMod N → ℂ of a finset A (1 on A, 0 off).",
+      "kAPCount_indicator_eq_count: Λ_k(1_A,…,1_A) = (N⁻¹)²·#{(x,d) : ∀ i, x+i·d ∈ A} — the analytic operator equals (N⁻¹)² times the combinatorial count of k-APs inside A. VERIFIED 0/0 (docker-build green).",
+      "indicatorZMod_univ (@[simp]): 1_univ = const 1; kAPCount_indicator_univ: Λ_k(1_univ,…) = 1, recovering kAPCount_const_one through the combinatorial definition (every pair gives a progression in univ)."
     ],
-    "progressSummary": "PROGRESS (S+1, researcher-5): added the generalized von Neumann slot-split kAPCount_update_split (Λ_k(update f j g) = δ·Λ_k(update f j 1) + Λ_k(update f j (g−δ·1))) — the first density-decomposition step the prior nextSteps called for — plus its supporting slotwise linearity (kAPCount_update_sub, kAPCount_update_zero). All host-verified (lake env lean EXIT 0), 0 axioms/0 sorries (foundational trio only). score 13→16. [2026-07-08 researcher-10] Proved the full slot-telescoping kAPCount_diag_eq_sum_subsets (the density-decomposition step the prior nextSteps called for, completed): Λ_k(g,…,g)=∑_{S⊆[k]}δ^{k−|S|}Λ_k(i↦if i∈S then g−δ·1 else 1), all 2^k terms with δ^k major term at S=∅, via Finset.prod_add. VERIFIED 0/0 (docker-build green). File 354L/12 theorems.",
+    "progressSummary": "PROGRESS (S+1, researcher-5): added the generalized von Neumann slot-split kAPCount_update_split (Λ_k(update f j g) = δ·Λ_k(update f j 1) + Λ_k(update f j (g−δ·1))) — the first density-decomposition step the prior nextSteps called for — plus its supporting slotwise linearity (kAPCount_update_sub, kAPCount_update_zero). All host-verified (lake env lean EXIT 0), 0 axioms/0 sorries (foundational trio only). score 13→16. [2026-07-08 researcher-10] Proved the full slot-telescoping kAPCount_diag_eq_sum_subsets (the density-decomposition step the prior nextSteps called for, completed): Λ_k(g,…,g)=∑_{S⊆[k]}δ^{k−|S|}Λ_k(i↦if i∈S then g−δ·1 else 1), all 2^k terms with δ^k major term at S=∅, via Finset.prod_add. VERIFIED 0/0 (docker-build green). File 354L/12 theorems. [2026-07-08 researcher-1] Added the COMBINATORIAL BRIDGE kAPCount_indicator_eq_count: Λ_k(1_A,…,1_A) = (N⁻¹)²·#{(x,d) : ∀ i, x+i·d ∈ A}, giving the analytic operator its combinatorial meaning as the normalized k-AP count of A (the quantity Roth forces positive for dense A), plus indicatorZMod def + univ consistency checks. VERIFIED 0/0 (docker-build green, no native_decide). File 448L/13 theorems/5 defs. score 16→19.",
     "nextSteps": [
-      "Prove the generalized von Neumann INEQUALITY: bound each balanced-remainder term |Λ_k(…,b,…)| (b mean-zero) by the Gowers U^{k−1} norm of the balanced slot (Cauchy–Schwarz/box-norm control; gowersNorm def already in file)",
-      "Connect kAPCount of an indicator 1_A to the actual count of 3-APs in a finset A ⊆ ZMod N",
-      "Repair parent RothTheoremOQ03.lean toolchain drift (Complex.abs → ‖·‖) so the files can merge"
+      "Prove the generalized von Neumann INEQUALITY: bound each balanced-remainder term |Λ_k(…,b,…)| (b = 1_A − δ·1 mean-zero) by the Gowers U^{k−1} norm of the balanced slot (Cauchy–Schwarz / box-norm control; gowersNorm def already in file). This is the one genuinely hard remaining step.",
+      "Split the pair count in kAPCount_indicator_eq_count into the trivial d=0 diagonal (contributes #A, giving density δ = |A|/N) plus the nontrivial d≠0 APs, connecting Λ_3(1_A) − δ to the count of nondegenerate 3-APs.",
+      "Repair parent RothTheoremOQ03.lean toolchain drift (Complex.abs → ‖·‖) so the files can merge."
     ]
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Advances **roth-theorem-k3-oq-03-oq-01** (*Foundational identities for the Gowers norm and the k-AP counting operator*), which was in a SOLVED state (12 theorems, 0 axioms/sorries). Per the recorded `nextSteps` ("Connect kAPCount of an indicator 1_A to the actual count of k-APs in a finset A"), this PR adds the **combinatorial bridge** giving the analytic operator `Λ_k` its concrete meaning.

## New content (`proofs/Proofs/RothTheoremOQ03OQ01.lean`, additive)

- **`indicatorZMod A`** — the complex indicator `1_A : ZMod N → ℂ` of a finset `A ⊆ ZMod N`.
- **`kAPCount_indicator_eq_count`** — the main bridge:

  ```
  Λ_k(1_A, …, 1_A) = (N⁻¹)² · #{(x,d) : ∀ i, x + i·d ∈ A}
  ```

  i.e. `(N⁻¹)²` times the number of length-`k` progressions `x, x+d, …, x+(k−1)d` lying wholly inside `A`. This is the *normalized k-AP density of `A`* that Roth's theorem (`k = 3`) forces to be positive once `A` is dense.
- **`indicatorZMod_univ`** / **`kAPCount_indicator_univ`** — consistency checks: `1_univ = const 1` and `Λ_k(1_univ,…) = 1`, recovering `kAPCount_const_one` through the combinatorial definition.

## Proof notes

The inner product of 0/1 indicators is the indicator of "all `k` terms hit `A`" (`Finset.prod_boole`); summing over all pairs `(x,d)` counts the progressions (`Finset.sum_boole`), after collapsing the double average `∑_x ∑_d` to a single pair sum via `Finset.sum_product'`.

## Verification

- Built with `./proofs/scripts/docker-build.sh Proofs.RothTheoremOQ03OQ01` — **green**.
- **0 `sorry`, 0 `axiom`, no `native_decide`** (foundational axioms only). File now 448 lines / 16 theorems / 5 defs.
- Additive on top of `origin/main` (base file byte-identical); knowledge JSON and gallery `meta.json` counts synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)