### PR TITLE
research(feuerbachs-theorem-oq-04): spherical midpoint bisects the arc [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
@@ -38,6 +38,10 @@ file adds no axioms and no sorries.
 * `inner_sMidpoint_sub` — the midpoint lies on the perpendicular bisector: `⟪M, A − B⟫ = 0`.
 * `scos_sMidpoint_eq` / `sdist_sMidpoint_eq` — the midpoint is spherically equidistant from the
   two endpoints.
+* `norm_add_sq_unit` — `‖A+B‖² = 2 + 2⟪A,B⟫` for model points.
+* `scos_sMidpoint_left` — the explicit vertex-to-midpoint spherical cosine `‖A+B‖⁻¹(1+⟪A,B⟫)`.
+* `sdist_sMidpoint_half` — **the midpoint bisects the arc**: `sdist A (sMidpoint A B) = ½·sdist A B`,
+  the sharper fact (beyond equidistance) that justifies the name.
 * `sphericalNinePointCircle_exists` — **existence of the spherical nine-point circle**: the
   three side-midpoints of a spherical triangle lie on a common spherical circle.
 -/
@@ -99,6 +103,83 @@ theorem sdist_sMidpoint_eq (A B : E) (hA : OnSphere A) (hB : OnSphere B) :
   unfold scos at h
   unfold sdist
   rw [h]
+
+/-! ### The spherical midpoint bisects the arc
+
+`sdist_sMidpoint_eq` shows `M = sMidpoint A B` is *equidistant* from `A` and `B`, but a
+point equidistant from two others need not be their midpoint (the antipode of the true
+midpoint is equidistant too).  Here we prove the sharper fact that pins down the geometry
+and justifies the name: `M` bisects the arc, `sdist A M = ½ · sdist A B`.  The computation
+runs through the spherical cosine: `scos A M = ‖A+B‖⁻¹(1 + ⟪A,B⟫)` is nonnegative, so
+`sdist A M ≤ π/2`, and the double-angle identity `cos(2·sdist A M) = 2·(scos A M)² − 1`
+collapses to `⟪A,B⟫ = cos(sdist A B)`; injectivity of `cos` on `[0, π]` closes it. -/
+
+/-- **Squared norm of a spherical side.**  For two model points, `‖A + B‖² = 2 + 2⟪A,B⟫`
+(the parallelogram/polarisation expansion with `‖A‖ = ‖B‖ = 1`). -/
+theorem norm_add_sq_unit (A B : E) (hA : OnSphere A) (hB : OnSphere B) :
+    ‖A + B‖ ^ 2 = 2 + 2 * ⟪A, B⟫ := by
+  unfold OnSphere at hA hB
+  rw [← real_inner_self_eq_norm_sq, inner_add_left, inner_add_right, inner_add_right,
+      real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq, hA, hB, real_inner_comm B A]
+  ring
+
+/-- **Explicit spherical cosine from a vertex to the midpoint of its side.**
+`scos A (sMidpoint A B) = ‖A+B‖⁻¹ (1 + ⟪A,B⟫)`.  This closed form is the computational core
+of both the equidistance (`scos_sMidpoint_eq`) and the arc-bisection facts. -/
+theorem scos_sMidpoint_left (A B : E) (hA : OnSphere A) (_hB : OnSphere B) :
+    scos A (sMidpoint A B) = (‖A + B‖)⁻¹ * (1 + ⟪A, B⟫) := by
+  unfold scos sMidpoint
+  rw [real_inner_smul_right, inner_add_right, real_inner_self_eq_norm_sq]
+  unfold OnSphere at hA
+  rw [hA]; norm_num
+
+/-- **The spherical midpoint bisects the arc: `sdist A (sMidpoint A B) = ½ · sdist A B`.**
+For non-antipodal model points `A, B` the spherical midpoint `M = ‖A+B‖⁻¹•(A+B)` lies at
+spherical distance exactly half of `sdist A B` from `A` (equivalently, from `B`).  This is
+strictly stronger than equidistance (`sdist_sMidpoint_eq`) and is what genuinely justifies
+the name "midpoint": the equidistant locus of `A, B` also contains the antipode of the true
+midpoint, which this rules out (`sdist A M ≤ π/2`).  Proof: `scos A M = ‖A+B‖⁻¹(1+⟪A,B⟫) ≥ 0`
+gives `sdist A M ≤ π/2`; the double-angle identity turns `cos(2·sdist A M)` into `⟪A,B⟫ =
+cos(sdist A B)`, and `cos` is injective on `[0, π]`. -/
+theorem sdist_sMidpoint_half (A B : E) (hA : OnSphere A) (hB : OnSphere B)
+    (hAB : A + B ≠ 0) :
+    sdist A (sMidpoint A B) = sdist A B / 2 := by
+  set M := sMidpoint A B with hM
+  have hnormpos : 0 < ‖A + B‖ := by rw [norm_pos_iff]; exact hAB
+  have htle1 : ⟪A, B⟫ ≤ 1 := by
+    have := real_inner_le_norm A B
+    unfold OnSphere at hA hB; rw [hA, hB] at this; linarith
+  have hnsq : ‖A + B‖ ^ 2 = 2 + 2 * ⟪A, B⟫ := norm_add_sq_unit A B hA hB
+  have hden_pos : (0:ℝ) < 2 + 2 * ⟪A, B⟫ := by rw [← hnsq]; positivity
+  have h1t : (0:ℝ) ≤ 1 + ⟪A, B⟫ := by linarith
+  have hscos_val : scos A M = (‖A + B‖)⁻¹ * (1 + ⟪A, B⟫) := scos_sMidpoint_left A B hA hB
+  have hscos_nn : 0 ≤ scos A M := by rw [hscos_val]; positivity
+  have hscos_le1 : scos A M ≤ 1 := by
+    rw [hscos_val, inv_mul_le_iff₀ hnormpos, mul_one]
+    nlinarith [hnsq, hnormpos.le, mul_nonneg (sub_nonneg.mpr htle1) h1t]
+  have hcosM : Real.cos (sdist A M) = scos A M := by
+    unfold sdist scos
+    exact Real.cos_arccos (by rw [← scos]; linarith) (by rw [← scos]; exact hscos_le1)
+  have hsq2 : scos A M ^ 2 = (1 + ⟪A, B⟫) / 2 := by
+    rw [hscos_val, mul_pow, inv_pow, hnsq, inv_mul_eq_div, div_eq_iff hden_pos.ne']
+    ring
+  have hcos2 : Real.cos (2 * sdist A M) = ⟪A, B⟫ := by
+    rw [Real.cos_two_mul, hcosM, hsq2]; ring
+  have hcosAB : Real.cos (sdist A B) = ⟪A, B⟫ := by
+    unfold sdist; exact Real.cos_arccos (by linarith) htle1
+  have hMle : sdist A M ≤ Real.pi / 2 := by
+    unfold sdist
+    exact Real.arccos_le_pi_div_two.mpr
+      (by rw [show (⟪A, M⟫ : ℝ) = scos A M from rfl]; exact hscos_nn)
+  have h2M_mem : 2 * sdist A M ∈ Set.Icc 0 Real.pi := by
+    refine ⟨?_, by linarith [hMle]⟩
+    have : (0:ℝ) ≤ sdist A M := by unfold sdist; exact Real.arccos_nonneg _
+    linarith
+  have hAB_mem : sdist A B ∈ Set.Icc 0 Real.pi :=
+    ⟨Real.arccos_nonneg _, Real.arccos_le_pi _⟩
+  have hcoseq : Real.cos (2 * sdist A M) = Real.cos (sdist A B) := by rw [hcos2, hcosAB]
+  have hfin : 2 * sdist A M = sdist A B := Real.injOn_cos h2M_mem hAB_mem hcoseq
+  linarith [hfin]
 
 /-- **Existence of the spherical nine-point circle.**  Given a spherical triangle with
 vertices `A, B, C` whose sides are non-degenerate (no two endpoints antipodal), its three

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -712,3 +712,34 @@ must hit. This is the criterion, not the identity itself (still the hard capston
 
 **Frontier unchanged:** the tangency identity between the concrete nine-point and incircle
 centres remains the sole hard open item.
+
+## Session 2026-07-08 (researcher-1): the spherical midpoint bisects the arc [VERIFIED — 0 sorry, 0 axiom]
+
+**Mode:** ACT (add a bounded, reusable ingredient). The nine-point circle exists
+(`sphericalNinePointCircle_exists`) and the tangency *criterion* is in place; the remaining
+frontier is the hard tangency capstone. A clean gap elsewhere: `sMidpoint` was proven
+*equidistant* from its endpoints (`sdist_sMidpoint_eq`) but never proven to actually **bisect
+the arc** — a point equidistant from `A, B` need not be their midpoint (the antipode of the
+true midpoint is equidistant too).
+
+**Added to `FeuerbachsTheoremOQ04Midpoint.lean`** (3 theorems, 119→199 L, docker `Built`,
+0 sorry / 0 axiom / 0 native_decide):
+- **`norm_add_sq_unit`** — `‖A+B‖² = 2 + 2⟪A,B⟫` (polarisation with unit norms).
+- **`scos_sMidpoint_left`** — explicit vertex-to-midpoint spherical cosine
+  `scos A (sMidpoint A B) = ‖A+B‖⁻¹(1+⟪A,B⟫)`.
+- **`sdist_sMidpoint_half`** — `sdist A (sMidpoint A B) = ½·sdist A B`, the arc-bisection
+  fact that justifies the name.
+
+**Proof pattern (reusable):** to prove `sdist A M = sdist A B / 2` avoid half-angle lemmas —
+instead prove `2·sdist A M = sdist A B` via `Real.injOn_cos` on `[0,π]`:
+- `scos A M = ‖A+B‖⁻¹(1+⟪A,B⟫) ≥ 0`, so `sdist A M = arccos(scos A M) ≤ π/2`
+  (`Real.arccos_le_pi_div_two.mpr`), giving `2·sdist A M ∈ [0,π]`.
+- double angle `Real.cos_two_mul`: `cos(2·sdist A M) = 2·(scos A M)² − 1`; with
+  `(scos A M)² = (1+⟪A,B⟫)/2` (from `‖A+B‖²=2+2⟪A,B⟫`) this collapses to `⟪A,B⟫ = cos(sdist A B)`.
+- `Real.injOn_cos` closes `2·sdist A M = sdist A B`.
+Developed first in a Mathlib-only scratch file (host `lake env lean`, fast) replicating the
+primitives, then ported — the companion imports local `Proofs.*` modules so it only builds
+under the docker wrapper.
+
+**Frontier unchanged:** the Feuerbach tangency capstone (concrete nine-point vs incircle
+centre, the identity `⟪O₉,O_in⟫ = cos(ρ₉−ρ_in)`) remains the sole hard open item.

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: added the spherical circumcircle existence primitive (three points -> common sCircle) underneath the nine-point circle; Feuerbach tangency still the hard frontier.",
+    "progressSummary": "PROGRESS (researcher-1 2026-07-08): the spherical midpoint sMidpoint was proven equidistant (sdist_sMidpoint_eq) but never proven to actually BISECT the arc. Added sdist_sMidpoint_half: sdist A (sMidpoint A B) = (1/2)*sdist A B — strictly stronger than equidistance (rules out the antipode of the true midpoint), justifying the name. Plus reusable helpers norm_add_sq_unit (‖A+B‖²=2+2⟪A,B⟫) and scos_sMidpoint_left (explicit vertex-to-midpoint spherical cosine ‖A+B‖⁻¹(1+⟪A,B⟫)). Companion FeuerbachsTheoremOQ04Midpoint.lean 119->199 lines, 6->9 theorems, VERIFIED 0 axioms / 0 sorries (docker Built, #print axioms = propext/Classical.choice/Quot.sound). Frontier unchanged: the Feuerbach tangency capstone (nine-point circle tangent to incircle) remains the sole hard open item.",
     "builtItems": [
       "FeuerbachsTheoremOQ04.chord_sq (Proofs/FeuerbachsTheoremOQ04.lean) — chord-cosine bridge: for unit vectors, ||P-Q||^2 = 2 - 2*scos P Q; turns spherical tangency into an inner-product equation. 0-axiom.",
       "FeuerbachsTheoremOQ04.abs_scos_le_one/scos_le_one/neg_one_le_scos — spherical cosine in [-1,1] (Cauchy-Schwarz on unit vectors)",
@@ -429,8 +429,8 @@
     {
       "path": "Proofs/FeuerbachsTheoremOQ04Midpoint.lean",
       "filename": "FeuerbachsTheoremOQ04Midpoint.lean",
-      "lineCount": 119,
-      "theoremCount": 6,
+      "lineCount": 199,
+      "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

In the spherical Feuerbach development, `sMidpoint A B = ‖A+B‖⁻¹•(A+B)` was proven *equidistant* from its endpoints (`sdist_sMidpoint_eq`), but a point equidistant from `A` and `B` need not be their midpoint — the antipode of the true midpoint is equidistant too. This PR proves the sharper fact that pins down the geometry and justifies the name. Added to `Proofs/FeuerbachsTheoremOQ04Midpoint.lean`:

- **`sdist_sMidpoint_half`** — the midpoint **bisects the arc**: `sdist A (sMidpoint A B) = ½·sdist A B`.
- **`norm_add_sq_unit`** — `‖A+B‖² = 2 + 2⟪A,B⟫` for model points (reusable polarisation).
- **`scos_sMidpoint_left`** — the explicit vertex-to-midpoint spherical cosine `‖A+B‖⁻¹(1+⟪A,B⟫)`.

### Proof note

The bisection avoids half-angle lemmas: `scos A M = ‖A+B‖⁻¹(1+⟪A,B⟫) ≥ 0` gives `sdist A M ≤ π/2`, so `2·sdist A M ∈ [0,π]`; the double-angle identity `cos(2·sdist A M) = 2·(scos A M)² − 1` collapses (via `(scos A M)² = (1+⟪A,B⟫)/2`) to `⟪A,B⟫ = cos(sdist A B)`, and `Real.injOn_cos` on `[0,π]` closes it.

## Verification

- Docker build: `Built Proofs.FeuerbachsTheoremOQ04Midpoint` (7745 jobs).
- `#print axioms` for all three new theorems = `{propext, Classical.choice, Quot.sound}` — **0 sorries, 0 axioms, no native_decide**.
- Companion 119→199 lines, 6→9 theorems; research `leanFiles` entry synced.

## Scope

A bounded, reusable ingredient. The hard Feuerbach tangency capstone (nine-point circle tangent to the incircle) remains the sole open frontier and is not touched.