### PR TITLE
audit: gcd-algorithm-oq-01 re-verified CLEAN — bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19593,9 +19593,9 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "gcd-algorithm-oq-01": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:22Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "gcd-algorithm-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: gcd-algorithm-oq-01 (Average-Case Complexity of the Euclidean Algorithm / Lamé)
**Result**: CLEAN — no integrity issues.

### Verified
- **Counts match**: 0 sorries, 0 literal `axiom` decls, 4 defs, 28 theorems — all match meta.json.
- **native_decide is load-bearing** in NAMED theorems (`lame_pair_bound` L104/125/126, `euclideanSteps_fib` L171, `fib_ge_pow10` L232), not just examples. So `Lean.ofReduceBool` is correctly disclosed → `axiomCount: 1`, `status: axiomatized`, `badge: axiom`. `leanFile.axiomCount: 0` (literal decls) is also correct per policy.
- **Honest scoping**: conclusion admits the average-case (Dixon's theorem) — the actual open question — remains **unformalized**; only worst-case + infrastructure is proved. No inequality-as-theorem inflation.
- **No True stubs, no phantom decls**: headline theorems (`lame_theorem`, `euclideanSteps_fib`, `fib_exponential_lower`, `euclideanSteps_log_bound`) are genuine substantive proofs; all `originalContributions` bullets map to real theorems.

### Change
Bump `lastAudited` 2026-05-03 → 2026-07-09 (was stalest at 3× prior audits). No meta.json edits needed.

---
Discovered during gallery integrity audit.