### PR TITLE
Enrich binary-gcd-oq-03 (Lehmer-Schönhage GCD): add references

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03/meta.json
@@ -3,6 +3,32 @@
   "title": "Lehmer-Schönhage Hybrid GCD Algorithm",
   "slug": "binary-gcd-oq-03",
   "description": "Formalizes Lehmer's GCD acceleration (1938): extract top bits, run Euclidean on small approximations to get a 2×2 cofactor matrix, then apply it to full-precision inputs. Proves the core GCD invariance theorem for det ±1 integer matrices via Cramer's rule.",
+  "references": [
+    {
+      "authors": "Derrick H. Lehmer",
+      "title": "Euclid's Algorithm for Large Numbers",
+      "year": 1938,
+      "note": "American Mathematical Monthly 45(4), 227–233. Introduces the single-precision acceleration of the Euclidean algorithm via top-bit approximation and cofactor matrices, the method formalized here."
+    },
+    {
+      "authors": "Arnold Schönhage",
+      "title": "Schnelle Berechnung von Kettenbruchentwicklungen",
+      "year": 1971,
+      "note": "Acta Informatica 1(2), 139–144. The half-GCD / fast continued-fraction refinement of Lehmer's idea underlying subquadratic GCD."
+    },
+    {
+      "authors": "Donald E. Knuth",
+      "title": "The Art of Computer Programming, Vol. 2: Seminumerical Algorithms",
+      "year": 1997,
+      "note": "3rd ed., Addison-Wesley, §4.5.2, Algorithm L. Lehmer's algorithm and the correctness of the cofactor-matrix step."
+    },
+    {
+      "authors": "Torbjörn Granlund et al.",
+      "title": "GNU Multiple Precision Arithmetic Library (GMP) — mpn_gcd / HGCD",
+      "year": 2020,
+      "note": "The production Lehmer/half-GCD implementation motivating this development."
+    }
+  ],
   "meta": {
     "author": "Lehmer (1938), Schönhage (1971), formalized in Lean 4",
     "date": "1938",


### PR DESCRIPTION
## Enrichment: fill empty references

`binary-gcd-oq-03` ("Lehmer–Schönhage Hybrid GCD Algorithm") had **no `references` array**, despite the Lean docstring already naming the four canonical sources. Formalized them into the schema:

- **Lehmer, *Euclid's Algorithm for Large Numbers*** (Amer. Math. Monthly 45, 1938) — the single-precision acceleration via cofactor matrices.
- **Schönhage, *Schnelle Berechnung von Kettenbruchentwicklungen*** (Acta Informatica 1, 1971) — the half-GCD subquadratic refinement.
- **Knuth, *TAOCP* Vol. 2, §4.5.2, Algorithm L** — the textbook treatment and correctness.
- **GMP mpn_gcd / HGCD** — the production implementation.

Single-field addition; well under the 60 KB cap.