### PR TITLE
audit: geometric-series-oq-02 re-verified CLEAN — bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19730,9 +19730,9 @@
       "result": "clean"
     },
     "geometric-series-oq-02": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:21Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T02:28:52Z",
       "result": "clean"
     },
     "geometric-series-oq-02-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Audit — geometric-series-oq-02 (Neumann Series)

Re-audited the stalest uncovered tracker entry (last audited 2026-05-03). **Result: CLEAN.**

### Verification
- **13 theorems**, matches `theoremCount: 13` ✓
- **0 sorries, 0 axiom declarations, 0 native_decide** ✓ → `status: verified` justified
- **0 definitions**, 237 lines — all counts match ✓
- **Tier B (Mathlib bridge)**, `badge: mathlib` — correct. Core results delegate to Mathlib (`Units.oneSub`, `summable_geometric_of_norm_lt_one`, `Ring.inverse_unit`), fully disclosed in `mathlibDependencies`, author field, and description.
- All 5 `mathlibDependencies` names verified present in source ✓
- All 6 `originalContributions` bullets backed by real theorems (`neumann_sum`, `left/right_inverse_identity`, `invertible_near_one`, `neumann_sum_comm`, `norm_neumann_le`) ✓
- Sections + mathContext accurate (e.g. `NormOneClass` requirement on `norm_neumann_le` matches source line 161)

An exemplary honest Mathlib-bridge entry — no overclaiming. Tracker bumped only.

---
Discovered during periodic gallery integrity audit.