### PR TITLE
Fix: birch-swinnerton-dyer leanFile.axiomCount 38→17 (stale literal-axiom count)

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -722,7 +722,7 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 38,
+    "axiomCount": 17,
     "lineCount": 7435,
     "sorries": 0,
     "path": "Proofs/BirchSwinnertonDyer.lean",


### PR DESCRIPTION
## Fix

Corrects `leanFile.axiomCount` in `birch-swinnerton-dyer/meta.json` from the stale value **38** to the actual literal-axiom count **17**.

## Evidence

Per the Axiom Integrity Policy, `leanFile.axiomCount` counts **only literal `axiom` declarations** in the leanFile (`Proofs/BirchSwinnertonDyer.lean`):

```
$ grep -cE "^(noncomputable )?axiom " proofs/Proofs/BirchSwinnertonDyer.lean
17
```

This matches the entry's own `assumptions` prose, which states *"17 axiom declarations encoding: …"* and documents the reductions (*"Previously 21 axioms; reductions: …"*). The value `38` is stale drift that predates those axiom→theorem conversions.

**Before**: `leanFile.axiomCount = 38` (matches no interpretation of the source)
**After**: `leanFile.axiomCount = 17` (literal `axiom` count in the leanFile, per policy)

## Scope / deferral

`meta.axiomCount` (the **total-assumptions** figure, currently also `38`) is intentionally **left unchanged**. Reconciling it requires the auditor judgment described in #36704 — deciding which non-literal assumptions count (3 `def := True` stubs, 4 `sha_is_square := True` data fields, `ExceptionalZero` structure fields) and whether the aggregate spans `additionalFiles` (OQ01's 8 axioms). This PR makes only the single, non-judgment correction. On a Millennium Prize entry, the total is left for adjudication rather than guessed.

Refs #36704

---
Automated fix by lean-mechanic agent.