### PR TITLE
research(erdos-729-oq-02): eliminate UNSOUND barreto_leeham_bound axiom [VERIFIED, 2→1 axioms]

### DIFF
--- a/proofs/Proofs/Erdos729Problem.lean
+++ b/proofs/Proofs/Erdos729Problem.lean
@@ -135,11 +135,30 @@ The answer is NO: the bound persists even modulo small primes.
 axiom barreto_leeham_theorem (C : ℝ) (hC : C > 0) :
     ¬InfinitelyManyExceptions C
 
-/-- Equivalently: for large n, a + b ≤ n + O(log n) even modulo small primes -/
-axiom barreto_leeham_bound (C : ℝ) (hC : C > 0) :
-    ∃ D : ℝ, D > 0 ∧ ∀ n a b : ℕ,
+/-- **The small-prime bound is axiom-free (sound uniform form).**  For every threshold
+    `C > 0` there is a single `D > 0` such that whenever the denominator of `C(n,·)` keeps
+    only primes `≤ C` (`DividesFactorialModSmall n a b C`) and `n ≥ 2`, the bound
+    `a + b ≤ n + D·log n` holds.
+
+    This was previously an `axiom`, but it is in fact a corollary of the elementary,
+    axiom-free `Erdos729DigitSum.erdos_1968_uniform`: `DividesFactorialModSmall n a b C`
+    unfolds to `∃ k, (small primes) ∧ k·a!·b! ∣ n!`, which already forces `a!·b! ∣ n!`
+    (as `a!·b! ∣ k·a!·b!`), so the plain factorial bound applies verbatim.  The `2 ≤ n`
+    hypothesis is required for soundness — the old axiom, stated for *all* `n`, was false
+    at `n ∈ {0, 1}` (e.g. `n = 1, a = b = 1`: the divisibility holds yet `a + b = 2 > 1 +
+    D·log 1 = 1` for every `D`), the same small-`n` defect noted for the retired
+    `erdos_1968_classical`. -/
+theorem barreto_leeham_bound (C : ℝ) (_hC : C > 0) :
+    ∃ D : ℝ, D > 0 ∧ ∀ n a b : ℕ, 2 ≤ n →
       DividesFactorialModSmall n a b C →
-      (a + b : ℝ) ≤ n + D * Real.log n
+      (a + b : ℝ) ≤ n + D * Real.log n := by
+  obtain ⟨D, hD, hbound⟩ := Erdos729DigitSum.erdos_1968_uniform
+  refine ⟨D, hD, fun n a b hn hmod => ?_⟩
+  obtain ⟨k, _hk, hdvd⟩ := hmod
+  -- `k·a!·b! ∣ n!` forces `a!·b! ∣ n!`, so the axiom-free uniform bound applies.
+  have hrw : k * a.factorial * b.factorial = a.factorial * b.factorial * k := by ring
+  rw [hrw] at hdvd
+  exact hbound n a b hn ((dvd_mul_right (a.factorial * b.factorial) k).trans hdvd)
 
 /-
 ## Part 6: The Proof Strategy
@@ -241,7 +260,8 @@ theorem erdos_729_summary :
     -- Answer: NO
     (∀ C : ℝ, C > 0 → ¬InfinitelyManyExceptions C) ∧
     -- The bound a + b ≤ n + O(log n) is intrinsic to factorial structure
-    (∀ C : ℝ, C > 0 → ∃ D : ℝ, D > 0 ∧ ∀ n a b : ℕ,
+    -- (sound uniform form, n ≥ 2; discharged axiom-free by barreto_leeham_bound)
+    (∀ C : ℝ, C > 0 → ∃ D : ℝ, D > 0 ∧ ∀ n a b : ℕ, 2 ≤ n →
       DividesFactorialModSmall n a b C →
       (a + b : ℝ) ≤ n + D * Real.log n) := by
   constructor

--- a/research/problems/erdos-729-oq-02/knowledge.md
+++ b/research/problems/erdos-729-oq-02/knowledge.md
@@ -111,3 +111,35 @@ sibling → its olean, then the edited parent → EXIT 0, then `#print axioms`).
 Classical direction now fully axiom-free. Remaining `barreto_leeham_*` axioms are the
 genuine open-question answer (published, multi-week) — NOT session-sized. Do not reclaim
 for axiom elimination.
+
+## Session 2026-07-08 (researcher-1): eliminate the UNSOUND barreto_leeham_bound axiom [VERIFIED — 1 axiom remains]
+
+**Mode:** AXIOM HUNT. `Erdos729Problem.lean` carried 2 axioms. Inspection showed
+`barreto_leeham_bound` was not merely unproven but **unsound** — it asserts a false
+proposition:
+`∀ C>0, ∃ D>0, ∀ n a b, DividesFactorialModSmall n a b C → a+b ≤ n + D·log n`.
+For any `D`, take `n=1, a=b=1`: `k·1!·1! ∣ 1!` forces `k=1` (prime factors of `1` empty, so
+`DividesFactorialModSmall 1 1 1 C` holds), yet `a+b = 2 > 1 + D·log 1 = 1`. Same small-`n`
+defect the companion already documented for the retired `erdos_1968_classical`. An axiom
+asserting `False` makes the file logically inconsistent.
+
+**Fix (2→1 axioms):**
+- `DividesFactorialModSmall n a b C` unfolds to `∃ k, (primes of k ≤ C) ∧ k·a!·b! ∣ n!`,
+  which already forces `a!·b! ∣ n!` (since `a!·b! ∣ k·a!·b!`, via `k·a!·b! = a!·b!·k` +
+  `dvd_mul_right`).
+- So the **sound** uniform form (add `2 ≤ n`) is a corollary of the axiom-free
+  `Erdos729DigitSum.erdos_1968_uniform` (`C = 4/log 2`). Converted the axiom to a verified
+  `theorem barreto_leeham_bound` and tightened `erdos_729_summary`'s second conjunct with
+  `2 ≤ n`.
+- The deep `barreto_leeham_theorem` (`¬InfinitelyManyExceptions C`, the actual
+  Barreto–Leeham "NO" resolution — genuinely open/hard for small `C`) is left as a
+  documented axiom.
+
+**Verification:** docker `Built Proofs.Erdos729Problem`; `#print axioms barreto_leeham_bound`
+= `{propext, Classical.choice, Quot.sound}` (axiom-free), and `erdos_729_summary` now depends
+only on `barreto_leeham_theorem` (the removed axiom no longer appears). File 251→271 lines,
+7→8 theorems, 2→1 axioms. meta.json + research metadata synced.
+
+**Note for future work:** the remaining axiom is the deep resolution and is not
+session-sized. The elementary axiom-free theory (digit-sum bound, uniform real-log bound,
+Legendre identities) is complete across the companion files.

--- a/src/data/proofs/erdos-729/meta.json
+++ b/src/data/proofs/erdos-729/meta.json
@@ -45,11 +45,11 @@
       "Defined relaxed divisibility allowing small prime factors",
       "Discharged the Legendre identity v_2(n!) = n - s_2(n) from Mathlib (removed legendre_identity axiom)"
     ],
-    "axiomCount": 2,
-    "lineCount": 251,
-    "assumptions": "2 axioms: barreto_leeham_theorem, barreto_leeham_bound. 0 sorries. The classical Erdős 1968 bound is now proved axiom-free (re-exported from Erdos729DigitSum.erdos_1968_uniform); its former erdos_1968_classical axiom has been removed. The Legendre identity v_2(n!) = n - s_2(n) (legendre_for_two) is fully proved from Mathlib's sub_one_mul_padicValNat_factorial; the former legendre_identity axiom has been removed.",
+    "axiomCount": 1,
+    "lineCount": 271,
+    "assumptions": "1 axiom: barreto_leeham_theorem (the deep Barreto-Leeham resolution ¬InfinitelyManyExceptions C, an external research result — genuinely open/hard for small C, left as a documented axiom). 0 sorries. The former barreto_leeham_bound axiom was UNSOUND (asserted a false proposition — failed at n∈{0,1}, e.g. n=1,a=b=1) and has been eliminated: its sound uniform form (2≤n) is now a verified theorem derived axiom-free from Erdos729DigitSum.erdos_1968_uniform via DividesFactorialModSmall ⟹ a!·b!∣n!. The classical Erdős 1968 bound is proved axiom-free (erdos_1968_uniform); its former erdos_1968_classical axiom was removed. The Legendre identity v_2(n!) = n - s_2(n) is proved from Mathlib; the former legendre_identity axiom was removed.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 8
   },
   "overview": {
@@ -195,9 +195,9 @@
       "Real"
     ],
     "namespace": "Erdos729",
-    "lineCount": 251,
-    "axiomCount": 2,
-    "theoremCount": 7,
+    "lineCount": 271,
+    "axiomCount": 1,
+    "theoremCount": 8,
     "definitionCount": 8,
     "path": "Proofs/Erdos729Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-3, 2026-07-08): added the honest UNIFORM real-logarithmic Erdős-1968 bound to the companion Erdos729DigitSumBound.lean, axiom-free (0 axioms/0 sorries). erdos_1968_uniform: ∃ single C=4/log2>0, ∀ n≥2, ∀ a,b with a!b!∣n!, (a+b:ℝ)≤n+C·log n. This is the correct replacement for the parent file's axiom erdos_1968_classical, which is BOTH unsound at n∈{0,1} (n=0,a=b=1: 1∣1 but 2≤0 false) AND vacuous for n≥2 (C chosen per-instance inside ∀ ⟹ take C=(a+b)/log n). Derived from the elementary 2-adic digit-sum bound via a Nat.log→Real.log bridge (2^⌊log₂n⌋≤n).",
+    "progressSummary": "AXIOM ELIMINATION (researcher-1 2026-07-08): removed the UNSOUND barreto_leeham_bound axiom (Erdos729Problem.lean 2->1 axioms). It asserted a FALSE proposition — for any D it fails at n in {0,1} (e.g. n=1,a=b=1: DividesFactorialModSmall holds yet a+b=2 > 1+D*log 1 = 1), the same small-n defect as the retired erdos_1968_classical. Since DividesFactorialModSmall n a b C unfolds to exists k (small primes) with k*a!*b! | n!, which forces a!*b! | n!, the SOUND uniform form (2<=n) is a corollary of the axiom-free Erdos729DigitSum.erdos_1968_uniform. Converted the axiom to a verified theorem and tightened erdos_729_summary with 2<=n. Only barreto_leeham_theorem (the deep Barreto-Leeham resolution) remains as a documented axiom. VERIFIED docker Built; #print axioms: barreto_leeham_bound axiom-free, erdos_729_summary depends only on barreto_leeham_theorem.",
     "builtItems": [
       "digitSum_prime_mul_add (p n r)(hp:1<p)(hr:r<p): (Nat.digits p (p*n+r)).sum = (Nat.digits p n).sum + r -- general base-p digit left-shift, Erdos729LegendrePrimeRecurrence.lean",
       "digitSum_prime_mul (p n)(hp:1<p): s_p(p*n)=s_p(n) -- r=0 invariant",
@@ -149,9 +149,9 @@
     {
       "path": "Proofs/Erdos729Problem.lean",
       "filename": "Erdos729Problem.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
-      "axiomCount": 3,
+      "lineCount": 271,
+      "theoremCount": 8,
+      "axiomCount": 1,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

`Erdos729Problem.lean` carried two axioms. One of them, `barreto_leeham_bound`, was not merely unproven but **unsound** — it asserts a *false* proposition, so the file was logically inconsistent through it.

The axiom claimed:
```
∀ C > 0, ∃ D > 0, ∀ n a b, DividesFactorialModSmall n a b C → a + b ≤ n + D·log n
```
For any `D`, take `n = 1, a = b = 1`: `k·1!·1! ∣ 1!` forces `k = 1` (the prime factors of `1` are empty, so `DividesFactorialModSmall 1 1 1 C` holds), yet `a + b = 2 > 1 + D·log 1 = 1`. This is exactly the small-`n` defect already documented for the retired `erdos_1968_classical`.

## Fix (2 → 1 axioms)

`DividesFactorialModSmall n a b C` unfolds to `∃ k, (primes of k ≤ C) ∧ k·a!·b! ∣ n!`, which already forces `a!·b! ∣ n!` (as `a!·b! ∣ k·a!·b!`). So the **sound** uniform form (with `2 ≤ n`) is a direct corollary of the axiom-free `Erdos729DigitSum.erdos_1968_uniform` (`C = 4/log 2`).

- Converted the `axiom` into a verified `theorem barreto_leeham_bound` (with `2 ≤ n`).
- Tightened `erdos_729_summary`'s second conjunct to add `2 ≤ n` (its previous statement was the same unsound claim).
- The deep `barreto_leeham_theorem` (`¬InfinitelyManyExceptions C` — the actual Barreto–Leeham resolution, genuinely open/hard for small `C`) is **left as a documented axiom**.

## Verification

- Docker build: `Built Proofs.Erdos729Problem` (7744 jobs).
- `#print axioms barreto_leeham_bound` = `{propext, Classical.choice, Quot.sound}` — **axiom-free**.
- `#print axioms erdos_729_summary` now lists only `barreto_leeham_theorem` (the removed axiom no longer appears).
- meta.json: `axiomCount` 2 → 1 (status stays `axiomatized`, one deep axiom remains), counts 251/7 → 271/8; `assumptions` field updated.

## Axiom-integrity note

Per the repo's axiom policy this stays `axiomatized` (one genuine deep assumption remains). The change strictly *reduces* assumptions and removes an unsound one.