### PR TITLE
audit(hilbert-19): fix phantom mainTheorem name + fabricated leanType

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20708,10 +20708,10 @@
       "issues": []
     },
     "hilbert-19": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:02:38Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T01:37:20Z",
+      "result": "issues-fixed"
     },
     "hilbert-19-oq-03": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/hilbert-19/meta.json
+++ b/src/data/proofs/hilbert-19/meta.json
@@ -212,10 +212,10 @@
   ],
   "mainTheorems": [
     {
-      "name": "de_giorgi_nash",
+      "name": "hilbert19_regularity",
       "type": "core",
-      "description": "Solutions of elliptic variational problems are analytic",
-      "leanType": "EllipticVariational F -> minimizer u -> Analytic u"
+      "description": "Minimizers of smooth, uniformly-elliptic variational problems are C^infinity smooth; reduces to the schauder_estimates axiom. Analyticity of analytic data is a separate axiom (hilbert19_analytic_regularity).",
+      "leanType": "IsUniformlyElliptic L 1 -> HasSmoothCoefficients L -> SatisfiesEulerLagrange L u -> ContDiff ℝ ⊤ u"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: hilbert-19 (Hilbert's Nineteenth Problem)
**Problem**: The `mainTheorems` block named a declaration and leanType that do not exist in the Lean source, and overstated the result as "analytic".

## Evidence

**meta.json claimed** (`mainTheorems[0]`):
- name: `de_giorgi_nash` — **no such declaration** in `Hilbert19Regularity.lean`
- leanType: `EllipticVariational F -> minimizer u -> Analytic u` — none of `EllipticVariational`, `minimizer`, or `Analytic` exist in the file
- description: "Solutions of elliptic variational problems are analytic"

**Lean source shows**: The actual headline theorem is `hilbert19_regularity` (line 194), whose type is
`IsUniformlyElliptic L 1 → HasSmoothCoefficients L → SatisfiesEulerLagrange L u → ContDiff ℝ ⊤ u`
and whose proof reduces to the `schauder_estimates` axiom. It concludes **C^∞ smoothness**, not analyticity. Analyticity is a *separate* axiom `hilbert19_analytic_regularity`, and even there `HasAnalyticCoefficients` is defined as `HasSmoothCoefficients` (line 169) with the axiom concluding `ContDiff` (line 206).

## Fix

Replaced the phantom `mainTheorems` entry with the real theorem `hilbert19_regularity`, an accurate leanType, and a description that scopes the result to C^∞ smoothness via the `schauder_estimates` axiom (noting analyticity is a separate axiom).

## Verified correct (no change)
- axiomCount 6 ✓ (deGiorgiNashMoser_holder_regularity, schauder_estimates, hilbert19_analytic_regularity, caccioppoli_inequality, deGiorgi_oscillation_decay, minimal_surface_singularities_exist)
- theoremCount 8 ✓, definitionCount 12 ✓, sorries 0 ✓
- status `axiomatized` / badge `axiom` ✓; all 6 axioms disclosed in `assumptions`

---
Discovered during gallery integrity audit.