### PR TITLE
chore(auditor): record clean re-audit of erdos-147/148/149/151

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11161,21 +11161,21 @@
       "result": "issues-fixed"
     },
     "erdos-147": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:48Z",
+      "lastAudited": "2026-07-09T21:32:42Z",
       "result": "clean"
     },
     "erdos-148": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:48Z",
+      "lastAudited": "2026-07-09T21:32:42Z",
       "result": "clean"
     },
     "erdos-149": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:48Z",
+      "lastAudited": "2026-07-09T21:32:42Z",
       "result": "clean"
     },
     "erdos-15": {
@@ -11191,9 +11191,9 @@
       "result": "clean"
     },
     "erdos-151": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:48Z",
+      "lastAudited": "2026-07-09T21:32:42Z",
       "result": "clean"
     },
     "erdos-152": {


### PR DESCRIPTION
## Auditor: coverage rotation

Re-audited the four **oldest-audited** gallery entries (all last audited 2026-05-03, `auditCount=4`). Prior re-audits never persisted to `main` (auditor worktree is deregistered; local `complete` writes land in a non-git worktree and are lost). This advances their tracker state so the audit loop rotates to the next-oldest targets instead of re-surfacing these.

## Verdict: all four CLEAN

| Entry | axioms | theorems | defs | sorries | status/badge |
|-------|--------|----------|------|---------|--------------|
| erdos-147 | 3 ✓ | 1 ✓ | 1 ✓ | 0 ✓ | axiomatized / axiom ✓ |
| erdos-148 | 3 ✓ | 1 ✓ | 5 ✓ | 0 ✓ | axiomatized / axiom ✓ |
| erdos-149 | 3 ✓ | 2 ✓ | 7 ✓ (6 def + 1 structure) | 0 ✓ | axiomatized / axiom ✓ |
| erdos-151 | 11 ✓ | 7 ✓ | 2 ✓ | 0 ✓ | axiomatized / axiom ✓ |

- All meta counts match the Lean source exactly.
- 0 sorries, 0 True-stubs, no `native_decide` in theorem bodies.
- `status=axiomatized` / `badge=axiom` correct for these open conjectures.
- `originalContributions` honestly distinguish every axiom / theorem / definition (post the #36027/#36031 axiom-disclosure cluster fix). No axiom-masking: e.g. erdos-147 notes "the disproof itself is the axiom"; erdos-149 flags `current_gap` as "the one non-axiom quantitative result".

Tracker-only change; **no gallery content modified**.

---
Discovered during gallery integrity audit (auditor agent).