### PR TITLE
Research: erdos-1092-oq-02 - fThreshold is a genuine finite max in the non-degenerate regime (+parent build repair)

### DIFF
--- a/proofs/Proofs/Erdos1092OQ02.lean
+++ b/proofs/Proofs/Erdos1092OQ02.lean
@@ -73,7 +73,7 @@ theorem canReduce_removeAll {n : ℕ} (H : SGraph n) {r : ℕ} (hr : 1 ≤ r) :
   · -- The reduced graph has no edges (every pair is "removed"), so it is `r`-colorable.
     refine ⟨fun _ => ⟨0, by omega⟩, ?_⟩
     rintro u v ⟨_, hmem, _⟩
-    exact hmem (Finset.mem_univ _)
+    exact absurd (Finset.mem_univ _) hmem
 
 /-- The defining set of `fThreshold r n`: budgets `k` for which "every induced subgraph is
 `r`-reducible with `≤ k` edge deletions" already forces `(r+1)`-colorability of the whole
@@ -98,16 +98,19 @@ theorem fThresholdSet_downClosed {r n k k' : ℕ} (hk : k' ≤ k)
   -- Upgrade the `k'`-hypothesis to a `k`-hypothesis, then apply `hmem`.
   exact hmem G (fun S => CanReduceChromatic_mono_k _ hk (hP' S))
 
-/-- **The defining set is bounded above by `n*n` in the good regime `r + 2 ≤ n`.**
+/-- **The defining set is bounded above by `n*n` in the non-degenerate regime
+`1 ≤ r` and `r + 2 ≤ n`.**
 
 Take `K_n` as a witness. With the full budget `k = n*n`, every induced subgraph of `K_n`
-is `r`-reducible (`canReduce_removeAll`), so `K_n` satisfies the hypothesis; but `K_n` is
-*not* `(r+1)`-colorable when `r + 1 < n` (`completeGraph_not_hasColoring`). Hence
-`n*n ∉ fThresholdSet`, and by downward-closedness every element of the set is `< n*n`. -/
-theorem fThresholdSet_bddAbove {r n : ℕ} (hn : r + 2 ≤ n) :
+is `r`-reducible (`canReduce_removeAll`, which needs `1 ≤ r` — reducing to `0` colors is
+impossible on `n ≥ 1` vertices, the *lower* degeneracy of the problem, complementing the
+parent file's documented *upper* degeneracy `r + 1 ≥ n`), so `K_n` satisfies the
+hypothesis; but `K_n` is *not* `(r+1)`-colorable when `r + 1 < n`
+(`completeGraph_not_hasColoring`). Hence `n*n ∉ fThresholdSet`, and by downward-closedness
+every element of the set is `< n*n`. -/
+theorem fThresholdSet_bddAbove {r n : ℕ} (hr : 1 ≤ r) (hn : r + 2 ≤ n) :
     BddAbove (fThresholdSet r n) := by
   -- `n*n` is not in the set: `K_n` witnesses the failure.
-  have hr1 : 1 ≤ r + 1 := Nat.le_add_left 1 r
   have hnotmem : n * n ∉ fThresholdSet r n := by
     intro hmem
     -- `K_n` satisfies the full-budget hypothesis...
@@ -115,7 +118,7 @@ theorem fThresholdSet_bddAbove {r n : ℕ} (hn : r + 2 ≤ n) :
         (SGraph.mk (fun u v => u ∈ S ∧ v ∈ S ∧ (SGraph.completeGraph n).adj u v)
           (fun u v ⟨hu, hv, h⟩ => ⟨hv, hu, (SGraph.completeGraph n).symm u v h⟩)
           (fun v ⟨_, _, h⟩ => (SGraph.completeGraph n).irrefl v h)) (n * n) r :=
-      fun S => canReduce_removeAll _ hr1
+      fun S => canReduce_removeAll _ hr
     -- ...so `hmem` would make `K_n` be `(r+1)`-colorable, which is false.
     exact completeGraph_not_hasColoring (by omega) (hmem (SGraph.completeGraph n) hP)
   -- `n*n` is an upper bound: any element `> n*n` would drag `n*n` into the set.
@@ -125,25 +128,26 @@ theorem fThresholdSet_bddAbove {r n : ℕ} (hn : r + 2 ≤ n) :
   push_neg at hlt   -- `n*n < k`
   exact hnotmem (fThresholdSet_downClosed (le_of_lt hlt) hk)
 
-/-- **`fThreshold` is a genuine, finite maximum in the good regime.** In the regime
-`r + 2 ≤ n`, `fThreshold r n ≤ n * n`. This upgrades the parent file's prose caveat about
-the `sSup`-pathology into a proved bound: outside the degenerate `r + 1 ≥ n` range, the
-threshold is a real supremum of a bounded set, not the `sSup ℕ = 0` artifact. -/
-theorem fThreshold_le_sq {r n : ℕ} (hn : r + 2 ≤ n) : fThreshold r n ≤ n * n := by
+/-- **`fThreshold` is a genuine, finite maximum in the non-degenerate regime.** For
+`1 ≤ r` and `r + 2 ≤ n`, `fThreshold r n ≤ n * n`. This upgrades the parent file's prose
+caveat about the `sSup`-pathology into a proved bound: away from *both* degeneracies —
+the upper `r + 1 ≥ n` (documented in the parent) and the lower `r = 0` (surfaced here) —
+the threshold is a real supremum of a bounded set, not the `sSup ℕ = 0` artifact. -/
+theorem fThreshold_le_sq {r n : ℕ} (hr : 1 ≤ r) (hn : r + 2 ≤ n) :
+    fThreshold r n ≤ n * n := by
   rw [fThreshold_eq_sSup]
   refine csSup_le' ?_
   -- `n*n` is an upper bound of the defining set (same argument as boundedness).
   intro k hk
   by_contra hlt
   push_neg at hlt
-  have hr1 : 1 ≤ r + 1 := Nat.le_add_left 1 r
   have hnotmem : n * n ∉ fThresholdSet r n := by
     intro hmem
     have hP : ∀ S : Finset (Fin n), CanReduceChromatic
         (SGraph.mk (fun u v => u ∈ S ∧ v ∈ S ∧ (SGraph.completeGraph n).adj u v)
           (fun u v ⟨hu, hv, h⟩ => ⟨hv, hu, (SGraph.completeGraph n).symm u v h⟩)
           (fun v ⟨_, _, h⟩ => (SGraph.completeGraph n).irrefl v h)) (n * n) r :=
-      fun S => canReduce_removeAll _ hr1
+      fun S => canReduce_removeAll _ hr
     exact completeGraph_not_hasColoring (by omega) (hmem (SGraph.completeGraph n) hP)
   exact hnotmem (fThresholdSet_downClosed (le_of_lt hlt) hk)
 

--- a/proofs/Proofs/Erdos1092OQ02.lean
+++ b/proofs/Proofs/Erdos1092OQ02.lean
@@ -1,0 +1,156 @@
+/-
+# Erdős Problem #1092 OQ-02: Well-definedness of the threshold `fThreshold`
+
+The parent entry (`erdos-1092`, `Erdos1092Problem.lean`) defines
+
+  `fThreshold r n = sSup { k | ∀ G : SGraph n,
+      (∀ S, CanReduceChromatic (induced S) k r) → G.hasColoring (r+1) }`
+
+using `sSup` over `ℕ`. The parent file *documents* — in prose only — the crucial
+caveat that this `sSup` is meaningful **only** when `r + 2 ≤ n`:
+
+  * If `r + 1 ≥ n` then every `n`-vertex graph is already `(r+1)`-colorable
+    (`SGraph.hasColoring_self` + monotonicity), so the defining set is **all of `ℕ`**,
+    which is unbounded, and `sSup ℕ = 0` in Lean's `ConditionallyCompleteLinearOrderBot`
+    — a junk value.
+  * The parent's own removed axioms broke precisely because they ignored this.
+
+The open question left implicit there is: **in the good regime `r + 2 ≤ n`, is the
+defining set genuinely bounded above, so that `fThreshold` is a real maximum rather than a
+`sSup`-of-an-unbounded-set artifact?**
+
+This file answers it **yes**, rigorously and axiom-free:
+
+* `SGraph.completeGraph`   — the complete graph `K_n`.
+* `completeGraph_not_hasColoring` — `K_n` is not `r`-colorable when `r < n` (pigeonhole).
+* `canReduce_removeAll`   — deleting *every* edge makes any graph `r`-colorable (`r ≥ 1`),
+  so the full budget `k = n*n` reduces every induced subgraph.
+* `fThresholdSet` + `fThresholdSet_downClosed` — the defining set is downward closed.
+* `fThresholdSet_bddAbove` — **the defining set is bounded above by `n*n`** once
+  `r + 2 ≤ n` (using `K_n` as the witness graph that fails the conclusion).
+* `fThreshold_le_sq` — consequently `fThreshold r n ≤ n * n` in the good regime: the
+  `sSup` is a genuine, finite maximum, not the `sSup ℕ = 0` junk value.
+
+No new axioms; the two `axiom`s in the parent file are untouched (and unused here).
+-/
+
+import Mathlib
+import Proofs.Erdos1092Problem
+
+namespace Erdos1092OQ02
+
+/-- **The complete graph `K_n`.** Every pair of distinct vertices is adjacent. -/
+def SGraph.completeGraph (n : ℕ) : SGraph n where
+  adj u v := u ≠ v
+  symm _ _ h := h.symm
+  irrefl v := by simp
+
+/-- **`K_n` is not `r`-colorable when `r < n`.** A proper coloring of `K_n` must be
+injective (distinct vertices are adjacent, hence differently colored); an injection
+`Fin n ↪ Fin r` forces `n ≤ r`. -/
+theorem completeGraph_not_hasColoring {n r : ℕ} (h : r < n) :
+    ¬ (SGraph.completeGraph n).hasColoring r := by
+  rintro ⟨c, hc⟩
+  -- The coloring is injective on vertices.
+  have hinj : Function.Injective c := by
+    intro a b hab
+    by_contra hne
+    exact hc a b hne hab
+  -- An injection `Fin n → Fin r` gives `n ≤ r`, contradicting `r < n`.
+  have := Fintype.card_le_of_injective c hinj
+  simp only [Fintype.card_fin] at this
+  omega
+
+/-- **Deleting every edge trivializes the chromatic number.** For any graph `H` on `n`
+vertices and any `r ≥ 1`, removing all `n*n` candidate edges leaves the empty graph, which
+is `r`-colorable. Hence `H` can have its chromatic number reduced to `≤ r` within the
+budget `k = n*n`. -/
+theorem canReduce_removeAll {n : ℕ} (H : SGraph n) {r : ℕ} (hr : 1 ≤ r) :
+    CanReduceChromatic H (n * n) r := by
+  refine ⟨Finset.univ, ?_, ?_⟩
+  · -- `|Fin n × Fin n| = n * n`.
+    rw [Finset.card_univ, Fintype.card_prod, Fintype.card_fin]
+  · -- The reduced graph has no edges (every pair is "removed"), so it is `r`-colorable.
+    refine ⟨fun _ => ⟨0, by omega⟩, ?_⟩
+    rintro u v ⟨_, hmem, _⟩
+    exact hmem (Finset.mem_univ _)
+
+/-- The defining set of `fThreshold r n`: budgets `k` for which "every induced subgraph is
+`r`-reducible with `≤ k` edge deletions" already forces `(r+1)`-colorability of the whole
+graph. This is exactly the set `fThreshold r n = sSup (·)` ranges over. -/
+def fThresholdSet (r n : ℕ) : Set ℕ :=
+  { k : ℕ | ∀ G : SGraph n,
+      (∀ S : Finset (Fin n), CanReduceChromatic
+        (SGraph.mk (fun u v => u ∈ S ∧ v ∈ S ∧ G.adj u v)
+          (fun u v ⟨hu, hv, h⟩ => ⟨hv, hu, G.symm u v h⟩)
+          (fun v ⟨_, _, h⟩ => G.irrefl v h)) k r) →
+      G.hasColoring (r + 1) }
+
+/-- `fThresholdSet` really is the set `fThreshold` takes its `sSup` over. -/
+theorem fThreshold_eq_sSup (r n : ℕ) : fThreshold r n = sSup (fThresholdSet r n) := rfl
+
+/-- **The defining set is downward closed.** If budget `k` already forces the conclusion,
+so does any smaller budget `k' ≤ k`: a smaller budget makes the hypothesis *stronger*
+(fewer graphs satisfy it), via `CanReduceChromatic_mono_k`. -/
+theorem fThresholdSet_downClosed {r n k k' : ℕ} (hk : k' ≤ k)
+    (hmem : k ∈ fThresholdSet r n) : k' ∈ fThresholdSet r n := by
+  intro G hP'
+  -- Upgrade the `k'`-hypothesis to a `k`-hypothesis, then apply `hmem`.
+  exact hmem G (fun S => CanReduceChromatic_mono_k _ hk (hP' S))
+
+/-- **The defining set is bounded above by `n*n` in the good regime `r + 2 ≤ n`.**
+
+Take `K_n` as a witness. With the full budget `k = n*n`, every induced subgraph of `K_n`
+is `r`-reducible (`canReduce_removeAll`), so `K_n` satisfies the hypothesis; but `K_n` is
+*not* `(r+1)`-colorable when `r + 1 < n` (`completeGraph_not_hasColoring`). Hence
+`n*n ∉ fThresholdSet`, and by downward-closedness every element of the set is `< n*n`. -/
+theorem fThresholdSet_bddAbove {r n : ℕ} (hn : r + 2 ≤ n) :
+    BddAbove (fThresholdSet r n) := by
+  -- `n*n` is not in the set: `K_n` witnesses the failure.
+  have hr1 : 1 ≤ r + 1 := Nat.le_add_left 1 r
+  have hnotmem : n * n ∉ fThresholdSet r n := by
+    intro hmem
+    -- `K_n` satisfies the full-budget hypothesis...
+    have hP : ∀ S : Finset (Fin n), CanReduceChromatic
+        (SGraph.mk (fun u v => u ∈ S ∧ v ∈ S ∧ (SGraph.completeGraph n).adj u v)
+          (fun u v ⟨hu, hv, h⟩ => ⟨hv, hu, (SGraph.completeGraph n).symm u v h⟩)
+          (fun v ⟨_, _, h⟩ => (SGraph.completeGraph n).irrefl v h)) (n * n) r :=
+      fun S => canReduce_removeAll _ hr1
+    -- ...so `hmem` would make `K_n` be `(r+1)`-colorable, which is false.
+    exact completeGraph_not_hasColoring (by omega) (hmem (SGraph.completeGraph n) hP)
+  -- `n*n` is an upper bound: any element `> n*n` would drag `n*n` into the set.
+  refine ⟨n * n, ?_⟩
+  intro k hk
+  by_contra hlt
+  push_neg at hlt   -- `n*n < k`
+  exact hnotmem (fThresholdSet_downClosed (le_of_lt hlt) hk)
+
+/-- **`fThreshold` is a genuine, finite maximum in the good regime.** In the regime
+`r + 2 ≤ n`, `fThreshold r n ≤ n * n`. This upgrades the parent file's prose caveat about
+the `sSup`-pathology into a proved bound: outside the degenerate `r + 1 ≥ n` range, the
+threshold is a real supremum of a bounded set, not the `sSup ℕ = 0` artifact. -/
+theorem fThreshold_le_sq {r n : ℕ} (hn : r + 2 ≤ n) : fThreshold r n ≤ n * n := by
+  rw [fThreshold_eq_sSup]
+  refine csSup_le' ?_
+  -- `n*n` is an upper bound of the defining set (same argument as boundedness).
+  intro k hk
+  by_contra hlt
+  push_neg at hlt
+  have hr1 : 1 ≤ r + 1 := Nat.le_add_left 1 r
+  have hnotmem : n * n ∉ fThresholdSet r n := by
+    intro hmem
+    have hP : ∀ S : Finset (Fin n), CanReduceChromatic
+        (SGraph.mk (fun u v => u ∈ S ∧ v ∈ S ∧ (SGraph.completeGraph n).adj u v)
+          (fun u v ⟨hu, hv, h⟩ => ⟨hv, hu, (SGraph.completeGraph n).symm u v h⟩)
+          (fun v ⟨_, _, h⟩ => (SGraph.completeGraph n).irrefl v h)) (n * n) r :=
+      fun S => canReduce_removeAll _ hr1
+    exact completeGraph_not_hasColoring (by omega) (hmem (SGraph.completeGraph n) hP)
+  exact hnotmem (fThresholdSet_downClosed (le_of_lt hlt) hk)
+
+#check @completeGraph_not_hasColoring
+#check @canReduce_removeAll
+#check @fThresholdSet_downClosed
+#check @fThresholdSet_bddAbove
+#check @fThreshold_le_sq
+
+end Erdos1092OQ02

--- a/proofs/Proofs/Erdos1092Problem.lean
+++ b/proofs/Proofs/Erdos1092Problem.lean
@@ -140,10 +140,8 @@ is also r₂-colorable for any r₂ ≥ r₁ (embed colors via inclusion). -/
 theorem SGraph.hasColoring_mono {n : ℕ} (G : SGraph n) {r₁ r₂ : ℕ} (h : r₁ ≤ r₂)
     (hc : G.hasColoring r₁) : G.hasColoring r₂ := by
   obtain ⟨c, hc⟩ := hc
-  refine ⟨fun v => ⟨(c v).val, lt_of_lt_of_le (c v).isLt h⟩, fun u v hadj heq => ?_⟩
-  apply hc u v hadj
-  have hnat : (c u).val = (c v).val := congrArg Fin.val heq
-  exact Fin.ext hnat
+  refine ⟨fun v => Fin.castLE h (c v), fun u v hadj heq => ?_⟩
+  exact hc u v hadj (Fin.castLE_injective h heq)
 
 /-- If G is already r-colorable, removing zero edges suffices. -/
 theorem canReduce_zero {n : ℕ} (G : SGraph n) (r : ℕ) (hc : G.hasColoring r) :

--- a/proofs/Proofs/Erdos1092Problem.lean
+++ b/proofs/Proofs/Erdos1092Problem.lean
@@ -27,6 +27,8 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Combinatorics.SimpleGraph.Basic
 
+open scoped Classical
+
 /- ## Definitions -/
 
 /-- A simple graph on n vertices. -/
@@ -44,9 +46,11 @@ noncomputable def SGraph.edgeCount {n : ℕ} (G : SGraph n) : ℕ :=
 def SGraph.hasColoring {n : ℕ} (G : SGraph n) (r : ℕ) : Prop :=
   ∃ c : Fin n → Fin r, ∀ u v, G.adj u v → c u ≠ c v
 
-/-- The chromatic number: minimum r such that G has a proper r-coloring. -/
+/-- The chromatic number: minimum r such that G has a proper r-coloring.
+    (`G` is always `n`-colorable via `SGraph.hasColoring_self`, so this set is nonempty
+    and `sInf` returns the genuine minimum.) -/
 noncomputable def SGraph.chromaticNum {n : ℕ} (G : SGraph n) : ℕ :=
-  Nat.find ⟨n, ⟨Fin.elim0, fun u v _ => (Fin.elim0 u).elim⟩⟩
+  sInf { r | G.hasColoring r }
 
 /-- Removing k edges from G: there exist k edges whose deletion
     yields a graph with chromatic number ≤ r. -/
@@ -136,8 +140,10 @@ is also r₂-colorable for any r₂ ≥ r₁ (embed colors via inclusion). -/
 theorem SGraph.hasColoring_mono {n : ℕ} (G : SGraph n) {r₁ r₂ : ℕ} (h : r₁ ≤ r₂)
     (hc : G.hasColoring r₁) : G.hasColoring r₂ := by
   obtain ⟨c, hc⟩ := hc
-  exact ⟨fun v => ⟨(c v).val, lt_of_lt_of_le (c v).isLt h⟩,
-    fun u v hadj heq => hc u v hadj (Fin.ext (congr_arg Fin.val heq))⟩
+  refine ⟨fun v => ⟨(c v).val, lt_of_lt_of_le (c v).isLt h⟩, fun u v hadj heq => ?_⟩
+  apply hc u v hadj
+  have hnat : (c u).val = (c v).val := congrArg Fin.val heq
+  exact Fin.ext hnat
 
 /-- If G is already r-colorable, removing zero edges suffices. -/
 theorem canReduce_zero {n : ℕ} (G : SGraph n) (r : ℕ) (hc : G.hasColoring r) :

--- a/research/problems/erdos-1092-oq-02/knowledge.md
+++ b/research/problems/erdos-1092-oq-02/knowledge.md
@@ -19,3 +19,47 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-09 (researcher-5) — fThreshold well-definedness + parent build-repair
+
+**Mode**: BUILD/ACT. **Outcome**: VERIFIED (docker [7744/7744], 0 sorry, 0 axiom) —
+new file `Erdos1092OQ02.lean` (+ repaired the build-broken parent).
+
+### New file `Erdos1092OQ02.lean`
+Answers the OQ-02 question of whether `fThreshold`'s `sSup` (parent
+`Erdos1092Problem.lean`) is a *genuine finite maximum* or the degenerate `sSup ℕ = 0`
+artifact. Proved: **yes, in the non-degenerate regime `1 ≤ r ∧ r + 2 ≤ n`.**
+- `SGraph.completeGraph` + `completeGraph_not_hasColoring` — `K_n` not `r`-colorable for
+  `r < n` (pigeonhole `Fintype.card_le_of_injective`).
+- `canReduce_removeAll` — deleting all `n*n` edges makes any graph `r`-colorable (`r ≥ 1`).
+- `fThresholdSet` + `fThresholdSet_downClosed` — defining set is downward closed
+  (via parent's `CanReduceChromatic_mono_k`).
+- `fThresholdSet_bddAbove` — bounded above by `n*n` (K_n witness) in the regime.
+- `fThreshold_le_sq` — `fThreshold r n ≤ n*n` (`csSup_le'`, no nonemptiness needed).
+
+### Key mathematical finding
+The problem has **two** degeneracies, not one:
+- *Upper* (documented in parent): `r + 1 ≥ n` ⇒ every graph is `(r+1)`-colorable ⇒
+  defining set = `ℕ` ⇒ `sSup = 0`.
+- *Lower* (surfaced here): `r = 0` ⇒ reducing to `0` colors is impossible on `n ≥ 1`
+  vertices ⇒ the antecedent `∀S CanReduce(·,k,0)` is always false ⇒ implication vacuous
+  ⇒ defining set = `ℕ` ⇒ `sSup = 0`.
+So the precise non-degenerate regime is `1 ≤ r ∧ r + 2 ≤ n`.
+
+### Parent build-repair (was broken on main vs Mathlib 4.26)
+- `SGraph.edgeCount`: `DecidablePred` synth failed on Prop-valued `G.adj` → `open scoped
+  Classical`.
+- `SGraph.chromaticNum`: malformed `Nat.find` (predicate unspecified, `Fin.elim0` witness
+  only valid at `n=0`) → `sInf {r | G.hasColoring r}`.
+- `SGraph.hasColoring_mono`: `Fin.val` elaborated at wrong `Fin` type → rewrote via
+  `Fin.castLE` + `Fin.castLE_injective`.
+
+### Gotchas
+- `exact hmem (mem_univ _)` gives `False`, but the coloring goal is `c u ≠ c v` → use
+  `absurd (mem_univ _) hmem`.
+- `csSup_le'` (for `ConditionallyCompleteLinearOrderBot`) needs only an upper-bound
+  membership, NOT nonemptiness — clean for `sSup`-of-possibly-empty ℕ sets.
+- Persistent fleet SIGBUS-135 at olean-*write* (`[7744/7744]`, deps "Completed
+  successfully"): elaboration is clean; only the write is killed. Also several corrupted
+  Mathlib cache artifacts (`.ir`/`.trace` "invalid header"/"unexpected end of input") —
+  `rm` the named file and rebuild. Needed ~15 build attempts to catch a clean write.

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -198,7 +198,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 160,
+    "lineCount": 164,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 6,

--- a/src/data/research/problems/erdos-1092-oq-02.json
+++ b/src/data/research/problems/erdos-1092-oq-02.json
@@ -29,9 +29,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "PROGRESS (VERIFIED 0/0, researcher-5 2026-07-09): new file Erdos1092OQ02.lean proves the fThreshold sSup is a genuine finite maximum (not the sSup ℕ = 0 junk value) in the non-degenerate regime 1 ≤ r ∧ r+2 ≤ n — turning the parent Erdos1092Problem.lean prose caveat into a theorem. Discovered r=0 is ALSO degenerate (lower degeneracy: reducing to 0 colors impossible on n≥1 vertices → defining set = ℕ), complementing the parent-documented upper degeneracy r+1 ≥ n. Also build-repaired the parent file, which was broken on main against the Mathlib 4.26 pin (edgeCount DecidablePred, malformed chromaticNum Nat.find, hasColoring_mono Fin.val ambiguity). Key lemmas: completeGraph_not_hasColoring (pigeonhole), canReduce_removeAll (delete all edges), fThresholdSet_downClosed, fThresholdSet_bddAbove, fThreshold_le_sq. 0 axioms, 0 sorries.",
     "builtItems": [],
-    "insights": [],
+    "insights": [
+      "fThreshold has TWO degeneracies: upper r+1≥n (set=ℕ, all graphs (r+1)-colorable) and lower r=0 (set=ℕ, no 0-coloring on n≥1 vertices). Non-degenerate regime is 1≤r ∧ r+2≤n.",
+      "Boundedness of the fThreshold defining set follows from K_n as a witness that satisfies the full-budget hypothesis (empty-graph reduction) yet fails (r+1)-colorability (pigeonhole)."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-1092-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for `erdos-1092-oq-02` (Erdős #1092, chromatic decomposition threshold).
Two deliverables, both VERIFIED (`docker-build.sh` → `Built [7744/7744]`, 0 sorry, 0 axiom):

1. **New file `Erdos1092OQ02.lean`** — resolves the open question of whether the parent's
   `fThreshold r n = sSup {k | …}` is a genuine finite maximum or the degenerate
   `sSup ℕ = 0` artifact. **Answer: a genuine bounded maximum in the non-degenerate
   regime `1 ≤ r ∧ r + 2 ≤ n`.**
2. **Build repair of the parent `Erdos1092Problem.lean`**, which was broken on `main`
   against the Mathlib 4.26 pin (see below).

## New results (`Erdos1092OQ02.lean`)
- `SGraph.completeGraph` + `completeGraph_not_hasColoring` — `K_n` is not `r`-colorable
  for `r < n` (pigeonhole via `Fintype.card_le_of_injective`).
- `canReduce_removeAll` — deleting all `n*n` candidate edges makes any graph `r`-colorable
  (`r ≥ 1`), so the full budget reduces every induced subgraph.
- `fThresholdSet` + `fThresholdSet_downClosed` — the defining set is downward closed.
- `fThresholdSet_bddAbove` — the defining set is **bounded above by `n*n`** in the regime
  `1 ≤ r ∧ r + 2 ≤ n` (using `K_n` as a witness graph that satisfies the full-budget
  hypothesis yet fails `(r+1)`-colorability).
- `fThreshold_le_sq` — consequently `fThreshold r n ≤ n * n`: the `sSup` is a real,
  finite maximum, not the `sSup ℕ = 0` junk value.

## Key mathematical finding
The threshold has **two** degeneracies, not one:
- *Upper* (already documented in the parent): `r + 1 ≥ n` ⇒ every `n`-vertex graph is
  `(r+1)`-colorable ⇒ defining set `= ℕ` ⇒ `sSup = 0`.
- *Lower* (**surfaced here**): `r = 0` ⇒ reducing to `0` colors is impossible on `n ≥ 1`
  vertices ⇒ the hypothesis `∀S, CanReduce(·, k, 0)` is always false ⇒ the implication is
  vacuous ⇒ defining set `= ℕ` ⇒ `sSup = 0`.

So the precise non-degenerate regime is `1 ≤ r ∧ r + 2 ≤ n`, sharpening the parent's
prose caveat (`r + 2 ≤ n`).

## Parent build repair (`Erdos1092Problem.lean`, broken on main)
- `SGraph.edgeCount`: `DecidablePred` synthesis failed on the Prop-valued `G.adj` →
  `open scoped Classical`.
- `SGraph.chromaticNum`: malformed `Nat.find` (predicate unspecified; `Fin.elim0` witness
  valid only at `n = 0`) → `sInf {r | G.hasColoring r}`.
- `SGraph.hasColoring_mono`: injectivity extraction elaborated `Fin.val` at the wrong
  `Fin` type → rewrote via `Fin.castLE` + `Fin.castLE_injective`.
- Preserves 0 axioms, 0 sorries.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos1092OQ02` → `Build completed successfully
  (7744 jobs)`. New file: 160 lines, 6 theorems, 2 defs, 0 axioms, 0 sorries.
- Note: the build ran under a persistent fleet SIGBUS-135 storm at the olean-*write* step;
  elaboration is clean (all `#check`s print, no `error: …OQ02.lean:NN`), and a clean write
  was ultimately captured.

## Status
**Outcome**: progress (new verified results + build repair)
**Next Steps**: the underlying Erdős–Hajnal–Szemerédi growth questions (`f₂(n) ≫ n`?) are
disproved/removed in the parent; the well-definedness gap addressed here was the natural
remaining formalization target.

🤖 Generated by researcher-5