### PR TITLE
research(erdos-1026-oq-05): canonical sharp-threshold Erdős–Szekeres form [VERIFIED 0/0, +1 thm]

### DIFF
--- a/proofs/Proofs/Erdos1026OQ05ErdosSzekeres.lean
+++ b/proofs/Proofs/Erdos1026OQ05ErdosSzekeres.lean
@@ -136,4 +136,31 @@ theorem lt_max_LIS_LDS (seq : RealSeq n) (hinj : Function.Injective seq)
   · exact lt_of_lt_of_le h' (le_max_left _ _)
   · exact lt_of_lt_of_le h' (le_max_right _ _)
 
+/-! ## Canonical (sharp-threshold) form
+
+The `erdos_szekeres` lemma above is stated in the strict `r · s < n` form (`LIS > r` or
+`LDS > s`). The recognizable textbook statement of the theorem instead pins the *exact*
+Erdős–Szekeres threshold: **any sequence of `(r-1)(s-1) + 1` distinct reals contains a
+strictly increasing subsequence of length `r` or a strictly decreasing subsequence of
+length `s`.** The number `(r-1)(s-1) + 1` is the sharp one — the block construction of
+length `(r-1)(s-1)` with `LIS = r-1`, `LDS = s-1` shows no smaller threshold works.
+
+This is the same counting content as `erdos_szekeres`, restated at the canonical
+threshold; it is derived, not re-proved. -/
+
+/-- **Erdős–Szekeres theorem (canonical threshold form).** For a sequence of distinct
+reals of length `n`, if `(r-1)(s-1) < n` (equivalently `n ≥ (r-1)(s-1) + 1`) then there is
+a strictly increasing subsequence of length `r` or a strictly decreasing subsequence of
+length `s`: `r ≤ LIS seq ∨ s ≤ LDS seq`.
+
+This is the textbook statement with the sharp Erdős–Szekeres number `(r-1)(s-1)+1`; it
+follows from the strict form `erdos_szekeres` applied at `(r-1, s-1)`, converting each
+`· - 1 < ·` to `· ≤ ·` (valid for all `r, s : ℕ`, including the degenerate `r = 0` or
+`s = 0`). -/
+theorem erdos_szekeres_threshold (seq : RealSeq n) (hinj : Function.Injective seq)
+    {r s : ℕ} (h : (r - 1) * (s - 1) < n) : r ≤ LIS seq ∨ s ≤ LDS seq := by
+  rcases erdos_szekeres seq hinj h with h' | h'
+  · exact Or.inl (by omega)
+  · exact Or.inr (by omega)
+
 end Erdos1026OQ05ErdosSzekeres

--- a/research/problems/erdos-1026-oq-05/knowledge.md
+++ b/research/problems/erdos-1026-oq-05/knowledge.md
@@ -81,3 +81,27 @@ storm, not a math error. Deployer should re-attempt a green build before merge.
 ### Still open
 The matching `O(√n)` **upper** bound (few monotone pieces always suffice — the hard
 constructive Hanani direction) is stated in the file docstring, not axiomatized.
+
+## Session 2026-07-09 (researcher-1) — canonical sharp-threshold ES form (VERIFIED) + saturation note
+
+**Saturation assessment.** All 5 OQ-05 files (main OQ05 18 thm, IncreasingIdentity 26,
+KMonotonic 10, ErdosSzekeres, plus OQ02) are VERIFIED, 0 axioms, 0 sorries. The tractable
+theory is complete: Mirsky lower bound, minMonotonicParts bracket + positivity, exact
+minIncreasingParts=LDS identity, product bound n≤LIS·LDS, pigeonhole form, k-monotone
+sandwich + k=1 endpoint. The ONLY remaining direction is the hard constructive O(√n)
+Hanani UPPER bound (few monotone pieces always suffice) — genuinely open, not session-sized,
+not Aristotle-shaped. Deliberately did NOT pad with trivial reindexed corollaries.
+
+**One genuine gap filled (Erdos1026OQ05ErdosSzekeres.lean, 5→6 thm).** The file stated the
+theorem only in the loose strict form `r·s<n ⟹ r<LIS ∨ s<LDS`; added the canonical textbook
+statement with the SHARP Erdős–Szekeres number:
+- `erdos_szekeres_threshold`: `(r-1)*(s-1) < n → r ≤ LIS seq ∨ s ≤ LDS seq`. Derived from
+  the strict form at `(r-1, s-1)`; `omega` converts each `·-1 < ·` to `· ≤ ·` (valid for
+  all r,s:ℕ incl. degenerate 0). Honestly a restatement at the canonical threshold, not new
+  counting content — included for gallery recognizability (the famous (r-1)(s-1)+1 constant).
+
+**Build.** VERIFIED `Built Proofs.Erdos1026OQ05ErdosSzekeres (3.8s)` at LEAN_MEMORY_LIMIT=8192.
+Hit a shared-cache corruption first (`Mathlib/.../Acyclic.ir invalid header` from fleet race)
+→ fixed with `docker-build.sh --repair-cache` (force cache re-download) → then the usual
+SIGBUS-135 at olean-write on busy fleet, cleared in a quiet window. meta ES additionalFiles
+synced 139→166 / 5→6.

--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -162,10 +162,10 @@
       },
       {
         "path": "Proofs/Erdos1026OQ05ErdosSzekeres.lean",
-        "lineCount": 139,
-        "theoremCount": 5,
+        "lineCount": 166,
+        "theoremCount": 6,
         "definitionCount": 0,
-        "description": "Erdős–Szekeres product bound n ≤ LIS·LDS derived from the Mirsky increasing-covering identity, plus the classical pigeonhole theorem (r·s<n ⟹ r<LIS ∨ s<LDS) and the >k² ⟹ monotone-run >k corollary."
+        "description": "Erdős–Szekeres product bound n ≤ LIS·LDS derived from the Mirsky increasing-covering identity, the classical pigeonhole theorem (r·s<n ⟹ r<LIS ∨ s<LDS), the >k² ⟹ monotone-run >k corollary, and the canonical sharp-threshold form ((r-1)(s-1)<n ⟹ r≤LIS ∨ s≤LDS)."
       },
       {
         "path": "Proofs/Erdos1026OQ05KMonotonic.lean",


### PR DESCRIPTION
## Summary

The `Erdos1026OQ05ErdosSzekeres` companion proved the Erdős–Szekeres theorem only in the loose strict form `r·s < n ⟹ r < LIS ∨ s < LDS`. This adds the **canonical textbook statement** with the *sharp* Erdős–Szekeres number `(r-1)(s-1)+1` (5 → 6 theorems):

- **`erdos_szekeres_threshold`** — `(r-1)·(s-1) < n → r ≤ LIS seq ∨ s ≤ LDS seq`, i.e. any sequence of `(r-1)(s-1)+1` distinct reals has a strictly increasing subsequence of length `r` or a strictly decreasing one of length `s`. Derived from the strict form applied at `(r-1, s-1)`; `omega` converts each `·-1 < ·` to `· ≤ ·` (valid for all `r, s : ℕ`, including the degenerate `r=0`/`s=0`).

## Honest framing

This is a **restatement at the canonical sharp threshold**, not new counting content — included for gallery recognizability, since `(r-1)(s-1)+1` is the famous exact Erdős–Szekeres number that every reference states, whereas the file previously only carried the looser `r·s` form.

The problem `erdos-1026-oq-05` is **saturated for tractable work**: all its files are verified with 0 axioms / 0 sorries (Mirsky lower bound, `minMonotonicParts` bracket + positivity, the exact `minIncreasingParts = LDS` identity, the product bound, the pigeonhole form, and the k-monotone sandwich). The only remaining direction is the hard constructive **O(√n) Hanani upper bound**, which is genuinely open and not session-sized. I deliberately did not pad with further trivial reindexed corollaries.

## Verification

- Build **VERIFIED**: `LEAN_MEMORY_LIMIT=8192 ./proofs/scripts/docker-build.sh Proofs.Erdos1026OQ05ErdosSzekeres` → `Built ... (3.8s)`, `Build completed successfully (7745 jobs)`. **0 new axioms, 0 new sorries.**
- Encountered (and fixed) a transient shared-cache corruption (`Mathlib/.../Acyclic.ir invalid header` from concurrent fleet builds) via `docker-build.sh --repair-cache`.
- `meta.json` `additionalFiles` entry for the ES companion synced 139→166 lines / 5→6 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)