### PR TITLE
Enrich Fibonacci doubled-argument transform (fibonacci-identities-oq-06-oq-01-oq-03): cover header

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-oq060103-header",
+    "proofId": "fibonacci-identities-oq-06-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "context",
+    "title": "Feeding the Binomial Transform Even-Indexed Fibonacci: The (5,5) Lucas Sequence",
+    "content": "The header frames the open question. The parent proved the Fibonacci binomial transform ∑_{k≤n} C(n,k)Fₖ = F₂ₙ (index-doubling); a sibling handled the alternating transform. This entry asks what happens when the transform is fed the even-indexed Fibonacci numbers F₂ₖ, i.e. Cₙ = ∑_{k≤n} C(n,k)F₂ₖ. The naive guess F₄ₙ is WRONG: the sequence 0,1,5,20,75,275,1000,… is no Fibonacci sequence at any index — it is the Lucas sequence Uₙ(P,Q) with P=5, Q=5, satisfying Cₙ₊₂ = 5Cₙ₊₁ − 5Cₙ, C₀=0, C₁=1. Why (5,5): by Binet ∑ C(n,k)φ²ᵏ = (1+φ²)ⁿ, and since φ²=φ+1 the base is 1+φ² = φ+2 = √5·φ (likewise 1+ψ² = −√5·ψ), so φ+2, ψ+2 are the roots of x²−5x+5. Tracking the √5 factors yields the closed form Cₙ = 5^{n/2}Fₙ (n even) / 5^{(n−1)/2}Lₙ (n odd) — the transform scales by powers of √5 and alternates Fibonacci/Lucas rather than doubling the index again. The engine is pascal_conv_ring (ring-valued Pascal convolution) applied to F₂ₖ and F₂ₖ₊₂, plus the even-index recurrence F_{m+4} = 3F_{m+2} − F_m, giving the coupled first-order system Cₙ₊₁ = Cₙ + Dₙ, Dₙ₊₁ = 4Dₙ − Cₙ that collapses to the (5,5) recurrence. No axioms, no sorry, no native_decide.",
+    "mathContext": "$C_n = \\sum_{k\\le n}\\binom{n}{k}F_{2k}$ satisfies $C_{n+2}=5C_{n+1}-5C_n$ ($P{=}Q{=}5$), NOT $F_{4n}$; roots $\\varphi+2,\\psi+2$ of $x^2-5x+5$ since $1+\\varphi^2=\\sqrt5\\,\\varphi$. Closed form $C_n = 5^{n/2}F_n$ (even $n$), $5^{(n-1)/2}L_n$ (odd $n$).",
+    "significance": "context",
+    "relatedConcepts": ["binomial transform", "Lucas sequences U_n(P,Q)", "Binet formula", "golden ratio identities φ²=φ+1", "Pascal convolution"],
+    "prerequisites": ["the parent Fibonacci binomial transform", "Binet / golden ratio", "second-order linear recurrences"]
+  },
+  {
     "id": "ann-oq060103-pascal-ring",
     "proofId": "fibonacci-identities-oq-06-oq-01-oq-03",
     "range": {


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-06-oq-01-oq-03`.

**Gap addressed:** annotation coverage started at line 59, leaving the substantial docstring header (lines 1–58) uncovered.

**Added:** a `context` annotation covering lines 1–58 — framing the open question (feed the binomial transform even-indexed Fibonacci F₂ₖ) and the surprising answer: Cₙ = ∑ C(n,k)F₂ₖ is **not** F₄ₙ but the Lucas sequence Uₙ(5,5) with Cₙ₊₂ = 5Cₙ₊₁ − 5Cₙ, derived via Binet (1+φ² = √5·φ ⟹ roots of x²−5x+5), with the √5-scaling closed form Cₙ = 5^{n/2}Fₙ (even) / 5^{(n−1)/2}Lₙ (odd), and the `pascal_conv_ring` + even-index-recurrence engine.

Annotation count 4 → 5, header coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries, no native_decide).