### PR TITLE
Enrich Quintic Bernoulli Endpoint: lateral crossref to sibling branch

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -152,6 +152,11 @@
       "targetId": "bernoulli-inequality-oq-01-oq-01",
       "relationship": "extends",
       "description": "The grandparent proves strict Bernoulli on the full weak domain −2 ≤ a; this entry continues the per-exponent endpoint analysis into the quintic case"
+    },
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "A sibling branch off the same grandparent: rather than locating per-exponent endpoints aₙ* below −2, it isolates the magnitude argument used on the hard subrange −2 ≤ a ≤ −1 (the line-escapes-a-bounded-power lemma, |1 + a| ≤ 1 traps the power in [−1, 1] while the line escapes). The two branches are complementary readings of the same −2 ≤ a domain — this entry sharpens the sign structure at the endpoint, that one sharpens the magnitude structure in the interior"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `bernoulli-inequality-oq-01-oq-01-oq-01-oq-01` (quality 95, pass 0).

## Assessment
The entry is already well-curated and comfortably under all size caps (17 KB):
- 7 annotations, each with mathContext / significance / relatedConcepts / prerequisites
- historicalContext (453 chars), proofStrategy (968 chars), 4 keyInsights
- 7 sections covering the full 161-line Lean file
- conclusion with summary, implications, 3 open questions
- counts (9 theorems, 1 def, 161 lines, 0 axioms) verified accurate against the Lean source

Per the diminishing-returns rule, deepening an already-at-target entry would be accretion, not improvement. Instead I made **one sharp, verifiable structural fix**.

## Change
The Bernoulli family has 8 gallery entries, but this one only cross-referenced its *ancestry chain*. Added a `related` crossReference to `bernoulli-inequality-oq-01-oq-01-oq-02` — the sibling branch off the same grandparent that handles the hard subrange −2 ≤ a ≤ −1 by a magnitude argument (the line-escapes-a-bounded-power lemma). This gives the family lateral navigation between its two complementary lines of investigation (2 → 3 crossReferences, well under the 20 cap). Target verified to exist.

Gallery data validation (`pnpm build` enrichment + search-index checks) passes; JSON valid.