### PR TITLE
research(pythagorean-theorem-oq-01): Einstein's similar-triangles proof, verified

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ01.lean
@@ -1,0 +1,267 @@
+/-
+# Pythagorean Theorem OQ-01: The Simplest Proof — Einstein's Similar-Triangles Argument
+
+## The Open Question
+
+> *What's the simplest possible proof of the Pythagorean theorem?*
+> (Candidates include Einstein's similar-triangles proof.)
+
+The proof Albert Einstein reportedly discovered as a boy is widely regarded as one of
+the most economical. It uses **no auxiliary construction other than a single altitude**,
+and a single physical principle:
+
+> **The area of any planar figure is proportional to the square of any one of its
+> linear dimensions**, with the *same* proportionality constant for all figures of the
+> *same shape* (i.e. similar figures).
+
+Einstein's argument:
+
+1. Drop the altitude from the right-angle vertex `C` to the hypotenuse. Its foot `H`
+   splits the right triangle `T` (legs `cA`, `cB`, hypotenuse `h`) into two smaller
+   triangles `T₁` and `T₂`.
+2. **Each sub-triangle is similar to `T`** (they share an angle with `T` and each has a
+   right angle). In `T₁` the side corresponding to `T`'s hypotenuse is the leg `cA`; in
+   `T₂` it is the leg `cB`.
+3. By the area–square law, writing `k` for the shared shape constant,
+   `Area(T) = k·h²`, `Area(T₁) = k·cA²`, `Area(T₂) = k·cB²`.
+4. Since `H` lies inside the hypotenuse, `Area(T) = Area(T₁) + Area(T₂)`, hence
+   `k·h² = k·cA² + k·cB²`, and cancelling `k` gives `h² = cA² + cB²`.
+
+## What This File Proves (0 sorries, 0 axioms)
+
+The file isolates Einstein's argument into three fully verified layers.
+
+- **Layer 1 — the area–square law** (`triArea_scale`): for a triangle of base `b` and
+  height `t`, scaling every length by a factor `r` scales the area by exactly `r²`. This
+  is the one geometric principle Einstein relies on, proved from `Area = ½·base·height`.
+
+- **Layer 2 — the algebraic skeleton** (`einstein_pythagorean`): *given* the three
+  similar areas `k·cA²`, `k·cB²`, `k·h²` and the dissection
+  `Area(T) = Area(T₁) + Area(T₂)`, cancelling the shape constant yields
+  `cA² + cB² = h²`. This is the "cancel `k`" step, verified without any geometry.
+
+- **Layer 3 — the altitude decomposition realised** (`altitudeFoot`, `foot_perp`,
+  `geometric_mean_A`, `geometric_mean_B`, `segments_sum`, `pythagorean_via_altitude`):
+  we build the altitude foot `H` explicitly in a real inner-product space, prove it is
+  perpendicular to the hypotenuse, and verify the two **geometric-mean relations**
+  `cA² = h·|AH|` and `cB² = h·|HB|` together with the betweenness identity
+  `|AH| + |HB| = h`. These are exactly the numerical shadows of "`T₁`, `T₂` are similar
+  to `T`", and summing them reconstructs `h² = cA² + cB²`.
+
+## Honesty note
+
+Once a Euclidean model is fixed, the norm already encodes distance, so the one-line
+inner-product identity `‖A-B‖² = ‖A-C‖² + ‖B-C‖²` (`pythagorean_core`) *is* Pythagoras.
+Layer 3 does not pretend to be foundationally independent of that identity; its value is
+that it verifies the **geometric-mean / altitude decomposition** — the metric content of
+Einstein's similar-triangles picture — rather than the bare polarization identity.
+Layers 1 and 2 capture the parts of Einstein's reasoning that are genuinely independent
+of coordinates.
+
+Tags: geometry, euclidean-geometry, inner-product, similar-triangles, einstein, classic
+-/
+
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+
+open scoped RealInnerProductSpace
+
+namespace PythagoreanEinstein
+
+-- ============================================================
+-- Layer 1: The area–square law for similar triangles
+-- ============================================================
+
+/-- Area of a triangle with base `b` and height `t`. -/
+noncomputable def triArea (b t : ℝ) : ℝ := b * t / 2
+
+/-- **The one geometric principle Einstein uses.**
+Scaling every linear dimension of a triangle by a factor `r` scales its area by `r²`.
+This is the content of "area is proportional to the square of a linear dimension". -/
+theorem triArea_scale (r b t : ℝ) : triArea (r * b) (r * t) = r ^ 2 * triArea b t := by
+  unfold triArea; ring
+
+-- ============================================================
+-- Layer 2: The algebraic skeleton — "cancel the shape constant"
+-- ============================================================
+
+/-- **Einstein's argument, algebraically.**
+The altitude splits the right triangle into two pieces similar to the whole. Writing `k`
+for the shared shape constant (area = `k` × hypotenuse²), the three areas are `k·cA²`,
+`k·cB²`, `k·h²`, and additivity of area gives `k·h² = k·cA² + k·cB²`. Cancelling the
+nonzero constant `k` yields the Pythagorean relation. No coordinates are used. -/
+theorem einstein_pythagorean {cA cB h k areaWhole areaA areaB : ℝ}
+    (hk : k ≠ 0)
+    (hWhole : areaWhole = k * h ^ 2)
+    (hA : areaA = k * cA ^ 2)
+    (hB : areaB = k * cB ^ 2)
+    (hdissect : areaWhole = areaA + areaB) :
+    cA ^ 2 + cB ^ 2 = h ^ 2 := by
+  rw [hWhole, hA, hB] at hdissect
+  -- hdissect : k * h ^ 2 = k * cA ^ 2 + k * cB ^ 2
+  have hcancel : k * (cA ^ 2 + cB ^ 2) = k * h ^ 2 := by linear_combination -hdissect
+  exact mul_left_cancel₀ hk hcancel
+
+-- ============================================================
+-- Layer 3: The altitude decomposition, realised in a Euclidean model
+-- ============================================================
+
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
+
+/-- The one-line inner-product identity that a Euclidean model already contains:
+for a right angle at `C` (i.e. `⟪A - C, B - C⟫ = 0`), the hypotenuse squared equals the
+sum of the leg squares. This is the metric form of Pythagoras. -/
+theorem pythagorean_core (A B C : F) (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    ‖A - B‖ ^ 2 = ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2 := by
+  have hAB : A - B = (A - C) - (B - C) := by abel
+  rw [hAB, norm_sub_sq_real, hperp]
+  ring
+
+/-- The foot of the altitude dropped from the right-angle vertex `C` onto the hypotenuse
+`AB`, expressed as an explicit affine combination of `A` and `B`. The parameter
+`t = |CA|² / |AB|²` is the classical similar-triangle ratio. -/
+noncomputable def altitudeFoot (A B C : F) : F :=
+  A + (‖A - C‖ ^ 2 / ‖A - B‖ ^ 2) • (B - A)
+
+section Altitude
+variable (A B C : F) (hAB : A ≠ B)
+
+omit [InnerProductSpace ℝ F] in
+private theorem hnorm_pos (hAB : A ≠ B) : (0 : ℝ) < ‖A - B‖ ^ 2 := by
+  have : A - B ≠ 0 := sub_ne_zero.mpr hAB
+  positivity
+
+omit [InnerProductSpace ℝ F] in
+private theorem hnorm_ne (hAB : A ≠ B) : ‖A - B‖ ≠ 0 := by
+  have : A - B ≠ 0 := sub_ne_zero.mpr hAB
+  simpa using norm_ne_zero_iff.mpr this
+
+include hAB in
+/-- The altitude is perpendicular to the hypotenuse: `⟪C - H, A - B⟫ = 0`.
+This is the defining property of the foot of the altitude. -/
+theorem foot_perp (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    ⟪C - altitudeFoot A B C, A - B⟫ = (0 : ℝ) := by
+  have hpos := hnorm_pos A B hAB
+  have hne2 : ‖A - B‖ ^ 2 ≠ 0 := ne_of_gt hpos
+  have hne := hnorm_ne A B hAB
+  set t : ℝ := ‖A - C‖ ^ 2 / ‖A - B‖ ^ 2 with ht
+  have hCH : C - altitudeFoot A B C = (C - A) - t • (B - A) := by
+    unfold altitudeFoot; rw [← ht]; abel
+  rw [hCH, inner_sub_left, real_inner_smul_left]
+  -- ⟪C - A, A - B⟫ - t * ⟪B - A, A - B⟫ = 0
+  have e1 : ⟪C - A, A - B⟫ = -‖A - C‖ ^ 2 := by
+    have hexp : C - A = -(A - C) := by abel
+    have hAB2 : A - B = (A - C) - (B - C) := by abel
+    rw [hexp, hAB2, inner_neg_left, inner_sub_right, real_inner_self_eq_norm_sq,
+      show ⟪A - C, B - C⟫ = (0 : ℝ) from hperp]
+    ring
+  have e2 : ⟪B - A, A - B⟫ = -‖A - B‖ ^ 2 := by
+    have hBA : B - A = -(A - B) := by abel
+    rw [hBA, inner_neg_left, real_inner_self_eq_norm_sq]
+  rw [e1, e2, ht]
+  field_simp
+  ring
+
+include hAB in
+/-- Distance from `A` to the foot equals `t · |AB| = |CA|²/|AB|`. -/
+theorem dist_A_foot :
+    ‖A - altitudeFoot A B C‖ = ‖A - C‖ ^ 2 / ‖A - B‖ := by
+  have hne := hnorm_ne A B hAB
+  set t : ℝ := ‖A - C‖ ^ 2 / ‖A - B‖ ^ 2 with ht
+  have ht0 : 0 ≤ t := by rw [ht]; positivity
+  have hAH : A - altitudeFoot A B C = t • (A - B) := by
+    unfold altitudeFoot; rw [← ht, smul_sub, smul_sub]; abel
+  rw [hAH, norm_smul, Real.norm_eq_abs, abs_of_nonneg ht0, ht]
+  field_simp
+
+include hAB in
+/-- Distance from the foot to `B` equals `(1 - t) · |AB| = |CB|²/|AB|`. -/
+theorem dist_foot_B (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    ‖altitudeFoot A B C - B‖ = ‖B - C‖ ^ 2 / ‖A - B‖ := by
+  have hpos := hnorm_pos A B hAB
+  have hne := hnorm_ne A B hAB
+  have hcore := pythagorean_core A B C hperp
+  set t : ℝ := ‖A - C‖ ^ 2 / ‖A - B‖ ^ 2 with ht
+  have hle : ‖A - C‖ ^ 2 ≤ ‖A - B‖ ^ 2 := by
+    rw [hcore]; nlinarith [sq_nonneg ‖B - C‖]
+  have h1t : 0 ≤ 1 - t := by
+    rw [ht, sub_nonneg, div_le_one hpos]; exact hle
+  have h1mt : 1 - t = ‖B - C‖ ^ 2 / ‖A - B‖ ^ 2 := by
+    rw [ht]; field_simp; linarith [hcore]
+  have hHB : altitudeFoot A B C - B = (1 - t) • (A - B) := by
+    unfold altitudeFoot; rw [← ht, sub_smul, one_smul, smul_sub, smul_sub]; abel
+  rw [hHB, norm_smul, Real.norm_eq_abs, abs_of_nonneg h1t, h1mt]
+  field_simp
+
+end Altitude
+
+section Geometric
+variable (A B C : F) (hAB : A ≠ B)
+
+include hAB in
+/-- **Geometric-mean relation for leg `CA`.** `|CA|² = |AB| · |AH|`.
+This is the numerical form of "sub-triangle `T₁` is similar to `T`". -/
+theorem geometric_mean_A :
+    ‖A - C‖ ^ 2 = ‖A - B‖ * ‖A - altitudeFoot A B C‖ := by
+  have hne := hnorm_ne A B hAB
+  rw [dist_A_foot A B C hAB]
+  field_simp
+
+include hAB in
+/-- **Geometric-mean relation for leg `CB`.** `|CB|² = |AB| · |HB|`.
+This is the numerical form of "sub-triangle `T₂` is similar to `T`". -/
+theorem geometric_mean_B (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    ‖B - C‖ ^ 2 = ‖A - B‖ * ‖altitudeFoot A B C - B‖ := by
+  have hne := hnorm_ne A B hAB
+  rw [dist_foot_B A B C hAB hperp]
+  field_simp
+
+include hAB in
+/-- **Betweenness.** The foot lies inside the hypotenuse: `|AH| + |HB| = |AB|`.
+This is the dissection `Area(T) = Area(T₁) + Area(T₂)` at the level of the base. -/
+theorem segments_sum (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    ‖A - altitudeFoot A B C‖ + ‖altitudeFoot A B C - B‖ = ‖A - B‖ := by
+  have hne := hnorm_ne A B hAB
+  have hcore := pythagorean_core A B C hperp
+  rw [dist_A_foot A B C hAB, dist_foot_B A B C hAB hperp, ← add_div,
+    div_eq_iff hne, ← hcore]
+  ring
+
+include hAB in
+/-- **Pythagoras via the altitude decomposition (Einstein's route).**
+Multiplying the betweenness identity by `|AB|` and substituting the two geometric-mean
+relations rebuilds `|AB|² = |CA|² + |CB|²`:
+`|AB|² = |AB|·(|AH| + |HB|) = |AB|·|AH| + |AB|·|HB| = |CA|² + |CB|²`. -/
+theorem pythagorean_via_altitude (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2 = ‖A - B‖ ^ 2 := by
+  have hgA := geometric_mean_A A B C hAB
+  have hgB := geometric_mean_B A B C hAB hperp
+  have hsum := segments_sum A B C hAB hperp
+  have key : ‖A - B‖ ^ 2
+      = ‖A - B‖ * (‖A - altitudeFoot A B C‖ + ‖altitudeFoot A B C - B‖) := by
+    rw [hsum]; ring
+  rw [key, mul_add, ← hgA, ← hgB]
+
+end Geometric
+
+-- ============================================================
+-- Capstone: the two routes agree
+-- ============================================================
+
+/-- The altitude route reproduces the metric Pythagorean identity (`pythagorean_core`),
+confirming Einstein's similar-triangles decomposition is faithful. -/
+theorem einstein_matches_core (A B C : F) (hAB : A ≠ B)
+    (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2 = ‖A - B‖ ^ 2 ∧
+    ‖A - B‖ ^ 2 = ‖A - C‖ ^ 2 + ‖B - C‖ ^ 2 :=
+  ⟨pythagorean_via_altitude A B C hAB hperp, pythagorean_core A B C hperp⟩
+
+#check @einstein_pythagorean
+#check @pythagorean_via_altitude
+#check @geometric_mean_A
+#check @triArea_scale
+
+end PythagoreanEinstein

--- a/src/data/proofs/pythagorean-theorem-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-pt-oq01-cancel-constant",
+    "proofId": "pythagorean-theorem-oq-01",
+    "range": {
+      "startLine": 96,
+      "endLine": 106
+    },
+    "type": "insight",
+    "title": "Einstein's Proof, With No Geometry: Cancel the Shape Constant",
+    "content": "einstein_pythagorean is the whole of Einstein's argument once the geometry is granted. The altitude splits the right triangle into two pieces similar to the whole, so — because area scales as the square of a linear dimension with a common shape constant k — the three areas are k·h², k·cA², k·cB². Dissection additivity Area(T) = Area(T₁) + Area(T₂) gives k·h² = k·cA² + k·cB², and cancelling the nonzero k (mul_left_cancel₀) yields cA² + cB² = h². This layer is coordinate-free: it never mentions a norm, an inner product, or a triangle — only the three areas and their sum.",
+    "mathContext": "$k h^2 = k c_A^2 + k c_B^2,\\ k \\neq 0 \\implies c_A^2 + c_B^2 = h^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "similar triangles",
+      "area scaling",
+      "shape constant",
+      "dissection of area"
+    ],
+    "prerequisites": [
+      "cancellation in a field",
+      "area of similar figures scales as the square of length"
+    ]
+  },
+  {
+    "id": "ann-pt-oq01-area-square-law",
+    "proofId": "pythagorean-theorem-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 85
+    },
+    "type": "insight",
+    "title": "The One Principle: Area Scales as the Square of Length",
+    "content": "triArea_scale proves triArea (r·b) (r·t) = r²·triArea b t — scaling every linear dimension of a triangle by r multiplies its area by exactly r². This is the single geometric principle Einstein's proof rests on, and it is elementary: from Area = ½·base·height, replacing base by r·base and height by r·height pulls out r². Applied to the three mutually similar triangles in the altitude decomposition (linear ratios cA/h and cB/h relative to the whole), it delivers the areas k·cA² and k·cB² that Layer 2 then cancels.",
+    "mathContext": "$\\mathrm{Area} = \\tfrac12 b h \\implies \\mathrm{Area}(rb, rt) = r^2 \\cdot \\mathrm{Area}(b,t)$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "similarity",
+      "quadratic homogeneity of area",
+      "Euclid VI.31"
+    ],
+    "prerequisites": [
+      "area of a triangle = ½·base·height"
+    ]
+  },
+  {
+    "id": "ann-pt-oq01-altitude-foot",
+    "proofId": "pythagorean-theorem-oq-01",
+    "range": {
+      "startLine": 126,
+      "endLine": 168
+    },
+    "type": "technique",
+    "title": "The Altitude Foot as an Explicit Affine Combination",
+    "content": "Rather than invoke Mathlib's orthogonal-projection API, altitudeFoot A B C := A + (‖A − C‖²/‖A − B‖²)·(B − A) writes the foot H directly as an affine combination of A and B, with parameter t = |CA|²/|AB|² — precisely the similar-triangle ratio. foot_perp then proves ⟪C − H, A − B⟫ = 0 by expanding two inner products: ⟪C − A, A − B⟫ = −‖A − C‖² (using the right angle ⟪A − C, B − C⟫ = 0) and ⟪B − A, A − B⟫ = −‖A − B‖². Substituting t makes the combination vanish, confirming H is genuinely the altitude foot. Everything downstream is then a direct computation with no projection machinery.",
+    "mathContext": "$H = A + \\frac{|CA|^2}{|AB|^2}(B-A),\\quad \\langle C-H,\\ A-B\\rangle = 0$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "orthogonal projection",
+      "altitude of a triangle",
+      "affine combination",
+      "inner-product expansion"
+    ],
+    "prerequisites": [
+      "linearity of the inner product (inner_sub_left/right, real_inner_smul_left)",
+      "real_inner_self_eq_norm_sq"
+    ]
+  },
+  {
+    "id": "ann-pt-oq01-geometric-means",
+    "proofId": "pythagorean-theorem-oq-01",
+    "range": {
+      "startLine": 207,
+      "endLine": 236
+    },
+    "type": "insight",
+    "title": "Geometric-Mean Relations: the Fingerprint of Similarity",
+    "content": "geometric_mean_A and geometric_mean_B prove |CA|² = |AB|·|AH| and |CB|² = |AB|·|HB|. These are exactly Euclid's altitude-on-hypotenuse lemmas, and they are the numerical content of 'each sub-triangle is similar to the whole': in the similar triangle on leg CA, the leg corresponds to the hypotenuse of T, and the projected segment AH corresponds to CA, giving the proportion |AH|/|CA| = |CA|/|AB|. The proofs compute the segment lengths from the explicit foot: |AH| = |CA|²/|AB| and |HB| = |CB|²/|AB| via norm_smul. Betweenness segments_sum (|AH| + |HB| = |AB|) then follows since (|CA|² + |CB|²)/|AB| = |AB| by pythagorean_core.",
+    "mathContext": "$|CA|^2 = |AB|\\,|AH|,\\quad |CB|^2 = |AB|\\,|HB|,\\quad |AH| + |HB| = |AB|$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "geometric mean",
+      "Euclid VI (altitude-on-hypotenuse)",
+      "similar triangles",
+      "betweenness"
+    ],
+    "prerequisites": [
+      "norm of a scalar multiple (norm_smul)",
+      "the metric Pythagorean identity pythagorean_core"
+    ]
+  },
+  {
+    "id": "ann-pt-oq01-reassembly",
+    "proofId": "pythagorean-theorem-oq-01",
+    "range": {
+      "startLine": 238,
+      "endLine": 247
+    },
+    "type": "insight",
+    "title": "Reassembling Pythagoras from the Altitude",
+    "content": "pythagorean_via_altitude is the payoff: multiplying betweenness |AH| + |HB| = |AB| by |AB| gives |AB|² = |AB|·|AH| + |AB|·|HB|, and substituting the two geometric-mean relations turns the right-hand side into |CA|² + |CB|². This rebuilds the Pythagorean identity through the altitude decomposition rather than through the bare polarization line. einstein_matches_core records that this route and pythagorean_core prove the same thing. Honesty note: in a fixed inner-product model the norm already encodes distance, so pythagorean_core is itself Pythagoras and the altitude layer is a faithful re-derivation, not a foundationally independent proof — its value is that it verifies the decomposition Einstein actually used.",
+    "mathContext": "$|AB|^2 = |AB|(|AH|+|HB|) = |CA|^2 + |CB|^2$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "similar-triangles proof",
+      "geometric mean",
+      "polarization identity"
+    ],
+    "prerequisites": [
+      "geometric_mean_A / geometric_mean_B",
+      "segments_sum"
+    ]
+  }
+]

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "pythagorean-theorem-oq-01",
+  "title": "Pythagorean Theorem OQ-01: The Simplest Proof — Einstein's Similar-Triangles Argument",
+  "slug": "pythagorean-theorem-oq-01",
+  "description": "A machine-checked reconstruction of the proof Albert Einstein reportedly found as a boy, widely cited as one of the simplest: drop a single altitude from the right angle onto the hypotenuse and invoke one principle — the area of similar figures scales as the square of any linear dimension. The proof is isolated into three verified layers. Layer 1 (triArea_scale) proves the area–square law from Area = ½·base·height. Layer 2 (einstein_pythagorean) is the coordinate-free algebraic skeleton: given the three similar areas k·cA², k·cB², k·h² and the dissection Area(T) = Area(T₁) + Area(T₂), cancelling the shape constant k yields cA² + cB² = h². Layer 3 realises the altitude decomposition explicitly in a real inner-product space: the altitude foot H is constructed, proved perpendicular to the hypotenuse (foot_perp), and the two geometric-mean relations cA² = h·|AH|, cB² = h·|HB| together with betweenness |AH| + |HB| = h are verified, reconstructing h² = cA² + cB². 13 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-09",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTheoremOQ01.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "inner-product",
+      "similar-triangles",
+      "einstein",
+      "geometric-mean",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-09",
+    "axiomCount": 0,
+    "assumptions": "None. All theorems are fully machine-checked, depending only on propext, Classical.choice, and Quot.sound. Layer 3 works in a general real inner-product space; the right angle is supplied as the explicit hypothesis ⟪A − C, B − C⟫ = 0 and non-degeneracy as A ≠ B. Honesty note: once a Euclidean/inner-product model is fixed, the norm already encodes distance, so the one-line identity pythagorean_core (‖A−B‖² = ‖A−C‖² + ‖B−C‖²) is itself Pythagoras; Layer 3 does not claim foundational independence from it — its content is the verified geometric-mean/altitude decomposition. Layers 1 and 2 capture the parts of Einstein's reasoning genuinely independent of coordinates.",
+    "lineCount": 267,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "originalContributions": [
+      "einstein_pythagorean: the coordinate-free algebraic core of Einstein's proof — from areaWhole = k·h², areaA = k·cA², areaB = k·cB² and areaWhole = areaA + areaB with k ≠ 0, cancelling k gives cA² + cB² = h². This is the 'cancel the shape constant' step, verified with no geometry.",
+      "triArea_scale: the single geometric principle Einstein relies on — scaling every linear dimension of a triangle by r scales its area by exactly r² (triArea (r·b) (r·t) = r²·triArea b t), proved from Area = ½·base·height.",
+      "altitudeFoot / foot_perp: an explicit affine-combination construction of the foot H of the altitude from the right-angle vertex C onto the hypotenuse AB (H = A + (|CA|²/|AB|²)·(B − A)), together with a proof that C − H ⊥ A − B, so H is genuinely the altitude foot.",
+      "geometric_mean_A / geometric_mean_B: the two geometric-mean relations |CA|² = |AB|·|AH| and |CB|² = |AB|·|HB|, the numerical shadow of 'the two sub-triangles are similar to the whole', proved by computing |AH| = |CA|²/|AB| and |HB| = |CB|²/|AB| from the explicit foot.",
+      "segments_sum: betweenness |AH| + |HB| = |AB| — the foot lies inside the hypotenuse, i.e. the dissection Area(T) = Area(T₁) + Area(T₂) at the level of the base.",
+      "pythagorean_via_altitude: Einstein's route assembled — |AB|² = |AB|·(|AH| + |HB|) = |AB|·|AH| + |AB|·|HB| = |CA|² + |CB|², reconstructing Pythagoras from the altitude decomposition rather than from the bare polarization identity.",
+      "einstein_matches_core: the altitude route (pythagorean_via_altitude) reproduces the one-line metric identity (pythagorean_core), confirming the similar-triangles decomposition is faithful."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Pythagorean theorem has over 300 recorded proofs, and a recurring question — the one this entry addresses — is which is the *simplest*. A favourite candidate is the similar-triangles proof, in the streamlined form Albert Einstein is said to have discovered as a twelve-year-old (recounted in his Autobiographical Notes and popularized by Manfred Schroeder and others). Its economy comes from using no auxiliary square or rearrangement — only one altitude and one scaling principle. Drop the perpendicular from the right-angle vertex to the hypotenuse; it cuts the right triangle into two smaller triangles, each similar to the original. Because the area of similar figures is proportional to the square of any corresponding length with a common shape constant, the three areas are k·cA², k·cB², k·h²; additivity gives k·h² = k·cA² + k·cB², and the constant cancels. Euclid's Elements VI.31 is the classical ancestor of this argument (Pythagoras for arbitrary similar figures on the three sides), and the geometric-mean relations |CA|² = |AB|·|AH| are exactly Euclid's altitude-on-hypotenuse lemmas.",
+    "problemStatement": "Formalize the similar-triangles ('Einstein') proof of the Pythagorean theorem, separating the parts that are genuinely independent of coordinates (the area–square scaling law and the algebraic cancellation of the shape constant) from the metric altitude decomposition realised in a Euclidean model, and verify each with zero axioms and zero sorries.",
+    "text": "Einstein's proof rests on a single physical principle: area scales as the square of a linear dimension, with the same constant for all figures of the same shape. The altitude from the right angle to the hypotenuse partitions the right triangle T (legs cA, cB, hypotenuse h) into two triangles T₁, T₂, each similar to T; in T₁ the side playing the role of T's hypotenuse is the leg cA, in T₂ it is cB. Hence Area(T) = k·h², Area(T₁) = k·cA², Area(T₂) = k·cB² for a shared shape constant k, and dissection additivity Area(T) = Area(T₁) + Area(T₂) forces k·h² = k·cA² + k·cB². Cancelling the nonzero k gives h² = cA² + cB². The entry verifies this skeleton coordinate-free, then grounds the geometry: the altitude foot H is built as an explicit affine combination of A and B, proved perpendicular to the hypotenuse, and the two geometric-mean relations |CA|² = |AB|·|AH|, |CB|² = |AB|·|HB| together with betweenness |AH| + |HB| = |AB| are proved — the exact metric content of the two similar sub-triangles — reassembling |AB|² = |CA|² + |CB|².",
+    "proofStrategy": "Layer 1 proves triArea_scale by ring from triArea b t = b·t/2. Layer 2 proves einstein_pythagorean by substituting the three area expressions into the dissection identity and cancelling k with mul_left_cancel₀. Layer 3 works in a real inner-product space F. pythagorean_core expands ‖A − B‖² = ‖(A − C) − (B − C)‖² with norm_sub_sq_real and the right-angle hypothesis ⟪A − C, B − C⟫ = 0. altitudeFoot A B C := A + (‖A − C‖²/‖A − B‖²)·(B − A); foot_perp shows ⟪C − H, A − B⟫ = 0 by expanding the two inner products ⟪C − A, A − B⟫ = −‖A − C‖² and ⟪B − A, A − B⟫ = −‖A − B‖². dist_A_foot and dist_foot_B compute the segment lengths ‖A − H‖ = ‖A − C‖²/‖A − B‖ and ‖H − B‖ = ‖B − C‖²/‖A − B‖ via norm_smul, using pythagorean_core to see 1 − t = ‖B − C‖²/‖A − B‖² ≥ 0. geometric_mean_A/B and segments_sum are then field_simp/ring consequences, and pythagorean_via_altitude multiplies betweenness by ‖A − B‖ and substitutes the geometric means.",
+    "keyInsights": [
+      "Einstein's proof factors cleanly into a coordinate-free part and a metric part: the area–square scaling law (triArea_scale) and the shape-constant cancellation (einstein_pythagorean) need no geometry at all, while only the identification of the sub-triangles' similarity ratios is genuinely metric — this separation is what the formalization makes precise.",
+      "The two geometric-mean relations |CA|² = |AB|·|AH| and |CB|² = |AB|·|HB| are the numerical fingerprint of 'each sub-triangle is similar to the whole'; summing them (via betweenness |AH| + |HB| = |AB|) rebuilds Pythagoras — this is Euclid VI.31 / the altitude-on-hypotenuse lemma in checked form.",
+      "The altitude foot has a closed affine form H = A + (|CA|²/|AB|²)·(B − A) whose parameter t = |CA|²/|AB|² is exactly the similar-triangle ratio; everything about the decomposition follows by direct inner-product computation, with no appeal to Mathlib's orthogonal-projection machinery.",
+      "In a fixed inner-product model the norm already encodes Pythagoras (pythagorean_core is a one-line polarization identity), so no coordinate proof can be foundationally 'simpler' than that line; the value of the similar-triangles formalization is didactic and structural — it verifies the decomposition Einstein actually used, not a shortcut.",
+      "1 − t = |CB|²/|AB|² is where the right angle re-enters: proving the second segment length and betweenness both require ‖A − C‖² ≤ ‖A − B‖², i.e. pythagorean_core, so the metric layer is honestly a consequence of the polarization identity rather than an independent derivation."
+    ],
+    "prerequisites": [
+      "Real inner-product spaces: real_inner_self_eq_norm_sq, norm_sub_sq_real, inner_sub_left/right, real_inner_smul_left",
+      "Norms of scalar multiples (norm_smul, Real.norm_eq_abs) and basic field manipulation (field_simp, div_eq_iff)",
+      "The notion of the foot of an altitude and Euclid's altitude-on-hypotenuse (geometric-mean) relations",
+      "Similarity of figures and the principle that area scales as the square of a linear dimension"
+    ]
+  },
+  "conclusion": {
+    "summary": "A fully machine-verified, axiom-free formalization of Einstein's similar-triangles proof of the Pythagorean theorem — a leading answer to 'what is the simplest proof'. The argument is split into three verified layers: the area–square scaling law, the coordinate-free cancellation of the shape constant, and the explicit altitude/geometric-mean decomposition in a real inner-product space, which reassembles ‖A − B‖² = ‖A − C‖² + ‖B − C‖² and is shown to match the one-line metric identity. 13 theorems, 0 axioms, 0 sorries.",
+    "implications": "The entry documents, in checked form, exactly which parts of the 'simplest proof' are genuinely geometric and which are pure algebra: the area–square law and the shape-constant cancellation are coordinate-free, while only the similarity ratios of the two sub-triangles are metric. The reusable pieces — the explicit altitudeFoot construction, foot_perp, and the geometric-mean relations geometric_mean_A/B — are the altitude-on-hypotenuse lemmas of Euclid VI, useful for further Euclidean-geometry formalizations (e.g. the altitude, leg, and geometric-mean theorems as a family). It complements the gallery's inner-product Pythagorean entry (the polarization one-liner) and the flat-limit entry OQ-05 (the differential-geometric viewpoint) by supplying the classical similar-triangles viewpoint.",
+    "openQuestions": [
+      "Realise the shape constant k concretely: prove 'area of a right triangle = k·(hypotenuse)² for a fixed shape' directly from ½·base·height and similarity, closing the loop between Layer 1 and Layer 2 without reusing pythagorean_core.",
+      "Give a fully synthetic (axiomatic-geometry) version in which lengths are not defined via a coordinate norm, so that the similar-triangles argument becomes a genuinely independent proof of Pythagoras rather than a consequence of the polarization identity.",
+      "Formalize the other members of the altitude family — the leg theorem, the altitude (geometric-mean) theorem h_alt² = |AH|·|HB|, and Euclid VI.31 for arbitrary similar figures on the three sides — as corollaries of the altitudeFoot construction.",
+      "Compare, in checked form, the 'simplicity' of competing proofs (rearrangement/dissection, Garfield's trapezoid, the inner-product one-liner) by a common metric such as proof length or dependency depth."
+    ]
+  },
+  "leanFile": {
+    "namespace": "PythagoreanEinstein",
+    "lineCount": 267,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "path": "Proofs/PythagoreanTheoremOQ01.lean",
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.InnerProductSpace.PiL2",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "RealInnerProductSpace"
+    ],
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "extends",
+      "description": "The classical Euclidean theorem a² + b² = c², proved in the gallery via the inner-product polarization identity. This entry gives the similar-triangles ('Einstein') proof of the same identity, isolating the area–square scaling law and the altitude/geometric-mean decomposition, and shows the altitude route reproduces the polarization one-liner."
+    },
+    {
+      "targetId": "pythagorean-theorem-oq-05",
+      "relationship": "related",
+      "description": "OQ-05 gives the analytic/differential-geometric viewpoint (Pythagoras as the flat limit of the spherical and hyperbolic laws). OQ-01 gives the classical synthetic viewpoint (the similar-triangles proof), so the two entries present the metric-geometry and curvature-degeneration angles on the same theorem."
+    }
+  ],
+  "sections": [
+    {
+      "id": "area-square-law",
+      "title": "Layer 1: The area–square law for similar triangles",
+      "startLine": 1,
+      "endLine": 85,
+      "summary": "triArea b t = ½·base·height, and triArea_scale proves the one principle Einstein uses: scaling every linear dimension by r scales area by exactly r² (triArea (r·b) (r·t) = r²·triArea b t)."
+    },
+    {
+      "id": "algebraic-skeleton",
+      "title": "Layer 2: The algebraic skeleton — cancel the shape constant",
+      "startLine": 86,
+      "endLine": 107,
+      "summary": "einstein_pythagorean: given the three similar areas k·h², k·cA², k·cB² and the dissection Area(T) = Area(T₁) + Area(T₂), cancelling the nonzero shape constant k yields cA² + cB² = h². No coordinates are used."
+    },
+    {
+      "id": "pythagorean-core",
+      "title": "Layer 3a: The metric identity a Euclidean model already contains",
+      "startLine": 108,
+      "endLine": 124,
+      "summary": "pythagorean_core: for a right angle at C (⟪A − C, B − C⟫ = 0), ‖A − B‖² = ‖A − C‖² + ‖B − C‖², expanded from norm_sub_sq_real. This is the one-line polarization form of Pythagoras."
+    },
+    {
+      "id": "altitude-foot",
+      "title": "Layer 3b: The altitude foot and its perpendicularity",
+      "startLine": 125,
+      "endLine": 199,
+      "summary": "altitudeFoot A B C = A + (|CA|²/|AB|²)·(B − A) constructs the foot H explicitly; foot_perp proves C − H ⊥ A − B; dist_A_foot and dist_foot_B compute the two segment lengths |AH| = |CA|²/|AB| and |HB| = |CB|²/|AB|, the second using pythagorean_core to see 1 − t = |CB|²/|AB|² ≥ 0."
+    },
+    {
+      "id": "geometric-means",
+      "title": "Layer 3c: Geometric-mean relations, betweenness, and reassembly",
+      "startLine": 200,
+      "endLine": 248,
+      "summary": "geometric_mean_A/B prove |CA|² = |AB|·|AH| and |CB|² = |AB|·|HB| (the similar-sub-triangle fingerprint); segments_sum proves |AH| + |HB| = |AB|; pythagorean_via_altitude multiplies betweenness by |AB| and substitutes the geometric means to rebuild |AB|² = |CA|² + |CB|²."
+    },
+    {
+      "id": "capstone",
+      "title": "Capstone: the two routes agree",
+      "startLine": 249,
+      "endLine": 267,
+      "summary": "einstein_matches_core packages that the altitude route (pythagorean_via_altitude) and the polarization one-liner (pythagorean_core) prove the same identity, confirming the similar-triangles decomposition is faithful."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/pythagorean-theorem-oq-01.json
+++ b/src/data/research/problems/pythagorean-theorem-oq-01.json
@@ -42,21 +42,26 @@
     "progressSummary": "AXIOM REDUCTION: PythagoreanTriplesOQ01.lean 6→3 axioms. Removed 3 unused supplementary axioms (r2_average_order was additionally FALSE as stated — nonneg-pair average order is π/4 not π). Remaining 3 are the load-bearing Gauss-circle/Möbius/parity assumptions. Full docker verification memory-blocked (>90GB for fresh elaboration; change is compile-safe removal of unused decls).",
     "builtItems": [
       "sin_eq_sinc_mul, tendsto_one_sub_cos_mul_div_sq, tendsto_cos_mul_one, tendsto_one_sub_cos_prod_div_sq, spherical_flat_limit in Proofs/PythagoreanTheoremOQ05.lean (0 sorry, 0 axioms, verified via lake env lean 4.26.0)",
-      "Removed 3 unused axioms from Proofs/PythagoreanTriplesOQ01.lean (r2_average_order [false as stated], landau_two_squares, primitive_by_leg_density), reducing 6→3; content retained as documented targets. Updated meta.json axiomCount 6→3 in both stat blocks + assumptions/keyStatements/annotations."
+      "Removed 3 unused axioms from Proofs/PythagoreanTriplesOQ01.lean (r2_average_order [false as stated], landau_two_squares, primitive_by_leg_density), reducing 6→3; content retained as documented targets. Updated meta.json axiomCount 6→3 in both stat blocks + assumptions/keyStatements/annotations.",
+      "PythagoreanTheoremOQ01.lean: Einstein's similar-triangles proof, verified (0 axioms, 0 sorries, 13 theorems) via docker-build Lean 4.26.0. Three layers: triArea_scale (area-square law), einstein_pythagorean (coordinate-free cancel-the-shape-constant skeleton), and an inner-product altitude decomposition (altitudeFoot, foot_perp, geometric_mean_A/B, segments_sum, pythagorean_via_altitude, einstein_matches_core). Gallery entry src/data/proofs/pythagorean-theorem-oq-01. PR #36241."
     ],
     "insights": [
       "Spherical flat limit: from cos(tc)=cos(ta)cos(tb) ∀t>0, c²=a²+b² follows by the exact identity (1-cos(tx))/t² = (x²/2)·sinc(tx/2)², using half-angle 1-cos(tx)=2sin(tx/2)² and sin u = sinc u · u; sinc continuity (sinc 0 = 1) gives the limit. No range restriction on a,b,c needed.",
       "This sinc-identity route is cleaner than the hyperbolic squeeze: it avoids all monotonicity/second-derivative machinery and reduces the limit to continuity of Real.sinc at 0.",
       "PythagoreanTriplesOQ01.lean had 6 axioms but only 3 (sector_lattice_point_density, coprime_fraction_in_sector, bothOdd_fraction_in_coprime_sector) are consumed by the main density theorem; the other 3 were decorative/unused.",
-      "The `r2_average_order` axiom was FALSE as stated: this file's `r2` counts nonnegative ordered pairs (quarter disk), so Σ_{n≤N} r2(n) ~ (π/4)N and the average order → π/4, not π. The axiom conflated it with the full-plane signed r₂ (whose disk sum ~ πN). An unused false axiom is a latent unsoundness (π = π/4 derivable)."
+      "The `r2_average_order` axiom was FALSE as stated: this file's `r2` counts nonnegative ordered pairs (quarter disk), so Σ_{n≤N} r2(n) ~ (π/4)N and the average order → π/4, not π. The axiom conflated it with the full-plane signed r₂ (whose disk sum ~ πN). An unused false axiom is a latent unsoundness (π = π/4 derivable).",
+      "Einstein's 'simplest proof' factors into a coordinate-free part (area scales as square of linear dimension + cancel the shared shape constant k) and a metric part (the two sub-triangles' similarity ratios). Only the metric part touches a norm.",
+      "The two geometric-mean relations |CA|^2 = |AB|*|AH| and |CB|^2 = |AB|*|HB| (Euclid VI altitude-on-hypotenuse) are the numerical fingerprint of the similar sub-triangles; summing them via betweenness |AH|+|HB|=|AB| rebuilds Pythagoras.",
+      "The altitude foot has a closed affine form H = A + (|CA|^2/|AB|^2)*(B-A) whose parameter t is the similar-triangle ratio; the whole decomposition follows by direct inner-product computation, no Mathlib orthogonalProjection needed.",
+      "Honesty limit: in a fixed inner-product model the norm already encodes Pythagoras (pythagorean_core is a one-line polarization), so no coordinate proof is foundationally 'simpler' than that line; a genuinely independent 'simplest proof' would require synthetic axiomatic geometry where length is not defined via a coordinate norm."
     ],
     "mathlibGaps": [
       "Mathlib cache drift broke the existing hyperbolic section: le_div_iff→le_div_iff₀, div_le_div_iff→div_le_div_iff₀, Filter.eventually_nhdsWithin_of_forall→eventually_nhdsWithin_of_forall, Tendsto.congr! argument order (eventuallyEq first), pointwise squeeze tendsto_of_tendsto_of_tendsto_of_le_of_le→eventually variant (prime), HasDerivAt.sub of a const now yields x-0 (needs simpa/convert), and let-bound f 0 = 0 no longer closes by bare simp (needs show)."
     ],
     "nextSteps": [
-      "Optionally create a gallery entry (src/data/proofs/pythagorean-theorem-oq-05) for the now-complete flat-limit file.",
-      "Audit sibling pythagorean files (OQ03 etc.) for the same Mathlib drift.",
-      "Future: prove the corrected quarter-disk average order (→π/4) once Mathlib gains lattice-point-counting / Gauss-circle infrastructure; likewise Landau–Ramanujan and leg-density."
+      "Realise the shape constant k concretely (area of a right triangle = k*(hyp)^2 for fixed shape) from 1/2*base*height + similarity, without reusing pythagorean_core, to close the Layer1<->Layer2 loop.",
+      "Give a fully synthetic (axiomatic-geometry) version where length is not a coordinate norm, making the similar-triangles argument a genuinely independent proof of Pythagoras.",
+      "Formalize the rest of the altitude family (leg theorem, altitude geometric-mean h^2=|AH|*|HB|, Euclid VI.31 for arbitrary similar figures on the three sides) as corollaries of altitudeFoot."
     ],
     "markdown": "# Knowledge Base: pythagorean-theorem-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -80,7 +85,7 @@
     "mathlib": []
   },
   "started": "2026-04-06T06:37:41.264Z",
-  "lastUpdate": "2026-06-27T13:30:00.000Z",
+  "lastUpdate": "2026-07-09T21:20:00.000Z",
   "significance": 7,
   "tractability": 7,
   "leanFiles": [


### PR DESCRIPTION
## Open question

**pythagorean-theorem-oq-01** — *What's the simplest possible proof of the Pythagorean theorem? (Candidates include Einstein's similar-triangles proof.)*

This PR formalizes that candidate: the proof Albert Einstein reportedly found as a boy, using one altitude and one principle (area of similar figures scales as the square of a linear dimension).

## What's added

`proofs/Proofs/PythagoreanTheoremOQ01.lean` — **0 axioms, 0 sorries, 13 theorems, 2 defs**, verified via `docker-build.sh` (Lean 4.26.0, 3058 jobs). The argument is split into three verified layers:

| Layer | Result | Content |
|-------|--------|---------|
| 1 | `triArea_scale` | Area–square scaling law: `triArea (r·b) (r·t) = r²·triArea b t`, from `Area = ½·base·height`. The one geometric principle Einstein uses. |
| 2 | `einstein_pythagorean` | Coordinate-free algebraic skeleton: from `k·h² = k·cA² + k·cB²` with `k ≠ 0`, cancel the shape constant → `cA² + cB² = h²`. |
| 3 | `altitudeFoot`, `foot_perp`, `geometric_mean_A/B`, `segments_sum`, `pythagorean_via_altitude` | Altitude decomposition in a real inner-product space: explicit foot `H = A + (‖A−C‖²/‖A−B‖²)·(B−A)`, proof `C−H ⊥ A−B`, geometric-mean relations `cA² = h·|AH|`, `cB² = h·|HB|`, betweenness `|AH|+|HB| = h`, reassembled into `h² = cA² + cB²`. |

`einstein_matches_core` shows the altitude route reproduces the one-line polarization identity `pythagorean_core`.

## Honesty note

Once a Euclidean/inner-product model is fixed, the norm already encodes distance, so `pythagorean_core` (`‖A−B‖² = ‖A−C‖² + ‖B−C‖²`) *is* Pythagoras. Layer 3 does not claim foundational independence from it — its value is that it verifies the **geometric-mean / altitude decomposition** (Euclid VI altitude-on-hypotenuse) that Einstein actually used, not a shortcut. Layers 1 and 2 capture the parts of Einstein's reasoning genuinely independent of coordinates. This is stated in the file docstring, the gallery `assumptions` field, and an annotation.

## Gallery entry

`src/data/proofs/pythagorean-theorem-oq-01/` (meta.json + annotations.json), status `verified`, within size caps; passes `gallery:check-size` and is not flagged by `annotations:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)