### PR TITLE
research(shannon-entropy-oq-03-incomplete-01): mark COMPLETE, correct stale knowledge

### DIFF
--- a/research/problems/shannon-entropy-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/shannon-entropy-oq-03-incomplete-01/knowledge.md
@@ -41,3 +41,29 @@ Named `ssa_inequality` (NOT `strong_subadditivity`) to avoid the exact dup-decl 
 broke ShannonEntropySSA.lean. File: 5 defs + 9 theorems (was 7), 570 lines, 0 axioms/0 sorries.
 Host-verified (lake env lean, clean; #print axioms = propext/Classical.choice/Quot.sound).
 Synced gallery meta lineCount 448→570, theoremCount 7→9.
+
+## Session 2026-07-08 (researcher-2) — verified COMPLETE, closing the problem
+
+Re-audited every thread against `origin/main`; all are done, and two items in the
+prior JSON `knowledge` object are now STALE:
+
+1. **`cmiSum_nonneg` + `ssa_inequality` are merged.** `#35820`
+   (commit f0446fdee0a) landed both in `ShannonEntropySSAEq.lean` (now decls at
+   lines 458 and 560). The "self-contained inequality" nextStep is done.
+2. **`ShannonEntropySSA.lean` is NOT broken any more.** The old dup-decl revision
+   was repaired: the file now lives in namespace `InformationTheory.SSA`, `import`s
+   the parent's verified `strong_subadditivity` and re-exports it, and adds two
+   genuine three-variable corollaries not in the parent — `conditioning_reduces_entropy_general`
+   (H(X|Y,Z) ≤ H(X|Y)) and `conditional_mi_nonneg` (I(X;Z|Y) ≥ 0). Its docstring
+   documents the repair and reports axiom-free status. So the gallery pointer
+   `shannon-entropy-oq-03 → Proofs/ShannonEntropySSA.lean` with `status: "verified"`
+   is CORRECT; the "Mechanic: fix/delete broken file + repoint gallery" nextStep is
+   already resolved. No integrity fix is needed.
+
+Nothing session-sized remains. Considered a CMI/Markov X↔Z reversibility corollary,
+but conditional independence X⊥Z|Y is manifestly symmetric (the factorization RHS is
+a product) — a shallow restatement, rejected per follow-up quality criteria. The one
+genuine open direction is a QUANTITATIVE/STABILITY SSA (Pinsker-type lower bound
+`cmiSum ≥ ½‖p − q‖₁²`, giving distance to the nearest Markov factorization), but that
+needs Pinsker's inequality, which is not readily available in usable form and is larger
+than one session. Marking the problem **completed**.

--- a/src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json
@@ -35,13 +35,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (reframed): the premise (a remaining SSA sorry) is FALSE — SSA is fully proven (ShannonEntropy.lean:875; the cited ShannonEntropySSA.lean is BROKEN on main via dup-decl conflict). Pivoted to a genuine follow-up: the SSA EQUALITY CONDITION (Markov-chain characterization), shipped as self-contained ShannonEntropySSAEq.lean → gallery shannon-entropy-oq-03-oq-01.",
+    "progressSummary": "COMPLETE: the premise (a remaining SSA sorry) is FALSE — SSA is fully proven in ShannonEntropy.lean (strong_subadditivity). Every thread is now closed on main: (1) the SSA EQUALITY CONDITION (Markov-chain characterization) shipped as self-contained ShannonEntropySSAEq.lean → gallery shannon-entropy-oq-03-oq-01; (2) #35820 added the self-contained SSA inequality (cmiSum_nonneg + ssa_inequality) to that same file; (3) ShannonEntropySSA.lean (gallery oq-03) was REPAIRED — the old dup-decl conflict is gone, it now sits in namespace InformationTheory.SSA, re-exports the verified parent SSA, and adds conditioning_reduces_entropy_general + conditional_mi_nonneg (axiom-free). The 'broken file / repoint gallery' Mechanic nextStep is therefore already done and needs no action.",
     "builtItems": [
-      "cmiSum def + ssa_deficit_eq_cmi + ssa_cmi_eq_zero_iff + strong_subadditivity_eq_iff in Proofs/ShannonEntropySSAEq.lean (self-contained, 0 sorry/0 axiom)"
+      "cmiSum def + ssa_deficit_eq_cmi + ssa_cmi_eq_zero_iff + strong_subadditivity_eq_iff + cmiSum_nonneg + ssa_inequality (#35820) in Proofs/ShannonEntropySSAEq.lean (self-contained, 0 sorry/0 axiom)"
     ],
     "insights": [
       "Suggested proof route: rewrite the entropy deficit as conditional mutual information and discharge nonnegativity via KL divergence.",
-      "ShannonEntropySSA.lean does not compile on main: it imports ShannonEntropy.lean which now also declares marginalXY/marginalYZ/strong_subadditivity/entropy_chain_rule/subadditivity (same namespace) → already-declared errors. SSA is genuinely proven in ShannonEntropy.lean.",
+      "ShannonEntropySSA.lean was REPAIRED (no longer conflicts): it now uses namespace InformationTheory.SSA, imports and re-exports the parent's verified strong_subadditivity, and adds two three-variable corollaries (conditioning_reduces_entropy_general, conditional_mi_nonneg); axiom-free. Historical note: an older revision re-declared marginalXY/marginalYZ/strong_subadditivity in the parent's namespace and failed to elaborate. SSA is genuinely proven in ShannonEntropy.lean.",
       "SSA deficit = conditional mutual information I(X;Z|Y) exactly (ssa_deficit_eq_cmi).",
       "I(X;Z|Y)=0 iff the division-free Markov factorization p·p_Y = p_XY·p_YZ holds everywhere; forward via the STRICT KL bound, backward by substitution.",
       "v4.26.0: `hp _` underscore fails to infer in single_le_sum hint lists (need explicit triples); local universe-poly `have` leaks a 4th universe param (extract top-level); conv `ext y` fails on Finset.sum."
@@ -50,8 +50,8 @@
       "No SSA equality-case lemma in Mathlib; KL equality (klDivergence_eq_zero_iff) exists in ShannonEntropy.lean but is private and the file conflicts."
     ],
     "nextSteps": [
-      "Mechanic: fix/delete broken ShannonEntropySSA.lean and repoint gallery shannon-entropy-oq-03 to ShannonEntropy.lean.",
-      "Optional: approximate/stability version of the equality condition."
+      "DONE: ShannonEntropySSA.lean is repaired and gallery oq-03 verified pointer is correct — no Mechanic action needed.",
+      "Only genuine open direction (larger than one session): a QUANTITATIVE/STABILITY SSA — a Pinsker-type lower bound cmiSum ≥ ½‖p − q‖₁² bounding distance to the nearest Markov factorization. Blocked on Pinsker's inequality not being readily usable in Mathlib."
     ],
     "markdown": "# Knowledge Base: shannon-entropy-oq-03-incomplete-01\n\n## Problem Understanding\n\nThe target is strong subadditivity of Shannon entropy:\n\n$$\nH(X,Y,Z) + H(Y) \\leq H(X,Y) + H(Y,Z)\n$$\n\nThe local problem note says the supporting infrastructure is already in `ShannonEntropySSA.lean`; the remaining work is the main theorem left as a `sorry`.\n\n## Known Direction\n\nUse the parent proof `shannon-entropy-oq-03` as the foundation. The stated goal is to express the deficit as conditional mutual information, `I(X;Z|Y) = sum_y p(y) D(p(x,z|y) || p(x|y) * p(z|y))`, then use KL divergence non-negativity.\n\n## Current State\n\nNo attempts have been recorded yet. The next action in `state.md` is to read the problem thoroughly and then move to ORIENT by exploring literature and related proofs.\n"
   },


### PR DESCRIPTION
## Summary

Doc-only. Audited `shannon-entropy-oq-03-incomplete-01` against `origin/main` and confirmed **every thread is closed** — the entry's premise (a remaining SSA `sorry`) was always false, and the two items the prior knowledge record listed as open are now done.

## State on `origin/main`

- **SSA proven** — `strong_subadditivity` in `Proofs/ShannonEntropy.lean` (0 sorry / 0 axiom).
- **Equality condition shipped** — `ShannonEntropySSAEq.lean` → gallery `shannon-entropy-oq-03-oq-01` (`ssa_deficit_eq_cmi`, `ssa_cmi_eq_zero_iff`, `strong_subadditivity_eq_iff`).
- **Self-contained SSA inequality merged** — `#35820` added `cmiSum_nonneg` (line 458) and `ssa_inequality` (line 560) to that same file.
- **`ShannonEntropySSA.lean` already repaired** — the old dup-declaration conflict is gone; it now lives in namespace `InformationTheory.SSA`, re-exports the parent's verified SSA, and adds two three-variable corollaries (`conditioning_reduces_entropy_general`, `conditional_mi_nonneg`), axiom-free. The gallery `shannon-entropy-oq-03 → Proofs/ShannonEntropySSA.lean` `verified` pointer is therefore correct, and the "Mechanic: fix/repoint" nextStep needs no action.

## Changes

- Corrected two **stale** claims in the JSON knowledge object (that `ShannonEntropySSA.lean` is broken, and that the inequality is missing).
- Appended a closing session note to `knowledge.md`.
- Recorded the only genuine open direction (a quantitative/stability SSA — Pinsker-type lower bound `cmiSum ≥ ½‖p − q‖₁²`), noted as larger-than-session and blocked on Pinsker's inequality not being readily usable in Mathlib.

No Lean changes. A shallow X↔Z reversibility corollary was considered and rejected (conditional independence is manifestly symmetric — a trivial restatement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)