### PR TITLE
Enrich Weighted LGV entry (ballot-problem-oq-03-oq-02-oq-03): cover header section

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-wlgv-header",
+    "proofId": "ballot-problem-oq-03-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 59 },
+    "type": "context",
+    "title": "Weighted LGV: the Algebraic Core, and the Honest Open Boundary",
+    "content": "The header states the inherited open question — extend the parent's fully-proved r×r Lindström–Gessel–Viennot lemma (lgv_lemma_rxr) to weighted lattice paths, the generating-function version. In weighted LGV each path P carries a weight w(P) in a commutative ring R and the plain path count e(Aᵢ,Bⱼ) is replaced by the generating function h(Aᵢ,Bⱼ) = ∑_{P:Aᵢ→Bⱼ} w(P); the theorem then reads det[h(Aᵢ,Bⱼ)] = ∑_{non-intersecting families} ∏ᵢ w(Pᵢ). This file formalizes, over an arbitrary CommRing with abstract finite path types, the ALGEBRAIC HALF (★): det H = ∑_σ sign(σ) • ∑_{path families} ∏ w — the column Leibniz expansion (Matrix.det_apply after transpose) with each product of generating-function entries expanded over path families (Fintype.prod_sum). Specializing every weight to 1 recovers the parent's counting form, so this genuinely generalizes it. What remains OPEN (recorded as the def WeightedLGVConjecture, explicitly NOT proved or assumed): the Gessel–Viennot sign-reversing involution collapsing the σ≠1 terms to leave only non-intersecting families. Crucially the file is honest — status verified, 0 axioms, 0 sorries, no native_decide; the open combinatorial core is a stated Prop, not an axiom.",
+    "mathContext": "Weighted LGV: $\\det[h(A_i,B_j)] = \\sum_{\\text{non-intersecting } (P_1,\\dots,P_r)} \\prod_i w(P_i)$. Proved here (algebraic half): $\\det H = \\sum_\\sigma \\operatorname{sign}(\\sigma)\\, \\sum_{f\\in\\prod_i \\mathrm{Path}\\,i\\,(\\sigma i)} \\prod_i w(i,\\sigma i, f_i)$.",
+    "significance": "context",
+    "relatedConcepts": ["Lindström–Gessel–Viennot lemma", "generating functions", "Leibniz determinant expansion", "sign-reversing involution", "non-intersecting lattice paths"],
+    "prerequisites": ["determinants over a commutative ring", "the unweighted LGV lemma (parent)", "generating functions of weighted paths"]
+  },
+  {
     "id": "ann-wlgv-structure",
     "proofId": "ballot-problem-oq-03-oq-02-oq-03",
     "range": {


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-03-oq-02-oq-03`.

**Gap addressed:** annotation coverage started at line 60, leaving the substantial header docstring (lines 1–59) uncovered.

**Added:** a `context` annotation covering lines 1–59 — *Weighted LGV: the Algebraic Core, and the Honest Open Boundary* — framing the inherited open question (generating-function LGV), the algebraic-core identity (★) actually proved here via the Leibniz expansion + `Fintype.prod_sum`, the weight-1 specialization recovering the unweighted parent, and the honest boundary: the Gessel–Viennot sign-reversing involution remains a stated `def : Prop` (`WeightedLGVConjecture`), explicitly not proved or assumed.

Annotation count 4 → 5, full preamble now covered. meta.json unchanged. Axiom/status integrity confirmed against the Lean file: verified, 0 axioms, 0 sorries, no native_decide; the open piece is a Prop, not an axiom.