### PR TITLE
fix(algebraic-numbers-countable-oq-07): add missing solution file to leanFiles

### DIFF
--- a/src/data/research/problems/algebraic-numbers-countable-oq-07.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-07.json
@@ -66,6 +66,17 @@
   },
   "leanFiles": [
     {
+      "path": "Proofs/AlgebraicRealsNull.lean",
+      "filename": "AlgebraicRealsNull.lean",
+      "lineCount": 273,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicRealsNull.lean"
+    },
+    {
       "path": "Proofs/AlgebraicNumbersCountable.lean",
       "filename": "AlgebraicNumbersCountable.lean",
       "lineCount": 255,
@@ -344,5 +355,5 @@
     "almost-everywhere"
   ],
   "started": "2026-06-21",
-  "lastUpdate": "2026-06-21"
+  "lastUpdate": "2026-07-09"
 }


### PR DESCRIPTION
## Summary

Integrity fix for the gallery entry **algebraic-numbers-countable-oq-07** ("The Algebraic Reals are Lebesgue-Null"), which is `COMPLETED`.

Its `leanFiles` array listed **21 parent-family sibling files** (`AlgebraicNumbersCountable*.lean`) but **omitted its own solution file**, `AlgebraicRealsNull.lean` — the file that actually proves the null / conull / Hausdorff-dimension-zero results and is referenced throughout the entry's `knowledge.builtItems`. No other problem meta references `AlgebraicRealsNull.lean`, confirming it belongs here.

This PR inserts `AlgebraicRealsNull.lean` as the primary `leanFiles` entry with counts verified against the source on `main`:

| field | value |
|-------|-------|
| lineCount | 273 |
| theoremCount | 16 |
| axiomCount | 0 |
| defCount | 1 |
| sorryCount | 0 |

Data-only change (one JSON meta); no Lean sources touched. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)