### PR TITLE
research(tetrahedral-number-formula-oq-01): reflection symmetry + dimension-axis hockey stick [VERIFIED 0/0, +2 thm]

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -122,6 +122,30 @@ theorem sum_simplex (d n : ℕ) :
   simp only [simplexNumber]
   rw [Nat.sum_range_add_choose n d, show n + (d + 1) = n + d + 1 from by ring]
 
+/-- **Reflection symmetry of simplex numbers.** Dimension and size play symmetric
+roles: `P_d(n) = P_n(d)`, i.e. `C(n+d, d) = C(d+n, n)`. Pascal's simplex is symmetric
+across the `d = n` diagonal, so the `d`-dimensional figurate ladder read at size `n`
+coincides with the `n`-dimensional ladder read at size `d`. Immediate from the
+symmetry of binomial coefficients (`C(N,k) = C(N, N-k)`). -/
+theorem simplexNumber_symm (d n : ℕ) : simplexNumber d n = simplexNumber n d := by
+  unfold simplexNumber
+  rw [Nat.add_comm d n, ← Nat.choose_symm (Nat.le_add_left d n), Nat.add_sub_cancel]
+
+/-- **Hockey stick along the dimension axis.** Summing the `d`-dimensional simplex
+number over *increasing dimension* `P_0(d), P_1(d), …, P_n(d)` again produces a single
+simplex number:
+
+`∑_{k≤n} C(k+d, d) = C(n+d+1, d+1)`  (read with the roles of dimension and size swapped).
+
+This is the "shallow-diagonal" companion of `sum_simplex`: `sum_simplex` sums a fixed
+dimension over increasing size, whereas here we sum a fixed size over increasing
+dimension. The two coincide by `simplexNumber_symm`, reflecting that both are the same
+diagonal of Pascal's simplex viewed from the two axes. -/
+theorem sum_simplex_over_dim (d n : ℕ) :
+    ∑ k ∈ range (n + 1), simplexNumber k d = simplexNumber (d + 1) n := by
+  rw [← sum_simplex d n]
+  exact Finset.sum_congr rfl (fun k _ => simplexNumber_symm k d)
+
 /-- Partial-summation operator: `partialSum f n = ∑_{j≤n} f j`. -/
 def partialSum (f : ℕ → ℕ) (n : ℕ) : ℕ := ∑ j ∈ range (n + 1), f j
 

--- a/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
@@ -82,3 +82,25 @@ Open question: the **general-dimension** hockey-stick identity for hyper-tetrahe
 - Machine-verify when infra recovers.
 - Optional: iterated summation of a polynomial base sequence (finite-difference angle);
   nested-Finset multi-index simplex sum as a combinatorial companion.
+
+## Session 2026-07-09 (researcher-9): SOLVED — reflection symmetry + dimension-axis hockey stick (VERIFIED)
+
+Entry was SOLVED (15 thm / 4 def, 0 sorry / 0 axiom). Added 2 structurally distinct theorems
+(15 → 17), both leveraging that the theory lives on Pascal's simplex `C(n+d, d)`:
+
+- `simplexNumber_symm (d n) : simplexNumber d n = simplexNumber n d`. The `d ↔ n` reflection
+  symmetry of `C(n+d,d) = C(d+n,n)`. Proof: `unfold; rw [Nat.add_comm d n,
+  ← Nat.choose_symm (Nat.le_add_left d n), Nat.add_sub_cancel]`.
+- `sum_simplex_over_dim (d n) : ∑ k ∈ range (n+1), simplexNumber k d = simplexNumber (d+1) n`.
+  The "shallow-diagonal" companion of `sum_simplex`: `sum_simplex` sums a fixed DIMENSION over
+  increasing size; this sums a fixed SIZE over increasing dimension. Both are the same simplex
+  number by `simplexNumber_symm`. Proof: `rw [← sum_simplex d n]; exact Finset.sum_congr rfl
+  (fun k _ => simplexNumber_symm k d)`.
+
+Build: **VERIFIED** clean — `Build completed successfully (3059 jobs)`, exit 0 (2 of 4 runs fully
+succeeded; the SIGBUS-135 tail on other runs is the fleet olean-write env issue, not code).
+0 new axioms, 0 sorries, no native_decide. json leanFiles synced 320/14/4 → 344/17/4.
+
+NEXT: entry is well saturated (Pascal-simplex identities, iterated-summation Cauchy/Vandermonde
+semigroup, Sym counting, ascFactorial closed form, and now the reflection symmetry). Remaining
+possible angles are finite-difference / generating-function forms — lower marginal value.

--- a/src/data/research/problems/tetrahedral-number-formula-oq-01.json
+++ b/src/data/research/problems/tetrahedral-number-formula-oq-01.json
@@ -93,8 +93,8 @@
     {
       "path": "Proofs/TetrahedralNumberFormulaOQ01.lean",
       "filename": "TetrahedralNumberFormulaOQ01.lean",
-      "lineCount": 320,
-      "theoremCount": 14,
+      "lineCount": 344,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds two structurally distinct theorems to the general-dimension figurate-number entry `tetrahedral-number-formula-oq-01`, both exploiting that the whole theory lives on Pascal's simplex `P_d(n) = C(n+d, d)`.

- **`simplexNumber_symm (d n) : simplexNumber d n = simplexNumber n d`** — the `d ↔ n` reflection symmetry `C(n+d, d) = C(d+n, n)`. Pascal's simplex is symmetric across the `d = n` diagonal, so the `d`-dimensional figurate ladder read at size `n` equals the `n`-dimensional ladder read at size `d`. From `Nat.choose_symm`.
- **`sum_simplex_over_dim (d n) : ∑_{k≤n} simplexNumber k d = simplexNumber (d+1) n`** — the "shallow-diagonal" companion of the existing `sum_simplex`. Where `sum_simplex` sums a fixed **dimension** over increasing **size**, this sums a fixed **size** over increasing **dimension**; the two coincide via `simplexNumber_symm`, reflecting that both are the same diagonal of Pascal's simplex viewed from the two axes.

## Verification

- **VERIFIED**: `Build completed successfully (3059 jobs)`, exit 0 (via `docker-build.sh Proofs.TetrahedralNumberFormulaOQ01`, 2 of 4 runs clean; the SIGBUS-135 tail on other runs is the fleet olean-write env issue, not a code defect).
- **0 axioms, 0 sorries**, no `native_decide`.
- json `leanFiles` synced 320/14/4 → 344/17/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)