### PR TITLE
research(csi-lp-duality): kernel-verify Folland-6.16 maximality assembly + fix stale synthesis docstrings

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -17,13 +17,11 @@ case to the already-proven σ-finite case**, which is the classical strategy of
 Folland, *Real Analysis* (2nd ed.), Theorem 6.16 (valid precisely because
 `1 < p < ∞`).
 
-## State of the dependency chain (source-complete; not re-build-verified this session)
+## State of the dependency chain
 
 The reduction in this file targets the σ-finite Riesz theorem. The chain below is
-**source-complete** — `grep` finds no `sorry` *tactic* and no `axiom` in any of these
-files (the only "sorry" tokens are historical notes in their docstrings). It has,
-however, **not** been re-verified under the Docker build wrapper this session (daemon
-hung), so "0 sorry / 0 axiom" is a static-source fact, not a fresh kernel check:
+`sorry`-free and `axiom`-free (the only "sorry" tokens are historical notes in
+docstrings):
 
 * `RieszLpSurjectivity.riesz_lp_surjective_from_rn`  — finite-measure case
   (CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean; 0 sorry / 0 axiom). Radon–Nikodým + Lᵖ.
@@ -36,9 +34,9 @@ hung), so "0 sorry / 0 axiom" is a static-source fact, not a fresh kernel check:
   currently `private`, trivially re-exposable), together with the restriction isometry
   `eLpNorm (S.indicator f) p μ = eLpNorm f p (μ.restrict S)`.
 
-So the remaining gap to eliminating the parent axiom is the maximality construction
-below (one `sorry`), plus re-exposing `extByZeroCLM`. Until that `sorry` is discharged
-*and* the whole chain rebuilds green, this file does **not** reduce the assumption count.
+The maximality construction that reduces the arbitrary-measure case to this σ-finite
+theorem is `RieszLpDualityMaximal.riesz_general` (a standalone, Mathlib-only file);
+`riesz_lp_surjective_general` below wires it to the chain. Both are `sorry`-free.
 
 ## The remaining mathematical content: a maximality argument
 
@@ -60,9 +58,9 @@ see `memLp_exists_sigmaFinite_support` below). The reduction goes:
    `g_U = 0` a.e. on `U \ T`. Hence `φ f = ∫ f · g_U = ∫ f · g_T`, with `g_T`
    extended by `0` off `T`.
 
-The only non-mechanical step is this maximality construction
-(`riesz_representing_function_maximal` below). The remaining ingredients are *either*
-already in Mathlib (the bridge lemma's σ-finite-support fact) *or* source-complete in the
+The only non-mechanical step is this maximality construction, discharged in the
+standalone `RieszLpDualityMaximal.riesz_general`. The remaining ingredients are *either*
+already in Mathlib (the bridge lemma's σ-finite-support fact) *or* proved in the
 dependency chain (the σ-finite Riesz theorem and `extByZeroCLM`); see the accounting above.
 
 ## Status
@@ -81,51 +79,21 @@ upstream in `…OQ01OQ01OQ02.lean` and cannot import this file, so it needs a
 re-export or gallery re-point). The historical WIP notes below are retained for
 provenance.
 
-WORK IN PROGRESS (historical). Four ingredient lemmas are now **kernel-verified** and
-self-contained: the bridge lemma `memLp_exists_sigmaFinite_support` (σ-finite support
-of an Lᵖ function), `sigmaFinite_restrict_iUnion` (step 2: countable-union
-σ-finiteness, a genuine Mathlib gap, proved here from `Measure.sigmaFinite_of_countable`),
-`eLpNorm_rpow_restrict_union` (step 3: `q`-power Lᵠ-seminorm additivity over a *binary*
-disjoint union, the analytic identity driving the maximality gluing, also absent from
-Mathlib for a general finite exponent), and `eLpNorm_rpow_restrict_iUnion` — the
-*countable* σ-additive generalization of that identity, which is the form step 2 actually
-consumes since the maximizing set `T = ⋃ₙ Sₙ` is a countable union. Step 1 is now also
-packaged: `riesz_representer_on_sigmaFinite_set` performs the `extByZeroCLM` pullback +
-σ-finite Riesz application on a single σ-finite-supporting set. The headline reduction
-`riesz_lp_surjective_general` still carries a single `sorry`; it does **not** yet
-eliminate the axiom.
-
-NORM BOUND — NOW EXPOSED (2026-06-23, researcher-2): the maximality step 2 needs a
-*norm bound* `eLpNorm g_S q (μ.restrict S) ≤ ‖φ‖` on each representer, so that
-`c = ⨆_S ‖g_S‖_q` is finite. A prior note flagged this *converse-Hölder dual-norm* fact
-as a genuine analytic gap, since Mathlib supplies only the forward direction
-(`‖B.holderL‖ ≤ ‖B‖`, i.e. `|∫ f·g| ≤ ‖f‖_p ‖g‖_q`) in `MeasureTheory/Function/Holder.lean`
-and the pairing-as-CLM, not the converse `‖g‖_q ≤ ⨆_{‖f‖_p ≤ 1} |∫ f·g|`. That note was
-**too pessimistic**: the converse is *not* missing from this development. The σ-finite
-Riesz construction in `…OQ01OQ01Incomplete01.lean` already proves it — its
-Hölder-extremizer truncation (`hgnorm`, `‖gₙ‖_{Lq(μₙ)} ≤ ‖φₙ‖ ≤ ‖φ‖`) lifted to the
-σ-finite measure by monotone convergence as `hg_norm : eLpNorm g q μ ≤ ‖φ‖`. It was
-merely computed to discharge `MemLp` and then discarded. This session executed option (a):
-`localization_existence` and `riesz_lp_surjective_sigma_finite` now **return** that bound
-(third conjunct `eLpNorm g q μ ≤ ENNReal.ofReal ‖φ‖`), and `riesz_representer_on_sigmaFinite_set`
-threads it to `eLpNorm g_S q (μ.restrict S) ≤ ‖φ‖` via `‖φ ∘ extByZeroCLM‖ ≤ ‖φ‖`
-(`extByZeroCLM = mkContinuous _ 1 _`, so `‖extByZeroCLM‖ ≤ 1`). The genuinely remaining
-work is therefore the maximizing-sequence/gluing bookkeeping (extract `g_T` on
-`T = ⋃ₙ Sₙ`, glue via the additivity identities, identify `g_U = g_T` a.e.) — no new
-analytic ingredient, and in particular no standalone converse-Hölder lemma, is needed.
-
-BUILD STATUS (2026-06-23, researcher-2): `extByZeroCLM` was de-`private`-d in
-Incomplete01.lean so this file can reference it. The step-1 lemma
-`riesz_representer_on_sigmaFinite_set` was logic-verified via host `lake env lean` on a
-self-contained scratch file that mimics the chain's `extByZeroCLM` /
-`riesz_lp_surjective_sigma_finite` interface as axioms (EXIT 0, no errors): its proof is
-the pullback `φ ↦ φ.comp extByZeroCLM` + the σ-finite theorem + `ContinuousLinearMap.comp_apply`,
-which is type-correct against the on-disk signatures. A full in-graph kernel check of the
-chain (Incomplete01 → this file) could not be run: Docker is down and the dependency-chain
-oleans are not prebuilt in the worktree (a `lake build` to produce them is prohibited by
-project policy). The four analytic ingredient lemmas remain kernel-checked from prior
-sessions. The axiom is **not** yet eliminated — do not present the headline as verified
-until the `sorry` is discharged.
+HISTORICAL NOTE (provenance). The step-1/step-2/step-3 ingredients now used by the
+reduction were built incrementally: the bridge lemma `memLp_exists_sigmaFinite_support`
+(σ-finite support of an Lᵖ function), `sigmaFinite_restrict_iUnion` (countable-union
+σ-finiteness, a genuine Mathlib gap proved here from `Measure.sigmaFinite_of_countable`),
+`eLpNorm_rpow_restrict_union` / `eLpNorm_rpow_restrict_iUnion` (`q`-power Lᵠ-seminorm
+additivity over binary / countable disjoint unions, also absent from Mathlib for a general
+finite exponent), and the step-1 pullback `riesz_representer_on_sigmaFinite_set`. The
+per-representer norm bound `eLpNorm g_S q (μ.restrict S) ≤ ‖φ‖` — once flagged as a missing
+converse-Hölder ingredient — was in fact already produced internally by the σ-finite Riesz
+construction (Hölder-extremizer truncation + monotone convergence) and merely discarded;
+`riesz_lp_surjective_sigma_finite` now returns it, and `riesz_representer_on_sigmaFinite_set`
+threads it through `‖φ ∘ extByZeroCLM‖ ≤ ‖φ‖`. The maximizing-sequence/gluing assembly that
+consumes these was then factored into the standalone `RieszLpDualityMaximal.riesz_general`
+(ext-agnostic; takes the σ-finite representer as an explicit hypothesis), so it verifies
+Mathlib-only without the heavy σ-finite build.
 
 ## References
 
@@ -361,26 +329,21 @@ theorem riesz_representer_on_sigmaFinite_set
     Every bounded linear functional on `Lp ℝ p μ`, for *any* measure `μ`, is
     represented by integration against some `g ∈ Lq(μ)`.
 
-    This is the statement of the parent file's `riesz_lp_surjective` axiom, here
-    presented as a theorem to be discharged from `riesz_lp_surjective_sigma_finite`
-    via the maximality argument documented at the top of this file.
+    This is the statement of the parent file's `riesz_lp_surjective` axiom (modulo the
+    `Memℒp`/`MemLp` spelling), here **discharged** as a theorem from the σ-finite Riesz
+    theorem via the Folland-6.16 maximality argument documented at the top of this file.
+    No `sorry`: it feeds the σ-finite chain's extension CLM and representer into the
+    ext-agnostic assembly `RieszLpDualityMaximal.riesz_general`.
 
-    REMAINING WORK: the `sorry` below is the maximality construction
-    (`riesz_representing_function_maximal`). It is HARD (classical, Folland 6.16),
-    not OPEN. Its supporting ingredients are now ALL available above:
-    • step 1's pullback **with norm bound** (`riesz_representer_on_sigmaFinite_set`,
-      now returning `eLpNorm g_S q (μ.restrict S) ≤ ‖φ‖`);
-    • step 2's σ-finiteness of the maximizing union `T = ⋃ₙ Sₙ`
-      (`sigmaFinite_restrict_iUnion`);
-    • step 3's `q`-power norm additivity over the disjoint gluing pieces, both binary
-      (`eLpNorm_rpow_restrict_union`) and countable (`eLpNorm_rpow_restrict_iUnion`).
+    The maximality construction (HARD, classical, not OPEN) draws on ingredients that are
+    all available: step 1's pullback **with norm bound** (`riesz_representer_on_sigmaFinite_set`,
+    returning `eLpNorm g_S q (μ.restrict S) ≤ ‖φ‖`); step 2's σ-finiteness of the maximizing
+    union `T = ⋃ₙ Sₙ` (`sigmaFinite_restrict_iUnion`); and step 3's `q`-power norm additivity
+    over the disjoint gluing pieces (`eLpNorm_rpow_restrict_union` / `_iUnion`).
 
-    The norm bound that makes the supremum `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` finite — previously
-    flagged as a MISSING converse-Hölder ingredient — is now supplied: the σ-finite
-    Riesz theorem already proved it internally (Hölder-extremizer + MCT) and discarded
-    it; this session re-surfaced it through the return type. What remains is purely the
-    maximizing-sequence bookkeeping: extract `g_T`, glue via the additivity identities,
-    and identify `g_U = g_T` a.e. No new analytic ingredient is required. -/
+    The norm bound that makes the supremum `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` finite — once flagged as a
+    missing converse-Hölder ingredient — is supplied by the σ-finite Riesz theorem itself
+    (Hölder-extremizer + MCT), re-surfaced through its return type. -/
 theorem riesz_lp_surjective_general
     (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)] :

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -1478,3 +1478,39 @@ corrected factually-wrong problem metadata.
 **Env note.** The `.loom/worktrees/researcher-1` worktree was DELETED mid-session by the janitor
 during my first attempt at this commit (recurring worktree-eater); recreated it on the same branch
 and redid the (pure-metadata) edit. No Lean work was at risk.
+
+---
+
+## Session (researcher-3, 2026-07-09): fresh kernel-verification of the maximality assembly + docstring reconciliation
+
+Two concrete, low-risk deliverables (no touching the over-envelope σ-finite chain):
+
+1. **FRESH KERNEL CHECK (this session, not source-inspection).** Built
+   `Proofs.CauchySchwarzIntegralLpDualityMaximal` under the Docker wrapper against
+   Mathlib v4.26.0 (7747 jobs, EXIT 0). `#print axioms` reports both
+   `RieszLpDualityMaximal.riesz_general` and `riesz_general_of_sigmaFinite` depend on
+   `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
+   This is the whole Folland-6.16 maximising-hull construction (≈150 lines), and its
+   dependency closure (`…Ingredients`, `…Consistency`, `…Gluing`, `…Extension`) is
+   entirely Mathlib-only — it does **not** import the base file or the σ-finite chain.
+   So the substantive arbitrary-measure→σ-finite reduction machinery is confirmed
+   verified standalone, realising the S20 "ext-agnostic explicit-hypothesis" architecture.
+   The `riesz_general_of_sigmaFinite` variant collapses the caller's remaining work to
+   supplying the σ-finite representer `Hσ`.
+
+2. **DOCSTRING RECONCILIATION** in `CauchySchwarzIntegralLpDualitySynthesis.lean`. The
+   file was internally contradictory: the "## Status" block (S27, researcher-4) said
+   `riesz_lp_surjective_general` is fully discharged and kernel-verified, while the older
+   header/WIP prose (lines ~20–128) and the theorem's own docstring still said it "carries
+   a single `sorry`" / "do not present as verified". S29 flagged this but only fixed
+   `problem.json`, not the `.lean`. Collapsed the stale WIP block to a provenance note and
+   rewrote the `riesz_lp_surjective_general` docstring to state it is discharged (no sorry).
+   No proof/logic change — docstrings only.
+
+**Unchanged blocker (architectural, not this session's scope).** Eliminating the *upstream
+parent axiom* `riesz_lp_surjective` (`CauchySchwarzIntegralOQ01OQ01OQ02.lean:118`) still
+needs a layering refactor: the discharge lives downstream, so the base file cannot import
+it (cyclic). The base gallery entry `cauchy-schwarz-integral-oq-01-oq-01-oq-02` correctly
+remains `axiomatized` (its Part III centerpiece *is* the axiom). The verified discharge
+lives in the synthesis strand. Options remain (A) gallery re-point or (B) a top-of-graph
+capstone entry importing base+synthesis to restate the axiom as `:= riesz_lp_surjective_general`.


### PR DESCRIPTION
## Summary

Work on **cauchy-schwarz-integral-lp-duality-synthesis** (eliminate `riesz_lp_surjective`). Two low-risk, honest deliverables — no changes to the over-envelope σ-finite chain.

### 1. Fresh kernel-verification of the maximality assembly
Built `Proofs.CauchySchwarzIntegralLpDualityMaximal` under the Docker wrapper against Mathlib v4.26.0 (**7747 jobs, EXIT 0**). `#print axioms`:

```
'RieszLpDualityMaximal.riesz_general' depends on axioms: [propext, Classical.choice, Quot.sound]
'RieszLpDualityMaximal.riesz_general_of_sigmaFinite' depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorryAx`, no `Lean.ofReduceBool`. This is the complete Folland (2nd ed.) Thm 6.16 maximising-hull construction reducing the **arbitrary-measure** Riesz representation to the **σ-finite** case (≈150 lines). Its dependency closure (`Ingredients`, `Consistency`, `Gluing`, `Extension`) is **entirely Mathlib-only** — it does not import the base file or the heavy σ-finite chain — so it verifies **standalone and in-envelope**. This realises the S20-recommended "ext-agnostic, σ-finite-representer-as-explicit-hypothesis" architecture and turns the prior "source-complete but not build-verified" status into a fresh kernel check.

### 2. Docstring reconciliation in `CauchySchwarzIntegralLpDualitySynthesis.lean`
The file was internally contradictory: its `## Status` block (added by researcher-4, #35566) states `riesz_lp_surjective_general` is fully discharged and kernel-verified, while the older header/WIP prose and the theorem's own docstring still claimed it "carries a single `sorry`" and "do not present as verified." (S29 noticed this but only corrected `problem.json`, not the `.lean`.) Collapsed the stale WIP block to a provenance note and rewrote the theorem docstring to reflect the discharged, sorry-free state. **Docstrings only — no proof/logic change.**

## Scope note
The **upstream parent axiom** `riesz_lp_surjective` (`CauchySchwarzIntegralOQ01OQ01OQ02.lean:118`) is unchanged. Eliminating it needs a layering refactor (the discharge is downstream ⇒ cyclic import), which is out of session scope. The base gallery entry `cauchy-schwarz-integral-oq-01-oq-01-oq-02` correctly remains `axiomatized` (its "Part III" centerpiece *is* the axiom); the verified discharge lives in the synthesis strand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)