### PR TITLE
erdos-1058-oq-03: pin the least prime factor of n!+1 at the primality boundary (Wilson × engine)

### DIFF
--- a/proofs/Proofs/Erdos1058OQ03.lean
+++ b/proofs/Proofs/Erdos1058OQ03.lean
@@ -198,6 +198,44 @@ theorem exists_prime_gt (n : ℕ) : ∃ p, p.Prime ∧ n < p := by
   obtain ⟨p, hp, hpd⟩ := Nat.exists_prime_and_dvd hne
   exact ⟨p, hp, prime_dvd_factorial_add_one_gt hp hpd⟩
 
+/-! ## The least prime factor of `n! + 1`
+
+The engine `prime_dvd_factorial_add_one_gt` bounds *every* prime factor of `n!+1`
+from below by `n`; applied to the least prime factor it gives `(n!+1).minFac > n`.
+Combined with the Wilson flagship `succ_dvd_factorial_add_one_iff_prime`, this pins
+the least prime factor *exactly* at the primality boundary: `(n!+1).minFac = n+1`
+precisely when `n+1` is prime.  This is the elementary lower-bound core of "bounding
+the smallest prime factor of `n!+1`" (the matching *upper* bound / distinctness from
+`n+1` at composite `n+1` is the genuinely analytic part, out of elementary reach). -/
+
+/-- **The least prime factor of `n! + 1` exceeds `n`.**  For `n ≥ 1`, `n!+1 ≥ 2`, so its
+    least prime factor is a genuine prime dividing `n!+1`; the engine forces it above `n`.
+    Every prime factor of `n!+1` therefore lies in `(n, ∞)` — the quantitative form of the
+    factorial construction behind Euclid's theorem. -/
+theorem factorial_add_one_minFac_gt {n : ℕ} (hn : 1 ≤ n) : n < (n ! + 1).minFac := by
+  have hne : n ! + 1 ≠ 1 := by have := Nat.factorial_pos n; omega
+  exact prime_dvd_factorial_add_one_gt (Nat.minFac_prime hne) (Nat.minFac_dvd _)
+
+/-- **Wilson pins the least prime factor at the primality boundary.**  For `n ≥ 1`,
+    `(n!+1).minFac = n+1` if and only if `n+1` is prime.
+
+    (⇐) When `n+1` is prime, Wilson gives `(n+1) ∣ n!+1`, so `minFac ≤ n+1`; the engine
+    gives `minFac > n`; hence `minFac = n+1`.  (⇒) `minFac` is always prime, so if it
+    equals `n+1` then `n+1` is prime.  When `n+1` is composite the two facts instead give
+    `(n!+1).minFac ≥ n+2` (it exceeds `n` and cannot be the non-divisor `n+1`). -/
+theorem factorial_add_one_minFac_eq_succ_iff {n : ℕ} (hn : 1 ≤ n) :
+    (n ! + 1).minFac = n + 1 ↔ (n + 1).Prime := by
+  have hne : n ! + 1 ≠ 1 := by have := Nat.factorial_pos n; omega
+  constructor
+  · intro h
+    have hp := Nat.minFac_prime hne
+    rwa [h] at hp
+  · intro hp
+    have hdvd : (n + 1) ∣ n ! + 1 := (succ_dvd_factorial_add_one_iff_prime hn).mpr hp
+    have hle : (n ! + 1).minFac ≤ n + 1 := Nat.minFac_le_of_dvd (by omega) hdvd
+    have hgt : n < (n ! + 1).minFac := factorial_add_one_minFac_gt hn
+    omega
+
 /-! ## Twin coprimality of the sibling expressions -/
 
 /-- **The two siblings are coprime.**  For `n ≥ 2`, `gcd (n! - 1) (n! + 1) = 1`:


### PR DESCRIPTION
## Summary

Adds two verified theorems to `proofs/Proofs/Erdos1058OQ03.lean`, sharpening the smallest-prime-factor question (the entry's next-step #1) by combining the file's two existing engines.

The file already proves the *engine* — every prime factor of `n!+1` exceeds `n` (`prime_dvd_factorial_add_one_gt`) — and the *Wilson flagship* — `(n+1) ∣ n!+1 ↔ (n+1)` prime (`succ_dvd_factorial_add_one_iff_prime`). Together they pin the **least** prime factor exactly:

- **`factorial_add_one_minFac_gt`** — `(n!+1).minFac > n` for `n ≥ 1`: the least prime factor (a genuine prime dividing `n!+1`) is forced above `n`, so *every* prime factor of `n!+1` lies in `(n, ∞)`.
- **`factorial_add_one_minFac_eq_succ_iff`** — `(n!+1).minFac = n+1 ↔ (n+1)` is prime. (⇐) Wilson gives `(n+1) ∣ n!+1` ⇒ `minFac ≤ n+1`, and the engine gives `minFac > n` ⇒ equality. (⇒) `minFac` is always prime. When `n+1` is composite the same two facts give `minFac ≥ n+2`.

This is the elementary lower-bound core of "bound the smallest prime factor of `n!±1`"; the matching *upper* bound / distinctness-from-`n+1` at composite `n+1` is the genuinely analytic part and is left out of scope.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos1058OQ03` → `Build completed successfully (7743 jobs)` (confirmed on 3 runs). Remains 0-sorry / 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)