### PR TITLE
Enrich second-order Bernoulli (bernoulli-inequality-oq-01-oq-02): add HLP reference, complete tail coverage

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02/annotations.json
@@ -74,7 +74,7 @@
   {
     "id": "witnesses",
     "proofId": "bernoulli-inequality-oq-01-oq-02",
-    "range": { "startLine": 155, "endLine": 169 },
+    "range": { "startLine": 155, "endLine": 170 },
     "type": "concept",
     "title": "Exactness and Sharpness Witnesses",
     "content": "Three witnesses anchor the classification. The n = 2 identity holds for every a — the quadratic truncation is the complete expansion (1+a)² = 1 + 2a + a². A concrete strict instance at a = 1, n = 4 gives 1 + 4 + 6 = 11 < 16 = 2⁴. The sharpness witness shows the hypothesis a ≥ 0 is necessary: at a = −1/2, n = 3 the truncation 1 − 3/2 + 3/8 = 1/4 EXCEEDS (1/2)³ = 1/8, so the second-order inequality fails on −1 < a < 0 — unlike the first-order inequality, which holds down to a = −2.",

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02/meta.json
@@ -194,6 +194,13 @@
       "year": "1970",
       "venue": "Springer-Verlag",
       "note": "Standard reference on Bernoulli's inequality and its higher-order refinements"
+    },
+    {
+      "authors": "G. H. Hardy, J. E. Littlewood, G. Pólya",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Classic treatment placing Bernoulli's inequality within the convexity/binomial framework that underlies the successive-truncation pattern (each degree-k truncation of (1+a)ⁿ is a lower bound for a ≥ 0)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass on `bernoulli-inequality-oq-01-oq-02` (quality 95, pass 0). The entry is already thoroughly enriched (7 full annotations, 4 keyInsights, complete conclusion, 3 crossRefs, sections spanning 1–170), so this is a focused, non-bloating pass — two accurate gaps:

- **Reference:** add Hardy–Littlewood–Pólya, *Inequalities* (Cambridge, 1934) — the canonical text situating Bernoulli's inequality within the convexity/binomial framework that underlies the successive-truncation pattern this entry generalizes. Previously only Bernoulli (1689) and Mitrinović (1970) were listed.
- **Coverage:** extend the `witnesses` annotation range 155–169 → 155–170 so it covers the namespace-close, matching its `sections` entry (already 155–170); annotations now span to EOF.

No content removed. meta.json 15.8 KB (well under the 60 KB cap). JSON validated with jq; size checked with `check-meta-size.ts`. Lean claims re-verified against `Proofs/BernoulliInequalityOQ01OQ02.lean` (6 theorems + 3 examples, all accurately described).