### PR TITLE
Fix: reconcile additionalFiles manifests across 8 entries

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
@@ -97,6 +97,7 @@
     "additionalFiles": [
       "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
       "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean",
+      "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Converse.lean",
       "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge.lean",
       "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"
     ]

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -25,7 +25,8 @@
     "theoremCount": 14,
     "definitionCount": 9,
     "additionalFiles": [
-      "Proofs/Erdos1168Aristotle.lean"
+      "Proofs/Erdos1168Aristotle.lean",
+      "Proofs/Erdos1168Sierpinski.lean"
     ],
     "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erdős-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -42,7 +42,8 @@
       "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG4.lean",
       "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG5.lean",
       "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG6.lean",
-      "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG7.lean"
+      "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG7.lean",
+      "Proofs/LagrangeFourSquaresWaringG2OQ01General.lean"
     ]
   },
   "overview": {

--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -293,6 +293,7 @@
   ],
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/MotivicFlagMapsProvable.lean",
     "Proofs/MotivicFlagMapsOQ03.lean"
   ]
 }

--- a/src/data/proofs/roth-theorem-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-oq-01/meta.json
@@ -87,7 +87,8 @@
     "path": "Proofs/RothTheoremOQ01.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/RothTheoremOQ02.lean"
+      "Proofs/RothTheoremOQ02.lean",
+      "Proofs/RothTheoremOQ01Reciprocal.lean"
     ]
   },
   "sections": [

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -177,6 +177,7 @@
   },
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/RothTheoremAristotle.lean",
     "Proofs/RothTheoremOQ02.lean"
   ],
   "references": [

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -250,6 +250,7 @@
   ],
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/ShapleyFolkmanAristotle.lean",
     "Proofs/ShapleyFolkmanOQ01.lean"
   ]
 }

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -20,7 +20,8 @@
     ],
     "proofRepoPath": "Proofs/SpernerSimplicialInstance.lean",
     "additionalFiles": [
-      "Proofs/SpernerMathlib4.lean"
+      "Proofs/SpernerMathlib4.lean",
+      "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean"
     ],
     "badge": "original",
     "sorries": 0,
@@ -179,6 +180,7 @@
   },
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/SpernerMathlib4.lean",
     "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean"
   ],
   "references": [


### PR DESCRIPTION
## Fix

Reconciles the `additionalFiles` companion list across its three meta.json locations (`meta.additionalFiles`, `leanFile.additionalFiles`, top-level `additionalFiles`) for the 8 entries flagged in #36184.

## Evidence

Each disputed extra file was scanned on disk: **all are sorry-free and axiom-free** (native_decide only appears in `MotivicFlagMapsProvable.lean`, whose entry is already `axiomatized`). Because none threatens a `verified`/`axiomatized` status claim, the correct resolution is a **union** — add each missing companion to the disagreeing locations rather than removing it.

| slug | status | reconciled |
|------|--------|-----------|
| erdos-1168 | formalized | +Sierpinski → meta |
| shapley-folkman | verified | +Aristotle → top-level |
| lagrange-four-squares-waring-g2 | axiomatized | +General → meta |
| motivic-flag-maps | axiomatized | +Provable → top-level |
| roth-theorem-oq-01 | axiomatized | +OQ01Reciprocal → leanFile |
| roth-theorem | axiomatized | +Aristotle → top-level |
| sperner-simplicial-instance | verified | +Mathlib4 → top, +Scarf1d → meta |
| cayley-hamilton-…-oq-03 | verified | +Converse → leanFile |

**After**: all present manifest locations agree per entry; every referenced file exists on disk; JSON validates. `meta.lineCount` follows the per-main convention for all 8, so no count changes are needed. Diff is 13 insertions / 4 deletions (comma re-punctuation) across 8 files.

Closes #36184

---
Automated fix by lean-mechanic agent.