### PR TITLE
Enrich Cos 2π/n OQ-02→OQ-01: foundational references

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-01/meta.json
@@ -217,6 +217,26 @@
       "venue": "Springer GTM 83, 2nd ed.",
       "year": "1997",
       "note": "The maximal real subfield ℚ(ζ_n)⁺ = ℚ(ζ_n + ζ_n⁻¹) = ℚ(cos 2π/n) and its index-2 relation to ℚ(ζ_n) via complex conjugation — the field-theoretic statement this entry realizes at the element level."
+    },
+    {
+      "key": "Gauss-Disquisitiones",
+      "authors": [
+        "C. F. Gauss"
+      ],
+      "title": "Disquisitiones Arithmeticae, Section VII (arts. 335–366: theory of the equation xⁿ − 1 = 0)",
+      "venue": "G. Fleischer, Leipzig",
+      "year": "1801",
+      "note": "The founding treatment of cyclotomy: Gauss studied ℚ(ζ_n), its real generator ζ + ζ⁻¹ = 2cos 2π/n, and the tower of subfields, and characterized the constructible regular n-gons — the source of the degree [ℚ(cos 2π/n):ℚ] = φ(n)/2 whose index-2 halving this entry witnesses via complex conjugation."
+    },
+    {
+      "key": "Wantzel-1837",
+      "authors": [
+        "P. L. Wantzel"
+      ],
+      "title": "Recherches sur les moyens de reconnaître si un problème de Géométrie peut se résoudre avec la règle et le compas",
+      "venue": "Journal de Mathématiques Pures et Appliquées, 1re série, tome 2, pp. 366–372",
+      "year": "1837",
+      "note": "The first proof that a general angle cannot be trisected (nor the cube duplicated) with straightedge and compass, via the degree of the minimal polynomial — the classical impossibility result that the cos 2π/n degree formula makes precise for the cos 20° = cos 2π/18 instance."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `angle-trisection-cos-20-gal-oq-02-oq-01`.

## Gap addressed
The entry was already well-enriched (5 annotations with full line coverage, rich overview/conclusion), but its `references` array had only 2 modern items and omitted the two foundational historical sources the mathematics rests on.

## Change
- Added **Gauss, *Disquisitiones Arithmeticae* (1801), Section VII** — the founding treatment of cyclotomy (ℚ(ζ_n), its real generator 2cos 2π/n, and constructible regular n-gons); the origin of the degree formula [ℚ(cos 2π/n):ℚ] = φ(n)/2 whose index-2 halving this entry witnesses.
- Added **Wantzel (1837)** — the first straightedge-and-compass impossibility proof for angle trisection, the classical result the cos 2π/n degree formula makes precise for cos 20° = cos 2π/18.
- `references` 2 → 4 (well under the 25-item cap). No other fields modified.

## Validation
- `jq empty` on meta.json — valid.
- `check-meta-size.ts` — within caps (meta.json 18 KB ≤ 60 KB).
- No status/axiom/count claims altered; only historically-accurate citations added.