### PR TITLE
Research: algebraic-numbers-countable-oq-07 — algebraic reals null for every atomless measure

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -270,4 +270,53 @@ theorem transcendental_complex_dense :
   rw [algebraic_complex_dimH_zero]
   exact_mod_cast Module.finrank_pos
 
+-- ============================================================================
+-- § 5. Generalization to arbitrary atomless measures
+-- ============================================================================
+
+/-!
+The measure-zero results above are stated for Lebesgue `volume`, but the only
+property used is that a *countable* set is null for any measure **without atoms**
+(`Set.Countable.measure_zero`). So the same conclusion holds verbatim for every
+atomless Borel measure on `ℝ` (or `ℂ`) — Gaussian, exponential, any absolutely
+continuous law, etc. The algebraic reals are `μ`-null not because of any special
+feature of Lebesgue measure but purely because they are countable.
+-/
+
+/-- **The algebraic reals are null for every atomless measure**, not just Lebesgue
+`volume`: countability alone forces `μ`-measure zero whenever `μ` has no atoms. -/
+theorem algebraic_reals_null_of_noAtoms (μ : Measure ℝ) [NoAtoms μ] :
+    μ {x : ℝ | IsAlgebraic ℚ x} = 0 :=
+  (AlgebraicNumbersCountable.algebraic_reals_countable).measure_zero μ
+
+/-- **Almost every real is transcendental, for any atomless measure `μ`.** Generalizes
+`ae_transcendental` from Lebesgue `volume` to every `[NoAtoms μ]`. -/
+theorem ae_transcendental_of_noAtoms (μ : Measure ℝ) [NoAtoms μ] :
+    ∀ᵐ x : ℝ ∂μ, Transcendental ℚ x := by
+  have hset : {x : ℝ | Transcendental ℚ x} = {x : ℝ | IsAlgebraic ℚ x}ᶜ := by
+    ext x; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  rw [Filter.eventually_iff, hset]
+  exact compl_mem_ae_iff.mpr (algebraic_reals_null_of_noAtoms μ)
+
+/-- **The algebraic complex numbers are null for every atomless measure on `ℂ`.** The
+complex analogue of `algebraic_reals_null_of_noAtoms`. -/
+theorem algebraic_complex_null_of_noAtoms (μ : Measure ℂ) [NoAtoms μ] :
+    μ {z : ℂ | IsAlgebraic ℚ z} = 0 :=
+  (AlgebraicNumbersCountable.algebraic_complex_countable).measure_zero μ
+
+/-- **Positive-measure sets contain transcendentals, for any atomless `μ`.** If `μ` has no
+atoms and `μ s > 0`, then `s` contains a transcendental — otherwise `s ⊆ {algebraic}` would be
+`μ`-null. Generalizes `exists_transcendental_of_pos_measure` beyond Lebesgue measure. -/
+theorem exists_transcendental_of_pos_measure_noAtoms {μ : Measure ℝ} [NoAtoms μ]
+    {s : Set ℝ} (hs : 0 < μ s) : ∃ x ∈ s, Transcendental ℚ x := by
+  by_contra h
+  push_neg at h
+  have hsub : s ⊆ {x : ℝ | IsAlgebraic ℚ x} := by
+    intro x hx
+    have := h x hx
+    simpa only [mem_setOf_eq, Transcendental, not_not] using this
+  have hz : μ s = 0 := measure_mono_null hsub (algebraic_reals_null_of_noAtoms μ)
+  rw [hz] at hs
+  exact lt_irrefl 0 hs
+
 end AlgebraicRealsNull


### PR DESCRIPTION
## Summary

`AlgebraicRealsNull.lean` proves the algebraic reals/complexes are Lebesgue-null (and a.e. transcendental, dense complement, etc.), all stated for `volume`. But the only ingredient is that a **countable** set is null for any measure **without atoms** (`Set.Countable.measure_zero`, `[NoAtoms μ]`). This PR generalizes to *arbitrary atomless Borel measures* — matching the entry's own listed nextStep:

- **`algebraic_reals_null_of_noAtoms`** — `μ {x | IsAlgebraic ℚ x} = 0` for every `[NoAtoms μ]` on ℝ.
- **`algebraic_complex_null_of_noAtoms`** — the complex analogue on ℂ.
- **`ae_transcendental_of_noAtoms`** — a.e. `x` is transcendental for any atomless `μ` (generalizes `ae_transcendental`).
- **`exists_transcendental_of_pos_measure_noAtoms`** — any `μ`-positive-measure set contains a transcendental (generalizes `exists_transcendental_of_pos_measure`).

This records that the transcendentals are conull not by any special feature of Lebesgue measure but purely because the algebraic numbers are countable — the statement holds for Gaussian, exponential, or any absolutely continuous law.

## Proof notes
- Pure reuse of `AlgebraicNumbersCountable.algebraic_{reals,complex}_countable` and `Set.Countable.measure_zero`; the `ae` and positive-measure proofs mirror the file's existing `ae_transcendental` / `exists_transcendental_of_pos_measure` patterns with `μ` in place of `volume`.
- No `sorry`, no `axiom`.

## Build status
Elaboration is **clean**: every Docker run reaches `[3073/3073] Building Proofs.AlgebraicRealsNull` (~1s) with no elaboration errors. The olean **write** hits the recurring fleet `SIGBUS`/exit-135 this session (stochastic per-run; other files wrote green this same session). Marked elaboration-verified pending a clean write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)