### PR TITLE
research(shannon-awgn-oq-02-oq-02): MRC equality case — Cauchy–Schwarz optimum is the matched ray

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -1476,4 +1476,135 @@ theorem mrc_max_snr_lt_of_signal {ι : Type*} {s t : Finset ι} (hst : s ⊆ t) 
   have h2 : (0 : ℝ) < sig j ^ 2 := lt_of_le_of_ne (sq_nonneg _) (Ne.symm (pow_ne_zero 2 hsig))
   exact div_pos h2 (hv j hj)
 
+/-! ### Cauchy–Schwarz equality case: the MRC optimum is the *matched ray*
+
+`mrc_snr_le` is a bare inequality and `mrc_snr_matched` pins the single matched point
+`aᵢ = sigᵢ/vᵢ`.  The results below characterise the **entire** equality locus.  The engine is
+the classical Lagrange / Binet–Cauchy identity, which turns the Cauchy–Schwarz *gap* into a
+manifestly-nonnegative sum of `2×2` minors — so equality holds *iff* every minor vanishes,
+i.e. the two vectors are proportional.  Specialised to the MRC split
+`aᵢsigᵢ = (aᵢ√vᵢ)·(sigᵢ/√vᵢ)`, this says the MRC bound is attained exactly on the matched ray
+`{a : aᵢ ∝ sigᵢ/vᵢ}`. -/
+
+/-- **Lagrange / Binet–Cauchy identity for finite sums.**  The Cauchy–Schwarz gap is a sum of
+squared `2×2` minors:
+
+    ∑ᵢ∑ⱼ (fᵢgⱼ − fⱼgᵢ)² = 2·((∑ᵢ fᵢ²)(∑ⱼ gⱼ²) − (∑ᵢ fᵢgᵢ)²).
+
+The left side is manifestly `≥ 0`, giving Cauchy–Schwarz, and vanishes exactly when every
+minor `fᵢgⱼ − fⱼgᵢ` is zero (proportionality). -/
+theorem lagrange_sum_identity {ι : Type*} (s : Finset ι) (f g : ι → ℝ) :
+    ∑ i ∈ s, ∑ j ∈ s, (f i * g j - f j * g i) ^ 2
+      = 2 * ((∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) - (∑ i ∈ s, f i * g i) ^ 2) := by
+  have hP1 : ∑ i ∈ s, ∑ j ∈ s, f i ^ 2 * g j ^ 2
+      = (∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) := (Finset.sum_mul_sum s s _ _).symm
+  have hP2 : ∑ i ∈ s, ∑ j ∈ s, f j ^ 2 * g i ^ 2
+      = (∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) := by
+    rw [Finset.sum_comm, ← Finset.sum_mul_sum]
+  have hP3 : ∑ i ∈ s, ∑ j ∈ s, (f i * g i) * (f j * g j)
+      = (∑ i ∈ s, f i * g i) ^ 2 := by
+    rw [← Finset.sum_mul_sum, ← pow_two]
+  calc ∑ i ∈ s, ∑ j ∈ s, (f i * g j - f j * g i) ^ 2
+      = ∑ i ∈ s, ∑ j ∈ s,
+          (f i ^ 2 * g j ^ 2 + f j ^ 2 * g i ^ 2 - 2 * ((f i * g i) * (f j * g j))) := by
+        refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+        ring
+    _ = (∑ i ∈ s, ∑ j ∈ s, f i ^ 2 * g j ^ 2)
+          + (∑ i ∈ s, ∑ j ∈ s, f j ^ 2 * g i ^ 2)
+          - 2 * (∑ i ∈ s, ∑ j ∈ s, (f i * g i) * (f j * g j)) := by
+        simp_rw [Finset.sum_sub_distrib, Finset.sum_add_distrib, Finset.mul_sum]
+    _ = 2 * ((∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) - (∑ i ∈ s, f i * g i) ^ 2) := by
+        rw [hP1, hP2, hP3]; ring
+
+/-- **Cauchy–Schwarz equality characterization (finite sums).**  For real sequences `f, g` on a
+finite index set, Cauchy–Schwarz holds with *equality*,
+`(∑ᵢ fᵢgᵢ)² = (∑ᵢ fᵢ²)(∑ⱼ gⱼ²)`, if and only if every `2×2` minor vanishes,
+`fᵢgⱼ = fⱼgᵢ` for all `i, j ∈ s` — i.e. the vectors `f` and `g` are proportional.  Read off the
+Lagrange identity `lagrange_sum_identity`: the gap is a sum of squares, zero iff each term is. -/
+theorem cauchy_schwarz_eq_iff {ι : Type*} (s : Finset ι) (f g : ι → ℝ) :
+    (∑ i ∈ s, f i * g i) ^ 2 = (∑ i ∈ s, f i ^ 2) * (∑ j ∈ s, g j ^ 2) ↔
+      ∀ i ∈ s, ∀ j ∈ s, f i * g j = f j * g i := by
+  have hL := lagrange_sum_identity s f g
+  constructor
+  · intro heq
+    have hzero : ∑ i ∈ s, ∑ j ∈ s, (f i * g j - f j * g i) ^ 2 = 0 := by
+      rw [hL, heq]; ring
+    have hnonneg : ∀ i ∈ s, 0 ≤ ∑ j ∈ s, (f i * g j - f j * g i) ^ 2 :=
+      fun i _ => Finset.sum_nonneg fun j _ => sq_nonneg _
+    have houter := (Finset.sum_eq_zero_iff_of_nonneg hnonneg).mp hzero
+    intro i hi j hj
+    have hinner := (Finset.sum_eq_zero_iff_of_nonneg
+      (fun j _ => sq_nonneg (f i * g j - f j * g i))).mp (houter i hi)
+    have hterm : f i * g j - f j * g i = 0 := sq_eq_zero_iff.mp (hinner j hj)
+    linarith [hterm]
+  · intro h
+    have hzero : ∑ i ∈ s, ∑ j ∈ s, (f i * g j - f j * g i) ^ 2 = 0 := by
+      refine Finset.sum_eq_zero fun i hi => Finset.sum_eq_zero fun j hj => ?_
+      rw [h i hi j hj]; ring
+    rw [hzero] at hL
+    linarith [hL]
+
+/-- **Sharp Cauchy–Schwarz equality case of the MRC signal bound.**  For deterministic gains `a`,
+signal amplitudes `sig`, and strictly positive branch noise variances `v`, the maximal-ratio-
+combining bound `mrc_signal_sq_le` holds with *equality*,
+
+    (∑ᵢ aᵢ·sigᵢ)² = (∑ᵢ aᵢ²·vᵢ) · (∑ᵢ sigᵢ²/vᵢ),
+
+*if and only if* the gain vector is proportional to the matched-filter vector `sigᵢ/vᵢ`, written
+cross-multiplied as `aᵢ·vᵢ·sigⱼ = aⱼ·vⱼ·sigᵢ` for all `i, j ∈ s`.  This identifies the MRC
+optimum as exactly the *matched ray* `{a : aᵢ ∝ sigᵢ/vᵢ}`, sharpening `mrc_snr_le` (a bare
+inequality) and generalizing `mrc_snr_matched` (the single point `aᵢ = sigᵢ/vᵢ`).  Proof:
+`cauchy_schwarz_eq_iff` on the split `aᵢsigᵢ = (aᵢ√vᵢ)·(sigᵢ/√vᵢ)`, then clear the `√vᵢ`. -/
+theorem mrc_signal_sq_eq_iff {ι : Type*} (s : Finset ι) (a sig v : ι → ℝ)
+    (hv : ∀ i ∈ s, 0 < v i) :
+    (∑ i ∈ s, a i * sig i) ^ 2 = (∑ i ∈ s, a i ^ 2 * v i) * (∑ i ∈ s, sig i ^ 2 / v i) ↔
+      ∀ i ∈ s, ∀ j ∈ s, a i * v i * sig j = a j * v j * sig i := by
+  have e1 : ∀ i ∈ s, (a i * Real.sqrt (v i)) * (sig i / Real.sqrt (v i)) = a i * sig i := by
+    intro i hi
+    have hne : Real.sqrt (v i) ≠ 0 := Real.sqrt_ne_zero'.mpr (hv i hi)
+    field_simp
+  have e2 : ∀ i ∈ s, (a i * Real.sqrt (v i)) ^ 2 = a i ^ 2 * v i := by
+    intro i hi; rw [mul_pow, Real.sq_sqrt (hv i hi).le]
+  have e3 : ∀ i ∈ s, (sig i / Real.sqrt (v i)) ^ 2 = sig i ^ 2 / v i := by
+    intro i hi; rw [div_pow, Real.sq_sqrt (hv i hi).le]
+  rw [show (∑ i ∈ s, a i * sig i)
+        = ∑ i ∈ s, (a i * Real.sqrt (v i)) * (sig i / Real.sqrt (v i))
+        from (Finset.sum_congr rfl e1).symm,
+      show (∑ i ∈ s, a i ^ 2 * v i) = ∑ i ∈ s, (a i * Real.sqrt (v i)) ^ 2
+        from (Finset.sum_congr rfl e2).symm,
+      show (∑ i ∈ s, sig i ^ 2 / v i) = ∑ j ∈ s, (sig j / Real.sqrt (v j)) ^ 2
+        from (Finset.sum_congr rfl e3).symm,
+      cauchy_schwarz_eq_iff s (fun i => a i * Real.sqrt (v i))
+        (fun i => sig i / Real.sqrt (v i))]
+  dsimp only
+  refine forall_congr' fun i => imp_congr_right fun hi => forall_congr' fun j =>
+    imp_congr_right fun hj => ?_
+  have hxx : Real.sqrt (v i) * Real.sqrt (v i) = v i := Real.mul_self_sqrt (hv i hi).le
+  have hyy : Real.sqrt (v j) * Real.sqrt (v j) = v j := Real.mul_self_sqrt (hv j hj).le
+  have hxne : Real.sqrt (v i) ≠ 0 := Real.sqrt_ne_zero'.mpr (hv i hi)
+  have hyne : Real.sqrt (v j) ≠ 0 := Real.sqrt_ne_zero'.mpr (hv j hj)
+  constructor
+  · intro h
+    rw [← mul_div_assoc, ← mul_div_assoc, div_eq_div_iff hyne hxne] at h
+    linear_combination h - (a i * sig j) * hxx + (a j * sig i) * hyy
+  · intro h
+    rw [← mul_div_assoc, ← mul_div_assoc, div_eq_div_iff hyne hxne]
+    linear_combination h + (a i * sig j) * hxx - (a j * sig i) * hyy
+
+/-- **MRC matched-ray achievability.**  Every gain vector on the matched ray, `aᵢ = c·sigᵢ/vᵢ`
+for a scalar `c`, attains the Cauchy–Schwarz equality in the MRC signal bound.  Combined with
+`mrc_signal_sq_eq_iff` this shows the optimum is achieved on the *entire* ray through the
+matched-filter vector, not merely at `c = 1` (`mrc_snr_matched`): scaling the gains leaves the
+equality intact, so the maximal-SNR set is a one-dimensional ray, never an isolated point. -/
+theorem mrc_matched_ray_eq {ι : Type*} (s : Finset ι) (c : ℝ) (sig v : ι → ℝ)
+    (hv : ∀ i ∈ s, 0 < v i) :
+    (∑ i ∈ s, (c * (sig i / v i)) * sig i) ^ 2
+      = (∑ i ∈ s, (c * (sig i / v i)) ^ 2 * v i) * (∑ i ∈ s, sig i ^ 2 / v i) := by
+  rw [mrc_signal_sq_eq_iff s (fun i => c * (sig i / v i)) sig v hv]
+  intro i hi j hj
+  have hvi : v i ≠ 0 := (hv i hi).ne'
+  have hvj : v j ≠ 0 := (hv j hj).ne'
+  field_simp
+  ring
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0/0): maximal-ratio-combining (MRC) SNR optimality proved — the max output SNR of a linear combiner over an uncorrelated AWGN branch block equals the summed per-branch SNRs ∑sᵢ²/Var[Nᵢ] (Cauchy-Schwarz upper bound + matched-weight achievability + measure-theoretic capstone resting on the weighted power law). Ties the abstract variance-of-a-weighted-sum theory to the actual AWGN receiver-design theorem.",
+    "progressSummary": "PROGRESS (VERIFIED 0/0): MRC bound equality case now sharp — mrc_signal_sq_eq_iff proves the Cauchy–Schwarz optimum is attained IFF gains lie on the matched ray aᵢ∝sigᵢ/vᵢ, via a self-contained Lagrange/Binet–Cauchy identity and the general finite-sum CS equality condition. Identifies the max-SNR set as a 1-dim ray (mrc_matched_ray_eq), completing the achievability picture beyond the single matched point. Correlated-noise (aᵀΣa) generalization remains the only genuinely open direction.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -68,7 +68,11 @@
       "mrc_signal_sq_le (ShannonChannelCodingAWGNOQ02OQ02.lean): (∑aᵢsigᵢ)²≤(∑aᵢ²vᵢ)(∑sigᵢ²/vᵢ) via Cauchy-Schwarz split fᵢ=aᵢ√vᵢ, gᵢ=sigᵢ/√vᵢ [VERIFIED 0/0]",
       "mrc_snr_le (ShannonChannelCodingAWGNOQ02OQ02.lean): output SNR (∑aᵢsigᵢ)²/(∑aᵢ²vᵢ)≤∑sigᵢ²/vᵢ when noise power>0 [VERIFIED 0/0]",
       "mrc_snr_matched (ShannonChannelCodingAWGNOQ02OQ02.lean): matched weights aᵢ=sigᵢ/vᵢ attain the bound, SNR=∑sigᵢ²/vᵢ [VERIFIED 0/0]",
-      "mrc_output_signal_sq_le_variance_mul (ShannonChannelCodingAWGNOQ02OQ02.lean): measure-theoretic MRC capstone (∑aᵢsigᵢ)²≤Var[∑aᵢ•Nᵢ]·(∑sigᵢ²/Var[Nᵢ]) for pairwise-uncorrelated positive-variance noise [VERIFIED 0/0]"
+      "mrc_output_signal_sq_le_variance_mul (ShannonChannelCodingAWGNOQ02OQ02.lean): measure-theoretic MRC capstone (∑aᵢsigᵢ)²≤Var[∑aᵢ•Nᵢ]·(∑sigᵢ²/Var[Nᵢ]) for pairwise-uncorrelated positive-variance noise [VERIFIED 0/0]",
+      "lagrange_sum_identity (ShannonChannelCodingAWGNOQ02OQ02.lean): ∑ᵢ∑ⱼ(fᵢgⱼ−fⱼgᵢ)² = 2·((∑fᵢ²)(∑gⱼ²)−(∑fᵢgᵢ)²) via Finset.sum_mul_sum + sum_comm",
+      "cauchy_schwarz_eq_iff (same file): (∑fᵢgᵢ)²=(∑fᵢ²)(∑gⱼ²) ↔ ∀i,j fᵢgⱼ=fⱼgᵢ, from Lagrange gap = sum of squares (sum_eq_zero_iff_of_nonneg + sq_eq_zero_iff)",
+      "mrc_signal_sq_eq_iff (same file): sharp MRC equality characterization, matched ray aᵢvᵢsigⱼ=aⱼvⱼsigᵢ, via CS split aᵢsigᵢ=(aᵢ√vᵢ)(sigᵢ/√vᵢ) then div_eq_div_iff + linear_combination to clear √v",
+      "mrc_matched_ray_eq (same file): every aᵢ=c·sigᵢ/vᵢ attains equality (scale-invariance of the optimum), generalizing mrc_snr_matched from c=1 to whole ray"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -89,7 +93,8 @@
       "Strict triangle inequality needs NO fresh analysis: it is purely lt_iff_le_and_ne applied to both sides of the equality boundary (stddev_add_le gives ≤ on the left, abs_correlation_le_one gives ρ≤1 on the right), then not_iff_not on the eq-iff. simp only [stddev_add_le hX hY, hρle, true_and, ne_eq, not_iff_not] discharges the whole reduction in one line.",
       "Weighted combining lifts the whole Bienaymé stack by bilinearity: covariance_smul_left/right push each aᵢ,aⱼ out of cov[aᵢWᵢ,aⱼWⱼ]=aᵢaⱼcov, and variance_smul gives the diagonal Var[aᵢWᵢ]=aᵢ²Var[Wᵢ]; no new analysis, just scalar-out rewrites — working in the a•W (smul) form (not fun ω=>a*W ω) aligns directly with Mathlib covariance_smul_*/variance_smul/MemLp.const_smul.",
       "MRC (maximal-ratio-combining) optimality is a direct Cauchy-Schwarz consequence of the weighted power law: splitting aᵢsᵢ=(aᵢ√vᵢ)(sᵢ/√vᵢ) and applying Finset.sum_mul_sq_le_sq_mul_sq gives (∑aᵢsᵢ)²≤(∑aᵢ²vᵢ)(∑sᵢ²/vᵢ); the noise-power factor ∑aᵢ²vᵢ IS the output variance Var[∑aᵢNᵢ] from variance_smul_sum_of_pairwise_uncorrelated, so combiner optimality rests on the Bienaymé structure, not a fresh hypothesis.",
-      "The maximum output SNR of a linear combiner over an uncorrelated AWGN branch block equals the sum of per-branch SNRs ∑sᵢ²/vᵢ, attained exactly at matched weights aᵢ=sᵢ/vᵢ (both combined signal ∑(sᵢ/vᵢ)sᵢ and noise power ∑(sᵢ/vᵢ)²vᵢ collapse to S=∑sᵢ²/vᵢ, so SNR=S²/S=S) — the achievability half making mrc_snr_le sharp."
+      "The maximum output SNR of a linear combiner over an uncorrelated AWGN branch block equals the sum of per-branch SNRs ∑sᵢ²/vᵢ, attained exactly at matched weights aᵢ=sᵢ/vᵢ (both combined signal ∑(sᵢ/vᵢ)sᵢ and noise power ∑(sᵢ/vᵢ)²vᵢ collapse to S=∑sᵢ²/vᵢ, so SNR=S²/S=S) — the achievability half making mrc_snr_le sharp.",
+      "MRC bound equality is a Cauchy–Schwarz equality case: attained IFF gains are proportional to the matched vector sigᵢ/vᵢ (cross-multiplied aᵢvᵢsigⱼ = aⱼvⱼsigᵢ). The optimum is a full 1-dim RAY, not the isolated point aᵢ=sigᵢ/vᵢ — mrc_snr_matched was only the c=1 slice."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -111,7 +116,9 @@
       "Affine form of the multivariate boundary: √Var[∑Wᵢ]=∑σ requires a COMMON increasing-affine template (all Wᵢ =ᵐ aᵢ·Y+bᵢ, aᵢ>0) — harder than pairwise, needs a shared regressor Y; the pairwise-correlation form is the clean stopping point.",
       "Strict multivariate form: σ[∑Wᵢ] < ∑σ[Wᵢ] ⟺ NOT all pairs perfectly positively correlated — strict companion of stddev_sum_eq_iff_pairwise_correlation_eq_one, via lt_iff_le_and_ne on stddev_sum_le (needs the finite-family ρ≤1 pairwise ceiling, else just ≠-form).",
       "MRC equality condition in variance form: (∑aᵢsigᵢ)²=Var[∑aᵢ•Nᵢ]·(∑sigᵢ²/Var[Nᵢ]) iff a is proportional to the matched vector sigᵢ/Var[Nᵢ] — the Cauchy-Schwarz equality case (vectors aᵢ√vᵢ ∥ sigᵢ/√vᵢ).",
-      "Correlated-noise MRC: replace diagonal ∑aᵢ²vᵢ by the full quadratic form aᵀΣa (Σ=covariance matrix); optimum SNR = sᵀΣ⁻¹s at a=Σ⁻¹s — needs a PD-matrix Cauchy-Schwarz / whitening argument, a genuine generalisation beyond the uncorrelated diagonal case."
+      "Correlated-noise MRC: replace diagonal ∑aᵢ²vᵢ by the full quadratic form aᵀΣa (Σ=covariance matrix); optimum SNR = sᵀΣ⁻¹s at a=Σ⁻¹s — needs a PD-matrix Cauchy-Schwarz / whitening argument, a genuine generalisation beyond the uncorrelated diagonal case.",
+      "MRC equality in variance/measure-theoretic form: lift mrc_signal_sq_eq_iff so vᵢ = Var[Nᵢ] and state the equality condition on the actual noise variances (companion to mrc_output_signal_sq_le_variance_mul).",
+      "Correlated-noise MRC (still open, harder): replace diagonal ∑aᵢ²vᵢ by full quadratic form aᵀΣa; optimum SNR = sᵀΣ⁻¹s at a=Σ⁻¹s — needs PD-matrix Cauchy–Schwarz / whitening, a genuine generalization beyond the diagonal case."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends `ShannonChannelCodingAWGNOQ02OQ02.lean` (VERIFIED 0/0) with the **sharp equality case** of the maximal-ratio-combining (MRC) bound — the natural open next-step for this RICH problem. Previously the file had `mrc_snr_le` (a bare inequality) and `mrc_snr_matched` (the single matched point `aᵢ = sigᵢ/vᵢ`). This PR characterizes the *entire* equality locus.

## New results (4 theorems, pure algebra, 0 axioms / 0 sorries)

- **`lagrange_sum_identity`** — Lagrange / Binet–Cauchy identity: `∑ᵢ∑ⱼ (fᵢgⱼ − fⱼgᵢ)² = 2·((∑fᵢ²)(∑gⱼ²) − (∑fᵢgᵢ)²)`. The Cauchy–Schwarz gap as a manifestly-nonnegative sum of 2×2 minors.
- **`cauchy_schwarz_eq_iff`** — general finite-sum Cauchy–Schwarz equality condition: `(∑fᵢgᵢ)² = (∑fᵢ²)(∑gⱼ²) ↔ ∀ i,j, fᵢgⱼ = fⱼgᵢ` (proportionality).
- **`mrc_signal_sq_eq_iff`** — the payoff: the MRC bound `(∑aᵢsigᵢ)² = (∑aᵢ²vᵢ)(∑sigᵢ²/vᵢ)` holds **iff** `aᵢvᵢsigⱼ = aⱼvⱼsigᵢ` for all `i,j`, i.e. the gains are proportional to the matched vector `sigᵢ/vᵢ`. This identifies the MRC optimum as exactly the **matched ray** `{a : aᵢ ∝ sigᵢ/vᵢ}`.
- **`mrc_matched_ray_eq`** — every `aᵢ = c·sigᵢ/vᵢ` attains equality, generalizing `mrc_snr_matched` from the single point `c = 1` to the whole ray (scale-invariance of the optimum).

## Method

The engine is a self-contained Lagrange identity, applied via the Cauchy–Schwarz split `aᵢsigᵢ = (aᵢ√vᵢ)·(sigᵢ/√vᵢ)`; the `√vᵢ` factors are cleared with `div_eq_div_iff` + `linear_combination`. No inner-product-space detour needed.

## Status

`verified` unchanged (0 axioms, 0 sorries). meta.json counts synced (1610 lines / 64 theorems). knowledge.json updated; the only remaining open direction is the correlated-noise MRC generalization (full quadratic form `aᵀΣa`, needs PD-matrix Cauchy–Schwarz / whitening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)