### PR TITLE
Enrich Buffon convex 0-or-2 dichotomy (buffons-needle-oq-01-oq-04-oq-01): cover header

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-04-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-buffon-oq040101-header",
+    "proofId": "buffons-needle-oq-01-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "context",
+    "title": "Building the Missing Convex 0-or-2 Dichotomy Bearer",
+    "content": "The header frames the open question resolved here. The parent BuffonsNeedleOQ01OQ04 (Buffon's coin) *defined* the number of grid lines cutting a convex body as half the boundary-crossing count, flagging that this factor-of-two was encoded definitionally because Mathlib v4.26.0 has no convex line-intersection API. This file builds exactly that missing bearer: for a genuine line ℓ(t) = p + t•v (direction v ≠ 0) in an arbitrary real normed space and a compact convex body K, it proves the 0-or-2 dichotomy as a theorem of pure convex geometry — no analytic Buffon machinery. The chain: lineParams_convex (the line meets K in a convex parameter subset — an interval, the 'no gaps' content), lineParams_eq_Icc (for compact convex K it is a closed segment Icc a b), line_Ioo_mem_interior (interior parameters map into the topological interior), and the headline line_through_interior_meets_frontier_in_two / line_through_interior_frontier_ncard_two (a line through the interior meets ∂K in exactly two points {ℓa, ℓb}, so ncard = 2). The '0' half is the contrapositive: a line meeting only the boundary is a supporting line and may share a flat edge, so the clean count 2 requires — and characterizes — an interior crossing, matching Buffon's coin where a grid line 'cuts' precisely when it passes through the interior. Fully verified, 0 axioms, 0 sorries.",
+    "mathContext": "For a line $\\ell$ through the interior of a compact convex $K$: $\\{t : \\ell(t)\\in\\partial K\\} = \\{a,b\\}$ with $a<b$, so $\\#(\\ell\\cap\\partial K)=2$ — the convex 0-or-2 dichotomy underlying the Cauchy–Crofton / Buffon-coin perimeter formula.",
+    "significance": "context",
+    "relatedConcepts": ["convex bodies", "supporting vs cutting lines", "Cauchy–Crofton formula", "Buffon's coin", "frontier / boundary of a convex set"],
+    "prerequisites": ["convex sets and intervals", "compactness in a normed space", "topological interior and frontier"]
+  },
+  {
     "id": "ann-buffon-oq040101-setup",
     "proofId": "buffons-needle-oq-01-oq-04-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `buffons-needle-oq-01-oq-04-oq-01`.

**Gap addressed:** annotation coverage started at line 57, leaving the substantial convex-geometry docstring header (lines 1–56) uncovered.

**Added:** a `context` annotation covering lines 1–56 — *Building the Missing Convex 0-or-2 Dichotomy Bearer* — framing the open question (the parent encoded the factor-of-two definitionally because Mathlib had no convex line-intersection API), the line/compact-convex-body setup, the convexity chain (`lineParams_convex` → `lineParams_eq_Icc` → `line_Ioo_mem_interior` → `line_through_interior_meets_frontier_in_two`), and the 0-half contrapositive (supporting lines).

Annotation count 4 → 5, header coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).