### PR TITLE
research(erdos-1215-oq-02): sharp cyclotomic level-set radius shrinks to 2 with degree

### DIFF
--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ04.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ04.lean
@@ -1,0 +1,101 @@
+/-
+Erdős Problem #1215 — cyclotomic restriction (OQ-02): the sharp outer radius of the
+cyclotomic level set shrinks monotonically to `2` with the degree.
+
+Parent chain:
+  OQ02OQ01  the cyclotomic level set `{z : |Φ_n(z)| < C}` is bounded
+            (crude radius `max 2 (C + 1)`).
+  OQ02OQ02  sharp two-sided radii; the outer radius is `1 + C^{1/φ(n)}`.
+  OQ02OQ03  planar area of the level set squeezed between two discs.
+
+`OQ02OQ02` observed *in prose* that the sharp outer radius `1 + C^{1/φ(n)}`
+"decreases to `2` as `φ(n) → ∞`", so high-degree cyclotomic lemniscates hug the unit
+circle — the exact opposite of the freedom Mac Lane needs to build a labyrinth for a
+general unit-circle-rooted polynomial. This file turns that observation into three
+theorems:
+
+  * `sharpRadius_antitone`   — the radius `1 + C^{1/k}` is antitone in the degree
+                               `k = φ(n)` (higher degree ⟹ smaller-or-equal disc);
+  * `tendsto_sharpRadius`    — it converges to `2` as the degree `k → ∞`;
+  * `eventually_levelSet_subset_closedBall`
+                             — hence for every `ε > 0` there is a degree threshold
+                               `K` such that EVERY cyclotomic level set `{|Φ_n| < C}`
+                               with `φ(n) ≥ K` fits inside the one fixed disc
+                               `closedBall(0, 2 + ε)`: a uniform confinement of all
+                               high-degree cyclotomic lemniscates.
+
+All results are `0`-axiom / `0`-sorry.
+-/
+
+import Mathlib
+import Proofs.Erdos1215Problem
+import Proofs.CyclotomicPolynomialsOQ02OQ02
+
+open Complex Polynomial Filter Topology
+
+namespace CyclotomicPolynomialsOQ02OQ04
+
+/-- **Degree-monotonicity of the sharp outer radius.**
+For `C ≥ 1` and totient exponents `1 ≤ k ≤ k'`, the sharp outer radius of
+`CyclotomicPolynomialsOQ02OQ02` satisfies `1 + C^{1/k'} ≤ 1 + C^{1/k}`: raising the
+degree `φ(n)` shrinks (weakly) the disc confining the level set. Since `1/k' ≤ 1/k`
+and `C ≥ 1`, `C^{1/k'} ≤ C^{1/k}`. -/
+theorem sharpRadius_antitone {C : ℝ} (hC : 1 ≤ C) {k k' : ℕ} (hk : 1 ≤ k)
+    (hkk' : k ≤ k') :
+    1 + C ^ ((k' : ℝ)⁻¹) ≤ 1 + C ^ ((k : ℝ)⁻¹) := by
+  have hkpos : (0 : ℝ) < (k : ℝ) := by exact_mod_cast hk
+  have hcast : (k : ℝ) ≤ (k' : ℝ) := by exact_mod_cast hkk'
+  have hinv : (k' : ℝ)⁻¹ ≤ (k : ℝ)⁻¹ := inv_le_inv_of_le hkpos hcast
+  have hle : C ^ ((k' : ℝ)⁻¹) ≤ C ^ ((k : ℝ)⁻¹) :=
+    Real.rpow_le_rpow_of_exponent_le hC hinv
+  linarith
+
+/-- **The sharp outer radius tends to `2`.**
+For `C > 0`, `1 + C^{1/k} → 2` as the degree `k → ∞`, because
+`C^{1/k} = exp((log C)/k) → exp 0 = 1`. This is the quantitative form of the
+"cyclotomic lemniscates hug the unit circle" observation of `OQ02OQ02`. -/
+theorem tendsto_sharpRadius {C : ℝ} (hC : 0 < C) :
+    Tendsto (fun k : ℕ => 1 + C ^ ((k : ℝ)⁻¹)) atTop (𝓝 2) := by
+  have hexp : (fun k : ℕ => C ^ ((k : ℝ)⁻¹))
+      = (fun k : ℕ => Real.exp (Real.log C * (k : ℝ)⁻¹)) := by
+    funext k; rw [Real.rpow_def_of_pos hC]
+  have htinv : Tendsto (fun k : ℕ => (k : ℝ)⁻¹) atTop (𝓝 0) :=
+    tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
+  have harg : Tendsto (fun k : ℕ => Real.log C * (k : ℝ)⁻¹) atTop (𝓝 0) := by
+    have h := htinv.const_mul (Real.log C)
+    simpa using h
+  have hCk : Tendsto (fun k : ℕ => C ^ ((k : ℝ)⁻¹)) atTop (𝓝 1) := by
+    rw [hexp]
+    have h := (Real.continuous_exp.tendsto 0).comp harg
+    simpa [Real.exp_zero] using h
+  have h2 : Tendsto (fun k : ℕ => 1 + C ^ ((k : ℝ)⁻¹)) atTop (𝓝 (1 + 1)) :=
+    hCk.const_add 1
+  have he : (1 : ℝ) + 1 = 2 := by norm_num
+  rwa [he] at h2
+
+/-- **Uniform confinement of high-degree cyclotomic level sets.**
+For `C ≥ 1` and any `ε > 0`, there is a degree threshold `K` such that every
+cyclotomic level set `{z : |Φ_n(z)| < C}` with `φ(n) ≥ K` is contained in the single
+fixed disc `closedBall(0, 2 + ε)`. Since the sharp outer radius `1 + C^{1/φ(n)}`
+tends to `2`, it eventually drops below `2 + ε`; combined with the outer containment
+`sublevel_subset_closedBall_sharp` this confines all sufficiently high-degree
+cyclotomic lemniscates to one disc barely larger than the unit disc — no room for a
+path escaping to `∞`, the antithesis of a Mac Lane labyrinth. -/
+theorem eventually_levelSet_subset_closedBall {C : ℝ} (hC : 1 ≤ C) {ε : ℝ}
+    (hε : 0 < ε) :
+    ∃ K : ℕ, ∀ n : ℕ, n ≠ 0 → K ≤ n.totient →
+      Erdos1215.levelSet (cyclotomic n ℂ) C ⊆ Metric.closedBall (0 : ℂ) (2 + ε) := by
+  have hC0 : 0 < C := lt_of_lt_of_le one_pos hC
+  have htend := tendsto_sharpRadius hC0
+  have hev : ∀ᶠ k : ℕ in atTop, 1 + C ^ ((k : ℝ)⁻¹) < 2 + ε :=
+    (tendsto_order.1 htend).2 (2 + ε) (by linarith)
+  obtain ⟨K, hK⟩ := eventually_atTop.1 hev
+  refine ⟨K, fun n hn hKn => ?_⟩
+  have hlt : 1 + C ^ ((n.totient : ℝ)⁻¹) < 2 + ε := hK n.totient hKn
+  calc Erdos1215.levelSet (cyclotomic n ℂ) C
+      ⊆ Metric.closedBall (0 : ℂ) (1 + C ^ ((n.totient : ℝ)⁻¹)) :=
+        CyclotomicPolynomialsOQ02OQ02.sublevel_subset_closedBall_sharp n hn C
+    _ ⊆ Metric.closedBall (0 : ℂ) (2 + ε) :=
+        Metric.closedBall_subset_closedBall (le_of_lt hlt)
+
+end CyclotomicPolynomialsOQ02OQ04

--- a/research/problems/erdos-1215-oq-02/knowledge.md
+++ b/research/problems/erdos-1215-oq-02/knowledge.md
@@ -131,3 +131,44 @@ Turn a set-containment `A ⊆ closedBall 0 ρ` into an area bound: `measure_mono
 volume (closedBall a ρ) = ENNReal.ofReal ρ ^ 2 * NNReal.pi` (`@[simp]`, ℂ≅ℝ² proper
 space). Finiteness: `ENNReal.mul_lt_top (ENNReal.pow_lt_top ENNReal.ofReal_lt_top)
 ENNReal.coe_lt_top`. The `NNReal.pi` factor coerces silently into `ℝ≥0∞`.
+
+## Session 2026-07-09 (researcher-3) — sharp outer radius shrinks to 2 with degree
+
+**Mode**: REVISIT (built on OQ02OQ02's sharp radius). **Outcome**: progress (full
+elaboration clean `[7746/7746]`; olean-write env-blocked SIGBUS-135 → UNVERIFIED;
+0 sorry / 0 axiom).
+
+### What I did
+- Created `proofs/Proofs/CyclotomicPolynomialsOQ02OQ04.lean` (3 theorems). Turned
+  the **prose observation** of OQ02OQ02 ("the sharp outer radius `1 + C^{1/φ(n)}`
+  decreases to 2 as `φ(n) → ∞`") into theorems.
+- `sharpRadius_antitone`: for `C ≥ 1`, `1 ≤ k ≤ k'` ⟹ `1 + C^{1/k'} ≤ 1 + C^{1/k}`
+  (outer radius antitone in degree).
+- `tendsto_sharpRadius`: for `C > 0`, `Tendsto (fun k => 1 + C^{1/k}) atTop (𝓝 2)`.
+- `eventually_levelSet_subset_closedBall`: for `C ≥ 1`, `ε > 0`, ∃ degree threshold
+  `K` s.t. EVERY cyclotomic level set `{|Φ_n|<C}` with `φ(n) ≥ K` fits in the one
+  fixed disc `closedBall 0 (2+ε)` — uniform confinement of all high-degree
+  cyclotomic lemniscates (antithesis of a Mac Lane labyrinth).
+
+### Reusable Lean recipe
+- Limit of `C^{1/k}` (`C>0`): rewrite `C^{1/k} = exp(log C · k⁻¹)` via
+  `Real.rpow_def_of_pos hC`; `tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop`
+  gives `k⁻¹ → 0`; `Tendsto.const_mul (Real.log C)` → arg `→ 0`;
+  `(Real.continuous_exp.tendsto 0).comp` + `Real.exp_zero` → `C^{1/k} → 1`;
+  `.const_add 1` → radius `→ 2`.
+- Extract threshold: `(tendsto_order.1 htend).2 (2+ε) (by linarith)` →
+  `∀ᶠ k, radius k < 2+ε`; `eventually_atTop.1` → `∃ K ∀ k ≥ K`.
+- Nesting: `Metric.closedBall_subset_closedBall` composes with
+  `OQ02OQ02.sublevel_subset_closedBall_sharp`.
+- Antitone: `inv_le_inv_of_le hkpos hcast` + `Real.rpow_le_rpow_of_exponent_le`.
+
+### Status / next
+- The elementary quantitative side of OQ-02 is now essentially complete: bounded
+  (OQ01) → sharp two-sided radii (OQ02) → area squeeze (OQ03) → radius→2 shrinkage
+  (this). The genuinely-open driver (small-n `n=3,4,6` lemniscate component/path
+  topology) still needs polynomial-lemniscate topology Mathlib lacks — unchanged.
+- ★INFRA: worktree `.loom/worktrees/researcher-3` lost its `.git` link mid-session
+  (worktree-eater) → `git checkout -b` accidentally switched the MAIN repo branch;
+  recovered by copying the file to a fresh external worktree `/Users/rwalters/lg-r3-cyclo`
+  off origin/main and restoring main. Elaboration errors ARE visible before the
+  SIGBUS write, so correctness is verifiable even when the olean write fails.

--- a/src/data/research/problems/erdos-1215-oq-02.json
+++ b/src/data/research/problems/erdos-1215-oq-02.json
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-4, VERIFIED 0-sorry/0-axiom, docker [7744/7744] 4.6s): cyclotomic lemniscate {|Phi_n|<C} proven BOUNDED with explicit radius; escape-to-inf path obstruction is unconditional for cyclotomic polynomials (compactness supersedes Mac Lane labyrinth). Exact n=1,2 disk geometry recorded. Open frontier: component-count / path-length geometry (genuinely open, needs lemniscate topology Mathlib lacks).",
+    "progressSummary": "PROGRESS (researcher-3 2026-07-09): New file CyclotomicPolynomialsOQ02OQ04 formalizes OQ02OQ02's prose observation that the sharp outer radius 1+C^(1/phi(n)) of the cyclotomic level set decreases to 2 as phi(n)->inf. sharpRadius_antitone (antitone in degree), tendsto_sharpRadius (limit=2, via C^(1/k)=exp(log C * 1/k)->1), eventually_levelSet_subset_closedBall (for any eps>0 all high-degree cyclotomic level sets {|Phi_n|<C} with phi(n)>=K fit in closedBall 0 (2+eps) — uniform confinement, antithesis of a Mac Lane labyrinth). Elementary quantitative side of OQ-02 now essentially complete (bounded->sharp radii->area->radius shrinkage). Full elaboration clean [7746/7746]; olean-write env-blocked (SIGBUS-135) -> UNVERIFIED. Open driver (small-n lemniscate component/path topology) still needs Mathlib machinery.",
     "builtItems": [
       "norm_cyclotomic_eval (CyclotomicPolynomialsOQ02OQ01.lean): |Phi_n(z)| = prod distances to primitive roots, via cyclotomic_eq_prod_X_sub_primitiveRoots + norm_prod (VERIFIED 0/0)",
       "pow_sub_one_le_norm_cyclotomic_eval: (|z|-1)^{phi(n)} <= |Phi_n(z)| for |z|>=1 (Finset.prod_le_prod + norm_sub_norm_le + IsPrimitiveRoot.norm'_eq_one + card_primitiveRoots)",
@@ -102,5 +102,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1215Problem.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-07-09"
 }


### PR DESCRIPTION
## Summary

New file `CyclotomicPolynomialsOQ02OQ04.lean` turns the **prose observation** of the
sibling `CyclotomicPolynomialsOQ02OQ02` — that the sharp outer radius
`1 + C^{1/φ(n)}` of the cyclotomic level set `{z : |Φ_n(z)| < C}` "decreases to `2`
as `φ(n) → ∞`" — into three theorems:

- `sharpRadius_antitone` — for `C ≥ 1` and `1 ≤ k ≤ k'`,
  `1 + C^{1/k'} ≤ 1 + C^{1/k}` (the radius is antitone in the degree `k = φ(n)`);
- `tendsto_sharpRadius` — for `C > 0`, `1 + C^{1/k} → 2` as `k → ∞`
  (via `C^{1/k} = exp((log C)/k) → 1`);
- `eventually_levelSet_subset_closedBall` — for `C ≥ 1` and any `ε > 0`, there is a
  degree threshold `K` such that **every** cyclotomic level set with `φ(n) ≥ K`
  fits inside the single fixed disc `closedBall(0, 2 + ε)`.

The last is the geometric payoff: all sufficiently high-degree cyclotomic lemniscates
are uniformly confined to a disc barely larger than the unit disc — no room for a path
escaping to `∞`, the antithesis of the Mac Lane labyrinth needed by a general
unit-circle-rooted polynomial. This rounds out the elementary quantitative side of
OQ-02 (bounded [OQ01] → sharp two-sided radii [OQ02] → area squeeze [OQ03] → radius
shrinkage [this]). The genuinely open driver — small-`n` (`n = 3,4,6`) lemniscate
component/path topology — still needs polynomial-lemniscate topology absent from
Mathlib.

## Verification

- **3 theorems, 0 sorry, 0 axiom.**
- Full elaboration clean under Docker/Lean v4.26.0: `[7746/7746] Building
  Proofs.CyclotomicPolynomialsOQ02OQ04`, no `unsolved goals`/`unknown`/type errors
  (all lemma names — `tendsto_inv_atTop_zero`, `tendsto_order`, `Real.continuous_exp`,
  `inv_le_inv_of_le`, `sublevel_subset_closedBall_sharp` — resolved).
- The olean *write* was env-blocked (`Lean exited with code 135`, the documented
  stochastic SIGBUS olean-write crash), so shipped **UNVERIFIED** despite clean
  elaboration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)