### PR TITLE
research(law-of-cosines-oq-03-oq-03): hyperbolic law of sines from second-law inversion [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos79Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos79Incomplete01OQ01.lean
@@ -163,6 +163,88 @@ theorem K4_is_minimal_from_single_diamond
     isMinimallyNonLinear (completeGraphN 4) :=
   K4_is_minimal_of_single' K4_not_linear h01
 
+/- ## Iso-invariance of superlinearity and of minimal non-linearity
+
+   Erdős #79 asks whether there are infinitely many minimally non-linear graphs
+   *up to isomorphism* (`erdos_79_question := minimalNonLinearGraphs.Infinite`),
+   yet the whole gallery formalisation works with concrete graphs on the fixed
+   vertex set `ℕ`.  For that count to be meaningful, the defining predicate
+   `isMinimallyNonLinear` must be an isomorphism invariant.  We prove it is —
+   grounded, like heredity and iso-invariance of size-linearity above, in the
+   two atomic Ramsey properties alone (via `isRamseySizeLinear_congr`), with no
+   new axioms. -/
+
+/-- **Superlinearity is iso-invariant.**  The negation of an iso-invariant
+    predicate is iso-invariant: transport size-linearity back along `e.symm`. -/
+theorem isRamseySizeSuperlinear_congr {G G' : SimpleGraph ℕ} (e : G ≃g G')
+    (h : isRamseySizeSuperlinear G) : isRamseySizeSuperlinear G' :=
+  fun h' => h (isRamseySizeLinear_congr e.symm h')
+
+/-- Relabelling `H'` by the isomorphism `e : G ≃g G'` (i.e. `SimpleGraph.comap ⇑e H'`)
+    produces a graph isomorphic to `H'`: the bijection is `e` itself, and
+    adjacency matches by the very definition of `comap`. -/
+def comapIso {G G' : SimpleGraph ℕ} (e : G ≃g G') (H' : SimpleGraph ℕ) :
+    SimpleGraph.comap ⇑e H' ≃g H' where
+  toEquiv := e.toEquiv
+  map_rel_iff' := Iff.rfl
+
+/-- Pulling `G'` itself back along `e : G ≃g G'` returns `G`: `comap ⇑e G' = G`.
+    This is just the defining property of an isomorphism. -/
+theorem comap_self {G G' : SimpleGraph ℕ} (e : G ≃g G') :
+    SimpleGraph.comap ⇑e G' = G := by
+  ext a b
+  simp only [SimpleGraph.comap_adj]
+  exact e.map_rel_iff
+
+/-- A proper subgraph `H' ⊊ G'` pulls back along `e : G ≃g G'` to a proper
+    subgraph `comap ⇑e H' ⊊ G`.  Monotone (edges of `H'` map to edges of `G`)
+    and proper (`comap ⇑e` is injective, so `comap ⇑e H' = G = comap ⇑e G'`
+    would force `H' = G'`). -/
+theorem comap_properSubgraph {G G' H' : SimpleGraph ℕ} (e : G ≃g G')
+    (hH' : isProperSubgraph H' G') :
+    isProperSubgraph (SimpleGraph.comap ⇑e H') G := by
+  refine ⟨?_, ?_⟩
+  · -- monotonicity: comap ⇑e H' ≤ G
+    intro a b hab
+    rw [SimpleGraph.comap_adj] at hab
+    exact e.map_rel_iff.mp (hH'.1 hab)
+  · -- properness: if `comap ⇑e H' = G` then `H' = G'`, contradicting `hH'.2`
+    intro hEq
+    apply hH'.2
+    ext a' b'
+    -- evaluate `hEq` at the preimages `e.symm a', e.symm b'`
+    have key := congrArg (fun g : SimpleGraph ℕ => g.Adj (e.symm a') (e.symm b')) hEq
+    simp only [SimpleGraph.comap_adj, RelIso.apply_symm_apply] at key
+    -- `key : H'.Adj a' b' = G.Adj (e.symm a') (e.symm b')`
+    -- and `hmap : G'.Adj a' b' ↔ G.Adj (e.symm a') (e.symm b')`
+    have hmap := e.map_rel_iff (a := e.symm a') (b := e.symm b')
+    simp only [RelIso.apply_symm_apply] at hmap
+    rw [iff_of_eq key]
+    exact hmap.symm
+
+/-- **Minimal non-linearity is an isomorphism invariant.**  If `G ≃g G'` and
+    `G` is minimally non-Ramsey-size-linear, then so is `G'`.  Both clauses
+    transport: superlinearity via `isRamseySizeSuperlinear_congr`, and
+    "every proper subgraph is linear" by pulling each proper subgraph `H' ⊊ G'`
+    back to a proper subgraph `comap ⇑e H' ⊊ G` (linear by hypothesis) and
+    pushing linearity forward across the iso `comap ⇑e H' ≃g H'`.  Derived from
+    the two atomic Ramsey properties only — no new axioms. -/
+theorem isMinimallyNonLinear_congr {G G' : SimpleGraph ℕ} (e : G ≃g G')
+    (h : isMinimallyNonLinear G) : isMinimallyNonLinear G' := by
+  obtain ⟨hsuper, hsub⟩ := h
+  refine ⟨isRamseySizeSuperlinear_congr e hsuper, ?_⟩
+  intro H' hH'
+  have hlin : isRamseySizeLinear (SimpleGraph.comap ⇑e H') :=
+    hsub _ (comap_properSubgraph e hH')
+  exact isRamseySizeLinear_congr (comapIso e H') hlin
+
+/-- The invariant set `minimalNonLinearGraphs` is closed under isomorphism:
+    membership depends only on the isomorphism type.  A direct restatement of
+    `isMinimallyNonLinear_congr` on the parent's set `minimalNonLinearGraphs`. -/
+theorem minimalNonLinearGraphs_iso_closed {G G' : SimpleGraph ℕ} (e : G ≃g G')
+    (hG : G ∈ minimalNonLinearGraphs) : G' ∈ minimalNonLinearGraphs :=
+  isMinimallyNonLinear_congr e hG
+
 /- Verified axiom basis (`#print axioms K4_is_minimal_from_single_diamond`):
 
      [propext, Classical.choice, Quot.sound,
@@ -177,5 +259,20 @@ theorem K4_is_minimal_from_single_diamond
    `ramseyNumber` is `opaque`, so it is irreducible but does not itself appear
    in `#print axioms`. -/
 -- #print axioms K4_is_minimal_from_single_diamond
+
+/- Iso-invariance of minimal non-linearity has an even leaner basis
+   (`#print axioms isMinimallyNonLinear_congr`):
+
+     [propext, Classical.choice, Quot.sound,
+      Erdos79Incomplete01OQ01.ramseyNumber_congr_left]
+
+   i.e. only the single ATOMIC *congruence* property of the Ramsey number
+   (monotonicity `ramseyNumber_mono_left` is not even needed) plus the ordinary
+   foundational axioms.  So "minimally non-linear" being an isomorphism
+   invariant — the well-posedness of Erdős #79's count of such graphs up to
+   isomorphism (`minimalNonLinearGraphs.Infinite`) — reduces to nothing more
+   than: the Ramsey number depends only on the isomorphism type of its first
+   argument. -/
+-- #print axioms isMinimallyNonLinear_congr
 
 end Erdos79Incomplete01OQ01

--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -1,5 +1,6 @@
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+import Mathlib.Analysis.SpecialFunctions.Arcosh
 import Mathlib.Tactic
 
 /-
@@ -627,5 +628,101 @@ theorem hyperbolic_law_of_sines (t : HyperbolicTriangle) :
   refine ⟨?_, ?_⟩
   · rw [div_eq_div_iff hA hB]; linear_combination law_of_sines_ab t
   · rw [div_eq_div_iff hB hC]; linear_combination law_of_sines_bc t
+
+-- ============================================================
+-- PART 10: Realizability — the defect condition A+B+C<π is SUFFICIENT
+-- ============================================================
+
+/-- **The defect inequality.** For any three angles in `(0, π)` with positive angular
+    defect `A + B + C < π`, the second-law numerator dominates: `sin A · sin B < cos C +
+    cos A · cos B`. This is the raw-real form of the inequality inside
+    `angle_formula_gt_one`, extracted so it can be applied to a *hypothetical* angle triple
+    (before any triangle is known to exist). Only `C > 0` and the defect are needed. -/
+theorem angle_ineq (A B C : ℝ) (hA : 0 < A) (hB : 0 < B) (hC : 0 < C)
+    (hdef : A + B + C < Real.pi) :
+    Real.sin A * Real.sin B < Real.cos C + Real.cos A * Real.cos B := by
+  have hAB_pos : (0 : ℝ) ≤ A + B := by linarith
+  have hpi : Real.pi - C ≤ Real.pi := by linarith
+  have hAB_lt : A + B < Real.pi - C := by linarith
+  have hlt : Real.cos (Real.pi - C) < Real.cos (A + B) :=
+    Real.cos_lt_cos_of_nonneg_of_le_pi hAB_pos hpi hAB_lt
+  rw [Real.cos_pi_sub, Real.cos_add] at hlt
+  linarith
+
+/-- **Realizability: positive defect is sufficient.** Every angle triple with each angle in
+    `(0, π)` and angle sum `< π` is realized by an actual hyperbolic triangle. This is the
+    converse to `HyperbolicTriangle.defect` (which shows the defect is *necessary*).
+
+    The construction is direct: because the three second laws are **decoupled** — the law at
+    a vertex constrains only that vertex's opposite side — each side is defined independently
+    by inverting its own law, `cosh a = (cos A + cos B cos C)/(sin B sin C)`, etc. The three
+    angle inequalities (all instances of `angle_ineq` with the angles permuted, since the
+    defect is symmetric) make each quotient exceed `1`, so `arcosh` returns a genuine positive
+    length. -/
+theorem exists_triangle_of_defect (A B C : ℝ)
+    (hA : 0 < A) (hB : 0 < B) (hC : 0 < C)
+    (hAlt : A < Real.pi) (hBlt : B < Real.pi) (hClt : C < Real.pi)
+    (hdef : A + B + C < Real.pi) :
+    ∃ t : HyperbolicTriangle, t.A = A ∧ t.B = B ∧ t.C = C := by
+  have hsA := Real.sin_pos_of_pos_of_lt_pi hA hAlt
+  have hsB := Real.sin_pos_of_pos_of_lt_pi hB hBlt
+  have hsC := Real.sin_pos_of_pos_of_lt_pi hC hClt
+  have hsAne := hsA.ne'
+  have hsBne := hsB.ne'
+  have hsCne := hsC.ne'
+  -- Three angle inequalities (the defect is symmetric in A, B, C).
+  have hIa : Real.sin B * Real.sin C < Real.cos A + Real.cos B * Real.cos C :=
+    angle_ineq B C A hB hC hA (by linarith)
+  have hIb : Real.sin A * Real.sin C < Real.cos B + Real.cos A * Real.cos C :=
+    angle_ineq A C B hA hC hB (by linarith)
+  have hIc : Real.sin A * Real.sin B < Real.cos C + Real.cos A * Real.cos B :=
+    angle_ineq A B C hA hB hC hdef
+  -- Each inverted side value exceeds 1.
+  have hva1 : 1 < (Real.cos A + Real.cos B * Real.cos C) / (Real.sin B * Real.sin C) := by
+    rw [lt_div_iff₀ (mul_pos hsB hsC), one_mul]; exact hIa
+  have hvb1 : 1 < (Real.cos B + Real.cos A * Real.cos C) / (Real.sin A * Real.sin C) := by
+    rw [lt_div_iff₀ (mul_pos hsA hsC), one_mul]; exact hIb
+  have hvc1 : 1 < (Real.cos C + Real.cos A * Real.cos B) / (Real.sin A * Real.sin B) := by
+    rw [lt_div_iff₀ (mul_pos hsA hsB), one_mul]; exact hIc
+  refine ⟨{ a := Real.arcosh ((Real.cos A + Real.cos B * Real.cos C) / (Real.sin B * Real.sin C))
+            b := Real.arcosh ((Real.cos B + Real.cos A * Real.cos C) / (Real.sin A * Real.sin C))
+            c := Real.arcosh ((Real.cos C + Real.cos A * Real.cos B) / (Real.sin A * Real.sin B))
+            A := A, B := B, C := C
+            ha := Real.arcosh_pos hva1
+            hb := Real.arcosh_pos hvb1
+            hc := Real.arcosh_pos hvc1
+            hA := hA, hB := hB, hC := hC
+            hA_lt := hAlt, hB_lt := hBlt, hC_lt := hClt
+            defect := hdef
+            lawA := by rw [Real.cosh_arcosh hva1.le]; field_simp; ring
+            lawB := by rw [Real.cosh_arcosh hvb1.le]; field_simp; ring
+            lawC := by rw [Real.cosh_arcosh hvc1.le]; field_simp; ring }, rfl, rfl, rfl⟩
+
+/-- **Full realizability (bijection characterization).** A triple of angles, each in
+    `(0, π)`, is realized by a hyperbolic triangle **iff** the angle sum is `< π`. The forward
+    direction is `HyperbolicTriangle.defect`; the converse is `exists_triangle_of_defect`.
+    Combined with the AAA congruence of PART 4, the map (angles) ↦ (triangle) is a bijection
+    between the open defect region `{(A,B,C) : 0 < A,B,C < π, A+B+C < π}` and congruence
+    classes of hyperbolic triangles — the exact hyperbolic replacement for the Euclidean
+    angle-sum identity `A + B + C = π`. -/
+theorem exists_iff_defect (A B C : ℝ)
+    (hA : 0 < A) (hB : 0 < B) (hC : 0 < C)
+    (hAlt : A < Real.pi) (hBlt : B < Real.pi) (hClt : C < Real.pi) :
+    (∃ t : HyperbolicTriangle, t.A = A ∧ t.B = B ∧ t.C = C) ↔ A + B + C < Real.pi := by
+  constructor
+  · rintro ⟨t, hta, htb, htc⟩
+    have h := t.defect; rw [hta, htb, htc] at h; exact h
+  · intro hdef
+    exact exists_triangle_of_defect A B C hA hB hC hAlt hBlt hClt hdef
+
+/-- **Existence of the equilateral family.** For every admissible common angle
+    `θ ∈ (0, π/3)`, a hyperbolic equilateral triangle with all three angles `θ` exists. This
+    specializes `exists_triangle_of_defect` to `A = B = C = θ`; the bound `θ < π/3` is exactly
+    the defect condition `3θ < π`, matching `equilateral_angle_lt_pi_third`. It shows the
+    equilateral results (PARTS 5, 7, 8) are non-vacuous across the whole range `(0, π/3)`. -/
+theorem exists_equilateral (θ : ℝ) (hθ : 0 < θ) (hθ3 : θ < Real.pi / 3) :
+    ∃ t : HyperbolicTriangle, t.A = θ ∧ t.B = θ ∧ t.C = θ := by
+  have hθpi : θ < Real.pi := by linarith [Real.pi_pos]
+  exact exists_triangle_of_defect θ θ θ hθ hθ hθ hθpi hθpi hθpi (by linarith)
 
 end HyperbolicAAA

--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -429,4 +429,203 @@ theorem equilateral_side_antitone (t₁ t₂ : HyperbolicTriangle)
   (Real.cosh_strictMonoOn.lt_iff_lt (mem_Ici.mpr t₂.hc.le) (mem_Ici.mpr t₁.hc.le)).mp
     (equilateral_cosh_antitone t₁ t₂ h₁ h₁' h₂ h₂' hlt)
 
+-- ============================================================
+-- PART 9: The hyperbolic law of sines (from the second-law inversion)
+-- ============================================================
+
+/-- The common **Gram numerator** of a hyperbolic triangle. Expanding `cosh² - 1`
+    after the inversion `cosh a = (cos A + cos B cos C)/(sin B sin C)` collapses to this
+    fully symmetric expression in the three angles. Its symmetry is exactly what forces
+    the law of sines: every side's `sinh` shares the same numerator. -/
+noncomputable def gramNumerator (t : HyperbolicTriangle) : ℝ :=
+  Real.cos t.A ^ 2 + Real.cos t.B ^ 2 + Real.cos t.C ^ 2
+    + 2 * Real.cos t.A * Real.cos t.B * Real.cos t.C - 1
+
+/-- Two positive reals with equal squares are equal. -/
+private theorem eq_of_sq_eq_of_pos {x y : ℝ} (h : x ^ 2 = y ^ 2)
+    (hx : 0 < x) (hy : 0 < y) : x = y := by
+  have hfac : (x - y) * (x + y) = 0 := by linear_combination h
+  rcases mul_eq_zero.mp hfac with h' | h'
+  · linarith
+  · linarith [add_pos hx hy]
+
+/-- Positivity of `sinh a` from positivity of the side `a`. -/
+theorem sinh_a_pos (t : HyperbolicTriangle) : 0 < Real.sinh t.a := by
+  have h := Real.sinh_strictMono t.ha
+  rwa [Real.sinh_zero] at h
+
+/-- Positivity of `sinh b`. -/
+theorem sinh_b_pos (t : HyperbolicTriangle) : 0 < Real.sinh t.b := by
+  have h := Real.sinh_strictMono t.hb
+  rwa [Real.sinh_zero] at h
+
+/-- Positivity of `sinh c`. -/
+theorem sinh_c_pos (t : HyperbolicTriangle) : 0 < Real.sinh t.c := by
+  have h := Real.sinh_strictMono t.hc
+  rwa [Real.sinh_zero] at h
+
+/-- **Gram numerator via side `a`.** `(sinh a · sin B · sin C)² = gramNumerator`.
+    Squaring the side-from-angle inversion and using `sinh² = cosh² − 1`, the
+    Pythagorean identities `sin² = 1 − cos²` collapse the result to the symmetric
+    Gram numerator. -/
+theorem sinh_a_num_sq (t : HyperbolicTriangle) :
+    (Real.sinh t.a * (Real.sin t.B * Real.sin t.C)) ^ 2 = gramNumerator t := by
+  have hne : Real.sin t.B * Real.sin t.C ≠ 0 :=
+    mul_ne_zero (sin_B_pos t).ne' (sin_C_pos t).ne'
+  have h1 : Real.cosh t.a * (Real.sin t.B * Real.sin t.C)
+      = Real.cos t.A + Real.cos t.B * Real.cos t.C :=
+    (eq_div_iff hne).mp (cosh_a_eq t)
+  have h1sq : Real.cosh t.a ^ 2 * (Real.sin t.B ^ 2 * Real.sin t.C ^ 2)
+      = (Real.cos t.A + Real.cos t.B * Real.cos t.C) ^ 2 := by
+    have e : (Real.cosh t.a * (Real.sin t.B * Real.sin t.C)) ^ 2
+        = Real.cosh t.a ^ 2 * (Real.sin t.B ^ 2 * Real.sin t.C ^ 2) := by ring
+    rw [← e, h1]
+  have hsinh : Real.sinh t.a ^ 2 = Real.cosh t.a ^ 2 - 1 := by
+    have := Real.cosh_sq_sub_sinh_sq t.a; linarith
+  have pB : Real.sin t.B ^ 2 = 1 - Real.cos t.B ^ 2 := by
+    have := Real.sin_sq_add_cos_sq t.B; linarith
+  have pC : Real.sin t.C ^ 2 = 1 - Real.cos t.C ^ 2 := by
+    have := Real.sin_sq_add_cos_sq t.C; linarith
+  calc (Real.sinh t.a * (Real.sin t.B * Real.sin t.C)) ^ 2
+      = Real.sinh t.a ^ 2 * (Real.sin t.B ^ 2 * Real.sin t.C ^ 2) := by ring
+    _ = (Real.cosh t.a ^ 2 - 1) * (Real.sin t.B ^ 2 * Real.sin t.C ^ 2) := by rw [hsinh]
+    _ = Real.cosh t.a ^ 2 * (Real.sin t.B ^ 2 * Real.sin t.C ^ 2)
+          - Real.sin t.B ^ 2 * Real.sin t.C ^ 2 := by ring
+    _ = (Real.cos t.A + Real.cos t.B * Real.cos t.C) ^ 2
+          - Real.sin t.B ^ 2 * Real.sin t.C ^ 2 := by rw [h1sq]
+    _ = (Real.cos t.A + Real.cos t.B * Real.cos t.C) ^ 2
+          - (1 - Real.cos t.B ^ 2) * (1 - Real.cos t.C ^ 2) := by rw [pB, pC]
+    _ = gramNumerator t := by unfold gramNumerator; ring
+
+/-- **Gram numerator via side `b`.** `(sinh b · sin A · sin C)² = gramNumerator`. -/
+theorem sinh_b_num_sq (t : HyperbolicTriangle) :
+    (Real.sinh t.b * (Real.sin t.A * Real.sin t.C)) ^ 2 = gramNumerator t := by
+  have hne : Real.sin t.A * Real.sin t.C ≠ 0 :=
+    mul_ne_zero (sin_A_pos t).ne' (sin_C_pos t).ne'
+  have h1 : Real.cosh t.b * (Real.sin t.A * Real.sin t.C)
+      = Real.cos t.B + Real.cos t.A * Real.cos t.C :=
+    (eq_div_iff hne).mp (cosh_b_eq t)
+  have h1sq : Real.cosh t.b ^ 2 * (Real.sin t.A ^ 2 * Real.sin t.C ^ 2)
+      = (Real.cos t.B + Real.cos t.A * Real.cos t.C) ^ 2 := by
+    have e : (Real.cosh t.b * (Real.sin t.A * Real.sin t.C)) ^ 2
+        = Real.cosh t.b ^ 2 * (Real.sin t.A ^ 2 * Real.sin t.C ^ 2) := by ring
+    rw [← e, h1]
+  have hsinh : Real.sinh t.b ^ 2 = Real.cosh t.b ^ 2 - 1 := by
+    have := Real.cosh_sq_sub_sinh_sq t.b; linarith
+  have pA : Real.sin t.A ^ 2 = 1 - Real.cos t.A ^ 2 := by
+    have := Real.sin_sq_add_cos_sq t.A; linarith
+  have pC : Real.sin t.C ^ 2 = 1 - Real.cos t.C ^ 2 := by
+    have := Real.sin_sq_add_cos_sq t.C; linarith
+  calc (Real.sinh t.b * (Real.sin t.A * Real.sin t.C)) ^ 2
+      = Real.sinh t.b ^ 2 * (Real.sin t.A ^ 2 * Real.sin t.C ^ 2) := by ring
+    _ = (Real.cosh t.b ^ 2 - 1) * (Real.sin t.A ^ 2 * Real.sin t.C ^ 2) := by rw [hsinh]
+    _ = Real.cosh t.b ^ 2 * (Real.sin t.A ^ 2 * Real.sin t.C ^ 2)
+          - Real.sin t.A ^ 2 * Real.sin t.C ^ 2 := by ring
+    _ = (Real.cos t.B + Real.cos t.A * Real.cos t.C) ^ 2
+          - Real.sin t.A ^ 2 * Real.sin t.C ^ 2 := by rw [h1sq]
+    _ = (Real.cos t.B + Real.cos t.A * Real.cos t.C) ^ 2
+          - (1 - Real.cos t.A ^ 2) * (1 - Real.cos t.C ^ 2) := by rw [pA, pC]
+    _ = gramNumerator t := by unfold gramNumerator; ring
+
+/-- **Gram numerator via side `c`.** `(sinh c · sin A · sin B)² = gramNumerator`. -/
+theorem sinh_c_num_sq (t : HyperbolicTriangle) :
+    (Real.sinh t.c * (Real.sin t.A * Real.sin t.B)) ^ 2 = gramNumerator t := by
+  have hne : Real.sin t.A * Real.sin t.B ≠ 0 :=
+    mul_ne_zero (sin_A_pos t).ne' (sin_B_pos t).ne'
+  have h1 : Real.cosh t.c * (Real.sin t.A * Real.sin t.B)
+      = Real.cos t.C + Real.cos t.A * Real.cos t.B :=
+    (eq_div_iff hne).mp (cosh_c_eq t)
+  have h1sq : Real.cosh t.c ^ 2 * (Real.sin t.A ^ 2 * Real.sin t.B ^ 2)
+      = (Real.cos t.C + Real.cos t.A * Real.cos t.B) ^ 2 := by
+    have e : (Real.cosh t.c * (Real.sin t.A * Real.sin t.B)) ^ 2
+        = Real.cosh t.c ^ 2 * (Real.sin t.A ^ 2 * Real.sin t.B ^ 2) := by ring
+    rw [← e, h1]
+  have hsinh : Real.sinh t.c ^ 2 = Real.cosh t.c ^ 2 - 1 := by
+    have := Real.cosh_sq_sub_sinh_sq t.c; linarith
+  have pA : Real.sin t.A ^ 2 = 1 - Real.cos t.A ^ 2 := by
+    have := Real.sin_sq_add_cos_sq t.A; linarith
+  have pB : Real.sin t.B ^ 2 = 1 - Real.cos t.B ^ 2 := by
+    have := Real.sin_sq_add_cos_sq t.B; linarith
+  calc (Real.sinh t.c * (Real.sin t.A * Real.sin t.B)) ^ 2
+      = Real.sinh t.c ^ 2 * (Real.sin t.A ^ 2 * Real.sin t.B ^ 2) := by ring
+    _ = (Real.cosh t.c ^ 2 - 1) * (Real.sin t.A ^ 2 * Real.sin t.B ^ 2) := by rw [hsinh]
+    _ = Real.cosh t.c ^ 2 * (Real.sin t.A ^ 2 * Real.sin t.B ^ 2)
+          - Real.sin t.A ^ 2 * Real.sin t.B ^ 2 := by ring
+    _ = (Real.cos t.C + Real.cos t.A * Real.cos t.B) ^ 2
+          - Real.sin t.A ^ 2 * Real.sin t.B ^ 2 := by rw [h1sq]
+    _ = (Real.cos t.C + Real.cos t.A * Real.cos t.B) ^ 2
+          - (1 - Real.cos t.A ^ 2) * (1 - Real.cos t.B ^ 2) := by rw [pA, pB]
+    _ = gramNumerator t := by unfold gramNumerator; ring
+
+/-- **The Gram numerator is nonnegative.** It equals a square, so a valid hyperbolic
+    triangle always has `cos²A + cos²B + cos²C + 2 cos A cos B cos C ≥ 1`. -/
+theorem gramNumerator_nonneg (t : HyperbolicTriangle) : 0 ≤ gramNumerator t := by
+  rw [← sinh_a_num_sq t]; positivity
+
+/-- **Hyperbolic law of sines, pair `a,b` (cross form).**
+    `sinh a · sin B = sinh b · sin A`. Both `(sinh a · sin B · sin C)²` and
+    `(sinh b · sin A · sin C)²` equal the Gram numerator; cancelling the common
+    `sin² C` and taking the positive square root yields the identity. -/
+theorem law_of_sines_ab (t : HyperbolicTriangle) :
+    Real.sinh t.a * Real.sin t.B = Real.sinh t.b * Real.sin t.A := by
+  have h : (Real.sinh t.a * (Real.sin t.B * Real.sin t.C)) ^ 2
+      = (Real.sinh t.b * (Real.sin t.A * Real.sin t.C)) ^ 2 := by
+    rw [sinh_a_num_sq, sinh_b_num_sq]
+  have hsC : Real.sin t.C ^ 2 ≠ 0 := pow_ne_zero 2 (sin_C_pos t).ne'
+  have hsq : (Real.sinh t.a * Real.sin t.B) ^ 2 = (Real.sinh t.b * Real.sin t.A) ^ 2 := by
+    have e : (Real.sinh t.a * Real.sin t.B) ^ 2 * Real.sin t.C ^ 2
+        = (Real.sinh t.b * Real.sin t.A) ^ 2 * Real.sin t.C ^ 2 := by linear_combination h
+    exact mul_right_cancel₀ hsC e
+  exact eq_of_sq_eq_of_pos hsq
+    (mul_pos (sinh_a_pos t) (sin_B_pos t)) (mul_pos (sinh_b_pos t) (sin_A_pos t))
+
+/-- **Hyperbolic law of sines, pair `b,c` (cross form).**
+    `sinh b · sin C = sinh c · sin B`. -/
+theorem law_of_sines_bc (t : HyperbolicTriangle) :
+    Real.sinh t.b * Real.sin t.C = Real.sinh t.c * Real.sin t.B := by
+  have h : (Real.sinh t.b * (Real.sin t.A * Real.sin t.C)) ^ 2
+      = (Real.sinh t.c * (Real.sin t.A * Real.sin t.B)) ^ 2 := by
+    rw [sinh_b_num_sq, sinh_c_num_sq]
+  have hsA : Real.sin t.A ^ 2 ≠ 0 := pow_ne_zero 2 (sin_A_pos t).ne'
+  have hsq : (Real.sinh t.b * Real.sin t.C) ^ 2 = (Real.sinh t.c * Real.sin t.B) ^ 2 := by
+    have e : (Real.sinh t.b * Real.sin t.C) ^ 2 * Real.sin t.A ^ 2
+        = (Real.sinh t.c * Real.sin t.B) ^ 2 * Real.sin t.A ^ 2 := by linear_combination h
+    exact mul_right_cancel₀ hsA e
+  exact eq_of_sq_eq_of_pos hsq
+    (mul_pos (sinh_b_pos t) (sin_C_pos t)) (mul_pos (sinh_c_pos t) (sin_B_pos t))
+
+/-- **Hyperbolic law of sines, pair `a,c` (cross form).**
+    `sinh a · sin C = sinh c · sin A`. -/
+theorem law_of_sines_ac (t : HyperbolicTriangle) :
+    Real.sinh t.a * Real.sin t.C = Real.sinh t.c * Real.sin t.A := by
+  have h : (Real.sinh t.a * (Real.sin t.B * Real.sin t.C)) ^ 2
+      = (Real.sinh t.c * (Real.sin t.A * Real.sin t.B)) ^ 2 := by
+    rw [sinh_a_num_sq, sinh_c_num_sq]
+  have hsB : Real.sin t.B ^ 2 ≠ 0 := pow_ne_zero 2 (sin_B_pos t).ne'
+  have hsq : (Real.sinh t.a * Real.sin t.C) ^ 2 = (Real.sinh t.c * Real.sin t.A) ^ 2 := by
+    have e : (Real.sinh t.a * Real.sin t.C) ^ 2 * Real.sin t.B ^ 2
+        = (Real.sinh t.c * Real.sin t.A) ^ 2 * Real.sin t.B ^ 2 := by linear_combination h
+    exact mul_right_cancel₀ hsB e
+  exact eq_of_sq_eq_of_pos hsq
+    (mul_pos (sinh_a_pos t) (sin_C_pos t)) (mul_pos (sinh_c_pos t) (sin_A_pos t))
+
+/-- **The hyperbolic law of sines.** In any hyperbolic triangle the ratios of `sinh`
+    of a side to the sine of its opposite angle agree:
+
+      sinh a / sin A = sinh b / sin B = sinh c / sin C.
+
+    This is the exact hyperbolic analogue of the Euclidean law of sines, obtained here
+    as a corollary of the *second* law of cosines: the shared symmetric Gram numerator
+    forces the three ratios to coincide. Together with the two laws of cosines already
+    in this file it completes the elementary trigonometry of the hyperbolic triangle. -/
+theorem hyperbolic_law_of_sines (t : HyperbolicTriangle) :
+    Real.sinh t.a / Real.sin t.A = Real.sinh t.b / Real.sin t.B
+      ∧ Real.sinh t.b / Real.sin t.B = Real.sinh t.c / Real.sin t.C := by
+  have hA : Real.sin t.A ≠ 0 := (sin_A_pos t).ne'
+  have hB : Real.sin t.B ≠ 0 := (sin_B_pos t).ne'
+  have hC : Real.sin t.C ≠ 0 := (sin_C_pos t).ne'
+  refine ⟨?_, ?_⟩
+  · rw [div_eq_div_iff hA hB]; linear_combination law_of_sines_ab t
+  · rw [div_eq_div_iff hB hC]; linear_combination law_of_sines_bc t
+
 end HyperbolicAAA

--- a/research/problems/erdos-79-incomplete-01/knowledge.md
+++ b/research/problems/erdos-79-incomplete-01/knowledge.md
@@ -62,3 +62,44 @@ atomic axiom declarations), status stays `axiomatized`/`axiom`.
 
 VERIFIED docker exit 0 ([7745/7745], 3.6–3.8s, first try; `#print axioms`
 output captured in-file).
+
+## Session 2026-07-08 (researcher-4) — minimal non-linearity is an isomorphism invariant
+
+**Mode**: FRESH (continuation) · **Outcome**: progress (structural; 0 sorries; no new axioms)
+
+Extended the OQ01 companion `Erdos79Incomplete01OQ01.lean`. The prior session
+derived heredity + size-linearity iso-invariance from the two atomic Ramsey
+properties. This session closes the natural structural gap: the ENTIRE predicate
+`isMinimallyNonLinear` is an isomorphism invariant.
+
+New (0 sorry, NO new axioms):
+- `isRamseySizeSuperlinear_congr` — superlinearity transports across iso
+  (negation of the iso-invariant size-linearity, via `e.symm`).
+- `comapIso` / `comap_self` / `comap_properSubgraph` — subgraph transport:
+  a proper subgraph `H' ⊊ G'` pulls back along `e : G ≃g G'` to a proper
+  subgraph `comap ⇑e H' ⊊ G`, isomorphic to `H'` (bijection `e`, adjacency by
+  `comap` definition). Monotonicity via `e.map_rel_iff`; properness via
+  `congrArg` of the graph equality evaluated at preimages `e.symm`.
+- `isMinimallyNonLinear_congr` — `G ≃g G' → isMinimallyNonLinear G →
+  isMinimallyNonLinear G'`. Superlinear clause via `isRamseySizeSuperlinear_congr`;
+  subgraph clause by pulling each `H' ⊊ G'` back to `comap ⇑e H' ⊊ G` (linear by
+  hypothesis) then pushing linearity forward across `comapIso e H'`.
+- `minimalNonLinearGraphs_iso_closed` — restatement on the parent's set.
+
+**Axiom basis** (`#print axioms isMinimallyNonLinear_congr`):
+`[propext, Classical.choice, Quot.sound, ramseyNumber_congr_left]` — only the
+single CONGRUENCE axiom; monotonicity `ramseyNumber_mono_left` is not even
+needed. So the well-posedness of Erdős #79's count of minimally non-linear
+graphs *up to isomorphism* (`minimalNonLinearGraphs.Infinite`) reduces to
+exactly one atomic fact: the Ramsey number depends only on the isomorphism type
+of its first argument. Significant because the whole gallery formalisation works
+with concrete graphs on the fixed vertex set `ℕ`.
+
+**Honest scope**: no new axioms, no change to the assumption count; purely a
+structural strengthening. Elementary scaffold now at terminus — the remaining
+OPEN content (single-diamond size-linearity `R(K₄−e,H)=O(e(H))` and K₄
+superlinearity) is genuine Ramsey theory beyond Mathlib.
+
+**Files**: `proofs/Proofs/Erdos79Incomplete01OQ01.lean` (181→278 lines; +5
+theorems, +1 def, +0 axioms). VERIFIED docker exit 0 ([7745/7745], 3.6s, first
+try; `#print axioms` captured in-file).

--- a/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
+++ b/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
@@ -121,3 +121,34 @@ structure-encoded axioms in `HyperbolicTriangle`). Findings:
   Genuine 7→6 structure-axiom reduction. Deferred (hard, needs fresh budget); left this
   sketch so it's a clean next win. Other nextSteps (SAS/ASA congruence, area-defect
   integral) are also substantial.
+
+## Session 2026-07-08 (researcher-4) - Hyperbolic law of sines
+
+**Mode**: REVISIT (RICH, completed) | **Outcome**: progress (new theory)
+
+### What I Did
+- Added PART 9 to `LawOfCosinesOQ03OQ03.lean`: the **hyperbolic law of sines**,
+  derived as a corollary of the *second* law of cosines already in the file.
+- Key identity: squaring the inversion `cosh a = (cos A + cos B cos C)/(sin B sin C)`
+  and applying `sinh² = cosh² − 1` + Pythagoras collapses `(sinh a·sin B·sin C)²` to the
+  fully symmetric **Gram numerator** `N = cos²A+cos²B+cos²C+2cosAcosBcosC−1`.
+- Symmetry of `N` across the three sides is exactly the law of sines: cancelling the
+  common third sine gives `sinh a·sin B = sinh b·sin A`, hence
+  `sinh a/sin A = sinh b/sin B = sinh c/sin C`.
+- Bonus: `gramNumerator_nonneg` (N ≥ 0 for free, since N is a square) — an angle
+  constraint on every hyperbolic triangle.
+
+### Theorems added (11 public + 1 private + 1 def)
+`gramNumerator`, `sinh_a/b/c_pos`, `sinh_a/b/c_num_sq`, `gramNumerator_nonneg`,
+`law_of_sines_ab/bc/ac` (cross form), `hyperbolic_law_of_sines` (ratio form),
+`eq_of_sq_eq_of_pos` (private helper).
+
+### Verification
+Docker `Built Proofs.LawOfCosinesOQ03OQ03 (2.4s)` — 0 sorries, 0 new axioms
+(7 structure-encoded assumptions unchanged). One fix: `gramNumerator` needed
+`noncomputable` (depends on `Real.cos`).
+
+### Next Steps
+- Derive the FIRST law of cosines `cosh c = cosh a cosh b − sinh a sinh b cos C`
+  from the second-law structure + this law of sines (closes the trig system).
+- SAS / ASA congruence by inverting the angle–side system.

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,9 +17,9 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 432,
-    "theoremCount": 26,
-    "definitionCount": 1
+    "lineCount": 631,
+    "theoremCount": 37,
+    "definitionCount": 2
   },
   "openQuestion": {
     "id": "law-of-cosines-oq-03-oq-03",
@@ -365,9 +365,9 @@
     ],
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 432,
-    "theoremCount": 26,
-    "definitionCount": 1,
+    "lineCount": 631,
+    "theoremCount": 37,
+    "definitionCount": 2,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",
       "cosh_c_eq / cosh_a_eq / cosh_b_eq: inversion of the second law giving each side as a function of the angles",

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 631,
-    "theoremCount": 37,
+    "lineCount": 728,
+    "theoremCount": 41,
     "definitionCount": 2
   },
   "openQuestion": {
@@ -294,6 +294,18 @@
       "type": "theorem",
       "statement": "For two equilateral hyperbolic triangles with common angles θ₁ < θ₂, the second has the strictly shorter side: t₂.c < t₁.c.",
       "significance": "The monotone hyperbolic counterpart of the Euclidean fact that all equilateral triangles are similar: here each admissible common angle pins down a unique size, refining AAA congruence into a strict monotonicity along the equilateral family (via cosh injectivity on [0,∞))."
+    },
+    {
+      "name": "exists_triangle_of_defect",
+      "type": "theorem",
+      "statement": "For angles A,B,C each in (0,π) with A+B+C<π, there exists a HyperbolicTriangle t with t.A=A, t.B=B, t.C=C.",
+      "significance": "The converse to the angular-defect condition: positive defect is not only necessary but sufficient. Since the three second laws of cosines are decoupled (each constrains only its own opposite side), each side is realized independently by arcosh of the inverted law, made valid by the defect inequality. Every admissible angle triple is realized."
+    },
+    {
+      "name": "exists_iff_defect",
+      "type": "theorem",
+      "statement": "For angles each in (0,π): (∃ hyperbolic triangle with those angles) ↔ A+B+C<π.",
+      "significance": "Combined with AAA congruence (Part 4), this makes angles↦triangle a bijection between the open defect region {0<A,B,C<π, A+B+C<π} and congruence classes of hyperbolic triangles — the hyperbolic analogue of the Euclidean angle-sum law A+B+C=π (an identity there, a strict-inequality region here)."
     }
   ],
   "references": [
@@ -365,8 +377,8 @@
     ],
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 631,
-    "theoremCount": 37,
+    "lineCount": 728,
+    "theoremCount": 41,
     "definitionCount": 2,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",
@@ -377,7 +389,9 @@
       "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) for the equilateral triangle",
       "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — holding two angles fixed, increasing the third strictly shortens the opposite side (refines AAA congruence to a strict comparison)",
       "Equilateral corollaries (Part 7): equilateral_angle_lt_pi_third (an equilateral hyperbolic triangle has common angle < π/3, the sharp defect-driven counterpart of the Euclidean π/3) and equilateral_pi_four_cosh (the all-angles-π/4 equilateral triangle has every side arcosh(1+√2), i.e. cosh = 1+√2) — no new assumptions",
-      "Equilateral-family monotonicity (Part 8): equilateral_cosh_antitone and equilateral_side_antitone — along the one-parameter equilateral family, the side is a strictly decreasing function of the common angle θ ∈ (0, π/3). This sharpens AAA congruence (Part 4) into a strict order statement across the family, complementing the two-angles-fixed monotonicity of Part 4b."
+      "Equilateral-family monotonicity (Part 8): equilateral_cosh_antitone and equilateral_side_antitone — along the one-parameter equilateral family, the side is a strictly decreasing function of the common angle θ ∈ (0, π/3). This sharpens AAA congruence (Part 4) into a strict order statement across the family, complementing the two-angles-fixed monotonicity of Part 4b.",
+      "Realizability of hyperbolic triangles (Part 10): exists_triangle_of_defect — every angle triple with each angle in (0,π) and A+B+C<π is realized by an actual HyperbolicTriangle. The construction inverts each decoupled second law independently (cosh a = (cos A+cos B cos C)/(sin B sin C), etc.), with angle_ineq (a raw-real form of the Part-3 defect inequality, applied under the three cyclic permutations) guaranteeing each quotient exceeds 1 so that arcosh yields a genuine positive side. This is the converse of the structure-encoded defect field.",
+      "Bijection characterization and equilateral existence (Part 10): exists_iff_defect — an angle triple is realized iff A+B+C<π, so (with Part 4 AAA congruence) the map angles↦triangle is a bijection between the open defect region and congruence classes, the exact hyperbolic replacement for the Euclidean angle-sum identity A+B+C=π; and exists_equilateral — a hyperbolic equilateral triangle exists for every common angle θ∈(0,π/3), showing the equilateral results of Parts 5/7/8 are non-vacuous. No new assumptions."
     ],
     "proofStrategy": "Invert each second law of cosines (linear in cosh of the opposite side) via eq_div_iff + linear_combination to get cosh(side) as a ratio of angle functions. Prove the angle ratio exceeds 1 from the defect using cos(A+B) > cos(π-C) = -cos C (strict antitonicity of cos on [0,π]). Conclude AAA congruence by cosh injectivity on [0,∞). Specialize to the equilateral case for a closed form.",
     "openQuestions": [

--- a/src/data/research/problems/erdos-79-incomplete-01.json
+++ b/src/data/research/problems/erdos-79-incomplete-01.json
@@ -29,21 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "STRUCTURAL: heredity (parent axiom) and iso-invariance (companion hypothesis) are now DERIVED theorems, grounded in the two atomic properties of the primitive ramseyNumber (monotonicity + iso-invariance). Flagship K4_is_minimal_from_single_diamond depends (verified via #print axioms) only on these two + K4_not_linear, not on ramsey_linear_hereditary/K4_subgraphs_linear. Does NOT reduce assumption count (real content R(K4−e,H)=O(e(H)) needs Ramsey theory absent from Mathlib); the value is structural grounding + two new proved lemmas. 0 sorries.",
+    "progressSummary": "PROGRESS (structural, 0 sorry, no new axioms): minimal-non-linearity is now a machine-checked isomorphism invariant, so Erdos #79 count up-to-iso is well-posed. Elementary scaffold at terminus; remaining content is genuine Ramsey theory.",
     "builtItems": [
       "Erdos79Incomplete01OQ01.isRamseySizeLinear_hereditary — heredity as a THEOREM from ramseyNumber_mono_left (was parent axiom)",
       "Erdos79Incomplete01OQ01.isRamseySizeLinear_congr — iso-invariance as a THEOREM from ramseyNumber_congr_left (was companion hypothesis hcongr)",
       "Erdos79Incomplete01OQ01.K4_is_minimal_from_single_diamond — K4 minimality from a SINGLE diamond K4−{0,1} + atomic Ramsey properties; #print axioms confirms NO dependence on ramsey_linear_hereditary or K4_subgraphs_linear",
-      "Erdos79Incomplete01OQ01.{ramseyNumber_mono_left, ramseyNumber_congr_left} — the two atomic primitive-level axioms (monotone/iso-invariant in first arg)"
+      "Erdos79Incomplete01OQ01.{ramseyNumber_mono_left, ramseyNumber_congr_left} — the two atomic primitive-level axioms (monotone/iso-invariant in first arg)",
+      "isMinimallyNonLinear_congr in Erdos79Incomplete01OQ01.lean: G-iso-G' then minimal-non-linear G implies minimal-non-linear G', 0 sorry, no new axioms",
+      "isRamseySizeSuperlinear_congr, comapIso (def), comap_self, comap_properSubgraph, minimalNonLinearGraphs_iso_closed in Erdos79Incomplete01OQ01.lean"
     ],
     "insights": [
       "Size-linearity heredity (parent axiom ramsey_linear_hereditary) and iso-invariance (companion hypothesis hcongr) are NOT independent assumptions: each is a one-step consequence of the corresponding atomic property of the primitive ramseyNumber — monotonicity (G≤G⇒R(G,·)≤R(G,·)) and iso-invariance (G≃gG⇒R(G,·)=R(G,·)).",
-      "Same linearity constant C transfers under both operations: for H≤G, R(H,K)≤R(G,K)≤C·e(K); under G≃gG, R(G,K)=R(G,K) so the bound is verbatim. So heredity/iso-invariance of isRamseySizeLinear need no new constant, only mono/congr of R."
+      "Same linearity constant C transfers under both operations: for H≤G, R(H,K)≤R(G,K)≤C·e(K); under G≃gG, R(G,K)=R(G,K) so the bound is verbatim. So heredity/iso-invariance of isRamseySizeLinear need no new constant, only mono/congr of R.",
+      "Iso-invariance of the WHOLE predicate isMinimallyNonLinear is derivable (0 sorry) from just the congruence axiom ramseyNumber_congr_left — monotonicity is not even needed. print axioms isMinimallyNonLinear_congr = [propext, Classical.choice, Quot.sound, ramseyNumber_congr_left]. Makes Erdos #79 well-posed as a count of graphs UP TO ISOMORPHISM despite the gallery using concrete graphs on the fixed vertex set N.",
+      "Subgraph transport across a graph iso e:G-iso-G' uses SimpleGraph.comap: proper subgraph H'<G' pulls back to comap e H' < G (monotone via e.map_rel_iff; proper via congrArg of the equality at preimages e.symm), and comap e H' iso H' via toEquiv:=e.toEquiv, map_rel_iff':=Iff.rfl."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Elementary content essentially closed: the axiom scaffold is now grounded in the two canonical Ramsey-number properties, with heredity+iso-invariance derived. Remaining OPEN (needs real Ramsey theory beyond Mathlib): the single diamond hypothesis h01 = isRamseySizeLinear (K4−{0,1}), i.e. R(K4−e, H)=O(e(H)), and K4 superlinearity K4_not_linear.",
-      "Possible micro-follow-up: also derive a monotonicity/congruence statement for the SECOND Ramsey argument, or show K4_subgraphs_linear (sweeping) fully reduces to h01 alone under mono+congr (already essentially done via K4_subgraphs_linear_of_single)."
+      "Elementary structural scaffold essentially complete: heredity, size-linearity iso-invariance, AND minimal-non-linearity iso-invariance all derived from the two atomic Ramsey properties (mono_left/congr_left). Remaining OPEN needs real Ramsey theory beyond Mathlib: R(K4-e,H)=O(e(H)) (single-diamond hypothesis h01) and K4 superlinearity K4_not_linear. No further elementary structural reductions apparent."
     ],
     "markdown": "# Knowledge Base: erdos-79-incomplete-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -13,7 +13,7 @@
   "significance": "AAA congruence is one of the sharpest qualitative differences between hyperbolic and Euclidean geometry, and underlies the rigidity of hyperbolic structures (Thurston). Completes the basic congruence theory alongside the parent law of cosines and sibling law of sines.",
   "currentState": "COMPLETED. Proved AAA congruence: the second law of cosines inverts to cosh c = (cos C + cos A cos B)/(sin A sin B), a function of the angles alone; injectivity of cosh on [0,∞) turns equal angles into equal sides. Also proved internal consistency (the defect A+B+C<π is exactly what makes the formula exceed 1) and the equilateral closed form cosh(side)=cos θ/(1-cos θ).",
   "knowledge": {
-    "progressSummary": "COMPLETE: hyperbolic AAA congruence formalized (20 theorems, 1 structure, 7 structure-encoded axioms, 0 sorries; verified 0-axiom — only propext/Classical/Quot, no native_decide). Extended 2026-07-08 with strict angle-side monotonicity. PR #27561.",
+    "progressSummary": "COMPLETE + EXTENDED 2026-07-08: hyperbolic law of sines (ratio + cross forms) and the symmetric Gram-numerator identity added to the AAA-congruence file. 37 theorems, 1 structure + 1 def, 7 structure-encoded axioms, 0 sorries; no new axioms. Verified via Docker (Built, not replayed).",
     "builtItems": [
       "LawOfCosinesOQ03OQ03.lean: hyperbolic AAA congruence (0 sorries, 7 structure-encoded axioms)",
       "HyperbolicTriangle: structure with sides a,b,c, angles A,B,C, side positivity, angle bounds, defect, and three second laws of cosines lawA/lawB/lawC",
@@ -23,7 +23,8 @@
       "aaa_congruence: equal angles ⟹ equal sides via Real.cosh_strictMonoOn.injOn",
       "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) using sin²θ=(1-cosθ)(1+cosθ) + div_eq_div_iff",
       "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — with two angles fixed, increasing the third strictly shortens the opposite side (cosh_c_eq numerator antitone in C + cosh injectivity)",
-      "Part 7 equilateral corollaries: equilateral_angle_lt_pi_third (θ<π/3 from the defect) and equilateral_pi_four_cosh (all angles π/4 ⟹ cosh side = 1+√2). Concrete/structural additions to the AAA-congruence file; no new assumptions, status stays axiomatized."
+      "Part 7 equilateral corollaries: equilateral_angle_lt_pi_third (θ<π/3 from the defect) and equilateral_pi_four_cosh (all angles π/4 ⟹ cosh side = 1+√2). Concrete/structural additions to the AAA-congruence file; no new assumptions, status stays axiomatized.",
+      "LawOfCosinesOQ03OQ03.lean PART 9: hyperbolic law of sines derived from the second law of cosines. gramNumerator (symmetric Gram numerator of the three angles); sinh_a/b/c_num_sq: (sinh side · product of the two adjacent sines)^2 = gramNumerator; law_of_sines_ab/bc/ac (cross form sinh a sin B = sinh b sin A); hyperbolic_law_of_sines (ratio form sinh a/sin A = sinh b/sin B = sinh c/sin C); gramNumerator_nonneg."
     ],
     "insights": [
       "The second law of cosines is linear in cosh of the opposite side, so it inverts algebraically — no Euclidean analogue, since the Euclidean law relates a side to the other two sides, not purely to angles.",
@@ -31,12 +32,14 @@
       "cosh injectivity on [0,∞) (Real.cosh_strictMonoOn.injOn) upgrades equal cosh-sides to equal sides; side positivity (ha/hb/hc) places sides in the domain.",
       "lt_div_iff was renamed to lt_div_iff₀ in current Mathlib (4.26.0).",
       "Equilateral case collapses to cos θ/(1-cos θ): the (1+cos θ) factors cancel between sin²θ and the numerator cos θ(1+cos θ).",
-      "Angle-side monotonicity is a free corollary of the inversion: cosh c = (cos C + cos A cos B)/(sin A sin B) is strictly antitone in C over a fixed positive denominator, so a larger opposite angle forces a strictly shorter side — the reverse of the Euclidean larger-angle/longer-side law, and quantitative because the side is a definite function of the angles."
+      "Angle-side monotonicity is a free corollary of the inversion: cosh c = (cos C + cos A cos B)/(sin A sin B) is strictly antitone in C over a fixed positive denominator, so a larger opposite angle forces a strictly shorter side — the reverse of the Euclidean larger-angle/longer-side law, and quantitative because the side is a definite function of the angles.",
+      "Squaring the side-from-angle inversion cosh a=(cosA+cosBcosC)/(sinBsinC) and using sinh^2=cosh^2-1, the Pythagorean identities collapse (sinh a sinB sinC)^2 to the fully SYMMETRIC Gram numerator N = cos^2A+cos^2B+cos^2C+2cosAcosBcosC-1. Symmetry across a,b,c is exactly the law of sines: every side shares numerator N, so cancelling the common third sine gives sinh a sinB = sinh b sinA. The hyperbolic law of sines is thus a COROLLARY of the second law of cosines, no independent axiom needed.",
+      "N >= 0 for free: it equals a real square (sinh a sinB sinC)^2, giving the triangle inequality-type constraint cos^2A+cos^2B+cos^2C+2cosAcosBcosC >= 1 on the angles of any hyperbolic triangle (gramNumerator_nonneg)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Derive the three second laws of cosines from a single first law to reduce structure-encoded axioms",
-      "Formalize SAS and ASA hyperbolic congruence by the same inversion technique",
+      "Derive the FIRST law of cosines cosh c = cosh a cosh b - sinh a sinh b cos C from the second-law structure + the law of sines (dual identity closing the trig system)",
+      "Formalize SAS and ASA hyperbolic congruence by inverting the angle-side system",
       "Recover the area defect as an integral of the side-from-angle formulas"
     ]
   },

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -13,7 +13,7 @@
   "significance": "AAA congruence is one of the sharpest qualitative differences between hyperbolic and Euclidean geometry, and underlies the rigidity of hyperbolic structures (Thurston). Completes the basic congruence theory alongside the parent law of cosines and sibling law of sines.",
   "currentState": "COMPLETED. Proved AAA congruence: the second law of cosines inverts to cosh c = (cos C + cos A cos B)/(sin A sin B), a function of the angles alone; injectivity of cosh on [0,∞) turns equal angles into equal sides. Also proved internal consistency (the defect A+B+C<π is exactly what makes the formula exceed 1) and the equilateral closed form cosh(side)=cos θ/(1-cos θ).",
   "knowledge": {
-    "progressSummary": "COMPLETE + EXTENDED 2026-07-08: hyperbolic law of sines (ratio + cross forms) and the symmetric Gram-numerator identity added to the AAA-congruence file. 37 theorems, 1 structure + 1 def, 7 structure-encoded axioms, 0 sorries; no new axioms. Verified via Docker (Built, not replayed).",
+    "progressSummary": "COMPLETE: AAA congruence + hyperbolic law of sines + realizability (defect condition is necessary AND sufficient; angles↦triangle is a bijection). 0 sorries, structure-encoded second-law assumptions only.",
     "builtItems": [
       "LawOfCosinesOQ03OQ03.lean: hyperbolic AAA congruence (0 sorries, 7 structure-encoded axioms)",
       "HyperbolicTriangle: structure with sides a,b,c, angles A,B,C, side positivity, angle bounds, defect, and three second laws of cosines lawA/lawB/lawC",
@@ -24,7 +24,10 @@
       "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) using sin²θ=(1-cosθ)(1+cosθ) + div_eq_div_iff",
       "side_antitone_in_angle / cosh_c_antitone_in_C: angle-side monotonicity — with two angles fixed, increasing the third strictly shortens the opposite side (cosh_c_eq numerator antitone in C + cosh injectivity)",
       "Part 7 equilateral corollaries: equilateral_angle_lt_pi_third (θ<π/3 from the defect) and equilateral_pi_four_cosh (all angles π/4 ⟹ cosh side = 1+√2). Concrete/structural additions to the AAA-congruence file; no new assumptions, status stays axiomatized.",
-      "LawOfCosinesOQ03OQ03.lean PART 9: hyperbolic law of sines derived from the second law of cosines. gramNumerator (symmetric Gram numerator of the three angles); sinh_a/b/c_num_sq: (sinh side · product of the two adjacent sines)^2 = gramNumerator; law_of_sines_ab/bc/ac (cross form sinh a sin B = sinh b sin A); hyperbolic_law_of_sines (ratio form sinh a/sin A = sinh b/sin B = sinh c/sin C); gramNumerator_nonneg."
+      "LawOfCosinesOQ03OQ03.lean PART 9: hyperbolic law of sines derived from the second law of cosines. gramNumerator (symmetric Gram numerator of the three angles); sinh_a/b/c_num_sq: (sinh side · product of the two adjacent sines)^2 = gramNumerator; law_of_sines_ab/bc/ac (cross form sinh a sin B = sinh b sin A); hyperbolic_law_of_sines (ratio form sinh a/sin A = sinh b/sin B = sinh c/sin C); gramNumerator_nonneg.",
+      "angle_ineq (LawOfCosinesOQ03OQ03.lean Part 10): raw-real form sin A sin B < cos C + cos A cos B from 0<A,B,C and A+B+C<π; applied under cyclic permutations to bound all three inverted-side quotients above 1",
+      "exists_triangle_of_defect (Part 10): constructs a HyperbolicTriangle from any A,B,C∈(0,π) with A+B+C<π, sides = arcosh of inverted second-law quotients (Real.cosh_arcosh, Real.arcosh_pos); laws proved by field_simp;ring",
+      "exists_iff_defect + exists_equilateral (Part 10): full bijection characterization (realized ⟺ defect>0) and equilateral existence for every θ∈(0,π/3)"
     ],
     "insights": [
       "The second law of cosines is linear in cosh of the opposite side, so it inverts algebraically — no Euclidean analogue, since the Euclidean law relates a side to the other two sides, not purely to angles.",
@@ -34,7 +37,8 @@
       "Equilateral case collapses to cos θ/(1-cos θ): the (1+cos θ) factors cancel between sin²θ and the numerator cos θ(1+cos θ).",
       "Angle-side monotonicity is a free corollary of the inversion: cosh c = (cos C + cos A cos B)/(sin A sin B) is strictly antitone in C over a fixed positive denominator, so a larger opposite angle forces a strictly shorter side — the reverse of the Euclidean larger-angle/longer-side law, and quantitative because the side is a definite function of the angles.",
       "Squaring the side-from-angle inversion cosh a=(cosA+cosBcosC)/(sinBsinC) and using sinh^2=cosh^2-1, the Pythagorean identities collapse (sinh a sinB sinC)^2 to the fully SYMMETRIC Gram numerator N = cos^2A+cos^2B+cos^2C+2cosAcosBcosC-1. Symmetry across a,b,c is exactly the law of sines: every side shares numerator N, so cancelling the common third sine gives sinh a sinB = sinh b sinA. The hyperbolic law of sines is thus a COROLLARY of the second law of cosines, no independent axiom needed.",
-      "N >= 0 for free: it equals a real square (sinh a sinB sinC)^2, giving the triangle inequality-type constraint cos^2A+cos^2B+cos^2C+2cosAcosBcosC >= 1 on the angles of any hyperbolic triangle (gramNumerator_nonneg)."
+      "N >= 0 for free: it equals a real square (sinh a sinB sinC)^2, giving the triangle inequality-type constraint cos^2A+cos^2B+cos^2C+2cosAcosBcosC >= 1 on the angles of any hyperbolic triangle (gramNumerator_nonneg).",
+      "Realizability (converse of AAA): the angular-defect condition A+B+C<π is not just necessary but SUFFICIENT — every admissible angle triple is realized by an actual hyperbolic triangle. Key structural observation: the three second laws of cosines are DECOUPLED (the law at a vertex constrains only that vertex opposite side), so each side is constructed independently by inverting its own law via arcosh."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Extends the hyperbolic AAA-congruence file `LawOfCosinesOQ03OQ03.lean` with **PART 9: the hyperbolic law of sines**, derived as a corollary of the *second* law of cosines already formalized there. Previously the file had both laws of cosines and AAA congruence but not the third fundamental identity of hyperbolic trigonometry.

## Mathematical content

Squaring the side-from-angle inversion `cosh a = (cos A + cos B cos C)/(sin B sin C)` and applying `sinh² = cosh² − 1` together with the Pythagorean identities collapses `(sinh a · sin B · sin C)²` to the **fully symmetric Gram numerator**

```
N = cos²A + cos²B + cos²C + 2·cos A·cos B·cos C − 1.
```

Because `N` is shared by all three sides, cancelling the common third sine yields the cross form `sinh a·sin B = sinh b·sin A`, hence the ratio form

```
sinh a / sin A = sinh b / sin B = sinh c / sin C.
```

So the hyperbolic law of sines needs **no independent axiom** — it falls out of the existing second-law structure. As a free bonus, `gramNumerator_nonneg` records `N ≥ 0` (since `N` is a square), i.e. every hyperbolic triangle's angles satisfy `cos²A + cos²B + cos²C + 2 cos A cos B cos C ≥ 1`.

## Theorems added

- `gramNumerator` (def) and `gramNumerator_nonneg`
- `sinh_a_pos`, `sinh_b_pos`, `sinh_c_pos`
- `sinh_a_num_sq`, `sinh_b_num_sq`, `sinh_c_num_sq` — the shared-numerator identity
- `law_of_sines_ab`, `law_of_sines_bc`, `law_of_sines_ac` — cross form
- `hyperbolic_law_of_sines` — ratio form (headline)
- `eq_of_sq_eq_of_pos` (private helper)

## Verification

- Docker build: `Built Proofs.LawOfCosinesOQ03OQ03 (2.4s)` — **0 sorries, 0 new axioms**.
- The 7 structure-encoded assumptions of `HyperbolicTriangle` are unchanged; status stays `axiomatized`.
- Gallery counts updated: `theoremCount 26→37`, `definitionCount 1→2`, `lineCount 432→631`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)