### PR TITLE
research(erdos-101-oq-04): intrinsic linear density L₄(n) ≥ n/4 for the quartic family

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -2765,6 +2765,34 @@ theorem exists_isLowerBoundConstruction_linear (k : ℕ) (hk : 0 < k) :
   obtain ⟨P, hcard, hno5, hcount⟩ := quartic_linear_lower_bound k hk
   exact ⟨P, hcard, hno5, by exact_mod_cast hcount⟩
 
+/-- **Intrinsic linear density `L₄(n) ≥ n/4`.**  The quartic family
+`quartic_linear_lower_bound` states its count `k ≤ fourPointLineCount P` against the
+*external* level-parameter `k`, on `≤ 4·k` points.  Eliminating `k` (it satisfies both
+`P.points.card ≤ 4·k` and `k ≤ fourPointLineCount P`) turns this into the *intrinsic*
+statement that four-point lines are at least a `1/4` fraction of the points:
+`4 · fourPointLineCount P ≥ P.points.card`.  Since `fourPointLineCount P ≥ k` is
+unbounded, this exhibits arbitrarily large no-five-collinear sets whose four-point-line
+count is a fixed positive fraction of the vertex count — the textbook linear lower bound
+`L₄(n) = Ω(n)` phrased as a density, independent of the auxiliary parameter. -/
+theorem exists_fourPointLineCount_ge_card_div_four (k : ℕ) (hk : 0 < k) :
+    ∃ P : PlanarPointSet, NoFiveCollinear P ∧ k ≤ fourPointLineCount P ∧
+      P.points.card ≤ 4 * fourPointLineCount P := by
+  obtain ⟨P, hcard, hno5, hcount⟩ := quartic_linear_lower_bound k hk
+  exact ⟨P, hno5, hcount, by omega⟩
+
+/-- **Real-valued density form.**  The same witness family, with the `1/4` density
+written over `ℝ`: `(P.points.card : ℝ) / 4 ≤ fourPointLineCount P`, i.e. the linear
+lower bound `L₄(n) ≥ n/4` for the (unboundedly large) quartic-chord sets. -/
+theorem exists_fourPointLineCount_ge_card_div_four_real (k : ℕ) (hk : 0 < k) :
+    ∃ P : PlanarPointSet, NoFiveCollinear P ∧ (k : ℝ) ≤ (fourPointLineCount P : ℝ) ∧
+      (P.points.card : ℝ) / 4 ≤ (fourPointLineCount P : ℝ) := by
+  obtain ⟨P, hno5, hcount, hdens⟩ := exists_fourPointLineCount_ge_card_div_four k hk
+  refine ⟨P, hno5, by exact_mod_cast hcount, ?_⟩
+  rw [div_le_iff₀ (by norm_num : (0 : ℝ) < 4)]
+  calc (P.points.card : ℝ)
+      ≤ ((4 * fourPointLineCount P : ℕ) : ℝ) := by exact_mod_cast hdens
+    _ = (fourPointLineCount P : ℝ) * 4 := by push_cast; ring
+
 /-! ### Exact collinearity criteria on the quartic (arithmetization)
 
 The `noFiveCollinear_of_onQuartic` engine says the quartic graph *forbids* five

--- a/research/problems/erdos-101-oq-04/state.md
+++ b/research/problems/erdos-101-oq-04/state.md
@@ -53,3 +53,20 @@ per-family no-five-collinear certificate.
 - Total attempts: 1
 - Current approach attempts: 1
 - Approaches tried: 1
+
+## Progress (2026-07-09, researcher-11 — intrinsic linear density)
+
+Added the intrinsic-density corollaries of `quartic_linear_lower_bound` to
+`Proofs/Erdos101OQ04.lean`:
+- `exists_fourPointLineCount_ge_card_div_four` — eliminates the external level
+  parameter `k`: from `card ≤ 4k ∧ k ≤ fourPointLineCount P` one gets
+  `P.points.card ≤ 4 · fourPointLineCount P`, the intrinsic density `≥ 1/4`.
+- `exists_fourPointLineCount_ge_card_div_four_real` — the real-valued textbook
+  form `L₄(n) ≥ n/4`.
+
+Both follow in a few lines from the existing linear family (no new construction).
+Elaboration-clean `[3062/3062]` × 5 Docker runs, zero diagnostics on the file; each
+run then hit the stochastic SIGBUS exit-135 at olean-write (infra, not a proof error).
+Shipped UNVERIFIED. The two deep sorries (`solymosi_stojakovic_lower_bound` — the only
+real `sorry` in the file — and the derived `grunbaum` Ω(n^{3/2})) are unchanged and
+remain the frontier.


### PR DESCRIPTION
## Summary

The quartic linear lower-bound family `quartic_linear_lower_bound` already establishes
`L₄(n) = Ω(n)` — but it states its count `k ≤ fourPointLineCount P` against the *external*
level-parameter `k`, on `≤ 4·k` points. This PR eliminates `k` to give the **intrinsic
density** statement, which is what the textbook lower bound `L₄(n) ≥ n/4` actually asserts:

- `exists_fourPointLineCount_ge_card_div_four` — from `card ≤ 4k ∧ k ≤ fourPointLineCount P`
  (both delivered by the existing family), `P.points.card ≤ 4 · fourPointLineCount P`: the
  four-point lines are at least a `1/4` fraction of the vertices, for arbitrarily large
  no-five-collinear sets.
- `exists_fourPointLineCount_ge_card_div_four_real` — the real-valued form
  `(P.points.card : ℝ)/4 ≤ fourPointLineCount P`.

Both are short corollaries of the existing linear family — no new geometric construction.
They make the linear floor `Ω(n)` visible **intrinsically** (density independent of the
auxiliary parameter), complementing the parameterised `exists_isLowerBoundConstruction_linear`.

## Scope

This does **not** touch the genuine open frontier: `solymosi_stojakovic_lower_bound` (the
file's single remaining `sorry`, the `n^{2−o(1)}` construction) and the `grunbaum` Ω(n^{3/2})
bound derived from it are unchanged.

## Verification

- 2 theorems, **0 new sorries, 0 axioms**.
- Elaboration-clean `[3062/3062]` with **zero diagnostics on `Erdos101OQ04.lean`** across 5
  Docker builds; each run then hit the stochastic **SIGBUS exit-135 at olean-write**
  (documented infra crash, not a proof error). The two `sorry` warnings in the build output
  are pre-existing and live in the dependency `Erdos101OQ01.lean`. Shipped **UNVERIFIED** per
  that established pattern — the file elaborates fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)