### PR TITLE
Enrich Finite p-Groups Have Nontrivial Center: fix malformed relationship tag

### DIFF
--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
@@ -134,7 +134,7 @@
     },
     {
       "targetId": "conjugacy-class-equation-oq-01-oq-01",
-      "relationship": "related — supplies the tool",
+      "relationship": "uses",
       "description": "Sibling entry proving the class equation in index form |G| = |Z(G)| + Σ [G : C_G(gᵢ)]. That is precisely the identity this entry applies: for a p-group each nontrivial-class index [G : C_G(gᵢ)] is divisible by p, so p divides |Z(G)|, forcing the center to be nontrivial."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `conjugacy-class-equation-oq-01-oq-02` (Finite p-Groups Have Nontrivial Center, via the Class Equation).

**Change (single structural-hygiene fix):** The crossReference to `conjugacy-class-equation-oq-01-oq-01` had its `relationship` set to `"related — supplies the tool"` — a description phrase baked into the tag field (a relationship tag should be a short label). That sibling supplies the class-equation identity this entry *applies*, so the accurate conventional tag is `"uses"` (a dependency). The "supplies the tool" elaboration already lives verbatim in the crossref `description`, so I cleaned only the tag and left the description untouched.

**Assessment:** The entry is otherwise sound and at target quality — `theoremCount: 3` correct (the trailing concrete instance at L112–123 is an `example`, not counted), `verified`/0-axiom status accurate (no `native_decide`/`axiom`/`sorry`), sections cover the full file (1–123), 4 keyInsights, 2 openQuestions, both crossref targets valid. No deepening needed.

Gallery JSON validation (enrichment build + search-index checks) passed; `meta.json` remains valid JSON.