### PR TITLE
research(erdos-79): strict-partial-order + completeGraphN monotonicity foundations [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos79Problem.lean
+++ b/proofs/Proofs/Erdos79Problem.lean
@@ -213,6 +213,58 @@ theorem minimal_form_antichain :
   exact ⟨fun hGH => hGsup (hHmin G hGH), fun hHG => hHsup (hGmin H hHG)⟩
 
 /-
+## Order-theoretic foundations
+
+The `isProperSubgraph` relation is exactly the strict order `<` on graphs, and
+`completeGraphN` is monotone.  These are the structural facts that make the
+"minimal element" language above well-posed: `minimal_form_antichain` is an
+instance of "minimal elements of a strict partial order are pairwise
+incomparable", and monotonicity places the complete graphs `K₀ ≤ K₁ ≤ K₂ ≤ ⋯`
+in a chain through which every proper subgraph of `K₄` is approached.
+-/
+
+/-- `isProperSubgraph` is irreflexive: no graph is a proper subgraph of itself. -/
+theorem isProperSubgraph_irrefl (G : SimpleGraph ℕ) : ¬ isProperSubgraph G G :=
+  fun h => h.2 rfl
+
+/-- `isProperSubgraph` is asymmetric: `H ⊏ G` rules out `G ⊏ H`.  (This is the
+    two-graph form of `minimal_form_antichain`'s incomparability, holding for *all*
+    graphs, not only minimal ones.) -/
+theorem isProperSubgraph_asymm {G H : SimpleGraph ℕ}
+    (h : isProperSubgraph H G) : ¬ isProperSubgraph G H :=
+  fun h' => h.2 (le_antisymm h.1 h'.1)
+
+/-- `isProperSubgraph` is transitive, so it is a strict partial order. -/
+theorem isProperSubgraph_trans {F G H : SimpleGraph ℕ}
+    (h1 : isProperSubgraph F G) (h2 : isProperSubgraph G H) :
+    isProperSubgraph F H := by
+  refine ⟨le_trans h1.1 h2.1, ?_⟩
+  intro hFH
+  exact h2.2 (le_antisymm h2.1 (hFH ▸ h1.1))
+
+/-- **Monotonicity of the complete graphs.**  `Kₘ ≤ Kₙ` whenever `m ≤ n`: adding
+    vertices only adds edges. -/
+theorem completeGraphN_mono {m n : ℕ} (h : m ≤ n) :
+    completeGraphN m ≤ completeGraphN n := by
+  intro u v huv
+  obtain ⟨hne, hu, hv⟩ := huv
+  exact ⟨hne, lt_of_lt_of_le hu h, lt_of_lt_of_le hv h⟩
+
+/-- `K₀` is the empty graph. -/
+theorem completeGraphN_zero : completeGraphN 0 = ⊥ := by
+  ext u v
+  simp only [SimpleGraph.bot_adj, iff_false]
+  rintro ⟨_, hu, _⟩
+  omega
+
+/-- `K₁` is the empty graph: a single vertex has no edges. -/
+theorem completeGraphN_one : completeGraphN 1 = ⊥ := by
+  ext u v
+  simp only [SimpleGraph.bot_adj, iff_false]
+  rintro ⟨hne, hu, hv⟩
+  omega
+
+/-
 ## Summary
 
 This file formalizes Erdős Problem #79 on minimally non-Ramsey-size-linear graphs.

--- a/src/data/proofs/erdos-79/meta.json
+++ b/src/data/proofs/erdos-79/meta.json
@@ -32,10 +32,10 @@
       "erdos-562"
     ],
     "axiomCount": 4,
-    "lineCount": 239,
+    "lineCount": 291,
     "assumptions": "4 axioms: ramsey_linear_hereditary, K4_not_linear, K4_subgraphs_linear, wigderson_theorem. 0 sorries. ramseyNumber is an opaque parameter (value unspecified, so the K4 axioms stay consistent). No native_decide — Lean.ofReduceBool is not used.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 4,
+    "theoremCount": 10,
     "definitionCount": 12,
     "additionalFiles": [
       "Proofs/Erdos79ProblemAristotle.lean",
@@ -181,9 +181,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos79",
-    "lineCount": 239,
+    "lineCount": 291,
     "axiomCount": 4,
-    "theoremCount": 4,
+    "theoremCount": 10,
     "definitionCount": 12,
     "path": "Proofs/Erdos79Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

`Erdos79Problem.lean` proves `minimal_form_antichain` (minimally non-Ramsey-size-linear graphs are pairwise incomparable) but never records the underlying **order structure** that makes the "minimal element" language well-posed. This PR supplies it — 6 theorems using only the file's own definitions, no reference to the opaque `ramseyNumber` (so all fully machine-checked, no new axioms).

## New theorems

**`isProperSubgraph` is a strict partial order:**
- `isProperSubgraph_irrefl` — no graph is a proper subgraph of itself.
- `isProperSubgraph_asymm` — `H ⊏ G ⟹ ¬ G ⊏ H`. This is the *all-graphs* form of the incomparability in `minimal_form_antichain` (which specializes it to minimal graphs).
- `isProperSubgraph_trans` — transitivity; together with irreflexivity this makes "minimal element" a well-posed notion.

**Complete graphs form a chain:**
- `completeGraphN_mono` — `Kₘ ≤ Kₙ` for `m ≤ n`.
- `completeGraphN_zero`, `completeGraphN_one` — `K₀ = K₁ = ⊥` (empty graph).

## Significance

These place the complete graphs `K₀ ≤ K₁ ≤ ⋯` in a monotone chain (the ambient order through which every proper subgraph of `K₄` is approached) and expose the strict-partial-order structure that `minimal_form_antichain` implicitly uses. Modest but genuine foundations that were missing from a heavily-scaffolded, otherwise-axiomatized entry.

## Verification

- **Docker build green**: `Built Proofs.Erdos79Problem (994/994)`.
- 0 sorries, 0 new axioms (the 6 theorems use only `le_antisymm`/`le_trans` and the graph definitions).
- `meta.json` (erdos-79): `theoremCount` 4→10, `lineCount` 239→291; `definitionCount`, `axiomCount` (4) and `axiomatized` status unchanged.