### PR TITLE
Enrich Cayley–Hamilton/Putzer entry: annotate the uncovered Putzer core

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-01/annotations.json
@@ -73,5 +73,53 @@
       "Fin.prod_univ_eq_prod_range",
       "Algebra.algebraMap_eq_smul_one"
     ]
+  },
+  {
+    "id": "choq0201-concatenation",
+    "proofId": "cayley-hamilton-oq-02-oq-01",
+    "range": { "startLine": 134, "endLine": 158 },
+    "type": "theorem",
+    "title": "The Concatenation (Semigroup) Law for Partial Products",
+    "content": "rho_add is the multiplicative concatenation law ρ_{j+k} = ρ_j · ρ'_k, where ρ' uses the shifted eigenvalue sequence i ↦ λ_{j+i} — the matrix analogue of splitting a product ∏_{i<j+k} = (∏_{i<j})·(∏_{j≤i<j+k}). It holds on the nose because ρ is built by right-multiplication; the proof inducts on k with the k=1 case being rho_succ. rho_dvd_rho_add reads off the immediate corollary: ρ_j left-divides every longer ρ_{j+k}, exhibiting the quotient ρ' explicitly. This semigroup structure is what lets the later derivative computation reindex partial products freely.",
+    "mathContext": "$\\rho_{j+k} = \\rho_j \\cdot \\rho'_k$ with $\\rho'$ formed from $i\\mapsto\\lambda_{j+i}$; hence $\\rho_j \\mid \\rho_{j+k}$ (left divisor). Generalizes $\\rho_{k+1}=\\rho_k\\,(A-\\lambda_k)$ (the $k=1$ case).",
+    "significance": "supporting",
+    "relatedConcepts": ["concatenation / semigroup law", "partial products", "left divisibility", "induction on length", "shifted eigenvalue sequence"],
+    "prerequisites": ["rho_succ recursion", "induction on ℕ", "right-multiplicative products"]
+  },
+  {
+    "id": "choq0201-two-sided-telescoping",
+    "proofId": "cayley-hamilton-oq-02-oq-01",
+    "range": { "startLine": 159, "endLine": 197 },
+    "type": "theorem",
+    "title": "Two-Sided Factor Structure and Sum-Level Telescoping",
+    "content": "Because each factor A − λ_i•1 is a polynomial in A it commutes with every ρ_k, so the defining factor can be pulled to either side: rho_succ_left gives ρ_{k+1} = (A − λ_k•1)·ρ_k (the left mirror of the right-multiplying rho_succ), and rho_mul_A gives the right telescoping identity ρ_k·A = ρ_{k+1} + λ_k•ρ_k. A_mul_sum_rho lifts this to the whole finite Putzer sum: A·∑_{k<m} a_k•ρ_k = ∑_{k<m} a_k•(ρ_{k+1} + λ_k•ρ_k). This converts left-multiplication by A into a shift ρ_k ↦ ρ_{k+1} plus a diagonal λ_k term — the purely algebraic content of the derivative computation Ṁ = A·M, with no analysis, over any CommRing.",
+    "mathContext": "$\\rho_{k+1} = (A-\\lambda_k)\\rho_k = \\rho_k(A-\\lambda_k)$; $\\ \\rho_k A = \\rho_{k+1}+\\lambda_k\\rho_k$; $\\ A\\sum_{k<m} a_k\\rho_k = \\sum_{k<m} a_k(\\rho_{k+1}+\\lambda_k\\rho_k)$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping", "commuting factors (polynomials in A)", "shift operator ρ_k ↦ ρ_{k+1}", "Finset.mul_sum distributivity", "algebraic derivative Ṁ = A·M"],
+    "prerequisites": ["commute_A_rho", "A_mul_rho telescoping identity", "distributing a product over a finite sum"]
+  },
+  {
+    "id": "choq0201-analytic-bridge",
+    "proofId": "cayley-hamilton-oq-02-oq-01",
+    "range": { "startLine": 198, "endLine": 269 },
+    "type": "insight",
+    "title": "The Algebraic Form of Ṁ = A·M (the Analytic Bridge)",
+    "content": "Putzer's solution M(t) = ∑_{k<n} P_k(t)•ρ_k has scalar coefficients obeying the triangular ODE Ṗ_k = λ_k P_k + P_{k−1} (with P_{−1} ≡ 0), so term-by-term differentiation gives Ṁ = ∑ (λ_k P_k + P_{k−1})•ρ_k. Before any analysis, the claim 'Putzer solves Ṁ = A·M' is exactly the algebraic identity A·∑ P_k•ρ_k = ∑ (λ_k P_k + P_{k−1})•ρ_k. sum_P_rho_succ handles the P_{−1}=0 convention cleanly (no ℕ-subtraction) via a second family Pprev with Pprev 0 = 0, Pprev(k+1)=P k, reindexing ∑ P_k•ρ_{k+1} through Finset.sum_range_succ'. A_mul_putzer_sum then proves the identity under the single hypothesis ρ_m = 0 — the boundary term P_{m−1}•ρ_m is precisely what the vanishing kills. A_mul_putzer_sum_charpoly specializes m = n, discharging that boundary automatically from the Cayley–Hamilton truncation rho_card (ρ_n = 0). This is the exact statement the deferred analytic layer will differentiate against.",
+    "mathContext": "$A\\!\\sum_{k<n} P_k\\rho_k = \\sum_{k<n}(\\lambda_k P_k + P_{k-1})\\rho_k$, closing because $\\rho_n=0$ deletes the boundary $P_{n-1}\\rho_n$; the LHS is $A\\,M(t)$ and the RHS is $\\dot M(t)$ once the $P_k$ become ODE solutions.",
+    "significance": "key",
+    "relatedConcepts": ["Putzer's algorithm", "matrix exponential e^{tA}", "triangular ODE system", "boundary term cancellation via Cayley–Hamilton", "P_{-1}=0 convention without ℕ-subtraction"],
+    "prerequisites": ["A_mul_sum_rho sum-level telescoping", "rho_card truncation ρ_n = 0", "Finset.sum_range_succ' reindexing"]
+  },
+  {
+    "id": "choq0201-initial-condition",
+    "proofId": "cayley-hamilton-oq-02-oq-01",
+    "range": { "startLine": 271, "endLine": 319 },
+    "type": "theorem",
+    "title": "The Algebraic Initial Condition M(0) = I and the Full IVP Skeleton",
+    "content": "putzer_sum_initial evaluates the finite sum at t = 0: with Putzer's initial data (c 0 = 1, c k = 0 for k > 0) the sum ∑_{k<m} c_k•ρ_k collapses to the single surviving k=0 term c_0•ρ_0 = 1•1 = 1 (using ρ_0 = 1), i.e. M(0) = I, for any m ≥ 1. putzer_ivp_charpoly assembles both halves: when χ_A = ∏(X − λ_i) and P carries the Putzer initial data, the matrix sum M = ∑_{k<n} P_k•ρ_k satisfies simultaneously A·M = ∑(λ_k P_k + P_{k−1})•ρ_k (the Ṁ = A·M right-hand side) AND M = 1. For n ≥ 1 this is the complete algebraic skeleton of Putzer's theorem: once the deferred analytic layer supplies coefficient functions P_k(t) with these values at 0 and these derivatives, matrix-ODE uniqueness yields M(t) = e^{tA} — everything here is pure CommRing bookkeeping.",
+    "mathContext": "$\\sum_{k<m} c_k\\rho_k = c_0\\rho_0 = 1$ when $c_0=1,\\ c_{k>0}=0$ (so $M(0)=I$); combined with $A\\,M = \\sum(\\lambda_k P_k + P_{k-1})\\rho_k$ gives the algebraic IVP $\\dot M = AM,\\ M(0)=I$ whose unique solution is $e^{tA}$.",
+    "significance": "key",
+    "relatedConcepts": ["initial value problem", "M(0) = I", "matrix exponential", "Finset.sum_eq_single collapse", "ODE uniqueness (deferred analytic layer)"],
+    "prerequisites": ["rho_zero = 1", "A_mul_putzer_sum_charpoly", "Finset.sum_eq_single"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-oq-02-oq-01`.

**Gap addressed:** the entry was substantially under-annotated — 4 annotations covered only lines 61–123 of a **319-line** file, leaving the entire Putzer / analytic-bridge core (11 lemmas, lines 134–319) with no inline annotations, despite meta.json already having matching sections.

**Added 4 annotations** (all verified against the Lean source), one per existing meta section:
- **Concatenation (semigroup) law** — `rho_add` (ρ_{j+k} = ρ_j·ρ'_k) and `rho_dvd_rho_add` (134–158)
- **Two-sided factor structure + sum-level telescoping** — `rho_succ_left`, `rho_mul_A`, `A_mul_sum_rho` (159–197)
- **Algebraic form of Ṁ = A·M** — `sum_P_rho_succ`, `A_mul_putzer_sum`, `A_mul_putzer_sum_charpoly`; the boundary term is killed precisely by the Cayley–Hamilton truncation ρ_n = 0 (198–269)
- **Algebraic initial condition M(0) = I and the full IVP skeleton** — `putzer_sum_initial`, `putzer_ivp_charpoly` (271–319)

Annotation count 4 → 8; inline coverage now spans the whole file (max endLine 319). meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).