### PR TITLE
research(erdos-1090-incomplete-01): realizable cardinalities = full ray [R(k),∞) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -561,6 +561,51 @@ theorem exists_hasRamseyProperty_card_eq_ramseyNumber (k : ℕ) (hk : k ≥ 3) :
   obtain ⟨A, hcard, hA⟩ := Nat.sInf_mem hne
   exact ⟨A, hcard, hA⟩
 
+/-- The plane `ℝ²` is infinite: `t ↦ (t, 0)` (via `EuclideanSpace.single`) injects `ℝ`. -/
+instance : Infinite Point :=
+  Infinite.of_injective (fun a : ℝ => EuclideanSpace.single (0 : Fin 2) a) (fun a b h => by
+    have hb : EuclideanSpace.single (0 : Fin 2) a = EuclideanSpace.single (0 : Fin 2) b := h
+    have h0 : (EuclideanSpace.single (0 : Fin 2) a) 0
+            = (EuclideanSpace.single (0 : Fin 2) b) 0 := by rw [hb]
+    simpa [EuclideanSpace.single_apply] using h0)
+
+/--
+**Every size above `R(k)` is realizable.**
+For `k ≥ 3` and any `n ≥ R(k)` there is a configuration of *exactly* `n` points with the
+Ramsey property.  Take the extremal witness of size `R(k)`
+(`exists_hasRamseyProperty_card_eq_ramseyNumber`) and pad it with fresh plane points, one at
+a time: the plane is infinite, so a point outside the current set always exists, and enlarging
+preserves the Ramsey property (`hasRamseyProperty_mono`).  Thus the property is not a knife-edge
+phenomenon at the threshold — it persists for all larger cardinalities.
+-/
+theorem exists_hasRamseyProperty_card_eq {k : ℕ} (hk : k ≥ 3) {n : ℕ}
+    (hn : ramseyNumber k ≤ n) :
+    ∃ A : Finset Point, A.card = n ∧ HasRamseyProperty A k := by
+  obtain ⟨A, hAcard, hA⟩ := exists_hasRamseyProperty_card_eq_ramseyNumber k hk
+  have hAn : A.card ≤ n := hAcard ▸ hn
+  clear hAcard hn
+  induction n, hAn using Nat.le_induction with
+  | base => exact ⟨A, rfl, hA⟩
+  | succ m _ ih =>
+    obtain ⟨B, hBcard, hB⟩ := ih
+    obtain ⟨p, hp⟩ := Infinite.exists_notMem_finset B
+    exact ⟨insert p B, by rw [Finset.card_insert_of_notMem hp, hBcard],
+      hasRamseyProperty_mono (Finset.subset_insert p B) hB⟩
+
+/--
+**Realizable cardinalities are exactly the ray `[R(k), ∞)`.**
+For `k ≥ 3`, a finite point set of size `n` with the Ramsey property exists *iff* `R(k) ≤ n`.
+The forward direction is `ramseyNumber_le_of_hasRamseyProperty` (any witness bounds the infimum
+from above); the reverse is the padding argument `exists_hasRamseyProperty_card_eq`.  This pins
+down the realizable-size set completely: it is the full up-set above the threshold, with no gaps.
+-/
+theorem hasRamseyProperty_realizable_card_iff {k : ℕ} (hk : k ≥ 3) (n : ℕ) :
+    (∃ A : Finset Point, A.card = n ∧ HasRamseyProperty A k) ↔ ramseyNumber k ≤ n := by
+  constructor
+  · rintro ⟨A, hcard, hA⟩
+    exact hcard ▸ ramseyNumber_le_of_hasRamseyProperty hA
+  · exact exists_hasRamseyProperty_card_eq hk
+
 /-
 **R(3) is Small:**
 The k = 3 case can be achieved with a small set of points.

--- a/research/problems/erdos-1090-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1090-incomplete-01/knowledge.md
@@ -101,3 +101,27 @@ Remaining next-steps: `SylvesterGallai` still a placeholder DEF (needs a from-sc
 proof — not currently available); quantitative `ramseyNumber k` UPPER bound (only lower bound
 ≥ k proved; the HJ construction gives |A| ≤ k^|ι| but ι from Mathlib HJ is non-explicit);
 projection-body dedup (3 verified copies, left as-is).
+
+## Session 2026-07-08 (researcher-3): realizable cardinalities = full ray [R(k),∞)
+
+**Mode**: ACT (look-outward on SOLVED). **Outcome**: progress, 0-axiom. Added a complete
+characterization of which finite-set *sizes* admit the Ramsey property.
+- `instance : Infinite Point` — the plane ℝ² is infinite (reused the `EuclideanSpace.single`
+  injection idiom from `Erdos105OQ01.lean`; needs the `have hb : … := h` beta-reduction
+  intermediate before `rw`, else the redex `(fun a => single a) a` blocks the rewrite).
+- `exists_hasRamseyProperty_card_eq (hk : k≥3) (hn : ramseyNumber k ≤ n)`: **padding** — every
+  size ≥ R(k) is realizable. Take the extremal witness (`exists_hasRamseyProperty_card_eq_ramseyNumber`,
+  from #36101) and `Nat.le_induction` up, inserting a fresh plane point each step
+  (`Infinite.exists_notMem_finset`), Ramsey property preserved by `hasRamseyProperty_mono`.
+- `hasRamseyProperty_realizable_card_iff (hk : k≥3) (n)`: **∃ A, |A|=n ∧ HasRamseyProperty A k ↔
+  R(k) ≤ n**. Forward = `ramseyNumber_le_of_hasRamseyProperty`; reverse = the padding lemma.
+  Pins the realizable-size set down as *exactly* the up-set [R(k),∞) — the property is not a
+  knife-edge at the threshold, it persists for all larger cardinalities with no gaps.
+
+File 805→850 lines, 18→20 theorems (defs 18 unchanged; the new `instance` is not counted in
+definitionCount per the auditor convention def+abbrev+structure). Docker build EXIT 0, 0 sorry /
+0 axiom. Gallery `erdos-1090/meta.json` line/thm synced in both .meta and .leanFile blocks.
+
+Remaining next-steps unchanged: `SylvesterGallai` still a placeholder DEF (not in Mathlib,
+from-scratch); quantitative `ramseyNumber k` UPPER bound in closed form (HJ ι non-explicit);
+projection-body dedup (3 verified copies, left as-is).

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -70,9 +70,9 @@
       "helly_planar (0-axiom): proves the previously-unproved placeholder HellyProperty 2 for the plane by specializing Mathlib's Convex.helly_theorem_set to finrank ℝ ℝ² = 2 — every finite family of ≥3 planar convex sets whose 3-element subfamilies each intersect has a common point (classical planar Helly number d+1=3)"
     ],
     "axiomCount": 0,
-    "lineCount": 805,
+    "lineCount": 850,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 18
   },
   "overview": {
@@ -109,9 +109,9 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 805,
+    "lineCount": 850,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 18,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Erdős #1090 — realizable-size characterization

On this SOLVED entry (0 sorry / 0 axiom), a look-outward session adding a complete
characterization of **which finite-set sizes** admit the Ramsey property.

### New results
- **`instance : Infinite Point`** — the plane ℝ² is infinite (reuses the
  `EuclideanSpace.single` injection idiom).
- **`exists_hasRamseyProperty_card_eq`** (padding): for `k ≥ 3` and any `n ≥ R(k)` there
  is a configuration of *exactly* `n` points with the Ramsey property. Take the extremal
  witness of size `R(k)` (`exists_hasRamseyProperty_card_eq_ramseyNumber`) and `Nat.le_induction`
  upward, inserting a fresh plane point each step (`Infinite.exists_notMem_finset`); the
  property is preserved by `hasRamseyProperty_mono`.
- **`hasRamseyProperty_realizable_card_iff`**: `(∃ A, |A| = n ∧ HasRamseyProperty A k) ↔ R(k) ≤ n`.
  Forward = `ramseyNumber_le_of_hasRamseyProperty`; reverse = the padding lemma. This pins the
  realizable-size set down as **exactly the up-set `[R(k), ∞)`** — the property is not a
  knife-edge phenomenon at the threshold; it persists for all larger cardinalities, with no gaps.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos1090Problem` → **EXIT 0**, 0 sorry / 0 axiom.
- File 805 → 850 lines, 18 → 20 theorems (defs unchanged; the new `instance` is not counted in
  `definitionCount` per the auditor convention). Gallery `meta.json` line/thm synced in both
  `.meta` and `.leanFile` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)