### PR TITLE
research(erdos-1039): eliminate degenerate random_polynomial_expected axiom (5→4)

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -486,11 +486,21 @@ theorem clustered_implies_large_disc (ε : ℝ) (hε : ε > 0) (hε' : ε < 1) :
 ## Random Polynomials
 -/
 
-/-- For random polynomials, the expected ρ is of order 1/√n. -/
-axiom random_polynomial_expected :
+/-- For random polynomials, the expected ρ is of order 1/√n.
+
+    NOTE: as *stated in Lean* this proposition is degenerate — the intended middle
+    term `Expected[rho(random poly of degree n)]` is only a comment, so the actual
+    statement collapses to `c₁/√n ≤ c₂/√n`, which is trivially true (take
+    `c₁ = c₂ = 1`). It therefore carries no genuine assumption and is discharged
+    here as a theorem rather than left as an `axiom`, removing a spurious entry
+    from the axiom list. The real content — that the *expected* order of magnitude
+    of `ρ` for a random degree-`n` polynomial is `Θ(1/√n)` — requires an
+    `Expected[·]` functional and remains unformalized. -/
+theorem random_polynomial_expected :
   ∃ c₁ > 0, ∃ c₂ > 0, ∀ n : ℕ, n ≥ 2 →
     c₁ / Real.sqrt n ≤ -- Expected[rho(random poly of degree n)]
-    c₂ / Real.sqrt n
+    c₂ / Real.sqrt n :=
+  ⟨1, one_pos, 1, one_pos, fun _ _ => le_refl _⟩
 
 /-
 ## The Open Question

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -22,9 +22,9 @@
     "erdosUrl": "https://erdosproblems.com/1039",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 5,
-    "lineCount": 533,
-    "assumptions": "5 axioms, all genuine published research results the proof correctly leaves unformalized (not overclaimed): benchmark_upper (Erdos-Herzog-Piranian benchmark rho(z^n-1) <= pi/(2n)), pommerenke_lower (Pommerenke 1961, rho >= 1/(2en^2)), klr_lower and klr_area_bound (Krishnapur-Lundberg-Ramachandran 2025, rho >> 1/(n*sqrt(log n))), and random_polynomial_expected. Formalizing any of these would require reproducing the source papers, so they are stated as axioms. The three elementary-geometry lemmas (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc) were completed in PR #33815 and the main file Proofs/Erdos1039Problem.lean now has 0 sorries (533 lines). The deprecated stub Proofs/Stubs/Erdos1039Problem.lean still holds the pre-#33815 state (3 sorries, the same 5 axioms) and is no longer byte-identical to the main file; it is not the presented proof (proofRepoPath is the main file) and adds no distinct assumptions. Note: random_polynomial_expected is currently degenerate as stated (the intended Expected[rho] middle term is a comment, so the Lean statement reduces to the trivial c1/sqrt(n) <= c2/sqrt(n)); a future session could either encode an Expected functional or convert it to a proved trivial lemma.",
+    "axiomCount": 4,
+    "lineCount": 543,
+    "assumptions": "4 axioms, all genuine published research results the proof correctly leaves unformalized (not overclaimed): benchmark_upper (Erdos-Herzog-Piranian benchmark rho(z^n-1) <= pi/(2n)), pommerenke_lower (Pommerenke 1961, rho >= 1/(2en^2)), and klr_lower + klr_area_bound (Krishnapur-Lundberg-Ramachandran 2025, rho >> 1/(n*sqrt(log n))). Formalizing any of these would require reproducing the source papers, so they are stated as axioms. The three elementary-geometry lemmas (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc) were completed in PR #33815 and the main file Proofs/Erdos1039Problem.lean has 0 sorries (543 lines). UPDATE: the former 5th axiom random_polynomial_expected was DEGENERATE — its intended Expected[rho] middle term was only a comment, so the Lean proposition collapsed to the trivially-true c1/sqrt(n) <= c2/sqrt(n); it has been converted to a proved theorem (witness c1=c2=1), removing a spurious entry from the axiom list (5 -> 4). The real Theta(1/sqrt n) expected-order claim needs an Expected functional and remains unformalized. The deprecated stub Proofs/Stubs/Erdos1039Problem.lean still holds the pre-#33815 state (3 sorries, the original 5 axioms) and is not the presented proof (proofRepoPath is the main file); it adds no distinct assumptions.",
     "mathlib_version": "4.29.0",
     "mathlibDependencies": [
       {
@@ -57,9 +57,9 @@
       "pommerenke_lower axiom: ρ(f) ≥ 1/(2en²) for any UnitDiscPolynomial (Pommerenke 1961)",
       "klr_lower axiom: ρ(f) ≥ c/(n√log n) (Krishnapur-Lundberg-Ramachandran 2025)",
       "klr_area_bound axiom: sublevelArea ≥ c/n² (area lower bound driving the KLR result)",
-      "random_polynomial_expected axiom: expected inscribed disc radius for random roots ≫ 1/n"
+      "random_polynomial_expected: now a proved theorem (degenerate as stated — c₁/√n ≤ c₂/√n, witness c₁=c₂=1); the genuine Θ(1/√n) expected-order claim needs an Expected functional and is unformalized"
     ],
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 17,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
@@ -242,9 +242,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1039",
-    "lineCount": 533,
-    "axiomCount": 5,
-    "theoremCount": 14,
+    "lineCount": 543,
+    "axiomCount": 4,
+    "theoremCount": 15,
     "definitionCount": 17,
     "path": "Proofs/Erdos1039Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-1039-incomplete-01.json
+++ b/src/data/research/problems/erdos-1039-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: PR #33815 confirmed MERGED (0 sorries on main); thorough static verification confirms hardest measure-coercion proof matches Mathlib idiom exactly; docker build verification launched to close BUILD-PENDING.",
+    "progressSummary": "COMPLETE: the sorry-completion (PR #33815, 3 elementary-geometry lemmas) is MERGED — 0 sorries on origin/main. Axiom-elimination pass (researcher-2, 07-08): converted the degenerate random_polynomial_expected axiom to a proved theorem (its Expected[rho] middle term was only a comment, so the Lean statement was the trivially-true c1/sqrt n <= c2/sqrt n; witness c1=c2=1). Axiom count 5 -> 4. The 4 remaining axioms (benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound) are genuine published EHP/Pommerenke/KLR results, correctly axiomatized — not session-eliminable. File elaborates cleanly in Docker (reached [7743/7743], zero type errors, 5 attempts); a green Docker exit-0 was blocked by fleet-memory SIGBUS at the olean-write stage (135/139), NOT a math error. Host lake env lean shows a spurious line-380 error from host mathlib-olean drift (identical on the pristine origin/main file), so is not a reliable oracle here.",
     "builtItems": [
       "Proved area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc in Proofs/Erdos1039Problem.lean (was 3 sorries, now 0).",
       "Added helpers: inscribed_ball_subset, inscribed_radius_le, sublevelSet_subset_ball, bddAbove_inscribed_radii, sublevelSet_degree_zero.",
@@ -47,8 +47,9 @@
       "No ball_subset_ball_iff for open balls (necessary direction); had to prove inscribed_radius_le by hand."
     ],
     "nextSteps": [
-      "BUILD VERIFICATION in flight: /tmp/verify-erdos1039.sh runs docker-build.sh Proofs.Erdos1039Problem once the concurrent lean-build volume frees (log /tmp/erdos1039-build.log). Could not run immediately: a 28min concurrent build held the shared lean-mathlib-cache olean volume (concurrent build = corruption risk).",
-      "Only residual static risk is line ~399 `_ = sublevelArea f := by field_simp` on goal `pi*(A/pi)=A`; field_simp discharger proves pi != 0 via positivity so expected OK; if build fails, harden to `field_simp` -> `rw [mul_div_cancel_left0 _ Real.pi_ne_zero]` or add `; ring`."
+      "DONE: axiom count reduced 5 -> 4 by discharging the degenerate random_polynomial_expected. Remaining 4 axioms are deep published results (EHP benchmark, Pommerenke 1961, KLR 2025 x2) — reproducing them is a paper-scale effort, not session work.",
+      "The one genuine formalization target left is to give random_polynomial_expected real content: define an Expected[rho(random degree-n poly)] functional and prove it is Theta(1/sqrt n). That needs a probability model over UnitDiscPolynomial and is a multi-session build, not an incremental step.",
+      "Housekeeping: the deprecated stub Proofs/Stubs/Erdos1039Problem.lean still holds the pre-#33815 state; a Mechanic could delete it (not the presented proof; adds no distinct assumptions)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Axiom-elimination pass on `erdos-1039` (polynomial-lemniscate disc radius). The sorry-completion (PR #33815) was already merged — `Erdos1039Problem.lean` has 0 sorries on `main` but carried **5 axioms**. One of them was spurious.

`random_polynomial_expected` was **degenerate**: its intended middle term `Expected[rho(random poly of degree n)]` is only a comment, so the Lean proposition collapsed to

```
∃ c₁ > 0, ∃ c₂ > 0, ∀ n ≥ 2, c₁/√n ≤ c₂/√n
```

which is trivially true (`c₁ = c₂ = 1`). Stating a trivial truth as an `axiom` inflates the assumption list, so it is now discharged as a proved theorem. **Axiom count 5 → 4.**

The 4 remaining axioms are genuine published research results and are *not* session-eliminable:
- `benchmark_upper` — Erdős–Herzog–Piranian benchmark `ρ(zⁿ−1) ≤ π/(2n)`
- `pommerenke_lower` — Pommerenke 1961, `ρ ≥ 1/(2en²)`
- `klr_lower`, `klr_area_bound` — Krishnapur–Lundberg–Ramachandran 2025

The real `Θ(1/√n)` expected-order claim needs an `Expected[·]` functional over a probability model and remains unformalized (documented in the theorem docstring and meta assumptions).

## Verification

The file **elaborates cleanly in Docker** — reached `[7743/7743]` with **zero type errors** across 5 build attempts. A green `exit-0` was blocked by **fleet-memory SIGBUS at the olean-write stage** (`code 135`/`139` after ~2–3s of clean elaboration), a memory artifact under concurrent fleet load, not a math error. Host `lake env lean` reports a spurious `line 380` error that is present **identically on the pristine `origin/main` file** (host mathlib-olean drift), so it is not a reliable oracle here.

## Meta sync

`axiomCount` 5→4, `lineCount` 533→543, `theoremCount` 14→15, `assumptions` field updated (both `.meta.*` and `.leanFile.*`). Status stays `axiomatized` / badge `axiom` (4 genuine axioms remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)