### PR TITLE
research(erdos-1080-oq-03): fresh-verify companion (0/0) + fix stale parent-sorry docstrings, mark terminus

### DIFF
--- a/proofs/Proofs/Erdos1080OQ03.lean
+++ b/proofs/Proofs/Erdos1080OQ03.lean
@@ -14,8 +14,10 @@ extensions of the C₄/C₆ story are the longer even cycles.
 
 The bipartition / cycle-length definitions are inlined here (mirroring those in
 Erdos1080Problem.lean) so that this companion is self-contained and independently
-verifiable; the parent gallery file currently carries an unrelated `sorry` in
-`c4_free_iff_no_K22` and a malformed doc-comment, so it is not imported.
+verifiable, and to keep its import surface minimal (only the SimpleGraph modules it
+needs, not the parent's full-Mathlib import). The parent's `c4_free_iff_no_K22` — once
+a `sorry` placeholder — is now a discharged theorem there; the equivalence below is the
+independently-verified companion form.
 
 Main results (all 0 sorries / 0 axioms, over an arbitrary vertex type):
 * `bipartite_walk_parity` — the parity engine: along any walk the endpoint's
@@ -315,9 +317,9 @@ theorem isBipartite_iff_colorable_two : IsBipartite G ↔ G.Colorable 2 := by
 
 In a bipartition `(X, Y)`, a `4`-cycle is exactly a `K_{2,2}`: two distinct
 left vertices `a₁, a₂ ∈ X` and two distinct right vertices `b₁, b₂ ∈ Y` with all
-four cross edges present.  The two lemmas below establish this equivalence,
-discharging the `c4_free_iff_no_K22` placeholder that the parent problem file
-(`Erdos1080Problem.lean`) still carries as a `sorry`.
+four cross edges present.  The two lemmas below establish this equivalence, the
+companion form of the parent problem file's `c4_free_iff_no_K22`
+(`Erdos1080Problem.lean`, now a discharged theorem — formerly a `sorry` placeholder).
 
 Since the bipartition forces the cycle's vertices to alternate sides, a `4`-cycle
 must visit exactly two `X`-vertices and two `Y`-vertices; conversely a `K_{2,2}`

--- a/src/data/research/problems/erdos-1080-oq-03.json
+++ b/src/data/research/problems/erdos-1080-oq-03.json
@@ -4,8 +4,8 @@
   "tier": "B",
   "significance": 5,
   "tractability": 6,
-  "status": "active",
-  "phase": "ACT",
+  "status": "completed",
+  "phase": "COMPLETED",
   "path": "proofs/Proofs/Erdos1080OQ03.lean",
   "started": "2026-07-08",
   "lastUpdate": "2026-07-08",
@@ -84,8 +84,9 @@
       "Mathlib has cycleGraph + bicoloring_of_even + cycleGraph_EulerianCircuit but NO lemma that cycleGraph is Hamiltonian / its Eulerian circuit IsCycle — built the explicit cycle from scratch"
     ],
     "nextSteps": [
-      "Attempt Erdos C8 existence observation (erdos_c8_observation axiom): dense C4,C6-free bipartite graph must contain C8 - genuinely hard extremal/moment-count core, NOT elementary and NOT session-sized. This is the sole remaining open core; all elementary spectrum/parity results are now complete."
+      "OUT OF SCOPE: the two remaining parent axioms (luw_superlinear, erdos_c8_observation) are deep extremal graph theory (LUW algebraic construction; Erdős C₈-in-dense-bipartite). Not elementary, not in Mathlib, not session-sized — do not re-mine.",
+      "Optional structural: OQ03 could drop its inlined bipartition/cycle definitions and import the parent (now sorry-free) instead, but that trades minimal import surface for de-duplication and needs a full-graph rebuild; low value."
     ],
-    "progressSummary": "PROGRESS (verified 0 sorries / 0 axioms): completed the cycle-graph parity dichotomy (cycleGraph bipartite ⟺ N even) as the converse-sharp complement to the realizability capstone. Also resolved the PR #35973 merge conflict, unblocking the ~528-line VERIFIED realizability+parent-restore work onto main. Elementary spectrum/parity theory now fully closed; only the hard extremal C8-existence core remains open."
+    "progressSummary": "TERMINUS for session-sized work (researcher-3, 2026-07-09). Elementary spectrum/parity theory is fully closed and VERIFIED 0 sorry / 0 axiom in Erdos1080OQ03.lean (bipartite walk-parity engine, closed-walk-even, girth ≥ 4, C₄⇔K₂,₂, cycleGraph bipartite ⟺ N even parity dichotomy). This session: fresh kernel build of Proofs.Erdos1080OQ03 + fixed two stale docstrings that claimed the parent Erdos1080Problem.lean still carries a `sorry` in `c4_free_iff_no_K22` — it is now a discharged theorem (parent line 387), and the parent has 0 sorries. The ONLY remaining axioms live in the parent and are both deep, out-of-scope extremal results: luw_superlinear (Lazebnik–Ustimenko–Woldar 1994 f(n,⌊n^(2/3)⌋) ≥ c₀·n^(16/15) construction) and erdos_c8_observation (Erdős C₈ existence for dense C₄,C₆-free bipartite graphs — a moment/KST-type extremal core). Neither is in Mathlib nor session-sized."
   }
 }


### PR DESCRIPTION
## Summary

Work on **erdos-1080-oq-03** (Erdős #1080, C₄/C₆-free bipartite spectrum). Verification + integrity cleanup — no proof/logic change.

### Fresh kernel-verification
Built `Proofs.Erdos1080OQ03` under the Docker wrapper against current Mathlib (**[1164/1164], EXIT 0**, no errors/sorries). Confirms the elementary spectrum/parity theory is verified **0 sorry / 0 axiom**: bipartite walk-parity engine, closed-walk-even, girth ≥ 4, C₄ ⇔ K₂,₂, and the cycleGraph bipartite ⟺ N even parity dichotomy.

### Docstring integrity fix
Two docstrings in `Erdos1080OQ03.lean` claimed the parent `Erdos1080Problem.lean` "currently carries an unrelated `sorry` in `c4_free_iff_no_K22`." That placeholder is now a **discharged theorem** (parent line 387), and the parent has **0 sorries**. Corrected both references. Docstrings only — the build above is of the identical code.

### Terminus
Set `status: completed` / `phase: COMPLETED`. The only remaining axioms live in the parent and are both deep, out-of-scope extremal results:
- `luw_superlinear` — Lazebnik–Ustimenko–Woldar (1994) `f(n, ⌊n^{2/3}⌋) ≥ c₀·n^{16/15}` algebraic construction;
- `erdos_c8_observation` — Erdős's C₈-in-dense-C₄,C₆-free-bipartite observation (moment/KST-type extremal core).

Neither is in Mathlib nor session-sized. The strand is at its achievable frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)