### PR TITLE
Enrich Hexagrammum S₆ census: full-file section coverage + accurate summaries

### DIFF
--- a/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
@@ -82,20 +82,42 @@
     {
       "id": "intro-docstring",
       "startLine": 1,
-      "endLine": 74,
-      "title": "§0: Lineage, Conway–Ryba Indexing, and Honest Scope"
+      "endLine": 63,
+      "title": "§0: Lineage, Conway–Ryba Indexing, and Honest Scope",
+      "summary": "Imports and the module docstring: the parent lineage (pascals-hexagon → oq-03 scaffold → this file), the Conway–Ryba (2012) indexing of the 95-point/95-line Hexagrammum by S₆ conjugacy classes, the predicate/size table (720, 120, 40, 15), and an explicit honest-scope disclaimer that only the class sizes — not the projective bijection — are certified, and that native_decide makes the file depend on Lean.ofReduceBool (not axiom-free).",
+      "mathContext": "6-cycles ↔ 60 Pascal lines + 60 Kirkman points; (3,3) ↔ 20 Steiner + 20 Cayley; (2,2,2) ↔ 15 Plücker + 15 Salmon (self-paired)."
     },
     {
       "id": "predicates",
-      "startLine": 76,
-      "endLine": 129,
-      "title": "Cycle-type predicates and their Decidable instances"
+      "startLine": 64,
+      "endLine": 104,
+      "title": "Cycle-type predicates and their Decidable instances",
+      "summary": "The concrete group is Equiv.Perm (Fin 6). FixedPointFree σ := ∀ i, σ i ≠ i, then each relevant conjugacy class is pinned by an elementary power/fixed-point predicate rather than the cycleType API: IsSixCycle (fpf, σ⁶=1, σ²≠1, σ³≠1), IsDoubleThreeCycle (fpf, σ³=1), IsTripleTransposition (fpf, σ²=1). Each carries a hand-supplied Decidable instance so the later Finset.filter counts native-evaluate quickly.",
+      "mathContext": "Fixed-point-free cycle types of Fin 6 are (6),(4,2),(3,3),(2,2,2); power conditions σ²≠1, σ³≠1, σⁿ=1 select each."
     },
     {
       "id": "census",
-      "startLine": 131,
-      "endLine": 156,
-      "title": "The three census theorems (120 / 40 / 15) and object counts"
+      "startLine": 105,
+      "endLine": 129,
+      "title": "The three census theorems: |Sym(6)| = 720 and class sizes 120 / 40 / 15",
+      "summary": "The anchor card_sym6 (|Sym(6)| = 720) and the three governing class-size theorems, each discharged by native_decide over Finset.univ.filter: card_sixCycles = 120 (Pascal/Kirkman), card_doubleThreeCycles = 40 (Steiner/Cayley), card_tripleTranspositions = 15 (Plücker/Salmon, self-paired).",
+      "mathContext": "|Sym(6)|=720; 120 six-cycles, 40 double-3-cycles, 15 triple-transpositions."
+    },
+    {
+      "id": "completeness",
+      "startLine": 130,
+      "endLine": 184,
+      "title": "Completeness of the fixed-point-free census (the inert (4,2) class, D₆ = 265)",
+      "summary": "Adds the fourth fixed-point-free cycle type (4,2) — IsFourTwoCycle (fpf, σ⁴=1, σ²≠1), card_fourTwoCycles = 90 — which indexes NO Hexagrammum object. fixedPointFree_iff_census proves the four classes exhaust every derangement of Fin 6, card_fixedPointFree = 265 = D₆ is the sixth derangement number, and fixedPointFree_census_sum (120+90+40+15=265) forces the classes to be disjoint and exhaustive.",
+      "mathContext": "Derangements of Fin 6: D₆ = 265 = 120 + 90 + 40 + 15; the 90-element (4,2) class is geometrically inert."
+    },
+    {
+      "id": "object-counts",
+      "startLine": 185,
+      "endLine": 213,
+      "title": "Hexagrammum object counts and the (95₃, 95₃) totals",
+      "summary": "The geometric object counts as arithmetic corollaries of the census under the Conway–Ryba 2:1 outer-automorphism pairing (self-paired at the (2,2,2) class): 60 Pascal lines, 60 Kirkman points (120/2), 20 Steiner points, 20 Cayley–Salmon lines (40/2), 15 Plücker lines and 15 Salmon points; and the configuration totals 60+20+15 = 95 points and 95 lines, i.e. a (95₃, 95₃) configuration.",
+      "mathContext": "Points: 60 Kirkman + 20 Steiner + 15 Salmon = 95; lines: 60 Pascal + 20 Cayley + 15 Plücker = 95."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `pascals-hexagon-oq-03-incomplete-01` (Hexagrammum Mysticum: The S₆ Cycle-Type Census).

**Structural gap fixed: sections now span the full 213-line file.** The `sections` array previously covered only 1–74, 76–129, and 131–156, leaving lines **157–213 entirely uncovered** — the whole fixed-point-free classification (`fixedPointFree_iff_census`), the derangement count `card_fixedPointFree = 265 = D₆`, the census-closure sum, and *all* the Hexagrammum object-count theorems (60 Pascal / 60 Kirkman / 20 Steiner / 20 Cayley / 15 Plücker / 15 Salmon and the (95₃, 95₃) totals). Additionally, the old `census` section (131–156) was **mislabeled** — its title claimed 'the three census theorems (120/40/15) and object counts', but that range actually spans the (4,2)-completeness block, while the real census theorems live at 105–128 and the object counts at 185–213.

Rewrote the sections into five accurate, contiguous parts spanning 1–213, verified line-by-line against `Proofs/PascalsHexagonOQ03Incomplete01.lean`:
1. §0 docstring / lineage / honest scope (1–63)
2. Cycle-type predicates + Decidable instances (64–104)
3. The census: |Sym(6)|=720 and sizes 120/40/15 (105–129)
4. Completeness — the inert (4,2) class and D₆=265 (130–184)
5. Hexagrammum object counts and (95₃,95₃) totals (185–213)

Each section now carries a `summary` and `mathContext` (the originals had neither).

Size: meta.json 15.4 → 18.5 KB, within the 60 KB cap. No content removed. Axiom integrity unchanged and already correct: status `axiomatized`, badge `axiom`, axiomCount 1, `Lean.ofReduceBool` disclosed (native_decide on the census theorems). Not superseded (origin/main still has 3 sections).