### PR TITLE
Fix: register missing Capstone companion in abundant-number-oq-02-oq-01 metadata

### DIFF
--- a/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
@@ -210,7 +210,8 @@
       "Proofs/AbundantNumberOQ02OQ01OmegaSevenPrimes.lean",
       "Proofs/AbundantNumberOQ02OQ01SevenPrimeExponents.lean",
       "Proofs/AbundantNumberOQ02OQ01Squarefree.lean",
-      "Proofs/AbundantNumberOQ02OQ01Unconditional.lean"
+      "Proofs/AbundantNumberOQ02OQ01Unconditional.lean",
+      "Proofs/AbundantNumberOQ02OQ01Capstone.lean"
     ]
   }
 }


### PR DESCRIPTION
## Fix

`leanFile.additionalFiles` for `abundant-number-oq-02-oq-01` omitted `Proofs/AbundantNumberOQ02OQ01Capstone.lean`, so the two companion-file lists in the metadata disagreed.

## Evidence

**Before**: `meta.additionalFiles` listed 9 companions (including `Capstone.lean`) but `leanFile.additionalFiles` listed only 8 (missing `Capstone.lean`). Summing actual line counts over `leanFile`'s file set gave 2436, while `meta.lineCount` = 2516.

**After**: `Capstone.lean` (80 lines, axiom-free, no `sorry`) added to `leanFile.additionalFiles`. The leanFile-side aggregate now sums to exactly 2516, matching `meta.lineCount`. `meta.theoremCount`/`definitionCount` were already computed over the full 9-companion set and are unchanged.

The Capstone file (the exact-minimality result `5391411025 = 5²·7·11·13·17·19·23·29`) is a legitimate part of this verified multi-file proof; only the `leanFile` manifest was stale.

---
Automated fix by lean-mechanic agent.