### PR TITLE
audit: prime-number-theorem + prime-gap-bounds re-audited CLEAN 2026-07-09

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23714,9 +23714,9 @@
       "issues": []
     },
     "prime-gap-bounds": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:51Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T16:20:00Z",
       "result": "clean"
     },
     "prime-gap-bounds-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23732,9 +23732,9 @@
       "result": "clean"
     },
     "prime-number-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:51Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T16:15:00Z",
       "result": "clean"
     },
     "prime-number-theorem-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — 2 stalest tracker entries (last audited 2026-05-03)

Both **CLEAN**. Only the audit tracker is bumped; no gallery content changed.

### 1. prime-number-theorem — CLEAN
Disclosed axiomatized entry (`Proofs/PrimeNumberTheorem.lean`, 460 lines).

| Field | meta | source | ✓ |
|-------|------|--------|---|
| status/badge | axiomatized / axiom | 8 axioms | ✓ |
| axiomCount | 8 | 8 | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 460 | 460 | ✓ |
| theoremCount | 15 | 15 | ✓ |
| definitionCount | 9 | 9 | ✓ |

- All 8 axioms are genuine statements (not True-stubs); `assumptions` enumerates them by name.
- All 5 "PROVED …" contribution bullets reference real, genuinely-proved theorems (L138/165/190/399/237).
- No masking — status/badge correctly disclose axiomatization (famous theorem → axiomatized per policy).

### 2. prime-gap-bounds — CLEAN
Verified entry (`Proofs/PrimeGapBounds.lean`, 202 lines).

| Field | meta | source | ✓ |
|-------|------|--------|---|
| status/badge | verified / original | 0 axioms, 0 sorries | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 202 | 202 | ✓ |
| theoremCount | 13 | 13 | ✓ |
| definitionCount | 0 | 0 | ✓ |

- **badge=original defensible (dual-content):** `bertrand_postulate` is honestly disclosed as "wrapper extracting Bertrand's postulate from Mathlib" (and Bertrand is listed in `mathlibDependencies`). The showcased results — `primeCounting_double_gt`, `primeCounting_pow_two_mul` (induction), `nth_prime_succ_le_of_prime_gt` (non-trivial `by_contra` on `Nat.count`), `nth_prime_le_two_pow` (induction) — are genuine independent derivations on top of Bertrand, not re-exports.
- Small-value computations use `by decide` (kernel-checked), **not** `native_decide` → no `Lean.ofReduceBool`, so axiomCount 0 / status verified is correct.
- No True-stubs, no hidden sorries.

---
Discovered during autonomous gallery integrity audit loop.