### PR TITLE
research(erdos-214-incomplete-01): √2·ℤ² avoids an infinite family of EVEN distances (n≡6 mod 8)

### DIFF
--- a/proofs/Proofs/Erdos214Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos214Incomplete01OQ01.lean
@@ -195,4 +195,77 @@ theorem scaledLattice_unitDistanceFree_of_odd : IsUnitDistanceFree ScaledLattice
   have h := scaledLattice_dist_ne_sqrt_odd hp hq (n := 1) (by decide)
   simpa [Real.sqrt_one] using h
 
+/-!
+## Further strengthening: an infinite family of *even* avoided distances
+
+The odd result above is not the whole story: the squared distance is not merely
+even, it is `2·(u² + v²)` — twice a **sum of two integer squares**.  Since a sum
+of two squares is never `≡ 3 (mod 4)`, the squared distance is never `≡ 6 (mod 8)`.
+Hence `√2·ℤ²` also avoids every distance `√n` with `n ≡ 6 (mod 8)` — the infinite
+family `√6, √14, √22, …` of *even* distances, none of which is caught by the
+odd-`n` result.
+-/
+
+/-- **A sum of two integer squares is never `≡ 3 (mod 4)`.**  Each square is
+`0` or `1 (mod 4)` (even/odd split), so the sum lies in `{0, 1, 2} (mod 4)`. -/
+theorem sq_add_sq_mod_four_ne_three (u v : ℤ) : (u ^ 2 + v ^ 2) % 4 ≠ 3 := by
+  have key : ∀ w : ℤ, w ^ 2 % 4 = 0 ∨ w ^ 2 % 4 = 1 := by
+    intro w
+    rcases Int.even_or_odd w with ⟨k, hk⟩ | ⟨k, hk⟩
+    · left; subst hk
+      have : (k + k) ^ 2 = 4 * k ^ 2 := by ring
+      rw [this]; omega
+    · right; subst hk
+      have : (2 * k + 1) ^ 2 = 4 * (k ^ 2 + k) + 1 := by ring
+      rw [this]; omega
+  rcases key u with hu | hu <;> rcases key v with hv | hv <;> omega
+
+/-- **Squared lattice distances are twice a sum of two squares.**  Sharpens
+`scaledLattice_dist_sq_even` by exposing the two-square structure of the even
+factor: `dist p q ^ 2 = 2·(u² + v²)` with `u = a − a'`, `v = b − b'`. -/
+theorem scaledLattice_dist_sq_two_mul_sq_add_sq {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) :
+    ∃ u v : ℤ, dist p q ^ 2 = 2 * ((u : ℝ) ^ 2 + (v : ℝ) ^ 2) := by
+  obtain ⟨a, b, hpa, hpb⟩ := hp
+  obtain ⟨a', b', hqa, hqb⟩ := hq
+  refine ⟨a - a', b - b', ?_⟩
+  rw [dist_eq_coords]
+  have hs : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have hx : (p 0 - q 0) ^ 2 = 2 * ((a : ℝ) - a') ^ 2 := by
+    rw [hpa, hqa]
+    have e : (Real.sqrt 2 * (a : ℝ) - Real.sqrt 2 * a') ^ 2
+        = Real.sqrt 2 ^ 2 * ((a : ℝ) - a') ^ 2 := by ring
+    rw [e, hs]
+  have hy : (p 1 - q 1) ^ 2 = 2 * ((b : ℝ) - b') ^ 2 := by
+    rw [hpb, hqb]
+    have e : (Real.sqrt 2 * (b : ℝ) - Real.sqrt 2 * b') ^ 2
+        = Real.sqrt 2 ^ 2 * ((b : ℝ) - b') ^ 2 := by ring
+    rw [e, hs]
+  have hnn : 0 ≤ (p 0 - q 0) ^ 2 + (p 1 - q 1) ^ 2 := by positivity
+  rw [Real.sq_sqrt hnn, hx, hy]
+  push_cast; ring
+
+/-- **`√2·ℤ²` avoids every distance `√n` with `n ≡ 6 (mod 8)`.**  The squared
+distance is `2·(u² + v²)`; if it equalled `n ≡ 6 (mod 8)` then `u² + v² ≡ 3 (mod 4)`,
+impossible by `sq_add_sq_mod_four_ne_three`.  This is a genuinely *new* infinite
+family of avoided distances — all **even** (`√6, √14, √22, …`), none reachable from
+the odd-`n` theorem. -/
+theorem scaledLattice_dist_ne_sqrt_six_mod_eight {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice)
+    {n : ℕ} (hn : n % 8 = 6) : dist p q ≠ Real.sqrt n := by
+  intro h
+  obtain ⟨u, v, huv⟩ := scaledLattice_dist_sq_two_mul_sq_add_sq hp hq
+  have hsq : dist p q ^ 2 = (n : ℝ) := by rw [h, Real.sq_sqrt (by positivity)]
+  rw [hsq] at huv
+  have hz : (n : ℤ) = 2 * (u ^ 2 + v ^ 2) := by exact_mod_cast huv
+  have h3 := sq_add_sq_mod_four_ne_three u v
+  omega
+
+/-- **Concrete instance:** no two points of `√2·ℤ²` are at distance `√6`
+(`n = 6 ≡ 6 mod 8`, an *even* distance beyond the reach of the odd-`n` result). -/
+theorem scaledLattice_dist_ne_sqrt_six {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) :
+    dist p q ≠ Real.sqrt 6 :=
+  scaledLattice_dist_ne_sqrt_six_mod_eight hp hq (n := 6) (by decide)
+
 end Erdos214Incomplete01OQ01

--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -134,3 +134,41 @@ does not touch the axiomatized core `juhasz_stronger`. PR opened.
 ### Files Modified
 - `proofs/Proofs/Erdos214Incomplete01OQ01.lean` (+70 lines: 4 theorems)
 - `src/data/research/problems/erdos-214-incomplete-01.json` (OQ01 leanFile counts)
+
+## Session 2026-07-09 (researcher-1) — √2·ℤ² avoids an infinite family of EVEN distances (n≡6 mod 8)
+
+**Mode:** REVISIT (core still BLOCKED on `juhasz_stronger`; strengthened the verified
+axiom-free content in the self-contained `Erdos214Incomplete01OQ01.lean`).
+
+### Key realization
+`scaledLattice_dist_ne_sqrt_odd` (dist²=2m even ⟹ avoids odd √n) throws away that the
+even factor m is a SUM OF TWO SQUARES: dist² = 2·(u²+v²), u=a−a', v=b−b'. Since
+u²+v² ≢ 3 (mod 4), dist² ≢ 6 (mod 8), so √2·ℤ² ALSO avoids every √n with n≡6 mod 8 —
+the infinite family √6, √14, √22, … of EVEN distances, none reachable from the odd result.
+
+### Added (4 theorems, 0 sorry, 0 axioms)
+- `sq_add_sq_mod_four_ne_three (u v : ℤ) : (u²+v²)%4 ≠ 3` — even/odd square split
+  (`Int.even_or_odd`; (k+k)²=4k², (2k+1)²=4(k²+k)+1; `rw;omega`), then
+  `rcases key u <;> rcases key v <;> omega`.
+- `scaledLattice_dist_sq_two_mul_sq_add_sq` — dist²=2(u²+v²) (sharpens dist_sq_even by
+  exposing u,v; identical hx/hy/`push_cast;ring` skeleton, returns a−a', b−b').
+- `scaledLattice_dist_ne_sqrt_six_mod_eight {n} (hn: n%8=6)` — the new family. crux:
+  exact_mod_cast to (n:ℤ)=2(u²+v²), then `omega` chains n%8=6 → u²+v²≡3 mod4 vs h3.
+  omega handles the mixed ℕ/ℤ modular reasoning with u²,v² as opaque atoms.
+- `scaledLattice_dist_ne_sqrt_six` — concrete √6 instance (even, beyond odd result).
+
+### Verification — VERIFIED-by-elaboration (olean-write SIGBUS-135)
+Same pattern as researcher-6's session on this file: after the shared Mathlib cache
+corruption cleared (2 early runs hit `invalid header` on random Mathlib .ir/.olean deps
+at the import line — fleet cache race, different file each run), 5 runs reached
+`[7743/7743] Building … (1.4–5.8s)` with ZERO `.lean:LINE:COL` diagnostics, then
+`code 135` at olean serialization. A failed tactic prints a source-location error not a
+SIGBUS, so the clean elaboration confirms all 4 proofs type-check. 0 sorry, 0 new axioms,
+core `juhasz_stronger` untouched. File 198→271 lines, 9→13 theorems. Also fixed a stale
+json sorryCount (1→0; the "1" was a docstring "no `sorry`" false-positive).
+
+### Frontier
+Unchanged: `juhasz_stronger` BLOCKED. The achieved squared distances of √2·ℤ² are
+exactly {2·(u²+v²)}; odd n and n≡6 mod 8 are the two clean elementary sufficient
+avoidance conditions now formalized. Full characterization would need the sum-of-two-
+squares (Fermat) predicate.

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -68,18 +68,18 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.206Z",
-  "lastUpdate": "2026-07-10",
+  "lastUpdate": "2026-07-09",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos214Incomplete01OQ01.lean",
       "filename": "Erdos214Incomplete01OQ01.lean",
-      "lineCount": 198,
-      "theoremCount": 9,
+      "lineCount": 271,
+      "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos214Incomplete01OQ01.lean"
     }


### PR DESCRIPTION
## Summary

Strengthens the odd-distance result in the self-contained `Proofs/Erdos214Incomplete01OQ01.lean`. The existing `scaledLattice_dist_ne_sqrt_odd` shows `√2·ℤ²` avoids `√n` for odd `n` (squared distance is even). But the squared distance is not merely even — it is `2·(u² + v²)`, **twice a sum of two integer squares**. Since a sum of two squares is never `≡ 3 (mod 4)`, the squared distance is never `≡ 6 (mod 8)`, so `√2·ℤ²` also avoids the infinite family of **even** distances `√6, √14, √22, …` (`n ≡ 6 mod 8`) — none of which is reachable from the odd-`n` theorem.

## Added (4 theorems, 0 sorries, 0 new axioms)

- `sq_add_sq_mod_four_ne_three (u v : ℤ) : (u^2 + v^2) % 4 ≠ 3` — the number-theoretic core (even/odd square split + `omega`).
- `scaledLattice_dist_sq_two_mul_sq_add_sq` — `dist p q ^ 2 = 2·(u² + v²)`, sharpening `scaledLattice_dist_sq_even` by exposing the two-square structure (`u = a−a'`, `v = b−b'`).
- `scaledLattice_dist_ne_sqrt_six_mod_eight {n} (hn : n % 8 = 6)` — the new avoided family.
- `scaledLattice_dist_ne_sqrt_six` — concrete `√6` witness (an even distance beyond the odd result).

Does not touch the axiomatized core `juhasz_stronger`.

## Verification: VERIFIED-by-elaboration (olean-write SIGBUS)

Two early build attempts failed reading random corrupted Mathlib dependency files (`SemidirectProduct.ir`, `Cofix.olean`, `invalid header`) at the import line — a fleet shared-cache race, a different file each run, unrelated to this change. Once the cache cleared, **5 consecutive runs reached full elaboration** `[7743/7743] Building Proofs.Erdos214Incomplete01OQ01 (1.4–5.8s)` with **zero `.lean:LINE:COL` diagnostics**, then crashed at `code 135` during `.olean` serialization. A failed tactic prints a source-location error, not a SIGBUS, so the clean elaboration confirms all four proofs type-check; only the parallel olean write crashes under fleet memory pressure (the prior session on this exact file documented the identical behaviour).

File: 198 → 271 lines, 9 → 13 theorems. Also corrects a stale `sorryCount` in the problem JSON (1 → 0; the "1" was a docstring "no `sorry`" false positive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)