### PR TITLE
research(erdos-634): repair two soundness inconsistencies in the dissection entry

### DIFF
--- a/proofs/Proofs/Erdos634Problem.lean
+++ b/proofs/Proofs/Erdos634Problem.lean
@@ -24,6 +24,18 @@
   - Beeson: proved 7 and 11 fail
   - Zhang (2025): recent progress on sufficient conditions
 
+  Formalization note (soundness):
+  - `IsDissectable` requires an *abstract* tiling witness `Tiles` (covering +
+    interior-disjointness) on top of area balance. Without it, area balance is
+    trivially satisfiable for every n ≥ 1 (see `Erdos634AreaCollapse.lean`), which
+    would make Beeson's `¬IsDissectable 7/11` axioms provably false. The `Tiles`
+    abstraction is the minimal change that keeps the positive constructions and
+    Beeson's negative results mutually consistent; Mathlib has no polygonal-tiling
+    API to define `Tiles` outright.
+  - `Similar` and `Congruent` are both stated on the *unordered* multiset of side
+    lengths, so `congruent_implies_similar` holds (an order-pinned `Similar` would
+    make it false, since congruence permits relabelling the vertices).
+
   Tags: geometry, dissection, congruent-triangles, open-problem
 -/
 
@@ -71,14 +83,23 @@ theorem congruent_trans {T₁ T₂ T₃ : Triangle} :
 A weaker notion than congruence.
 -/
 
-/-- Two triangles are similar if their side lengths are proportional. -/
+/-- Two triangles are similar if one side-length multiset is a positive scaling
+    of the other. Like `Congruent`, this is stated on the *unordered* multiset of
+    sides: geometric similarity is invariant under relabelling the vertices, so a
+    faithful predicate must not pin the correspondence to the `a/b/c` order. (The
+    earlier order-sensitive `T₂.a = k * T₁.a ∧ …` version was *not* implied by the
+    multiset-based `Congruent` — e.g. sides `(3,4,5)` vs `(4,3,5)` are congruent
+    but admit no single `k` for the fixed order — so `congruent_implies_similar`
+    below was unprovable as stated. This multiset form repairs that.) -/
 def Similar (T₁ T₂ : Triangle) : Prop :=
-  ∃ k : ℝ, k > 0 ∧ T₂.a = k * T₁.a ∧ T₂.b = k * T₁.b ∧ T₂.c = k * T₁.c
+  ∃ k : ℝ, k > 0 ∧
+    Multiset.ofList [T₂.a, T₂.b, T₂.c] =
+      Multiset.ofList [k * T₁.a, k * T₁.b, k * T₁.c]
 
 /-- Congruent triangles are similar (with k = 1). -/
-theorem congruent_implies_similar {T₁ T₂ : Triangle} :
-    Congruent T₁ T₂ → Similar T₁ T₂ := by
-  sorry
+theorem congruent_implies_similar {T₁ T₂ : Triangle}
+    (h : Congruent T₁ T₂) : Similar T₁ T₂ :=
+  ⟨1, one_pos, by simpa only [Congruent, one_mul] using h.symm⟩
 
 /-
 ## Part III: Triangle Dissection
@@ -107,9 +128,30 @@ structure Dissection (T : Triangle) (n : ℕ) where
 def IsCongruentDissection (T : Triangle) (n : ℕ) (D : Dissection T n) : Prop :=
   ∀ i j : Fin n, Congruent (D.pieces i) (D.pieces j)
 
-/-- **Definition**: n is dissectable if some triangle can be cut into n congruent triangles. -/
+/-- **The tiling condition (abstract).** `Tiles T n pieces` asserts that the `n`
+    triangular `pieces` genuinely *tile* `T`: they cover `T` and have pairwise
+    disjoint interiors. Mathlib has no polygonal-tiling API, so this predicate is
+    left **abstract** (declared, not defined).
+
+    This abstraction is not cosmetic — it is exactly what keeps the file
+    *consistent*. The companion `Erdos634AreaCollapse.lean` proves that the
+    area-balance condition alone (`Dissection` + `IsCongruentDissection`) is
+    satisfied for **every** `n ≥ 1`, so a dissectability predicate built from area
+    balance *only* would make Beeson's `¬IsDissectable 7` and `¬IsDissectable 11`
+    (below) provably false — an outright contradiction. Requiring the extra
+    abstract `Tiles` witness blocks that trivial equal-area construction, so the
+    positive constructions and Beeson's negative results can coexist without
+    inconsistency. -/
+axiom Tiles (T : Triangle) (n : ℕ) (pieces : Fin n → Triangle) : Prop
+
+/-- **Definition**: `n` is dissectable if some triangle can be cut into `n`
+    congruent triangles that genuinely tile it — area balance (`Dissection`),
+    mutual congruence (`IsCongruentDissection`), **and** the abstract `Tiles`
+    covering/disjointness witness. The `Tiles` conjunct is what makes this
+    compatible with the negative results of Part V. -/
 def IsDissectable (n : ℕ) : Prop :=
-  ∃ T : Triangle, ∃ D : Dissection T n, IsCongruentDissection T n D
+  ∃ T : Triangle, ∃ D : Dissection T n,
+    IsCongruentDissection T n D ∧ Tiles T n D.pieces
 
 /-
 ## Part IV: Known Positive Results

--- a/research/problems/erdos-634/knowledge.md
+++ b/research/problems/erdos-634/knowledge.md
@@ -1,0 +1,45 @@
+# Erdős #634 — Triangle Dissection into Congruent Pieces
+
+Status: gallery entry present (`Erdos634Problem.lean`), status `axiomatized`.
+The general classification of (T, R, N) is OPEN ($25 prize).
+
+## Session (researcher-6, 2026-07-09): soundness repair of the base entry
+
+The shipped entry `Erdos634Problem.lean` was **logically inconsistent** — it
+could derive `False` two independent ways. Both fixed in PR #36318.
+
+1. **Area-only `IsDissectable` contradicted Beeson.** Dissectability was defined
+   by area balance alone (`∑ pieceᵢ.area = T.area`). The companion
+   `Erdos634AreaCollapse.lean` (merged, PR #35219, 0-axiom) proves this holds for
+   *every* `n ≥ 1` (n equilateral pieces of side `1/√n`). Hence `IsDissectable 7`
+   is provable, contradicting the axiom `¬IsDissectable 7`.
+   **Fix:** added an abstract `axiom Tiles (T) (n) (pieces) : Prop`
+   (covering + interior-disjointness) and made
+   `IsDissectable n := ∃ T D, IsCongruentDissection T n D ∧ Tiles T n D.pieces`.
+   The `Tiles` conjunct blocks the trivial equal-area witness, so Beeson's
+   negatives are now consistent. `Tiles` stays abstract because Mathlib has no
+   polygonal-tiling API.
+
+2. **`congruent_implies_similar` was a `sorry` on a FALSE statement.** `Congruent`
+   is on the unordered side multiset, but `Similar` was order-pinned
+   (`T₂.a = k·T₁.a ∧ …`), which congruence does not imply (`(3,4,5)` vs `(4,3,5)`).
+   **Fix:** restated `Similar` on the unordered multiset (faithful, relabelling-
+   invariant); the theorem is now a real 1-liner
+   `⟨1, one_pos, by simpa only [Congruent, one_mul] using h.symm⟩`.
+
+Counts after: axioms 3→4, sorries 6→5 (the 5 remaining are the genuine reptiling
+constructions `squares/two/three/six/sum`, blocked only on a Mathlib tiling API).
+
+### Verification note
+File elaborated cleanly: a Docker build reached
+`[7743/7743] Building Proofs.Erdos634Problem (2.5s)` with zero type errors.
+A fully green olean write was not obtainable this session (host Docker containerd
+I/O errors + intermittent Mathlib-cache corruption / SIGBUS-135 under fleet load —
+pure infrastructure, never type/math errors).
+
+### Remaining / next directions
+- The real open frontier is a **non-abstract `Tiles`**: a Mathlib polygonal-tiling
+  API (covering + interior-disjoint measurable pieces). The `-oq-02` covering line
+  (`Erdos634MedialCoveringOQ02.lean`) is the concrete-covering seed.
+- Mathematically #634 itself (classification of achievable N) is open; `n=19` is
+  the smallest unknown; `4k+3` prime conjecture (excluding 3).

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 5,
     "erdosNumber": 634,
     "erdosUrl": "https://erdosproblems.com/634",
     "erdosProblemStatus": "open",
@@ -55,9 +55,9 @@
     "relatedProblems": [
       "erdos-633"
     ],
-    "axiomCount": 3,
-    "assumptions": "3 axioms: seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 6 sorries in Erdos634Problem.lean: congruent_implies_similar plus the five positive-result stubs (squares/two/three/six/sum). IMPORTANT CAVEAT (proven in Erdos634AreaCollapse.lean, 0-sorry/0-axiom): the area_partition condition does NOT remove the internal inconsistency an earlier note claimed it did — IsDissectable n is provable for every n ≥ 1 by taking n congruent equilateral pieces of side 1/√n (a constant-function witness that DOES satisfy area_partition). Hence the Beeson non-dissectability axioms are logically incompatible with the area-only Dissection predicate; only a definition enforcing genuine covering and interior-disjointness (the oq-02 covering line) resolves this.",
-    "lineCount": 331,
+    "axiomCount": 4,
+    "assumptions": "4 axioms in Erdos634Problem.lean: Tiles (abstract tiling predicate), seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 5 sorries: the five positive-result stubs (squares/two/three/six/sum), each a genuine reptiling construction blocked only on Mathlib's missing polygonal-tiling API. SOUNDNESS (resolved): a prior version was internally inconsistent — the area-only IsDissectable is provable for every n >= 1 (constant equilateral witnesses of side 1/sqrt(n), proven in Erdos634AreaCollapse.lean), which contradicted the Beeson non-dissectability axioms; and congruent_implies_similar was a sorry on a false statement (unordered-multiset Congruent vs order-pinned Similar). Both are now fixed: IsDissectable additionally requires an abstract Tiles (covering + interior-disjointness) witness, blocking the trivial equal-area construction so Beeson's negatives are consistent; and Similar is restated on the unordered side multiset, making congruent_implies_similar a real 1-line proof. A faithful non-abstract Tiles still awaits a Mathlib tiling API (the oq-02 covering line).",
+    "lineCount": 373,
     "theoremCount": 16,
     "definitionCount": 20,
     "additionalFiles": [
@@ -201,11 +201,11 @@
       "Function"
     ],
     "namespace": "Erdos634",
-    "lineCount": 331,
-    "axiomCount": 3,
+    "lineCount": 373,
+    "axiomCount": 4,
     "theoremCount": 16,
     "definitionCount": 20,
-    "sorries": 6,
+    "sorries": 5,
     "path": "Proofs/Erdos634Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos634Aristotle.lean",
@@ -266,5 +266,5 @@
       "description": "Lagrange's four squares theorem (every positive integer is a sum of four squares) contrasts with the incomplete coverage of dissectable numbers: k², 2k², 3k², k²+m² cover most integers but not all (7, 11, 19 are open). The arithmetic of sums of squares governs which n are dissectable — Lagrange and Fermat's results on square representations directly constrain the structure of dissectable families."
     }
   ],
-  "sorries": 6
+  "sorries": 5
 }


### PR DESCRIPTION
## Summary

`Erdos634Problem.lean` (the shipped gallery entry for Erdős #634) was **logically inconsistent** — its axiom/sorry set could derive `False` two independent ways. This PR repairs both with a minimal diff, leaving all positive constructions and the mathematical content intact.

### Inconsistency 1 — area-only `IsDissectable` vs Beeson's negatives
The entry defined dissectability purely by **area balance** (`∑ pieceᵢ.area = T.area`). The companion `Erdos634AreaCollapse.lean` (merged, 0-axiom) already proves this is satisfied for **every** `n ≥ 1` (take `n` congruent equilateral pieces of side `1/√n`). So `IsDissectable 7` is *provable*, directly contradicting the axiom `¬IsDissectable 7` (Beeson) — i.e. the file's axioms yield `False`.

**Fix:** strengthen `IsDissectable` with an **abstract** tiling witness
```lean
axiom Tiles (T : Triangle) (n : ℕ) (pieces : Fin n → Triangle) : Prop
def IsDissectable (n : ℕ) : Prop :=
  ∃ T, ∃ D : Dissection T n, IsCongruentDissection T n D ∧ Tiles T n D.pieces
```
`Tiles` (genuine covering + interior-disjointness) is left abstract because Mathlib has no polygonal-tiling API. Requiring it blocks the trivial equal-area witness, so the positive constructions and Beeson's negatives are now mutually consistent.

### Inconsistency 2 — `congruent_implies_similar` was a `sorry` on a *false* statement
`Congruent` is defined on the **unordered** side multiset, but `Similar` was order-pinned (`T₂.a = k·T₁.a ∧ …`). Congruent triangles `(3,4,5)` vs `(4,3,5)` then admit **no** single `k`, so the theorem is false — and a `sorry` on a false goal is itself a route to `False`.

**Fix:** restate `Similar` on the unordered multiset (the faithful, relabelling-invariant notion). `congruent_implies_similar` becomes a genuine one-line proof:
```lean
theorem congruent_implies_similar (h : Congruent T₁ T₂) : Similar T₁ T₂ :=
  ⟨1, one_pos, by simpa only [Congruent, one_mul] using h.symm⟩
```

## Net effect
- Entry is now **consistent** (no route to `False`).
- Counts: axioms 3 → 4 (added `Tiles`), sorries 6 → 5 (`congruent_implies_similar` proved). The 5 remaining sorries are the genuine reptiling constructions, blocked only on a Mathlib tiling API.
- No positive-result statement changed; downstream lemmas (`twenty_seven_dissectable`, `three_dissectable`, `conjecture_implies_19`, `erdos_634_partial`) untouched.
- `meta.json` counts synced; `assumptions` field updated to record the inconsistency as **resolved**.

## Build status
Honest disclosure: the committed file **elaborated cleanly** — a Docker build reached `[7743/7743] Building Proofs.Erdos634Problem (2.5s)` with **zero type errors** — but a fully green run (olean write) was not obtainable this session: the host Docker daemon is currently throwing containerd I/O errors and the Mathlib cache is intermittently corrupt under fleet load (SIGBUS-135). The failures are pure infrastructure, never type/math errors. A deployer rebuild once the host recovers will confirm the green olean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)