### PR TITLE
Enrich Structural Identities for σₖ: add cross-references + reference

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-04/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04/meta.json
@@ -169,6 +169,16 @@
       "targetId": "abundant-number-oq-03",
       "relationship": "related",
       "description": "The σ-form of perfection (σ(n) = 2n) sits beside the abundance condition (σ(n) > 2n) in the same divisor-sum classification of integers"
+    },
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "related — perfection criterion",
+      "description": "The Euclid–Euler theorem classifies the even perfect numbers as 2^(p−1)(2^p−1) with 2^p−1 a Mersenne prime. Its arithmetic engine is exactly `perfect_iff_sigma_one` proved here — perfection is the equation σ(n) = 2n — together with the closed prime-power form `sigma_one_prime_pow_mul` that evaluates σ on the 2^(p−1) factor. This entry supplies the σ-side identities the Euclid–Euler proof consumes."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related — sibling multiplicative function",
+      "description": "Euler's totient φ is the companion multiplicative arithmetic function to σ: both are read off Mathlib's prime-power API and both factor across coprime arguments via `IsMultiplicative.map_mul_of_coprime`. Where this entry gives σ(pⁱ)·(p−1) = p^{i+1}−1 and σ(pq) = (p+1)(q+1), the totient satisfies the parallel φ(pⁱ) = pⁱ−p^{i−1} and φ(pq) = (p−1)(q−1)."
     }
   ],
   "conclusion": {
@@ -209,6 +219,13 @@
       "year": "1976",
       "venue": "Springer Undergraduate Texts in Mathematics",
       "note": "Theorem 2.13 and surrounding: σ is multiplicative with σ(pᵃ) = (p^{a+1}−1)/(p−1)"
+    },
+    {
+      "authors": "McCarthy, Paul J.",
+      "title": "Introduction to Arithmetical Functions",
+      "year": "1986",
+      "venue": "Springer Universitext",
+      "note": "Monograph devoted to multiplicative arithmetical functions; develops σₖ, τ, and φ uniformly through their values on prime powers and the multiplicativity that this entry formalizes"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `sum-of-divisors-oq-04` (structural σₖ identities: primes, prime powers, multiplicativity).

**Cross-references 2→4** (both targets verified present in the gallery):
- `perfect-numbers` — the Euclid–Euler classification of even perfect numbers is powered by exactly `perfect_iff_sigma_one` (σ(n)=2n) and the closed prime-power form proved here.
- `euler-totient` — φ is the sibling multiplicative arithmetic function to σ, evaluated through the same prime-power / `map_mul_of_coprime` API; parallel prime-power and two-prime formulas noted.

**References 2→3:** added McCarthy, *Introduction to Arithmetical Functions* (Springer, 1986), the standard monograph on multiplicative arithmetic functions.

No content removed. meta.json well under the 60 KB cap. Counts unchanged (5 theorems, 0 sorries, 0 axioms; `status: verified` accurate).