### PR TITLE
research(erdos-1064-oq-03): parametric reversal family (18m+3)·2^(k+1)

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -2598,4 +2598,81 @@ theorem classifySeed_fiveTimes_gt {q : ℕ} (hq : q.Prime) (hq13 : 13 ≤ q)
   exact (classifySeed_gt_iff hodd (by omega) 1).mp
     (mem_ForwardSet_fiveTimes hq hq13 hq1 hb 1)
 
+-- ----------------------------------------------------------------------------
+-- A prime-triple–indexed REVERSAL family: `n = (18m+3)·2^(k+1)`
+-- ----------------------------------------------------------------------------
+
+/-- **A parametric reversal family.**  For every `m ≥ 1` such that the three
+    numbers `4m+1`, `6m+1`, `14m+3` are *all* prime, the seed `a = 18m+3`
+    (`= 3·(6m+1)`) lands the *entire* family `n = (18m+3)·2^(k+1)` in the reversal
+    regime `φ(n) < φ(D(n))` for all `k`.  This is the reversal analogue of the
+    Sophie–Germain equality family `mem_EqualitySet_sophieGermain` and the
+    parametric forward family `mem_ForwardSet_fiveTimes`, completing the trichotomy
+    of *k*-free parametric seed families (equality / forward / **reversal**).  It
+    unifies the previously isolated reversal seeds `21` (`m=1`) and `129` (`m=7`)
+    into a single parametric statement; the next member is `453` (`m=25`, giving
+    `4m+1=101`, `6m+1=151`, `14m+3=353` all prime).
+
+    Mechanism (a clean collapse of the general reversal criterion
+    `dblIter_reversal_iff_general`):
+
+    * `a = 3·(6m+1)` so `φ(a) = 2·6m = 12m`;
+    * `2a − φ(a) = (36m+6) − 12m = 24m+6 = 2·(12m+3)`, so `s = 1`,
+      `b = 12m+3 = 3·(4m+1)` (odd) and `φ(b) = 2·4m = 8m`;
+    * the landing constant is `C = 2a − φ(b) = (36m+6) − 8m = 28m+6 = (14m+3)·2¹`,
+      so `t = 1`, `e = 14m+3` (odd);
+    * the classifier compares `φ(e)·2^{t−1} = φ(14m+3) = 14m+2` against
+      `φ(a) = 12m`, and `12m < 14m+2` holds for **every** `m`, so the family
+      reverses.
+
+    All three primality conditions are load-bearing: `6m+1` and `4m+1` give the
+    clean totient values `φ(a) = 12m`, `φ(b) = 8m`, while the *reversal* itself
+    needs the lower bound `φ(e) = 14m+2 > 12m`, which requires `14m+3` prime — for a
+    composite landing `φ(e)` could drop below `12m` and the family would not
+    reverse.  (The restriction to the semiprime landing `b = 3·(4m+1)` is why the
+    other observed reversal seeds `55 = 5·11`, `175 = 5²·7` — whose seeds are of the
+    form `5q`, not `3q` — lie outside this particular family; reversals are not
+    confined to it.) -/
+theorem mem_ReversalSet_primeTriple {m : ℕ} (hm : 1 ≤ m)
+    (hp : (4 * m + 1).Prime) (hq : (6 * m + 1).Prime) (he : (14 * m + 3).Prime)
+    (k : ℕ) : (18 * m + 3) * 2 ^ (k + 1) ∈ ReversalSet := by
+  have hcopa : Nat.Coprime 3 (6 * m + 1) :=
+    (Nat.coprime_primes (by norm_num) hq).mpr (by omega)
+  have hcopb : Nat.Coprime 3 (4 * m + 1) :=
+    (Nat.coprime_primes (by norm_num) hp).mpr (by omega)
+  -- φ(a) = 12m  (a = 18m+3 = 3·(6m+1))
+  have hφa : Nat.totient (18 * m + 3) = 12 * m := by
+    rw [show 18 * m + 3 = 3 * (6 * m + 1) from by ring, Nat.totient_mul hcopa,
+        show Nat.totient 3 = 2 from by decide, Nat.totient_prime hq]; omega
+  -- φ(b) = 8m  (b = 12m+3 = 3·(4m+1))
+  have hφb : Nat.totient (12 * m + 3) = 8 * m := by
+    rw [show 12 * m + 3 = 3 * (4 * m + 1) from by ring, Nat.totient_mul hcopb,
+        show Nat.totient 3 = 2 from by decide, Nat.totient_prime hp]; omega
+  -- oddness of the three odd data
+  have ha_odd : Odd (18 * m + 3) := Nat.odd_iff.mpr (by omega)
+  have hb_odd : Odd (12 * m + 3) := Nat.odd_iff.mpr (by omega)
+  have he_odd : Odd (14 * m + 3) := Nat.odd_iff.mpr (by omega)
+  have p0 : (2 : ℕ) ^ (1 - 1) = 1 := by norm_num
+  have p1 : (2 : ℕ) ^ 1 = 2 := by norm_num
+  -- transport data:  2a − φ(a) = 2¹·b  and  2a − φ(b)·2^(s−1) = e·2¹
+  have hstep : 2 * (18 * m + 3) - Nat.totient (18 * m + 3)
+      = 2 ^ 1 * (12 * m + 3) := by rw [hφa, p1]; omega
+  have hC : 2 * (18 * m + 3) - Nat.totient (12 * m + 3) * 2 ^ (1 - 1)
+      = (14 * m + 3) * 2 ^ 1 := by rw [hφb, p0, p1]; omega
+  -- feed the k-free reversal criterion; reversal ⇔ φ(a) < φ(e)·2^(t−1) = 14m+2
+  rw [dblIter_reversal_iff_general ha_odd hb_odd he_odd (le_refl 1) (le_refl 1)
+        hstep hC k, hφa, p0, mul_one, Nat.totient_prime he]
+  omega
+
+/-- **Classifier value on the reversal family seeds.**  Specialising through
+    `classifySeed_lt_iff`: every seed `18m+3` in the parametric reversal family
+    (`m ≥ 1`, `4m+1`, `6m+1`, `14m+3` all prime) is classified `lt` by the total
+    decision procedure. -/
+theorem classifySeed_primeTriple_lt {m : ℕ} (hm : 1 ≤ m)
+    (hp : (4 * m + 1).Prime) (hq : (6 * m + 1).Prime) (he : (14 * m + 3).Prime) :
+    classifySeed (18 * m + 3) = Ordering.lt := by
+  have hodd : Odd (18 * m + 3) := Nat.odd_iff.mpr (by omega)
+  exact (classifySeed_lt_iff hodd (by omega) 1).mp
+    (mem_ReversalSet_primeTriple hm hp hq he 1)
+
 end Erdos1064OQ03

--- a/research/problems/erdos-1064-oq-03/knowledge.md
+++ b/research/problems/erdos-1064-oq-03/knowledge.md
@@ -451,3 +451,43 @@ non-trivial plumbing, not a one-liner.
 - Full `seedS=1` reversal characterization (covering composite landings like 165)
   needs a lower bound on `φ(seedE a)/seedE a` beyond the prime case.
 - The genuinely-open direction remains the density-1 forward `ψ(x,y)` statement.
+
+## Session 2026-07-09 (researcher-3) — parametric REVERSAL family (completes the trichotomy)
+
+**Mode**: REVISIT (RICH tier) | **Outcome**: progress (full elaboration clean
+`[3058/3058]`, olean-write env-blocked SIGBUS-135 across 4 runs → UNVERIFIED;
+0 sorry / 0 axiom).
+
+### What I Did
+- Added the **parametric reversal family** that was the missing third leg beside
+  the Sophie–Germain equality family (`3q`) and the `5q` forward family. All prior
+  reversal knowledge was either the *isolated* seeds `21,55,129,175` or the
+  criterion `classifySeed_lt_iff_of_seedS_one_seedE_prime`; there was no closed
+  infinite reversal family stated as a single parametric theorem.
+- `mem_ReversalSet_primeTriple (hm : 1 ≤ m)(4m+1 prime)(6m+1 prime)(14m+3 prime)`:
+  `(18m+3)·2^(k+1) ∈ ReversalSet` for all `k`.
+- `classifySeed_primeTriple_lt`: the seed `18m+3` is classified `.lt`.
+
+### Mechanism (collapse of `dblIter_reversal_iff_general`)
+- `a = 18m+3 = 3·(6m+1)`, `φ(a) = 12m`.
+- `2a − φ(a) = 24m+6 = 2·(12m+3)` ⟹ `s=1`, `b = 12m+3 = 3·(4m+1)`, `φ(b) = 8m`.
+- landing `C = 2a − φ(b) = 28m+6 = (14m+3)·2¹` ⟹ `t=1`, `e = 14m+3`.
+- reversal ⇔ `φ(a) < φ(e)·2^{t−1} = 14m+2`, i.e. `12m < 14m+2` — **automatic**.
+- All three primality hypotheses load-bearing: `6m+1`,`4m+1` give the clean
+  totients; `14m+3` prime is essential for the lower bound `φ(e)=14m+2>12m`
+  (composite landing could drop `φ(e)` below `12m` and kill the reversal).
+
+### Members / honesty
+- `m=1 → 21` (`5,7,17` prime), `m=7 → 129` (`29,43,101`), `m=25 → 453`
+  (`101,151,353`). Unifies the docstring's isolated `21` and `129`.
+- Honestly bounded: the `5q`-type reversal seeds `55,175` are NOT captured (their
+  seed is `5q` not `3q`), so this is one sub-family, not all reversals.
+
+### Files Modified
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (+~85 lines, 2 theorems)
+- `src/data/research/problems/erdos-1064-oq-03.json`
+
+### Next Steps
+- Structural/elementary side stays COMPLETE. Only open direction is the
+  analytically-hard density-1 forward ψ(x,y) smooth-number statement (Mathlib gap).
+- Optional: an analogous `5q` parametric reversal family capturing `55,175`.

--- a/src/data/research/problems/erdos-1064-oq-03.json
+++ b/src/data/research/problems/erdos-1064-oq-03.json
@@ -4,7 +4,7 @@
   "phase": "ACT",
   "status": "in-progress",
   "started": "2026-07-08T00:00:00.000Z",
-  "lastUpdate": "2026-07-08",
+  "lastUpdate": "2026-07-09",
   "path": "full",
   "parentId": "erdos-1064",
   "tier": "B",
@@ -35,7 +35,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (r1 2026-07-09): Added the missing REVERSAL (.lt) engine to the transport-admissible regime seedS a=1. classifySeed_lt_iff_of_seedS_one_seedE_prime gives an EXACT reversal criterion φ(seedB a)+2^seedT a < 2(a−φ(a)) when seedE a is prime, the .lt companion to the excluded-regime ne_lt/gt engines. Uniformly recovers all known prime-landing reversal seeds (21,55,129,175); honestly bounded (165 reverses with composite landing, outside scope). Elab-clean, olean-write env-blocked. Only open direction remains the analytically-hard density-1 forward ψ(x,y) statement.",
+    "progressSummary": "PROGRESS (researcher-3 2026-07-09): Added a PARAMETRIC REVERSAL family, completing the trichotomy of k-free parametric seed families. mem_ReversalSet_primeTriple: for m>=1 with 4m+1, 6m+1, 14m+3 all prime, the seed a=18m+3 (=3*(6m+1)) puts the whole family n=(18m+3)*2^(k+1) in ReversalSet (phi(n)<phi(D(n))) for all k, via a clean collapse of dblIter_reversal_iff_general (s=1, b=3*(4m+1), t=1, e=14m+3; reversal criterion 12m<14m+2 automatic). Unifies the previously isolated reversal seeds 21 (m=1) and 129 (m=7) into one statement; next member 453 (m=25). classifySeed_primeTriple_lt gives the classifier value. All three primality conditions load-bearing (e=14m+3 prime needed for the phi(e)=14m+2>12m lower bound). This is the reversal analogue of the Sophie-Germain equality family (3q) and the 5q forward family. Full elaboration clean [3058/3058]; olean-write env-blocked (SIGBUS-135, 4 runs), shipped UNVERIFIED. Only open direction remains the analytically-hard density-1 forward psi(x,y) statement.",
     "builtItems": [
       "dblIter (EulerTotientOQ04OQ03.lean) — the double cototient iterate D(n) = n − φ(n − φ(n)), the object of OQ-03.",
       "dblIter_prime — collapse lemma: for EVERY prime p, D(p) = p − 1 exactly (φ(p)=p−1 ⟹ p−φ(p)=1 ⟹ φ(1)=1 ⟹ D(p)=p−1).",
@@ -98,7 +98,9 @@
       "prime_triple_reversal_iff in EulerTotientOQ04OQ03.lean: the prime-triple family reverses iff p∈{3,5}, contributing exactly seeds {21,55}",
       "Strict-gt classifier engine (2026-07-09 researcher-2, VERIFIED 0/0): added classifySeed_gt_of_excess_bound (the missing .gt companion of the ne_lt engine — same excess bound + 2≤seedE a ⟹ .gt via strict φ(seedE)<seedE), completing the excluded-regime trichotomy as a function of seedE (=1⟹eq, ≥2⟹gt); and classifySeed_prime_three_mod_four_gt_of_seedE reducing the excluded-prime forward regime to the single fact seedE p≥2. Docker Build succeeded 3058 jobs (attempt 2).",
       "classifySeed_lt_iff_of_seedS_one_seedE_prime in EulerTotientOQ04OQ03.lean — reversal iff-criterion on prime-landing transport-admissible seeds (elab-clean [3058/3058], olean-write blocked by env SIGBUS-135/139)",
-      "prime_landing_family_reversal in EulerTotientOQ04OQ03.lean — packages criterion into a·2^(k+1) ⊆ ReversalSet for every k"
+      "prime_landing_family_reversal in EulerTotientOQ04OQ03.lean — packages criterion into a·2^(k+1) ⊆ ReversalSet for every k",
+      "mem_ReversalSet_primeTriple (EulerTotientOQ04OQ03.lean) — parametric reversal family: m>=1 & 4m+1,6m+1,14m+3 prime ⇒ (18m+3)*2^(k+1) ∈ ReversalSet ∀k; unifies seeds 21,129,453.",
+      "classifySeed_primeTriple_lt — the reversal family seeds 18m+3 are classified .lt by the total decision procedure."
     ],
     "insights": [
       "On primes the higher iterate is trivial: D(p) = p − 1 for all primes p, because the first cototient step p − φ(p) = 1 and φ(1) = 1. So φ(D(p)) = φ(p−1), and φ(p−1) < p−1 = φ(p) for every p ≥ 3 (with equality only at p = 2). This gives the forward direction on an infinite explicit family with a one-line reduction to Nat.totient_lt — no density machinery needed.",


### PR DESCRIPTION
## Summary

Adds the missing **parametric reversal family** for the double totient iterate
`D(n) = n − φ(n − φ(n))` (Erdős #1064, OQ-03), completing the trichotomy of
`k`-free parametric seed families in `EulerTotientOQ04OQ03.lean`:

| regime | family | condition |
|--------|--------|-----------|
| equality | `3q` (`mem_EqualitySet_sophieGermain`) | `q`, `2q+1` prime |
| forward | `5q` (`mem_ForwardSet_fiveTimes`) | `q≡1 (4)`, `3q+2` prime |
| **reversal** | **`18m+3` (`mem_ReversalSet_primeTriple`)** | **`4m+1`, `6m+1`, `14m+3` prime** |

**`mem_ReversalSet_primeTriple`**: for every `m ≥ 1` with `4m+1`, `6m+1`, `14m+3`
all prime, the seed `a = 18m+3 = 3·(6m+1)` puts the *whole* family
`n = (18m+3)·2^(k+1)` in `ReversalSet` (`φ(n) < φ(D(n))`) for all `k`.
`classifySeed_primeTriple_lt` records the classifier value `.lt`.

This **unifies the previously isolated reversal seeds** `21` (`m=1`) and `129`
(`m=7`) — which appeared only as one-off `decide` facts — into a single
parametric statement; the next member is `453` (`m=25`: `4m+1=101`, `6m+1=151`,
`14m+3=353` all prime).

## Mechanism (collapse of `dblIter_reversal_iff_general`)

- `φ(a) = 12m`; `2a − φ(a) = 24m+6 = 2·(12m+3)` ⟹ `s=1`, `b = 3·(4m+1)`, `φ(b)=8m`;
- landing `C = 2a − φ(b) = 28m+6 = (14m+3)·2¹` ⟹ `t=1`, `e = 14m+3`;
- reversal ⇔ `φ(a) < φ(e) = 14m+2`, i.e. `12m < 14m+2` — automatic.

All three primality conditions are load-bearing: `4m+1`, `6m+1` give the clean
totient values, while `14m+3` prime is essential for the lower bound
`φ(e)=14m+2 > 12m` (a composite landing could drop `φ(e)` below `12m`).
Honestly bounded: the `5q`-type reversal seeds `55`, `175` are *not* captured
(their seed is `5q`, not `3q`), so this is one sub-family, not all reversals.

## Verification

- **2 theorems, 0 sorry, 0 axiom.**
- Full elaboration clean under Docker/Lean v4.26.0: `[3058/3058] Building
  Proofs.EulerTotientOQ04OQ03`, no `unsolved goals`/`unknown tactic`/type errors.
- The olean *write* was env-blocked (`Lean exited with code 135`, the documented
  stochastic SIGBUS olean-write crash) across 4 runs, so this is shipped
  **UNVERIFIED** despite clean elaboration. The proof reuses only already-verified
  in-file lemmas (`dblIter_reversal_iff_general`, `classifySeed_lt_iff`) plus
  `Nat.totient_mul`/`Nat.totient_prime`/`omega`, and the `m=1` member matches the
  independently-proven `classify_21 = .lt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)