### PR TITLE
Enrich Triangle sum-to-product identities (triangle-angle-sum-oq-06): add references

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-06/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-06/meta.json
@@ -164,5 +164,35 @@
       "description": "Sum-to-product for a sine difference: sin x − sin y = 2·cos((x+y)/2)·sin((x−y)/2).",
       "leanType": "(x y : ℝ) → sin x - sin y = 2 * cos ((x + y) / 2) * sin ((x - y) / 2)"
     }
+  ],
+  "references": [
+    {
+      "authors": "Abramowitz, Milton; Stegun, Irene A. (eds.)",
+      "title": "Handbook of Mathematical Functions",
+      "year": "1964",
+      "venue": "National Bureau of Standards, Applied Mathematics Series 55 (§4.3)",
+      "note": "Standard reference table for the sum-to-product (prosthaphaeresis) identities sin x ± sin y and cos x ± cos y formalized here as cos_add_cos, cos_sub_cos, sin_add_sin, sin_sub_sin."
+    },
+    {
+      "authors": "Loney, Sidney Luxton",
+      "title": "Plane Trigonometry",
+      "year": "1893",
+      "venue": "Cambridge University Press",
+      "note": "Classic text deriving the triangle identities for A + B + C = π, including sin A + sin B + sin C = 4·cos(A/2)cos(B/2)cos(C/2) and the cos-sum half-angle product proved here as triangle_sin_sum and triangle_cos_sum."
+    },
+    {
+      "authors": "Thoren, Victor E.",
+      "title": "Prosthaphaeresis Revisited",
+      "year": "1988",
+      "venue": "Historia Mathematica 15(1), 32–39",
+      "note": "Historical account of prosthaphaeresis — the sum-to-product formulas used by 16th-century astronomers (Tycho Brahe's circle) to convert multiplication into addition before logarithms; the identities cos_add_cos etc. are their modern statement."
+    },
+    {
+      "authors": "Zwillinger, Daniel (ed.)",
+      "title": "CRC Standard Mathematical Tables and Formulae",
+      "year": "2018",
+      "venue": "33rd ed., CRC Press",
+      "note": "Comprehensive reference tables for trigonometric sum-to-product and half-angle identities, including the triangle half-angle product forms."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `triangle-angle-sum-oq-06`. Fills the structural gap — empty `references` list (mainTheorems, cross-refs, and overview already rich).

**Added `references` (4)**: Abramowitz–Stegun *Handbook of Mathematical Functions* 1964 (§4.3, sum-to-product tables), Loney *Plane Trigonometry* 1893 (triangle half-angle products), Thoren 'Prosthaphaeresis Revisited' 1988 (*Historia Mathematica* — the historical use of these identities for pre-logarithm multiplication), CRC *Standard Mathematical Tables* 2018.

Under 60 KB cap (check-meta-size passes). No existing content removed; JSON validated with jq. Verified status unchanged.