### PR TITLE
Enrich erdos-143: correct lineCount to 119

### DIFF
--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -46,7 +46,7 @@
       "Formalized the KLL 2025 partial resolution"
     ],
     "axiomCount": 3,
-    "lineCount": 118,
+    "lineCount": 119,
     "assumptions": "3 axiom(s): kll_theorem, well_separated_integers_primitive, erdos_1935_primitive. See Lean source for complete statements.",
     "theoremCount": 1,
     "definitionCount": 8
@@ -221,7 +221,7 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 118,
+    "lineCount": 119,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 8,


### PR DESCRIPTION
## Enrichment pass — structural defect fix

`erdos-143/meta.json` reported `lineCount: 118` (in both `meta` and `leanFile`), but `Erdos143Problem.lean` actually spans **119** lines — `end Erdos143` sits on line 119. The file has no trailing newline, so `wc -l` undercounts by one; the `historical` section correctly references `endLine: 119`, which previously overran the stated `lineCount`.

**Fix:** set both `lineCount` fields 118 → 119, matching the real source and the section bound.

### Verification
- Last content line of the source is line 119 (`end Erdos143`).
- Section `historical` (98–119) now sits within `lineCount`.
- Edited `meta.json` passes JSON validation.