### PR TITLE
research(erdos-1-oq-02-incomplete-01): strengthen f_two_max to carry hasDistinctSubsetSums witness [elab-clean; build blocked by fleet SIGBUS]

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -514,9 +514,22 @@ theorem f_one : ∃ (A : Finset ℕ), A.card = 1 ∧ hasDistinctSubsetSums A ∧
   rcases hS with rfl | rfl <;> rcases hT with rfl | rfl <;> simp_all
 
 /-- f(2) = 2: The set {1,2} has 4 distinct subset sums (0,1,2,3).
-    The subsets are ∅ (sum 0), {1} (sum 1), {2} (sum 2), {1,2} (sum 3). -/
-theorem f_two_max : ∃ (A : Finset ℕ), A.card = 2 ∧ A.sup id = 2 := by
-  exact ⟨{1, 2}, by simp, by simp⟩
+    The subsets are ∅ (sum 0), {1} (sum 1), {2} (sum 2), {1,2} (sum 3), so it
+    has distinct subset sums with maximum element 2.
+
+    Strengthened to carry the `hasDistinctSubsetSums` witness (matching `f_one`):
+    the previous statement only asserted `card = 2 ∧ sup = 2`, weaker than the
+    `f(2) = 2` extremal claim in the docstring and the OEIS A005318 framing.  The
+    `hasDistinctSubsetSums {1,2}` obligation is discharged by enumerating the four
+    subsets of `{1,2}` (`fin_cases` over the powerset) and deciding each of the
+    16 subset-pair sum comparisons. -/
+theorem f_two_max :
+    ∃ (A : Finset ℕ), A.card = 2 ∧ hasDistinctSubsetSums A ∧ A.sup id = 2 := by
+  refine ⟨{1, 2}, by decide, ?_, by decide⟩
+  intro S T hS hT heq
+  have hS' : S ∈ ({1, 2} : Finset ℕ).powerset := Finset.mem_powerset.mpr hS
+  have hT' : T ∈ ({1, 2} : Finset ℕ).powerset := Finset.mem_powerset.mpr hT
+  fin_cases hS' <;> fin_cases hT' <;> revert heq <;> decide
 
 /-! ## Conclusion
 

--- a/src/data/proofs/erdos-1-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1-oq-02/annotations.json
@@ -176,7 +176,7 @@
     },
     "type": "concept",
     "title": "Small Cases: f(1)=1, f(2)=2 (Concrete Verification)",
-    "content": "`f_one` proves $f(1) = 1$: the set $\\{1\\}$ has $2^1 = 2$ distinct subset sums ($0$ and $1$) with $\\max = 1$. `f_two_max` proves $f(2) = 2$: $\\{1, 2\\}$ has $\\max = 2$. These are the smallest cases of OEIS A005318 (the known values of $f(n)$: 1, 2, 3, 5, 11, 22, 44, 88, ...). For `f_one`, the proof manually checks the DSS condition using `Finset.subset_singleton_iff`. For `f_two_max`, the proof is trivial via `simp`.",
+    "content": "`f_one` proves $f(1) = 1$: the set $\\{1\\}$ has $2^1 = 2$ distinct subset sums ($0$ and $1$) with $\\max = 1$. `f_two_max` proves $f(2) = 2$: $\\{1, 2\\}$ has all $4$ subset sums distinct ($0,1,2,3$) with $\\max = 2$. These are the smallest cases of OEIS A005318 (the known values of $f(n)$: 1, 2, 3, 5, 11, 22, 44, 88, ...). For `f_one`, the proof manually checks the DSS condition using `Finset.subset_singleton_iff`. For `f_two_max`, the `hasDistinctSubsetSums` witness is discharged by `fin_cases` over the four subsets of $\\{1,2\\}$ followed by `decide`.",
     "mathContext": "The known optimal sets for small $n$ are: $f(1)$: $\\{1\\}$; $f(2)$: $\\{1, 2\\}$; $f(3)$: $\\{2, 3, 7\\}$; $f(4)$: $\\{3, 5, 6, 7\\}$; $f(5)$: $\\{6, 9, 11, 12, 13\\}$. The DFX lower bound $\\sqrt{2/\\pi} \\cdot 2^n/\\sqrt{n}$ gives for $n=1$: $\\approx 0.798$, so $f(1) \\geq 1$ \u2713; for $n=2$: $\\approx 1.13$, so $f(2) \\geq 2$ \u2713. The bound is tight up to the constant $\\sqrt{2/\\pi}$ vs the true constant $c \\approx \\sqrt{2/\\pi}$ for the Conway\u2013Guy sequence.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 546,
+    "lineCount": 559,
     "assumptions": "0 axioms. The former anticoncentration_bound axiom (2^n ≤ 3√Q + 2 for distinct-subset-sums sets) is now PROVED in-file (theorem anticoncentration_bound) by an elementary, probability-free discharge: the second-moment identity over the powerset, a parity-aware central-interval count, and a discrete Chebyshev tail. dfx_lower_bound and pow2_dss proved; sum_sq_cauchy_schwarz proved. Fully machine-checked, 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -118,7 +118,7 @@
       "startLine": 161,
       "endLine": 194,
       "summary": "Concrete verification: f_one (DSS set with 1 element, max = 1), f_two_max (DSS set with 2 elements, max = 2). Also improvement_factor (n < n² for n ≥ 2) as a technical lemma.",
-      "mathContext": "`f_one`: $\\{1\\}$ has all $2^1 = 2$ subset sums distinct ($0$ and $1$); $\\max = 1$. `f_two_max`: $\\{1,2\\}$ has $\\max = 2$ (can be verified by `simp`). `improvement_factor`: $n < n^2$ for $n \\geq 2$ (in $\\mathbb{N}$, proved by `omega`) — the algebraic core of the asymptotic comparison DFX $\\sim 2^n/\\sqrt{n}$ vs counting $\\sim 2^n/n$."
+      "mathContext": "`f_one`: $\\{1\\}$ has all $2^1 = 2$ subset sums distinct ($0$ and $1$); $\\max = 1$. `f_two_max`: $\\{1,2\\}$ has all $2^2 = 4$ subset sums distinct with $\\max = 2$ (the `hasDistinctSubsetSums` witness discharged by `fin_cases` over the four subsets + `decide`). `improvement_factor`: $n < n^2$ for $n \\geq 2$ (in $\\mathbb{N}$, proved by `omega`) — the algebraic core of the asymptotic comparison DFX $\\sim 2^n/\\sqrt{n}$ vs counting $\\sim 2^n/n$."
     }
   ],
   "conclusion": {
@@ -211,7 +211,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 546,
+    "lineCount": 559,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

The registered `erdos-1-oq-02` entry (Dubroff–Fox–Xu subset-sum lower bound) is already **verified** on `main` (0 sorry, 0 axiom) — the candidate note "has 2 sorry statements that need to be filled in" is stale (they were discharged earlier). This PR fixes a genuine, previously-unnoticed **correctness gap** in a small-case theorem.

## The gap

`f_two_max` claimed (in its docstring and via the OEIS A005318 `f(2)=2` framing) that `{1,2}` is the extremal *distinct-subset-sums* set of size 2, but the **theorem statement only asserted `card = 2 ∧ sup = 2`** — omitting the `hasDistinctSubsetSums` witness that the sibling `f_one` includes. So the stated theorem was strictly weaker than advertised.

## Fix

```lean
theorem f_two_max :
    ∃ (A : Finset ℕ), A.card = 2 ∧ hasDistinctSubsetSums A ∧ A.sup id = 2
```
Witness `{1,2}` (subset sums `0,1,2,3` all distinct). The `hasDistinctSubsetSums {1,2}` obligation is discharged by `fin_cases` over the four subsets of `{1,2}` (via powerset membership) followed by `decide` on the 16 subset-pair sum comparisons. No code depends on the old weaker signature (checked: only descriptive JSON referenced it, updated here).

## ⚠️ Verification status — please read

The file **elaborates cleanly** (kernel-checked, **0 type errors**) on every one of ~10 build attempts this session, but the `.olean` write **consistently aborts with SIGBUS (exit 135)** under sustained concurrent fleet memory pressure. That pressure also corrupted the shared Mathlib cache mid-session (`invalid header` on unrelated `.olean`/`.ir` files), which I repaired once via `docker-build.sh --repair-cache`. A cached **exit-0** build was **unobtainable** in this window.

Because the proof is a `decide` over concrete finite data and elaborates green (the kernel runs `decide` during elaboration, so a proof error would surface as an elaboration error, not a post-elaboration SIGBUS), confidence in correctness is high. **Please re-run** `./proofs/scripts/docker-build.sh Proofs.Erdos1OQ02` in a quieter window to confirm exit 0 before/at merge. Not labeled `[VERIFIED]` precisely because I could not obtain the green build myself.

## Gallery

- `meta.json` `lineCount` synced 546→559 (both blocks); `mathContext` updated to reflect the DSS witness and `fin_cases`+`decide` method.
- `annotations.json` `f_two_max` description corrected (was "trivial via `simp`", now the DSS-witness discharge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)