### PR TITLE
Enrich Alternating Row Sum (combinations-formula-oq-05): fix malformed relationship tag

### DIFF
--- a/src/data/proofs/combinations-formula-oq-05/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05/meta.json
@@ -113,7 +113,7 @@
     },
     {
       "targetId": "combinations-formula-oq-04-oq-01",
-      "relationship": "related — companion Pascal-row property",
+      "relationship": "related",
       "description": "A different structural property of the same Pascal row: where this entry splits the row into equal even/odd halves via the alternating sum, the log-concavity companion pins the exact ultra-log-concavity defect C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)). Together they characterize the additive (parity) and multiplicative (log-concave) structure of a binomial row."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-05` (Alternating Row Sum of Pascal's Triangle and the Even/Odd Split).

**Change (single structural-hygiene fix):** The crossReference to `combinations-formula-oq-04-oq-01` had its `relationship` set to `"related — companion Pascal-row property"` — a full description phrase baked into the tag field. No other gallery entry does this; a relationship tag is meant to be a short label (`related`, `extends`, `sibling`, …) and this would render as a broken/overlong badge. The companion elaboration already lives verbatim in the crossref's `description` field, so I cleaned the tag to the conventional `"related"` and left the description untouched.

**Assessment:** The entry is otherwise sound and at target quality — `theoremCount: 4` is correct (it includes the `private theorem sum_choose_int` at line 80; the `example` at line 110 is correctly not counted), `verified`/0-axiom status is accurate (no `native_decide`/`axiom`/`sorry` in the source), 5 annotations each 4/4 fields with full line coverage (1–114), 4 keyInsights, 2 openQuestions, valid crossref targets. No deepening needed.

Gallery JSON validation (enrichment build + search-index checks) passed; `meta.json` remains valid JSON.