### PR TITLE
research(erdos-490-incomplete-01): multiplicative energy symmetry + strict-excess trichotomy

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -685,6 +685,55 @@ theorem multiplicativeEnergy_ge (A B : Finset ℕ) :
         (Finset.card_image_of_injOn hinj).symm
     _ ≤ multiplicativeEnergy A B := Finset.card_le_card hsub
 
+/-- **Multiplicative energy is symmetric**: `E(A, B) = E(B, A)`.  Swapping the two
+factors, `((a₁, a₂), (b₁, b₂)) ↦ ((b₁, b₂), (a₁, a₂))`, is a bijection between the two
+energy sets: the defining relation `a₁·b₁ = a₂·b₂` is carried to `b₁·a₁ = b₂·a₂` by
+`mul_comm`, and the swap is its own inverse. -/
+theorem multiplicativeEnergy_comm (A B : Finset ℕ) :
+    multiplicativeEnergy A B = multiplicativeEnergy B A := by
+  classical
+  unfold multiplicativeEnergy
+  refine Finset.card_bij'
+    (fun q _ => ((q.2.1, q.2.2), (q.1.1, q.1.2)))
+    (fun q _ => ((q.2.1, q.2.2), (q.1.1, q.1.2)))
+    ?hi ?hj ?left ?right
+  case hi =>
+    rintro ⟨⟨a₁, a₂⟩, ⟨b₁, b₂⟩⟩ hq
+    rw [Finset.mem_filter] at hq
+    simp only [Finset.mem_product] at hq
+    obtain ⟨⟨⟨ha1, ha2⟩, hb1, hb2⟩, hrel⟩ := hq
+    rw [Finset.mem_filter]
+    refine ⟨?_, ?_⟩
+    · simp only [Finset.mem_product]; exact ⟨⟨hb1, hb2⟩, ha1, ha2⟩
+    · show b₁ * a₁ = b₂ * a₂
+      rw [mul_comm b₁ a₁, mul_comm b₂ a₂]; exact hrel
+  case hj =>
+    rintro ⟨⟨b₁, b₂⟩, ⟨a₁, a₂⟩⟩ hq
+    rw [Finset.mem_filter] at hq
+    simp only [Finset.mem_product] at hq
+    obtain ⟨⟨⟨hb1, hb2⟩, ha1, ha2⟩, hrel⟩ := hq
+    rw [Finset.mem_filter]
+    refine ⟨?_, ?_⟩
+    · simp only [Finset.mem_product]; exact ⟨⟨ha1, ha2⟩, hb1, hb2⟩
+    · show a₁ * b₁ = a₂ * b₂
+      rw [mul_comm a₁ b₁, mul_comm a₂ b₂]; exact hrel
+  case left =>
+    rintro ⟨⟨a₁, a₂⟩, ⟨b₁, b₂⟩⟩ _; rfl
+  case right =>
+    rintro ⟨⟨b₁, b₂⟩, ⟨a₁, a₂⟩⟩ _; rfl
+
+/-- **Strict energy excess characterizes product collisions.**  Combining the general
+lower bound `|A||B| ≤ E(A, B)` (`multiplicativeEnergy_ge`) with its equality case
+(`distinct_minimal_energy`): the energy *strictly* exceeds `|A||B|` exactly when the
+products are not all distinct.  This completes the trichotomy — energy equals `|A||B|`
+iff products are distinct, and exceeds it otherwise. -/
+theorem multiplicativeEnergy_gt_iff_not_distinctProducts (A B : Finset ℕ) :
+    A.card * B.card < multiplicativeEnergy A B ↔ ¬HasDistinctProducts A B := by
+  rw [distinct_minimal_energy]
+  constructor
+  · intro hlt heq; rw [heq] at hlt; exact lt_irrefl _ hlt
+  · intro hne; exact lt_of_le_of_ne (multiplicativeEnergy_ge A B) (Ne.symm hne)
+
 /-
 ## Part VIII: Bounds History
 -/

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -82,9 +82,9 @@
       "erdos490_analytic_tail (in Erdos490Chebyshev.lean, 0-axiom): ∃c>0,∃N₀,∀n≥N₀, the elementary θ-gap lower bound (n/3)·log4 − log n − √(2n)·log(2n) ≥ c·n, proved from Real.isLittleO_log_id_atTop and isLittleO_log_rpow_atTop (exponent 1/2). This is the single analytic input that converted the Chebyshev θ-gap axiom into a theorem."
     ],
     "axiomCount": 1,
-    "lineCount": 861,
+    "lineCount": 937,
     "assumptions": "1 axiom, 0 sorries. Axiom: szemeredi_theorem (Szemerédi 1976 N²/log N upper bound, deep — the hard analytic input of the problem). The former second axiom chebyshev_theta_upper_half_lower_bound (the classical Chebyshev θ-gap lower bound θ(N)−θ(N/2) ≥ c·N) is NOW A THEOREM (0-axiom), proved by combining the verified central-binomial estimate Erdos490Cheb.theta_gap_lower_bound with the analytic tail Erdos490Cheb.erdos490_analytic_tail (log n and √(2n)·log(2n) are o(n)) and a Bertrand-based θ(N)−θ(N/2) ≥ log 2 for the finitely many small N. Only the deep Szemerédi upper bound remains axiomatized; status stays 'axiomatized'.",
-    "theoremCount": 26,
+    "theoremCount": 29,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
@@ -217,9 +217,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 888,
+    "lineCount": 937,
     "axiomCount": 1,
-    "theoremCount": 27,
+    "theoremCount": 29,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Two derived theorems on the completed Erdős #490 file (`Erdos490Problem.lean`), building on the recently merged `multiplicativeEnergy_ge` / `distinct_minimal_energy` (#36708). **0 new axioms** (only `mul_comm`, order lemmas, and the two existing energy results).

### 1. `multiplicativeEnergy_comm` — E(A,B) = E(B,A)
The canonical symmetry of multiplicative energy, previously absent. The swap `((a₁,a₂),(b₁,b₂)) ↦ ((b₁,b₂),(a₁,a₂))` is a self-inverse bijection between the two energy filter-sets (`Finset.card_bij'`); the defining relation `a₁·b₁ = a₂·b₂` transports to `b₁·a₁ = b₂·a₂` by `mul_comm`.

### 2. `multiplicativeEnergy_gt_iff_not_distinctProducts` — |A||B| < E(A,B) ↔ ¬HasDistinctProducts A B
Completes the energy trichotomy by combining the two existing results:
- `multiplicativeEnergy_ge` : `|A||B| ≤ E(A,B)` (always),
- `distinct_minimal_energy` : `E(A,B) = |A||B| ↔ HasDistinctProducts A B` (equality case).

So the energy is *minimized* (equal to `|A||B|`) exactly when the products are all distinct, and *strictly exceeds* `|A||B|` precisely when there is a product collision.

## Verification
- Elaboration is **clean**: `docker-build.sh Proofs.Erdos490Problem` compiles the file in ~1–4 s on every run (6+ runs) with **zero Lean diagnostics** (no `unsolved goals` / `unknown identifier` / `type mismatch` in the full log).
- The olean *write* crashes with SIGBUS (exit 135/139) on the shared docker cache volume — a known stochastic infrastructure failure at disk-write time, not an elaboration error. Marking **UNVERIFIED** (olean not persisted) per the honest-status convention; the source elaborates cleanly and a clean-cache rebuild should turn it green.
- `meta.json` counts synced: 27 → 29 theorems, 888 → 937 lines (also reconciles a pre-existing `.meta`/`.leanFile` drift where the `.meta` block still read 861/26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)