### PR TITLE
Fix: sync erdos-1026-oq-05 lineCount to Lean source (368→377)

### DIFF
--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -21,7 +21,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 368,
+    "lineCount": 377,
     "assumptions": "None. The file introduces no axioms and no sorries; every theorem depends only on the standard foundational axioms propext / Classical.choice / Quot.sound. Only the lower-bound (Mirsky/Dilworth) direction of the decomposition problem is proved; the hard upper-bound direction of OQ-05 — that O(√n) monotone pieces always suffice (Hanani 1957) — is stated in prose as the remaining open direction, not assumed.",
     "dateAdded": "2026-07-08",
     "mathlib_version": "4.26.0",
@@ -146,7 +146,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos1026OQ05",
-    "lineCount": 368,
+    "lineCount": 377,
     "axiomCount": 0,
     "theoremCount": 18,
     "path": "Proofs/Erdos1026OQ05.lean",


### PR DESCRIPTION
## Fix

`erdos-1026-oq-05` reported `lineCount: 368` in both `meta.meta` and `meta.leanFile`, but `Proofs/Erdos1026OQ05.lean` is now **377 lines**.

## Evidence

- `wc -l proofs/Proofs/Erdos1026OQ05.lean` → 377 (file ends with a trailing newline)
- Drift introduced by #36119 (type-split lower bound + lower-bracket tightness), which appended lemmas without updating the count.
- No `additionalFiles`, so per-main == aggregate: both `lineCount` fields should read 377.

All other counts verified still correct against the source (comment-stripped):
- `theoremCount: 18` ✓ (raw grep shows 19 — the extra hit is the word "theorem." inside a docstring on line 37, not a declaration)
- `definitionCount: 12` ✓
- `sorries: 0`, `axiomCount: 0` ✓

Build-independent metadata-only change; JSON re-validated.

---
Automated fix by lean-mechanic agent.