### PR TITLE
research(erdos-1144-oq-03): sharp tight partial-sum bound |S_N| ≤ N-1 (verified)

### DIFF
--- a/proofs/Proofs/Erdos1144Problem.lean
+++ b/proofs/Proofs/Erdos1144Problem.lean
@@ -208,6 +208,32 @@ theorem partialSum_trivial_bound {f : ℕ → ℤ} (hf : IsRademacherMultiplicat
     simp only [Finset.sum_const, nsmul_eq_mul, mul_one]
     exact_mod_cast (Finset.card_filter_le _ _).trans (le_of_eq (Finset.card_range N)))
 
+/-- **Sharp deterministic bound:** `|∑_{m ≤ N} f(m)| ≤ N - 1` for `N ≥ 1`.
+
+    The partial sum ranges over `{1, …, N-1}` — the `m = 0` term is excluded by the
+    `· ≥ 1` filter — so there are only `N - 1` unit terms, one fewer than the naive
+    `partialSum_trivial_bound` (`≤ N`). This bound is **tight**: the constant
+    function `f ≡ 1` attains `partialSum = N - 1` exactly (`partialSum_const_one`),
+    so `N - 1` is the best deterministic ceiling and no purely structural argument
+    can do better. The entire content of Erdős #1144 is the almost-sure collapse
+    from this linear ceiling down to the `√N (log N)^{1+o(1)}` scale
+    (`atherfold_upper_bound`) and the conjectured `√N` lower oscillation. -/
+theorem partialSum_sharp_bound {f : ℕ → ℤ} (hf : IsRademacherMultiplicative f)
+    {N : ℕ} (hN : 1 ≤ N) : |(partialSum f N : ℝ)| ≤ (N : ℝ) - 1 := by
+  have h_each : ∀ m ∈ ((Finset.range N).filter (fun n => n ≥ 1)), |(f m : ℝ)| ≤ 1 := by
+    intro m hm
+    rcases rademacher_values_pm1 hf (Finset.mem_filter.mp hm |>.2) with h | h <;> simp [h]
+  have h_bound : |(partialSum f N : ℝ)| ≤
+      ∑ _m ∈ ((Finset.range N).filter (fun n => n ≥ 1)), (1 : ℝ) :=
+    le_trans (mod_cast Finset.abs_sum_le_sum_abs _ _) (Finset.sum_le_sum h_each)
+  have hset : ((Finset.range N).filter (fun n => n ≥ 1)) = Finset.Ico 1 N := by
+    ext x
+    simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_Ico]
+    omega
+  refine le_trans h_bound ?_
+  rw [Finset.sum_const, nsmul_eq_mul, mul_one, hset, Nat.card_Ico, Nat.cast_sub hN]
+  norm_num
+
 /-- The conjecture, if true, would mean the growth rate is exactly √N
 up to logarithmic factors: between C·√N (infinitely often, from conjecture)
 and C'·√N·(log N)^{1+ε} (eventually, from Atherfold). -/


### PR DESCRIPTION
## Summary

Sharpens the partial-sum infrastructure of `Proofs/Erdos1144Problem.lean` (Erdős
Problem #1144 — partial sums of random multiplicative functions, OPEN).

### New theorem (verified, axiom-free, 0 sorries)

- **`partialSum_sharp_bound`** — for a Rademacher multiplicative `f` and `N ≥ 1`,
  `|∑_{m ≤ N} f(m)| ≤ N - 1`.

The existing `partialSum_trivial_bound` gives `≤ N`. But `partialSum` ranges over
`{1, …, N-1}` — the `m = 0` term is dropped by the `· ≥ 1` filter — so there are
only `N - 1` unit terms. This bound is **tight**: the constant function `f ≡ 1`
attains `partialSum = N - 1` exactly (the file's `partialSum_const_one`), so `N-1`
is the best possible *deterministic* ceiling and no purely structural argument can
do better.

This directly serves the oq-03 goal ("preserve/extend the verified partial-sum
infrastructure while separating it from the Atherfold axiom"): it pins the exact
linear ceiling above which the *entire* content of Erdős #1144 lives — the almost-sure
collapse from `N-1` down to the `√N (log N)^{1+o(1)}` scale (`atherfold_upper_bound`)
and the conjectured `√N` lower oscillation.

### Proof

Mirrors the proven `partialSum_trivial_bound` idiom (`Finset.abs_sum_le_sum_abs` +
`Finset.sum_le_sum` with `rademacher_values_pm1`), replacing the loose
`card ≤ N` step with the exact `({1,…,N-1}).card = N-1` computed via
`(range N).filter (·≥1) = Finset.Ico 1 N` and `Nat.card_Ico`.

## Build status: ✅ VERIFIED

`✔ [3058/3058] Built Proofs.Erdos1144Problem (162s)` via the Docker wrapper.
Axiom-free, `sorry`-free (the file's sole `atherfold_upper_bound` axiom is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)