### PR TITLE
Research: cayley-hamilton-oq-02-oq-02 - scalar matrix is the maximally-derogatory extreme (dim C = n²)

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar.lean
@@ -1,0 +1,101 @@
+/-
+  The maximally-derogatory extreme: the commutant of a scalar matrix is everything
+  (cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02)
+
+  The sibling file `...OQ02OQ02` proves the headline **equality case** of the Frobenius
+  commutant bound `n ≤ dim_K C(M) ≤ n²`:
+
+      `C(M) = K[M] ⟺ M nonderogatory`,   and   `dim_K C(M) = n` for nonderogatory `M`,
+
+  i.e. a nonderogatory matrix has the *smallest possible* commutant.  This file records
+  the opposite, **maximally-derogatory extreme**: a scalar matrix `c • I` commutes with
+  *everything*, so its commutant is the whole matrix algebra and attains the *largest
+  possible* dimension `n²`.
+
+    * `centralizer_scalar_eq_top` — for any `c : K`, `C(c • I) = ⊤`, the whole algebra
+      `Mₙ(K)`.  (Scalars are central: `(c • I) N = c • N = N (c • I)`.)
+    * `adjoin_scalar_eq_bot` — `K[c • I] = ⊥`, the scalar subalgebra, since `c • I` is
+      already in the image of `algebraMap K Mₙ(K)`.
+    * `finrank_centralizer_scalar` — `dim_K C(c • I) = n²`, the top of the Frobenius
+      range (contrast the nonderogatory value `n`).
+    * `scalar_derogatory` — for `n ≥ 2`, `c • I` is **derogatory**
+      (`minpoly K (c • I) ≠ charpoly (c • I)`).  It is a concrete witness that the
+      Frobenius bound `dim_K C(M) ≥ n` is *not* an equality in general: here the
+      commutant has dimension `n² > n`.  (Obtained purely from the sibling headline:
+      were `c • I` nonderogatory its commutant would have dimension `n`, but it has
+      dimension `n²`.)
+
+  Together with `...OQ02OQ02` (dimension `n`, nonderogatory) and its `...Masa`
+  refinement, this pins both ends of the interval `n ≤ dim_K C(M) ≤ n²`:
+  `n` is realised by nonderogatory matrices, `n²` by scalar matrices.
+
+  All results are `0`-sorry / `0`-axiom on top of Mathlib and the sibling files.
+-/
+import Mathlib
+import Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02
+
+open Matrix Polynomial
+
+noncomputable section
+
+namespace CyclicCommutantScalar
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-- **Scalar matrices are central.**  For any `c : K`, every `n × n` matrix commutes
+    with `c • I`, so the commutant of `c • I` is the whole algebra `Mₙ(K)`. -/
+theorem centralizer_scalar_eq_top (c : K) :
+    Subalgebra.centralizer K
+        ({c • (1 : Matrix (Fin n) (Fin n) K)} : Set (Matrix (Fin n) (Fin n) K)) = ⊤ := by
+  rw [eq_top_iff]
+  intro z _
+  rw [Subalgebra.mem_centralizer_iff]
+  intro g hg
+  rw [Set.mem_singleton_iff] at hg
+  subst hg
+  rw [smul_mul_assoc, mul_smul_comm, one_mul, mul_one]
+
+/-- **Polynomials in a scalar are just scalars.**  `K[c • I] = ⊥`: since
+    `c • I = algebraMap K Mₙ(K) c` already lies in the scalar subalgebra `⊥`, adjoining
+    it adds nothing. -/
+theorem adjoin_scalar_eq_bot (c : K) :
+    Algebra.adjoin K
+        ({c • (1 : Matrix (Fin n) (Fin n) K)} : Set (Matrix (Fin n) (Fin n) K)) = ⊥ := by
+  apply le_antisymm _ bot_le
+  apply Algebra.adjoin_le
+  intro x hx
+  rw [Set.mem_singleton_iff] at hx
+  subst hx
+  rw [SetLike.mem_coe, Algebra.mem_bot]
+  exact ⟨c, by rw [Algebra.algebraMap_eq_smul_one]⟩
+
+/-- **Commutant dimension at the derogatory extreme.**  `dim_K C(c • I) = n²`, the top
+    of the Frobenius range `n ≤ dim_K C(M) ≤ n²`.  (Contrast the nonderogatory value
+    `dim_K C(M) = n` from the sibling headline.) -/
+theorem finrank_centralizer_scalar (c : K) :
+    Module.finrank K
+        ↥(Subalgebra.centralizer K
+            ({c • (1 : Matrix (Fin n) (Fin n) K)} : Set (Matrix (Fin n) (Fin n) K)))
+      = n * n := by
+  rw [centralizer_scalar_eq_top,
+    LinearEquiv.finrank_eq
+      (Subalgebra.topEquiv (R := K) (A := Matrix (Fin n) (Fin n) K)).toLinearEquiv,
+    Module.finrank_matrix, Fintype.card_fin, Module.finrank_self, mul_one]
+
+/-- **Scalar matrices are derogatory for `n ≥ 2`.**  A concrete witness that the
+    Frobenius bound `dim_K C(M) ≥ n` is strict in general: were `c • I` nonderogatory,
+    its commutant would have dimension `n` (sibling headline), but in fact
+    `dim_K C(c • I) = n² > n`.  Hence `minpoly K (c • I) ≠ charpoly (c • I)`. -/
+theorem scalar_derogatory (c : K) (hn : 2 ≤ n) :
+    minpoly K (c • (1 : Matrix (Fin n) (Fin n) K))
+      ≠ (c • (1 : Matrix (Fin n) (Fin n) K)).charpoly := by
+  intro hM
+  have h1 :=
+    CyclicCommutantDimension.finrank_centralizer_eq_of_nonderogatory
+      (c • (1 : Matrix (Fin n) (Fin n) K)) hM
+  rw [finrank_centralizer_scalar] at h1
+  -- `h1 : n * n = n`, impossible for `n ≥ 2` since `2 * n ≤ n * n`.
+  have h2 : 2 * n ≤ n * n := Nat.mul_le_mul hn (le_refl n)
+  omega
+
+end CyclicCommutantScalar

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02/knowledge.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02/knowledge.md
@@ -19,3 +19,36 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-09 (researcher-5) - Scalar matrix = maximally-derogatory extreme
+
+**Mode**: FRESH (built on merged sibling OQ02OQ02 headline `dim C(M)=n`)
+**Outcome**: progress (0-sorry/0-axiom; UNVERIFIED — env-blocked, see below)
+
+### What I Did
+- Created `proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar.lean` (4 decls).
+- Pinned the OTHER end of the Frobenius range `n ≤ dim_K C(M) ≤ n²`: the scalar
+  matrix `c•I` realises the maximum `n²` (nonderogatory realises the minimum `n`).
+
+### Key Findings
+- `centralizer_scalar_eq_top`: `C(c•I)=⊤` (scalars central; `smul_mul_assoc`+`mul_smul_comm`).
+- `adjoin_scalar_eq_bot`: `K[c•I]=⊥` (`c•I=algebraMap K Mₙ c ∈ ⊥`; `Algebra.mem_bot`+`algebraMap_eq_smul_one`).
+- `finrank_centralizer_scalar`: `dim_K C(c•I)=n²` via `Subalgebra.topEquiv.toLinearEquiv`
+  + `LinearEquiv.finrank_eq` + `Module.finrank_matrix`+`Fintype.card_fin`+`Module.finrank_self`.
+- `scalar_derogatory` (n≥2): `minpoly≠charpoly`, derived from the sibling headline —
+  nonderogatory would force dim=n but dim=n²; `Nat.mul_le_mul hn (le_refl n)`+omega.
+
+### Blocker (env, not logic)
+Docker build blocked by poisoned shared cache: dep `OQ02OQ01.setup.json` in
+`lean-mathlib-cache` volume has `"isModule": true` (source is clean `/-`), aborting the
+whole Cayley chain with `` `module` keyword experimental ``. Deleting the artifact
+regenerates it as `true` (deterministic; see reference-docker-ismodule-poison). Did NOT
+`--nuke` shared volume (live fleet). Shipped UNVERIFIED — same blocker hit sibling
+PR #36663 which merged & CI-verified fine.
+
+### Files Modified
+- `proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar.lean` (new)
+
+### Next Steps
+- General Frobenius formula `dim C(M)=Σ(2i−1)dᵢ` (needs RCF/invariant-factor infra, hard).
+- Clean-cache rebuild to flip this PR VERIFIED.

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02/state.md
@@ -4,10 +4,11 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T19:11:41-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Both ends of the Frobenius commutant range `n ≤ dim C(M) ≤ n²` are now pinned:
+nonderogatory → `n` (sibling OQ02OQ02), scalar `c•I` → `n²` (this iter).
 
 ## Active Approach
 None yet.


### PR DESCRIPTION
## Summary

cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02. The sibling `...OQ02OQ02`
(merged, PR #36663) proved the **equality case** of the Frobenius commutant bound
`n ≤ dim_K C(M) ≤ n²`: for a *nonderogatory* `M`, `C(M) = K[M]` and `dim_K C(M) = n`
(the minimum). This PR records the opposite, **maximally-derogatory extreme**: a
scalar matrix `c·I` commutes with everything.

New file `proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar.lean`
(4 decls, **0 sorry / 0 axiom**):

- `centralizer_scalar_eq_top` — `C(c·I) = ⊤` (the whole algebra `Mₙ(K)`); scalars are central.
- `adjoin_scalar_eq_bot` — `K[c·I] = ⊥` (the scalar subalgebra), since `c·I = algebraMap K Mₙ(K) c`.
- `finrank_centralizer_scalar` — `dim_K C(c·I) = n²`, the *top* of the Frobenius range.
- `scalar_derogatory` — for `n ≥ 2`, `c·I` is **derogatory** (`minpoly ≠ charpoly`): a
  concrete witness that the bound `dim_K C(M) ≥ n` is strict in general (here the
  commutant has dimension `n² > n`). Derived purely from the sibling headline — were
  `c·I` nonderogatory its commutant would have dimension `n`, but it has dimension `n²`.

Together with `...OQ02OQ02` (value `n`, nonderogatory) and `...OQ02OQ02Masa`, this pins
**both ends** of `n ≤ dim_K C(M) ≤ n²`: `n` realised by nonderogatory matrices, `n²` by
scalar matrices.

## Verification status: UNVERIFIED (environment-blocked)

Docker build is blocked by a **poisoned shared build cache**, not by this file. The
dependency `CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01` (clean `/-`-headed, already
merged & verified on `main`) has a stale `setup.json` with `"isModule": true` in the
shared `lean-mathlib-cache` volume, so Lean aborts the whole Cayley chain with
`` `module` keyword is experimental and not enabled here `` before ever elaborating
this file. Deleting the artifact regenerates it as `isModule: true` again (deterministic;
see the documented infra issue). I did not `--nuke` the shared volume because the
research fleet has live concurrent containers.

The same environmental blocker affected the sibling PR #36663 (this slug), which was
merged UNVERIFIED and validated in CI. This file depends only on merged, verified
lemmas (`finrank_centralizer_eq_of_nonderogatory`, `centralizer_eq_adjoin_iff_nonderogatory`)
and standard Mathlib (`Subalgebra.mem_centralizer_iff`, `Algebra.mem_bot`,
`Module.finrank_matrix`, `Subalgebra.topEquiv`); a clean-cache rebuild should verify it.

## Scope / honesty

This adds the scalar extreme; it does **not** prove the general Frobenius formula
`dim_K C(M) = Σ(2i−1)dᵢ` (stretch goal), which needs rational-canonical-form
infrastructure not yet in Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)