### PR TITLE
Enrich Area-of-Circle OQ-05-OQ-01: realign 6 stale annotation ranges

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "area-of-circle-oq-05-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 22
+      "endLine": 37
     },
     "type": "concept",
     "title": "OQ-01: Formalizing the Polar-Coordinate Proof of the Gaussian Integral",
@@ -27,8 +27,8 @@
     "id": "ann-polar-sum-sq",
     "proofId": "area-of-circle-oq-05-oq-01",
     "range": {
-      "startLine": 59,
-      "endLine": 67
+      "startLine": 68,
+      "endLine": 94
     },
     "type": "concept",
     "title": "polar_sum_sq: Pythagorean Identity for Polar Coordinates (0 sorry)",
@@ -49,8 +49,8 @@
     "id": "ann-polar-cov",
     "proofId": "area-of-circle-oq-05-oq-01",
     "range": {
-      "startLine": 69,
-      "endLine": 82
+      "startLine": 95,
+      "endLine": 103
     },
     "type": "concept",
     "title": "integral_comp_polarCoord_symm: The Key Change-of-Variables Theorem",
@@ -72,8 +72,8 @@
     "id": "ann-radial-import",
     "proofId": "area-of-circle-oq-05-oq-01",
     "range": {
-      "startLine": 100,
-      "endLine": 108
+      "startLine": 122,
+      "endLine": 131
     },
     "type": "concept",
     "title": "Reusing GaussianIntegralCircle.radial_integral from AreaOfCircleOQ05",
@@ -95,8 +95,8 @@
     "id": "ann-angular",
     "proofId": "area-of-circle-oq-05-oq-01",
     "range": {
-      "startLine": 84,
-      "endLine": 98
+      "startLine": 104,
+      "endLine": 121
     },
     "type": "insight",
     "title": "Angular Integral 2π: The Geometric Origin of π",
@@ -119,8 +119,8 @@
     "id": "ann-main-polar",
     "proofId": "area-of-circle-oq-05-oq-01",
     "range": {
-      "startLine": 135,
-      "endLine": 152
+      "startLine": 175,
+      "endLine": 201
     },
     "type": "insight",
     "title": "gaussian_integral_sq_via_polar: The Complete Proof Chain",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-05-oq-01` (passes: 0).

## Defect
All 6 annotation `range`s were stale relative to the current Lean file (the file grew after the annotations were authored), so the gallery highlighted the **wrong code** for every annotation — e.g. the `polar_sum_sq` annotation pointed at 59–67 but the theorem is at line 79; the main-theorem annotation pointed at 135–152 but `gaussian_integral_sq_via_polar` is at 188.

## Fix
Realigned each annotation to contain its subject theorem (verified by grepping the decl inside each new range):

| annotation | old | new | theorem |
|---|---|---|---|
| overview | 1–22 | 1–37 | module docstring |
| polar_sum_sq | 59–67 | 68–94 | `polar_sum_sq` @79 |
| polar-cov | 69–82 | 95–103 | `double_integral_eq_polar` @95 |
| angular | 84–98 | 104–121 | `angular_integral` @117 |
| radial-import | 100–108 | 122–131 | `radial_integral_eq` @128 |
| main-polar | 135–152 | 175–201 | `gaussian_integral_sq_via_polar` @188 |

Content unchanged. `jq empty` passes.

**Note for a follow-up pass:** the `meta.json` `sections` are also drifted, and Sections I (Fubini), V (factorization), and VII (circle-area connection) have no annotation. Left out of this PR to keep it a clean, verifiable range fix.