### PR TITLE
Enrich polar decomposition from PSD square root: add references (REFS0 fix)

### DIFF
--- a/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/meta.json
@@ -136,5 +136,28 @@
   "crossReferences": [
     "matrix-posdef-sqrt-oq-01"
   ],
+  "references": [
+    {
+      "title": "Matrix Analysis",
+      "author": "Roger A. Horn and Charles R. Johnson",
+      "year": "2013",
+      "venue": "Cambridge University Press (2nd edition)",
+      "description": "Theorem 7.3.1 gives the polar decomposition A = UP with P = (AᴴA)^{1/2} positive semidefinite and U unitary, together with the uniqueness of the PSD factor P — exactly the existence and uniqueness statements formalized here."
+    },
+    {
+      "title": "Functions of Matrices: Theory and Computation",
+      "author": "Nicholas J. Higham",
+      "year": "2008",
+      "venue": "SIAM",
+      "description": "Chapters 6 and 8 treat the principal matrix square root and the polar decomposition via the functional calculus, mirroring this entry's construction of P = √(AᴴA) through CFC.sqrt and the recovery of U = A·P⁻¹ for invertible A."
+    },
+    {
+      "title": "Matrix Computations",
+      "author": "Gene H. Golub and Charles F. Van Loan",
+      "year": "2013",
+      "venue": "Johns Hopkins University Press (4th edition)",
+      "description": "Develops the polar decomposition and its link to the singular value decomposition, the standard computational reference for the factorization A = U·√(AᴴA) whose structural uniqueness this entry proves needs no invertibility hypothesis."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Fills the empty `references` array (REFS0 defect) for matrix-posdef-sqrt-oq-01-oq-01 with 3 accurate matrix-analysis sources:

- **Horn & Johnson, *Matrix Analysis* (2013)** — Thm 7.3.1, polar decomposition + uniqueness of the PSD factor.
- **Higham, *Functions of Matrices* (2008)** — matrix square root & polar decomposition via functional calculus (mirrors CFC.sqrt).
- **Golub & Van Loan, *Matrix Computations* (2013)** — polar decomposition and its SVD link.

Sources verified against the docstring (A = U·√(AᴴA); P = √(AᴴA) forced by any U·P with U unitary, no invertibility needed). No other fields touched.