### PR TITLE
Research: eqr-oq-03-oq-02-wip-01 — complete Kronecker character-axiom normalizations

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -759,6 +759,42 @@ theorem kronecker_neg_numerator_three_mod_four (a : ℤ) (n : ℕ) (hn4 : n % 4 
   rw [kronecker_neg_numerator_if a n (by omega) (by omega) ha,
     if_neg (by omega : ¬ n % 4 = 1), neg_one_mul]
 
+-- ============================================================
+-- Section 11: The remaining character-axiom normalizations
+-- ============================================================
+
+/-! Section 10 pinned the numerator normalization at `1` (`kronecker_one_left`,
+`(1/n) = 1`). The two facts below complete the Dirichlet-character axiom set for
+`(·/n)`: the character **vanishes at `0`** (the canonical non-unit), and it is
+**exactly of order two on the units** (not merely order dividing two). Together with
+`kronecker_one_left`, `kronecker_mul_left`, `kronecker_mod_numerator`,
+`kronecker_eq_zero_iff` and `kronecker_eq_one_or_neg_one_of_coprime` these are the
+complete data of a real (quadratic) Dirichlet character. -/
+
+/-- **The character vanishes at numerator `0`.** For every modulus `n ≠ 0, ±1` (i.e.
+`|n| ≥ 2`), `(0/n) = 0` — the numerator `0` is the canonical non-unit and a Dirichlet
+character kills it. This is the `χ(0) = 0` companion to the `χ(1) = 1` normalization
+`kronecker_one_left`; the excluded moduli are exactly the degenerate ones where the
+symbol is constant (`(0/1) = 1`, `(0/0) = 0` by the special-modulus definitions). Via
+`kronecker_eq_sign_jacobi` it reduces to `jacobiSym.zero_left` (`J(0 | b) = 0` for
+`b > 1`). -/
+theorem kronecker_zero_left (n : ℤ) (hn0 : n ≠ 0) (hn1 : n ≠ 1) (hnm1 : n ≠ -1) :
+    kronecker 0 n = 0 := by
+  rw [kronecker_eq_sign_jacobi 0 n hn0]
+  have hb : 1 < n.natAbs := by omega
+  rw [jacobiSym.zero_left hb, mul_zero]
+
+/-- **On the units the character has order exactly two.** For odd positive `n` and
+`a` coprime to `n`, `(a/n)² = 1`. This sharpens the unconditional `kronecker_sq_mem`
+(`(a/n)² ∈ {0, 1}`) by ruling out the `0` value on units: `(·/n)` restricted to
+`(ℤ/nℤ)ˣ` is a genuine `{±1}`-valued quadratic character. Immediate from
+`kronecker_eq_one_or_neg_one_of_coprime`. -/
+theorem kronecker_sq_eq_one_of_coprime (a : ℤ) (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1)
+    (h : Int.gcd a n = 1) : kronecker a n ^ 2 = 1 := by
+  rcases kronecker_eq_one_or_neg_one_of_coprime a n hn hno h with h1 | hm1
+  · rw [h1]; norm_num
+  · rw [hm1]; norm_num
+
 /-!
 ## Module note: what remains open
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
@@ -159,3 +159,26 @@ numerator analog of the denominator law `kronecker_neg_one_odd`.
 - Reusable ingredient for the still-open generalized-reciprocity (Gauss-sum) core (Target 2).
 Still open: Target 2 Gauss-sum reciprocity core; refinement (1) wiring `kronecker2` into
 the even-modulus branch.
+
+## Update (2026-07-09, researcher-6 — PR pending)
+
+Added **Section 11: remaining character-axiom normalizations** to
+`ElementaryQuadraticReciprocityOQ03OQ02.lean` (2 theorems, 0 sorries/axioms).
+Both stated WIP Targets (`kronecker_mul_left`/`kronecker_mul_right`) are ALREADY DONE
+(lines 296/341); this fills the two omitted Dirichlet-character axioms for `(·/n)`:
+- `kronecker_zero_left (n) (hn0 hn1 hnm1) : kronecker 0 n = 0` — the `χ(0)=0` companion
+  to the existing `χ(1)=1` `kronecker_one_left`. Via `kronecker_eq_sign_jacobi 0 n hn0`
+  + `jacobiSym.zero_left (hb : 1 < n.natAbs)` (`omega` gets `1<natAbs` from n∉{0,±1}) + `mul_zero`.
+- `kronecker_sq_eq_one_of_coprime (a n hn hno h) : kronecker a n ^ 2 = 1` — sharpens the
+  unconditional `kronecker_sq_mem` (∈{0,1}) to `=1` on units; rcases
+  `kronecker_eq_one_or_neg_one_of_coprime` + norm_num.
+
+**Build status: elaboration-clean, UNVERIFIED (olean-write SIGBUS-135).** ~9 docker runs
+all reached `[3058/3058]` and elaborated my file cleanly (0.3–4.1s, never a `.lean` error),
+then exit 135 at the olean write — the documented environmental crash for this larger file
+(809 L). `docker-repair-cache.sh` (full 7727-file refresh) did NOT clear it this cycle.
+Prior sessions (R3/R4) on this same file eventually built green when the env cooperated;
+the 2 added lemmas depend only on already-proven in-file results + Mathlib `jacobiSym.zero_left`.
+
+Still open (unchanged, NOT session-sized): Target 2 Gauss-sum generalized reciprocity core;
+refinement (1) wiring `kronecker2` into the even-modulus branch.


### PR DESCRIPTION
## Problem
**Kronecker Symbol WIP completion** (`elementary-quadratic-reciprocity-oq-03-oq-02-wip-01`).

## State of the WIP
Both explicitly-stated targets are **already proven** in
`ElementaryQuadraticReciprocityOQ03OQ02.lean`: first-argument multiplicativity
`kronecker_mul_left` (line 296) and second-argument `kronecker_mul_right` (line 341).
The file is a mature 809-line development (researchers 3, 4) with the full supplementary-law,
periodicity, trichotomy, and support machinery.

## This PR
New **Section 11** (2 theorems, 0 sorry / 0 axiom) filling the two omitted
Dirichlet-character axioms for $(\cdot/n)$, companions to the existing normalizations:

| Decl | Statement | Role |
|------|-----------|------|
| `kronecker_zero_left` | $n \neq 0,\pm 1 \Rightarrow (0/n) = 0$ | the $\chi(0)=0$ axiom, companion to the existing $\chi(1)=1$ `kronecker_one_left` |
| `kronecker_sq_eq_one_of_coprime` | $n$ odd $>0$, $\gcd(a,n)=1 \Rightarrow (a/n)^2 = 1$ | order **exactly** two on units, sharpening the unconditional `kronecker_sq_mem` ($\in\{0,1\}$) |

Both reduce immediately to already-proven in-file lemmas plus Mathlib's
`jacobiSym.zero_left`: `kronecker_zero_left` via `kronecker_eq_sign_jacobi` + `jacobiSym.zero_left`;
`kronecker_sq_eq_one_of_coprime` via `kronecker_eq_one_or_neg_one_of_coprime` + `norm_num`.

## Build status — ⚠️ elaboration-clean, UNVERIFIED
~9 docker builds all reached `[3058/3058]` and **elaborated the file cleanly** (0.3–4.1s,
never a Lean error), then exited 135 (SIGBUS) at the `.olean` **write** step — the documented
environmental crash for this larger file; a full `docker-repair-cache.sh` refresh did not
clear it this cycle. Prior sessions on this same file built green when the environment
cooperated, and the two added lemmas depend only on already-proven results, so I'm shipping
elaboration-clean per the project's established UNVERIFIED convention. A clean-env rebuild is
advised before merge.

The deep open work (Target 2: Gauss-sum generalized reciprocity; refinement wiring `kronecker2`
into the even-modulus branch) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)