### PR TITLE
audit: geometric-series-oq-01 re-verified CLEAN — bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19694,9 +19694,9 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "geometric-series-oq-01": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:20Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "geometric-series-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: geometric-series-oq-01 — "Geometric Series at the Boundary: |r| = 1"
**Result**: ✅ CLEAN (no integrity issues)

Re-audited the stalest uncovered entry (last audited 2026-05-03). harmonic-divergence and greens-theorem — the two staler entries — are already covered by open PR #36671.

## Verification

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status | `verified` | 0 sorry, 0 axiom, 0 True-stub, 0 native_decide | ✅ |
| sorries | 0 | 0 (both files) | ✅ |
| axiomCount | 0 | 0 | ✅ |
| theoremCount / definitionCount | 13 / 1 | 13 thm + 1 def in `GeometricSeriesOQ01.lean` (250 lines) | ✅ |
| badge | `original` | defensible — see below | ✅ |

## Badge & claim assessment

All 5 `originalContributions` are backed by genuine theorems in `GeometricSeriesOQ01.lean`:
- Divergence at r=1: `geom_sum_one_diverges : Tendsto … atTop atTop`
- Grandi oscillation: `grandi_even`/`grandi_odd` (S₂ₘ=0, S₂ₘ₊₁=1)
- Non-summability for |r|≥1: `not_summable_geom_of_one_le_norm`
- Cesàro summability: `grandiCesaro_tendsto : Tendsto grandiCesaro atTop (nhds (1/2))` — proved by hand via `sum_grandi_partial_sums` induction + `grandiCesaro_bound` squeeze
- Complete boundary characterization

Badge `original` is defensible (Tier A): the Mathlib lemmas used (`mul_neg_geom_sum`, `one_le_pow₀`, `Summable.tendsto_atTop_zero`) are building blocks, not the claimed core results, which are proved independently. The Cesàro theorem is the substantive contribution and is fully formalized from scratch.

Note: the `GeometricSeriesOQ01Neumann.lean` companion (8 Mathlib-delegated Neumann-series theorems) is not cited in `originalContributions` — no overclaim.

Tracker bumped: auditCount 3→4, lastAudited → 2026-07-09, result `clean`.

---
Discovered during gallery integrity audit. Tracker-only change.