### PR TITLE
audit(hilbert-4): disclose vacuous placeholder axioms + True-stub headline theorem

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20800,10 +20800,10 @@
       "issues": []
     },
     "hilbert-4": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:01:59Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "hilbert-4-oq-04": {
       "auditCount": 2,

--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -43,7 +43,7 @@
     "dateAdded": "2025-12-29",
     "hilbertNumber": 4,
     "axiomCount": 5,
-    "assumptions": "5 axiom declarations: minkowski_geodesics_are_straight (lines are geodesics in Minkowski), minkowski_straight_line_shortest (line is shortest path), busemann_classification (exhaustive metric classification), hamel_theorem_2d (2D Minkowski characterization), funk_geodesics_straight (Funk metric geodesics). Some axioms are placeholder/vacuous pending proper formalization of metric geometry foundations.",
+    "assumptions": "5 axiom declarations. Substantive geometric statements: minkowski_geodesics_are_straight (lines are geodesics in Minkowski geometry), minkowski_straight_line_shortest (line is shortest path), busemann_classification (Busemann's exhaustive metric classification). Currently VACUOUS placeholders: hamel_theorem_2d concludes only `∃ M : MinkowskiGeometry, True` (independent of the input metric d), and funk_geodesics_straight is stated over `FunkMetric := fun _ _ => 0`, so it reduces to 0 + 0 = 0. Additionally, the headline theorem `hilbert_geodesics_are_straight` has conclusion `True` (a formal-statement placeholder proved by `trivial`). The only genuinely machine-checked theorems are `euclidean_triangle` and `taxicab_triangle` (triangle inequalities for the Euclidean and taxicab norms). This entry is a formal scaffold for Hilbert's 4th problem, not a verified solution.",
     "lineCount": 459,
     "prerequisites": [
       "Metric spaces and geodesics",
@@ -220,8 +220,8 @@
     {
       "name": "hilbert4_metric",
       "type": "core",
-      "description": "Construction of metrics for which straight lines are geodesics",
-      "leanType": "exists metric, forall line, is_geodesic metric line"
+      "description": "Formal scaffold for Hilbert's 4th problem. The geodesic-straightness of Minkowski/Hilbert geometries is axiomatized (minkowski_geodesics_are_straight); the file's headline theorem hilbert_geodesics_are_straight is currently a True-typed placeholder. The machine-checked theorems are the Euclidean and taxicab triangle inequalities.",
+      "leanType": "axiomatized: minkowski_geodesics_are_straight; headline hilbert_geodesics_are_straight : (...) -> True (placeholder)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Auditor finding — under-disclosed vacuity in an axiomatized scaffold

Re-audit of **hilbert-4** (Hilbert's 4th Problem, `Hilbert4Geodesics.lean`). The entry is correctly `status: axiomatized`, `badge: axiom`, `axiomCount: 5`, and counts all match source (5 axioms, 3 theorems, 18 defs, 0 sorries, 459 lines). `originalContributions` appropriately use "Definition of"/"Statement of" language. This is a legitimate Tier C formal scaffold.

However, the disclosure understated the vacuity. Reading each declaration:

**Vacuous placeholder axioms** (assumptions field only said "some axioms are placeholder/vacuous" without naming them):
- `hamel_theorem_2d` concludes only `∃ M : MinkowskiGeometry, True` — completely independent of the input metric `d` it purports to characterize.
- `funk_geodesics_straight` is stated over `FunkMetric := fun _ _ => 0` (a literal placeholder def), so it reduces to `0 + 0 = 0`.

**Undisclosed `True`-stub headline theorem:**
- `hilbert_geodesics_are_straight` (the file's namesake result) has conclusion `True`, proved by `trivial`. Its `mainTheorems` entry `hilbert4_metric` advertised leanType `exists metric, forall line, is_geodesic metric line` — materially stronger than what is proved.

**Genuinely machine-checked:** only `euclidean_triangle` and `taxicab_triangle` (triangle inequalities for the Euclidean/taxicab norms).

### Fix (prose only — no status/badge/count change)
- `assumptions`: names which axioms are substantive vs. vacuous, quantifies the vacuity (`∃ M, True`; `0+0=0`), and discloses the `True`-typed headline theorem.
- `mainTheorems[0]`: description + leanType now state the geodesic-straightness is axiomatized and the headline theorem is a placeholder.

Status/badge already correctly signal "axiomatized" — this only tightens the wording so the vacuity isn't mistaken for verified content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)