### PR TITLE
research(abel-ruffini-galois-extensions-oq-06-galois-direction): |H| ∣ p(p-1) Galois order-bound corollary [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -666,4 +666,24 @@ theorem primitive_solvable_subgroup_embeds_AGL1Z
   exact ⟨ψ.comp (Subgroup.inclusion hHle),
     hinj.comp (Subgroup.inclusion_injective hHle)⟩
 
+/-- **Corollary (Galois order bound).** A primitive solvable subgroup of
+    `S_p = Equiv.Perm (ZMod p)` has order dividing `p * (p - 1)`.
+
+    This is the classical numeric form of Galois's 1832 theorem: a solvable
+    transitive permutation group of prime degree `p` has order dividing
+    `p (p - 1) = |AGL(1, p)|`.  It is immediate from
+    `primitive_solvable_subgroup_embeds_AGL1Z`: that theorem provides an
+    injective group homomorphism `φ : H ↪ AGL(1, p)`, so Lagrange's theorem
+    (`Subgroup.card_dvd_of_injective`) gives `|H| ∣ |AGL(1, p)|`, and
+    `AGL1Z.nat_card_eq` evaluates the right-hand side as `p (p - 1)`.  No new
+    `sorry`, no axiom. -/
+theorem primitive_solvable_subgroup_card_dvd
+    (H : Subgroup (Equiv.Perm (ZMod p)))
+    (hPrim : MulAction.IsPreprimitive H (ZMod p))
+    (hSolv : IsSolvable H) :
+    Nat.card H ∣ p * (p - 1) := by
+  obtain ⟨φ, hφ⟩ := primitive_solvable_subgroup_embeds_AGL1Z H hPrim hSolv
+  have hdvd : Nat.card H ∣ Nat.card (AGL1Z p) := Subgroup.card_dvd_of_injective φ hφ
+  rwa [AGL1Z.nat_card_eq] at hdvd
+
 end AbelRuffiniGaloisExtensionsOQ06GaloisDirection


### PR DESCRIPTION
## Summary

The registered main theorem for this slug — `primitive_solvable_subgroup_embeds_AGL1Z` (every primitive solvable subgroup of `S_p` embeds into `AGL(1,p)`) — is already COMPLETE and verified on `main` (builds green, 0 sorry, 0 axiom). This PR adds the natural, previously-missing **numeric corollary** that is the classical statement of Galois's theorem.

## What's new

`primitive_solvable_subgroup_card_dvd` in `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean`:

> Every primitive solvable subgroup `H` of `S_p = Equiv.Perm (ZMod p)` has **`Nat.card H ∣ p * (p - 1)`**.

This is the classical numeric form of **Galois's 1832 theorem**: a solvable transitive permutation group of prime degree `p` has order dividing `p(p-1)`.

## Proof

Immediate from the completed main theorem: it supplies an injective group homomorphism `φ : H ↪ AGL(1,p)`, so Lagrange's theorem (`Subgroup.card_dvd_of_injective`) gives `|H| ∣ |AGL(1,p)|`, and the existing `AGL1Z.nat_card_eq` evaluates `|AGL(1,p)| = p(p-1)`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirection` → `Built ...` (7746 jobs), 0 errors. Only pre-existing lint/deprecation warnings on untouched lines.
- 0 sorries, 0 axiom declarations, no structure-encoded assumptions.
- No gallery `meta.json` tracks this research file, so no gallery changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)