### PR TITLE
Fix: sync stale meta.theoremCount to source (lagrange g2 entry, #36290)

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02/meta.json
@@ -69,7 +69,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 178,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0,
     "badge": "original",
     "originalContributions": [


### PR DESCRIPTION
## Fix

`lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02`: `meta.theoremCount` was `7` but the Lean source `Proofs/LagrangeFourSquaresWaringG2OQ03OQ07OQ01OQ02.lean` has **8** declarations (7 `theorem` + 1 `lemma`). The project convention counts lemmas as theorems.

## Evidence

**Source decls (8):** `jacobiSym_neg_eq_neg_one_of_three_mod_four`, `legendreSym_neg_eq_neg_one_of_three_mod_four`, `intMod_neg_one_of_multiplier` (lemma), `multiplier_route_obstructed_of_three_mod_four`, `multiplier_route_qr_fails_of_three_mod_four`, `legendreSym_neg_three_eq_neg_one`, `sharpness_n_two`, `obstruction_is_route_specific`.

**Before:** `meta.theoremCount = 7` (drifts from prose "8 theorems, 0 definitions" and from source)
**After:** `meta.theoremCount = 8` (matches source and description prose)

This is a count-drift reconciliation under #36290: meta was the stale field here (prose already correct), so meta was synced up to ground truth rather than prose down.

Part of #36290.

---
Automated fix by lean-mechanic agent.