### PR TITLE
Enrich abel-ruffini-oq-04-oq-07: clamp section past file end

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -119,7 +119,7 @@
       "id": "bring-radical",
       "title": "Bring Radical: Definition and Properties",
       "startLine": 296,
-      "endLine": 377,
+      "endLine": 376,
       "summary": "Defines bringRadical t = the unique real root of x⁵+x+t=0. Proves: bringRadical_spec (satisfies equation), bringRadical_unique, bringRadical_anti_mono, bringRadical_zero, bringRadical_neg (odd function). (An earlier degenerate axiom bringRadical_not_in_radicals was removed as unsound; the genuine axiom-free replacement lives in the sibling entry OQ-04-OQ-07-OQ-02.) Summary theorem packages the main results.",
       "mathContext": "BR$(t)$ satisfies BR$(t)^5 + \\mathrm{BR}(t) + t = 0$, is strictly anti-monotone, odd, and BR$(0) = 0$. Not expressible by nested radicals (axiom).",
       "theorems": [


### PR DESCRIPTION
## Enrichment pass — structural defect fix

The `bring-radical` section in `abel-ruffini-oq-04-oq-07/meta.json` ended at line **377**, one past the **376**-line Lean file (`AbelRuffiniOQ04OQ07.lean` ends at `end BringJerrardReduction` on line 376; `leanFile.lineCount = 376`).

**Fix:** clamp `endLine` 377 → 376. No annotation overruns in this entry.

### Verification
- `wc -l` of the source = 376, matches `leanFile.lineCount`.
- Edited `meta.json` passes JSON validation.