### PR TITLE
Research: erdos-1093 — formalize the ELS pigeonhole mechanism

### DIFF
--- a/proofs/Proofs/Erdos1093Problem.lean
+++ b/proofs/Proofs/Erdos1093Problem.lean
@@ -255,3 +255,80 @@ theorem finitely_many_for_fixed_k (k : ℕ) :
   obtain ⟨hn2k, hnsp, hndef⟩ := hn
   simp only [Set.mem_Iic]
   exact Nat.cast_le.mp ((hels n k hn2k hnsp hndef).trans (Nat.le_ceil _))
+
+/-
+## Section X: Structural Pigeonhole (the ELS mechanism)
+
+The deficiency of C(n,k) counts the k-smooth terms among n, n-1, …, n-k+1.
+A term is *not* k-smooth exactly when it carries a prime factor exceeding k
+(under n ≥ 2k every term is positive, so this dichotomy is genuine).
+
+The engine of Erdős–Lacampagne–Selfridge is the elementary observation that
+a prime p > k can divide **at most one** of the k consecutive integers
+n, n-1, …, n-k+1: consecutive multiples of p are p > k apart, wider than the
+window. Together with the complement identity `deficiency + (# non-smooth) = k`,
+this forces every non-smooth term to be "charged" to a distinct large prime,
+which is the counting heart behind the ELS bound n ≪ 2^k · √k.
+-/
+
+/-- A positive integer fails to be k-smooth precisely when it has a prime
+factor larger than k. (For m = 0 both sides hold; for m = 1 both fail.) -/
+theorem not_isKSmooth_iff_exists_large_prime {k m : ℕ} :
+    ¬ IsKSmooth k m ↔ ∃ p, p.Prime ∧ p ∣ m ∧ k < p := by
+  unfold IsKSmooth
+  push_neg
+  rfl
+
+/-- **Complement identity.** Splitting the window {n, …, n-k+1} into k-smooth
+terms (the deficiency) and non-smooth terms partitions all k indices. -/
+theorem deficiency_add_nonsmooth_eq (n k : ℕ) :
+    deficiency n k
+      + (Finset.filter (fun i => ¬ IsKSmooth k (n - i)) (Finset.range k)).card = k := by
+  unfold deficiency
+  have h := Finset.filter_card_add_filter_neg_card_eq_card
+    (s := Finset.range k) (p := fun i => IsKSmooth k (n - i))
+  rw [Finset.card_range] at h
+  exact h
+
+/-- Deficiency 1 is equivalent to exactly k-1 of the window terms being
+non-k-smooth. -/
+theorem deficiency_eq_one_iff_nonsmooth_eq (n k : ℕ) :
+    deficiency n k = 1 ↔
+      (Finset.filter (fun i => ¬ IsKSmooth k (n - i)) (Finset.range k)).card = k - 1 := by
+  have h := deficiency_add_nonsmooth_eq n k
+  constructor
+  · intro hd; omega
+  · intro hd; omega
+
+/-- **The ELS pigeonhole.** A prime p > k divides at most one of the k
+consecutive integers n, n-1, …, n-k+1. (Consecutive multiples of p are
+p > k apart, wider than the length-k window.) -/
+theorem at_most_one_multiple_of_large_prime {n k p : ℕ} (hkn : k ≤ n) (hp : k < p) :
+    (Finset.filter (fun i => p ∣ (n - i)) (Finset.range k)).card ≤ 1 := by
+  rw [Finset.card_le_one]
+  intro i hi j hj
+  rw [Finset.mem_filter, Finset.mem_range] at hi hj
+  obtain ⟨hik, hpi⟩ := hi
+  obtain ⟨hjk, hpj⟩ := hj
+  rcases le_total i j with hij | hij
+  · have hd : p ∣ (n - i) - (n - j) := Nat.dvd_sub hpi hpj
+    have heq : (n - i) - (n - j) = j - i := by omega
+    rw [heq] at hd
+    rcases Nat.eq_zero_or_pos (j - i) with h0 | hpos
+    · omega
+    · have := Nat.le_of_dvd hpos hd; omega
+  · have hd : p ∣ (n - j) - (n - i) := Nat.dvd_sub hpj hpi
+    have heq : (n - j) - (n - i) = i - j := by omega
+    rw [heq] at hd
+    rcases Nat.eq_zero_or_pos (i - j) with h0 | hpos
+    · omega
+    · have := Nat.le_of_dvd hpos hd; omega
+
+/-- Restatement of the pigeonhole lemma for two explicit indices: distinct
+indices in the window cannot share a common prime factor exceeding k. -/
+theorem no_shared_large_prime {n k p i j : ℕ} (hkn : k ≤ n) (hp : k < p)
+    (hi : i < k) (hj : j < k) (hpi : p ∣ (n - i)) (hpj : p ∣ (n - j)) : i = j := by
+  have h := at_most_one_multiple_of_large_prime (n := n) (k := k) (p := p) hkn hp
+  rw [Finset.card_le_one] at h
+  exact h i (Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hi, hpi⟩)
+           j (Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hj, hpj⟩)

--- a/src/data/proofs/erdos-1093/meta.json
+++ b/src/data/proofs/erdos-1093/meta.json
@@ -20,10 +20,10 @@
     "erdosUrl": "https://erdosproblems.com/1093",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 257,
+    "lineCount": 334,
     "assumptions": "2 axioms: (1) els_upper_bound (ELS 1993 upper bound theorem), and (2) Lean.ofReduceBool, introduced by the native_decide-verified deficiency computations (e.g. deficiency_7_3, deficiency_284_28), which trust the Lean compiler's kernel reduction rather than the ordinary kernel. Former many_deficiency_one_examples axiom eliminated by 16 individually verified native_decide examples spanning k=3..28. Section VIII adds 5 additional verified examples (including all known deficiency-2 pairs). Section IX proves finitely_many_for_fixed_k as a zero-sorry corollary of the ELS axiom.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 44,
+    "theoremCount": 49,
     "definitionCount": 6
   },
   "overview": {
@@ -241,9 +241,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 257,
+    "lineCount": 334,
     "axiomCount": 1,
-    "theoremCount": 44,
+    "theoremCount": 49,
     "definitionCount": 6,
     "path": "Proofs/Erdos1093Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Formalizes the **structural engine** behind Erdős–Lacampagne–Selfridge for the deficiency of C(n,k) (Erdős Problem #1093). Adds a new **Section X** with 5 theorems (0 sorries, **no new axioms**).

The deficiency counts the k-smooth terms among the window `n, n-1, …, n-k+1`. The ELS mechanism rests on an elementary pigeonhole fact that this PR now proves in Lean:

- **`not_isKSmooth_iff_exists_large_prime`** — a number fails k-smoothness iff it carries a prime factor `> k` (the term-level dichotomy).
- **`deficiency_add_nonsmooth_eq`** — complement identity: `deficiency + (#non-smooth terms) = k`, partitioning the window.
- **`deficiency_eq_one_iff_nonsmooth_eq`** — deficiency 1 ⟺ exactly `k-1` non-smooth terms.
- **`at_most_one_multiple_of_large_prime`** — **the ELS pigeonhole**: a prime `p > k` divides at most one of the `k` consecutive integers `n, …, n-k+1` (consecutive multiples of `p` are `p > k` apart — wider than the length-`k` window).
- **`no_shared_large_prime`** — two-index restatement: distinct window indices cannot share a common prime factor `> k`.

Together these formalize *why* every non-smooth term must be charged to a distinct large prime — the counting heart behind the ELS bound `n ≪ 2^k·√k` (the existing `els_upper_bound` axiom). The main problem itself remains **OPEN**.

## Verification

The file **elaborates cleanly** — zero type errors across 6 Docker builds (the initial run flagged 3 real errors at lines 299/312/318, all fixed; subsequent runs show no `.lean:NNN` errors). The final `.olean` write is blocked by the recurring **fleet SIGBUS-135** memory-contention issue (documented environment problem, not a math/type error). The proofs type-check; the artifact is UNVERIFIED only at the olean-write level.

Counts synced in `meta.json`: theoremCount 44→49, lineCount 257→334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)