### PR TITLE
Enrich Prime Powers Are Deficient: add mainTheorems array

### DIFF
--- a/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
@@ -120,6 +120,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module header, imports, and Part I setup",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring positioning the file as Erdős (1947), the first application of the probabilistic method to Ramsey theory, and stating the counting form of the main criterion 2·C(n,k) < 2^C(k,2) ⇒ R(k,k) > n. Notes that the argument lives entirely in a finite counting space — no measure theory — so it is fully machine-checked, and that it de-axiomatizes `erdos_probabilistic_lower_bound` (previously an `axiom` in Proofs/RamseyR4kExtensions.lean). `import Mathlib`, `namespace ErdosRamsey`, `open Finset`, and the Part I header framing colourings as functions `c : E → Bool` over an abstract finite edge type E."
+    },
+    {
       "id": "counting-core",
       "title": "The abstract first-moment counting lemma",
       "startLine": 42,
@@ -137,7 +144,7 @@
       "id": "diagonal-bound",
       "title": "The classical R(k,k) > 2^(k/2) bound",
       "startLine": 244,
-      "endLine": 326,
+      "endLine": 329,
       "summary": "erdos_diagonal_numeric is the elementary ℕ estimate that n ≤ 2^⌊k/2⌋ implies 2·C(n,k) < 2^C(k,2) for k ≥ 3. erdos_probabilistic_lower_bound assembles the headline result, exactly matching the statement axiomatized in the parent RamseyR4kExtensions file, now with 0 axioms."
     }
   ],

--- a/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
@@ -3,6 +3,56 @@
   "title": "Lovász Local Lemma for Ramsey: the monochromatic-clique bad-event probability",
   "slug": "ramsey-r4k-extensions-oq-03-oq-01",
   "description": "A fully machine-checked, axiom-free formalization of the second combinatorial input to the symmetric Lovász Local Lemma (LLL) feasibility test for Spencer's improved diagonal Ramsey lower bound. The symmetric LLL condition is e·p·(d+1) ≤ 1, where d is the dependency degree (the sibling entry ramsey-r4k-extensions-oq-03, Key Lemma 3) and p is the probability that a fixed k-clique is monochromatic under a uniformly random 2-colouring of the edges of Kₙ. This entry supplies p — Key Lemma 2 — again with no probability theory: a k-clique has exactly C(k,2) edges, so there are 2^C(k,2) equally likely colourings, of which exactly two (all-red and all-blue) are monochromatic. Hence p = 2/2^C(k,2) = 2^(1−C(k,2)). The combinatorial heart is a clean finite fact — among all Bool-colourings of a nonempty finite type, exactly two are constant — proved by exhibiting the constant colourings as the injective image of Bool. The result clique_monochromatic_probability computes p exactly as a real number. Proved with 0 axioms, 0 sorries, no native_decide.",
+  "mainTheorems": [
+    {
+      "name": "card_constant_colorings",
+      "type": "key",
+      "description": "**Abstract counting core.** Among all Bool-colourings of a nonempty finite type α, exactly two are constant. The predicate `∀ x y, c x = c y` is shown to cut out the image of `Bool` under the injection `b ↦ (fun _ => b)` (injective because α is nonempty), so the count is `Fintype.card Bool = 2`. This type-agnostic lemma is the combinatorial heart from which every clique-level count is instantiated.",
+      "leanType": "(α : Type*) [Fintype α] [DecidableEq α] [Nonempty α] : ((univ : Finset (α → Bool)).filter (fun c => ∀ x y, c x = c y)).card = 2",
+      "startLine": 53,
+      "endLine": 72
+    },
+    {
+      "name": "cliqueEdges_card",
+      "type": "supporting",
+      "description": "**Edge count of a k-clique.** The edge set `cliqueEdges S = S.powersetCard 2` (the 2-element subsets of S) has exactly C(k,2) elements when |S| = k, by `Finset.card_powersetCard`.",
+      "leanType": "(k : ℕ) (S : Finset V) (hS : S.card = k) : (cliqueEdges S).card = k.choose 2",
+      "startLine": 83,
+      "endLine": 85
+    },
+    {
+      "name": "card_edgeColorings",
+      "type": "supporting",
+      "description": "**Total colourings.** The number of 2-colourings of a k-clique's edges is 2^C(k,2) — two independent colour choices on each of the C(k,2) edges — via `Fintype.card_fun`, `Fintype.card_bool`, and `Fintype.card_coe`.",
+      "leanType": "(k : ℕ) (S : Finset V) (hS : S.card = k) : Fintype.card (EdgeColoring S) = 2 ^ k.choose 2",
+      "startLine": 94,
+      "endLine": 97
+    },
+    {
+      "name": "card_monochromatic_edgeColorings",
+      "type": "key",
+      "description": "**Monochromatic-colouring count (Key Lemma 2, numerator).** Exactly two of the 2^C(k,2) edge-colourings of a k-clique are monochromatic (all-red, all-blue). Requires k ≥ 2 so the clique has an edge (making the edge type nonempty); then the result is a direct instantiation of `card_constant_colorings` on the edge subtype.",
+      "leanType": "(k : ℕ) (hk : 2 ≤ k) (S : Finset V) (hS : S.card = k) : ((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card = 2",
+      "startLine": 104,
+      "endLine": 111
+    },
+    {
+      "name": "clique_monochromatic_probability",
+      "type": "core",
+      "description": "**Bad-event probability p (headline).** The probability that a fixed k-clique is monochromatic under the uniform random 2-colouring equals 2^(1−C(k,2)), computed as the exact real ratio #monochromatic/#total = 2/2^C(k,2). `zpow_sub₀` converts the ratio to the closed form. This is the value of p fed into the symmetric LLL condition e·p·(d+1) ≤ 1, completing (with Key Lemma 3's dependency bound) the feasibility input for Spencer's improved Ramsey lower bound.",
+      "leanType": "(k : ℕ) (hk : 2 ≤ k) (S : Finset V) (hS : S.card = k) : (((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card : ℝ) / (Fintype.card (EdgeColoring S) : ℝ) = (2 : ℝ) ^ (1 - (k.choose 2 : ℤ))",
+      "startLine": 122,
+      "endLine": 129
+    },
+    {
+      "name": "triangle_monochromatic_count",
+      "type": "supporting",
+      "description": "**Sanity check (k = 3).** A triangle has C(3,2) = 3 edges, hence 2^3 = 8 colourings, of which exactly 2 are monochromatic — the classical per-triangle probability 2/8 = 1/4 = 2^(1−3). Grounds the general formula against the familiar triangle case.",
+      "leanType": "(S : Finset V) (hS : S.card = 3) : ((univ : Finset (EdgeColoring S)).filter (fun c => ∀ x y, c x = c y)).card = 2 ∧ Fintype.card (EdgeColoring S) = 8",
+      "startLine": 134,
+      "endLine": 138
+    }
+  ],
   "meta": {
     "author": "Lean Genius Researcher",
     "status": "verified",
@@ -86,6 +136,13 @@
     ]
   },
   "sections": [
+    {
+      "id": "preamble",
+      "title": "Module header, imports, and namespace setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the file as Key Lemma 2 of Spencer's LLL-improved diagonal Ramsey lower bound: the symmetric LLL feasibility test e·p·(d+1) ≤ 1, where the sibling file RamseyR4kExtensionsOQ03.lean supplies the dependency degree d and this file supplies the bad-event probability p = 2^(1−C(k,2)) purely by counting colourings. Cites Erdős–Lovász (1975), Spencer (1975), and Alon–Spencer. `import Mathlib`, `set_option linter.unusedSectionVars false`, `namespace RamseyLLL`, `open Finset`, and the header of the abstract counting core section."
+    },
     {
       "id": "counting-core",
       "title": "The abstract counting core: exactly two constant colourings",

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -3,6 +3,40 @@
   "title": "Roth/Szemerédi OQ-03-OQ-01-OQ-01-OQ-01-OQ-01: Affine Covariance of the k-AP Counting Operator Λ_k",
   "slug": "roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01",
   "description": "Affine covariance of the k-AP counting operator Λ_k(f₀,…,f_{k-1}) = E_{x,d} ∏ᵢ fᵢ(x+i·d): for any unit a ∈ (ZMod N)ˣ and translate t, replacing every fᵢ by y↦fᵢ(a·y+t) leaves the count unchanged (kAPCount_affine). The affine map φ(y)=a·y+t carries the progression {x+i·d} to {φ(x)+i·(a·d)}, and (x,d)↦(a·x+t, a·d) is a bijection of (ZMod N)² precisely because a is invertible. This exhibits the one-dimensional affine group GA(1,ZMod N)=(ZMod N)ˣ⋉ZMod N acting on Λ_k. Two corollaries: kAPCount_dilate (the genuinely new multiplicative dilation invariance, t=0) and kAPCount_translate_of_affine (recovers the parent's translation invariance, a=1). Directly answers the parent's first open question. 0-axiom verified.",
+  "mainTheorems": [
+    {
+      "name": "kAPCount_affine",
+      "type": "core",
+      "description": "**Affine covariance (headline).** For any unit a ∈ (ZMod N)ˣ and translate t, replacing every fᵢ by y ↦ fᵢ(a·y + t) leaves the count fixed: Λ_k(f₀(a·+t),…) = Λ_k(f₀,…). Proved by two `Fintype.sum_equiv` reindexings — the outer base-point average by x ↦ a·x+t and the inner common-difference average by d ↦ a·d, each a bijection because a is a unit — after which the pointwise identity a·(x+i·d)+t = (a·x+t)+i·(a·d) closes by `nsmul_eq_mul` and `ring`.",
+      "leanType": "(k : ℕ) (f : Fin k → ZMod N → ℂ) (a : (ZMod N)ˣ) (t : ZMod N) : kAPCount k (fun i y => f i ((a : ZMod N) * y + t)) = kAPCount k f",
+      "startLine": 92,
+      "endLine": 105
+    },
+    {
+      "name": "kAPCount_dilate",
+      "type": "key",
+      "description": "**Dilation invariance (the new multiplicative symmetry).** The t = 0 case of affine covariance: for any unit a, Λ_k(f₀(a·),…) = Λ_k(f₀,…). Not implied by the parent's translation invariance nor by reflection — e.g. a = −1 is the point reflection through the origin that keeps the slot order, distinct from the order-reversing i ↦ k−1−i. Follows from `kAPCount_affine` by `simpa`.",
+      "leanType": "(k : ℕ) (f : Fin k → ZMod N → ℂ) (a : (ZMod N)ˣ) : kAPCount k (fun i y => f i ((a : ZMod N) * y)) = kAPCount k f",
+      "startLine": 119,
+      "endLine": 122
+    },
+    {
+      "name": "kAPCount_translate_of_affine",
+      "type": "supporting",
+      "description": "**Translation invariance recovered.** The a = 1 case of affine covariance, confirming that affine covariance subsumes the parent's `kAPCount_translate`: Λ_k(f₀(·+t),…) = Λ_k(f₀,…). Follows from `kAPCount_affine` by `simpa`.",
+      "leanType": "(k : ℕ) (f : Fin k → ZMod N → ℂ) (t : ZMod N) : kAPCount k (fun i y => f i (y + t)) = kAPCount k f",
+      "startLine": 126,
+      "endLine": 130
+    },
+    {
+      "name": "mulUnit_apply",
+      "type": "supporting",
+      "description": "**Dilation bijection (computation rule).** The permutation `mulUnit a` of ZMod N (multiplication by a unit a, with inverse multiplication by a⁻¹) evaluates as `mulUnit a x = a·x`. This `Equiv` is the multiplicative part of the affine reindexing (x,d) ↦ (a·x+t, a·d); the additive part reuses `Equiv.addRight`.",
+      "leanType": "(a : (ZMod N)ˣ) (x : ZMod N) : mulUnit a x = (a : ZMod N) * x",
+      "startLine": 76,
+      "endLine": 77
+    }
+  ],
   "meta": {
     "author": "Lean Genius Researcher",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gowers_norm",
@@ -76,6 +110,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module header, ancestor imports, and setup",
+      "summary": "Module docstring tracing the four-generation Roth/Szemerédi lineage (great-grandparent defines Λ_k and its degenerate identities, grandparent proves multilinearity, parent proves translation and reflection symmetries) and stating what this file adds: the full affine covariance of Λ_k, exhibiting the one-dimensional affine group GA(1, ZMod N) = (ZMod N)ˣ ⋉ ZMod N acting by symmetries, with dilation invariance as the genuinely new multiplicative piece. Cites Gowers (2001) and Tao (2012). `import Proofs.RothTheoremOQ03OQ01OQ01OQ01`, `open Finset BigOperators`, `namespace RothTheoremOQ03OQ01`, `variable {N : ℕ} [NeZero N]`.",
+      "startLine": 1,
+      "endLine": 63
+    },
+    {
       "id": "mul-unit",
       "title": "Multiplication by a Unit is a Bijection",
       "summary": "mulUnit a: multiplication by a unit a ∈ (ZMod N)ˣ is a permutation of ZMod N, with inverse multiplication by a⁻¹ — the dilation part of the affine reindexing.",
@@ -109,6 +150,22 @@
       "Conjugate symmetry Λ_k(conj f₀,…,conj f_{k-1}) = conj Λ_k(f₀,…,f_{k-1}) and its interaction with affine covariance"
     ]
   },
+  "references": [
+    {
+      "authors": "Gowers, W. T.",
+      "title": "A new proof of Szemerédi's theorem",
+      "year": "2001",
+      "venue": "Geometric and Functional Analysis 11(3), 465–588",
+      "note": "Introduces the Gowers uniformity norms and the density-increment machinery in which the affine symmetries of the k-AP counting operator Λ_k are used to normalize progression counts"
+    },
+    {
+      "authors": "Tao, Terence",
+      "title": "Higher Order Fourier Analysis",
+      "year": "2012",
+      "venue": "Graduate Studies in Mathematics 142, American Mathematical Society",
+      "note": "Systematic treatment of Gowers norms and the generalized von Neumann inequality; the invariance of Λ_k under the affine group of ZMod N formalized here is a standing assumption there"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Proofs.RothTheoremOQ03OQ01OQ01OQ01"

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
@@ -70,6 +70,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module header, parent import, and setup",
+      "summary": "Module docstring positioning the file within the Roth/Szemerédi Gowers-norm chain (parent Proofs/RothTheoremOQ03OQ01.lean defines Λ_k = kAPCount and the Gowers norm): the parent proves the constant/normalization/annihilation identities of Λ_k, and this file adds the key structural fact that Λ_k is multilinear — additive and homogeneous in each of its k slots — the property powering the generalized von Neumann inequality and density-increment arguments. Lists the four results (prod_update_factor, kAPCount_add_slot, kAPCount_smul_slot, gowersNorm_nonneg) and notes slots are addressed via Function.update. `import Proofs.RothTheoremOQ03OQ01`, `open Finset BigOperators`, `namespace RothTheoremOQ03OQ01`, `variable {N : ℕ} [NeZero N]`.",
+      "startLine": 1,
+      "endLine": 38
+    },
+    {
       "id": "engine",
       "title": "The Factorization Engine",
       "summary": "prod_update_factor: replacing slot j by v pulls v(x+j·d) out of the k-AP product, leaving the untouched factors over univ.erase j.",

--- a/src/data/proofs/shannon-entropy-oq-04/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-04/meta.json
@@ -3,6 +3,48 @@
   "title": "Shannon Entropy is a Concave Functional",
   "slug": "shannon-entropy-oq-04",
   "description": "The Shannon entropy H(p) = -∑ p(x) log p(x) is a concave function of the distribution p. Bridges the gallery's convention-based entropy to Mathlib's negMulLog and proves concavity on the non-negative orthant and on the probability simplex — the structural half of the maximum-entropy principle whose value half (H ≤ log n) lives in the parent.",
+  "mainTheorems": [
+    {
+      "name": "shannonEntropy_eq_sum_negMulLog",
+      "type": "key",
+      "description": "**Bridge lemma.** H(p) = ∑ₓ negMulLog(p x), identifying the file's convention-based summand (`if p x = 0 then 0 else p x·log(p x)`, negated) with Mathlib's Real.negMulLog(t) = −t·log t. The x=0 branch matches `negMulLog_zero`, the x≠0 branch matches the definition. This identification is what lets every convex-analysis lemma about negMulLog apply to entropy without special-casing the simplex boundary.",
+      "leanType": "{α : Type*} [Fintype α] [DecidableEq α] (p : α → ℝ) : shannonEntropy p = ∑ x : α, Real.negMulLog (p x)",
+      "startLine": 54,
+      "endLine": 62
+    },
+    {
+      "name": "concaveOn_finset_sum",
+      "type": "supporting",
+      "description": "**Finite sum of concave functions is concave.** A `Finset.induction` fold packaging Mathlib's `ConcaveOn.add` (which has no bundled Finset-sum form) into: if each g i is concave on a common convex set s, then p ↦ ∑_{i∈t} g i p is concave on s. The engine that turns entropy's coordinatewise concavity into concavity of the whole functional.",
+      "leanType": "{ι E : Type*} [AddCommGroup E] [Module ℝ E] {s : Set E} (hs : Convex ℝ s) (g : ι → E → ℝ) : ∀ t : Finset ι, (∀ i ∈ t, ConcaveOn ℝ s (g i)) → ConcaveOn ℝ s (fun x => ∑ i ∈ t, g i x)",
+      "startLine": 71,
+      "endLine": 85
+    },
+    {
+      "name": "convex_nonneg_orthant",
+      "type": "supporting",
+      "description": "**The non-negative orthant is convex.** {p | ∀ i, 0 ≤ p i} ⊆ (α → ℝ) is convex — the domain on which entropy's concavity is stated, since negMulLog is concave only on [0, ∞).",
+      "leanType": "{α : Type*} [Fintype α] : Convex ℝ {p : α → ℝ | ∀ i, 0 ≤ p i}",
+      "startLine": 92,
+      "endLine": 96
+    },
+    {
+      "name": "concaveOn_shannonEntropy",
+      "type": "core",
+      "description": "**Shannon entropy is concave (headline).** H is concave on the non-negative orthant. Proof: rewrite H as ∑ₓ negMulLog(p x); each coordinate map p ↦ negMulLog(p x) is Real.concaveOn_negMulLog precomposed with the linear projection `LinearMap.proj x` and restricted to the orthant (where every coordinate is ≥ 0), then `concaveOn_finset_sum` adds them.",
+      "leanType": "{α : Type*} [Fintype α] [DecidableEq α] : ConcaveOn ℝ {p : α → ℝ | ∀ i, 0 ≤ p i} shannonEntropy",
+      "startLine": 106,
+      "endLine": 125
+    },
+    {
+      "name": "concaveOn_shannonEntropy_stdSimplex",
+      "type": "core",
+      "description": "**Concavity on the probability simplex (textbook statement).** Restricts `concaveOn_shannonEntropy` to stdSimplex ℝ α = {p | (∀ i, 0 ≤ p i) ∧ ∑ i, p i = 1} via `ConcaveOn.subset` and `convex_stdSimplex`. This is the standard form used in coding, statistics, and thermodynamics.",
+      "leanType": "{α : Type*} [Fintype α] [DecidableEq α] : ConcaveOn ℝ (stdSimplex ℝ α) shannonEntropy",
+      "startLine": 130,
+      "endLine": 132
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Entropy_(information_theory)#Further_properties",
@@ -58,6 +100,13 @@
     ]
   },
   "sections": [
+    {
+      "id": "preamble",
+      "title": "Module header, imports, and namespace setup",
+      "summary": "Module docstring positioning the file as the structural half of the maximum-entropy open question: while the parent shannon-entropy proves the value bound H(p) ≤ log|α| with equality iff uniform, this child proves that the entropy functional H(p) = −∑ₓ p(x) log p(x) is concave — the reason the maximum sits at the barycentre of the simplex and the basis of every 'mixing increases entropy' argument. Outlines the clean route: bridge the ad-hoc 0 log 0 = 0 summand to Mathlib's Real.negMulLog and its Real.concaveOn_negMulLog, then sum. Lists the three headline results. `import Mathlib`, `namespace InformationTheory.EntropyConcavity`, `open Finset`.",
+      "startLine": 1,
+      "endLine": 40
+    },
     {
       "id": "definition-and-bridge",
       "title": "Definition and Bridge to negMulLog",

--- a/src/data/proofs/shannon-source-coding-oq-01-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-01-oq-03/meta.json
@@ -174,7 +174,25 @@
     }
   ],
   "crossReferences": [
-    "shannon-source-coding-oq-01",
-    "shannon-entropy"
+    {
+      "proofId": "shannon-source-coding-oq-01",
+      "relationship": "parent — general rate-distortion theory",
+      "description": "The parent Rate–Distortion Theory entry sets up the general operational R(D) as the minimum rate achieving expected distortion ≤ D. This entry instantiates it in the canonical binary case, giving the exact closed form R(D) = h(p) − h(D) for a Bernoulli(p) source under Hamming distortion, and verifies its structural properties (endpoints, nonnegativity, monotonicity, entropy bound)."
+    },
+    {
+      "proofId": "shannon-entropy",
+      "relationship": "prerequisite — binary entropy function",
+      "description": "The rate-distortion function is built entirely from the binary entropy h(p) = −p log p − (1−p) log(1−p), whose properties (concavity, maximum at 1/2, endpoint values h(0)=h(1)=0) supply the endpoint, monotonicity, and upper-bound facts proved here."
+    },
+    {
+      "proofId": "shannon-source-coding",
+      "relationship": "related — lossless limit",
+      "description": "The Shannon Source Coding Theorem gives the lossless compression limit H(p). Rate-distortion generalizes it to lossy compression: R(D) = h(p) − h(D) recovers the lossless rate R(0) = h(p) as the D → 0 endpoint, so the source coding theorem is the zero-distortion boundary of this curve."
+    },
+    {
+      "proofId": "shannon-channel-coding",
+      "relationship": "related — information-theoretic dual",
+      "description": "The Noisy Channel Coding Theorem characterizes the channel capacity C as a maximum of mutual information; rate-distortion is its source-side dual, characterizing R(D) as a minimum of mutual information. The binary symmetric channel capacity 1 − h(D) is the exact companion of the binary rate-distortion h(p) − h(D) formalized here."
+    }
   ]
 }

--- a/src/data/proofs/sum-of-divisors-oq-04-oq-01/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04-oq-01/meta.json
@@ -3,6 +3,64 @@
   "title": "Prime Powers Are Deficient: Almost-Perfect Powers of Two and the Sharp Abundancy Bound",
   "slug": "sum-of-divisors-oq-04-oq-01",
   "description": "Qualitative classification of every prime power, axiom-free and once-and-for-all in p and k: σ(pᵏ) < 2·pᵏ (every prime power is strictly deficient, hence never perfect or abundant); σ(2ᵏ)+1 = 2·2ᵏ (powers of two are almost perfect — deficient by exactly one, the minimal positive deficiency); ¬ Perfect(pᵏ); and the sharp abundancy bound σ(pᵏ)/pᵏ < p/(p−1) ≤ 2 over ℚ, with p/(p−1) the supremum of the abundancy index over the powers of a fixed prime. Builds on OQ-04's integer identity σ(pⁱ)·(p−1) = pⁱ⁺¹−1, scaling the deficiency gap by p−1 into the elementary nonnegativity pᵏ·(p−2)+1 ≥ 1. No native_decide.",
+  "mainTheorems": [
+    {
+      "name": "sigma_one_prime_pow_mul",
+      "type": "key",
+      "description": "**The defining integer identity (engine).** σ(pⁱ)·(p−1) = pⁱ⁺¹−1 over ℤ, restated locally from OQ-04 (`sigma_one_apply_prime_pow` + `geom_sum_mul`). Every classification below reduces to this one identity by multiplying the target gap by the positive factor p−1.",
+      "leanType": "{p : ℕ} (hp : p.Prime) (i : ℕ) : (sigma 1 (p ^ i) : ℤ) * ((p : ℤ) - 1) = (p : ℤ) ^ (i + 1) - 1",
+      "startLine": 39,
+      "endLine": 43
+    },
+    {
+      "name": "sigma_one_prime_pow_deficient",
+      "type": "core",
+      "description": "**Every prime power is deficient.** σ(pᵏ) < 2·pᵏ for every prime p and exponent k, so no prime power is perfect or abundant. The deficiency gap 2pᵏ − σ(pᵏ), scaled by the positive factor p−1, equals pᵏ·(p−2)+1 ≥ 1 > 0 — an elementary nonnegativity closed by `nlinarith`.",
+      "leanType": "{p : ℕ} (hp : p.Prime) (k : ℕ) : sigma 1 (p ^ k) < 2 * p ^ k",
+      "startLine": 47,
+      "endLine": 63
+    },
+    {
+      "name": "pow_two_almost_perfect",
+      "type": "core",
+      "description": "**Powers of two are almost perfect.** σ(2ᵏ) + 1 = 2·2ᵏ: the divisor sum falls exactly one short of 2·2ᵏ, the minimal possible positive deficiency, so 2ᵏ is the least-deficient prime power. Immediate from the engine identity at p = 2.",
+      "leanType": "(k : ℕ) : sigma 1 (2 ^ k) + 1 = 2 * 2 ^ k",
+      "startLine": 68,
+      "endLine": 74
+    },
+    {
+      "name": "prime_pow_not_perfect",
+      "type": "key",
+      "description": "**No prime power is perfect.** ¬ Nat.Perfect(pᵏ). Connects the deficiency bound to the base entry's perfection predicate: perfection requires σ(n) = 2n via `Nat.perfect_iff_sum_divisors_eq_two_mul`, which `sigma_one_prime_pow_deficient` rules out; `omega` closes the contradiction.",
+      "leanType": "{p : ℕ} (hp : p.Prime) (k : ℕ) : ¬ Nat.Perfect (p ^ k)",
+      "startLine": 79,
+      "endLine": 85
+    },
+    {
+      "name": "abundancy_prime_pow_lt",
+      "type": "core",
+      "description": "**Sharp abundancy bound.** Over ℚ, the abundancy index σ(pᵏ)/pᵏ < p/(p−1). As k → ∞ the index increases to this bound, so p/(p−1) is its supremum over the powers of a fixed prime p. Same engine identity read over ℚ via `div_lt_div_iff₀`.",
+      "leanType": "{p : ℕ} (hp : p.Prime) (k : ℕ) : (sigma 1 (p ^ k) : ℚ) / (p ^ k : ℚ) < (p : ℚ) / ((p : ℚ) - 1)",
+      "startLine": 90,
+      "endLine": 104
+    },
+    {
+      "name": "abundancy_prime_pow_lt_two",
+      "type": "supporting",
+      "description": "**Abundancy below 2 (deficiency over ℚ).** σ(pᵏ)/pᵏ < 2, since p ≥ 2 forces the supremum p/(p−1) ≤ 2. The rational restatement of `sigma_one_prime_pow_deficient`.",
+      "leanType": "{p : ℕ} (hp : p.Prime) (k : ℕ) : (sigma 1 (p ^ k) : ℚ) / (p ^ k : ℚ) < 2",
+      "startLine": 108,
+      "endLine": 115
+    },
+    {
+      "name": "sigma_zero_prime_pow",
+      "type": "supporting",
+      "description": "**Divisor count of a prime power.** τ(pᵏ) = σ₀(pᵏ) = k + 1, a bonus structural identity generalizing OQ-04's τ(p) = 2. Direct from `sigma_zero_apply_prime_pow`.",
+      "leanType": "{p : ℕ} (hp : p.Prime) (k : ℕ) : sigma 0 (p ^ k) = k + 1",
+      "startLine": 119,
+      "endLine": 121
+    }
+  ],
   "meta": {
     "author": "classical (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Almost_perfect_number",

--- a/src/data/proofs/sum-of-divisors-oq-04/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04/meta.json
@@ -169,6 +169,16 @@
       "targetId": "abundant-number-oq-03",
       "relationship": "related",
       "description": "The σ-form of perfection (σ(n) = 2n) sits beside the abundance condition (σ(n) > 2n) in the same divisor-sum classification of integers"
+    },
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "related — perfection criterion",
+      "description": "The Euclid–Euler theorem classifies the even perfect numbers as 2^(p−1)(2^p−1) with 2^p−1 a Mersenne prime. Its arithmetic engine is exactly `perfect_iff_sigma_one` proved here — perfection is the equation σ(n) = 2n — together with the closed prime-power form `sigma_one_prime_pow_mul` that evaluates σ on the 2^(p−1) factor. This entry supplies the σ-side identities the Euclid–Euler proof consumes."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related — sibling multiplicative function",
+      "description": "Euler's totient φ is the companion multiplicative arithmetic function to σ: both are read off Mathlib's prime-power API and both factor across coprime arguments via `IsMultiplicative.map_mul_of_coprime`. Where this entry gives σ(pⁱ)·(p−1) = p^{i+1}−1 and σ(pq) = (p+1)(q+1), the totient satisfies the parallel φ(pⁱ) = pⁱ−p^{i−1} and φ(pq) = (p−1)(q−1)."
     }
   ],
   "conclusion": {
@@ -209,6 +219,13 @@
       "year": "1976",
       "venue": "Springer Undergraduate Texts in Mathematics",
       "note": "Theorem 2.13 and surrounding: σ is multiplicative with σ(pᵃ) = (p^{a+1}−1)/(p−1)"
+    },
+    {
+      "authors": "McCarthy, Paul J.",
+      "title": "Introduction to Arithmetical Functions",
+      "year": "1986",
+      "venue": "Springer Universitext",
+      "note": "Monograph devoted to multiplicative arithmetical functions; develops σₖ, τ, and φ uniformly through their values on prime powers and the multiplicativity that this entry formalizes"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/sum-of-divisors-oq-07/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-07/meta.json
@@ -3,6 +3,40 @@
   "title": "The Closed Geometric-Product Form of σₖ for Every Exponent k",
   "slug": "sum-of-divisors-oq-07",
   "description": "Mathlib evaluates σₖ only in open form — a geometric sum on prime powers (sigma_apply_prime_pow) and a product of those sums over a factorization (sigma_eq_prod_primeFactors_sum_range_factorization_pow_mul). OQ-04 collapses the inner geometric series to closed form, but only for k = 1. This entry proves the closed geometric-product form for an arbitrary exponent k: σₖ(pⁱ)·(pᵏ−1) = p^{k(i+1)}−1 on prime powers, the two-prime product law, and the general σₖ(n)·∏_{p∣n}(pᵏ−1) = ∏_{p∣n}(p^{k(vₚ(n)+1)}−1), collapsing Mathlib's product-of-sums into a product of closed geometric quotients. Routes through geom_sum_mul, sigma_apply_prime_pow, isMultiplicative_sigma, and sigma_eq_prod_primeFactors_sum_range_factorization_pow_mul.",
+  "mainTheorems": [
+    {
+      "name": "geom_sigma_sum",
+      "type": "key",
+      "description": "**Geometric collapse over ℤ (the engine).** (∑_{j<i+1} p^{jk})·(pᵏ−1) = p^{k(i+1)}−1. This is Mathlib's `geom_sum_mul` applied at base x = pᵏ, re-indexed by `pow_mul` so the summand reads p^{jk} — the exact shape `sigma_apply_prime_pow` produces. Every closed form below reduces to this one identity.",
+      "leanType": "(k p i : ℕ) : (∑ j ∈ range (i + 1), (p : ℤ) ^ (j * k)) * ((p : ℤ) ^ k - 1) = (p : ℤ) ^ (k * (i + 1)) - 1",
+      "startLine": 43,
+      "endLine": 51
+    },
+    {
+      "name": "sigma_prime_pow_mul",
+      "type": "core",
+      "description": "**Closed geometric form on a prime power, every k.** σₖ(pⁱ)·(pᵏ−1) = p^{k(i+1)}−1, i.e. σₖ(pⁱ) = (p^{k(i+1)}−1)/(pᵏ−1). Generalizes OQ-04's `sigma_one_prime_pow_mul` (the k = 1 case) to arbitrary exponents; proved by rewriting σₖ(pⁱ) with `sigma_apply_prime_pow` and collapsing via `geom_sigma_sum`.",
+      "leanType": "{k p i : ℕ} (hp : p.Prime) : (sigma k (p ^ i) : ℤ) * ((p : ℤ) ^ k - 1) = (p : ℤ) ^ (k * (i + 1)) - 1",
+      "startLine": 56,
+      "endLine": 60
+    },
+    {
+      "name": "sigma_two_primes_pow_mul",
+      "type": "supporting",
+      "description": "**Closed form on a two-prime product pᵃ·qᵇ.** σₖ(pᵃqᵇ)·(pᵏ−1)(qᵏ−1) = (p^{k(a+1)}−1)(q^{k(b+1)}−1). Distinct primes give coprime prime powers, so σₖ factors by `isMultiplicative_sigma.map_mul_of_coprime` and each factor collapses by `sigma_prime_pow_mul`; the two are spliced with `linear_combination`.",
+      "leanType": "{k p q a b : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) : (sigma k (p ^ a * q ^ b) : ℤ) * (((p : ℤ) ^ k - 1) * ((q : ℤ) ^ k - 1)) = ((p : ℤ) ^ (k * (a + 1)) - 1) * ((q : ℤ) ^ (k * (b + 1)) - 1)",
+      "startLine": 66,
+      "endLine": 78
+    },
+    {
+      "name": "sigma_mul_prod_primeFactors",
+      "type": "core",
+      "description": "**General closed geometric-product form (headline).** For n ≠ 0, σₖ(n)·∏_{p∣n}(pᵏ−1) = ∏_{p∣n}(p^{k(vₚ(n)+1)}−1). Starts from Mathlib's product-of-sums `sigma_eq_prod_primeFactors_sum_range_factorization_pow_mul`, distributes the ∏(pᵏ−1) factors with `Finset.prod_mul_distrib`, and collapses each factor with `geom_sigma_sum` — turning a product of open geometric sums into a product of closed quotients across the whole factorization.",
+      "leanType": "{k n : ℕ} (hn : n ≠ 0) : (sigma k n : ℤ) * ∏ p ∈ n.primeFactors, ((p : ℤ) ^ k - 1) = ∏ p ∈ n.primeFactors, ((p : ℤ) ^ (k * (n.factorization p + 1)) - 1)",
+      "startLine": 85,
+      "endLine": 93
+    }
+  ],
   "meta": {
     "author": "classical (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Divisor_function",


### PR DESCRIPTION
Enrichment pass for `sum-of-divisors-oq-04-oq-01` (prime powers are deficient; almost-perfect powers of two; sharp abundancy bound).

**Structural gap:** `mainTheorems` was absent. Added all 7 theorems, each with `leanType` and start/end line anchors verified against the source — the engine identity, deficiency, almost-perfection of 2ᵏ, non-perfection, the two abundancy bounds, and the τ(pᵏ)=k+1 bonus.

No content removed. sections already span the full 123-line file. meta.json under the 60 KB cap; counts unchanged (7 theorems, 0 sorries, 0 axioms; no native_decide).