### PR TITLE
Audit: mark handshake-lemma-oq-01 clean (coverage 4795/4795)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -29755,8 +29755,14 @@
       "lastAudited": "2026-07-10T00:30:30Z",
       "result": "clean",
       "issues": []
+    },
+    "handshake-lemma-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-10T01:10:15Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T00:56:23Z"
+  "lastUpdated": "2026-07-10T01:10:15Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — handshake-lemma-oq-01

**Result: CLEAN** ✅ — persists the audit-tracker bump for the last unaudited entry (auditor `complete` writes land in the deregistered worktree tracker, not main).

### Entry
**Minimal Edge Deficiency from the Handshake Parity Obstruction** — quantifies the classical handshake parity obstruction via a degree-deficiency functional `∑_v (d − deg v) = n·d − 2|E|`, proving it shares the parity of `n·d`, is `≥ 1` when `n·d` is odd, caps edges at `2|E| ≤ n·d − 1`, and exhibits an attaining witness.

### Verification against `Proofs/HandshakeLemmaOQ01.lean`
| Claim | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| theorems | 9 | 9 | ✓ |
| definitions | 1 | 1 (`deficiency`) | ✓ |
| lineCount | 135 | 135 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |

- **No True stubs.** All 9 theorems prove substantive statements.
- **Kernel `decide`, not `native_decide`.** The 3 `by decide` uses (sharpness witness + 2 examples) are kernel decide, so `Lean.ofReduceBool` is correctly *not* introduced — exactly as the `assumptions` field claims.
- **status `verified` / badge `original` defensible.** The deficiency quantification is a genuine original derivation; the Mathlib handshake identity `sum_degrees_eq_twice_card_edges` is a disclosed supporting lemma, not a delegated headline. All 5 `mathlibDependencies` are real and used.
- **mainTheorems `leanType`s** and all 6 `originalContributions` map to real declarations.
- **Honest scoping.** `assumptions` explicitly notes it does *not* prove general realisability (Erdős–Gallai / Havel–Hakimi territory), left to the sibling entry.

Only `src/data/proofs/audit-tracker.json` is touched (one entry added + `lastUpdated`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)