### PR TITLE
Enrich Diagonal Beta value (beta-integral-recurrence-oq-01-oq-01): sync openQuestions

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-01/meta.json
@@ -140,6 +140,11 @@
       "id": "beta-integral-recurrence-oq-01-oq-01-oq-01",
       "question": "Prove the Wallis-product / asymptotic consequence: B(n+1,n+1) = 1/((2n+1)·C(2n,n)) ~ √(πn)/(2n+1)·4^(−n), exhibiting the exponential decay of the symmetric Beta normalization and its link to the central limit scaling of the Beta(n+1,n+1) density toward a Gaussian.",
       "significance": "medium"
+    },
+    {
+      "id": "beta-integral-recurrence-oq-01-oq-01-oq-02",
+      "question": "Generalize from the diagonal to the off-diagonal Beta value B(m+1,n+1) = m!·n!/(m+n+1)! and recover B(n+1,n+1) = 1/((2n+1)·C(2n,n)) as its symmetric special case; then read off the ordinary generating function Σ_n B(n+1,n+1) xⁿ in closed form.",
+      "significance": "medium"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-01` (the diagonal Euler Beta value B(n+1,n+1) = 1/((2n+1)·C(2n,n))).

The entry was already comprehensive (18 KB, 4 annotations covering lines 4–98, 5 keyInsights, sections spanning the full 98-line file contiguously, 2 cross-refs — both present). Per anti-bloat guardrails I did not deepen it. The one genuine defect:

- **openQuestions consistency**: the top-level `openQuestions` array (object format) listed only oq-01 (the Wallis-product/asymptotic decay question), while `conclusion.openQuestions` carried a second substantive question — generalizing from the diagonal to the off-diagonal Beta value B(m+1,n+1) = m!·n!/(m+n+1)! and reading off its OGF. Added it as oq-02 so the top-level array matches the conclusion.

Verified against source: counts accurate (5 theorems, 0 definitions, 98 lines), both cross-reference targets present, axiom integrity intact (`verified`, `axiomCount: 0`, 0 sorries). Size 18 KB (under cap). Gallery-data validation and search-index checks pass under `pnpm build`; only the final `tsc` step fails (no `node_modules` in the isolated worktree).