### PR TITLE
Fix structural metadata drift: hilbert-17 counts + cayley-hamilton-oq-02 section range

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02/meta.json
@@ -118,7 +118,7 @@
       "id": "consequences",
       "title": "Consequences: commutant_commutative and aeval_commute",
       "startLine": 179,
-      "endLine": 208,
+      "endLine": 207,
       "summary": "The centralizer of a cyclic matrix is commutative (any two commuting matrices are polynomials in M, which commute), and the trivial inclusion K[M] ⊆ centralizer(M) — together giving centralizer(M) = K[M]."
     }
   ],

--- a/src/data/proofs/hilbert-17/meta.json
+++ b/src/data/proofs/hilbert-17/meta.json
@@ -45,12 +45,12 @@
     "dateAdded": "2025-12-29",
     "hilbertNumber": 17,
     "axiomCount": 1,
-    "lineCount": 590,
+    "lineCount": 640,
     "assumptions": [
       "pfister_bound_aux: At most 2^n rational function squares needed for n-variable PSD polynomials (Pfister forms)"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 8,
     "description": "Axiom-reduction history: three axioms were redundant restatements of deeper ones and are now derived theorems (artin_hilbert17 and cassels_bound_bivariate from pfister_bound_aux; artin_univariate from univariate_psd_is_sos_aux), and four more have been fully discharged by elementary 0-axiom child proofs — motzkin_not_sos_polynomial_aux (Hilbert17MotzkinNotSOS.lean), robinson_not_sos_aux (Hilbert17RobinsonNotSOS.lean), univariate_psd_is_sos_aux (Hilbert17UnivariatePSDSOS.lean), and quadratic_psd_is_sos_aux (Hilbert17QuadraticGram.lean: the homogeneous Gram/Cholesky core plus affine homogenisation by one extra coordinate). The single remaining independent axiom is pfister_bound_aux (Pfister's 2ⁿ bound)."
   },
@@ -215,9 +215,9 @@
       "RatFunc"
     ],
     "namespace": "Hilbert17",
-    "lineCount": 590,
+    "lineCount": 640,
     "axiomCount": 1,
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 8,
     "path": "Proofs/Hilbert17SumOfSquares.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

A pool-wide structural-integrity scan (4795 entries) found no dead crossrefs but surfaced two genuine, verifiable metadata defects. Both are fixed here.

### hilbert-17 — stale count fields
The Lean source `Proofs/Hilbert17SumOfSquares.lean` grew to **640 lines / 16 top-level theorems** via merged PRs (#35705 SOS-cone closure, #29155, #29121), but the metadata still declared the old **590 lines / 11 theorems**. The `sections` array already correctly spans 640, so only the count fields were stale.
- `meta.lineCount` & `leanFile.lineCount`: 590 → **640** (matches `wc -l`)
- `meta.theoremCount` & `leanFile.theoremCount`: 11 → **16** (verified against actual top-level `theorem`/`lemma` decls, excluding a comment-line false positive)
- `definitionCount` (8), `axiomCount` (1), status `axiomatized` — unchanged, already correct.

### cayley-hamilton-cyclic-vector-all-fields-oq-02 — section past EOF
The final section "Consequences" had `endLine: 208`, one line past the 207-line file. Clamped to **207**.

## Verification
- Both counts checked against the actual Lean sources.
- JSON validated by `pnpm build` (search-index + enrichment passes succeeded; the trailing `tsc` failure is a worktree `node_modules` issue, unrelated to these data-only edits).
- Diffs are minimal (hilbert-17: 4 lines; cayley: 1 line).

No content deepening — this is pure structural-accuracy repair in an otherwise saturated pool.