### PR TITLE
Enrich ∑ k·rᵏ closed form: full section coverage + generatingfunctionology ref

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01/meta.json
@@ -77,7 +77,7 @@
       "id": "by-parts",
       "title": "Re-derivation via Abel Summation by Parts",
       "startLine": 67,
-      "endLine": 81,
+      "endLine": 83,
       "summary": "sum_range_mul_geom_eq_byParts: the same sum equals (n−1)·Gₙ − ∑_{i<n−1} G_{i+1} with Gₘ = ∑_{j<m} rʲ, directly from Finset.sum_range_by_parts.",
       "mathContext": "The weight f k = k has constant forward differences f(k+1)−f k = 1, so smul_eq_mul + push_cast + ring reduce the Abel transform to a sum of geometric partial sums."
     }
@@ -116,6 +116,15 @@
       "year": "1997",
       "venue": "3rd ed., Addison-Wesley",
       "note": "Summation by parts and closed forms for weighted geometric sums via the finite-calculus operators."
+    },
+    {
+      "authors": [
+        "Wilf, H.S."
+      ],
+      "title": "generatingfunctionology",
+      "year": "2006",
+      "venue": "3rd ed., A K Peters",
+      "note": "The generating-function view of ∑ k·rᵏ as r·d/dr of the geometric series ∑ rᵏ = 1/(1−r), the calculus heuristic whose exact finite-field skeleton this entry proves."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01` (finite arithmetico-geometric sum).

Already a strong, well-curated entry (2 mainTheorems, object crossReferences, 4 keyInsights, complete conclusion). Two small targeted improvements:

- **Section coverage**: the by-parts section ended at line 81, leaving the closing `end` (82–83) uncovered; extended to 83 so sections span the full file.
- **New reference**: Wilf, *generatingfunctionology* — the generating-function derivation ∑ k·rᵏ = r·d/dr(1/(1−r)) that the entry's keyInsight and implications already invoke, previously uncited.

meta.json stays well under the 60 KB cap; references 2 → 3 (≤ 25). JSON validated; check-meta-size passes.