### PR TITLE
Enrich Quintic Bernoulli Endpoint: fix section-map completeness

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -93,10 +93,10 @@
     },
     {
       "id": "strict-mono",
-      "title": "The Residual Cubic Is Strictly Increasing",
+      "title": "The Residual Cubic Is Strictly Increasing (and Continuous)",
       "startLine": 68,
       "endLine": 83,
-      "summary": "g(b) − g(a) = (b−a)·(a²+ab+b²+5a+5b+10); the bracket is positive-definite since 12·bracket = (3a+3b+10)² + 3(a−b)² + 20, so g is strictly monotone (hence injective, giving a unique endpoint).",
+      "summary": "g(b) − g(a) = (b−a)·(a²+ab+b²+5a+5b+10); the bracket is positive-definite since 12·bracket = (3a+3b+10)² + 3(a−b)² + 20, so g is strictly monotone (hence injective, giving a unique endpoint). A one-line companion (continuous_residualCubic, by fun_prop) records that g is continuous — the second hypothesis the intermediate value theorem needs to locate the endpoint.",
       "mathContext": "StrictMono (a ↦ a³ + 5a² + 10a + 10)."
     },
     {


### PR DESCRIPTION
Enrichment pass for `bernoulli-inequality-oq-01-oq-01-oq-01-oq-01`.

This entry is already at target quality (95): 16.5 KB meta (under cap), 7 fully-annotated ranges covering the whole file, 4 keyInsights, complete conclusion with 3 open questions, valid crossrefs. Per the diminishing-returns rule I did **not** deepen it — instead fixed one verifiable structural accuracy gap:

- The `strict-mono` section spans lines 68–83, which contains **two** main results: `residualCubic_strictMono` (68–76) and `continuous_residualCubic` (78–80). The section summary described only monotonicity, so the continuity lemma — the second hypothesis `intermediate_value_Ioo` relies on to locate a₅* — was invisible in the section map. Updated the section title and summary to record it.

No content deleted; no caps approached (meta size check passes). JSON validated.