### PR TITLE
Enrich Pell general norm form (pell-equation-oq-04): add preamble section for full file coverage

### DIFF
--- a/src/data/proofs/pell-equation-oq-04/meta.json
+++ b/src/data/proofs/pell-equation-oq-04/meta.json
@@ -121,6 +121,14 @@
   },
   "sections": [
     {
+      "id": "module-header-and-definitions",
+      "title": "Module Header, the Norm Form & Composition",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "The module docstring frames the open question — generalizing Pell's equation from x²−Dy²=1 to the general norm form x²−Dy²=N for arbitrary N — and lays out the multiplicative/group-action skeleton the file builds (Brahmagupta–Fibonacci multiplicativity, composition of solutions, the Pell group of norm-1 solutions acting on every N, and the no-solutions-or-infinitely-many dichotomy), together with its honest scope (orbit classification / genus theory is not attempted). After `import Mathlib` and `namespace PellEquationOQ04`, the two core definitions are given: `normForm D x y = x² − D y²` (the norm of x + y√D in ℤ[√D], so the equation is `normForm D x y = N`) and `comp D p q` (multiplication in ℤ[√D], (x+y√D)(u+v√D) = (xu+Dyv) + (xv+yu)√D), with the `@[simp]` accessors comp_fst / comp_snd.",
+      "mathContext": "$\\mathrm{normForm}\\,D\\,x\\,y = x^2 - D y^2 = N(x + y\\sqrt{D})$; $\\mathrm{comp}\\,D$ is multiplication in $\\mathbb{Z}[\\sqrt{D}]$: $(x+y\\sqrt D)(u+v\\sqrt D) = (xu+Dyv) + (xv+yu)\\sqrt D$."
+    },
+    {
       "id": "multiplicativity",
       "title": "Multiplicativity of the Norm Form",
       "startLine": 64,


### PR DESCRIPTION
## Enrichment pass

The `sections` array started at line 64, leaving lines **1-63** uncovered — the module docstring, imports, namespace, and the two core definitions (`normForm D x y = x² − D y²` and `comp D p q`, multiplication in ℤ[√D], with their `@[simp]` accessors).

Add a **"Module Header, the Norm Form & Composition"** section (1-63) so sections span the full 251-line file:

| Section | Lines |
|---|---|
| Module Header, the Norm Form & Composition | 1-63 |
| Multiplicativity of the Norm Form | 64-96 |
| The Pell Group of Norm-1 Solutions | 97-167 |
| Infinitude from a Single Seed | 168-251 |

The new section summarizes the open-question framing (generalizing x²−Dy²=1 to arbitrary N), the multiplicative/group-action skeleton, the honest scope, and the two definitions with a matching `mathContext`.

meta.json: 15.9 KB (within the ~60 KB cap). Purely additive section coverage.