### PR TITLE
Enrich Bézout OQ-04-OQ-01: realign 10 misplaced annotation ranges

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 37
+      "endLine": 42
     },
     "type": "concept",
     "title": "Imports and Mathematical Context",
@@ -27,8 +27,8 @@
     "id": "ann-unimodular-def",
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
-      "startLine": 47,
-      "endLine": 74
+      "startLine": 43,
+      "endLine": 91
     },
     "type": "definition",
     "title": "Unimodular Matrices: The ℤ-Invertibility Condition",
@@ -53,8 +53,8 @@
     "id": "ann-snf-structure",
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
-      "startLine": 78,
-      "endLine": 109
+      "startLine": 92,
+      "endLine": 126
     },
     "type": "theorem",
     "title": "Smith Normal Form Structure: Invariant Factors and Decomposition",
@@ -79,8 +79,8 @@
     "id": "ann-snf-exists",
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
-      "startLine": 111,
-      "endLine": 131
+      "startLine": 127,
+      "endLine": 168
     },
     "type": "concept",
     "title": "SNF Existence Axiom: Euclidean Row/Column Reduction",
@@ -104,8 +104,8 @@
     "id": "ann-invariant-factor-rank",
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
-      "startLine": 133,
-      "endLine": 148
+      "startLine": 169,
+      "endLine": 184
     },
     "type": "definition",
     "title": "Invariant Factor Extraction and Matrix Rank",
@@ -129,8 +129,8 @@
     "id": "ann-solvability-criterion",
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
-      "startLine": 149,
-      "endLine": 167
+      "startLine": 185,
+      "endLine": 204
     },
     "type": "concept",
     "title": "Solvability Criterion: Diagonal Reduction of the System",
@@ -155,8 +155,8 @@
     "id": "ann-bezout-from-snf",
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
-      "startLine": 169,
-      "endLine": 202
+      "startLine": 205,
+      "endLine": 311
     },
     "type": "insight",
     "title": "Classical Bézout Recovery: SNF Specializes to GCD",
@@ -181,8 +181,8 @@
     "id": "ann-null-space",
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
-      "startLine": 204,
-      "endLine": 231
+      "startLine": 312,
+      "endLine": 355
     },
     "type": "concept",
     "title": "Integer Null Space: A Free ℤ-Submodule",
@@ -207,8 +207,8 @@
     "id": "ann-solution-lattice",
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
-      "startLine": 233,
-      "endLine": 257
+      "startLine": 356,
+      "endLine": 381
     },
     "type": "insight",
     "title": "Affine Lattice of Solutions: Coset Structure",
@@ -233,8 +233,8 @@
     "id": "ann-examples",
     "proofId": "bezout-identity-oq-04-oq-01",
     "range": {
-      "startLine": 259,
-      "endLine": 285
+      "startLine": 382,
+      "endLine": 409
     },
     "type": "concept",
     "title": "Concrete Examples: Solvability and Obstruction",


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-04-oq-01` (passes: 0).

## Defect fixed
All 10 annotation `range`s were shifted **earlier** than the Lean code their content describes — they were authored against an earlier, shorter revision of the file. On the gallery this highlights the wrong lines (e.g. the "Concrete Examples" annotation, whose content is about `three_var_example` / `two_var_no_solution` at lines 382–409, was anchored to 259–285, inside the `snf_1x2` proof).

## Fix
Realigned every annotation range to its matching `meta.json` `sections` entry (which were already correct) and the actual declarations:

| annotation | old | new |
|---|---|---|
| imports | 1–37 | 1–42 |
| unimodular | 47–74 | 43–91 |
| snf-structure | 78–109 | 92–126 |
| snf-exists | 111–131 | 127–168 |
| invariant-factor | 133–148 | 169–184 |
| solvability | 149–167 | 185–204 |
| bezout-from-snf | 169–202 | 205–311 |
| null-space | 204–231 | 312–355 |
| solution-lattice | 233–257 | 356–381 |
| examples | 259–285 | 382–409 |

Annotation **content is unchanged** — only ranges corrected. Coverage is now contiguous over lines 1–409 (410–473 is the summary comment block).

## Validation
- `jq empty` passes; ranges verified to match meta sections 1:1.
- meta.json untouched.