### PR TITLE
Research: erdos-1215-oq-02 - area of cyclotomic level set squeezed between two discs

### DIFF
--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ03.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ03.lean
@@ -1,0 +1,99 @@
+/-
+Erdős Problem #1215 — cyclotomic restriction (OQ-02): the **area** of the cyclotomic
+level set, squeezed between two concentric discs.
+
+Parent: `Proofs.Erdos1215Problem` asks whether, for polynomials `P` with all roots on
+the unit circle, there is a bounded-level path from `0` to `∞` inside
+`{z : |P(z)| < C}`.  OQ-02 restricts to the *cyclotomic* polynomials `Φ_n`.
+
+The companion `CyclotomicPolynomialsOQ02OQ02` pinned the level set
+`{z : |Φ_n(z)| < C}` between two concentric balls about the origin:
+
+      closedBall(0, r)  ⊆  {|Φ_n| < C}  ⊆  closedBall(0, 1 + C^{1/φ(n)}),
+                                          whenever `0 ≤ r` and `(r + 1)^{φ(n)} < C`.
+
+This entry pushes that geometric sandwich through the Lebesgue measure on `ℂ ≅ ℝ²`,
+turning the two-sided *containment* into a two-sided *area* estimate.  Using
+`Complex.volume_closedBall` (`volume (closedBall a ρ) = ENNReal.ofReal ρ ^ 2 · π`)
+and monotonicity of measure, we get, for `0 ≤ r` and `(r + 1)^{φ(n)} < C`,
+
+      π · r²  ≤  area {|Φ_n| < C}  ≤  π · (1 + C^{1/φ(n)})².
+
+In particular the cyclotomic level set has **finite area** — a purely
+measure-theoretic strengthening of researcher-4's qualitative boundedness result.
+This is the "area between two balls" follow-up requested in `state.md`, and it is the
+antithesis of a Mac Lane labyrinth: not only is the region bounded, its planar
+Lebesgue measure is controlled by an explicit, degree-uniform disc area that shrinks
+towards `π · 2² = 4π` as `φ(n) → ∞` (for fixed `C > 1`).
+
+Main results:
+* `volume_levelSet_le`        : `area {|Φ_n| < C} ≤ π · (1 + C^{1/φ(n)})²`.
+* `volume_levelSet_lt_top`    : the cyclotomic level set has finite area.
+* `le_volume_levelSet`        : `π · r² ≤ area {|Φ_n| < C}` for `(r+1)^{φ(n)} < C`.
+* `volume_levelSet_sandwich`  : both bounds together, the disc-area squeeze.
+
+All results are `0`-axiom / `0`-sorry.
+-/
+
+import Mathlib
+import Proofs.Erdos1215Problem
+import Proofs.CyclotomicPolynomialsOQ02OQ01
+import Proofs.CyclotomicPolynomialsOQ02OQ02
+
+open Complex Polynomial MeasureTheory
+
+namespace CyclotomicPolynomialsOQ02OQ03
+
+/-- **Outer area bound.**
+The planar Lebesgue measure of the cyclotomic level set `{|Φ_n| < C}` is at most the
+area `π · (1 + C^{1/φ(n)})²` of the sharp outer disc from
+`CyclotomicPolynomialsOQ02OQ02.sublevel_subset_closedBall_sharp`. -/
+theorem volume_levelSet_le (n : ℕ) (hn : n ≠ 0) (C : ℝ) :
+    volume (Erdos1215.levelSet (cyclotomic n ℂ) C) ≤
+      ENNReal.ofReal (1 + C ^ ((n.totient : ℝ)⁻¹)) ^ 2 * NNReal.pi := by
+  calc volume (Erdos1215.levelSet (cyclotomic n ℂ) C)
+      ≤ volume (Metric.closedBall (0 : ℂ) (1 + C ^ ((n.totient : ℝ)⁻¹))) :=
+        measure_mono (CyclotomicPolynomialsOQ02OQ02.sublevel_subset_closedBall_sharp n hn C)
+    _ = ENNReal.ofReal (1 + C ^ ((n.totient : ℝ)⁻¹)) ^ 2 * NNReal.pi :=
+        Complex.volume_closedBall _ _
+
+/-- **Finite area.**
+The cyclotomic level set `{|Φ_n| < C}` has finite planar Lebesgue measure.  This is a
+measure-theoretic strengthening of the qualitative boundedness proved in
+`CyclotomicPolynomialsOQ02OQ01`: not only is the region contained in a ball, its area
+is a genuine (finite) real number. -/
+theorem volume_levelSet_lt_top (n : ℕ) (hn : n ≠ 0) (C : ℝ) :
+    volume (Erdos1215.levelSet (cyclotomic n ℂ) C) < ⊤ := by
+  refine lt_of_le_of_lt (volume_levelSet_le n hn C) ?_
+  exact ENNReal.mul_lt_top (ENNReal.pow_lt_top ENNReal.ofReal_lt_top) ENNReal.coe_lt_top
+
+/-- **Inner area bound.**
+For any radius `r ≥ 0` with `(r + 1)^{φ(n)} < C`, the area `π · r²` of the inner disc
+of `CyclotomicPolynomialsOQ02OQ02.closedBall_subset_levelSet_cyclotomic` is a lower
+bound for the area of the cyclotomic level set. -/
+theorem le_volume_levelSet (n : ℕ) (hn : n ≠ 0) (C r : ℝ) (hr0 : 0 ≤ r)
+    (hr : (r + 1) ^ n.totient < C) :
+    ENNReal.ofReal r ^ 2 * NNReal.pi ≤
+      volume (Erdos1215.levelSet (cyclotomic n ℂ) C) := by
+  calc ENNReal.ofReal r ^ 2 * NNReal.pi
+      = volume (Metric.closedBall (0 : ℂ) r) := (Complex.volume_closedBall _ _).symm
+    _ ≤ volume (Erdos1215.levelSet (cyclotomic n ℂ) C) :=
+        measure_mono
+          (CyclotomicPolynomialsOQ02OQ02.closedBall_subset_levelSet_cyclotomic n hn C r hr0 hr)
+
+/-- **The disc-area squeeze.**
+Combining the inner and outer bounds: for `0 ≤ r` with `(r + 1)^{φ(n)} < C`, the area
+of the cyclotomic level set `{|Φ_n| < C}` is trapped between the two disc areas
+
+      π · r²  ≤  area {|Φ_n| < C}  ≤  π · (1 + C^{1/φ(n)})².
+
+This is the measure-theoretic form of the two-sided ball containment of
+`CyclotomicPolynomialsOQ02OQ02`. -/
+theorem volume_levelSet_sandwich (n : ℕ) (hn : n ≠ 0) (C r : ℝ) (hr0 : 0 ≤ r)
+    (hr : (r + 1) ^ n.totient < C) :
+    ENNReal.ofReal r ^ 2 * NNReal.pi ≤ volume (Erdos1215.levelSet (cyclotomic n ℂ) C) ∧
+      volume (Erdos1215.levelSet (cyclotomic n ℂ) C) ≤
+        ENNReal.ofReal (1 + C ^ ((n.totient : ℝ)⁻¹)) ^ 2 * NNReal.pi :=
+  ⟨le_volume_levelSet n hn C r hr0 hr, volume_levelSet_le n hn C⟩
+
+end CyclotomicPolynomialsOQ02OQ03

--- a/research/problems/erdos-1215-oq-02/knowledge.md
+++ b/research/problems/erdos-1215-oq-02/knowledge.md
@@ -95,3 +95,39 @@ Take `k`-th roots of a natural-power bound `a^k < C` (with `a ≥ 0`, `k ≠ 0`)
 `Real.pow_rpow_inv_natCast ha hk0 : (a^k)^((k:ℝ)⁻¹) = a` collapses the LHS. Exponent
 `1/φ(n) ≤ 1` via `inv_le_one_of_one_le₀`; `Real.rpow_le_rpow_of_exponent_le` compares
 `C^{1/φ(n)} ≤ C^1 = C`. Upper factor bound uses `norm_sub_le` + `pow_le_pow_left₀`.
+
+## Session 2026-07-09 (researcher-5) - Area of the level set (disc squeeze)
+
+**Mode**: FRESH (built on researcher-6's OQ02OQ02 two-sided ball containment)
+**Outcome**: progress (VERIFIED 0-sorry/0-axiom, docker `[7746/7746]` 3.9s)
+
+### What I Did
+- Created `proofs/Proofs/CyclotomicPolynomialsOQ02OQ03.lean` (4 decls, 0 sorry / 0 axiom).
+- Executed the "area between the two balls" next-step: pushed the iter-3 two-sided
+  ball containment through the planar Lebesgue measure on `ℂ ≅ ℝ²`.
+
+### Key Findings
+- `volume_levelSet_le`: `area {|Φ_n|<C} ≤ π·(1+C^{1/φ(n)})²` — `measure_mono` on the
+  sharp outer containment `sublevel_subset_closedBall_sharp` + `Complex.volume_closedBall`.
+- `le_volume_levelSet`: `π·r² ≤ area {|Φ_n|<C}` when `0≤r`, `(r+1)^{φ(n)}<C` — mirror
+  via `closedBall_subset_levelSet_cyclotomic`.
+- `volume_levelSet_sandwich`: both together → `π·r² ≤ area ≤ π·(1+C^{1/φ(n)})²`.
+- `volume_levelSet_lt_top`: the level set has **finite** planar area (measure-theoretic
+  strengthening of researcher-4's qualitative boundedness). For fixed `C>1` the outer
+  disc area → `4π` as `φ(n)→∞`, so the region's measure stays uniformly controlled —
+  the opposite of a Mac Lane labyrinth.
+
+### Files Modified
+- `proofs/Proofs/CyclotomicPolynomialsOQ02OQ03.lean` (new)
+
+### Next Steps
+- Small-n (n=3,4,6) explicit lemniscate boundary / component count — still the open
+  driver (polynomial-lemniscate topology not in Mathlib). The ball squeeze cannot give
+  the exact area, only two-sided bounds.
+
+### Reusable Lean recipe
+Turn a set-containment `A ⊆ closedBall 0 ρ` into an area bound: `measure_mono` gives
+`volume A ≤ volume (closedBall 0 ρ)`, then `Complex.volume_closedBall a ρ :
+volume (closedBall a ρ) = ENNReal.ofReal ρ ^ 2 * NNReal.pi` (`@[simp]`, ℂ≅ℝ² proper
+space). Finiteness: `ENNReal.mul_lt_top (ENNReal.pow_lt_top ENNReal.ofReal_lt_top)
+ENNReal.coe_lt_top`. The `NNReal.pi` factor coerces silently into `ℝ≥0∞`.

--- a/research/problems/erdos-1215-oq-02/state.md
+++ b/research/problems/erdos-1215-oq-02/state.md
@@ -4,10 +4,11 @@
 **Phase**: PROVE
 **Path**: full
 **Since**: 2026-07-09T15:40:18-07:00
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
-Two-sided radius geometry of the cyclotomic level set `{|Φ_n(z)| < C}`.
+Planar **area** of the cyclotomic level set `{|Φ_n(z)| < C}`, squeezed between the
+two concentric discs established in iter 3.
 
 ## Active Approach
 Approach A/B hybrid: elementary two-sided factor bounds `‖z‖-1 ≤ ‖z-μ‖ ≤ ‖z‖+1`
@@ -15,7 +16,7 @@ on primitive-root factors, giving `(‖z‖-1)^{φ(n)} ≤ |Φ_n(z)| ≤ (‖z�
 `φ(n)`-th roots to pin the level set between concentric balls.
 
 ## Attempt Count
-- Total attempts: 3
+- Total attempts: 4
 - Current approach attempts: 1
 - Approaches tried: 2
 
@@ -30,7 +31,13 @@ rectifiable-path arc length not yet in Mathlib.
 - Iter 3 (researcher-6): sharpened outer radius to `1 + C^{1/φ(n)}`, added inner
   ball containment; `1 + C^{1/φ(n)} ≤ max 2 (C+1)` and → 2 as φ(n) → ∞
   (`CyclotomicPolynomialsOQ02OQ02.lean`, VERIFIED 0/0).
+- Iter 4 (researcher-5): pushed the iter-3 two-sided ball containment through the
+  Lebesgue measure on `ℂ≅ℝ²` (`Complex.volume_closedBall` + `measure_mono`), giving
+  the disc-area squeeze `π·r² ≤ area{|Φ_n|<C} ≤ π·(1+C^{1/φ(n)})²` and finite-area
+  (`CyclotomicPolynomialsOQ02OQ03.lean`, VERIFIED 0/0, docker `[7746/7746]`).
 
 ## Next Action
-Small-n (n=3,4,6) explicit lemniscate geometry, or the area of `{|Φ_n|<C}` squeezed
-between the two balls now established.
+Small-n (n=3,4,6) explicit lemniscate geometry / component count (the genuinely open
+driver, needs polynomial-lemniscate topology Mathlib currently lacks). Area is now
+sandwiched between the two discs; a sharper area asymptotic would need the exact
+lemniscate boundary, not just the ball containment.


### PR DESCRIPTION
## Summary

Erdős #1215 (cyclotomic restriction, OQ-02). Iteration 4, building directly on the
two-sided ball containment established in `CyclotomicPolynomialsOQ02OQ02`
(researcher-6):

    closedBall(0, r) ⊆ {|Φ_n| < C} ⊆ closedBall(0, 1 + C^{1/φ(n)}).

This PR pushes that geometric sandwich through the planar Lebesgue measure on
`ℂ ≅ ℝ²` (`Complex.volume_closedBall` + `measure_mono`), turning containment into an
**area** estimate. For `0 ≤ r` and `(r+1)^{φ(n)} < C`:

    π·r²  ≤  area {|Φ_n| < C}  ≤  π·(1 + C^{1/φ(n)})².

In particular the cyclotomic level set has **finite area** — a measure-theoretic
strengthening of researcher-4's qualitative boundedness. For fixed `C > 1` the outer
disc area decreases to `4π` as `φ(n) → ∞`, so the region's planar measure is uniformly
controlled — the opposite of a Mac Lane labyrinth.

## New file

`proofs/Proofs/CyclotomicPolynomialsOQ02OQ03.lean` — 4 declarations, **0 sorry / 0 axiom**:
- `volume_levelSet_le` — outer area bound.
- `volume_levelSet_lt_top` — finite area.
- `le_volume_levelSet` — inner area bound.
- `volume_levelSet_sandwich` — the two-sided disc-area squeeze.

## Verification

Docker build: `✔ [7746/7746] Built Proofs.CyclotomicPolynomialsOQ02OQ03 (3.9s)`,
VERIFIED 0-sorry/0-axiom. (Pre-existing unused-variable warning in the sibling
OQ02OQ02 file is unrelated to this change.)

## Scope / honesty

This bounds the area between two discs; it does **not** compute the exact area or
resolve the genuinely open driver (does a cyclotomic labyrinth exist / path-length
≤ C·n), which needs polynomial-lemniscate topology and rectifiable arc length not yet
in Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)