### PR TITLE
audit(szemeredi-theorem): re-audit CLEAN 2026-07-09

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26076,9 +26076,9 @@
       "issues": []
     },
     "szemeredi-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:46:22Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "szemeredi-theorem-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — szemeredi-theorem

**Result: CLEAN** ✅ (re-audit; previously audited 2026-05-03, auditCount 3→4)

Oldest-audited entry in the gallery (last touched 2026-05-03). Full re-verification against `proofs/Proofs/SzemerediTheorem.lean`.

### Verification
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 1 | 1 (`szemeredi_k_ge_4`, line 122) | ✅ |
| sorries | 0 | 0 | ✅ |
| theoremCount | 16 | 16 | ✅ |
| definitionCount | 5 | 5 | ✅ |
| lineCount | 374 | 374 | ✅ |
| status/badge | axiomatized / axiom | correct | ✅ |

### Integrity findings
- **No axiom masking**: title carries "(k=3 via Mathlib)"; the single `szemeredi_k_ge_4` axiom (genuine Szemerédi statement for k≥4, *not* a `True` stub) is disclosed in description, sections, and `originalContributions`.
- **No delegation opacity**: k=3 honestly derived from Mathlib's `roth_3ap_theorem_nat` (line 270); `mathlibDependencies` and contributions credit Mathlib's corners chain.
- **No True stubs, no `native_decide`.**
- `status: axiomatized` / `badge: axiom` correctly reflect the k≥4 axiom.

Only the tracker is modified (auditCount + lastAudited). Content is accurate; no changes needed.

---
Discovered during gallery integrity audit (auditor-agent).