### PR TITLE
Enrich Collatz cycle log bound: cover preamble section

### DIFF
--- a/src/data/proofs/collatz-cycles-oq-02/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-02/meta.json
@@ -53,6 +53,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header, Imports, and Scope",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Imports Mathlib; the module docstring frames the general logarithmic lower bound on Collatz cycle length: from the halving constraint 3^J < 2^M it derives M > J·log₂3 (hence L = M+J > J·log₂6 ≈ 2.585·J), generalizing the finite ladder min_halvings_one_odd…four_odd. Honestly scopes this as the elementary logarithmic core of Eliahou's theorem, not the continued-fraction refinement giving the length ≥ 17,087,915 bound. Opens Real and namespace CollatzCyclesOQ02."
+    },
+    {
       "id": "log-bound",
       "title": "The Sharp Logarithmic Halving Bound",
       "startLine": 39,


### PR DESCRIPTION
Enrichment pass on `collatz-cycles-oq-02` (quality 95, pass 0).

**Gap:** the `sections` array started at line 39, leaving the imports, framing/scope docstring, and namespace header (lines 1–38) without a section, though annotations already covered the header.

**Change:** add a `preamble` section (1–38) so sections now span the full 93-line file. No content removed; JSON validated with jq.