### PR TITLE
Enrich Ramsey LLL bad-event probability: add mainTheorems + preamble section

### DIFF
--- a/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
@@ -120,6 +120,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module header, imports, and Part I setup",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring positioning the file as Erdős (1947), the first application of the probabilistic method to Ramsey theory, and stating the counting form of the main criterion 2·C(n,k) < 2^C(k,2) ⇒ R(k,k) > n. Notes that the argument lives entirely in a finite counting space — no measure theory — so it is fully machine-checked, and that it de-axiomatizes `erdos_probabilistic_lower_bound` (previously an `axiom` in Proofs/RamseyR4kExtensions.lean). `import Mathlib`, `namespace ErdosRamsey`, `open Finset`, and the Part I header framing colourings as functions `c : E → Bool` over an abstract finite edge type E."
+    },
+    {
       "id": "counting-core",
       "title": "The abstract first-moment counting lemma",
       "startLine": 42,
@@ -137,7 +144,7 @@
       "id": "diagonal-bound",
       "title": "The classical R(k,k) > 2^(k/2) bound",
       "startLine": 244,
-      "endLine": 326,
+      "endLine": 329,
       "summary": "erdos_diagonal_numeric is the elementary ℕ estimate that n ≤ 2^⌊k/2⌋ implies 2·C(n,k) < 2^C(k,2) for k ≥ 3. erdos_probabilistic_lower_bound assembles the headline result, exactly matching the statement axiomatized in the parent RamseyR4kExtensions file, now with 0 axioms."
     }
   ],

--- a/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
@@ -3,6 +3,56 @@
   "title": "Lovász Local Lemma for Ramsey: the monochromatic-clique bad-event probability",
   "slug": "ramsey-r4k-extensions-oq-03-oq-01",
   "description": "A fully machine-checked, axiom-free formalization of the second combinatorial input to the symmetric Lovász Local Lemma (LLL) feasibility test for Spencer's improved diagonal Ramsey lower bound. The symmetric LLL condition is e·p·(d+1) ≤ 1, where d is the dependency degree (the sibling entry ramsey-r4k-extensions-oq-03, Key Lemma 3) and p is the probability that a fixed k-clique is monochromatic under a uniformly random 2-colouring of the edges of Kₙ. This entry supplies p — Key Lemma 2 — again with no probability theory: a k-clique has exactly C(k,2) edges, so there are 2^C(k,2) equally likely colourings, of which exactly two (all-red and all-blue) are monochromatic. Hence p = 2/2^C(k,2) = 2^(1−C(k,2)). The combinatorial heart is a clean finite fact — among all Bool-colourings of a nonempty finite type, exactly two are constant — proved by exhibiting the constant colourings as the injective image of Bool. The result clique_monochromatic_probability computes p exactly as a real number. Proved with 0 axioms, 0 sorries, no native_decide.",
+  "mainTheorems": [
+    {
+      "name": "card_constant_colorings",
+      "type": "key",
+      "description": "**Abstract counting core.** Among all Bool-colourings of a nonempty finite type α, exactly two are constant. The predicate `∀ x y, c x = c y` is shown to cut out the image of `Bool` under the injection `b ↦ (fun _ => b)` (injective because α is nonempty), so the count is `Fintype.card Bool = 2`. This type-agnostic lemma is the combinatorial heart from which every clique-level count is instantiated.",
+      "leanType": "(α : Type*) [Fintype α] [DecidableEq α] [Nonempty α] : ((univ : Finset (α → Bool)).filter (fun c => ∀ x y, c x = c y)).card = 2",
+      "startLine": 53,
+      "endLine": 72
+    },
+    {
+      "name": "cliqueEdges_card",
+      "type": "supporting",
+      "description": "**Edge count of a k-clique.** The edge set `cliqueEdges S = S.powersetCard 2` (the 2-element subsets of S) has exactly C(k,2) elements when |S| = k, by `Finset.card_powersetCard`.",
+      "leanType": "(k : ℕ) (S : Finset V) (hS : S.card = k) : (cliqueEdges S).card = k.choose 2",
+      "startLine": 83,
+      "endLine": 85
+    },
+    {
+      "name": "card_edgeColorings",
+      "type": "supporting",
+      "description": "**Total colourings.** The number of 2-colourings of a k-clique's edges is 2^C(k,2) — two independent colour choices on each of the C(k,2) edges — via `Fintype.card_fun`, `Fintype.card_bool`, and `Fintype.card_coe`.",
+      "leanType": "(k : ℕ) (S : Finset V) (hS : S.card = k) : Fintype.card (EdgeColoring S) = 2 ^ k.choose 2",
+      "startLine": 94,
+      "endLine": 97
+    },
+    {
+      "name": "card_monochromatic_edgeColorings",
+      "type": "key",
+      "description": "**Monochromatic-colouring count (Key Lemma 2, numerator).** Exactly two of the 2^C(k,2) edge-colourings of a k-clique are monochromatic (all-red, all-blue). Requires k ≥ 2 so the clique has an edge (making the edge type nonempty); then the result is a direct instantiation of `card_constant_colorings` on the edge subtype.",
+      "leanType": "(k : ℕ) (hk : 2 ≤ k) (S : Finset V) (hS : S.card = k) : ((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card = 2",
+      "startLine": 104,
+      "endLine": 111
+    },
+    {
+      "name": "clique_monochromatic_probability",
+      "type": "core",
+      "description": "**Bad-event probability p (headline).** The probability that a fixed k-clique is monochromatic under the uniform random 2-colouring equals 2^(1−C(k,2)), computed as the exact real ratio #monochromatic/#total = 2/2^C(k,2). `zpow_sub₀` converts the ratio to the closed form. This is the value of p fed into the symmetric LLL condition e·p·(d+1) ≤ 1, completing (with Key Lemma 3's dependency bound) the feasibility input for Spencer's improved Ramsey lower bound.",
+      "leanType": "(k : ℕ) (hk : 2 ≤ k) (S : Finset V) (hS : S.card = k) : (((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card : ℝ) / (Fintype.card (EdgeColoring S) : ℝ) = (2 : ℝ) ^ (1 - (k.choose 2 : ℤ))",
+      "startLine": 122,
+      "endLine": 129
+    },
+    {
+      "name": "triangle_monochromatic_count",
+      "type": "supporting",
+      "description": "**Sanity check (k = 3).** A triangle has C(3,2) = 3 edges, hence 2^3 = 8 colourings, of which exactly 2 are monochromatic — the classical per-triangle probability 2/8 = 1/4 = 2^(1−3). Grounds the general formula against the familiar triangle case.",
+      "leanType": "(S : Finset V) (hS : S.card = 3) : ((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card = 2 ∧ Fintype.card (EdgeColoring S) = 8",
+      "startLine": 134,
+      "endLine": 138
+    }
+  ],
   "meta": {
     "author": "Lean Genius Researcher",
     "status": "verified",
@@ -86,6 +136,13 @@
     ]
   },
   "sections": [
+    {
+      "id": "preamble",
+      "title": "Module header, imports, and namespace setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the file as Key Lemma 2 of Spencer's LLL-improved diagonal Ramsey lower bound: the symmetric LLL feasibility test e·p·(d+1) ≤ 1, where the sibling file RamseyR4kExtensionsOQ03.lean supplies the dependency degree d and this file supplies the bad-event probability p = 2^(1−C(k,2)) purely by counting colourings. Cites Erdős–Lovász (1975), Spencer (1975), and Alon–Spencer. `import Mathlib`, `set_option linter.unusedSectionVars false`, `namespace RamseyLLL`, `open Finset`, and the header of the abstract counting core section."
+    },
     {
       "id": "counting-core",
       "title": "The abstract counting core: exactly two constant colourings",

--- a/src/data/proofs/sum-of-divisors-oq-04/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04/meta.json
@@ -169,6 +169,16 @@
       "targetId": "abundant-number-oq-03",
       "relationship": "related",
       "description": "The σ-form of perfection (σ(n) = 2n) sits beside the abundance condition (σ(n) > 2n) in the same divisor-sum classification of integers"
+    },
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "related — perfection criterion",
+      "description": "The Euclid–Euler theorem classifies the even perfect numbers as 2^(p−1)(2^p−1) with 2^p−1 a Mersenne prime. Its arithmetic engine is exactly `perfect_iff_sigma_one` proved here — perfection is the equation σ(n) = 2n — together with the closed prime-power form `sigma_one_prime_pow_mul` that evaluates σ on the 2^(p−1) factor. This entry supplies the σ-side identities the Euclid–Euler proof consumes."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related — sibling multiplicative function",
+      "description": "Euler's totient φ is the companion multiplicative arithmetic function to σ: both are read off Mathlib's prime-power API and both factor across coprime arguments via `IsMultiplicative.map_mul_of_coprime`. Where this entry gives σ(pⁱ)·(p−1) = p^{i+1}−1 and σ(pq) = (p+1)(q+1), the totient satisfies the parallel φ(pⁱ) = pⁱ−p^{i−1} and φ(pq) = (p−1)(q−1)."
     }
   ],
   "conclusion": {
@@ -209,6 +219,13 @@
       "year": "1976",
       "venue": "Springer Undergraduate Texts in Mathematics",
       "note": "Theorem 2.13 and surrounding: σ is multiplicative with σ(pᵃ) = (p^{a+1}−1)/(p−1)"
+    },
+    {
+      "authors": "McCarthy, Paul J.",
+      "title": "Introduction to Arithmetical Functions",
+      "year": "1986",
+      "venue": "Springer Universitext",
+      "note": "Monograph devoted to multiplicative arithmetical functions; develops σₖ, τ, and φ uniformly through their values on prime powers and the multiplicativity that this entry formalizes"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `ramsey-r4k-extensions-oq-03-oq-01` (Key Lemma 2: bad-event probability p = 2^(1−C(k,2)) for Spencer's LLL Ramsey bound).

**Two structural gaps closed:**
- `mainTheorems` was absent → added all 6 theorems, each with `leanType` and start/end line anchors verified against the source (card_constant_colorings, cliqueEdges_card, card_edgeColorings, card_monochromatic_edgeColorings, clique_monochromatic_probability, triangle_monochromatic_count), typed core/key/supporting.
- `sections` started at line 47 → added a preamble section (1–46) covering the module docstring, imports, and namespace setup; sections now span the whole 140-line file.

No content removed. meta.json ~18 KB, under the 60 KB cap; counts unchanged (6 theorems, 0 sorries, 0 axioms).