### PR TITLE
Enrich Hilbert-17 Robinson rational-SOS: Pfister-bound cross-reference

### DIFF
--- a/src/data/proofs/hilbert-17-oq-03-oq-06/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-06/meta.json
@@ -188,6 +188,11 @@
       "targetId": "hilbert-17-oq-03-oq-01",
       "relationship": "complements",
       "description": "The analogous constructive rational-SOS certificate for the Motzkin polynomial. Together the two entries realize Artin's theorem for both canonical extremal examples — the bivariate Motzkin form and the ternary Robinson form — and this entry answers that one's open question of generalizing the SDP-certificate pipeline to Robinson."
+    },
+    {
+      "targetId": "hilbert-17-oq-01",
+      "relationship": "relates",
+      "description": "Pfister's theorem bounds the number of rational-function squares needed to represent a nonnegative form in n variables by 2ⁿ. For Robinson (n=3) that bound is 8, whereas the un-optimized certificate here uses 21 = 7×3 squares — quantifying the gap between this explicit witness and the theoretical minimum, and framing the entry's first open question."
     }
   ],
   "sections": [


### PR DESCRIPTION
Enrichment pass for `hilbert-17-oq-03-oq-06`.

This entry was already at the quality ceiling (9 fully-populated annotations, rich overview/conclusion, sections covering the full 191-line Lean file, all fields verified accurate against `Proofs/Hilbert17RobinsonRationalSOS.lean`). The single genuine gap was a **consistency** one: `crossReferences` listed only 2 of the 3 related problems already named in `relatedProblems`.

**Change:**
- Added `crossReferences` link to `hilbert-17-oq-01` (Pfister's $2^n$ bound). For Robinson ($n=3$) the bound is 8, versus the 21 = 7×3 un-optimized squares used here — this is exactly the gap framed by keyInsight #5 and the entry's first open question, so the link is navigationally meaningful.

No inflation: no padded insights or duplicated content; meta.json remains well under the 60 KB cap. JSON validated through all gallery-data build stages (enrichment, search-index, loading-facts).