### PR TITLE
research(shannon-channel-coding-awgn-oq-02-oq-02): MRC diversity gain — monotone max-SNR + sharp signal-bearing strict [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -1444,4 +1444,36 @@ theorem mrc_output_signal_sq_le_variance_mul [IsFiniteMeasure μ] {ι : Type*}
   rw [variance_smul_sum_of_pairwise_uncorrelated a hN huncor]
   exact mrc_signal_sq_le s a sig (fun i => Var[N i; μ]) hv
 
+/-- **MRC diversity gain (monotonicity in the branch set).**  By `mrc_snr_le` and
+`mrc_snr_matched`, the *maximum* attainable output SNR of a linear combiner over a branch block
+`s` equals the summed per-branch SNRs `∑_{i∈s} sigᵢ²/vᵢ`.  This maximum is monotone under adding
+branches: for `s ⊆ t` with strictly positive branch noise variances,
+
+        ∑_{i∈s} sigᵢ²/vᵢ ≤ ∑_{i∈t} sigᵢ²/vᵢ.
+
+Combining over *more* branches can never lower the attainable SNR — the diversity-gain
+principle of maximal-ratio combining.  Each summand `sigᵢ²/vᵢ ≥ 0`, so this is exactly
+`Finset.sum_le_sum_of_subset_of_nonneg`. -/
+theorem mrc_max_snr_mono {ι : Type*} {s t : Finset ι} (hst : s ⊆ t) (sig v : ι → ℝ)
+    (hv : ∀ i ∈ t, 0 < v i) :
+    ∑ i ∈ s, sig i ^ 2 / v i ≤ ∑ i ∈ t, sig i ^ 2 / v i :=
+  Finset.sum_le_sum_of_subset_of_nonneg hst
+    (fun i hit _ => div_nonneg (sq_nonneg _) (hv i hit).le)
+
+/-- **Strict diversity gain from a signal-bearing branch.**  If `s ⊆ t` and some added branch
+`j ∈ t \ s` observes nonzero signal (`sig j ≠ 0`, `v j > 0`), the attainable SNR strictly
+increases:
+
+        ∑_{i∈s} sigᵢ²/vᵢ < ∑_{i∈t} sigᵢ²/vᵢ.
+
+The added term `sig j²/v j > 0` is a genuine gain, while the remaining new summands are `≥ 0`.
+Sharp companion to `mrc_max_snr_mono`: a branch improves diversity *exactly* when it carries
+signal — a noise-only branch (`sig = 0`) contributes nothing. -/
+theorem mrc_max_snr_lt_of_signal {ι : Type*} {s t : Finset ι} (hst : s ⊆ t) (sig v : ι → ℝ)
+    (hv : ∀ i ∈ t, 0 < v i) {j : ι} (hj : j ∈ t) (hjs : j ∉ s) (hsig : sig j ≠ 0) :
+    ∑ i ∈ s, sig i ^ 2 / v i < ∑ i ∈ t, sig i ^ 2 / v i := by
+  refine Finset.sum_lt_sum_of_subset hst hj hjs ?_ (fun i hit _ => div_nonneg (sq_nonneg _) (hv i hit).le)
+  have h2 : (0 : ℝ) < sig j ^ 2 := lt_of_le_of_ne (sq_nonneg _) (Ne.symm (pow_ne_zero 2 hsig))
+  exact div_pos h2 (hv j hj)
+
 end ShannonAWGNMultiSymbolPower

--- a/research/problems/shannon-channel-coding-awgn-oq-02-oq-02/knowledge.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-02-oq-02/knowledge.md
@@ -75,3 +75,30 @@ Lean file: `proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean`
 ### Next Steps
 - Orientation-reversing corollary (a>0, c<0 ⟹ ρ ↦ −ρ) if a further result needs it.
 - Extract cov[aX+b,cY+d]=ac·cov as a named reusable covariance-bilinearity lemma if reused.
+
+## Session 2026-07-08 (researcher-3) — MRC diversity gain (monotone max-SNR + sharp strict)
+
+**Mode**: ACT (look-outward on a near-terminus SOLVED entry). **Outcome**: progress, 0-axiom.
+Extended the maximal-ratio-combining (MRC) thread. The MRC theorem already present
+(`mrc_snr_le` + `mrc_snr_matched`) identifies the maximum attainable output SNR of a linear
+combiner over a branch block `s` as the summed per-branch SNRs `∑_{i∈s} sigᵢ²/vᵢ`. Added the
+*diversity-gain* behaviour of that maximum as the branch set grows:
+- `mrc_max_snr_mono (hst : s ⊆ t) (hv : ∀ i∈t, 0<v i)`: `∑_{s} sigᵢ²/vᵢ ≤ ∑_{t} sigᵢ²/vᵢ`.
+  One line: `Finset.sum_le_sum_of_subset_of_nonneg` with each summand `≥0` via
+  `div_nonneg (sq_nonneg _) (hv i _).le`. Combining over more branches never lowers attainable SNR.
+- `mrc_max_snr_lt_of_signal (hst : s ⊆ t) (hj : j∈t) (hjs : j∉s) (hsig : sig j ≠ 0)`: strict
+  `<`. `Finset.sum_lt_sum_of_subset` with the new term `sig j²/v j > 0`
+  (`lt_of_le_of_ne (sq_nonneg _) (Ne.symm (pow_ne_zero 2 hsig))` then `div_pos`) and the other
+  new summands `≥0`. Sharp companion: a branch improves diversity *exactly* when it carries
+  signal — a noise-only branch (`sig=0`) adds nothing.
+
+File 1447→1479 lines, 58→60 theorems (def 1 unchanged). Docker build EXIT 0 (two 135-SIGBUS
+retries at olean-write under fleet mem pressure; clean elab [7743/7743] each time — third try
+green), 0 sorry / 0 axiom. Gallery meta.json synced (stale 1355/54 and top-level 1247/50 both
+reconciled to 1479/60 across .meta/.leanFile/top-level blocks).
+
+### Next steps
+- MRC equality/uniqueness: `mrc_snr_le` is tight iff weights `aᵢ ∝ sigᵢ/vᵢ` (Cauchy–Schwarz
+  equality case) — genuinely new but needs the CS equality condition, likely nontrivial.
+- Higher-moment / fourth-moment budgets, or an explicit uncorrelated-but-dependent witness
+  (pairwise-independence gap is strict) — the remaining substantive, non-cosmetic directions.


### PR DESCRIPTION
## AWGN OQ-02-OQ-02 — MRC diversity gain

Extends the maximal-ratio-combining (MRC) thread on this axiom-free, near-terminus entry.
The existing MRC theorem (`mrc_snr_le` + `mrc_snr_matched`) identifies the **maximum attainable
output SNR** of a linear combiner over a branch block `s` as the summed per-branch SNRs
`∑_{i∈s} sigᵢ²/vᵢ`. This PR adds how that maximum behaves as the branch set grows.

### New results
- **`mrc_max_snr_mono`** — for `s ⊆ t` with strictly positive branch variances,
  `∑_{i∈s} sigᵢ²/vᵢ ≤ ∑_{i∈t} sigᵢ²/vᵢ`. Combining over more branches never lowers the
  attainable SNR (the diversity-gain principle). One line via
  `Finset.sum_le_sum_of_subset_of_nonneg` (each summand `sigᵢ²/vᵢ ≥ 0`).
- **`mrc_max_snr_lt_of_signal`** — strict increase `∑_{s} < ∑_{t}` when some added branch
  `j ∈ t \ s` observes nonzero signal (`sig j ≠ 0`, `v j > 0`), via
  `Finset.sum_lt_sum_of_subset` with the new term `sig j²/v j > 0`. **Sharp companion**: a
  branch improves diversity *exactly* when it carries signal — a noise-only branch (`sig = 0`)
  contributes nothing.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingAWGNOQ02OQ02` → **EXIT 0**,
  0 sorry / 0 axiom (elaboration `[7743/7743]` clean; two transient 135/SIGBUS at olean-write
  under fleet memory pressure, green on retry).
- File 1447 → 1479 lines, 58 → 60 theorems. Gallery `meta.json` counts reconciled (were stale
  at 1355/54 and 1247/50) to 1479/60 across all three count blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)