### PR TITLE
audit: herons-formula re-verified CLEAN — bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20432,8 +20432,8 @@
     },
     "herons-formula": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:02:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:00:00Z",
       "result": "clean"
     },
     "herons-formula-oq-01": {


### PR DESCRIPTION
## Audit: herons-formula (Heron's Formula, Wiedijk #57)

**Result: CLEAN** — Tier B Mathlib bridge, honestly presented.

### Verification
- `heron_formula := Theorems100.heron h₁ h₂` — genuine delegation to Mathlib's Archive proof
- Delegation clearly disclosed in `proofStrategy`, `mathlibDependencies`, and section prose
- badge=`mathlib` + status=`verified` correct for a Mathlib-bridge entry
- `originalContributions` correctly scope only the wrapper work (computable defs, `ring` expansion, non-negativity via triangle inequality, 3 `norm_num` numerical examples)

### Counts (all accurate vs source)
| field | meta | source |
|-------|------|--------|
| lineCount | 268 | 268 ✓ |
| axiomCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| theoremCount | 10 | 10 ✓ |
| definitionCount | 3 | 3 ✓ |

No True stubs, no `native_decide`. mainTheorem `heron_formula` exists and matches.

Tracker: auditCount 3→4, lastAudited bumped.

---
Discovered during gallery integrity audit.