### PR TITLE
audit(partition-theorem-oq-01): disclose Lean.ofReduceBool from native_decide

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23333,10 +23333,10 @@
       "result": "clean"
     },
     "partition-theorem-oq-01": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:56:21Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "partition-theorem-oq-01-oq-01": {
       "auditCount": 2,

--- a/src/data/proofs/partition-theorem-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01/meta.json
@@ -54,10 +54,10 @@
     ],
     "dateAdded": "2026-03-11",
     "mathlib_version": "4.26.0",
-    "axioms": 3,
-    "axiomCount": 3,
+    "axioms": 4,
+    "axiomCount": 4,
     "lineCount": 3552,
-    "assumptions": "3 axiom(s): rogers_ramanujan_first, rogers_ramanujan_second, schur_partition_identity_corrected. See Lean source for complete statements.",
+    "assumptions": "4 assumptions. (1) Three axiom declarations — rogers_ramanujan_first, rogers_ramanujan_second, schur_partition_identity_corrected — the deep Rogers-Ramanujan and Schur cardinality identities, which require q-series (Jacobi triple product) or bijective machinery not yet in Mathlib. (2) Lean.ofReduceBool: the computational-verification contributions (24 native_decide examples for n=0..7, 60+ for n=0..12) and 16 named concrete count/strict-subset theorems (rr1_count_*, schur_count_*, *_strict_subset_*_n, schurGapFull_ne_schurGap_9) are discharged via native_decide, which trusts the Lean compiler's kernel reduction and so adds the Lean.ofReduceBool axiom (#print axioms lists it). The ~140 structural containment/monotonicity theorems are native_decide-free (omega/Pairwise reasoning). leanFile.axiomCount remains 3 (literal axiom declarations only). See Lean source for complete statements.",
     "theoremCount": 143,
     "definitionCount": 40
   },


### PR DESCRIPTION
## Integrity Issue

**Proof**: partition-theorem-oq-01 (Rogers-Ramanujan and Schur Partition Identities)
**Severity**: LOW (axiom count off by 1 + missing assumption disclosure; status/badge already correct)

The entry is honestly `axiomatized`/badge `axiom` for its 3 identity axioms. However it *also* leans on `native_decide` for its prominently-listed computational-verification contributions, which was undisclosed.

## Evidence

**Source (`proofs/Proofs/PartitionTheoremOQ01.lean`):**
- 3 literal `axiom` declarations: `rogers_ramanujan_first`, `rogers_ramanujan_second`, `schur_partition_identity_corrected` (all substantive cardinality equalities, not stubs ✓)
- `native_decide` appears 96× — in 80 `example` blocks **and 16 named theorems** (`rr1_count_*`, `schur_count_*`, `*_strict_subset_*_n`, `schurGapFull_ne_schurGap_9`, `partitionsFrom_zero`).
- `originalContributions`/`conclusion` present these as headline results: *"Computational verification … (24 native_decide examples)"*, *"Extended computational verification … (60+ native_decide examples)"*.

**Before:** `meta.axiomCount` = 3, `assumptions` lists only the 3 axioms.
`native_decide` depends on `Lean.ofReduceBool` (`#print axioms` lists it) — undisclosed.

**Convention:** the parent `partition-theorem` counts `Lean.ofReduceBool` in `meta.axiomCount` and discloses it in `assumptions` for exactly this reason.

## Fix

- `meta.axiomCount` / `axioms`: 3 → 4 (3 identity axioms + `Lean.ofReduceBool`)
- `leanFile.axiomCount`: unchanged at 3 (literal declarations only, per policy)
- `assumptions`: expanded to explain the `native_decide` → `ofReduceBool` dependency and note the ~140 structural theorems are native_decide-free
- Counts otherwise verified accurate: lineCount 3552, theoremCount 143, definitionCount 40, sorries 0 — all match source
- Tracker bump (re-audit → issues-fixed)

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)