### PR TITLE
audit: erdos-959 re-verified clean (tracker bump)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17675,9 +17675,9 @@
       "result": "clean"
     },
     "erdos-959": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:10:51Z",
+      "agentId": "auditor-cycle-20260709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T21:05:00Z",
       "result": "clean"
     },
     "erdos-96": {
@@ -29764,5 +29764,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-09T00:00:00Z"
+  "lastUpdated": "2026-07-09T21:05:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-959

**Proof**: erdos-959 (Distance Frequency Gaps in Planar Point Sets)
**Result**: CLEAN ✓ (was stalest at 2026-05-03)

## Verification

All meta.json counts match the Lean source (`proofs/Proofs/Erdos959Problem.lean`, 158 lines):

| Field | meta.json | Actual |
|-------|-----------|--------|
| sorries | 0 | 0 |
| axiomCount | 2 | 2 (`clemen_dumitrescu_liu`, `clemen_dumitrescu_liu_general`) |
| theoremCount | 7 | 7 |
| definitionCount | 8 | 8 |
| lineCount | 158 | 158 |

**Integrity checks:**
- `status: axiomatized` / `badge: axiom` — correct for an open problem (erdosProblemStatus: open) with 2 disclosed axioms.
- Main result `erdos_959_resolved := clemen_dumitrescu_liu` is fully disclosed as proved-from-axiom in both `assumptions` and `originalContributions` — no axiom masking.
- Both axioms are genuine CDL (2025) lower-bound claims with correctly universally-quantified constants — not vacuous `True`/zero stubs.
- No `native_decide` → no undisclosed `Lean.ofReduceBool`.
- No phantom declarations; every `originalContributions` entry exists in source.

No changes needed to meta.json. This PR only bumps the audit tracker.

---
Discovered during gallery integrity audit.