### PR TITLE
Enrich odd-square Basel λ(2)=π²/8: cover positivity corollary

### DIFF
--- a/src/data/proofs/basel-problem-oq-09/annotations.json
+++ b/src/data/proofs/basel-problem-oq-09/annotations.json
@@ -154,11 +154,11 @@
     "proofId": "basel-problem-oq-09",
     "range": {
       "startLine": 82,
-      "endLine": 121
+      "endLine": 124
     },
     "type": "theorem",
     "title": "The Odd-Square Series ∑ 1/(2k+1)² = π²/8",
-    "content": "hasSum_odd_squares is the headline result, assembled from the even part, odd summability, the even_add_odd recombination, and uniqueness. tsum_odd_squares and summable_odd_squares package it in tsum and Summable form for downstream reuse. The value π²/8 is exactly λ(2), the s = 2 case of the Dirichlet odd-index zeta λ(s) = ∑ 1/(2k+1)^s = (1 − 2^{−s})ζ(s); here (1 − 1/4)·π²/6 = (3/4)·π²/6 = π²/8.",
+    "content": "hasSum_odd_squares is the headline result, assembled from the even part, odd summability, the even_add_odd recombination, and uniqueness. tsum_odd_squares and summable_odd_squares package it in tsum and Summable form for downstream reuse, and odd_squares_value_pos records the elementary corollary π²/8 > 0 (by positivity), which the mass-distribution comparison π²/24 < π²/8 later depends on. The value π²/8 is exactly λ(2), the s = 2 case of the Dirichlet odd-index zeta λ(s) = ∑ 1/(2k+1)^s = (1 − 2^{−s})ζ(s); here (1 − 1/4)·π²/6 = (3/4)·π²/6 = π²/8.",
     "mathContext": "$\\displaystyle\\sum_{k=0}^{\\infty} \\frac{1}{(2k+1)^2} = 1 + \\frac19 + \\frac1{25} + \\cdots = \\frac{\\pi^2}{8} = \\lambda(2).$",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
Enrichment pass on `basel-problem-oq-09` (quality 95, pass 0).

The entry already had full section coverage (1–148) and rich annotations. The one uncovered declaration was `odd_squares_value_pos` (π²/8 > 0, lines 123–124).

**Change:** extend the main-result annotation's range from 82→124 so it now covers that positivity corollary, and note its role in the later mass-distribution comparison π²/24 < π²/8. No content removed.

JSON validated with jq.