### PR TITLE
Enrich ProbMethod first-moment engine: cover the uncovered preamble in sections

### DIFF
--- a/src/data/proofs/prob-method-applications-wip-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01/meta.json
@@ -5,6 +5,14 @@
   "description": "The genuine counting form of the probabilistic method's first-moment principle, with an honest, non-vacuous Ramsey-style avoidance theorem proved from it. Completes the work-in-progress applications module, whose headline theorems were vacuous placeholders.",
   "sections": [
     {
+      "id": "context-setup",
+      "title": "Context: Completing the Vacuous WIP Applications",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Imports Mathlib and the module docstring. Explains why this file exists: the companion ProbMethodApplications.lean states headline probabilistic-method consequences (Ramsey lower bounds, Property B, tournament domination) as VACUOUS theorems — e.g. ramsey_lower_bound only asserts ∃ n, n ≥ 2^((k-1)/2), discharged by ⟨2^((k-1)/2), le_refl _⟩ with none of the hypotheses used. This file supplies the genuine engine: the first-moment / union-bound existence principle in exact counting form, plus an honest non-vacuous Ramsey-style application. Opens Finset, namespace ProbMethod.Core; 0 sorry, 0 axiom.",
+      "mathContext": "Counting first moment: $\\sum_i |A_i| < |\\Omega| \\implies \\exists\\,\\omega\\ \\forall i,\\ \\omega \\notin A_i$."
+    },
+    {
       "id": "first-moment",
       "title": "The First-Moment / Union-Bound Existence Principle",
       "startLine": 28,


### PR DESCRIPTION
Enrichment pass for `prob-method-applications-wip-01` (Probabilistic Method: First-Moment Existence Engine).

**Structural gap:** the `sections` array started at line 28, leaving the 27-line preamble uncovered — imports plus the module docstring that motivates the whole file (the companion `ProbMethodApplications.lean` states its headline theorems as *vacuous* placeholders, e.g. `ramsey_lower_bound` discharged by `⟨2^((k-1)/2), le_refl _⟩` with no hypothesis used; this file supplies the genuine first-moment engine). Added a **Context** section (1–27, with `summary` and `mathContext`) so the sections now span the full 179-line file (1-27, 28-63, 65-140, 142-179), verified against `Proofs/ProbMethodApplicationsWIP.lean`.

Size: meta.json 11.8 → 12.7 KB, well within the 60 KB cap. No content removed. status/badge/axiomCount (verified, verified, 0) unchanged and accurate — grep confirms no `native_decide`, no `axiom`, no `sorry` (only the docstring's '0 sorry, 0 axiom' line). Not superseded (origin/main still has 3 sections).