### PR TITLE
research(szemeredi-regularity-oq-04): explicit ⌊1/δ⌋₊ termination horizon [VERIFIED]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -186,4 +186,42 @@ theorem partitionEnergy_regular_step_exists
   · intro n; exact partitionEnergy_nonneg G (parts n)
   · intro n; exact partitionEnergy_le_one G (parts n) (hcover n) (hdisjoint n)
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART IV: EXPLICIT INTEGER TERMINATION HORIZON  ⌊1/δ⌋₊
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **A regular step occurs by time `⌊1/δ⌋₊`.**  Sharpening
+    `energy_regular_step_exists` from "some horizon `N > 1/δ`" to a *concrete
+    integer* bound: an `[0,1]`-valued potential fails to climb by `δ` at some step
+    `n ≤ ⌊1/δ⌋₊`.  This pins the abstract `O(1/δ)` termination time of the AFKS
+    iteration to an explicit natural number, obtained by instantiating the horizon
+    at `N = ⌊1/δ⌋₊ + 1 > 1/δ` (`Nat.lt_floor_add_one`). -/
+theorem energy_regular_step_exists_floor (f : ℕ → ℚ) (δ : ℚ) (hδ : 0 < δ)
+    (h0 : ∀ n, 0 ≤ f n) (h1 : ∀ n, f n ≤ 1) :
+    ∃ n ≤ ⌊1 / δ⌋₊, ¬ (f n + δ ≤ f (n + 1)) := by
+  have hN : 1 / δ < ((⌊1 / δ⌋₊ + 1 : ℕ) : ℚ) := by
+    push_cast
+    exact Nat.lt_floor_add_one (1 / δ)
+  obtain ⟨n, hn, hstep⟩ :=
+    energy_regular_step_exists f (⌊1 / δ⌋₊ + 1) δ hδ h0 h1 hN
+  exact ⟨n, by omega, hstep⟩
+
+/-- **Graph instantiation: a regular refinement step occurs by time `⌊1/δ⌋₊`.**
+    The concrete-integer counterpart of `partitionEnergy_regular_step_exists`: a
+    sequence of covering, pairwise-disjoint partitions reaches a non-increment
+    ("regular") step `n ≤ ⌊1/δ⌋₊` — the explicit `⌈1/δ⌉`-many-steps termination
+    bound for the AFKS energy-increment iteration, with no free horizon parameter. -/
+theorem partitionEnergy_regular_step_exists_floor
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (δ : ℚ) (hδ : 0 < δ)
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q) :
+    ∃ n ≤ ⌊1 / δ⌋₊,
+      ¬ (partitionEnergy G (parts n) + δ ≤ partitionEnergy G (parts (n + 1))) := by
+  refine energy_regular_step_exists_floor
+    (fun n => partitionEnergy G (parts n)) δ hδ ?_ ?_
+  · intro n; exact partitionEnergy_nonneg G (parts n)
+  · intro n; exact partitionEnergy_le_one G (parts n) (hcover n) (hdisjoint n)
+
 end Szemeredi.RegularityOQ04

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -546,3 +546,42 @@ branch research/szemeredi-oq04-prod-gain-r2
 - Sum the per-pair ε⁴ jump over all refined parts to get whole-partition energy
   monotonicity, then feed `afks_energy_iteration_count` (N ≤ 2n²/ε²).
 - Generalize the 2×2 grid to m×k product refinement (already-abstract atom bound).
+
+## Session 2026-07-09 (researcher-1) — explicit ⌊1/δ⌋₊ termination horizon (VERIFIED)
+
+**Mode**: REVISIT (RICH) · **Outcome**: progress (2 theorems VERIFIED 0/0, green build
+[7745/7745] 4.2s) · branch research/szemeredi-oq04-explicit-floor-horizon
+
+### What I Did
+On the SELF-CONTAINED abstract engine SzemerediRegularityOQ04.lean (depends only on
+Mathlib + SzemerediRegularity, NOT the hard Bridge/Energy blockers), sharpened the
+existing `energy_regular_step_exists` (∃ n < N for any horizon N > 1/δ) to a CONCRETE
+INTEGER bound:
+- `energy_regular_step_exists_floor`: `∃ n ≤ ⌊1/δ⌋₊, ¬(f n + δ ≤ f (n+1))` for any
+  [0,1]-valued ℚ potential. Instantiates the existing existence lemma at the horizon
+  N = ⌊1/δ⌋₊ + 1, which exceeds 1/δ by `Nat.lt_floor_add_one`; then n < ⌊1/δ⌋₊+1 ⟹
+  n ≤ ⌊1/δ⌋₊ by omega.
+- `partitionEnergy_regular_step_exists_floor`: graph instantiation (same
+  cover/disjoint hypotheses, feeds partitionEnergy_nonneg / partitionEnergy_le_one).
+
+Pins the abstract O(1/δ) AFKS termination TIME (the docstrings gesture at "⌈1/δ⌉ steps"
+but Part III left N a free parameter) to an explicit natural number — the natural
+capstone of the Part III existence result.
+
+### Key Findings
+- `Nat.lt_floor_add_one (a : α) : a < ⌊a⌋₊ + 1` is the whole trick; after `push_cast`
+  the goal `1/δ < ↑(⌊1/δ⌋₊ + 1)` matches it directly. No positivity side-goal needed
+  (Nat.lt_floor_add_one holds unconditionally; for a < 0 the floor is 0 and 0 < 1).
+- Reused existing engine verbatim — pure low-risk assembly of merged lemmas, zero new
+  arithmetic. Green on FIRST build attempt (contrast: all prior sessions this file hit
+  the SIGBUS write race — the abstract sub-file compiled clean this run).
+
+### Files Modified
+- proofs/Proofs/SzemerediRegularityOQ04.lean (Part IV, +2 theorems, ~40 lines)
+- research/problems/szemeredi-regularity-oq-04/knowledge.md
+
+### Next Steps (unchanged terminus)
+- Sum the per-pair ε⁴ jump (Bridge PART XI) over all refined parts → whole-partition
+  energy monotonicity, then feed this ⌊1/δ⌋₊ horizon to bound the refinement depth.
+- Full two-level strong-lemma statement (exceptional-pair accounting) remains the open
+  research terminus.


### PR DESCRIPTION
## Summary

Adds Part IV to the self-contained abstract engine `Proofs/SzemerediRegularityOQ04.lean`, sharpening the existing `energy_regular_step_exists` from *"some horizon `N > 1/δ`"* to a **concrete integer** termination time.

- `energy_regular_step_exists_floor` — for any `[0,1]`-valued potential `f : ℕ → ℚ`, a non-increment step occurs at some `n ≤ ⌊1/δ⌋₊`: `∃ n ≤ ⌊1/δ⌋₊, ¬ (f n + δ ≤ f (n+1))`.
- `partitionEnergy_regular_step_exists_floor` — the graph instantiation (covering, pairwise-disjoint partitions), giving the explicit `⌈1/δ⌉`-step termination bound for the AFKS energy-increment iteration with no free horizon parameter.

## Why

Part III (`energy_regular_step_exists`, `partitionEnergy_regular_step_exists`) proved a regular step is reached within *any* horizon `N > 1/δ`, but left `N` a free parameter — the docstrings gesture at "`O(1/δ)` steps" without pinning it. This pins the abstract termination time to an explicit natural number `⌊1/δ⌋₊`, the natural capstone of Part III.

## Proof

Pure assembly of already-verified lemmas: instantiate `energy_regular_step_exists` at `N = ⌊1/δ⌋₊ + 1`, which exceeds `1/δ` by `Nat.lt_floor_add_one`; then `n < ⌊1/δ⌋₊ + 1 ⟹ n ≤ ⌊1/δ⌋₊` by `omega`. No new arithmetic. The file remains **0 axioms / 0 sorries** and depends only on Mathlib + `SzemerediRegularity` — it does not touch the hard Bridge/Energy blockers.

## Verification

**VERIFIED** — green docker build: `✔ [7745/7745] Built Proofs.SzemerediRegularityOQ04 (4.2s)`, `Build completed successfully (7745 jobs)`. (The one `push_cast does nothing` warning is pre-existing in the `SzemerediRegularity` dependency, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)