### PR TITLE
audit: nth-root-irrational-oq-01 re-verified CLEAN — bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23219,9 +23219,9 @@
       "result": "clean"
     },
     "nth-root-irrational-oq-01": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:56:22Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "nth-root-irrational-oq-01-oq-01": {


### PR DESCRIPTION
Re-audit of `nth-root-irrational-oq-01` (Nth Root Irrationality via Irreducible Polynomials), the stalest genuinely-uncovered tracker entry (last audited 2026-05-03).

## Verdict: CLEAN

Verified `proofs/Proofs/NthRootIrrationalOQ01.lean` against `meta.json`:

- Theorems 12 (incl. 1 private), Definitions 0, Axioms 0, Sorries 0, Lines 209 — all match meta exactly
- No `native_decide`
- All 4 mathlibDependencies real and used (Eisenstein criterion, Gauss lemma, minpoly.irreducible)
- badge=original defensible: `irreducible_no_rational_root` and the private Eisenstein lemma `X_pow_sub_prime_irreducible_int` are genuine derivations, not thin wrappers
- status=verified correct; originalContributions all accurate
- Soft note (no action): `structural_subsumes_counting` is a definitional alias of `irrational_nthRoot_of_prime`, honestly disclosed in meta

Bumps tracker auditCount 3->4, lastAudited->2026-07-09. No content changes needed.

Generated with Claude Code