### PR TITLE
Enrich Sharp k=3 Birthday Threshold: fix backwards crossref relationship

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
@@ -129,8 +129,8 @@
     },
     {
       "targetId": "birthday-problem",
-      "relationship": "generalizes",
-      "description": "The classic k=2 birthday problem (23 people, >50% coincidence) that this whole chain refines: where the classic asks for the first coincidence (two people, threshold ~√(2d·ln2)), this entry pins the sharp threshold for the first triple coincidence (three people) at n = (6d²·ln2)^(1/3) + 1 + o(1). Both siblings in this cluster link to the root; this adds the parallel link so the k=3 refinement is reachable from and back to the flagship"
+      "relationship": "extends",
+      "description": "The classic k=2 birthday problem (23 people, >50% coincidence) that this whole chain refines: where the classic asks for the first coincidence (two people, threshold ~√(2d·ln2)), this entry extends the question to the first triple coincidence (three people), pinning its sharp threshold at n = (6d²·ln2)^(1/3) + 1 + o(1). Both siblings in this cluster link to the root; this adds the parallel link so the k=3 refinement is reachable from and back to the flagship"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01` (The Sharp k=3 Birthday Threshold, n = (6d²ln2)^(1/3) + 1 + o(1)).

**Assessment:** The entry is already at target quality — 8 annotations each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites` and full line coverage (3–162), 5 keyInsights, 3 openQuestions, `mainTheorems`, detailed `mathlibDependencies`, accurate counts (3 theorems / 0 defs / 162 lines matching the Lean source), correct `verified`/0-axiom status (confirmed by inline `#print axioms`), and comfortably under all size caps (15 KB). No deepening needed.

**Change (single semantic-accuracy fix):** The crossReference to the root `birthday-problem` was labeled `"generalizes"`, but a k=3 (triple-coincidence) *sharp constant* does not generalize the classic k=2 birthday problem — it **extends** the coincidence question from pairs to triples, which is exactly what the crossref description already says ("where the classic asks for the first coincidence (two people)... this entry ... the first triple coincidence (three people)"). Corrected the relationship to `"extends"` and reworded the description to match. `"extends"` is the second-most-common relationship in the gallery (2606 uses) and semantically correct here.

Gallery JSON validation (enrichment build + search-index checks) passed; `meta.json` remains valid JSON and unchanged in size class.