### PR TITLE
Fix: sync stale top-level meta counts in hilbert-17-oq-03-oq-05

### DIFF
--- a/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
@@ -48,7 +48,7 @@
       "The arithmetic–geometric mean (AM–GM) inequality and sum-of-squares certificates for non-negativity.",
       "Evaluation of multivariate polynomials and the PSD predicate ∀ v, 0 ≤ eval v p."
     ],
-    "lineCount": 142,
+    "lineCount": 345,
     "relatedProblems": [
       {
         "id": "hilbert-17-oq-03-oq-02",
@@ -68,7 +68,7 @@
       }
     ],
     "assumptions": "0 axioms. #print axioms reports only propext, Classical.choice, Quot.sound for motzkinFun_psd_iff, motzkinPoly_psd_iff, three_is_sharp, and motzkin_amgm. No sorryAx, no native_decide / Lean.ofReduceBool. The MvPolynomial PSD predicate IsPSDMv matches the parent entry's IsPositiveSemidefiniteMv definitionally.",
-    "theoremCount": 9,
+    "theoremCount": 21,
     "definitionCount": 3,
     "additionalFiles": []
   },


### PR DESCRIPTION
## Fix

The top-level `meta` block in `hilbert-17-oq-03-oq-05/meta.json` carried stale line/theorem counts that disagreed with the `leanFile` block (which matches the actual source).

## Evidence

`proofs/Proofs/Hilbert17OQ03OQ05.lean` is **345 lines** with **21/22 theorems** (22 raw; 21 excluding the one `private` theorem) and **3 defs**. The entry has no `additionalFiles`, so both count blocks should equal the single file.

| field | meta (before) | leanFile (authoritative) | actual |
|-------|--------------|--------------------------|--------|
| lineCount | 142 | 345 | 345 (`wc -l`) |
| theoremCount | 9 | 21 | 21/22 |
| definitionCount | 3 | 3 | 3 |

The `leanFile.lineCount` already equals the real `wc -l`, confirming it is the fresh block; the `meta` block was left behind by an earlier growth. Mirrored `leanFile` → `meta`. Definition count already agreed.

**Before**: `meta.lineCount=142`, `meta.theoremCount=9`
**After**: `meta.lineCount=345`, `meta.theoremCount=21`

---
Automated fix by lean-mechanic agent.