### PR TITLE
Fix sections-past-EOF in 4 gallery entries (structural metadata repair)

### DIFF
--- a/src/data/proofs/erdos-1002/meta.json
+++ b/src/data/proofs/erdos-1002/meta.json
@@ -120,14 +120,6 @@
       "startLine": 169,
       "endLine": 183,
       "mathContext": "Weyl: $\\{\\alpha k\\}$ equidistributed for irrational $\\alpha$, so $S(\\alpha,n) = o(n)$. For rational $\\alpha = p/q$: $\\{\\alpha k\\}$ is periodic with period $q$, giving exact closed forms."
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "Complete formalization: 7 axioms, 0 sorries, 2 theorems; main conjecture OPEN (mathematical gap, not formalization gap)",
-      "startLine": 185,
-      "endLine": 189,
-      "mathContext": "7 axioms encoding Kesten's theorem, Weyl equidistribution, and the main conjecture. 2 proved theorems: $f(\\alpha,n) = f(\\alpha,0,n)$ and rational periodicity. The open mathematical problem cannot be resolved by formal methods alone."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/meta.json
@@ -144,32 +144,32 @@
     {
       "id": "two-variable-solver",
       "title": "Two-Variable Constructive Solver",
-      "startLine": 44,
-      "endLine": 72,
+      "startLine": 34,
+      "endLine": 62,
       "summary": "bezoutX, bezoutY (explicit solution components from the Bézout cofactors) and bezout_solve_spec (their correctness when gcd a b ∣ c), plus the existence corollary bezout_two_exists.",
       "mathContext": "Int.gcd_eq_gcd_ab gives a·gcdA + b·gcdB = gcd a b; scaling by c/gcd and cancelling with Int.mul_ediv_cancel' yields a·x + b·y = c."
     },
     {
       "id": "vector-gcd",
       "title": "GCD of a Coefficient Vector",
-      "startLine": 74,
-      "endLine": 86,
+      "startLine": 63,
+      "endLine": 71,
       "summary": "vecGcd folds Int.gcd over a : Fin n → ℤ: vecGcd 0 _ = 0 and vecGcd (n+1) a = gcd (a 0) (vecGcd n (tail a)).",
       "mathContext": "A computable gcd of the coefficients matching the recursive structure of the solver."
     },
     {
       "id": "n-variable-solver",
       "title": "The n-Variable Constructive Solver",
-      "startLine": 88,
-      "endLine": 135,
+      "startLine": 72,
+      "endLine": 120,
       "summary": "exists_vec_combo: by recursion on n, builds an explicit x with ∑ aᵢxᵢ = c whenever vecGcd n a ∣ c. linear_solvable_of_gcd_dvd packages the existence statement.",
       "mathContext": "Head/tail recursion: solve a₀·x₀ + d·t = c with the two-variable solver (d = gcd of tail), then recurse to realise d·t over the tail; Fin.cons / Fin.sum_univ_succ assemble the witness."
     },
     {
       "id": "sanity-checks",
       "title": "Worked Instances",
-      "startLine": 137,
-      "endLine": 148,
+      "startLine": 121,
+      "endLine": 131,
       "summary": "3x + 5y = 1 and 6x + 4y = 10 are produced by the solver, demonstrating computability.",
       "mathContext": "gcd 3 5 = 1 ∣ 1 and gcd 6 4 = 2 ∣ 10, so each is solvable and the solver returns a witness."
     }

--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -150,7 +150,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 331,
-      "endLine": 371,
+      "endLine": 362,
       "summary": "Documentation block recapping solved cases (ℚ, imaginary quadratic) vs open cases (real quadratic, general). Lists #check statements for key definitions.",
       "mathContext": "The file's genuine Lean content comprises three machine-checked results: (1) `cyclotomic_galois_comm` proving $\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q})$ is abelian via the `autEquivPow` isomorphism to $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, (2) `cyclotomic_degree` proving $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\varphi(n)$ via `IsCyclotomicExtension.finrank`, and (3) `cyclotomic_irreducible` proving $\\Phi_n$ is irreducible over $\\mathbb{Z}$. All other results -- Kronecker-Weber, CM theory, Artin reciprocity, Stark conjectures, and the general Hilbert 12th problem -- are formulated as `Prop := True` placeholders whose deep proofs lie beyond current Mathlib infrastructure."
     }

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -118,15 +118,15 @@
       "title": "Part II: Irreducibility over ℚ (via Gauss's Lemma)",
       "summary": "The technical core: `f_no_int_root` (no integer root, since $X^4-10X^2+1$ has none in $\\mathbb{Z}$) feeds `irred_f`, proving $X^4-10X^2+1$ irreducible over $\\mathbb{Q}$ by ruling out both linear factors (Gauss's lemma / rational root test) and a factorization into two monic quadratics.",
       "startLine": 107,
-      "endLine": 356,
+      "endLine": 308,
       "mathContext": "Irreducibility over $\\mathbb{Q}$: no rational roots (Gauss) and no $\\mathbb{Q}$-quadratic split, so the quartic is irreducible."
     },
     {
       "id": "part3-consequences",
       "title": "Part III: Consequences of the Minimal Polynomial",
       "summary": "Draws the conclusions: `minpoly_sqrt2_plus_sqrt3` (the minimal polynomial is exactly $X^4-10X^2+1$, from monic + irreducible + root), `adjoin_sqrt2_plus_sqrt3_finrank` ($[\\mathbb{Q}(\\sqrt2+\\sqrt3):\\mathbb{Q}]=4$), and `sqrt2_plus_sqrt3_irrational` ($\\sqrt2+\\sqrt3\\notin\\mathbb{Q}$, since a rational would have degree 1).",
-      "startLine": 357,
-      "endLine": 403,
+      "startLine": 309,
+      "endLine": 350,
       "mathContext": "Minimal polynomial degree 4 $\\Rightarrow [\\mathbb{Q}(\\sqrt2+\\sqrt3):\\mathbb{Q}]=4 \\Rightarrow \\sqrt2+\\sqrt3$ irrational."
     }
   ],


### PR DESCRIPTION
## Structural metadata repair — `sections` ranges past EOF

A pool-wide scan (single-file entries, excluding `additionalFiles` multifile cases) found **4** gallery entries whose `meta.json` `sections` ranges extend past the actual Lean file's `lineCount`. The Lean files had been compressed/edited but the section maps were never resynced, leaving phantom sections and endLines beyond the file. Each was remapped to its true, header-aligned range verified against the current source.

| Entry | File lines | Defect | Fix |
|---|---|---|---|
| `hilbert-10-oq-04-oq-03-oq-01` | 131 | all 4 sections shifted ~10–16 lines; last `[137,148]` entirely past EOF | remapped to header positions `34 / 63 / 72 / 121` → `[34,62] [63,71] [72,120] [121,131]` |
| `sqrt2-plus-sqrt3-irrational-oq-03` | 350 | Part II `[107,356]` and Part III `[357,403]` past EOF | `[107,308]` + `[309,350]` (Part III header at 309) |
| `kroneckers-jugendtraum` | 362 | last Summary `[331,371]` over by 9 | clamp to `[331,362]` |
| `erdos-1002` | 183 | phantom Summary `[185,189]` entirely past the 183-line file | dropped (content already in conclusion + "Partial Results" section) |

### Verification
Each fix checked so every section `endLine ≤ lineCount` and section starts align to actual `/-! ##` / `Part` headers in the source. Metadata-only; JSON validated; gallery data build (enrichment + search-index) passes. Diffs are line-number-only (plus one dropped phantom section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)