### PR TITLE
Fix dead cross-reference in amgm-inequality-oq-02-oq-02-oq-05

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -112,7 +112,7 @@
   "crossReferences": [
     "amgm-inequality-oq-02-oq-02",
     "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
-    "newton-power-sum-identities",
+    "newton-power-sum-identities-oq-01",
     "descartes-rule-of-signs"
   ],
   "references": [


### PR DESCRIPTION
## Fix

Repoint the dead `crossReferences` entry `newton-power-sum-identities` to the canonical existing entry `newton-power-sum-identities-oq-01`.

## Evidence

**Before**: `src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json` listed `"newton-power-sum-identities"` in `crossReferences`, but no `src/data/proofs/newton-power-sum-identities/` directory exists — a gallery-wide scan flagged it as the sole dead cross-reference across all 4795 entries.

**After**: Points to `newton-power-sum-identities-oq-01` — the shallowest/canonical entry in that family, titled *"Newton's Identities in Low Degree: Power Sums from Elementary Symmetric Polynomials"*, exactly the intended reference target. Post-fix scan reports 0 dead cross-references.

JSON validated; gallery enrichment + search-index build steps pass (the `tsc: command not found` build failure is a pre-existing environment issue unrelated to this JSON edit).

---
Automated fix by lean-mechanic agent.