### PR TITLE
Enrich LLL-for-Ramsey: link the general Lovasz Local Lemma entry

### DIFF
--- a/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
@@ -148,6 +148,11 @@
       "targetId": "ramsey-r4k-extensions-oq-01",
       "relationship": "related",
       "description": "Formalizes Erdős's union-bound lower bound R(k,k) > 2^⌊k/2⌋; the LLL improves on it precisely by replacing that union bound with the dependency-aware feasibility test whose probability input p is computed here"
+    },
+    {
+      "targetId": "prob-method-lovasz-local",
+      "relationship": "related",
+      "description": "The general Lovász Local Lemma this entry applies: the symmetric feasibility test e·p·(d+1) ≤ 1 used here is precisely the symmetric LLL, and this Ramsey computation supplies its two combinatorial inputs (the bad-event probability p and the dependency degree d) for the monochromatic-clique events."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Enrichment pass — ramsey-r4k-extensions-oq-03-oq-01 (LLL for Ramsey: bad-event probability)

This entry computes the combinatorial inputs to the symmetric Lovász Local Lemma feasibility test ($e\cdot p\cdot(d+1)\le 1$) for Spencer's improved Ramsey bound, but didn't link the general LLL entry. Added:

- **prob-method-lovasz-local** — the general Lovász Local Lemma this entry applies; the symmetric test used here *is* the symmetric LLL, and this Ramsey computation supplies its two inputs (bad-event probability $p$, dependency degree $d$).

Pure cross-reference enrichment. crossReferences 3 → 4 (cap 20). JSON validated; target verified on disk; gallery-data build passes. No status/badge/axiomCount change ('verified', 0 axioms).