### PR TITLE
Enrich Dirichlet eta η(2)=π²/12: cover summary/namespace-close tail

### DIFF
--- a/src/data/proofs/basel-problem-oq-11/annotations.json
+++ b/src/data/proofs/basel-problem-oq-11/annotations.json
@@ -184,5 +184,29 @@
       "tsum notation",
       "convergence of series"
     ]
+  },
+  {
+    "id": "eta-summary",
+    "proofId": "basel-problem-oq-11",
+    "range": {
+      "startLine": 97,
+      "endLine": 114
+    },
+    "type": "context",
+    "title": "Result Table: The Four Exported Lemmas",
+    "content": "Closing the BaselEtaTwo namespace, the trailing comment tabulates the four public results and their provenance. Two are non-alternating Basel building blocks — hasSum_even_zeta_two (∑ 1/(2k)² = π²/24) and hasSum_odd_zeta_two (∑ 1/(2k+1)² = π²/8) — and two are the target eta value in complementary forms: hasSum_eta_two (the HasSum statement) and tsum_eta_two (the ∑' form for downstream citation). The provenance line records the entire development as a specialization of Mathlib's hasSum_zeta_two (ζ(2) = π²/6) through the HasSum.even_add_odd split, with 0 sorries and 0 axioms. This makes explicit that no new analytic input beyond the Basel value is used — only reindexing, scaling, and sign bookkeeping.",
+    "mathContext": "$\\begin{array}{ll}\\text{even Basel} & \\sum 1/(2k)^2 = \\pi^2/24\\\\ \\text{odd Basel} & \\sum 1/(2k+1)^2 = \\pi^2/8\\\\ \\text{eta value} & \\sum (-1)^{n+1}/n^2 = \\pi^2/12\\end{array}$",
+    "significance": "context",
+    "relatedConcepts": [
+      "HasSum",
+      "tsum",
+      "hasSum_zeta_two",
+      "Dirichlet eta function",
+      "proof provenance"
+    ],
+    "prerequisites": [
+      "HasSum and tsum API",
+      "the Basel identity ζ(2) = π²/6"
+    ]
   }
 ]

--- a/src/data/proofs/basel-problem-oq-11/meta.json
+++ b/src/data/proofs/basel-problem-oq-11/meta.json
@@ -124,6 +124,14 @@
       "endLine": 96,
       "summary": "Even-indexed alternating terms sum to -π²/24, odd-indexed to π²/8; HasSum.even_add_odd combines to π²/12, with a tsum corollary.",
       "mathContext": "The Dirichlet eta value η(2) = (1/2)ζ(2) = π²/12."
+    },
+    {
+      "id": "summary",
+      "title": "Namespace Close and Result Summary",
+      "startLine": 97,
+      "endLine": 114,
+      "summary": "Closes namespace BaselEtaTwo and tabulates the four exported results — hasSum_even_zeta_two (π²/24), hasSum_odd_zeta_two (π²/8), hasSum_eta_two and tsum_eta_two (π²/12) — recording that all reduce to Mathlib's hasSum_zeta_two with 0 sorries and 0 axioms.",
+      "mathContext": "The four building blocks — even Basel π²/24, odd Basel π²/8, and the eta value π²/12 in HasSum and tsum form — all descend from ζ(2) = π²/6."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass on `basel-problem-oq-11` (quality 95, pass 0).

**Gap addressed:** sections ended at line 96 and annotations at line 95, leaving the namespace close + result-summary table (lines 97–114) uncovered.

**Changes:**
- Add a `summary` section (97–114) so `sections` now span the full 114-line file.
- Add a matching `eta-summary` annotation documenting the four exported HasSum/tsum lemmas (π²/24, π²/8, π²/12) and their 0-sorry / 0-axiom provenance from Mathlib's `hasSum_zeta_two`.

No existing content removed. meta.json 13.4 KB (well under cap); JSON validated with jq; size guard passes.