### PR TITLE
Erdős #659 (oq-01): discharge the n/√(log n)→∞ axiom + Mathlib-drift build repair

### DIFF
--- a/proofs/Proofs/Erdos659OQ01.lean
+++ b/proofs/Proofs/Erdos659OQ01.lean
@@ -31,10 +31,13 @@ must have at least c·n/√(log n) distinct distances for some uniform constant 
 
 ## Sorries
 
-0 sorries (fully axiomatized). The three axioms capture:
+0 sorries. Two axioms remain (both genuinely deep, capturing Landau's theorem):
 - The structural constraint from the 4-point property (Moree-Osburn classification)
-- Landau's quantitative lower bound for quadratic forms
-- The uniformity of the Landau constant over all relevant forms
+- Landau's quantitative lower/upper bounds for quadratic forms
+
+The former "Axiom 3" (`n/√(log n) → ∞`) has been **discharged as a theorem** — it is
+a routine analytic limit, not part of Landau's theorem, so it does not belong as an
+assumption.
 
 ## Tags
 
@@ -45,7 +48,7 @@ lower-bounds, optimality
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Data.Real.Sqrt
-import Mathlib.Analysis.Asymptotics.Asymptotics
+import Mathlib.Analysis.Asymptotics.Lemmas
 import Mathlib.Order.Filter.AtTopBot.Basic
 import Mathlib.Topology.MetricSpace.Basic
 
@@ -114,11 +117,43 @@ axiom moreeosburn_upper_bound :
     ∀ n : ℕ, n > 1 →
       (distinctDistances (A n) : ℝ) ≤ C * (n : ℝ) / Real.sqrt (Real.log n)
 
-/-- **Axiom 3 (Log-growth of n/√(log n))**:
-    The function n/√(log n) grows to infinity (is not bounded), ensuring the bound
-    n/√(log n) → ∞ and the ratio test is non-degenerate. -/
-axiom ndiv_sqrt_log_tendsto_infty :
-    Tendsto (fun n : ℕ => (n : ℝ) / Real.sqrt (Real.log n)) atTop atTop
+/-- **Log-growth of `n/√(log n)` — proved, no longer an axiom.**
+    The function `n/√(log n)` grows to infinity, ensuring the bound `n/√(log n) → ∞`
+    and the ratio test is non-degenerate.  This is a routine analytic fact (it does
+    NOT require Landau's theorem), so it is discharged here from Mathlib rather than
+    assumed.  Proof: for `n ≥ 2`, `log n ≤ n` gives `√(log n) ≤ √n`, hence
+    `n/√(log n) ≥ n/√n = √n`, and `√n → ∞`. -/
+theorem ndiv_sqrt_log_tendsto_infty :
+    Tendsto (fun n : ℕ => (n : ℝ) / Real.sqrt (Real.log n)) atTop atTop := by
+  rw [tendsto_atTop_atTop]
+  intro b
+  refine ⟨max 2 (⌈b⌉₊ ^ 2 + 1), fun n hn => ?_⟩
+  have hn2 : 2 ≤ n := le_trans (le_max_left _ _) hn
+  have hnceil : ⌈b⌉₊ ^ 2 + 1 ≤ n := le_trans (le_max_right _ _) hn
+  have hn1R : (1 : ℝ) < n := by exact_mod_cast (by omega : 1 < n)
+  have hnRpos : (0 : ℝ) < n := by linarith
+  have hlogpos : 0 < Real.log n := Real.log_pos hn1R
+  have hsqrtlogpos : 0 < Real.sqrt (Real.log n) := Real.sqrt_pos.mpr hlogpos
+  have hlogle : Real.log n ≤ (n : ℝ) := by
+    have := Real.log_le_sub_one_of_pos hnRpos; linarith
+  -- `b ≤ √n`, choosing `n ≥ ⌈b⌉₊² + 1`
+  have hble : b ≤ Real.sqrt n := by
+    have hpow : (⌈b⌉₊ : ℝ) ^ 2 ≤ (n : ℝ) := by
+      have h1 : ⌈b⌉₊ ^ 2 ≤ n := by omega
+      calc (⌈b⌉₊ : ℝ) ^ 2 = ((⌈b⌉₊ ^ 2 : ℕ) : ℝ) := by push_cast; ring
+        _ ≤ (n : ℝ) := by exact_mod_cast h1
+    calc b ≤ (⌈b⌉₊ : ℝ) := Nat.le_ceil b
+      _ = Real.sqrt ((⌈b⌉₊ : ℝ) ^ 2) := (Real.sqrt_sq (by positivity)).symm
+      _ ≤ Real.sqrt n := Real.sqrt_le_sqrt hpow
+  -- `√n ≤ n / √(log n)` since `√(log n) ≤ √n`
+  have hsqle : Real.sqrt (Real.log n) ≤ Real.sqrt n := Real.sqrt_le_sqrt hlogle
+  have hkey : Real.sqrt n ≤ (n : ℝ) / Real.sqrt (Real.log n) := by
+    rw [le_div_iff₀ hsqrtlogpos]
+    calc Real.sqrt n * Real.sqrt (Real.log n)
+        ≤ Real.sqrt n * Real.sqrt n :=
+          mul_le_mul_of_nonneg_left hsqle (Real.sqrt_nonneg _)
+      _ = (n : ℝ) := Real.mul_self_sqrt (by positivity)
+  linarith
 
 -- ============================================================
 -- SECTION III: Main Results
@@ -142,8 +177,9 @@ theorem no_improvement_possible :
   obtain ⟨c, hc_pos, hlandau⟩ := uniform_landau_lower_bound
   -- achievesImprovedBound means distances / (n/√(log n)) → 0
   rw [achievesImprovedBound, isLittleO_iff] at hcontra
-  -- Apply with the constant c/2
-  have hsmall := hcontra (c / 2) (half_pos hc_pos)
+  -- Apply with the constant c/2 (`c` is strict-implicit in `isLittleO_iff`,
+  -- inferred here from the positivity proof `half_pos hc_pos : 0 < c/2`)
+  have hsmall := hcontra (half_pos hc_pos)
   -- For large enough n, distinctDistances(A n) ≤ (c/2) · n/√(log n)
   rw [Filter.eventually_atTop] at hsmall
   obtain ⟨N₀, hN₀⟩ := hsmall
@@ -173,8 +209,16 @@ theorem no_improvement_possible :
     have h1 : |(distinctDistances (A n₀) : ℝ)| ≤ c / 2 * |(n₀ : ℝ) / Real.sqrt (Real.log n₀)| := hupper
     rw [abs_of_nonneg (by positivity), abs_of_pos hdenom_pos] at h1
     linarith
-  -- Contradiction: c · d ≤ distinctDistances ≤ (c/2) · d, but c · d > (c/2) · d
-  linarith
+  -- Rewrite the lower bound as `c · D` with `D = n₀ / √(log n₀) > 0`, so both
+  -- bounds are expressed over the same positive factor `D` (linarith alone cannot
+  -- relate `(c·n₀)/√L` and `n₀/√L`, which are distinct nonlinear atoms).
+  set D : ℝ := (n₀ : ℝ) / Real.sqrt (Real.log n₀) with hD_def
+  have hDpos : 0 < D := hdenom_pos
+  have hlower' : c * D ≤ (distinctDistances (A n₀) : ℝ) := by
+    have heq : c * (n₀ : ℝ) / Real.sqrt (Real.log n₀) = c * D := by rw [hD_def]; ring
+    rw [heq] at hlower; exact hlower
+  -- Contradiction: `c·D ≤ d ≤ (c/2)·D` with `c, D > 0` forces `(c/2)·D ≤ 0`.
+  nlinarith [mul_pos (half_pos hc_pos) hDpos, hlower', hupper']
 
 /-- **Corollary**: The answer to OQ-01 is "No" — the bound is sharp. -/
 theorem erdos_659_oq01 :

--- a/research/problems/erdos-659-incomplete-01/knowledge.md
+++ b/research/problems/erdos-659-incomplete-01/knowledge.md
@@ -100,3 +100,35 @@ few-distances bound. The √(log) saving is intrinsic to the genuine 2-D box.
 ### Key names
 `Int.card_Icc` (`#(Icc a b)=(b+1-a).toNat`), `Finset.card_product`, `Finset.card_image_of_injective`,
 `Nat.le_self_pow (hn:n≠0) m : m ≤ m^n`, `mul_right_cancel₀`.
+
+## Session 2026-07-09 (researcher-7) — OQ01 axiom elimination + build repair (3→2 axioms)
+
+**Mode**: AXIOM HUNT. Claimed `erdos-659-incomplete-01`; parent `Erdos659Problem.lean` at
+terminus (1 deep axiom `moreeOsburnWorks`). Highest-value available work in the family:
+`Erdos659OQ01.lean` carried **3 axioms**, one of which — `ndiv_sqrt_log_tendsto_infty`
+(`Tendsto (fun n => n/√(log n)) atTop atTop`) — was **mislabeled**: it is a routine analytic
+limit, NOT part of Landau's theorem.
+
+**Done (VERIFIED, docker `[1931/1931]` green):**
+- **Discharged `ndiv_sqrt_log_tendsto_infty` as a theorem** (axiom-free). Proof: for n≥2,
+  `Real.log_le_sub_one_of_pos` ⇒ log n ≤ n ⇒ `Real.sqrt_le_sqrt` ⇒ √(log n) ≤ √n ⇒
+  n/√(log n) ≥ n/√n = √n; and √n → ∞ (via `tendsto_atTop_atTop`, pick N = max 2 (⌈b⌉₊²+1),
+  `Real.sqrt_sq`+`Nat.le_ceil` give b ≤ √n). OQ01 axiomCount **3→2**.
+- **Build repair** (file had NOT compiled against current pin — broken since a Mathlib bump):
+  - `import Mathlib.Analysis.Asymptotics.Asymptotics` no longer exists → split into Defs/Lemmas;
+    changed to `import Mathlib.Analysis.Asymptotics.Lemmas`.
+  - `isLittleO_iff` binder changed to **strict-implicit** `⦃c⦄` → `hcontra (c/2) (half_pos …)`
+    became `hcontra (half_pos hc_pos)` (c inferred as c/2 from the `0 < c/2` proof).
+  - Final contradiction `linarith` failed: `(c·n₀)/√L` and `n₀/√L` are distinct nonlinear
+    atoms. Fixed by `set D := n₀/√L`, rewriting lower bound to `c·D` (via `ring`:
+    `c*n₀/√L = c*(n₀/√L)`), then `nlinarith [mul_pos (half_pos hc_pos) hDpos, …]`.
+
+**Verification:** `#print axioms ndiv_sqrt_log_tendsto_infty` = {propext, Classical.choice,
+Quot.sound}; `no_improvement_possible` depends only on `uniform_landau_lower_bound` (+foundational).
+meta.json synced: axiomCount 3→2, theoremCount 3→4, lineCount 207→251, assumptions + axioms-section
+summary updated. Remaining 2 axioms (`uniform_landau_lower_bound`, `moreeosburn_upper_bound`) are the
+genuinely-deep Landau bounds — out of session scope.
+
+**Gotchas:** persistent SIGBUS-135 flakes + one corrupt dep `Data/List/Pairwise.ir` invalid-header
+→ `docker-repair-cache.sh` (force cache get) then default-32GB build went green (reduced 24576 kept
+135-flaking). Default memory beat reduced here.

--- a/src/data/proofs/erdos-659-oq-01/meta.json
+++ b/src/data/proofs/erdos-659-oq-01/meta.json
@@ -21,8 +21,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
-    "assumptions": "3 axioms: uniform_landau_lower_bound (Landau's theorem gives c·n/√(log n) lower bound uniformly over all n-point sets with the 4-point property), moreeosburn_upper_bound (Moree-Osburn lattice achieves the upper bound, parent problem result), ndiv_sqrt_log_tendsto_infty (n/√(log n) → ∞, standard analysis fact missing from Mathlib for this exact form). All reduce to Landau's quantitative theorem for binary quadratic forms and the Moree-Osburn 2006 result. Consequence theorems (no_improvement_possible, bound_is_tight) are fully proved from these axioms.",
+    "axiomCount": 2,
+    "assumptions": "2 axioms: uniform_landau_lower_bound (Landau's theorem gives c·n/√(log n) lower bound uniformly over all n-point sets with the 4-point property), moreeosburn_upper_bound (Moree-Osburn lattice achieves the upper bound, parent problem result). Both reduce to Landau's quantitative theorem for binary quadratic forms and the Moree-Osburn 2006 result. The former third axiom ndiv_sqrt_log_tendsto_infty (n/√(log n) → ∞) was discharged as a theorem — it is a routine analytic limit, not part of Landau's theorem. Consequence theorems (no_improvement_possible, bound_is_tight) are fully proved from these axioms.",
     "erdosNumber": 659,
     "erdosUrl": "https://erdosproblems.com/659",
     "originalContributions": [
@@ -33,8 +33,8 @@
       "achievesImprovedBound: formal definition of 'improvement' via little-o",
       "familyFourPointProperty: formal definition of 4-point property for families"
     ],
-    "lineCount": 207,
-    "theoremCount": 3,
+    "lineCount": 251,
+    "theoremCount": 4,
     "defCount": 5,
     "definitionCount": 5
   },
@@ -72,7 +72,7 @@
     {
       "id": "axioms",
       "title": "Axioms",
-      "summary": "Three axioms: Landau lower bound (uniform), Moree-Osburn upper bound, log growth",
+      "summary": "Two axioms: Landau lower bound (uniform), Moree-Osburn upper bound. The former log-growth axiom (n/√(log n) → ∞) is now a proved theorem.",
       "startLine": 96,
       "endLine": 130,
       "mathContext": "uniform_landau_lower_bound reduces to Landau 1908 + Moree-Osburn classification"
@@ -111,12 +111,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 207,
+    "lineCount": 251,
     "path": "Proofs/Erdos659OQ01.lean",
-    "axiomCount": 3,
+    "axiomCount": 2,
     "sorries": 0,
     "definitionCount": 5,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "additionalFiles": [
       "Proofs/Erdos659OQ01OQ02.lean"
     ]


### PR DESCRIPTION
## Summary

`Erdos659OQ01.lean` carried **3 axioms**. One of them, `ndiv_sqrt_log_tendsto_infty`
(`Tendsto (fun n => n/√(log n)) atTop atTop`), was **mislabeled** — it is a routine
analytic limit, *not* part of Landau's theorem, so it should never have been an assumption.
This PR **discharges it as a theorem**, dropping OQ01 from 3 → 2 axioms.

Along the way it repairs the file, which had **not compiled** since a Mathlib bump.

## Axiom elimination (3 → 2)

`ndiv_sqrt_log_tendsto_infty` is now proved from Mathlib: for `n ≥ 2`,
`log n ≤ n` (`Real.log_le_sub_one_of_pos`) ⇒ `√(log n) ≤ √n` ⇒ `n/√(log n) ≥ n/√n = √n`,
and `√n → ∞` (`tendsto_atTop_atTop` with `N = max 2 (⌈b⌉₊²+1)`, `Real.sqrt_sq` + `Nat.le_ceil`).

`#print axioms ndiv_sqrt_log_tendsto_infty` = `{propext, Classical.choice, Quot.sound}`.
The two remaining axioms (`uniform_landau_lower_bound`, `moreeosburn_upper_bound`) are the
genuinely-deep Landau bounds — out of session scope.

## Build repair (Mathlib drift)

The file did not compile against the current pin:
- `import Mathlib.Analysis.Asymptotics.Asymptotics` (removed upstream; split into
  `Defs`/`Lemmas`) → `import Mathlib.Analysis.Asymptotics.Lemmas`.
- `isLittleO_iff`'s `c` is now strict-implicit `⦃c⦄`: `hcontra (c/2) (half_pos hc_pos)`
  → `hcontra (half_pos hc_pos)` (c inferred from the `0 < c/2` proof).
- Final contradiction `linarith` could not relate `(c·n₀)/√L` and `n₀/√L` (distinct
  nonlinear atoms): `set D := n₀/√L`, rewrite the lower bound to `c·D` (`ring`), close with
  `nlinarith [mul_pos (half_pos hc_pos) hDpos, …]`.

## Verification

- Docker build `[1931/1931] Built Proofs.Erdos659OQ01` (green; one pre-existing unused-simp warning).
- `no_improvement_possible` depends only on `uniform_landau_lower_bound` (+ foundational).
- meta.json synced: `axiomCount` 3→2, `theoremCount` 3→4, `lineCount` 207→251, assumptions
  + axioms-section summary updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)