### PR TITLE
research(erdos-490): mark strand terminus — correct stale θ-gap-axiom metadata

### DIFF
--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -535,3 +535,24 @@ see through the def — must `unfold maxProductSize` first. `Nat.find_mono` dire
 Modest: a basic structural sanity property, not progress on the deep axiom.
 `szemeredi_theorem` (the N²/log N upper bound, Szemerédi 1976) stays correctly
 axiomatized — out of scope. Meta leanFile lineCount 843→861, theoremCount 25→26.
+
+## Session 2026-07-09 (researcher-3) — metadata correction: strand at terminus
+
+**No code change.** Corrected stale metadata that was mis-directing the fleet.
+
+The top-of-file `progressSummary` (and `nextSteps`) still asserted the Chebyshev θ-gap
+axiom `chebyshev_theta_upper_half_lower_bound` was **NOT yet eliminated** and listed
+"prove chebyshev_theta_upper_half_lower_bound (~300-500 lines, multi-session)" as pending.
+That was resolved months ago: it is a **theorem** in `Erdos490Problem.lean` (#35530,
+axiomCount 2→1), assembled from the verified `Erdos490Chebyshev.lean` ingredients
+(`theta_gap_lower_bound`, `erdos490_analytic_tail`, Bertrand small-N via `optimalB_nonempty`).
+Later verified additions: `maxProductSize_monotone` (#35699), unconditional optimal-example
+upper bound (#35676), `theta_gap_ge_linear` (#36014). Confirmed by static scan this session:
+`Erdos490Problem.lean` = 1 axiom / 0 sorry; `Erdos490Chebyshev.lean` = 0 / 0;
+`Erdos490OQ01.lean` = 1 axiom / 0 sorry.
+
+**Terminus.** The only remaining axioms — `szemeredi_theorem` (Problem) and `szemeredi_upper`
+(OQ01) — both state the deep Szemerédi (1976) distinct-products upper bound
+`|A|·|B| ≤ C·N²/log N`, a famous hard theorem not in Mathlib. Correctly axiomatized, out of
+session scope. Everything elementary / combinatorial / build-repair is done. Set
+`status: completed`, `phase: COMPLETED` so the strand stops being re-served.

--- a/src/data/research/problems/erdos-490-incomplete-01.json
+++ b/src/data/research/problems/erdos-490-incomplete-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-490-incomplete-01",
   "title": "Erdős #490 (distinct products): build repair + sorry reduction",
-  "status": "progress",
-  "phase": "ACT",
+  "status": "completed",
+  "phase": "COMPLETED",
   "path": "fast",
   "tier": "B",
   "significance": 5,
@@ -71,11 +71,11 @@
       "Mathlib.NumberTheory.Chebyshev has NO lower bound on θ/ψ (only theta_le_log4_mul_x, psi_le_const_mul_self); the central-binomial lower bound θ(N)−θ(N/2) ≥ c·N is the missing piece."
     ],
     "nextSteps": [
-      "Eliminate primes_upper_half_lower_bound by proving a Chebyshev lower bound π(N)−π(N/2) ≳ N/log N from Mathlib primitives (Bertrand/centralBinom machinery) — a multi-session infrastructure effort; Mathlib's Nat.primeCounting currently has only an upper bound. With optimalB_card_eq_primeCounting in place, the axiom can be restated purely against Nat.primeCounting: ∃ c>0, c*N/log N ≤ ↑(N.primeCounting - (N/2).primeCounting).",
-      "DONE (2026-06-30): proved (optimalB N).card = N.primeCounting - (N/2).primeCounting (optimalB_card_eq_primeCounting), bridging the axiom to Mathlib's primeCounting API.",
-      "Prove chebyshev_theta_upper_half_lower_bound: θ(N)−θ(N/2) ≥ c·N via central binomial coefficient. Path: log(centralBinom n) ≤ ψ(2n) (Legendre valuation ≤ prime-power count) + centralBinom n ≥ 4^n/(2n+1) gives ψ lower bound; then the Erdős (2n/3,2n] product estimate (already partly in Mathlib.NumberTheory.Bertrand internals: centralBinom_factorization_small) refines this to the θ-difference. Multi-session (~300-500 lines)."
+      "OUT OF SCOPE: eliminating szemeredi_theorem / szemeredi_upper requires formalizing the Szemerédi (1976) upper bound |A||B| ≪ N²/log N for distinct-product sets (Erdős multiplication-table circle of ideas) — a major multi-paper formalization absent from Mathlib. Do not re-mine as session-sized.",
+      "If continuing: a purely structural bridge maxProd N (Erdos490OQ01) ↔ maxProductSize N (Erdos490Problem) would let the two Szemerédi axioms share one statement, but this reduces neither the count nor the mathematical assumption."
     ],
-    "progressSummary": "PROGRESS (researcher-4, 2026-07-07): Added standalone 0-axiom/0-sorry file Erdos490Chebyshev.lean proving the central-binomial decomposition crux of the Chebyshev θ-gap lower bound (Mathlib's own TODO) and reducing the remaining axiom chebyshev_theta_upper_half_lower_bound to the elementary bound θ(2n)−θ(n) ≥ n·log4−⌊2n/3⌋·log4−log n−√(2n)·log(2n). Axiom NOT yet eliminated: remaining is the analytic tail √n·log n=o(n) + small-n Bertrand reconciliation. Main file unchanged (2 axioms)."
+    "progressSummary": "TERMINUS for session-sized work (researcher-3, 2026-07-09). The Chebyshev θ-gap axiom chebyshev_theta_upper_half_lower_bound is ELIMINATED — now a fully-proved theorem in Erdos490Problem.lean (#35530, axiomCount 2→1), assembled from the verified Erdos490Chebyshev.lean (0 axiom/0 sorry): theta_gap_lower_bound (central-binomial estimate), erdos490_analytic_tail (√n·log n, log n = o(n)), and Bertrand small-N reconciliation via optimalB_nonempty. Subsequent verified additions: maxProductSize_monotone (#35699), unconditional optimal-example upper bound (#35676), theta_gap_ge_linear (#36014). All files 0-sorry. The ONLY remaining axioms are the deep Szemerédi (1976) N²/log N distinct-products UPPER bound — szemeredi_theorem (Erdos490Problem.lean) and szemeredi_upper (Erdos490OQ01.lean) — a famous hard theorem not in Mathlib, correctly axiomatized and out of session scope. The lower-bound / combinatorial / build-repair side is complete.",
+    "nextAction": "None session-sized. Strand at terminus; remaining axioms are the deep out-of-scope Szemerédi upper bound."
   },
   "knownResults": {
     "established": [


### PR DESCRIPTION
## Summary

Metadata-only correction for **erdos-490-incomplete-01** (Erdős #490, distinct products). No Lean/code change.

The research metadata (`progressSummary`, `nextSteps`) still asserted the Chebyshev θ-gap axiom `chebyshev_theta_upper_half_lower_bound` was **not yet eliminated** and listed proving it (~300–500 lines, "multi-session") as pending work. That was resolved months ago:

- `chebyshev_theta_upper_half_lower_bound` is a **fully-proved theorem** in `Erdos490Problem.lean` (#35530, axiomCount 2→1), assembled from the verified `Erdos490Chebyshev.lean` ingredients (`theta_gap_lower_bound`, `erdos490_analytic_tail`, Bertrand small-N via `optimalB_nonempty`).
- Later verified additions: `maxProductSize_monotone` (#35699), unconditional optimal-example upper bound (#35676), `theta_gap_ge_linear` (#36014).

Static confirmation this session: `Erdos490Problem.lean` = 1 axiom / 0 sorry, `Erdos490Chebyshev.lean` = 0/0, `Erdos490OQ01.lean` = 1 axiom / 0 sorry.

### Terminus
The only remaining axioms — `szemeredi_theorem` (Problem) and `szemeredi_upper` (OQ01) — both state the deep **Szemerédi (1976)** distinct-products upper bound `|A|·|B| ≪ N²/log N`, a famous hard theorem not in Mathlib. Correctly axiomatized, out of session scope. Everything elementary / combinatorial / build-repair is complete.

Set `status: completed` / `phase: COMPLETED` and rewrote the summary + next-steps so the fleet stops re-mining a strand at its achievable frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)