### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-02): f'' periodicity + Fourier-mode inversion

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
@@ -79,4 +79,31 @@ theorem fourierCoeffOn_deriv2_periodic (f : ℝ → ℝ) (hf : ContDiff ℝ 2 f)
       I_mul_I]
   ring
 
+/-- The **second** derivative of a periodic function is periodic with the same period.
+    Iterating `deriv_periodic_of_periodic`: `deriv f` is periodic (first application),
+    hence so is `deriv (deriv f)` (second application).  This is the periodicity input
+    that `fourierCoeffOn_deriv2_periodic` uses internally, packaged as a reusable fact. -/
+theorem deriv2_periodic_of_periodic (f : ℝ → ℝ) (T : ℝ)
+    (hperiod : ∀ t, f (t + T) = f t) (t : ℝ) :
+    deriv (deriv f) (t + T) = deriv (deriv f) t :=
+  deriv_periodic_of_periodic (deriv f) T
+    (fun s => deriv_periodic_of_periodic f T hperiod s) t
+
+/-- **Recovering `f` from `f''` on nonzero modes.**  Since `ĉₙ(f'') = −n²·ĉₙ(f)` and
+    `n ≠ 0`, the `n`-th Fourier coefficient of `f` is recovered by dividing:
+
+        ĉₙ(f) = −ĉₙ(f'') / n².
+
+    This inverts the second-derivative operator on every nonzero Fourier mode — the
+    algebraic heart of solving `f'' = g` by Fourier series (each mode `n ≠ 0` is divided
+    by the eigenvalue `−n²`, while the `n = 0` mode is the obstruction/mean). -/
+theorem fourierCoeffOn_eq_of_deriv2_periodic (f : ℝ → ℝ) (hf : ContDiff ℝ 2 f)
+    (hperiod : ∀ t, f (t + 2 * π) = f t)
+    (hab : (0 : ℝ) < 2 * π) (n : ℤ) (hn : n ≠ 0) :
+    fourierCoeffOn hab (ofReal ∘ f) n
+      = -(fourierCoeffOn hab (ofReal ∘ deriv (deriv f)) n) / (n : ℂ) ^ 2 := by
+  have hn2 : (n : ℂ) ^ 2 ≠ 0 := pow_ne_zero 2 (Int.cast_ne_zero.mpr hn)
+  rw [fourierCoeffOn_deriv2_periodic f hf hperiod hab n hn, eq_div_iff hn2]
+  ring
+
 end IsoperimetricFourier


### PR DESCRIPTION
## Summary

Two additions to the second-derivative Fourier-identity file (`AreaOfCircleOQ01OQ02OQ02OQ02.lean`, the Hurwitz/Wirtinger isoperimetric stepping-stone). **0 new axioms, 0 sorries.**

The file proves `ĉₙ(f'') = −n²·ĉₙ(f)` for `n ≠ 0`. This PR rounds it out:

- **`deriv2_periodic_of_periodic`** — the second derivative of a periodic function is periodic (iterates the file's own `deriv_periodic_of_periodic` twice). This is the periodicity fact the main identity uses internally, now packaged as a reusable lemma.

- **`fourierCoeffOn_eq_of_deriv2_periodic`** — inverts the identity to recover `f` from `f''` on nonzero modes:
  ```
  ĉₙ(f) = −ĉₙ(f'') / n²      (n ≠ 0).
  ```
  This is the algebraic heart of solving `f'' = g` by Fourier series: each nonzero mode is divided by the eigenvalue `−n²` (the `n = 0` mode being the mean/obstruction). Proved via `eq_div_iff` + `ring`.

## Verification
- Elaboration is **clean**: `docker-build.sh Proofs.AreaOfCircleOQ01OQ02OQ02OQ02` type-checks the file in ~1–3 s across runs with **no errors at the new lines** and no `unsolved goals` / `type mismatch` / `no goals` in the log.
- The olean *write* crashes with SIGBUS (exit 135/139) on the shared docker cache — a known stochastic infrastructure failure at disk-write (one earlier run also hit a transient corrupted-dependency olean, `TaylorSeries.olean.server invalid header`, which cleared on retry). Marking **elaboration-clean / UNVERIFIED-write**; a clean-cache rebuild persists the olean. Additions are purely additive.
- Research-layer file (no gallery `meta.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)