### PR TITLE
research(shannon-awgn-oq-02-oq-02): weighted power law + MRC Cauchy-Schwarz SNR optimality [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -1244,4 +1244,112 @@ theorem awgn_weighted_multisymbol_power_of_uncorrelated [IsProbabilityMeasure μ
   refine Finset.sum_congr rfl fun i hi => ?_
   rw [second_moment_eq_variance (hW i hi) (hmean i hi)]
 
+/-! ### Maximal-ratio combining: the Cauchy–Schwarz SNR optimum
+
+The weighted power law `Var[∑ᵢ aᵢ·Wᵢ] = ∑ᵢ aᵢ²·Var[Wᵢ]` says the *output noise power*
+of a linear combiner over uncorrelated branches is the square-weighted sum of the branch
+noise variances.  Pairing it with a *deterministic signal* component `∑ᵢ aᵢ·sᵢ` yields the
+central receiver-design question for the AWGN channel: over all gain vectors `a`, how large
+can the output signal-to-noise ratio
+
+        SNR(a) = (∑ᵢ aᵢ·sᵢ)² / (∑ᵢ aᵢ²·vᵢ)
+
+be made, where `vᵢ > 0` is the `i`-th branch noise variance?  The answer is the classical
+**maximal-ratio-combining (MRC)** theorem: the supremum equals the sum of per-branch SNRs
+`∑ᵢ sᵢ²/vᵢ`, attained exactly at the *matched* weights `aᵢ = sᵢ/vᵢ`.  The mathematics is a
+single application of the finite-sum Cauchy–Schwarz inequality
+`Finset.sum_mul_sq_le_sq_mul_sq` to the split `aᵢ·sᵢ = (aᵢ√vᵢ)·(sᵢ/√vᵢ)`. -/
+
+/-- **MRC signal bound (Cauchy–Schwarz core).**  For deterministic gains `a`, signal
+amplitudes `sig`, and strictly positive branch noise variances `v`, the squared combined
+signal is bounded by the product of the output noise power `∑ aᵢ²vᵢ` and the summed
+per-branch SNRs `∑ sᵢ²/vᵢ`:
+
+        (∑ᵢ aᵢ·sᵢ)² ≤ (∑ᵢ aᵢ²·vᵢ) · (∑ᵢ sᵢ²/vᵢ).
+
+Proof: Cauchy–Schwarz `(∑ fᵢgᵢ)² ≤ (∑ fᵢ²)(∑ gᵢ²)` with `fᵢ = aᵢ·√vᵢ`, `gᵢ = sᵢ/√vᵢ`, so
+`fᵢgᵢ = aᵢsᵢ` (the `√vᵢ` cancels), `fᵢ² = aᵢ²vᵢ`, `gᵢ² = sᵢ²/vᵢ`. -/
+theorem mrc_signal_sq_le {ι : Type*} (s : Finset ι) (a sig v : ι → ℝ)
+    (hv : ∀ i ∈ s, 0 < v i) :
+    (∑ i ∈ s, a i * sig i) ^ 2
+      ≤ (∑ i ∈ s, a i ^ 2 * v i) * (∑ i ∈ s, sig i ^ 2 / v i) := by
+  have e1 : ∀ i ∈ s, (a i * Real.sqrt (v i)) * (sig i / Real.sqrt (v i)) = a i * sig i := by
+    intro i hi
+    have hne : Real.sqrt (v i) ≠ 0 := Real.sqrt_ne_zero'.mpr (hv i hi)
+    field_simp
+  have e2 : ∀ i ∈ s, (a i * Real.sqrt (v i)) ^ 2 = a i ^ 2 * v i := by
+    intro i hi; rw [mul_pow, Real.sq_sqrt (hv i hi).le]
+  have e3 : ∀ i ∈ s, (sig i / Real.sqrt (v i)) ^ 2 = sig i ^ 2 / v i := by
+    intro i hi; rw [div_pow, Real.sq_sqrt (hv i hi).le]
+  calc (∑ i ∈ s, a i * sig i) ^ 2
+      = (∑ i ∈ s, (a i * Real.sqrt (v i)) * (sig i / Real.sqrt (v i))) ^ 2 := by
+        rw [Finset.sum_congr rfl (fun i hi => (e1 i hi).symm)]
+    _ ≤ (∑ i ∈ s, (a i * Real.sqrt (v i)) ^ 2) * (∑ i ∈ s, (sig i / Real.sqrt (v i)) ^ 2) :=
+        Finset.sum_mul_sq_le_sq_mul_sq s _ _
+    _ = (∑ i ∈ s, a i ^ 2 * v i) * (∑ i ∈ s, sig i ^ 2 / v i) := by
+        rw [Finset.sum_congr rfl e2, Finset.sum_congr rfl e3]
+
+/-- **MRC upper bound on output SNR.**  Whenever the output noise power `∑ aᵢ²vᵢ` is
+strictly positive, the combiner's signal-to-noise ratio is at most the sum of the
+per-branch SNRs:
+
+        (∑ᵢ aᵢ·sᵢ)² / (∑ᵢ aᵢ²·vᵢ) ≤ ∑ᵢ sᵢ²/vᵢ.
+
+No gain vector `a` can beat the summed branch SNRs — the fundamental limit of linear
+combining over an uncorrelated AWGN block. -/
+theorem mrc_snr_le {ι : Type*} (s : Finset ι) (a sig v : ι → ℝ)
+    (hv : ∀ i ∈ s, 0 < v i) (hpos : 0 < ∑ i ∈ s, a i ^ 2 * v i) :
+    (∑ i ∈ s, a i * sig i) ^ 2 / (∑ i ∈ s, a i ^ 2 * v i)
+      ≤ ∑ i ∈ s, sig i ^ 2 / v i := by
+  rw [div_le_iff₀ hpos]
+  calc (∑ i ∈ s, a i * sig i) ^ 2
+      ≤ (∑ i ∈ s, a i ^ 2 * v i) * (∑ i ∈ s, sig i ^ 2 / v i) := mrc_signal_sq_le s a sig v hv
+    _ = (∑ i ∈ s, sig i ^ 2 / v i) * (∑ i ∈ s, a i ^ 2 * v i) := by ring
+
+/-- **MRC achievability (matched weights attain the bound).**  Setting the gains to the
+matched-filter values `aᵢ = sᵢ/vᵢ` makes the output SNR equal the summed per-branch SNRs,
+so the bound `mrc_snr_le` is sharp:
+
+        (∑ᵢ (sᵢ/vᵢ)·sᵢ)² / (∑ᵢ (sᵢ/vᵢ)²·vᵢ) = ∑ᵢ sᵢ²/vᵢ.
+
+Both the combined signal `∑ (sᵢ/vᵢ)·sᵢ` and the output noise power `∑ (sᵢ/vᵢ)²·vᵢ` collapse
+to `∑ sᵢ²/vᵢ`, so the ratio is `S²/S = S`.  Together with `mrc_snr_le` this identifies the
+maximum output SNR of a linear combiner as exactly `∑ᵢ sᵢ²/vᵢ`. -/
+theorem mrc_snr_matched {ι : Type*} (s : Finset ι) (sig v : ι → ℝ)
+    (hv : ∀ i ∈ s, 0 < v i) (hpos : 0 < ∑ i ∈ s, sig i ^ 2 / v i) :
+    (∑ i ∈ s, (sig i / v i) * sig i) ^ 2 / (∑ i ∈ s, (sig i / v i) ^ 2 * v i)
+      = ∑ i ∈ s, sig i ^ 2 / v i := by
+  have hnum : ∑ i ∈ s, (sig i / v i) * sig i = ∑ i ∈ s, sig i ^ 2 / v i := by
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [div_mul_eq_mul_div, ← pow_two]
+  have hden : ∑ i ∈ s, (sig i / v i) ^ 2 * v i = ∑ i ∈ s, sig i ^ 2 / v i := by
+    apply Finset.sum_congr rfl
+    intro i hi
+    have hne : v i ≠ 0 := (hv i hi).ne'
+    field_simp
+  rw [hnum, hden, pow_two, mul_div_assoc, div_self hpos.ne', mul_one]
+
+/-- **MRC theorem in measure-theoretic form (capstone).**  Let `N : ι → Ω → ℝ` be a finite
+block of pairwise-uncorrelated, square-integrable noise branches with strictly positive
+variances, and let `sig i` be the deterministic per-branch signal amplitudes.  Then the
+squared combined signal is bounded by the *actual output noise variance*
+`Var[∑ᵢ aᵢ·Nᵢ]` times the summed per-branch SNRs:
+
+        (∑ᵢ aᵢ·sigᵢ)² ≤ Var[∑ᵢ aᵢ·Nᵢ] · (∑ᵢ sigᵢ²/Var[Nᵢ]).
+
+This is `mrc_signal_sq_le` with the noise power `∑ aᵢ²vᵢ` supplied by the weighted power law
+`variance_smul_sum_of_pairwise_uncorrelated` (`vᵢ = Var[Nᵢ]`): the Cauchy–Schwarz SNR bound
+is not a separate hypothesis but a *consequence* of the variance-of-a-weighted-sum identity,
+tying the combiner's optimality directly to the Bienaymé structure of uncorrelated noise. -/
+theorem mrc_output_signal_sq_le_variance_mul [IsFiniteMeasure μ] {ι : Type*}
+    {N : ι → Ω → ℝ} {s : Finset ι} (a sig : ι → ℝ)
+    (hN : ∀ i ∈ s, MemLp (N i) 2 μ)
+    (huncor : Set.Pairwise ↑s fun i j => cov[N i, N j; μ] = 0)
+    (hv : ∀ i ∈ s, 0 < Var[N i; μ]) :
+    (∑ i ∈ s, a i * sig i) ^ 2
+      ≤ Var[∑ i ∈ s, a i • N i; μ] * (∑ i ∈ s, sig i ^ 2 / Var[N i; μ]) := by
+  rw [variance_smul_sum_of_pairwise_uncorrelated a hN huncor]
+  exact mrc_signal_sq_le s a sig (fun i => Var[N i; μ]) hv
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 1247,
+    "lineCount": 1355,
     "axiomCount": 0,
-    "theoremCount": 50,
+    "theoremCount": 54,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 1247,
-    "theoremCount": 50,
+    "lineCount": 1355,
+    "theoremCount": 54,
     "definitionCount": 1,
     "badge": "mathlib",
     "originalContributions": [

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0/0): added the weighted-combining power law Var[∑aᵢWᵢ]=∑aᵢ²Var[Wᵢ] for pairwise-uncorrelated families (bilinear Bienaymé double-sum + uncorrelated diagonal + zero-mean output-power capstone) — the maximal-ratio-combining / matched-filter second-order identity, the aᵢ-weighted generalisation of the unweighted variance_sum_of_pairwise_uncorrelated stack.",
+    "progressSummary": "PROGRESS (VERIFIED 0/0): maximal-ratio-combining (MRC) SNR optimality proved — the max output SNR of a linear combiner over an uncorrelated AWGN branch block equals the summed per-branch SNRs ∑sᵢ²/Var[Nᵢ] (Cauchy-Schwarz upper bound + matched-weight achievability + measure-theoretic capstone resting on the weighted power law). Ties the abstract variance-of-a-weighted-sum theory to the actual AWGN receiver-design theorem.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -64,7 +64,11 @@
       "stddev_add_lt_iff_not_affine_pos (ShannonChannelCodingAWGNOQ02OQ02.lean): σ[X+Y] < σ[X]+σ[Y] ⟺ ¬∃a>0,b. X=ᵐa·Y+b — structural negation of stddev_add_eq_iff_affine_pos",
       "variance_smul_sum: Var[∑aᵢ•Wᵢ]=∑ᵢ∑ⱼ aᵢaⱼ·cov[Wᵢ,Wⱼ] (weighted Bienaymé double-sum, ShannonChannelCodingAWGNOQ02OQ02.lean:1186)",
       "variance_smul_sum_of_pairwise_uncorrelated: Var[∑aᵢ•Wᵢ]=∑ᵢ aᵢ²·Var[Wᵢ] for pairwise-uncorrelated families — the MRC/matched-filter power law, a≡1 recovers variance_sum_of_pairwise_uncorrelated (line 1208)",
-      "awgn_weighted_multisymbol_power_of_uncorrelated: E[(∑aᵢ•Wᵢ)²]=∑ᵢ aᵢ²·E[Wᵢ²] for zero-mean uncorrelated symbols — physical weighted output power (line 1230)"
+      "awgn_weighted_multisymbol_power_of_uncorrelated: E[(∑aᵢ•Wᵢ)²]=∑ᵢ aᵢ²·E[Wᵢ²] for zero-mean uncorrelated symbols — physical weighted output power (line 1230)",
+      "mrc_signal_sq_le (ShannonChannelCodingAWGNOQ02OQ02.lean): (∑aᵢsigᵢ)²≤(∑aᵢ²vᵢ)(∑sigᵢ²/vᵢ) via Cauchy-Schwarz split fᵢ=aᵢ√vᵢ, gᵢ=sigᵢ/√vᵢ [VERIFIED 0/0]",
+      "mrc_snr_le (ShannonChannelCodingAWGNOQ02OQ02.lean): output SNR (∑aᵢsigᵢ)²/(∑aᵢ²vᵢ)≤∑sigᵢ²/vᵢ when noise power>0 [VERIFIED 0/0]",
+      "mrc_snr_matched (ShannonChannelCodingAWGNOQ02OQ02.lean): matched weights aᵢ=sigᵢ/vᵢ attain the bound, SNR=∑sigᵢ²/vᵢ [VERIFIED 0/0]",
+      "mrc_output_signal_sq_le_variance_mul (ShannonChannelCodingAWGNOQ02OQ02.lean): measure-theoretic MRC capstone (∑aᵢsigᵢ)²≤Var[∑aᵢ•Nᵢ]·(∑sigᵢ²/Var[Nᵢ]) for pairwise-uncorrelated positive-variance noise [VERIFIED 0/0]"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -83,7 +87,9 @@
       "The triangle-equality boundary sits at the OPPOSITE Cauchy-Schwarz endpoint from variance_add_eq_iff_covariance_zero: variances add iff cov=0 (orthogonal), but standard deviations add iff cov=σ[X]σ[Y] (perfectly positively correlated, ρ=+1).",
       "Multivariate stddev-triangle equality (√Var[∑Wᵢ]=∑σ[Wᵢ]) reduces via square+variance_sum'+Finset.sum_mul_sum to ∑ᵢ∑ⱼcov=∑ᵢ∑ⱼσᵢσⱼ; each summand obeys Cauchy–Schwarz cov≤σᵢσⱼ, so the two double sums are equal iff every ordered pair saturates it — Finset.sum_eq_sum_iff_of_le twice (nested).",
       "Strict triangle inequality needs NO fresh analysis: it is purely lt_iff_le_and_ne applied to both sides of the equality boundary (stddev_add_le gives ≤ on the left, abs_correlation_le_one gives ρ≤1 on the right), then not_iff_not on the eq-iff. simp only [stddev_add_le hX hY, hρle, true_and, ne_eq, not_iff_not] discharges the whole reduction in one line.",
-      "Weighted combining lifts the whole Bienaymé stack by bilinearity: covariance_smul_left/right push each aᵢ,aⱼ out of cov[aᵢWᵢ,aⱼWⱼ]=aᵢaⱼcov, and variance_smul gives the diagonal Var[aᵢWᵢ]=aᵢ²Var[Wᵢ]; no new analysis, just scalar-out rewrites — working in the a•W (smul) form (not fun ω=>a*W ω) aligns directly with Mathlib covariance_smul_*/variance_smul/MemLp.const_smul."
+      "Weighted combining lifts the whole Bienaymé stack by bilinearity: covariance_smul_left/right push each aᵢ,aⱼ out of cov[aᵢWᵢ,aⱼWⱼ]=aᵢaⱼcov, and variance_smul gives the diagonal Var[aᵢWᵢ]=aᵢ²Var[Wᵢ]; no new analysis, just scalar-out rewrites — working in the a•W (smul) form (not fun ω=>a*W ω) aligns directly with Mathlib covariance_smul_*/variance_smul/MemLp.const_smul.",
+      "MRC (maximal-ratio-combining) optimality is a direct Cauchy-Schwarz consequence of the weighted power law: splitting aᵢsᵢ=(aᵢ√vᵢ)(sᵢ/√vᵢ) and applying Finset.sum_mul_sq_le_sq_mul_sq gives (∑aᵢsᵢ)²≤(∑aᵢ²vᵢ)(∑sᵢ²/vᵢ); the noise-power factor ∑aᵢ²vᵢ IS the output variance Var[∑aᵢNᵢ] from variance_smul_sum_of_pairwise_uncorrelated, so combiner optimality rests on the Bienaymé structure, not a fresh hypothesis.",
+      "The maximum output SNR of a linear combiner over an uncorrelated AWGN branch block equals the sum of per-branch SNRs ∑sᵢ²/vᵢ, attained exactly at matched weights aᵢ=sᵢ/vᵢ (both combined signal ∑(sᵢ/vᵢ)sᵢ and noise power ∑(sᵢ/vᵢ)²vᵢ collapse to S=∑sᵢ²/vᵢ, so SNR=S²/S=S) — the achievability half making mrc_snr_le sharp."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -103,7 +109,9 @@
       "Consider corr sign-flip corollary for a>0,c<0 (orientation-reversing): ρ[aX+b,cY+d]=−ρ[X,Y] as the negative companion of correlation_affine_invariant_of_pos.",
       "Dual equality for the finite-sum triangle inequality stddev_sum_le: σ[∑Wᵢ]=∑σ[Wᵢ] iff all pairs are perfectly positively correlated (all centered contributions a.e. nonneg-proportional to a common direction) — needs an induction handling the shared-direction propagation.",
       "Affine form of the multivariate boundary: √Var[∑Wᵢ]=∑σ requires a COMMON increasing-affine template (all Wᵢ =ᵐ aᵢ·Y+bᵢ, aᵢ>0) — harder than pairwise, needs a shared regressor Y; the pairwise-correlation form is the clean stopping point.",
-      "Strict multivariate form: σ[∑Wᵢ] < ∑σ[Wᵢ] ⟺ NOT all pairs perfectly positively correlated — strict companion of stddev_sum_eq_iff_pairwise_correlation_eq_one, via lt_iff_le_and_ne on stddev_sum_le (needs the finite-family ρ≤1 pairwise ceiling, else just ≠-form)."
+      "Strict multivariate form: σ[∑Wᵢ] < ∑σ[Wᵢ] ⟺ NOT all pairs perfectly positively correlated — strict companion of stddev_sum_eq_iff_pairwise_correlation_eq_one, via lt_iff_le_and_ne on stddev_sum_le (needs the finite-family ρ≤1 pairwise ceiling, else just ≠-form).",
+      "MRC equality condition in variance form: (∑aᵢsigᵢ)²=Var[∑aᵢ•Nᵢ]·(∑sigᵢ²/Var[Nᵢ]) iff a is proportional to the matched vector sigᵢ/Var[Nᵢ] — the Cauchy-Schwarz equality case (vectors aᵢ√vᵢ ∥ sigᵢ/√vᵢ).",
+      "Correlated-noise MRC: replace diagonal ∑aᵢ²vᵢ by the full quadratic form aᵀΣa (Σ=covariance matrix); optimum SNR = sᵀΣ⁻¹s at a=Σ⁻¹s — needs a PD-matrix Cauchy-Schwarz / whitening argument, a genuine generalisation beyond the uncorrelated diagonal case."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the multi-symbol AWGN output-power theory (`ShannonChannelCodingAWGNOQ02OQ02.lean`) with the **maximal-ratio-combining (MRC) SNR optimality theorem** — the genuine AWGN receiver-design capstone — resting on the weighted variance-of-a-sum law.

This branch carries two verified increments:

### 1. Weighted power law (earlier commits)
- `variance_smul_sum'` — `Var[∑aᵢWᵢ] = ∑ᵢ∑ⱼ aᵢaⱼ cov[Wᵢ,Wⱼ]` (weighted Bienaymé double sum via bilinearity of covariance).
- `variance_smul_sum_of_pairwise_uncorrelated` — `Var[∑aᵢWᵢ] = ∑ aᵢ²Var[Wᵢ]` for pairwise-uncorrelated families (MRC output power).
- `awgn_weighted_multisymbol_power_of_uncorrelated` — zero-mean second-moment form.

### 2. MRC SNR optimality (this session)
- `mrc_signal_sq_le` — Cauchy–Schwarz core: `(∑aᵢsᵢ)² ≤ (∑aᵢ²vᵢ)(∑sᵢ²/vᵢ)` via the split `aᵢsᵢ = (aᵢ√vᵢ)(sᵢ/√vᵢ)` and `Finset.sum_mul_sq_le_sq_mul_sq`.
- `mrc_snr_le` — output SNR `(∑aᵢsᵢ)²/(∑aᵢ²vᵢ) ≤ ∑sᵢ²/vᵢ`: no gain vector beats the summed per-branch SNRs.
- `mrc_snr_matched` — **achievability**: matched weights `aᵢ = sᵢ/vᵢ` attain the bound, giving output SNR `= ∑sᵢ²/vᵢ` (so the bound is sharp).
- `mrc_output_signal_sq_le_variance_mul` — measure-theoretic capstone: `(∑aᵢsigᵢ)² ≤ Var[∑aᵢ•Nᵢ]·(∑sigᵢ²/Var[Nᵢ])`, with the noise-power factor supplied by the weighted power law itself (not a fresh hypothesis).

**Result:** the maximum output SNR of a linear combiner over an uncorrelated AWGN branch block equals the sum of per-branch SNRs `∑sᵢ²/Var[Nᵢ]`, attained at matched-filter weights — the mathematical content of MRC, tied directly to the Bienaymé variance structure.

## Verification
- Docker build: `✔ Built Proofs.ShannonChannelCodingAWGNOQ02OQ02` (0 errors)
- 0 `sorry`, 0 `axiom` declarations, 0 `native_decide` — **VERIFIED 0/0**
- Gallery counts synced (54 theorems, 1355 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)