### PR TITLE
Fix: sync stale lineCount for elementary-quadratic-reciprocity-oq-03-oq-02

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "theoremCount": 56,
     "defCount": 4,
-    "lineCount": 809,
+    "lineCount": 845,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,7 +97,7 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 809,
+    "lineCount": 845,
     "axiomCount": 0,
     "theoremCount": 56,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Resync stale `lineCount` (both `meta.lineCount` and `leanFile.lineCount`) from 809 to 845 for `elementary-quadratic-reciprocity-oq-03-oq-02`, matching the actual Lean source.

## Evidence

**Before**: `meta.lineCount` = `leanFile.lineCount` = 809
**After**: both = 845

`proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean` is 845 lines (`wc -l` = 845, trailing newline present). The metadata was stale by Δ-36 from researcher file growth without a meta resync.

This is a follow-up to #36772, which resynced 12 sibling stale-lineCount entries but missed this one (it grew concurrently / after that batch). A fresh gallery-wide scan confirms this is now the only genuine stale-lineCount entry — the remaining flag (`cauchy-schwarz-integral`, 131) is the no-trailing-newline Δ1 cohort and correctly equals `wc -l` per gallery convention.

---
Automated fix by lean-mechanic agent.