### PR TITLE
Enrich Metacyclic Upper Bound |Gal(X⁵−p)|=20: add dedup-context annotation

### DIFF
--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01-oq-01/annotations.json
@@ -66,6 +66,26 @@
     ]
   },
   {
+    "id": "ann-dedup",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 63 },
+    "type": "context",
+    "title": "Why this file proves only one of its three theorems",
+    "content": "This namespace-hygiene note explains an apparent mismatch: the docstring above narrates three results (the ceiling gal_card_le_n_mul_totient, the coprime pin gal_card_eq_n_mul_totient_of_coprime, and the quintic witness gal_card_quintic_eq_twenty), yet the file below declares only the last. The two general lemmas were originally proved here but were later merged verbatim into the ancestor InverseGaloisD4OQ02.lean (PR #31630) and deleted from this file to keep a single canonical home and avoid duplicate declarations poisoning the build. They remain in scope through the transitive import (line 50), so the quintic instance can still invoke gal_card_eq_n_mul_totient_of_coprime directly. This is why meta.theoremCount is 1 even though the entry's mathematical content is the full three-theorem story: the counts track this file's own declarations, while the assumptions field documents the merge and confirms all three results remain 0-axiom in the ancestor.",
+    "mathContext": "The file's contribution reduces to a single instantiation $n = 5$ of an imported general theorem; the ceiling $|\\mathrm{Gal}| \\le n\\varphi(n)$ and coprime pin $|\\mathrm{Gal}| = n\\varphi(n)$ live upstream in $\\texttt{InverseGaloisD4OQ02}$, imported transitively.",
+    "significance": "context",
+    "relatedConcepts": [
+      "namespace hygiene / duplicate removal",
+      "transitive import",
+      "declaration counting vs mathematical content",
+      "upstream merge (PR #31630)"
+    ],
+    "prerequisites": [
+      "Lean import/namespace model",
+      "theorem reuse across files"
+    ]
+  },
+  {
     "id": "ann-quintic",
     "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01-oq-01",
     "range": { "startLine": 65, "endLine": 73 },


### PR DESCRIPTION
Enrichment pass for `inverse-galois-d4-oq-02-oq-03-oq-01-oq-01` (quality 89, passes 0).

The entry is otherwise well-enriched (16.9 KB meta, under cap; 4 keyInsights; complete conclusion with 3 open questions; 4 valid crossrefs). Its one genuine gap: only **4** annotations (enricher minimum is 5), and the namespace-hygiene / dedup comment block at lines 55–63 had **no** annotation.

That block explains a real point of reader confusion: the file's docstring narrates three theorems (the ceiling `gal_card_le_n_mul_totient`, the coprime pin `gal_card_eq_n_mul_totient_of_coprime`, and the quintic witness `gal_card_quintic_eq_twenty`) yet the file declares only the last — the other two were merged upstream into `InverseGaloisD4OQ02.lean` (PR #31630) and removed here as duplicates, reused via the transitive import. This is why `theoremCount` is 1 despite the three-theorem story.

**Change:** added one `context` annotation `ann-dedup` (range 55–63) covering that rationale. 4 → 5 annotations.

**Disclosure:** the annotation anchors on a `--` comment block (no Lean declaration at its startLine), so the annotation resolver emits its non-strict 'No Lean construct found' lint — the same accepted pattern used by ~10 existing `context`/`failure` annotations (e.g. `erdos-811` `ann-811-k4-fails`, `fatou-lemma` `dct-failure-package`). The annotation renders correctly (ranges are used verbatim). No content deleted; meta size check passes; JSON validated.