### PR TITLE
research(binary-gcd-oq-01-oq-04-oq-03): exact a=1 average total at every N

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ04OQ03.lean
@@ -357,5 +357,71 @@ theorem totalSteps_one_pow_two (n : ℕ) :
   have hIco := sum_Ico_one_pow_two n
   omega
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VII: EXACT CLOSED FORM AT EVERY N  (a = 1 row)
+-- ═══════════════════════════════════════════════════════════════════
+--
+-- `totalSteps_one_pow_two` pins the a = 1 total only on the dyadic subsequence
+-- N = 2^n.  Extending across the partial final block `(2^n, N]` — on which
+-- `binaryGcdSteps 1 b = n + 1` is constant — pins the a = 1 total EXACTLY at
+-- EVERY N, subsuming both `totalSteps_one_eq` (removes the abstract ∑ log₂ b) and
+-- `totalSteps_one_pow_two` (its dyadic special case):
+--
+--     totalSteps 1 N + 2^{n+1} = (N + 1)·n + N + 2,   n = ⌊log₂ N⌋.
+
+/-- **Exact `a = 1` total at every `N ≥ 1`.**  With `n = ⌊log₂ N⌋`,
+
+      totalSteps 1 N + 2^{n+1} = (N+1)·n + N + 2,
+
+    i.e. `totalSteps 1 N = (N+1)·⌊log₂N⌋ − 2^{⌊log₂N⌋+1} + N + 2`.  This is the
+    exact average-case total for the `a = 1` row at *every* `N` (not merely the
+    dyadic `N = 2^n` of `totalSteps_one_pow_two`), and it removes the abstract
+    `∑ log₂ b` left standing in `totalSteps_one_eq`.  It is the fully elementary,
+    closed-form counterpart of Brent's `≈ 0.7050 · log₂ N` average — the latter's
+    transcendental leading constant stays out of reach (see file header).
+
+    Proof: split `[1,N] = [1, 2^n] ⊍ (2^n, N]`.  The head is the dyadic total
+    `totalSteps_one_pow_two`; on the partial tail every `b` satisfies
+    `2^n ≤ b < 2^{n+1}`, so `⌊log₂ b⌋ = n` and `binaryGcdSteps 1 b = n+1`, giving
+    the constant contribution `(N − 2^n)·(n+1)`.  A single `linear_combination`
+    with the dyadic total closes the resulting polynomial identity in `N`, `n`,
+    `2^n`. -/
+theorem totalSteps_one_closed (N : ℕ) (hN : 1 ≤ N) :
+    totalSteps 1 N + 2 ^ (Nat.log 2 N + 1) = (N + 1) * Nat.log 2 N + N + 2 := by
+  set n := Nat.log 2 N with hn
+  have hpow_le : 2 ^ n ≤ N := Nat.pow_log_le_self 2 (by omega)
+  have hlt_pow : N < 2 ^ (n + 1) := Nat.lt_pow_succ_log_self (by norm_num) N
+  have hdisj : Disjoint (Finset.Icc 1 (2 ^ n)) (Finset.Ioc (2 ^ n) N) :=
+    Finset.disjoint_left.mpr (fun x hx hx' => by
+      rw [Finset.mem_Icc] at hx; rw [Finset.mem_Ioc] at hx'; omega)
+  have hunion : Finset.Icc 1 (2 ^ n) ∪ Finset.Ioc (2 ^ n) N = Finset.Icc 1 N :=
+    Finset.Icc_union_Ioc_eq_Icc Nat.one_le_two_pow hpow_le
+  -- the partial tail (2^n, N] contributes the constant (N − 2^n)·(n+1)
+  have htail : ∑ b ∈ Finset.Ioc (2 ^ n) N, binaryGcdSteps 1 b = (N - 2 ^ n) * (n + 1) := by
+    have hval : ∀ b ∈ Finset.Ioc (2 ^ n) N, binaryGcdSteps 1 b = n + 1 := by
+      intro b hb
+      rw [Finset.mem_Ioc] at hb
+      have hb1 : 1 ≤ b := le_trans Nat.one_le_two_pow (le_of_lt hb.1)
+      have hlogb : Nat.log 2 b = n :=
+        Nat.log_eq_of_pow_le_of_lt_pow (le_of_lt hb.1) (lt_of_le_of_lt hb.2 hlt_pow)
+      rw [binaryGcdSteps_one_eq_log b hb1, hlogb]
+    rw [Finset.sum_congr rfl hval, Finset.sum_const, Nat.card_Ioc, smul_eq_mul]
+  -- split the total at the dyadic point 2^n
+  have hsum : totalSteps 1 N
+      = totalSteps 1 (2 ^ n) + ∑ b ∈ Finset.Ioc (2 ^ n) N, binaryGcdSteps 1 b := by
+    unfold totalSteps
+    rw [← Finset.sum_union hdisj, hunion]
+  have hdya : totalSteps 1 (2 ^ n) + 2 ^ n = n * 2 ^ n + n + 2 := totalSteps_one_pow_two n
+  rw [hsum, htail]
+  zify [hpow_le] at hdya ⊢
+  have hp : (2 : ℤ) ^ (n + 1) = 2 * 2 ^ n := by rw [pow_succ]; ring
+  rw [hp]
+  linear_combination hdya
+
+-- Concrete check of the closed form (a = 1, N = 100): n = ⌊log₂100⌋ = 6,
+--   totalSteps 1 100 + 2^7 = 101·6 + 100 + 2 = 708.
+example : totalSteps 1 100 + 2 ^ (Nat.log 2 100 + 1) = (100 + 1) * Nat.log 2 100 + 100 + 2 :=
+  totalSteps_one_closed 100 (by norm_num)
+
 
 end BinaryGcdOQ01OQ04OQ03

--- a/research/problems/binary-gcd-oq-01-oq-04-oq-03/knowledge.md
+++ b/research/problems/binary-gcd-oq-01-oq-04-oq-03/knowledge.md
@@ -100,3 +100,40 @@ leaves open. All Lean steps are **Docker-gated** and deferred until the build in
 - *A rigorous version of R. P. Brent's model for the binary Euclidean algorithm*,
   arXiv:1409.0729 (Adv. Math. 2015).
 - Knuth, *TAOCP* Vol. 2 (open questions on binary GCD averages).
+
+---
+
+## Session 2026-07-09 (researcher-3) — exact a=1 total closed form at EVERY N
+
+**Mode**: REVISIT (MODERATE tier). **Outcome**: progress (full elaboration clean
+`[7745/7745]`; olean-write env-blocked SIGBUS-135 ×4 → UNVERIFIED; 0 sorry/0 axiom).
+
+### What I did
+- The file already pins the `a = 1` row to `Θ(log N)` with a **dyadic** exact
+  closed form `totalSteps_one_pow_two` (`N = 2^n`), plus the abstract exact form
+  `totalSteps_one_eq` (`= (∑ log₂ b) + N`) and the `Ω(N log N)` lower bound.
+- Added the crowning **general-N exact closed form** `totalSteps_one_closed`:
+  with `n = ⌊log₂ N⌋`,
+      `totalSteps 1 N + 2^(n+1) = (N+1)·n + N + 2`
+  (i.e. `totalSteps 1 N = (N+1)·⌊log₂N⌋ − 2^(⌊log₂N⌋+1) + N + 2`), valid at
+  **every** `N ≥ 1`. Subsumes the dyadic case and removes the abstract `∑ log₂ b`.
+  Numerically checked at N=1..128 (Python) before formalizing.
+
+### Proof recipe (reusable: sum of a floor-log-constant statistic over [1,N])
+- Split `Icc 1 N = Icc 1 (2^n) ∪ Ioc (2^n) N` via
+  `Finset.Icc_union_Ioc_eq_Icc Nat.one_le_two_pow hpow_le`; disjointness by
+  `Finset.disjoint_left` + `omega` on the membership bounds.
+- On the partial tail `Ioc (2^n) N`, every `b` has `2^n ≤ b < 2^(n+1)` so
+  `Nat.log 2 b = n` (`Nat.log_eq_of_pow_le_of_lt_pow`), giving a constant summand;
+  `Finset.sum_const` + `Nat.card_Ioc` → `(N − 2^n)·(n+1)`.
+- Head = dyadic total `totalSteps_one_pow_two n`. Combine with `zify [hpow_le]`
+  (handles the `N − 2^n` truncated sub) then `linear_combination hdya` — the
+  residual is a ring identity in `N, n, 2^n`.
+- Key Mathlib: `Nat.pow_log_le_self 2 (N≠0)`, `Nat.lt_pow_succ_log_self`,
+  `Nat.log_eq_of_pow_le_of_lt_pow`, `Finset.Icc_union_Ioc_eq_Icc`, `Nat.card_Ioc`.
+
+### Status
+- The `a = 1` row is now COMPLETE: exact closed form + Θ(log N) sandwich.
+- Depth-3 slug ⇒ 0 follow-up questions generated (OQ-depth guard).
+- Sharp Brent `0.7050` constant remains genuinely BLOCKED (transfer-operator /
+  Ruelle–Mayer spectral theory absent from Mathlib) — unchanged.

--- a/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-03.json
@@ -32,11 +32,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED (researcher-2, 2026-07-07): the matching Ω(N·log N) lower bound `totalSteps_one_ge : (N - N/2)*(Nat.log 2 N - 1) ≤ totalSteps 1 N` now BUILDS GREEN (docker-build Proofs.BinaryGcdOQ01OQ04OQ03, 0 sorry / 0 axiom / 0 native_decide). Together with `totalSteps_one_eq` (exact a=1 total) and `avgSteps_le` (O(log N) ceiling) it pins the a=1 average at a genuine Θ(log N) — closing the file header's one stated tractable open sub-goal (the matching averaged lower bound). Proof: restrict ∑_{b=1}^N log₂ b to the upper half b∈(⌊N/2⌋,N]; each term ≥ log₂⌊N/2⌋ = log₂ N − 1 (Nat.log_mono_right + Nat.log_div_base), and the sub-range has N−⌊N/2⌋ elements (Finset.sum_le_sum_of_subset + Finset.sum_const). The prior exit-135 blackout was environmental olean corruption; the cache is healthy this session. || PRIOR: the a=1 row is EXACTLY logarithmic — binaryGcdSteps 1 b = Nat.log 2 b + 1 for all b≥1 (binaryGcdSteps_one_eq_log), generalizing the parent sparse family 2^n-1 to the whole row. Open: general-a average lower bound (density count) and the sharp Brent constant 0.7050 (transfer-operator analysis, not in Mathlib).",
+    "progressSummary": "PROGRESS (researcher-3 2026-07-09): Added totalSteps_one_closed — the EXACT a=1 average-case total at every N: with n=floor(log2 N), totalSteps 1 N + 2^(n+1) = (N+1)*n + N + 2. Subsumes the dyadic totalSteps_one_pow_two and removes the abstract sum(log2 b) of totalSteps_one_eq, completing the elementary a=1 analysis (exact closed form + Theta(log N) sandwich). Split [1,N]=[1,2^n]+(2^n,N], constant tail (N-2^n)*(n+1), linear_combination with the dyadic total. Full elaboration clean [7745/7745], olean-write env-blocked (SIGBUS-135 x4) -> UNVERIFIED. Sharp Brent 0.7050 constant remains BLOCKED (transfer-operator theory absent from Mathlib).",
     "builtItems": [
       "BinaryGcdOQ01OQ04OQ03.lean: totalSteps (average-case object), totalSteps_le (O(log N) total-sum ceiling), avgSteps_le (rational average ceiling) — all verified, 0 sorry / 0 axiom / 0 native_decide",
       "BinaryGcdOQ01OQ04OQ03.lean PART IV: binaryGcdSteps_one_step (unified floor-halving one-step), binaryGcdSteps_one_eq_log (EXACT binaryGcdSteps 1 b = log₂ b + 1 ∀b≥1), totalSteps_one_eq (exact a=1 total = ∑log₂b + N) — verified, 0 sorry/0 axiom/0 native_decide",
-      "BinaryGcdOQ01OQ04OQ03.lean PART V: totalSteps_one_ge (matching Ω(N·log N) lower bound (N−⌊N/2⌋)·(log₂N−1) ≤ totalSteps 1 N, via upper-half density count) — VERIFIED, 0 sorry/0 axiom/0 native_decide. Pins the a=1 average at Θ(log N)."
+      "BinaryGcdOQ01OQ04OQ03.lean PART V: totalSteps_one_ge (matching Ω(N·log N) lower bound (N−⌊N/2⌋)·(log₂N−1) ≤ totalSteps 1 N, via upper-half density count) — VERIFIED, 0 sorry/0 axiom/0 native_decide. Pins the a=1 average at Θ(log N).",
+      "totalSteps_one_closed (BinaryGcdOQ01OQ04OQ03.lean) — exact a=1 total at EVERY N: totalSteps 1 N + 2^(floor(log2 N)+1) = (N+1)*floor(log2 N) + N + 2."
     ],
     "insights": [
       "Sharp Brent (1976) constant 0.7050·log₂max(a,b) for the AVERAGE binary-GCD step count is OUT OF REACH in Mathlib 4.26: the constant has no closed form and comes from a transfer-operator/dynamical-systems analysis of the Euclidean-type map (Brent; Vallée). Mathlib has measure theory but none of the spectral machinery to pin the leading constant.",
@@ -86,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-06-13T12:52:52.056Z",
-  "lastUpdate": "2026-07-07T00:00:00.000Z",
+  "lastUpdate": "2026-07-09",
   "leanFiles": [
     {
       "path": "Proofs/BinaryGcdOQ01.lean",


### PR DESCRIPTION
## Summary

Adds `totalSteps_one_closed`, the **exact closed form of the `a = 1` average-case
total at every `N`** for the binary-GCD step count (average-case OQ of Brent's
`≈ 0.7050 · log₂ N`). With `n = ⌊log₂ N⌋`:

```
totalSteps 1 N + 2^(n+1) = (N+1)·n + N + 2
```

equivalently `totalSteps 1 N = (N+1)·⌊log₂N⌋ − 2^(⌊log₂N⌋+1) + N + 2`.

This **subsumes** the file's two existing exact statements:
- `totalSteps_one_pow_two` — the *dyadic-only* case `N = 2^n`;
- `totalSteps_one_eq` — the *abstract* form `(∑ log₂ b) + N` (this new theorem
  evaluates that sum in closed form).

Together with the existing `Θ(log N)` sandwich (`avgSteps_le` / `avgSteps_one_ge`),
the `a = 1` row of the average-case problem is now completely and exactly resolved
— the fully elementary, closed-form analogue of Brent's average. The sharp
transcendental leading constant `0.7050` remains genuinely out of reach (it needs
Ruelle–Mayer transfer-operator spectral theory absent from Mathlib; see file
header and knowledge base).

## Proof

Split `[1,N] = [1,2^n] ⊍ (2^n, N]`. The head is the dyadic total; on the partial
tail every `b` has `2^n ≤ b < 2^{n+1}`, so `⌊log₂ b⌋ = n` and
`binaryGcdSteps 1 b = n+1` is constant, contributing `(N − 2^n)·(n+1)`. A single
`linear_combination` with the dyadic total closes the polynomial identity in
`N, n, 2^n`. Numerically cross-checked at `N = 1…128` before formalizing; a
concrete `example` at `N = 100` is included.

## Verification

- **1 theorem, 0 sorry, 0 axiom.** Depth-3 slug → 0 follow-up questions
  (OQ-depth guard).
- Full elaboration clean under Docker/Lean v4.26.0: `[7745/7745] Building
  Proofs.BinaryGcdOQ01OQ04OQ03`, no `unsolved goals`/`unknown`/type errors.
- The olean *write* was env-blocked (`Lean exited with code 135`, the documented
  stochastic SIGBUS olean-write crash) across 4 runs, so shipped **UNVERIFIED**
  despite clean elaboration. The proof reuses only in-file verified lemmas
  (`totalSteps_one_pow_two`, `binaryGcdSteps_one_eq_log`) plus standard
  `Nat.log`/`Finset` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)