### PR TITLE
Research: erdos-744-incomplete-01 — complete the bipartitionNumber extremal API [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -169,6 +169,42 @@ theorem bipartitionNumber_eq_zero_iff {V : Type*} [Fintype V] [LinearOrder V]
       Finset.inf'_le _ (Finset.mem_univ c)
     omega
 
+/-- **Universal lower bound.** The bipartition number is at most the monochromatic-edge count
+    of *every* 2-coloring: `bipartitionNumber G ≤ monochromaticEdges G c`. Half of its
+    characterization as the minimum over all colorings. -/
+theorem bipartitionNumber_le {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] (c : V → Bool) :
+    bipartitionNumber G ≤ monochromaticEdges G c :=
+  Finset.inf'_le _ (Finset.mem_univ c)
+
+/-- **The minimum is attained.** Some 2-coloring realizes the bipartition number exactly:
+    the optimal (fewest-monochromatic-edge) colouring exists. Together with
+    `bipartitionNumber_le` this is the full universal property of `bipartitionNumber` as a
+    minimum. -/
+theorem exists_coloring_eq_bipartitionNumber {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    ∃ c : V → Bool, monochromaticEdges G c = bipartitionNumber G := by
+  obtain ⟨c, -, hc⟩ :=
+    Finset.exists_mem_eq_inf' (Finset.univ_nonempty (α := V → Bool)) (monochromaticEdges G)
+  exact ⟨c, hc.symm⟩
+
+/-- **Positivity ⟺ genuinely non-bipartite.** The bipartition number is positive iff *no*
+    2-coloring is proper — every colouring leaves at least one monochromatic edge. The
+    contrapositive companion of `bipartitionNumber_eq_zero_iff`: at least one edge deletion is
+    required exactly when `G` has no proper 2-colouring. -/
+theorem bipartitionNumber_pos_iff {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    0 < bipartitionNumber G ↔ ∀ c : V → Bool, ∃ u v, G.Adj u v ∧ c u = c v := by
+  rw [Nat.pos_iff_ne_zero, ne_eq, bipartitionNumber_eq_zero_iff, not_exists]
+  constructor
+  · intro h c
+    have hc := h c
+    push_neg at hc
+    exact hc
+  · intro h c hc
+    obtain ⟨u, v, hadj, huv⟩ := h c
+    exact hc u v hadj huv
+
 /-
 # Part 3b: Structural properties of the bipartition number
 


### PR DESCRIPTION
## Summary

`Erdos744Problem.lean` defines the intrinsic, axiom-free `bipartitionNumber G` = min over 2-colorings of the monochromatic-edge count, and proves `bipartitionNumber_eq_zero_iff`, `_mono`, `_le_edgeCount`. This PR completes its extremal API with three axiom-free lemmas:

- **`bipartitionNumber_le`** — universal lower bound: `bipartitionNumber G ≤ monochromaticEdges G c` for *every* coloring `c`.
- **`exists_coloring_eq_bipartitionNumber`** — the minimum is attained: some coloring realizes it exactly. (Together with `bipartitionNumber_le`, the full universal property of the minimum.)
- **`bipartitionNumber_pos_iff`** — `0 < bipartitionNumber G ↔ ∀ c, ∃ u v, G.Adj u v ∧ c u = c v`: at least one edge deletion is required iff `G` has *no* proper 2-coloring. The contrapositive companion of `bipartitionNumber_eq_zero_iff`.

No new axioms — `chromaticNumber` and `rodl_tuza_theorem` are untouched; all three additions rest only on `Finset.inf'` API and the axiom-free `bipartitionNumber_eq_zero_iff`.

## Build status

**VERIFIED** — `docker-build.sh Proofs.Erdos744Problem` → `Build completed successfully (3060 jobs)`, clean olean write. 0 sorries; the file's 2 pre-existing legitimate axioms are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)