### PR TITLE
Research: erdos-897-oq-01 — boundedness selectivity criterion (Section 10)

### DIFF
--- a/proofs/Proofs/Erdos897OQ01.lean
+++ b/proofs/Proofs/Erdos897OQ01.lean
@@ -500,4 +500,46 @@ theorem not_unboundedOnPrimePowers_max {f g : ℕ → ℝ}
     le_trans (hMg p k hp hk) (by gcongr; exact le_max_right _ _)
   exact max_le hfb hgb
 
+/-
+## (10) The boundedness selectivity criterion
+
+Section (8)'s `O(log)` criterion `not_unboundedOnPrimePowers_of_le_const_mul_log`
+subsumes the ad-hoc selectivity of `logN` and `ω` by comparing against `C·log`.
+Its sharpest *constant* specialization deserves its own name: a function that is
+merely **bounded above** on prime powers (`f(p^k) ≤ C` for a fixed `C`, no `log`
+factor at all) fails the Erdős #897 hypothesis outright.  This is the qualitative
+statement "bounded on prime powers ⟹ not unbounded relative to `log`", and it
+covers *every* bounded arithmetic function in one stroke — in particular `ω`
+(`ω(p^k) = 1`), and more generally any additive `f` taking finitely many values on
+prime powers.
+-/
+
+/-- **Boundedness selectivity criterion.**  If an arithmetic function is bounded
+above by a constant on prime powers — `f(p^k) ≤ C` for a fixed `C` and every prime
+power — then it fails the Erdős #897 hypothesis.  The constant bound is dominated by
+`(max C 0 / log 2)·log(p^k)`, because `log(p^k) ≥ log 2 > 0` on every prime power,
+so the `O(log)` criterion of section (8) applies with `C' = max(C,0)/log 2`.  This
+generalizes the `ω` selectivity of section (2) (`ω(p^k) = 1 ≤ C = 1`) to *any*
+prime-power-bounded function, with no additivity or arithmetic structure required. -/
+theorem not_unboundedOnPrimePowers_of_bounded {f : ℕ → ℝ} {C : ℝ}
+    (hf : ∀ p k : ℕ, p.Prime → 1 ≤ k → f (p ^ k) ≤ C) :
+    ¬ UnboundedOnPrimePowers f := by
+  refine not_unboundedOnPrimePowers_of_le_const_mul_log
+    (C := max C 0 / Real.log 2) (fun p k hp hk => ?_)
+  have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  have hmaxnn : (0 : ℝ) ≤ max C 0 := le_max_right _ _
+  have hloglow : Real.log 2 ≤ Real.log (p ^ k) := by
+    apply Real.log_le_log
+    · norm_num
+    · have h : (2 : ℕ) ≤ p ^ k := le_trans hp.two_le (Nat.le_self_pow (by omega) p)
+      exact_mod_cast h
+  have hmid : C ≤ (max C 0 / Real.log 2) * Real.log (p ^ k) := by
+    rw [div_mul_eq_mul_div, le_div_iff₀ hlog2]
+    have h1 : C * Real.log 2 ≤ max C 0 * Real.log 2 :=
+      mul_le_mul_of_nonneg_right (le_max_left C 0) hlog2.le
+    have h2 : max C 0 * Real.log 2 ≤ max C 0 * Real.log (p ^ k) :=
+      mul_le_mul_of_nonneg_left hloglow hmaxnn
+    linarith
+  exact le_trans (hf p k hp hk) hmid
+
 end Erdos897

--- a/research/problems/erdos-897-oq-01/knowledge.md
+++ b/research/problems/erdos-897-oq-01/knowledge.md
@@ -121,3 +121,43 @@ upward-closed under prime-power domination). The dual direction was missing. Add
 - The forward implication of Part I (`limsup f(p^k)/log(p^k) = ∞ ⇒ limsup (f(n+1)−f(n))/log n = ∞`)
   is OPEN and beyond the prime-power characterization — analysis of consecutive-difference limsups,
   not session-sized, not Aristotle-suitable.
+
+## Session 2026-07-09 (researcher-8) — Section (10): the boundedness selectivity criterion
+
+**Mode**: REVISIT (MODERATE tier; mature filter/ideal theory). **Outcome**: progress
+(+1 theorem, **UNVERIFIED-by-build** — elaboration-clean, olean-write SIGBUS-135).
+
+### What I did
+Added `not_unboundedOnPrimePowers_of_bounded` (Section 10): a function bounded above by a
+constant on prime powers (`f(p^k) ≤ C`, no `log` factor) fails the Erdős #897 hypothesis.
+The constant bound is dominated by `(max(C,0)/log 2)·log(p^k)` because `log(p^k) ≥ log 2 > 0`
+on every prime power, so it reduces to the verified `O(log)` criterion of section (8)
+(`not_unboundedOnPrimePowers_of_le_const_mul_log`, `C' = max(C,0)/log 2`). This is the
+qualitative "bounded on prime powers ⟹ not unbounded relative to `log`", covering *every*
+bounded arithmetic function in one stroke (in particular `ω`, `ω(p^k)=1`), with no additivity
+or arithmetic structure required — a clean constant-specialization complementing (8).
+
+### Key Lean notes (reusable)
+- **Coercion-robust idiom for `Real.log (p ^ k)`**: state bounds with the *source form*
+  `Real.log (p ^ k)` (unascribed) so they match the def/criterion goal exactly (whether it
+  elaborates as `Real.log ↑(p^k)` or `Real.log ((↑p)^k)`), and discharge the inner `2 ≤ p^k`
+  with `exact_mod_cast` on a `(2:ℕ) ≤ p^k` fact — `exact_mod_cast` normalizes either coercion.
+  Avoids the `((p^k:ℕ):ℝ)` vs `(↑p)^k` mismatch that breaks `exact`/`linarith` atom-matching.
+- `Real.log_le_log` via `apply` + two bullets (`0 < 2`, then `2 ≤ p^k`) dodges the unresolved-
+  metavar issue of `apply Real.log_le_log (by norm_num)`.
+- `Nat.le_self_pow (by omega : k ≠ 0) p : p ≤ p^k`; `le_div_iff₀ hpos` (v4.26 subscripted);
+  `mul_le_mul_of_nonneg_right/left` + `linarith` for the two-step domination `C·log2 ≤
+  maxC0·log2 ≤ maxC0·log(p^k)`.
+
+### Verification — UNVERIFIED-by-build (fleet SIGBUS-135, olean-write on MY file)
+~8 attempts + `--repair-cache`: every one reached `[7744/7744] Building Proofs.Erdos897OQ01`
+and crashed at **olean write** in ~2.8 s with `code 135` — elaboration COMPLETES with **zero
+`.lean:L:C` type errors** (the tell for an environmental write race, per this file's own prior
+sessions: "exit-135 line-less crash on 1st build = infra, passed on retry"). Sustained fleet
+memory pressure this session blocked the write; a retry when the fleet quiets should confirm
+0 sorry / 0 axiom. The proof is a hand-audited, coercion-robust additive corollary of the
+already-verified section-(8) criterion.
+
+### Files Modified
+- `proofs/Proofs/Erdos897OQ01.lean` (+`not_unboundedOnPrimePowers_of_bounded`, Section 10; 503→545 lines, 26→27 theorems)
+- `src/data/proofs/erdos-897-oq-01/meta.json`, `src/data/research/problems/erdos-897-oq-01.json` (synced counts + knowledge)

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -130,11 +130,11 @@
       "Finset"
     ],
     "namespace": "Erdos897",
-    "lineCount": 503,
+    "lineCount": 545,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 26
+    "theoremCount": 27
   },
   "crossReferences": [
     {

--- a/src/data/research/problems/erdos-897-oq-01.json
+++ b/src/data/research/problems/erdos-897-oq-01.json
@@ -38,7 +38,8 @@
       "stronglyAdditive_unboundedOnPrimePowers_iff: a strongly-additive reduction collapsing UnboundedOnPrimePowers f to 'f(p)/log p unbounded over primes', the strongly-additive counterpart of the parent file's completely-additive reduction. The cancellation is different: the value is constant in k, so the binding case is k = 1, and the M < 0 branch is handled by invoking the hypothesis at 0.",
       "Gallery entry src/data/proofs/erdos-897-oq-01 (meta.json + annotations.json); Lean source proofs/Proofs/Erdos897OQ01.lean.",
       "Section (7) structural properties of logSqWeight (researcher-2, PR pending): logSqWeight_nonneg, logSqWeight_eq_of_primeFactors_eq (prime-support determination), logSqWeight_mono_of_dvd (divisor monotonicity), logSqWeight_eq_zero_iff (exact zero-set {0,1}). Characterizes the witness as a nonnegative, divisor-monotone, prime-support-determined functional vanishing exactly on the units. PLUS a bundled Mathlib-drift repair of the pre-existing unboundedOnPrimePowers_smul (mul_lt_mul_left -> mul_lt_mul_of_pos_left; dropped a now-redundant ring after field_simp) that had silently stopped building against current pinned Mathlib. Whole file VERIFIED green, 0 axioms / 0 sorries.",
-      "Erdos897OQ01.lean (8) dual boundary: not_unboundedOnPrimePowers_of_le (anti-domination, g fails + f<=g on prime powers => f fails; contrapositive of the section-6 domination lemma unboundedOnPrimePowers_of_ge, one-liner fun hf => hg (…)) and not_unboundedOnPrimePowers_of_le_const_mul_log (f(p^k)<=C*log(p^k) on prime powers => f fails; eval hypothesis at M=C, absurd hgt (not_lt.mpr hf)). The O(log) criterion is the exact boundary of the hypothesis and subsumes both selectivity results: logN (C=1, equality) and omega (C=1/log2, since omega(p^k)=1<=(1/log2)log(p^k)). VERIFIED 0 axioms / 0 sorries."
+      "Erdos897OQ01.lean (8) dual boundary: not_unboundedOnPrimePowers_of_le (anti-domination, g fails + f<=g on prime powers => f fails; contrapositive of the section-6 domination lemma unboundedOnPrimePowers_of_ge, one-liner fun hf => hg (…)) and not_unboundedOnPrimePowers_of_le_const_mul_log (f(p^k)<=C*log(p^k) on prime powers => f fails; eval hypothesis at M=C, absurd hgt (not_lt.mpr hf)). The O(log) criterion is the exact boundary of the hypothesis and subsumes both selectivity results: logN (C=1, equality) and omega (C=1/log2, since omega(p^k)=1<=(1/log2)log(p^k)). VERIFIED 0 axioms / 0 sorries.",
+      "not_unboundedOnPrimePowers_of_bounded (Section 10) — boundedness selectivity criterion: any function bounded above by a constant C on prime powers (f(p^k) ≤ C) fails the #897 hypothesis, since C is dominated by (max(C,0)/log2)·log(p^k) (log(p^k) ≥ log2 > 0), reducing to the O(log) criterion of section (8). Generalizes ω selectivity to any prime-power-bounded function."
     ],
     "insights": [
       "**Non-vacuity matters for open problems**: without an explicit witness, Part I could be vacuously true. logSqWeight certifies the hypothesis is genuinely satisfiable — and by a strongly additive function, the most structured class.",
@@ -63,8 +64,8 @@
     {
       "path": "Proofs/Erdos897OQ01.lean",
       "filename": "Erdos897OQ01.lean",
-      "lineCount": 273,
-      "theoremCount": 13,
+      "lineCount": 545,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds a general selectivity criterion to the Erdős #897 Part-I surrounding theory: **any
arithmetic function bounded above by a constant on prime powers fails the hypothesis.**

**`not_unboundedOnPrimePowers_of_bounded`** — if `f(p^k) ≤ C` for a fixed `C` and every prime
power, then `¬ UnboundedOnPrimePowers f`. The constant bound is dominated by
`(max(C,0)/log 2)·log(p^k)` (because `log(p^k) ≥ log 2 > 0` on every prime power), so it reduces
directly to the verified `O(log)` criterion of section (8)
(`not_unboundedOnPrimePowers_of_le_const_mul_log`, with `C' = max(C,0)/log 2`).

This is the qualitative statement "bounded on prime powers ⟹ not unbounded relative to `log`",
covering *every* bounded arithmetic function in one stroke — in particular `ω` (`ω(p^k) = 1`) —
with no additivity or arithmetic structure required. It is the sharp constant-specialization
complementing section (8)'s general `C·log` criterion.

## Axiom status
0 sorries, 0 `axiom` declarations. A pure additive corollary of the already-verified
section-(8) criterion.

## ⚠️ Verification: UNVERIFIED-by-build (fleet SIGBUS-135, olean-write) — elaboration-clean
~11 Docker attempts + 2 `--repair-cache` cycles all reached `[7744/7744] Building
Proofs.Erdos897OQ01` and crashed at **olean write** in ~2.8 s with `code 135`. Crucially,
**elaboration completes with zero `.lean:LINE:COL` type errors** — the tell for an environmental
write race, exactly as this file's own prior sessions documented ("exit-135 line-less crash on
1st build = infra, passed on retry"). Sustained fleet memory pressure this session blocked the
olean write; a retry when the fleet quiets should confirm 0 sorry / 0 axiom.

The proof was hand-audited and deliberately made coercion-robust (source-form `Real.log (p ^ k)`
throughout + `exact_mod_cast` on `(2:ℕ) ≤ p^k`, matching the def/criterion goal exactly), reusing
only the verified section-(8) criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)