### PR TITLE
Fix: sync BallotProblemOQ02OQ05 additionalFile metadata to source

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02/meta.json
@@ -279,12 +279,12 @@
     "additionalFiles": [
       {
         "path": "Proofs/BallotProblemOQ02OQ05.lean",
-        "lineCount": 283,
-        "theorems": 5,
+        "lineCount": 357,
+        "theorems": 6,
         "definitions": 7,
         "axioms": 1,
-        "sorries": 4,
-        "description": "OQ-05: Donsker's functional CLT statement layer connecting the discrete ballot problem to its continuous-time Brownian-motion shadow. Defines the interpolated rescaled random walk S_n*(t), an ad hoc weak-convergence predicate WeakConvergesInC01 (Mathlib v4.26.0 lacks Polish structure on C([0,1],ℝ)), and axiomatizes donsker_fclt (Wiedijk #45). Discrete reflection identity + first-passage / Sparre-Andersen / arcsine pipeline is staged across S3-S7 (4 acknowledged sorries scaffolding R4-sub/R5/LOW/R6)."
+        "sorries": 2,
+        "description": "OQ-05: Donsker's functional CLT statement layer connecting the discrete ballot problem to its continuous-time Brownian-motion shadow. Defines the interpolated rescaled random walk S_n*(t), an ad hoc weak-convergence predicate WeakConvergesInC01 (Mathlib v4.26.0 lacks Polish structure on C([0,1],ℝ)), and axiomatizes donsker_fclt (Wiedijk #45). Discrete reflection identity + first-passage / Sparre-Andersen / arcsine pipeline is staged across S3-S7 (R4/R5 now proved; 2 acknowledged sorries scaffolding LOW/R6)."
       }
     ]
   },


### PR DESCRIPTION
## Fix

The `BallotProblemOQ02OQ05.lean` additionalFile metadata block in `ballot-problem-oq-02/meta.json` was stale after the file was updated (R4/R5 lemmas proved, file grew). Synced its counts to the current source.

## Evidence

Comment-stripped scan of `proofs/Proofs/BallotProblemOQ02OQ05.lean`:

| Field | meta (before) | source (after) |
|-------|---------------|----------------|
| `sorries` | 4 | **2** (tactic `sorry` at lines 334, 353) |
| `theorems` | 5 | **6** |
| `lineCount` | 283 | **357** |
| `definitions` | 7 | 7 (unchanged) |
| `axioms` | 1 | 1 (unchanged) |

The file's own docstring confirms: "R4 (`reflectAt_involutive`) and R5 (`partialSumBool_reflectAt_endpoint`) are now proved; 2 `sorry`s remain". Description text updated from "4 acknowledged sorries scaffolding R4-sub/R5/LOW/R6" to "R4/R5 now proved; 2 acknowledged sorries scaffolding LOW/R6".

Primary gallery file (`BallotProblemOQ02.lean`) is unaffected — it remains 0-sorry; only the research companion block was stale.

`pnpm build` gallery-data + search-index checks pass. (Unrelated pre-existing `tsc: command not found` env failure at the end is not caused by this change.)

---
Automated fix by lean-mechanic agent.