### PR TITLE
Enrich Algebraic Points Null OQ-07-OQ-03: header/overview annotation

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-07-oq-03/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07-oq-03/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-oq0703-overview",
+    "proofId": "algebraic-numbers-countable-oq-07-oq-03",
+    "range": {
+      "startLine": 8,
+      "endLine": 65
+    },
+    "type": "context",
+    "title": "The n-Dimensional Open Question and Its Two Distinct Smallness Statements",
+    "content": "The header docstring frames the entry as the answer to the parent's third open question: generalize `volume {x : ℝ | IsAlgebraic ℚ x} = 0` from ℝ (and ℂ) to ℝⁿ and ℂⁿ. Working in the product space `Fin n → ℝ`, it isolates two genuinely different notions of 'small' that coincide in dimension one but split for n ≥ 2. First, the *measure* statement: the set with **at least one** algebraic coordinate is Lebesgue-null for every n — and this null set is uncountable (in ℝ² it contains every vertical line through an algebraic number). Second, the *cardinality* statement: the set with **all** coordinates algebraic is a finite product of countable sets, hence countable, hence null — but only for n ≥ 1, since ℝ⁰ is a single all-algebraic point of measure 1. The docstring stresses that for n ≥ 2 'measure zero' is strictly weaker than 'countable', and records the conull dual: almost every point of ℝⁿ (and ℂⁿ) is coordinatewise transcendental.",
+    "mathContext": "For n ≥ 2: {x | ∃ i, IsAlgebraic ℚ (x i)} is null yet uncountable, while {x | ∀ i, IsAlgebraic ℚ (x i)} is countable (hence null for n ≥ 1). The n = 0 boundary (ℝ⁰ = single point, measure 1, vacuously all-algebraic) is invisible to the one-dimensional parent.",
+    "significance": "context",
+    "relatedConcepts": [
+      "product Lebesgue measure",
+      "null vs countable",
+      "conull / almost-everywhere",
+      "coordinatewise transcendence",
+      "n = 0 boundary case"
+    ],
+    "prerequisites": [
+      "Lebesgue measure and null sets",
+      "countable sets and finite products",
+      "the parent result volume {x : ℝ | IsAlgebraic ℚ x} = 0"
+    ]
+  },
+  {
     "id": "ann-oq0703-cylinder-null",
     "proofId": "algebraic-numbers-countable-oq-07-oq-03",
     "range": {


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-07-oq-03` (quality 95, pass 0).

This entry is content-rich (~24 KB, 201-line Lean file, 9 documented main theorems, 5 sections, 5 key insights) but had a real **annotation coverage gap**: the four existing annotations covered lines 71–201, leaving the entire 65-line header docstring (the open-question framing and definitions) with no annotation, and the entry sat one below the 5-annotation quality minimum.

Added one annotation covering docstring lines 8–65:

> **The n-Dimensional Open Question and Its Two Distinct Smallness Statements** — the parent's third open question (generalize `volume {x : ℝ | IsAlgebraic ℚ x} = 0` to ℝⁿ/ℂⁿ), and the two notions of 'small' that coincide in dimension 1 but split for n ≥ 2: the at-least-one-algebraic set is null-but-uncountable, while the all-algebraic set is countable (null only for n ≥ 1, given the ℝ⁰ measure-1 boundary).

Mathematically faithful to the docstring; brings annotations 4 → 5 and gives full header coverage. Annotations JSON validated; size check passes.