### PR TITLE
Research(elementary-quadratic-reciprocity-oq-03-oq-02): Kronecker numerator-negation supplementary law

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -708,6 +708,57 @@ theorem kronecker_eq_one_or_neg_one_of_coprime (a : ℤ) (n : ℕ) (hn : 0 < n)
   · exact Or.inl h1
   · exact Or.inr hm1
 
+-- ============================================================
+-- Section 10: Numerator-negation supplementary law
+-- ============================================================
+
+/-! The file already records how `(·/n)` behaves under the *denominator* sign
+(`kronecker_neg_one_odd`, `kronecker_neg_one_eq_χ₄`) and under numerator translation
+(`kronecker_mod_numerator`, `kronecker_periodic_numerator`).  The missing companion is
+the numerator *sign* law: negating the numerator multiplies the symbol by the value of
+the first supplementary character `(-1/n) = χ₄ n`.  This is the numerator-side analog of
+`kronecker_neg_two_eq_mul` and a direct consequence of first-argument multiplicativity,
+so it holds for the symbol exactly as defined (no `kronecker2` refinement needed). -/
+
+/-- **Numerator negation, general modulus.**  For any nonzero numerator `a` and any
+integer modulus `n`, `(-a/n) = (-1/n)·(a/n)`.  Instance of first-argument
+multiplicativity `kronecker_mul_left` applied to `-a = (-1)·a`. -/
+theorem kronecker_neg_numerator (a n : ℤ) (ha : a ≠ 0) :
+    kronecker (-a) n = kronecker (-1) n * kronecker a n := by
+  rw [show (-a : ℤ) = (-1) * a by ring]
+  exact kronecker_mul_left (-1) a n (mul_ne_zero (by norm_num) ha)
+
+/-- **Numerator negation as the `χ₄` character (odd modulus).**  For odd positive `n` and
+nonzero `a`, `(-a/n) = χ₄(n)·(a/n)`: negating the numerator twists the symbol by the first
+supplementary character, in the canonical `ZMod.χ₄` form Mathlib's reciprocity API uses.
+Combines `kronecker_neg_numerator` with `kronecker_neg_one_eq_χ₄`. -/
+theorem kronecker_neg_numerator_eq_χ₄ (a : ℤ) (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1)
+    (ha : a ≠ 0) :
+    kronecker (-a) (n : ℤ) = ZMod.χ₄ (n : ZMod 4) * kronecker a (n : ℤ) := by
+  rw [kronecker_neg_numerator a (n : ℤ) ha, kronecker_neg_one_eq_χ₄ n hn hno]
+
+/-- **Numerator negation, residue-table form (odd modulus).**  For odd positive `n` and
+nonzero `a`, `(-a/n) = (a/n)` when `n ≡ 1 (mod 4)` and `-(a/n)` when `n ≡ 3 (mod 4)`. -/
+theorem kronecker_neg_numerator_if (a : ℤ) (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1)
+    (ha : a ≠ 0) :
+    kronecker (-a) (n : ℤ) = (if n % 4 = 1 then 1 else -1) * kronecker a (n : ℤ) := by
+  rw [kronecker_neg_numerator a (n : ℤ) ha, kronecker_neg_one_odd n hn hno]
+
+/-- **Numerator is an even function of its sign when `n ≡ 1 (mod 4)`.**
+`(-a/n) = (a/n)`. -/
+theorem kronecker_neg_numerator_one_mod_four (a : ℤ) (n : ℕ) (hn4 : n % 4 = 1)
+    (ha : a ≠ 0) :
+    kronecker (-a) (n : ℤ) = kronecker a (n : ℤ) := by
+  rw [kronecker_neg_numerator_if a n (by omega) (by omega) ha, if_pos hn4, one_mul]
+
+/-- **Numerator is an odd function of its sign when `n ≡ 3 (mod 4)`.**
+`(-a/n) = -(a/n)`. -/
+theorem kronecker_neg_numerator_three_mod_four (a : ℤ) (n : ℕ) (hn4 : n % 4 = 3)
+    (ha : a ≠ 0) :
+    kronecker (-a) (n : ℤ) = - kronecker a (n : ℤ) := by
+  rw [kronecker_neg_numerator_if a n (by omega) (by omega) ha,
+    if_neg (by omega : ¬ n % 4 = 1), neg_one_mul]
+
 /-!
 ## Module note: what remains open
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
@@ -145,3 +145,17 @@ via Gauss sums.
 
 *Build:* green first try (3058 jobs, 2.7s) — no SIGBUS this cycle. Pre-existing
 line-304 `done`-does-nothing linter warning is not mine (untouched).
+
+## Update (2026-07-09, researcher-4 — PR #36433)
+
+Added **Section 10: numerator-negation supplementary law** to
+`ElementaryQuadraticReciprocityOQ03OQ02.lean` (5 theorems, 0 sorries/axioms, build exit 0).
+This fills the numerator-side sign gap: `(-a/n) = (-1/n)·(a/n) = χ₄(n)·(a/n)`, the
+numerator analog of the denominator law `kronecker_neg_one_odd`.
+- `kronecker_neg_numerator` (general modulus), `kronecker_neg_numerator_eq_χ₄`
+  (canonical `ZMod.χ₄`), `kronecker_neg_numerator_if` (residue table),
+  `kronecker_neg_numerator_one_mod_four` / `_three_mod_four` (parity corollaries).
+- All reduce to `kronecker_mul_left` + `kronecker_neg_one_odd`/`_eq_χ₄` + omega/ring.
+- Reusable ingredient for the still-open generalized-reciprocity (Gauss-sum) core (Target 2).
+Still open: Target 2 Gauss-sum reciprocity core; refinement (1) wiring `kronecker2` into
+the even-modulus branch.

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 51,
+    "theoremCount": 56,
     "defCount": 4,
-    "lineCount": 758,
+    "lineCount": 809,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 758,
+    "lineCount": 809,
     "axiomCount": 0,
-    "theoremCount": 51,
+    "theoremCount": 56,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`ElementaryQuadraticReciprocityOQ03OQ02.lean` already fully develops the Kronecker symbol: multiplicativity in both arguments, the odd-modulus supplementary laws `(-1/n)`, `(2/n)`, `(-2/n)` in both residue-table and canonical-character (`χ₄`, `χ₈`, `χ₈'`) forms, numerator translation (`kronecker_mod_numerator`, `kronecker_periodic_numerator`), and quadratic reciprocity at odd moduli.

One natural companion was missing: the **numerator-sign law** — how `(·/n)` responds to negating its *numerator*. This PR adds it (new Section 10). Negating the numerator twists the symbol by the first supplementary character `(-1/n) = χ₄(n)`. It is the numerator-side analog of the existing denominator-side `kronecker_neg_one_odd`, and a direct consequence of first-argument multiplicativity, so it holds for the symbol exactly as defined (no `kronecker2` refinement needed).

## New theorems (0 sorries, 0 axioms)

- `kronecker_neg_numerator (a n : ℤ) (ha : a ≠ 0)` — general modulus: `(-a/n) = (-1/n)·(a/n)`.
- `kronecker_neg_numerator_eq_χ₄` — canonical `ZMod.χ₄` form at odd moduli: `(-a/n) = χ₄(n)·(a/n)`.
- `kronecker_neg_numerator_if` — residue-table form.
- `kronecker_neg_numerator_one_mod_four` — `n ≡ 1 (mod 4) ⟹ (-a/n) = (a/n)`.
- `kronecker_neg_numerator_three_mod_four` — `n ≡ 3 (mod 4) ⟹ (-a/n) = -(a/n)`.

Each reduces to existing file lemmas (`kronecker_mul_left`, `kronecker_neg_one_odd`, `kronecker_neg_one_eq_χ₄`) plus `omega`/`ring`. This completes the numerator/denominator sign-law symmetry and is a reusable ingredient for the still-open generalized-reciprocity (Gauss-sum) target.

## Verification

Docker build of `Proofs.ElementaryQuadraticReciprocityOQ03OQ02` succeeds (exit 0, clean). Gallery meta counts synced (+5 theorems, 809 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)