### PR TITLE
Fix: reconcile additionalFiles manifest for erdos-79-incomplete-01

### DIFF
--- a/src/data/proofs/erdos-79-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-79-incomplete-01/meta.json
@@ -29,7 +29,9 @@
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
     "definitionCount": 7,
-    "additionalFiles": []
+    "additionalFiles": [
+      "Proofs/Erdos79Incomplete01OQ01.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #79 (Erdős–Faudree–Rousseau–Schelp) asks whether infinitely many graphs are minimally non-Ramsey-size-linear: not Ramsey size-linear themselves, yet all of whose proper subgraphs are. Wigderson (2024) proved infinitely many exist non-constructively; K₄ remains the only explicit example. The parent formalization `Proofs/Erdos79Problem.lean` keeps the Ramsey number `ramseyNumber` opaque and packages the two hard facts about K₄ as axioms: `K4_not_linear` (K₄ is superlinear) and the sweeping `K4_subgraphs_linear` (every proper subgraph of K₄ is size-linear, quantified over infinitely many `H : SimpleGraph ℕ`). This companion attacks the second axiom's SHAPE: over the opaque `ramseyNumber` no specific graph's size-linearity is derivable, but the combinatorial reduction of the quantifier structure is fully provable.",


### PR DESCRIPTION
## Fix

`erdos-79-incomplete-01` had an inconsistent `additionalFiles` manifest: `meta.additionalFiles` was `[]` while `leanFile.additionalFiles` listed `Proofs/Erdos79Incomplete01OQ01.lean`. This is the same class of manifest inconsistency as #36184 (an entry the auditor's 8-row table did not enumerate).

## Evidence

- `Proofs/Erdos79Incomplete01OQ01.lean` exists on disk (278 lines), imports `Proofs.Erdos79Incomplete01` (the main module) + Mathlib, and is glob-registered via `lakefile.toml` (`globs = ["Proofs", "Proofs.*"]`) — a genuine, buildable companion carrying the `Erdos79Incomplete01` slug prefix.
- It has **0 real sorries** (the only `sorry` token is inside a docstring: "…we DERIVE (0 sorry)") and 2 declared axioms.
- The entry status is already `axiomatized` (`meta.axiomCount: 3`), so unioning the companion into the manifest does not alter the status claim.
- Per-main count convention is preserved (`meta.lineCount = 267 = main file`); only the manifest list was reconciled.

**Before**: `meta.additionalFiles = []`, `leanFile.additionalFiles = ["Proofs/Erdos79Incomplete01OQ01.lean"]` (disagree)
**After**: both list `["Proofs/Erdos79Incomplete01OQ01.lean"]` (agree)

Relates to #36184 (this entry was outside the original 8-row table; the 8 are handled by #36191, and the sibling `abundant-number-oq-02-oq-01` aggregate case by #36181).

---
Automated fix by lean-mechanic agent.