### PR TITLE
Fix: sync stale meta.* counts (abel-ruffini-oq-04-oq-01-oq-03, erdos-761)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-03/meta.json
@@ -66,8 +66,8 @@
       "exists_pComplement: Schur-Zassenhaus (Subgroup.exists_right_complement'_of_coprime) gives a p-complement H of order m to the normal Sylow-p subgroup ⟨c⟩ — needs only p ∤ m.",
       "exists_normal_pComplement_of_coprime_index: when ⟨c⟩ is central the complement H is itself normal (proved via the IsComplement' factorization g = n·h₀ with n central), exhibiting G as the internal direct product ⟨c⟩ × H of its central Sylow-p subgroup and a normal p-complement — the structural endgame of the coprime-index analysis."
     ],
-    "lineCount": 1227,
-    "theoremCount": 47,
+    "lineCount": 1282,
+    "theoremCount": 49,
     "definitionCount": 0
   },
   "leanFile": {

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -38,10 +38,10 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 483,
+    "lineCount": 532,
     "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation`; SimpleGraph.dichromNumber and SimpleGraph.cochromNumber are declared with `_root_.` prefix so dot notation `G.dichromNumber` continues to resolve. Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, dichrom_le_of_colorable, cochrom_le_of_colorable, dichrom_le_chromaticNumber, cochrom_le_chromaticNumber (Iter 9: ℕ∞ lifts to Mathlib's `SimpleGraph.chromaticNumber`), bipartite_dichrom_le_two (now a 1-line corollary of dichrom_le_of_colorable), dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 7,
     "additionalFiles": [
       "Proofs/Stubs/Erdos761Aristotle.lean"


### PR DESCRIPTION
## Fix

Two gallery entries had a stale nested `meta.*` count block that disagreed with the up-to-date `leanFile.*` block (and, for erdos-761, the top-level block). Synced `meta.*` to the true enumerated values.

## Evidence

| Entry | field | before → after | Basis |
|-------|-------|----------------|-------|
| `abel-ruffini-oq-04-oq-01-oq-03` | meta.lineCount | 1227 → 1282 | `wc -l` = 1282; leanFile.lineCount already 1282 (no additionalFiles, per-main) |
| `abel-ruffini-oq-04-oq-01-oq-03` | meta.theoremCount | 47 → 49 | comment-stripped theorem/lemma count = 49; leanFile.theoremCount already 49 |
| `erdos-761` | meta.lineCount | 483 → 532 | main file `wc -l` = 532; leanFile & top-level already 532 |
| `erdos-761` | meta.theoremCount | 20 → 22 | comment-stripped count = 22; leanFile & top-level already 22 |

**Root cause**: research PR #36068 grew `Erdos761Problem.lean` and updated `leanFile.*` + top-level counts but missed the nested `meta.*` block; abel-ruffini's `meta.*` block similarly lagged the file growth from #36163/#36136/#36097.

**Not touched**: `axiomCount` (structure-encoded vs literal distinction per Axiom Integrity Policy), `definitionCount` (already consistent). Both files JSON-validated; no residual line/theorem/def drift.

---
Automated fix by lean-mechanic agent.