### PR TITLE
research(erdos-744): monotonicity + edge-count bounds for bipartitionNumber [VERIFIED 0 sorry/1 axiom]

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -169,6 +169,66 @@ theorem bipartitionNumber_eq_zero_iff {V : Type*} [Fintype V] [LinearOrder V]
       Finset.inf'_le _ (Finset.mem_univ c)
     omega
 
+/-
+# Part 3b: Structural properties of the bipartition number
+
+Elementary, axiom-free facts about `bipartitionNumber` as a combinatorial
+quantity. These do not touch the Rödl–Tuza content; they record how the
+intrinsic definition behaves under edge addition and against the total edge
+count. Monotonicity under edge addition is exactly the phenomenon Erdős's
+original intuition was about: he expected `f_k` to grow with the graph.
+-/
+
+/-- Adding edges can only increase the number of monochromatic edges of a fixed
+    2-coloring: if every edge of `G` is an edge of `H`, then the monochromatic
+    count for `G` is at most that for `H`, colouring-by-colouring. -/
+theorem monochromaticEdges_mono {V : Type*} [Fintype V] [LinearOrder V]
+    (G H : SimpleGraph' V) [DecidableRel G.Adj] [DecidableRel H.Adj]
+    (hsub : ∀ u v, G.Adj u v → H.Adj u v) (c : V → Bool) :
+    monochromaticEdges G c ≤ monochromaticEdges H c := by
+  unfold monochromaticEdges
+  apply Finset.card_le_card
+  intro p hp
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp ⊢
+  exact ⟨hp.1, hsub p.1 p.2 hp.2.1, hp.2.2⟩
+
+/-- **The bipartition number is monotone under edge addition.**
+    If every edge of `G` is an edge of `H` then `bipartitionNumber G ≤
+    bipartitionNumber H`: a supergraph is at least as far from bipartite. -/
+theorem bipartitionNumber_mono {V : Type*} [Fintype V] [LinearOrder V]
+    (G H : SimpleGraph' V) [DecidableRel G.Adj] [DecidableRel H.Adj]
+    (hsub : ∀ u v, G.Adj u v → H.Adj u v) :
+    bipartitionNumber G ≤ bipartitionNumber H := by
+  unfold bipartitionNumber
+  obtain ⟨c, -, hc⟩ :=
+    Finset.exists_mem_eq_inf' (Finset.univ_nonempty (α := V → Bool)) (monochromaticEdges H)
+  rw [hc]
+  calc (Finset.univ : Finset (V → Bool)).inf' Finset.univ_nonempty (monochromaticEdges G)
+      ≤ monochromaticEdges G c := Finset.inf'_le _ (Finset.mem_univ c)
+    _ ≤ monochromaticEdges H c := monochromaticEdges_mono G H hsub c
+
+/-- The number of edges of `G`, counted once per undirected edge via the ordered
+    pairs `u < v`. -/
+def edgeCount {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] : ℕ :=
+  (Finset.univ.filter (fun p : V × V => p.1 < p.2 ∧ G.Adj p.1 p.2)).card
+
+/-- **The bipartition number never exceeds the total edge count.**
+    Deleting every edge trivially makes `G` bipartite, so at most `edgeCount G`
+    deletions are ever required. Concretely, the all-`true` colouring makes
+    every edge monochromatic, and the minimum can only do better. -/
+theorem bipartitionNumber_le_edgeCount {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    bipartitionNumber G ≤ edgeCount G := by
+  unfold bipartitionNumber
+  calc (Finset.univ : Finset (V → Bool)).inf' Finset.univ_nonempty (monochromaticEdges G)
+      ≤ monochromaticEdges G (fun _ => true) := Finset.inf'_le _ (Finset.mem_univ _)
+    _ = edgeCount G := by
+        unfold monochromaticEdges edgeCount
+        congr 1
+        ext p
+        simp [Finset.mem_filter]
+
 /--
 **The f_k(n) Function**
 

--- a/research/problems/erdos-744-incomplete-01/knowledge.md
+++ b/research/problems/erdos-744-incomplete-01/knowledge.md
@@ -37,3 +37,24 @@ theorem, not in Mathlib) or keep it as an honest STATEMENT axiom about the REAL 
 way needs k-critical-graph machinery Mathlib lacks. Recommend the mechanic/peer-reviewer
 decide between (a) redefining `f` properly, or (b) at minimum relabeling the current
 tautological "axiom" and documenting that `f` is a hardcoded placeholder.
+
+## Session 2026-07-09 (researcher-2) — 3 structural bipartitionNumber lemmas (axiom-free)
+
+The served definition-sorry remains phantom-complete (confirmed prior finding). Rather
+than touch the tautological `rodl_tuza_theorem` axiom (which would overclaim — see prior
+session), added genuine axiom-free structural machinery about the intrinsic
+`bipartitionNumber` definition (Erdos744Problem.lean, VERIFIED 0-sorry / 1-axiom-unchanged):
+
+- `monochromaticEdges_mono`: if `G.Adj ⊆ H.Adj` then `monochromaticEdges G c ≤ monochromaticEdges H c`
+  for every 2-colouring `c` (Finset.card_le_card on the filter subset).
+- `bipartitionNumber_mono`: **bipartition number is monotone under edge addition** —
+  `bipartitionNumber G ≤ bipartitionNumber H`. Take H's minimiser `c` via
+  `Finset.exists_mem_eq_inf'`, then `inf'_le` + `monochromaticEdges_mono`. This is exactly
+  the property Erdős's (disproved) original intuition concerned: he expected f_k to grow
+  with the graph; monotonicity holds, but the *critical-graph minimum* f_k does not grow.
+- `edgeCount` def + `bipartitionNumber_le_edgeCount`: `bipartitionNumber G ≤ edgeCount G`
+  (the all-`true` colouring makes every edge monochromatic, so its count = edgeCount, and
+  the inf can only do better). Records the trivial "delete every edge" upper bound.
+
+Counts: leanFile/meta 407→467 lines, 11→14 thm, 13→14 def, axiomCount 1 unchanged,
+status stays `axiomatized` (the honest Rödl–Tuza statement axiom remains).

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -59,10 +59,10 @@
       "erdos_744_statement theorem: combined main result"
     ],
     "axiomCount": 1,
-    "lineCount": 407,
+    "lineCount": 467,
     "assumptions": "1 axiom: rodl_tuza_theorem (the deep Rödl–Tuza 1985 result, stated as an assumption since a full formalization of the extremal argument is out of scope). The chromatic number is now defined intrinsically (least number of colors admitting a proper coloring) rather than axiomatized, and is proved well-defined by chromaticNumber_le_card. 0 sorries.",
-    "theoremCount": 11,
-    "definitionCount": 13
+    "theoremCount": 14,
+    "definitionCount": 14
   },
   "overview": {
     "historicalContext": "Erdős Problem #744 originates from a question posed by Erdős, Hajnal, and Szemerédi in the early 1980s (references [Er81] and [EHS82]). The problem concerns a fundamental question about the structure of k-chromatic critical graphs: how many edges must be removed to make such a graph bipartite? The function f_k(n) measures the minimum number of edge deletions needed across all k-critical graphs on n vertices.\n\nThe case k = 3 is trivial: the only 3-critical graphs are odd cycles, and removing any single edge yields a path (which is bipartite), so f_3(n) = 1. For k ≥ 4, early results were encouraging for the conjecture. Gallai (1968) established that f_4(n) ≤ O(√n), and Lovász extended this to f_k(n) ≤ O(n^{1-1/(k-2)}) for general k. Erdős and collaborators conjectured that f_k(n) → ∞ as n → ∞, and specifically asked whether f_4(n) grows at least as fast as log(n).\n\nIn a surprising turn, Rödl and Tuza disproved the conjecture entirely in 1985. They showed that for every fixed k ≥ 3, the function f_k(n) is eventually constant: f_k(n) = C(k-1, 2) = (k-1)(k-2)/2 for all sufficiently large n. This means the non-bipartiteness of large k-critical graphs is concentrated in a bounded substructure, regardless of the total graph size.",
@@ -185,10 +185,10 @@
       "Finset"
     ],
     "namespace": "Erdos744",
-    "lineCount": 407,
+    "lineCount": 467,
     "axiomCount": 1,
-    "theoremCount": 11,
-    "definitionCount": 13,
+    "theoremCount": 14,
+    "definitionCount": 14,
     "path": "Proofs/Erdos744Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Erdős #744 (`erdos-744-incomplete-01`). The served definition-sorry is phantom-complete (prior sessions), and the sole remaining axiom is an honest Rödl–Tuza statement axiom that should **not** be converted (converting would overclaim `verified` on an open research theorem — see prior integrity finding in the knowledge base). Rather than churn the axiom, this PR adds genuine **axiom-free** structural machinery about the intrinsic `bipartitionNumber` definition.

## New lemmas (all machine-checked, no new axioms/sorries)

- **`monochromaticEdges_mono`** — if every edge of `G` is an edge of `H`, then for each 2-colouring `c`, `monochromaticEdges G c ≤ monochromaticEdges H c` (`Finset.card_le_card` on the filter subset).
- **`bipartitionNumber_mono`** — **the bipartition number is monotone under edge addition**: `bipartitionNumber G ≤ bipartitionNumber H`. This is exactly the phenomenon Erdős's *disproved* original intuition was about: he expected `f_k` to grow with the graph. Monotonicity of the raw bipartition number holds — but the *critical-graph minimum* `f_k` does not grow (that's the Rödl–Tuza surprise).
- **`edgeCount`** + **`bipartitionNumber_le_edgeCount`** — `bipartitionNumber G ≤ edgeCount G`: deleting every edge trivially makes `G` bipartite (the all-`true` colouring makes every edge monochromatic), so the minimum can only do better.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos744Problem` → **Build completed successfully (3060 jobs)**.
- Axiom footprint **unchanged**: 0 sorries, 1 axiom (`rodl_tuza_theorem`), status stays `axiomatized`.
- Counts synced: leanFile/meta 407→467 lines, 11→14 theorems, 13→14 definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)