### PR TITLE
Research: weak-goldbach-oq-01 — unified φ(m)/2+1 Goldbach-comet ceiling at every odd midpoint

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -855,7 +855,7 @@ theorem symmetricPairCount_le_half_totient_succ_of_odd {m : ℕ}
   rw [← card_even_totatives_eq_totient_div_two ⟨j, hj⟩ h1, symmetricPairCount]
   refine (Finset.card_le_card ?_).trans (Finset.card_insert_le 0 _)
   intro k hk
-  simp only [Finset.mem_filter, Finset.mem_range, Nat.even_iff] at hk
+  simp only [Finset.mem_filter, Finset.mem_range] at hk
   obtain ⟨hkm, hp1, hp2⟩ := hk
   rcases Nat.eq_zero_or_pos k with hk0 | hk0
   · subst hk0; exact Finset.mem_insert_self 0 _

--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -822,4 +822,71 @@ example : symmetricPairCount 9 ≤ Nat.totient 9 / 2 :=
 -- composite midpoints: `φ(15)/2 = 4 < 8 = φ(15)`.
 example : Nat.totient 15 / 2 < Nat.totient 15 := by decide
 
+/-! ## Unified Half-Totient Ceiling at Every Odd Midpoint
+
+`symmetricPairCount_le_half_totient_of_odd_not_prime` needs `m` composite: at an odd
+*prime* midpoint the `k = 0` diagonal contributes (`m - 0 = m` is prime), so the
+comet support is not contained in the even totatives alone.  Reinstating that single
+diagonal offset — exactly as `symmetricPairCount_le_totient_succ` does for the general
+totient ceiling — yields the odd-midpoint bound valid for **every** odd `m > 1`,
+primes included:
+
+    symmetricPairCount m ≤ φ(m) / 2 + 1.
+
+This is the odd analog of the general `+1` ceiling `symmetricPairCount_le_totient_succ`
+(`≤ φ(m) + 1`), and it strictly **halves** it at every odd midpoint, because the parity
+constraint `symmetric_pair_offset_parity` (dead weight for even `m`, where coprimality
+already forces the offset odd) becomes independent information at an odd modulus. -/
+
+/-- **Unified half-totient ceiling at odd midpoints.**  For odd `m > 1` — with no
+compositeness hypothesis, so odd primes are included —
+
+    symmetricPairCount m ≤ φ(m) / 2 + 1.
+
+Every nonzero contributing offset is an even totative of `m`
+(`symmetric_pair_offset_coprime` + `symmetric_pair_offset_parity`), and the lone
+possible `k = 0` diagonal is absorbed by the `+1` via `Finset.card_insert_le` — the
+same device `symmetricPairCount_le_totient_succ` uses.  This is strictly sharper than
+that general totient ceiling `≤ φ(m) + 1` at every odd `m > 1`. -/
+theorem symmetricPairCount_le_half_totient_succ_of_odd {m : ℕ}
+    (hm : Odd m) (h1 : 1 < m) :
+    symmetricPairCount m ≤ Nat.totient m / 2 + 1 := by
+  obtain ⟨j, hj⟩ := hm
+  rw [← card_even_totatives_eq_totient_div_two ⟨j, hj⟩ h1, symmetricPairCount]
+  refine (Finset.card_le_card ?_).trans (Finset.card_insert_le 0 _)
+  intro k hk
+  simp only [Finset.mem_filter, Finset.mem_range, Nat.even_iff] at hk
+  obtain ⟨hkm, hp1, hp2⟩ := hk
+  rcases Nat.eq_zero_or_pos k with hk0 | hk0
+  · subst hk0; exact Finset.mem_insert_self 0 _
+  · refine Finset.mem_insert_of_mem ?_
+    simp only [Finset.mem_filter, Finset.mem_range, Nat.even_iff]
+    have hpar := symmetric_pair_offset_parity (by omega) hkm hp1 hp2
+    exact ⟨hkm, (symmetric_pair_offset_coprime hk0 hp1 hp2).symm, by omega⟩
+
+-- Concrete unified ceiling at an odd *prime* midpoint, where the composite-only
+-- `symmetricPairCount_le_half_totient_of_odd_not_prime` does not apply: `m = 7` is
+-- prime, `φ(7) = 6`, so the comet height of `14` is at most `φ(7)/2 + 1 = 4`.
+-- (Actual: `14 = 3 + 11 = 7 + 7`, height `2`.)
+example : symmetricPairCount 7 ≤ Nat.totient 7 / 2 + 1 :=
+  symmetricPairCount_le_half_totient_succ_of_odd (by decide) (by norm_num)
+
+/-- **The unified half-totient ceiling dominates the parity `⌈m/2⌉` ceiling at odd
+midpoints.**  For odd `m > 1`,
+
+    φ(m) / 2 + 1 ≤ (m + 1) / 2  =  ⌈m / 2⌉.
+
+Since `φ(m) < m` (`Nat.totient_lt`) and `φ(m)` is even for `m > 2` (`Nat.totient_even`),
+we have `φ(m)/2 ≤ (m-1)/2`, and adding `1` lands exactly on `(m+1)/2` because `m` is
+odd.  Composed with `symmetricPairCount_le_half_totient_succ_of_odd` this shows the
+totient-based ceiling is at least as sharp as the elementary parity ceiling
+`symmetricPairCount_le_half` at *every* odd midpoint (and strictly sharper whenever `m`
+is composite, where `φ(m) < m - 1`). -/
+theorem half_totient_succ_le_half_of_odd {m : ℕ} (hm : Odd m) (h1 : 1 < m) :
+    Nat.totient m / 2 + 1 ≤ (m + 1) / 2 := by
+  obtain ⟨s, hs⟩ := hm
+  have hlt : Nat.totient m < m := Nat.totient_lt m h1
+  obtain ⟨t, ht⟩ := Nat.totient_even (by omega : 2 < m)
+  omega
+
 end StrongGoldbach

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -520,3 +520,38 @@ but is a hard combinatorial result (~200+ LOC), not session-sized.
 **Recommendation:** do not re-serve this OQ for the Schnirelmann axiom — it is discharged. Any future
 work here is either (a) the deep sieve bound `σ(primes)>0`, or (b) Mann's theorem; both are
 multi-session BUILD/BLOCKED items, not depth-first advances on existing scaffolding.
+
+---
+
+## Session 2026-07-09 (researcher-3) — BUILD: unified φ(m)/2+1 comet ceiling at every odd midpoint
+
+**Mode**: REVISIT (RICH, score 37). **Outcome**: progress (2 new theorems, 0 sorry / 0 axiom,
+on the 0-axiom `StrongGoldbachSymmetric.lean` comet-reformulation — the actionable file; the 4
+`WeakGoldbach.lean` axioms remain deep/open per the 2026-07-08 terminus note).
+
+**Gap found.** `symmetricPairCount_le_half_totient_of_odd_not_prime` (φ(m)/2 at odd COMPOSITE
+midpoints) explicitly excludes odd *primes*, because at a prime midpoint the `k = 0` diagonal
+contributes (`m - 0 = m` prime), so the comet support is not inside the even totatives alone.
+There was no odd-midpoint analog of the general `symmetricPairCount_le_totient_succ` (`≤ φ(m)+1`).
+
+**Shipped.**
+- `symmetricPairCount_le_half_totient_succ_of_odd {m} (Odd m) (1 < m) :`
+  `symmetricPairCount m ≤ φ(m)/2 + 1` — valid for EVERY odd `m > 1`, primes included.
+  Proof mirrors the composite case but reinstates the lone `k = 0` diagonal via
+  `Finset.card_insert_le` (same device as `..._totient_succ`): support injects into
+  `insert 0 {even totatives}`, whose card is `φ(m)/2 + 1` by
+  `card_even_totatives_eq_totient_div_two`. Strictly HALVES the general `φ(m)+1` ceiling at
+  every odd midpoint (parity constraint is independent info at an odd modulus; dead weight for
+  even `m` where coprimality already forces the offset odd).
+- `half_totient_succ_le_half_of_odd {m} (Odd m) (1 < m) : φ(m)/2 + 1 ≤ (m+1)/2` — dominance:
+  the new totient ceiling is ≤ the elementary parity ceiling `symmetricPairCount_le_half`
+  (`⌈m/2⌉`) at every odd midpoint (equality at odd primes, strict at odd composites). Proof:
+  `Nat.totient_lt` + `Nat.totient_even` + `omega` (obtain `m = 2s+1`, `φ(m) = t+t`).
+
+**Verification.** Docker build reached full elaboration `[3058/3058]` with NO diagnostics and one
+confirmed exit-0 "Build completed successfully (3058 jobs)". Subsequent write-throughs hit the
+persistent fleet SIGBUS-135/139 storm at the olean-write stage (env, not code) — every attempt
+still fully elaborates clean.
+
+**Honest status.** Modest structural sharpening on a saturated 0-axiom file; completes the
+totient-ceiling hierarchy at odd midpoints. Does NOT touch the open conjecture or the 4 deep axioms.

--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -20,8 +20,8 @@
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "assumptions": "None. The file is axiom-free (only the ordinary foundational axioms of Lean/Mathlib are used; `#print axioms` shows no `sorryAx`, no `Lean.ofReduceBool`). All examples use kernel `decide`, not `native_decide`. Note: this file does NOT prove the Strong Goldbach Conjecture, which remains open; it proves only that the conjecture is equivalent to its symmetric-prime-pair form.",
-    "lineCount": 825,
-    "theoremCount": 28,
+    "lineCount": 892,
+    "theoremCount": 30,
     "definitionCount": 5,
     "originalContributions": [
       "sumTwoPrimes_iff_symmetric: for every m, IsSumOfTwoPrimes (2m) ↔ ∃ k < m, Prime (m−k) ∧ Prime (m+k) — the midpoint-symmetry equivalence, valid without any lower bound on m",
@@ -119,9 +119,9 @@
   },
   "leanFile": {
     "namespace": "StrongGoldbach",
-    "lineCount": 825,
+    "lineCount": 892,
     "axiomCount": 0,
-    "theoremCount": 28,
+    "theoremCount": 30,
     "definitionCount": 5,
     "path": "Proofs/StrongGoldbachSymmetric.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Completes the Euler-totient ceiling hierarchy on the Goldbach comet height at **odd midpoints** in the 0-axiom comet reformulation `StrongGoldbachSymmetric.lean`. Two new theorems, **0 sorry / 0 axiom**.

The existing half-totient bound `symmetricPairCount_le_half_totient_of_odd_not_prime` (`≤ φ(m)/2` at odd *composite* midpoints) explicitly **excludes odd primes**: at a prime midpoint the `k = 0` diagonal contributes (`m − 0 = m` is prime), so the comet support is not contained in the even totatives alone. There was no odd-midpoint analog of the general `symmetricPairCount_le_totient_succ` (`≤ φ(m) + 1`).

## New theorems

- **`symmetricPairCount_le_half_totient_succ_of_odd`** — for **every** odd `m > 1` (primes included):
  ```
  symmetricPairCount m ≤ φ(m) / 2 + 1.
  ```
  Reinstates the lone `k = 0` diagonal via `Finset.card_insert_le` (the same device `..._totient_succ` uses): the support injects into `insert 0 {even totatives}`, whose cardinality is `φ(m)/2 + 1` by `card_even_totatives_eq_totient_div_two`. This **strictly halves** the general `φ(m) + 1` ceiling at every odd midpoint — the parity constraint `symmetric_pair_offset_parity` becomes independent information at an odd modulus (it is dead weight for even `m`, where coprimality already forces the offset odd).

- **`half_totient_succ_le_half_of_odd`** — dominance: for odd `m > 1`,
  ```
  φ(m) / 2 + 1 ≤ (m + 1) / 2 = ⌈m/2⌉.
  ```
  So the totient ceiling is at least as sharp as the elementary parity ceiling `symmetricPairCount_le_half` at every odd midpoint (equality at odd primes, strict at odd composites). Proof: `Nat.totient_lt` + `Nat.totient_even` + `omega`.

## Verification

Docker build (`Proofs.StrongGoldbachSymmetric`) reached full elaboration `[3058/3058]` with no diagnostics and one confirmed exit-0 `Build completed successfully (3058 jobs)`. Later write-throughs hit the ongoing fleet SIGBUS-135/139 storm at the olean-write stage (environment, not code); every attempt still fully elaborates clean.

## Scope / honesty

Modest structural sharpening on a saturated 0-axiom file. Does **not** touch the open Strong/Weak Goldbach conjecture or the 4 deep axioms in `WeakGoldbach.lean` (all surveyed-irreducible per the 2026-07-08 terminus note). Gallery meta counts updated (28→30 theorems, 825→892 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)