### PR TITLE
audit(fundamental-arithmetic): fix phantom mainTheorem name + fabricated leanType

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19357,10 +19357,10 @@
       "issues": []
     },
     "fundamental-arithmetic": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:55Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T12:00:00Z",
+      "result": "issues-fixed"
     },
     "fundamental-arithmetic-oq-01": {
       "auditCount": 3,

--- a/src/data/proofs/fundamental-arithmetic/meta.json
+++ b/src/data/proofs/fundamental-arithmetic/meta.json
@@ -217,15 +217,15 @@
   },
   "mainTheorems": [
     {
-      "name": "fundamental_theorem_arithmetic",
+      "name": "fundamental_theorem_of_arithmetic",
       "type": "core",
-      "description": "Every integer > 1 has a unique prime factorization",
-      "leanType": "(n : Nat) -> 1 < n -> exists! (factors : Multiset Nat), (forall p in factors, Nat.Prime p) and factors.prod = n"
+      "description": "Every integer >= 2 has a sorted prime-list factorization, unique up to permutation",
+      "leanType": "(n : Nat) -> 2 <= n -> exists l : List Nat, (forall p in l, Nat.Prime p) and l.Sorted (<=) and l.prod = n and (forall l', (forall p in l', Nat.Prime p) -> l'.prod = n -> l'.Perm l)"
     },
     {
-      "name": "unique_factorization",
+      "name": "nat_is_ufm",
       "type": "key",
-      "description": "Nat is a unique factorization domain",
+      "description": "Nat is a unique factorization monoid",
       "leanType": "UniqueFactorizationMonoid Nat"
     }
   ],


### PR DESCRIPTION
## Auditor Finding

**Entry:** fundamental-arithmetic (Fundamental Theorem of Arithmetic, Wiedijk #80)

### Issue: phantom mainTheorem name + fabricated leanType

`mainTheorems[0]` claimed name `fundamental_theorem_arithmetic` (actual decl: `fundamental_theorem_of_arithmetic`) with leanType `(n : Nat) -> 1 < n -> exists! (factors : Multiset Nat), ...`.

The file actually proves (`proofs/Proofs/FundamentalArithmetic.lean:118`):
```
(n : ℕ) (hn : 2 ≤ n) : ∃ l : List ℕ,
  (∀ p ∈ l, Nat.Prime p) ∧ l.Sorted (· ≤ ·) ∧ l.prod = n ∧
  (∀ l', (∀ p ∈ l', Nat.Prime p) → l'.prod = n → l'.Perm l)
```
i.e. plain `∃` over `List ℕ` with a sorted + permutation-uniqueness clause — **not** `exists!` unique-existence over `Multiset`. Corrected name + leanType to match source; also corrected `unique_factorization` label to its real decl `nat_is_ufm`.

### Verified accurate (no change)
- Counts: 11 theorems, 0 defs, 0 literal axioms, 0 sorries ✓
- `mathlibDependencies` all present in source ✓
- `originalContributions` all real (coprime_disjoint_factors is a genuine hand proof) ✓
- native_decide confined to `example` blocks; conservative `axiomatized`/axiomCount:1 with `Lean.ofReduceBool` disclosed — left as-is ✓

Tracker bumped (2026-05-03 → re-audited, issues-fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)