### PR TITLE
Fix: sync stale meta counts (erdos-1090, erdos-761)

### DIFF
--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -70,9 +70,9 @@
       "helly_planar (0-axiom): proves the previously-unproved placeholder HellyProperty 2 for the plane by specializing Mathlib's Convex.helly_theorem_set to finrank ℝ ℝ² = 2 — every finite family of ≥3 planar convex sets whose 3-element subfamilies each intersect has a common point (classical planar Helly number d+1=3)"
     ],
     "axiomCount": 0,
-    "lineCount": 777,
+    "lineCount": 805,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 18
   },
   "overview": {

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -38,10 +38,10 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 314,
+    "lineCount": 483,
     "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation`; SimpleGraph.dichromNumber and SimpleGraph.cochromNumber are declared with `_root_.` prefix so dot notation `G.dichromNumber` continues to resolve. Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, dichrom_le_of_colorable, cochrom_le_of_colorable, dichrom_le_chromaticNumber, cochrom_le_chromaticNumber (Iter 9: ℕ∞ lifts to Mathlib's `SimpleGraph.chromaticNumber`), bipartite_dichrom_le_two (now a 1-line corollary of dichrom_le_of_colorable), dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 20,
     "definitionCount": 7,
     "additionalFiles": [
       "Proofs/Stubs/Erdos761Aristotle.lean"


### PR DESCRIPTION
## Fix

Two gallery entries carried stale line/theorem counts in their `meta` sub-block while the `leanFile` block (and, for erdos-761, the top-level fields) already reflected the current Lean source.

## Evidence

**erdos-1090** (`Proofs/Erdos1090Problem.lean`, no additionalFiles):
- `meta.lineCount` 777 → **805** (`wc -l` = 805)
- `meta.theoremCount` 16 → **18** (comment-stripped + raw grep = 18; matches `leanFile.theoremCount`)

**erdos-761** (`Proofs/Erdos761Problem.lean`):
- `meta.lineCount` 314 → **483** (`wc -l` = 483)
- `meta.theoremCount` 11 → **20** (top-level `theoremCount` and `leanFile.theoremCount` already agree on 20)

Both are single-main-file drifts (the large meta≫leanFile gaps in other entries are the legitimate additionalFiles-aggregate convention and were left untouched). `definitionCount`/`axiomCount`/`sorries` already matched and were not changed. Prose/`assumptions` fields untouched (enricher scope).

---
Automated fix by lean-mechanic agent.