### PR TITLE
research(erdos-1039-incomplete-01): Pommerenke-conjecture gap + Mathlib-drift repair [elab-clean 0 new axioms, +2 thm]

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -238,7 +238,6 @@ theorem conjecturedBound_div_klrBound (c : ℝ) (hc : 0 < c) (n : ℕ) (hn : n �
   have h3 : Real.sqrt (Real.log (n : ℝ)) ≠ 0 := hsqrt_pos.ne'
   simp only [conjecturedBound, klrBound]
   field_simp
-  ring
 
 /-- The multiplicative gap `conjecturedBound / klrBound` is unbounded — it grows like
     `√log n → ∞`.  Hence KLR does not reach the conjectured rate even up to constants. -/
@@ -287,7 +286,6 @@ theorem conjecturedBound_div_pommerenkeBound (c : ℝ) (hc : 0 < c) (n : ℕ) (h
   have h2 : Real.exp 1 ≠ 0 := (Real.exp_pos 1).ne'
   simp only [conjecturedBound, pommerenkeBound]
   field_simp
-  ring
 
 /-- The multiplicative gap `conjecturedBound / pommerenkeBound` is unbounded — it grows like
     `2ec·n → ∞`.  So Pommerenke's bound, too, does not reach the conjectured rate even up to
@@ -491,7 +489,7 @@ theorem area_implies_disc_bound :
     have hsup_bound :
         sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r}
           ≤ Real.sqrt (sublevelArea f / Real.pi) := by
-      apply csSup_le ⟨r0, c0, hr0pos, hsub0⟩
+      refine csSup_le ⟨r0, c0, hr0pos, hsub0⟩ ?_
       rintro r ⟨c, hrpos, hsub⟩
       have h1 : Real.pi * r ^ 2 ≤ sublevelArea f := hkey r ⟨c, hrpos, hsub⟩
       have h2 : r ^ 2 ≤ sublevelArea f / Real.pi := by

--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -260,6 +260,51 @@ theorem conjecturedBound_div_klrBound_tendsto_atTop (c : ℝ) (hc : 0 < c) :
   exact (conjecturedBound_div_klrBound c hc n hn).symm
 
 /-
+## The Pommerenke–Conjecture Gap
+
+The block above measures how far the *KLR* bound `c/(n√log n)` sits below the conjectured
+`c/n`: exactly a factor `√log n`, which is unbounded but grows only logarithmically.  The
+*older* Pommerenke bound `1/(2en²)` falls short by much more.  Here we pin down the Pommerenke
+shortfall the same way:
+
+* `conjecturedBound_div_pommerenkeBound` — the *exact* multiplicative gap is `2ec·n` (linear
+  in `n`, versus KLR's `√log n`).
+* `conjecturedBound_div_pommerenkeBound_tendsto_atTop` — that gap diverges.
+
+Together with the KLR block this shows both published lower bounds are asymptotically infinitely
+far (up to constants) from the conjecture, and quantifies *how much* the 2025 KLR bound improved
+on Pommerenke's 1961 bound: the shortfall dropped from a factor `Θ(n)` to a factor `Θ(√log n)`.
+Like the KLR block these are unconditional facts about the bound *functions* and use none of the
+deep axioms.
+-/
+
+/-- The exact multiplicative gap between the conjectured and Pommerenke bounds is `2ec·n`
+    (for `c > 0`, `n ≥ 1`) — linear in `n`, in contrast with KLR's `√log n`. -/
+theorem conjecturedBound_div_pommerenkeBound (c : ℝ) (hc : 0 < c) (n : ℕ) (hn : n ≥ 1) :
+    conjecturedBound c n / pommerenkeBound n = 2 * Real.exp 1 * c * n := by
+  have hn_pos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast show 0 < n by omega
+  have h1 : (n : ℝ) ≠ 0 := hn_pos.ne'
+  have h2 : Real.exp 1 ≠ 0 := (Real.exp_pos 1).ne'
+  simp only [conjecturedBound, pommerenkeBound]
+  field_simp
+  ring
+
+/-- The multiplicative gap `conjecturedBound / pommerenkeBound` is unbounded — it grows like
+    `2ec·n → ∞`.  So Pommerenke's bound, too, does not reach the conjectured rate even up to
+    constants, and (comparing with `conjecturedBound_div_klrBound_tendsto_atTop`) it falls short
+    far faster than KLR. -/
+theorem conjecturedBound_div_pommerenkeBound_tendsto_atTop (c : ℝ) (hc : 0 < c) :
+    Filter.Tendsto (fun n : ℕ => conjecturedBound c n / pommerenkeBound n)
+      Filter.atTop Filter.atTop := by
+  have hlin : Filter.Tendsto (fun n : ℕ => 2 * Real.exp 1 * c * (n : ℝ))
+      Filter.atTop Filter.atTop :=
+    Filter.Tendsto.const_mul_atTop (by positivity : (0 : ℝ) < 2 * Real.exp 1 * c)
+      tendsto_natCast_atTop_atTop
+  refine hlin.congr' ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  exact (conjecturedBound_div_pommerenkeBound c hc n hn).symm
+
+/-
 ## Lemniscate Properties
 -/
 

--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -504,7 +504,10 @@ theorem area_implies_disc_bound :
     have hsq :
         (sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r}) ^ 2
           ≤ sublevelArea f / Real.pi := by
-      have hs := Real.sq_sqrt (div_nonneg ENNReal.toReal_nonneg hpi.le)
+      have harea : (0 : ℝ) ≤ sublevelArea f := by
+        unfold sublevelArea; exact ENNReal.toReal_nonneg
+      have hs : Real.sqrt (sublevelArea f / Real.pi) ^ 2 = sublevelArea f / Real.pi :=
+        Real.sq_sqrt (div_nonneg harea hpi.le)
       nlinarith [hsup_bound, hsup_nonneg, hs, Real.sqrt_nonneg (sublevelArea f / Real.pi)]
     calc Real.pi * (sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r}) ^ 2
         ≤ Real.pi * (sublevelArea f / Real.pi) := mul_le_mul_of_nonneg_left hsq hpi.le

--- a/research/problems/erdos-1039-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1039-incomplete-01/knowledge.md
@@ -1,0 +1,31 @@
+
+## Session 2026-07-09 (researcher-9): Pommerenke–conjecture gap + Mathlib-drift repair (elab-clean, olean-write blocked)
+
+Entry SOLVED (0 sorries, 4 deep published axioms correctly axiomatized). Added the missing
+half of the quantitative gap analysis and repaired 4 Mathlib-drift breakages that had left the
+file un-buildable on the current pinned Mathlib.
+
+New theorems (18 → 20, 0 new axioms):
+- `conjecturedBound_div_pommerenkeBound (c n) : conj/pomm = 2·e·c·n` — the EXACT multiplicative
+  shortfall of Pommerenke's 1961 bound from the conjectured rate is LINEAR in n (vs KLR's √log n).
+- `conjecturedBound_div_pommerenkeBound_tendsto_atTop` — that gap diverges. Parallels the existing
+  KLR block (`conjecturedBound_div_klrBound*`); together they show BOTH known lower bounds are
+  asymptotically infinitely far (up to constants) from the conjecture, and quantify that KLR (2025)
+  shrank the shortfall from Θ(n) to Θ(√log n).
+
+Mathlib-drift repairs (pre-existing, file did NOT build on current main; each unmasked the next):
+- L241 `conjecturedBound_div_klrBound`: `field_simp` now closes the goal outright → removed dead `ring`.
+- L290 (my new pommerenke lemma): same — `field_simp` closes it, no `ring`.
+- L492 `apply csSup_le ⟨…⟩` → `refine csSup_le ⟨…⟩ ?_` (Nonempty arg no longer elaborates under bare `apply`).
+- L507 `Real.sq_sqrt (div_nonneg ENNReal.toReal_nonneg …)`: standalone `have` could not infer the
+  ENNReal implicit → pinned via `have harea : 0 ≤ sublevelArea f := by unfold sublevelArea; exact
+  ENNReal.toReal_nonneg` and an explicit type on `hs`.
+
+Build: elaboration CLEAN `[7743/7743]`, 0 Lean errors across 5 runs (1.3–2.4s); every run failed
+only at olean-write with SIGBUS-135 (fleet env). Shipped VERIFIED-elaboration / UNVERIFIED-olean.
+axiomCount stays 4 (deep EHP/Pommerenke/KLR results untouched). gallery meta erdos-1039 synced
+18/612 → 20/658.
+
+NEXT: the 4 axioms are paper-scale published results — not session work. Entry is saturated for
+elementary work; the gap-analysis block is now complete for both known lower bounds. A future
+Mechanic/Auditor should note the drift repairs made the file buildable again on pinned Mathlib.

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 4,
-    "lineCount": 612,
+    "lineCount": 658,
     "assumptions": "4 axioms, all genuine published research results the proof correctly leaves unformalized (not overclaimed): benchmark_upper (Erdos-Herzog-Piranian benchmark rho(z^n-1) <= pi/(2n)), pommerenke_lower (Pommerenke 1961, rho >= 1/(2en^2)), and klr_lower + klr_area_bound (Krishnapur-Lundberg-Ramachandran 2025, rho >> 1/(n*sqrt(log n))). Formalizing any of these would require reproducing the source papers, so they are stated as axioms. The three elementary-geometry lemmas (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc) were completed in PR #33815 and the main file Proofs/Erdos1039Problem.lean has 0 sorries (543 lines). UPDATE: the former 5th axiom random_polynomial_expected was DEGENERATE — its intended Expected[rho] middle term was only a comment, so the Lean proposition collapsed to the trivially-true c1/sqrt(n) <= c2/sqrt(n); it has been converted to a proved theorem (witness c1=c2=1), removing a spurious entry from the axiom list (5 -> 4). The real Theta(1/sqrt n) expected-order claim needs an Expected functional and remains unformalized. The deprecated stub Proofs/Stubs/Erdos1039Problem.lean still holds the pre-#33815 state (3 sorries, the original 5 axioms) and is not the presented proof (proofRepoPath is the main file); it adds no distinct assumptions.",
     "mathlib_version": "4.29.0",
     "mathlibDependencies": [
@@ -59,7 +59,7 @@
       "klr_area_bound axiom: sublevelArea ≥ c/n² (area lower bound driving the KLR result)",
       "random_polynomial_expected: now a proved theorem (degenerate as stated — c₁/√n ≤ c₂/√n, witness c₁=c₂=1); the genuine Θ(1/√n) expected-order claim needs an Expected functional and is unformalized"
     ],
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 17,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
@@ -242,9 +242,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1039",
-    "lineCount": 612,
+    "lineCount": 658,
     "axiomCount": 4,
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 17,
     "path": "Proofs/Erdos1039Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Two contributions to Erdős #1039 (inscribed-disc radius `ρ(f)` for unit-disc polynomials).

### New theorems (+2, 0 new axioms)
The existing "KLR–Conjecture Gap" block quantifies how far the 2025 KLR bound `c/(n√log n)` sits below the conjectured `c/n` (exactly a factor `√log n`). This PR adds the parallel — and genuinely distinct — analysis for the older **Pommerenke (1961)** bound `1/(2en²)`:

- **`conjecturedBound_div_pommerenkeBound`** — the *exact* multiplicative shortfall is `2ec·n`, **linear** in `n` (versus KLR's `√log n`).
- **`conjecturedBound_div_pommerenkeBound_tendsto_atTop`** — that gap diverges.

Together with the KLR block this shows both published lower bounds are asymptotically infinitely far (up to constants) from the conjecture, and quantifies how much KLR improved on Pommerenke: the shortfall dropped from `Θ(n)` to `Θ(√log n)`.

### Mathlib-drift repair (pre-existing breakage)
`Erdos1039Problem.lean` no longer built on the current pinned Mathlib; four independent drift errors (each masking the next) are fixed:
- `field_simp` now closes the two gap-ratio goals outright → removed two dead `ring` calls (`conjecturedBound_div_klrBound` and the new Pommerenke lemma);
- `apply csSup_le ⟨…⟩` → `refine csSup_le ⟨…⟩ ?_` (the `Nonempty` argument no longer elaborates under bare `apply`);
- pinned the `Real.sq_sqrt (div_nonneg ENNReal.toReal_nonneg …)` argument type (standalone `have` could not infer the `ℝ≥0∞` implicit).

## Verification

- Elaboration **clean** `[7743/7743]`, **0 Lean errors across 5 Docker builds** (1.3–2.4s each). Every run then failed only at olean-write with SIGBUS-135 — the persistent fleet environment issue, not a code defect. Shipped VERIFIED-elaboration / UNVERIFIED-olean.
- **0 new axioms** — the 4 deep published axioms (EHP benchmark, Pommerenke 1961, KLR 2025 ×2) are untouched and correctly axiomatized.
- gallery meta `erdos-1039` synced 18/612 → 20/658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)