### PR TITLE
research(burnside-counting-oq-02): general primitive-rotation fixed-point count |Fix(r)|=k for unit r [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/BurnsideCounting.lean
+++ b/proofs/Proofs/BurnsideCounting.lean
@@ -501,3 +501,110 @@ theorem binary_necklaces_3 :
   rw [show (∑ a : ZMod 3,
       Fintype.card { c : Coloring 3 2 // IsFixedByRotation a c }) = 12 from by decide] at h
   omega
+
+/-! ## Part VI: The Primitive-Rotation Fixed-Point Count
+
+The concrete facts `|Fix(1)| = |Fix(3)| = 2` used in `fixed_point_sum_binary_4`
+are the `(n, k) = (4, 2)` instances of a general theorem: when the rotation
+amount `r` is a **unit** of `ZMod n` (equivalently `gcd(r, n) = 1`, i.e. `r`
+generates the cyclic group), the only colorings fixed by `r` are the constant
+ones, so `|Fix(r)| = k`.  This is the `gcd = 1` case of the classical necklace
+fixed-point formula `|Fix(r)| = k ^ gcd(r, n)`; it feeds the general engine
+`sum_fixedBy_eq_card_necklaces_mul` and evaluates the primitive-rotation fixed
+sets with no `decide` cost. -/
+
+/-- Iterating a fixed rotation: if `c` is fixed by `r` then it is fixed by every
+    natural multiple `m • r`.  Proof by induction on `m` using only the
+    `AddAction` axioms (`zero_vadd`, `add_vadd`). -/
+theorem isFixed_nsmul {n k : ℕ} [NeZero n] {r : ZMod n} {c : Coloring n k}
+    (h : r +ᵥ c = c) : ∀ m : ℕ, (m • r) +ᵥ c = c := by
+  intro m
+  induction m with
+  | zero => rw [zero_nsmul, zero_vadd]
+  | succ m ih => rw [succ_nsmul, add_vadd, h, ih]
+
+/-- A coloring fixed by the rotation `1` is constant: rotation by `1` sends
+    position `i` to `i - 1`, so `c(i) = c(i-1)` for every `i`; iterating around
+    the `n`-cycle forces every position to agree with position `0`. -/
+theorem isConstant_of_isFixedByRotation_one {n k : ℕ} [NeZero n]
+    {c : Coloring n k} (h : IsFixedByRotation (1 : ZMod n) c) : IsConstant c := by
+  have hn : 0 < n := NeZero.pos n
+  have h' : rotateColoring n k 1 c = c := h
+  suffices hbase : ∀ m (hm : m < n), c ⟨m, hm⟩ = c ⟨0, hn⟩ by
+    intro i j
+    calc c i = c ⟨i.val, i.isLt⟩ := by rw [Fin.eta]
+      _ = c ⟨0, hn⟩ := hbase i.val i.isLt
+      _ = c ⟨j.val, j.isLt⟩ := (hbase j.val j.isLt).symm
+      _ = c j := by rw [Fin.eta]
+  rcases eq_or_ne n 1 with hn1 | hn1
+  · -- `n = 1`: only position `0` exists.
+    intro m hm
+    have : m = 0 := by omega
+    subst this
+    rfl
+  · haveI : Fact (1 < n) := ⟨by omega⟩
+    have hv1 : (1 : ZMod n).val = 1 := ZMod.val_one n
+    intro m
+    induction m with
+    | zero => intro hm; rfl
+    | succ m ih =>
+      intro hm
+      -- Rotation by `1` sends position `m + 1` to position `m`.
+      have hrot : rotatedIndex n 1 ⟨m + 1, hm⟩ = ⟨m, by omega⟩ := by
+        apply Fin.ext
+        simp only [rotatedIndex, Fin.val_mk, hv1]
+        have h1n : 1 % n = 1 := Nat.mod_eq_of_lt (by omega)
+        rw [h1n]
+        have he : (m + 1) + n - 1 = m + n := by omega
+        rw [he, Nat.add_mod_right, Nat.mod_eq_of_lt (by omega : m < n)]
+      have step : c ⟨m, by omega⟩ = c ⟨m + 1, hm⟩ := by
+        have hi := congrFun h' ⟨m + 1, hm⟩
+        rw [show rotateColoring n k 1 c ⟨m + 1, hm⟩
+              = c (rotatedIndex n 1 ⟨m + 1, hm⟩) from rfl, hrot] at hi
+        exact hi
+      rw [← step]
+      exact ih (by omega)
+
+/-- **Unit rotations fix only constant colorings.**  For a unit `r : ZMod n`
+    (equivalently `gcd(r, n) = 1`), a coloring is fixed by rotation by `r` iff it
+    is constant.  The forward direction promotes "fixed by `r`" to "fixed by
+    `1`" — since some multiple `m • r = 1` when `r` is a unit — and then applies
+    `isConstant_of_isFixedByRotation_one`; the reverse direction is immediate
+    because constant colorings are fixed by every rotation. -/
+theorem isFixedByRotation_unit_iff_isConstant {n k : ℕ} [NeZero n]
+    {r : ZMod n} (hr : IsUnit r) (c : Coloring n k) :
+    IsFixedByRotation r c ↔ IsConstant c := by
+  constructor
+  · intro hc
+    obtain ⟨u, rfl⟩ := hr
+    have hc' : (↑u : ZMod n) +ᵥ c = c := hc
+    obtain ⟨m, hm⟩ : ∃ m : ℕ, (m : ZMod n) = (↑u⁻¹ : ZMod n) :=
+      ⟨(↑u⁻¹ : ZMod n).val, ZMod.natCast_rightInverse _⟩
+    have key : (m • (↑u : ZMod n)) = 1 := by
+      rw [nsmul_eq_mul, hm, ← Units.val_mul, inv_mul_cancel, Units.val_one]
+    have h1 : (1 : ZMod n) +ᵥ c = c := by
+      have hfix := isFixed_nsmul hc' m
+      rwa [key] at hfix
+    exact isConstant_of_isFixedByRotation_one h1
+  · intro hconst
+    show r +ᵥ c = c
+    funext i
+    show rotateColoring n k r c i = c i
+    exact hconst _ i
+
+/-- **Primitive-rotation fixed-point count.**  For any length `n ≥ 1`, palette
+    size `k`, and unit rotation `r : ZMod n` (i.e. `gcd(r, n) = 1`), the number
+    of colorings fixed by `r` is exactly `k` — the `k` constant colorings.  This
+    is the `gcd = 1` case of `|Fix(r)| = k ^ gcd(r, n)` and generalizes the
+    hard-coded `|Fix(1)| = |Fix(3)| = 2` used for binary `4`-necklaces. -/
+theorem fixedBy_card_of_isUnit {n k : ℕ} [NeZero n] {r : ZMod n} (hr : IsUnit r) :
+    Fintype.card { c : Coloring n k // IsFixedByRotation r c } = k := by
+  rw [Fintype.card_congr
+    (Equiv.subtypeEquivRight (isFixedByRotation_unit_iff_isConstant hr))]
+  exact constant_coloring_count n k
+
+/-- Cross-check: for binary `4`-necklaces the primitive rotation by `1` fixes
+    exactly the `2` constant colorings, recovering the `|Fix(1)| = 2` entry of
+    `fixed_point_sum_binary_4` from the general formula. -/
+example : Fintype.card { c : Coloring 4 2 // IsFixedByRotation 1 c } = 2 :=
+  fixedBy_card_of_isUnit isUnit_one

--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. The S5 drift repair (Mathlib v4.26) replaces every `native_decide` with kernel `decide` plus a genuine application of Mathlib's additive Burnside lemma `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup`, so the file no longer depends on `Lean.ofReduceBool`. `#print axioms fixed_point_sum_binary_4` and `#print axioms binary_necklaces_4` report only the foundational trio [propext, Classical.choice, Quot.sound]. 0 literal `axiom` declarations, 0 sorries, no assumption-carrying structures.",
-    "lineCount": 503,
-    "theoremCount": 15,
+    "lineCount": 610,
+    "theoremCount": 19,
     "definitionCount": 9,
     "originalContributions": [
       "burnside_lemma: Burnside orbit-counting theorem from Mathlib (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
@@ -72,9 +72,9 @@
   },
   "leanFile": {
     "namespace": "BurnsideCounting",
-    "lineCount": 503,
+    "lineCount": 610,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 19,
     "definitionCount": 9,
     "path": "Proofs/BurnsideCounting.lean",
     "sorries": 0
@@ -135,6 +135,13 @@
       "statement": "$|(\\mathrm{Coloring}\\ 4\\ 2)/\\sim| = 6$",
       "significance": "**The headline application (now proved).** The number of distinct binary necklaces of length 4 is exactly 6: $\\{0000\\}, \\{1111\\}, \\{0001, 0010, 0100, 1000\\}, \\{0011, 0110, 1100, 1001\\}, \\{0101, 1010\\}, \\{0111, 1011, 1101, 1110\\}$. Matches OEIS A000029 (necklaces under rotation) at $n=4$. Discharged in S4 ACT (burnside-counting-oq-01) — the last of the 5 original axioms, making the file axiom-free.",
       "description": "Stated against `coloringSetoid` (= `AddAction.orbitRel (ZMod 4) (Coloring 4 2)`) and the computable `coloringQuotientFintype` instance (both derived, not axiomatized, since S2). S4 ACT originally discharged this by a single `native_decide` over the computable quotient. The S5 drift repair replaces that with a genuine application of Mathlib's additive Burnside lemma `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup`: `∑ a : ZMod 4, |Fix a| = |orbits| * |ZMod 4|`, where the fixed-point sum is 24 (`fixed_point_sum_binary_4`, whose subtypes are defeq to `fixedBy`) and `|ZMod 4| = 4`, so `|orbits| = 6` by arithmetic — kernel-checked with `decide` for the finite counts and no `Lean.ofReduceBool`. Previously stated as an axiom."
+    },
+    {
+      "name": "fixedBy_card_of_isUnit",
+      "type": "core",
+      "statement": "For a unit $r : \\mathbb{Z}/n\\mathbb{Z}$ (i.e. $\\gcd(r,n)=1$), $|\\mathrm{Fix}(r)| = k$",
+      "significance": "**General primitive-rotation fixed-point count.** Generalizes the hard-coded facts $|\\mathrm{Fix}(1)| = |\\mathrm{Fix}(3)| = 2$ used in `fixed_point_sum_binary_4` to arbitrary length $n$ and palette size $k$: whenever the rotation amount $r$ generates $\\mathbb{Z}/n\\mathbb{Z}$ (a unit, equivalently $\\gcd(r,n)=1$), the only fixed colorings are the $k$ constant ones. This is exactly the $\\gcd = 1$ case of the classical necklace fixed-point formula $|\\mathrm{Fix}(r)| = k^{\\gcd(r,n)}$, and feeds the general engine `sum_fixedBy_eq_card_necklaces_mul` with no `decide` cost for primitive rotations.",
+      "description": "Proved via two supporting lemmas. `isFixed_nsmul`: if $c$ is fixed by $r$ then it is fixed by every natural multiple $m \\cdot r$ (induction on $m$ using only the `AddAction` axioms). `isConstant_of_isFixedByRotation_one`: a coloring fixed by rotation $1$ satisfies $c(i)=c(i-1)$ around the whole $n$-cycle, hence is constant. For a unit $r$, some multiple $m \\cdot r = 1$ (take $m = (r^{-1}).\\mathrm{val}$), promoting fixed-by-$r$ to fixed-by-$1$; the reverse inclusion is immediate since constant colorings are fixed by every rotation. The count then follows from `constant_coloring_count` via `Equiv.subtypeEquivRight`. Kernel-checked, no `native_decide`, no `Lean.ofReduceBool`."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

The literal task for `burnside-counting-oq-02` — verify `fixed_point_sum_binary_4` — was already complete on `main` (proven by kernel `decide`, even better than the requested `native_decide`; see the doc-only PR #35444). Rather than re-mark it done, this PR makes a **genuine mathematical advance** on the same file: the general closed form for primitive-rotation fixed-point counts.

## What's new

Adds the `gcd = 1` case of the classical necklace fixed-point formula `|Fix(r)| = k^gcd(r,n)` to `proofs/Proofs/BurnsideCounting.lean`, generalizing the file's hard-coded `|Fix(1)| = |Fix(3)| = 2` (the entries feeding `fixed_point_sum_binary_4`) to **arbitrary** length `n` and palette size `k`.

New theorems (all kernel-checked — no `native_decide`, no `Lean.ofReduceBool`):

| Theorem | Statement |
|---|---|
| `isFixed_nsmul` | if `c` is fixed by `r` then it is fixed by every natural multiple `m • r` (induction using only the `AddAction` axioms) |
| `isConstant_of_isFixedByRotation_one` | a coloring fixed by rotation `1` satisfies `c(i) = c(i-1)` around the whole `n`-cycle, hence is constant |
| `isFixedByRotation_unit_iff_isConstant` | for a unit `r : ZMod n` (i.e. `gcd(r,n)=1`), `c` is fixed by `r` iff `c` is constant |
| `fixedBy_card_of_isUnit` | **`|Fix(r)| = k`** for any unit `r : ZMod n` |

The proof promotes "fixed by `r`" to "fixed by `1`" (some multiple `m • r = 1` when `r` is a unit), applies the cycle argument to force constancy, and closes with `constant_coloring_count` via `Equiv.subtypeEquivRight`. This is exactly the `gcd = 1` slice of the full formula and feeds the existing engine `sum_fixedBy_eq_card_necklaces_mul` with **no `decide` cost** for primitive rotations.

A cross-check `example` recovers `|Fix(1)| = 2` for binary 4-necklaces from the general theorem.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BurnsideCounting` → `Built Proofs.BurnsideCounting` (3058 jobs), 0 errors. Only pre-existing unused-simp-arg lint warnings on untouched lines.
- 0 sorries, 0 axiom declarations, no structure-encoded assumptions in the new material.

## Gallery

- `meta.json` counts synced: `lineCount` 503→610, `theoremCount` 15→19 (both `meta` and `leanFile` blocks).
- Added a `mainTheorems` entry for `fixedBy_card_of_isUnit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)