### PR TITLE
Research: erdos-1138-oq-03-oq-01 - abstract sublinearity engine (source exponent parametric)

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -183,4 +183,34 @@ theorem bhp_gap_le_eps_effective (ε : ℝ) (x : ℕ)
   have hfinal : (maxPrimeGap x : ℝ) / x ≤ ε := le_trans (gap_div_le_rpow_neg x hx25) hneg
   rwa [div_le_iff₀ hx_pos] at hfinal
 
+/-- **Abstract sublinearity engine.** The specific Baker–Harman–Pintz exponent `0.525` plays no
+role in the sublinearity conclusion: *any* eventual power envelope `maxPrimeGap x ≤ x^θ` with a
+sub-linear exponent `θ < 1` already forces the normalised gap `maxPrimeGap x / x → 0`. The envelope
+`x^θ / x = x^(θ - 1) = x^(-(1 - θ))` vanishes because `1 - θ > 0`.
+
+This isolates the mathematical content of `bhp_implies_gap_littleo` — which is the instance
+`θ = 0.525` — from the arithmetic input. Any future strengthening of the BHP bound (to `0.5 + ε`,
+or a conjectural `θ → 1/2`) plugs straight into this engine without re-running the real-analysis
+squeeze. The hypothesis is stated in `atTop`-eventual form, so it also subsumes bounds that hold
+only past an unspecified threshold. -/
+theorem gap_littleo_of_rpow_bound {θ : ℝ} (hθ : θ < 1)
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
+    Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / x) atTop (𝓝 0) := by
+  have hpos : 0 < 1 - θ := by linarith
+  -- Envelope: x^(θ - 1) = x^(-(1 - θ)) → 0 (compose the ℝ-limit with the ℕ-cast).
+  have h_env : Tendsto (fun x : ℕ => (x : ℝ) ^ (-(1 - θ))) atTop (𝓝 0) :=
+    (tendsto_rpow_neg_atTop hpos).comp tendsto_natCast_atTop_atTop
+  have h_lo : ∀ x : ℕ, 0 ≤ (maxPrimeGap x : ℝ) / x := fun x =>
+    div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+  -- Upper bound: divide the envelope hypothesis by `x` (valid once `x ≥ 1`).
+  have h_hi : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) / x ≤ (x : ℝ) ^ (-(1 - θ)) := by
+    filter_upwards [H, eventually_ge_atTop 1] with x hx hx1
+    have hx_pos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast (lt_of_lt_of_le Nat.zero_lt_one hx1)
+    have hdiv : (x : ℝ) ^ θ / x = (x : ℝ) ^ (-(1 - θ)) := by
+      rw [show (-(1 - θ)) = θ - 1 by ring, Real.rpow_sub hx_pos, Real.rpow_one]
+    calc (maxPrimeGap x : ℝ) / x
+        ≤ (x : ℝ) ^ θ / x := by gcongr <;> exact hx
+      _ = (x : ℝ) ^ (-(1 - θ)) := hdiv
+  exact squeeze_zero' (Eventually.of_forall h_lo) h_hi h_env
+
 end Erdos1138OQ03

--- a/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
+++ b/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
@@ -79,3 +79,29 @@ meta synced 5→8 thm / 131→186 lines at both `.meta.*` and `.leanFile.*`.
 
 NEXT: entry is saturated for elementary work; only remaining lever is proving/replacing the
 `baker_harman_pintz` axiom itself (deep analytic number theory — out of session scope).
+
+## Session 2026-07-09 (researcher-7): abstract sublinearity engine (source-exponent parametric)
+
+The main target `bhp_implies_gap_littleo` and its o/O/ε companions were already complete
+(8 thm). The one genuine structural gap: every result bootstrapped from the *fixed* exponent
+`0.525`. Added the engine that isolates the mechanism from the constant:
+
+```lean
+theorem gap_littleo_of_rpow_bound {θ : ℝ} (hθ : θ < 1)
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
+    Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / x) atTop (𝓝 0)
+```
+
+Any eventual sub-linear power envelope (`θ < 1`) forces `gap/x → 0`; `bhp_implies_gap_littleo`
+is the `θ = 0.525` instance. Future BHP tightenings (0.5+ε, conjectural θ→1/2) plug in without
+re-running the squeeze. Proof mirrors `bhp_implies_gap_littleo`: envelope `x^(θ-1)=x^(-(1-θ))→0`
+via `tendsto_rpow_neg_atTop (1-θ>0) ∘ tendsto_natCast_atTop_atTop`, `squeeze_zero'` with the
+`filter_upwards [H, eventually_ge_atTop 1]` upper bound (`gcongr <;> exact hx` for the div step,
+matching the sibling `gap_div_le_rpow_neg` gcongr pattern). Only assumption remains the deep
+parent `axiom baker_harman_pintz` (BHP theorem — genuinely unprovable from Mathlib).
+
+### ⚠️ BUILD STATUS: UNVERIFIED (fleet SIGBUS storm, 2026-07-09)
+Elaboration CLEAN across 6 builds (mem 6–16 GB) — zero Lean type-error diagnostics; olean-WRITE
+crashes exit 135 (SIGBUS), plus intermittent transient dep-cache corruptions on the `import`
+line (`Piecewise.olean` / different file each run = fleet race, not this file). Deployer should
+re-attempt a green build in a quiet window (`--repair-cache` + low `LEAN_MEMORY_LIMIT`).

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -140,9 +140,9 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 186,
+    "lineCount": 216,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/Erdos1138OQ03OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1138-oq-03-oq-01.json
+++ b/src/data/research/problems/erdos-1138-oq-03-oq-01.json
@@ -32,16 +32,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: bhp_implies_gap_littleo proved (maxPrimeGap x / x -> 0) from the inherited baker_harman_pintz axiom; unconditional twin of the parent conditional cramer_implies_gap_sublinear. 0 sorries, 0 new axioms. Gallery entry + PR #35062.",
+    "progressSummary": "COMPLETE + generalized: bhp_implies_gap_littleo (θ=0.525) now subsumed by the abstract engine gap_littleo_of_rpow_bound (any θ<1 power envelope ⟹ sublinear). Only assumption remains the deep parent axiom baker_harman_pintz (BHP theorem, unprovable from Mathlib). 0 sorries, 0 new axioms.",
     "builtItems": [
       "gap_div_le_rpow_neg (Erdos1138OQ03OQ01.lean:37): maxPrimeGap x / x <= x^(-0.475) for x >= 25",
       "bhp_implies_gap_littleo (Erdos1138OQ03OQ01.lean:57): Tendsto (maxPrimeGap x / x) atTop (nhds 0)",
-      "bhp_gap_eventually_le_eps (Erdos1138OQ03OQ01.lean:74): forall eps>0, eventually maxPrimeGap x <= eps*x"
+      "bhp_gap_eventually_le_eps (Erdos1138OQ03OQ01.lean:74): forall eps>0, eventually maxPrimeGap x <= eps*x",
+      "Erdos1138OQ03OQ01.lean:186 gap_littleo_of_rpow_bound (source-exponent-parametric sublinearity engine). Elaboration-clean; olean-write blocked by fleet SIGBUS storm."
     ],
     "insights": [
       "BHP exponent 0.525 < 1: one division by x yields a negative power x^(-0.475) that vanishes at infinity - no finer analysis needed",
       "x^0.525 / x must be rewritten via Real.rpow_sub on x^(0.525-1); rewriting x as x^1 via rpow_one hits the numerator base and fails",
-      "tendsto_rpow_neg_atTop is root-namespace (not Real.); the earlier survey mis-quoted it"
+      "tendsto_rpow_neg_atTop is root-namespace (not Real.); the earlier survey mis-quoted it",
+      "Abstract sublinearity engine: the specific BHP exponent 0.525 is inessential — ANY eventual power envelope maxPrimeGap x ≤ x^θ with θ<1 forces maxPrimeGap x / x → 0 (envelope x^θ/x = x^(θ-1) = x^(-(1-θ)) → 0 since 1-θ>0). gap_littleo_of_rpow_bound {θ} (hθ:θ<1) (H: ∀ᶠ x, gap ≤ x^θ). bhp_implies_gap_littleo is the θ=0.525 instance; future BHP tightenings (0.5+ε) plug in with no re-proof."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Research session for **erdos-1138-oq-03-oq-01** (BHP ⟹ prime gaps sublinear). The main target
`bhp_implies_gap_littleo` and its o/O/ε companions were already complete (8 theorems). The one
genuine structural gap: every result bootstrapped from the *fixed* Baker–Harman–Pintz exponent
`0.525`. This adds the engine that isolates the mechanism from the constant.

## Progress
One new theorem (0 sorries, 0 new axioms — only the parent `axiom baker_harman_pintz`):

```lean
theorem gap_littleo_of_rpow_bound {θ : ℝ} (hθ : θ < 1)
    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
    Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / x) atTop (𝓝 0)
```

*Any* eventual sub-linear power envelope (`θ < 1`) already forces `maxPrimeGap x / x → 0` — the
envelope `x^θ / x = x^(θ-1) = x^(-(1-θ))` vanishes because `1 - θ > 0`. `bhp_implies_gap_littleo`
is exactly the `θ = 0.525` instance; any future strengthening of the BHP bound (to `0.5 + ε`, or a
conjectural `θ → 1/2`) plugs straight into this engine with no re-proof. The hypothesis is in
`atTop`-eventual form, so it also covers bounds holding only past an unspecified threshold.

Files: `proofs/Proofs/Erdos1138OQ03OQ01.lean` (186→216 lines, 8→9 thm), meta.json, knowledge.

## Findings
- The proof mirrors the existing `bhp_implies_gap_littleo` squeeze; the `gcongr <;> exact hx`
  division step matches the sibling `gap_div_le_rpow_neg` gcongr pattern already in the file.
- The single remaining assumption is the deep parent `axiom baker_harman_pintz` (the BHP theorem
  `p_{n+1} - p_n ≪ p_n^0.525`) — a genuine analytic-number-theory result, not provable from Mathlib.

## Status
**Outcome**: progress (structural generalization; one build caveat)
**Build**: ⚠️ UNVERIFIED — elaboration is CLEAN across 6 builds (mem 6–16 GB), zero Lean type-error
diagnostics; the olean **write** crashes with SIGBUS-135 (persistent fleet memory-pressure storm),
plus intermittent transient dep-cache corruptions on the `import Mathlib` line (a different file
each run = fleet race, not this file). **Deployer should re-attempt a green build in a quiet
window** (`--repair-cache` + low `LEAN_MEMORY_LIMIT`).
**Next Steps**: none tractable — the file's theory is complete and the sole axiom is the deep BHP
theorem. (Slug at OQ-depth 2; no cosmetic follow-ups proposed.)

🤖 Generated by researcher-7