### PR TITLE
collatz-structured-oq-02-oq-03: combinatorial 3/2-heuristic drop criterion

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1373,6 +1373,38 @@ families, where the halvings always outnumber the triplings: e.g. `3 (mod 16)` u
 example : ¬ (leadCoeff [true, false, true, false, true, false] (2 ^ 3) < 2 ^ 3) := by
   decide
 
+/-- **The Collatz 3/2 heuristic as a purely combinatorial drop criterion.**  The Terras
+drop condition `3 ^ a < 2 ^ b` — the `a` triplings of a window must be overcome by its
+`b` halvings — is *implied* by the clean count inequality `2 * a < b`: twice as many
+halvings as triplings always suffice, with no exponentiation to evaluate.  The proof is
+the heuristic made exact, using only `3 ≤ 4 = 2²`:
+`3 ^ a ≤ 4 ^ a = 2 ^ (2 * a) < 2 ^ b`.  (The constant `2` is not sharp — the true
+threshold is `log₂ 3 ≈ 1.585` — but `2` is the cheapest integer bound that is provable
+without evaluating any power, and it already certifies every gallery family: `3 (mod 16)`
+has `a = 2, b = 4` with `2·2 < 4` failing by equality, so the sharper count `2·a ≤ b`
+with a strict-power check is what the gallery uses; `2·a < b` is the slack version that
+needs no power comparison at all.) -/
+theorem pow_three_lt_two_pow_of_two_mul_lt {a b : ℕ} (h : 2 * a < b) :
+    3 ^ a < 2 ^ b :=
+  calc 3 ^ a ≤ 4 ^ a := Nat.pow_le_pow_left (by norm_num) a
+    _ = 2 ^ (2 * a) := by rw [pow_mul]; norm_num
+    _ < 2 ^ b := pow_lt_pow_right₀ (by norm_num) h
+
+/-- **Count-only residue-drop corollary of the Terras engine.**  A valid residue-window
+`v` for the dyadic modulus `2 ^ b` (performing exactly its `b` halvings) certifies a drop
+below `r` as soon as it carries more than twice as many halvings as triplings —
+`2 * v.count true < b` — with the additive constant landing below `r`.  This removes the
+last arithmetic obligation from `terras_attainsBelow`: the drop hypothesis is now a pure
+count inequality (`omega`-checkable), not a power comparison `3 ^ a < 2 ^ b`.  Combined
+with `deriveVec`, a new residue class becomes a one-line certificate whenever its forced
+window is halving-dominated. -/
+theorem terras_attainsBelow_of_count {b r : ℕ} (v : List Bool) (hk : 0 < v.length)
+    (hcount : v.count false = b) (hval : AffValid v (2 ^ b) r)
+    (hcnt : 2 * v.count true < b)
+    (hd : (affOrbit v (2 ^ b, r)).2 < r)
+    {n : ℕ} (hn : n % 2 ^ b = r) : AttainsBelow n :=
+  terras_attainsBelow v hk hcount hval (pow_three_lt_two_pow_of_two_mul_lt hcnt) hd hn
+
 /-! ### Decidable certificates: the engine as a one-shot `by decide`
 
 `AffValid` is a `Prop`-valued inductive, so supplying a certificate still means writing

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,14 +20,15 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1820,
+    "lineCount": 1852,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 66,
+    "theoremCount": 68,
     "definitionCount": 13,
     "originalContributions": [
-      "attainsBelow_density_of_autoDropCert: fuses the general density lemma attainsBelow_density_of_residues with the turnkey autoDropCert engine, so the drop-below density floor at any 2^b level is (#auto-certified residues)·(N-1) with ZERO per-residue proof — the residue count is a decide, every drop hypothesis is autoDropCert_attainsBelow (axiom-free, no native_decide)"
+      "attainsBelow_density_of_autoDropCert: fuses the general density lemma attainsBelow_density_of_residues with the turnkey autoDropCert engine, so the drop-below density floor at any 2^b level is (#auto-certified residues)·(N-1) with ZERO per-residue proof — the residue count is a decide, every drop hypothesis is autoDropCert_attainsBelow (axiom-free, no native_decide)",
+      "pow_three_lt_two_pow_of_two_mul_lt / terras_attainsBelow_of_count: the Collatz 3/2 heuristic as a purely combinatorial drop criterion — the count inequality 2·a < b implies the Terras power condition 3^a < 2^b via 3^a ≤ 4^a = 2^(2a) < 2^b (only 3 ≤ 4 = 2²; no power evaluated), and terras_attainsBelow_of_count wires it into the residue engine so a halving-dominated window certifies a drop by an omega-checkable count instead of a power comparison (axiom-free, no decide)"
     ]
   },
   "overview": {
@@ -137,9 +138,9 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1820,
+    "lineCount": 1852,
     "axiomCount": 1,
-    "theoremCount": 66,
+    "theoremCount": 68,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 13

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -53,7 +53,8 @@
       "parityVector_attainsBelow: residue class drops below itself from a certificate v with realized c_k<M, d_k<r; new families reduce to a decidable certificate check (mod16/3 re-derived as validation example)",
       "attainsBelow_density_of_residues (CollatzStructuredOQ02OQ03.lean): general residue-class density floor — for 1≤M and any certified residue set R, |R|·(N-1) ≤ #{n∈[1,M·N] : AttainsBelow n}. Axiom-free.",
       "attainsBelow_density_lower_16_general: re-derives the 13/16 floor from the general lemma; residue count 13 via kernel `decide` (axiom-free), drop hypotheses via omega-checked congruences + Part II lemmas.",
-      "CollatzStructuredOQ02OQ03.autoDropCert_colMin_lt: autoDropCert b r = true & n%2^b=r -> colMin n < n (general Part VII->Part III bridge, VERIFIED, no new axiom/decide)"
+      "CollatzStructuredOQ02OQ03.autoDropCert_colMin_lt: autoDropCert b r = true & n%2^b=r -> colMin n < n (general Part VII->Part III bridge, VERIFIED, no new axiom/decide)",
+      "pow_three_lt_two_pow_of_two_mul_lt / terras_attainsBelow_of_count (CollatzStructuredOQ02OQ03.lean): the Collatz 3/2 heuristic as a purely COMBINATORIAL drop criterion. The arithmetic core proves the count inequality 2*a < b implies the Terras power condition 3^a < 2^b via 3^a ≤ 4^a = 2^(2*a) < 2^b (Nat.pow_le_pow_left + pow_mul + pow_lt_pow_right₀, using only 3 ≤ 4 = 2²; no power evaluated). terras_attainsBelow_of_count wires it into the residue engine: a valid dyadic window with 2*(v.count true) < b (halvings more than double the triplings) certifies AttainsBelow by an omega-checkable count instead of a 3^a<2^b power comparison. Axiom-free, no decide."
     ],
     "insights": [
       "The odd residue class n ≡ 1 (mod 4), n ≥ 5, deterministically drops below itself in 3 Collatz steps: 4m+1 → 12m+4 → 6m+2 → 3m+1, with 3m+1 < 4m+1 iff m ≥ 1. First elementary family exercising the 3n+1 branch (even/powers-of-two only touch the n/2 branch).",
@@ -66,7 +67,8 @@
       "ENGINE: separating the certificate (AffValid: parities forced, checked per step) from the realization (affOrbit_realize: one induction) is what generalizes the chase. The realization needs only that 2*c'*m is recognizably even — omega atomizes (2*c')*m as one nonlinear blob and loses the factor 2, so supply 2*c'*m=2*(c'*m) explicitly. With that, the whole engine is 6 theorems + 1 inductive and a new residue family is a (decidable) certificate, not a bespoke proof.",
       "The four explicit density floors (3/4, 13/16, 7/8, 115/128) all instantiate ONE counting pattern: a finite certified residue set mod M gives lower density |R|/M. Abstracting it removes ~600 lines of per-level pairwise-disjointness bookkeeping.",
       "Disjointness across residue classes collapses to a single injectivity: (r,m) ↦ M·m+r is injective on R ×ˢ [1,N-1] because r<M is exactly the remainder of M·m+r mod M (Nat.add_mul_mod_self_left). No per-pair Disjoint witnesses needed.",
-      "Kernel decide on autoDropCert (deriveVec/affOrbit over Nat with 2^b) is very memory-heavy; the file sits near the kernel memory ceiling, so each added autoDropCert `by decide` risks a deterministic line-less exit 135 (SIGBUS 128+7) independent of build concurrency. Prefer the general colMin bridge lemma over inline decide examples."
+      "Kernel decide on autoDropCert (deriveVec/affOrbit over Nat with 2^b) is very memory-heavy; the file sits near the kernel memory ceiling, so each added autoDropCert `by decide` risks a deterministic line-less exit 135 (SIGBUS 128+7) independent of build concurrency. Prefer the general colMin bridge lemma over inline decide examples.",
+      "The Terras drop condition 3^a < 2^b has a slack combinatorial sufficient form 2*a < b (halvings at least double the triplings), provable with NO power evaluation via 3^a ≤ 4^a = 2^(2a) < 2^b. The integer constant 2 is not sharp (the true threshold is log₂3 ≈ 1.585): the gallery's tightest family 3 (mod 16) has a=2, b=4 with 2·2 = 4 = b failing the strict 2a<b, so its certification still needs the exact 3²=9<16=2^4 power check — but 2a<b removes the power obligation entirely for any window with genuine halving slack, converting terras_attainsBelow's drop hypothesis into an omega goal."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -96,7 +98,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T18:39:05.245Z",
-  "lastUpdate": "2026-07-08",
+  "lastUpdate": "2026-07-09",
   "leanFiles": [
     {
       "path": "Proofs/CollatzStructured.lean",


### PR DESCRIPTION
## Summary

Adds two axiom-free theorems to the Terras residue-drop engine in `CollatzStructuredOQ02OQ03.lean`, expressing the classical Collatz **3/2 heuristic** as a purely combinatorial drop criterion.

- **`pow_three_lt_two_pow_of_two_mul_lt`** `{a b : ℕ} (h : 2 * a < b) : 3 ^ a < 2 ^ b`
  The Terras power drop condition `3^a < 2^b` follows from the count inequality `2·a < b` (halvings more than double the triplings), proved with **no power evaluation**: `3^a ≤ 4^a = 2^(2a) < 2^b`, using only `3 ≤ 4 = 2²`.
- **`terras_attainsBelow_of_count`** — wires the above into `terras_attainsBelow`, so a valid dyadic residue window with `2·(v.count true) < b` certifies `AttainsBelow n` by an `omega`-checkable count instead of a `3^a < 2^b` power comparison.

## Why it matters

The engine's per-residue drop obligation was previously a power comparison. For any window whose halvings genuinely outnumber the triplings by a factor of 2, that obligation is now discharged by a pure count inequality — the classical `3/2`-vs-`1/2` Collatz heuristic made exact and mechanized. The integer constant `2` is not sharp (true threshold `log₂3 ≈ 1.585`), so the tightest gallery family `3 (mod 16)` (`a=2, b=4`) still uses the exact `9 < 16` check; the new lemma removes the power obligation for all halving-dominated windows.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CollatzStructuredOQ02OQ03` → ✔ Built (7743 jobs, 24GB).
- Additions are axiom-free (`Nat.pow_le_pow_left` + `pow_mul` + `pow_lt_pow_right₀`, composing existing verified engine lemmas). No `decide`/`native_decide`/`sorry`.
- File unchanged status: 0 sorries, 1 axiom (`tao_2019`). Counts 66→68 theorems, 1820→1852 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)