### PR TITLE
research(erdos-165-oq-05): symmetric [1/2,1] bracket completion [VERIFIED 0 new axioms, +2 thm]

### DIFF
--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -343,6 +343,39 @@ theorem constantConjecture_refuted_of_one_lt (c : ℝ) (hc : 1 < c) :
   have : c ≤ 1 := R3_lower_constant_le_one c hlower
   linarith
 
+/-- **Any conjectured constant `< 1/2` is refuted by the HHKP lower bound.**  The general
+    form of `pgm_conjecture_refuted` (the PGM constant `1/4` is just the `c = 1/4` instance):
+    a conjecture `R(3,k) ~ c·k²/log k` with `c < 1/2` has an upper half asserting a valid
+    first-order upper constant `c`, but `R3_upper_constant_ge_half` forces every valid upper
+    constant to be `≥ 1/2`.  The only Ramsey input is `hhkp_bound`. -/
+theorem constantConjecture_refuted_of_lt_half (c : ℝ) (hc : c < 1/2) :
+    ¬ constantConjecture c := by
+  intro h
+  have hupper : ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
+      (R3 k : ℝ) ≤ (c + ε) * k^2 / log k := by
+    intro ε hε
+    obtain ⟨k₀, hk₀⟩ := h ε hε
+    exact ⟨k₀, fun k hk => (hk₀ k hk).2⟩
+  have : (1:ℝ)/2 ≤ c := R3_upper_constant_ge_half c hupper
+  linarith
+
+/-- **The exact constant, if it exists, lies in `[1/2, 1]`.**  Unifying headline of the
+    two-sided obstruction: any conjectured exact asymptotic constant `c` for `R(3,k)`
+    (`constantConjecture c`) must satisfy `1/2 ≤ c ≤ 1`.  The lower fence is HHKP
+    (`constantConjecture_refuted_of_lt_half`), the upper fence is Shearer
+    (`constantConjecture_refuted_of_one_lt`); the PGM value `1/4` is excluded by the former
+    and Erdős's conjectured `1/2` sits exactly on the lower fence, hence survives.  Both
+    Ramsey inputs (`hhkp_bound`, `shearer_upper_bound`) are used; no new axioms. -/
+theorem constantConjecture_forces_bracket (c : ℝ) (h : constantConjecture c) :
+    (1:ℝ)/2 ≤ c ∧ c ≤ 1 := by
+  refine ⟨?_, ?_⟩
+  · by_contra hlt
+    push_neg at hlt
+    exact constantConjecture_refuted_of_lt_half c hlt h
+  · by_contra hgt
+    push_neg at hgt
+    exact constantConjecture_refuted_of_one_lt c hgt h
+
 /- ## Part VII: Related Problems -/
 
 /-

--- a/research/problems/erdos-165-oq-05/knowledge.md
+++ b/research/problems/erdos-165-oq-05/knowledge.md
@@ -64,3 +64,24 @@ Added the *above* mirror using Shearer (upper constant 1):
 the constant ≥ 1/2 from below; Shearer pins it ≤ 1 from above. Together they bracket the
 (open) exact constant to **[1/2, 1]** using only the two Ramsey axioms. 0 new axioms;
 still 10 deep-Ramsey axioms (Kim/Shearer/HHKP/AKS), none Mathlib-eliminable. VERIFIED build.
+
+## Session 2026-07-09 (researcher-1) — symmetric completion of the [1/2,1] bracket (VERIFIED)
+
+Completed the two-sided obstruction into a single headline. The prior sessions refuted
+constantConjecture from below only at the specific PGM value 1/4 (`pgm_conjecture_refuted`)
+and from above for c>1 (`constantConjecture_refuted_of_one_lt`). Added (8→10 thm):
+- `constantConjecture_refuted_of_lt_half (c) (hc : c < 1/2) : ¬ constantConjecture c` — the
+  GENERAL lower refutation (PGM 1/4 is the c=1/4 instance); its upper half asserts a valid
+  upper constant c<1/2, contradicting `R3_upper_constant_ge_half` (HHKP). Mirrors `_of_one_lt`.
+- `constantConjecture_forces_bracket (c) (h) : 1/2 ≤ c ∧ c ≤ 1` — unifying headline: any
+  conjectured exact first-order constant for R(3,k)/(k²/log k) MUST lie in [1/2,1]. Lower
+  fence = HHKP, upper fence = Shearer; Erdős's conjectured 1/2 sits on the lower fence (survives),
+  PGM 1/4 excluded. by_contra + push_neg dispatches each fence to the two refutation lemmas.
+
+0 new axioms (still 10 deep-Ramsey axioms Kim/Shearer/HHKP/AKS, none Mathlib-eliminable).
+VERIFIED `Built Proofs.Erdos165Problem (2.3s)` at LEAN_MEMORY_LIMIT=8192. meta synced 7→10 thm
+/ 363→396 lines (also corrected a pre-existing -1 drift).
+
+**Terminus note.** The exact-constant question is genuinely open (the [1/2,1] gap is the real
+Ramsey frontier); the formal side is now saturated — the bracket is as tight as the two
+available Ramsey axioms allow, and narrowing it needs new deep Ramsey input, not Lean work.

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -56,10 +56,10 @@
       "Repaired latent Mathlib-drift breakage in erdos_165 (linarith could not widen 5/4 to 2 without k²/log k ≥ 0)"
     ],
     "axiomCount": 10,
-    "lineCount": 363,
+    "lineCount": 396,
     "assumptions": "10 axioms (unchanged): ramseyNumber, ramseyNumber_symm, ramseyNumber_recurrence, R3_small_values, aks_upper_bound, shearer_upper_bound, kim_lower_bound, bk_pgm_bound, cjms_bound, hhkp_bound. 0 sorries. New theorems add no axioms; asymptotic_constant_le is fully axiom-free; pgm_conjecture_refuted depends only on the existing hhkp_bound.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 10,
     "definitionCount": 4,
     "additionalFiles": [
       "Proofs/Stubs/Erdos165Aristotle.lean"
@@ -166,9 +166,9 @@
       "Real"
     ],
     "namespace": "Erdos165",
-    "lineCount": 363,
+    "lineCount": 396,
     "axiomCount": 10,
-    "theoremCount": 7,
+    "theoremCount": 10,
     "definitionCount": 4,
     "path": "Proofs/Erdos165Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Completes the two-sided obstruction on the (open) first-order Ramsey constant for `R(3,k) ~ c·k²/log k` into a single headline (8 → 10 theorems). Prior sessions refuted the exact-constant conjecture from *below* only at the specific PGM value `1/4`, and from *above* for `c > 1`. This adds the general lower refutation and the unifying bracket:

- **`constantConjecture_refuted_of_lt_half`** — for every `c < 1/2`, `¬ constantConjecture c`. Its upper half would assert a valid first-order upper constant `c < 1/2`, contradicting `R3_upper_constant_ge_half` (the HHKP `≥ 1/2` obstruction). This is the general form of `pgm_conjecture_refuted` (the PGM `1/4` is the `c = 1/4` instance), mirroring the existing `constantConjecture_refuted_of_one_lt` (Shearer, from above).
- **`constantConjecture_forces_bracket`** — the headline: any conjectured *exact* asymptotic constant `c` for `R(3,k)/(k²/log k)` must satisfy `1/2 ≤ c ≤ 1`. The lower fence is HHKP, the upper fence is Shearer; Erdős's conjectured `1/2` sits exactly on the lower fence (and survives), while PGM's `1/4` is excluded.

## Verification

- Build **VERIFIED**: `LEAN_MEMORY_LIMIT=8192 ./proofs/scripts/docker-build.sh Proofs.Erdos165Problem` → `Built ... (2.3s)`, `Build completed successfully`.
- **0 new axioms** — the 10 deep-Ramsey axioms (Kim/Shearer/HHKP/AKS) are unchanged and remain Mathlib-ineliminable; status stays `axiomatized`.
- `meta.json` synced 7 → 10 theorems / 363 → 396 lines (also corrects a pre-existing −1 count drift).

## Status

The exact-constant question is genuinely open — the `[1/2, 1]` gap is the real Ramsey frontier. The *formal* side is now saturated: the bracket is as tight as the two available Ramsey axioms permit, and narrowing it requires new deep Ramsey input, not further Lean work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)