### PR TITLE
Fix: sync stale leanFile counts on grown erdos-897-oq-01 (#36290)

### DIFF
--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -130,11 +130,11 @@
       "Finset"
     ],
     "namespace": "Erdos897",
-    "lineCount": 439,
+    "lineCount": 503,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 23
+    "theoremCount": 26
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

`erdos-897-oq-01` leanFile block advertised stale counts from before the file grew. `meta.*` already matched the current `Proofs/Erdos897OQ01.lean`; the nested `leanFile.*` descriptor was behind.

## Evidence

Actual file (`wc -l`, comment-aware decl count): **503 lines, 26 theorems, 1 def**.

| field | meta (before) | leanFile (before) | actual | now |
|-------|--------------|-------------------|--------|-----|
| lineCount | 503 ✓ | 439 ✗ | 503 | 503 |
| theoremCount | 26 ✓ | 23 ✗ | 26 | 26 |
| definitionCount | 1 ✓ | 1 ✓ | 1 | 1 |

Single-file entry (no `additionalFiles`), so no aggregate convention applies — `meta` and `leanFile` must agree. Updated `leanFile.lineCount` 439→503 and `leanFile.theoremCount` 23→26; they now match both `meta.*` and the source.

Part of #36290.

---
Automated fix by lean-mechanic agent.