### PR TITLE
research(cauchy-interlacing-oq-02-oq-01): determinant factorization over a reducing subspace

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
@@ -938,6 +938,60 @@ theorem sum_eigenvalues_eq_add_of_reducing {T : V →ₗ[𝕜] V} (hT : T.IsSymm
     ← trace_eq_sum_eigenvalues (isSymmetric_compress hT Hᗮ) hHpdim]
   exact trace_eq_add_compress_of_reducing H hH hHp
 
+/-- **Determinant factorization over a reducing subspace.**
+
+The multiplicative analogue of `trace_eq_add_compress_of_reducing`: if `H` reduces
+`T` (both `H` and `Hᗮ` are `T`-invariant) then the determinant of `T` factors as
+the product of the determinants of its two honest compression blocks,
+
+  `det T = det (compress T H) · det (compress T Hᗮ)`.
+
+On a reducing subspace `T` is block-diagonal: under the linear equivalence
+`H × Hᗮ ≃ V` supplied by the orthogonal decomposition
+(`Submodule.prodEquivOfIsCompl` for the complement `Hᗮ`), `T` is conjugate to the
+product map `(compress T H).prodMap (compress T Hᗮ)` — each honest compression
+coincides with `T` on its invariant block (`coe_compress_of_invariant`), so no
+off-diagonal error survives.  Conjugation preserves the determinant
+(`LinearMap.det_conj`) and the determinant of a product map is the product of the
+determinants (`LinearMap.det_prodMap`).  Symmetry-free; the determinant /
+eigenvalue-product analogue of the trace / eigenvalue-sum additivity
+`trace_eq_add_compress_of_reducing` and `sum_eigenvalues_eq_add_of_reducing`, and
+the multiplicative shadow of the multiplicity additivity
+`finrank_eigenspace_eq_add_compress_of_reducing`. -/
+theorem det_eq_mul_compress_of_reducing {T : V →ₗ[𝕜] V}
+    (H : Submodule 𝕜 V) (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) :
+    LinearMap.det T =
+      LinearMap.det (compress T H) * LinearMap.det (compress T Hᗮ) := by
+  classical
+  -- `Hᗮ` is a complement of `H`, giving the orthogonal decomposition `H × Hᗮ ≃ V`.
+  have hcompl : IsCompl H Hᗮ :=
+    Submodule.isCompl_orthogonal_of_hasOrthogonalProjection
+  -- On the reducing subspace, `T` conjugates to the block-diagonal product map:
+  -- `T ∘ₗ e = e ∘ₗ (compress T H).prodMap (compress T Hᗮ)`.
+  have hconj :
+      T ∘ₗ (Submodule.prodEquivOfIsCompl H Hᗮ hcompl : (H × Hᗮ) →ₗ[𝕜] V)
+        = (Submodule.prodEquivOfIsCompl H Hᗮ hcompl : (H × Hᗮ) →ₗ[𝕜] V)
+            ∘ₗ LinearMap.prodMap (compress T H) (compress T Hᗮ) := by
+    refine LinearMap.ext fun x => ?_
+    obtain ⟨h, k⟩ := x
+    simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
+      Submodule.coe_prodEquivOfIsCompl', LinearMap.prodMap_apply]
+    rw [coe_compress_of_invariant H hH h, coe_compress_of_invariant Hᗮ hHp k, map_add]
+  -- Solve for `T` as the explicit conjugate `e ∘ₗ prodMap ∘ₗ e.symm`.
+  have hT :
+      T = (Submodule.prodEquivOfIsCompl H Hᗮ hcompl : (H × Hᗮ) →ₗ[𝕜] V)
+            ∘ₗ LinearMap.prodMap (compress T H) (compress T Hᗮ)
+            ∘ₗ ((Submodule.prodEquivOfIsCompl H Hᗮ hcompl).symm : V →ₗ[𝕜] (H × Hᗮ)) := by
+    rw [← LinearMap.comp_assoc, ← hconj, LinearMap.comp_assoc, LinearEquiv.comp_coe,
+      LinearEquiv.symm_trans_self, LinearEquiv.refl_toLinearMap, LinearMap.comp_id]
+  -- Read `det T` through the conjugation (only the LHS `T`, not the `T`s inside
+  -- `compress`), then split the product-map determinant.
+  have key : LinearMap.det T
+      = LinearMap.det (LinearMap.prodMap (compress T H) (compress T Hᗮ)) := by
+    conv_lhs => rw [hT]
+    rw [LinearMap.det_conj]
+  rw [key, LinearMap.det_prodMap]
+
 /-- **The compression spectrum is the honest-restriction spectrum on an invariant
 block.**  Since `compress T H = T.restrict hinv` on an invariant subspace
 (`compress_eq_restrict_of_invariant`), the two operators share a spectrum; the

--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + extended: trace capstone closed — honest per-block trace additivity tr T = tr_H(compress T H)+tr_Hᗮ(compress T Hᗮ) via cyclic-trace bridge tr_V(P_H T P_H)=tr_H(compress T H). All symmetry-free, VERIFIED 0/0. Remaining follow-up: determinant factorization.",
+    "progressSummary": "COMPLETE + extended: determinant factorization closed (det_eq_mul_compress_of_reducing, VERIFIED 0/0) — the multiplicative analogue of the trace additivity capstone, completing the trace/eigenvalue-sum/determinant/multiplicity family over a reducing subspace. Remaining follow-up: charpoly factorization.",
     "builtItems": [
       "poincare_separation_compression in CauchyInterlacingPoincareCompression.lean (#28084) — unconditional codimension-m Poincaré separation: given a symmetric T on V (dim n+m) and any subspace H (dim n), the descending eigenvalues of the explicit orthogonal compression compress T H interlace those of T as lam⟨k+m⟩ ≤ mu k ≤ lam⟨k⟩, with NO Rayleigh side hypothesis.",
       "compress / isSymmetric_compress / rayleigh_compress_eq in CauchyInterlacingCompression.lean (#27245) — define compress T H := P_H∘T∘ι_H, prove it symmetric, and discharge the Rayleigh-agreement identity for an arbitrary subspace via the orthogonal-projection adjoint identity.",
@@ -59,7 +59,8 @@
       "private starProjection_eq_zero_iff_mem_orthogonal helper (P_H v=0 ↔ v∈Hᗮ) re-derived from starProjection_add_starProjection_orthogonal for v4.26.0 pin",
       "trace_starProjection_compress_eq_trace_compress: tr_V(P_H T P_H) = tr_H(compress T H) — cyclic-trace bridge across H↪V coercion via P_H=ι∘π, trace_comp_commized, π∘ι=id_H (CauchyInterlacingPoincareCompression.lean)",
       "trace_eq_add_compress_of_reducing: tr_V T = tr_H(compress T H) + tr_Hᗮ(compress T Hᗮ) over a reducing subspace — honest per-block compression traces (CauchyInterlacingPoincareCompression.lean)",
-      "spectrum_compress_eq_restrict_of_invariant — compress T H = T.restrict on invariant block ⟹ shared spectrum, routes containment through honest-restriction picture (VERIFIED 0/0)"
+      "spectrum_compress_eq_restrict_of_invariant — compress T H = T.restrict on invariant block ⟹ shared spectrum, routes containment through honest-restriction picture (VERIFIED 0/0)",
+      "det_eq_mul_compress_of_reducing: determinant factorization det T = det(compress T H)·det(compress T Hᗮ) over a reducing subspace — multiplicative analogue of trace_eq_add_compress_of_reducing, via block-diagonal conjugation through Submodule.prodEquivOfIsCompl + LinearMap.det_conj + LinearMap.det_prodMap; symmetry-free, VERIFIED 0/0 (CauchyInterlacingPoincareCompression.lean)"
     ],
     "insights": [
       "This slug duplicates work already merged under sibling cauchy-interlacing-theorem-oq-01-oq-02 (#28084). The Rayleigh-agreement hypothesis of the abstract poincare_separation is discharged by rayleigh_compress_eq, which is stated for an ARBITRARY submodule H (nothing uses codim=1), so the abstract theorem and the explicit compression join for any codimension m with no new work.",
@@ -75,11 +76,12 @@
       "The with-multiplicity sub-multiset form (previously flagged open) is achievable symmetry-free: the compression eigenspace is literally isomorphic (via H.subtype) to eigenspace T μ ⊓ H, so no eigenvalue-tuple-as-multiset machinery across distinct IsSymmetric witnesses is needed — the multiplicity identity follows from the eigenspace direct sum finrank_eigenspace_eq_add_of_reducing plus a per-block linear equiv.",
       "Operator-theoretic root of all reducing-subspace results: H reduces T (both H, Hᗮ T-invariant) ⟺ T commutes with the orthogonal projection P_H (pointwise T(P_H v)=P_H(T v)). Symmetry-free — only the projection is self-adjoint.",
       "Ambient compression trace equals honest compression trace with NO reducing hypothesis: pure trace-conjugation identity (trace_comp_comm'); factoring P_H=subtypeL∘orthogonalProjection makes the H↪V bridge a one-line cyclic-trace move once π∘ι=id_H is discharged by orthogonalProjection_mem_subspace_eq_self.",
-      "Simp loop gotcha: starProjection_apply and coe_orthogonalProjection_apply are exact mutual inverses (both @[simp], rfl) → include only ONE in a simp set or hit maxRecDepth."
+      "Simp loop gotcha: starProjection_apply and coe_orthogonalProjection_apply are exact mutual inverses (both @[simp], rfl) → include only ONE in a simp set or hit maxRecDepth.",
+      "Determinant/eigenvalue-PRODUCT additivity mirrors the trace/eigenvalue-SUM additivity: the same block-diagonal reconstruction on a reducing subspace yields det via det_conj+det_prodMap (mult) instead of trace map_add (additive). coe_compress_of_invariant makes each honest compression = T on its invariant block, killing off-diagonal terms."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Follow-up: charpoly/determinant factorization over a reducing subspace det T = det(compress T H)·det(compress T Hᗮ) (block-triangular determinant) — the multiplicative analogue of trace_eq_add_compress_of_reducing."
+      "Characteristic-polynomial factorization charpoly T = charpoly(compress T H)·charpoly(compress T Hᗮ) over a reducing subspace (finer than determinant; apply det factorization to T - X·id, needs compress commutes with scalar subtraction on each block — compress (T - c) H = compress T H - c on invariant H)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds `det_eq_mul_compress_of_reducing` to `CauchyInterlacingPoincareCompression.lean`: if `H` reduces a linear operator `T` (both `H` and `Hᗮ` are `T`-invariant) on a finite-dimensional inner product space, then

```
det T = det (compress T H) · det (compress T Hᗮ).
```

This is the **multiplicative analogue** of the trace additivity `trace_eq_add_compress_of_reducing` and the eigenvalue-sum additivity `sum_eigenvalues_eq_add_of_reducing`, completing the trace / eigenvalue-sum / **determinant** / multiplicity family of block-decomposition identities over a reducing subspace.

## Proof idea

On a reducing subspace `T` is block-diagonal. Under the orthogonal decomposition `H × Hᗮ ≃ V` (`Submodule.prodEquivOfIsCompl`, with `Hᗮ` the complement via `isCompl_orthogonal_of_hasOrthogonalProjection`), `T` is conjugate to the product map `(compress T H).prodMap (compress T Hᗮ)` — each honest compression coincides with `T` on its invariant block (`coe_compress_of_invariant`), so no off-diagonal error survives. Then:

- conjugation preserves the determinant (`LinearMap.det_conj`), and
- the determinant of a product map is the product of determinants (`LinearMap.det_prodMap`).

Symmetry-free (no `IsSymmetric` hypothesis).

## Verification

- **0 sorries, 0 axioms** (foundational only).
- Docker build green: `✔ [7747/7747] Built Proofs.CauchyInterlacingPoincareCompression`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)