### PR TITLE
audit(hilbert-14): fix phantom nagata_counterexample mainTheorem

### DIFF
--- a/src/data/proofs/hilbert-14/meta.json
+++ b/src/data/proofs/hilbert-14/meta.json
@@ -180,10 +180,10 @@
   ],
   "mainTheorems": [
     {
-      "name": "nagata_counterexample",
+      "name": "polynomial_ring_over_field_noetherian",
       "type": "core",
-      "description": "Hilbert's 14th: Nagata's counterexample shows invariant rings need not be finitely generated",
-      "leanType": "exists G action, not (FinitelyGenerated (invariantRing G))"
+      "description": "Foundation for Hilbert's 14th (Hilbert's Basis Theorem, via Mathlib): the polynomial ring k[x_1,...,x_n] over a field is Noetherian. NOTE: the 14th problem itself -- Nagata's counterexample and the reductive-group finiteness theorem -- is expository doc-comment only and is NOT formalized in this file.",
+      "leanType": "(k : Type*) [Field k] (n : ℕ) : IsNoetherianRing (MvPolynomial (Fin n) k)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: hilbert-14 (Hilbert's Fourteenth Problem)
**Problem**: The `mainTheorems` field advertised a phantom `core` theorem that does not exist in the Lean source, overstating what is formalized.

## Evidence

**meta.json claimed** (mainTheorems):
- name: `nagata_counterexample`, type: `core`
- leanType: `exists G action, not (FinitelyGenerated (invariantRing G))`

**Lean file shows** (`proofs/Proofs/Hilbert14Invariants.lean`): no `nagata_counterexample` declaration exists. The only proved theorems are Hilbert's Basis Theorem re-exports (`hilbert_basis_theorem_univariate`, `polynomial_ring_noetherian`, `field_is_noetherian`, `polynomial_ring_over_field_noetherian`) plus two definitions. The Nagata counterexample appears only as doc-comments (lines 252-279); line 365 explicitly states it "requires explicit construction of the group" and is unformalized.

This directly contradicted the entry's own honest `assumptions` and `originalContributions` fields, which correctly state Hilbert's 14th is NOT formalized.

## Fix

Replaced the phantom mainTheorem with `polynomial_ring_over_field_noetherian` (the actual proved headline — Hilbert's Basis Theorem via Mathlib), with a scope note that the 14th problem itself is expository only. `status: axiomatized` / `badge: wip` / counts unchanged (already correct).

---
Discovered during gallery integrity audit.