### PR TITLE
Research(eisenstein-oq-01-oq-02): degree of ℚ(ⁿ√p) via minimal polynomial Xⁿ−p

### DIFF
--- a/proofs/Proofs/EisensteinCriterionOQ01OQ02.lean
+++ b/proofs/Proofs/EisensteinCriterionOQ01OQ02.lean
@@ -1,0 +1,121 @@
+/-
+  Degree of `ℚ(ⁿ√p)`: the minimal polynomial `Xⁿ − p` via Eisenstein
+  (eisenstein-criterion-oq-01-oq-02)
+
+  The gallery entry `eisenstein-criterion-oq-01` proves that `Xⁿ − p` is
+  irreducible over `ℤ` for every prime `p` and every `n ≥ 1`
+  (`EisensteinCriterionOQ01.irreducible_X_pow_sub_C_prime`).  This file draws the
+  standard field-theoretic corollary:
+
+  * Gauss's lemma transports that irreducibility to `ℚ`
+    (`irreducible_X_pow_sub_C_prime_rat`).
+  * Since `Xⁿ − p` is monic, irreducible over `ℚ`, and vanishes at the real
+    `n`-th root `p^{1/n}`, it is *the* minimal polynomial of `p^{1/n}` over `ℚ`
+    (`minpoly_eq_X_pow_sub_C`).
+  * Hence `[ℚ(p^{1/n}) : ℚ] = n` (`finrank_adjoin_eq`), and Eisenstein produces
+    a real algebraic number of every prescribed degree
+    (`exists_algebraic_number_of_degree`).
+
+  Concrete instances: `[ℚ(√2):ℚ] = 2` and `[ℚ(∛2):ℚ] = 3`.
+
+  All results are `0`-sorry / `0`-axiom on top of Mathlib and the parent entry.
+-/
+import Mathlib
+import Proofs.EisensteinCriterionOQ01
+
+open Polynomial IntermediateField
+
+namespace EisensteinCriterionOQ01OQ02
+
+open EisensteinCriterionOQ01
+
+/-! ### Irreducibility over `ℚ`
+
+Gauss's lemma: a primitive integer polynomial is irreducible over `ℤ` iff its
+image in `ℚ[X]` is irreducible.  `Xⁿ − p` is monic (hence primitive), so the
+parent's `ℤ`-irreducibility gives irreducibility over `ℚ` for *every* `n ≥ 1`. -/
+
+/-- `Xⁿ − p` is irreducible over `ℚ` for every prime `p` and every `n ≥ 1`. -/
+theorem irreducible_X_pow_sub_C_prime_rat {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℚ[X]) ^ n - C (p : ℚ)) := by
+  have hpz : Prime (p : ℤ) := Nat.prime_iff_prime_int.mp hp
+  have hZ : Irreducible ((X : ℤ[X]) ^ n - C (p : ℤ)) :=
+    irreducible_X_pow_sub_C_prime hpz hn
+  have hprim : ((X : ℤ[X]) ^ n - C (p : ℤ)).IsPrimitive :=
+    (monic_X_pow_sub_C (p : ℤ) hn.ne').isPrimitive
+  -- the image of `Xⁿ − p` under `ℤ → ℚ` is `Xⁿ − p`
+  have hmap : ((X : ℤ[X]) ^ n - C (p : ℤ)).map (Int.castRingHom ℚ)
+      = (X : ℚ[X]) ^ n - C (p : ℚ) := by
+    simp
+  have := (Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast hprim).mp hZ
+  rwa [hmap] at this
+
+/-! ### The minimal polynomial of a real `n`-th root of a prime -/
+
+/-- The real `n`-th root `α` of a prime `p` (any `α` with `αⁿ = p`) is a root of
+`Xⁿ − p` over `ℚ`. -/
+theorem aeval_root {p : ℕ} {n : ℕ} {α : ℝ} (hα : α ^ n = (p : ℝ)) :
+    (Polynomial.aeval α) ((X : ℚ[X]) ^ n - C (p : ℚ)) = 0 := by
+  have h : (Polynomial.aeval α) ((X : ℚ[X]) ^ n - C (p : ℚ)) = α ^ n - (p : ℝ) := by
+    simp
+  rw [h, hα, sub_self]
+
+/-- **Minimal polynomial.** For a prime `p`, `n ≥ 1`, and any real `α` with
+`αⁿ = p`, the minimal polynomial of `α` over `ℚ` is exactly `Xⁿ − p`. -/
+theorem minpoly_eq_X_pow_sub_C {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n)
+    {α : ℝ} (hα : α ^ n = (p : ℝ)) :
+    minpoly ℚ α = (X : ℚ[X]) ^ n - C (p : ℚ) :=
+  (minpoly.eq_of_irreducible_of_monic
+    (irreducible_X_pow_sub_C_prime_rat hp hn)
+    (aeval_root hα)
+    (monic_X_pow_sub_C (p : ℚ) hn.ne')).symm
+
+/-- Such an `α` is integral over `ℚ`. -/
+theorem isIntegral_root {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n)
+    {α : ℝ} (hα : α ^ n = (p : ℝ)) : IsIntegral ℚ α := by
+  rw [← minpoly.ne_zero_iff, minpoly_eq_X_pow_sub_C hp hn hα]
+  exact (monic_X_pow_sub_C (p : ℚ) hn.ne').ne_zero
+
+/-! ### The degree of the radical extension -/
+
+/-- **`[ℚ(p^{1/n}) : ℚ] = n`.** For a prime `p`, `n ≥ 1`, and any real `α` with
+`αⁿ = p`, the simple extension `ℚ(α)/ℚ` has degree exactly `n`. -/
+theorem finrank_adjoin_eq {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n)
+    {α : ℝ} (hα : α ^ n = (p : ℝ)) :
+    Module.finrank ℚ ℚ⟮α⟯ = n := by
+  rw [IntermediateField.adjoin.finrank (isIntegral_root hp hn hα),
+    minpoly_eq_X_pow_sub_C hp hn hα, natDegree_X_pow_sub_C]
+
+/-- **Eisenstein produces an algebraic number of every prescribed degree.**
+For every prime `p` and every `n ≥ 1`, the real `n`-th root `p^{1/n}` is
+algebraic over `ℚ` of degree exactly `n`. -/
+theorem exists_algebraic_number_of_degree {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n) :
+    ∃ α : ℝ, IsIntegral ℚ α ∧ Module.finrank ℚ ℚ⟮α⟯ = n := by
+  have hα : ((p : ℝ) ^ ((n : ℝ)⁻¹)) ^ n = (p : ℝ) :=
+    Real.rpow_inv_natCast_pow (by positivity) hn.ne'
+  exact ⟨(p : ℝ) ^ ((n : ℝ)⁻¹), isIntegral_root hp hn hα, finrank_adjoin_eq hp hn hα⟩
+
+/-! ### Concrete instances -/
+
+/-- `minpoly ℚ (√2) = X² − 2`. -/
+theorem minpoly_sqrt_two : minpoly ℚ (Real.sqrt 2) = (X : ℚ[X]) ^ 2 - C 2 := by
+  have hα : Real.sqrt 2 ^ 2 = ((2 : ℕ) : ℝ) := by
+    rw [Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]; norm_num
+  have h := minpoly_eq_X_pow_sub_C Nat.prime_two (by norm_num) hα
+  simpa using h
+
+/-- `[ℚ(√2) : ℚ] = 2`. -/
+theorem finrank_adjoin_sqrt_two : Module.finrank ℚ ℚ⟮(Real.sqrt 2)⟯ = 2 := by
+  have hα : Real.sqrt 2 ^ 2 = ((2 : ℕ) : ℝ) := by
+    rw [Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]; norm_num
+  exact finrank_adjoin_eq Nat.prime_two (by norm_num) hα
+
+/-- `[ℚ(∛2) : ℚ] = 3`. -/
+theorem finrank_adjoin_cbrt_two :
+    Module.finrank ℚ ℚ⟮((2 : ℝ) ^ (((3 : ℕ) : ℝ)⁻¹))⟯ = 3 := by
+  have hα : ((2 : ℝ) ^ (((3 : ℕ) : ℝ)⁻¹)) ^ 3 = ((2 : ℕ) : ℝ) := by
+    have h := Real.rpow_inv_natCast_pow (x := (2 : ℝ)) (n := 3) (by norm_num) (by norm_num)
+    simpa using h
+  exact finrank_adjoin_eq Nat.prime_three (by norm_num) hα
+
+end EisensteinCriterionOQ01OQ02

--- a/proofs/Proofs/EisensteinCriterionOQ01OQ02.lean
+++ b/proofs/Proofs/EisensteinCriterionOQ01OQ02.lean
@@ -116,6 +116,6 @@ theorem finrank_adjoin_cbrt_two :
   have hα : ((2 : ℝ) ^ (((3 : ℕ) : ℝ)⁻¹)) ^ 3 = ((2 : ℕ) : ℝ) := by
     have h := Real.rpow_inv_natCast_pow (x := (2 : ℝ)) (n := 3) (by norm_num) (by norm_num)
     simpa using h
-  exact finrank_adjoin_eq Nat.prime_three (by norm_num) hα
+  exact finrank_adjoin_eq Nat.prime_two (by norm_num) hα
 
 end EisensteinCriterionOQ01OQ02

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-02/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "eisenstein-criterion-oq-01-oq-02-module-header",
+    "proofId": "eisenstein-criterion-oq-01-oq-02",
+    "type": "concept",
+    "range": { "startLine": 1, "endLine": 22 },
+    "title": "Module Header: Degree of ℚ(ⁿ√p)",
+    "content": "The parent entry proves $X^n - p$ irreducible over $\\mathbb{Z}$. This file draws the field-theoretic corollary: Gauss's lemma lifts that to $\\mathbb{Q}$, so $X^n - p$ is the **minimal polynomial** over $\\mathbb{Q}$ of the real $n$-th root $p^{1/n}$, giving $[\\mathbb{Q}(p^{1/n}) : \\mathbb{Q}] = n$. Eisenstein thus produces a real algebraic number of every prescribed degree $n \\ge 1$, with concrete instances $[\\mathbb{Q}(\\sqrt2):\\mathbb{Q}] = 2$ and $[\\mathbb{Q}(\\sqrt[3]2):\\mathbb{Q}] = 3$.",
+    "mathContext": "$p$ prime, $n \\ge 1$, $\\alpha^n = p \\Rightarrow \\operatorname{minpoly}_{\\mathbb Q}\\alpha = X^n - p$ and $[\\mathbb Q(\\alpha):\\mathbb Q] = n$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "minimal polynomial",
+      "field extension degree",
+      "radical extension",
+      "algebraic numbers of every degree"
+    ],
+    "prerequisites": [
+      "Eisenstein's criterion",
+      "Gauss's lemma",
+      "simple field extensions"
+    ]
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-02-irreducible-rat",
+    "proofId": "eisenstein-criterion-oq-01-oq-02",
+    "type": "technique",
+    "range": { "startLine": 32, "endLine": 54 },
+    "title": "Irreducibility over ℚ via Gauss's Lemma",
+    "content": "The single new algebraic input. Since $X^n - p$ is monic it is **primitive**, and primitive-polynomial Gauss's lemma (`IsPrimitive.Int.irreducible_iff_irreducible_map_cast`) says it is irreducible over $\\mathbb{Z}$ iff its image in $\\mathbb{Q}[X]$ is. The image of $X^n - C\\,p$ under $\\mathbb{Z} \\to \\mathbb{Q}$ is again $X^n - C\\,p$ (closed by `simp`), so the parent's $\\mathbb{Z}$-irreducibility transfers to $\\mathbb{Q}$ for **every** exponent $n$, not just prime $n$.",
+    "mathContext": "$f$ primitive over $\\mathbb Z$: $\\operatorname{Irreducible} f \\iff \\operatorname{Irreducible}(f \\otimes \\mathbb Q)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gauss's lemma",
+      "primitive polynomial",
+      "content of a polynomial"
+    ],
+    "prerequisites": [
+      "primitive polynomials",
+      "fraction fields"
+    ]
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-02-minpoly",
+    "proofId": "eisenstein-criterion-oq-01-oq-02",
+    "type": "technique",
+    "range": { "startLine": 56, "endLine": 78 },
+    "title": "Identifying the Minimal Polynomial",
+    "content": "A monic irreducible polynomial that vanishes at $\\alpha$ **is** the minimal polynomial of $\\alpha$ (`minpoly.eq_of_irreducible_of_monic`). Here $\\operatorname{aeval}_\\alpha(X^n - C\\,p) = \\alpha^n - p = 0$ for any real $\\alpha$ with $\\alpha^n = p$, the polynomial is monic (`monic_X_pow_sub_C`) and irreducible over $\\mathbb{Q}$, so $\\operatorname{minpoly}_{\\mathbb Q}\\alpha = X^n - p$. Integrality of $\\alpha$ then follows from `minpoly.ne_zero_iff` applied to this monic minimal polynomial.",
+    "mathContext": "$f$ monic irreducible, $f(\\alpha)=0 \\Rightarrow f = \\operatorname{minpoly}_K\\alpha$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "minimal polynomial",
+      "integral element",
+      "monic polynomial"
+    ],
+    "prerequisites": [
+      "minimal polynomials over a field",
+      "integral elements"
+    ]
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-02-degree",
+    "proofId": "eisenstein-criterion-oq-01-oq-02",
+    "type": "main-result",
+    "range": { "startLine": 83, "endLine": 98 },
+    "title": "The Extension Degree Equals the Exponent",
+    "content": "For $\\alpha$ integral over $K$, $\\dim_K K\\langle\\alpha\\rangle = \\deg(\\operatorname{minpoly}_K\\alpha)$ (`IntermediateField.adjoin.finrank`). Substituting the identified minimal polynomial and $\\operatorname{natDegree}(X^n - p) = n$ gives $[\\mathbb{Q}(\\alpha) : \\mathbb{Q}] = n$. Taking $\\alpha = p^{1/n}$ (via `Real.rpow_inv_natCast_pow`) shows **Eisenstein furnishes a real algebraic number of every prescribed degree** $n \\ge 1$.",
+    "mathContext": "$[\\mathbb Q(p^{1/n}):\\mathbb Q] = \\operatorname{natDegree}(X^n - p) = n$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "degree of a field extension",
+      "radical extension",
+      "algebraic numbers of every degree"
+    ],
+    "prerequisites": [
+      "simple field extensions",
+      "finite-dimensional extensions"
+    ]
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-02-instances",
+    "proofId": "eisenstein-criterion-oq-01-oq-02",
+    "type": "example",
+    "range": { "startLine": 100, "endLine": 119 },
+    "title": "Concrete Instances: √2 and ∛2",
+    "content": "Instantiations of the general lemma. With $p = 2$, $n = 2$ and $(\\sqrt2)^2 = 2$ (`Real.sq_sqrt`): $\\operatorname{minpoly}_{\\mathbb Q}(\\sqrt2) = X^2 - 2$ and $[\\mathbb{Q}(\\sqrt2):\\mathbb{Q}] = 2$. With $p = 2$, $n = 3$ and $(2^{1/3})^3 = 2$: $[\\mathbb{Q}(\\sqrt[3]2):\\mathbb{Q}] = 3$. All three are single-line specializations of the arbitrary-root theorems above.",
+    "mathContext": "$\\operatorname{minpoly}_{\\mathbb Q}\\sqrt2 = X^2-2$; $[\\mathbb Q(\\sqrt2):\\mathbb Q]=2$; $[\\mathbb Q(\\sqrt[3]2):\\mathbb Q]=3$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "quadratic irrational",
+      "cube root",
+      "concrete extension degree"
+    ],
+    "prerequisites": [
+      "real n-th roots",
+      "square roots in ℝ"
+    ]
+  }
+]

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-02/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-02/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "eisenstein-criterion-oq-01-oq-02",
+  "title": "Degree of ℚ(ⁿ√p): the Minimal Polynomial Xⁿ − p",
+  "slug": "eisenstein-criterion-oq-01-oq-02",
+  "description": "The field-theoretic corollary of Eisenstein irreducibility. Building on the parent entry's proof that Xⁿ − p is irreducible over ℤ (eisenstein-criterion-oq-01), Gauss's lemma transports that irreducibility to ℚ, so for any real α with αⁿ = p the monic irreducible Xⁿ − p is the minimal polynomial of α over ℚ; hence [ℚ(p^{1/n}) : ℚ] = n. This answers the parent's stated open question: Eisenstein furnishes a real algebraic number of every prescribed degree n ≥ 1. Concrete instances [ℚ(√2):ℚ] = 2 and [ℚ(∛2):ℚ] = 3, plus minpoly ℚ (√2) = X² − 2. 9 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(field_theory)",
+    "date": "Gotthold Eisenstein, 1850 (field-degree corollary is classical)",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "irreducibility",
+      "number-theory",
+      "field-theory",
+      "minimal-polynomial",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/EisensteinCriterionOQ01OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+        "description": "Gauss's lemma over ℤ: a primitive integer polynomial is irreducible over ℤ iff its image in ℚ[X] is irreducible. Transports the parent's ℤ-irreducibility of Xⁿ − p to ℚ.",
+        "module": "Mathlib.RingTheory.Polynomial.GaussLemma"
+      },
+      {
+        "theorem": "minpoly.eq_of_irreducible_of_monic",
+        "description": "A monic irreducible polynomial vanishing at x equals minpoly A x. Combined with monicity, ℚ-irreducibility, and aeval α (Xⁿ − p) = 0 it identifies the minimal polynomial of the n-th root.",
+        "module": "Mathlib.FieldTheory.Minpoly.Field"
+      },
+      {
+        "theorem": "IntermediateField.adjoin.finrank",
+        "description": "For x integral over K, finrank K K⟮x⟯ = (minpoly K x).natDegree. Turns the identified minimal polynomial into the degree of the extension.",
+        "module": "Mathlib.FieldTheory.IntermediateField.Adjoin.Basic"
+      },
+      {
+        "theorem": "Polynomial.natDegree_X_pow_sub_C / Polynomial.monic_X_pow_sub_C",
+        "description": "natDegree (Xⁿ − C r) = n and monicity of Xⁿ − C r, supplying the degree value n and the monic hypothesis of the minimal-polynomial identification.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Operations"
+      },
+      {
+        "theorem": "Real.rpow_inv_natCast_pow / Real.sq_sqrt",
+        "description": "(x^{1/n})ⁿ = x for x ≥ 0, n ≠ 0, and (√x)² = x for x ≥ 0. Provide the concrete real n-th roots witnessing αⁿ = p for the existence theorem and the √2 / ∛2 instances.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "assumptions": "None. All 9 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide is used. Build note: under the current shared-cache build infrastructure the file elaborates cleanly ([7744/7744], ~1.5s, no type errors) but the Docker olean-write stage intermittently hits the environmental SIGBUS (exit 135) / dependency .ir corruption affecting the whole fleet; this is a memory/serialization issue, not a proof error.",
+    "originalContributions": [
+      "irreducible_X_pow_sub_C_prime_rat: Xⁿ − p is irreducible over ℚ for every prime p and n ≥ 1, via Gauss's lemma from the parent's ℤ-irreducibility (works for all n, not just prime n)",
+      "aeval_root: any real α with αⁿ = p is a root of Xⁿ − p over ℚ",
+      "minpoly_eq_X_pow_sub_C: the minimal polynomial over ℚ of any real α with αⁿ = p is exactly Xⁿ − p",
+      "isIntegral_root: such an α is integral over ℚ",
+      "finrank_adjoin_eq: [ℚ(α) : ℚ] = n for any real α with αⁿ = p (prime p, n ≥ 1)",
+      "exists_algebraic_number_of_degree: for every prime p and n ≥ 1 the real n-th root p^{1/n} is algebraic over ℚ of degree exactly n — Eisenstein produces algebraic numbers of every prescribed degree",
+      "minpoly_sqrt_two: minpoly ℚ (√2) = X² − 2",
+      "finrank_adjoin_sqrt_two: [ℚ(√2) : ℚ] = 2",
+      "finrank_adjoin_cbrt_two: [ℚ(∛2) : ℚ] = 3"
+    ],
+    "dateAdded": "2026-07-09",
+    "lineCount": 121,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Eisenstein's criterion (1850; Schönemann 1846) is the standard elementary irreducibility test. Its most cited application is that Xⁿ − p is irreducible for prime p, which — via the theory of minimal polynomials and simple field extensions — shows that the real n-th root ⁿ√p generates a degree-n extension of ℚ. This is the textbook route to exhibiting algebraic numbers of arbitrarily large prescribed degree, and one of the first worked examples in any Galois-theory course.",
+    "problemStatement": "**Open Question (OQ-01-OQ-02)**: On top of the gallery's Eisenstein entry (Xⁿ − p irreducible over ℤ) and Mathlib, formalize that Xⁿ − p is the minimal polynomial over ℚ of the real n-th root p^{1/n} (prime p, n ≥ 1), and derive [ℚ(p^{1/n}) : ℚ] = n, including at least one concrete instance.\n\n**Formalized**: irreducibility over ℚ (irreducible_X_pow_sub_C_prime_rat), the minimal-polynomial identification (minpoly_eq_X_pow_sub_C), the degree formula (finrank_adjoin_eq), the every-degree existence statement (exists_algebraic_number_of_degree), and the concrete instances [ℚ(√2):ℚ] = 2 and [ℚ(∛2):ℚ] = 3.",
+    "text": "A 121-line formalization that closes the loop from irreducibility to field degree. The parent entry proved Xⁿ − p irreducible over ℤ; the single new algebraic input here is Gauss's lemma (Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast), which — since Xⁿ − p is monic, hence primitive — transports irreducibility to ℚ for every n ≥ 1. From there the argument is pure field theory: Xⁿ − p is monic and irreducible over ℚ and vanishes at any real α with αⁿ = p, so minpoly.eq_of_irreducible_of_monic identifies it as the minimal polynomial, and IntermediateField.adjoin.finrank reads off [ℚ(α):ℚ] = natDegree(Xⁿ − p) = n. The main theorems are stated for an arbitrary real root α (any α with αⁿ = p), then instantiated by Real.rpow for the general existence statement and by √2 / ∛2 for the concrete degrees. All 9 theorems compile with 0 sorries and 0 axioms, no native_decide.",
+    "proofStrategy": "**Irreducibility over ℚ (irreducible_X_pow_sub_C_prime_rat)**: from the parent's Irreducible ((X:ℤ[X])ⁿ − C p) with p prime; Xⁿ − p is monic hence IsPrimitive, and its image under Int.castRingHom ℚ is (X:ℚ[X])ⁿ − C p (by simp), so Gauss's lemma gives ℚ-irreducibility.\n\n**Minimal polynomial (minpoly_eq_X_pow_sub_C)**: aeval α (Xⁿ − C p) = αⁿ − p = 0 (aeval_root), the polynomial is monic (monic_X_pow_sub_C) and irreducible over ℚ; minpoly.eq_of_irreducible_of_monic yields Xⁿ − p = minpoly ℚ α.\n\n**Degree (finrank_adjoin_eq)**: α is integral over ℚ (minpoly.ne_zero_iff applied to the monic minimal polynomial); IntermediateField.adjoin.finrank rewrites finrank ℚ ℚ⟮α⟯ to (minpoly ℚ α).natDegree, then substitute the minimal polynomial and natDegree_X_pow_sub_C to get n.\n\n**Existence and instances**: exists_algebraic_number_of_degree takes α = p^{1/n} with (p^{1/n})ⁿ = p from Real.rpow_inv_natCast_pow; the √2 instance uses Real.sq_sqrt and the ∛2 instance uses Real.rpow_inv_natCast_pow with p = 2, n = 3.",
+    "keyInsights": [
+      "**Gauss's lemma is the only new algebraic input.** All the hard work (irreducibility of Xⁿ − p) is done over ℤ in the parent; passing to ℚ is a single application of primitive-polynomial Gauss's lemma, and it works for every exponent n, not just prime n.",
+      "**Irreducible + monic + vanishing ⇒ minimal polynomial.** The minimal polynomial is characterized abstractly: any monic irreducible polynomial that kills α must be minpoly ℚ α. No explicit degree computation of the extension is needed beyond reading off natDegree.",
+      "**Degree equals the exponent.** [ℚ(p^{1/n}) : ℚ] = natDegree(Xⁿ − p) = n, so Eisenstein delivers a real algebraic number of every prescribed degree — the constructive content of 'algebraic numbers of unbounded degree exist'.",
+      "**One theorem, any root.** The core results are stated for an arbitrary real α with αⁿ = p, so √2, ∛2, and the general rpow root are all instances of a single lemma rather than separate proofs.",
+      "**0-axiom, no native_decide.** Every result is kernel-elaborated, depending only on propext / Classical.choice / Quot.sound, which do not count as assumptions."
+    ],
+    "prerequisites": [
+      "Eisenstein's criterion and the irreducibility of Xⁿ − p over ℤ (parent entry eisenstein-criterion-oq-01)",
+      "Gauss's lemma: primitive polynomials and irreducibility over ℤ vs its fraction field ℚ",
+      "Minimal polynomials over a field; the characterization minpoly.eq_of_irreducible_of_monic",
+      "Simple field extensions K⟮α⟯ and the degree formula finrank K K⟮α⟯ = (minpoly K α).natDegree",
+      "Real n-th roots via rpow and √; (x^{1/n})ⁿ = x and (√x)² = x for x ≥ 0"
+    ]
+  },
+  "conclusion": {
+    "summary": "Formalizes the field-degree corollary of Eisenstein irreducibility: for every prime p and n ≥ 1, Xⁿ − p is the minimal polynomial over ℚ of the real n-th root p^{1/n}, so [ℚ(p^{1/n}) : ℚ] = n. Gauss's lemma lifts the parent's ℤ-irreducibility to ℚ, and the minimal-polynomial / adjoin-degree API of Mathlib does the rest. Concrete instances [ℚ(√2):ℚ] = 2 and [ℚ(∛2):ℚ] = 3, plus minpoly ℚ (√2) = X² − 2. All 9 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "Directly answers the parent entry's stated open question ('state the consequence for field degrees'). The result is the standard construction of algebraic numbers of arbitrary degree and a foundational example for field-extension towers and Galois theory. The abstract lemma (minpoly ℚ α = Xⁿ − p for any α with αⁿ = p) can be reused for any real radical p^{1/n} in downstream extension-degree computations.",
+    "openQuestions": [
+      "Compute the Galois group of Xⁿ − p over ℚ (for n where it is not automatically cyclic, this requires adjoining roots of unity) and the degree [ℚ(ζₙ, p^{1/n}) : ℚ].",
+      "Extend the minimal-polynomial identification to Xⁿ − a for non-prime a that is not a perfect k-th power for any k ∣ n (general Kummer-extension irreducibility, partially covered by Mathlib's KummerExtension)."
+    ]
+  },
+  "references": [
+    {
+      "text": "Minimal polynomial (field theory): a monic irreducible polynomial vanishing at α is the minimal polynomial of α, and [K(α):K] = deg(minpoly).",
+      "url": "https://en.wikipedia.org/wiki/Minimal_polynomial_(field_theory)"
+    },
+    {
+      "text": "Dummit, D. & Foote, R. Abstract Algebra. Eisenstein's criterion, Gauss's lemma, and degrees of radical extensions ℚ(ⁿ√p).",
+      "url": "https://en.wikipedia.org/wiki/Eisenstein%27s_criterion"
+    },
+    {
+      "text": "Mathlib4: Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast (Gauss's lemma), minpoly.eq_of_irreducible_of_monic, IntermediateField.adjoin.finrank, Polynomial.natDegree_X_pow_sub_C, Real.rpow_inv_natCast_pow.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "crossReferences": [
+    "eisenstein-criterion-oq-01"
+  ],
+  "sorries": [],
+  "mainTheorems": [
+    "minpoly_eq_X_pow_sub_C",
+    "finrank_adjoin_eq",
+    "exists_algebraic_number_of_degree"
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.EisensteinCriterionOQ01"
+    ],
+    "namespace": "EisensteinCriterionOQ01OQ02",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/EisensteinCriterionOQ01OQ02.lean",
+    "sorries": 0
+  }
+}

--- a/src/data/research/problems/eisenstein-criterion-oq-01-oq-02.json
+++ b/src/data/research/problems/eisenstein-criterion-oq-01-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "eisenstein-criterion-oq-01-oq-02",
   "title": "Degree of Q(n-th root of p): minimal polynomial X^n - p via Eisenstein",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -52,5 +52,15 @@
   },
   "significance": 6,
   "tractability": 6,
-  "category": "extension"
+  "category": "extension",
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-4, 2026-07-09). Formalized the field-degree corollary in proofs/Proofs/EisensteinCriterionOQ01OQ02.lean (9 theorems, 0 sorries, 0 axioms, no native_decide). Gauss lemma (Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast) lifts the parent EisensteinCriterionOQ01.irreducible_X_pow_sub_C_prime from ℤ to ℚ for every n≥1; minpoly.eq_of_irreducible_of_monic identifies Xⁿ−p as minpoly ℚ α for any real α with αⁿ=p; IntermediateField.adjoin.finrank + natDegree_X_pow_sub_C give [ℚ(α):ℚ]=n. exists_algebraic_number_of_degree instantiates α=p^(1/n) via Real.rpow_inv_natCast_pow. Concrete: minpoly ℚ(√2)=X²−2, [ℚ(√2):ℚ]=2, [ℚ(∛2):ℚ]=3. Gallery entry created. Answers the parent OQ-01 stated open question on field degrees.",
+    "nextAction": null,
+    "insights": [
+      "Gauss lemma is the only new algebraic input: the parent already did the hard ℤ-irreducibility; passing to ℚ is one application of primitive-polynomial Gauss lemma and works for ALL n (not just prime n).",
+      "minpoly.eq_of_irreducible_of_monic characterizes the minimal polynomial abstractly (monic + irreducible + vanishing ⇒ = minpoly); no explicit extension-degree computation is needed beyond reading natDegree.",
+      "Stating the core theorems for an arbitrary real root α (any α with αⁿ=p) makes √2, ∛2, and the general rpow root all one-line instances of a single lemma.",
+      "Build infra note: file elaborates cleanly ([7744/7744] ~1.5s, no type errors) but Docker olean-write intermittently SIGBUS-135 / hits fleet-race dependency .ir corruption; environmental, not a proof error."
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Formalizes the field-theoretic corollary of Eisenstein irreducibility, answering the parent entry's (`eisenstein-criterion-oq-01`) stated open question on field degrees.

For a prime `p` and `n ≥ 1`, and any real `α` with `αⁿ = p`:
- **`Xⁿ − p` is irreducible over ℚ** (`irreducible_X_pow_sub_C_prime_rat`) — Gauss's lemma lifts the parent's ℤ-irreducibility to ℚ, for *every* `n` (not just prime `n`).
- **`minpoly ℚ α = Xⁿ − p`** (`minpoly_eq_X_pow_sub_C`) — monic + irreducible + vanishing.
- **`[ℚ(p^{1/n}) : ℚ] = n`** (`finrank_adjoin_eq`) — `adjoin.finrank` + `natDegree_X_pow_sub_C`.
- **Eisenstein produces an algebraic number of every prescribed degree** (`exists_algebraic_number_of_degree`), via `Real.rpow_inv_natCast_pow`.

Concrete instances: `minpoly ℚ (√2) = X² − 2`, `[ℚ(√2):ℚ] = 2`, `[ℚ(∛2):ℚ] = 3`.

## Files
- `proofs/Proofs/EisensteinCriterionOQ01OQ02.lean` — 9 theorems, 0 defs, **0 sorries, 0 axioms**, no `native_decide`. Imports `Proofs.EisensteinCriterionOQ01`.
- `src/data/proofs/eisenstein-criterion-oq-01-oq-02/{meta.json,annotations.json}` — gallery entry (`status: verified`, `badge: mathlib`).
- Research knowledge JSON marked solved.

## Verification

The Lean file **elaborates cleanly** — Docker reaches `[7744/7744] Building Proofs.EisensteinCriterionOQ01OQ02 (~1.5s)` with no located type error. The only genuine error found during development (a wrong prime in the ∛2 instance, `lean:119:56`) was fixed in commit `ae1ea16`. The Docker **olean-write** stage then intermittently hits the environmental `SIGBUS` (exit 135) / fleet-race dependency `.ir` corruption documented across recent sessions — a memory/serialization issue, not a proof error. Gallery meta + annotations pass `annotations:build --strict` and `gallery:check-size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)