### PR TITLE
Fix: sync stale erdos-761 meta counts to Lean source

### DIFF
--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -38,10 +38,10 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 314,
+    "lineCount": 483,
     "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation`; SimpleGraph.dichromNumber and SimpleGraph.cochromNumber are declared with `_root_.` prefix so dot notation `G.dichromNumber` continues to resolve. Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, dichrom_le_of_colorable, cochrom_le_of_colorable, dichrom_le_chromaticNumber, cochrom_le_chromaticNumber (Iter 9: ℕ∞ lifts to Mathlib's `SimpleGraph.chromaticNumber`), bipartite_dichrom_le_two (now a 1-line corollary of dichrom_le_of_colorable), dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 20,
     "definitionCount": 7,
     "additionalFiles": [
       "Proofs/Stubs/Erdos761Aristotle.lean"


### PR DESCRIPTION
## Fix

The `meta` count block for `erdos-761` was stale relative to the Lean source. `meta.lineCount` (314) was even smaller than the main file alone (483), and `meta.theoremCount` (11) was far below the actual 20.

## Evidence

Main file `proofs/Proofs/Erdos761Problem.lean` (comment-stripped): **483 lines, 20 theorems/lemmas, 7 defs, 2 axioms, 0 sorries**.

The `meta` block already correctly mirrored the main file for `definitionCount=7`, `axiomCount=2`, `sorries=0` — only `lineCount` and `theoremCount` were left stale after the file grew. The top-level block and `leanFile` block both already read 483/20, so the `meta` block was the lone outlier.

**Before**: `meta.lineCount=314`, `meta.theoremCount=11`
**After**: `meta.lineCount=483`, `meta.theoremCount=20` (now consistent with top-level and `leanFile` blocks)

Pure metadata fix; no Lean source changes.

---
Automated fix by lean-mechanic agent.