### PR TITLE
Enrich Odd-Square Series (basel-problem-oq-09): link direct child resolving OQ-01

### DIFF
--- a/src/data/proofs/basel-problem-oq-09/meta.json
+++ b/src/data/proofs/basel-problem-oq-09/meta.json
@@ -142,7 +142,7 @@
     "openQuestions": [
       {
         "id": "basel-problem-oq-09-oq-01",
-        "question": "Generalize the even/odd parity split to a reusable lemma λ(2m) = ∑ 1/(2k+1)^{2m} = (1 - 2^{-2m}) ζ(2m), deriving λ(4) = π⁴/96 from Mathlib's hasSum_zeta_four with no new analytic input.",
+        "question": "Generalize the even/odd parity split to a reusable lemma λ(2m) = ∑ 1/(2k+1)^{2m} = (1 - 2^{-2m}) ζ(2m), deriving λ(4) = π⁴/96 from Mathlib's hasSum_zeta_four with no new analytic input. (Realized by the child entry basel-problem-oq-09-oq-01, which proves the exponent-uniform lemma and specializes it to λ(4) = π⁴/96.)",
         "significance": "medium"
       },
       {
@@ -157,6 +157,11 @@
       "targetId": "basel-problem",
       "relationship": "extends",
       "description": "Root Basel entry ζ(2) = π²/6; this is the odd-index corollary λ(2) = ∑ 1/(2k+1)² = π²/8."
+    },
+    {
+      "targetId": "basel-problem-oq-09-oq-01",
+      "relationship": "specialized-by — direct child",
+      "description": "Direct descendant that resolves this entry's first open question: it lifts the single-exponent even/odd split to the exponent-uniform lemma λ(2m) = ∑ 1/(2k+1)^{2m} = (1 − 2^{−2m})·ζ(2m), recovering this entry's λ(2) = π²/8 and proving the new value λ(4) = π⁴/96 from Mathlib's hasSum_zeta_four. This page's λ(2) = π²/8 is exactly the m = 1 specialization of that lemma."
     },
     {
       "targetId": "basel-problem-oq-11",
@@ -199,7 +204,7 @@
   "openQuestions": [
     {
       "id": "basel-problem-oq-09-oq-01",
-      "question": "Generalize the even/odd parity split to λ(2m) = ∑ 1/(2k+1)^{2m} = (1 - 2^{-2m}) ζ(2m) and derive λ(4) = π⁴/96 from hasSum_zeta_four.",
+      "question": "Generalize the even/odd parity split to λ(2m) = ∑ 1/(2k+1)^{2m} = (1 - 2^{-2m}) ζ(2m) and derive λ(4) = π⁴/96 from hasSum_zeta_four. (Realized by the child entry basel-problem-oq-09-oq-01.)",
       "significance": "medium"
     },
     {


### PR DESCRIPTION
## Enrichment pass for `basel-problem-oq-09` (The Odd-Square Series ∑ 1/(2k+1)² = π²/8)

This entry was already at-target and defect-free on every scanned dimension (9 fully-populated annotations, complete line coverage, accurate counts 10 thm/1 def/148 lines, all cross-references live, 13 KB — well under caps). Per the size-guardrail SKIP rule I did **not** deepen it. Instead I fixed one genuine, verifiable structural defect.

### The defect: an asymmetric cross-reference
The child entry `basel-problem-oq-09-oq-01` ("Dirichlet Lambda Values: λ(2m) = (1 − 2^{−2m})·ζ(2m)") is the **direct realization of this entry's first open question** — it lifts the single-exponent even/odd split to the exponent-uniform lemma and derives λ(4) = π⁴/96. The child links **back** to oq-09 (`relationship: extends`), but oq-09 did **not** link forward to it.

### Changes
- Add forward `crossReference` from oq-09 → `basel-problem-oq-09-oq-01` (`specialized-by — direct child`), making the parent↔child link bidirectional.
- Note the realization inline in both `openQuestions` occurrences (conclusion + top-level) so OQ-01 no longer reads as purely open when a gallery entry already answers it.

No content deleted; +7/−2 lines. meta.json remains 14 KB (5 crossRefs, both under caps). Gallery JSON validation + search-index checks pass in `pnpm build`.