### PR TITLE
Enrich Cayley-Hamilton coprime CRT merge (cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05): add mathContext to all sections

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
@@ -64,28 +64,32 @@
       "title": "Module header, imports, and parent scaffold",
       "startLine": 1,
       "endLine": 54,
-      "summary": "Imports Mathlib and the sorry-free parent CayleyHamiltonReductionOQ02OQ01WIP01, which supplies charpoly (C(p) ⊕ C(q)) = p·q and minpoly (C(p) ⊕ C(q)) = lcm p q. The docstring frames the goal: since lcm p q ∣ p·q strictly in general the block sum is derogatory, and the coprime case (lcm = product) is exactly where it becomes nonderogatory. Opens the parent namespaces and fixes the ambient variable {F : Type*} [Field F] under which the entire merge is generic."
+      "summary": "Imports Mathlib and the sorry-free parent CayleyHamiltonReductionOQ02OQ01WIP01, which supplies charpoly (C(p) ⊕ C(q)) = p·q and minpoly (C(p) ⊕ C(q)) = lcm p q. The docstring frames the goal: since lcm p q ∣ p·q strictly in general the block sum is derogatory, and the coprime case (lcm = product) is exactly where it becomes nonderogatory. Opens the parent namespaces and fixes the ambient variable {F : Type*} [Field F] under which the entire merge is generic.",
+      "mathContext": "Inherited from the parent: $\\chi_{C(p)\\oplus C(q)} = p\\cdot q$ and $\\mu_{C(p)\\oplus C(q)} = \\operatorname{lcm}(p,q)$; a block sum is nonderogatory iff $\\mu = \\chi$, i.e. iff $\\operatorname{lcm}(p,q) = p\\cdot q$."
     },
     {
       "id": "lcm-coprime",
       "title": "lcm = product for coprime monic polynomials",
       "startLine": 55,
       "endLine": 71,
-      "summary": "lcm_eq_mul_of_isCoprime_monic: for coprime monic p, q over a field (with DecidableEq F for the GCDMonoid instance), lcm p q = p·q by mutual divisibility of two monic polynomials."
+      "summary": "lcm_eq_mul_of_isCoprime_monic: for coprime monic p, q over a field (with DecidableEq F for the GCDMonoid instance), lcm p q = p·q by mutual divisibility of two monic polynomials.",
+      "mathContext": "$\\operatorname{lcm}(p,q) = p\\cdot q$ for coprime monic $p,q \\in F[X]$: $\\operatorname{lcm}(p,q) \\mid p q$ always, and $pq \\mid \\operatorname{lcm}(p,q)$ via $\\texttt{IsCoprime.mul\\_dvd}$; two monic polynomials that divide each other are equal."
     },
     {
       "id": "coprime-readout",
       "title": "Minpoly = charpoly = p·q for coprime blocks",
       "startLine": 73,
       "endLine": 88,
-      "summary": "companion_block_coprime_minpoly_eq_charpoly: combines the parent scaffold's minpoly = lcm and charpoly = product with lcm = product to read off minpoly = charpoly = p·q."
+      "summary": "companion_block_coprime_minpoly_eq_charpoly: combines the parent scaffold's minpoly = lcm and charpoly = product with lcm = product to read off minpoly = charpoly = p·q.",
+      "mathContext": "For coprime monic $p,q$: $\\mu_{C(p)\\oplus C(q)} = \\operatorname{lcm}(p,q) = p q = \\chi_{C(p)\\oplus C(q)}$, substituting L5 into the parent's minpoly-as-lcm readout."
     },
     {
       "id": "nonderogatory",
       "title": "Coprime companion blocks are nonderogatory",
       "startLine": 89,
       "endLine": 106,
-      "summary": "companion_block_coprime_nonderogatory: the block sum satisfies minpoly = charpoly, the cyclic criterion, hence is similar to the single companion matrix C(p·q) — the CRT collapse of two coprime invariant factors."
+      "summary": "companion_block_coprime_nonderogatory: the block sum satisfies minpoly = charpoly, the cyclic criterion, hence is similar to the single companion matrix C(p·q) — the CRT collapse of two coprime invariant factors.",
+      "mathContext": "$\\mu_{C(p)\\oplus C(q)} = \\chi_{C(p)\\oplus C(q)}$, so $C(p)\\oplus C(q)$ is nonderogatory (cyclic) and similar to $C(pq)$ — the matrix form of CRT: $F[X]/(pq) \\cong F[X]/(p) \\times F[X]/(q)$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass on `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05` (quality 95, pass 0). The entry is already strong — 5 annotations (all with mathContext/relatedConcepts/prerequisites) spanning lines 4–104, 6 keyInsights, 3 crossReferences, contiguous sections covering the full 106-line file. The one consistent gap: **none of the 4 `sections` had a `mathContext` field**, though every annotation does.

**Change:** add accurate LaTeX `mathContext` to each section:
- header/setup: the inherited parent facts `χ = p·q`, `μ = lcm(p,q)`, and the nonderogatory criterion `μ = χ ⟺ lcm(p,q) = p·q`;
- lcm lemma (L5): `lcm(p,q) = p·q` for coprime monic `p,q` by mutual divisibility;
- readout: `μ = lcm(p,q) = pq = χ`;
- nonderogatory: `C(p)⊕C(q) ~ C(pq)`, the matrix form of CRT `F[X]/(pq) ≅ F[X]/(p) × F[X]/(q)`.

Also verified the "verified, 0 axioms" claim: the imported parent `CayleyHamiltonReductionOQ02OQ01WIP01` is sorry-free (0 sorries/axioms), so the claim holds. No content removed. meta.json 12.5 KB (well under 60 KB cap). JSON validated with jq. Claims re-checked against the Lean file (3 theorems, 0 axioms, 0 sorries).
