### PR TITLE
audit(lagrange-theorem-oq-03): disclose Lean.ofReduceBool from native_decide (axiomCount 2→3)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21883,10 +21883,10 @@
       "issues": []
     },
     "lagrange-theorem-oq-03": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:02Z",
-      "result": "clean"
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:05:25Z",
+      "result": "issues-fixed"
     },
     "lagrange-theorem-oq-03-oq-02": {
       "auditCount": 1,
@@ -22079,9 +22079,9 @@
       "result": "clean"
     },
     "laws-of-large-numbers-oq-01": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:02Z",
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:05:25Z",
       "result": "clean"
     },
     "laws-of-large-numbers-oq-01-oq-01": {
@@ -22121,9 +22121,9 @@
       "issues": []
     },
     "lebesgue-measure": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:02Z",
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:05:25Z",
       "result": "clean"
     },
     "lebesgue-measure-oq-01": {
@@ -22268,9 +22268,9 @@
       "issues": []
     },
     "leibniz-pi": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:02Z",
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:05:25Z",
       "result": "clean"
     },
     "leibniz-pi-oq-01": {
@@ -22750,9 +22750,9 @@
       "issues": []
     },
     "mean-value-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:57:34Z",
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:05:25Z",
       "result": "clean"
     },
     "mean-value-theorem-oq-02": {
@@ -22792,9 +22792,9 @@
       "issues": []
     },
     "mean-value-theorem-oq-03": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:01Z",
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:05:25Z",
       "result": "clean"
     },
     "mean-value-theorem-oq-04": {
@@ -29732,5 +29732,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T23:47:20Z"
+  "lastUpdated": "2026-07-10T00:05:25Z"
 }

--- a/src/data/proofs/lagrange-theorem-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-03/meta.json
@@ -60,9 +60,9 @@
     "dateAdded": "2026-03-11",
     "mathlib_version": "4.26.0",
     "axioms": 3,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 373,
-    "assumptions": "2 axiom(s): hall_existence, hall_conjugacy. See Lean source for complete statements.",
+    "assumptions": "3 assumptions: 2 axioms (hall_existence, hall_conjugacy — Hall's theorem on the existence and conjugacy of Hall subgroups in finite solvable groups) plus Lean.ofReduceBool, introduced by native_decide in the A₄ counterexample theorems a4_card (|A₄| = 12) and a4_squares_card (9 distinct squares). See Lean source for complete statements. (leanFile.axiomCount = 2 counts only the literal axiom declarations.)",
     "theoremCount": 27,
     "definitionCount": 1
   },
@@ -188,7 +188,7 @@
     "implications": "**Theoretical Significance**: Hall's theorem is foundational for the structure theory of solvable groups, providing a complete description of which subgroup orders are realized.\n\nThe Schur-Zassenhaus complement gives semidirect product decompositions $G \\cong N \\rtimes K$ for normal Hall subgroups. In applications, Hall subgroups appear in the classification of finite solvable groups (Hall's theorem is the solvable-group analogue of the Sylow theorems) and in computational group theory where finding Hall subgroups is a key algorithmic primitive.",
     "openQuestions": [
       "Can Hall existence be proved constructively in Lean using derived series induction?",
-      "Can the A₄ counterexample be computationally verified using native_decide on the explicit group table?",
+      "The A₄ counterexample is already verified computationally via native_decide (a4_card, a4_squares_card, relying on Lean.ofReduceBool); can the same cardinalities be established by a kernel-checkable decide or an explicit combinatorial proof that avoids the compiler-trust axiom?",
       "What is the relationship between Hall subgroups and Burnside's p^a·q^b theorem for solvable groups of order p^a·q^b?",
       "Can the formalization be extended to π-separable groups (Chunikhin's generalization of Hall's theorem)?"
     ]


### PR DESCRIPTION
## Auditor finding — lagrange-theorem-oq-03

Deep re-audit of the stalest gallery entries (last audited 2026-05-03). One genuine integrity issue found; five sibling entries re-verified clean.

### Issue fixed: undisclosed `Lean.ofReduceBool`
`Proofs/LagrangeTheoremOQ03.lean` uses `native_decide` in **two named, substantive theorems** — not example blocks:
- `a4_card : Fintype.card (alternatingGroup (Fin 4)) = 12` (line 167)
- `a4_squares_card : ... = 9` (line 195)

These are the computational core of the A₄ counterexample to the converse of Lagrange's theorem. Per the Axiom Integrity Policy, `native_decide` trusts the compiler kernel and depends on `Lean.ofReduceBool`, which must be disclosed and counted.

Before this PR the entry had:
- `meta.axiomCount: 2` (only the 2 real axioms `hall_existence`, `hall_conjugacy`)
- `assumptions`: "2 axiom(s): ..." — no mention of `Lean.ofReduceBool`
- an open question literally asking whether the A₄ counterexample *can* be verified via `native_decide` — when it already **is**

Changes (meta.json only, source unchanged):
- `meta.axiomCount` 2 → 3 (2 axioms + `Lean.ofReduceBool`); `meta.axioms` was already 3, now consistent
- `assumptions` rewritten to disclose `Lean.ofReduceBool` and name the two `native_decide` theorems
- corrected the stale open question (the computational verification already exists)

**Detector-safe:** `leanFile.axiomCount` stays 2 (literal `axiom` declarations only). The detector compares `actual (2) > claimed (3)` → false, so no false positive. `status: axiomatized` / `badge: axiom` unchanged. This mirrors #36475 (partition-theorem-oq-01) and #36496 (legendre-partial).

### Re-verified CLEAN (tracker bump only)
Counts, badge/status, Mathlib deps, and contributions all match source:
- **mean-value-theorem** — 163 lines, 4 thm, 0 def/axiom/sorry, badge mathlib ✓ (previously covered by closed PR #36488, never persisted)
- **mean-value-theorem-oq-03** — 461 lines, 17 thm, 0 axiom ✓
- **lebesgue-measure** — 417 lines, 20 thm, 0 axiom ✓
- **leibniz-pi** — 178 lines, 9 thm, 1 def, 0 axiom ✓
- **laws-of-large-numbers-oq-01** — 403 lines, 13 thm, 1 axiom (disclosed), no native_decide ✓

Tracker `lastAudited` bumped for all six (the 2026-05-03 batch timestamps kept re-serving them because prior audit PRs lost their bumps to the git-tracked-tracker race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)