### PR TITLE
Audit: mark hilbert-17-oq-03-oq-06 clean (completes gallery coverage 4790/4790)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29715,8 +29715,14 @@
       "lastAudited": "2026-07-09T06:09:30Z",
       "result": "clean",
       "issues": []
+    },
+    "hilbert-17-oq-03-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-09T20:49:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T06:30:13Z"
+  "lastUpdated": "2026-07-09T20:49:30Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Persists the audit-tracker completion for **hilbert-17-oq-03-oq-06** (the Robinson-form rational-SOS certificate entry). Tracker writes from the (deregistered) auditor-agent worktree don't reach main, so this PR records the result.

**Result: CLEAN** — all public claims match `proofs/Proofs/Hilbert17RobinsonRationalSOS.lean`:

- Counts consistent everywhere: 13 defs, 7 theorems, 191 lines, 0 sorries, 0 axioms
- No `sorry`/`admit`/`native_decide`/`decide`; `IsSumOfSquaresMv`/`IsSumOfSquaresRF` are genuine existentials, not `True` stubs
- No axiom masking: the parent's axiomatized `artin_hilbert17` is explicitly credited; this entry is scoped to a single explicit certificate for the Robinson form (does not claim to prove Artin in general)
- No phantom names: all 5 `mainTheorems` and `originalContributions` decls exist; parent/sibling cross-refs (`hilbert-17`, `hilbert-17-oq-03-oq-01`) exist
- Mathlib deps (`IsFractionRing.injective`, `Fintype.sum_prod_type`, `finProdFinEquiv`, `Finset.sum_div`, `eval`) are genuinely used as infrastructure — not core-theorem delegation; badge `original`/status `verified` is defensible (Tier A: certificate + rational-SOS conclusion proved by `ring`/`field_simp`)

This was the last unaudited entry — merging brings gallery audit coverage to 4790/4790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)