### PR TITLE
Fix: sync stale line/theorem counts (cauchy-interlacing-theorem-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -12,8 +12,8 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
-    "lineCount": 952,
-    "theoremCount": 33,
+    "lineCount": 1006,
+    "theoremCount": 35,
     "definitionCount": 0,
     "difficulty": "advanced",
     "category": "linear-algebra",
@@ -62,9 +62,9 @@
       "CauchyInterlacing.Poincare"
     ],
     "namespace": "CauchyInterlacing.PoincareCompression",
-    "lineCount": 952,
+    "lineCount": 1006,
     "axiomCount": 0,
-    "theoremCount": 33,
+    "theoremCount": 35,
     "definitionCount": 0,
     "path": "Proofs/CauchyInterlacingPoincareCompression.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `lineCount` and `theoremCount` in `cauchy-interlacing-theorem-oq-01-oq-02/meta.json` to match the actual Lean source.

## Evidence

`proofs/Proofs/CauchyInterlacingPoincareCompression.lean` currently has:
- **1006** lines (`wc -l`), meta claimed **952**
- **35** theorem/lemma declarations (verified by comment-stripped count + raw `grep`), meta claimed **33**

The file grew (research added ~2 theorems / 54 lines) without a corresponding meta sync. `definitionCount` (0), `sorries` (0), and `axiomCount` (0) are unchanged and already correct. Both the `leanFile` block and its mirror block were updated. No `additionalFiles`, so the aggregate equals the main-file count — unambiguous.

**Before**: `lineCount: 952`, `theoremCount: 33`
**After**: `lineCount: 1006`, `theoremCount: 35`

---
Automated fix by lean-mechanic agent.