### PR TITLE
audit(isoperimetric-theorem): fix phantom decl names + equality-axiom overclaim in prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21247,10 +21247,10 @@
       "result": "clean"
     },
     "isoperimetric-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:19Z",
-      "result": "clean"
+      "agentId": "auditor-cycle-20260709-isoperimetric",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:24:30Z",
+      "result": "issues-fixed"
     },
     "isoperimetric-theorem-oq-01": {
       "auditCount": 4,

--- a/src/data/proofs/isoperimetric-theorem/meta.json
+++ b/src/data/proofs/isoperimetric-theorem/meta.json
@@ -149,16 +149,16 @@
       "title": "Equality Characterization",
       "startLine": 239,
       "endLine": 276,
-      "summary": "Defines `IsOptimal` ($4\\pi A = L^2$) and proves circles satisfy it. Axiomatizes the converse: optimality implies circularity. This **rigidity** result is the key qualitative insight.",
-      "mathContext": "Defines `IsOptimal` ($4\\$\\pi$ A = L^2$) and proves circles satisfy it. Axiomatizes the converse: optimality implies circularity. This **rigidity** result is the key qualitative insight."
+      "summary": "Defines `IsOptimal` ($4\\pi A = L^2$), proves `isOptimal_iff_ratio`, and proves `circle_isOptimal` (circles satisfy it). The converse rigidity result (optimality $\\Rightarrow$ circle) is documented in a docstring but is **not** formalized — neither proved nor axiomatized.",
+      "mathContext": "Defines `IsOptimal` ($4\\pi A = L^2$), proves `isOptimal_iff_ratio` and `circle_isOptimal` (circles are optimal). The converse rigidity result (optimality $\\Rightarrow$ circle) is documented in a docstring but is not formalized (neither proved nor axiomatized)."
     },
     {
       "id": "examples-comparison",
       "title": "Examples: Square vs Circle",
       "startLine": 281,
       "endLine": 370,
-      "summary": "Defines `Square` and `EquilateralTriangle`, computes their isoperimetric ratios ($1/16$ and $1/(12\\sqrt{3})$ respectively), and proves both are strictly suboptimal compared to circles.",
-      "mathContext": "Formal definition: Defines `Square` and `EquilateralTriangle`, computes their isoperimetric ratios ($1/16$ and $1/(12\\sqrt{3})$ respectively), and proves both are strictly suboptimal compared to circles."
+      "summary": "Defines the `Square` structure, computes its isoperimetric ratio (`square_ratio` $= 1/16$), and proves it is strictly suboptimal compared to circles (`square_suboptimal`). Also states the 3D isoperimetric inequality $36\\pi V^2 \\le S^3$ as a reference `Prop` (`isoperimetric_3d_statement`).",
+      "mathContext": "Formal definition: defines the `Square` structure, computes its isoperimetric ratio (`square_ratio` $= 1/16$), and proves it is strictly suboptimal compared to circles (`square_suboptimal`)."
     },
     {
       "id": "higher-dimensions",


### PR DESCRIPTION
## Auditor finding — claim vs. source (prose accuracy)

Re-audit of the stale `isoperimetric-theorem` entry (last audited 2026-05-03). **Counts are correct** (447 lines, 14 theorems, 17 defs, **1 axiom**, 0 sorries) — `status: axiomatized` is right. The issue is descriptive prose that named declarations absent from `Proofs/IsoperimetricTheorem.lean` and overclaimed the axiomatization.

### Phantom / wrong declaration names
| meta prose | actual in source |
|---|---|
| `ClosedCurve`, `enclosed_area` | `SimpleClosedCurve` (fields `perimeter`, `enclosedArea`) |
| `circle_achieves_equality` | `circle_achieves_optimal_ratio` |
| `isoperimetric_quotient` | `isoperimetricRatio` |
| `regular_polygon_quotient`, regular $n$-gons | *absent* |
| `EquilateralTriangle` (ratio $1/(12\sqrt3)$) | *absent* — only `Square` (`square_ratio` = 1/16) |
| "Steiner symmetrization lemma" | Steiner appears only in docstring commentary, not a lemma |
| "449-line" | 447 |

### Axiomatization overclaim
- `overview.text`: *"Axioms encode the curve-theoretic inequality **and the equality characterization**."*
- `sections[equality-case]`: *"**Axiomatizes the converse**: optimality implies circularity."*

The file has exactly **one** axiom, `isoperimetric_inequality` (the $4\pi A \le L^2$ bound). The equality/rigidity converse (optimality ⇒ circle) exists only as a bare docstring ("Characterization of Equality (Axiomatized)", lines 262–271) with **no `axiom` following it** — it is neither proved nor axiomatized. Only the forward direction `circle_isOptimal` is proved.

### Fix
Rewrote `overview.text`, both `equality-case` fields, and both `examples-comparison` fields to name the real declarations and state that the converse is documented-but-not-formalized. Also fixed malformed LaTeX (`4\$\pi$ A`). No status/count/axiom changes. Tracker bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)