### PR TITLE
Fix: reconcile additionalFiles manifests for 8 gallery entries (#36184)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
@@ -97,6 +97,7 @@
     "additionalFiles": [
       "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
       "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean",
+      "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Converse.lean",
       "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge.lean",
       "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"
     ]

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -25,7 +25,8 @@
     "theoremCount": 14,
     "definitionCount": 9,
     "additionalFiles": [
-      "Proofs/Erdos1168Aristotle.lean"
+      "Proofs/Erdos1168Aristotle.lean",
+      "Proofs/Erdos1168Sierpinski.lean"
     ],
     "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erdős-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -42,7 +42,8 @@
       "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG4.lean",
       "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG5.lean",
       "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG6.lean",
-      "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG7.lean"
+      "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG7.lean",
+      "Proofs/LagrangeFourSquaresWaringG2OQ01General.lean"
     ]
   },
   "overview": {

--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -293,6 +293,7 @@
   ],
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/MotivicFlagMapsProvable.lean",
     "Proofs/MotivicFlagMapsOQ03.lean"
   ]
 }

--- a/src/data/proofs/roth-theorem-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-oq-01/meta.json
@@ -87,7 +87,8 @@
     "path": "Proofs/RothTheoremOQ01.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/RothTheoremOQ02.lean"
+      "Proofs/RothTheoremOQ02.lean",
+      "Proofs/RothTheoremOQ01Reciprocal.lean"
     ]
   },
   "sections": [

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -177,6 +177,7 @@
   },
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/RothTheoremAristotle.lean",
     "Proofs/RothTheoremOQ02.lean"
   ],
   "references": [

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -250,6 +250,7 @@
   ],
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/ShapleyFolkmanAristotle.lean",
     "Proofs/ShapleyFolkmanOQ01.lean"
   ]
 }

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -20,7 +20,8 @@
     ],
     "proofRepoPath": "Proofs/SpernerSimplicialInstance.lean",
     "additionalFiles": [
-      "Proofs/SpernerMathlib4.lean"
+      "Proofs/SpernerMathlib4.lean",
+      "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean"
     ],
     "badge": "original",
     "sorries": 0,
@@ -179,6 +180,7 @@
   },
   "sorries": 0,
   "additionalFiles": [
+    "Proofs/SpernerMathlib4.lean",
     "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean"
   ],
   "references": [


### PR DESCRIPTION
## Fix

For 8 gallery entries, the `additionalFiles` companion list disagreed between its three manifest locations (top-level `additionalFiles`, `meta.additionalFiles`, `leanFile.additionalFiles`). This reconciles each entry's present locations to the union of listed companions. Closes #36184.

## Per-file judgment

Every added companion was verified on disk:
- **exists** and carries the entry's slug prefix
- for the 3 **verified** entries, the added companion is **sorry-free and axiom-free**:
  - `cayley-hamilton-cyclic-vector-all-fields-oq-03` → `…OQ03Converse.lean` (the only `sorry` match is the docstring `"0 sorry / 0 axiom"`)
  - `shapley-folkman` → `ShapleyFolkmanAristotle.lean` (clean)
  - `sperner-simplicial-instance` → `…OQ05Scarf1d.lean` (clean)
- axiomatized/formalized entries (`lagrange-four-squares-waring-g2`, `motivic-flag-maps` [native_decide], `roth-theorem`, `roth-theorem-oq-01` [1 axiom], `erdos-1168` [formalized/wip]) may carry axioms/native_decide/sorries consistent with their status

## Validation
- all 8 `meta.json` remain valid JSON
- all three present manifest locations now agree by path for every entry
- every referenced companion path exists on disk (0 phantoms)

## Note
Supersedes #36191 and #36192, which each closed the other as a duplicate, leaving #36184 unresolved on `main`. This re-applies the same human-blessed union fix from #36191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)