### PR TITLE
research(erdos101-oq-04): sum-of-squares four-point-line criterion + general arithmetic counting engine

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -2860,4 +2860,144 @@ theorem four_onQuartic_collinear_iff {a b c d : ℝ × ℝ}
     · linear_combination (a.1 + b.1 + c.1) * he1 - he2
     · linear_combination (a.1 + b.1 + d.1) * he1 - he2
 
+/-! ### Sum-of-squares form and the general arithmetic counting engine
+
+`four_onQuartic_collinear_iff` phrases a four-point line on `y = x⁴ − 5x²` through the
+two Vieta relations `Σx = 0` and `Σ_{i<j}xᵢxⱼ = −5`.  Under `Σx = 0` the second relation
+is equivalent — via `(Σx)² = Σx² + 2·Σ_{i<j}xᵢxⱼ` — to the *sum-of-squares* condition
+`Σx² = 10`, the "four abscissae on a common squared-radius-`10` circle" reading.  This
+form is the one an additive count actually uses, and it powers the general engine below:
+`quartic_fourPointLineCount_from_quadruples` turns **any** injective family of arithmetic
+quadruples `(Σx = 0, Σx² = 10)` into a `fourPointLineCount ≥ k` lower bound, dropping the
+"horizontal / symmetric" restriction baked into `quartic_linear_lower_bound`.  It is the
+exact reduction the open growth question rests on: a *super-linear* family of such
+quadruples (necessarily oblique) would give a super-linear four-point-line count. -/
+
+/-- **Sum-of-squares form of the four-point-line criterion on the quartic.**
+Four points on `y = x⁴ − 5x²` with pairwise-distinct abscissae are collinear iff their
+abscissae satisfy `Σx = 0` and `Σx² = 10`.  Equivalent to `four_onQuartic_collinear_iff`
+by `(Σx)² = Σx² + 2·Σ_{i<j}xᵢxⱼ`: under `Σx = 0`, `Σ_{i<j}xᵢxⱼ = −5 ↔ Σx² = 10`. -/
+theorem four_onQuartic_collinear_iff_sq {a b c d : ℝ × ℝ}
+    (ha : onQuartic a) (hb : onQuartic b) (hc : onQuartic c) (hd : onQuartic d)
+    (hab : a.1 ≠ b.1) (hbc : b.1 ≠ c.1) (hca : c.1 ≠ a.1)
+    (hbd : b.1 ≠ d.1) (hda : d.1 ≠ a.1) (hcd : c.1 ≠ d.1) :
+    (collinear a b c ∧ collinear a b d) ↔
+      (a.1 + b.1 + c.1 + d.1 = 0 ∧
+       a.1 ^ 2 + b.1 ^ 2 + c.1 ^ 2 + d.1 ^ 2 = 10) := by
+  rw [four_onQuartic_collinear_iff ha hb hc hd hab hbc hca hbd hda hcd]
+  constructor
+  · rintro ⟨h1, h2⟩
+    exact ⟨h1, by linear_combination (a.1 + b.1 + c.1 + d.1) * h1 - 2 * h2⟩
+  · rintro ⟨h1, h2⟩
+    exact ⟨h1, by
+      linear_combination (1 / 2 : ℝ) * (a.1 + b.1 + c.1 + d.1) * h1 - (1 / 2 : ℝ) * h2⟩
+
+/-- **General four-point-line count from arithmetic quadruples.**
+Let `x : Fin k → Fin 4 → ℝ` list `k` quadruples of abscissae with
+* four distinct entries per quadruple (`hx_inj`),
+* each quadruple satisfying `Σx = 0` and `Σx² = 10` (`hsum`, `hsq`), and
+* distinct quadruples producing distinct abscissa-sets (`hset_inj`).
+
+Then the image of all these abscissae under `x ↦ (x, x⁴ − 5x²)` is a no-five-collinear
+planar point set on at most `4·k` points with `fourPointLineCount ≥ k`.
+
+This subsumes `quartic_linear_lower_bound`, whose witnesses are the symmetric quadruples
+`(a, −a, b, −b)` with `a² + b² = 5`; the engine additionally accepts *oblique* quadruples,
+so any super-linear family of solutions to `Σx = 0 ∧ Σx² = 10` would immediately upgrade
+the linear floor.  It does not resolve the OPEN `Ω(n^{3/2})` / `n^{2−o(1)}` growth. -/
+theorem quartic_fourPointLineCount_from_quadruples (k : ℕ) (hk : 0 < k)
+    (x : Fin k → Fin 4 → ℝ)
+    (hx_inj : ∀ i, Function.Injective (x i))
+    (hsum : ∀ i, x i 0 + x i 1 + x i 2 + x i 3 = 0)
+    (hsq : ∀ i, x i 0 ^ 2 + x i 1 ^ 2 + x i 2 ^ 2 + x i 3 ^ 2 = 10)
+    (hset_inj : Function.Injective
+      (fun i => (Finset.univ.image (x i) : Finset ℝ))) :
+    ∃ P : PlanarPointSet, P.points.card ≤ 4 * k ∧
+      NoFiveCollinear P ∧ k ≤ fourPointLineCount P := by
+  classical
+  -- The quartic embedding `Q` and the image-line family `L`.
+  let Q : ℝ → ℝ × ℝ := fun t => (t, t ^ 4 - 5 * t ^ 2)
+  let L : Fin k → Finset (ℝ × ℝ) := fun i => (Finset.univ.image (x i)).image Q
+  have hQq : ∀ t, onQuartic (Q t) := fun _ => rfl
+  have hQinj : Function.Injective Q := by
+    intro s t h; exact congrArg Prod.fst h
+  -- Pairwise distinctness of the four abscissae in each quadruple.
+  have hxne : ∀ (i : Fin k) (m n : Fin 4), m ≠ n → x i m ≠ x i n :=
+    fun i m n hmn h => hmn (hx_inj i h)
+  -- Each image-line has exactly four elements.
+  have hLcard : ∀ i, (L i).card = 4 := by
+    intro i
+    change ((Finset.univ.image (x i)).image Q).card = 4
+    rw [Finset.card_image_of_injective _ hQinj,
+      Finset.card_image_of_injective _ (hx_inj i), Finset.card_univ, Fintype.card_fin]
+  -- Membership: `Q (x i j) ∈ L i`.
+  have hQmem : ∀ (i : Fin k) (j : Fin 4), Q (x i j) ∈ L i := by
+    intro i j
+    change Q (x i j) ∈ (Finset.univ.image (x i)).image Q
+    exact Finset.mem_image_of_mem _ (Finset.mem_image_of_mem _ (Finset.mem_univ j))
+  -- The point set: union of all image-lines.
+  have hpts_ne : (Finset.univ.biUnion L).Nonempty :=
+    ⟨Q (x ⟨0, hk⟩ 0), by rw [Finset.mem_biUnion];
+      exact ⟨⟨0, hk⟩, Finset.mem_univ _, hQmem _ 0⟩⟩
+  let P : PlanarPointSet := ⟨Finset.univ.biUnion L, Finset.card_pos.mpr hpts_ne⟩
+  -- Every point lies on the quartic graph, so no five are collinear.
+  have hquartic : ∀ p ∈ P.points, onQuartic p := by
+    intro p hp
+    have hp' : p ∈ Finset.univ.biUnion L := hp
+    rw [Finset.mem_biUnion] at hp'
+    obtain ⟨i, _, hpi⟩ := hp'
+    change p ∈ (Finset.univ.image (x i)).image Q at hpi
+    rw [Finset.mem_image] at hpi
+    obtain ⟨w, _, rfl⟩ := hpi
+    exact hQq w
+  have hno5 : NoFiveCollinear P := noFiveCollinear_of_onQuartic P hquartic
+  -- Each line is a four-point collinear subset of `P`.
+  have hmem : ∀ i, L i ⊆ P.points := by
+    intro i
+    change L i ⊆ Finset.univ.biUnion L
+    exact Finset.subset_biUnion_of_mem L (Finset.mem_univ i)
+  have hcol : ∀ i, ∃ a b : ℝ × ℝ, a ∈ L i ∧ b ∈ L i ∧ a ≠ b ∧
+      ∀ p ∈ L i, collinear a b p := by
+    intro i
+    refine ⟨Q (x i 0), Q (x i 1), hQmem i 0, hQmem i 1, ?_, ?_⟩
+    · intro heq; exact hxne i 0 1 (by decide) (hQinj heq)
+    -- The two non-anchor points are collinear via the sum-of-squares criterion.
+    · have hcd : collinear (Q (x i 0)) (Q (x i 1)) (Q (x i 2)) ∧
+          collinear (Q (x i 0)) (Q (x i 1)) (Q (x i 3)) := by
+        rw [four_onQuartic_collinear_iff_sq (hQq _) (hQq _) (hQq _) (hQq _)
+          (hxne i 0 1 (by decide)) (hxne i 1 2 (by decide)) (hxne i 2 0 (by decide))
+          (hxne i 1 3 (by decide)) (hxne i 3 0 (by decide)) (hxne i 2 3 (by decide))]
+        refine ⟨?_, ?_⟩
+        · show x i 0 + x i 1 + x i 2 + x i 3 = 0; exact hsum i
+        · show x i 0 ^ 2 + x i 1 ^ 2 + x i 2 ^ 2 + x i 3 ^ 2 = 10; exact hsq i
+      have hline : ∀ j : Fin 4, collinear (Q (x i 0)) (Q (x i 1)) (Q (x i j)) := by
+        intro j
+        fin_cases j
+        · unfold collinear; ring
+        · unfold collinear; ring
+        · exact hcd.1
+        · exact hcd.2
+      intro p hp
+      change p ∈ (Finset.univ.image (x i)).image Q at hp
+      rw [Finset.mem_image] at hp
+      obtain ⟨w, hw, rfl⟩ := hp
+      rw [Finset.mem_image] at hw
+      obtain ⟨j, _, rfl⟩ := hw
+      exact hline j
+  -- Distinct indices give distinct lines (abscissa-sets are injective under `Q`).
+  have hLinj : Function.Injective L := by
+    intro i j hij
+    apply hset_inj
+    change (Finset.univ.image (x i)).image Q = (Finset.univ.image (x j)).image Q at hij
+    exact Finset.image_injective hQinj hij
+  -- Point count `≤ 4·k`.
+  have hcardP : P.points.card ≤ 4 * k := by
+    change (Finset.univ.biUnion L).card ≤ 4 * k
+    calc (Finset.univ.biUnion L).card
+        ≤ ∑ i : Fin k, (L i).card := Finset.card_biUnion_le
+      _ = ∑ _i : Fin k, 4 := Finset.sum_congr rfl (fun i _ => hLcard i)
+      _ = 4 * k := by
+          rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]; ring
+  exact ⟨P, hcardP, hno5, fourPointLineCount_ge_of_injOn_family P k L hmem hLcard hcol hLinj⟩
+
 end Erdos101OQ04

--- a/research/problems/erdos101-problem-oq-04/state.md
+++ b/research/problems/erdos101-problem-oq-04/state.md
@@ -1,9 +1,57 @@
 # Current State
 
-**Phase**: ACT (open lower-bound obligations reduced from two to one: Grünbaum Ω(n^{3/2}) is now *derived* from Solymosi–Stojaković)
+**Phase**: ACT (arithmetization complete: four-point-line counting on the quartic is now the additive problem "count 4-subsets with Σx=0 ∧ Σx²=10")
 **Since**: 2026-07-01
-**Last Updated**: 2026-07-08 (Iteration 10, researcher-8)
-**Iteration**: 10
+**Last Updated**: 2026-07-09 (Iteration 11, researcher-4)
+**Iteration**: 11
+
+## Iteration 11 (researcher-4, 2026-07-09) — sum-of-squares criterion + general arithmetic counting engine [UNVERIFIED — env SIGBUS]
+
+**Outcome**: two additions to `Proofs/Erdos101OQ04.lean` (0 new axioms, 0 new
+sorries), sharpening the Vieta arithmetization (iteration 10, researcher-2) into
+the exact geometry⇒arithmetic *count* reduction and removing the "horizontal /
+symmetric" restriction from the growing lower bound.
+
+1. **`four_onQuartic_collinear_iff_sq`** — the sum-of-squares form of the
+   four-point-line criterion: four points on `y = x⁴ − 5x²` with distinct
+   abscissae are collinear iff `Σx = 0 ∧ Σx² = 10`.  Derived from
+   `four_onQuartic_collinear_iff` (whose second condition is
+   `Σ_{i<j}xᵢxⱼ = −5`) via the identity `(Σx)² = Σx² + 2·Σ_{i<j}xᵢxⱼ`: under
+   `Σx = 0`, `Σxy = −5 ↔ Σx² = 10`.  This is the "four abscissae on a common
+   squared-radius-10 circle" reading — the form an additive count actually
+   operates on (two `linear_combination` steps).
+
+2. **`quartic_fourPointLineCount_from_quadruples`** — the general engine: any
+   injective family `x : Fin k → Fin 4 → ℝ` of quadruples with distinct entries,
+   each satisfying `Σx = 0 ∧ Σx² = 10`, yields a no-five-collinear point set on
+   `≤ 4k` points with `fourPointLineCount ≥ k`.  Built by pushing each quadruple
+   through the embedding `t ↦ (t, t⁴−5t²)`, certifying collinearity per line via
+   `four_onQuartic_collinear_iff_sq`, and closing with the existing
+   `fourPointLineCount_ge_of_injOn_family` plumbing.  **Subsumes**
+   `quartic_linear_lower_bound`, whose witnesses are the symmetric quadruples
+   `(a,−a,b,−b)` with `a²+b² = 5` (`Σx=0`, `Σx²=2(a²+b²)=10`); the engine
+   additionally accepts *oblique* quadruples, so **a super-linear family of
+   solutions to `Σx=0 ∧ Σx²=10` would immediately give a super-linear
+   four-point-line count**.  This is the exact reduction the OPEN
+   `n^{2−o(1)}` growth (`solymosi_stojakovic_lower_bound`) rests on.
+
+**Honest scope**: this does NOT resolve any open growth. The symmetric solutions
+form a one-parameter family (linear count); the hard open content is exhibiting a
+super-linear family of quadruples (necessarily oblique — over `ℝ` the only
+*integer* solutions are the symmetric `{±1,±2}`), which is precisely the
+Grünbaum/Solymosi–Stojaković construction. The single remaining `sorry`
+(`solymosi_stojakovic_lower_bound`) is untouched.
+
+**Build note — UNVERIFIED (environmental, not code)**: `docker-build.sh
+Proofs.Erdos101OQ04` crashed with exit 135 (SIGBUS) / 139 (SIGSEGV) at
+~0.3–1.8 s across 6 attempts (incl. `LEAN_MEMORY_LIMIT=24576`) — far too fast to
+have elaborated the 2900-line file, i.e. a crash at olean *load*, not on the new
+code.  **Confirmed environmental**: rebuilding the *pristine* origin/main file
+with a whitespace cache-buster (forcing full elaboration) ALSO crashed
+(exit 139, 346 ms).  The pristine file replays from a cached olean fine, so this
+is a session-wide fresh-elaboration flake (same one documented in iteration 10:
+"session-wide, location-less exit-135 that also crashes untouched siblings").
+Each proof step was hand-checked; CI in a clean environment is the ground truth.
 
 ## Iteration 10 (researcher-8, 2026-07-08) — prove Grünbaum from Solymosi–Stojaković (2 sorries → 1)
 

--- a/src/data/research/problems/erdos101-problem-oq-04.json
+++ b/src/data/research/problems/erdos101-problem-oq-04.json
@@ -34,14 +34,9 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-08",
-    "iteration": 10,
-    "focus": "ACT iteration 10 (researcher-2, 2026-07-08) — docker-build verified (lean v4.26.0, 0 new axioms / 0 new sorries). Added the first unconditional GROWING lower bound, breaking the constant-witness treadmill (crossSet 2 / asteriskSet 3 / gridSet 10): noFiveCollinear_of_onQuartic (any subset of the quartic graph y = x^4 - 5x^2 is no-five-collinear, via Polynomial.card_roots' on a degree-4 polynomial — a single degree fact replacing the bespoke finite case-splits), and quartic_linear_lower_bound: for every k>=1 a no-five-collinear set on <=4k points with fourPointLineCount >= k, so L4(n)=Omega(n) unconditionally and the count is unbounded. Witness = k horizontal chords of the quartic (levels u in (0,5/2), points (+-sqrt u, c),(+-sqrt(5-u),c)). Does NOT touch the single remaining sorry (solymosi_stojakovic_lower_bound, the open n^{2-o(1)} measure-theoretic construction); this is the linear floor beneath it.",
-    "blockers": [
-      "S3-B2-β 4-collinear COUNT `Ω(p^{3/2})`: the parabola itself is now PROVEN to be no-three-collinear, so it has zero four-point lines on its own — the Ω(p^{3/2}) four-point-line witness requires the further sumset/grid construction over this general-position base, not the bare parabola.",
-      "S4-S5 (Path A random-projection genericity): unchanged from S2 — measure-theoretic infrastructure deferred to dedicated multi-session ACT."
-    ],
-    "nextAction": "S3-B6: certify the two diagonals of gridSet to reach the full four-point-line count of 10 (fourPointLineCount gridSet = 10), completing the maximal-grid witness. ALTERNATIVE (Path B): parameterize a growing family — e.g. a superlinearly-staggered stack of 4-wide rows so no external line threads 5 points — to obtain the first NON-constant (unbounded) fourPointLineCount lower bound, the genuine stepping stone toward grunbaum_lower_bound_three_halves. The S4-S5 random-projection genericity (measure theory) remains deferred to a dedicated multi-session ACT."
+    "since": "2026-07-09",
+    "iteration": 11,
+    "focus": "ACT iteration 11 (researcher-4, 2026-07-09) — UNVERIFIED (env SIGBUS on fresh elaboration, confirmed via pristine-file crash; not code). Added four_onQuartic_collinear_iff_sq (four points on y=x^4-5x^2 collinear iff Sum x=0 and Sum x^2=10, the sum-of-squares form of the Vieta criterion) and quartic_fourPointLineCount_from_quadruples (any injective family of k quadruples with Sum x=0, Sum x^2=10 gives a no-five-collinear set on <=4k points with fourPointLineCount >= k). Subsumes quartic_linear_lower_bound (symmetric quadruples) and drops the horizontal restriction; the exact geometry->arithmetic count reduction the open n^(2-o(1)) growth rests on. 0 new axioms, 0 new sorries; single open sorry (solymosi_stojakovic_lower_bound) untouched."
   },
   "leanFiles": [
     {
@@ -166,7 +161,7 @@
     "sourceTitle": "Erdős Problem #101: Four-Point Lines from Planar Point Sets",
     "sourceType": "open-question"
   },
-  "lastUpdate": "2026-07-08",
+  "lastUpdate": "2026-07-09",
   "relatedProofs": [
     "erdos-101",
     "erdos101-problem",


### PR DESCRIPTION
## Summary

Two additions to \`proofs/Proofs/Erdos101OQ04.lean\` (Erdős #101, lower-bound side — the open \$100 four-point-line problem). **0 new axioms, 0 new sorries**; the single open \`sorry\` (\`solymosi_stojakovic_lower_bound\`) is untouched.

These sharpen the Vieta arithmetization from iteration 10 into the exact **geometry ⇒ arithmetic count** reduction and remove the "horizontal/symmetric" restriction from the growing lower bound.

### 1. `four_onQuartic_collinear_iff_sq`
Four points on `y = x⁴ − 5x²` with pairwise-distinct abscissae are collinear **iff `Σx = 0` and `Σx² = 10`**.

Derived from the existing `four_onQuartic_collinear_iff` (second condition `Σ_{i<j}xᵢxⱼ = −5`) via `(Σx)² = Σx² + 2·Σ_{i<j}xᵢxⱼ`: under `Σx = 0`, `Σxy = −5 ↔ Σx² = 10`. This is the "four abscissae on a common squared-radius-10 circle" reading — the form an additive count actually uses.

### 2. `quartic_fourPointLineCount_from_quadruples`
Any injective family `x : Fin k → Fin 4 → ℝ` of quadruples with distinct entries, each satisfying `Σx = 0 ∧ Σx² = 10`, yields a no-five-collinear planar point set on `≤ 4k` points with `fourPointLineCount ≥ k`.

- **Subsumes** `quartic_linear_lower_bound`, whose witnesses are the symmetric quadruples `(a,−a,b,−b)` with `a²+b²=5` (so `Σx=0`, `Σx²=2(a²+b²)=10`).
- Additionally accepts **oblique** quadruples, so a *super-linear* family of arithmetic solutions to `Σx=0 ∧ Σx²=10` would immediately give a super-linear four-point-line count. This is the exact reduction the OPEN `n^{2−o(1)}` growth rests on.
- Reuses the existing `fourPointLineCount_ge_of_injOn_family` counting plumbing; the only new content is the per-line geometric certificate.

## Honest scope
Does **not** resolve any open growth. The symmetric solutions form a one-parameter family (linear count); over `ℝ` the only *integer* solutions are the symmetric `{±1,±2}`, so a super-linear family is necessarily oblique — precisely the hard Grünbaum/Solymosi–Stojaković content.

## Build status — UNVERIFIED (environmental, not code)
`docker-build.sh Proofs.Erdos101OQ04` crashed with exit **135 (SIGBUS) / 139 (SIGSEGV)** at ~0.3–1.8 s across 6 attempts (incl. `LEAN_MEMORY_LIMIT=24576`) — far too fast to have elaborated the 2900-line file (a crash at olean *load*, not on the new code).

**Confirmed environmental**: rebuilding the *pristine* `origin/main` file with a whitespace cache-buster (forcing full re-elaboration) **also crashed** (exit 139, 346 ms), while the cached pristine olean replays fine. This is the session-wide fresh-elaboration flake documented in iteration 10. Every proof step was hand-checked; **CI in a clean environment is the ground truth.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)