### PR TITLE
Fix: correct phantom mainTheorem in abel-ruffini-oq-04-oq-07 meta

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -227,9 +227,9 @@
   },
   "mainTheorems": [
     {
-      "name": "linear_tschirnhaus_depresses",
+      "name": "depressed_quintic_forward",
       "type": "key",
-      "description": "The substitution y = x + a₄/5 eliminates the x⁴ term from any monic quintic (proved via polynomial identity)"
+      "description": "The linear Tschirnhaus substitution y = x + a₄/5 sends a root of any monic quintic to a root of the depressed quintic (no x⁴ term), proved via polynomial identity"
     },
     {
       "name": "bringRadical",


### PR DESCRIPTION
## Fix

The `mainTheorems` list in `abel-ruffini-oq-04-oq-07/meta.json` named a theorem `linear_tschirnhaus_depresses` that does not exist in the Lean source.

## Evidence

**Before**: mainTheorem `linear_tschirnhaus_depresses` — no such declaration in `proofs/Proofs/AbelRuffiniOQ04OQ07.lean` (`grep` finds nothing).

**After**: renamed to `depressed_quintic_forward` (the real theorem at line 128), whose docstring is exactly the linear Tschirnhaus depression step `y = x + a₄/5` that eliminates the x⁴ term. The other three mainTheorems (`bringRadical`, `bringRadical_unique`, `bringJerrard_summary`) already match real declarations.

Metadata-only fix; no Lean changes. JSON validated; gallery enrichment + search-index build steps pass.

This addresses the auditor `issues-found` flag on `abel-ruffini-oq-04-oq-07` (audit-tracker.json, 2026-07-09).

---
Automated fix by lean-mechanic agent.