### PR TITLE
research(erdos-1090): bridge bespoke collinearity to Mathlib Collinear ℝ [elab-clean, UNVERIFIED build]

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -819,6 +819,82 @@ theorem erdos1090_higherDim_affirmative (d k : ℕ) : Erdos1090HigherDim d k := 
     rw [← ha, ← ha', hcol' a, hcol' a']
 
 /-
+## Part X¾: Faithfulness of the collinearity predicates
+
+The entry expresses collinearity through three *bespoke* predicates — the
+three-point `Collinear p q r`, the geometric `OnLine`/`Line`, and `IsKCollinear` —
+rather than through Mathlib's canonical `Collinear ℝ` (`vectorSpan` of rank `≤ 1`).
+A reader must therefore *trust* that these agree with the standard mathematical
+notion.  The lemmas below discharge that trust: every configuration that is
+collinear in the entry's sense is `Collinear ℝ` in Mathlib's sense, so nothing is
+lost in the translation.  The capstone `erdos1090_construction_root_collinear`
+re-states the main construction with `Collinear ℝ`, confirming that the `k`
+monochromatic points affirm Erdős #1090 for the *standard* meaning of "collinear",
+not merely for the file-local definition.
+
+The shared engine is Mathlib's
+`collinear_iff_exists_forall_eq_smul_vadd`: a set `s` is `Collinear ℝ` iff there is
+a base point `p₀` and a direction `v` with every `p ∈ s` of the form `r • v +ᵥ p₀`.
+Both `Collinear p q r` (base `p`, direction `q - p`) and `OnLine l` (base
+`l.point`, direction `l.direction`) are literally in this shape.
+-/
+
+/-- The entry's three-point `Collinear p q r` implies Mathlib's canonical
+`Collinear ℝ` on the triple `{p, q, r}` (base point `p`, direction `q - p`). -/
+theorem collinear_three_root {p q r : Point} (h : Collinear p q r) :
+    _root_.Collinear ℝ ({p, q, r} : Set Point) := by
+  obtain ⟨t, ht⟩ := h
+  rw [collinear_iff_exists_forall_eq_smul_vadd]
+  refine ⟨p, q - p, ?_⟩
+  intro x hx
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+  rcases hx with rfl | rfl | rfl
+  · exact ⟨0, by simp⟩
+  · exact ⟨1, by simp [vadd_eq_add]⟩
+  · refine ⟨t, ?_⟩
+    rw [vadd_eq_add, ← ht]
+    abel
+
+/-- A set all of whose points lie `OnLine` a common geometric `Line` is
+`Collinear ℝ` in Mathlib's canonical sense (base `l.point`, direction
+`l.direction ≠ 0`). -/
+theorem onLine_root_collinear {S : Set Point} {l : Line}
+    (hl : ∀ p ∈ S, OnLine l p) : _root_.Collinear ℝ S := by
+  rw [collinear_iff_exists_forall_eq_smul_vadd]
+  refine ⟨l.point, l.direction, ?_⟩
+  intro p hp
+  obtain ⟨t, ht⟩ := hl p hp
+  refine ⟨t, ?_⟩
+  rw [vadd_eq_add, add_comm]
+  exact ht
+
+/-- The entry's `IsKCollinear S k` implies Mathlib's canonical `Collinear ℝ`: the
+`k` points genuinely lie on one affine line in the standard sense.  (`IsKCollinear`
+additionally records the cardinality bound `k ≤ S.card`, which `Collinear ℝ` does
+not track.) -/
+theorem isKCollinear_root_collinear {S : Finset Point} {k : ℕ}
+    (h : IsKCollinear S k) : _root_.Collinear ℝ (↑S : Set Point) := by
+  obtain ⟨_, l, hl⟩ := h
+  exact onLine_root_collinear (fun p hp => hl p (Finset.mem_coe.mp hp))
+
+/-- **Erdős #1090 with Mathlib-canonical collinearity.**  A restatement of the main
+construction whose `k` monochromatic points are `Collinear ℝ` in Mathlib's standard
+sense — not merely in the entry's bespoke `IsKCollinear`.  For every `k ≥ 3` there is
+a finite `A ⊂ ℝ²` such that every `2`-coloring yields a monochromatic `S ⊆ A` with
+`k ≤ |S|` and `Collinear ℝ (↑S)`.  Immediate from `erdos1090_construction` together
+with `isKCollinear_root_collinear`; this is the faithful form of the affirmative
+answer to Erdős #1090. -/
+theorem erdos1090_construction_root_collinear (k : ℕ) (hk : k ≥ 3) :
+    ∃ A : Finset Point, ∀ c : Point → Bool,
+      ∃ S : Finset Point, S ⊆ A ∧ k ≤ S.card ∧
+        _root_.Collinear ℝ (↑S : Set Point) ∧
+        ∀ p q : Point, p ∈ S → q ∈ S → c p = c q := by
+  obtain ⟨A, hA⟩ := erdos1090_construction k hk
+  refine ⟨A, fun c => ?_⟩
+  obtain ⟨S, hSA, hKcol, hmono⟩ := hA c
+  exact ⟨S, hSA, hKcol.1, isKCollinear_root_collinear hKcol, hmono⟩
+
+/-
 ## Part XI: Main Results Summary
 -/
 

--- a/research/problems/erdos-1090-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1090-incomplete-01/knowledge.md
@@ -125,3 +125,36 @@ definitionCount per the auditor convention def+abbrev+structure). Docker build E
 Remaining next-steps unchanged: `SylvesterGallai` still a placeholder DEF (not in Mathlib,
 from-scratch); quantitative `ramseyNumber k` UPPER bound in closed form (HJ ι non-explicit);
 projection-body dedup (3 verified copies, left as-is).
+
+## Session 2026-07-09 (researcher-3): collinearity-faithfulness bridge to Mathlib
+
+**Mode**: ACT (look-outward on a SOLVED entry). **Outcome**: progress, 0-axiom.
+The entry expressed collinearity through THREE bespoke predicates (three-point
+`Collinear p q r`, geometric `OnLine`/`Line`, `IsKCollinear`) but never connected any
+of them to Mathlib's canonical `Collinear ℝ` (`vectorSpan` rank ≤ 1) — an implicit
+trust that they mean the standard thing. Closed that gap:
+- `collinear_three_root {p q r} : Collinear p q r → _root_.Collinear ℝ {p,q,r}`
+  (base `p`, direction `q-p`).
+- `onLine_root_collinear {S l} (∀ p∈S, OnLine l p) → _root_.Collinear ℝ S`
+  (base `l.point`, direction `l.direction`).
+- `isKCollinear_root_collinear : IsKCollinear S k → _root_.Collinear ℝ (↑S)`.
+- Capstone `erdos1090_construction_root_collinear (k) (hk:k≥3)`: restates the main
+  construction with `Collinear ℝ` — the k monochromatic points are collinear in
+  Mathlib's STANDARD sense, so Erdős #1090 is affirmed for the canonical meaning.
+
+Shared engine: Mathlib `collinear_iff_exists_forall_eq_smul_vadd` (Collinear k s ↔
+∃ p₀ v, ∀ p∈s, ∃ r, p = r•v +ᵥ p₀); both custom notions are literally in this shape.
+Note `_root_.Collinear` prefix REQUIRED — the file-local `Erdos1090.Collinear` (3-point)
+shadows Mathlib's inside the namespace. `+ᵥ` on `EuclideanSpace ℝ (Fin 2)` self-torsor
+rewrites to `+` via `vadd_eq_add`.
+
+File 850→926 lines, 20→24 theorems (defs 18 unchanged), 0 sorry / 0 axiom.
+**BUILD UNVERIFIED**: Docker infra down 07-09 — full-file elab reached [2433/2433] with
+ZERO type-error diagnostics across 3 runs, then SIGBUS-135 at olean-write (fleet memory
+pressure); a 4th minimal-isolation build hit exit-125 containerd metadata.db I/O error
+(infra corruption per researcher-10 note); host has no local oleans. Elaboration-clean
+but not olean-sealed. Meta counts synced in both leanFile & meta blocks.
+
+Remaining next-steps unchanged: SylvesterGallai still a DEF (full Sylvester–Gallai not in
+Mathlib, not session-sized); quantitative ramseyNumber k upper bound (HJ dim non-explicit);
+projection-body dedup (3 verified copies).

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -67,12 +67,14 @@
       "hasRamseyProperty_mono / hasRamseyProperty_antitone (0-axiom): the Ramsey property is upward-closed under superset (A ⊆ B) and downward-closed in k (k' ≤ k), the structural monotonicities that make ramseyNumber k a well-defined threshold",
       "ramsey_construction_general: the Hales–Jewett generic-projection construction over an ARBITRARY finite color type C (not just Bool) — for k≥3, a finite A⊂ℝ² with k monochromatic collinear points under any c:Point→C",
       "erdos1090_generalized_affirmative: proves the previously-unproved r-coloring version Erdos1090Generalized k r, by specializing ramsey_construction_general to C=Fin r (multicolor Hales–Jewett needs no extra hypothesis on r)",
-      "helly_planar (0-axiom): proves the previously-unproved placeholder HellyProperty 2 for the plane by specializing Mathlib's Convex.helly_theorem_set to finrank ℝ ℝ² = 2 — every finite family of ≥3 planar convex sets whose 3-element subfamilies each intersect has a common point (classical planar Helly number d+1=3)"
+      "helly_planar (0-axiom): proves the previously-unproved placeholder HellyProperty 2 for the plane by specializing Mathlib's Convex.helly_theorem_set to finrank ℝ ℝ² = 2 — every finite family of ≥3 planar convex sets whose 3-element subfamilies each intersect has a common point (classical planar Helly number d+1=3)",
+      "collinear_three_root / onLine_root_collinear / isKCollinear_root_collinear (0-axiom): bridge the entry's three bespoke collinearity predicates (three-point Collinear p q r, geometric OnLine/Line, IsKCollinear) to Mathlib's canonical Collinear ℝ via collinear_iff_exists_forall_eq_smul_vadd — closing the implicit faithfulness gap that the file-local notions agree with the standard vectorSpan-rank-≤-1 definition",
+      "erdos1090_construction_root_collinear (0-axiom): the faithful form of the affirmative answer — restates the main construction so its k monochromatic points are Collinear ℝ in Mathlib's standard sense, confirming Erdős #1090 holds for the canonical meaning of \"collinear\", not merely the bespoke IsKCollinear"
     ],
     "axiomCount": 0,
-    "lineCount": 850,
+    "lineCount": 926,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 20,
+    "theoremCount": 24,
     "definitionCount": 18
   },
   "overview": {
@@ -109,9 +111,9 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 850,
+    "lineCount": 926,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 24,
     "definitionCount": 18,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #1090 (monochromatic collinear points) is already fully solved in the gallery (0 axiom / 0 sorry). This session closes an **implicit faithfulness gap**: the entry expressed collinearity through *three bespoke predicates* — the three-point `Collinear p q r`, the geometric `OnLine`/`Line`, and `IsKCollinear` — but **never connected any of them to Mathlib's canonical `Collinear ℝ`** (`vectorSpan` rank ≤ 1). A reader had to trust that the file-local notions agree with the standard mathematical one.

Four new theorems discharge that trust:

- `collinear_three_root : Collinear p q r → _root_.Collinear ℝ {p, q, r}` (base `p`, direction `q - p`)
- `onLine_root_collinear : (∀ p ∈ S, OnLine l p) → _root_.Collinear ℝ S` (base `l.point`, direction `l.direction`)
- `isKCollinear_root_collinear : IsKCollinear S k → _root_.Collinear ℝ (↑S)`
- **Capstone** `erdos1090_construction_root_collinear (k) (hk : k ≥ 3)`: restates the main construction so its `k` monochromatic points are `Collinear ℝ` in Mathlib's **standard** sense — confirming Erdős #1090 is affirmed for the canonical meaning of "collinear", not merely for the file-local `IsKCollinear`.

Shared engine: Mathlib's `collinear_iff_exists_forall_eq_smul_vadd` — both custom notions are literally in the `∃ p₀ v, ∀ p ∈ s, ∃ r, p = r • v +ᵥ p₀` shape.

## Counts
- File `Erdos1090Problem.lean`: 850 → 926 lines, 20 → 24 theorems (18 defs unchanged)
- **0 axioms, 0 sorries** added. `_root_.Collinear` prefix required (file-local `Collinear` shadows Mathlib's inside the namespace).

## Build status — ⚠️ UNVERIFIED (infra down)
Docker build infra is currently failing:
- Full-file elaboration reached `[2433/2433] Building Proofs.Erdos1090Problem` with **zero type-error diagnostics across 3 runs**, then **SIGBUS exit-135 at the olean-write stage** (fleet memory pressure).
- A 4th minimal-isolation build hit **exit-125 `containerd metadata.db: input/output error`** (Docker daemon corruption).
- Host has no locally-built oleans, so `lake env lean` is unavailable.

Elaboration-clean but **not olean-sealed**. The proofs use only standard Mathlib affine-collinearity API and elementary rewriting (`vadd_eq_add`, `abel`, `add_comm`); a re-build once infra recovers should seal them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)