### PR TITLE
meta(law-of-cosines-oq-03-oq-03): sync meta.json to derived defect (7→6), match merged #36240

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "law-of-cosines-oq-03-oq-03",
   "title": "Hyperbolic AAA Congruence",
   "slug": "law-of-cosines-oq-03-oq-03",
-  "description": "Formalizes hyperbolic AAA congruence: in hyperbolic geometry the three angles determine the triangle, so there are no non-trivial similar triangles. Inverts the second law of cosines to express each side purely in terms of the angles, cosh(c) = (cos C + cos A cos B)/(sin A sin B), then uses injectivity of cosh on [0,∞) to conclude equal angles force equal sides. Also proves an internal-consistency theorem (the angular defect A+B+C<π is exactly what makes the angle formula exceed 1, so cosh c > 1) and a closed form for the equilateral triangle, cosh(side) = cos θ/(1-cos θ). 18 theorems, 1 structure, 7 structure-encoded axioms, 0 sorries.",
+  "description": "Formalizes hyperbolic AAA congruence: in hyperbolic geometry the three angles determine the triangle, so there are no non-trivial similar triangles. Inverts the second law of cosines to express each side purely in terms of the angles, cosh(c) = (cos C + cos A cos B)/(sin A sin B), then uses injectivity of cosh on [0,∞) to conclude equal angles force equal sides. Also proves an internal-consistency theorem (the angular defect A+B+C<π is exactly what makes the angle formula exceed 1, so cosh c > 1) and a closed form for the equilateral triangle, cosh(side) = cos θ/(1-cos θ). The angular defect is derived, not assumed: 6 structure-encoded axioms, 0 sorries.",
   "leanFile": {
     "path": "Proofs/LawOfCosinesOQ03OQ03.lean",
     "namespace": "HyperbolicAAA",
@@ -17,15 +17,15 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 728,
-    "theoremCount": 42,
+    "lineCount": 810,
+    "theoremCount": 45,
     "definitionCount": 2
   },
   "openQuestion": {
     "id": "law-of-cosines-oq-03-oq-03",
     "parentId": "law-of-cosines-oq-03",
     "question": "In hyperbolic geometry, do the three angles of a triangle determine its size, or are there similar (same-angle, different-size) triangles as in Euclidean geometry?",
-    "answer": "AAA congruence holds: the angles determine the triangle. The second hyperbolic law of cosines cos C = -cos A cos B + sin A sin B cosh c inverts to cosh c = (cos C + cos A cos B)/(sin A sin B), a function of the angles alone (and symmetrically for cosh a, cosh b). Since cosh is injective on [0,∞) and side lengths are positive, equal angles force equal sides. There are no non-trivial similar triangles in hyperbolic geometry. The angular defect A+B+C<π is precisely what makes the angle formula exceed 1 (cos(A+B) > cos(π-C) = -cos C), so a valid side cosh c>1 exists. 7 structure-encoded axioms, 0 sorries."
+    "answer": "AAA congruence holds: the angles determine the triangle. The second hyperbolic law of cosines cos C = -cos A cos B + sin A sin B cosh c inverts to cosh c = (cos C + cos A cos B)/(sin A sin B), a function of the angles alone (and symmetrically for cosh a, cosh b). Since cosh is injective on [0,∞) and side lengths are positive, equal angles force equal sides. There are no non-trivial similar triangles in hyperbolic geometry. The angular defect A+B+C<π is precisely what makes the angle formula exceed 1 (cos(A+B) > cos(π-C) = -cos C), so a valid side cosh c>1 exists. The defect itself is derived from the three laws and side positivity, not assumed: 6 structure-encoded axioms, 0 sorries."
   },
   "highlights": [
     "Hyperbolic AAA congruence: equal angles ⟹ equal sides (no similar triangles)",
@@ -38,11 +38,11 @@
     "HyperbolicTriangle.ha: 0 < a (structure field — side length positive)",
     "HyperbolicTriangle.hb: 0 < b (structure field — side length positive)",
     "HyperbolicTriangle.hc: 0 < c (structure field — side length positive)",
-    "HyperbolicTriangle.defect: A+B+C < π (structure field — angular defect)",
     "HyperbolicTriangle.lawA: cos A = -cos B cos C + sin B sin C cosh a (structure field — second law of cosines at A)",
     "HyperbolicTriangle.lawB: cos B = -cos A cos C + sin A sin C cosh b (structure field — second law of cosines at B)",
     "HyperbolicTriangle.lawC: cos C = -cos A cos B + sin A sin B cosh c (structure field — second law of cosines at C)",
-    "Angle-range fields (hA, hB, hC, hA_lt, hB_lt, hC_lt: 0 < A,B,C < π) are additional well-formedness constraints (not counted among the 7 mathematical axioms, consistent with the sibling law-of-sines entry)."
+    "The angular defect A+B+C < π is NOT assumed: it is derived as the theorem HyperbolicTriangle.defect from the three laws and strict side positivity (see PART 1b), reducing the mathematical-assumption count from 7 to 6.",
+    "Angle-range fields (hA, hB, hC, hA_lt, hB_lt, hC_lt: 0 < A,B,C < π) are additional well-formedness constraints (not counted among the 6 mathematical axioms, consistent with the sibling law-of-sines entry)."
   ],
   "implications": [
     {
@@ -92,7 +92,7 @@
       "title": "HyperbolicTriangle Structure",
       "startLine": 66,
       "endLine": 94,
-      "summary": "Defines HyperbolicTriangle with side lengths a,b,c, angles A,B,C, side positivity (ha,hb,hc), angle range bounds (hA,hB,hC and hA_lt,hB_lt,hC_lt), the angular defect (defect: A+B+C<π), and the three second laws of cosines (lawA, lawB, lawC). The 7 mathematical axioms are ha,hb,hc,defect,lawA,lawB,lawC; angle-range fields are domain constraints.",
+      "summary": "Defines HyperbolicTriangle with side lengths a,b,c, angles A,B,C, side positivity (ha,hb,hc), angle range bounds (hA,hB,hC and hA_lt,hB_lt,hC_lt), and the three second laws of cosines (lawA, lawB, lawC). The angular defect A+B+C<π is NOT a field — it is derived as HyperbolicTriangle.defect. The 6 mathematical axioms are ha,hb,hc,lawA,lawB,lawC; angle-range fields are domain constraints.",
       "mathContext": "The second law of cosines cos C = -cos A cos B + sin A sin B cosh c has no Euclidean analogue and is the source of AAA rigidity. Axiomatizing it as a structure field is consistent with the parent LawOfCosinesOQ03 and the sibling law of sines."
     },
     {
@@ -151,6 +151,13 @@
       "statement": "For a hyperbolic triangle t, 0 < sin t.A (and symmetrically sin_B_pos, sin_C_pos).",
       "significance": "Each angle lies strictly in (0, π), so its sine is positive. This is the non-vanishing that licenses dividing by sin A · sin B when inverting the second law of cosines — every later formula depends on it.",
       "description": "Immediate from Real.sin_pos_of_pos_of_lt_pi applied to the structure's angle-bound fields hA and hA_lt."
+    },
+    {
+      "name": "HyperbolicTriangle.defect",
+      "type": "theorem",
+      "statement": "For every hyperbolic triangle t, t.A + t.B + t.C < π.",
+      "significance": "The angular defect is DERIVED, not assumed — it is no longer a structure field. This reduces the structure-encoded assumption count from 7 to 6: side positivity plus the three second laws of cosines already force the angle sum below π. The defect (= area, by Gauss–Bonnet) is therefore a theorem of the hyperbolic metric, not an extra hypothesis.",
+      "description": "Side positivity gives cosh a, cosh c > 1 (Real.one_lt_cosh), so the second-law numerators dominate: sin A sin B < cos C + cos A cos B and sin B sin C < cos A + cos B cos C. The self-contained lemma defect_of_laws closes it: sum-to-product (Real.cos_add_cos) turns each into cos((A+B+C)/2)·cos(half-difference) > 0; since (A+B+C)/2 ∈ [π/2, 3π/2) forces cos ≤ 0 (cos_nonpos_of_pi_div_two_le_of_le) and the products are nonzero, cos((A+B+C)/2) < 0, hence both half-differences exceed π/2 (contrapositive of cos_nonneg_of_neg_pi_div_two_le_of_le), giving A+B−C > π and B+C−A > π whose sum yields B > π, contradicting B < π. #print axioms: only propext, Classical.choice, Quot.sound."
     },
     {
       "name": "sin_B_pos",
@@ -338,10 +345,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Hyperbolic AAA congruence is formalized by inverting the second law of cosines: cosh c = (cos C + cos A cos B)/(sin A sin B) expresses each side as a function of the angles, and injectivity of cosh on [0,∞) turns equal angles into equal sides. An internal-consistency theorem shows the angular defect A+B+C<π is exactly the condition making the formula exceed 1 (cosh c > 1), and the equilateral case yields the closed form cosh(side) = cos θ/(1-cos θ). 7 structure-encoded axioms, 0 sorries.",
+    "summary": "Hyperbolic AAA congruence is formalized by inverting the second law of cosines: cosh c = (cos C + cos A cos B)/(sin A sin B) expresses each side as a function of the angles, and injectivity of cosh on [0,∞) turns equal angles into equal sides. An internal-consistency theorem shows the angular defect A+B+C<π is exactly the condition making the formula exceed 1 (cosh c > 1), and the equilateral case yields the closed form cosh(side) = cos θ/(1-cos θ). The angular defect is now derived rather than assumed: 6 structure-encoded axioms, 0 sorries.",
     "implications": "AAA congruence is the precise sense in which hyperbolic geometry is rigid: there are no similar non-congruent triangles, in sharp contrast to Euclidean geometry. The same inversion underlies the fact that hyperbolic structures on surfaces are determined by their holonomy/angle data, a theme central to Thurston's geometrization. Together with the parent law of cosines and the sibling law of sines, this completes the basic congruence theory of hyperbolic triangles.",
     "openQuestions": [
-      "Derive the three second laws of cosines from a single first law of cosines (and the metric), reducing the structure-encoded axiom count.",
+      "Derive the three second laws of cosines from a single first law of cosines (and the metric), further reducing the structure-encoded axiom count (the angular-defect field has already been eliminated via HyperbolicTriangle.defect, 7→6).",
       "Formalize SAS and ASA congruence for hyperbolic triangles using the same inversion technique.",
       "Quantify the size-from-angles map: prove monotonicity of cosh(side) in the opposite angle and recover the area defect as the integral of the side formulas."
     ]
@@ -376,9 +383,9 @@
       "open-question"
     ],
     "sorries": 0,
-    "axiomCount": 7,
-    "lineCount": 728,
-    "theoremCount": 42,
+    "axiomCount": 6,
+    "lineCount": 810,
+    "theoremCount": 45,
     "definitionCount": 2,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",
@@ -402,7 +409,7 @@
     "sections": [
       {
         "title": "HyperbolicTriangle Structure",
-        "content": "7 mathematical axioms: ha,hb,hc (side positivity), defect (A+B+C<π), lawA,lawB,lawC (second laws of cosines). Angle-range fields are domain constraints.",
+        "content": "6 mathematical axioms: ha,hb,hc (side positivity), lawA,lawB,lawC (second laws of cosines). The angular defect A+B+C<π is derived (HyperbolicTriangle.defect), not assumed. Angle-range fields are domain constraints.",
         "startLine": 66,
         "endLine": 94,
         "theorems": []


### PR DESCRIPTION
## Why

PR #36240 (merged) removed the angular defect as a structure field of `HyperbolicTriangle` and replaced it with the derived theorem `HyperbolicTriangle.defect` — reducing structure-encoded assumptions **7 → 6**. The Lean change landed on `main`, but the accompanying `meta.json` commit was dropped during merge, leaving `main`'s metadata **stale and inconsistent** with the source (it still claims 7 axioms and lists `defect` as a structure field).

This PR resyncs the metadata to the merged `Proofs/LawOfCosinesOQ03OQ03.lean` (verified on main: 810 lines, `theorem HyperbolicTriangle.defect`, no `defect` field).

## Changes (meta.json only)

- `meta.axiomCount` 7 → **6**; `defect` removed from `assumptions[]` with a note it is now *derived* from the three laws + side positivity.
- `lineCount` 728 → **810**, `theoremCount` 42 → **45** on both `meta` and `leanFile`.
- Added `HyperbolicTriangle.defect` to `mainTheorems`.
- Updated `description`, `answer`, structure-section summary, `conclusion`, and the axiom-reduction `nextStep` prose (now notes the defect elimination is done).

## Integrity

Status stays **axiomatized** / badge **axiom** (6 structure-encoded assumptions remain: `ha, hb, hc, lawA, lawB, lawC`). Pure metadata resync — no Lean change. The proof itself is already verified on main (Docker green; `#print axioms` on the new theorems = propext/Classical.choice/Quot.sound only).