### PR TITLE
Enrich Stark rank-one regulator: add leanFile block + full section coverage

### DIFF
--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
@@ -4,6 +4,25 @@
   "slug": "kroneckers-jugendtraum-oq-02",
   "description": "When a number field has unit rank 1 — the setting of the rank-one abelian Stark conjecture — its regulator collapses from an (r×r) determinant to a single archimedean logarithm of the fundamental (Stark) unit.",
   "proofRepoPath": "Proofs/KroneckersJugendtraumStarkRankOne.lean",
+  "leanFile": {
+    "path": "Proofs/KroneckersJugendtraumStarkRankOne.lean",
+    "imports": [
+      "Mathlib.NumberTheory.NumberField.Units.Regulator",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "NumberField",
+      "NumberField.Units",
+      "NumberField.InfinitePlace",
+      "scoped NumberField"
+    ],
+    "namespace": "KroneckersJugendtraumStarkRankOne",
+    "lineCount": 79,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "sorries": 0
+  },
   "meta": {
     "author": "researcher-1",
     "date": "2026-06-25",
@@ -89,23 +108,23 @@
   "sections": [
     {
       "id": "context-hilbert-12-stark",
-      "title": "Hilbert's 12th & the Rank-One Stark Setting",
-      "startLine": 4,
-      "endLine": 41,
-      "summary": "The module docstring frames Hilbert's 12th problem (Kronecker's Jugendtraum) — explicit generators of abelian extensions, solved for ℚ (Kronecker–Weber) and imaginary quadratic fields (complex multiplication) — and the Stark conjectures' rank-one instance, where L'(0, χ) is predicted to be a rational multiple of a single log|ε| of a Stark unit. It scopes the file to the provable structural regulator-collapse fact, explicitly excluding the open problem of computing Stark units effectively, and lists the two main theorems and the proof strategy (Dirichlet rank characterization + Matrix.det_unique)."
+      "title": "Imports, Module Header & the Rank-One Stark Setting",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Imports (NumberField.Units.Regulator, Tactic) and the module docstring, which frames Hilbert's 12th problem (Kronecker's Jugendtraum) — explicit generators of abelian extensions, solved for ℚ (Kronecker–Weber) and imaginary quadratic fields (complex multiplication) — and the Stark conjectures' rank-one instance, where L'(0, χ) is predicted to be a rational multiple of a single log|ε| of a Stark unit. Scopes the file to the provable structural regulator-collapse fact, excluding the open problem of computing Stark units effectively, and lists the two main theorems and the proof strategy (Dirichlet rank characterization + Matrix.det_unique). Then opens the NumberField namespaces, enters namespace KroneckersJugendtraumStarkRankOne, and declares the ambient variable (K : Type*) [Field K] [NumberField K]."
     },
     {
       "id": "rank-characterization",
       "title": "Rank One ⟺ Two Infinite Places",
       "startLine": 50,
-      "endLine": 56,
+      "endLine": 57,
       "summary": "rank_eq_one_iff_card_infinitePlace_eq_two: since rank K = #(InfinitePlace K) − 1 by Dirichlet's unit theorem, rank K = 1 holds exactly when K has two infinite places — the real quadratic (2,0) and mixed-signature cubic (1,1) fields where the rank-one Stark conjecture lives. Proved by `rw [rank]; omega`."
     },
     {
       "id": "regulator-collapse",
       "title": "The Rank-One Regulator is a Single Logarithm",
       "startLine": 58,
-      "endLine": 77,
+      "endLine": 79,
       "summary": "regulator_eq_single_log_of_rank_eq_one: when rank K = 1, the regulator collapses from a determinant of logarithms to mult(w)·|log(w ε)| for the fundamental (Stark) unit ε. Transports the Unique instance along equivFinRank and applies Matrix.det_unique to read off the single 1×1 entry."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `kroneckers-jugendtraum-oq-02` (rank-one regulator collapses to a single logarithm).

Strong entry (2 mainTheorems, 3 references, object crossReferences, 4 keyInsights, complete conclusion). Two data/structural gaps:

- **Missing top-level `leanFile` block.** Unlike sibling entries, this one had no `leanFile` object. Added it with `path`, `imports`, `opens`, `namespace`, and the count fields (lineCount 79, axiomCount 0, theoremCount 2, definitionCount 0, sorries 0), verified against Proofs/KroneckersJugendtraumStarkRankOne.lean.
- **Section coverage**: `sections` started at line 4 and ended at 77, leaving the imports (1–2), the opens/namespace/variable setup (42–49), and the closing `end` (78–79) uncovered. Extended the ranges so sections span the full 79-line file.

meta.json stays well under the 60 KB cap. JSON validated; check-meta-size passes.