### PR TITLE
audit(fourier-series-oq-03): re-verified CLEAN — bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19150,8 +19150,8 @@
     },
     "fourier-series-oq-03": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:56Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T03:06:59Z",
       "result": "clean"
     },
     "fourier-series-oq-04": {


### PR DESCRIPTION
## Audit: fourier-series-oq-03 (Dirichlet Fourier Pointwise Convergence)

Re-audited the stalest uncovered gallery entry (last audited 2026-05-03). **Result: CLEAN.**

### Verification vs `proofs/Proofs/FourierSeriesOQ03.lean`
| Claim | meta.json | source | ✓ |
|---|---|---|---|
| lineCount | 808 | 808 | ✓ |
| axiomCount | 3 | 3 | ✓ |
| sorries | 0 | 0 | ✓ |
| definitionCount | 9 | 9 | ✓ |
| theoremCount | 31 | 31 (incl. private) | ✓ |

### Integrity findings
- **Axioms are genuine, not vacuous**: `hasBV_implies_rightLimit_exists`, `hasBV_implies_leftLimit_exists` (BV one-sided limits), `dirichlet_localization` (convolution → midpoint). Each is a real `Tendsto` statement, disclosed by name in `assumptions`, `keyInsights`, and `proofStrategy`.
- **Main theorem is an honest reduction**: `dirichlet_pointwise_convergence` chains the 3 axioms + proved convolution lemma. Status `axiomatized` / badge `axiom` correct (Tier C).
- **Bessel/Parseval genuinely proved**: `bessel_inequality`/`parseval_theorem` derived from Mathlib's `hasSum_sq_fourierCoeff`, matching the "fully proved" claim in `assumptions`.
- All `originalContributions` decls exist in source; no True stubs, phantom names, or `native_decide`.

Tracker bumped to `2026-07-10`, result `clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)