### PR TITLE
audit(hilbert-5): re-verify CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20812,9 +20812,10 @@
       "issues": []
     },
     "hilbert-5": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:02:00Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-07-10T01:02:08Z",
       "result": "clean"
     },
     "hilbert-5-oq-02": {


### PR DESCRIPTION
## Auditor: hilbert-5 (Hilbert's 5th Problem / Lie groups) re-verified CLEAN

Re-audited the stalest tracker entry (`lastAudited` was 2026-05-03). No integrity issues.

### Findings
- **status/badge**: `axiomatized` / `axiom` — correct.
- **axiomCount = 5** matches source (`gleason_lemma_1`, `gleason_lemma_2`, `no_small_subgroups_suggests_lie_structure`, `montgomery_zippin_theorem`, `von_neumann_compact_groups`); all five disclosed by name in `assumptions`.
- **originalContributions** honestly framed as *Definition of / Statement of / Formalization of* — no proof overclaim.
- **conclusion** explicitly states the entry "axiomatizes the main biconditional theorem" — honest.
- The 8 `theorem` decls are decorative `True`-stubs / `1+1=2` placeholders, but none are cited in `mainTheorems`, `originalContributions`, or `assumptions` as proved results, so there is no masking or overclaim.
- `mainTheorems[0].name` (`hilbert5_gleason`) is a conceptual label, not a live decl — benign under the axiomatized status (content genuinely axiomatized via `montgomery_zippin_theorem`).

Consistent with the parallel-postulate (#36488-class) and kepler (#36563) honest-Tier-C-scaffold pattern. No changes to gallery content; tracker bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)