### PR TITLE
audit(four-color-theorem): fix axiom-masking in originalContributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19026,10 +19026,10 @@
       "result": "clean"
     },
     "four-color-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:56Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T12:20:00Z",
+      "result": "issues-fixed"
     },
     "four-color-theorem-oq-01": {
       "auditCount": 3,

--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -25,14 +25,14 @@
       }
     ],
     "originalContributions": [
-      "Five Color Theorem complete proof via Kempe chains",
-      "Reducibility and unavoidability framework",
-      "Main theorem combining reducibility and unavoidability"
+      "Fully proved planar-graph infrastructure lemmas: colorable_of_card_le, planar_of_subgraph, and exists_degree_le_five (every nonempty planar graph has a vertex of degree <= 5, via the handshaking lemma and a planar edge bound)",
+      "Five Color Theorem stated and reduced to the axiom five_color_theorem_nonempty (the vertex-deletion induction is not yet available in Mathlib); only the empty-graph case is discharged directly",
+      "Four Color Theorem axiomatized as four_color_theorem_axiom (the Appel-Haken / Gonthier result is not ported to Lean), with four_implies_five derived from it. KempeChain is defined for exposition only and is not used in any proof; the file contains no reducibility/unavoidability formalization"
     ],
     "dateAdded": "2025-12-21",
     "wiedijkNumber": 32,
     "axiomCount": 2,
-    "assumptions": "2 axiom(s). No sorries.",
+    "assumptions": "2 axioms carrying the core results themselves: five_color_theorem_nonempty (Colorable G 5 for nonempty planar G) and four_color_theorem_axiom (Colorable G 4). The Four and Five Color Theorems are therefore assumed, not proved, in this file; the theorems five_color_theorem, four_color_theorem, and four_implies_five are thin wrappers over these axioms. Genuinely proved: supporting infrastructure (colorable_of_card_le, planar_of_subgraph, exists_degree_le_five). No sorries.",
     "proofRepoPath": "Proofs/FourColorTheorem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 294,


### PR DESCRIPTION
## Auditor Finding

**Entry:** four-color-theorem (Wiedijk #32). Correctly `status: axiomatized`, `badge: axiom`, `axiomCount: 2` — but `originalContributions` masked the axioms with overclaims.

### Issue: axiom masking (failure mode #2)

The file's actual structure (`proofs/Proofs/FourColorTheorem.lean`):
- `five_color_theorem_nonempty` (line 182) — **axiom**
- `five_color_theorem` (line 185) — wrapper: empty case direct, non-empty case `exact five_color_theorem_nonempty G hne`
- `four_color_theorem_axiom` (line 243) — **axiom**
- `four_color_theorem` (line 246) — `:= four_color_theorem_axiom G`
- `KempeChain` (line 210) — defined, **used in zero proofs**

The old `originalContributions` claimed:
| Claim | Reality |
|-------|---------|
| "Five Color Theorem complete proof via Kempe chains" | Axiomatized; Kempe chains unused; comments admit vertex-deletion induction absent |
| "Reducibility and unavoidability framework" | Phantom — words appear only in docstring prose (lines 221-223, 282), no decls |
| "Main theorem combining reducibility and unavoidability" | `four_color_theorem := four_color_theorem_axiom`, a direct axiom wrapper |

### Fix
Rewrote `originalContributions` to distinguish genuinely-proved infrastructure (`colorable_of_card_le`, `planar_of_subgraph`, `exists_degree_le_five` — a real handshaking + planar-edge-bound proof) from the axiomatized core theorems. Expanded the terse `assumptions` ("2 axiom(s). No sorries.") to name the two core-carrying axioms.

No change to status/badge/axiomCount (already correct). Tracker bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)