### PR TITLE
audit: mark ballot-problem-oq-05-oq-02 + catalan-numbers-oq-05-oq-02-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29743,6 +29743,12 @@
       "lastAudited": "2026-07-10T00:27:52Z",
       "result": "clean",
       "issues": []
+    },
+    "catalan-numbers-oq-05-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-10T00:30:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29737,6 +29737,12 @@
       "lastAudited": "2026-07-10T00:16:16Z",
       "result": "clean",
       "issues": []
+    },
+    "ballot-problem-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-10T00:27:52Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Auditor tracker bumps — two sibling entries re-audited **CLEAN** (both result: clean, auditCount 1). Tracker-only; no source/meta changes needed.

## ballot-problem-oq-05-oq-02
- Counts accurate: 5 theorems, 1 def (`reflectBallot`), 4 `decide` examples, 0 sorries, 0 axioms.
- No native_decide (examples use kernel `decide`, no `Lean.ofReduceBool`).
- Every theorem statement matches meta: `reflectBallot_eq` is a genuine binomial-symmetry derivation; transported corollaries honestly disclose delegation to parent `ballotNumber_mul_add/_div/_catalan`. Parent `BallotProblemOQ05` is axiom-free.
- badge=original defensible; status=verified correct.

## catalan-numbers-oq-05-oq-02-oq-01
- Counts accurate: 6 theorems, 1 def (`ballotNumber`), 4 `decide` examples, 0 sorries, 0 axioms.
- No native_decide (plain kernel `decide` only).
- Main theorem `sum_ballotNumber_row` (Σ ballotNumber n k = catalan(n+1)) genuinely proved via hockey-stick + Pascal/symmetry + `succ_mul_catalan_eq_centralBinom`. All 7 originalContributions map to real decls.
- **Exemplary honesty**: openly corrects the false seed statement (`C(2n+1,n)` is wrong; row sums are `catalan(n+1)`).
- badge=original defensible (Mathlib has neither the Catalan triangle nor this identity); status=verified correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)