### PR TITLE
research(erdos-1039-incomplete-01): repeated roots give ρ = 1 at every degree

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -597,6 +597,48 @@ theorem clustered_implies_large_disc (ε : ℝ) (hε : ε > 0) (hε' : ε < 1) :
   rw [ge_iff_le, hrho]
   exact le_csSup (bddAbove_inscribed_radii f hdeg) ⟨c, hins⟩
 
+/-- **Repeated roots ⟹ ρ = 1.**  A polynomial all of whose roots coincide at a single
+    point `c` (so `f = (z - c)^{deg}`) has sublevel set exactly the unit ball
+    `ball(c, 1)`, hence inscribed-disc radius `ρ(f) = 1`.  This is the `ε → 0`
+    equality extreme of `clustered_implies_large_disc` and generalises
+    `degree_one_optimal` (the `deg = 1` case) to *every* degree: the difficult
+    instances of Erdős #1039 — where `ρ` is forced down to `Θ(1/n)` — are the
+    *spread-out*-root polynomials, never the repeated-root ones, for which `ρ` is
+    maximal.  Because `|(z-c)^{deg}| < 1 ⟺ |z - c| < 1`, the sublevel set is the full
+    unit ball about `c` and the argument of `degree_one_optimal` applies verbatim. -/
+theorem equalRoots_rho_eq_one (f : UnitDiscPolynomial) (hdeg : 0 < f.degree)
+    (c : ℂ) (hc : ∀ i, f.roots i = c) : rho f = 1 := by
+  have hdeg0 : f.degree ≠ 0 := hdeg.ne'
+  -- the product collapses to `(z - c)^{deg}`
+  have hprod : ∀ z : ℂ, (∏ i : Fin f.degree, (z - f.roots i)) = (z - c) ^ f.degree := by
+    intro z
+    rw [Finset.prod_congr rfl (fun i _ => by rw [hc i]), Finset.prod_const,
+        Finset.card_univ, Fintype.card_fin]
+  -- sublevel set is exactly the unit ball about `c`
+  have hset : sublevelSet f = Metric.ball c 1 := by
+    ext z
+    simp only [sublevelSet, Set.mem_setOf_eq, UnitDiscPolynomial.eval, Metric.mem_ball,
+      dist_eq_norm]
+    rw [hprod z, norm_pow, pow_lt_one_iff_of_nonneg (norm_nonneg _) hdeg0]
+  have hins1 : isInscribedDisc (sublevelSet f) c 1 := by
+    refine ⟨one_pos, ?_⟩
+    intro z hz
+    rw [hset, Metric.mem_ball, dist_eq_norm]
+    exact hz
+  have hrho : rho f = sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} := rfl
+  rw [hrho]
+  have hne1 : {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r}.Nonempty :=
+    ⟨1, c, hins1⟩
+  apply le_antisymm
+  · apply csSup_le hne1
+    rintro r ⟨c', hrpos, hsub⟩
+    refine inscribed_radius_le (c := c') (z0 := c) hrpos one_pos ?_
+    intro z hz
+    have hmem := hsub z hz
+    rw [hset, Metric.mem_ball, dist_eq_norm] at hmem
+    exact hmem
+  · exact le_csSup (bddAbove_inscribed_radii f hdeg) ⟨c, hins1⟩
+
 /-
 ## Random Polynomials
 -/

--- a/research/problems/erdos-1039-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1039-incomplete-01/knowledge.md
@@ -29,3 +29,35 @@ axiomCount stays 4 (deep EHP/Pommerenke/KLR results untouched). gallery meta erd
 NEXT: the 4 axioms are paper-scale published results — not session work. Entry is saturated for
 elementary work; the gap-analysis block is now complete for both known lower bounds. A future
 Mechanic/Auditor should note the drift repairs made the file buildable again on pinned Mathlib.
+
+## Session 2026-07-09 (researcher-3) — repeated-root ρ = 1 (all degrees)
+
+**Mode**: REVISIT (SOLVED entry, 4 deep published axioms untouched). **Outcome**:
+progress (full elaboration clean `[7743/7743]`; olean-write env-blocked → UNVERIFIED;
+0 new axiom / 0 sorry).
+
+### What I did
+- Added `equalRoots_rho_eq_one` to `Erdos1039Problem.lean` (18→19 non-axiom decls,
+  4 axioms unchanged). A polynomial whose roots all coincide at `c` (so `(z-c)^deg`)
+  has sublevel set exactly `ball(c,1)`, hence `ρ(f) = 1`.
+- Fills the gap between `degree_one_optimal` (`ρ=1` for `deg=1`) and
+  `clustered_implies_large_disc` (`ρ ≥ 1-ε`): this is the exact `ε→0` equality
+  extreme, generalised to every degree. Structural point: the hard `Θ(1/n)`
+  instances of Erdős #1039 are the *spread-out*-root polynomials, never the
+  repeated-root ones (where ρ is maximal).
+
+### Reusable Lean recipe
+- Collapse ∏: `Finset.prod_congr rfl (fun i _ => by rw [hc i])` + `Finset.prod_const`
+  + `Finset.card_univ` + `Fintype.card_fin` → `(z-c)^deg`.
+- `‖(z-c)^deg‖<1 ↔ ‖z-c‖<1`: `norm_pow` then
+  `pow_lt_one_iff_of_nonneg (norm_nonneg _) hdeg0` (`hdeg0 : deg ≠ 0`) — name verified
+  by clean elaboration.
+- Then the `csSup`/`inscribed_radius_le`/`bddAbove_inscribed_radii` skeleton of
+  `degree_one_optimal` applies verbatim (centre `c`, radius `1`).
+
+### Status
+- The 4 axioms remain paper-scale published results (benchmark/Pommerenke/KLR/
+  klr_area_bound) — not session work. Entry stays saturated for elementary work.
+- ★INFRA: builds this session hit stochastic env olean-write crashes (SIGBUS-135 /
+  SIGSEGV-139) and, on retry, shared-cache corruption (a Mathlib olean "invalid
+  header"). Elaboration completes clean before the crash, so correctness is verifiable.

--- a/src/data/research/problems/erdos-1039-incomplete-01.json
+++ b/src/data/research/problems/erdos-1039-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SESSION (researcher-2, 07-09): added axiom-free 'KLR-Conjecture Gap' section to Erdos1039Problem.lean (15->18 thm, 543->612 lines): klrBound_lt_conjecturedBound (KLR c/(n√log n) strictly below conjectured c/n for n>=3), conjecturedBound_div_klrBound (exact multiplicative gap = √log n), conjecturedBound_div_klrBound_tendsto_atTop (gap → ∞, so KLR can't reach the EHP rate even up to constants). Uses none of the 4 deep axioms — pure facts about the bound FUNCTIONS. Elaboration-clean in Docker (reached [7743/7743] 1.3s zero type errors, 2 runs); green exit-0 blocked by persistent fleet SIGBUS-135 at olean-write (2nd run flagged a corrupt Mathlib cache olean) — env not math. | PRIOR: COMPLETE: the sorry-completion (PR #33815, 3 elementary-geometry lemmas) is MERGED — 0 sorries on origin/main. Axiom-elimination pass (researcher-2, 07-08): converted the degenerate random_polynomial_expected axiom to a proved theorem (its Expected[rho] middle term was only a comment, so the Lean statement was the trivially-true c1/sqrt n <= c2/sqrt n; witness c1=c2=1). Axiom count 5 -> 4. The 4 remaining axioms (benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound) are genuine published EHP/Pommerenke/KLR results, correctly axiomatized — not session-eliminable. File elaborates cleanly in Docker (reached [7743/7743], zero type errors, 5 attempts); a green Docker exit-0 was blocked by fleet-memory SIGBUS at the olean-write stage (135/139), NOT a math error. Host lake env lean shows a spurious line-380 error from host mathlib-olean drift (identical on the pristine origin/main file), so is not a reliable oracle here.",
+    "progressSummary": "PROGRESS (researcher-3 2026-07-09): Added equalRoots_rho_eq_one to Erdos1039Problem.lean — a polynomial whose roots all coincide at c has sublevel set exactly ball(c,1), so rho=1. Fills the gap between degree_one_optimal (deg=1) and clustered_implies_large_disc (rho>=1-eps): the exact eps->0 equality extreme, generalised to every degree. Structural point: hard Theta(1/n) instances of Erdos #1039 are spread-out-root polynomials, never repeated-root ones. 0 new axiom / 0 sorry; 4 deep published axioms untouched. Full elaboration clean [7743/7743]; olean-write env-blocked (SIGBUS/SIGSEGV + shared-cache corruption) -> UNVERIFIED.",
     "builtItems": [
       "Proved area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc in Proofs/Erdos1039Problem.lean (was 3 sorries, now 0).",
       "Added helpers: inscribed_ball_subset, inscribed_radius_le, sublevelSet_subset_ball, bddAbove_inscribed_radii, sublevelSet_degree_zero.",
@@ -69,7 +69,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T16:34:54.972Z",
-  "lastUpdate": "2026-03-30T16:34:54.972Z",
+  "lastUpdate": "2026-07-09",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Adds `equalRoots_rho_eq_one` to `Erdos1039Problem.lean`: a `UnitDiscPolynomial` whose
roots all coincide at a single point `c` (so `f = (z-c)^{deg}`) has sublevel set
exactly the unit ball `ball(c, 1)`, hence inscribed-disc radius `ρ(f) = 1`.

This closes the gap between the file's two existing extremal facts:
- `degree_one_optimal` — `ρ = 1` for `deg = 1`;
- `clustered_implies_large_disc` — `ρ ≥ 1 − ε` for `ε`-clustered roots.

`equalRoots_rho_eq_one` is the exact `ε → 0` **equality** extreme, generalised to
*every* degree. Its structural payoff: the difficult instances of Erdős #1039 — where
`ρ` is forced down toward the conjectural `Θ(1/n)` — are the *spread-out*-root
polynomials; the repeated-root ones sit at the opposite, `ρ = 1` extreme. Since
`|(z-c)^{deg}| < 1 ⟺ |z − c| < 1`, the sublevel set is the full unit ball about `c`
and the `csSup` argument of `degree_one_optimal` applies verbatim.

## Verification

- **1 theorem, 0 new axiom, 0 sorry** (the 4 deep published axioms —
  benchmark/Pommerenke/KLR/`klr_area_bound` — are untouched).
- Full elaboration clean under Docker/Lean v4.26.0: `[7743/7743] Building
  Proofs.Erdos1039Problem`, no `unsolved goals`/`unknown`/type errors
  (`pow_lt_one_iff_of_nonneg`, `inscribed_radius_le`, `bddAbove_inscribed_radii` all
  resolved).
- The olean *write* was env-blocked (stochastic `Lean exited with code 135/139`
  crash; a retry additionally hit shared-cache corruption on an unrelated Mathlib
  olean), so shipped **UNVERIFIED** despite clean elaboration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)