### PR TITLE
research(inverse-galois-oq-03): trivial center + realizing-field degree = |𝕄|

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ03.lean
+++ b/proofs/Proofs/InverseGaloisOQ03.lean
@@ -192,6 +192,23 @@ theorem Monster_commutator_eq_top : commutator Monster = ⊤ := by
     exact (Subgroup.mem_center_iff.mp ha b).symm
   · exact h
 
+/-- 𝕄 has trivial center: `Z(𝕄) = ⊥`.
+
+    The center is a normal subgroup, so by simplicity it is `⊥` or `⊤`. It cannot be
+    `⊤`, since that would force `a * b = b * a` for all `a, b` and make 𝕄 abelian,
+    contradicting `Monster_not_commutative`. Hence the center is trivial — as it must
+    be for every non-abelian simple group. -/
+theorem Monster_center_eq_bot : Subgroup.center Monster = ⊥ := by
+  haveI := Monster_isSimple
+  rcases Monster_isSimple.eq_bot_or_eq_top_of_normal (Subgroup.center Monster) inferInstance with
+    h | h
+  · exact h
+  · exfalso
+    apply Monster_not_commutative
+    intro a b
+    have ha : a ∈ Subgroup.center Monster := h ▸ Subgroup.mem_top a
+    exact (Subgroup.mem_center_iff.mp ha b).symm
+
 /-- 𝕄 is not solvable.
 
     A solvable simple group is abelian (`IsSimpleGroup.comm_iff_isSolvable`), but
@@ -243,6 +260,31 @@ theorem Monster_realized_beyond_Shafarevich :
       (∃ (K : Type) (_ : Field K) (_ : Algebra ℚ K) (_ : FiniteDimensional ℚ K)
         (_ : IsGalois ℚ K), Nonempty (Monster ≃* (K ≃ₐ[ℚ] K))) :=
   ⟨Monster_not_solvable, Monster_realizable_over_Q⟩
+
+/-- The realizability axiom is not merely qualitative: it pins the **degree** of the
+    realizing field exactly. Any field `K` with `Gal(K/ℚ) ≅ 𝕄` satisfies
+
+      `[K : ℚ] = |Gal(K/ℚ)| = |𝕄| = 2⁴⁶·3²⁰·5⁹·7⁶·11²·13³·17·19·23·29·31·41·47·59·71`,
+
+    since for a finite Galois extension the degree equals the order of the Galois group
+    (`IsGalois.card_aut_eq_finrank`), and the isomorphism `𝕄 ≃* Gal(K/ℚ)` transports
+    `Monster_card` across. So Thompson's field is a ℚ-vector space of dimension ≈ 8·10⁵³,
+    a concrete numerical consequence extracted from the (otherwise purely existential)
+    realizability input. -/
+theorem Monster_realizing_field_finrank :
+    ∃ (K : Type) (_ : Field K) (_ : Algebra ℚ K) (_ : FiniteDimensional ℚ K)
+      (_ : IsGalois ℚ K),
+      Module.finrank ℚ K =
+        808017424794512875886459904961710757005754368000000000 := by
+  obtain ⟨K, fK, aK, fdK, gK, ⟨e⟩⟩ := Monster_realizable_over_Q
+  haveI := fK; haveI := aK; haveI := fdK; haveI := gK
+  refine ⟨K, fK, aK, fdK, gK, ?_⟩
+  have hgal : Nat.card (K ≃ₐ[ℚ] K) = Module.finrank ℚ K :=
+    IsGalois.card_aut_eq_finrank ℚ K
+  have hcard : Nat.card (K ≃ₐ[ℚ] K) = Nat.card Monster :=
+    Nat.card_congr e.toEquiv.symm
+  rw [hcard, Nat.card_eq_fintype_card, Monster_card] at hgal
+  exact hgal.symm
 
 -- ============================================================================
 -- Part VI: The Sporadic Realizability Census

--- a/src/data/proofs/inverse-galois-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-oq-03/meta.json
@@ -39,9 +39,9 @@
         "relationship": "Sister entry on the non-solvable frontier and the solvability divide"
       }
     ],
-    "lineCount": 261,
+    "lineCount": 303,
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 0,
     "additionalFiles": []
   },
@@ -90,28 +90,28 @@
       "id": "non-solvability",
       "title": "Part III: Non-Solvability — The Core Structural Result",
       "startLine": 153,
-      "endLine": 203,
-      "summary": "𝕄 is non-commutative, perfect ([𝕄,𝕄] = 𝕄), and not solvable — all derived without sorry"
+      "endLine": 220,
+      "summary": "𝕄 is non-commutative, perfect ([𝕄,𝕄] = 𝕄), has trivial center (Z(𝕄) = ⊥), and is not solvable — all derived without sorry"
     },
     {
       "id": "shafarevich-gap",
       "title": "Part IV: Position in the Inverse Galois Program",
-      "startLine": 205,
-      "endLine": 218,
+      "startLine": 222,
+      "endLine": 235,
       "summary": "Since 𝕄 is non-solvable, Shafarevich's theorem does not cover it; realization needs the rigidity method"
     },
     {
       "id": "realizability",
       "title": "Part V: The Realizability Theorem (Thompson 1984)",
-      "startLine": 220,
-      "endLine": 246,
-      "summary": "Thompson's theorem (axiom): 𝕄 is realizable over ℚ; the explicit contrast with the open M₂₃ case"
+      "startLine": 237,
+      "endLine": 288,
+      "summary": "Thompson's theorem (axiom): 𝕄 is realizable over ℚ; the explicit contrast with the open M₂₃ case; and the extracted numerical consequence that any realizing field K has degree [K:ℚ] = |𝕄| over ℚ"
     },
     {
       "id": "sporadic-census",
       "title": "Part VI: The Sporadic Realizability Census",
-      "startLine": 248,
-      "endLine": 261,
+      "startLine": 290,
+      "endLine": 303,
       "summary": "25 sporadic groups realized over ℚ (including 𝕄) + 1 open (M₂₃) = 26"
     }
   ],
@@ -145,10 +145,10 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ03.lean",
-    "lineCount": 261,
+    "lineCount": 303,
     "axiomCount": 6,
     "sorries": 0,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

Two new derived theorems on the saturated Monster (𝕄) entry `inverse-galois-oq-03`, adding genuine mathematical content with **0 new axioms** (still 6). All prior 14 theorems untouched.

### 1. `Monster_center_eq_bot` — Z(𝕄) = ⊥
The center is a normal subgroup, so by simplicity it is ⊥ or ⊤. It cannot be ⊤ (that would make 𝕄 abelian, contradicting the existing `Monster_not_commutative`), hence trivial — the canonical structural fact for any non-abelian simple group. Complements the existing `Monster_commutator_eq_top` (perfectness).

### 2. `Monster_realizing_field_finrank` — [K : ℚ] = |𝕄|
Turns the previously **purely existential** realizability axiom `Monster_realizable_over_Q` (Thompson 1984) into a hard numerical constraint: any field `K` with `Gal(K/ℚ) ≅ 𝕄` has degree
```
[K : ℚ] = |Gal(K/ℚ)| = |𝕄| = 808017424794512875886459904961710757005754368000000000
```
For a finite Galois extension the degree equals the order of the Galois group (`IsGalois.card_aut_eq_finrank`), and the isomorphism `𝕄 ≃* Gal(K/ℚ)` transports `Monster_card` across (`Nat.card_congr`). This is the **first theorem in the file that actually consumes** the realizability axiom, rather than merely restating it — so Thompson's field is pinned as a ℚ-vector space of dimension ≈ 8·10⁵³.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.InverseGaloisOQ03` → **Target completed successfully** (module elaborates cleanly across multiple runs).
- The full-library build reports pre-existing SIGBUS/flaky failures in three unrelated modules (`NthRootIrrationalOQ01`, `InverseGaloisA5`, `AbelRuffiniOQ04OQ01`); none import `InverseGaloisOQ03` and none are in its dependency closure.
- 0 sorries, 6 axioms (unchanged), theoremCount 14 → 16, lineCount 261 → 303.
- `meta.json` counts and section ranges synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)