### PR TITLE
Enrich binomial moments (combinations-formula-oq-09): add mathContext to all sections

### DIFF
--- a/src/data/proofs/combinations-formula-oq-09/meta.json
+++ b/src/data/proofs/combinations-formula-oq-09/meta.json
@@ -56,35 +56,40 @@
       "title": "Open Question and Mathematical Context",
       "startLine": 1,
       "endLine": 44,
-      "summary": "Header stating OQ-09: the first and second moments of a binomial row, their probabilistic meaning (mean n/2, variance n/4 of Binomial(n,½)), and the absorption-identity method."
+      "summary": "Header stating OQ-09: the first and second moments of a binomial row, their probabilistic meaning (mean n/2, variance n/4 of Binomial(n,½)), and the absorption-identity method.",
+      "mathContext": "First moment $\\sum_{k=0}^{n} k\\binom{n}{k} = n\\,2^{n-1}$ and second moment $\\sum_{k=0}^{n} k^2\\binom{n}{k} = n(n+1)\\,2^{n-2}$; dividing by $2^n$ gives the mean $n/2$ and $\\mathbb{E}[k^2] = n(n+1)/4$ of $\\mathrm{Binomial}(n,\\tfrac12)$."
     },
     {
       "id": "absorb",
       "title": "Absorption Identity",
       "startLine": 46,
       "endLine": 57,
-      "summary": "absorb: (k+1)·C(n+1,k+1) = (n+1)·C(n,k), Mathlib's Nat.add_one_mul_choose_eq with sides commuted — the single workhorse for both moments."
+      "summary": "absorb: (k+1)·C(n+1,k+1) = (n+1)·C(n,k), Mathlib's Nat.add_one_mul_choose_eq with sides commuted — the single workhorse for both moments.",
+      "mathContext": "$(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$: absorb the factor $k+1$ into the coefficient, trading it for the row index $n+1$ — the identity $k\\binom{n}{k} = n\\binom{n-1}{k-1}$ in shifted form."
     },
     {
       "id": "first-moment",
       "title": "First Moment",
       "startLine": 59,
       "endLine": 78,
-      "summary": "sum_range_succ_mul_choose: ∑_{k≤n+1} k·C(n+1,k) = (n+1)·2^n (peel k=0, apply absorb, sum_range_choose); sum_range_mul_choose: the classic ∑_{k≤n} k·C(n,k) = n·2^{n-1}."
+      "summary": "sum_range_succ_mul_choose: ∑_{k≤n+1} k·C(n+1,k) = (n+1)·2^n (peel k=0, apply absorb, sum_range_choose); sum_range_mul_choose: the classic ∑_{k≤n} k·C(n,k) = n·2^{n-1}.",
+      "mathContext": "$\\sum_{k=0}^{n} k\\binom{n}{k} = n\\,2^{n-1}$: after peeling the $k=0$ term, absorption turns each summand into $(n+1)\\binom{n}{k}$, and $\\sum_k\\binom{n}{k} = 2^n$ closes it."
     },
     {
       "id": "second-moment",
       "title": "Second Moment",
       "startLine": 80,
       "endLine": 116,
-      "summary": "sum_range_succ_succ_sq_mul_choose: ∑_{k≤n+2} k²·C(n+2,k) = (n+2)(n+3)·2^n (k²=k·k, one absorption, split into first moment + row sum); sum_range_sq_mul_choose: the classic ∑_{k≤n} k²·C(n,k) = n(n+1)·2^{n-2} for n ≥ 2."
+      "summary": "sum_range_succ_succ_sq_mul_choose: ∑_{k≤n+2} k²·C(n+2,k) = (n+2)(n+3)·2^n (k²=k·k, one absorption, split into first moment + row sum); sum_range_sq_mul_choose: the classic ∑_{k≤n} k²·C(n,k) = n(n+1)·2^{n-2} for n ≥ 2.",
+      "mathContext": "$\\sum_{k=0}^{n} k^2\\binom{n}{k} = n(n+1)\\,2^{n-2}$ for $n \\ge 2$: absorption gives $(k+1)^2\\binom{n+2}{k+1} = (n+2)(k+1)\\binom{n+1}{k}$, and $\\sum(k+1)\\binom{n+1}{k}$ splits into the first moment plus the row sum $2^{n+1}$."
     },
     {
       "id": "checks",
       "title": "Sanity Checks",
       "startLine": 118,
       "endLine": 122,
-      "summary": "Worked numerical verifications at n = 4: ∑ k·C(4,k) = 32 = 4·2³ and ∑ k²·C(4,k) = 80 = 4·5·2²."
+      "summary": "Worked numerical verifications at n = 4: ∑ k·C(4,k) = 32 = 4·2³ and ∑ k²·C(4,k) = 80 = 4·5·2².",
+      "mathContext": "Row $n=4$: $\\sum_k k\\binom{4}{k} = 32 = 4\\cdot 2^3$ and $\\sum_k k^2\\binom{4}{k} = 80 = 4\\cdot 5\\cdot 2^2$, both closed by $\\texttt{decide}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass on `combinations-formula-oq-09` (quality 95, pass 0). Already well-annotated (all annotations carry mathContext), 4 keyInsights, contiguous sections covering the full 122-line file, verified 0 axioms / 0 sorries. Consistent gap: **none of the 5 `sections` had a `mathContext` field.**

**Change:** add accurate LaTeX `mathContext` to each section:
- header: first moment `∑ k·C(n,k) = n·2^(n-1)`, second moment `∑ k²·C(n,k) = n(n+1)·2^(n-2)`, and the Binomial(n,½) mean/second-moment reading;
- absorption: `(k+1)C(n+1,k+1) = (n+1)C(n,k)`;
- first moment: peel `k=0`, absorb, close with `∑C(n,k)=2^n`;
- second moment: `(k+1)²C(n+2,k+1) = (n+2)(k+1)C(n+1,k)`, split into first moment + row sum;
- checks: row-4 `32 = 4·2³`, `80 = 4·5·2²`.

Verified against the Lean file (5 theorems, 0 axioms, 0 sorries). No content removed. meta.json ~10 KB (far under 60 KB cap). JSON validated with jq.
