### PR TITLE
Enrich combinations-formula log-concavity (combinations-formula-oq-04-oq-01): cover summary tail

### DIFF
--- a/src/data/proofs/combinations-formula-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-01/annotations.json
@@ -82,5 +82,17 @@
     "significance": "key",
     "relatedConcepts": ["ultra-log-concavity", "linear_combination", "div_eq_div_iff", "rational excess"],
     "prerequisites": ["choose_adjacent_ratio_prod", "casting ℕ identities to ℚ"]
+  },
+  {
+    "id": "ann-cf0401-summary",
+    "proofId": "combinations-formula-oq-04-oq-01",
+    "range": { "startLine": 194, "endLine": 215 },
+    "type": "context",
+    "title": "Signature Checks and the Exact-Defect Summary",
+    "content": "The file closes with #check commands listing the seven theorems, then a summary of what the entry adds over the parent. Where the parent proves only that the Pascal row is log-concave (a qualitative inequality), this entry upgrades it to the EXACT defect identity (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2), equivalently the rational ratio C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)). Both the parent's ≤ and its strict interior < are then one-line corollaries: the excess (n+1)/((k+1)(n−k−1)) is ≥ 0 always and > 0 on the interior k+2 ≤ n. The whole development rests only on Mathlib's Nat.choose_succ_right_eq — no new axioms.",
+    "mathContext": "$\\frac{\\binom{n}{k+1}^2}{\\binom{n}{k}\\binom{n}{k+2}} = 1 + \\frac{n+1}{(k+1)(n-k-1)}$; excess $>0$ iff $k+2\\le n$, giving the strict interior log-concavity.",
+    "significance": "context",
+    "relatedConcepts": ["exact log-concavity defect", "ultra-log-concavity", "Nat.choose_succ_right_eq", "qualitative → quantitative", "#check verification"],
+    "prerequisites": ["the exact defect and ratio identities above", "#check output"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-04-oq-01`.

**Gap addressed:** annotations stopped at line 192, leaving the `#check` signature commands + summary (lines 194–215) uncovered.

**Added:** a `context` annotation documenting the closing verification checks and the entry's headline result — the **exact** log-concavity defect identity (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2), equivalently the rational ratio 1 + (n+1)/((k+1)(n−k−1)) — from which the parent's ≤ and strict interior < follow as one-line corollaries, all resting only on `Nat.choose_succ_right_eq`.

Annotation count 7 → 8, tail coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).