### PR TITLE
audit(legendre-partial): disclose Lean.ofReduceBool from native_decide (axiomCount 1→2)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22257,8 +22257,9 @@
     "legendre-partial": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:01Z",
-      "result": "clean"
+      "lastAudited": "2026-07-09T23:47:20Z",
+      "result": "issues-fixed",
+      "lastResult": "issues-fixed"
     },
     "legendre-partial-oq-04": {
       "auditCount": 1,
@@ -29731,5 +29732,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T23:40:00Z"
+  "lastUpdated": "2026-07-09T23:47:20Z"
 }

--- a/src/data/proofs/legendre-partial/meta.json
+++ b/src/data/proofs/legendre-partial/meta.json
@@ -30,9 +30,9 @@
       "Gap formula: (n+1)^2 - n^2 = 2n + 1"
     ],
     "dateAdded": "2025-12-31",
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 165,
-    "assumptions": "1 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "assumptions": "2 assumptions. (1) axiom legendre_conjecture: the full open conjecture (for all n >= 1, there is a prime in (n^2, (n+1)^2)), stated as an axiom since it has been unproven since 1798. (2) Lean.ofReduceBool: introduced by native_decide, which discharges all 20 verified cases legendre_1..legendre_20 and thus trusts the compiler kernel reduction. leanFile.axiomCount is 1 (literal axiom declarations only); meta.axiomCount is 2 to also count the native_decide (ofReduceBool) dependency. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 21,
     "definitionCount": 3,


### PR DESCRIPTION
## Gallery Integrity Fix — undisclosed `Lean.ofReduceBool`

**Proof**: legendre-partial (Legendre's Conjecture, Partial)

### Problem
The 20 headline theorems `legendre_1 … legendre_20` — the entry's featured "20 verified cases" — are each proved by `native_decide`. `native_decide` trusts the Lean compiler's kernel reduction and depends on the **`Lean.ofReduceBool`** axiom (it appears in `#print axioms`; the results are *not* axiom-free). These are substantive, **named** theorems the entry presents as verified, so per the project's `native_decide` policy the dependency must be counted and disclosed.

Before this PR:
- `meta.axiomCount = 1` (counted only the `legendre_conjecture` axiom)
- `assumptions` was a vague placeholder ("1 axiom(s) encoding mathematical hypotheses. See the Lean source for details.") — `Lean.ofReduceBool` was **not disclosed**.

Same pattern previously fixed for partition-theorem-oq-01 (#36475).

### Fix
- `meta.axiomCount`: **1 → 2** (`legendre_conjecture` axiom + `Lean.ofReduceBool`).
- `meta.assumptions`: rewritten to name both assumptions explicitly.
- `leanFile.axiomCount`: **unchanged at 1** — it counts literal `axiom` declarations only, so `meta.axiomCount (2) > leanFile.axiomCount (1)` is correct and detector-safe.

Status/badge already correct (`axiomatized`/`axiom`, due to the `legendre_conjecture` axiom). Counts otherwise verified accurate: 21 theorems (20 cases + `square_gap_linear`), 3 defs, 0 sorries, 165 lines.

---
Discovered during gallery integrity audit.