### PR TITLE
audit(hilbert-6): disclose degenerate placeholder axioms & fix phantom mainTheorem

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20827,8 +20827,8 @@
     "hilbert-6": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
-      "lastAudited": "2026-05-03T23:02:01Z",
-      "result": "clean"
+      "lastAudited": "2026-07-10T01:17:00Z",
+      "result": "issues-fixed"
     },
     "hilbert-9-reciprocity": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/hilbert-6/meta.json
+++ b/src/data/proofs/hilbert-6/meta.json
@@ -39,14 +39,14 @@
       "Kolmogorov probability axioms demonstration",
       "Conditional probability and Bayes theorem",
       "Quantum state formalization (Born rule)",
-      "Classical mechanics Lagrangian structure",
+      "Classical mechanics Lagrangian structure (definitions and action functional; Hamilton's principle is a placeholder axiom, not formalized)",
       "Thermodynamics Caratheodory formulation"
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 6,
     "axiomCount": 7,
     "lineCount": 326,
-    "assumptions": "7 axioms: bayes_theorem, total_probability, born_probability_le_one, and 4 more. See Lean source for complete statements.",
+    "assumptions": "7 axioms. Four state genuine mathematical facts taken as axioms rather than proved: bayes_theorem, total_probability, born_probability_le_one (Cauchy-Schwarz), caratheodory_axiom and entropy_exists. Two are non-rigorous placeholder axioms that do NOT faithfully formalize the physics they name and are degenerate as literally stated: hamiltons_principle asserts 'isPhysical <-> (there exists a Prop that holds)', whose right side is trivially true, so it collapses to 'isPhysical is always true' for any proposition; unified_physics_open asserts 'not (there exists a nonempty type)', which is provably false (Unit is nonempty). As written these two axioms are logically inconsistent, so they should be read as informal scaffolding markers, not verified statements. The genuinely machine-checked content is the Kolmogorov probability layer (kolmogorov_axiom_1/2/3, probability_nonneg/le_one/compl/union_le) and the Born-rule lemmas (born_probability_nonneg/self), derived from Mathlib's measure/inner-product-space theory.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 7
@@ -194,10 +194,10 @@
   ],
   "mainTheorems": [
     {
-      "name": "hilbert6_axiomatization",
+      "name": "hilbert_6_status",
       "type": "core",
-      "description": "Mathematical axiomatization of physical theories",
-      "leanType": "PhysicalTheory T -> exists axioms, Consistent axioms and Models T axioms"
+      "description": "Status marker recording that probability, QM, thermodynamics, and mechanics are each axiomatized; the substantive machine-checked results are the Kolmogorov probability theorems (kolmogorov_axiom_1/2/3) and the Born-rule lemmas. There is no single 'hilbert6_axiomatization' theorem proving consistency or model existence.",
+      "leanType": "(exists _ : Prop, True) and (exists _ : Prop, True) and (exists _ : Prop, True) and (exists _ : Prop, True)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit — hilbert-6 (Hilbert's Sixth Problem)

Counts are all accurate (7 axioms, 10 theorems, 7 defs, 0 sorries, 326 lines); `status: axiomatized` / `badge: axiom` are correct. The generic framing ("partially achieved", "remains elusive") is honest. Three specific prose/metadata issues fixed:

### 1. Undisclosed degenerate/inconsistent axioms (MEDIUM)
Two of the seven axioms do not faithfully formalize the physics they name and are **inconsistent as literally stated**:

- `hamiltons_principle (S) (q) (isPhysical : Prop) : isPhysical ↔ ∃ (stationarity : Prop), stationarity` — the RHS is trivially true (witness `True`), so this collapses to "`isPhysical` holds for **any** proposition."
- `unified_physics_open : ¬∃ (UnifiedTheory : Type), Nonempty UnifiedTheory` — this proposition is **provably false** (`Unit` is a nonempty type).

The `assumptions` field now enumerates all 7 axioms, distinguishes the four genuine-fact axioms (bayes, total_probability, born_probability_le_one, caratheodory, entropy) from these two placeholder markers, and states they are informal scaffolding, not verified statements.

### 2. Phantom `mainTheorems[0]` with fabricated leanType (MEDIUM)
`mainTheorems[0]` named `hilbert6_axiomatization` (no such declaration exists) with `leanType: "PhysicalTheory T -> exists axioms, Consistent axioms and Models T axioms"` — a fabricated formal statement about consistency/model existence that the file never proves. Repointed to the file's actual status theorem `hilbert_6_status` (a tautology), with its real type and a note that the substantive content is the Kolmogorov probability + Born-rule layer.

### 3. originalContributions overstatement (LOW)
Qualified the "Classical mechanics Lagrangian structure" bullet to note Hamilton's principle is a placeholder axiom, not formalized.

### Genuine content (unchanged, accurately described)
Kolmogorov axioms (`kolmogorov_axiom_1/2/3`), `probability_nonneg/le_one/compl/union_le`, and Born-rule lemmas (`born_probability_nonneg/self`) are real Mathlib-bridge results.

### Follow-up for Mechanic
The two degenerate axioms in `proofs/Proofs/Hilbert6PhysicsAxioms.lean` warrant repair to non-vacuous statements.

Also bumps `audit-tracker.json` for hilbert-6 (last audited 2026-05-03 → 2026-07-10).

---
Discovered during gallery integrity audit.