### PR TITLE
research(abel-ruffini-oq-04-oq-01-oq-03): dihedral sharpness witness for order-pq cyclic classification [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ01OQ03Sharpness.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01OQ03Sharpness.lean
@@ -1,0 +1,96 @@
+import Mathlib
+
+/-
+# abel-ruffini-oq-04-oq-01-oq-03 (sharpness witness): non-cyclic groups of order `pq`
+
+`AbelRuffiniOQ04OQ01OQ03.lean` proves the two halves of the classical order-`pq`
+classification for primes `p < q`:
+
+* **Positive half** `isCyclic_of_card_eq_prime_mul_prime_of_not_dvd` — if `p ∤ q − 1` then every
+  group of order `p·q` is cyclic;
+* **Necessity** `dvd_sub_one_of_not_isCyclic_card_eq_prime_mul_prime` — if some order-`pq` group
+  fails to be cyclic then `p ∣ q − 1`.
+
+The necessity direction is proved as a pure contrapositive of the positive half, so it does **not**
+exhibit any non-cyclic group.  This file supplies the missing **existence witness** that makes the
+dichotomy genuinely *sharp*: whenever the arithmetic condition `p ∣ q − 1` is met, a finite
+non-cyclic group of order `pq` actually exists.
+
+We realize the witness cleanly for the family `p = 2` using Mathlib's `DihedralGroup`.  For an odd
+prime `q` one has `2 ∣ q − 1` automatically, and
+
+    DihedralGroup q     has order `2q`  (`DihedralGroup.nat_card`)
+    DihedralGroup q     is not cyclic   (`dihedralGroup_not_isCyclic`)
+
+so `DihedralGroup q` is a non-cyclic group of order `2q`.  Consequently the implication
+"order `2q` ⟹ cyclic" is *false* for every odd prime `q`
+(`not_forall_isCyclic_card_eq_two_mul`), i.e. the condition `p ∤ q − 1` in the positive half cannot
+be dropped — it is exactly the boundary between the cyclic-forced and non-cyclic-possible regimes.
+
+The non-cyclicity is elementary: `r 1` and `sr 0` fail to commute
+(`r 1 * sr 0 = sr (-1)` but `sr 0 * r 1 = sr 1`, and `-1 ≠ 1` in `ZMod q` once `q > 2`), while every
+cyclic group is commutative (`IsCyclic.commutative`).
+
+Self-contained: imports only `Mathlib`; the parent classification is referenced by name only.
+No axioms, no sorries.
+-/
+
+open DihedralGroup
+
+namespace AbelRuffiniOQ04OQ01OQ03Sharpness
+
+/-- **`DihedralGroup n` is not cyclic for `n > 2`.**  The rotation `r 1` and the reflection
+`sr 0` do not commute: `r 1 * sr 0 = sr (0 - 1) = sr (-1)` while `sr 0 * r 1 = sr (0 + 1) = sr 1`,
+and `-1 ≠ 1` in `ZMod n` precisely because `n ∤ 2` when `n > 2`.  A cyclic group is commutative
+(`IsCyclic.commutative`), so `DihedralGroup n` cannot be cyclic. -/
+theorem dihedralGroup_not_isCyclic {n : ℕ} (hn : 2 < n) :
+    ¬ IsCyclic (DihedralGroup n) := by
+  intro hcyc
+  haveI := hcyc
+  -- A cyclic group is commutative, so `r 1` and `sr 0` would commute.
+  have hcomm : (r 1 : DihedralGroup n) * sr 0 = sr 0 * r 1 :=
+    (IsCyclic.commutative (α := DihedralGroup n)).comm (r 1) (sr 0)
+  rw [r_mul_sr, sr_mul_r, zero_sub, zero_add, sr.injEq] at hcomm
+  -- Now `hcomm : (-1 : ZMod n) = 1`, forcing `(2 : ZMod n) = 0`, i.e. `n ∣ 2`.
+  have h2 : ((2 : ℕ) : ZMod n) = 0 := by
+    have h : (2 : ZMod n) = 0 := by linear_combination -hcomm
+    exact_mod_cast h
+  have hdvd : n ∣ 2 := (CharP.cast_eq_zero_iff (ZMod n) n 2).mp h2
+  exact absurd (Nat.le_of_dvd (by norm_num) hdvd) (by omega)
+
+/-- An odd prime is at least `3`. -/
+private theorem two_lt_of_odd_prime {q : ℕ} (hq : q.Prime) (hodd : Odd q) : 2 < q := by
+  rcases eq_or_lt_of_le hq.two_le with heq | hlt
+  · rw [← heq] at hodd; exact absurd hodd (by decide)
+  · exact hlt
+
+/-- **Sharpness witness (family `p = 2`).**  For every odd prime `q`, there is a *finite,
+non-cyclic* group of order `2q` — namely `DihedralGroup q`.  Since `2 ∣ q − 1` for every odd `q`,
+this shows the necessity condition `p ∣ q − 1` of
+`dvd_sub_one_of_not_isCyclic_card_eq_prime_mul_prime` is realizable, so the order-`pq`
+classification is genuinely two-sided rather than only sufficient. -/
+theorem exists_finite_not_isCyclic_card_eq_two_mul {q : ℕ} (hq : q.Prime) (hodd : Odd q) :
+    ∃ (G : Type) (_ : Group G) (_ : Finite G), Nat.card G = 2 * q ∧ ¬ IsCyclic G := by
+  haveI : NeZero q := ⟨hq.pos.ne'⟩
+  exact ⟨DihedralGroup q, inferInstance, inferInstance,
+    DihedralGroup.nat_card, dihedralGroup_not_isCyclic (two_lt_of_odd_prime hq hodd)⟩
+
+/-- **The order-`2q` classification is sharp.**  For every odd prime `q` (so that `2 ∣ q − 1`),
+it is *false* that every finite group of order `2q` is cyclic — the dihedral witness above refutes
+it.  This is the precise sense in which the hypothesis `p ∤ q − 1` cannot be removed from the
+positive half of the classification. -/
+theorem not_forall_isCyclic_card_eq_two_mul {q : ℕ} (hq : q.Prime) (hodd : Odd q) :
+    ¬ ∀ (G : Type) [Group G] [Finite G], Nat.card G = 2 * q → IsCyclic G := by
+  intro H
+  obtain ⟨G, hG, hFin, hcard, hnc⟩ := exists_finite_not_isCyclic_card_eq_two_mul hq hodd
+  exact hnc (@H G hG hFin hcard)
+
+/-- **Smallest instance.**  A non-cyclic group of order `6` exists (`DihedralGroup 3 ≅ S₃`); this is
+the least order `pq` (`p = 2, q = 3`) admitting a non-cyclic group. -/
+theorem exists_finite_not_isCyclic_card_six :
+    ∃ (G : Type) (_ : Group G) (_ : Finite G), Nat.card G = 6 ∧ ¬ IsCyclic G := by
+  obtain ⟨G, hG, hFin, hcard, hnc⟩ :=
+    exists_finite_not_isCyclic_card_eq_two_mul (q := 3) (by norm_num) (by decide)
+  exact ⟨G, hG, hFin, hcard.trans (by norm_num), hnc⟩
+
+end AbelRuffiniOQ04OQ01OQ03Sharpness

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-03.json
@@ -34,7 +34,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0/0): full positive half of the classical order-pq classification (p<q primes, p∤q−1 ⟹ cyclic) proved for ARBITRARY primes — generalizing the previous order-15-only instance — together with its SHARP converse (non-cyclic ⟹ p∣q−1) obtained as a one-line contrapositive. Only the Frobenius-group WITNESS construction (order 21) and the density-1 Galois-obstruction forward direction remain open.",
+    "progressSummary": "PROGRESS (VERIFIED 0/0): supplied the missing existence witness that makes the order-pq cyclic classification genuinely two-sided. For the p=2 family, DihedralGroup q (odd prime q) is a finite non-cyclic group of order 2q, refuting order-2q => cyclic and realizing the necessity condition p | q-1. Remaining open: general-p (p|q-1) Frobenius witness (semidirect product) and the density-1 Galois-obstruction forward direction (analytically blocked).",
     "builtItems": [
       "zpowers_sylow_normal in AbelRuffiniOQ04OQ01OQ03.lean — arbitrary-prime Sylow-elimination core: order p·m + p∤m + no-small-divisor ⇒ ⟨c⟩ (order-p) normal",
       "conj_mem_zpowers_sylow — every g normalizes ⟨c⟩ (general prime consequence)",
@@ -64,7 +64,10 @@
       "mul_comm_of_card_eq_prime_mul_prime_of_not_dvd (AbelRuffiniOQ04OQ01OQ03.lean): general commutativity for order pq, p<q primes, p∤q−1 — VERIFIED 0/0",
       "isCyclic_of_card_eq_prime_mul_prime_of_not_dvd: general positive half of order-pq classification, generalizes isCyclic_of_card_fifteen — VERIFIED 0/0",
       "dvd_sub_one_of_not_isCyclic_card_eq_prime_mul_prime: sharp converse (non-cyclic ⟹ p∣q−1) via contrapositive — VERIFIED 0/0",
-      "isCyclic_of_card_thirtyfive (35=5·7) and isCyclic_of_card_thirtythree (33=3·11): concrete instances beyond order 15 — VERIFIED 0/0"
+      "isCyclic_of_card_thirtyfive (35=5·7) and isCyclic_of_card_thirtythree (33=3·11): concrete instances beyond order 15 — VERIFIED 0/0",
+      "dihedralGroup_not_isCyclic (n>2 => ¬IsCyclic (DihedralGroup n)) in Proofs/AbelRuffiniOQ04OQ01OQ03Sharpness.lean",
+      "exists_finite_not_isCyclic_card_eq_two_mul (odd prime q => ∃ finite non-cyclic G, Nat.card G = 2q) — the DihedralGroup q witness",
+      "not_forall_isCyclic_card_eq_two_mul (odd prime q => ¬∀ finite G of order 2q, IsCyclic G) — crisp sharpness statement; plus exists_finite_not_isCyclic_card_six (order-6 instance, D3≅S3)"
     ],
     "insights": [
       "Generalizing the fixed prime 5 to a variable prime p is NOT a rename: the two number-theoretic steps change tactic. n_p ≡ 1 (mod p) ⇒ n_p = 1 needs Nat.mod_eq_of_lt hp.out.one_lt to evaluate 1 % p (omega cannot do variable-modulus mod); index cancellation [G:P]·p = p·m ⇒ [G:P] = m needs Nat.eq_of_mul_eq_mul_right (omega cannot cancel a variable multiplier).",
@@ -83,7 +86,9 @@
       "The single-element centrality criterion promotes cleanly to the whole Sylow-p subgroup and yields a genuine GLOBAL class-equation consequence p | |Z(G)| (centre nontrivial) without needing the full sum-over-conjugacy-classes packaging.",
       "Central normal Hall subgroup splits off as a direct factor: Schur-Zassenhaus complement + centrality => complement automatically normal (conjugation by the central factor is trivial), giving internal direct product — elementary content of Burnside normal p-complement in this cyclic-Sylow regime.",
       "Order-pq classification (p<q primes): cyclicity is governed ENTIRELY by whether p ∣ q−1. The Sylow-elimination engine (mem_center_of_coprime_index, mul_comm_of_prime_index_coprime) already supplies the positive half for ARBITRARY p,q — order 15 was just the p=3,q=5 instance.",
-      "The sharp CONVERSE (non-cyclic order-pq ⟹ p ∣ q−1) is a free one-line contrapositive of the sufficiency theorem — no Frobenius-group construction needed to state the sharp boundary. Constructing ℤ/q⋊ℤ/p to WITNESS non-cyclicity when p∣q−1 remains the only heavier open direction."
+      "The sharp CONVERSE (non-cyclic order-pq ⟹ p ∣ q−1) is a free one-line contrapositive of the sufficiency theorem — no Frobenius-group construction needed to state the sharp boundary. Constructing ℤ/q⋊ℤ/p to WITNESS non-cyclicity when p∣q−1 remains the only heavier open direction.",
+      "Sharpness of the order-pq cyclic classification is witnessed concretely for the family p=2: for every odd prime q one has 2 | q-1, and DihedralGroup q is a finite non-cyclic group of order 2q — so the necessity condition p | q-1 (dvd_sub_one_of_not_isCyclic_card_eq_prime_mul_prime) is realizable, not vacuous.",
+      "Non-cyclicity of DihedralGroup n (n>2) is elementary and Mathlib-native: r 1 and sr 0 fail to commute (r 1 * sr 0 = sr(-1) via r_mul_sr, sr 0 * r 1 = sr 1 via sr_mul_r), and -1 != 1 in ZMod n once n>2; combined with IsCyclic.commutative (a cyclic group is Std.Commutative) this refutes IsCyclic without any group-order computation."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -93,7 +98,8 @@
       "Abelian regime is now complete through prime-index/order-15. A natural next follow-up: order 21 = 3·7 (nonabelian example exists) vs the coprime criterion — sharpness of the abelian conclusion when q ∤ (p-1) fails (e.g. 7 ≡ 1 mod 3 gives the nonabelian group of order 21).",
       "Package exists_normal_pComplement_of_coprime_index into a genuine MulEquiv G ≃* ⟨c⟩ × H (needs internal-direct-product MulEquiv from two complementary normal subgroups; Mathlib Complement.lean lacks a ready lemma, would build from commute_of_normal_of_disjoint).",
       "Consequence: under coprime index G is a (nontrivial-centre) group with G/Z abelian-ish? Investigate whether central Sylow-p + p-complement forces G nilpotent iff H nilpotent.",
-      "Construct the nonabelian Frobenius group ℤ/q ⋊ ℤ/p (via SemidirectProduct with a nontrivial hom ℤ/p → (ZMod q)ˣ of order p, exists when p ∣ q−1) to WITNESS the sharpness of dvd_sub_one_of_not_isCyclic — e.g. the order-21 group. Heavier (~150-300 lines): need order computation of the semidirect product and a non-commuting pair."
+      "Construct the nonabelian Frobenius group ℤ/q ⋊ ℤ/p (via SemidirectProduct with a nontrivial hom ℤ/p → (ZMod q)ˣ of order p, exists when p ∣ q−1) to WITNESS the sharpness of dvd_sub_one_of_not_isCyclic — e.g. the order-21 group. Heavier (~150-300 lines): need order computation of the semidirect product and a non-commuting pair.",
+      "Extend the sharpness witness beyond p=2 to general p|q-1: construct the nonabelian ℤ/q ⋊ ℤ/p (e.g. order 21) via SemidirectProduct with a nontrivial hom ZMod p → (ZMod q)ˣ of order p — heavier (semidirect-product order + non-commuting pair), ~150-300 lines."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds a self-contained verified companion `proofs/Proofs/AbelRuffiniOQ04OQ01OQ03Sharpness.lean` supplying the missing **existence witness** for the order-`pq` cyclic classification in `AbelRuffiniOQ04OQ01OQ03.lean`.

That file proves both halves of the classification for primes `p < q`:
- **positive**: `p ∤ q−1 ⟹` every order-`pq` group is cyclic;
- **necessity**: `¬IsCyclic ⟹ p ∣ q−1` (`dvd_sub_one_of_not_isCyclic_card_eq_prime_mul_prime`), proved as a pure contrapositive — so it exhibits **no** non-cyclic group.

This PR closes that gap: when `p ∣ q−1` is realizable, a finite non-cyclic group of order `pq` **actually exists**, making the dichotomy genuinely two-sided.

## Main results (family `p = 2`, via Mathlib `DihedralGroup`)

- `dihedralGroup_not_isCyclic` — for `n > 2`, `DihedralGroup n` is not cyclic. Elementary: `r 1 * sr 0 = sr(−1)` but `sr 0 * r 1 = sr 1`, and `−1 ≠ 1` in `ZMod n` once `n > 2`; a cyclic group is commutative (`IsCyclic.commutative`).
- `exists_finite_not_isCyclic_card_eq_two_mul` — for every odd prime `q` (so `2 ∣ q−1`), `DihedralGroup q` is a **finite non-cyclic group of order `2q`**.
- `not_forall_isCyclic_card_eq_two_mul` — hence `order 2q ⟹ cyclic` is **false** for all odd primes `q`: the crisp sharpness statement.
- `exists_finite_not_isCyclic_card_six` — smallest instance (order 6, `D₃ ≅ S₃`).

## Verification
- Docker build: `✔ Built Proofs.AbelRuffiniOQ04OQ01OQ03Sharpness` (7743 jobs).
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only.
- **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.** Status: `verified`.

Self-contained: imports only `Mathlib`; the parent classification is referenced by name. New namespace `AbelRuffiniOQ04OQ01OQ03Sharpness`, no clashes.

## Remaining open
General-`p` (`p ∣ q−1`) Frobenius witness `ℤ/q ⋊ ℤ/p` (e.g. order 21) via `SemidirectProduct`; and the density-1 Galois-obstruction forward direction (analytically blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)