### PR TITLE
Fix broken gallery metadata: 4 dead cross-references + 10 drifted section ranges

### DIFF
--- a/src/data/proofs/abundant-number-oq-01-oq-02/meta.json
+++ b/src/data/proofs/abundant-number-oq-01-oq-02/meta.json
@@ -124,11 +124,6 @@
       "targetId": "abundant-number-oq-01-oq-04",
       "relationship": "related",
       "description": "Sibling OQ of the same abundant-number family; both extend the parent's abundance analysis with further extremal or structural results."
-    },
-    {
-      "targetId": "abundant-number",
-      "relationship": "depends-on",
-      "description": "The root abundance predicate Nat.Abundant whose smallest odd instance is the object of this entry."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/beta-diag-effective-rate/meta.json
+++ b/src/data/proofs/beta-diag-effective-rate/meta.json
@@ -129,7 +129,7 @@
       "description": "Parent entry: proves the leading-order equivalence $B(n+1,n+1)\\sim\\sqrt{\\pi n}/((2n+1)4^n)$ as an `IsEquivalent`. This entry answers its first open question by supplying explicit two-sided constants valid for all $n\\ge1$."
     },
     {
-      "targetId": "beta-central-binomial",
+      "targetId": "beta-integral-recurrence-oq-01-oq-01",
       "relationship": "related",
       "description": "Root entry establishing the closed form $B(n+1,n+1)=1/((2n+1)\\binom{2n}{n})$ that both the asymptotic and this effective rate build upon."
     },

--- a/src/data/proofs/erdos-1017-oq-05/meta.json
+++ b/src/data/proofs/erdos-1017-oq-05/meta.json
@@ -109,9 +109,9 @@
   },
   "crossReferences": [
     {
-      "targetId": "erdos-1017-oq-04",
+      "targetId": "erdos-1017",
       "relationship": "parent",
-      "description": "The graph case (k=2): defines EdgeCliqueCover / EdgeCliquePartition on a SimpleGraph and proves cc(G) ≤ cp(G) with the same partition ⟹ cover structure, the trivial partition, the edge_unique_clique keystone, and positivity. This entry lifts that whole framework to k-uniform hypergraphs, showing the inequality is uniform in k."
+      "description": "Root Erdős Problem #1017 (clique partition of graphs: f(n,k) = min cliques to partition a graph with n vertices and k edges, the Erdős–Goodman–Pósa bound f(n,k) ≤ ⌊n²/4⌋). The k = 2 cover-vs-partition inequality cc(G) ≤ cp(G) is the graph case; this entry lifts that always-true direction to k-uniform hypergraphs (ccₖ(H) ≤ cpₖ(H)), showing the inequality is uniform in the uniformity k."
     }
   ]
 }

--- a/src/data/proofs/inverse-galois-oq-04/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04/meta.json
@@ -124,11 +124,6 @@
       "targetId": "inverse-galois-oq-04-oq-01",
       "relationship": "related",
       "description": "Child entry that formalizes step (1) — the Kummer\u2013Dedekind Step-1 brick showing the prime matching an irreducible factor of a polynomial mod p has that factor's degree as its inertia degree — directly answering this entry's first open question."
-    },
-    {
-      "targetId": "inverse-galois-oq-04-oq-02",
-      "relationship": "related",
-      "description": "Child entry supplying the concrete Kummer\u2013Dedekind input for the A\u2085 quintic at p = 7 (the irreducible cubic factor of q mod 7 that this entry's reduction form consumes), advancing the composition toward discharging three_dvd_gal_card."
     }
   ],
   "references": [


### PR DESCRIPTION
Two classes of **verifiable structural defects** found by pool-wide scans of all 4794 gallery entries — the kind the heuristic quality scorer (top entries pinned at quality 95) cannot detect.

## 1. Dead cross-references (4 → 0)

`crossReferences.targetId`s pointing at proof entries that don't exist:

| Entry | Dead target | Fix |
|-------|-------------|-----|
| `abundant-number-oq-01-oq-02` | `abundant-number` | Removed (redundant; root already linked as `abundant-number-oq-01`). |
| `beta-diag-effective-rate` | `beta-central-binomial` | Repointed to `beta-integral-recurrence-oq-01-oq-01` (the entry whose title *is* the closed form B(n+1,n+1) = 1/((2n+1)·C(2n,n))). |
| `erdos-1017-oq-05` | `erdos-1017-oq-04` | Repointed to root `erdos-1017` (oq-04 never existed; this was the entry's only crossref). |
| `inverse-galois-oq-04` | `inverse-galois-oq-04-oq-02` | Removed (planned child never created; real child `oq-04-oq-01` already linked). |

## 2. Drifted section line ranges (10 entries)

`meta.lineCount` is accurate everywhere; the `sections` arrays had stale `startLine`/`endLine` pointing past the true end of the referenced Lean file. Every fix verified against the actual Lean source (section-header comments / EOF):

- **Tail-clamp** (last section a few lines past EOF): abel-ruffini-oq-04-oq-07, cayley-hamilton-…-oq-02, erdos-11-oq-03, erdos-143, kroneckers-jugendtraum.
- **Remap** to real section-header markers: sqrt2-plus-sqrt3-oq-03 (Part III at L309), hilbert-10-oq-04-oq-03-oq-01 (Sanity-checks at L121), knights-tour-oblique (Section 7 at L2238), erdos-1002 (dropped phantom "summary" section past a 183-line file).
- **Rebuild**: cauchy-schwarz-…-incomplete-01 — 9 sections describing the pre-split ~952-line monolith replaced with 2 matching the actual 47-line assembly stub (step detail lives in the imported Loc/Norm/Infra companions).

### Deliberately left untouched (not defects / out of scope)
- **nth-root-irrational-oq-01-oq-01**: sections validly annotate its 4 `additionalFiles`; ranges match Real=113 / Cos=150 / CosRational=103 / Degree=270 exactly. A naive "endLine > primary lineCount" scan false-positives on multi-file entries.
- **simson-line-theorem-oq-01**: deeper meta/source mismatch — overview/sections describe `simson_area_identity`/`simson_converse`/nine-point decls that live in the *root* `SimsonLineTheorem.lean`, not this OQ01 file. Flagged for an audit/mechanic pass rather than a range tweak.

## Verification
- All edited `meta.json` re-parse as valid JSON.
- Dead-crossref scan: **4 → 0** across all 4794 entries.
- Section-range scan: the only residual flags are the nth-root false positive and the deferred simson mismatch.
- Gallery data pipeline (`pnpm build`): enrichment linking + search-index + loading-facts all pass. Size guardrails: all entries under caps (net reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)