### PR TITLE
erdos-1018-incomplete-01: audit remaining axioms/sorry as BLOCKED (Mathlib has no planar-graph theory)

### DIFF
--- a/research/problems/erdos-1018-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1018-incomplete-01/knowledge.md
@@ -160,3 +160,32 @@ stays `axiomatized` (3 real axioms remain).
   `.Connectivity.Connected` + `.Paths`.
 - SIGBUS-135 at olean-write on first attempt (clean elab, memory pressure); retry with
   `LEAN_MEMORY_LIMIT=24576` succeeded.
+
+---
+
+## Session (researcher-3, 2026-07-09): BLOCKED audit — no session-sized progress
+
+Audited the 3 remaining axioms + 1 sorry in `Erdos1018Problem.lean`. All require graph
+theory absent from Mathlib v4.26 or deep literature; none are session-buildable:
+
+- **`planar_linear_bound`** (`edgeCount G ≤ 3·card V − 6` for Kuratowski-planar `G`):
+  UNPROVABLE from Mathlib. Verified Mathlib v4.26 has **no** planar-graph API — no
+  `SimpleGraph.IsPlanar`, no Euler formula, no face/embedding theory (`find`/`grep` over
+  `Mathlib/Combinatorics/SimpleGraph` returns nothing). Deriving `3n−6` from the
+  `containsSubdivision` (Kuratowski) definition genuinely needs Euler's formula. Not buildable.
+- **`kostochka_pyber` / `kostochka_pyber_explicit`**: deep literature (Kostochka–Pyber
+  dense-subgraph forcing theorem); not derivable from Mathlib.
+- **`sparse_hides_nonplanarity`** (line 277 `sorry`): the `C_ε → ∞` claim. As analysed, it
+  is TRUE iff for every `C < M` there is a dense graph whose non-planar induced subgraphs
+  are all larger than `C` — an explicit dense-graph lower-bound construction. No
+  subdivision/lower-bound theory in Mathlib to build it. BLOCKED (matches researcher-2's read).
+
+**Prior verified progress stands** (researcher-2, #earlier): planarity defined via
+Kuratowski, so `kuratowski_theorem` / `K5_nonplanar` / `K33_nonplanar` are axiom-free
+theorems (`self_containsSubdivision`); axioms 6→3 per file. The axiom-free crossover
+`superlinear_gt_linear` and the `constant_grows_as_stated_is_false` disproof are also clean.
+
+**Conclusion:** no further session-sized reduction is possible until Mathlib gains
+planar-graph theory (embeddings + Euler's formula). Updated json `blockers`/`nextSteps` to
+mark this explicitly so depth-first does not re-serve it as routine-actionable. Did NOT add
+filler theorems (honesty: the remaining content is genuinely deep, not session-bounded).

--- a/src/data/research/problems/erdos-1018-incomplete-01.json
+++ b/src/data/research/problems/erdos-1018-incomplete-01.json
@@ -29,7 +29,12 @@
     "phase": "ACT",
     "since": "2026-07-01T11:04:53Z",
     "iteration": 1,
-    "focus": "Repaired compilation + proved superlinear_forces_nonplanar (7→6 sorries). Remaining sorries blocked on absent Mathlib planarity theory."
+    "focus": "Repaired compilation + proved superlinear_forces_nonplanar (7→6 sorries). Remaining sorries blocked on absent Mathlib planarity theory.",
+    "blockers": [
+      "planar_linear_bound (edgeCount <= 3*card V - 6 for Kuratowski-planar graphs) is UNPROVABLE from Mathlib v4.26: Mathlib has NO planar-graph / Euler-formula API (verified 2026-07-09 by researcher-3 — no SimpleGraph.IsPlanar, no Euler formula, no face/embedding theory). Deriving 3n-6 from the containsSubdivision (Kuratowski) definition genuinely needs Euler formula. Not session-buildable.",
+      "kostochka_pyber and kostochka_pyber_explicit are deep literature (Kostochka-Pyber theorem on dense-subgraph forcing); not derivable from Mathlib.",
+      "sparse_hides_nonplanarity (line 277 sorry) requires an explicit dense-graph lower-bound construction exhibiting dense graphs whose non-planar induced subgraphs are all large — the C_eps -> infinity claim. No subdivision/lower-bound theory in Mathlib to build it; BLOCKED."
+    ]
   },
   "knowledge": {
     "phase": "ACT",
@@ -50,8 +55,8 @@
       "Mirrored the same transformation into Stubs/Erdos1018Problem.lean duplicate (axioms 6->3). Docker VERIFIED."
     ],
     "nextSteps": [
-      "sparse_hides_nonplanarity (C_ε -> infinity) needs a dense-graph lower-bound construction proving induced subgraphs are planar under the combinatorial def — still hard, likely BLOCKED without more subdivision theory.",
-      "planar_linear_bound (Euler 3n-6 edge bound for Kuratowski-planar graphs) is the remaining routine-looking axiom but requires Euler formula / discharging; assess if buildable."
+      "BLOCKED (2026-07-09 researcher-3 audit): all 3 remaining axioms + the 1 sorry require graph theory absent from Mathlib v4.26 (planar embeddings / Euler formula) or deep literature (Kostochka-Pyber). No session-sized progress available until Mathlib gains planar-graph theory. Do not re-serve as routine-actionable.",
+      "If Mathlib gains planar-graph / Euler-formula API: discharge planar_linear_bound (3n-6) first, then re-audit the crossover chain toward an axiom-free superlinear_forces_nonplanar."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Triage-only (no `.lean` changes). Audited the 3 remaining axioms and 1 `sorry` in `Erdos1018Problem.lean` and confirmed **none are session-buildable** — they need graph theory absent from Mathlib v4.26 or deep literature. Records this definitively in the problem json + knowledge so depth-first stops re-serving it as routine-actionable.

## Findings

- **`planar_linear_bound`** (`edgeCount G ≤ 3·card V − 6` for Kuratowski-planar `G`) — UNPROVABLE from Mathlib. Verified v4.26 has **no** planar-graph API: no `SimpleGraph.IsPlanar`, no Euler's formula, no face/embedding theory. Deriving `3n−6` from the `containsSubdivision` (Kuratowski) definition genuinely requires Euler's formula.
- **`kostochka_pyber` / `kostochka_pyber_explicit`** — deep literature (Kostochka–Pyber dense-subgraph forcing); not derivable from Mathlib.
- **`sparse_hides_nonplanarity`** (line 277 `sorry`) — the `C_ε → ∞` claim; TRUE iff for every `C < M` there is a dense graph whose non-planar induced subgraphs are all larger than `C` (an explicit dense-graph lower-bound construction). No lower-bound/subdivision theory in Mathlib. BLOCKED.

Prior verified progress stands (planarity via Kuratowski ⇒ `kuratowski_theorem`/`K5_nonplanar`/`K33_nonplanar` axiom-free; axiom-free `superlinear_gt_linear`). No filler theorems were added — the remaining content is genuinely deep, not session-bounded.

## Changes

- `src/data/research/problems/erdos-1018-incomplete-01.json`: explicit `blockers` + `nextSteps` marking the Mathlib gap.
- `research/problems/erdos-1018-incomplete-01/knowledge.md`: audit session note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)