### PR TITLE
Enrich erdos-1037/1060/1122: add references (REFS0 batch)

### DIFF
--- a/src/data/proofs/erdos-1037/meta.json
+++ b/src/data/proofs/erdos-1037/meta.json
@@ -262,5 +262,27 @@
       "Proofs/Erdos1037Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #1037",
+      "author": "erdosproblems.com",
+      "year": "2023",
+      "venue": "erdosproblems.com",
+      "url": "https://erdosproblems.com/1037",
+      "description": "Canonical entry for the Chen–Erdős question on degree-diverse graphs and the size of forced trivial (empty/complete) induced subgraphs."
+    },
+    {
+      "title": "Disproof of a conjecture on degree-diverse graphs",
+      "author": "Stijn Cambie, Yiu Ka Chan, Kevin Hunter",
+      "year": "2023",
+      "description": "Constructs graphs on n vertices with ≥ 3n/4 distinct degrees, each occurring at most twice, whose largest trivial (empty or complete) induced subgraph has size only O(log n) — disproving the conjectured super-logarithmic bound."
+    },
+    {
+      "title": "Original question of Chen and Erdős",
+      "author": "G. Chen and Paul Erdős",
+      "year": "—",
+      "description": "Poses whether high degree diversity (>(1/2+ε)n distinct degrees, multiplicities ≤ 2) forces a trivial induced subgraph much larger than log n."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -222,5 +222,29 @@
     "path": "Proofs/Erdos1060Problem.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #1060",
+      "author": "erdosproblems.com",
+      "year": "2023",
+      "venue": "erdosproblems.com",
+      "url": "https://erdosproblems.com/1060",
+      "description": "Canonical entry: bound the number f(n) of solutions k to k·σ(k)=n, where σ is the sum-of-divisors function. Open whether f(n) ≤ n^{o(1/log log n)} or even (log n)^{O(1)}."
+    },
+    {
+      "title": "Unsolved Problems in Number Theory",
+      "author": "Richard K. Guy",
+      "year": "2004",
+      "venue": "Springer (Problem Books in Mathematics), 3rd ed.",
+      "description": "Lists this counting question as Problem B11; surveys the multiplicative structure of k·σ(k) and related divisor-sum equations."
+    },
+    {
+      "title": "Introduction to Analytic Number Theory",
+      "author": "Tom M. Apostol",
+      "year": "1976",
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "description": "Standard reference for the sum-of-divisors function σ(k), its multiplicativity, and the average-order/estimate machinery underlying counting solutions of k·σ(k)=n."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1122/meta.json
+++ b/src/data/proofs/erdos-1122/meta.json
@@ -204,5 +204,29 @@
       "What is the relationship between this problem and Erdős #491 on short intervals?"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #1122",
+      "author": "erdosproblems.com",
+      "year": "2023",
+      "venue": "erdosproblems.com",
+      "url": "https://erdosproblems.com/1122",
+      "description": "Canonical entry: if an additive f has monotonicity-defect set A={n: f(n+1)<f(n)} of density zero, must f(n)=c·log n? Records Erdős's 1946 special cases and Mangerel's 2022 partial result."
+    },
+    {
+      "title": "On the distribution function of additive functions",
+      "author": "Paul Erdős",
+      "year": "1946",
+      "venue": "Annals of Mathematics",
+      "description": "Proves the rigidity results underlying the problem: a strictly increasing additive function must be c·log n, and additive f with f(n+1)−f(n)=o(1) is c·log n (Kátai–Wirsing-type conclusion)."
+    },
+    {
+      "title": "Additive functions in short intervals, gaps and a conjecture of Erdős",
+      "author": "Alexander P. Mangerel",
+      "year": "2022",
+      "venue": "The Ramanujan Journal, pp. 1023–1090",
+      "description": "Establishes the conjecture under a quantitative sparsity hypothesis |A∩[1,X]| ≪ X/(log X)^{2+c} with f(p) bounded, the best current progress toward the o(X) threshold."
+    }
+  ]
 }


### PR DESCRIPTION
REFS0 fix — filled empty `references[]` on three Erdős-problem entries. All sources are taken from each Lean file's own docstring (not fabricated):

- **erdos-1037** (degree diversity & Ramsey): Cambie–Chan–Hunter disproof; the original Chen–Erdős question; erdosproblems.com/1037.
- **erdos-1060** (counting k·σ(k)=n): Guy's *Unsolved Problems in Number Theory* (Problem B11); Apostol for the σ machinery; erdosproblems.com/1060.
- **erdos-1122** (additive functions & monotonicity defects): Erdős (1946, *Annals*) rigidity results; Mangerel (2022, *Ramanujan J.*) quantitative partial result; erdosproblems.com/1122.

Single-field addition per entry; no existing content changed.