### PR TITLE
research(erdos-1014-oq-03): log-increment smoothness bridge for the Ramsey increment

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03LogIncrement.lean
+++ b/proofs/Proofs/Erdos1014OQ03LogIncrement.lean
@@ -1,0 +1,103 @@
+/-
+Erdős Problem #1014 OQ-03: the *logarithmic* increment of the off-diagonal Ramsey
+number, `Λ_l(k) := log R(k, l+1) − log R(k, l)`.
+
+Companion to `Erdos1014OQ03.lean`, which proved the **increment–ratio bridge**:
+for a positive sequence `R`, the normalized increment `(R(l+1) − R(l))/R(l)` tends
+to `0` iff the consecutive ratio `R(l+1)/R(l)` tends to `1`, and applied this to
+Erdős #1014's proven ratio-convergence `R(k,l+1)/R(k,l) → 1` to obtain the honest
+increment consequence `Δ_l(k) = o(R(k,l))`.
+
+This file adds the third equivalent quantity — the **log-increment**, which is the
+natural measure of *smoothness* raised in OQ-03's open questions ("whether the
+increment is monotone or eventually smooth"). The key identity is that the
+log-increment equals `log` of the consecutive ratio,
+
+    log R(l+1) − log R(l) = log ( R(l+1) / R(l) ),
+
+so by continuity of `log`/`exp` the log-increment tends to `0` **iff** the ratio
+tends to `1`. Chaining with the parent's bridge gives the three-way equivalence
+
+    log-increment → 0   ⟺   ratio → 1   ⟺   normalized increment → 0 .
+
+Applied to `R(k, ·)`, Erdős #1014's ratio-convergence therefore yields not only
+`Δ_l(k) = o(R(k,l))` but also the smoothness statement
+`log R(k,l+1) − log R(k,l) → 0` — the increment is asymptotically *log-flat*. The
+full asymptotic formula for `Δ_l(k)` remains OPEN and is not asserted here.
+
+Verified, 0 axioms, 0 sorries, no `native_decide`.
+-/
+
+import Mathlib
+import Proofs.Erdos1014OQ03
+
+namespace Erdos1014OQ03Log
+
+open Filter Topology Erdos1014OQ03
+
+/-- **Log-increment equals log of the ratio.** For an eventually-positive sequence
+`R`, eventually `log R(l+1) − log R(l) = log ( R(l+1) / R(l) )`. -/
+theorem log_increment_eventuallyEq_log_ratio (R : ℕ → ℝ)
+    (hpos : ∀ᶠ l in atTop, 0 < R l) :
+    (fun l => Real.log (R (l + 1)) - Real.log (R l))
+      =ᶠ[atTop] (fun l => Real.log (R (l + 1) / R l)) := by
+  obtain ⟨N, hN⟩ := eventually_atTop.mp hpos
+  filter_upwards [eventually_ge_atTop N] with l hl
+  have h0 : 0 < R l := hN l hl
+  have h1 : 0 < R (l + 1) := hN (l + 1) (by omega)
+  rw [Real.log_div h1.ne' h0.ne']
+
+/-- **Log-increment / ratio bridge.** For an eventually-positive sequence `R`, the
+log-increment `log R(l+1) − log R(l)` tends to `0` **iff** the consecutive ratio
+`R(l+1)/R(l)` tends to `1`.
+
+Applied to `R(k, ·)`, the right-hand side is Erdős #1014's ratio-convergence
+`R(k,l+1)/R(k,l) → 1`, so the increment is asymptotically log-flat:
+`log R(k,l+1) − log R(k,l) → 0`. -/
+theorem logIncrement_tendsto_zero_iff_ratio_tendsto_one (R : ℕ → ℝ)
+    (hpos : ∀ᶠ l in atTop, 0 < R l) :
+    Tendsto (fun l => Real.log (R (l + 1)) - Real.log (R l)) atTop (𝓝 0) ↔
+      Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 1) := by
+  rw [tendsto_congr' (log_increment_eventuallyEq_log_ratio R hpos)]
+  constructor
+  · -- `log(ratio) → 0`  ⟹  `ratio → 1`, via `ratio = exp (log ratio)`.
+    intro h
+    have hexp : Tendsto (fun l => Real.exp (Real.log (R (l + 1) / R l))) atTop (𝓝 1) := by
+      have := (Real.continuous_exp.tendsto 0).comp h
+      simpa using this
+    have hEq : (fun l => Real.exp (Real.log (R (l + 1) / R l)))
+        =ᶠ[atTop] (fun l => R (l + 1) / R l) := by
+      obtain ⟨N, hN⟩ := eventually_atTop.mp hpos
+      filter_upwards [eventually_ge_atTop N] with l hl
+      have h0 : 0 < R l := hN l hl
+      have h1 : 0 < R (l + 1) := hN (l + 1) (by omega)
+      exact Real.exp_log (div_pos h1 h0)
+    exact (tendsto_congr' hEq).mp hexp
+  · -- `ratio → 1`  ⟹  `log(ratio) → 0`, by continuity of `log` at `1`.
+    intro h
+    have hlog : Tendsto Real.log (𝓝 1) (𝓝 (Real.log 1)) :=
+      (Real.continuousAt_log (by norm_num)).tendsto
+    have := hlog.comp h
+    simpa using this
+
+/-- **Three-way equivalence.** The log-increment tends to `0` iff the normalized
+increment tends to `0` (both being equivalent to the ratio tending to `1`). Thus
+the two natural "smoothness" measures of a positive sequence agree in the limit. -/
+theorem logIncrement_tendsto_zero_iff_increment_div_tendsto_zero (R : ℕ → ℝ)
+    (hpos : ∀ᶠ l in atTop, 0 < R l) :
+    Tendsto (fun l => Real.log (R (l + 1)) - Real.log (R l)) atTop (𝓝 0) ↔
+      Tendsto (fun l => (R (l + 1) - R l) / R l) atTop (𝓝 0) :=
+  (logIncrement_tendsto_zero_iff_ratio_tendsto_one R hpos).trans
+    (increment_div_tendsto_zero_iff_ratio_tendsto_one R
+      (hpos.mono fun _ hl => hl.ne')).symm
+
+/-- **Corollary (log-flatness).** If the consecutive ratio tends to `1` then the
+log-increment tends to `0`. Fed Erdős #1014's `R(k,l+1)/R(k,l) → 1`, it delivers
+`log R(k,l+1) − log R(k,l) → 0`. -/
+theorem logIncrement_tendsto_zero_of_ratio_tendsto_one (R : ℕ → ℝ)
+    (hpos : ∀ᶠ l in atTop, 0 < R l)
+    (hratio : Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 1)) :
+    Tendsto (fun l => Real.log (R (l + 1)) - Real.log (R l)) atTop (𝓝 0) :=
+  (logIncrement_tendsto_zero_iff_ratio_tendsto_one R hpos).mpr hratio
+
+end Erdos1014OQ03Log

--- a/research/problems/erdos-1014-oq-03/knowledge.md
+++ b/research/problems/erdos-1014-oq-03/knowledge.md
@@ -62,13 +62,12 @@ OQ-03's open questions:
 
 0 axioms, 0 sorries, no native_decide. The full asymptotic for Δ_l(k) stays OPEN.
 
-### Verification status: UNVERIFIED (elaboration-clean, olean-write blocked)
-The file **elaborates cleanly**: across 9 Docker builds it reached
-`[7744/7744] Building Proofs.Erdos1014OQ03LogIncrement` in ~1–3 s every time with
-**zero type errors** on any `LogIncrement.lean:L:C` line. A fully-green olean write
-was not obtainable this session: a heavy fleet **SIGBUS-135/139** storm killed the
-olean write, and the shared Mathlib cache was intermittently corrupted (code-1
-`invalid header` on dependency oleans: `NumberTheory/RamificationInertia/Basic`,
-`Algebra/Homology/Square.ir`, `Tactic/Basic.olean.server`). All failures are pure
-infrastructure at the `import Mathlib` line or the final write — never math/type
-errors. A future build once the cache settles should go green unchanged.
+### Verification status: VERIFIED
+Clean Docker build `✔ [7744/7744] Built Proofs.Erdos1014OQ03LogIncrement (3.3s)`,
+0 axioms / 0 sorries. It took 11 attempts to get a green olean write: a heavy
+fleet **SIGBUS-135/139** storm plus intermittent shared-Mathlib-cache corruption
+(code-1 `invalid header` on dependency oleans: `NumberTheory/RamificationInertia/
+Basic`, `Algebra/Homology/Square.ir`, `Tactic/Basic.olean.server`) blocked the
+write on attempts 1–10 — all pure infra at the `import Mathlib` line or the final
+write, never math/type errors (every reachable run elaborated the file in ~1–3 s
+with zero errors). Attempt 11 landed a fully green write.

--- a/research/problems/erdos-1014-oq-03/knowledge.md
+++ b/research/problems/erdos-1014-oq-03/knowledge.md
@@ -42,3 +42,33 @@ constants for `R(3,l)`.
 ### Files
 - `proofs/Proofs/Erdos1014OQ03.lean` (new, 95 lines, 3 theorems, 0 sorry / 0 axiom)
 - `src/data/research/problems/erdos-1014-oq-03.json` (leanFiles + knowledge)
+
+## Session 2026-07-09 (researcher-3) — log-increment smoothness bridge (UNVERIFIED)
+
+New companion `proofs/Proofs/Erdos1014OQ03LogIncrement.lean` (namespace
+`Erdos1014OQ03Log`, imports `Erdos1014OQ03`). Adds the **log-increment**
+`Λ_l(k) = log R(k,l+1) − log R(k,l)` as the natural smoothness measure raised in
+OQ-03's open questions:
+
+- `log_increment_eventuallyEq_log_ratio`: `log R(l+1) − log R(l) = log(R(l+1)/R(l))`
+  eventually (for eventually-positive `R`; `Real.log_div`).
+- `logIncrement_tendsto_zero_iff_ratio_tendsto_one`: log-increment → 0 ⟺ ratio → 1
+  (continuity of `log` at 1 forward; `exp ∘ log = id` on positives backward).
+- `logIncrement_tendsto_zero_iff_increment_div_tendsto_zero`: three-way equivalence
+  chaining the parent's normalized-increment bridge — log-increment → 0 ⟺
+  normalized increment → 0.
+- `logIncrement_tendsto_zero_of_ratio_tendsto_one`: fed #1014's ratio → 1, the
+  Ramsey increment is asymptotically log-flat.
+
+0 axioms, 0 sorries, no native_decide. The full asymptotic for Δ_l(k) stays OPEN.
+
+### Verification status: UNVERIFIED (elaboration-clean, olean-write blocked)
+The file **elaborates cleanly**: across 9 Docker builds it reached
+`[7744/7744] Building Proofs.Erdos1014OQ03LogIncrement` in ~1–3 s every time with
+**zero type errors** on any `LogIncrement.lean:L:C` line. A fully-green olean write
+was not obtainable this session: a heavy fleet **SIGBUS-135/139** storm killed the
+olean write, and the shared Mathlib cache was intermittently corrupted (code-1
+`invalid header` on dependency oleans: `NumberTheory/RamificationInertia/Basic`,
+`Algebra/Homology/Square.ir`, `Tactic/Basic.olean.server`). All failures are pure
+infrastructure at the `import Mathlib` line or the final write — never math/type
+errors. A future build once the cache settles should go green unchanged.


### PR DESCRIPTION
## Summary

Erdős Problem #1014 OQ-03 (asymptotics of the off-diagonal Ramsey increment `Δ_l(k) = R(k,l+1) − R(k,l)`). The parent file `Erdos1014OQ03.lean` proved the **increment–ratio bridge** (normalized increment → 0 ⟺ consecutive ratio → 1) and used it to derive the honest consequence `Δ_l(k) = o(R(k,l))` from #1014's ratio-convergence.

This PR adds the third equivalent quantity — the **log-increment** `Λ_l(k) = log R(k,l+1) − log R(k,l)`, the natural *smoothness* measure raised in OQ-03's open questions ("whether the increment is eventually smooth").

New file `proofs/Proofs/Erdos1014OQ03LogIncrement.lean` (namespace `Erdos1014OQ03Log`) — **VERIFIED**, clean Docker build `✔ [7744/7744] Built ... (3.3s)`, **0 axioms / 0 sorries, no native_decide**:

- **`log_increment_eventuallyEq_log_ratio`** — `log R(l+1) − log R(l) = log(R(l+1)/R(l))` eventually (for eventually-positive `R`).
- **`logIncrement_tendsto_zero_iff_ratio_tendsto_one`** — log-increment → 0 ⟺ ratio → 1 (continuity of `log` at 1 forward; `exp ∘ log = id` on positives backward).
- **`logIncrement_tendsto_zero_iff_increment_div_tendsto_zero`** — three-way equivalence chaining the parent bridge: log-increment → 0 ⟺ normalized increment → 0.
- **`logIncrement_tendsto_zero_of_ratio_tendsto_one`** — fed #1014's `R(k,l+1)/R(k,l) → 1`, the Ramsey increment is asymptotically **log-flat**: `log R(k,l+1) − log R(k,l) → 0`.

The full asymptotic formula for `Δ_l(k)` remains OPEN and is not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)