### PR TITLE
research(erdos-214): generalize √2·ℤ² to the c·ℤ² unit-distance-free family (c²>1)

### DIFF
--- a/proofs/Proofs/Erdos214Problem.lean
+++ b/proofs/Proofs/Erdos214Problem.lean
@@ -216,6 +216,52 @@ theorem scaledLattice_unitDistanceFree : IsUnitDistanceFree ScaledLattice := by
   have hint : (2 * ((a₁ - a₂) ^ 2 + (b₁ - b₂) ^ 2) : ℤ) = 1 := by exact_mod_cast hdist
   omega
 
+/-- **General scaled lattice `c·ℤ²`.** Vertices are `(c·a, c·b)` for integers `a, b`.
+The earlier `ScaledLattice` is the `c = √2` instance (`scaledLattice_eq_gen`). -/
+def ScaledLatticeGen (c : ℝ) : Set Plane :=
+  {p : Plane | ∃ a b : ℤ, p 0 = c * a ∧ p 1 = c * b}
+
+/-- **Every lattice `c·ℤ²` with `c² > 1` is unit-distance-free.**
+
+Two distinct lattice points `(c·a₁, c·b₁)`, `(c·a₂, c·b₂)` are at squared distance
+`c²·m`, where `m = (a₁-a₂)² + (b₁-b₂)²` is a nonnegative integer. A unit distance would
+force `c²·m = 1`; but `m = 0` gives `0 ≠ 1`, and `m ≥ 1` gives `c²·m ≥ c² > 1`, so no
+two points are at distance `1`.
+
+This generalises `scaledLattice_unitDistanceFree` (the `c² = 2` case) to a whole
+one-parameter family of explicit infinite unit-distance-free sets.  The bound `c² > 1`
+is *sufficient but not necessary*: integrality of `m` means only `m` that are sums of
+two squares can occur, so e.g. `c = 1/√3` also works (`1/c² = 3` is not a sum of two
+squares) despite `c² < 1`.  The clean scale-invariant condition captured here is that
+`c` is large enough (`|c| > 1`) that no positive integer multiple of `c²` can equal `1`. -/
+theorem scaledLatticeGen_unitDistanceFree {c : ℝ} (hc : 1 < c ^ 2) :
+    IsUnitDistanceFree (ScaledLatticeGen c) := by
+  rintro p q ⟨a₁, b₁, hp0, hp1⟩ ⟨a₂, b₂, hq0, hq1⟩ _ hdist
+  set m : ℤ := (a₁ - a₂) ^ 2 + (b₁ - b₂) ^ 2 with hm
+  have hX : (p 0 - q 0) ^ 2 + (p 1 - q 1) ^ 2 = c ^ 2 * (m : ℝ) := by
+    rw [hp0, hp1, hq0, hq1, hm]; push_cast; ring
+  rw [dist_sq, hX, Real.sqrt_eq_one] at hdist
+  have hm0 : 0 ≤ m := by rw [hm]; positivity
+  rcases eq_or_lt_of_le hm0 with hm_eq | hm_pos
+  · -- m = 0 : the squared distance is 0, not 1
+    have : (m : ℝ) = 0 := by exact_mod_cast hm_eq.symm
+    rw [this, mul_zero] at hdist
+    exact absurd hdist (by norm_num)
+  · -- m ≥ 1 : squared distance is at least c² > 1
+    have hm1 : (1 : ℝ) ≤ (m : ℝ) := by
+      have : (1 : ℤ) ≤ m := by omega
+      exact_mod_cast this
+    have hc0 : (0 : ℝ) < c ^ 2 := lt_trans one_pos hc
+    have hge : c ^ 2 * 1 ≤ c ^ 2 * (m : ℝ) := mul_le_mul_of_nonneg_left hm1 hc0.le
+    rw [mul_one] at hge
+    linarith
+
+/-- **`ScaledLattice` is the `c = √2` instance of `ScaledLatticeGen`.** Definitional:
+both unfold to `{p | ∃ a b : ℤ, p 0 = √2·a ∧ p 1 = √2·b}`.  In particular
+`scaledLattice_unitDistanceFree` is `scaledLatticeGen_unitDistanceFree` applied at
+`c = √2` (where `c² = 2 > 1`). -/
+theorem scaledLattice_eq_gen : ScaledLattice = ScaledLatticeGen (Real.sqrt 2) := rfl
+
 /-
 ## Part 8: Related Problems
 -/

--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -52,7 +52,8 @@
       "Metric helpers dist_self (dist p p = 0) and dist_comm (symmetry) — basic coordinate-distance facts previously absent.",
       "isUnitSquare_of_isometry: any distance-preserving map carries a unit square to a unit square — the reusable geometric heart of the reduction unit_square_from_stronger (a congruent copy of the standard unit square is again a unit square precisely because the witness is an isometry).",
       "IsUnitSquare.distinct: a unit square has four pairwise-distinct vertices (edges have length 1≠0, diagonals length √2≠0, and dist p p = 0), certifying ContainsUnitSquare is a genuinely non-degenerate 4-point statement.",
-      "complement_contains_distinct_unit_square: capstone — the complement of any unit-distance-free set contains a unit square on four PAIRWISE-DISTINCT points, sharpening the problem's 'four points' phrasing (combines erdos_214_solved with vertex-distinctness)."
+      "complement_contains_distinct_unit_square: capstone — the complement of any unit-distance-free set contains a unit square on four PAIRWISE-DISTINCT points, sharpening the problem's 'four points' phrasing (combines erdos_214_solved with vertex-distinctness).",
+      "scaledLatticeGen_unitDistanceFree: generalizes the √2·ℤ² unit-distance-free construction to the one-parameter family c·ℤ² for every real c with c²>1 (squared distance c²·m, m a nonnegative-integer sum of two squares, never equals 1); scaledLattice_eq_gen (rfl) recovers the √2 case."
     ],
     "relatedProblems": [
       {
@@ -85,10 +86,10 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 414,
+    "lineCount": 460,
     "assumptions": "1 axiom: juhasz_stronger (Juhász 1979 — a unit-distance-free set's complement contains a congruent copy of ANY 4-point configuration). The original Problem #214 statement (juhasz_1979 : Erdos214Statement) is no longer a separate axiom: it is DERIVED from juhasz_stronger via the proved reduction unit_square_from_stronger (a unit square is a special 4-point configuration, transported into the complement by Juhász's isometry). 0 sorries. The problem's hypothesis is now shown non-vacuous: scaledLattice_unitDistanceFree proves √2·ℤ² is an explicit infinite unit-distance-free set (no assumptions).",
-    "theoremCount": 23,
-    "definitionCount": 13,
+    "theoremCount": 25,
+    "definitionCount": 14,
     "additionalFiles": [
       "Proofs/Erdos214ProblemAristotle.lean"
     ]
@@ -198,10 +199,10 @@
       "Real"
     ],
     "namespace": "Erdos214",
-    "lineCount": 414,
+    "lineCount": 460,
     "axiomCount": 1,
-    "theoremCount": 23,
-    "definitionCount": 13,
+    "theoremCount": 25,
+    "definitionCount": 14,
     "path": "Proofs/Erdos214Problem.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -1,85 +1,87 @@
 {
- "slug": "erdos-214-incomplete-01",
- "title": "Erdős Problem #214: Unit Distance Free Sets and Unit Squares",
- "phase": "ACT",
- "status": "active",
- "tier": "A",
- "path": "full",
- "problemStatement": {
-  "formal": "",
-  "plain": "",
-  "whyMatters": []
- },
- "knownResults": {
-  "proven": [],
-  "open": [],
-  "goal": "",
-  "completedThisIter": [
-   "researcher-8, 2026-07-09: added 3 verified axiom-free theorems answering the 'maximum size of a unit-distance-free set' half of #214 for the plane — IsUnitDistanceFree.mono (subsets of UDF sets are UDF), exists_unitDistanceFree_finset_card (a UDF finset of every cardinality n via an n-subset of the infinite scaledLattice), and no_maximum_unitDistanceFree_card (no finite cap). Docker build 2364 jobs, 0 errors/sorry, axiomCount unchanged (1)."
+  "slug": "erdos-214-incomplete-01",
+  "title": "Erdős Problem #214: Unit Distance Free Sets and Unit Squares",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "",
+    "completedThisIter": [
+      "researcher-8, 2026-07-09: added 3 verified axiom-free theorems answering the 'maximum size of a unit-distance-free set' half of #214 for the plane — IsUnitDistanceFree.mono (subsets of UDF sets are UDF), exists_unitDistanceFree_finset_card (a UDF finset of every cardinality n via an n-subset of the infinite scaledLattice), and no_maximum_unitDistanceFree_card (no finite cap). Docker build 2364 jobs, 0 errors/sorry, axiomCount unchanged (1)."
+    ]
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T08:28:28Z",
+    "iteration": 2,
+    "focus": "S+1 ACT (researcher-8, 2026-07-09): core sorry unit_square_exists_in_set remains BLOCKED on juhasz_stronger (deep incidence geometry, absent from Mathlib). Added peripheral verified corollaries showing UDF-set cardinality is unbounded (no finite maximum). File 382->414 lines, theoremCount 20->23.",
+    "blockers": [],
+    "nextAction": "Core still needs juhasz_stronger (not session-sized / not in Mathlib). Optional: explicit finite UDF configurations, or the 5-point case HoldsFor5Points.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "AXIOMATIZED/BLOCKED on juhasz_stronger. Axiom-free scaffolding now includes: full metric axioms for Erdos214.dist, isometry-invariance + vertex-distinctness of unit squares, and infinitude of the √2·ℤ² witness. 0 sorries, 1 intended axiom.",
+    "builtItems": [
+      "Erdos214Problem.lean: dist_coords (coordinate distance formula), isUnitSquare_standard (the standard unit square is a unit square), unit_square_from_stronger (sorry eliminated, 0-axiom reduction)",
+      "Fixed Mathlib-4.26 build break: UnitDistanceGraph tuple set-builder → setOf on Prod",
+      "dist_nonneg, dist_triangle in Erdos214Problem.lean: the two metric axioms missing from dist_self/dist_comm (via norm_nonneg, norm_add_le + sub_add_sub_cancel) — Erdos214.dist certified a genuine metric",
+      "scaledLattice_horiz_mem + scaledLattice_infinite: √2·ℤ² is infinite (horizontal axis n↦(√2·n,0) embeds ℤ via Set.infinite_of_injective_forall_mem), sharpening scaledLattice_unitDistanceFree from non-empty to infinite",
+      "scaledLatticeGen_unitDistanceFree: c·ℤ² is unit-distance-free for every real c with c²>1 (generalizes the √2 case; squared distance c²·m never hits 1 since m∈ℕ, m=0→0, m≥1→c²·m≥c²>1). scaledLattice_eq_gen (rfl) exhibits ScaledLattice as the c=√2 instance. [elaboration-clean [2364/2364]; olean-write blocked by fleet SIGBUS-135/139]"
+    ],
+    "insights": [
+      "erdos-214 (Juhász 1979, unit-distance-free sets): the 1 sorry was in unit_square_from_stronger (JuhaszStrongerTheorem → Erdos214Statement) — a pure logical reduction, NOT one of the 2 deep Juhász axioms.",
+      "Proved it: apply the stronger theorem to the standard unit square P=(0,0),(1,0),(1,1),(0,1) as a PointSet 4; the congruent copy in Sᶜ is again a unit square since the witnessing map is an isometry (dist-preserving), carrying P's 4 edges (=1) and 2 diagonals (=√2).",
+      "Key helper dist_coords: dist(!₂[a,b],!₂[c,d]) = √((a-c)²+(b-d)²) via EuclideanSpace.dist_eq + Fin.sum_univ_two + Real.dist_eq + sq_abs; concrete unit square checked by norm_num [Real.sqrt_one].",
+      "The file ALSO didn't compile on pinned Mathlib 4.26: UnitDistanceGraph used the tuple set-builder {(p,q) | ...} which no longer parses ('unknown identifier q'); rewrote as {pq | pq.1∈S ∧ ...}.",
+      "Coordinate extraction from !₂[a,b]: congrFun FAILS (WithLp.toLp wrapper not a syntactic pi type) — use congrArg (fun x => x 0) then simp [Matrix.cons_val_zero]",
+      "Root Mathlib dist is Dist.dist, NOT accessible as _root_.dist; prove metric facts directly from ‖p-q‖ (norm_nonneg/norm_add_le) rather than bridging to Mathlib dist",
+      "The √2 lattice is not special: any scaling c with |c|>1 yields a unit-distance-free copy of ℤ². The sharp condition is arithmetic (no sum-of-two-squares integer m with c²·m=1), so c²>1 is sufficient but not necessary (e.g. c=1/√3 also works since 3 is not a sum of two squares)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Remaining elementary follow-ups exhausted around definitions; core BLOCKED on juhasz_stronger (deep 1979 4-point theorem, not in Mathlib). Only substantial work left = formalizing that axiom."
+    ],
+    "markdown": "# Knowledge: erdos-214-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "erdos-2",
+    "erdos-21",
+    "erdos-214",
+    "erdos-214-incomplete-01-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T08:27:10.206Z",
+  "lastUpdate": "2026-07-10",
+  "significance": 7,
+  "tractability": 4,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos214Incomplete01OQ01.lean",
+      "filename": "Erdos214Incomplete01OQ01.lean",
+      "lineCount": 198,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos214Incomplete01OQ01.lean"
+    }
   ]
- },
- "currentState": {
-  "phase": "OBSERVE",
-  "since": "2026-04-03T08:28:28Z",
-  "iteration": 2,
-  "focus": "S+1 ACT (researcher-8, 2026-07-09): core sorry unit_square_exists_in_set remains BLOCKED on juhasz_stronger (deep incidence geometry, absent from Mathlib). Added peripheral verified corollaries showing UDF-set cardinality is unbounded (no finite maximum). File 382->414 lines, theoremCount 20->23.",
-  "blockers": [],
-  "nextAction": "Core still needs juhasz_stronger (not session-sized / not in Mathlib). Optional: explicit finite UDF configurations, or the 5-point case HoldsFor5Points.",
-  "attemptCounts": {
-   "total": 0,
-   "currentApproach": 0,
-   "approachesTried": 0
-  }
- },
- "knowledge": {
-  "progressSummary": "AXIOMATIZED/BLOCKED on juhasz_stronger. Axiom-free scaffolding now includes: full metric axioms for Erdos214.dist, isometry-invariance + vertex-distinctness of unit squares, and infinitude of the √2·ℤ² witness. 0 sorries, 1 intended axiom.",
-  "builtItems": [
-   "Erdos214Problem.lean: dist_coords (coordinate distance formula), isUnitSquare_standard (the standard unit square is a unit square), unit_square_from_stronger (sorry eliminated, 0-axiom reduction)",
-   "Fixed Mathlib-4.26 build break: UnitDistanceGraph tuple set-builder → setOf on Prod",
-   "dist_nonneg, dist_triangle in Erdos214Problem.lean: the two metric axioms missing from dist_self/dist_comm (via norm_nonneg, norm_add_le + sub_add_sub_cancel) — Erdos214.dist certified a genuine metric",
-   "scaledLattice_horiz_mem + scaledLattice_infinite: √2·ℤ² is infinite (horizontal axis n↦(√2·n,0) embeds ℤ via Set.infinite_of_injective_forall_mem), sharpening scaledLattice_unitDistanceFree from non-empty to infinite"
-  ],
-  "insights": [
-   "erdos-214 (Juhász 1979, unit-distance-free sets): the 1 sorry was in unit_square_from_stronger (JuhaszStrongerTheorem → Erdos214Statement) — a pure logical reduction, NOT one of the 2 deep Juhász axioms.",
-   "Proved it: apply the stronger theorem to the standard unit square P=(0,0),(1,0),(1,1),(0,1) as a PointSet 4; the congruent copy in Sᶜ is again a unit square since the witnessing map is an isometry (dist-preserving), carrying P's 4 edges (=1) and 2 diagonals (=√2).",
-   "Key helper dist_coords: dist(!₂[a,b],!₂[c,d]) = √((a-c)²+(b-d)²) via EuclideanSpace.dist_eq + Fin.sum_univ_two + Real.dist_eq + sq_abs; concrete unit square checked by norm_num [Real.sqrt_one].",
-   "The file ALSO didn't compile on pinned Mathlib 4.26: UnitDistanceGraph used the tuple set-builder {(p,q) | ...} which no longer parses ('unknown identifier q'); rewrote as {pq | pq.1∈S ∧ ...}.",
-   "Coordinate extraction from !₂[a,b]: congrFun FAILS (WithLp.toLp wrapper not a syntactic pi type) — use congrArg (fun x => x 0) then simp [Matrix.cons_val_zero]",
-   "Root Mathlib dist is Dist.dist, NOT accessible as _root_.dist; prove metric facts directly from ‖p-q‖ (norm_nonneg/norm_add_le) rather than bridging to Mathlib dist"
-  ],
-  "mathlibGaps": [],
-  "nextSteps": [
-   "Remaining elementary follow-ups exhausted around definitions; core BLOCKED on juhasz_stronger (deep 1979 4-point theorem, not in Mathlib). Only substantial work left = formalizing that axiom."
-  ],
-  "markdown": "# Knowledge: erdos-214-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
- },
- "tags": [],
- "relatedProofs": [
-  "erdos-2",
-  "erdos-21",
-  "erdos-214",
-  "erdos-214-incomplete-01-oq-01"
- ],
- "references": {
-  "papers": [],
-  "urls": [],
-  "mathlib": []
- },
- "started": "2026-04-03T08:27:10.206Z",
- "lastUpdate": "2026-07-09T00:00:00.000Z",
- "significance": 7,
- "tractability": 4,
- "leanFiles": [
-  {
-   "path": "Proofs/Erdos214Incomplete01OQ01.lean",
-   "filename": "Erdos214Incomplete01OQ01.lean",
-   "lineCount": 198,
-   "theoremCount": 9,
-   "axiomCount": 0,
-   "defCount": 3,
-   "sorryCount": 1,
-   "isAristotle": false,
-   "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos214Incomplete01OQ01.lean"
-  }
- ]
 }


### PR DESCRIPTION
## Summary

Erdős #214 (Juhász 1979) asks whether the complement of a unit-distance-free set in ℝ² must contain a unit square. The gallery file's core rests on the single deep axiom `juhasz_stronger`; the elementary layer around it is otherwise complete. This PR adds a genuine **generalization** to the existing explicit-witness lemma.

The file previously exhibited exactly one explicit infinite unit-distance-free set, `√2·ℤ²` (`scaledLattice_unitDistanceFree`). I generalize this to a **one-parameter family**:

- `def ScaledLatticeGen (c : ℝ)` — the lattice `c·ℤ²` = `{(c·a, c·b) : a,b ∈ ℤ}`.
- `scaledLatticeGen_unitDistanceFree {c} (hc : 1 < c^2)` — **every** `c·ℤ²` with `c² > 1` is unit-distance-free. Two distinct lattice points sit at squared distance `c²·m` with `m = (a₁-a₂)²+(b₁-b₂)²` a nonnegative integer; a unit distance would force `c²·m = 1`, impossible since `m = 0` gives `0` and `m ≥ 1` gives `c²·m ≥ c² > 1`.
- `scaledLattice_eq_gen : ScaledLattice = ScaledLatticeGen (√2)` (by `rfl`) — recovers the original `√2` lattice as the `c² = 2` instance.

The docstring is honest that `c² > 1` is **sufficient but not necessary**: because `m` ranges over sums of two squares, e.g. `c = 1/√3` also works (`3` is not a sum of two squares) despite `c² < 1`.

**Math value:** shows the `√2` construction is not special — an entire real-parameter family of explicit infinite unit-distance-free sets realizes Problem #214's hypothesis.

## Verification status

**Elaboration-clean but UNVERIFIED (olean not written).** Every Docker build run (6+ attempts) fully elaborated the file — `✖ [2364/2364] Building Proofs.Erdos214Problem (~1s)` — then crashed at the final `.olean` write with exit 135/139 (SIGBUS/SIGSEGV), the known environment crash under fleet memory pressure, not a code defect. The proof uses only robust elementary tactics (`rintro`, `set`, `push_cast`, `ring`, `positivity`, `rcases`, `omega`, `exact_mod_cast`, `mul_le_mul_of_nonneg_left`, `linarith`); **0 sorries, 0 new axioms**.

## Files
- `proofs/Proofs/Erdos214Problem.lean` — +1 def, +2 theorems (414→460 lines)
- `src/data/proofs/erdos-214/meta.json` — counts synced (23→25 thm, 13→14 def, 460 lines) + originalContributions entry
- `src/data/research/problems/erdos-214-incomplete-01.json` — knowledge/insights recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)