### PR TITLE
Auditor: fix sqrt2-from-axioms badge (mathlib→original) + phantom mainTheorem

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25305,10 +25305,10 @@
       "result": "clean"
     },
     "sqrt2-from-axioms": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:50:51Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "sqrt2-from-axioms-oq-01": {
       "auditCount": 4,

--- a/src/data/proofs/sqrt2-from-axioms/meta.json
+++ b/src/data/proofs/sqrt2-from-axioms/meta.json
@@ -15,7 +15,7 @@
       "first-principles",
       "classic"
     ],
-    "badge": "mathlib",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -182,10 +182,10 @@
   ],
   "mainTheorems": [
     {
-      "name": "sqrt2_exists",
+      "name": "sqrt2_irrational",
       "type": "core",
-      "description": "Existence of sqrt(2) from field axioms and completeness",
-      "leanType": "exists x : R, x > 0 and x * x = 2"
+      "description": "No coprime naturals a, b satisfy a² = 2b² — the arithmetic core of √2's irrationality, proved from hand-built even/odd/coprime definitions via infinite descent (no Mathlib number-theory theorem)",
+      "leanType": "∀ a b : ℕ, b > 0 → a * a = 2 * b * b → ¬Coprime a b"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: sqrt2-from-axioms
**Severity**: MEDIUM (badge misclassification + phantom mainTheorem; status/counts already correct)

This entry is a deliberately *from-scratch* proof of √2's irrationality (title "From Axioms", slug `sqrt2-from-axioms`), the pedagogical counterpart to the Mathlib-wrapper `sqrt2-irrational` entry. Two meta.json fields contradicted the source.

### 1. Badge `mathlib` → `original`

`proofs/Proofs/Sqrt2IrrationalFromAxioms.lean` imports only `Mathlib.Tactic`. It defines `Even`/`Odd`/`Coprime` from scratch, proves all parity lemmas manually, and proves the main theorem by infinite descent. `mathlibDependencies` lists only **tactics** (`ring`, `omega`) — no Mathlib theorem does the core work. This is Tier A (original), not Tier B (mathlib bridge). The `originalContributions` ("from scratch", "built manually", "Full irrationality proof using infinite descent") already assert originality; badge `mathlib` contradicted them.

Note: line 208's `exact irrational_sqrt_two` is inside a `/-! -/` docstring comparing to the *other* file — it is not code in this file.

### 2. Phantom `mainTheorems`

| Field | Was | Reality |
|---|---|---|
| name | `sqrt2_exists` | no such decl; actual is `sqrt2_irrational` (line 151) |
| leanType | `exists x : R, x > 0 and x * x = 2` | never proved here (no reals constructed) |
| description | "Existence of sqrt(2) from field axioms and completeness" | file proves *no coprime a,b with a²=2b²* |

Replaced with the actual theorem `sqrt2_irrational : ∀ a b : ℕ, b > 0 → a * a = 2 * b * b → ¬Coprime a b`.

No change to status (`verified`), axiomCount (0), sorries (0), or counts (14 theorems / 3 defs, all confirmed).

---
Discovered during gallery integrity audit (re-audit of stale 2026-05-03 entry).