### PR TITLE
seeker: add 4 diverse Erdős WIP-completion research problems

### DIFF
--- a/research/problems/erdos-103-wip-01/knowledge.md
+++ b/research/problems/erdos-103-wip-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-103-wip-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-103-wip-01/literature/README.md
+++ b/research/problems/erdos-103-wip-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-103-wip-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-103-wip-01/problem.md
+++ b/research/problems/erdos-103-wip-01/problem.md
@@ -1,0 +1,115 @@
+# Problem: Complete Erdős Problem #103 — Incongruent Optimal Point Configurations
+
+**Slug**: erdos-103-wip-01
+**Created**: 2026-07-09T19:15:58-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+h(n) := \#\Big\{ P \subseteq \mathbb{R}^2 : |P| = n,\ \forall x \neq y \in P\ \|x-y\| \ge 1,\ \operatorname{diam}(P) = D(n) \Big\}\Big/\cong
+$$
+
+where $D(n)$ is the minimum diameter of an $n$-point set with pairwise distances at least $1$, and configurations are counted up to congruence. **Question:** does $h(n) \to \infty$ as $n \to \infty$?
+
+### Plain Language
+
+Place $n$ points in the plane so that no two are closer than distance $1$, and make the overall spread (the largest distance between any two points) as small as possible. Such "optimal" configurations need not be unique. $h(n)$ counts how many genuinely different (non-congruent) optimal arrangements exist. Erdős asked whether this count grows without bound as $n$ increases.
+
+### Why This Matters
+
+The problem probes the *diversity* of extremal configurations in discrete geometry, a theme distinct from merely computing the optimum $D(n)$. It is intimately tied to densest circle packing (place $n$ unit-diameter circles in the smallest enclosing circle) where the hexagonal/triangular lattice is asymptotically optimal (Thue–Minkowski). Understanding multiplicity of optima connects extremal geometry, packing theory, and rigidity.
+
+## Known Results
+
+### What's Already Proven
+
+- Thue–Minkowski: the triangular lattice is the densest packing of congruent circles in the plane — provides asymptotic structure of near-optimal configurations.
+- Bateman–Erdős and later work on minimum-diameter point sets with prescribed separation give bounds on $D(n)$.
+- Gallery entry `erdos-103` formalizes the definitional scaffolding (diameter, separation constraint) in Lean.
+
+### What's Still Open
+
+- Whether $h(n) \to \infty$ (the main conjecture) remains open.
+- Even a lower bound $h(n) \ge 2$ for all large $n$ is nontrivial to establish rigorously.
+
+### Our Goal
+
+Complete the work-in-progress gallery formalization `erdos-103`: discharge any remaining `sorry`/scaffolding, state the conjecture as a formal proposition, and formalize whatever partial results (e.g. constructions exhibiting multiple incongruent optima for small $n$, or lattice-based lower-bound families) are attainable in Lean 4 + Mathlib.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-103 | Base WIP entry this problem completes | diameter/separation defs, extremal geometry |
+| erdos-99 | Neighboring Erdős distance problem | combinatorial geometry |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Explicit constructions for small $n$**: exhibit two or more incongruent optimal configurations for concrete $n$ (e.g. triangular-lattice fragments vs. rotated/reflected variants), formalizing the congruence check.
+   - Why it might work: small cases are finitely checkable and give a foothold on $h(n) \ge 2$.
+   - Risk: proving optimality (that no smaller diameter exists) is the hard part, often requiring case analysis.
+
+2. **Lattice-perturbation families**: near-optimal hexagonal patches admit multiple boundary completions; formalize a family whose size grows with $n$.
+   - Why it might work: boundary degrees of freedom naturally multiply configurations.
+   - Risk: showing every member is *exactly* optimal (not just near-optimal) is delicate.
+
+### Key Difficulties
+
+- Establishing exact optimality of $D(n)$ is itself hard; multiplicity sits on top of it.
+- Congruence classification in $\mathbb{R}^2$ (mod rotations/reflections/translations) is fiddly to formalize.
+
+### What Would a Proof Need?
+
+- Key lemma 1: a rigorous handle on $D(n)$ or a certified lower bound for specific $n$.
+- Key lemma 2: a decidable/checkable congruence predicate on finite planar point sets.
+- Technical requirements: Mathlib `EuclideanSpace`, `Isometry`, convex geometry lemmas.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The full conjecture $h(n) \to \infty$ is an open problem.
+- Formalizing the definitions and small-case multiplicity is a realistic completion target.
+- Mathlib has isometry and Euclidean-distance infrastructure but limited discrete-packing results.
+
+**Estimated Effort**:
+- Exploration: days
+- If tractable (definitions + partial results): weeks
+- If hard (full conjecture): unknown
+
+## References
+
+### Papers
+- P. Erdős, "Some of my favourite unsolved problems" (1994) [Er94b] — original posing.
+- L. Fejes Tóth, "Über die dichteste Zusammenstellung von kongruenten Kreisen in einer Ebene" — densest circle arrangements.
+- H. Bateman, P. Erdős, "On the problem of minimum diameter of point sets with prescribed distances."
+
+### Online Resources
+- Erdős Problems database, Problem #103 — https://www.erdosproblems.com/103
+
+### Mathlib
+- `Mathlib.Analysis.InnerProductSpace.EuclideanDist` / `EuclideanSpace` — planar distances.
+- `Mathlib.Topology.MetricSpace.Isometry` — congruence via isometries.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorial-geometry
+  - packing
+  - distances
+  - extremal-geometry
+related_proofs:
+  - erdos-103
+  - erdos-99
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T19:15:58-07:00
+```

--- a/research/problems/erdos-103-wip-01/state.md
+++ b/research/problems/erdos-103-wip-01/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-103-wip-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T19:15:58-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1068-wip-01/knowledge.md
+++ b/research/problems/erdos-1068-wip-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1068-wip-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1068-wip-01/literature/README.md
+++ b/research/problems/erdos-1068-wip-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1068-wip-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1068-wip-01/problem.md
+++ b/research/problems/erdos-1068-wip-01/problem.md
@@ -1,0 +1,115 @@
+# Problem: Complete Erdős Problem #1068 — Countable Infinitely-Connected Subgraphs
+
+**Slug**: erdos-1068-wip-01
+**Created**: 2026-07-09T19:15:59-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall\, G\ \big(\chi(G) = \aleph_1\big) \ \Longrightarrow\ \exists\, H \subseteq G\ \text{countable with}\ H\ \text{infinitely vertex-connected}.
+$$
+
+**Question:** does every graph of chromatic number $\aleph_1$ contain a *countable* subgraph that is infinitely (vertex-)connected?
+
+### Plain Language
+
+Colour the vertices of a graph so adjacent vertices differ; suppose you genuinely need uncountably many ($\aleph_1$) colours. Must the graph then contain a small (countable) piece that is extremely well-connected — one that stays connected after deleting any finite set of vertices? This is a countable-subgraph refinement of the Erdős–Hajnal program relating chromatic number to connectivity.
+
+### Why This Matters
+
+It is part of the **Erdős–Hajnal** structural program (1966) linking large chromatic number to forced substructure. Soukup (2015, *Combinatorica*) constructed, in ZFC, an uncountably chromatic graph where every *uncountable* vertex set fails high connectivity — showing the naive uncountable version is false and sharpening attention on the *countable* formulation, which remains open.
+
+## Known Results
+
+### What's Already Proven
+
+- **Erdős–Hajnal (1966):** foundational results connecting chromatic number and set-system structure.
+- **Soukup (2015):** first ZFC construction of an uncountably chromatic graph in which every uncountable set is at most finitely connected — refutes the uncountable analogue.
+- Classical infinite-graph connectivity theory (Menger's theorem for infinite graphs).
+- Gallery entry `erdos-1068` formalizes the chromatic-number / connectivity framing in Lean.
+
+### What's Still Open
+
+- The countable-subgraph version (the main question) is open.
+- Whether the answer is independent of ZFC / sensitive to additional set-theoretic axioms.
+
+### Our Goal
+
+Complete the WIP gallery formalization `erdos-1068`: formalize chromatic number $\aleph_1$, the notion of infinite vertex-connectivity, and the precise conjecture as a formal proposition. Formalize what is settled (e.g. Soukup's obstruction at the uncountable level, or reductions), discharging remaining scaffolding.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1068 | Base WIP entry this problem completes | infinite chromatic number, connectivity |
+| — | Menger-type infinite-graph connectivity | set theory / graph theory |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Formalize the definitions and statement precisely**: chromatic number as a cardinal, $k$-vertex-connectivity, and the $\aleph_1 \Rightarrow$ countable-infinitely-connected implication.
+   - Why it might work: getting the statement type-correct in Mathlib is a concrete, valuable deliverable even without a full proof.
+   - Risk: Mathlib's `SimpleGraph` cardinal-chromatic and infinite-connectivity support is thin; may need new definitions.
+
+2. **Formalize the Soukup obstruction / uncountable counterexample framing**: state why the uncountable analogue fails, isolating what makes the countable version subtle.
+   - Why it might work: clarifies the problem boundary and records a genuine theorem.
+   - Risk: the full ZFC construction is intricate to formalize.
+
+### Key Difficulties
+
+- Infinite/cardinal chromatic number and infinite connectivity are under-developed in Mathlib.
+- The core question is open and possibly set-theoretically sensitive.
+
+### What Would a Proof Need?
+
+- Key lemma 1: a workable Lean definition of infinite vertex-connectivity for `SimpleGraph`.
+- Key lemma 2: cardinal-valued chromatic number with $\chi(G) = \aleph_1$ expressible.
+- Technical requirements: `Mathlib.Combinatorics.SimpleGraph`, `Mathlib.SetTheory.Cardinal`.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The main question is an open Erdős–Hajnal-type problem, possibly independent of ZFC.
+- Formalizing definitions and the statement is a realistic, useful completion target.
+- Mathlib's infinite-graph / cardinal support is limited, so groundwork may be needed.
+
+**Estimated Effort**:
+- Exploration: days
+- If tractable (definitions + statement + partial results): weeks
+- If hard (full resolution): unknown
+
+## References
+
+### Papers
+- P. Erdős, A. Hajnal, "On chromatic number of graphs and set-systems," *Acta Math. Acad. Sci. Hungar.* 17 (1966) 61–99.
+- L. Soukup, construction of uncountably chromatic graphs with low connectivity, *Combinatorica* (2015).
+- Menger's theorem for infinite graphs (Aharoni–Berger and classical sources).
+
+### Online Resources
+- Erdős Problems database, Problem #1068 — https://www.erdosproblems.com/1068
+
+### Mathlib
+- `Mathlib.Combinatorics.SimpleGraph.Connectivity` — connectivity primitives.
+- `Mathlib.SetTheory.Cardinal.Basic` — $\aleph_1$ and cardinal chromatic number.
+
+## Metadata
+
+```yaml
+tags:
+  - graph-theory
+  - set-theory
+  - chromatic-number
+  - infinite-connectivity
+related_proofs:
+  - erdos-1068
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T19:15:59-07:00
+```

--- a/research/problems/erdos-1068-wip-01/state.md
+++ b/research/problems/erdos-1068-wip-01/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1068-wip-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T19:15:59-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-241-wip-01/knowledge.md
+++ b/research/problems/erdos-241-wip-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-241-wip-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-241-wip-01/literature/README.md
+++ b/research/problems/erdos-241-wip-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-241-wip-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-241-wip-01/problem.md
+++ b/research/problems/erdos-241-wip-01/problem.md
@@ -1,0 +1,115 @@
+# Problem: Complete Erdős Problem #241 — Maximum Size of B₃ Sets
+
+**Slug**: erdos-241-wip-01
+**Created**: 2026-07-09T19:15:58-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+f(N) := \max\Big\{ |A| : A \subseteq \{1,\dots,N\},\ \text{all sums } a_1+a_2+a_3\ (a_i \in A,\ a_1\le a_2\le a_3)\ \text{distinct} \Big\}
+$$
+
+**Question:** is $f(N) \sim N^{1/3}$ as $N \to \infty$? (A set with all three-element sums distinct is called a $B_3$ set.)
+
+### Plain Language
+
+A $B_3$ set is a set of integers in which every unordered triple has a distinct sum — no two different triples add to the same value. We want the largest such subset of $\{1,\dots,N\}$. Trivially there are about $N^{1/3}$ elements achievable, and no more than a constant times $N^{1/3}$; the question is whether the constant is exactly $1$, i.e. whether $f(N)/N^{1/3} \to 1$.
+
+### Why This Matters
+
+$B_3$ sets are the degree-3 generalization of Sidon ($B_2$) sets, central objects in additive combinatorics. Pinning down the constant tests how sharp our upper-bound machinery (Fourier/moment methods) is against algebraic constructions. Erdős attached a **\$100 prize** to closing the gap, linking finite-field constructions, additive energy, and analytic number theory.
+
+## Known Results
+
+### What's Already Proven
+
+- **Bose–Chowla (1962):** explicit $B_3$ sets of size $(1+o(1))N^{1/3}$ via the cubing map in $\mathbb{F}_{p^3}$ — a matching *lower* bound.
+- **Upper bound:** $f(N) \le (1.519\ldots + o(1))N^{1/3}$ (Green and later refinements), still above the conjectured constant $1$.
+- Gallery entry `erdos-241` formalizes the $B_3$ definition and the lower-bound framing in Lean.
+
+### What's Still Open
+
+- Whether the true constant is $1$ (i.e. $f(N) \sim N^{1/3}$) — the main conjecture.
+- Closing the gap between the constructive constant $1$ and the analytic constant $\approx 1.519$.
+
+### Our Goal
+
+Complete the WIP gallery formalization `erdos-241`: formalize the $B_3$ predicate, the Bose–Chowla lower-bound construction (or its counting core), and state the asymptotic conjecture as a formal proposition. Discharge remaining scaffolding `sorry`s where the mathematics is settled.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-241 | Base WIP entry this problem completes | $B_3$ definition, additive combinatorics |
+| erdos-350 | Sidon / dissociated sets (neighbor) | additive combinatorics |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Formalize the counting core**: prove the distinct-triple-sums condition forces $\binom{|A|}{3} \lesssim$ (number of possible sums) $\approx 3N$, yielding $f(N) = O(N^{1/3})$.
+   - Why it might work: elementary double counting, expressible with `Finset` reasoning.
+   - Risk: the *sharp* constant needs Fourier-analytic input beyond elementary counting.
+
+2. **Formalize Bose–Chowla lower bound**: construct the $\mathbb{F}_{p^3}$ set and prove the $B_3$ property from injectivity of cubing.
+   - Why it might work: algebraic, self-contained; Mathlib has finite-field infrastructure.
+   - Risk: transferring the finite-field set back to $\{1,\dots,N\}$ with size control is technical.
+
+### Key Difficulties
+
+- The sharp upper constant is genuinely open — only the $O(N^{1/3})$ order is provable elementarily.
+- Finite-field-to-integer transfer requires careful size/injectivity bookkeeping.
+
+### What Would a Proof Need?
+
+- Key lemma 1: injectivity of $x \mapsto x^3$ giving distinct triple sums in $\mathbb{F}_{p^3}$.
+- Key lemma 2: double-counting bound $\binom{|A|}{3} \le \#\{\text{possible sums}\}$.
+- Technical requirements: Mathlib `Finset`, `ZMod`, finite-field cardinality lemmas.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The sharp asymptotic constant is an open, prize problem.
+- The order-of-magnitude bounds ($\Theta(N^{1/3})$) are formalizable and a realistic completion target.
+- Mathlib supports finite fields and `Finset` double counting.
+
+**Estimated Effort**:
+- Exploration: days
+- If tractable (order bounds + construction): weeks
+- If hard (sharp constant): unknown
+
+## References
+
+### Papers
+- R. C. Bose, S. Chowla, "Theorems in the additive theory of numbers" (1962) — $B_h$ constructions.
+- K. O'Bryant, "A complete annotated bibliography of work related to Sidon sets."
+- B. Green, upper bounds for $B_3$ sets.
+
+### Online Resources
+- Erdős Problems database, Problem #241 — https://www.erdosproblems.com/241
+
+### Mathlib
+- `Mathlib.FieldTheory.Finite.Basic` — finite fields for Bose–Chowla.
+- `Mathlib.Combinatorics.Additive` / `Mathlib.Data.Finset.Card` — additive/counting tools.
+
+## Metadata
+
+```yaml
+tags:
+  - additive-combinatorics
+  - sidon-sets
+  - b3-sets
+  - number-theory
+related_proofs:
+  - erdos-241
+  - erdos-350
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T19:15:58-07:00
+```

--- a/research/problems/erdos-241-wip-01/state.md
+++ b/research/problems/erdos-241-wip-01/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-241-wip-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T19:15:58-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-352-wip-01/knowledge.md
+++ b/research/problems/erdos-352-wip-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-352-wip-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-352-wip-01/literature/README.md
+++ b/research/problems/erdos-352-wip-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-352-wip-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-352-wip-01/problem.md
+++ b/research/problems/erdos-352-wip-01/problem.md
@@ -1,0 +1,114 @@
+# Problem: Complete Erdős Problem #352 — Triangles of Area 1 in Measurable Sets
+
+**Slug**: erdos-352-wip-01
+**Created**: 2026-07-09T19:15:58-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\exists\, c > 0 \ \ \text{such that}\ \ \forall\, A \subseteq \mathbb{R}^2\ \text{measurable with}\ \lambda(A) \ge c,\ \ \exists\, x,y,z \in A\ \text{with}\ \operatorname{area}(\triangle xyz) = 1.
+$$
+
+**Question:** does such a threshold $c$ exist? Erdős conjectured the optimal value $c = \dfrac{4\pi}{\sqrt{27}}$.
+
+### Plain Language
+
+If a region of the plane is "big enough" (has Lebesgue measure at least some universal constant $c$), must it contain three of its own points forming a triangle of area exactly $1$? Erdős conjectured yes, with the smallest sufficient area being $4\pi/\sqrt{27}$.
+
+### Why This Matters
+
+The problem lies at the intersection of geometric measure theory and combinatorial geometry: it asks how much *measure* forces a prescribed geometric configuration. It is a continuous analogue of many extremal/Ramsey-type "large object must contain structure" statements, and the conjectured sharp constant hints at an extremal configuration (related to circular/lattice arrangements).
+
+## Known Results
+
+### What's Already Proven
+
+- **Erdős (1978/79, 1984):** sets of *infinite* measure contain unit-area triangles; *unbounded* sets of positive measure contain them. Both follow from the Lebesgue density theorem.
+- Partial and conditional bounds on the threshold $c$ appear in the literature; the sharp value $4\pi/\sqrt{27}$ remains conjectural.
+- Gallery entry `erdos-352` sets up the measurable-set / triangle-area framing in Lean.
+
+### What's Still Open
+
+- Existence of a *finite* universal threshold $c$ for all measurable sets — the main conjecture.
+- The exact optimal constant $c = 4\pi/\sqrt{27}$.
+
+### Our Goal
+
+Complete the WIP gallery formalization `erdos-352`: formalize the statement, the area-of-triangle predicate, and the two Erdős special cases (infinite-measure and unbounded positive-measure sets) via the Lebesgue density theorem. State the general conjecture as a formal proposition; discharge settled scaffolding.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-352 | Base WIP entry this problem completes | Lebesgue measure, density points |
+| erdos-103 | Sibling discrete/geometric extremal problem | combinatorial geometry |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Formalize the special cases via density points**: for infinite-measure or unbounded sets, use `MeasureTheory` density-point machinery to locate three points spanning area $1$.
+   - Why it might work: these cases are proven and rely on tools present in Mathlib (Lebesgue density / Vitali).
+   - Risk: constructing the explicit triple with exact area $1$ from a density point needs a scaling/continuity argument.
+
+2. **Continuity/scaling lemma**: the area of a triangle on three continuously-moving points takes all values in an interval; combine with positive-measure structure to hit area $1$.
+   - Why it might work: intermediate-value + measure positivity is formalizable.
+   - Risk: the universal *finite* threshold for bounded sets is the open core and likely out of reach.
+
+### Key Difficulties
+
+- The general bounded-set threshold is open; only special cases are provable.
+- Extracting an exact-area-$1$ triangle (not merely "some large triangle") requires a continuity/scaling step.
+
+### What Would a Proof Need?
+
+- Key lemma 1: Lebesgue density theorem applied to $A$ (Mathlib: `MeasureTheory` density results).
+- Key lemma 2: triangle-area as a continuous function of three points, with an intermediate-value hit at area $1$.
+- Technical requirements: `MeasureTheory.Measure`, `EuclideanSpace`, area via determinant.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- The full conjecture (finite universal threshold, sharp constant) is open.
+- The Erdős special cases are formalizable and a realistic completion target.
+- Mathlib has substantial measure-theory and density-point infrastructure.
+
+**Estimated Effort**:
+- Exploration: days
+- If tractable (special cases): weeks
+- If hard (general threshold): unknown
+
+## References
+
+### Papers
+- P. Erdős, [Er78d] (1978/79) and [Er83d] (1984) — original problem and special cases.
+- Surveys on geometric measure theory and configurations in positive-measure sets.
+
+### Online Resources
+- Erdős Problems database, Problem #352 — https://www.erdosproblems.com/352
+
+### Mathlib
+- `Mathlib.MeasureTheory.Covering.Density` — Lebesgue density points.
+- `Mathlib.Analysis.InnerProductSpace.EuclideanDist` — planar geometry / area via determinant.
+
+## Metadata
+
+```yaml
+tags:
+  - geometric-measure-theory
+  - lebesgue-measure
+  - triangles
+  - combinatorial-geometry
+related_proofs:
+  - erdos-352
+  - erdos-103
+difficulty: high
+source: proof-suggestion
+created: 2026-07-09T19:15:58-07:00
+```

--- a/research/problems/erdos-352-wip-01/state.md
+++ b/research/problems/erdos-352-wip-01/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-352-wip-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-09T19:15:58-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Summary

Proactive candidate-pool top-up by the **Seeker** agent. The pristine (0-attempt) available pool had drifted down to ~17 and consisted entirely of deep open-question chains. This adds 4 diverse, grounded completion problems for existing WIP gallery proofs to restore buffer and domain diversity.

| Slug | Domain | Erdős problem |
|------|--------|---------------|
| `erdos-103-wip-01` | discrete/combinatorial geometry | incongruent optimal point configurations |
| `erdos-241-wip-01` | additive combinatorics | maximum size of $B_3$ sets ($100 prize) |
| `erdos-352-wip-01` | geometric measure theory | triangles of area 1 in measurable sets |
| `erdos-1068-wip-01` | graph / set theory | countable infinitely-connected subgraphs |

## Workflow followed
- Inserted into `research/db/knowledge.db` (status=`available`) and ran `sync_pool.py` — pool now shows all 4 as available (durable feed; researchers can claim immediately).
- Initialized workspaces and filled `problem.md` with genuine content grounded in each base proof's gallery metadata (formal statement, plain language, known results, approaches, Mathlib pointers, references).
- All 4 pass `validate-seeker-stubs.ts` (no template placeholders).

## Notes
- Each is a **completion** task for a WIP gallery proof; the base `erdos-NNN` entry provides the mathematical context.
- No `loom:review-requested` label — this is a math PR for direct deployer merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)