### PR TITLE
research(shannon-channel-coding-awgn-oq-03-oq-01): nonnegativity + power-monotonicity of equal-noise capacity [VERIFIED]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean
@@ -114,4 +114,33 @@ theorem parallelRate_le_equalNoise [Nonempty ι] (N : ι → ℝ) {c : ℝ} (hc 
     _ = (Fintype.card ι : ℝ) / 2 * Real.log (1 + P / (Fintype.card ι * c)) :=
         waterAlloc_rate_equalNoise N hc hN hP.le
 
+/-! ## Nonnegativity and power-monotonicity of the equal-noise capacity -/
+
+/-- **The equal-noise capacity is nonnegative.**  `(n/2)·log(1 + P/(n·c)) ≥ 0` for
+    `P ≥ 0`, `c > 0`: the achievable rate never drops below the zero baseline. -/
+theorem rate_equalNoise_nonneg [Nonempty ι] {c : ℝ} (hc : 0 < c) {P : ℝ} (hP : 0 ≤ P) :
+    0 ≤ (Fintype.card ι : ℝ) / 2 * Real.log (1 + P / (Fintype.card ι * c)) := by
+  have hn : 0 < (Fintype.card ι : ℝ) := by exact_mod_cast Fintype.card_pos
+  have hnc : 0 < (Fintype.card ι : ℝ) * c := mul_pos hn hc
+  have h1 : (1 : ℝ) ≤ 1 + P / (Fintype.card ι * c) := by
+    have : 0 ≤ P / (Fintype.card ι * c) := div_nonneg hP hnc.le
+    linarith
+  exact mul_nonneg (by positivity) (Real.log_nonneg h1)
+
+/-- **The equal-noise capacity is monotone in the power budget.**  `P₁ ≤ P₂ ⟹
+    C(P₁) ≤ C(P₂)`: allocating more total power never decreases the achievable rate,
+    since `log(1 + P/(n·c))` increases in `P`. -/
+theorem rate_equalNoise_mono_power [Nonempty ι] {c : ℝ} (hc : 0 < c)
+    {P₁ P₂ : ℝ} (hP₁ : 0 ≤ P₁) (h : P₁ ≤ P₂) :
+    (Fintype.card ι : ℝ) / 2 * Real.log (1 + P₁ / (Fintype.card ι * c))
+      ≤ (Fintype.card ι : ℝ) / 2 * Real.log (1 + P₂ / (Fintype.card ι * c)) := by
+  have hn : 0 < (Fintype.card ι : ℝ) := by exact_mod_cast Fintype.card_pos
+  have hnc : 0 < (Fintype.card ι : ℝ) * c := mul_pos hn hc
+  have hx1 : (0 : ℝ) < 1 + P₁ / (Fintype.card ι * c) := by
+    have : 0 ≤ P₁ / (Fintype.card ι * c) := div_nonneg hP₁ hnc.le
+    linarith
+  have hle : 1 + P₁ / (Fintype.card ι * c) ≤ 1 + P₂ / (Fintype.card ι * c) := by
+    gcongr
+  exact mul_le_mul_of_nonneg_left (Real.log_le_log hx1 hle) (by positivity)
+
 end ShannonWaterFilling

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-03-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-03-oq-01.json
@@ -59,14 +59,16 @@
     "insights": [
       "Water-filling KKT optimality has a fully ELEMENTARY proof: the first-order condition is replaced by the per-channel tangent bound log u <= u-1 (Real.log_le_sub_one_of_pos), summed across channels. No differentiability/Lagrange/KKT machinery needed.",
       "Key identity N_i + (mu-N_i)_+ = max mu N_i turns the derivative coefficient 1/(2(N_i+P_i*)) into 1/(2 max(mu,N_i)), which is constant 1/(2mu) on ACTIVE channels (N_i<mu) and <= 1/(2mu) on inactive ones (P_i*=0, x_i>=0). This case split is exactly what makes the aggregated linear term collapse to (sum x_i - P)/(2mu) <= 0.",
-      "Water level existence = IVT on the continuous monotone budget g(mu)=sum (mu-N_i)_+ between g(0)=0 and g(N_{i0}+P)>=P; uniqueness (for P>0) = strict monotonicity of g wherever g>0 (some channel active)."
+      "Water level existence = IVT on the continuous monotone budget g(mu)=sum (mu-N_i)_+ between g(0)=0 and g(N_{i0}+P)>=P; uniqueness (for P>0) = strict monotonicity of g wherever g>0 (some channel active).",
+      "VERIFIED (researcher-2, 2026-07-09, GREEN build attempt 1): capacity properties of the equal-noise closed form C(P)=(n/2)log(1+P/(nc)) in ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean. rate_equalNoise_nonneg (C(P)≥0 for P≥0, via Real.log_nonneg on 1≤1+P/(nc) + mul_nonneg) and rate_equalNoise_mono_power (P₁≤P₂⟹C(P₁)≤C(P₂), via Real.log_le_log + gcongr for the argument monotonicity). Standard 'capacity is a nonneg increasing function of the power budget' facts, absent from the file. The three parent open items (optimality, water-level existence/uniqueness, closed form) + equal-noise specialization are all complete; remaining nextSteps (operational random-coding theorem, infinite-band integral limit) are substantial."
     ],
     "builtItems": [
       "waterfilling_optimal (KKT optimality of P_i*=(mu-N_i)_+) in ShannonChannelCodingAWGNOQ03OQ01.lean",
       "awgnCapacity_sub_le (per-channel tangent bound, the FOC in elementary form)",
       "add_waterAlloc (N_i + (mu-N_i)_+ = max mu N_i)",
       "waterAlloc_rate_closedForm (R(P*) = sum 1/2 log(max mu N_i / N_i))",
-      "exists_waterLevel (IVT existence) + waterLevel_unique (strict-monotone uniqueness) + continuous/monotone_waterBudget"
+      "exists_waterLevel (IVT existence) + waterLevel_unique (strict-monotone uniqueness) + continuous/monotone_waterBudget",
+      "ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean: rate_equalNoise_nonneg + rate_equalNoise_mono_power. VERIFIED green, 0 axioms/sorries. File now 7 theorems."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Shannon AWGN water-filling OQ-03-OQ-01 — capacity as a function of power

The equal-noise file proves the closed form `C(P) = (n/2)·log(1 + P/(n·c))` for
`n` identical parallel Gaussian channels, plus its operational optimality. What
was missing are the two standard qualitative properties of capacity as a function
of the power budget. This PR adds them.

### New results (0 axioms, 0 sorries)

- **`rate_equalNoise_nonneg`** — `C(P) ≥ 0` for `P ≥ 0`, `c > 0`: the achievable
  rate never drops below the zero baseline (`Real.log_nonneg` on `1 ≤ 1 + P/(nc)`).
- **`rate_equalNoise_mono_power`** — `P₁ ≤ P₂ ⟹ C(P₁) ≤ C(P₂)`: allocating more
  total power never decreases the rate (`Real.log_le_log` + argument monotonicity).

These are the "capacity is a nonnegative, non-decreasing function of the power
budget" facts one expects of any capacity formula.

### Build status

**Fully verified**: `✔ Built Proofs.ShannonChannelCodingAWGNOQ03OQ01EqualNoise`
(green Docker build on the first attempt, olean written). 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)