### PR TITLE
research(sylow-theorem-oq-04-oq-03): Bruhat generation ⟨U,U⁻⟩ = SL(2,p) [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -609,6 +609,7 @@ theorem weylW_eq_root_word :
       = [[1, a], [0, 1]] · [[1, 0], [-a⁻¹, 1]] · [[1, a], [0, 1]] · [[0, -1], [1, 0]].
 
 Hence the whole split torus `T` lies in `⟨U, U⁻⟩`. -/
+set_option maxHeartbeats 800000 in
 theorem torusDiag_eq_root_word (a : (ZMod p)ˣ) :
     torusDiag a
       = unipotentUpper (a : ZMod p) * lowerUnipotent (-((a : ZMod p)⁻¹))
@@ -624,9 +625,7 @@ theorem torusDiag_eq_root_word (a : (ZMod p)ˣ) :
   rw [hinv]
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one,
-      Matrix.head_cons] <;>
-    field_simp <;> ring
+    simp [Matrix.mul_apply, Fin.sum_univ_two] <;> field_simp <;> ring
 
 /-- The two opposite root groups `U ∪ U⁻`, the Bruhat generators of `SL(2, p)`. -/
 def rootGroups : Set (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) :=
@@ -662,6 +661,7 @@ nonzero lies in `⟨U, U⁻⟩`, via the Bruhat factorization
 
 where `a = g₀₀`, `d = g₁₁`.  (The top-right entry checks out because
 `ad − bc = 1`.)  Since `u(·), w, diag(c)` all lie in `⟨U, U⁻⟩`, so does `g`. -/
+set_option maxHeartbeats 800000 in
 theorem mem_closure_of_lowerLeft_ne_zero
     (g : Matrix.SpecialLinearGroup (Fin 2) (ZMod p))
     (hc : (g : Matrix (Fin 2) (Fin 2) (ZMod p)) 1 0 ≠ 0) :
@@ -680,19 +680,18 @@ theorem mem_closure_of_lowerLeft_ne_zero
       val_torusDiag, Units.val_mk0, hv2]
     ext i j
     fin_cases i <;> fin_cases j <;>
-      simp only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one,
-        Matrix.head_cons]
-    · field_simp <;> ring
-    · field_simp
+      simp [Matrix.mul_apply, Fin.sum_univ_two] <;>
+      field_simp <;>
       first
+        | ring
         | linear_combination hdet
         | linear_combination -hdet
         | linear_combination (A 1 0) * hdet
         | linear_combination -(A 1 0) * hdet
-    · field_simp <;> ring
-    · field_simp <;> ring
   have hword : g = unipotentUpper (A 0 0 * (A 1 0)⁻¹) * weylW * torusDiag (Units.mk0 (A 1 0) hc)
-      * unipotentUpper (A 1 1 * (A 1 0)⁻¹) := Subtype.ext key.symm
+      * unipotentUpper (A 1 1 * (A 1 0)⁻¹) := by
+    apply Subtype.ext
+    exact key.symm
   rw [hword]
   exact mul_mem (mul_mem (mul_mem (unipotentUpper_mem_closure_rootGroups _)
     weylW_mem_closure_rootGroups) (torusDiag_mem_closure_rootGroups _))
@@ -725,9 +724,7 @@ theorem closure_rootGroups_eq_top :
     have hbl : ((lowerUnipotent 1 * g : Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) :
         Matrix (Fin 2) (Fin 2) (ZMod p)) 1 0 ≠ 0 := by
       rw [Matrix.SpecialLinearGroup.coe_mul, val_lowerUnipotent]
-      simp only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one,
-        Matrix.head_cons, hc, mul_zero, add_zero]
-      exact hane
+      simpa [Matrix.mul_apply, Fin.sum_univ_two, hc] using hane
     have hmem : lowerUnipotent 1 * g ∈ Subgroup.closure (rootGroups (p := p)) :=
       mem_closure_of_lowerLeft_ne_zero _ hbl
     have hinv : lowerUnipotent (-1 : ZMod p) * lowerUnipotent 1 = 1 := by

--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -541,4 +541,201 @@ theorem exists_lowerUnipotent_isCommutator (hp : 5 ≤ p) (s : ZMod p) :
     group
   rw [key, hc, weylW_conj_unipotent, neg_neg]
 
+/-!
+## Bruhat generation: `⟨U, U⁻⟩ = SL(2, p)`
+
+The final structural input to Iwasawa's criterion is the **generation hypothesis**:
+the two opposite root groups generate the whole group,
+
+    ⟨U, U⁻⟩ = SL(2, 𝔽_p).
+
+Combined with the perfectness lemmas above (`exists_unipotent_isCommutator` and
+`exists_lowerUnipotent_isCommutator`, which place `U` and `U⁻` inside the derived
+subgroup for `p ≥ 5`), this makes `SL(2, p)` perfect — the perfectness half of
+Iwasawa — and it is also the generation clause of Iwasawa's lemma itself.
+
+The proof is the concrete **Bruhat/Gauss decomposition** of `SL(2)`.  Two
+elementary factorizations feed it:
+
+* the Weyl element is a word in the root groups,
+  `w = u(-1) · l(1) · u(-1)` (`weylW_eq_root_word`);
+* every torus element is a word in the root groups,
+  `diag(a) = u(a) · l(-a⁻¹) · u(a) · w` (`torusDiag_eq_root_word`), so the whole
+  split torus `T` lies in `⟨U, U⁻⟩`.
+
+With `w, T ⊆ ⟨U, U⁻⟩` (and `U, U⁻` there by definition) the Bruhat cell
+`u(x)·w·diag(c)·u(y)` covers every matrix with nonzero lower-left entry
+(`mem_closure_of_lowerLeft_ne_zero`); a single lower transvection `l(1)` moves the
+remaining `c = 0` matrices into that cell, giving
+`closure_rootGroups_eq_top`.
+-/
+
+/-- The lower unipotent embedding is additive:
+`[[1,0],[s,1]] · [[1,0],[t,1]] = [[1,0],[s+t,1]]`. -/
+theorem lowerUnipotent_mul (s t : ZMod p) :
+    lowerUnipotent s * lowerUnipotent t = lowerUnipotent (s + t) := by
+  apply Subtype.ext
+  show (!![1, 0; s, 1] : Matrix (Fin 2) (Fin 2) (ZMod p)) * !![1, 0; t, 1]
+      = !![1, 0; s + t, 1]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two, add_comm]
+
+/-- The lower unipotent embedding sends `0` to the identity matrix. -/
+theorem lowerUnipotent_zero : lowerUnipotent (0 : ZMod p) = 1 := by
+  apply Subtype.ext
+  show (!![1, (0 : ZMod p); 0, 1] : Matrix (Fin 2) (Fin 2) (ZMod p)) = 1
+  rw [Matrix.one_fin_two]
+
+/-- **The Weyl element is a word in the two root groups.**  `w = u(-1)·l(1)·u(-1)`:
+
+    [[0, -1], [1, 0]] = [[1, -1], [0, 1]] · [[1, 0], [1, 1]] · [[1, -1], [0, 1]].
+
+This exhibits `w ∈ ⟨U, U⁻⟩`, the Bruhat generator that swaps the two root groups. -/
+theorem weylW_eq_root_word :
+    weylW (p := p)
+      = unipotentUpper (-1) * lowerUnipotent 1 * unipotentUpper (-1) := by
+  apply Subtype.ext
+  show (!![0, -1; 1, 0] : Matrix (Fin 2) (Fin 2) (ZMod p))
+      = !![1, -1; 0, 1] * !![1, 0; 1, 1] * !![1, -1; 0, 1]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two] <;> ring
+
+/-- **Every torus element is a word in the two root groups.**
+`diag(a) = u(a)·l(-a⁻¹)·u(a)·w`:
+
+    [[a, 0], [0, a⁻¹]]
+      = [[1, a], [0, 1]] · [[1, 0], [-a⁻¹, 1]] · [[1, a], [0, 1]] · [[0, -1], [1, 0]].
+
+Hence the whole split torus `T` lies in `⟨U, U⁻⟩`. -/
+theorem torusDiag_eq_root_word (a : (ZMod p)ˣ) :
+    torusDiag a
+      = unipotentUpper (a : ZMod p) * lowerUnipotent (-((a : ZMod p)⁻¹))
+          * unipotentUpper (a : ZMod p) * weylW := by
+  have hc : (a : ZMod p) ≠ 0 := a.ne_zero
+  have hinv : ((a⁻¹ : (ZMod p)ˣ) : ZMod p) = (a : ZMod p)⁻¹ :=
+    Units.val_inv_eq_inv_val a
+  apply Subtype.ext
+  show (!![(a : ZMod p), 0; 0, ((a⁻¹ : (ZMod p)ˣ) : ZMod p)]
+        : Matrix (Fin 2) (Fin 2) (ZMod p))
+      = !![1, (a : ZMod p); 0, 1] * !![1, 0; -((a : ZMod p)⁻¹), 1]
+          * !![1, (a : ZMod p); 0, 1] * !![0, -1; 1, 0]
+  rw [hinv]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.head_cons] <;>
+    field_simp <;> ring
+
+/-- The two opposite root groups `U ∪ U⁻`, the Bruhat generators of `SL(2, p)`. -/
+def rootGroups : Set (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) :=
+  Set.range (unipotentUpper (p := p)) ∪ Set.range (lowerUnipotent (p := p))
+
+theorem unipotentUpper_mem_closure_rootGroups (t : ZMod p) :
+    unipotentUpper t ∈ Subgroup.closure (rootGroups (p := p)) :=
+  Subgroup.subset_closure (Set.mem_union_left _ ⟨t, rfl⟩)
+
+theorem lowerUnipotent_mem_closure_rootGroups (t : ZMod p) :
+    lowerUnipotent t ∈ Subgroup.closure (rootGroups (p := p)) :=
+  Subgroup.subset_closure (Set.mem_union_right _ ⟨t, rfl⟩)
+
+/-- The Weyl element lies in `⟨U, U⁻⟩`. -/
+theorem weylW_mem_closure_rootGroups :
+    weylW ∈ Subgroup.closure (rootGroups (p := p)) := by
+  rw [weylW_eq_root_word]
+  exact mul_mem (mul_mem (unipotentUpper_mem_closure_rootGroups _)
+    (lowerUnipotent_mem_closure_rootGroups _)) (unipotentUpper_mem_closure_rootGroups _)
+
+/-- The whole split torus `T` lies in `⟨U, U⁻⟩`. -/
+theorem torusDiag_mem_closure_rootGroups (a : (ZMod p)ˣ) :
+    torusDiag a ∈ Subgroup.closure (rootGroups (p := p)) := by
+  rw [torusDiag_eq_root_word]
+  exact mul_mem (mul_mem (mul_mem (unipotentUpper_mem_closure_rootGroups _)
+    (lowerUnipotent_mem_closure_rootGroups _)) (unipotentUpper_mem_closure_rootGroups _))
+    weylW_mem_closure_rootGroups
+
+/-- **Bruhat cell membership.**  Every `g ∈ SL(2, p)` whose lower-left entry `c` is
+nonzero lies in `⟨U, U⁻⟩`, via the Bruhat factorization
+
+    g = u(a·c⁻¹) · w · diag(c) · u(d·c⁻¹),
+
+where `a = g₀₀`, `d = g₁₁`.  (The top-right entry checks out because
+`ad − bc = 1`.)  Since `u(·), w, diag(c)` all lie in `⟨U, U⁻⟩`, so does `g`. -/
+theorem mem_closure_of_lowerLeft_ne_zero
+    (g : Matrix.SpecialLinearGroup (Fin 2) (ZMod p))
+    (hc : (g : Matrix (Fin 2) (Fin 2) (ZMod p)) 1 0 ≠ 0) :
+    g ∈ Subgroup.closure (rootGroups (p := p)) := by
+  set A := (g : Matrix (Fin 2) (Fin 2) (ZMod p)) with hA
+  have hdet : A 0 0 * A 1 1 - A 0 1 * A 1 0 = 1 := by
+    have h : A.det = 1 := Matrix.SpecialLinearGroup.det_coe g
+    rw [Matrix.det_fin_two] at h
+    exact h
+  have hv2 : (((Units.mk0 (A 1 0) hc)⁻¹ : (ZMod p)ˣ) : ZMod p) = (A 1 0)⁻¹ := by
+    rw [Units.val_inv_eq_inv_val, Units.val_mk0]
+  have key : ((unipotentUpper (A 0 0 * (A 1 0)⁻¹) * weylW * torusDiag (Units.mk0 (A 1 0) hc)
+        * unipotentUpper (A 1 1 * (A 1 0)⁻¹) : Matrix.SpecialLinearGroup (Fin 2) (ZMod p))
+        : Matrix (Fin 2) (Fin 2) (ZMod p)) = A := by
+    simp only [Matrix.SpecialLinearGroup.coe_mul, val_unipotentUpper, val_weylW,
+      val_torusDiag, Units.val_mk0, hv2]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one,
+        Matrix.head_cons]
+    · field_simp <;> ring
+    · field_simp
+      first
+        | linear_combination hdet
+        | linear_combination -hdet
+        | linear_combination (A 1 0) * hdet
+        | linear_combination -(A 1 0) * hdet
+    · field_simp <;> ring
+    · field_simp <;> ring
+  have hword : g = unipotentUpper (A 0 0 * (A 1 0)⁻¹) * weylW * torusDiag (Units.mk0 (A 1 0) hc)
+      * unipotentUpper (A 1 1 * (A 1 0)⁻¹) := Subtype.ext key.symm
+  rw [hword]
+  exact mul_mem (mul_mem (mul_mem (unipotentUpper_mem_closure_rootGroups _)
+    weylW_mem_closure_rootGroups) (torusDiag_mem_closure_rootGroups _))
+    (unipotentUpper_mem_closure_rootGroups _)
+
+/-- **`⟨U, U⁻⟩ = SL(2, p)`.**  The two opposite root groups generate the whole
+special linear group.  This is the Bruhat generation theorem: matrices with a
+nonzero lower-left entry are covered by the big Bruhat cell
+(`mem_closure_of_lowerLeft_ne_zero`), and the remaining matrices — those with
+lower-left entry `0`, forcing the top-left entry to be a unit — are pulled into
+that cell by one lower transvection `l(1)`.
+
+Together with `exists_unipotent_isCommutator` / `exists_lowerUnipotent_isCommutator`
+(both root groups lie in the derived subgroup for `p ≥ 5`) this yields perfectness
+of `SL(2, p)` for `p ≥ 5`, and it is the generation hypothesis of Iwasawa's
+simplicity criterion for `PSL(2, p)`. -/
+theorem closure_rootGroups_eq_top :
+    Subgroup.closure (rootGroups (p := p)) = ⊤ := by
+  rw [Subgroup.eq_top_iff']
+  intro g
+  by_cases hc : (g : Matrix (Fin 2) (Fin 2) (ZMod p)) 1 0 = 0
+  · -- lower-left entry `0`: `det = 1` forces the top-left entry `g₀₀ ≠ 0`.
+    have hane : (g : Matrix (Fin 2) (Fin 2) (ZMod p)) 0 0 ≠ 0 := by
+      intro ha0
+      have h : (g : Matrix (Fin 2) (Fin 2) (ZMod p)).det = 1 :=
+        Matrix.SpecialLinearGroup.det_coe g
+      rw [Matrix.det_fin_two, ha0, hc] at h
+      simp at h
+    -- `l(1) · g` then has lower-left entry `g₀₀ + g₁₀ = g₀₀ ≠ 0`.
+    have hbl : ((lowerUnipotent 1 * g : Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) :
+        Matrix (Fin 2) (Fin 2) (ZMod p)) 1 0 ≠ 0 := by
+      rw [Matrix.SpecialLinearGroup.coe_mul, val_lowerUnipotent]
+      simp only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one,
+        Matrix.head_cons, hc, mul_zero, add_zero]
+      exact hane
+    have hmem : lowerUnipotent 1 * g ∈ Subgroup.closure (rootGroups (p := p)) :=
+      mem_closure_of_lowerLeft_ne_zero _ hbl
+    have hinv : lowerUnipotent (-1 : ZMod p) * lowerUnipotent 1 = 1 := by
+      rw [lowerUnipotent_mul, neg_add_cancel, lowerUnipotent_zero]
+    have hg : g = lowerUnipotent (-1) * (lowerUnipotent 1 * g) := by
+      rw [← mul_assoc, hinv, one_mul]
+    rw [hg]
+    exact mul_mem (lowerUnipotent_mem_closure_rootGroups _) hmem
+  · exact mem_closure_of_lowerLeft_ne_zero g hc
+
 end SylowOQ04OQ03

--- a/research/problems/sylow-theorem-oq-04-oq-03/state.md
+++ b/research/problems/sylow-theorem-oq-04-oq-03/state.md
@@ -48,3 +48,30 @@ meta.theoremCount 17→18 + mainTheorems entry). PR pending.
 **Still BLOCKED** (deep theorem): full perfectness needs ⟨U,U⁻⟩=SL(2,p) generation; the
 simplicity theorem needs the P¹(𝔽_p) action + 2-transitivity + Iwasawa assembly (>1000 L,
 absent from Mathlib). Next tractable BUILD: generation ⟨U,U⁻⟩=SL(2,p) via Bruhat/Gauss.
+
+
+## Session 2026-07-09 (researcher-1) — BUILD: Bruhat generation ⟨U,U⁻⟩ = SL(2,p) [UNVERIFIED]
+Closed the **generation hypothesis** of Iwasawa's criterion by proving
+`closure_rootGroups_eq_top : Subgroup.closure (rootGroups) = ⊤` (rootGroups = range U ∪ range U⁻),
+the concrete Bruhat/Gauss decomposition of SL(2,p) — no P¹ action needed:
+- `weylW_eq_root_word`: `w = u(-1)·l(1)·u(-1)` (w is a word in the root groups);
+- `torusDiag_eq_root_word`: `diag(a) = u(a)·l(-a⁻¹)·u(a)·w` (whole split torus T ⊆ ⟨U,U⁻⟩);
+- `mem_closure_of_lowerLeft_ne_zero`: g with lower-left c≠0 = `u(ac⁻¹)·w·diag(c)·u(dc⁻¹)`
+  (top-right closes via ad−bc=1);
+- c=0 case: det=1 ⇒ g₀₀≠0, and `l(1)·g` has nonzero lower-left, so `l(-1)·(l(1)·g)` sweeps it in.
+Plus helpers `lowerUnipotent_mul/_zero` and membership lemmas for U, U⁻, w, T.
+Re-establishes and **completes** PR #35565's reverted rootGroups material (that had only membership
+of w/T, not the full `= ⊤`). File 544→738 L, 0 sorry / 0 axiom.
+
+**BLOCKER this session**: Docker Desktop's containerd metadata DB hit a persistent `input/output error`
+(`write .../io.containerd.metadata.v1.bolt/meta.db: input/output error`), so `docker run`/image build
+fails before reaching Lean — verification could NOT complete. An earlier repaired-cache build DID reach
+the file and showed only tactic-automation gaps (simp only left `!![..] ⟨0,⋯⟩ j` unevaluated), which are
+fixed by using full `simp [Matrix.mul_apply, Fin.sum_univ_two]` for index evaluation before
+`field_simp`/`linear_combination`, plus `maxHeartbeats 800000` on the two 4-matrix-product theorems.
+Work is committed+pushed on branch `research/sylow-oq0403-s1783630146`; **needs a clean Docker build to
+confirm** before it can be called VERIFIED.
+
+## Next Action
+Once Docker recovers, build `Proofs.SylowTheoremOQ04OQ03`; if green, upgrade status to VERIFIED and
+package perfectness `commutator (SL(2,p)) = ⊤` (p≥5) from generation + the derived-subgroup lemmas.

--- a/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
@@ -56,14 +56,15 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "BUILD/VERIFIED (researcher-1, 2026-07-08): added the perfectness engine — the T–U commutator identity [diag(a),u(t)]=u((a²−1)t) and its corollary that for p≥5 every unipotent is a commutator [diag(2),u(t)] (a²−1=3 a unit iff p∉{2,3}). SylowTheoremOQ04OQ03.lean now 520 lines / 0 sorry / 0 axiom. This supplies the perfectness hypothesis of Iwasawa's criterion; the deep simplicity theorem (PSL(2,p) action on P¹, 2-transitivity, Iwasawa assembly) remains open.",
+    "progressSummary": "BUILD (researcher-1, 2026-07-09) [UNVERIFIED — build blocked by Docker daemon containerd I/O corruption, not a code error]: added the Bruhat generation theorem closure_rootGroups_eq_top : ⟨U,U⁻⟩ = ⊤ for SL(2,p). Two elementary root-group factorizations feed it — weylW_eq_root_word (w = u(-1)·l(1)·u(-1)) and torusDiag_eq_root_word (diag(a) = u(a)·l(-a⁻¹)·u(a)·w, so the whole split torus T ⊆ ⟨U,U⁻⟩) — plus the Bruhat cell lemma mem_closure_of_lowerLeft_ne_zero (g = u(a·c⁻¹)·w·diag(c)·u(d·c⁻¹) covers every matrix with nonzero lower-left entry) and a single lower transvection l(1) to sweep in the c=0 matrices. This CLOSES the generation hypothesis of Iwasawa's criterion and, with the existing perfectness lemmas (U,U⁻ ⊆ derived subgroup for p≥5), gives perfectness of SL(2,p). Re-establishes & completes PR #35565's reverted rootGroups material (which only had membership, not the '= ⊤' theorem). File 544→738 lines / 0 sorry / 0 axiom (pending build confirmation).",
     "insights": [
       "The right tool is Iwasawa's criterion, not raw Sylow counting: PSL(2,p) acts 2-transitively (hence primitively and faithfully) on the p+1 points of P¹(𝔽_p); the unipotent upper-triangular subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} is abelian, normal in the stabilizer of ∞, and its PSL-conjugates generate PSL(2,p); with perfectness for p ≥ 5, IwasawaStructure.isSimpleGroup concludes.",
       "Mathlib's PSL support is a single 39-line abbreviation with no order, no group action, and no simplicity lemmas — so the bottleneck is entirely the missing connective infrastructure, not the final criterion.",
       "The p = 5 case is already in Mathlib as isSimpleGroup_five (PSL(2,5) ≅ A₅); a parametrized proof must recover it uniformly, so a family-level Iwasawa argument is genuinely more than re-deriving the parent.",
       "Perfectness (commutator PSL = ⊤) is the p ≥ 5 hinge: for p = 2 (PSL(2,2) ≅ S₃) and p = 3 (PSL(2,3) ≅ A₄) the group is NOT simple, precisely because perfectness fails — the p ≥ 5 hypothesis enters through this Iwasawa side condition.",
       "Perfectness of SL(2,p)/PSL(2,p) for p≥5 reduces to a single commutator identity: [diag(a),u(t)] = u((a²−1)·t). Composing torusHom_conj_unipotent (diag(a)·u(t)·diag(a)⁻¹ = u(a²t)) with the additive law u(a²t)·u(−t) = u((a²−1)t) gives it in two rewrites. When a²−1 is a unit the map t↦[diag(a),u(t)] is onto U, so every unipotent is a commutator.",
-      "The range p≥5 in the simplicity theorem is exactly the range where the perfectness engine fires: a=2 gives a²−1=3, a unit iff p∉{2,3}. This pins the failure at p=2,3 to the non-invertibility of 3 (=2²−1) mod p, matching PSL(2,2)≅S₃ and PSL(2,3)≅A₄ being non-simple."
+      "The range p≥5 in the simplicity theorem is exactly the range where the perfectness engine fires: a=2 gives a²−1=3, a unit iff p∉{2,3}. This pins the failure at p=2,3 to the non-invertibility of 3 (=2²−1) mod p, matching PSL(2,2)≅S₃ and PSL(2,3)≅A₄ being non-simple.",
+      "The generation ⟨U,U⁻⟩ = SL(2,p) is the concrete Bruhat/Gauss decomposition and needs no P¹ action: (i) w = u(-1)·l(1)·u(-1) and diag(a) = u(a)·l(-a⁻¹)·u(a)·w are explicit words in the root groups, so w and the entire torus T lie in ⟨U,U⁻⟩; (ii) any g with lower-left c≠0 factors as u(ac⁻¹)·w·diag(c)·u(dc⁻¹) (the top-right entry closes via ad-bc=1); (iii) g with c=0 has g₀₀≠0, and l(1)·g has lower-left g₀₀≠0, so l(-1)·(l(1)·g) pulls it into the Bruhat cell. This is the missing 'PSL-conjugates of U generate' clause of Iwasawa, obtained entirely inside SL(2,ZMod p)."
     ],
     "mathlibGaps": [
       "No cardinality of SL(2,𝔽_p) or PSL(2,p) in Mathlib (need |SL(2,𝔽_p)| = p(p²−1)).",
@@ -72,19 +73,19 @@
       "No perfectness result commutator (PSL(2,p)) = ⊤ for p ≥ 5."
     ],
     "nextSteps": [
-      "BUILD (standalone, ~300–500 lines): formalize the action of SL(2,𝔽_p) on P¹(𝔽_p) = points/lines of 𝔽_p², prove it is 2-transitive, and identify the stabilizer of ∞ as the Borel subgroup of upper-triangular matrices. This is reusable infrastructure independent of the simplicity goal.",
-      "BUILD: prove |SL(2,𝔽_p)| = p(p²−1) and derive |PSL(2,p)| = p(p²−1)/2 for odd p (Sylow-p subgroup is exactly the order-p unipotent U).",
-      "Assemble the Iwasawa structure (U abelian-normal-in-stabilizer, conjugates generate) and prove perfectness for p ≥ 5, then apply IwasawaStructure.isSimpleGroup.",
-      "Until the P¹ action infrastructure exists, keep this entry BLOCKED rather than attempting the simplicity theorem directly on top of missing foundations.",
-      "Package the commutator result as membership in the derived subgroup (commutator/perfect group API), then combine with card_unipotent_range to show U ⊆ [SL(2,p),SL(2,p)] and step toward perfectness of the whole group.",
-      "REGRESSION to flag: PR #35565's rootGroups material (⟨U,U⁻⟩ contains w and the torus, file→539 lines) was reverted on main by a stale-base merge in #35578 (erdos-1064); main is back to 436 lines. Consider restoring that verified generation step."
+      "VERIFY the Bruhat generation additions once Docker recovers (host containerd meta.db I/O error blocked the build this session; the earlier clean elaboration of the pre-fix version showed only tactic-automation gaps in torusDiag_eq_root_word / key, now addressed with full-simp index evaluation + uniform closers).",
+      "Package perfectness: with closure_rootGroups_eq_top plus exists_unipotent_isCommutator / exists_lowerUnipotent_isCommutator, prove commutator (SL(2,p)) = ⊤ for p≥5 (U,U⁻ generate and both lie in the derived subgroup ⇒ derived = ⊤). This is the perfectness input to Iwasawa in closed form.",
+      "BUILD |SL(2,𝔽_p)| = p(p²−1) (still absent from Mathlib) and derive |PSL(2,p)|.",
+      "BUILD the action of SL(2,𝔽_p) on P¹(𝔽_p), its 2-transitivity, and the Borel point-stabilizer — the remaining Iwasawa ingredient before IwasawaStructure.isSimpleGroup can be applied.",
+      "Assemble IwasawaStructure and conclude PSL(2,p) simple for p≥5."
     ],
     "builtItems": [
       "SylowTheoremOQ04OQ03.lean (VERIFIED, 0-axiom/0-sorry, 388 lines / 17 lemmas): PART I unipotent Sylow-p U={[[1,t],[0,1]]} (unipotentHom injective additive hom, |U|=p); PART II split torus T={diag(a,a⁻¹)} (torusHom injective, |T|=p-1) with torusHom_conj_unipotent + torus_normalizes_unipotent (T normalises U); PART III Weyl element weylW=[[0,-1],[1,0]] with explicit inverse, weylW_conj_torus (reflection a↦a⁻¹), lowerUnipotent U⁻ + weylW_conj_unipotent (w·U·w⁻¹=U⁻), and unipotent_inter_torus_trivial (U∩T=1 ⇒ B=U⋊T internal semidirect product). All Iwasawa/Bruhat ingredients toward PSL(2,p) simplicity.",
       "torus_unipotent_commutator (SylowTheoremOQ04OQ03.lean): [diag(a),u(t)] = u((a²−1)·t), VERIFIED 0/0",
       "unipotent_isCommutator_of_isUnit (SylowTheoremOQ04OQ03.lean): a²−1 a unit ⟹ every u(s) is a T–U commutator, VERIFIED 0/0",
       "exists_unipotent_isCommutator (SylowTheoremOQ04OQ03.lean): p≥5 ⟹ every u(s) is a commutator [diag(2),u(t)] (perfectness input), VERIFIED 0/0",
-      "unipotentUpper_inv (SylowTheoremOQ04OQ03.lean): (u(t))⁻¹ = u(−t) helper, VERIFIED 0/0"
+      "unipotentUpper_inv (SylowTheoremOQ04OQ03.lean): (u(t))⁻¹ = u(−t) helper, VERIFIED 0/0",
+      "closure_rootGroups_eq_top + weylW_eq_root_word + torusDiag_eq_root_word + mem_closure_of_lowerLeft_ne_zero + rootGroups + membership lemmas + lowerUnipotent_mul/_zero (SylowTheoremOQ04OQ03.lean, +~194 lines): Bruhat generation ⟨U,U⁻⟩ = SL(2,p). [UNVERIFIED — Docker daemon I/O corruption blocked the build; mathematically hand-checked, tactics mirror the file's verified matrix-identity idiom.]"
     ]
   },
   "leanFiles": [


### PR DESCRIPTION
## Summary

Closes the **generation hypothesis** of Iwasawa's simplicity criterion for PSL(2,p): the two opposite root groups generate the whole special linear group,

```
closure_rootGroups_eq_top : Subgroup.closure (rootGroups) = ⊤    -- rootGroups = range U ∪ range U⁻
```

This is the concrete **Bruhat/Gauss decomposition** of SL(2,p), obtained entirely inside `SL(2, ZMod p)` — it needs none of the (still-missing) P¹(𝔽_p) action infrastructure. It re-establishes **and completes** the rootGroups material from PR #35565 (reverted on main by a stale-base merge in #35578), which had only *membership* of the Weyl element and torus, not the full `= ⊤` theorem.

### New results (+~194 lines, still 0 sorry / 0 axiom)
- `weylW_eq_root_word` — `w = u(-1)·l(1)·u(-1)` (Weyl element is a word in the root groups)
- `torusDiag_eq_root_word` — `diag(a) = u(a)·l(-a⁻¹)·u(a)·w`, so the whole split torus `T ⊆ ⟨U,U⁻⟩`
- `mem_closure_of_lowerLeft_ne_zero` — the Bruhat cell: any `g` with lower-left `c ≠ 0` equals `u(a·c⁻¹)·w·diag(c)·u(d·c⁻¹)` (top-right entry closes via `ad − bc = 1`)
- `closure_rootGroups_eq_top` — the `c = 0` matrices are pulled into that cell by one lower transvection `l(1)` (since `det = 1 ⇒ g₀₀ ≠ 0`)
- supporting: `rootGroups`, membership lemmas for U/U⁻/w/T, `lowerUnipotent_mul`, `lowerUnipotent_zero`

Together with the existing perfectness lemmas (`exists_unipotent_isCommutator` / `exists_lowerUnipotent_isCommutator`, which place both root groups in the derived subgroup for `p ≥ 5`), this yields perfectness of `SL(2,p)` for `p ≥ 5` — the perfectness input to Iwasawa — and the generation clause is now closed.

## ⚠️ Verification status: UNVERIFIED — build blocked by host infrastructure

The Docker build could **not** be completed this session: Docker Desktop's containerd metadata DB hit a persistent `input/output error` (`write .../io.containerd.metadata.v1.bolt/meta.db: input/output error`), so `docker run`/image build fails before Lean even starts.

An earlier build (after `--repair-cache`) *did* reach the file and showed only **tactic-automation** gaps — `simp only` left `!![..] ⟨0,⋯⟩ j` unevaluated on `fin_cases` Fin literals, so `field_simp`/`ring` timed out. Those are fixed here by using full `simp [Matrix.mul_apply, Fin.sum_univ_two]` for index evaluation (the idiom the rest of this file uses), a uniform `first | ring | linear_combination …` closer, and `maxHeartbeats 800000` on the two 4-matrix-product theorems. The matrix identities were hand-verified.

**Please build `Proofs.SylowTheoremOQ04OQ03` before merging.** If any automation closer needs a tweak it will be a localized `linear_combination` coefficient / `field_simp` adjustment, not a structural issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)