### PR TITLE
research(cauchy-interlacing-oq-02-oq-01): characteristic-polynomial factorization over a reducing subspace

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
@@ -992,6 +992,57 @@ theorem det_eq_mul_compress_of_reducing {T : V →ₗ[𝕜] V}
     rw [LinearMap.det_conj]
   rw [key, LinearMap.det_prodMap]
 
+/-- **Characteristic-polynomial factorization over a reducing subspace.**
+
+The polynomial master identity of the reducing-subspace block decomposition: if `H`
+reduces `T` (both `H` and `Hᗮ` are `T`-invariant) then the characteristic polynomial of
+`T` factors as the product of the characteristic polynomials of its two honest compression
+blocks,
+
+  `charpoly T = charpoly (compress T H) · charpoly (compress T Hᗮ)`.
+
+This *subsumes* both scalar factorizations already proved on the reducing subspace: the
+trace additivity `trace_eq_add_compress_of_reducing` is the second-from-top coefficient of
+this identity, and the determinant factorization `det_eq_mul_compress_of_reducing` is its
+constant term (up to the sign `(-1)^{finrank V}`).  The proof mirrors
+`det_eq_mul_compress_of_reducing` exactly — the same block-diagonal conjugation
+`T = e.conj ((compress T H).prodMap (compress T Hᗮ))` through the orthogonal decomposition
+`e : (H × Hᗮ) ≃ₗ V` — but reads it through `LinearEquiv.charpoly_conj` (charpoly is
+conjugation-invariant) and `LinearMap.charpoly_prodMap` (the charpoly of a block-diagonal
+map is the product, `Matrix.charpoly_fromBlocks_zero₁₂`).  Symmetry-free. -/
+theorem charpoly_eq_mul_compress_of_reducing {T : V →ₗ[𝕜] V}
+    (H : Submodule 𝕜 V) (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) :
+    LinearMap.charpoly T =
+      LinearMap.charpoly (compress T H) * LinearMap.charpoly (compress T Hᗮ) := by
+  classical
+  have hcompl : IsCompl H Hᗮ :=
+    Submodule.isCompl_orthogonal_of_hasOrthogonalProjection
+  -- Same block-diagonal conjugation as `det_eq_mul_compress_of_reducing`:
+  -- `T ∘ₗ e = e ∘ₗ (compress T H).prodMap (compress T Hᗮ)`.
+  have hconj :
+      T ∘ₗ (Submodule.prodEquivOfIsCompl H Hᗮ hcompl : (H × Hᗮ) →ₗ[𝕜] V)
+        = (Submodule.prodEquivOfIsCompl H Hᗮ hcompl : (H × Hᗮ) →ₗ[𝕜] V)
+            ∘ₗ LinearMap.prodMap (compress T H) (compress T Hᗮ) := by
+    refine LinearMap.ext fun x => ?_
+    obtain ⟨h, k⟩ := x
+    simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
+      Submodule.coe_prodEquivOfIsCompl', LinearMap.prodMap_apply]
+    rw [coe_compress_of_invariant H hH h, coe_compress_of_invariant Hᗮ hHp k, map_add]
+  -- Package the conjugation as `T = e.conj (prodMap …)`.
+  have hT :
+      T = (Submodule.prodEquivOfIsCompl H Hᗮ hcompl).conj
+            (LinearMap.prodMap (compress T H) (compress T Hᗮ)) := by
+    rw [LinearEquiv.conj_apply, ← LinearMap.comp_assoc, ← hconj, LinearMap.comp_assoc,
+      LinearEquiv.comp_coe, LinearEquiv.symm_trans_self, LinearEquiv.refl_toLinearMap,
+      LinearMap.comp_id]
+  -- Read `charpoly T` through the conjugation (only the LHS `T`, not the `T`s inside
+  -- `compress`), then split the block-diagonal charpoly.
+  have key : LinearMap.charpoly T
+      = LinearMap.charpoly (LinearMap.prodMap (compress T H) (compress T Hᗮ)) := by
+    conv_lhs => rw [hT]
+    rw [LinearEquiv.charpoly_conj]
+  rw [key, LinearMap.charpoly_prodMap]
+
 /-- **The compression spectrum is the honest-restriction spectrum on an invariant
 block.**  Since `compress T H = T.restrict hinv` on an invariant subspace
 (`compress_eq_restrict_of_invariant`), the two operators share a spectrum; the

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -12,8 +12,8 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
-    "lineCount": 1006,
-    "theoremCount": 35,
+    "lineCount": 1057,
+    "theoremCount": 36,
     "definitionCount": 0,
     "difficulty": "advanced",
     "category": "linear-algebra",
@@ -62,9 +62,9 @@
       "CauchyInterlacing.Poincare"
     ],
     "namespace": "CauchyInterlacing.PoincareCompression",
-    "lineCount": 1006,
+    "lineCount": 1057,
     "axiomCount": 0,
-    "theoremCount": 35,
+    "theoremCount": 36,
     "definitionCount": 0,
     "path": "Proofs/CauchyInterlacingPoincareCompression.lean",
     "sorries": 0

--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE + extended: determinant factorization closed (det_eq_mul_compress_of_reducing, VERIFIED 0/0) — the multiplicative analogue of the trace additivity capstone, completing the trace/eigenvalue-sum/determinant/multiplicity family over a reducing subspace. Remaining follow-up: charpoly factorization.",
+    "progressSummary": "COMPLETE. Reducing-subspace block calculus fully built out: Poincaré separation, spectrum union, eigenspace/multiplicity additivity, trace additivity, eigenvalue-sum additivity, determinant factorization (#36233), and now the characteristic-polynomial factorization (PR #36265) that subsumes the trace and det identities. All symmetry-free, 0 axiom/0 sorry.",
     "builtItems": [
       "poincare_separation_compression in CauchyInterlacingPoincareCompression.lean (#28084) — unconditional codimension-m Poincaré separation: given a symmetric T on V (dim n+m) and any subspace H (dim n), the descending eigenvalues of the explicit orthogonal compression compress T H interlace those of T as lam⟨k+m⟩ ≤ mu k ≤ lam⟨k⟩, with NO Rayleigh side hypothesis.",
       "compress / isSymmetric_compress / rayleigh_compress_eq in CauchyInterlacingCompression.lean (#27245) — define compress T H := P_H∘T∘ι_H, prove it symmetric, and discharge the Rayleigh-agreement identity for an arbitrary subspace via the orthogonal-projection adjoint identity.",
@@ -60,7 +60,8 @@
       "trace_starProjection_compress_eq_trace_compress: tr_V(P_H T P_H) = tr_H(compress T H) — cyclic-trace bridge across H↪V coercion via P_H=ι∘π, trace_comp_commized, π∘ι=id_H (CauchyInterlacingPoincareCompression.lean)",
       "trace_eq_add_compress_of_reducing: tr_V T = tr_H(compress T H) + tr_Hᗮ(compress T Hᗮ) over a reducing subspace — honest per-block compression traces (CauchyInterlacingPoincareCompression.lean)",
       "spectrum_compress_eq_restrict_of_invariant — compress T H = T.restrict on invariant block ⟹ shared spectrum, routes containment through honest-restriction picture (VERIFIED 0/0)",
-      "det_eq_mul_compress_of_reducing: determinant factorization det T = det(compress T H)·det(compress T Hᗮ) over a reducing subspace — multiplicative analogue of trace_eq_add_compress_of_reducing, via block-diagonal conjugation through Submodule.prodEquivOfIsCompl + LinearMap.det_conj + LinearMap.det_prodMap; symmetry-free, VERIFIED 0/0 (CauchyInterlacingPoincareCompression.lean)"
+      "det_eq_mul_compress_of_reducing: determinant factorization det T = det(compress T H)·det(compress T Hᗮ) over a reducing subspace — multiplicative analogue of trace_eq_add_compress_of_reducing, via block-diagonal conjugation through Submodule.prodEquivOfIsCompl + LinearMap.det_conj + LinearMap.det_prodMap; symmetry-free, VERIFIED 0/0 (CauchyInterlacingPoincareCompression.lean)",
+      "charpoly_eq_mul_compress_of_reducing (CauchyInterlacingPoincareCompression.lean, PR #36265) — charpoly T = charpoly(compress T H)*charpoly(compress T Hᗮ) on a reducing subspace; polynomial master identity subsuming trace additivity + det factorization; symmetry-free"
     ],
     "insights": [
       "This slug duplicates work already merged under sibling cauchy-interlacing-theorem-oq-01-oq-02 (#28084). The Rayleigh-agreement hypothesis of the abstract poincare_separation is discharged by rayleigh_compress_eq, which is stated for an ARBITRARY submodule H (nothing uses codim=1), so the abstract theorem and the explicit compression join for any codimension m with no new work.",
@@ -81,6 +82,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "DONE: determinant factorization landed on main (#36233); charpoly factorization landed (PR #36265). The scalar (trace/det) and polynomial (charpoly) block factorizations over a reducing subspace are now all closed. No further session-sized follow-up in this direction.",
       "Characteristic-polynomial factorization charpoly T = charpoly(compress T H)·charpoly(compress T Hᗮ) over a reducing subspace (finer than determinant; apply det factorization to T - X·id, needs compress commutes with scalar subtraction on each block — compress (T - c) H = compress T H - c on invariant H)."
     ]
   },


### PR DESCRIPTION
## Summary

Adds **`charpoly_eq_mul_compress_of_reducing`** to `Proofs/CauchyInterlacingPoincareCompression.lean`: on a reducing subspace (both `H` and `Hᗮ` are `T`-invariant),

```
charpoly T = charpoly (compress T H) · charpoly (compress T Hᗮ).
```

This is the **polynomial master identity** of the reducing-subspace block decomposition. It *subsumes* the two scalar factorizations already merged on this entry:

- the **trace additivity** `trace_eq_add_compress_of_reducing` is its sub-leading coefficient;
- the **determinant factorization** `det_eq_mul_compress_of_reducing` (#36233) is its constant term, up to the sign `(-1)^{finrank V}`.

## Proof

Mirrors the determinant proof exactly. The orthogonal complementarity `IsCompl H Hᗮ` gives the internal direct sum `e : (H × Hᗮ) ≃ₗ V` (`Submodule.prodEquivOfIsCompl`); because both blocks are invariant, `e` conjugates `T` to the block-diagonal endomorphism `(compress T H).prodMap (compress T Hᗮ)` — the same conjugation `T = e.conj (prodMap …)` established for the det factorization, with the per-block collapse via `coe_compress_of_invariant`. Reading it through:

- `LinearEquiv.charpoly_conj` (charpoly is conjugation-invariant), and
- `LinearMap.charpoly_prodMap` (charpoly of a block-diagonal map is the product, `Matrix.charpoly_fromBlocks_zero₁₂`)

gives the factorization. **Symmetry-free** (needs only invariance of the two blocks, no `T.IsSymmetric`).

## Verification

- Elaboration-clean: the file reaches `[7747/7747]` and elaborates the new theorem with **zero** type/goal/linter errors (repeatable, ~0.9s compile).
- The final olean write intermittently hit `code 135` (SIGBUS) under concurrent fleet memory pressure at time of writing — an environment issue, not a proof issue. `charpoly_prodMap` / `charpoly_conj` / `prodEquivOfIsCompl` / `coe_compress_of_invariant` are all pre-existing verified lemmas; the proof reuses the exact structure of the already-merged `det_eq_mul_compress_of_reducing`.
- Counts synced: `theoremCount` 35→36, `lineCount` 1006→1057.

0 sorries, 0 axioms.