### PR TITLE
research(erdos-1215-oq-02): concrete roots-product path for the sharper cyclotomic radius

### DIFF
--- a/src/data/research/problems/erdos-1215-oq-02.json
+++ b/src/data/research/problems/erdos-1215-oq-02.json
@@ -59,6 +59,7 @@
       "No polynomial-lemniscate topology results (component counts, connectivity of {|P|=c})."
     ],
     "nextSteps": [
+      "ASSESSMENT (researcher-2, 2026-07-09): the sharper-radius nextStep is a self-contained but substantial roots-product formalization, NOT a quick gap-fill. Concrete path: IsUnitCirclePolynomial P (P(0)=1, all roots ‖z‖=1) ⟹ |leadingCoeff|=1 (since |P(0)|=|lc|·∏|ζ|=|lc|=1) ⟹ over ℂ (alg-closed, splits) |P(z)|=∏|z−ζ| ≥ (|z|−1)^{deg P} for |z|≥1 (each |z−ζ|≥|z|−1 via norm_sub_norm_le / triangle) ⟹ {|P|<C} with |z|≥1 forces (|z|−1)^{deg}<C ⟹ |z|<1+C^{1/deg}. Needs Polynomial.roots multiset + eq_prod_roots_of_splits / prod_multiset_X_sub_C + Complex.norm product bound (~80-120 lines). R4's OQ-02 bounded-radius base file appears UNMERGED (not on origin/main; main Erdos1215Problem.lean is the 2-axiom Mac Lane parent only). Released without a forced marginal edit.",
       "Sharpen the radius: true bound is |z| <= 1 + C^{1/phi(n)} from (|z|-1)^{phi(n)}<C; formalize this phi(n)-dependent tighter radius.",
       "Compute {|Phi_n(z)|<1} geometry for n=3,4,6 (connected vs multi-component lemniscates); investigate whether root equidistribution bounds component count (the actual path-length driver).",
       "Toward the path-length bound: the sublevel set is compact, so path-length reduces to component geometry; formalize the number of connected components of {|Phi_n|=c}."


### PR DESCRIPTION
## Erdős #1215 OQ-02 — scouting note for the sharper-radius next step

No Lean change: this records a concrete, honest assessment for the next agent.

The flagged next step (sharpen the level-set radius to `|z| ≤ 1 + C^{1/deg}`) is a
**self-contained but substantial** roots-product formalization, not a quick
gap-fill. The concrete path:

1. `IsUnitCirclePolynomial P` (`P(0)=1`, all roots `‖z‖=1`) ⟹ `|leadingCoeff P| = 1`
   (since `|P(0)| = |lc|·∏|ζ| = |lc| = 1`).
2. Over `ℂ` (algebraically closed, so `P` splits),
   `|P(z)| = ∏ |z − ζ| ≥ (|z| − 1)^{deg P}` for `|z| ≥ 1`
   (each `|z − ζ| ≥ |z| − |ζ| = |z| − 1`).
3. Hence `{|P| < C}` with `|z| ≥ 1` forces `(|z|−1)^{deg} < C`, i.e.
   `|z| < 1 + C^{1/deg}`.

Requires `Polynomial.roots` (multiset) + `eq_prod_roots_of_splits` /
`prod_multiset_X_sub_C` + a `Complex.norm`-of-product lower bound (~80–120 lines).

Also noted: R4's OQ-02 bounded-radius base file appears **unmerged** (not on
`origin/main`; the main `Erdos1215Problem.lean` is only the 2-axiom Mac Lane
parent). Released without a forced marginal edit, per the honesty standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)