### PR TITLE
research(szemeredi-regularity-oq-04): sharp ε⁴-route AFKS iteration count N ≤ n²/(ε⁴·m) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Bridge.lean
@@ -297,6 +297,38 @@ theorem afks_energy_iteration_count (G : SimpleGraph V) [DecidableRel G.Adj]
     (ε ^ 2 / (2 * (Fintype.card V : ℚ) ^ 2)) hδ hcover hdisjoint hstep
   rwa [one_div_div] at hbound
 
+/-- **Sharp AFKS iteration count (no-loss `ε⁴` route).**  The counterpart of
+    `afks_energy_iteration_count` for the *simultaneous* two-coordinate refinement of
+    `partitionEnergy_prod_gain_eps4`, which raises the whole-partition energy by the
+    sharp `ε⁴·|A||B|/n²` — free of the factor-`¼` loss the one-sided branches
+    (`partitionEnergy_gain_of_irregular_pair`) incur.  If every one of the first `N`
+    refinement steps clears the *uniform* floor `ε⁴·m/n²`, where `m` lower-bounds the
+    mass-product `|A||B|` of the refined pair, then
+
+    `N ≤ n² / (ε⁴·m)`.
+
+    Where the one-sided route pays `2n²/ε²`, the no-loss product route pays only
+    `n²/(ε⁴·m)`: once the refined cells carry macroscopic mass (`m ≳ 1/ε²`) the sharp
+    floor `ε⁴·m/n²` exceeds the one-sided `ε²/(2n²)`, so this is the tighter
+    finiteness bound.  Like its `ε²` sibling it is a thin corollary of the abstract
+    `[0,1]`-potential bound `partitionEnergy_iteration_bound`, here specialised to the
+    sharp floor that `partitionEnergy_prod_gain_eps4` supplies. -/
+theorem afks_energy_iteration_count_sharp (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (ε m : ℚ) (hε : 0 < ε) (hm : 0 < m)
+    (hcard : 0 < (Fintype.card V : ℚ))
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hstep : ∀ n, n < N →
+      partitionEnergy G (parts n) + ε ^ 4 * m / (Fintype.card V : ℚ) ^ 2 ≤
+        partitionEnergy G (parts (n + 1))) :
+    (N : ℚ) ≤ (Fintype.card V : ℚ) ^ 2 / (ε ^ 4 * m) := by
+  have hδ : 0 < ε ^ 4 * m / (Fintype.card V : ℚ) ^ 2 :=
+    div_pos (mul_pos (pow_pos hε 4) hm) (pow_pos hcard 2)
+  have hbound := Szemeredi.RegularityOQ04.partitionEnergy_iteration_bound G parts N
+    (ε ^ 4 * m / (Fintype.card V : ℚ) ^ 2) hδ hcover hdisjoint hstep
+  rwa [one_div_div] at hbound
+
 -- ═══════════════════════════════════════════════════════════════════
 -- PART V: FROM AN IRREGULARITY WITNESS TO THE TWO-HALVES DEVIATION
 -- ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Adds `afks_energy_iteration_count_sharp` to `SzemerediRegularityOQ04Bridge.lean` — the **sharp-route (no-loss) counterpart** of the existing `afks_energy_iteration_count`.

The one-sided refinement route yields the AFKS finiteness bound `N ≤ 2n²/ε²` from the uniform floor `ε²/(2n²)`. The *simultaneous two-coordinate* refinement `partitionEnergy_prod_gain_eps4` raises the whole-partition energy by the sharp `ε⁴·|A||B|/n²`, free of the factor-¼ loss the one-sided branches incur. Feeding that floor into the abstract `[0,1]`-potential bound `partitionEnergy_iteration_bound` (δ = ε⁴·m/n²) gives:

> If every one of the first `N` refinement steps clears the uniform floor `ε⁴·m/n²` (with `m` a lower bound on the refined pair's mass-product `|A||B|`), then **`N ≤ n²/(ε⁴·m)`**.

Once the refined cells carry macroscopic mass (`m ≳ 1/ε²`) the sharp floor exceeds the one-sided `ε²/(2n²)`, so this is the tighter finiteness count — the quantitative payoff of the no-loss product route. Like its ε² sibling it is a thin, honest corollary of the abstract engine; the value is pinning the sharp route's iteration count to an explicit `n²/(ε⁴·m)`.

## Verification
- Docker build green `[7748/7748]` (identical file content; base commit is unrelated erdos-1090 API work that does not touch szemeredi files)
- **0 sorry / 0 axiom**
- Abstract theorem (takes `hstep` as a hypothesis), so it is independent of the outstanding witness-cell freshness blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)