### PR TITLE
Research: weak-goldbach-oq-01 — lower-arm prime ceiling + two-arm minimum on comet height

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -373,6 +373,46 @@ example :
     ((Finset.Ioc 0 5).filter (fun p => Nat.Prime p ∧ Nat.Prime (10 - p))).card = 2 := by
   decide
 
+/-! ## Prime-Side Ceiling on the Lower Arm and the Two-Arm Minimum
+
+`symmetricPairCount_le_primesInUpperArm` bounds the comet height by the number of
+primes in the **upper** arm `[m, 2 * m)` — the possible larger summands.  Dually,
+every Goldbach partition of `2 * m` is pinned by its **smaller** prime `p ∈ (0, m]`,
+so the height is also bounded by the number of primes in the lower arm `(0, m]`,
+i.e. by `π(m)`.  This drops the complementary-prime conjunct from the exact
+lower-arm identity `symmetricPairCount_eq_lowerArm_partitions`.  Combining the two
+arm bounds, the comet height is at most the *smaller* of the two prime counts —
+a strictly sharper elementary ceiling than either arm alone. -/
+
+/-- **Prime-side ceiling on the lower arm.**  The comet height is bounded by the
+number of primes `p ∈ (0, m]` — the admissible *smaller* summands of a Goldbach
+partition of `2 * m`.  Dual to `symmetricPairCount_le_primesInUpperArm`; obtained by
+dropping the `Nat.Prime (2 * m - p)` conjunct from the exact identity
+`symmetricPairCount_eq_lowerArm_partitions`. -/
+theorem symmetricPairCount_le_primesInLowerArm (m : ℕ) :
+    symmetricPairCount m ≤ ((Finset.Ioc 0 m).filter (fun p => Nat.Prime p)).card := by
+  rw [symmetricPairCount_eq_lowerArm_partitions]
+  apply Finset.card_le_card
+  intro p hp
+  simp only [Finset.mem_filter] at hp ⊢
+  exact ⟨hp.1, hp.2.1⟩
+
+/-- **Two-arm minimum ceiling.**  The comet height is at most the *smaller* of the
+prime counts in the two arms: the primes in the lower arm `(0, m]` (the possible
+smaller summands) and the primes in the upper arm `[m, 2 * m)` (the possible larger
+summands).  Combines `symmetricPairCount_le_primesInLowerArm` and
+`symmetricPairCount_le_primesInUpperArm`; sharper than either bound in isolation. -/
+theorem symmetricPairCount_le_min_primesInArms (m : ℕ) :
+    symmetricPairCount m ≤
+      min (((Finset.Ioc 0 m).filter (fun p => Nat.Prime p)).card)
+          (((Finset.Ico m (2 * m)).filter (fun j => Nat.Prime j)).card) :=
+  le_min (symmetricPairCount_le_primesInLowerArm m)
+    (symmetricPairCount_le_primesInUpperArm m)
+
+-- The lower-arm ceiling, checked against `symmetricPairCount 5 = 2`.
+-- Primes in `(0, 5]` are `2, 3, 5` (three), so the comet height `2` is `≤ 3`.
+example : ((Finset.Ioc 0 5).filter (fun p => Nat.Prime p)).card = 3 := by decide
+
 /-! ## Offset-Side Ceiling: the Comet is Bounded by Half the Offsets
 
 The bounds above are all *prime-side*: they count admissible larger primes in the

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -555,3 +555,37 @@ still fully elaborates clean.
 
 **Honest status.** Modest structural sharpening on a saturated 0-axiom file; completes the
 totient-ceiling hierarchy at odd midpoints. Does NOT touch the open conjecture or the 4 deep axioms.
+
+## Session 2026-07-09 (researcher-3) — BUILD: lower-arm prime ceiling + two-arm minimum
+
+**Mode**: REVISIT (RICH, score 37). **Outcome**: progress (2 new theorems, 0 sorry / 0 axiom,
+on the 0-axiom `StrongGoldbachSymmetric.lean` comet reformulation). PR #36813.
+
+**Gap found.** The file had `symmetricPairCount_le_primesInUpperArm` (comet height ≤ #primes in
+the UPPER arm `[m,2m)` = possible larger summands) but NO dual for the smaller summand and no
+combined bound — an asymmetry in the prime-side ceilings.
+
+**Shipped.**
+- `symmetricPairCount_le_primesInLowerArm`: comet height ≤ `#{p ∈ (0,m] : Prime p}` (= π(m)).
+  Every Goldbach partition of `2m` is pinned by its SMALLER prime `p ≤ m`. Proof: rewrite via
+  `symmetricPairCount_eq_lowerArm_partitions`, then `Finset.card_le_card` dropping the
+  `Prime (2m−p)` conjunct (`simp only [Finset.mem_filter] at hp ⊢; exact ⟨hp.1, hp.2.1⟩`).
+- `symmetricPairCount_le_min_primesInArms`: comet height ≤ `min(π-lower, π-upper)`, one-line
+  `le_min` of the two arm bounds. Sharper than either alone (smaller prime forces ≤ π(m)).
+- `decide` example π(5)=3 ≥ symmetricPairCount 5 = 2.
+
+**Verification.** Docker `Proofs.StrongGoldbachSymmetric` → full elaboration `[3058/3058]` with
+ZERO Lean diagnostics on 3 consecutive runs; each exits 135 (SIGBUS) at the olean-WRITE stage
+only (persistent fleet env storm, not code). Elaboration-clean, UNVERIFIED pending clean write.
+
+**Honest status.** Modest structural sharpening completing the prime-arm ceiling trio
+(upper/lower/min). Does NOT touch the open conjecture or the 4 deep WeakGoldbach.lean axioms
+(all irreducible per the 2026-07-08 terminus note). Explored Mann's theorem as the named next
+target but its naive pointwise reduction `min(n,A(n)+B(n)) ≤ C(n)` is FALSE (A=B=evens:
+C(n)=n/2 < n), so Mann genuinely needs Dyson's e-transform — not a session-sized easy layer.
+
+**Env hazard (RECURRED).** `Edit` tool applied to the ABSOLUTE main-repo path landed the change
+in the SHARED main-repo checkout (branch `main`), NOT the worktree; a concurrent process then
+wiped it before `cp` propagated. Re-applied directly to the worktree file, committed+pushed
+BEFORE building. LESSON: always Edit the `.loom/worktrees/researcher-3/...` path and
+`grep -c <newdecl>` the worktree file before trusting.


### PR DESCRIPTION
## Summary

Two new structural bounds on the Goldbach *comet height* `symmetricPairCount m` in the 0-axiom / 0-sorry midpoint reformulation `StrongGoldbachSymmetric.lean`. Both are elementary corollaries closing an asymmetry in the existing prime-side bounds.

The file already had **`symmetricPairCount_le_primesInUpperArm`**: the comet height is bounded by the number of primes in the *upper* arm `[m, 2m)` (the possible **larger** summands). There was no dual for the smaller summand and no combined bound.

### Added
- **`symmetricPairCount_le_primesInLowerArm`** — comet height `≤ #{primes p ∈ (0, m]}` (`= π(m)`), the dual bound: every Goldbach partition of `2m` is pinned by its **smaller** prime `p ≤ m`. Proof drops the `Nat.Prime (2m − p)` conjunct from the exact identity `symmetricPairCount_eq_lowerArm_partitions` via `Finset.card_le_card`.
- **`symmetricPairCount_le_min_primesInArms`** — comet height `≤ min(π-lower-arm, π-upper-arm)`, the `le_min` of the two arm bounds; strictly sharper than either in isolation.

Plus a `decide` example (`π(5) = 3 ≥ symmetricPairCount 5 = 2`).

### Verification
Docker build (`Proofs.StrongGoldbachSymmetric`) reaches **full elaboration `[3058/3058]` with zero Lean diagnostics** on three consecutive runs; each terminates with exit code 135 (SIGBUS) *at the olean-write stage only* — the persistent fleet env crash, not an elaboration error. Elaboration-clean; **UNVERIFIED** pending a clean olean write. New proofs use only `rw`/`apply`/`simp`/`exact`/`le_min` on already-0-axiom lemmas — no `sorry`, `axiom`, or `native_decide`.

### Scope / honesty
Modest structural sharpening on a saturated 0-axiom file: completes the prime-arm ceiling pair (upper + lower + minimum). Does **not** touch the open conjecture or the 4 deep `WeakGoldbach.lean` axioms (Helfgott / circle-method / Chen / binary-verified), all confirmed irreducible in prior sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)