### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): SLₙ(ℤ) primitivity-invariance foundation for transitivity

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -1,0 +1,142 @@
+/-
+# Primitive integer vectors and the `SLₙ(ℤ)` action
+
+Research: bezout-identity-oq-01-oq-02-oq-02
+
+The parent proof `bezout-identity-oq-01-oq-02` builds, for a coprime pair `(a, b)`,
+an explicit `bezoutSL a b ∈ SL₂(ℤ)` carrying `(a, b)` to the first basis vector
+`(1, 0)`.  The open question asks to generalize this to `n` coordinates:
+construct a unimodular `n × n` matrix carrying an arbitrary **primitive** integer
+vector to `e₁`, i.e. to establish transitivity of the `SLₙ(ℤ)`-action on
+primitive vectors.
+
+The full transitivity statement `∀ v primitive, ∃ U ∈ SLₙ(ℤ), U · v = e₁`
+requires a Euclidean descent (an iterated Bézout reduction across coordinates).
+This file builds the **invariant-theoretic foundation** that any such descent
+must respect, all fully machine-checked with no new axioms:
+
+* `IsPrimitive v` — the coordinate-free notion: `v` has an integer *dual*
+  `w` with `w · v = 1` (dot product).  Over `ℤ` this is exactly the classical
+  "entries generate the unit ideal" / "gcd of the entries is `1`"; see
+  `isPrimitive_iff_span_eq_top`.
+* `isPrimitive_single` — the target vector `eᵢ` is primitive.
+* `IsPrimitive.mulVec` / `isPrimitive_mulVec_iff` — **`SLₙ(ℤ)` preserves
+  primitivity**, in both directions.  This is the exact invariance the
+  transitivity action lives inside: the `SLₙ(ℤ)`-orbit of `e₁` consists
+  precisely of primitive vectors on the "reachable" side, and no unimodular move
+  can leave the primitive locus.
+* `transvectionSL` — the elementary generators: each transvection
+  `I + c·Eᵢⱼ` (`i ≠ j`) is packaged as an element of `SLₙ(ℤ)`, with its explicit
+  action `transvectionSL_mulVec` adding `c·vⱼ` to `vᵢ`.  These are the atomic
+  moves of the Euclidean descent, and (being in `SLₙ(ℤ)`) they preserve
+  primitivity by the general lemma.
+* `orbit_e_isPrimitive` — the "easy half" of transitivity assembled from the
+  above: everything in the `SLₙ(ℤ)`-orbit of `eᵢ` is primitive.  The converse
+  (every primitive vector is in the orbit) is the remaining Euclidean-descent
+  step recorded for future work.
+-/
+import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+import Mathlib.LinearAlgebra.Matrix.Transvection
+import Mathlib.RingTheory.Ideal.Span
+import Mathlib.RingTheory.Ideal.Operations
+import Mathlib.Tactic
+
+namespace BezoutPrimitive
+
+open Matrix
+
+variable {n : ℕ}
+
+local notation:1024 "↑ₘ" A:1024 =>
+  ((A : Matrix.SpecialLinearGroup (Fin n) ℤ) : Matrix (Fin n) (Fin n) ℤ)
+
+/-! ### Primitive vectors -/
+
+/-- An integer vector `v` is **primitive** if it has an integer *dual*: a vector
+`w` with `w ⬝ᵥ v = 1`.  Equivalently (over `ℤ`, a Bézout domain) the entries of
+`v` are setwise coprime, i.e. their gcd is `1`.  This dot-product form is
+manifestly `SLₙ(ℤ)`-invariant, which is why it is the convenient notion for the
+transitivity question. -/
+def IsPrimitive (v : Fin n → ℤ) : Prop := ∃ w : Fin n → ℤ, w ⬝ᵥ v = 1
+
+/-- **The standard basis vector `eᵢ` is primitive** — its own indicator is a dual
+pairing to `1`.  This is the target of the transitivity reduction. -/
+theorem isPrimitive_single (i : Fin n) : IsPrimitive (Pi.single i (1 : ℤ)) := by
+  refine ⟨Pi.single i 1, ?_⟩
+  simp [dotProduct, Pi.single_apply, Finset.sum_ite_eq]
+
+/-- **Bridge to the classical notion.**  `v` is primitive iff its entries
+generate the unit ideal of `ℤ`, i.e. `Ideal.span (range v) = ⊤`.  Over `ℤ` the
+right-hand side says exactly that the gcd of the entries is a unit. -/
+theorem isPrimitive_iff_span_eq_top (v : Fin n → ℤ) :
+    IsPrimitive v ↔ Ideal.span (Set.range v) = ⊤ := by
+  rw [Ideal.eq_top_iff_one, Ideal.span, Submodule.mem_span_range_iff_exists_fun]
+  constructor
+  · rintro ⟨w, hw⟩
+    exact ⟨w, by simpa [dotProduct, smul_eq_mul, mul_comm] using hw⟩
+  · rintro ⟨c, hc⟩
+    exact ⟨c, by simpa [dotProduct, smul_eq_mul, mul_comm] using hc⟩
+
+/-! ### `SLₙ(ℤ)` preserves primitivity -/
+
+/-- **`SLₙ(ℤ)` sends primitive vectors to primitive vectors.**  If `w ⬝ᵥ v = 1`
+then `(w ᵥ* ↑ₘA⁻¹) ⬝ᵥ (↑ₘA *ᵥ v) = 1`, because `↑ₘA⁻¹ * ↑ₘA = 1`.  So the
+transformed dual `w ᵥ* ↑ₘA⁻¹` witnesses primitivity of `↑ₘA *ᵥ v`. -/
+theorem IsPrimitive.mulVec (A : Matrix.SpecialLinearGroup (Fin n) ℤ)
+    {v : Fin n → ℤ} (h : IsPrimitive v) : IsPrimitive (↑ₘA *ᵥ v) := by
+  obtain ⟨w, hw⟩ := h
+  refine ⟨w ᵥ* ↑ₘ(A⁻¹), ?_⟩
+  have hinv : ↑ₘ(A⁻¹) * ↑ₘA = 1 := by
+    rw [← SpecialLinearGroup.coe_mul, inv_mul_cancel, SpecialLinearGroup.coe_one]
+  rw [dotProduct_mulVec, vecMul_vecMul, hinv, vecMul_one, hw]
+
+/-- **`SLₙ(ℤ)` preserves primitivity, both directions.**  Since `↑ₘA⁻¹ *ᵥ (↑ₘA *ᵥ v) = v`,
+the forward lemma applied to `A⁻¹` gives the reverse implication. -/
+theorem isPrimitive_mulVec_iff (A : Matrix.SpecialLinearGroup (Fin n) ℤ)
+    (v : Fin n → ℤ) : IsPrimitive (↑ₘA *ᵥ v) ↔ IsPrimitive v := by
+  refine ⟨fun h => ?_, fun h => h.mulVec A⟩
+  have h2 := h.mulVec A⁻¹
+  rwa [← mulVec_mulVec, ← SpecialLinearGroup.coe_mul, inv_mul_cancel,
+    SpecialLinearGroup.coe_one, one_mulVec] at h2
+
+/-! ### Elementary generators: transvections in `SLₙ(ℤ)` -/
+
+/-- The **transvection** `I + c·Eᵢⱼ` (`i ≠ j`), packaged as an element of
+`SLₙ(ℤ)`.  These are the elementary Bézout moves of the Euclidean descent that
+proves transitivity; each has determinant `1`. -/
+def transvectionSL (i j : Fin n) (h : i ≠ j) (c : ℤ) :
+    Matrix.SpecialLinearGroup (Fin n) ℤ :=
+  ⟨Matrix.transvection i j c, Matrix.det_transvection_of_ne h c⟩
+
+/-- **Action of a transvection on a vector.**  `transvectionSL i j h c` adds
+`c · vⱼ` to the `i`-th coordinate of `v` and leaves the others fixed — one
+elementary step of Bézout reduction. -/
+theorem transvectionSL_mulVec (i j : Fin n) (h : i ≠ j) (c : ℤ) (v : Fin n → ℤ) :
+    ↑ₘ(transvectionSL i j h c) *ᵥ v = Function.update v i (v i + c * v j) := by
+  show Matrix.transvection i j c *ᵥ v = _
+  rw [Matrix.transvection, add_mulVec, one_mulVec, single_mulVec]
+  funext k
+  rcases eq_or_ne k i with rfl | hk
+  · simp
+  · simp [Function.update_of_ne hk, Function.update_of_ne (a := (0 : Fin n → ℤ)) hk]
+
+/-- **A transvection preserves primitivity** — a special case of
+`IsPrimitive.mulVec`, recorded because transvections are the atomic moves of the
+descent. -/
+theorem IsPrimitive.transvection (i j : Fin n) (h : i ≠ j) (c : ℤ) {v : Fin n → ℤ}
+    (hv : IsPrimitive v) : IsPrimitive (Function.update v i (v i + c * v j)) := by
+  rw [← transvectionSL_mulVec i j h c v]
+  exact hv.mulVec _
+
+/-! ### The easy half of transitivity -/
+
+/-- **Every vector in the `SLₙ(ℤ)`-orbit of a basis vector is primitive.**  This
+is the "necessity" half of the transitivity characterization: primitivity is a
+necessary condition for a vector to be `SLₙ(ℤ)`-equivalent to `eᵢ`.  The converse
+— that primitivity is also *sufficient* (every primitive vector is in the orbit)
+— is the remaining Euclidean-descent construction. -/
+theorem orbit_e_isPrimitive (A : Matrix.SpecialLinearGroup (Fin n) ℤ) (i : Fin n) :
+    IsPrimitive (↑ₘA *ᵥ Pi.single i (1 : ℤ)) :=
+  (isPrimitive_single i).mulVec A
+
+end BezoutPrimitive

--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean
@@ -70,7 +70,7 @@ generate the unit ideal of `ℤ`, i.e. `Ideal.span (range v) = ⊤`.  Over `ℤ`
 right-hand side says exactly that the gcd of the entries is a unit. -/
 theorem isPrimitive_iff_span_eq_top (v : Fin n → ℤ) :
     IsPrimitive v ↔ Ideal.span (Set.range v) = ⊤ := by
-  rw [Ideal.eq_top_iff_one, Ideal.span, Submodule.mem_span_range_iff_exists_fun]
+  rw [Ideal.eq_top_iff_one, Ideal.mem_span_range_iff_exists_fun]
   constructor
   · rintro ⟨w, hw⟩
     exact ⟨w, by simpa [dotProduct, smul_eq_mul, mul_comm] using hw⟩
@@ -96,7 +96,7 @@ theorem isPrimitive_mulVec_iff (A : Matrix.SpecialLinearGroup (Fin n) ℤ)
     (v : Fin n → ℤ) : IsPrimitive (↑ₘA *ᵥ v) ↔ IsPrimitive v := by
   refine ⟨fun h => ?_, fun h => h.mulVec A⟩
   have h2 := h.mulVec A⁻¹
-  rwa [← mulVec_mulVec, ← SpecialLinearGroup.coe_mul, inv_mul_cancel,
+  rwa [mulVec_mulVec, ← SpecialLinearGroup.coe_mul, inv_mul_cancel,
     SpecialLinearGroup.coe_one, one_mulVec] at h2
 
 /-! ### Elementary generators: transvections in `SLₙ(ℤ)` -/
@@ -118,7 +118,7 @@ theorem transvectionSL_mulVec (i j : Fin n) (h : i ≠ j) (c : ℤ) (v : Fin n �
   funext k
   rcases eq_or_ne k i with rfl | hk
   · simp
-  · simp [Function.update_of_ne hk, Function.update_of_ne (a := (0 : Fin n → ℤ)) hk]
+  · simp [Function.update_of_ne hk]
 
 /-- **A transvection preserves primitivity** — a special case of
 `IsPrimitive.mulVec`, recorded because transvections are the atomic moves of the

--- a/research/problems/bezout-identity-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/bezout-identity-oq-01-oq-02-oq-02/state.md
@@ -1,9 +1,9 @@
 # Research State: bezout-identity-oq-01-oq-02-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T16:43:19-07:00
+**Since**: 2026-07-09T20:50:32-07:00
 **Iteration**: 1
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -36718,11 +36718,11 @@
     },
     {
       "slug": "bezout-identity-oq-01-oq-02-oq-02",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-07-10T00:01:19.560Z",
       "status": "active",
-      "lastUpdate": "2026-07-10T00:01:19.628Z"
+      "lastUpdate": "2026-07-09T20:50:32-07:00"
     },
     {
       "slug": "brouwer-fixed-point-oq-01-oq-03-oq-02",

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "ann-isprimitive-def",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-02",
+    "range": { "startLine": 56, "endLine": 82 },
+    "type": "definition",
+    "title": "IsPrimitive: the Coordinate-Free Dual Notion",
+    "content": "Defines IsPrimitive v := ∃ w : Fin n → ℤ, w ⬝ᵥ v = 1 — a vector is primitive when it admits an integer dual pairing to 1. isPrimitive_single shows the standard basis vector eᵢ = Pi.single i 1 is primitive (its own indicator is a dual). isPrimitive_iff_span_eq_top proves this dot-product form agrees with the classical condition that the entries generate the unit ideal, IsPrimitive v ↔ Ideal.span (Set.range v) = ⊤, via Ideal.eq_top_iff_one and Ideal.mem_span_range_iff_exists_fun (matching the dot product to ∑ cᵢ • vᵢ through smul_eq_mul). Over ℤ this is exactly gcd of the entries = 1.",
+    "mathContext": "$v \\text{ primitive} \\iff \\exists w,\\ \\langle w, v\\rangle = 1 \\iff \\langle v_0,\\dots,v_{n-1}\\rangle_{\\mathbb Z} = \\mathbb Z$",
+    "significance": "key",
+    "relatedConcepts": [
+      "primitive vector",
+      "dot product dual",
+      "unit ideal",
+      "n-ary Bézout"
+    ],
+    "prerequisites": [
+      "Matrix.dotProduct",
+      "Ideal.eq_top_iff_one",
+      "Ideal.mem_span_range_iff_exists_fun"
+    ]
+  },
+  {
+    "id": "ann-invariance",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-02",
+    "range": { "startLine": 84, "endLine": 104 },
+    "type": "theorem",
+    "title": "SLₙ(ℤ) Preserves Primitivity (Both Directions)",
+    "content": "IsPrimitive.mulVec: if w ⬝ᵥ v = 1 and A ∈ SLₙ(ℤ), then the transported dual w ᵥ* ↑ₘA⁻¹ witnesses primitivity of ↑ₘA *ᵥ v, because (w ᵥ* ↑ₘA⁻¹) ⬝ᵥ (↑ₘA *ᵥ v) = w ᵥ* (↑ₘA⁻¹ * ↑ₘA) ⬝ᵥ v = w ᵥ* 1 ⬝ᵥ v = w ⬝ᵥ v = 1, using dotProduct_mulVec, vecMul_vecMul, and ↑ₘA⁻¹ * ↑ₘA = 1 (SpecialLinearGroup.coe_mul + inv_mul_cancel). isPrimitive_mulVec_iff upgrades this to a biconditional by applying the forward lemma to A⁻¹ and simplifying with mulVec_mulVec. This is the exact invariant the transitivity action lives inside: primitivity is necessary for SLₙ(ℤ)-equivalence to a basis vector.",
+    "mathContext": "$A \\in \\mathrm{SL}_n(\\mathbb Z) \\ \\Rightarrow\\ \\big(A v \\text{ primitive} \\iff v \\text{ primitive}\\big)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "SLₙ(ℤ) action",
+      "invariance",
+      "contravariant dual",
+      "transitivity"
+    ],
+    "prerequisites": [
+      "Matrix.dotProduct_mulVec",
+      "Matrix.vecMul_vecMul",
+      "SpecialLinearGroup.coe_mul"
+    ]
+  },
+  {
+    "id": "ann-transvections",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-02",
+    "range": { "startLine": 106, "endLine": 131 },
+    "type": "definition",
+    "title": "transvectionSL: the Euclidean-Descent Generators",
+    "content": "Packages Mathlib's transvection i j c = I + c·Eᵢⱼ (i ≠ j), which has determinant 1 (det_transvection_of_ne), as an element transvectionSL i j h c of Matrix.SpecialLinearGroup (Fin n) ℤ. transvectionSL_mulVec computes its action: ↑ₘ(transvectionSL i j h c) *ᵥ v = Function.update v i (vᵢ + c·vⱼ) — one elementary Bézout step adding c·vⱼ to coordinate i — proved by unfolding transvection = 1 + Matrix.single via add_mulVec, one_mulVec, single_mulVec and Function.update case analysis. IsPrimitive.transvection records that each such step preserves primitivity, a special case of the general SLₙ(ℤ) lemma. Because the whole Euclidean descent is a product of these generators, it stays in SLₙ(ℤ) automatically.",
+    "mathContext": "$T_{ij}(c)\\, v = v + c\\, v_j\\, e_i, \\qquad \\det T_{ij}(c) = 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "transvection",
+      "elementary matrix",
+      "Euclidean algorithm",
+      "generators of SLₙ(ℤ)"
+    ],
+    "prerequisites": [
+      "Matrix.transvection",
+      "Matrix.det_transvection_of_ne",
+      "Matrix.single_mulVec"
+    ]
+  },
+  {
+    "id": "ann-orbit",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-02",
+    "range": { "startLine": 133, "endLine": 142 },
+    "type": "theorem",
+    "title": "Necessity Half of Transitivity",
+    "content": "orbit_e_isPrimitive: every vector in the SLₙ(ℤ)-orbit of a basis vector eᵢ is primitive, i.e. IsPrimitive (↑ₘA *ᵥ Pi.single i 1), assembled from isPrimitive_single and IsPrimitive.mulVec. This is the ⊆ direction of the sharp characterization 'the SLₙ(ℤ)-orbit of e₀ equals the set of primitive vectors'; the ⊇ (sufficiency) direction — every primitive vector is reachable — is the remaining Euclidean-descent construction, for which transvectionSL and the invariance lemma above are the tools.",
+    "mathContext": "$\\mathrm{SL}_n(\\mathbb Z)\\cdot e_i \\subseteq \\{\\text{primitive vectors}\\}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "group orbit",
+      "transitivity",
+      "primitive vector"
+    ],
+    "prerequisites": [
+      "IsPrimitive.mulVec",
+      "isPrimitive_single"
+    ]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "bezout-identity-oq-01-oq-02-oq-02",
+  "title": "Primitive Integer Vectors and the SLₙ(ℤ) Action: the Invariance Foundation",
+  "slug": "bezout-identity-oq-01-oq-02-oq-02",
+  "description": "Builds the SLₙ(ℤ)-invariant foundation for the parent entry's open question — transitivity of SLₙ(ℤ) on primitive integer vectors, generalizing the n=2 bezoutSL. Introduces a coordinate-free notion of primitivity, IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 (v has an integer dual pairing to 1), proves it agrees with the classical 'entries generate the unit ideal' (isPrimitive_iff_span_eq_top), and — the crux — proves SLₙ(ℤ) preserves primitivity in both directions (isPrimitive_mulVec_iff), since ↑ₘA⁻¹ * ↑ₘA = 1. Packages the Euclidean-descent generators as SLₙ(ℤ) elements (transvectionSL, with explicit vector action transvectionSL_mulVec) and assembles the necessity half of transitivity: every vector in the orbit of eᵢ is primitive (orbit_e_isPrimitive). The sufficiency converse (every primitive vector reaches eᵢ via Euclidean descent) is left as the documented next step. 7 theorems, 2 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-09",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
+    "tags": [
+      "number-theory",
+      "linear-algebra",
+      "special-linear-group",
+      "primitive-vector",
+      "transvection",
+      "unimodular-matrix",
+      "bezout-identity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-09",
+    "axiomCount": 0,
+    "assumptions": "None beyond Mathlib's foundational axioms. Fully machine-checked (0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide). Note: in the local Docker sandbox the file elaborates cleanly across repeated runs but the .olean cache write intermittently aborts with SIGBUS (exit 135), an environment/IO issue independent of the proofs; CI produces the build artifact.",
+    "lineCount": 142,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "originalContributions": [
+      "IsPrimitive v := ∃ w, w ⬝ᵥ v = 1 — a coordinate-free, manifestly SLₙ(ℤ)-invariant notion of primitivity for integer vectors (absent from Mathlib)",
+      "isPrimitive_mulVec_iff: SLₙ(ℤ) preserves primitivity in both directions — the exact invariant transitivity must respect",
+      "transvectionSL / transvectionSL_mulVec: the elementary Euclidean-descent generators packaged in SLₙ(ℤ) with their explicit action v ↦ update v i (vᵢ + c·vⱼ)",
+      "orbit_e_isPrimitive: the necessity half of transitivity — every SLₙ(ℤ)-orbit of a basis vector consists of primitive vectors"
+    ]
+  },
+  "overview": {
+    "historicalContext": "That SLₙ(ℤ) acts transitively on primitive integer vectors — every vector with setwise-coprime coordinates can be carried to the first standard basis vector by a determinant-one integer matrix — is a classical structural fact (Newman, Integral Matrices; Dummit–Foote via Smith normal form). It underlies the theory of the modular group, continued fractions, Farey/Stern–Brocot fractions, and the reduction theory of quadratic forms. The parent entry bezout-identity-oq-01-oq-02 established the n=2 case in closed form (bezoutSL carries a coprime pair to (1,0)); its open question asks for the general n. This entry does not yet supply the full n-dimensional matrix but builds the invariant-theoretic scaffolding any such construction lives inside: a clean SLₙ(ℤ)-invariant notion of primitivity and the elementary transvection generators of the Euclidean descent.",
+    "problemStatement": "Toward transitivity of SLₙ(ℤ) on primitive integer vectors: (1) give a coordinate-free notion of primitivity that is transparently SLₙ(ℤ)-invariant; (2) prove SLₙ(ℤ) preserves it; (3) exhibit the elementary generators (transvections) as SLₙ(ℤ) elements with explicit action; (4) deduce the necessity half — the orbit of a basis vector consists of primitive vectors.",
+    "text": "Define IsPrimitive v := ∃ w : Fin n → ℤ, w ⬝ᵥ v = 1 (v has an integer dual vector pairing to 1). Over ℤ this is exactly the classical condition that the entries generate the unit ideal, equivalently that their gcd is 1: isPrimitive_iff_span_eq_top identifies IsPrimitive v with Ideal.span (Set.range v) = ⊤ via Ideal.mem_span_range_iff_exists_fun. The dot-product form makes SLₙ(ℤ)-invariance immediate: if w ⬝ᵥ v = 1 and A ∈ SLₙ(ℤ), then (w ᵥ* ↑ₘA⁻¹) ⬝ᵥ (↑ₘA *ᵥ v) = w ᵥ* (↑ₘA⁻¹ * ↑ₘA) ⬝ᵥ v = w ⬝ᵥ v = 1, using ↑ₘA⁻¹ * ↑ₘA = 1 (SpecialLinearGroup.coe_mul + inv_mul_cancel). Applying this to A and to A⁻¹ gives the biconditional isPrimitive_mulVec_iff. The Euclidean-descent moves are Mathlib transvections transvection i j c = I + c·Eᵢⱼ (i≠j), each of determinant 1 (det_transvection_of_ne), packaged as transvectionSL ∈ SLₙ(ℤ); their action adds c·vⱼ to coordinate vᵢ. Since eᵢ is primitive (isPrimitive_single) and SLₙ(ℤ) preserves primitivity, every vector in the orbit of eᵢ is primitive (orbit_e_isPrimitive) — the necessity half of the transitivity characterization.",
+    "proofStrategy": "Primitivity of eᵢ is a one-line dual (its own indicator). The span bridge uses Ideal.eq_top_iff_one and Ideal.mem_span_range_iff_exists_fun, matching the dot product to ∑ cᵢ • vᵢ via smul_eq_mul. Invariance is dotProduct_mulVec + vecMul_vecMul + the coe_mul/inv_mul_cancel identity ↑ₘA⁻¹ * ↑ₘA = 1 + vecMul_one; the reverse direction reuses the forward lemma at A⁻¹ with mulVec_mulVec. The transvection action unfolds transvection = 1 + Matrix.single via add_mulVec, one_mulVec, single_mulVec and Function.update case analysis.",
+    "keyInsights": [
+      "The right notion of primitivity for the transitivity question is the coordinate-free dual: ∃ w, w ⬝ᵥ v = 1. Unlike 'gcd of entries = 1', this form makes SLₙ(ℤ)-invariance a two-line computation, because the dual transforms contravariantly by ↑ₘA⁻¹.",
+      "SLₙ(ℤ)-invariance is the necessity half of transitivity: primitivity is a NECESSARY condition for a vector to be SLₙ(ℤ)-equivalent to a basis vector. The still-open sufficiency (every primitive vector is reachable) is precisely the Euclidean-descent construction.",
+      "The elementary moves of that descent are exactly Mathlib's transvections, which already carry determinant 1; packaging them as transvectionSL means the whole descent is automatically a product of SLₙ(ℤ) elements, sidestepping the block-embedding bookkeeping of a naive 2×2-in-n×n approach.",
+      "Every transvection preserves primitivity as a special case of the general SLₙ(ℤ) lemma — a consistency check that the descent never leaves the primitive locus."
+    ],
+    "prerequisites": [
+      "Matrix.SpecialLinearGroup and its coercion, SpecialLinearGroup.coe_mul / coe_one",
+      "dotProduct, mulVec, vecMul and their compatibilities (dotProduct_mulVec, vecMul_vecMul, mulVec_mulVec)",
+      "Mathlib transvections: Matrix.transvection, det_transvection_of_ne, single_mulVec",
+      "Ideal.span over ℤ: Ideal.eq_top_iff_one, Ideal.mem_span_range_iff_exists_fun"
+    ]
+  },
+  "conclusion": {
+    "summary": "Establishes the SLₙ(ℤ)-invariant foundation for transitivity on primitive vectors: a coordinate-free primitivity predicate (dot-product dual) equivalent to the classical unit-ideal condition, its SLₙ(ℤ)-invariance in both directions, the transvection generators of the Euclidean descent with explicit action, and the necessity half of transitivity (the orbit of a basis vector is primitive). 7 theorems, 2 definitions, 0 sorries, 0 axioms, 142 lines.",
+    "implications": "Reduces the parent's open question to a single remaining step: the sufficiency converse — every primitive vector is SLₙ(ℤ)-equivalent to e₀ — for which the transvection generators and the invariance guarantee here are exactly the tools. Because primitivity is now an SLₙ(ℤ)-invariant, the transitivity theorem takes the sharp form 'the SLₙ(ℤ)-orbit of e₀ is precisely the set of primitive vectors', of which the ⊆ direction is proved here.",
+    "openQuestions": [
+      "Prove sufficiency: every primitive v ∈ ℤⁿ is SLₙ(ℤ)-equivalent to e₀, by strong induction on ∑ᵢ|vᵢ| applying transvectionSL (the Euclidean algorithm across coordinates) and accumulating the transvection product.",
+      "Add the determinant-one coordinate swap (a rotation built from three transvections) needed to normalize the surviving coordinate to position 0.",
+      "Relate IsPrimitive to Finset.univ.gcd of the entries being 1, bridging explicitly to the parent's n=2 IsCoprime phrasing."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "isPrimitive_mulVec_iff",
+      "type": "core",
+      "description": "SLₙ(ℤ) preserves primitivity in both directions: IsPrimitive (↑ₘA *ᵥ v) ↔ IsPrimitive v. The forward direction transports the dual w by ↑ₘA⁻¹; the reverse reuses it at A⁻¹. This is the invariant the transitivity action must respect."
+    },
+    {
+      "name": "isPrimitive_iff_span_eq_top",
+      "type": "core",
+      "description": "The dot-product notion agrees with the classical one: IsPrimitive v ↔ Ideal.span (Set.range v) = ⊤, i.e. the entries of v generate the unit ideal of ℤ (equivalently their gcd is 1)."
+    },
+    {
+      "name": "transvectionSL_mulVec",
+      "type": "core",
+      "description": "The elementary generator transvectionSL i j h c ∈ SLₙ(ℤ) acts on v by adding c·vⱼ to the i-th coordinate: ↑ₘ(transvectionSL i j h c) *ᵥ v = Function.update v i (vᵢ + c·vⱼ). One step of the Euclidean descent."
+    },
+    {
+      "name": "orbit_e_isPrimitive",
+      "type": "supporting",
+      "description": "Every vector in the SLₙ(ℤ)-orbit of a basis vector eᵢ is primitive — the necessity half of the transitivity characterization, assembled from isPrimitive_single and IsPrimitive.mulVec."
+    },
+    {
+      "name": "isPrimitive_single",
+      "type": "supporting",
+      "description": "The standard basis vector eᵢ (Pi.single i 1) is primitive, witnessed by its own indicator as the dual. The target of the transitivity reduction."
+    }
+  ],
+  "leanFile": {
+    "namespace": "BezoutPrimitive",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "path": "Proofs/BezoutIdentityOQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Builds the closed-form n=2 reduction bezoutSL carrying a coprime pair to (1,0) and poses the open question — generalize transitivity of SLₙ(ℤ) on primitive vectors to all n — whose invariant-theoretic foundation is built here."
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "related",
+      "description": "The classical Bézout identity; the coordinate-free primitivity predicate here is its n-ary 'the entries generate the unit ideal' form."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Documents the parent's open question and states the scope: the SLₙ(ℤ)-invariant foundation for transitivity on primitive vectors (primitivity predicate, its invariance, transvection generators, necessity half), with the sufficiency converse left as future work. Imports and the local ↑ₘ notation for the SpecialLinearGroup-to-matrix coercion."
+    },
+    {
+      "id": "sec-primitive",
+      "title": "Primitive Vectors and the Classical Bridge",
+      "startLine": 54,
+      "endLine": 82,
+      "summary": "Defines IsPrimitive v := ∃ w, w ⬝ᵥ v = 1; proves eᵢ is primitive (isPrimitive_single) and the bridge isPrimitive_iff_span_eq_top to Ideal.span (range v) = ⊤ via Ideal.mem_span_range_iff_exists_fun."
+    },
+    {
+      "id": "sec-invariance",
+      "title": "SLₙ(ℤ) Preserves Primitivity",
+      "startLine": 84,
+      "endLine": 104,
+      "summary": "IsPrimitive.mulVec transports the dual by ↑ₘA⁻¹ using ↑ₘA⁻¹ * ↑ₘA = 1; isPrimitive_mulVec_iff upgrades to a biconditional by applying the forward lemma at A⁻¹ (mulVec_mulVec)."
+    },
+    {
+      "id": "sec-transvections",
+      "title": "Elementary Generators: Transvections in SLₙ(ℤ)",
+      "startLine": 106,
+      "endLine": 131,
+      "summary": "transvectionSL packages Matrix.transvection (det 1) as an SLₙ(ℤ) element; transvectionSL_mulVec gives its explicit action v ↦ update v i (vᵢ + c·vⱼ); IsPrimitive.transvection records that it preserves primitivity."
+    },
+    {
+      "id": "sec-orbit",
+      "title": "The Necessity Half of Transitivity",
+      "startLine": 133,
+      "endLine": 142,
+      "summary": "orbit_e_isPrimitive: every vector in the SLₙ(ℤ)-orbit of a basis vector is primitive, from isPrimitive_single and IsPrimitive.mulVec — the ⊆ direction of 'orbit of e₀ = primitive vectors'."
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "M. Newman",
+      "title": "Integral Matrices",
+      "year": 1972,
+      "venue": "Academic Press",
+      "note": "Transitivity of SLₙ(ℤ) / GLₙ(ℤ) on primitive vectors and unimodular completion of a primitive vector to a basis."
+    },
+    {
+      "authors": "D. S. Dummit, R. M. Foote",
+      "title": "Abstract Algebra",
+      "year": 2004,
+      "venue": "Wiley",
+      "note": "Smith normal form over a PID, from which primitive vectors extend to a ℤ-basis."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Matrix.SpecialLinearGroup, Matrix.transvection with det_transvection_of_ne, and the Ideal.span machinery used here."
+    }
+  ]
+}

--- a/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
@@ -42,11 +42,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: Built the SLₙ(ℤ)-invariant foundation for transitivity on primitive vectors — coordinate-free primitivity (dot-product dual), its SLₙ(ℤ)-invariance (both directions), transvection generators with explicit action, and the necessity half of transitivity. The Euclidean-descent converse (sufficiency) remains for a follow-up session.",
+    "builtItems": [
+      "IsPrimitive (Fin n → ℤ) := ∃ w, w ⬝ᵥ v = 1 — BezoutIdentityOQ01OQ02OQ02.lean",
+      "isPrimitive_iff_span_eq_top: IsPrimitive v ↔ Ideal.span (range v) = ⊤ (bridge to classical gcd=1 via Ideal.mem_span_range_iff_exists_fun)",
+      "IsPrimitive.mulVec + isPrimitive_mulVec_iff: SLₙ(ℤ) preserves primitivity, both directions",
+      "transvectionSL i j h c: elementary generator in SpecialLinearGroup (Fin n) ℤ; transvectionSL_mulVec: explicit vector action",
+      "orbit_e_isPrimitive: the easy half — every vector in the SLₙ(ℤ)-orbit of eᵢ is primitive"
+    ],
+    "insights": [
+      "Primitivity of an integer vector v is cleanly captured coordinate-free as: ∃ dual w with w ⬝ᵥ v = 1. This dot-product form is manifestly SLₙ(ℤ)-invariant, unlike the gcd-of-entries phrasing.",
+      "SLₙ(ℤ) preserves primitivity in BOTH directions: if w ⬝ᵥ v = 1 then (w ᵥ* ↑ₘA⁻¹) ⬝ᵥ (↑ₘA *ᵥ v) = 1, because ↑ₘA⁻¹ * ↑ₘA = 1. This is the exact invariant the transitivity action must respect — the necessity half of the transitivity characterization.",
+      "The Euclidean-descent generators are Mathlib transvections: transvection i j c = I + c·Eᵢⱼ (i≠j) has det 1 (det_transvection_of_ne), so it packages directly into SLₙ(ℤ); its action adds c·vⱼ to vᵢ (Function.update)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no packaged transitivity of SLₙ(ℤ) on primitive vectors (only n=2 pieces via bezoutSL in the parent). Foundation built here; the Euclidean-descent converse (every primitive vector reaches eᵢ) remains.",
+      "No IsPrimitive predicate for integer vectors in Mathlib; defined here via the dot-product dual."
+    ],
+    "nextSteps": [
+      "Prove the converse (open direction): every primitive v is SLₙ(ℤ)-equivalent to e₀, via strong induction on ∑ᵢ|vᵢ| using transvectionSL_mulVec (Euclidean algorithm across coordinates), accumulating the transvection product.",
+      "Add the sign-fixing rotation (3 transvections, det 1) to convert coordinate swaps without leaving SLₙ(ℤ).",
+      "Bridge IsPrimitive to Finset.univ.gcd of entries = 1 to connect explicitly with the parent n=2 IsCoprime phrasing."
+    ]
   },
   "tags": [
     "number-theory",


### PR DESCRIPTION
## Research: bezout-identity-oq-01-oq-02-oq-02

Toward the parent entry's open question — **transitivity of SLₙ(ℤ) on primitive integer vectors** (generalizing the n=2 `bezoutSL`). This session builds the **SLₙ(ℤ)-invariant foundation** the full construction lives inside, fully self-contained (0 sorries, 0 axioms).

### New file: `proofs/Proofs/BezoutIdentityOQ01OQ02OQ02.lean` (142 lines, 7 theorems, 2 defs)

- **`IsPrimitive v := ∃ w, w ⬝ᵥ v = 1`** — a coordinate-free, manifestly SLₙ(ℤ)-invariant notion of primitivity (a vector has an integer *dual* pairing to 1). Absent from Mathlib.
- **`isPrimitive_iff_span_eq_top`** — bridge to the classical notion: `IsPrimitive v ↔ Ideal.span (Set.range v) = ⊤` (the entries generate the unit ideal, i.e. gcd = 1).
- **`isPrimitive_mulVec_iff`** — the crux: **SLₙ(ℤ) preserves primitivity in both directions**, because `↑ₘA⁻¹ * ↑ₘA = 1` transports the dual contravariantly. This is exactly the invariant transitivity must respect (primitivity is *necessary* for SLₙ(ℤ)-equivalence to a basis vector).
- **`transvectionSL` / `transvectionSL_mulVec`** — the Euclidean-descent generators: each transvection `I + c·Eᵢⱼ` (det 1) packaged in SLₙ(ℤ), with explicit action `v ↦ update v i (vᵢ + c·vⱼ)`. Since the whole descent is a product of these, it stays in SLₙ(ℤ) automatically (no block-embedding bookkeeping).
- **`orbit_e_isPrimitive`** — the **necessity half** of transitivity: every vector in the SLₙ(ℤ)-orbit of `eᵢ` is primitive (the ⊆ direction of "orbit of e₀ = primitive vectors").

### Honest scope
This does **not** prove the full transitivity theorem. The remaining **sufficiency converse** (every primitive vector reaches `e₀` via Euclidean descent, by strong induction on `∑|vᵢ|` using `transvectionSL`) is documented as the next step in `knowledge` and the entry's `openQuestions`.

### Build status
The file **elaborates cleanly** across repeated local Docker runs (reaches `[3058/3058]`, ~3s, **zero line-numbered Lean errors**), but the `.olean` cache write intermittently aborts with **SIGBUS (exit 135)** — a known environment/IO issue in this sandbox, independent of the proofs. CI produces the build artifact. Flagging for a clean-cache confirmation build on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
