### PR TITLE
Enrich Sylow characteristic/nilpotent TFAE (sylow-theorem-oq-02-oq-01-oq-01): add preamble section for full file coverage

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01-oq-01/meta.json
@@ -87,6 +87,14 @@
   },
   "sections": [
     {
+      "id": "module-header-and-setup",
+      "title": "Module Header, Imports & Setup",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "The module docstring situates the leaf: OQ-02-OQ-01-OQ-01 sharpens the parent's `IsNilpotent G ↔ ∀ p P, (P : Subgroup G).Normal` from *normal* to *characteristic*, explaining why the two coincide for a Sylow subgroup (uniqueness of a normal Sylow forces automorphism-invariance) and enumerating the six main results plus the closing TFAE. Imports pull in Mathlib's nilpotency (GroupTheory.Nilpotent) and Sylow (GroupTheory.Sylow) machinery; the `SylowCharacteristic` namespace opens with the ambient hypotheses `variable {G : Type*} [Group G] [Finite G]` shared by every result, and the section closes with the docstring of the first re-derived criterion.",
+      "mathContext": "Setting: a finite group $G$. Characteristic (invariance under every $\\varphi \\in \\mathrm{Aut}(G)$) is strictly stronger than normal (invariance under inner automorphisms), yet the two coincide on Sylow subgroups — the theme the file formalizes."
+    },
+    {
       "id": "self-contained-criteria",
       "title": "Nilpotency Criteria (Self-Contained)",
       "startLine": 63,


### PR DESCRIPTION
## Enrichment pass

The `sections` array previously started at line 63, leaving lines **1-62** of the 149-line Lean file uncovered — the module docstring, imports, and `namespace`/`variable` setup had no section.

Add a **"Module Header, Imports & Setup"** section (lines 1-62) so the sections array now spans the full file contiguously:

| Section | Lines |
|---|---|
| Module Header, Imports & Setup | 1-62 |
| Nilpotency Criteria (Self-Contained) | 63-90 |
| Characteristic ⟺ Normal for a Sylow Subgroup | 91-110 |
| Characteristic-Tier Characterization of Nilpotency | 111-149 |

The new section summarizes the docstring's framing (why characteristic and normal coincide for a Sylow subgroup — uniqueness of a normal Sylow forces automorphism-invariance), the imports, and the shared `{G : Type*} [Group G] [Finite G]` setup, with a `mathContext` noting characteristic ⊋ normal in general.

meta.json: 19.2 KB (within the ~60 KB cap). No content removed; purely additive section coverage.