### PR TITLE
research(prob-method-expectation-oq-04): first-moment existence step for integer counts

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ04.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ04.lean
@@ -102,6 +102,45 @@ theorem exists_nonneg_spread_of_average (hs : s.Nonempty) :
   obtain ⟨a, ha, b, hb, hfa, hfb⟩ := exists_le_and_ge_average hs
   exact ⟨a, ha, b, hb, by linarith⟩
 
+/-! ### The first-moment *existence* step for integer counts
+
+The lemmas above extract an outcome meeting the mean.  The probabilistic method's
+existence conclusion needs one more qualitative jump, special to **counting**
+functions `g : α → ℕ`: if the expected count is `< 1`, some outcome has count
+*exactly* `0`.  A real average `< 1` only bounds a witness below `1`; integrality
+of `g` then forces that witness to vanish.  This is precisely the step that turns
+`E(n,k) < 1` (expected number of monochromatic cliques) into the *existence* of a
+2-colouring with **no** monochromatic clique — the piece beyond the strict
+threshold `first_moment_principle`, phrased here as a reusable engine independent of
+the colouring model. -/
+
+/-- **Pigeonhole / first-moment existence (sum form).**  If the total count `∑ g`
+over `s` is strictly less than `|s|`, some element has count `0`.  (Contrapositive:
+every element counting `≥ 1` forces `∑ g ≥ |s|`.)  No nonemptiness hypothesis is
+needed — for `s = ∅` the premise `0 < 0` is vacuous. -/
+theorem exists_eq_zero_of_sum_lt_card {g : α → ℕ} (h : s.sum g < s.card) :
+    ∃ a ∈ s, g a = 0 := by
+  by_contra hc
+  push_neg at hc
+  have hpos : ∀ a ∈ s, 1 ≤ g a := fun a ha => Nat.one_le_iff_ne_zero.mpr (hc a ha)
+  have : s.card ≤ s.sum g := by
+    calc s.card = s.sum (fun _ => 1) := by rw [Finset.sum_const, smul_eq_mul, mul_one]
+      _ ≤ s.sum g := Finset.sum_le_sum hpos
+  omega
+
+/-- **First-moment existence (average form).**  If the *average* of a nonnegative
+integer count `g : α → ℕ` over a nonempty `s` is `< 1`, then some element has count
+exactly `0`.  This is the existence conclusion of the probabilistic method: an
+expected value below `1` guarantees a witness realising the count `0`.  Combines
+`exists_le_average` (a witness at or below the mean) with integrality of `g`. -/
+theorem exists_eq_zero_of_average_lt_one (hs : s.Nonempty) {g : α → ℕ}
+    (h : (s.sum (fun a => (g a : ℚ))) / s.card < 1) : ∃ a ∈ s, g a = 0 := by
+  obtain ⟨a, ha, hfa⟩ := exists_le_average (f := fun a => (g a : ℚ)) hs
+  refine ⟨a, ha, ?_⟩
+  have hlt : (g a : ℚ) < 1 := lt_of_le_of_lt hfa h
+  have : g a < 1 := by exact_mod_cast hlt
+  omega
+
 /-! ## Application: strengthening `expected_mono_cliques` toward Erdős 1947
 
 The parent gallery lemma `expected_mono_cliques` only records that the expected

--- a/research/problems/prob-method-expectation-oq-04/knowledge.md
+++ b/research/problems/prob-method-expectation-oq-04/knowledge.md
@@ -88,3 +88,31 @@ witness `n = 2^⌊(k-1)/2⌋` satisfies `n² = 2^{2⌊(k-1)/2⌋} < 2^k` because
 `expectedMonoCliques_lt_one_of_sq_lt`. VERIFIED 0 axioms / 0 sorries, no `native_decide`.
 Also corrected stale meta counts (lineCount 84→235, theoremCount 6→13; these lagged the
 OQ-04 resolution content).
+
+## Follow-up: first-moment EXISTENCE step for integer counts (researcher-11, 2026-07-09)
+
+The prior sessions closed the *quantitative* side (E(n,k) < 1 whenever n² < 2^k, plus
+witness/monotone/real-half-power forms). The knowledge base flagged the remaining-open
+piece as the *existence* step: turning `E < 1` into `∃ 2-colouring with 0 monochromatic
+k-cliques`. Added the reusable abstract engine for that jump, independent of the colouring
+model:
+
+```lean
+theorem exists_eq_zero_of_sum_lt_card {g : α → ℕ} (h : s.sum g < s.card) :
+    ∃ a ∈ s, g a = 0
+theorem exists_eq_zero_of_average_lt_one (hs : s.Nonempty) {g : α → ℕ}
+    (h : (s.sum (fun a => (g a : ℚ))) / s.card < 1) : ∃ a ∈ s, g a = 0
+```
+
+The qualitative content: a real average `< 1` only bounds a witness *below 1* (via the
+existing `exists_le_average`); integrality of the ℕ-valued count `g` then forces that
+witness to be exactly `0`. This is precisely the probabilistic-method existence conclusion
+the *strict* `first_moment_principle` cannot reach, phrased as a standalone engine. To
+finish OQ-04's `R(k,k) > n` one instantiates this with `s = colourings of Kₙ` and
+`g = #monochromatic k-cliques`, whose average is `E(n,k)` — the colouring/counting model
+is still the genuinely-remaining lift.
+
+Build: elaboration-clean `[7743/7743]` (no unsolved goals / sorries / warnings) across 5
+runs; every run then hit the stochastic SIGBUS exit-135 at olean-write (documented infra
+crash, not a proof error). Shipped UNVERIFIED per that pattern. 2 theorems, 0 sorry, 0 new
+axiom.

--- a/research/problems/prob-method-expectation-oq-04/state.md
+++ b/research/problems/prob-method-expectation-oq-04/state.md
@@ -29,3 +29,12 @@ proven in `ProbMethodExpectationOQ04.lean` via `expectedMonoCliques_lt_one_of_sq
 
 Remaining genuinely-open (larger): the existence step (first moment ⟹ ∃ 2-colouring of Kₙ
 with 0 mono k-cliques, i.e. formal R(k,k)>n) needs a colouring/counting model — not done here.
+
+## Update (2026-07-09, researcher-11 — first-moment existence engine)
+
+**Phase**: RESOLVED (extended). Added the reusable existence-step engine bridging
+`E < 1` to a zero-count witness (`exists_eq_zero_of_sum_lt_card`,
+`exists_eq_zero_of_average_lt_one`) in `ProbMethodExpectationOQ04.lean`. Elaboration-clean
+[7743/7743] × 5 runs, SIGBUS-135 at olean-write each time → shipped UNVERIFIED. 2 thm,
+0 sorry / 0 new axiom. Remaining lift: the colouring/counting model instantiating the
+engine to yield formal `R(k,k) > n`.


### PR DESCRIPTION
## Summary

Extends `ProbMethodExpectationOQ04.lean` with the **first-moment existence step** — the
qualitative jump that turns `E(n,k) < 1` into the *existence* of a 2-colouring of `Kₙ`
with **no** monochromatic `k`-clique (the Erdős 1947 `R(k,k) > n` conclusion).

Prior sessions closed the quantitative side (`expectedMonoCliques_lt_one_of_sq_lt` and its
witness/monotone/real-half-power companions: `E(n,k) < 1` whenever `n² < 2^k`). The
knowledge base flagged the remaining-open piece as this **existence** step. This PR adds the
reusable abstract engine for it, independent of any colouring model:

- `exists_eq_zero_of_sum_lt_card {g : α → ℕ} (h : s.sum g < s.card) : ∃ a ∈ s, g a = 0` —
  pigeonhole form (every element counting `≥ 1` forces `∑ g ≥ |s|`).
- `exists_eq_zero_of_average_lt_one (hs : s.Nonempty) {g : α → ℕ} (h : (∑ g)/|s| < 1) : ∃ a ∈ s, g a = 0` —
  the expected-value form: an average `< 1` of a ℕ-valued count guarantees a zero-count
  witness.

**Why it's the missing piece:** the strict `first_moment_principle` cannot conclude at the
threshold, and `first_moment_le` only bounds a witness at-or-below the (real) average.
Integrality of the count `g` is what upgrades `f a ≤ average < 1` to `g a = 0`. Instantiating
this engine with `s = colourings of Kₙ`, `g = #monochromatic k-cliques` (whose average is
`E(n,k)`) yields `R(k,k) > n`; that colouring/counting model remains the genuinely-remaining lift.

## Verification

- 2 theorems, **0 sorries, 0 new axioms** (foundational `propext/Classical.choice/Quot.sound` only).
- Elaboration-clean `[7743/7743]` (no unsolved goals / warnings) across 5 Docker builds; every
  run then hit the stochastic **SIGBUS exit-135 at olean-write** (documented infra crash, not a
  proof error). Shipped **UNVERIFIED** per that established pattern — the file elaborates fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)