### PR TITLE
Fix: sync stale declaration counts for 4 gallery entries (count drift)

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-04-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-04-oq-01/meta.json
@@ -13,7 +13,7 @@
     "namespace": "DivisibilityRulesOQ04OQ01",
     "lineCount": 105,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 1,
     "path": "Proofs/DivisibilityRulesOQ04OQ01.lean",
     "sorries": 0
@@ -33,7 +33,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 105,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 1,
     "badge": "mathlib",
     "originalContributions": [

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -69,7 +69,7 @@
     "axiomCount": 1,
     "lineCount": 1503,
     "assumptions": "1 axiom: erdos_lewin_infinite (Erdős-Lewin 1996, deep forward direction: {p,q}≠{2,3} ⟹ infinitely many non-representable numbers). The backward direction ({2,3} ⟹ finite, in fact NonRepresentable = {0}) is proved unconditionally (finite_nonRepresentable_of_two_three), and the EXISTENCE of a positive non-representable for every other coprime pair is also proved unconditionally (exists_positive_nonRepresentable_of_ne_two_three) — only the infinitude itself remains axiomatized.",
-    "theoremCount": 70,
+    "theoremCount": 71,
     "definitionCount": 7
   },
   "overview": {
@@ -267,7 +267,7 @@
     "namespace": "Erdos1110",
     "lineCount": 1503,
     "axiomCount": 1,
-    "theoremCount": 70,
+    "theoremCount": 71,
     "definitionCount": 7,
     "path": "Proofs/Erdos1110Problem.lean",
     "sorries": 0

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 728,
-    "theoremCount": 41,
+    "theoremCount": 42,
     "definitionCount": 2
   },
   "openQuestion": {
@@ -378,7 +378,7 @@
     "sorries": 0,
     "axiomCount": 7,
     "lineCount": 728,
-    "theoremCount": 41,
+    "theoremCount": 42,
     "definitionCount": 2,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",

--- a/src/data/proofs/picks-theorem-oq-04/meta.json
+++ b/src/data/proofs/picks-theorem-oq-04/meta.json
@@ -173,7 +173,7 @@
     "lineCount": 308,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/PicksTheoremOQ04.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Four gallery entries had stale declaration counts after research growth. Synced each to the true enumerated count.

## Evidence

| Entry | field | before → after | Basis |
|-------|-------|----------------|-------|
| `divisibility-rules-oq-04-oq-01` | theoremCount (both blocks) | 8 → 9 | 9 decls at lines 41,49,57,61,65,71,79,92,100; the line-21 grep hit is a docstring backtick-mention |
| `erdos-1110` | theoremCount (both blocks) | 70 → 71 | raw grep and comment-stripped counts both = 71 |
| `law-of-cosines-oq-03-oq-03` | theoremCount (both blocks) | 41 → 42 | grown by #36142 (hyperbolic law of sines); raw grep and comment-stripped both = 42 |
| `picks-theorem-oq-04` | leanFile.definitionCount | 9 → 10 | 10 top-level defs (1 abbrev + 9 def) at lines 69,78,90,109,118,129,193,196,236,239 |

Notes:
- For the first three, both count blocks (`leanFile.*` and `meta.*`) carried the same stale value and were synced together.
- For `picks-theorem-oq-04`, only the `leanFile` block (which matches the actual file: 308 lines, 14 thm) was corrected; its separate `meta` block (453 lines / 21 thm / 11 def) describes a different aggregate/prior scope and was left untouched.
- Line counts and `law-of-cosines` `meta.axiomCount=7` (structure-encoded, vs `leanFile.axiomCount=0` literal) left as-is per the Axiom Integrity Policy.

JSON validated for all four files.

---
Automated fix by lean-mechanic agent.