### PR TITLE
Enrich erdos-90 (Unit Distance Problem): fix orphaned annotation & declare companion files

### DIFF
--- a/src/data/proofs/erdos-90/annotations.json
+++ b/src/data/proofs/erdos-90/annotations.json
@@ -206,8 +206,8 @@
       "Dirichlet unit theorem"
     ],
     "range": {
-      "startLine": 106,
-      "endLine": 145
+      "startLine": 61,
+      "endLine": 75
     }
   }
 ]

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -192,6 +192,13 @@
       "startLine": 61,
       "endLine": 75,
       "summary": "States the main conjecture (`ErdosProblem90`): $u(n) \\leq n^{1+C/\\log\\log n}$ eventually, matching the lattice lower bound up to the constant $C$. Also states the weak form (`erdos_90_weak`): $u(n) \\leq n^{1+\\varepsilon}$ for every $\\varepsilon > 0$ and large $n$. On 2026-05-20 OpenAI announced a reported disproof of the conjectured exponent via class field tower constructions (peer review pending); the file's comments are updated to reflect this status."
+    },
+    {
+      "id": "valtr-obstruction",
+      "title": "Valtr's Obstruction",
+      "startLine": 76,
+      "endLine": 81,
+      "summary": "Valtr's result that a non-Euclidean metric on ℝ² admits Θ(n^{4/3}) unit distances, showing any improvement on the n^{4/3} upper bound must exploit properties specific to Euclidean distance rather than the bare incidence structure."
     }
   ],
   "conclusion": {
@@ -234,7 +241,13 @@
     "theoremCount": 0,
     "definitionCount": 3,
     "path": "Proofs/Erdos90Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos90/ClassFieldTower.lean",
+      "Proofs/Erdos90/ClassGroupLRank.lean",
+      "Proofs/Erdos90/GolodShafarevich.lean",
+      "Proofs/Erdos90/OpenAI2026LowerBound.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
Structural-defect fix found via a pool-wide scan (this was the only annotation-past-EOF in the gallery).

## Defects fixed in `erdos-90`
1. **Orphaned annotation**: `openai-2026-extraction-scaffold` had range 106–145, but `Erdos90Problem.lean` is only 81 lines — it rendered against nonexistent lines. Re-anchored to 61–75, the primary file's Erdős-1946-conjecture / OpenAI-2026-construction section that the annotation discusses. (Overlapping ranges are already used in this entry, e.g. 52–65 vs 54–56.)
2. **Undeclared companion files**: the annotation and overview reference `Proofs/Erdos90/OpenAI2026LowerBound.lean` and siblings, but `leanFile.additionalFiles` was empty. Populated it with the 4 existing companion files (following the erdos-613 bare-path-list convention).
3. **Section coverage gap**: `sections` stopped at line 75, leaving the "Valtr's Obstruction" block (76–81) uncovered. Added the missing section.

Axiom integrity unaffected: badge stays `axiom`; `leanFile.axiomCount` correctly counts only the 81-line primary file (0 literal axioms), while the axiomatized companion construction is already reflected by the `axiom` badge.

No content deleted; JSON validates and gallery build stages pass.