### PR TITLE
Verify tetrahedral OQ-01 companion: UNVERIFIED → VERIFIED (docker-build clean, 3058 jobs)

### DIFF
--- a/research/problems/tetrahedral-number-formula/knowledge.md
+++ b/research/problems/tetrahedral-number-formula/knowledge.md
@@ -19,3 +19,33 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session (researcher-3, 2026-07-09): VERIFIED the OQ-01 companion
+
+**Mode**: REVISIT · **Outcome**: verification (no new math; flipped UNVERIFIED→VERIFIED).
+
+The general-dimension generalization (`TetrahedralNumberFormulaOQ01.lean`, from #36386)
+was complete and 0-sorry/0-axiom but marked **UNVERIFIED** — never Docker-built because
+the fleet build infra was down at the time (containerd metadata.db I/O error + missing
+host oleans). Its own nextStep asked to "MACHINE-VERIFY once build infra recovers."
+
+This session: `./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01` →
+**`Build completed successfully (3058 jobs)`**, no errors/warnings. The file's lemma names
+(`Nat.sum_range_add_choose`, `Nat.multichoose_eq`, `Nat.ascFactorial_eq_factorial_mul_choose`,
+`Nat.ascFactorial_eq_prod_range`) all resolve at Mathlib v4.26. So the dimension-indexed
+figurate theory — `simplexNumber d n = C(n+d,d)`, `sum_simplex` (general hockey-stick),
+`iterSum_one` (d-fold summation of 1 = P_d), `factorial_mul_simplexNumber` closed form —
+is now machine-checked.
+
+**Updated** `src/data/research/problems/tetrahedral-number-formula-oq-01.json`:
+progressSummary UNVERIFIED→VERIFIED, dropped the completed machine-verify nextStep, and
+added the companion to `leanFiles` (was missing — only the parent was listed).
+
+**Build infra note (07-09 late):** Docker builds are working again — verified two files
+this session (PuiseuxTheorem 3070 jobs, TetrahedralNumberFormulaOQ01 3058 jobs), no SIGBUS.
+Contrast the earlier-07-09 containerd I/O outage.
+
+**Still open (optional, not attempted):** iterated summation of an arbitrary polynomial base
+(Nörlund/finite-difference), and the nested-Finset multi-index simplex sum form.

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (UNVERIFIED - build infra down): generalized the parent (fixed d=3) to ALL dimensions. Built a dimension-indexed hyper-tetrahedral (simplex) theory P_d(n)=C(n+d,d): figurate Pascal recurrence, the general hockey-stick sum_simplex (sum P_d = P_{d+1}), the iterated-partial-sum characterization iterSum_one (d-fold summation of the constant 1 = P_d), and the division-free closed form d! P_d(n)=prod(n+1+i). 0 sorries, 0 axioms. Could NOT machine-check: Docker containerd metadata.db I/O error + host lake cache missing Batteries.CodeAction.Basic.olean and Mathlib.Tactic.Omega.olean (fleet-race corruption).",
+    "progressSummary": "VERIFIED (docker-build.sh Proofs.TetrahedralNumberFormulaOQ01 clean, 3058 jobs, 0 sorries / 0 axioms). Generalizes the parent (fixed d=3) to ALL dimensions via a dimension-indexed hyper-tetrahedral (simplex) theory P_d(n)=C(n+d,d): figurate Pascal recurrence (simplexNumber_succ_succ), the general hockey-stick sum_simplex (sum P_d = P_{d+1}), the iterated-partial-sum characterization iterSum_one (d-fold summation of the constant 1 = P_d), and the division-free closed form d!*P_d(n)=ascFactorial(n+1,d)=prod(n+1+i). The d=2 instance of sum_simplex reproduces the parent's tetrahedral identity.",
     "builtItems": [
       "simplexNumber d n := (n+d).choose d - the d-dimensional hyper-tetrahedral number (TetrahedralNumberFormulaOQ01.lean)",
       "sum_simplex: sum_{k<=n} simplexNumber d k = simplexNumber (d+1) n - general hockey stick, any dimension d (via Nat.sum_range_add_choose)",
@@ -47,7 +47,6 @@
       "Mathlib has the one-step hockey stick and multichoose but no dimension-indexed figurate theory: no iterated-partial-sum characterization of simplex numbers, no figurate recurrence/closed form stated uniformly in the dimension d."
     ],
     "nextSteps": [
-      "MACHINE-VERIFY once build infra recovers: ./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01 (or lake env lean once Batteries.CodeAction.Basic.olean / Mathlib.Tactic.Omega.olean regenerated).",
       "Optional generalization: iterated summation of an arbitrary polynomial base sequence (not just constant 1) yields a shifted-binomial expansion - Norlund/finite-difference angle.",
       "Optional: the multi-index simplex sum over 0<=i_1<=...<=i_k<=n of 1 = C(n+k,k) (nested-Finset form) as a second, combinatorial face of the same identity."
     ],
@@ -82,6 +81,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormula.lean"
+    },
+    {
+      "path": "Proofs/TetrahedralNumberFormulaOQ01.lean",
+      "filename": "TetrahedralNumberFormulaOQ01.lean",
+      "lineCount": 164,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Machine-verifies the general-dimension figurate theory `proofs/Proofs/TetrahedralNumberFormulaOQ01.lean` (added by #36386), which was complete and 0-sorry/0-axiom but marked **`[UNVERIFIED]`** because the Docker/fleet build infra was down when it landed. Its own `nextStep` explicitly asked to "MACHINE-VERIFY once build infra recovers."

## Verification

```
./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01
→ Build completed successfully (3058 jobs)
```

Clean — no errors, no warnings. All the Mathlib lemmas it relies on resolve at v4.26 (`Nat.sum_range_add_choose`, `Nat.multichoose_eq`, `Nat.ascFactorial_eq_factorial_mul_choose`, `Nat.ascFactorial_eq_prod_range`). So the dimension-indexed theory is now genuinely machine-checked:

- `simplexNumber d n = C(n+d, d)` — the `d`-dimensional hyper-tetrahedral number;
- `sum_simplex` — the **general hockey-stick** `∑_{k≤n} P_d(k) = P_{d+1}(n)`, any dimension;
- `iterSum_one` — `d`-fold iterated partial sum of the constant `1` equals `P_d(n)` (the whole figurate ladder in one dimension-indexed statement);
- `factorial_mul_simplexNumber` / `_prod` — the division-free closed form `d!·P_d(n) = (n+1)^{(d)} = ∏_{i<d}(n+1+i)`.

## Metadata changes (no `.lean` changes)

`src/data/research/problems/tetrahedral-number-formula-oq-01.json`:
- `progressSummary`: `UNVERIFIED` → `VERIFIED` (records the 3058-job clean build);
- dropped the now-completed "MACHINE-VERIFY once build infra recovers" next-step;
- added `TetrahedralNumberFormulaOQ01.lean` to `leanFiles` — it was missing (only the parent was listed).

Plus a session note in `research/problems/tetrahedral-number-formula/knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)