### PR TITLE
audit(pythagorean-theorem): mark clean 2026-07-09

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24112,9 +24112,9 @@
       "issues": []
     },
     "pythagorean-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:21Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T23:00:00Z",
       "result": "clean"
     },
     "pythagorean-theorem-oq-03": {
@@ -29729,5 +29729,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T22:30:32Z"
+  "lastUpdated": "2026-07-09T23:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

Re-audit of the stalest uncovered tracker entry (`pythagorean-theorem`, lastAudited 2026-05-03).

### Verified
| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 214 | 214 | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 3 | 3 (abbrev + def + structure) | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |

- No `native_decide`, no `True` stubs.
- **Badge `original` defensible**: `pythagorean_theorem` is a genuine bilinearity expansion (`inner_add_left`/`inner_add_right` + `ring`), not a one-line delegation to a Mathlib Pythagorean lemma. `mathlibDependencies` honestly lists only `InnerProductSpace` basic structure.
- `additionalFiles: [OQ05]` is a benign cross-reference — that file is owned by the separate `pythagorean-theorem-oq-05` entry; base counts reflect the main file only (no inflation).

Only `audit-tracker.json` is modified.

---
Discovered during gallery integrity audit.