### PR TITLE
Enrich Sharp Triple Birthday Threshold (birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01): annotate headline theorem

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/annotations.json
@@ -24,6 +24,18 @@
     "prerequisites": ["real powers (rpow)"]
   },
   {
+    "id": "ann-main-statement",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 66, "endLine": 83 },
+    "type": "insight",
+    "title": "The Sharp k = 3 Threshold: c + 1 ≤ n ≤ c + 1 + 1/(3c)",
+    "content": "birthday_triple_threshold_sharp is the headline result. It assumes n ≥ 2 solves the expected-triple balance n(n−1)(n−2) = 6d²·ln 2 — the equation whose solution is the birthday-coincidence threshold for triples among d equally likely days — and concludes, with c := (6d²ln 2)^{1/3}, the two-sided bound c + 1 ≤ n ≤ c + 1 + 1/(3c). The lower-order term is therefore *exactly* 1, up to a remainder ≤ 1/(3c) = O(d^{−2/3}) that vanishes as d → ∞. This sharpens the parent's cruder band c ≤ n ≤ c + 2 to a window of width 1/(3c), pinning the leading correction to the cube-root scaling. The proof rests entirely on the centered substitution m = n − 1, which turns the balance into m³ − m = c³.",
+    "mathContext": "Balance $n(n-1)(n-2)=6d^2\\ln 2$, $c=(6d^2\\ln 2)^{1/3}$ $\\Rightarrow$ $c+1\\le n\\le c+1+\\tfrac{1}{3c}$, so $n = c + 1 + O(d^{-2/3})$.",
+    "significance": "key",
+    "relatedConcepts": ["birthday problem", "triple coincidence threshold", "asymptotic expansion", "centered substitution"],
+    "prerequisites": ["the expected-triple balance equation", "cube-root scaling of the threshold"]
+  },
+  {
     "id": "ann-c-cubed",
     "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
     "range": { "startLine": 84, "endLine": 91 },


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01` (the sharp k=3 birthday coincidence threshold).

The entry was already comprehensive (14 KB, sections covering the full 162-line file, 5 keyInsights, 2 cross-refs — both present). Per anti-bloat guardrails I did not deepen it. The one genuine gap:

- **Headline theorem statement unannotated**: inline annotation coverage jumped from the cube-root helper (62–65) straight to the proof internals (84–91), leaving the main result `birthday_triple_threshold_sharp` — its docstring and statement (66–83) — without a dedicated annotation. Added a `key` annotation stating the sharp two-sided bound c + 1 ≤ n ≤ c + 1 + 1/(3c) (so n = c + 1 + O(d^{−2/3})), which sharpens the parent's cruder band c ≤ n ≤ c + 2 to a window of width 1/(3c).

Now 8 annotations. Verified against source: counts accurate (3 theorems, 0 definitions, 162 lines), both cross-reference targets present, axiom integrity intact (`verified`, `axiomCount: 0`). Top-level `openQuestions` legitimately absent (string-array `conclusion.openQuestions` convention, 3 questions). Size within cap (`check-meta-size` passes).

Note: this fresh worktree lacks `node_modules`, so validation was via `jq` (JSON well-formedness) + `scripts/gallery/check-meta-size.ts` run from the main repo, rather than a full `pnpm build`.