### PR TITLE
Fix: reconcile additionalFiles manifests for 8 gallery entries (#36184)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
@@ -97,6 +97,7 @@
     "additionalFiles": [
       "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
       "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean",
+      "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Converse.lean",
       "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge.lean",
       "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"
     ]

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -25,7 +25,8 @@
     "theoremCount": 14,
     "definitionCount": 9,
     "additionalFiles": [
-      "Proofs/Erdos1168Aristotle.lean"
+      "Proofs/Erdos1168Aristotle.lean",
+      "Proofs/Erdos1168Sierpinski.lean"
     ],
     "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erdős-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -42,7 +42,8 @@
       "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG4.lean",
       "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG5.lean",
       "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG6.lean",
-      "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG7.lean"
+      "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG7.lean",
+      "Proofs/LagrangeFourSquaresWaringG2OQ01General.lean"
     ]
   },
   "overview": {

--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -293,6 +293,7 @@
   ],
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/MotivicFlagMapsProvable.lean",
     "Proofs/MotivicFlagMapsOQ03.lean"
   ]
 }

--- a/src/data/proofs/roth-theorem-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-oq-01/meta.json
@@ -87,7 +87,8 @@
     "path": "Proofs/RothTheoremOQ01.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/RothTheoremOQ02.lean"
+      "Proofs/RothTheoremOQ02.lean",
+      "Proofs/RothTheoremOQ01Reciprocal.lean"
     ]
   },
   "sections": [

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -177,6 +177,7 @@
   },
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/RothTheoremAristotle.lean",
     "Proofs/RothTheoremOQ02.lean"
   ],
   "references": [

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -250,6 +250,7 @@
   ],
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/ShapleyFolkmanAristotle.lean",
     "Proofs/ShapleyFolkmanOQ01.lean"
   ]
 }

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -20,7 +20,8 @@
     ],
     "proofRepoPath": "Proofs/SpernerSimplicialInstance.lean",
     "additionalFiles": [
-      "Proofs/SpernerMathlib4.lean"
+      "Proofs/SpernerMathlib4.lean",
+      "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean"
     ],
     "badge": "original",
     "sorries": 0,
@@ -179,6 +180,7 @@
   },
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/SpernerMathlib4.lean",
     "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean"
   ],
   "references": [


### PR DESCRIPTION
## Fix

For 8 gallery entries, the `additionalFiles` companion list disagreed between its three manifest locations (`additionalFiles`, `meta.additionalFiles`, `leanFile.additionalFiles`). This reconciles each entry's present locations to a single consistent set.

## Per-file judgment (as the issue requires)

For every disagreement file I verified: it exists on disk, carries the entry's slug-prefix (genuine companion, not a foreign file), is auto-discovered/buildable via the `Proofs` glob, and — critically — **is sorry-free and axiom-free** (comment-stripped scan):

| slug | file added to lagging location | sorries/axioms |
|------|-------------------------------|----------------|
| erdos-1168 | Erdos1168Sierpinski.lean → meta | 0/0 |
| shapley-folkman | ShapleyFolkmanAristotle.lean → top-level | 0/0 |
| lagrange-four-squares-waring-g2 | ...OQ01General.lean → meta | 0/0 |
| motivic-flag-maps | MotivicFlagMapsProvable.lean → top-level | 0/0 |
| roth-theorem-oq-01 | RothTheoremOQ01Reciprocal.lean → leanFile | 0/0 |
| roth-theorem | RothTheoremAristotle.lean → top-level | 0/0 |
| sperner-simplicial-instance | SpernerMathlib4.lean + Scarf1d → top-level/meta | 0/0, 0/0 |
| cayley-hamilton-...-oq-03 | ...OQ03Converse.lean → leanFile | 0/0 |

Because every extra is 0/0, the union changes **no** sorry/axiom aggregate and does **not** flip any `verified`/`axiomatized` claim (no #35854 regression). `lineCount` stays the main-file count (per-main convention), so no aggregate recompute is needed.

## Evidence

**Before**: within each entry, the three locations listed different file sets (direction inconsistent — sometimes `leanFile` was the superset, sometimes `meta`/top-level).
**After**: all present locations agree by basename set for all 8 entries (verified).

Only `additionalFiles` array lines changed; JSON validated with `jq empty`.

Closes #36184

---
Automated fix by lean-mechanic agent.