### PR TITLE
Research: handshake-lemma-oq-01 — minimal edge/degree deficiency from handshake parity [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/HandshakeLemmaOQ01.lean
+++ b/proofs/Proofs/HandshakeLemmaOQ01.lean
@@ -1,0 +1,135 @@
+import Mathlib
+
+/-!
+# Minimal edge/degree deficiency from the handshake parity obstruction
+
+## Open question (`handshake-lemma-oq-01`)
+
+The parent entry (`HandshakeLemma.lean`) proves the handshake lemma
+`∑_v deg(v) = 2·|E|` and its parity corollary that the number of odd-degree
+vertices is even. Its first open question asks to **quantify the parity
+obstruction**: for `d`-regular graphs on `n` vertices with `d` odd and `n` odd
+(which cannot exist), what is the *minimal deficiency* — how far must any actual
+graph fall short of the regular ideal, and is that floor attained?
+
+## What this entry proves
+
+Fix a target degree `d`. For a finite simple graph `G` on `n = |V|` vertices
+whose every vertex has degree `≤ d`, define the **degree deficiency**
+
+  `deficiency G d = ∑_v (d − deg v) = n·d − ∑_v deg v = n·d − 2·|E|`.
+
+Because `∑_v deg v = 2·|E|` is always even, the deficiency has the **same parity
+as `n·d`**. Hence:
+
+* `deficiency_eq` — the deficiency equals `n·d − 2·|E|` (assuming `deg ≤ d`).
+* `deficiency_parity` — `deficiency G d ≡ n·d  (mod 2)`.
+* `deficiency_odd` / `one_le_deficiency` — when `n·d` is **odd**, the deficiency is
+  odd, hence `≥ 1`: a `d`-regular graph is impossible and *any* graph with
+  `deg ≤ d` misses the ideal degree sum by at least `1`.
+* `edge_upper_bound` — equivalently `2·|E| ≤ n·d − 1`: the edge count cannot reach
+  the regular ideal `n·d/2`; this is the **minimal edge deficiency**.
+* `not_isRegularOfDegree_of_odd_mul` — the clean impossibility corollary: no
+  `d`-regular graph on `n` vertices exists once `n·d` is odd (in particular when
+  both `n` and `d` are odd).
+
+## Sharpness
+
+The floor `1` is attained: `deficiency_floor_attained` exhibits the empty graph on
+one vertex with `d = 1`, where `n·d = 1` is odd and the deficiency is exactly `1`.
+So the lower bound `one_le_deficiency` cannot be improved.
+
+Everything is sorry-free and axiom-free; the sharpness witness uses kernel
+`decide`, not `native_decide`, so no extra trust assumptions are introduced.
+-/
+
+namespace HandshakeLemmaOQ01
+
+open Finset SimpleGraph
+
+variable {V : Type*} [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-- **Degree deficiency toward `d`-regularity.**
+`deficiency G d = ∑_v (d − deg v)`, the total shortfall of the vertex degrees
+from the target degree `d`. When `deg v ≤ d` for all `v` this is `n·d − 2|E|`. -/
+def deficiency (d : ℕ) : ℕ := ∑ v, (d - G.degree v)
+
+/-- The degree sum is even — the handshake identity `∑ deg = 2|E|`. -/
+theorem even_sum_degrees : Even (∑ v, G.degree v) := by
+  rw [G.sum_degrees_eq_twice_card_edges]; exact even_two_mul _
+
+/-- **Deficiency as an ideal shortfall.** If every vertex has degree at most `d`
+then `deficiency G d = n·d − ∑_v deg v = n·d − 2|E|`. -/
+theorem deficiency_eq (d : ℕ) (hbound : ∀ v, G.degree v ≤ d) :
+    deficiency G d = Fintype.card V * d - ∑ v, G.degree v := by
+  unfold deficiency
+  rw [Finset.sum_tsub_distrib _ (fun v _ => hbound v), Finset.sum_const, Finset.card_univ,
+    smul_eq_mul]
+
+/-- The deficiency has the same parity as `n·d`: it differs from `n·d` by the even
+number `∑_v deg v = 2|E|`. -/
+theorem deficiency_parity (d : ℕ) (hbound : ∀ v, G.degree v ≤ d) :
+    deficiency G d % 2 = (Fintype.card V * d) % 2 := by
+  obtain ⟨m, hm⟩ := even_sum_degrees G
+  have hle : ∑ v, G.degree v ≤ Fintype.card V * d := by
+    calc ∑ v, G.degree v ≤ ∑ _v : V, d := Finset.sum_le_sum (fun v _ => hbound v)
+      _ = Fintype.card V * d := by rw [Finset.sum_const, Finset.card_univ, smul_eq_mul]
+  rw [deficiency_eq G d hbound]
+  omega
+
+/-- **The parity obstruction, quantitative form.** If `n·d` is odd then the degree
+deficiency is odd. -/
+theorem deficiency_odd (d : ℕ) (hbound : ∀ v, G.degree v ≤ d)
+    (hodd : Odd (Fintype.card V * d)) : Odd (deficiency G d) := by
+  rw [Nat.odd_iff] at hodd ⊢
+  rw [deficiency_parity G d hbound, hodd]
+
+/-- **Minimal deficiency `≥ 1`.** When `n·d` is odd, *every* graph with `deg ≤ d`
+has degree deficiency at least `1`; there is no `d`-regular graph. -/
+theorem one_le_deficiency (d : ℕ) (hbound : ∀ v, G.degree v ≤ d)
+    (hodd : Odd (Fintype.card V * d)) : 1 ≤ deficiency G d := by
+  obtain ⟨k, hk⟩ := deficiency_odd G d hbound hodd
+  omega
+
+/-- **Minimal edge deficiency.** When `n·d` is odd, the number of edges satisfies
+`2·|E| ≤ n·d − 1`: the edge count cannot reach the regular ideal `n·d / 2`. -/
+theorem edge_upper_bound (d : ℕ) (hbound : ∀ v, G.degree v ≤ d)
+    (hodd : Odd (Fintype.card V * d)) :
+    2 * G.edgeFinset.card ≤ Fintype.card V * d - 1 := by
+  have hdef := one_le_deficiency G d hbound hodd
+  rw [deficiency_eq G d hbound, G.sum_degrees_eq_twice_card_edges] at hdef
+  have hle : 2 * G.edgeFinset.card ≤ Fintype.card V * d := by
+    rw [← G.sum_degrees_eq_twice_card_edges]
+    calc ∑ v, G.degree v ≤ ∑ _v : V, d := Finset.sum_le_sum (fun v _ => hbound v)
+      _ = Fintype.card V * d := by rw [Finset.sum_const, Finset.card_univ, smul_eq_mul]
+  omega
+
+/-- **Impossibility corollary.** No `d`-regular graph on `n` vertices exists when
+`n·d` is odd — in particular when both `n` and `d` are odd. -/
+theorem not_isRegularOfDegree_of_odd_mul (d : ℕ) (hodd : Odd (Fintype.card V * d)) :
+    ¬ G.IsRegularOfDegree d := by
+  intro hreg
+  -- A `d`-regular graph has `∑ deg = n·d`, which would be odd, contradicting handshake parity.
+  have hsum : ∑ v, G.degree v = Fintype.card V * d := by
+    simp only [hreg.degree_eq, Finset.sum_const, Finset.card_univ, smul_eq_mul]
+  have heven : Even (Fintype.card V * d) := hsum ▸ even_sum_degrees G
+  obtain ⟨a, ha⟩ := hodd
+  obtain ⟨b, hb⟩ := heven
+  omega
+
+/-- **The impossibility for `n` and `d` both odd** (the headline case). -/
+theorem not_isRegularOfDegree_of_odd_odd (d : ℕ) (hn : Odd (Fintype.card V))
+    (hd : Odd d) : ¬ G.IsRegularOfDegree d :=
+  not_isRegularOfDegree_of_odd_mul G d (hn.mul hd)
+
+/-- **Sharpness: the floor `1` is attained.** The empty graph on a single vertex,
+with target degree `d = 1`, has `n·d = 1` odd and degree deficiency exactly `1`.
+So the lower bound `one_le_deficiency` cannot be improved. -/
+theorem deficiency_floor_attained :
+    deficiency (⊥ : SimpleGraph (Fin 1)) 1 = 1 := by decide
+
+/-- The witness graph indeed has `n·d = 1` odd and every degree `≤ 1`. -/
+example : Odd (Fintype.card (Fin 1) * 1) := by decide
+example : ∀ v, (⊥ : SimpleGraph (Fin 1)).degree v ≤ 1 := by decide
+
+end HandshakeLemmaOQ01

--- a/src/data/proofs/handshake-lemma-oq-01/meta.json
+++ b/src/data/proofs/handshake-lemma-oq-01/meta.json
@@ -1,0 +1,222 @@
+{
+  "id": "handshake-lemma-oq-01",
+  "title": "Minimal Edge Deficiency from the Handshake Parity Obstruction",
+  "slug": "handshake-lemma-oq-01",
+  "description": "The parent entry (handshake-lemma) proves ∑_v deg v = 2|E| and its parity corollary. Its first open question asks to QUANTIFY the parity obstruction: for d-regular graphs on n vertices with n·d odd — which cannot exist — how far must any actual graph fall short of the regular ideal, and is that floor attained? This entry answers it. Fix a target degree d and, for a finite simple graph G on n = |V| vertices with every degree ≤ d, define the degree deficiency deficiency G d = ∑_v (d − deg v) = n·d − 2|E|. Because ∑_v deg v = 2|E| is always even (handshake lemma), the deficiency has the SAME PARITY as n·d. Hence: (i) deficiency_eq: deficiency = n·d − 2|E|; (ii) deficiency_parity: deficiency ≡ n·d (mod 2); (iii) deficiency_odd / one_le_deficiency: when n·d is odd the deficiency is odd, so ≥ 1 — no d-regular graph exists and every graph with deg ≤ d misses the ideal degree sum by at least 1; (iv) edge_upper_bound: equivalently 2|E| ≤ n·d − 1, the minimal EDGE deficiency (the edge count cannot reach the regular ideal n·d/2); (v) not_isRegularOfDegree_of_odd_mul and not_isRegularOfDegree_of_odd_odd: the clean impossibility corollary (no d-regular graph once n·d is odd, in particular when n and d are both odd). Sharpness: deficiency_floor_attained exhibits the empty graph on one vertex with d = 1, where n·d = 1 is odd and the deficiency is exactly 1, so the lower bound cannot be improved. Verified, 0 axioms, 0 sorries; the sharpness witness uses kernel decide, not native_decide, so no extra trust assumptions are introduced.",
+  "meta": {
+    "author": "Classical (handshake parity); quantitative deficiency formulation and Lean formalization original",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Handshaking_lemma",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HandshakeLemmaOQ01.lean",
+    "tags": [
+      "graph-theory",
+      "combinatorics",
+      "handshake-lemma",
+      "parity",
+      "regular-graph",
+      "degree-sequence",
+      "edge-count",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.sum_degrees_eq_twice_card_edges",
+        "description": "∑_v G.degree v = 2·|E|. The handshake identity; supplies the evenness of the degree sum that pins the deficiency's parity to n·d.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
+      },
+      {
+        "theorem": "Finset.sum_tsub_distrib",
+        "description": "(∀ x ∈ s, g x ≤ f x) → ∑ (f x − g x) = ∑ f x − ∑ g x. Distributes the truncated subtraction in ∑_v (d − deg v), giving deficiency = ∑_v d − ∑_v deg v = n·d − ∑_v deg v under the degree bound deg ≤ d.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_const",
+        "description": "∑ _ ∈ s, c = s.card • c. Evaluates ∑_v d = |V|·d, the ideal (regular) degree sum against which the deficiency is measured.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "SimpleGraph.IsRegularOfDegree",
+        "description": "IsRegularOfDegree d := ∀ v, G.degree v = d. The regularity predicate whose impossibility (when n·d is odd) is the headline corollary; IsRegularOfDegree.degree_eq extracts deg v = d to compute ∑ deg = n·d.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "Even.mul (Odd.mul)",
+        "description": "Odd m → Odd n → Odd (m·n). Combines odd n and odd d into odd n·d, the hypothesis of the both-odd impossibility corollary.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "deficiency: the degree deficiency ∑_v (d − deg v) of a finite simple graph toward d-regularity — the total shortfall of the vertex degrees from a target degree d; equals n·d − 2|E| when every degree is ≤ d.",
+      "deficiency_parity: the deficiency is congruent to n·d modulo 2, because it differs from n·d by the even number ∑_v deg v = 2|E|. This is the exact quantitative content of the handshake parity obstruction.",
+      "one_le_deficiency: when n·d is odd, every graph with deg ≤ d has deficiency ≥ 1 — the sharp lower bound on how far any realisable graph must fall short of the d-regular ideal.",
+      "edge_upper_bound: the minimal EDGE deficiency 2|E| ≤ n·d − 1 when n·d is odd — the edge count cannot reach the regular ideal n·d/2.",
+      "not_isRegularOfDegree_of_odd_mul / not_isRegularOfDegree_of_odd_odd: no d-regular graph on n vertices exists once n·d is odd (in particular when both n and d are odd), the impossibility corollary that motivated the deficiency quantification.",
+      "deficiency_floor_attained: sharpness — the empty graph on one vertex with d = 1 has n·d = 1 odd and deficiency exactly 1, so the lower bound one_le_deficiency is attained and cannot be improved."
+    ],
+    "dateAdded": "2026-07-09",
+    "relatedProblems": [
+      {
+        "id": "handshake-lemma",
+        "relationship": "Parent entry. The handshake lemma supplies the evenness of the degree sum; this entry turns that parity into a quantitative deficiency bound and the d-regular impossibility for odd n·d."
+      },
+      {
+        "id": "handshake-lemma-oq-02",
+        "relationship": "Sibling. handshake-lemma-oq-02 formalises the necessity of the Erdős–Gallai inequalities (which degree sequences are graphical); this entry quantifies the parity necessary condition and the minimal deficiency when it fails."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 135,
+    "assumptions": "0 axioms, 0 sorries. The sharpness witness deficiency_floor_attained and the two accompanying examples use kernel `decide` (not `native_decide`), so no Lean.ofReduceBool and no extra trust assumptions are introduced; #print axioms on the main results reports only the foundational propext / Classical.choice / Quot.sound. Scope: this quantifies the parity obstruction and proves the deficiency lower bound is attained by an explicit witness. It does NOT prove general realisability — that for every odd n·d there is a graph with deg ≤ d and deficiency exactly 1 — which is a degree-sequence construction (Erdős–Gallai / Havel–Hakimi territory, handshake-lemma-oq-02).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The handshake lemma states the one easy necessary condition for d-regularity: since ∑_v deg v = 2|E| is even, a d-regular graph on n vertices needs n·d even. When n·d is odd no such graph exists — the classic parity obstruction (e.g. no 3-regular graph on 5 vertices). The natural follow-up, and the parent entry's first open question, is to make the obstruction quantitative: not merely 'impossible', but 'how far off must you be, and is that minimum achievable?'. This entry answers it with a degree-deficiency functional whose parity is forced by the handshake lemma.",
+    "problemStatement": "Quantify the handshake parity obstruction. For a finite simple graph G on n vertices with every degree ≤ a target d, measure the degree deficiency ∑_v (d − deg v) = n·d − 2|E|. Show it has the same parity as n·d, so that when n·d is odd it is odd and hence ≥ 1 (no d-regular graph, and the edge count is capped at (n·d − 1)/2), and exhibit a witness attaining the floor 1.",
+    "text": "For a target degree d, the deficiency ∑_v (d − deg v) measures the total shortfall of the degrees from d. Under deg ≤ d it equals n·d − ∑_v deg v, and by the handshake lemma ∑_v deg v = 2|E| is even. Therefore deficiency ≡ n·d (mod 2). When n·d is odd the deficiency is odd, hence at least 1: a d-regular graph (deficiency 0) is impossible, and equivalently 2|E| ≤ n·d − 1 so the edge count falls short of the regular ideal n·d/2. The bound is sharp: the one-vertex empty graph with d = 1 has n·d = 1 odd and deficiency exactly 1.",
+    "proofStrategy": "Everything is finite arithmetic over ℕ once the deficiency is expressed against the ideal degree sum.\n\n1. **Deficiency as shortfall (deficiency_eq).** With deg ≤ d pointwise, Finset.sum_tsub_distrib turns ∑_v (d − deg v) into ∑_v d − ∑_v deg v, and Finset.sum_const evaluates ∑_v d = n·d.\n\n2. **Parity (deficiency_parity).** The handshake lemma gives ∑_v deg v = 2|E| even; writing it as 2m, omega concludes (n·d − 2m) ≡ n·d (mod 2).\n\n3. **Odd ⇒ ≥ 1 (deficiency_odd, one_le_deficiency).** If n·d is odd then the deficiency's residue is 1, so it is odd and positive.\n\n4. **Edge form (edge_upper_bound).** Substituting ∑ deg = 2|E| into deficiency ≥ 1 gives 2|E| ≤ n·d − 1.\n\n5. **Impossibility (not_isRegularOfDegree_of_odd_mul).** A d-regular graph has ∑ deg = n·d; evenness of ∑ deg then contradicts n·d odd.\n\n6. **Sharpness (deficiency_floor_attained).** Kernel `decide` evaluates the one-vertex empty graph: deficiency = 1.",
+    "keyInsights": [
+      "**The obstruction is a parity functional, not just an impossibility.** Rather than only asserting 'no d-regular graph when n·d is odd', the deficiency ∑_v (d − deg v) records exactly how far a graph is from regular, and the handshake lemma pins its parity to n·d — turning a yes/no obstruction into a sharp numeric lower bound.",
+      "**Evenness of the degree sum is the whole engine.** ∑_v deg v = 2|E| is even, so subtracting it from the ideal n·d cannot change parity: deficiency ≡ n·d (mod 2). The single fact 2 | ∑ deg drives every consequence.",
+      "**Degree deficiency and edge deficiency are the same statement.** deficiency = n·d − 2|E|, so a degree shortfall of ≥ 1 is exactly an edge-count cap 2|E| ≤ n·d − 1: the graph cannot reach the regular ideal of n·d/2 edges.",
+      "**The floor is attained, so the bound is sharp.** The one-vertex empty graph with d = 1 realises deficiency exactly 1 with n·d = 1 odd, certifying that one_le_deficiency cannot be strengthened. General realisability of the floor (a near-regular graph for every odd n·d) is a separate degree-sequence construction, left to the Erdős–Gallai sibling."
+    ],
+    "prerequisites": [
+      "Simple graphs, vertex degrees, and the handshake lemma (Mathlib SimpleGraph)",
+      "The regularity predicate IsRegularOfDegree and the parity obstruction to d-regularity",
+      "Finset cardinality, sums of constants, and truncated (ℕ) subtraction",
+      "Parity reasoning modulo 2 (Even / Odd, omega)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "mathContext": "Goal: quantify the deficiency $\\sum_v (d-\\deg v) = n\\cdot d - 2|E|$ and its parity when $n\\cdot d$ is odd.",
+      "summary": "Module docstring framing the open question and the deficiency approach, import of Mathlib, and the namespace/open/variable setup (a finite SimpleGraph G with decidable adjacency)."
+    },
+    {
+      "id": "sec-deficiency",
+      "title": "The Degree Deficiency and its Ideal-Shortfall Form",
+      "startLine": 57,
+      "endLine": 82,
+      "mathContext": "$\\mathrm{deficiency}\\,G\\,d = \\sum_v (d-\\deg v) = n\\cdot d - \\sum_v \\deg v$",
+      "summary": "The definition deficiency G d and even_sum_degrees (∑ deg = 2|E| is even), then deficiency_eq expressing the deficiency as n·d − ∑ deg via Finset.sum_tsub_distrib and Finset.sum_const under the degree bound."
+    },
+    {
+      "id": "sec-parity",
+      "title": "Parity of the Deficiency and the Lower Bound",
+      "startLine": 83,
+      "endLine": 108,
+      "mathContext": "$\\mathrm{deficiency}\\equiv n\\cdot d\\ (\\mathrm{mod}\\ 2)$; $n\\cdot d$ odd $\\Rightarrow \\mathrm{deficiency}\\ge 1$.",
+      "summary": "deficiency_parity (same parity as n·d, since it differs by the even ∑ deg), deficiency_odd (odd when n·d is odd), and one_le_deficiency (hence ≥ 1) — the quantitative parity obstruction."
+    },
+    {
+      "id": "sec-edge-impossibility",
+      "title": "Edge Bound and the d-Regular Impossibility",
+      "startLine": 109,
+      "endLine": 124,
+      "mathContext": "$2|E|\\le n\\cdot d - 1$; no $d$-regular graph when $n\\cdot d$ is odd.",
+      "summary": "edge_upper_bound (the minimal edge deficiency 2|E| ≤ n·d − 1) and not_isRegularOfDegree_of_odd_mul / not_isRegularOfDegree_of_odd_odd (no d-regular graph when n·d is odd, in particular n and d both odd)."
+    },
+    {
+      "id": "sec-sharpness",
+      "title": "Sharpness: the Floor is Attained",
+      "startLine": 125,
+      "endLine": 135,
+      "mathContext": "Empty graph on $\\mathrm{Fin}\\,1$ with $d=1$: $n\\cdot d = 1$ odd, deficiency $=1$.",
+      "summary": "deficiency_floor_attained certifies (by kernel decide) that the one-vertex empty graph with d = 1 attains deficiency exactly 1, so the lower bound cannot be improved; two examples confirm n·d = 1 is odd and all degrees are ≤ 1."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "handshake-lemma",
+      "relationship": "extends",
+      "description": "The handshake lemma gives the even degree sum; this entry turns that parity into a quantitative deficiency bound and the d-regular impossibility when n·d is odd."
+    },
+    {
+      "targetId": "handshake-lemma-oq-02",
+      "relationship": "related",
+      "description": "The Erdős–Gallai necessity sibling characterises which degree sequences are graphical; this entry quantifies the parity necessary condition and the minimal deficiency when it fails."
+    }
+  ],
+  "conclusion": {
+    "summary": "The handshake parity obstruction is made quantitative via a degree-deficiency functional ∑_v (d − deg v) = n·d − 2|E|. Because the degree sum is even, the deficiency shares the parity of n·d, so when n·d is odd it is odd and hence ≥ 1: no d-regular graph exists, the edge count is capped at (n·d − 1)/2, and the floor 1 is attained by an explicit one-vertex witness. Verified, 0 axioms, 0 sorries.",
+    "implications": "Upgrades the classical 'impossible when n·d is odd' to a sharp numeric bound with an attained minimum, and packages the impossibility as a reusable corollary (not_isRegularOfDegree_of_odd_mul). The deficiency-parity pattern — measure the shortfall against an ideal and let an even invariant fix its parity — applies to other regularity/realisability obstructions.",
+    "openQuestions": [
+      "General realisability of the floor: prove that for every odd n·d there EXISTS a simple graph on n vertices with all degrees ≤ d and deficiency exactly 1 (a near-regular graph), turning the sharpness witness into a theorem for all n, d — a degree-sequence construction in the spirit of Havel–Hakimi.",
+      "Relate the deficiency to the number of odd-degree vertices: bound deficiency below by (number of vertices whose degree has the wrong parity relative to d)/2, connecting to the even-odd-degree corollary of the handshake lemma.",
+      "Extend to prescribed non-constant degree targets d : V → ℕ, quantifying the shortfall ∑_v (d v − deg v) and its parity against ∑_v d v."
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/HandshakeLemmaOQ01.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "SimpleGraph"
+    ],
+    "namespace": "HandshakeLemmaOQ01",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 9
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Solutio problematis ad geometriam situs pertinentis",
+      "year": "1736",
+      "venue": "Commentarii academiae scientiarum Petropolitanae 8, 128–140",
+      "note": "Origin of the handshake lemma (even degree sum) whose parity drives the deficiency bound."
+    },
+    {
+      "authors": "West, Douglas B.",
+      "title": "Introduction to Graph Theory",
+      "year": "2001",
+      "venue": "Prentice Hall (2nd ed.)",
+      "note": "Standard reference for the handshake lemma, regular graphs, and the parity obstruction to d-regularity for odd n·d."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "one_le_deficiency",
+      "type": "core",
+      "description": "When n·d is odd, every finite simple graph with all degrees ≤ d has degree deficiency ∑_v (d − deg v) ≥ 1 — the sharp minimal shortfall from d-regularity.",
+      "leanType": "(d : ℕ) → (∀ v, G.degree v ≤ d) → Odd (Fintype.card V * d) → 1 ≤ deficiency G d"
+    },
+    {
+      "name": "deficiency_parity",
+      "type": "supporting",
+      "description": "The degree deficiency is congruent to n·d modulo 2, since it differs from n·d by the even degree sum 2|E|.",
+      "leanType": "(d : ℕ) → (∀ v, G.degree v ≤ d) → deficiency G d % 2 = (Fintype.card V * d) % 2"
+    },
+    {
+      "name": "edge_upper_bound",
+      "type": "supporting",
+      "description": "The minimal edge deficiency: when n·d is odd, 2|E| ≤ n·d − 1, so the edge count cannot reach the regular ideal n·d/2.",
+      "leanType": "(d : ℕ) → (∀ v, G.degree v ≤ d) → Odd (Fintype.card V * d) → 2 * G.edgeFinset.card ≤ Fintype.card V * d - 1"
+    },
+    {
+      "name": "not_isRegularOfDegree_of_odd_odd",
+      "type": "supporting",
+      "description": "No d-regular graph on n vertices exists when both n and d are odd (the classical parity obstruction).",
+      "leanType": "(d : ℕ) → Odd (Fintype.card V) → Odd d → ¬ G.IsRegularOfDegree d"
+    },
+    {
+      "name": "deficiency_floor_attained",
+      "type": "supporting",
+      "description": "Sharpness: the empty graph on one vertex with d = 1 (n·d = 1 odd) has deficiency exactly 1, so one_le_deficiency is attained.",
+      "leanType": "deficiency (⊥ : SimpleGraph (Fin 1)) 1 = 1"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the parent's first open question (`handshake-lemma-oq-01`): **quantify the handshake parity obstruction** to d-regularity.

For a finite simple graph `G` on `n = |V|` vertices with every degree `≤ d`, define the **degree deficiency**
```
deficiency G d = ∑_v (d − deg v) = n·d − 2|E|.
```
Since `∑_v deg v = 2|E|` is always even (handshake lemma), the deficiency has the **same parity as n·d**. Consequences:

- `deficiency_eq` — `deficiency = n·d − 2|E|` (under `deg ≤ d`)
- `deficiency_parity` — `deficiency ≡ n·d (mod 2)`
- `deficiency_odd` / `one_le_deficiency` — when `n·d` is **odd**, deficiency is odd hence **≥ 1**: no d-regular graph, and every graph misses the ideal by ≥ 1
- `edge_upper_bound` — equivalently `2|E| ≤ n·d − 1` (the **minimal edge deficiency**: edge count can't reach the regular ideal `n·d/2`)
- `not_isRegularOfDegree_of_odd_mul` / `_of_odd_odd` — clean impossibility corollary (no d-regular graph once `n·d` odd, in particular `n, d` both odd)
- `deficiency_floor_attained` — **sharpness**: the one-vertex empty graph with `d = 1` has `n·d = 1` odd and deficiency exactly `1`, so the bound is attained

## Verification

- **9 theorems, 1 definition**, 135 lines
- **0 axioms, 0 sorries**; sharpness witness uses **kernel `decide`** (not `native_decide`), so no `Lean.ofReduceBool`
- Docker build `Proofs.HandshakeLemmaOQ01`: elaboration clean `[7743/7743]`, green on retry (fleet SIGBUS-135 at olean-write only)

## Scope / honesty

This quantifies the obstruction and proves the lower bound is **attained** by an explicit witness. It does **not** prove general realisability (that for *every* odd `n·d` a near-regular graph with deficiency 1 exists) — that is a degree-sequence construction (Erdős–Gallai / Havel–Hakimi, sibling `handshake-lemma-oq-02`).

Gallery entry added at `src/data/proofs/handshake-lemma-oq-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)