### PR TITLE
Enrich Buffon noodle multi-family (buffons-noodle-oq-01-oq-02): cover worked-instances tail

### DIFF
--- a/src/data/proofs/buffons-noodle-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/buffons-noodle-oq-01-oq-02/annotations.json
@@ -46,5 +46,17 @@
     "significance": "supporting",
     "relatedConcepts": ["Fin.sum_univ_add", "Fin.castAdd", "subsum monotonicity", "square grid"],
     "prerequisites": ["buffon_noodle_multi_family", "Finset.sum_nonneg", "Fin index arithmetic"]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-01-oq-02-examples",
+    "proofId": "buffons-noodle-oq-01-oq-02",
+    "range": { "startLine": 156, "endLine": 179 },
+    "type": "context",
+    "title": "Worked Instances: Harmonic Spacings and the Square Grid",
+    "content": "Section 4 exercises the general identity on two concrete family sets. The first takes three line families with spacings 1, 2, 3 and evaluates the expected crossings to (2L/π)(1 + 1/2 + 1/3), the harmonic partial sum appearing directly as ∑ⱼ 1/dⱼ — closed by rewriting with buffon_noodle_multi_family and Fin.sum_univ_three. The second recovers the parent's square grid as the k=2 equal-spacing case: two families at common spacing d give (2L/π)(1/d + 1/d) = 4L/(πd), dispatched by buffon_noodle_multi_family_const then push_cast; ring. Together they confirm the general formula degenerates correctly to the known single/double-grid Buffon–Laplace results and shows the reciprocal-spacing sum is the exact object that generalizes the classic 2L/(πd).",
+    "mathContext": "Spacings $1,2,3$: $\\frac{2L}{\\pi}\\left(1+\\tfrac12+\\tfrac13\\right)$. Square grid ($k=2$, spacing $d$): $\\frac{2L}{\\pi}\\cdot\\frac2d = \\frac{4L}{\\pi d}$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "harmonic sum of spacings", "square grid recovery", "Buffon–Laplace formula", "sanity check"],
+    "prerequisites": ["buffon_noodle_multi_family", "buffon_noodle_multi_family_const", "Fin.sum_univ_three"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `buffons-noodle-oq-01-oq-02`.

**Gap addressed:** annotations stopped at line 154, leaving the "§ 4 : Worked instances" section (lines 156–179) uncovered.

**Added:** a `context` annotation for the two worked examples — three families with harmonic spacings 1, 2, 3 giving (2L/π)(1 + 1/2 + 1/3), and the square grid (k=2, equal spacing d) recovering the parent's 4L/(πd) — confirming the general reciprocal-spacing formula ∑ⱼ 1/dⱼ degenerates correctly to the classic Buffon–Laplace results.

Annotation count 4 → 5, tail coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).