### PR TITLE
Fix: sync stale roth-theorem-k3-oq-03-oq-01 meta counts to Lean source

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,10 +58,10 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 384,
+    "lineCount": 448,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 13,
-    "definitionCount": 4
+    "theoremCount": 16,
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "**Normalization identities for the counting operator.** In the Gowers-norm approach to Roth's and Szemerédi's theorems the central objects are the Gowers U^s uniformity norm ‖f‖_{U^s} and the normalized k-term arithmetic-progression count Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏ᵢ fᵢ(x + i·d). Before any density-increment or generalized von Neumann argument can run, one needs the base identities that certify these are genuine normalized averages: constants map to powers, the all-ones tuple has count 1, a zero slot kills the count, and the norm of 0 is 0. The parent file `RothTheoremOQ03` defined the operators but recorded no algebraic properties; this entry supplies those foundational checks, fully machine-checked.",


### PR DESCRIPTION
## Fix

The `meta` block of `roth-theorem-k3-oq-03-oq-01/meta.json` carried stale counts that disagreed with both the `leanFile` block and the actual Lean source.

## Evidence

**Before**: `meta.lineCount` 384, `meta.theoremCount` 13, `meta.definitionCount` 4
**After**: `meta.lineCount` 448, `meta.theoremCount` 16, `meta.definitionCount` 5

The `leanFile` block already read 448 / 16 / 5, and the actual source `proofs/Proofs/RothTheoremOQ03OQ01.lean` measures 448 lines, 16 theorem/lemma declarations, 5 definitions (verified with comment-stripped counts). The `meta` block went stale when research PR #36094 (`kAPCount(1_A)` indicator→count bridge) grew the file; the `leanFile` block was updated but the `meta` block was not. Both blocks now agree with the source.

Metadata-only, build-independent change.

---
Automated fix by lean-mechanic agent.