### PR TITLE
audit(isoperimetric-theorem): fix phantom isoperimetric_equality mainTheorem

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21248,10 +21248,10 @@
       "result": "clean"
     },
     "isoperimetric-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:19Z",
-      "result": "clean"
+      "agentId": "auditor-cycle-20260709-iso",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "isoperimetric-theorem-oq-01": {
       "auditCount": 4,
@@ -29764,5 +29764,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T02:15:00Z"
+  "lastUpdated": "2026-07-09T00:00:00Z"
 }

--- a/src/data/proofs/isoperimetric-theorem/meta.json
+++ b/src/data/proofs/isoperimetric-theorem/meta.json
@@ -229,10 +229,10 @@
       "leanType": "ClosedCurve gamma -> length gamma = L -> area_enclosed gamma <= L^2 / (4 * pi)"
     },
     {
-      "name": "isoperimetric_equality",
+      "name": "circle_isOptimal",
       "type": "key",
-      "description": "Equality holds iff the curve is a circle",
-      "leanType": "area_enclosed gamma = L^2 / (4 * pi) <-> is_circle gamma"
+      "description": "Circles achieve equality in the isoperimetric inequality (4πA = L²). The rigidity converse (equality ⇒ circle) is discussed in a docstring but not formalized.",
+      "leanType": "(c : Circle) → IsOptimal c.toCurve"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: isoperimetric-theorem
**Result**: issues-fixed (1 phantom mainTheorem corrected)
**Severity**: MEDIUM (phantom theorem / equality-case overclaim)

## Problem

The top-level `mainTheorems` array listed a **phantom** entry:

```json
{ "name": "isoperimetric_equality",
  "description": "Equality holds iff the curve is a circle",
  "leanType": "area_enclosed gamma = L^2 / (4 * pi) <-> is_circle gamma" }
```

No declaration named `isoperimetric_equality` exists in `proofs/Proofs/IsoperimetricTheorem.lean`, and that biconditional is **not formalized**. In Part 6 ("Characterizing Equality"), the source only proves:

- `IsOptimal C := 4πA = L²` (def)
- `isOptimal_iff_ratio` — `IsOptimal C ↔ ratio = optimalRatio` (algebraic restatement)
- `circle_isOptimal` — **circles achieve equality** (the `circle ⇒ equality` direction only)

The rigidity converse (`equality ⇒ circle`) appears **only in a docstring** (lines 262–271), explicitly marked "Axiomatized" in prose but with no corresponding `axiom` or `theorem`. So claiming the `iff` as a main theorem overstates what the Lean kernel guarantees.

This is a leftover from the same phantom-decl family cleaned in #36548, which fixed `overview.text` but missed the top-level `mainTheorems` array.

## Fix

Replace the phantom entry with the real theorem `circle_isOptimal` (`(c : Circle) → IsOptimal c.toCurve`), and state plainly that the rigidity converse is discussed but not formalized. The `isoperimetric_inequality` core axiom entry is accurate and unchanged.

## Verified (otherwise CLEAN)

- `status: axiomatized`, `badge: axiom` — correct (1 real axiom `isoperimetric_inequality`) ✓
- `sorries: 0`, `axiomCount: 1`, `theoremCount: 14`, `definitionCount: 17` — all match source ✓
- No True stubs ✓

Also persists the tracker bump lost to the `git reset --hard` race (was stuck at 2026-05-03 despite #36548 merging).

---
Discovered during periodic gallery integrity audit.