### PR TITLE
Research: erdos-490-oq-01 - unconditional Bolzano–Weierstrass accumulation point

### DIFF
--- a/proofs/Proofs/Erdos490OQ01.lean
+++ b/proofs/Proofs/Erdos490OQ01.lean
@@ -296,13 +296,15 @@ theorem productRatio_accumulation :
       ∃ φ : ℕ → ℕ, StrictMono φ ∧
         Tendsto (fun k => productRatio' (φ k + 2) (Nat.le_add_left 2 (φ k)))
           atTop (nhds L) := by
-  obtain ⟨c, C, hc, _hC, hcC, hbound⟩ := productRatio_sandwich
+  obtain ⟨c, hc, hc_bound⟩ := productRatio_bounded_below
+  obtain ⟨C, _hC, hC_bound⟩ := productRatio_bounded_above
+  -- `c ≤ C` since both bound the same value at `N = 2`.
+  have hcC : c ≤ C := le_trans (hc_bound 2 (by omega)) (hC_bound 2 (by omega))
   -- The shifted sequence `n ↦ productRatio'(n+2)` lands in the compact interval `[c, C]`.
   have hmem : ∀ n : ℕ,
       (fun m => productRatio' (m + 2) (Nat.le_add_left 2 m)) n ∈ Set.Icc c C := by
     intro n
-    have h := hbound (n + 2) (Nat.le_add_left 2 n)
-    exact ⟨h.1, h.2⟩
+    exact ⟨hc_bound (n + 2) (Nat.le_add_left 2 n), hC_bound (n + 2) (Nat.le_add_left 2 n)⟩
   -- Bolzano–Weierstrass: a bounded real sequence has a convergent subsequence.
   obtain ⟨L, hLmem, φ, hφ, htend⟩ := isCompact_Icc.tendsto_subseq hmem
   refine ⟨c, C, L, hc, hcC, hLmem.1, hLmem.2, φ, hφ, ?_⟩

--- a/proofs/Proofs/Erdos490OQ01.lean
+++ b/proofs/Proofs/Erdos490OQ01.lean
@@ -283,6 +283,31 @@ theorem limit_in_sandwich :
     rw [abs_lt] at hN₀_bound
     linarith
 
+/-- **Accumulation point (unconditional Bolzano–Weierstrass).**  `limit_in_sandwich`
+only says *if* the limit exists it lies in `[c, C]`.  This is the unconditional companion:
+without assuming the limit exists, the bounded ratio sequence still has at least one
+subsequential limit `L`, and every such `L` lies in the sandwich interval `[c, C]` (in
+particular `0 < c ≤ L`).  So the limit question posed by `LimitExists'` is *non-vacuous* —
+accumulation points always exist and are pinned to `[c, C]`; the open question is precisely
+whether they all coincide.  The subsequence is indexed by the shift `N = φ k + 2`, which
+makes the hypothesis `2 ≤ N` automatic (`Nat.le_add_left`). -/
+theorem productRatio_accumulation :
+    ∃ (c C L : ℝ), 0 < c ∧ c ≤ C ∧ c ≤ L ∧ L ≤ C ∧
+      ∃ φ : ℕ → ℕ, StrictMono φ ∧
+        Tendsto (fun k => productRatio' (φ k + 2) (Nat.le_add_left 2 (φ k)))
+          atTop (nhds L) := by
+  obtain ⟨c, C, hc, _hC, hcC, hbound⟩ := productRatio_sandwich
+  -- The shifted sequence `n ↦ productRatio'(n+2)` lands in the compact interval `[c, C]`.
+  have hmem : ∀ n : ℕ,
+      (fun m => productRatio' (m + 2) (Nat.le_add_left 2 m)) n ∈ Set.Icc c C := by
+    intro n
+    have h := hbound (n + 2) (Nat.le_add_left 2 n)
+    exact ⟨h.1, h.2⟩
+  -- Bolzano–Weierstrass: a bounded real sequence has a convergent subsequence.
+  obtain ⟨L, hLmem, φ, hφ, htend⟩ := isCompact_Icc.tendsto_subseq hmem
+  refine ⟨c, C, L, hc, hcC, hLmem.1, hLmem.2, φ, hφ, ?_⟩
+  simpa [Function.comp] using htend
+
 -- ============================================================================
 -- § 6. Structural Analysis
 -- ============================================================================
@@ -337,6 +362,7 @@ theorem productRatio_sandwich :
 #check @productRatio_bounded_above
 #check @productRatio_bounded_below
 #check @limit_in_sandwich
+#check @productRatio_accumulation
 #check @productRatio_nonneg
 #check @card_le_of_subset_upto
 #check @maxProd_le_sq

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -556,3 +556,40 @@ upper bound (#35676), `theta_gap_ge_linear` (#36014). Confirmed by static scan t
 `|A|·|B| ≤ C·N²/log N`, a famous hard theorem not in Mathlib. Correctly axiomatized, out of
 session scope. Everything elementary / combinatorial / build-repair is done. Set
 `status: completed`, `phase: COMPLETED` so the strand stops being re-served.
+
+## Session 2026-07-09 (researcher-5) — unconditional accumulation point (Erdos490OQ01)
+
+**Mode**: ACT (SOLVED problem, structural consequence). **Outcome**: added 1 verified
+0-new-axiom theorem to the OQ-01 limit-question file. The two deep Szemerédi upper-bound
+axioms remain (out of scope, as documented).
+
+### What I Did (verified, docker [7745/7745])
+Added `productRatio_accumulation` to `Erdos490OQ01.lean`: the **unconditional** companion
+to the conditional `limit_in_sandwich`. Where `limit_in_sandwich` says *if* the limit of
+`productRatio'(N) = maxProd(N)·log N/N²` exists then it lies in `[c,C]`, this new theorem
+drops the hypothesis: the bounded ratio sequence **always** has at least one subsequential
+limit `L ∈ [c,C]` (in particular `0 < c ≤ L`). So the `LimitExists'` open question is
+**non-vacuous** — accumulation points exist and are pinned to the sandwich; the open
+question is precisely whether they all coincide.
+
+### Technique
+- Bolzano–Weierstrass via `IsCompact.tendsto_subseq` on the compact `Set.Icc c C`
+  (`isCompact_Icc`), applied to the **shifted** sequence `n ↦ productRatio'(n+2)` so the
+  hypothesis `2 ≤ N` is discharged by `Nat.le_add_left 2 n` (a real proof term, no
+  `by omega` in the index).
+- Membership `u n ∈ Icc c C` from `productRatio_bounded_below`/`_above` directly (NOT
+  `productRatio_sandwich`, which is defined *later* in the file → forward-reference error).
+- `simpa [Function.comp] using htend` to match the `u ∘ φ` composition against the
+  explicit-lambda goal (proof-irrelevance handles the `hN` argument).
+
+### Gotchas
+- `productRatio_sandwich` lives in §6, *after* the §5 limit block — using it in a §5
+  theorem gives `Unknown identifier`. Obtain `c`/`C` from the §4 bounded lemmas instead.
+- Same-session cache corruption: a truncated Mathlib olean/trace
+  (`CategoryTheory/Limits/Constructions/Pullbacks.trace: unexpected end of input`) caused a
+  spurious exit-135 on a *dependency*; `rm` the corrupted artifacts + rebuild → clean.
+
+Verification: docker-build.sh `Built Proofs.Erdos490OQ01 [7745/7745]`, 0 sorry, file
+axiomCount unchanged at 1 (the theorem depends on the existing `szemeredi_upper` via
+`productRatio_bounded_above`, no new axiom). Gallery meta `erdos-490-oq-01/meta.json`
+leanFile lineCount 343→371, theoremCount 13→14.

--- a/src/data/proofs/erdos-490-oq-01/meta.json
+++ b/src/data/proofs/erdos-490-oq-01/meta.json
@@ -133,9 +133,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 343,
+    "lineCount": 371,
     "axiomCount": 1,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 5,
     "path": "Proofs/Erdos490OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary
Research session for `erdos-490-incomplete-01` (Erdős #490 OQ-01: does
`lim maxProd(N)·log N/N²` exist?). Adds one verified, 0-new-axiom theorem that
strengthens the file's limit analysis.

## Progress
- **New theorem `productRatio_accumulation`** in `proofs/Proofs/Erdos490OQ01.lean`:
  the *unconditional* companion to the existing *conditional* `limit_in_sandwich`.
  - `limit_in_sandwich`: **if** the limit `L` exists, then `L ∈ [c, C]`.
  - `productRatio_accumulation`: **without** assuming existence, the bounded ratio
    sequence `productRatio'(N) = maxProd(N)·log N/N²` still has at least one
    subsequential limit `L ∈ [c, C]` (in particular `0 < c ≤ L`).
- Consequence: the `LimitExists'` open question is **non-vacuous** — accumulation
  points always exist and are pinned to the sandwich interval `[c, C]`; the genuine
  open question is precisely whether they all coincide.

## Findings / Technique
- Bolzano–Weierstrass via `IsCompact.tendsto_subseq` on the compact `Set.Icc c C`
  (`isCompact_Icc`), applied to the shifted sequence `n ↦ productRatio'(n+2)` so the
  side condition `2 ≤ N` is discharged by `Nat.le_add_left` (proof term, not a tactic
  in the index).
- Membership drawn from `productRatio_bounded_below`/`_above` (earlier in the file),
  not `productRatio_sandwich` (defined later → forward reference).

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos490OQ01` → `Built [7745/7745]`, 0 sorry.
- **No new axiom**: the theorem depends on the pre-existing `szemeredi_upper` (via
  `productRatio_bounded_above`); file `axiomCount` stays **1**. The two deep Szemerédi
  (1976) upper-bound axioms remain correctly axiomatized and out of session scope.
- Gallery meta `erdos-490-oq-01/meta.json`: leanFile lineCount 343→371, theoremCount 13→14.

## Status
**Outcome**: progress (structural consequence on a SOLVED problem)
**Next Steps**: the remaining axioms (`szemeredi_theorem`, `szemeredi_upper`) require the
full Szemerédi (1976) `N²/log N` distinct-products upper bound — a major formalization not
in Mathlib, out of session scope.

🤖 Generated by researcher-5