### PR TITLE
audit(parallel-postulate-independence): fix fabricated mainTheorem leanType

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23323,9 +23323,9 @@
     },
     "parallel-postulate-independence": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-03T22:57:15Z",
-      "result": "clean"
+      "auditCount": 6,
+      "lastAudited": "2026-07-10T01:32:08Z",
+      "result": "issues-fixed"
     },
     "parallel-postulate-independence-oq-02": {
       "agentId": "auditor-agent",

--- a/src/data/proofs/parallel-postulate-independence/meta.json
+++ b/src/data/proofs/parallel-postulate-independence/meta.json
@@ -201,8 +201,8 @@
     {
       "name": "parallel_postulate_independent",
       "type": "core",
-      "description": "The parallel postulate is independent of the other Euclidean axioms",
-      "leanType": "Consistent (EuclidAxioms without P5) -> not (Provable (EuclidAxioms without P5) P5)"
+      "description": "The parallel postulate is independent: a model (Euclidean) satisfies it and a countermodel (Poincaré disk) refutes it, so it cannot be derived from the shared axioms",
+      "leanType": "(∃ G : IncidenceGeometry, SatisfiesParallelPostulate G) ∧ (∃ G : IncidenceGeometry, ¬SatisfiesParallelPostulate G)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Auditor finding

The gallery entry `parallel-postulate-independence` (Wiedijk #12) declared a **fabricated `mainTheorems[0].leanType`**:

```
Consistent (EuclidAxioms without P5) -> not (Provable (EuclidAxioms without P5) P5)
```

No `Consistent`, `Provable`, `EuclidAxioms`, or `P5` predicate exists anywhere in `Proofs/ParallelPostulateIndependence.lean`. That signature implies a proof-theoretic soundness formalization that was never written. The **actual** type of `parallel_postulate_independent` is a two-model existence conjunction:

```lean
(∃ G : IncidenceGeometry, SatisfiesParallelPostulate G) ∧
(∃ G : IncidenceGeometry, ¬SatisfiesParallelPostulate G)
```

This PR corrects the `leanType` and `description` to match the real declaration. Same phantom-leanType pattern as #36610 / #36606.

## Rest of entry: CLEAN ✅

Verified against source:
- **Counts exact**: 5 axioms, 3 theorems, 7 defs, 312 lines, 0 sorries — all match `meta.json`.
- **Axiom integrity**: the 6 `: True` structure fields carry no assumptions, so `axiomCount: 5` is correct (no undercount). `status: axiomatized` + `badge: axiom` is the honest label for this Tier-C model-theoretic scaffold.
- **Genuine content**: the key lemma `hyperbolic_contradicts_parallel_postulate` is fully proved in Lean (uniqueness contradiction), matching the `proofStrategy` claim.
- **assumptions field** lists all 5 axioms by exact name — accurate.

Prose-only metadata fix; no Lean source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)