### PR TITLE
audit: pythagorean-theorem-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29721,6 +29721,12 @@
       "lastAudited": "2026-07-09T20:49:30Z",
       "result": "clean",
       "issues": []
+    },
+    "pythagorean-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-09T14:24:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: \`pythagorean-theorem-oq-01\` (Einstein's similar-triangles Pythagorean proof)

Records the clean audit result in \`audit-tracker.json\` (persisted via PR because the auditor loop's \`git reset --hard\` clobbers direct tracker writes on main).

### Verification
| Check | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| theorems | 13 | 13 | ✓ |
| definitions | 2 | 2 | ✓ |
| axioms | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| lineCount | 267 | 267 | ✓ |

- All 7 \`originalContributions\` bullets name real, **proved** theorems (\`einstein_pythagorean\`, \`triArea_scale\`, \`altitudeFoot\`/\`foot_perp\`, \`geometric_mean_A/B\`, \`segments_sum\`, \`pythagorean_via_altitude\`, \`einstein_matches_core\`) — no phantom decls, no axiom-as-proof.
- Badge \`mathlib\` + status \`verified\` is appropriately conservative given inner-product infrastructure reliance.
- Exemplary honesty note: explicitly discloses \`pythagorean_core\` is the one-line polarization identity and that Layer 3 is not foundationally independent of it.

No integrity issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)