### PR TITLE
research(erdos-1138-oq-03-oq-01): little-o idiom + effective sublinearity [VERIFIED 0/1, +3 thm]

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -128,4 +128,58 @@ theorem bhp_gap_div_rpow_littleo (a : ℝ) (ha : (0.525 : ℝ) < a) :
       _ = (x : ℝ) ^ (-(a - 0.525)) := hdiv
   exact squeeze_zero' (Eventually.of_forall h_lo) h_hi h_env
 
+/-- **Sublinearity in the little-o idiom.** The maximal prime gap is `o(x)`.
+
+    This is the asymptotics-idiom repackaging of `bhp_implies_gap_littleo`: the entry's
+    title claim ("sublinearity") is exactly the statement `maxPrimeGap =o[atTop] id`, which
+    `bhp_implies_gap_littleo` records only as a `Tendsto (·/x) → 0`. The two are equivalent
+    via `isLittleO_iff_tendsto'` (the denominator `x` is eventually nonzero). -/
+theorem bhp_gap_isLittleO_id :
+    (fun x : ℕ => (maxPrimeGap x : ℝ)) =o[atTop] (fun x : ℕ => (x : ℝ)) := by
+  refine (isLittleO_iff_tendsto' ?_).mpr bhp_implies_gap_littleo
+  filter_upwards [eventually_ge_atTop 1] with x hx h0
+  have hxpos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one hx
+  rw [h0] at hxpos
+  exact absurd hxpos (lt_irrefl 0)
+
+/-- **Sharp little-o at every exponent above `0.525`.** For any `a > 0.525`,
+    `maxPrimeGap =o[atTop] (x ↦ x^a)`. This is the little-o idiom form of
+    `bhp_gap_div_rpow_littleo`, using the full BHP exponent: sublinearity holds not just at
+    `a = 1` (`bhp_gap_isLittleO_id`) but for every exponent strictly above the BHP threshold. -/
+theorem bhp_gap_isLittleO_rpow (a : ℝ) (ha : (0.525 : ℝ) < a) :
+    (fun x : ℕ => (maxPrimeGap x : ℝ)) =o[atTop] (fun x : ℕ => (x : ℝ) ^ a) := by
+  refine (isLittleO_iff_tendsto' ?_).mpr (bhp_gap_div_rpow_littleo a ha)
+  filter_upwards [eventually_ge_atTop 1] with x hx h0
+  have hxpos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one hx
+  have hrp : (0 : ℝ) < (x : ℝ) ^ a := Real.rpow_pos_of_pos hxpos a
+  rw [h0] at hrp
+  exact absurd hrp (lt_irrefl 0)
+
+/-- **Effective (pointwise) sublinearity.** A concrete sufficient condition replacing the
+    qualitative "eventually" of `bhp_gap_eventually_le_eps`: for `ε > 0`, once `x ≥ 25` and
+    the explicit threshold `1 ≤ ε · x^0.475` holds, we already have `maxPrimeGap x ≤ ε · x`.
+
+    The threshold `1 ≤ ε · x^0.475` is exactly `x^(-0.475) ≤ ε`, i.e. the point at which the
+    envelope `maxPrimeGap x / x ≤ x^(-0.475)` has dropped below `ε`; it holds for all
+    sufficiently large `x` (since `x^0.475 → ∞`), recovering `bhp_gap_eventually_le_eps`. -/
+theorem bhp_gap_le_eps_effective (ε : ℝ) (hε : 0 < ε) (x : ℕ)
+    (hx25 : 25 ≤ x) (hthr : 1 ≤ ε * (x : ℝ) ^ (0.475 : ℝ)) :
+    (maxPrimeGap x : ℝ) ≤ ε * x := by
+  have hx_pos : (0 : ℝ) < (x : ℝ) := by
+    have : (0 : ℕ) < x := lt_of_lt_of_le (by norm_num) hx25
+    exact_mod_cast this
+  have hxneg_pos : (0 : ℝ) < (x : ℝ) ^ (-(0.475 : ℝ)) := Real.rpow_pos_of_pos hx_pos _
+  -- x^(-0.475) · x^0.475 = x^0 = 1, so multiplying the threshold by x^(-0.475) gives the bound.
+  have hmul : (x : ℝ) ^ (-(0.475 : ℝ)) * (x : ℝ) ^ (0.475 : ℝ) = 1 := by
+    rw [← Real.rpow_add hx_pos]; norm_num
+  have hneg : (x : ℝ) ^ (-(0.475 : ℝ)) ≤ ε := by
+    calc (x : ℝ) ^ (-(0.475 : ℝ))
+        = (x : ℝ) ^ (-(0.475 : ℝ)) * 1 := by ring
+      _ ≤ (x : ℝ) ^ (-(0.475 : ℝ)) * (ε * (x : ℝ) ^ (0.475 : ℝ)) :=
+          mul_le_mul_of_nonneg_left hthr (le_of_lt hxneg_pos)
+      _ = ε * ((x : ℝ) ^ (-(0.475 : ℝ)) * (x : ℝ) ^ (0.475 : ℝ)) := by ring
+      _ = ε := by rw [hmul]; ring
+  have hfinal : (maxPrimeGap x : ℝ) / x ≤ ε := le_trans (gap_div_le_rpow_neg x hx25) hneg
+  rwa [div_le_iff₀ hx_pos] at hfinal
+
 end Erdos1138OQ03

--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -156,13 +156,14 @@ theorem bhp_gap_isLittleO_rpow (a : ℝ) (ha : (0.525 : ℝ) < a) :
   exact absurd hrp (lt_irrefl 0)
 
 /-- **Effective (pointwise) sublinearity.** A concrete sufficient condition replacing the
-    qualitative "eventually" of `bhp_gap_eventually_le_eps`: for `ε > 0`, once `x ≥ 25` and
+    qualitative "eventually" of `bhp_gap_eventually_le_eps`: once `x ≥ 25` and
     the explicit threshold `1 ≤ ε · x^0.475` holds, we already have `maxPrimeGap x ≤ ε · x`.
 
     The threshold `1 ≤ ε · x^0.475` is exactly `x^(-0.475) ≤ ε`, i.e. the point at which the
     envelope `maxPrimeGap x / x ≤ x^(-0.475)` has dropped below `ε`; it holds for all
-    sufficiently large `x` (since `x^0.475 → ∞`), recovering `bhp_gap_eventually_le_eps`. -/
-theorem bhp_gap_le_eps_effective (ε : ℝ) (hε : 0 < ε) (x : ℕ)
+    sufficiently large `x` (since `x^0.475 → ∞`), recovering `bhp_gap_eventually_le_eps`.
+    (Positivity of `ε` is not assumed — it is forced by the threshold, as `x^0.475 > 0`.) -/
+theorem bhp_gap_le_eps_effective (ε : ℝ) (x : ℕ)
     (hx25 : 25 ≤ x) (hthr : 1 ≤ ε * (x : ℝ) ^ (0.475 : ℝ)) :
     (maxPrimeGap x : ℝ) ≤ ε * x := by
   have hx_pos : (0 : ℝ) < (x : ℝ) := by

--- a/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
+++ b/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
@@ -54,3 +54,28 @@ NEXT (build-capable session): add the two theorems to a new
 only `{propext, Classical.choice, Quot.sound}` plus the inherited `baker_harman_pintz`,
 then create the `src/data/proofs/erdos-1138-oq-03-oq-01/` gallery entry
 (status `axiomatized` — it depends on the BHP axiom).
+
+## Session 2026-07-09 (researcher-1): SOLVED — asymptotics-idiom + effective forms (VERIFIED)
+
+Entry was already SOLVED (5 thm, 0 sorry, 1 inherited `baker_harman_pintz` axiom, merged #36057).
+Looked outward and added 3 genuinely distinct theory-level theorems (5 → 8):
+
+- `bhp_gap_isLittleO_id`: `maxPrimeGap =o[atTop] (x ↦ x)` — the little-o idiom form. The
+  entry's title claim ("sublinearity") *is* the `=o` statement; the file previously only had
+  the `Tendsto (·/x) → 0` form and a `=O` at exponent 0.525. Bridged via `isLittleO_iff_tendsto'`
+  (denominator eventually nonzero).
+- `bhp_gap_isLittleO_rpow (a) (ha : 0.525 < a)`: `maxPrimeGap =o[atTop] (x ↦ x^a)` — idiom form
+  of `bhp_gap_div_rpow_littleo`, using the full BHP exponent (sublinear at every a > 0.525, not
+  just a = 1).
+- `bhp_gap_le_eps_effective (ε x) (hx25 : 25 ≤ x) (hthr : 1 ≤ ε·x^0.475)`: `maxPrimeGap x ≤ ε·x`.
+  Effective/pointwise replacement for the qualitative `bhp_gap_eventually_le_eps`: an explicit
+  sufficient threshold. Proof multiplies the envelope `x^(-0.475) ≤ ε` (equivalent to hthr via
+  `x^(-0.475)·x^0.475 = x^0 = 1`) by `x`. `ε > 0` NOT assumed — forced by the threshold.
+
+Build: VERIFIED clean (`Completed successfully!`, 0 warnings) at `LEAN_MEMORY_LIMIT=16384`
+(32768/24576 both hit fleet SIGBUS-135 at olean-write after clean elab [7744/7744] ~1s).
+No new axioms (`axiomCount` stays 1: inherited `baker_harman_pintz`), no `native_decide`.
+meta synced 5→8 thm / 131→186 lines at both `.meta.*` and `.leanFile.*`.
+
+NEXT: entry is saturated for elementary work; only remaining lever is proving/replacing the
+`baker_harman_pintz` axiom itself (deep analytic number theory — out of session scope).

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -49,9 +49,9 @@
     "dateAdded": "2026-07-05",
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
-    "lineCount": 131,
+    "lineCount": 186,
     "assumptions": "1 axiom, inherited from the parent Erdos1138OQ03: baker_harman_pintz (maxPrimeGap x <= x^0.525 for x >= 25). No axiom is declared in this file (leanFile.axiomCount = 0); the assumption is imported. #print axioms confirms the results depend only on {propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}. No sorries, no native_decide.",
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -140,9 +140,9 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 131,
+    "lineCount": 186,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/Erdos1138OQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The entry **erdos-1138-oq-03-oq-01** ("Unconditional Sublinearity of Prime Gaps from Baker–Harman–Pintz") was already SOLVED (5 theorems, 0 sorries, 1 inherited `baker_harman_pintz` axiom). Following the SOLVED strategy (look outward, add theory-level content), this adds **3 genuinely distinct theorems** (5 → 8):

- **`bhp_gap_isLittleO_id`** — `maxPrimeGap =o[atTop] (x ↦ x)`. The entry's title claim ("sublinearity") *is* the little-o statement, but the file previously only carried the `Tendsto (·/x) → 0` form and a `=O` at exponent 0.525. Bridged via `isLittleO_iff_tendsto'` (denominator eventually nonzero).
- **`bhp_gap_isLittleO_rpow (a) (0.525 < a)`** — `maxPrimeGap =o[atTop] (x ↦ x^a)`. Little-o idiom form of the existing `bhp_gap_div_rpow_littleo`, using the full BHP exponent (sublinear at *every* exponent above 0.525, not just `a = 1`).
- **`bhp_gap_le_eps_effective (ε x) (25 ≤ x) (1 ≤ ε·x^0.475)`** — `maxPrimeGap x ≤ ε·x`. An **effective/pointwise** sufficient condition replacing the qualitative "eventually" of `bhp_gap_eventually_le_eps`. The threshold `1 ≤ ε·x^0.475` is exactly `x^(-0.475) ≤ ε`; the proof multiplies the envelope through by `x`. Positivity of `ε` is *not* assumed — it is forced by the threshold.

## Verification

- Build **VERIFIED clean** (`Completed successfully!`, 0 warnings) via `LEAN_MEMORY_LIMIT=16384 ./proofs/scripts/docker-build.sh Proofs.Erdos1138OQ03OQ01`. (Default 32768 / 24576 both hit the fleet SIGBUS-135 at the olean-write stage *after* clean elaboration `[7744/7744] ~1s` — memory, not math.)
- **No new axioms** — `axiomCount` stays 1 (inherited `baker_harman_pintz`). No `native_decide`. Status remains `axiomatized`.
- `meta.json` synced 5→8 theorems / 131→186 lines at both `.meta.*` and `.leanFile.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)