### PR TITLE
audit(shannon-source-coding-oq-02): sync stale axiom prose — monotonicity is proved

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-02/meta.json
@@ -40,10 +40,9 @@
       "Complete proof of Shannon coding Kraft validity via log-exp monotonicity",
       "Complete proof of Shannon coding upper bound L < H/ln2 + 1",
       "Tight sandwich bounds on optimal code length combining lower and upper bounds",
-      "Axiomatized optimal code monotonicity (exchange argument) and Huffman optimality"
+      "Complete proof of optimal-code monotonicity (p_i > p_j => l_i <= l_j) via the exchange/swap argument; only Huffman optimality itself remains axiomatized"
     ],
     "assumptions": [
-      "optimal_code_monotone: In an optimal code, more probable symbols get shorter codewords (provable by the exchange/swap argument)",
       "huffman_optimal: Among all prefix-free codes, Huffman achieves minimum average code length (provable by induction on alphabet size)"
     ],
     "dateAdded": "2026-03-23",


### PR DESCRIPTION
## Integrity Issue (LOW — stale prose, safe direction)

**Proof**: shannon-source-coding-oq-02 (Huffman Coding Optimality)

`optimal_code_monotone` was upgraded from an axiom to a **fully-proved theorem** (exchange/swap argument, `ShannonSourceCodingOQ02.lean:225`, no sorry/stub), but two meta.json fields were never re-synced and still described it as axiomatized:

- `originalContributions` last bullet: "Axiomatized optimal code monotonicity (exchange argument) and Huffman optimality"
- `assumptions`: listed `optimal_code_monotone` as an assumption alongside `huffman_optimal`

This contradicted the file (only `huffman_optimal` at line 328 is a real axiom) and other already-synced parts of the same meta (a mainTheorems summary already says "proved, not axiomatized"; sections + openQuestions already correct).

## Verified against source

- `axiomCount: 1` ✓ (only `huffman_optimal`)
- `sorries: 0` ✓
- `theoremCount: 9` ✓ (6 theorems + 3 `private lemma`)
- `definitionCount: 4` ✓
- `lineCount: 357` ✓
- `status: axiomatized`, `badge: axiom` ✓

## Fix

- Rewrote the `originalContributions` bullet to state monotonicity is proved and only Huffman remains axiomatized.
- Removed the phantom `optimal_code_monotone` entry from `assumptions` so it matches `axiomCount: 1`.

---
Discovered during gallery integrity audit.