### PR TITLE
Erdős #729 (oq-02): Kummer at p=2 — carry identity + binary digit-sum subadditivity

### DIFF
--- a/proofs/Proofs/Erdos729DigitSumBound.lean
+++ b/proofs/Proofs/Erdos729DigitSumBound.lean
@@ -30,6 +30,13 @@
   * `erdos_two_adic_bound`  — the digit-sum bound (★), axiom-free.
   * `digitSum_two_le_log`   — `s₂(m) ≤ Nat.log 2 m + 1` (digit sum ≤ bit count).
   * `erdos_two_adic_bound_log` — the logarithmic corollary of (★).
+  * `v2_choose_add_digitSum` — Kummer at `p = 2`, subtraction-free:
+                              `v₂(C(a+b,a)) + s₂(a+b) = s₂(a) + s₂(b)`.
+  * `digitSum_two_add_le`   — binary digit-sum subadditivity `s₂(a+b) ≤ s₂ a + s₂ b`
+                              (NOT a named Mathlib lemma).
+  * `excess_eq_v2_choose`   — the slack in (★) at `n = a+b` is the carry count.
+  * `choose_odd_iff_digitSum_add` — no-carry criterion: `C(a+b,a)` odd iff
+                              `s₂(a+b) = s₂ a + s₂ b`.
 
   None of these are named Mathlib lemmas. Bearer lemmas (Mathlib pin `v4.26.0`):
   `sub_one_mul_padicValNat_factorial`, `Nat.factorization_prime_le_iff_dvd`,
@@ -197,5 +204,89 @@ theorem erdos_1968_uniform :
     exact natLog_two_mul_log_two_le_log n (by omega)
   -- assemble:  a+b ≤ n + 2·⌊log₂ n⌋ + 2 ≤ n + 2L + 2L = n + 4L
   linarith
+
+-- ----------------------------------------------------------------------------
+-- Kummer at `p = 2`: the sharp carry content behind the bound (★).
+--
+-- The bound (★), `a + b ≤ n + s₂(a) + s₂(b)`, is obtained by dropping the
+-- nonnegative Legendre slack `v₂(n!) − v₂(a!) − v₂(b!) ≥ 0`.  At the extremal
+-- point `n = a + b` the divisibility `a!·b! ∣ (a+b)!` holds automatically, and
+-- that slack is *exactly* `v₂(C(a+b,a))` — Kummer's number of carries when `a`
+-- and `b` are added in base 2.  We compute it in closed digit-sum form and read
+-- off two facts that Mathlib does not carry as named lemmas: subadditivity of
+-- the binary digit sum, and the odd-binomial (no-carry) criterion.
+--
+-- Mathlib does have Kummer in digit form
+-- (`Nat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits'`), but only with
+-- truncated ℕ-subtraction on the right.  The subtraction-free identity below is
+-- proved directly from this file's `v2_factorial`, so it is self-contained and
+-- immediately usable (its `omega` closers need no side conditions).
+-- ----------------------------------------------------------------------------
+
+/-- **Kummer's identity at `p = 2`, subtraction-free.**
+For all `a, b`, the 2-adic valuation of the binomial `C(a+b, a)` together with the
+binary digit sum of `a + b` recover the digit sums of the two parts:
+    `v₂(C(a+b, a)) + s₂(a+b) = s₂(a) + s₂(b)`.
+The summand `v₂(C(a+b,a))` is Kummer's count of carries in the base-2 addition
+`a + b`.  Proof: take `v₂` of the factorial identity `C(a+b,a)·a!·b! = (a+b)!`
+and substitute Legendre (`v2_factorial`); the truncated subtractions cancel under
+`omega` given `digit_sum_le`. -/
+theorem v2_choose_add_digitSum (a b : ℕ) :
+    padicValNat 2 (Nat.choose (a + b) a) + (Nat.digits 2 (a + b)).sum
+      = (Nat.digits 2 a).sum + (Nat.digits 2 b).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hchoose : Nat.choose (a + b) a ≠ 0 := (Nat.choose_pos (Nat.le_add_right a b)).ne'
+  -- The core factorial identity `C(a+b,a) · a! · b! = (a+b)!`.
+  have hkey : Nat.choose (a + b) a * a ! * b ! = (a + b)! := by
+    have h := Nat.choose_mul_factorial_mul_factorial (Nat.le_add_right a b)
+    rwa [Nat.add_sub_cancel_left] at h
+  -- `v₂` is additive over the product (all factors nonzero).
+  have hval : padicValNat 2 (Nat.choose (a + b) a) + padicValNat 2 (a !)
+      + padicValNat 2 (b !) = padicValNat 2 ((a + b)!) := by
+    have e2 : padicValNat 2 (Nat.choose (a + b) a * a !)
+        = padicValNat 2 (Nat.choose (a + b) a) + padicValNat 2 (a !) :=
+      padicValNat.mul hchoose (Nat.factorial_ne_zero a)
+    have e1 : padicValNat 2 (Nat.choose (a + b) a * a ! * b !)
+        = padicValNat 2 (Nat.choose (a + b) a * a !) + padicValNat 2 (b !) :=
+      padicValNat.mul (mul_ne_zero hchoose (Nat.factorial_ne_zero a)) (Nat.factorial_ne_zero b)
+    rw [hkey, e2] at e1
+    omega
+  rw [v2_factorial, v2_factorial, v2_factorial] at hval
+  have ha := Nat.digit_sum_le 2 a
+  have hb := Nat.digit_sum_le 2 b
+  have hab := Nat.digit_sum_le 2 (a + b)
+  omega
+
+/-- **Binary digit-sum subadditivity.**  `s₂(a+b) ≤ s₂(a) + s₂(b)`.  Immediate
+from the Kummer identity by dropping the nonnegative valuation term.  Not a named
+lemma in the pinned Mathlib. -/
+theorem digitSum_two_add_le (a b : ℕ) :
+    (Nat.digits 2 (a + b)).sum ≤ (Nat.digits 2 a).sum + (Nat.digits 2 b).sum := by
+  have h := v2_choose_add_digitSum a b
+  omega
+
+/-- **The slack in (★) is Kummer's carry count.**  At the extremal case
+`n = a + b` (where `a!·b! ∣ n!` holds automatically), the deficit between the
+digit-sum bound (★) value `n + s₂(a)+s₂(b)` and the actual `a+b` equals
+`s₂(a)+s₂(b) − s₂(a+b) = v₂(C(a+b,a))`, the number of binary carries. -/
+theorem excess_eq_v2_choose (a b : ℕ) :
+    (Nat.digits 2 a).sum + (Nat.digits 2 b).sum - (Nat.digits 2 (a + b)).sum
+      = padicValNat 2 (Nat.choose (a + b) a) := by
+  have h := v2_choose_add_digitSum a b
+  omega
+
+/-- **The no-carry criterion.**  The binomial `C(a+b,a)` is odd iff adding `a`
+and `b` in base 2 produces no carries iff the binary digit sums add exactly:
+    `¬ 2 ∣ C(a+b,a) ↔ s₂(a+b) = s₂(a) + s₂(b)`.
+This is the `p = 2` case of Kummer's carry count vanishing; the forward direction
+is the classical "central-binomial parity via 1-bits" fact. -/
+theorem choose_odd_iff_digitSum_add (a b : ℕ) :
+    ¬ 2 ∣ Nat.choose (a + b) a ↔
+      (Nat.digits 2 (a + b)).sum = (Nat.digits 2 a).sum + (Nat.digits 2 b).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hchoose : Nat.choose (a + b) a ≠ 0 := (Nat.choose_pos (Nat.le_add_right a b)).ne'
+  have hkey := v2_choose_add_digitSum a b
+  rw [dvd_iff_padicValNat_ne_zero hchoose, not_not]
+  omega
 
 end Erdos729DigitSum

--- a/research/problems/erdos-729-oq-02/knowledge.md
+++ b/research/problems/erdos-729-oq-02/knowledge.md
@@ -143,3 +143,39 @@ only on `barreto_leeham_theorem` (the removed axiom no longer appears). File 251
 **Note for future work:** the remaining axiom is the deep resolution and is not
 session-sized. The elementary axiom-free theory (digit-sum bound, uniform real-log bound,
 Legendre identities) is complete across the companion files.
+
+## Session 2026-07-09 (researcher-7) — Kummer at p=2: carry content of (★) (0 new axioms)
+
+**Mode**: ACT (SOLVED-side; executes researcher-6's deferred "Next Steps": characterize
+`s₂(a)+s₂(b)−s₂(a+b)` = base-2 carries via Kummer). Parent + companions were at frontier
+(1 deep axiom `barreto_leeham_theorem`; elementary theory complete). Added the sharp *carry*
+layer under the bound (★) `a+b ≤ n+s₂(a)+s₂(b)`, which prior sessions left as a one-sided
+inequality without its equality/slack analysis.
+
+**Added to `Erdos729DigitSumBound.lean` (4 theorems, VERIFIED 0-axiom, docker `[7743/7743]` green):**
+- `v2_choose_add_digitSum`: **subtraction-free Kummer at p=2** —
+  `v₂(C(a+b,a)) + s₂(a+b) = s₂(a) + s₂(b)`. The valuation term is Kummer's carry count.
+- `digitSum_two_add_le`: **binary digit-sum subadditivity** `s₂(a+b) ≤ s₂(a)+s₂(b)` —
+  NOT a named lemma in the pinned Mathlib (checked). Immediate corollary (drop v₂ ≥ 0).
+- `excess_eq_v2_choose`: the slack of (★) at the extremal `n=a+b` equals `v₂(C(a+b,a))`.
+- `choose_odd_iff_digitSum_add`: **no-carry criterion** `¬2∣C(a+b,a) ↔ s₂(a+b)=s₂(a)+s₂(b)`.
+
+**Key findings / API:**
+- Mathlib HAS Kummer digit-form `Nat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits'`, but
+  only with truncated ℕ-subtraction on the RHS. Proved the subtraction-free additive form
+  directly from this file's `v2_factorial` instead: take `padicValNat 2` of the factorial
+  identity `C(a+b,a)·a!·b! = (a+b)!` (`Nat.choose_mul_factorial_mul_factorial` +
+  `Nat.add_sub_cancel_left`), split via `padicValNat.mul` (needs all factors ≠0), substitute
+  Legendre, close with `omega` + three `Nat.digit_sum_le`. Self-contained; omega handles the
+  truncated subtractions given `s₂ ≤ n`.
+- `dvd_iff_padicValNat_ne_zero hchoose` + `not_not` turns the odd criterion into
+  `padicValNat 2 (choose) = 0 ↔ …`, then `omega` off the identity (proves the iff directly).
+- `(Nat.choose_pos (Nat.le_add_right a b)).ne'` for `choose (a+b) a ≠ 0`.
+- 3× SIGBUS exit-135 at olean-write (elaboration clean `[7743/7743]` 2.5–3.0s, no type
+  errors) — fleet memory pressure, not code; retry-loop went green. `#print axioms` build
+  also needed a 135 retry (then all 4 = {propext, Classical.choice, Quot.sound}).
+
+### Terminus (unchanged)
+Only `barreto_leeham_theorem` (the deep Barreto–Leeham "NO" resolution) remains axiomatized
+in the parent — genuinely open/hard, not session-sized. The elementary 2-adic theory now
+covers both the bound (★) AND its exact carry-slack characterization.


### PR DESCRIPTION
## Summary

Adds the sharp **carry content** behind the parent's 2-adic bound (★)
`a + b ≤ n + s₂(a) + s₂(b)` (where `s₂` = binary digit sum), which prior sessions
left as a one-sided inequality with no equality/slack analysis. This executes
researcher-6's deferred *Next Step*: characterize `s₂(a)+s₂(b)−s₂(a+b)` as the number
of base-2 carries via Kummer's theorem.

All in the existing companion `proofs/Proofs/Erdos729DigitSumBound.lean` (201 → 292 lines).

## New theorems (4, all VERIFIED 0-axiom)

- **`v2_choose_add_digitSum`** — subtraction-free Kummer at `p = 2`:
  `v₂(C(a+b,a)) + s₂(a+b) = s₂(a) + s₂(b)`. The valuation term is Kummer's carry count.
- **`digitSum_two_add_le`** — binary digit-sum **subadditivity** `s₂(a+b) ≤ s₂(a)+s₂(b)`.
  Not a named lemma in the pinned Mathlib (checked); immediate corollary (`v₂ ≥ 0`).
- **`excess_eq_v2_choose`** — the slack of (★) at the extremal `n = a+b` equals `v₂(C(a+b,a))`.
- **`choose_odd_iff_digitSum_add`** — no-carry criterion `¬ 2 ∣ C(a+b,a) ↔ s₂(a+b) = s₂(a)+s₂(b)`.

## Method

Mathlib carries Kummer only in truncated-ℕ-subtraction form
(`Nat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits'`). The additive/subtraction-free
identity here is proved directly from the file's own `v2_factorial`: take `padicValNat 2`
of `C(a+b,a)·a!·b! = (a+b)!`, split via `padicValNat.mul`, substitute Legendre, and close
with `omega` + `Nat.digit_sum_le`. Self-contained and immediately usable.

## Verification

- Docker build `[7743/7743] Built Proofs.Erdos729DigitSumBound` (green).
- `#print axioms` = `{propext, Classical.choice, Quot.sound}` for all 4 theorems
  (0 new axioms, 0 sorries).

The parent's only remaining axiom, `barreto_leeham_theorem` (the deep Barreto–Leeham
resolution), is untouched and correctly axiomatized — genuinely open, out of session scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)