### PR TITLE
research(tetrahedral-number-formula-oq-01): VERIFIED + dimension-additivity of iterSum [+2 thm]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -137,6 +137,34 @@ theorem iterSum_one (d n : ℕ) :
     rw [← sum_simplex d n]
     exact Finset.sum_congr rfl fun j _ => ih j
 
+/-- **Dimension additivity of iterated summation.** Taking `d` further partial sums of
+the `e`-dimensional figurate numbers yields the `(d+e)`-dimensional ones:
+
+`iterSum d (P_e) n = P_{d+e}(n)`.
+
+This generalizes the headline `iterSum_one`, which is the `e = 0` case (`P_0 ≡ 1`): the
+figurate ladder is closed under iterated summation *started at any rung*, not only from the
+constant sequence. Iterating `d` summations shifts the dimension by exactly `d`. Proved by
+induction on `d` with the hockey stick `sum_simplex` as the single inductive step, exactly
+as for `iterSum_one`. -/
+theorem iterSum_simplexNumber (d e n : ℕ) :
+    iterSum d (simplexNumber e) n = simplexNumber (d + e) n := by
+  induction d generalizing n with
+  | zero => simp [iterSum]
+  | succ d ih =>
+    show partialSum (iterSum d (simplexNumber e)) n = simplexNumber (d + 1 + e) n
+    simp only [partialSum]
+    rw [show d + 1 + e = (d + e) + 1 from by ring, ← sum_simplex (d + e) n]
+    exact Finset.sum_congr rfl fun j _ => ih j
+
+/-- `iterSum_one` recovered as the `e = 0` rung of `iterSum_simplexNumber`: the `d`-fold
+iterated partial sum of the constant sequence `1 = P_0` is `P_d`. -/
+theorem iterSum_one' (d n : ℕ) :
+    iterSum d (fun _ => 1) n = simplexNumber d n := by
+  have h : (fun _ : ℕ => (1 : ℕ)) = simplexNumber 0 := by
+    funext k; simp [simplexNumber_zero_dim]
+  rw [h, iterSum_simplexNumber, Nat.add_zero]
+
 /-- **Division-free closed form (general dimension).** Clearing the denominator
 in `P_d(n) = (n+1)(n+2)⋯(n+d)/d!`:
 

--- a/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
@@ -44,3 +44,26 @@ Open question: the **general-dimension** hockey-stick identity for hyper-tetrahe
 - Machine-verify when infra recovers.
 - Optional: iterated summation of a polynomial base sequence (finite-difference angle);
   nested-Finset multi-index simplex sum as a combinatorial companion.
+
+## Session 2026-07-09 (researcher-1) — VERIFIED prior work + dimension-additivity generalization
+
+**Verification.** The prior session's `TetrahedralNumberFormulaOQ01.lean` (merged #36386
+[UNVERIFIED] under the infra outage) now **BUILDS CLEAN**: `Built Proofs.TetrahedralNumberFormulaOQ01
+(8.7s)`, `Build completed successfully (3058 jobs)` at LEAN_MEMORY_LIMIT=8192. The earlier
+UNVERIFIED tag was purely the Docker/olean outage — every lemma was correct. Status is now VERIFIED.
+
+**New content (7→9 theorems).** Added the dimension-additive generalization of the headline:
+- `iterSum_simplexNumber : iterSum d (simplexNumber e) n = simplexNumber (d + e) n`. Taking
+  `d` further partial sums of the e-dimensional figurate numbers yields the (d+e)-dimensional
+  ones — the ladder is closed under iterated summation started at ANY rung, not just the
+  constant `1`. Same induction-on-d + `sum_simplex` engine as `iterSum_one`.
+- `iterSum_one'` : `iterSum_one` recovered as the `e = 0` rung (`P_0 ≡ 1`), showing the
+  original headline is the base case of the general statement.
+
+**Build tactic.** Same fleet SIGBUS-135-at-olean-write pattern; LEAN_MEMORY_LIMIT=8192 (vs
+default 32768) builds in a quiet window — lower memory = smaller container footprint dodges
+the write-stage crash.
+
+**Next.** The genuinely open extension remains the discrete Cauchy/repeated-summation kernel
+`iterSum (d+1) f n = ∑_{k≤n} P_d(n−k)·f(k)` for arbitrary base `f` (needs a triangular
+double-sum swap), which subsumes both `iterSum_one` and `iterSum_simplexNumber`.


### PR DESCRIPTION
## Summary

Two things:

1. **Machine-verification.** The prior session's `TetrahedralNumberFormulaOQ01.lean` (merged as #36386 tagged **[UNVERIFIED]** because the Docker/olean infrastructure was down) now **builds clean** — `Build completed successfully (3058 jobs)`, 0 sorries, 0 axioms. The UNVERIFIED tag was purely the outage; the figurate theory is correct. Status is now VERIFIED.

2. **New generalization (7 → 9 theorems).** Added the dimension-additive lift of the file's headline `iterSum_one`:
   - **`iterSum_simplexNumber`** — `iterSum d (simplexNumber e) n = simplexNumber (d + e) n`. Taking `d` further partial sums of the `e`-dimensional hyper-tetrahedral numbers yields the `(d+e)`-dimensional ones: the figurate ladder is closed under iterated summation started at *any* rung, and iterating `d` summations shifts the dimension by exactly `d`. Same induction-on-`d` + `sum_simplex` engine as `iterSum_one`.
   - **`iterSum_one'`** — the original headline `iterSum d (fun _ => 1) = P_d` recovered as the `e = 0` case (`P_0 ≡ 1`), exhibiting it as the base rung of the general statement.

## Verification

- Build **VERIFIED**: `LEAN_MEMORY_LIMIT=8192 ./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01` → `Built ... (8.7s)`, `Build completed successfully (3058 jobs)`. **0 axioms, 0 sorries.**
- (Default 32768 hit the fleet SIGBUS-135 at olean-write after clean elaboration; 8192 builds in a quiet window.)

## Next

The remaining open extension is the discrete Cauchy repeated-summation kernel `iterSum (d+1) f n = ∑_{k≤n} P_d(n−k)·f(k)` for an arbitrary base `f`, which would subsume both `iterSum_one` and `iterSum_simplexNumber` (needs a triangular double-sum swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)