### PR TITLE
Fix: sync stale meta.lineCount to actual Lean sources (7 entries)

### DIFF
--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/1092",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 160,
+    "lineCount": 164,
     "assumptions": "0 axioms, 0 sorries. 5 structural theorems fully proved. 2 True-stub documentation markers for disproved claims (Q1, Q2 refuted by Rödl 1982). Main conjectures removed; file is primarily graph coloring infrastructure. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,

--- a/src/data/proofs/erdos-490-oq-01/meta.json
+++ b/src/data/proofs/erdos-490-oq-01/meta.json
@@ -45,7 +45,7 @@
       "Eliminated the optimal_lower axiom: proved maxProd(N) ≥ c·N²/log N (0-axiom) by transferring the sibling file's verified bound_is_optimal through maxProd_is_upper (axiom count 2 → 1)"
     ],
     "axiomCount": 1,
-    "lineCount": 343,
+    "lineCount": 371,
     "assumptions": "1 axiom (a deep number-theoretic result): the Szemerédi upper bound maxProd(N) ≤ C·N²/log N. The optimal-example lower bound maxProd(N) ≥ c·N²/log N is now a proved theorem (`optimal_lower`, 0-axiom): it is transferred from the sibling file's verified `Erdos490.bound_is_optimal` via `maxProd_is_upper` (the maximum dominates the optimal example's product), with small cases N ∈ {2,3} handled by `maxProd_ge_self`. The existence/achievability of the maximum (`maxProd_exists`) is likewise a proved theorem — the optimization ranges over subsets of the finite set {1,...,N}, so the achievable-value set is a nonempty finite Finset of naturals and the maximum is its Finset.max'. Fully machine-checked apart from the single stated axiom (#print axioms of optimal_lower lists only propext/Classical.choice/Quot.sound — no sorryAx, no Lean.ofReduceBool).",
     "mathlib_version": "4.26.0",
     "theoremCount": 13,

--- a/src/data/proofs/erdos-57-oq-04/meta.json
+++ b/src/data/proofs/erdos-57-oq-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 540,
+    "lineCount": 343,
     "dateAdded": "06/27/26",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -49,7 +49,7 @@
       "Verified the necessity side (mod-8 obstruction) of the arithmetic characterization: not_representable_of_mod8 proves no integer ≡ 5 or 7 (mod 8) is a value of x²+2y² (finite decide over ZMod 8), with five_not_representable / seven_not_representable as the smallest concrete witnesses — the first non-representability results in the file, showing the form is not universal (5, 7 are inert in ℤ[√-2])"
     ],
     "axiomCount": 1,
-    "lineCount": 421,
+    "lineCount": 482,
     "assumptions": "1 axiom: moreeOsburnWorks (the two deep geometric facts about the box-truncated lattice — the 4-point property and the Landau/x²+2y² distinct-distance bound m/√(log m); not available in Mathlib 4.26). The cardinality (2k+1)² is now a verified theorem (moreeOsburnLattice_card), not an assumption. 0 sorries.",
     "theoremCount": 18,
     "definitionCount": 9

--- a/src/data/proofs/erdos-897-oq-01/meta.json
+++ b/src/data/proofs/erdos-897-oq-01/meta.json
@@ -54,7 +54,7 @@
       "unboundedOnPrimePowers_max_left / _max_right / not_unboundedOnPrimePowers_max: PROVED the JOIN (sup) closure completing the file's prime-power domination order into a lattice — the Erdős #897 hypothesis functions form a sup-closed filter (closed under pointwise max with any function), and the failing O(log)-on-prime-powers functions form a sup-closed ideal (closed under max of two, merging the two O(log) constants via log(p^k) ≥ 0)."
     ],
     "axiomCount": 0,
-    "lineCount": 503,
+    "lineCount": 545,
     "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries; proofs use no native_decide (so #print axioms shows only propext/Classical.choice/Quot.sound). Part I of Erdős #897 — whether the prime-power growth hypothesis forces limsup_n (f(n+1)-f(n))/log n = ∞ — remains OPEN and is NOT asserted; this entry proves only the verified surrounding theory (non-vacuity, selectivity, plain unboundedness, and the strongly-additive reduction).",
     "theoremCount": 26,
     "definitionCount": 1

--- a/src/data/proofs/halting-problem-oq-01/meta.json
+++ b/src/data/proofs/halting-problem-oq-01/meta.json
@@ -24,7 +24,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 405,
+    "lineCount": 255,
     "mathlibDependencies": [
       {
         "theorem": "ComputablePred.halting_problem_re",

--- a/src/data/proofs/picks-theorem-oq-04/meta.json
+++ b/src/data/proofs/picks-theorem-oq-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 453,
+    "lineCount": 308,
     "theoremCount": 21,
     "definitionCount": 11,
     "dateAdded": "2026-06-28",


### PR DESCRIPTION
## Fix

Sync stale `meta.lineCount` fields to the actual `wc -l` of each entry's Lean source. In 6 of the 7 entries `leanFile.lineCount` was already correct, so `meta.lineCount` had drifted out of sync (files grew/shrank after research edits without a meta resync).

## Evidence

| slug | meta.lineCount before → after | actual (wc -l) |
|------|-------------------------------|----------------|
| erdos-897-oq-01 | 503 → 545 | 545 |
| picks-theorem-oq-04 | 453 → 308 | 308 |
| erdos-57-oq-04 | 540 → 343 | 343 |
| erdos-1092 | 160 → 164 | 164 |
| halting-problem-oq-01 | 405 → 255 | 255 |
| erdos-490-oq-01 | 343 → 371 | 371 |
| erdos-659 | 421 → 482 | 482 |

Convention used: gallery `lineCount` = `wc -l` = count of `\n` (matches the already-correct `leanFile.lineCount` values). The Δ1 no-trailing-newline cohort (e.g. erdos-143, where meta+leanFile agree at split-length) is intentionally left untouched.

Gallery build (`pnpm build`) processes all entries cleanly.

---
Automated fix by lean-mechanic agent.