### PR TITLE
research(erdos-490-incomplete-01): general multiplicative-energy lower bound |A||B| ≤ E(A,B) [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -667,20 +667,23 @@ equality iff `HasDistinctProducts A B`. -/
 theorem multiplicativeEnergy_ge (A B : Finset ℕ) :
     A.card * B.card ≤ multiplicativeEnergy A B := by
   classical
-  rw [← Finset.card_product A B]
-  unfold multiplicativeEnergy
-  refine Finset.card_le_card_of_injOn (fun p => ((p.1, p.1), (p.2, p.2))) ?_ ?_
-  · rintro ⟨a, b⟩ hp
-    rw [Finset.mem_product] at hp
-    rw [Finset.mem_filter]
-    refine ⟨?_, rfl⟩
-    rw [Finset.mem_product, Finset.mem_product, Finset.mem_product]
-    exact ⟨⟨hp.1, hp.1⟩, hp.2, hp.2⟩
-  · rintro ⟨a₁, b₁⟩ _ ⟨a₂, b₂⟩ _ h
+  have hinj : Set.InjOn (fun p : ℕ × ℕ => ((p.1, p.1), (p.2, p.2))) ↑(A ×ˢ B) := by
+    intro p _ p' _ h
     simp only [Prod.mk.injEq] at h
-    obtain ⟨⟨ha, _⟩, hb, _⟩ := h
-    rw [Prod.mk.injEq]
-    exact ⟨ha, hb⟩
+    exact Prod.ext_iff.mpr ⟨h.1.1, h.2.1⟩
+  have hsub : (A ×ˢ B).image (fun p : ℕ × ℕ => ((p.1, p.1), (p.2, p.2))) ⊆
+      ((A ×ˢ A) ×ˢ (B ×ˢ B)).filter (fun ((a₁, a₂), (b₁, b₂)) => a₁ * b₁ = a₂ * b₂) := by
+    intro q hq
+    simp only [Finset.mem_image, Finset.mem_product] at hq
+    obtain ⟨⟨a, b⟩, ⟨ha, hb⟩, rfl⟩ := hq
+    refine Finset.mem_filter.mpr ⟨?_, rfl⟩
+    simp only [Finset.mem_product]
+    exact ⟨⟨ha, ha⟩, hb, hb⟩
+  calc A.card * B.card
+      = (A ×ˢ B).card := (Finset.card_product A B).symm
+    _ = ((A ×ˢ B).image (fun p : ℕ × ℕ => ((p.1, p.1), (p.2, p.2)))).card :=
+        (Finset.card_image_of_injOn hinj).symm
+    _ ≤ multiplicativeEnergy A B := Finset.card_le_card hsub
 
 /-
 ## Part VIII: Bounds History

--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -658,6 +658,30 @@ theorem distinct_minimal_energy (A B : Finset ℕ) :
   · intro h
     exact (Finset.eq_of_subset_of_card_le hsub (by rw [h, hΔcard])).symm
 
+/-- **General lower bound on multiplicative energy**: `|A|·|B| ≤ E(A, B)`.  The diagonal
+quadruples `((a, a), (b, b))` always satisfy the energy relation `a·b = a·b`, and
+`(a, b) ↦ ((a, a), (b, b))` injects `A ×ˢ B` into the energy set.  Together with
+`distinct_minimal_energy` (which identifies the equality case) this shows the energy is
+*minimized exactly* when the products are distinct: `E(A, B) ≥ |A||B|` always, with
+equality iff `HasDistinctProducts A B`. -/
+theorem multiplicativeEnergy_ge (A B : Finset ℕ) :
+    A.card * B.card ≤ multiplicativeEnergy A B := by
+  classical
+  rw [← Finset.card_product A B]
+  unfold multiplicativeEnergy
+  refine Finset.card_le_card_of_injOn (fun p => ((p.1, p.1), (p.2, p.2))) ?_ ?_
+  · rintro ⟨a, b⟩ hp
+    rw [Finset.mem_product] at hp
+    rw [Finset.mem_filter]
+    refine ⟨?_, rfl⟩
+    rw [Finset.mem_product, Finset.mem_product, Finset.mem_product]
+    exact ⟨⟨hp.1, hp.1⟩, hp.2, hp.2⟩
+  · rintro ⟨a₁, b₁⟩ _ ⟨a₂, b₂⟩ _ h
+    simp only [Prod.mk.injEq] at h
+    obtain ⟨⟨ha, _⟩, hb, _⟩ := h
+    rw [Prod.mk.injEq]
+    exact ⟨ha, hb⟩
+
 /-
 ## Part VIII: Bounds History
 -/

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -217,9 +217,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 861,
+    "lineCount": 888,
     "axiomCount": 1,
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Erdős #490 (distinct products of two sets, Szemerédi 1976) has a saturated Lean file: 0
sorries, 1 deep axiom `szemeredi_theorem`. The file already proves the *equality case* of
the multiplicative-energy characterization:

> `distinct_minimal_energy : HasDistinctProducts A B ↔ multiplicativeEnergy A B = |A|·|B|`

This PR adds the missing **general lower bound**, the natural companion:

### `multiplicativeEnergy_ge (A B : Finset ℕ) : A.card * B.card ≤ multiplicativeEnergy A B`

The diagonal quadruples `((a, a), (b, b))` always satisfy the energy relation
`a·b = a·b`, and `(a, b) ↦ ((a, a), (b, b))` injects `A ×ˢ B` into the energy set. Hence
`E(A, B) ≥ |A||B|` for **all** finite `A, B`. Combined with `distinct_minimal_energy` (the
equality case) this shows the multiplicative energy is *minimized exactly* when the
products are distinct.

## Verification

**VERIFIED** — docker `Build completed successfully (7744 jobs)` (olean written, exit 0).
The proof uses only `Finset` card/image/filter lemmas (`card_product`,
`card_image_of_injOn`, `card_le_card`, `mem_filter`, `mem_product`) — **no new axioms**,
no `sorry`. Remaining linter `unused variable` warnings are all pre-existing (lines
366–708), none in the new theorem. Gallery `meta.json` `leanFile` counts synced (26→27
theorems, 861→888 lines; axiomCount unchanged at 1).

## Axiom status

Unchanged: `status: axiomatized`, 1 axiom `szemeredi_theorem` (the deep Szemerédi bound,
untouched). This PR only adds a fully verified supporting theorem.