### PR TITLE
research(erdos-703-incomplete-01): exact diagonal value T(n,n) = 2ⁿ − 1 [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -483,6 +483,66 @@ theorem T_eq_pow_of_lt (n r : ℕ) (h : n < r) : T n r = 2 ^ n := by
     _ ≤ _ := Finset.le_sup hmem
 
 /--
+**For subsets of `[n]`, an intersection of size `n` fills the ground set.**
+If `A, B ⊆ [n]` and `|A ∩ B| = n`, then `A ∩ B = [n]` (it is an `n`-element subset
+of the `n`-element set `[n]`), forcing `A = B = [n]`. This is the structural fact
+behind the diagonal value `T(n,n)`. -/
+theorem inter_card_eq_n_iff {n : ℕ} {A B : Finset ℕ}
+    (hA : A ⊆ Finset.range n) (hB : B ⊆ Finset.range n) :
+    (A ∩ B).card = n ↔ A = Finset.range n ∧ B = Finset.range n := by
+  constructor
+  · intro h
+    have hsub : A ∩ B ⊆ Finset.range n := (Finset.inter_subset_left).trans hA
+    have heq : A ∩ B = Finset.range n :=
+      Finset.eq_of_subset_of_card_le hsub (by rw [Finset.card_range, h])
+    have hAn : Finset.range n ⊆ A := heq ▸ Finset.inter_subset_left
+    have hBn : Finset.range n ⊆ B := heq ▸ Finset.inter_subset_right
+    exact ⟨Finset.Subset.antisymm hA hAn, Finset.Subset.antisymm hB hBn⟩
+  · rintro ⟨rfl, rfl⟩
+    rw [Finset.inter_self, Finset.card_range]
+
+/--
+**The diagonal value `T(n,n) = 2^n − 1`.**
+A family `F ⊆ 2^{[n]}` avoids `n`-intersection iff it omits the full ground set
+`[n]`: the *only* pair of subsets of `[n]` meeting in `n` elements is `[n]` with
+itself (`inter_card_eq_n_iff`), and `avoidsRIntersection` forbids that self-pair.
+Hence the largest `n`-avoiding family is the powerset minus the single set `[n]`,
+of size `2^n − 1`. Together with `T(n,0) = 2^{n-1}` and `T(n,r) = 2^n` for `n < r`,
+this pins the third exactly-known boundary value of `T`, at the diagonal `r = n`. -/
+theorem T_n_n (n : ℕ) : T n n = 2 ^ n - 1 := by
+  apply le_antisymm
+  · -- Upper bound: every avoiding family omits `[n]`, so embeds in `powerset \ {[n]}`.
+    apply Finset.sup_le
+    intro F hF
+    rw [Finset.mem_filter, Finset.mem_powerset] at hF
+    obtain ⟨hFsub, hFavoid⟩ := hF
+    have hnotmem : Finset.range n ∉ F := fun hmem =>
+      hFavoid (Finset.range n) (Finset.range n) hmem hmem
+        (by rw [Finset.inter_self, Finset.card_range])
+    have hsub : F ⊆ (Finset.range n).powerset.erase (Finset.range n) := by
+      intro A hA
+      rw [Finset.mem_erase]
+      exact ⟨fun h => hnotmem (h ▸ hA), hFsub hA⟩
+    calc F.card ≤ ((Finset.range n).powerset.erase (Finset.range n)).card :=
+          Finset.card_le_card hsub
+      _ = (Finset.range n).powerset.card - 1 :=
+          Finset.card_erase_of_mem (Finset.mem_powerset.mpr (Finset.Subset.refl _))
+      _ = 2 ^ n - 1 := by rw [Finset.card_powerset, Finset.card_range]
+  · -- Lower bound: `powerset \ {[n]}` is itself `n`-avoiding, of size `2^n − 1`.
+    have hmem : (Finset.range n).powerset.erase (Finset.range n) ∈
+        ((Finset.range n).powerset.powerset).filter (avoidsRIntersection n) := by
+      rw [Finset.mem_filter, Finset.mem_powerset]
+      refine ⟨Finset.erase_subset _ _, ?_⟩
+      intro A B hA hB
+      rw [Finset.mem_erase, Finset.mem_powerset] at hA hB
+      intro hcontra
+      exact hA.1 ((inter_card_eq_n_iff hA.2 hB.2).mp hcontra).1
+    calc 2 ^ n - 1 = ((Finset.range n).powerset.erase (Finset.range n)).card := by
+          rw [Finset.card_erase_of_mem (Finset.mem_powerset.mpr (Finset.Subset.refl _)),
+            Finset.card_powerset, Finset.card_range]
+      _ ≤ T n n := Finset.le_sup hmem
+
+/--
 **The `r = 1` large-set family is contained in `franklFurediOdd n 1`.**
 `largeSetsFamily n` filters on `|A| > (n+1)/2`, exactly the "large" disjunct of
 `franklFurediOdd n 1` (whose threshold `(n+1)/2` coincides). So the general-`r`

--- a/src/data/research/problems/erdos-703-incomplete-01.json
+++ b/src/data/research/problems/erdos-703-incomplete-01.json
@@ -17,25 +17,29 @@
   },
   "currentState": "T(n,0)=2^{n-1} is fully machine-checked, and BOTH parities of the Frankl-Füredi extremal construction are now proved r-avoiding with matching T(n,r) lower bounds: franklFurediOdd_avoids_r / _card_le_T (all n,r) and the new even-parity companions franklFurediEven_avoids_r / _card_le_T (n+r even, n≥1). The deep Frankl-Rödl exponential bound (frankl_rodl_1987) remains the sole axiom. Entry status: axiomatized, 1 axiom, 0 sorries.",
   "knowledge": {
-    "progressSummary": "PROGRESS: trivial case T(n,0)=2^{n-1} fully machine-checked (sorry eliminated); deep cases remain axiomatized | 2026-07-08 (researcher-3): advanced the r=1 case — assembled large_sets_avoid_1 into largeSetsFamily (Frankl 1977 lower-bound construction) and proved largeSetsFamily_card_le_T: |largeSetsFamily n| ≤ T(n,1). Verified, 0 new axioms.",
+    "progressSummary": "PROGRESS (researcher-2, 2026-07-09, VERIFIED green build): proved the exact diagonal value T(n,n)=2^n-1, the third exactly-known boundary value of T(n,r) alongside T(n,0)=2^{n-1} and T(n,r)=2^n (n<r). A family avoids n-intersection iff it omits the full ground set [n] (the unique n-meeting pair among subsets of [n] is [n] with itself, forbidden as a self-pair by avoidsRIntersection). Deep frankl_rodl_1987 axiom and exact T(n,1) (Frankl 1977 upper bound) remain open.",
     "builtItems": [
       "card_le_of_avoids_zero (Erdos703Problem.lean:97): complement-pairing upper bound |F| <= 2^{n-1} for 0-avoiding families",
       "star_family_card (Erdos703Problem.lean:164): fixed-point star family has 2^{n-1} members (Finset.card_nbij' bijection)",
       "T_n_0 (Erdos703Problem.lean:204): full machine-checked proof T(n,0) = 2^{n-1} via le_antisymm (replaced a sorry)",
       "franklFurediEven_avoids_r (Erdos703Problem.lean): the even-parity (n+r even, n≥1) companion of franklFurediOdd_avoids_r — the family {A⊆[n] : |A\\{0}|≥(n+r)/2 ∨ |A|<r} avoids r-intersection. Large-large case uses inclusion-exclusion on the centred sets A\\{0},B\\{0} in the (n-1)-element ground set {1,…,n-1}: |A∩B|≥2⌊(n+r)/2⌋-(n-1)=r+1. VERIFIED 0 extra axioms.",
-      "franklFurediEven_card_le_T (Erdos703Problem.lean): even-parity T(n,r) lower bound, mirroring franklFurediOdd_card_le_T via Finset.le_sup. VERIFIED 0 extra axioms."
+      "franklFurediEven_card_le_T (Erdos703Problem.lean): even-parity T(n,r) lower bound, mirroring franklFurediOdd_card_le_T via Finset.le_sup. VERIFIED 0 extra axioms.",
+      "Erdos703Problem.lean: inter_card_eq_n_iff (|A cap B|=n iff A=B=range n for A,B subseteq range n; Finset.eq_of_subset_of_card_le) + T_n_n (T(n,n)=2^n-1 via le_antisymm: upper = every avoiding family omits range n so embeds in powerset.erase, Finset.card_erase_of_mem+card_powerset; lower = powerset.erase(range n) is n-avoiding via inter_card_eq_n_iff, Finset.le_sup). VERIFIED GREEN [7743/7743], 0 new axioms/sorries."
     ],
     "insights": [
       "T(n,0) = 2^{n-1}: the 0-avoiding families are exactly the intersecting families; the complement map sending A to its complement in [n] injects any intersecting F into a disjoint copy, giving 2|F| <= 2^n, hence |F| <= 2^{n-1}.",
       "Sharpness is witnessed by the star family of all subsets of [n] containing 0, in bijection with the powerset of [n] minus {0} via A maps to A.erase 0, so it has exactly 2^{n-1} members.",
       "The remaining open content (Frankl-Rodl 1987 main bound, exponential chromatic number) is genuinely deep and stays axiomatized; only the trivial base case was within reach of a from-scratch Lean proof.",
-      "The even-parity Frankl-Füredi family needs the |A\\{0}| (centred) size condition, not |A|: removing the fixed element 0 shrinks the ground set to n-1, which exactly compensates for the non-strict ≥ so that 2⌊(n+r)/2⌋-(n-1)=r+1 when n+r is even. For n+r odd the same bound only gives r (not r+1), which is why franklFurediOdd (strict >) covers the odd parity instead."
+      "The even-parity Frankl-Füredi family needs the |A\\{0}| (centred) size condition, not |A|: removing the fixed element 0 shrinks the ground set to n-1, which exactly compensates for the non-strict ≥ so that 2⌊(n+r)/2⌋-(n-1)=r+1 when n+r is even. For n+r odd the same bound only gives r (not r+1), which is why franklFurediOdd (strict >) covers the odd parity instead.",
+      "VERIFIED (researcher-2, 2026-07-09, GREEN docker build [7743/7743]): the exact DIAGONAL value T(n,n)=2^n-1. Key structural fact inter_card_eq_n_iff: for A,B subseteq [n]=range n, |A cap B|=n iff A=B=[n] (an n-element subset of the n-element ground set is the whole set). Since avoidsRIntersection quantifies over ALL pairs INCLUDING A=B, a family avoids n-intersection iff it omits [n] itself (the self-pair ([n],[n]) has |[n] cap [n]|=n, forbidden), and no other pair can meet in n. So the maximum n-avoiding family = powerset(range n).erase (range n), card 2^n-1. This is the THIRD exactly-known boundary value, completing T(n,0)=2^{n-1} (trivial/intersecting) and T(n,r)=2^n for n<r (degenerate large-r); T(n,n) is the r=n diagonal endpoint. 0 axioms (does not touch frankl_rodl_1987)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "T(n,1) (Frankl 1977) is the next non-trivial case; large_sets_avoid_1 already proves large sets cannot 1-intersect - extend to a full extremal count.",
-      "Frankl-Rodl 1987 and the chromatic-number consequence remain axiomatized; formalizing either is a major project (likely 1000+ lines)."
-    ]
+      "Exact T(n,1) (Frankl 1977): large_sets_avoid_1 / largeSetsFamily give the lower-bound construction; the matching upper bound is the hard extremal direction (genuine Frankl 1977 theorem, not trivial).",
+      "Frankl-Rodl 1987 main bound and exponential chromatic-number consequence remain axiomatized (frankl_rodl_1987); formalizing either is 1000+ lines.",
+      "Possible small extension: an explicit closed form / binomial-sum lower bound for |largeSetsFamily n| = sum_{k>(n+1)/2} C(n,k), giving a concrete numeric lower bound for T(n,1)."
+    ],
+    "score": 13
   },
   "tags": [
     "erdos",


### PR DESCRIPTION
## Erdős #703 — the exact diagonal value T(n,n) = 2ⁿ − 1

`Erdos703Problem.lean` studies `T(n,r)`, the maximum size of a family
`F ⊆ 2^{[n]}` avoiding `r`-intersection (no two members `A, B` with
`|A ∩ B| = r`, where the quantification includes the self-pair `A = B`). The file
already has three of the four analytically-accessible facts: the trivial case
`T(n,0) = 2^{n-1}`, the degenerate large-`r` case `T(n,r) = 2^n` for `n < r`, and
the Frankl–Füredi lower-bound constructions. The deep Frankl–Rödl 1987 bound
stays axiomatized.

This PR adds the remaining **exactly-known boundary value**, at the diagonal
`r = n`.

### New results (0 axioms, 0 sorries — fully verified)

- **`inter_card_eq_n_iff`** — for `A, B ⊆ [n]`, `|A ∩ B| = n ⇔ A = B = [n]`. An
  `n`-element subset of the `n`-element ground set `[n]` is the whole set, so the
  intersection fills `[n]` and forces both sets to equal it.
- **`T_n_n`** — `T(n,n) = 2ⁿ − 1`. Because `avoidsRIntersection` forbids the
  self-pair `(A, A)` whenever `|A| = n`, a family avoids `n`-intersection **iff it
  omits the full ground set `[n]`** (the unique `n`-meeting pair among subsets of
  `[n]` is `[n]` with itself). The largest such family is therefore the powerset
  minus the single set `[n]`, of size `2ⁿ − 1`.

### Significance

This completes the exactly-known boundary of `T(n,r)`:

| regime | value |
|--------|-------|
| `r = 0` | `2^{n-1}` (intersecting families) |
| `r = n` (diagonal) | `2ⁿ − 1` — **this PR** |
| `n < r` | `2ⁿ` (no constraint achievable) |

The interior (`0 < r < n`), including the still-open exact `T(n,1)` (Frankl 1977)
and the Frankl–Rödl exponential bound, remains genuinely deep. This result does
not touch the `frankl_rodl_1987` axiom.

### Build status

**Fully verified**: `✔ [7743/7743] Built Proofs.Erdos703Problem` with the olean
written (green Docker build, no SIGBUS). 0 new axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)