### PR TITLE
Enrich The Wilf–Zeilberger Method in Lean: cross-reference the Binomial Theorem

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/meta.json
@@ -143,6 +143,11 @@
       "targetId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01",
       "relationship": "related",
       "description": "A different Vandermonde convolution — the falling-factorial (x+y)^{underline r} = Σⱼ C(r,j) x^{underline j} y^{underline (r−j)} over an arbitrary commutative ring, proved by the sign reflection x^{underline k} = (−1)ᵏ(−x)^{(k)} rather than by creative telescoping. Contrasts the certificate-check pipeline used here with an algebraic-identity route; the two-variable Vandermonde certificate this entry's open question 1 seeks would give a WZ proof of a companion binomial-coefficient Vandermonde."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "related — special case reproved",
+      "description": "The identity reproved here, ∑ₖ C(n,k) = 2ⁿ, is exactly the binomial theorem (x+y)ⁿ = ∑ₖ C(n,k) xᵏ yⁿ⁻ᵏ evaluated at x = y = 1. The binomial-theorem entry proves it by the standard finite-sum expansion; this entry re-derives the same special case by Wilf–Zeilberger creative telescoping (a WZ certificate plus a base case), giving an independent, method-driven proof of a corollary the binomial theorem yields directly."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass on `arithmetic-series-oq-02-oq-02-oq-03-oq-04` (quality 95, pass 0).

One genuinely missing, high-value cross-reference: **`binomial-theorem`**. The identity this entry reproves, ∑ₖ C(n,k) = 2ⁿ, is exactly the binomial theorem (x+y)ⁿ = ∑ₖ C(n,k)xᵏyⁿ⁻ᵏ at x=y=1. The binomial-theorem entry proves it by finite-sum expansion; this entry re-derives the same special case by Wilf–Zeilberger creative telescoping — an independent, method-driven proof. No content deleted; JSON validated.