### PR TITLE
Enrich Pythagorean flat-limit (spherical/hyperbolic → Euclidean): add references (REFS0 fix)

### DIFF
--- a/src/data/proofs/pythagorean-theorem-oq-05/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-05/meta.json
@@ -157,5 +157,28 @@
       "summary": "tendsto_one_sub_cos_prod_div_sq telescopes the product side to (a²+b²)/2; spherical_flat_limit then mirrors the hyperbolic argument: cos(t·c) = cos(t·a)·cos(t·b) forces c²/2 = (a²+b²)/2 by uniqueness of limits, hence c² = a² + b² with no range restriction on a, b, c."
     }
   ],
+  "references": [
+    {
+      "title": "Spherical Trigonometry, For the Use of Colleges and Schools",
+      "author": "Isaac Todhunter",
+      "year": "1886",
+      "venue": "Macmillan (5th edition)",
+      "description": "Classical development of spherical trigonometry, including the right-angled formula cos c = cos a · cos b (the spherical Pythagorean theorem) whose small-triangle expansion recovers c² = a² + b², the spherical half of this entry."
+    },
+    {
+      "title": "Foundations of Hyperbolic Manifolds",
+      "author": "John G. Ratcliffe",
+      "year": "2019",
+      "venue": "Springer (Graduate Texts in Mathematics 149, 3rd edition)",
+      "description": "Develops hyperbolic trigonometry and the hyperbolic law of cosines; for a right angle it gives cosh c = cosh a · cosh b (the hyperbolic Pythagorean theorem), the curvature −1 counterpart whose flat limit this entry proves recovers Euclidean Pythagoras."
+    },
+    {
+      "title": "Non-Euclidean Geometry",
+      "author": "H. S. M. Coxeter",
+      "year": "1998",
+      "venue": "Mathematical Association of America (6th edition)",
+      "description": "Unified treatment of spherical, Euclidean, and hyperbolic geometry as the curvature-parametrized family K > 0, K = 0, K < 0, making explicit that the Euclidean identity c² = a² + b² is the common K → 0 limit of the two non-Euclidean Pythagorean laws — the mechanism formalized here via rescaling the sides by t = 1/R."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Fills the empty `references` array (REFS0 defect) for pythagorean-theorem-oq-05 with 3 accurate sources:

- **Todhunter, *Spherical Trigonometry* (1886)** — the spherical right-triangle law cos c = cos a·cos b.
- **Ratcliffe, *Foundations of Hyperbolic Manifolds* (2019)** — the hyperbolic law cosh c = cosh a·cosh b.
- **Coxeter, *Non-Euclidean Geometry* (1998)** — curvature-parametrized unification; Euclidean Pythagoras as the K → 0 limit.

Sources verified against the entry's docstring (rescale sides by t = 1/R, let t → 0⁺; both non-Euclidean laws collapse to c² = a² + b²). No other fields touched.