### PR TITLE
research(erdos-666): Conder ε=1/3 refutation — axiom count held at 1

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -164,23 +164,74 @@ contains C₆.
 def ErdosConjecture : Prop :=
   ∀ ε : ℝ, ε > 0 → ConjectureAt ε
 
+/-!
+### Monotonicity of the conjecture in the density `ε`
+
+`ConjectureAt` is monotone in `ε`: strengthening the density hypothesis (larger
+`ε`) can only make the conjecture easier to satisfy.  Dually, a single
+counterexample at one density refutes the conjecture at every *smaller* density.
+These three lemmas are pure bookkeeping — no axioms — and are used below in two
+ways: to recover Chung's `1/4` refutation as a corollary of Conder's sharper
+`1/3` one (so the file needs a single deep axiom, not two), and to spread each
+refutation across an entire interval of densities (Part IV.5).
+-/
+
+unseal EpsilonDenseSubgraph in
+/-- **`ε`-density is antitone in `ε`.**  A subgraph that is `ε`-dense is also
+`ε'`-dense for every `ε' ≤ ε`, since the required edge count `ε' · Eₙ ≤ ε · Eₙ`
+only decreases (the hypercube edge count `Eₙ = n·2ⁿ⁻¹` is nonnegative). -/
+theorem epsilonDense_antitone {n : ℕ} {ε ε' : ℝ} (hle : ε' ≤ ε)
+    {H : SimpleGraph (Fin (2^n))} (hH : EpsilonDenseSubgraph n ε H) :
+    EpsilonDenseSubgraph n ε' H :=
+  le_trans (mul_le_mul_of_nonneg_right hle (Nat.cast_nonneg _)) hH
+
+/-- **`DenseForcesC6` is monotone in `ε`.**  If every `ε'`-dense subgraph is forced
+to contain `C₆`, then so is every `ε`-dense subgraph for `ε ≥ ε'` (the `ε`-dense
+subgraphs form a subclass of the `ε'`-dense ones). -/
+theorem denseForcesC6_mono {n : ℕ} {ε ε' : ℝ} (hle : ε' ≤ ε)
+    (h : DenseForcesC6 n ε') : DenseForcesC6 n ε :=
+  fun H hH => h H (epsilonDense_antitone hle hH)
+
+/-- **`ConjectureAt` is monotone in `ε`.**  The same threshold `N` witnesses the
+conjecture at the larger density `ε` once it holds at `ε' ≤ ε`. -/
+theorem conjectureAt_mono {ε ε' : ℝ} (hle : ε' ≤ ε)
+    (h : ConjectureAt ε') : ConjectureAt ε :=
+  let ⟨N, hN⟩ := h
+  ⟨N, fun n hn => denseForcesC6_mono hle (hN n hn)⟩
+
 /--
-**Chung's theorem (1992), refutation form.**
-For the density `ε = 1/4` there is *no* threshold `N` beyond which every
-`(1/4)`-dense subgraph of `Qₙ` contains a `C₆`.
+**Conder's theorem (1993), refutation form — the sharpest known counterexample.**
+For the density `ε = 1/3` there is *no* threshold `N` beyond which every
+`(1/3)`-dense subgraph of `Qₙ` contains a `C₆`.
 
-Chung edge-partitions `Qₙ` (for `n ≥ 3`) into four `C₆`-free subgraphs; by
-pigeonhole one part carries `≥ 1/4` of the `n·2ⁿ⁻¹` edges while remaining
-`C₆`-free. Hence for *every* candidate threshold `N`, taking `n = max N 3`
-produces a `(1/4)`-dense `C₆`-free subgraph — so `ConjectureAt (1/4)` fails.
-We axiomatize this consequence directly: the explicit `4`-partition construction
-is combinatorial and not available in Mathlib.
+Conder (1993) refined Chung's four-part construction to a proper `3`-edge-colouring
+of `Qₙ` (for `n ≥ 3`) in which no colour class contains a `C₄` or a `C₆`.  By
+pigeonhole one of the three colour classes carries `≥ 1/3` of the `n·2ⁿ⁻¹` edges
+while remaining `C₆`-free, so for *every* candidate threshold `N` (taking
+`n = max N 3`) there is a `(1/3)`-dense `C₆`-free subgraph — hence
+`ConjectureAt (1/3)` fails.  The explicit `3`-colouring is combinatorial and not
+available in Mathlib, so we axiomatize this consequence directly.
 
-This is stated in the arrow/negation form `¬ ConjectureAt (1/4)` (rather than the
+This is stated in the negation form `¬ ConjectureAt (1/3)` (rather than the
 mathematically-equivalent `∃ H, dense H ∧ ¬ HasC6 H`) because the latter's type
 triggers a Mathlib v4.26 elaborator stack overflow; see the header note.
+
+This is the **single** deep combinatorial input of the file: Chung's earlier `1/4`
+refutation (`chung_no_threshold`) is recovered from it by monotonicity, so we
+axiomatize only the strongest published result rather than each density separately.
 -/
-axiom chung_no_threshold : ¬ ConjectureAt (1/4)
+axiom conder_no_threshold : ¬ ConjectureAt (1/3)
+
+/--
+**Chung's theorem (1992), refutation form — now a corollary of Conder's.**
+`ConjectureAt (1/4)` fails.  Chung's original `4`-partition of `Qₙ` yields a
+`(1/4)`-dense `C₆`-free subgraph directly; here we obtain the same conclusion for
+free from the sharper `conder_no_threshold` via `conjectureAt_mono` (since
+`1/4 ≤ 1/3`).  Keeping this as a named theorem preserves every downstream use of
+`chung_no_threshold` while letting the file rest on Conder's single axiom.
+-/
+theorem chung_no_threshold : ¬ ConjectureAt (1/4) :=
+  fun h => conder_no_threshold (conjectureAt_mono (by norm_num : (1 : ℝ) / 4 ≤ 1 / 3) h)
 
 /-
 **C₆-free subgraphs of `Qₙ` exist (existence form).**
@@ -216,39 +267,16 @@ theorem erdos_conjecture_false : ¬ErdosConjecture := fun hConj =>
   chung_no_threshold (hConj (1/4) (by norm_num))
 
 /-!
-### Part IV.5: The refutation holds on the whole interval `ε ≤ 1/4`
+### Part IV.5: Each refutation holds on a whole interval of densities
 
-Chung's axiom only names the single density `ε = 1/4`, but the counterexample it
-supplies refutes the conjecture for *every* smaller density as well: a graph that
-is `(1/4)`-dense and `C₆`-free is automatically `ε`-dense for any `ε ≤ 1/4`, so no
-threshold can work at any such `ε`.  Formally this is a monotonicity fact —
-`ConjectureAt` is monotone in `ε` — and it costs **no new axioms**, only the
-already-assumed `chung_no_threshold`.  The upshot: Erdős's conjecture fails not at
-an isolated bad density but robustly across the entire range `(0, 1/4]`.
+A single counterexample at some density refutes the conjecture for *every* smaller
+density: a graph that is `ε₀`-dense and `C₆`-free is automatically `ε`-dense for any
+`ε ≤ ε₀`, so no threshold can work at any such `ε` (this is the monotonicity of
+`ConjectureAt` proved above).  Applying it to Conder's `1/3` axiom — and to the
+`1/4` corollary — spreads each refutation across an interval.  The upshot: Erdős's
+conjecture fails not at isolated bad densities but robustly across the entire range
+`(0, 1/3]`, with no new axioms beyond `conder_no_threshold`.
 -/
-
-unseal EpsilonDenseSubgraph in
-/-- **`ε`-density is antitone in `ε`.**  A subgraph that is `ε`-dense is also
-`ε'`-dense for every `ε' ≤ ε`, since the required edge count `ε' · Eₙ ≤ ε · Eₙ`
-only decreases (the hypercube edge count `Eₙ = n·2ⁿ⁻¹` is nonnegative). -/
-theorem epsilonDense_antitone {n : ℕ} {ε ε' : ℝ} (hle : ε' ≤ ε)
-    {H : SimpleGraph (Fin (2^n))} (hH : EpsilonDenseSubgraph n ε H) :
-    EpsilonDenseSubgraph n ε' H :=
-  le_trans (mul_le_mul_of_nonneg_right hle (Nat.cast_nonneg _)) hH
-
-/-- **`DenseForcesC6` is monotone in `ε`.**  If every `ε'`-dense subgraph is forced
-to contain `C₆`, then so is every `ε`-dense subgraph for `ε ≥ ε'` (the `ε`-dense
-subgraphs form a subclass of the `ε'`-dense ones). -/
-theorem denseForcesC6_mono {n : ℕ} {ε ε' : ℝ} (hle : ε' ≤ ε)
-    (h : DenseForcesC6 n ε') : DenseForcesC6 n ε :=
-  fun H hH => h H (epsilonDense_antitone hle hH)
-
-/-- **`ConjectureAt` is monotone in `ε`.**  The same threshold `N` witnesses the
-conjecture at the larger density `ε` once it holds at `ε' ≤ ε`. -/
-theorem conjectureAt_mono {ε ε' : ℝ} (hle : ε' ≤ ε)
-    (h : ConjectureAt ε') : ConjectureAt ε :=
-  let ⟨N, hN⟩ := h
-  ⟨N, fun n hn => denseForcesC6_mono hle (hN n hn)⟩
 
 /-- **Chung's refutation extends to every `ε ≤ 1/4`.**  Were the conjecture to hold
 at some `ε ≤ 1/4`, monotonicity would push it up to `ε = 1/4`, contradicting
@@ -257,12 +285,22 @@ in particular for every positive density `0 < ε ≤ 1/4`. -/
 theorem chung_no_threshold_le {ε : ℝ} (hε : ε ≤ 1/4) : ¬ ConjectureAt ε :=
   fun h => chung_no_threshold (conjectureAt_mono hε h)
 
+/-- **Conder's refutation extends to every `ε ≤ 1/3`** — the sharpest interval.
+Were the conjecture to hold at some `ε ≤ 1/3`, monotonicity would push it up to
+`ε = 1/3`, contradicting `conder_no_threshold`.  So `ConjectureAt ε` fails for the
+whole interval `ε ≤ 1/3`, strictly extending the `ε ≤ 1/4` range of
+`chung_no_threshold_le`.  In particular Erdős's conjecture fails for every positive
+density `0 < ε ≤ 1/3`. -/
+theorem conder_no_threshold_le {ε : ℝ} (hε : ε ≤ 1/3) : ¬ ConjectureAt ε :=
+  fun h => conder_no_threshold (conjectureAt_mono hε h)
+
 /-
 ## Part V: Chung's Result (1992)
 
-The deep combinatorial content — Chung's edge-partition of `Qₙ` into four
-`C₆`-free subgraphs — is captured by the axioms `chung_no_threshold` and
-`chung_c6free` in Part IV. Here we record the immediate ε = 1/4 counterexample
+The single deep combinatorial axiom of the file is `conder_no_threshold`
+(Conder's sharper `1/3` result); Chung's `1/4` refutation `chung_no_threshold` is
+derived from it in Part IV by monotonicity, and `chung_c6free` is proved outright
+from the empty subgraph. Here we record the immediate ε = 1/4 existence
 corollary.
 -/
 
@@ -287,24 +325,31 @@ with no monochromatic C₄ or C₆.
 
 **Conder's 3-coloring theorem (1993):** For n ≥ 3, the edges of Qₙ can be
 3-colored with no monochromatic C₄ or C₆. This improves Chung/BDT from 4
-colors to 3.
+colors to 3, pushing the refuting density from `1/4` up to `1/3`.
+
+The density content of Conder's improvement is exactly `conder_no_threshold`
+(`¬ ConjectureAt (1/3)`) and its interval form `conder_no_threshold_le`, both
+established in Part IV.  We record here only the honest *existence* corollary that
+Conder's construction supplies a `C₆`-free subgraph of `Qₙ` — the extra density
+`1/3 > 1/4` cannot be attached to the existence statement itself without the
+Mathlib v4.26 elaborator crash (see the header note), so it lives in the axiom.
+
+(The previous formulation of this corollary attached a vacuous `True` conjunct in
+place of the `1/3` density claim; that placeholder is removed — the real `1/3`
+content is now the axiom `conder_no_threshold` and the theorem
+`conder_no_threshold_le`.)
 -/
 
 /--
-**Improved bound: ε = 1/3:**
-With 3 colors, each color class has ~1/3 of edges but no C₆. The conclusion only
-needs existence of a C₆-free subgraph, which Chung's construction already gives.
--/
-theorem conder_better_bound (n : ℕ) (hn : n ≥ 3) :
-    ∃ H : SimpleGraph (Fin (2^n)),
-      -- H has ~1/3 of the edges (even denser than Chung's 1/4)
-      True ∧
-      -- H has no C₆
-      ¬HasC6 H := by
-  -- Conder's 3-coloring improves Chung's 4-coloring, but the conclusion
-  -- only needs existence of a C₆-free subgraph, which Chung already gives.
-  obtain ⟨H, h⟩ := chung_counterexample n hn
-  exact ⟨H, trivial, h⟩
+**Conder's ε = 1/3 counterexample (existence form).**
+Conder's `3`-colouring supplies, for every `n ≥ 3`, a `C₆`-free subgraph of `Qₙ`
+(one of the three colour classes, each carrying `~1/3` of all edges).  The bare
+existence statement carries no edge-count data, so it follows from the empty-graph
+witness already used for Chung; the `1/3` density content is the separate axiom
+`conder_no_threshold`. -/
+theorem conder_counterexample (n : ℕ) (hn : n ≥ 3) :
+    ∃ H : SimpleGraph (Fin (2^n)), ¬HasC6 H :=
+  chung_c6free n hn
 
 /-
 ## Part VIII: Erdős's Generalization

--- a/research/problems/erdos-666-incomplete-01/knowledge.md
+++ b/research/problems/erdos-666-incomplete-01/knowledge.md
@@ -47,3 +47,62 @@ Match the existing `chung_c6free` order: `unseal … in` / `/-- … -/` / `theor
 **Remaining (unchanged):** `conder_better_bound` keeps a `True` placeholder for the
 ε=1/3 density (needs Conder's 3-coloring = a new deep axiom); `GeneralizedConjecture`
 (C_{2k}) open. Build: green attempt 1.
+
+## Session 2026-07-09 (researcher-4) — Conder ε=1/3 sharpening, axiom count held at 1
+
+**Mode**: REVISIT (MODERATE) · **Outcome**: progress (VERIFIED 0 sorry / 1 axiom,
+host `lake env lean` EXIT=0, `#print axioms` = propext/Classical.choice/Quot.sound +
+`Erdos666.conder_no_threshold` only — no sorryAx).
+
+### What I did
+Replaced the vacuous `conder_better_bound` (a `True`-placeholder theorem whose
+docstring *claimed* Conder's ε=1/3 improvement but proved nothing about density)
+with the genuine, published result — **without raising the axiom count**:
+
+1. **Axiomatized the STRONGER result.** `conder_no_threshold : ¬ ConjectureAt (1/3)`
+   (Conder 1993's 3-edge-colouring, each class C₄,C₆-free ⇒ a (1/3)-dense C₆-free
+   subgraph) is now the single deep axiom, replacing `chung_no_threshold`.
+2. **Derived Chung from Conder.** `chung_no_threshold : ¬ConjectureAt (1/4)` is now a
+   THEOREM: `fun h => conder_no_threshold (conjectureAt_mono (by norm_num : (1:ℝ)/4 ≤ 1/3) h)`.
+   `#print axioms chung_no_threshold` confirms its only nonstd dep is
+   `conder_no_threshold` (not itself). So axiom count stays **1** (swap 1/4→1/3,
+   the stronger), and every downstream user of `chung_no_threshold` (erdos_conjecture_false,
+   chung_no_threshold_le) is untouched.
+3. **Sharp interval.** `conder_no_threshold_le : ε ≤ 1/3 → ¬ConjectureAt ε` extends the
+   refutation to the whole (0, 1/3], strictly beyond researcher-2's (0, 1/4].
+4. Renamed the placeholder `conder_better_bound` → honest `conder_counterexample`
+   (existence witness only, no fake density claim). Moved the three monotonicity
+   lemmas up (before the axiom) so `chung_no_threshold` can consume `conjectureAt_mono`.
+
+### Files modified
+- `proofs/Proofs/Erdos666Problem.lean` (368 → 413 lines; axiom 1→1 renamed, theorems 9→11).
+- `src/data/proofs/erdos-666/meta.json` — leanFile counts, assumptions, proofStrategy
+  (×2: .meta + .overview), section line-ranges remapped, conder section text.
+- `src/data/proofs/erdos-666/annotations.json` — ann-666-chung (both now theorems),
+  ann-666-conder-bound (real 1/3 content, range 323–354).
+
+### Key findings / notes (reusable)
+- **Axiom-count-neutral strengthening pattern**: when a file axiomatizes result A and a
+  strictly stronger published result B implies A, axiomatize B and DERIVE A as a theorem.
+  Net axioms unchanged, math strengthened, and (here) a `True` placeholder removed.
+  Requires the monotonicity/implication lemma to be defined *before* the derived corollary.
+- `#print axioms <derived>` is the honesty check: it must list the NEW axiom, proving the
+  old name is genuinely derived, not silently re-axiomatized.
+- **Fleet-race cache corruption** hammered every build this session: docker + host
+  `lake env lean` failed on a DIFFERENT missing/invalid Mathlib olean/.ir each run
+  (OpenPartialHomeomorph → aesop Index.ir → AddTorsor.Coord → Monoidal.Action.Opposites →
+  Ring.Basic); one run even SIGSEGV'd (exit 139) with no error. Control test on the
+  *original* file gave EXIT=0, and `lake exe cache get!` (force full re-download) then
+  gave my file a clean EXIT=0 — the crashes were environment, not code. Verify with the
+  ORIGINAL file as a control before blaming your edit.
+- **Worktree-eater struck again** mid-`git commit`: `.loom/worktrees/researcher-4-2` was
+  deleted, staged changes lost. RECOVERY: the edited Lean file survived in a `/tmp` copy
+  made during verification; JSON edits were reconstructed from the session's jq commands.
+  Lesson: keep a `/tmp` copy of the main edited file, and the branch ref survives worktree
+  deletion (recreate with `git worktree add <path> <branch>`).
+
+### Next steps (unchanged hard core)
+- `GeneralizedConjecture` (C_{2k}) remains open — genuinely different (sparser
+  c·n^{aₖ}·2ⁿ density), not a specialization of the C₆ refutation.
+- Erdős's dense C₄,C₆-free ⇒ C₈ existence (moment/KST counting) — not session-sized,
+  not in Mathlib. The elementary refutation theory is now essentially complete.

--- a/src/data/proofs/erdos-666/annotations.json
+++ b/src/data/proofs/erdos-666/annotations.json
@@ -240,7 +240,7 @@
     },
     "type": "concept",
     "title": "Chung's Partition (1992)",
-    "content": "**chung_no_threshold / chung_c6free:**\n\nFor n ≥ 3, Qₙ can be edge-partitioned into 4 subgraphs H₁, H₂, H₃, H₄ such that:\n1. Each Hᵢ is a subgraph of Qₙ\n2. The Hᵢ partition Qₙ's edges (disjoint union)\n3. Each Hᵢ is C₆-free\n\nEach part has approximately n·2ⁿ⁻¹/4 edges - a 1/4 fraction. This is captured by two axioms: chung_no_threshold (no threshold N forces C₆ in every (1/4)-dense subgraph) supplies the disproof, and chung_c6free (a C₆-free subgraph exists for n ≥ 3) supplies the corollaries. The split avoids a Mathlib v4.26 elaborator stack overflow on the bundled ∃ H, dense ∧ ¬C₆ form.",
+    "content": "**chung_no_threshold / chung_c6free:**\n\nFor n ≥ 3, Qₙ can be edge-partitioned into 4 subgraphs H₁, H₂, H₃, H₄ such that:\n1. Each Hᵢ is a subgraph of Qₙ\n2. The Hᵢ partition Qₙ's edges (disjoint union)\n3. Each Hᵢ is C₆-free\n\nEach part has approximately n·2ⁿ⁻¹/4 edges — a 1/4 fraction, giving the ε = 1/4 counterexample. Neither statement is an axiom here: chung_no_threshold (no threshold N forces C₆ in every (1/4)-dense subgraph) is DERIVED from the sharper Conder axiom conder_no_threshold (¬ ConjectureAt 1/3) by monotonicity, and chung_c6free (a C₆-free subgraph exists for n ≥ 3) is proved outright from the empty subgraph ⊥. The single deep axiom is conder_no_threshold; the ¬ ConjectureAt arrow form avoids a Mathlib v4.26 elaborator stack overflow on the bundled ∃ H, dense ∧ ¬C₆ form.",
     "mathContext": "Published in J. Graph Theory. The construction is explicit and algebraic, using properties of binary strings.",
     "significance": "key",
     "relatedConcepts": [
@@ -327,13 +327,13 @@
     "id": "ann-666-conder-bound",
     "proofId": "erdos-666",
     "range": {
-      "startLine": 220,
-      "endLine": 231
+      "startLine": 323,
+      "endLine": 354
     },
     "type": "concept",
     "title": "ε = 1/3 Counterexample",
-    "content": "**conder_better_bound:**\n\nFor n ≥ 3, there exists H ⊆ Qₙ with ~1/3 of all edges and no C₆.\n\nThis is a stronger counterexample than Chung's ε = 1/4.\n\n**Open question:** Is 3 optimal, or can we do even better with 2 colors?",
-    "mathContext": "The gap between ε = 1/3 and ε = 1/2 remains unexplored.",
+    "content": "**Conder (1993), ε = 1/3 — sharpest refutation.** conder_no_threshold : ¬ ConjectureAt (1/3) axiomatizes Conder's 3-edge-colouring (each colour class C₄,C₆-free, carrying ~1/3 of the edges), giving a (1/3)-dense C₆-free subgraph for every large n. conder_no_threshold_le then refutes the conjecture on the whole interval ε ≤ 1/3, strictly extending Chung's ε ≤ 1/4. Chung's own 1/4 result is recovered as the corollary chung_no_threshold by monotonicity, so the file needs only this one deep axiom. (A previous version stated a vacuous True-placeholder existence theorem here; the real 1/3 density content lives in the axiom + interval theorem.)",
+    "mathContext": "The refutation is now sharp on (0, 1/3]; the gap between ε = 1/3 and the trivial ε = 1/2 barrier remains unexplored.",
     "significance": "key",
     "relatedConcepts": [
       "Better bound",

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -58,13 +58,14 @@
     "lineCount": 368,
     "assumptions": "1 axiom (Chung 1992): chung_no_threshold — no threshold N makes every (1/4)-dense subgraph of Qₙ contain C₆; a consequence of Chung's edge-partition of Qₙ into four C₆-free subgraphs, not available in Mathlib. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) was previously axiomatized but is now PROVED outright — it carries no edge-count data, so the empty subgraph ⊥ (no edges, hence no cycle) is an honest witness. The deep density content stays isolated in the single axiom chung_no_threshold.",
     "theoremCount": 9,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "proofStrategy": "**Formalization Approach**\\n\\n1. **Hypercube Definition:** Qₙ defined on Fin(2ⁿ) - vertices x, y are adjacent iff their bitwise XOR is a power of two (exactly one differing bit, i.e. Hamming distance 1). Symmetry and looplessness are discharged from Nat.xor_comm and Nat.xor_self.\\n\\n2. **Cycle Definitions:**\\n   - HasCycle G k: injective k-sequence with cyclic adjacency\\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\\n\\n3. **Density:**\\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\\n\\n4. **Main Results:**\\n   - ErdosConjecture: the (false) original conjecture\\n   - erdos_conjecture_false: theorem showing it is false, fully proved (no sorry) from chung_no_threshold\\n   - conder_no_threshold axiom (ε = 1/3): no threshold N forces C₆ in every (1/3)-dense subgraph of Qₙ — the pigeonhole consequence of Conder 1993's 3-edge-colouring, the sharpest known refutation and the single deep input\\n   - chung_no_threshold theorem (ε = 1/4): now DERIVED from conder_no_threshold via monotonicity of ConjectureAt (1/4 ≤ 1/3), so no separate Chung axiom is needed; still consumed by erdos_conjecture_false\\n   - conjectureAt_mono / epsilonDense_antitone / denseForcesC6_mono: axiom-free monotonicity bookkeeping used to derive Chung from Conder and to spread each refutation across an interval\\n   - chung_no_threshold_le / conder_no_threshold_le: the refutation holds on the whole intervals ε ≤ 1/4 and (sharpest) ε ≤ 1/3\\n   - chung_c6free theorem (de-axiomatized): for n ≥ 3, Qₙ has a C₆-free subgraph — proved via the empty subgraph ⊥ (no edges ⇒ no C₆)\\n   - chung_counterexample / conder_counterexample: ε = 1/4 and ε = 1/3 C₆-free existence witnesses, both derived from chung_c6free\\n\\n5. **Why axioms:** Conder's explicit 3-edge-colouring construction is combinatorial and not available in Mathlib. It is captured by a single density axiom conder_no_threshold, whose ¬ ConjectureAt (1/3) arrow form avoids a Mathlib v4.26 elaborator stack overflow triggered by the bundled ∃ H, (edge bound) ∧ ¬ HasC6 H form. Definitions HasCycle/HasC6/EpsilonDenseSubgraph are marked @[irreducible] for the same reason (1 axiom, 0 sorries)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #666**\n\nErdős posed this problem in 1991, asking whether dense subgraphs of the n-dimensional hypercube must contain 6-cycles. The hypercube Qₙ has 2ⁿ vertices (binary strings of length n) and n·2ⁿ⁻¹ edges (vertices adjacent iff they differ in exactly one coordinate).\n\n**Resolution (1992-1993):**\nThe answer is NO, disproved independently by two groups:\n- **Chung (1992):** Constructed an explicit 4-partition of Qₙ's edges into C₆-free subgraphs\n- **Brouwer-Dejter-Thomassen (1993):** Independent 4-coloring construction avoiding C₄ and C₆\n\n**Further Improvement:**\nConder (1993) showed that only 3 colors suffice - the edges of Qₙ can be 3-colored with no monochromatic C₄ or C₆. This means subgraphs with 1/3 of all edges need not contain C₆.",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet Qₙ be the n-dimensional hypercube (2ⁿ vertices, n·2ⁿ⁻¹ edges).\n\n**Conjecture:** For every ε > 0, if n is sufficiently large, every subgraph of Qₙ with ≥ ε·n·2ⁿ⁻¹ edges contains C₆.\n\n**Answer:** NO\n\n**Counterexamples:**\n- ε = 1/4: Chung's 4-partition (1992)\n- ε = 1/3: Conder's 3-coloring (1993)\n\n**Generalized Conjecture (OPEN):** For C_{2k}, ∃ c > 0 and aₖ < 1 such that ≥ c·n^{aₖ}·2ⁿ edges forces C_{2k}, with aₖ → 0 as k → ∞.",
     "text": "Does every ε-dense subgraph of the n-hypercube Qₙ contain C₆? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Qₙ can be 4-partitioned into C₆-free subgraphs.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Hypercube Definition:** Qₙ defined on Fin(2ⁿ) - vertices x, y are adjacent iff their bitwise XOR is a power of two (exactly one differing bit, i.e. Hamming distance 1). Symmetry and looplessness are discharged from Nat.xor_comm and Nat.xor_self.\n\n2. **Cycle Definitions:**\n   - HasCycle G k: injective k-sequence with cyclic adjacency\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\n\n3. **Density:**\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\n\n4. **Main Results:**\n   - ErdosConjecture: the (false) original conjecture\n   - erdos_conjecture_false: theorem showing it is false, fully proved (no sorry) from chung_no_threshold\n   - chung_no_threshold axiom: for ε = 1/4 no threshold N forces C₆ in every (1/4)-dense subgraph of Qₙ — the pigeonhole consequence of Chung's 4-partition, and exactly what the disproof consumes\n   - chung_c6free theorem (de-axiomatized): for n ≥ 3, Qₙ has a C₆-free subgraph — proved via the empty subgraph ⊥ (no edges ⇒ no C₆)\n   - chung_counterexample / conder_better_bound: ε = 1/4 and ε = 1/3 C₆-free witnesses, both derived from chung_c6free\n\n5. **Why axioms:** Chung's explicit 4-partition construction is combinatorial and not available in Mathlib. It is captured by a single density axiom chung_no_threshold, whose ¬ ConjectureAt (1/4) arrow form avoids a Mathlib v4.26 elaborator stack overflow triggered by the bundled ∃ H, (edge bound) ∧ ¬ HasC6 H form. Definitions HasCycle/HasC6/EpsilonDenseSubgraph are marked @[irreducible] for the same reason (1 axiom, 0 sorries).",
+    "proofStrategy": "**Formalization Approach**\\n\\n1. **Hypercube Definition:** Qₙ defined on Fin(2ⁿ) - vertices x, y are adjacent iff their bitwise XOR is a power of two (exactly one differing bit, i.e. Hamming distance 1). Symmetry and looplessness are discharged from Nat.xor_comm and Nat.xor_self.\\n\\n2. **Cycle Definitions:**\\n   - HasCycle G k: injective k-sequence with cyclic adjacency\\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\\n\\n3. **Density:**\\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\\n\\n4. **Main Results:**\\n   - ErdosConjecture: the (false) original conjecture\\n   - erdos_conjecture_false: theorem showing it is false, fully proved (no sorry) from chung_no_threshold\\n   - conder_no_threshold axiom (ε = 1/3): no threshold N forces C₆ in every (1/3)-dense subgraph of Qₙ — the pigeonhole consequence of Conder 1993's 3-edge-colouring, the sharpest known refutation and the single deep input\\n   - chung_no_threshold theorem (ε = 1/4): now DERIVED from conder_no_threshold via monotonicity of ConjectureAt (1/4 ≤ 1/3), so no separate Chung axiom is needed; still consumed by erdos_conjecture_false\\n   - conjectureAt_mono / epsilonDense_antitone / denseForcesC6_mono: axiom-free monotonicity bookkeeping used to derive Chung from Conder and to spread each refutation across an interval\\n   - chung_no_threshold_le / conder_no_threshold_le: the refutation holds on the whole intervals ε ≤ 1/4 and (sharpest) ε ≤ 1/3\\n   - chung_c6free theorem (de-axiomatized): for n ≥ 3, Qₙ has a C₆-free subgraph — proved via the empty subgraph ⊥ (no edges ⇒ no C₆)\\n   - chung_counterexample / conder_counterexample: ε = 1/4 and ε = 1/3 C₆-free existence witnesses, both derived from chung_c6free\\n\\n5. **Why axioms:** Conder's explicit 3-edge-colouring construction is combinatorial and not available in Mathlib. It is captured by a single density axiom conder_no_threshold, whose ¬ ConjectureAt (1/3) arrow form avoids a Mathlib v4.26 elaborator stack overflow triggered by the bundled ∃ H, (edge bound) ∧ ¬ HasC6 H form. Definitions HasCycle/HasC6/EpsilonDenseSubgraph are marked @[irreducible] for the same reason (1 axiom, 0 sorries).",
     "keyInsights": [
       "**Hypercube Structure:** Qₙ vertices are binary strings, adjacent iff Hamming distance = 1",
       "**Size:** |V| = 2ⁿ, |E| = n·2ⁿ⁻¹, degree = n (n-regular)",
@@ -85,71 +86,71 @@
       "title": "Hypercube Graph",
       "summary": "Definition of Qₙ via XOR, vertices, edges, regularity",
       "startLine": 36,
-      "endLine": 68,
+      "endLine": 81,
       "mathContext": "Formal definition: Definition of Qₙ via XOR, vertices, edges, regularity"
     },
     {
       "id": "cycles",
       "title": "Cycles in Graphs",
       "summary": "HasCycle, HasC4, HasC6, HasC2k definitions",
-      "startLine": 69,
-      "endLine": 97,
+      "startLine": 82,
+      "endLine": 115,
       "mathContext": "Formal definition: HasCycle, HasC4, HasC6, HasC2k definitions"
     },
     {
       "id": "density",
       "title": "Subgraphs and Density",
       "summary": "DenseSubgraph, EpsilonDenseSubgraph",
-      "startLine": 98,
-      "endLine": 118,
+      "startLine": 116,
+      "endLine": 140,
       "mathContext": "Mathematical content: DenseSubgraph, EpsilonDenseSubgraph"
     },
     {
       "id": "conjecture",
       "title": "Erdős's Conjecture (Disproved)",
       "summary": "ErdosConjecture, erdos_conjecture_false",
-      "startLine": 119,
-      "endLine": 141,
+      "startLine": 141,
+      "endLine": 296,
       "mathContext": "Mathematical content: ErdosConjecture, erdos_conjecture_false"
     },
     {
       "id": "chung",
       "title": "Chung's Result (1992)",
       "summary": "4-partition into C₆-free subgraphs",
-      "startLine": 142,
-      "endLine": 175,
+      "startLine": 297,
+      "endLine": 315,
       "mathContext": "Mathematical content: 4-partition into C₆-free subgraphs"
     },
     {
       "id": "bdt",
       "title": "Brouwer-Dejter-Thomassen (1993)",
       "summary": "Informal commentary on BDT independent 4-coloring result (no formal declarations in file)",
-      "startLine": 176,
-      "endLine": 178,
+      "startLine": 316,
+      "endLine": 322,
       "mathContext": "Informal commentary: BDT independent 4-coloring result (no formal declarations)"
     },
     {
       "id": "conder",
       "title": "Conder's Improvement (1993)",
-      "summary": "conder_better_bound: ε = 1/3 counterexample theorem derived from chung_c6free",
-      "startLine": 179,
-      "endLine": 201,
-      "mathContext": "Mathematical content: conder_better_bound theorem (3-coloring, ε = 1/3 counterexample)"
+      "summary": "conder_no_threshold (axiom, ε=1/3) with chung_no_threshold derived as a corollary; conder_no_threshold_le (interval ε≤1/3) and conder_counterexample (existence)",
+      "startLine": 323,
+      "endLine": 354,
+      "mathContext": "Mathematical content: Conder 1993 sharpened refutation — axiom conder_no_threshold (¬ConjectureAt 1/3), theorem conder_no_threshold_le (ε≤1/3 interval), theorem conder_counterexample (existence witness)"
     },
     {
       "id": "generalized",
       "title": "Generalized Conjecture",
       "summary": "GeneralizedConjecture: open question for C_{2k} in dense hypercube subgraphs",
-      "startLine": 203,
-      "endLine": 218,
+      "startLine": 355,
+      "endLine": 381,
       "mathContext": "Mathematical content: GeneralizedConjecture definition (open question for C_{2k})"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_666_summary: combined theorem stating conjecture is false and C₆-free subgraphs exist",
-      "startLine": 232,
-      "endLine": 261,
+      "startLine": 382,
+      "endLine": 413,
       "mathContext": "Mathematical content: erdos_666_summary theorem"
     }
   ],
@@ -171,9 +172,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 368,
+    "lineCount": 413,
     "axiomCount": 1,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 13,
     "path": "Proofs/Erdos666Problem.lean",
     "sorries": 0
@@ -195,5 +196,6 @@
       "description": "Related Erdős problem sharing themes: disproved, extremal-graph-theory, graph-theory"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "assumptions": "1 axiom (Conder 1993): conder_no_threshold — no threshold N makes every (1/3)-dense subgraph of Qₙ contain C₆; a consequence of Conder's 3-edge-colouring of Qₙ into C₄,C₆-free colour classes, not available in Mathlib. This is the single deep combinatorial input and the sharpest known refutation. Chung's earlier (1/4)-density result chung_no_threshold is now PROVED as a corollary of conder_no_threshold by monotonicity of ConjectureAt (since 1/4 ≤ 1/3), so the file rests on one axiom rather than two. The existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) is also proved outright — it carries no edge-count data, so the empty subgraph ⊥ is an honest witness. Refutation now holds on the whole interval (0, 1/3] via conder_no_threshold_le."
 }

--- a/src/data/research/problems/erdos-666-incomplete-01.json
+++ b/src/data/research/problems/erdos-666-incomplete-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-03T12:23:52.517Z",
-    "iteration": 2,
-    "focus": "Strengthened Chung refutation from the single point ε=1/4 to the whole interval ε≤1/4 (researcher-2): density monotonicity (epsilonDense_antitone, denseForcesC6_mono, conjectureAt_mono) turns the axiom chung_no_threshold into chung_no_threshold_le : ε≤1/4 → ¬ConjectureAt ε. Zero new axioms. File 0 sorry, 1 axiom.",
+    "iteration": 3,
+    "focus": "Conder ε=1/3 sharpening (researcher-4): axiomatize the STRONGER conder_no_threshold (¬ConjectureAt 1/3) and DERIVE chung_no_threshold (1/4) from it by monotonicity — axiom count held at 1 (swap, not add). Added conder_no_threshold_le (interval ε≤1/3) and replaced the vacuous True-placeholder conder_better_bound with the honest conder_counterexample. 0 sorry, 1 axiom, #print axioms clean.",
     "blockers": [],
-    "nextAction": "Remaining structural gaps: (1) conder_better_bound still carries a True placeholder for the ε=1/3 density claim (needs Conder 3-coloring construction, a new deep axiom); (2) GeneralizedConjecture for C_{2k} remains open. The single axiom chung_no_threshold is genuinely deep (Chung 4-partition, not in Mathlib) — not eliminable.",
+    "nextAction": "Elementary refutation theory is essentially complete: refutation now sharp on (0,1/3] (conder_no_threshold_le). Remaining open: (1) GeneralizedConjecture for C_{2k} (genuinely different sparser density, not a C₆ specialization); (2) Erdős dense C₄,C₆-free ⇒ C₈ existence (moment/KST counting, not in Mathlib, not session-sized). The single axiom conder_no_threshold is genuinely deep (Conder 3-colouring) — not eliminable without ~1000+ lines.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,23 +29,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Discharged the lone sorry in erdos_conjecture_false and repaired the file so it actually compiles (it previously had 24 errors: nonexistent Nat.popcount, missing Real/edgeFinset imports, orphaned docstrings, a buggy HasCycle mod_lt, and a malformed conder_better_bound tuple). The disproof now follows from a single well-formed axiom chung_1992 (density form). 0 sorries, 1 axiom; #print axioms shows only propext/Classical.choice/Quot.sound + chung_1992.",
+    "progressSummary": "Refutation strengthened to Conder ε=1/3 with axiom count held at 1: conder_no_threshold (¬ConjectureAt 1/3) is the single deep axiom; chung_no_threshold (1/4) is now DERIVED from it by monotonicity (conjectureAt_mono, 1/4≤1/3). conder_no_threshold_le extends the refutation to the whole interval (0,1/3]. The prior True-placeholder conder_better_bound is replaced by the honest existence witness conder_counterexample. 0 sorries, 1 axiom; #print axioms shows only propext/Classical.choice/Quot.sound + Erdos666.conder_no_threshold.",
     "builtItems": [
       "Proved Erdos666.erdos_conjecture_false from chung_1992 (Proofs/Erdos666Problem.lean)",
       "Repaired Hypercube, HasCycle, DenseSubgraph defs and imports so the file compiles (282 lines, 0 errors)",
       "epsilonDense_antitone / denseForcesC6_mono / conjectureAt_mono: ConjectureAt is monotone in ε (density antitone, forcing/conjecture monotone) [VERIFIED]",
-      "chung_no_threshold_le : ε ≤ 1/4 → ¬ConjectureAt ε — Chung refutation extended from the point 1/4 to the whole interval (0,1/4], 0 new axioms [VERIFIED]"
+      "chung_no_threshold_le : ε ≤ 1/4 → ¬ConjectureAt ε — Chung refutation extended from the point 1/4 to the whole interval (0,1/4], 0 new axioms [VERIFIED]",
+      "conder_no_threshold : ¬ConjectureAt (1/3) — Conder 1993 3-edge-colouring axiom, the single deepest input, replacing chung_no_threshold [VERIFIED axiom]",
+      "chung_no_threshold : ¬ConjectureAt (1/4) — now a THEOREM derived from conder_no_threshold by monotonicity (axiom count held at 1) [VERIFIED]",
+      "conder_no_threshold_le : ε ≤ 1/3 → ¬ConjectureAt ε — refutation sharp on the whole interval (0,1/3], strictly beyond (0,1/4] [VERIFIED]",
+      "conder_counterexample — honest ε=1/3 existence witness replacing the vacuous True-placeholder conder_better_bound [VERIFIED]"
     ],
     "insights": [
       "The old chung_1992 axiom (bare 4-partition, only H1/H2 disjointness, no edge counts) was insufficient AND malformed: it could not justify erdos_conjecture_false because the disproof needs a density lower bound on one part.",
       "Restating Chung as its density consequence (for n>=3, exists C6-free subgraph with >= 1/4 of edges, packaged with its DecidableRel instance) makes the disproof a 3-line term: instantiate ε=1/4, take n = max N 3, the witness contradicts the conjecture.",
       "Hypercube adjacency 'popcount(x XOR y)=1' (Hamming dist 1) is equivalent to 'x XOR y is a power of two'; the latter avoids the nonexistent Nat.popcount and discharges symm/loopless via Nat.xor_comm / Nat.xor_self + pow_ne_zero.",
-      "HasCycle's Fin index (i+1)%k needs 0<k; derive it from the element i via lt_of_le_of_lt (Nat.zero_le _) i.2 instead of a hypothesis-free omega."
+      "HasCycle's Fin index (i+1)%k needs 0<k; derive it from the element i via lt_of_le_of_lt (Nat.zero_le _) i.2 instead of a hypothesis-free omega.",
+      "Axiom-count-neutral strengthening: when the file axiomatizes result A and a strictly stronger published result B implies A, axiomatize B and derive A as a theorem — net axioms unchanged, math strengthened. #print axioms on the derived A must list B (proof it is genuinely derived, not silently re-axiomatized)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Replace the True placeholder in conder_better_bound with a real ε=1/3 density statement (needs Conder 3-coloring = new deep axiom).",
-      "Optional: formalize Chung's explicit 4-partition to eliminate the single remaining axiom (large, ~1000+ lines)."
+      "GeneralizedConjecture (C_{2k}) is open and genuinely distinct: its c·n^{aₖ}·2ⁿ density is much sparser than ε·n·2ⁿ⁻¹, so the C₆ refutation does not specialize to it.",
+      "Erdős dense C₄,C₆-free ⇒ C₈ existence (moment/KST counting) — the hard core, not in Mathlib, not session-sized.",
+      "Optional: formalize Conder's explicit 3-colouring to eliminate the single remaining axiom (large, ~1000+ lines)."
     ]
   },
   "tags": [
@@ -64,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T12:23:52.517Z",
-  "lastUpdate": "2026-07-08T00:00:00Z",
+  "lastUpdate": "2026-07-09",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Erdős Problem #666 (does every ε-dense subgraph of the hypercube Qₙ contain C₆? — **answer NO**) already carried Chung's ε=1/4 refutation as its single axiom, plus a **vacuous** `conder_better_bound` theorem whose docstring advertised Conder 1993's ε=1/3 improvement but proved only `True ∧ ¬HasC6 H` (nothing about density).

This PR formalizes the genuine sharper published result **without raising the axiom count** and removes the placeholder:

- **Axiomatize the stronger result.** `conder_no_threshold : ¬ ConjectureAt (1/3)` — Conder 1993's 3-edge-colouring of Qₙ (each colour class C₄,C₆-free ⇒ a (1/3)-dense C₆-free subgraph) — is now the single deep combinatorial input, replacing the `chung_no_threshold` axiom.
- **Derive Chung from Conder.** `chung_no_threshold : ¬ ConjectureAt (1/4)` is now a **theorem**, obtained by monotonicity of `ConjectureAt` (`1/4 ≤ 1/3`). Every downstream user (`erdos_conjecture_false`, `chung_no_threshold_le`) is untouched, and the file rests on **one** axiom (a swap, not an addition).
- **Sharp interval.** `conder_no_threshold_le : ε ≤ 1/3 → ¬ ConjectureAt ε` refutes the conjecture on the whole interval `(0, 1/3]`, strictly extending the prior `(0, 1/4]`.
- **Honesty fix.** The `True`-placeholder `conder_better_bound` is replaced by `conder_counterexample` (an honest existence witness with no fabricated density claim).

## Verification

- Host `lake env lean` → **EXIT=0**, 0 sorries, 1 axiom.
- `#print axioms Erdos666.erdos_666_summary` = `[propext, Classical.choice, Erdos666.conder_no_threshold, Quot.sound]` — **no `sorryAx`**.
- `#print axioms Erdos666.chung_no_threshold` depends on `Erdos666.conder_no_threshold` (confirming it is genuinely **derived**, not silently re-axiomatized).
- `Erdos666Problem.lean`: 368 → 413 lines; theorems 9 → 11; axiom 1 → 1 (renamed).

Docker builds this session were blocked by fleet-race Mathlib cache corruption (a different missing/invalid olean each run); the file itself was confirmed clean via host `lake env lean` after a forced cache restore, with the original file as an EXIT=0 control.

## Status

`axiomatized` / badge `axiom` — the single axiom `conder_no_threshold` (Conder's 3-colouring) is genuinely deep and not available in Mathlib. Elementary refutation theory for #666 is now essentially complete; the remaining open core is the dense C₄,C₆-free ⇒ C₈ existence (moment/KST counting).