### PR TITLE
research(catalan-numbers-oq-05-oq-02-oq-01): row sums of Catalan's triangle = catalan(n+1) [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/CatalanNumbersOQ05OQ02OQ01.lean
+++ b/proofs/Proofs/CatalanNumbersOQ05OQ02OQ01.lean
@@ -1,5 +1,4 @@
 import Mathlib
-import Proofs.CatalanNumbersOQ05OQ02
 
 /-!
 # Row sums of Catalan's triangle: `Σₖ T(n,k) = catalan (n+1)`
@@ -17,6 +16,11 @@ the *next* Catalan number,
 
   `Σ_{k=0}^{n} ballotNumber n k = catalan (n+1)`.
 
+To keep the file self-contained (and robust to the heavy parent module), we
+restate the parent's `ballotNumber` definition and re-derive the single
+well-posedness fact `C(n+k, n+1) ≤ C(n+k, k)` that we need; the definition is
+identical to the parent's `CatalanNumbersOQ05OQ02.ballotNumber`.
+
 ## A correction to the seeded statement
 
 The seed problem stated the row sum as `C(2n+1, n)`. That is **false**: for `n = 1`
@@ -28,8 +32,8 @@ say. We prove the correct identity.
 ## Proof outline
 
 Write `A(n) = Σ_{k≤n} C(n+k, k)` and `B(n) = Σ_{k≤n} C(n+k, n+1)`. Since each
-term satisfies `C(n+k, n+1) ≤ C(n+k, k)` (parent `ballotNumber_le`), the row sum is
-`A(n) − B(n)` (proved in additive form to avoid truncated subtraction).
+term satisfies `C(n+k, n+1) ≤ C(n+k, k)`, the row sum is `A(n) − B(n)` (proved in
+additive form to avoid truncated subtraction).
 
 * `sum_choose_diag`  : `A(n) = C(2n+1, n+1)` — hockey stick (`Nat.sum_Icc_choose`).
 * `sum_choose_reflected` : `B(n) = C(2n+1, n+2)` — hockey stick, dropping the zero `k=0` term.
@@ -46,7 +50,30 @@ open Nat Finset
 
 namespace CatalanNumbersOQ05OQ02OQ01
 
-open CatalanNumbersOQ05OQ02 (ballotNumber ballotNumber_le)
+/-- **Catalan's triangle / ballot number** (restated from the parent entry).
+`ballotNumber n k = C(n+k, k) − C(n+k, n+1)`; the second term is the reflected
+("bad path") count. -/
+def ballotNumber (n k : ℕ) : ℕ :=
+  (n + k).choose k - (n + k).choose (n + 1)
+
+/-- **Well-posedness of the reflected term.** `C(n+k, n+1) ≤ C(n+k, k)` for `k ≤ n`.
+
+By the absorption law `Nat.choose_succ_right_eq`,
+`C(n+k, n+1)·(n+1) = C(n+k, n)·k = C(n+k, k)·k ≤ C(n+k, k)·(n+1)`, then cancel `n+1`. -/
+theorem choose_reflected_le (n k : ℕ) (hk : k ≤ n) :
+    (n + k).choose (n + 1) ≤ (n + k).choose k := by
+  have h := Nat.choose_succ_right_eq (n + k) n
+  rw [show n + k - n = k by omega] at h
+  -- `h : (n+k).choose (n+1) * (n+1) = (n+k).choose n * k`
+  have hsym : (n + k).choose n = (n + k).choose k := by
+    rw [← Nat.choose_symm (show k ≤ n + k by omega)]
+    congr 1
+    omega
+  rw [hsym] at h
+  -- `h : (n+k).choose (n+1) * (n+1) = (n+k).choose k * k`
+  have hmul : (n + k).choose (n + 1) * (n + 1) ≤ (n + k).choose k * (n + 1) := by
+    rw [h]; gcongr; omega
+  exact Nat.le_of_mul_le_mul_right hmul (by omega)
 
 /-- **Hockey stick, main diagonal.** `Σ_{k=0}^{n} C(n+k, k) = C(2n+1, n+1)`.
 
@@ -54,17 +81,14 @@ open CatalanNumbersOQ05OQ02 (ballotNumber ballotNumber_le)
 direct instance of the hockey-stick identity `Nat.sum_Icc_choose`. -/
 theorem sum_choose_diag (n : ℕ) :
     ∑ k ∈ range (n + 1), (n + k).choose k = (2 * n + 1).choose (n + 1) := by
-  -- Replace `C(n+k, k)` by `C(n+k, n)` termwise.
   have hsymm : ∀ k ∈ range (n + 1), (n + k).choose k = (n + k).choose n := by
     intro k _
     rw [← Nat.choose_symm (show k ≤ n + k by omega)]
     congr 1
     omega
   rw [Finset.sum_congr rfl hsymm]
-  -- Turn the target central binomial into the hockey-stick `Icc` sum, then reindex.
   rw [← Nat.sum_Icc_choose (2 * n) n, ← Nat.Ico_succ_right,
     Finset.sum_Ico_eq_sum_range]
-  -- `∑ i ∈ range (2n+1-n), (n+i).choose n`, and `2n+1-n = n+1`.
   rw [show 2 * n + 1 - n = n + 1 by omega]
 
 /-- **Hockey stick, reflected diagonal.** `Σ_{k=0}^{n} C(n+k, n+1) = C(2n+1, n+2)`.
@@ -73,11 +97,9 @@ The `k = 0` summand is `C(n, n+1) = 0`; the rest is again `Nat.sum_Icc_choose`. 
 theorem sum_choose_reflected (n : ℕ) :
     ∑ k ∈ range (n + 1), (n + k).choose (n + 1) = (2 * n + 1).choose (n + 2) := by
   rw [Finset.sum_range_succ']
-  -- `(∑ i ∈ range n, (n+(i+1)).choose (n+1)) + (n+0).choose (n+1)`
   have h0 : (n + 0).choose (n + 1) = 0 := by
     simp [Nat.choose_eq_zero_of_lt]
   rw [h0, add_zero]
-  -- Reindex the target `C(2n+1, n+2)` back to a `range` sum over `Icc (n+1) (2n)`.
   rw [← Nat.sum_Icc_choose (2 * n) (n + 1), ← Nat.Ico_succ_right,
     Finset.sum_Ico_eq_sum_range, show 2 * n + 1 - (n + 1) = n by omega]
   apply Finset.sum_congr rfl
@@ -92,28 +114,21 @@ Multiplying by `n+2`: `(n+2)·catalan (n+1) = centralBinom (n+1) = 2·C(2n+1, n+
 Hence `(n+2)·(catalan (n+1) + C(2n+1, n+2)) = (n+2)·C(2n+1, n+1)`, and we cancel `n+2`. -/
 theorem choose_sub_eq_catalan (n : ℕ) :
     (2 * n + 1).choose (n + 1) = catalan (n + 1) + (2 * n + 1).choose (n + 2) := by
-  -- `C(2n+1, n) = C(2n+1, n+1)` by symmetry.
   have hsym : (2 * n + 1).choose n = (2 * n + 1).choose (n + 1) := by
     rw [← Nat.choose_symm (show n + 1 ≤ 2 * n + 1 by omega)]
     congr 1
     omega
-  -- `centralBinom (n+1) = 2 · C(2n+1, n+1)`.
   have h2 : (n + 1).centralBinom = 2 * (2 * n + 1).choose (n + 1) := by
     rw [Nat.centralBinom_eq_two_mul_choose, show 2 * (n + 1) = (2 * n + 1) + 1 by ring,
       Nat.choose_succ_succ' (2 * n + 1) n, hsym]
     ring
-  -- `(n+2) · catalan (n+1) = centralBinom (n+1)`.
   have h3 : (n + 2) * catalan (n + 1) = (n + 1).centralBinom :=
     succ_mul_catalan_eq_centralBinom (n + 1)
-  -- `(n+2) · catalan (n+1) = 2 · C(2n+1, n+1)`.
   have hA2 : (n + 2) * catalan (n + 1) = 2 * (2 * n + 1).choose (n + 1) := h3.trans h2
-  -- Absorption: `C(2n+1, n+2) · (n+2) = C(2n+1, n+1) · n`.
   have h1 : (2 * n + 1).choose (n + 2) * (n + 2) = (2 * n + 1).choose (n + 1) * n := by
     have h := Nat.choose_succ_right_eq (2 * n + 1) (n + 1)
     rw [show 2 * n + 1 - (n + 1) = n by omega] at h
-    -- `h : C(2n+1, n+2) * (n+2) = C(2n+1, n+1) * n`   (note `(n+1)+1 = n+2`)
     simpa using h
-  -- Multiply the goal through by `n+2` and cancel.
   have key : (n + 2) * (catalan (n + 1) + (2 * n + 1).choose (n + 2))
       = (n + 2) * (2 * n + 1).choose (n + 1) := by
     calc (n + 2) * (catalan (n + 1) + (2 * n + 1).choose (n + 2))
@@ -126,7 +141,7 @@ theorem choose_sub_eq_catalan (n : ℕ) :
 /-- **Additive split.** `(Σ ballotNumber n k) + (Σ C(n+k, n+1)) = Σ C(n+k, k)`.
 
 Termwise, `ballotNumber n k + C(n+k, n+1) = C(n+k, k)` for `k ≤ n`, by
-`Nat.sub_add_cancel` and the parent's well-posedness `ballotNumber_le`. -/
+`Nat.sub_add_cancel` and well-posedness `choose_reflected_le`. -/
 theorem sum_add_reflected (n : ℕ) :
     (∑ k ∈ range (n + 1), ballotNumber n k)
       + ∑ k ∈ range (n + 1), (n + k).choose (n + 1)
@@ -136,7 +151,7 @@ theorem sum_add_reflected (n : ℕ) :
   intro k hk
   rw [Finset.mem_range] at hk
   show ((n + k).choose k - (n + k).choose (n + 1)) + (n + k).choose (n + 1) = (n + k).choose k
-  exact Nat.sub_add_cancel (ballotNumber_le n k (by omega))
+  exact Nat.sub_add_cancel (choose_reflected_le n k (by omega))
 
 /-- **Row sums of Catalan's triangle are the Catalan numbers.**
 

--- a/proofs/Proofs/CatalanNumbersOQ05OQ02OQ01.lean
+++ b/proofs/Proofs/CatalanNumbersOQ05OQ02OQ01.lean
@@ -1,0 +1,157 @@
+import Mathlib
+import Proofs.CatalanNumbersOQ05OQ02
+
+/-!
+# Row sums of Catalan's triangle: `Σₖ T(n,k) = catalan (n+1)`
+
+`catalan-numbers-oq-05-oq-02-oq-01`
+
+The parent entry (`catalan-numbers-oq-05-oq-02`, `Proofs/CatalanNumbersOQ05OQ02.lean`)
+defines the ballot number / Catalan-triangle entry
+
+  `ballotNumber n k = C(n+k, k) − C(n+k, n+1)`
+
+and proves its closed form and the reflection-principle recurrence. This file
+proves the **row-sum identity**: summing an entire row of the triangle reproduces
+the *next* Catalan number,
+
+  `Σ_{k=0}^{n} ballotNumber n k = catalan (n+1)`.
+
+## A correction to the seeded statement
+
+The seed problem stated the row sum as `C(2n+1, n)`. That is **false**: for `n = 1`
+the row is `T(1,0) + T(1,1) = 1 + 1 = 2`, whereas `C(3,1) = 3`. The row sums are
+in fact the Catalan numbers `1, 2, 5, 14, …` (`= catalan (n+1)`), exactly as the
+problem's own plain-language paragraph and its "equivalently `catalan (n+1)`" note
+say. We prove the correct identity.
+
+## Proof outline
+
+Write `A(n) = Σ_{k≤n} C(n+k, k)` and `B(n) = Σ_{k≤n} C(n+k, n+1)`. Since each
+term satisfies `C(n+k, n+1) ≤ C(n+k, k)` (parent `ballotNumber_le`), the row sum is
+`A(n) − B(n)` (proved in additive form to avoid truncated subtraction).
+
+* `sum_choose_diag`  : `A(n) = C(2n+1, n+1)` — hockey stick (`Nat.sum_Icc_choose`).
+* `sum_choose_reflected` : `B(n) = C(2n+1, n+2)` — hockey stick, dropping the zero `k=0` term.
+* `choose_sub_eq_catalan` : `C(2n+1, n+1) = catalan (n+1) + C(2n+1, n+2)` — the
+  arithmetic identity, via `succ_mul_catalan_eq_centralBinom`, Pascal + symmetry,
+  and the absorption law `Nat.choose_succ_right_eq`.
+
+Assembling these gives the main theorem `sum_ballotNumber_row`.
+
+All results are `0`-sorry, `0`-axiom over `ℕ`.
+-/
+
+open Nat Finset
+
+namespace CatalanNumbersOQ05OQ02OQ01
+
+open CatalanNumbersOQ05OQ02 (ballotNumber ballotNumber_le)
+
+/-- **Hockey stick, main diagonal.** `Σ_{k=0}^{n} C(n+k, k) = C(2n+1, n+1)`.
+
+`C(n+k, k) = C(n+k, n)` by symmetry, and the reindexed sum over `Icc n (2n)` is a
+direct instance of the hockey-stick identity `Nat.sum_Icc_choose`. -/
+theorem sum_choose_diag (n : ℕ) :
+    ∑ k ∈ range (n + 1), (n + k).choose k = (2 * n + 1).choose (n + 1) := by
+  -- Replace `C(n+k, k)` by `C(n+k, n)` termwise.
+  have hsymm : ∀ k ∈ range (n + 1), (n + k).choose k = (n + k).choose n := by
+    intro k _
+    rw [← Nat.choose_symm (show k ≤ n + k by omega)]
+    congr 1
+    omega
+  rw [Finset.sum_congr rfl hsymm]
+  -- Turn the target central binomial into the hockey-stick `Icc` sum, then reindex.
+  rw [← Nat.sum_Icc_choose (2 * n) n, ← Nat.Ico_succ_right,
+    Finset.sum_Ico_eq_sum_range]
+  -- `∑ i ∈ range (2n+1-n), (n+i).choose n`, and `2n+1-n = n+1`.
+  rw [show 2 * n + 1 - n = n + 1 by omega]
+
+/-- **Hockey stick, reflected diagonal.** `Σ_{k=0}^{n} C(n+k, n+1) = C(2n+1, n+2)`.
+
+The `k = 0` summand is `C(n, n+1) = 0`; the rest is again `Nat.sum_Icc_choose`. -/
+theorem sum_choose_reflected (n : ℕ) :
+    ∑ k ∈ range (n + 1), (n + k).choose (n + 1) = (2 * n + 1).choose (n + 2) := by
+  rw [Finset.sum_range_succ']
+  -- `(∑ i ∈ range n, (n+(i+1)).choose (n+1)) + (n+0).choose (n+1)`
+  have h0 : (n + 0).choose (n + 1) = 0 := by
+    simp [Nat.choose_eq_zero_of_lt]
+  rw [h0, add_zero]
+  -- Reindex the target `C(2n+1, n+2)` back to a `range` sum over `Icc (n+1) (2n)`.
+  rw [← Nat.sum_Icc_choose (2 * n) (n + 1), ← Nat.Ico_succ_right,
+    Finset.sum_Ico_eq_sum_range, show 2 * n + 1 - (n + 1) = n by omega]
+  apply Finset.sum_congr rfl
+  intro i _
+  congr 1
+  omega
+
+/-- **Arithmetic core.** `C(2n+1, n+1) = catalan (n+1) + C(2n+1, n+2)`.
+
+Multiplying by `n+2`: `(n+2)·catalan (n+1) = centralBinom (n+1) = 2·C(2n+1, n+1)`
+(Pascal + symmetry), while the absorption law gives `(n+2)·C(2n+1, n+2) = n·C(2n+1, n+1)`.
+Hence `(n+2)·(catalan (n+1) + C(2n+1, n+2)) = (n+2)·C(2n+1, n+1)`, and we cancel `n+2`. -/
+theorem choose_sub_eq_catalan (n : ℕ) :
+    (2 * n + 1).choose (n + 1) = catalan (n + 1) + (2 * n + 1).choose (n + 2) := by
+  -- `C(2n+1, n) = C(2n+1, n+1)` by symmetry.
+  have hsym : (2 * n + 1).choose n = (2 * n + 1).choose (n + 1) := by
+    rw [← Nat.choose_symm (show n + 1 ≤ 2 * n + 1 by omega)]
+    congr 1
+    omega
+  -- `centralBinom (n+1) = 2 · C(2n+1, n+1)`.
+  have h2 : (n + 1).centralBinom = 2 * (2 * n + 1).choose (n + 1) := by
+    rw [Nat.centralBinom_eq_two_mul_choose, show 2 * (n + 1) = (2 * n + 1) + 1 by ring,
+      Nat.choose_succ_succ' (2 * n + 1) n, hsym]
+    ring
+  -- `(n+2) · catalan (n+1) = centralBinom (n+1)`.
+  have h3 : (n + 2) * catalan (n + 1) = (n + 1).centralBinom :=
+    succ_mul_catalan_eq_centralBinom (n + 1)
+  -- `(n+2) · catalan (n+1) = 2 · C(2n+1, n+1)`.
+  have hA2 : (n + 2) * catalan (n + 1) = 2 * (2 * n + 1).choose (n + 1) := h3.trans h2
+  -- Absorption: `C(2n+1, n+2) · (n+2) = C(2n+1, n+1) · n`.
+  have h1 : (2 * n + 1).choose (n + 2) * (n + 2) = (2 * n + 1).choose (n + 1) * n := by
+    have h := Nat.choose_succ_right_eq (2 * n + 1) (n + 1)
+    rw [show 2 * n + 1 - (n + 1) = n by omega] at h
+    -- `h : C(2n+1, n+2) * (n+2) = C(2n+1, n+1) * n`   (note `(n+1)+1 = n+2`)
+    simpa using h
+  -- Multiply the goal through by `n+2` and cancel.
+  have key : (n + 2) * (catalan (n + 1) + (2 * n + 1).choose (n + 2))
+      = (n + 2) * (2 * n + 1).choose (n + 1) := by
+    calc (n + 2) * (catalan (n + 1) + (2 * n + 1).choose (n + 2))
+        = (n + 2) * catalan (n + 1) + (2 * n + 1).choose (n + 2) * (n + 2) := by ring
+      _ = 2 * (2 * n + 1).choose (n + 1) + (2 * n + 1).choose (n + 1) * n := by rw [hA2, h1]
+      _ = (n + 2) * (2 * n + 1).choose (n + 1) := by ring
+  have := Nat.eq_of_mul_eq_mul_left (show 0 < n + 2 by omega) key
+  omega
+
+/-- **Additive split.** `(Σ ballotNumber n k) + (Σ C(n+k, n+1)) = Σ C(n+k, k)`.
+
+Termwise, `ballotNumber n k + C(n+k, n+1) = C(n+k, k)` for `k ≤ n`, by
+`Nat.sub_add_cancel` and the parent's well-posedness `ballotNumber_le`. -/
+theorem sum_add_reflected (n : ℕ) :
+    (∑ k ∈ range (n + 1), ballotNumber n k)
+      + ∑ k ∈ range (n + 1), (n + k).choose (n + 1)
+      = ∑ k ∈ range (n + 1), (n + k).choose k := by
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro k hk
+  rw [Finset.mem_range] at hk
+  show ((n + k).choose k - (n + k).choose (n + 1)) + (n + k).choose (n + 1) = (n + k).choose k
+  exact Nat.sub_add_cancel (ballotNumber_le n k (by omega))
+
+/-- **Row sums of Catalan's triangle are the Catalan numbers.**
+
+`Σ_{k=0}^{n} ballotNumber n k = catalan (n+1)`. -/
+theorem sum_ballotNumber_row (n : ℕ) :
+    ∑ k ∈ range (n + 1), ballotNumber n k = catalan (n + 1) := by
+  have hC := sum_add_reflected n
+  rw [sum_choose_diag n, sum_choose_reflected n] at hC
+  have hD := choose_sub_eq_catalan n
+  omega
+
+/-- Sanity checks: the first few row sums are `1, 2, 5, 14` (Catalan numbers). -/
+example : ∑ k ∈ range 1, ballotNumber 0 k = 1 := by decide
+example : ∑ k ∈ range 2, ballotNumber 1 k = 2 := by decide
+example : ∑ k ∈ range 3, ballotNumber 2 k = 5 := by decide
+example : ∑ k ∈ range 4, ballotNumber 3 k = 14 := by decide
+
+end CatalanNumbersOQ05OQ02OQ01

--- a/src/data/proofs/catalan-numbers-oq-05-oq-02-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-05-oq-02-oq-01/meta.json
@@ -1,0 +1,227 @@
+{
+  "id": "catalan-numbers-oq-05-oq-02-oq-01",
+  "title": "Row sums of Catalan's triangle: Σₖ T(n,k) = catalan (n+1)",
+  "slug": "catalan-numbers-oq-05-oq-02-oq-01",
+  "description": "Proves the row-sum identity for the Catalan triangle / ballot numbers T(n,k) = C(n+k,k) − C(n+k,n+1) established by the parent (catalan-numbers-oq-05-oq-02): summing an entire row reproduces the NEXT Catalan number, Σ_{k=0}^{n} T(n,k) = catalan (n+1). The proof splits the row sum additively (avoiding truncated ℕ subtraction) into A(n) = Σ C(n+k,k) and B(n) = Σ C(n+k,n+1), evaluates each by the hockey-stick identity Nat.sum_Icc_choose after a range→Icc reindexing (A(n) = C(2n+1,n+1), B(n) = C(2n+1,n+2)), and reconciles A(n) − B(n) with catalan (n+1) through the arithmetic identity C(2n+1,n+1) = catalan (n+1) + C(2n+1,n+2) — derived from succ_mul_catalan_eq_centralBinom, Pascal's rule with symmetry (centralBinom (n+1) = 2·C(2n+1,n+1)), and the binomial absorption law Nat.choose_succ_right_eq. IMPORTANT CORRECTION: the seed problem stated the row sum as C(2n+1,n); that value is wrong (for n=1 the row sums to 2 but C(3,1)=3). The true and here-verified closed form is catalan (n+1) = 1,2,5,14,… (OEIS A000108), matching the problem's own plain-language description and its 'equivalently catalan (n+1)' note. Verified with 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (row sums of Catalan's triangle / hockey-stick aggregation of ballot numbers); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CatalanNumbersOQ05OQ02OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "catalan-triangle",
+      "ballot-numbers",
+      "hockey-stick-identity",
+      "central-binomial",
+      "binomial-coefficients",
+      "finite-sums",
+      "reflection-principle",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-09",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_Icc_choose",
+        "description": "∑ m ∈ Icc k n, m.choose k = (n+1).choose (k+1). The hockey-stick / parallel-summation identity. Applied at (2n, n) it evaluates Σ_{m=n}^{2n} C(m,n) = C(2n+1,n+1) (the main-diagonal row sum), and at (2n, n+1) it evaluates Σ_{m=n+1}^{2n} C(m,n+1) = C(2n+1,n+2) (the reflected row sum).",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Finset.sum_Ico_eq_sum_range",
+        "description": "∑ i ∈ Ico m n, f i = ∑ i ∈ range (n−m), f (m+i). Converts the hockey-stick Icc/Ico sums into the range (n+1) index the row sum is stated over, matching the summand C(n+k, ·).",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "k ≤ n → n.choose (n−k) = n.choose k. Rewrites C(n+k,k) = C(n+k,n) so the main-diagonal sum matches the hockey-stick shape, and C(2n+1,n) = C(2n+1,n+1) inside the centralBinom split.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "n.choose (k+1)·(k+1) = n.choose k·(n−k). Instantiated at (2n+1, n+1) with (2n+1)−(n+1)=n it gives the absorption law C(2n+1,n+2)·(n+2) = C(2n+1,n+1)·n, the multiplicative relation between the two reflected binomials needed to identify the sum with catalan (n+1). Also drives the well-posedness re-derivation C(n+k,n+1) ≤ C(n+k,k).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ'",
+        "description": "(n+1).choose (k+1) = n.choose k + n.choose (k+1). Pascal's rule; applied on the top row to split centralBinom (n+1) = C(2n+2,n+1) = C(2n+1,n) + C(2n+1,n+1) = 2·C(2n+1,n+1).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "(n+1)·catalan n = Nat.centralBinom n. At argument n+1 it gives (n+2)·catalan (n+1) = centralBinom (n+1) = C(2n+2,n+1), the bridge that turns the pure-binomial closed form of the row sum into the Catalan number.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "Nat.centralBinom n = (2n).choose n. Bridges Mathlib's centralBinom spelling with the explicit (2·(n+1)).choose (n+1) form used in the Pascal split.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "0 < a → a·b = a·c → b = c. Cancels the positive factor (n+2) from (n+2)·(catalan (n+1) + C(2n+1,n+2)) = (n+2)·C(2n+1,n+1) to establish the arithmetic core identity.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "sum_ballotNumber_row: the main result Σ_{k=0}^{n} ballotNumber n k = catalan (n+1) — the row sums of Catalan's triangle are the Catalan numbers. Mathlib has neither the Catalan triangle nor this row-sum identity.",
+      "sum_choose_diag: Σ_{k=0}^{n} C(n+k,k) = C(2n+1,n+1) — the main-diagonal hockey-stick row sum, via symmetry and a range→Icc reindexing onto Nat.sum_Icc_choose.",
+      "sum_choose_reflected: Σ_{k=0}^{n} C(n+k,n+1) = C(2n+1,n+2) — the reflected-diagonal row sum, dropping the vanishing k=0 term and applying the hockey stick.",
+      "choose_sub_eq_catalan: C(2n+1,n+1) = catalan (n+1) + C(2n+1,n+2) — the arithmetic identity reconciling the difference of the two hockey-stick sums with the next Catalan number, via succ_mul_catalan_eq_centralBinom, Pascal+symmetry, and the absorption law.",
+      "sum_add_reflected: the additive-form row split (Σ T) + (Σ C(n+k,n+1)) = Σ C(n+k,k), sidestepping truncated ℕ subtraction by summing the per-term identity T(n,k) + C(n+k,n+1) = C(n+k,k).",
+      "choose_reflected_le (self-contained re-derivation of the parent's well-posedness C(n+k,n+1) ≤ C(n+k,k) for k ≤ n) and ballotNumber (def, restated from the parent), keeping the file independent of the heavy parent module.",
+      "CORRECTION of the seed statement: the row sum is catalan (n+1) (1,2,5,14,…), NOT C(2n+1,n); the discrepancy already appears at n=1 (row sum 2 vs C(3,1)=3)."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. No native_decide (only plain kernel `decide` on closed numeric sanity checks, which introduces no axioms). Depends only on the foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 172,
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Catalan's triangle (OEIS A009766) is the triangular array of ballot numbers T(n,k), whose diagonal entries T(n,n) are the Catalan numbers Cₙ (OEIS A000108). A basic structural fact about the array is that its row sums are again Catalan numbers: Σ_{k=0}^{n} T(n,k) = C_{n+1}. Intuitively, aggregating over all valid endpoints of a row collects every diagonal-bounded lattice path of the next length, so the total is the next ballot count. The parent entry (catalan-numbers-oq-05-oq-02) formalized the individual entries T(n,k) = C(n+k,k) − C(n+k,n+1), their closed form, and the reflection recurrence; this leaf closes the loop by aggregating a whole row.",
+    "problemStatement": "The parent's open question asked to formalize the row sum Σ_{k=0}^{n} T(n,k). The seed stated the target as C(2n+1,n), but that closed form is incorrect — for n=1 the row T(1,0)+T(1,1)=1+1=2 while C(3,1)=3. The correct value, also named in the problem's plain-language paragraph, is catalan (n+1). This entry proves Σ_{k=0}^{n} ballotNumber n k = catalan (n+1) over ℕ, reusing the parent's ballotNumber definition and well-posedness.",
+    "keyIdea": "Split the row sum additively rather than subtractively. Because each term satisfies C(n+k,n+1) ≤ C(n+k,k), the identity T(n,k) + C(n+k,n+1) = C(n+k,k) holds without truncated subtraction; summing it gives (Σ T) + B(n) = A(n) with A(n) = Σ C(n+k,k) and B(n) = Σ C(n+k,n+1). Each of A and B is a hockey-stick sum: after rewriting C(n+k,k) = C(n+k,n) by symmetry and reindexing range (n+1) onto Icc, Nat.sum_Icc_choose evaluates A(n) = C(2n+1,n+1) and B(n) = C(2n+1,n+2). Finally the arithmetic identity C(2n+1,n+1) = catalan (n+1) + C(2n+1,n+2) — obtained by multiplying through by n+2 and using (n+2)·catalan (n+1) = centralBinom (n+1) = 2·C(2n+1,n+1) together with the absorption law (n+2)·C(2n+1,n+2) = n·C(2n+1,n+1) — identifies A(n) − B(n) with the next Catalan number, and omega finishes.",
+    "proofStrategy": "(1) choose_reflected_le: from Nat.choose_succ_right_eq (n+k) n and symmetry, C(n+k,n+1)·(n+1) = C(n+k,k)·k ≤ C(n+k,k)·(n+1); cancel n+1. (2) sum_choose_diag: rewrite each C(n+k,k)=C(n+k,n) (Nat.choose_symm), rewrite the target C(2n+1,n+1) back through Nat.sum_Icc_choose (2n) n and Nat.Ico_succ_right into an Ico sum, and Finset.sum_Ico_eq_sum_range converts to the range (2n+1−n)=n+1 form. (3) sum_choose_reflected: Finset.sum_range_succ' peels the k=0 term C(n,n+1)=0, then the same hockey-stick/reindex machinery at (2n) (n+1) gives C(2n+1,n+2). (4) choose_sub_eq_catalan: establish hsym C(2n+1,n)=C(2n+1,n+1), h2 centralBinom (n+1)=2·C(2n+1,n+1) via Pascal, h3 (n+2)·catalan (n+1)=centralBinom (n+1), and h1 C(2n+1,n+2)·(n+2)=C(2n+1,n+1)·n via absorption; a calc multiplies the goal by n+2 and Nat.eq_of_mul_eq_mul_left cancels it. (5) sum_add_reflected: rewrite the goal as one sum via Finset.sum_add_distrib and discharge the per-term identity by Nat.sub_add_cancel on choose_reflected_le. (6) sum_ballotNumber_row: rewrite A and B in the split by (2)&(3), add the arithmetic identity (4), and close with omega over the opaque binomial/catalan atoms. No induction on the main results, no native_decide.",
+    "keyInsights": [
+      "The row sums of Catalan's triangle are the Catalan numbers themselves: Σ_{k=0}^{n} T(n,k) = C_{n+1}. This is the natural structural closure of the parent's per-entry work — it ties the two-parameter array back to the one-parameter sequence that indexes its diagonal.",
+      "The seeded closed form C(2n+1,n) is FALSE; the true value is catalan (n+1). The discrepancy is visible at the very first nontrivial row (n=1: sum 2, C(3,1)=3). Verifying the correct identity — and documenting the correction — is part of the contribution.",
+      "Splitting the sum additively (T(n,k) + C(n+k,n+1) = C(n+k,k)) rather than subtractively is what keeps the whole argument inside honest ℕ arithmetic: the single well-posedness inequality per term lets Finset.sum_add_distrib do the work that truncated subtraction would otherwise obstruct.",
+      "Both halves of the split are hockey-stick sums in disguise. The only real work is a range→Icc reindexing (via Nat.Ico_succ_right and Finset.sum_Ico_eq_sum_range) so that Mathlib's Nat.sum_Icc_choose applies verbatim; symmetry C(n+k,k)=C(n+k,n) aligns the summand.",
+      "The final identification with catalan (n+1) is pure ℕ absorption arithmetic: multiply by n+2, use (n+2)·catalan (n+1) = centralBinom (n+1) = 2·C(2n+1,n+1) (Pascal+symmetry) and the choose absorption law (n+2)·C(2n+1,n+2) = n·C(2n+1,n+1), then cancel — no division, no rationals."
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-header",
+      "title": "Overview: row sums of Catalan's triangle and the seed correction",
+      "startLine": 3,
+      "endLine": 51,
+      "summary": "Module docstring: states the row-sum identity Σ_{k=0}^{n} T(n,k) = catalan (n+1), documents that the seed's C(2n+1,n) is wrong (n=1 gives 2, not C(3,1)=3), explains the self-contained restatement of ballotNumber, and lays out the additive-split + hockey-stick + arithmetic-core proof plan."
+    },
+    {
+      "id": "ballot-number-def",
+      "title": "The ballot number / Catalan-triangle entry (restated)",
+      "startLine": 54,
+      "endLine": 61,
+      "summary": "ballotNumber n k := (n+k).choose k − (n+k).choose (n+1), identical to the parent's definition, restated locally so the file depends only on Mathlib."
+    },
+    {
+      "id": "choose-reflected-le",
+      "title": "Well-posedness: C(n+k,n+1) ≤ C(n+k,k)",
+      "startLine": 63,
+      "endLine": 80,
+      "summary": "choose_reflected_le: self-contained re-derivation of the parent's ordering. From the absorption law Nat.choose_succ_right_eq (n+k) n and symmetry C(n+k,n)=C(n+k,k), C(n+k,n+1)·(n+1) = C(n+k,k)·k ≤ C(n+k,k)·(n+1) since k ≤ n+1; cancel n+1."
+    },
+    {
+      "id": "sum-choose-diag",
+      "title": "Hockey stick I: Σ C(n+k,k) = C(2n+1,n+1)",
+      "startLine": 82,
+      "endLine": 95,
+      "summary": "sum_choose_diag: rewrite each C(n+k,k)=C(n+k,n) by symmetry, then convert the target central binomial through Nat.sum_Icc_choose (2n) n, Nat.Ico_succ_right, and Finset.sum_Ico_eq_sum_range into the range (n+1) sum — a verbatim hockey-stick instance."
+    },
+    {
+      "id": "sum-choose-reflected",
+      "title": "Hockey stick II: Σ C(n+k,n+1) = C(2n+1,n+2)",
+      "startLine": 97,
+      "endLine": 113,
+      "summary": "sum_choose_reflected: Finset.sum_range_succ' peels the vanishing k=0 term C(n,n+1)=0; the remaining sum is evaluated by the same hockey-stick/reindex machinery at (2n) (n+1), giving C(2n+1,n+2)."
+    },
+    {
+      "id": "choose-sub-eq-catalan",
+      "title": "Arithmetic core: C(2n+1,n+1) = catalan (n+1) + C(2n+1,n+2)",
+      "startLine": 115,
+      "endLine": 143,
+      "summary": "choose_sub_eq_catalan: assembles hsym (C(2n+1,n)=C(2n+1,n+1)), h2 (centralBinom (n+1)=2·C(2n+1,n+1) via Pascal), h3 ((n+2)·catalan (n+1)=centralBinom (n+1)), and h1 (absorption C(2n+1,n+2)·(n+2)=C(2n+1,n+1)·n); a calc multiplies through by n+2 and Nat.eq_of_mul_eq_mul_left cancels it."
+    },
+    {
+      "id": "sum-add-reflected",
+      "title": "Additive split of the row sum",
+      "startLine": 145,
+      "endLine": 157,
+      "summary": "sum_add_reflected: (Σ T) + (Σ C(n+k,n+1)) = Σ C(n+k,k) by Finset.sum_add_distrib and the per-term identity T(n,k)+C(n+k,n+1)=C(n+k,k), discharged via Nat.sub_add_cancel on choose_reflected_le."
+    },
+    {
+      "id": "main-and-checks",
+      "title": "Main theorem and Catalan sanity checks",
+      "startLine": 159,
+      "endLine": 172,
+      "summary": "sum_ballotNumber_row: combine the additive split (with the two hockey-stick evaluations) and the arithmetic core, then omega yields Σ_{k=0}^{n} ballotNumber n k = catalan (n+1). Examples confirm the first row sums 1,2,5,14 by kernel decide."
+    }
+  ],
+  "references": [
+    {
+      "authors": "André, Désiré",
+      "title": "Solution directe du problème résolu par M. Bertrand",
+      "year": "1887",
+      "note": "C. R. Acad. Sci. Paris 105, 436–437 — the reflection principle producing the ballot numbers T(n,k) whose rows are aggregated here."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "note": "Cambridge University Press — Catalan's triangle, the ballot numbers, and the row-sum / hockey-stick relations tying the array to the Catalan sequence."
+    },
+    {
+      "authors": "Graham, Ronald L.; Knuth, Donald E.; Patashnik, Oren",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Addison-Wesley — the hockey-stick (parallel summation) identity Σ_{m} C(m,k) = C(top+1,k+1) used to evaluate both halves of the row sum."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A009766 (Catalan's triangle) and A000108 (Catalan numbers)",
+      "year": "2024",
+      "note": "The On-Line Encyclopedia of Integer Sequences — Catalan's triangle T(n,k) with row sums equal to the Catalan numbers 1, 2, 5, 14, …"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "catalan-numbers-oq-05-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry defining the ballot number / Catalan-triangle entry T(n,k) = C(n+k,k) − C(n+k,n+1), its closed form, and the reflection recurrence. This leaf answers its row-sum open question (correcting the seeded C(2n+1,n) to the true value catalan (n+1))."
+    },
+    {
+      "proofId": "catalan-numbers-oq-05-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling leaf on a single ballot number as a difference of central binomials. This entry instead aggregates a full row of the triangle into the next Catalan number."
+    },
+    {
+      "proofId": "catalan-numbers-oq-05",
+      "relationship": "ancestor",
+      "description": "Grandparent entry proving the diagonal identity catalan n = C(2n,n) − C(2n,n+1). The row-sum identity here is the aggregate counterpart of that per-diagonal fact."
+    },
+    {
+      "proofId": "catalan-numbers-oq-01",
+      "relationship": "related",
+      "description": "Root Catalan-numbers entry; this leaf extends the reflection/ballot thread with a row-sum aggregation identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves that the row sums of Catalan's triangle are the Catalan numbers: Σ_{k=0}^{n} ballotNumber n k = catalan (n+1). The row sum is split additively into two hockey-stick sums A(n) = C(2n+1,n+1) and B(n) = C(2n+1,n+2) (via Nat.sum_Icc_choose after a range→Icc reindex), and A(n) − B(n) is identified with catalan (n+1) through the arithmetic identity C(2n+1,n+1) = catalan (n+1) + C(2n+1,n+2). Along the way it corrects the seed problem's erroneous closed form C(2n+1,n) to the true value catalan (n+1). Verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Completes the arithmetic layer of the parent's ballot-number strand: the two-parameter array is now tied back to the one-parameter Catalan sequence not only on its diagonal (T(n,n)=catalan n) but through its row aggregates (Σ_k T(n,k)=catalan (n+1)). The additive-split + hockey-stick + absorption recipe is reusable for other Catalan-triangle summation identities.",
+    "openQuestions": [
+      "Prove the column sums / partial row sums of Catalan's triangle in closed form, and the antidiagonal sums, completing the aggregation identities for the array.",
+      "Establish the honest Dyck-path bijection: define diagonal-bounded lattice paths as a Finset whose cardinality is ballotNumber n k, so the row sum becomes a genuine equinumerosity Σ_k |paths to row n| = |Dyck-type objects of the next size|."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "CatalanNumbersOQ05OQ02OQ01",
+    "lineCount": 172,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/CatalanNumbersOQ05OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/catalan-numbers-oq-05-oq-02-oq-01.json
+++ b/src/data/research/problems/catalan-numbers-oq-05-oq-02-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "catalan-numbers-oq-05-oq-02-oq-01",
   "title": "Row sums of Catalan's triangle: Σₖ T(n,k) = C(2n+1, n)",
-  "phase": "OBSERVE",
-  "status": "available",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -36,11 +36,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "COMPLETE: Σ_{k≤n} T(n,k)=catalan(n+1) verified 0/0 (corrected seed C(2n+1,n)→catalan(n+1)). PR opened.",
+    "builtItems": [
+      "sum_ballotNumber_row (Proofs/CatalanNumbersOQ05OQ02OQ01.lean): Σ_{k≤n} ballotNumber n k = catalan(n+1), VERIFIED 0/0",
+      "sum_choose_diag: Σ C(n+k,k)=C(2n+1,n+1); sum_choose_reflected: Σ C(n+k,n+1)=C(2n+1,n+2)",
+      "choose_sub_eq_catalan: C(2n+1,n+1)=catalan(n+1)+C(2n+1,n+2); choose_reflected_le: well-posedness re-derivation"
+    ],
+    "insights": [
+      "The seed closed form C(2n+1,n) is FALSE; the true row sum is catalan(n+1) (1,2,5,14,…). Discrepancy visible at n=1: row sum 2 vs C(3,1)=3.",
+      "Splitting the row sum additively (T(n,k)+C(n+k,n+1)=C(n+k,k), valid since C(n+k,n+1)≤C(n+k,k)) avoids truncated ℕ subtraction and lets Finset.sum_add_distrib reduce to two hockey-stick sums.",
+      "Both halves are hockey-stick sums: A(n)=Σ C(n+k,k)=C(2n+1,n+1) and B(n)=Σ C(n+k,n+1)=C(2n+1,n+2), each a range→Icc reindexing onto Nat.sum_Icc_choose.",
+      "Identification with catalan(n+1) is pure ℕ absorption arithmetic: multiply by n+2, use (n+2)·catalan(n+1)=centralBinom(n+1)=2·C(2n+1,n+1) (Pascal+symm) and (n+2)·C(2n+1,n+2)=n·C(2n+1,n+1) (Nat.choose_succ_right_eq), then cancel."
+    ],
+    "mathlibGaps": [
+      "Mathlib has Nat.sum_Icc_choose (hockey stick) but no Catalan-triangle row-sum identity; centralBinom/catalan bridge via succ_mul_catalan_eq_centralBinom"
+    ],
+    "nextSteps": [
+      "Column/antidiagonal sums of Catalan triangle in closed form",
+      "Honest Dyck-path Finset bijection to upgrade row sum to equinumerosity"
+    ]
   },
   "tags": [
     "combinatorics",


### PR DESCRIPTION
## Summary

Proves the **row-sum identity for Catalan's triangle** (`catalan-numbers-oq-05-oq-02-oq-01`, leaf of `catalan-numbers-oq-05-oq-02`):

$$\sum_{k=0}^{n} T(n,k) \;=\; \operatorname{catalan}(n+1), \qquad T(n,k) = \binom{n+k}{k} - \binom{n+k}{n+1}.$$

The row sums of Catalan's triangle are the Catalan numbers `1, 2, 5, 14, …`.

**Main theorem** `sum_ballotNumber_row : ∑ k ∈ range (n+1), ballotNumber n k = catalan (n+1)`.

## ⚠️ Correction to the seeded statement

The seed problem stated the row sum as `C(2n+1, n)`. **That is false**: for `n = 1` the row is `T(1,0)+T(1,1) = 1+1 = 2`, whereas `C(3,1) = 3`. The correct closed form is `catalan (n+1)` — exactly the value named in the problem's own plain-language paragraph and its parenthetical "equivalently `catalan (n+1)`" note. This PR proves and documents the corrected identity.

## Proof structure (all 0-sorry, 0-axiom over ℕ)

- `choose_reflected_le` — well-posedness `C(n+k,n+1) ≤ C(n+k,k)` (self-contained re-derivation via the absorption law).
- `sum_choose_diag` — `Σ C(n+k,k) = C(2n+1,n+1)` by hockey stick (`Nat.sum_Icc_choose`) after a range→Icc reindex.
- `sum_choose_reflected` — `Σ C(n+k,n+1) = C(2n+1,n+2)` (peel the vanishing `k=0` term, then hockey stick).
- `choose_sub_eq_catalan` — the arithmetic core `C(2n+1,n+1) = catalan(n+1) + C(2n+1,n+2)`, via `succ_mul_catalan_eq_centralBinom`, Pascal + symmetry, and `Nat.choose_succ_right_eq`.
- `sum_add_reflected` — additive split `(Σ T) + (Σ C(n+k,n+1)) = Σ C(n+k,k)`, avoiding truncated subtraction.

The main theorem combines the additive split with the two hockey-stick evaluations and the arithmetic core, then `omega`.

## Verification

Docker build **succeeded** (`Build completed successfully (7743 jobs)`). Zero sorries, zero axioms, no `native_decide` (only plain kernel `decide` on the `1,2,5,14` sanity checks). The file is self-contained (imports only `Mathlib`; the parent module is heavy and was crashing olean-write under host memory pressure, so `ballotNumber` and its well-posedness lemma are restated locally, identical to the parent's).

## Files

- `proofs/Proofs/CatalanNumbersOQ05OQ02OQ01.lean` (new, 172 lines, 6 theorems, 1 def)
- `src/data/proofs/catalan-numbers-oq-05-oq-02-oq-01/meta.json` (new gallery entry)
- `src/data/research/problems/catalan-numbers-oq-05-oq-02-oq-01.json` (knowledge + status → completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)