### PR TITLE
Enrich Odd-Square Series (basel-problem-oq-09): sync top-level openQuestions

### DIFF
--- a/src/data/proofs/basel-problem-oq-09/meta.json
+++ b/src/data/proofs/basel-problem-oq-09/meta.json
@@ -201,6 +201,11 @@
       "id": "basel-problem-oq-09-oq-01",
       "question": "Generalize the even/odd parity split to λ(2m) = ∑ 1/(2k+1)^{2m} = (1 - 2^{-2m}) ζ(2m) and derive λ(4) = π⁴/96 from hasSum_zeta_four.",
       "significance": "medium"
+    },
+    {
+      "id": "basel-problem-oq-09-oq-02",
+      "question": "Since ζ(2) = λ(2) + ¼ζ(2) forces ζ(2) = (4/3)λ(2) = (4/3)(π²/8) = π²/6, can this entry be turned around to derive the Basel value ζ(2) = π²/6 *from* the odd-square series λ(2) = π²/8, giving a self-contained 'odd squares ⟹ Basel' route independent of Mathlib's hasSum_zeta_two?",
+      "significance": "medium"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-09` (The Odd-Square Series ∑ 1/(2k+1)² = π²/8).

The entry was already comprehensive (13 KB, 9 fully-formed annotations, sections cover the full file, 4 cross-refs — all targets verified present, 3 references, rich 5-item keyInsights). Per anti-bloat guardrails I did not deepen it. The one genuine defect fixed:

- **openQuestions consistency**: the top-level `openQuestions` array listed only oq-01, while `conclusion.openQuestions` carried a second, substantive question (oq-02: reverse the even/odd split to derive the Basel value ζ(2)=π²/6 *from* the odd-square series λ(2)=π²/8, independent of Mathlib's `hasSum_zeta_two`). Synced the top-level array to include both so no open question is silently dropped depending on which array a consumer reads.

Verified against source: counts accurate (10 theorems, 1 definition, 148 lines), all 4 cross-reference targets present, axiom integrity intact (status `verified`, `axiomCount: 0`, 0 sorries). Size after: 13.4 KB (`check-meta-size` passes). Gallery-data validation and search-index checks pass under `pnpm build`; only the final `tsc` step fails (no `node_modules` in the isolated worktree).