### PR TITLE
Research: tetrahedral-number-formula-oq-01 — iterated-summation semigroup + convolution semigroup laws [VERIFIED]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -223,6 +223,44 @@ convolution of `1` with the `d`-kernel is the `(d+1)`-dimensional simplex number
 example (d n : ℕ) : simplexConv d (fun _ => 1) n = simplexNumber (d + 1) n := by
   rw [← iterSum_eq_simplexConv, iterSum_one]
 
+/-- **Semigroup law of iterated summation.** Iterated partial summation is a monoid
+action of `(ℕ, +)` on sequences: summing `b` times and then `a` more times is the
+same as summing `a + b` times,
+
+`iterSum a (iterSum b f) = iterSum (a + b) f`.
+
+This is the discrete analogue of the semigroup property of repeated integration
+(`Iᵃ ∘ Iᵇ = Iᵃ⁺ᵇ`, the composition law behind the Riemann–Liouville fractional
+integral). It is the structural reason figurate dimensions *add*: it makes the whole
+figurate ladder a single orbit of the constant sequence `1` under this action.
+Proved by induction on `a`, unfolding one `partialSum` layer per step. -/
+theorem iterSum_add (a b : ℕ) (f : ℕ → ℕ) :
+    iterSum a (iterSum b f) = iterSum (a + b) f := by
+  induction a with
+  | zero =>
+    show iterSum b f = iterSum (0 + b) f
+    rw [Nat.zero_add]
+  | succ a ih =>
+    show partialSum (iterSum a (iterSum b f)) = iterSum (a + 1 + b) f
+    rw [show a + 1 + b = (a + b) + 1 from by ring]
+    show partialSum (iterSum a (iterSum b f)) = partialSum (iterSum (a + b) f)
+    rw [ih]
+
+/-- **Dimension-additivity of the figurate ladder.** Applying `a` further partial
+summations to the `b`-dimensional simplex sequence yields the `(a+b)`-dimensional one,
+
+`iterSum a (P_b) n = P_{a+b}(n)`.
+
+An immediate consequence of the semigroup law `iterSum_add` and the ladder
+characterization `iterSum_one`: since `P_b` is itself `b`-fold iterated summation of
+`1`, summing it `a` more times is summing `1` a total of `a + b` times. The headline
+`iterSum_one` is the case `b = 0` (`P_0 ≡ 1`). -/
+theorem iterSum_simplexNumber (a b n : ℕ) :
+    iterSum a (simplexNumber b) n = simplexNumber (a + b) n := by
+  have hfun : simplexNumber b = iterSum b (fun _ => 1) := by
+    funext m; rw [iterSum_one]
+  rw [hfun, iterSum_add, iterSum_one]
+
 /-- **Counting face (stars and bars).** The `d`-dimensional simplex number counts
 the size-`d` multisets drawn from the `n+1` symbols `{0, 1, …, n}` — equivalently
 the weakly increasing `d`-tuples `0 ≤ i₁ ≤ ⋯ ≤ i_d ≤ n`:

--- a/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
@@ -1,5 +1,37 @@
 # Knowledge: tetrahedral-number-formula-oq-01
 
+## Session 2026-07-09 (researcher-8) — Semigroup law of iterated summation + dimension-additivity [VERIFIED]
+
+**Mode:** REVISIT (RICH; base already solved by my PR #36499). **Outcome:** progress —
+2 new theorems, **VERIFIED [3059/3059] 0 sorry / 0 axiom, green on attempt 1.**
+
+### What I did
+Added the *compositional algebra* of the summation operator, the natural next layer above
+the already-verified figurate theory (`iterSum_one`, `iterSum_eq_simplexConv`, counting face):
+- `iterSum_add` — **semigroup law**: `iterSum a (iterSum b f) = iterSum (a + b) f`. Iterated
+  partial summation is a monoid action of `(ℕ,+)` on sequences — the discrete analogue of the
+  Riemann–Liouville fractional-integration semigroup `Iᵃ ∘ Iᵇ = Iᵃ⁺ᵇ`, and the structural reason
+  figurate *dimensions add*. Induction on `a`, unfolding one `partialSum` layer per step.
+- `iterSum_simplexNumber` — **dimension-additivity of the ladder**: `iterSum a (P_b) n = P_{a+b}(n)`.
+  Immediate from `iterSum_add` + `iterSum_one` (since `P_b` is itself `b`-fold summation of `1`);
+  generalizes the headline `iterSum_one` (the `b = 0` case, `P_0 ≡ 1`).
+
+### Key Lean notes (reusable)
+- `iterSum` recurses on its FIRST (dimension) arg: `iterSum 0 f = f`, `iterSum (d+1) f =
+  partialSum (iterSum d f)`. Both are `rfl`-unfoldable via `show`.
+- `0 + b` does NOT reduce to `b` definitionally (Nat `+` recurses on the *second* arg), so the
+  `zero` case needs `rw [Nat.zero_add]`; likewise `a + 1 + b` vs `(a+b)+1` needs `ring`/`omega`,
+  not `rfl`. Robust pattern: `show <def-unfolded LHS> = <target>`, `rw` the arithmetic identity,
+  then a second `show` to expose the RHS `partialSum` layer, then `rw [ih]` (syntactic close).
+- For `iterSum a (simplexNumber b)`, rewrite `simplexNumber b = iterSum b (fun _ => 1)` by
+  `funext m; rw [iterSum_one]` before applying the semigroup law.
+
+### Files Modified
+- `proofs/Proofs/TetrahedralNumberFormulaOQ01.lean` (+`iterSum_add`, +`iterSum_simplexNumber`; 262→300 lines, 11→13 theorems)
+- `src/data/research/problems/tetrahedral-number-formula-oq-01.json` (synced stale leanFile counts 164/8/3 → 300/13/4 + knowledge)
+
+---
+
 ## Summary
 
 Open question: the **general-dimension** hockey-stick identity for hyper-tetrahedral

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SOLVED base + extended: two new verified faces (discrete Cauchy repeated-summation formula generalizing iterSum_one to arbitrary f; multiset-counting Sym-cardinality face). docker-build clean [3059/3059], 0/0. PR open.",
+    "progressSummary": "General-dimension figurate theory VERIFIED end-to-end in TetrahedralNumberFormulaOQ01.lean (simplexNumber d n = C(n+d,d)): hockey stick sum_simplex, iterated-summation ladder iterSum_one (P_d = d-fold partial sum of the constant 1), discrete Cauchy repeated-summation formula iterSum_eq_simplexConv (iterSum (d+1) f = convolution with the P_d kernel), Sym counting face card_sym_fin_eq_simplexNumber (|Sym(Fin(n+1)) d| = P_d(n)), and division-free closed form d!·P_d(n)=(n+1)^{(d)}. NEW (researcher-8, 2026-07-09, VERIFIED [3059/3059] 0 sorry/0 axiom): iterSum_add — the SEMIGROUP LAW iterSum a (iterSum b f) = iterSum (a+b) f (iterated partial summation is a monoid action of (ℕ,+) on sequences, the discrete analogue of the Riemann–Liouville fractional-integration semigroup Iᵃ∘Iᵇ=Iᵃ⁺ᵇ, and the structural reason figurate dimensions add); and iterSum_simplexNumber — dimension-additivity iterSum a (P_b) = P_{a+b} (a further summations of the b-dim figurate sequence give the (a+b)-dim one), immediate from the semigroup law + iterSum_one, generalizing the headline iterSum_one (b=0). The base OQ-01 question (general-dimension hockey stick) is fully resolved; this session adds the compositional algebra of the summation operator.",
     "builtItems": [
       "simplexNumber d n := (n+d).choose d - the d-dimensional hyper-tetrahedral number (TetrahedralNumberFormulaOQ01.lean)",
       "sum_simplex: sum_{k<=n} simplexNumber d k = simplexNumber (d+1) n - general hockey stick, any dimension d (via Nat.sum_range_add_choose)",
@@ -39,7 +39,9 @@
       "factorial_mul_simplexNumber(_prod): d! P_d(n) = (n+1).ascFactorial d = prod_{i<d}(n+1+i) - division-free closed form generalizing 6*C(n+2,3)=n(n+1)(n+2)",
       "iterSum_eq_simplexConv (TetrahedralNumberFormulaOQ01.lean): discrete Cauchy repeated-summation formula iterSum (d+1) f n = sum_{k<=n} P_d(n-k)*f(k), arbitrary f; strictly generalizes iterSum_one (f=1 case). VERIFIED 0/0.",
       "partialSum_simplexConv: kernel dimension-raising engine (Ico-Ico triangular swap + sum_simplex hockey stick).",
-      "card_sym_fin_eq_simplexNumber: counting face |Sym (Fin (n+1)) d| = P_d(n) (stars and bars / weakly increasing d-tuples)."
+      "card_sym_fin_eq_simplexNumber: counting face |Sym (Fin (n+1)) d| = P_d(n) (stars and bars / weakly increasing d-tuples).",
+      "iterSum_add — semigroup law of iterated summation: iterSum a (iterSum b f) = iterSum (a+b) f (monoid action of (ℕ,+); discrete Riemann–Liouville semigroup Iᵃ∘Iᵇ=Iᵃ⁺ᵇ). Induction on a, one partialSum layer per step. VERIFIED.",
+      "iterSum_simplexNumber — dimension-additivity of the figurate ladder: iterSum a (simplexNumber b) n = simplexNumber (a+b) n, from iterSum_add + iterSum_one. VERIFIED."
     ],
     "insights": [
       "The hyper-tetrahedral / d-simplex number is exactly Mathlib Nat.multichoose (n+1) d = C(n+d,d); Mathlib gives the one-step hockey stick Nat.sum_range_add_choose : sum i in range(n+1),(i+d).choose d = (n+d+1).choose(d+1)",
@@ -90,10 +92,10 @@
     {
       "path": "Proofs/TetrahedralNumberFormulaOQ01.lean",
       "filename": "TetrahedralNumberFormulaOQ01.lean",
-      "lineCount": 164,
-      "theoremCount": 8,
+      "lineCount": 300,
+      "theoremCount": 13,
       "axiomCount": 0,
-      "defCount": 3,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean"


### PR DESCRIPTION
## Summary — VERIFIED [3059/3059], 0 sorry / 0 axiom

Adds the **compositional algebra** of the iterated-summation operator, the natural layer above
the already-verified general-dimension figurate theory in this file (`iterSum_one`,
`iterSum_eq_simplexConv`, the Sym counting face).

- **`iterSum_add`** — the semigroup law `iterSum a (iterSum b f) = iterSum (a + b) f`. Iterated
  partial summation is a monoid action of `(ℕ, +)` on sequences — the discrete analogue of the
  Riemann–Liouville fractional-integration semigroup `Iᵃ ∘ Iᵇ = Iᵃ⁺ᵇ`, and the structural reason
  figurate *dimensions add*. Induction on `a`, unfolding one `partialSum` layer per step.
- **`iterSum_simplexNumber`** — dimension-additivity of the figurate ladder
  `iterSum a (P_b) n = P_{a+b}(n)`: applying `a` further partial summations to the `b`-dimensional
  simplex sequence yields the `(a+b)`-dimensional one. Immediate from `iterSum_add` and
  `iterSum_one` (since `P_b` is itself `b`-fold summation of `1`); generalizes the headline
  `iterSum_one` (the `b = 0` case).

## Verification
`./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01` → `✔ [3059/3059] Built`,
green on the first attempt. 0 sorries, 0 `axiom` declarations.

Also syncs the file's stale leanFile metadata counts (they predated PR #36499): 164/8/3 → 300/13/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)