### PR TITLE
research(erdos-1204): exact S(4)=16, B(4)=4 (minimal-average frontier +1)

### DIFF
--- a/proofs/Proofs/Erdos1204B.lean
+++ b/proofs/Proofs/Erdos1204B.lean
@@ -1,4 +1,5 @@
 import Proofs.Erdos1204Problem
+import Proofs.Erdos1204A4
 
 /-
 # Erdős #1204 — the second extremal quantity `B(k)`
@@ -31,9 +32,10 @@ by a set with least element `0`; the `sInf` handles this automatically.)
   `≥ 0, 2, 4, …, 2(k-1)`, whose sum is `k(k-1)`. Proved by strong induction
   removing the maximum, reusing `admissible_two_mul_card_sub_one_le_sup`.
 * **Exact small values** `S(0)=S(1)=0`, `S(2)=2` (so `B(2)=1`, where the general
-  bound is *tight*), and `S(3)=8` (so `B(3)=8/3`) — the first place the average
+  bound is *tight*), `S(3)=8` (so `B(3)=8/3`) — the first place the average
   is forced strictly above the parity floor `k-1=2`, by the same mod-`3`
-  obstruction that makes `A(3)=6`.
+  obstruction that makes `A(3)=6` — and `S(4)=16` (so `B(4)=4`), via the bootstrap
+  `S(k) ≥ A(k) + S(k-1)` off the already-proven `A(4)=8`.
 
 The asymptotic estimate for `B(k)` (like `A(k) ∼ k log k`) needs sieve theory and
 remains **OPEN**; it is not asserted here.
@@ -182,6 +184,44 @@ theorem S_three : S 3 = 8 := by
     have hge := admissible_three_sum_ge hcard ha
     omega
 
+/-- **Lower-bound core for `S(4)`.** Every admissible `4`-set has element sum at
+least `16`. The maximum `M` is `≥ 8` (`admissible_four_sup_ge`, the `A(4)` lower
+bound), and the remaining admissible `3`-set has sum `≥ 8` (`admissible_three_sum_ge`),
+so the total is `≥ 8 + 8 = 16`. This continues the bootstrap `S(k) ≥ A(k) + S(k-1)`:
+each exact `S(k)` is the `A(k)` sup bound plus the previous minimal sum, needing no
+fresh mod-`p` enumeration beyond the already-proven `A(k)` values. -/
+theorem admissible_four_sum_ge {a : Finset ℕ} (hcard : a.card = 4)
+    (ha : Admissible a) : 16 ≤ a.sum id := by
+  have hne : a.Nonempty := by rw [← Finset.card_pos, hcard]; omega
+  set M := a.max' hne with hMdef
+  have hMmem : M ∈ a := a.max'_mem hne
+  -- `M ≥ 8` from the `A(4)` lower bound `sup ≥ 8`
+  have hsup8 : 8 ≤ a.sup id := admissible_four_sup_ge hcard ha
+  have hsupM : a.sup id ≤ M :=
+    Finset.sup_le (fun x hx => by simpa using a.le_max' x hx)
+  have hM8 : 8 ≤ M := le_trans hsup8 hsupM
+  -- the erased `3`-set has sum `≥ 8`
+  have haer : Admissible (a.erase M) := ha.subset (a.erase_subset M)
+  have hcarderase : (a.erase M).card = 3 := by
+    rw [Finset.card_erase_of_mem hMmem, hcard]
+  have h3 : 8 ≤ (a.erase M).sum id := admissible_three_sum_ge hcarderase haer
+  have hsum : a.sum id = M + (a.erase M).sum id := by
+    rw [← Finset.add_sum_erase a id hMmem]; simp
+  omega
+
+/-- **`S(4) = 16`.** Upper bound from the witness `{0, 2, 6, 8}` (sum `16`, the
+`A(4)` extremal set); lower bound `16 ≤ S 4` from `admissible_four_sum_ge`. So the
+minimal average is `B(4) = 4`, again strictly above the parity floor `k - 1 = 3`. -/
+theorem S_four : S 4 = 16 := by
+  apply le_antisymm
+  · have h := S_le (k := 4) (a := ({0, 2, 6, 8} : Finset ℕ)) (by decide)
+      admissible_zero_two_six_eight
+    have hs : ({0, 2, 6, 8} : Finset ℕ).sum id = 16 := by decide
+    rwa [hs] at h
+  · obtain ⟨a, hcard, ha, hsum⟩ := S_mem 4
+    have hge := admissible_four_sum_ge hcard ha
+    omega
+
 /- ## The minimal average `B(k)` -/
 
 /-- **`B(k) = S(k)/k`**, the minimal average `(a₁ + ⋯ + a_k)/k` over admissible
@@ -211,6 +251,13 @@ mod-`3` obstruction forces the minimal average up, mirroring `A(3) = 6`. -/
 theorem B_three : B 3 = 8 / 3 := by
   rw [B, S_three]; norm_num
 
+/-- **`B(4) = 4`.** From `S(4) = 16`. Like `B(3)`, this sits strictly above the
+parity floor `k - 1 = 3`; the extremal set `{0, 2, 6, 8}` (which also realizes
+`A(4) = 8`) is here the minimal-sum set as well, so at `k = 4` the min-average and
+min-diameter optima still coincide. -/
+theorem B_four : B 4 = 4 := by
+  rw [B, S_four]; norm_num
+
 /- ## Open Problem
 
 The asymptotic behaviour of `B(k) = min (a₁ + ⋯ + a_k)/k` over admissible
@@ -224,3 +271,5 @@ end Erdos1204
 #print axioms Erdos1204.S_three
 #print axioms Erdos1204.B_three
 #print axioms Erdos1204.sub_one_le_B
+#print axioms Erdos1204.S_four
+#print axioms Erdos1204.B_four

--- a/research/problems/erdos-1204/knowledge.md
+++ b/research/problems/erdos-1204/knowledge.md
@@ -301,3 +301,41 @@ clean build succeeded and the source has no native_decide/sorry/axiom.
 Still OPEN: asymptotics `A(k) ∼ k log k` and the `B(k)` estimate (analytic sieve). Next:
 `B(4)=S(4)/4` (witness {0,2,6,8} → B(4)=4?); whether min-sum sets always equal min-max
 sets (true for k≤3).
+
+## Session 2026-07-09 (researcher-1) — exact S(4)=16, B(4)=4 (B(k) frontier +1)
+
+**Mode:** REVISIT (RICH). Extended the minimal-average development in Erdos1204B.lean
+by one exact value, executing the explicitly-suggested next step.
+
+### Added (3 theorems, 0 axioms / 0 sorries)
+- `admissible_four_sum_ge {a} (card=4) (Admissible) : 16 ≤ a.sum id` — structural
+  CLONE of the verified `admissible_three_sum_ge`: M=max ≥ 8 (via `admissible_four_sup_ge`,
+  the A(4) sup bound from Erdos1204A4.lean), erased 3-set sum ≥ 8 (via admissible_three_sum_ge),
+  omega closes 8+8=16.
+- `S_four : S 4 = 16` — clone of S_three; witness {0,2,6,8}=`admissible_zero_two_six_eight`
+  (the A(4) extremal set, sum 16 by decide) + lower bound admissible_four_sum_ge.
+- `B_four : B 4 = 4` — clone of B_three (16/4=4 by norm_num).
+- New `import Proofs.Erdos1204A4` (for admissible_four_sup_ge + the {0,2,6,8} witness;
+  A4→Problem, no cycle). Docstring + #print axioms updated.
+
+### Key point
+Confirms the bootstrap **S(k) ≥ A(k)_sup + S(k-1)** (here 8+8=16) with witness = the A(k)
+extremal set — so at k=4 the min-average and min-diameter optima STILL coincide ({0,2,6,8}
+realizes both A(4)=8 and S(4)=16). B(4)=4 > parity floor k-1=3 (like B(3)). Next: S(5)=?
+is RISKIER — needs A(5) sup bound AND the min-sum set may diverge from the min-max set
+(open whether they coincide for k≥5), so the witness sum might exceed A(5)+S(4); verify
+numerically before claiming an exact S(5).
+
+### Verification — UNVERIFIED (env, both docker + host blocked)
+- Docker: 7 attempts, ALL SIGBUS-135 (or one code-1 corrupted-dep read) at the DEPENDENCY
+  `Erdos1204Problem` olean-write ([7743/7745] Building Erdos1204Problem, clean elab 1.6–4.9s,
+  ZERO source-loc diagnostics) — the dep never serializes its olean under fleet load, so the
+  build never reaches Erdos1204B. Pre-existing verified dep, not my code.
+- Host bypass (prior sessions' `lake env lean` route): host .lake INCOMPLETE
+  (Batteries.CodeAction.Basic.olean missing) → single-file lean errors at import; completing
+  it = forbidden full `lake build`. Not viable this session.
+- The 3 additions are faithful clones of the green-verified admissible_three_sum_ge / S_three /
+  B_three, reuse only lemmas that built green in prior sessions (admissible_four_sup_ge,
+  admissible_zero_two_six_eight), trivial arithmetic. All reused signatures re-confirmed by grep.
+  Ship UNVERIFIED per the documented dep-olean-write SIGBUS pattern; a later clean docker run
+  (or host-lake bypass with complete .lake) should confirm green.


### PR DESCRIPTION
## Summary

Extends the minimal-average `B(k)` development in `Proofs/Erdos1204B.lean` (opened last session) by one exact value, executing the explicitly-suggested next step.

- `admissible_four_sum_ge` — every admissible 4-set has element sum ≥ 16 (maximum `M ≥ 8` from the A(4) sup bound `admissible_four_sup_ge`; erased admissible 3-set sums to ≥ 8 via `admissible_three_sum_ge`; `omega` closes `8 + 8 = 16`).
- `S_four : S 4 = 16` — witness `{0,2,6,8}` (the A(4) extremal set, `admissible_zero_two_six_eight`) meets the lower bound.
- `B_four : B 4 = 4`.

Requires the new `import Proofs.Erdos1204A4` (for the A(4) sup bound and the `{0,2,6,8}` witness; `A4 → Problem`, no cycle). File stays **0 axioms / 0 sorries**.

## Why

Confirms the bootstrap `S(k) ≥ A(k)_sup + S(k-1)` (here `8 + 8 = 16`), with the witness being the A(k) extremal set — so at `k = 4` the minimal-average and minimal-diameter optima still coincide (`{0,2,6,8}` realizes both `A(4)=8` and `S(4)=16`). `B(4) = 4` sits strictly above the parity floor `k-1 = 3`, as at `k = 3`. Structurally these are faithful clones of the existing verified `admissible_three_sum_ge` / `S_three` / `B_three`.

## Verification: UNVERIFIED (environment — both docker and host blocked)

- **Docker** (7 attempts): every run hits `SIGBUS` (exit 135, once a corrupted-dep exit 1) at the **dependency** `Erdos1204Problem` olean-write — `[7743/7745] Building Proofs.Erdos1204Problem`, clean elaboration (1.6–4.9s), **zero source-location diagnostics** — so the dependency never serializes its `.olean` under fleet load and the build never reaches `Erdos1204B`. `Erdos1204Problem` is a pre-existing verified file, not this change.
- **Host bypass** (`lake env lean`, used by prior sessions on this file family): the host `.lake` is incomplete (`Batteries.CodeAction.Basic.olean` missing); completing it would require the forbidden full `lake build`.

The three additions are faithful clones of the green-verified `S_three` pattern, reuse only lemmas that built green in prior sessions (`admissible_four_sup_ge`, `admissible_zero_two_six_eight`, `admissible_three_sum_ge`), and involve only trivial arithmetic (`8+8=16`, `16/4=4`); all reused signatures were re-confirmed. A later clean docker run (or host `.lake` completion) should confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)