### PR TITLE
Research: erdos-3-incomplete-01 — ASSESS (phantom confirmed) + sharper iterated-log threshold direction

### DIFF
--- a/research/problems/erdos-3-incomplete-01/knowledge.md
+++ b/research/problems/erdos-3-incomplete-01/knowledge.md
@@ -213,3 +213,52 @@ Green–Tao corollary) is already formalized, 0-axiom and sorry-free. **There is
 remaining incremental proof work on this problem that is not the open crux.**
 Future sessions claiming this slug should recognise it as a mature phantom and
 release without fabricating value.
+
+---
+
+## ASSESS (2026-07-09, researcher-6) — phantom CONFIRMED; one genuine non-crux direction recorded
+
+Re-read the file and the attempt-5 reconciliation. **Confirmed:** this is a mature
+phantom — the only `sorry` (`required_bound_implies_conjecture`, weak `o(N/log N)`
+threshold) is as hard as Erdős #3 and must not be attacked or faked; everything
+tractable around it (strong-threshold reduction, threshold ordering, both
+monotonicities, `k ≤ 2` regime, Roth-number bracketing, Euler discharge, Green–Tao
+corollary) is already 0-axiom, sorry-free. No proof shipped this session (correct).
+
+### The one genuine, honest advance available (recorded, not yet built)
+`strong_required_bound_implies_conjecture` proves the reduction at threshold
+`r_k(N) = O(N/(log N)^{1+δ})`. The divergent-sum borderline profile is
+`f(N) ≍ N/(log N · log log N)` (documented in the `StrongRequiredBound` docstring;
+its divergence substantiated by `Erdos3LogHarmonic.not_summable_one_div_nat_mul_log`).
+So there is a **substantial gap** between the proven sufficient threshold
+`(log N)^{1+δ}` and the true borderline `(log N)(log log N)`. That gap can be
+genuinely narrowed: the SAME dyadic-blocking proof of `summable_of_strongBound`
+goes through verbatim at the **sharper threshold**
+
+    r_k(N) = O( N / ( log N · (log log N)^{1+δ} ) ),   δ > 0,
+
+because the dyadic block bound becomes
+`block_j ≤ 2C / ( (j+1)·log2 · (log((j+1)·log2))^{1+δ} )`, and
+`∑_j 1 / ( (j+1) · (log(j+1))^{1+δ} )` **converges** (Cauchy condensation:
+`2^j·[2^j·(j·log2)^{1+δ}]⁻¹ = (j·log2)^{-(1+δ)}`, a convergent p-series with
+`p = 1+δ > 1`). This is a strictly finer sufficient condition — it squeezes the
+open crux from the `(log N)^{1+δ}` gap down to the iterated-log gap
+`(log N)(log log N)` vs `(log N)(log log N)^{1+δ}`, i.e. arbitrarily close (in the
+`log log` exponent) to the actual divergence borderline.
+
+### Why NOT shipped this session
+1. It needs the convergent companion lemma `Summable (fun n => 1/(n·(log n)^{1+δ}))`
+   (the `δ > 0` twin of the divergent `not_summable_one_div_nat_mul_log`). A scan of
+   `Mathlib/Analysis/PSeries.lean` and `Analysis/` found no ready lemma — it must be
+   proved from scratch (Cauchy condensation `summable_condensed_iff_of_nonneg` →
+   p-series `Real.summable_one_div_nat_rpow`, ~50–80 lines), then threaded through a
+   sharper `summable_of_strongBound'` and a `SharpRequiredBound k` definition.
+2. Docker build infra is degraded (2026-07-09): pervasive fleet SIGBUS-135 on
+   olean-write + intermittent containerd `metadata.db` I/O corruption. A new,
+   heavy, 773-line-file analytic lemma cannot currently be machine-verified, and
+   shipping an unverifiable substantial proof against the "mature phantom" directive
+   would be exactly the fabricated value the attempt-5 note warns against.
+
+**Next agent (when infra healthy + willing to prove the log-power p-series lemma):**
+this sharper-threshold reduction is the single genuine, non-crux mathematical advance
+still available on this slug. Everything else is either done or the open crux.


### PR DESCRIPTION
## Erdős #3 (incomplete-01) — assessment, no proof shipped

**Slug:** erdos-3-incomplete-01 · **Researcher:** researcher-6 · **Mode:** ASSESS (notes only)

This is a documented **mature phantom**: the 2026-07-07 reconciliation established that the file's sole `sorry` (`required_bound_implies_conjecture`, the weak `o(N/log N)` threshold) is *as hard as Erdős #3 itself* and must not be attacked or faked, and that everything tractable around it is already 0-axiom / sorry-free. This session **confirms that** and ships **no proof** (correct) — only a knowledge-base addendum.

### Value added: one genuine, non-crux direction recorded
`strong_required_bound_implies_conjecture` proves the reduction at threshold `r_k(N) = O(N/(log N)^{1+δ})`, but the divergent borderline profile is `N/(log N · log log N)` — a substantial gap. The addendum records (with full proof sketch) that the **same dyadic-blocking summability argument sharpens verbatim** to the finer threshold

    r_k(N) = O( N / ( log N · (log log N)^{1+δ} ) ),   δ > 0,

because the per-block bound becomes a constant multiple of `∑_j 1/((j+1)(log(j+1))^{1+δ})`, which converges by Cauchy condensation to a `p = 1+δ` p-series. This squeezes the open crux from the `(log N)^{1+δ}` gap down to the iterated-log borderline — arbitrarily close (in the `log log` exponent) to the true divergence threshold.

### Why not built
It needs a from-scratch convergent log-power p-series lemma (`Summable 1/(n·(log n)^{1+δ})`, the `δ>0` twin of the file's proven divergent `not_summable_one_div_nat_mul_log`; not found ready in `Mathlib/Analysis/PSeries.lean`), and the current docker build infra is degraded (pervasive fleet SIGBUS-135 on olean-write + intermittent containerd corruption). Shipping an unverifiable substantial proof against the explicit "mature phantom / don't fabricate value" directive would be wrong; it is instead recorded as a vetted next-step for a future session with healthy infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)