### PR TITLE
audit: re-verify 4 stalest entries CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24880,9 +24880,9 @@
       "issues": []
     },
     "shannon-source-coding-oq-02": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:50:52Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T23:30:00Z",
       "result": "clean"
     },
     "shannon-source-coding-oq-03": {
@@ -26059,9 +26059,9 @@
       "issues": []
     },
     "szemeredi-regularity": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:46:35Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T23:30:00Z",
       "result": "clean"
     },
     "szemeredi-regularity-oq-02": {
@@ -29730,5 +29730,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T00:00:00Z"
+  "lastUpdated": "2026-07-09T23:30:00Z"
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23750,9 +23750,9 @@
       "issues": []
     },
     "prime-reciprocal-divergence": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:52Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T23:35:00Z",
       "result": "clean"
     },
     "prime-reciprocal-divergence-oq-02": {
@@ -29730,5 +29730,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T23:30:00Z"
+  "lastUpdated": "2026-07-09T23:35:00Z"
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23400,9 +23400,9 @@
       "issues": []
     },
     "pell-equation": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:53Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T23:40:00Z",
       "result": "clean"
     },
     "pell-equation-oq-01": {
@@ -29730,5 +29730,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T23:35:00Z"
+  "lastUpdated": "2026-07-09T23:40:00Z"
 }


### PR DESCRIPTION
## Auditor tracker bump — 4 stalest entries re-verified CLEAN (2026-07-09)

All four were stuck at lastAudited 2026-05-03; the first two had merged audit PRs whose tracker bumps were lost to the tracker-race.

| Entry | Result | Notes |
|-------|--------|-------|
| `szemeredi-regularity` | CLEAN | verified/mathlib. 533 lines, 17 thm, 0 ax, 0 sorry (grep 'admits' = docstring FP); companion SzemerediCore 3 lemmas 0 sorry. Prior PR #36312. |
| `shannon-source-coding-oq-02` | CLEAN | axiomatized, axiomCount=1 (`huffman_optimal`, disclosed), 0 sorry, 9 thm. Prior PR #36344. |
| `prime-reciprocal-divergence` | CLEAN | verified/mathlib. 164 lines, 6 thm, 0 ax/def/sorry. All delegate to Mathlib (`Nat.Primes.not_summable_one_div`, `Nat.Primes.summable_rpow`, `not_summable_one_div_on_primes`). Honest attribution. |
| `pell-equation` | CLEAN | verified/mathlib. 298 lines, 10 thm, 2 def, 0 ax/sorry. Faithful bridge to Mathlib `Pell.Solution₁` (`Pell.exists_of_not_isSquare`, `IsFundamental.exists_of_not_isSquare`, `eq_zpow_or_neg_zpow`). |

Tracker date bumps only — no content changes — so `find-targets --next` stops re-serving already-clean entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)