### PR TITLE
Fix odd-squares-sum-oq-01: remove shadowed duplicate mainTheorems key

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -3,24 +3,6 @@
   "title": "Sum of Squares of the First n Odd Numbers: ∑(2k−1)² = n(2n−1)(2n+1)/3",
   "slug": "odd-squares-sum-oq-01",
   "description": "A fully machine-checked, self-contained proof that the sum of the squares of the first n odd numbers has the closed form n(2n−1)(2n+1)/3: ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3. The result is established both as a division-free exact identity over ℕ — 3·∑(2k+1)² + n = 4n³, phrased additively so the inductive step has no truncated subtraction and closes by `ring` alone — and as the classical rational closed form over ℚ. This is the odd-indexed companion of the square-pyramidal identity ∑k² = n(n+1)(2n+1)/6, which Mathlib has; this variant it does not.",
-  "mainTheorems": [
-    {
-      "name": "sum_odd_squares_rat",
-      "type": "main",
-      "description": "The classical rational closed form: the sum of the squares of the first n odd numbers is n(2n−1)(2n+1)/3. Proved over ℚ (where the division by 3 is genuine) by induction, with push_cast; ring discharging the cubic step.",
-      "leanType": "(n : ℕ) : ∑ k ∈ range n, (2 * (k : ℚ) + 1) ^ 2 = (n : ℚ) * (2 * n - 1) * (2 * n + 1) / 3",
-      "startLine": 64,
-      "endLine": 72
-    },
-    {
-      "name": "three_mul_sum_odd_squares",
-      "type": "supporting",
-      "description": "The division-free exact ℕ identity 3·∑(2k+1)² + n = 4n³. Its additive phrasing contains no truncated natural subtraction, so the whole inductive step closes by a single ring after one reassociation — the certificate underlying the rational closed form.",
-      "leanType": "(n : ℕ) : 3 * (∑ k ∈ range n, (2 * k + 1) ^ 2) + n = 4 * n ^ 3",
-      "startLine": 46,
-      "endLine": 58
-    }
-  ],
   "leanFile": {
     "path": "Proofs/OddSquaresSum.lean",
     "namespace": "OddSquaresSum",


### PR DESCRIPTION
`meta.json` for `odd-squares-sum-oq-01` had **two top-level `mainTheorems` arrays**. Since `JSON.parse` keeps only the last occurrence of a duplicate key, the first block (`sum_odd_squares_rat`/`three_mul_sum_odd_squares` with types `main`/`supporting`) was dead, shadowed content never rendered by the gallery.

**Change:** removed the shadowed first block, keeping the effective richer block (`three_mul_sum_odd_squares`/`sum_odd_squares_rat` with `core`/`key` types and fuller markdown descriptions) that the gallery already displays.

- No behavior change (the kept block is exactly what `getProofAsync` already parsed).
- Fixes malformed duplicate-key JSON and removes ~18 lines of dead content.
- Verified: single `mainTheorems` key remains, JSON valid, within size caps.