### PR TITLE
research(ballot-oq-05-oq-02): André reflection form reconciled to the cycle-lemma ballot number

### DIFF
--- a/proofs/Proofs/BallotProblemOQ05OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ05OQ02.lean
@@ -75,13 +75,16 @@ theorem reflectBallot_eq (a b : ℕ) (hb : 1 ≤ b) :
   have e1 : a + 1 + b - 1 = a + b := by omega
   have e2 : a + 1 - 1 = a := by omega
   simp only [reflectBallot, ballotNumber, e1, e2]
-  congr 1
-  · -- `C(a+b, b) = C(a+b, a)` via `k ↦ (a+b) − k` symmetry
-    have hba : b = (a + b) - a := by omega
-    rw [hba, Nat.choose_symm (Nat.le_add_right a b)]
-  · -- `C(a+b, b−1) = C(a+b, a+1)`, valid since `1 ≤ b`
-    have hba : b - 1 = (a + b) - (a + 1) := by omega
-    rw [hba, Nat.choose_symm (by omega : a + 1 ≤ a + b)]
+  -- `C(a+b, b) = C(a+b, a)` via `k ↦ (a+b) − k` symmetry
+  have h1 : (a + b).choose b = (a + b).choose a := by
+    have h := Nat.choose_symm (Nat.le_add_right a b)
+    rwa [Nat.add_sub_cancel_left] at h
+  -- `C(a+b, b−1) = C(a+b, a+1)`, valid since `1 ≤ b`
+  have h2 : (a + b).choose (b - 1) = (a + b).choose (a + 1) := by
+    have h := Nat.choose_symm (show a + 1 ≤ a + b by omega)
+    have e3 : a + b - (a + 1) = b - 1 := by omega
+    rwa [e3] at h
+  rw [h1, h2]
 
 /-- The reflection subtraction is **exact** for `b ≤ a`: `C(a+b, b−1) ≤ C(a+b, b)`, so
 `reflectBallot a b + C(a+b, b−1) = C(a+b, b)` with no `ℕ` truncation. -/

--- a/proofs/Proofs/BallotProblemOQ05OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ05OQ02.lean
@@ -1,0 +1,144 @@
+/-
+# The Reflection (André) Form of the Ballot Number, `C(a+b,b) − C(a+b,b−1)`
+
+The companion file `Proofs.BallotProblemOQ05` derives the **strict** Bertrand ballot
+number from the Dvoretzky–Motzkin cycle lemma and records it in the reflection form
+
+  `ballotNumber a b = C(a+b−1, a−1) − C(a+b−1, a)`,
+
+counting the sequences of `a` up-steps `(+1)` and `b` down-steps `(−1)` whose every
+partial sum is *strictly* positive.
+
+This file treats the *other* classical reflection form,
+
+  `reflectBallot a b = C(a+b, b) − C(a+b, b−1)`,
+
+which is the count of sequences whose every partial sum is `≥ 0` — the
+**non-negative** (weakly-ahead) ballot number, the entries of the Catalan triangle.
+The two are *not* the same sequence: e.g. `reflectBallot 2 1 = 2` while the strict
+`ballotNumber 2 1 = 1`.  The purpose of this file is to **reconcile** them.
+
+## Main result
+
+The non-negative and strict ballot numbers are related by the classical
+**prepend-an-up-step bijection**: a non-negative `(a, b)`-path becomes a strictly
+positive `(a+1, b)`-path by inserting a mandatory initial `+1`, and conversely.
+Arithmetically this is the single shift `a ↦ a + 1`:
+
+* `reflectBallot_eq` — `reflectBallot a b = ballotNumber (a+1) b`  (for `1 ≤ b`).
+
+Everything else is a corollary of this one identity together with the cycle-lemma
+arithmetic already proved in the parent file:
+
+* `reflectBallot_sub_exact` — the `ℕ` subtraction `C(a+b,b) − C(a+b,b−1)` is *exact*
+  (no truncation) whenever `b ≤ a`, because `C(a+b, b−1) ≤ C(a+b, b)` there.
+* `reflectBallot_mul` — the cycle-lemma aggregate for the non-negative count:
+  `reflectBallot a b · (a+1+b) = (a+1−b) · C(a+1+b, a+1)`.
+* `reflectBallot_div` — the corresponding probability `(a+1−b)/(a+1+b)` over `ℚ`.
+* `reflectBallot_catalan` — the diagonal `reflectBallot n n = catalan n` (`1 ≤ n`),
+  the number of Dyck paths of semilength `n`.
+
+The two reflection derivations therefore agree: the André count `C(a+b,b) − C(a+b,b−1)`
+is exactly the cycle-lemma count of the shifted parameters.  Elementary binomial
+arithmetic throughout — no axioms, no `sorry`, no `native_decide`.
+
+## References
+* André, D. (1887), *Solution directe du problème résolu par M. Bertrand*.
+* Renault, M. (2008), *Lost (and found) in translation: André's actual method*.
+-/
+import Mathlib
+import Proofs.BallotProblemOQ05
+
+namespace BallotProblemOQ05OQ02
+
+open BallotProblemOQ05
+
+/-- The **non-negative ballot number** `reflectBallot a b`, in André's reflection form.
+
+This counts the sequences of `a` up-steps `(+1)` and `b` down-steps `(−1)` whose every
+partial sum is `≥ 0` (weak dominance).  Equivalently these are the entries of the
+Catalan triangle; the diagonal `a = b` recovers the Catalan numbers. -/
+def reflectBallot (a b : ℕ) : ℕ :=
+  (a + b).choose b - (a + b).choose (b - 1)
+
+/-- **The reconciliation identity.**  For `1 ≤ b`, the non-negative ballot number is the
+strict ballot number of the parameters shifted by one up-step:
+
+  `reflectBallot a b = ballotNumber (a+1) b`.
+
+This is the arithmetic shadow of the **prepend-an-up-step bijection**: a non-negative
+`(a, b)`-path is precisely a strictly-positive `(a+1, b)`-path with its forced initial
+`+1` removed.  Both sides are reflection differences of the *same* binomials read
+through the symmetry `C(a+b, k) = C(a+b, a+b−k)`. -/
+theorem reflectBallot_eq (a b : ℕ) (hb : 1 ≤ b) :
+    reflectBallot a b = ballotNumber (a + 1) b := by
+  have e1 : a + 1 + b - 1 = a + b := by omega
+  have e2 : a + 1 - 1 = a := by omega
+  simp only [reflectBallot, ballotNumber, e1, e2]
+  congr 1
+  · -- `C(a+b, b) = C(a+b, a)` via `k ↦ (a+b) − k` symmetry
+    have hba : b = (a + b) - a := by omega
+    rw [hba, Nat.choose_symm (Nat.le_add_right a b)]
+  · -- `C(a+b, b−1) = C(a+b, a+1)`, valid since `1 ≤ b`
+    have hba : b - 1 = (a + b) - (a + 1) := by omega
+    rw [hba, Nat.choose_symm (by omega : a + 1 ≤ a + b)]
+
+/-- The reflection subtraction is **exact** for `b ≤ a`: `C(a+b, b−1) ≤ C(a+b, b)`, so
+`reflectBallot a b + C(a+b, b−1) = C(a+b, b)` with no `ℕ` truncation. -/
+theorem reflectBallot_sub_exact (a b : ℕ) (hb : 1 ≤ b) (hab : b ≤ a) :
+    reflectBallot a b + (a + b).choose (b - 1) = (a + b).choose b := by
+  have hle : (a + b).choose (b - 1) ≤ (a + b).choose b := by
+    -- Pascal ratio: `C(a+b, b) · b = C(a+b, b−1) · (a+1)`
+    have h := Nat.choose_succ_right_eq (a + b) (b - 1)
+    have eb : b - 1 + 1 = b := by omega
+    have ed : (a + b) - (b - 1) = a + 1 := by omega
+    rw [eb, ed] at h
+    -- h : C(a+b, b) * b = C(a+b, b−1) * (a+1)
+    have hstep : (a + b).choose (b - 1) * (a + 1) ≤ (a + b).choose b * (a + 1) := by
+      rw [← h]; gcongr; omega
+    exact Nat.le_of_mul_le_mul_right hstep (by omega)
+  simp only [reflectBallot]; omega
+
+/-- **Cycle-lemma aggregate for the non-negative count.**  Applying the parent file's
+`ballotNumber_mul_add` to the shifted parameters `(a+1, b)`:
+
+  `reflectBallot a b · (a+1+b) = (a+1−b) · C(a+1+b, a+1)`.
+
+So the André reflection number carries the same `(a′−b)/(a′+b)` cycle-lemma meaning at
+the shifted top count `a′ = a+1`; in particular `a+1+b` divides `(a+1−b)·C(a+1+b, a+1)`. -/
+theorem reflectBallot_mul (a b : ℕ) (hb : 1 ≤ b) :
+    reflectBallot a b * (a + 1 + b) = (a + 1 - b) * (a + 1 + b).choose (a + 1) := by
+  rw [reflectBallot_eq a b hb]
+  exact ballotNumber_mul_add (a + 1) b (by omega)
+
+/-- **Non-negative ballot probability.**  For `1 ≤ b ≤ a`, over `ℚ`:
+
+  `reflectBallot a b / C(a+1+b, a+1) = (a+1−b)/(a+1+b)`. -/
+theorem reflectBallot_div (a b : ℕ) (hb : 1 ≤ b) (hab : b ≤ a) :
+    (reflectBallot a b : ℚ) / (((a + 1) + b).choose (a + 1) : ℚ)
+      = (((a + 1 : ℕ) : ℚ) - b) / (((a + 1 : ℕ) : ℚ) + b) := by
+  rw [reflectBallot_eq a b hb]
+  exact ballotNumber_div (a + 1) b (by omega) (by omega)
+
+/-- **Catalan (Dyck-path) specialisation.**  On the diagonal `a = b = n` (`1 ≤ n`) the
+non-negative ballot number is the `n`-th Catalan number: the count of non-negative
+paths with `n` up- and `n` down-steps is the number of Dyck paths of semilength `n`. -/
+theorem reflectBallot_catalan (n : ℕ) (hn : 1 ≤ n) : reflectBallot n n = catalan n := by
+  rw [reflectBallot_eq n n hn]
+  exact ballotNumber_catalan n
+
+/-! ### Worked examples (checked by `decide`, hence `0`-axiom) -/
+
+/-- `a = 2, b = 1`: `C(3,1) − C(3,0) = 3 − 1 = 2` (vs. strict `ballotNumber 2 1 = 1`). -/
+example : reflectBallot 2 1 = 2 := by decide
+
+/-- `a = 3, b = 2`: `C(5,2) − C(5,1) = 10 − 5 = 5`. -/
+example : reflectBallot 3 2 = 5 := by decide
+
+/-- Diagonal `n = 2`: `C(4,2) − C(4,1) = 6 − 4 = 2 = catalan 2`. -/
+example : reflectBallot 2 2 = 2 := by decide
+
+/-- Diagonal `n = 3`: `C(6,3) − C(6,2) = 20 − 15 = 5 = catalan 3`. -/
+example : reflectBallot 3 3 = 5 := by decide
+
+end BallotProblemOQ05OQ02

--- a/src/data/proofs/ballot-problem-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-05-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ballot-oq0502-ann-header",
+    "proofId": "ballot-problem-oq-05-oq-02",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "Two reflection forms, two different counts",
+    "content": "The ballot problem carries two classical reflection formulas that count *different* objects. The sibling entry `BallotProblemOQ05` records the **strict** ballot number (candidate A always strictly ahead) as `ballotNumber a b = C(a+b-1,a-1) - C(a+b-1,a)`. This file treats the **non-negative** ballot number (A never behind, ties allowed), `reflectBallot a b = C(a+b,b) - C(a+b,b-1)` — the entries of the Catalan triangle. They are not the same sequence: already `reflectBallot 2 1 = 2` while the strict `ballotNumber 2 1 = 1`. The task, a listed open question of the parent, is to state this reflection form correctly and reconcile it with the cycle-lemma count.",
+    "mathContext": "$\\text{reflectBallot}(a,b) = \\binom{a+b}{b} - \\binom{a+b}{b-1}, \\qquad \\text{strict } BN(a,b) = \\binom{a+b-1}{a-1} - \\binom{a+b-1}{a}$",
+    "significance": "supporting",
+    "relatedConcepts": ["reflection principle", "André's method", "Catalan triangle", "non-negative lattice paths"],
+    "prerequisites": ["binomial coefficients"]
+  },
+  {
+    "id": "ballot-oq0502-ann-def",
+    "proofId": "ballot-problem-oq-05-oq-02",
+    "range": { "startLine": 56, "endLine": 63 },
+    "type": "definition",
+    "title": "The non-negative ballot number",
+    "content": "`reflectBallot a b = C(a+b,b) - C(a+b,b-1)` counts sequences of `a` up-steps and `b` down-steps whose every partial sum is `≥ 0` (weak dominance). These are the entries of the Catalan triangle; the diagonal `a = b` recovers the Catalan numbers. The subtraction is a genuine ℕ subtraction here, shown to be exact in its natural domain `b ≤ a` by `reflectBallot_sub_exact`.",
+    "mathContext": "$T(a,b) = \\binom{a+b}{b} - \\binom{a+b}{b-1}$",
+    "significance": "central",
+    "relatedConcepts": ["Catalan triangle", "weakly-ahead sequences", "Dyck paths"],
+    "prerequisites": ["Nat.choose"]
+  },
+  {
+    "id": "ballot-oq0502-ann-reconcile",
+    "proofId": "ballot-problem-oq-05-oq-02",
+    "range": { "startLine": 64, "endLine": 85 },
+    "type": "key-step",
+    "title": "The reconciliation: prepend an up-step",
+    "content": "The main theorem `reflectBallot_eq` proves `reflectBallot a b = ballotNumber (a+1) b` for `1 ≤ b`. This is the arithmetic shadow of the classical **prepend-an-up-step bijection**: a non-negative `(a,b)`-path becomes a strictly-positive `(a+1,b)`-path by inserting a forced initial `+1`, and conversely. The proof is a single use of binomial symmetry `C(a+b,k) = C(a+b,a+b-k)` (`Nat.choose_symm`): it sends `C(a+b,b) ↦ C(a+b,a)` and `C(a+b,b-1) ↦ C(a+b,a+1)` (the latter needs `1 ≤ b`), which are exactly the two binomials of `ballotNumber (a+1) b` once its reflection indices `a+1+b-1 = a+b` and `a+1-1 = a` simplify.",
+    "mathContext": "$\\binom{a+b}{b} - \\binom{a+b}{b-1} = \\binom{a+b}{a} - \\binom{a+b}{a+1} = BN(a+1,b)$",
+    "significance": "central",
+    "relatedConcepts": ["prepend-an-up-step bijection", "binomial symmetry", "reflection principle"],
+    "prerequisites": ["Nat.choose_symm", "Nat.add_sub_cancel_left"]
+  },
+  {
+    "id": "ballot-oq0502-ann-exact",
+    "proofId": "ballot-problem-oq-05-oq-02",
+    "range": { "startLine": 86, "endLine": 110 },
+    "type": "key-step",
+    "title": "The reflection subtraction is exact",
+    "content": "`reflectBallot_sub_exact` shows that for `b ≤ a` the ℕ subtraction loses nothing: `C(a+b,b-1) ≤ C(a+b,b)`, so `reflectBallot a b + C(a+b,b-1) = C(a+b,b)`. The inequality comes from the Pascal ratio `C(a+b,b)·b = C(a+b,b-1)·(a+1)` (`Nat.choose_succ_right_eq`): since `b ≤ a+1`, the right factor `a+1` dominates `b`, forcing `C(a+b,b-1) ≤ C(a+b,b)` after cancelling `a+1`. This certifies that `reflectBallot` is a genuine count on its natural domain, not an artifact of truncation.",
+    "mathContext": "$\\binom{a+b}{b}\\,b = \\binom{a+b}{b-1}(a+1), \\quad b \\le a+1 \\ \\Rightarrow\\ \\binom{a+b}{b-1} \\le \\binom{a+b}{b}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Pascal ratio", "unimodality of binomial coefficients"],
+    "prerequisites": ["Nat.choose_succ_right_eq"]
+  },
+  {
+    "id": "ballot-oq0502-ann-consequences",
+    "proofId": "ballot-problem-oq-05-oq-02",
+    "range": { "startLine": 111, "endLine": 133 },
+    "type": "key-step",
+    "title": "Aggregate, probability, and the Catalan diagonal — all by transport",
+    "content": "Once `reflectBallot a b = ballotNumber (a+1) b` is known, the parent's cycle-lemma arithmetic transports along the shift `a ↦ a+1` with no new combinatorics. `reflectBallot_mul` gives the aggregate `reflectBallot a b · (a+1+b) = (a+1-b)·C(a+1+b,a+1)` from `ballotNumber_mul_add`; `reflectBallot_div` gives the probability `(a+1-b)/(a+1+b)` over ℚ from `ballotNumber_div`; and `reflectBallot_catalan` gives the diagonal `reflectBallot n n = catalan n` (`1 ≤ n`) — the number of Dyck paths of semilength `n` — from `ballotNumber_catalan`.",
+    "mathContext": "$\\text{reflectBallot}(a,b)\\,(a{+}1{+}b) = (a{+}1{-}b)\\binom{a{+}1{+}b}{a{+}1}, \\qquad \\text{reflectBallot}(n,n) = C_n$",
+    "significance": "central",
+    "relatedConcepts": ["cycle lemma", "Bertrand ballot probability", "Catalan numbers", "Dyck paths"],
+    "prerequisites": ["BallotProblemOQ05.ballotNumber_mul_add", "BallotProblemOQ05.ballotNumber_catalan"]
+  },
+  {
+    "id": "ballot-oq0502-ann-examples",
+    "proofId": "ballot-problem-oq-05-oq-02",
+    "range": { "startLine": 134, "endLine": 147 },
+    "type": "concept",
+    "title": "Worked examples: the two-form distinction and the Catalan diagonal",
+    "content": "Four `decide`-checked examples ground the development without `native_decide`: `reflectBallot 2 1 = 2` (contrast the strict `ballotNumber 2 1 = 1`, the whole point of the two-form distinction); `reflectBallot 3 2 = 5`; and the Catalan diagonal `reflectBallot 2 2 = 2 = catalan 2`, `reflectBallot 3 3 = 5 = catalan 3`. `decide` uses kernel reduction, so these carry no `Lean.ofReduceBool` axiom.",
+    "mathContext": "$\\binom{3}{1}-\\binom{3}{0}=2,\\ \\binom{4}{2}-\\binom{4}{1}=2=C_2,\\ \\binom{6}{3}-\\binom{6}{2}=5=C_3$",
+    "significance": "supporting",
+    "relatedConcepts": ["decidability", "worked examples"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-05-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-05-oq-02/meta.json
@@ -1,0 +1,153 @@
+{
+  "id": "ballot-problem-oq-05-oq-02",
+  "title": "The Reflection (André) Form of the Ballot Number: C(a+b,b) − C(a+b,b−1) Reconciled to the Cycle-Lemma Count",
+  "slug": "ballot-problem-oq-05-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BallotProblemOQ05"
+    ],
+    "opens": [
+      "BallotProblemOQ05"
+    ],
+    "namespace": "BallotProblemOQ05OQ02",
+    "lineCount": 147,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/BallotProblemOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "description": "Resolves the reflection-principle open question of the sibling entry BallotProblemOQ05. That file records the STRICT Bertrand ballot number (sequences of a up-steps and b down-steps whose every partial sum is strictly positive) in the reflection form ballotNumber a b = C(a+b-1,a-1) - C(a+b-1,a). This entry treats the OTHER classical reflection form, reflectBallot a b = C(a+b,b) - C(a+b,b-1), which is the NON-NEGATIVE (weakly-ahead) ballot number — the entries of the Catalan triangle, counting sequences whose every partial sum is ≥ 0. The two are distinct sequences: reflectBallot 2 1 = 2 while the strict ballotNumber 2 1 = 1. The main theorem reconciles them by a single parameter shift, reflectBallot a b = ballotNumber (a+1) b for 1 ≤ b — the arithmetic shadow of the classical prepend-an-up-step bijection (a non-negative (a,b)-path is exactly a strictly-positive (a+1,b)-path with its forced initial +1 removed). Both sides are reflection differences of the SAME binomials read through the symmetry C(a+b,k) = C(a+b,a+b-k). From this one identity everything follows as corollaries of the cycle-lemma arithmetic already in the parent: reflectBallot_sub_exact shows the ℕ subtraction is exact (C(a+b,b-1) ≤ C(a+b,b)) for b ≤ a; reflectBallot_mul gives the cycle-lemma aggregate reflectBallot a b · (a+1+b) = (a+1-b)·C(a+1+b,a+1); reflectBallot_div gives the probability (a+1-b)/(a+1+b) over ℚ; and reflectBallot_catalan gives the diagonal reflectBallot n n = catalan n (1 ≤ n) counting Dyck paths of semilength n. Elementary binomial arithmetic throughout — one binomial-symmetry step plus the Pascal ratio C(a+b,b)·b = C(a+b,b-1)·(a+1). 5 theorems, 1 definition, 4 decide-checked worked examples, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BallotProblemOQ05OQ02.lean",
+    "tags": [
+      "probability",
+      "ballot-problem",
+      "cycle-lemma",
+      "reflection-principle",
+      "combinatorics",
+      "catalan-numbers",
+      "binomial-coefficients",
+      "ballot-number",
+      "catalan-triangle"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-09",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked against the repo's Lean v4.26.0 / Mathlib pin (compiles green via ./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ05OQ02: ✔ [7744/7744] Built Proofs.BallotProblemOQ05OQ02). 0 sorries, 0 axiom declarations, no native_decide; the four worked examples use decide (kernel reduction, not the compiler), so no Lean.ofReduceBool. The development imports the sibling entry Proofs.BallotProblemOQ05 and reuses its cycle-lemma arithmetic (ballotNumber_mul_add, ballotNumber_div, ballotNumber_catalan) as input; #print axioms of the results lists only the standard foundational axioms (propext / Classical.choice / Quot.sound) supplied by Mathlib. Scope is honest: this file establishes the arithmetic reconciliation of the two reflection forms of the ballot number and their consequences; it does not re-derive the cycle lemma itself (that is BallotProblemOQ01).",
+    "lineCount": 147,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "originalContributions": [
+      "reflectBallot: the non-negative (weakly-ahead) ballot number defined in André's reflection form C(a+b,b) - C(a+b,b-1) — the count of sequences of a up-steps and b down-steps whose every partial sum is ≥ 0, i.e. the entries of the Catalan triangle",
+      "reflectBallot_eq: THE reconciliation identity reflectBallot a b = ballotNumber (a+1) b for 1 ≤ b — the arithmetic shadow of the prepend-an-up-step bijection between non-negative (a,b)-paths and strictly-positive (a+1,b)-paths, proved by reading both reflection differences through the binomial symmetry C(a+b,k) = C(a+b,a+b-k)",
+      "reflectBallot_sub_exact: the reflection subtraction is EXACT for b ≤ a — C(a+b,b-1) ≤ C(a+b,b), so reflectBallot a b + C(a+b,b-1) = C(a+b,b) with no ℕ truncation, proved from the Pascal ratio C(a+b,b)·b = C(a+b,b-1)·(a+1) and b ≤ a+1",
+      "reflectBallot_mul: the cycle-lemma aggregate for the non-negative count, reflectBallot a b · (a+1+b) = (a+1-b)·C(a+1+b,a+1), obtained by transporting the parent's ballotNumber_mul_add along the shift a ↦ a+1",
+      "reflectBallot_div: the non-negative ballot PROBABILITY reflectBallot a b / C(a+1+b,a+1) = (a+1-b)/(a+1+b) over ℚ, transported from the parent's ballotNumber_div",
+      "reflectBallot_catalan: the Catalan (Dyck-path) diagonal reflectBallot n n = catalan n for 1 ≤ n, the number of non-negative paths with n up- and n down-steps, obtained from the parent's ballotNumber_catalan through the reconciliation shift",
+      "Four decide-checked worked examples (reflectBallot 2 1 = 2 vs strict 1, reflectBallot 3 2 = 5, reflectBallot 2 2 = 2 = catalan 2, reflectBallot 3 3 = 5 = catalan 3) grounding the two-form distinction and the Catalan diagonal without native_decide"
+    ]
+  },
+  "references": [
+    {
+      "authors": "André, Désiré",
+      "title": "Solution directe du problème résolu par M. Bertrand",
+      "year": "1887",
+      "venue": "Comptes Rendus de l'Académie des Sciences, Paris 105, 436–437"
+    },
+    {
+      "authors": "Renault, Marc",
+      "title": "Lost (and found) in translation: André's actual method and its application to the generalized ballot problem",
+      "year": "2008",
+      "venue": "American Mathematical Monthly 115(4), 358–363"
+    },
+    {
+      "authors": "Dvoretzky, Aryeh and Motzkin, Theodore",
+      "title": "A problem of arrangements",
+      "year": "1947",
+      "venue": "Duke Mathematical Journal 14(2), 305–313"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Nat.choose_symm, Nat.choose_succ_right_eq, Nat.add_sub_cancel_left, catalan",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "There are two classical reflection formulas attached to the ballot problem, and they count two different (but closely related) things. The STRICT ballot number counts vote sequences in which candidate A is ahead at every step; its reflection form is C(a+b-1,a-1) - C(a+b-1,a) and it equals (a-b)/(a+b)·C(a+b,a) (formalized in the sibling entry BallotProblemOQ05 via the Dvoretzky–Motzkin cycle lemma). The NON-NEGATIVE ballot number counts sequences in which A is never behind (ties allowed); its reflection form is C(a+b,b) - C(a+b,b-1), the entries of the Catalan triangle, whose diagonal is the Catalan numbers. André's 1887 reflection argument is usually stated for the second, weak form. The elementary bijection between the two — prepend a mandatory initial up-step to turn a non-negative path into a strictly-positive one — is folklore, but making it an exact arithmetic identity ties the two reflection derivations together.",
+    "problemStatement": "OQ-05-OQ-02 (a listed open question of BallotProblemOQ05): 'Prove the reflection-principle identity BN(a,b) = C(a+b,b) - C(a+b,b-1) and reconcile the reflection and cycle-lemma derivations of the ballot number in a single file.' The subtlety, made explicit here, is that C(a+b,b) - C(a+b,b-1) is NOT the strict ballotNumber of the parent (they disagree already at a=2,b=1: 2 vs 1); it is the non-negative ballot number. The reconciliation is therefore an equation between the André form of the non-negative count and the cycle-lemma-derived strict count of shifted parameters.",
+    "proofStrategy": "Define reflectBallot a b = C(a+b,b) - C(a+b,b-1). The single engine is binomial symmetry C(a+b,k) = C(a+b,a+b-k) (Nat.choose_symm): it sends C(a+b,b) to C(a+b,a) and C(a+b,b-1) to C(a+b,a+1) (the latter needs 1 ≤ b), which are exactly the two binomials in ballotNumber (a+1) b after the reflection-form indices a+1+b-1 = a+b and a+1-1 = a simplify. This proves reflectBallot a b = ballotNumber (a+1) b (reflectBallot_eq). Every other result is that identity composed with the parent's cycle-lemma arithmetic: the aggregate relation (reflectBallot_mul), the ℚ-probability (reflectBallot_div), and the Catalan diagonal (reflectBallot_catalan) transport ballotNumber_mul_add, ballotNumber_div, and ballotNumber_catalan along a ↦ a+1. Separately, reflectBallot_sub_exact shows the ℕ subtraction loses nothing when b ≤ a, via the Pascal ratio C(a+b,b)·b = C(a+b,b-1)·(a+1) (Nat.choose_succ_right_eq) and b ≤ a+1.",
+    "keyInsights": [
+      "The two 'reflection forms' of the ballot problem count different objects: C(a+b-1,a-1) - C(a+b-1,a) is the STRICT count (A always strictly ahead), while C(a+b,b) - C(a+b,b-1) is the NON-NEGATIVE count (A never behind). They disagree — already reflectBallot 2 1 = 2 vs strict 1 — so the OQ's identity 'BN(a,b) = C(a+b,b) - C(a+b,b-1)' is really the definition of the weak ballot number.",
+      "The reconciliation is a single parameter shift: reflectBallot a b = ballotNumber (a+1) b. This is the arithmetic form of the classical bijection 'prepend a forced initial up-step', which turns a non-negative (a,b)-path into a strictly-positive (a+1,b)-path.",
+      "The whole identity is one application of binomial symmetry C(a+b,k) = C(a+b,a+b-k) to each term of the reflection difference: C(a+b,b) ↦ C(a+b,a) and C(a+b,b-1) ↦ C(a+b,a+1).",
+      "Because reflectBallot equals a cycle-lemma count of shifted parameters, it inherits — for free — the aggregate relation, the (a+1-b)/(a+1+b) probability, and the Catalan diagonal from the parent file: no new combinatorics, only transport along the shift.",
+      "The non-negative subtraction C(a+b,b) - C(a+b,b-1) is exact for b ≤ a: the Pascal ratio C(a+b,b)·b = C(a+b,b-1)·(a+1) plus b ≤ a+1 forces C(a+b,b-1) ≤ C(a+b,b), so the reflection count never suffers ℕ truncation in its natural domain."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Non-Negative Ballot Number in André's Reflection Form",
+      "summary": "Header contrasting the strict reflection form of the parent with the non-negative form treated here, and the definition reflectBallot a b = C(a+b,b) - C(a+b,b-1) — the entries of the Catalan triangle.",
+      "startLine": 1,
+      "endLine": 69,
+      "mathContext": "Non-negative (weakly-ahead) paths with a up-steps and b down-steps; the diagonal a=b recovers the Catalan numbers."
+    },
+    {
+      "id": "reconciliation",
+      "title": "The Reconciliation Identity",
+      "summary": "reflectBallot_eq: reflectBallot a b = ballotNumber (a+1) b for 1 ≤ b, the arithmetic shadow of the prepend-an-up-step bijection, proved by binomial symmetry C(a+b,k) = C(a+b,a+b-k) on each term.",
+      "startLine": 70,
+      "endLine": 85,
+      "mathContext": "C(a+b,b) = C(a+b,a) and C(a+b,b-1) = C(a+b,a+1) turn the reflection difference into the strict reflection form of the parameters (a+1,b)."
+    },
+    {
+      "id": "exactness",
+      "title": "Exactness of the Reflection Subtraction",
+      "summary": "reflectBallot_sub_exact: for b ≤ a, C(a+b,b-1) ≤ C(a+b,b), so reflectBallot a b + C(a+b,b-1) = C(a+b,b) with no ℕ truncation, from the Pascal ratio C(a+b,b)·b = C(a+b,b-1)·(a+1).",
+      "startLine": 86,
+      "endLine": 110,
+      "mathContext": "The reflection count is a genuine count in its natural domain b ≤ a: the subtracted binomial is never larger than the minuend."
+    },
+    {
+      "id": "consequences",
+      "title": "Aggregate, Probability, Catalan Diagonal, and Worked Examples",
+      "summary": "reflectBallot_mul (cycle-lemma aggregate), reflectBallot_div (probability (a+1-b)/(a+1+b) over ℚ), and reflectBallot_catalan (diagonal = catalan n) transport the parent's results along a ↦ a+1; four decide-checked examples.",
+      "startLine": 111,
+      "endLine": 147,
+      "mathContext": "Everything past the reconciliation is the parent's cycle-lemma arithmetic read at shifted parameters (a+1,b); the diagonal recovers Dyck paths of semilength n."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry resolves the reflection-principle open question of BallotProblemOQ05. It distinguishes the two classical reflection forms of the ballot problem — the strict count C(a+b-1,a-1) - C(a+b-1,a) formalized in the parent, and the non-negative count reflectBallot a b = C(a+b,b) - C(a+b,b-1) defined here — and proves they are the same sequence under a single parameter shift: reflectBallot a b = ballotNumber (a+1) b for 1 ≤ b, the arithmetic form of the prepend-an-up-step bijection. Because the non-negative count is thereby a cycle-lemma count of shifted parameters, it inherits the aggregate relation reflectBallot a b · (a+1+b) = (a+1-b)·C(a+1+b,a+1), the probability (a+1-b)/(a+1+b) over ℚ, and the Catalan diagonal reflectBallot n n = catalan n. Separately the reflection subtraction is shown exact for b ≤ a. Elementary binomial arithmetic — one symmetry step and the Pascal ratio — verified with 0 axioms, 0 sorries, and no native_decide.",
+    "implications": "The file closes the arithmetic loop between the two reflection derivations of the ballot number: the André (non-negative) form and the cycle-lemma (strict) form are now a machine-checked single identity, reconciling the two combinatorial stories the family tells. The reconciliation lemma reflectBallot_eq is a reusable bridge — anything proved about the strict ballotNumber transports immediately to the Catalan-triangle entries, and vice versa. Remaining open in the family: carrying out the aggregate double-count over the Finset of all arrangements to derive the ballot count from the cycle lemma end-to-end, and connecting the combinatorial probability to the measure-theoretic ballot theorem of BallotProblem.lean (Wiedijk #30).",
+    "openQuestions": [
+      "Formalize the prepend-an-up-step bijection itself as an explicit Finset.card equality (non-negative (a,b)-paths ≃ strictly-positive (a+1,b)-paths), upgrading the arithmetic identity reflectBallot_eq to a bijective proof.",
+      "Prove the Catalan-triangle recurrence reflectBallot a b = reflectBallot (a-1) b + reflectBallot a (b-1) (for the interior) directly from the reflection form, exhibiting reflectBallot as the Catalan triangle and tying it to the row-sum entry catalan-numbers-oq-05-oq-02-oq-01."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "ballot-problem-oq-05",
+      "relationship": "parent",
+      "description": "The arithmetic capstone that defines the STRICT ballot number ballotNumber a b = C(a+b-1,a-1) - C(a+b-1,a) via the cycle lemma and proves its integrality, probability, and Catalan specialisation. This entry resolves that file's listed reflection-principle open question by treating the NON-NEGATIVE reflection form C(a+b,b) - C(a+b,b-1) and reconciling it to the parent's strict count via the shift a ↦ a+1, reusing ballotNumber_mul_add, ballotNumber_div, and ballotNumber_catalan directly."
+    },
+    {
+      "targetId": "ballot-problem-oq-01",
+      "relationship": "related",
+      "description": "The sibling entry that formalizes the Dvoretzky–Motzkin cycle lemma itself (0-axiom). The strict count this entry reconciles to is the cycle-lemma aggregate proved there; the non-negative count treated here is its a ↦ a+1 shift."
+    },
+    {
+      "targetId": "ballot-problem-oq-04",
+      "relationship": "related",
+      "description": "A sibling ballot/Catalan strand connecting the ballot/Dyck bijection to Catalan-counted structures. This entry adds the non-negative ballot number whose diagonal reflectBallot n n = catalan n is the Dyck-path count of semilength n."
+    }
+  ]
+}

--- a/src/data/research/problems/ballot-problem-oq-05-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-05-oq-02.json
@@ -36,11 +36,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: reflectBallot a b = C(a+b,b) - C(a+b,b-1) formalized as the NON-NEGATIVE ballot number and reconciled to the parent strict ballotNumber(a+1,b) via the prepend-an-up-step shift; verified 0/0.",
+    "builtItems": [
+      "reflectBallot (def): non-negative ballot number C(a+b,b) - C(a+b,b-1) in Proofs/BallotProblemOQ05OQ02.lean:61",
+      "reflectBallot_eq: reflectBallot a b = ballotNumber (a+1) b for 1≤b (reconciliation) — BallotProblemOQ05OQ02.lean:73",
+      "reflectBallot_sub_exact: C(a+b,b-1) ≤ C(a+b,b) for b≤a, subtraction exact — :91",
+      "reflectBallot_mul: aggregate reflectBallot a b·(a+1+b)=(a+1-b)·C(a+1+b,a+1) — :112",
+      "reflectBallot_div: probability (a+1-b)/(a+1+b) over ℚ — :120",
+      "reflectBallot_catalan: reflectBallot n n = catalan n (1≤n) — :129"
+    ],
+    "insights": [
+      "The OQ identity C(a+b,b)-C(a+b,b-1) is NOT the parent strict ballotNumber (disagree at a=2,b=1: 2 vs 1); it is the non-negative (weakly-ahead) ballot number = Catalan-triangle entries.",
+      "Reconciliation is the single shift a↦a+1: reflectBallot a b = ballotNumber(a+1) b, arithmetic form of the prepend-an-up-step bijection. Proved by binomial symmetry Nat.choose_symm on each term.",
+      "All consequences (aggregate/probability/Catalan diagonal) transport for free from the parents cycle-lemma arithmetic along the shift.",
+      "b=0 boundary: reflectBallot a 0 = 0 ≠ ballotNumber(a+1,0)=1 due to ℕ truncation of b-1, so reconciliation requires 1≤b; Catalan diagonal requires 1≤n (n=0 gives 0≠catalan 0=1)."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Upgrade reflectBallot_eq to an explicit Finset.card bijection (non-negative (a,b)-paths ≃ strictly-positive (a+1,b)-paths).",
+      "Prove the Catalan-triangle recurrence reflectBallot a b = reflectBallot (a-1) b + reflectBallot a (b-1) directly from the reflection form."
+    ]
   },
   "tags": [
     "probability",


### PR DESCRIPTION
## Summary

Resolves the reflection-principle **open question** listed in `BallotProblemOQ05`:

> *Prove the reflection-principle identity `BN(a,b) = C(a+b,b) − C(a+b,b−1)` and reconcile the reflection and cycle-lemma derivations of the ballot number in a single file.*

The key mathematical observation, made explicit here, is that `C(a+b,b) − C(a+b,b−1)` is **not** the parent's *strict* `ballotNumber` — they already disagree at `a=2, b=1` (**2** vs **1**). It is the **non-negative** (weakly-ahead) ballot number, i.e. the entries of the Catalan triangle. The reconciliation is a single parameter shift.

## Main result

- `reflectBallot a b = C(a+b,b) − C(a+b,b−1)` — the non-negative ballot number (new `def`).
- **`reflectBallot_eq`** : `reflectBallot a b = ballotNumber (a+1) b` for `1 ≤ b`.
  The arithmetic shadow of the classical **prepend-an-up-step bijection** (a non-negative `(a,b)`-path is a strictly-positive `(a+1,b)`-path with its forced initial `+1` removed). Proved by one application of binomial symmetry `C(a+b,k) = C(a+b,a+b−k)` to each term.

## Corollaries (transported from the parent along `a ↦ a+1`)

- `reflectBallot_sub_exact` — the ℕ subtraction is exact for `b ≤ a` (`C(a+b,b−1) ≤ C(a+b,b)`, via the Pascal ratio).
- `reflectBallot_mul` — cycle-lemma aggregate `reflectBallot a b · (a+1+b) = (a+1−b)·C(a+1+b, a+1)`.
- `reflectBallot_div` — probability `(a+1−b)/(a+1+b)` over ℚ.
- `reflectBallot_catalan` — diagonal `reflectBallot n n = catalan n` (`1 ≤ n`), the Dyck-path count.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ05OQ02` → **✔ [7744/7744] Built**.
- 5 theorems, 1 definition, 4 `decide`-checked worked examples.
- **0 sorries, 0 axioms, no `native_decide`** (`decide` uses kernel reduction, no `Lean.ofReduceBool`).
- Gallery data (`meta.json`, `annotations.json`) added; `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)