### PR TITLE
research(erdos-1058-oq-03): Euclid engine — prime factors of n!±1 exceed n, infinitude, twin coprimality [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/Erdos1058OQ03.lean
+++ b/proofs/Proofs/Erdos1058OQ03.lean
@@ -28,7 +28,15 @@
     • `eq_of_prime_dvd_of_isPrimePow` — reusable: a prime-power has a unique prime
         divisor; used to *prove* (axiom-free) that `6! + 1 = 721 = 7·103` and
         `5! - 1 = 119 = 7·17` are **not** prime powers, alongside the prime-power
-        cases `4!+1 = 5²`, `5!+1 = 11²`, `3!-1 = 5`.
+        cases `4!+1 = 5²`, `5!+1 = 11²`, `7!+1 = 71²`, `3!-1 = 5`.
+    • `prime_dvd_factorial_add_one_gt` / `prime_dvd_factorial_sub_one_gt` — **the
+        engine**: every prime factor of `n! + 1` (resp. `n! - 1`) exceeds `n`, the
+        universal form of the divisor obstruction and the reason the technique can
+        localise attention to primes near `n`.
+    • `exists_prime_gt` — Euclid's theorem recovered *through* the factorial
+        construction: for every `n` there is a prime `p > n`.
+    • `coprime_factorial_sub_one_add_one` — the two siblings are coprime:
+        `gcd (n! - 1) (n! + 1) = 1` for `n ≥ 2`.
 
   Reference: https://erdosproblems.com/1058
 -/
@@ -147,5 +155,68 @@ theorem not_isPrimePow_five_factorial_sub_one : ¬ IsPrimePow (Nat.factorial 5 -
   have : (7 : ℕ) = 17 :=
     eq_of_prime_dvd_of_isPrimePow h (by norm_num) (by norm_num) h7 h17
   norm_num at this
+
+/-- The `+1` prime-power pattern resumes at `7`: `7! + 1 = 5041 = 71²`.  (It held at
+    `4!+1 = 5²` and `5!+1 = 11²`, failed at `6!+1 = 7·103`, and returns here.) -/
+theorem isPrimePow_seven_factorial_add_one : IsPrimePow (7 ! + 1) :=
+  (isPrimePow_nat_iff _).mpr ⟨71, 2, by norm_num, by norm_num, by decide⟩
+
+/-! ## The Euclid engine: every prime factor of `n! ± 1` exceeds `n`
+
+The single fact that makes the whole factorial technique work — and the reason
+Erdős–Stewart could restrict attention to primes *near* `n` — is that a prime
+dividing `n! + 1` (or `n! - 1`) must be larger than `n`.  This is the sharp,
+universally-quantified form of `not_dvd_factorial_add_one_of_dvd_factorial`, and it
+immediately re-proves Euclid's theorem through the factorial construction. -/
+
+/-- **The engine (for `n! + 1`).**  Any prime `p` dividing `n! + 1` satisfies
+    `n < p`: if `p ≤ n` then `p ∣ n!`, so `p` would divide `(n!+1) - n! = 1`. -/
+theorem prime_dvd_factorial_add_one_gt {p n : ℕ} (hp : p.Prime)
+    (hpd : p ∣ n ! + 1) : n < p := by
+  by_contra h
+  push_neg at h
+  exact not_dvd_factorial_add_one_of_dvd_factorial hp.one_lt
+    (Nat.dvd_factorial hp.pos h) hpd
+
+/-- **The engine transfers to the sibling `n! - 1`.**  Any prime `p` dividing
+    `n! - 1` also satisfies `n < p`: if `p ≤ n` then `p ∣ n!`, and since
+    `n! = (n! - 1) + 1`, `p` would divide `1`. -/
+theorem prime_dvd_factorial_sub_one_gt {p n : ℕ} (hp : p.Prime)
+    (hpd : p ∣ (n !) - 1) : n < p := by
+  by_contra h
+  push_neg at h
+  have hpdvd : p ∣ n ! := Nat.dvd_factorial hp.pos h
+  have hsplit : n ! = ((n !) - 1) + 1 := by have := Nat.factorial_pos n; omega
+  have h1 : p ∣ 1 := (Nat.dvd_add_right hpd).mp (hsplit ▸ hpdvd)
+  exact hp.one_lt.ne' (Nat.dvd_one.mp h1)
+
+/-- **Euclid's theorem via the factorial technique.**  For every `n` there is a
+    prime exceeding `n`: take any prime factor of `n! + 1` and apply the engine.
+    This is the classical use of the `n! + 1` construction to force new primes. -/
+theorem exists_prime_gt (n : ℕ) : ∃ p, p.Prime ∧ n < p := by
+  have hne : n ! + 1 ≠ 1 := by have := Nat.factorial_pos n; omega
+  obtain ⟨p, hp, hpd⟩ := Nat.exists_prime_and_dvd hne
+  exact ⟨p, hp, prime_dvd_factorial_add_one_gt hp hpd⟩
+
+/-! ## Twin coprimality of the sibling expressions -/
+
+/-- **The two siblings are coprime.**  For `n ≥ 2`, `gcd (n! - 1) (n! + 1) = 1`:
+    the gcd divides their difference `2`, but `2 ∣ n!` makes `n! + 1` odd, so the
+    gcd cannot be `2`.  Hence `n! - 1` and `n! + 1` share no prime factor. -/
+theorem coprime_factorial_sub_one_add_one {n : ℕ} (hn : 2 ≤ n) :
+    Nat.Coprime ((n !) - 1) ((n !) + 1) := by
+  have hd1 : Nat.gcd ((n !) - 1) ((n !) + 1) ∣ ((n !) - 1) := Nat.gcd_dvd_left _ _
+  have hd2 : Nat.gcd ((n !) - 1) ((n !) + 1) ∣ ((n !) + 1) := Nat.gcd_dvd_right _ _
+  have hg2 : Nat.gcd ((n !) - 1) ((n !) + 1) ∣ 2 := by
+    have hsplit : (n !) + 1 = ((n !) - 1) + 2 := by have := Nat.factorial_pos n; omega
+    exact (Nat.dvd_add_right hd1).mp (hsplit ▸ hd2)
+  have h2 : ¬ (2 : ℕ) ∣ ((n !) + 1) := by
+    have hdf : (2 : ℕ) ∣ n ! := Nat.dvd_factorial (by norm_num) hn
+    intro hc
+    have : (2 : ℕ) ∣ 1 := (Nat.dvd_add_right hdf).mp hc
+    norm_num at this
+  rcases (Nat.dvd_prime Nat.prime_two).mp hg2 with h1 | h2eq
+  · exact h1
+  · exact absurd (h2eq ▸ hd2) h2
 
 end Erdos1058OQ03

--- a/research/problems/erdos-1058-oq-03/knowledge.md
+++ b/research/problems/erdos-1058-oq-03/knowledge.md
@@ -1,0 +1,44 @@
+# Knowledge Base: erdos-1058-oq-03
+
+Companion `Erdos1058OQ03.lean` answers OQ-03 ("does the factorial-expression
+technique extend?") with a 0-axiom / 0-sorry Wilson-based development on `n! ± 1`.
+
+## Session 2026-07-09 (researcher-2) — the Euclid engine + infinitude + twin coprimality
+
+**Mode**: DEPTH-FIRST follow-up (file was verified 11 thm; added the general
+structural core) · **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, host
+`lake env lean` exit 0; `#print axioms` = propext/Classical.choice/Quot.sound).
+
+### Added (5 theorems, 11 → 16; 151 → 222 lines) — PR #36306
+- `prime_dvd_factorial_add_one_gt` — every prime factor of `n!+1` exceeds `n`
+  (universal form of the existing divisor obstruction; the reason Erdős–Stewart
+  can localise to primes near `n`). One-liner: `by_contra; push_neg;` then reuse
+  `not_dvd_factorial_add_one_of_dvd_factorial hp.one_lt (Nat.dvd_factorial hp.pos h)`.
+- `prime_dvd_factorial_sub_one_gt` — sibling for `n!-1`.
+- `exists_prime_gt` — Euclid's infinitude *through* the factorial construction:
+  `Nat.exists_prime_and_dvd (n!+1 ≠ 1)` + the engine.
+- `coprime_factorial_sub_one_add_one` — `gcd(n!-1, n!+1) = 1` for `n ≥ 2`.
+- `isPrimePow_seven_factorial_add_one` — `7!+1 = 5041 = 71²` (pattern resumes at 7).
+
+### Gotchas (reusable, this Mathlib pin — Lean 4.26.0)
+- `Nat.dvd_sub'` is GONE (unknown constant). For ℕ, avoid truncated subtraction:
+  rewrite `n! = (n!-1)+1` (via `have := Nat.factorial_pos n; omega`) and use
+  `(Nat.dvd_add_right hpd).mp (hsplit ▸ hpdvd) : p ∣ 1`. Same trick gives
+  `gcd ∣ 2` from `(n!+1) = (n!-1)+2`.
+- **Parsing**: `n ! - 1` mis-parses (`!-1` read as boolean-not applied). `n ! + 1`
+  is fine, but for `- 1` parenthesise the factorial: `(n !) - 1`. (Existing file
+  dodges this by writing `Nat.factorial 5 - 1` / `(n+1)! - 1`.)
+- `Nat.dvd_prime Nat.prime_two : m ∣ 2 ↔ m = 1 ∨ m = 2` cleanly splits the gcd.
+- **Docker olean-write crash (135/139)**: elaboration hit `[7743/7743]` clean in
+  1.7–2.9s with ZERO type errors, then SIGBUS/SIGSEGV on serialization — the fleet
+  memory issue, NOT the code. Verified via single-file host `lake env lean` (no
+  `-o`, so no olean write) after `lake exe cache get` restored a missing module.
+- **Worktree-eater struck again**: `.loom/worktrees/researcher-2-3` was deleted
+  mid-session with uncommitted (verified) edits. Recovered from context, recreated
+  worktree off origin/main, and committed+pushed BEFORE any build.
+
+### Frontier
+The elementary factorial-technique content is now essentially complete: exact
+Wilson characterisation, sibling `n!-1`, the prime-factor-exceeds-`n` engine,
+Euclid infinitude, twin coprimality, and the prime-power data. The parent #1058
+core (Luca's finiteness classification) remains genuinely deep / axiomatized.

--- a/src/data/proofs/erdos-1058-oq-03/meta.json
+++ b/src/data/proofs/erdos-1058-oq-03/meta.json
@@ -51,9 +51,9 @@
       "Axiom-free prime-power classification: 4!+1=5², 5!+1=11² are prime powers; 6!+1=721=7·103 is not; sibling 3!−1=5 prime, 5!−1=119=7·17 not"
     ],
     "axiomCount": 0,
-    "lineCount": 151,
+    "lineCount": 222,
     "assumptions": "None. Fully machine-checked; #print axioms lists only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool — small cases use kernel `decide`, not `native_decide`).",
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 0
   },
   "overview": {
@@ -160,9 +160,9 @@
       "Nat"
     ],
     "namespace": "Erdos1058OQ03",
-    "lineCount": 151,
+    "lineCount": 222,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 0,
     "path": "Proofs/Erdos1058OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the `erdos-1058-oq-03` companion (`Erdos1058OQ03.lean`), which demonstrates the Wilson/factorial-expression technique on `n! ± 1`, with the **general "engine"** behind the Erdős–Stewart restriction to primes near `n`. Where the prior file gave the exact `(n+1) ∣ n!+1 ↔ Prime` characterisation and per-value prime-power computations, this adds the universally-quantified structural facts and their classical consequences.

## New results (5 theorems, all 0 axioms / 0 sorries)

- **`prime_dvd_factorial_add_one_gt`** — every prime factor of `n! + 1` exceeds `n` (the sharp, universal form of `not_dvd_factorial_add_one_of_dvd_factorial`).
- **`prime_dvd_factorial_sub_one_gt`** — the engine transfers to the sibling `n! - 1`.
- **`exists_prime_gt`** — Euclid's theorem (infinitely many primes) recovered *through* the `n!+1` construction: for every `n` there is a prime `p > n`.
- **`coprime_factorial_sub_one_add_one`** — the two siblings are coprime: `gcd(n!-1, n!+1) = 1` for `n ≥ 2`.
- **`isPrimePow_seven_factorial_add_one`** — `7! + 1 = 5041 = 71²`; the `+1` prime-power pattern (`4!+1=5²`, `5!+1=11²`, fails at `6!+1=7·103`) resumes at `7`.

These are classical facts, framed here as showing exactly how far the factorial technique reaches: it forces new primes (Euclid) and separates the twin values.

## Verification

- Host `lake env lean Erdos1058OQ03.lean` (Lean 4.26.0, main-repo Mathlib cache): **exit 0**, no errors/warnings.
- `#print axioms` for all 5 new theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
- File 151 → 222 lines, 11 → 16 theorems; gallery `meta.json` counts synced. Remains `status: verified`, `axiomCount: 0`.

> Note: Docker `docker-build.sh` crashed at the olean-write stage (exit 135/139) *after* clean elaboration (`[7743/7743]`, zero type errors) — the recurring fleet memory-corruption issue, not a code fault. Verified instead via single-file host elaboration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)