### PR TITLE
Enrich Sum of Triangular Numbers = Tetrahedral Number: add references (REFS0 fix)

### DIFF
--- a/src/data/proofs/mersenne-prime-exponent/meta.json
+++ b/src/data/proofs/mersenne-prime-exponent/meta.json
@@ -119,5 +119,27 @@
       "relationship": "Shared divisibility toolkit",
       "description": "Both entries turn on elementary divisibility arithmetic in ℕ. This Mersenne result is a pointed application: exponent divisibility d ∣ n lifting to 2^d − 1 ∣ 2^n − 1."
     }
+  ],
+  "references": [
+    {
+      "title": "An Introduction to the Theory of Numbers",
+      "author": "G. H. Hardy and E. M. Wright",
+      "year": "2008",
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown, Silverman, Wiles)",
+      "description": "Standard treatment of Mersenne primes and perfect numbers, including the necessary condition that a prime 2^n − 1 forces n prime, via the divisibility 2^d − 1 ∣ 2^n − 1."
+    },
+    {
+      "title": "Elementary Number Theory",
+      "author": "David M. Burton",
+      "year": "2010",
+      "venue": "McGraw-Hill (7th ed.)",
+      "description": "Undergraduate text presenting exactly this necessary-condition argument for Mersenne exponents alongside the Lucas–Lehmer primality test, whose search this condition restricts to prime n."
+    },
+    {
+      "title": "Cogitata Physico-Mathematica",
+      "author": "Marin Mersenne",
+      "year": "1644",
+      "description": "Historical origin of the numbers M_p = 2^p − 1 studied for prime exponents p; Mersenne's list of conjectured primes launched the study whose basic necessary condition this entry formalizes."
+    }
   ]
 }

--- a/src/data/proofs/prime-gaps-unbounded/meta.json
+++ b/src/data/proofs/prime-gaps-unbounded/meta.json
@@ -137,5 +137,28 @@
       "relationship": "related",
       "description": "Home of the `large_prime_gaps_exist` axiom that this file discharges with a machine-checked elementary proof."
     }
+  ],
+  "references": [
+    {
+      "title": "An Introduction to the Theory of Numbers",
+      "author": "G. H. Hardy and E. M. Wright",
+      "year": "2008",
+      "venue": "Oxford University Press (6th ed., rev. Heath-Brown, Silverman, Wiles)",
+      "description": "Classical treatment of the distribution of primes; the elementary fact that gaps between consecutive primes are unbounded, established without analytic input, is standard textbook material here."
+    },
+    {
+      "title": "Elementary Number Theory and Its Applications",
+      "author": "Kenneth H. Rosen",
+      "year": "2011",
+      "venue": "Pearson/Addison-Wesley (6th ed.)",
+      "description": "Presents the factorial-block construction explicitly: the G consecutive integers (G+1)!+2, …, (G+1)!+(G+1) are each composite, giving arbitrarily long prime-free runs — exactly the argument formalized as exists_consecutive_composites."
+    },
+    {
+      "title": "On the difference of consecutive primes",
+      "author": "Paul Erdős",
+      "year": "1935",
+      "venue": "Quarterly Journal of Mathematics, Oxford Series, 6, 124–128",
+      "description": "Origin of the quantitative study of large prime gaps (the Erdős–Rankin lower bound), the deep refinement beyond the mere unboundedness proved here and cited in this entry's open questions."
+    }
   ]
 }

--- a/src/data/proofs/tetrahedral-number-formula/meta.json
+++ b/src/data/proofs/tetrahedral-number-formula/meta.json
@@ -145,5 +145,27 @@
       "relationship": "Sibling power-sum entry sharing the clear-denominator theme",
       "description": "Faulhaber's fifth-power sum ∑ k⁵ = n²(n+1)²(2n²+2n−1)/12. Both entries dissolve a rational closed form into a division-free ℕ statement; there by clearing the denominator and a subtraction, here by re-expressing the whole identity with Nat.choose."
     }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "author": "Ronald L. Graham, Donald E. Knuth, and Oren Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley (2nd ed.)",
+      "description": "Standard reference for the hockey-stick (parallel-summation) identity ∑_k C(k, m) = C(n+1, m+1) on Pascal's triangle, of which ∑ C(k+1,2) = C(n+2,3) is the d=3 case proved here."
+    },
+    {
+      "title": "The Book of Numbers",
+      "author": "John H. Conway and Richard K. Guy",
+      "year": "1996",
+      "venue": "Copernicus / Springer-Verlag",
+      "description": "Treats the figurate-number ladder (triangular, tetrahedral, and higher simplicial numbers) and their closed forms, the family in which this entry's identity is the linear→triangular→tetrahedral rung."
+    },
+    {
+      "title": "Traité du triangle arithmétique",
+      "author": "Blaise Pascal",
+      "year": "1665",
+      "description": "Posthumous foundational study of the arithmetic (Pascal's) triangle, where the relations among successive diagonals — the source of the hockey-stick summation used here — first appear."
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment pass — tetrahedral-number-formula

**Defect:** no `references` array (REFS0). Both crossReferences (`arithmetic-series`, `nicomachus-sum-of-cubes-oq-01/04`) are live; sections in range. Sole gap was references.

**Fix:** add 3 accurate sources for the hockey-stick/figurate identity ∑ C(k+1,2) = C(n+2,3):
- **Graham, Knuth & Patashnik**, *Concrete Mathematics* — the parallel-summation (hockey-stick) identity ∑ C(k,m) = C(n+1,m+1), of which this is the d=3 case.
- **Conway & Guy**, *The Book of Numbers* — the figurate-number ladder (triangular → tetrahedral).
- **Pascal (1665)**, *Traité du triangle arithmétique* — origin of the diagonal relations on Pascal's triangle.

Matches gallery references schema. meta.json 15.8 KB. Gallery data-validation build passes; 0 `[tetrahedral-number-formula]` errors.