### PR TITLE
audit: fix mislabeled axioms in erdos-171/246 (gallery integrity)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9218,9 +9218,10 @@
     },
     "erdos-1036": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:09:22Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T06:05:27Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-1036-oq-01": {
       "auditCount": 1,
@@ -10576,9 +10577,11 @@
     },
     "erdos-1167": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:46:05Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T06:05:27Z",
+      "result": "clean",
+      "issues": [],
+      "note": "2026-07-09 audit CLEAN: 2 axioms (erdos_1167_conjecture OPEN, erdos_rado_theorem); the apparent 3rd axiom is comment prose (\"axiom count from 3 to 2\"); infinite_ramsey now genuinely proved."
     },
     "erdos-1168": {
       "auditCount": 3,
@@ -11350,10 +11353,11 @@
       "result": "clean"
     },
     "erdos-171": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T21:14:45Z",
-      "result": "clean"
+      "lastAudited": "2026-07-09T06:05:27Z",
+      "result": "issues-fixed",
+      "note": "2026-07-09 audit: FIXED originalContributions+proofStrategy that mislabeled proved theorems moser_spindle and isbell_upper_bound as \"Axiom\" (real axioms are isbell_coloring + de_grey_graph). Bumped meta.axiomCount 2->3 to disclose Lean.ofReduceBool (native_decide in moser_not_3_colorable discharges substantive chi>=4 lower bound); leanFile.axiomCount stays 2 (literal)."
     },
     "erdos-172": {
       "auditCount": 4,
@@ -11977,9 +11981,11 @@
     },
     "erdos-246": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T21:14:46Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T06:05:27Z",
+      "result": "issues-fixed",
+      "issues": [],
+      "note": "2026-07-09 audit: FIXED originalContributions bullet that called axiom greedyRepresentation a \"definition\" (it is an axiom; docstring says implementation axiomatized). 4 axioms correctly counted+disclosed in assumptions."
     },
     "erdos-247": {
       "agentId": "auditor-cycle-20-batch",
@@ -12002,9 +12008,11 @@
     },
     "erdos-248": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T21:14:46Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T06:05:27Z",
+      "result": "clean",
+      "issues": [],
+      "note": "2026-07-09 audit CLEAN: 9 native_decide all on trivial small-number facts (omega(6)=2, omega(1+k)<=2k); substantive erdos_248 is an axiom, so no ofReduceBool disclosure required."
     },
     "erdos-249": {
       "auditCount": 4,
@@ -29703,5 +29711,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T05:46:53Z"
+  "lastUpdated": "2026-07-09T06:05:27Z"
 }

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -49,13 +49,13 @@
       "Definition of UnitDistanceGraph as SimpleGraph on ℝ²",
       "Definition of IsProperColoring for unit distance graph",
       "Definition of chromaticNumberPlane via sInf",
-      "Axiom moser_spindle (7-vertex 4-chromatic graph)",
+      "Theorem moser_spindle: 7-vertex unit-distance graph is 4-chromatic — PROVED via explicit Q(√3,√11) coordinates (moserPt) with native_decide discharging non-3-colorability (moser_not_3_colorable)",
       "Axiom de_grey_graph (<2000 vertex 5-chromatic graph)",
-      "Axiom isbell_upper_bound (χ ≤ 7 via hexagonal tiling)",
+      "Axiom isbell_coloring: a proper 7-coloring of the plane exists (Isbell 1950); theorem isbell_upper_bound (χ ≤ 7) is proved from it via Nat.sInf_le",
       "Aristotle-verified: clique_number_3 (equilateral triangle)",
       "Aristotle-verified: no_4_clique (no tetrahedron in ℝ²)"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 302,
     "references": [
       {
@@ -82,7 +82,7 @@
         "description": "Optimizes de Grey's construction to 553 vertices requiring 5 colors"
       }
     ],
-    "assumptions": "2 axioms: isbell_coloring (7-coloring of plane exists via hexagonal tiling), de_grey_graph (de Grey's 2018 finite graph non-4-colorable). moser_spindle PROVED with explicit Q(√3,√11) coordinates + native_decide. 0 sorries.",
+    "assumptions": "3 assumptions: axioms isbell_coloring (a proper 7-coloring of the plane exists — Isbell 1950 upper bound) and de_grey_graph (de Grey's 2018 finite 5-chromatic unit-distance graph), plus Lean.ofReduceBool. The substantive lower bound moser_spindle / lower_bound_4 (χ ≥ 4) is PROVED via explicit Q(√3,√11) coordinates with native_decide discharging non-3-colorability (moser_not_3_colorable), which trusts the compiler kernel (Lean.ofReduceBool). 0 sorries; 2 literal axiom declarations.",
     "theoremCount": 16,
     "definitionCount": 5
   },
@@ -90,7 +90,7 @@
     "historicalContext": "The **Hadwiger-Nelson problem** asks for the chromatic number χ(ℝ²) of the unit distance graph: the minimum number of colors needed to color the plane so no two points at distance 1 share a color.\n\n**Historical Timeline**:\n- **1950**: Edward Nelson proved χ ≥ 4 using a 7-vertex graph (later called the Moser spindle)\n- **1950**: John Isbell proved χ ≤ 7 using a hexagonal tiling\n- **1950-2018**: No progress on the bounds for 68 years!\n- **2018**: Aubrey de Grey proved χ ≥ 5, finding a unit distance graph with ~1581 vertices that requires 5 colors\n\n**The de Grey Breakthrough**: After nearly 70 years with no improvement, de Grey used computer-aided construction to find a graph embedding where 4 colors are insufficient. This was later optimized to 553 vertices by Exoo and Ismailescu.\n\n**Current State**: 5 ≤ χ(ℝ²) ≤ 7. The exact value remains unknown.",
     "problemStatement": "**Erdős Problem #171**: What is the chromatic number $\\chi(\\mathbb{R}^2)$ of the unit distance graph?\n\n**Definition**: The **unit distance graph** $G$ has:\n- Vertices: All points in $\\mathbb{R}^2$\n- Edges: Connect points at Euclidean distance exactly 1\n\n**Question**: What is $\\chi(G)$, the minimum number of colors needed for a proper coloring (adjacent vertices have different colors)?\n\n**Known Bounds**:\n- **Lower**: $\\chi \\geq 5$ (de Grey 2018)\n- **Upper**: $\\chi \\leq 7$ (Isbell 1950)\n\n**Related Results**:\n- Clique number $\\omega = 3$ (equilateral triangle)\n- Fractional chromatic number $\\chi_f = 4$",
     "text": "What is the chromatic number χ(ℝ²) of the unit distance graph? The Hadwiger-Nelson problem. Nelson (1950): χ ≥ 4. Isbell (1950): χ ≤ 7. de Grey (2018): χ ≥ 5. Current knowledge: 5 ≤ χ(ℝ²) ≤ 7.",
-    "proofStrategy": "The formalization captures the structure of the problem and known results:\n\n1. **Core Definitions**:\n   - `UnitDistanceGraph`: SimpleGraph on EuclideanSpace ℝ (Fin 2)\n   - `IsProperColoring`: No adjacent vertices share colors\n   - `chromaticNumberPlane`: sInf of valid coloring counts\n\n2. **Lower Bounds** (proved):\n   - `moser_spindle`: 7-vertex graph requiring 4 colors (axiom)\n   - `lower_bound_4`: χ ≥ 4 (proved from Moser spindle via le_csInf + Fin restriction)\n   - `de_grey_graph`: <2000 vertex graph requiring 5 colors (axiom)\n   - `de_grey`: χ ≥ 5 (proved from de Grey graph via same pattern)\n\n3. **Upper Bound**:\n   - `isbell_coloring`: Witness axiom — a proper 7-coloring exists\n   - `isbell_upper_bound`: χ ≤ 7 (proved from isbell_coloring via Nat.sInf_le)\n\n4. **Clique Results** (Aristotle verified):\n   - `clique_number_3`: Equilateral triangle is a 3-clique\n   - `no_4_clique`: No 4-clique exists in ℝ²",
+    "proofStrategy": "The formalization captures the structure of the problem and known results:\n\n1. **Core Definitions**:\n   - `UnitDistanceGraph`: SimpleGraph on EuclideanSpace ℝ (Fin 2)\n   - `IsProperColoring`: No adjacent vertices share colors\n   - `chromaticNumberPlane`: sInf of valid coloring counts\n\n2. **Lower Bounds** (proved):\n   - `moser_spindle`: 7-vertex graph requiring 4 colors (theorem, proved via explicit Q(√3,√11) coordinates + native_decide)\n   - `lower_bound_4`: χ ≥ 4 (proved from Moser spindle via le_csInf + Fin restriction)\n   - `de_grey_graph`: <2000 vertex graph requiring 5 colors (axiom)\n   - `de_grey`: χ ≥ 5 (proved from de Grey graph via same pattern)\n\n3. **Upper Bound**:\n   - `isbell_coloring`: Witness axiom — a proper 7-coloring exists\n   - `isbell_upper_bound`: χ ≤ 7 (proved from isbell_coloring via Nat.sInf_le)\n\n4. **Clique Results** (Aristotle verified):\n   - `clique_number_3`: Equilateral triangle is a 3-clique\n   - `no_4_clique`: No 4-clique exists in ℝ²",
     "keyInsights": [
       "**The 68-year gap**: From 1950 to 2018, the best known bounds were 4 ≤ χ ≤ 7. De Grey's improvement to χ ≥ 5 was a major breakthrough.",
       "**Why is this hard?**: The graph is uncountable and highly symmetric. Local constructions (like Moser spindle) give limited information about the global chromatic number.",

--- a/src/data/proofs/erdos-246/meta.json
+++ b/src/data/proofs/erdos-246/meta.json
@@ -52,7 +52,7 @@
       "single_powers_not_complete axiom: powers of a ≥ 3 not complete",
       "powerSetUpTo definition",
       "numRepresentations definition",
-      "greedyRepresentation definition and greedy_eventually_works axiom"
+      "greedyRepresentation axiom (axiomatized List ℕ-valued greedy function) and greedy_eventually_works axiom"
     ],
     "axiomCount": 4,
     "lineCount": 186,


### PR DESCRIPTION
## Gallery Integrity Audit — erdős 17x/24x/10xx batch

Audited the next stalest cluster (last audited 2026-05-03). Two entries had disclosure-accuracy issues (meta.json fixed here); three were clean.

### erdos-171 — Hadwiger-Nelson (MEDIUM, fixed)
`originalContributions` and `proofStrategy` labeled the **proved theorems** `moser_spindle` and `isbell_upper_bound` as **"Axiom"**, contradicting the source and the entry's own `assumptions` field. The actual axioms are `isbell_coloring` (χ≤7 witness) and `de_grey_graph` (χ≥5). This mislabel *understated* genuine proved work — `moser_spindle` (χ≥4) is fully proved via explicit Q(√3,√11) coordinates with `native_decide` discharging non-3-colorability (`moser_not_3_colorable`).
- Corrected the two `originalContributions` bullets and the `proofStrategy` parenthetical.
- Bumped `meta.axiomCount` 2→3 to disclose **`Lean.ofReduceBool`**, since that `native_decide` discharges the *substantive* χ≥4 lower bound (Axiom Integrity Policy). `leanFile.axiomCount` stays 2 (literal declarations only) — detector allows meta > actual.

### erdos-246 — {aᵏbˡ} completeness (LOW, fixed)
`originalContributions` called the axiom `greedyRepresentation` a "definition"; it is an `axiom` (its own docstring: "the implementation is axiomatized"). Corrected. The 4 axioms are correctly counted and disclosed in `assumptions`.

### Clean (no changes)
| Entry | Notes |
|-------|-------|
| erdos-248 | 9 `native_decide` all on trivial small-n facts (omega(6)=2, omega(1+k)≤2k); substantive `erdos_248` is an axiom → no ofReduceBool disclosure required |
| erdos-1036 | 2 axioms (`shelah_1998`, `nonRamseyExists`), all theorems proved from them; empty originalContributions (no masking vector) |
| erdos-1167 | 2 axioms (`erdos_1167_conjecture` OPEN, `erdos_rado_theorem`); the apparent 3rd `axiom` grep-hit was comment prose ("axiom count from 3 to 2"); `infinite_ramsey` now genuinely proved |

All entries: `status: axiomatized`, `badge: axiom`, 0 sorries, no `True` stubs. Also persists audit-tracker timestamps the auditor loop's `git reset --hard` would otherwise clobber.

---
Discovered during autonomous gallery integrity audit. Label `loom:auditor`.