### PR TITLE
fix(e-transcendental-oq-02): repair main build break in sum_match_count_eq (from #36470 early-merge)

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -1212,18 +1212,18 @@ theorem sum_match_count_eq (b : ℕ) (hb : 2 ≤ b) (x : ℝ) (k N : ℕ) :
     ext n
     simp only [Finset.mem_filter]
     exact and_congr_right (fun _ => (key n s).symm)
-  calc
-    ∑ s : Fin k → Fin b,
-        ((Finset.range N).filter
-          (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card
+  -- Rewrite each match-filter to its fiber, then count fiberwise.
+  have step1 :
+      ∑ s : Fin k → Fin b,
+          ((Finset.range N).filter
+            (fun n => ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ))).card
         = ∑ s : Fin k → Fin b,
             ((Finset.range N).filter (fun n => F n = s)).card :=
-          Finset.sum_congr rfl (fun s _ => by rw [hfilter s])
-      _ = (Finset.range N).card :=
-          (Finset.card_eq_sum_card_fiberwise
-            (s := Finset.range N) (t := Finset.univ)
-            (f := F) (fun n _ => Finset.mem_univ (F n))).symm
-      _ = N := Finset.card_range N
+    Finset.sum_congr rfl (fun s _ => by rw [hfilter s])
+  rw [step1]
+  exact (Finset.card_eq_sum_card_fiberwise
+      (s := Finset.range N) (t := Finset.univ)
+      (f := F) (fun n _ => Finset.mem_univ (F n))).symm.trans (Finset.card_range N)
 
 /-- **Frequencies form a probability distribution.** For `N ≥ 1` the empirical
     frequencies of the `bᵏ` tuples sum to `1` — the normalised form of the

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 84,
+    "theoremCount": 89,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -78,10 +78,10 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 1809,
+    "lineCount": 1985,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
-    "definitionCount": 6
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "In 1909, Émile Borel introduced the concept of a **normal number** and proved that almost every real number (in the sense of Lebesgue measure) is absolutely normal. His theorem is a remarkable fact: though normality is the 'generic' property, proving any specific constant is normal has proved extraordinarily difficult.\n\nFor Euler's constant e = 2.71828182845904523536..., we know:\n- e is irrational (Euler, 1737) — proved via continued fractions and factorial series\n- e is transcendental (Hermite, 1873) — not a root of any polynomial with integer coefficients\n- e has a regular continued fraction [2; 1, 2, 1, 1, 4, 1, 1, 6, 1, 1, 8, ...] with a transparent pattern\n- The first 5 × 10¹³ decimal digits of e have been computed; statistical tests detect no anomalies\n\nYet despite all this, we cannot prove e is normal in base 10, base 2, or ANY base. Indeed, no specific real number has ever been proved normal. Borel's theorem proves normality is generic without identifying a single example.\n\nThe irrationality measure of e is exactly 2 (the minimum possible for any irrational) — see e-transcendental-oq-03. This excellent rational approximability property comes from the predictable continued fraction, but paradoxically does not help prove normality.",
@@ -211,10 +211,10 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 1809,
+    "lineCount": 1985,
     "axiomCount": 1,
-    "theoremCount": 84,
-    "definitionCount": 6,
+    "theoremCount": 89,
+    "definitionCount": 7,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0
   },

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -74,7 +74,11 @@
       "Theorem liouvilleNumber_not_normal_base_two (this session): the Liouville constant is NOT normal in base 2 — the first application of the frequency criterion to a number whose non-normality is invisible to the missing-digit criterion (an irrational base-2 real omits no digit).",
       "Theorem liouvilleNumber_two_one_density_zero (this session): the base-2 digit 1 of the Liouville constant has asymptotic density 0, not 1/2 — the decisive frequency anomaly, since digit 1 occurs exactly at the density-0 factorial positions.",
       "Theorem exists_irrational_not_normal_of_two_le (this session): extends the sharpness of normal ⇒ irrational to all bases b ≥ 2 (base 2 via the digit-1 density anomaly, b ≥ 3 via a missing digit), strengthening exists_irrational_not_normal from b ≥ 3.",
-      "Lemmas two_pow_le_factorial_succ / liouvilleNumber_two_one_count_le / tendsto_natLog_two_div_atTop_zero (this session): the analytic core — 2^(k-1) ≤ k! forces the 1-positions below N to number ≤ Nat.log 2 N + 4, and Nat.log 2 N / N → 0 (via Real.log =o[atTop] id)."
+      "Lemmas two_pow_le_factorial_succ / liouvilleNumber_two_one_count_le / tendsto_natLog_two_div_atTop_zero (this session): the analytic core — 2^(k-1) ≤ k! forces the 1-positions below N to number ≤ Nat.log 2 N + 4, and Nat.log 2 N / N → 0 (via Real.log =o[atTop] id).",
+      "Theorem sum_match_count_eq (conservation law): since every base-b digit lies in [0,b), each starting position carries a unique k-block, so the b^k tuple-match filters partition Finset.range N and their counts sum to exactly N. A pure combinatorial identity of the digit expansion, assuming no normality.",
+      "Definition matchFreq and theorem sum_matchFreq_eq_one: the empirical tuple frequencies form a genuine probability distribution on Fin k -> Fin b, summing to 1 at every window N >= 1.",
+      "Theorem matchFreq_tendsto_of_others (conservation-closure of normality): if every k-tuple except one has matching frequency converging to b^{-k}, then the omitted tuple does too, since the frequencies sum to 1; equidistribution of one block is forced by that of all the others.",
+      "Theorem isNormalInBase_of_all_but_one: a normality test needs only all-but-one block per length; the omitted block's equidistribution is supplied automatically by the conservation law."
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,


### PR DESCRIPTION
## Urgent: main is currently broken

PR #36470 (digit-tuple conservation law) was squash-merged **between commits** — it captured the initial commit (which had a fragile multi-line `calc` in `sum_match_count_eq`) plus the `heq.mono` robustness fix, but **missed** the subsequent commit that repaired the `calc` and the meta count sync.

As merged, `proofs/Proofs/ETranscendentalOQ02.lean` fails to build:
```
error: ...:1221: Function expected at  Finset.sum_congr rfl fun s x => ?m.157
error: ...:1222: unexpected token ':='; expected command
error: ...:1193: unsolved goals
```

## Fix
- Replace the fragile `calc` with the verified `have step1 := Finset.sum_congr … ; rw [step1]; exact (Finset.card_eq_sum_card_fiberwise …).symm.trans (Finset.card_range N)` chain (alpha-defeq `exact` dodges the `calc`/rw pattern-match failure on the Σ).
- Land the meta.json count sync that also missed the merge: **89 theorems / 7 definitions / 1985 lines** (both `meta.*` and `leanFile.*`).

## Verification
`./proofs/scripts/docker-build.sh Proofs.ETranscendentalOQ02` → `Build completed successfully (3085 jobs)`, exit 0, **0 errors, 0 sorries, no new axioms**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)