### PR TITLE
research(shannon-awgn-oq-02-oq-02): correlated-noise MRC optimum via matrix Cauchy–Schwarz

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ02OQ02.lean
@@ -1695,4 +1695,105 @@ theorem awgn_weighted_power_eq_covariance_quadratic_form [IsProbabilityMeasure �
   have hSum0 : μ[∑ i ∈ s, a i • W i] = 0 := sum_mean_zero hV hVmean
   rw [second_moment_eq_variance hSum hSum0, variance_smul_sum' a hW]
 
+/-!
+### Correlated-noise MRC optimum (matrix Cauchy–Schwarz)
+
+The uncorrelated MRC theory above (`mrc_signal_sq_le`, `mrc_signal_sq_eq_iff`,
+`mrc_snr_matched`) bounds the output SNR of a linear combiner when the branch noises are
+*uncorrelated*, so the output power collapses to the diagonal `∑ᵢ aᵢ²·vᵢ`.  The genuinely
+open direction is the **correlated** case, where the output power is the full quadratic form
+`aᵀΣa = ∑ᵢ∑ⱼ aᵢ·aⱼ·cov[Wᵢ, Wⱼ]` (`awgn_weighted_power_eq_covariance_quadratic_form`).
+
+The classical resolution passes through matrix square-roots / whitening (`Σ^{-1/2}`), but that
+machinery is heavy in Lean.  The observation that makes it session-sized here is that the two
+combiners `∑ᵢ aᵢ·Wᵢ` and `∑ⱼ bⱼ·Wⱼ` are *themselves* scalar random variables, so the entire
+matrix Cauchy–Schwarz reduces to the **scalar** covariance Cauchy–Schwarz
+`covariance_sq_le_variance_mul_variance` after expanding the covariance/variance quadratic
+forms bilinearly (`covariance_sum_sum'`, `variance_smul_sum'`).  No matrix inverse or square
+root is needed, and the optimum `sᵀΣ⁻¹s` is realized (inverse-free) as the matched power
+`bᵀΣb` at the matched combiner `s = Σb`.
+-/
+
+/-- **Bilinear covariance expansion for two weighted combiners.**  The cross-covariance of two
+deterministically-weighted combinations of a common family `W` expands as the bilinear form of
+the covariance matrix `Σᵢⱼ = cov[Wᵢ, Wⱼ]`:
+
+    cov[∑ᵢ aᵢ·Wᵢ, ∑ⱼ bⱼ·Wⱼ] = ∑ᵢ∑ⱼ aᵢ·bⱼ·cov[Wᵢ, Wⱼ]  (= aᵀΣb).
+
+The polarised / two-vector companion of the diagonal Bienaymé identity `variance_smul_sum'`
+(recovered at `b = a`): Mathlib's `covariance_sum_sum'` distributes the covariance over both
+finite sums, and `covariance_smul_left`/`covariance_smul_right` pull out the scalar gains. -/
+theorem covariance_smul_sum' [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (a b : ι → ℝ) (hW : ∀ i ∈ s, MemLp (W i) 2 μ) :
+    cov[∑ i ∈ s, a i • W i, ∑ j ∈ s, b j • W j; μ]
+      = ∑ i ∈ s, ∑ j ∈ s, a i * b j * cov[W i, W j; μ] := by
+  have hVa : ∀ i ∈ s, MemLp (a i • W i) 2 μ := fun i hi => (hW i hi).const_smul (a i)
+  have hVb : ∀ i ∈ s, MemLp (b i • W i) 2 μ := fun i hi => (hW i hi).const_smul (b i)
+  rw [covariance_sum_sum' hVa hVb]
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [covariance_smul_left, covariance_smul_right]
+  ring
+
+/-- **Correlated-noise generalized Cauchy–Schwarz (matrix MRC bound).**  For an arbitrary noise
+covariance matrix `Σᵢⱼ = cov[Wᵢ, Wⱼ]` and any two gain vectors `a, b`, the bilinear form is
+bounded by the geometric mean of the two quadratic forms:
+
+    (∑ᵢ∑ⱼ aᵢ·bⱼ·cov[Wᵢ, Wⱼ])²  ≤  (∑ᵢ∑ⱼ aᵢ·aⱼ·cov[Wᵢ, Wⱼ]) · (∑ᵢ∑ⱼ bᵢ·bⱼ·cov[Wᵢ, Wⱼ]),
+
+i.e. `(aᵀΣb)² ≤ (aᵀΣa)(bᵀΣb)`.  This is the correlated-noise generalisation of the diagonal
+combining bound `mrc_signal_sq_le` (where `Σ` is diagonal and the forms collapse to
+`∑ aᵢbᵢvᵢ`, `∑ aᵢ²vᵢ`, `∑ bᵢ²vᵢ`).  The proof is inverse/square-root free: the two combiners
+`X = ∑ᵢ aᵢ·Wᵢ`, `Y = ∑ⱼ bⱼ·Wⱼ` are scalar random variables, so this is exactly the scalar
+covariance Cauchy–Schwarz `covariance_sq_le_variance_mul_variance` with the covariance and
+variances expanded by `covariance_smul_sum'` and `variance_smul_sum'`. -/
+theorem covariance_quadratic_form_cauchy_schwarz [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (a b : ι → ℝ) (hW : ∀ i ∈ s, MemLp (W i) 2 μ) :
+    (∑ i ∈ s, ∑ j ∈ s, a i * b j * cov[W i, W j; μ]) ^ 2
+      ≤ (∑ i ∈ s, ∑ j ∈ s, a i * a j * cov[W i, W j; μ])
+        * (∑ i ∈ s, ∑ j ∈ s, b i * b j * cov[W i, W j; μ]) := by
+  have hVa : MemLp (∑ i ∈ s, a i • W i) 2 μ :=
+    memLp_finset_sum' s (fun i hi => (hW i hi).const_smul (a i))
+  have hVb : MemLp (∑ i ∈ s, b i • W i) 2 μ :=
+    memLp_finset_sum' s (fun i hi => (hW i hi).const_smul (b i))
+  have h := covariance_sq_le_variance_mul_variance hVa hVb
+  rwa [covariance_smul_sum' a b hW, variance_smul_sum' a hW, variance_smul_sum' b hW] at h
+
+/-- **Correlated-noise MRC output-SNR bound.**  For any combiner `a` with strictly positive
+output power `aᵀΣa > 0`, the output SNR — the ratio of the squared matched signal
+`(∑ᵢ∑ⱼ aᵢ·bⱼ·cov[Wᵢ, Wⱼ])² = (aᵀΣb)²` to the output power `aᵀΣa` — is bounded by the matched
+power `bᵀΣb`:
+
+    (aᵀΣb)² / (aᵀΣa)  ≤  bᵀΣb.
+
+This is the correlated-noise generalisation of `mrc_snr_le`: dividing the matrix Cauchy–Schwarz
+`covariance_quadratic_form_cauchy_schwarz` by the (positive) output power identifies `bᵀΣb` as
+a uniform upper bound on the attainable SNR over all combiners `a`.  With the matched vector
+`s = Σb`, `bᵀΣb = sᵀΣ⁻¹s`, recovering the classical optimum `SNR ≤ sᵀΣ⁻¹s`. -/
+theorem mrc_correlated_snr_le [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (a b : ι → ℝ) (hW : ∀ i ∈ s, MemLp (W i) 2 μ)
+    (hpos : 0 < ∑ i ∈ s, ∑ j ∈ s, a i * a j * cov[W i, W j; μ]) :
+    (∑ i ∈ s, ∑ j ∈ s, a i * b j * cov[W i, W j; μ]) ^ 2
+        / (∑ i ∈ s, ∑ j ∈ s, a i * a j * cov[W i, W j; μ])
+      ≤ ∑ i ∈ s, ∑ j ∈ s, b i * b j * cov[W i, W j; μ] := by
+  rw [div_le_iff₀ hpos, mul_comm]
+  exact covariance_quadratic_form_cauchy_schwarz a b hW
+
+/-- **Matched combiner attains the correlated-noise SNR optimum (sharpness).**  Taking the
+combiner equal to the matched vector `a = b`, the output SNR of `mrc_correlated_snr_le` is met
+with equality:
+
+    (bᵀΣb)² / (bᵀΣb)  =  bᵀΣb.
+
+So the upper bound `bᵀΣb` in `mrc_correlated_snr_le` is not merely valid but *sharp* — it is
+achieved by the matched combiner, exactly as in the uncorrelated case `mrc_snr_matched`.  Hence
+`bᵀΣb` is the true maximal attainable output SNR over all combiners with positive output
+power. -/
+theorem mrc_correlated_snr_matched [IsFiniteMeasure μ] {ι : Type*}
+    {W : ι → Ω → ℝ} {s : Finset ι} (b : ι → ℝ)
+    (hpos : 0 < ∑ i ∈ s, ∑ j ∈ s, b i * b j * cov[W i, W j; μ]) :
+    (∑ i ∈ s, ∑ j ∈ s, b i * b j * cov[W i, W j; μ]) ^ 2
+        / (∑ i ∈ s, ∑ j ∈ s, b i * b j * cov[W i, W j; μ])
+      = ∑ i ∈ s, ∑ j ∈ s, b i * b j * cov[W i, W j; μ] := by
+  rw [sq, mul_div_assoc, div_self (ne_of_gt hpos), mul_one]
+
 end ShannonAWGNMultiSymbolPower

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-02-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0/0): MRC bound equality case now sharp — mrc_signal_sq_eq_iff proves the Cauchy–Schwarz optimum is attained IFF gains lie on the matched ray aᵢ∝sigᵢ/vᵢ, via a self-contained Lagrange/Binet–Cauchy identity and the general finite-sum CS equality condition. Identifies the max-SNR set as a 1-dim ray (mrc_matched_ray_eq), completing the achievability picture beyond the single matched point. Correlated-noise (aᵀΣa) generalization remains the only genuinely open direction.",
+    "progressSummary": "PROGRESS (VERIFIED 0/0, PR #36590): correlated-noise MRC optimum resolved. Matrix Cauchy-Schwarz (aTSigma b)^2 <= (aTSigma a)(bTSigma b) with SNR bound bTSigma b attained at matched combiner a=b -- the previously-open full-covariance generalization of the diagonal MRC bound. Inverse-free (combiners are scalar RVs). Only open follow-up: the equality-iff-affine-dependent (matched-ray) characterization.",
     "builtItems": [
       "variance_sum_of_pairwise_uncorrelated (ShannonChannelCodingAWGNOQ02OQ02.lean:131): Var[∑ i∈s, Wi] = ∑ Var[Wi] from Set.Pairwise cov=0 + MemLp; [IsFiniteMeasure].",
       "variance_sum_of_pairwise_indep (:150): independence ⟹ uncorrelated ⟹ identity, via IndepFun.covariance_eq_zero — shows the sharp version subsumes IndepFun.variance_sum.",
@@ -72,7 +72,11 @@
       "lagrange_sum_identity (ShannonChannelCodingAWGNOQ02OQ02.lean): ∑ᵢ∑ⱼ(fᵢgⱼ−fⱼgᵢ)² = 2·((∑fᵢ²)(∑gⱼ²)−(∑fᵢgᵢ)²) via Finset.sum_mul_sum + sum_comm",
       "cauchy_schwarz_eq_iff (same file): (∑fᵢgᵢ)²=(∑fᵢ²)(∑gⱼ²) ↔ ∀i,j fᵢgⱼ=fⱼgᵢ, from Lagrange gap = sum of squares (sum_eq_zero_iff_of_nonneg + sq_eq_zero_iff)",
       "mrc_signal_sq_eq_iff (same file): sharp MRC equality characterization, matched ray aᵢvᵢsigⱼ=aⱼvⱼsigᵢ, via CS split aᵢsigᵢ=(aᵢ√vᵢ)(sigᵢ/√vᵢ) then div_eq_div_iff + linear_combination to clear √v",
-      "mrc_matched_ray_eq (same file): every aᵢ=c·sigᵢ/vᵢ attains equality (scale-invariance of the optimum), generalizing mrc_snr_matched from c=1 to whole ray"
+      "mrc_matched_ray_eq (same file): every aᵢ=c·sigᵢ/vᵢ attains equality (scale-invariance of the optimum), generalizing mrc_snr_matched from c=1 to whole ray",
+      "covariance_smul_sum: cov[Sum a_i W_i, Sum b_j W_j] = Sum_ij a_i b_j cov[W_i,W_j] (aTSigma b) in ShannonChannelCodingAWGNOQ02OQ02.lean",
+      "covariance_quadratic_form_cauchy_schwarz: (aTSigma b)^2 <= (aTSigma a)(bTSigma b), correlated generalization of mrc_signal_sq_le",
+      "mrc_correlated_snr_le: (aTSigma b)^2/(aTSigma a) <= bTSigma b (SNR bound)",
+      "mrc_correlated_snr_matched: a=b attains bTSigma b (sharpness). VERIFIED 0/0, PR #36590"
     ],
     "insights": [
       "Bienaymé variance-of-a-sum needs only PAIRWISE UNCORRELATEDNESS (cov[Wi,Wj]=0 for i≠j), not pairwise independence: the off-diagonal covariances of Var[∑Wi]=∑i∑j cov[Wi,Wj] (Mathlib variance_sum´) are exactly what must vanish. Independence is strictly stronger (there exist uncorrelated dependent variables).",
@@ -94,7 +98,8 @@
       "Weighted combining lifts the whole Bienaymé stack by bilinearity: covariance_smul_left/right push each aᵢ,aⱼ out of cov[aᵢWᵢ,aⱼWⱼ]=aᵢaⱼcov, and variance_smul gives the diagonal Var[aᵢWᵢ]=aᵢ²Var[Wᵢ]; no new analysis, just scalar-out rewrites — working in the a•W (smul) form (not fun ω=>a*W ω) aligns directly with Mathlib covariance_smul_*/variance_smul/MemLp.const_smul.",
       "MRC (maximal-ratio-combining) optimality is a direct Cauchy-Schwarz consequence of the weighted power law: splitting aᵢsᵢ=(aᵢ√vᵢ)(sᵢ/√vᵢ) and applying Finset.sum_mul_sq_le_sq_mul_sq gives (∑aᵢsᵢ)²≤(∑aᵢ²vᵢ)(∑sᵢ²/vᵢ); the noise-power factor ∑aᵢ²vᵢ IS the output variance Var[∑aᵢNᵢ] from variance_smul_sum_of_pairwise_uncorrelated, so combiner optimality rests on the Bienaymé structure, not a fresh hypothesis.",
       "The maximum output SNR of a linear combiner over an uncorrelated AWGN branch block equals the sum of per-branch SNRs ∑sᵢ²/vᵢ, attained exactly at matched weights aᵢ=sᵢ/vᵢ (both combined signal ∑(sᵢ/vᵢ)sᵢ and noise power ∑(sᵢ/vᵢ)²vᵢ collapse to S=∑sᵢ²/vᵢ, so SNR=S²/S=S) — the achievability half making mrc_snr_le sharp.",
-      "MRC bound equality is a Cauchy–Schwarz equality case: attained IFF gains are proportional to the matched vector sigᵢ/vᵢ (cross-multiplied aᵢvᵢsigⱼ = aⱼvⱼsigᵢ). The optimum is a full 1-dim RAY, not the isolated point aᵢ=sigᵢ/vᵢ — mrc_snr_matched was only the c=1 slice."
+      "MRC bound equality is a Cauchy–Schwarz equality case: attained IFF gains are proportional to the matched vector sigᵢ/vᵢ (cross-multiplied aᵢvᵢsigⱼ = aⱼvⱼsigᵢ). The optimum is a full 1-dim RAY, not the isolated point aᵢ=sigᵢ/vᵢ — mrc_snr_matched was only the c=1 slice.",
+      "Correlated-noise MRC optimum is inverse/square-root free: the two combiners Sum a_i W_i and Sum b_j W_j are scalar random variables, so the matrix Cauchy-Schwarz (a^T Sigma b)^2 <= (a^T Sigma a)(b^T Sigma b) is exactly the scalar covariance CS (covariance_sq_le_variance_mul_variance) after bilinear expansion via covariance_sum_sum and variance_smul_sum. No whitening / Sigma^{-1/2} needed."
     ],
     "mathlibGaps": [
       "Mathlib has no pairwise-uncorrelated variance-sum lemma (only variance_sum´ double-sum form and IndepFun.variance_sum). Candidate upstream contribution: variance_sum under Set.Pairwise (cov=0).",
@@ -118,7 +123,8 @@
       "MRC equality condition in variance form: (∑aᵢsigᵢ)²=Var[∑aᵢ•Nᵢ]·(∑sigᵢ²/Var[Nᵢ]) iff a is proportional to the matched vector sigᵢ/Var[Nᵢ] — the Cauchy-Schwarz equality case (vectors aᵢ√vᵢ ∥ sigᵢ/√vᵢ).",
       "Correlated-noise MRC: replace diagonal ∑aᵢ²vᵢ by the full quadratic form aᵀΣa (Σ=covariance matrix); optimum SNR = sᵀΣ⁻¹s at a=Σ⁻¹s — needs a PD-matrix Cauchy-Schwarz / whitening argument, a genuine generalisation beyond the uncorrelated diagonal case.",
       "MRC equality in variance/measure-theoretic form: lift mrc_signal_sq_eq_iff so vᵢ = Var[Nᵢ] and state the equality condition on the actual noise variances (companion to mrc_output_signal_sq_le_variance_mul).",
-      "Correlated-noise MRC (still open, harder): replace diagonal ∑aᵢ²vᵢ by full quadratic form aᵀΣa; optimum SNR = sᵀΣ⁻¹s at a=Σ⁻¹s — needs PD-matrix Cauchy–Schwarz / whitening, a genuine generalization beyond the diagonal case."
+      "Correlated-noise MRC (still open, harder): replace diagonal ∑aᵢ²vᵢ by full quadratic form aᵀΣa; optimum SNR = sᵀΣ⁻¹s at a=Σ⁻¹s — needs PD-matrix Cauchy–Schwarz / whitening, a genuine generalization beyond the diagonal case.",
+      "Correlated-noise MRC optimum now DONE (matrix CS, PR #36590). Remaining follow-up: equality/attainment characterization iff combiners are affinely dependent (a proportional to b as random variables), via the abs_correlation_eq_one_iff_affine criterion already referenced in-file -- the correlated analog of mrc_signal_sq_eq_iff (matched ray)."
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-awgn-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Resolves the stated open direction of **shannon-channel-coding-awgn-oq-02-oq-02**: the **correlated-noise** MRC output-SNR optimum, where the noise covariance is a full matrix Σ (not diagonal). The existing gallery entry handled only the uncorrelated/diagonal case (`mrc_signal_sq_le`, `mrc_signal_sq_eq_iff`, `mrc_snr_matched`) plus the output-power identity `awgn_weighted_power_eq_covariance_quadratic_form` (output power = aᵀΣa). This PR supplies the missing optimization.

## Key idea (inverse/square-root free)

The classical route uses matrix whitening (Σ^{-1/2}), which is heavy in Lean. The observation that makes it session-sized: the two combiners `∑ᵢ aᵢWᵢ` and `∑ⱼ bⱼWⱼ` are *themselves scalar random variables*, so the entire matrix Cauchy–Schwarz reduces to the **scalar** covariance Cauchy–Schwarz (`covariance_sq_le_variance_mul_variance`, already in the file) after bilinearly expanding the forms via Mathlib's `covariance_sum_sum'` and the file's `variance_smul_sum'`. No matrix inverse or square root appears.

## New theorems (all VERIFIED, 0 sorry, 0 new axioms)

- `covariance_smul_sum'` — bilinear expansion `cov[∑aᵢWᵢ, ∑bⱼWⱼ] = ∑∑ aᵢbⱼ cov[Wᵢ,Wⱼ]` (= aᵀΣb); the two-vector companion of `variance_smul_sum'`.
- `covariance_quadratic_form_cauchy_schwarz` — **correlated generalized Cauchy–Schwarz**: `(aᵀΣb)² ≤ (aᵀΣa)(bᵀΣb)`.
- `mrc_correlated_snr_le` — output-SNR bound `(aᵀΣb)² / (aᵀΣa) ≤ bᵀΣb` (matched power = optimum sᵀΣ⁻¹s at s = Σb).
- `mrc_correlated_snr_matched` — the matched combiner `a = b` attains `bᵀΣb` exactly, so the bound is **sharp**.

## Verification

`./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingAWGNOQ02OQ02` → **Build succeeded** (elaboration clean; required a couple of retries past a transient dependency-olean-corruption / SIGSEGV-at-write under fleet memory pressure — not a code issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)