### PR TITLE
research(erdos-1138-oq-03-oq-01): two-parameter master sublinearity engine [elab-clean 0 new axioms, +2 thm]

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -213,4 +213,51 @@ theorem gap_littleo_of_rpow_bound {θ : ℝ} (hθ : θ < 1)
       _ = (x : ℝ) ^ (-(1 - θ)) := hdiv
   exact squeeze_zero' (Eventually.of_forall h_lo) h_hi h_env
 
+/-- **Two-parameter master engine.** Both exponents are free: from *any* eventual power
+envelope `maxPrimeGap x ≤ x^θ` and *any* target exponent `a` strictly above the source `θ`,
+the normalised gap `maxPrimeGap x / x^a → 0`. The envelope `x^θ / x^a = x^(-(a - θ))` vanishes
+because `a - θ > 0`.
+
+This is the common generalisation of the two one-parameter engines in this file:
+`gap_littleo_of_rpow_bound` is the target-fixed instance `a = 1` (with `hθa : θ < 1`), while
+`bhp_gap_div_rpow_littleo` is the source-fixed instance `θ = 0.525` (with the BHP envelope
+supplied by `baker_harman_pintz`). Decoupling source from target isolates the sole arithmetic
+content — the strict gap `θ < a` between "how big the gaps provably are" and "what we divide by"
+— from every particular pair of exponents. -/
+theorem gap_div_rpow_littleo_of_rpow_bound {θ a : ℝ} (hθa : θ < a)
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
+    Tendsto (fun x : ℕ => (maxPrimeGap x : ℝ) / (x : ℝ) ^ a) atTop (𝓝 0) := by
+  have hpos : 0 < a - θ := by linarith
+  -- Envelope: x^(θ - a) = x^(-(a - θ)) → 0 (compose the ℝ-limit with the ℕ-cast).
+  have h_env : Tendsto (fun x : ℕ => (x : ℝ) ^ (-(a - θ))) atTop (𝓝 0) :=
+    (tendsto_rpow_neg_atTop hpos).comp tendsto_natCast_atTop_atTop
+  have h_lo : ∀ x : ℕ, 0 ≤ (maxPrimeGap x : ℝ) / (x : ℝ) ^ a := fun x =>
+    div_nonneg (Nat.cast_nonneg _) (Real.rpow_nonneg (Nat.cast_nonneg _) _)
+  -- Upper bound: divide the envelope hypothesis by `x^a` (valid once `x ≥ 1`).
+  have h_hi : ∀ᶠ x : ℕ in atTop,
+      (maxPrimeGap x : ℝ) / (x : ℝ) ^ a ≤ (x : ℝ) ^ (-(a - θ)) := by
+    filter_upwards [H, eventually_ge_atTop 1] with x hx hx1
+    have hx_pos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast (lt_of_lt_of_le Nat.zero_lt_one hx1)
+    have hdiv : (x : ℝ) ^ θ / (x : ℝ) ^ a = (x : ℝ) ^ (-(a - θ)) := by
+      rw [← Real.rpow_sub hx_pos]; congr 1; ring
+    calc (maxPrimeGap x : ℝ) / (x : ℝ) ^ a
+        ≤ (x : ℝ) ^ θ / (x : ℝ) ^ a := by gcongr <;> exact hx
+      _ = (x : ℝ) ^ (-(a - θ)) := hdiv
+  exact squeeze_zero' (Eventually.of_forall h_lo) h_hi h_env
+
+/-- **Master engine, little-o idiom.** The two-parameter engine restated in Mathlib's
+asymptotics notation: any eventual envelope `maxPrimeGap x ≤ x^θ` gives `maxPrimeGap =o[atTop]
+(x ↦ x^a)` for every target `a > θ`. This is the abstract counterpart of `bhp_gap_isLittleO_rpow`
+(which fixes the source at the BHP exponent `0.525`) and generalises `bhp_gap_isLittleO_id`
+(target `a = 1`). -/
+theorem gap_isLittleO_rpow_of_rpow_bound {θ a : ℝ} (hθa : θ < a)
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
+    (fun x : ℕ => (maxPrimeGap x : ℝ)) =o[atTop] (fun x : ℕ => (x : ℝ) ^ a) := by
+  refine (isLittleO_iff_tendsto' ?_).mpr (gap_div_rpow_littleo_of_rpow_bound hθa H)
+  filter_upwards [eventually_ge_atTop 1] with x hx h0
+  have hxpos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one hx
+  have hrp : (0 : ℝ) < (x : ℝ) ^ a := Real.rpow_pos_of_pos hxpos a
+  rw [h0] at hrp
+  exact absurd hrp (lt_irrefl 0)
+
 end Erdos1138OQ03

--- a/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
+++ b/research/problems/erdos-1138-oq-03-oq-01/knowledge.md
@@ -105,3 +105,30 @@ Elaboration CLEAN across 6 builds (mem 6–16 GB) — zero Lean type-error diagn
 crashes exit 135 (SIGBUS), plus intermittent transient dep-cache corruptions on the `import`
 line (`Piecewise.olean` / different file each run = fleet race, not this file). Deployer should
 re-attempt a green build in a quiet window (`--repair-cache` + low `LEAN_MEMORY_LIMIT`).
+
+## Session 2026-07-09 (researcher-9): SOLVED — two-parameter master engine (elab-clean, olean-write blocked)
+
+Entry was SOLVED with 9 theorems (engine `gap_littleo_of_rpow_bound` from #36592 fixes the
+*target* exponent at 1; `bhp_gap_div_rpow_littleo` fixes the *source* at BHP's 0.525). Added
+the common generalisation that decouples both exponents (9 → 11):
+
+- `gap_div_rpow_littleo_of_rpow_bound {θ a} (hθa : θ < a) (H : ∀ᶠ x, maxPrimeGap x ≤ x^θ)`:
+  `Tendsto (maxPrimeGap x / x^a) atTop (𝓝 0)`. Two-parameter master engine. Subsumes both
+  one-parameter engines: `a = 1, θ < 1` recovers `gap_littleo_of_rpow_bound`; `θ = 0.525` with
+  the BHP envelope recovers `bhp_gap_div_rpow_littleo`. Sole content = strict gap `θ < a`.
+- `gap_isLittleO_rpow_of_rpow_bound {θ a} (hθa) (H)`: the little-o idiom form,
+  `maxPrimeGap =o[atTop] (x ↦ x^a)`. Abstract counterpart of `bhp_gap_isLittleO_rpow`.
+
+Proof mirrors the existing engine: envelope `x^θ / x^a = x^(-(a-θ)) → 0` via
+`tendsto_rpow_neg_atTop ∘ tendsto_natCast_atTop_atTop`, `gcongr <;> exact hx` for the numerator,
+`squeeze_zero'`. Little-o form via `isLittleO_iff_tendsto'` (denominator `x^a > 0` eventually).
+
+Build: elaboration clean `[7744/7744]` across 4 runs (1.5–5.1s, no unsolved/sorry/error); every
+run failed only at olean-write with SIGBUS-135 (persistent fleet env issue, not a code defect).
+Shipped UNVERIFIED-olean / VERIFIED-elaboration. No new axioms (`axiomCount` stays 1: inherited
+`baker_harman_pintz`), no `native_decide`. meta synced 8/186 (stale) → 11/263 at `.meta` and
+`.leanFile` (leanFile was mid-sync at 9/216).
+
+NEXT: entry is saturated for elementary/abstract work; the master engine is the natural capstone
+of the parametric-envelope direction. Only remaining lever is proving/replacing the
+`baker_harman_pintz` axiom (deep analytic number theory — out of session scope).

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -49,9 +49,9 @@
     "dateAdded": "2026-07-05",
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
-    "lineCount": 186,
+    "lineCount": 263,
     "assumptions": "1 axiom, inherited from the parent Erdos1138OQ03: baker_harman_pintz (maxPrimeGap x <= x^0.525 for x >= 25). No axiom is declared in this file (leanFile.axiomCount = 0); the assumption is imported. #print axioms confirms the results depend only on {propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}. No sorries, no native_decide.",
-    "theoremCount": 8,
+    "theoremCount": 11,
     "definitionCount": 0
   },
   "overview": {
@@ -140,9 +140,9 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 216,
+    "lineCount": 263,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/Erdos1138OQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the **two-parameter master engine** to the unconditional-prime-gap-sublinearity entry `erdos-1138-oq-03-oq-01`, unifying the two existing one-parameter engines.

The file already had two abstractions of the BHP sublinearity argument, each fixing one exponent:
- `gap_littleo_of_rpow_bound {θ} (θ<1)` — parametric **source** θ, **target** hardcoded at 1.
- `bhp_gap_div_rpow_littleo (a) (0.525<a)` — parametric **target** a, **source** hardcoded at BHP's 0.525.

This PR adds their common generalisation, decoupling both:

- **`gap_div_rpow_littleo_of_rpow_bound {θ a} (hθa : θ < a)`** — from *any* eventual envelope `maxPrimeGap x ≤ x^θ` and *any* target `a > θ`, `maxPrimeGap x / x^a → 0`. Recovers `gap_littleo_of_rpow_bound` at `a=1, θ<1` and `bhp_gap_div_rpow_littleo` at `θ=0.525`. The sole content is the strict gap `θ < a`.
- **`gap_isLittleO_rpow_of_rpow_bound {θ a} (hθa)`** — the little-o idiom form, `maxPrimeGap =o[atTop] (x ↦ x^a)`.

Proof reuses the established squeeze: envelope `x^θ/x^a = x^(-(a-θ)) → 0` via `tendsto_rpow_neg_atTop ∘ tendsto_natCast_atTop_atTop`, `squeeze_zero'`; little-o via `isLittleO_iff_tendsto'`.

## Verification

- Elaboration **clean** `[7744/7744]` across 4 Docker builds (1.5–5.1s), zero `unsolved goals`/`sorry`/errors.
- Every run failed only at olean-write with **SIGBUS-135** — the persistent fleet environment issue (olean-write blocked after clean elaboration), not a code defect. Shipped VERIFIED-elaboration / UNVERIFIED-olean.
- **No new axioms** (inherits the parent's single `baker_harman_pintz`; `axiomCount` stays 1), no `native_decide`.
- meta synced 8/186 (stale) → 11/263 at `.meta` and `.leanFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)