### PR TITLE
Enrich Degree Factorisation for Normal Extensions

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01/annotations.json
@@ -36,15 +36,27 @@
     "prerequisites": ["the parent equality", "degree multiplicativity"]
   },
   {
-    "id": "normdeg-ann-quotient-boundary",
+    "id": "normdeg-ann-quotient",
     "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01",
-    "range": { "startLine": 95, "endLine": 147 },
+    "range": { "startLine": 95, "endLine": 110 },
     "type": "insight",
-    "title": "The inseparable degree as quotient, and the separability boundary",
-    "content": "card_algEquiv_pos (the automorphism count is positive, via NeZero of the separable degree) licenses cancellation. finInsepDegree_eq_finrank_div_card gives the explicit automorphism-theoretic formula [K:F]_i = [K:F] / |Aut_F(K)| (Nat.mul_div_cancel_left on the factorisation): the inseparable degree is exactly the residual quotient after the automorphism count. card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one and card_algEquiv_eq_finrank_iff_isSeparable read the separability boundary through the cofactor — |Aut| = [K:F] ⟺ [K:F]_i = 1 ⟺ K/F separable — and card_algEquiv_eq_finrank_of_isSeparable recovers Mathlib's IsGalois.card_aut_eq_finrank as the inseparable-cofactor-equals-1 specialisation.",
-    "mathContext": "$[K:F]_i = [K:F] / |\\mathrm{Aut}_F(K)|$; and $|\\mathrm{Aut}_F(K)| = [K:F] \\iff [K:F]_i = 1 \\iff K/F$ separable.",
+    "title": "Positivity and the inseparable degree as a quotient",
+    "content": "card_algEquiv_pos records that for a finite normal extension the automorphism count is positive: it equals the separable degree, which carries a NeZero instance in the finite-dimensional case. This positivity is exactly what licenses cancellation in the factorisation. finInsepDegree_eq_finrank_div_card then rewrites [K:F] = |Aut_F(K)| · [K:F]_i and applies Nat.mul_div_cancel_left to isolate the cofactor, giving the explicit automorphism-theoretic formula [K:F]_i = [K:F] / |Aut_F(K)|. The reading is conceptual: the automorphism group measures precisely the separable part of the degree, so the inseparable degree is the residual quotient — the part of the degree the automorphisms cannot detect.",
+    "mathContext": "$0 < |\\mathrm{Aut}_F(K)|$ (finite case), hence $[K:F]_i = [K:F] / |\\mathrm{Aut}_F(K)|$ via $\\texttt{Nat.mul\\_div\\_cancel\\_left}$ on the factorisation.",
     "significance": "key",
-    "relatedConcepts": ["Nat.mul_div_cancel_left", "isSeparable_iff_finInsepDegree_eq_one", "IsGalois.card_aut_eq_finrank", "inseparable degree formula"],
-    "prerequisites": ["positivity of the separable degree", "the degree factorisation"]
+    "relatedConcepts": ["Nat.mul_div_cancel_left", "NeZero (finSepDegree F K)", "inseparable degree formula", "cancellation"],
+    "prerequisites": ["positivity of the separable degree (NeZero)", "the degree factorisation"]
+  },
+  {
+    "id": "normdeg-ann-boundary",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01",
+    "range": { "startLine": 111, "endLine": 147 },
+    "type": "insight",
+    "title": "The separability boundary and the Galois corollary",
+    "content": "The final block reads the separability boundary off the factorisation. card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one cancels the positive automorphism count (Nat.eq_of_mul_eq_mul_left) to show |Aut_F(K)| = [K:F] ⟺ the inseparable cofactor [K:F]_i = 1. card_algEquiv_eq_finrank_iff_isSeparable composes this with isSeparable_iff_finInsepDegree_eq_one to reach the intrinsic form: full automorphism count ⟺ K/F separable ⟺ Galois — the parent's boundary re-derived through the complementary inseparable degree. card_algEquiv_eq_finrank_of_isSeparable is the Galois corollary, recovering Mathlib's IsGalois.card_aut_eq_finrank as the [K:F]_i = 1 specialisation of the degree formula, and closing the namespace.",
+    "mathContext": "$|\\mathrm{Aut}_F(K)| = [K:F] \\iff [K:F]_i = 1 \\iff K/F$ separable; the Galois case is the inseparable-cofactor-$=1$ specialisation.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.eq_of_mul_eq_mul_left", "isSeparable_iff_finInsepDegree_eq_one", "IsGalois.card_aut_eq_finrank", "separability boundary"],
+    "prerequisites": ["the inseparable-degree quotient", "positivity of the automorphism count"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01`.

## Gap addressed
The entry already had full annotation coverage, but the trailing annotation lumped two distinct mathematical ideas across 53 lines (95–147): the inseparable-degree quotient and the separability-boundary/Galois corollary. Only 4 annotations (target ≥5).

## Change
- Split the 95–147 annotation into two, aligned with the section structure:
  - `normdeg-ann-quotient` (95–110): positivity of the automorphism count + the explicit formula [K:F]_i = [K:F] / |Aut_F(K)|.
  - `normdeg-ann-boundary` (111–147): the separability boundary |Aut|=[K:F] ⟺ [K:F]_i=1 ⟺ separable, and the Galois corollary recovering IsGalois.card_aut_eq_finrank.
- 5 annotations total; contiguous full coverage 1–147 preserved; each has mathContext, significance, relatedConcepts, prerequisites.

## Validation
- `jq empty` on annotations.json — valid.
- `check-meta-size.ts` — within caps.
- meta.json unchanged; no status/axiom claims altered.
- pnpm build not run (fresh worktree has no node_modules).