### PR TITLE
Fix: sync stale line/theorem/def counts on 9 grown proofs (#36290)

### DIFF
--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,12 +20,12 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1908,
+    "lineCount": 1994,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 72,
-    "definitionCount": 13,
+    "theoremCount": 75,
+    "definitionCount": 14,
     "originalContributions": [
       "attainsBelow_density_of_autoDropCert: fuses the general density lemma attainsBelow_density_of_residues with the turnkey autoDropCert engine, so the drop-below density floor at any 2^b level is (#auto-certified residues)·(N-1) with ZERO per-residue proof — the residue count is a decide, every drop hypothesis is autoDropCert_attainsBelow (axiom-free, no native_decide)",
       "pow_three_lt_two_pow_of_two_mul_lt / terras_attainsBelow_of_count: the Collatz 3/2 heuristic as a purely combinatorial drop criterion — the count inequality 2·a < b implies the Terras power condition 3^a < 2^b via 3^a ≤ 4^a = 2^(2a) < 2^b (only 3 ≤ 4 = 2²; no power evaluated), and terras_attainsBelow_of_count wires it into the residue engine so a halving-dominated window certifies a drop by an omega-checkable count instead of a power comparison (axiom-free, no decide)"
@@ -138,12 +138,12 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1908,
+    "lineCount": 1994,
     "axiomCount": 1,
-    "theoremCount": 72,
+    "theoremCount": 75,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
-    "definitionCount": 13
+    "definitionCount": 14
   },
   "sorries": 0,
   "highlights": [

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 84,
+    "theoremCount": 89,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -78,10 +78,10 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 1809,
+    "lineCount": 1985,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "In 1909, Émile Borel introduced the concept of a **normal number** and proved that almost every real number (in the sense of Lebesgue measure) is absolutely normal. His theorem is a remarkable fact: though normality is the 'generic' property, proving any specific constant is normal has proved extraordinarily difficult.\n\nFor Euler's constant e = 2.71828182845904523536..., we know:\n- e is irrational (Euler, 1737) — proved via continued fractions and factorial series\n- e is transcendental (Hermite, 1873) — not a root of any polynomial with integer coefficients\n- e has a regular continued fraction [2; 1, 2, 1, 1, 4, 1, 1, 6, 1, 1, 8, ...] with a transparent pattern\n- The first 5 × 10¹³ decimal digits of e have been computed; statistical tests detect no anomalies\n\nYet despite all this, we cannot prove e is normal in base 10, base 2, or ANY base. Indeed, no specific real number has ever been proved normal. Borel's theorem proves normality is generic without identifying a single example.\n\nThe irrationality measure of e is exactly 2 (the minimum possible for any irrational) — see e-transcendental-oq-03. This excellent rational approximability property comes from the predictable continued fraction, but paradoxically does not help prove normality.",
@@ -211,10 +211,10 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 1809,
+    "lineCount": 1985,
     "axiomCount": 1,
-    "theoremCount": 84,
-    "definitionCount": 6,
+    "theoremCount": 89,
+    "definitionCount": 7,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1058-oq-03/meta.json
+++ b/src/data/proofs/erdos-1058-oq-03/meta.json
@@ -51,9 +51,9 @@
       "Axiom-free prime-power classification: 4!+1=5², 5!+1=11² are prime powers; 6!+1=721=7·103 is not; sibling 3!−1=5 prime, 5!−1=119=7·17 not"
     ],
     "axiomCount": 0,
-    "lineCount": 222,
+    "lineCount": 260,
     "assumptions": "None. Fully machine-checked; #print axioms lists only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool — small cases use kernel `decide`, not `native_decide`).",
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 0
   },
   "overview": {
@@ -160,9 +160,9 @@
       "Nat"
     ],
     "namespace": "Erdos1058OQ03",
-    "lineCount": 222,
+    "lineCount": 260,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 0,
     "path": "Proofs/Erdos1058OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -36,8 +36,8 @@
       "neumann_full_theorem: the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite",
       "center_finiteIndex_iff_relIndex_core: ω(Γ(G)) finite ⟹ [G:Z(G)] finite iff Z(G) has finite index within the explicit finite-index core H = ⋂ₐ C_G(a); localizes the residual axiom to (center G).relIndex H, whose Mathlib endgame is Subgroup.index_center_le_pow gated on Finite (commutatorSet G)"
     ],
-    "lineCount": 440,
-    "theoremCount": 14,
+    "lineCount": 471,
+    "theoremCount": 15,
     "defCount": 3,
     "definitionCount": 3
   },
@@ -139,12 +139,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 440,
+    "lineCount": 471,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 14
+    "theoremCount": 15
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1144/meta.json
+++ b/src/data/proofs/erdos-1144/meta.json
@@ -74,9 +74,9 @@
       "conjecture_and_atherfold_pinch"
     ],
     "axiomCount": 1,
-    "lineCount": 226,
+    "lineCount": 252,
     "assumptions": "1 axiom (atherfold_upper_bound — deep published result, 2025).",
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 5
   },
   "overview": {
@@ -229,9 +229,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 226,
+    "lineCount": 252,
     "axiomCount": 1,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 5,
     "path": "Proofs/Erdos1144Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
@@ -63,10 +63,10 @@
     ],
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
-    "lineCount": 127,
+    "lineCount": 198,
     "mathlib_version": "4.26.0",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). In particular this result does NOT use the parent entry's axiomatized juhasz_1979 / juhasz_stronger.",
-    "theoremCount": 5,
+    "theoremCount": 9,
     "definitionCount": 4
   },
   "overview": {
@@ -160,9 +160,9 @@
     ],
     "opens": [],
     "namespace": "Erdos214Incomplete01OQ01",
-    "lineCount": 127,
+    "lineCount": 198,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 9,
     "definitionCount": 4,
     "sorries": 0,
     "path": "Proofs/Erdos214Incomplete01OQ01.lean"

--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -12,9 +12,9 @@
       "KeplerConjecture"
     ],
     "namespace": "KeplerConjectureOQ04",
-    "lineCount": 993,
+    "lineCount": 1028,
     "axiomCount": 2,
-    "theoremCount": 33,
+    "theoremCount": 35,
     "definitionCount": 10,
     "path": "Proofs/KeplerConjectureOQ04.lean",
     "sorries": 0,
@@ -40,8 +40,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 993,
-    "theoremCount": 33,
+    "lineCount": 1028,
+    "theoremCount": 35,
     "definitionCount": 10,
     "assumptions": "0 sorries, 2 axioms in this file: (i) `bezdek_kuperberg_ellipsoid_lattice_upper_bound` (Bezdek-Kuperberg 2007, the ellipsoid lattice density bound, stated but not proved in Lean — published proof relies on affine density invariance under linear transforms, not yet in Mathlib v4.26.0); and (ii) `ulam_conjecture` (Ulam 1972, OPEN — the bound `fccDensity ≤ δ_K` for centrally symmetric convex bodies `K ⊂ ℝ³`, stated as a STATEMENT axiom because the conjecture remains unproven after 50+ years). The parent `Proofs/KeplerConjecture.lean` axiomatizes (a) `thues_theorem` (2D hexagonal optimality, Thue 1892 / Fejes Tóth 1940), (b) `fccDensity_lt_one` (numerical bound), and (c) the Kepler conjecture itself (Hales 1998, Flyspeck 2014). This OQ-04 file defines the Chen-Engel-Glotzer rational constant 4000/4671, the `tetrahedronDimerPacking : PackingDensity` instance, the `EllipsoidLatticePacking` marker structure, and the `SymmetricConvexBody3DPacking` marker structure; proves eleven theorems including `tetrahedronDimerDensity_gt_fccDensity` (the central refutation `π/(3√2) < 4000/4671`, via `Real.pi_lt_d2` and `Real.lt_sqrt`, axiom-free), the existential corollary `exists_packingDensity_gt_fcc`, the Bezdek-Kuperberg-derived corollary `ellipsoid_lattice_le_fccPacking`, the Ulam-derived corollary `ulam_le_fccPacking_density`, and the S7 aggregator `density_hierarchy_3d`. (S15 SOUNDNESS FIX, researcher-8) The shape-restricted bound axioms were over-quantified: this file's `EllipsoidLatticePacking` / `SymmetricConvexBody3DPacking` were contentless `extends PackingDensity` markers (anonymous constructor `PackingDensity → ·`), so the tetrahedral dimer (density > fccDensity) could be wrapped into `bezdek_kuperberg_ellipsoid_lattice_upper_bound` to derive `tetrahedronDimerDensity ≤ fccDensity` — contradicting the axiom-free `tetrahedronDimerDensity_gt_fccDensity` — and a density-0 packing wrapped into `ulam_conjecture` gives `fccDensity ≤ 0`; i.e. the file proved `False`. The parent `Proofs/KeplerConjecture.lean` was independently inconsistent: `thues_theorem`, `kepler_conjecture`, `gauss_lattice_theorem` each bounded EVERY `PackingDensity` by a constant `< 1` (refuted by the trivially constructible density-1 packing), and `viazovska_theorem_8d` bounded every real in `[0,1]` by `e8Density ≈ 0.2537` (refuted by `d = 1/2`). Fix: gate each shape-specific bound behind an uninterpreted `opaque IsDiskPacking / IsSpherePacking / IsSpherePacking8D / IsEllipsoidLatticePacking / IsSymmetricConvexBody3DPacking` predicate (no introduction rule, so no concrete witness can be manufactured), and forward the hypothesis through the derived theorems. The two child statement axioms (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, `ulam_conjecture`) and the parent's count are unchanged — opaque predicates assert nothing, so axiomCount stays 2. The mathematical content (each bound, restricted to its genuine shape class) is preserved; only the unsound over-quantification is removed. (S16 ENRICH, researcher-2) Added three axiom-free derived theorems (no new axioms; axiomCount stays 2): (1) `fccDensity_lt_35329_div_46710` — a division-cleared rational upper bound `fccDensity < 35329/46710 ≈ 0.75634`, the same `Real.pi_lt_d2` + `Real.lt_sqrt` linear chain as the central refutation (`π·46710 < 35329·3·√2`, i.e. `147136.5 < 148381.8`); (2) `tetrahedronDimerDensity_gt_fccDensity_margin` — strengthens the bare strict inequality `tetrahedronDimerDensity_gt_fccDensity` to an explicit quantitative separation `fccDensity + 1/10 < tetrahedronDimerDensity` (the ≈ 0.1159 gap is bounded below by a clean rational `1/10`; `35329/46710 = 4000/4671 − 1/10`, so it follows from (1) by `linarith`); (3) `ellipsoid_lattice_lt_tetrahedronDimer` — a cross-shape strict-domination corollary `e.density < tetrahedronDimerDensity` for every ellipsoid lattice packing `e`, transitivity through `fccDensity` of the Bezdek-Kuperberg upper bound and the axiom-free tetrahedral refutation (so FCC density is a strict separator: no ellipsoid lattice packing can match the tetrahedral dimer). lineCount 497→570, theoremCount 8→11. (S17 ACT, researcher-1) Added the attained top of the ladder (no new axioms; axiomCount stays 2): the space-filling rhombic dodecahedron (Voronoi cell of the FCC lattice, tiles ℝ³) at packing density exactly 1 — `rhombicDodecahedronPackingDensity : ℝ := 1`, bundled into `rhombicDodecahedronPacking : PackingDensity` whose `le_one` field is satisfied by equality. Capstone `exists_packingDensity_eq_one : ∃ p : PackingDensity, p.density = 1` proves the parent's structural bound `PackingDensity.le_one` is SHARP (attained, not merely approached), so the FCC ceiling π/(3√2) ≈ 0.7405 is strictly interior to the attainable range (0, 1]. Plus `octahedron_lt_rhombicDodecahedron` (18/19 < 1), the strict four-shape ladder `fcc_lt_tetra_lt_octa_lt_rhombicDodecahedron`, and `rhombicDodecahedron_not_ellipsoidLattice` (third non-vacuity witness for the S5 opaque gate). lineCount 570→872, theoremCount 11→26, definitionCount 4→6.",
     "mathlib_version": "4.26.0",
@@ -208,6 +208,6 @@
       "description": "Ehrhart theory counts lattice points in polytope dilations, complementing the volumetric density theory of Kepler/Hales; the 4000/4671 dimer construction is polytopal and interfaces naturally with Ehrhart techniques."
     }
   ],
-  "theoremCount": 33,
+  "theoremCount": 35,
   "definitionCount": 10
 }

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -12,9 +12,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "ShannonAWGNMultiSymbolPower",
-    "lineCount": 1479,
+    "lineCount": 1698,
     "axiomCount": 0,
-    "theoremCount": 61,
+    "theoremCount": 68,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 1479,
-    "theoremCount": 61,
+    "lineCount": 1698,
+    "theoremCount": 68,
     "definitionCount": 1,
     "badge": "mathlib",
     "originalContributions": [
@@ -183,6 +183,6 @@
     }
   ],
   "sorries": [],
-  "lineCount": 1479,
-  "theoremCount": 61
+  "lineCount": 1698,
+  "theoremCount": 68
 }

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -24,9 +24,9 @@
     "dateAdded": "2026-07-04",
     "axiomCount": 0,
     "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, 0 structure-encoded hypotheses, no `native_decide` (so no `Lean.ofReduceBool`). `#print axioms` for `torusHom_conj_unipotent` and `card_torus_range` reports only the ordinary foundational axioms `propext`, `Classical.choice`, `Quot.sound`. Every result is machine-checked from Mathlib. The parent simplicity theorem for PSL(2, p) remains open; this entry proves only the verified unipotent-subgroup and split-torus infrastructure and makes no claim about the open question itself.",
-    "lineCount": 544,
-    "theoremCount": 33,
-    "definitionCount": 7,
+    "lineCount": 738,
+    "theoremCount": 43,
+    "definitionCount": 8,
     "originalContributions": [
       "unipotentUpper: the matrix [[1,t],[0,1]] packaged as a determinant-1 element of SL(2, ZMod p)",
       "unipotentUpper_mul: additivity [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]], giving an abelian one-parameter subgroup",
@@ -254,12 +254,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 544,
+    "lineCount": 738,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 7,
-    "theoremCount": 33
+    "definitionCount": 8,
+    "theoremCount": 43
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Nine gallery entries had `meta.json` summary-stat counts drifted below the current Lean source after research PRs grew the underlying files. This is the reliable, build-independent count-drift signal for gallery integrity issue #36290.

For each entry the counts are mirrored in **both** the nested `meta.*` block and the `leanFile.*` block; both were stale and both are now synced.

## Counts (lineCount / theoremCount / definitionCount)

| Entry | old → new |
|-------|-----------|
| collatz-structured-oq-02-oq-03 | 1908→1994 / 72→75 / 13→14 |
| e-transcendental-oq-02 | 1809→1985 / 84→89 / 6→7 |
| erdos-1058-oq-03 | 222→260 / 16→18 / 0 |
| erdos-1098-oq-01-oq-03 | 440→471 / 14→15 / 3 |
| erdos-1144 | 226→252 / 16→17 / 5 |
| erdos-214-incomplete-01-oq-01 | 127→198 / 5→9 / 4 |
| kepler-conjecture-oq-04 | 993→1028 / 33→35 / 10 |
| shannon-channel-coding-awgn-oq-02-oq-02 | 1479→1698 / 61→68 / 1 |
| sylow-theorem-oq-04-oq-03 | 544→738 / 33→43 / 7→8 |

## Method

- `lineCount` = `wc -l` of the source file (authoritative).
- `theoremCount` / `definitionCount` = comment-stripped (newline-preserving), attribute-aware count of `theorem`/`lemma` and `def`/`abbrev`/`structure`/`inductive`/`instance` line-starts. Validated against raw grep; the stripper correctly captures `@[simp] theorem …` lines that a naive grep misses. Definition-count convention confirmed against the 6 entries whose def count was unchanged (all matched).

Metadata-only; no Lean source changed.