### PR TITLE
Fix: re-anchor fundamental-theorem-calculus annotations to correct declarations

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus/annotations.json
+++ b/src/data/proofs/fundamental-theorem-calculus/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-integral-function",
     "proofId": "fundamental-theorem-calculus",
     "range": {
-      "startLine": 8,
-      "endLine": 43
+      "startLine": 60,
+      "endLine": 61
     },
     "type": "definition",
     "title": "The Integral Function F(x)",
@@ -26,8 +26,8 @@
     "id": "ann-ftc-part1",
     "proofId": "fundamental-theorem-calculus",
     "range": {
-      "startLine": 8,
-      "endLine": 43
+      "startLine": 65,
+      "endLine": 69
     },
     "type": "insight",
     "title": "FTC Part 1: Derivative of an Integral",
@@ -49,8 +49,8 @@
     "id": "ann-continuity-requirement",
     "proofId": "fundamental-theorem-calculus",
     "range": {
-      "startLine": 8,
-      "endLine": 43
+      "startLine": 72,
+      "endLine": 78
     },
     "type": "concept",
     "title": "Continuity is Essential",
@@ -72,8 +72,8 @@
     "id": "ann-ftc-part2",
     "proofId": "fundamental-theorem-calculus",
     "range": {
-      "startLine": 65,
-      "endLine": 69
+      "startLine": 91,
+      "endLine": 97
     },
     "type": "insight",
     "title": "FTC Part 2: Evaluation Theorem",
@@ -95,8 +95,8 @@
     "id": "ann-ftc-part2-conditions",
     "proofId": "fundamental-theorem-calculus",
     "range": {
-      "startLine": 65,
-      "endLine": 69
+      "startLine": 100,
+      "endLine": 105
     },
     "type": "concept",
     "title": "Conditions for FTC Part 2",
@@ -118,8 +118,8 @@
     "id": "ann-antiderivative-def",
     "proofId": "fundamental-theorem-calculus",
     "range": {
-      "startLine": 91,
-      "endLine": 97
+      "startLine": 120,
+      "endLine": 121
     },
     "type": "definition",
     "title": "Antiderivative Definition",
@@ -140,8 +140,8 @@
     "id": "ann-uniqueness",
     "proofId": "fundamental-theorem-calculus",
     "range": {
-      "startLine": 107,
-      "endLine": 117
+      "startLine": 143,
+      "endLine": 158
     },
     "type": "insight",
     "title": "Antiderivatives Differ by Constants",
@@ -163,8 +163,8 @@
     "id": "ann-zero-derivative",
     "proofId": "fundamental-theorem-calculus",
     "range": {
-      "startLine": 124,
-      "endLine": 128
+      "startLine": 132,
+      "endLine": 139
     },
     "type": "technique",
     "title": "Zero Derivative Implies Constant",
@@ -186,8 +186,8 @@
     "id": "ann-inverse-operations",
     "proofId": "fundamental-theorem-calculus",
     "range": {
-      "startLine": 80,
-      "endLine": 88
+      "startLine": 107,
+      "endLine": 117
     },
     "type": "insight",
     "title": "The Unity of Calculus",

--- a/src/data/proofs/fundamental-theorem-calculus/annotations.source.json
+++ b/src/data/proofs/fundamental-theorem-calculus/annotations.source.json
@@ -3,8 +3,9 @@
     "id": "ann-integral-function",
     "proofId": "fundamental-theorem-calculus",
     "anchor": {
-      "type": "section-doc",
-      "contains": "What This Proves"
+      "type": "declaration",
+      "name": "integralFunction",
+      "kind": "def"
     },
     "type": "definition",
     "title": "The Integral Function F(x)",
@@ -26,8 +27,9 @@
     "id": "ann-ftc-part1",
     "proofId": "fundamental-theorem-calculus",
     "anchor": {
-      "type": "section-doc",
-      "contains": "What This Proves"
+      "type": "declaration",
+      "name": "ftc_part1",
+      "kind": "theorem"
     },
     "type": "insight",
     "title": "FTC Part 1: Derivative of an Integral",
@@ -49,8 +51,9 @@
     "id": "ann-continuity-requirement",
     "proofId": "fundamental-theorem-calculus",
     "anchor": {
-      "type": "section-doc",
-      "contains": "What This Proves"
+      "type": "declaration",
+      "name": "ftc_part1_continuous",
+      "kind": "theorem"
     },
     "type": "concept",
     "title": "Continuity is Essential",
@@ -73,7 +76,7 @@
     "proofId": "fundamental-theorem-calculus",
     "anchor": {
       "type": "declaration",
-      "name": "ftc_part1",
+      "name": "ftc_part2",
       "kind": "theorem"
     },
     "type": "insight",
@@ -97,7 +100,7 @@
     "proofId": "fundamental-theorem-calculus",
     "anchor": {
       "type": "declaration",
-      "name": "ftc_part1",
+      "name": "ftc_part2_general",
       "kind": "theorem"
     },
     "type": "concept",
@@ -121,8 +124,8 @@
     "proofId": "fundamental-theorem-calculus",
     "anchor": {
       "type": "declaration",
-      "name": "ftc_part2",
-      "kind": "theorem"
+      "name": "IsAntiderivative",
+      "kind": "def"
     },
     "type": "definition",
     "title": "Antiderivative Definition",
@@ -143,8 +146,9 @@
     "id": "ann-uniqueness",
     "proofId": "fundamental-theorem-calculus",
     "anchor": {
-      "type": "block-comment",
-      "contains": "The Unity of Calculus"
+      "type": "declaration",
+      "name": "antiderivatives_differ_by_constant",
+      "kind": "theorem"
     },
     "type": "insight",
     "title": "Antiderivatives Differ by Constants",
@@ -167,7 +171,7 @@
     "proofId": "fundamental-theorem-calculus",
     "anchor": {
       "type": "declaration",
-      "name": "integral_is_antiderivative",
+      "name": "hasDerivAt_zero_implies_constant",
       "kind": "theorem"
     },
     "type": "technique",
@@ -191,7 +195,7 @@
     "proofId": "fundamental-theorem-calculus",
     "anchor": {
       "type": "block-comment",
-      "contains": "Part 2: The Integral of a Derivative"
+      "contains": "The Unity of Calculus"
     },
     "type": "insight",
     "title": "The Unity of Calculus",

--- a/src/data/proofs/fundamental-theorem-calculus/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus/meta.json
@@ -90,46 +90,46 @@
       "id": "setup",
       "title": "Setup and Imports",
       "startLine": 1,
-      "endLine": 30,
+      "endLine": 49,
       "summary": "Introduces the historical context, imports Mathlib's calculus and integration libraries, and opens the namespace.",
       "mathContext": "Imports: `FDeriv` (Fréchet derivative), `Deriv` (real derivative), `IntervalIntegral` ($\\int_a^b$), `FundThmCalculus` (Mathlib's FTC infrastructure), `MeanValue` (MVT), `Topology`."
     },
     {
       "id": "integral-function",
       "title": "The Integral Function",
-      "startLine": 31,
-      "endLine": 43,
+      "startLine": 50,
+      "endLine": 62,
       "summary": "Defines F(x) = ∫ₐˣ f(t)dt, the cumulative integral that measures accumulated area.",
       "mathContext": "$F(x) = \\int_a^x f(t)\\,dt$ defines a function $F : \\mathbb{R} \\to \\mathbb{R}$ that 'accumulates' the values of $f$ from the basepoint $a$."
     },
     {
       "id": "ftc-part1",
       "title": "FTC Part 1: Differentiation of Integrals",
-      "startLine": 44,
-      "endLine": 60,
+      "startLine": 63,
+      "endLine": 78,
       "summary": "Proves that the derivative of an integral recovers the original function: F'(x) = f(x).",
       "mathContext": "$\\frac{d}{dx}\\int_a^x f(t)\\,dt = f(x)$ for $f$ continuous. Lean: `HasDerivAt (integralFunction f a) (f b) b`."
     },
     {
       "id": "ftc-part2",
       "title": "FTC Part 2: Evaluation of Integrals",
-      "startLine": 61,
-      "endLine": 87,
+      "startLine": 79,
+      "endLine": 105,
       "summary": "Proves that the integral of a derivative equals the net change: ∫ₐᵇ F' = F(b) - F(a).",
       "mathContext": "$\\int_a^b F'(x)\\,dx = F(b) - F(a)$ for $F$ continuous on $[a,b]$, differentiable on $(a,b)$."
     },
     {
       "id": "antiderivatives",
       "title": "Antiderivatives and Uniqueness",
-      "startLine": 88,
-      "endLine": 140,
+      "startLine": 106,
+      "endLine": 158,
       "summary": "Shows that the integral function is an antiderivative, and that antiderivatives differ only by constants.",
       "mathContext": "$F' = G' \\Rightarrow (F-G)' = 0 \\Rightarrow F - G = c$. The kernel of $d/dx$ is $\\{\\text{constants}\\}$, so antiderivatives form an affine subspace $F + \\mathbb{R}$."
     },
     {
       "id": "checks",
       "title": "Type Checking",
-      "startLine": 141,
+      "startLine": 159,
       "endLine": 165,
       "summary": "Verifies the types of the main theorems using #check commands.",
       "mathContext": "Verified: `ftc_part1`, `ftc_part2`, `integral_is_antiderivative`, `antiderivatives_differ_by_constant`."


### PR DESCRIPTION
## Fix

Peer review (`review.json`, 2026-03-24) flagged that the annotation line ranges for `fundamental-theorem-calculus` point at the wrong code. Root cause: stale `anchor` entries in `annotations.source.json` (the resolver derives `annotations.json` line ranges from these anchors), written against an earlier file layout.

## Evidence

**Before**: 3 annotations resolved onto the module docstring (lines 8-43), and several onto the wrong declaration entirely — e.g. `ann-ftc-part2` was anchored to `ftc_part1` (65-69) and `ann-antiderivative-def` to `ftc_part2` (91-97). `pnpm annotations:build` emitted "No Lean construct found" errors for the docstring-anchored ones.

**After**: all 9 annotations re-anchored to the correct Lean constructs in `proofs/Proofs/FundamentalTheoremCalculus.lean`. Regenerated ranges:

| annotation | declaration | range |
|---|---|---|
| ann-integral-function | `integralFunction` (def) | 60-61 |
| ann-ftc-part1 | `ftc_part1` | 65-69 |
| ann-continuity-requirement | `ftc_part1_continuous` | 72-78 |
| ann-ftc-part2 | `ftc_part2` | 91-97 |
| ann-ftc-part2-conditions | `ftc_part2_general` | 100-105 |
| ann-antiderivative-def | `IsAntiderivative` (def) | 120-121 |
| ann-uniqueness | `antiderivatives_differ_by_constant` | 143-158 |
| ann-zero-derivative | `hasDerivAt_zero_implies_constant` | 132-139 |
| ann-inverse-operations | "Unity of Calculus" block comment | 107-117 |

`meta.json` sections retiled contiguously (1-165) to match; `annotations.json` is the regenerated artifact.

**Validation**: `pnpm annotations:build` reports **0 resolution errors** for this slug. `meta.json` overview/count/originalContributions were corrected in a prior pass; `wiedijkNumber` is left at 15 (correct — FTC is Wiedijk #15; the review's suggested #46 is mistaken).

Addresses the peer-review precision findings in `src/data/proofs/fundamental-theorem-calculus/review.json`.

---
Automated fix by lean-mechanic agent.