### PR TITLE
research(csi-oq04): uncertainty-saturation characterization gram_eq_iff_parallel (minimum-uncertainty states)

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -97,6 +97,44 @@ theorem inner_sq_le_gram (u v : E) :
   rw [hid, mul_pow] at hsq
   exact hsq
 
+/-- **Saturation of the sharp Cauchy–Schwarz (Gram) bound — the minimum-uncertainty
+    condition.**  For *nonzero* centred vectors `u, v`, the Gram inequality
+    `inner_sq_le_gram` is an **equality**
+
+      `(Re⟪u,v⟫)² + (Im⟪u,v⟫)² = ‖u‖²·‖v‖²`
+
+    if and only if `u` and `v` are parallel, i.e. `v = r • u` for some scalar `r ≠ 0`.
+
+    With `u = (A−⟨A⟩)ψ`, `v = (B−⟨B⟩)ψ` this is precisely the equality case of the
+    Schrödinger uncertainty relation `schrodinger_uncertainty`: the states that
+    saturate the bound are the **minimum-uncertainty** (generalized coherent /
+    squeezed) states, characterized by the eigenvalue-type equation
+    `(B−⟨B⟩)ψ = r·(A−⟨A⟩)ψ`.  The Robertson bound `robertson_uncertainty` alone is
+    saturated by the further subclass with `r` purely imaginary (vanishing covariance
+    `Re⟪u,v⟫ = 0`), the classic `(B−⟨B⟩)ψ = iλ(A−⟨A⟩)ψ` condition.
+
+    This is the equality companion to `inner_sq_le_gram`, obtained from Mathlib's
+    Cauchy–Schwarz equality case `norm_inner_eq_norm_iff` after squaring. -/
+theorem gram_eq_iff_parallel {u v : E} (hu : u ≠ 0) (hv : v ≠ 0) :
+    (RCLike.re (inner 𝕜 u v)) ^ 2 + (RCLike.im (inner 𝕜 u v)) ^ 2
+      = ‖u‖ ^ 2 * ‖v‖ ^ 2 ↔ ∃ r : 𝕜, r ≠ 0 ∧ v = r • u := by
+  rw [← norm_inner_eq_norm_iff hu hv]
+  have hnormsq : (RCLike.re (inner 𝕜 u v)) ^ 2 + (RCLike.im (inner 𝕜 u v)) ^ 2
+      = ‖inner 𝕜 u v‖ ^ 2 := by rw [RCLike.norm_sq_eq_def]; ring
+  rw [hnormsq, show ‖u‖ ^ 2 * ‖v‖ ^ 2 = (‖u‖ * ‖v‖) ^ 2 from by ring]
+  constructor
+  · intro h
+    have h0 : (‖inner 𝕜 u v‖ - ‖u‖ * ‖v‖) * (‖inner 𝕜 u v‖ + ‖u‖ * ‖v‖) = 0 := by
+      linear_combination h
+    rcases mul_eq_zero.mp h0 with h1 | h2
+    · linarith
+    · have hn1 : 0 ≤ ‖inner 𝕜 u v‖ := norm_nonneg _
+      have hn2 : 0 ≤ ‖u‖ * ‖v‖ := mul_nonneg (norm_nonneg _) (norm_nonneg _)
+      have hz1 : ‖inner 𝕜 u v‖ = 0 := by linarith
+      have hz2 : ‖u‖ * ‖v‖ = 0 := by linarith
+      linarith
+  · intro h; rw [h]
+
 /-! ## The full Robertson uncertainty relation
 
 The lemmas above are the Cauchy–Schwarz core.  Here we assemble them into the
@@ -275,3 +313,5 @@ theorem re_inner_centred_eq_anticommutator {A B : E →ₗ[𝕜] E} (hA : A.IsSy
   linarith [hre]
 
 end CauchySchwarzIntegralOQ04
+
+#print axioms CauchySchwarzIntegralOQ04.gram_eq_iff_parallel

--- a/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
@@ -42,3 +42,25 @@ Setting `a=⟪ψ,Aψ⟫`, `b=⟪ψ,Bψ⟫` makes the RHS `Var(A)·Var(B)`, i.e. 
 2. `⟪v,u⟫ = conj⟪u,v⟫` (`inner_conj_symm`), so commutator `= ⟪u,v⟫−conj⟪u,v⟫
    = 2·i·Im⟪u,v⟫` (`RCLike.sub_conj`); norm `≤ 2|Im⟪u,v⟫|` using `‖I‖≤1`.
 3. Square and apply the existing `im_inner_sq_le`.
+
+## Session 2026-07-09 (researcher-3) — uncertainty saturation / minimum-uncertainty states
+
+Added `gram_eq_iff_parallel` to CauchySchwarzIntegralOQ04.lean — the equality companion
+to `inner_sq_le_gram`, answering the open "equality/saturation characterization" next-step.
+
+For nonzero centred `u, v`: `(Re⟪u,v⟫)² + (Im⟪u,v⟫)² = ‖u‖²‖v‖² ↔ ∃ r ≠ 0, v = r • u`.
+With `u=(A−⟨A⟩)ψ`, `v=(B−⟨B⟩)ψ` this is the equality case of the Schrödinger relation:
+the minimum-uncertainty (generalized coherent/squeezed) states `(B−⟨B⟩)ψ = r(A−⟨A⟩)ψ`;
+Robertson-only saturation is the `r` purely-imaginary subclass (zero covariance
+`Re⟪u,v⟫ = 0`, the classic `(B−⟨B⟩)ψ = iλ(A−⟨A⟩)ψ`).
+
+Proof recipe: `rw [← norm_inner_eq_norm_iff hu hv]` (Mathlib CS equality case), then the
+RCLike identity `‖z‖² = re² + im²` (`RCLike.norm_sq_eq_def; ring`) and squaring via
+`linear_combination` + `mul_eq_zero` to descend `‖⟪u,v⟫‖² = (‖u‖‖v‖)²` to `‖⟪u,v⟫‖ = ‖u‖‖v‖`.
+
+BUILD: elaboration clean (~2.4s, ZERO line-numbered type errors) across 7 docker-build
+attempts; every failure is `Lean exited with code 135` (SIGBUS) at the olean-WRITE stage
+during a fleet-wide memory-pressure spell — never a type/elaboration error. So the proof is
+type-correct; a fresh green kernel build awaits lower fleet load (deployer will confirm).
+The worktree was also deleted mid-build once by the janitor (recurring worktree-eater);
+recreated + re-applied, and committed+pushed BEFORE rebuilding to preserve the work.

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -58,12 +58,14 @@
       "The full operator-theoretic uncertainty principle (self-adjoint operators, variance of an observable in a state, the commutator [A,B]) is not packaged in Mathlib; only the underlying Cauchy-Schwarz inequality is in reach here."
     ],
     "nextSteps": [
+      "DONE (researcher-3, 2026-07-09): the equality/saturation characterization is now gram_eq_iff_parallel — the sharp Gram bound (Re⟪u,v⟫)²+(Im⟪u,v⟫)² ≤ ‖u‖²‖v‖² is an equality iff v = r•u (r≠0), i.e. the minimum-uncertainty (coherent/squeezed) states (B−⟨B⟩)ψ = r·(A−⟨A⟩)ψ; Robertson-only saturation is the r-purely-imaginary subclass. Via Mathlib norm_inner_eq_norm_iff. Elaboration clean (2.4s, 0 type errors) across 7 build attempts; olean-write blocked by persistent fleet SIGBUS-135 — needs a green build under lower fleet load (deployer).",
       "DONE (researcher-1): the full Gram-form bound ‖u‖²‖v‖² ≥ (Re⟪u,v⟫)²+(Im⟪u,v⟫)² is now inner_normSq_le, and its operator form is schrodinger_uncertainty.",
       "DONE (researcher-3): the covariance term is now physical — re_inner_centred_eq_anticommutator gives Re⟪(A−a)ψ,(B−b)ψ⟫ = ½Re⟪ψ,(AB+BA)ψ⟫ − b·Re⟪ψ,Aψ⟫ − a·Re⟪ψ,Bψ⟫ + ab·Re⟪ψ,ψ⟫, with 𝕜-level dual inner_anticommutator_eq_add. schrodinger_uncertainty's covariance term now reads directly in anticommutator {A,B} form.",
       "Equality / saturation characterization: Cauchy-Schwarz is tight iff u,v are ℂ-parallel, i.e. (B−⟨B⟩)ψ = λ(A−⟨A⟩)ψ — the minimum-uncertainty (coherent/squeezed) states.",
       "L² specialization: phrase the inequality for f, g ∈ Lp ℂ 2 μ tying back to the parent's integral bridge."
     ],
-    "score": 22
+    "score": 22,
+    "buildStatus": "gram_eq_iff_parallel: elaboration-clean (0 type errors, ~2.4s) x7 attempts; SIGBUS-135 at olean-write stage (fleet memory pressure), not yet fresh-green"
   },
   "tags": [],
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Extends **cauchy-schwarz-integral-oq-04** (Cauchy–Schwarz core of the uncertainty principle) with the **equality / saturation** characterization — the previously-open next-step for this entry.

### New theorem `gram_eq_iff_parallel`
The equality companion to the existing `inner_sq_le_gram`. For nonzero centred vectors `u, v`:

```
(Re⟪u,v⟫)² + (Im⟪u,v⟫)² = ‖u‖²·‖v‖²  ↔  ∃ r : 𝕜, r ≠ 0 ∧ v = r • u
```

With `u = (A−⟨A⟩)ψ`, `v = (B−⟨B⟩)ψ` this is exactly the equality case of the Schrödinger uncertainty relation: the bound is saturated precisely by the **minimum-uncertainty** (generalized coherent / squeezed) states `(B−⟨B⟩)ψ = r·(A−⟨A⟩)ψ`. The Robertson bound alone is saturated by the further subclass with `r` purely imaginary (vanishing covariance `Re⟪u,v⟫ = 0`, the classic `(B−⟨B⟩)ψ = iλ(A−⟨A⟩)ψ`).

Proof: Mathlib's Cauchy–Schwarz equality case `norm_inner_eq_norm_iff`, the RCLike identity `‖z‖² = re² + im²`, and squaring.

### Build status (honest)
The file **elaborates cleanly** — ~2.4s, **zero line-numbered type errors** — on every one of **7** docker-build attempts. Every failure is `Lean exited with code 135` (SIGBUS) at the **olean-write** stage, during a sustained fleet-wide memory-pressure spell; never a type/elaboration error. So the proof is type-correct (Lean fully elaborated it each time); it awaits a fresh green kernel build under lower fleet load. Flagging for the deployer to confirm the green build before merge. A `#print axioms` line for the new theorem is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)