### PR TITLE
audit(friendship-theorem): re-verified CLEAN — bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19210,8 +19210,8 @@
     },
     "friendship-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:56Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T03:15:00Z",
       "result": "clean"
     },
     "friendship-theorem-oq-01": {


### PR DESCRIPTION
## Audit: friendship-theorem (Wiedijk #83)

Re-audited the Friendship Theorem entry. **Result: CLEAN.**

- Main `FriendshipTheorem.lean`: 373 lines, 10 theorems, 6 defs — all match meta; 0 axioms, 0 sorries. `friendship_theorem` and `friendship_graph_is_windmill` are genuinely proved via `FriendshipTheoremOQ01` helpers; `windmill2` example proved.
- additionalFile `FriendshipTheoremOQ02.lean`: 1 axiom `directed_friendship_mod4` (directed-tournament extension, `Fintype.card V % 4 = 3`) — non-vacuous, disclosed by name in `assumptions`. `meta.axiomCount` 1 correctly aggregates the companion axiom (`leanFile.axiomCount` 0 is the main file — both correct).
- `status: axiomatized` / `badge: axiom` is the correct conservative call: the classical result is axiom-free, but the entry bundles the OQ02 directed extension.
- The 3 `sorry` string-matches in `FriendshipTheoremOQ04Amalgam.lean` are docstring-only (marked *discharged*) and that file belongs to the separate `friendship-theorem-oq-04` entry — out of scope here.

No masking, no overclaim, no phantom decls. Tracker bumped to 2026-07-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)