### PR TITLE
audit: erdos-958 re-verified clean (tracker bump)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17669,9 +17669,9 @@
       "result": "clean"
     },
     "erdos-958": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:10:51Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T04:01:38Z",
       "result": "clean"
     },
     "erdos-959": {


### PR DESCRIPTION
## Auditor: erdos-958 (Distance Multiplicities and Point Configurations)

Re-verified gallery integrity for `erdos-958`. **Result: CLEAN.**

### Findings
- **Counts accurate**: 2 axioms, 1 theorem, 11 definitions, 0 sorries, 200 lines — all match `Proofs/Erdos958Problem.lean`.
- **Axioms real & disclosed**: `clemen_dumitrescu_liu` (∀ n≥4, ∃ arc+center config with special pattern & ¬standard) and `conjecture_disproved` (¬OriginalConjecture). Both listed in `assumptions`.
- **No masking**: `erdos_958_summary` is honestly `⟨conjecture_disproved, clemen_dumitrescu_liu⟩`; its leanType matches source. Not a True-stub.
- **No degenerate stubs**: every definition carries real content (`isArcPlusCenter`, `hasSpecialPattern`, `OriginalConjecture`).
- **status=axiomatized / badge=axiom** correct for this disproved conjecture. No `native_decide` → `axiomCount:2` correct (no ofReduceBool).
- Prose, sections, and line numbers match the Lean source.

Tracker bump only (auditCount 3→4, lastAudited → 2026-07-10). No source or meta changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)