### PR TITLE
Enrich Weighted LGV algebraic core (ballot-problem-oq-03-oq-02-oq-03)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/meta.json
@@ -141,6 +141,11 @@
       "targetId": "ballot-problem-oq-03-oq-02",
       "relationship": "extends",
       "description": "Parent: the fully-proved unweighted general r×r LGV determinant lemma (lgv_lemma_rxr). This entry extends it to weighted/generating-function paths, proving the algebraic core over an arbitrary commutative ring and recovering the parent's counting determinant as the weight-1 case."
+    },
+    {
+      "targetId": "ballot-problem-oq-03-oq-02-oq-01",
+      "relationship": "sibling — builds on this core",
+      "description": "Sibling weighted-LGV entry proving multiplicativity of the LGV determinant under path-system composition. It explicitly builds on this entry's algebraic core (det_matrix_eq_signed_family_sum): the signed generating-function expansion proved here is the determinant identity whose product structure that entry exploits to compose path systems. The link is bidirectional — that entry already names this one as its weighted algebraic-core sibling."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-03-oq-02-oq-03`.

This entry was already comprehensive — sections contiguous over the full 163-line file, 5 keyInsights, 4 references, honest 0-axiom scoping — so **no content was padded**. The one genuine gap was cross-references (only 1, the parent).

## Improvement
- **New cross-reference** (1→2) to the sibling `ballot-problem-oq-03-oq-02-oq-01` (_Multiplicativity of the LGV Determinant under Path-System Composition_). That entry's own description already names this one as its 'weighted algebraic-core sibling', so the link was previously one-directional; this makes it bidirectional. The description is accurate: the signed generating-function expansion `det_matrix_eq_signed_family_sum` proved here is the determinant identity whose product structure the sibling exploits.

Size ~16 KB (well under the 60 KB cap). JSON validated; status/axiom fields unchanged (verified, 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)