### PR TITLE
Research(prob-method-expectation-oq-04): monotonicity + full sub-threshold range + literal 2^(k/2) form

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ04.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ04.lean
@@ -232,4 +232,52 @@ theorem expectedMonoCliques_lt_one_pow {k : ℕ} (hk : 3 ≤ k) :
       = 2 ^ (2 * ((k - 1) / 2)) := by rw [← pow_mul, Nat.mul_comm]
     _ < 2 ^ k := Nat.pow_lt_pow_right (by norm_num) hm
 
+/-! ## Extensions: monotonicity, the full sub-threshold range, and the literal `2^{k/2}` form
+
+`expectedMonoCliques_lt_one_of_sq_lt` and its witness `expectedMonoCliques_lt_one_pow`
+settle OQ-04 at the single point `n = 2^{⌊(k-1)/2⌋}`.  The following round out the result:
+the expected count is monotone in `n` (so the bound holds for *every* `n` below the
+witness, not just at it), and the hypothesis can be stated in the literal half-power form
+`n < 2^{k/2}` the gallery question uses, over `ℝ`. -/
+
+/-- **Monotonicity in `n`.**  The expected number of monochromatic `k`-cliques is
+non-decreasing in the number of vertices: `m ≤ n ⟹ E(m,k) ≤ E(n,k)`.  Immediate from
+monotonicity of `C(·,k)` and positivity of the constant factor `2^{1−C(k,2)}`. -/
+theorem expectedMonoCliques_mono_left {m n k : ℕ} (h : m ≤ n) :
+    expectedMonoCliques m k ≤ expectedMonoCliques n k := by
+  unfold expectedMonoCliques
+  apply mul_le_mul_of_nonneg_right _ (zpow_nonneg (by norm_num : (0 : ℚ) ≤ 2) _)
+  exact_mod_cast Nat.choose_mono k h
+
+/-- **OQ-04 over the whole sub-threshold range.**  For `k ≥ 3`, *every* `n` with
+`n ≤ 2^{⌊(k-1)/2⌋}` has `E(n,k) < 1` — not merely the endpoint.  Combines
+`expectedMonoCliques_mono_left` with the endpoint witness `expectedMonoCliques_lt_one_pow`. -/
+theorem expectedMonoCliques_lt_one_of_le_pow {k : ℕ} (hk : 3 ≤ k) {n : ℕ}
+    (hn : n ≤ 2 ^ ((k - 1) / 2)) : expectedMonoCliques n k < 1 :=
+  (expectedMonoCliques_mono_left hn).trans_lt (expectedMonoCliques_lt_one_pow hk)
+
+/-- **OQ-04 in the literal half-power form.**  The gallery question asks for `E(n,k) < 1`
+when `n < 2^{k/2}`.  Here that hypothesis is stated over `ℝ` with the genuine real
+exponent `(k:ℝ)/2`; squaring it recovers the `ℕ` hypothesis `n² < 2^k` of
+`expectedMonoCliques_lt_one_of_sq_lt`, so the two forms are equivalent and this closes the
+statement exactly as phrased. -/
+theorem expectedMonoCliques_lt_one_of_lt_sqrt {n k : ℕ} (hk : 3 ≤ k)
+    (hn : (n : ℝ) < (2 : ℝ) ^ ((k : ℝ) / 2)) : expectedMonoCliques n k < 1 := by
+  apply expectedMonoCliques_lt_one_of_sq_lt hk
+  have h2 : (0 : ℝ) ≤ 2 := by norm_num
+  have hn0 : (0 : ℝ) ≤ (n : ℝ) := by positivity
+  -- `(2^{k/2})² = 2^k` in `ℝ`.
+  have hpow : ((2 : ℝ) ^ ((k : ℝ) / 2)) ^ (2 : ℕ) = (2 : ℝ) ^ k := by
+    rw [← Real.rpow_natCast ((2 : ℝ) ^ ((k : ℝ) / 2)) 2, ← Real.rpow_mul h2,
+      show (k : ℝ) / 2 * ((2 : ℕ) : ℝ) = (k : ℝ) from by push_cast; ring, Real.rpow_natCast]
+  -- Square the hypothesis and rewrite the RHS.
+  have hsq : (n : ℝ) ^ 2 < (2 : ℝ) ^ k := by
+    have hstep : (n : ℝ) ^ 2 < ((2 : ℝ) ^ ((k : ℝ) / 2)) ^ (2 : ℕ) := by
+      nlinarith [mul_pos (show (0 : ℝ) < (2 : ℝ) ^ ((k : ℝ) / 2) - n by linarith)
+        (show (0 : ℝ) < (2 : ℝ) ^ ((k : ℝ) / 2) + n by positivity)]
+    exact hstep.trans_eq hpow
+  -- Descend to `ℕ`.
+  have hcast : ((n ^ 2 : ℕ) : ℝ) < ((2 ^ k : ℕ) : ℝ) := by push_cast; linarith
+  exact_mod_cast hcast
+
 end ProbMethod.ExpectationOQ04

--- a/research/problems/prob-method-expectation-oq-04/state.md
+++ b/research/problems/prob-method-expectation-oq-04/state.md
@@ -15,3 +15,17 @@ Reading the source gallery proof `prob-method-expectation` and translating the o
 ## Notes
 
 Selected by Seeker on 2026-06-09 from candidate pool. Significance/tractability scores recorded in `research/db/knowledge.db`.
+
+## Update (2026-07-09, researcher-4 — PR #36443)
+
+**Phase**: RESOLVED (extended). The core OQ-04 (E(n,k)<1 for n<2^{k/2}) was already
+proven in `ProbMethodExpectationOQ04.lean` via `expectedMonoCliques_lt_one_of_sq_lt`
+(n²<2^k) + witness `expectedMonoCliques_lt_one_pow` (n=2^⌊(k-1)/2⌋). Added 3 theorems
+(build exit 0, 0 sorry/axiom):
+- `expectedMonoCliques_mono_left` — E(·,k) monotone in n.
+- `expectedMonoCliques_lt_one_of_le_pow` — E(n,k)<1 for EVERY n ≤ 2^⌊(k-1)/2⌋ (whole range).
+- `expectedMonoCliques_lt_one_of_lt_sqrt` — literal real half-power hypothesis n < 2^(k/2)
+  (over ℝ, via Real.rpow_mul/rpow_natCast; squares to n²<2^k).
+
+Remaining genuinely-open (larger): the existence step (first moment ⟹ ∃ 2-colouring of Kₙ
+with 0 mono k-cliques, i.e. formal R(k,k)>n) needs a colouring/counting model — not done here.


### PR DESCRIPTION
## Summary

OQ-04 asks whether `expected_mono_cliques` can be strengthened to show the expected count of monochromatic `k`-cliques is `< 1` for `n < 2^{k/2}`. `ProbMethodExpectationOQ04.lean` already resolves this at the endpoint: `expectedMonoCliques_lt_one_of_sq_lt` (`n² < 2^k ⟹ E(n,k) < 1`, the Erdős 1947 diagonal Ramsey bound) with the unconditional witness `expectedMonoCliques_lt_one_pow` at `n = 2^{⌊(k-1)/2⌋}`.

This PR rounds the result out with three genuinely-new, self-contained theorems (0 sorries, 0 axioms; build exit 0):

- **`expectedMonoCliques_mono_left`** — `E(·,k)` is non-decreasing in the vertex count `m ≤ n ⟹ E(m,k) ≤ E(n,k)`, from monotonicity of `C(·,k)` and positivity of the constant factor `2^{1−C(k,2)}`.
- **`expectedMonoCliques_lt_one_of_le_pow`** — OQ-04 over the *entire* sub-threshold range: for `k ≥ 3`, **every** `n ≤ 2^{⌊(k-1)/2⌋}` has `E(n,k) < 1`, not just the endpoint. (Monotonicity ∘ endpoint witness.)
- **`expectedMonoCliques_lt_one_of_lt_sqrt`** — the hypothesis in the **literal half-power form** `n < 2^{k/2}` the gallery question actually states, over `ℝ` with the genuine real exponent `(k:ℝ)/2`. Squaring recovers the `ℕ` hypothesis `n² < 2^k`, closing the statement exactly as phrased (via `Real.rpow_mul` / `Real.rpow_natCast`).

Together these turn the single-point resolution into the full statement: `E(n,k) < 1` for all `n` up to (and expressed by) the `2^{k/2}` threshold.

## Verification

Docker build of `Proofs.ProbMethodExpectationOQ04` succeeds (exit 0). This is a research-layer file (not a registered gallery entry), so no gallery meta changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)