### PR TITLE
Enrich birthday triple-threshold: cover summary/axiom-verification tail

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/annotations.json
@@ -70,5 +70,17 @@
     "significance": "key",
     "relatedConcepts": ["asymptotic expansion", "vanishing remainder", "sharp constant"],
     "prerequisites": ["asymptotics", "absolute value bounds"]
+  },
+  {
+    "id": "ann-summary-axiomcheck",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 141, "endLine": 162 },
+    "type": "context",
+    "title": "Summary and Inline Axiom Verification",
+    "content": "The file closes with a summary and two verification commands. #check confirms the signatures of the two headline theorems, and #print axioms birthday_triple_threshold_sharp / birthday_triple_threshold_const_one report their axiom dependencies inline — both resolve to only the standard foundational triple propext / Classical.choice / Quot.sound, an in-source confirmation of the entry's 0-axiom claim (no sorryAx, no Lean.ofReduceBool). The summary recaps the sharpening: the centered-cube identity n(n−1)(n−2) = (n−1)³ − (n−1) turns the threshold balance into the depressed cubic m³ − m = c³ (m = n−1), whose lower bound m³ ≥ c³ and upper bound collapsing to (m−c)² ≥ 0 tighten the parent's additive-error-2 band c ≤ n ≤ c+2 to the asymptotically exact n = (6d²ln2)^{1/3} + 1 + O(d^{−2/3}).",
+    "mathContext": "$\\#\\text{print axioms} \\Rightarrow \\{\\text{propext},\\ \\text{Classical.choice},\\ \\text{Quot.sound}\\}$ only; result $n = (6d^2\\ln 2)^{1/3} + 1 + O(d^{-2/3})$.",
+    "significance": "context",
+    "relatedConcepts": ["axiom integrity", "#print axioms", "self-verification", "asymptotic sharpening", "depressed cubic"],
+    "prerequisites": ["#print axioms output", "the two main threshold theorems"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01`.

**Gap addressed:** annotations stopped at line 140, leaving the summary + inline verification tail (lines 141–162) uncovered.

**Added:** a `context` annotation documenting the closing `#check` and `#print axioms` commands — both main theorems (`birthday_triple_threshold_sharp`, `birthday_triple_threshold_const_one`) resolve to only propext / Classical.choice / Quot.sound, an in-source confirmation of the 0-axiom claim — and recapping the centered-cube / depressed-cubic sharpening to n = (6d²ln2)^{1/3} + 1 + O(d^{−2/3}).

Annotation count 6 → 7, tail coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).