### PR TITLE
audit: minkowski-theorem + lhopital re-verified CLEAN 2026-07-09 — bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22315,9 +22315,9 @@
       "result": "clean"
     },
     "lhopital": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:01Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "lhopital-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22905,9 +22905,9 @@
       "issues": []
     },
     "minkowski-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:01Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "minkowski-theorem-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit — 2 stalest entries (both 2026-05-03)

Tracker-only change (persisted via API to survive the loop's `git reset --hard`). Both **CLEAN**.

### minkowski-theorem — CLEAN (auditCount 3→4)
- 0 sorries, 0 axioms, no `native_decide` → `axiomCount: 0` correct.
- `badge: mathlib` correct (Tier B): `minkowski_fundamental` + `*_proved` genuinely derived from Mathlib's `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`; disclosed in `assumptions` + `mathlibDependencies`.
- `HasVolume.volume_eq` is a supplied instance hypothesis, not a structure-encoded axiom.
- `theoremCount 19` exact; `definitionCount 16` = 14 defs + 2 structures.
- Minor LOW (no change): `fermat_from_minkowski` re-exports Mathlib's `Nat.Prime.sq_add_sq` (disclosed).

### lhopital — CLEAN (auditCount 3→4)
- 0 sorries, 0 axioms, 0 defs; `theoremCount 4` / `definitionCount 0` exact.
- `badge: mathlib` correct: all 4 theorems are thin wrappers over Mathlib's L'Hôpital (`lhopital_zero_{right,left,atTop,atBot}_on_{Ioo,Ioi,Iio}`). Delegation disclosed in overview.
- Minor (no change): `mathlibDependencies` lists 3 but source uses a 4th (`lhopital_zero_atBot_on_Iio`) — *understates* deps, not an overclaim.

---
Discovered during gallery integrity audit.