### PR TITLE
Enrich Brouwer analytic no-retraction reduction (brouwer-fixed-point-oq-01-oq-02-oq-01): add preamble section for full file coverage

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/meta.json
@@ -36,6 +36,14 @@
   },
   "sections": [
     {
+      "id": "module-header-and-setup",
+      "title": "Module Header, Imports & Setup",
+      "startLine": 1,
+      "endLine": 89,
+      "summary": "Imports (Euclidean space, Lebesgue/Haar measure, volume of balls, convex-set measure) plus the module docstring and the `open MeasureTheory Metric Set`, `noncomputable section`, `namespace BrouwerAnalytic` setup. The docstring poses the open question — can the companion's three singular-homology axioms for the No-Retraction Theorem be replaced by Mathlib analysis tools via Milnor's measure-theoretic route? — and states the answer: yes for the measure-theoretic scaffolding, 0-axiom, with one precisely-isolated remaining analytic gap. It gives the obstruction (a retraction would map the positive-volume ball onto the measure-zero sphere while a Jacobian/degree argument forces volume preservation), a table mapping each homology axiom to its proved analytic replacement, and an honesty note that continuity alone does not forbid a volume-collapsing surjection — the smooth degree input `hvol` is genuinely needed.",
+      "mathContext": "Milnor's obstruction: a retraction $r : B^n \\to S^{n-1}$ has $\\mathrm{vol}(r(B^n)) = 0$ (sphere is Lebesgue-null) yet a diffeomorphism family forces $\\mathrm{vol}(f_t(B^n))$ constant, contradicting $\\mathrm{vol}(B^n) > 0$; the isolated gap is $\\mathrm{vol}(r(B^n)) = \\mathrm{vol}(B^n)$."
+    },
+    {
       "id": "geometry",
       "title": "Geometry: ball, sphere, and retractions",
       "startLine": 90,
@@ -71,7 +79,7 @@
       "id": "homotopy",
       "title": "Milnor's straight-line homotopy",
       "startLine": 190,
-      "endLine": 226,
+      "endLine": 229,
       "summary": "straightLine f_t = (1-t)·id + t·r with continuous endpoints (f_0 = id, f_1 = r) and the fact that f_t fixes the sphere for every t. This is the family whose volume t ↦ vol(f_t(B^n)) Milnor proves is polynomial in t.",
       "mathContext": "Lays out the analytic program end to end; the polynomiality/degree bookkeeping is the remaining gap named in no_retraction_of_volume_preserved."
     }


### PR DESCRIPTION
## Enrichment pass

The `sections` array covered lines 90-226, leaving the **89-line preamble** (imports, the framing docstring on Milnor's measure-theoretic route and the homology-axiom → analytic-tool replacement table, and the `open`/`namespace` setup) and the closing `end` statements uncovered.

Add a **"Module Header, Imports & Setup"** section (1-89) and extend the last section to line 229, so sections span the full 229-line file (1-89, 90-113, 115-125, 127-175, 177-188, 190-229).

meta.json within the ~60 KB cap. Purely additive section coverage.