### PR TITLE
Enrich Dirichlet eta η(4) (basel-problem-oq-14): full section coverage + openQuestions sync

### DIFF
--- a/src/data/proofs/basel-problem-oq-14/meta.json
+++ b/src/data/proofs/basel-problem-oq-14/meta.json
@@ -121,8 +121,8 @@
       "id": "eta",
       "title": "hasSum_eta_four / tsum_eta_four — η(4) = 7π⁴/720",
       "startLine": 69,
-      "endLine": 95,
-      "summary": "Even-indexed alternating terms sum to -π⁴/1440, odd-indexed to π⁴/96; HasSum.even_add_odd combines to 7π⁴/720, with a tsum corollary.",
+      "endLine": 113,
+      "summary": "Even-indexed alternating terms sum to -π⁴/1440, odd-indexed to π⁴/96; HasSum.even_add_odd combines to 7π⁴/720, with a tsum corollary. Closes with a summary table of the four results (even ζ(4), odd ζ(4), and the η(4) HasSum and tsum forms) and the 0-sorry / 0-axiom status.",
       "mathContext": "The Dirichlet eta value η(4) = (1 - 1/8)ζ(4) = 7π⁴/720."
     }
   ],
@@ -185,6 +185,11 @@
     {
       "id": "basel-problem-oq-14-oq-01",
       "question": "Abstract the parity split into η(2m) = (1 - 2^(1-2m)) ζ(2m) and derive η(2), η(4), η(6), ... uniformly from hasSum_zeta_nat.",
+      "significance": "medium"
+    },
+    {
+      "id": "basel-problem-oq-14-oq-02",
+      "question": "Cross-link the weight-4 family {ζ(4), λ(4), η(4)} and formalize the coordinate identity η(2m) = (1 − 2^{−(2m−1)})ζ(2m): at m=2, η(4) = λ(4) − 2^{−4}ζ(4) = (15/16 − 1/16)ζ(4) = (7/8)ζ(4) = 7π⁴/720, the numerator 7 arising precisely from 1 − 2^{−3} = 7/8.",
       "significance": "medium"
     }
   ],


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-14` (Dirichlet eta η(4) = ∑ (−1)^{n+1}/n⁴ = 7π⁴/720).

The entry was already comprehensive (12 KB, 7 fully-formed annotations, 5 keyInsights, 3 references). Per anti-bloat guardrails I did not deepen it. Two genuine defects fixed:

- **Incomplete section coverage**: the `sections` array covered only lines 1–95 of a 113-line file — the closing summary table and `end` block (lines 96–113) fell outside every section. Extended the final `eta` section's `endLine` 95→113 so coverage now spans the whole file.
- **openQuestions consistency**: the top-level `openQuestions` array listed only oq-01, while `conclusion.openQuestions` carried a second substantive question (oq-02: cross-link the weight-4 family {ζ(4), λ(4), η(4)} and formalize η(2m) = (1 − 2^{−(2m−1)})ζ(2m); at m=2, η(4) = (7/8)ζ(4), the numerator 7 arising from 1 − 2^{−3} = 7/8). Synced the top-level array.

Verified against source: counts accurate (4 theorems, 1 definition, 113 lines), all 3 cross-reference targets present, axiom integrity intact (`verified`, `axiomCount: 0`, 0 sorries). Size after: 12.7 KB (`check-meta-size` passes). Gallery-data validation and search-index checks pass under `pnpm build`; only the final `tsc` step fails (no `node_modules` in the isolated worktree).