### PR TITLE
research(brouwer-fixed-point-oq-02-oq-02-oq-01): fixed-point uniqueness + sharpness of geometric decay [2 thm, 0 axiom/sorry]

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
@@ -202,4 +202,45 @@ theorem contraction_comp_list (fL : List ((ℝ → ℝ) × ℝ)) (hne : fL ≠ [
   exact ⟨list_prod_lt_one _ hne' hpos' hlt',
     fun x y => lipschitz_comp_list fL x y hpos hlip⟩
 
+/-! ### Well-definedness of `x*` and optimality of the geometric bound
+
+Every estimate above is stated for a *given* fixed point `x*`, but for `L < 1` a
+contraction has **at most one** fixed point, so the object `x*` the estimates refer
+to is unambiguous.  Conversely the geometric decay `iterate_dist` is **best
+possible**: the linear map `t ↦ L·t` is an `L`-contraction (with equality in the
+Lipschitz bound) whose iteration `xₙ = Lⁿ·x₀` from any `x₀` satisfies
+`|xₙ − x*| = Lⁿ·|x₀ − x*|` exactly. -/
+
+/-- **Uniqueness of the fixed point.**  A contraction with constant `L < 1` has at
+    most one fixed point: if `f p = p` and `f q = q` then `|p − q| = |f p − f q| ≤
+    L·|p − q|`, so `(1 − L)·|p − q| ≤ 0` with `1 − L > 0`, forcing `p = q`.  This is
+    what makes the `x*` in every estimate above well-defined. -/
+theorem fixed_point_unique (f : ℝ → ℝ) (L : ℝ) (hL1 : L < 1)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (p q : ℝ) (hp : f p = p) (hq : f q = q) : p = q := by
+  have h := hf p q
+  rw [hp, hq] at h
+  have hnn : 0 ≤ |p - q| := abs_nonneg _
+  have hq0 : |p - q| = 0 := by
+    by_contra hne
+    have hpos : 0 < |p - q| := lt_of_le_of_ne hnn (Ne.symm hne)
+    nlinarith [h, hpos, hL1]
+  exact sub_eq_zero.mp (abs_eq_zero.mp hq0)
+
+/-- **Sharpness of the geometric decay `iterate_dist`.**  The bound
+    `|xₙ − x*| ≤ Lⁿ·|x₀ − x*|` is attained, so it cannot be improved.  Witness: the
+    linear map `t ↦ L·t` (`L ≥ 0`) is an `L`-contraction *with equality*, has fixed
+    point `0`, and its iteration from `x₀` is `xₙ = Lⁿ·x₀`; for it the error decays
+    at *exactly* the geometric rate.  The four conjuncts record, in order: the exact
+    Lipschitz identity, the fixed-point equation, the iteration recurrence, and the
+    equality form of the decay bound. -/
+theorem iterate_dist_sharp (L : ℝ) (hL0 : 0 ≤ L) (x0 : ℝ) :
+    (∀ a b : ℝ, |L * a - L * b| = L * |a - b|) ∧
+    L * 0 = 0 ∧
+    (∀ k : ℕ, L ^ (k + 1) * x0 = L * (L ^ k * x0)) ∧
+    (∀ n : ℕ, |L ^ n * x0 - 0| = L ^ n * |x0 - 0|) := by
+  refine ⟨fun a b => ?_, by ring, fun k => by rw [pow_succ]; ring, fun n => ?_⟩
+  · rw [← mul_sub, abs_mul, abs_of_nonneg hL0]
+  · rw [sub_zero, sub_zero, abs_mul, abs_of_nonneg (pow_nonneg hL0 n)]
+
 end BrouwerOQ02OQ02OQ01


### PR DESCRIPTION
## Summary

`BrouwerFixedPointOQ02OQ02OQ01` develops the a priori / a posteriori error estimates for contraction iteration (`apriori_estimate`, `aposteriori_estimate`, `iterate_dist`, composition laws). Every estimate is stated for a **given** fixed point `x*` and provides only **upper** bounds. This PR closes the two matching structural gaps:

- **`fixed_point_unique`** — a contraction with constant `L < 1` has at most one fixed point: `|p − q| = |f p − f q| ≤ L·|p − q|` gives `(1 − L)·|p − q| ≤ 0` with `1 − L > 0`, forcing `p = q`. This is what makes the `x*` every estimate refers to *well-defined* (previously assumed, never justified).

- **`iterate_dist_sharp`** — the geometric decay `|xₙ − x*| ≤ Lⁿ·|x₀ − x*|` (`iterate_dist`) is **attained**, hence optimal. Witness: the linear map `t ↦ L·t` (`L ≥ 0`) is an `L`-contraction *with equality* in the Lipschitz bound, has fixed point `0`, and its iteration from any `x₀` is `xₙ = Lⁿ·x₀`, for which `|xₙ − 0| = Lⁿ·|x₀ − 0|` exactly. The theorem packages all four facts (exact Lipschitz identity, fixed-point equation, iteration recurrence, equality form of the decay).

Together: the fixed point is unique (so the estimates are unambiguous) and the geometric rate cannot be improved (so the estimates are best-possible).

## Contribution
- **2 new theorems**, 0 sorries, 0 axioms (research-layer file, not gallery-tracked).

## Build status
Full elaboration completes cleanly — `[7743/7743]`, **zero type errors / warnings / sorries** — then exits with code **135 (SIGBUS) during olean serialization**, the known fleet memory issue at the write stage (not the mathematics). Both proofs are elementary (`nlinarith` for the uniqueness squeeze; `abs_mul` / `abs_of_nonneg` / `pow_succ` for the sharpness identities) and self-contained in the file's abstract contraction setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)