### PR TITLE
research(erdos-1026-oq-05): Erdős–Szekeres product bound n≤LIS·LDS from Mirsky covering [UNVERIFIED-BUILD-ENV]

### DIFF
--- a/proofs/Proofs/Erdos1026OQ05ErdosSzekeres.lean
+++ b/proofs/Proofs/Erdos1026OQ05ErdosSzekeres.lean
@@ -1,0 +1,139 @@
+/-
+# erdos-1026-oq-05 (Erdős–Szekeres companion): the product bound `n ≤ LIS · LDS`
+
+`Erdos1026OQ05IncreasingIdentity.lean` proves the exact Mirsky/Dilworth min–max identity
+`minIncreasingParts seq = LDS seq` for a sequence of distinct reals, and constructs the explicit
+witnessing decomposition `mirskyIncreasingDecomposition` — a covering of all `n` indices by exactly
+`LDS seq` strictly-*increasing* parts.
+
+This file extracts the classical **Erdős–Szekeres product bound** as a structural consequence of
+that covering:
+
+    n ≤ LIS seq · LDS seq                              (`card_le_LIS_mul_LDS`)
+
+for a sequence of distinct reals. The derivation is the textbook counting argument, but phrased
+entirely in the gallery's own `LIS`/`LDS`/decomposition language:
+
+* **Cell-counting for increasing decompositions** (`incrDecomposition_numParts_lower_bound`): the
+  increasing analogue of the committed `monotonicDecomposition_numParts_lower_bound`. The parts'
+  index maps assemble into a surjection from the disjoint union of the parts onto `Fin n`, so
+  `n ≤ ∑ (part lengths)`; every part is strictly increasing, hence has length `≤ LIS seq`, and
+  summing this constant over the `numParts` parts gives `n ≤ numParts · LIS seq`.
+
+* **Product bound**: apply the cell count to `mirskyIncreasingDecomposition`, whose part count is
+  exactly `LDS seq`. This charges each of the `LDS seq` increasing parts its `LIS seq` budget:
+  `n ≤ LDS seq · LIS seq`.
+
+From the product bound the classical Erdős–Szekeres pigeonhole theorem follows by contradiction:
+
+    r · s < n  ⟹  r < LIS seq  ∨  s < LDS seq        (`erdos_szekeres`)
+
+and, specialising `r = s = k`, any sequence of more than `k²` distinct reals carries a strictly
+monotone subsequence of length `> k` (`exists_long_monotone`, `lt_max_LIS_LDS`).
+
+Mathlib has its own `Theorems100.erdos_szekeres`; the point here is a *self-contained* derivation
+from this entry's Mirsky covering identity, giving the product/pigeonhole form directly in the
+`LIS`/`LDS` vocabulary the rest of the OQ-05 development uses (distinctness is genuinely required:
+a constant sequence has `LIS = LDS = 1` yet arbitrary length).
+
+No axioms, no sorries.
+-/
+
+import Mathlib
+import Proofs.Erdos1026OQ05IncreasingIdentity
+
+open Finset
+
+namespace Erdos1026OQ05ErdosSzekeres
+
+open Erdos1026OQ05 Erdos1026OQ05IncreasingIdentity
+
+variable {n : ℕ}
+
+/-! ## Cell-counting for increasing decompositions -/
+
+/-- **Increasing cell count.** The increasing analogue of the committed
+`monotonicDecomposition_numParts_lower_bound`: every decomposition of a length-`n` sequence into
+strictly-increasing parts satisfies `n ≤ numParts · LIS seq`.
+
+Because each part is *increasing* (not merely monotone) it can only be as long as `LIS seq`, so this
+charges each part the sharper `LIS` budget rather than `max (LIS, LDS)`.
+
+Proof: the parts' index maps package into one map `g` out of the disjoint union
+`Σ i, Fin (length of part i)`; the covering condition says `g` is surjective, so
+`n = |Fin n| ≤ Σ i, (length of part i)`. Each length is `≤ LIS seq`, and summing the constant over
+the `numParts` parts gives the claim. -/
+theorem incrDecomposition_numParts_lower_bound
+    (seq : RealSeq n) (D : IncreasingDecomposition n seq) :
+    n ≤ D.numParts * LIS seq := by
+  classical
+  -- The parts' index maps, packaged as one map out of the disjoint union of the parts.
+  let g : (Σ i : Fin D.numParts, Fin (D.parts i).1) → Fin n :=
+    fun p => (D.parts p.1).2.indices p.2
+  -- Covering says this map is surjective.
+  have hsurj : Function.Surjective g := by
+    intro k
+    obtain ⟨i, m, hm, hk⟩ := D.covering k
+    exact ⟨⟨i, ⟨m, hm⟩⟩, hk⟩
+  -- Hence `n = |Fin n| ≤ |Σ i, Fin (part i length)| = Σ i, (part i length)`.
+  have hcard : Fintype.card (Fin n)
+      ≤ Fintype.card (Σ i : Fin D.numParts, Fin (D.parts i).1) :=
+    Fintype.card_le_of_surjective g hsurj
+  rw [Fintype.card_fin, Fintype.card_sigma] at hcard
+  simp only [Fintype.card_fin] at hcard
+  refine hcard.trans ?_
+  -- Each part is strictly increasing, so its length is at most `LIS seq`.
+  calc ∑ i, (D.parts i).1
+      ≤ ∑ _i : Fin D.numParts, LIS seq :=
+        Finset.sum_le_sum (fun i _ => len_le_LIS_of_increasing (D.increasing i))
+    _ = D.numParts * LIS seq := by
+        rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+
+/-! ## The Erdős–Szekeres product bound -/
+
+/-- **Erdős–Szekeres product bound.** For a sequence of distinct reals,
+`n ≤ LIS seq · LDS seq`.
+
+Proof: the Mirsky increasing decomposition covers all `n` indices with exactly `LDS seq`
+strictly-increasing parts, and `incrDecomposition_numParts_lower_bound` charges each part its `LIS`
+budget, giving `n ≤ LDS seq · LIS seq`. -/
+theorem card_le_LIS_mul_LDS (seq : RealSeq n) (hinj : Function.Injective seq) :
+    n ≤ LIS seq * LDS seq := by
+  -- `(mirskyIncreasingDecomposition seq hinj).numParts` is `LDS seq` definitionally.
+  have h : n ≤ LDS seq * LIS seq :=
+    incrDecomposition_numParts_lower_bound seq (mirskyIncreasingDecomposition seq hinj)
+  rwa [mul_comm] at h
+
+/-! ## The classical pigeonhole theorem and its monotone-run corollary -/
+
+/-- **Erdős–Szekeres theorem (product / pigeonhole form).** For a sequence of distinct reals, if
+`r · s < n` then either the longest strictly-increasing subsequence has length `> r`, or the longest
+strictly-decreasing subsequence has length `> s`.
+
+Contrapositive of the product bound: `LIS ≤ r` and `LDS ≤ s` would force
+`n ≤ LIS · LDS ≤ r · s < n`. -/
+theorem erdos_szekeres (seq : RealSeq n) (hinj : Function.Injective seq)
+    {r s : ℕ} (h : r * s < n) : r < LIS seq ∨ s < LDS seq := by
+  by_contra hcon
+  push_neg at hcon
+  obtain ⟨h1, h2⟩ := hcon
+  -- h1 : LIS seq ≤ r, h2 : LDS seq ≤ s
+  have hchain : n ≤ r * s :=
+    (card_le_LIS_mul_LDS seq hinj).trans (Nat.mul_le_mul h1 h2)
+  exact absurd hchain (not_le.mpr h)
+
+/-- Any sequence of more than `k²` distinct reals carries a strictly monotone subsequence of length
+`> k`: `k < LIS seq ∨ k < LDS seq`. The `r = s = k` specialisation of `erdos_szekeres`. -/
+theorem exists_long_monotone (seq : RealSeq n) (hinj : Function.Injective seq)
+    {k : ℕ} (h : k * k < n) : k < LIS seq ∨ k < LDS seq :=
+  erdos_szekeres seq hinj h
+
+/-- Packaged form: more than `k²` distinct reals force the *longest* monotone run (of either type) to
+exceed `k`, i.e. `k < max (LIS seq) (LDS seq)`. -/
+theorem lt_max_LIS_LDS (seq : RealSeq n) (hinj : Function.Injective seq)
+    {k : ℕ} (h : k * k < n) : k < max (LIS seq) (LDS seq) := by
+  rcases exists_long_monotone seq hinj h with h' | h'
+  · exact lt_of_lt_of_le h' (le_max_left _ _)
+  · exact lt_of_lt_of_le h' (le_max_right _ _)
+
+end Erdos1026OQ05ErdosSzekeres

--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -155,10 +155,17 @@
     "additionalFiles": [
       {
         "path": "Proofs/Erdos1026OQ05IncreasingIdentity.lean",
-        "lineCount": 331,
-        "theoremCount": 17,
-        "definitionCount": 8,
+        "lineCount": 487,
+        "theoremCount": 26,
+        "definitionCount": 15,
         "description": "Exact Mirsky/Dilworth min-max identity: minimum number of strictly-increasing parts covering the sequence equals LDS (distinct reals)."
+      },
+      {
+        "path": "Proofs/Erdos1026OQ05ErdosSzekeres.lean",
+        "lineCount": 139,
+        "theoremCount": 5,
+        "definitionCount": 0,
+        "description": "Erdős–Szekeres product bound n ≤ LIS·LDS derived from the Mirsky increasing-covering identity, plus the classical pigeonhole theorem (r·s<n ⟹ r<LIS ∨ s<LDS) and the >k² ⟹ monotone-run >k corollary."
       }
     ]
   },


### PR DESCRIPTION
## Summary

New self-contained companion **`Erdos1026OQ05ErdosSzekeres.lean`** (5 theorems, 0 defs, **0 axioms, 0 sorries**) deriving the classical **Erdős–Szekeres product bound** as a structural consequence of the entry's already-verified Mirsky increasing-covering identity (`minIncreasingParts = LDS`).

## Results

- **`incrDecomposition_numParts_lower_bound`** — `n ≤ numParts · LIS seq` for any strictly-increasing decomposition. The exact increasing analogue of the committed/verified `monotonicDecomposition_numParts_lower_bound`: identical surjection-from-disjoint-union cell count, but each *increasing* part is charged the sharper `LIS` budget instead of `max(LIS,LDS)`.
- **`card_le_LIS_mul_LDS`** — the product bound **`n ≤ LIS seq · LDS seq`** (distinct reals), obtained by applying the cell count to `mirskyIncreasingDecomposition`, which covers all `n` indices with exactly `LDS seq` increasing parts. Distinctness is essential (a constant sequence has `LIS = LDS = 1`).
- **`erdos_szekeres`** — the classical pigeonhole form: `r·s < n ⟹ r < LIS seq ∨ s < LDS seq` (contrapositive of the product bound).
- **`exists_long_monotone` / `lt_max_LIS_LDS`** — specialisation: any sequence of more than `k²` distinct reals carries a strictly monotone subsequence of length `> k`, i.e. `k < max(LIS, LDS)`.

This ties the gallery's covering-number theory to the extremal Erdős–Szekeres bound entirely in the entry's own `LIS`/`LDS`/decomposition vocabulary. (Mathlib has its own `Theorems100.erdos_szekeres`; the value here is the self-contained derivation *from the Mirsky covering identity* in the OQ-05 language.)

## meta.json

Registered the new companion and synced the stale `IncreasingIdentity` `additionalFiles` counts (`331/17/8 → 487/26/15`).

## ⚠️ Build status — UNVERIFIED (environmental)

The docker build could **not** be completed in the current fleet window. Across **16 attempts**, the dependency `Erdos1026OQ05IncreasingIdentity.lean` — which is **already VERIFIED on `origin/main`** — itself crashes at **olean-write with SIGBUS (exit 135/139)** after ~1–7s of *clean* elaboration, and the shared mathlib cache intermittently returns corrupted `.ir`/`.trace` headers ("unexpected end of input", "invalid header"). A diagnostic build of the verified dependency **alone** fails identically. My file never reaches elaboration.

This is memory contention / shared-cache corruption in the build fleet, **not** a defect in this code. The proofs mirror the already-verified monotone lower-bound lemma line-for-line.

**Deployer:** please re-run `./proofs/scripts/docker-build.sh Proofs.Erdos1026OQ05ErdosSzekeres` in a calmer window to confirm green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)