### PR TITLE
Fix gelfond-schneider axiom-catalog: 2 proved theorems mislabeled as axioms

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19662,10 +19662,10 @@
       "result": "clean"
     },
     "gelfond-schneider": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:22Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T02:42:15Z",
+      "result": "issues-fixed"
     },
     "gelfond-schneider-oq-01": {
       "auditCount": 1,

--- a/src/data/proofs/gelfond-schneider/meta.json
+++ b/src/data/proofs/gelfond-schneider/meta.json
@@ -123,8 +123,8 @@
       "title": "Axiom Catalog",
       "startLine": 126,
       "endLine": 202,
-      "summary": "Seven technical axioms bridging real and complex analysis: `real_algebraic_to_complex_algebraic`, `real_cpow_eq_rpow`, `transcendental_of_complex_eq_real`, Euler's identity $(-1)^{-i} = e^\\pi$, cube root properties, and the Hermite-Lindemann corollary for $\\log$.",
-      "mathContext": "Seven technical axioms bridging real and complex analysis: `real_algebraic_to_complex_algebraic` (algebraic over $\\mathbb{R}$ implies algebraic over $\\mathbb{C}$), complex exponential and logarithm properties, and the definition of $a^b := e^{b \\log a}$ for complex numbers."
+      "summary": "Five technical axioms bridging real and complex analysis: `real_cpow_eq_rpow` (real/complex power compatibility), Euler's identity `neg_one_cpow_neg_I` $(-1)^{-i} = e^\\pi$, cube root properties (`cbrt_two_algebraic`, `cbrt_two_irrational`), and the Hermite-Lindemann corollary `log_algebraic_transcendental`. Two former axioms — `real_algebraic_to_complex_algebraic` and `transcendental_of_complex_eq_real` — are now **proved** theorems (via `isAlgebraic_algebraMap_iff` and `transcendental_algebraMap_iff`).",
+      "mathContext": "Five technical axioms bridging real and complex analysis: `real_cpow_eq_rpow` (real power equals complex power for positive base), `neg_one_cpow_neg_I` (Euler's identity), `cbrt_two_algebraic`/`cbrt_two_irrational`, and `log_algebraic_transcendental` (Hermite-Lindemann corollary). The two coercion lemmas `real_algebraic_to_complex_algebraic` (algebraic over $\\mathbb{R}$ implies algebraic over $\\mathbb{C}$) and `transcendental_of_complex_eq_real` are proved theorems, not axioms. The complex Gelfond-Schneider statement itself is the sixth axiom (see the main-theorem section)."
     },
     {
       "id": "main-theorem",


### PR DESCRIPTION
## Gallery Integrity Audit — gelfond-schneider

Re-audited the stalest tracker entry (last audited 2026-05-03). Counts, badge (`axiom`), and status (`axiomatized`) are all **correct**: 6 axioms, 11 theorems, 2 defs, 0 sorries, 557 lines — all match the Lean source. The corollaries genuinely instantiate the axiomatized `gelfond_schneider` with hand-proved algebraicity/irrationality hypotheses; no vacuous/True stubs.

### One prose drift fixed

The `axiom-catalog` section (`summary` + `mathContext`) said **"Seven technical axioms"** and named `real_algebraic_to_complex_algebraic` and `transcendental_of_complex_eq_real` among them. Those two are **proved theorems** (lines 131, 155) — their docstrings even read *"formerly axiom, now proved"* (`isAlgebraic_algebraMap_iff` / `transcendental_algebraMap_iff`). The file has 6 axioms total, 5 in this section plus the main `gelfond_schneider` statement.

This is the *reverse* of axiom-masking: stale prose was understating the formalization by calling proved theorems axioms. Corrected both fields to describe the 5 genuine axioms in the section and note the two coercion lemmas are proved.

No code changes; `meta.axiomCount` (6) was already correct.

---
Discovered during gallery integrity audit.