### PR TITLE
Enrich n-fold i.i.d. entropy H(p^⊗n)=n·H(p): full section coverage

### DIFF
--- a/src/data/proofs/shannon-source-coding-wip-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-wip-01-oq-01/meta.json
@@ -67,6 +67,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "summary": "The docstring frames the result as iterating the parent's pairwise additivity H(pX ⊗ pY) = H(pX) + H(pY) to the n-fold i.i.d. product p^⊗n(x) = ∏ᵢ p(xᵢ), giving H(p^⊗n) = n·H(p) — the source-coding statement that a block of n i.i.d. symbols carries n·H(p) bits (backbone of the AEP and the rate H in Shannon's source coding theorem). Explains the induction along the tuple recursion Fin.consEquiv, the companion normalisation ∑ₓ ∏ᵢ p(xᵢ) = (∑ₐ p a)^n, lists the three results (entropy_prod, sum_prodDist, entropy_pow), imports Mathlib, enters namespace ShannonSourceCodingWIP01OQ01, opens Real/Finset, and declares variables {α} [Fintype α].",
+      "startLine": 1,
+      "endLine": 46,
+      "mathContext": "$H(p^{\\otimes n}) = n \\cdot H(p)$ for $\\sum_a p(a) = 1$; iterated from pairwise $H(p_X \\otimes p_Y) = H(p_X) + H(p_Y)$ along $\\mathrm{Fin.consEquiv}$."
+    },
+    {
       "id": "entropy-and-additivity",
       "title": "Entropy in negMulLog form and pairwise additivity",
       "startLine": 47,


### PR DESCRIPTION
Enrichment pass for `shannon-source-coding-wip-01-oq-01`.

Strong entry (3 mainTheorems, 4 references, object crossReferences, 4 keyInsights, complete conclusion). One structural gap: `sections` started at line 47, leaving the substantial module docstring (1–46) — which frames the iteration of pairwise additivity to the n-fold product and the Fin.consEquiv induction — uncovered.

- **New `header` section** (lines 1–46) with summary and mathContext, so `sections` now span the full 124-line file (last section already ends at 124).

meta.json stays well under the 60 KB cap. JSON validated; check-meta-size passes.