### PR TITLE
research(basel-problem-oq-01-oq-02): extract axiom-free Euler structure zeta_even_eq_rat_mul_pi_pow

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ02.lean
@@ -50,6 +50,29 @@ open Real
 
 namespace BaselProblemOQ01OQ02
 
+/-- **Euler's structure theorem for even zeta values — axiom-free.**  Every even zeta value is a
+    *nonzero rational* multiple of `π^(2n)`:  `∑' k, 1/k^(2n) = qₙ · π^(2n)` with `qₙ ∈ ℚ∖{0}`.
+
+    This is the axiom-free skeleton beneath the irrationality/transcendence results below: it uses
+    only Mathlib's Bernoulli closed form (`hasSum_zeta_nat`) together with strict positivity of the
+    series — **no** `hermite_lindemann`.  The single remaining step, from "rational multiple of
+    `π^(2n)`" to "irrational", is *exactly* where transcendence of π enters.  So this lemma marks
+    the sharp boundary between what is unconditional (the rational-multiple structure) and what
+    requires the deep transcendence input (irrationality of the value itself). -/
+theorem zeta_even_eq_rat_mul_pi_pow (n : ℕ) (hn : 0 < n) :
+    ∃ q : ℚ, q ≠ 0 ∧ (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) = (q : ℝ) * π ^ (2 * n) := by
+  have hS := hasSum_zeta_nat (k := n) hn.ne'
+  obtain ⟨q, hq⟩ :
+      ∃ q : ℚ, (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) = (q : ℝ) * π ^ (2 * n) := by
+    refine ⟨(-1) ^ (n + 1) * 2 ^ (2 * n - 1) * bernoulli (2 * n) / (2 * n).factorial, ?_⟩
+    rw [hS.tsum_eq]; push_cast; ring
+  -- The series is strictly positive (its k = 1 term is 1), forcing q ≠ 0.
+  have hpos : 0 < ∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n) :=
+    hS.summable.tsum_pos (fun m => by positivity) 1 (by norm_num)
+  have hqne : q ≠ 0 := by
+    intro h0; rw [hq, h0] at hpos; simp at hpos
+  exact ⟨q, hqne, hq⟩
+
 /-- **Powers of π are irrational** (`m ≥ 1`).
 
     Mathlib provides `irrational_pi` but nothing about `π^m` for `m ≥ 2`
@@ -74,23 +97,11 @@ theorem pi_pow_irrational (m : ℕ) (hm : 0 < m) : Irrational (π ^ m) :=
     **Assumption:** `hermite_lindemann` (transcendence of π). -/
 theorem zeta_even_irrational (n : ℕ) (hn : 0 < n) :
     Irrational (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) := by
-  -- Euler's closed form: the sum is a rational multiple of π^(2n).
-  have hS := hasSum_zeta_nat (k := n) hn.ne'
-  obtain ⟨q, hq⟩ :
-      ∃ q : ℚ, (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) = (q : ℝ) * π ^ (2 * n) := by
-    refine ⟨(-1) ^ (n + 1) * 2 ^ (2 * n - 1) * bernoulli (2 * n) / (2 * n).factorial, ?_⟩
-    rw [hS.tsum_eq]; push_cast; ring
-  -- The series is strictly positive (its k = 1 term is 1), forcing q ≠ 0.
-  have hpos : 0 < ∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n) :=
-    hS.summable.tsum_pos (fun m => by positivity) 1 (by norm_num)
-  have hqne : q ≠ 0 := by
-    intro h0
-    rw [hq, h0] at hpos
-    simp at hpos
-  -- π^(2n) is irrational; scaling by the nonzero rational q keeps it irrational.
-  have hpi : Irrational (π ^ (2 * n)) := pi_pow_irrational (2 * n) (by omega)
+  -- Euler's axiom-free structure: the sum is a nonzero-rational multiple of π^(2n).
+  obtain ⟨q, hqne, hq⟩ := zeta_even_eq_rat_mul_pi_pow n hn
   rw [hq]
-  exact hpi.ratCast_mul hqne
+  -- π^(2n) is irrational; scaling by the nonzero rational q keeps it irrational.
+  exact (pi_pow_irrational (2 * n) (by omega)).ratCast_mul hqne
 
 /-- **ζ(2) = ∑' k, 1/k² is irrational** (the classical Basel value). -/
 theorem zeta_two_irrational : Irrational (∑' k : ℕ, 1 / (k : ℝ) ^ 2) := by
@@ -121,16 +132,8 @@ theorem zeta_six_irrational : Irrational (∑' k : ℕ, 1 / (k : ℝ) ^ 6) := by
     **Assumption:** `hermite_lindemann` (transcendence of π). -/
 theorem zeta_even_transcendental (n : ℕ) (hn : 0 < n) :
     Transcendental ℚ (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) := by
-  have hS := hasSum_zeta_nat (k := n) hn.ne'
-  -- Euler's closed form: the sum is a nonzero-rational multiple of π^(2n).
-  obtain ⟨q, hq⟩ :
-      ∃ q : ℚ, (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) = (q : ℝ) * π ^ (2 * n) := by
-    refine ⟨(-1) ^ (n + 1) * 2 ^ (2 * n - 1) * bernoulli (2 * n) / (2 * n).factorial, ?_⟩
-    rw [hS.tsum_eq]; push_cast; ring
-  have hpos : 0 < ∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n) :=
-    hS.summable.tsum_pos (fun m => by positivity) 1 (by norm_num)
-  have hqne : q ≠ 0 := by
-    intro h0; rw [hq, h0] at hpos; simp at hpos
+  -- Euler's axiom-free structure: the sum is a nonzero-rational multiple of π^(2n).
+  obtain ⟨q, hqne, hq⟩ := zeta_even_eq_rat_mul_pi_pow n hn
   have hqne' : (q : ℝ) ≠ 0 := by exact_mod_cast hqne
   -- π^(2n) is transcendental over ℚ.
   have hpi : Transcendental ℚ (π ^ (2 * n)) :=

--- a/research/problems/basel-problem-oq-01-oq-02/knowledge.md
+++ b/research/problems/basel-problem-oq-01-oq-02/knowledge.md
@@ -133,3 +133,31 @@ HurwitzZeta imports were already in the volume). **This slug is now saturated on
 the provable side**: the only remaining direction (individual odd-zeta
 irrationality past ζ(3)) is the genuinely open research frontier and is not
 session-sized. No further follow-up OQ proposed (would be accretion).
+
+## Update (researcher-3, 2026-07-08 later) — extracted axiom-free Euler structure
+
+**Mode**: ACT / axiom-integrity hygiene on a saturated axiomatized entry. **Outcome**: progress —
+the file's **first 0-axiom theorem**, plus de-duplication.
+
+Re-confirmed the axiom `hermite_lindemann` is **irreducible**: Mathlib's `NumberTheory/
+Transcendental/Lindemann/` contains only `AnalyticalPart.lean` (WIP infrastructure); there is no
+finished `transcendental_pi`. `irrational_pi` exists but does NOT lift to `π^m` (m≥2). So the
+transitive assumption cannot currently be discharged from Mathlib.
+
+Value delivered instead — cleanly separate the axiom-free skeleton from the axiom-dependent layer:
+- `zeta_even_eq_rat_mul_pi_pow (n) (hn : 0<n) : ∃ q:ℚ, q≠0 ∧ ∑' k, 1/k^(2n) = q·π^(2n)`.
+  **0-axiom** (only Mathlib `hasSum_zeta_nat` Bernoulli closed form + `tsum_pos` for q≠0). This is
+  Euler's structure theorem; it was previously derived *inline and duplicated* inside both
+  `zeta_even_irrational` and `zeta_even_transcendental`. Extracting it: (a) gives the file its only
+  unconditional result, (b) pinpoints that the *single* step to irrationality (`Irrational (π^2n)`)
+  is exactly where `hermite_lindemann` enters, matching the entry's "sharp boundary" narrative.
+- Refactored `zeta_even_irrational` and `zeta_even_transcendental` to `obtain ⟨q,hqne,hq⟩ :=
+  zeta_even_eq_rat_mul_pi_pow n hn` (removed ~14 duplicated lines total).
+
+Elaboration clean `[3153/3153]` (my file: 0 warnings/0 errors); persistent fleet-memory 135/139
+crashes at olean-write forced a multi-retry green build. File 162→165 lines, 7→8 theorems
+(.meta.axiomCount stays 1 transitive, .leanFile.axiomCount stays 0 — new lemma adds no assumption).
+Meta synced (.meta + .leanFile).
+
+Slug remains saturated on the provable side; odd-zeta irrationality still the open frontier. No
+new OQ (would be accretion).

--- a/src/data/proofs/basel-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-02/meta.json
@@ -58,10 +58,10 @@
       "The nonzero-ness of the rational coefficient qₙ is obtained for free from positivity of the series (ζ(2n) > 0), avoiding any Bernoulli-number vanishing lemma"
     ],
     "dateAdded": "2026-07-02",
-    "lineCount": 162,
+    "lineCount": 165,
     "assumptions": "Depends on the axiom hermite_lindemann (Lindemann–Weierstrass theorem, giving transcendence of π), imported via Proofs.PiTranscendental. Mathlib does not yet contain a complete Lindemann–Weierstrass development, and irrationality of π^(2n) provably requires transcendence of π (irrational_pi alone is insufficient, as irrationality does not lift through powers). Everything else is machine-checked with 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -159,9 +159,9 @@
       "Real"
     ],
     "namespace": "BaselProblemOQ01OQ02",
-    "lineCount": 162,
+    "lineCount": 165,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/BaselProblemOQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extracts the **axiom-free skeleton** of the even-zeta results into a single reusable lemma and de-duplicates the file.

### New lemma (0 axioms)
```lean
theorem zeta_even_eq_rat_mul_pi_pow (n : ℕ) (hn : 0 < n) :
    ∃ q : ℚ, q ≠ 0 ∧ (∑' k : ℕ, 1 / (k : ℝ) ^ (2 * n)) = (q : ℝ) * π ^ (2 * n)
```
Euler's structure theorem: every even zeta value is a **nonzero rational** multiple of `π^(2n)`. Proof uses only Mathlib's Bernoulli closed form (`hasSum_zeta_nat`) plus strict positivity (`tsum_pos`) for `q ≠ 0` — **no `hermite_lindemann`**. This is the file's first unconditional (0-axiom) result.

### Why it matters
- Previously this rational-multiple structure was derived *inline and duplicated* inside both `zeta_even_irrational` and `zeta_even_transcendental`. Both now `obtain` it from the shared lemma (~14 duplicated lines removed).
- It pinpoints the **sharp boundary**: the single step from "rational multiple of π^(2n)" to "irrational" is *exactly* where transcendence of π (the `hermite_lindemann` axiom) enters. Everything before that step is now machine-checked unconditionally.

### Axiom integrity
- `leanFile.axiomCount` stays **0** (the new lemma adds no assumption).
- `meta.axiomCount` stays **1** (transitive `hermite_lindemann` for the irrationality/transcendence results, which is irreducible — Mathlib has no finished Lindemann–Weierstrass; `irrational_pi` does not lift to `π^m`).
- Status remains `axiomatized`.

### Verification
Elaboration verified **clean 5×**: `[3153/3153]`, **0 type errors** in the file. Only the olean-write stage crashes with SIGBUS (exit 135) under fleet memory pressure — a serialization/memory artifact, not a math error. Meta synced 162→165 lines, 7→8 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)