### PR TITLE
Research: lagrange-theorem-oq-01 - groups of order p² are abelian

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01PSquare.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01PSquare.lean
@@ -1,0 +1,74 @@
+/-
+  Lagrange's Theorem OQ-01 — order `p²` groups are abelian (a structural companion
+  to the `pq` classification)
+
+  The sibling `LagrangeTheoremOQ01` develops the **Sylow theorems** as the partial
+  converse to Lagrange, and `LagrangeTheoremOQ01OQ01` classifies groups of order `pq`
+  (distinct primes): coprime `n_p, n_q` forces the group to be **cyclic** (e.g. orders
+  `15, 35, 77`).
+
+  This file records the neighbouring structural fact for the *other* two-prime-factor
+  shape, a prime **square** `p²`:
+
+      a group of order `p²` is **abelian**.
+
+  This is genuinely weaker than the `pq`-cyclic conclusion, and the contrast is the
+  point: order `pq` (coprime data) forces *cyclic*, but order `p²` forces only
+  *abelian* — it need **not** be cyclic (the Klein four-group `C₂ × C₂` has order
+  `4 = 2²` and is abelian but not cyclic).  So `p²` is exactly the boundary where the
+  "few prime factors ⟹ cyclic" heuristic first fails while abelianness survives.
+
+  The proof wraps Mathlib's `IsPGroup.commutative_of_card_eq_prime_sq`, whose mechanism
+  is the classical one: a nontrivial `p`-group has nontrivial centre, so for `|G| = p²`
+  the quotient `G / Z(G)` has order `1` or `p`, hence is cyclic, and a group whose
+  central quotient is cyclic is abelian.
+
+  Main results:
+  * `card_prime_sq_commutative` — `Nat.card G = p²` (p prime) ⟹ `G` is abelian.
+  * `commGroupOfCardPrimeSq`     — the same, packaged as a `CommGroup` structure.
+  * `card_4_commutative`, `card_9_commutative`, `card_25_commutative`,
+    `card_49_commutative` — concrete instances (orders `2², 3², 5², 7²`), mirroring the
+    `order_15_cyclic` / `order_35_cyclic` concrete instances of the sibling file.
+
+  All results are `0`-sorry / `0`-axiom on top of Mathlib.
+-/
+
+import Mathlib
+
+namespace LagrangeOQ01PSquare
+
+variable {G : Type*} [Group G]
+
+/-- **A group of order `p²` is abelian.**  For a prime `p`, if `Nat.card G = p²` then
+    every pair of elements commutes.  (Contrast the sibling `pq`-classification: coprime
+    order `pq` forces *cyclic*, whereas order `p²` forces only *abelian* — cf. the Klein
+    four-group, order `4`, abelian but not cyclic.)  Wraps
+    `IsPGroup.commutative_of_card_eq_prime_sq`. -/
+theorem card_prime_sq_commutative {p : ℕ} (hp : p.Prime)
+    (hG : Nat.card G = p ^ 2) : ∀ a b : G, a * b = b * a := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  exact IsPGroup.commutative_of_card_eq_prime_sq hG
+
+/-- The abelian structure of an order-`p²` group, packaged as a `CommGroup`. -/
+noncomputable def commGroupOfCardPrimeSq {p : ℕ} (hp : p.Prime)
+    (hG : Nat.card G = p ^ 2) : CommGroup G :=
+  haveI : Fact p.Prime := ⟨hp⟩
+  IsPGroup.commGroupOfCardEqPrimeSq hG
+
+/-- Every group of order `4 = 2²` is abelian. -/
+theorem card_4_commutative (hG : Nat.card G = 4) : ∀ a b : G, a * b = b * a :=
+  card_prime_sq_commutative (p := 2) (by norm_num) (hG.trans (by norm_num))
+
+/-- Every group of order `9 = 3²` is abelian. -/
+theorem card_9_commutative (hG : Nat.card G = 9) : ∀ a b : G, a * b = b * a :=
+  card_prime_sq_commutative (p := 3) (by norm_num) (hG.trans (by norm_num))
+
+/-- Every group of order `25 = 5²` is abelian. -/
+theorem card_25_commutative (hG : Nat.card G = 25) : ∀ a b : G, a * b = b * a :=
+  card_prime_sq_commutative (p := 5) (by norm_num) (hG.trans (by norm_num))
+
+/-- Every group of order `49 = 7²` is abelian. -/
+theorem card_49_commutative (hG : Nat.card G = 49) : ∀ a b : G, a * b = b * a :=
+  card_prime_sq_commutative (p := 7) (by norm_num) (hG.trans (by norm_num))
+
+end LagrangeOQ01PSquare


### PR DESCRIPTION
## Summary

lagrange-theorem-oq-01 (Sylow / partial converse of Lagrange). The sibling tree
develops the Sylow theorems and classifies groups of order `pq` (coprime data ⟹
**cyclic**: orders `15, 35, 77`). This PR adds the neighbouring structural fact for the
*other* two-prime-factor shape, a prime **square** `p²`:

    a group of order p² is abelian.

New file `proofs/Proofs/LagrangeTheoremOQ01PSquare.lean` (6 decls, **0 sorry / 0 axiom**):

- `card_prime_sq_commutative` — `Nat.card G = p²` (p prime) ⟹ `∀ a b, a*b = b*a`.
- `commGroupOfCardPrimeSq` — the same, packaged as a `CommGroup`.
- `card_4_commutative`, `card_9_commutative`, `card_25_commutative`,
  `card_49_commutative` — concrete instances (orders `2², 3², 5², 7²`), mirroring the
  sibling's `order_15_cyclic` / `order_35_cyclic`.

The contrast is the mathematical point: order `pq` (coprime) forces *cyclic*, but order
`p²` forces only *abelian* — it need **not** be cyclic (the Klein four-group `C₂ × C₂`,
order `4`, is abelian but not cyclic). So `p²` is the boundary where "few prime factors
⟹ cyclic" first fails while abelianness survives. Wraps Mathlib's
`IsPGroup.commutative_of_card_eq_prime_sq` (mechanism: nontrivial centre ⟹ `G/Z(G)`
cyclic ⟹ `G` abelian).

## Verification status: UNVERIFIED (environment-blocked, high confidence)

Docker build **elaborates the file cleanly** — every build that reaches it shows
`[7743/7743] Building Proofs.LagrangeTheoremOQ01PSquare` in ~2s with **no** elaboration
errors — but consistently crashes with `Lean exited with code 135` (SIGBUS) at the
`.olean` **write** stage. This is the known stochastic olean-write SIGBUS from the shared
build volume, not a logic error (across 5 attempts, no run ever produced an "unsolved
goals" / "unknown identifier" error; all reached the final job before the write crash). I
force-refreshed the Mathlib cache (`cache get!`) mid-session to clear an upstream
truncated-olean SIGBUS, which let the build progress to this file. The file imports only
Mathlib and wraps a single established theorem with `norm_num` instances; a clean-write
rebuild should verify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)