### PR TITLE
Fix: sync stale meta line/theorem counts in hilbert-17-oq-03-oq-05

### DIFF
--- a/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
@@ -48,7 +48,7 @@
       "The arithmetic–geometric mean (AM–GM) inequality and sum-of-squares certificates for non-negativity.",
       "Evaluation of multivariate polynomials and the PSD predicate ∀ v, 0 ≤ eval v p."
     ],
-    "lineCount": 142,
+    "lineCount": 345,
     "relatedProblems": [
       {
         "id": "hilbert-17-oq-03-oq-02",
@@ -68,7 +68,7 @@
       }
     ],
     "assumptions": "0 axioms. #print axioms reports only propext, Classical.choice, Quot.sound for motzkinFun_psd_iff, motzkinPoly_psd_iff, three_is_sharp, and motzkin_amgm. No sorryAx, no native_decide / Lean.ofReduceBool. The MvPolynomial PSD predicate IsPSDMv matches the parent entry's IsPositiveSemidefiniteMv definitionally.",
-    "theoremCount": 9,
+    "theoremCount": 21,
     "definitionCount": 3,
     "additionalFiles": []
   },


### PR DESCRIPTION
## Fix

`meta.lineCount` and `meta.theoremCount` for `hilbert-17-oq-03-oq-05` were stale, reflecting the entry's original size before research PRs grew the Lean file.

## Evidence

`proofs/Proofs/Hilbert17OQ03OQ05.lean` has no `additionalFiles`, so the single-file counts are authoritative.

| field | meta (before) | leanFile / actual | meta (after) |
|-------|---------------|-------------------|--------------|
| lineCount | 142 | 345 (`wc -l`) | 345 |
| theoremCount | 9 | 21 (21 `theorem`/`lemma` decls) | 21 |
| definitionCount | 3 | 3 | 3 (unchanged) |

The `leanFile` block already carried the correct counts (345/21/3); this only mirrors `meta.*` to match.

---
Automated fix by lean-mechanic agent.