### PR TITLE
Enrich erdos-11-oq-03: clamp range past file end

### DIFF
--- a/src/data/proofs/erdos-11-oq-03/annotations.json
+++ b/src/data/proofs/erdos-11-oq-03/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-erdos11oq03-range",
     "proofId": "erdos-11-oq-03",
-    "range": { "startLine": 168, "endLine": 182 },
+    "range": { "startLine": 168, "endLine": 181 },
     "type": "tactic",
     "title": "Verified redundancy: ≥ 2 representations on 1 < n < 100 by one kernel decide",
     "content": "reprCount_odd_ge_two_range: ∀ n ∈ range 100, Odd n → 1 < n → 2 ≤ reprCount n. Because reprCount is a kernel-computable Nat (SquarefreeCheck reduces where Squarefree's minSqFac instance does not), a Finset.card inequality over the whole odd range discharges by a single kernel `decide` — no native_decide, hence no Lean.ofReduceBool. The bound is a genuine strengthening of the parent's 'verified representable' range to 'verified doubly representable': at least two distinct powers of two work, the minimum 2 being attained at n = 3, 5, 13, 29. isSquarefreePlusPow2_odd_range recovers the existence range as a weaker corollary. maxRecDepth 10000 lets the kernel walk the nested Finset.range recursions in the card computation — a resource budget, not a trust knob — and the trailing #print axioms confirms only propext / Classical.choice / Quot.sound.",

--- a/src/data/proofs/erdos-11-oq-03/meta.json
+++ b/src/data/proofs/erdos-11-oq-03/meta.json
@@ -102,7 +102,7 @@
       "id": "range",
       "title": "Verified Lower Bound by One Kernel decide",
       "startLine": 168,
-      "endLine": 182,
+      "endLine": 181,
       "summary": "reprCount_odd_ge_two_range: every odd 1 < n < 100 has 2 ≤ reprCount n (the representation is redundant, min 2 at n = 3, 5, 13, 29), by a single kernel decide on the reducible count (maxRecDepth 10000 is a recursion budget, not an axiom). isSquarefreePlusPow2_odd_range recovers the existence range as a weaker corollary. The trailing #print axioms confirms only propext / Classical.choice / Quot.sound — no Lean.ofReduceBool.",
       "mathContext": "$\\forall$ odd $n,\\ 1<n<100:\\ \\mathrm{reprCount}\\,n\\ge 2$, with $\\#\\mathrm{print\\ axioms}=\\{\\mathrm{propext},\\mathrm{Classical.choice},\\mathrm{Quot.sound}\\}$ only."
     }


### PR DESCRIPTION
## Enrichment pass — structural defect fix

`erdos-11-oq-03` had a **range overrun past the Lean file**: both the `range` section (`meta.json`) and the `ann-erdos11oq03-range` annotation ended at line **182**, while `Erdos11OQ03.lean` is only **181 lines** (`leanFile.lineCount = 181`).

**Fix:** clamp both `endLine` values 182 → 181. The block covered is `reprCount_odd_ge_two_range` and its trailing `#print axioms` lines, all within the real source.

### Verification
- `wc -l Erdos11OQ03.lean` = 181, matches `leanFile.lineCount`.
- Both edited JSON files pass `jq empty`.
- No content changed beyond the two `endLine` bounds.