### PR TITLE
audit(erdos-634): re-audit CLEAN — axiom/sorry counts match, exemplary disclosure

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15217,12 +15217,11 @@
     },
     "erdos-634": {
       "agentId": "auditor-loop-1777752145",
-      "auditCount": 7,
-      "lastAudited": "2026-07-08T05:49:40Z",
+      "auditCount": 8,
+      "lastAudited": "2026-07-09T21:48:12Z",
       "result": "clean",
       "issues": [
-        "sorries claim 7 actual 1 (PR #14856 reduced 7\u21921 but meta.json not refreshed); lineCount 298\u2192332; assumptions string still says \"7 sorries\"; deeper concern: Dissection structure has placeholder area condition (line 93), so *_dissectable theorems use trivial constant-function witness \u2014 issue #14859",
-        "Re-audit 2026-05-02 vs origin/main a0a5957: PR #14866 fixed only meta.json text; deeper Dissection placeholder + axiom inconsistency unresolved -> issue #14888"
+        "Re-audit 2026-07-09 vs origin/main 13c8036923: CLEAN. axiomCount 3 = 3 actual (seven_not_dissectable, eleven_not_dissectable, soifer_theorem), all disclosed by name in assumptions. sorries 6 = 6 actual (congruent_implies_similar + 5 positive-result stubs), no True stubs. status=axiomatized/badge=axiom correct for open Erd\u0151s problem. assumptions field is exemplary \u2014 proactively discloses the Erdos634AreaCollapse internal-inconsistency caveat. The detector's transient 'axiom undercount claims 3 actual 4' was a race (concurrent-edit mid-flight); recompute stable at 3 across repeated runs. Prior 2026-05 concerns (placeholder area condition, axiom inconsistency) are now openly documented in the entry, not masked."
       ]
     },
     "erdos-634-medial-congruence": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit — erdos-634

**Result: CLEAN** (auditCount 7→8, lastAudited → 2026-07-09)

Persists the tracker bump from today's re-audit. (Auditor loop runs with `REPO_ROOT` pointed at the deregistered worktree, so `claim-target.sh complete` writes never reach `main` — hence this PR.)

### Findings
- **Axioms**: meta claims 3, actual 3 — `seven_not_dissectable`, `eleven_not_dissectable`, `soifer_theorem`. All three disclosed by name in `assumptions` and `originalContributions`. None are `True`-stubs; each carries a genuine proposition.
- **Sorries**: meta claims 6, actual 6 — `congruent_implies_similar` + five positive-result stubs (`squares`/`two`/`three`/`six`/`sum_squares_dissectable`). Matches the `assumptions` description exactly.
- **Status/badge**: `axiomatized`/`axiom` — correct for an open Erdős problem.
- **Disclosure quality**: exemplary. The entry proactively documents the `Erdos634AreaCollapse.lean` internal-inconsistency caveat (the area-only `IsDissectable` predicate is satisfiable for every n≥1, so the Beeson axioms are incompatible with the area-only definition). No masking.

### On the detector's transient flag
The audit detector momentarily reported `axiom undercount: claims 3, actual declarations 4`. Recomputation is stable at **3** across repeated runs and instrumented file-set inspection (main + 2 additionalFiles, no import fan-out). The "4" was a concurrent-edit race, not a real drift.

No changes to gallery-facing content required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)