### PR TITLE
Enrich unitary-divisor count entry: add bibliographic references

### DIFF
--- a/src/data/proofs/automorphic-number-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01-oq-02/meta.json
@@ -208,5 +208,28 @@
       "relationship": "foundation",
       "description": "Fundamental Theorem of Arithmetic — unique factorization underlies ω(n), the identity n = ∏ p^v_p(n), and the powerset bijection between subsets of the primes and unitary divisors."
     }
+  ],
+  "references": [
+    {
+      "authors": "Eckford Cohen",
+      "title": "Arithmetical functions associated with the unitary divisors of an integer",
+      "year": "1960",
+      "venue": "Mathematische Zeitschrift 74, 66–80",
+      "note": "The standard reference defining unitary divisors (d ∣ n with gcd(d, n/d) = 1) and proving that their number is the unitary divisor function d*(n) = 2^ω(n) — exactly the count unitaryDivisors_card established here."
+    },
+    {
+      "authors": "R. Vaidyanathaswamy",
+      "title": "The theory of multiplicative arithmetic functions",
+      "year": "1931",
+      "venue": "Transactions of the American Mathematical Society 33 (2), 579–662",
+      "note": "Origin of the unitary (block/direct) convolution of arithmetic functions, in which a unitary divisor selects, at each prime, either the full prime-power p^{v_p(n)} or 1 — the structural fact underlying the powerset bijection s ↦ ∏_{p∈s} p^{v_p(n)}."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer, Undergraduate Texts in Mathematics",
+      "note": "Standard source for ω(n) = #{distinct primes ∣ n}, multiplicative arithmetic functions, and the appearance of 2^ω(n) as the number of squarefree divisors — the sibling interpretation this entry matches to the unitary-divisor count."
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment pass — `automorphic-number-oq-01-oq-01-oq-02`

This entry (#unitary divisors of n = 2^ω(n), and its bijection with idempotents of ℤ/n) was at target on every quality field **except references**, which was empty. This PR fills exactly that gap.

### Added references
- **Cohen** (1960, *Math. Z.*) — the classic paper defining unitary divisors and the count d*(n) = 2^ω(n).
- **Vaidyanathaswamy** (1931, *Trans. AMS*) — origin of unitary convolution: each prime contributes p^{v_p(n)} or 1.
- **Apostol**, *Introduction to Analytic Number Theory* — ω(n), multiplicative functions, 2^ω(n) as the squarefree-divisor count.

### Verification
- `meta.json` valid JSON, ~20 KB (under 60 KB cap); references = 3 (≤ 25 cap).
- No structural drift: counts (11 thm / 1 def / 0 axiom / 0 sorry), sections (cover the 212-line file), annotations, and 3 crossrefs all already consistent — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)