### PR TITLE
research(erdos-897-oq-01): structural properties of logSqWeight witness + Mathlib-drift repair [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -187,11 +187,10 @@ theorem unboundedOnPrimePowers_smul {f : ℕ → ℝ} (hf : UnboundedOnPrimePowe
   refine ⟨p, k, hp, hk, ?_⟩
   show c * f (p ^ k) > M * Real.log (p ^ k)
   have hstep : c * ((M / c) * Real.log (p ^ k)) < c * f (p ^ k) :=
-    (mul_lt_mul_left hc).mpr hgt
+    mul_lt_mul_of_pos_left hgt hc
   have heq : c * ((M / c) * Real.log (p ^ k)) = M * Real.log (p ^ k) := by
     have hc0 : c ≠ 0 := ne_of_gt hc
     field_simp
-    ring
   rwa [heq] at hstep
 
 /-- **Closure under adding a function nonnegative on prime powers.** If `f` is
@@ -347,5 +346,55 @@ theorem unboundedOnPrimePowers_of_ge_logSqWeight {g : ℕ → ℝ}
     (hg : ∀ p k : ℕ, p.Prime → 1 ≤ k → logSqWeight (p ^ k) ≤ g (p ^ k)) :
     UnboundedOnPrimePowers g :=
   unboundedOnPrimePowers_of_ge logSqWeight_unboundedOnPrimePowers hg
+
+/-
+## (7) Structural properties of the witness `logSqWeight`
+
+Beyond additivity and unboundedness, `logSqWeight` is a *prime-support functional*: a
+sum of nonnegative terms indexed by the prime divisors of `n`. That shape alone forces
+four structural facts — nonnegativity, determination by the prime support, monotonicity
+under divisibility, and an exact zero-set `{0, 1}` — which together explain why it is the
+natural *minimal* witness: every larger prime-support functional dominates it, feeding the
+cone of (6).
+-/
+
+/-- `logSqWeight` is nonnegative — it is a sum of squares. -/
+theorem logSqWeight_nonneg (n : ℕ) : 0 ≤ logSqWeight n :=
+  Finset.sum_nonneg (fun _ _ => sq_nonneg _)
+
+/-- **Prime-support determination.** `logSqWeight` depends only on the *set* of prime
+divisors: numbers with equal prime support have equal weight.  This is the structural
+root of strong additivity (`logSqWeight (p^k) = logSqWeight p`, since `p^k` and `p`
+share the prime support `{p}`). -/
+theorem logSqWeight_eq_of_primeFactors_eq {m n : ℕ}
+    (h : m.primeFactors = n.primeFactors) : logSqWeight m = logSqWeight n := by
+  simp only [logSqWeight, h]
+
+/-- **Monotonicity under divisibility.** If `m ∣ n` (with `n ≠ 0`) then
+`logSqWeight m ≤ logSqWeight n`: passing to a multiple only enlarges the prime support,
+and every term `(log p)²` is nonnegative. -/
+theorem logSqWeight_mono_of_dvd {m n : ℕ} (hn : n ≠ 0) (hmn : m ∣ n) :
+    logSqWeight m ≤ logSqWeight n :=
+  Finset.sum_le_sum_of_subset_of_nonneg
+    (Nat.primeFactors_mono hmn hn) (fun _ _ _ => sq_nonneg _)
+
+/-- **Exact zero-set.** `logSqWeight n = 0` iff `n` has no prime divisors, i.e. `n ∈ {0, 1}`.
+Every prime `p` contributes a strictly positive `(log p)²`, so any `n ≥ 2` has positive
+weight.  Combined with monotonicity this pins `logSqWeight` to the boundary of the positive
+cone: it is zero exactly on the units and grows off them. -/
+theorem logSqWeight_eq_zero_iff (n : ℕ) : logSqWeight n = 0 ↔ n = 0 ∨ n = 1 := by
+  rw [← Nat.primeFactors_eq_empty]
+  constructor
+  · intro h
+    by_contra hne
+    obtain ⟨p, hp⟩ := Finset.nonempty_of_ne_empty hne
+    have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+    have hlogpos : 0 < Real.log p := Real.log_pos (by exact_mod_cast hpp.one_lt)
+    have hterm : 0 < (Real.log p) ^ 2 := pow_pos hlogpos 2
+    have hz : (Real.log p) ^ 2 = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg (fun q _ => sq_nonneg _)).mp h p hp
+    exact absurd hz (ne_of_gt hterm)
+  · intro h
+    simp only [logSqWeight, h, Finset.sum_empty]
 
 end Erdos897

--- a/research/problems/erdos-897-oq-01/knowledge.md
+++ b/research/problems/erdos-897-oq-01/knowledge.md
@@ -54,3 +54,30 @@ Re-served an already-completed slug (file/gallery existed, verified). Added a
 File now 272 L, 13 thm / 1 def, 0 axioms, 0 sorries, no native_decide. VERIFIED
 (exit-135 line-less crash on 1st build = infra, passed on retry).
 Reused parent's `bigOmega_completelyAdditive` + `completelyAdditive_..._iff`.
+
+## Session 2026-07-08c (researcher-2) — structural properties of logSqWeight + Mathlib-drift repair
+
+Added new section (7) to `Erdos897OQ01.lean`: four genuinely-new structural facts about
+the witness `logSqWeight n = ∑_{p∈primeFactors n} (log p)²` as a *prime-support functional*
+(VERIFIED, whole file green, 0 axioms / 0 sorries / no native_decide):
+- `logSqWeight_nonneg` : 0 ≤ logSqWeight n (sum of squares, `Finset.sum_nonneg`+`sq_nonneg`).
+- `logSqWeight_eq_of_primeFactors_eq` : depends only on the prime support (`simp [logSqWeight,h]`);
+  the structural root of strong additivity.
+- `logSqWeight_mono_of_dvd` (n≠0, m∣n) : logSqWeight m ≤ logSqWeight n via
+  `Finset.sum_le_sum_of_subset_of_nonneg (Nat.primeFactors_mono hmn hn) (fun _ _ _ => sq_nonneg _)`.
+- `logSqWeight_eq_zero_iff` : logSqWeight n = 0 ↔ n=0∨n=1 (via `← Nat.primeFactors_eq_empty`;
+  forward by `Finset.sum_eq_zero_iff_of_nonneg` + each (log p)²>0 for prime p; reverse `sum_empty`).
+
+★MATHLIB-DRIFT REPAIR (bundled): the PRE-EXISTING merged `unboundedOnPrimePowers_smul`
+(from PR #35963) no longer built against the current pinned Mathlib — deterministic failures
+at lines 190/194 even on the pristine origin/main file (confirmed by building the untouched
+base) and even after a full `--repair-cache` olean refresh. Two drift symptoms:
+  - `(mul_lt_mul_left hc).mpr hgt` → "failed to synthesize" → replaced with the version-stable
+    `mul_lt_mul_of_pos_left hgt hc`.
+  - `field_simp; ring` → `field_simp` now fully closes the goal so `ring` errors "No goals to
+    be solved" → dropped the trailing `ring`.
+Both fixes are safe across Mathlib versions. This is why the file needed a rebuild-with-repair,
+not just a retry (the 135/139 crashes were ALSO present from fleet memory pressure, but the
+190/194 failure was genuine deterministic drift, not infra).
+
+File now 400 L / 21 thm / 1 def. Gallery meta synced (351→400, 17→21).

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -53,9 +53,9 @@
       "stronglyAdditive_unboundedOnPrimePowers_iff: a strongly-additive reduction collapsing UnboundedOnPrimePowers f to 'f(p)/log p unbounded over primes' — the strongly-additive counterpart of the parent's completely-additive reduction. Since f(p^k)=f(p) is constant in k, the binding case is k=1; the M<0 branch is handled by invoking the hypothesis at 0 (then f(p) > 0 ≥ M·log p)"
     ],
     "axiomCount": 0,
-    "lineCount": 351,
+    "lineCount": 400,
     "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries; proofs use no native_decide (so #print axioms shows only propext/Classical.choice/Quot.sound). Part I of Erdős #897 — whether the prime-power growth hypothesis forces limsup_n (f(n+1)-f(n))/log n = ∞ — remains OPEN and is NOT asserted; this entry proves only the verified surrounding theory (non-vacuity, selectivity, plain unboundedness, and the strongly-additive reduction).",
-    "theoremCount": 17,
+    "theoremCount": 21,
     "definitionCount": 1
   },
   "overview": {
@@ -129,11 +129,11 @@
       "Finset"
     ],
     "namespace": "Erdos897",
-    "lineCount": 351,
+    "lineCount": 400,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 17
+    "theoremCount": 21
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-897-oq-01.json
+++ b/src/data/research/problems/erdos-897-oq-01.json
@@ -35,13 +35,15 @@
       "not_unboundedOnPrimePowers_logN and not_unboundedOnPrimePowers_omega: selectivity of the hypothesis — the parent file's flagship additive functions log and ω both FAIL it. log sits exactly at the boundary (log(p^k)/log(p^k) = 1) and ω is bounded on prime powers (ω(p^k) = 1). The hypothesis therefore isolates functions growing strictly faster than log on prime powers.",
       "unboundedOnPrimePowers_unbounded: the hypothesis forces plain unboundedness — for every B some prime power has f(p^k) > B, obtained by dialing the defining constant M against the uniform lower bound log(p^k) ≥ log 2.",
       "stronglyAdditive_unboundedOnPrimePowers_iff: a strongly-additive reduction collapsing UnboundedOnPrimePowers f to 'f(p)/log p unbounded over primes', the strongly-additive counterpart of the parent file's completely-additive reduction. The cancellation is different: the value is constant in k, so the binding case is k = 1, and the M < 0 branch is handled by invoking the hypothesis at 0.",
-      "Gallery entry src/data/proofs/erdos-897-oq-01 (meta.json + annotations.json); Lean source proofs/Proofs/Erdos897OQ01.lean."
+      "Gallery entry src/data/proofs/erdos-897-oq-01 (meta.json + annotations.json); Lean source proofs/Proofs/Erdos897OQ01.lean.",
+      "Section (7) structural properties of logSqWeight (researcher-2, PR pending): logSqWeight_nonneg, logSqWeight_eq_of_primeFactors_eq (prime-support determination), logSqWeight_mono_of_dvd (divisor monotonicity), logSqWeight_eq_zero_iff (exact zero-set {0,1}). Characterizes the witness as a nonnegative, divisor-monotone, prime-support-determined functional vanishing exactly on the units. PLUS a bundled Mathlib-drift repair of the pre-existing unboundedOnPrimePowers_smul (mul_lt_mul_left -> mul_lt_mul_of_pos_left; dropped a now-redundant ring after field_simp) that had silently stopped building against current pinned Mathlib. Whole file VERIFIED green, 0 axioms / 0 sorries."
     ],
     "insights": [
       "**Non-vacuity matters for open problems**: without an explicit witness, Part I could be vacuously true. logSqWeight certifies the hypothesis is genuinely satisfiable — and by a strongly additive function, the most structured class.",
       "**The hypothesis is a strict growth condition**: log is the boundary (ratio identically 1) and ω is bounded on prime powers, so both flagship examples fail. The hypothesis selects functions growing strictly faster than log on prime powers.",
       "**Constant-in-k is the key to the strongly-additive reduction**: unlike the completely-additive case where k cancels in a ratio, here the value does not depend on k, so the worst case is simply k = 1.",
-      "**Squaring the log is the cheapest super-log weight**: (log p)²/log p = log p → ∞ gives the required divergence with a one-line estimate, avoiding any heavier construction."
+      "**Squaring the log is the cheapest super-log weight**: (log p)²/log p = log p → ∞ gives the required divergence with a one-line estimate, avoiding any heavier construction.",
+      "The merged Erdos897OQ01.lean had silently drifted out of buildability against current pinned Mathlib (unboundedOnPrimePowers_smul, lines 190/194): field_simp now closes the goal making a trailing ring error 'No goals', and (mul_lt_mul_left hc).mpr fails to synthesize. Confirmed genuine (not infra) by building the pristine origin/main file after a full --repair-cache. Version-stable replacements: mul_lt_mul_of_pos_left and dropping the redundant ring."
     ],
     "mathlibGaps": [],
     "nextSteps": []


### PR DESCRIPTION
## Summary

Two things, both verified by a full green Docker rebuild of `Erdos897OQ01.lean` (exit 0, **0 axioms, 0 sorries, no `native_decide`**).

### 1. New structural theory of the witness `logSqWeight` (section 7)
The file already establishes non-vacuity, selectivity, the positive-cone closure, the strongly-additive reduction, and the cone-of-witnesses. This adds four structural facts that characterize the witness `logSqWeight n = ∑_{p ∣ n} (log p)²` as a **prime-support functional**:
- `logSqWeight_nonneg`: `0 ≤ logSqWeight n` (a sum of squares).
- `logSqWeight_eq_of_primeFactors_eq`: depends only on the *set* of prime divisors — the structural root of strong additivity.
- `logSqWeight_mono_of_dvd`: `m ∣ n` (`n ≠ 0`) ⟹ `logSqWeight m ≤ logSqWeight n` (divisor monotonicity: the prime support only grows, terms are nonnegative).
- `logSqWeight_eq_zero_iff`: `logSqWeight n = 0 ↔ n ∈ {0, 1}` (every prime contributes a strictly positive `(log p)²`, so the weight vanishes exactly on the units).

Together: the witness is nonnegative, divisor-monotone, determined by the prime support, and zero exactly on `{0,1}` — pinning it to the boundary of the positive cone and explaining why it is the natural minimal witness feeding the cone-of-witnesses.

### 2. Mathlib-drift repair of a pre-existing merged break
The already-merged `unboundedOnPrimePowers_smul` (PR #35963) **no longer built** against the current pinned Mathlib — deterministic failures at lines 190/194, confirmed on the pristine `origin/main` file even after a full olean `--repair-cache`. Two version-stable fixes:
- `(mul_lt_mul_left hc).mpr hgt` → `mul_lt_mul_of_pos_left hgt hc` ("failed to synthesize" → stable lemma).
- `field_simp` now closes the goal, so the trailing `ring` (which errored "No goals to be solved") is dropped.

This is why the file needed a rebuild-with-repair rather than a retry; the 135/139 crashes seen alongside were fleet memory pressure, but the 190/194 failure was genuine drift.

### Verification
Docker build green (exit 0) after olean cache repair. Gallery meta synced (351→400 lines, 17→21 theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)