### PR TITLE
Enrich Linnik critical-exponent structure: cover preamble section

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01/meta.json
@@ -108,11 +108,18 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "The docstring frames the derived open question: isolate the axiom-free, sorry-free structural skeleton that makes the Linnik constant a well-defined critical exponent — upward-closure (ray), lower-boundedness by 0, the Ioi ⊆ admissible ⊆ Ici sandwich, and monotonicity under domination — all for an abstract growth function f over a base b ≥ 1, of which the Linnik setting (f = leastPrimeInAP, b = q) is one instance. Imports Mathlib; opens Real Set; namespace LinnikAdmissible with variable {I : Type*}."
+    },
+    {
       "id": "admissible-set",
       "title": "The Admissible-Exponent Set",
-      "startLine": 44,
+      "startLine": 38,
       "endLine": 60,
-      "summary": "Definition of `admissible f b`, boundedness below by 0, and upward closure via rpow-monotonicity."
+      "summary": "Definition of `admissible f b` (those L > 0 with f i ≤ c·(b i)^L uniformly), boundedness below by 0, and upward closure via rpow-monotonicity."
     },
     {
       "id": "critical-exponent",


### PR DESCRIPTION
Enrichment pass on `dirichlets-theorem-oq-03-oq-01` (quality 95, pass 0).

**Gap:** the `sections` array started at line 44, leaving the module docstring, imports, and namespace (lines 1–37) without a section; moreover the first section claimed to describe the `admissible` definition but its range (44–60) excluded that definition (lines 38–42).

**Change:** add a `preamble` section (1–37) and extend the admissible-set section to start at 38 so it actually covers the definition. Sections now span the full 144-line file. No content removed; JSON validated with jq.