### PR TITLE
Enrich Alternating Pascal Row Sum (combinations-formula-oq-05): fix + add cross-references

### DIFF
--- a/src/data/proofs/combinations-formula-oq-05/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05/meta.json
@@ -97,8 +97,19 @@
   },
   "crossReferences": [
     {
+      "targetId": "combinations-formula",
+      "relationship": "extends",
+      "description": "Root entry establishing the binomial coefficient C(n,k) = n!/(k!(n−k)!) and the total row sum ∑ₖ C(n,k) = 2ⁿ. This entry pairs that total with the alternating sum ∑ₖ (−1)ᵏ C(n,k) = 0 to split the row into equal even- and odd-index halves, each 2^{n−1}."
+    },
+    {
       "targetId": "combinations-formula-oq-02",
-      "relationship": "ancestor — the core combinations formula entry providing binomial coefficient context"
+      "relationship": "related",
+      "description": "Sibling entry on binomial coefficient identities; provides the core combinations-formula context (Pascal's rule and factorial form) that this entry's alternating-sum vanishing builds on."
+    },
+    {
+      "targetId": "combinations-formula-oq-04-oq-01",
+      "relationship": "related — companion Pascal-row property",
+      "description": "A different structural property of the same Pascal row: where this entry splits the row into equal even/odd halves via the alternating sum, the log-concavity companion pins the exact ultra-log-concavity defect C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)). Together they characterize the additive (parity) and multiplicative (log-concave) structure of a binomial row."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-05` (alternating row sum of Pascal's triangle and the even/odd split).

The entry was already well-formed (5 annotations covering the full 114-line file, sections spanning 1–114, 4 keyInsights, 3 references, string-array conclusion openQuestions). Per anti-bloat guardrails I did not deepen it. The one genuine defect: **navigability** — the entry had only **1 cross-reference**, and that reference's `description` was `null`.

- Filled the null description on the existing `combinations-formula-oq-02` link.
- Added the root `combinations-formula` entry (`extends`) — it establishes C(n,k) and the total row sum ∑ₖ C(n,k) = 2ⁿ, which this entry pairs with the alternating sum ∑ₖ (−1)ᵏ C(n,k) = 0 to split the row into equal even/odd halves (each 2^{n−1}).
- Added the sibling `combinations-formula-oq-04-oq-01` (`related`) — the multiplicative (log-concavity) structure of the same Pascal row, complementing this entry's additive/parity structure.

Cross-references now 3 (was 1), all targets verified present. Counts accurate (4 theorems, 0 definitions, 114 lines), axiom integrity intact (`verified`, `axiomCount: 0`). Size 8 KB.

Note: fresh worktree lacks `node_modules`; validated via `jq` + `check-meta-size.ts` (main repo).