### PR TITLE
Clamp 41 annotation/section ranges overshooting Lean EOF (40 entries)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/annotations.json
@@ -71,7 +71,7 @@
     "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01-oq-01",
     "range": {
       "startLine": 173,
-      "endLine": 195
+      "endLine": 192
     },
     "type": "theorem",
     "title": "The Packaged Relative Correspondence",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/annotations.json
@@ -107,7 +107,7 @@
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
     "range": {
       "startLine": 138,
-      "endLine": 168
+      "endLine": 167
     },
     "type": "concept",
     "title": "Corollaries and the Joint Sharp Threshold",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -119,7 +119,7 @@
       "id": "bring-radical",
       "title": "Bring Radical: Definition and Properties",
       "startLine": 296,
-      "endLine": 377,
+      "endLine": 376,
       "summary": "Defines bringRadical t = the unique real root of x⁵+x+t=0. Proves: bringRadical_spec (satisfies equation), bringRadical_unique, bringRadical_anti_mono, bringRadical_zero, bringRadical_neg (odd function). (An earlier degenerate axiom bringRadical_not_in_radicals was removed as unsound; the genuine axiom-free replacement lives in the sibling entry OQ-04-OQ-07-OQ-02.) Summary theorem packages the main results.",
       "mathContext": "BR$(t)$ satisfies BR$(t)^5 + \\mathrm{BR}(t) + t = 0$, is strictly anti-monotone, odd, and BR$(0) = 0$. Not expressible by nested radicals (axiom).",
       "theorems": [

--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-02/annotations.json
@@ -97,7 +97,7 @@
     "proofId": "area-of-circle-oq-07-oq-03-oq-02",
     "range": {
       "startLine": 153,
-      "endLine": 185
+      "endLine": 184
     },
     "type": "insight",
     "title": "Γ(1/2)² = π via Beta, Independently of the Gaussian Integral",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/annotations.json
@@ -77,7 +77,7 @@
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02",
     "range": {
       "startLine": 184,
-      "endLine": 222
+      "endLine": 220
     },
     "type": "tactic",
     "title": "Concrete Verification with decide (no native_decide)",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/annotations.json
@@ -165,7 +165,7 @@
     "proofId": "arithmetic-series-oq-02-oq-04",
     "range": {
       "startLine": 123,
-      "endLine": 158
+      "endLine": 156
     },
     "type": "insight",
     "title": "Summary: Compressed Rising Factorials",

--- a/src/data/proofs/arithmetic-series-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-02/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-concrete-coefficients",
     "proofId": "arithmetic-series-oq-04-oq-02",
-    "range": { "startLine": 140, "endLine": 164 },
+    "range": { "startLine": 140, "endLine": 163 },
     "type": "concept",
     "title": "Grounding the Abstraction in Computable Coefficients",
     "content": "To check the abstract generating functions describe the intended object, three coefficients are computed directly with `coeff_mk` followed by `norm_num`/`simp`: the X¹ coefficient for n=4 is S₁(4)/1! = 0+1+2+3 = 6; the X² coefficient is S₂(4)/2! = (0+1+4+9)/2 = 7; and the constant coefficient S₀(n) = ∑_{k<n} k⁰ = n (using 0⁰ = 1 in this Finset.range convention).",

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-01/annotations.json
@@ -86,7 +86,7 @@
   {
     "id": "bezout-oq010201-examples",
     "proofId": "bezout-identity-oq-01-oq-02-oq-01",
-    "range": { "startLine": 172, "endLine": 189 },
+    "range": { "startLine": 172, "endLine": 188 },
     "type": "concept",
     "title": "Concrete sanity checks, axiom-free",
     "content": "Three examples close the entry: (12,8) ↦ (gcd = 4, 0), the coprime pair (7,5) ↦ (1,0), and the quotient list euclidQuots 12 8 = [1,2] (from 12 = 1·8 + 4 and 8 = 2·4 + 0), so euclidProd 12 8 = E 2 · E 1. Crucially these are discharged by `simpa`/`norm_num` unfolding the recursion — not by native_decide — so the entry stays genuinely 0-axiom (only propext / Classical.choice / Quot.sound, and no Lean.ofReduceBool).",

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02/annotations.json
@@ -98,7 +98,7 @@
     "proofId": "birthday-problem-oq-02-oq-01-oq-02",
     "range": {
       "startLine": 128,
-      "endLine": 141
+      "endLine": 140
     },
     "type": "concept",
     "title": "No-Collision Probability is Maximized at Uniform",

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -56,7 +56,7 @@
   {
     "id": "ann-parent-recovery",
     "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
-    "range": { "startLine": 112, "endLine": 126 },
+    "range": { "startLine": 112, "endLine": 117 },
     "type": "concept",
     "title": "The Parent's Identity as the a = 1 Corollary",
     "content": "integral_sin_mul_cos_pow_eq_reflect re-proves the parent's single-power reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ as the special case a = 1, b = m of the headline lemma (with sin θ ^ 1 = sin θ, cos θ ^ 1 = cos θ via pow_one, then one mul_comm). This confirms the new two-parameter statement is a genuine generalization of the parent rather than a cosmetic restatement, and that the bespoke reflection the parent performed by hand is subsumed by the reusable lemma the open question requested.",

--- a/src/data/proofs/buffons-needle/annotations.json
+++ b/src/data/proofs/buffons-needle/annotations.json
@@ -182,7 +182,7 @@
     "proofId": "buffons-needle",
     "range": {
       "startLine": 226,
-      "endLine": 259
+      "endLine": 254
     },
     "type": "concept",
     "title": "Applications and Context",

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-corollary",
     "proofId": "cauchy-interlacing-theorem-oq-01",
-    "range": { "startLine": 98, "endLine": 139 },
+    "range": { "startLine": 98, "endLine": 138 },
     "type": "insight",
     "title": "The Unconditional Compression Corollary",
     "content": "`cauchy_interlacing_compression`: the spectral data of `T` on `V` and of `compress T H` on `H` are pulled from Mathlib's spectral theorem (`eigenvectorBasis`, `eigenvalues`, `eigenvalues_antitone`), `rayleigh_compress_eq` supplies the Rayleigh hypothesis, and the parent's `cauchy_interlacing` then yields `λ(k.succ) ≤ μ(k) ∧ μ(k) ≤ λ(k.castSucc)`. No hypothesis is needed beyond 'T symmetric, H a codimension-one subspace'.",

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -100,7 +100,7 @@
     "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01",
     "range": {
       "startLine": 172,
-      "endLine": 196
+      "endLine": 194
     },
     "type": "insight",
     "title": "Robertson is the Corollary; the Gap is Cov²",

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/annotations.json
@@ -101,7 +101,7 @@
     "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02",
     "range": {
       "startLine": 130,
-      "endLine": 148
+      "endLine": 147
     },
     "type": "concept",
     "title": "Heisenberg as Special Case: [A,B] = c·id Simplifies commutatorEV to c",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-02/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
     "range": {
       "startLine": 255,
-      "endLine": 286
+      "endLine": 268
     },
     "type": "concept",
     "title": "Scope and Open Work Toward Full Jordan Normal Form",

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/annotations.json
@@ -123,7 +123,7 @@
     "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
     "range": {
       "startLine": 355,
-      "endLine": 396
+      "endLine": 387
     },
     "type": "concept",
     "title": "RCF Roadmap: ~1800 Lines of Missing Infrastructure",

--- a/src/data/proofs/cramers-rule-oq-01-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-04-oq-03/annotations.json
@@ -101,7 +101,7 @@
     "proofId": "cramers-rule-oq-01-oq-04-oq-03",
     "range": {
       "startLine": 159,
-      "endLine": 178
+      "endLine": 177
     },
     "type": "concept",
     "title": "The Adjugate Bridge back to Cramer's Rule",

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02/annotations.json
@@ -156,7 +156,7 @@
     "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02",
     "range": {
       "startLine": 168,
-      "endLine": 189
+      "endLine": 175
     },
     "type": "tactic",
     "title": "Consistency checks",

--- a/src/data/proofs/derangements-convergence-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-01-oq-02/annotations.json
@@ -92,7 +92,7 @@
     "proofId": "derangements-convergence-oq-03-oq-01-oq-02",
     "range": {
       "startLine": 225,
-      "endLine": 271
+      "endLine": 266
     },
     "type": "insight",
     "title": "Squeezed Between Consecutive Unit Fractions",

--- a/src/data/proofs/derangements-oq-03/annotations.json
+++ b/src/data/proofs/derangements-oq-03/annotations.json
@@ -124,7 +124,7 @@
     "proofId": "derangements-oq-03",
     "range": {
       "startLine": 348,
-      "endLine": 402
+      "endLine": 398
     },
     "type": "concept",
     "title": "Alternating Approximation: Even Overshoot, Odd Undershoot",

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/annotations.json
@@ -115,7 +115,7 @@
     "proofId": "dissection-of-cubes-oq-01-oq-01",
     "range": {
       "startLine": 285,
-      "endLine": 327
+      "endLine": 324
     },
     "type": "concept",
     "title": "Achievability and Lower Bound Tightness",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -172,7 +172,7 @@
   {
     "id": "ann-eqr-oq01x4-verifications",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02",
-    "range": { "startLine": 208, "endLine": 252 },
+    "range": { "startLine": 208, "endLine": 243 },
     "type": "concept",
     "title": "Concrete Verifications via native_decide",
     "content": "Five private `Fact` instances make small primes 3, 5, 7, 11, 13 available, then four `example` declarations verify QR for the prime pairs $(3,5), (3,7), (5,7), (11,13)$ via `native_decide`. **Each example is a closed term of QR for two specific primes** — a strong validation that the formalization is operationally correct, not just propositionally derivable. The closing comment block summarizes the full assembly with a status table.",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/annotations.json
@@ -74,7 +74,7 @@
   {
     "id": "ann-concrete-instances",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
-    "range": { "startLine": 175, "endLine": 212 },
+    "range": { "startLine": 175, "endLine": 210 },
     "type": "concept",
     "title": "Verification for Small Primes",
     "content": "The concrete instances for p = 3, 5, 7, 13 serve as **existential sanity checks** for the abstract theorem. They assert the existence of a complex number τ with τ² = ±p, not a specific value of τ.\n\nThe actual Gauss sums for small primes are: τ(3) = e^{2πi/3} - e^{4πi/3} ≈ i√3 (so τ² = -3); τ(5) = 2cos(2π/5) - 2cos(4π/5) = √5 (so τ² = 5); τ(7) ≈ i√7 (so τ² = -7); τ(13) = √13 (so τ² = 13). These values illustrate the general pattern: τ ∈ {±√p, ±i√p} depending on p mod 4, and τ² is always a **rational integer** despite τ itself being a transcendental complex number.\n\nThe closing summary table confirms **7 theorems proved with 0 sorries and 0 axioms**, fully discharging the goal stated in the opening docstring.",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-eqr-oq010301010101-headline",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 267, "endLine": 320 },
+    "range": { "startLine": 267, "endLine": 318 },
     "type": "theorem",
     "title": "Prime-power Zolotarev: legendre power and Jacobi form",
     "content": "sign_ringMulPerm_eq_legendre_pow inducts the one-step recursion on the exponent to get sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ (base case n = 1: the non-unit block is the singleton {0}, sign 1). jacobiSym_prime_pow proves J(A | pⁿ) = (legendreSym p A)ⁿ via jacobiSym.mul_right, and sign_ringMulPerm_eq_jacobiSym packages the headline as the Jacobi symbol J(a | pⁿ) — closing the prime-power case of the Frobenius/Zolotarev identity.",

--- a/src/data/proofs/erdos-1039-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1039-oq-03/annotations.json
@@ -86,7 +86,7 @@
   {
     "id": "erdos1039-oq03-ann-obstruction",
     "proofId": "erdos-1039-oq-03",
-    "range": { "startLine": 143, "endLine": 165 },
+    "range": { "startLine": 143, "endLine": 164 },
     "type": "insight",
     "title": "The critical-point obstruction — why the conformal route stalls",
     "content": "`conformal_estimate_vacuous_at_critical_point` exhibits the limitation as a theorem. The witness $f \\equiv 0$ has sublevel set all of $\\mathbb{C}$ (every disc inscribed) yet $f' \\equiv 0$, so the radius bound becomes $r \\le 1/0 = 0$ (Lean junk value) — false for $r>0$. This certifies that the $f'(c)\\ne 0$ hypothesis is genuinely necessary. Because the extremal inscribed disc of a real lemniscate tends to sit near a critical point where $f$ is flat, the direct conformal estimate carries no information exactly where it is needed — the structural reason KLR fall back on the area approach. The degeneracy is *proved*, not informally argued.",

--- a/src/data/proofs/erdos-11-oq-03/annotations.json
+++ b/src/data/proofs/erdos-11-oq-03/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-erdos11oq03-range",
     "proofId": "erdos-11-oq-03",
-    "range": { "startLine": 168, "endLine": 182 },
+    "range": { "startLine": 168, "endLine": 181 },
     "type": "tactic",
     "title": "Verified redundancy: ≥ 2 representations on 1 < n < 100 by one kernel decide",
     "content": "reprCount_odd_ge_two_range: ∀ n ∈ range 100, Odd n → 1 < n → 2 ≤ reprCount n. Because reprCount is a kernel-computable Nat (SquarefreeCheck reduces where Squarefree's minSqFac instance does not), a Finset.card inequality over the whole odd range discharges by a single kernel `decide` — no native_decide, hence no Lean.ofReduceBool. The bound is a genuine strengthening of the parent's 'verified representable' range to 'verified doubly representable': at least two distinct powers of two work, the minimum 2 being attained at n = 3, 5, 13, 29. isSquarefreePlusPow2_odd_range recovers the existence range as a weaker corollary. maxRecDepth 10000 lets the kernel walk the nested Finset.range recursions in the card computation — a resource budget, not a trust knob — and the trailing #print axioms confirms only propext / Classical.choice / Quot.sound.",

--- a/src/data/proofs/erdos-11-oq-03/meta.json
+++ b/src/data/proofs/erdos-11-oq-03/meta.json
@@ -102,7 +102,7 @@
       "id": "range",
       "title": "Verified Lower Bound by One Kernel decide",
       "startLine": 168,
-      "endLine": 182,
+      "endLine": 181,
       "summary": "reprCount_odd_ge_two_range: every odd 1 < n < 100 has 2 ≤ reprCount n (the representation is redundant, min 2 at n = 3, 5, 13, 29), by a single kernel decide on the reducible count (maxRecDepth 10000 is a recursion budget, not an axiom). isSquarefreePlusPow2_odd_range recovers the existence range as a weaker corollary. The trailing #print axioms confirms only propext / Classical.choice / Quot.sound — no Lean.ofReduceBool.",
       "mathContext": "$\\forall$ odd $n,\\ 1<n<100:\\ \\mathrm{reprCount}\\,n\\ge 2$, with $\\#\\mathrm{print\\ axioms}=\\{\\mathrm{propext},\\mathrm{Classical.choice},\\mathrm{Quot.sound}\\}$ only."
     }

--- a/src/data/proofs/erdos-307-oq-02/annotations.json
+++ b/src/data/proofs/erdos-307-oq-02/annotations.json
@@ -146,7 +146,7 @@
     "proofId": "erdos-307-oq-02",
     "range": {
       "startLine": 252,
-      "endLine": 298
+      "endLine": 296
     },
     "type": "concept",
     "title": "Remaining Open Goals: p-adic Disjointness and Size Bound",

--- a/src/data/proofs/erdos-335/annotations.json
+++ b/src/data/proofs/erdos-335/annotations.json
@@ -527,7 +527,7 @@
     "proofId": "erdos-335",
     "range": {
       "startLine": 500,
-      "endLine": 524
+      "endLine": 523
     },
     "type": "theorem",
     "title": "Schnirelmann ≤ Asymptotic Density Bridge",

--- a/src/data/proofs/gauss-lemma-primitive-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/gauss-lemma-primitive-oq-01-oq-02/annotations.json
@@ -113,7 +113,7 @@
     "proofId": "gauss-lemma-primitive-oq-01-oq-02",
     "range": {
       "startLine": 115,
-      "endLine": 130
+      "endLine": 115
     },
     "type": "theorem",
     "title": "Descent to ℤ and the Headline over ℚ",

--- a/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-package",
     "proofId": "geometric-series-oq-01-oq-01-oq-02",
-    "range": { "startLine": 81, "endLine": 107 },
+    "range": { "startLine": 81, "endLine": 101 },
     "type": "concept",
     "title": "Packaging and the η(−1) Connection",
     "content": "abel_value_quarter packages the conclusion: 1 − 2 + 3 − 4 + ⋯ is Abel summable to 1/4. The closing remarks situate 1/4 = η(−1) within the analytic continuation of the Dirichlet eta function, η(s) = (1 − 2¹⁻ˢ)ζ(s), connecting this elementary, fully-verified real-analysis computation to the celebrated ζ(−1) = −1/12. Everything stays inside elementary summability — no native_decide, no axioms.",

--- a/src/data/proofs/geometric-series-oq-06/annotations.json
+++ b/src/data/proofs/geometric-series-oq-06/annotations.json
@@ -74,7 +74,7 @@
   {
     "id": "geomseries-oq06-ann-summary",
     "proofId": "geometric-series-oq-06",
-    "range": { "startLine": 117, "endLine": 145 },
+    "range": { "startLine": 117, "endLine": 144 },
     "type": "concept",
     "title": "Summary table and #check sanity",
     "content": "A markdown summary table lists all six results with their backing Mathlib lemmas, and re-derives the differentiation heuristic $\\sum r^n = 1/(1-r) \\Rightarrow \\sum n r^{n-1} = 1/(1-r)^2$. The trailing `#check`s confirm the exported signatures elaborate. Together these document that the entry's value is a clean, named gallery API over Mathlib's weighted-geometric lemmas, plus the genuinely-derived shifted companion.",

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -81,7 +81,7 @@
   {
     "id": "ann-card-descentfree",
     "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01",
-    "range": { "startLine": 115, "endLine": 125 },
+    "range": { "startLine": 115, "endLine": 122 },
     "type": "insight",
     "title": "The Descent-Free Base Rung ⟨n+1,0⟩ = 1",
     "content": "card_descentFree: the descent-free permutations of Fin (n+1) number exactly the Eulerian number ⟨n+1,0⟩ = 1. Using eulerian_succ_zero (the left border of the Eulerian triangle is 1) and Finset.card_eq_one, the goal reduces to exhibiting a unique element of the descent-free class — which descentCount_eq_zero_iff identifies as the identity. This is the k = 0 case of the open claim |{σ : descentCount σ = k}| = ⟨n+1,k⟩, the first rung where the abstract Eulerian number is matched against an actual descent-class cardinality.",

--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-03/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-bonferroni",
     "proofId": "inclusion-exclusion-oq-04-oq-03",
-    "range": { "startLine": 249, "endLine": 285 },
+    "range": { "startLine": 249, "endLine": 284 },
     "type": "insight",
     "title": "The Bonferroni Inequalities and the Exact Endpoint",
     "content": "`bonferroni_even` (m even ⟹ noneCard A ≤ bonf A m) and `bonferroni_odd` (m odd ⟹ bonf A m ≤ noneCard A) follow immediately from the core sign statement by specializing the parity of (-1)^m. `bonf_eq_noneCard_of_card_le` closes the circle: once m ≥ |ι|, every deg A x ≤ |ι| ≤ m forces C(deg−1, m) = 0 (Nat.choose_eq_zero_of_lt), so altPartial (deg A x) m becomes the exact indicator [deg A x = 0] and the truncated sieve equals the true count — the exact inclusion–exclusion principle as the endpoint of the Bonferroni ladder.",

--- a/src/data/proofs/infinitude-primes-4k1-oq-02/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k1-oq-02/annotations.json
@@ -96,7 +96,7 @@
   {
     "id": "ann-corollaries",
     "proofId": "infinitude-primes-4k1-oq-02",
-    "range": { "startLine": 243, "endLine": 260 },
+    "range": { "startLine": 243, "endLine": 250 },
     "type": "theorem",
     "title": "representation_unique_up_to_order / two_repr_unique — Corollaries",
     "content": "Two packagings of the main theorem: representation_unique_up_to_order restates uniqueness as the Multiset equality {a,b} = {c,d} (the swapped case uses Multiset.pair_comm), and two_repr_unique specializes to p = 2 to conclude that 2 = 1² + 1² is the only way to write 2 as a sum of two squares.",

--- a/src/data/proofs/kroneckers-jugendtraum/annotations.json
+++ b/src/data/proofs/kroneckers-jugendtraum/annotations.json
@@ -244,7 +244,7 @@
     "proofId": "kroneckers-jugendtraum",
     "range": {
       "startLine": 335,
-      "endLine": 371
+      "endLine": 362
     },
     "type": "concept",
     "title": "Problem Status Summary",

--- a/src/data/proofs/little-wedderburn-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/little-wedderburn-oq-02-oq-02/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "moebius-necklace",
     "proofId": "little-wedderburn-oq-02-oq-02",
-    "range": { "startLine": 171, "endLine": 202 },
+    "range": { "startLine": 171, "endLine": 201 },
     "type": "theorem",
     "title": "Möbius Inversion: Gauss's Necklace Formula",
     "content": "With the intrinsic count Nirr p d in hand, degree_identity reads p^m = Σ_{d∣m} d·N(d) for all m. Casting to ℤ and applying ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq inverts this divisor-sum relation into necklace_formula: n·N(n) = Σ_{(a,b): ab=n} μ(a)·p^b, i.e. n·N(n) = Σ_{d∣n} μ(n/d)·p^d — Gauss's count of monic irreducible polynomials of degree n over 𝔽_p.",

--- a/src/data/proofs/markov-equation-oq-02/annotations.json
+++ b/src/data/proofs/markov-equation-oq-02/annotations.json
@@ -82,7 +82,7 @@
   {
     "id": "markov-oq02-ann-sanity",
     "proofId": "markov-equation-oq-02",
-    "range": { "startLine": 97, "endLine": 105 },
+    "range": { "startLine": 97, "endLine": 104 },
     "type": "concept",
     "title": "Sanity Checks on Small Markov Triples",
     "content": "Four example checks instantiate markov_not_three_dvd on the smallest Markov triples (1,1,1), (1,1,2), (1,2,5), (2,5,29), confirming 3 ∤ 1, 3 ∤ 2, 3 ∤ 5, 3 ∤ 29 — concrete witnesses that the rigidity statement is non-vacuous and matches the known Markov numbers.",

--- a/src/data/proofs/property-b-first-moment-oq-01/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-01/annotations.json
@@ -74,7 +74,7 @@
   {
     "id": "propb-upper-oq01-ann-sharp",
     "proofId": "property-b-first-moment-oq-01",
-    "range": { "startLine": 141, "endLine": 152 },
+    "range": { "startLine": 141, "endLine": 151 },
     "type": "concept",
     "title": "Sharp bound m(3) ≤ 7 and why it beats the general bound",
     "content": "`exists_notTwoColorable_three` packages the Fano plane into $m(3) \\le 7$, and `fano_beats_general` (`decide`) records $7 < \\binom{5}{3} = 10$, so the Fano witness strictly improves the general bound at $k=3$. In fact $m(3) = 7$, so the Fano plane is extremal — the upper bound meets the truth here, while the parent's $2^{3-1}=4$ lower bound is not tight.",

--- a/src/data/proofs/schauder-fixed-point-oq-04/annotations.json
+++ b/src/data/proofs/schauder-fixed-point-oq-04/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-nonempty-compact",
     "proofId": "schauder-fixed-point-oq-04",
-    "range": { "startLine": 71, "endLine": 79 },
+    "range": { "startLine": 71, "endLine": 78 },
     "type": "theorem",
     "title": "Nonempty Compact Fixed-Point Set",
     "content": "Combining the two: the fixed-point set of a continuous self-map of $[a,b]$ is **nonempty** (1D Brouwer) and **compact** (closed subset of the compact interval). Where the base Schauder entry stops at existence, this records the full topological shape of the solution set — a nonempty compactum, so e.g. it has a least and greatest fixed point.",

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-02/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-02/annotations.json
@@ -62,7 +62,7 @@
   {
     "id": "ann-output-power",
     "proofId": "shannon-channel-coding-awgn-oq-02",
-    "range": { "startLine": 82, "endLine": 108 },
+    "range": { "startLine": 82, "endLine": 96 },
     "type": "insight",
     "title": "The Output Power E[Y²] = P + N",
     "content": "`awgn_output_power` is the headline: substituting the named powers $P=\\mathbb{E}[X^2]$, $N=\\mathbb{E}[Z^2]$ into the additivity lemma yields $\\mathbb{E}[(X+Z)^2]=P+N$ — exactly the quantity the parent converse assumes as `hvar`, now derived. `awgn_output_variance` restates it through Mathlib's `variance`: $\\mathrm{Var}[X+Z]=P+N$, obtained by applying the centered second-moment bridge to $X+Z$ (whose mean vanishes). The conceptual payoff: the converse's variance budget $\\le P+N$ is the genuine power accounting of an additive channel, not an external hypothesis, and the identity holds for any additive-noise channel — Gaussianity is needed only for the entropy half of the capacity.",


### PR DESCRIPTION
## Structural enrichment: range-past-EOF clamp

A gallery-wide structural scan (4795 entries) found **40 entries** whose final annotation or section `range.endLine` pointed **past the last line of the actual Lean proof file**. The recorded `lineCount` is accurate in every case (verified against `wc -l`); only the range's end value was set a few lines too far, so the gallery highlights a code region that runs off the end of the file.

### Fix
Each edit clamps only the overshooting `endLine` down to the file's true last line — a **pure single-line change per file** (41 insertions / 41 deletions total), original formatting otherwise untouched. Every clamped range is a *tail* range whose `startLine` is valid, so the intent is unambiguous: the closing annotation covers through EOF.

Examples: `gauss-lemma-primitive-oq-01-oq-02` `115-130 → 115-115`, `de-moivre-…-oq-02` `168-189 → 168-175`, `cayley-hamilton-minpoly-…` `255-286 → 255-268`, `shannon-channel-coding-awgn-oq-02` `82-108 → 82-96`.

### Deliberately deferred (not touched)
Six **Pattern-B** entries whose annotations *start* past EOF — stale annotation files written against a longer/rewritten Lean source. These need a content audit/rewrite, not a clamp:
`shannon-entropy-oq-03` (annotations to line 341 on a 92-line file), `sqrt2-plus-sqrt3-irrational-oq-03`, `inverse-galois-d4-oq-02-oq-03`, `inverse-galois-d4-oq-02-oq-03-oq-01-oq-01`, `erdos-482`, `simson-line-theorem-oq-01`.

Multi-file entries (per-companion sections that legitimately restart at `[1..N]`) were excluded from the scan to avoid false positives.

### Verification
- All 41 changed JSON files parse.
- `pnpm build` data pipeline + search-index checks pass.
- `tsc --noEmit` clean.