### PR TITLE
Enrich Maclaurin equality-case OQ-02-OQ-02-OQ-02: Cauchy–Schwarz cross-ref

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/meta.json
@@ -84,6 +84,11 @@
       "targetId": "amgm-inequality",
       "relationship": "ancestor",
       "description": "AM ≥ GM is the extreme instance M₁ ≥ Mₙ of the Maclaurin chain; its equality case (AM = GM iff all equal) is the endpoint of the characterization begun here."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related — necessity-direction tool",
+      "description": "The hard necessity direction of the equality case (this entry's open question) reduces at its first non-trivial step to Cauchy–Schwarz: M₁(x) = M₂(x) ⟺ n·∑xᵢ² = (∑xᵢ)², which is exactly the equality condition of Cauchy–Schwarz (equivalently ∑_{i,j}(xᵢ − xⱼ)² = 0 forcing all coordinates equal). The Cauchy–Schwarz entry supplies the base-case engine for the converse this entry leaves open."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-02-oq-02` (quality 95, pass 0).

This entry (Maclaurin's inequality, equality-case sufficiency direction) is already rich and under all caps (~14 KB): 7 fully-populated annotations, 5 contiguous sections spanning the 124-line Lean file, 5 documented main theorems, 4 key insights, 3 references, 3 open questions.

Added one accurate cross-reference (3 → 4) to `cauchy-schwarz` (confirmed present), directly grounded in the entry's own **open question #2**:

> The hard necessity direction reduces at its first non-trivial step to Cauchy–Schwarz: M₁(x) = M₂(x) ⟺ n·∑xᵢ² = (∑xᵢ)², exactly the Cauchy–Schwarz equality condition (∑_{i,j}(xᵢ − xⱼ)² = 0 forcing all coordinates equal).

The prior 3 cross-references were all amgm-family ancestors; this adds the one *tool* the entry names for the converse it leaves open. No content deleted; JSON validated; size check passes.