### PR TITLE
Enrich Linnik critical exponent (dirichlets-theorem-oq-03-oq-01): complete final annotation coverage

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01/annotations.json
@@ -163,7 +163,7 @@
   {
     "id": "ann-linnik-specialization",
     "proofId": "dirichlets-theorem-oq-03-oq-01",
-    "range": { "startLine": 116, "endLine": 138 },
+    "range": { "startLine": 116, "endLine": 144 },
     "type": "concept",
     "title": "Specializing to the Linnik Constant",
     "content": "The final block instantiates the abstract theory at the arithmetic-progression data without re-introducing axioms. `linnikConstantOf p` is `criticalExponent p (fun i => i.2)` — the base is the modulus `q = i.2`. `linnik_threshold` then states the sharp-threshold property directly for the Linnik constant: given Linnik's theorem as the single hypothesis that one admissible exponent exists (`hne`), and `q ≥ 1`, every exponent above the Linnik constant is admissible. The least-prime function `p` is kept abstract so the file remains fully machine-checked; supplying the genuine `leastPrimeInAP` and a concrete witness (e.g. Xylouris's `L = 5`) would discharge `hne` from the parent's analytic input.",


### PR DESCRIPTION
Enrichment pass for `dirichlets-theorem-oq-03-oq-01` (the Linnik constant as an abstract critical exponent).

The entry was already comprehensive (14 KB, 9 annotations, sections spanning the full 144-line file, 4 keyInsights, 4 references, 3 cross-refs — all present with descriptions, string-array conclusion openQuestions). Per anti-bloat guardrails I did not deepen it. The one genuine defect:

- **Annotation under-coverage of its own theorem**: the final annotation 'Specializing to the Linnik Constant' had range 116–138, but the `linnik_threshold` theorem it describes runs to line 140 and its section extends to 144 (the `#check` exports and namespace close). Extended the annotation's `endLine` 138→144 so it fully spans the theorem and closing block it documents.

Verified against source: counts accurate (11 theorems, 3 definitions, 144 lines), all 3 cross-reference targets present, axiom integrity intact (`verified`, `axiomCount: 0`). Size 14 KB.

Note: fresh worktree lacks `node_modules`; validated via `jq` + `check-meta-size.ts` (main repo).