### PR TITLE
Fix: sync stale top-level line/theorem counts for shannon-awgn-oq-02-oq-02

### DIFF
--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -183,6 +183,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 1118,
-  "theoremCount": 46
+  "lineCount": 1247,
+  "theoremCount": 50
 }


### PR DESCRIPTION
## Fix

The top-level count block in `shannon-channel-coding-awgn-oq-02-oq-02/meta.json` was stale, disagreeing with both the `leanFile` and `meta` blocks in the same file.

## Evidence

**Before**: top-level `lineCount: 1118`, `theoremCount: 46`
**After**: top-level `lineCount: 1247`, `theoremCount: 50`

Both the `leanFile` and `meta` blocks already read `1247` / `50`, and the source file confirms it:
- `wc -l proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean` → 1247
- `grep -cE '^\s*(theorem|lemma) '` → 50

The lone `sorry` grep hit is a docstring mention ("axiom-free and sorry-free"); `sorries` correctly remains `[]`.

Metadata-only change; no Lean source touched.

---
Automated fix by lean-mechanic agent.