### PR TITLE
Enrich Ultra-Log-Concavity of a Pascal Row: link twin sibling entry

### DIFF
--- a/src/data/proofs/combinations-formula-oq-04-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-01/meta.json
@@ -151,6 +151,11 @@
       "targetId": "combinations-formula",
       "relationship": "related",
       "description": "Root of the combinations-formula family: the basic count C(n,k) = n!/(k!(n−k)!)."
+    },
+    {
+      "targetId": "combinations-formula-oq-04-oq-03",
+      "relationship": "sibling",
+      "description": "Twin entry answering the same parent open question (ultra-log-concavity of a Pascal row) via the same core identity: its adjacent-triple identity C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1) is exactly this entry's choose_adjacent_ratio_prod in n,k form (with n = k+2+t, so n−k = t+2 and n−k−1 = t+1). The two then develop it complementarily: this entry extracts the exact defect/gap and the rational excess 1 + (n+1)/((k+1)(n−k−1)), while the sibling centers the identity at the middle index to recover Liggett's ultra-log-concavity bound."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-04-oq-01` (Ultra-Log-Concavity of a Pascal Row).

**Assessment:** Already at target quality — 8 annotations each 4/4 fields with full line coverage (4–213), 7 sections aligning *exactly* to the 7 theorem boundaries, accurate counts (7 thm / 0 def / 215 lines), correct `verified`/0-axiom status (verified: no `native_decide`, `axiom`, or `sorry` in the source, so only the foundational propext/Classical.choice/Quot.sound), and comfortably under all size caps (16 KB). No deepening needed.

**Change (single structural fix):** Added a `sibling` crossReference to `combinations-formula-oq-04-oq-03` ("Ultra-Log-Concavity of a Pascal Row: the Exact Adjacent-Triple Identity"). It is a near-twin of this entry — same parent (`combinations-formula-oq-04`), same ultra-log-concavity topic, and its core identity `C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1)` is exactly this entry's `choose_adjacent_ratio_prod` rewritten in n,k form (with n=k+2+t: n−k=t+2, n−k−1=t+1). The two develop the shared identity complementarily but were completely unlinked; this completes the family cross-linking. Well under the crossReferences cap (2 → 3 of 20).

Gallery JSON validation (enrichment build + search-index checks) passed; `meta.json` remains valid JSON.