### PR TITLE
Enrich Ramsey LLL bad-event probability (oq-03-oq-01): add mainTheorems

### DIFF
--- a/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
@@ -113,6 +113,44 @@
     "implications": "The exact probability p and the dependency degree d are the only Ramsey-specific quantities the symmetric LLL needs; both are now machine-checked, axiom-free counting statements independent of the (not-yet-formalized) measure-theoretic LLL machinery. This isolates the remaining work to the abstract LLL itself.",
     "openQuestions": "Formalizing the symmetric Lovász Local Lemma proper (the conditional-probability induction over dependency graphs) in Mathlib, and combining it with Key Lemmas 2 and 3 to discharge the axiom spencer_diagonal_lower_bound in Proofs/RamseyR4kExtensions.lean. Key Lemma 3's Lean file additionally needs a Mathlib-4.26 API-drift repair before it can be merged."
   },
+  "mainTheorems": [
+    {
+      "name": "clique_monochromatic_probability",
+      "type": "main",
+      "description": "The bad-event probability p: a fixed k-clique is monochromatic under the uniform random 2-colouring with probability 2/2^C(k,2) = 2^(1−C(k,2)), computed as #monochromatic / #total from the two counting lemmas. This is the value of p plugged into the symmetric LLL feasibility condition e·p·(d+1) ≤ 1 (Key Lemma 2).",
+      "leanType": "(k : ℕ) (hk : 2 ≤ k) (S : Finset V) (hS : S.card = k) : (((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card : ℝ) / (Fintype.card (EdgeColoring S) : ℝ) = (2 : ℝ) ^ (1 - (k.choose 2 : ℤ))"
+    },
+    {
+      "name": "card_monochromatic_edgeColorings",
+      "type": "main",
+      "description": "The numerator of the bad-event probability: exactly two of the 2^C(k,2) edge-colourings of a k-clique (k ≥ 2) are monochromatic — the all-red and all-blue colourings. Obtained by instantiating the abstract counting core at the clique's edge type, which is nonempty for k ≥ 2.",
+      "leanType": "(k : ℕ) (hk : 2 ≤ k) (S : Finset V) (hS : S.card = k) : ((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card = 2"
+    },
+    {
+      "name": "card_constant_colorings",
+      "type": "supporting",
+      "description": "The abstract counting core: among all Bool-colourings of a nonempty finite type α, exactly two are constant. Proved by showing the predicate ∀ x y, c x = c y cuts out the injective image of Bool under b ↦ (fun _ => b), whose cardinality is Fintype.card Bool = 2 — independent of how large α is.",
+      "leanType": "(α : Type*) [Fintype α] [DecidableEq α] [Nonempty α] : ((univ : Finset (α → Bool)).filter (fun c => ∀ x y, c x = c y)).card = 2"
+    },
+    {
+      "name": "card_edgeColorings",
+      "type": "supporting",
+      "description": "The denominator of the bad-event probability: the total number of 2-colourings of a k-clique's edges is 2^C(k,2), two independent colour choices on each of the C(k,2) edges (via Fintype.card_fun and Fintype.card_coe).",
+      "leanType": "(k : ℕ) (S : Finset V) (hS : S.card = k) : Fintype.card (EdgeColoring S) = 2 ^ k.choose 2"
+    },
+    {
+      "name": "cliqueEdges_card",
+      "type": "supporting",
+      "description": "A k-clique has exactly C(k,2) edges — its edge set is the 2-element subsets of the vertex set S, whose cardinality is Nat.choose k 2. This is where the parameter k enters the probability.",
+      "leanType": "(k : ℕ) (S : Finset V) (hS : S.card = k) : (cliqueEdges S).card = k.choose 2"
+    },
+    {
+      "name": "triangle_monochromatic_count",
+      "type": "supporting",
+      "description": "The k = 3 sanity check: a triangle has C(3,2) = 3 edges, hence 2^3 = 8 colourings, of which exactly 2 are monochromatic — the classical per-triangle probability 2/8 = 1/4 = 2^(1−3) that Spencer uses.",
+      "leanType": "(S : Finset V) (hS : S.card = 3) : ((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card = 2 ∧ Fintype.card (EdgeColoring S) = 8"
+    }
+  ],
   "references": [
     {
       "authors": "Erdős, Paul; Lovász, László",


### PR DESCRIPTION
Enrichment pass for `ramsey-r4k-extensions-oq-03-oq-01`. Fills the one structural gap — the entry had no `mainTheorems` array (references, cross-refs, and key-insights were already rich).

**Added `mainTheorems` (6)** with exact Lean signatures verified against `proofs/Proofs/RamseyR4kExtensionsOQ03OQ01.lean`:
- `clique_monochromatic_probability`, `card_monochromatic_edgeColorings` (main — the probability p = 2^(1−C(k,2)) and its numerator)
- `card_constant_colorings`, `card_edgeColorings`, `cliqueEdges_card`, `triangle_monochromatic_count` (supporting)

Size 16.9 KB (under 60 KB cap; check-meta-size passes). No existing content removed; JSON validated with jq. 0-axiom verified status unchanged.