### PR TITLE
Enrich Multinomial Covariance: fix annotation range + cover MGF machinery

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/annotations.json
@@ -101,11 +101,38 @@
     ]
   },
   {
+    "id": "ann-mgf-differentiation",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 167,
+      "endLine": 332
+    },
+    "type": "technique",
+    "title": "Bivariate MGF Differentiation: the Cross-Moment Machinery",
+    "content": "The mathematical heart of the file — the body of multinomial_cross_moment, previously uncovered. It realizes the mixed second derivative of the joint MGF entirely inside Lean's HasDerivAt calculus, with no measure theory. (1) hmgf proves the bivariate identity ∑_k P(k)(1+a)^{k(i)}(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n by rewriting each term with the erase-based product factorization hprod (∏_l g_l^{k_l} = (1+a)^{k(i)}(1+b)^{k(j)}) and the weight-sum identity hsum_g (∑_l p_l g_l = 1+pᵢa+pⱼb), then invoking multinomial_mgf_real. (2) hstep1 differentiates both sides in a at 0 via HasDerivAt.sum + deriv_add_pow and the uniqueness of derivatives (hd_lhs.unique hd_rhs), giving ∑_k P(k)k(i)(1+b)^{k(j)} = n·pᵢ(1+pⱼb)^{n-1}. (3) hstep2 differentiates that in b at 0 to reach ∑_k P(k)k(i)k(j) = n(n-1)pᵢpⱼ. The Nat.cast_pred hn step reconciles ↑(n-1) with (n:ℝ)-1, splitting the n=0 case. The technique is a fully formalized, elementary substitute for 'differentiate the MGF twice and set the arguments to zero'.",
+    "mathContext": "$\\partial_a\\partial_b\\big|_{0}\\,(1+p_i a+p_j b)^n = n(n-1)p_ip_j$, obtained termwise as $\\sum_k P(k)\\,\\partial_a\\partial_b\\big|_0 (1+a)^{k_i}(1+b)^{k_j} = \\sum_k P(k)\\,k_i k_j = E[X_iX_j]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "moment generating function differentiation",
+      "HasDerivAt.unique",
+      "Finset.mul_prod_erase / add_sum_erase factorization",
+      "deriv_add_pow",
+      "factorial moments"
+    ],
+    "prerequisites": [
+      "HasDerivAt calculus in Mathlib (sum, comp, const_mul)",
+      "uniqueness of the derivative",
+      "multinomial_mgf_real (BinomialTheoremOQ02OQ01OQ02)",
+      "Finset.mul_prod_erase and Finset.add_sum_erase",
+      "Nat.cast_pred"
+    ]
+  },
+  {
     "id": "ann-covariance-main",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-03",
     "range": {
-      "startLine": 168,
-      "endLine": 202
+      "startLine": 333,
+      "endLine": 370
     },
     "type": "insight",
     "title": "Main Theorem: Multinomial Covariance",


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-02-oq-01-oq-03` (passes: 0).

## Defect fixed
The annotation titled **"Main Theorem: Multinomial Covariance"** had range **168–202**, but `multinomial_covariance` is at **333–370**. Its range pointed into the middle of the cross-moment proof. Corrected to 333–370 (matches the meta `sections` entry).

## Coverage added
Added **ann-mgf-differentiation** (167–332) for the previously-uncovered body of `multinomial_cross_moment` — the bivariate-MGF double-differentiation machinery (`hmgf` product/sum factorizations, `hstep1`/`hstep2` via `HasDerivAt.sum` + `deriv_add_pow` + derivative uniqueness). This is the mathematical heart of the file and was entirely unannotated.

Annotations now cover lines **1–370 contiguously** (371–392 is the summary comment block). 6 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

## Validation
- `jq empty` passes on annotations.json.
- meta.json unchanged (11.5 KB, well under cap).
- No content removed.