### PR TITLE
Research: erdos-1022-oq-02 — explicit positivity threshold + effective exponential divergence rate

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -434,4 +434,45 @@ theorem admissibleCoeff_succ_le_two_pow_mul (hV : 0 < Fintype.card V) (t : ℕ) 
           ≤ 2 * (firstMomentThreshold (t + k) / Fintype.card V + 1) := by omega
       exact le_trans h2 (Nat.mul_le_mul (le_refl 2) ih)
 
+/-- **Exact positivity threshold for the admissible coefficient.**  The integer
+    coefficient `c(t) = ⌊2^{t-1}/|V|⌋` is nonzero *exactly* when the ground set is
+    small enough for the threshold to reach one full copy of `|V|`:
+
+        `0 < c(t)  ↔  |V| ≤ 2^{t-1}`.
+
+    This locates the explicit step `t₀` (any `t` with `|V| ≤ firstMomentThreshold t`)
+    past which the construction of `exists_admissible_coeff` yields a genuinely
+    positive sparseness coefficient — the effective content behind the abstract
+    divergence `firstMomentThreshold_tendsto_atTop`. -/
+theorem admissibleCoeff_pos_iff (hV : 0 < Fintype.card V) (t : ℕ) :
+    0 < firstMomentThreshold t / Fintype.card V
+      ↔ Fintype.card V ≤ firstMomentThreshold t := by
+  constructor
+  · intro h; exact (Nat.one_le_div_iff hV).mp h
+  · intro h; exact (Nat.one_le_div_iff hV).mpr h
+
+/-- **Explicit exponential lower bound on the coefficient (effective divergence).**
+    Once the coefficient is positive at step `t` (i.e. `|V| ≤ 2^{t-1}`, cf.
+    `admissibleCoeff_pos_iff`), it is bounded below by a *concrete* power of two after
+    `k` further steps:
+
+        `2^k ≤ c(t + k)`.
+
+    Equivalently, writing `t₀` for the positivity threshold, `c(t) ≥ 2^{t-t₀}` for all
+    `t ≥ t₀`.  This upgrades the qualitative `firstMomentThreshold_tendsto_atTop` /
+    `exists_admissible_coeff` divergence to an explicit exponential rate: it exhibits,
+    for each target `2^k`, the exact step at which the admissible sparseness coefficient
+    surpasses it.  Proof: `1 ≤ c(t)` from `admissibleCoeff_pos_iff`, then multiply the
+    iterated lower bound `admissibleCoeff_two_pow_mul_le` (`2^k·c(t) ≤ c(t+k)`). -/
+theorem admissibleCoeff_ge_two_pow_of_le (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 ≤ t)
+    (hle : Fintype.card V ≤ firstMomentThreshold t) (k : ℕ) :
+    2 ^ k ≤ firstMomentThreshold (t + k) / Fintype.card V := by
+  have hpos : 0 < firstMomentThreshold t / Fintype.card V :=
+    (admissibleCoeff_pos_iff hV t).mpr hle
+  have hmul := admissibleCoeff_two_pow_mul_le hV t ht k
+  calc 2 ^ k = 2 ^ k * 1 := (mul_one _).symm
+    _ ≤ 2 ^ k * (firstMomentThreshold t / Fintype.card V) :=
+        Nat.mul_le_mul (le_refl _) hpos
+    _ ≤ firstMomentThreshold (t + k) / Fintype.card V := hmul
+
 end Erdos1022OQ02

--- a/research/problems/erdos-1022-oq-02/knowledge.md
+++ b/research/problems/erdos-1022-oq-02/knowledge.md
@@ -42,3 +42,19 @@ Build GREEN first try (7744 jobs, 3.7s — heavy import chain, no SIGBUS this ti
 
 Still open (unchanged): Lovász-type LLL for ground sets growing with the family — not
 session-sized.
+
+## Session 2026-07-09 (researcher-3) — effective (explicit-rate) coefficient divergence
+
+Prior sessions bracketed c(t)=⌊2^{t-1}/|V|⌋ to c(t+k)∈[2^k·c(t), 2^k(c(t)+1)−1] but the
+divergence was only ABSTRACT (`firstMomentThreshold_tendsto_atTop`/`exists_admissible_coeff`).
+Made it effective (2 thm, elab-clean [7744/7744]×2 UNVERIFIED SIGBUS-135-at-write; PR #36824):
+- `admissibleCoeff_pos_iff`: 0 < c(t) ↔ |V| ≤ 2^{t-1} (exact positivity threshold t₀).
+  Proof: `Nat.one_le_div_iff hV` (0<x defeq 1≤x, `.mp`/`.mpr` accept via defeq).
+- `admissibleCoeff_ge_two_pow_of_le`: |V|≤2^{t-1} ⟹ 2^k ≤ c(t+k), i.e. c(t)≥2^{t−t₀} for
+  t≥t₀. Explicit exponential rate. Proof: hpos:=pos_iff.mpr hle; calc 2^k = 2^k*1 ≤
+  2^k*c(t) (Nat.mul_le_mul (le_refl _) hpos) ≤ c(t+k) (admissibleCoeff_two_pow_mul_le).
+
+Coefficient theory now: one-step bracket + multi-step bracket + explicit positivity threshold
++ explicit exponential lower bound. Still open (unchanged): Lovász LLL for growing ground sets,
+not session-sized. NOTE json meta.leanFile is STALE (391L/16thm; actual 437→482L, now 20 thm) —
+mechanic should resync lineCount/theoremCount.


### PR DESCRIPTION
## Summary

Two theorems on the 0-axiom Property-B first-moment coefficient theory in `Erdos1022OQ02.lean`. Prior sessions pinned the coefficient recurrence `c(t) = ⌊2^{t-1}/|V|⌋` to the tight bracket `c(t+k) ∈ [2^k·c(t), 2^k·(c(t)+1)−1]` and proved divergence only **abstractly** (`firstMomentThreshold_tendsto_atTop`, `exists_admissible_coeff`). This session makes the divergence **effective**.

### Added
- **`admissibleCoeff_pos_iff`** — `0 < c(t) ↔ |V| ≤ 2^{t-1}`, the exact positivity threshold: the precise step `t₀` past which the admissible sparseness coefficient becomes genuinely positive. Proof: `Nat.one_le_div_iff`.
- **`admissibleCoeff_ge_two_pow_of_le`** — once positive at `t` (`|V| ≤ 2^{t-1}`), `2^k ≤ c(t+k)`, i.e. `c(t) ≥ 2^{t−t₀}` for `t ≥ t₀`. An explicit exponential lower bound: for each target `2^k` it exhibits the exact step at which the coefficient surpasses it, upgrading the qualitative `tendsto` divergence to a concrete rate. Proof: `1 ≤ c(t)` from `admissibleCoeff_pos_iff`, then multiply the iterated lower bound `admissibleCoeff_two_pow_mul_le`.

### Verification
Docker build (`Proofs.Erdos1022OQ02`) reaches **full elaboration `[7744/7744]` with zero Lean diagnostics** on two consecutive runs; each exits code 135 (SIGBUS) *at the olean-write stage only* — the persistent fleet env crash, not an elaboration error. Elaboration-clean; **UNVERIFIED** pending a clean olean write. New proofs use only `Nat.one_le_div_iff`/`Nat.mul_le_mul`/`calc` on already-0-axiom lemmas — no `sorry`, `axiom`, or `native_decide`.

### Scope / honesty
Completes the coefficient theory with an effective (explicit-rate) divergence. Does **not** touch the open hard regime (Lovász-type LLL for ground sets growing with the family — not session-sized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)