### PR TITLE
Erdős #1058: ground prime_seq on Nat.nth Nat.Prime (eliminate opaque axiom, 3→2)

### DIFF
--- a/proofs/Proofs/Erdos1058Problem.lean
+++ b/proofs/Proofs/Erdos1058Problem.lean
@@ -23,9 +23,7 @@ References:
 - Luca [Lu01]: Complete solution (Math. Comp.)
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib
 
 namespace Erdos1058
 
@@ -34,20 +32,37 @@ namespace Erdos1058
 -/
 
 /--
-**The prime sequence:**
-p₁ = 2, p₂ = 3, p₃ = 5, p₄ = 7, ...
-The n-th prime number.
--/
-axiom prime_seq : ℕ → ℕ
+**The prime sequence**, `pₙ =` the `n`-th prime.  **0-indexed** (Mathlib's
+`Nat.nth` convention): `p₀ = 2, p₁ = 3, p₂ = 5, p₃ = 7, p₄ = 11, …`.
 
-/--
-**Basic properties of the prime sequence:**
-p₁ = 2, and pₙ₊₁ > pₙ for all n.
--/
-/--
-**First few primes:**
-p₁ = 2, p₂ = 3, p₃ = 5, p₄ = 7, p₅ = 11.
--/
+Grounded on `Nat.nth Nat.Prime` rather than left as an opaque `axiom prime_seq :
+ℕ → ℕ`.  This is a genuine improvement: an uninterpreted function axiom carries no
+information (it could be `fun _ => 0`), which made `inPrimeInterval`,
+`onlyTwoPrimesDivide`, and hence the entire Erdős–Stewart statement *vacuous*.
+Anchoring `prime_seq` to the actual primes makes those statements refer to the real
+object of study, and eliminates one axiom from the file. -/
+noncomputable def prime_seq (n : ℕ) : ℕ := Nat.nth Nat.Prime n
+
+/-- Every term of `prime_seq` is prime (`Nat.prime_nth_prime`). -/
+theorem prime_seq_prime (n : ℕ) : Nat.Prime (prime_seq n) :=
+  Nat.prime_nth_prime n
+
+/-- **The prime sequence is strictly increasing**: `pₘ < pₙ ↔ m < n`, in particular
+`pₙ < pₙ₊₁` (this is the "`pₙ₊₁ > pₙ`" property the header promised). -/
+theorem prime_seq_strictMono : StrictMono prime_seq :=
+  Nat.nth_strictMono Nat.infinite_setOf_prime
+
+/-- **First few primes** (grounding the header's table), now proved rather than
+asserted: `p₀ = 2, p₁ = 3, p₂ = 5, p₃ = 7, p₄ = 11`. -/
+theorem prime_seq_zero : prime_seq 0 = 2 := Nat.nth_prime_zero_eq_two
+
+theorem prime_seq_one : prime_seq 1 = 3 := Nat.nth_prime_one_eq_three
+
+theorem prime_seq_two : prime_seq 2 = 5 := Nat.nth_prime_two_eq_five
+
+theorem prime_seq_three : prime_seq 3 = 7 := Nat.nth_prime_three_eq_seven
+
+theorem prime_seq_four : prime_seq 4 = 11 := Nat.nth_prime_four_eq_eleven
 /-
 ## Part II: The Problem Statement
 -/

--- a/research/problems/erdos-1058-oq-03/knowledge.md
+++ b/research/problems/erdos-1058-oq-03/knowledge.md
@@ -42,3 +42,32 @@ The elementary factorial-technique content is now essentially complete: exact
 Wilson characterisation, sibling `n!-1`, the prime-factor-exceeds-`n` engine,
 Euclid infinitude, twin coprimality, and the prime-power data. The parent #1058
 core (Luca's finiteness classification) remains genuinely deep / axiomatized.
+
+## Session 2026-07-09 (researcher-7) — parent axiom elimination: ground prime_seq (3→2)
+
+**Mode**: AXIOM HUNT on the parent `Erdos1058Problem.lean` (OQ03 companion was already
+0-axiom/0-sorry and "essentially complete"). The parent carried **3 axioms**, one of which —
+`axiom prime_seq : ℕ → ℕ` — was an **opaque uninterpreted function** carrying zero information
+(it could be `fun _ => 0`). Because `inPrimeInterval` / `onlyTwoPrimesDivide` / `satisfiesCondition`
+are all defined in terms of it, the entire Erdős–Stewart statement was effectively **vacuous**.
+
+**Done (VERIFIED, docker `[7743/7743]` green first try):**
+- Replaced `axiom prime_seq : ℕ → ℕ` with `noncomputable def prime_seq (n) := Nat.nth Nat.Prime n`
+  (0-indexed: p₀=2). axiomCount **3→2**; the whole statement now refers to the *actual* primes.
+- Added 7 verified axiom-free theorems the header promised but never stated (impossible while
+  prime_seq was opaque): `prime_seq_prime` (`Nat.prime_nth_prime`), `prime_seq_strictMono`
+  (`Nat.nth_strictMono Nat.infinite_setOf_prime`, gives pₙ₊₁>pₙ), `prime_seq_zero..four`
+  (`Nat.nth_prime_zero_eq_two` … `_four_eq_eleven` = 2,3,5,7,11).
+
+**Key API (Mathlib pin v4.26.0):** `Nat.nth Nat.Prime` = n-th prime (0-indexed, `noncomputable`);
+`Nat.prime_nth_prime : Nat.Prime (nth Prime n)`; `Nat.nth_strictMono (hf : (setOf p).Infinite)`;
+`Nat.infinite_setOf_prime`; `Nat.nth_prime_{zero..four}_eq_{two..eleven}`. Switched file to
+`import Mathlib` (was 3 specific imports) to reach the Nth/PrimeCounting API.
+
+**Verification:** `#print axioms` of all new theorems = {propext, Classical.choice, Quot.sound}.
+Remaining 2 axioms (`erdos_stewart_conjecture_true`, `luca_theorem`) are the deep asserted
+Erdős–Stewart finiteness + Luca 2001 classification — out of scope. meta.json synced (axiomCount
+3→2, theoremCount 2→9, lineCount 165→180, assumptions + originalContributions updated).
+
+**Note:** this is the mislabeled/opaque-axiom pattern again (cf. erdos-659-oq-01 same session):
+an axiom that is either a routine fact or an uninterpreted placeholder → dischargeable/groundable.

--- a/src/data/proofs/erdos-1058/meta.json
+++ b/src/data/proofs/erdos-1058/meta.json
@@ -36,7 +36,8 @@
       }
     ],
     "originalContributions": [
-      "prime_seq axiom: the n-th prime number",
+      "prime_seq: the n-th prime, grounded on Nat.nth Nat.Prime (no longer an axiom)",
+      "prime_seq_prime / prime_seq_strictMono / prime_seq_zero..four: verified basic properties of the prime sequence (p_n prime, p_{n+1} > p_n, first five values 2,3,5,7,11)",
       "inPrimeInterval: n ∈ [p_{k-1}, p_k) predicate",
       "onlyTwoPrimesDivide: restricted factorization condition",
       "satisfiesCondition: the full Erdős-Stewart condition",
@@ -45,10 +46,10 @@
       "Computational verification of n!+1 for n = 1,...,6",
       "erdos_1058_status: combined finiteness and classification"
     ],
-    "axiomCount": 3,
-    "lineCount": 165,
-    "assumptions": "3 axioms: prime_seq, erdos_stewart_conjecture_true, luca_theorem. 0 sorries.",
-    "theoremCount": 2,
+    "axiomCount": 2,
+    "lineCount": 180,
+    "assumptions": "2 axioms: erdos_stewart_conjecture_true, luca_theorem (both deep, asserted: the Erdos-Stewart finiteness conjecture and Luca's 2001 classification n in {1,2,3,4,5}). 0 sorries. The former prime_seq axiom (an opaque N->N function) was eliminated by grounding it on Nat.nth Nat.Prime, which also makes the whole statement non-vacuous.",
+    "theoremCount": 9,
     "definitionCount": 4
   },
   "overview": {
@@ -187,9 +188,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1058",
-    "lineCount": 165,
-    "axiomCount": 3,
-    "theoremCount": 2,
+    "lineCount": 180,
+    "axiomCount": 2,
+    "theoremCount": 9,
     "definitionCount": 4,
     "path": "Proofs/Erdos1058Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`Erdos1058Problem.lean` declared the prime sequence as an **opaque axiom**
`axiom prime_seq : ℕ → ℕ`. An uninterpreted function axiom carries no information
(it could be `fun _ => 0`), and since `inPrimeInterval`, `onlyTwoPrimesDivide`, and
`satisfiesCondition` are all defined through it, the entire Erdős–Stewart statement was
effectively **vacuous**.

This PR **grounds `prime_seq` on Mathlib's `Nat.nth Nat.Prime`** — removing the axiom
(3 → 2) and making the whole formalization refer to the *actual* primes.

## Changes

- `axiom prime_seq : ℕ → ℕ` → `noncomputable def prime_seq (n) := Nat.nth Nat.Prime n`
  (0-indexed, `p₀ = 2`). **axiomCount 3 → 2.**
- Added 7 verified, axiom-free theorems the header's docstrings promised but could never
  state while `prime_seq` was opaque:
  - `prime_seq_prime` — each `pₙ` is prime (`Nat.prime_nth_prime`)
  - `prime_seq_strictMono` — `pₙ₊₁ > pₙ` (`Nat.nth_strictMono Nat.infinite_setOf_prime`)
  - `prime_seq_zero … prime_seq_four` — `p₀..p₄ = 2,3,5,7,11`
- Switched to `import Mathlib` (was 3 specific imports) to reach the `Nat.nth` API.

## Verification

- Docker build `[7743/7743] Built Proofs.Erdos1058Problem` (green, first try).
- `#print axioms` of every new theorem = `{propext, Classical.choice, Quot.sound}`.
- The two remaining axioms (`erdos_stewart_conjecture_true`, `luca_theorem`) are the deep
  asserted Erdős–Stewart finiteness conjecture + Luca's 2001 classification `n ∈ {1,2,3,4,5}` —
  out of scope, now stated over the actual primes.
- meta.json synced: `axiomCount` 3→2, `theoremCount` 2→9, `lineCount` 165→180, assumptions +
  originalContributions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)