### PR TITLE
Enrich Sharp k=3 Birthday Threshold: root link + annotation-anchor fix

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/annotations.json
@@ -26,7 +26,7 @@
   {
     "id": "ann-main-statement",
     "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
-    "range": { "startLine": 66, "endLine": 83 },
+    "range": { "startLine": 67, "endLine": 83 },
     "type": "insight",
     "title": "The Sharp k = 3 Threshold: c + 1 ≤ n ≤ c + 1 + 1/(3c)",
     "content": "birthday_triple_threshold_sharp is the headline result. It assumes n ≥ 2 solves the expected-triple balance n(n−1)(n−2) = 6d²·ln 2 — the equation whose solution is the birthday-coincidence threshold for triples among d equally likely days — and concludes, with c := (6d²ln 2)^{1/3}, the two-sided bound c + 1 ≤ n ≤ c + 1 + 1/(3c). The lower-order term is therefore *exactly* 1, up to a remainder ≤ 1/(3c) = O(d^{−2/3}) that vanishes as d → ∞. This sharpens the parent's cruder band c ≤ n ≤ c + 2 to a window of width 1/(3c), pinning the leading correction to the cube-root scaling. The proof rests entirely on the centered substitution m = n − 1, which turns the balance into m³ − m = c³.",

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
@@ -126,6 +126,11 @@
       "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
       "relationship": "related",
       "description": "Sibling: the general-k threshold (k!·d^(k-1)·ln2)^(1/k) with loose ±(k-1) band; for k=3 it recovers the parent's ±2, which this entry sharpens using the k=3-specific centered cube"
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "generalizes",
+      "description": "The classic k=2 birthday problem (23 people, >50% coincidence) that this whole chain refines: where the classic asks for the first coincidence (two people, threshold ~√(2d·ln2)), this entry pins the sharp threshold for the first triple coincidence (three people) at n = (6d²·ln2)^(1/3) + 1 + o(1). Both siblings in this cluster link to the root; this adds the parallel link so the k=3 refinement is reachable from and back to the flagship"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01` (quality 95, pass 0).

## Assessment
Entry is already well-curated and under all caps (15 KB): 8 annotations all with mathContext, historicalContext/proofStrategy at target, 5 keyInsights, 4 sections covering the full 162-line file, conclusion with 3 open questions, counts (3 thm, 0 def, 162 lines, 0 axioms) verified accurate. No deepening needed — instead, two sharp verifiable fixes:

## Changes
1. **Missing root link.** Both siblings in this k=3 cluster (`…-oq-03` and `…-oq-03-oq-03`) cross-reference the flagship root `birthday-problem` (the classic k=2 problem), but this entry did not. Added a `generalizes` crossReference restoring navigation symmetry — the sharp k=3 triple-coincidence threshold is a direct refinement of the classic two-person birthday problem (2 → 3 crossReferences, under the 20 cap). Target verified to exist.
2. **Annotation anchor fix.** `ann-main-statement` had `startLine: 66`, a blank line, which the annotations strict validator flagged as "No Lean construct found at line 66". Moved to line 67 (the theorem's docstring anchor, matching the convention used by the passing cube-root annotation at line 62). The slug is now clean under the validator.

Gallery data validation (`pnpm build`) passes; both JSON files valid; slug emits zero validator warnings.