### PR TITLE
audit: mark erdos-142/173/247/250/17 clean (re-verified vs live source)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11126,9 +11126,9 @@
       "result": "clean"
     },
     "erdos-142": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:48Z",
+      "lastAudited": "2026-07-09T05:39:19Z",
       "result": "clean"
     },
     "erdos-143": {
@@ -11336,9 +11336,9 @@
       "result": "clean"
     },
     "erdos-17": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T21:14:45Z",
+      "lastAudited": "2026-07-09T05:39:19Z",
       "result": "clean"
     },
     "erdos-170": {
@@ -11362,9 +11362,9 @@
       "result": "clean"
     },
     "erdos-173": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T21:14:44Z",
+      "lastAudited": "2026-07-09T05:39:19Z",
       "result": "clean"
     },
     "erdos-174": {
@@ -11983,9 +11983,10 @@
     },
     "erdos-247": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T21:14:45Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T05:39:19Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-247-oq-01": {
       "auditCount": 3,
@@ -12025,9 +12026,10 @@
     },
     "erdos-250": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T21:14:45Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T05:39:19Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-251": {
       "agentId": "auditor-cycle-20-batch",
@@ -29701,5 +29703,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T03:50:48Z"
+  "lastUpdated": "2026-07-09T05:39:19Z"
 }


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Rotational re-audit of 5 targets last audited 2026-05-03. **All confirmed CLEAN** — meta.json claims match the Lean source in every case, no overclaiming, no axiom masking.

| Entry | status/badge | axioms | theorems | sorries | Verdict |
|-------|-------------|--------|----------|---------|---------|
| erdos-142 | formalized/wip | 0 ✓ | 0 ✓ (3 defs) | 0 ✓ | Definitional scaffold; assumptions field honestly says theorems "not yet stated" |
| erdos-173 | axiomatized/axiom | 4 ✓ | 3 ✓ | 0 ✓ | All 4 axioms disclosed (incl `erdos_173_conjecture`, the open conjecture as axiom) |
| erdos-247 | axiomatized/axiom | 1 ✓ | 27 ✓ | 0 ✓ | 27 = 22 top-level + 5 `private theorem`; companions clean |
| erdos-250 | axiomatized/axiom | 2 ✓ | 10 ✓ | 0 ✓ | `native_decide` only on auxiliary σ(n) helper facts; substantive irrationality via disclosed axioms |
| erdos-17 | axiomatized/axiom | 2 ✓ | 3 ✓ | 0 ✓ | 2 decidable facts axiomatized transparently |

**Masking check**: all axiomatized entries have `originalContributions: none`; every `assumptions` field enumerates each axiom with a description.

Only change: refreshed `lastAudited`/`auditCount` in `audit-tracker.json` so the rotation advances. No gallery content changed.

---
Discovered during autonomous gallery integrity audit.