### PR TITLE
Enrich dihedral solvability (abel-ruffini-oq-04-oq-02-oq-04): cover header

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-abel-oq040204-header",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-04",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "Dihedral Groups Are Solvable — An Infinite Family Beyond Sₙ",
+    "content": "The header frames the open question. The parent (S₂,S₃,S₄ are solvable) asks whether analogues hold for other infinite families — dihedral groups Dₙ (expected solvable for all n) or general linear groups GLₙ(𝔽ₚ) (not solvable for n≥2). This file settles the dihedral half: DihedralGroup n is solvable for EVERY n (including n=0, the infinite dihedral group). Unlike Sₙ, which becomes non-solvable at n=5, the dihedral family is solvable across the board — a clean contrast showing the Abel–Ruffini obstruction is special to symmetric groups, not generic to infinite families. The structural reason, formalized: Dₙ is metabelian, with the cyclic rotation subgroup ⟨r⟩ ≅ ℤ/n as a normal subgroup of index 2 and abelian quotient ℤ/2. The file exhibits an inclusion rotation : Multiplicative(ZMod n) →* Dₙ (i ↦ rⁱ) whose range is the rotation subgroup, and a parity homomorphism Dₙ →* Multiplicative(ZMod 2) sending rotations to 1 and reflections to the generator, and observes ker(parity) = range(rotation). Both quotient/sub are abelian hence solvable, so solvable_of_ker_le_range gives IsSolvable(Dₙ). Mathlib had no prior DihedralGroup solvability result. Proved (0 axioms, 0 sorries): parity/rotation with parity_ker_eq_rotation_range, DihedralGroup.isSolvable, and the contrast S5_not_isSolvable_but_dihedral_is. The GLₙ(𝔽ₚ) half (needing PSL₂ simplicity) is left open.",
+    "mathContext": "$1 \\to \\mathbb{Z}/n \\to D_n \\xrightarrow{\\text{parity}} \\mathbb{Z}/2 \\to 1$ with abelian ends $\\Rightarrow D_n$ metabelian, solvable $\\forall n$; contrast: $S_5$ not solvable.",
+    "significance": "context",
+    "relatedConcepts": ["dihedral groups", "solvable groups", "metabelian / index-2 extension", "Abel–Ruffini", "Sₙ non-solvable for n≥5"],
+    "prerequisites": ["solvable groups and derived series", "dihedral group structure (rotations + reflections)", "short exact sequences / ker = range"]
+  },
+  {
     "id": "ann-parity-hom",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-04",
     "range": {


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-04`.

**Gap addressed:** annotation coverage started at line 54, leaving the substantial docstring header (lines 1–53) uncovered.

**Added:** a `context` annotation covering lines 1–53 — framing the open question (solvable analogues for infinite families beyond Sₙ), the result (DihedralGroup n is solvable for every n, including the infinite dihedral group, via the metabelian index-2 structure ker(parity) = range(rotation) with abelian ℤ/n and ℤ/2 ends), the clean S₅ contrast showing Abel–Ruffini is special to symmetric groups, and the open GLₙ(𝔽ₚ) half.

Annotation count 5 → 6, header coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).