### PR TITLE
Enrich Basel odd-square series (basel-problem-oq-09): cover header section

### DIFF
--- a/src/data/proofs/basel-problem-oq-09/annotations.json
+++ b/src/data/proofs/basel-problem-oq-09/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "basel-oq09-header",
+    "proofId": "basel-problem-oq-09",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "context",
+    "title": "The Odd-Square Series via the Even/Odd Split of Basel",
+    "content": "The header states the goal — ∑_{k≥0} 1/(2k+1)² = 1 + 1/9 + 1/25 + ⋯ = π²/8 — and the standard route from the Basel value ∑ 1/n² = π²/6. Split the Basel sum by index parity: ∑_{n≥1} 1/n² = ∑_{k≥1} 1/(2k)² + ∑_{k≥0} 1/(2k+1)². The even part is a quarter-scaled copy of the whole sum, ∑ 1/(2k)² = (1/4)∑ 1/k² = (1/4)(π²/6) = π²/24, so uniqueness of sums forces the odd part = π²/6 − π²/24 = π²/8. The proof imports Mathlib's Basel identity hasSum_zeta_two, recombines the even/odd subseries with HasSum.even_add_odd, rescales the even part via HasSum.mul_left, and pins the value with HasSum.unique — carrying out the decomposition explicitly rather than quoting the odd-square value. Status: complete, 0 sorries, 0 axioms.",
+    "mathContext": "$\\sum_{k\\ge 0}\\frac{1}{(2k+1)^2} = \\frac{\\pi^2}{8}$, from $\\sum_{n\\ge1}\\frac1{n^2}=\\frac{\\pi^2}{6}$ split as $\\underbrace{\\tfrac14\\cdot\\tfrac{\\pi^2}{6}}_{\\text{even}=\\pi^2/24} + \\text{odd}$, giving odd $= \\tfrac{\\pi^2}{6}-\\tfrac{\\pi^2}{24}=\\tfrac{\\pi^2}{8}$.",
+    "significance": "context",
+    "relatedConcepts": ["Basel problem ζ(2)=π²/6", "even/odd series decomposition", "HasSum.even_add_odd", "Dirichlet beta / Catalan analog", "quarter-scaling of the even part"],
+    "prerequisites": ["the Basel identity ∑ 1/n² = π²/6", "HasSum and uniqueness of sums", "summability and index reindexing"]
+  },
+  {
     "id": "basel-summand",
     "proofId": "basel-problem-oq-09",
     "range": {


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-09`.

**Gap addressed:** annotation coverage started at line 50, leaving the imports + docstring header (lines 1–49) uncovered.

**Added:** a `context` annotation covering lines 1–49 — *The Odd-Square Series via the Even/Odd Split of Basel* — framing the goal ∑ 1/(2k+1)² = π²/8, the parity split of the Basel sum, the quarter-scaling of the even part to π²/24, and the Mathlib route (`hasSum_zeta_two`, `HasSum.even_add_odd`, `HasSum.mul_left`, `HasSum.unique`).

Annotation count 8 → 9, full preamble now covered. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).