### PR TITLE
Enrich Newton's Inequality: fix dead cross-reference

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -112,7 +112,7 @@
   "crossReferences": [
     "amgm-inequality-oq-02-oq-02",
     "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
-    "newton-power-sum-identities",
+    "newton-power-sum-identities-oq-01",
     "descartes-rule-of-signs"
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass — structural defect fix

`src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json` ("Newton's Inequality via Real-Rootedness") carried a **dead cross-reference**: `crossReferences` listed the slug `newton-power-sum-identities`, which resolves to no gallery entry — the Newton power-sum family is slugged with an `-oq-01` suffix.

**Fix:** repoint to `newton-power-sum-identities-oq-01` ("Newton's Identities in Low Degree: Power Sums from Elementary Symmetric Polynomials"), the canonical family root and the natural target — Newton's inequalities are relations among exactly those power sums / elementary symmetric polynomials.

### Verification
- Gallery-wide dead-crossref scan: **0 remaining** after this fix (was the only defect in 4410 entries).
- `pnpm build` search-index + loading-facts validators pass; edited `meta.json` parses clean.
- Single-line JSON change; no content deleted.