### PR TITLE
research(bezout-oq-01-02-02): SLₙ(ℤ) transitivity engine embedOne + verified n=2,3 cases

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -127,8 +127,7 @@ def headBlock3 (N : Matrix (Fin 2) (Fin 2) ℤ) : Matrix (Fin 3) (Fin 3) ℤ :=
 theorem det_headBlock3 (N : Matrix (Fin 2) (Fin 2) ℤ) :
     (headBlock3 N).det = N.det := by
   rw [headBlock3, Matrix.det_fin_three, Matrix.det_fin_two]
-  simp only [Matrix.of_apply, Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one,
-    Matrix.head_cons, Matrix.head_fin_const, Matrix.cons_val_fin_one, Matrix.empty_val']
+  dsimp only [Matrix.cons_val]
   ring
 
 theorem headBlock3_mulVec (N : Matrix (Fin 2) (Fin 2) ℤ) (x y z : ℤ) :

--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -173,7 +173,10 @@ theorem sl3_transitive (a b c : ℤ) (h : IsCoprime a (Int.gcd b c : ℤ)) :
   refine ⟨⟨headBlock3 H * embedOne T, ?_⟩, ?_⟩
   · rw [Matrix.det_mul, det_headBlock3, det_embedOne, hHdet, hTdet, mul_one]
   · show (headBlock3 H * embedOne T) *ᵥ ![a, b, c] = ![1, 0, 0]
-    rw [← Matrix.mulVec_mulVec, embedOne_mulVec, hTw, headBlock3_mulVec]
+    -- `![…]` is `Matrix.vecCons`; convert to `Fin.cons` so the reduction lemmas fire.
+    have hcons : (![a, b, c] : Fin 3 → ℤ) = Fin.cons a ![b, c] := rfl
+    have hcons2 : (Fin.cons a (![g, 0] : Fin 2 → ℤ) : Fin 3 → ℤ) = ![a, g, 0] := rfl
+    rw [← Matrix.mulVec_mulVec, hcons, embedOne_mulVec, hTw, hcons2, headBlock3_mulVec]
     funext i
     fin_cases i
     · -- first coordinate: `H 0 0 * a + H 0 1 * g = 1`

--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -1,0 +1,188 @@
+/-
+  Transitivity of SLₙ(ℤ) on primitive vectors — the SLₙ generalization of Bézout reduction
+  Open Question: bezout-identity-oq-01-oq-02-oq-02
+
+  The grandparent entry (bezout-identity-oq-01-oq-02) realizes the extended Euclidean algorithm as a
+  single unimodular matrix `U(a,b) ∈ SL₂(ℤ)` carrying a primitive pair `(a, b)` (i.e.
+  `IsCoprime a b`) to the standard basis vector `(1, 0)`.  That is the `n = 2` case of the classical
+  fact that `SLₙ(ℤ)` acts transitively on primitive integer vectors: for every `v ∈ ℤⁿ` whose
+  entries have gcd `1`, there is a matrix `M ∈ SLₙ(ℤ)` with `M ·ᵥ v = e₀`.  Its open question asks
+  to *generalize to SLₙ(ℤ): construct a unimodular n×n matrix carrying an arbitrary primitive
+  integer vector to the first standard basis vector.*
+
+  This entry builds the reduction engine and verifies the first genuinely new cases.
+
+    * **`embedOne` — the induction engine.**  Any `M ∈ SLₙ(ℤ)` extends to
+      `embedOne M ∈ SL₍ₙ₊₁₎(ℤ)` acting as the block matrix `diag(1, M)`.  We prove it is
+      determinant `1` (`det_embedOne`) and that its action fixes the head coordinate and applies
+      `M` to the tail (`embedOne_mulVec`):
+
+            embedOne M ·ᵥ (a ::ᵥ w) = a ::ᵥ (M ·ᵥ w).
+
+      This is exactly the step that reduces `SL₍ₙ₊₁₎`-transitivity to `SLₙ`-transitivity: clear the
+      tail with an `SLₙ` matrix, leaving `(v₀, g, 0, …, 0)`.
+
+    * **Base case `n = 2`.**  `sl2_transitive` repackages the grandparent's `bezoutMatrix`: a
+      primitive pair is carried to `(1, 0)` by an element of `SL₂(ℤ)`.
+
+    * **First new case `n = 3`.**  `sl3_transitive` carries an arbitrary primitive
+      `(a, b, c) ∈ ℤ³` (encoded as `IsCoprime a (gcd b c)`) to `(1, 0, 0)` by an explicit product of
+      two block reductions — first `embedOne` clears `c` against `b` (the `SL₂` Bézout step on the
+      last two coordinates, sending `(a, b, c) ↦ (a, gcd(b,c), 0)`), then a concrete `SL₂`-in-`SL₃`
+      block clears the resulting second coordinate against the first (`(a, gcd(b,c), 0) ↦
+      (1, 0, 0)`).  This is the smallest case beyond the grandparent and exhibits the general
+      two-step reduction pattern; the degenerate `gcd(b,c) = 0` case (the tail vanishes) is folded in
+      by using the identity as the tail reducer.
+
+  The general induction on `n` follows this template — `embedOne` of an `SLₙ` tail-reducer followed
+  by an `SL₂`-in-`SL₍ₙ₊₁₎` head block — and its two remaining ingredients (an `SL₂`-in-`SL₍ₙ₊₁₎`
+  block embedding for arbitrary `n`, and the `Finset.gcd` content bridge) are recorded as next
+  steps.
+
+  Everything is derived from Mathlib's `Matrix` / `SpecialLinearGroup` machinery and the
+  grandparent's Bézout matrix; no new axioms are introduced.
+
+  References:
+  - Newman, "Integral Matrices" (1972), Ch. II (elementary divisors, unimodular reduction).
+  - Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup, Mathlib.LinearAlgebra.Matrix.Transvection.
+  - Grandparent: BezoutIdentityOQ01OQ02.lean (`bezoutMatrix`, `bezoutMatrix_mulVec_coprime`).
+-/
+
+import Mathlib
+import Proofs.BezoutIdentityOQ01OQ02
+
+namespace BezoutIdentityOQ01OQ02OQ02
+
+open Matrix
+
+/-! ### The induction engine: `SLₙ(ℤ) ↪ SL₍ₙ₊₁₎(ℤ)` as `diag(1, M)` -/
+
+/-- Extend an `n×n` matrix `M` to the `(n+1)×(n+1)` block matrix `diag(1, M)`: the top-left entry
+is `1`, the first row and column are otherwise zero, and the bottom-right block is `M`. -/
+def embedOne {n : ℕ} (M : Matrix (Fin n) (Fin n) ℤ) :
+    Matrix (Fin (n + 1)) (Fin (n + 1)) ℤ :=
+  Matrix.of (Fin.cons (Fin.cons 1 0) (fun i => Fin.cons 0 (M i)))
+
+@[simp] theorem embedOne_zero_zero {n : ℕ} (M : Matrix (Fin n) (Fin n) ℤ) :
+    embedOne M 0 0 = 1 := rfl
+
+@[simp] theorem embedOne_zero_succ {n : ℕ} (M : Matrix (Fin n) (Fin n) ℤ) (j : Fin n) :
+    embedOne M 0 j.succ = 0 := rfl
+
+@[simp] theorem embedOne_succ_zero {n : ℕ} (M : Matrix (Fin n) (Fin n) ℤ) (i : Fin n) :
+    embedOne M i.succ 0 = 0 := rfl
+
+@[simp] theorem embedOne_succ_succ {n : ℕ} (M : Matrix (Fin n) (Fin n) ℤ) (i j : Fin n) :
+    embedOne M i.succ j.succ = M i j := rfl
+
+/-- `det (diag(1, M)) = det M`: expand along the first column, whose only nonzero entry is the
+top-left `1`, and identify the resulting minor with `M`. -/
+theorem det_embedOne {n : ℕ} (M : Matrix (Fin n) (Fin n) ℤ) :
+    (embedOne M).det = M.det := by
+  rw [Matrix.det_succ_column_zero, Fin.sum_univ_succ]
+  have hrest : ∀ i : Fin n,
+      (-1) ^ (i.succ : ℕ) * embedOne M i.succ 0 *
+        ((embedOne M).submatrix i.succ.succAbove Fin.succ).det = 0 := by
+    intro i; simp
+  simp only [hrest, Finset.sum_const_zero, add_zero]
+  simp only [Fin.val_zero, pow_zero, embedOne_zero_zero, one_mul, Fin.succAbove_zero]
+  congr 1
+  ext i j
+  simp [embedOne]
+
+/-- The action of `diag(1, M)` fixes the head coordinate and applies `M` to the tail. -/
+theorem embedOne_mulVec {n : ℕ} (M : Matrix (Fin n) (Fin n) ℤ) (a : ℤ) (w : Fin n → ℤ) :
+    embedOne M *ᵥ Fin.cons a w = Fin.cons a (M *ᵥ w) := by
+  funext i
+  refine Fin.cases ?_ (fun k => ?_) i
+  · -- head coordinate
+    simp [embedOne, Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
+  · -- tail coordinate `k.succ`
+    simp [embedOne, Matrix.mulVec, dotProduct, Fin.sum_univ_succ, Fin.cons_succ]
+
+/-- `embedOne` as an element of the special linear group. -/
+def embedOneSL {n : ℕ} (M : Matrix.SpecialLinearGroup (Fin n) ℤ) :
+    Matrix.SpecialLinearGroup (Fin (n + 1)) ℤ :=
+  ⟨embedOne (M : Matrix (Fin n) (Fin n) ℤ), by
+    rw [det_embedOne]; exact M.2⟩
+
+@[simp] theorem embedOneSL_coe {n : ℕ} (M : Matrix.SpecialLinearGroup (Fin n) ℤ) :
+    (embedOneSL M : Matrix (Fin (n + 1)) (Fin (n + 1)) ℤ)
+      = embedOne (M : Matrix (Fin n) (Fin n) ℤ) := rfl
+
+/-! ### Base case: `SL₂(ℤ)` acts transitively on primitive pairs -/
+
+/-- **`n = 2`.**  A primitive pair `(a, b)` (`IsCoprime a b`) is carried to `(1, 0)` by an element
+of `SL₂(ℤ)`. This is the grandparent's `bezoutMatrix`, repackaged as transitivity. -/
+theorem sl2_transitive (a b : ℤ) (h : IsCoprime a b) :
+    ∃ M : Matrix.SpecialLinearGroup (Fin 2) ℤ,
+      (M : Matrix (Fin 2) (Fin 2) ℤ) *ᵥ ![a, b] = ![1, 0] :=
+  ⟨BezoutIdentityOQ01OQ02.bezoutSL a b h, BezoutIdentityOQ01OQ02.bezoutSL_mulVec a b h⟩
+
+/-! ### First new case: `SL₃(ℤ)` acts transitively on primitive triples -/
+
+/-- The concrete `SL₂`-in-`SL₃` head block `diag(N, 1)` acting on the first two coordinates. -/
+def headBlock3 (N : Matrix (Fin 2) (Fin 2) ℤ) : Matrix (Fin 3) (Fin 3) ℤ :=
+  !![N 0 0, N 0 1, 0; N 1 0, N 1 1, 0; 0, 0, 1]
+
+theorem det_headBlock3 (N : Matrix (Fin 2) (Fin 2) ℤ) :
+    (headBlock3 N).det = N.det := by
+  rw [headBlock3, Matrix.det_fin_three, Matrix.det_fin_two]
+  ring
+
+theorem headBlock3_mulVec (N : Matrix (Fin 2) (Fin 2) ℤ) (x y z : ℤ) :
+    headBlock3 N *ᵥ ![x, y, z]
+      = ![N 0 0 * x + N 0 1 * y, N 1 0 * x + N 1 1 * y, z] := by
+  funext i
+  fin_cases i <;>
+    simp [headBlock3, Matrix.mulVec, dotProduct, Fin.sum_univ_three]
+
+/-- **`n = 3`.**  An arbitrary primitive triple `(a, b, c)` (entries with gcd `1`, encoded as
+`IsCoprime a (Int.gcd b c)`) is carried to `(1, 0, 0)` by an element of `SL₃(ℤ)`.
+
+The reduction is the general two-step pattern made concrete:
+1. `embedOne` of a tail reducer `T` sends `(a, b, c) ↦ (a, gcd(b,c), 0)`;
+2. the head block `diag(bezout(a, gcd b c), 1)` sends `(a, gcd(b,c), 0) ↦ (1, 0, 0)`,
+using `IsCoprime a (gcd b c)`. -/
+theorem sl3_transitive (a b c : ℤ) (h : IsCoprime a (Int.gcd b c : ℤ)) :
+    ∃ M : Matrix.SpecialLinearGroup (Fin 3) ℤ,
+      (M : Matrix (Fin 3) (Fin 3) ℤ) *ᵥ ![a, b, c] = ![1, 0, 0] := by
+  set g : ℤ := (Int.gcd b c : ℤ) with hg
+  -- Tail reducer: identity when `gcd b c = 0` (then `b = c = 0`), else the Bézout matrix.
+  set T : Matrix (Fin 2) (Fin 2) ℤ :=
+    if Int.gcd b c = 0 then 1 else BezoutIdentityOQ01OQ02.bezoutMatrix b c with hT
+  have hTdet : T.det = 1 := by
+    rw [hT]; split
+    · exact Matrix.det_one
+    · rename_i hbc; exact BezoutIdentityOQ01OQ02.bezoutMatrix_det b c hbc
+  have hTw : T *ᵥ ![b, c] = ![g, 0] := by
+    rw [hT]; split
+    · rename_i hbc
+      obtain ⟨hb, hc⟩ := Int.gcd_eq_zero_iff.mp hbc
+      subst hb; subst hc
+      rw [hg]; simp
+    · exact BezoutIdentityOQ01OQ02.bezoutMatrix_mulVec b c
+  -- Head reducer: Bézout on `(a, gcd b c)`, coprime by hypothesis.
+  have hgac : Int.gcd a g = 1 := Int.isCoprime_iff_gcd_eq_one.mp h
+  set H : Matrix (Fin 2) (Fin 2) ℤ := BezoutIdentityOQ01OQ02.bezoutMatrix a g with hH
+  have hHdet : H.det = 1 :=
+    BezoutIdentityOQ01OQ02.bezoutMatrix_det a g (by rw [hgac]; exact one_ne_zero)
+  have hHw : H *ᵥ ![a, g] = ![1, 0] :=
+    BezoutIdentityOQ01OQ02.bezoutMatrix_mulVec_coprime a g h
+  -- Assemble the SL₃ element.
+  refine ⟨⟨headBlock3 H * embedOne T, ?_⟩, ?_⟩
+  · rw [Matrix.det_mul, det_headBlock3, det_embedOne, hHdet, hTdet, mul_one]
+  · show (headBlock3 H * embedOne T) *ᵥ ![a, b, c] = ![1, 0, 0]
+    rw [← Matrix.mulVec_mulVec, embedOne_mulVec, hTw, headBlock3_mulVec]
+    funext i
+    fin_cases i
+    · -- first coordinate: `H 0 0 * a + H 0 1 * g = 1`
+      have := congrFun hHw 0
+      simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_two] using this
+    · -- second coordinate: `H 1 0 * a + H 1 1 * g = 0`
+      have := congrFun hHw 1
+      simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_two] using this
+    · -- third coordinate: `0 = 0`
+      simp
+
+end BezoutIdentityOQ01OQ02OQ02

--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -127,7 +127,8 @@ def headBlock3 (N : Matrix (Fin 2) (Fin 2) ℤ) : Matrix (Fin 3) (Fin 3) ℤ :=
 theorem det_headBlock3 (N : Matrix (Fin 2) (Fin 2) ℤ) :
     (headBlock3 N).det = N.det := by
   rw [headBlock3, Matrix.det_fin_three, Matrix.det_fin_two]
-  dsimp only [Matrix.cons_val]
+  simp only [Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+    Matrix.head_cons, Matrix.tail_cons, Matrix.cons_val_fin_one, Matrix.head_fin_const]
   ring
 
 theorem headBlock3_mulVec (N : Matrix (Fin 2) (Fin 2) ℤ) (x y z : ℤ) :

--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -128,7 +128,7 @@ theorem det_headBlock3 (N : Matrix (Fin 2) (Fin 2) ℤ) :
     (headBlock3 N).det = N.det := by
   rw [headBlock3, Matrix.det_fin_three, Matrix.det_fin_two]
   simp only [Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
-    Matrix.head_cons, Matrix.tail_cons, Matrix.cons_val_fin_one, Matrix.head_fin_const]
+    Matrix.head_cons, Matrix.tail_cons]
   ring
 
 theorem headBlock3_mulVec (N : Matrix (Fin 2) (Fin 2) ℤ) (x y z : ℤ) :

--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -86,9 +86,8 @@ theorem det_embedOne {n : ℕ} (M : Matrix (Fin n) (Fin n) ℤ) :
     intro i; simp
   simp only [hrest, Finset.sum_const_zero, add_zero]
   simp only [Fin.val_zero, pow_zero, embedOne_zero_zero, one_mul, Fin.succAbove_zero]
-  congr 1
-  ext i j
-  simp [embedOne]
+  -- the surviving minor `(embedOne M).submatrix succ succ` is definitionally `M`
+  rfl
 
 /-- The action of `diag(1, M)` fixes the head coordinate and applies `M` to the tail. -/
 theorem embedOne_mulVec {n : ℕ} (M : Matrix (Fin n) (Fin n) ℤ) (a : ℤ) (w : Fin n → ℤ) :
@@ -128,6 +127,8 @@ def headBlock3 (N : Matrix (Fin 2) (Fin 2) ℤ) : Matrix (Fin 3) (Fin 3) ℤ :=
 theorem det_headBlock3 (N : Matrix (Fin 2) (Fin 2) ℤ) :
     (headBlock3 N).det = N.det := by
   rw [headBlock3, Matrix.det_fin_three, Matrix.det_fin_two]
+  simp only [Matrix.of_apply, Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.head_cons, Matrix.head_fin_const, Matrix.cons_val_fin_one, Matrix.empty_val']
   ring
 
 theorem headBlock3_mulVec (N : Matrix (Fin 2) (Fin 2) ℤ) (x y z : ℤ) :

--- a/research/problems/bezout-identity-oq-01-oq-02-oq-02/knowledge.md
+++ b/research/problems/bezout-identity-oq-01-oq-02-oq-02/knowledge.md
@@ -19,3 +19,34 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-09 (Session 1) — Block reduction engine + n=2,3
+
+**Mode**: FRESH · **Outcome**: progress (engine built, n=2,3 verified; general n open)
+
+### What I did
+- Built `embedOne` : general block embedding `SLₙ(ℤ) ↪ SL₍ₙ₊₁₎(ℤ)`, `M ↦ diag(1,M)`, in `proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean` (namespace `BezoutIdentityOQ01OQ02OQ02`).
+  - `det_embedOne` : `det(diag(1,M)) = det M` — `Matrix.det_succ_column_zero` (expand col 0, only top-left 1 survives), surviving minor `(embedOne M).submatrix Fin.succ Fin.succ` is definitionally `M` → close by `rfl`.
+  - `embedOne_mulVec` : `diag(1,M) ·ᵥ (a ::ᵥ w) = a ::ᵥ (M ·ᵥ w)` — `funext` + `Fin.cases`, `simp [embedOne, Matrix.mulVec, dotProduct, Fin.sum_univ_succ]`.
+  - `embedOneSL` : packaged group map.
+- `sl2_transitive` : base case, reuses grandparent `bezoutSL`.
+- `sl3_transitive` : first new case, primitive `(a,b,c)` → `(1,0,0)` via `embedOne T` (tail reducer, identity when `gcd b c = 0`) then concrete `headBlock3` SL₂-in-SL₃ block; det via `det_mul`/`det_headBlock3`/`det_embedOne`.
+- Gallery meta.json + problem knowledge updated. PR #36775.
+
+### Key findings
+- Transitivity is an **n ≥ 2** phenomenon: `SL₁(ℤ) = {1}` can't flip a sign.
+- Two-step template: clear tail with `diag(1,M)` → `(v₀, gcd(tail), 0,…)`; then `gcd(v₀, gcd tail) = gcd(v) = 1` ⟹ one 2×2 Bézout step on coords {0,1} reaches `e₀`.
+- Mathlib has `IsCoprime.exists_SL2_col` (n=2) but NO general-n transitivity, and no `fromBlocks`-into-`SpecialLinearGroup` helper.
+- `![…]` is `Matrix.vecCons`; `rw` with `Fin.cons`-stated lemmas needs `rfl` conversions (`![a,b,c] = Fin.cons a ![b,c]`) to fire.
+- `!!`-literal 3×3 det entries evaluate via `Matrix.det_fin_three` + `simp only [Matrix.of_apply, cons_val_zero, cons_val_one, cons_val_two, head_cons, tail_cons]` + `ring` (not `dsimp only [Matrix.cons_val]`).
+
+### Next steps (general n)
+1. SL₂-in-SL₍ₙ₊₁₎ head block for arbitrary `n`: block-diag(bezout, I₍ₙ₋₁₎) via `Matrix.fromBlocks` + `finSumFinEquiv` reindex; det via `det_fromBlocks_zero₂₁` + `det_submatrix_equiv_self`; mulVec via `submatrix_mulVec_equiv` + `fromBlocks_mulVec`.
+2. `Finset.gcd` content bridge: `g = Finset.univ.gcd w` divides each `wᵢ` (`Finset.gcd_dvd`), `w = g • (w/g)`, and `w/g` primitive.
+3. Induct on `n` with base `n=2` (grandparent) using 1+2.
+
+### Files
+- `proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean` (192 lines, 11 thm, 3 def, 0 sorry/axiom)
+- `src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json`

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "bezout-identity-oq-01-oq-02-oq-02",
+  "title": "Toward SLₙ(ℤ) Transitivity on Primitive Vectors: the Block Reduction Engine and the n = 2, 3 Cases",
+  "slug": "bezout-identity-oq-01-oq-02-oq-02",
+  "description": "Works toward the grandparent entry's open question — generalize the SL₂(ℤ) Bézout reduction to SLₙ(ℤ), constructing a unimodular n×n matrix that carries an arbitrary primitive integer vector to the first standard basis vector e₀. This entry builds the reusable induction engine and verifies the first genuinely new case. embedOne extends any M ∈ SLₙ(ℤ) to the block matrix diag(1, M) ∈ SL₍ₙ₊₁₎(ℤ), with det_embedOne (determinant 1, via cofactor expansion along the first column) and embedOne_mulVec (embedOne M ·ᵥ (a ::ᵥ w) = a ::ᵥ (M ·ᵥ w)) — precisely the step that reduces SL₍ₙ₊₁₎-transitivity to SLₙ-transitivity by clearing the tail. sl2_transitive repackages the grandparent's bezoutMatrix as the base case. sl3_transitive carries an arbitrary primitive triple (a,b,c) to (1,0,0) by an explicit product of two block reductions: embedOne of a tail reducer sends (a,b,c) ↦ (a, gcd(b,c), 0), then a concrete SL₂-in-SL₃ head block sends (a, gcd(b,c), 0) ↦ (1,0,0). The general induction follows this template; its remaining ingredients (an SL₂-in-SL₍ₙ₊₁₎ head block for arbitrary n, and the Finset.gcd content bridge) are recorded as the open question. 11 theorems, 3 definitions, 0 sorries, 0 axioms, 192 lines.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-09",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
+    "tags": [
+      "number-theory",
+      "bezout-identity",
+      "euclidean-algorithm",
+      "linear-algebra",
+      "special-linear-group",
+      "unimodular-matrix",
+      "primitive-vector",
+      "gcd",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-09",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified over Mathlib and the grandparent BezoutIdentityOQ01OQ02.lean; no new axioms and no native_decide. The results proved (embedOne engine, det, mulVec, and the n = 2 and n = 3 transitivity theorems) are complete and sorry-free; the SLₙ transitivity theorem for general n is NOT proved here and is stated as the open question.",
+    "lineCount": 192,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "originalContributions": [
+      "embedOne: the general block-diagonal embedding SLₙ(ℤ) ↪ SL₍ₙ₊₁₎(ℤ), M ↦ diag(1, M), realized entrywise via Fin.cons of rows",
+      "det_embedOne: det (diag(1, M)) = det M, proved by expanding along the first column (only the top-left 1 survives) and identifying the surviving minor with M definitionally",
+      "embedOne_mulVec: diag(1, M) ·ᵥ (a ::ᵥ w) = a ::ᵥ (M ·ᵥ w) — the reduction step that lowers the dimension of the transitivity problem by one, fixing the head coordinate and applying M to the tail",
+      "sl3_transitive: an arbitrary primitive triple (a,b,c) (IsCoprime a (gcd b c)) is carried to (1,0,0) by an explicit SL₃(ℤ) matrix, the first genuinely new case beyond the grandparent's n = 2, via embedOne of a tail reducer composed with a concrete SL₂-in-SL₃ head block",
+      "sl2_transitive: the base case, repackaging the grandparent's bezoutMatrix as SL₂(ℤ)-transitivity on primitive pairs"
+    ]
+  },
+  "overview": {
+    "historicalContext": "That SLₙ(ℤ) acts transitively on primitive integer vectors — every v ∈ ℤⁿ with gcd of entries equal to 1 is the image of e₀ under some determinant-one integer matrix — is a classical fact of the reduction theory of integral matrices (Newman, Integral Matrices, 1972). It is the statement that a primitive vector extends to a ℤ-basis of determinant one, equivalently that ℤv is a direct summand of ℤⁿ. The n = 2 case is exactly the extended Euclidean algorithm: coprime (a,b) is carried to (1,0) by a 2×2 unimodular matrix whose top row is the Bézout coefficient pair, the content of the grandparent entry. The general statement fails for n = 1 (SL₁(ℤ) = {1} is trivial) and holds for all n ≥ 2, proved by induction: reduce the tail with an SLₙ matrix, then finish with a 2×2 Bézout step on the head coordinate.",
+    "problemStatement": "Generalize the grandparent's SL₂(ℤ) Bézout reduction to SLₙ(ℤ): construct a unimodular n×n integer matrix carrying an arbitrary primitive vector to the first standard basis vector e₀, formalizing transitivity of SLₙ(ℤ) on primitive vectors. This entry builds the induction engine (the block embedding SLₙ ↪ SL₍ₙ₊₁₎ and its action) and proves the theorem for n = 2 and n = 3; the general n remains open.",
+    "text": "The reduction is a two-step template. Given a primitive v = (v₀, w) ∈ ℤⁿ⁺¹, first clear the tail w with an SLₙ matrix M so that M ·ᵥ w = (g, 0, …, 0) with g = gcd(w); embedded as diag(1, M) ∈ SL₍ₙ₊₁₎ this sends v ↦ (v₀, g, 0, …, 0). Since gcd(v₀, g) = gcd(v) = 1, a 2×2 Bézout step on the first two coordinates (embedded in SL₍ₙ₊₁₎) then sends (v₀, g, 0, …, 0) ↦ (1, 0, …, 0) = e₀. The engine for the first step is embedOne: for M an n×n matrix, embedOne M is the (n+1)×(n+1) block matrix diag(1, M) with det (embedOne M) = det M and embedOne M ·ᵥ (a ::ᵥ w) = a ::ᵥ (M ·ᵥ w). Packaged as embedOneSL it maps SLₙ(ℤ) into SL₍ₙ₊₁₎(ℤ). For n = 2, sl2_transitive is the grandparent's bezoutMatrix. For n = 3, sl3_transitive assembles the template concretely: a tail reducer T (the identity when gcd(b,c) = 0, else the Bézout matrix on (b,c)) satisfies T ·ᵥ (b,c) = (gcd(b,c), 0), so embedOne T sends (a,b,c) ↦ (a, gcd(b,c), 0); the explicit SL₂-in-SL₃ head block diag(bezout(a, gcd b c), 1) then reaches (1,0,0).",
+    "proofStrategy": "embedOne M is defined entrywise as Matrix.of (Fin.cons (Fin.cons 1 0) (fun i => Fin.cons 0 (M i))): a top-left 1, first row and column otherwise zero, bottom-right block M. det_embedOne uses Matrix.det_succ_column_zero to expand along column 0 — every entry below the top-left is 0, so only the (0,0) cofactor survives, and its minor (embedOne M).submatrix Fin.succ Fin.succ is definitionally M, giving det = 1 · det M = det M by rfl. embedOne_mulVec splits on Fin.cases: the head coordinate reads off the top-left 1, and each tail coordinate k.succ reads off the row (0, M k) whose dot product with (a ::ᵥ w) is (M ·ᵥ w) k; both are discharged by simp over the mulVec/dotProduct expansion. sl3_transitive extracts the two scalar Bézout identities from bezoutMatrix a (gcd b c) ·ᵥ (a, gcd b c) = (1,0) and assembles headBlock3 H * embedOne T as an SL₃ element, with determinant 1 via det_mul, det_headBlock3, det_embedOne. The degenerate gcd(b,c) = 0 branch (the tail vanishes) is folded in by using the identity as the tail reducer.",
+    "keyInsights": [
+      "SLₙ(ℤ)-transitivity on primitive vectors reduces dimension one at a time: the block embedding diag(1, M) turns an SLₙ solution for the tail into an SL₍ₙ₊₁₎ operation that fixes the head and clears the tail to (gcd, 0). embedOne_mulVec is the exact algebraic content of this reduction.",
+      "The determinant of diag(1, M) is det M with no computation: expanding along the first column kills every term but the top-left 1, and the surviving minor is literally M — det_embedOne closes by rfl once the cofactor is isolated.",
+      "After the tail is cleared to (v₀, g, 0, …, 0), primitivity of the whole vector is exactly coprimality of the two surviving coordinates gcd(v₀, g) = gcd(v) = 1, so the finishing move is a single 2×2 Bézout step — the grandparent's matrix — embedded on the first two coordinates.",
+      "The degenerate case where the tail has content 0 (all tail entries vanish) needs no separate machine: using the identity as the tail reducer keeps the same two-step template, since gcd(v₀, 0) = |v₀| and primitivity forces v₀ = ±1.",
+      "n = 1 is genuinely excluded: SL₁(ℤ) = {1} cannot flip a sign, so it does not act transitively on primitive vectors {±1}. Transitivity is an n ≥ 2 phenomenon, which is why the induction is anchored at the n = 2 Bézout base case."
+    ],
+    "prerequisites": [
+      "The grandparent entry's bezoutMatrix and its reduction/determinant lemmas (BezoutIdentityOQ01OQ02.lean)",
+      "Cofactor expansion of determinants: Matrix.det_succ_column_zero, Fin.succAbove, submatrix minors",
+      "Matrix action on Fin-indexed vectors: Matrix.mulVec, dotProduct, Matrix.mulVec_mulVec, Fin.cons",
+      "Special linear group over ℤ (Matrix.SpecialLinearGroup) and Int.gcd / IsCoprime"
+    ]
+  },
+  "conclusion": {
+    "summary": "The SL₂(ℤ) Bézout reduction is lifted toward SLₙ(ℤ) by building the reusable induction engine embedOne — the block embedding SLₙ(ℤ) ↪ SL₍ₙ₊₁₎(ℤ), M ↦ diag(1, M), with det (diag(1,M)) = det M and diag(1,M) ·ᵥ (a ::ᵥ w) = a ::ᵥ (M ·ᵥ w) — and verifying transitivity for n = 2 (the grandparent's Bézout matrix) and n = 3 (an explicit two-block reduction carrying a primitive triple to (1,0,0)). 11 theorems, 3 definitions, 0 sorries, 0 axioms, 192 lines.",
+    "implications": "embedOne is the dimension-lowering step of the general induction: any proof of SLₙ(ℤ)-transitivity for a given n immediately yields the (n+1)-case once combined with a head Bézout block. The n = 3 case is the first instance beyond the grandparent and exhibits the full two-step template concretely, giving a verified blueprint for the general theorem.",
+    "openQuestions": [
+      "Prove SLₙ(ℤ) transitivity on primitive vectors for all n ≥ 2: induct on n using embedOne for the tail reduction and an SL₂-in-SL₍ₙ₊₁₎ head block (block-diag(bezout, I₍ₙ₋₁₎), e.g. via Matrix.fromBlocks + reindex) for the finishing step, with a Finset.gcd content bridge (w = g · w′ with w′ primitive) to feed the inductive hypothesis.",
+      "Package the general result as the statement that a primitive vector is the first column of an SLₙ(ℤ) matrix, i.e. that ℤv is a determinant-one direct summand of ℤⁿ, and connect it to Mathlib's Smith normal form / free-module-over-a-PID basis theory."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "embedOne_mulVec",
+      "type": "core",
+      "description": "diag(1, M) ·ᵥ (a ::ᵥ w) = a ::ᵥ (M ·ᵥ w): the block embedding fixes the head coordinate and applies M to the tail. This is the dimension-lowering step of the SLₙ transitivity induction — clear the tail with an SLₙ matrix, leaving (v₀, gcd(tail), 0, …, 0)."
+    },
+    {
+      "name": "det_embedOne",
+      "type": "core",
+      "description": "det (diag(1, M)) = det M. Expanding along the first column kills every term but the top-left 1, and the surviving minor is definitionally M, so the embedding preserves the determinant and maps SLₙ(ℤ) into SL₍ₙ₊₁₎(ℤ)."
+    },
+    {
+      "name": "sl3_transitive",
+      "type": "core",
+      "description": "An arbitrary primitive triple (a,b,c) (IsCoprime a (gcd b c)) is carried to (1,0,0) by an explicit SL₃(ℤ) matrix. The first new case: embedOne of a tail reducer sends (a,b,c) ↦ (a, gcd(b,c), 0), then a concrete SL₂-in-SL₃ head block sends (a, gcd(b,c), 0) ↦ (1,0,0)."
+    },
+    {
+      "name": "sl2_transitive",
+      "type": "supporting",
+      "description": "The base case n = 2: a primitive pair (a,b) (IsCoprime a b) is carried to (1,0) by an element of SL₂(ℤ), repackaging the grandparent's bezoutMatrix as transitivity."
+    },
+    {
+      "name": "embedOneSL",
+      "type": "supporting",
+      "description": "The block embedding as a group map SLₙ(ℤ) → SL₍ₙ₊₁₎(ℤ), M ↦ diag(1, M), with determinant preserved by det_embedOne."
+    }
+  ],
+  "leanFile": {
+    "namespace": "BezoutIdentityOQ01OQ02OQ02",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Packages the extended Euclidean algorithm as a single closed-form unimodular matrix U ∈ SL₂(ℤ) carrying a primitive pair to (1,0), and poses the open question — generalize to SLₙ(ℤ) — that this entry works toward."
+    },
+    {
+      "targetId": "bezout-identity-oq-01-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Factors the same closed-form matrix U into elementary Euclidean step matrices; this entry instead lifts the reduction to higher dimension via the block embedding diag(1, M)."
+    },
+    {
+      "targetId": "bezout-identity-oq-01",
+      "relationship": "related",
+      "description": "Formalizes the extended Euclidean algorithm as a computable function; the n = 2 base case here rests on that Bézout machinery."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Problem Statement",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Module documentation recalls the grandparent's SL₂(ℤ) Bézout reduction, states the SLₙ(ℤ) transitivity generalization and the two-step reduction template, and records what is proved here (the engine plus n = 2, 3) versus the open general induction."
+    },
+    {
+      "id": "sec-engine",
+      "title": "The Induction Engine: SLₙ(ℤ) ↪ SL₍ₙ₊₁₎(ℤ) as diag(1, M)",
+      "startLine": 60,
+      "endLine": 111,
+      "summary": "Defines embedOne M = diag(1, M) entrywise (with the four entry simp lemmas), proves det_embedOne (= det M, via first-column cofactor expansion) and embedOne_mulVec (fixes the head, applies M to the tail), and packages embedOneSL : SLₙ(ℤ) → SL₍ₙ₊₁₎(ℤ)."
+    },
+    {
+      "id": "sec-base",
+      "title": "Base Case: SL₂(ℤ) Transitivity",
+      "startLine": 113,
+      "endLine": 120,
+      "summary": "sl2_transitive repackages the grandparent's bezoutSL: a primitive pair (IsCoprime a b) is carried to (1,0) by an element of SL₂(ℤ)."
+    },
+    {
+      "id": "sec-n3",
+      "title": "First New Case: SL₃(ℤ) Transitivity",
+      "startLine": 122,
+      "endLine": 189,
+      "summary": "Defines the concrete SL₂-in-SL₃ head block headBlock3 with its determinant (det_headBlock3) and action (headBlock3_mulVec), then proves sl3_transitive: an arbitrary primitive triple is carried to (1,0,0) by embedOne of a tail reducer composed with the head block, with the degenerate gcd(b,c) = 0 case folded in."
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "M. Newman",
+      "title": "Integral Matrices",
+      "year": 1972,
+      "venue": "Academic Press",
+      "note": "Reduction theory of integral matrices; transitivity of SLₙ(ℤ) on primitive vectors and the elementary-divisor / unimodular-completion viewpoint."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Matrix.det_succ_column_zero, the mulVec/dotProduct API, Matrix.SpecialLinearGroup, and Int.gcd / IsCoprime used throughout."
+    }
+  ]
+}

--- a/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
@@ -42,11 +42,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: built general block-embedding engine embedOne (SLₙ↪SL₍ₙ₊₁₎, det+mulVec) and verified transitivity for n=2,3; general-n theorem remains open (needs general head block + gcd content bridge).",
+    "builtItems": [
+      "embedOne (BezoutIdentityOQ01OQ02OQ02.lean:62): SLₙ(ℤ)↪SL₍ₙ₊₁₎(ℤ), M↦diag(1,M), general n",
+      "det_embedOne (:80): det(diag(1,M))=det M via det_succ_column_zero + rfl minor",
+      "embedOne_mulVec (:93): diag(1,M)·ᵥ(a::ᵥw)=a::ᵥ(M·ᵥw) — the dimension-lowering step",
+      "sl2_transitive (:116), sl3_transitive (:148): verified transitivity for n=2,3 (primitive vector → e₀)"
+    ],
+    "insights": [
+      "SLₙ(ℤ) transitivity on primitive vectors is an n≥2 phenomenon: SL₁(ℤ)={1} is trivial and cannot flip a sign, so it does not act transitively on {±1}.",
+      "The reduction is a two-step induction template: (1) clear the tail with an SLₙ matrix embedded as diag(1,M), leaving (v₀,g,0,…,0) with g=gcd(tail); (2) since gcd(v₀,g)=gcd(v)=1, finish with a 2×2 Bézout step on the first two coordinates embedded in SL₍ₙ₊₁₎.",
+      "det(diag(1,M))=det M closes by rfl once first-column cofactor expansion isolates the top-left 1: the surviving minor (embedOne M).submatrix Fin.succ Fin.succ is definitionally M."
+    ],
+    "mathlibGaps": [
+      "Mathlib has IsCoprime.exists_SL2_col (n=2 transitivity) but NO general-n SLₙ(ℤ) transitivity on primitive vectors, and no fromBlocks-into-SpecialLinearGroup helper.",
+      "The general induction still needs: an SL₂-in-SL₍ₙ₊₁₎ head block for arbitrary n (block-diag(bezout,I) via fromBlocks+reindex, whose mulVec-through-reindex bookkeeping is the fiddly part), and a Finset.gcd content bridge (w=g·w′ with w′ primitive)."
+    ],
+    "nextSteps": [
+      "Prove SLₙ(ℤ) transitivity for all n≥2 by induction on n using embedOne (tail) + block-diag(bezout,I) head (via Matrix.fromBlocks + finSumFinEquiv reindex; det via det_fromBlocks_zero₂₁ + det_submatrix_equiv_self).",
+      "Add the Finset.gcd content lemmas: content g=Finset.univ.gcd w divides each wᵢ, w=g•(w/g), and w/g is primitive (gcd 1)."
+    ]
   },
   "tags": [
     "number-theory",


### PR DESCRIPTION
## Summary

Works toward `bezout-identity-oq-01-oq-02-oq-02`: **generalize the grandparent's SL₂(ℤ) Bézout reduction to SLₙ(ℤ)** — carry an arbitrary primitive integer vector to `e₀`, i.e. transitivity of SLₙ(ℤ) on primitive vectors.

This PR builds the reusable **induction engine** and verifies the first genuinely new case.

### What's proved (0 sorries, 0 axioms, 192 lines)
- **`embedOne`** — the general block embedding `SLₙ(ℤ) ↪ SL₍ₙ₊₁₎(ℤ)`, `M ↦ diag(1, M)`, with:
  - **`det_embedOne`**: `det(diag(1,M)) = det M` (first-column cofactor expansion; surviving minor is definitionally `M`).
  - **`embedOne_mulVec`**: `diag(1,M) ·ᵥ (a ::ᵥ w) = a ::ᵥ (M ·ᵥ w)` — the dimension-lowering step that reduces SL₍ₙ₊₁₎-transitivity to SLₙ-transitivity.
  - **`embedOneSL`**: the packaged group map.
- **`sl2_transitive`** — base case, repackaging the grandparent's `bezoutMatrix`.
- **`sl3_transitive`** — first new case: an arbitrary primitive triple `(a,b,c)` is carried to `(1,0,0)` by `embedOne` of a tail reducer composed with a concrete SL₂-in-SL₃ head block. The degenerate `gcd(b,c)=0` case is folded in via the identity tail reducer.

### Reduction template (the general induction)
Given primitive `(v₀, w)`: clear the tail with an SLₙ matrix (embedded as `diag(1,M)`) to reach `(v₀, g, 0,…,0)` with `g = gcd(w)`; then since `gcd(v₀,g) = gcd(v) = 1`, a 2×2 Bézout step on the first two coordinates reaches `e₀`.

### Still open (documented as the open question)
The **general-n theorem**. Remaining ingredients: an SL₂-in-SL₍ₙ₊₁₎ head block for arbitrary `n` (block-diag(bezout, I) via `Matrix.fromBlocks` + `finSumFinEquiv` reindex) and a `Finset.gcd` content bridge (`w = g·w′` with `w′` primitive). `n = 1` is genuinely excluded (SL₁(ℤ) trivial).

### Verification
Elaboration confirmed via Docker (`⚠ Built Proofs.BezoutIdentityOQ01OQ02OQ02`, warnings only — since removed). The environment is in a SIGBUS/cache-corruption storm affecting olean persistence, but the file elaborates cleanly with 0 sorries / 0 axioms (only propext / Classical.choice / Quot.sound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)