### PR TITLE
Enrich Gamma Ladder OQ-07-OQ-03-OQ-03: mainTheorems + mathContext + ancestor cross-ref

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/annotations.json
@@ -18,6 +18,7 @@
     "type": "tactic",
     "title": "Whole-line integrability",
     "content": "x^{2n} e^{-x²} is integrable over ℝ. This is transferred from Mathlib's rpow-form lemma integrable_rpow_mul_exp_neg_mul_sq: the monoid power x^{2n} equals the rpow x^{(2n:ℝ)} for every real x (Real.rpow_natCast), so the two integrands agree almost everywhere.",
+    "mathContext": "$x^{2n}e^{-x^2} \\in L^1(\\mathbb{R})$: the Gaussian factor $e^{-x^2}$ decays faster than any polynomial $x^{2n}$ grows, so $\\int_{\\mathbb{R}} x^{2n}e^{-x^2} < \\infty$. The natural power agrees a.e. with the real power $x^{(2n:\\mathbb{R})}$.",
     "significance": "supporting",
     "relatedConcepts": ["Integrable.congr", "Real.rpow_natCast", "integrable_rpow_mul_exp_neg_mul_sq"]
   },
@@ -39,6 +40,7 @@
     "type": "insight",
     "title": "Even symmetry doubles the half-line integral",
     "content": "Since x^{2n} e^{-x²} is even, the Iic 0 half-integral equals the Ioi 0 half-integral (via the reflection integral_comp_neg_Ioi). Splitting ℝ = Iic 0 ∪ Ioi 0 (integral_add_compl) then gives the whole-line integral as twice the half-line value, cancelling the ½ and yielding Γ(n + 1/2).",
+    "mathContext": "$\\int_{\\mathbb{R}} = \\int_{-\\infty}^{0} + \\int_{0}^{\\infty} = 2\\int_{0}^{\\infty}$ for the even integrand, so $\\int_{\\mathbb{R}} x^{2n}e^{-x^2} = 2\\cdot\\tfrac12\\Gamma(n+\\tfrac12) = \\Gamma(n+\\tfrac12)$.",
     "significance": "critical",
     "relatedConcepts": ["even function", "integral_comp_neg_Ioi", "integral_add_compl", "compl_Iic"]
   },
@@ -60,6 +62,7 @@
     "type": "insight",
     "title": "Base cases n = 0 and n = 1",
     "content": "gaussian_moment_zero recovers the parent: ∫_ℝ e^{-x²} dx = √π = Γ(1/2). gaussian_moment_two gives the second even moment ∫_ℝ x² e^{-x²} dx = √π/2, from Γ(3/2) = (1/2)Γ(1/2) = √π/2 (Real.Gamma_add_one).",
+    "mathContext": "$\\int_{\\mathbb{R}} e^{-x^2} = \\Gamma(\\tfrac12) = \\sqrt\\pi$ (rung $n=0$); $\\int_{\\mathbb{R}} x^2 e^{-x^2} = \\Gamma(\\tfrac32) = \\tfrac12\\Gamma(\\tfrac12) = \\tfrac{\\sqrt\\pi}{2}$ (rung $n=1$).",
     "significance": "supporting",
     "relatedConcepts": ["Real.Gamma_one_half_eq", "Real.Gamma_add_one"]
   }

--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
@@ -92,11 +92,42 @@
       "significance": "medium"
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "gaussian_moment_eq_gamma",
+      "type": "main",
+      "description": "The ladder identity: every even Gaussian moment is a half-integer Gamma value, ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2) for all n. The half-line integral is ½ Γ(n + 1/2) via the u = x² substitution (integral_rpow_mul_exp_neg_rpow, matched through Real.rpow_natCast), doubled to the whole line by even symmetry (integral_comp_neg_Ioi). Extends the parent's single value Γ(1/2) = √π to the whole tower.",
+      "leanType": "(n : ℕ) : ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) = Real.Gamma (n + 1 / 2)"
+    },
+    {
+      "name": "gaussian_moment_closed",
+      "type": "main",
+      "description": "The double-factorial closed form ∫_ℝ x^{2n} e^{-x²} dx = (2n−1)‼ · √π / 2ⁿ, combining the ladder identity with Mathlib's Real.Gamma_nat_add_half.",
+      "leanType": "(n : ℕ) : ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) = (2 * n - 1)‼ * √π / 2 ^ n"
+    },
+    {
+      "name": "gaussian_moment_zero",
+      "type": "supporting",
+      "description": "Base case n = 0: ∫_ℝ e^{-x²} dx = √π — recovers the parent entry's Gaussian integral as the bottom rung of the ladder.",
+      "leanType": ": ∫ x : ℝ, Real.exp (-x ^ 2) = √π"
+    },
+    {
+      "name": "gaussian_moment_two",
+      "type": "supporting",
+      "description": "Base case n = 1: ∫_ℝ x² e^{-x²} dx = √π / 2 — the second even moment, the variance-type moment of the Gaussian weight.",
+      "leanType": ": ∫ x : ℝ, x ^ 2 * Real.exp (-x ^ 2) = √π / 2"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-07-oq-03",
       "relationship": "parent",
       "description": "The parent identifies the single value Γ(1/2) = √π with the Gaussian integral ∫_ℝ e^{-x²} dx. This entry extends that to the full half-integer ladder, identifying every Γ(n + 1/2) with the even Gaussian moment ∫_ℝ x^{2n} e^{-x²} dx; gaussian_moment_zero recovers the parent's value as the n = 0 case."
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "ancestor",
+      "description": "Root of the OQ chain: the area πr² ultimately rests on the constant π, of which √π = Γ(1/2) (the n = 0 rung here) is the Gaussian avatar. This entry sits at the analytic end of that lineage, expressing the whole √π ladder Γ(n + 1/2) through Gaussian moments."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-03-oq-03` (quality 95, pass 0).

Three concrete gaps addressed:

**1. `mainTheorems` was absent (0 cards).** Added 4 cards with source-verified `leanType`: `gaussian_moment_eq_gamma`, `gaussian_moment_closed` (main); `gaussian_moment_zero`, `gaussian_moment_two` (supporting).

**2. Three of six annotations lacked `mathContext`.** Added LaTeX math to the integrability, even-symmetry, and base-case annotations — all 6 now carry `mathContext` (meets the ≥5-with-mathContext quality target).

**3. `crossReferences` had only 1 (the parent).** Added `area-of-circle` (root ancestor of the OQ chain): √π = Γ(1/2) is the Gaussian avatar of the π behind the circle area.

No content deleted; both JSON files validated; size check passes.