### PR TITLE
Enrich Summation by Parts OQ-01: arithmetic-series cross-reference

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01/meta.json
@@ -146,6 +146,11 @@
       "targetId": "geometric-series",
       "relationship": "foundation",
       "description": "The base geometric series ∑ rᵏ = (rⁿ−1)/(r−1); summation by parts expresses the weighted sum ∑ k·rᵏ through its partial sums."
+    },
+    {
+      "targetId": "arithmetic-series",
+      "relationship": "removable-singularity limit",
+      "description": "Gauss's triangular sum ∑_{k<n} k = n(n−1)/2 is exactly the r → 1 limit of this entry's closed form: the numerator r − n·rⁿ + (n−1)·rⁿ⁺¹ vanishes to order 2 at r = 1, matching the (r−1)² denominator, and the resulting value N''(1)/2 = n(n−1)/2 is the arithmetic series. So ∑ k·rᵏ interpolates between the geometric closed form (generic r) and the arithmetic/triangular sum (the excluded point r = 1)."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01` (quality 94, pass 0).

This entry is already rich and under all caps (~12 KB): 5 annotations fully populated, contiguous sections spanning the 83-line Lean file, 2 documented main theorems, 5 key insights, 3 references. The thinnest field was `crossReferences` (2, both geometric-series entries).

Added one precise, accurate cross-reference (2 → 3) to `arithmetic-series` (Gauss's ∑k = n(n+1)/2, confirmed present):

> The triangular sum ∑_{k<n} k = n(n−1)/2 is exactly the **r → 1 removable-singularity limit** of this entry's closed form — the numerator vanishes to order 2 at r = 1, matching the (r−1)² denominator, giving N''(1)/2 = n(n−1)/2.

This makes concrete the connection already stated in the entry's own key insight #5 (the r = 1 point recovers Mathlib's `sum_range_id`). No content deleted; JSON validated; size check passes.