### PR TITLE
Enrich erdos-1126/1139/1142: add references (REFS0 batch)

### DIFF
--- a/src/data/proofs/erdos-1126/meta.json
+++ b/src/data/proofs/erdos-1126/meta.json
@@ -180,5 +180,28 @@
     "path": "Proofs/Erdos1126Problem.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #1126",
+      "author": "erdosproblems.com",
+      "year": "2023",
+      "venue": "erdosproblems.com",
+      "url": "https://erdosproblems.com/1126",
+      "description": "Canonical entry: if f(x+y)=f(x)+f(y) for almost all (x,y)∈ℝ², is there a genuinely additive g agreeing with f almost everywhere? Solved affirmatively."
+    },
+    {
+      "title": "On Cauchy's functional equation",
+      "author": "Wolfgang B. Jurkat",
+      "year": "1965",
+      "venue": "Proceedings of the American Mathematical Society",
+      "description": "One of two independent solutions: an almost-additive function on ℝ coincides almost everywhere with a genuinely additive function, which is essentially unique."
+    },
+    {
+      "title": "On almost additive functions",
+      "author": "N. G. de Bruijn",
+      "year": "1966",
+      "description": "Independent solution of the same repair theorem for almost-everywhere additive functions, obtained a year after Jurkat."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -188,5 +188,29 @@
       "description": "Erdős #218 on prime gap densities explores the distributional behavior of prime gaps, providing context for the almost-prime gap question."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #1139",
+      "author": "erdosproblems.com",
+      "year": "2023",
+      "venue": "erdosproblems.com",
+      "url": "https://erdosproblems.com/1139",
+      "description": "Canonical entry (OPEN): for the increasing sequence u_k of integers with at most 2 prime factors (primes and semiprimes), is limsup (u_{k+1}−u_k)/log k = ∞?"
+    },
+    {
+      "title": "Multiplicative Number Theory",
+      "author": "Harold Davenport",
+      "year": "2000",
+      "venue": "Springer (Graduate Texts in Mathematics 74), 3rd ed.",
+      "description": "Standard reference for the distribution of primes and almost-primes (E_2 numbers) via sieve methods, the analytic framework for gap questions on the semiprime sequence."
+    },
+    {
+      "title": "Sieve Methods",
+      "author": "Heini Halberstam and Hans-Egon Richert",
+      "year": "1974",
+      "venue": "Academic Press (London Mathematical Society Monographs)",
+      "description": "Develops the sieve theory of numbers with a bounded number of prime factors (P_2/almost-primes), the natural machinery for bounding gaps in the u_k sequence of this problem."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1142/meta.json
+++ b/src/data/proofs/erdos-1142/meta.json
@@ -229,5 +229,27 @@
     "path": "Proofs/Erdos1142Problem.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #1142",
+      "author": "erdosproblems.com",
+      "year": "2023",
+      "venue": "erdosproblems.com",
+      "url": "https://www.erdosproblems.com/1142",
+      "description": "Canonical entry (OPEN): are there n>105 such that n−2^k is prime for every 1<2^k<n? Known values n∈{4,7,15,21,45,75,105} (OEIS A039669)."
+    },
+    {
+      "title": "On a sequence of integers",
+      "author": "W. E. Mientka and R. C. Weitzenkamp",
+      "year": "1969",
+      "description": "Verified by computation that no n ≤ 2^44 beyond {4,7,15,21,45,75,105} has n−2^k prime for all 1<2^k<n."
+    },
+    {
+      "title": "Work on primes of the form n − 2^k (sparsity of admissible n)",
+      "author": "Robert C. Vaughan",
+      "year": "1973",
+      "description": "Showed the number of admissible n up to N is extremely sparse, the analytic basis for Erdős's o(log n) conjecture; cited in the problem file as Va99 §1.7. (Exact publication title uncertain — see erdosproblems.com/1142 for the bibliographic entry.)"
+    }
+  ]
 }


### PR DESCRIPTION
REFS0 fix — filled empty `references[]` on three more Erdős-problem entries. Sources drawn from each Lean file's docstring:

- **erdos-1126** (almost additive functions, SOLVED): Jurkat (1965) & de Bruijn (1966) independent solutions; erdosproblems.com/1126.
- **erdos-1139** (gaps in almost-primes, OPEN): sieve-theory framework (Davenport; Halberstam–Richert); erdosproblems.com/1139.
- **erdos-1142** (primes n−2^k, OPEN): Mientka–Weitzenkamp (1969) computation; Vaughan sparsity result (Va99 §1.7); OEIS A039669; erdosproblems.com/1142.

Titles kept conservative where the exact publication is uncertain (Vaughan entry flags this explicitly); vague venues omitted rather than fabricated. Single-field addition per entry.