### PR TITLE
Enrich Cos 2π/n OQ-02→OQ-01: trace/norm framing of the index-2 witness

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-01/annotations.json
@@ -18,9 +18,9 @@
     "type": "insight",
     "title": "Conjugation Maps ζ to the Other Root",
     "content": "conj_zeta proves conj(e^{iθ}) = e^{−iθ} via Complex.exp_conj (exp commutes with conjugation). zeta_mul gives the unit-circle product e^{iθ}·e^{−iθ} = 1; zeta_add gives the sum e^{iθ} + e^{−iθ} = 2cos θ (Complex.two_cos). quadratic_factor assembles these into (z − e^{iθ})(z − e^{−iθ}) = z² − (2cos θ)z + 1. The two roots are a complex-conjugate pair, so conjugation is exactly the swap of the two roots of this real quadratic.",
-    "mathContext": "$\\overline{e^{i\\theta}} = e^{-i\\theta}$; $e^{i\\theta}e^{-i\\theta}=1$, $e^{i\\theta}+e^{-i\\theta}=2\\cos\\theta$; hence $(z-e^{i\\theta})(z-e^{-i\\theta}) = z^2 - (2\\cos\\theta)z + 1$.",
+    "mathContext": "$\\overline{e^{i\\theta}} = e^{-i\\theta}$; $e^{i\\theta}e^{-i\\theta}=1$, $e^{i\\theta}+e^{-i\\theta}=2\\cos\\theta$; hence $(z-e^{i\\theta})(z-e^{-i\\theta}) = z^2 - (2\\cos\\theta)z + 1 = z^2 - \\mathrm{Tr}(\\zeta)z + \\mathrm{N}(\\zeta)$, the characteristic polynomial of $\\zeta$ over $\\mathbb{Q}(\\cos\\theta)$ (sum $=$ trace, product $=$ norm).",
     "significance": "key",
-    "relatedConcepts": ["Euler's formula", "complex conjugate roots", "Vieta's formulas", "minimal polynomial of ζ over ℝ"],
+    "relatedConcepts": ["Euler's formula", "complex conjugate roots", "Vieta's formulas", "trace and norm over a subfield", "minimal polynomial of ζ over ℝ"],
     "prerequisites": ["complex exponential", "exp_conj", "roots and coefficients of quadratics"]
   },
   {


### PR DESCRIPTION
Enrichment pass for `angle-trisection-cos-20-gal-oq-02-oq-01` (pass 0, quality 95 — already comprehensive; one sharp non-redundant addition rather than inflation).

**Added:**
- **keyInsight (5th):** the real generator 2cos θ = ζ + ζ⁻¹ = ζ + conj(ζ) is exactly the trace Tr_{ℚ(ζ)/ℚ(cos θ)}(ζ) over the two-element conjugation orbit. This explains *why* cos 2π/n generates the fixed field element-theoretically, and frames the quadratic X²−(2cos θ)X+1 as the characteristic polynomial X²−Tr(ζ)X+N(ζ) of ζ over ℚ(cos θ) (norm ζ·ζ⁻¹ = 1). Ties the element-level witness to the general trace/norm theory of fixed subfields.
- **conj-roots annotation:** sharpened mathContext + relatedConcepts with the same trace/norm framing at the point where the quadratic is assembled.

meta.json: 16.8 KB → 17.3 KB (well under 60 KB cap; keyInsights 4 → 5, under 12). No content deleted. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries — confirmed against the Lean file: 13 theorems, `by decide` only, no native_decide/axiom/sorry).