### PR TITLE
Fix: correct simson-line-theorem-oq-01 proofRepoPath to its own Lean file

### DIFF
--- a/src/data/proofs/simson-line-theorem-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01/meta.json
@@ -40,7 +40,7 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Simson_line",
     "date": "~1797 (Wallace)",
     "status": "verified",
-    "proofRepoPath": "Proofs/SimsonLineTheorem.lean",
+    "proofRepoPath": "Proofs/SimsonLineTheoremOQ01.lean",
     "tags": [
       "geometry",
       "triangle",


### PR DESCRIPTION
## Fix

`meta.proofRepoPath` for `simson-line-theorem-oq-01` pointed at the imported **base** file rather than the entry's own Lean file.

## Evidence

**Before**: `proofRepoPath = "Proofs/SimsonLineTheorem.lean"` (base theorem, 364 lines / 20 theorems)
**After**: `proofRepoPath = "Proofs/SimsonLineTheoremOQ01.lean"` (146 lines / 8 theorems)

The entry's meta counts (`lineCount 146`, `theoremCount 8`, `definitionCount 1`) and `leanFile.path` already describe `SimsonLineTheoremOQ01.lean`; `proofRepoPath` was the sole field still naming the base file that the OQ01 file `import`s. Actual file counts confirm 146/8/1.

Sibling entry `simson-line-theorem-oq-01-oq-01` establishes the convention (`proofRepoPath == leanFile.path`), as does the overwhelming majority of gallery entries.

Counts were already correct — this is a pure path-consistency fix (no count changes).

---
Automated fix by lean-mechanic agent.