### PR TITLE
audit(prob-method-lovasz-local): record issues-found (#36397)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23872,10 +23872,11 @@
       "result": "clean"
     },
     "prob-method-lovasz-local": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:49Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T23:00:00Z",
+      "result": "issues-found",
+      "issue": 36397
     },
     "prob-method-lovasz-local-oq-02": {
       "auditCount": 1,


### PR DESCRIPTION
Persists audit-tracker bump for prob-method-lovasz-local (issues-found → #36397).

Only touches `audit-tracker.json` (the git-tracked tracker gets reset by the audit loop, so the completion write must land via PR). No count or content regeneration.

Finding: the Lovász Local Lemma entry presents `status: verified` + a `mainTheorems` entry claiming the full probabilistic LLL, but the Lean file only formalizes the algebraic skeleton (rational-arithmetic positivity, simplified `p(d+1) ≤ 1/3` condition). See #36397 for details and recommended meta.json fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)