### PR TITLE
audit(fundamental-theorem-calculus): CLEAN (tracker bump)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19440,9 +19440,9 @@
       "issues": []
     },
     "fundamental-theorem-calculus": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:55Z",
+      "agentId": "auditor-cycle-20260709-ftc",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "fundamental-theorem-calculus-oq-01": {
@@ -29764,5 +29764,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T02:15:00Z"
+  "lastUpdated": "2026-07-09T00:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: fundamental-theorem-calculus (Wiedijk #48)
**Result**: CLEAN
**Was stalest**: last audited 2026-05-03 (tracker race)

## Verified against `proofs/Proofs/FundamentalTheoremCalculus.lean`

- **Tier B Mathlib bridge**, correctly labeled `status: verified` / `badge: mathlib`
- FTC Parts 1 & 2 delegate to Mathlib's `integral_hasDerivAt_right` / `integral_eq_sub_of_hasDerivAt_of_le` — disclosed in `assumptions`, docstring, and 6 `mathlibDependencies` ✓
- `sorries: 0`, `axiomCount: 0`, `theoremCount: 7`, `definitionCount: 2` — all match source ✓
- All `mainTheorems` names exist (`ftc_part1`, `ftc_part2`); all 3 `originalContributions` decls exist (`ftc_part1_continuous`, `ftc_part2_general`, `antiderivatives_differ_by_constant`) ✓
- No True stubs, no `native_decide`, no overclaiming ✓
- Antiderivative-uniqueness theorems (`antiderivatives_differ_by_constant`, `hasDerivAt_zero_implies_constant`) are genuinely proved via MVT `is_const_of_deriv_eq_zero` — real original content ✓
- Companion `FundamentalTheoremCalculusOQ04.lean` (9 theorems, 0 sorries/axioms) is honest bonus content, not overclaimed ✓

Persists the tracker bump lost to the `git reset --hard` race.

---
Discovered during periodic gallery integrity audit.