### PR TITLE
research(shannon-oq-02-oq-02): weighted combining power law Var[∑aᵢWᵢ]=∑aᵢ²Var[Wᵢ] [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -1156,4 +1156,92 @@ theorem stddev_sum_lt_iff_pairwise_correlation_ne_one [IsFiniteMeasure μ] {ι :
   simp only [stddev_sum_le hW s, true_and, ne_eq, not_iff_not]
   exact stddev_sum_eq_iff_pairwise_correlation_eq_one (fun i _ => hW i) hnd
 
+/-!
+### Weighted combining: output power of a scaled sum
+
+The results above treat the aggregate `∑ᵢ Wᵢ` as an unweighted superposition.  In the
+matched-filter / maximal-ratio-combining picture, each contribution enters the receiver
+scaled by a (deterministic) channel gain `aᵢ`, so the physically relevant output is the
+*weighted* sum `∑ᵢ aᵢ·Wᵢ`.  Bilinearity of covariance carries the Bienaymé machinery
+straight through the scaling: the general identity picks up an `aᵢ·aⱼ` on every
+covariance, and under pairwise uncorrelatedness the off-diagonal terms still vanish,
+leaving the **weighted power law**
+
+        Var[∑ᵢ aᵢ·Wᵢ] = ∑ᵢ aᵢ²·Var[Wᵢ].
+
+This is the exact statement that the received power of a linear combination of
+uncorrelated symbols is the `aᵢ²`-weighted sum of the individual powers — the second-order
+foundation of maximal-ratio combining and the SNR-scaling behaviour of a matched filter.
+-/
+
+/-- **Weighted Bienaymé identity (bilinear expansion).**  For any deterministic weights
+`a : ι → ℝ` and finite family of square-integrable contributions, the variance of the
+scaled sum expands as the `aᵢ·aⱼ`-weighted double sum of covariances:
+
+        Var[∑ᵢ aᵢ·Wᵢ] = ∑ᵢ ∑ⱼ aᵢ·aⱼ·cov[Wᵢ, Wⱼ].
+
+The weighted lift of `variance_sum'`: each covariance in the Bienaymé double sum is scaled
+by the product of the two weights, by bilinearity of covariance
+(`covariance_smul_left`/`covariance_smul_right`). -/
+theorem variance_smul_sum' [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (a : ι → ℝ) (hW : ∀ i ∈ s, MemLp (W i) 2 μ) :
+    Var[∑ i ∈ s, a i • W i; μ]
+      = ∑ i ∈ s, ∑ j ∈ s, a i * a j * cov[W i, W j; μ] := by
+  have hV : ∀ i ∈ s, MemLp (a i • W i) 2 μ := fun i hi => (hW i hi).const_smul (a i)
+  rw [variance_sum' hV]
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [covariance_smul_left, covariance_smul_right]
+  ring
+
+/-- **Weighted power law (sharp, uncorrelated form).**  For deterministic weights
+`a : ι → ℝ` and a finite family of *pairwise-uncorrelated* square-integrable
+contributions, the variance of the weighted sum is the `aᵢ²`-weighted sum of the
+individual variances:
+
+        Var[∑ᵢ aᵢ·Wᵢ] = ∑ᵢ aᵢ²·Var[Wᵢ].
+
+The weighted generalisation of `variance_sum_of_pairwise_uncorrelated` (recovered at
+`a ≡ 1`): scaling preserves pairwise uncorrelatedness (`cov[aᵢWᵢ, aⱼWⱼ] = aᵢaⱼ·cov = 0`),
+so only the diagonal `Var[aᵢWᵢ] = aᵢ²·Var[Wᵢ]` (`variance_smul`) survives. This is the
+maximal-ratio-combining power identity: the output power of a linear combination of
+uncorrelated symbols is the square-weighted sum of their powers. -/
+theorem variance_smul_sum_of_pairwise_uncorrelated [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (a : ι → ℝ) (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (huncor : Set.Pairwise ↑s fun i j => cov[W i, W j; μ] = 0) :
+    Var[∑ i ∈ s, a i • W i; μ] = ∑ i ∈ s, a i ^ 2 * Var[W i; μ] := by
+  have hV : ∀ i ∈ s, MemLp (a i • W i) 2 μ := fun i hi => (hW i hi).const_smul (a i)
+  have hVuncor : Set.Pairwise ↑s fun i j => cov[a i • W i, a j • W j; μ] = 0 := by
+    intro i hi j hj hij
+    rw [covariance_smul_left, covariance_smul_right, huncor hi hj hij, mul_zero, mul_zero]
+  rw [variance_sum_of_pairwise_uncorrelated hV hVuncor]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [variance_smul]
+
+/-- **Weighted multi-symbol AWGN output power (sharp).**  If the receiver forms the
+weighted combination `∑ᵢ aᵢ·Wᵢ` of *pairwise-uncorrelated*, zero-mean, square-integrable
+contributions with deterministic gains `aᵢ`, then the output second moment (power) is the
+`aᵢ²`-weighted sum of the per-contribution powers:
+
+        E[(∑ᵢ aᵢ·Wᵢ)²] = ∑ᵢ aᵢ²·E[Wᵢ²].
+
+The weighted companion of `awgn_multisymbol_power_of_uncorrelated`: each gain `aᵢ` scales
+the `i`-th symbol's power by `aᵢ²`, exactly the SNR-scaling of a matched filter /
+maximal-ratio combiner over an uncorrelated symbol block. -/
+theorem awgn_weighted_multisymbol_power_of_uncorrelated [IsProbabilityMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (a : ι → ℝ) (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (huncor : Set.Pairwise ↑s fun i j => cov[W i, W j; μ] = 0)
+    (hmean : ∀ i ∈ s, μ[W i] = 0) :
+    μ[(∑ i ∈ s, a i • W i) ^ 2] = ∑ i ∈ s, a i ^ 2 * μ[(W i) ^ 2] := by
+  have hV : ∀ i ∈ s, MemLp (a i • W i) 2 μ := fun i hi => (hW i hi).const_smul (a i)
+  have hVmean : ∀ i ∈ s, μ[a i • W i] = 0 := by
+    intro i hi
+    simp only [Pi.smul_apply, smul_eq_mul]
+    rw [integral_const_mul, hmean i hi, mul_zero]
+  have hSum : MemLp (∑ i ∈ s, a i • W i) 2 μ := memLp_finset_sum' s hV
+  have hSum0 : μ[∑ i ∈ s, a i • W i] = 0 := sum_mean_zero hV hVmean
+  rw [second_moment_eq_variance hSum hSum0,
+    variance_smul_sum_of_pairwise_uncorrelated a hW huncor]
+  refine Finset.sum_congr rfl fun i hi => ?_
+  rw [second_moment_eq_variance (hW i hi) (hmean i hi)]
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 1159,
+    "lineCount": 1247,
     "axiomCount": 0,
-    "theoremCount": 48,
+    "theoremCount": 50,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 1159,
-    "theoremCount": 48,
+    "lineCount": 1247,
+    "theoremCount": 50,
     "definitionCount": 1,
     "badge": "mathlib",
     "originalContributions": [

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0/0): strict standard-deviation triangle inequality proved in both correlation form (σ[X+Y]<σ[X]+σ[Y] ⟺ ρ<1) and structural/affine form (⟺ X not a.e. increasing-affine in Y) — the strict companions of the equality boundary, completing the ≤ / = / < trichotomy of stddev_add_le. Remaining open: analytic upper-bound terminus and finite-family strict form.",
+    "progressSummary": "PROGRESS (VERIFIED 0/0): added the weighted-combining power law Var[∑aᵢWᵢ]=∑aᵢ²Var[Wᵢ] for pairwise-uncorrelated families (bilinear Bienaymé double-sum + uncorrelated diagonal + zero-mean output-power capstone) — the maximal-ratio-combining / matched-filter second-order identity, the aᵢ-weighted generalisation of the unweighted variance_sum_of_pairwise_uncorrelated stack.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -61,7 +61,10 @@
       "stddev_sum_eq_iff_pairwise_covariance_eq_sqrt (ShannonChannelCodingAWGNOQ02OQ02.lean): √Var[∑ᵢ∈s Wᵢ]=∑ᵢ√Var[Wᵢ] ↔ ∀i,j∈s cov[Wᵢ,Wⱼ]=√Var[Wᵢ]·√Var[Wⱼ]; no non-degeneracy hyp (diagonal tight). Multivariate lift of stddev_add_eq_iff_covariance_eq_sqrt, dual of variance_sum_eq_iff_offDiag_covariance_zero.",
       "stddev_sum_eq_iff_pairwise_correlation_eq_one (same file): for non-degenerate family, √Var[∑]=∑σ ↔ ∀i,j∈s ρ[Wᵢ,Wⱼ]=1 (all pairs perfectly positively correlated); normalises the covariance form via correlation def + div_eq_one_iff_eq. Multivariate capstone of stddev_add_eq_iff_correlation_eq_one.",
       "stddev_add_lt_iff_correlation_lt_one (ShannonChannelCodingAWGNOQ02OQ02.lean): σ[X+Y] < σ[X]+σ[Y] ⟺ ρ<1 for non-degenerate X,Y — strict form of stddev_add_le via lt_iff_le_and_ne + abs_correlation_le_one (ρ≤1) + stddev_add_eq_iff_correlation_eq_one",
-      "stddev_add_lt_iff_not_affine_pos (ShannonChannelCodingAWGNOQ02OQ02.lean): σ[X+Y] < σ[X]+σ[Y] ⟺ ¬∃a>0,b. X=ᵐa·Y+b — structural negation of stddev_add_eq_iff_affine_pos"
+      "stddev_add_lt_iff_not_affine_pos (ShannonChannelCodingAWGNOQ02OQ02.lean): σ[X+Y] < σ[X]+σ[Y] ⟺ ¬∃a>0,b. X=ᵐa·Y+b — structural negation of stddev_add_eq_iff_affine_pos",
+      "variance_smul_sum: Var[∑aᵢ•Wᵢ]=∑ᵢ∑ⱼ aᵢaⱼ·cov[Wᵢ,Wⱼ] (weighted Bienaymé double-sum, ShannonChannelCodingAWGNOQ02OQ02.lean:1186)",
+      "variance_smul_sum_of_pairwise_uncorrelated: Var[∑aᵢ•Wᵢ]=∑ᵢ aᵢ²·Var[Wᵢ] for pairwise-uncorrelated families — the MRC/matched-filter power law, a≡1 recovers variance_sum_of_pairwise_uncorrelated (line 1208)",
+      "awgn_weighted_multisymbol_power_of_uncorrelated: E[(∑aᵢ•Wᵢ)²]=∑ᵢ aᵢ²·E[Wᵢ²] for zero-mean uncorrelated symbols — physical weighted output power (line 1230)"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -79,7 +82,8 @@
       "Sharp equality boundary of the stddev triangle inequality stddev_add_le: squaring the nonnegative identity σ[X+Y]=σ[X]+σ[Y] reduces it to the covariance attaining its Cauchy-Schwarz maximum cov[X,Y]=√Var[X]·√Var[Y]; NO non-degeneracy hypothesis needed (degenerate Y gives 0=σ[X]·0).",
       "The triangle-equality boundary sits at the OPPOSITE Cauchy-Schwarz endpoint from variance_add_eq_iff_covariance_zero: variances add iff cov=0 (orthogonal), but standard deviations add iff cov=σ[X]σ[Y] (perfectly positively correlated, ρ=+1).",
       "Multivariate stddev-triangle equality (√Var[∑Wᵢ]=∑σ[Wᵢ]) reduces via square+variance_sum'+Finset.sum_mul_sum to ∑ᵢ∑ⱼcov=∑ᵢ∑ⱼσᵢσⱼ; each summand obeys Cauchy–Schwarz cov≤σᵢσⱼ, so the two double sums are equal iff every ordered pair saturates it — Finset.sum_eq_sum_iff_of_le twice (nested).",
-      "Strict triangle inequality needs NO fresh analysis: it is purely lt_iff_le_and_ne applied to both sides of the equality boundary (stddev_add_le gives ≤ on the left, abs_correlation_le_one gives ρ≤1 on the right), then not_iff_not on the eq-iff. simp only [stddev_add_le hX hY, hρle, true_and, ne_eq, not_iff_not] discharges the whole reduction in one line."
+      "Strict triangle inequality needs NO fresh analysis: it is purely lt_iff_le_and_ne applied to both sides of the equality boundary (stddev_add_le gives ≤ on the left, abs_correlation_le_one gives ρ≤1 on the right), then not_iff_not on the eq-iff. simp only [stddev_add_le hX hY, hρle, true_and, ne_eq, not_iff_not] discharges the whole reduction in one line.",
+      "Weighted combining lifts the whole Bienaymé stack by bilinearity: covariance_smul_left/right push each aᵢ,aⱼ out of cov[aᵢWᵢ,aⱼWⱼ]=aᵢaⱼcov, and variance_smul gives the diagonal Var[aᵢWᵢ]=aᵢ²Var[Wᵢ]; no new analysis, just scalar-out rewrites — working in the a•W (smul) form (not fun ω=>a*W ω) aligns directly with Mathlib covariance_smul_*/variance_smul/MemLp.const_smul."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",


### PR DESCRIPTION
## Summary

Adds the **weighted-combining power law** to the multi-symbol AWGN output-power file — the maximal-ratio-combining / matched-filter second-order identity, generalising the existing *unweighted* Bienaymé stack (`variance_sum_of_pairwise_uncorrelated`) to deterministic per-symbol gains `aᵢ`.

Three new theorems (`ShannonChannelCodingAWGNOQ02OQ02.lean`), all **VERIFIED (0 sorry / 0 axiom)**, Docker build green (`[7743/7743] 5.1s`):

1. **`variance_smul_sum'`** — weighted Bienaymé bilinear expansion:
   `Var[∑ᵢ aᵢ•Wᵢ] = ∑ᵢ∑ⱼ aᵢaⱼ·cov[Wᵢ,Wⱼ]`. The weighted lift of `variance_sum'`; each covariance in the double sum is scaled by the product of weights via bilinearity (`covariance_smul_left/right`).

2. **`variance_smul_sum_of_pairwise_uncorrelated`** — the power law:
   `Var[∑ᵢ aᵢ•Wᵢ] = ∑ᵢ aᵢ²·Var[Wᵢ]` for pairwise-uncorrelated families. Scaling preserves uncorrelatedness (`aᵢaⱼ·0 = 0`), so only the diagonal `Var[aᵢWᵢ] = aᵢ²Var[Wᵢ]` (`variance_smul`) survives. Recovers `variance_sum_of_pairwise_uncorrelated` at `a ≡ 1`.

3. **`awgn_weighted_multisymbol_power_of_uncorrelated`** — physical output power:
   `E[(∑ᵢ aᵢ•Wᵢ)²] = ∑ᵢ aᵢ²·E[Wᵢ²]` for zero-mean uncorrelated symbols. The weighted companion of `awgn_multisymbol_power_of_uncorrelated`: each gain scales the `i`-th symbol's power by `aᵢ²` — exactly the SNR-scaling of a matched filter / MRC over an uncorrelated block.

## Why this is meaningful

The prior file treated only the unweighted superposition `∑ᵢ Wᵢ`. Weighted combining `∑ᵢ aᵢWᵢ` is the physically relevant receiver operation (maximal-ratio combining, matched filtering), and the `aᵢ²`-weighted power law is its second-order foundation. This is theory-level content, not a renaming: it introduces the deterministic-gain parameter and its square-scaling, of which the existing results are the `a ≡ 1` special case.

## Verification
- Docker build: `Built Proofs.ShannonChannelCodingAWGNOQ02OQ02 (5.1s)` — 0 sorries, 0 axioms in the new theorems.
- Gallery counts updated (meta + leanFile: 48→50 theorems, 1159→1247 lines).