### PR TITLE
Audit: register missing companion in abundant-number-oq-01 manifest

### DIFF
--- a/src/data/proofs/abundant-number-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-01/meta.json
@@ -20,8 +20,8 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 197,
-    "theoremCount": 10,
+    "lineCount": 236,
+    "theoremCount": 13,
     "definitionCount": 0,
     "dateAdded": "2026-06-18",
     "mathlib_version": "4.26.0",
@@ -199,6 +199,9 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/AbundantNumberOQ01.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Integrity Issue (manifest / count drift)

**Proof**: abundant-number-oq-01 (status: verified)

The entry's `overview.text`, `proofStrategy`, and `assumptions` prose all describe a **two-file** formalization (236 lines total):
- `AbundantMultiplesOQ01.lean` — closure under multiples + infinitude (registered)
- `AbundantNumberOQ01.lean` — minimality: `not_abundant_below_twelve : ∀ n < 12, ¬ Nat.Abundant n` and `smallest_abundant : IsLeast {n | n.Abundant} 12`, both proved axiom-free by kernel `decide` (**not registered**)

But `leanFile.additionalFiles` omitted the companion, and the aggregate `meta.lineCount` / `meta.theoremCount` counted only the primary file. As a result, the two minimality theorems — which are listed in `mainTheorems` and headlined in the title ("12 Is Smallest") — appeared to reference declarations absent from the registered source.

## Evidence

- `proofs/Proofs/AbundantNumberOQ01.lean` exists: 39 lines, 3 theorems (`twelve_abundant`, `not_abundant_below_twelve`, `smallest_abundant`), 0 sorries, 0 axioms.
- `meta.lineCount` was 197 but `overview.text` states "236 lines total" (= 197 + 39).
- The theorems are genuinely proved — this is **manifest/count drift, not a content overclaim** (same pattern as #35898 and the sibling fix #36181).

## Fix

- `leanFile.additionalFiles`: register `Proofs/AbundantNumberOQ01.lean`
- `meta.lineCount`: 197 → 236
- `meta.theoremCount`: 10 → 13
- `definitionCount` / `sorries` / `axiomCount` unchanged (companion adds 0 of each)

---
Discovered during gallery integrity audit.