### PR TITLE
Fix: verified entries must not advertise axiom-carrying companions (#35854)

### DIFF
--- a/src/data/proofs/euler-polyhedral-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-oq-01/meta.json
@@ -227,9 +227,7 @@
     "definitionCount": 14,
     "path": "Proofs/EulerPolyhedralOQ01.lean",
     "sorries": 0,
-    "additionalFiles": [
-      "Proofs/EulerPolyhedralOQ01OQ04.lean"
-    ]
+    "additionalFiles": []
   },
   "sections": [
     {

--- a/src/data/proofs/szemeredi-core/meta.json
+++ b/src/data/proofs/szemeredi-core/meta.json
@@ -173,9 +173,7 @@
     "definitionCount": 4,
     "path": "Proofs/SzemerediCore.lean",
     "sorries": 0,
-    "additionalFiles": [
-      "Proofs/SzemerediCoreOQ03.lean"
-    ]
+    "additionalFiles": []
   },
   "references": [
     {


### PR DESCRIPTION
## Finding

#35854/#35862 swept **sorry**-carrying companions off `verified` entries but did not cover **axiom**-carrying ones. Two entries badged `verified`/`original` with `axiomCount: 0` and assumptions "None. … 0 axioms" each advertise (in `leanFile.additionalFiles`) an exploratory OQ companion that is full of `axiom` declarations:

| Entry | Advertised companion | Axioms in companion |
|-------|----------------------|---------------------|
| `euler-polyhedral-oq-01` | `Proofs/EulerPolyhedralOQ01OQ04.lean` | 12 (`four_color_theorem`, `five_color_theorem`, `kuratowski_hard`, `euler_formula`, `hadwiger_conjecture_t5`, edge bounds, …) |
| `szemeredi-core` | `Proofs/SzemerediCoreOQ03.lean` | 1 (`gowers_regularity_exists`; the file itself notes the full formalization is a ~2000-line project) |

Both are OQ sub-problem explorations (OQ04 / OQ03) sitting beside the entry's actual verified main file (`EulerPolyhedralOQ01.lean`, `SzemerediCore.lean`).

## Fix

The main proof of each entry is genuinely verified (0 sorries, 0 axioms), so downgrading the entry to `axiomatized` would misrepresent real work. The honest, #35862-consistent remediation is to **unregister** the axiom-laden supplementary companion from the manifest (the `.lean` files remain on disk, just no longer advertised under a 0-axiom badge).

## Validation
- both `meta.json` remain valid JSON
- all three manifest locations (`additionalFiles`, `meta.additionalFiles`, `leanFile.additionalFiles`) now agree (empty)
- `meta.axiomCount`/`leanFile.axiomCount` remain 0 — now truthful

Part of the open #35854 hygiene theme (which stays open for the CI guard that would prevent regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)