### PR TITLE
Research: erdos-1026-oq-05 - antitone-in-k for k-monotone covering number

### DIFF
--- a/proofs/Proofs/Erdos1026OQ05KMonotonic.lean
+++ b/proofs/Proofs/Erdos1026OQ05KMonotonic.lean
@@ -301,14 +301,18 @@ clamps back to `j`. This is the direction opposite to reading off a single run. 
 theorem IsKMonotonic.mono {k k' : ℕ} (hk : 0 < k) (hkk' : k ≤ k') {seq : RealSeq n}
     {sub : Subsequence n m} (h : IsKMonotonic k seq sub) : IsKMonotonic k' seq sub := by
   obtain ⟨runs, hmono, hcov⟩ := h
-  refine ⟨fun j => runs ⟨min j.val (k - 1), by omega⟩, ?_, ?_⟩
-  · intro j; exact hmono _
-  · intro a
-    obtain ⟨j, b, hjb⟩ := hcov a
-    refine ⟨⟨j.val, by omega⟩, b, ?_⟩
-    have hclamp : (⟨min j.val (k - 1), by omega⟩ : Fin k) = j := by
-      apply Fin.ext; simp only; omega
-    rw [hclamp]; exact hjb
+  -- Clamp the extra run slots back into `Fin k` (`k ≥ 1`), repeating the last run.
+  set f : Fin k' → Fin k := fun j => ⟨min j.val (k - 1), by omega⟩ with hf
+  refine ⟨fun j => runs (f j), fun j => hmono _, ?_⟩
+  intro a
+  obtain ⟨j, b, hjb⟩ := hcov a
+  have hj'lt : j.val < k' := by omega
+  refine ⟨⟨j.val, hj'lt⟩, ?_⟩
+  -- The clamp sends the slot `⟨j, _⟩ : Fin k'` back to `j`, so its run is `runs j`.
+  have hfj : f ⟨j.val, hj'lt⟩ = j := by
+    apply Fin.ext; simp only [hf, Fin.val_mk]; omega
+  simp only [hfj]
+  exact ⟨b, hjb⟩
 
 /-- Lift a `k`-monotone decomposition to a `k'`-monotone one for `k ≤ k'` (`k ≥ 1`): each part is
 padded via `IsKMonotonic.mono`, while the disjointness and covering data are unchanged. -/

--- a/proofs/Proofs/Erdos1026OQ05KMonotonic.lean
+++ b/proofs/Proofs/Erdos1026OQ05KMonotonic.lean
@@ -311,7 +311,7 @@ theorem IsKMonotonic.mono {k k' : ℕ} (hk : 0 < k) (hkk' : k ≤ k') {seq : Rea
   -- The clamp sends the slot `⟨j, _⟩ : Fin k'` back to `j`, so its run is `runs j`.
   have hfj : f ⟨j.val, hj'lt⟩ = j := by
     apply Fin.ext; simp only [hf, Fin.val_mk]; omega
-  simp only [hfj]
+  rw [hfj]
   exact ⟨b, hjb⟩
 
 /-- Lift a `k`-monotone decomposition to a `k'`-monotone one for `k ≤ k'` (`k ≥ 1`): each part is

--- a/proofs/Proofs/Erdos1026OQ05KMonotonic.lean
+++ b/proofs/Proofs/Erdos1026OQ05KMonotonic.lean
@@ -279,4 +279,66 @@ theorem minKMonotonicParts_one_eq_minMonotonicParts (seq : RealSeq n) :
   le_antisymm (minKMonotonicParts_le_minMonotonicParts Nat.one_pos seq)
     (minMonotonicParts_le_minKMonotonicParts_one seq)
 
+/-! ## Monotonicity in `k`: `minKMonotonicParts` is non-increasing in the run budget
+
+The bracket `minKMonotonicParts_bracket` only compares the k-monotone covering number to the
+`k = 1` (ordinary monotone) endpoint. Here we prove the full **antitone** statement: for
+`1 ≤ k ≤ k'`, allowing more monotone runs per part cannot increase the covering number,
+
+    minKMonotonicParts k' seq ≤ minKMonotonicParts k seq.
+
+The engine is a **padding** lemma: a k-monotone piece is k'-monotone whenever `k ≤ k'`, obtained
+by clamping the run index `Fin k' → Fin k` (repeating the last run for the extra slots — no empty
+runs are needed, since the covering condition only requires *some* run to hit each index).
+Specializing to `k = 1` (with `minKMonotonicParts_one_eq_minMonotonicParts`) recovers
+`minKMonotonicParts_le_minMonotonicParts`. -/
+
+/-- **Padding a k-monotone piece to a larger run budget.** If `sub` is `k`-monotone and `k ≤ k'`
+(with `k ≥ 1`), then `sub` is `k'`-monotone: reindex the `k` runs by clamping `Fin k' → Fin k`
+(the map `j ↦ min j (k-1)`), which repeats the final run in the surplus slots. Every run stays
+monotone, and any index covered by run `j : Fin k` is still covered — the slot `j : Fin k'`
+clamps back to `j`. This is the direction opposite to reading off a single run. -/
+theorem IsKMonotonic.mono {k k' : ℕ} (hk : 0 < k) (hkk' : k ≤ k') {seq : RealSeq n}
+    {sub : Subsequence n m} (h : IsKMonotonic k seq sub) : IsKMonotonic k' seq sub := by
+  obtain ⟨runs, hmono, hcov⟩ := h
+  refine ⟨fun j => runs ⟨min j.val (k - 1), by omega⟩, ?_, ?_⟩
+  · intro j; exact hmono _
+  · intro a
+    obtain ⟨j, b, hjb⟩ := hcov a
+    refine ⟨⟨j.val, by omega⟩, b, ?_⟩
+    have hclamp : (⟨min j.val (k - 1), by omega⟩ : Fin k) = j := by
+      apply Fin.ext; simp only; omega
+    rw [hclamp]; exact hjb
+
+/-- Lift a `k`-monotone decomposition to a `k'`-monotone one for `k ≤ k'` (`k ≥ 1`): each part is
+padded via `IsKMonotonic.mono`, while the disjointness and covering data are unchanged. -/
+def KMonotonicDecomposition.mono {k k' : ℕ} (hk : 0 < k) (hkk' : k ≤ k') {seq : RealSeq n}
+    (D : KMonotonicDecomposition k n seq) : KMonotonicDecomposition k' n seq where
+  numParts := D.numParts
+  parts := D.parts
+  kmonotonic := fun i => (D.kmonotonic i).mono hk hkk'
+  disjoint := D.disjoint
+  covering := D.covering
+
+/-- **The k-monotone covering number is antitone in `k`.** For `1 ≤ k ≤ k'`,
+
+    minKMonotonicParts k' seq ≤ minKMonotonicParts k seq.
+
+The optimal `k`-monotone decomposition is, after padding (`KMonotonicDecomposition.mono`), a
+`k'`-monotone decomposition of the same size, so its part count bounds the `k'`-monotone infimum.
+Combined with `minKMonotonicParts_one_eq_minMonotonicParts`, taking `k = 1` recovers
+`minKMonotonicParts_le_minMonotonicParts`; the general statement makes precise the "non-increasing
+in `k`" picture that `minKMonotonicParts_bracket` only asserts informally. -/
+theorem minKMonotonicParts_antitone {k k' : ℕ} (hk : 0 < k) (hkk' : k ≤ k')
+    (seq : RealSeq n) : minKMonotonicParts k' seq ≤ minKMonotonicParts k seq := by
+  classical
+  have hne : {p | ∃ D : KMonotonicDecomposition k n seq, D.numParts = p}.Nonempty :=
+    ⟨n, monotonicToKMonotonic hk (singletonDecomposition seq), rfl⟩
+  obtain ⟨D, hD⟩ := Nat.sInf_mem hne
+  have hEq : minKMonotonicParts k seq = D.numParts := hD.symm
+  rw [hEq]
+  unfold minKMonotonicParts
+  apply Nat.sInf_le
+  exact ⟨D.mono hk hkk', rfl⟩
+
 end Erdos1026OQ05KMonotonic

--- a/research/problems/erdos-1026-oq-05/knowledge.md
+++ b/research/problems/erdos-1026-oq-05/knowledge.md
@@ -105,3 +105,39 @@ Hit a shared-cache corruption first (`Mathlib/.../Acyclic.ir invalid header` fro
 → fixed with `docker-build.sh --repair-cache` (force cache re-download) → then the usual
 SIGBUS-135 at olean-write on busy fleet, cleared in a quiet window. meta ES additionalFiles
 synced 139→166 / 5→6.
+
+## Session 2026-07-09 (researcher-7) — antitone-in-k (covering number non-increasing in the run budget)
+
+Added the last clean elementary structural fact to `Erdos1026OQ05KMonotonic.lean` (282→348 lines,
++2 thm / +1 def): the full **antitone law** the file's own docstring only asserted informally.
+
+- `IsKMonotonic.mono` (padding lemma): a `k`-monotone piece is `k'`-monotone whenever `1 ≤ k ≤ k'`,
+  by clamping the run index `Fin k' → Fin k` via `j ↦ min j (k-1)` (repeats the last run in the
+  surplus slots — **no empty runs needed**, since the covering condition only requires *some* run
+  to hit each index). This is the reverse direction of the existing `IsKMonotonic.isMonotonic_of_one`.
+- `KMonotonicDecomposition.mono`: lifts the padding to whole decompositions (parts padded, disjoint
+  + covering data unchanged) — same shape as `monotonicToKMonotonic` / `kMonotonicToMonotonic_one`.
+- `minKMonotonicParts_antitone`: `1 ≤ k ≤ k' ⟹ minKMonotonicParts k' seq ≤ minKMonotonicParts k seq`.
+  Padding the optimal `k`-decomposition gives a `k'`-decomposition of the same size, so its part
+  count bounds the `k'`-infimum (`Nat.sInf_le`). Combined with the k=1 identity this **subsumes**
+  `minKMonotonicParts_le_minMonotonicParts` (previously the only monotonicity fact, at k=1 only).
+
+**Significance:** completes the "non-increasing in k, pinned at the monotone covering number" picture.
+Genuinely new (not a reindexed corollary): the general `k ≤ k'` comparison did not exist before.
+
+### Gotcha (dependent-Sigma reindexing — the fiddly part flagged in prior notes)
+The covering witness needs `b : Fin (runs j).1` placed where `Fin (runs (clamp J)).1` is expected.
+`simp only [hfj]` REFUSES the rewrite (changes the bound variable `b`'s type → dependent motive,
+reported as "unused simp arg"). Fix: **`rw [hfj]`** — `rw` abstracts `clamp J` into a motive
+`fun x => ∃ b : Fin (runs x).1, …` that is type-correct for all `x : Fin k`, so the dependent
+rewrite goes through. Use `set f := (clamp) with hf` so `f J` is an atomic rewrite target; prove
+`f ⟨j.val,_⟩ = j` by `Fin.ext; simp only [hf, Fin.val_mk]; omega` (omega picks up `j.isLt` + `0<k`).
+
+### ⚠️ BUILD STATUS: UNVERIFIED (2026-07-09, same fleet storm as Extremal above)
+Elaboration is **CLEAN** — after the `rw` fix, ~6 consecutive builds show **zero** Lean type-error
+diagnostics; the file crashes at olean-WRITE with exit 135 (SIGBUS), 2–5 s, across mem 16–30 GB, plus
+intermittent transient dep-cache corruptions on the `import Mathlib` line (`FintypeCat.olean` /
+`KullbackLeibler/Basic.ir` / different file each run = fleet race, not this file). The pre-edit build
+of the unchanged file was green `[7744/7744] (4.4s)`, confirming toolchain is sound. Each of the 3 new
+decls is a structural near-clone of an already-verified decl in the same file. Deployer should
+re-attempt a green build in a quiet window (try `--repair-cache` + `LEAN_MEMORY_LIMIT=8192`).

--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -169,10 +169,10 @@
       },
       {
         "path": "Proofs/Erdos1026OQ05KMonotonic.lean",
-        "lineCount": 282,
-        "theoremCount": 10,
-        "definitionCount": 4,
-        "description": "k-monotone generalization: length bound m ≤ k·max(LIS,LDS), covering-number lower bound, and the sandwich n/(k·max) ≤ minKMonotonicParts k ≤ minMonotonicParts — with the EXACT k=1 identity minKMonotonicParts 1 = minMonotonicParts (a 1-monotone piece is monotone), pinning the k=1 endpoint of the bracket."
+        "lineCount": 348,
+        "theoremCount": 12,
+        "definitionCount": 5,
+        "description": "k-monotone generalization: length bound m ≤ k·max(LIS,LDS), covering-number lower bound, and the sandwich n/(k·max) ≤ minKMonotonicParts k ≤ minMonotonicParts — with the EXACT k=1 identity minKMonotonicParts 1 = minMonotonicParts (a 1-monotone piece is monotone) and the general antitone law minKMonotonicParts is non-increasing in k (padding a k-monotone piece to k'≥k via run-index clamping), making precise the whole non-increasing-in-k picture."
       },
       {
         "path": "Proofs/Erdos1026OQ05Extremal.lean",

--- a/src/data/research/problems/erdos-1026-oq-05.json
+++ b/src/data/research/problems/erdos-1026-oq-05.json
@@ -64,7 +64,8 @@
       "The increasing-only covering number satisfies an EXACT min-max identity minIncreasingParts = LDS (dual-Dilworth/Mirsky for sequences), sharper than the monotone bracket which is only [n/max(LIS,LDS), min(LIS,LDS)].",
       "Lower bound LDS <= numParts needs NO distinctness (pure pigeonhole: a longest strictly-decreasing subsequence meets each increasing part at most once); only the upper bound (Mirsky rank colouring) needs injective/distinct values.",
       "k-MONOTONIC generalization (this session): a k-monotone subsequence (index image covered by k monotone runs) has length <= k*max(LIS,LDS) via a Finset.card_biUnion_le counting argument over the run images; the k=1 case recovers len_le_max_of_monotonic. This is the clean generalization requested by OQ-05.",
-      "The k-monotone covering number minKMonotonicParts k satisfies the sandwich n/(k*max(LIS,LDS)) <= minKMonotonicParts k <= minMonotonicParts (k>=1): the upper half embeds every monotone decomposition (a monotone part is trivially k-monotone with constant runs), the lower half is the k-monotone Mirsky counting bound and weakens as k grows, matching the intuition that more direction-changes per part means fewer parts."
+      "The k-monotone covering number minKMonotonicParts k satisfies the sandwich n/(k*max(LIS,LDS)) <= minKMonotonicParts k <= minMonotonicParts (k>=1): the upper half embeds every monotone decomposition (a monotone part is trivially k-monotone with constant runs), the lower half is the k-monotone Mirsky counting bound and weakens as k grows, matching the intuition that more direction-changes per part means fewer parts.",
+      "Antitone-in-k for the k-monotone covering number: minKMonotonicParts is non-increasing in k (1≤k≤k′ ⟹ minKMonotonicParts k′ ≤ minKMonotonicParts k). Engine is a padding lemma IsKMonotonic.mono — clamp the run index Fin k′→Fin k via j↦min j (k−1), repeating the last run in the surplus slots (no empty runs needed since covering only requires SOME run to hit each index); lifted to decompositions by KMonotonicDecomposition.mono. Specializing k=1 (with the k=1 identity) recovers minKMonotonicParts_le_minMonotonicParts, so this subsumes the previously isolated monotone-endpoint bound."
     ],
     "builtItems": [
       "monotonicDecomposition_numParts_lower_bound: n ≤ numParts · max(LIS, LDS) (Erdos1026OQ05.lean:131)",
@@ -77,7 +78,8 @@
       "IncreasingDecomposition structure + minIncreasingParts (covering number) in Erdos1026OQ05IncreasingIdentity.lean",
       "minIncreasingParts_eq_LDS : Function.Injective seq -> minIncreasingParts seq = LDS seq  (Erdos1026OQ05IncreasingIdentity.lean) [VERIFIED 0/0]",
       "LDS_le_numParts (pigeonhole lower bound), mirskyIncreasingDecomposition (upper bound), minMonotonicParts_le_minIncreasingParts + re-derived minMonotonicParts_le_LDS",
-      "Erdos1026OQ05KMonotonic.lean (companion, VERIFIED 0 sorry/0 axiom, 204 lines): IsKMonotonic, len_le_kmono, KMonotonicDecomposition, kMonotonicDecomposition_numParts_lower_bound/_ge, monotonicToKMonotonic, minKMonotonicParts, minKMonotonicParts_ge/_le_minMonotonicParts/_bracket"
+      "Erdos1026OQ05KMonotonic.lean (companion, VERIFIED 0 sorry/0 axiom, 204 lines): IsKMonotonic, len_le_kmono, KMonotonicDecomposition, kMonotonicDecomposition_numParts_lower_bound/_ge, monotonicToKMonotonic, minKMonotonicParts, minKMonotonicParts_ge/_le_minMonotonicParts/_bracket",
+      "Erdos1026OQ05KMonotonic.lean: IsKMonotonic.mono (padding), KMonotonicDecomposition.mono (decomposition lift), minKMonotonicParts_antitone (non-increasing in k) — 3 decls, 0 sorries/0 axioms, elaboration-clean (olean-write blocked by fleet SIGBUS-135 storm)."
     ],
     "mathlibGaps": [
       "No Hanani-style monotonic decomposition theorem in Mathlib; the parent file only states the structure. Dilworth is available for antichains but not directly wired to the LIS/LDS monotone-run decomposition.",
@@ -93,7 +95,7 @@
       "Prove the EXACT k=1 identity minKMonotonicParts 1 = minMonotonicParts (need IsKMonotonic 1 -> IsMonotonic: a subsequence contained in a single monotone run is itself monotone, via order-preservation of the induced index map).",
       "Antitone-in-k: minKMonotonicParts is non-increasing in k (needs IsKMonotonic.mono padding runs Fin k -> Fin k with empty monotone runs; dependent-Sigma reindexing is the fiddly part)."
     ],
-    "progressSummary": "PROGRESS: k-monotonic generalization VERIFIED (Erdos1026OQ05KMonotonic.lean, 0 sorry/0 axiom) — length bound k*max(LIS,LDS), counting lower bound, and the sandwich n/(k*max)<=minKMonotonicParts k<=minMonotonicParts. Remaining open: exact k=1 identity, antitone-in-k, and the hard constructive O(sqrt n) Hanani upper bound."
+    "progressSummary": "PROGRESS: k-monotone covering number now proven ANTITONE in k (minKMonotonicParts_antitone), generalizing the k=1 monotone-endpoint bound to the full non-increasing-in-k law via a run-index clamp padding lemma. The two-sided bracket, exact k=1 identity, dual minDecreasingParts=LIS, and Erdős–Szekeres tightness are all complete. ONLY remaining open direction: the hard constructive O(√n) Hanani UPPER bound (√n monotone pieces suffice for EVERY sequence) — needs Dilworth chain-decomposition machinery absent from Mathlib; not session-sized."
   },
   "tags": [
     "combinatorics",


### PR DESCRIPTION
## Summary
Research session for **erdos-1026-oq-05** (k-monotonic decompositions / Hanani). Adds the last
clean elementary structural fact to `Erdos1026OQ05KMonotonic.lean`: the k-monotone covering number
`minKMonotonicParts k seq` is **antitone (non-increasing) in `k`** — the general law the file's own
`minKMonotonicParts_bracket` docstring previously asserted only informally.

## Progress
Three new declarations (0 sorries, 0 axioms), each a structural companion to existing verified decls:
- **`IsKMonotonic.mono`** — padding lemma: a `k`-monotone piece is `k'`-monotone for `1 ≤ k ≤ k'`,
  by clamping the run index `Fin k' → Fin k` via `j ↦ min j (k-1)` (repeats the last run in surplus
  slots; no empty runs needed, since covering only requires *some* run to hit each index). This is
  the reverse direction of the existing `IsKMonotonic.isMonotonic_of_one`.
- **`KMonotonicDecomposition.mono`** — lifts padding to whole decompositions (parts padded;
  disjointness + covering data unchanged).
- **`minKMonotonicParts_antitone`** — `1 ≤ k ≤ k' ⟹ minKMonotonicParts k' seq ≤ minKMonotonicParts k seq`.
  Padding the optimal `k`-decomposition yields a same-size `k'`-decomposition, bounding the `k'`-infimum.

Combined with the existing `minKMonotonicParts_one_eq_minMonotonicParts`, taking `k = 1` **subsumes**
`minKMonotonicParts_le_minMonotonicParts` (previously the only monotonicity fact, at the `k=1`
endpoint only).

Files modified: `proofs/Proofs/Erdos1026OQ05KMonotonic.lean` (282→348 lines),
`src/data/proofs/erdos-1026-oq-05/meta.json` (KMonotonic file 10→12 thm / 4→5 def), knowledge files.

## Findings
- The genuine content is the general `k ≤ k'` comparison, which did not exist before (not a reindexed corollary).
- Gotcha: the covering witness needs `b : Fin (runs j).1` where `Fin (runs (clamp J)).1` is expected.
  `simp only [hfj]` refuses (changing the bound variable's type = dependent motive); **`rw [hfj]`**
  succeeds because it abstracts `clamp J` into a type-correct motive over `Fin k`.

## Status
**Outcome**: progress (verified content, one build caveat)
**Build**: ⚠️ UNVERIFIED — elaboration is CLEAN (~6 consecutive builds, **zero** Lean type-error
diagnostics after the `rw` fix), but the olean **write** crashes with SIGBUS-135 / SIGSEGV-139 across
mem 8–30 GB (persistent fleet memory-pressure storm; plus intermittent transient dep-cache
corruptions on the `import Mathlib` line, a different file each run). The pre-edit build of the
unchanged file was green `[7744/7744] (4.4s)`, confirming the toolchain is sound. **Deployer should
re-attempt a green build in a quiet window** (`--repair-cache` + low `LEAN_MEMORY_LIMIT`).
**Next Steps**: only remaining open direction is the hard constructive `O(√n)` Hanani UPPER bound
(needs Dilworth chain-decomposition machinery absent from Mathlib; not session-sized).

🤖 Generated by researcher-7