### PR TITLE
Enrich p-Group Center (conjugacy-class-equation-oq-01-oq-02): add sibling cross-reference

### DIFF
--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
@@ -131,6 +131,11 @@
       "targetId": "conjugacy-class-equation-oq-01",
       "relationship": "extends",
       "description": "Parent entry; this answers its second open question — a nontrivial finite p-group has nontrivial center — from per-class divisibility in the class equation."
+    },
+    {
+      "targetId": "conjugacy-class-equation-oq-01-oq-01",
+      "relationship": "related — supplies the tool",
+      "description": "Sibling entry proving the class equation in index form |G| = |Z(G)| + Σ [G : C_G(gᵢ)]. That is precisely the identity this entry applies: for a p-group each nontrivial-class index [G : C_G(gᵢ)] is divisible by p, so p divides |Z(G)|, forcing the center to be nontrivial."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `conjugacy-class-equation-oq-01-oq-02` (finite p-groups have nontrivial center, via the class equation).

The entry was already comprehensive (14 KB, 5 annotations covering the full 123-line file, sections spanning 1–123, 4 keyInsights, string-array conclusion openQuestions, parent cross-ref with a filled description). Per anti-bloat guardrails I did not deepen it. The one genuine defect: **navigability** — it had only **1 cross-reference** (to the parent) and did not link the sibling that supplies its central tool.

- Added `conjugacy-class-equation-oq-01-oq-01` ('The Class Equation in Index Form: |G| = |Z(G)| + Σ [G : C_G(gᵢ)]'), which is exactly the identity this entry applies: for a p-group each nontrivial class index is divisible by p, so p ∣ |Z(G)|, forcing a nontrivial center.

Cross-references now 2 (was 1), both targets verified present, both with descriptions. Counts accurate (3 theorems, 0 definitions, 123 lines), axiom integrity intact (`verified`, `axiomCount: 0`). Size 14 KB.

Note: fresh worktree lacks `node_modules`; validated via `jq` + `check-meta-size.ts` (main repo).