### PR TITLE
audit(prob-method-expectation): re-verify CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23843,9 +23843,9 @@
       "issues": []
     },
     "prob-method-expectation": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:53:50Z",
+      "agentId": "auditor-cycle-20260709-reaudit",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:56:23Z",
       "result": "clean"
     },
     "prob-method-expectation-oq-01": {
@@ -29757,5 +29757,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T00:38:05Z"
+  "lastUpdated": "2026-07-10T00:56:23Z"
 }


### PR DESCRIPTION
Re-audit of stalest gallery entry.

**Verdict: CLEAN.** Tracker was stuck at 2026-05-03 because the merged #36421 tracker bump was lost to the loop's `git reset --hard` race.

- All 8 theorems genuinely proved; `axiomCount=0`; no sorries, no `native_decide`.
- `erdos_ramsey_lower_bound` remains a tautology placeholder (`∃n, n≥2^(k/2)∧n>0`), and #36421's honest framing ("the Ramsey bound itself is not derived here", "placeholder") is fully present in description, conclusion, and mainTheorems.
- Only change: bump the audit-tracker entry to reflect this re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)