### PR TITLE
Enrich sqrt2-plus-sqrt3-irrational-oq-03: fix stale annotation ranges past EOF

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/annotations.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/annotations.json
@@ -28,8 +28,8 @@
     "id": "ann-sqrt23-root-witness",
     "proofId": "sqrt2-plus-sqrt3-irrational-oq-03",
     "range": {
-      "startLine": 38,
-      "endLine": 70
+      "startLine": 39,
+      "endLine": 69
     },
     "type": "concept",
     "title": "Root Witness: Step-by-Step Algebraic Computation",
@@ -53,7 +53,7 @@
     "id": "ann-sqrt23-monic",
     "proofId": "sqrt2-plus-sqrt3-irrational-oq-03",
     "range": {
-      "startLine": 71,
+      "startLine": 72,
       "endLine": 92
     },
     "type": "concept",
@@ -78,7 +78,7 @@
     "proofId": "sqrt2-plus-sqrt3-irrational-oq-03",
     "range": {
       "startLine": 93,
-      "endLine": 356
+      "endLine": 308
     },
     "type": "insight",
     "title": "Irreducibility: Klein 4-Group Obstruction (via Gauss's Lemma)",
@@ -90,7 +90,7 @@
       "Galois group",
       "rational root theorem",
       "quadratic factor case analysis",
-      "sorry in Lean"
+      "Gauss's lemma (ℤ[X] ⇒ ℚ[X])"
     ],
     "prerequisites": [
       "Polynomial.Irreducible in Mathlib",
@@ -103,8 +103,8 @@
     "id": "ann-sqrt23-minpoly-main",
     "proofId": "sqrt2-plus-sqrt3-irrational-oq-03",
     "range": {
-      "startLine": 357,
-      "endLine": 368
+      "startLine": 311,
+      "endLine": 318
     },
     "type": "insight",
     "title": "Main Theorem: One-Line Assembly via minpoly.eq_of_irreducible_of_monic",
@@ -127,8 +127,8 @@
     "id": "ann-sqrt23-consequences",
     "proofId": "sqrt2-plus-sqrt3-irrational-oq-03",
     "range": {
-      "startLine": 369,
-      "endLine": 403
+      "startLine": 319,
+      "endLine": 349
     },
     "type": "insight",
     "title": "Consequences: Extension Degree 4 and Irrationality Certificate",


### PR DESCRIPTION
Enrichment pass fixing an annotation/source desync in `sqrt2-plus-sqrt3-irrational-oq-03` (Minimal Polynomial of √2 + √3, X⁴−10X²+1).

## Defect fixed
Three annotations pointed **past the 350-line file** (irreducibility 93–**356**, minpoly-main 357–**368**, consequences 369–**403**), left stale from an earlier longer version. The `sections` array was already correct.

## Changes (annotations.json only)
- Remapped to the actual declaration lines: irreducibility 93–356 → 93–308 (`irred_f`), minpoly-main 357–368 → 311–318 (`minpoly_sqrt2_plus_sqrt3`), consequences 369–403 → 319–349 (`adjoin…finrank` + `sqrt2_plus_sqrt3_irrational`).
- Fixed two pre-existing blank-line anchors that failed `annotations:build --strict` (root-witness 38 → 39, monic 71 → 72).
- Replaced a vestigial `"sorry in Lean"` relatedConcept (the proof is 0-sorry, as the annotation content itself states) with `"Gauss's lemma (ℤ[X] ⇒ ℚ[X])"`.

## Verification
- All annotation ranges now ≤ 350; the slug is **clean under `annotations:build --strict`** (previously 5 errors: 3 past-EOF + 2 blank anchors).
- Counts (8 theorems, 0 sorries, 0 axioms), `status: verified`, `lineCount: 350` confirmed against the source and unchanged. meta.json untouched (12.2 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)