### PR TITLE
Enrich Odd-Square Series (basel-problem-oq-09): fix false dependency claim in annotation

### DIFF
--- a/src/data/proofs/basel-problem-oq-09/annotations.json
+++ b/src/data/proofs/basel-problem-oq-09/annotations.json
@@ -158,7 +158,7 @@
     },
     "type": "theorem",
     "title": "The Odd-Square Series ∑ 1/(2k+1)² = π²/8",
-    "content": "hasSum_odd_squares is the headline result, assembled from the even part, odd summability, the even_add_odd recombination, and uniqueness. tsum_odd_squares and summable_odd_squares package it in tsum and Summable form for downstream reuse, and odd_squares_value_pos records the elementary corollary π²/8 > 0 (by positivity), which the mass-distribution comparison π²/24 < π²/8 later depends on. The value π²/8 is exactly λ(2), the s = 2 case of the Dirichlet odd-index zeta λ(s) = ∑ 1/(2k+1)^s = (1 − 2^{−s})ζ(s); here (1 − 1/4)·π²/6 = (3/4)·π²/6 = π²/8.",
+    "content": "hasSum_odd_squares is the headline result, assembled from the even part, odd summability, the even_add_odd recombination, and uniqueness. tsum_odd_squares and summable_odd_squares package it in tsum and Summable form for downstream reuse, and odd_squares_value_pos records the elementary corollary π²/8 > 0 (by positivity) as a standalone sanity check on the value (the later mass-distribution comparison π²/24 < π²/8 is proved independently). The value π²/8 is exactly λ(2), the s = 2 case of the Dirichlet odd-index zeta λ(s) = ∑ 1/(2k+1)^s = (1 − 2^{−s})ζ(s); here (1 − 1/4)·π²/6 = (3/4)·π²/6 = π²/8.",
     "mathContext": "$\\displaystyle\\sum_{k=0}^{\\infty} \\frac{1}{(2k+1)^2} = 1 + \\frac19 + \\frac1{25} + \\cdots = \\frac{\\pi^2}{8} = \\lambda(2).$",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-09` (∑ 1/(2k+1)² = π²/8).

**Correctness fix (annotation accuracy).** The `main-result` annotation asserted that `odd_squares_value_pos` (the corollary π²/8 > 0) is something the mass-distribution comparison π²/24 < π²/8 "later depends on." This is false: in `Proofs/BaselProblemOQ09.lean`, `odd_part_gt_even_part` is proved independently via its own `have : 0 < π^2 := by positivity; linarith` — it does not reference `odd_squares_value_pos`. Reworded to describe `odd_squares_value_pos` as a standalone sanity check and to note the comparison is proved independently.

Single-line, non-inflating change. Entry is already comprehensively enriched (9 annotations, 5 keyInsights, full sections/conclusion) and remains well under all size caps (~13.4 KB). JSON validates; annotation schema build reports no errors for this slug.