### PR TITLE
Enrich Gödel incompleteness axiom-independence (godel-first-incompleteness-oq01-oq-03): cover header

### DIFF
--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-03/annotations.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "godel-oq0103-header",
+    "proofId": "godel-first-incompleteness-oq01-oq-03",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "context",
+    "title": "OQ-03: Are the Five Axioms Independent? (A Soundness Finding)",
+    "content": "The header states the open question — the parent proves First Incompleteness from five axioms on an opaque Provable predicate and asks whether they are genuinely logically independent — and delivers a surprising negative answer with a soundness finding. Restricting the four substantive axioms to the single relevant trio {G, Prov⌜G⌝, ¬G} (codes 42, 84, 43), the entry proves two things over an arbitrary P : ℕ → Prop. (1) core_inconsistency: the three axioms D1G (P G → P Prov⌜G⌝), SelfRef (P G ↔ ¬P Prov⌜G⌝), OmegaCons (¬P G → ¬P Prov⌜G⌝) are JOINTLY INCONSISTENT for every P, so the parent's axiom set has no model (no_model_of_all_axioms) — its incompleteness theorem holds only vacuously, a subtler form of the 'Provable := fun _ => False' vacuity the parent tried to avoid. The flaw diagnosed: the meta-level equivalence ⊢G ↔ ¬⊢Prov⌜G⌝ was asserted as an axiom, whereas genuine arithmetic only has the object-level F ⊢ (G ↔ ¬Prov⌜G⌝). (2) negGProv_derivable: the fourth axiom is derivable from D1G ∧ SelfRef, hence not independent. The three-axiom inconsistency is shown minimal (each independent of the other two via a model). Honest answer to OQ-03: the axioms are NOT independent. Stated abstractly so nothing imports the parent's inconsistent global axioms; 0 sorries, 0 axiom declarations, no native_decide.",
+    "mathContext": "For all $P$: $D1G \\wedge SelfRef \\wedge OmegaCons$ is inconsistent (no model), and $NegGProv$ follows from $D1G\\wedge SelfRef$. Root cause: meta-level $\\vdash G \\leftrightarrow \\neg\\vdash\\mathrm{Prov}\\ulcorner G\\urcorner$ asserted as an axiom instead of object-level $F\\vdash(G\\leftrightarrow\\neg\\mathrm{Prov}\\ulcorner G\\urcorner)$.",
+    "significance": "context",
+    "relatedConcepts": ["Gödel's first incompleteness theorem", "axiom independence", "vacuous truth / no model", "meta-level vs object-level provability", "ω-consistency"],
+    "prerequisites": ["provability predicates", "self-reference / diagonal lemma", "logical consistency and models"]
+  },
+  {
     "id": "ann-encoding",
     "proofId": "godel-first-incompleteness-oq01-oq-03",
     "range": {


### PR DESCRIPTION
Enrichment pass for `godel-first-incompleteness-oq01-oq-03`.

**Gap addressed:** annotation coverage started at line 52, leaving the substantial docstring header (lines 1–51) uncovered.

**Added:** a `context` annotation covering lines 1–51 — framing OQ-03 (are the parent's five axioms genuinely independent?) and the two findings: (1) three axioms (D1G, SelfRef, OmegaCons) are jointly inconsistent for every P, so the parent's axiom set has no model and its incompleteness theorem holds only vacuously — root cause being a meta-level equivalence asserted as an axiom where genuine arithmetic has only the object-level form; (2) the fourth axiom is derivable from two others. Honest answer: the axioms are not independent.

Annotation count 4 → 5, header coverage closed. meta.json unchanged. Axiom/status integrity confirmed against the Lean file (verified, 0 axioms, 0 sorries, no native_decide; stated abstractly over an arbitrary P so it does not import the parent's inconsistent axioms).