### PR TITLE
research(burnside-counting-oq-02): prime-length necklace count + Fermat's Little Theorem

### DIFF
--- a/proofs/Proofs/BurnsideCounting.lean
+++ b/proofs/Proofs/BurnsideCounting.lean
@@ -608,3 +608,63 @@ theorem fixedBy_card_of_isUnit {n k : ℕ} [NeZero n] {r : ZMod n} (hr : IsUnit 
     `fixed_point_sum_binary_4` from the general formula. -/
 example : Fintype.card { c : Coloring 4 2 // IsFixedByRotation 1 c } = 2 :=
   fixedBy_card_of_isUnit isUnit_one
+
+/-! ## Part VII: Prime-Length Necklaces and Fermat's Little Theorem
+
+For a **prime** length `p`, every nonzero rotation `a : ZMod p` is a unit (since
+`ZMod p` is a field), so by `fixedBy_card_of_isUnit` it fixes only the `k` constant
+colorings, while the identity fixes all `kᵖ`.  Burnside's engine then evaluates the
+necklace count in closed form, and the divisibility it forces is exactly Fermat's
+Little Theorem. -/
+
+/-- **Necklace count for prime length.**  For a prime `p` and palette size `k`, the
+number of rotation orbits (necklaces) of `Coloring p k` satisfies
+`|necklaces| · p = kᵖ + (p − 1)·k`.  The identity fixes all `kᵖ` colorings; every
+nonzero rotation is a unit of the field `ZMod p` and hence fixes only the `k` constant
+colorings (`fixedBy_card_of_isUnit`).  Summing over the `p` rotations and applying the
+Burnside engine `sum_fixedBy_eq_card_necklaces_mul` gives the identity. -/
+theorem necklaces_prime_length_mul {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    @Fintype.card (Quotient (@coloringSetoid p k _)) (coloringQuotientFintype p k) * p
+      = k ^ p + (p - 1) * k := by
+  haveI : NeZero p := ⟨hp.pos.ne'⟩
+  haveI : Fact p.Prime := ⟨hp⟩
+  -- Fixed-point count at each rotation: `kᵖ` at the identity, `k` at every unit.
+  have hf : ∀ a : ZMod p,
+      Fintype.card { c : Coloring p k // IsFixedByRotation a c }
+        = if a = 0 then k ^ p else k := by
+    intro a
+    by_cases ha : a = 0
+    · subst ha
+      rw [if_pos rfl]
+      have huniv : ∀ c : Coloring p k, IsFixedByRotation (0 : ZMod p) c :=
+        fun c => zero_vadd c
+      rw [Fintype.card_congr (Equiv.subtypeUnivEquiv huniv)]
+      show Fintype.card (Fin p → Fin k) = k ^ p
+      rw [Fintype.card_fun, Fintype.card_fin, Fintype.card_fin]
+    · rw [if_neg ha]
+      exact fixedBy_card_of_isUnit (isUnit_iff_ne_zero.mpr ha)
+  -- Evaluate the total fixed-point sum: `kᵖ + (p−1)·k`.
+  have hsum : (∑ a : ZMod p, Fintype.card { c : Coloring p k // IsFixedByRotation a c })
+      = k ^ p + (p - 1) * k := by
+    simp only [hf]
+    rw [← Finset.add_sum_erase Finset.univ _ (Finset.mem_univ (0 : ZMod p)), if_pos rfl]
+    congr 1
+    rw [Finset.sum_congr rfl (fun a ha => if_neg (Finset.ne_of_mem_erase ha)),
+      Finset.sum_const, Finset.card_erase_of_mem (Finset.mem_univ (0 : ZMod p)),
+      Finset.card_univ, ZMod.card, smul_eq_mul]
+  exact (sum_fixedBy_eq_card_necklaces_mul p k).symm.trans hsum
+
+/-- **Fermat's Little Theorem, combinatorially.**  For a prime `p` and any `k`,
+`p ∣ kᵖ − k`.  The prime-length necklace identity `|necklaces| · p = kᵖ + (p−1)·k`
+rearranges to `kᵖ − k = (kᵖ + (p−1)·k) − ((p−1)·k + k)`, a difference of two multiples
+of `p`: the `p` cyclic rotations partition the `kᵖ − k` non-constant colorings into
+orbits of size exactly `p`.  No `native_decide`, no `Lean.ofReduceBool`. -/
+theorem prime_dvd_pow_sub_self {p : ℕ} (hp : p.Prime) (k : ℕ) : p ∣ k ^ p - k := by
+  have h := necklaces_prime_length_mul hp k
+  have hdvd1 : p ∣ k ^ p + (p - 1) * k := by rw [← h]; exact dvd_mul_left p _
+  have hpk : (p - 1) * k + k = p * k := by
+    rw [Nat.sub_one_mul, Nat.sub_add_cancel (Nat.le_mul_of_pos_left k hp.pos)]
+  have hdvd2 : p ∣ (p - 1) * k + k := by rw [hpk]; exact dvd_mul_right p k
+  have hrw : k ^ p - k = (k ^ p + (p - 1) * k) - ((p - 1) * k + k) := by omega
+  rw [hrw]
+  exact Nat.dvd_sub' hdvd1 hdvd2

--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. The S5 drift repair (Mathlib v4.26) replaces every `native_decide` with kernel `decide` plus a genuine application of Mathlib's additive Burnside lemma `AddAction.sum_card_fixedBy_eq_card_orbits_mul_card_addGroup`, so the file no longer depends on `Lean.ofReduceBool`. `#print axioms fixed_point_sum_binary_4` and `#print axioms binary_necklaces_4` report only the foundational trio [propext, Classical.choice, Quot.sound]. 0 literal `axiom` declarations, 0 sorries, no assumption-carrying structures.",
-    "lineCount": 610,
-    "theoremCount": 19,
+    "lineCount": 670,
+    "theoremCount": 21,
     "definitionCount": 9,
     "originalContributions": [
       "burnside_lemma: Burnside orbit-counting theorem from Mathlib (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
@@ -72,9 +72,9 @@
   },
   "leanFile": {
     "namespace": "BurnsideCounting",
-    "lineCount": 610,
+    "lineCount": 670,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 9,
     "path": "Proofs/BurnsideCounting.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Two general theorems added to the verified Burnside gallery entry (`BurnsideCounting.lean`), both built on the file's **own** Burnside engine (`sum_fixedBy_eq_card_necklaces_mul`) and unit-rotation lemma (`fixedBy_card_of_isUnit`). **0 new axioms**, 0 sorries.

Context: OQ-02's literal task (`fixed_point_sum_binary_4` via `decide`) is already resolved on `main`. This PR contributes a genuine generalization in the spirit of the entry's open questions rather than restating settled work.

### 1. `necklaces_prime_length_mul` — closed-form count for prime length
For a prime `p` and palette size `k`:
```
|necklaces(p,k)| · p = kᵖ + (p − 1)·k
```
The identity rotation fixes all `kᵖ` colorings; every **nonzero** rotation `a : ZMod p` is a unit (as `ZMod p` is a field), so by `fixedBy_card_of_isUnit` it fixes only the `k` constant colorings. Summing the fixed-point counts over the `p` rotations and applying the Burnside engine gives the identity. This generalizes the file's concrete `binary_necklaces_3` (`p=3, k=2`: `4·3 = 8 + 2·2 = 12`).

### 2. `prime_dvd_pow_sub_self` — Fermat's Little Theorem, combinatorially
```
p prime  ⟹  p ∣ kᵖ − k
```
Obtained by rearranging the necklace identity into `kᵖ − k = (kᵖ + (p−1)k) − ((p−1)k + k)`, a difference of two multiples of `p` (`Nat.dvd_sub'`). Combinatorially: the `p` cyclic rotations partition the `kᵖ − k` non-constant colorings into free orbits of size exactly `p`. Kernel-checked; no `native_decide`, no `Lean.ofReduceBool`.

## Verification
- Elaboration is **clean**: `docker-build.sh Proofs.BurnsideCounting` type-checks the whole file in ~0.3–0.9 s across runs with **zero Lean diagnostics** (no `unsolved goals` / `type mismatch` / `failed to synthesize` in the full log).
- The olean *write* to the shared docker cache crashes with SIGBUS (exit 135/139) — a known stochastic infrastructure failure at disk-write time, not an elaboration error. Marking the additions **elaboration-clean / UNVERIFIED-write**; a clean-cache rebuild persists the olean. The additions are purely additive — no existing (verified) theorem is modified.
- `meta.json` counts synced: 19 → 21 theorems, 610 → 670 lines. Status/axiomCount unchanged (`verified` / 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)