### PR TITLE
Research(erdos-1-oq-02-oq-01): superincreasing sets have distinct subset sums

### DIFF
--- a/proofs/Proofs/Erdos1OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos1OQ02OQ01.lean
@@ -206,4 +206,124 @@ theorem exists_extremal_geomSet (n : ℕ) (hn : 1 ≤ n) :
   exact ⟨geomSet n, card_geomSet n, geomSet_hasDistinctSubsetSums n,
     hne, max'_geomSet hn hne⟩
 
+/-!
+## Section 5: superincreasing sets — the structural principle behind the construction
+
+Section 4 shows the *specific* set `{2⁰, …, 2^{n-1}}` has distinct subset sums, via
+uniqueness of binary expansions (`geomSum_injective`). But that distinctness is an
+instance of a single structural principle: a set is **superincreasing** when every
+element exceeds the sum of all strictly smaller elements, and *every* superincreasing
+set has distinct subset sums (this is the mechanism underlying knapsack/Merkle–Hellman
+constructions). The powers of two are simply the slowest-growing superincreasing set
+(each `2ⁱ = (2⁰ + ⋯ + 2^{i-1}) + 1`, meeting the superincreasing inequality with the
+least possible slack), which is exactly why they minimise the maximum and sit on the
+upper wall `M(n) ≤ 2^{n-1}` of Section 4.
+
+The distinctness proof here is fully self-contained (no `geomSum_injective`): strong
+induction peeling the largest element `m`. If two subsets `S, T` have equal sums then
+either both or neither contain `m` (recurse on `A \ {m}`), or exactly one does — say
+`m ∈ S`, `m ∉ T` — but then `Σ T ≤ Σ(A ∩ [0,m)) < m ≤ Σ S`, a contradiction.
+-/
+
+/-- `A` is **superincreasing**: every element exceeds the sum of all strictly smaller
+    elements of `A`. Equivalently, sorting `A = {a₁ < ⋯ < aₙ}`, one has
+    `aₖ > a₁ + ⋯ + a_{k-1}` for every `k`. -/
+def Superincreasing (A : Finset ℕ) : Prop :=
+  ∀ a ∈ A, (A.filter (· < a)).sum id < a
+
+/-- Superincreasing is hereditary: erasing an element keeps the property. -/
+theorem Superincreasing.erase {A : Finset ℕ} (h : Superincreasing A) (m : ℕ) :
+    Superincreasing (A.erase m) := by
+  intro a ha
+  have haA : a ∈ A := mem_of_mem_erase ha
+  have hsub : (A.erase m).filter (· < a) ⊆ A.filter (· < a) :=
+    filter_subset_filter _ (erase_subset _ _)
+  exact lt_of_le_of_lt (sum_le_sum_of_subset hsub) (h a haA)
+
+/-- **Superincreasing ⟹ distinct subset sums.** The key structural principle: because
+    each element dominates the sum of everything below it, a subset is determined by
+    its sum. Proof by strong induction, peeling the largest element. -/
+theorem Superincreasing.hasDistinctSubsetSums {A : Finset ℕ}
+    (h : Superincreasing A) : HasDistinctSubsetSums A := by
+  revert h
+  induction A using Finset.strongInduction with
+  | _ A ih =>
+    intro h S T hS hT hST
+    rcases A.eq_empty_or_nonempty with hA | hA
+    · subst hA
+      rw [subset_empty] at hS hT
+      rw [hS, hT]
+    · set m := A.max' hA with hm
+      have hmA : m ∈ A := A.max'_mem hA
+      -- any subset of `A` avoiding the maximum has sum strictly below `m`
+      have hlt : ∀ U : Finset ℕ, U ⊆ A → m ∉ U → U.sum id < m := by
+        intro U hU hmU
+        have hUsub : U ⊆ A.filter (· < m) := by
+          intro x hx
+          rw [mem_filter]
+          have hxle : x ≤ m := A.le_max' x (hU hx)
+          have hxne : x ≠ m := fun hxm => hmU (hxm ▸ hx)
+          exact ⟨hU hx, by omega⟩
+        exact lt_of_le_of_lt (sum_le_sum_of_subset hUsub) (h m hmA)
+      by_cases hmS : m ∈ S
+      · by_cases hmT : m ∈ T
+        · -- both contain `m`: recurse on the erased subsets
+          have hSe : S.erase m ⊆ A.erase m := by
+            intro x hx; rw [mem_erase] at hx ⊢; exact ⟨hx.1, hS hx.2⟩
+          have hTe : T.erase m ⊆ A.erase m := by
+            intro x hx; rw [mem_erase] at hx ⊢; exact ⟨hx.1, hT hx.2⟩
+          have hsum : (S.erase m).sum id = (T.erase m).sum id := by
+            have hs := Finset.sum_erase_add S id hmS
+            have ht := Finset.sum_erase_add T id hmT
+            simp only [id_eq] at hs ht hST ⊢
+            omega
+          have := ih (A.erase m) (erase_ssubset hmA) (h.erase m)
+            (S.erase m) (T.erase m) hSe hTe hsum
+          rw [← Finset.insert_erase hmS, ← Finset.insert_erase hmT, this]
+        · -- `m ∈ S`, `m ∉ T`: sums cannot be equal
+          exfalso
+          have h1 : T.sum id < m := hlt T hT hmT
+          have h2 : m ≤ S.sum id := by
+            have := Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le i) hmS
+            simpa using this
+          omega
+      · by_cases hmT : m ∈ T
+        · exfalso
+          have h1 : S.sum id < m := hlt S hS hmS
+          have h2 : m ≤ T.sum id := by
+            have := Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le i) hmT
+            simpa using this
+          omega
+        · -- neither contains `m`: recurse on `A \ {m}`
+          have hSe : S ⊆ A.erase m := subset_erase.mpr ⟨hS, hmS⟩
+          have hTe : T ⊆ A.erase m := subset_erase.mpr ⟨hT, hmT⟩
+          exact ih (A.erase m) (erase_ssubset hmA) (h.erase m) S T hSe hTe hST
+
+/-- The powers-of-two set is superincreasing: `2ⁱ` exceeds the sum
+    `2⁰ + ⋯ + 2^{i-1} = 2ⁱ − 1` of all smaller elements. -/
+theorem geomSet_superincreasing (n : ℕ) : Superincreasing (geomSet n) := by
+  intro a ha
+  rw [mem_geomSet] at ha
+  obtain ⟨i, _, rfl⟩ := ha
+  have hsub : (geomSet n).filter (· < 2 ^ i) ⊆ geomSet i := by
+    intro x hx
+    rw [mem_filter, mem_geomSet] at hx
+    obtain ⟨⟨j, _, rfl⟩, hlt⟩ := hx
+    rw [mem_geomSet]
+    refine ⟨j, ?_, rfl⟩
+    by_contra hji
+    push_neg at hji
+    exact absurd hlt (by simpa using Nat.pow_le_pow_right (by norm_num) hji)
+  have hpos : 0 < 2 ^ i := pow_pos (by norm_num) i
+  calc ((geomSet n).filter (· < 2 ^ i)).sum id
+      ≤ (geomSet i).sum id := sum_le_sum_of_subset hsub
+    _ = 2 ^ i - 1 := sum_geomSet i
+    _ < 2 ^ i := by omega
+
+/-- The Section 4 distinctness of the powers-of-two set is subsumed by the general
+    superincreasing principle: `geomSet_hasDistinctSubsetSums` also follows from
+    `geomSet_superincreasing` alone, with no appeal to `geomSum_injective`. -/
+example (n : ℕ) : HasDistinctSubsetSums (geomSet n) :=
+  (geomSet_superincreasing n).hasDistinctSubsetSums
+
 end Erdos1OQ02OQ01

--- a/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1-oq-02-oq-01/meta.json
@@ -11,11 +11,11 @@
       "Finset"
     ],
     "namespace": "Erdos1OQ02OQ01",
-    "lineCount": 209,
+    "lineCount": 329,
     "axiomCount": 0,
-    "theoremCount": 15,
-    "substantiveTheoremCount": 11,
-    "definitionCount": 2,
+    "theoremCount": 18,
+    "substantiveTheoremCount": 14,
+    "definitionCount": 3,
     "path": "Proofs/Erdos1OQ02OQ01.lean",
     "sorries": 0
   },
@@ -73,11 +73,11 @@
     ],
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
-    "lineCount": 209,
+    "lineCount": 329,
     "mathlib_version": "4.31.0",
     "assumptions": "None beyond Lean/Mathlib's standard foundations. Fully verified with 0 sorries and 0 axiom declarations. #print axioms reports only the ordinary foundational axioms propext / Classical.choice / Quot.sound for every result — no sorryAx, no Lean.ofReduceBool, no native_decide. Self-contained: restates the HasDistinctSubsetSums predicate and imports only Mathlib.",
-    "theoremCount": 15,
-    "definitionCount": 2
+    "theoremCount": 18,
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Erdős's distinct-subset-sums problem (#1) asks: if a finite set A ⊆ ℕ has all 2^|A| subset sums distinct, how large must its elements be? The powers of two {1,2,…,2^{n−1}} qualify with maximum 2^{n−1}, and Erdős conjectured max(A) ≥ c·2^{|A|} for an absolute constant c — offering money for a proof. The parent gallery entry (`erdos-1-oq-02`) formalizes the sharp analytic step toward this, the second-moment anticoncentration bound 2^{|A|} ≤ 3·√(Σaᵢ²) + 2.\n\nBefore any analysis, there is a purely combinatorial lower bound, essentially Moser's: the subset sums are 2^{|A|} distinct numbers in {0,…,ΣA}, so 2^{|A|} ≤ ΣA + 1, which with ΣA ≤ |A|·max(A) gives max(A) ≥ (2^{|A|} − 1)/|A|. This entry formalizes exactly that elementary bound.",

--- a/src/data/research/problems/erdos-1-oq-02-incomplete-01.json
+++ b/src/data/research/problems/erdos-1-oq-02-incomplete-01.json
@@ -34,7 +34,8 @@
       "Corrected axiom anticoncentration_bound (Chebyshev form) in Erdos1OQ02.lean",
       "Re-proved dfx_lower_bound: 2ⁿ ≤ 3·√n·N+2 (0 sorries) in Erdos1OQ02.lean",
       "Repaired Mathlib-4.26 build breakages in sum_sq_le_card_mul_max_sq, sum_sq_cauchy_schwarz, improvement_factor",
-      "Erdos1OQ02OQ01.lean Section 4: geomSet, twoPow_injective, card_geomSet, mem_geomSet, sum_image_twoPow, geomSet_hasDistinctSubsetSums, sum_geomSet, max'_geomSet, exists_extremal_geomSet (8 thm + 1 def, host-verified 0-axiom/0-sorry)."
+      "Erdos1OQ02OQ01.lean Section 4: geomSet, twoPow_injective, card_geomSet, mem_geomSet, sum_image_twoPow, geomSet_hasDistinctSubsetSums, sum_geomSet, max'_geomSet, exists_extremal_geomSet (8 thm + 1 def, host-verified 0-axiom/0-sorry).",
+      "Erdos1OQ02OQ01.lean Section 5: Superincreasing (def), Superincreasing.erase (hereditary), Superincreasing.hasDistinctSubsetSums (self-contained strong-induction proof peeling the max, no geomSum_injective), geomSet_superincreasing (+ example re-deriving geomSet distinctness from the general principle). 3 thm + 1 def, docker-verified 0-axiom/0-sorry [7743]."
     ],
     "insights": [
       "The 'incomplete-01' snapshot (2 sorries, dated 2026-03-30) is obsolete: those sorries were filled long ago. The live file Erdos1OQ02.lean had 0 sorries but a FALSE axiom.",
@@ -44,12 +45,14 @@
       "dfx_lower_bound re-derived via Σaᵢ²≤n·N² (sum_sq_le_card_mul_max_sq) → √Q≤√n·N → 2ⁿ≤3·√n·N+2; dropped the now-unnecessary hN/hA_pos hypotheses (the +2 slack covers small n).",
       "Session 2026-06-30 (researcher-2): AXIOM DISCHARGED. The anticoncentration_bound axiom (2^n ≤ 3√Q+2) is now a proved theorem in Erdos1OQ02.lean (0 axioms / 0 sorries, docker-verified [7744]); gallery entry erdos-1-oq-02 flipped axiomatized→verified. Combine of the prior ingredients: V = 2^n distinct same-parity doubled deviations with ΣV v²=2^n Q; split at ⌈2√Q⌉ — central-interval parity count ≤ L+1, discrete Chebyshev tail (new ℤ-indexed card_mul_le_sum_of_nonneg) ≤ 2^n/4 — gives (3/4)2^n ≤ 2√Q+1 ⇒ 2^n ≤ 3√Q+2. Q≥1 from distinct-subset-sums forcing 0∉A.",
       "Session 2026-07-08 (researcher-4): the claimed problem was phantom-complete (parent erdos-1-oq-02 fully VERIFIED 0-axiom since #31542, child oq-01 since #33160). Looked outward and resolved the child's top open question: the powers-of-two set is now PROVEN to have distinct subset sums, not just an arithmetic tightness identity.",
-      "Distinctness of {2^0,…,2^{n-1}} follows cleanly from Mathlib Finset.geomSum_injective (Colex.lean: I↦∑_{i∈I}n^i injective for n≥2, uniqueness of n-ary expansions) + Finset.subset_image_iff (every subset of an image is an image of an index subset). No from-scratch max-element induction needed."
+      "Distinctness of {2^0,…,2^{n-1}} follows cleanly from Mathlib Finset.geomSum_injective (Colex.lean: I↦∑_{i∈I}n^i injective for n≥2, uniqueness of n-ary expansions) + Finset.subset_image_iff (every subset of an image is an image of an index subset). No from-scratch max-element induction needed.",
+      "Session 2026-07-09 (researcher-4): generalized the child oq-01 construction. The powers-of-two distinctness (Section 4, via geomSum_injective) is one instance of a single structural principle: a superincreasing set (each element > sum of all strictly smaller ones) always has distinct subset sums. Powers of two are the slowest-growing superincreasing set (2^i = (2^0+...+2^{i-1})+1, minimal slack), which is exactly why they minimise the max and sit on the upper wall M(n) ≤ 2^{n-1}."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "The elementary entry oq-01 is now complete both directions (lower counting wall + upper doubling construction). To sharpen the UPPER wall on the constant c below 1/2, formalize a Conway–Guy / Atkinson–Negro–Santoro construction (max A < 0.23·2^n) — this is a genuinely harder, non-elementary construction.",
-      "Cross-problem: exists_extremal_geomSet / geomSet_hasDistinctSubsetSums are reusable witnesses for any other distinct-subset-sums research entry needing an explicit extremal example."
+      "Cross-problem: exists_extremal_geomSet / geomSet_hasDistinctSubsetSums are reusable witnesses for any other distinct-subset-sums research entry needing an explicit extremal example.",
+      "Superincreasing.hasDistinctSubsetSums is a reusable engine for constructing distinct-subset-sums witnesses from any superincreasing sequence (e.g. Conway-Guy candidates once formalized)."
     ],
     "markdown": "# Knowledge Base: erdos-1-oq-02-incomplete-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the child entry **erdos-1-oq-02-oq-01** (elementary counting bound for Erdős's distinct-subset-sums problem #1) with the **structural principle** underlying its powers-of-two construction.

Section 4 already proves the specific set `{2⁰,…,2^{n-1}}` has distinct subset sums, via uniqueness of binary expansions (`geomSum_injective`). New **Section 5** shows this is one instance of a single principle:

> **Superincreasing ⟹ distinct subset sums.** If every element of `A` exceeds the sum of all strictly smaller elements, then a subset is determined by its sum.

The powers of two are simply the *slowest-growing* superincreasing set (`2ⁱ = (2⁰+⋯+2^{i-1})+1`, meeting the inequality with minimal slack), which is exactly why they minimise the maximum and sit on the upper wall `M(n) ≤ 2^{n-1}` of Section 4.

## What's added (Section 5, all 0-axiom / 0-sorry)

- `def Superincreasing` — every element > sum of all strictly smaller elements.
- `Superincreasing.erase` — the property is hereditary under erasing an element.
- `Superincreasing.hasDistinctSubsetSums` — the main principle, proved **self-contained** (no `geomSum_injective`) by strong induction peeling the maximum `m`: if `S,T` have equal sums then both/neither contain `m` (recurse on `A\{m}`), or exactly one does — say `m∈S, m∉T` — but then `ΣT ≤ Σ(A∩[0,m)) < m ≤ ΣS`, contradiction.
- `geomSet_superincreasing` — the powers-of-two set is superincreasing.
- An `example` re-deriving `geomSet`'s distinctness from the general principle, showing Section 4 is subsumed.

`Superincreasing.hasDistinctSubsetSums` is a reusable engine: it manufactures distinct-subset-sums witnesses from *any* superincreasing sequence.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos1OQ02OQ01` → `✔ [7743/7743] Built` (Lean 4.26.0). 0 sorries, 0 `axiom` declarations, no `native_decide`. Gallery meta counts synced (15→18 thm, 2→3 def, 209→329 lines).

Note: the parent Erdős #1 conjecture (`max A ≥ c·2^n`) itself remains open; this is theory around the elementary walls, not a resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)