### PR TITLE
audit: hermite-lindemann re-verified CLEAN — bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20408,8 +20408,8 @@
     },
     "hermite-lindemann": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:02:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T00:05:00Z",
       "result": "clean"
     },
     "hermite-sawtooth-identity": {


### PR DESCRIPTION
## Audit: hermite-lindemann

**Result: CLEAN** — exemplary honest single-axiom scaffold (Tier C, correctly badged).

### Verification
- Single axiom `hermite_lindemann : ∀ α:ℂ, α≠0 → IsAlgebraic ℚ α → Transcendental ℤ (Complex.exp α)` — deep analytic number theory not in Mathlib, honestly disclosed in `assumptions`
- All 5 corollaries **genuinely derived** from the axiom (not True-stubs):
  - `e_transcendental_int`, `e_transcendental_rationals`
  - `pi_transcendental` — real proof via Euler's identity exp(iπ)=−1 + algebraic closure
  - `pi_transcendental_real`, `exp_int_transcendental`
- `status=axiomatized` / `badge=axiom` correct
- No True stubs, no `sorry`, no `native_decide`

### Counts (accurate vs source)
| field | meta | source |
|-------|------|--------|
| lineCount | 373 | 373 ✓ |
| axiomCount | 1 | 1 ✓ |
| sorries | 0 | 0 ✓ |
| theoremCount | 5 | 5 ✓ |
| definitionCount | 1 | 1 ✓ |

Minor (not fixed, benign): mainTheorems `leanType` labels paraphrase over ℚ/Real.exp while the axiom is stated over ℤ/Complex.exp — conceptual labels, provably equivalent for these numbers.

Tracker: auditCount 3→4.

---
Discovered during gallery integrity audit.