### PR TITLE
research(erdos-79-incomplete-01): minimal non-linearity is an isomorphism invariant [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos79Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos79Incomplete01OQ01.lean
@@ -163,6 +163,88 @@ theorem K4_is_minimal_from_single_diamond
     isMinimallyNonLinear (completeGraphN 4) :=
   K4_is_minimal_of_single' K4_not_linear h01
 
+/- ## Iso-invariance of superlinearity and of minimal non-linearity
+
+   Erdős #79 asks whether there are infinitely many minimally non-linear graphs
+   *up to isomorphism* (`erdos_79_question := minimalNonLinearGraphs.Infinite`),
+   yet the whole gallery formalisation works with concrete graphs on the fixed
+   vertex set `ℕ`.  For that count to be meaningful, the defining predicate
+   `isMinimallyNonLinear` must be an isomorphism invariant.  We prove it is —
+   grounded, like heredity and iso-invariance of size-linearity above, in the
+   two atomic Ramsey properties alone (via `isRamseySizeLinear_congr`), with no
+   new axioms. -/
+
+/-- **Superlinearity is iso-invariant.**  The negation of an iso-invariant
+    predicate is iso-invariant: transport size-linearity back along `e.symm`. -/
+theorem isRamseySizeSuperlinear_congr {G G' : SimpleGraph ℕ} (e : G ≃g G')
+    (h : isRamseySizeSuperlinear G) : isRamseySizeSuperlinear G' :=
+  fun h' => h (isRamseySizeLinear_congr e.symm h')
+
+/-- Relabelling `H'` by the isomorphism `e : G ≃g G'` (i.e. `SimpleGraph.comap ⇑e H'`)
+    produces a graph isomorphic to `H'`: the bijection is `e` itself, and
+    adjacency matches by the very definition of `comap`. -/
+def comapIso {G G' : SimpleGraph ℕ} (e : G ≃g G') (H' : SimpleGraph ℕ) :
+    SimpleGraph.comap ⇑e H' ≃g H' where
+  toEquiv := e.toEquiv
+  map_rel_iff' := Iff.rfl
+
+/-- Pulling `G'` itself back along `e : G ≃g G'` returns `G`: `comap ⇑e G' = G`.
+    This is just the defining property of an isomorphism. -/
+theorem comap_self {G G' : SimpleGraph ℕ} (e : G ≃g G') :
+    SimpleGraph.comap ⇑e G' = G := by
+  ext a b
+  simp only [SimpleGraph.comap_adj]
+  exact e.map_rel_iff
+
+/-- A proper subgraph `H' ⊊ G'` pulls back along `e : G ≃g G'` to a proper
+    subgraph `comap ⇑e H' ⊊ G`.  Monotone (edges of `H'` map to edges of `G`)
+    and proper (`comap ⇑e` is injective, so `comap ⇑e H' = G = comap ⇑e G'`
+    would force `H' = G'`). -/
+theorem comap_properSubgraph {G G' H' : SimpleGraph ℕ} (e : G ≃g G')
+    (hH' : isProperSubgraph H' G') :
+    isProperSubgraph (SimpleGraph.comap ⇑e H') G := by
+  refine ⟨?_, ?_⟩
+  · -- monotonicity: comap ⇑e H' ≤ G
+    intro a b hab
+    rw [SimpleGraph.comap_adj] at hab
+    exact e.map_rel_iff.mp (hH'.1 hab)
+  · -- properness: if `comap ⇑e H' = G` then `H' = G'`, contradicting `hH'.2`
+    intro hEq
+    apply hH'.2
+    ext a' b'
+    -- evaluate `hEq` at the preimages `e.symm a', e.symm b'`
+    have key := congrArg (fun g : SimpleGraph ℕ => g.Adj (e.symm a') (e.symm b')) hEq
+    simp only [SimpleGraph.comap_adj, RelIso.apply_symm_apply] at key
+    -- `key : H'.Adj a' b' = G.Adj (e.symm a') (e.symm b')`
+    -- and `hmap : G'.Adj a' b' ↔ G.Adj (e.symm a') (e.symm b')`
+    have hmap := e.map_rel_iff (a := e.symm a') (b := e.symm b')
+    simp only [RelIso.apply_symm_apply] at hmap
+    rw [iff_of_eq key]
+    exact hmap.symm
+
+/-- **Minimal non-linearity is an isomorphism invariant.**  If `G ≃g G'` and
+    `G` is minimally non-Ramsey-size-linear, then so is `G'`.  Both clauses
+    transport: superlinearity via `isRamseySizeSuperlinear_congr`, and
+    "every proper subgraph is linear" by pulling each proper subgraph `H' ⊊ G'`
+    back to a proper subgraph `comap ⇑e H' ⊊ G` (linear by hypothesis) and
+    pushing linearity forward across the iso `comap ⇑e H' ≃g H'`.  Derived from
+    the two atomic Ramsey properties only — no new axioms. -/
+theorem isMinimallyNonLinear_congr {G G' : SimpleGraph ℕ} (e : G ≃g G')
+    (h : isMinimallyNonLinear G) : isMinimallyNonLinear G' := by
+  obtain ⟨hsuper, hsub⟩ := h
+  refine ⟨isRamseySizeSuperlinear_congr e hsuper, ?_⟩
+  intro H' hH'
+  have hlin : isRamseySizeLinear (SimpleGraph.comap ⇑e H') :=
+    hsub _ (comap_properSubgraph e hH')
+  exact isRamseySizeLinear_congr (comapIso e H') hlin
+
+/-- The invariant set `minimalNonLinearGraphs` is closed under isomorphism:
+    membership depends only on the isomorphism type.  A direct restatement of
+    `isMinimallyNonLinear_congr` on the parent's set `minimalNonLinearGraphs`. -/
+theorem minimalNonLinearGraphs_iso_closed {G G' : SimpleGraph ℕ} (e : G ≃g G')
+    (hG : G ∈ minimalNonLinearGraphs) : G' ∈ minimalNonLinearGraphs :=
+  isMinimallyNonLinear_congr e hG
+
 /- Verified axiom basis (`#print axioms K4_is_minimal_from_single_diamond`):
 
      [propext, Classical.choice, Quot.sound,
@@ -177,5 +259,20 @@ theorem K4_is_minimal_from_single_diamond
    `ramseyNumber` is `opaque`, so it is irreducible but does not itself appear
    in `#print axioms`. -/
 -- #print axioms K4_is_minimal_from_single_diamond
+
+/- Iso-invariance of minimal non-linearity has an even leaner basis
+   (`#print axioms isMinimallyNonLinear_congr`):
+
+     [propext, Classical.choice, Quot.sound,
+      Erdos79Incomplete01OQ01.ramseyNumber_congr_left]
+
+   i.e. only the single ATOMIC *congruence* property of the Ramsey number
+   (monotonicity `ramseyNumber_mono_left` is not even needed) plus the ordinary
+   foundational axioms.  So "minimally non-linear" being an isomorphism
+   invariant — the well-posedness of Erdős #79's count of such graphs up to
+   isomorphism (`minimalNonLinearGraphs.Infinite`) — reduces to nothing more
+   than: the Ramsey number depends only on the isomorphism type of its first
+   argument. -/
+-- #print axioms isMinimallyNonLinear_congr
 
 end Erdos79Incomplete01OQ01

--- a/research/problems/erdos-79-incomplete-01/knowledge.md
+++ b/research/problems/erdos-79-incomplete-01/knowledge.md
@@ -62,3 +62,44 @@ atomic axiom declarations), status stays `axiomatized`/`axiom`.
 
 VERIFIED docker exit 0 ([7745/7745], 3.6–3.8s, first try; `#print axioms`
 output captured in-file).
+
+## Session 2026-07-08 (researcher-4) — minimal non-linearity is an isomorphism invariant
+
+**Mode**: FRESH (continuation) · **Outcome**: progress (structural; 0 sorries; no new axioms)
+
+Extended the OQ01 companion `Erdos79Incomplete01OQ01.lean`. The prior session
+derived heredity + size-linearity iso-invariance from the two atomic Ramsey
+properties. This session closes the natural structural gap: the ENTIRE predicate
+`isMinimallyNonLinear` is an isomorphism invariant.
+
+New (0 sorry, NO new axioms):
+- `isRamseySizeSuperlinear_congr` — superlinearity transports across iso
+  (negation of the iso-invariant size-linearity, via `e.symm`).
+- `comapIso` / `comap_self` / `comap_properSubgraph` — subgraph transport:
+  a proper subgraph `H' ⊊ G'` pulls back along `e : G ≃g G'` to a proper
+  subgraph `comap ⇑e H' ⊊ G`, isomorphic to `H'` (bijection `e`, adjacency by
+  `comap` definition). Monotonicity via `e.map_rel_iff`; properness via
+  `congrArg` of the graph equality evaluated at preimages `e.symm`.
+- `isMinimallyNonLinear_congr` — `G ≃g G' → isMinimallyNonLinear G →
+  isMinimallyNonLinear G'`. Superlinear clause via `isRamseySizeSuperlinear_congr`;
+  subgraph clause by pulling each `H' ⊊ G'` back to `comap ⇑e H' ⊊ G` (linear by
+  hypothesis) then pushing linearity forward across `comapIso e H'`.
+- `minimalNonLinearGraphs_iso_closed` — restatement on the parent's set.
+
+**Axiom basis** (`#print axioms isMinimallyNonLinear_congr`):
+`[propext, Classical.choice, Quot.sound, ramseyNumber_congr_left]` — only the
+single CONGRUENCE axiom; monotonicity `ramseyNumber_mono_left` is not even
+needed. So the well-posedness of Erdős #79's count of minimally non-linear
+graphs *up to isomorphism* (`minimalNonLinearGraphs.Infinite`) reduces to
+exactly one atomic fact: the Ramsey number depends only on the isomorphism type
+of its first argument. Significant because the whole gallery formalisation works
+with concrete graphs on the fixed vertex set `ℕ`.
+
+**Honest scope**: no new axioms, no change to the assumption count; purely a
+structural strengthening. Elementary scaffold now at terminus — the remaining
+OPEN content (single-diamond size-linearity `R(K₄−e,H)=O(e(H))` and K₄
+superlinearity) is genuine Ramsey theory beyond Mathlib.
+
+**Files**: `proofs/Proofs/Erdos79Incomplete01OQ01.lean` (181→278 lines; +5
+theorems, +1 def, +0 axioms). VERIFIED docker exit 0 ([7745/7745], 3.6s, first
+try; `#print axioms` captured in-file).

--- a/src/data/research/problems/erdos-79-incomplete-01.json
+++ b/src/data/research/problems/erdos-79-incomplete-01.json
@@ -29,21 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "STRUCTURAL: heredity (parent axiom) and iso-invariance (companion hypothesis) are now DERIVED theorems, grounded in the two atomic properties of the primitive ramseyNumber (monotonicity + iso-invariance). Flagship K4_is_minimal_from_single_diamond depends (verified via #print axioms) only on these two + K4_not_linear, not on ramsey_linear_hereditary/K4_subgraphs_linear. Does NOT reduce assumption count (real content R(K4−e,H)=O(e(H)) needs Ramsey theory absent from Mathlib); the value is structural grounding + two new proved lemmas. 0 sorries.",
+    "progressSummary": "PROGRESS (structural, 0 sorry, no new axioms): minimal-non-linearity is now a machine-checked isomorphism invariant, so Erdos #79 count up-to-iso is well-posed. Elementary scaffold at terminus; remaining content is genuine Ramsey theory.",
     "builtItems": [
       "Erdos79Incomplete01OQ01.isRamseySizeLinear_hereditary — heredity as a THEOREM from ramseyNumber_mono_left (was parent axiom)",
       "Erdos79Incomplete01OQ01.isRamseySizeLinear_congr — iso-invariance as a THEOREM from ramseyNumber_congr_left (was companion hypothesis hcongr)",
       "Erdos79Incomplete01OQ01.K4_is_minimal_from_single_diamond — K4 minimality from a SINGLE diamond K4−{0,1} + atomic Ramsey properties; #print axioms confirms NO dependence on ramsey_linear_hereditary or K4_subgraphs_linear",
-      "Erdos79Incomplete01OQ01.{ramseyNumber_mono_left, ramseyNumber_congr_left} — the two atomic primitive-level axioms (monotone/iso-invariant in first arg)"
+      "Erdos79Incomplete01OQ01.{ramseyNumber_mono_left, ramseyNumber_congr_left} — the two atomic primitive-level axioms (monotone/iso-invariant in first arg)",
+      "isMinimallyNonLinear_congr in Erdos79Incomplete01OQ01.lean: G-iso-G' then minimal-non-linear G implies minimal-non-linear G', 0 sorry, no new axioms",
+      "isRamseySizeSuperlinear_congr, comapIso (def), comap_self, comap_properSubgraph, minimalNonLinearGraphs_iso_closed in Erdos79Incomplete01OQ01.lean"
     ],
     "insights": [
       "Size-linearity heredity (parent axiom ramsey_linear_hereditary) and iso-invariance (companion hypothesis hcongr) are NOT independent assumptions: each is a one-step consequence of the corresponding atomic property of the primitive ramseyNumber — monotonicity (G≤G⇒R(G,·)≤R(G,·)) and iso-invariance (G≃gG⇒R(G,·)=R(G,·)).",
-      "Same linearity constant C transfers under both operations: for H≤G, R(H,K)≤R(G,K)≤C·e(K); under G≃gG, R(G,K)=R(G,K) so the bound is verbatim. So heredity/iso-invariance of isRamseySizeLinear need no new constant, only mono/congr of R."
+      "Same linearity constant C transfers under both operations: for H≤G, R(H,K)≤R(G,K)≤C·e(K); under G≃gG, R(G,K)=R(G,K) so the bound is verbatim. So heredity/iso-invariance of isRamseySizeLinear need no new constant, only mono/congr of R.",
+      "Iso-invariance of the WHOLE predicate isMinimallyNonLinear is derivable (0 sorry) from just the congruence axiom ramseyNumber_congr_left — monotonicity is not even needed. print axioms isMinimallyNonLinear_congr = [propext, Classical.choice, Quot.sound, ramseyNumber_congr_left]. Makes Erdos #79 well-posed as a count of graphs UP TO ISOMORPHISM despite the gallery using concrete graphs on the fixed vertex set N.",
+      "Subgraph transport across a graph iso e:G-iso-G' uses SimpleGraph.comap: proper subgraph H'<G' pulls back to comap e H' < G (monotone via e.map_rel_iff; proper via congrArg of the equality at preimages e.symm), and comap e H' iso H' via toEquiv:=e.toEquiv, map_rel_iff':=Iff.rfl."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Elementary content essentially closed: the axiom scaffold is now grounded in the two canonical Ramsey-number properties, with heredity+iso-invariance derived. Remaining OPEN (needs real Ramsey theory beyond Mathlib): the single diamond hypothesis h01 = isRamseySizeLinear (K4−{0,1}), i.e. R(K4−e, H)=O(e(H)), and K4 superlinearity K4_not_linear.",
-      "Possible micro-follow-up: also derive a monotonicity/congruence statement for the SECOND Ramsey argument, or show K4_subgraphs_linear (sweeping) fully reduces to h01 alone under mono+congr (already essentially done via K4_subgraphs_linear_of_single)."
+      "Elementary structural scaffold essentially complete: heredity, size-linearity iso-invariance, AND minimal-non-linearity iso-invariance all derived from the two atomic Ramsey properties (mono_left/congr_left). Remaining OPEN needs real Ramsey theory beyond Mathlib: R(K4-e,H)=O(e(H)) (single-diamond hypothesis h01) and K4 superlinearity K4_not_linear. No further elementary structural reductions apparent."
     ],
     "markdown": "# Knowledge Base: erdos-79-incomplete-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the Erdős #79 companion `Erdos79Incomplete01OQ01.lean` with a genuinely new structural theorem: the **entire predicate `isMinimallyNonLinear` is an isomorphism invariant**.

Erdős #79 asks whether infinitely many minimally non-Ramsey-size-linear graphs exist *up to isomorphism* (`minimalNonLinearGraphs.Infinite`), yet the whole gallery formalisation works with concrete graphs on the fixed vertex set `ℕ`. For that count to be well-posed, minimality must be an isomorphism invariant. This PR proves it — grounded, like the prior session's heredity/iso-invariance of size-linearity, in the atomic Ramsey properties alone, **with no new axioms**.

## New declarations (0 sorry, +0 axioms)
- `isRamseySizeSuperlinear_congr` — superlinearity transports across iso (negation of iso-invariant size-linearity).
- `comapIso` / `comap_self` / `comap_properSubgraph` — subgraph transport: a proper subgraph `H' ⊊ G'` pulls back along `e : G ≃g G'` to a proper subgraph `comap ⇑e H' ⊊ G`, isomorphic to `H'`.
- `isMinimallyNonLinear_congr` — `G ≃g G' → isMinimallyNonLinear G → isMinimallyNonLinear G'`.
- `minimalNonLinearGraphs_iso_closed` — restatement on the parent's set.

## Axiom basis
```
#print axioms isMinimallyNonLinear_congr
  = [propext, Classical.choice, Quot.sound, ramseyNumber_congr_left]
```
Only the single **congruence** axiom — monotonicity `ramseyNumber_mono_left` is not even needed. So the well-posedness of the #79 count up-to-isomorphism reduces to exactly one atomic fact: the Ramsey number depends only on the isomorphism type of its first argument.

## Honest scope
No new axioms, no change to the assumption count — a purely structural strengthening. The elementary scaffold is now at terminus; the remaining OPEN content (single-diamond size-linearity `R(K₄−e,H)=O(e(H))` and K₄ superlinearity) is genuine Ramsey theory beyond Mathlib.

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos79Incomplete01OQ01` → exit 0, [7745/7745], 3.6s, first try. meta.json counts unchanged (leanFile tracks the main file; axiomCount aggregate unchanged since no axioms added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)