### PR TITLE
Enrich Explicit Remainder Bound for p-Series Tail

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-isc-oq010102-setup",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "context",
+    "title": "From a Uniform Bound to a Quantitative Rate: the Open Question",
+    "content": "The module docstring frames the entry as the open-question companion to the parent AntitoneIntegralSumComparisonOQ01OQ01. The parent used the antitone integral test to bound every p-series partial sum by the single constant 1/(p−1) = ∫₁^∞ x^{−p} dx, proving convergence for p > 1 — but that constant says nothing about the *speed* of convergence. The refinement here runs the identical integral comparison from base point x = N rather than x = 1, pinning the tail: ∑_{n>N} 1/nᵖ ≤ ∫_N^∞ x^{−p} dx = N^{1−p}/(p−1) = 1/((p−1)·N^{p−1}). The docstring previews the four results (tail partial-sum bound, tail tsum bound, genuine remainder bound, explicit textbook form) and the Basel specialization ∑_{n>N} 1/n² ≤ 1/N. `import Mathlib` pulls in the integral-test and interval-integral machinery; the namespace is opened with the BigOperators, Finset, and intervalIntegral scopes.",
+    "mathContext": "\\sum_{n>N}\\frac{1}{n^p} \\;\\le\\; \\int_N^\\infty x^{-p}\\,dx \\;=\\; \\frac{N^{1-p}}{p-1} \\;=\\; \\frac{1}{(p-1)\\,N^{p-1}} \\quad (p>1,\\ N\\ge 1)",
+    "significance": "context",
+    "relatedConcepts": ["integral test", "rate of convergence", "p-series tail", "base-point shift"],
+    "prerequisites": ["the parent's uniform partial-sum bound 1/(p−1)", "improper integrals ∫ x^{-p} dx", "truncation error of a convergent series"]
+  },
+  {
     "id": "ann-isc-oq010102-tail-partial",
     "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",
     "range": { "startLine": 45, "endLine": 99 },


### PR DESCRIPTION
Enrichment pass for `antitone-integral-sum-comparison-oq-01-oq-01-oq-02`.

## Gap addressed
Annotations covered lines 45–159 but the header/module-docstring preamble (lines 1–44) had no annotation coverage, and the entry had only 4 annotations (target ≥5).

## Change
- Added `ann-isc-oq010102-setup` (type `context`) covering lines 1–44: the `import Mathlib`, the module docstring framing the open question (from the parent's single uniform bound 1/(p−1) to the quantitative tail rate N^{1−p}/(p−1) = 1/((p−1)·N^{p−1})), and the namespace/opens. Includes mathContext, significance, relatedConcepts, prerequisites.
- 5 annotations total; body coverage 45–159 preserved.

## Validation
- `jq empty` on annotations.json — valid.
- `check-meta-size.ts` — within caps (meta.json 12.6 KB ≤ 60 KB).
- meta.json unchanged; no status/axiom claims altered.