### PR TITLE
Enrich Quintic Bernoulli Endpoint (bernoulli-inequality-oq-01-oq-01-oq-01-oq-01): cover preamble

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -76,6 +76,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Overview, Imports, and the Residual Cubic Definition",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring stating the open question (locate the n = 5 odd endpoint a₅* of the strict Bernoulli inequality 1 + 5a < (1+a)⁵) and previewing the six main results — the factorization, the residual cubic's strict monotonicity, the sign-of-g form, the headline endpoint a₅* ∈ (−3, −2), the concrete bracketing witnesses, and the universal below-−2 companion. Imports Mathlib, opens the BernoulliInequalityOQ01OQ01OQ01OQ01 namespace and Real, and defines the residual cubic g(a) = a³ + 5a² + 10a + 10 left after dividing the quintic gap by a².",
+      "mathContext": "The quintic Bernoulli gap factors as $(1+a)^5 - (1+5a) = a^2\\,g(a)$ with $g(a) = a^3 + 5a^2 + 10a + 10$; the strict inequality is governed entirely by the sign of $g$."
+    },
+    {
       "id": "factorization",
       "title": "The Residual Cubic Factorization",
       "startLine": 53,
@@ -119,7 +127,7 @@
       "id": "below-neg-two",
       "title": "Every Odd Endpoint Sits Below −2",
       "startLine": 153,
-      "endLine": 160,
+      "endLine": 161,
       "summary": "For every odd n ≥ 2 the strict inequality holds at a = −2, since (1 + (−2))ⁿ = (−1)ⁿ = −1 beats 1 − 2n; so −2 is interior for each odd n and aₙ* < −2 universally.",
       "mathContext": "Odd n, n ≥ 2 ⟹ 1 + n·(−2) < (1 + (−2))ⁿ."
     }


### PR DESCRIPTION
Enrichment pass for `bernoulli-inequality-oq-01-oq-01-oq-01-oq-01` (The Quintic Bernoulli Endpoint a₅* ∈ (−3, −2)).

The entry was already comprehensive (7 fully-formed annotations covering lines 3–161, 4 keyInsights, rich conclusion with 3 open questions, 2 cross-refs — both present). Per anti-bloat guardrails I did not deepen it. The one genuine defect:

- **Uncovered preamble**: the `sections` array started at line 53, leaving lines 1–52 — a substantial 41-line module docstring that states the open question and previews all six main results, plus the imports and the `residualCubic` definition — outside every section. Added a `preamble` section (1–52) summarizing that content, and extended the final `below-neg-two` section `endLine` 160→161. Sections now span the whole file contiguously.

Verified against source: counts accurate (9 theorems, 1 definition, 161 lines), both cross-reference targets present, axiom integrity intact (`verified`, `axiomCount: 0`, 0 sorries). The top-level `openQuestions` is legitimately absent — this entry uses the string-array `conclusion.openQuestions` convention (3 questions), so no sync was needed. Size after: 16.5 KB (`check-meta-size` passes). Gallery-data validation and search-index checks pass under `pnpm build`; only the final `tsc` step fails (no `node_modules` in the isolated worktree).