### PR TITLE
Enrich Shannon binary rate-distortion: structured cross-references

### DIFF
--- a/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
@@ -120,6 +120,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module header, imports, and Part I setup",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring positioning the file as Erdős (1947), the first application of the probabilistic method to Ramsey theory, and stating the counting form of the main criterion 2·C(n,k) < 2^C(k,2) ⇒ R(k,k) > n. Notes that the argument lives entirely in a finite counting space — no measure theory — so it is fully machine-checked, and that it de-axiomatizes `erdos_probabilistic_lower_bound` (previously an `axiom` in Proofs/RamseyR4kExtensions.lean). `import Mathlib`, `namespace ErdosRamsey`, `open Finset`, and the Part I header framing colourings as functions `c : E → Bool` over an abstract finite edge type E."
+    },
+    {
       "id": "counting-core",
       "title": "The abstract first-moment counting lemma",
       "startLine": 42,
@@ -137,7 +144,7 @@
       "id": "diagonal-bound",
       "title": "The classical R(k,k) > 2^(k/2) bound",
       "startLine": 244,
-      "endLine": 326,
+      "endLine": 329,
       "summary": "erdos_diagonal_numeric is the elementary ℕ estimate that n ≤ 2^⌊k/2⌋ implies 2·C(n,k) < 2^C(k,2) for k ≥ 3. erdos_probabilistic_lower_bound assembles the headline result, exactly matching the statement axiomatized in the parent RamseyR4kExtensions file, now with 0 axioms."
     }
   ],

--- a/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
@@ -3,6 +3,56 @@
   "title": "Lovász Local Lemma for Ramsey: the monochromatic-clique bad-event probability",
   "slug": "ramsey-r4k-extensions-oq-03-oq-01",
   "description": "A fully machine-checked, axiom-free formalization of the second combinatorial input to the symmetric Lovász Local Lemma (LLL) feasibility test for Spencer's improved diagonal Ramsey lower bound. The symmetric LLL condition is e·p·(d+1) ≤ 1, where d is the dependency degree (the sibling entry ramsey-r4k-extensions-oq-03, Key Lemma 3) and p is the probability that a fixed k-clique is monochromatic under a uniformly random 2-colouring of the edges of Kₙ. This entry supplies p — Key Lemma 2 — again with no probability theory: a k-clique has exactly C(k,2) edges, so there are 2^C(k,2) equally likely colourings, of which exactly two (all-red and all-blue) are monochromatic. Hence p = 2/2^C(k,2) = 2^(1−C(k,2)). The combinatorial heart is a clean finite fact — among all Bool-colourings of a nonempty finite type, exactly two are constant — proved by exhibiting the constant colourings as the injective image of Bool. The result clique_monochromatic_probability computes p exactly as a real number. Proved with 0 axioms, 0 sorries, no native_decide.",
+  "mainTheorems": [
+    {
+      "name": "card_constant_colorings",
+      "type": "key",
+      "description": "**Abstract counting core.** Among all Bool-colourings of a nonempty finite type α, exactly two are constant. The predicate `∀ x y, c x = c y` is shown to cut out the image of `Bool` under the injection `b ↦ (fun _ => b)` (injective because α is nonempty), so the count is `Fintype.card Bool = 2`. This type-agnostic lemma is the combinatorial heart from which every clique-level count is instantiated.",
+      "leanType": "(α : Type*) [Fintype α] [DecidableEq α] [Nonempty α] : ((univ : Finset (α → Bool)).filter (fun c => ∀ x y, c x = c y)).card = 2",
+      "startLine": 53,
+      "endLine": 72
+    },
+    {
+      "name": "cliqueEdges_card",
+      "type": "supporting",
+      "description": "**Edge count of a k-clique.** The edge set `cliqueEdges S = S.powersetCard 2` (the 2-element subsets of S) has exactly C(k,2) elements when |S| = k, by `Finset.card_powersetCard`.",
+      "leanType": "(k : ℕ) (S : Finset V) (hS : S.card = k) : (cliqueEdges S).card = k.choose 2",
+      "startLine": 83,
+      "endLine": 85
+    },
+    {
+      "name": "card_edgeColorings",
+      "type": "supporting",
+      "description": "**Total colourings.** The number of 2-colourings of a k-clique's edges is 2^C(k,2) — two independent colour choices on each of the C(k,2) edges — via `Fintype.card_fun`, `Fintype.card_bool`, and `Fintype.card_coe`.",
+      "leanType": "(k : ℕ) (S : Finset V) (hS : S.card = k) : Fintype.card (EdgeColoring S) = 2 ^ k.choose 2",
+      "startLine": 94,
+      "endLine": 97
+    },
+    {
+      "name": "card_monochromatic_edgeColorings",
+      "type": "key",
+      "description": "**Monochromatic-colouring count (Key Lemma 2, numerator).** Exactly two of the 2^C(k,2) edge-colourings of a k-clique are monochromatic (all-red, all-blue). Requires k ≥ 2 so the clique has an edge (making the edge type nonempty); then the result is a direct instantiation of `card_constant_colorings` on the edge subtype.",
+      "leanType": "(k : ℕ) (hk : 2 ≤ k) (S : Finset V) (hS : S.card = k) : ((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card = 2",
+      "startLine": 104,
+      "endLine": 111
+    },
+    {
+      "name": "clique_monochromatic_probability",
+      "type": "core",
+      "description": "**Bad-event probability p (headline).** The probability that a fixed k-clique is monochromatic under the uniform random 2-colouring equals 2^(1−C(k,2)), computed as the exact real ratio #monochromatic/#total = 2/2^C(k,2). `zpow_sub₀` converts the ratio to the closed form. This is the value of p fed into the symmetric LLL condition e·p·(d+1) ≤ 1, completing (with Key Lemma 3's dependency bound) the feasibility input for Spencer's improved Ramsey lower bound.",
+      "leanType": "(k : ℕ) (hk : 2 ≤ k) (S : Finset V) (hS : S.card = k) : (((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card : ℝ) / (Fintype.card (EdgeColoring S) : ℝ) = (2 : ℝ) ^ (1 - (k.choose 2 : ℤ))",
+      "startLine": 122,
+      "endLine": 129
+    },
+    {
+      "name": "triangle_monochromatic_count",
+      "type": "supporting",
+      "description": "**Sanity check (k = 3).** A triangle has C(3,2) = 3 edges, hence 2^3 = 8 colourings, of which exactly 2 are monochromatic — the classical per-triangle probability 2/8 = 1/4 = 2^(1−3). Grounds the general formula against the familiar triangle case.",
+      "leanType": "(S : Finset V) (hS : S.card = 3) : ((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card = 2 ∧ Fintype.card (EdgeColoring S) = 8",
+      "startLine": 134,
+      "endLine": 138
+    }
+  ],
   "meta": {
     "author": "Lean Genius Researcher",
     "status": "verified",
@@ -86,6 +136,13 @@
     ]
   },
   "sections": [
+    {
+      "id": "preamble",
+      "title": "Module header, imports, and namespace setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the file as Key Lemma 2 of Spencer's LLL-improved diagonal Ramsey lower bound: the symmetric LLL feasibility test e·p·(d+1) ≤ 1, where the sibling file RamseyR4kExtensionsOQ03.lean supplies the dependency degree d and this file supplies the bad-event probability p = 2^(1−C(k,2)) purely by counting colourings. Cites Erdős–Lovász (1975), Spencer (1975), and Alon–Spencer. `import Mathlib`, `set_option linter.unusedSectionVars false`, `namespace RamseyLLL`, `open Finset`, and the header of the abstract counting core section."
+    },
     {
       "id": "counting-core",
       "title": "The abstract counting core: exactly two constant colourings",

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -3,6 +3,40 @@
   "title": "Roth/Szemerédi OQ-03-OQ-01-OQ-01-OQ-01-OQ-01: Affine Covariance of the k-AP Counting Operator Λ_k",
   "slug": "roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01",
   "description": "Affine covariance of the k-AP counting operator Λ_k(f₀,…,f_{k-1}) = E_{x,d} ∏ᵢ fᵢ(x+i·d): for any unit a ∈ (ZMod N)ˣ and translate t, replacing every fᵢ by y↦fᵢ(a·y+t) leaves the count unchanged (kAPCount_affine). The affine map φ(y)=a·y+t carries the progression {x+i·d} to {φ(x)+i·(a·d)}, and (x,d)↦(a·x+t, a·d) is a bijection of (ZMod N)² precisely because a is invertible. This exhibits the one-dimensional affine group GA(1,ZMod N)=(ZMod N)ˣ⋉ZMod N acting on Λ_k. Two corollaries: kAPCount_dilate (the genuinely new multiplicative dilation invariance, t=0) and kAPCount_translate_of_affine (recovers the parent's translation invariance, a=1). Directly answers the parent's first open question. 0-axiom verified.",
+  "mainTheorems": [
+    {
+      "name": "kAPCount_affine",
+      "type": "core",
+      "description": "**Affine covariance (headline).** For any unit a ∈ (ZMod N)ˣ and translate t, replacing every fᵢ by y ↦ fᵢ(a·y + t) leaves the count fixed: Λ_k(f₀(a·+t),…) = Λ_k(f₀,…). Proved by two `Fintype.sum_equiv` reindexings — the outer base-point average by x ↦ a·x+t and the inner common-difference average by d ↦ a·d, each a bijection because a is a unit — after which the pointwise identity a·(x+i·d)+t = (a·x+t)+i·(a·d) closes by `nsmul_eq_mul` and `ring`.",
+      "leanType": "(k : ℕ) (f : Fin k → ZMod N → ℂ) (a : (ZMod N)ˣ) (t : ZMod N) : kAPCount k (fun i y => f i ((a : ZMod N) * y + t)) = kAPCount k f",
+      "startLine": 92,
+      "endLine": 105
+    },
+    {
+      "name": "kAPCount_dilate",
+      "type": "key",
+      "description": "**Dilation invariance (the new multiplicative symmetry).** The t = 0 case of affine covariance: for any unit a, Λ_k(f₀(a·),…) = Λ_k(f₀,…). Not implied by the parent's translation invariance nor by reflection — e.g. a = −1 is the point reflection through the origin that keeps the slot order, distinct from the order-reversing i ↦ k−1−i. Follows from `kAPCount_affine` by `simpa`.",
+      "leanType": "(k : ℕ) (f : Fin k → ZMod N → ℂ) (a : (ZMod N)ˣ) : kAPCount k (fun i y => f i ((a : ZMod N) * y)) = kAPCount k f",
+      "startLine": 119,
+      "endLine": 122
+    },
+    {
+      "name": "kAPCount_translate_of_affine",
+      "type": "supporting",
+      "description": "**Translation invariance recovered.** The a = 1 case of affine covariance, confirming that affine covariance subsumes the parent's `kAPCount_translate`: Λ_k(f₀(·+t),…) = Λ_k(f₀,…). Follows from `kAPCount_affine` by `simpa`.",
+      "leanType": "(k : ℕ) (f : Fin k → ZMod N → ℂ) (t : ZMod N) : kAPCount k (fun i y => f i (y + t)) = kAPCount k f",
+      "startLine": 126,
+      "endLine": 130
+    },
+    {
+      "name": "mulUnit_apply",
+      "type": "supporting",
+      "description": "**Dilation bijection (computation rule).** The permutation `mulUnit a` of ZMod N (multiplication by a unit a, with inverse multiplication by a⁻¹) evaluates as `mulUnit a x = a·x`. This `Equiv` is the multiplicative part of the affine reindexing (x,d) ↦ (a·x+t, a·d); the additive part reuses `Equiv.addRight`.",
+      "leanType": "(a : (ZMod N)ˣ) (x : ZMod N) : mulUnit a x = (a : ZMod N) * x",
+      "startLine": 76,
+      "endLine": 77
+    }
+  ],
   "meta": {
     "author": "Lean Genius Researcher",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gowers_norm",
@@ -76,6 +110,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module header, ancestor imports, and setup",
+      "summary": "Module docstring tracing the four-generation Roth/Szemerédi lineage (great-grandparent defines Λ_k and its degenerate identities, grandparent proves multilinearity, parent proves translation and reflection symmetries) and stating what this file adds: the full affine covariance of Λ_k, exhibiting the one-dimensional affine group GA(1, ZMod N) = (ZMod N)ˣ ⋉ ZMod N acting by symmetries, with dilation invariance as the genuinely new multiplicative piece. Cites Gowers (2001) and Tao (2012). `import Proofs.RothTheoremOQ03OQ01OQ01OQ01`, `open Finset BigOperators`, `namespace RothTheoremOQ03OQ01`, `variable {N : ℕ} [NeZero N]`.",
+      "startLine": 1,
+      "endLine": 63
+    },
+    {
       "id": "mul-unit",
       "title": "Multiplication by a Unit is a Bijection",
       "summary": "mulUnit a: multiplication by a unit a ∈ (ZMod N)ˣ is a permutation of ZMod N, with inverse multiplication by a⁻¹ — the dilation part of the affine reindexing.",
@@ -109,6 +150,22 @@
       "Conjugate symmetry Λ_k(conj f₀,…,conj f_{k-1}) = conj Λ_k(f₀,…,f_{k-1}) and its interaction with affine covariance"
     ]
   },
+  "references": [
+    {
+      "authors": "Gowers, W. T.",
+      "title": "A new proof of Szemerédi's theorem",
+      "year": "2001",
+      "venue": "Geometric and Functional Analysis 11(3), 465–588",
+      "note": "Introduces the Gowers uniformity norms and the density-increment machinery in which the affine symmetries of the k-AP counting operator Λ_k are used to normalize progression counts"
+    },
+    {
+      "authors": "Tao, Terence",
+      "title": "Higher Order Fourier Analysis",
+      "year": "2012",
+      "venue": "Graduate Studies in Mathematics 142, American Mathematical Society",
+      "note": "Systematic treatment of Gowers norms and the generalized von Neumann inequality; the invariance of Λ_k under the affine group of ZMod N formalized here is a standing assumption there"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Proofs.RothTheoremOQ03OQ01OQ01OQ01"

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
@@ -70,6 +70,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module header, parent import, and setup",
+      "summary": "Module docstring positioning the file within the Roth/Szemerédi Gowers-norm chain (parent Proofs/RothTheoremOQ03OQ01.lean defines Λ_k = kAPCount and the Gowers norm): the parent proves the constant/normalization/annihilation identities of Λ_k, and this file adds the key structural fact that Λ_k is multilinear — additive and homogeneous in each of its k slots — the property powering the generalized von Neumann inequality and density-increment arguments. Lists the four results (prod_update_factor, kAPCount_add_slot, kAPCount_smul_slot, gowersNorm_nonneg) and notes slots are addressed via Function.update. `import Proofs.RothTheoremOQ03OQ01`, `open Finset BigOperators`, `namespace RothTheoremOQ03OQ01`, `variable {N : ℕ} [NeZero N]`.",
+      "startLine": 1,
+      "endLine": 38
+    },
+    {
       "id": "engine",
       "title": "The Factorization Engine",
       "summary": "prod_update_factor: replacing slot j by v pulls v(x+j·d) out of the k-AP product, leaving the untouched factors over univ.erase j.",

--- a/src/data/proofs/shannon-source-coding-oq-01-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-01-oq-03/meta.json
@@ -174,7 +174,25 @@
     }
   ],
   "crossReferences": [
-    "shannon-source-coding-oq-01",
-    "shannon-entropy"
+    {
+      "proofId": "shannon-source-coding-oq-01",
+      "relationship": "parent — general rate-distortion theory",
+      "description": "The parent Rate–Distortion Theory entry sets up the general operational R(D) as the minimum rate achieving expected distortion ≤ D. This entry instantiates it in the canonical binary case, giving the exact closed form R(D) = h(p) − h(D) for a Bernoulli(p) source under Hamming distortion, and verifies its structural properties (endpoints, nonnegativity, monotonicity, entropy bound)."
+    },
+    {
+      "proofId": "shannon-entropy",
+      "relationship": "prerequisite — binary entropy function",
+      "description": "The rate-distortion function is built entirely from the binary entropy h(p) = −p log p − (1−p) log(1−p), whose properties (concavity, maximum at 1/2, endpoint values h(0)=h(1)=0) supply the endpoint, monotonicity, and upper-bound facts proved here."
+    },
+    {
+      "proofId": "shannon-source-coding",
+      "relationship": "related — lossless limit",
+      "description": "The Shannon Source Coding Theorem gives the lossless compression limit H(p). Rate-distortion generalizes it to lossy compression: R(D) = h(p) − h(D) recovers the lossless rate R(0) = h(p) as the D → 0 endpoint, so the source coding theorem is the zero-distortion boundary of this curve."
+    },
+    {
+      "proofId": "shannon-channel-coding",
+      "relationship": "related — information-theoretic dual",
+      "description": "The Noisy Channel Coding Theorem characterizes the channel capacity C as a maximum of mutual information; rate-distortion is its source-side dual, characterizing R(D) as a minimum of mutual information. The binary symmetric channel capacity 1 − h(D) is the exact companion of the binary rate-distortion h(p) − h(D) formalized here."
+    }
   ]
 }

--- a/src/data/proofs/sum-of-divisors-oq-04/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04/meta.json
@@ -169,6 +169,16 @@
       "targetId": "abundant-number-oq-03",
       "relationship": "related",
       "description": "The σ-form of perfection (σ(n) = 2n) sits beside the abundance condition (σ(n) > 2n) in the same divisor-sum classification of integers"
+    },
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "related — perfection criterion",
+      "description": "The Euclid–Euler theorem classifies the even perfect numbers as 2^(p−1)(2^p−1) with 2^p−1 a Mersenne prime. Its arithmetic engine is exactly `perfect_iff_sigma_one` proved here — perfection is the equation σ(n) = 2n — together with the closed prime-power form `sigma_one_prime_pow_mul` that evaluates σ on the 2^(p−1) factor. This entry supplies the σ-side identities the Euclid–Euler proof consumes."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related — sibling multiplicative function",
+      "description": "Euler's totient φ is the companion multiplicative arithmetic function to σ: both are read off Mathlib's prime-power API and both factor across coprime arguments via `IsMultiplicative.map_mul_of_coprime`. Where this entry gives σ(pⁱ)·(p−1) = p^{i+1}−1 and σ(pq) = (p+1)(q+1), the totient satisfies the parallel φ(pⁱ) = pⁱ−p^{i−1} and φ(pq) = (p−1)(q−1)."
     }
   ],
   "conclusion": {
@@ -209,6 +219,13 @@
       "year": "1976",
       "venue": "Springer Undergraduate Texts in Mathematics",
       "note": "Theorem 2.13 and surrounding: σ is multiplicative with σ(pᵃ) = (p^{a+1}−1)/(p−1)"
+    },
+    {
+      "authors": "McCarthy, Paul J.",
+      "title": "Introduction to Arithmetical Functions",
+      "year": "1986",
+      "venue": "Springer Universitext",
+      "note": "Monograph devoted to multiplicative arithmetical functions; develops σₖ, τ, and φ uniformly through their values on prime powers and the multiplicativity that this entry formalizes"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `shannon-source-coding-oq-01-oq-03` (binary rate-distortion R(D) = h(p) − h(D)).

**Structural gap:** `crossReferences` were bare id strings (`"shannon-source-coding-oq-01"`, `"shannon-entropy"`) carrying no relationship or description. Upgraded both to full objects and expanded 2→4 (all targets verified present):
- `shannon-source-coding-oq-01` — parent general rate-distortion theory
- `shannon-entropy` — prerequisite binary entropy function
- `shannon-source-coding` — lossless limit (R(0) = h(p) is the D→0 endpoint)
- `shannon-channel-coding` — information-theoretic dual (BSC capacity 1−h(D) companions this R(D))

No content removed. meta.json under the 60 KB cap; counts unchanged (6 theorems, 0 sorries).