### PR TITLE
Gallery integrity: szemeredi-counting overstates contributions (placeholder + phantom results)

### DIFF
--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -39,11 +39,10 @@
       }
     ],
     "originalContributions": [
-      "Counting lemma for triangles in epsilon-regular triples",
-      "Triangle removal lemma from regularity + counting",
-      "Quantitative triangle removal with explicit gamma and proper R construction",
-      "General graph removal lemma framework",
-      "Connection between triangle removal and Roth's theorem"
+      "Counting lemma for triangles in epsilon-regular triples (counting_lemma, counting_lemma_lower_bound)",
+      "Quantitative triangle removal lemma with explicit gamma and a proper edge-removal set R satisfying |R| <= delta*n^2 (triangle_removal_quantitative)",
+      "Good/bad vertex decomposition and per-vertex density bounds underlying the counting argument (bad_vertices_small, perVertex_density_bound)",
+      "Regularity bridge exposing Mathlib's szemeredi_regularity as an epsilon-regular Finpartition (regularity_with_finpartition)"
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
@@ -55,7 +54,7 @@
       "Roth's theorem on 3-term arithmetic progressions"
     ],
     "lineCount": 1230,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. The core epsilon-regular partition is obtained from Mathlib's szemeredi_regularity theorem (badge: mathlib), not independently proved here; this file builds the triangle counting lemma and the quantitative triangle removal lemma on top of it.",
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
     "definitionCount": 7


### PR DESCRIPTION
## Integrity Issue

**Proof**: szemeredi-counting
**Problem**: `originalContributions` credits three items that are not actual results.

## Evidence (proofs/Proofs/SzemerediCounting.lean)

| Contribution bullet | Lean referent | Reality |
|---|---|---|
| "Triangle removal lemma from regularity + counting" | `triangle_removal_lemma` (line 475) | Edge-removal bound stubbed to `True` (line 485); proof takes `R = all edges` (line 494). Vacuous placeholder — the source comment itself calls it a "placeholder". Superseded by the quantitative version. |
| "General graph removal lemma framework" | `graph_removal_lemma` (line 507) | Conclusion is only `∃ gamma : ℚ, gamma > 0`, proved by `⟨1, by norm_num⟩`. States nothing about removal. |
| "Connection between triangle removal and Roth's theorem" | — | **Phantom**: file contains no Roth / ThreeAPFree / corner / AP content at all. |

The genuine results are the counting lemma (`counting_lemma`) and the quantitative triangle removal lemma (`triangle_removal_quantitative`, line 597 — real `|R| ≤ δn²` bound, fully proved). The file is genuinely sorry-free and axiom-free.

## Fix applied

- Rewrote `originalContributions` to list only what is actually proved (counting lemma, quantitative triangle removal, good/bad vertex decomposition, Mathlib regularity bridge).
- Updated `assumptions` to disclose reliance on Mathlib's `szemeredi_regularity` (consistent with `badge: mathlib`) instead of "None. Fully verified."
- `status` stays `verified` (sorry-free, axiom-free); no over/under-claim there.

## Follow-up (Mechanic)

The dead placeholder theorems `triangle_removal_lemma` and `graph_removal_lemma` could be removed from the Lean source since `triangle_removal_quantitative` subsumes them.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)