### PR TITLE
audit(hilbert-16): fix axiom-masking in originalContributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20636,10 +20636,10 @@
       "issues": []
     },
     "hilbert-16": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:02:38Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T01:39:46Z",
+      "result": "issues-fixed"
     },
     "hilbert-17": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/hilbert-16/meta.json
+++ b/src/data/proofs/hilbert-16/meta.json
@@ -18,9 +18,9 @@
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [
-      "Definition of limit cycles",
-      "Proof that linear systems have no limit cycles",
-      "Statement of the Hilbert 16th problem"
+      "Definition of limit cycles and the Hilbert number H(n)",
+      "Proof that linear vector-field components have polynomial total degree <= 1 (linear_poly_degree_le_one); the H(1)=0 no-limit-cycles result itself is axiomatized (linear_no_limit_cycles_axiom, H1_eq_zero_axiom)",
+      "Statement of the Hilbert 16th problem, with finiteness (Ecalle-Ilyashenko), lower bounds (H(2)>=4, H(3)>=13), and Poincare-Bendixson axiomatized"
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 16,


### PR DESCRIPTION
## Integrity Issue

**Proof**: hilbert-16 (Hilbert's 16th Problem — Limit Cycles)
**Problem**: `originalContributions` claimed "Proof that linear systems have no limit cycles", but that result is **axiomatized**, not proved.

## Evidence

**meta.json claimed** (`originalContributions[1]`): "Proof that linear systems have no limit cycles"

**Lean source shows**:
- `linear_no_limit_cycles` (Hilbert16.lean:287) `:= linear_no_limit_cycles_axiom L` — restates an axiom.
- `H1_eq_zero` (:309) `:= H1_eq_zero_axiom` — restates an axiom.
- The **only** genuinely proved nontrivial theorem is `linear_poly_degree_le_one` (:247), a real `MvPolynomial` total-degree bound.

Calling an axiom-backed restatement a "Proof" is the axiom-masking failure mode.

## Fix

Rewrote `originalContributions` to (a) credit the genuine proof `linear_poly_degree_le_one`, (b) state plainly that the H(1)=0 / no-limit-cycles result is axiomatized, and (c) note finiteness / lower bounds / Poincaré-Bendixson are axiomatized. `proofStrategy` and `keyInsights` were already honest (they say "axiomatized" throughout) and are unchanged.

## Verified correct (no change)
- axiomCount 9 ✓, theoremCount 11 ✓, definitionCount 26 ✓, sorries 0 ✓
- status `axiomatized` / badge `axiom` ✓ (open conjecture, correctly flagged)

---
Discovered during gallery integrity audit.