### PR TITLE
Enrich Sylvester symmetry-removal: cover the uncovered preamble in sections

### DIFF
--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/meta.json
@@ -67,6 +67,14 @@
   },
   "sections": [
     {
+      "id": "context-setup",
+      "title": "Context: The Retained-Axiom Gap and Honest Scope",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Imports (Matrix multiplication/determinant, BigOperators) and the module docstring. Situates the file against PascalsHexagon.lean, whose Sylvester reduction sylvester_stdConic_of_isotropic carries a standing hC_sym hypothesis and whose residual axiom conic_implies_pascal_constraint is retained for the 'asymmetric and degenerate' cases. The parent's proof sketch lists 'replace C with symmetrized (C + Cᵀ)/2 (same zero set)' as its first outstanding step but never proves it — this file does, self-contained. States the honest scope: it removes the symmetry hypothesis from the reduction, not the hard indefinite-symmetric Sylvester direction, and reproduces the conic API locally because the parent is bit-rotted under toolchain 4.26.0. Opens the namespace; 0 sorries, 0 axiom declarations, no native_decide.",
+      "mathContext": "Reduce the general (possibly asymmetric) non-degenerate conic to the symmetric case via symmetrize C = (C + Cᵀ)/2."
+    },
+    {
       "id": "api",
       "title": "Minimal Conic API",
       "startLine": 53,


### PR DESCRIPTION
Enrichment pass for `pascals-hexagon-incomplete-01-oq-01` (Sylvester Reduction: Removing the Symmetry Hypothesis).

**Structural gap:** the `sections` array started at line 53, leaving the entire 52-line preamble — imports and the substantial module docstring that explains the retained-axiom gap in `PascalsHexagon.lean`, the reduction being discharged, and the honest scope — uncovered. Added a **Context** section (1–52, with `summary` and `mathContext`) so the sections now span the full 160-line file (1-52, 53-83, 85-118, 119-160), verified against `Proofs/PascalsHexagonIncomplete01OQ01.lean`.

Size: meta.json 15.4 → 16.5 KB, within the 60 KB cap. No content removed; the three existing sections and all other fields are untouched. status/badge/axiomCount (verified, original, 0) unchanged and accurate — the file's own docstring (line 48) confirms 0 sorries, 0 axiom declarations, no native_decide. Not superseded (origin/main still has 3 sections).