### PR TITLE
Enrich odd-square Basel entry (basel-problem-oq-09): add Dirichlet-lambda reference

### DIFF
--- a/src/data/proofs/basel-problem-oq-09/meta.json
+++ b/src/data/proofs/basel-problem-oq-09/meta.json
@@ -187,6 +187,13 @@
       "year": "1974",
       "venue": "Academic Press",
       "description": "Develops ζ and its companions (the Dirichlet eta and lambda functions) whose integer values follow from the same machinery."
+    },
+    {
+      "title": "Introduction to Analytic Number Theory",
+      "author": "Tom M. Apostol",
+      "year": "1976",
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "description": "Standard reference for the Dirichlet lambda function λ(s) = ∑ 1/(2k+1)^s = (1 − 2^{−s})ζ(s) and the eta/beta companions; establishes ζ(2m) = (rational)·π^{2m} via Bernoulli numbers, the identity behind this entry's λ(2) = π²/8 and the λ(2m) generalization in open question 1."
     }
   ],
   "openQuestions": [


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-09` (quality 95, passes 0).

Already a complete, high-quality entry under all caps (12.5 KB, 9 fully-populated annotations covering the whole Lean file, 5 keyInsights, 4 crossRefs, full section coverage). The one genuinely thin field was `references` (2, below the gallery norm).

**references (2 → 3):** added Apostol, *Introduction to Analytic Number Theory* (1976) — the standard source for the Dirichlet lambda $\lambda(s)=\sum 1/(2k+1)^s=(1-2^{-s})\zeta(s)$ framing the entry repeatedly uses, and the $\zeta(2m)=(\text{rational})\cdot\pi^{2m}$ identity underlying open question 1's $\lambda(2m)$ generalization.

Accurate, real reference tied directly to the entry's stated framing. Within all caps. JSON validity and meta-size guardrail pass.