### PR TITLE
Enrich Second-order Bernoulli (bernoulli-inequality-oq-01-oq-02): cover header section

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "bern-oq0102-header",
+    "proofId": "bernoulli-inequality-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "context",
+    "title": "Second-Order Bernoulli and Its Equality Characterization",
+    "content": "The header frames the open question — characterize equality in Bernoulli's inequality (1+a)ⁿ ≥ 1 + n·a — and states this entry's new content, the second-order refinement. The first-order equality (a = 0 ∨ n ≤ 1) is settled by the parent/sibling entries and recorded here as a one-line corollary; the fresh result is the sharper quadratic-truncation bound for a ≥ 0: (1+a)ⁿ ≥ 1 + n·a + C(n,2)·a² with C(n,2) = n(n−1)/2, together with its own sharp equality characterization a = 0 ∨ n ≤ 2. The threshold shifts from n ≤ 1 (first order) to n ≤ 2 (second order): the quadratic truncation is exact through n = 2 (since (1+a)² = 1 + 2a + a² is the full expansion) and becomes strict exactly once the cubic term a³ can appear, i.e. n ≥ 3, a > 0. Mechanism: a one-line induction multiplying the inductive bound by 1+a ≥ 0 and using Pascal C(n,2) + n = C(n+1,2), discarding the nonnegative tail C(n,2)·a³. The restriction a ≥ 0 is sharp — for −1 < a < 0 the quadratic truncation overshoots (n=3, a=−1/2 gives 1/4 > 1/8), unlike the first-order form which holds down to a = −2. Mathlib has only first-order integer-power Bernoulli, so the second-order version with equality characterization is original.",
+    "mathContext": "$(1+a)^n \\ge 1 + na + \\binom{n}{2}a^2$ for $a\\ge 0$, with equality $\\iff a=0 \\lor n\\le 2$; strict for $a>0,\\ n\\ge3$. First order: equality $\\iff a=0 \\lor n\\le1$.",
+    "significance": "context",
+    "relatedConcepts": ["Bernoulli's inequality", "binomial theorem truncation", "equality characterization", "Pascal's rule C(n,2)+n=C(n+1,2)", "sharpness of a ≥ 0"],
+    "prerequisites": ["first-order Bernoulli (parent entries)", "induction on n", "binomial coefficients C(n,2)"]
+  },
+  {
     "id": "weak",
     "proofId": "bernoulli-inequality-oq-01-oq-02",
     "range": { "startLine": 59, "endLine": 76 },


### PR DESCRIPTION
Enrichment pass for `bernoulli-inequality-oq-01-oq-02`.

**Gap addressed:** annotation coverage started at line 59, leaving the substantial docstring header (lines 1–58) uncovered.

**Added:** a `context` annotation covering lines 1–58 — *Second-Order Bernoulli and Its Equality Characterization* — framing the equality open question, the quadratic-truncation bound (1+a)ⁿ ≥ 1 + n·a + C(n,2)·a² for a ≥ 0, its sharp equality characterization (a = 0 ∨ n ≤ 2), the n ≤ 1 → n ≤ 2 threshold shift, the Pascal-rule induction mechanism, and the sharpness of the a ≥ 0 restriction.

Annotation count 6 → 7, header coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).