### PR TITLE
Enrich erdos-485/69/167: clamp annotation endLine to file EOF

### DIFF
--- a/src/data/proofs/erdos-167/annotations.json
+++ b/src/data/proofs/erdos-167/annotations.json
@@ -290,7 +290,7 @@
     "proofId": "erdos-167",
     "range": {
       "startLine": 266,
-      "endLine": 275
+      "endLine": 274
     },
     "type": "concept",
     "title": "Summary and Status",

--- a/src/data/proofs/erdos-485/annotations.json
+++ b/src/data/proofs/erdos-485/annotations.json
@@ -208,7 +208,7 @@
     "type": "definition",
     "range": {
       "startLine": 210,
-      "endLine": 226
+      "endLine": 225
     },
     "title": "Sparse Polynomials and Product Density",
     "content": "**isSparse(P, c):** termCount(P) ≤ c · log(deg(P) + 1). A polynomial is sparse when its term count is logarithmic in its degree.\n\n**sparse_product_density (axiom):** ∃ c > 0 such that for sparse P, Q: termCount(P·Q) ≥ termCount(P) + termCount(Q) - 1.",

--- a/src/data/proofs/erdos-69/annotations.json
+++ b/src/data/proofs/erdos-69/annotations.json
@@ -165,7 +165,7 @@
     "proofId": "erdos-69",
     "range": {
       "startLine": 179,
-      "endLine": 189
+      "endLine": 188
     },
     "type": "concept",
     "title": "Erdős Problem 69: The Two-Line Solution",


### PR DESCRIPTION
## Structural defect: annotation ranges past EOF

Pool-wide scan found three gallery entries whose **closing annotation** had `range.endLine` exactly **one line past** the Lean file's true end — the annotation overhung nonexistent lines.

| Entry | Annotation | endLine | Lean file (wc -l) |
|-------|-----------|---------|-------------------|
| erdos-485 | `ann-e485-sparse` | 226 → **225** | Erdos485Problem.lean (225) |
| erdos-69 | `ann-e69-main` | 189 → **188** | Erdos69Problem.lean (188) |
| erdos-167 | `ann-e167-summary` | 275 → **274** | Erdos167Problem.lean (274) |

## Fix

**Pattern-A tail clamps.** In each case the annotation's `startLine` is well within the file and only the `endLine` overshoots by 1, so clamping to `lineCount` is unambiguous (the closing annotation covers through EOF). `wc -l` confirms each declared `lineCount` is accurate — the drift is in the annotation, not the count.

Surgical edits only: **3 files, 3 insertions, 3 deletions.** JSON validates; all annotation ranges now within EOF.