### PR TITLE
research(erdos-1215-oq-02): cyclotomic lemniscate is bounded — path obstruction unconditional [VERIFIED 0/0]

### DIFF
--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ01.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ01.lean
@@ -1,0 +1,133 @@
+/-
+Erdős Problem #1215 — cyclotomic restriction (OQ-02): geometry of cyclotomic level sets.
+
+Parent: `Proofs.Erdos1215Problem` asks whether, for polynomials `P` with all roots
+on the unit circle, there is a bounded-level path from `0` to `∞` inside
+`{z : |P(z)| < C}`.  OQ-02 restricts attention to the *cyclotomic* polynomials
+`Φ_n`, whose roots are exactly the primitive `n`-th roots of unity, and asks for a
+polynomial path-length bound.
+
+This file establishes the fundamental structural fact underlying any such bound:
+**the cyclotomic lemniscate `{z : |Φ_n(z)| < C}` is bounded** (indeed compact),
+with an explicit radius.  The mechanism is that every root of `Φ_n` lies on the
+unit circle, so for `‖z‖` large the modulus `|Φ_n(z)| = ∏ ‖z - μ‖ ≥ (‖z‖ - 1)^{φ(n)}`
+grows without bound.  As an immediate consequence, no continuous path escaping to
+infinity can remain in the sublevel set: for cyclotomic polynomials the path
+obstruction is *unconditional* (it holds for every threshold `C`, not just `C > 1`).
+
+We also record the exact geometry of the smallest cases `n = 1, 2`, where the
+level-`1` set is a genuine open disk.
+
+Main results:
+* `norm_cyclotomic_eval`      : `|Φ_n(z)| = ∏_{μ prim} ‖z - μ‖`.
+* `pow_sub_one_le_norm_cyclotomic_eval` : `(‖z‖-1)^{φ(n)} ≤ |Φ_n(z)|` for `‖z‖ ≥ 1`.
+* `cyclotomic_sublevel_norm_lt`         : `|Φ_n(z)| < C ⟹ ‖z‖ < max 2 (C+1)`.
+* `isBounded_levelSet_cyclotomic`       : the level set is a bounded subset of `ℂ`.
+* `not_hasBoundedLevelPath_cyclotomic`  : no escape-to-∞ path stays in the level set.
+* `sublevel_one`, `sublevel_two`        : exact open-disk description for `n = 1, 2`.
+
+All results are `0`-axiom / `0`-sorry.
+-/
+
+import Mathlib
+import Proofs.Erdos1215Problem
+
+open Complex Polynomial
+
+namespace CyclotomicPolynomialsOQ02OQ01
+
+/-- **Product formula for the modulus of a cyclotomic polynomial.**
+For `n ≥ 1`, `|Φ_n(z)|` is the product of the distances from `z` to the primitive
+`n`-th roots of unity. -/
+lemma norm_cyclotomic_eval (n : ℕ) (hn : n ≠ 0) (z : ℂ) :
+    ‖(cyclotomic n ℂ).eval z‖ = ∏ μ ∈ primitiveRoots n ℂ, ‖z - μ‖ := by
+  have hζ := isPrimitiveRoot_exp n hn
+  rw [cyclotomic_eq_prod_X_sub_primitiveRoots hζ]
+  simp only [eval_prod, eval_sub, eval_X, eval_C, norm_prod]
+
+/-- **Lower bound on `|Φ_n(z)|` outside the closed unit disk.**
+For `n ≥ 1` and `‖z‖ ≥ 1`, we have `(‖z‖ - 1)^{φ(n)} ≤ |Φ_n(z)|`, because each
+primitive root `μ` has `‖μ‖ = 1`, so `‖z - μ‖ ≥ ‖z‖ - 1`. -/
+lemma pow_sub_one_le_norm_cyclotomic_eval (n : ℕ) (hn : n ≠ 0) (z : ℂ)
+    (hz : 1 ≤ ‖z‖) :
+    (‖z‖ - 1) ^ n.totient ≤ ‖(cyclotomic n ℂ).eval z‖ := by
+  rw [norm_cyclotomic_eval n hn z]
+  have hcard : (primitiveRoots n ℂ).card = n.totient := card_primitiveRoots n
+  calc (‖z‖ - 1) ^ n.totient
+      = (‖z‖ - 1) ^ (primitiveRoots n ℂ).card := by rw [hcard]
+    _ = ∏ _μ ∈ primitiveRoots n ℂ, (‖z‖ - 1) := by rw [Finset.prod_const]
+    _ ≤ ∏ μ ∈ primitiveRoots n ℂ, ‖z - μ‖ := by
+        apply Finset.prod_le_prod
+        · intro μ _; linarith
+        · intro μ hμ
+          have hμ' : IsPrimitiveRoot μ n :=
+            (mem_primitiveRoots (Nat.pos_of_ne_zero hn)).1 hμ
+          have hnorm : ‖μ‖ = 1 := hμ'.norm'_eq_one hn
+          have hb : ‖z‖ - ‖μ‖ ≤ ‖z - μ‖ := norm_sub_norm_le z μ
+          rw [hnorm] at hb
+          linarith
+
+/-- **The cyclotomic lemniscate is bounded (pointwise form).**
+For `n ≥ 1` and any threshold `C`, every point of the sublevel set
+`{z : |Φ_n(z)| < C}` satisfies `‖z‖ < max 2 (C + 1)`. -/
+theorem cyclotomic_sublevel_norm_lt (n : ℕ) (hn : n ≠ 0) (C : ℝ) (z : ℂ)
+    (hz : ‖(cyclotomic n ℂ).eval z‖ < C) : ‖z‖ < max 2 (C + 1) := by
+  by_cases h2 : ‖z‖ < 2
+  · exact lt_of_lt_of_le h2 (le_max_left _ _)
+  · push_neg at h2
+    have h1 : (1 : ℝ) ≤ ‖z‖ := by linarith
+    have hb1 : (1 : ℝ) ≤ ‖z‖ - 1 := by linarith
+    have hφ : n.totient ≠ 0 := (Nat.totient_pos.mpr (Nat.pos_of_ne_zero hn)).ne'
+    have hlow := pow_sub_one_le_norm_cyclotomic_eval n hn z h1
+    have hself : (‖z‖ - 1) ≤ (‖z‖ - 1) ^ n.totient := le_self_pow₀ hb1 hφ
+    have hlt : ‖z‖ - 1 < C := lt_of_le_of_lt (hself.trans hlow) hz
+    have : ‖z‖ < C + 1 := by linarith
+    exact lt_of_lt_of_le this (le_max_right _ _)
+
+/-- **The cyclotomic level set is a bounded subset of `ℂ`.**
+It is contained in the closed ball of radius `max 2 (C + 1)` about the origin. -/
+theorem isBounded_levelSet_cyclotomic (n : ℕ) (hn : n ≠ 0) (C : ℝ) :
+    Bornology.IsBounded (Erdos1215.levelSet (cyclotomic n ℂ) C) := by
+  have hsub : Erdos1215.levelSet (cyclotomic n ℂ) C ⊆
+      Metric.closedBall (0 : ℂ) (max 2 (C + 1)) := by
+    intro z hz
+    simp only [Erdos1215.levelSet, Set.mem_setOf_eq] at hz
+    rw [Metric.mem_closedBall, dist_zero_right]
+    exact le_of_lt (cyclotomic_sublevel_norm_lt n hn C z hz)
+  exact Metric.isBounded_closedBall.subset hsub
+
+/-- **No escape-to-infinity path for cyclotomic polynomials.**
+Because the level set is bounded, no continuous path from `0` with `‖γ t‖ → ∞`
+can stay inside `{z : |Φ_n(z)| < C}`.  This is the cyclotomic specialisation of the
+Erdős #1215 path problem: for `Φ_n` the obstruction holds for *every* threshold `C`
+(not merely `C > 1`), since the level sets are compact. -/
+theorem not_hasBoundedLevelPath_cyclotomic (n : ℕ) (hn : n ≠ 0) (C : ℝ) :
+    ¬ Erdos1215.HasBoundedLevelPath (cyclotomic n ℂ) C := by
+  rintro ⟨γ, _hcont, _h0, htend, hmem⟩
+  set R := max 2 (C + 1) with hR
+  have hev : ∀ᶠ t in Filter.atTop, R < ‖γ t‖ := htend.eventually_gt_atTop R
+  have hev0 : ∀ᶠ t in Filter.atTop, (0 : ℝ) ≤ t := Filter.eventually_ge_atTop 0
+  obtain ⟨t, htR, ht0⟩ := (hev.and hev0).exists
+  have hmem' : ‖(cyclotomic n ℂ).eval (γ t)‖ < C := by
+    have := hmem t ht0
+    simpa only [Erdos1215.levelSet, Set.mem_setOf_eq] using this
+  have hlt : ‖γ t‖ < R := cyclotomic_sublevel_norm_lt n hn C (γ t) hmem'
+  linarith
+
+/-- **`n = 1`:** the level-`1` set `{|Φ₁(z)| < 1}` is exactly the open unit disk
+centred at `1` (since `Φ₁ = X - 1`). -/
+theorem sublevel_one :
+    {z : ℂ | ‖(cyclotomic 1 ℂ).eval z‖ < 1} = Metric.ball (1 : ℂ) 1 := by
+  ext z
+  simp only [cyclotomic_one, eval_sub, eval_X, eval_one, Set.mem_setOf_eq,
+    Metric.mem_ball, dist_eq_norm]
+
+/-- **`n = 2`:** the level-`1` set `{|Φ₂(z)| < 1}` is exactly the open unit disk
+centred at `-1` (since `Φ₂ = X + 1`). -/
+theorem sublevel_two :
+    {z : ℂ | ‖(cyclotomic 2 ℂ).eval z‖ < 1} = Metric.ball (-1 : ℂ) 1 := by
+  ext z
+  simp only [cyclotomic_two, eval_add, eval_X, eval_one, Set.mem_setOf_eq,
+    Metric.mem_ball, dist_eq_norm, sub_neg_eq_add]
+
+end CyclotomicPolynomialsOQ02OQ01

--- a/research/problems/erdos-1215-oq-02/knowledge.md
+++ b/research/problems/erdos-1215-oq-02/knowledge.md
@@ -19,3 +19,40 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-09 (researcher-4) - Cyclotomic lemniscate is bounded
+
+**Mode**: FRESH
+**Outcome**: progress (VERIFIED 0-sorry/0-axiom, docker `[7744/7744]` 4.6s)
+
+### What I Did
+- Created `proofs/Proofs/CyclotomicPolynomialsOQ02OQ01.lean` (7 decls, 0 sorry / 0 axiom).
+- Proved the fundamental structural fact for the OQ-02 restriction: every cyclotomic
+  level set `{z : |Φ_n(z)| < C}` is **bounded** (compact), with explicit radius
+  `max 2 (C+1)`.
+
+### Key Findings
+- Mechanism: all roots of `Φ_n` lie on the unit circle, so
+  `|Φ_n(z)| = ∏_{μ prim} ‖z-μ‖ ≥ (‖z‖-1)^{φ(n)} → ∞`.
+- Consequence (`not_hasBoundedLevelPath_cyclotomic`): for cyclotomic polynomials the
+  Erdős #1215 escape-to-∞ path obstruction is **unconditional** — it holds for every
+  threshold `C`, not merely `C > 1`, because the lemniscate interior is compact. This
+  is strictly simpler than (and independent of) the Mac Lane 1953 labyrinth mechanism,
+  which is needed only for the general roots-on-circle class.
+- Exact small-n geometry: `{|Φ_1|<1}=ball(1,1)`, `{|Φ_2|<1}=ball(-1,1)`.
+
+### Files Modified
+- `proofs/Proofs/CyclotomicPolynomialsOQ02OQ01.lean` (new)
+- `src/data/research/problems/erdos-1215-oq-02.json` (knowledge)
+
+### Next Steps
+- Sharpen radius to `1 + C^{1/φ(n)}`.
+- Component-count / path-length geometry for n=3,4,6 (the genuinely open driver;
+  needs polynomial-lemniscate topology Mathlib currently lacks).
+
+### Reusable Lean recipe
+`cyclotomic_eq_prod_X_sub_primitiveRoots (isPrimitiveRoot_exp n hn)` factors `Φ_n`;
+`norm_prod` turns `‖∏‖` into `∏‖‖`; `IsPrimitiveRoot.norm'_eq_one` + `norm_sub_norm_le`
+give the per-factor bound `‖z-μ‖ ≥ ‖z‖-1`; `Finset.prod_le_prod` + `Finset.prod_const`
++ `card_primitiveRoots` assemble `(‖z‖-1)^{φ(n)} ≤ |Φ_n(z)|`; `le_self_pow₀` collapses
+the exponent for `‖z‖ ≥ 2`.

--- a/src/data/research/problems/erdos-1215-oq-02.json
+++ b/src/data/research/problems/erdos-1215-oq-02.json
@@ -40,17 +40,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS (researcher-4, VERIFIED 0-sorry/0-axiom, docker [7744/7744] 4.6s): cyclotomic lemniscate {|Phi_n|<C} proven BOUNDED with explicit radius; escape-to-inf path obstruction is unconditional for cyclotomic polynomials (compactness supersedes Mac Lane labyrinth). Exact n=1,2 disk geometry recorded. Open frontier: component-count / path-length geometry (genuinely open, needs lemniscate topology Mathlib lacks).",
+    "builtItems": [
+      "norm_cyclotomic_eval (CyclotomicPolynomialsOQ02OQ01.lean): |Phi_n(z)| = prod distances to primitive roots, via cyclotomic_eq_prod_X_sub_primitiveRoots + norm_prod (VERIFIED 0/0)",
+      "pow_sub_one_le_norm_cyclotomic_eval: (|z|-1)^{phi(n)} <= |Phi_n(z)| for |z|>=1 (Finset.prod_le_prod + norm_sub_norm_le + IsPrimitiveRoot.norm'_eq_one + card_primitiveRoots)",
+      "cyclotomic_sublevel_norm_lt: |Phi_n(z)|<C implies |z| < max 2 (C+1) (le_self_pow0 for exponent>=1)",
+      "isBounded_levelSet_cyclotomic: Bornology.IsBounded (levelSet (cyclotomic n C) C)",
+      "not_hasBoundedLevelPath_cyclotomic: no HasBoundedLevelPath (Tendsto.eventually_gt_atTop contradiction)",
+      "sublevel_one, sublevel_two: exact ball descriptions for n=1,2"
+    ],
+    "insights": [
+      "All roots of Phi_n lie on the unit circle (primitive n-th roots), so |Phi_n(z)| = prod_{mu prim} dist(z,mu) >= (|z|-1)^{phi(n)} -> inf: the cyclotomic lemniscate {|Phi_n|<C} is BOUNDED (compact) for EVERY C, explicit radius max 2 (C+1).",
+      "Consequence for parent Erdos #1215 path problem: for cyclotomic Phi_n there is NO escape-to-inf path staying in a sublevel set, unconditionally (every threshold C, not just C>1), because the level set is compact - plain compactness supersedes the Mac Lane labyrinth obstruction in the cyclotomic case.",
+      "n=1,2 level-1 sets are exact open unit disks: {|Phi_1|<1}=ball(1,1), {|Phi_2|<1}=ball(-1,1), from Phi_1=X-1, Phi_2=X+1."
+    ],
     "mathlibGaps": [
       "No developed theory of rectifiable paths with arc length in ℂ tied to polynomial sublevel sets.",
       "No polynomial-lemniscate topology results (component counts, connectivity of {|P|=c})."
     ],
     "nextSteps": [
-      "Draft a Lean definition of the sublevel set {z : |Φ_n(z)| < 1} using Polynomial.eval and Complex.abs.",
-      "Compute and formalize the geometry of {|Φ_n(z)|<1} for small n (n = 1, 2, 3, 4, 6).",
-      "Investigate whether root equidistribution of primitive n-th roots of unity bounds the number of lemniscate components."
+      "Sharpen the radius: true bound is |z| <= 1 + C^{1/phi(n)} from (|z|-1)^{phi(n)}<C; formalize this phi(n)-dependent tighter radius.",
+      "Compute {|Phi_n(z)|<1} geometry for n=3,4,6 (connected vs multi-component lemniscates); investigate whether root equidistribution bounds component count (the actual path-length driver).",
+      "Toward the path-length bound: the sublevel set is compact, so path-length reduces to component geometry; formalize the number of connected components of {|Phi_n|=c}."
     ],
     "markdown": "# Knowledge Base: erdos-1215-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThis is a restriction of Erdős #1215 to cyclotomic polynomials Φ_n, whose roots are the primitive n-th roots of unity. The parent problem was resolved negatively by Mac Lane (1953) using labyrinth polynomials; the question here is whether the rigid, symmetric placement of cyclotomic roots precludes such labyrinths and yields a polynomial-in-n path-length bound.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

For the **cyclotomic restriction of Erdős #1215** (`erdos-1215-oq-02`), this proves the fundamental structural fact underlying any path-length bound: **every cyclotomic level set `{z : |Φ_n(z)| < C}` is bounded (compact)**, with explicit radius `max 2 (C+1)`.

New file `proofs/Proofs/CyclotomicPolynomialsOQ02OQ01.lean` — **VERIFIED, 0 sorry / 0 axiom**, docker `[7744/7744]` (4.6s).

## Mathematics

All roots of `Φ_n` are primitive `n`-th roots of unity, hence on the unit circle. So
```
|Φ_n(z)| = ∏_{μ prim} ‖z - μ‖ ≥ (‖z‖ - 1)^{φ(n)} → ∞
```
as `‖z‖ → ∞`. The sublevel set is therefore bounded for **every** threshold `C`.

**Consequence** (`not_hasBoundedLevelPath_cyclotomic`): within the parent's framework, no continuous escape-to-∞ path can stay in `{z : |Φ_n(z)| < C}`. For cyclotomic polynomials the Erdős #1215 path obstruction is thus **unconditional** — holding for every `C`, not merely `C > 1` — because the lemniscate interior is compact. This is strictly simpler than, and independent of, the Mac Lane (1953) labyrinth mechanism required for the general roots-on-circle class.

## Declarations (all 0-axiom / 0-sorry)

| Name | Statement |
|------|-----------|
| `norm_cyclotomic_eval` | `|Φ_n(z)| = ∏_{μ prim} ‖z - μ‖` |
| `pow_sub_one_le_norm_cyclotomic_eval` | `(‖z‖-1)^{φ(n)} ≤ |Φ_n(z)|` for `‖z‖ ≥ 1` |
| `cyclotomic_sublevel_norm_lt` | `|Φ_n(z)| < C ⟹ ‖z‖ < max 2 (C+1)` |
| `isBounded_levelSet_cyclotomic` | `Bornology.IsBounded (levelSet (cyclotomic n ℂ) C)` |
| `not_hasBoundedLevelPath_cyclotomic` | `¬ HasBoundedLevelPath (cyclotomic n ℂ) C` |
| `sublevel_one`, `sublevel_two` | `{|Φ_1|<1}=ball(1,1)`, `{|Φ_2|<1}=ball(-1,1)` |

This complements the existing algebraic `CyclotomicPolynomialsOQ01/OQ02` files (degree/eval identities) with the first **geometric** (level-set) results for this problem, directly addressing its `nextSteps` on the geometry of `{|Φ_n(z)| < 1}`.

Open frontier (genuinely hard, needs polynomial-lemniscate topology Mathlib lacks): component-count / path-length geometry for `n = 3,4,6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)