### PR TITLE
Research: erdos-1098-oq-01-oq-03 — bounded cliques pass to subgroups (VERIFIED)

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -394,6 +394,37 @@ theorem abelian_bounded_cliques {H : Type*} [CommGroup H] : BoundedCliques H := 
   rw [CommGroup.center_eq_top, Subgroup.index_top]
   exact one_ne_zero
 
+/-- **Bounded cliques pass to subgroups (heredity of ω(Γ)).**  The non-commuting
+    graph `Γ(H)` of a subgroup `H ≤ G` is an *induced subgraph* of `Γ(G)`: the
+    inclusion `H ↪ G` is an injective homomorphism, so it carries every clique of
+    `Γ(H)` to a clique of `Γ(G)` of the same size.  Hence any uniform clique bound
+    for `G` is also one for `H`, i.e. `ω(Γ(H)) ≤ ω(Γ(G))`.
+
+    Combined with Neumann's theorem this is a genuine structural consequence: if
+    `[G : Z(G)]` is finite then `[H : Z(H)]` is finite for *every* subgroup `H ≤ G`
+    — finiteness of the central index is inherited downward. Axiom-free (it uses
+    only the easy transfer of cliques, not the BFC core). -/
+theorem boundedCliques_of_subgroup (H : Subgroup G) (h : BoundedCliques G) :
+    BoundedCliques H := by
+  obtain ⟨B, hB⟩ := h
+  refine ⟨B, fun S hS => ?_⟩
+  have hinj : Function.Injective (H.subtype) := H.subtype_injective
+  let e : H ↪ G := ⟨H.subtype, hinj⟩
+  have hclique : IsClique (S.map e) := by
+    intro a ha b hb hab
+    rw [Finset.mem_map] at ha hb
+    obtain ⟨a', ha', rfl⟩ := ha
+    obtain ⟨b', hb', rfl⟩ := hb
+    have hne : a' ≠ b' := fun heq => hab (by rw [heq])
+    have key := hS a' ha' b' hb' hne
+    intro hEq
+    apply key
+    apply hinj
+    rw [map_mul, map_mul]
+    exact hEq
+  rw [← Finset.card_map e]
+  exact hB _ hclique
+
 /-- **The hard direction holds unconditionally — and axiom-free — for finite groups.**
     When `G` is finite the centre automatically has finite index (`[G:Z(G)] ≤ |G| < ∞`,
     here via `Subgroup.index_ne_zero_of_finite`), so the forward implication of

--- a/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
+++ b/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
@@ -33,3 +33,18 @@ existing `abelian_bounded_cliques` (easy direction, abelian case).
 
 *Build:* exit-135 SIGBUS at [3059/3059] on first fresh build (elaborated fully, crashed
 on olean-write under fleet memory), plain retry `✔ Built (2.3s)`. Not a proof error.
+
+## Session 2026-07-09 (researcher-6) — subgroup heredity of BoundedCliques (VERIFIED)
+
+Added `boundedCliques_of_subgroup (H : Subgroup G) : BoundedCliques G → BoundedCliques H`
+(1 thm, VERIFIED 3061 jobs, 0 sorry, 0 new axioms — axiom count unchanged). Γ(H) is
+an induced subgraph of Γ(G): the inclusion H ↪ G is an injective hom (`H.subtype`,
+`Subgroup.subtype_injective`) carrying each clique of Γ(H) to a clique of Γ(G) of the
+same size (`Finset.map e`, `map_mul`, `Finset.card_map`), so ω(Γ(H)) ≤ ω(Γ(G)) and any
+uniform bound for G bounds H. Structural consequence via Neumann: [G:Z(G)] finite ⟹
+[H:Z(H)] finite for EVERY subgroup — central-index finiteness inherited downward.
+Complements `abelian_bounded_cliques` + the finite-G results; axiom-free (easy clique
+transfer, NOT the blocked BFC core `neumann_hard_direction`). PR #36461.
+
+Blocked core unchanged: eliminating `neumann_hard_direction` for infinite G needs BFC
+(`Finite (commutatorSet G)`), circular via `index_center_le_pow`, absent from Mathlib.

--- a/src/data/research/problems/erdos-1098-oq-01-oq-03.json
+++ b/src/data/research/problems/erdos-1098-oq-01-oq-03.json
@@ -1,170 +1,170 @@
 {
-  "slug": "erdos-1098-oq-01-oq-03",
-  "title": "erdos-1098-oq-01-oq-03",
-  "phase": "COMPLETE",
-  "status": "completed",
-  "tier": "B",
-  "path": "full",
-  "problemStatement": {
-    "formal": "BoundedCliques G ↔ (Subgroup.center G).index ≠ 0",
-    "plain": "Neumann's theorem: the non-commuting graph Γ(G) has finite clique number ω if and only if the centre Z(G) has finite index in G.",
-    "whyMatters": [
-      "Resolves the dichotomy underlying Erdős problem #1098",
-      "Provides the Neumann backdrop for the classification of groups by clique number"
-    ]
-  },
-  "knownResults": {
-    "proven": [
-      "Reverse direction (finite index ⟹ bounded cliques) with sharp bound ω ≤ [G:Z(G)]",
-      "Coset separation: non-commuting elements lie in distinct Z(G)-cosets",
-      "Injectivity of the quotient map G → G/Z(G) on any clique"
-    ],
-    "open": [
-      "Formalize Neumann's covering argument to discharge the neumann_hard_direction axiom"
-    ],
-    "goal": "Prove ω(Γ(G)) finite ⟺ [G:Z(G)] finite via Mathlib Subgroup.index."
-  },
-  "currentState": {
-    "phase": "COMPLETE",
-    "since": "2026-06-25T08:00:00-07:00",
-    "iteration": 1,
-    "focus": "Formalized Neumann's full theorem as an iff: reverse direction fully proved, forward direction (Neumann 1976) axiomatized.",
-    "blockers": [],
-    "nextAction": "None — proof complete and submitted as a gallery entry.",
-    "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
-      "approachesTried": 1
-    }
-  },
-  "knowledge": {
-    "progressSummary": "PROGRESS: Added center_finiteIndex_iff_relIndex_core — localizes Neumann axiom to Z(G) finite index within an explicit finite-index core H=⋂ₐC_G(a); identified Mathlib Subgroup.index_center_le_pow as the Schur-side endgame (gated on Finite commutatorSet = BFC content). Axiom unchanged (1); build green; 2 new verified theorems.",
-    "builtItems": [
-      "commuting_of_invMul_mem_center",
-      "nonCommuting_distinct_image",
-      "clique_inj_on_quotient",
-      "clique_card_le_index",
-      "bounded_cliques_of_finite_index",
-      "neumann_full_theorem",
-      "center_le_centralizer_singleton",
-      "center_finiteIndex_iff_relIndex_core"
-    ],
-    "insights": [
-      "Mathlib's index = 0 convention makes 'finite index' the clean hypothesis index ≠ 0",
-      "QuotientGroup.eq reduces coset equality to membership a⁻¹*b ∈ Z(G), giving a one-line non-commuting separation",
-      "Nat.card_pos_iff turns finite index into a Finite quotient instance, the only ingredient needed for the cardinality bound",
-      "Neumann axiom localizes: [G:Z(G)] finite ⟺ Z(G) finite index within the finite-index core H = ⋂ₐ C_G(a) (Z(G) ≤ H since central elts commute with all a; index tower relIndex_mul_index). Residual gap = bound (center G).relIndex H.",
-      "Mathlib Schur endgame is Subgroup.index_center_le_pow / finiteIndex_center (Commutator/Finite.lean): Finite (commutatorSet G) [+ Group.FG] ⟹ (center G) finite index. Hypothesis Finite (commutatorSet G) from bounded cliques is itself the BFC content (equally hard), so it does not eliminate the axiom."
-    ],
-    "mathlibGaps": [
-      "No formalization of B. H. Neumann's BFC theorem (bounded non-commuting sets ⟹ finite centre index)"
-    ],
-    "nextSteps": [
-      "Attempt bounded cliques ⟹ Finite (commutatorSet G) (BFC), then chain Mathlib Subgroup.index_center_le_pow to remove neumann_hard_direction — this is the deep Neumann 1976 content",
-      "Alternatively bound (center G).relIndex H directly within the finite-index core H that centralizes a maximal clique"
-    ],
-    "markdown": "# Knowledge Base: erdos-1098-oq-01-oq-03\n\n## Problem Understanding\n\nNeumann's theorem (Erdős #1098): ω(Γ(G)) finite ⟺ [G:Z(G)] finite.\n\n## Insights\n\n- Reverse direction is elementary and sharp: ω ≤ [G:Z(G)] via injectivity of G → G/Z(G) on cliques.\n- Forward direction is Neumann (1976), a BFC/covering argument, axiomatized.\n\n## Dead Ends\n\n- Direct formalization of Neumann's covering argument is out of reach in one session.\n"
-  },
-  "tags": [
-    "group-theory",
-    "non-commuting-graph",
-    "neumann",
-    "lean-mathlib"
-  ],
-  "relatedProofs": [
-    "erdos-1",
-    "erdos-10",
-    "erdos-109",
-    "erdos-1098",
-    "erdos-1098-oq-01",
-    "erdos-1098-oq-01-oq-01",
-    "erdos-1098-oq-01-oq-03",
-    "erdos-1098-oq-03",
-    "erdos-1098-oq-04"
-  ],
-  "references": {
-    "papers": [
-      "B. H. Neumann, A problem of Paul Erdős on groups, J. Austral. Math. Soc. 21 (1976), 467–472",
-      "Abdollahi, Akbari, Maimani, Non-commuting graph of a group, J. Algebra 298 (2006)"
-    ],
-    "urls": [
-      "https://erdosproblems.com/1098"
-    ],
-    "mathlib": [
-      "Subgroup.index_eq_card",
-      "QuotientGroup.eq",
-      "Finset.card_le_card_of_injOn",
-      "Nat.card_pos_iff"
-    ]
-  },
-  "started": "2026-06-25T08:00:00.000Z",
-  "lastUpdate": "2026-06-25T08:00:00.000Z",
-  "leanFiles": [
-    {
-      "path": "Proofs/Erdos1098OQ01.lean",
-      "filename": "Erdos1098OQ01.lean",
-      "lineCount": 123,
-      "theoremCount": 8,
-      "axiomCount": 0,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ01.lean"
-    },
-    {
-      "path": "Proofs/Erdos1098OQ01OQ01.lean",
-      "filename": "Erdos1098OQ01OQ01.lean",
-      "lineCount": 206,
-      "theoremCount": 8,
-      "axiomCount": 2,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ01OQ01.lean"
-    },
-    {
-      "path": "Proofs/Erdos1098OQ01OQ03.lean",
-      "filename": "Erdos1098OQ01OQ03.lean",
-      "lineCount": 392,
-      "theoremCount": 12,
-      "axiomCount": 2,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ01OQ03.lean"
-    },
-    {
-      "path": "Proofs/Erdos1098OQ03.lean",
-      "filename": "Erdos1098OQ03.lean",
-      "lineCount": 160,
-      "theoremCount": 15,
-      "axiomCount": 0,
-      "defCount": 4,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ03.lean"
-    },
-    {
-      "path": "Proofs/Erdos1098OQ04.lean",
-      "filename": "Erdos1098OQ04.lean",
-      "lineCount": 134,
-      "theoremCount": 7,
-      "axiomCount": 0,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ04.lean"
-    },
-    {
-      "path": "Proofs/Erdos1098Problem.lean",
-      "filename": "Erdos1098Problem.lean",
-      "lineCount": 349,
-      "theoremCount": 14,
-      "axiomCount": 1,
-      "defCount": 11,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098Problem.lean"
-    }
+ "slug": "erdos-1098-oq-01-oq-03",
+ "title": "erdos-1098-oq-01-oq-03",
+ "phase": "COMPLETE",
+ "status": "completed",
+ "tier": "B",
+ "path": "full",
+ "problemStatement": {
+  "formal": "BoundedCliques G ↔ (Subgroup.center G).index ≠ 0",
+  "plain": "Neumann's theorem: the non-commuting graph Γ(G) has finite clique number ω if and only if the centre Z(G) has finite index in G.",
+  "whyMatters": [
+   "Resolves the dichotomy underlying Erdős problem #1098",
+   "Provides the Neumann backdrop for the classification of groups by clique number"
   ]
+ },
+ "knownResults": {
+  "proven": [
+   "Reverse direction (finite index ⟹ bounded cliques) with sharp bound ω ≤ [G:Z(G)]",
+   "Coset separation: non-commuting elements lie in distinct Z(G)-cosets",
+   "Injectivity of the quotient map G → G/Z(G) on any clique"
+  ],
+  "open": [
+   "Formalize Neumann's covering argument to discharge the neumann_hard_direction axiom"
+  ],
+  "goal": "Prove ω(Γ(G)) finite ⟺ [G:Z(G)] finite via Mathlib Subgroup.index."
+ },
+ "currentState": {
+  "phase": "COMPLETE",
+  "since": "2026-06-25T08:00:00-07:00",
+  "iteration": 1,
+  "focus": "Formalized Neumann's full theorem as an iff: reverse direction fully proved, forward direction (Neumann 1976) axiomatized.",
+  "blockers": [],
+  "nextAction": "None — proof complete and submitted as a gallery entry.",
+  "attemptCounts": {
+   "total": 1,
+   "currentApproach": 1,
+   "approachesTried": 1
+  }
+ },
+ "knowledge": {
+  "progressSummary": "PROGRESS: Added center_finiteIndex_iff_relIndex_core — localizes Neumann axiom to Z(G) finite index within an explicit finite-index core H=⋂ₐC_G(a); identified Mathlib Subgroup.index_center_le_pow as the Schur-side endgame (gated on Finite commutatorSet = BFC content). Axiom unchanged (1); build green; 2 new verified theorems.",
+  "builtItems": [
+   "commuting_of_invMul_mem_center",
+   "nonCommuting_distinct_image",
+   "clique_inj_on_quotient",
+   "clique_card_le_index",
+   "bounded_cliques_of_finite_index",
+   "neumann_full_theorem",
+   "center_le_centralizer_singleton",
+   "center_finiteIndex_iff_relIndex_core"
+  ],
+  "insights": [
+   "Mathlib's index = 0 convention makes 'finite index' the clean hypothesis index ≠ 0",
+   "QuotientGroup.eq reduces coset equality to membership a⁻¹*b ∈ Z(G), giving a one-line non-commuting separation",
+   "Nat.card_pos_iff turns finite index into a Finite quotient instance, the only ingredient needed for the cardinality bound",
+   "Neumann axiom localizes: [G:Z(G)] finite ⟺ Z(G) finite index within the finite-index core H = ⋂ₐ C_G(a) (Z(G) ≤ H since central elts commute with all a; index tower relIndex_mul_index). Residual gap = bound (center G).relIndex H.",
+   "Mathlib Schur endgame is Subgroup.index_center_le_pow / finiteIndex_center (Commutator/Finite.lean): Finite (commutatorSet G) [+ Group.FG] ⟹ (center G) finite index. Hypothesis Finite (commutatorSet G) from bounded cliques is itself the BFC content (equally hard), so it does not eliminate the axiom."
+  ],
+  "mathlibGaps": [
+   "No formalization of B. H. Neumann's BFC theorem (bounded non-commuting sets ⟹ finite centre index)"
+  ],
+  "nextSteps": [
+   "Attempt bounded cliques ⟹ Finite (commutatorSet G) (BFC), then chain Mathlib Subgroup.index_center_le_pow to remove neumann_hard_direction — this is the deep Neumann 1976 content",
+   "Alternatively bound (center G).relIndex H directly within the finite-index core H that centralizes a maximal clique"
+  ],
+  "markdown": "# Knowledge Base: erdos-1098-oq-01-oq-03\n\n## Problem Understanding\n\nNeumann's theorem (Erdős #1098): ω(Γ(G)) finite ⟺ [G:Z(G)] finite.\n\n## Insights\n\n- Reverse direction is elementary and sharp: ω ≤ [G:Z(G)] via injectivity of G → G/Z(G) on cliques.\n- Forward direction is Neumann (1976), a BFC/covering argument, axiomatized.\n\n## Dead Ends\n\n- Direct formalization of Neumann's covering argument is out of reach in one session.\n"
+ },
+ "tags": [
+  "group-theory",
+  "non-commuting-graph",
+  "neumann",
+  "lean-mathlib"
+ ],
+ "relatedProofs": [
+  "erdos-1",
+  "erdos-10",
+  "erdos-109",
+  "erdos-1098",
+  "erdos-1098-oq-01",
+  "erdos-1098-oq-01-oq-01",
+  "erdos-1098-oq-01-oq-03",
+  "erdos-1098-oq-03",
+  "erdos-1098-oq-04"
+ ],
+ "references": {
+  "papers": [
+   "B. H. Neumann, A problem of Paul Erdős on groups, J. Austral. Math. Soc. 21 (1976), 467–472",
+   "Abdollahi, Akbari, Maimani, Non-commuting graph of a group, J. Algebra 298 (2006)"
+  ],
+  "urls": [
+   "https://erdosproblems.com/1098"
+  ],
+  "mathlib": [
+   "Subgroup.index_eq_card",
+   "QuotientGroup.eq",
+   "Finset.card_le_card_of_injOn",
+   "Nat.card_pos_iff"
+  ]
+ },
+ "started": "2026-06-25T08:00:00.000Z",
+ "lastUpdate": "2026-06-25T08:00:00.000Z",
+ "leanFiles": [
+  {
+   "path": "Proofs/Erdos1098OQ01.lean",
+   "filename": "Erdos1098OQ01.lean",
+   "lineCount": 123,
+   "theoremCount": 8,
+   "axiomCount": 0,
+   "defCount": 3,
+   "sorryCount": 0,
+   "isAristotle": false,
+   "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ01.lean"
+  },
+  {
+   "path": "Proofs/Erdos1098OQ01OQ01.lean",
+   "filename": "Erdos1098OQ01OQ01.lean",
+   "lineCount": 206,
+   "theoremCount": 8,
+   "axiomCount": 2,
+   "defCount": 3,
+   "sorryCount": 0,
+   "isAristotle": false,
+   "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ01OQ01.lean"
+  },
+  {
+   "path": "Proofs/Erdos1098OQ01OQ03.lean",
+   "filename": "Erdos1098OQ01OQ03.lean",
+   "lineCount": 471,
+   "theoremCount": 15,
+   "axiomCount": 2,
+   "defCount": 3,
+   "sorryCount": 0,
+   "isAristotle": false,
+   "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ01OQ03.lean"
+  },
+  {
+   "path": "Proofs/Erdos1098OQ03.lean",
+   "filename": "Erdos1098OQ03.lean",
+   "lineCount": 160,
+   "theoremCount": 15,
+   "axiomCount": 0,
+   "defCount": 4,
+   "sorryCount": 0,
+   "isAristotle": false,
+   "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ03.lean"
+  },
+  {
+   "path": "Proofs/Erdos1098OQ04.lean",
+   "filename": "Erdos1098OQ04.lean",
+   "lineCount": 134,
+   "theoremCount": 7,
+   "axiomCount": 0,
+   "defCount": 3,
+   "sorryCount": 0,
+   "isAristotle": false,
+   "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ04.lean"
+  },
+  {
+   "path": "Proofs/Erdos1098Problem.lean",
+   "filename": "Erdos1098Problem.lean",
+   "lineCount": 349,
+   "theoremCount": 14,
+   "axiomCount": 1,
+   "defCount": 11,
+   "sorryCount": 0,
+   "isAristotle": false,
+   "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098Problem.lean"
+  }
+ ]
 }


### PR DESCRIPTION
## Erdős #1098 OQ-01/OQ-03 (Neumann: ω(Γ(G)) finite ⟺ [G:Z(G)] finite)

**Slug:** erdos-1098-oq-01-oq-03 · **Researcher:** researcher-6 · **VERIFIED** (docker 3061 jobs, 0 sorry, 0 new axioms).

### What's new
`boundedCliques_of_subgroup (H : Subgroup G) : BoundedCliques G → BoundedCliques H`.

The non-commuting graph `Γ(H)` of a subgroup `H ≤ G` is an **induced subgraph** of `Γ(G)`: the inclusion `H ↪ G` is an injective homomorphism, so it carries every clique of `Γ(H)` to a clique of `Γ(G)` of the same size. Hence any uniform clique bound for `G` bounds the cliques of `H` too — i.e. `ω(Γ(H)) ≤ ω(Γ(G))`.

Combined with Neumann's theorem this is a genuine structural consequence: **if `[G : Z(G)]` is finite then `[H : Z(H)]` is finite for every subgroup `H ≤ G`** — finiteness of the central index is inherited downward. It complements the existing `abelian_bounded_cliques` (easy direction, abelian case) and the finite-group results, and is entirely **axiom-free** — it uses only the easy transfer of cliques, not the blocked BFC/coset-covering core `neumann_hard_direction`.

### Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos1098OQ01OQ03` → **Build completed successfully (3061 jobs)**. 0 sorry; axiom count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)