### PR TITLE
Enrich Reflection Symmetry of Bounded Weak Compositions: add references (REFS0 fix)

### DIFF
--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-02-oq-02/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-02-oq-02/meta.json
@@ -116,5 +116,25 @@
   "crossReferences": [
     "stars-and-bars-weak-compositions-oq-02",
     "stars-and-bars-weak-compositions"
+  ],
+  "references": [
+    {
+      "key": "Andrews1998Partitions",
+      "citation": "Andrews, G. E. (1998). The Theory of Partitions. Cambridge Mathematical Library. Cambridge University Press.",
+      "type": "book",
+      "note": "Standard reference for Gaussian (q-)binomial coefficients. B(k,n,b) is the coefficient of qⁿ in the Gaussian binomial [k+b; b]_q, and the reflection n ↦ kb − n formalized here is the combinatorial content of the palindromic symmetry of the coefficient sequence."
+    },
+    {
+      "key": "StanleyEC1",
+      "citation": "Stanley, R. P. (2012). Enumerative Combinatorics, Vol. 1 (2nd ed.), §1.7–1.8. Cambridge University Press.",
+      "type": "book",
+      "note": "Treats compositions and weak compositions (stars and bars), the inclusion–exclusion count of bounded compositions, and the symmetry/unimodality of Gaussian binomial coefficients that underlies the reflection B(k,n,b) = B(k, kb−n, b)."
+    },
+    {
+      "key": "KacCheung2002",
+      "citation": "Kac, V., & Cheung, P. (2002). Quantum Calculus. Universitext. Springer.",
+      "type": "book",
+      "note": "Gives the q-binomial reflection identity [m; r]_q = [m; r]_{q⁻¹} · q^{r(m−r)} specialized here at q = 1 to the finite bijection f ↦ (i ↦ b − f i) between compositions of n and of kb − n."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `stars-and-bars-weak-compositions-oq-02-oq-02`.

**Defect fixed:** entry had no `references` field (REFS0). Added 3 accurate sources drawn from the entry's own docstring framing (B(k,n,b) = coefficient of qⁿ in the Gaussian binomial [k+b; b]_q; reflection n ↦ kb − n = palindromic symmetry at q=1):

1. **Andrews, *The Theory of Partitions*** — Gaussian q-binomial coefficients and their palindromic symmetry.
2. **Stanley, *Enumerative Combinatorics* Vol. 1, §1.7–1.8** — weak compositions (stars and bars), inclusion–exclusion for bounded compositions, Gaussian symmetry.
3. **Kac & Cheung, *Quantum Calculus*** — the q-binomial reflection identity [m;r]_q = [m;r]_{q⁻¹}·q^{r(m−r)}, specialized to q=1 here.

Only the `references` field added; JSON validates.