### PR TITLE
Enrich Sum of squares of first n odd numbers (odd-squares-sum-oq-01)

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -3,24 +3,6 @@
   "title": "Sum of Squares of the First n Odd Numbers: ∑(2k−1)² = n(2n−1)(2n+1)/3",
   "slug": "odd-squares-sum-oq-01",
   "description": "A fully machine-checked, self-contained proof that the sum of the squares of the first n odd numbers has the closed form n(2n−1)(2n+1)/3: ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3. The result is established both as a division-free exact identity over ℕ — 3·∑(2k+1)² + n = 4n³, phrased additively so the inductive step has no truncated subtraction and closes by `ring` alone — and as the classical rational closed form over ℚ. This is the odd-indexed companion of the square-pyramidal identity ∑k² = n(n+1)(2n+1)/6, which Mathlib has; this variant it does not.",
-  "mainTheorems": [
-    {
-      "name": "sum_odd_squares_rat",
-      "type": "main",
-      "description": "The classical rational closed form: the sum of the squares of the first n odd numbers is n(2n−1)(2n+1)/3. Proved over ℚ (where the division by 3 is genuine) by induction, with push_cast; ring discharging the cubic step.",
-      "leanType": "(n : ℕ) : ∑ k ∈ range n, (2 * (k : ℚ) + 1) ^ 2 = (n : ℚ) * (2 * n - 1) * (2 * n + 1) / 3",
-      "startLine": 64,
-      "endLine": 72
-    },
-    {
-      "name": "three_mul_sum_odd_squares",
-      "type": "supporting",
-      "description": "The division-free exact ℕ identity 3·∑(2k+1)² + n = 4n³. Its additive phrasing contains no truncated natural subtraction, so the whole inductive step closes by a single ring after one reassociation — the certificate underlying the rational closed form.",
-      "leanType": "(n : ℕ) : 3 * (∑ k ∈ range n, (2 * k + 1) ^ 2) + n = 4 * n ^ 3",
-      "startLine": 46,
-      "endLine": 58
-    }
-  ],
   "leanFile": {
     "path": "Proofs/OddSquaresSum.lean",
     "namespace": "OddSquaresSum",
@@ -86,13 +68,13 @@
       "id": "integer-form",
       "title": "Division-free integer form (subtraction-free step)",
       "startLine": 46,
-      "endLine": 62,
+      "endLine": 59,
       "summary": "The exact ℕ identity 3·∑_{k<n} (2k+1)² + n = 4n³, proved by induction. Phrased additively it contains no truncated subtraction. The step peels the top odd square with sum_range_succ, reassociates so the inductive hypothesis 3·∑ + m = 4m³ appears verbatim, and a single `ring` closes the branch. The whole proof lives in ℕ — no casts to ℤ or ℚ."
     },
     {
       "id": "rational-closed-form",
       "title": "Rational closed form n(2n−1)(2n+1)/3",
-      "startLine": 64,
+      "startLine": 60,
       "endLine": 74,
       "summary": "The classical closed form ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3 over ℚ. Base case is `simp` (empty sum). The inductive step peels the top term, rewrites by the hypothesis, and `push_cast; ring` discharges the polynomial identity — verifying (m(2m−1)(2m+1)/3) + (2m+1)² = (m+1)(2m+1)(2m+3)/3 in the field ℚ where division is genuine."
     }
@@ -123,7 +105,8 @@
       "**Clear the denominator additively.** Rewriting $\\sum = (4n^3 - n)/3$ as $3\\sum + n = 4n^3$ removes both the division *and* the subtraction, so the entire inductive step is a single `ring` call with no case split and no truncation hazard.",
       "**The step is one cubic identity.** After substituting the hypothesis, the goal collapses to $4m^3 + 3(2m+1)^2 + 1 = 4(m+1)^3$ — a fact about the single number $m$, independent of the sum.",
       "**Use ℚ for the headline form.** Division by $3$ is only honest in a field, so the classical $n(2n-1)(2n+1)/3$ form is stated and proved over $\\mathbb{Q}$, where `push_cast; ring` handles the casts and the cubic algebra in one stroke.",
-      "**Relation to the square-pyramidal sum.** The identity is exactly $\\sum_{j<2n} j^2 - 4\\sum_{k<n} k^2$, tying the odd-square sum to Mathlib's even-indexed power-sum machinery."
+      "**Relation to the square-pyramidal sum.** The identity is exactly $\\sum_{j<2n} j^2 - 4\\sum_{k<n} k^2$, tying the odd-square sum to Mathlib's even-indexed power-sum machinery.",
+      "**Shape the goal to fit the hypothesis.** After `sum_range_succ` the goal reads $3(\\sum_{k<m} + (2m+1)^2) + (m+1)$, in which the induction hypothesis's cluster $3\\sum_{k<m} + m$ is not yet syntactically present. A single `ring`-proved `have key` regroups the left side as $(3\\sum_{k<m} + m) + (3(2m+1)^2 + 1)$, exposing the cluster verbatim so `rw [key, ih]` fires; this 'regroup, then rewrite' move is why the entire step needs only two `ring` calls and no `omega` or case split."
     ],
     "prerequisites": [
       "Mathematical induction",


### PR DESCRIPTION
Enrichment pass for `odd-squares-sum-oq-01`.

## Improvements
- **Data-quality fix**: removed a **duplicate `mainTheorems` JSON key**. The file had two `mainTheorems` arrays; JSON parsers keep only the last, so the first block was dead, shadowed weight. Removed it — the effective, richer block (with detailed descriptions and correct line ranges) is retained.
- **Section coverage fix**: line 63 was uncovered between `integer-form` (ended 62) and `rational-closed-form` (started 64). Sections are now contiguous over the full 74-line file, aligned to the actual theorem/docstring boundaries.
- **New keyInsight** (4→5): surfaces the reusable 'regroup, then rewrite' Lean technique — a single `ring`-proved `have key` reshapes the goal so the induction hypothesis cluster `3∑ + m` appears verbatim, which is why the inductive step needs only two `ring` calls and no case split.

Size after: 14.0 KB (down from 14.5 KB; well under the 60 KB cap). JSON validated; `mainTheorems` now a single key with 2 entries. Status/axiom fields unchanged (verified, 0 axioms, accurate to the Lean source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)