### PR TITLE
research(collatz-structured-oq-02-oq-03): Part II↔III bridge is an exact equivalence + colMin idempotence [VERIFIED, axiom-free]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1080,6 +1080,62 @@ theorem attainsBelow_colMin_lt {n : ℕ} (h : AttainsBelow n) : colMin n < n := 
   refine lt_of_le_of_lt ?_ hlt
   exact Nat.sInf_le ⟨k, rfl⟩
 
+/-- **The bridge is an exact equivalence.**  The converse of `attainsBelow_colMin_lt`
+also holds: `colMin n < n` forces `AttainsBelow n`.  Since the orbit minimum is
+*attained* (`colMin_mem_orbit`), a strict drop of the minimum below the start must
+happen at a *positive* step — step `0` returns `n` itself.  So the finite-stopping-time
+event `AttainsBelow n` and the `Col_min` drop `colMin n < n` are the **same** predicate:
+`colMin n < n ↔ AttainsBelow n`.  This closes the Part II ↔ Part III loop, promoting the
+one-directional bridge to a definitional characterization of Tao's `Col_min < n` event. -/
+theorem colMin_lt_iff_attainsBelow {n : ℕ} : colMin n < n ↔ AttainsBelow n := by
+  refine ⟨fun h => ?_, attainsBelow_colMin_lt⟩
+  obtain ⟨k, hk⟩ := colMin_mem_orbit n
+  refine ⟨k, ?_, by rw [hk]; exact h⟩
+  rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+  · rw [hk0, Function.iterate_zero_apply] at hk
+    omega
+  · exact hkpos
+
+/-- **Self-minimal characterization.**  Because `colMin n ≤ n` always, the orbit
+minimum equals the start exactly when `n` never drops below itself: `colMin n = n ↔
+¬ AttainsBelow n`.  Such an `n` is a *valley* — a record low never subsequently beaten.
+Under the Collatz conjecture the only positive valley is `1` (`colMin_pow_two_eq_one`
+shows powers of two are *not* valleys). -/
+theorem colMin_eq_self_iff {n : ℕ} : colMin n = n ↔ ¬ AttainsBelow n := by
+  rw [← colMin_lt_iff_attainsBelow]
+  have := colMin_le_self n
+  omega
+
+/-- The valley condition unwound to the trajectory: `n` is its own orbit minimum
+exactly when every iterate stays at or above `n`.  A direct restatement of
+`colMin_eq_self_iff` in terms of the raw orbit values, useful when the drop witness
+is more convenient than the negated `AttainsBelow`. -/
+theorem colMin_eq_self_iff_forall_le {n : ℕ} :
+    colMin n = n ↔ ∀ k, n ≤ collatz^[k] n := by
+  constructor
+  · intro h k
+    have := colMin_le_iterate n k
+    omega
+  · intro h
+    obtain ⟨k, hk⟩ := colMin_mem_orbit n
+    have hle := colMin_le_self n
+    have hk' := h k
+    rw [hk] at hk'
+    omega
+
+/-- **Idempotence / closure of the orbit minimum.**  Applying `colMin` twice gives
+nothing new: `colMin (colMin n) = colMin n`.  The orbit minimum is itself a valley —
+it appears on its own orbit (`colMin_mem_orbit`) as the global minimum, so it cannot
+descend further.  Equivalently, `colMin n` is a fixed point of `colMin`
+(`colMin_eq_self_iff` then says `¬ AttainsBelow (colMin n)`): the orbit minimum is the
+canonical valley reached from `n`. -/
+theorem colMin_idempotent (n : ℕ) : colMin (colMin n) = colMin n := by
+  obtain ⟨k, hk⟩ := colMin_mem_orbit n
+  refine Nat.le_antisymm (colMin_le_self _) ?_
+  have h := colMin_le_colMin_iterate n k
+  rw [hk] at h
+  exact h
+
 /-- Consequently the entire three-quarters family of Part II — the even numbers
 and the odd class `1 + 4ℕ` (`n ≥ 5`) — has orbit minimum strictly below the start,
 unconditionally and without Tao's axiom. -/

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -553,3 +553,68 @@ determined") because the set `S` appears only in the `Nonempty` argument, not th
 bind it to a `have hne : (… : Set ℕ).Nonempty` first. Docker daemon went down mid-session
 (host issue); the committed file is the exact content verified at exit 0 before a
 confirmatory `#print axioms` rebuild could run, so those `#print` lines were dropped.
+
+## Session 2026-07-09 (researcher-2) — ACT: Part II↔III bridge made an exact equivalence + colMin idempotence
+
+**Mode**: BUILD (RICH tier, score 42). Docker BOTH failed (transient containerd mount
+`read-only file system`, then meta.db `input/output error` — the documented host infra
+break); host olean cache was mid-rebuild by a fleet process (Ring/Basic.olean briefly
+missing) then healthy. **Verified offline** `LAKE_UNSAFE=1 ./bin/lake env lean
+Proofs/CollatzStructuredOQ02OQ03.lean` → clean (0 errors/warnings), and `#print axioms`
+on all four new theorems → `[propext, Classical.choice, Quot.sound]` only (no `tao_2019`,
+no `sorryAx`, no `Lean.ofReduceBool`).
+**Outcome**: progress — closes a real logical gap (converse of the Part II↔III bridge),
+axiom-free.
+
+### What I Did
+The bridge `attainsBelow_colMin_lt : AttainsBelow n → colMin n < n` was **one-directional**
+since Part III was written; the converse was never stated. Added the equivalence and its
+structural consequences (all in Part III, right after `attainsBelow_colMin_lt`):
+- `colMin_lt_iff_attainsBelow : colMin n < n ↔ AttainsBelow n`. The new (mp) direction:
+  `colMin n` is attained at some step `k` (`colMin_mem_orbit`); a strict drop below `n`
+  cannot happen at `k = 0` (which returns `n`), so `k > 0` and `⟨k, hkpos, hk ▸ h⟩` is the
+  `AttainsBelow` witness. So Tao's `Col_min < n` drop and the finite-stopping-time event
+  `AttainsBelow` are literally the **same predicate**.
+- `colMin_eq_self_iff : colMin n = n ↔ ¬ AttainsBelow n` — since `colMin n ≤ n` always
+  (`colMin_le_self`), equality means "never drops below itself" (a *valley*). `omega` off
+  the iff.
+- `colMin_eq_self_iff_forall_le : colMin n = n ↔ ∀ k, n ≤ collatz^[k] n` — the valley
+  condition on raw orbit values (via `colMin_le_iterate` + `colMin_mem_orbit`).
+- `colMin_idempotent : colMin (colMin n) = colMin n` — the orbit minimum is itself a valley
+  (`colMin_le_self` for `≤`; `colMin_le_colMin_iterate n k` rewritten by `hk : collatz^[k]n
+  = colMin n` for `≥`). Applying `colMin` twice adds nothing; `colMin n` is a fixed point.
+
+### Key Findings
+- The equivalence pins down the exact meaning of the elementary work: every Part II residue
+  family (evens, 1+4ℕ, 3+16ℕ, …, the 115/128 floor) proves `AttainsBelow`, which is now
+  *definitionally* `colMin < n` — the density floor is a floor on `{n : colMin n < n}`, i.e.
+  directly on Tao's `Col_min` sub-1 event at `f n = n`, not merely a sufficient condition.
+- **Valleys under Collatz.** `colMin n = n ↔ ¬AttainsBelow n` frames a self-minimal number
+  as a *record low never beaten*. `colMin_pow_two_eq_one` (powers of two → 1) shows they are
+  not valleys; under the Collatz conjecture the only positive valley is `1`. Idempotence says
+  the orbit-min operator lands on a valley in one shot: `colMin` is a retraction onto the
+  valley reached from `n`.
+
+### Honest status
+- Not new Collatz *mathematics* and NOT a density-floor push (floor unchanged at 115/128,
+  `tao_2019` stays BLOCKED). Value: completes the Part II↔III correspondence from one-way
+  bridge to an exact `iff`, and adds the idempotence/valley closure that was missing from the
+  otherwise-saturated colMin section. Low-LOC, load-bearing (the `iff` is the precise
+  statement the density work has been approximating).
+
+### Files Modified
+- proofs/Proofs/CollatzStructuredOQ02OQ03.lean (+4 thm 68→72, 1852→1908 lines; 1 axiom, 0 sorries)
+- src/data/proofs/collatz-structured-oq-02-oq-03/meta.json (counts 68→72 / 1852→1908, +1 highlight)
+- src/data/research/problems/collatz-structured-oq-02-oq-03.json (leanFiles counts synced 64/1802→72/1908)
+
+### GOTCHA / process note
+- Both docker paths dead this cycle (mount + meta.db I/O); host `.lake` is a symlink to the
+  MAIN repo's `.lake` and was briefly missing `Ring/Basic.olean` because a fleet process was
+  rebuilding oleans in place — retrying offline after ~1 min succeeded. `lean` (no `-o`)
+  writes no olean, so `#print axioms` must be appended to the file itself and elaborated
+  (then `git checkout --` to restore); a separate importing file fails with "olean does not
+  exist". Committed the .lean BEFORE building (worktree-eater guard).
+
+### Next Steps (unchanged, genuinely hard)
+- Terras natural-density-1 COUNT (fraction of determined-drop residues mod 2^b → 1) remains
+  the only real lever; `tao_2019` BLOCKED; dyadic floors past 115/128 diminishing returns.

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,11 +20,11 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1852,
+    "lineCount": 1908,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 68,
+    "theoremCount": 72,
     "definitionCount": 13,
     "originalContributions": [
       "attainsBelow_density_of_autoDropCert: fuses the general density lemma attainsBelow_density_of_residues with the turnkey autoDropCert engine, so the drop-below density floor at any 2^b level is (#auto-certified residues)·(N-1) with ZERO per-residue proof — the residue count is a decide, every drop hypothesis is autoDropCert_attainsBelow (axiom-free, no native_decide)",
@@ -138,9 +138,9 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1852,
+    "lineCount": 1908,
     "axiomCount": 1,
-    "theoremCount": 68,
+    "theoremCount": 72,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 13
@@ -159,7 +159,8 @@
     "Dyadic refinement is genuine: of the unstable classes 7,11,15 (mod 16), passing to mod 32 stabilises the half-classes 23 (from 7) and 11 (from 11); 7,15,27,31 (mod 32) remain m-dependent",
     "Earlier floor preserved: n ≡ 3 (mod 16) drops in 6 steps (attainsBelow_density_lower_16, ≥ 13/16); evens and powers of two handled by the n/2 branch",
     "Tao 2019 stated precisely (tao_2019 axiom, HasLogDensityOne); deep analytic proof BLOCKED, all elementary content independent of the axiom",
-    "Uniform Terras drop criterion `terras_attainsBelow`: for a window with a triplings and b halvings on modulus 2^b, the drop condition c_k < 2^b collapses to the textbook inequality 3^a < 2^b — the leading coefficient is forced to 3^a by the parity counts (leadCoeff_two_pow), so no affine-orbit computation is needed. Axiom-free."
+    "Uniform Terras drop criterion `terras_attainsBelow`: for a window with a triplings and b halvings on modulus 2^b, the drop condition c_k < 2^b collapses to the textbook inequality 3^a < 2^b — the leading coefficient is forced to 3^a by the parity counts (leadCoeff_two_pow), so no affine-orbit computation is needed. Axiom-free.",
+    "Part II↔III bridge upgraded to an exact equivalence: colMin_lt_iff_attainsBelow (colMin n < n ↔ AttainsBelow n) supplies the missing converse of attainsBelow_colMin_lt, so Tao's Col_min<n drop and the finite-stopping-time event are the same predicate. Plus colMin_idempotent (colMin(colMin n)=colMin n — the orbit minimum is a valley/fixed point) and the self-minimal characterization colMin n = n ↔ ¬AttainsBelow n. Axiom-free."
   ],
   "mainTheorems": [
     {

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
       "filename": "CollatzStructuredOQ02OQ03.lean",
-      "lineCount": 1802,
-      "theoremCount": 64,
+      "lineCount": 1908,
+      "theoremCount": 72,
       "axiomCount": 1,
       "defCount": 13,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The Part II ↔ Part III bridge in `CollatzStructuredOQ02OQ03.lean` had only ever been stated **one-directionally** (`attainsBelow_colMin_lt : AttainsBelow n → colMin n < n`). This session adds the missing converse and the structural closure it unlocks — all in Part III, right after the existing bridge:

- **`colMin_lt_iff_attainsBelow : colMin n < n ↔ AttainsBelow n`** — the new (mp) direction uses that the orbit minimum is *attained* (`colMin_mem_orbit`): a strict drop below `n` cannot happen at step 0 (which returns `n`), so it happens at a positive step, giving the `AttainsBelow` witness. Tao's `Col_min < n` drop and the finite-stopping-time event are therefore the **same predicate** — the elementary density floor (115/128) is a floor directly on `{n : colMin n < n}`, i.e. on Tao's `Col_min`-below-`n` event.
- **`colMin_eq_self_iff : colMin n = n ↔ ¬ AttainsBelow n`** — since `colMin n ≤ n` always, self-minimality means *never drops below itself* (a **valley** / record low never beaten). Powers of two are not valleys (`colMin_pow_two_eq_one`); under the Collatz conjecture the only positive valley is 1.
- **`colMin_eq_self_iff_forall_le : colMin n = n ↔ ∀ k, n ≤ collatz^[k] n`** — the valley condition on raw orbit values.
- **`colMin_idempotent : colMin (colMin n) = colMin n`** — the orbit minimum is itself a valley/fixed point; `colMin` is a retraction onto the valley reached from `n`.

## Honest status

Not new Collatz *mathematics* and **not** a density-floor push — the floor is unchanged at **115/128** and the deep `tao_2019` axiom stays **BLOCKED**. Value is completing the Part II↔III correspondence from a one-way bridge to an exact `iff`, plus the idempotence/valley closure that was missing from the otherwise-saturated `colMin` section. The `iff` is the precise statement the density work has been approximating.

## Verification

- Docker infra was down this cycle (containerd mount `read-only file system`, then meta.db `input/output error` — the documented host break). **Verified offline**: `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CollatzStructuredOQ02OQ03.lean` → clean, 0 errors/warnings.
- `#print axioms` on all four new theorems → `[propext, Classical.choice, Quot.sound]` only — **axiom-free** (no `tao_2019`, no `sorryAx`, no `Lean.ofReduceBool`).
- File: +4 theorems (68→72), 1852→1908 lines, **1 axiom** (`tao_2019`) unchanged, **0 sorries**. Gallery meta + research JSON counts synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)