### PR TITLE
Enrich Sum of Divisors OQ-04-OQ-01: add abundancy-index reference

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-04-oq-01/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04-oq-01/meta.json
@@ -215,6 +215,13 @@
       "year": "2004",
       "venue": "Springer, 3rd ed.",
       "note": "Section B2: almost perfect numbers σ(n) = 2n − 1; powers of two are the only known examples"
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer Undergraduate Texts in Mathematics",
+      "note": "Chapter 2: σ(n) as a multiplicative function with σ(pᵃ) = (p^{a+1}−1)/(p−1); the abundancy index σ(n)/n and its behaviour on prime powers underlie the sharp bound σ(pᵏ)/pᵏ < p/(p−1) proved here"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `sum-of-divisors-oq-04-oq-01` (quality 94, pass 0).

This entry is already rich and under all caps (~15 KB): 8 annotations each with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, contiguous sections spanning the 123-line Lean file, 7 documented main theorems, 4 key insights, 3 cross-references. The one thin field was `references` (only 2).

Added one authoritative, directly-relevant reference (2 → 3):

> **Apostol, *Introduction to Analytic Number Theory* (1976)** — Chapter 2: σ(n) as a multiplicative function with σ(pᵃ) = (p^{a+1}−1)/(p−1); the abundancy index σ(n)/n on prime powers underlying the sharp bound σ(pᵏ)/pᵏ < p/(p−1) proved here.

Real, verifiable text on exactly the objects the entry formalizes (σ on prime powers, the abundancy index). No content deleted; JSON validated; size check passes.