### PR TITLE
Enrich Prime powers are deficient (sum-of-divisors-oq-04-oq-01)

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-04-oq-01/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04-oq-01/meta.json
@@ -81,7 +81,8 @@
       "**Scaling the gap linearises the problem.** The deficiency gap 2·pᵏ − σ(pᵏ) is awkward directly, but multiplying by the positive p−1 and substituting the closed geometric identity reduces it to pᵏ·(p−2)+1 — a quantity manifestly ≥ 1 for every prime. One ring identity classifies the entire infinite family.",
       "**Powers of two are exactly one short.** σ(2ᵏ) = 2·2ᵏ − 1, the smallest possible positive deficiency: 2ᵏ is 'almost perfect'. This is the sharp endpoint of the deficiency bound and the reason powers of two are the only known almost-perfect numbers.",
       "**p/(p−1) is the supremum, not a perfect number.** The abundancy index σ(pᵏ)/pᵏ = (p − p⁻ᵏ)/(p−1) increases in k toward p/(p−1) but never reaches it; since p/(p−1) ≤ 2 for p ≥ 2, a prime power can approach but never attain perfection (abundancy 2).",
-      "**Deficiency over ℕ and abundancy over ℚ agree.** σ(pᵏ) < 2·pᵏ in ℕ and σ(pᵏ)/pᵏ < 2 in ℚ are the same fact in two registers; both follow from the single identity pᵏ⁺¹ − 1 < pᵏ⁺¹."
+      "**Deficiency over ℕ and abundancy over ℚ agree.** σ(pᵏ) < 2·pᵏ in ℕ and σ(pᵏ)/pᵏ < 2 in ℚ are the same fact in two registers; both follow from the single identity pᵏ⁺¹ − 1 < pᵏ⁺¹.",
+      "**Almost-perfection of 2ᵏ is the seed of every even perfect number.** The computation σ(2ᵏ) = 2ᵏ⁺¹ − 1 here is exactly the Mersenne number Mₖ₊₁; when it is prime, Euclid's construction 2ᵏ·Mₖ₊₁ is perfect, and Euler proved these are all the even perfect numbers. So the deficiency-by-one of a power of two is not a curiosity but the arithmetic engine of the Euclid–Euler theorem: perfection is manufactured by multiplying the almost-perfect 2ᵏ by its own prime deficiency σ(2ᵏ)."
     ],
     "prerequisites": [
       "Mathlib's ArithmeticFunction.sigma and its prime-power API",
@@ -95,7 +96,7 @@
       "id": "header",
       "title": "Module Header and the Defining Identity",
       "startLine": 1,
-      "endLine": 43,
+      "endLine": 44,
       "summary": "Module docstring framing the deficiency classification of prime powers, the Mathlib import, namespace, opens, and sigma_one_prime_pow_mul (OQ-04's integer identity σ(pⁱ)·(p−1) = pⁱ⁺¹−1, the engine for everything below).",
       "mathContext": "$\\sigma(p^i)\\,(p-1) = p^{i+1}-1$."
     },
@@ -103,7 +104,7 @@
       "id": "deficiency",
       "title": "Deficiency and Almost-Perfect Powers of Two",
       "startLine": 45,
-      "endLine": 84,
+      "endLine": 85,
       "summary": "sigma_one_prime_pow_deficient (σ(pᵏ) < 2·pᵏ for every prime power), pow_two_almost_perfect (σ(2ᵏ)+1 = 2·2ᵏ), and prime_pow_not_perfect (no prime power is perfect).",
       "mathContext": "$\\sigma(p^k) < 2p^k$, $\\sigma(2^k)+1 = 2\\cdot 2^k$, $\\neg\\,\\mathrm{Perfect}(p^k)$."
     },
@@ -131,6 +132,11 @@
       "targetId": "sum-of-divisors",
       "relationship": "extends",
       "description": "Generalises the base entry's native_decide deficiency checks on specific numbers to the universally quantified family of prime powers, 0-axiom"
+    },
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "related — Euclid–Euler seed",
+      "description": "The almost-perfect identity σ(2ᵏ) = 2ᵏ⁺¹ − 1 proved here is precisely the Mersenne factor in the Euclid–Euler classification of even perfect numbers 2ᵏ(2ᵏ⁺¹ − 1): when 2ᵏ⁺¹ − 1 is prime, that construction is perfect. This entry supplies the σ-value of the 2ᵏ factor that the Euclid–Euler proof consumes; that entry closes the loop by showing multiplying it by the Mersenne prime attains σ(n) = 2n."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `sum-of-divisors-oq-04-oq-01`.

## Improvements
- **Section coverage fix**: `prime_pow_not_perfect` spans lines 76–85, but the `deficiency` section ended at 84, leaving line 85 (the closing `omega`) uncovered; line 44 was also a gap. Sections are now contiguous over the full 123-line file (1–44, 45–85, 86–123). (`mainTheorems` carry no line numbers here and are unaffected.)
- **New keyInsight** (4→5): the almost-perfect identity `σ(2ᵏ) = 2ᵏ⁺¹ − 1` proved here is exactly the Mersenne number `Mₖ₊₁`; when prime, Euclid's `2ᵏ·Mₖ₊₁` is perfect and Euler showed these exhaust the even perfect numbers — so the deficiency-by-one of a power of two is the arithmetic engine of the Euclid–Euler theorem.
- **New cross-reference** (3→4) to `perfect-numbers` making that Euclid–Euler connection explicit and bidirectional with the σ-side identities.

Size after: 16.1 KB (well under the 60 KB cap). JSON validated; status/axiom fields unchanged (verified, 0 axioms, no native_decide — accurate to the Lean source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)