### PR TITLE
Enrich Leibniz–Lagrange Identity: full-file section coverage + references

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07-oq-02-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-02-oq-01/meta.json
@@ -51,25 +51,36 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Setup: Coordinate-Free Affine Framework",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Imports Mathlib and the module docstring situating this entry as the answer to the parent's (law-of-cosines-oq-07-oq-02) open question. Opens the RealInnerProductSpace scope and fixes the coordinate-free setting: a real inner product space V acting on a point space P as a NormedAddTorsor, so a, b, c, p are genuine points and distances are dist. No dimension or basis is chosen, so every result holds verbatim in every Euclidean affine space.",
+      "mathContext": "V a real inner product space, P a NormedAddTorsor over V; points a,b,c,p ∈ P with dist p x = ‖p -ᵥ x‖."
+    },
+    {
       "id": "part1-centroid",
       "title": "Part I: The Centroid and its Balance",
       "startLine": 53,
-      "endLine": 64,
-      "summary": "The explicit centroid centroid₃ a b c = ⅓·((b -ᵥ a)+(c -ᵥ a)) +ᵥ a, and its defining balance (a -ᵥ g)+(b -ᵥ g)+(c -ᵥ g) = 0 closed by the module tactic."
+      "endLine": 63,
+      "summary": "The explicit centroid centroid₃ a b c = ⅓·((b -ᵥ a)+(c -ᵥ a)) +ᵥ a, and its defining balance (a -ᵥ g)+(b -ᵥ g)+(c -ᵥ g) = 0 closed by the module tactic.",
+      "mathContext": "g = ⅓·((b -ᵥ a)+(c -ᵥ a)) +ᵥ a; balance: (a -ᵥ g)+(b -ᵥ g)+(c -ᵥ g)=0."
     },
     {
       "id": "part2-leibniz",
       "title": "Part II: The Leibniz / Lagrange Identity",
-      "startLine": 76,
-      "endLine": 98,
-      "summary": "For any balanced point g, dist(p,a)²+dist(p,b)²+dist(p,c)² = 3·dist(p,g)² + ∑ dist(g,vertex)², by polarising about g and killing the cross term with the balance hypothesis."
+      "startLine": 64,
+      "endLine": 97,
+      "summary": "For any balanced point g, dist(p,a)²+dist(p,b)²+dist(p,c)² = 3·dist(p,g)² + ∑ dist(g,vertex)², by polarising each squared distance about g (p -ᵥ vᵢ = (p -ᵥ g)+(g -ᵥ vᵢ), norm_add_sq_real) and killing the cross term 2⟪p -ᵥ g, ∑(g -ᵥ vᵢ)⟫ with the balance hypothesis.",
+      "mathContext": "∑ dist(p,vᵢ)² = 3·dist(p,g)² + ∑ dist(g,vᵢ)²; cross term 2⟪p -ᵥ g, (g -ᵥ a)+(g -ᵥ b)+(g -ᵥ c)⟫ = 0."
     },
     {
       "id": "part3-centroid-identity",
       "title": "Part III: The Centroid Moment Identity",
-      "startLine": 100,
-      "endLine": 133,
-      "summary": "Instantiation at the explicit centroid (leibniz_centroid) and the moment identity ∑ dist(g,vertex)² = ⅓·∑ side², from three vertex instances of the Leibniz identity."
+      "startLine": 98,
+      "endLine": 135,
+      "summary": "Instantiation at the explicit centroid (leibniz_centroid) and the moment identity ∑ dist(g,vertex)² = ⅓·∑ side², obtained by feeding the three vertex instances (p = a, b, c) of the Leibniz identity plus the dist symmetries into linarith.",
+      "mathContext": "∑ dist(g,vertex)² = ⅓·(dist(a,b)²+dist(b,c)²+dist(c,a)²), from leibniz_centroid at p ∈ {a,b,c}."
     }
   ],
   "conclusion": {
@@ -108,6 +119,18 @@
       "title": "Leibniz / Lagrange identity for barycentres (parallel axis theorem)",
       "year": 1700,
       "note": "Classical affine identity relating squared distances to a point and to the barycentre"
+    },
+    {
+      "author": "Joseph-Louis Lagrange",
+      "title": "Mécanique analytique",
+      "year": 1788,
+      "note": "The identity is also named for Lagrange, who used the barycentric decomposition of the moment of inertia; the constant term ∑ dist(g,vertex)² is the moment of inertia about the centroid, and the 3·dist(p,g)² term is the parallel-axis shift to an arbitrary point p."
+    },
+    {
+      "author": "H. S. M. Coxeter",
+      "title": "Introduction to Geometry",
+      "year": 1969,
+      "note": "Standard reference for the centroid/median relations of a triangle; §1.4 and the barycentric-coordinate chapters give the classical median-sum identity that this coordinate-free Leibniz identity generalises (the median sum is the p-ranges-over-vertices instance)."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `law-of-cosines-oq-07-oq-02-oq-01` (The Leibniz–Lagrange Identity for a Triangle).

Two structural gaps addressed (both verified against `Proofs/LawOfCosinesOQ07OQ02OQ01.lean`):

**Section coverage 3 → 4, now spanning the full file.** The `sections` array previously started at line 53, leaving the entire preamble (lines 1–52: imports, the module docstring, the `RealInnerProductSpace` scope, and the `NormedAddTorsor` variable setup) uncovered, plus inter-section gaps at 65–75, 99, and 134–135. Added a **Setup** section (1–52) describing the coordinate-free affine framework and made the remaining boundaries contiguous (53-63, 64-97, 98-135) so the sections span 1–135 exactly. Each section now carries a `mathContext` line.

**References 1 → 3.** The entry cited only Leibniz. Added Lagrange (*Mécanique analytique*, 1788 — the moment-of-inertia / parallel-axis reading where ∑ dist(g,vertex)² is the moment about the centroid and 3·dist(p,g)² the parallel-axis shift) and Coxeter (*Introduction to Geometry*, 1969 — the classical triangle median/centroid relations this coordinate-free identity generalises).

Size: meta.json 12.6 → 14.7 KB, well within the 60 KB cap. No content removed; status/badge/axiomCount (verified, original, 0) unchanged and accurate. Not superseded (origin/main still has 3 sections / 1 reference).