### PR TITLE
research(tetrahedral-number-formula-oq-01): general hockey-stick for hyper-tetrahedral numbers [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -75,9 +75,8 @@ theorem simplexNumber_one_dim (n : ℕ) : simplexNumber 1 n = n + 1 := by
 `n+1` symbols. -/
 theorem simplexNumber_eq_multichoose (d n : ℕ) :
     simplexNumber d n = Nat.multichoose (n + 1) d := by
-  rw [simplexNumber, Nat.multichoose_eq]
-  congr 1
-  omega
+  have hidx : n + 1 + d - 1 = n + d := by omega
+  rw [simplexNumber, Nat.multichoose_eq, hidx]
 
 /-- **Figurate Pascal recurrence.** The `(d+1)`-dimensional simplex number obeys
 `P_{d+1}(n+1) = P_{d+1}(n) + P_d(n+1)`: growing the "size" argument by one adds a

--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -1,0 +1,165 @@
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Nat.Factorial.BigOperators
+import Mathlib.Tactic
+
+/-
+# The General Hockey-Stick Identity for Hyper-Tetrahedral Numbers
+
+## Open Question (tetrahedral-number-formula-oq-01)
+
+The parent entry `TetrahedralNumberFormula` proves the *fixed* `d = 3` rung of the
+figurate-number ladder: the running total of triangular numbers is the
+tetrahedral number, `∑_{k≤n} C(k+1, 2) = C(n+2, 3)`. This follow-up asks for the
+*general-dimension* statement: the hockey-stick identity for hyper-tetrahedral
+(`d`-dimensional simplex) numbers, valid simultaneously for every dimension `d`.
+
+## Result
+
+Working with the `d`-dimensional simplex (hyper-tetrahedral) number
+
+    P_d(n) = C(n + d, d)                    (`simplexNumber d n`)
+
+we establish, with **0 sorries and 0 axioms**, a small self-contained theory:
+
+* `simplexNumber_eq_multichoose` : `P_d(n) = multichoose (n+1) d`, identifying the
+  hyper-tetrahedral numbers with Mathlib's multiset coefficient;
+* `simplexNumber_succ_succ` : the figurate Pascal recurrence
+  `P_{d+1}(n+1) = P_{d+1}(n) + P_d(n+1)`;
+* `sum_simplex` : **the general hockey-stick identity**
+  `∑_{k≤n} P_d(k) = P_{d+1}(n)` — summing the `d`-dimensional figurate numbers
+  produces the `(d+1)`-dimensional one (any dimension `d`);
+* `iterSum_one` : **the headline generalization** — the `d`-fold iterated partial
+  sum of the constant sequence `1` is exactly `P_d(n)`. This says the entire
+  figurate ladder (`1 → n → triangular → tetrahedral → …`) arises by *iterating
+  summation*, and it packages the whole ladder into a single statement indexed
+  by the dimension `d`, proved by induction on `d` with `sum_simplex` as the
+  one-step engine;
+* `factorial_mul_simplexNumber` / `..._prod` : the division-free closed form
+  `d! · P_d(n) = (n+1)^{(d)} = ∏_{i<d}(n+1+i)`, the general-dimension analogue of
+  the parent's `6·C(n+2,3) = n(n+1)(n+2)`.
+
+## Novelty
+
+Mathlib supplies the one-step hockey stick (`Nat.sum_range_add_choose`) and the
+multiset coefficient (`Nat.multichoose`), but not the *dimension-indexed*
+figurate theory: neither the iterated-partial-sum characterization of simplex
+numbers (`iterSum_one`) nor the figurate recurrence and cleared closed form
+stated uniformly in `d`. The parent entry only handles the single dimension
+`d = 3`; this file lifts the whole ladder to arbitrary dimension, with the
+`d = 2` instance (`sum_simplex 2 n`) reproducing the parent's tetrahedral
+identity.
+
+0 sorries, 0 axioms.
+-/
+
+namespace TetrahedralNumberFormulaOQ01
+
+open Finset Nat
+
+/-- The `d`-dimensional hyper-tetrahedral (simplex / figurate) number
+`P_d(n) = C(n+d, d)`. For `d = 1` this is the linear number `n+1`, for `d = 2`
+the triangular number `C(n+2, 2)`, for `d = 3` the tetrahedral number, and so on
+up the figurate ladder. -/
+def simplexNumber (d n : ℕ) : ℕ := (n + d).choose d
+
+/-- Dimension `0`: the "point" figurate number is constantly `1`. -/
+@[simp] theorem simplexNumber_zero_dim (n : ℕ) : simplexNumber 0 n = 1 := by
+  simp [simplexNumber]
+
+/-- Dimension `1`: the linear figurate number `P_1(n) = n + 1`. -/
+theorem simplexNumber_one_dim (n : ℕ) : simplexNumber 1 n = n + 1 := by
+  simp [simplexNumber, Nat.choose_one_right]
+
+/-- Hyper-tetrahedral numbers are exactly Mathlib's multiset coefficients:
+`P_d(n) = multichoose (n+1) d`, the number of size-`d` multisets drawn from
+`n+1` symbols. -/
+theorem simplexNumber_eq_multichoose (d n : ℕ) :
+    simplexNumber d n = Nat.multichoose (n + 1) d := by
+  rw [simplexNumber, Nat.multichoose_eq]
+  congr 1
+  omega
+
+/-- **Figurate Pascal recurrence.** The `(d+1)`-dimensional simplex number obeys
+`P_{d+1}(n+1) = P_{d+1}(n) + P_d(n+1)`: growing the "size" argument by one adds a
+full `d`-dimensional layer. This is Pascal's rule read along the figurate
+ladder. -/
+theorem simplexNumber_succ_succ (d n : ℕ) :
+    simplexNumber (d + 1) (n + 1)
+      = simplexNumber (d + 1) n + simplexNumber d (n + 1) := by
+  unfold simplexNumber
+  have h1 : n + 1 + (d + 1) = (n + d + 1) + 1 := by ring
+  have h2 : n + (d + 1) = n + d + 1 := by ring
+  have h3 : n + 1 + d = n + d + 1 := by ring
+  rw [h1, h2, h3, Nat.choose_succ_succ (n + d + 1) d,
+    Nat.add_comm ((n + d + 1).choose d) ((n + d + 1).choose (d + 1))]
+
+/-- **General hockey-stick identity (figurate form).** Summing the
+`d`-dimensional simplex numbers `P_d(0), …, P_d(n)` yields the `(d+1)`-dimensional
+simplex number:
+
+`∑_{k≤n} C(k+d, d) = C(n+d+1, d+1)`.
+
+Valid for *every* dimension `d`; the `d = 2` case recovers the parent entry's
+`∑ triangular = tetrahedral`. Immediate from Zhu Shijie's identity
+`Nat.sum_range_add_choose`. -/
+theorem sum_simplex (d n : ℕ) :
+    ∑ k ∈ range (n + 1), simplexNumber d k = simplexNumber (d + 1) n := by
+  simp only [simplexNumber]
+  rw [Nat.sum_range_add_choose n d, show n + (d + 1) = n + d + 1 from by ring]
+
+/-- Partial-summation operator: `partialSum f n = ∑_{j≤n} f j`. -/
+def partialSum (f : ℕ → ℕ) (n : ℕ) : ℕ := ∑ j ∈ range (n + 1), f j
+
+/-- `d`-fold iterated partial summation. `iterSum 0 f = f`, and each successive
+level takes running totals of the previous one. -/
+def iterSum : ℕ → (ℕ → ℕ) → (ℕ → ℕ)
+  | 0,     f => f
+  | d + 1, f => partialSum (iterSum d f)
+
+/-- **Iterated-summation characterization of the figurate ladder.** The `d`-fold
+iterated partial sum of the constant sequence `1` is exactly the `d`-dimensional
+hyper-tetrahedral number:
+
+`iterSum d (fun _ => 1) n = P_d(n) = C(n+d, d)`.
+
+This is the structural heart of the figurate numbers: starting from the constant
+`1`, one summation gives the linear numbers, a second gives the triangular
+numbers, a third the tetrahedral numbers, and in general `d` summations give the
+`d`-dimensional simplex numbers. The whole ladder is one statement in the
+dimension `d`, proved by induction on `d` with the hockey stick `sum_simplex` as
+the single inductive step. -/
+theorem iterSum_one (d n : ℕ) :
+    iterSum d (fun _ => 1) n = simplexNumber d n := by
+  induction d generalizing n with
+  | zero => simp [iterSum, simplexNumber]
+  | succ d ih =>
+    show partialSum (iterSum d (fun _ => 1)) n = simplexNumber (d + 1) n
+    simp only [partialSum]
+    rw [← sum_simplex d n]
+    exact Finset.sum_congr rfl fun j _ => ih j
+
+/-- **Division-free closed form (general dimension).** Clearing the denominator
+in `P_d(n) = (n+1)(n+2)⋯(n+d)/d!`:
+
+`d! · P_d(n) = (n+1)^{(d)}` (the ascending factorial).
+
+This is the general-`d` analogue of the parent's `6·C(n+2,3) = n(n+1)(n+2)`. -/
+theorem factorial_mul_simplexNumber (d n : ℕ) :
+    d ! * simplexNumber d n = (n + 1).ascFactorial d := by
+  rw [simplexNumber, Nat.ascFactorial_eq_factorial_mul_choose]
+
+/-- The closed form as an explicit product:
+`d! · P_d(n) = ∏_{i<d} (n+1+i) = (n+1)(n+2)⋯(n+d)`. -/
+theorem factorial_mul_simplexNumber_prod (d n : ℕ) :
+    d ! * simplexNumber d n = ∏ i ∈ range d, (n + 1 + i) := by
+  rw [factorial_mul_simplexNumber, Nat.ascFactorial_eq_prod_range]
+
+/-- Bridge to the parent `TetrahedralNumberFormula`. The `d = 2` instance of the
+general hockey stick sums the triangular numbers `C(k+2, 2)` to the tetrahedral
+number `C(n+3, 3)`, matching the parent's `∑ T_k = C(n+2, 3)` up to the standard
+index shift. -/
+example (n : ℕ) :
+    ∑ k ∈ range (n + 1), (k + 2).choose 2 = (n + 3).choose 3 := by
+  simpa [simplexNumber] using sum_simplex 2 n
+
+end TetrahedralNumberFormulaOQ01

--- a/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
@@ -1,0 +1,46 @@
+# Knowledge: tetrahedral-number-formula-oq-01
+
+## Summary
+
+Open question: the **general-dimension** hockey-stick identity for hyper-tetrahedral
+(d-dimensional simplex) numbers, generalizing the parent `tetrahedral-number-formula`
+(which only proves the fixed d=3 rung: sum of triangular numbers = tetrahedral number).
+
+## Session 2026-07-09 (Session 1) - General figurate theory
+
+**Mode**: FRESH
+**Outcome**: progress (UNVERIFIED — build infrastructure down)
+
+### What I Did
+- Built a dimension-indexed theory in `proofs/Proofs/TetrahedralNumberFormulaOQ01.lean`
+  around `simplexNumber d n := (n+d).choose d`.
+- Proved (manually reviewed; 0 sorries, 0 axioms):
+  - `sum_simplex`: general hockey stick `∑_{k≤n} P_d(k) = P_{d+1}(n)` for every d.
+  - `iterSum_one`: the headline — the figurate ladder is the d-fold iterated partial
+    sum of the constant sequence 1; `iterSum d (fun _=>1) n = P_d(n)`, by induction on
+    the DIMENSION d with `sum_simplex` as the one-step engine.
+  - `simplexNumber_succ_succ`: figurate Pascal recurrence P_{d+1}(n+1)=P_{d+1}(n)+P_d(n+1).
+  - `simplexNumber_eq_multichoose`: P_d(n) = Nat.multichoose (n+1) d.
+  - `factorial_mul_simplexNumber(_prod)`: d!·P_d(n) = (n+1).ascFactorial d = ∏_{i<d}(n+1+i).
+
+### Key Findings
+- Mathlib supplies the ONE-STEP hockey stick (`Nat.sum_range_add_choose`) and the
+  multiset coefficient (`Nat.multichoose`), but NOT the dimension-indexed figurate
+  theory. The iterated-partial-sum characterization is the novel content.
+- Induction on dimension d (not on n) is the structural difference from the parent.
+
+### Blocker (verification)
+- Docker build: containerd `metadata.db` I/O error (exit 125) — host infra corruption.
+- Host `lake env lean`: main-repo cache missing `Batteries.CodeAction.Basic.olean` and
+  `Mathlib.Tactic.Omega.olean` (fleet-race olean deletion). Not found in any fleet cache.
+- Result: shipped [UNVERIFIED] after careful manual review; every lemma name/statement
+  checked against Mathlib source (Choose/Sum.lean, Choose/Basic.lean, Factorial/BigOperators.lean).
+
+### Files Modified
+- proofs/Proofs/TetrahedralNumberFormulaOQ01.lean (new)
+- src/data/research/problems/tetrahedral-number-formula-oq-01.json (knowledge)
+
+### Next Steps
+- Machine-verify when infra recovers.
+- Optional: iterated summation of a polynomial base sequence (finite-difference angle);
+  nested-Finset multi-index simplex sum as a combinatorial companion.

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -1,0 +1,87 @@
+{
+  "slug": "tetrahedral-number-formula-oq-01",
+  "title": "General Hockey-Stick Identity for Hyper-Tetrahedral Numbers",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\sum_{k=0}^{n} \\binom{k+d-2}{\\,d-1\\,} \\;=\\; \\binom{n+d-1}{\\,d\\,}\n\\qquad\\text{for all } d \\ge 1,\\; n \\ge 0.",
+    "plain": "The gallery already proves that the sum of the first `n` triangular numbers equals",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-09T15:01:52-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS (UNVERIFIED - build infra down): generalized the parent (fixed d=3) to ALL dimensions. Built a dimension-indexed hyper-tetrahedral (simplex) theory P_d(n)=C(n+d,d): figurate Pascal recurrence, the general hockey-stick sum_simplex (sum P_d = P_{d+1}), the iterated-partial-sum characterization iterSum_one (d-fold summation of the constant 1 = P_d), and the division-free closed form d! P_d(n)=prod(n+1+i). 0 sorries, 0 axioms. Could NOT machine-check: Docker containerd metadata.db I/O error + host lake cache missing Batteries.CodeAction.Basic.olean and Mathlib.Tactic.Omega.olean (fleet-race corruption).",
+    "builtItems": [
+      "simplexNumber d n := (n+d).choose d - the d-dimensional hyper-tetrahedral number (TetrahedralNumberFormulaOQ01.lean)",
+      "sum_simplex: sum_{k<=n} simplexNumber d k = simplexNumber (d+1) n - general hockey stick, any dimension d (via Nat.sum_range_add_choose)",
+      "iterSum_one: iterSum d (fun _=>1) n = simplexNumber d n - figurate ladder as d-fold iterated partial summation, induction on dimension",
+      "simplexNumber_succ_succ: P_{d+1}(n+1)=P_{d+1}(n)+P_d(n+1) - figurate Pascal recurrence",
+      "simplexNumber_eq_multichoose: P_d(n) = Nat.multichoose (n+1) d",
+      "factorial_mul_simplexNumber(_prod): d! P_d(n) = (n+1).ascFactorial d = prod_{i<d}(n+1+i) - division-free closed form generalizing 6*C(n+2,3)=n(n+1)(n+2)"
+    ],
+    "insights": [
+      "The hyper-tetrahedral / d-simplex number is exactly Mathlib Nat.multichoose (n+1) d = C(n+d,d); Mathlib gives the one-step hockey stick Nat.sum_range_add_choose : sum i in range(n+1),(i+d).choose d = (n+d+1).choose(d+1)",
+      "The whole figurate ladder (1 -> linear -> triangular -> tetrahedral -> ...) is captured in one dimension-indexed statement: it is the d-fold iterate of the partial-summation operator applied to the constant sequence 1. Induction is on the DIMENSION d, with the hockey stick as the single inductive step - a genuinely different structure from the parent's induction on n at fixed d=3.",
+      "The cleared closed form is uniform in d via the ascending factorial: d!*C(n+d,d) = (n+1).ascFactorial d (Nat.ascFactorial_eq_factorial_mul_choose), with the explicit product from Nat.ascFactorial_eq_prod_range."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the one-step hockey stick and multichoose but no dimension-indexed figurate theory: no iterated-partial-sum characterization of simplex numbers, no figurate recurrence/closed form stated uniformly in the dimension d."
+    ],
+    "nextSteps": [
+      "MACHINE-VERIFY once build infra recovers: ./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01 (or lake env lean once Batteries.CodeAction.Basic.olean / Mathlib.Tactic.Omega.olean regenerated).",
+      "Optional generalization: iterated summation of an arbitrary polynomial base sequence (not just constant 1) yields a shifted-binomial expansion - Norlund/finite-difference angle.",
+      "Optional: the multi-index simplex sum over 0<=i_1<=...<=i_k<=n of 1 = C(n+k,k) (nested-Finset form) as a second, combinatorial face of the same identity."
+    ],
+    "markdown": "# Knowledge Base: tetrahedral-number-formula-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "number-theory",
+    "figurate-numbers",
+    "binomial-coefficients",
+    "hockey-stick-identity",
+    "induction"
+  ],
+  "relatedProofs": [
+    "tetrahedral-number-formula"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-09T22:13:38.918Z",
+  "lastUpdate": "2026-07-09T22:13:39.047Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/TetrahedralNumberFormula.lean",
+      "filename": "TetrahedralNumberFormula.lean",
+      "lineCount": 128,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormula.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
`tetrahedral-number-formula-oq-01` — the **general-dimension** hockey-stick identity for
hyper-tetrahedral (d-dimensional simplex) numbers. The parent entry
`TetrahedralNumberFormula` only proves the fixed `d=3` rung (∑ triangular = tetrahedral);
this lifts the whole figurate ladder to arbitrary dimension.

## Contribution — `proofs/Proofs/TetrahedralNumberFormulaOQ01.lean`
A dimension-indexed theory around `simplexNumber d n := (n+d).choose d`:

- **`sum_simplex`** — the general hockey stick: `∑_{k≤n} P_d(k) = P_{d+1}(n)` for *every* dimension `d`.
- **`iterSum_one`** (headline) — the figurate ladder `1 → n → triangular → tetrahedral → …`
  is exactly the `d`-fold iterated partial sum of the constant sequence `1`:
  `iterSum d (fun _ => 1) n = P_d(n)`. Proved by **induction on the dimension `d`** (not on `n`),
  with `sum_simplex` as the single inductive step — a genuinely different structure from the
  parent's fixed-`d` induction.
- **`simplexNumber_succ_succ`** — figurate Pascal recurrence `P_{d+1}(n+1)=P_{d+1}(n)+P_d(n+1)`.
- **`simplexNumber_eq_multichoose`** — `P_d(n) = Nat.multichoose (n+1) d`.
- **`factorial_mul_simplexNumber(_prod)`** — division-free closed form
  `d!·P_d(n) = (n+1).ascFactorial d = ∏_{i<d}(n+1+i)`, generalizing the parent's
  `6·C(n+2,3) = n(n+1)(n+2)`.
- `d=2` instance reproduces the parent's `∑ C(k+2,2) = C(n+3,3)`.

0 sorries, 0 `axiom` declarations, no structure-encoded assumptions.

## Novelty
Mathlib supplies the one-step hockey stick (`Nat.sum_range_add_choose`) and the multiset
coefficient (`Nat.multichoose`), but not the dimension-indexed figurate theory: the
iterated-partial-sum characterization, figurate recurrence, and closed form stated uniformly
in `d` are new here.

## ⚠️ VERIFICATION STATUS: UNVERIFIED
Could **not** machine-check this session due to build-infrastructure outage:
- Docker build fails at exit 125 — containerd `metadata.db` I/O error (host corruption).
- Host `lake env lean` fails — the main-repo Mathlib cache is missing
  `Batteries.CodeAction.Basic.olean` and `Mathlib.Tactic.Omega.olean` (fleet-race olean
  deletion); the missing oleans were not present in any fleet worktree cache.

All lemma names and statements were checked against the actual Mathlib source
(`Data/Nat/Choose/Sum.lean`, `Data/Nat/Choose/Basic.lean`, `Data/Nat/Factorial/BigOperators.lean`)
and the proofs manually reviewed, but this file has **not** been elaborated by Lean. Please
re-run `./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01` once infra recovers
before treating as verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)