### PR TITLE
Enrich Erdős-1026 approximate monotonicity (erdos-1026-oq-02): cover header

### DIFF
--- a/src/data/proofs/erdos-1026-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1026-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "erdos1026-oq02-header",
+    "proofId": "erdos-1026-oq-02",
+    "range": { "startLine": 1, "endLine": 72 },
+    "type": "context",
+    "title": "Does the Monotonic-Subsequence Bound Survive ε-Approximate Monotonicity?",
+    "content": "The header frames OQ-02 of Erdős Problem #1026. By Erdős–Szekeres every sequence of k²+1 distinct reals has a monotonic subsequence of length k+1; the optimization variant maximizes the sum such a subsequence carries. OQ-02 relaxes rigid monotonicity to ε-approximate monotonicity — a subsequence whose later values may dip below earlier ones by at most a tolerance ε ≥ 0 (dually for decreasing), the natural noise-robust variant — and asks whether the same length guarantees hold or whether the slack ε permits provably longer subsequences. This file proves, axiom-free, the EASY HALF: approximate monotonicity is a genuine relaxation of exact monotonicity, so every classical lower bound transfers verbatim. Concretely: at ε=0 the approximate notion is exactly strict monotonicity (isApproxIncreasing_zero_iff); the tolerance is monotone, larger ε is weaker (isApproxIncreasing_mono); every exactly monotonic subsequence is ε-approximately monotonic (IsIncreasing.isApproxIncreasing); hence existence transfers (exists_approxMonotonic_of_exists_monotonic). LEFT OPEN — the hard, interesting direction: whether the slack is ever strictly helpful (some sequence has an ε-approx-monotonic subsequence strictly longer than any exactly monotonic one). The notions genuinely differ (approxIncreasing_not_increasing gives a witness), so the question is nonvacuous; quantifying the gain is the open content. The framework re-states the minimal Subsequence interface of Erdos1026Problem rather than importing it (that file depends on Archive.Wiedijk100Theorems). No axioms, no sorries.",
+    "mathContext": "$\\varepsilon$-approx increasing: for $i<j$, $\\mathrm{seq}(\\mathrm{idx}_i)-\\varepsilon < \\mathrm{seq}(\\mathrm{idx}_j)$. At $\\varepsilon=0$: strict increase. Easy half: every length-$m$ monotonic subsequence gives an $\\varepsilon$-approx one, so the $k+1$ lower bound persists.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős–Szekeres theorem", "monotonic subsequences", "ε-approximate / noise-robust monotonicity", "relaxation transfers lower bounds", "Erdős Problem #1026"],
+    "prerequisites": ["Erdős–Szekeres monotonic subsequence bound", "subsequences as strictly monotone index maps", "relaxation vs. tightening of a constraint"]
+  },
+  {
     "id": "approx-increasing-def",
     "proofId": "erdos-1026-oq-02",
     "range": {


### PR DESCRIPTION
Enrichment pass for `erdos-1026-oq-02`.

**Gap addressed:** annotation coverage started at line 73, leaving the substantial docstring header (lines 1–72) uncovered.

**Added:** a `context` annotation covering lines 1–72 — framing OQ-02 (does the Erdős–Szekeres monotonic-subsequence guarantee survive when monotonicity is relaxed to ε-approximate?), the axiom-free **easy half** proved here (approximate monotonicity is a genuine relaxation, so every classical lower bound transfers: ε=0 ⟺ strict, monotone tolerance, exact ⟹ approximate, existence transfer), and the **open hard direction** (is the slack ever strictly helpful — the notions genuinely differ, so it's nonvacuous).

Annotation count 5 → 6, header coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).