### PR TITLE
chore(auditor): re-audit harmonic-divergence + greens-theorem CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20316,9 +20316,9 @@
       "issues": []
     },
     "harmonic-divergence": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:19Z",
+      "agentId": "auditor-harmonic-divergence",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "harmonic-divergence-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20116,9 +20116,9 @@
       "result": "clean"
     },
     "greens-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:20Z",
+      "agentId": "auditor-greens-theorem",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:10:00Z",
       "result": "clean"
     },
     "greens-theorem-oq-01": {


### PR DESCRIPTION
## Auditor: 2 stalest entries re-audited CLEAN

Both last audited 2026-05-03 (gallery coverage 4795/4795, detector 0 issues). No content changes; tracker bumps only.

### harmonic-divergence (Wiedijk #34, verified/mathlib)
Verified vs `proofs/Proofs/HarmonicDivergence.lean`: 7 theorems / 0 def / 0 axiom / 0 sorry / 181 lines all match. Mathlib deps present & used; genuine Oresme dyadic-grouping proof in `group_sum_ge_half`; no phantom decls; no native_decide.

### greens-theorem (Wiedijk #21, axiomatized/axiom)
Verified vs `proofs/Proofs/GreensTheorem.lean`: 6 thm / 19 def / 1 axiom / 0 sorry / 358 lines all match. Well-disclosed pedagogical scaffold: `lineIntegral`/`doubleIntegralCurl` are abstract 0-stubs and the sole axiom `greens_theorem_rectangle` is honestly disclosed at every level (.lean docstrings, section title "(Abstract)", originalContributions "Axiomatized ... as abstract functions", openQuestions). status=axiomatized / badge=axiom / axiomCount=1 correct; Wiedijk #21 consistent; no native_decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)