### PR TITLE
research(szemeredi-regularity-oq-04): m×k product-refinement energy increment [VERIFIED]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Product.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Product.lean
@@ -1,0 +1,218 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: the m×k product-refinement energy increment.
+
+  The companion file `SzemerediRegularityOQ04Energy` supplies the 2×2 simultaneous
+  refinement increment (`pairEnergy_prod_refinement_gain`): refining a pair `(A, B)`
+  into a disjoint `{A₁,A₂}×{B₁,B₂}` grid raises the normalized pair energy by at
+  least `(|A₁||B₁|/n²)·d²` whenever the corner sub-cell deviates from `d(A,B)` by
+  `≥ d`.  That result is the 2×2 instance of the abstract atom gain
+  `weighted_second_moment_atom_gain`, which already handles an *arbitrary* finite
+  index.  This file discharges the standing next step recorded in the problem's
+  knowledge base: lift the 2×2 grid to a genuine **m×k product refinement** driven
+  by two arbitrary disjoint families `{Aᵢ}_{i∈I}` and `{Bⱼ}_{j∈J}`.
+
+  The crux is the **general law of total density**
+
+    `|A||B|·d(A,B) = Σ_{i∈I} Σ_{j∈J} |Aᵢ||Bⱼ|·d(Aᵢ,Bⱼ)`,   `A = ⋃Aᵢ, B = ⋃Bⱼ`,
+
+  which certifies that `d(A,B)` is the honest `|Aᵢ||Bⱼ|`-weighted centroid of the
+  refined density distribution.  We obtain it by iterating the two one-sided 2-way
+  laws (`edgeDensity_union_mul`, `edgeDensity_union_mul_right`) over each family via
+  `Finset.induction`.  Feeding the mean identity plus the total-weight identity
+  `Σ_{i,j} |Aᵢ||Bⱼ| = |A||B|` into `weighted_second_moment_atom_gain` over the
+  product index `I ×ˢ J` yields, for any single deviating witness cell `(i₀,j₀)`,
+  the energy jump
+
+    `pairEnergy G A B + (|A_{i₀}||B_{j₀}|/n²)·d²
+       ≤ Σ_{i∈I} Σ_{j∈J} pairEnergy G Aᵢ Bⱼ`.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000); Komlós–Simonovits (1996).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Energy
+
+namespace Szemeredi.RegularityOQ04Energy
+
+open Szemeredi.Core Szemeredi.Regularity
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: THE GENERAL ONE-SIDED LAW OF TOTAL DENSITY (biUnion)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **A-side general law of total density.**  For a disjoint family `{Aᵢ}_{i∈I}`
+    and a fixed `B`, the edge-count-weighted density of the union splits as a sum
+    over the family:
+    `|⋃Aᵢ|·|B|·d(⋃Aᵢ,B) = Σ_{i∈I} |Aᵢ|·|B|·d(Aᵢ,B)`.
+    Proved by `Finset.induction` on `I`, peeling one part off with the 2-way
+    one-sided identity `edgeDensity_union_mul` at each step. -/
+theorem edgeDensity_biUnion_mul (G : SimpleGraph V) [DecidableRel G.Adj]
+    {ι : Type*} [DecidableEq ι] (I : Finset ι) (As : ι → Finset V) (B : Finset V)
+    (hdisj : (↑I : Set ι).PairwiseDisjoint As) :
+    (↑(I.biUnion As).card : ℚ) * ↑B.card * edgeDensity G (I.biUnion As) B =
+      ∑ i ∈ I, (↑(As i).card : ℚ) * ↑B.card * edgeDensity G (As i) B := by
+  revert hdisj
+  induction I using Finset.induction with
+  | empty => intro _; simp
+  | @insert a s ha ih =>
+    intro hdisj
+    have hsub : (↑s : Set ι).PairwiseDisjoint As :=
+      hdisj.subset (Finset.coe_subset.mpr (Finset.subset_insert a s))
+    have hdisjBig : Disjoint (As a) (s.biUnion As) := by
+      rw [Finset.disjoint_biUnion_right]
+      intro i hi
+      exact hdisj (Finset.mem_coe.mpr (Finset.mem_insert_self a s))
+        (Finset.mem_coe.mpr (Finset.mem_insert_of_mem hi)) (fun h => ha (h ▸ hi))
+    rw [Finset.biUnion_insert,
+        edgeDensity_union_mul G (As a) (s.biUnion As) B hdisjBig,
+        Finset.sum_insert ha, ih hsub]
+
+/-- **B-side general law of total density.**  Mirror of `edgeDensity_biUnion_mul`
+    on the second coordinate: for a fixed `A` and a disjoint family `{Bⱼ}_{j∈J}`,
+    `|A|·|⋃Bⱼ|·d(A,⋃Bⱼ) = Σ_{j∈J} |A|·|Bⱼ|·d(A,Bⱼ)`. -/
+theorem edgeDensity_mul_biUnion (G : SimpleGraph V) [DecidableRel G.Adj]
+    {κ : Type*} [DecidableEq κ] (A : Finset V) (J : Finset κ) (Bs : κ → Finset V)
+    (hdisj : (↑J : Set κ).PairwiseDisjoint Bs) :
+    (↑A.card : ℚ) * ↑(J.biUnion Bs).card * edgeDensity G A (J.biUnion Bs) =
+      ∑ j ∈ J, (↑A.card : ℚ) * ↑(Bs j).card * edgeDensity G A (Bs j) := by
+  revert hdisj
+  induction J using Finset.induction with
+  | empty => intro _; simp
+  | @insert b t hb ih =>
+    intro hdisj
+    have hsub : (↑t : Set κ).PairwiseDisjoint Bs :=
+      hdisj.subset (Finset.coe_subset.mpr (Finset.subset_insert b t))
+    have hdisjBig : Disjoint (Bs b) (t.biUnion Bs) := by
+      rw [Finset.disjoint_biUnion_right]
+      intro j hj
+      exact hdisj (Finset.mem_coe.mpr (Finset.mem_insert_self b t))
+        (Finset.mem_coe.mpr (Finset.mem_insert_of_mem hj)) (fun h => hb (h ▸ hj))
+    rw [Finset.biUnion_insert,
+        edgeDensity_union_mul_right G A (Bs b) (t.biUnion Bs) hdisjBig,
+        Finset.sum_insert hb, ih hsub]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE PRODUCT LAW OF TOTAL DENSITY AND TOTAL WEIGHT
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The general product law of total density.**  When a pair is refined
+    simultaneously into two arbitrary disjoint families `{Aᵢ}_{i∈I}`, `{Bⱼ}_{j∈J}`,
+    the whole edge-count-weighted density is the double sum of the sub-cell ones:
+
+      `|⋃Aᵢ|·|⋃Bⱼ|·d(⋃Aᵢ,⋃Bⱼ) = Σ_{i∈I} Σ_{j∈J} |Aᵢ||Bⱼ|·d(Aᵢ,Bⱼ)`.
+
+    Equivalently, `d(A,B)` is the `|Aᵢ||Bⱼ|`-weighted mean of the `m·k` sub-densities:
+    the mean identity that `weighted_second_moment_atom_gain` consumes.  Proved by
+    the A-side biUnion law followed by the B-side one inside each term. -/
+theorem edgeDensity_prod_family_split (G : SimpleGraph V) [DecidableRel G.Adj]
+    {ι κ : Type*} [DecidableEq ι] [DecidableEq κ]
+    (I : Finset ι) (J : Finset κ) (As : ι → Finset V) (Bs : κ → Finset V)
+    (hA : (↑I : Set ι).PairwiseDisjoint As) (hB : (↑J : Set κ).PairwiseDisjoint Bs) :
+    (↑(I.biUnion As).card : ℚ) * ↑(J.biUnion Bs).card *
+        edgeDensity G (I.biUnion As) (J.biUnion Bs) =
+      ∑ i ∈ I, ∑ j ∈ J,
+        (↑(As i).card : ℚ) * ↑(Bs j).card * edgeDensity G (As i) (Bs j) := by
+  rw [edgeDensity_biUnion_mul G I As (J.biUnion Bs) hA]
+  exact Finset.sum_congr rfl (fun i _ => edgeDensity_mul_biUnion G (As i) J Bs hB)
+
+/-- **Total refined weight.**  The `|Aᵢ||Bⱼ|` weights of an `m×k` product
+    refinement sum to `|A||B|`, since the family cardinalities add over each
+    disjoint union (`Finset.card_biUnion`) and the double sum factors as a product
+    of the two marginal sums (`Finset.sum_mul_sum`). -/
+theorem prod_family_total_weight
+    {ι κ : Type*} [DecidableEq ι] [DecidableEq κ]
+    (I : Finset ι) (J : Finset κ) (As : ι → Finset V) (Bs : κ → Finset V)
+    (hA : (↑I : Set ι).PairwiseDisjoint As) (hB : (↑J : Set κ).PairwiseDisjoint Bs) :
+    (∑ i ∈ I, ∑ j ∈ J, (↑(As i).card : ℚ) * ↑(Bs j).card) =
+      (↑(I.biUnion As).card : ℚ) * ↑(J.biUnion Bs).card := by
+  rw [Finset.card_biUnion
+        (fun x hx y hy hxy => hA (Finset.mem_coe.mpr hx) (Finset.mem_coe.mpr hy) hxy),
+      Finset.card_biUnion
+        (fun x hx y hy hxy => hB (Finset.mem_coe.mpr hx) (Finset.mem_coe.mpr hy) hxy)]
+  push_cast
+  rw [Finset.sum_mul_sum]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: THE m×k PRODUCT-REFINEMENT ENERGY INCREMENT
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The m×k product-refinement energy increment.**  Refining a pair `(A, B)`
+    simultaneously into two arbitrary disjoint families `{Aᵢ}_{i∈I}`, `{Bⱼ}_{j∈J}`
+    (with `A = ⋃Aᵢ`, `B = ⋃Bⱼ`) raises the normalized pair energy by at least
+    `(|A_{i₀}||B_{j₀}|/n²)·d²` whenever a single witness sub-cell `(i₀,j₀)` has
+    density deviating from the whole density `d(A,B)` by at least `d`:
+
+      `pairEnergy G A B + (|A_{i₀}||B_{j₀}|/n²)·d²
+         ≤ Σ_{i∈I} Σ_{j∈J} pairEnergy G Aᵢ Bⱼ`.
+
+    This is the full-generality form of `pairEnergy_prod_refinement_gain` (the `2×2`
+    case, `I = J = {·,·}`).  It is exactly `weighted_second_moment_atom_gain` over
+    the product index `I ×ˢ J`, with weights `|Aᵢ||Bⱼ|`, values `d(Aᵢ,Bⱼ)`, mean
+    `d(A,B)` (discharged by `edgeDensity_prod_family_split`), total weight `|A||B|`
+    (`prod_family_total_weight`), and the witness cell as the deviating atom; the
+    raw variance excess is scaled by `1/n²` and the `pairEnergy` terms read off.
+    For an `ε`-irregular witness `|A_{i₀}| ≥ ε|A|`, `|B_{j₀}| ≥ ε|B|`,
+    `|d(A_{i₀},B_{j₀}) − d(A,B)| > ε`, this gives an energy jump `≥ ε⁴·|A||B|/n²`. -/
+theorem pairEnergy_prod_family_refinement_gain (G : SimpleGraph V) [DecidableRel G.Adj]
+    {ι κ : Type*} [DecidableEq ι] [DecidableEq κ]
+    (I : Finset ι) (J : Finset κ) (As : ι → Finset V) (Bs : κ → Finset V)
+    (hA : (↑I : Set ι).PairwiseDisjoint As) (hB : (↑J : Set κ).PairwiseDisjoint Bs)
+    (i₀ : ι) (j₀ : κ) (hi₀ : i₀ ∈ I) (hj₀ : j₀ ∈ J)
+    (d : ℚ) (hd : 0 ≤ d)
+    (hdev : d ≤ |edgeDensity G (As i₀) (Bs j₀) -
+                  edgeDensity G (I.biUnion As) (J.biUnion Bs)|) :
+    pairEnergy G (I.biUnion As) (J.biUnion Bs) +
+        (↑(As i₀).card : ℚ) * ↑(Bs j₀).card / (Fintype.card V : ℚ) ^ 2 * d ^ 2 ≤
+      ∑ i ∈ I, ∑ j ∈ J, pairEnergy G (As i) (Bs j) := by
+  classical
+  set w : ι × κ → ℚ := fun p => (↑(As p.1).card : ℚ) * ↑(Bs p.2).card with hwdef
+  set x : ι × κ → ℚ := fun p => edgeDensity G (As p.1) (Bs p.2) with hxdef
+  set μ : ℚ := edgeDensity G (I.biUnion As) (J.biUnion Bs) with hμdef
+  have hmem : (i₀, j₀) ∈ I ×ˢ J := Finset.mem_product.mpr ⟨hi₀, hj₀⟩
+  have hwnn : ∀ p ∈ I ×ˢ J, 0 ≤ w p := by
+    intro p _; simp only [hwdef]; positivity
+  -- Total weight `Σ w = |A||B|`.
+  have hWtot : (∑ p ∈ I ×ˢ J, w p) =
+      (↑(I.biUnion As).card : ℚ) * ↑(J.biUnion Bs).card := by
+    rw [Finset.sum_product]
+    simpa only [hwdef] using prod_family_total_weight I J As Bs hA hB
+  -- Mean identity `Σ w·x = (Σ w)·d(A,B)` — the general law of total density.
+  have hmean : (∑ p ∈ I ×ˢ J, w p * x p) = (∑ p ∈ I ×ˢ J, w p) * μ := by
+    rw [hWtot, Finset.sum_product]
+    simp only [hwdef, hxdef, hμdef]
+    exact (edgeDensity_prod_family_split G I J As Bs hA hB).symm
+  -- The witness cell is the deviating atom.
+  have hdev' : d ≤ |x (i₀, j₀) - μ| := by
+    show d ≤ |edgeDensity G (As i₀) (Bs j₀) - μ|
+    exact hdev
+  -- Apply the abstract atom gain over the product index.
+  have hgain := weighted_second_moment_atom_gain (I ×ˢ J) w x hwnn μ hmean
+    (i₀, j₀) hmem (w (i₀, j₀)) d (hwnn _ hmem) hd (le_refl _) hdev'
+  -- Scale the raw excess by `1/n² ≥ 0` and identify the `pairEnergy` terms.
+  have hn2 : (0 : ℚ) ≤ 1 / (Fintype.card V : ℚ) ^ 2 := by positivity
+  have hscaled := mul_le_mul_of_nonneg_left hgain hn2
+  have hL : pairEnergy G (I.biUnion As) (J.biUnion Bs) +
+        (↑(As i₀).card : ℚ) * ↑(Bs j₀).card / (Fintype.card V : ℚ) ^ 2 * d ^ 2
+      = 1 / (Fintype.card V : ℚ) ^ 2 *
+          ((∑ p ∈ I ×ˢ J, w p) * μ ^ 2 + w (i₀, j₀) * d ^ 2) := by
+    rw [hWtot, hμdef]
+    simp only [hwdef]
+    unfold pairEnergy
+    ring
+  have hR : (∑ i ∈ I, ∑ j ∈ J, pairEnergy G (As i) (Bs j))
+      = 1 / (Fintype.card V : ℚ) ^ 2 * (∑ p ∈ I ×ˢ J, w p * x p ^ 2) := by
+    rw [Finset.sum_product, Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun j _ => ?_)
+    simp only [hwdef, hxdef]
+    unfold pairEnergy
+    ring
+  rw [hL, hR]
+  exact hscaled
+
+end Szemeredi.RegularityOQ04Energy

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -57,7 +57,11 @@
       "partitionEnergy_prod_refinement_gain (SzemerediRegularityOQ04Assembly.lean): sharp whole-partition 2×2 gain — refining two distinct parts A,B into {A₁,A₂}×{B₁,B₂} raises partitionEnergy by (|A₁||B₁|/n²)·d², d=|d(A₁,B₁)−d(A,B)|. Lifts pairEnergy_prod_refinement_gain via ordered-pair block decomposition.",
       "partitionEnergy_prod_gain_eps4 (SzemerediRegularityOQ04Assembly.lean): AFKS-consumable ε⁴ floor of the sharp lift — ε-irregular pair refined on both coords raises whole-partition energy by ≥ ε⁴|A||B|/n², free of the one-sided factor-¼/⅛ loss.",
       "afks_sharp_energy_iteration_count (SzemerediRegularityOQ04Assembly.lean): SHARP AFKS iteration count N ≤ n²/(ε⁴·M). Feeds the no-loss floor δ=ε⁴·M/n² (M = min refined-pair mass |A||B|) into the [0,1]-potential termination engine partitionEnergy_iteration_bound (N≤1/δ) via one_div_div. Factor-¼-free counterpart of afks_energy_iteration_count (δ=ε²/(2n²), N≤2n²/ε²). [VERIFIED 0/0]",
-      "afks_sharp_energy_iteration_count_of_prod_witness (Assembly): end-to-end sharp certificate — derives the per-step hstep from an actual per-step ε-irregular product witness (parts n = insert A (insert B R), parts (n+1) = 2×2 grid, |A₁|≥ε|A|, |B₁|≥ε|B|, |d(A₁,B₁)−d(A,B)|≥ε, part masses ≥ m). Floors |A||B|≥m² via partitionEnergy_prod_gain_eps4 → N ≤ n²/(ε⁴·m²). Freshness stays hypothesis. [VERIFIED 0/0]"
+      "afks_sharp_energy_iteration_count_of_prod_witness (Assembly): end-to-end sharp certificate — derives the per-step hstep from an actual per-step ε-irregular product witness (parts n = insert A (insert B R), parts (n+1) = 2×2 grid, |A₁|≥ε|A|, |B₁|≥ε|B|, |d(A₁,B₁)−d(A,B)|≥ε, part masses ≥ m). Floors |A||B|≥m² via partitionEnergy_prod_gain_eps4 → N ≤ n²/(ε⁴·m²). Freshness stays hypothesis. [VERIFIED 0/0]",
+      "edgeDensity_biUnion_mul / edgeDensity_mul_biUnion (SzemerediRegularityOQ04Product.lean): general one-sided law of total density over an arbitrary disjoint Finset family, by Finset.induction peeling the 2-way edgeDensity_union_mul(_right) at each step",
+      "edgeDensity_prod_family_split (SzemerediRegularityOQ04Product.lean): general product law of total density |A||B|d(A,B)=ΣΣ|Aᵢ||Bⱼ|d(Aᵢ,Bⱼ) for arbitrary disjoint families {Aᵢ}_I,{Bⱼ}_J",
+      "prod_family_total_weight (SzemerediRegularityOQ04Product.lean): ΣΣ|Aᵢ||Bⱼ|=|A||B| via Finset.card_biUnion + Finset.sum_mul_sum",
+      "pairEnergy_prod_family_refinement_gain (SzemerediRegularityOQ04Product.lean): the full m×k product-refinement energy increment — pairEnergy A B + (|A_{i₀}||B_{j₀}|/n²)d² ≤ ΣΣ pairEnergy Aᵢ Bⱼ from a single deviating witness cell; VERIFIED 0/0, generalizes the 2×2 pairEnergy_prod_refinement_gain"
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
@@ -79,14 +83,17 @@
       "Final /n² scaling: avoid convert (mis-pairs the + tree); prove goal=1/n²·raw via unfold+ring both sides then exact the scaled inequality.",
       "The sharp direct 2×2 gain (no factor-¼ loss) DOES lift to the whole partition cleanly: the ordered-pair double sum splits into R×R (untouched), A/B rows & cols vs R (pure pairEnergy_split_mono/_mono_right), and the {A,B}² 4-term block refining into 16 sub-cells — diagonal A²,B² and the (B,A) cross by monotonicity, only the single (A,B) cross carries the variance-atom gain. So the whole-partition floor ε⁴|A||B|/n² beats the one-sided partitionEnergy_gain_of_irregular_pair floor ε²/(8n²).",
       "The deployer's file-level dedup (PR #36107 closed as superseded) discarded a UNIQUE already-VERIFIED theorem (afks_sharp_energy_iteration_count) because the winning competing PR added the same Assembly file WITHOUT that theorem — file-basename dedup is lossy when two branches touch one file with different content. Recovered + extended it.",
-      "The sharp iteration count is a thin one_div_div wrapper over the generic δ engine; the genuine new content is the witness-driven certificate that packages partitionEnergy_prod_gain_eps4 into hstep, closing per-step-witness → sharp count N≤n²/(ε⁴m²) with the freshness the only remaining hypothesis."
+      "The sharp iteration count is a thin one_div_div wrapper over the generic δ engine; the genuine new content is the witness-driven certificate that packages partitionEnergy_prod_gain_eps4 into hstep, closing per-step-witness → sharp count N≤n²/(ε⁴m²) with the freshness the only remaining hypothesis.",
+      "The 2×2 product-refinement increment generalizes verbatim to an arbitrary m×k product of disjoint families: weighted_second_moment_atom_gain already handles arbitrary finite index, so only the general law of total density (mean identity) and total-weight identity are needed as new inputs. Both are Finset.induction/card_biUnion routine over the existing 2-way one-sided laws.",
+      "General law of total density is obtained compositionally: one A-side biUnion induction (edgeDensity_biUnion_mul) times one B-side biUnion induction (edgeDensity_mul_biUnion), avoiding any direct product-partition biUnion decomposition."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Discharge the freshness hypotheses (A₁,A₂,B₁,B₂ distinct and ∉R) of afks_sharp_energy_iteration_count_of_prod_witness / partitionEnergy_prod_gain_eps4 from a nonempty-equipartition model to obtain a fully-internal ∃P′ capstone from ¬IsEpsilonRegular (the standing blocker, shared with the one-sided route).",
       "Bound the minimum refined-pair mass m in terms of an equipartition (parts of size ≈n/k) to turn afks_sharp_energy_iteration_count into a k-explicit tower-free bound N ≤ k²/ε⁴.",
       "Generalize 2×2 → m×k product refinement via Finset(Finset V) families + card_biUnion over a product partition.",
-      "State two-level AFKS conclusion with dependent tolerance E:ℕ→(0,1]."
+      "State two-level AFKS conclusion with dependent tolerance E:ℕ→(0,1].",
+      "Wire pairEnergy_prod_family_refinement_gain into a whole-partition energy monotonicity over an m×k equipartition-refinement to feed afks_sharp_energy_iteration_count with a k-explicit index, moving toward the tower-free N ≤ k²/ε⁴ bound."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -197,7 +204,18 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04Energy.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04Product.lean",
+      "filename": "SzemerediRegularityOQ04Product.lean",
+      "lineCount": 218,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04Product.lean"
     }
   ],
-  "lastUpdate": "2026-07-08T00:00:00Z"
+  "lastUpdate": "2026-07-09"
 }


### PR DESCRIPTION
## Summary

Generalizes the 2×2 simultaneous-refinement energy increment of the strong (Alon–Fischer–Krivelevich–Szegedy) regularity lemma to a genuine **m×k product refinement** — the standing next step recorded in the problem's knowledge base.

The companion `SzemerediRegularityOQ04Energy.lean` already proves the 2×2 case (`pairEnergy_prod_refinement_gain`) as an instance of the abstract atom gain `weighted_second_moment_atom_gain`, which handles an *arbitrary* finite index. The only genuinely new ingredient needed for the general case is the **general law of total density**, supplied here.

## New file `proofs/Proofs/SzemerediRegularityOQ04Product.lean` (5 theorems, 0 sorry, 0 axiom)

- **`edgeDensity_biUnion_mul` / `edgeDensity_mul_biUnion`** — the one-sided law of total density over an arbitrary disjoint `Finset` family, `|⋃Aᵢ||B|·d(⋃Aᵢ,B) = Σᵢ |Aᵢ||B|·d(Aᵢ,B)`, by `Finset.induction` peeling one part at a time with the existing 2-way `edgeDensity_union_mul(_right)`.
- **`edgeDensity_prod_family_split`** — the general product law `|A||B|·d(A,B) = Σᵢ Σⱼ |Aᵢ||Bⱼ|·d(Aᵢ,Bⱼ)`, obtained compositionally (A-side biUnion × B-side biUnion), so `d(A,B)` is the honest `|Aᵢ||Bⱼ|`-weighted centroid.
- **`prod_family_total_weight`** — `Σᵢ Σⱼ |Aᵢ||Bⱼ| = |A||B|` via `Finset.card_biUnion` + `Finset.sum_mul_sum`.
- **`pairEnergy_prod_family_refinement_gain`** — the full increment:
  `pairEnergy G A B + (|A_{i₀}||B_{j₀}|/n²)·d² ≤ Σᵢ Σⱼ pairEnergy G Aᵢ Bⱼ`
  from a single witness sub-cell deviating from `d(A,B)` by `≥ d`, via `weighted_second_moment_atom_gain` over the product index `I ×ˢ J`. This is the full-generality form of `pairEnergy_prod_refinement_gain` (the `2×2` case, `I = J = {·,·}`); for an ε-irregular witness it yields the AFKS-consumable `ε⁴·|A||B|/n²` energy jump.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04Product` → **Build completed successfully (7746 jobs)**, 0 sorries, 0 axioms.
- One prior attempt reached the file's own elaboration step `[7746/7746] … (3.2s)` with zero type errors before an olean-write SIGBUS (fleet-memory write race); a retry landed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)