### PR TITLE
Research: erdos-1014-oq-03 — increment–ratio bridge for the Ramsey increment [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03.lean
+++ b/proofs/Proofs/Erdos1014OQ03.lean
@@ -1,0 +1,95 @@
+/-
+Erdős Problem #1014 OQ-03: The consecutive off-diagonal Ramsey increment
+Δ_l(k) = R(k, l+1) − R(k, l)
+
+The parent problem (Erdős #1014) proves the *ratio* convergence
+`R(k,l+1)/R(k,l) → 1`. OQ-03 asks whether the *increment* `Δ_l(k)` admits a clean
+asymptotic formula `Δ_l(k) ~ g_k(l)`. The full asymptotic is OPEN and is **not**
+asserted here.
+
+## A cautionary observation about the naive derivation
+
+A tempting "Approach A" derives the increment asymptotic from a power law
+`R(k,l) ~ c_k · l^{k-1}/(log l)^{k-2}` by expanding
+`Δ_l(k) = R(k,l)·((l+1)/l)^{k-1}(1+o(1)) − R(k,l)`. This is **not valid from
+asymptotic equivalence alone**: the consecutive difference of a sequence is *not*
+determined by its asymptotic equivalence class. For example `u_l = l²` and
+`v_l = l² + l·sin l` satisfy `u ~ v` yet have wildly different increments
+(`u_{l+1}−u_l = 2l+1` versus an `Θ(l)`-oscillating difference for `v`). So the
+expansion secretly assumes the *ratio* asymptotic `R(k,l+1)/R(k,l) → ((l+1)/l)^{k-1}`,
+which does not follow from `R(k,l) ~ g(l)`. A rigorous increment statement must
+hypothesize the ratio (or a regularity/monotonicity) condition directly.
+
+## What is proved here (unconditional, self-contained)
+
+The **increment–ratio bridge**: for any positive sequence `R`, the normalized
+increment equals the consecutive ratio minus one,
+
+    (R(l+1) − R(l)) / R(l) = R(l+1)/R(l) − 1,
+
+so the increment is `o(R(l))` **iff** the consecutive ratio tends to `1`. Applied to
+`R(k,·)` this converts Erdős #1014's proven ratio-convergence
+`R(k,l+1)/R(k,l) → 1` into the rigorous increment consequence
+`Δ_l(k) = o(R(k,l))` — the correct, hypothesis-honest bridge from #1014 to increment
+behavior, sidestepping the invalid power-law expansion above.
+
+Verified, 0 axioms, 0 sorries, no `native_decide`.
+
+References:
+- Erdős [Er71], Problem 1014
+- Erdős–Szekeres (1935), AKS (1980), Kim (1995): `R(3,l) = Θ(l²/log l)`
+-/
+
+import Mathlib
+
+namespace Erdos1014OQ03
+
+open Filter Topology
+
+/-- **The increment–ratio identity.** For a sequence `R` with `R l ≠ 0`, the
+normalized consecutive increment equals the consecutive ratio minus one:
+
+`(R(l+1) − R(l)) / R(l) = R(l+1)/R(l) − 1`.
+
+Purely algebraic; the engine of the increment–ratio bridge below. -/
+theorem increment_div_eq_ratio_sub_one (R : ℕ → ℝ) (l : ℕ) (h : R l ≠ 0) :
+    (R (l + 1) - R l) / R l = R (l + 1) / R l - 1 := by
+  rw [sub_div, div_self h]
+
+/-- **Increment–ratio bridge.** For an eventually-nonzero sequence `R`, the
+normalized increment `(R(l+1) − R(l))/R(l)` tends to `0` **iff** the consecutive
+ratio `R(l+1)/R(l)` tends to `1`.
+
+Applied to `R(k, ·)` for fixed `k`, the right-hand side is exactly Erdős #1014's
+ratio-convergence statement `R(k,l+1)/R(k,l) → 1`; the left-hand side says the
+Ramsey increment is `o(R(k,l))`, i.e. `Δ_l(k) = R(k,l+1) − R(k,l) = o(R(k,l))`.
+Thus #1014 rigorously yields `Δ_l(k) = o(R(k,l))` with no extra hypotheses — the
+honest increment consequence, avoiding the (invalid-from-`~`-alone) power-law
+expansion. -/
+theorem increment_div_tendsto_zero_iff_ratio_tendsto_one (R : ℕ → ℝ)
+    (hpos : ∀ᶠ l in atTop, R l ≠ 0) :
+    Tendsto (fun l => (R (l + 1) - R l) / R l) atTop (𝓝 0) ↔
+      Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 1) := by
+  have heq : (fun l => (R (l + 1) - R l) / R l)
+      =ᶠ[atTop] (fun l => R (l + 1) / R l - 1) := by
+    filter_upwards [hpos] with l hl using increment_div_eq_ratio_sub_one R l hl
+  rw [tendsto_congr' heq]
+  constructor
+  · intro h
+    have h1 := h.add_const 1
+    simpa using h1
+  · intro h
+    have h1 := h.sub_const 1
+    simpa using h1
+
+/-- **Corollary (the increment is `o(R)`).** If the consecutive ratio tends to `1`
+then the normalized increment tends to `0`. This is the forward direction, packaged
+for direct use: fed Erdős #1014's `R(k,l+1)/R(k,l) → 1`, it delivers
+`(R(k,l+1) − R(k,l))/R(k,l) → 0`. -/
+theorem increment_div_tendsto_zero_of_ratio_tendsto_one (R : ℕ → ℝ)
+    (hpos : ∀ᶠ l in atTop, R l ≠ 0)
+    (hratio : Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 1)) :
+    Tendsto (fun l => (R (l + 1) - R l) / R l) atTop (𝓝 0) :=
+  (increment_div_tendsto_zero_iff_ratio_tendsto_one R hpos).mpr hratio
+
+end Erdos1014OQ03

--- a/research/problems/erdos-1014-oq-03/knowledge.md
+++ b/research/problems/erdos-1014-oq-03/knowledge.md
@@ -1,21 +1,44 @@
 # Knowledge Base: erdos-1014-oq-03
 
-Insights accumulated during research on this problem.
+Asymptotics of the consecutive off-diagonal Ramsey increment Δ_l(k) = R(k,l+1) − R(k,l).
 
 ---
 
-## Problem Understanding
+## Session 2026-07-09 (researcher-8) — increment–ratio bridge [VERIFIED]
 
-[Initial observations about the problem will be recorded here]
+**Mode**: FRESH (iteration 1, OBSERVE → ACT). **Outcome**: progress
+(new file `Erdos1014OQ03.lean`, 3 theorems, **VERIFIED [7743] 0 sorry / 0 axiom**).
 
----
+### Key mathematical finding (corrects the problem's proposed Approach A)
+The problem statement's "Approach A" proposes deriving the increment asymptotic from a power
+law `R(k,l) ~ c_k·l^{k-1}/(log l)^{k-2}` by expanding `Δ_l = R(l)·((l+1)/l)^{k-1}(1+o(1)) − R(l)`.
+**This is invalid from asymptotic equivalence alone.** A sequence's consecutive difference is
+NOT determined by its `~`-equivalence class: `u_l = l²` and `v_l = l² + l·sin l` satisfy `u ~ v`
+but `u_{l+1}−u_l = 2l+1` while `v`'s increment oscillates at order `l`. The expansion secretly
+assumes the *ratio* asymptotic `R(l+1)/R(l) → ((l+1)/l)^{k-1}`, which does not follow from
+`R(l) ~ g(l)`. A rigorous increment statement must hypothesize the ratio (or regular
+variation / monotonicity) directly. **So the "tractable target" as written needs a stronger
+hypothesis than stated.**
 
-## Insights
+### What I proved (unconditional, self-contained, no Ramsey import)
+The correct bridge that IS valid:
+- `increment_div_eq_ratio_sub_one` — `(R(l+1) − R(l))/R(l) = R(l+1)/R(l) − 1` (algebraic engine,
+  `rw [sub_div, div_self h]`).
+- `increment_div_tendsto_zero_iff_ratio_tendsto_one` — for eventually-nonzero `R`, the
+  normalized increment `→ 0` **iff** the consecutive ratio `→ 1`. Proof: the two functions are
+  eventually equal (via the identity), `tendsto_congr'`, then `Tendsto.add_const/​sub_const`.
+- `increment_div_tendsto_zero_of_ratio_tendsto_one` — forward corollary.
 
-[Insights from research attempts will be accumulated here]
+**Payoff.** Fed Erdős #1014's proven ratio-convergence `R(k,l+1)/R(k,l) → 1`, the bridge yields
+the rigorous, hypothesis-free increment consequence `Δ_l(k) = o(R(k,l))` — the honest bridge
+from #1014 to increment behavior, sidestepping the invalid power-law expansion.
 
----
+### Still open
+The full increment asymptotic `Δ_l(k) ~ g_k(l)` (conjecturally `~ c·l/log l` for `k=3`) remains
+OPEN — it requires a genuine ratio/regular-variation hypothesis on `R(k,·)`, not obtainable from
+the `~` asymptotic alone, and is entangled with the still-open matching of the `Θ(l²/log l)`
+constants for `R(3,l)`.
 
-## Dead Ends
-
-[Approaches known not to work will be documented here]
+### Files
+- `proofs/Proofs/Erdos1014OQ03.lean` (new, 95 lines, 3 theorems, 0 sorry / 0 axiom)
+- `src/data/research/problems/erdos-1014-oq-03.json` (leanFiles + knowledge)

--- a/research/problems/erdos-1014-oq-03/state.md
+++ b/research/problems/erdos-1014-oq-03/state.md
@@ -1,16 +1,16 @@
 # Research State: erdos-1014-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T15:40:17-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Delivered the increment-ratio bridge (VERIFIED). Found Approach A invalid from ~ alone.
 
 ## Active Approach
-None yet.
+Increment-ratio bridge (DONE). Full asymptotic needs a ratio/regular-variation hypothesis.
 
 ## Attempt Count
 - Total attempts: 0
@@ -21,5 +21,4 @@ None yet.
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+The elementary bridge is complete and verified. The remaining open asymptotic Delta_l(k) ~ g_k(l) is not session-sized (needs a regular-variation hypothesis + the R(3,l) constant matching, both open).

--- a/src/data/research/problems/erdos-1014-oq-03.json
+++ b/src/data/research/problems/erdos-1014-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1014-oq-03",
   "title": "Does R(k,l+1) - R(k,l) have a meaningful asymptotic formula for fixed k",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -42,8 +42,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
+    "progressSummary": "VERIFIED (researcher-8, 2026-07-09, [7743] 0 sorry/0 axiom): new file Erdos1014OQ03.lean. KEY FINDING: the proposed Approach A (deriving the increment asymptotic from R(k,l) ~ c*l^{k-1}/(log l)^{k-2}) is INVALID from asymptotic equivalence alone — a sequence's consecutive difference is not determined by its ~-class (l^2 vs l^2+l*sin l are equivalent, different increments); the expansion secretly assumes the ratio asymptotic. Proved the CORRECT unconditional increment-ratio bridge instead: (R(l+1)-R(l))/R(l) = R(l+1)/R(l)-1 (increment_div_eq_ratio_sub_one), hence the normalized increment -> 0 IFF the consecutive ratio -> 1 (increment_div_tendsto_zero_iff_ratio_tendsto_one). Fed Erdos #1014's proven R(k,l+1)/R(k,l)->1, this yields the rigorous, hypothesis-free increment consequence Delta_l(k) = o(R(k,l)). Abstract over positive real sequences (no Ramsey import). The full asymptotic Delta_l(k) ~ g_k(l) remains OPEN (needs a ratio/regular-variation hypothesis, not derivable from ~ alone).",
+    "builtItems": [
+      "increment_div_eq_ratio_sub_one — (R(l+1)-R(l))/R(l) = R(l+1)/R(l)-1 (algebraic engine).",
+      "increment_div_tendsto_zero_iff_ratio_tendsto_one — normalized increment ->0 IFF consecutive ratio ->1; converts #1014's ratio convergence into Delta_l(k)=o(R(k,l)).",
+      "increment_div_tendsto_zero_of_ratio_tendsto_one — forward corollary packaged for direct use."
+    ],
     "insights": [],
     "mathlibGaps": [],
     "nextSteps": [
@@ -126,6 +130,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1014Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1014OQ03.lean",
+      "filename": "Erdos1014OQ03.lean",
+      "lineCount": 95,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1014OQ03.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary — VERIFIED [7743 jobs], 0 sorry / 0 axiom

Fresh problem (OQ-03): asymptotics of the consecutive off-diagonal Ramsey increment
`Δ_l(k) = R(k,l+1) − R(k,l)`. New self-contained file `Erdos1014OQ03.lean`.

### Mathematical finding (corrects the proposed Approach A)
The problem's "Approach A" — deriving the increment asymptotic from a power law
`R(k,l) ~ c·l^{k-1}/(log l)^{k-2}` — is **invalid from asymptotic equivalence alone**: a
sequence's consecutive difference is not determined by its `~`-class (`l²` and `l² + l·sin l`
are equivalent but have different increments). The expansion secretly assumes the *ratio*
asymptotic, which does not follow from `R(l) ~ g(l)`.

### What's proved (the correct, unconditional bridge)
- `increment_div_eq_ratio_sub_one` — `(R(l+1) − R(l))/R(l) = R(l+1)/R(l) − 1`.
- `increment_div_tendsto_zero_iff_ratio_tendsto_one` — for eventually-nonzero `R`, the
  normalized increment `→ 0` **iff** the consecutive ratio `→ 1`.
- `increment_div_tendsto_zero_of_ratio_tendsto_one` — forward corollary.

**Payoff:** fed Erdős #1014's proven ratio-convergence `R(k,l+1)/R(k,l) → 1`, the bridge yields
the rigorous, hypothesis-free increment consequence `Δ_l(k) = o(R(k,l))` — the honest bridge
from #1014 to increment behavior, avoiding the invalid power-law expansion. Abstract over
positive real sequences (no Ramsey import).

The full asymptotic `Δ_l(k) ~ g_k(l)` remains OPEN (needs a ratio/regular-variation hypothesis,
not derivable from `~` alone).

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos1014OQ03` → `Build completed successfully (7743 jobs)`.
0 sorries, 0 `axiom` declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)