### PR TITLE
Puiseux subfield: full inverse-closure via embDomain preimage reconstruction

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -774,17 +774,138 @@ def puiseuxSubalgebra (K : Type*) [CommRing K] : Subalgebra K (HahnSeries ℚ K)
 /-- **First inverse-closure fact: the inverse of a single-term series is Puiseux.**
 
 Over a field `K`, `(single m a)⁻¹ = single (-m) a⁻¹` (`HahnSeries.inv_single`), which is
-again a single term, hence a Puiseux series.  This is the base case of the (still open)
-full inverse-closure `IsPuiseuxSeries f → IsPuiseuxSeries f⁻¹` that would upgrade the
-subring/subalgebra to a subfield.  The general case needs a "series supported on the
-subgroup `(1/n)ℤ` form a subfield" reconstruction (via `HahnSeries.embDomainRingHom`
-from `ℤ ↪o ℚ`), which is not yet available in Mathlib. -/
+again a single term, hence a Puiseux series.  This is the base case of the full
+inverse-closure `IsPuiseuxSeries f → IsPuiseuxSeries f⁻¹`, which is now established in
+full generality below (`isPuiseux_inv`, Part X) and upgrades the subring/subalgebra to a
+genuine **subfield**. -/
 theorem isPuiseux_inv_single {K : Type*} [Field K] (m : ℚ) (a : K) :
     IsPuiseuxSeries (HahnSeries.single m a)⁻¹ := by
   rw [HahnSeries.inv_single]
   exact isPuiseux_single (-m) a⁻¹
 
 end Subalgebra
+
+/-! ### Part X: Full inverse-closure — the Puiseux series form a subfield
+
+Parts VIII/IX bundled the Puiseux series into a `Subring`/`K`-subalgebra of
+`HahnSeries ℚ K`.  The one closure property still missing for a **field** was inverse-
+closure: `IsPuiseuxSeries f → IsPuiseuxSeries f⁻¹`.  Part IX only handled the
+single-term base case (`isPuiseux_inv_single`).
+
+The general statement is exactly the algebraic reason "Puiseux series form a field": a
+series `f` supported on the subgroup `(1/n)ℤ ⊆ ℚ` is the image, under the domain-
+embedding ring homomorphism `HahnSeries.embDomainRingHom` induced by `ℤ ↪o ℚ, k ↦ k/n`,
+of a series `g : HahnSeries ℤ K`.  That homomorphism is an *injective field homomorphism*
+between two Hahn-series fields, so it transports inverses (`map_inv₀`): `f⁻¹ = φ(g⁻¹)` is
+again supported on `(1/n)ℤ`, hence Puiseux with the *same* ramification `n`.
+
+The single missing piece of plumbing is the preimage-reconstruction lemma
+`exists_embDomain_of_support_subset_range`: a Hahn series whose support lands inside the
+range of an order embedding is itself in the range of `embDomain`.  It is proved here by
+building the preimage series coefficient-wise (`g.coeff k = f.coeff (emb k)`) and checking
+its support is partially well-ordered, transporting a would-be descending sequence back
+through the order embedding to contradict well-ordering of `f.support`.
+-/
+
+section Subfield
+
+/-- **Preimage reconstruction for `embDomain`.**
+
+If the support of a Hahn series `f : HahnSeries Γ' R` is contained in the range of an
+order embedding `emb : Γ ↪o Γ'` (with `Γ` a linear order), then `f` is in the range of
+`HahnSeries.embDomain emb`: there is a `g : HahnSeries Γ R` with `embDomain emb g = f`.
+
+The witness is `g.coeff k = f.coeff (emb k)`; its support is `emb ⁻¹' f.support`, which is
+partially well-ordered because an infinite descending sequence there would map, through the
+strictly monotone `emb`, to one in the well-ordered `f.support`.  Mathlib has
+`support_embDomain_subset` (the forward inclusion) and `embDomain_injective`, but no such
+onto-its-range statement; this supplies it. -/
+theorem exists_embDomain_of_support_subset_range
+    {Γ Γ' R : Type*} [Zero R] [LinearOrder Γ] [PartialOrder Γ']
+    (emb : Γ ↪o Γ') {f : HahnSeries Γ' R} (hf : f.support ⊆ Set.range emb) :
+    ∃ g : HahnSeries Γ R, HahnSeries.embDomain emb g = f := by
+  have hpwo : (emb ⁻¹' f.support).IsPWO := by
+    rw [Set.isPWO_iff_isWF, Set.isWF_iff_no_descending_seq]
+    intro s hs hmem
+    exact (Set.isWF_iff_no_descending_seq.mp f.isPWO_support.isWF) (fun n => emb (s n))
+      (emb.strictMono.comp_strictAnti hs) hmem
+  refine ⟨{ coeff := fun k => f.coeff (emb k), isPWO_support' := hpwo.mono (fun k hk => hk) }, ?_⟩
+  ext b
+  by_cases hb : b ∈ Set.range emb
+  · obtain ⟨a, rfl⟩ := hb
+    rw [HahnSeries.embDomain_coeff]
+  · have hb0 : f.coeff b = 0 := by
+      by_contra hne
+      exact hb (hf ((HahnSeries.mem_support _ _).2 hne))
+    rw [HahnSeries.embDomain_notin_range hb, hb0]
+
+/-- **Full inverse-closure: the inverse of a Puiseux series is a Puiseux series.**
+
+If `IsPuiseuxSeries f` with ramification `n`, then `f⁻¹` is Puiseux with the *same*
+ramification `n`.  The proof factors `f` through the field homomorphism
+`φ = embDomainRingHom (k ↦ k/n) : HahnSeries ℤ K →+* HahnSeries ℚ K`: writing `f = φ g`
+via `exists_embDomain_of_support_subset_range`, we get `f⁻¹ = (φ g)⁻¹ = φ (g⁻¹)` by
+`map_inv₀`, whose support lies in the range of `ℤ ↪o ℚ, k ↦ k/n`, i.e. in `(1/n)ℤ`.
+
+This is the general case whose single-term instance was `isPuiseux_inv_single`, and it is
+exactly the closure needed to upgrade the subring/subalgebra to a subfield
+(`puiseuxSubfield`).  Note `f = 0` needs no special handling: then `g = 0`, `φ 0 = 0`, and
+`0⁻¹ = 0` is (vacuously) Puiseux. -/
+theorem isPuiseux_inv {K : Type*} [Field K] {f : HahnSeries ℚ K}
+    (hf : IsPuiseuxSeries f) : IsPuiseuxSeries f⁻¹ := by
+  obtain ⟨n, hn⟩ := hf
+  have hn0 : (0 : ℚ) < (n : ℚ) := by exact_mod_cast n.pos
+  -- the additive hom `ℤ →+ ℚ`, `k ↦ k / n`
+  let φ₀ : ℤ →+ ℚ :=
+    { toFun := fun k => (k : ℚ) / (n : ℚ)
+      map_zero' := by simp
+      map_add' := fun a b => by push_cast; ring }
+  have hmono : ∀ g g' : ℤ, φ₀ g ≤ φ₀ g' ↔ g ≤ g' := by
+    intro g g'
+    show (g : ℚ) / (n : ℚ) ≤ (g' : ℚ) / (n : ℚ) ↔ g ≤ g'
+    rw [div_le_div_iff_of_pos_right hn0, Int.cast_le]
+  have hfi : Function.Injective φ₀ := fun a b hab =>
+    le_antisymm ((hmono a b).1 hab.le) ((hmono b a).1 hab.ge)
+  -- the order embedding underlying `embDomainRingHom φ₀`
+  let emb : ℤ ↪o ℚ := ⟨⟨φ₀, hfi⟩, hmono _ _⟩
+  -- `f` is supported on the range of `emb = (1/n)ℤ`
+  have hfr : f.support ⊆ Set.range emb := by
+    intro q hq
+    obtain ⟨k, hk⟩ := hn q hq
+    exact ⟨k, hk.symm⟩
+  obtain ⟨g, hg⟩ := exists_embDomain_of_support_subset_range emb hfr
+  have key : ∀ x, HahnSeries.embDomainRingHom φ₀ hfi hmono x = HahnSeries.embDomain emb x :=
+    fun _ => rfl
+  have hgf : HahnSeries.embDomainRingHom φ₀ hfi hmono g = f := by rw [key]; exact hg
+  have hinv : f⁻¹ = HahnSeries.embDomain emb g⁻¹ := by
+    rw [← hgf, ← map_inv₀ (HahnSeries.embDomainRingHom φ₀ hfi hmono) g, key]
+  rw [hinv]
+  refine ⟨n, fun q hq => ?_⟩
+  obtain ⟨k, hk⟩ := Set.image_subset_range _ _ (HahnSeries.support_embDomain_subset hq)
+  exact ⟨k, hk.symm⟩
+
+/-- **The Puiseux series form a subfield of `HahnSeries ℚ K`.**
+
+Upgrades `puiseuxSubring`/`puiseuxSubalgebra` (Parts VIII/IX) to a `Subfield`: the closure
+lemmas `isPuiseux_zero/one/add/mul/neg` together with the full inverse-closure
+`isPuiseux_inv` (Part X) supply every field-subobject axiom.  The carrier is again exactly
+`{f | IsPuiseuxSeries f}`, so this makes the informal "the Puiseux series form a field"
+a machine-checked substructure fact — the honest algebraic status of the fragment
+formalized in this file (short of full Newton–Puiseux algebraic closure). -/
+def puiseuxSubfield (K : Type*) [Field K] : Subfield (HahnSeries ℚ K) where
+  carrier := {f | IsPuiseuxSeries f}
+  zero_mem' := isPuiseux_zero
+  one_mem' := isPuiseux_one
+  add_mem' := fun ha hb => isPuiseux_add ha hb
+  mul_mem' := fun ha hb => isPuiseux_mul ha hb
+  neg_mem' := fun ha => isPuiseux_neg ha
+  inv_mem' := fun _ hx => isPuiseux_inv hx
+
+/-- Membership in the Puiseux subfield is definitionally the Puiseux condition. -/
+@[simp] theorem mem_puiseuxSubfield {K : Type*} [Field K] (y : HahnSeries ℚ K) :
+    y ∈ puiseuxSubfield K ↔ IsPuiseuxSeries y := Iff.rfl
+
+end Subfield
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 SUMMARY

--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -874,7 +874,8 @@ theorem isPuiseux_inv {K : Type*} [Field K] {f : HahnSeries ℚ K}
     obtain ⟨k, hk⟩ := hn q hq
     exact ⟨k, hk.symm⟩
   obtain ⟨g, hg⟩ := exists_embDomain_of_support_subset_range emb hfr
-  have key : ∀ x, HahnSeries.embDomainRingHom φ₀ hfi hmono x = HahnSeries.embDomain emb x :=
+  have key : ∀ x : HahnSeries ℤ K,
+      HahnSeries.embDomainRingHom φ₀ hfi hmono x = HahnSeries.embDomain emb x :=
     fun _ => rfl
   have hgf : HahnSeries.embDomainRingHom φ₀ hfi hmono g = f := by rw [key]; exact hg
   have hinv : f⁻¹ = HahnSeries.embDomain emb g⁻¹ := by

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -124,3 +124,54 @@ SIGBUS risk — deferred, not attempted this session.
 **Files Modified:** proofs/Proofs/PuiseuxTheorem.lean (+import Summable; +Part IX:
 isPuiseux_algebraMap, puiseuxSubalgebra, mem_puiseuxSubalgebra, isPuiseux_inv_single;
 758→811 lines, 18→19 numbered theorems + def).
+
+## Session (researcher-3, 2026-07-09): Full inverse-closure → subfield (Part X)
+
+**Mode**: REVISIT (MODERATE, depth-first) · **Outcome**: progress
+(1 reusable HahnSeries lemma + 2 theorems + 1 def, VERIFIED 0-sorry/0-axiom,
+docker-build 3070 jobs clean on 2nd attempt).
+
+**Contribution — Part X: the Puiseux series form a `Subfield`.** This closes the
+exact gap flagged as the "real next step" by researcher-2: the general
+inverse-closure `IsPuiseuxSeries f → IsPuiseuxSeries f⁻¹` (Part IX only had the
+single-term base case `isPuiseux_inv_single`).
+
+1. `exists_embDomain_of_support_subset_range` — the missing plumbing lemma. For an
+   order embedding `emb : Γ ↪o Γ'` (`Γ` a `LinearOrder`), a Hahn series `f` with
+   `f.support ⊆ Set.range emb` is in the range of `HahnSeries.embDomain emb`:
+   witness `g.coeff k = f.coeff (emb k)`. The only non-formal step is PWO of the
+   preimage support, done by `Set.isPWO_iff_isWF` + `Set.isWF_iff_no_descending_seq`:
+   a descending seq in `emb ⁻¹' f.support` maps through `emb.strictMono.comp_strictAnti`
+   to a descending seq in the well-ordered `f.support`. Complements Mathlib's
+   `support_embDomain_subset` (forward) / `embDomain_injective`.
+2. `isPuiseux_inv` — factor `f` (ramification `n`) through the field hom
+   `φ = embDomainRingHom (φ₀ : ℤ →+ ℚ, k ↦ k/n)`. Reconstruction gives `f = φ g`,
+   then `f⁻¹ = (φ g)⁻¹ = φ (g⁻¹)` by `map_inv₀`, whose support ⊆ range emb = (1/n)ℤ,
+   so Puiseux with the SAME ramification `n`. `f = 0` needs no special case
+   (`g = 0`, `φ 0 = 0`, `0⁻¹ = 0`).
+3. `puiseuxSubfield (K) [Field K] : Subfield (HahnSeries ℚ K)` + `mem_puiseuxSubfield`
+   (`Iff.rfl`). Upgrades `puiseuxSubring`/`puiseuxSubalgebra` — "the Puiseux series
+   form a field" is now a machine-checked substructure fact.
+
+**Technique / gotchas:**
+- `embDomainRingHom [NonAssocSemiring R] (f : Γ →+ Γ') hfi hf` has `R` IMPLICIT —
+  writing `embDomainRingHom φ₀ hfi hmono x` with `x`'s type unpinned gives a stuck
+  `Zero ?R` typeclass error. Annotate `x : HahnSeries ℤ K` (or `(R := K)`).
+- The OrderEmbedding underlying `embDomainRingHom φ₀ hfi hmono` is literally
+  `⟨⟨φ₀, hfi⟩, hmono _ _⟩`; defining `emb` as that exact term makes
+  `embDomainRingHom φ₀ hfi hmono x = embDomain emb x` hold by `rfl`.
+- `φ₀ : ℤ →+ ℚ`, `k ↦ (k:ℚ)/(n:ℚ)`: `map_add'` via `push_cast; ring`; monotone via
+  `div_le_div_iff_of_pos_right hn0` + `Int.cast_le`; injectivity for free from the
+  order-iff (`le_antisymm`).
+- `Set.IsPWO.mono (fun k hk => hk)` transports the anonymous preimage-series support
+  into `emb ⁻¹' f.support` by defeq (both unfold to `{k | f.coeff (emb k) ≠ 0}`).
+- Build: clean elaboration `[3070/3070]`, ONE real error first pass (the implicit-R
+  stuck instance), fixed → clean 2nd attempt. No SIGBUS this session.
+
+**Deferred (unchanged):** full Newton–Puiseux algebraic closure `IsAlgClosed (PuiseuxField K)`
+still needs the Newton-polygon term-by-term convergence machinery absent from Mathlib
+(>1000-line foundational build). The subfield statement is the natural terminus of the
+"structural rounding-out" line — beyond it is only the deep convergence result.
+
+**Files Modified:** proofs/Proofs/PuiseuxTheorem.lean (+Part X: 3 theorems + 1 def;
+811→933 lines, 21→24 numbered theorems, 4→5 defs), meta.json counts synced.

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -55,11 +55,11 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 811,
+    "lineCount": 933,
     "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The two headline placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). Four narrative theorems remain as String-literal descriptors carrying no formal content (curve_branches_are_puiseux, newton_polygon_tropicalization, galois_group_is_profinite_integers, char_zero_required); each merely asserts ∃ desc : String, desc = \"…\" and marks an informal application/connection rather than a machine-checked result. This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 21,
-    "definitionCount": 4
+    "theoremCount": 24,
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Newton discovered the algorithm for computing fractional power series roots of polynomials in 1676. Puiseux gave the first rigorous proof in 1850 that these series provide the algebraic closure of the Laurent series field, establishing that allowing fractional exponents suffices to solve all polynomial equations over formal power series (in characteristic 0). The study of algebraic curves via local parametrization goes back to Newton who introduced the Newton polygon method to compute the branches of an algebraic curve at a singular point. The formal algebraic closure result was refined in the 20th century by Hironaka and others in connection with resolution of singularities, and the characteristic-0 hypothesis is essential: in characteristic p, the Artin-Schreier phenomenon means p-th power extensions cannot be captured by Puiseux series.",
@@ -173,10 +173,10 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 811,
+    "lineCount": 933,
     "axiomCount": 0,
-    "theoremCount": 21,
-    "definitionCount": 4,
+    "theoremCount": 24,
+    "definitionCount": 5,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Adds **Part X** to `proofs/Proofs/PuiseuxTheorem.lean` (Wiedijk #41), closing the exact gap prior sessions left open: the general inverse-closure of Puiseux series, which upgrades the existing `Subring`/`K`-subalgebra to a genuine **`Subfield`**.

Prior work (`isPuiseux_inv_single`, Part IX) only handled the single-term base case and documented full inverse-closure as blocked on "a preimage-reconstruction lemma absent from Mathlib." This PR supplies that lemma and completes the argument.

### New declarations (all VERIFIED, 0 sorry / 0 axiom)

1. **`exists_embDomain_of_support_subset_range`** — a reusable general HahnSeries lemma. For an order embedding `emb : Γ ↪o Γ'` (`Γ` linearly ordered), a Hahn series `f` with `f.support ⊆ Set.range emb` lies in the range of `HahnSeries.embDomain emb`. Witness `g.coeff k = f.coeff (emb k)`; support PWO by transporting a would-be descending sequence back through the strictly monotone `emb` to contradict well-ordering of `f.support`. Complements Mathlib's `support_embDomain_subset` (forward inclusion) and `embDomain_injective`.
2. **`isPuiseux_inv`** — `IsPuiseuxSeries f → IsPuiseuxSeries f⁻¹`, with the **same** ramification `n`. Factors `f` through the field homomorphism `embDomainRingHom (k ↦ k/n) : HahnSeries ℤ K →+* HahnSeries ℚ K`: writing `f = φ g`, `f⁻¹ = (φ g)⁻¹ = φ (g⁻¹)` via `map_inv₀`, supported on `(1/n)ℤ`. (`f = 0` needs no special case.)
3. **`puiseuxSubfield`** + **`mem_puiseuxSubfield`** — bundles all closure facts into `Subfield (HahnSeries ℚ K)`, making "the Puiseux series form a field" a machine-checked substructure fact.

### Verification

`./proofs/scripts/docker-build.sh Proofs.PuiseuxTheorem` → `Build completed successfully (3070 jobs)`. File remains 0-sorry / 0-axiom (only `propext`/`Classical.choice`/`Quot.sound`). meta.json counts synced (811→933 lines, +3 theorems, +1 def).

### Scope / honesty

This is the structural terminus of the Puiseux-field line: the subfield statement is the strongest algebraic-substructure fact reachable **without** the Newton–Puiseux term-by-term convergence machinery. Full algebraic closure `IsAlgClosed (PuiseuxField K)` remains an unformalized open remainder (>1000-line foundational build not in Mathlib); the gallery badge stays `wip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)