### PR TITLE
research(sylow-theorem-oq-04-oq-03): SL(2,p) is perfect for p≥5 (commutator_eq_top)

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -735,4 +735,39 @@ theorem closure_rootGroups_eq_top :
     exact mul_mem (lowerUnipotent_mem_closure_rootGroups _) hmem
   · exact mem_closure_of_lowerLeft_ne_zero g hc
 
+/-!
+## Perfectness of `SL(2, p)` for `p ≥ 5`
+
+The two structural inputs are now in place:
+* every root-group element is a commutator (`exists_unipotent_isCommutator` and
+  `exists_lowerUnipotent_isCommutator`), so `U ∪ U⁻ ⊆ [SL(2,p), SL(2,p)]`;
+* the root groups generate the whole group (`closure_rootGroups_eq_top`).
+
+A subgroup containing a generating set is the whole group, so the derived subgroup is
+everything: `SL(2, p)` is **perfect** for `p ≥ 5`.  This is exactly the perfectness
+hypothesis of Iwasawa's simplicity criterion for `PSL(2, p)`, whose validity range
+`p ≥ 5` matches the range on which `PSL(2, p)` is simple. -/
+
+/-- **`SL(2, p)` is perfect for `p ≥ 5`**: `[SL(2,p), SL(2,p)] = SL(2, p)`.
+
+Both root groups lie in the derived subgroup — every upper unipotent is a commutator
+(`exists_unipotent_isCommutator`, taking `[diag(2), u(t)]`) and every lower unipotent is
+a commutator (`exists_lowerUnipotent_isCommutator`, the Weyl-conjugate). Since the root
+groups generate `SL(2, p)` (`closure_rootGroups_eq_top`), the derived subgroup contains a
+generating set and hence is all of `SL(2, p)`. -/
+theorem commutator_eq_top (hp : 5 ≤ p) :
+    commutator (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) = ⊤ := by
+  apply top_le_iff.mp
+  rw [← closure_rootGroups_eq_top (p := p), Subgroup.closure_le]
+  intro g hg
+  rw [SetLike.mem_coe]
+  simp only [rootGroups, Set.mem_union, Set.mem_range] at hg
+  rcases hg with ⟨s, rfl⟩ | ⟨s, rfl⟩
+  · obtain ⟨a, t, hc⟩ := exists_unipotent_isCommutator hp s
+    rw [← hc]
+    exact Subgroup.commutator_mem_commutator (Subgroup.mem_top _) (Subgroup.mem_top _)
+  · obtain ⟨x, y, hc⟩ := exists_lowerUnipotent_isCommutator hp s
+    rw [← hc]
+    exact Subgroup.commutator_mem_commutator (Subgroup.mem_top _) (Subgroup.mem_top _)
+
 end SylowOQ04OQ03

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -24,8 +24,8 @@
     "dateAdded": "2026-07-04",
     "axiomCount": 0,
     "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, 0 structure-encoded hypotheses, no `native_decide` (so no `Lean.ofReduceBool`). `#print axioms` for `torusHom_conj_unipotent` and `card_torus_range` reports only the ordinary foundational axioms `propext`, `Classical.choice`, `Quot.sound`. Every result is machine-checked from Mathlib. The parent simplicity theorem for PSL(2, p) remains open; this entry proves only the verified unipotent-subgroup and split-torus infrastructure and makes no claim about the open question itself.",
-    "lineCount": 738,
-    "theoremCount": 43,
+    "lineCount": 773,
+    "theoremCount": 44,
     "definitionCount": 8,
     "originalContributions": [
       "unipotentUpper: the matrix [[1,t],[0,1]] packaged as a determinant-1 element of SL(2, ZMod p)",
@@ -254,12 +254,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 738,
+    "lineCount": 773,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 8,
-    "theoremCount": 43
+    "theoremCount": 44
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Formalizes **perfectness of `SL(2, p)` for `p ≥ 5`** — the result the file's `closure_rootGroups_eq_top` docstring names in prose ("this yields perfectness of `SL(2, p)` for `p ≥ 5`") but never proves. **0 new axioms, 0 sorries.** Pure assembly of three existing theorems in the file.

### New theorem
```lean
theorem commutator_eq_top (hp : 5 ≤ p) :
    commutator (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) = ⊤
```
Proof: both root groups lie in the derived subgroup — every upper unipotent is a commutator (`exists_unipotent_isCommutator`, via `[diag(2), u(t)]`) and every lower unipotent is a commutator (`exists_lowerUnipotent_isCommutator`, the Weyl-conjugate). The root groups generate `SL(2, p)` (`closure_rootGroups_eq_top`, the Bruhat/Gauss decomposition). A subgroup containing a generating set is the whole group, so the derived subgroup `[SL(2,p), SL(2,p)]` is `⊤`.

This is exactly the **perfectness hypothesis** of Iwasawa's simplicity criterion for `PSL(2, p)`, whose validity range `p ≥ 5` matches the range on which `PSL(2, p)` is simple. It closes one of the two remaining structural inputs to that criterion (the other — the `P¹(𝔽_p)` action / 2-transitivity — remains blocked on Mathlib infrastructure).

## Verification
- Elaboration is **clean**: `docker-build.sh Proofs.SylowTheoremOQ04OQ03` type-checks the file in ~0.7–0.9 s across runs with **zero Lean diagnostics** (no `unsolved goals` / `type mismatch` / `failed to synthesize` in the full log).
- The olean *write* to the shared docker cache crashes with SIGBUS (exit 135) — a known stochastic infrastructure failure at disk-write, not an elaboration error. Marking **elaboration-clean / UNVERIFIED-write**; a clean-cache rebuild persists the olean. The addition is purely additive (no existing theorem modified).
- `meta.json` counts synced: 43 → 44 theorems, 738 → 773 lines. Status/axiomCount unchanged (`verified` / 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)