### PR TITLE
Enrich Odd Squares Sum: add mainTheorems array + Faulhaber reference

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -79,6 +79,24 @@
       "summary": "The classical closed form ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3 over ℚ. Base case is `simp` (empty sum). The inductive step peels the top term, rewrites by the hypothesis, and `push_cast; ring` discharges the polynomial identity — verifying (m(2m−1)(2m+1)/3) + (2m+1)² = (m+1)(2m+1)(2m+3)/3 in the field ℚ where division is genuine."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "three_mul_sum_odd_squares",
+      "type": "core",
+      "description": "**Division-free integer form (headline over ℕ).** 3·∑_{k<n} (2k+1)² + n = 4n³. The closed form n(2n−1)(2n+1)/3 is cleared of its denominator and rearranged additively so every term is a genuine natural number — no truncated ℕ subtraction anywhere. Proved by induction: `sum_range_succ` peels the top odd square, one `ring`-verified reassociation makes the hypothesis 3·∑ + m = 4m³ appear verbatim, and a final `ring` closes the branch on the cubic identity 4m³ + 3(2m+1)² + 1 = 4(m+1)³.",
+      "leanType": "(n : ℕ) : 3 * (∑ k ∈ range n, (2 * k + 1) ^ 2) + n = 4 * n ^ 3",
+      "startLine": 46,
+      "endLine": 60
+    },
+    {
+      "name": "sum_odd_squares_rat",
+      "type": "key",
+      "description": "**Classical closed form over ℚ.** ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3. Stated over the field ℚ where division by 3 is honest. Base case is `simp` (empty sum); the inductive step peels the top term with `sum_range_succ`, rewrites by the hypothesis, and `push_cast; ring` discharges the polynomial identity, normalizing the ℕ→ℚ cast of n+1 automatically.",
+      "leanType": "(n : ℕ) : ∑ k ∈ range n, (2 * (k : ℚ) + 1) ^ 2 = (n : ℚ) * (2 * n - 1) * (2 * n + 1) / 3",
+      "startLine": 64,
+      "endLine": 72
+    }
+  ],
   "overview": {
     "historicalContext": "**Odd-indexed power sums**\n\nThe squares of the odd numbers $1^2, 3^2, 5^2, \\dots$ sum to a strikingly clean closed form. Writing the $k$-th odd number as $2k+1$ for $k = 0, 1, \\dots, n-1$,\n$$1^2 + 3^2 + 5^2 + \\cdots + (2n-1)^2 = \\frac{n(2n-1)(2n+1)}{3}.$$\nThis is the odd-indexed sibling of the *square-pyramidal* identity $\\sum_{k\\le n} k^2 = \\tfrac{n(n+1)(2n+1)}{6}$. Indeed, summing all squares up to $2n-1$ and subtracting the even squares $\\sum (2k)^2 = 4\\sum k^2$ recovers exactly this formula. Mathlib provides the square-pyramidal identity but not this odd variant; this entry supplies it.",
     "problemStatement": "**Sum of squares of the first $n$ odd numbers**\n\nFor every natural number $n$,\n$$\\sum_{k<n} (2k+1)^2 = \\frac{n(2n-1)(2n+1)}{3}.$$\nThe goal is a fully machine-checked proof with no axioms and no sorries, in a form that avoids artifacts of natural-number division.",
@@ -109,6 +127,13 @@
       "year": "1996",
       "venue": "Springer-Verlag",
       "note": "Popular account of figurate and polygonal numbers, including sums of squares of consecutive and odd integers"
+    },
+    {
+      "authors": "Beardon, A. F.",
+      "title": "Sums of Powers of Integers",
+      "year": "1996",
+      "venue": "American Mathematical Monthly 103(3), 201–213",
+      "note": "Systematic derivation of Faulhaber-type closed forms ∑ kᵐ and their odd-indexed relatives, situating identities like ∑(2k+1)² within the general polynomial power-sum framework this entry instantiates at degree 2"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `odd-squares-sum-oq-01`.

**Structural gap closed:** the entry had no `mainTheorems` array. Added both theorems from `OddSquaresSum.lean`, each with `leanType` and line anchors verified against the source:
- `three_mul_sum_odd_squares` (core) — division-free ℕ form `3·∑(2k+1)² + n = 4n³` (lines 46–60)
- `sum_odd_squares_rat` (key) — rational closed form `∑(2k+1)² = n(2n−1)(2n+1)/3` (lines 64–72)

**Reference:** added Beardon, *Sums of Powers of Integers* (AMM 1996), situating the degree-2 odd-index sum in the general Faulhaber framework (references 2→3).

No existing content removed. meta.json 11.7→13.5 KB, well under the 60 KB cap. Counts unchanged (2 theorems, 0 sorries, 0 axioms).