### PR TITLE
Enrich Newton k=2 / Maclaurin (amgm-inequality-oq-02-oq-01-oq-05-oq-01): cover symmetric-means form

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05-oq-01/annotations.json
@@ -70,5 +70,17 @@
     "significance": "key",
     "relatedConcepts": ["equality locus", "sum-of-squares vanishing set", "Newton equality case", "degenerate configurations"],
     "prerequisites": ["Lean `nlinarith` / `by_contra` / `positivity` tactics", "vanishing of a sum of squares"]
+  },
+  {
+    "id": "ann-symmetric-means-form",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+    "range": { "startLine": 105, "endLine": 124 },
+    "type": "theorem",
+    "title": "Maclaurin (Symmetric-Means) Form — the Literal Open-Question Statement",
+    "content": "newton_k2_symmetric_means restates the result in the normalized symmetric-means (Maclaurin) form the open question actually asks for: with S₁ = e₁/C(3,1) = e₁/3, S₂ = e₂/C(3,2) = e₂/3, S₃ = e₃/C(3,3) = e₃, it proves S₂² ≥ S₁·S₃. Because the denominators C(3,k) are constants, no positivity side-conditions are needed — this is the literal, sign-agnostic S₂² ≥ S₁S₃ statement over ALL reals. The proof factors the difference as (e₂² − 3e₁e₃)/9 and applies the already-proven newton_k2_allreals_three (e₂² ≥ 3e₁e₃). The file closes with #print axioms newton_k2_symmetric_means — a kernel-checked audit confirming dependence only on propext / Classical.choice / Quot.sound (no native_decide, no ofReduceBool), so the verified/0-axiom status is honest.",
+    "mathContext": "$S_2^2 \\ge S_1 S_3$ with $S_1=\\tfrac{e_1}{3}, S_2=\\tfrac{e_2}{3}, S_3=e_3$; equals $\\tfrac{e_2^2-3e_1e_3}{9}\\ge 0$ — Maclaurin's inequality at $k=2$, $n=3$, all reals.",
+    "significance": "key",
+    "relatedConcepts": ["Maclaurin's inequality", "symmetric means Sₖ", "Newton's inequalities", "#print axioms audit", "normalization by binomial coefficients"],
+    "prerequisites": ["newton_k2_allreals_three", "elementary symmetric polynomials", "#print axioms output"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-01-oq-05-oq-01`.

**Gap addressed:** annotations stopped at line 104, leaving the final theorem `newton_k2_symmetric_means` and the `#print axioms` audit (lines 105–124) uncovered.

**Added:** a `theorem` annotation for the Maclaurin (symmetric-means) form — the literal open-question statement S₂² ≥ S₁·S₃ with Sₖ = eₖ/C(3,k), sign-agnostic over all reals since the denominators are constant — plus the closing `#print axioms` audit confirming dependence only on propext / Classical.choice / Quot.sound (no native_decide/ofReduceBool), so the 0-axiom status is honest.

Annotation count 6 → 7, tail coverage closed. meta.json unchanged. Axiom/status integrity unchanged (verified, 0 axioms, 0 sorries).