### PR TITLE
research(erdos-214): metric axioms + infinitude of the √2·ℤ² witness [VERIFIED 0/1]

### DIFF
--- a/proofs/Proofs/Erdos214Problem.lean
+++ b/proofs/Proofs/Erdos214Problem.lean
@@ -325,4 +325,58 @@ theorem complement_contains_distinct_unit_square
   obtain ⟨d12, d23, d34, d41, d13, d24⟩ := hsq.distinct
   exact ⟨p₁, p₂, p₃, p₄, h1, h2, h3, h4, hsq, d12, d23, d34, d41, d13, d24⟩
 
+/-
+## Part 12: The coordinate distance is a genuine metric; the scaled lattice is infinite
+
+Two further axiom-free strengthenings, independent of the Juhász input.
+
+First, `Erdos214.dist` is `‖p - q‖`, so it inherits the two metric axioms missing from
+the earlier `dist_self` / `dist_comm` pair: non-negativity (`norm_nonneg`) and the
+triangle inequality (`norm_add_le`).  Together with `dist_self` and `dist_comm` this
+certifies `Erdos214.dist` really is a metric.
+
+Second, `scaledLattice_unitDistanceFree` exhibits a unit-distance-free set, but only
+guarantees it is non-empty.  Here we show `√2·ℤ²` is in fact *infinite*: the horizontal
+axis `{(√2·n, 0) : n ∈ ℤ}` already embeds `ℤ`.  So Problem #214's hypothesis is satisfied
+by an explicit infinite family, not merely a single configuration.
+-/
+
+/-- **Non-negativity of the coordinate distance.** A metric axiom: `dist p q = ‖p - q‖ ≥ 0`. -/
+theorem dist_nonneg (p q : Plane) : 0 ≤ dist p q := by
+  unfold dist
+  exact norm_nonneg _
+
+/-- **Triangle inequality for the coordinate distance.** The last metric axiom: writing
+`p - r = (p - q) + (q - r)` and applying `norm_add_le`.  With `dist_self`, `dist_comm`
+and `dist_nonneg` this shows `Erdos214.dist` is a genuine metric. -/
+theorem dist_triangle (p q r : Plane) : dist p r ≤ dist p q + dist q r := by
+  unfold dist
+  calc ‖p - r‖ = ‖(p - q) + (q - r)‖ := by rw [sub_add_sub_cancel]
+    _ ≤ ‖p - q‖ + ‖q - r‖ := norm_add_le _ _
+
+/-- The point `(√2·n, 0)` lies in the scaled lattice for every integer `n`
+(take lattice coordinates `a = n`, `b = 0`). -/
+theorem scaledLattice_horiz_mem (n : ℤ) :
+    (!₂[Real.sqrt 2 * (n : ℝ), 0] : Plane) ∈ ScaledLattice := by
+  refine ⟨n, 0, ?_, ?_⟩ <;>
+    simp [Matrix.cons_val_zero, Matrix.cons_val_one]
+
+/-- **The scaled lattice `√2·ℤ²` is infinite.** The horizontal embedding
+`n ↦ (√2·n, 0)` is injective (because `√2 ≠ 0`) and lands in the lattice, so the lattice
+contains a copy of `ℤ`.  This sharpens `scaledLattice_unitDistanceFree`: Problem #214's
+hypothesis is realised by an explicit *infinite* unit-distance-free set. -/
+theorem scaledLattice_infinite : ScaledLattice.Infinite := by
+  apply Set.infinite_of_injective_forall_mem
+    (f := fun n : ℤ => (!₂[Real.sqrt 2 * (n : ℝ), 0] : Plane))
+  · -- injectivity: recover `n` from the first coordinate `√2·n`
+    intro m n hmn
+    have hmn' : (!₂[Real.sqrt 2 * (m : ℝ), 0] : Plane)
+        = !₂[Real.sqrt 2 * (n : ℝ), 0] := hmn
+    have h0 : Real.sqrt 2 * (m : ℝ) = Real.sqrt 2 * (n : ℝ) := by
+      have hc := congrArg (fun x : Plane => x 0) hmn'
+      simpa [Matrix.cons_val_zero] using hc
+    have hs : (Real.sqrt 2 : ℝ) ≠ 0 := by positivity
+    exact_mod_cast mul_left_cancel₀ hs h0
+  · exact scaledLattice_horiz_mem
+
 end Erdos214

--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -70,3 +70,33 @@ Unchanged: `juhasz_stronger` (Juhász 1979 4-point congruent-copy theorem) is de
 incidence geometry absent from Mathlib — BLOCKED. Remaining elementary follow-ups:
 `Set.Infinite ScaledLattice` (strengthen non-vacuity to genuinely infinite), or a
 concrete finite unit-distance-free configuration.
+
+## Session 2026-07-08 (researcher-8) — full metric axioms + infinitude of the √2·ℤ² witness
+
+**Mode:** INFRASTRUCTURE (core still BLOCKED on `juhasz_stronger`; added verified,
+axiom-free geometric content). VERIFIED, 0 sorry / axiom count unchanged (1).
+Build green (2364 jobs, exit 0). File 328→382 lines, 16→20 theorems.
+
+### Added (all axiom-free)
+- `dist_nonneg` : `0 ≤ dist p q` via `norm_nonneg`.
+- `dist_triangle` : `dist p r ≤ dist p q + dist q r` via
+  `sub_add_sub_cancel` (`(p-q)+(q-r)=p-r`) + `norm_add_le`. Together with the earlier
+  `dist_self`/`dist_comm` this certifies `Erdos214.dist` is a genuine metric.
+- `scaledLattice_horiz_mem` : `(√2·n, 0) ∈ ScaledLattice` for every `n : ℤ`.
+- `scaledLattice_infinite` : `ScaledLattice.Infinite` — the horizontal axis embeds `ℤ`
+  (`Set.infinite_of_injective_forall_mem`, injectivity from `mul_left_cancel₀` on `√2≠0`).
+  Sharpens `scaledLattice_unitDistanceFree` from non-empty to infinite.
+
+### Gotchas (reusable)
+- Root Mathlib `dist` is `Dist.dist` — **not** reachable as `_root_.dist` (unknown
+  identifier). Prove metric facts straight from `‖p - q‖` (`norm_nonneg`, `norm_add_le`)
+  instead of trying to bridge to Mathlib's `dist`.
+- Extracting a coordinate from `!₂[a, b]` (= `WithLp.toLp 2 ![a,b]`): `congrFun` FAILS
+  ("application type mismatch, expected ?m = ?m") because the `WithLp` wrapper is not a
+  syntactic pi type. Use `congrArg (fun x : Plane => x 0) h` then `simp [Matrix.cons_val_zero]`.
+
+### Frontier
+Unchanged: `juhasz_stronger` (Juhász 1979 congruent-4-point theorem) is deep incidence
+geometry absent from Mathlib — BLOCKED. The elementary scaffolding around the definitions
+is now essentially complete (metric axioms, isometry-invariance, vertex-distinctness,
+infinite witness). The only substantial remaining work is formalizing the axiom itself.

--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -85,9 +85,9 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 328,
+    "lineCount": 382,
     "assumptions": "1 axiom: juhasz_stronger (Juhász 1979 — a unit-distance-free set's complement contains a congruent copy of ANY 4-point configuration). The original Problem #214 statement (juhasz_1979 : Erdos214Statement) is no longer a separate axiom: it is DERIVED from juhasz_stronger via the proved reduction unit_square_from_stronger (a unit square is a special 4-point configuration, transported into the complement by Juhász's isometry). 0 sorries. The problem's hypothesis is now shown non-vacuous: scaledLattice_unitDistanceFree proves √2·ℤ² is an explicit infinite unit-distance-free set (no assumptions).",
-    "theoremCount": 15,
+    "theoremCount": 20,
     "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Erdos214ProblemAristotle.lean"
@@ -198,9 +198,9 @@
       "Real"
     ],
     "namespace": "Erdos214",
-    "lineCount": 328,
+    "lineCount": 382,
     "axiomCount": 1,
-    "theoremCount": 15,
+    "theoremCount": 20,
     "definitionCount": 13,
     "path": "Proofs/Erdos214Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-214-incomplete-01",
   "title": "Erdős Problem #214: Unit Distance Free Sets and Unit Squares",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -29,20 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: eliminated the single sorry in Erdos214Problem.lean (unit_square_from_stronger) and repaired a Mathlib-4.26 build break (UnitDistanceGraph). File compiles cleanly (host lake env lean vs pinned Mathlib v4.26.0), 0 sorries; #print axioms unit_square_from_stronger = [propext, Classical.choice, Quot.sound] — no sorryAx. The 2 remaining axioms (juhasz_1979, juhasz_stronger) are the intentional deep solved-theorem inputs; entry stays axiomatized/axiom, axiomCount 2.",
+    "progressSummary": "AXIOMATIZED/BLOCKED on juhasz_stronger. Axiom-free scaffolding now includes: full metric axioms for Erdos214.dist, isometry-invariance + vertex-distinctness of unit squares, and infinitude of the √2·ℤ² witness. 0 sorries, 1 intended axiom.",
     "builtItems": [
       "Erdos214Problem.lean: dist_coords (coordinate distance formula), isUnitSquare_standard (the standard unit square is a unit square), unit_square_from_stronger (sorry eliminated, 0-axiom reduction)",
-      "Fixed Mathlib-4.26 build break: UnitDistanceGraph tuple set-builder → setOf on Prod"
+      "Fixed Mathlib-4.26 build break: UnitDistanceGraph tuple set-builder → setOf on Prod",
+      "dist_nonneg, dist_triangle in Erdos214Problem.lean: the two metric axioms missing from dist_self/dist_comm (via norm_nonneg, norm_add_le + sub_add_sub_cancel) — Erdos214.dist certified a genuine metric",
+      "scaledLattice_horiz_mem + scaledLattice_infinite: √2·ℤ² is infinite (horizontal axis n↦(√2·n,0) embeds ℤ via Set.infinite_of_injective_forall_mem), sharpening scaledLattice_unitDistanceFree from non-empty to infinite"
     ],
     "insights": [
       "erdos-214 (Juhász 1979, unit-distance-free sets): the 1 sorry was in unit_square_from_stronger (JuhaszStrongerTheorem → Erdos214Statement) — a pure logical reduction, NOT one of the 2 deep Juhász axioms.",
       "Proved it: apply the stronger theorem to the standard unit square P=(0,0),(1,0),(1,1),(0,1) as a PointSet 4; the congruent copy in Sᶜ is again a unit square since the witnessing map is an isometry (dist-preserving), carrying P's 4 edges (=1) and 2 diagonals (=√2).",
       "Key helper dist_coords: dist(!₂[a,b],!₂[c,d]) = √((a-c)²+(b-d)²) via EuclideanSpace.dist_eq + Fin.sum_univ_two + Real.dist_eq + sq_abs; concrete unit square checked by norm_num [Real.sqrt_one].",
-      "The file ALSO didn't compile on pinned Mathlib 4.26: UnitDistanceGraph used the tuple set-builder {(p,q) | ...} which no longer parses ('unknown identifier q'); rewrote as {pq | pq.1∈S ∧ ...}."
+      "The file ALSO didn't compile on pinned Mathlib 4.26: UnitDistanceGraph used the tuple set-builder {(p,q) | ...} which no longer parses ('unknown identifier q'); rewrote as {pq | pq.1∈S ∧ ...}.",
+      "Coordinate extraction from !₂[a,b]: congrFun FAILS (WithLp.toLp wrapper not a syntactic pi type) — use congrArg (fun x => x 0) then simp [Matrix.cons_val_zero]",
+      "Root Mathlib dist is Dist.dist, NOT accessible as _root_.dist; prove metric facts directly from ‖p-q‖ (norm_nonneg/norm_add_le) rather than bridging to Mathlib dist"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Optional: formalize one of the Juhász axioms (deep 1979 result) — substantial; or leave as the documented axiomatized solved entry."
+      "Remaining elementary follow-ups exhausted around definitions; core BLOCKED on juhasz_stronger (deep 1979 4-point theorem, not in Mathlib). Only substantial work left = formalizing that axiom."
     ],
     "markdown": "# Knowledge: erdos-214-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
   },


### PR DESCRIPTION
## Erdős Problem #214 — axiom-free structural scaffolding

The core of Problem #214 (Juhász 1979) rests on a single intended deep axiom
`juhasz_stronger` (the congruent-4-point theorem, not in Mathlib). This PR adds
**verified, axiom-free** geometric content around the definitions — no new axioms,
no sorries. Build green (2364 jobs, exit 0).

### New theorems (`proofs/Proofs/Erdos214Problem.lean`, Part 12)
- **`dist_nonneg`**, **`dist_triangle`** — the two metric axioms missing from the earlier
  `dist_self` / `dist_comm` pair. With those, `Erdos214.dist` is now certified a genuine
  metric (`0 ≤ dist`, and `dist p r ≤ dist p q + dist q r` via `sub_add_sub_cancel` +
  `norm_add_le`).
- **`scaledLattice_horiz_mem`** — `(√2·n, 0) ∈ ScaledLattice` for every `n : ℤ`.
- **`scaledLattice_infinite`** — `ScaledLattice.Infinite`. The horizontal axis
  `n ↦ (√2·n, 0)` injectively embeds `ℤ` (injectivity from `mul_left_cancel₀` on
  `√2 ≠ 0`). This sharpens `scaledLattice_unitDistanceFree` from *non-empty* to
  *infinite*: Problem #214's hypothesis is realised by an explicit infinite
  unit-distance-free set.

### Status
- 0 sorries; axiom count unchanged (**1**: `juhasz_stronger`) — entry stays
  `axiomatized` / `axiom`.
- Meta counts synced: 15→20 theorems, 328→382 lines.

The elementary scaffolding around the definitions (metric axioms, isometry-invariance,
vertex-distinctness, infinite witness) is now essentially complete; the only substantial
remaining work is formalizing the deep Juhász axiom itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)