### PR TITLE
Enrich hyperbolic Ptolemy (OQ-02): cover the docstring preamble

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy-oq-02/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy-oq-02/meta.json
@@ -62,6 +62,14 @@
   },
   "sections": [
     {
+      "id": "context-setup",
+      "title": "Context: Discharging the Hyperbolic Ptolemy Conjecture",
+      "startLine": 1,
+      "endLine": 88,
+      "summary": "Imports (the parent PtolemysComplexProof, Arsinh) and the module docstring. The synthesis file SynthesisCurvaturePtolemy.lean unified the Euclidean (K=0) and spherical (K>0) Ptolemy theorems via curvatureSin K but left the hyperbolic case (K=-1) as a conjecture, remarking a full treatment needs the Poincaré-disk metric space (~800-1200 lines, blocked in Mathlib). This file discharges it as a fully verified theorem with no such machinery: the key observation is that every product in the Ptolemy relation shares the common conformal denominator √∏(1-‖zᵢ‖²), so clearing it reduces the hyperbolic inequality DIRECTLY to the Euclidean ptolemy_inequality. Includes an explicit honesty note: poincareDist is DEFINED by the standard closed form (2·arsinh of the conformal chord), not re-derived to be a genuine metric, and no metric axiom is used. Sets linter.unusedVariables false.",
+      "mathContext": "poincareChord z w = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)) = sinh(d_H/2) = curvatureSin(-1)(d_H/2); conformal-factor cancellation reduces K=-1 Ptolemy to the Euclidean case."
+    },
+    {
       "id": "conformal-chord",
       "title": "The Conformal Chord of the Poincaré Disk",
       "startLine": 89,


### PR DESCRIPTION
Enrichment pass for `synthesis-curvature-ptolemy-oq-02` (Hyperbolic Ptolemy Theorem in the Poincaré Disk, K = -1).

**Structural gap:** the `sections` array started at line 89, leaving the 88-line preamble uncovered — imports (the parent `PtolemysComplexProof`, `Arsinh`) and the substantial module docstring that carries the whole argument: how the K=-1 hyperbolic case (left as a conjecture by the synthesis file, thought to need ~800-1200 lines of blocked Poincaré-disk metric machinery) is discharged instead by *conformal-factor cancellation* down to the Euclidean `ptolemy_inequality`, plus the explicit honesty note on how `poincareDist` is defined. Added a **Context** section (1–88, with `summary` and `mathContext`) so the sections now span the full 306-line file, verified against `Proofs/SynthesisCurvaturePtolemyOQ02.lean`.

Size: meta.json 18.9 → 19.8 KB, within the 60 KB cap. No content removed; the five existing sections keep their descriptions/summaries/mathContext. status/badge/axiomCount (verified, original, 0) unchanged and accurate — the only grep hit for sorry/axiom is the docstring's '0 sorries / 0 axioms' note. Not superseded (origin/main still has 5 sections).