### PR TITLE
Fix: sync count drift for shannon-channel-coding-awgn-oq-02-oq-02

### DIFF
--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "shannon-channel-coding-awgn-oq-02-oq-02",
   "slug": "shannon-channel-coding-awgn-oq-02-oq-02",
   "title": "Multi-Symbol AWGN Output Power E[(∑Wᵢ)²] = ∑E[Wᵢ²] from the Variance of a Pairwise-Independent Sum",
-  "description": "Generalizes the parent two-term AWGN output-power identity E[(X+Z)²] = E[X²] + E[Z²] to a finite block of symbols: for pairwise-independent, zero-mean, square-integrable contributions Wᵢ (i ∈ s), the aggregate output power adds, E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The proof is the variance-of-a-sum (Bienaymé) identity for pairwise-independent families — ProbabilityTheory.IndepFun.variance_sum, where the vanishing pairwise covariances collapse the double sum to the diagonal — specialized to zero mean via E[W²] = Var[W] (ProbabilityTheory.variance_eq_sub). Pairwise (not mutual) independence already suffices. 1447 lines, 59 theorems, 0 axioms, 0 sorries.",
+  "description": "Generalizes the parent two-term AWGN output-power identity E[(X+Z)²] = E[X²] + E[Z²] to a finite block of symbols: for pairwise-independent, zero-mean, square-integrable contributions Wᵢ (i ∈ s), the aggregate output power adds, E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The proof is the variance-of-a-sum (Bienaymé) identity for pairwise-independent families — ProbabilityTheory.IndepFun.variance_sum, where the vanishing pairwise covariances collapse the double sum to the diagonal — specialized to zero mean via E[W²] = Var[W] (ProbabilityTheory.variance_eq_sub). Pairwise (not mutual) independence already suffices. 1479 lines, 61 theorems, 0 axioms, 0 sorries.",
   "leanFile": {
     "imports": [
       "Mathlib"
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 1447,
+    "lineCount": 1479,
     "axiomCount": 0,
-    "theoremCount": 59,
+    "theoremCount": 61,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 1447,
-    "theoremCount": 59,
+    "lineCount": 1479,
+    "theoremCount": 61,
     "definitionCount": 1,
     "badge": "mathlib",
     "originalContributions": [
@@ -183,6 +183,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 1447,
-  "theoremCount": 59
+  "lineCount": 1479,
+  "theoremCount": 61
 }


### PR DESCRIPTION
## Fix

Metadata count drift: commit #36174 appended 32 lines and 2 theorems (MRC diversity-gain lemmas `mrc_max_snr_mono` + `mrc_max_snr_lt_of_signal`) to `Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean` but left `meta.json` counts stale.

## Evidence

**Before**: `lineCount: 1447`, `theoremCount: 59` (in all three locations: `leanFile`, `meta`, top-level; plus description prose)
**After**: `lineCount: 1479`, `theoremCount: 61`

- `wc -l` on the Lean file = 1479 (confirmed).
- Appended block (git `32 0` numstat on #36174) adds exactly 2 theorems, both at column 0.
- `definitionCount` (1), `axiomCount` (0), `sorries` (0) unchanged — still `verified`.

Metadata-only fix; no Lean code changed.

---
Automated fix by lean-mechanic agent.