### PR TITLE
Enrich Binomial log-concavity defect (combinations-formula-oq-04-oq-01): split last section + cover tail

### DIFF
--- a/src/data/proofs/combinations-formula-oq-04-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-01/meta.json
@@ -116,7 +116,14 @@
       "title": "Centered Form and Rational Excess",
       "summary": "choose_logConcavity_defect' (the identity at a centered index j) and choose_ratio_rat: C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)) over ℚ, the explicit ultra-log-concavity excess over the geometric value 1.",
       "startLine": 154,
-      "endLine": 213
+      "endLine": 192
+    },
+    {
+      "id": "summary",
+      "title": "Signature Checks and Exact-Defect Summary",
+      "summary": "Closing #check signature confirmations of the headline results and a summary docstring recording the exact defect identity (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2) and its rational-ratio form, noting the whole file rests only on Mathlib's Nat.choose_succ_right_eq with no new axioms; closes the namespace.",
+      "startLine": 194,
+      "endLine": 215
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-04-oq-01` (the exact log-concavity defect of a Pascal row).

The entry was already comprehensive (13.7 KB, 8 annotations, 4 keyInsights, 2 cross-refs — both present, string-array conclusion openQuestions). Per anti-bloat guardrails I did not deepen it. The one genuine gap:

- **Coarse final section + uncovered tail**: the last section (154–213) lumped two distinct theorems (`choose_logConcavity_defect'`, `choose_ratio_rat`) together with a separate summary/`#check` block, and its `endLine` was 213 on a 215-line file (the `end` line 215 uncovered). Split it into `centered-and-ratio` (154–192, the two theorems) and a new `summary` section (194–215, the signature checks + exact-defect summary + namespace close). Sections now span the whole file, matching the annotation structure (194–215 is already its own annotation).

Verified against source: counts accurate (7 theorems, 0 definitions, 215 lines), both cross-reference targets present, axiom integrity intact (`verified`, `axiomCount: 0`). Size within cap.

Note: fresh worktree lacks `node_modules`; validated via `jq` + `check-meta-size.ts` (main repo).