### PR TITLE
audit: mark shannon-channel-coding + russell-1-plus-1 clean 2026-07-09

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24719,9 +24719,9 @@
       "issues": []
     },
     "shannon-channel-coding": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:50:53Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "shannon-channel-coding-awgn": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24570,9 +24570,9 @@
       "result": "clean"
     },
     "russell-1-plus-1": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:50:54Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "russell-1-plus-1-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — shannon-channel-coding

**Result: CLEAN.** Re-audited (was stale at 2026-05-03). This PR only bumps the audit tracker; no meta/source changes needed.

### Verified against `proofs/Proofs/ShannonChannelCoding.lean`
- Counts exact vs meta.json: **18** theorems / **9** definitions (2 structures + 7 defs) / **2** axioms / **0** sorries / **612** lines.
- No `native_decide`, no `True`-stubs.
- All 18 theorem names in `assumptions`/`originalContributions` prose exist in source (no phantom decls).
- `fano_inequality` is a genuine proved theorem (delegated to `FanoFromConditionalEntropy.fano_inequality_proved` in `ShannonChannelCodingOQ02OQ01`) — matches the "proved Fano inequality" claim.
- The 2 axioms (`channel_coding_achievability`, `channel_coding_converse`) carry substantive quantitative propositions (not vacuous `True`-placeholders) and are pervasively disclosed as axioms across sections, conclusion, and `assumptions`.
- `status: axiomatized` + `badge: axiom` correct for 2 stated axioms; famous-theorem title is not axiom-masking given the thorough disclosure.

Exemplary honest axiomatization — no changes required.

---
Discovered during gallery integrity audit.