### PR TITLE
Fix knights-tour-oblique stale section ranges (past EOF)

### DIFF
--- a/src/data/proofs/knights-tour-oblique/meta.json
+++ b/src/data/proofs/knights-tour-oblique/meta.json
@@ -88,14 +88,14 @@
       "id": "uniqueness",
       "title": "Uniqueness via Certified Search",
       "startLine": 2047,
-      "endLine": 2358,
+      "endLine": 2237,
       "summary": "Construct the unique minimal-oblique tour explicitly (64 squares from Knuth's Fig. A-19(t)), verify it has exactly 4 oblique turns, and accept Knuth's computational verification as an axiom that any tour with 4 obliques is D4-equivalent to this one."
     },
     {
       "id": "main-theorems",
       "title": "Main Theorems",
-      "startLine": 2359,
-      "endLine": 2445,
+      "startLine": 2238,
+      "endLine": 2341,
       "summary": "State the two main results: (1) every closed tour has at least 4 oblique turns, and (2) exactly one tour (up to symmetry) achieves this minimum."
     }
   ],


### PR DESCRIPTION
## Summary
Continuation of the structural-integrity scan (see #36680). The `knights-tour-oblique` Lean file was trimmed to **2341 lines**, but two `sections` entries still referenced line ranges up to **2445** (the file's earlier length), placing them past EOF.

Remapped to the real boundaries, anchored on the `/-! ## Section 7: Main Theorems` docstring header at line **2238**:
- **"Uniqueness via Certified Search"**: `endLine` 2358 → **2237** (ends just before the Section 7 header)
- **"Main Theorems"**: `2359–2445` → **2238–2341** (Section 7 header through EOF)

## Verification
- Boundaries anchored on the actual `## Section 7` header (L2238) and file EOF (L2341, `wc -l`).
- `lineCount` (2341) and `theoremCount` (106, all-forms count incl. `private`/`noncomputable`) verified accurate against the source — left unchanged.
- Minimal 3-line diff; JSON validated.