### PR TITLE
Gallery integrity: riesz-sf description contradicts verified status (stale BUILD BROKEN note)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4755,9 +4755,9 @@
       "lastAudited": "2026-07-08T05:29:02Z"
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-07-08T05:29:02Z",
-      "result": "clean",
+      "auditCount": 5,
+      "lastAudited": "2026-07-09T05:46:53Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01": {
@@ -29703,5 +29703,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T05:39:19Z"
+  "lastUpdated": "2026-07-09T05:46:53Z"
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
   "title": "Lp Riesz Representation for Sigma-Finite Measures (Complete)",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
-  "description": "Sigma-finite Lp Riesz representation theorem formalized in Lean 4: all three steps (A localization, B Lp truncation convergence, C density extension) with 0 sorries in this file. Step A (localization_existence, ~600 lines) was completed in PR #15581 via the Hölder extremizer construction; Step B uses Vitali's convergence theorem; Step C uses Lp.induction. NOTE (2026-06-24, #28788): this file transitively fails to compile against the pinned v4.26.0 toolchain because its imported foundation has 53 Mathlib-drift errors; status downgraded to formalized until the chain builds green.",
+  "description": "Sigma-finite Lp Riesz representation theorem formalized in Lean 4: all three steps (A localization, B Lp truncation convergence, C density extension) with 0 sorries in this file. Step A (localization_existence, ~600 lines) was completed in PR #15581 via the Hölder extremizer construction; Step B uses Vitali's convergence theorem; Step C uses Lp.induction. The earlier BUILD BROKEN note (#28788) is resolved: the imported foundation was repaired in #35112 and the file was migrated to Mathlib v4.26 in #35122, where the 1012-line monolith was split into a 47-line assembling file plus the Infra/Norm/Loc companions (same namespace RieszSigmaFiniteComplete, ~1118 lines / 17 declarations total, all 0-sorry / 0-axiom).",
   "leanFile": {
     "namespace": "RieszSigmaFiniteComplete",
     "lineCount": 47,


### PR DESCRIPTION
## Integrity Issue

**Proof**: cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01 ("Lp Riesz Representation for Sigma-Finite Measures (Complete)")

**Problem**: The public `description` field ended with a stale note that directly contradicts the entry's own status:

> NOTE (2026-06-24, #28788): this file transitively fails to compile against the pinned v4.26.0 toolchain … **status downgraded to formalized until the chain builds green.**

Meanwhile `meta.status` = `verified`, `meta.badge` = `original`, and the `assumptions` field already states the opposite — that the build was **resolved** (#35112 foundation repair, #35122 v4.26 migration + Infra/Norm/Loc split). A gallery reader sees "BUILD BROKEN / downgraded to formalized" while the badge advertises a fully verified original result.

## Evidence

- Four assembled source files exist on disk and are all **0-sorry / 0-axiom** (verified by grep for `sorry` / `^axiom ` / `native_decide` / `admit` / True-stubs — only docstring matches):
  - `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean` (47-line assembling file)
  - `…Infra.lean`, `…Loc.lean`, `…Norm.lean` (~1118 lines / 17 decls total)
- Main theorem `riesz_lp_surjective_sigma_finite` is a genuine, non-vacuous Lp Riesz representation statement (∀ φ, ∃ g ∈ Lq with norm bound and integral representation), assembled from the file's own `localization_existence` / `integral_representation_sf` lemmas.
- The split files are dated Jul 7–8, postdating the 2026-06-24 note — confirming the note is the stale part, not the status.

## Fix

Rewrite the trailing `description` sentence to reflect the resolved state (consistent with `assumptions`): the BUILD BROKEN note is resolved via #35112 / #35122 and the file is now a 47-line assembler plus 0-sorry/0-axiom companions. Also marks the audit `issues-fixed` in `audit-tracker.json`.

Note: static audit only — I cannot run `lake build`. The fix aligns the narrative with the documented repair PRs and the on-disk source; if the chain does **not** in fact build green under v4.26.0, the correct fix is instead to downgrade `status`, and that should be filed separately.

---
Discovered during gallery integrity audit.