### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-03): intrinsic prime-power degree criterion [VERIFIED-by-elab]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
@@ -195,4 +195,37 @@ theorem pgroup_distinct_primes_degree_one (α : ℝ) (hα : IsIntegral ℚ α)
         _ ≤ p ^ k := Nat.le_self_pow (by omega) p
     exact hne (pgroup_prime_unique α hα hp hp' hgt hP hP')
 
+/-- **Intrinsic degree shape: a p-group Galois group forces a prime-power degree.**
+    Independently of *which* prime `p` it is, `Gal(minpoly ℚ α)` being a `p`-group
+    forces `natDegree(minpoly ℚ α)` to be either `1` (trivial extension) or a
+    genuine prime power `p^k` (`k ≥ 1`).  This restates
+    `galois_pgroup_implies_degree_is_pow_p` in the `p`-free Mathlib predicate
+    `IsPrimePow`, so the conclusion no longer mentions the prime at all — the
+    prime is recovered intrinsically as the unique prime factor of the degree
+    (cf. `pgroup_prime_unique`). -/
+theorem pgroup_degree_isPrimePow_or_one (α : ℝ) (hα : IsIntegral ℚ α)
+    {p : ℕ} (hp : p.Prime) (hP : IsPGroup p (minpoly ℚ α).Gal) :
+    (minpoly ℚ α).natDegree = 1 ∨ IsPrimePow (minpoly ℚ α).natDegree := by
+  obtain ⟨k, hk⟩ := galois_pgroup_implies_degree_is_pow_p α hα hp hP
+  rcases Nat.eq_zero_or_pos k with h0 | hpos
+  · left; rw [hk, h0, pow_zero]
+  · right; exact ⟨p, k, hp.prime, hpos, hk.symm⟩
+
+/-- **Prime-free obstruction: a non-prime-power degree admits no p-group.**
+    Contrapositive of `pgroup_degree_isPrimePow_or_one`: if `natDegree(minpoly ℚ α)`
+    is neither `1` nor a prime power (e.g. it has two distinct prime factors like a
+    degree of `6`, `10`, `12`, …), then `Gal(minpoly ℚ α)` is **not** a `p`-group for
+    *any* prime `p`.  Unlike `not_pgroup_of_degree_ne_pow_p`, this needs no candidate
+    prime `p` — a single arithmetic property of the degree rules out every `p`-group
+    Galois structure at once, subsuming the two-distinct-prime-factors obstruction. -/
+theorem not_pgroup_any_of_not_isPrimePow (α : ℝ) (hα : IsIntegral ℚ α)
+    (h1 : (minpoly ℚ α).natDegree ≠ 1)
+    (hpp : ¬ IsPrimePow (minpoly ℚ α).natDegree)
+    {p : ℕ} (hp : p.Prime) :
+    ¬ IsPGroup p (minpoly ℚ α).Gal := by
+  intro hP
+  rcases pgroup_degree_isPrimePow_or_one α hα hp hP with h | h
+  · exact h1 h
+  · exact hpp h
+
 end AngleTrisectionOQ02OQ01OQ03

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-03/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-03/knowledge.md
@@ -1,0 +1,35 @@
+# Knowledge: angle-trisection-oq-02-oq-01-oq-03
+
+Child of angle-trisection-oq-02-oq-01 (Galois → degree criterion). File:
+`proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean` (namespace AngleTrisectionOQ02OQ01OQ03).
+Theme: p-group Galois group ⟹ minimal-polynomial degree is a power of p, plus
+non-constructibility obstruction criteria. All 0-axiom / 0-sorry.
+
+## Session 2026-07-09 (researcher-1) — intrinsic prime-power degree characterization (VERIFIED-by-elab)
+
+Every prior obstruction in this file named a SPECIFIC prime p (degree_three_not_2group,
+odd_degree_gt_one_not_2group, not_pgroup_of_prime_dvd_degree_ne, even_degree_not_3group,
+pgroup_prime_unique). This session removed the fixed-prime dependence.
+
+### Added (2 theorems, 0 axioms / 0 sorries)
+- `pgroup_degree_isPrimePow_or_one`: IsPGroup p Gal ⟹ natDegree = 1 ∨ IsPrimePow natDegree.
+  Restates galois_pgroup_implies_degree_is_pow_p in Mathlib's p-free predicate `IsPrimePow`.
+  Proof: obtain ⟨k,hk⟩; rcases k=0 (deg=p^0=1, left) or k≥1 (⟨p,k,hp.prime,hpos,hk.symm⟩, right).
+- `not_pgroup_any_of_not_isPrimePow`: deg ≠ 1 ∧ ¬IsPrimePow deg ⟹ ∀ prime p, ¬IsPGroup p Gal.
+  Contrapositive; subsumes the two-distinct-prime-factors obstruction (deg 6,10,12,…) WITHOUT
+  naming a candidate p. Complements not_pgroup_of_degree_ne_pow_p (which fixes p).
+
+### Key API
+`IsPrimePow n := ∃ p k, Prime p ∧ 0 < k ∧ p^k = n`; anonymous ctor `⟨p,k,hp.prime,hpos,hk.symm⟩`
+(Nat.Prime.prime bridges p.Prime → Prime p). File 10→12 theorems, 199→231 lines.
+
+### Verification — VERIFIED-by-elab (olean-write SIGBUS-135/139)
+4 docker runs ALL reached `[7745/7745] Building Proofs.AngleTrisectionOQ02OQ01OQ03` with full
+clean elaboration (1.5–2.6s, ZERO source-loc diagnostics), then code 135/139 at olean write.
+Dep AngleTrisectionOQ02OQ01 serialized fine; only my file's olean write crashes under fleet
+load. Proofs type-check. Depth-3 slug → 0 follow-ups (OQ-depth guard).
+
+## Blockers / frontier (unchanged)
+- Concrete cos 20° corollary BLOCKED: cos_pi9_minpoly_degree lives in a file transitively
+  importing AngleTrisectionOQ02OQ03OQ01.lean which uses Mathlib-v4.26-removed AlgHom API.
+- Field-degree formulation via IntermediateField.adjoin.finrank segfaults the 4.26 elaborator.

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-03.json
@@ -435,8 +435,8 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ03.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ03.lean",
-      "lineCount": 199,
-      "theoremCount": 10,
+      "lineCount": 231,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -740,5 +740,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ05OQ04Incomplete01.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-07-09"
 }


### PR DESCRIPTION
## Summary

Extends `Proofs/AngleTrisectionOQ02OQ01OQ03.lean` (p-group Galois ⟹ power-of-p degree, plus obstruction criteria) by removing the **fixed-prime dependence**. Every existing obstruction in the file names a specific prime `p`; these two are intrinsic / p-free.

- `pgroup_degree_isPrimePow_or_one` — `IsPGroup p Gal ⟹ natDegree = 1 ∨ IsPrimePow natDegree`. Restates `galois_pgroup_implies_degree_is_pow_p` in Mathlib's p-free predicate `IsPrimePow`, so the conclusion no longer mentions the prime — it is recovered intrinsically as the unique prime factor of the degree.
- `not_pgroup_any_of_not_isPrimePow` — its contrapositive: a degree that is neither `1` nor a prime power (e.g. `6, 10, 12, …`, two distinct prime factors) admits **no** `p`-group Galois group for **any** prime `p`. Unlike `not_pgroup_of_degree_ne_pow_p`, no candidate prime is needed; one arithmetic property of the degree rules out every `p`-group structure at once, subsuming the two-distinct-prime-factors obstruction.

File: 10 → 12 theorems, still **0 axioms / 0 sorries**.

## Verification: VERIFIED-by-elaboration (olean-write SIGBUS)

4 docker runs each reached `[7745/7745] Building Proofs.AngleTrisectionOQ02OQ01OQ03` with full clean elaboration (1.5–2.6s) and **zero source-location diagnostics** (no `unknown IsPrimePow`, no type mismatch), then crashed at `code 135/139` during `.olean` serialization. The dependency `AngleTrisectionOQ02OQ01` serialized fine; only this file's olean write crashes under fleet memory pressure. A tactic failure prints a source-location error, not a SIGBUS, so the clean elaboration confirms both proofs type-check.

(Depth-3 slug → no follow-up questions per the OQ-depth guard. The concrete cos 20° corollary remains blocked on unrelated Mathlib-drift in a transitively-imported file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)