### PR TITLE
research(szemeredi-oq04): sharp whole-partition 2×2 energy route + sharp AFKS iteration count [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
@@ -126,7 +126,7 @@ theorem partitionEnergy_prod_refinement_gain (G : SimpleGraph V) [DecidableRel G
     have a := pairEnergy_split_mono G B₁ B₂ (A₁ ∪ A₂) hdisjB
     have b := pairEnergy_split_mono_right G B₁ A₁ A₂ hdisjA
     have c := pairEnergy_split_mono_right G B₂ A₁ A₂ hdisjA
-    rw [hAunion, hBunion] at a b c; linarith
+    rw [hBunion, hAunion] at a; rw [hAunion] at b c; linarith
   -- Column sums against `R`: `d(A,·)` splits, `d(B,·)` splits.
   have hcolA : R.sum (fun Q => pairEnergy G A Q) ≤
       R.sum (fun Q => pairEnergy G A₁ Q) + R.sum (fun Q => pairEnergy G A₂ Q) := by

--- a/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
@@ -1,0 +1,197 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: lifting the *sharp* direct 2×2 energy
+  increment to the whole partition.
+
+  The companion file `SzemerediRegularityOQ04Bridge` proves the sharp per-pair
+  increment `pairEnergy_prod_gain_of_irregular_eps4`: refining an ε-irregular pair
+  `(A, B)` simultaneously on *both* coordinates into the 2×2 grid
+  `{A′, A∖A′} × {B′, B∖B′}` raises the four-cell `pairEnergy` sum by at least
+  `ε⁴·|A||B|/n²` — with **no factor-¼ loss**.  That statement, however, lives only
+  at the `pairEnergy` level.  The whole-partition capstone that actually feeds the
+  AFKS finiteness engine (`partitionEnergy_gain_of_irregular_pair`) still routes
+  through the *one-sided* branches and therefore only realizes the lossy floor
+  `(ε/2)²/(2n²) = ε²/(8n²)`.
+
+  This file closes that gap: it lifts the **sharp** 2×2 gain to `partitionEnergy`.
+
+  * `partitionEnergy_prod_refinement_gain` — replacing two distinct parts `A, B`
+    of a partition by the 2×2 grid `{A′, A∖A′} × {B′, B∖B′}` raises
+    `partitionEnergy` by the sharp size-dependent increment `(|A′||B′|/n²)·d²`,
+    where `d = |d(A′,B′) − d(A,B)|` is the witness deviation.  The proof is the
+    two-coordinate analogue of `partitionEnergy_single_split_gain`: expand the
+    ordered-pair sum into blocks; the `R×R` block is untouched, every row/column
+    against the remaining parts `R` splits by pure `pairEnergy` monotonicity, and
+    the `{A,B}²` block refines into its sixteen sub-cells with the single `(A,B)`
+    cross-block carrying the variance-atom gain (`pairEnergy_prod_refinement_gain`).
+
+  * `partitionEnergy_prod_gain_eps4` — the AFKS-consumable `ε⁴` floor of the same
+    lift: with the witness size thresholds `|A′| ≥ ε|A|`, `|B′| ≥ ε|B|`, the
+    increment is at least `ε⁴·|A||B|/n²`, the sharp partition-level energy jump
+    free of the one-sided factor-¼ loss.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Bridge
+
+namespace Szemeredi.RegularityOQ04Bridge
+
+open Szemeredi.Core Szemeredi.Regularity Szemeredi.RegularityOQ04Energy
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- The bridge in nested-double-sum form (local re-derivation of the Bridge file's
+    `private` helper), convenient for block decompositions. -/
+private theorem partitionEnergy_eq_double_sum (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : Finset (Finset V)) :
+    partitionEnergy G parts =
+      parts.sum (fun P => parts.sum (fun Q => pairEnergy G P Q)) := by
+  rw [partitionEnergy_eq_sum_pairEnergy,
+    show parts.product parts = parts ×ˢ parts from rfl, Finset.sum_product]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- THE SHARP DIRECT 2×2 ENERGY INCREMENT, LIFTED TO THE WHOLE PARTITION
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Sharp whole-partition 2×2 refinement gain.**  Let `R` be the remaining parts
+    of a partition and `A, B` two further distinct parts, split disjointly as
+    `A = A₁ ∪ A₂`, `B = B₁ ∪ B₂` (the witness cell being `A₁ × B₁`).  If the witness
+    density `d(A₁, B₁)` deviates from the coarse density `d(A, B)` by at least `d`,
+    then refining the partition by the 2×2 grid `{A₁, A₂} × {B₁, B₂}` raises
+    `partitionEnergy` by the sharp increment `(|A₁||B₁|/n²)·d²`:
+
+    `partitionEnergy G (insert A (insert B R)) + (|A₁||B₁|/n²)·d²
+        ≤ partitionEnergy G (insert A₁ (insert A₂ (insert B₁ (insert B₂ R))))`.
+
+    Unlike the one-sided routes (`partitionEnergy_Aside_gain_of_irregular`), which
+    keep one coordinate whole and pay a factor-¼ tolerance loss through a triangle
+    detour, the deviation here is measured *directly* against `d(A,B)` and consumed
+    by the 2×2 variance-atom gain `pairEnergy_prod_refinement_gain` with no loss.
+
+    The ordered-pair double sum decomposes into: the `R×R` block (identical on both
+    partitions); the `A,B` rows/columns against `R` (each splits by pure
+    `pairEnergy_split_mono` / `_mono_right`); and the `{A,B}²` block, whose four
+    coarse terms refine into sixteen sub-cells — the diagonal `A²`, `B²` blocks and
+    the `(B,A)` cross by monotonicity, and the single `(A,B)` cross carrying the
+    variance-atom gain. -/
+theorem partitionEnergy_prod_refinement_gain (G : SimpleGraph V) [DecidableRel G.Adj]
+    (R : Finset (Finset V)) (A B A₁ A₂ B₁ B₂ : Finset V)
+    (hAunion : A₁ ∪ A₂ = A) (hBunion : B₁ ∪ B₂ = B)
+    (hdisjA : Disjoint A₁ A₂) (hdisjB : Disjoint B₁ B₂)
+    -- coarse-side freshness
+    (hAins : A ∉ insert B R) (hBR : B ∉ R)
+    -- fine-side freshness
+    (hA₁ins : A₁ ∉ insert A₂ (insert B₁ (insert B₂ R)))
+    (hA₂ins : A₂ ∉ insert B₁ (insert B₂ R))
+    (hB₁ins : B₁ ∉ insert B₂ R) (hB₂R : B₂ ∉ R)
+    (d : ℚ) (hd : 0 ≤ d)
+    (hdev : d ≤ |edgeDensity G A₁ B₁ - edgeDensity G A B|) :
+    partitionEnergy G (insert A (insert B R)) +
+        (↑A₁.card : ℚ) * ↑B₁.card / (Fintype.card V : ℚ) ^ 2 * d ^ 2 ≤
+      partitionEnergy G
+        (insert A₁ (insert A₂ (insert B₁ (insert B₂ R)))) := by
+  -- Block inequalities.  Diagonal `A²` block (pure monotonicity).
+  have hAA : pairEnergy G A A ≤
+      pairEnergy G A₁ A₁ + pairEnergy G A₁ A₂ +
+        pairEnergy G A₂ A₁ + pairEnergy G A₂ A₂ := by
+    have a := pairEnergy_split_mono G A₁ A₂ (A₁ ∪ A₂) hdisjA
+    have b := pairEnergy_split_mono_right G A₁ A₁ A₂ hdisjA
+    have c := pairEnergy_split_mono_right G A₂ A₁ A₂ hdisjA
+    rw [hAunion] at a b c; linarith
+  -- Diagonal `B²` block (pure monotonicity).
+  have hBB : pairEnergy G B B ≤
+      pairEnergy G B₁ B₁ + pairEnergy G B₁ B₂ +
+        pairEnergy G B₂ B₁ + pairEnergy G B₂ B₂ := by
+    have a := pairEnergy_split_mono G B₁ B₂ (B₁ ∪ B₂) hdisjB
+    have b := pairEnergy_split_mono_right G B₁ B₁ B₂ hdisjB
+    have c := pairEnergy_split_mono_right G B₂ B₁ B₂ hdisjB
+    rw [hBunion] at a b c; linarith
+  -- `(A,B)` cross block: carries the variance-atom gain.
+  have hAB : pairEnergy G A B +
+        (↑A₁.card : ℚ) * ↑B₁.card / (Fintype.card V : ℚ) ^ 2 * d ^ 2 ≤
+      pairEnergy G A₁ B₁ + pairEnergy G A₁ B₂ +
+        pairEnergy G A₂ B₁ + pairEnergy G A₂ B₂ := by
+    have hdev' : d ≤
+        |edgeDensity G A₁ B₁ - edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)| := by
+      rw [hAunion, hBunion]; exact hdev
+    have g := pairEnergy_prod_refinement_gain G A₁ A₂ B₁ B₂ hdisjA hdisjB d hd hdev'
+    rw [hAunion, hBunion] at g; exact g
+  -- `(B,A)` cross block (pure monotonicity).
+  have hBA : pairEnergy G B A ≤
+      pairEnergy G B₁ A₁ + pairEnergy G B₁ A₂ +
+        pairEnergy G B₂ A₁ + pairEnergy G B₂ A₂ := by
+    have a := pairEnergy_split_mono G B₁ B₂ (A₁ ∪ A₂) hdisjB
+    have b := pairEnergy_split_mono_right G B₁ A₁ A₂ hdisjA
+    have c := pairEnergy_split_mono_right G B₂ A₁ A₂ hdisjA
+    rw [hAunion, hBunion] at a b c; linarith
+  -- Column sums against `R`: `d(A,·)` splits, `d(B,·)` splits.
+  have hcolA : R.sum (fun Q => pairEnergy G A Q) ≤
+      R.sum (fun Q => pairEnergy G A₁ Q) + R.sum (fun Q => pairEnergy G A₂ Q) := by
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_le_sum fun Q _ => ?_
+    have := pairEnergy_split_mono G A₁ A₂ Q hdisjA; rwa [hAunion] at this
+  have hcolB : R.sum (fun Q => pairEnergy G B Q) ≤
+      R.sum (fun Q => pairEnergy G B₁ Q) + R.sum (fun Q => pairEnergy G B₂ Q) := by
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_le_sum fun Q _ => ?_
+    have := pairEnergy_split_mono G B₁ B₂ Q hdisjB; rwa [hBunion] at this
+  -- Row sums against `R`: `d(·,A)` splits, `d(·,B)` splits.
+  have hrowA : R.sum (fun P => pairEnergy G P A) ≤
+      R.sum (fun P => pairEnergy G P A₁) + R.sum (fun P => pairEnergy G P A₂) := by
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_le_sum fun P _ => ?_
+    have := pairEnergy_split_mono_right G P A₁ A₂ hdisjA; rwa [hAunion] at this
+  have hrowB : R.sum (fun P => pairEnergy G P B) ≤
+      R.sum (fun P => pairEnergy G P B₁) + R.sum (fun P => pairEnergy G P B₂) := by
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_le_sum fun P _ => ?_
+    have := pairEnergy_split_mono_right G P B₁ B₂ hdisjB; rwa [hBunion] at this
+  -- Expand both partition energies to their block decompositions.
+  rw [partitionEnergy_eq_double_sum, partitionEnergy_eq_double_sum]
+  simp only [Finset.sum_insert hAins, Finset.sum_insert hBR,
+    Finset.sum_insert hA₁ins, Finset.sum_insert hA₂ins,
+    Finset.sum_insert hB₁ins, Finset.sum_insert hB₂R,
+    Finset.sum_add_distrib]
+  linarith [hAA, hBB, hAB, hBA, hcolA, hcolB, hrowA, hrowB]
+
+/-- **AFKS-consumable `ε⁴` floor of the sharp whole-partition 2×2 gain.**  Flooring
+    the size-dependent increment `(|A₁||B₁|/n²)·d²` by the size thresholds
+    `|A₁| ≥ ε|A|`, `|B₁| ≥ ε|B|`, `d ≥ ε`, an ε-irregular pair refined
+    simultaneously on both coordinates raises the whole-partition energy by at least
+    `ε⁴·|A||B|/n²` — the sharp partition-level jump, free of the factor-¼ loss the
+    one-sided branches (`partitionEnergy_gain_of_irregular_pair`) incur. -/
+theorem partitionEnergy_prod_gain_eps4 (G : SimpleGraph V) [DecidableRel G.Adj]
+    (R : Finset (Finset V)) (A B A₁ A₂ B₁ B₂ : Finset V)
+    (hAunion : A₁ ∪ A₂ = A) (hBunion : B₁ ∪ B₂ = B)
+    (hdisjA : Disjoint A₁ A₂) (hdisjB : Disjoint B₁ B₂)
+    (hAins : A ∉ insert B R) (hBR : B ∉ R)
+    (hA₁ins : A₁ ∉ insert A₂ (insert B₁ (insert B₂ R)))
+    (hA₂ins : A₂ ∉ insert B₁ (insert B₂ R))
+    (hB₁ins : B₁ ∉ insert B₂ R) (hB₂R : B₂ ∉ R)
+    (eps : ℚ) (hε : 0 ≤ eps)
+    (hcardA : eps * A.card ≤ (A₁.card : ℚ)) (hcardB : eps * B.card ≤ (B₁.card : ℚ))
+    (hdev : eps ≤ |edgeDensity G A₁ B₁ - edgeDensity G A B|) :
+    partitionEnergy G (insert A (insert B R)) +
+        eps ^ 4 * (↑A.card * ↑B.card) / (Fintype.card V : ℚ) ^ 2 ≤
+      partitionEnergy G
+        (insert A₁ (insert A₂ (insert B₁ (insert B₂ R)))) := by
+  have hgain := partitionEnergy_prod_refinement_gain G R A B A₁ A₂ B₁ B₂
+    hAunion hBunion hdisjA hdisjB hAins hBR hA₁ins hA₂ins hB₁ins hB₂R eps hε hdev
+  -- Floor the exact cell increment `(|A₁||B₁|/n²)·ε²` by `ε⁴·|A||B|/n²`.
+  have hcard : (eps * A.card) * (eps * B.card) ≤ (↑A₁.card : ℚ) * ↑B₁.card :=
+    mul_le_mul hcardA hcardB (by positivity) (by positivity)
+  have he2 : (0 : ℚ) ≤ eps ^ 2 / (Fintype.card V : ℚ) ^ 2 := by positivity
+  have hfloor : eps ^ 4 * (↑A.card * ↑B.card) / (Fintype.card V : ℚ) ^ 2
+      ≤ (↑A₁.card : ℚ) * ↑B₁.card / (Fintype.card V : ℚ) ^ 2 * eps ^ 2 :=
+    calc eps ^ 4 * (↑A.card * ↑B.card) / (Fintype.card V : ℚ) ^ 2
+        = (eps * A.card) * (eps * B.card) * (eps ^ 2 / (Fintype.card V : ℚ) ^ 2) := by
+          ring
+      _ ≤ (↑A₁.card : ℚ) * ↑B₁.card * (eps ^ 2 / (Fintype.card V : ℚ) ^ 2) :=
+          mul_le_mul_of_nonneg_right hcard he2
+      _ = (↑A₁.card : ℚ) * ↑B₁.card / (Fintype.card V : ℚ) ^ 2 * eps ^ 2 := by ring
+  linarith [hgain, hfloor]
+
+end Szemeredi.RegularityOQ04Bridge

--- a/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Assembly.lean
@@ -194,4 +194,41 @@ theorem partitionEnergy_prod_gain_eps4 (G : SimpleGraph V) [DecidableRel G.Adj]
       _ = (↑A₁.card : ℚ) * ↑B₁.card / (Fintype.card V : ℚ) ^ 2 * eps ^ 2 := by ring
   linarith [hgain, hfloor]
 
+-- ═══════════════════════════════════════════════════════════════════
+-- THE SHARP AFKS ITERATION COUNT (NO-LOSS FLOOR → TERMINATION)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Sharp AFKS energy-iteration count.**  The termination engine
+    `partitionEnergy_iteration_bound` bounds the number of refinement steps by
+    `1/δ` once every step raises `partitionEnergy` by a fixed `δ > 0`.  The lossy
+    one-sided route (`afks_energy_iteration_count`) can only supply the floor
+    `δ = ε²/(2n²)`, giving `N ≤ 2n²/ε²`.  The **sharp** 2×2 route earns the
+    no-loss floor `partitionEnergy_prod_gain_eps4`, which — once the refined pair
+    carries mass at least `M` (i.e. `|A||B| ≥ M`, guaranteed by a minimum-part-mass
+    hypothesis on the partition) — is `δ = ε⁴·M/n²`.  Feeding this into the same
+    `[0,1]`-potential engine yields the sharp iteration count
+
+    `N ≤ n² / (ε⁴·M)`,
+
+    the termination bound the factor-¼-free route delivers.  Unlike
+    `afks_energy_iteration_count`, whose floor is independent of the refined pair,
+    the sharp floor scales with the ε⁴ tolerance and the pair mass `M`; the two
+    bounds coincide in order of magnitude only when `M ≈ ε²n²/2`, and the sharp
+    bound is strictly better once the refined pairs are more massive than that. -/
+theorem afks_sharp_energy_iteration_count (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (eps M : ℚ)
+    (hε : 0 < eps) (hM : 0 < M) (hcard : 0 < (Fintype.card V : ℚ))
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hstep : ∀ n, n < N →
+      partitionEnergy G (parts n) + eps ^ 4 * M / (Fintype.card V : ℚ) ^ 2 ≤
+        partitionEnergy G (parts (n + 1))) :
+    (N : ℚ) ≤ (Fintype.card V : ℚ) ^ 2 / (eps ^ 4 * M) := by
+  have hδ : 0 < eps ^ 4 * M / (Fintype.card V : ℚ) ^ 2 :=
+    div_pos (mul_pos (by positivity) hM) (pow_pos hcard 2)
+  have hbound := Szemeredi.RegularityOQ04.partitionEnergy_iteration_bound G parts N
+    (eps ^ 4 * M / (Fintype.card V : ℚ) ^ 2) hδ hcover hdisjoint hstep
+  rwa [one_div_div] at hbound
+
 end Szemeredi.RegularityOQ04Bridge

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -498,3 +498,50 @@ branch research/szemeredi-oq04-prod-gain-r2
 - Sum the per-pair ε⁴ jump over all refined parts to get whole-partition energy
   monotonicity, then feed `afks_energy_iteration_count` (N ≤ 2n²/ε²).
 - Generalize the 2×2 grid to m×k product refinement (already-abstract atom bound).
+
+## Session 2026-07-08 (researcher-8) — Sharp AFKS iteration count (no-loss floor → termination)
+
+**Mode**: FRESH (RICH, depth-over-breadth on my own branch) · **Outcome**: progress (1 theorem VERIFIED 0/0), branch research/szemeredi-oq04-sharp-partition-lift
+
+### What I Did
+- `afks_sharp_energy_iteration_count` (Assembly file): the SHARP AFKS termination
+  count `N ≤ n²/(ε⁴·M)`. Feeds the no-loss whole-partition floor
+  `partitionEnergy_prod_gain_eps4` (per step `δ = ε⁴·M/n²`, with `M` a uniform lower
+  bound on the refined-pair mass `|A||B|`) into the `[0,1]`-potential termination
+  engine `partitionEnergy_iteration_bound` (`N ≤ 1/δ`), reshaping `1/δ` to
+  `n²/(ε⁴M)` via `one_div_div`.
+
+### Key Findings
+- This completes the sharp no-loss route **end-to-end as an iteration certificate**:
+  per-pair ε⁴ gain (`pairEnergy_prod_gain_of_irregular_eps4`) → sharp whole-partition
+  gain (`partitionEnergy_prod_gain_eps4`) → sharp termination count
+  (`afks_sharp_energy_iteration_count`). Previously the sharp lift stopped at the
+  per-partition gain; nothing converted its distinct floor `ε⁴M/n²` into a step count.
+- Honest scope: the termination engine `partitionEnergy_iteration_bound` already
+  takes a **generic** `δ` and returns `N ≤ 1/δ` (the same engine
+  `afks_energy_iteration_count` uses for the lossy floor `ε²/(2n²)`), so the only new
+  content is δ-positivity + the `one_div_div` reshaping. It is a thin but genuine
+  wrapper — the theorem that makes the sharp floor *usable* for termination, exactly
+  parallel to the existing `afks_energy_iteration_count`. The sharp bound beats the
+  one-sided `2n²/ε²` once refined pairs carry mass `M > ε²n²/2`.
+- The `∃P′` existential capstone was considered but rejected as padding: unlike the
+  one-sided `partitionEnergy_gain_of_irregular_pair` (whose ∃ genuinely quantifies
+  over the A-side/B-side *dichotomy* producing different refinements), the sharp route
+  always refines into the same fixed 2×2 grid, so its ∃ is a trivial single-witness
+  intro over `partitionEnergy_prod_gain_eps4`.
+
+### Files Modified
+- proofs/Proofs/SzemerediRegularityOQ04Assembly.lean (+afks_sharp_energy_iteration_count; 197→234 lines, 3→4 theorems)
+- src/data/research/problems/szemeredi-regularity-oq-04.json (knowledge + leanFiles entry for Assembly)
+
+### Build note
+- `[7749/7749] … (1.8s)` elaborated with **zero type errors** (only the pre-existing
+  unused-section-variable linter warnings), then exit-135 at the olean write. Retry:
+  `Build completed successfully (7749 jobs)` on the very next two attempts. Same
+  fleet-memory write race documented in prior sessions — not a math error.
+
+### Next Steps
+- Discharge witness-cell freshness from a nonempty-parts partition model to get a
+  fully-internal `∃P′` sharp capstone from `¬IsEpsilonRegular` (the remaining hard
+  blocker; handle the degenerate `A′=A ⇒ A∖A′=∅` cell).
+- Bound `M` via an equipartition (parts ≈ n/k) to make the count k-explicit.

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -26,7 +26,7 @@
     "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: the SHARP direct 2×2 energy increment (no factor-¼ loss) now lifts to the whole partition (partitionEnergy_prod_refinement_gain + ε⁴ floor partitionEnergy_prod_gain_eps4, VERIFIED 0/0). Remaining blocker for a fully-internal capstone is witness-cell freshness, shared with the one-sided route.",
+    "progressSummary": "PROGRESS: the sharp no-loss 2×2 route is now COMPLETE end-to-end as an iteration certificate — per-pair ε⁴ gain (pairEnergy_prod_gain_of_irregular_eps4) → sharp whole-partition gain (partitionEnergy_prod_gain_eps4) → sharp termination count afks_sharp_energy_iteration_count (N≤n²/(ε⁴M)), all VERIFIED 0/0. Remaining blocker for a FULLY-INTERNAL ∃P′ capstone from ¬IsEpsilonRegular is unchanged: discharging witness-cell freshness (A₁,A₂,B₁,B₂ distinct and ∉R) from a nonempty-parts partition model (shared with the one-sided partitionEnergy_gain_of_irregular_pair).",
     "builtItems": [
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
       "pairEnergy def + pairEnergy_split_mono — one-sided refinement never decreases the normalized pair energy (|A||B|/n^2)d^2; transports density_sq_convex to partitionEnergy units.",
@@ -55,7 +55,8 @@
       "pairEnergy_prod_gain_of_irregular: direct 2x2 energy increment from an irregular pair (no triangle detour) — refine both coordinates via the witness (A′,A\\A′,B′,B\\B′), gain (|A′||B′|/n²)·ε² [VERIFIED]",
       "pairEnergy_prod_gain_of_irregular_eps4: explicit ε⁴·|A||B|/n² energy jump from ¬IsEpsilonRegular, the AFKS-consumable floor (no factor-¼ loss of the one-sided branches) [VERIFIED]",
       "partitionEnergy_prod_refinement_gain (SzemerediRegularityOQ04Assembly.lean): sharp whole-partition 2×2 gain — refining two distinct parts A,B into {A₁,A₂}×{B₁,B₂} raises partitionEnergy by (|A₁||B₁|/n²)·d², d=|d(A₁,B₁)−d(A,B)|. Lifts pairEnergy_prod_refinement_gain via ordered-pair block decomposition.",
-      "partitionEnergy_prod_gain_eps4 (SzemerediRegularityOQ04Assembly.lean): AFKS-consumable ε⁴ floor of the sharp lift — ε-irregular pair refined on both coords raises whole-partition energy by ≥ ε⁴|A||B|/n², free of the one-sided factor-¼/⅛ loss."
+      "partitionEnergy_prod_gain_eps4 (SzemerediRegularityOQ04Assembly.lean): AFKS-consumable ε⁴ floor of the sharp lift — ε-irregular pair refined on both coords raises whole-partition energy by ≥ ε⁴|A||B|/n², free of the one-sided factor-¼/⅛ loss.",
+      "afks_sharp_energy_iteration_count (SzemerediRegularityOQ04Assembly.lean): the SHARP AFKS iteration count N ≤ n²/(ε⁴·M). Feeds the no-loss floor partitionEnergy_prod_gain_eps4 (δ=ε⁴·M/n², M=minimum refined-pair mass |A||B|) into the [0,1]-potential termination engine partitionEnergy_iteration_bound (N≤1/δ). Factor-¼-free counterpart of afks_energy_iteration_count (δ=ε²/(2n²), N≤2n²/ε²). [VERIFIED 0/0]"
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
@@ -75,12 +76,13 @@
       "The ε-irregular witness deviation |d(A,B)−d(A,B)| is DIRECTLY against the coarse mean, so refining both coords simultaneously makes the witness cell a single variance atom — dodging the S5 mixed-second-difference defect entirely (no Cauchy–Schwarz on cross terms).",
       "Bool×Bool index + Fintype.sum_prod_type/sum_bool cleanly instantiates the abstract atom gain over 4 cells; linear_combination needs coeff −1 against edgeDensity_prod_split (whole=Σcells orientation).",
       "Final /n² scaling: avoid convert (mis-pairs the + tree); prove goal=1/n²·raw via unfold+ring both sides then exact the scaled inequality.",
-      "The sharp direct 2×2 gain (no factor-¼ loss) DOES lift to the whole partition cleanly: the ordered-pair double sum splits into R×R (untouched), A/B rows & cols vs R (pure pairEnergy_split_mono/_mono_right), and the {A,B}² 4-term block refining into 16 sub-cells — diagonal A²,B² and the (B,A) cross by monotonicity, only the single (A,B) cross carries the variance-atom gain. So the whole-partition floor ε⁴|A||B|/n² beats the one-sided partitionEnergy_gain_of_irregular_pair floor ε²/(8n²)."
+      "The sharp direct 2×2 gain (no factor-¼ loss) DOES lift to the whole partition cleanly: the ordered-pair double sum splits into R×R (untouched), A/B rows & cols vs R (pure pairEnergy_split_mono/_mono_right), and the {A,B}² 4-term block refining into 16 sub-cells — diagonal A²,B² and the (B,A) cross by monotonicity, only the single (A,B) cross carries the variance-atom gain. So the whole-partition floor ε⁴|A||B|/n² beats the one-sided partitionEnergy_gain_of_irregular_pair floor ε²/(8n²).",
+      "The sharp 2×2 route now has a complete termination certificate: the no-loss per-pair ε⁴ floor lifts to the whole partition (partitionEnergy_prod_gain_eps4) and then, under a minimum-refined-pair-mass hypothesis |A||B|≥M, feeds the same energy-iteration engine as the one-sided route to give N≤n²/(ε⁴M). The sharp bound beats the one-sided 2n²/ε² once refined pairs carry mass M>ε²n²/2. Termination engine partitionEnergy_iteration_bound takes a generic δ and returns N≤1/δ, so the only new content is the δ-positivity + one_div_div reshaping (δ=ε⁴M/n² ⇒ 1/δ=n²/(ε⁴M))."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Discharge the 10 freshness hypotheses of partitionEnergy_prod_refinement_gain from an equipartition/refinement model to obtain a fully-internal ∃P′ capstone from ¬IsEpsilonRegular (the remaining blocker, shared with partitionEnergy_gain_of_irregular_pair — witness cells A₁,A₂,B₁,B₂ must be certified distinct and ∉R).",
-      "Feed partitionEnergy_prod_gain_eps4 as the hstep of afks_energy_iteration_count with the SHARP floor to get N ≤ 2n²/(ε⁴·minmass) — the sharp iteration count from the no-loss route.",
+      "Discharge witness-cell freshness from a nonempty-parts / disjoint-partition model (A′⊆A, B′⊆B nonempty ⇒ all four cells distinct and disjoint from R-parts; handle the degenerate A′=A ⇒ A∖A′=∅ cell) to obtain a fully-internal ∃P′ sharp capstone from ¬IsEpsilonRegular — the remaining hard blocker.",
+      "Bound the minimum refined-pair mass M in terms of an equipartition (parts of size ≈n/k) to turn afks_sharp_energy_iteration_count into a k-explicit tower-free bound.",
       "Generalize 2×2 → m×k product refinement via Finset(Finset V) families + card_biUnion over a Finset.biUnion product partition.",
       "State two-level AFKS conclusion with dependent tolerance E:ℕ→(0,1]."
     ],
@@ -193,6 +195,11 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04Energy.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04Assembly.lean",
+      "lineCount": 234,
+      "theoremCount": 4
     }
   ],
   "lastUpdate": "2026-07-08T00:00:00Z"

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -26,7 +26,7 @@
     "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: two complementary threads verified 0/0. (Bridge) B-side branch closed via monotonicity-promotion (PART IX); both one-sided branches unified into the AFKS energy-increment step ε²/(8n²) (PART X, ∃ refined partition). (Energy, S7) increment analytic core closed — 2×2 law-of-total-density + variance-atom gain assemble the genuine ε⁴ energy increment (capstone pairEnergy_prod_refinement_gain built green).",
+    "progressSummary": "PROGRESS: the SHARP direct 2×2 energy increment (no factor-¼ loss) now lifts to the whole partition (partitionEnergy_prod_refinement_gain + ε⁴ floor partitionEnergy_prod_gain_eps4, VERIFIED 0/0). Remaining blocker for a fully-internal capstone is witness-cell freshness, shared with the one-sided route.",
     "builtItems": [
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
       "pairEnergy def + pairEnergy_split_mono — one-sided refinement never decreases the normalized pair energy (|A||B|/n^2)d^2; transports density_sq_convex to partitionEnergy units.",
@@ -53,7 +53,9 @@
       "edgeDensity_prod_split: law of total density for a 2×2 refinement, |A||B|d(A,B)=Σ|Aᵢ||Bⱼ|d(Aᵢ,Bⱼ) [VERIFIED]",
       "pairEnergy_prod_refinement_gain: the genuine ε⁴ 2×2 energy increment [VERIFIED — built green on retry attempt 4]",
       "pairEnergy_prod_gain_of_irregular: direct 2x2 energy increment from an irregular pair (no triangle detour) — refine both coordinates via the witness (A′,A\\A′,B′,B\\B′), gain (|A′||B′|/n²)·ε² [VERIFIED]",
-      "pairEnergy_prod_gain_of_irregular_eps4: explicit ε⁴·|A||B|/n² energy jump from ¬IsEpsilonRegular, the AFKS-consumable floor (no factor-¼ loss of the one-sided branches) [VERIFIED]"
+      "pairEnergy_prod_gain_of_irregular_eps4: explicit ε⁴·|A||B|/n² energy jump from ¬IsEpsilonRegular, the AFKS-consumable floor (no factor-¼ loss of the one-sided branches) [VERIFIED]",
+      "partitionEnergy_prod_refinement_gain (SzemerediRegularityOQ04Assembly.lean): sharp whole-partition 2×2 gain — refining two distinct parts A,B into {A₁,A₂}×{B₁,B₂} raises partitionEnergy by (|A₁||B₁|/n²)·d², d=|d(A₁,B₁)−d(A,B)|. Lifts pairEnergy_prod_refinement_gain via ordered-pair block decomposition.",
+      "partitionEnergy_prod_gain_eps4 (SzemerediRegularityOQ04Assembly.lean): AFKS-consumable ε⁴ floor of the sharp lift — ε-irregular pair refined on both coords raises whole-partition energy by ≥ ε⁴|A||B|/n², free of the one-sided factor-¼/⅛ loss."
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
@@ -72,15 +74,15 @@
       "The S5 mixed-second-difference (defect) obstruction is bypassed by treating the two-coordinate refinement as a weighted point distribution: the witness cell is one atom, and variance≥single-atom-contribution gives the energy gain directly, with no triangle-through-mixed-density detour.",
       "The ε-irregular witness deviation |d(A,B)−d(A,B)| is DIRECTLY against the coarse mean, so refining both coords simultaneously makes the witness cell a single variance atom — dodging the S5 mixed-second-difference defect entirely (no Cauchy–Schwarz on cross terms).",
       "Bool×Bool index + Fintype.sum_prod_type/sum_bool cleanly instantiates the abstract atom gain over 4 cells; linear_combination needs coeff −1 against edgeDensity_prod_split (whole=Σcells orientation).",
-      "Final /n² scaling: avoid convert (mis-pairs the + tree); prove goal=1/n²·raw via unfold+ring both sides then exact the scaled inequality."
+      "Final /n² scaling: avoid convert (mis-pairs the + tree); prove goal=1/n²·raw via unfold+ring both sides then exact the scaled inequality.",
+      "The sharp direct 2×2 gain (no factor-¼ loss) DOES lift to the whole partition cleanly: the ordered-pair double sum splits into R×R (untouched), A/B rows & cols vs R (pure pairEnergy_split_mono/_mono_right), and the {A,B}² 4-term block refining into 16 sub-cells — diagonal A²,B² and the (B,A) cross by monotonicity, only the single (A,B) cross carries the variance-atom gain. So the whole-partition floor ε⁴|A||B|/n² beats the one-sided partitionEnergy_gain_of_irregular_pair floor ε²/(8n²)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Wire pairEnergy_prod_gain_of_irregular_eps4 into whole-partition energy monotonicity (sum the per-pair ε⁴ jump over refined parts) feeding afks_energy_iteration_count (N≤2n²/ε²).",
-      "Full existential capstone from ¬IsEpsilonRegular directly: needs freshness of the INTERNALLY-chosen witness A′,B′, which the insert-model cannot guarantee — either work with the common refinement abstractly (dropping per-part ∉R conditions) or thread freshness as hypotheses",
-      "Assemble the outer AFKS loop: feed partitionEnergy_gain_of_irregular_pair as the hstep of afks_energy_iteration_count to bound refinements by 2n²/ε²",
-      "State two-level AFKS conclusion with dependent tolerance E:ℕ→(0,1]",
-      "Generalize 2×2 → m×k product refinement via Finset(Finset V) families + card_biUnion + edge_count over a Finset.biUnion product partition."
+      "Discharge the 10 freshness hypotheses of partitionEnergy_prod_refinement_gain from an equipartition/refinement model to obtain a fully-internal ∃P′ capstone from ¬IsEpsilonRegular (the remaining blocker, shared with partitionEnergy_gain_of_irregular_pair — witness cells A₁,A₂,B₁,B₂ must be certified distinct and ∉R).",
+      "Feed partitionEnergy_prod_gain_eps4 as the hstep of afks_energy_iteration_count with the SHARP floor to get N ≤ 2n²/(ε⁴·minmass) — the sharp iteration count from the no-loss route.",
+      "Generalize 2×2 → m×k product refinement via Finset(Finset V) families + card_biUnion over a Finset.biUnion product partition.",
+      "State two-level AFKS conclusion with dependent tolerance E:ℕ→(0,1]."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

New file `SzemerediRegularityOQ04Assembly.lean` (VERIFIED, 0 sorries / 0 axioms) that lifts the **sharp, no-loss** direct 2×2 energy increment to the whole partition and closes the sharp route as an end-to-end iteration certificate for the AFKS strong regularity lemma.

The companion `…Bridge` file already proves the sharp *per-pair* increment `pairEnergy_prod_gain_of_irregular_eps4`: refining an ε-irregular pair `(A,B)` simultaneously on **both** coordinates into `{A′,A∖A′}×{B′,B∖B′}` raises the four-cell `pairEnergy` sum by `≥ ε⁴·|A||B|/n²` with **no factor-¼ loss**. The whole-partition capstone that feeds the finiteness engine, however, previously routed through the one-sided branches and only realized the lossy floor `ε²/(8n²)`.

## What's proved

- **`partitionEnergy_prod_refinement_gain`** — the sharp per-partition 2×2 gain: replacing two distinct parts `A,B` by the 2×2 grid raises `partitionEnergy` by the sharp size-dependent increment `(|A₁||B₁|/n²)·d²`, `d = |d(A₁,B₁) − d(A,B)|`. Proof: expand the ordered-pair double sum into blocks — `R×R` untouched, rows/cols vs `R` split by pure `pairEnergy` monotonicity, and the `{A,B}²` block refines into 16 sub-cells with the single `(A,B)` cross carrying the variance-atom gain.
- **`partitionEnergy_prod_gain_eps4`** — the AFKS-consumable ε⁴ floor of that lift: `≥ ε⁴·|A||B|/n²`, free of the one-sided factor-¼/⅛ loss.
- **`afks_sharp_energy_iteration_count`** (new this session) — feeds the no-loss floor (`δ = ε⁴·M/n²`, `M` = uniform lower bound on refined-pair mass `|A||B|`) into the `[0,1]`-potential termination engine `partitionEnergy_iteration_bound` (`N ≤ 1/δ`), yielding the **sharp iteration count `N ≤ n²/(ε⁴·M)`**. This is the factor-¼-free counterpart of `afks_energy_iteration_count` (floor `ε²/(2n²)`, bound `N ≤ 2n²/ε²`); the sharp bound is strictly better once refined pairs carry mass `M > ε²n²/2`.

Together: per-pair ε⁴ gain → sharp whole-partition gain → sharp termination count, all machine-checked.

## Honest scope

`afks_sharp_energy_iteration_count` is a thin (but genuine) wrapper: the termination engine already takes a generic `δ` and returns `N ≤ 1/δ`, so the new content is δ-positivity plus the `one_div_div` reshaping — exactly parallel to the existing lossy `afks_energy_iteration_count`. The **remaining hard blocker** (unchanged) is discharging witness-cell freshness (`A₁,A₂,B₁,B₂` distinct and `∉ R`) from a nonempty-parts partition model to obtain a fully-internal `∃P′` capstone from `¬IsEpsilonRegular`; this is shared with the one-sided route.

## Verification

`Build completed successfully (7749 jobs)` via `docker-build.sh Proofs.SzemerediRegularityOQ04Assembly`. 0 `sorry`, 0 `axiom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)