### PR TITLE
Fix: sync stale prose theorem/definition counts to meta (kepler-oq-04, #36290)

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -82,7 +82,7 @@
       "title": "Module Docstring: Three-Flagship Survey + S2-S7 Status",
       "startLine": 1,
       "endLine": 83,
-      "summary": "Surveys the three OQ-04 sub-questions (tetrahedral refutation, ellipsoid records, Ulam's conjecture) with citations to Chen-Engel-Glotzer 2010, Donev et al. 2004, Bezdek-Kuperberg 2007, and Ulam 1972. Records the S2 SCAFFOLD goal, the S3 ACT linear-margin chain `4671 · π < 14_713.65 < 16_800 < 4000 · 3 · √2`, the S4 ACT existential corollary, the S5 ACT Bezdek-Kuperberg +1 STATEMENT axiom, the S6 ACT Ulam +1 STATEMENT axiom, and the S7 ACT final aggregation `density_hierarchy_3d`. Closes with the post-S7 status block: 0 sorries, 2 axioms, 4 definitions, 8 theorems."
+      "summary": "Surveys the three OQ-04 sub-questions (tetrahedral refutation, ellipsoid records, Ulam's conjecture) with citations to Chen-Engel-Glotzer 2010, Donev et al. 2004, Bezdek-Kuperberg 2007, and Ulam 1972. Records the S2 SCAFFOLD goal, the S3 ACT linear-margin chain `4671 · π < 14_713.65 < 16_800 < 4000 · 3 · √2`, the S4 ACT existential corollary, the S5 ACT Bezdek-Kuperberg +1 STATEMENT axiom, the S6 ACT Ulam +1 STATEMENT axiom, and the S7 ACT final aggregation `density_hierarchy_3d`. Closes with the post-S7 status block: 0 sorries, 2 axioms, 10 definitions, 33 theorems."
     },
     {
       "id": "imports",


### PR DESCRIPTION
## Fix

The conclusion `summary` prose for `kepler-conjecture-oq-04` reported a stale "post-S7 status block" count that drifted after the Lean file grew.

## Evidence

**Before**: prose read `0 sorries, 2 axioms, 4 definitions, 8 theorems`
**After**: prose reads `0 sorries, 2 axioms, 10 definitions, 33 theorems`

`meta.theoremCount` (33), `meta.definitionCount` (10), and `leanFile.{theoremCount,definitionCount}` (33/10) all agree, and a comment-stripped scan of `Proofs/KeplerConjectureOQ04.lean` confirms 33 theorems/lemmas and 10 definitions. The `0 sorries` / `2 axioms` portion of the block is still accurate (`leanFile.sorries=0`, `leanFile.axiomCount=2`), so only the theorem/definition counts were synced.

Closes part of #36290.

---
Automated fix by lean-mechanic agent.