### PR TITLE
audit(prob-method-second-moment): badge mathlib→verified, drop phantom deps

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23884,10 +23884,10 @@
       "result": "clean"
     },
     "prob-method-second-moment": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:22Z",
-      "result": "clean"
+      "agentId": "auditor-cycle-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "prob-method-second-moment-oq-01": {
       "auditCount": 2,
@@ -29729,5 +29729,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T23:00:00Z"
+  "lastUpdated": "2026-07-09T00:00:00Z"
 }

--- a/src/data/proofs/prob-method-second-moment/meta.json
+++ b/src/data/proofs/prob-method-second-moment/meta.json
@@ -16,23 +16,13 @@
       "probability",
       "intermediate"
     ],
-    "badge": "mathlib",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
-        "theorem": "MeasureTheory.Integral.Lebesgue",
-        "description": "Lebesgue integration for variance computation",
-        "module": "Mathlib.MeasureTheory.Integral.Lebesgue"
-      },
-      {
-        "theorem": "Probability.Variance",
-        "description": "Variance and covariance definitions",
-        "module": "Mathlib.Probability.Variance"
-      },
-      {
-        "theorem": "Combinatorics.SimpleGraph.Basic",
-        "description": "Graph definitions for threshold applications",
-        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+        "theorem": "Finset.sum / Finset.induction_on",
+        "description": "Finite big-operator and induction infrastructure used for the from-scratch sum manipulations (Chebyshev, Cauchy-Schwarz, Paley-Zygmund). No deep Mathlib probability theorem is used.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
       }
     ],
     "originalContributions": [
@@ -51,7 +41,7 @@
       "Random graphs G(n,p) and threshold functions",
       "Indicator random variables and covariance"
     ],
-    "assumptions": "0 sorries, 0 axioms. Fully verified.",
+    "assumptions": "0 sorries, 0 axioms. Fully verified. Self-contained discrete formalization over ℚ-valued Finset functions: Chebyshev, Paley-Zygmund, and the Cauchy-Schwarz helper are all proved from scratch (the finite Cauchy-Schwarz lemma by induction) — no deep Mathlib probability or measure-theory theorem does the core work.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
     "definitionCount": 0
@@ -59,7 +49,7 @@
   "overview": {
     "historicalContext": "The second moment method extends the first moment method by incorporating variance to prove that random variables are concentrated near their expectation. While the first moment method can only guarantee that a maximum or minimum exists, the second moment method shows that typical outcomes are close to the mean — and in particular, that a positive-mean random variable is positive with substantial probability.\n\nChebyshev's inequality, published by Pafnuty Chebyshev in 1867, is the foundation: $\\Pr[|X - E[X]| \\geq t] \\leq \\operatorname{Var}[X]/t^2$. The inequality was proved using Chebyshev's elegant application of Markov's inequality to the squared deviation. Irénée-Jules Bienaymé had stated a version earlier (1853), so the result is sometimes called the Bienaymé-Chebyshev inequality.\n\nThe Paley-Zygmund inequality, due to Raymond Paley and Antoni Zygmund (1932), provides a complementary lower bound: for $X \\geq 0$, $\\Pr[X > 0] \\geq (E[X])^2/E[X^2]$. While Chebyshev bounds the probability of large deviations from above, Paley-Zygmund bounds the probability of positivity from below — exactly what combinatorial existence proofs require.\n\nThe second moment method became indispensable in the study of random graphs after Erdős and Rényi's foundational 1959 paper 'On Random Graphs I,' which introduced the $G(n,p)$ model. Their key insight was that many graph properties exhibit sharp thresholds: a property either holds with probability tending to 0 or to 1, with a sharp transition at a critical edge probability $p^*(n)$. The second moment method is the standard tool for establishing these thresholds. Bollobás, Friedgut, and others later developed the theory of sharp thresholds into a rich field connecting probability, combinatorics, and statistical physics.",
     "problemStatement": "Chebyshev's Inequality: For any random variable $X$ with finite variance, $\\Pr[|X - E[X]| \\geq t] \\leq \\operatorname{Var}[X] / t^2$.\n\nPaley-Zygmund Inequality: For a non-negative random variable $X$, $\\Pr[X > 0] \\geq (E[X])^2 / E[X^2]$.\n\nApplication: If the expected number of copies of a subgraph $H$ in a random graph $G(n,p)$ tends to infinity and the variance is controlled, then $G(n,p)$ contains $H$ with high probability.",
-    "text": "A 226-line formalization of the second moment method with 0 sorries, providing the concentration toolkit for probabilistic combinatorics. The file builds four layers: (1) a discrete Chebyshev inequality bounding the number of elements deviating from the mean by at least $t$ as $|s| \\cdot \\operatorname{Var}[f]/t^2$; (2) a qualitative Paley-Zygmund inequality proving that non-negative functions with positive sum have a positive element; (3) a quantitative existence theorem showing that if $E[X^2] \\cdot |s| \\leq 2(E[X])^2$, then at least half the sample space has $X > 0$; and (4) a quantitative Paley-Zygmund inequality showing that $|\\{a : f(a) \\geq \\theta\\mu\\}| \\geq (1-\\theta)^2 (\\sum f)^2 / \\sum f^2$ for threshold parameter $0 \\leq \\theta < 1$. Supporting helper lemmas include a finite Cauchy-Schwarz inequality $(\\sum f)^2 \\leq |s| \\cdot \\sum f^2$ proved by induction, and support/monotonicity lemmas for non-negative functions. The framework uses $\\mathbb{Q}$-valued functions on `Finset` for exact arithmetic, avoiding measure-theoretic overhead while capturing the essential probabilistic arguments.",
+    "text": "A 225-line formalization of the second moment method with 0 sorries, providing the concentration toolkit for probabilistic combinatorics. The file builds four layers: (1) a discrete Chebyshev inequality bounding the number of elements deviating from the mean by at least $t$ as $|s| \\cdot \\operatorname{Var}[f]/t^2$; (2) a qualitative Paley-Zygmund inequality proving that non-negative functions with positive sum have a positive element; (3) a quantitative existence theorem showing that if $E[X^2] \\cdot |s| \\leq 2(E[X])^2$, then at least half the sample space has $X > 0$; and (4) a quantitative Paley-Zygmund inequality showing that $|\\{a : f(a) \\geq \\theta\\mu\\}| \\geq (1-\\theta)^2 (\\sum f)^2 / \\sum f^2$ for threshold parameter $0 \\leq \\theta < 1$. Supporting helper lemmas include a finite Cauchy-Schwarz inequality $(\\sum f)^2 \\leq |s| \\cdot \\sum f^2$ proved by induction, and support/monotonicity lemmas for non-negative functions. The framework uses $\\mathbb{Q}$-valued functions on `Finset` for exact arithmetic, avoiding measure-theoretic overhead while capturing the essential probabilistic arguments.",
     "proofStrategy": "The formalization builds the second moment toolkit:\n\n1. **Variance definition**: $\\operatorname{Var}[X] = E[X^2] - (E[X])^2$ for finite probability spaces, with the Finset-based computation framework.\n\n2. **Chebyshev's inequality**: From Markov's inequality applied to $(X - E[X])^2$. This gives an upper bound on the probability of large deviations.\n\n3. **Paley-Zygmund inequality**: By Cauchy-Schwarz, $E[X]^2 = E[X \\cdot \\mathbf{1}_{X>0}]^2 \\leq E[X^2] \\cdot \\Pr[X > 0]$. Rearranging gives the lower bound on $\\Pr[X > 0]$.\n\n4. **Application to indicator sums**: For $X = \\sum_i X_i$ with indicators $X_i$, compute $\\operatorname{Var}[X] = \\sum_i \\operatorname{Var}[X_i] + \\sum_{i \\neq j} \\operatorname{Cov}[X_i, X_j]$. When the covariance sum is small relative to $(E[X])^2$, the second moment method yields strong concentration.",
     "keyInsights": [
       "The second moment method converts variance bounds into existence guarantees: low variance relative to the mean squared ensures positive probability",


### PR DESCRIPTION
## Integrity Issue (badge/tier mislabel + phantom dependencies)

**Proof**: prob-method-second-moment (Second Moment Method)
**Detector status**: 0 issues (counts all match) — this is a narrative/tier finding the count detector cannot catch.

### Problem 1 — badge underclaim (Tier B → actually Tier A)
`badge` was `"mathlib"`, signaling the core result is derived from a Mathlib theorem. It is not. Reading all 7 declarations in `proofs/Proofs/ProbMethodSecondMoment.lean`:
- `chebyshev_finite` — proved via elementary `Finset.sum` manipulation
- `paley_zygmund` — elementary contradiction argument
- `sq_sum_le_card_mul_sum_sq` (finite Cauchy-Schwarz) — proved **by induction** (`Finset.induction_on`)
- `second_moment_existence`, `paley_zygmund_quantitative` — built from the file's own lemmas

Everything is self-contained over ℚ-valued `Finset` functions; the description itself says it is "avoiding measure-theoretic overhead." No deep Mathlib probability/measure theorem does the core work → **Tier A**, `badge: "verified"`. (Same underclaim pattern as sqrt2-from-axioms, #36331.)

### Problem 2 — phantom mathlibDependencies
The listed deps `MeasureTheory.Integral.Lebesgue`, `Probability.Variance`, `Combinatorics.SimpleGraph.Basic` appear **nowhere** in the source (`grep` returns zero hits). Replaced with the actual dependency: Mathlib's `Finset` big-operator / induction infrastructure.

### Problem 3 — cosmetic
Prose said "226-line formalization"; `lineCount` and `wc -l` are both 225. Fixed.

## Fix
- `badge`: `mathlib` → `verified`
- `mathlibDependencies`: 3 phantom probability/measure entries → 1 honest Finset-infrastructure entry
- `assumptions`: clarified self-contained from-scratch status
- `text`: 226 → 225

Counts verified unchanged: 7 theorems (4 public + 3 private lemma), 0 def, 0 sorry, 0 axiom.

---
Discovered during gallery integrity audit. Tracker bumped (auditCount 3→4, result issues-fixed).