### PR TITLE
research(cayley-hamilton-oq-02-oq-02): commutant dimension dim_K C(M)=n for nonderogatory M

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
@@ -72,7 +72,7 @@ theorem centralizer_eq_adjoin_of_nonderogatory
     have hcomm : A * M = M * A := (hA M (by simp)).symm
     obtain ⟨p, rfl⟩ :=
       CyclicCommutant.commuting_matrix_is_polynomial M v hcyc A hcomm
-    rw [Algebra.adjoin_singleton_eq_range_aeval]
+    rw [Algebra.adjoin_singleton_eq_range_aeval K M]
     exact ⟨p, rfl⟩
   · -- `K[M] ⊆ C(M)`: `M` commutes with `M`, so `adjoin K {M}` centralizes `M`.
     apply Algebra.adjoin_le

--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
@@ -1,0 +1,157 @@
+/-
+  Dimension of the commutant: `dim_K C(M) = n` for nonderogatory `M`
+  (cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02)
+
+  The triple equivalence for a single `n × n` matrix `M` over a field `K`
+  (Hoffman & Kunze §7.5, Roman §10.4) links
+
+      (i)   `M` admits a cyclic vector
+      (ii)  `M` is nonderogatory  (`minpoly K M = charpoly M`)
+      (iii) the centralizer `C(M) = {N : NM = MN}` equals `K[M] = Algebra.adjoin K {M}`.
+
+  The sibling development supplies:
+    * `CyclicCommutant.commuting_matrix_is_polynomial` — the forward edge
+      **(i) ⟹ (iii)** (a cyclic vector forces every commuting matrix to be a
+      polynomial in `M`);
+    * `CyclicCommutantConverse.centralizer_eq_adjoin_implies_nonderogatory` — the
+      converse edge **(iii) ⟹ (ii)**;
+    * `CyclicVectorBiconditional.nonderogatory_iff_has_cyclic_vector` — **(ii) ⟺ (i)**;
+    * `CyclicCommutantConverse.finrank_adjoin_eq_natDegree_minpoly` —
+      `dim_K K[M] = deg(minpoly K M)`;
+    * `CyclicCommutantConverse.finrank_centralizer_ge` — the Frobenius bound
+      `n ≤ dim_K C(M)`.
+
+  This file closes the **(ii) ⟹ (iii)** edge, packaging the full biconditional
+  `C(M) = K[M] ⟺ M nonderogatory`, and draws the headline **dimension count**:
+
+      for a nonderogatory `M`,      `dim_K C(M) = n`.
+
+  Indeed a nonderogatory `M` has a cyclic vector (ii ⟹ i), so its centralizer is
+  exactly `K[M]` (i ⟹ iii); and `dim_K K[M] = deg(minpoly K M) = deg(charpoly M)
+  = n`.  This is the equality case of the Frobenius bound `dim_K C(M) ≥ n`: the
+  commutant of a nonderogatory matrix is as small as it can possibly be.
+
+  All results are `0`-sorry / `0`-axiom on top of Mathlib and the sibling files.
+-/
+import Mathlib
+import Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01
+
+open Matrix Polynomial
+
+noncomputable section
+
+namespace CyclicCommutantDimension
+
+open GeneralCyclicVector
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-! ### The forward edge (ii) ⟹ (iii): nonderogatory ⟹ `C(M) = K[M]` -/
+
+/-- **Forward edge of the triple equivalence (ii) ⟹ (iii).**  If `M` is
+    nonderogatory (`minpoly K M = charpoly M`), then its centralizer coincides
+    with the algebra of polynomials in `M`:
+
+      `C(M) = {N : NM = MN} = Algebra.adjoin K {M} = K[M]`.
+
+    The inclusion `K[M] ⊆ C(M)` is automatic (polynomials in `M` commute with
+    `M`).  For `C(M) ⊆ K[M]`: nonderogatory `M` has a cyclic vector (parent
+    biconditional), and `commuting_matrix_is_polynomial` then writes every matrix
+    commuting with `M` as a polynomial in `M`. -/
+theorem centralizer_eq_adjoin_of_nonderogatory
+    (M : Matrix (Fin n) (Fin n) K) (hM : minpoly K M = M.charpoly) :
+    Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))
+      = Algebra.adjoin K ({M} : Set (Matrix (Fin n) (Fin n) K)) := by
+  -- nonderogatory ⟹ cyclic vector
+  obtain ⟨v, hcyc⟩ :=
+    (CyclicVectorBiconditional.nonderogatory_iff_has_cyclic_vector M).mp hM
+  apply le_antisymm
+  · -- `C(M) ⊆ K[M]`: a commuting matrix is a polynomial in `M`.
+    intro A hA
+    rw [Subalgebra.mem_centralizer_iff] at hA
+    have hcomm : A * M = M * A := (hA M (by simp)).symm
+    obtain ⟨p, rfl⟩ :=
+      CyclicCommutant.commuting_matrix_is_polynomial M v hcyc A hcomm
+    rw [Algebra.adjoin_singleton_eq_range_aeval]
+    exact ⟨p, rfl⟩
+  · -- `K[M] ⊆ C(M)`: `M` commutes with `M`, so `adjoin K {M}` centralizes `M`.
+    apply Algebra.adjoin_le
+    intro x hx
+    rw [Set.mem_singleton_iff] at hx
+    subst hx
+    rw [SetLike.mem_coe, Subalgebra.mem_centralizer_iff]
+    intro g hg
+    rw [Set.mem_singleton_iff] at hg
+    subst hg
+    rfl
+
+/-! ### The full (ii) ⟺ (iii) biconditional -/
+
+/-- **Commutant characterization of nonderogatory matrices.**  The centralizer of
+    `M` equals `K[M]` **iff** `M` is nonderogatory.  This packages the new
+    forward edge with the sibling converse
+    `centralizer_eq_adjoin_implies_nonderogatory`, closing the (ii) ⟺ (iii) edge
+    of the triple equivalence. -/
+theorem centralizer_eq_adjoin_iff_nonderogatory
+    (M : Matrix (Fin n) (Fin n) K) :
+    Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))
+        = Algebra.adjoin K ({M} : Set (Matrix (Fin n) (Fin n) K))
+      ↔ minpoly K M = M.charpoly :=
+  ⟨CyclicCommutantConverse.centralizer_eq_adjoin_implies_nonderogatory M,
+   centralizer_eq_adjoin_of_nonderogatory M⟩
+
+/-! ### The headline: `dim_K C(M) = n` -/
+
+/-- **Commutant dimension (headline).**  For a nonderogatory `n × n` matrix `M`
+    over a field `K`, the centralizer `C(M) = {N : NM = MN}` has `K`-dimension
+    exactly `n`:
+
+      `dim_K C(M) = n`.
+
+    This is the equality case of the Frobenius bound `dim_K C(M) ≥ n`
+    (`finrank_centralizer_ge`): among all `n × n` matrices, the nonderogatory
+    ones are precisely those whose commutant is as small as possible.
+
+    Proof: `C(M) = K[M]` (forward edge) and
+    `dim_K K[M] = deg(minpoly K M) = deg(charpoly M) = n`. -/
+theorem finrank_centralizer_eq_of_nonderogatory
+    (M : Matrix (Fin n) (Fin n) K) (hM : minpoly K M = M.charpoly) :
+    Module.finrank K
+        ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))) = n := by
+  rw [centralizer_eq_adjoin_of_nonderogatory M hM,
+    CyclicCommutantConverse.finrank_adjoin_eq_natDegree_minpoly M, hM,
+    M.charpoly_natDegree_eq_dim, Fintype.card_fin]
+
+/-- The commutant dimension equals `deg(charpoly M)` for nonderogatory `M`
+    (a restatement of the headline before collapsing `deg(charpoly) = n`). -/
+theorem finrank_centralizer_eq_natDegree_charpoly
+    (M : Matrix (Fin n) (Fin n) K) (hM : minpoly K M = M.charpoly) :
+    Module.finrank K
+        ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K)))
+      = M.charpoly.natDegree := by
+  rw [finrank_centralizer_eq_of_nonderogatory M hM, M.charpoly_natDegree_eq_dim,
+    Fintype.card_fin]
+
+/-! ### Summary -/
+
+/-- **De Moivre / Cayley–Hamilton OQ-02-OQ-02 summary.**  For an `n × n` matrix
+    `M` over a field `K`:
+
+    (1) `C(M) = K[M]` ⟺ `M` is nonderogatory (`minpoly = charpoly`); and
+
+    (2) when `M` is nonderogatory, `dim_K C(M) = n` — the equality case of the
+        Frobenius bound `dim_K C(M) ≥ n`. -/
+theorem cayley_hamilton_oq02_oq02_summary
+    (M : Matrix (Fin n) (Fin n) K) :
+    (Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))
+        = Algebra.adjoin K ({M} : Set (Matrix (Fin n) (Fin n) K))
+      ↔ minpoly K M = M.charpoly)
+    ∧ (minpoly K M = M.charpoly →
+        Module.finrank K
+          ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))) = n) :=
+  ⟨centralizer_eq_adjoin_iff_nonderogatory M,
+   finrank_centralizer_eq_of_nonderogatory M⟩
+
+end CyclicCommutantDimension
+
+end

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02/state.md
@@ -1,9 +1,9 @@
 # Research State: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T16:03:14-07:00
+**Since**: 2026-07-09T19:11:41-07:00
 **Iteration**: 1
 
 ## Current Focus

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02.json
@@ -59,5 +59,22 @@
   },
   "significance": 6,
   "tractability": 6,
-  "category": "extension"
+  "category": "extension",
+  "knowledge": {
+    "insights": [
+      "Commutant dimension dim_K C(M)=n for nonderogatory M is the equality case of Frobenius bound dim_K C(M)≥n; assembled purely from sibling lemmas (commuting_matrix_is_polynomial, finrank_adjoin_eq_natDegree_minpoly, nonderogatory_iff_has_cyclic_vector).",
+      "Completed the (ii)⟺(iii) edge of the triple equivalence: prior work had only (iii)⟹(ii); this adds the forward (ii)⟹(iii) nonderogatory⟹C(M)=K[M]."
+    ],
+    "builtItems": [
+      "centralizer_eq_adjoin_of_nonderogatory, centralizer_eq_adjoin_iff_nonderogatory, finrank_centralizer_eq_of_nonderogatory (=n), finrank_centralizer_eq_natDegree_charpoly, cayley_hamilton_oq02_oq02_summary in proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean (PR #36663)"
+    ],
+    "mathlibGaps": [
+      "ENV BLOCKER (not mathlib): shared docker cache had isModule:true poisoned setup.json for dependency OQ02OQ01, blocking build of the whole cayley-hamilton chain in Lean 4.26."
+    ],
+    "nextSteps": [
+      "Rebuild PR #36663 in a clean docker cache to obtain machine verification; clear isModule:true poisoning of Proofs setup.json for cayley-hamilton chain.",
+      "Possible follow-up: converse dim_K C(M)=n ⟹ nonderogatory (needs full Frobenius invariant-factor dimension formula, not yet built)."
+    ],
+    "progressSummary": "PROGRESS (UNVERIFIED build, env-blocked): proved forward edge (ii)⟹(iii) + headline dim_K C(M)=n; source 0-sorry/0-axiom, machine verification blocked by poisoned shared cache (dependency OQ02OQ01 isModule flag)."
+  }
 }


### PR DESCRIPTION
## Problem
`cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02` — **Dimension of the commutant: `dim_K C(M) = n` for nonderogatory `M`.**

## What this adds
The sibling files already built the triple equivalence for a single `n×n` matrix `M` over a field `K`:
- (i) cyclic vector  (ii) nonderogatory (`minpoly = charpoly`)  (iii) `C(M) = K[M]`
- forward edge **(i)⟹(iii)** `CyclicCommutant.commuting_matrix_is_polynomial`
- converse edge **(iii)⟹(ii)** `CyclicCommutantConverse.centralizer_eq_adjoin_implies_nonderogatory`
- **(ii)⟺(i)** `CyclicVectorBiconditional.nonderogatory_iff_has_cyclic_vector`
- `dim_K K[M] = deg(minpoly)` and the Frobenius bound `dim_K C(M) ≥ n`.

This file supplies the missing **forward edge (ii)⟹(iii)** and draws the headline dimension count:

1. `centralizer_eq_adjoin_of_nonderogatory` — nonderogatory ⟹ `C(M) = Algebra.adjoin K {M}`.
2. `centralizer_eq_adjoin_iff_nonderogatory` — full **(ii)⟺(iii)** biconditional `C(M) = K[M] ⟺ M nonderogatory`.
3. `finrank_centralizer_eq_of_nonderogatory` — **headline** `dim_K C(M) = n`, the *equality case* of the Frobenius bound `dim_K C(M) ≥ n`.
4. `finrank_centralizer_eq_natDegree_charpoly`, `cayley_hamilton_oq02_oq02_summary`.

Mechanical assembly of already-merged, verified lemmas; `0` sorries, `0` axioms in source.

## ⚠️ Build status: UNVERIFIED (environmental blocker, external to this proof)
Docker build could **not** be completed: the shared build cache is poisoned — `proofs/.lake/build/ir/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.setup.json` has `"isModule": true` (1 of 275 Proofs setup files), making Lean 4.26 reject the **dependency** `CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean:1:0` with `` `module` keyword is experimental and not enabled here `` — although that file is a clean `/-`-headed, **merged and verified** file (PR #29999).

Reproduced identically when building merged `OQ02OQ01` **standalone** with all artifacts nuked + source inode refreshed, so it is unrelated to this PR. Clean-cache rebuild (hours, disruptive to concurrent fleet builds) not done unilaterally.

**Action for deployer/mechanic:** rebuild in a clean cache (or clear the poisoned `isModule:true` state for the cayley-hamilton chain) before merge. Proof hand-checked lemma-by-lemma against sibling source signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)