### PR TITLE
research(descartes-oq-01-oq-03): general Fin n same-sign ⇒ 0 sign changes + nonneg-coeff corollary [VERIFIED]

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ03.lean
@@ -551,4 +551,64 @@ theorem x2_minus_x_plus_1_signChanges :
 
 end Quadratic
 
+/- ## § 5. General `Fin n` vanishing of the sign-change count (verified, axiom-free)
+
+The length-2 and length-3 lemmas above resolve small cases by enumerating index
+pairs.  One implication, however, holds for *every* length `n`: a sequence whose
+entries all share a sign (all `≥ 0`, or all `≤ 0`) has **no** sign change, because
+`SignChangeBetween` demands a strictly-negative product `f i · f j < 0`.  These are
+the general (arbitrary-`n`) companions of `countSignChanges_two` and
+`countSignChanges_three_mid_zero_zero`, and they yield the "no Descartes sign
+variation from one-signed coefficients" fact for polynomials of *any* degree
+(`signChangesInCoeffs_eq_zero_of_coeff_nonneg`) — the coefficient-side statement
+behind "a polynomial with nonnegative coefficients has no positive roots". -/
+
+/-- **A nonnegative sequence has no sign change.**  For any length `n`, if every
+entry of `f : Fin n → ℝ` is `≥ 0` then `countSignChanges f = 0`: a sign change
+requires a strictly-negative product `f i · f j`, impossible when both factors are
+nonnegative.  Axiom-free, general in `n`. -/
+theorem countSignChanges_eq_zero_of_nonneg {n : ℕ} {f : Fin n → ℝ}
+    (h : ∀ i, 0 ≤ f i) : DescartesRuleOfSigns.countSignChanges f = 0 := by
+  unfold DescartesRuleOfSigns.countSignChanges
+  rw [Finset.card_eq_zero]
+  apply Finset.filter_eq_empty_iff.mpr
+  rintro ⟨i, j⟩ -
+  simp only [decide_eq_true_eq, DescartesRuleOfSigns.SignChangeBetween,
+    DescartesRuleOfSigns.oppositeSign]
+  rintro ⟨-, -, -, -, hopp⟩
+  exact absurd hopp (not_lt.mpr (mul_nonneg (h i) (h j)))
+
+/-- **A nonpositive sequence has no sign change.**  Dual of
+`countSignChanges_eq_zero_of_nonneg`: if every entry of `f : Fin n → ℝ` is `≤ 0`
+then `countSignChanges f = 0` (a product of two nonpositive reals is nonnegative).
+Axiom-free, general in `n`. -/
+theorem countSignChanges_eq_zero_of_nonpos {n : ℕ} {f : Fin n → ℝ}
+    (h : ∀ i, f i ≤ 0) : DescartesRuleOfSigns.countSignChanges f = 0 := by
+  unfold DescartesRuleOfSigns.countSignChanges
+  rw [Finset.card_eq_zero]
+  apply Finset.filter_eq_empty_iff.mpr
+  rintro ⟨i, j⟩ -
+  simp only [decide_eq_true_eq, DescartesRuleOfSigns.SignChangeBetween,
+    DescartesRuleOfSigns.oppositeSign]
+  rintro ⟨-, -, -, -, hopp⟩
+  have hprod : 0 ≤ f i * f j := by
+    have := mul_nonneg (neg_nonneg.mpr (h i)) (neg_nonneg.mpr (h j))
+    rwa [neg_mul_neg] at this
+  exact absurd hopp (not_lt.mpr hprod)
+
+/-- **A polynomial with nonnegative coefficients has no coefficient sign change.**
+`signChangesInCoeffs p = 0` whenever every coefficient of `p` is `≥ 0`.  Immediate
+from `countSignChanges_eq_zero_of_nonneg` applied to the coefficient sequence
+`coeffSequence p p.natDegree` (`i ↦ p.coeff (natDegree − i) ≥ 0`); the `p = 0`
+branch of `signChangesInCoeffs` is `0` by definition.  Classical reading: a real
+polynomial whose coefficients are all one sign exhibits no Descartes sign variation
+(and hence, via Descartes' rule, no positive root). -/
+theorem signChangesInCoeffs_eq_zero_of_coeff_nonneg {p : ℝ[X]}
+    (h : ∀ k, 0 ≤ p.coeff k) :
+    DescartesRuleOfSigns.signChangesInCoeffs p = 0 := by
+  unfold DescartesRuleOfSigns.signChangesInCoeffs
+  split
+  · rfl
+  · exact countSignChanges_eq_zero_of_nonneg fun i => h _
+
 end DescartesRuleOfSignsOQ01OQ03

--- a/research/problems/descartes-rule-of-signs-oq-01-oq-03/state.md
+++ b/research/problems/descartes-rule-of-signs-oq-01-oq-03/state.md
@@ -59,3 +59,16 @@ since it cannot import this descendant); (c) a general `Fin n` sign-change count
 - Total attempts: 1
 - Current approach attempts: 1
 - Approaches tried: 1
+
+## Session 2026-07-09 (researcher-8) — general Fin n same-sign ⇒ 0 sign changes
+
+Generalized the small-case (`Fin 2`/`Fin 3`) sign-change lemmas to *arbitrary*
+length `n` for the one implication that holds unconditionally: a same-signed
+sequence has no sign change. Added 3 verified axiom-free theorems —
+`countSignChanges_eq_zero_of_nonneg`, `countSignChanges_eq_zero_of_nonpos`
+(general `Fin n`), and the polynomial corollary
+`signChangesInCoeffs_eq_zero_of_coeff_nonneg` (a real polynomial with nonnegative
+coefficients has no coefficient sign variation — the coefficient side of "nonneg
+coefficients ⇒ no positive root"). leanFile 554→614 lines, 20→23 theorems,
+0 sorry / 0 new axiom. docker-build VERIFIED (Proofs.DescartesRuleOfSignsOQ01OQ03,
+3064 jobs, exit 0, Lean v4.26.0).

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
@@ -49,9 +49,9 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 554,
+    "lineCount": 614,
     "assumptions": "The general direction (Sturm ⟹ Descartes for an arbitrary polynomial) is a reduction: it is conditional on a `SturmReduction p` bridge structure whose five fields package Sturm's exact positive-root count on (0, B] together with the three classical coefficient-comparison facts σ_p(0) ≤ V(p), Even(V(p) − σ_p(0)), and Even(σ_p(B)). Per the project's axiom-integrity policy these structure fields are mathematical assumptions (counted here as axiomCount 1; obtaining the data for a general p requires Sturm's theorem, axiomatized in the parent entry as sturm_exact_count_axiom, plus standard Sturm/Descartes comparison theory). No `axiom` declarations and no sorries appear in the file (leanFile.axiomCount = 0). The reduction theorems (upper_bound_core, parity_core, descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm) are fully machine-checked implications, and the Sturm half is validated UNCONDITIONALLY and axiom-free on linear polynomials X − c (c > 0), reusing the gallery's axiom-free Sturm computations. The linear-polynomial validation (X − c, c > 0) is now fully unconditional and axiom-free: the coefficient sign-change count V(X − c) = 1 is computed directly (linear_signChanges, via the new axiom-free countSignChanges_two), so the previously-assumed hypothesis hV has been discharged and linearReduction/linear_descartes_bound carry no standing assumption for the linear case.",
-    "theoremCount": 20,
+    "theoremCount": 23,
     "mathlib_version": "4.26.0",
     "definitionCount": 2
   },
@@ -122,9 +122,9 @@
       "Proofs.DescartesRuleOfSignsOQ02OQ01OQ02"
     ],
     "namespace": "DescartesRuleOfSignsOQ01OQ03",
-    "lineCount": 554,
+    "lineCount": 614,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 23,
     "definitionCount": 2,
     "path": "Proofs/DescartesRuleOfSignsOQ01OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The existing file proves sign-change counts case-by-case for length-2 and length-3 sequences (enumerating index pairs). This PR generalizes the *one* implication that holds for **every** length `n`: a same-signed sequence has no sign change.

```lean
theorem countSignChanges_eq_zero_of_nonneg {n : ℕ} {f : Fin n → ℝ}
    (h : ∀ i, 0 ≤ f i) : DescartesRuleOfSigns.countSignChanges f = 0

theorem countSignChanges_eq_zero_of_nonpos {n : ℕ} {f : Fin n → ℝ}
    (h : ∀ i, f i ≤ 0) : DescartesRuleOfSigns.countSignChanges f = 0

theorem signChangesInCoeffs_eq_zero_of_coeff_nonneg {p : ℝ[X]}
    (h : ∀ k, 0 ≤ p.coeff k) : DescartesRuleOfSigns.signChangesInCoeffs p = 0
```

**Idea:** `SignChangeBetween` requires a strictly-negative product `f i · f j < 0`; if all entries share a sign the product is nonnegative, so the filtered index-pair set is empty and the count is `0`. The polynomial corollary specializes this to the coefficient sequence — a real polynomial with nonnegative coefficients exhibits no Descartes sign variation (the coefficient side of "nonnegative coefficients ⇒ no positive root"). These are the general-`n` companions of the file's `countSignChanges_two` / `countSignChanges_three_mid_zero_zero`.

## Verification
Docker build `Proofs.DescartesRuleOfSignsOQ01OQ03`: **succeeded, 3064 jobs, exit 0**, 0 sorries, no new axioms. File 554→614 lines, theoremCount 20→23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)