### PR TITLE
research(erdos-703): exact boundary value T(n,r)=2ⁿ for r>n [VERIFIED 0/0-new]

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -449,6 +449,40 @@ theorem one_le_T (n r : ℕ) (hr : 1 ≤ r) : 1 ≤ T n r := by
     _ ≤ _ := Finset.le_sup hmem
 
 /--
+**When `r` exceeds the ground set, the forbidden intersection size is
+unattainable.** Every `A, B ⊆ [n]` satisfy `|A ∩ B| ≤ |A| ≤ n < r`, so the
+entire powerset `2^{[n]}` is (vacuously) an `r`-avoiding family. -/
+theorem full_powerset_avoids_r_of_lt (n r : ℕ) (h : n < r) :
+    avoidsRIntersection r ((Finset.range n).powerset) := by
+  intro A B hA _hB
+  rw [Finset.mem_powerset] at hA
+  have hle : (A ∩ B).card ≤ n :=
+    calc (A ∩ B).card ≤ A.card := Finset.card_le_card Finset.inter_subset_left
+      _ ≤ (Finset.range n).card := Finset.card_le_card hA
+      _ = n := Finset.card_range n
+  omega
+
+/--
+**Exact value `T(n,r) = 2ⁿ` for `r > n`.**
+Once the forbidden intersection size `r` exceeds the ground-set size `n`, no two
+subsets of `[n]` can meet in exactly `r` points (`|A ∩ B| ≤ n < r`), so the whole
+powerset is a valid `r`-avoiding family of size `2ⁿ`. Together with the ceiling
+`T_le_pow`, this pins the value exactly. This is the degenerate large-`r`
+boundary of `T`, complementing the trivial small case `T(n,0) = 2^{n-1}`.
+-/
+theorem T_eq_pow_of_lt (n r : ℕ) (h : n < r) : T n r = 2 ^ n := by
+  refine le_antisymm (T_le_pow n r) ?_
+  unfold T
+  have hmem : (Finset.range n).powerset ∈
+      ((Finset.range n).powerset.powerset).filter (avoidsRIntersection r) := by
+    rw [Finset.mem_filter]
+    exact ⟨Finset.mem_powerset.mpr (Finset.Subset.refl _),
+      full_powerset_avoids_r_of_lt n r h⟩
+  calc 2 ^ n = ((Finset.range n).powerset).card := by
+        rw [Finset.card_powerset, Finset.card_range]
+    _ ≤ _ := Finset.le_sup hmem
+
+/--
 **The `r = 1` large-set family is contained in `franklFurediOdd n 1`.**
 `largeSetsFamily n` filters on `|A| > (n+1)/2`, exactly the "large" disjunct of
 `franklFurediOdd n 1` (whose threshold `(n+1)/2` coincides). So the general-`r`

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -49,10 +49,10 @@
       "largeSetsFamily / largeSetsFamily_avoids_1 / largeSetsFamily_card_le_T: Frankl's (1977) r=1 lower-bound construction — the family of sets larger than (n+1)/2 is a valid 1-avoiding family, giving a verified lower bound |largeSetsFamily n| ≤ T(n,1)"
     ],
     "axiomCount": 1,
-    "lineCount": 544,
+    "lineCount": 578,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 8
   },
   "crossReferences": [
@@ -186,9 +186,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 544,
+    "lineCount": 578,
     "axiomCount": 1,
-    "theoremCount": 17,
+    "theoremCount": 19,
     "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the exact **large-`r` boundary value** of `T(n,r)` (the maximum size of an `r`-avoiding family of subsets of `[n]`) to the Erdős #703 entry.

The problem `erdos-703-incomplete-01` was tagged "1 sorry to fill", but the file has **no `sorry`** (the lone match is the word "sorry" inside a docstring). The only genuinely open content is the deep Frankl–Rödl 1987 exponential bound, recorded as the axiom `frankl_rodl_1987` — not a session-sized target. So this PR instead extends the verified structural suite around `T` (`T_le_pow`, `T_mono_ground`, `one_le_T`, added recently in #36040).

## What's new

- **`full_powerset_avoids_r_of_lt (n r) (h : n < r)`** — when `r` exceeds the ground set, every `A, B ⊆ [n]` satisfy `|A ∩ B| ≤ |A| ≤ n < r`, so the *entire* powerset `2^{[n]}` is (vacuously) an `r`-avoiding family.
- **`T_eq_pow_of_lt (n r) (h : n < r) : T n r = 2^n`** — combining the above (lower bound `2ⁿ ≤ T` via `Finset.le_sup`) with the existing ceiling `T_le_pow` (`T ≤ 2ⁿ`) pins the value exactly by `le_antisymm`.

This is the degenerate large-`r` corner of `T`, complementing the file's trivial small case `T(n,0) = 2^{n-1}`.

## Verification

- Docker build green — `[7743/7743] Built Proofs.Erdos703Problem`.
- New proofs use only `omega` + `Finset` cardinality lemmas: **0 sorries, 0 new axioms**. The sole pre-existing assumption `frankl_rodl_1987` is unchanged, so the entry remains `axiomatized` (axiomCount 1).
- meta counts synced: `theoremCount` 17→19, `lineCount` 544→578.

## Honest scope note

This is a modest, elementary boundary value — it does not touch the main Erdős #703 question (the Frankl–Rödl `(2−δ)ⁿ` bound), which remains axiomatized. Its value is rounding out the exactly-known values of `T` alongside the existing `T(n,0)` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)