### PR TITLE
Fix: sync stale lineCount for erdos-666 (#36290)

### DIFF
--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -55,7 +55,7 @@
       "GeneralizedConjecture: open question for C_{2k}"
     ],
     "axiomCount": 1,
-    "lineCount": 413,
+    "lineCount": 432,
     "assumptions": "1 axiom (Chung 1992): chung_no_threshold — no threshold N makes every (1/4)-dense subgraph of Qₙ contain C₆; a consequence of Chung's edge-partition of Qₙ into four C₆-free subgraphs, not available in Mathlib. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) was previously axiomatized but is now PROVED outright — it carries no edge-count data, so the empty subgraph ⊥ (no edges, hence no cycle) is an honest witness. The deep density content stays isolated in the single axiom chung_no_threshold.",
     "theoremCount": 11,
     "definitionCount": 13,
@@ -172,7 +172,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 413,
+    "lineCount": 432,
     "axiomCount": 1,
     "theoremCount": 11,
     "definitionCount": 13,


### PR DESCRIPTION
## Fix

`erdos-666` meta.json advertised `lineCount: 413` in both the `meta` and `leanFile` blocks, but the Lean source `Proofs/Erdos666Problem.lean` grew to 432 lines via research commits (#36486, #36327, #36033) that did not resync the gallery metadata.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 413`
**After**: both `= 432` (`wc -l proofs/Proofs/Erdos666Problem.lean` → 432)

Scope limited to `lineCount` (objective `wc` ground truth). `theoremCount`/`definitionCount` left untouched: meta and leanFile agree (11/13) and a comment-stripping recount is not reliable enough to override two agreeing fields.

Part of #36290.

---
Automated fix by lean-mechanic agent.