### PR TITLE
Seeker: add 15 research problems across diverse domains

### DIFF
--- a/research/problems/beta-central-binomial-asymptotic-oq-01/knowledge.md
+++ b/research/problems/beta-central-binomial-asymptotic-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: beta-central-binomial-asymptotic-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/beta-central-binomial-asymptotic-oq-01/literature/README.md
+++ b/research/problems/beta-central-binomial-asymptotic-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for beta-central-binomial-asymptotic-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/beta-central-binomial-asymptotic-oq-01/problem.md
+++ b/research/problems/beta-central-binomial-asymptotic-oq-01/problem.md
@@ -1,0 +1,119 @@
+# Problem: Effective Two-Sided Rate for the Diagonal Euler Beta Value
+
+**Slug**: beta-central-binomial-asymptotic-oq-01
+**Created**: 2026-07-09T15:40:16-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\exists\, c_1, c_2 > 0,\ \forall n \ge 1:\quad c_1 \cdot \frac{\sqrt{\pi n}}{(2n+1)\,4^{n}} \ \le\ B(n+1, n+1) \ \le\ c_2 \cdot \frac{\sqrt{\pi n}}{(2n+1)\,4^{n}},
+$$
+
+where $B(n+1,n+1) = \mathrm{betaDiag}(n) = 1/((2n+1)\,\binom{2n}{n})$ is the diagonal Euler Beta value, and the constants $c_1, c_2$ are explicit rational or elementary closed forms rather than existential black boxes.
+
+### Plain Language
+
+The parent entry proves only that the diagonal Beta value $B(n+1,n+1)$ is *asymptotically equivalent* to $\sqrt{\pi n}/((2n+1)4^{n})$ — the ratio tends to $1$ as $n \to \infty$, but this says nothing about how close the two sides are for any particular finite $n$. This problem asks to strengthen that bare limit into an honest, computable inequality: nail down concrete numerical constants $c_1$ and $c_2$ so that the leading term, scaled by those constants, sandwiches the true Beta value for *every* $n \ge 1$, not merely in the limit.
+
+### Why This Matters
+
+An asymptotic equivalence is qualitative; a two-sided effective bound is quantitative and usable. With explicit constants one can certify the Beta value's size at concrete $n$, feed it into estimates for Catalan-number growth, random-walk return probabilities, and de Moivre–Laplace central-limit error terms, and obtain machine-checkable numerics rather than a limit statement. It also demonstrates that Mathlib's effective Stirling apparatus (the genuine lower bound $\sqrt\pi \le \mathrm{stirlingSeq}\,n$ plus antitonicity) is strong enough to convert a pure `IsEquivalent` into a rate — a reusable pattern for other Stirling-derived asymptotics in the gallery.
+
+## Known Results
+
+### What's Already Proven
+
+- `betaDiag_isEquivalent` (parent entry `beta-central-binomial-asymptotic`) — proves the bare equivalence $B(n+1,n+1) \sim \sqrt{\pi n}/((2n+1)4^{n})$, 0 axioms / 0 sorries.
+- `beta-diag-effective-rate` (sibling gallery entry) — **answers this question affirmatively**: it factors $B(n+1,n+1)$ as its leading term times a correction $\mathrm{ratioR}\,n = \mathrm{stirlingSeq}(n)^2/(\sqrt\pi\,\mathrm{stirlingSeq}(2n))$ and pins it to $\sqrt{2\pi}/e \le \mathrm{ratioR}\,n \le e^2/(2\pi)$, giving constants $c_1 \approx 0.922$ and $c_2 \approx 1.176$ valid for all $n \ge 1$ (`ratioR_ge`, `ratioR_le`), 0 axioms / 0 sorries.
+- Mathlib `Stirling.stirlingSeq` — supplies $\mathrm{stirlingSeq}\,n \to \sqrt\pi$, the lower bound $\sqrt\pi \le \mathrm{stirlingSeq}\,n$, and antitonicity `stirlingSeq'_antitone`, the raw material for the envelope.
+
+### What's Still Open
+
+- Sharpening the envelope $[\sqrt{2\pi}/e,\, e^2/(2\pi)] \approx [0.922, 1.176]$ toward the tight $1 + O(1/n)$ correction (pursued separately in `beta-central-binomial-explicit-rate`).
+- Whether the same effective-envelope method extends to off-diagonal Beta values $B(an+1, bn+1)$ with $a \ne b$.
+
+### Our Goal
+
+Record and cross-reference the affirmative resolution supplied by `beta-diag-effective-rate`: an explicit two-sided rate for $\mathrm{betaDiag}(n)$ with elementary constants $\sqrt{2\pi}/e$ and $e^2/(2\pi)$, valid for all $n \ge 1$, obtained purely from Mathlib's `stirlingSeq` bounds with no new axioms.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| beta-central-binomial-asymptotic | Parent entry; states the bare equivalence this problem upgrades | Wallis ratio identity, `IsEquivalent` congruence transport |
+| beta-diag-effective-rate | Sibling that resolves this question with explicit constants | `stirlingSeq` lower bound + antitonicity, exact algebraic factorization |
+| beta-central-binomial-explicit-rate | Sharpens the envelope to a $1+O(1/n)$ Landau form | Telescoped Stirling tail bound |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Factor $B(n+1,n+1)$ as leading-term $\times$ correction and bound the correction.
+   - Why it might work: this is exactly what `beta-diag-effective-rate` does — write $\mathrm{ratioR}\,n = \mathrm{stirlingSeq}(n)^2/(\sqrt\pi\,\mathrm{stirlingSeq}(2n))$ via an exact identity, then apply the two Mathlib bounds.
+   - Risk: the exact identity $\binom{2n}{n}\sqrt n\,\mathrm{stirlingSeq}(n)^2 = \mathrm{stirlingSeq}(2n)\,4^n$ must be manipulated carefully to avoid division-by-zero side goals.
+
+2. **Approach B**: Robbins-style direct $e^{1/(12n+1)} < n!/(\sqrt{2\pi n}(n/e)^n) < e^{1/(12n)}$ bounds.
+   - Why it might work: gives sharper, monotone-in-$n$ constants closer to $1$.
+   - Risk: Mathlib does not package the Robbins refinement, so it would require proving new Stirling tail estimates from scratch.
+
+### Key Difficulties
+
+- Turning a limit `IsEquivalent` statement into a per-$n$ inequality requires an *exact* algebraic bridge, not just an asymptotic one.
+- Obtaining a *two-sided* bound needs both a genuine lower bound and an upper bound for `stirlingSeq`; the upper direction comes only via antitonicity evaluated at $n=1$.
+
+### What Would a Proof Need?
+
+- Key lemma 1: exact identity relating $\binom{2n}{n}$ to `stirlingSeq(n)` and `stirlingSeq(2n)` (the $4^n$ collapse).
+- Key lemma 2: two-sided control $\sqrt{2\pi}/e \le \mathrm{ratioR}\,n \le e^2/(2\pi)$ from `stirlingSeq` monotonicity.
+- Technical requirements: positivity of `stirlingSeq`, $\binom{2n}{n} > 0$, and careful `field_simp`/`nlinarith` bookkeeping.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The sibling entry `beta-diag-effective-rate` already completes this with 0 axioms and 0 sorries, so the mathematical path is fully validated.
+- All required Stirling bounds (`stirlingSeq` lower bound, `stirlingSeq'_antitone`) already exist in Mathlib.
+- The only real labor is the exact algebraic factorization and the arithmetic of the constant-factor envelope.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: days (already realized in the sibling entry)
+- If hard: not applicable — resolved
+
+## References
+
+### Papers
+- H. Robbins, "A Remark on Stirling's Formula", Amer. Math. Monthly 62 (1955) — sharp two-sided factorial bounds $e^{1/(12n+1)} < n!/(\sqrt{2\pi n}(n/e)^n) < e^{1/(12n)}$.
+- J. Wallis, "Arithmetica Infinitorum", 1656 — origin of the $\pi/2$ product underlying the $\sqrt{\pi n}$ rate.
+
+### Online Resources
+- https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/SpecialFunctions/Stirling.html — Mathlib's Stirling sequence and its convergence.
+
+### Mathlib
+- `Mathlib.Analysis.SpecialFunctions.Stirling` — provides `Stirling.stirlingSeq`, its limit $\sqrt\pi$, the lower bound, and antitonicity used to build the envelope.
+- `Mathlib.Analysis.SpecialFunctions.Gamma.Beta` — the complex Euler Beta integral that `betaDiag` is identified with.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - asymptotics
+  - beta-function
+  - stirling
+  - wallis
+  - central-binomial
+  - research
+related_proofs:
+  - beta-central-binomial-asymptotic
+  - beta-diag-effective-rate
+  - beta-central-binomial-explicit-rate
+difficulty: medium
+source: proof-suggestion
+created: 2026-07-09T15:40:16-07:00
+```

--- a/research/problems/beta-central-binomial-asymptotic-oq-01/state.md
+++ b/research/problems/beta-central-binomial-asymptotic-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: beta-central-binomial-asymptotic-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:16-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1-wip-01-oq-04/knowledge.md
+++ b/research/problems/erdos-1-wip-01-oq-04/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1-wip-01-oq-04
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1-wip-01-oq-04/literature/README.md
+++ b/research/problems/erdos-1-wip-01-oq-04/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1-wip-01-oq-04
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1-wip-01-oq-04/problem.md
+++ b/research/problems/erdos-1-wip-01-oq-04/problem.md
@@ -1,0 +1,127 @@
+# Problem: Characterizing Non-Superincreasing DSS Sets
+
+**Slug**: erdos-1-wip-01-oq-04
+**Created**: 2026-07-09T00:00:00Z
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{Characterize } \mathcal{F}_{\mathrm{DSS}} = \{A \subset \mathbb{N} : \forall S, T \subseteq A,\ \textstyle\sum_{s \in S} s = \sum_{t \in T} t \Rightarrow S = T\}
+$$
+
+$$
+\text{via intrinsic combinatorial predicates } P(A) \text{ with } P(A) \iff A \in \mathcal{F}_{\mathrm{DSS}}, \quad P \text{ not the superincreasing condition } \big(a_k > \textstyle\sum_{j<k} a_j\big).
+$$
+
+### Plain Language
+
+A set $A$ of positive integers has *distinct subset sums* (DSS) when no two different subsets add up to the same total. There is a clean sufficient condition: if the elements, sorted increasingly, are *superincreasing* (each element exceeds the sum of all smaller ones, as with $1, 2, 4, 8, \ldots$), then $A$ automatically has DSS. But the converse fails: sets like $\{6, 9, 11, 12, 13\}$ have DSS yet are *not* superincreasing. This problem asks whether the structural theory built for superincreasing DSS sets can be extended to describe *all* DSS sets — ideally through combinatorial properties (a growth pattern, a counting invariant, a forbidden configuration) that certify DSS membership without simply re-checking the $2^n$ subset sums by definition.
+
+### Why This Matters
+
+The Erdős distinct-subset-sum problem (\$500, posed c. 1931) asks how small the largest element of an $n$-element DSS set can be, conjecturally $\max(A) \geq c \cdot 2^n$. The best constructions (Conway–Guy, $\max \approx 0.22 \cdot 2^n$) are superincreasing, but so are the far-from-optimal powers of 2 ($\max = 2^{n-1}$) — superincreasing-ness alone does not explain optimality. Because optimal DSS sets need not be superincreasing (indeed for $n \geq 4$ the extremal max is below $2^{n-1}$), any route to the Erdős conjecture that leans on the superincreasing lemma is fundamentally limited. A genuine characterization of the whole family $\mathcal{F}_{\mathrm{DSS}}$ — or even a strictly larger, still-verifiable sufficient class — would give researchers a handle on non-superincreasing extremal sets and a cleaner target for formalization than raw subset-sum injectivity.
+
+## Known Results
+
+### What's Already Proven
+
+- `dss_superincreasing_extend` — superincreasing extension is sufficient for DSS; formalized in `Proofs/Erdos1Wip01.lean` (erdos-1-wip-01, verified, 0 sorries/0 axioms).
+- `dss_elements_pos`, `not_dss_of_mem_zero` — every DSS set consists of positive integers, since $\emptyset$ and $\{0\}$ collide (erdos-1-wip-01).
+- `dss_subset`, `dss_singleton` — DSS is hereditary (downward closed) and every singleton qualifies, so $\mathcal{F}_{\mathrm{DSS}}$ is an independence system (erdos-1-wip-01).
+- `dss_sum_lower_bound`, `dss_sum_ge_pow_sub_one` — pigeonhole gives $2^n \le \mathrm{sum}(A) + 1$, i.e. $\mathrm{sum}(A) \ge 2^n - 1$ (erdos-1-wip-01).
+- Counting bound $\max(A) \ge (2^n - 1)/n$ and the Dubroff–Fox–Xu entropy bound $\max(A) \ge \sqrt{2/\pi}\,2^n/\sqrt{n}$ (erdos-1 gallery cluster, OQ01/OQ02).
+
+### What's Still Open
+
+- Whether an intrinsic combinatorial predicate (not subset-sum injectivity restated) can characterize $\mathcal{F}_{\mathrm{DSS}}$ exactly.
+- Whether there is a sufficient condition strictly weaker than superincreasing that still certifies DSS and captures known non-superincreasing examples such as $\{6, 9, 11, 12, 13\}$.
+- Whether the independence system $\mathcal{F}_{\mathrm{DSS}}$ has additional axioms (beyond hereditary + positivity + the sum bound) distinguishing it structurally.
+- Whether such a characterization would sharpen the max-element bound toward the Erdős constant $c$.
+
+### Our Goal
+
+Begin an OBSERVE-phase investigation: catalogue small non-superincreasing DSS sets, formalize candidate intermediate sufficient conditions in Lean (e.g. a "bounded-deficit" relaxation of superincreasing), and prove or refute that a chosen relaxed condition still implies DSS. The near-term formal target is a Lean lemma of the form "if $A$ satisfies weaker condition $Q$ then $A$ has DSS," strictly generalizing `dss_superincreasing_extend`, together with a witnessed example showing $Q$ captures a non-superincreasing set.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1-wip-01 | Provides the superincreasing lemma, positivity, hereditary, and sum-bound results this problem extends | Finset subset-sum case analysis, induction, pigeonhole |
+| erdos-1 | States the Erdős conjecture and proves the counting bound the characterization aims to sharpen | Counting / pigeonhole on subset sums |
+| erdos-1-oq-02 | Entropy/Fourier lower bound giving the strongest current constraint on max element | Fourier analysis, entropy inequalities |
+| erdos-1-oq-03 | Defines `minDSSBound` via `Nat.find`; a characterization would make its values more computable | `Nat.find`, existence witnesses |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Bounded-deficit relaxation**: Replace "each $a_k$ exceeds the sum of predecessors" with "each $a_k$ exceeds the sum minus a controlled deficit," then prove DSS survives when deficits cannot align to a collision.
+   - Why it might work: known non-superincreasing DSS sets violate superincreasing by small margins; a quantified slack may still forbid subset-sum coincidences.
+   - Risk: the deficit bookkeeping may reduce back to checking injectivity, giving no genuinely new predicate.
+
+2. **Approach B — Forbidden-configuration / independence-system axioms**: Study $\mathcal{F}_{\mathrm{DSS}}$ as an independence system and search for a finite list of forbidden minors or an exchange-type axiom characterizing membership.
+   - Why it might work: hereditary families often admit forbidden-substructure characterizations (matroid/greedoid analogy).
+   - Risk: DSS independence systems are known not to be matroids (no exchange axiom), so a clean finite characterization may not exist.
+
+### Key Difficulties
+
+- Any candidate predicate must be provably equivalent to (or strictly imply) DSS without secretly re-encoding the $2^n$-subset-sum test.
+- Non-superincreasing DSS sets are irregular; enumerating and pattern-matching them (e.g. via OEIS A005318 extremal sets) may not reveal a uniform law.
+
+### What Would a Proof Need?
+
+- Key lemma 1: a relaxed sufficient condition $Q$ with `Q A → hasDistinctSubsetSums A`, generalizing `dss_superincreasing_extend`.
+- Key lemma 2: a concrete non-superincreasing witness (e.g. $\{6,9,11,12,13\}$) satisfying $Q$ but not the superincreasing predicate, verified in Lean.
+- Technical requirements: Finset sum manipulation, `decide`/`Finset.powerset` evaluation for small witnesses, and careful case analysis mirroring the existing 4-case extension proof.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The full characterization is likely as hard as the Erdős conjecture itself; partial relaxations are more realistic.
+- Similar hereditary-family characterizations (matroids, greedoids) exist but the DSS system lacks the exchange axiom, removing the standard toolkit.
+- Mathlib provides Finset, powerset, and sum infrastructure sufficient to state and check candidate conditions on small sets, but no ready-made DSS theory beyond what erdos-1-wip-01 built.
+
+**Estimated Effort**:
+- Exploration: several days to enumerate small non-superincreasing DSS sets and propose a candidate predicate.
+- If tractable: 1–3 weeks to formalize a strictly-weaker sufficient condition and a witness.
+- If hard: unknown (a full characterization is plausibly open-problem hard).
+
+## References
+
+### Papers
+- Erdős, P., "Problems in additive number theory," Proc. ICM Amsterdam, 1955 — original posing of the distinct-subset-sum question.
+- Conway, J. H.; Guy, R. K., "Solution of a problem of P. Erdős," Colloq. Math. 20 (1968), 307–309 — superincreasing sequence with $\max \approx 0.22009 \cdot 2^n$.
+- Dubroff, Q.; Fox, J.; Xu, M. W., "A note on the Erdős distinct subset sums problem," SIAM J. Discrete Math., 2021 — entropy lower bound $\max(A) \ge \sqrt{2/\pi}\,2^n/\sqrt{n}$.
+
+### Online Resources
+- https://oeis.org/A005318 — minimum largest element of an $n$-element DSS set (Conway–Guy sequence), listing extremal, often non-superincreasing, sets.
+- https://www.erdosproblems.com/1 — Erdős Problem #1 catalogue entry with status and known bounds.
+
+### Mathlib
+- `Mathlib.Data.Finset.Powerset` — powerset enumeration for evaluating subset sums on small witnesses.
+- `Mathlib.Algebra.BigOperators.Basic` — `Finset.sum` lemmas used throughout the DSS case analysis.
+- `Mathlib.Data.Nat.Log` / `Mathlib.Algebra.Order.Monoid` — ordering and geometric-sum utilities for growth-condition bookkeeping.
+
+## Metadata
+
+```yaml
+tags:
+  - additive-combinatorics
+  - subset-sums
+  - extremal-combinatorics
+  - structural-theory
+  - number-theory
+  - erdos
+related_proofs:
+  - erdos-1-wip-01
+  - erdos-1
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T00:00:00Z
+```

--- a/research/problems/erdos-1-wip-01-oq-04/state.md
+++ b/research/problems/erdos-1-wip-01-oq-04/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1-wip-01-oq-04
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:19-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1000-oq-04/knowledge.md
+++ b/research/problems/erdos-1000-oq-04/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1000-oq-04
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1000-oq-04/literature/README.md
+++ b/research/problems/erdos-1000-oq-04/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1000-oq-04
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1000-oq-04/problem.md
+++ b/research/problems/erdos-1000-oq-04/problem.md
@@ -1,0 +1,125 @@
+# Problem: Measure of Increasing Sequences with Vanishing Cesàro Average of the Generalized Totient
+
+**Slug**: erdos-1000-oq-04
+**Created**: 2026-07-09T15:40:19-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\mu\bigl(\{A = (n_1 < n_2 < \cdots) : \lim_{N\to\infty} \tfrac{1}{N}\textstyle\sum_{k=1}^{N} \tfrac{\varphi_A(k)}{n_k} = 0\}\bigr) = \; ?
+$$
+
+where $\varphi_A(k) = |\{1 \le m \le n_k : n_k/\gcd(m,n_k) \ne n_j \text{ for all } j < k\}|$ is the generalized totient, and $\mu$ is a suitable measure on the space of strictly increasing positive-integer sequences.
+
+### Plain Language
+
+Erdős Problem #1000 asks whether some strictly increasing integer sequence $A$ makes the Cesàro average of the "new denominator density" $\varphi_A(k)/n_k$ tend to zero. Haight answered yes: such sequences exist. This follow-up question asks a quantitative refinement: among *all* increasing sequences, how large is the collection of those exhibiting a vanishing average? We want to determine the measure of the set of vanishing-average sequences under a natural probability measure on sequence space, deciding whether the Haight phenomenon is exceptional (measure zero) or typical (positive, or even full, measure).
+
+### Why This Matters
+
+Haight's construction shows vanishing-average sequences *exist*, but existence alone does not reveal whether they are rare special constructions or a generic feature of increasing sequences. Measuring the set separates two very different pictures: if the measure is zero the vanishing average is a delicate, atypical phenomenon achievable only by carefully engineered highly composite sequences; if it is positive the phenomenon is robust and reflects generic behavior of the generalized totient. Answering this ties Erdős #1000 to metric number theory (à la the Khinchin-Groshev framework Cassels used) and to the general theme of how averaging tames the pointwise oscillation of arithmetic functions.
+
+## Known Results
+
+### What's Already Proven
+
+- Haight's resolution: there exists an increasing sequence $A$ with $\lim_N C_A(N) = 0$ — formalized as the axiom `haight_resolution` in `Proofs/Erdos1000Problem.lean`
+- Erdős' no-zero-limit theorem: the pointwise ratio $\varphi_A(k)/n_k$ never converges to $0$ for any $A$ — theorem `erdos_no_zero_limit` in `Proofs/Erdos1000Problem.lean`
+- Erdős' dichotomy: if $\liminf_k \varphi_A(k)/n_k = 0$ then $\limsup_k \varphi_A(k)/n_k = 1$ — axiom `erdos_dichotomy` in `Proofs/Erdos1000Problem.lean`
+- Structural lower bound: $\varphi_A(k) \ge \varphi(n_k)$ (Euler's totient), giving the density floor $\varphi_A(k)/n_k \ge \varphi(n_k)/n_k$ — theorem `phiA_ge_totient` in `Proofs/Erdos1000Problem.lean`
+- Pointwise/Cesàro separation: there is an $A$ with vanishing average but non-vanishing pointwise density — theorem `pointwise_cesaro_gap` in `Proofs/Erdos1000Problem.lean`
+
+### What's Still Open
+
+- Which measure $\mu$ on the space of increasing sequences makes the question well-posed (e.g. a product/renewal measure on gaps, or a Cantor-style coding measure)
+- Whether the set of vanishing-average sequences has measure $0$, measure $1$, or an intermediate positive value under that $\mu$
+- Whether the answer depends on the growth regime imposed on the gaps $n_{k+1} - n_k$
+
+### Our Goal
+
+Formalize the measure-theoretic setup for the space of strictly increasing positive-integer sequences and state the measurability of the vanishing-average event $\{A : \lim_N C_A(N) = 0\}$, then establish a first quantitative bound (for instance, that under a fast-growth product measure the event is measure zero, mirroring the `not_densityToZero_of_fast_growth` growth-floor results). Full determination of the measure is a moonshot; the tractable milestone is a rigorous framework plus one measure-zero or positive-measure lemma for a concrete measure.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1000 | Parent problem: defines $\varphi_A$, the Cesàro average, Haight's resolution, and the density floor this question quantifies | Generalized totient, Cesàro means, Euler product, highly composite numbers, filter limits |
+| erdos-1003 | Studies Euler's totient $\varphi(n)$, which provides the density floor $\varphi_A(k) \ge \varphi(n_k)$ | Totient identities, multiplicative function estimates |
+| erdos-1004 | Distribution of totient values, the baseline arithmetic function underlying $\varphi_A$ | Totient value distribution, counting arguments |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Product/renewal measure on gaps.
+   - Why it might work: modeling the gaps $g_k = n_{k+1}-n_k$ as i.i.d. (or Markov) random variables turns $C_A(N)$ into an ergodic average, so a strong law or Birkhoff-type argument could pin down the measure of the vanishing event.
+   - Risk: the vanishing average requires highly composite $n_k$, which is a strongly correlated arithmetic condition that i.i.d. gap models may assign measure zero to trivially, making the "interesting" measure hard to choose.
+
+2. **Approach B**: Growth-floor / Borel-Cantelli route.
+   - Why it might work: the formalized results `not_densityToZero_of_fast_growth` and `densityRatio_gt_half_of_fast_growth` show fast-growing sequences keep the density above $1/2$; a Borel-Cantelli argument could show that under many measures the sequence is "fast" almost surely, forcing the vanishing event to be null.
+   - Risk: establishes only an upper bound (measure zero) for specific measures and says nothing about measures concentrated on slowly growing / highly composite sequences.
+
+### Key Difficulties
+
+- Choosing a canonical, defensible measure $\mu$ on an inherently discrete but infinite-dimensional sequence space; the answer is meaningless without fixing $\mu$
+- The vanishing-average condition mixes an analytic tail limit with the delicate arithmetic (highly composite structure) that Haight exploited, so measurability and estimation require both metric and multiplicative tools
+- Mathlib has strong `MeasureTheory` and product-measure infrastructure but limited support for measures on spaces of monotone integer sequences, so encoding the space is itself work
+
+### What Would a Proof Need?
+
+- Key lemma 1: a measurable coding of strictly increasing sequences (e.g. via the gap sequence in $\mathbb{N}_{\ge 1}^{\mathbb{N}}$ with a product $\sigma$-algebra) and measurability of $A \mapsto C_A(N)$ for each $N$
+- Key lemma 2: measurability of the event $\{A : C_A(N) \to 0\}$ as a countable combination of the $C_A(N)$ (via `Filter.Tendsto` characterizations), plus a $0$-$1$ style law under a product measure
+- Technical requirements: `MeasureTheory.Measure`, `MeasurePreserving`/ergodic tooling, `Filter.Tendsto`, and the already-formalized growth-floor lemmas from `Proofs/Erdos1000Problem.lean` to seed the first bound
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The full measure is a genuinely open, likely moonshot-level metric number theory question with no known answer in the literature
+- Setting up a measurable framework and proving measurability of the vanishing event is tractable and mirrors standard product-measure constructions already in Mathlib
+- Mathlib's `MeasureTheory` (product measures, measurability of limits, Borel-Cantelli, ergodic-theory lemmas) plus the existing `Erdos1000Problem.lean` growth-floor theorems provide the tools for a first measure-zero bound under a concrete measure
+
+**Estimated Effort**:
+- Exploration: 3-5 days
+- If tractable: 2-4 weeks for the measurable framework plus one quantitative bound
+- If hard: unknown (full determination of the measure is open)
+
+## References
+
+### Papers
+- Haight, J.A., "A generalisation of a problem of Cassels and Erdős" (relevant work resolving #1000) — establishes existence of vanishing-average sequences, the phenomenon whose measure is sought
+- Cassels, J.W.S., "An Introduction to Diophantine Approximation", 1957 — origin of the generalized totient and its metric-approximation context
+- Erdős, P., work of 1964 on the no-zero-limit and dichotomy — the pointwise constraints that shape which sequences can have vanishing average
+
+### Online Resources
+- https://erdosproblems.com/1000 — canonical statement and status of Erdős Problem #1000
+- https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000Problem.lean — the formalized parent proof with the density-floor and growth lemmas
+
+### Mathlib
+- `Mathlib.MeasureTheory.Measure.Basic` and product-measure modules — provide the measure-space and product-measure infrastructure for coding sequence space
+- `Mathlib.MeasureTheory.Constructions.BorelSpace.Basic` — measurability of limits of measurable functions, needed for the vanishing-average event
+- `Mathlib.Dynamics.Ergodic.Ergodic` — ergodic/law-of-large-numbers tooling for evaluating Cesàro averages under an invariant measure
+- `Mathlib.Analysis.Nat.Totient` — Euler's totient and its Euler product, underlying the density floor $\varphi_A(k) \ge \varphi(n_k)$
+
+## Metadata
+
+```yaml
+tags:
+  - erdos
+  - number-theory
+  - diophantine-approximation
+  - totient-function
+  - cesaro-averages
+related_proofs:
+  - erdos-1000
+  - erdos-1003
+  - erdos-1004
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:19-07:00
+```

--- a/research/problems/erdos-1000-oq-04/state.md
+++ b/research/problems/erdos-1000-oq-04/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1000-oq-04
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:19-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1007-oq-03/knowledge.md
+++ b/research/problems/erdos-1007-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1007-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1007-oq-03/literature/README.md
+++ b/research/problems/erdos-1007-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1007-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1007-oq-03/problem.md
+++ b/research/problems/erdos-1007-oq-03/problem.md
@@ -1,0 +1,119 @@
+# Problem: Computational Complexity of Determining Graph Dimension
+
+**Slug**: erdos-1007-oq-03
+**Created**: 2026-07-09T15:40:16-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{Is } \mathrm{DIM}(G, d) := \bigl[\, \dim(G) \le d \,\bigr] \in \mathsf{NP\text{-}hard}\ ?
+\qquad \dim(G) = \min\{\, d : \exists f\colon V \to \mathbb{R}^d,\ \|f(u)-f(v)\|_2 = 1\ \forall\, uv \in E \,\}
+$$
+
+### Plain Language
+
+The dimension of a graph $G$ is the smallest Euclidean dimension $d$ in which $G$ can be drawn so that every edge is exactly a unit-length segment. This problem asks whether deciding "is $\dim(G) \le d$?" (equivalently, computing $\dim(G)$) is computationally intractable — specifically whether it is NP-hard. Deciding embeddability amounts to asking whether a system of quadratic equations $\|f(u)-f(v)\|^2 = 1$, one per edge, has a real solution, which places the problem in the realm of the existential theory of the reals.
+
+### Why This Matters
+
+Erdős, Harary, and Tutte introduced graph dimension in 1965, and the exact extremal values (e.g. minimum edges for dimension 4 being 9, uniquely $K_{3,3}$) were settled only recently by House (2013) and Chaffee–Noble (2016). Those results describe *what* the extremal graphs look like, but say nothing about *how hard it is to compute* the dimension of an arbitrary input graph. Establishing NP-hardness (or worse, $\exists\mathbb{R}$-hardness) would explain why closed-form extremal answers are so difficult to obtain in general, and would connect graph dimension to the well-studied complexity of geometric realizability problems such as unit-distance representability and graph rigidity.
+
+## Known Results
+
+### What's Already Proven
+
+- $\dim(K_{n+1}) = n$ via regular simplex embeddings, and the extremal values $e(1)=1, e(2)=3, e(3)=6, e(4)=9, e(5)=15$ — Erdős–Harary–Tutte (1965), House (2013), Chaffee–Noble (2016).
+- The related decision problem "unit-distance graph in $\mathbb{R}^2$" and many geometric realizability questions are $\exists\mathbb{R}$-complete (hence NP-hard) — Schaefer, *Complexity of Some Geometric and Topological Problems* (2009).
+- Graph rigidity and Euclidean distance matrix completion problems, close cousins of dimension computation, have known hardness results (Saxe, 1979, on embeddability of weighted graphs in $\mathbb{R}^d$).
+
+### What's Still Open
+
+- Whether the specific decision problem $\dim(G) \le d$ is NP-hard, and whether it lies in NP at all (membership is unclear because certificates may require irrational, high-precision coordinates).
+- The exact complexity class: is it NP-complete, $\exists\mathbb{R}$-complete, or something between, and does hardness hold for fixed $d$ versus $d$ part of the input?
+
+### Our Goal
+
+Formalize in Lean 4 the framework needed to state the NP-hardness question precisely: a decision-problem encoding of graph dimension, the reduction target (feasibility of the quadratic unit-distance system), and a skeleton reduction from a known NP-hard problem. The concrete deliverable is a rigorous statement of `graphDimensionDecision` and its relationship to real-solvability of the edge-distance equation system, leaving the hardness reduction itself as the open theorem.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1007 | Parent problem: defines graph dimension and unit-distance embeddings; this OQ studies the complexity of computing that dimension | Unit-distance embedding structure, `graphDimension` via `Nat.find`, axiomatized extremal bounds |
+| erdos-135 | Both connect graph combinatorics to Euclidean distance geometry; distinct-distance counting shares the algebraic-distance-system flavor | Distance geometry, extremal counting |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Reduce from a known NP-hard geometric problem (e.g. unit-distance graph recognition or Euclidean embeddability of a weighted graph).
+   - Why it might work: Schaefer's $\exists\mathbb{R}$-completeness results already handle unit-distance realizability; adapting the gadget graphs to force a *specific* dimension could transfer hardness.
+   - Risk: Forcing an exact dimension (not just $\le d$ realizability) requires rigidity gadgets that pin the embedding, which are delicate to construct and formalize.
+
+2. **Approach B**: Cast the decision problem inside the existential theory of the reals and argue $\exists\mathbb{R}$-hardness directly.
+   - Why it might work: The edge equations $\|f(u)-f(v)\|^2 = 1$ are literally polynomial constraints, so the problem is natively an $\exists\mathbb{R}$ instance.
+   - Risk: Establishing hardness (not just membership) still needs a reduction; and $\exists\mathbb{R}$ machinery is not formalized in Mathlib.
+
+### Key Difficulties
+
+- NP membership is genuinely unclear: an optimal embedding may require coordinates that are algebraic numbers of high degree, so a polynomial-size certificate is not obvious.
+- Distinguishing "embeddable in $\le d$" from "dimension exactly $d$" requires ruling out lower-dimensional embeddings, a universally quantified (co-NP-flavored) condition.
+
+### What Would a Proof Need?
+
+- Key lemma 1: A faithful encoding of `graphDimensionDecision (G, d)` as feasibility of a finite polynomial system over $\mathbb{R}$.
+- Key lemma 2: A gadget construction that forces any unit-distance embedding of a target graph to realize a prescribed dimension.
+- Technical requirements: A Lean model of decision problems / reductions, plus a formal statement of an $\exists\mathbb{R}$- or NP-complete source problem to reduce from.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- Full NP-hardness (or $\exists\mathbb{R}$-hardness) proofs for geometric realizability are research-level and rely on intricate gadget constructions not present in Mathlib.
+- Similar problems (unit-distance recognition, weighted-graph embeddability) are known hard, giving a plausible route, but the reductions are nontrivial to formalize.
+- Mathlib has real-analysis and Euclidean-space infrastructure but no complexity-theory (NP, reductions, $\exists\mathbb{R}$) framework, so much scaffolding must be built.
+
+**Estimated Effort**:
+- Exploration: 1–2 days to survey complexity encodings and rigidity gadgets.
+- If tractable: 2–4 weeks to formalize the decision-problem framework and a skeleton reduction.
+- If hard: unknown — a complete formal NP-hardness proof may be a multi-month effort.
+
+## References
+
+### Papers
+- Erdős, P.; Harary, F.; Tutte, W. T., "On the dimension of a graph", *Mathematika* 12 (1965) — foundational definition of graph dimension.
+- House, R. L., "A 4-dimensional graph has at least 9 edges", *Discrete Mathematics* 313 (2013) — extremal result for dimension 4.
+- Schaefer, M., "Complexity of Some Geometric and Topological Problems", *Graph Drawing* (2009) — $\exists\mathbb{R}$-completeness of geometric realizability, including unit-distance representations.
+- Saxe, J. B., "Embeddability of weighted graphs in $k$-space is strongly NP-hard", *Proc. Allerton Conf.* (1979) — hardness of Euclidean embeddability of weighted graphs.
+
+### Online Resources
+- https://erdosproblems.com/1007 — Erdős Problem #1007 statement and status.
+- https://en.wikipedia.org/wiki/Existential_theory_of_the_reals — background on the $\exists\mathbb{R}$ complexity class relevant to distance-system feasibility.
+
+### Mathlib
+- `Mathlib.Analysis.InnerProductSpace.EuclideanDist` — Euclidean distance in $\mathbb{R}^n$, needed to state unit-distance constraints.
+- `Mathlib.Combinatorics.SimpleGraph.Basic` — simple graph structure for encoding input instances.
+
+## Metadata
+
+```yaml
+tags:
+  - erdos
+  - graph-theory
+  - geometry
+  - dimension
+  - unit-distance
+  - embedding
+  - complexity
+related_proofs:
+  - erdos-1007
+  - erdos-135
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:16-07:00
+```

--- a/research/problems/erdos-1007-oq-03/state.md
+++ b/research/problems/erdos-1007-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1007-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:16-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1011-oq-02/knowledge.md
+++ b/research/problems/erdos-1011-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1011-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1011-oq-02/literature/README.md
+++ b/research/problems/erdos-1011-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1011-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1011-oq-02/problem.md
+++ b/research/problems/erdos-1011-oq-02/problem.md
@@ -1,0 +1,129 @@
+# Problem: Is the leading constant c = 1 in g(r) ~ c·r² log r?
+
+**Slug**: erdos-1011-oq-02
+**Created**: 2026-07-09T15:40:17-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{Determine whether } g(r) = (1 + o(1))\, r^2 \log r, \text{ i.e. whether the constant } c \text{ with } g(r) \sim c\, r^2 \log r \text{ equals } 1.
+$$
+
+### Plain Language
+
+In Erdős Problem #1011 one studies f_r(n), the least edge count forcing a triangle in an
+n-vertex graph of chromatic number at least r. Simonovits showed that asymptotically
+f_r(n) = n²/4 - g(r)·n/2 + O(1), where g(r) measures how many vertices must be deleted
+from a triangle-free graph of chromatic number r to make it bipartite. The current bounds
+are (1/2 - o(1))·r² log r ≤ g(r) ≤ (2 + o(1))·r² log r, leaving a factor-of-four gap in the
+leading constant c of g(r) ~ c·r² log r. This problem asks whether the "natural" guess
+c = 1 is correct — pinning the constant exactly halfway between the two known bounds.
+
+### Why This Matters
+
+Fixing c would close the last quantitative gap in a sixty-year-old extremal program linking
+edge count, chromatic number, and triangle existence. The value of c is directly tied to the
+asymptotics of the off-diagonal Ramsey number R(3,k), so a proof that c = 1 (or a refutation)
+would sharpen our understanding of both extremal graph theory and Ramsey theory simultaneously.
+
+## Known Results
+
+### What's Already Proven
+
+- Simonovits asymptotic f_r(n) = n²/4 - g(r)·n/2 + O(1) — Simonovits, "A method for solving extremal problems in graph theory" (1966), formalized as `simonovits_asymptotic` in `Proofs/Erdos1011Problem.lean`
+- Lower bound g(r) ≥ (1/2 - o(1))·r² log r — Davies & Illingworth (2022), axiom `davies_illingworth_lower`
+- Upper bound g(r) ≤ (2 + o(1))·r² log r — Hefetz, Horn, King & Pfender (2025), axiom `hhkp_upper`
+- Exact small cases f_2, f_3, f_4 (Turán; Erdős-Gallai; Ren-Wang-Wang-Yang) — axioms `turan_theorem`, `erdos_gallai_theorem`
+
+### What's Still Open
+
+- Whether the leading constant c in g(r) ~ c·r² log r equals 1
+- Whether the lower bound 1/2 or the upper bound 2 (or some value between) is the truth
+- Any matching pair of bounds that would determine c exactly
+
+### Our Goal
+
+We do not attempt to resolve the open constant. Instead we aim to formalize the statement
+"c = 1" as a precise conjecture in Lean 4, together with the surrounding bounds g(r) ≥ (1/2 -
+o(1))·r² log r and g(r) ≤ (2 + o(1))·r² log r, so that the claim c = 1 is expressible and its
+consistency with the known bounds is machine-checked.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1011 | Parent problem defining f_r(n), g(r), and the bounds that bracket c | Threshold functions, axiomatized extremal bounds |
+| ramseys-theorem | Off-diagonal R(3,k) controls the upper bound on g(r) and hence on c | Ramsey coloring arguments, probabilistic bounds |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Formalize c as the (conjectural) limit of g(r)/(r² log r) and state c = 1 as a definition-level conjecture.
+   - Why it might work: it needs only the existing axiomatized bounds plus a limit definition, so it is expressible without new mathematics.
+   - Risk: the limit may not be known to exist, so the statement must be phrased conditionally (liminf/limsup) to be faithful.
+
+2. **Approach B**: State the sandwich 1/2 ≤ liminf g(r)/(r² log r) ≤ limsup ≤ 2 and record c = 1 as the midpoint conjecture.
+   - Why it might work: keeps everything within currently provable bounds and isolates the open gap cleanly.
+   - Risk: proving even the sandwich in Lean requires unpacking the Davies-Illingworth and HHKP axioms into asymptotic form, which may need substantial real-analysis scaffolding.
+
+### Key Difficulties
+
+- The constant c is genuinely open; no proof strategy for c = 1 exists in the literature.
+- Expressing r² log r asymptotics and o(1) error terms rigorously in Lean requires careful handling of `Filter.Tendsto` and `Asymptotics`.
+
+### What Would a Proof Need?
+
+- Key lemma 1: a Lean definition of g(r) consistent with the Simonovits asymptotic used in the parent file.
+- Key lemma 2: formal statements of the lower and upper asymptotic bounds implying 1/2 ≤ liminf and limsup ≤ 2.
+- Technical requirements: Mathlib's `Filter`, `Asymptotics.IsLittleO`, and real-logarithm infrastructure to phrase c = 1 faithfully.
+
+## Tractability Assessment
+
+**Difficulty**: Moonshot
+
+**Justification**:
+- Determining c is an open research problem with a factor-of-four gap unresolved since Simonovits's 1966 work.
+- Similar constant-determination problems (e.g. exact off-diagonal Ramsey constants) remain famously open.
+- Mathlib provides asymptotic and filter tooling for stating the conjecture, but no machinery capable of closing the gap.
+
+**Estimated Effort**:
+- Exploration: 2-3 days to formalize the statement and its consistency with known bounds
+- If tractable: weeks for the formal-statement scaffolding only
+- If hard: unknown (resolving c is open research)
+
+## References
+
+### Papers
+- M. Simonovits, "A method for solving extremal problems in graph theory", 1966 — introduces g(r) and the asymptotic f_r(n) = n²/4 - g(r)·n/2 + O(1).
+- E. Davies & M. Illingworth, "Triangles in graphs with forbidden subgraphs and large chromatic number", 2022 — proves g(r) ≥ (1/2 - o(1))·r² log r.
+- P. Hefetz, M. Horn, R. King & F. Pfender, "Triangles in graphs with high chromatic number", 2025 — proves g(r) ≤ (2 + o(1))·r² log r.
+
+### Online Resources
+- https://erdosproblems.com/1011 — canonical statement of Erdős Problem #1011 and its status.
+
+### Mathlib
+- `Mathlib.Analysis.Asymptotics.Asymptotics` — provides `IsLittleO`/`IsBigO` for phrasing o(1) and ~ statements.
+- `Mathlib.Order.Filter.Basic` — `liminf`/`limsup` needed to state the conjectural constant c.
+
+## Metadata
+
+```yaml
+tags:
+  - extremal-graph-theory
+  - graph-theory
+  - chromatic-number
+  - triangles
+  - turan-type
+  - open-problem
+related_proofs:
+  - erdos-1011
+  - ramseys-theorem
+difficulty: moonshot
+source: proof-suggestion
+created: 2026-07-09T15:40:17-07:00
+```

--- a/research/problems/erdos-1011-oq-02/state.md
+++ b/research/problems/erdos-1011-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1011-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:17-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1014-oq-03/knowledge.md
+++ b/research/problems/erdos-1014-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1014-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1014-oq-03/literature/README.md
+++ b/research/problems/erdos-1014-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1014-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1014-oq-03/problem.md
+++ b/research/problems/erdos-1014-oq-03/problem.md
@@ -1,0 +1,121 @@
+# Problem: Asymptotic formula for the consecutive off-diagonal Ramsey difference R(k,l+1) − R(k,l)
+
+**Slug**: erdos-1014-oq-03
+**Created**: 2026-07-09T15:40:17-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{Fix } k \ge 3. \text{ Determine whether } \Delta_l(k) := R(k,l+1) - R(k,l) \text{ admits an asymptotic formula } \Delta_l(k) \sim g_k(l) \ (l \to \infty).
+$$
+
+### Plain Language
+
+The Ramsey number $R(k,l)$ is the smallest $n$ so that every red/blue edge-coloring of the complete graph $K_n$ contains a red $K_k$ or a blue $K_l$. For a fixed first argument $k$, we look at how much this number jumps when we bump the second argument by one: the increment $R(k,l+1) - R(k,l)$. This open question asks whether that increment settles into a clean, predictable growth rate — some explicit function $g_k(l)$ that it is asymptotically equal to — rather than fluctuating erratically as $l$ grows.
+
+### Why This Matters
+
+A meaningful asymptotic for the increment is strictly stronger than the ratio-convergence statement of Erdős Problem #1014 ($R(k,l+1)/R(k,l) \to 1$): knowing $\Delta_l(k) \sim g_k(l)$ pins down the local growth *rate* of the Ramsey function, not just that it grows smoothly. It would sharply constrain any conjectured closed form for $R(k,l)$ (for $k=3$ the expectation is $\Delta_l(3) \sim c\, l/\log l$, matching $R(3,l) \sim c\, l^2/\log l$), connect Ramsey growth to finite-difference/discrete-derivative techniques, and provide a concrete quantitative target that is often easier to attack than a full closed-form asymptotic.
+
+## Known Results
+
+### What's Already Proven
+
+- Erdős–Szekeres upper bound $R(k,l) \le \binom{k+l-2}{k-1}$, giving polynomial growth $R(k,l) = O(l^{k-1})$ for fixed $k$ — Erdős–Szekeres (1935); `diagonal_ramsey_upper` in `Proofs/Erdos1014Problem.lean`
+- Recurrence $R(k,l+1) \le R(k,l) + R(k-1,l+1)$, hence the increment bound $\Delta_l(k) \le R(k-1,l+1)$; for $k=3$ this specializes to $\Delta_l(3) \le l+1$ — `increment_bound_general`, `increment_bound_k3`
+- Tight order of magnitude $R(3,l) = \Theta(l^2/\log l)$: AKS upper bound (1980) and Kim/Shearer lower bound (1995/1983) — `R3_asymptotic_bounds`, `R3_ratio_convergence`
+- Monotonicity $R(k,l) \le R(k,l+1)$, so $\Delta_l(k) \ge 0$ — `ramsey_monotone_left`
+
+### What's Still Open
+
+- Whether $\Delta_l(3) := R(3,l+1) - R(3,l)$ has an asymptotic formula (conjecturally $\sim c\, l/\log l$), which is open because the implied constants in the $\Theta(l^2/\log l)$ bounds for $R(3,l)$ differ
+- Whether any explicit $g_k(l)$ describes $\Delta_l(k)$ for fixed $k \ge 4$, where even the order of magnitude of $R(k,l)$ is unknown
+- Whether the increment is even monotone or eventually smooth in $l$, as opposed to oscillating
+
+### Our Goal
+
+We do not attempt to resolve the open asymptotic. The tractable target is to formalize the *structural* consequences: prove in Lean that a power-law asymptotic $R(k,l) \sim c_k\, l^{k-1}/(\log l)^{k-2}$ would force $\Delta_l(k) \sim (k-1)\, c_k\, l^{k-2}/(\log l)^{k-2}$, and to relate this increment asymptotic to the already-formalized ratio and difference reformulations of #1014, giving a clean conditional bridge from asymptotics to increment behavior.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1014 | Parent problem: ratio convergence $R(k,l+1)/R(k,l)\to1$; supplies the increment bounds and $R(3,l)$ asymptotics this question builds on | Axiomatized Ramsey number, recurrence, real-analysis growth-ratio lemmas, ε–δ convergence |
+| erdos-544 | Studies $R(3,l)$ growth, the best-understood case for the $k=3$ increment | Triangle-free process, probabilistic lower bounds |
+| erdos-1030 | Diagonal Ramsey asymptotics $R(k,k)^{1/k}$; parallel regularity question along the diagonal | Stirling estimates, exponential growth bounds |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Conditional derivation from power-law asymptotics.
+   - Why it might work: If $R(k,l) \sim c_k\, l^{k-1}/(\log l)^{k-2}$, then $\Delta_l(k) = R(k,l)\big((l+1)/l\big)^{k-1}(1+o(1)) - R(k,l)$ expands via the mean-value/binomial estimate to $\sim (k-1)R(k,l)/l$. This reuses the `GrowthRatioHelpers` lemmas already in the parent file.
+   - Risk: It only yields a *conditional* increment asymptotic; it does not settle the unconditional open question and depends on an unproven hypothesis.
+
+2. **Approach B**: Sandwich the $k=3$ increment between analytic bounds.
+   - Why it might work: The upper increment bound $\Delta_l(3) \le l+1$ together with a lower bound derived from $R(3,l) = \Theta(l^2/\log l)$ could pin $\Delta_l(3)$ to order $l/\log l$ if the constants could be matched.
+   - Risk: The constants in the AKS and Kim bounds genuinely differ; without matching them no true asymptotic (only an order-of-magnitude window) can be obtained — this is precisely why the problem is open.
+
+### Key Difficulties
+
+- The gap between the implied constants in $R(3,l) = \Theta(l^2/\log l)$ prevents comparing consecutive values sharply enough to isolate a leading term for the difference.
+- For $k \ge 4$ the increment $R(k-1,l+1)$ is itself superlinear and of order comparable to $R(k,l)$, so no clean separation of scales exists.
+- No Mathlib infrastructure computes or bounds Ramsey numbers beyond tiny explicit cases, so all growth facts must be axiomatized.
+
+### What Would a Proof Need?
+
+- Key lemma 1: A finite-difference expansion showing $g \sim c\, l^{a}/(\log l)^{b} \implies g(l+1)-g(l) \sim a\, c\, l^{a-1}/(\log l)^{b}$ over the reals.
+- Key lemma 2: A transfer lemma converting the increment asymptotic into the ratio/difference statements already in `Erdos1014Problem.lean`.
+- Technical requirements: `Filter.Tendsto`, `Asymptotics.IsEquivalent`, and the existing `GrowthRatioHelpers` real-analysis lemmas; an axiomatized $R(k,l)$ with recurrence and monotonicity.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The unconditional question is genuinely open (open even for $k=3$), so only conditional/structural formalization is realistically attainable.
+- Similar conditional reductions were successfully formalized in the parent `erdos-1014` (e.g. `ratio_from_asymptotics`, `ratio_equiv_difference`), giving a proven template.
+- Mathlib provides the analytic scaffolding (`Filter.Tendsto`, `Asymptotics.IsEquivalent`) but nothing Ramsey-specific, so the combinatorial content must remain axiomatic.
+
+**Estimated Effort**:
+- Exploration: 1–2 days
+- If tractable: 1–2 weeks for the conditional increment-asymptotic formalization
+- If hard: unknown (the unconditional asymptotic is a genuine open problem)
+
+## References
+
+### Papers
+- Erdős, P., "On some extremal problems on r-graphs", Discrete Mathematics 1(1) (1971), 1–6 — poses Problem #1014 on Ramsey ratio growth, the parent of this increment question.
+- Ajtai, M., Komlós, J., Szemerédi, E., "A note on Ramsey numbers", J. Combin. Theory Ser. A 29(3) (1980), 354–360 — upper bound $R(3,l) \le c\, l^2/\log l$.
+- Kim, J.H., "The Ramsey number R(3,t) has order of magnitude t²/log t", Random Structures & Algorithms 7(3) (1995), 173–207 — matching lower bound via the triangle-free process.
+- Mattheus, S., Verstraëte, J., "The asymptotics of r(4,t)", Annals of Mathematics 199(2) (2024), 919–941 — improved off-diagonal lower-bound constants via finite-field constructions.
+
+### Online Resources
+- https://erdosproblems.com/1014 — Erdős Problems database entry for the parent ratio-convergence problem.
+
+### Mathlib
+- `Mathlib.Analysis.Asymptotics.AsymptoticEquivalent` — provides `IsEquivalent` for stating $\Delta_l(k) \sim g_k(l)$.
+- `Mathlib.Order.Filter.Basic` / `Mathlib.Topology.Algebra.Order.Tendsto` — `Filter.Tendsto` machinery for the limit reductions reused from the parent file.
+
+## Metadata
+
+```yaml
+tags:
+  - erdos
+  - graph-theory
+  - ramsey-theory
+  - combinatorics
+  - asymptotics
+  - open
+related_proofs:
+  - erdos-1014
+  - erdos-544
+  - erdos-1030
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:17-07:00
+```

--- a/research/problems/erdos-1014-oq-03/state.md
+++ b/research/problems/erdos-1014-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1014-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:17-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1023-oq-04/knowledge.md
+++ b/research/problems/erdos-1023-oq-04/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1023-oq-04
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1023-oq-04/literature/README.md
+++ b/research/problems/erdos-1023-oq-04/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1023-oq-04
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1023-oq-04/problem.md
+++ b/research/problems/erdos-1023-oq-04/problem.md
@@ -1,0 +1,120 @@
+# Problem: Union-Free Extremal Bounds for Multisets and Infinite Families
+
+**Slug**: erdos-1023-oq-04
+**Created**: 2026-07-09T15:40:19-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+F_{\text{multi}}(n, r) \;=\; \max \{\, |\mathcal{F}| : \mathcal{F} \subseteq \{0,1,\dots,r\}^{[n]},\ \text{no } A \in \mathcal{F} \text{ is the multiset union of other members} \,\}
+$$
+
+For the infinite-family variant, given an infinite ground set $\Omega$ we ask which cardinal invariants govern the largest union-free family $\mathcal{F} \subseteq \mathcal{P}(\Omega)$ closed under the same forbidden-union condition, and whether an analogue of the middle-layer bound $\binom{n}{\lfloor n/2 \rfloor}$ survives.
+
+### Plain Language
+
+Erdős Problem #1023 concerns *union-free* families of subsets of $\{1,\dots,n\}$: collections in which no set equals the union of other members. Its answer is exact and clean — the maximum size is $F(n) = \binom{n}{\lfloor n/2 \rfloor}$, achieved by the middle layer, with asymptotics $F(n) \sim \sqrt{2/\pi}\,\cdot 2^n/\sqrt{n}$. This open question asks how that story changes when subsets are replaced by *multisets* (elements may appear with multiplicity up to $r$) or when the ground set is *infinite*. In both settings the classical antichain/Sperner machinery no longer applies verbatim, and we want to know whether a comparable extremal formula and matching asymptotic can be recovered.
+
+### Why This Matters
+
+Union-free families sit at the crossroads of extremal set theory, Sperner-type antichain theory, and the additive-combinatorics notion of sum-free / union-free structure. The subset case is fully solved and formally verified in the gallery, so it forms a rigorous springboard. Understanding the multiset and infinite generalizations would clarify how much of the answer is intrinsic to the Boolean lattice versus an artifact of finiteness, connect the problem to Sidon-type and dissociated-set phenomena, and expose which parts of the Erdős–Kleitman upper-bound argument are lattice-structural rather than combinatorial.
+
+## Known Results
+
+### What's Already Proven
+
+- $F(n) = \binom{n}{\lfloor n/2 \rfloor}$ for the subset case — Erdős–Kleitman (1968), *On combinations of sets*; formalized as `unionFreeMax_eq_middle` in `Proofs/Erdos1023Problem.lean` (upper bound axiomatized as `erdos_kleitman_upper`).
+- Every antichain is union-free, and the middle layer is a maximum antichain — Sperner (1928); formalized as `antichain_unionFree` and `middleLayer_antichain`.
+- Asymptotic $F(n) \sim \sqrt{2/\pi}\,\cdot 2^n/\sqrt{n}$ via Stirling — formalized as `unionFreeMax_asymptotic` (constant `asymptoticConstant`, `stirling_central` axiomatized).
+- The subset result also follows from Problem #447 (2-union-free families) since union-free $\subseteq$ 2-union-free — Hunter's observation, `hunter_observation`.
+
+### What's Still Open
+
+- The exact value or growth rate of the multiset extremal function $F_{\text{multi}}(n,r)$ for $r \ge 2$; no Sperner analogue on $\{0,\dots,r\}^{[n]}$ (a graded lattice that is not Boolean) is known to be tight here.
+- Whether an infinite ground set admits a meaningful extremal invariant, or whether the family can be made arbitrarily large so that only density/measure-theoretic refinements carry content.
+- Which lemmas of the Erdős–Kleitman upper-bound argument are lattice-structural and survive the passage to $\{0,\dots,r\}^{[n]}$ or to $\mathcal{P}(\Omega)$ with $|\Omega|$ infinite.
+
+### Our Goal
+
+Formalize a precise Lean 4 statement of the multiset union-free extremal function $F_{\text{multi}}(n,r)$, establish the lower bound coming from the largest middle layer of the graded lattice $\{0,\dots,r\}^{[n]}$, and identify (with proof or documented gap) whether the Erdős–Kleitman upper bound generalizes. As a first concrete milestone, settle the base case $r = 1$ (recovering the existing subset theorem) and the smallest genuinely new case $r = 2$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1023 | Direct parent: subset union-free extremal theorem being generalized | Antichains, Sperner middle layer, Erdős–Kleitman upper bound, Stirling asymptotics |
+| erdos-447 | 2-union-free families with the same extremal answer; template for a stronger forbidden-union condition | Sperner-type extremal bound, Hunter's reduction |
+| erdos-1062 | Arithmetic antichain analogue (no element divides two others), solved by middle-layer argument | Maximum-antichain / middle-layer bound |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Graded-lattice middle layer**: Model multisets as $\{0,\dots,r\}^{[n]}$, a graded lattice under coordinatewise $\le$, and take the largest rank level as a lower-bound union-free family (multiset unions strictly raise total degree, so an antichain in this order is union-free).
+   - Why it might work: the union-strictly-increases-rank argument that makes antichains union-free is purely order-theoretic and does not use the Boolean structure.
+   - Risk: the maximum antichain in $\{0,\dots,r\}^{[n]}$ (given by the middle rank, a Sperner-type result for this poset) may not be *tight* as a union-free family — the upper bound is the hard, possibly false, direction.
+
+2. **Approach B — Reduction to the Boolean case**: Encode each coordinate value in $\{0,\dots,r\}$ by a monotone block of Boolean coordinates (order-embedding into $\{0,1\}^{n\lceil \log_2(r+1)\rceil}$) and transport the subset bound.
+   - Why it might work: reuses the fully formalized subset result directly.
+   - Risk: the embedding need not preserve the *union* operation, so union-freeness of the image may not correspond to union-freeness of the preimage; likely yields only a loose bound.
+
+### Key Difficulties
+
+- The multiset lattice is not Boolean, so Sperner's exact middle-layer theorem must be replaced by its graded-poset generalization, and the Erdős–Kleitman compression/shifting argument may not transfer.
+- The infinite case likely lacks a finite extremal invariant, forcing a reformulation (density, measure, or cardinal characteristic) before anything can be proved.
+
+### What Would a Proof Need?
+
+- Key lemma 1: multiset union strictly increases total degree, hence any rank-antichain in $\{0,\dots,r\}^{[n]}$ is union-free (lower bound).
+- Key lemma 2: a Sperner-type / LYM inequality for the graded lattice $\{0,\dots,r\}^{[n]}$ identifying the largest antichain.
+- Technical requirements: a formal `Multiset`/`Fin (r+1) → Fin n` model, a rank function, and either a generalized Erdős–Kleitman upper bound or a documented axiom marking the open gap.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The subset case required an axiomatized Erdős–Kleitman upper bound even after full formalization; the multiset upper bound is strictly harder and may be genuinely open in the literature.
+- The lower bound (rank-antichain) is plausibly tractable and mirrors `middleLayer_unionFree` from the parent proof, giving a concrete first deliverable.
+- Mathlib provides `Finset`, `Multiset`, `Nat.Choose.Central`, and partial antichain/`IsAntichain` infrastructure, but no graded-poset Sperner theorem, so the hard direction lacks direct support.
+
+**Estimated Effort**:
+- Exploration: 2–4 days
+- If tractable: 2–4 weeks (lower bound plus $r=2$ base cases)
+- If hard: unknown (general multiset upper bound and infinite reformulation)
+
+## References
+
+### Papers
+- P. Erdős and D. J. Kleitman, *On combinations of sets*, Nordisk Matematisk Tidskrift 16 (1968), 20–25 — establishes $F(n) = \binom{n}{\lfloor n/2\rfloor}$ for subsets; the argument to be generalized.
+- E. Sperner, *Ein Satz über Untermengen einer endlichen Menge*, Math. Z. 27 (1928), 544–548 — antichain theorem underlying the lower bound; the graded-lattice analogue is what the multiset case needs.
+- P. Frankl, *Extremal set systems*, Handbook of Combinatorics (1995), 1293–1329 — survey of union-free families and shifting/compression methods relevant to the upper bound.
+
+### Online Resources
+- https://erdosproblems.com/1023 — canonical statement and status of the parent Erdős problem.
+
+### Mathlib
+- `Mathlib.Data.Nat.Choose.Central` — central binomial coefficients for the exact and asymptotic subset bound.
+- `Mathlib.Order.Antichain` / `Mathlib.Combinatorics.SetFamily` — antichain and set-family infrastructure to be adapted to the graded multiset lattice.
+- `Mathlib.Data.Multiset.Basic` — multiset model for the generalized ground objects.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - set-families
+  - erdos
+  - extremal-combinatorics
+  - antichains
+related_proofs:
+  - erdos-1023
+  - erdos-447
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:19-07:00
+```

--- a/research/problems/erdos-1023-oq-04/state.md
+++ b/research/problems/erdos-1023-oq-04/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1023-oq-04
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:19-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1038-oq-01/knowledge.md
+++ b/research/problems/erdos-1038-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1038-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1038-oq-01/literature/README.md
+++ b/research/problems/erdos-1038-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1038-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1038-oq-01/problem.md
+++ b/research/problems/erdos-1038-oq-01/problem.md
@@ -1,0 +1,117 @@
+# Problem: Exact Value of the Infimum Sublevel-Set Measure (Erdős #1038)
+
+**Slug**: erdos-1038-oq-01
+**Created**: 2026-07-09T00:00:00Z
+**Status**: Active
+**Source**: proof-suggestion
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\inf_{f} \left| \{ x \in \mathbb{R} : |f(x)| < 1 \} \right| \;=\; ?, \qquad f(x) = \prod_{i=1}^{n} (x - r_i),\; r_i \in [-1,1],\; n \ge 1,
+$$
+
+where $|\cdot|$ denotes Lebesgue measure and the infimum ranges over all non-constant monic polynomials whose roots all lie in $[-1,1]$. The current best bounds are $2^{4/3} - 1 \approx 1.519 \le \inf_f |\{x : |f(x)| < 1\}| \le 1.835$; the exact value is unknown.
+
+### Plain Language
+
+Take a monic polynomial whose roots all sit inside the interval $[-1,1]$, and look at the set of real numbers where the polynomial has absolute value less than $1$. That "sublevel set" always has some total length. Erdős, Herzog, and Piranian asked how large and how small this length can be as the polynomial varies. Tao settled the largest possible length in 2025 (it is $2\sqrt{2}$), but the smallest possible length — the infimum — is still not pinned down. We know it lies somewhere between about $1.519$ and $1.835$, and the goal is to determine its exact value.
+
+### Why This Matters
+
+Determining the infimum would complete the metric picture of polynomial sublevel sets begun by Erdős–Herzog–Piranian (1958) and continued by Tao (2025). The quantity links polynomial approximation on $[-1,1]$ to logarithmic potential theory, equilibrium measures, and transfinite diameter, so an exact answer would sharpen our understanding of how root placement constrains the region where a monic polynomial stays small. It also feeds into the sibling Erdős problems (#1039–#1046) on lemniscate geometry and disc containment, where the same sublevel sets are studied topologically and geometrically.
+
+## Known Results
+
+### What's Already Proven
+
+- Supremum equals $2\sqrt{2}$ for monic polynomials with all roots in $[-1,1]$ — Tao (2025), announced December 2025.
+- Upper bound $\sup \le 2\sqrt{2}$ for roots in $\{-1,1\}$, plus $\inf < 2$ via families like $(x+1)(x-1)^3$ — Erdős, Herzog, Piranian (1958).
+- Lower bound $\inf \ge 2^{4/3} - 1 \approx 1.519$ from potential-theoretic estimates — see the erdos-1038 gallery entry.
+
+### What's Still Open
+
+- The exact value of $\inf_f |\{x : |f(x)| < 1\}|$ within the interval $[1.519, 1.835]$.
+- Whether that infimum is attained by an explicit polynomial or realized only as a limit of a polynomial family.
+
+### Our Goal
+
+Determine (or tightly bound) the exact value of the infimum, and formalize the resulting statement in Lean 4 by improving the current explicit lower and upper bound witnesses. As a first tractable step we target narrowing the gap: sharpen either the lower bound beyond $2^{4/3} - 1$ or the upper bound below $1.835$ using an explicit polynomial family, and formalize the measure estimate for that witness.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1038 | Parent entry stating both the supremum ($2\sqrt{2}$) and the open infimum bounds | Measure theory, potential theory, polynomial analysis |
+| erdos-1040 | Generalizes sublevel-set measure to closed sets $F \subseteq \mathbb{C}$ via transfinite diameter | Transfinite diameter, logarithmic capacity |
+| erdos-1046 | Disc containment for connected lemniscates $\{z : |f(z)| < 1\}$ | Lemniscate geometry, conformal estimates |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Extremal polynomial families. Study families such as $(x+1)^a (x-1)^b$ and Chebyshev-type combinations, compute the measure of $\{x : |f(x)| < 1\}$ explicitly, and minimize over the family to push the upper bound below $1.835$.
+   - Why it might work: the current bounds already come from explicit families, so a richer parametrization may reveal a sharper minimizer.
+   - Risk: the true minimizer may be a limit object, so no finite family attains the infimum and only asymptotic estimates result.
+
+2. **Approach B**: Potential-theoretic lower bound. Represent the sublevel-set measure via the logarithmic potential / equilibrium measure of the root distribution and apply capacity inequalities to raise the lower bound above $2^{4/3} - 1$.
+   - Why it might work: Tao's supremum proof shows potential theory captures the extremal behavior; the same machinery should constrain the minimum.
+   - Risk: the required capacity estimates are not in Mathlib, so formalization would need substantial new infrastructure.
+
+### Key Difficulties
+
+- The infimum may be an irrational constant with no closed form, making an exact Lean statement hard to phrase.
+- Lebesgue measure of a semialgebraic sublevel set requires careful ENNReal handling and Mathlib currently lacks logarithmic capacity / equilibrium measure theory.
+
+### What Would a Proof Need?
+
+- Key lemma 1: an explicit formula (or sharp bound) for $|\{x : |f(x)| < 1\}|$ for a chosen parametric family.
+- Key lemma 2: a potential-theoretic lower bound tying the measure to the logarithmic capacity of the root set $[-1,1]$.
+- Technical requirements: `MeasureTheory.volume` reasoning over `ENNReal`, monic-polynomial factorization in Mathlib, and real-analytic estimates for the sublevel set boundary.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The exact infimum is an open research problem with a substantial $[1.519, 1.835]$ gap and no known closed form.
+- Related metric-property questions (e.g. Tao's supremum) required serious potential theory, indicating the infimum is comparably hard.
+- Mathlib provides Lebesgue measure and polynomial factorization but no equilibrium-measure or transfinite-diameter theory, so a full formalization would need new groundwork.
+
+**Estimated Effort**:
+- Exploration: several days
+- If tractable (narrowing the gap with an explicit witness): weeks
+- If hard (exact value): unknown / open-ended
+
+## References
+
+### Papers
+- P. Erdős, G. Herzog, G. Piranian, "Metric properties of polynomials", J. d'Analyse Math. 6 (1958), 125–148 — original source posing the infimum question.
+- T. Tao, "Sublevel set measure for monic polynomials", arXiv (2025) — resolved the supremum at $2\sqrt{2}$.
+- T. Ransford, "Potential Theory in the Complex Plane", Cambridge Univ. Press (1995) — logarithmic capacity and transfinite diameter background.
+
+### Online Resources
+- https://erdosproblems.com/1038 — canonical statement and status of Erdős Problem #1038.
+
+### Mathlib
+- Mathlib.MeasureTheory.Measure.Lebesgue.Basic — Lebesgue measure `volume` on $\mathbb{R}$ used for the sublevel-set length.
+- Mathlib.Algebra.Polynomial.Monic — monic polynomial definitions and factorization needed to model the root constraint.
+
+## Metadata
+
+```yaml
+tags:
+  - erdos
+  - measure-theory
+  - polynomials
+  - potential-theory
+  - real-analysis
+related_proofs:
+  - erdos-1038
+  - erdos-1040
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T00:00:00Z
+```

--- a/research/problems/erdos-1038-oq-01/state.md
+++ b/research/problems/erdos-1038-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1038-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:17-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1039-oq-05
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1039-oq-05/literature/README.md
+++ b/research/problems/erdos-1039-oq-05/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1039-oq-05
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1039-oq-05/problem.md
+++ b/research/problems/erdos-1039-oq-05/problem.md
@@ -1,0 +1,122 @@
+# Problem: Relating ρ(f) to transfinite diameter and logarithmic capacity
+
+**Slug**: erdos-1039-oq-05
+**Created**: 2026-07-09T15:40:19-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\rho(f) = \sup\{r > 0 : \exists c \in \mathbb{C},\ B(c,r) \subseteq \{z : |f(z)| < 1\}\}, \qquad f(z) = \prod_{i=1}^{n}(z - z_i),\ |z_i| \le 1.
+$$
+
+Let $d(Z)$ be the transfinite diameter of the root multiset $Z = \{z_1,\dots,z_n\}$ and let $\operatorname{cap}(E)$ denote the logarithmic capacity of the lemniscate complement $E = \{z : |f(z)| \ge 1\}$. The task is to determine explicit quantitative relations of the form $\rho(f) \gtrsim g\big(d(Z), \operatorname{cap}(E)\big)$ and to decide whether either potential-theoretic quantity governs the conjectured lower bound $\rho(f) \gg 1/n$.
+
+### Plain Language
+
+For a monic polynomial whose roots all lie in the closed unit disc, the region where $|f(z)| < 1$ (a "lemniscate interior", a union of at most $n$ petals) contains a largest inscribed disc of radius $\rho(f)$. Two classical potential-theoretic numbers are attached to the same polynomial: the transfinite diameter of the set of roots (roughly, how spread out the roots are), and the logarithmic capacity of the complementary set where $|f| \ge 1$. We want to know, precisely, how the size of the biggest inscribed disc is controlled by these two capacity-type quantities.
+
+### Why This Matters
+
+The lemniscate $\{|f(z)| = 1\}$ is the level-1 set of the Green's function of the complement of $\{|f| < 1\}$, so $\rho(f)$ is a genuinely potential-theoretic quantity in disguise. Pinning down its relationship with transfinite diameter and logarithmic capacity would recast the open Erdős–Herzog–Piranian conjecture $\rho(f) \gg 1/n$ as a capacity inequality, connecting Problem 1039 directly to Problem 1040 (transfinite diameter) and Problem 1038 (sublevel-set measure). Because logarithmic capacity is exactly the tool Pommerenke (1961) used for the first lower bound $\rho(f) \ge 1/(2en^2)$ and underlies the KLR (2025) area method, a clean capacity characterization could be the route to eliminating the residual $\sqrt{\log n}$ gap.
+
+## Known Results
+
+### What's Already Proven
+
+- Pommerenke (1961): $\rho(f) \ge 1/(2en^2)$ for every unit-disc polynomial, via Green's-function and Koebe-distortion estimates — capacity is already the engine — captured as the `pommerenke_lower` axiom in `Proofs/Erdos1039Problem.lean`.
+- Krishnapur–Lundberg–Ramachandran (2025): area$(\{|f|<1\}) \ge \pi/(n^2\log n)$ hence $\rho(f) \ge c/(n\sqrt{\log n})$ — the `klr_area_bound` and `klr_lower` axioms.
+- Fekete–Szegő theory: for a compact set $E$, transfinite diameter $d(E)$, logarithmic capacity $\operatorname{cap}(E)$, and Chebyshev constant coincide; the lemniscate $\{|f| \le 1\}$ has $\operatorname{cap} = 1$ for monic $f$ of degree $n$ (a classical normalization).
+- Benchmark $\rho(z^n-1) \le \pi/(2n)$ — the `benchmark_upper` axiom — fixes the target rate $\Theta(1/n)$.
+
+### What's Still Open
+
+- Whether $\rho(f)$ admits a two-sided bound purely in terms of $d(Z)$ and $\operatorname{cap}(\{|f| \ge 1\})$, uniformly in $n$.
+- Whether the transfinite diameter of the root set alone (independent of their fine spacing) can force $\rho(f) \ge c/n$, or whether spacing information beyond capacity is essential.
+- The main Erdős–Herzog–Piranian conjecture $\rho(f) \gg 1/n$ itself, and in particular removal of the $\sqrt{\log n}$ factor.
+
+### Our Goal
+
+Formalize the definitions of transfinite diameter of the root multiset and logarithmic capacity of the lemniscate complement in the existing `Erdos1039` framework, and state (as theorems where provable, axioms where they cite the literature) the quantitative links $\rho(f) \gtrsim g(d(Z), \operatorname{cap})$. We do not attempt to resolve the $1/n$ conjecture; we scope to making the capacity/transfinite-diameter relationship precise and machine-checkable, mirroring the `pommerenke_lower`/`klr_area_bound` axiom pattern.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1039 | Parent problem: defines ρ(f), sublevel set, and the bound hierarchy this OQ extends | Lemniscate geometry, inscribed disc radius, area bounds, axiomatized capacity results |
+| erdos-1040 | Directly about transfinite diameter and sublevel-set measure — the other half of this relationship | Transfinite diameter, Green's functions, potential theory |
+| erdos-1038 | Sublevel-set measure feeds the KLR area bound linking capacity to ρ(f) | Lebesgue measure of {\|f\|<1}, capacity estimates |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Capacity-to-radius via Green's function**: Express $\rho(f)$ through the Green's function $g_E$ of the lemniscate complement, use $\operatorname{cap}(E)=1$ normalization, and derive $\rho(f) \gtrsim h(\operatorname{cap})$ from Harnack/Koebe distortion of $g_E$ near the level-1 curve.
+   - Why it might work: this is precisely Pommerenke's toolkit, already implicitly axiomatized, so the scaffolding exists.
+   - Risk: making the Green's-function machinery explicit in Lean/Mathlib may require infrastructure (subharmonic functions, capacity) that Mathlib currently lacks.
+
+2. **Approach B — Fekete points and transfinite diameter of $Z$**: Bound $\rho(f)$ below using the transfinite diameter $d(Z)$ of the root multiset via the arithmetic–geometric spread of $|f|$ on a candidate disc.
+   - Why it might work: $d(Z)$ controls the minimal product $\prod|z-z_i|$ and hence where $|f|<1$ holds; roots-of-unity minimize spread and give the worst case.
+   - Risk: $d(Z)$ alone may not distinguish clustered from spread configurations finely enough to reach $1/n$; capacity of the complement may be the sharper invariant.
+
+### Key Difficulties
+
+- Mathlib has essentially no logarithmic-capacity / transfinite-diameter API, so definitions must be built from scratch or axiomatized.
+- Separating what is genuinely provable from what must cite Pommerenke/KLR (to respect the axiom-integrity policy: any literature-dependent inequality becomes an `axiom`, counted in `axiomCount`).
+
+### What Would a Proof Need?
+
+- Key lemma 1: a formal definition of transfinite diameter $d(Z) = \lim_k \big(\max \prod_{i<j}|w_i-w_j|\big)^{2/(k(k-1))}$ specialized to the finite root multiset (or its finite-$n$ discrete version $\prod_{i<j}|z_i-z_j|^{2/(n(n-1))}$).
+- Key lemma 2: a formal definition of logarithmic capacity of the compact complement piece $\{|f|\ge 1\}\cap\overline{B(0,R)}$ and the normalization $\operatorname{cap}=1$.
+- Technical requirements: Green's-function estimates or an equivalent isoperimetric/area bridge connecting capacity to the inscribed disc radius, plus the existing `sublevelArea`/`area_implies_disc_bound` lemmas.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The underlying mathematics is open research (the $1/n$ conjecture is unresolved), so a full characterization is a moonshot; a *stated, axiom-backed* relationship is high-but-feasible.
+- Similar problems solved: the parent `erdos-1039` successfully axiomatized Pommerenke and KLR while proving the elementary geometry lemmas — the same pattern applies here.
+- Techniques available in Mathlib: `MeasureTheory.volume`, `Complex.abs`, `Polynomial.eval₂`, `Real.log` exist; capacity/transfinite-diameter do not, so those pieces must be defined or axiomatized.
+
+**Estimated Effort**:
+- Exploration: 2–4 days
+- If tractable: 2–3 weeks (definitions + stated relations with a few proved special cases)
+- If hard: unknown (a genuine capacity characterization implying $1/n$ would resolve the open conjecture)
+
+## References
+
+### Papers
+- Erdős, Herzog, Piranian, "Metric properties of polynomials", J. Analyse Math. 6 (1958) — origin of $\rho(f)$ and the lemniscate geometry questions.
+- Pommerenke, "On metric properties of complex polynomials", Michigan Math. J. 8 (1961) — capacity/Green's-function lower bound $\rho \ge 1/(2en^2)$.
+- Krishnapur, Lundberg, Ramachandran, "Inscribed discs in polynomial lemniscates" (2025) — area/capacity method giving $\rho \ge c/(n\sqrt{\log n})$.
+
+### Online Resources
+- https://erdosproblems.com/1039 — canonical statement, status, and bound history for Problem 1039.
+- https://erdosproblems.com/1040 — companion transfinite-diameter problem referenced by this open question.
+
+### Mathlib
+- Mathlib.MeasureTheory.Measure.MeasureSpace — Lebesgue measure for area bounds bridging capacity to $\rho(f)$.
+- Mathlib.Analysis.SpecialFunctions.Complex.Circle — `Complex.abs` for the sublevel set and lemniscate.
+- Mathlib.Analysis.SpecialFunctions.Log.Basic — `Real.log` for capacity/Green's-function-style logarithmic quantities.
+
+## Metadata
+
+```yaml
+tags:
+  - complex-analysis
+  - polynomials
+  - potential-theory
+  - lemniscates
+  - open-problem
+related_proofs:
+  - erdos-1039
+  - erdos-1040
+  - erdos-1038
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:19-07:00
+```

--- a/research/problems/erdos-1039-oq-05/state.md
+++ b/research/problems/erdos-1039-oq-05/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1039-oq-05
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:19-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1067-oq-03/knowledge.md
+++ b/research/problems/erdos-1067-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1067-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1067-oq-03/literature/README.md
+++ b/research/problems/erdos-1067-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1067-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1067-oq-03/problem.md
+++ b/research/problems/erdos-1067-oq-03/problem.md
@@ -1,0 +1,122 @@
+# Problem: Erdős-Hajnal Connectivity Question at ℵ₂ and Higher Alephs
+
+**Slug**: erdos-1067-oq-03
+**Created**: 2026-07-09T15:40:18-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall \kappa \in \{\aleph_2, \aleph_3, \dots\}: \Big(\chi(G) = \kappa \implies \exists H \subseteq G,\ H \text{ infinitely connected} \wedge \chi(H) = \kappa\Big) \stackrel{?}{=} \text{FALSE}
+$$
+
+The gallery proof of Erdős Problem #1067 established that at $\kappa = \aleph_1$ the universal implication is **false** (Soukup 2015, Bowler-Pitz 2024): there exist graphs with $\chi(G) = \aleph_1$ whose every infinitely connected subgraph has chromatic number strictly below $\aleph_1$. The present problem asks whether the same negative answer holds when $\aleph_1$ is replaced by $\aleph_2$ or any higher aleph $\aleph_\alpha$ ($\alpha \ge 2$), and whether the ZFC-independence seen in the $|V(G)| = \aleph_1$ restriction reappears at these larger cardinals.
+
+### Plain Language
+
+A graph is *infinitely connected* if between any two vertices there are infinitely many internally disjoint paths (no finite set of vertices can separate them). The chromatic number $\chi(G)$ measures how many colors are needed so adjacent vertices differ. Erdős and Hajnal asked whether a graph that genuinely needs $\aleph_1$ colors must hide inside it a highly-connected piece that still needs $\aleph_1$ colors. The answer at $\aleph_1$ turned out to be no. This problem asks the next natural question: if a graph needs $\aleph_2$ colors (or $\aleph_3$, or any higher uncountable cardinal), is it still possible to build a counterexample where the "hard-to-color core" avoids being infinitely connected? And does the phenomenon where the answer flips depending on which set-theoretic axioms you assume — seen for the $\aleph_1$-vertex variant — continue to appear at these larger scales?
+
+### Why This Matters
+
+Resolving this would clarify whether the decoupling of chromatic number from connectivity is a special feature of $\aleph_1$ or a general phenomenon of uncountable chromatic combinatorics. If the negative answer lifts uniformly to all $\aleph_\alpha$, it strengthens the structural picture that "chromatic difficulty" can always be distributed across thin, tree-like regions regardless of scale. If the independence phenomenon persists (or intensifies) at $\aleph_2$, it would tie the question to large-cardinal and forcing hierarchies, connecting Erdős-style combinatorics to the deepest parts of set theory. The Soukup and Bowler-Pitz constructions are cardinal-parametrized, so understanding which parts survive successor and limit cardinals is a concrete test of how robust those techniques are.
+
+## Known Results
+
+### What's Already Proven
+
+- Erdős-Hajnal question at $\aleph_1$ is **false** in ZFC (Soukup 2015) — axiomatized as `soukup_counterexample_2015` in `Proofs/Erdos1067Problem.lean`
+- Elementary counterexample at $\aleph_1$ (Bowler-Pitz 2024) — axiomatized as `bowler_pitz_counterexample_2024` in the same file
+- Consistency of a counterexample via forcing, plus ZFC-independence for the $|V(G)| = \aleph_1$ restriction (Komjáth 2013) — `Combinatorica`
+- Edge-connectivity analogue at $\aleph_1$ is also false (Thomassen 2017) — `Journal of Graph Theory`
+
+### What's Still Open
+
+- Whether $\chi(G) = \aleph_2$ forces an infinitely connected subgraph with $\chi = \aleph_2$ (no published ZFC counterexample known at $\aleph_2$)
+- Whether the ZFC-independence of the vertex-restricted variant reappears when $|V(G)| = \aleph_2$ or $|V(G)| = \aleph_\alpha$
+- Whether Soukup's ladder-tree construction generalizes to successor cardinals $\aleph_{\alpha+1}$ and to limit cardinals such as $\aleph_\omega$
+- Whether large-cardinal hypotheses change the answer at sufficiently high alephs
+
+### Our Goal
+
+Formalize the *statement* of the generalized Erdős-Hajnal question at arbitrary aleph $\kappa$ (parametrized by an ordinal $\alpha$), building on the existing `ErdosHajnalQuestion` definition so that the $\aleph_1$ case is recovered by specialization. Establish the axiomatized negative answer at $\aleph_2$ conditional on the appropriate construction, and record the independence-versus-ZFC dichotomy as separate hypotheses. The concrete scope is a Lean scaffold that (a) generalizes `hasAleph1ChromaticNumber` to `hasChromaticNumber κ`, and (b) states the higher-aleph question as a theorem whose proof is deferred to axioms mirroring the $\aleph_1$ structure.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1067 | Direct parent: this generalizes its $\aleph_1$ result to higher alephs | Cardinal chromatic number, infinite connectivity, axiomatized counterexamples, `push_neg` |
+| erdos-1068 | Countable-connectivity companion from the same Soukup 2015 paper | Infinite vertex connectivity, uncountable $\chi$ |
+| erdos-62 | Common-subgraph structure of graphs with $\chi = \aleph_1$ | Uncountable chromatic graphs, shared subgraph existence |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Cardinal-parametrize Soukup's ladder-tree construction**: Rework Soukup's construction with $\aleph_2$ (or $\aleph_\alpha$) replacing $\aleph_1$ throughout, using trees of height/width scaled to $\kappa$.
+   - Why it might work: The construction's chromatic bottleneck comes from global tree structure, which is cardinal-agnostic in principle.
+   - Risk: Successor-cardinal combinatorics (e.g. the tree property, $\square_\kappa$ principles) may obstruct the coloring argument at $\aleph_2$, making the "locally countably colorable" step fail.
+
+2. **Approach B — Reduce higher alephs to $\aleph_1$ via elementary submodels or partition calculus**: Try to derive a counterexample at $\aleph_2$ from the $\aleph_1$ counterexample by a lifting / product argument.
+   - Why it might work: Partition relations $\kappa \to (\kappa)^2_\lambda$ style transfers sometimes carry combinatorial obstructions upward.
+   - Risk: Chromatic number does not behave multiplicatively under natural products; a naive lift may only give $\chi = \aleph_1$, not $\aleph_2$.
+
+### Key Difficulties
+
+- Successor cardinals above $\aleph_1$ carry extra combinatorial structure (stationary reflection, square principles) that can either enable or destroy the construction, and these are themselves independence-sensitive.
+- Mathlib has cardinal arithmetic (`Cardinal.aleph`) but essentially no infinite-graph coloring or infinite Menger/connectivity theory, so most supporting infrastructure must be built or axiomatized.
+
+### What Would a Proof Need?
+
+- Key lemma 1: A cardinal-parametrized chromatic-number predicate `hasChromaticNumber κ G` generalizing `hasAleph1ChromaticNumber`, with the $\aleph_1$ instance definitionally recovered.
+- Key lemma 2: A statement `ErdosHajnalQuestionAt κ` and, conditional on axioms, its refutation at $\kappa = \aleph_2$ mirroring `erdos_1067_answer`.
+- Technical requirements: Infinite Menger equivalence for the parametrized `InfinitelyConnected` predicate; a means to record ZFC-independence hypotheses as explicit assumptions rather than proved facts.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The mathematical question is genuinely open at $\aleph_2$; no known ZFC counterexample exists, and the independence behavior is unresolved, so a full resolution is a research-level set-theory problem.
+- The *formalization of the statement* and an axiomatized scaffold are tractable, following the established pattern of the erdos-1067 gallery entry.
+- Similar axiomatize-the-deep-result approach already succeeded at $\aleph_1$ (Soukup, Bowler-Pitz axioms), giving a clear template.
+- Mathlib provides `Cardinal.aleph` and `SimpleGraph` but no infinite chromatic/connectivity theory, so unaxiomatized progress is limited.
+
+**Estimated Effort**:
+- Exploration: 2-4 days
+- If tractable (statement + axiomatized scaffold): 1-2 weeks
+- If hard (unaxiomatized construction or independence result): unknown / open research
+
+## References
+
+### Papers
+- Lajos Soukup, "Infinite graphs with no odd cycles of a given length", European Journal of Combinatorics, 2015 — ZFC counterexample at $\aleph_1$; the construction to attempt to lift.
+- Nathan Bowler, Steffen Pitz, "A simpler proof of the Erdős-Hajnal conjecture for forests", arXiv, 2024 — elementary $\aleph_1$ construction, a candidate for cleaner cardinal parametrization.
+- Péter Komjáth, "A note on uncountably chromatic graphs", Combinatorica, 2013 — ZFC-independence of the vertex-restricted variant; template for higher-aleph independence.
+- Paul Erdős, András Hajnal, "On chromatic number of graphs and set-systems", Acta Mathematica Hungarica, 1966 — origin of the question and uncountable-chromatic program.
+
+### Online Resources
+- https://erdosproblems.com/1067 — canonical statement and status of Erdős Problem #1067.
+
+### Mathlib
+- `Mathlib.SetTheory.Cardinal.Ordinal` — provides `Cardinal.aleph` for $\aleph_\alpha$ indexed by ordinals, needed to parametrize the question.
+- `Mathlib.Combinatorics.SimpleGraph.Basic` — `SimpleGraph` structure underlying the graph, subgraph, and coloring definitions.
+
+## Metadata
+
+```yaml
+tags:
+  - set-theory
+  - graph-theory
+  - chromatic-number
+  - infinite-graphs
+  - connectivity
+related_proofs:
+  - erdos-1067
+  - erdos-1068
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:18-07:00
+```

--- a/research/problems/erdos-1067-oq-03/state.md
+++ b/research/problems/erdos-1067-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1067-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:18-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1080-oq-01/knowledge.md
+++ b/research/problems/erdos-1080-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1080-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1080-oq-01/literature/README.md
+++ b/research/problems/erdos-1080-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1080-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1080-oq-01/problem.md
+++ b/research/problems/erdos-1080-oq-01/problem.md
@@ -1,0 +1,113 @@
+# Problem: Determine the exact exponent for f(n, ⌊n^(2/3)⌋)
+
+**Slug**: erdos-1080-oq-01
+**Created**: 2026-07-09T15:40:16-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{Determine } \alpha \text{ such that } f(n, \lfloor n^{2/3} \rfloor) = \Theta(n^{\alpha}), \quad \text{where currently } \tfrac{16}{15} \le \alpha \le \tfrac{10}{9}.
+$$
+
+### Plain Language
+
+Let $f(n, m)$ be the maximum number of edges in a bipartite graph on $n$ vertices, one part of size $m = \lfloor n^{2/3} \rfloor$, that contains neither a $C_4$ nor a $C_6$. De Caen–Székely showed this function grows superlinearly, with an upper bound of $O(n^{10/9})$ and Lazebnik–Ustimenko–Woldar improved the lower bound to $\Omega(n^{16/15})$. The exact growth exponent $\alpha$ is unknown, and this problem asks to pin it down.
+
+### Why This Matters
+
+Fixing the exponent would close a long-standing gap in extremal graph theory that has stood since the 1990s. It would sharpen our understanding of how forbidding short even cycles constrains edge density in imbalanced bipartite graphs, and it connects directly to algebraic constructions from finite geometry that realize the current best lower bounds.
+
+## Known Results
+
+### What's Already Proven
+
+- De Caen–Székely (1992) upper bound $f(n, \lfloor n^{2/3}\rfloor) = O(n^{10/9})$ — Sets, Graphs and Numbers (Budapest, 1991), Colloq. Math. Soc. János Bolyai, Vol. 60
+- Lazebnik–Ustimenko–Woldar (1994/1995) lower bound $\Omega(n^{16/15})$ via algebraic incidence-graph constructions — Bull. Amer. Math. Soc. 32(1), 73–79
+
+### What's Still Open
+
+- Whether the true exponent equals the upper bound $10/9$, the lower bound $16/15$, or some value strictly between them
+- Whether a matching construction and matching counting argument can be produced to collapse the interval to a single value
+
+### Our Goal
+
+Formalize the current best-known bounds on $f(n, \lfloor n^{2/3}\rfloor)$ in Lean 4 and, where feasible, tighten either the upper or lower bound so the interval $[16/15, 10/9]$ shrinks toward a single exponent.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1080 | Parent problem; establishes the disproof and the superlinear bounds framing this open question | Bipartition predicates, cycle-free predicates, axiomatized LUW construction |
+| erdos-1008 | Companion extremal question on $C_4$-free subgraphs | Forbidden-subgraph edge counting |
+| erdos-113 | Extremal numbers and degeneracy of bipartite graphs | Turán-type density arguments |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Refine the De Caen–Székely counting argument to lower the $10/9$ upper exponent.
+   - Why it might work: The upper bound relies on double-counting paths of length two and three; a tighter accounting of the imbalanced partition may sharpen the constant and possibly the exponent.
+   - Risk: The $10/9$ bound may already be tight from above, making improvement impossible.
+
+2. **Approach B**: Search for denser algebraic constructions than the LUW incidence graphs to raise the $16/15$ lower exponent.
+   - Why it might work: New generalized polygon or projective-plane incidence structures could yield graphs with more edges while remaining $C_4,C_6$-free.
+   - Risk: Known algebraic families appear to plateau near $16/15$, so a genuinely new construction may be required.
+
+### Key Difficulties
+
+- The gap between $16/15 \approx 1.0667$ and $10/9 \approx 1.1111$ is narrow, so both directions demand precise asymptotic control.
+- Extremal constructions live in finite geometry, an area with limited Mathlib coverage.
+
+### What Would a Proof Need?
+
+- Key lemma 1: A clean Lean statement of $f(n,m)$ as a supremum of edge counts over $C_4,C_6$-free bipartite graphs.
+- Key lemma 2: An asymptotic upper-bound lemma reproducing the $O(n^{10/9})$ counting argument.
+- Technical requirements: Real-exponent asymptotics ($n^{\alpha}$) and incidence-graph combinatorics not yet in Mathlib.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- Determining the exact exponent is a genuinely open research question that has resisted resolution since 1992.
+- Similar extremal-Turán exponent problems (e.g., the Zarankiewicz function) remain open even for classical parameter ranges.
+- Mathlib provides SimpleGraph, Walk, and cardinality infrastructure but no finite-geometry incidence graphs, so foundational scaffolding is required.
+
+**Estimated Effort**:
+- Exploration: several days
+- If tractable: several weeks to formalize the known bounds
+- If hard: unknown; closing the exponent gap is open research
+
+## References
+
+### Papers
+- De Caen, D. and Székely, L. A., "The maximum size of 4- and 6-cycle-free bipartite graphs on n vertices", 1992 — establishes the $O(n^{10/9})$ upper and superlinear lower bounds
+- Lazebnik, F., Ustimenko, V. A., and Woldar, A. J., "A new series of dense graphs of high girth", 1995 — improves the lower bound to $\Omega(n^{16/15})$
+
+### Online Resources
+- https://erdosproblems.com/1080 — canonical statement and status of Erdős Problem #1080
+
+### Mathlib
+- Mathlib.Combinatorics.SimpleGraph.Basic — simple graph structure for expressing bipartite graphs
+- Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting — walks and cycles used to define $C_4,C_6$-freeness
+- Mathlib.Data.Set.Card — set cardinality for defining the extremal function $f(n,m)$
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - graph-theory
+  - extremal-graph-theory
+  - bipartite-graphs
+  - cycles
+related_proofs:
+  - erdos-1080
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:16-07:00
+```

--- a/research/problems/erdos-1080-oq-01/state.md
+++ b/research/problems/erdos-1080-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1080-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:16-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1102-oq-01/knowledge.md
+++ b/research/problems/erdos-1102-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1102-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1102-oq-01/literature/README.md
+++ b/research/problems/erdos-1102-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1102-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1102-oq-01/problem.md
+++ b/research/problems/erdos-1102-oq-01/problem.md
@@ -1,0 +1,119 @@
+# Problem: Do the sequences 2ⁿ − 1 have property P
+
+**Slug**: erdos-1102-oq-01
+**Created**: 2026-07-09T15:40:19-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+A = \{\, 2^n - 1 : n \ge 1 \,\} \;\overset{?}{\in}\; P \quad\text{where}\quad P = \Bigl\{ A : \forall n \ge 1,\; \bigl|\{\, a \in A : \mu^2(n + a) = 1 \,\}\bigr| < \infty \Bigr\}.
+$$
+
+### Plain Language
+
+Erdős's property P asks: for a set of integers A, is it true that for every fixed shift n ≥ 1 only finitely many elements a of A make n + a squarefree? Equivalently, each translate A + n eventually avoids squarefree numbers entirely. This open question asks whether the specific fast-growing sequence of Mersenne-type numbers 2ⁿ − 1 = 1, 3, 7, 15, 31, 63, 127, … satisfies property P.
+
+### Why This Matters
+
+Property P is one of the two extremal squarefree conditions Erdős introduced in Problem #1102, resolved in general by van Doorn–Tao (2025): P-sequences must have density 0. But density 0 alone does not decide any particular sparse sequence, and 2ⁿ − 1 grows exponentially, so it is a natural test case that van Doorn–Tao list as unresolved. Deciding it would sharpen our understanding of how additive shifts interact with squarefree distribution for multiplicatively structured sequences, and connects to classical questions about squarefree values of 2ⁿ − 1 (e.g. Wieferich-prime obstructions to squarefreeness).
+
+## Known Results
+
+### What's Already Proven
+
+- van Doorn–Tao (2025): every sequence with property P has natural density 0 — arXiv preprint "Squarefree properties P and Q"
+- The density of squarefree integers is 6/π² = 1/ζ(2) — classical (Basel problem / Mirsky 1947)
+- Q-sequences have upper density at most 6/π², achieved by the squarefree numbers themselves — van Doorn–Tao (2025), formalized in gallery entry `erdos-1102`
+
+### What's Still Open
+
+- Whether A = {2ⁿ − 1 : n ≥ 1} has property P (this problem)
+- Whether the factorial sequences n! ± 1 have property P — Erdős, listed in `erdos-1102` open questions
+- Behaviour of the variant properties P′ and P′∞ for these specific sequences
+
+### Our Goal
+
+Formalize a precise Lean 4 statement of the assertion "{2ⁿ − 1 : n ≥ 1} has property P", reusing the `propertyP` predicate and `powersOfTwoMinus1` definition already present in `Proofs/Erdos1102Problem.lean`, and either establish the implication toward it that is provable or record it as a stated conjecture with the supporting finiteness lemmas needed to attack it.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1102 | Parent entry defining properties P and Q; already contains `propertyP` and `powersOfTwoMinus1` | Squarefree density, axiomatized van Doorn–Tao Q result |
+| erdos-1103 | Squarefree sumsets — complementary squarefree-translate question | Sieve / density arguments |
+| erdos-969 | Error term in squarefree counting — precision of the 6/π² constant | Analytic squarefree distribution |
+| erdos-208 | Gaps between squarefree numbers — local squarefree distribution | Counting squarefree integers |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Direct finiteness via forbidden residues. For a fixed n, show that n + (2ᵏ − 1) is divisible by a fixed prime square for all but finitely many k by exploiting periodicity of 2ᵏ mod p².
+   - Why it might work: 2ᵏ is eventually periodic modulo any prime power, so n + 2ᵏ − 1 lands in a fixed residue class infinitely often; if that class is divisible by p² we get non-squarefreeness.
+   - Risk: Guaranteeing a single p² covering *all* large k for every n is not obviously possible; residues cycle but need not always hit a square divisor.
+
+2. **Approach B**: Reduce to a covering-system / Wieferich argument. Assemble finitely many prime squares p² whose associated residues of 2ᵏ cover every sufficiently large exponent, giving a covering system that forces n + 2ᵏ − 1 non-squarefree.
+   - Why it might work: Covering systems are the standard tool for exponential sequences (à la Erdős's covering congruences), and only finitely many exceptions need excluding.
+   - Risk: No covering system may exist for a given n; existence is exactly what is open, so this may hit the genuine mathematical obstruction.
+
+### Key Difficulties
+
+- Squarefreeness of n + 2ᵏ − 1 depends on square divisors p², whose behaviour under the map k ↦ 2ᵏ mod p² is delicate (order of 2 modulo p²).
+- The problem is genuinely open, so a full resolution is unlikely; the tractable target is a faithful formalization plus provable partial lemmas.
+
+### What Would a Proof Need?
+
+- Key lemma 1: periodicity of k ↦ 2ᵏ mod m and its multiplicative order, available from `ZMod` / `orderOf` in Mathlib.
+- Key lemma 2: a criterion linking a fixed square divisor p² of n + 2ᵏ − 1 to an arithmetic progression of exponents k.
+- Technical requirements: `Nat.Squarefree`, `Nat.factorization`, `ZMod`, and finiteness (`Set.Finite`) infrastructure.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The underlying number-theoretic question is unresolved even in the literature (listed open by van Doorn–Tao).
+- Covering-system techniques for 2ⁿ ± c are subtle and partial in general.
+- Mathlib provides `ZMod`, `orderOf`, and `Squarefree`, so a formal *statement* and small partial lemmas are within reach, but a full proof is a moonshot-adjacent effort.
+
+**Estimated Effort**:
+- Exploration: 2–4 days
+- If tractable: 2–4 weeks for meaningful partial results
+- If hard: unknown (matches open status)
+
+## References
+
+### Papers
+- van Doorn, Floris; Tao, Terence, "Squarefree properties P and Q", 2025 — resolves Erdős #1102 in general and lists 2ⁿ − 1 as an open special case
+- Erdős, Paul, "Problems and results in combinatorial number theory", 1981 (Astérisque 94) — original source of properties P and Q
+- Mirsky, Leon, "On the frequency of pairs of square-free numbers with a given difference", 1947 — squarefree-difference distribution underpinning the density 6/π²
+
+### Online Resources
+- https://erdosproblems.com/1102 — canonical statement and status of Erdős Problem #1102
+
+### Mathlib
+- Mathlib.NumberTheory.Squarefree — `Squarefree` predicate for the translate condition
+- Mathlib.Data.ZMod.Basic — modular reduction of 2ᵏ needed for periodicity arguments
+- Mathlib.GroupTheory.OrderOfElement — order of 2 modulo prime powers
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - squarefree
+  - analytic-number-theory
+  - density
+  - erdos
+related_proofs:
+  - erdos-1102
+  - erdos-1103
+  - erdos-969
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:19-07:00
+```

--- a/research/problems/erdos-1102-oq-01/state.md
+++ b/research/problems/erdos-1102-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1102-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:19-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1144-oq-03/knowledge.md
+++ b/research/problems/erdos-1144-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1144-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1144-oq-03/literature/README.md
+++ b/research/problems/erdos-1144-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1144-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1144-oq-03/problem.md
+++ b/research/problems/erdos-1144-oq-03/problem.md
@@ -1,0 +1,142 @@
+# Problem: Sharpness of the (log N)^{1+ε} factor in Atherfold's bound
+
+**Slug**: erdos-1144-oq-03
+**Created**: 2026-07-09T15:40:18-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{Atherfold (2025) proved } \Big|\sum_{m \le N} f(m)\Big| \ll \sqrt{N}\,(\log N)^{1+o(1)} \text{ a.s.; show the } (\log N)^{1+o(1)} \text{ factor cannot be replaced by } (\log N)^{K} \text{ for any fixed } K < \infty.
+$$
+
+### Plain Language
+
+Atherfold's 2025 theorem gives an almost-sure upper bound on the partial sums of a
+Rademacher random multiplicative function: the sum of $f(m)$ over $m \le N$ grows no faster
+than $\sqrt{N}$ times $(\log N)^{1+o(1)}$. The exponent $1 + o(1)$ hides a factor that tends
+to infinity slower than any fixed positive power of $\log N$. This problem asks whether that
+extra logarithmic factor is genuinely necessary in that exact shape — specifically, whether
+one could tighten Atherfold's bound so the log power stays below some fixed constant $K$
+instead of drifting up to $1 + o(1)$. Proving it cannot be reduced to a bounded power means
+showing the true growth really does require the $(\log N)^{1+o(1)}$ correction, so the $o(1)$
+in the exponent is not an artifact of Atherfold's method but a real feature of the extremal
+behaviour.
+
+### Why This Matters
+
+Pinning down the exact logarithmic correction in the upper bound is the crux of understanding
+the extreme fluctuations of random multiplicative functions. Harper's 2013 work showed the
+*typical* size is $\sqrt{N}/(\log\log N)^{3/4+o(1)}$ — smaller than $\sqrt{N}$ — while the
+*maximal* fluctuations are believed to be much larger, and Erdős Problem #1144 conjectures the
+limsup of $|S_f(N)|/\sqrt{N}$ diverges. Whether the maximum sits at $\sqrt{N}(\log N)^{1+o(1)}$
+or something with a bounded log power decides how sharp the pinch between the conjectured lower
+bound and Atherfold's upper bound really is. A negative answer (the factor cannot be reduced)
+would confirm $(\log N)^{1+o(1)}$ as the correct order of the maximum and connect random
+multiplicative functions to the theory of log-correlated fields, where a $(\log N)^{1}$-type
+factor is the signature of a branching-random-walk maximum.
+
+## Known Results
+
+### What's Already Proven
+
+- Atherfold's almost-sure upper bound $|S_f(N)| \ll \sqrt{N}(\log N)^{1+o(1)}$ — Atherfold, "Almost sure upper bounds for random multiplicative functions", 2025 (preprint); axiomatized in `Proofs/Erdos1144Problem.lean` as `atherfold_upper_bound`.
+- Harper's typical-size theorem $S_f(N) = \sqrt{N}/(\log\log N)^{3/4+o(1)}$ — Harper, arXiv:1302.7208, 2013.
+- Wintner's classical $O(N^{1/2+\varepsilon})$ almost-sure bound — Wintner, Duke Math. J. 11(2), 1944.
+- The growth-rate "pinch" theorem: conjecture + Atherfold's bound pin $|S_f(N)|$ between $C_1\sqrt{N}$ and $C_2\sqrt{N}(\log N)^{1+\varepsilon}$ — `conjecture_and_atherfold_pinch` in `Proofs/Erdos1144Problem.lean` (fully proved, 0 sorries).
+
+### What's Still Open
+
+- Whether the $(\log N)^{1+o(1)}$ factor is optimal or can be shrunk to a fixed power $(\log N)^K$.
+- The matching lower bound for the maximum: is there a.s. a subsequence $N_k$ with $|S_f(N_k)| \gg \sqrt{N_k}(\log N_k)^{1-o(1)}$?
+- The primary Erdős #1144 conjecture $\limsup |S_f(N)|/\sqrt{N} = \infty$ a.s.
+
+### Our Goal
+
+Formalize the $o(1)$-refinement question in Lean 4: state precisely the claim that no fixed
+$K$ yields an almost-sure bound $|S_f(N)| \ll \sqrt{N}(\log N)^K$, and build the logical scaffold
+that would derive a contradiction from such a bound using the (conjectured) maximal lower bound.
+The deliverable is a faithful statement plus the reduction lemmas connecting a hypothetical
+bounded-power bound to the maximal fluctuation conjecture, mirroring the axiomatize-and-pinch
+architecture already present for the base problem.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1144 | Parent problem; supplies definitions, Atherfold axiom, and pinch theorem | Filter.atTop, strong induction on prime factorization, triangle inequality |
+| erdos-520 | Partial sums restricted to squarefree integers; same multiplicative-sum theme | Multiplicative function estimates, growth-rate bounds |
+| prime-number-theorem | Governs the distribution of the primes defining $f$ | Analytic number theory, asymptotics |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Contradiction via the maximal lower bound.
+   - Why it might work: If one assumes a bounded-power bound $|S_f(N)| \ll \sqrt{N}(\log N)^K$ and combines it with an a.s. maximal lower bound of order $\sqrt{N}(\log N)^{1-o(1)}$ along a subsequence, taking $K$ below $1$ gives a direct contradiction; the whole difficulty concentrates in supplying the maximal lower bound.
+   - Risk: The maximal lower bound is itself open and would likely need to be axiomatized, so the "cannot be reduced" claim becomes conditional.
+
+2. **Approach B**: Second-moment / Gaussian-multiplicative-chaos comparison.
+   - Why it might work: Harper's methods connect $|S_f(N)|$ to critical multiplicative chaos, where the maximum of a log-correlated field carries a $(\log N)^{1}$ factor; transporting this heuristic gives the exact exponent and shows a bounded power is impossible.
+   - Risk: Multiplicative chaos and log-correlated maxima are far outside current Mathlib coverage, so full formalization is a moonshot.
+
+### Key Difficulties
+
+- The refinement is a statement about $o(1)$ in an exponent — Lean has no native notion of $o(1)$-in-the-exponent, so it must be encoded via "for all $K$, not $O(\sqrt N (\log N)^K)$".
+- The underlying maximal lower bound is unproven in the literature, forcing an axiomatized/conditional formalization.
+- Mathlib lacks multiplicative chaos, log-correlated field, and random-multiplicative-function infrastructure.
+
+### What Would a Proof Need?
+
+- Key lemma 1: A precise Lean statement "no fixed $K$ gives $|S_f(N)| \le C\sqrt{N}(\log N)^K$ eventually", quantifying over $K$ and $C$.
+- Key lemma 2: A reduction showing that such a bounded-power bound contradicts an a.s. maximal lower bound of order $\sqrt{N}(\log N)^{1-\varepsilon}$ along a subsequence.
+- Technical requirements: Real logarithm and power API (`Real.log`, `Real.rpow`), `Filter.atTop` frequently/eventually machinery, and an axiom capturing the maximal fluctuation lower bound.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The mathematical statement is open in the literature; only the formal scaffolding and a conditional reduction are realistically achievable.
+- Similar conditional formalizations exist here: the parent `erdos-1144` axiomatizes Atherfold's bound and proves a pinch theorem around it, providing a proven template.
+- Mathlib supplies the real analysis primitives (`Real.log`, `Real.rpow`, filters) but nothing on multiplicative chaos or random multiplicative functions.
+
+**Estimated Effort**:
+- Exploration: 2–4 days
+- If tractable: 1–2 weeks for the conditional statement plus reduction lemmas
+- If hard: unknown (unconditional resolution is a research-level open problem)
+
+## References
+
+### Papers
+- T. Atherfold, "Almost sure upper bounds for random multiplicative functions", 2025 (preprint) — source of the $(\log N)^{1+o(1)}$ upper bound.
+- A. J. Harper, "Moments of random multiplicative functions and truncated characteristic polynomials", arXiv:1302.7208, 2013 — typical size $\sqrt{N}/(\log\log N)^{3/4+o(1)}$.
+- A. Wintner, "Random factorizations and Riemann's hypothesis", Duke Math. J. 11(2), 1944 — foundational $O(N^{1/2+\varepsilon})$ bound.
+
+### Online Resources
+- https://erdosproblems.com/1144 — Erdős Problem #1144 catalogue entry and status.
+
+### Mathlib
+- `Mathlib.Analysis.SpecialFunctions.Log.Basic` — real logarithm needed to express $(\log N)^K$.
+- `Mathlib.Analysis.SpecialFunctions.Pow.Real` — real powers `Real.rpow` for the exponent $K$ and for $\sqrt{N}$.
+- `Mathlib.Order.Filter.AtTopBot` — `Filter.atTop` to encode "eventually" and "infinitely often".
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - probability
+  - analysis
+  - multiplicative-functions
+  - open
+related_proofs:
+  - erdos-1144
+  - erdos-520
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:18-07:00
+```

--- a/research/problems/erdos-1144-oq-03/state.md
+++ b/research/problems/erdos-1144-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1144-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:18-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1215-oq-02/knowledge.md
+++ b/research/problems/erdos-1215-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1215-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1215-oq-02/literature/README.md
+++ b/research/problems/erdos-1215-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1215-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1215-oq-02/problem.md
+++ b/research/problems/erdos-1215-oq-02/problem.md
@@ -1,0 +1,114 @@
+# Problem: Polynomial Path-Length Bounds for Cyclotomic Sublevel Sets
+
+**Slug**: erdos-1215-oq-02
+**Created**: 2026-07-09T15:40:18-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\exists\, C\!:\! \mathbb{R},\ \forall\, n\!:\!\mathbb{N},\ \forall\, P = \Phi_n \text{ (the } n\text{-th cyclotomic polynomial, normalized so } P(0)=\pm 1\text{)},\ \exists\, \gamma\!:\![0,1]\to\{z\in\mathbb{C} : |P(z)| < 1\},\ \gamma(0)=0,\ |P(\gamma(1))|=1,\ \operatorname{length}(\gamma) \le C\cdot n.
+$$
+
+### Plain Language
+
+Erdős Problem #1215 asks whether every polynomial $P$ with $P(0)=1$ and all roots on the unit circle admits a short path (length bounded by a constant times the degree) from the origin to the boundary of the sublevel set $\{|P(z)|<1\}$, staying inside that set. Mac Lane (1953) answered NO in general: he built "labyrinth" polynomials whose sublevel sets force arbitrarily long detours. This sub-question restricts attention to the special, highly structured family of **cyclotomic polynomials** $\Phi_n$ — whose roots are exactly the primitive $n$-th roots of unity, evenly spaced on the unit circle. The question: does the rigidity of cyclotomic root placement rule out labyrinths, so that a polynomial (in $n$) path-length bound *does* hold for this restricted class, even though it fails for arbitrary unit-circle-rooted polynomials?
+
+### Why This Matters
+
+Cyclotomic polynomials are the most arithmetically important family of unit-circle-rooted polynomials, central to number theory (Mahler measure, Lehmer's problem), Galois theory, and harmonic analysis. Mac Lane's negative resolution of #1215 relies on the freedom to cluster roots arbitrarily to sculpt a labyrinth; cyclotomic roots are, by contrast, rigidly and symmetrically distributed. Determining whether this rigidity forces bounded path complexity would sharpen the boundary between "wild" and "tame" polynomial lemniscates, and connect the topology of sublevel sets to the arithmetic of roots of unity. A positive answer would give the first natural sub-class of #1215 with a uniform bound; a negative answer would show even cyclotomic geometry is topologically wild.
+
+## Known Results
+
+### What's Already Proven
+
+- Mac Lane's negative resolution of Erdős #1215 — for arbitrary simply-connected compact $A\subset\{|z|<1\}$ there is a $P$ with $P(0)=1$, unit-circle roots, and $|P|>2$ on $A$ (Mac Lane, *Duke Math. J.*, 1953); see gallery proof `erdos-1215`.
+- Cyclotomic polynomial infrastructure in Mathlib: `Polynomial.cyclotomic n R`, its roots are the primitive $n$-th roots of unity, degree $\varphi(n)$, and irreducibility over $\mathbb{Q}$ — `Mathlib.RingTheory.Polynomial.Cyclotomic.Basic`.
+- Mahler measure of any monic polynomial with all roots on the unit circle equals $1$ ("flat" polynomials), including all $\Phi_n$ — classical (Kronecker's theorem context).
+
+### What's Still Open
+
+- Whether the sublevel set $\{|\Phi_n(z)|<1\}$ can host a Mac Lane–style labyrinth, or whether the symmetric spacing of primitive $n$-th roots of unity precludes it.
+- The exact form of the target bound (linear $C\cdot n$, logarithmic $C\cdot\log n$, or some other function of $n$ or $\varphi(n)$), which is left partially ambiguous by the original #1215 statement.
+
+### Our Goal
+
+Formalize a precise Lean 4 statement of the cyclotomic-restricted path-length question — defining the sublevel set of $\Phi_n$, a rectifiable path, its arc length, and the quantified bound — and prove the tractable building blocks (basic geometry of $\{|\Phi_n(z)|<1\}$ for small $n$, e.g. $n = 1, 2, 3, 4, 6$) rather than the full uniform theorem, which requires analytic infrastructure not yet in Mathlib.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1215 | Parent problem: general path-length question resolved negatively by Mac Lane; this restricts to cyclotomic $P$ | Polynomial lemniscates, approximation, labyrinth construction |
+| angle-trisection-cos-20-gal-oq-03-oq-01 | Also concerns polynomials with roots on the unit circle and cyclotomic-type structure | Cyclotomic/Galois computations |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Explicit small-$n$ analysis of $\{|\Phi_n(z)|<1\}$.
+   - Why it might work: For $n=1,2,3,4,6$ the cyclotomic polynomials are simple ($z-1$, $z+1$, $z^2+z+1$, $z^2+1$, $z^2-z+1$); their sublevel sets are elementary regions whose connectivity and path lengths can be computed directly and formalized.
+   - Risk: Small cases may all be trivially bounded, giving no insight into whether a labyrinth can appear as $n\to\infty$.
+
+2. **Approach B**: Symmetry/rigidity argument ruling out labyrinths for all $n$.
+   - Why it might work: Primitive $n$-th roots of unity are equidistributed and $\Phi_n$ has bounded coefficient growth (heights), which may bound the number and winding of lemniscate components, precluding Mac Lane's construction.
+   - Risk: The link between coefficient/root regularity and sublevel-set topology is subtle; a clean quantitative bound may not exist, or the labyrinth may reappear via high multiplicity of near-coincident level curves.
+
+### Key Difficulties
+
+- Mathlib lacks a developed theory of rectifiable paths with arc length in $\mathbb{C}$ tied to polynomial sublevel sets, and lacks polynomial-lemniscate topology results.
+- Distinguishing "cyclotomic geometry is tame" from "cyclotomic geometry is wild" requires either an explicit labyrinth-free proof or an explicit cyclotomic labyrinth family — neither is known.
+
+### What Would a Proof Need?
+
+- Key lemma 1: A formal definition of the sublevel set $\{z : |\Phi_n(z)| < 1\}$ and its boundary lemniscate $\{|\Phi_n(z)|=1\}$ in Lean via `Polynomial.eval` and `Complex.abs`.
+- Key lemma 2: A rectifiable-path type with arc-length functional (via `MeasureTheory.integral` of the derivative norm) and a lower/upper bound on lengths inside the sublevel set.
+- Technical requirements: connectivity/topology of the sublevel set, control of the number of components of $\{|\Phi_n(z)|=1\}$ in terms of $\varphi(n)$, and quantitative estimates on $|\Phi_n|$ from root equidistribution.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The full uniform statement inherits all the analytic infrastructure gaps that make the parent `erdos-1215` a stub (arc length, lemniscate topology, polynomial approximation).
+- Similar "tame vs. wild geometry" questions for structured polynomial families are genuinely open in the literature, so a complete resolution is a research-level target, not a formalization exercise.
+- Mathlib does provide solid cyclotomic-polynomial and complex-analysis basics, so small-$n$ sublevel-set computations and a precise formal statement are attainable near-term.
+
+**Estimated Effort**:
+- Exploration: 2–3 days to survey Mathlib path/measure/cyclotomic tools and draft a formal statement.
+- If tractable (small-$n$ / statement-only): 1–2 weeks for a formalized statement plus verified small cases.
+- If hard (full uniform theorem): unknown — likely requires new Mathlib analytic infrastructure and possibly new mathematics.
+
+## References
+
+### Papers
+- G. R. Mac Lane, "Concerning the uniformization of certain Riemann surfaces allied to the inverse-cosine and inverse-gamma surfaces," and related lemniscate work, *Duke Math. J.* (1953) — source of the negative resolution and labyrinth construction for #1215.
+- D. H. Lehmer, "Factorization of certain cyclotomic functions," *Ann. of Math.* (1933) — cyclotomic polynomial structure and Mahler measure context.
+
+### Online Resources
+- https://erdosproblems.com/1215 — canonical statement and status of the parent Erdős problem.
+- https://en.wikipedia.org/wiki/Cyclotomic_polynomial — properties of $\Phi_n$, roots, and degree $\varphi(n)$.
+
+### Mathlib
+- `Mathlib.RingTheory.Polynomial.Cyclotomic.Basic` — the cyclotomic polynomials `Polynomial.cyclotomic`, their roots and degree.
+- `Mathlib.Analysis.SpecialFunctions.Complex.Circle` and `Complex.abs` — modulus and unit-circle machinery for defining sublevel sets.
+- `Mathlib.MeasureTheory.Integral.IntervalIntegral` — arc-length / path-length integrals for a rectifiable-path formulation.
+
+## Metadata
+
+```yaml
+tags:
+  - erdos
+  - complex-analysis
+  - polynomial-theory
+  - topology
+  - unit-circle
+related_proofs:
+  - erdos-1215
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:18-07:00
+```

--- a/research/problems/erdos-1215-oq-02/state.md
+++ b/research/problems/erdos-1215-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1215-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:18-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-740-incomplete-01-oq-01/knowledge.md
+++ b/research/problems/erdos-740-incomplete-01-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-740-incomplete-01-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-740-incomplete-01-oq-01/literature/README.md
+++ b/research/problems/erdos-740-incomplete-01-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-740-incomplete-01-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-740-incomplete-01-oq-01/problem.md
+++ b/research/problems/erdos-740-incomplete-01-oq-01/problem.md
@@ -1,0 +1,120 @@
+# Problem: Rödl's Theorem (𝔪 = ℵ₀, r = 3) — Triangle-Free Subgraphs of Countably Infinite Chromatic Number
+
+**Slug**: erdos-740-incomplete-01-oq-01
+**Created**: 2026-07-09T15:40:17-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall\,G,\ \chi(G) = \aleph_0 \implies \exists\, H \subseteq G,\ \big(\text{$H$ is triangle-free}\big) \wedge \chi(H) = \aleph_0 .
+$$
+
+Here $G$ ranges over (possibly infinite) simple graphs, $\chi$ denotes the chromatic number as a cardinal, "triangle-free" means $H$ contains no $K_3$ (no odd cycle of length $\le 3$), and $H \subseteq G$ is a subgraph of $G$.
+
+### Plain Language
+
+Erdős Problem #740 asks: if a graph has chromatic number equal to an infinite cardinal 𝔪, and we fix a bound r, must the graph contain a subgraph of the same chromatic number 𝔪 that avoids all short odd cycles (odd cycles of length at most r)? Rödl proved the first genuine positive instance: when the chromatic number is exactly ℵ₀ (countably infinite) and r = 3, such a subgraph always exists. In other words, every graph whose chromatic number is countably infinite contains a *triangle-free* subgraph whose chromatic number is still countably infinite. This is the smallest nontrivial case of the general Erdős–Hajnal question, and it is the positive counterpart to the (settled, negative) bipartite/r = ∞ boundary case handled by the parent gallery entry.
+
+### Why This Matters
+
+The parent gallery proof `erdos-740-incomplete-01` settles the *negative* extreme of #740: the bipartite (r = ∞) case fails, because a bipartite graph has χ ≤ 2 and so can never realize a large chromatic number. That leaves the substantive *positive* content of #740 — the finite-r regime where subgraphs of full chromatic number really do exist — completely unformalized. Rödl's 1977 theorem is exactly the base case of that positive theory (𝔪 = ℵ₀, r = 3). Formalizing it would: (1) turn the gallery's coverage of #740 from "boundary-only" into genuine engagement with the hard direction; (2) exercise Mathlib's infinite-graph and cardinal-valued chromatic-number machinery on a real combinatorial construction rather than an elementary bound; and (3) provide reusable infrastructure (triangle-freeness, chromatic number as a cardinal, subgraph extraction) for the wider Erdős–Hajnal program on chromatic numbers of subgraphs.
+
+## Known Results
+
+### What's Already Proven
+
+- Bipartite (r = ∞) case of #740 fails — parent entry `erdos-740-incomplete-01` (`Proofs/Erdos740BipartiteIncomplete01.lean`): χ(bipartite) ≤ 2, so χ(G) > 2 admits no induced bipartite subgraph realizing χ(G).
+- Rödl (1977): a graph of chromatic number ℵ₀ contains a triangle-free subgraph of chromatic number ℵ₀ — the target theorem, proved on paper but not in Lean.
+- Monotonicity of χ under graph homomorphisms and `χ(G.induce s) ≤ χ(G)` — Mathlib `SimpleGraph.chromaticNumber_mono_of_hom` and the parent entry's `induce_chromaticNumber_le`.
+- χ(Kₙ) = n and the finite complete-graph witnesses — Mathlib `SimpleGraph.chromaticNumber_top`, used by the parent entry.
+
+### What's Still Open
+
+- The general Erdős #740 for arbitrary infinite 𝔪 and arbitrary finite r ≥ 3 remains open (Erdős listed it among problems he most wished to see solved).
+- No Lean formalization exists of Rödl's countable case, nor of the underlying construction extracting a triangle-free subgraph while preserving infinite chromatic number.
+
+### Our Goal
+
+Formalize, in Lean 4 over Mathlib, the single positive statement of Rödl's theorem for 𝔪 = ℵ₀ and r = 3: every simple graph G with chromatic number ℵ₀ admits a subgraph H that is triangle-free and still has chromatic number ℵ₀. We target this specific case only — not the general infinite-cardinal or larger-r versions, which stay open. A staged path (state the theorem, build the triangle-freeness and cardinal-χ scaffolding, then the extraction argument) is expected.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-740-incomplete-01 | Parent entry; settles the negative r = ∞ boundary case with real χ | χ monotone under homomorphisms, induced-subgraph bound, bipartite χ ≤ 2 |
+| erdos-740 | Original #740 formalization using a placeholder chromatic number | Cardinal-valued χ scaffolding, odd-cycle avoidance framing |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Direct formalization of Rödl's original construction — iteratively remove/reroute edges of triangles while tracking a lower bound on chromatic number.
+   - Why it might work: it follows the published proof and stays close to the combinatorial content.
+   - Risk: infinite bookkeeping (transfinite/inductive edge removal) is delicate to formalize; preserving χ = ℵ₀ across the construction is the crux and may need careful cardinal arithmetic.
+
+2. **Approach B**: Reduce to a Mathlib-friendly reformulation — express "χ = ℵ₀" via colorability failing for every finite palette, and extract the triangle-free subgraph as a suitable limit / subgraph selected by compactness-style reasoning.
+   - Why it might work: Mathlib has colorability and cardinal infrastructure; phrasing χ = ℵ₀ as "not Colorable n for all finite n, but Colorable ℵ₀" may make the χ lower bound tractable.
+   - Risk: the compactness/limit step for infinite graphs may not be directly available in Mathlib and could require substantial new supporting lemmas.
+
+### Key Difficulties
+
+- Preserving countably infinite chromatic number while deleting all triangles is the entire mathematical content; it is not an elementary bound.
+- Mathlib's chromatic-number API is strongest for finite/ℕ∞-valued χ; working with χ as a genuine cardinal ℵ₀ on infinite vertex types may expose gaps.
+
+### What Would a Proof Need?
+
+- Key lemma 1: a workable predicate for "triangle-free" (no `K₃` subgraph / no 3-clique) with lemmas relating it to subgraph passage.
+- Key lemma 2: a cardinal-valued chromatic-number lower bound that survives the triangle-removing construction (χ(H) ≥ ℵ₀).
+- Technical requirements: infinite-graph subgraph selection, cardinal arithmetic at ℵ₀, and a faithful encoding of Rödl's extraction step in Mathlib.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The result is a genuine (non-elementary) combinatorial theorem about infinite graphs, unlike the parent entry's elementary χ ≤ 2 bound.
+- Mathlib's infinite-graph and cardinal-χ tooling is thinner than its finite-graph coloring API, so supporting infrastructure will likely need to be built.
+- Related finite chromatic-number results are formalizable, but the transfinite extraction preserving χ = ℵ₀ has no direct Mathlib analogue.
+
+**Estimated Effort**:
+- Exploration: several days
+- If tractable: several weeks
+- If hard: unknown
+
+## References
+
+### Papers
+- Rödl, V., "On the chromatic number of subgraphs of a given graph", Proc. Amer. Math. Soc. 64 (1977), 370–371 — proves the 𝔪 = ℵ₀, r = 3 case (triangle-free subgraph of countable chromatic number).
+- Erdős, P., "On the combinatorial problems which I would most like to see solved", Combinatorica 1 (1981), 25–42 — lists #740 among Erdős's most-wanted problems.
+- Erdős, P. and Hajnal, A., "On chromatic number of graphs and set-systems", Acta Math. Acad. Sci. Hungar. 17 (1966), 61–99 — origin of the chromatic-subgraph question.
+
+### Online Resources
+- https://erdosproblems.com/740 — statement and status of Erdős Problem #740.
+
+### Mathlib
+- Mathlib.Combinatorics.SimpleGraph.Coloring — chromatic number, `chromaticNumber_mono_of_hom`, colorability.
+- Mathlib.Combinatorics.SimpleGraph.Clique — cliques and triangle (`K₃`) predicates for triangle-freeness.
+- Mathlib.SetTheory.Cardinal.Basic — cardinal arithmetic at ℵ₀ for the chromatic-number lower bound.
+
+## Metadata
+
+```yaml
+tags:
+  - erdos
+  - graph-theory
+  - chromatic-number
+  - triangle-free
+  - odd-cycles
+  - induced-subgraph
+  - research
+related_proofs:
+  - erdos-740-incomplete-01
+  - erdos-740
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T15:40:17-07:00
+```

--- a/research/problems/erdos-740-incomplete-01-oq-01/state.md
+++ b/research/problems/erdos-740-incomplete-01-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-740-incomplete-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T15:40:17-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/src/data/research/problems/beta-central-binomial-asymptotic-oq-01.json
+++ b/src/data/research/problems/beta-central-binomial-asymptotic-oq-01.json
@@ -1,0 +1,90 @@
+{
+  "slug": "beta-central-binomial-asymptotic-oq-01",
+  "title": "Can the bare equivalence be upgraded to an effective two-sided rate with explicit constants valid for all n?",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\exists\\, c_1, c_2 > 0,\\ \\forall n \\ge 1:\\quad c_1 \\cdot \\frac{\\sqrt{\\pi n}}{(2n+1)\\,4^{n}} \\le B(n+1, n+1) \\le c_2 \\cdot \\frac{\\sqrt{\\pi n}}{(2n+1)\\,4^{n}}, \\quad \\text{where } B(n+1,n+1) = 1/((2n+1)\\binom{2n}{n}) \\text{ and } c_1, c_2 \\text{ are explicit elementary constants.}",
+    "plain": "The parent entry proves only that the diagonal Beta value B(n+1,n+1) is asymptotically equivalent to sqrt(pi*n)/((2n+1)4^n): the ratio tends to 1 as n grows, but this gives no control at any finite n. This problem asks to upgrade that bare limit into an honest two-sided inequality with explicit numerical constants c1, c2 that sandwich the true value for every n >= 1.",
+    "whyMatters": [
+      "An asymptotic equivalence is qualitative; a two-sided effective bound is quantitative and directly usable at concrete n.",
+      "Explicit constants let one certify the Beta value's size in estimates for Catalan-number growth, random-walk return probabilities, and de Moivre-Laplace error terms.",
+      "It shows Mathlib's effective Stirling apparatus (the lower bound sqrt(pi) <= stirlingSeq n plus antitonicity) is strong enough to convert a pure IsEquivalent into a rate, a reusable pattern for other Stirling-derived asymptotics."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "betaDiag_isEquivalent (parent beta-central-binomial-asymptotic): the bare equivalence B(n+1,n+1) ~ sqrt(pi*n)/((2n+1)4^n), 0 axioms / 0 sorries.",
+      "beta-diag-effective-rate (sibling gallery entry) ANSWERS THIS AFFIRMATIVELY: factoring B(n+1,n+1) as leading term times ratioR n = stirlingSeq(n)^2/(sqrt(pi)*stirlingSeq(2n)), it proves sqrt(2*pi)/e <= ratioR n <= e^2/(2*pi), giving constants c1 ~ 0.922 and c2 ~ 1.176 valid for all n >= 1 (ratioR_ge, ratioR_le), 0 axioms / 0 sorries.",
+      "Mathlib Stirling.stirlingSeq: supplies stirlingSeq n -> sqrt(pi), the lower bound sqrt(pi) <= stirlingSeq n, and antitonicity stirlingSeq'_antitone."
+    ],
+    "open": [
+      "Sharpening the envelope [sqrt(2*pi)/e, e^2/(2*pi)] ~ [0.922, 1.176] toward the tight 1 + O(1/n) correction (pursued in beta-central-binomial-explicit-rate).",
+      "Whether the same effective-envelope method extends to off-diagonal Beta values B(a*n+1, b*n+1) with a != b."
+    ],
+    "goal": "Record and cross-reference the affirmative resolution supplied by beta-diag-effective-rate: an explicit two-sided rate for betaDiag(n) with elementary constants sqrt(2*pi)/e and e^2/(2*pi), valid for all n >= 1, obtained purely from Mathlib's stirlingSeq bounds with no new axioms."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Confirm and cross-reference how beta-diag-effective-rate turns the bare betaDiag equivalence into an explicit two-sided rate valid for all n >= 1.",
+    "blockers": [],
+    "nextAction": "Review beta-diag-effective-rate's ratioR_ge / ratioR_le and the exact stirlingSeq factorization to extract the constant-factor envelope and its numerical constants.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Extract the exact identity binom(2n,n)*sqrt(n)*stirlingSeq(n)^2 = stirlingSeq(2n)*4^n underlying the factorization.",
+      "Apply Mathlib's lower bound sqrt(pi) <= stirlingSeq n and antitonicity at n=1 to bound ratioR n on both sides.",
+      "Feed the interval [sqrt(2*pi)/e, e^2/(2*pi)] back through betaDiag_eq to obtain the effective two-sided rate for all n >= 1."
+    ],
+    "markdown": "# Knowledge Base: beta-central-binomial-asymptotic-oq-01\n\nThe open question from the parent entry beta-central-binomial-asymptotic asks whether the bare equivalence B(n+1,n+1) ~ sqrt(pi*n)/((2n+1)4^n) can be upgraded to an effective two-sided rate with explicit constants valid for all n. This has been answered affirmatively by the sibling gallery entry beta-diag-effective-rate.\n\n## Resolution\n\nThe correction factor ratioR n = stirlingSeq(n)^2/(sqrt(pi)*stirlingSeq(2n)) is pinned to [sqrt(2*pi)/e, e^2/(2*pi)] ~ [0.922, 1.176] using only Mathlib's stirlingSeq lower bound and antitonicity, yielding the effective envelope for betaDiag n valid at every n >= 1, with 0 axioms and 0 sorries.\n"
+  },
+  "tags": [
+    "analysis",
+    "asymptotics",
+    "beta-function",
+    "stirling",
+    "wallis",
+    "central-binomial",
+    "research"
+  ],
+  "relatedProofs": [
+    "beta-central-binomial-asymptotic",
+    "beta-integral-recurrence-oq-01-oq-01-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Analysis.SpecialFunctions.Stirling - stirlingSeq, its limit sqrt(pi), the lower bound, and antitonicity used to build the envelope.",
+      "Mathlib.Analysis.SpecialFunctions.Gamma.Beta - the complex Euler Beta integral that betaDiag is identified with."
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/BetaCentralBinomialAsymptotic.lean",
+      "filename": "BetaCentralBinomialAsymptotic.lean",
+      "lineCount": 148,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BetaCentralBinomialAsymptotic.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1-wip-01-oq-04.json
+++ b/src/data/research/problems/erdos-1-wip-01-oq-04.json
@@ -1,0 +1,121 @@
+{
+  "slug": "erdos-1-wip-01-oq-04",
+  "title": "Non-superincreasing DSS sets: Can the structural theory be extended to characterize all DSS sets, not just superincreasing ones?",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Characterize the family $\\mathcal{F}_{\\mathrm{DSS}} = \\{A \\subset \\mathbb{N} : \\forall S, T \\subseteq A,\\ \\sum_{s \\in S} s = \\sum_{t \\in T} t \\Rightarrow S = T\\}$ via an intrinsic combinatorial predicate $P(A)$ satisfying $P(A) \\iff A \\in \\mathcal{F}_{\\mathrm{DSS}}$, where $P$ is not merely the superincreasing condition $a_k > \\sum_{j<k} a_j$ nor a restatement of subset-sum injectivity.",
+    "plain": "A set of positive integers has distinct subset sums (DSS) when no two different subsets share a total. Superincreasing sets (each element bigger than the sum of the smaller ones, like 1,2,4,8) always have DSS, but the converse fails: {6,9,11,12,13} has DSS yet is not superincreasing. Can the structural theory be extended to characterize all DSS sets, through combinatorial properties beyond the sum bound and positivity, without directly invoking the subset-sum injectivity definition?",
+    "whyMatters": [
+      "The Erdős distinct-subset-sum problem carries a $500 prize and asks whether max(A) >= c*2^n for an absolute constant c; a real characterization of DSS sets would give a handle on the extremal (non-superincreasing) cases.",
+      "Optimal DSS constructions (Conway-Guy, max ~ 0.22*2^n) and the far-from-optimal powers of 2 (max = 2^(n-1)) are both superincreasing, so superincreasing-ness alone cannot explain optimality.",
+      "For n >= 4 the extremal maximum drops below 2^(n-1), so extremal DSS sets need not be superincreasing, limiting any argument that relies solely on the superincreasing extension lemma.",
+      "A verifiable sufficient class strictly larger than superincreasing would be a cleaner formalization target than raw subset-sum injectivity."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Superincreasing extension is sufficient for DSS (dss_superincreasing_extend, erdos-1-wip-01, verified).",
+      "Every DSS set consists of positive integers and cannot contain 0 (dss_elements_pos, not_dss_of_mem_zero).",
+      "DSS is hereditary and every singleton qualifies, so F_DSS is an independence system (dss_subset, dss_singleton).",
+      "Pigeonhole sum bound: 2^n <= sum(A) + 1, i.e. sum(A) >= 2^n - 1 (dss_sum_lower_bound, dss_sum_ge_pow_sub_one).",
+      "Counting bound max(A) >= (2^n - 1)/n and the Dubroff-Fox-Xu entropy bound max(A) >= sqrt(2/pi)*2^n/sqrt(n) (erdos-1 cluster)."
+    ],
+    "open": [
+      "Whether an intrinsic combinatorial predicate (not subset-sum injectivity restated) characterizes F_DSS exactly.",
+      "Whether a sufficient condition strictly weaker than superincreasing still certifies DSS and captures examples like {6,9,11,12,13}.",
+      "Whether the DSS independence system has additional axioms beyond hereditary, positivity, and the sum bound.",
+      "Whether such a characterization would sharpen the max-element bound toward the Erdős constant c."
+    ],
+    "goal": "OBSERVE-phase: catalogue small non-superincreasing DSS sets and formalize a candidate sufficient condition Q strictly weaker than superincreasing, proving Q(A) -> hasDistinctSubsetSums A together with a non-superincreasing witness satisfying Q."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Understand which combinatorial properties distinguish DSS from non-DSS sets beyond superincreasing, positivity, and the sum bound.",
+    "blockers": [],
+    "nextAction": "Enumerate small non-superincreasing DSS sets (e.g. {6,9,11,12,13}) and propose a relaxed sufficient predicate Q to formalize alongside a witness.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Enumerate n<=6 non-superincreasing DSS sets using Finset.powerset evaluation.",
+      "Draft a bounded-deficit relaxation of the superincreasing predicate and test it against enumerated sets.",
+      "Attempt a Lean lemma Q(A) -> hasDistinctSubsetSums A generalizing dss_superincreasing_extend.",
+      "Study F_DSS as an independence system to check for forbidden-configuration axioms."
+    ],
+    "markdown": "# Knowledge Base: erdos-1-wip-01-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nDSS = distinct subset sums (Erdős Problem #1). Superincreasing implies DSS but not conversely; {6,9,11,12,13} is a non-superincreasing DSS set. We seek an intrinsic combinatorial characterization (or a strictly-weaker sufficient condition) that does not restate subset-sum injectivity.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "additive-combinatorics",
+    "subset-sums",
+    "extremal-combinatorics",
+    "structural-theory",
+    "combinatorics",
+    "number-theory"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-1-wip-01",
+    "erdos-1-wip-01-oq-02",
+    "erdos-1-wip-01-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Algebra.BigOperators.Basic",
+      "Mathlib.Data.Nat.Log"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1Wip01.lean",
+      "filename": "Erdos1Wip01.lean",
+      "lineCount": 320,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1Wip01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1Wip01OQ02.lean",
+      "filename": "Erdos1Wip01OQ02.lean",
+      "lineCount": 252,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1Wip01OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos1Wip01OQ03.lean",
+      "filename": "Erdos1Wip01OQ03.lean",
+      "lineCount": 167,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1Wip01OQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1000-oq-04.json
+++ b/src/data/research/problems/erdos-1000-oq-04.json
@@ -1,0 +1,189 @@
+{
+  "slug": "erdos-1000-oq-04",
+  "title": "What is the measure (in the space of increasing sequences) of those with vanishing average?",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\mu\\bigl(\\{A = (n_1 < n_2 < \\cdots) : \\lim_{N\\to\\infty} \\tfrac{1}{N}\\sum_{k=1}^{N} \\tfrac{\\varphi_A(k)}{n_k} = 0\\}\\bigr) = \\; ?, \\text{ where } \\varphi_A(k) = |\\{1 \\le m \\le n_k : n_k/\\gcd(m,n_k) \\ne n_j \\text{ for all } j < k\\}| \\text{ and } \\mu \\text{ is a suitable measure on the space of strictly increasing positive-integer sequences.}",
+    "plain": "Erdős Problem #1000 asks whether some strictly increasing integer sequence A makes the Cesàro average of the 'new denominator density' φ_A(k)/n_k tend to zero; Haight showed such sequences exist. This follow-up asks a quantitative refinement: among all increasing sequences, how large is the set of those with vanishing average? We want the measure of that set under a natural measure on sequence space, deciding whether the Haight phenomenon is exceptional (measure zero) or typical (positive or full measure).",
+    "whyMatters": [
+      "Haight's construction proves vanishing-average sequences exist but does not reveal whether they are rare engineered constructions or a generic feature of increasing sequences.",
+      "Measuring the set distinguishes a delicate atypical phenomenon (measure zero) from a robust generic one (positive measure), sharpening the meaning of Erdős #1000's resolution.",
+      "The question connects Erdős #1000 to metric number theory (the Khinchin-Groshev framework Cassels used) and to the broad theme of averaging taming pointwise oscillation of arithmetic functions."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Haight's resolution: there exists an increasing sequence A with C_A(N) → 0 (axiom haight_resolution in Erdos1000Problem.lean).",
+      "Erdős' no-zero-limit: the pointwise ratio φ_A(k)/n_k never converges to 0 for any A (theorem erdos_no_zero_limit).",
+      "Erdős' dichotomy: liminf φ_A(k)/n_k = 0 implies limsup φ_A(k)/n_k = 1 (axiom erdos_dichotomy).",
+      "Density floor: φ_A(k) ≥ φ(n_k), hence φ_A(k)/n_k ≥ φ(n_k)/n_k (theorem phiA_ge_totient).",
+      "Fast-growth density floor: sufficiently fast-growing sequences keep φ_A(k)/n_k > 1/2 (theorem not_densityToZero_of_fast_growth)."
+    ],
+    "open": [
+      "Which measure μ on the space of increasing sequences makes the question well-posed (product/renewal measure on gaps, Cantor-style coding measure, etc.).",
+      "Whether the vanishing-average set has measure 0, measure 1, or an intermediate positive value under that μ.",
+      "Whether the answer depends on the growth regime imposed on the gaps n_{k+1} − n_k."
+    ],
+    "goal": "Formalize a measure-theoretic framework for the space of strictly increasing positive-integer sequences, prove measurability of the vanishing-average event {A : C_A(N) → 0}, and establish a first quantitative bound (e.g. measure zero under a fast-growth product measure via the formalized growth-floor lemmas)."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Choose a canonical measure on the space of strictly increasing integer sequences and establish measurability of the vanishing-Cesàro-average event.",
+    "blockers": [],
+    "nextAction": "Survey Mathlib MeasureTheory product-measure and Borel-measurability infrastructure and pick a coding of sequence space via the gap sequence.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Encode strictly increasing sequences via their gap sequence in a product space and fix a σ-algebra and measure μ.",
+      "Prove measurability of A ↦ C_A(N) for each N and of the event {A : C_A(N) → 0}.",
+      "Use the formalized growth-floor lemmas (not_densityToZero_of_fast_growth) to attempt a first measure-zero bound under a fast-growth product measure."
+    ],
+    "markdown": "# Knowledge Base: erdos-1000-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nQuantitative refinement of Erdős #1000: measure the set of increasing sequences whose generalized-totient Cesàro average vanishes. The answer depends on the choice of measure μ on sequence space, which must be fixed to make the question well-posed.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "number-theory",
+    "diophantine-approximation",
+    "totient-function",
+    "cesaro-averages"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-100",
+    "erdos-1000",
+    "erdos-1000-oq-02",
+    "erdos-1000-oq-03",
+    "erdos-1000-oq-03-oq-01",
+    "erdos-1000-oq-03-oq-01-oq-01",
+    "erdos-1000-oq-03-oq-02",
+    "erdos-1000-oq-03-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.MeasureTheory.Measure.Basic",
+      "Mathlib.MeasureTheory.Constructions.BorelSpace.Basic",
+      "Mathlib.Dynamics.Ergodic.Ergodic",
+      "Mathlib.Analysis.Nat.Totient"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1000OQ01.lean",
+      "filename": "Erdos1000OQ01.lean",
+      "lineCount": 247,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1000OQ01Aristotle.lean",
+      "filename": "Erdos1000OQ01Aristotle.lean",
+      "lineCount": 49,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/Erdos1000OQ02.lean",
+      "filename": "Erdos1000OQ02.lean",
+      "lineCount": 198,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos1000OQ03.lean",
+      "filename": "Erdos1000OQ03.lean",
+      "lineCount": 241,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos1000OQ03OQ01.lean",
+      "filename": "Erdos1000OQ03OQ01.lean",
+      "lineCount": 180,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1000OQ03OQ01OQ01.lean",
+      "filename": "Erdos1000OQ03OQ01OQ01.lean",
+      "lineCount": 170,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000OQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1000OQ03OQ02.lean",
+      "filename": "Erdos1000OQ03OQ02.lean",
+      "lineCount": 249,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000OQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos1000OQ03OQ03.lean",
+      "filename": "Erdos1000OQ03OQ03.lean",
+      "lineCount": 124,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000OQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos1000Problem.lean",
+      "filename": "Erdos1000Problem.lean",
+      "lineCount": 1154,
+      "theoremCount": 56,
+      "axiomCount": 2,
+      "defCount": 11,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1000Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1007-oq-03.json
+++ b/src/data/research/problems/erdos-1007-oq-03.json
@@ -1,0 +1,164 @@
+{
+  "slug": "erdos-1007-oq-03",
+  "title": "Computational complexity of determining graph dimension: is it NP-hard",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Is } \\mathrm{DIM}(G,d) := [\\dim(G) \\le d] \\in \\mathsf{NP\\text{-}hard}? \\quad \\dim(G) = \\min\\{d : \\exists f : V \\to \\mathbb{R}^d,\\ \\|f(u)-f(v)\\|_2 = 1\\ \\forall uv \\in E\\}",
+    "plain": "The dimension of a graph is the smallest Euclidean dimension in which it embeds with every edge a unit-length segment. Is deciding whether dim(G) <= d (equivalently, computing the dimension) NP-hard? The question reduces to whether a system of quadratic distance equations, one per edge, has a real solution.",
+    "whyMatters": [
+      "The extremal values of graph dimension are known (e.g. 9 edges minimum for dimension 4, uniquely K_{3,3}), but the computational cost of determining an arbitrary graph's dimension is unresolved.",
+      "NP-hardness would explain why general closed-form extremal answers are elusive, and would tie graph dimension to the well-studied complexity of geometric realizability and rigidity problems.",
+      "The problem is a natural instance of the existential theory of the reals, linking combinatorial graph theory to real algebraic geometry and complexity theory."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "dim(K_{n+1}) = n via regular simplex embeddings; extremal edge counts e(4)=9 (House 2013) and e(5)=15 (Chaffee-Noble 2016).",
+      "Many geometric realizability problems, including unit-distance representation, are exists-R-complete and hence NP-hard (Schaefer 2009).",
+      "Embeddability of weighted graphs in R^k is strongly NP-hard (Saxe 1979)."
+    ],
+    "open": [
+      "Whether the decision problem dim(G) <= d is NP-hard, and whether it even lies in NP given that certificates may require irrational high-precision coordinates.",
+      "The exact complexity class (NP-complete vs exists-R-complete) and whether hardness holds for fixed d versus d part of the input."
+    ],
+    "goal": "Formalize a precise decision-problem encoding of graph dimension in Lean 4, relate it to real-solvability of the per-edge quadratic distance system, and provide a skeleton reduction from a known hard geometric problem, leaving the hardness theorem itself as the open target."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Encode graphDimensionDecision as feasibility of the quadratic unit-distance equation system and survey reduction targets.",
+    "blockers": [],
+    "nextAction": "Survey Mathlib Euclidean-distance and simple-graph infrastructure and known hardness results for geometric realizability to identify a reduction source.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Define a decision-problem encoding graphDimensionDecision (G, d) in Lean.",
+      "State the equivalence between dim(G) <= d and real solvability of the edge-distance equation system.",
+      "Identify an exists-R-hard or NP-hard source problem (e.g. unit-distance recognition) to reduce from.",
+      "Sketch a rigidity gadget that forces a target graph to realize a prescribed dimension."
+    ],
+    "markdown": "# Knowledge Base: erdos-1007-oq-03\n\nInsights accumulated during research on the computational complexity of graph dimension.\n\n---\n\n## Problem Understanding\n\nDeciding dim(G) <= d is equivalent to asking whether the polynomial system { ||f(u)-f(v)||^2 = 1 : uv in E } has a real solution with image in R^d. This is natively an existential-theory-of-the-reals instance.\n\n---\n\n## Insights\n\n- NP membership is not obvious: optimal embeddings may need high-degree algebraic coordinates.\n- Distinguishing 'embeddable in <= d' from 'dimension exactly d' adds a universally quantified (co-NP-flavored) condition.\n\n---\n\n## Dead Ends\n\n(None recorded yet.)\n"
+  },
+  "tags": [
+    "erdos",
+    "graph-theory",
+    "geometry",
+    "dimension",
+    "unit-distance",
+    "embedding",
+    "complexity"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-100",
+    "erdos-1007",
+    "erdos-1007-oq-01",
+    "erdos-1007-oq-01-oq-01",
+    "erdos-1007-oq-04",
+    "erdos-1007-oq-05",
+    "erdos-1007-oq-05-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Analysis.InnerProductSpace.EuclideanDist",
+      "Mathlib.Combinatorics.SimpleGraph.Basic"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1007OQ01.lean",
+      "filename": "Erdos1007OQ01.lean",
+      "lineCount": 1338,
+      "theoremCount": 63,
+      "axiomCount": 0,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1007OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1007OQ01Aristotle.lean",
+      "filename": "Erdos1007OQ01Aristotle.lean",
+      "lineCount": 111,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1007OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/Erdos1007OQ01OQ01.lean",
+      "filename": "Erdos1007OQ01OQ01.lean",
+      "lineCount": 389,
+      "theoremCount": 32,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1007OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1007OQ04.lean",
+      "filename": "Erdos1007OQ04.lean",
+      "lineCount": 315,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1007OQ04.lean"
+    },
+    {
+      "path": "Proofs/Erdos1007OQ05.lean",
+      "filename": "Erdos1007OQ05.lean",
+      "lineCount": 142,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1007OQ05.lean"
+    },
+    {
+      "path": "Proofs/Erdos1007OQ05OQ01.lean",
+      "filename": "Erdos1007OQ05OQ01.lean",
+      "lineCount": 110,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1007OQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1007Problem.lean",
+      "filename": "Erdos1007Problem.lean",
+      "lineCount": 130,
+      "theoremCount": 3,
+      "axiomCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1007Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1011-oq-02.json
+++ b/src/data/research/problems/erdos-1011-oq-02.json
@@ -1,0 +1,79 @@
+{
+  "slug": "erdos-1011-oq-02",
+  "title": "Is c = 1 (the 'natural' guess) in g(r) ~ c·r² log r?",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Determine whether g(r) = (1 + o(1)) \\cdot r^2 \\log r, i.e. whether the constant c with g(r) \\sim c \\cdot r^2 \\log r equals 1, where g(r) appears in the Simonovits asymptotic f_r(n) = n^2/4 - g(r) \\cdot n/2 + O(1).",
+    "plain": "In Erdős Problem #1011, f_r(n) is the least edge count forcing a triangle in an n-vertex graph with chromatic number at least r. Simonovits showed f_r(n) = n²/4 - g(r)·n/2 + O(1). The quantity g(r) grows like c·r² log r, but only the bounds 1/2 ≤ c ≤ 2 are known. This problem asks whether the natural guess c = 1 is correct.",
+    "whyMatters": [
+      "Fixes the last quantitative gap in a sixty-year-old extremal program relating edge count, chromatic number, and triangle existence.",
+      "The constant c is tied to the asymptotics of the off-diagonal Ramsey number R(3,k), so determining c sharpens both extremal graph theory and Ramsey theory.",
+      "Resolves a factor-of-four gap left open since Simonovits's 1966 work."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Simonovits asymptotic f_r(n) = n²/4 - g(r)·n/2 + O(1) (Simonovits, 1966).",
+      "Lower bound g(r) ≥ (1/2 - o(1))·r² log r (Davies & Illingworth, 2022).",
+      "Upper bound g(r) ≤ (2 + o(1))·r² log r (Hefetz, Horn, King & Pfender, 2025).",
+      "Exact small cases f_2, f_3, f_4 (Turán; Erdős-Gallai; Ren-Wang-Wang-Yang)."
+    ],
+    "open": [
+      "Whether the leading constant c in g(r) ~ c·r² log r equals 1.",
+      "Whether the truth is the lower value 1/2, the upper value 2, or some intermediate constant.",
+      "Any matching pair of bounds that would pin c exactly."
+    ],
+    "goal": "Formalize the conjecture c = 1 in Lean 4 alongside the surrounding bounds 1/2 ≤ c ≤ 2, so the claim is expressible and its consistency with known results is machine-checked. Resolving c itself is open research and out of scope."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Formalize the statement that g(r) ~ c·r² log r with c = 1 as a conjecture, bracketed by the known 1/2 and 2 bounds.",
+    "blockers": [],
+    "nextAction": "Survey Mathlib asymptotic (IsLittleO) and filter (liminf/limsup) tooling and mirror the g(r) definition from Proofs/Erdos1011Problem.lean.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Locate the g(r) and simonovits_asymptotic definitions in Proofs/Erdos1011Problem.lean.",
+      "State the lower and upper asymptotic bounds implying 1/2 ≤ liminf and limsup ≤ 2.",
+      "Express c = 1 as a midpoint conjecture using Filter and Asymptotics infrastructure."
+    ],
+    "markdown": "# Knowledge Base: erdos-1011-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThe constant c is the leading coefficient in g(r) ~ c·r² log r, where g(r) is the Simonovits quantity in f_r(n) = n²/4 - g(r)·n/2 + O(1). Known bounds give 1/2 ≤ c ≤ 2; the conjecture asks whether c = 1.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "graph-theory",
+    "chromatic-number",
+    "triangles",
+    "turan-type",
+    "extremal-graph-theory",
+    "open-problem"
+  ],
+  "relatedProofs": [
+    "erdos-1011"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Analysis.Asymptotics.Asymptotics",
+      "Mathlib.Order.Filter.Basic"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": []
+}

--- a/src/data/research/problems/erdos-1014-oq-03.json
+++ b/src/data/research/problems/erdos-1014-oq-03.json
@@ -1,0 +1,131 @@
+{
+  "slug": "erdos-1014-oq-03",
+  "title": "Does R(k,l+1) - R(k,l) have a meaningful asymptotic formula for fixed k",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Fix } k \\ge 3. \\text{ Determine whether } \\Delta_l(k) := R(k,l+1) - R(k,l) \\text{ satisfies } \\Delta_l(k) \\sim g_k(l) \\text{ for some explicit } g_k \\text{ as } l \\to \\infty.",
+    "plain": "For a fixed first argument k, look at how much the Ramsey number R(k,l) jumps when l increases by one: the increment R(k,l+1) - R(k,l). This question asks whether that increment has a clean asymptotic formula (some explicit function g_k(l) it is asymptotically equal to) rather than growing erratically as l grows.",
+    "whyMatters": [
+      "An asymptotic for the increment is strictly stronger than the ratio-convergence statement of Erdős Problem #1014: it pins down the local growth rate of the Ramsey function, not just that it grows smoothly.",
+      "It would sharply constrain any conjectured closed form for R(k,l); for k=3 the expectation is Δ_l(3) ~ c·l/log l, matching R(3,l) ~ c·l²/log l.",
+      "It connects Ramsey growth to finite-difference/discrete-derivative techniques and gives a concrete quantitative target often easier to attack than a full closed-form asymptotic."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Erdős–Szekeres upper bound R(k,l) ≤ C(k+l-2, k-1), giving polynomial growth O(l^{k-1}) for fixed k (diagonal_ramsey_upper).",
+      "Recurrence R(k,l+1) ≤ R(k,l) + R(k-1,l+1), hence increment bound Δ_l(k) ≤ R(k-1,l+1); for k=3, Δ_l(3) ≤ l+1 (increment_bound_general, increment_bound_k3).",
+      "Tight order of magnitude R(3,l) = Θ(l²/log l) from AKS upper and Kim/Shearer lower bounds (R3_asymptotic_bounds).",
+      "Monotonicity R(k,l) ≤ R(k,l+1), so Δ_l(k) ≥ 0 (ramsey_monotone_left)."
+    ],
+    "open": [
+      "Whether Δ_l(3) = R(3,l+1) - R(3,l) has an asymptotic formula (conjecturally ~ c·l/log l); open because the implied constants in the Θ(l²/log l) bounds differ.",
+      "Whether any explicit g_k(l) describes Δ_l(k) for fixed k ≥ 4, where even the order of magnitude of R(k,l) is unknown.",
+      "Whether the increment is monotone or eventually smooth in l rather than oscillating."
+    ],
+    "goal": "Formalize the structural consequences: prove that a power-law asymptotic R(k,l) ~ c_k·l^{k-1}/(log l)^{k-2} would force Δ_l(k) ~ (k-1)·c_k·l^{k-2}/(log l)^{k-2}, and relate this increment asymptotic to the already-formalized ratio and difference reformulations of Erdős #1014."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Understand the increment Δ_l(k) = R(k,l+1) - R(k,l) and how a power-law asymptotic for R(k,l) transfers to an asymptotic for the increment.",
+    "blockers": [],
+    "nextAction": "Review the GrowthRatioHelpers real-analysis lemmas in Erdos1014Problem.lean and draft the finite-difference expansion for a power-law-with-log function.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Formalize the real-analysis lemma: g ~ c·l^a/(log l)^b implies g(l+1) - g(l) ~ a·c·l^{a-1}/(log l)^b.",
+      "Prove the conditional increment asymptotic Δ_l(k) ~ (k-1)·c_k·l^{k-2}/(log l)^{k-2} from the power-law hypothesis on R(k,l).",
+      "Relate the increment asymptotic to ratio_equiv_difference and ratio_from_asymptotics in the parent file.",
+      "Document the constant-matching obstruction that keeps the k=3 case open."
+    ],
+    "markdown": "# Knowledge Base: erdos-1014-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThis is an open question spun off from Erdős Problem #1014. The parent asks whether R(k,l+1)/R(k,l) → 1; this asks the stronger question of whether the raw increment Δ_l(k) = R(k,l+1) - R(k,l) has a meaningful asymptotic formula for fixed k.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "graph-theory",
+    "ramsey-theory",
+    "combinatorics",
+    "asymptotics",
+    "open"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-101",
+    "erdos-1014",
+    "erdos-1014-oq-01",
+    "erdos-1014-oq-02",
+    "erdos-1014-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Analysis.Asymptotics.AsymptoticEquivalent",
+      "Mathlib.Order.Filter.Basic",
+      "Mathlib.Topology.Algebra.Order.Tendsto"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1014OQ01.lean",
+      "filename": "Erdos1014OQ01.lean",
+      "lineCount": 368,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1014OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1014OQ02.lean",
+      "filename": "Erdos1014OQ02.lean",
+      "lineCount": 187,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1014OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos1014OQ04.lean",
+      "filename": "Erdos1014OQ04.lean",
+      "lineCount": 211,
+      "theoremCount": 2,
+      "axiomCount": 2,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1014OQ04.lean"
+    },
+    {
+      "path": "Proofs/Erdos1014Problem.lean",
+      "filename": "Erdos1014Problem.lean",
+      "lineCount": 484,
+      "theoremCount": 15,
+      "axiomCount": 12,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1014Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1023-oq-04.json
+++ b/src/data/research/problems/erdos-1023-oq-04.json
@@ -1,0 +1,186 @@
+{
+  "slug": "erdos-1023-oq-04",
+  "title": "Union-Free Extremal Bounds for Multisets and Infinite Families",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "F_{\\text{multi}}(n, r) \\;=\\; \\max \\{\\, |\\mathcal{F}| : \\mathcal{F} \\subseteq \\{0,1,\\dots,r\\}^{[n]},\\ \\text{no } A \\in \\mathcal{F} \\text{ is the multiset union of other members} \\,\\}",
+    "plain": "Erdős Problem #1023 concerns *union-free* families of subsets of $\\{1,\\dots,n\\}$: collections in which no set equals the union of other members. Its answer is exact and clean — the maximum size is $F(n) = \\binom{n}{\\lfloor n/2 \\rfloor}$, achieved by the middle layer, with asymptotics $F(n) \\sim \\sqrt{2/\\pi}\\,\\cdot 2^n/\\sqrt{n}$. This open question asks how that story changes when subsets are replaced by *multisets* (elements may appear with multiplicity up to $r$) or when the ground set is *infinite*. In both settings the classical antichain/Sperner machinery no longer applies verbatim, and we want to know whether a comparable extremal formula and matching asymptotic can be recovered.",
+    "whyMatters": [
+      "Isolates which parts of the Erdős–Kleitman answer are intrinsic to the Boolean lattice versus artifacts of finiteness.",
+      "Connects union-free extremal theory to graded-poset Sperner theory and to Sidon/dissociated-set phenomena in additive combinatorics.",
+      "The subset case is already formally verified in the gallery, giving a rigorous springboard for the generalization."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Subset case: F(n) = C(n, floor(n/2)), Erdős–Kleitman (1968), formalized as unionFreeMax_eq_middle in Proofs/Erdos1023Problem.lean.",
+      "Every antichain is union-free and the middle layer is a maximum antichain (Sperner 1928), formalized as antichain_unionFree and middleLayer_antichain.",
+      "Asymptotic F(n) ~ sqrt(2/pi) * 2^n / sqrt(n) via Stirling, formalized as unionFreeMax_asymptotic.",
+      "Subset result also follows from Problem #447 (2-union-free) since union-free is 2-union-free (Hunter's observation)."
+    ],
+    "open": [
+      "Exact value or growth rate of the multiset extremal function F_multi(n, r) for r >= 2.",
+      "Whether an infinite ground set admits a finite extremal invariant or requires density/measure refinements.",
+      "Which lemmas of the Erdős–Kleitman upper-bound argument survive passage to {0,...,r}^{[n]} or to P(Omega) with Omega infinite."
+    ],
+    "goal": "Formalize F_multi(n, r) in Lean 4, prove the rank-antichain lower bound on the graded lattice {0,...,r}^{[n]}, and settle the base cases r=1 (recovering the subset theorem) and r=2, documenting whether the upper bound generalizes or remains an open gap."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Model multisets as the graded lattice {0,...,r}^{[n]} and determine whether the middle-rank antichain gives a tight union-free extremal bound.",
+    "blockers": [],
+    "nextAction": "Survey Mathlib antichain and Multiset infrastructure, then formalize the rank-antichain lower bound and check the r=1 case against the existing subset theorem.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Define the multiset union-free extremal function F_multi(n, r) over {0,...,r}^{[n]}.",
+      "Prove that multiset union strictly increases total degree, so rank-antichains are union-free (lower bound).",
+      "Investigate a Sperner-type / LYM inequality for the graded lattice {0,...,r}^{[n]}.",
+      "Assess whether the Erdős–Kleitman upper-bound argument transfers or must be axiomatized as an open gap."
+    ],
+    "markdown": "# Knowledge Base: erdos-1023-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "set-families",
+    "erdos",
+    "extremal-combinatorics",
+    "antichains"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-102",
+    "erdos-1023",
+    "erdos-1023-oq-01",
+    "erdos-1023-oq-01-oq-01",
+    "erdos-1023-oq-01-problem",
+    "erdos-1023-oq-02",
+    "erdos-1023-oq-03",
+    "erdos-1023-oq-04",
+    "erdos-1023-oq-05"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "lastUpdate": "2026-07-09T22:44:27.678Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1023InterFree.lean",
+      "filename": "Erdos1023InterFree.lean",
+      "lineCount": 327,
+      "theoremCount": 25,
+      "axiomCount": 0,
+      "defCount": 11,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1023InterFree.lean"
+    },
+    {
+      "path": "Proofs/Erdos1023OQ01.lean",
+      "filename": "Erdos1023OQ01.lean",
+      "lineCount": 661,
+      "theoremCount": 37,
+      "axiomCount": 1,
+      "defCount": 19,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1023OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1023OQ01OQ01.lean",
+      "filename": "Erdos1023OQ01OQ01.lean",
+      "lineCount": 201,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1023OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1023OQ01Problem.lean",
+      "filename": "Erdos1023OQ01Problem.lean",
+      "lineCount": 245,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1023OQ01Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1023OQ03.lean",
+      "filename": "Erdos1023OQ03.lean",
+      "lineCount": 220,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1023OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos1023OQ04.lean",
+      "filename": "Erdos1023OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1023OQ04.lean"
+    },
+    {
+      "path": "Proofs/Erdos1023OQ05.lean",
+      "filename": "Erdos1023OQ05.lean",
+      "lineCount": 157,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1023OQ05.lean"
+    },
+    {
+      "path": "Proofs/Erdos1023Problem.lean",
+      "filename": "Erdos1023Problem.lean",
+      "lineCount": 367,
+      "theoremCount": 17,
+      "axiomCount": 5,
+      "defCount": 14,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1023Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1023ProblemOQ03.lean",
+      "filename": "Erdos1023ProblemOQ03.lean",
+      "lineCount": 440,
+      "theoremCount": 21,
+      "axiomCount": 0,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1023ProblemOQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1038-oq-01.json
+++ b/src/data/research/problems/erdos-1038-oq-01.json
@@ -1,0 +1,110 @@
+{
+  "slug": "erdos-1038-oq-01",
+  "title": "What is the exact value of the infimum sublevel-set measure (Erdős #1038)?",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\inf_{f} \\left| \\{ x \\in \\mathbb{R} : |f(x)| < 1 \\} \\right| = ?, \\quad f(x) = \\prod_{i=1}^{n} (x - r_i),\\ r_i \\in [-1,1],\\ n \\ge 1, \\text{ with } 2^{4/3} - 1 \\approx 1.519 \\le \\inf_f \\le 1.835.",
+    "plain": "For monic polynomials whose roots all lie in [-1,1], the sublevel set {x : |f(x)| < 1} has some total length. Tao proved in 2025 that the largest possible length is 2√2. The smallest possible length — the infimum — remains open, known only to lie between about 1.519 and 1.835. The goal is its exact value.",
+    "whyMatters": [
+      "Completes the metric picture of polynomial sublevel sets started by Erdős–Herzog–Piranian (1958) and continued by Tao's 2025 supremum result.",
+      "Connects polynomial approximation on [-1,1] to logarithmic potential theory, equilibrium measures, and transfinite diameter.",
+      "Feeds into the sibling Erdős problems (#1039–#1046) on lemniscate geometry and disc containment."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Supremum equals 2√2 for monic polynomials with all roots in [-1,1] (Tao, 2025).",
+      "sup ≤ 2√2 for roots in {-1,1} and inf < 2 via families like (x+1)(x-1)^3 (Erdős–Herzog–Piranian, 1958).",
+      "Lower bound inf ≥ 2^(4/3) - 1 ≈ 1.519 from potential-theoretic estimates."
+    ],
+    "open": [
+      "The exact value of inf_f |{x : |f(x)| < 1}| within [1.519, 1.835].",
+      "Whether the infimum is attained by an explicit polynomial or only realized as a limit of a polynomial family."
+    ],
+    "goal": "Determine (or tightly bound) the exact value of the infimum, narrowing the [1.519, 1.835] gap with an explicit witness and formalizing the resulting measure estimate in Lean 4."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Understand the sublevel-set measure for monic polynomials with roots in [-1,1] and the source of the current infimum bounds 2^(4/3)-1 ≤ inf ≤ 1.835.",
+    "blockers": [],
+    "nextAction": "Survey explicit polynomial families (x+1)^a (x-1)^b and Chebyshev-type combinations to compute their sublevel-set measures and probe the upper bound.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [
+      "No logarithmic capacity, equilibrium measure, or transfinite diameter theory in Mathlib for potential-theoretic lower bounds."
+    ],
+    "nextSteps": [
+      "Compute |{x : |f(x)| < 1}| explicitly for the family (x+1)^a (x-1)^b and minimize over parameters.",
+      "Investigate whether a potential-theoretic argument can raise the lower bound above 2^(4/3) - 1.",
+      "Formalize a Lebesgue-measure estimate for the best explicit witness using MeasureTheory.volume over ENNReal."
+    ],
+    "markdown": "# Knowledge Base: erdos-1038-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThe infimum of interest is inf_f |{x ∈ ℝ : |f(x)| < 1}| over non-constant monic polynomials f with all roots in [-1,1]. Tao (2025) settled the supremum (2√2); the infimum is open with bounds 2^(4/3) - 1 ≈ 1.519 ≤ inf ≤ 1.835.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "measure-theory",
+    "polynomials",
+    "potential-theory",
+    "real-analysis"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-103",
+    "erdos-1038"
+  ],
+  "references": {
+    "papers": [
+      "P. Erdős, G. Herzog, G. Piranian, Metric properties of polynomials, J. d'Analyse Math. 6 (1958), 125–148.",
+      "T. Tao, Sublevel set measure for monic polynomials, arXiv (2025).",
+      "T. Ransford, Potential Theory in the Complex Plane, Cambridge University Press (1995)."
+    ],
+    "urls": [
+      "https://erdosproblems.com/1038"
+    ],
+    "mathlib": [
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.Algebra.Polynomial.Monic",
+      "Mathlib.Topology.Instances.ENNReal"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1038Problem.lean",
+      "filename": "Erdos1038Problem.lean",
+      "lineCount": 94,
+      "theoremCount": 0,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1038Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1038WIP01.lean",
+      "filename": "Erdos1038WIP01.lean",
+      "lineCount": 369,
+      "theoremCount": 21,
+      "axiomCount": 0,
+      "defCount": 9,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1038WIP01.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -1,0 +1,128 @@
+{
+  "slug": "erdos-1039-oq-05",
+  "title": "How does ρ(f) relate to the transfinite diameter of the root set and to the logarithmic capacity of the lemniscate complement?",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\rho(f) = \\sup\\{r > 0 : \\exists c \\in \\mathbb{C},\\ B(c,r) \\subseteq \\{z : |f(z)| < 1\\}\\},\\quad f(z)=\\prod_{i=1}^{n}(z-z_i),\\ |z_i|\\le 1. \\text{ Relate } \\rho(f) \\text{ to the transfinite diameter } d(\\{z_i\\}) \\text{ and to } \\operatorname{cap}(\\{z : |f(z)|\\ge 1\\}).",
+    "plain": "For a monic polynomial with all roots in the closed unit disc, ρ(f) is the radius of the largest disc fitting inside the lemniscate interior {|f(z)| < 1}. Determine explicit quantitative relations between ρ(f), the transfinite diameter of the root multiset, and the logarithmic capacity of the complement {|f(z)| ≥ 1}.",
+    "whyMatters": [
+      "Recasts the open Erdős–Herzog–Piranian conjecture ρ(f) ≫ 1/n as a potential-theoretic (capacity) inequality.",
+      "Capacity and Green's functions are exactly the tools behind Pommerenke's 1/(2en²) bound and the KLR 2025 area method, so a clean relation could remove the residual √(log n) gap.",
+      "Connects Problem 1039 directly to Problem 1040 (transfinite diameter) and Problem 1038 (sublevel-set measure)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Pommerenke (1961): ρ(f) ≥ 1/(2en²) via Green's-function/Koebe estimates (capacity-driven), axiomatized as pommerenke_lower.",
+      "KLR (2025): area({|f|<1}) ≥ π/(n² log n), hence ρ(f) ≥ c/(n√log n), axiomatized as klr_area_bound and klr_lower.",
+      "Fekete–Szegő: transfinite diameter, logarithmic capacity, and Chebyshev constant coincide; monic degree-n lemniscate {|f|≤1} has capacity 1.",
+      "Benchmark ρ(zⁿ−1) ≤ π/(2n) fixes the target rate Θ(1/n)."
+    ],
+    "open": [
+      "Whether ρ(f) admits a two-sided bound purely in terms of d({z_i}) and cap({|f|≥1}), uniformly in n.",
+      "Whether transfinite diameter of the root set alone forces ρ(f) ≥ c/n, or whether spacing beyond capacity is essential.",
+      "The main conjecture ρ(f) ≫ 1/n, including removal of the √(log n) factor."
+    ],
+    "goal": "Formalize transfinite diameter of the root multiset and logarithmic capacity of the lemniscate complement in the Erdos1039 framework, and state the quantitative links ρ(f) ≳ g(d, cap) as theorems where provable and axioms where they cite the literature."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Define transfinite diameter of the root multiset and logarithmic capacity of {|f|≥1}, then state their relationship to ρ(f).",
+    "blockers": [],
+    "nextAction": "Survey Mathlib for any capacity/transfinite-diameter API and choose between building definitions from scratch or axiomatizing them, mirroring the pommerenke_lower/klr_area_bound pattern in Erdos1039Problem.lean.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Locate any logarithmic-capacity or transfinite-diameter definitions in Mathlib (expected: none).",
+      "Formalize d({z_i}) via the finite discrete spread ∏_{i<j}|z_i−z_j|^{2/(n(n-1))}.",
+      "Formalize logarithmic capacity of the compact complement piece and the cap=1 normalization.",
+      "State ρ(f) ≳ g(d, cap) relations, proving special cases (degree 1, clustered roots) and axiomatizing literature-dependent inequalities."
+    ],
+    "markdown": "# Knowledge Base: erdos-1039-oq-05\n\nInsights accumulated during research on relating ρ(f) to transfinite diameter and logarithmic capacity.\n\n---\n\n## Problem Understanding\n\nρ(f) is the inscribed-disc radius of the lemniscate interior {|f|<1}. The lemniscate {|f|=1} is the level-1 curve of the Green's function of the complement, so ρ(f) is potential-theoretic. Two capacity-type invariants attach to f: the transfinite diameter d of the root multiset, and the logarithmic capacity of {|f|≥1}.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "complex-analysis",
+    "polynomials",
+    "erdos",
+    "lemniscates",
+    "open-problem"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-103",
+    "erdos-1039",
+    "erdos-1039-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.MeasureTheory.Measure.MeasureSpace",
+      "Mathlib.Analysis.SpecialFunctions.Complex.Circle",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1039Aristotle.lean",
+      "filename": "Erdos1039Aristotle.lean",
+      "lineCount": 167,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1039Aristotle.lean"
+    },
+    {
+      "path": "Proofs/Erdos1039Conformal.lean",
+      "filename": "Erdos1039Conformal.lean",
+      "lineCount": 165,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1039Conformal.lean"
+    },
+    {
+      "path": "Proofs/Erdos1039Problem.lean",
+      "filename": "Erdos1039Problem.lean",
+      "lineCount": 544,
+      "theoremCount": 15,
+      "axiomCount": 4,
+      "defCount": 16,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1039Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1039ProblemAristotle.lean",
+      "filename": "Erdos1039ProblemAristotle.lean",
+      "lineCount": 102,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1039ProblemAristotle.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1067-oq-03.json
+++ b/src/data/research/problems/erdos-1067-oq-03.json
@@ -1,0 +1,97 @@
+{
+  "slug": "erdos-1067-oq-03",
+  "title": "Does the analogous question for χ = ℵ₂ or higher alephs have the same answer? Does the independence phenomenon persist?",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall \\alpha \\ge 2:\\ \\Big(\\chi(G) = \\aleph_\\alpha \\implies \\exists H \\subseteq G,\\ H \\text{ infinitely connected} \\wedge \\chi(H) = \\aleph_\\alpha\\Big) \\stackrel{?}{=} \\text{FALSE}",
+    "plain": "The Erdős-Hajnal question asks whether a graph needing ℵ₁ colors must contain an infinitely connected subgraph that still needs ℵ₁ colors; the answer at ℵ₁ is no (Soukup 2015, Bowler-Pitz 2024). This problem asks whether the same negative answer holds at ℵ₂ and higher alephs, and whether the ZFC-independence seen for the ℵ₁-vertex variant reappears at these larger cardinals.",
+    "whyMatters": [
+      "Determines whether the decoupling of chromatic number from connectivity is special to ℵ₁ or a general feature of uncountable chromatic combinatorics.",
+      "Persistence of ZFC-independence at ℵ₂ would connect an Erdős-style graph question to forcing and large-cardinal hierarchies.",
+      "Tests how robust the cardinal-parametrized Soukup and Bowler-Pitz constructions are across successor and limit cardinals."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Erdős-Hajnal question at ℵ₁ is false in ZFC (Soukup 2015), axiomatized in Proofs/Erdos1067Problem.lean.",
+      "Elementary ℵ₁ counterexample (Bowler-Pitz 2024), axiomatized in the same file.",
+      "Consistency via forcing plus ZFC-independence for the |V(G)| = ℵ₁ restriction (Komjáth 2013).",
+      "Edge-connectivity analogue at ℵ₁ is also false (Thomassen 2017)."
+    ],
+    "open": [
+      "Whether χ(G) = ℵ₂ forces an infinitely connected subgraph with χ = ℵ₂.",
+      "Whether ZFC-independence of the vertex-restricted variant reappears at |V(G)| = ℵ₂ or higher.",
+      "Whether Soukup's ladder-tree construction generalizes to successor cardinals ℵ_{α+1} and limit cardinals such as ℵ_ω.",
+      "Whether large-cardinal hypotheses change the answer at sufficiently high alephs."
+    ],
+    "goal": "Formalize the generalized Erdős-Hajnal question at arbitrary aleph κ = ℵ_α, generalizing hasAleph1ChromaticNumber and ErdosHajnalQuestion so the ℵ₁ case is recovered by specialization, and state the higher-aleph answer via axioms mirroring the ℵ₁ structure with the independence dichotomy recorded as explicit hypotheses."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Understand how the Soukup and Bowler-Pitz ℵ₁ constructions depend on the cardinal and which parts survive at ℵ₂ and higher alephs.",
+    "blockers": [],
+    "nextAction": "Generalize the chromatic-number and question predicates from erdos-1067 to a cardinal parameter κ = ℵ_α and draft an axiomatized scaffold for the ℵ₂ case.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Define hasChromaticNumber κ G generalizing hasAleph1ChromaticNumber.",
+      "State ErdosHajnalQuestionAt κ generalizing ErdosHajnalQuestion.",
+      "Investigate whether Soukup's ladder-tree construction is cardinal-parametrized enough to lift to ℵ₂.",
+      "Record the ZFC-independence dichotomy as explicit assumption fields."
+    ],
+    "markdown": "# Knowledge Base: erdos-1067-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nGeneralizes Erdős Problem #1067 from ℵ₁ to ℵ₂ and higher alephs. At ℵ₁ the answer is a ZFC-provable no (Soukup 2015, Bowler-Pitz 2024); the question is whether this and the ℵ₁-vertex independence phenomenon persist at larger cardinals.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "graph-theory",
+    "chromatic-number",
+    "infinite-graphs",
+    "set-theory",
+    "connectivity",
+    "disproved"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-106",
+    "erdos-1067"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.SetTheory.Cardinal.Ordinal",
+      "Mathlib.SetTheory.Cardinal.Basic",
+      "Mathlib.Combinatorics.SimpleGraph.Basic"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1067Problem.lean",
+      "filename": "Erdos1067Problem.lean",
+      "lineCount": 227,
+      "theoremCount": 3,
+      "axiomCount": 2,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1067Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1080-oq-01.json
+++ b/src/data/research/problems/erdos-1080-oq-01.json
@@ -1,0 +1,105 @@
+{
+  "slug": "erdos-1080-oq-01",
+  "title": "Determine the exact exponent for f(n, ⌊n^(2/3)⌋)",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Determine \\alpha such that f(n, \\lfloor n^{2/3} \\rfloor) = \\Theta(n^{\\alpha}), where f(n,m) is the maximum number of edges in a C_4,C_6-free bipartite graph on n vertices with one part of size m, and currently 16/15 \\le \\alpha \\le 10/9.",
+    "plain": "For bipartite graphs on n vertices with one part of size ⌊n^(2/3)⌋ that avoid both 4-cycles and 6-cycles, let f be the maximum edge count. This function grows like n^α for some exponent α known only to lie between 16/15 and 10/9. Determine the exact value of α.",
+    "whyMatters": [
+      "Closes a gap in extremal graph theory that has been open since the De Caen–Székely disproof of Erdős Problem #1080 in 1992.",
+      "Clarifies how forbidding short even cycles limits edge density in imbalanced bipartite graphs.",
+      "Connects to algebraic incidence-graph constructions from finite geometry that realize the best-known lower bounds."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "De Caen–Székely (1992): f(n, ⌊n^(2/3)⌋) = O(n^(10/9)) upper bound.",
+      "Lazebnik–Ustimenko–Woldar (1994/1995): f(n, ⌊n^(2/3)⌋) = Ω(n^(16/15)) lower bound via algebraic constructions.",
+      "The function grows superlinearly, disproving Erdős's conjecture that O(n) edges force a C_6."
+    ],
+    "open": [
+      "Whether the true exponent equals 10/9, 16/15, or a value strictly between.",
+      "Whether a matching construction and counting argument exist to collapse the interval to a single exponent."
+    ],
+    "goal": "Formalize the known bounds on f(n, ⌊n^(2/3)⌋) in Lean 4 and, where feasible, tighten the upper or lower bound to shrink the interval [16/15, 10/9]."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Formalize the extremal function f(n,m) and the known asymptotic bounds for the C_4,C_6-free imbalanced bipartite setting.",
+    "blockers": [],
+    "nextAction": "Survey Mathlib SimpleGraph and cardinality infrastructure and draft a clean Lean definition of f(n,m) as a supremum of edge counts.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "State f(n, ⌊n^(2/3)⌋) as a supremum over C_4,C_6-free bipartite graphs in Lean.",
+      "Reproduce the De Caen–Székely O(n^(10/9)) upper-bound counting argument.",
+      "Investigate algebraic incidence-graph constructions for a matching lower bound."
+    ],
+    "markdown": ""
+  },
+  "tags": [
+    "erdos",
+    "combinatorics",
+    "graph-theory",
+    "extremal-graph-theory",
+    "bipartite-graphs",
+    "cycles",
+    "disproved"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-108",
+    "erdos-1080",
+    "erdos-1080-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Combinatorics.SimpleGraph.Basic",
+      "Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting",
+      "Mathlib.Data.Set.Card"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1080OQ03.lean",
+      "filename": "Erdos1080OQ03.lean",
+      "lineCount": 629,
+      "theoremCount": 28,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1080OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos1080Problem.lean",
+      "filename": "Erdos1080Problem.lean",
+      "lineCount": 471,
+      "theoremCount": 10,
+      "axiomCount": 2,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1080Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1102-oq-01.json
+++ b/src/data/research/problems/erdos-1102-oq-01.json
@@ -1,0 +1,92 @@
+{
+  "slug": "erdos-1102-oq-01",
+  "title": "Do the sequences 2ⁿ - 1 have property P",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "A = \\{\\, 2^n - 1 : n \\ge 1 \\,\\} \\overset{?}{\\in} P, \\quad P = \\{ A : \\forall n \\ge 1,\\; |\\{\\, a \\in A : \\mu^2(n + a) = 1 \\,\\}| < \\infty \\}.",
+    "plain": "Does the fast-growing Mersenne-type sequence 2ⁿ − 1 = 1, 3, 7, 15, 31, 63, … satisfy Erdős's property P: for every fixed shift n ≥ 1, only finitely many elements a of the sequence make n + a squarefree?",
+    "whyMatters": [
+      "Property P is one of the two extremal squarefree conditions in Erdős Problem #1102, resolved in general by van Doorn–Tao (2025) who showed P-sequences have density 0.",
+      "Density 0 does not decide any particular sparse sequence, so 2ⁿ − 1 is a natural exponential test case that van Doorn–Tao explicitly leave open.",
+      "Deciding it clarifies how additive shifts interact with squarefree distribution for multiplicatively structured sequences and connects to squarefree values of 2ⁿ − 1 (Wieferich-prime obstructions)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "van Doorn–Tao (2025): every sequence with property P has natural density 0.",
+      "The density of squarefree integers is 6/π² = 1/ζ(2) (classical).",
+      "Q-sequences have upper density at most 6/π², achieved by the squarefree numbers, formalized in gallery entry erdos-1102."
+    ],
+    "open": [
+      "Whether A = {2ⁿ − 1 : n ≥ 1} has property P (this problem).",
+      "Whether the factorial sequences n! ± 1 have property P.",
+      "Behaviour of the variant properties P′ and P′∞ for these specific sequences."
+    ],
+    "goal": "Formalize a precise Lean 4 statement that {2ⁿ − 1 : n ≥ 1} has property P, reusing the propertyP predicate and powersOfTwoMinus1 definition in Proofs/Erdos1102Problem.lean, and either prove the tractable implications or record it as a stated conjecture with the finiteness lemmas needed to attack it."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Understand how the squarefreeness of n + 2ᵏ − 1 depends on the order of 2 modulo prime squares, using the existing propertyP predicate.",
+    "blockers": [],
+    "nextAction": "Survey Mathlib's ZMod, orderOf, and Squarefree infrastructure and draft a Lean statement of propertyP powersOfTwoMinus1.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Draft the Lean 4 statement propertyP {2ⁿ − 1 : n ≥ 1} reusing definitions from Erdos1102Problem.lean.",
+      "Investigate periodicity of k ↦ 2ᵏ modulo p² via orderOf in ZMod (p²).",
+      "Assess whether a covering-system argument can force n + 2ᵏ − 1 non-squarefree for large k."
+    ],
+    "markdown": "# Knowledge Base: erdos-1102-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nProperty P (Erdős #1102): a set A has property P if for every n ≥ 1 only finitely many a ∈ A make n + a squarefree. The question asks whether A = {2ⁿ − 1 : n ≥ 1} has property P. van Doorn–Tao (2025) proved P-sequences have density 0 but leave this exponential sequence open.\n\n---\n\n## Insights\n\nSquarefreeness of n + 2ᵏ − 1 hinges on fixed square divisors p²; the map k ↦ 2ᵏ mod p² is periodic with period the order of 2 modulo p², suggesting covering-congruence approaches.\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "number-theory",
+    "squarefree",
+    "density",
+    "analytic-number-theory"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-11",
+    "erdos-110",
+    "erdos-1102"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.NumberTheory.Squarefree — Squarefree predicate for the translate condition",
+      "Mathlib.Data.ZMod.Basic — modular reduction of 2ᵏ for periodicity arguments",
+      "Mathlib.GroupTheory.OrderOfElement — order of 2 modulo prime powers"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1102Problem.lean",
+      "filename": "Erdos1102Problem.lean",
+      "lineCount": 159,
+      "theoremCount": 2,
+      "axiomCount": 1,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1102Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1144-oq-03.json
+++ b/src/data/research/problems/erdos-1144-oq-03.json
@@ -1,0 +1,104 @@
+{
+  "slug": "erdos-1144-oq-03",
+  "title": "Prove that the (log N)^{1+ε} factor in Atherfold's bound cannot be reduced to a bounded power of log N (the o(1) refinement)",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Atherfold (2025): } \\Big|\\sum_{m \\le N} f(m)\\Big| \\ll \\sqrt{N}\\,(\\log N)^{1+o(1)} \\text{ a.s. Show: for no fixed } K < \\infty \\text{ does } \\Big|\\sum_{m \\le N} f(m)\\Big| \\ll \\sqrt{N}\\,(\\log N)^{K} \\text{ hold almost surely.}",
+    "plain": "Atherfold's 2025 theorem bounds the partial sums of a Rademacher random multiplicative function by sqrt(N) times (log N)^{1+o(1)}. This problem asks to show that the (log N)^{1+o(1)} correction cannot be tightened to (log N)^K for any fixed finite K, i.e. the o(1) in the exponent is a genuine feature of the extremal growth, not an artifact of the proof.",
+    "whyMatters": [
+      "Determines the exact order of the maximal fluctuations of random multiplicative functions, sharpening the pinch between the conjectured lower bound and Atherfold's upper bound.",
+      "Connects random multiplicative functions to log-correlated fields and multiplicative chaos, where a (log N)^1-type factor is the signature of a branching-random-walk maximum.",
+      "A negative answer confirms (log N)^{1+o(1)} as the true order of the maximum, complementing Harper's typical-size result sqrt(N)/(log log N)^{3/4+o(1)}."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Atherfold's almost-sure upper bound |S_f(N)| << sqrt(N)(log N)^{1+o(1)} (2025 preprint; axiomatized as atherfold_upper_bound in Proofs/Erdos1144Problem.lean).",
+      "Harper's typical-size theorem: S_f(N) has size sqrt(N)/(log log N)^{3/4+o(1)} (arXiv:1302.7208, 2013).",
+      "Wintner's classical O(N^{1/2+ε}) almost-sure bound (Duke Math. J. 11(2), 1944).",
+      "Growth-rate pinch theorem conjecture_and_atherfold_pinch (fully proved, 0 sorries) bounding |S_f(N)| between C1·sqrt(N) and C2·sqrt(N)(log N)^{1+ε}."
+    ],
+    "open": [
+      "Whether the (log N)^{1+o(1)} factor is optimal or can be reduced to a fixed power (log N)^K.",
+      "The matching maximal lower bound: a.s. existence of a subsequence N_k with |S_f(N_k)| >> sqrt(N_k)(log N_k)^{1-o(1)}.",
+      "The primary Erdős #1144 conjecture limsup |S_f(N)|/sqrt(N) = ∞ almost surely."
+    ],
+    "goal": "Formalize the o(1)-refinement in Lean 4: state precisely that no fixed K yields an a.s. bound |S_f(N)| << sqrt(N)(log N)^K, and build the reduction lemmas deriving a contradiction from such a bound using the (conditional) maximal fluctuation lower bound, mirroring the axiomatize-and-pinch architecture of the parent problem."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "State the o(1)-refinement of Atherfold's bound in Lean 4 and identify the reduction to a maximal lower bound.",
+    "blockers": [],
+    "nextAction": "Survey Mathlib's Real.log / Real.rpow and Filter.atTop APIs and draft the 'no fixed K' statement plus an axiom for the maximal lower bound.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [
+      "No random multiplicative function or Rademacher random model infrastructure in Mathlib.",
+      "No multiplicative chaos or log-correlated field theory in Mathlib."
+    ],
+    "nextSteps": [
+      "Encode 'no fixed K gives |S_f(N)| <= C·sqrt(N)(log N)^K eventually' via a universal quantifier over K and C.",
+      "Add an axiom capturing an a.s. maximal lower bound of order sqrt(N)(log N)^{1-ε} along a subsequence.",
+      "Prove the reduction lemma: a bounded-power upper bound contradicts the maximal lower bound.",
+      "Cross-check the statement against the parent conjecture_and_atherfold_pinch pinch theorem."
+    ],
+    "markdown": "# Knowledge Base: erdos-1144-oq-03\n\nInsights accumulated during research on the o(1) refinement of Atherfold's bound.\n\n---\n\n## Problem Understanding\n\nAtherfold's a.s. upper bound |S_f(N)| << sqrt(N)(log N)^{1+o(1)} carries an exponent 1+o(1). The question is whether the o(1) can be dropped to give a fixed power K. Encoding requires quantifying over all K and C in Filter.atTop language.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "number-theory",
+    "probability",
+    "analysis",
+    "multiplicative-functions",
+    "open"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-11",
+    "erdos-114",
+    "erdos-1144"
+  ],
+  "references": {
+    "papers": [
+      "T. Atherfold, 'Almost sure upper bounds for random multiplicative functions', 2025 (preprint).",
+      "A. J. Harper, 'Moments of random multiplicative functions and truncated characteristic polynomials', arXiv:1302.7208, 2013.",
+      "A. Wintner, 'Random factorizations and Riemann's hypothesis', Duke Math. J. 11(2), 1944."
+    ],
+    "urls": [
+      "https://erdosproblems.com/1144"
+    ],
+    "mathlib": [
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic — real logarithm for (log N)^K.",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real — Real.rpow for the exponent K and sqrt(N).",
+      "Mathlib.Order.Filter.AtTopBot — Filter.atTop for 'eventually' and 'infinitely often'."
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1144Problem.lean",
+      "filename": "Erdos1144Problem.lean",
+      "lineCount": 227,
+      "theoremCount": 16,
+      "axiomCount": 1,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1144Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1215-oq-02.json
+++ b/src/data/research/problems/erdos-1215-oq-02.json
@@ -1,0 +1,94 @@
+{
+  "slug": "erdos-1215-oq-02",
+  "title": "For the restricted class of cyclotomic polynomials (with roots at roots of unity), is there a polynomial path-length bound?",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\exists\\, C : \\mathbb{R},\\ \\forall\\, n : \\mathbb{N},\\ \\text{for } P = \\Phi_n \\text{ (the } n\\text{-th cyclotomic polynomial)},\\ \\exists\\, \\gamma : [0,1] \\to \\{z \\in \\mathbb{C} : |P(z)| < 1\\},\\ \\gamma(0) = 0 \\wedge |P(\\gamma(1))| = 1 \\wedge \\operatorname{length}(\\gamma) \\le C \\cdot n.",
+    "plain": "Erdős #1215 asks whether every polynomial with P(0)=1 and all roots on the unit circle has a short path (length bounded by a constant times the degree) from the origin to the boundary of {|P|<1}, staying inside. Mac Lane (1953) showed NO in general via labyrinth polynomials. This restricts to the highly symmetric family of cyclotomic polynomials Φ_n, whose roots are the primitive n-th roots of unity, and asks whether their rigidity forces a polynomial-in-n path-length bound even though the general case fails.",
+    "whyMatters": [
+      "Cyclotomic polynomials are the most arithmetically important unit-circle-rooted family (Mahler measure, Lehmer's problem, Galois theory), so understanding their sublevel-set geometry links topology to number theory.",
+      "Mac Lane's labyrinth construction exploits the freedom to cluster roots; cyclotomic roots are rigidly equidistributed, so this sub-question probes the boundary between wild and tame polynomial lemniscates.",
+      "A positive answer would give the first natural sub-class of Erdős #1215 with a uniform path-length bound; a negative answer would show even cyclotomic geometry is topologically wild."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Mac Lane (1953) resolved the general Erdős #1215 negatively: for any simply-connected compact A ⊂ {|z|<1} there is P with P(0)=1, unit-circle roots, and |P|>2 on A, forcing arbitrarily long paths.",
+      "Mathlib provides cyclotomic polynomials Polynomial.cyclotomic with roots the primitive n-th roots of unity and degree φ(n).",
+      "Every monic polynomial with all roots on the unit circle (including all Φ_n) has Mahler measure exactly 1."
+    ],
+    "open": [
+      "Whether {|Φ_n(z)|<1} can host a Mac Lane-style labyrinth, or whether the symmetric spacing of primitive n-th roots of unity precludes it.",
+      "The exact target bound (linear C·n, logarithmic C·log n, or another function of n or φ(n)), left ambiguous by the original #1215 statement."
+    ],
+    "goal": "Formalize a precise Lean 4 statement of the cyclotomic-restricted path-length question and prove tractable building blocks (sublevel-set geometry for small n such as n = 1, 2, 3, 4, 6), rather than the full uniform theorem which needs analytic infrastructure not yet in Mathlib."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Understand the sublevel-set geometry of cyclotomic polynomials Φ_n and whether cyclotomic root rigidity rules out Mac Lane labyrinths.",
+    "blockers": [],
+    "nextAction": "Survey Mathlib cyclotomic-polynomial, complex-modulus, and interval-integral (arc-length) infrastructure and draft a precise formal statement of the restricted path-length bound.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [
+      "No developed theory of rectifiable paths with arc length in ℂ tied to polynomial sublevel sets.",
+      "No polynomial-lemniscate topology results (component counts, connectivity of {|P|=c})."
+    ],
+    "nextSteps": [
+      "Draft a Lean definition of the sublevel set {z : |Φ_n(z)| < 1} using Polynomial.eval and Complex.abs.",
+      "Compute and formalize the geometry of {|Φ_n(z)|<1} for small n (n = 1, 2, 3, 4, 6).",
+      "Investigate whether root equidistribution of primitive n-th roots of unity bounds the number of lemniscate components."
+    ],
+    "markdown": "# Knowledge Base: erdos-1215-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThis is a restriction of Erdős #1215 to cyclotomic polynomials Φ_n, whose roots are the primitive n-th roots of unity. The parent problem was resolved negatively by Mac Lane (1953) using labyrinth polynomials; the question here is whether the rigid, symmetric placement of cyclotomic roots precludes such labyrinths and yields a polynomial-in-n path-length bound.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "complex-analysis",
+    "polynomial-theory",
+    "topology",
+    "unit-circle"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-12",
+    "erdos-121",
+    "erdos-1215"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Complex.Circle",
+      "Mathlib.MeasureTheory.Integral.IntervalIntegral"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1215Problem.lean",
+      "filename": "Erdos1215Problem.lean",
+      "lineCount": 71,
+      "theoremCount": 1,
+      "axiomCount": 2,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1215Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-740-incomplete-01-oq-01.json
+++ b/src/data/research/problems/erdos-740-incomplete-01-oq-01.json
@@ -1,0 +1,84 @@
+{
+  "slug": "erdos-740-incomplete-01-oq-01",
+  "title": "Formalize Rödl's theorem (𝔪 = ℵ₀, r = 3): a graph of chromatic number ℵ₀ contains a triangle-free subgraph of chromatic number ℵ₀ — the genuine positive result of #740.",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall\\, G,\\ \\chi(G) = \\aleph_0 \\implies \\exists\\, H \\subseteq G,\\ (\\text{$H$ triangle-free}) \\wedge \\chi(H) = \\aleph_0",
+    "plain": "Every simple graph whose chromatic number is countably infinite (ℵ₀) contains a triangle-free subgraph whose chromatic number is still ℵ₀. This is Rödl's theorem, the base case (𝔪 = ℵ₀, r = 3) of Erdős Problem #740, and the positive counterpart to the negative bipartite (r = ∞) boundary case settled in the parent gallery entry.",
+    "whyMatters": [
+      "It is the genuine positive content of Erdős #740, unlike the parent entry which only settles the negative r = ∞ boundary case.",
+      "Formalizing it turns the gallery's coverage of #740 from boundary-only into engagement with the hard direction.",
+      "It exercises Mathlib's infinite-graph and cardinal-valued chromatic-number machinery on a real combinatorial construction rather than an elementary bound.",
+      "It builds reusable infrastructure (triangle-freeness, cardinal-valued χ, subgraph extraction) for the wider Erdős–Hajnal program."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Bipartite (r = ∞) case of #740 fails: χ(bipartite) ≤ 2, so χ(G) > 2 admits no induced bipartite subgraph realizing χ(G) — parent entry erdos-740-incomplete-01.",
+      "Rödl (1977) proved on paper that a graph of chromatic number ℵ₀ contains a triangle-free subgraph of chromatic number ℵ₀.",
+      "Monotonicity of χ under graph homomorphisms and χ(G.induce s) ≤ χ(G) — Mathlib chromaticNumber_mono_of_hom and the parent's induce_chromaticNumber_le.",
+      "χ(Kₙ) = n via Mathlib chromaticNumber_top."
+    ],
+    "open": [
+      "The general Erdős #740 for arbitrary infinite 𝔪 and finite r ≥ 3 remains open.",
+      "No Lean formalization exists of Rödl's countable case or of the triangle-free subgraph extraction preserving infinite chromatic number."
+    ],
+    "goal": "Formalize in Lean 4 over Mathlib the single positive statement of Rödl's theorem for 𝔪 = ℵ₀, r = 3: every simple graph G with chromatic number ℵ₀ admits a triangle-free subgraph H with χ(H) = ℵ₀. Target this specific case only; the general infinite-cardinal and larger-r versions stay open."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T00:00:00Z",
+    "iteration": 1,
+    "focus": "Survey Mathlib's cardinal-valued chromatic-number and triangle-free (clique) infrastructure for infinite graphs, and frame Rödl's ℵ₀, r = 3 case.",
+    "blockers": [],
+    "nextAction": "Draft the Lean statement of Rödl's theorem and assess whether Mathlib's colorability/clique/cardinal APIs suffice for the χ = ℵ₀ lower bound after triangle removal.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "State Rödl's theorem in Lean: χ(G) = ℵ₀ implies existence of a triangle-free subgraph H with χ(H) = ℵ₀.",
+      "Identify a Mathlib-friendly predicate for triangle-freeness (no K₃ / no 3-clique) and lemmas for subgraph passage.",
+      "Assess the cardinal-valued χ lower bound (χ(H) ≥ ℵ₀) machinery available in Mathlib.",
+      "Evaluate Approach A (direct Rödl construction) vs Approach B (colorability/compactness reformulation)."
+    ],
+    "markdown": "# Knowledge Base: erdos-740-incomplete-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nRödl's theorem (1977) is the base case 𝔪 = ℵ₀, r = 3 of Erdős #740: every graph of countably infinite chromatic number contains a triangle-free subgraph of countably infinite chromatic number. This is the positive counterpart to the parent entry's negative r = ∞ (bipartite) boundary result.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "erdos",
+    "graph-theory",
+    "chromatic-number",
+    "bipartite",
+    "odd-cycles",
+    "induced-subgraph",
+    "research"
+  ],
+  "relatedProofs": [
+    "erdos-7",
+    "erdos-74",
+    "erdos-740",
+    "erdos-740-incomplete-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Combinatorics.SimpleGraph.Coloring",
+      "Mathlib.Combinatorics.SimpleGraph.Clique",
+      "Mathlib.SetTheory.Cardinal.Basic"
+    ]
+  },
+  "started": "2026-07-09T00:00:00Z",
+  "significance": 5,
+  "leanFiles": []
+}


### PR DESCRIPTION
## Summary

Replenishes the research candidate pool. Cross-checking the pool against existing workspaces showed only **1** genuinely fresh (no-workspace) problem remained available — well below the threshold of 15. This adds 15 new **Tier-B** extension/generalization problems, one per mathematical domain for diversity, each grounded in an existing gallery entry.

| Domain | Slug |
|--------|------|
| graph-theory | erdos-1080-oq-01 |
| geometry | erdos-1007-oq-03 |
| analysis | beta-central-binomial-asymptotic-oq-01 |
| ramsey-theory | erdos-1014-oq-03 |
| extremal-graph-theory | erdos-1011-oq-02 |
| chromatic-number | erdos-740-incomplete-01-oq-01 |
| measure-theory | erdos-1038-oq-01 |
| probability | erdos-1144-oq-03 |
| set-theory | erdos-1067-oq-03 |
| topology | erdos-1215-oq-02 |
| analytic-number-theory | erdos-1102-oq-01 |
| polynomials | erdos-1039-oq-05 |
| additive-combinatorics | erdos-1-wip-01-oq-04 |
| number-theory | erdos-1000-oq-04 |
| combinatorics | erdos-1023-oq-04 |

## Workflow followed

- Database-first: inserted into `research/db/knowledge.db` → `sync_pool.py` → all 15 present in the consumed pool as `available`.
- `research.sh init` created each workspace; `problem.md` and the site JSON stub filled for every slug.
- **OQ-chain guardrails**: all pass (depth ≤ 3, no repeated-index loops).
- **Validation**: `validate-seeker-stubs.ts` reports PASS for all 15 (no template placeholders); all site JSON parses.

Math-agent PR — no `loom:review-requested`; the deployer merges directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)