### PR TITLE
audit(erdos-1026-oq-05): sync stale companion-file counts

### DIFF
--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -155,9 +155,9 @@
     "additionalFiles": [
       {
         "path": "Proofs/Erdos1026OQ05IncreasingIdentity.lean",
-        "lineCount": 331,
-        "theoremCount": 17,
-        "definitionCount": 8,
+        "lineCount": 487,
+        "theoremCount": 26,
+        "definitionCount": 15,
         "description": "Exact Mirsky/Dilworth min-max identity: minimum number of strictly-increasing parts covering the sequence equals LDS (distinct reals)."
       }
     ]


### PR DESCRIPTION
## Integrity Audit — erdos-1026-oq-05

**Result**: Counts drifted (LOW severity). Status/axiom/sorry claims all correct.

### What drifted

The `leanFile.additionalFiles[0]` record for the companion `Proofs/Erdos1026OQ05IncreasingIdentity.lean` went stale as the companion file grew across #36153 and #36166:

| Field | meta.json (stale) | live source |
|-------|------|-------------|
| lineCount | 331 | **487** |
| theoremCount | 17 | **26** |
| definitionCount | 8 | **15** |

Def-count convention (`def`/`abbrev`/`structure`/`instance`) calibrated against the main file's `definitionCount: 12`, which matches exactly.

### What is correct (verified against source)

- `status: verified`, `badge: verified` — main file `Erdos1026OQ05.lean`: 0 axioms, 0 sorries, 18 theorems, 12 defs (all match meta).
- Companion: 0 axioms, 0 sorries.
- The two structures (`Subsequence`, `MonotonicDecomposition`) are definitional, not assumption-carrying — no hidden axioms.

Cosmetic count reconciliation only; no claim change.

---
Discovered during gallery integrity audit.