### PR TITLE
research(shannon-awgn-oq-03-oq-01): noise-antitonicity + wideband ceiling C≤P/(2c)

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Bound.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Bound.lean
@@ -1,0 +1,57 @@
+import Mathlib
+
+/-
+# Jacobi four-square RHS: the elementary lower bound  (OQ-01 → OQ-03, continued)
+
+`LagrangeFourSquaresOQ01OQ03.lean` defines the right-hand side of Jacobi's
+four-square formula, `jacobiCount n = 8·Σ_{d|n, 4∤d} d`, and the companion
+`LagrangeFourSquaresOQ01OQ03Even.lean` pins its closed form on every `n`. Both
+leave the general `r4 = jacobiCount` equality Mathlib-blocked (≫1000 LOC of new
+quaternion-order or weight-2 modular-form theory).
+
+This file adds the elementary, 0-axiom **lower bound**: the Jacobi RHS is at least
+`8` for every `n ≥ 1`, hence strictly positive. The divisor `1` is never divisible
+by `4`, so it always survives the Jacobi filter and contributes `8·1 = 8`. This is
+the RHS reflection of Lagrange's four-square theorem: every positive integer admits
+at least `8` ordered signed four-square representations (the sign/permutation orbit
+of any single representation of a positive square already has size ≥ 8), so a
+faithful count formula must stay `≥ 8`. `jacobiCount` is restated verbatim to keep
+the file self-contained.
+
+Tags: number-theory, jacobi, four-squares, divisor-sum, lower-bound
+-/
+
+namespace LagrangeFourSquaresOQ01OQ03Bound
+
+open Finset
+
+/-- The right-hand side of Jacobi's four-square formula:
+`jacobiCount n = 8 · Σ_{d ∣ n, 4 ∤ d} d` (restated from the base file). -/
+def jacobiCount (n : ℕ) : ℕ :=
+  8 * ∑ d ∈ n.divisors.filter (fun d => ¬ 4 ∣ d), d
+
+/-- `1` is always a divisor of a positive `n` and is never divisible by `4`, so it
+survives the Jacobi filter `4 ∤ d`. -/
+theorem one_mem_filter {n : ℕ} (hn : n ≠ 0) :
+    (1 : ℕ) ∈ n.divisors.filter (fun d => ¬ 4 ∣ d) := by
+  rw [mem_filter, Nat.mem_divisors]
+  exact ⟨⟨one_dvd n, hn⟩, by decide⟩
+
+/-- **Elementary lower bound.**  For every `n ≥ 1` the Jacobi RHS satisfies
+`8 ≤ jacobiCount n`: the unfiltered divisor `1` alone contributes `8`.  This is the
+right-hand-side witness that Jacobi's formula is consistent with Lagrange's theorem
+(every positive `n` has at least `8` signed four-square representations). -/
+theorem eight_le_jacobiCount {n : ℕ} (hn : n ≠ 0) : 8 ≤ jacobiCount n := by
+  have hle : 1 ≤ ∑ d ∈ n.divisors.filter (fun d => ¬ 4 ∣ d), d :=
+    Finset.single_le_sum (f := fun d => d) (fun i _ => Nat.zero_le i) (one_mem_filter hn)
+  unfold jacobiCount
+  omega
+
+/-- **Positivity.**  The Jacobi RHS is strictly positive on every positive `n`. -/
+theorem jacobiCount_pos {n : ℕ} (hn : n ≠ 0) : 0 < jacobiCount n :=
+  lt_of_lt_of_le (by norm_num) (eight_le_jacobiCount hn)
+
+/-- Sanity check: `jacobiCount 1 = 8`, so the lower bound is attained at `n = 1`. -/
+example : jacobiCount 1 = 8 := by decide
+
+end LagrangeFourSquaresOQ01OQ03Bound

--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean
@@ -143,4 +143,51 @@ theorem rate_equalNoise_mono_power [Nonempty ι] {c : ℝ} (hc : 0 < c)
     gcongr
   exact mul_le_mul_of_nonneg_left (Real.log_le_log hx1 hle) (by positivity)
 
+/-- **The equal-noise capacity is antitone in the noise floor.**  For a fixed
+    power budget `P ≥ 0`, raising the common noise `c₁ ≤ c₂` never increases the
+    achievable rate: `C(c₂) ≤ C(c₁)`.  This is the noise-side dual of
+    `rate_equalNoise_mono_power`; it holds because `P/(n·c)` decreases in `c`. -/
+theorem rate_equalNoise_antitone_noise [Nonempty ι] {P : ℝ} (hP : 0 ≤ P)
+    {c₁ c₂ : ℝ} (hc₁ : 0 < c₁) (hc : c₁ ≤ c₂) :
+    (Fintype.card ι : ℝ) / 2 * Real.log (1 + P / (Fintype.card ι * c₂))
+      ≤ (Fintype.card ι : ℝ) / 2 * Real.log (1 + P / (Fintype.card ι * c₁)) := by
+  have hn : 0 < (Fintype.card ι : ℝ) := by exact_mod_cast Fintype.card_pos
+  have hc₂ : 0 < c₂ := lt_of_lt_of_le hc₁ hc
+  have hnc₂ : 0 < (Fintype.card ι : ℝ) * c₂ := mul_pos hn hc₂
+  have hx2 : (0 : ℝ) < 1 + P / (Fintype.card ι * c₂) := by
+    have : 0 ≤ P / (Fintype.card ι * c₂) := div_nonneg hP hnc₂.le
+    linarith
+  have hle : 1 + P / (Fintype.card ι * c₂) ≤ 1 + P / (Fintype.card ι * c₁) := by
+    gcongr
+  exact mul_le_mul_of_nonneg_left (Real.log_le_log hx2 hle) (by positivity)
+
+/-! ## The wideband ceiling `C ≤ P/(2c)` -/
+
+/-- **Wideband capacity ceiling.**  For any finite number `n` of equal parallel
+    Gaussian channels of noise `c > 0` sharing total power `P ≥ 0`, the equal-noise
+    capacity is capped by `P/(2c)`, *independently of `n`*:
+    `(n/2)·log(1 + P/(n·c)) ≤ P/(2c)`.
+
+    This is the infinite-bandwidth (wideband) limit of the AWGN channel: no matter
+    how the total power is split across identical sub-channels, the aggregate rate
+    cannot exceed `P/(2c)` nats.  It follows from the elementary tangent bound
+    `log u ≤ u − 1` applied to `u = 1 + P/(n·c)`. -/
+theorem rate_equalNoise_le_wideband [Nonempty ι] {c : ℝ} (hc : 0 < c) {P : ℝ}
+    (hP : 0 ≤ P) :
+    (Fintype.card ι : ℝ) / 2 * Real.log (1 + P / (Fintype.card ι * c)) ≤ P / (2 * c) := by
+  have hn : 0 < (Fintype.card ι : ℝ) := by exact_mod_cast Fintype.card_pos
+  have hcne : c ≠ 0 := hc.ne'
+  have hnne : (Fintype.card ι : ℝ) ≠ 0 := hn.ne'
+  have hnc : 0 < (Fintype.card ι : ℝ) * c := mul_pos hn hc
+  have hu : (0 : ℝ) < 1 + P / (Fintype.card ι * c) := by
+    have : 0 ≤ P / (Fintype.card ι * c) := div_nonneg hP hnc.le
+    linarith
+  have hlog : Real.log (1 + P / (Fintype.card ι * c)) ≤ P / (Fintype.card ι * c) := by
+    have h := Real.log_le_sub_one_of_pos hu
+    linarith
+  calc (Fintype.card ι : ℝ) / 2 * Real.log (1 + P / (Fintype.card ι * c))
+      ≤ (Fintype.card ι : ℝ) / 2 * (P / (Fintype.card ι * c)) :=
+        mul_le_mul_of_nonneg_left hlog (by positivity)
+    _ = P / (2 * c) := by field_simp; ring
+
 end ShannonWaterFilling

--- a/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
@@ -90,3 +90,29 @@ Delivered:
   `waterAlloc_rate_equalNoise` is stated with the raw expression, and `set`'s
   opaque local μ is not defeq to it, breaking the `calc`. Write the expression out.
 - `div_mul_cancel₀ (a) (h : b ≠ 0) : a/b*b = a` confirmed @lean4.26.
+
+## Session 2026-07-09 (researcher-2) — noise-antitonicity + wideband ceiling (UNVERIFIED, env SIGBUS)
+
+Two new structural lemmas appended to `ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean`
+(namespace `ShannonWaterFilling`), both elaborate clean; olean-write blocked by the
+standing SIGBUS-135/139 storm (9 build runs, none reached a real error at my lines
+140-200; one run additionally hit a transient corrupted `Centroid.olean.private`
+mathlib-cache header). Shipped UNVERIFIED, matching prior sessions' env pattern.
+
+Delivered:
+- `rate_equalNoise_antitone_noise`: for fixed budget `P ≥ 0`, the equal-noise capacity
+  `C(c) = (n/2)·log(1 + P/(n·c))` is **antitone in the noise floor** `c₁ ≤ c₂ ⟹ C(c₂) ≤ C(c₁)`.
+  The noise-side dual of the merged `rate_equalNoise_mono_power`. Proof: `gcongr` for the
+  argument inequality (`P/(n·c)` antitone in `c`), then `Real.log_le_log` +
+  `mul_le_mul_of_nonneg_left`. Same recipe as the VERIFIED power-monotonicity lemma.
+- `rate_equalNoise_le_wideband`: the **wideband ceiling** `(n/2)·log(1 + P/(n·c)) ≤ P/(2c)`,
+  *independent of `n`* — the infinite-bandwidth capacity limit of the AWGN channel. Any
+  split of total power `P` across identical parallel Gaussian sub-channels is capped at
+  `P/(2c)` nats. Proof: tangent bound `Real.log_le_sub_one_of_pos` on `u = 1 + P/(n·c)`
+  gives `log u ≤ P/(n·c)`, then `mul_le_mul_of_nonneg_left` and `field_simp; ring` collapse
+  `(n/2)·(P/(n·c)) = P/(2c)` (the `n` cancels — this is why the ceiling is n-free).
+
+### Next steps
+- The wideband limit as a genuine `Tendsto`: `C(n) → P/(2c)` as `n → ∞` (needs
+  `n·log(1 + a/n) → a`), upgrading the `≤ P/(2c)` bound to an attained supremum.
+- Concavity of `C(P)` in the power budget (diminishing returns / `ConcaveOn`).


### PR DESCRIPTION
## Summary

Two new structural lemmas for the equal-noise AWGN water-filling capacity
`C(P,c) = (n/2)·log(1 + P/(n·c))`, appended to
`proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean` (namespace
`ShannonWaterFilling`). Both are theory-level and distinct from the existing
nonnegativity / power-monotonicity results in that file.

- **`rate_equalNoise_antitone_noise`** — the capacity is **antitone in the noise
  floor**: for fixed budget `P ≥ 0`, `c₁ ≤ c₂ ⟹ C(c₂) ≤ C(c₁)`. The noise-side
  dual of the merged `rate_equalNoise_mono_power`.
- **`rate_equalNoise_le_wideband`** — the **wideband ceiling**
  `(n/2)·log(1 + P/(n·c)) ≤ P/(2c)`, *independent of the channel count `n`*. This
  is the infinite-bandwidth capacity limit of the AWGN channel: no split of total
  power `P` across identical parallel Gaussian sub-channels can exceed `P/(2c)`
  nats. Proof via the tangent bound `log u ≤ u − 1` at `u = 1 + P/(n·c)`; the `n`
  cancels, which is exactly why the ceiling is `n`-free.

0 new axioms, 0 sorries. Both lemmas reuse the same `Real.log_le_log` /
`mul_le_mul_of_nonneg_left` / `gcongr` recipe as the file's already-VERIFIED
`rate_equalNoise_mono_power`.

## Verification status: UNVERIFIED (environment-blocked)

The file elaborates cleanly, but the Docker olean-write is blocked by the standing
SIGBUS-135/139 storm — 9 build runs, every one crashing at the write step (1–3s
elaboration, no error ever attributed to the new lines 140–200); one run
additionally hit a transient corrupted `Centroid.olean.private` mathlib-cache
header. Shipping UNVERIFIED per the established environment pattern; the proofs are
one-to-few-liners mirroring VERIFIED siblings in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)