### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02): real-character structure of the Kronecker symbol

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -659,6 +659,55 @@ theorem kronecker_sq_mem (a n : ℤ) :
     kronecker a n ^ 2 = 0 ∨ kronecker a n ^ 2 = 1 := by
   rcases kronecker_trichotomy a n with h | h | h <;> rw [h] <;> norm_num
 
+/-- **Normalization at numerator `1`.**  `(1/n) = 1` for *every* modulus `n`
+(including the special moduli `0, ±1`): the constant `1` numerator is a square
+everywhere, so it is fixed by the character.  Together with the numerator
+multiplicativity `kronecker_mul_left` and periodicity `kronecker_mod_numerator`,
+this is the identity-normalization axiom exhibiting `(·/n)` as a genuine (real)
+Dirichlet character in the numerator. -/
+theorem kronecker_one_left (n : ℤ) : kronecker 1 n = 1 := by
+  rcases eq_or_ne n 0 with rfl | hn0
+  · simp [kronecker, kronecker0]
+  · rw [kronecker_eq_sign_jacobi 1 n hn0]
+    simp [kroneckerNeg1, jacobiSym.one_left]
+
+/-- **Normalization at modulus `1`.**  `(a/1) = 1` for every numerator `a`: the
+trivial modulus is the identity of the second argument (the base case of the
+second-argument multiplicativity `kronecker_mul_right`). -/
+theorem kronecker_one_right (a : ℤ) : kronecker a 1 = 1 := by
+  simp [kronecker]
+
+/-- **Support of the character: the symbol vanishes exactly on non-coprime pairs.**
+For odd positive `n`, `(a/n) = 0 ↔ gcd(a, n) ≠ 1`.  This pins the zero set of the
+Dirichlet character `(·/n)` — it is supported precisely on the units of `ℤ/nℤ` —
+substantiating the `kronecker_sq_mem` remark that `(a/n)² = 0` "on non-coprime
+pairs".  Proved by reducing to the Jacobi symbol
+(`jacobiSym.eq_zero_iff_not_coprime`). -/
+theorem kronecker_eq_zero_iff (a : ℤ) (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker a n = 0 ↔ Int.gcd a n ≠ 1 := by
+  rw [kronecker_eq_jacobi a n hn hno]
+  haveI : NeZero n := ⟨hn.ne'⟩
+  exact jacobiSym.eq_zero_iff_not_coprime
+
+/-- **The character is nonzero on units.**  For odd positive `n`, if `gcd(a, n) = 1`
+then `(a/n) ≠ 0`; the contrapositive of `kronecker_eq_zero_iff`. -/
+theorem kronecker_ne_zero_of_coprime (a : ℤ) (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1)
+    (h : Int.gcd a n = 1) : kronecker a n ≠ 0 := by
+  intro hz
+  exact (kronecker_eq_zero_iff a n hn hno).mp hz h
+
+/-- **On units the character takes values `±1`.**  Combining the trichotomy with the
+support characterization: for odd positive `n` with `gcd(a, n) = 1`,
+`(a/n) ∈ {1, -1}`.  This is the concrete statement that `(·/n)` restricts to a
+`{±1}`-valued (quadratic) character on `(ℤ/nℤ)ˣ`. -/
+theorem kronecker_eq_one_or_neg_one_of_coprime (a : ℤ) (n : ℕ) (hn : 0 < n)
+    (hno : n % 2 = 1) (h : Int.gcd a n = 1) :
+    kronecker a n = 1 ∨ kronecker a n = -1 := by
+  rcases kronecker_trichotomy a n with h0 | h1 | hm1
+  · exact absurd h0 (kronecker_ne_zero_of_coprime a n hn hno h)
+  · exact Or.inl h1
+  · exact Or.inr hm1
+
 /-!
 ## Module note: what remains open
 

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 709,
+    "lineCount": 758,
     "axiomCount": 0,
-    "theoremCount": 46,
+    "theoremCount": 51,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Rounds out the Section-10 ("the symbol is a real character") theory of the Kronecker symbol `(a/n)` in `ElementaryQuadraticReciprocityOQ03OQ02.lean` with five axiom-free lemmas. The file already had multiplicativity (`kronecker_mul_left`/`_right`), periodicity (`kronecker_mod_numerator`) and `{−1,0,1}`-valuedness (`kronecker_trichotomy`), but was **missing the identity normalization and the support characterization** — the remaining pieces that make `(·/n)` a genuine Dirichlet character.

- **`kronecker_one_left`** — `(1/n) = 1` for *every* modulus `n` (including `0, ±1`): identity normalization on the numerator side.
- **`kronecker_one_right`** — `(a/1) = 1`: identity of the second argument.
- **`kronecker_eq_zero_iff`** (headline) — for odd positive `n`, `(a/n) = 0 ↔ gcd(a,n) ≠ 1`. This pins the **support** of the character to the units of `ℤ/nℤ`, via `jacobiSym.eq_zero_iff_not_coprime`. It substantiates the existing `kronecker_sq_mem` docstring claim that `(a/n)² = 0` "on non-coprime pairs" — which was asserted but never proven.
- **`kronecker_ne_zero_of_coprime`** — coprime ⇒ `(a/n) ≠ 0`.
- **`kronecker_eq_one_or_neg_one_of_coprime`** — on units, `(a/n) ∈ {1,-1}` (trichotomy + support).

## Honesty / verification

- These are modest structural completions (short proofs off `kronecker_eq_jacobi` / `kronecker_eq_sign_jacobi` and the corresponding Jacobi-symbol lemmas), but they fill genuine gaps: none of the five were present, and the support characterization is the concrete fact the character narrative was implicitly relying on.
- No `sorry`, no `native_decide`, no `axiom` — file **axiom count stays 0**.
- Build: `docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02` → **Build succeeded**. (The file is documented to SIGSEGV on `#print axioms` due to a stack-overflow in that command, unrelated to the proofs; the axiom block is commented out upstream for this reason.)
- meta.json synced: theoremCount 46→51, lineCount updated.

The two genuinely open targets (rewiring `kronecker` to use `kronecker2` at even moduli; the Gauss-sum generalized-reciprocity core) remain untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)