### PR TITLE
Enrich q-Binomial Theorem entry: cover Section 5 sanity checks

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -97,5 +97,17 @@
       "Finset.prod_const and Finset.card_range",
       "definition of the q-Pochhammer symbol"
     ]
+  },
+  {
+    "id": "ann-qbt-sanity-checks",
+    "proofId": "arithmetic-series-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 189, "endLine": 222 },
+    "type": "context",
+    "title": "Small-Case Sanity Checks (decide, not native_decide)",
+    "content": "Section 5 evaluates the master identity on concrete numbers, each proved by rewriting with the already-established theorem rather than a separate computation. check_n2_q2_x3 verifies the n=2, q=2, x=3 case over ℤ: the product (1+3)(1+3·2) = 4·7 = 28 matches the RHS 1 + [2,1]₂·3 + 2·[2,2]₂·9 = 1 + 9 + 18 = 28, closed by `rw [qBinomialTheorem]`. check_n3_q1_x1 verifies the q=1 collapse (1+1)³ = 8 = ∑ C(3,k) = 1+3+3+1 via `rw [qBinomialTheorem_q_one]`. The trailing docstring summarizes the five sections. Crucially these use `decide`, not `native_decide`, so they add no axioms — the entry remains 0-axiom, 0-sorry, and its verified status is honest.",
+    "mathContext": "$n=2,q=2,x=3$: $(1+3)(1+6)=28$; $n=3,q=1,x=1$: $(1+1)^3 = \\sum_k \\binom{3}{k} = 8$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "q-binomial coefficients", "decide vs native_decide", "specialization by rewriting"],
+    "prerequisites": ["the proven qBinomialTheorem and its q=1 form", "decide as a kernel-checked decision procedure", "q-binomial coefficient values"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-01-oq-01-oq-01`.

**Gap addressed:** annotations stopped at line 191, leaving Section 5 (small-case sanity checks, lines 189–222) uncovered.

**Added:** a `context` annotation for the sanity-check section — the two concrete evaluations (n=2, q=2, x=3 over ℤ giving 28; n=3, q=1, x=1 giving 8 = 2³), each closed by `rw [qBinomialTheorem]` / `rw [qBinomialTheorem_q_one]` rather than a standalone computation — with the explicit note that these use `decide` (not `native_decide`), so the entry's 0-axiom/0-sorry verified status is honest.

Annotation count 4 → 5, tail coverage gap closed. meta.json unchanged. Axiom/status integrity confirmed against the Lean file (decide only, no native_decide/axiom/sorry).