### PR TITLE
Audit erdos-143: remove stale Aristotle diagnostic comment

### DIFF
--- a/proofs/Proofs/Erdos143Problem.lean
+++ b/proofs/Proofs/Erdos143Problem.lean
@@ -34,10 +34,6 @@ Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>
 
 import Mathlib
 
-
-/- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
-
-Unexpected axioms were added during verification: ['Erdos143.kll_theorem', 'harmonicSorry781341', 'Erdos143.well_separated_integers_primitive', 'Erdos143.erdos_1935_primitive']-/
 open Filter Set
 
 open scoped Topology

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11135,10 +11135,10 @@
       "result": "clean"
     },
     "erdos-143": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:48Z",
-      "result": "clean"
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "erdos-144": {
       "auditCount": 5,

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -46,7 +46,7 @@
       "Formalized the KLL 2025 partial resolution"
     ],
     "axiomCount": 3,
-    "lineCount": 122,
+    "lineCount": 118,
     "assumptions": "3 axiom(s): kll_theorem, well_separated_integers_primitive, erdos_1935_primitive. See Lean source for complete statements.",
     "theoremCount": 1,
     "definitionCount": 8
@@ -221,7 +221,7 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 122,
+    "lineCount": 118,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 8,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-143

**Proof**: erdos-143 (Erdős Problem #143, partially solved)
**Result**: issues-fixed (cosmetic / credibility)

### Problem
The Lean source (`proofs/Proofs/Erdos143Problem.lean`) carried a leftover Aristotle diagnostic block comment near the imports:

> `/- Aristotle failed to load this code into its environment. ... Unexpected axioms were added during verification: [..., 'harmonicSorry781341', ...] -/`

This falsely states the file failed to load and references a phantom `harmonicSorry781341` axiom that does **not** exist in the file (0 sorries, 3 legitimate axioms). Because the gallery renders Lean source publicly, this misleading comment is a credibility blemish.

### Fix
- Removed the stale comment block.
- Reconciled `lineCount` 122 → 118 in both meta.json count blocks (meta + leanFile).

### Verified clean (no other issues)
- **Axioms**: 3 (`kll_theorem`, `well_separated_integers_primitive`, `erdos_1935_primitive`) — matches `axiomCount: 3` and the `assumptions` field.
- **Counts**: 1 theorem, 8 defs, 0 sorries — all match meta.json.
- **Status/badge**: `axiomatized` / `axiom` — correct for this open problem; no overclaiming.
- `originalContributions` are honestly scoped (adapted from DeepMind formal-conjectures, KLL 2025 partial resolution).

Tracker updated for erdos-143 (`result: issues-fixed`).

---
Discovered during gallery integrity audit.