### PR TITLE
Enrich Ultra-Log-Concavity of a Pascal Row: annotation-anchor fix

### DIFF
--- a/src/data/proofs/combinations-formula-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-01/annotations.json
@@ -86,7 +86,7 @@
   {
     "id": "ann-cf0401-summary",
     "proofId": "combinations-formula-oq-04-oq-01",
-    "range": { "startLine": 194, "endLine": 215 },
+    "range": { "startLine": 202, "endLine": 213 },
     "type": "context",
     "title": "Signature Checks and the Exact-Defect Summary",
     "content": "The file closes with #check commands listing the seven theorems, then a summary of what the entry adds over the parent. Where the parent proves only that the Pascal row is log-concave (a qualitative inequality), this entry upgrades it to the EXACT defect identity (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2), equivalently the rational ratio C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)). Both the parent's ≤ and its strict interior < are then one-line corollaries: the excess (n+1)/((k+1)(n−k−1)) is ≥ 0 always and > 0 on the interior k+2 ≤ n. The whole development rests only on Mathlib's Nat.choose_succ_right_eq — no new axioms.",


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-04-oq-01` (quality 95, pass 0).

## Assessment
Entry is already well-curated and under caps (15.7 KB): 8 annotations all with mathContext, historicalContext/proofStrategy at target, 4 keyInsights, 7 sections covering the full 215-line file, conclusion with 3 open questions, counts (7 thm, 0 def, 215 lines, 0 axioms) verified accurate against the Lean source. CrossReferences already symmetric with siblings (parent `-oq-04` + root `combinations-formula`). No deepening warranted — one sharp verifiable fix.

## Change
`ann-cf0401-summary` was anchored at `startLine: 194`, a `#check` command that the annotations strict validator does not treat as a Lean construct ('No Lean construct found at line 194'). Re-anchored to the recognized summary block-comment at 202-213 (same construct class as the passing overview annotation at 4-55). The slug now emits zero validator warnings.

Gallery data validation (`pnpm build`) passes; JSON valid.