### PR TITLE
Enrich erdos-1147/1156/1159: add references (REFS0 batch)

### DIFF
--- a/src/data/proofs/erdos-1147/meta.json
+++ b/src/data/proofs/erdos-1147/meta.json
@@ -208,5 +208,28 @@
       "description": "Both concern additive completeness: #123 studies d-complete sequences (every sufficiently large integer as a sum of d elements), #1147 asks about order-2 additive bases from approximation sets"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #1147",
+      "author": "erdosproblems.com",
+      "year": "2023",
+      "venue": "erdosproblems.com",
+      "url": "https://erdosproblems.com/1147",
+      "description": "Canonical entry: for irrational α>0, is A={n≥1 : ‖αn²‖<1/log n} an additive basis of order 2? Disproved by Konieczny."
+    },
+    {
+      "title": "Konieczny's disproof of the additive-basis conjecture (Ko16b)",
+      "author": "Jakub Konieczny",
+      "year": "2016",
+      "description": "Disproves the conjecture: the Diophantine-approximation set A={n:‖αn²‖<1/log n} is NOT an additive basis of order 2. Cited in the problem file as [Ko16b]; see erdosproblems.com/1147 for the exact bibliographic entry."
+    },
+    {
+      "title": "An Introduction to the Theory of Numbers",
+      "author": "G. H. Hardy and E. M. Wright",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "description": "Standard reference for Diophantine approximation and the distribution of ‖αn²‖ (distance to nearest integer), the background for defining the set A."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1156/meta.json
+++ b/src/data/proofs/erdos-1156/meta.json
@@ -181,5 +181,29 @@
       "description": "Erdős #2 also concerns random graph properties and probabilistic combinatorics"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #1156",
+      "author": "erdosproblems.com",
+      "year": "2023",
+      "venue": "erdosproblems.com",
+      "url": "https://erdosproblems.com/1156",
+      "description": "Canonical entry (OPEN): is χ(G(n,1/2)) a.s. concentrated on a constant number of values, and is there matching anti-concentration?"
+    },
+    {
+      "title": "The chromatic number of random graphs",
+      "author": "Béla Bollobás",
+      "year": "1988",
+      "venue": "Combinatorica",
+      "description": "Determined the asymptotics χ(G(n,1/2)) ~ n/(2 log₂ n) almost surely, the baseline for all concentration questions."
+    },
+    {
+      "title": "Non-concentration of the chromatic number of a random graph",
+      "author": "Annika Heckel",
+      "year": "2021",
+      "venue": "Journal of the American Mathematical Society",
+      "description": "Proved two-point concentration fails in general and, for at least half of all n, χ(G(n,1/2)) is concentrated on two consecutive values; strengthens Shamir–Spencer (1987) and Alon–Krivelevich (1997)."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1159/meta.json
+++ b/src/data/proofs/erdos-1159/meta.json
@@ -148,5 +148,28 @@
     "path": "Proofs/Erdos1159Problem.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #1159",
+      "author": "erdosproblems.com",
+      "year": "2023",
+      "venue": "erdosproblems.com",
+      "url": "https://erdosproblems.com/1159",
+      "description": "Canonical entry (OPEN): does an absolute constant C>1 exist so that every finite projective plane has a set S meeting each line in between 1 and C points (a C-bounded blocking set)?"
+    },
+    {
+      "title": "Erdős–Silverman–Stein result on bounded blocking sets (1983)",
+      "author": "Paul Erdős, D. R. Silverman, A. Stein",
+      "year": "1983",
+      "description": "Proved every projective plane of order n admits a blocking set S with |S∩ℓ|=O(log n) for all lines ℓ; the open question is whether O(log n) can be replaced by an absolute constant. See erdosproblems.com/1159 for the exact citation."
+    },
+    {
+      "title": "Projective Planes",
+      "author": "Daniel R. Hughes and Fred C. Piper",
+      "year": "1973",
+      "venue": "Springer (Graduate Texts in Mathematics 6)",
+      "description": "Standard reference for finite projective planes, lines, blocking sets, and incidence structure underlying the C-bounded blocking-set question."
+    }
+  ]
 }


### PR DESCRIPTION
REFS0 fix — filled empty `references[]` on three more Erdős-problem entries, all sourced from each Lean file's docstring:

- **erdos-1147** (additive basis from Diophantine approximation, DISPROVED): Konieczny [Ko16b] disproof; Hardy–Wright for the approximation background.
- **erdos-1156** (chromatic-number concentration in G(n,1/2), OPEN): Bollobás (1988, *Combinatorica*) asymptotics; Heckel (2021, *JAMS*) non-concentration.
- **erdos-1159** (bounded blocking sets in projective planes, OPEN): Erdős–Silverman–Stein (1983) O(log n) blocking set; Hughes–Piper for projective-plane background.

Titles softened where the exact publication is uncertain, with pointers to erdosproblems.com rather than fabricated bibliographic detail.