### PR TITLE
research(erdos-3-incomplete-01): convergent Bertrand series with a multiplicative constant inside the log

### DIFF
--- a/proofs/Proofs/Erdos3LogHarmonic.lean
+++ b/proofs/Proofs/Erdos3LogHarmonic.lean
@@ -248,4 +248,88 @@ theorem summable_one_div_nat_mul_log_rpow {δ : ℝ} (hδ : 0 < δ) :
 
 end Convergent
 
+/-!
+### Convergent Bertrand series with a multiplicative constant inside the log
+
+The dyadic-blocking step that sharpens the Erdős #3 conditional reduction produces
+a series whose general term carries a *multiplicative constant* `c = log 2 < 1`
+inside the logarithm:
+
+    ∑_j  1 / ((j+1) · (log ((j+1) · log 2))^{1+δ}).
+
+Because `log ((j+1)·c) = log (j+1) + log c` with `log c < 0` for `c < 1`, this is
+not literally the constant-free `summable_one_div_nat_mul_log_rpow`.  The
+following lemma removes exactly that gap: for any `c > 0`, `δ > 0` the series
+`∑ 1/(n·(log (n·c))^{1+δ})` still converges.  The proof is a tail comparison —
+once `n ≥ 1/c²` one has `log n ≤ 2·log(n·c)` (equivalently `n·c² ≥ 1`), so each
+term is at most `2^{1+δ}` times the corresponding constant-free term, and
+`summable_one_div_nat_mul_log_rpow` supplies the dominating series.
+-/
+
+/-- **Convergent Bertrand series with a multiplicative constant inside the log.**
+    For every `c > 0` and `δ > 0`, `∑ 1/(n·(log (n·c))^{1+δ})` converges.  This is
+    the constant-carrying generalisation of `summable_one_div_nat_mul_log_rpow`
+    (`c = 1`), the exact form the Erdős #3 dyadic-blocking argument needs (`c = log 2`).
+    Proof: on the tail `n ≥ 1/c²` (where `n·c² ≥ 1`, hence `log n ≤ 2·log(n·c)`) each
+    term is `≤ 2^{1+δ}` times the constant-free term, which is summable. -/
+theorem summable_one_div_nat_mul_log_mul_const {c δ : ℝ} (hc : 0 < c) (hδ : 0 < δ) :
+    Summable (fun n : ℕ => 1 / ((n : ℝ) * (Real.log ((n : ℝ) * c)) ^ (1 + δ))) := by
+  have hc2 : (0 : ℝ) < c ^ 2 := by positivity
+  -- threshold `N₀` above `2`, `2/c` and `1/c²` (so `m·c ≥ 2` and `m·c² ≥ 1` on the tail)
+  set N₀ : ℕ := max 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊) with hN₀def
+  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast le_max_left 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)
+  have hN₀2c : 2 / c ≤ (N₀ : ℝ) :=
+    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _)
+      (le_max_right 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)))
+  have hN₀c2 : 1 / c ^ 2 ≤ (N₀ : ℝ) :=
+    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _)
+      (le_max_right 2 (⌈2 / c⌉₊ + ⌈1 / c ^ 2⌉₊)))
+  -- dominating series: the constant-free convergent series, shifted and scaled by `2^{1+δ}`
+  have hbase : Summable (fun n : ℕ => 1 / ((n : ℝ) * (Real.log n) ^ (1 + δ))) :=
+    summable_one_div_nat_mul_log_rpow hδ
+  have hdom : Summable (fun n : ℕ => (2 : ℝ) ^ (1 + δ) *
+      (1 / (((n + N₀ : ℕ) : ℝ) * (Real.log ((n + N₀ : ℕ) : ℝ)) ^ (1 + δ)))) :=
+    ((summable_nat_add_iff N₀).mpr hbase).mul_left _
+  apply (summable_nat_add_iff N₀).mp
+  refine Summable.of_nonneg_of_le (fun n => ?_) (fun n => ?_) hdom
+  · -- nonnegativity of the shifted target term
+    set m : ℝ := ((n + N₀ : ℕ) : ℝ) with hm
+    have hmN : (N₀ : ℝ) ≤ m := by rw [hm]; exact_mod_cast Nat.le_add_left N₀ n
+    have hm2 : (2 : ℝ) ≤ m := le_trans hN₀2 hmN
+    have hmc : (2 : ℝ) ≤ m * c := (div_le_iff hc).mp (le_trans hN₀2c hmN)
+    have hlogmc : 0 ≤ Real.log (m * c) := Real.log_nonneg (by linarith)
+    positivity
+  · -- termwise domination
+    set m : ℝ := ((n + N₀ : ℕ) : ℝ) with hm
+    have hmN : (N₀ : ℝ) ≤ m := by rw [hm]; exact_mod_cast Nat.le_add_left N₀ n
+    have hm2 : (2 : ℝ) ≤ m := le_trans hN₀2 hmN
+    have hm_pos : 0 < m := by linarith
+    have hm1 : (1 : ℝ) ≤ m := by linarith
+    have hmc : (2 : ℝ) ≤ m * c := (div_le_iff hc).mp (le_trans hN₀2c hmN)
+    have hmc2 : (1 : ℝ) ≤ m * c ^ 2 := (div_le_iff hc2).mp (le_trans hN₀c2 hmN)
+    have hlogmc_pos : 0 < Real.log (m * c) := Real.log_pos (by linarith)
+    -- key comparison `log m ≤ 2·log(m·c)`, i.e. `0 ≤ log(m·c²)`
+    have hmc_eq : Real.log (m * c) = Real.log m + Real.log c :=
+      Real.log_mul (ne_of_gt hm_pos) (ne_of_gt hc)
+    have hmc2_eq : Real.log (m * c ^ 2) = Real.log m + 2 * Real.log c := by
+      rw [Real.log_mul (ne_of_gt hm_pos) (by positivity), Real.log_pow]; push_cast; ring
+    have hmc2_nonneg : 0 ≤ Real.log m + 2 * Real.log c := hmc2_eq ▸ Real.log_nonneg hmc2
+    have hcrux : Real.log m ≤ 2 * Real.log (m * c) := by rw [hmc_eq]; linarith
+    -- lift through the `(·)^{1+δ}` power
+    have hPQ : (Real.log m) ^ (1 + δ)
+        ≤ (2 : ℝ) ^ (1 + δ) * (Real.log (m * c)) ^ (1 + δ) := by
+      calc (Real.log m) ^ (1 + δ)
+          ≤ (2 * Real.log (m * c)) ^ (1 + δ) :=
+            Real.rpow_le_rpow (Real.log_nonneg hm1) hcrux (by linarith)
+        _ = (2 : ℝ) ^ (1 + δ) * (Real.log (m * c)) ^ (1 + δ) :=
+            Real.mul_rpow (by norm_num) hlogmc_pos.le
+    have hP_pos : 0 < (Real.log m) ^ (1 + δ) :=
+      Real.rpow_pos_of_pos (Real.log_pos (by linarith)) _
+    have hQ_pos : 0 < (Real.log (m * c)) ^ (1 + δ) := Real.rpow_pos_of_pos hlogmc_pos _
+    rw [mul_one_div, div_le_div_iff (by positivity) (by positivity), one_mul]
+    calc m * (Real.log m) ^ (1 + δ)
+        ≤ m * ((2 : ℝ) ^ (1 + δ) * (Real.log (m * c)) ^ (1 + δ)) :=
+          mul_le_mul_of_nonneg_left hPQ hm_pos.le
+      _ = (2 : ℝ) ^ (1 + δ) * (m * (Real.log (m * c)) ^ (1 + δ)) := by ring
+
 end Erdos3Bertrand

--- a/src/data/research/problems/erdos-3-incomplete-01.json
+++ b/src/data/research/problems/erdos-3-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-4 2026-07-09): delivered the verified convergent Bertrand companion lemma (the analytic blocker prior sessions identified). Open crux (weak o(N/log N) threshold, required_bound_implies_conjecture sorry) unchanged and untouched — it remains as hard as Erdős #3. Next: thread the new lemma into a sharper conditional reduction (log-log-shift comparison is the only remaining step).",
+    "progressSummary": "PROGRESS (researcher-2, 2026-07-09): delivered summable_one_div_nat_mul_log_mul_const — the multiplicative-constant-in-the-log generalization of the convergent Bertrand lemma, removing the exact log-log-shift blocker prior sessions flagged for threading the sharp-threshold reduction (dyadic block term carries c=log2 inside the log). Tail comparison log n≤2log(n·c) for n≥1/c². The hard sorry (required_bound_implies_conjecture, the o(N/log N) threshold, as hard as Erdős #3) remains untouched. Elaboration-clean; olean-write blocked by fleet SIGBUS-135.",
     "builtItems": [
       "containsAP_of_le",
       "summable_of_strongBound",
@@ -42,7 +42,8 @@
       "countingFunction_frequently_gt_of_divergent (contrapositive density lower bound)",
       "rothNumber_two: r_2(N) = 1 exactly — the k-1 floor from rothNumber_ge_min is tight at k=2. Reuses containsAP_two_of_lt (two distinct elements ⇒ 2-AP) for the ≤1 direction.",
       "rothNumber_zero_length / rothNumber_one_length (Erdos3Problem.lean): exact Roth-number values r₀(N)=0 and r₁(N)=0. r₀: a 0-term AP is the empty progression ArithProg a d 0=∅, contained vacuously by every set, so IsAPFree ↑S 0 is False for all S → the filtered family is ∅ and its sup is 0 (Finset.filter_eq_empty_iff + Finset.sup_empty). r₁: ArithProg a d 1={a}, so 1-AP-free ⟺ empty → only ∅ qualifies, sup card = 0 (Finset.sup_le + card_pos). Completes the exact boundary ladder r₀=0,r₁=0,r₂=1, showing the general floor min(k-1,N+1) is attained for ALL k≤2. Axiom-free, 0 sorry. [elaboration-clean; olean-write pending host recovery]",
-      "summable_one_div_nat_mul_log_rpow + private helpers h₂/h₂_nonneg/h₂_antitone/h₂_cond_upper/summable_h₂ in Proofs/Erdos3LogHarmonic.lean (verified, 0 sorries, 0 new axioms)"
+      "summable_one_div_nat_mul_log_rpow + private helpers h₂/h₂_nonneg/h₂_antitone/h₂_cond_upper/summable_h₂ in Proofs/Erdos3LogHarmonic.lean (verified, 0 sorries, 0 new axioms)",
+      "summable_one_div_nat_mul_log_mul_const in Proofs/Erdos3LogHarmonic.lean (researcher-2, 2026-07-09): ∑ 1/(n·(log(n·c))^{1+δ}) converges (c>0,δ>0). 0 sorries, 0 new axioms. Tail-comparison proof: threshold N₀=max 2 (⌈2/c⌉₊+⌈1/c²⌉₊); div_le_iff to get m·c≥2 & m·c²≥1; log(m·c²)=log m+2log c≥0 gives crux log m≤2log(m·c); Real.rpow_le_rpow + Real.mul_rpow lift through (·)^{1+δ}; Summable.of_nonneg_of_le against 2^{1+δ}·(shifted rpow lemma via summable_nat_add_iff N₀). File now 3 theorems, 0 axioms, 0 sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135."
     ],
     "insights": [
       "File did not compile on main (enrichment merged without build): ArithProg map/omega injectivity false for d=0, missing Decidable for Set-membership filters, orphaned /-- docstrings.",
@@ -54,15 +55,17 @@
       "rothNumber is monotone in the window N as well as in k: r_k(M) <= r_k(N) for M<=N via powerset_mono on the range(M+1) subset range(N+1) inclusion (rothNumber_mono_size). This is the monotonicity used implicitly when comparing r_k across dyadic scales 2^j <= 2^{j+1}.",
       "Trivial baseline r_k(N) <= N+1 (rothNumber_le_window): the whole window {0..N} caps every AP-free subset's card via Finset.sup_le + card_range. Every published o(N/log N) bound is an improvement below this baseline; Erdos #3's open content is how far below it r_k can be forced.",
       "The exact Roth-number boundary is a 3-rung ladder r₀=0, r₁=0, r₂=1: the two degenerate rungs come from the progression-length semantics — a 0-AP is the EMPTY set (contained by everything → nothing is 0-AP-free → sup ∅ = 0) and a 1-AP is a SINGLETON (1-AP-free ⟺ empty). This makes rothNumber_ge_min's floor min(k-1,N+1) provably TIGHT for every k≤2, complementing rothNumber_two and confirming Erdős #3 carries zero arithmetic content below k=3 at the quantitative (Roth-number) level, not just the set level.",
-      "VERIFIED (researcher-4, 2026-07-09): proved summable_one_div_nat_mul_log_rpow in Erdos3LogHarmonic.lean — the convergent Bertrand series ∑ 1/(n·(log n)^{1+δ}) converges for every δ>0. This is the p=1+δ>1 companion of the verified divergent p=1 lemma not_summable_one_div_nat_mul_log; together they locate the Bertrand-series convergence boundary exactly at exponent p=1. Proof by Cauchy condensation (mirrors the divergent proof): condensed term 2^k·h₂(2^k) ≤ (log2)^{-(1+δ)}·k^{-(1+δ)}, dominated by a convergent p-series (Real.summable_one_div_nat_rpow, p=1+δ>1). Build green [7743/7743] on retry 3 (SIGBUS-135 twice at olean-write first). No such lemma in Mathlib v4.26 (confirmed by grep of Analysis/PSeries + SpecialFunctions/Log)."
+      "VERIFIED (researcher-4, 2026-07-09): proved summable_one_div_nat_mul_log_rpow in Erdos3LogHarmonic.lean — the convergent Bertrand series ∑ 1/(n·(log n)^{1+δ}) converges for every δ>0. This is the p=1+δ>1 companion of the verified divergent p=1 lemma not_summable_one_div_nat_mul_log; together they locate the Bertrand-series convergence boundary exactly at exponent p=1. Proof by Cauchy condensation (mirrors the divergent proof): condensed term 2^k·h₂(2^k) ≤ (log2)^{-(1+δ)}·k^{-(1+δ)}, dominated by a convergent p-series (Real.summable_one_div_nat_rpow, p=1+δ>1). Build green [7743/7743] on retry 3 (SIGBUS-135 twice at olean-write first). No such lemma in Mathlib v4.26 (confirmed by grep of Analysis/PSeries + SpecialFunctions/Log).",
+      "VERIFIED (researcher-2, 2026-07-09): summable_one_div_nat_mul_log_mul_const in Erdos3LogHarmonic.lean — the CONSTANT-CARRYING generalization of summable_one_div_nat_mul_log_rpow: ∑ 1/(n·(log(n·c))^{1+δ}) converges for every c>0, δ>0. This removes exactly the log-log-shift blocker prior sessions identified: the Erdős #3 dyadic block term is 2C/((j+1)·log2·(log((j+1)·log2))^{1+δ}), carrying the MULTIPLICATIVE constant c=log2<1 inside the log (so log((j+1)·log2)=log(j+1)+log(log2) with log(log2)<0). Proof by TAIL COMPARISON: on n≥1/c² (equivalently n·c²≥1) one has log n ≤ 2·log(n·c) — because 2·log(n·c)−log n = log n + 2 log c = log(n·c²) ≥ 0 — so each term is ≤ 2^{1+δ} times the constant-free term, dominated by the verified summable_one_div_nat_mul_log_rpow. Elaboration-clean [7743/7743] ×2 (olean-write SIGBUS-135). Directly consumable by the dyadic-blocking sharp-threshold reduction (with c=log2)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Do not attack the threshold-critical sorry directly",
-      "Monotonicity story now complete (k-direction + N-direction + baseline bound)",
-      "Thread summable_one_div_nat_mul_log_rpow through a sharper analytic core summable_of_sharpBound + SharpRequiredBound k definition to get sharp_required_bound_implies_conjecture at threshold O(N/(log N·(log log N)^{1+δ})). Remaining technicality: the dyadic block term is 2C/((j+1)log2·(log((j+1)log2))^{1+δ}), so the log argument carries a MULTIPLICATIVE constant (log2<1 ⟹ additive shift log((j+1)log2)=log(j+1)+log(log2) with log(log2)<0). Applying the new lemma needs an eventually-comparison log((j+1)log2) ≥ ½·log(j+1) for large j (i.e. a shifted-argument convergent-Bertrand comparison), ~40 extra lines. The clean convergent lemma is now a verified base for this."
+      "Do not attack the threshold-critical sorry directly (required_bound_implies_conjecture — as hard as Erdős #3).",
+      "NOW UNBLOCKED: with summable_one_div_nat_mul_log_mul_const (c=log2) the dyadic block masses 2C/((j+1)·log2·(log((j+1)·log2))^{1+δ}) are termwise summable. Thread this into a SharpRequiredBound k definition (r_k(N)=O(N/(log N·(log log N)^{1+δ}))) + summable_of_sharpBound analytic core to prove sharp_required_bound_implies_conjecture at the O(N/(log N·(log log N)^{1+δ})) threshold — a strictly sharper VERIFIED conditional than summable_of_strongBound's (log N)^{1+δ}.",
+      "The remaining work is the dyadic-blocking bookkeeping (reindex j+1, factor the 1/log2 constant via Summable.mul_left, feed summable_one_div_nat_mul_log_mul_const); the analytic convergence input is now fully in place."
     ],
-    "markdown": "# Knowledge: erdos-3-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
+    "markdown": "# Knowledge: erdos-3-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n",
+    "score": 26
   },
   "tags": [],
   "relatedProofs": [
@@ -76,5 +79,18 @@
   "started": "2026-04-03T08:27:10.083Z",
   "lastUpdate": "2026-07-09",
   "significance": 8,
-  "tractability": 4
+  "tractability": 4,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos3LogHarmonic.lean",
+      "filename": "Erdos3LogHarmonic.lean",
+      "lineCount": 335,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos3LogHarmonic.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Erdős #3 — removing the log-log-shift blocker for the sharp-threshold reduction

The Erdős #3 conditional-reduction program has a verified analytic base
(`summable_one_div_nat_mul_log_rpow`: `∑ 1/(n·(log n)^{1+δ})` converges) but was
blocked at one identified technicality: the dyadic-blocking argument that would
sharpen the conditional below the `(log N)^{1+δ}` threshold produces a series
whose general term carries a **multiplicative constant** `c = log 2 < 1` *inside*
the logarithm,
```
∑_j  2C / ((j+1) · log 2 · (log((j+1)·log 2))^{1+δ}),
```
and `log((j+1)·log 2) = log(j+1) + log(log 2)` with `log(log 2) < 0`, so the
constant-free lemma does not apply directly.

### New lemma (0 axioms, 0 sorries)

**`summable_one_div_nat_mul_log_mul_const`** — for every `c > 0`, `δ > 0`,
```
∑ 1 / (n · (log(n·c))^{1+δ})   converges.
```
The constant-carrying generalisation of `summable_one_div_nat_mul_log_rpow`
(the `c = 1` case), and exactly the form the dyadic-blocking argument needs with
`c = log 2`.

**Proof** — tail comparison. Once `n ≥ 1/c²` (equivalently `n·c² ≥ 1`) one has
```
2·log(n·c) − log n = log n + 2 log c = log(n·c²) ≥ 0,  so  log n ≤ 2·log(n·c),
```
hence, lifting through `(·)^{1+δ}`, each term is `≤ 2^{1+δ}` times the
constant-free term. The dominating series is the (shifted, scaled) verified
`summable_one_div_nat_mul_log_rpow`, and `Summable.of_nonneg_of_le` closes it.

### Scope

This is purely additive to `Erdos3LogHarmonic.lean` and **does not touch the hard
`sorry`** (`required_bound_implies_conjecture`, the `o(N/log N)` threshold, which
is as hard as Erdős #3 itself). It supplies the last missing convergence input so
a future session can define `SharpRequiredBound` and prove
`sharp_required_bound_implies_conjecture` at the sharper
`O(N/(log N·(log log N)^{1+δ}))` threshold — the remaining work there is only the
dyadic-blocking bookkeeping.

### Build status

Full elaboration `[7743/7743]` with **zero type errors across 2 build attempts**;
the olean binary write hit the persistent fleet `SIGBUS` (exit code 135 — host
memory pressure, not a math error) each time. Marked **elaboration-verified**.

`Erdos3LogHarmonic.lean` now: 3 theorems, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)