### PR TITLE
Enrich Weighted Binomial Sums (combinations-formula-oq-09): fix + add cross-references

### DIFF
--- a/src/data/proofs/combinations-formula-oq-09/meta.json
+++ b/src/data/proofs/combinations-formula-oq-09/meta.json
@@ -97,12 +97,19 @@
   },
   "crossReferences": [
     {
+      "targetId": "combinations-formula",
+      "relationship": "extends",
+      "description": "Root entry establishing the binomial coefficient C(n,k) = n!/(k!(n−k)!). This entry computes the weighted sums (moments) of a Pascal row: the zeroth moment is the total row sum ∑ C(n,k) = 2ⁿ, and it adds the first moment ∑ k·C(n,k) = n·2^{n−1} and second moment ∑ k²·C(n,k) = n(n+1)·2^{n−2}."
+    },
+    {
       "targetId": "combinations-formula-oq-01",
-      "relationship": "sibling — provides the row sum ∑ C(n,k) = 2^n and alternating sum ∑ (-1)^k C(n,k) = 0 that these moments complement"
+      "relationship": "sibling",
+      "description": "Provides the zeroth-moment identities of a Pascal row — the total row sum ∑ C(n,k) = 2ⁿ and the alternating sum ∑ (−1)ᵏ C(n,k) = 0 — that the first and second moments computed here complement."
     },
     {
       "targetId": "combinations-formula-oq-02",
-      "relationship": "ancestor — the core combinations formula entry providing binomial coefficient context"
+      "relationship": "related",
+      "description": "The core combinations-formula entry supplying the binomial-coefficient context (Pascal's rule, factorial form) on which the moment computations here rest."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-09` (first and second moments of a Pascal row).

The entry was already well-formed (6 annotations covering the full 122-line file, sections spanning 1–122, 4 keyInsights, 3 references, string-array conclusion openQuestions). Per anti-bloat guardrails I did not deepen it. The one genuine defect: **navigability** — both cross-references had `null` `description` fields (their explanatory text was crammed into the `relationship` tag), and there was no link to the root `combinations-formula` entry.

- Moved the explanatory text into proper `description` fields and reduced the `relationship` tags to clean short forms (`sibling`, `related`).
- Added the root `combinations-formula` (`extends`) — this entry computes the weighted sums (moments) of a Pascal row, extending the base binomial coefficient and the zeroth-moment row sum ∑ C(n,k) = 2ⁿ with ∑ k·C(n,k) = n·2^{n−1} and ∑ k²·C(n,k) = n(n+1)·2^{n−2}.

Cross-references now 3 (was 2), all targets verified present, none with null descriptions. Counts accurate (5 theorems, 0 definitions, 122 lines), axiom integrity intact (`verified`, `axiomCount: 0`). Size 8.6 KB.

Note: fresh worktree lacks `node_modules`; validated via `jq` + `check-meta-size.ts` (main repo).