### PR TITLE
research(shannon-awgn-oq-02-oq-02): strict multivariate stddev triangle trichotomy [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -1115,4 +1115,45 @@ theorem stddev_sum_eq_iff_pairwise_correlation_eq_one [IsFiniteMeasure μ] {ι :
     rw [correlation] at hcorr
     exact (div_eq_one_iff_eq (hden i hi j hj)).mp hcorr
 
+/-- **Strict multivariate standard-deviation triangle inequality (covariance form).**  For any
+finite family of square-integrable contributions the L² triangle inequality
+`σ[∑ᵢ Wᵢ] ≤ ∑ᵢ σ[Wᵢ]` of `stddev_sum_le` is *strict*,
+
+        √Var[∑ᵢ Wᵢ] < ∑ᵢ √Var[Wᵢ],
+
+*if and only if* **some** ordered pair fails to saturate the covariance Cauchy–Schwarz bound,
+`cov[Wᵢ, Wⱼ] ≠ √Var[Wᵢ]·√Var[Wⱼ]`.  The strict companion of
+`stddev_sum_eq_iff_pairwise_covariance_eq_sqrt`: the aggregate standard deviation reaches its ceiling
+exactly when *every* pair is tight and undershoots it the moment a single pair slackens.  Together
+with `stddev_sum_le` (`≤`) and the equality boundary (`=`) this closes the `≤ / = / <` trichotomy of
+the finite-family triangle inequality at the covariance level. -/
+theorem stddev_sum_lt_iff_pairwise_covariance_ne_sqrt [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i, MemLp (W i) 2 μ) :
+    Real.sqrt (Var[∑ i ∈ s, W i; μ]) < ∑ i ∈ s, Real.sqrt (Var[W i; μ]) ↔
+      ¬ ∀ i ∈ s, ∀ j ∈ s,
+        cov[W i, W j; μ] = Real.sqrt (Var[W i; μ]) * Real.sqrt (Var[W j; μ]) := by
+  rw [lt_iff_le_and_ne]
+  simp only [stddev_sum_le hW s, true_and, ne_eq, not_iff_not]
+  exact stddev_sum_eq_iff_pairwise_covariance_eq_sqrt (fun i _ => hW i)
+
+/-- **Strict multivariate standard-deviation triangle inequality (correlation form).**  For a finite
+family of *non-degenerate* square-integrable contributions (`Var[Wᵢ] ≠ 0` for all `i ∈ s`) the
+aggregate standard deviations add *strictly*,
+
+        √Var[∑ᵢ Wᵢ] < ∑ᵢ √Var[Wᵢ],
+
+*if and only if* the family is **not** fully perfectly-positively-correlated, i.e. some pair has
+`ρ[Wᵢ, Wⱼ] ≠ 1`.  The strict companion of `stddev_sum_eq_iff_pairwise_correlation_eq_one` and the
+multivariate capstone of the two-variable `stddev_add_lt_iff_correlation_lt_one`: perfect alignment
+of *every* pair is exactly the razor's edge where the triangle inequality becomes an equality, and
+any deviation from it makes the aggregate standard deviation strictly smaller than the sum. -/
+theorem stddev_sum_lt_iff_pairwise_correlation_ne_one [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (hW : ∀ i, MemLp (W i) 2 μ)
+    (hnd : ∀ i ∈ s, Var[W i; μ] ≠ 0) :
+    Real.sqrt (Var[∑ i ∈ s, W i; μ]) < ∑ i ∈ s, Real.sqrt (Var[W i; μ]) ↔
+      ¬ ∀ i ∈ s, ∀ j ∈ s, correlation (W i) (W j) μ = 1 := by
+  rw [lt_iff_le_and_ne]
+  simp only [stddev_sum_le hW s, true_and, ne_eq, not_iff_not]
+  exact stddev_sum_eq_iff_pairwise_correlation_eq_one (fun i _ => hW i) hnd
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 1118,
+    "lineCount": 1159,
     "axiomCount": 0,
-    "theoremCount": 46,
+    "theoremCount": 48,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 1118,
-    "theoremCount": 46,
+    "lineCount": 1159,
+    "theoremCount": 48,
     "definitionCount": 1,
     "badge": "mathlib",
     "originalContributions": [


### PR DESCRIPTION
## Summary

Completes the `≤ / = / <` trichotomy of the **finite-family standard-deviation triangle inequality** `σ[∑ᵢ Wᵢ] ≤ ∑ᵢ σ[Wᵢ]` (`stddev_sum_le`) by adding its two strict companions, in both covariance and correlation form:

- `stddev_sum_lt_iff_pairwise_covariance_ne_sqrt` — `√Var[∑ᵢ Wᵢ] < ∑ᵢ √Var[Wᵢ]` **iff** some ordered pair fails to saturate the covariance Cauchy–Schwarz bound (`cov[Wᵢ,Wⱼ] ≠ √Var[Wᵢ]·√Var[Wⱼ]`). No non-degeneracy hypothesis.
- `stddev_sum_lt_iff_pairwise_correlation_ne_one` — for non-degenerate contributions (`Var[Wᵢ]≠0`), the aggregate std-dev is strictly below the sum **iff** the family is not fully perfectly-positively-correlated, i.e. some pair has `ρ[Wᵢ,Wⱼ] ≠ 1`.

These are the multivariate lift of the two-variable `stddev_add_lt_iff_correlation_lt_one`, and the strict duals of the equality-boundary theorems `stddev_sum_eq_iff_pairwise_covariance_eq_sqrt` / `stddev_sum_eq_iff_pairwise_correlation_eq_one` already in the gallery. Each proof is a 3-line corollary: `lt_iff_le_and_ne` on `stddev_sum_le` collapses the strict inequality to the negation of the equality boundary via `not_iff_not`.

## Verification

- Docker build green `[7743/7743]`, **0 sorry / 0 axiom**.
- Branch based on current `origin/main`; net diff is exactly the 2 new theorems + meta count sync (1118→1159 lines, 46→48 theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)