### PR TITLE
Enrich minimal-normal-subgroups (lagrange-theorem-oq-01-oq-03-oq-02): cover header

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-lagrange-oq010302-header",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 65 },
+    "type": "context",
+    "title": "Minimal Normal Subgroups: Existence and Abelianness in the Solvable Case",
+    "content": "The header frames the open question, a continuation of the Hall's-theorem thread. The sibling proved the Schur–Zassenhaus lifting step of Hall's theorem (0 axioms) and pinpointed the remaining gap: a 0-axiom Hall theorem for solvable groups needs minimal-normal-subgroup machinery that Mathlib 4.26 lacks. This file supplies two of those facts, with 0 axioms: exists_minimal_normal_subgroup (a nontrivial finite group has a minimal normal subgroup N — normal, ≠ ⊥, with no proper nontrivial normal subgroup below it) and minimal_normal_abelian_of_solvable (a minimal normal subgroup of a solvable group is abelian), packaged as exists_abelian_minimal_normal_subgroup. Existence: for finite G the subgroup lattice is finite, so {K | K.Normal ∧ K ≠ ⊥} is finite and nonempty (⊤ qualifies) and has a minimal element (Set.Finite.exists_minimal). Abelianness: for a minimal normal N in a solvable G, the commutator ⁅N,N⁆ is normal in G (Subgroup.commutator_normal), contained in N, and strictly smaller than N by solvability (IsSolvable.commutator_lt_of_ne_bot); minimality forces ⁅N,N⁆ = ⊥, i.e. N ≤ centralizer N, so N is abelian. The header also records the next increment toward full Hall (elementary-abelianness via characteristic p-torsion + Cauchy) — explicitly NOT claimed here.",
+    "mathContext": "Minimal normal $N$: normal, $N\\ne\\bot$, no proper nontrivial normal subgroup below. In solvable $G$: $\\lbrack N,N\\rbrack \\lhd G$, $\\lbrack N,N\\rbrack < N$ (solvability) $\\Rightarrow \\lbrack N,N\\rbrack=\\bot \\Rightarrow N$ abelian.",
+    "significance": "context",
+    "relatedConcepts": ["minimal normal subgroup", "solvable groups", "Hall's theorem", "commutator subgroup ⁅N,N⁆", "finite subgroup lattice"],
+    "prerequisites": ["normal subgroups and the subgroup lattice", "solvability and derived series", "commutators and centralizers"]
+  },
+  {
     "id": "ann-is-minimal-normal",
     "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
     "range": { "startLine": 66, "endLine": 70 },


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-01-oq-03-oq-02`.

**Gap addressed:** annotation coverage started at line 66, leaving the substantial docstring header (lines 1–65) uncovered.

**Added:** a `context` annotation covering lines 1–65 — framing the Hall's-theorem thread and the two 0-axiom facts this file supplies: existence of a minimal normal subgroup of a nontrivial finite group (finite subgroup lattice → `Set.Finite.exists_minimal`), and abelianness of a minimal normal subgroup of a solvable group (⁅N,N⁆ normal, strictly below N by `IsSolvable.commutator_lt_of_ne_bot`, hence ⊥). The header's next-increment elementary-abelian gap is noted as explicitly not claimed here.

Annotation count 4 → 5, header coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).