### PR TITLE
Audit: five-color-theorem (CRITICAL, issue #36758) + 4 erdos entries clean, 2026-07-09

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17826,9 +17826,9 @@
       "result": "clean"
     },
     "erdos-980": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:08:23Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "erdos-981": {
@@ -17850,9 +17850,9 @@
       "result": "clean"
     },
     "erdos-983": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:06:34Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "erdos-984": {
@@ -17880,9 +17880,9 @@
       "result": "clean"
     },
     "erdos-988": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:06:34Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "erdos-989": {
@@ -17940,9 +17940,9 @@
       "result": "clean"
     },
     "erdos-997": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:06:34Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "erdos-998": {
@@ -18177,10 +18177,10 @@
       "result": "clean"
     },
     "euler-polyhedral-formula-oq-01-oq-01": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:06:33Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-found"
     },
     "euler-polyhedral-formula-oq-01-oq-01-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — batch 2 (2026-07-09)

Continued re-auditing the stalest entries. Tracker bumps for 5 entries.

### `euler-polyhedral-formula-oq-01-oq-01` — ISSUES FOUND (CRITICAL) → issue #36758
Titled "Five Color Theorem via Kempe Chain Argument" (`FiveColorTheorem.lean`), status `axiomatized`. **3 of its 4 axioms are logically false as stated** (inconsistent axiom set):
- `five_color_axiom`: `G.Colorable 5` for *every* finite graph, no planarity hypothesis — false (K₆).
- `kuratowski_wagner`: no-minor hypothesis stubbed to `True →`, asserts every graph satisfies `E ≤ 3V−6` — false (K₆: 15 ≤ 12).
- `kempe_chain_separation`: no planarity hypothesis; its `∃ f'` is unsatisfiable for K₆'s degree-5 vertices.
- Plus `hadwiger_implies_five_color` is a vacuous tautology (`∀ t, t ≤ 5 → t < 6`) mislabeled as a Hadwiger⇒5-color implication.

Full evidence and recommended Lean fixes (add planarity hypotheses) in **#36758** for the mechanic.

### CLEAN (honest axiomatizations of hard/open results, badge=axiom)
| Entry | Axioms | Notes |
|-------|--------|-------|
| `erdos-983` | 2 | `erdos_question_answer` (¬ErdosQuestion983, a real "→∞" prop), `difference_is_sublinear`. Contributions label axioms honestly. |
| `erdos-988` | 5 | Roth 1954 / Schmidt 1969 / sphere discrepancy bounds — genuine analytic statements. |
| `erdos-997` | 1 | `CLLW_theorem` (2024 existence result), real `WellDistributed` predicate. |
| `erdos-980` | 4 | `c_2/c_k_positive`, `erdos_1961_quadratic`, `elliott_1967_general` — genuine asymptotics. |

All: 0 sorries, 0 `native_decide`, 0 True-stubs; axiom counts match meta; defined predicates are substantive (no `:= True` stubs).

---
Discovered during gallery integrity audit.