### PR TITLE
research(erdos101-problem-oq-04): exact quartic collinearity criteria [VERIFIED 0/0 new, +2 thm]

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -2765,4 +2765,99 @@ theorem exists_isLowerBoundConstruction_linear (k : ℕ) (hk : 0 < k) :
   obtain ⟨P, hcard, hno5, hcount⟩ := quartic_linear_lower_bound k hk
   exact ⟨P, hcard, hno5, by exact_mod_cast hcount⟩
 
+/-! ### Exact collinearity criteria on the quartic (arithmetization)
+
+The `noFiveCollinear_of_onQuartic` engine says the quartic graph *forbids* five
+collinear points.  The two results below go the other way and pin down *exactly*
+which triples and quadruples on the quartic *are* collinear, turning the geometric
+collinearity test into pure arithmetic conditions on the abscissae.
+
+The mechanism is a single algebraic factorisation.  For three points on
+`y = x⁴ − 5x²` the signed-area determinant factors as
+
+    (b₁−a₁)(c₂−a₂) − (c₁−a₁)(b₂−a₂)
+      = (a₁−b₁)(b₁−c₁)(c₁−a₁) · (a₁²+b₁²+c₁²+a₁b₁+b₁c₁+c₁a₁ − 5),
+
+a Vandermonde factor (nonzero for distinct abscissae) times a symmetric quadratic.
+Collinearity of a triple therefore reduces to `Σx² + Σxy = 5`, and — anchoring two
+points — collinearity of a quadruple reduces to the two Newton/Vieta relations
+`Σx = 0` and `Σ_{i<j} xᵢxⱼ = −5` (the vanishing of the cubic and the value `−5` of
+the quadratic elementary symmetric polynomial, exactly the `x³`- and `x²`-coefficients
+of `x⁴ − 5x²` a line must meet).
+
+This is the combinatorial engine behind any curve-based four-point-line count:
+counting four-point lines among `n` points on the quartic becomes counting
+`4`-subsets of the abscissa set satisfying `Σx = 0 ∧ Σxy = −5`, a purely additive
+question.  It does not resolve the OPEN `Ω(n^{2−o(1)})` growth
+(`solymosi_stojakovic_lower_bound`), but it is the exact arithmetic reformulation a
+sharper construction operates on. -/
+
+/-- **Exact three-point collinearity criterion on the quartic.**
+Three points on the graph `y = x⁴ − 5x²` with pairwise-distinct abscissae are
+collinear iff `a₁² + b₁² + c₁² + a₁b₁ + b₁c₁ + c₁a₁ = 5`. -/
+theorem collinear_onQuartic_iff {a b c : ℝ × ℝ}
+    (ha : onQuartic a) (hb : onQuartic b) (hc : onQuartic c)
+    (hab : a.1 ≠ b.1) (hbc : b.1 ≠ c.1) (hca : c.1 ≠ a.1) :
+    collinear a b c ↔
+      a.1 ^ 2 + b.1 ^ 2 + c.1 ^ 2 + a.1 * b.1 + b.1 * c.1 + c.1 * a.1 = 5 := by
+  simp only [onQuartic] at ha hb hc
+  -- The determinant factors as Vandermonde × (symmetric quadratic − 5).
+  have key : (b.1 - a.1) * (c.2 - a.2) - (c.1 - a.1) * (b.2 - a.2)
+      = (a.1 - b.1) * (b.1 - c.1) * (c.1 - a.1) *
+          (a.1 ^ 2 + b.1 ^ 2 + c.1 ^ 2 + a.1 * b.1 + b.1 * c.1 + c.1 * a.1 - 5) := by
+    rw [ha, hb, hc]; ring
+  have hV : (a.1 - b.1) * (b.1 - c.1) * (c.1 - a.1) ≠ 0 :=
+    mul_ne_zero (mul_ne_zero (sub_ne_zero.mpr hab) (sub_ne_zero.mpr hbc))
+      (sub_ne_zero.mpr hca)
+  constructor
+  · intro hcol
+    have hEq : (b.1 - a.1) * (c.2 - a.2) = (c.1 - a.1) * (b.2 - a.2) := hcol
+    have hD : (a.1 - b.1) * (b.1 - c.1) * (c.1 - a.1) *
+        (a.1 ^ 2 + b.1 ^ 2 + c.1 ^ 2 + a.1 * b.1 + b.1 * c.1 + c.1 * a.1 - 5) = 0 := by
+      rw [← key]; linarith [hEq]
+    rcases mul_eq_zero.mp hD with h | h
+    · exact absurd h hV
+    · linarith [h]
+  · intro hcond
+    show (b.1 - a.1) * (c.2 - a.2) = (c.1 - a.1) * (b.2 - a.2)
+    have hzero : (b.1 - a.1) * (c.2 - a.2) - (c.1 - a.1) * (b.2 - a.2) = 0 := by
+      rw [key]
+      have : a.1 ^ 2 + b.1 ^ 2 + c.1 ^ 2 + a.1 * b.1 + b.1 * c.1 + c.1 * a.1 - 5 = 0 := by
+        linarith [hcond]
+      rw [this, mul_zero]
+    linarith [hzero]
+
+/-- **Vieta criterion for a four-point line on the quartic.**
+Four points on `y = x⁴ − 5x²` with pairwise-distinct abscissae are collinear
+(all four lie on one line, witnessed by the two anchored triples through `a, b`)
+iff their abscissae satisfy the Newton/Vieta relations `Σx = 0` and `Σ_{i<j} xᵢxⱼ = −5`.
+
+These are exactly the `x³`- and `x²`-coefficient conditions: a line `y = mx + e`
+meets the quartic where `x⁴ − 5x² − mx − e = 0`, whose four roots (for a genuine
+four-point line) have elementary symmetric sums `e₁ = 0` and `e₂ = −5`. -/
+theorem four_onQuartic_collinear_iff {a b c d : ℝ × ℝ}
+    (ha : onQuartic a) (hb : onQuartic b) (hc : onQuartic c) (hd : onQuartic d)
+    (hab : a.1 ≠ b.1) (hbc : b.1 ≠ c.1) (hca : c.1 ≠ a.1)
+    (hbd : b.1 ≠ d.1) (hda : d.1 ≠ a.1) (hcd : c.1 ≠ d.1) :
+    (collinear a b c ∧ collinear a b d) ↔
+      (a.1 + b.1 + c.1 + d.1 = 0 ∧
+       a.1 * b.1 + a.1 * c.1 + a.1 * d.1 + b.1 * c.1 + b.1 * d.1 + c.1 * d.1 = -5) := by
+  rw [collinear_onQuartic_iff ha hb hc hab hbc hca,
+      collinear_onQuartic_iff ha hb hd hab hbd hda]
+  constructor
+  · rintro ⟨habc, habd⟩
+    -- Subtracting the two triple conditions exposes the Vandermonde factor (c₁−d₁).
+    have hfac : (c.1 - d.1) * (a.1 + b.1 + c.1 + d.1) = 0 := by
+      linear_combination habc - habd
+    have he1 : a.1 + b.1 + c.1 + d.1 = 0 := by
+      rcases mul_eq_zero.mp hfac with h | h
+      · exact absurd (sub_eq_zero.mp h) hcd
+      · exact h
+    refine ⟨he1, ?_⟩
+    linear_combination (a.1 + b.1 + c.1) * he1 - habc
+  · rintro ⟨he1, he2⟩
+    refine ⟨?_, ?_⟩
+    · linear_combination (a.1 + b.1 + c.1) * he1 - he2
+    · linear_combination (a.1 + b.1 + d.1) * he1 - he2
+
 end Erdos101OQ04

--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -128,4 +128,58 @@ theorem bhp_gap_div_rpow_littleo (a : ℝ) (ha : (0.525 : ℝ) < a) :
       _ = (x : ℝ) ^ (-(a - 0.525)) := hdiv
   exact squeeze_zero' (Eventually.of_forall h_lo) h_hi h_env
 
+/-- **Sublinearity in the little-o idiom.** The maximal prime gap is `o(x)`.
+
+    This is the asymptotics-idiom repackaging of `bhp_implies_gap_littleo`: the entry's
+    title claim ("sublinearity") is exactly the statement `maxPrimeGap =o[atTop] id`, which
+    `bhp_implies_gap_littleo` records only as a `Tendsto (·/x) → 0`. The two are equivalent
+    via `isLittleO_iff_tendsto'` (the denominator `x` is eventually nonzero). -/
+theorem bhp_gap_isLittleO_id :
+    (fun x : ℕ => (maxPrimeGap x : ℝ)) =o[atTop] (fun x : ℕ => (x : ℝ)) := by
+  refine (isLittleO_iff_tendsto' ?_).mpr bhp_implies_gap_littleo
+  filter_upwards [eventually_ge_atTop 1] with x hx h0
+  have hxpos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one hx
+  rw [h0] at hxpos
+  exact absurd hxpos (lt_irrefl 0)
+
+/-- **Sharp little-o at every exponent above `0.525`.** For any `a > 0.525`,
+    `maxPrimeGap =o[atTop] (x ↦ x^a)`. This is the little-o idiom form of
+    `bhp_gap_div_rpow_littleo`, using the full BHP exponent: sublinearity holds not just at
+    `a = 1` (`bhp_gap_isLittleO_id`) but for every exponent strictly above the BHP threshold. -/
+theorem bhp_gap_isLittleO_rpow (a : ℝ) (ha : (0.525 : ℝ) < a) :
+    (fun x : ℕ => (maxPrimeGap x : ℝ)) =o[atTop] (fun x : ℕ => (x : ℝ) ^ a) := by
+  refine (isLittleO_iff_tendsto' ?_).mpr (bhp_gap_div_rpow_littleo a ha)
+  filter_upwards [eventually_ge_atTop 1] with x hx h0
+  have hxpos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one hx
+  have hrp : (0 : ℝ) < (x : ℝ) ^ a := Real.rpow_pos_of_pos hxpos a
+  rw [h0] at hrp
+  exact absurd hrp (lt_irrefl 0)
+
+/-- **Effective (pointwise) sublinearity.** A concrete sufficient condition replacing the
+    qualitative "eventually" of `bhp_gap_eventually_le_eps`: for `ε > 0`, once `x ≥ 25` and
+    the explicit threshold `1 ≤ ε · x^0.475` holds, we already have `maxPrimeGap x ≤ ε · x`.
+
+    The threshold `1 ≤ ε · x^0.475` is exactly `x^(-0.475) ≤ ε`, i.e. the point at which the
+    envelope `maxPrimeGap x / x ≤ x^(-0.475)` has dropped below `ε`; it holds for all
+    sufficiently large `x` (since `x^0.475 → ∞`), recovering `bhp_gap_eventually_le_eps`. -/
+theorem bhp_gap_le_eps_effective (ε : ℝ) (hε : 0 < ε) (x : ℕ)
+    (hx25 : 25 ≤ x) (hthr : 1 ≤ ε * (x : ℝ) ^ (0.475 : ℝ)) :
+    (maxPrimeGap x : ℝ) ≤ ε * x := by
+  have hx_pos : (0 : ℝ) < (x : ℝ) := by
+    have : (0 : ℕ) < x := lt_of_lt_of_le (by norm_num) hx25
+    exact_mod_cast this
+  have hxneg_pos : (0 : ℝ) < (x : ℝ) ^ (-(0.475 : ℝ)) := Real.rpow_pos_of_pos hx_pos _
+  -- x^(-0.475) · x^0.475 = x^0 = 1, so multiplying the threshold by x^(-0.475) gives the bound.
+  have hmul : (x : ℝ) ^ (-(0.475 : ℝ)) * (x : ℝ) ^ (0.475 : ℝ) = 1 := by
+    rw [← Real.rpow_add hx_pos]; norm_num
+  have hneg : (x : ℝ) ^ (-(0.475 : ℝ)) ≤ ε := by
+    calc (x : ℝ) ^ (-(0.475 : ℝ))
+        = (x : ℝ) ^ (-(0.475 : ℝ)) * 1 := by ring
+      _ ≤ (x : ℝ) ^ (-(0.475 : ℝ)) * (ε * (x : ℝ) ^ (0.475 : ℝ)) :=
+          mul_le_mul_of_nonneg_left hthr (le_of_lt hxneg_pos)
+      _ = ε * ((x : ℝ) ^ (-(0.475 : ℝ)) * (x : ℝ) ^ (0.475 : ℝ)) := by ring
+      _ = ε := by rw [hmul]; ring
+  have hfinal : (maxPrimeGap x : ℝ) / x ≤ ε := le_trans (gap_div_le_rpow_neg x hx25) hneg
+  rwa [div_le_iff₀ hx_pos] at hfinal
+
 end Erdos1138OQ03

--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -156,13 +156,14 @@ theorem bhp_gap_isLittleO_rpow (a : ℝ) (ha : (0.525 : ℝ) < a) :
   exact absurd hrp (lt_irrefl 0)
 
 /-- **Effective (pointwise) sublinearity.** A concrete sufficient condition replacing the
-    qualitative "eventually" of `bhp_gap_eventually_le_eps`: for `ε > 0`, once `x ≥ 25` and
+    qualitative "eventually" of `bhp_gap_eventually_le_eps`: once `x ≥ 25` and
     the explicit threshold `1 ≤ ε · x^0.475` holds, we already have `maxPrimeGap x ≤ ε · x`.
 
     The threshold `1 ≤ ε · x^0.475` is exactly `x^(-0.475) ≤ ε`, i.e. the point at which the
     envelope `maxPrimeGap x / x ≤ x^(-0.475)` has dropped below `ε`; it holds for all
-    sufficiently large `x` (since `x^0.475 → ∞`), recovering `bhp_gap_eventually_le_eps`. -/
-theorem bhp_gap_le_eps_effective (ε : ℝ) (hε : 0 < ε) (x : ℕ)
+    sufficiently large `x` (since `x^0.475 → ∞`), recovering `bhp_gap_eventually_le_eps`.
+    (Positivity of `ε` is not assumed — it is forced by the threshold, as `x^0.475 > 0`.) -/
+theorem bhp_gap_le_eps_effective (ε : ℝ) (x : ℕ)
     (hx25 : 25 ≤ x) (hthr : 1 ≤ ε * (x : ℝ) ^ (0.475 : ℝ)) :
     (maxPrimeGap x : ℝ) ≤ ε * x := by
   have hx_pos : (0 : ℝ) < (x : ℝ) := by

--- a/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
+++ b/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
@@ -54,3 +54,28 @@ NEXT (build-capable session): add the two theorems to a new
 only `{propext, Classical.choice, Quot.sound}` plus the inherited `baker_harman_pintz`,
 then create the `src/data/proofs/erdos-1138-oq-03-oq-01/` gallery entry
 (status `axiomatized` — it depends on the BHP axiom).
+
+## Session 2026-07-09 (researcher-1): SOLVED — asymptotics-idiom + effective forms (VERIFIED)
+
+Entry was already SOLVED (5 thm, 0 sorry, 1 inherited `baker_harman_pintz` axiom, merged #36057).
+Looked outward and added 3 genuinely distinct theory-level theorems (5 → 8):
+
+- `bhp_gap_isLittleO_id`: `maxPrimeGap =o[atTop] (x ↦ x)` — the little-o idiom form. The
+  entry's title claim ("sublinearity") *is* the `=o` statement; the file previously only had
+  the `Tendsto (·/x) → 0` form and a `=O` at exponent 0.525. Bridged via `isLittleO_iff_tendsto'`
+  (denominator eventually nonzero).
+- `bhp_gap_isLittleO_rpow (a) (ha : 0.525 < a)`: `maxPrimeGap =o[atTop] (x ↦ x^a)` — idiom form
+  of `bhp_gap_div_rpow_littleo`, using the full BHP exponent (sublinear at every a > 0.525, not
+  just a = 1).
+- `bhp_gap_le_eps_effective (ε x) (hx25 : 25 ≤ x) (hthr : 1 ≤ ε·x^0.475)`: `maxPrimeGap x ≤ ε·x`.
+  Effective/pointwise replacement for the qualitative `bhp_gap_eventually_le_eps`: an explicit
+  sufficient threshold. Proof multiplies the envelope `x^(-0.475) ≤ ε` (equivalent to hthr via
+  `x^(-0.475)·x^0.475 = x^0 = 1`) by `x`. `ε > 0` NOT assumed — forced by the threshold.
+
+Build: VERIFIED clean (`Completed successfully!`, 0 warnings) at `LEAN_MEMORY_LIMIT=16384`
+(32768/24576 both hit fleet SIGBUS-135 at olean-write after clean elab [7744/7744] ~1s).
+No new axioms (`axiomCount` stays 1: inherited `baker_harman_pintz`), no `native_decide`.
+meta synced 5→8 thm / 131→186 lines at both `.meta.*` and `.leanFile.*`.
+
+NEXT: entry is saturated for elementary work; only remaining lever is proving/replacing the
+`baker_harman_pintz` axiom itself (deep analytic number theory — out of session scope).

--- a/research/problems/erdos101-problem-oq-04/knowledge.md
+++ b/research/problems/erdos101-problem-oq-04/knowledge.md
@@ -264,3 +264,41 @@ coeff_X]; norm_num` for `q.coeff 4`.
   (Path A). A *quartic-sumset* or curve-of-higher-degree refinement of
   this session's construction is the natural bridge toward `Ω(n^{3/2})`
   (Path B), now that the no-5 obligation is a cheap degree fact.
+
+## Iteration (researcher-1, 2026-07-09) — ACT: exact collinearity arithmetization (VERIFIED)
+
+**Outcome (VERIFIED, 0 new axioms, 0 new sorries).** Added the exact
+converse to `noFiveCollinear_of_onQuartic`: which triples/quadruples on the
+quartic `y = x⁴ − 5x²` actually ARE collinear, as pure arithmetic on abscissae.
+
+New declarations in `Proofs/Erdos101OQ04.lean` (+2 theorems):
+- `collinear_onQuartic_iff` — three points on the quartic with distinct
+  abscissae are collinear iff `a² + b² + c² + ab + bc + ca = 5`. Proof: the
+  signed-area determinant factors as `(a−b)(b−c)(c−a)·(Σx² + Σxy − 5)` (checked
+  by `ring` after substituting `onQuartic`); the Vandermonde factor is nonzero
+  for distinct abscissae, so collinearity ⟺ the symmetric-quadratic vanishes.
+- `four_onQuartic_collinear_iff` — four points (anchored triples through a,b)
+  are collinear iff the Newton/Vieta relations `Σx = 0` and `Σ_{i<j} xᵢxⱼ = −5`
+  hold. These are exactly the x³- and x²-coefficient conditions of the quartic a
+  line must meet. Proof: apply the triple criterion twice; subtracting the two
+  triple conditions exposes the Vandermonde factor `(c−d)` forcing `e₁ = 0`, and
+  two `linear_combination`s (coefficient `Σ_{first three} x` on `e₁`, minus a
+  triple condition) close `e₂ = −5` and the converse.
+
+**Value.** This is the exact arithmetic reformulation a curve-based construction
+operates on: counting four-point lines among `n` points on the quartic becomes
+counting 4-subsets of the abscissa set with `Σx = 0 ∧ Σxy = −5` — a purely
+additive-combinatorics question. It is the bridge lemma toward a super-linear
+`L₄(n)` bound, complementing the prior Ω(n) horizontal-chord floor (the symmetric
+quadruple `{±√u, ±√(5−u)}` is exactly the `e₁=0, e₂=−5` solution set the earlier
+construction used; the criterion also certifies the asymmetric solutions it misses).
+
+**Scope honesty.** Does NOT touch the open `solymosi_stojakovic_lower_bound` sorry
+(the deep `n^{2−o(1)}` random-projection construction, line 287). This is an
+elementary structural/arithmetization advance, not a resolution of the open bound.
+
+**Build notes.** VERIFIED clean at `LEAN_MEMORY_LIMIT=8192` (`Built ... (11s)`,
+`Build completed successfully (3062 jobs)`). Higher limits (32768/24576/20480/16384/
+12288) all hit fleet SIGBUS-135 at the olean-write stage AFTER clean elaboration
+`[3062/3062]` in ~2–3s (zero type-error lines on the file) — memory/write contention,
+not math. Lower memory footprint (8GB) fit in a quiet fleet window.

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -49,9 +49,9 @@
     "dateAdded": "2026-07-05",
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
-    "lineCount": 131,
+    "lineCount": 186,
     "assumptions": "1 axiom, inherited from the parent Erdos1138OQ03: baker_harman_pintz (maxPrimeGap x <= x^0.525 for x >= 25). No axiom is declared in this file (leanFile.axiomCount = 0); the assumption is imported. #print axioms confirms the results depend only on {propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}. No sorries, no native_decide.",
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -140,9 +140,9 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 131,
+    "lineCount": 186,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/Erdos1138OQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the exact arithmetic **converse** to the existing `noFiveCollinear_of_onQuartic` engine in the OQ-04 four-point-line program: which triples/quadruples on the quartic `y = x⁴ − 5x²` actually *are* collinear, expressed as pure conditions on the abscissae (62 → 64 theorems).

- **`collinear_onQuartic_iff`** — three points on the quartic with pairwise-distinct abscissae are collinear **iff** `a² + b² + c² + ab + bc + ca = 5`. The signed-area determinant factors as `(a−b)(b−c)(c−a) · (Σx² + Σxy − 5)` (verified by `ring` after substituting `onQuartic`); the Vandermonde factor is nonzero for distinct abscissae, so collinearity reduces to the symmetric quadratic vanishing.
- **`four_onQuartic_collinear_iff`** — four points (anchored via the two triples through `a, b`) are collinear **iff** the Newton/Vieta relations `Σx = 0` and `Σ_{i<j} xᵢxⱼ = −5` hold. These are exactly the `x³`- and `x²`-coefficient conditions of `x⁴ − 5x²` that a line `y = mx + e` must meet. Proof applies the triple criterion twice; subtracting the two triple conditions exposes the Vandermonde factor `(c−d)` forcing `e₁ = 0`, and two `linear_combination`s close `e₂ = −5` and the converse.

## Value

This arithmetizes four-point-line counting on the curve: counting four-point lines among `n` points on the quartic becomes counting `4`-subsets of the abscissa set satisfying `Σx = 0 ∧ Σxy = −5` — a purely additive-combinatorics question. It is the natural bridge lemma toward a **super-linear** `L₄(n)` bound, complementing the prior unconditional `Ω(n)` horizontal-chord floor (whose symmetric quadruples `{±√u, ±√(5−u)}` are precisely the `e₁=0, e₂=−5` solutions; the criterion also certifies the asymmetric solutions that family misses).

## Scope honesty

Does **not** touch the open `solymosi_stojakovic_lower_bound` sorry (the deep `n^{2−o(1)}` random-projection construction). This is an elementary structural/arithmetization advance, not a resolution of the open bound.

## Verification

- Build **VERIFIED clean**: `LEAN_MEMORY_LIMIT=8192 ./proofs/scripts/docker-build.sh Proofs.Erdos101OQ04` → `Build completed successfully (3062 jobs)`. (The one `sorry` warning at line 287 is the pre-existing open `solymosi_stojakovic_lower_bound`.) Higher memory limits hit fleet SIGBUS-135 at the olean-write stage after clean elaboration `[3062/3062]` ~2–3s — memory/write contention, not math.
- **0 new axioms, 0 new sorries.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)