### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-03): fully general Fin 3 sign-change count (nonzero middle) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -243,6 +243,143 @@ theorem countSignChanges_three_mid_zero_zero {f : Fin 3 → ℝ}
   obtain ⟨rfl, rfl⟩ := hij02
   exact absurd hopp (not_lt.mpr h)
 
+/- ## § 2⅞. Three-term counts with a NON-zero middle (verified, axiom-free)
+
+The `§ 2¾` lemmas handle a *zero* middle coefficient (the quadratics the base
+file happened to axiomatise, `X² ± 1`).  A general quadratic `a·X² + b·X + c`
+with `b ≠ 0` has a nonzero middle entry, and then the count is governed by the
+two *adjacent* pairs `(0,1)` and `(1,2)` — the jump-over pair `(0,2)` is
+impossible once the middle entry is nonzero.  The count is therefore
+`[f 0·f 1 < 0] + [f 1·f 2 < 0]`, taking each of the values `0, 1, 2`.  We record
+the four sign patterns explicitly, which — together with `§ 2¾` — give the
+complete `Fin 3` sign-change count for every real length-3 sequence.  The value
+`2` (both adjacent pairs alternate) is genuinely new: a zero middle can never
+produce two sign changes, so this is exactly the quadratic case Descartes' bound
+allows to be *tight* (two coefficient sign changes, up to two positive roots). -/
+
+/-- **Two sign changes (strictly alternating).**  If both adjacent pairs of a
+`Fin 3 → ℝ` sequence have opposite signs (`f 0·f 1 < 0` and `f 1·f 2 < 0`, e.g.
+the pattern `+ − +`), then `f` has exactly two sign changes — the pairs `(0,1)`
+and `(1,2)`.  Axiom-free.  This is the maximal count for a length-3 sequence and
+is unreachable with a zero middle entry. -/
+theorem countSignChanges_three_alternating {f : Fin 3 → ℝ}
+    (h01 : f 0 * f 1 < 0) (h12 : f 1 * f 2 < 0) :
+    DescartesRuleOfSigns.countSignChanges f = 2 := by
+  have hf0 : f 0 ≠ 0 := fun he => by rw [he, zero_mul] at h01; exact lt_irrefl 0 h01
+  have hf1 : f 1 ≠ 0 := fun he => by rw [he, mul_zero] at h01; exact lt_irrefl 0 h01
+  have hf2 : f 2 ≠ 0 := fun he => by rw [he, mul_zero] at h12; exact lt_irrefl 0 h12
+  unfold DescartesRuleOfSigns.countSignChanges
+  rw [Finset.card_eq_two]
+  refine ⟨(0, 1), (1, 2), by decide, ?_⟩
+  ext ⟨i, j⟩
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert,
+    Finset.mem_singleton, decide_eq_true_eq, DescartesRuleOfSigns.SignChangeBetween,
+    DescartesRuleOfSigns.oppositeSign, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hij, _, _, hbtw, _⟩
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact Or.inl ⟨rfl, rfl⟩
+        | exact Or.inr ⟨rfl, rfl⟩
+        | exact absurd (hbtw 1 (by decide) (by decide)) hf1
+        | exact absurd hij (by decide)
+  · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩)
+    · refine ⟨by decide, hf0, hf1, ?_, h01⟩
+      intro k hk0 hk1
+      fin_cases k <;>
+        first
+          | exact absurd hk0 (by decide)
+          | exact absurd hk1 (by decide)
+    · refine ⟨by decide, hf1, hf2, ?_, h12⟩
+      intro k hk1 hk2
+      fin_cases k <;>
+        first
+          | exact absurd hk1 (by decide)
+          | exact absurd hk2 (by decide)
+
+/-- **One sign change, left pair (nonzero middle).**  If the first adjacent pair
+alternates (`f 0·f 1 < 0`) but the second does not (`0 ≤ f 1·f 2`), then `f` has
+exactly one sign change — the pair `(0,1)`. -/
+theorem countSignChanges_three_mid_ne_left {f : Fin 3 → ℝ}
+    (h01 : f 0 * f 1 < 0) (h12 : 0 ≤ f 1 * f 2) :
+    DescartesRuleOfSigns.countSignChanges f = 1 := by
+  have hf0 : f 0 ≠ 0 := fun he => by rw [he, zero_mul] at h01; exact lt_irrefl 0 h01
+  have hf1 : f 1 ≠ 0 := fun he => by rw [he, mul_zero] at h01; exact lt_irrefl 0 h01
+  unfold DescartesRuleOfSigns.countSignChanges
+  rw [Finset.card_eq_one]
+  refine ⟨(0, 1), ?_⟩
+  ext ⟨i, j⟩
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_singleton,
+    decide_eq_true_eq, DescartesRuleOfSigns.SignChangeBetween,
+    DescartesRuleOfSigns.oppositeSign, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hij, _, _, hbtw, hopp⟩
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact ⟨rfl, rfl⟩
+        | exact absurd (hbtw 1 (by decide) (by decide)) hf1
+        | exact absurd hopp (not_lt.mpr h12)
+        | exact absurd hij (by decide)
+  · rintro ⟨rfl, rfl⟩
+    refine ⟨by decide, hf0, hf1, ?_, h01⟩
+    intro k hk0 hk1
+    fin_cases k <;>
+      first
+        | exact absurd hk0 (by decide)
+        | exact absurd hk1 (by decide)
+
+/-- **One sign change, right pair (nonzero middle).**  If the second adjacent
+pair alternates (`f 1·f 2 < 0`) but the first does not (`0 ≤ f 0·f 1`), then `f`
+has exactly one sign change — the pair `(1,2)`. -/
+theorem countSignChanges_three_mid_ne_right {f : Fin 3 → ℝ}
+    (h01 : 0 ≤ f 0 * f 1) (h12 : f 1 * f 2 < 0) :
+    DescartesRuleOfSigns.countSignChanges f = 1 := by
+  have hf1 : f 1 ≠ 0 := fun he => by rw [he, zero_mul] at h12; exact lt_irrefl 0 h12
+  have hf2 : f 2 ≠ 0 := fun he => by rw [he, mul_zero] at h12; exact lt_irrefl 0 h12
+  unfold DescartesRuleOfSigns.countSignChanges
+  rw [Finset.card_eq_one]
+  refine ⟨(1, 2), ?_⟩
+  ext ⟨i, j⟩
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_singleton,
+    decide_eq_true_eq, DescartesRuleOfSigns.SignChangeBetween,
+    DescartesRuleOfSigns.oppositeSign, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hij, _, _, hbtw, hopp⟩
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact ⟨rfl, rfl⟩
+        | exact absurd (hbtw 1 (by decide) (by decide)) hf1
+        | exact absurd hopp (not_lt.mpr h01)
+        | exact absurd hij (by decide)
+  · rintro ⟨rfl, rfl⟩
+    refine ⟨by decide, hf1, hf2, ?_, h12⟩
+    intro k hk1 hk2
+    fin_cases k <;>
+      first
+        | exact absurd hk1 (by decide)
+        | exact absurd hk2 (by decide)
+
+/-- **No sign change (nonzero middle, both pairs non-alternating).**  If the
+middle entry is nonzero (`f 1 ≠ 0`) and neither adjacent pair has strictly
+opposite signs (`0 ≤ f 0·f 1` and `0 ≤ f 1·f 2`, e.g. the pattern `+ + +`), then
+`f` has no sign change.  Axiom-free. -/
+theorem countSignChanges_three_mid_ne_zero {f : Fin 3 → ℝ}
+    (hmid : f 1 ≠ 0) (h01 : 0 ≤ f 0 * f 1) (h12 : 0 ≤ f 1 * f 2) :
+    DescartesRuleOfSigns.countSignChanges f = 0 := by
+  unfold DescartesRuleOfSigns.countSignChanges
+  rw [Finset.card_eq_zero]
+  apply Finset.filter_eq_empty_iff.mpr
+  rintro ⟨i, j⟩ -
+  simp only [decide_eq_true_eq, DescartesRuleOfSigns.SignChangeBetween,
+    DescartesRuleOfSigns.oppositeSign]
+  rintro ⟨hij, _, _, hbtw, hopp⟩
+  fin_cases i <;> fin_cases j <;>
+    first
+      | exact absurd (hbtw 1 (by decide) (by decide)) hmid
+      | exact absurd hopp (not_lt.mpr h01)
+      | exact absurd hopp (not_lt.mpr h12)
+      | exact absurd hij (by decide)
+
 /- ## § 3. Axiom-free validation of the Sturm half on linear polynomials
 
 For `p = X − c` with `c > 0`, the gallery already proves (axiom-free) that the
@@ -380,6 +517,37 @@ theorem x2_plus_1_signChanges :
     have e2 : DescartesRuleOfSigns.coeffSequence (X ^ 2 + 1 : ℝ[X]) 2 2 = 1 := by
       simp [DescartesRuleOfSigns.coeffSequence, coeff_add, coeff_X_pow, coeff_one]
     rw [e0, e2]; norm_num
+
+/-- **`X² − X + 1` has two coefficient sign changes, computed axiom-free.**  The
+coefficient sequence is `[1, −1, 1]` (leading to constant): a strictly
+alternating pattern `+ − +` with nonzero middle, hence two sign changes — the
+maximal count, unreachable by the middle-zero `§ 2¾` lemmas.  This exercises the
+new `countSignChanges_three_alternating` and shows Descartes' bound is *attained*
+at the coefficient level (two sign changes allow up to two positive roots). -/
+theorem x2_minus_x_plus_1_signChanges :
+    signChangesInCoeffs (X ^ 2 - X + 1 : ℝ[X]) = 2 := by
+  have hne : (X ^ 2 - X + 1 : ℝ[X]) ≠ 0 := by
+    intro h
+    have : (X ^ 2 - X + 1 : ℝ[X]).coeff 2 = 0 := by rw [h]; simp
+    simp [coeff_add, coeff_sub, coeff_X_pow, coeff_X, coeff_one] at this
+  have hdeg : (X ^ 2 - X + 1 : ℝ[X]).natDegree = 2 := by compute_degree!
+  unfold signChangesInCoeffs
+  rw [dif_neg hne, hdeg]
+  apply countSignChanges_three_alternating
+  · have e0 : DescartesRuleOfSigns.coeffSequence (X ^ 2 - X + 1 : ℝ[X]) 2 0 = 1 := by
+      simp [DescartesRuleOfSigns.coeffSequence, coeff_add, coeff_sub, coeff_X_pow,
+        coeff_X, coeff_one]
+    have e1 : DescartesRuleOfSigns.coeffSequence (X ^ 2 - X + 1 : ℝ[X]) 2 1 = -1 := by
+      simp [DescartesRuleOfSigns.coeffSequence, coeff_add, coeff_sub, coeff_X_pow,
+        coeff_X, coeff_one]
+    rw [e0, e1]; norm_num
+  · have e1 : DescartesRuleOfSigns.coeffSequence (X ^ 2 - X + 1 : ℝ[X]) 2 1 = -1 := by
+      simp [DescartesRuleOfSigns.coeffSequence, coeff_add, coeff_sub, coeff_X_pow,
+        coeff_X, coeff_one]
+    have e2 : DescartesRuleOfSigns.coeffSequence (X ^ 2 - X + 1 : ℝ[X]) 2 2 = 1 := by
+      simp [DescartesRuleOfSigns.coeffSequence, coeff_add, coeff_sub, coeff_X_pow,
+        coeff_X, coeff_one]
+    rw [e1, e2]; norm_num
 
 end Quadratic
 

--- a/research/problems/descartes-rule-of-signs-oq-01-oq-03/state.md
+++ b/research/problems/descartes-rule-of-signs-oq-01-oq-03/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: SOLVED
 **Since**: 2026-06-25T21:00:00.000Z
-**Iteration**: 4
+**Iteration**: 5
 
 ## Current Focus
 
@@ -22,13 +22,37 @@ A prerequisite Mathlib-rot repair was made to the base file `Proofs/DescartesRul
 
 **Iteration 4 increment (2026-07-08):** carried out the iteration-3 "next intermediate step" — extended the axiom-free coefficient sign-change computation from `Fin 2` to the `Fin 3` middle-zero pattern. Two reusable lemmas, `countSignChanges_three_mid_zero_pos` (zero middle, opposite outer signs ⟹ one sign change, via the single pair `(0,2)`) and `countSignChanges_three_mid_zero_zero` (zero middle, non-opposite outer signs ⟹ no sign change, filter is empty), generalise `countSignChanges_two`. Using them, the base file's two *axiomatised* quadratic examples are now discharged **axiom-free** as theorems `x2_minus_1_signChanges : signChangesInCoeffs (X²−1) = 1` and `x2_plus_1_signChanges : signChangesInCoeffs (X²+1) = 0` (coefficient sequences `[1,0,−1]` and `[1,0,1]`; `natDegree = 2` via `compute_degree!`, coefficients via `simp [coeffSequence, coeff_sub/coeff_add, coeff_X_pow, coeff_one]`). This shows the base file's `example_x2_minus_1_sign_changes`/`example_x2_plus_1_sign_changes` axioms are removable. The entry stays `axiomatized` because the general-polynomial `SturmReduction` bridge remains a standing structural assumption.
 
+**Iteration 5 increment (2026-07-08, researcher-7):** carried out the iteration-4
+"further generalisation" — the **fully general `Fin 3` sign-change count with an
+arbitrary NON-zero middle**, completing the length-3 (quadratic) theory. Four
+axiom-free lemmas classify every sign pattern of a length-3 real sequence with
+`f 1 ≠ 0`: `countSignChanges_three_alternating` (both adjacent pairs opposite ⟹
+**2** — the maximal count, genuinely new since a zero middle can only give 0 or
+1), `countSignChanges_three_mid_ne_left`/`_right` (exactly one adjacent pair
+opposite ⟹ 1) and `countSignChanges_three_mid_ne_zero` (neither ⟹ 0). Together
+with the `§ 2¾` middle-zero lemmas these give the complete count
+`[f0·f1<0] + [f1·f2<0]` for **every** `Fin 3 → ℝ`, so all quadratics `aX²+bX+c`
+(`b ≠ 0` included) are covered. Validated on `X²−X+1` (coefficient sequence
+`[1,−1,1]`, pattern `+−+`) via the new axiom-free theorem
+`x2_minus_x_plus_1_signChanges : signChangesInCoeffs = 2` — the first count-2
+(Descartes-tight) evaluation. Docker VERIFIED
+(`Proofs.DescartesRuleOfSignsOQ01OQ03`, 3064 jobs, EXIT 0, 0 sorry / 0 axiom /
+no native_decide). leanFile 14→20 theorems, 386→554 lines.
+
 ## Blockers
 
 None.
 
 ## Next Action
 
-Solved. The remaining open direction is unchanged: prove the three comparison facts (B1)-(B3) for *general* polynomials to make the general Sturm ⟹ Descartes implication unconditional. Follow-up mechanical step now enabled: replace the two `axiom` declarations in the base gallery file `Proofs/DescartesRuleOfSigns.lean` with theorems (the proofs now exist in this entry as `x2_minus_1_signChanges`/`x2_plus_1_signChanges`; a base-file edit would need the `Fin 3` helpers relocated into the base file, since it cannot import this descendant). A further generalisation is a fully general `Fin 3` sign-change count (arbitrary nonzero middle) to handle quadratics `aX²+bX+c` with `b ≠ 0`.
+The `Fin 3` (quadratic) sign-change theory is COMPLETE. Remaining open directions
+(unchanged): (a) prove the three comparison facts (B1)-(B3) for *general*
+polynomials to make the general Sturm ⟹ Descartes implication unconditional;
+(b) the mechanical step of replacing the base file's two quadratic `axiom`
+declarations with theorems (proofs now exist here as `x2_minus_1_signChanges` /
+`x2_plus_1_signChanges`; needs the `Fin 3` helpers relocated into the base file,
+since it cannot import this descendant); (c) a general `Fin n` sign-change count
+(the length-3 case is now a template — adjacent pairs jumping across zero blocks).
 
 ## Attempt Counts
 

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
@@ -49,9 +49,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 386,
+    "lineCount": 554,
     "assumptions": "The general direction (Sturm ⟹ Descartes for an arbitrary polynomial) is a reduction: it is conditional on a `SturmReduction p` bridge structure whose five fields package Sturm's exact positive-root count on (0, B] together with the three classical coefficient-comparison facts σ_p(0) ≤ V(p), Even(V(p) − σ_p(0)), and Even(σ_p(B)). Per the project's axiom-integrity policy these structure fields are mathematical assumptions (counted here as axiomCount 1; obtaining the data for a general p requires Sturm's theorem, axiomatized in the parent entry as sturm_exact_count_axiom, plus standard Sturm/Descartes comparison theory). No `axiom` declarations and no sorries appear in the file (leanFile.axiomCount = 0). The reduction theorems (upper_bound_core, parity_core, descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm) are fully machine-checked implications, and the Sturm half is validated UNCONDITIONALLY and axiom-free on linear polynomials X − c (c > 0), reusing the gallery's axiom-free Sturm computations. The linear-polynomial validation (X − c, c > 0) is now fully unconditional and axiom-free: the coefficient sign-change count V(X − c) = 1 is computed directly (linear_signChanges, via the new axiom-free countSignChanges_two), so the previously-assumed hypothesis hV has been discharged and linearReduction/linear_descartes_bound carry no standing assumption for the linear case.",
-    "theoremCount": 14,
+    "theoremCount": 20,
     "mathlib_version": "4.26.0",
     "definitionCount": 2
   },
@@ -122,9 +122,9 @@
       "Proofs.DescartesRuleOfSignsOQ02OQ01OQ02"
     ],
     "namespace": "DescartesRuleOfSignsOQ01OQ03",
-    "lineCount": 386,
+    "lineCount": 554,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 20,
     "definitionCount": 2,
     "path": "Proofs/DescartesRuleOfSignsOQ01OQ03.lean",
     "sorries": 0

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
@@ -45,14 +45,19 @@
       "descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm",
       "linear_positiveRoots, linear_sturm_count, linearReduction, linear_descartes_bound (axiom-free linear validation)",
       "countSignChanges_three_mid_zero_pos / _zero: Fin 3 middle-zero sign-change counts (axiom-free), generalising countSignChanges_two",
-      "x2_minus_1_signChanges, x2_plus_1_signChanges: axiom-free evaluations discharging the base file's two quadratic sign-change axioms"
+      "x2_minus_1_signChanges, x2_plus_1_signChanges: axiom-free evaluations discharging the base file's two quadratic sign-change axioms",
+      "countSignChanges_three_alternating (r7): both adjacent pairs opposite => count 2 (the maximal Fin 3 count, unreachable with a zero middle) — axiom-free",
+      "countSignChanges_three_mid_ne_left / _mid_ne_right (r7): exactly one adjacent pair opposite (nonzero middle) => count 1 — axiom-free",
+      "countSignChanges_three_mid_ne_zero (r7): nonzero middle, neither adjacent pair opposite => count 0 — axiom-free; the four nonzero-middle lemmas + the middle-zero pair complete the Fin 3 count for every length-3 real sequence",
+      "x2_minus_x_plus_1_signChanges (r7): axiom-free evaluation signChangesInCoeffs (X^2 - X + 1) = 2 (coefficient sequence [1,-1,1]) — the first count-2 (Descartes-tight) quadratic validation"
     ],
     "insights": [
       "The entire 'exact count => bound + parity' content reduces to two omega lemmas once the count is written as a non-increasing difference hi - lo; the inequality and the parity fall out of upper_bound_core and parity_core respectively.",
       "Isolating Sturm's theorem and the classical comparison estimates as explicit hypotheses in a SturmReduction structure makes the general implication transparently conditional (a reduction), keeping the descent to Descartes pure combinatorics.",
       "The bridge structure is inhabitable: for linear factors X - c the three comparison facts trivialise to 1 <= 1, Even 0, Even 0, giving an end-to-end axiom-free instance via linearReduction.",
       "Gallery base file DescartesRuleOfSigns.lean had rotted against Mathlib 4.26.0 (Polynomial.card_roots_le_degree removed; Fin.castSucc_lt_succ arg now implicit; Multiset.countP_le_card needs explicit multiset) and required repair before any dependent could build.",
-      "The base file's axiomatised concrete counts (example_x2_minus_1_sign_changes = 1, example_x2_plus_1_sign_changes = 0) are removable: with a Fin 3 middle-zero sign-change lemma the coefficient sequences [1,0,-1] and [1,0,1] are counted axiom-free (natDegree via compute_degree!, coefficients via simp on coeffSequence/coeff_X_pow/coeff_one)."
+      "The base file's axiomatised concrete counts (example_x2_minus_1_sign_changes = 1, example_x2_plus_1_sign_changes = 0) are removable: with a Fin 3 middle-zero sign-change lemma the coefficient sequences [1,0,-1] and [1,0,1] are counted axiom-free (natDegree via compute_degree!, coefficients via simp on coeffSequence/coeff_X_pow/coeff_one).",
+      "The full Fin 3 sign-change count is governed by the two ADJACENT pairs: count = [f0*f1<0] + [f1*f2<0] whenever the middle f1 is nonzero (the jump-over pair (0,2) is impossible once f1 != 0). A zero middle instead activates (0,2) and caps the count at 1; so the value 2 is exactly the nonzero-middle alternating case, matching Descartes' bound being tight for quadratics with two positive roots (r7)."
     ],
     "mathlibGaps": [
       "No packaged Sturm-sequence sign-variation theory in Mathlib connecting sigma_p to the coefficient sign-change count V(p); the comparison facts (B1)-(B3) must be supplied as assumptions."


### PR DESCRIPTION
## Summary

Completes the length-3 (quadratic) coefficient sign-change theory for the Sturm ⟹ Descartes entry. Prior work (§2¾) covered a **zero** middle coefficient (the quadratics `X² ± 1` the base file happened to axiomatise), giving counts 0 or 1. This PR adds the arbitrary **nonzero** middle, where the count is governed by the two *adjacent* pairs `[f0·f1<0] + [f1·f2<0]` (the jump-over pair `(0,2)` is impossible once `f 1 ≠ 0`):

- `countSignChanges_three_alternating` — both adjacent pairs opposite ⟹ **2** (the maximal length-3 count, genuinely new: a zero middle can never produce two sign changes)
- `countSignChanges_three_mid_ne_left` / `_mid_ne_right` — exactly one adjacent pair opposite ⟹ **1**
- `countSignChanges_three_mid_ne_zero` — neither pair opposite (nonzero middle) ⟹ **0**

Together with the existing middle-zero lemmas, these classify **every** `Fin 3 → ℝ` sequence, so all quadratics `aX² + bX + c` (including `b ≠ 0`) are now covered — the "fully general Fin 3 count" flagged as the next step in the entry's state notes.

Validated by a new axiom-free evaluation `x2_minus_x_plus_1_signChanges : signChangesInCoeffs (X² − X + 1) = 2` (coefficient sequence `[1, −1, 1]`, pattern `+ − +`) — the first count-2 case, where Descartes' bound is tight (two coefficient sign changes ⟹ up to two positive roots).

## Verification

- Docker build `Proofs.DescartesRuleOfSignsOQ01OQ03`: **Build completed successfully** (3064 jobs, v4.26.0)
- 0 `sorry`, 0 `axiom` declarations, no `native_decide` in the new content
- 5 new theorems; leanFile 14 → 20 theorems, 386 → 554 lines; gallery meta counts synced

The entry remains `axiomatized` (the general-polynomial `SturmReduction` bridge is still a standing structural assumption); this PR only strengthens the axiom-free combinatorial sign-change layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)