### PR TITLE
Research: tetrahedral-number-formula-oq-01 — convolution semigroup law for figurate kernels [VERIFIED]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -261,6 +261,26 @@ theorem iterSum_simplexNumber (a b n : ℕ) :
     funext m; rw [iterSum_one]
   rw [hfun, iterSum_add, iterSum_one]
 
+/-- **Convolution semigroup law for the figurate kernels.** Convolving with the
+`b`-dimensional simplex kernel and then the `a`-dimensional one is convolution with the
+`(a+b+1)`-dimensional kernel:
+
+`simplexConv a (simplexConv b f) = simplexConv (a + b + 1) f`.
+
+This is the semigroup law `iterSum_add` transported through the discrete Cauchy formula
+`iterSum_eq_simplexConv` (which identifies `simplexConv d = iterSum (d+1)`): composing the
+two convolutions is `iterSum (a+1) ∘ iterSum (b+1) = iterSum (a+b+2)`, and `a+b+2` is the
+`(d+1)` of `d = a+b+1`. Expanded, it is a Vandermonde-type identity for the figurate
+kernels — the discrete analogue of the fractional-integral composition
+`(x-·)^a/a! ∗ (x-·)^b/b! = (x-·)^{a+b+1}/(a+b+1)!` — the summation-side manifestation of
+`P_a ∗ P_b = P_{a+b+1}`. -/
+theorem simplexConv_comp (a b : ℕ) (f : ℕ → ℕ) (n : ℕ) :
+    simplexConv a (simplexConv b f) n = simplexConv (a + b + 1) f n := by
+  have hb : simplexConv b f = iterSum (b + 1) f := by
+    funext m; rw [iterSum_eq_simplexConv]
+  rw [← iterSum_eq_simplexConv, hb, iterSum_add,
+    show a + 1 + (b + 1) = (a + b + 1) + 1 from by ring, iterSum_eq_simplexConv]
+
 /-- **Counting face (stars and bars).** The `d`-dimensional simplex number counts
 the size-`d` multisets drawn from the `n+1` symbols `{0, 1, …, n}` — equivalently
 the weakly increasing `d`-tuples `0 ≤ i₁ ≤ ⋯ ≤ i_d ≤ n`:

--- a/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
@@ -15,6 +15,12 @@ the already-verified figurate theory (`iterSum_one`, `iterSum_eq_simplexConv`, c
 - `iterSum_simplexNumber` — **dimension-additivity of the ladder**: `iterSum a (P_b) n = P_{a+b}(n)`.
   Immediate from `iterSum_add` + `iterSum_one` (since `P_b` is itself `b`-fold summation of `1`);
   generalizes the headline `iterSum_one` (the `b = 0` case, `P_0 ≡ 1`).
+- `simplexConv_comp` (added after PR #36589 merged) — **convolution semigroup law** for the
+  figurate kernels: `simplexConv a (simplexConv b f) = simplexConv (a + b + 1) f`. The semigroup
+  law transported through the discrete Cauchy formula `iterSum_eq_simplexConv`
+  (`simplexConv d = iterSum (d+1)`): `iterSum (a+1) ∘ iterSum (b+1) = iterSum (a+b+2)`, i.e.
+  `P_a ∗ P_b = P_{a+b+1}` — the summation-side analogue of the fractional-integral composition
+  `(x-·)^a/a! ∗ (x-·)^b/b! = (x-·)^{a+b+1}/(a+b+1)!`, a Vandermonde-type kernel identity. VERIFIED.
 
 ### Key Lean notes (reusable)
 - `iterSum` recurses on its FIRST (dimension) arg: `iterSum 0 f = f`, `iterSum (d+1) f =

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -41,7 +41,8 @@
       "partialSum_simplexConv: kernel dimension-raising engine (Ico-Ico triangular swap + sum_simplex hockey stick).",
       "card_sym_fin_eq_simplexNumber: counting face |Sym (Fin (n+1)) d| = P_d(n) (stars and bars / weakly increasing d-tuples).",
       "iterSum_add — semigroup law of iterated summation: iterSum a (iterSum b f) = iterSum (a+b) f (monoid action of (ℕ,+); discrete Riemann–Liouville semigroup Iᵃ∘Iᵇ=Iᵃ⁺ᵇ). Induction on a, one partialSum layer per step. VERIFIED.",
-      "iterSum_simplexNumber — dimension-additivity of the figurate ladder: iterSum a (simplexNumber b) n = simplexNumber (a+b) n, from iterSum_add + iterSum_one. VERIFIED."
+      "iterSum_simplexNumber — dimension-additivity of the figurate ladder: iterSum a (simplexNumber b) n = simplexNumber (a+b) n, from iterSum_add + iterSum_one. VERIFIED.",
+      "simplexConv_comp — convolution semigroup law for figurate kernels: simplexConv a (simplexConv b f) = simplexConv (a+b+1) f (P_a ∗ P_b = P_{a+b+1}, discrete fractional-integral composition / Vandermonde identity), from iterSum_add + iterSum_eq_simplexConv. VERIFIED."
     ],
     "insights": [
       "The hyper-tetrahedral / d-simplex number is exactly Mathlib Nat.multichoose (n+1) d = C(n+d,d); Mathlib gives the one-step hockey stick Nat.sum_range_add_choose : sum i in range(n+1),(i+d).choose d = (n+d+1).choose(d+1)",
@@ -92,8 +93,8 @@
     {
       "path": "Proofs/TetrahedralNumberFormulaOQ01.lean",
       "filename": "TetrahedralNumberFormulaOQ01.lean",
-      "lineCount": 300,
-      "theoremCount": 13,
+      "lineCount": 320,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary — VERIFIED [3059/3059], 0 sorry / 0 axiom

Follow-up to the merged #36589 (iterated-summation semigroup law). Adds the **kernel-level**
companion:

**`simplexConv_comp`** — the convolution semigroup law for the figurate kernels:

`simplexConv a (simplexConv b f) = simplexConv (a + b + 1) f`.

Convolving with the `b`-dimensional simplex kernel and then the `a`-dimensional one equals
convolving with the `(a+b+1)`-dimensional kernel. This is the semigroup law `iterSum_add`
transported through the discrete Cauchy formula `iterSum_eq_simplexConv`
(`simplexConv d = iterSum (d+1)`): `iterSum (a+1) ∘ iterSum (b+1) = iterSum (a+b+2)`. Expanded,
it is the figurate-kernel Vandermonde identity `P_a ∗ P_b = P_{a+b+1}` — the summation-side
analogue of the fractional-integral composition
`(x-·)^a/a! ∗ (x-·)^b/b! = (x-·)^{a+b+1}/(a+b+1)!`.

## Verification
`./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01` → `✔ [3059/3059] Built`,
green on the first attempt. 0 sorries, 0 `axiom` declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)