### PR TITLE
research(erdos-1058-oq-03): Brocard–Ramanujan n!+1=m² — 3 Brown numbers + root>n via Euclid engine

### DIFF
--- a/proofs/Proofs/Erdos1058OQ03.lean
+++ b/proofs/Proofs/Erdos1058OQ03.lean
@@ -257,4 +257,62 @@ theorem coprime_factorial_sub_one_add_one {n : ℕ} (hn : 2 ≤ n) :
   · exact h1
   · exact absurd (h2eq ▸ hd2) h2
 
+/-! ## Brocard's problem: the factorial squares `n! + 1 = m²`
+
+The three prime-power values proved above — `4!+1 = 5²`, `5!+1 = 11²`, `7!+1 = 71²`
+— are precisely the three known **Brown numbers**, the only known solutions of the
+**Brocard–Ramanujan equation** `n! + 1 = m²` (Brocard 1876 / Ramanujan 1913; whether
+there are others is a well-known open problem).  Note each root `5, 11, 71` is prime,
+matching the `IsPrimePow` results above.  We (i) record that these three `n` are
+solutions, (ii) rule out the intervening `n = 6`, and (iii) prove — via the Euclid
+engine `prime_dvd_factorial_add_one_gt` — the structural constraint that in *any*
+solution the root `m` must exceed `n`. -/
+
+/-- **Brocard–Ramanujan predicate.**  `n! + 1` is a perfect square; a solution `n`
+    is a *Brown number*.  Only `n = 4, 5, 7` are known. -/
+def IsBrocardSolution (n : ℕ) : Prop := ∃ m, n ! + 1 = m ^ 2
+
+/-- `n = 4` is a Brown number: `4! + 1 = 25 = 5²`. -/
+theorem isBrocardSolution_four : IsBrocardSolution 4 := ⟨5, by decide⟩
+
+/-- `n = 5` is a Brown number: `5! + 1 = 121 = 11²`. -/
+theorem isBrocardSolution_five : IsBrocardSolution 5 := ⟨11, by decide⟩
+
+/-- `n = 7` is a Brown number: `7! + 1 = 5041 = 71²`. -/
+theorem isBrocardSolution_seven : IsBrocardSolution 7 := ⟨71, by decide⟩
+
+/-- `n = 6` is **not** a Brown number: `6! + 1 = 721` lies strictly between
+    `26² = 676` and `27² = 729`, so it is not a perfect square.  (The gap between the
+    known solutions `5` and `7` contains no solution.) -/
+theorem not_isBrocardSolution_six : ¬ IsBrocardSolution 6 := by
+  rintro ⟨m, hm⟩
+  have h721 : (6 : ℕ)! + 1 = 721 := by decide
+  rw [h721, pow_two] at hm      -- hm : 721 = m * m
+  have hup : m < 27 := by
+    by_contra h'
+    push_neg at h'
+    have := Nat.mul_le_mul h' h'   -- 27 * 27 ≤ m * m
+    omega
+  interval_cases m <;> omega
+
+/-- **Structural constraint on Brocard solutions (via the Euclid engine).**  In any
+    solution `n! + 1 = m²` with `n ≥ 1`, the root satisfies `n < m`.  Indeed `m ≥ 2`,
+    so its least prime factor `p` divides `m² = n! + 1`; the engine
+    `prime_dvd_factorial_add_one_gt` forces `p > n`, and `p ≤ m` gives `n < m`.  Thus a
+    factorial square is always rooted *above* `n` — the quantitative shadow of Euclid's
+    argument on the Brocard equation. -/
+theorem brocard_root_gt {n m : ℕ} (hn : 1 ≤ n) (h : n ! + 1 = m ^ 2) : n < m := by
+  have hfac : 1 ≤ n ! := Nat.factorial_pos n
+  have hmpos : 2 ≤ m ^ 2 := by omega
+  have hm2 : 2 ≤ m := by
+    by_contra h'
+    push_neg at h'
+    interval_cases m <;> simp_all
+  have hp : (m.minFac).Prime := Nat.minFac_prime (by omega)
+  have hpn1 : m.minFac ∣ n ! + 1 := by
+    rw [h]; exact (Nat.minFac_dvd m).trans (dvd_pow_self m (by norm_num))
+  have hlt : n < m.minFac := prime_dvd_factorial_add_one_gt hp hpn1
+  have hple : m.minFac ≤ m := Nat.minFac_le (by omega)
+  omega
+
 end Erdos1058OQ03

--- a/research/problems/erdos-1058-oq-03/knowledge.md
+++ b/research/problems/erdos-1058-oq-03/knowledge.md
@@ -71,3 +71,34 @@ Erdős–Stewart finiteness + Luca 2001 classification — out of scope. meta.js
 
 **Note:** this is the mislabeled/opaque-axiom pattern again (cf. erdos-659-oq-01 same session):
 an axiom that is either a routine fact or an uninterpreted placeholder → dischargeable/groundable.
+
+## Session 2026-07-09 (researcher-1) — Brocard–Ramanujan framing of the prime-power data
+
+**Mode**: DEPTH-FIRST follow-up (file was VERIFIED 16 thm / 0 axiom / 0 sorry, "essentially
+complete") · **Outcome**: progress (VERIFIED 0 sorry / 0 axiom, docker `[7743/7743]` green on
+retry-2; first attempt hit the fleet SIGBUS-135 olean-write crash at clean elaboration).
+
+### Insight
+The three `IsPrimePow` values already in the file — `4!+1 = 5²`, `5!+1 = 11²`, `7!+1 = 71²` —
+are *exactly* the three known **Brown numbers**, the only known solutions of the
+**Brocard–Ramanujan equation** `n! + 1 = m²`. Reframed that data as the Brocard problem and
+connected it to the file's own Euclid engine.
+
+### Added (5 decls, 18 → 23 thm + 1 def; 260 → 318 lines) — PR #36562-sibling (new branch)
+- `IsBrocardSolution n := ∃ m, n! + 1 = m^2` — the Brocard–Ramanujan predicate (Brown numbers).
+- `isBrocardSolution_{four,five,seven}` — the three known solutions (roots 5, 11, 71 all prime).
+- `not_isBrocardSolution_six` — `6!+1 = 721 ∈ (26², 27²)` is not a square (gap 5..7 has no soln);
+  proof: `rw [.., pow_two]`, bound `m < 27` via `Nat.mul_le_mul h' h'` + omega, `interval_cases m <;> omega`.
+- `brocard_root_gt` — **structural**: any solution `n!+1 = m²` with `n ≥ 1` has `n < m`. Uses the
+  file's engine `prime_dvd_factorial_add_one_gt` on `m.minFac` (divides `m ∣ m² = n!+1`), then
+  `minFac ≤ m`. The quantitative shadow of Euclid's argument on the Brocard equation.
+
+### Gotchas (reusable, Lean 4.26.0)
+- Perfect-square non-membership: `rw [pow_two] at hm` turns `k = m^2` into `k = m*m` so
+  `interval_cases m <;> omega` closes each concrete case (omega folds literal `a*a`, but NOT `m^2`).
+- `dvd_pow_self m (by norm_num : 2 ≠ 0) : m ∣ m^2`; chain via `(Nat.minFac_dvd m).trans …`.
+- **Worktree/main split-brain AGAIN**: first Edit landed in the *main-repo* copy of the file (abs
+  path resolved to `/GitHub/lean-genius/proofs/...` not the worktree), and a concurrent fleet
+  `reset --hard` then reverted it → "nothing to commit". Re-applied to the explicit worktree path
+  `.loom/worktrees/researcher-1-4/proofs/...`; commit+push landed. Always edit the worktree path.
+- SIGBUS-135: retry docker build 1–2× (warm cache ~fast); attempt-2 wrote the olean cleanly.

--- a/src/data/proofs/erdos-1058-oq-03/meta.json
+++ b/src/data/proofs/erdos-1058-oq-03/meta.json
@@ -51,10 +51,10 @@
       "Axiom-free prime-power classification: 4!+1=5², 5!+1=11² are prime powers; 6!+1=721=7·103 is not; sibling 3!−1=5 prime, 5!−1=119=7·17 not"
     ],
     "axiomCount": 0,
-    "lineCount": 260,
+    "lineCount": 318,
     "assumptions": "None. Fully machine-checked; #print axioms lists only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool — small cases use kernel `decide`, not `native_decide`).",
-    "theoremCount": 18,
-    "definitionCount": 0
+    "theoremCount": 23,
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "The parent entry (Erdős #1058, Erdős–Stewart / Luca 2001) axiomatizes its entire arithmetic content: the prime sequence, the finiteness conjecture, and Luca's classification are all `opaque`/`axiom`, so no genuine divisibility fact is actually derived there. The parent explicitly poses three open questions, including 'Can the techniques extend to other factorial-based expressions?' (this oq-03) and 'Are there similar finiteness results for n!−1?'. This companion answers the technique question constructively and axiom-free.",
@@ -160,10 +160,10 @@
       "Nat"
     ],
     "namespace": "Erdos1058OQ03",
-    "lineCount": 260,
+    "lineCount": 318,
     "axiomCount": 0,
-    "theoremCount": 18,
-    "definitionCount": 0,
+    "theoremCount": 23,
+    "definitionCount": 1,
     "path": "Proofs/Erdos1058OQ03.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Depth-first follow-up on the already-verified `Erdos1058OQ03.lean` companion (0 axioms / 0 sorries, 16 theorems). The file's three `IsPrimePow` values — `4!+1 = 5²`, `5!+1 = 11²`, `7!+1 = 71²` — are **exactly the three known Brown numbers**, the only known solutions of the **Brocard–Ramanujan equation** `n! + 1 = m²`. This PR reframes that data as the Brocard problem and connects it to the file's own Euclid engine.

## Added (4 theorems + 1 definition, all 0 axioms / 0 sorries)

- **`IsBrocardSolution n := ∃ m, n! + 1 = m^2`** — the Brocard–Ramanujan predicate (Brown numbers).
- **`isBrocardSolution_{four,five,seven}`** — the three known solutions (roots `5, 11, 71` are all prime, matching the prime-power results).
- **`not_isBrocardSolution_six`** — `6!+1 = 721` lies strictly between `26² = 676` and `27² = 729`, so it is not a perfect square; the gap between the known solutions `5` and `7` contains none.
- **`brocard_root_gt`** — *structural constraint*: in any solution `n!+1 = m²` with `n ≥ 1`, the root satisfies `n < m`. Proved via the file's Euclid engine `prime_dvd_factorial_add_one_gt` applied to `m.minFac` (which divides `m ∣ m² = n!+1`), then `minFac ≤ m`. The quantitative shadow of Euclid's argument on the Brocard equation.

## Honesty

Brocard's problem (are `4, 5, 7` the only solutions?) is **open** — this PR does not claim to resolve it. It proves only the three known solutions are solutions, rules out `n = 6`, and derives the general lower bound `m > n`. Status remains `verified` (0 axioms / 0 sorries).

## Verification

Docker build `[7743/7743]` green (clean elaboration first try; olean written on retry-2 after an intermittent fleet SIGBUS-135). `meta.json` counts synced: 18→23 theorems, +1 definition, 260→318 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)