### PR TITLE
Enrich Dirichlet eta η(4)=7π⁴/720: cover summary/namespace-close tail

### DIFF
--- a/src/data/proofs/basel-problem-oq-14/annotations.json
+++ b/src/data/proofs/basel-problem-oq-14/annotations.json
@@ -160,5 +160,29 @@
       "infinite series",
       "fourth zeta value"
     ]
+  },
+  {
+    "id": "eta4-summary",
+    "proofId": "basel-problem-oq-14",
+    "range": {
+      "startLine": 96,
+      "endLine": 113
+    },
+    "type": "context",
+    "title": "Result Table: The Four Exported Lemmas",
+    "content": "Closing the BaselEtaFour namespace, the trailing comment tabulates the four public results and their provenance. Two are non-alternating fourth-power building blocks — hasSum_even_zeta_four (∑ 1/(2k)⁴ = π⁴/1440) and hasSum_odd_zeta_four (∑ 1/(2k+1)⁴ = π⁴/96) — and two are the target eta value in complementary forms: hasSum_eta_four (the HasSum statement) and tsum_eta_four (the ∑' form for downstream citation). The provenance line records the whole development as a specialization of Mathlib's hasSum_zeta_four (ζ(4) = π⁴/90) through the HasSum.even_add_odd split, with 0 sorries and 0 axioms — the fourth-power twin of the η(2) = π²/12 entry, using no analytic input beyond ζ(4).",
+    "mathContext": "$\\begin{array}{ll}\\text{even} & \\sum 1/(2k)^4 = \\pi^4/1440\\\\ \\text{odd} & \\sum 1/(2k+1)^4 = \\pi^4/96\\\\ \\text{eta value} & \\sum (-1)^{n+1}/n^4 = 7\\pi^4/720\\end{array}$",
+    "significance": "context",
+    "relatedConcepts": [
+      "HasSum",
+      "tsum",
+      "hasSum_zeta_four",
+      "Dirichlet eta function",
+      "proof provenance"
+    ],
+    "prerequisites": [
+      "HasSum and tsum API",
+      "the fourth zeta value ζ(4) = π⁴/90"
+    ]
   }
 ]

--- a/src/data/proofs/basel-problem-oq-14/meta.json
+++ b/src/data/proofs/basel-problem-oq-14/meta.json
@@ -124,6 +124,14 @@
       "endLine": 95,
       "summary": "Even-indexed alternating terms sum to -π⁴/1440, odd-indexed to π⁴/96; HasSum.even_add_odd combines to 7π⁴/720, with a tsum corollary.",
       "mathContext": "The Dirichlet eta value η(4) = (1 - 1/8)ζ(4) = 7π⁴/720."
+    },
+    {
+      "id": "summary",
+      "title": "Namespace Close and Result Summary",
+      "startLine": 96,
+      "endLine": 113,
+      "summary": "Closes namespace BaselEtaFour and tabulates the four exported results — hasSum_even_zeta_four (π⁴/1440), hasSum_odd_zeta_four (π⁴/96), hasSum_eta_four and tsum_eta_four (7π⁴/720) — recording that all reduce to Mathlib's hasSum_zeta_four with 0 sorries and 0 axioms.",
+      "mathContext": "The four building blocks — even π⁴/1440, odd π⁴/96, and the eta value 7π⁴/720 in HasSum and tsum form — all descend from ζ(4) = π⁴/90."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass on `basel-problem-oq-14` (quality 95, pass 0).

**Gap:** sections ended at line 95 and annotations at 94, leaving the namespace close + result-summary table (lines 96–113) uncovered — the same tail gap fixed in the η(2) sibling (basel-problem-oq-11).

**Changes:**
- Add a `summary` section (96–113) so `sections` span the full 113-line file.
- Add a matching `eta4-summary` annotation documenting the four exported HasSum/tsum lemmas (π⁴/1440, π⁴/96, 7π⁴/720) and their 0-sorry / 0-axiom provenance from Mathlib's `hasSum_zeta_four`.

No content removed. meta.json 12.7 KB (under cap); JSON validated with jq.