### PR TITLE
Enrich Dirichlet eta η(4) (oq-13-oq-01): annotate results table

### DIFF
--- a/src/data/proofs/basel-problem-oq-13-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-13-oq-01/annotations.json
@@ -94,5 +94,28 @@
       "uniqueness of sums",
       "tsum API"
     ]
+  },
+  {
+    "id": "eta-four-summary",
+    "proofId": "basel-problem-oq-13-oq-01",
+    "range": {
+      "startLine": 93,
+      "endLine": 110
+    },
+    "type": "context",
+    "title": "Results Table and Provenance",
+    "content": "The closing summary tabulates the four exported results — hasSum_eta_four_even (∑ (-1)^{2k+1}/(2k)⁴ = −π⁴/1440), hasSum_eta_four_odd (∑ (-1)^{2k+2}/(2k+1)⁴ = π⁴/96), hasSum_eta_four (∑ (-1)^{n+1}/n⁴ = 7π⁴/720, HasSum form), and tsum_eta_four (the ∑' restatement) — and records their provenance: everything is built from the parent BaselProblemOQ13's even/odd fourth-power sums (hasSum_even_zeta_four, hasSum_odd_zeta_four) recombined through HasSum.even_add_odd, with 0 sorries and 0 axioms. It is the s = 4 instance of the Dirichlet eta value η(s) = (1 − 2^{1−s})ζ(s), so η(4) = (1 − 2^{−3})ζ(4) = (7/8)(π⁴/90) = 7π⁴/720.",
+    "mathContext": "\\eta(4) = \\Big(1 - 2^{-3}\\Big)\\zeta(4) = \\tfrac{7}{8}\\cdot\\frac{\\pi^4}{90} = \\frac{7\\pi^4}{720}",
+    "significance": "context",
+    "relatedConcepts": [
+      "Dirichlet eta at even integers",
+      "ζ(4) = π⁴/90",
+      "η(s) = (1 − 2^{1−s})ζ(s)",
+      "provenance from the parent even/odd sums"
+    ],
+    "prerequisites": [
+      "the parent's fourth-power even/odd zeta sums",
+      "the value ζ(4) = π⁴/90"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-13-oq-01`.

## Assessment
This entry was already well-enriched (header covered, 4 theorem annotations with full fields, complete meta). The one genuinely uncovered region was the closing summary/results table (lines 101–110).

## Change
- Added `eta-four-summary` (type `context`, lines 93–110): tabulates the four exported results and their provenance from the parent's even/odd fourth-power sums, and states the s=4 instance η(4) = (1−2^{−3})ζ(4) = (7/8)(π⁴/90) = 7π⁴/720.
- 5 annotations total; coverage now spans the full 110-line file.

## Validation
- `jq empty` on annotations.json — valid.
- meta.json unchanged; no status/axiom claims altered.