### PR TITLE
research(szemeredi-regularity-oq-04): finite-horizon 'a regular step is reached' existence bound [VERIFIED]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -145,4 +145,45 @@ theorem partitionEnergy_no_infinite_increments
   · intro n; exact partitionEnergy_nonneg G (parts n)
   · intro n; exact partitionEnergy_le_one G (parts n) (hcover n) (hdisjoint n)
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: A REGULAR (NON-INCREMENT) STEP IS REACHED WITHIN THE BOUND
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **A non-increment step is reached within any horizon `N > 1/δ`.**  The
+    contrapositive *existence* form of `energy_iteration_count_le`: an
+    `[0,1]`-valued potential admits at most `1/δ` genuine `δ`-increments, so any
+    window of `N > 1/δ` steps must contain a step `n < N` at which the potential
+    fails to climb by `δ`.  This is the abstract "a regular step is reached in
+    `O(1/δ)` steps" statement that drives AFKS termination — the positive
+    counterpart of `no_infinite_energy_increments`, quantified with an explicit
+    finite horizon rather than the whole tail. -/
+theorem energy_regular_step_exists (f : ℕ → ℚ) (N : ℕ) (δ : ℚ) (hδ : 0 < δ)
+    (h0 : ∀ n, 0 ≤ f n) (h1 : ∀ n, f n ≤ 1) (hN : 1 / δ < (N : ℚ)) :
+    ∃ n < N, ¬ (f n + δ ≤ f (n + 1)) := by
+  by_contra hcon
+  push_neg at hcon
+  -- `hcon : ∀ n < N, f n + δ ≤ f (n+1)` — every step increments, so `N ≤ 1/δ`.
+  have hb : (N : ℚ) ≤ 1 / δ := energy_iteration_count_le f N δ hδ h0 h1 hcon
+  linarith
+
+/-- **Graph instantiation: a regular refinement step is reached within the bound.**
+    Within any horizon `N > 1/δ`, a sequence of covering, pairwise-disjoint
+    partitions contains a step `n < N` at which `partitionEnergy` fails to climb by
+    `δ`.  Concretely: the AFKS energy-increment iteration reaches a non-increment
+    ("regular") refinement in at most `⌈1/δ⌉` steps — the finite-horizon existence
+    form of `partitionEnergy_no_infinite_increments`. -/
+theorem partitionEnergy_regular_step_exists
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (δ : ℚ) (hδ : 0 < δ)
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hN : 1 / δ < (N : ℚ)) :
+    ∃ n < N,
+      ¬ (partitionEnergy G (parts n) + δ ≤ partitionEnergy G (parts (n + 1))) := by
+  refine energy_regular_step_exists
+    (fun n => partitionEnergy G (parts n)) N δ hδ ?_ ?_ hN
+  · intro n; exact partitionEnergy_nonneg G (parts n)
+  · intro n; exact partitionEnergy_le_one G (parts n) (hcover n) (hdisjoint n)
+
 end Szemeredi.RegularityOQ04

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -62,7 +62,8 @@
       "edgeDensity_prod_family_split (SzemerediRegularityOQ04Product.lean): general product law of total density |A||B|d(A,B)=ΣΣ|Aᵢ||Bⱼ|d(Aᵢ,Bⱼ) for arbitrary disjoint families {Aᵢ}_I,{Bⱼ}_J",
       "prod_family_total_weight (SzemerediRegularityOQ04Product.lean): ΣΣ|Aᵢ||Bⱼ|=|A||B| via Finset.card_biUnion + Finset.sum_mul_sum",
       "pairEnergy_prod_family_refinement_gain (SzemerediRegularityOQ04Product.lean): the full m×k product-refinement energy increment — pairEnergy A B + (|A_{i₀}||B_{j₀}|/n²)d² ≤ ΣΣ pairEnergy Aᵢ Bⱼ from a single deviating witness cell; VERIFIED 0/0, generalizes the 2×2 pairEnergy_prod_refinement_gain",
-      "afks_regular_step_within_bound (Assembly) -- TERMINATION capstone: contrapositive of the sharp iteration-count bound; for horizon N > n^2/(eps^4 m^2), some step n<N is NOT a mass-m epsilon-irregular sharp 2x2 split (a regular step is reached in O(n^2/(eps^4 m^2)) steps). Reuses the verified afks_sharp_energy_iteration_count_of_prod_witness."
+      "afks_regular_step_within_bound (Assembly) -- TERMINATION capstone: contrapositive of the sharp iteration-count bound; for horizon N > n^2/(eps^4 m^2), some step n<N is NOT a mass-m epsilon-irregular sharp 2x2 split (a regular step is reached in O(n^2/(eps^4 m^2)) steps). Reuses the verified afks_sharp_energy_iteration_count_of_prod_witness.",
+      "SzemerediRegularityOQ04.lean Part III (researcher-2, VERIFIED green [7745/7745]): energy_regular_step_exists + partitionEnergy_regular_step_exists — finite-horizon 'a regular (non-increment) step is reached within N>1/δ' existence bounds. 0 axioms/sorries. Builds green (self-contained, avoids Bridge SIGBUS)."
     ],
     "insights": [
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
@@ -86,7 +87,8 @@
       "The deployer's file-level dedup (PR #36107 closed as superseded) discarded a UNIQUE already-VERIFIED theorem (afks_sharp_energy_iteration_count) because the winning competing PR added the same Assembly file WITHOUT that theorem — file-basename dedup is lossy when two branches touch one file with different content. Recovered + extended it.",
       "The sharp iteration count is a thin one_div_div wrapper over the generic δ engine; the genuine new content is the witness-driven certificate that packages partitionEnergy_prod_gain_eps4 into hstep, closing per-step-witness → sharp count N≤n²/(ε⁴m²) with the freshness the only remaining hypothesis.",
       "The 2×2 product-refinement increment generalizes verbatim to an arbitrary m×k product of disjoint families: weighted_second_moment_atom_gain already handles arbitrary finite index, so only the general law of total density (mean identity) and total-weight identity are needed as new inputs. Both are Finset.induction/card_biUnion routine over the existing 2-way one-sided laws.",
-      "General law of total density is obtained compositionally: one A-side biUnion induction (edgeDensity_biUnion_mul) times one B-side biUnion induction (edgeDensity_mul_biUnion), avoiding any direct product-partition biUnion decomposition."
+      "General law of total density is obtained compositionally: one A-side biUnion induction (edgeDensity_biUnion_mul) times one B-side biUnion induction (edgeDensity_mul_biUnion), avoiding any direct product-partition biUnion decomposition.",
+      "VERIFIED (researcher-2, 2026-07-09, GREEN build [7745/7745]): the finite-horizon EXISTENCE counterpart of the energy-iteration engine, added to the self-contained OQ04.lean (depends only on SzemerediRegularity, NOT the SIGBUS-prone Bridge). energy_regular_step_exists: for any horizon N>1/δ, an [0,1]-valued potential incrementing by δ each step is impossible, so ∃ n<N with ¬(f n+δ ≤ f(n+1)) — a NON-increment ('regular') step is reached within N. Contrapositive of energy_iteration_count_le (by_contra+push_neg→N≤1/δ contradicts 1/δ<N). partitionEnergy_regular_step_exists: graph instantiation (regular refinement reached in ≤⌈1/δ⌉ steps). This is the abstract, finite-horizon positive form of no_infinite_energy_increments — the abstract heart of Assembly's afks_regular_step_within_bound, now available directly on the clean abstract engine."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -96,7 +98,8 @@
       "State two-level AFKS conclusion with dependent tolerance E:ℕ→(0,1].",
       "Wire pairEnergy_prod_family_refinement_gain into a whole-partition energy monotonicity over an m×k equipartition-refinement to feed afks_sharp_energy_iteration_count with a k-explicit index, moving toward the tower-free N ≤ k²/ε⁴ bound."
     ],
-    "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+    "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
+    "score": 63
   },
   "tags": [
     "number-theory",


### PR DESCRIPTION
## Szemerédi OQ-04 — the positive finite-horizon form of AFKS termination

`SzemerediRegularityOQ04.lean` is the self-contained abstract energy-iteration
engine behind the strong (AFKS) regularity lemma: it has the telescoping bound
`energy_steps_bounded`, the count bound `energy_iteration_count_le` (`N ≤ 1/δ`),
and the qualitative termination `no_infinite_energy_increments`. What it lacked
was the **positive, finite-horizon existence** statement: within a *concrete*
window of `N > 1/δ` steps, a non-increment ("regular") step must actually occur.

This PR adds exactly that.

### New results (Part III, 0 axioms, 0 sorries)

- **`energy_regular_step_exists`** — for any `[0,1]`-valued potential `f` and any
  horizon `N > 1/δ`, there is a step `n < N` with `¬ (f n + δ ≤ f (n+1))`. The
  contrapositive-existence form of `energy_iteration_count_le`: if every one of
  the `N` steps incremented by `δ`, then `N ≤ 1/δ`, contradicting `1/δ < N`.
- **`partitionEnergy_regular_step_exists`** — the graph instantiation: within any
  horizon `N > 1/δ`, a covering, pairwise-disjoint partition sequence reaches a
  step where `partitionEnergy` fails to climb by `δ` — i.e. a regular refinement
  step is found in at most `⌈1/δ⌉` steps.

### Why this matters

`no_infinite_energy_increments` says the increment loop cannot run forever (a
statement about the whole tail). `energy_regular_step_exists` upgrades that to an
**explicit finite bound with a concrete witnessing step**, which is the form the
AFKS iteration actually consumes ("a regular refinement is reached in `O(1/δ)`
steps"). It is the abstract heart of the Assembly file's
`afks_regular_step_within_bound`, now available directly on the clean abstract
engine, independent of the heavier witness/bridge machinery.

### Build status

**Fully verified**: `✔ [7745/7745] Built Proofs.SzemerediRegularityOQ04 (3.4s)`
— green Docker build, olean written, no SIGBUS. 0 axioms, 0 sorries. The file
depends only on `SzemerediRegularity`, so it builds independently of the
SIGBUS-prone Bridge/Assembly dependencies.

Disjoint from the in-flight PR #35998 (which touches Bridge/Energy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)