### PR TITLE
Research: erdos-1064-oq-03 — prime-triple reversal family collapses to {21,55} [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -827,6 +827,129 @@ theorem two_distinct_reversal_families :
   ⟨reversal_via_criterion, reversal_via_criterion_55, by decide⟩
 
 -- ===========================================================================
+-- THE PRIME-TRIPLE REVERSAL FAMILY COLLAPSES TO `{21, 55}`
+-- ---------------------------------------------------------------------------
+-- The two known reversal seeds `21 = 3·7` and `55 = 5·11` are both of the form
+-- `a = p·(2p+1)` for the two smallest Sophie-Germain primes `p = 3, 5` (with the
+-- extra property that `p+2` is also prime).  It is tempting to hope that this
+-- natural infinite candidate family — odd primes `p` with `p+2` and `2p+1` also
+-- prime — furnishes infinitely many reversal seeds, which would give a purely
+-- elementary proof that the reversal *seed* set is infinite.  It does NOT.
+--
+-- For such a `p` write `a = p·(2p+1)`.  Then (all coprimalities from primality):
+--     φ(a) = (p−1)·2p,
+--     first cototient step  2a − φ(a) = 2p(p+2)  (2-adic valuation 1, so
+--                                                  transport-admissible, b = p(p+2)),
+--     φ(b) = (p−1)(p+1) = p²−1,
+--     landing constant  C = 2a − φ(b) = 3p²+2p+1 = 2·e   with  e = (3p²+2p+1)/2,
+--                                                  and v₂(C) = 1 (t = 1).
+-- The `k`-free reversal criterion `dblIter_reversal_iff` says the family reverses
+-- iff  φ(a) < φ(e)·2^(t−1) = φ(e).  But `φ(e) ≤ e − 1 = (3p²+2p−1)/2` always, and
+--     (3p²+2p−1)/2 ≤ 2p(p−1)   ⟺   0 ≤ p²−6p+1   ⟺   p ≥ 6,
+-- so for every `p ≥ 7` we get `φ(e) ≤ φ(a)` and the family does NOT reverse — the
+-- forward/equality regime wins.  Only the two exceptional small primes `p = 3, 5`
+-- (below the quadratic threshold `3+2√2 ≈ 5.83`) reverse.  Hence this family
+-- yields exactly the two seeds `{21, 55}`, and the infinitude of the reversal seed
+-- set (if true) is genuinely harder than exhibiting one infinite candidate family.
+-- Note the crucial point: proving `φ(e) ≤ e−1` needs NO knowledge of the (wildly
+-- varying) factorisation of `e`, which is precisely what makes the bound uniform.
+-- ===========================================================================
+
+/-- **The prime-triple reversal family does not reverse for `p ≥ 7`.**  For an
+    odd prime `p` with `p+2` and `2p+1` also prime, the transport-admissible seed
+    `a = p·(2p+1)` has `φ(a) = 2p(p−1)` and landing constant `C = 3p²+2p+1 = 2e`;
+    reversal of the family `a·2^(k+1)` would require `φ(a) < φ(e)`, but
+    `φ(e) ≤ e−1 ≤ φ(a)` whenever `p ≥ 7` (equivalently `p²−6p+1 ≥ 0`).  So no
+    member of this natural infinite candidate family with `p ≥ 7` is a reversal
+    seed; the only reversing members are the two small exceptions `p = 3` (→ 21)
+    and `p = 5` (→ 55). -/
+theorem prime_triple_family_not_reversal {p : ℕ}
+    (hp : p.Prime) (hp2 : (p + 2).Prime) (hq : (2 * p + 1).Prime)
+    (hp7 : 7 ≤ p) (k : ℕ) :
+    p * (2 * p + 1) * 2 ^ (k + 1) ∉ ReversalSet := by
+  -- write the odd prime `p ≥ 7` as `p = 2j+1` with `j ≥ 3`
+  have hpodd : p % 2 = 1 := (hp.eq_two_or_odd).resolve_left (by omega)
+  obtain ⟨j, rfl⟩ : ∃ j, p = 2 * j + 1 := ⟨p / 2, by omega⟩
+  have hj3 : 3 ≤ j := by omega
+  -- coprimalities from distinct primality
+  have hcopa : Nat.Coprime (2 * j + 1) (2 * (2 * j + 1) + 1) :=
+    (Nat.coprime_primes hp hq).mpr (by omega)
+  have hcopb : Nat.Coprime (2 * j + 1) ((2 * j + 1) + 2) :=
+    (Nat.coprime_primes hp hp2).mpr (by omega)
+  -- φ(a) = 2j·(2·(2j+1)),  φ(b) = 2j·((2j+1)+1)
+  have hφa : Nat.totient ((2 * j + 1) * (2 * (2 * j + 1) + 1))
+      = 2 * j * (2 * (2 * j + 1)) := by
+    rw [Nat.totient_mul hcopa, Nat.totient_prime hp, Nat.totient_prime hq,
+        show (2 * j + 1) - 1 = 2 * j from by omega,
+        show 2 * (2 * j + 1) + 1 - 1 = 2 * (2 * j + 1) from by omega]
+  have hφb : Nat.totient ((2 * j + 1) * ((2 * j + 1) + 2))
+      = 2 * j * ((2 * j + 1) + 1) := by
+    rw [Nat.totient_mul hcopb, Nat.totient_prime hp, Nat.totient_prime hp2,
+        show (2 * j + 1) - 1 = 2 * j from by omega,
+        show (2 * j + 1) + 2 - 1 = (2 * j + 1) + 1 from by omega]
+  -- oddness of the three odd data
+  have ha_odd : Odd ((2 * j + 1) * (2 * (2 * j + 1) + 1)) :=
+    (Nat.odd_iff.mpr (by omega)).mul (Nat.odd_iff.mpr (by omega))
+  have hb_odd : Odd ((2 * j + 1) * ((2 * j + 1) + 2)) :=
+    (Nat.odd_iff.mpr (by omega)).mul (Nat.odd_iff.mpr (by omega))
+  have he_odd : Odd (6 * j ^ 2 + 8 * j + 3) := ⟨3 * j ^ 2 + 4 * j + 1, by ring⟩
+  -- transport data:  2a − φ(a) = 2b  and  2a − φ(b) = e·2¹
+  have hstep : 2 * ((2 * j + 1) * (2 * (2 * j + 1) + 1))
+      - Nat.totient ((2 * j + 1) * (2 * (2 * j + 1) + 1))
+      = 2 * ((2 * j + 1) * ((2 * j + 1) + 2)) := by
+    rw [hφa]
+    have h : 2 * ((2 * j + 1) * (2 * (2 * j + 1) + 1))
+        = 2 * ((2 * j + 1) * ((2 * j + 1) + 2)) + 2 * j * (2 * (2 * j + 1)) := by ring
+    omega
+  have hC : 2 * ((2 * j + 1) * (2 * (2 * j + 1) + 1))
+      - Nat.totient ((2 * j + 1) * ((2 * j + 1) + 2))
+      = (6 * j ^ 2 + 8 * j + 3) * 2 ^ 1 := by
+    rw [hφb]
+    have h : 2 * ((2 * j + 1) * (2 * (2 * j + 1) + 1))
+        = (6 * j ^ 2 + 8 * j + 3) * 2 ^ 1 + 2 * j * ((2 * j + 1) + 1) := by ring
+    omega
+  -- feed the k-free reversal criterion and refute the sign inequality
+  rw [dblIter_reversal_iff ha_odd hb_odd he_odd (le_refl 1) hstep hC k]
+  simp only [Nat.sub_self, pow_zero, mul_one]
+  rw [hφa]
+  -- goal: ¬ (2j·(2·(2j+1)) < φ(6j²+8j+3));  i.e. φ(e) ≤ φ(a)
+  push_neg
+  have he2 : 1 < 6 * j ^ 2 + 8 * j + 3 := by nlinarith [hj3]
+  have hφe : Nat.totient (6 * j ^ 2 + 8 * j + 3) < 6 * j ^ 2 + 8 * j + 3 :=
+    Nat.totient_lt _ he2
+  have hquad : 6 * j ^ 2 + 8 * j + 2 ≤ 2 * j * (2 * (2 * j + 1)) := by nlinarith [hj3]
+  omega
+
+/-- **The prime-triple family reverses exactly at `p ∈ {3, 5}`.**  For every odd
+    prime `p` with `p+2` and `2p+1` also prime, the family `p·(2p+1)·2^(k+1)`
+    lands in the reversal regime `φ(n) < φ(D(n))` iff `p = 3` (seed `21`) or
+    `p = 5` (seed `55`).  The `p ≥ 7` members are ruled out by
+    `prime_triple_family_not_reversal`; the two small cases are the known reversal
+    families.  Thus the natural Sophie-Germain-type candidate family contributes
+    exactly the two reversal seeds `21` and `55` — it does not, by itself, prove
+    the reversal seed set infinite. -/
+theorem prime_triple_reversal_iff {p : ℕ}
+    (hp : p.Prime) (hp2 : (p + 2).Prime) (hq : (2 * p + 1).Prime) (k : ℕ) :
+    p * (2 * p + 1) * 2 ^ (k + 1) ∈ ReversalSet ↔ (p = 3 ∨ p = 5) := by
+  constructor
+  · intro hmem
+    by_contra hne
+    push_neg at hne
+    obtain ⟨h3, h5⟩ := hne
+    -- an odd prime with `p+2, 2p+1` prime and `p ∉ {3,5}` must be `≥ 7`
+    have h2le := hp.two_le
+    have hp7 : 7 ≤ p := by
+      by_contra hlt
+      push_neg at hlt
+      interval_cases p <;> revert hp hp2 hq h3 h5 <;> decide
+    exact prime_triple_family_not_reversal hp hp2 hq hp7 k hmem
+  · rintro (rfl | rfl)
+    · rw [show (3 : ℕ) * (2 * 3 + 1) = 21 from by norm_num]
+      exact reversal_via_criterion k
+    · rw [show (5 : ℕ) * (2 * 5 + 1) = 55 from by norm_num]
+      exact reversal_via_criterion_55 k
+
+-- ===========================================================================
 -- A COMPUTABLE DECISION PROCEDURE FOR TRANSPORT FAMILIES
 -- ---------------------------------------------------------------------------
 -- The `k`-free criterion above still asks the caller to *supply* the odd data

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -325,3 +325,45 @@ elaboration) — verified on host instead (file imports only Mathlib).
 - Sharpen the necessary condition with φ(seedE a)/seedE a to attempt the excluded-regime
   non-reversal claim; relate φ(seedE a) back to φ(a) = p^(k-1)(p-1) for a = p^k, p≡3 mod4.
 - Density-1 forward direction still analytically blocked (ψ(x,y) smooth-number density).
+
+## Session 2026-07-08 (researcher-3) — prime-triple reversal family collapses to {21,55}
+
+**Mode**: REVISIT (RICH tier) | **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, Docker `Built (7.4s)`, 3058 jobs; axioms propext/Classical.choice/Quot.sound; no native_decide)
+
+### What I Did
+- Observed the two known reversal seeds `21 = 3·7`, `55 = 5·11` are exactly
+  `a = p·(2p+1)` for the two smallest Sophie-Germain primes `p = 3, 5` (with the
+  extra property that `p+2` is also prime — a "prime triple" `(p, p+2, 2p+1)`).
+- Proved this natural infinite candidate family does NOT furnish infinitely many
+  reversal seeds:
+  - `prime_triple_family_not_reversal`: for `p ≥ 7` with `p, p+2, 2p+1` all
+    prime, `p(2p+1)·2^(k+1) ∉ ReversalSet`.
+  - `prime_triple_reversal_iff`: the family reverses iff `p ∈ {3, 5}`.
+
+### Key Findings / proof recipe
+- For `a = p(2p+1)` (p, 2p+1 prime): `φ(a) = 2p(p−1)`, first step
+  `2a−φ(a) = 2p(p+2)` (v₂ = 1, transport-admissible, `b = p(p+2)`),
+  `φ(b) = p²−1`, landing `C = 2a−φ(b) = 3p²+2p+1 = 2e`, `t = 1`.
+- Reversal ⟺ `φ(a) < φ(e)` (via `dblIter_reversal_iff`, `t = 1`). The uniform
+  non-reversal bound uses ONLY `φ(e) ≤ e−1` (no factorisation of the wildly
+  varying `e` needed!): `φ(e) ≤ e−1 = (3p²+2p−1)/2 ≤ 2p(p−1) = φ(a)` ⟺
+  `p²−6p+1 ≥ 0` ⟺ `p ≥ 6`. Below the threshold `3+2√2 ≈ 5.83` only `p = 3, 5`.
+- Lean plumbing: substitute `p = 2j+1` (j ≥ 3) to kill all nat-subtraction in
+  the polynomial identities; `φ(a)`, `φ(b)` via `Nat.totient_mul` +
+  `Nat.totient_prime` with the two `show (2j+1)-1 = 2j` rewrites; `hstep`/`hC`
+  each proven by a `ring` additive identity fed to `omega` (which abstracts the
+  nonlinear products as atoms and discharges the nat subtraction); final sign
+  refutation by `Nat.totient_lt` + two `nlinarith [hj3]` + `omega`.
+- `prime_triple_reversal_iff` forward: an odd prime with `p+2, 2p+1` prime and
+  `p ∉ {3,5}` is forced `≥ 7` by `interval_cases p <;> revert … <;> decide`.
+
+### Files Modified
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (+123 lines, 2 theorems)
+- `src/data/research/problems/erdos-1064-oq-03.json`
+
+### Next Steps
+- Elementary terminus stands: the only open direction remains the analytically
+  hard density-1 forward statement (ψ(x,y) smooth-number density / Luca–Pomerance)
+  — a genuine Mathlib gap, not session-sized. Reversal-seed-set infinitude, if
+  true, is essentially the hard direction (this session shows the natural
+  candidate family degenerates). Do not reclaim for elementary work.

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "MILESTONE (researcher-6, VERIFIED 0/0): the STRUCTURAL side of Erdős 1064 OQ-03 is now COMPLETE. Proved that NO excluded seed (seedS≥2, = prime powers p≡3 mod4) ever reverses, hence every totient-inequality reversal occurs strictly in the transport-admissible regime seedS=1 (reversal_seed_transport_admissible / reversal_mem_implies_transport_regime). This converts the long-standing structural conjecture into a theorem. The ONLY remaining open part is the analytically-hard density-1 forward direction (ψ(x,y) smooth-number density), a genuine Mathlib gap.",
+    "progressSummary": "PROGRESS: Structural result on which admissible seeds reverse. The natural Sophie-Germain-type family a=p(2p+1) [p,p+2,2p+1 prime] reverses only at p=3,5 (seeds 21,55); every p≥7 member is non-reversing (proven, VERIFIED 0/0). Shows reversal-seed-set infinitude is genuinely harder than one candidate family. Excluded regime already fully closed; only open direction remains the analytically-hard density-1 forward ψ(x,y) statement (Mathlib gap, not session-sized).",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -93,7 +93,9 @@
       "prime_pow_three_mod_four_family_not_reversal (EulerTotientOQ04OQ03.lean): p^k·2^(j+1)∉ReversalSet for all prime p≡3 mod4, k≥1, j. VERIFIED 0/0",
       "excluded_seed_never_reverses (EulerTotientOQ04OQ03.lean): seedS a≥2 ⟹ classifySeed a≠.lt for odd a≥3. VERIFIED 0/0",
       "reversal_seed_transport_admissible (EulerTotientOQ04OQ03.lean): classifySeed a=.lt ⟹ seedS a=1. VERIFIED 0/0",
-      "reversal_mem_implies_transport_regime (EulerTotientOQ04OQ03.lean): a·2^(k+1)∈ReversalSet ⟹ seedS a=1. VERIFIED 0/0"
+      "reversal_mem_implies_transport_regime (EulerTotientOQ04OQ03.lean): a·2^(k+1)∈ReversalSet ⟹ seedS a=1. VERIFIED 0/0",
+      "prime_triple_family_not_reversal in EulerTotientOQ04OQ03.lean: for p≥7 with p,p+2,2p+1 all prime, family p(2p+1)·2^(k+1) never reverses (φ(e)≤e−1≤φ(a) once p²−6p+1≥0; uniform since φ(e)≤e−1 needs no factorisation of e)",
+      "prime_triple_reversal_iff in EulerTotientOQ04OQ03.lean: the prime-triple family reverses iff p∈{3,5}, contributing exactly seeds {21,55}"
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",
@@ -122,7 +124,8 @@
       "The full excluded prime-power case is now closed: EVERY prime power a=p^k with p≡3 mod4 (k≥1) never reverses. This subsumes both prior infinite families (3^k tower AND primes p≡3 mod4, k=1) as special slices.",
       "Uniform prime-power arithmetic: a=p^(m+1) gives a−φ(a)=p^m and 2a−φ(a)=p^m·(p+1); factoring p+1=w·2^S (w odd, S=v2(p+1)≥2) yields seedS=S, seedB=p^m·w. The engine bound becomes p^m≤φ(p^m)·φ(w)·2^(S−2).",
       "The bound splits into two elementary facts: p^m≤2·φ(p^m) (any prime p, via φ(p^m)=p^(m-1)(p-1) and 2(p-1)≥p) and 2≤φ(w)·2^(S−2). The latter holds precisely when p>3: S=2∧w=1 forces p+1=4 ⟹ p=3, so p≥7 gives either S≥3 (2^(S-2)≥2) or w≥3 odd (φ(w)≥2). p=3 is dispatched by the 3^k tower.",
-      "CAPSTONE (structural conjecture now proven): the excluded seeds (seedS a≥2) are EXACTLY prime powers p^k with p≡3 mod4 (seedS_ge_two_iff_totient_mod_four composed with totient_mod_four_eq_two_iff_prime_pow_three_mod_four, both already in the file). Since all such powers never reverse, NO excluded seed reverses — equivalently every reversing seed has seedS a=1 (transport-admissible). The long-conjectured structural dichotomy is a theorem."
+      "CAPSTONE (structural conjecture now proven): the excluded seeds (seedS a≥2) are EXACTLY prime powers p^k with p≡3 mod4 (seedS_ge_two_iff_totient_mod_four composed with totient_mod_four_eq_two_iff_prime_pow_three_mod_four, both already in the file). Since all such powers never reverse, NO excluded seed reverses — equivalently every reversing seed has seedS a=1 (transport-admissible). The long-conjectured structural dichotomy is a theorem.",
+      "Both known reversal seeds 21=3·7 and 55=5·11 are exactly a=p·(2p+1) for the two smallest Sophie-Germain primes p=3,5 (with p+2 also prime); this natural infinite candidate family does NOT give infinitely many reversal seeds."
     ],
     "mathlibGaps": [
       "Kernel `decide` on Nat.totient of a seed (e.g. totient 21) blows the stack → SIGBUS (Lean exit 135, line-less); must prove totient values by factorisation (Nat.totient_mul + Nat.totient_prime). Reconfirms the file's existing note."


### PR DESCRIPTION
## Summary
Research session for **erdos-1064-oq-03** (higher-iterate totient inequality; RICH tier). The excluded regime was already fully closed in prior sessions (every reversal is transport-admissible, `seedS a = 1`). This session addresses the noted follow-up — *which* transport-admissible seeds actually reverse — via a clean structural result.

## Progress (VERIFIED, 0 sorry / 0 axiom)
Both known reversal seeds `21 = 3·7` and `55 = 5·11` are exactly `a = p·(2p+1)` for the two smallest Sophie-Germain primes `p = 3, 5` (with `p+2` also prime — a "prime triple" `(p, p+2, 2p+1)`). One might hope this natural **infinite** candidate family furnishes infinitely many reversal seeds — an elementary proof that the reversal *seed* set is infinite. **It does not.**

- `prime_triple_family_not_reversal`: for every `p ≥ 7` with `p, p+2, 2p+1` all prime, `p(2p+1)·2^(k+1) ∉ ReversalSet`.
- `prime_triple_reversal_iff`: the family reverses **iff** `p ∈ {3, 5}`.

## Findings
For `a = p(2p+1)`: `φ(a) = 2p(p−1)`, first cototient step `2a−φ(a) = 2p(p+2)` (2-adic valuation 1, transport-admissible, `b = p(p+2)`), `φ(b) = p²−1`, landing constant `C = 2a−φ(b) = 3p²+2p+1 = 2e` with `t = 1`. Via the existing `k`-free criterion `dblIter_reversal_iff`, reversal ⟺ `φ(a) < φ(e)`. The uniform non-reversal bound uses **only** `φ(e) ≤ e−1` (no knowledge of the wildly varying factorisation of `e`):
`φ(e) ≤ e−1 = (3p²+2p−1)/2 ≤ 2p(p−1) = φ(a)  ⟺  p²−6p+1 ≥ 0  ⟺  p ≥ 6`.
Only the two primes below the threshold `3+2√2 ≈ 5.83` reverse. So this candidate family contributes exactly `{21, 55}`; the infinitude of the reversal seed set, if true, is genuinely harder — essentially the hard (density-1 forward) direction.

## Files Modified
- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (+123 lines, 2 theorems)
- `src/data/research/problems/erdos-1064-oq-03.json`, `research/problems/erdos-1064-oq-03/knowledge.md`

## Status
**Outcome**: progress. Docker `Built (7.4s)`, 3058 jobs, 0 sorry / 0 axiom (`propext`/`Classical.choice`/`Quot.sound` only; no `native_decide`).
**Next Steps**: Elementary terminus stands — the only open direction remains the analytically-hard density-1 forward statement (ψ(x,y) smooth-number density / Luca–Pomerance), a genuine Mathlib gap, not session-sized.

🤖 Generated by researcher-3