### PR TITLE
Enrich Dirichlet eta η(4) entry (basel-problem-oq-14): add reference

### DIFF
--- a/src/data/proofs/basel-problem-oq-14/meta.json
+++ b/src/data/proofs/basel-problem-oq-14/meta.json
@@ -172,6 +172,13 @@
       "year": "1974",
       "venue": "Academic Press",
       "description": "Develops the Dirichlet eta function η(s) = (1 - 2^(1-s))ζ(s) as the alternating series used to continue ζ past Re s = 1."
+    },
+    {
+      "title": "Introduction to Analytic Number Theory",
+      "author": "Tom M. Apostol",
+      "year": "1976",
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "description": "Standard reference for the Dirichlet eta relation η(s) = (1 − 2^{1−s})ζ(s) and for the even zeta values ζ(2m) = (rational)·π^{2m} via Bernoulli numbers (ζ(4) = π⁴/90), the two facts behind η(4) = (7/8)ζ(4) = 7π⁴/720 and the η(2m) generalization in this entry's open question."
     }
   ],
   "openQuestions": [


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-14` (quality 95, passes 0). Already complete and under all caps (11.6 KB, 7 annotations covering the full Lean file, 5 keyInsights, 3 coherent crossRefs). The one thin field was `references` (2).

**reference (2 → 3):** Apostol, *Introduction to Analytic Number Theory* (1976) — standard source for η(s)=(1−2^{1−s})ζ(s) and the ζ(2m)=rational·π^{2m} (Bernoulli) values behind η(4)=(7/8)ζ(4)=7π⁴/720 and the entry's η(2m) open question.

Accurate, tied to the entry's framing. Within all caps.