### PR TITLE
Fix: sync stale lineCount metadata to actual wc -l (3 entries)

### DIFF
--- a/src/data/proofs/abundant-number-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-01/meta.json
@@ -20,7 +20,7 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 236,
+    "lineCount": 197,
     "theoremCount": 13,
     "definitionCount": 0,
     "dateAdded": "2026-06-18",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-03/meta.json
@@ -49,7 +49,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 740,
+    "lineCount": 870,
     "assumptions": "The general direction (Sturm ⟹ Descartes for an arbitrary polynomial) is a reduction: it is conditional on a `SturmReduction p` bridge structure whose five fields package Sturm's exact positive-root count on (0, B] together with the three classical coefficient-comparison facts σ_p(0) ≤ V(p), Even(V(p) − σ_p(0)), and Even(σ_p(B)). Per the project's axiom-integrity policy these structure fields are mathematical assumptions (counted here as axiomCount 1; obtaining the data for a general p requires Sturm's theorem, axiomatized in the parent entry as sturm_exact_count_axiom, plus standard Sturm/Descartes comparison theory). No `axiom` declarations and no sorries appear in the file (leanFile.axiomCount = 0). The reduction theorems (upper_bound_core, parity_core, descartes_upper_bound_via_sturm, descartes_parity_via_sturm, descartes_rule_via_sturm) are fully machine-checked implications, and the Sturm half is validated UNCONDITIONALLY and axiom-free on linear polynomials X − c (c > 0), reusing the gallery's axiom-free Sturm computations. The linear-polynomial validation (X − c, c > 0) is now fully unconditional and axiom-free: the coefficient sign-change count V(X − c) = 1 is computed directly (linear_signChanges, via the new axiom-free countSignChanges_two), so the previously-assumed hypothesis hV has been discharged and linearReduction/linear_descartes_bound carry no standing assumption for the linear case.",
     "theoremCount": 26,
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "assumptions": "None. The file is axiom-free (only the ordinary foundational axioms of Lean/Mathlib are used; `#print axioms` shows no `sorryAx`, no `Lean.ofReduceBool`). All examples use kernel `decide`, not `native_decide`. Note: this file does NOT prove the Strong Goldbach Conjecture, which remains open; it proves only that the conjecture is equivalent to its symmetric-prime-pair form.",
-    "lineCount": 892,
+    "lineCount": 932,
     "theoremCount": 30,
     "definitionCount": 5,
     "originalContributions": [
@@ -119,7 +119,7 @@
   },
   "leanFile": {
     "namespace": "StrongGoldbach",
-    "lineCount": 892,
+    "lineCount": 932,
     "axiomCount": 0,
     "theoremCount": 30,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Resync stale `leanFile.lineCount` / `meta.lineCount` to the actual Lean source line count in 3 single-file gallery entries **not** already covered by open PR #36821.

## Evidence

Researcher file growth updated the `.lean` sources but left the metadata line counts stale. The gallery's canonical convention (4193/4201 entries agree) is `lineCount == wc -l` (count of `\n`). All 3 files end in a trailing newline.

| slug | old meta.lineCount | actual wc -l |
|------|-----|-----|
| descartes-rule-of-signs-oq-01-oq-03 | 740 | 870 |
| strong-goldbach-symmetric | 892 | 932 |
| abundant-number-oq-01 | 236 | 197 |

`strong-goldbach-symmetric` also had a stale `leanFile.lineCount` (892→932); the other two had `leanFile.lineCount` already correct with only `meta.lineCount` drifted.

Scope was deliberately trimmed to avoid overlapping the 4 single-file entries (erdos-897-oq-01, erdos-1092, erdos-490-oq-01, erdos-659) already fixed in the still-open #36821. Multi-file entries (with `additionalFiles`) are out of scope here.

---
Automated fix by lean-mechanic agent.