### PR TITLE
audit(hilbert-20): fix phantom mainTheorem + overclaimed contributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20720,10 +20720,10 @@
       "result": "clean"
     },
     "hilbert-20": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:02:02Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "hilbert-20-oq-01": {
       "auditCount": 3,

--- a/src/data/proofs/hilbert-20/meta.json
+++ b/src/data/proofs/hilbert-20/meta.json
@@ -36,17 +36,17 @@
       }
     ],
     "originalContributions": [
-      "Dirichlet problem formulation and existence",
-      "Lax-Milgram theorem statement",
-      "Weak formulation framework",
-      "Poisson equation existence",
-      "Lewy's counterexample demonstration"
+      "Dirichlet problem formulation (DirichletProblem definition; harmonicity via the opaque IsHarmonic axiom — existence is not proved)",
+      "Weak-formulation framework: bounded/coercive bilinear forms and bounded functionals (IsBoundedBilinear, IsCoercive, IsBoundedFunctional)",
+      "Energy-functional definition for symmetric Lax-Milgram (EnergyFunctional; the Lax-Milgram theorem itself is described in prose, not stated as a Lean declaration)",
+      "Sobolev space H₀¹ and the weak Poisson problem declared as opaque axioms (H1_zero, WeakPoisson — no existence theorem)",
+      "Lewy's operator declared as an axiom (LewyOperator — non-existence of solutions is discussed in prose, not demonstrated in Lean)"
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 20,
     "axiomCount": 4,
     "lineCount": 244,
-    "assumptions": "4 axioms: IsHarmonic, H1_zero, WeakPoisson, and 1 more. See Lean source for complete statements.",
+    "assumptions": "4 axioms: IsHarmonic, H1_zero, WeakPoisson, LewyOperator. The core PDE results (Lax-Milgram existence, Dirichlet/Poisson solvability, Lewy non-existence) are axiomatized or sketched in prose, not proved in Lean; the sole theorem hilbert_20_status is a trivially-true placeholder conjunction. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
     "definitionCount": 8
@@ -210,10 +210,10 @@
   ],
   "mainTheorems": [
     {
-      "name": "hilbert20_existence",
-      "type": "core",
-      "description": "Solutions to elliptic boundary value problems exist under Hilbert's conditions",
-      "leanType": "EllipticOperator L -> BoundaryData g -> exists u, L u = f and u|_boundary = g"
+      "name": "hilbert_20_status",
+      "type": "summary",
+      "description": "A placeholder status summary asserting the qualified resolution of Hilbert's 20th problem. The statement is a conjunction of four trivially-true existential propositions (∃ _ : Prop, True) and carries no mathematical content; the substantive existence/non-existence results (Lax-Milgram, Dirichlet, Poisson, Lewy) are only sketched via definitions, opaque axioms, and docstrings. No hilbert20_existence theorem exists in the source.",
+      "leanType": "(∃ _ : Prop, True) ∧ (∃ _ : Prop, True) ∧ (∃ _ : Prop, True) ∧ (∃ _ : Prop, True)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: hilbert-20 (Hilbert's Twentieth Problem: Boundary Value Problems)
**Tier**: C — axiomatized scaffold (status/badge/counts all correct)

Counts are accurate (4 axioms `IsHarmonic`/`H1_zero`/`WeakPoisson`/`LewyOperator`, 1 theorem, 8 defs; `status: axiomatized`, `badge: axiom`). The **prose overstates** what is formalized — same pattern as hilbert-4 (#36574) and hilbert-6 (#36606).

## Evidence

- **Phantom mainTheorem**: `mainTheorems[0].name = "hilbert20_existence"` with `leanType "EllipticOperator L -> BoundaryData g -> exists u, L u = f and u|_boundary = g"`. No such declaration exists in `Hilbert20BoundaryValue.lean`. The only theorem is `hilbert_20_status`, a pure True-stub: `(∃ _ : Prop, True) ∧ (∃ _ : Prop, True) ∧ (∃ _ : Prop, True) ∧ (∃ _ : Prop, True)` — proves no mathematical content.
- **No Lax-Milgram declaration**: `section LaxMilgram` contains only an `EnergyFunctional` def. `originalContributions` claimed "Lax-Milgram theorem statement" — there is no statement, only a docstring.
- **Overclaimed existence/demonstration**: "Dirichlet problem ... existence", "Poisson equation existence", "Lewy's counterexample demonstration" — these rest on the opaque axioms `IsHarmonic`/`WeakPoisson`/`LewyOperator`; no existence or non-existence theorem is proved.

## Fix (meta.json prose only — Lean source unchanged)

- `mainTheorems`: replace phantom `hilbert20_existence` with the real `hilbert_20_status`, described honestly as a trivially-true status-summary placeholder; honest `leanType`.
- `originalContributions`: reframe each item to reflect what actually exists (definitions, opaque axioms, energy functional) rather than proved existence/demonstration.
- `assumptions`: name the 4th axiom (`LewyOperator`) and note the sole theorem is a placeholder.
- Tracker bumped (issues-fixed).

---
Discovered during gallery integrity audit.