### PR TITLE
Audit: erdos-97 phantom-contribution fix + 4 erdos entries clean (2026-07-09)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17699,9 +17699,9 @@
       "result": "clean"
     },
     "erdos-962": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:10:51Z",
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "erdos-963": {
@@ -17717,9 +17717,9 @@
       "result": "clean"
     },
     "erdos-965": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:10:51Z",
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "erdos-966": {
@@ -17747,10 +17747,10 @@
       "result": "clean"
     },
     "erdos-97": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:10:51Z",
-      "result": "clean"
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "erdos-970": {
       "agentId": "auditor-cycle-20-batch",
@@ -17765,15 +17765,15 @@
       "result": "clean"
     },
     "erdos-972": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:10:50Z",
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "erdos-973": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:10:50Z",
+      "agentId": "auditor-agent-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "erdos-974": {
@@ -29764,5 +29764,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T02:00:00Z"
+  "lastUpdated": "2026-07-09T00:00:00Z"
 }

--- a/src/data/proofs/erdos-97/meta.json
+++ b/src/data/proofs/erdos-97/meta.json
@@ -42,11 +42,11 @@
       }
     ],
     "originalContributions": [
-      "Definition of hasKEquidistantAt for k-equidistant neighbors",
-      "Definition of hasKEquidistantProperty for sets",
-      "Definition of hasKUnitDistanceProperty for unit distances",
-      "Definition of isConvexPosition for convex polygons",
-      "Erdos97Question: the k = 4 open problem",
+      "Definition of HasNEquidistantPointsAt for n equidistant neighbors of a vertex",
+      "Definition of HasNEquidistantProperty for sets",
+      "Definition of HasNUnitDistanceProperty for unit distances",
+      "Convexity modeled via Mathlib's ConvexIndep (not a bespoke definition)",
+      "Erdos97Conjecture: the k = 4 open problem",
       "Axioms for Danzer and Fishburn-Reeds counterexamples",
       "GeneralKConjecture: does any k work?",
       "Connection to unit distance bounds"
@@ -64,7 +64,7 @@
     "historicalContext": "Erdős originally conjectured (1946) that every convex polygon has a vertex with no other 3 vertices equidistant from it. Danzer disproved this with a 9-point counterexample where every vertex has exactly 3 vertices equidistant from it.\n\nThe problem was then raised for k = 4: does every convex polygon have a vertex with no other 4 vertices equidistant? This remains open.\n\nFishburn and Reeds (1992) found an even stronger example: a convex 20-gon where every vertex has 3 vertices at UNIT distance (not just equidistant at varying radii). They also proved 20 is minimal for this property.",
     "problemStatement": "**Erdős Problem #97 (OPEN for k = 4)**\n\nDoes every convex polygon have a vertex with no other 4 vertices equidistant from it?\n\n**Solved Variants**:\n- k = 3: NO (Danzer's 9-point counterexample)\n- k = 3 unit distance: NO (Fishburn-Reeds 20-point example)\n\n**Open Questions**:\n- The k = 4 case\n- Does any k work?\n\n**Prize**: $100",
     "text": "Does every convex polygon have a vertex with no other 4 vertices equidistant from it?",
-    "proofStrategy": "We formalize the key concepts and counterexamples:\n\n1. **hasKEquidistantAt**: k points at same distance from a vertex\n\n2. **hasKEquidistantProperty**: k-equidistant from every vertex\n\n3. **isConvexPosition**: vertices of a convex polygon\n\n4. **Erdos97Question**: the open k = 4 question\n\n5. **danzerCounterexample** (axiom): 9-point convex with 3-equidistant\n\n6. **fishburnReedsExample** (axiom): 20-point with 3 unit-distance",
+    "proofStrategy": "We formalize the key concepts and counterexamples:\n\n1. **HasNEquidistantPointsAt**: n points at the same distance from a vertex\n\n2. **HasNEquidistantProperty**: n-equidistant from every vertex\n\n3. **ConvexIndep** (Mathlib): vertices in convex position\n\n4. **Erdos97Conjecture**: the open k = 4 question\n\n5. **danzer_counterexample** (axiom): 9-point convex with 3-equidistant\n\n6. **fishburn_reeds_example** (axiom): 20-point with 3 unit-distance",
     "keyInsights": [
       "**Convexity is crucial**: Without convexity, hypercube graphs give arbitrarily high equidistance.",
       "**Danzer's surprise**: A 9-point convex polygon can have 3 equidistant from every vertex.",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos batch (2026-07-09)

Re-audited the stalest uncovered tracker entries (all stuck at 2026-05-03).

### \`erdos-97\` — ISSUES FOUND & FIXED (prose)
Equidistant Vertices in Convex Polygons (`Erdos97Problem.lean`), status `axiomatized`, badge `axiom`. Counts all correct (4 axioms, 2 theorems, 6 defs incl. `abbrev ℝ²`, 0 sorries, no native_decide). But `originalContributions` and `proofStrategy` named declarations that don't exist / were renamed:
- **Phantom**: "Definition of `isConvexPosition` for convex polygons" — no such def; convexity is modeled with Mathlib's `ConvexIndep id`, not a bespoke definition.
- **Wrong name**: `Erdos97Question` → actual decl is `Erdos97Conjecture`.
- **Stale names**: `hasKEquidistantAt`/`hasKEquidistantProperty`/`hasKUnitDistanceProperty` → actual `HasNEquidistantPointsAt`/`HasNEquidistantProperty`/`HasNUnitDistanceProperty`; `danzerCounterexample`/`fishburnReedsExample` → `danzer_counterexample`/`fishburn_reeds_example`.

Fixed the contributions/proofStrategy prose to the real declaration names. No Lean or count changes.

### CLEAN (honest axiomatizations of open/hard results, badge=axiom)
| Entry | Axioms | Notes |
|-------|--------|-------|
| `erdos-972` | 1 | `vinogradov_uniform_distribution` (real infinitude-of-Beatty-primes statement); open conjecture stated as `def`, examples for rational α. |
| `erdos-973` | 4 | Turán power-sum bounds; "proved" theorems honestly labeled "(PROVED from axiom)" derivations, `AnswerSummary` = conjunction of disclosed axioms. |
| `erdos-965` | 4 | Monochromatic sums; `counterexample_exists`/`komjath_unconditional` (real cardinality/coloring props); theorems derive from disclosed axioms. |
| `erdos-962` | 2 | `tang_lower_bound`/`tao_upper_bound` (genuine asymptotics); summary theorems = conjunction of the two. |

All CLEAN entries: 0 sorries, 0 `native_decide`, 0 True-stubs; axiom counts match meta; defined predicates are substantive (no `:= True` stubs).

Tracker bumped for all 5 entries.

---
Discovered during gallery integrity audit.