### PR TITLE
research(algebraic-numbers-countable-oq-07): Hausdorff dimension zero sharpens Lebesgue-null

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -2,6 +2,7 @@ import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
 import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 import Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms
+import Mathlib.Topology.MetricSpace.HausdorffDimension
 import Mathlib.Tactic
 import Proofs.AlgebraicNumbersCountable
 
@@ -201,5 +202,72 @@ theorem ae_transcendental_complex :
     ext z; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
   rw [Filter.eventually_iff, hset]
   exact compl_mem_ae_iff.mpr algebraic_complex_null
+
+-- ============================================================================
+-- § 6. Hausdorff dimension zero — a sharpening of Lebesgue-null
+-- ============================================================================
+
+/-!
+Lebesgue-null (`algebraic_reals_null`) is the order-`1` slice of a much stronger
+statement: the algebraic reals have **Hausdorff dimension zero**.  A countable set
+has Hausdorff dimension `0` (`Set.Countable.dimH_zero`), and dimension `0` forces
+*every* positive-order Hausdorff measure to vanish, not merely the order-`1`
+(Lebesgue) one.  So the algebraic reals are null for the entire one-parameter
+family of Hausdorff gauges `μH[d]`, `d > 0` — an infinitely stronger form of
+metric smallness than the single Lebesgue-null fact.
+
+A purely dimensional corollary also recovers the topological largeness of the
+transcendentals: since `dimH {algebraic} = 0 < finrank ℝ ℝ`, the complement is
+dense (`dense_compl_of_dimH_lt_finrank`) — the transcendentals are dense in `ℝ`
+(and, by the same argument with `finrank ℝ ℂ = 2`, in `ℂ`), obtained here from the
+dimension bound rather than from the Baire-category argument.
+-/
+
+/-- **The algebraic reals have Hausdorff dimension zero.**  Sharper than
+Lebesgue-null: a countable set has Hausdorff dimension `0` (`Set.Countable.dimH_zero`),
+and dimension `0` kills every positive-order Hausdorff measure at once. -/
+theorem algebraic_reals_dimH_zero :
+    dimH {x : ℝ | IsAlgebraic ℚ x} = 0 :=
+  (AlgebraicNumbersCountable.algebraic_reals_countable).dimH_zero
+
+/-- **Every positive-order Hausdorff measure of the algebraic reals vanishes.**
+For each `d > 0`, `μH[d] {algebraic} = 0`.  The order-`d = 1` case is exactly
+`algebraic_reals_null` (Lebesgue-null); dimension zero delivers the whole scale
+`d > 0`, so the algebraic reals are null for *every* Hausdorff gauge, not just
+Lebesgue measure. -/
+theorem algebraic_reals_hausdorffMeasure_zero {d : NNReal} (hd : 0 < d) :
+    μH[(d : ℝ)] {x : ℝ | IsAlgebraic ℚ x} = 0 :=
+  hausdorffMeasure_of_dimH_lt (by
+    rw [algebraic_reals_dimH_zero]; exact_mod_cast hd)
+
+/-- **The complex algebraic numbers have Hausdorff dimension zero.**  Same
+countable-set argument as on `ℝ`. -/
+theorem algebraic_complex_dimH_zero :
+    dimH {z : ℂ | IsAlgebraic ℚ z} = 0 :=
+  (AlgebraicNumbersCountable.algebraic_complex_countable).dimH_zero
+
+/-- **The transcendental reals are dense**, obtained from the dimensional bound:
+`dimH {algebraic} = 0 < 1 = finrank ℝ ℝ`, so the complement of the algebraic reals
+is dense (`dense_compl_of_dimH_lt_finrank`).  A dimension-theoretic route to the
+topological largeness of the transcendentals, independent of Baire category. -/
+theorem transcendental_reals_dense :
+    Dense {x : ℝ | Transcendental ℚ x} := by
+  have hcompl : {x : ℝ | Transcendental ℚ x} = {x : ℝ | IsAlgebraic ℚ x}ᶜ := by
+    ext x; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  rw [hcompl]
+  apply dense_compl_of_dimH_lt_finrank
+  rw [algebraic_reals_dimH_zero]
+  exact_mod_cast Module.finrank_pos
+
+/-- **The transcendental complex numbers are dense**, by the same dimensional
+argument with `finrank ℝ ℂ = 2 > 0 = dimH {algebraic}`. -/
+theorem transcendental_complex_dense :
+    Dense {z : ℂ | Transcendental ℚ z} := by
+  have hcompl : {z : ℂ | Transcendental ℚ z} = {z : ℂ | IsAlgebraic ℚ z}ᶜ := by
+    ext z; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  rw [hcompl]
+  apply dense_compl_of_dimH_lt_finrank
+  rw [algebraic_complex_dimH_zero]
+  exact_mod_cast Module.finrank_pos
 
 end AlgebraicRealsNull

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -20,8 +20,8 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 205,
-    "theoremCount": 11,
+    "lineCount": 273,
+    "theoremCount": 16,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",
     "mathlibDependencies": [
@@ -44,6 +44,11 @@
         "theorem": "compl_mem_ae_iff",
         "description": "A set is conull iff its complement is null; converts algebraic_reals_null into the almost-everywhere statement ae_transcendental.",
         "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      },
+      {
+        "theorem": "Set.Countable.dimH_zero",
+        "description": "A countable set has Hausdorff dimension zero; applied to the countable algebraic reals/complex algebraic numbers to strengthen Lebesgue-null to dimension zero (algebraic_reals_dimH_zero), whence every positive-order Hausdorff measure vanishes (hausdorffMeasure_of_dimH_lt) and the transcendentals are dense (dense_compl_of_dimH_lt_finrank).",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDimension"
       }
     ],
     "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. The core result `algebraic_reals_null` is a one-liner: the countability of the algebraic reals is imported from the parent `AlgebraicNumbersCountable.algebraic_reals_countable`, and `Set.Countable.measure_zero` (with Mathlib's atomless `Real.noAtoms_volume`) upgrades countable to null. The file's independent content is the measure-theoretic packaging (conull/ae/interval/existence corollaries) and the `NoAtoms (volume : Measure ℂ)` instance transported through `Complex.volume_preserving_equiv_real_prod`. `#print axioms` reports only propext, Classical.choice, Quot.sound — no `Lean.ofReduceBool`, no `sorryAx`.",
@@ -172,8 +177,8 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicRealsNull.lean",
-    "lineCount": 205,
-    "theoremCount": 11,
+    "lineCount": 273,
+    "theoremCount": 16,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0

--- a/src/data/research/problems/algebraic-numbers-countable-oq-07.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-07.json
@@ -37,29 +37,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Proved the algebraic reals (and complex algebraic numbers) have Lebesgue measure zero, supplying the measure pillar of the cardinality/category/measure smallness trichotomy. Dually, almost every real (and complex) number is transcendental, and any positive-measure set contains a transcendental. 11 theorems, 0 sorries, 0 axioms (only propext/Classical.choice/Quot.sound).",
+    "progressSummary": "COMPLETED + SHARPENED: the algebraic reals are Lebesgue-null (existing) and now shown to have Hausdorff DIMENSION zero — strictly stronger, killing every positive-order Hausdorff gauge μH[d] (Lebesgue-null = d=1 slice). Dimensional corollary yields density of the transcendentals in ℝ and ℂ (dimH 0 < finrank), a route independent of Baire category. 16 theorems, 0 axioms, 0 sorries (elaboration-clean; olean-write blocked by fleet SIGBUS-135).",
     "builtItems": [
       "algebraic_reals_null: volume {x : ℝ | IsAlgebraic ℚ x} = 0 in Proofs/AlgebraicRealsNull.lean",
       "ae_transcendental: almost every real is transcendental (∀ᵐ x ∂volume, Transcendental ℚ x)",
       "transcendental_full_on_interval: transcendentals carry the full measure ofReal (b − a) of any interval",
       "exists_transcendental_of_pos_measure: any positive-measure set contains a transcendental",
-      "NoAtoms (volume : Measure ℂ) + algebraic_complex_null: complex algebraic numbers are null"
+      "NoAtoms (volume : Measure ℂ) + algebraic_complex_null: complex algebraic numbers are null",
+      "AlgebraicRealsNull.lean §6 (researcher-2): algebraic_reals_dimH_zero (dimH{alg reals}=0 via Set.Countable.dimH_zero), algebraic_reals_hausdorffMeasure_zero (μH[d]{alg}=0 for d>0 via hausdorffMeasure_of_dimH_lt), algebraic_complex_dimH_zero, transcendental_reals_dense + transcendental_complex_dense (dense_compl_of_dimH_lt_finrank + Module.finrank_pos). File now 16 theorems, 0 axioms, 0 sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135."
     ],
     "insights": [
       "Countable ⟹ null requires the measure to be atomless; Lebesgue measure qualifies via Real.noAtoms_volume, so Set.Countable.measure_zero applies to the parent's countability theorem in one line.",
       "Transcendental ℚ x is definitionally ¬ IsAlgebraic ℚ x, so the transcendentals are the set-complement of the algebraic reals; conull and a.e. statements follow from compl_mem_ae_iff.",
       "The complex case needs NoAtoms (volume : Measure ℂ), which is not a single named instance; transport singletons through the measure-preserving ℂ ≃ᵐ ℝ × ℝ to the atomless planar measure (Measure.prod.instNoAtoms_fst).",
-      "measure_diff_null gives the interval full-measure result directly: Ioo a b ∩ {transcendental} = Ioo a b \\ {algebraic}, and removing the null algebraic set leaves the interval's measure unchanged."
+      "measure_diff_null gives the interval full-measure result directly: Ioo a b ∩ {transcendental} = Ioo a b \\ {algebraic}, and removing the null algebraic set leaves the interval's measure unchanged.",
+      "SHARPENING (researcher-2, 2026-07-09): the algebraic reals have Hausdorff DIMENSION zero, strictly stronger than Lebesgue-null. Since {x|IsAlgebraic ℚ x} is countable, Set.Countable.dimH_zero gives dimH=0; then hausdorffMeasure_of_dimH_lt kills EVERY positive-order Hausdorff measure μH[d] (d>0), of which Lebesgue-null (algebraic_reals_null) is only the d=1 slice. Dimensional corollary: dimH{alg}=0 < finrank ℝ ℝ=1 (and < finrank ℝ ℂ=2), so dense_compl_of_dimH_lt_finrank makes the transcendentals DENSE in ℝ and ℂ — a dimension-theoretic route to their topological largeness, independent of the Baire-category argument. Added algebraic_reals_dimH_zero, algebraic_reals_hausdorffMeasure_zero, algebraic_complex_dimH_zero, transcendental_reals_dense, transcendental_complex_dense to AlgebraicRealsNull.lean §6. Elaboration-clean [3073/3073] (olean-write SIGBUS-135)."
     ],
     "mathlibGaps": [
       "No single named NoAtoms instance for volume on ℂ; derived locally via the measure-preserving equivalence to ℝ × ℝ."
     ],
     "nextSteps": [
-      "Refine measure-zero to Hausdorff dimension zero for the algebraic reals.",
-      "Contrast with Liouville numbers (comeagre but null) to formalize independence of category and measure.",
-      "Generalize to ℝⁿ / ℂⁿ and to arbitrary atomless Borel probability measures."
+      "Contrast with Liouville numbers (comeagre but null) to formalize independence of category and measure — the algebraic reals are small in ALL of {cardinality, category, measure, dimension}, whereas Liouville numbers separate category (comeagre) from measure (null).",
+      "Generalize dimension-zero / measure-zero to ℝⁿ / arbitrary atomless Borel probability measures (the countable-set argument is dimension-agnostic).",
+      "Quantify the Hausdorff gauge boundary: is the algebraic reals' generalized Hausdorff measure with gauge h(t)=1/log(1/t) still zero? (finer than dimension)."
     ],
-    "markdown": "# Knowledge Base: algebraic-numbers-countable-oq-07\n\n## Result\n\nThe algebraic reals are Lebesgue-null, completing the cardinality/category/measure smallness trichotomy. Dually, almost every real (and complex) number is transcendental, and any positive-measure set contains a transcendental.\n\n## Key technique\n\nA countable set is null for any atomless measure (`Set.Countable.measure_zero` + `Real.noAtoms_volume`), so the parent's countability theorem upgrades to measure zero in one line. The complex case transports singletons through the measure-preserving `ℂ ≃ᵐ ℝ × ℝ`.\n"
+    "markdown": "# Knowledge Base: algebraic-numbers-countable-oq-07\n\n## Result\n\nThe algebraic reals are Lebesgue-null, completing the cardinality/category/measure smallness trichotomy. Dually, almost every real (and complex) number is transcendental, and any positive-measure set contains a transcendental.\n\n## Key technique\n\nA countable set is null for any atomless measure (`Set.Countable.measure_zero` + `Real.noAtoms_volume`), so the parent's countability theorem upgrades to measure zero in one line. The complex case transports singletons through the measure-preserving `ℂ ≃ᵐ ℝ × ℝ`.\n",
+    "score": 15
   },
   "leanFiles": [
     {


### PR DESCRIPTION
## Algebraic-numbers-countable OQ-07 — sharpening the measure pillar

The entry `AlgebraicRealsNull.lean` establishes the **measure** pillar of the
cardinality/category/measure smallness trichotomy: the algebraic reals are
Lebesgue-null. This PR sharpens that from a *single* measure to the *whole
one-parameter family* of Hausdorff gauges, and extracts a topological corollary.

### New results (§ 6, 0 axioms, 0 sorries)

- **`algebraic_reals_dimH_zero`** — `dimH {x | IsAlgebraic ℚ x} = 0`. A countable
  set has Hausdorff dimension zero (`Set.Countable.dimH_zero`).
- **`algebraic_reals_hausdorffMeasure_zero`** — for every `d > 0`,
  `μH[d] {algebraic} = 0`. Dimension zero kills *every* positive-order Hausdorff
  measure; the existing `algebraic_reals_null` (Lebesgue-null) is just the `d = 1`
  slice. So the algebraic reals are null for the entire scale of Hausdorff gauges,
  a strictly stronger metric-smallness statement.
- **`algebraic_complex_dimH_zero`** — the same for the complex algebraic numbers.
- **`transcendental_reals_dense`, `transcendental_complex_dense`** — since
  `dimH {algebraic} = 0 < finrank ℝ ℝ` (resp. `< finrank ℝ ℂ = 2`),
  `dense_compl_of_dimH_lt_finrank` gives that the transcendentals are dense in `ℝ`
  and `ℂ`. This recovers the topological largeness of the transcendentals from the
  **dimension** bound, independently of the Baire-category argument.

### Why this is a genuine strengthening

Lebesgue-null says the order-1 Hausdorff measure vanishes. Dimension zero says
*all* orders `d > 0` vanish simultaneously — an infinitely stronger form of metric
smallness — and additionally forces density of the complement via
`dense_compl_of_dimH_lt_finrank`. It slots directly under the existing
countable/meagre/null trichotomy as a fourth, sharpest, metric layer.

### Build status

The dependency `AlgebraicNumbersCountable` and this file both reach full
elaboration `[3073/3073]` with **zero type errors** (verified across multiple
attempts, 8.3s elaboration); the olean write then hit the persistent fleet
`SIGBUS` (exit code 135 — host memory pressure, not a math error). Marked
**elaboration-verified**. All new lemma references
(`Set.Countable.dimH_zero`, `hausdorffMeasure_of_dimH_lt`,
`dense_compl_of_dimH_lt_finrank`, `Module.finrank_pos`) are confirmed against
Mathlib v4.26.

Gallery `meta.json` counts synced (11 → 16 theorems, 205 → 273 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)