### PR TITLE
Enrich Markov Vieta ascent geometric growth (markov-equation-oq-06-oq-01)

### DIFF
--- a/src/data/proofs/markov-equation-oq-06-oq-01/meta.json
+++ b/src/data/proofs/markov-equation-oq-06-oq-01/meta.json
@@ -66,7 +66,8 @@
       "Strict monotonicity is qualitative; doubling is quantitative. The parent's seq_top_strictMono only gives top(seq n) ≥ n + 1. The single extra observation 3bc − a ≥ 2c upgrades this to top(seq n) ≥ 2ⁿ — an exponential lower bound from one linear inequality on a sorted triple.",
       "The doubling reduces to one nonnegative product. 3bc − a − 2c ≥ 3c(b − 1) ≥ 0 because c ≥ 0 and b − 1 ≥ 0 on a sorted triple with b ≥ 1; feeding nlinarith the product c·(b − 1) ≥ 0 together with a ≤ c closes it with no case analysis.",
       "No new arithmetic beyond the parent. The proof consumes the parent's seq (the iterated ascent map) and seq_spec (every term is a sorted Markov triple) as black boxes; the successor's top coordinate is read off definitionally by rfl, so the whole geometric bound is a two-line induction on top of existing infrastructure.",
-      "Geometric growth immediately gives unboundedness, hence infinitely many Markov numbers by a second route: the top coordinates already exhaust every bound, complementing the parent's Set.Infinite conclusion about triples."
+      "Geometric growth immediately gives unboundedness, hence infinitely many Markov numbers by a second route: the top coordinates already exhaust every bound, complementing the parent's Set.Infinite conclusion about triples.",
+      "The clean 2ⁿ bound is deliberately loose, and that is its virtue. Along this branch the successor top is 3bc − a with b, c the two previous tops (1, 2, 5, 29, 433, 37666, …), so top(seq (n+1)) ≈ 3·top(seq n)·top(seq (n−1)): log top(seq n) obeys a Fibonacci-type recurrence and top(seq n) is in fact doubly exponential, growing like C^(φⁿ). The point of two_mul_top_le_succ is not to capture that true rate but to extract the cheapest exponential lower bound that follows from a single linear inequality on a sorted triple — enough for unboundedness and the counting input, with no product recurrence to analyze."
     ]
   },
   "sections": [
@@ -81,13 +82,13 @@
       "id": "sec-doubling",
       "title": "The Doubling Step",
       "startLine": 47,
-      "endLine": 72,
+      "endLine": 67,
       "summary": "two_mul_top_le_succ proves that one ascent step at least doubles the top coordinate: 2·(seq n).2.2 ≤ (seq (n+1)).2.2. Using the parent's seq_spec to get a sorted Markov triple 1 ≤ a ≤ b ≤ c, the successor's top coordinate 3bc − a (obtained by rfl) satisfies 3bc − a − 2c ≥ 3c(b − 1) ≥ 0, discharged by nlinarith with the nonnegative product c·(b − 1)."
     },
     {
       "id": "sec-geometric",
       "title": "The Geometric Lower Bound and Unboundedness",
-      "startLine": 74,
+      "startLine": 68,
       "endLine": 93,
       "summary": "seq_top_ge_two_pow proves (2 : ℤ)^n ≤ (seq n).2.2 by induction from (seq 0).2.2 = 1, chaining 2^(n+1) = 2·2ⁿ ≤ 2·(seq n).2.2 ≤ (seq (n+1)).2.2 through the doubling step. seq_top_unbounded then uses pow_unbounded_of_one_lt (archimedeanity of ℤ) to show the top coordinates exceed every bound."
     }


### PR DESCRIPTION
Enrichment pass for `markov-equation-oq-06-oq-01`.

## Improvements
- **New keyInsight** (4→5): explains that the clean `2ⁿ` lower bound is deliberately loose. Along this ascent branch the successor top is `3bc − a` with `b, c` the two previous tops (1, 2, 5, 29, 433, 37666, …), so `top(n+1) ≈ 3·top(n)·top(n−1)` — log grows Fibonacci-like and the true rate is doubly exponential (`top(n) ~ C^(φⁿ)`). The point of `two_mul_top_le_succ` is the cheapest exponential bound from one sorted-triple inequality, not the true rate.
- **Section coverage fix**: line 73 was uncovered between `sec-doubling` (ended 72) and `sec-geometric` (started 74). Sections are now contiguous over the full 93-line file, aligned to the actual theorem boundaries (doubling 47–67, geometric+unbounded 68–93).

Size after: 14.7 KB (well under the 60 KB cap). JSON validated; axiom/status fields unchanged (verified, 0 axioms, accurate to the Lean source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)