### PR TITLE
Enrich Odd-Square Series ∑1/(2k+1)²=π²/8: degree-4 + Leibniz cross-refs

### DIFF
--- a/src/data/proofs/basel-problem-oq-09/meta.json
+++ b/src/data/proofs/basel-problem-oq-09/meta.json
@@ -162,6 +162,16 @@
       "targetId": "basel-problem-oq-11",
       "relationship": "related",
       "description": "The Dirichlet eta companion η(2) = π²/12 uses the same even/odd splitting machinery and reuses the odd-square value π²/8."
+    },
+    {
+      "targetId": "basel-problem-oq-13",
+      "relationship": "related — degree-4 analog",
+      "description": "The degree-4 counterpart ∑ 1/(2k+1)⁴ = π⁴/96 = λ(4) applies this entry's exact even/odd template to ζ(4) = π⁴/90 (even part = (1/16)ζ(4), odd part by uniqueness). It is precisely the λ(2m) generalization this entry's first open question asks for, at m = 2, so it is the direct realization of the reusable-split idiom advocated here."
+    },
+    {
+      "targetId": "basel-problem-oq-10",
+      "relationship": "related — odd-reciprocal companion",
+      "description": "Leibniz's series ∑ (−1)ᵏ/(2k+1) = π/4 sums over the same odd denominators 2k+1 but with alternating signs and first (rather than second) powers — the β(1) companion to this entry's λ(2). Together they illustrate how the odd-index reciprocals produce π/4 (alternating, linear) and π²/8 (positive, squared) from different Dirichlet L-functions on the same index set."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass on `basel-problem-oq-09` (quality 95, pass 0).

Two genuinely missing, high-value cross-references (meta.json 11.5 KB → 12.5 KB, well under cap):

- **`basel-problem-oq-13`** (∑1/(2k+1)⁴ = π⁴/96) — the exact degree-4 analog of this construction and precisely the λ(2m) realization this entry's own first open question asks for (m=2), via the same even/odd split of ζ(4).
- **`basel-problem-oq-10`** (Leibniz π/4) — the alternating odd-reciprocal β(1) companion to this entry's λ(2), over the same odd index set 2k+1.

No content deleted; JSON validated.