### PR TITLE
Enrich Sum of Divisors OQ-07: add σ-family cross-references

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-07/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-07/meta.json
@@ -127,6 +127,16 @@
       "targetId": "sum-of-divisors",
       "relationship": "extends",
       "description": "Extends the base entry's divisor-sum properties to the full divisor-power family σₖ in closed geometric-product form"
+    },
+    {
+      "targetId": "sum-of-divisors-oq-04-oq-01",
+      "relationship": "related — k = 1 abundancy specialization",
+      "description": "OQ-04-OQ-01 uses the k = 1 closed prime-power form to pin the abundancy index σ(pᵏ)/pᵏ strictly below p/(p−1) and classify every prime power as deficient. This entry supplies the general-k closed form σₖ(pⁱ)·(pᵏ−1) = p^{k(i+1)}−1 of which that k = 1 bound is the specialization, setting up the higher-order abundancy index σₖ(n)/nᵏ."
+    },
+    {
+      "targetId": "sum-of-divisors-oq-05",
+      "relationship": "related — abundancy multiplicativity",
+      "description": "OQ-05 proves the abundancy index σ(n)/n is multiplicative (the k = 1 case). This entry's open question asks for the same for the higher-order index σₖ(n)/nᵏ, and its general closed product form σₖ(n)·∏_{p∣n}(pᵏ−1) = ∏_{p∣n}(p^{k(vₚ(n)+1)}−1) is the evaluation on which that multiplicativity rests."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `sum-of-divisors-oq-07` (quality 94, pass 0).

This entry is already rich and under all caps (~14 KB): 5 annotations fully populated, contiguous sections spanning the 95-line Lean file, 4 documented main theorems, 5 key insights, 2 references (both apt). The one thin field was `crossReferences` (2).

Added two accurate, directly-relevant σ-family cross-references (2 → 4), both to gallery entries confirmed present:

- **`sum-of-divisors-oq-04-oq-01`** — the k = 1 abundancy specialization: its bound σ(pᵏ)/pᵏ < p/(p−1) is a special case of this entry's general-k closed form.
- **`sum-of-divisors-oq-05`** — abundancy-index multiplicativity, *explicitly named in this entry's own open question* on the higher-order index σₖ(n)/nᵏ.

No content deleted; JSON validated; size check passes; both link targets verified to exist.