### PR TITLE
Research: erdos-1215-oq-02 — sharp two-sided radii of the cyclotomic level set

### DIFF
--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ02.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ02.lean
@@ -1,0 +1,150 @@
+/-
+Erdős Problem #1215 — cyclotomic restriction (OQ-02): sharp two-sided radii of the
+cyclotomic level set.
+
+Parent: `Proofs.Erdos1215Problem` asks whether, for polynomials `P` with all roots
+on the unit circle, there is a bounded-level path from `0` to `∞` inside
+`{z : |P(z)| < C}`.  OQ-02 restricts to the *cyclotomic* polynomials `Φ_n`.
+
+The companion `CyclotomicPolynomialsOQ02OQ01` proved the qualitative fact that the
+cyclotomic level set `{z : |Φ_n(z)| < C}` is bounded, contained in the ball of the
+crude radius `max 2 (C + 1)`.  This entry **sharpens the outer radius to
+`1 + C^{1/φ(n)}`** and supplies the complementary **inner containment**, pinning the
+level set between two concentric balls about the origin:
+
+      { z : ‖z‖ + 1 < C^{1/φ(n)} }  ⊆  {|Φ_n(z)| < C}  ⊆  closedBall(0, 1 + C^{1/φ(n)}).
+
+The mechanism is the elementary two-sided factor bound `‖z‖ - 1 ≤ ‖z - μ‖ ≤ ‖z‖ + 1`
+on each primitive-root factor (`‖μ‖ = 1`), giving
+
+      (‖z‖ - 1)^{φ(n)} ≤ |Φ_n(z)| ≤ (‖z‖ + 1)^{φ(n)}.
+
+Quantitatively the sharp outer radius `1 + C^{1/φ(n)}` is a genuine improvement over
+`max 2 (C + 1)`: for a fixed threshold `C > 1` it decreases to `2` as the degree
+`φ(n) → ∞`, so high-degree cyclotomic lemniscates hug the unit circle — the exact
+opposite of the freedom Mac Lane needs to build a labyrinth for arbitrary
+unit-circle-rooted polynomials.
+
+Main results:
+* `norm_cyclotomic_eval_le`              : `|Φ_n(z)| ≤ (‖z‖ + 1)^{φ(n)}`.
+* `mem_levelSet_of_norm_add_one_pow_lt`  : `(‖z‖+1)^{φ(n)} < C ⟹ z ∈ {|Φ_n| < C}`.
+* `closedBall_subset_levelSet_cyclotomic`: inner ball contained in the level set.
+* `cyclotomic_sublevel_norm_lt_sharp`    : `|Φ_n(z)| < C ⟹ ‖z‖ < 1 + C^{1/φ(n)}`.
+* `sublevel_subset_closedBall_sharp`     : level set ⊆ `closedBall(0, 1 + C^{1/φ(n)})`.
+* `sharp_radius_le_crude`                : `1 + C^{1/φ(n)} ≤ max 2 (C + 1)` (it really
+                                           is a sharpening of the OQ-01 radius).
+
+All results are `0`-axiom / `0`-sorry.
+-/
+
+import Mathlib
+import Proofs.Erdos1215Problem
+import Proofs.CyclotomicPolynomialsOQ02OQ01
+
+open Complex Polynomial
+
+namespace CyclotomicPolynomialsOQ02OQ02
+
+/-- **Upper bound on `|Φ_n(z)|`.**
+For `n ≥ 1`, `|Φ_n(z)| ≤ (‖z‖ + 1)^{φ(n)}`, because each primitive root `μ` has
+`‖μ‖ = 1`, so `‖z - μ‖ ≤ ‖z‖ + 1`.  This is the mirror image of the OQ-01 lower
+bound `(‖z‖ - 1)^{φ(n)} ≤ |Φ_n(z)|`. -/
+lemma norm_cyclotomic_eval_le (n : ℕ) (hn : n ≠ 0) (z : ℂ) :
+    ‖(cyclotomic n ℂ).eval z‖ ≤ (‖z‖ + 1) ^ n.totient := by
+  rw [CyclotomicPolynomialsOQ02OQ01.norm_cyclotomic_eval n hn z]
+  have hcard : (primitiveRoots n ℂ).card = n.totient := card_primitiveRoots n
+  calc ∏ μ ∈ primitiveRoots n ℂ, ‖z - μ‖
+      ≤ ∏ _μ ∈ primitiveRoots n ℂ, (‖z‖ + 1) := by
+        apply Finset.prod_le_prod
+        · intro μ _; positivity
+        · intro μ hμ
+          have hμ' : IsPrimitiveRoot μ n :=
+            (mem_primitiveRoots (Nat.pos_of_ne_zero hn)).1 hμ
+          have hnorm : ‖μ‖ = 1 := hμ'.norm'_eq_one hn
+          calc ‖z - μ‖ ≤ ‖z‖ + ‖μ‖ := norm_sub_le z μ
+            _ = ‖z‖ + 1 := by rw [hnorm]
+    _ = (‖z‖ + 1) ^ (primitiveRoots n ℂ).card := by rw [Finset.prod_const]
+    _ = (‖z‖ + 1) ^ n.totient := by rw [hcard]
+
+/-! ### Inner containment: a ball inside the level set -/
+
+/-- **Sufficient condition for level-set membership.**
+If `(‖z‖ + 1)^{φ(n)} < C` then `z` lies in `{|Φ_n| < C}`.  Directly from the upper
+bound. -/
+theorem mem_levelSet_of_norm_add_one_pow_lt (n : ℕ) (hn : n ≠ 0) (C : ℝ) (z : ℂ)
+    (hz : (‖z‖ + 1) ^ n.totient < C) :
+    z ∈ Erdos1215.levelSet (cyclotomic n ℂ) C := by
+  simp only [Erdos1215.levelSet, Set.mem_setOf_eq]
+  exact lt_of_le_of_lt (norm_cyclotomic_eval_le n hn z) hz
+
+/-- **Inner ball containment.**
+For a radius `r ≥ 0` with `(r + 1)^{φ(n)} < C`, the entire closed ball of radius `r`
+about the origin lies inside the cyclotomic level set `{|Φ_n| < C}`.  Together with the
+outer bound below, this sandwiches the level set between concentric balls. -/
+theorem closedBall_subset_levelSet_cyclotomic (n : ℕ) (hn : n ≠ 0) (C r : ℝ)
+    (hr0 : 0 ≤ r) (hr : (r + 1) ^ n.totient < C) :
+    Metric.closedBall (0 : ℂ) r ⊆ Erdos1215.levelSet (cyclotomic n ℂ) C := by
+  intro z hz
+  rw [Metric.mem_closedBall, dist_zero_right] at hz
+  apply mem_levelSet_of_norm_add_one_pow_lt n hn C z
+  have hmono : (‖z‖ + 1) ^ n.totient ≤ (r + 1) ^ n.totient :=
+    pow_le_pow_left₀ (by positivity) (by linarith) n.totient
+  linarith
+
+/-! ### Sharp outer radius `1 + C^{1/φ(n)}` -/
+
+/-- **Sharp pointwise bound.**
+For `n ≥ 1`, every point of the level set satisfies `‖z‖ < 1 + C^{1/φ(n)}`.
+This sharpens `CyclotomicPolynomialsOQ02OQ01.cyclotomic_sublevel_norm_lt`
+(radius `max 2 (C + 1)`): taking `φ(n)`-th roots of the lower bound
+`(‖z‖ - 1)^{φ(n)} ≤ |Φ_n(z)| < C` gives `‖z‖ - 1 < C^{1/φ(n)}`. -/
+theorem cyclotomic_sublevel_norm_lt_sharp (n : ℕ) (hn : n ≠ 0) (C : ℝ) (z : ℂ)
+    (hz : ‖(cyclotomic n ℂ).eval z‖ < C) :
+    ‖z‖ < 1 + C ^ ((n.totient : ℝ)⁻¹) := by
+  have hC : 0 < C := lt_of_le_of_lt (norm_nonneg _) hz
+  have hk0 : n.totient ≠ 0 := (Nat.totient_pos.mpr (Nat.pos_of_ne_zero hn)).ne'
+  have hkpos : (0 : ℝ) < (n.totient : ℝ)⁻¹ := by
+    apply inv_pos.mpr; exact_mod_cast Nat.pos_of_ne_zero hk0
+  have hCr : 0 < C ^ ((n.totient : ℝ)⁻¹) := Real.rpow_pos_of_pos hC _
+  by_cases h1 : ‖z‖ < 1
+  · linarith
+  · push_neg at h1
+    have ha : (0 : ℝ) ≤ ‖z‖ - 1 := by linarith
+    have hlow :=
+      CyclotomicPolynomialsOQ02OQ01.pow_sub_one_le_norm_cyclotomic_eval n hn z h1
+    have hak : (‖z‖ - 1) ^ n.totient < C := lt_of_le_of_lt hlow hz
+    have hmono : ((‖z‖ - 1) ^ n.totient) ^ ((n.totient : ℝ)⁻¹)
+        < C ^ ((n.totient : ℝ)⁻¹) :=
+      Real.rpow_lt_rpow (pow_nonneg ha _) hak hkpos
+    rw [Real.pow_rpow_inv_natCast ha hk0] at hmono
+    linarith
+
+/-- **Sharp level-set containment.**
+The cyclotomic level set `{|Φ_n| < C}` is contained in the closed ball of the sharp
+radius `1 + C^{1/φ(n)}` about the origin. -/
+theorem sublevel_subset_closedBall_sharp (n : ℕ) (hn : n ≠ 0) (C : ℝ) :
+    Erdos1215.levelSet (cyclotomic n ℂ) C ⊆
+      Metric.closedBall (0 : ℂ) (1 + C ^ ((n.totient : ℝ)⁻¹)) := by
+  intro z hz
+  simp only [Erdos1215.levelSet, Set.mem_setOf_eq] at hz
+  rw [Metric.mem_closedBall, dist_zero_right]
+  exact le_of_lt (cyclotomic_sublevel_norm_lt_sharp n hn C z hz)
+
+/-- **The sharp radius really is a sharpening.**
+For `C ≥ 1` and `n ≥ 1`, the sharp radius `1 + C^{1/φ(n)}` never exceeds the crude
+OQ-01 radius `max 2 (C + 1)`.  (Since `1/φ(n) ≤ 1`, we have `C^{1/φ(n)} ≤ C`, whence
+`1 + C^{1/φ(n)} ≤ 1 + C = C + 1 ≤ max 2 (C + 1)`.) -/
+theorem sharp_radius_le_crude (n : ℕ) (hn : n ≠ 0) (C : ℝ) (hC : 1 ≤ C) :
+    1 + C ^ ((n.totient : ℝ)⁻¹) ≤ max 2 (C + 1) := by
+  have hk0 : n.totient ≠ 0 := (Nat.totient_pos.mpr (Nat.pos_of_ne_zero hn)).ne'
+  have hone_le : (1 : ℝ) ≤ (n.totient : ℝ) := by
+    exact_mod_cast Nat.one_le_iff_ne_zero.mpr hk0
+  have hinv_le_one : (n.totient : ℝ)⁻¹ ≤ 1 := inv_le_one_of_one_le₀ hone_le
+  have hle : C ^ ((n.totient : ℝ)⁻¹) ≤ C ^ (1 : ℝ) :=
+    Real.rpow_le_rpow_of_exponent_le hC hinv_le_one
+  rw [Real.rpow_one] at hle
+  calc 1 + C ^ ((n.totient : ℝ)⁻¹) ≤ 1 + C := by linarith
+    _ = C + 1 := by ring
+    _ ≤ max 2 (C + 1) := le_max_right _ _
+
+end CyclotomicPolynomialsOQ02OQ02

--- a/research/problems/erdos-1215-oq-02/knowledge.md
+++ b/research/problems/erdos-1215-oq-02/knowledge.md
@@ -56,3 +56,42 @@ Insights accumulated during research on this problem.
 give the per-factor bound `‖z-μ‖ ≥ ‖z‖-1`; `Finset.prod_le_prod` + `Finset.prod_const`
 + `card_primitiveRoots` assemble `(‖z‖-1)^{φ(n)} ≤ |Φ_n(z)|`; `le_self_pow₀` collapses
 the exponent for `‖z‖ ≥ 2`.
+
+## Session 2026-07-09 (researcher-6) - Sharp two-sided radii
+
+**Mode**: FRESH (built on researcher-4's OQ02OQ01)
+**Outcome**: progress (VERIFIED 0-sorry/0-axiom, docker `[7745/7745]` build succeeded)
+
+### What I Did
+- Created `proofs/Proofs/CyclotomicPolynomialsOQ02OQ02.lean` (6 decls, 0 sorry / 0 axiom).
+- Executed the first "Next Step" left by researcher-4: **sharpened the outer radius**
+  of the cyclotomic level set from the crude `max 2 (C+1)` to `1 + C^{1/φ(n)}`, and
+  added the complementary **inner ball containment**.
+
+### Key Findings
+- Mirror of the OQ01 lower bound: `‖z-μ‖ ≤ ‖z‖+1` per factor ⟹
+  `|Φ_n(z)| ≤ (‖z‖+1)^{φ(n)}` (`norm_cyclotomic_eval_le`).
+- Inner containment: `(‖z‖+1)^{φ(n)} < C ⟹ z ∈ {|Φ_n|<C}`, hence
+  `closedBall(0,r) ⊆ {|Φ_n|<C}` when `(r+1)^{φ(n)} < C`.
+- Sharp outer radius: taking `φ(n)`-th roots of `(‖z‖-1)^{φ(n)} ≤ |Φ_n(z)| < C`
+  gives `‖z‖ < 1 + C^{1/φ(n)}` (`cyclotomic_sublevel_norm_lt_sharp`).
+- Quantitative payoff (`sharp_radius_le_crude`): for `C ≥ 1`,
+  `1 + C^{1/φ(n)} ≤ max 2 (C+1)`, and the sharp radius → 2 as `φ(n) → ∞`. So
+  high-degree cyclotomic lemniscates hug the unit circle — the antithesis of the
+  clustering freedom Mac Lane needs for a labyrinth.
+
+### Files Modified
+- `proofs/Proofs/CyclotomicPolynomialsOQ02OQ02.lean` (new)
+
+### Next Steps
+- Component-count / path-length geometry for n=3,4,6 (still the genuinely open driver;
+  needs polynomial-lemniscate topology Mathlib currently lacks).
+- Two-sided sandwich is now in place; a natural follow-up is the *area* of
+  `{|Φ_n|<C}` squeezed between the two balls.
+
+### Reusable Lean recipe
+Take `k`-th roots of a natural-power bound `a^k < C` (with `a ≥ 0`, `k ≠ 0`):
+`Real.rpow_lt_rpow (pow_nonneg ha _) hak hkpos` lifts to `(a^k)^{1/k} < C^{1/k}`, then
+`Real.pow_rpow_inv_natCast ha hk0 : (a^k)^((k:ℝ)⁻¹) = a` collapses the LHS. Exponent
+`1/φ(n) ≤ 1` via `inv_le_one_of_one_le₀`; `Real.rpow_le_rpow_of_exponent_le` compares
+`C^{1/φ(n)} ≤ C^1 = C`. Upper factor bound uses `norm_sub_le` + `pow_le_pow_left₀`.

--- a/research/problems/erdos-1215-oq-02/state.md
+++ b/research/problems/erdos-1215-oq-02/state.md
@@ -1,25 +1,36 @@
 # Research State: erdos-1215-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: PROVE
 **Path**: full
 **Since**: 2026-07-09T15:40:18-07:00
-**Iteration**: 1
+**Iteration**: 3
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Two-sided radius geometry of the cyclotomic level set `{|Φ_n(z)| < C}`.
 
 ## Active Approach
-None yet.
+Approach A/B hybrid: elementary two-sided factor bounds `‖z‖-1 ≤ ‖z-μ‖ ≤ ‖z‖+1`
+on primitive-root factors, giving `(‖z‖-1)^{φ(n)} ≤ |Φ_n(z)| ≤ (‖z‖+1)^{φ(n)}`, then
+`φ(n)`-th roots to pin the level set between concentric balls.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 3
+- Current approach attempts: 1
+- Approaches tried: 2
 
 ## Blockers
-None.
+None for the geometric sandwich. The genuinely open driver (does a cyclotomic
+labyrinth exist / path-length ≤ C·n) still needs polynomial-lemniscate topology and
+rectifiable-path arc length not yet in Mathlib.
+
+## Progress Log
+- Iter 2 (researcher-4): level set bounded by `max 2 (C+1)`; escape-to-∞ path
+  impossible for all C (`CyclotomicPolynomialsOQ02OQ01.lean`).
+- Iter 3 (researcher-6): sharpened outer radius to `1 + C^{1/φ(n)}`, added inner
+  ball containment; `1 + C^{1/φ(n)} ≤ max 2 (C+1)` and → 2 as φ(n) → ∞
+  (`CyclotomicPolynomialsOQ02OQ02.lean`, VERIFIED 0/0).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Small-n (n=3,4,6) explicit lemniscate geometry, or the area of `{|Φ_n|<C}` squeezed
+between the two balls now established.


### PR DESCRIPTION
## Problem
**Erdős #1215, cyclotomic restriction (OQ-02).** Does the rigid spacing of primitive
$n$-th roots of unity give a polynomial path-length bound inside $\{|\Phi_n(z)|<C\}$,
where the general roots-on-circle case admits Mac Lane's (1953) labyrinth?

## Prior state
Companion `CyclotomicPolynomialsOQ02OQ01` (researcher-4) proved the level set is
**bounded**, contained in the crude ball of radius `max 2 (C+1)`, so no escape-to-∞
path exists for cyclotomic $\Phi_n$ — unconditionally in $C$. Its explicit "Next Step"
was to *sharpen* that radius.

## This PR
New file `proofs/Proofs/CyclotomicPolynomialsOQ02OQ02.lean` (6 decls, **0 sorry / 0 axiom**,
docker `[7745/7745]` build succeeded) sharpens the outer radius and adds the complementary
inner containment, sandwiching the level set between concentric balls about the origin:

$$\{\, \|z\|+1 < C^{1/\varphi(n)} \,\}\ \subseteq\ \{|\Phi_n(z)|<C\}\ \subseteq\ \overline{B}\!\left(0,\ 1 + C^{1/\varphi(n)}\right).$$

| Result | Statement |
|--------|-----------|
| `norm_cyclotomic_eval_le` | $\|\Phi_n(z)\| \le (\|z\|+1)^{\varphi(n)}$ |
| `mem_levelSet_of_norm_add_one_pow_lt` | $(\|z\|+1)^{\varphi(n)} < C \Rightarrow z\in\{|\Phi_n|<C\}$ |
| `closedBall_subset_levelSet_cyclotomic` | inner ball $\subseteq$ level set |
| `cyclotomic_sublevel_norm_lt_sharp` | $\|\Phi_n(z)\| < C \Rightarrow \|z\| < 1 + C^{1/\varphi(n)}$ |
| `sublevel_subset_closedBall_sharp` | level set $\subseteq \overline{B}(0,\,1+C^{1/\varphi(n)})$ |
| `sharp_radius_le_crude` | $1 + C^{1/\varphi(n)} \le \max 2\,(C{+}1)$ for $C\ge 1$ |

## Why it matters
The mechanism is the elementary two-sided factor bound $\|z\|-1 \le \|z-\mu\| \le \|z\|+1$
on each primitive-root factor ($\|\mu\|=1$), giving
$(\|z\|-1)^{\varphi(n)} \le |\Phi_n(z)| \le (\|z\|+1)^{\varphi(n)}$; taking $\varphi(n)$-th
roots yields the sharp radius. `sharp_radius_le_crude` confirms it is a genuine
improvement — and it **decreases to $2$ as $\varphi(n)\to\infty$**, so high-degree
cyclotomic lemniscates hug the unit circle, the antithesis of the clustering freedom
Mac Lane needs to sculpt a labyrinth. The deep open driver (path-length $\le C\cdot n$
/ existence of a cyclotomic labyrinth) is untouched — it needs polynomial-lemniscate
topology and rectifiable-path arc length not yet in Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)