### PR TITLE
Enrich Odd Squares Sum: add mainTheorems array + full section coverage

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -3,6 +3,24 @@
   "title": "Sum of Squares of the First n Odd Numbers: ∑(2k−1)² = n(2n−1)(2n+1)/3",
   "slug": "odd-squares-sum-oq-01",
   "description": "A fully machine-checked, self-contained proof that the sum of the squares of the first n odd numbers has the closed form n(2n−1)(2n+1)/3: ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3. The result is established both as a division-free exact identity over ℕ — 3·∑(2k+1)² + n = 4n³, phrased additively so the inductive step has no truncated subtraction and closes by `ring` alone — and as the classical rational closed form over ℚ. This is the odd-indexed companion of the square-pyramidal identity ∑k² = n(n+1)(2n+1)/6, which Mathlib has; this variant it does not.",
+  "mainTheorems": [
+    {
+      "name": "sum_odd_squares_rat",
+      "type": "main",
+      "description": "The classical rational closed form: the sum of the squares of the first n odd numbers is n(2n−1)(2n+1)/3. Proved over ℚ (where the division by 3 is genuine) by induction, with push_cast; ring discharging the cubic step.",
+      "leanType": "(n : ℕ) : ∑ k ∈ range n, (2 * (k : ℚ) + 1) ^ 2 = (n : ℚ) * (2 * n - 1) * (2 * n + 1) / 3",
+      "startLine": 64,
+      "endLine": 72
+    },
+    {
+      "name": "three_mul_sum_odd_squares",
+      "type": "supporting",
+      "description": "The division-free exact ℕ identity 3·∑(2k+1)² + n = 4n³. Its additive phrasing contains no truncated natural subtraction, so the whole inductive step closes by a single ring after one reassociation — the certificate underlying the rational closed form.",
+      "leanType": "(n : ℕ) : 3 * (∑ k ∈ range n, (2 * k + 1) ^ 2) + n = 4 * n ^ 3",
+      "startLine": 46,
+      "endLine": 58
+    }
+  ],
   "leanFile": {
     "path": "Proofs/OddSquaresSum.lean",
     "namespace": "OddSquaresSum",
@@ -75,7 +93,7 @@
       "id": "rational-closed-form",
       "title": "Rational closed form n(2n−1)(2n+1)/3",
       "startLine": 64,
-      "endLine": 72,
+      "endLine": 74,
       "summary": "The classical closed form ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3 over ℚ. Base case is `simp` (empty sum). The inductive step peels the top term, rewrites by the hypothesis, and `push_cast; ring` discharges the polynomial identity — verifying (m(2m−1)(2m+1)/3) + (2m+1)² = (m+1)(2m+1)(2m+3)/3 in the field ℚ where division is genuine."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `odd-squares-sum-oq-01`.

The entry was missing the `mainTheorems` array entirely (a structural gap — all sibling entries have one). Added it, plus closed a small section-coverage gap:

- **mainTheorems** (new): `sum_odd_squares_rat` (the ℚ closed form n(2n−1)(2n+1)/3, type `main`) and `three_mul_sum_odd_squares` (the division-free ℕ identity 3·∑+n=4n³, type `supporting`), each with exact `leanType` and start/end lines verified against Proofs/OddSquaresSum.lean.
- **Section coverage**: extended the last section end from 72 to 74 so `sections` span the full 74-line file.

meta.json 11.7 → 12.7 KB (well under 60 KB cap). JSON validated; check-meta-size passes.