### PR TITLE
Enrich uniform Dirichlet eta bridge (oq-13-oq-01-oq-01): annotate results table

### DIFF
--- a/src/data/proofs/basel-problem-oq-13-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-13-oq-01-oq-01/annotations.json
@@ -93,5 +93,28 @@
       "ζ(2) = π²/6 and ζ(4) = π⁴/90",
       "the eta–zeta bridge"
     ]
+  },
+  {
+    "id": "eta-uniform-summary",
+    "proofId": "basel-problem-oq-13-oq-01-oq-01",
+    "range": {
+      "startLine": 158,
+      "endLine": 177
+    },
+    "type": "context",
+    "title": "Results Table: One Bridge, Every Eta Value",
+    "content": "The closing summary tabulates the exports and states the entry's organizing idea: a single analytic-free lemma hasSum_eta_of_hasSum_zeta packages the even/odd parity split once, so every Dirichlet eta value is a specialisation of it composed with a zeta HasSum. From ζ(m) = Z it gives η(m) = (1 − 2/2ᵐ)·Z for any exponent m; hasSum_eta_two_mul_nat specializes to the even family η(2k) = (1 − 2^{1−2k})ζ(2k) (with eta_factor_eq proving 1 − 2/2^{2k} = 1 − 2^{1−2k}), and composing with hasSum_zeta_two / hasSum_zeta_four yields η(2) = π²/12 and η(4) = 7π⁴/720, each also given in tsum form. This factor-out-the-parity-split design avoids re-deriving the split per exponent, unlike the sibling entries that prove η(2) and η(4) separately. 0 sorries, 0 axioms.",
+    "mathContext": "\\zeta(m) = Z \\;\\Rightarrow\\; \\eta(m) = \\Big(1 - \\tfrac{2}{2^m}\\Big) Z = \\big(1 - 2^{1-m}\\big)\\zeta(m)",
+    "significance": "context",
+    "relatedConcepts": [
+      "exponent-independent bridge lemma",
+      "η(s) = (1 − 2^{1−s})ζ(s)",
+      "even eta family η(2k)",
+      "reuse via specialisation"
+    ],
+    "prerequisites": [
+      "the eta–zeta bridge hasSum_eta_of_hasSum_zeta",
+      "Mathlib's zeta values hasSum_zeta_two / hasSum_zeta_four"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-13-oq-01-oq-01`.

## Gap addressed
Header and the 7 theorems were annotated, but the closing summary/results-table block (lines 158–177) had no coverage.

## Change
- Added `eta-uniform-summary` (type `context`, lines 158–177): tabulates the exports and states the entry's organizing idea — one analytic-free bridge lemma `hasSum_eta_of_hasSum_zeta` packages the parity split once, and every eta value η(m) = (1−2^{1−m})ζ(m) is a specialisation of it composed with a zeta HasSum.
- 5 annotations total; coverage now spans the full 177-line file.

## Validation
- `jq empty` on annotations.json — valid.
- meta.json unchanged; no status/axiom claims altered.