### PR TITLE
Fix: sync stale description count summary on shannon-awgn-oq-02-oq-02

### DIFF
--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "shannon-channel-coding-awgn-oq-02-oq-02",
   "slug": "shannon-channel-coding-awgn-oq-02-oq-02",
   "title": "Multi-Symbol AWGN Output Power E[(∑Wᵢ)²] = ∑E[Wᵢ²] from the Variance of a Pairwise-Independent Sum",
-  "description": "Generalizes the parent two-term AWGN output-power identity E[(X+Z)²] = E[X²] + E[Z²] to a finite block of symbols: for pairwise-independent, zero-mean, square-integrable contributions Wᵢ (i ∈ s), the aggregate output power adds, E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The proof is the variance-of-a-sum (Bienaymé) identity for pairwise-independent families — ProbabilityTheory.IndepFun.variance_sum, where the vanishing pairwise covariances collapse the double sum to the diagonal — specialized to zero mean via E[W²] = Var[W] (ProbabilityTheory.variance_eq_sub). Pairwise (not mutual) independence already suffices. 1479 lines, 61 theorems, 0 axioms, 0 sorries.",
+  "description": "Generalizes the parent two-term AWGN output-power identity E[(X+Z)²] = E[X²] + E[Z²] to a finite block of symbols: for pairwise-independent, zero-mean, square-integrable contributions Wᵢ (i ∈ s), the aggregate output power adds, E[(∑ᵢ Wᵢ)²] = ∑ᵢ E[Wᵢ²]. The proof is the variance-of-a-sum (Bienaymé) identity for pairwise-independent families — ProbabilityTheory.IndepFun.variance_sum, where the vanishing pairwise covariances collapse the double sum to the diagonal — specialized to zero mean via E[W²] = Var[W] (ProbabilityTheory.variance_eq_sub). Pairwise (not mutual) independence already suffices. 1698 lines, 68 theorems, 0 axioms, 0 sorries.",
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
## Fix

The `description` field of `shannon-channel-coding-awgn-oq-02-oq-02` advertised **"1479 lines, 61 theorems"** — both stale.

## Evidence

**Before**: description ends `... 1479 lines, 61 theorems, 0 axioms, 0 sorries.`
**After**: `... 1698 lines, 68 theorems, 0 axioms, 0 sorries.`

Authoritative values (all agree):
- `meta.lineCount` = 1698, `meta.leanFile.lineCount` = 1698, real `wc -l` of `Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean` = 1698
- `meta.theoremCount` = 68, `meta.leanFile.theoremCount` = 68

## Scope / collision note

Touches **only** the `description` field. The in-flight #36541 corrects `theoremCount` (61→68) inside `conclusion.summary` but leaves the `description` field (which it never touches) and the `"1479 lines"` references stale. This PR edits a different line, so it merges cleanly alongside #36541. The residual `"1479 lines"` in `conclusion.summary` sits on #36541's edited line and will be swept in a follow-up cycle once #36541 lands.

Part of #36290.

---
Automated fix by lean-mechanic agent.