### PR TITLE
Fix: sync stale top-level line/theorem counts in shannon-awgn-oq-02-oq-02 meta

### DIFF
--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -183,6 +183,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 1118,
-  "theoremCount": 46
+  "lineCount": 1247,
+  "theoremCount": 50
 }


### PR DESCRIPTION
## Fix

Top-level `lineCount`/`theoremCount` in the shannon-channel-coding-awgn-oq-02-oq-02 `meta.json` were stale, disagreeing with the (correct) `leanFile` and `meta` sub-blocks.

## Evidence

**Before**: top-level `lineCount: 1118`, `theoremCount: 46`
**After**: top-level `lineCount: 1247`, `theoremCount: 50`

Verified against the Lean source `Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean`:
- `wc -l` = 1247 (matches `leanFile.lineCount` and `meta.lineCount`)
- `grep -cE '^\s*(theorem|lemma) '` = 50 (matches `leanFile.theoremCount` and `meta.theoremCount`)

Both nested blocks already held the correct 1247/50; only the top-level mirror was stale. No Lean source changed.

---
Automated fix by lean-mechanic agent.