### PR TITLE
research(sperner-ndim-oq-02): reverse pivot reciprocity — two-sided involution

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -3685,4 +3685,119 @@ theorem topPivotCell_zeroPivotCell (s : GridSimplex d N) (hd1 : 0 < d)
       congr 1; apply Fin.ext; show (k.val - 1) + 1 = k.val; omega
   · rw [topPivotCell_miss, zeroPivotCell_miss]
 
+-- ============================================================
+-- Reverse reciprocity: `zeroPivotCell (topPivotCell u) = u`
+-- ============================================================
+-- `topPivotCell_zeroPivotCell` proves ONE composition of the two
+-- cross-facet pivots is the identity (`topPivotCell ∘ zeroPivotCell =
+-- id`).  This section proves the OTHER composition
+-- (`zeroPivotCell ∘ topPivotCell = id`), upgrading the partial-involution
+-- reciprocity to a genuine two-sided involution: on the feasible regime the
+-- facet-`0` cross-chain pivot and the dual top-facet pivot are mutually
+-- inverse bijections.  This is exactly the well-definedness the boundary
+-- `adj` needs — the gluing at a shared cross-chain facet is an involution,
+-- so each of the two cells filling it maps to the other and back.
+--
+-- The feasibility bridge is automatic: `topPivotCell u`'s apex is `u.verts
+-- (d-1)`, whose `miss` coordinate is `base_miss − (d−1) ≥ d − (d−1) = 1`
+-- (`miss_coord_at` + `base_miss_ge_d`), so the facet-`0` pivot is always
+-- applicable to it.  The crux is the dual apex-recovery
+-- `zeroPivotTop (topPivotCell u) = u.verts (Fin.last d)` — the mirror of
+-- `topPivotBottom_zeroPivotCell`: the new apex the facet-`0` pivot appends
+-- above `topPivotCell u`'s chain reconstructs `u`'s deleted apex, coordinate
+-- by coordinate via the last chain step `u.step_inc/step_dec/step_same` at
+-- `⟨d-1⟩`.  All 0-sorry, 0-axiom.
+
+/-- **Feasibility bridge.**  The facet-`0` cross-chain pivot is always
+applicable to the dual cell `topPivotCell u`: its apex is `u.verts (d-1)`,
+whose `miss` coordinate is `base_miss − (d−1) ≥ 1` (it descends by one at each
+of the `d−1` steps and starts `≥ d`, `miss_coord_at` + `base_miss_ge_d`). -/
+theorem topPivotCell_zeroFeasible (u : GridSimplex d N) (hd1 : 0 < d)
+    (hfeas : 1 ≤ (u.verts 0).coords (lastIncDir u hd1)) :
+    1 ≤ ((topPivotCell u hd1 hfeas).verts (Fin.last d)).coords
+          (topPivotCell u hd1 hfeas).miss := by
+  have hne : (Fin.last d).val ≠ 0 := by simp only [Fin.val_last]; omega
+  rw [topPivotCell_verts, topPivotCell_miss,
+    topPivotVerts_of_pos u hd1 hfeas (Fin.last d) hne, u.miss_coord_at]
+  have hb := u.base_miss_ge_d
+  simp only [Fin.val_last]
+  omega
+
+/-- **Dual apex recovery** (mirror of `topPivotBottom_zeroPivotCell`).  The new
+apex that the facet-`0` pivot appends above `topPivotCell u`'s chain
+reconstructs exactly `u`'s deleted apex `u.verts (Fin.last d)`.  Proved
+coordinate-by-coordinate from the last chain step of `u` (`step_inc` at the
+reversed `lastIncDir` direction, `step_dec` at `miss`, `step_same` elsewhere)
+evaluated between `u.verts (d-1)` and `u.verts (Fin.last d)`. -/
+theorem zeroPivotTop_topPivotCell (u : GridSimplex d N) (hd1 : 0 < d)
+    (hfeas : 1 ≤ (u.verts 0).coords (lastIncDir u hd1)) :
+    zeroPivotTop (topPivotCell u hd1 hfeas) hd1
+        (topPivotCell_zeroFeasible u hd1 hfeas) = u.verts (Fin.last d) := by
+  have hlt : d - 1 < d := by omega
+  have hne : (Fin.last d).val ≠ 0 := by simp only [Fin.val_last]; omega
+  have hsucc : (⟨d - 1, hlt⟩ : Fin d).succ = Fin.last d := by
+    apply Fin.ext; show d - 1 + 1 = (Fin.last d).val; simp only [Fin.val_last]; omega
+  have hinc : (topPivotCell u hd1 hfeas).incDir ⟨0, hd1⟩ = u.incDir ⟨d - 1, hlt⟩ :=
+    topPivotInc_eq_lastIncDir u hd1 ⟨0, hd1⟩ rfl
+  have hmiss : (topPivotCell u hd1 hfeas).miss = u.miss := topPivotCell_miss u hd1 hfeas
+  have hapex : (topPivotCell u hd1 hfeas).verts (Fin.last d)
+      = u.verts (⟨d - 1, hlt⟩ : Fin d).castSucc := by
+    rw [topPivotCell_verts, topPivotVerts_of_pos u hd1 hfeas (Fin.last d) hne]
+    congr 1
+  ext j
+  by_cases hP : j = (topPivotCell u hd1 hfeas).incDir ⟨0, hd1⟩
+  · subst hP
+    rw [zeroPivotTop_coords_incDir0, hapex, hinc]
+    have hs := u.step_inc ⟨d - 1, hlt⟩
+    rw [hsucc] at hs
+    exact hs.symm
+  · by_cases hQ : j = (topPivotCell u hd1 hfeas).miss
+    · subst hQ
+      rw [zeroPivotTop_coords_miss, hapex, hmiss]
+      have hs := u.step_dec ⟨d - 1, hlt⟩
+      rw [hsucc] at hs
+      omega
+    · rw [zeroPivotTop_coords_other _ _ _ j hP hQ, hapex]
+      have hj1 : j ≠ u.incDir ⟨d - 1, hlt⟩ := by rw [← hinc]; exact hP
+      have hj2 : j ≠ u.miss := by rw [← hmiss]; exact hQ
+      have hs := u.step_same ⟨d - 1, hlt⟩ j hj1 hj2
+      rw [hsucc] at hs
+      exact hs.symm
+
+/-- **Cell-level reverse reciprocity: the two pivots invert one another (other
+direction).**  Applying the facet-`0` cross-chain pivot `zeroPivotCell` to the
+dual top-facet partner `topPivotCell u` reconstructs `u` exactly.  Together with
+`topPivotCell_zeroPivotCell` this establishes that, on the feasible regime,
+`zeroPivotCell` and `topPivotCell` are mutually inverse bijections — a genuine
+two-sided involution, the well-definedness the boundary `adj` requires.  Vertex
+`Fin.last d` is recovered by `zeroPivotTop_topPivotCell`; each lower vertex
+`k < d` is `u.verts k` because `topPivotCell` slid `u`'s chain up one index and
+`zeroPivotCell` slides it back; `incDir` matches by the two mutually-inverse
+cyclic rotations, and `miss` is preserved. -/
+theorem zeroPivotCell_topPivotCell (u : GridSimplex d N) (hd1 : 0 < d)
+    (hfeas : 1 ≤ (u.verts 0).coords (lastIncDir u hd1)) :
+    zeroPivotCell (topPivotCell u hd1 hfeas) hd1
+        (topPivotCell_zeroFeasible u hd1 hfeas) = u := by
+  apply gridSimplex_ext
+  · funext k
+    by_cases hk : k.val < d
+    · rw [zeroPivotCell_verts_of_lt _ hd1 _ k hk, topPivotCell_verts,
+        topPivotVerts_of_pos u hd1 hfeas ⟨k.val + 1, by omega⟩ (by simp)]
+      congr 1
+    · have hklast : k = Fin.last d := by
+        apply Fin.ext; simp only [Fin.val_last]; have := k.isLt; omega
+      rw [hklast, zeroPivotCell_verts_last]
+      exact zeroPivotTop_topPivotCell u hd1 hfeas
+  · funext k
+    show zeroPivotInc (topPivotCell u hd1 hfeas) hd1 k = u.incDir k
+    by_cases hk : k.val + 1 < d
+    · rw [zeroPivotInc_of_lt _ hd1 k hk, topPivotCell_incDir,
+        topPivotInc_of_pos u hd1 ⟨k.val + 1, hk⟩ (by simp)]
+      congr 1
+    · rw [zeroPivotInc_last _ hd1 k hk, topPivotCell_incDir,
+        topPivotInc_eq_lastIncDir u hd1 ⟨0, hd1⟩ rfl]
+      show u.incDir ⟨d - 1, by omega⟩ = u.incDir k
+      congr 1; apply Fin.ext; show d - 1 = k.val; have := k.isLt; omega
+  · rw [zeroPivotCell_miss, topPivotCell_miss]
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -339,3 +339,62 @@ reciprocal-base identity, the incDir rotations are mutual inverses).
    constructions produce).
 2. Total `adj` with geometric none-fibre exactly `{Fin.last d}`; discharge `boundary_face`.
 3. Assemble `SpernerTriangulation`; Phase-2 door-parity induction on `d`; apply `sperner_ndim`.
+
+## Session 2026-07-09 (Session 23, researcher-1) — reverse pivot reciprocity (two-sided involution)
+
+**Mode**: ACT (CONTINUE Phase-1). **Outcome**: PROGRESS — proved the OTHER
+composition of the two cross-facet pivots is the identity, upgrading the partial
+involution to a genuine two-sided involution on the feasible regime. Does NOT close
+the crux (cross-`miss` terminal partner for `base_miss = d` remains). **+3 theorems,
+file 3688→3803 L. 0-sorry, 0-axiom**; `docker-build.sh Proofs.SpernerNDimOQ02` →
+`Built (7.5s)`, 7745 jobs, exit 0 (clean elaboration on first non-SIGBUS run; caught 4
+real errors first — see gotchas). Branch `feature/researcher-1-4-...`.
+
+### What was delivered
+Session 22 (#…) proved `topPivotCell_zeroPivotCell : topPivotCell (zeroPivotCell s) = s`
+(one composition = id). This session proves the DUAL:
+- **`topPivotCell_zeroFeasible`** — feasibility bridge: the facet-`0` pivot is ALWAYS
+  applicable to `topPivotCell u`. Its apex is `u.verts (d-1)`, whose `miss` coord is
+  `base_miss − (d−1) ≥ d − (d−1) = 1` (`miss_coord_at` descends by 1/step +
+  `base_miss_ge_d`). So no side hypothesis is needed — feasibility is automatic.
+- **`zeroPivotTop_topPivotCell`** (crux, mirror of `topPivotBottom_zeroPivotCell`) —
+  the new apex the facet-`0` pivot appends above `topPivotCell u`'s chain reconstructs
+  `u`'s deleted apex `u.verts (Fin.last d)`, coordinate-by-coordinate via `u`'s LAST
+  chain step at `k = ⟨d-1⟩`: `step_inc` at the reversed `lastIncDir`, `step_dec` at
+  `miss`, `step_same` elsewhere.
+- **`zeroPivotCell_topPivotCell`** (capstone) — `zeroPivotCell (topPivotCell u) = u`.
+  With Session 22's forward identity, `zeroPivotCell` and `topPivotCell` are now
+  MUTUALLY INVERSE bijections on the feasible regime — the well-definedness the
+  boundary `adj` needs (each of the two cells filling a shared cross-chain facet maps
+  to the other and back).
+
+### Lean gotchas caught this session (all found by the build, fixed pre-merge)
+- `.incDir` field access on `zeroPivotCell t` is NOT syntactically `zeroPivotInc t hd1`
+  — `rw [zeroPivotInc_of_lt …]` fails ("did not find pattern `zeroPivotInc ?m hd1 k`").
+  Prefix the funext branch with `show zeroPivotInc (topPivotCell u hd1 hfeas) hd1 k =
+  u.incDir k` (defeq) to expose the field, then the `zeroPivotInc_*` rewrites fire.
+- `congr 1` on `u.verts A = u.verts B` / `u.incDir A = u.incDir B` with `A`, `B`
+  DEFEQ (`⟨(Fin.last d).val-1,_⟩` vs `⟨d-1⟩.castSucc`; `⟨(k+1)-1,_⟩` vs `k`) closes the
+  goal OUTRIGHT — a trailing `apply Fin.ext; …` then errors "No goals to be solved".
+  Drop everything after `congr 1` in those cases. (When `A`, `B` are only propositionally
+  equal — `⟨d-1,_⟩` vs `k` under `k+1=d` — keep `congr 1; apply Fin.ext; show d-1=k.val;
+  omega`.)
+- `hinc : (topPivotCell u ..).incDir ⟨0,hd1⟩ = u.incDir ⟨d-1,hlt⟩` typechecks directly as
+  `topPivotInc_eq_lastIncDir u hd1 ⟨0,hd1⟩ rfl` (whose stated type ends in `lastIncDir u
+  hd1`) — Lean accepts by defeq (`lastIncDir = u.incDir ⟨d-1, _⟩`, proof-irrelevant mk).
+- Use `k.castSucc`/`k.succ` (from `k : Fin d`) for the Fin(d+1) vertex indices, NOT a raw
+  `⟨d-1, hlt⟩` — hlt : d-1<d does NOT typecheck as the Fin(d+1) bound; going through the
+  step index `k=⟨d-1,hlt⟩:Fin d` lets `step_inc/dec/same` line up with `hapex` (which uses
+  `k.castSucc`) after a single `rw [hsucc]` (`k.succ = Fin.last d`), no `hcast` needed.
+- `simp only [Fin.val_mk, Fin.val_last]` → `Fin.val_mk` flagged unused by the
+  `unusedSimpArgs` linter (Fin.val_last's normalisation already reduces the mk); drop it.
+
+### Frontier UNCHANGED (genuine blocker — same as sessions 16–22)
+1. **(crux)** Cross-`miss` TERMINAL partner for the infeasible regime `base_miss = d`.
+2. Total `adj` with geometric none-fibre exactly `{Fin.last d}`; discharge `boundary_face`.
+3. Assemble `SpernerTriangulation`; Phase-2 door-parity induction on `d`; apply `sperner_ndim`.
+
+### Next steps
+1. **(crux)** Cross-`miss` terminal partner for `base_miss = d`.
+2. Total `adj` from the now two-sided pivot involution + `gridNeighbor` on interior facets.
+3. Phase-2 parity.


### PR DESCRIPTION
## Summary

Adds the **reverse composition** of the two cross-facet pivots in `SpernerNDimOQ02.lean`, upgrading the partial-involution reciprocity to a genuine **two-sided involution** on the feasible regime.

Session 22 (`topPivotCell_zeroPivotCell`) proved `topPivotCell (zeroPivotCell s) = s` — one composition is the identity. This PR proves the dual:

- **`topPivotCell_zeroFeasible`** — feasibility bridge. The facet-`0` pivot is *always* applicable to `topPivotCell u`: its apex is `u.verts (d-1)`, whose `miss` coordinate is `base_miss − (d−1) ≥ 1` (`miss_coord_at` + `base_miss_ge_d`). No side hypothesis needed.
- **`zeroPivotTop_topPivotCell`** (crux, mirror of `topPivotBottom_zeroPivotCell`) — the new apex the facet-`0` pivot appends above `topPivotCell u`'s chain reconstructs `u`'s deleted apex `u.verts (Fin.last d)`, proved coordinate-by-coordinate from `u`'s last chain step (`step_inc`/`step_dec`/`step_same` at `⟨d-1⟩`).
- **`zeroPivotCell_topPivotCell`** (capstone) — `zeroPivotCell (topPivotCell u) = u`. With Session 22's forward identity, `zeroPivotCell` and `topPivotCell` are now **mutually inverse bijections** on the feasible regime — the well-definedness the boundary `adj` requires (each of the two cells filling a shared cross-chain facet maps to the other and back).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.SpernerNDimOQ02` → **Built (7.5s), 7745 jobs, exit 0**
- **0 sorries, 0 axiom declarations** (new theorems use only `rw`/`omega`/`congr`/structure step-lemmas; no `native_decide`). File 3688→3803 L, +3 theorems.

## Scope / honesty

This completes the involution *pair* on the feasible regime. It does **NOT** close the crux frontier — the cross-`miss` **terminal partner** for the infeasible regime `base_miss = d` remains open, as does the total-`adj` assembly and the Phase-2 door-parity induction. Modest structural increment on a deeply-developed file (Session 23).