### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-03): the p-group prime must divide the degree

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
@@ -228,4 +228,29 @@ theorem not_pgroup_any_of_not_isPrimePow (α : ℝ) (hα : IsIntegral ℚ α)
   · exact h1 h
   · exact hpp h
 
+/-- **A nontrivial p-group Galois group forces `p` to divide the degree.**
+    A `p`-group Galois group makes the degree `p^k`; nontriviality (`degree > 1`) forces
+    `k ≥ 1`, so `p ∣ degree`.  This exposes as a named lemma the divisibility that the
+    proof of `pgroup_prime_unique` uses internally, pinning the `p`-group prime down as a
+    *divisor* of the degree — the cleanest positive form of the "which prime" constraint. -/
+theorem prime_dvd_degree_of_pgroup (α : ℝ) (hα : IsIntegral ℚ α)
+    {p : ℕ} (hp : p.Prime) (hgt : 1 < (minpoly ℚ α).natDegree)
+    (hP : IsPGroup p (minpoly ℚ α).Gal) :
+    p ∣ (minpoly ℚ α).natDegree := by
+  obtain ⟨k, hk⟩ := galois_pgroup_implies_degree_is_pow_p α hα hp hP
+  have hk0 : k ≠ 0 := by rintro rfl; rw [pow_zero] at hk; omega
+  rw [hk]; exact dvd_pow_self p hk0
+
+/-- **The p-group prime must divide the degree (contrapositive, crispest form).**
+    If the prime `p` does *not* divide `natDegree(minpoly ℚ α)` and the extension is
+    nontrivial (`degree > 1`), then `Gal(minpoly ℚ α)` is not a `p`-group.  This is the
+    tightest hypothesis form of the prime-factor obstruction — no dividing prime `q` need
+    be exhibited — and generalises `odd_degree_gt_one_not_2group` (the `p = 2` case, where
+    `2 ∤ degree` is exactly `degree` odd) to every prime `p`. -/
+theorem not_pgroup_of_not_dvd_degree (α : ℝ) (hα : IsIntegral ℚ α)
+    {p : ℕ} (hp : p.Prime) (hgt : 1 < (minpoly ℚ α).natDegree)
+    (hndvd : ¬ p ∣ (minpoly ℚ α).natDegree) :
+    ¬ IsPGroup p (minpoly ℚ α).Gal :=
+  fun hP => hndvd (prime_dvd_degree_of_pgroup α hα hp hgt hP)
+
 end AngleTrisectionOQ02OQ01OQ03


### PR DESCRIPTION
## Summary

Two named primitives added to the p-group-Galois / minimal-polynomial-degree file (`AngleTrisectionOQ02OQ01OQ03.lean`), the algebraic core of angle-trisection impossibility. **0 new axioms, 0 sorries.** Both use only existing results in the file.

- **`prime_dvd_degree_of_pgroup`** — a nontrivial `p`-group Galois group (`degree > 1`) forces `p ∣ natDegree(minpoly ℚ α)`. This exposes as a reusable named lemma the divisibility that the proof of `pgroup_prime_unique` currently inlines, pinning the `p`-group prime down as a *divisor* of the degree (the cleanest positive form of the "which prime" constraint).

- **`not_pgroup_of_not_dvd_degree`** — its contrapositive in the crispest hypothesis form: if `p ∤ natDegree` and the extension is nontrivial, then `Gal` is not a `p`-group. Unlike the existing obstructions, no dividing prime `q` need be exhibited. It generalises `odd_degree_gt_one_not_2group` (the `p = 2` case, where `2 ∤ degree` is exactly "degree odd") to every prime `p`.

Together they crystallise the fundamental constraint the file develops: *the `p`-group prime of a nontrivial Galois extension is precisely a prime divisor of its degree.*

## Verification
- Elaboration is **clean**: `docker-build.sh Proofs.AngleTrisectionOQ02OQ01OQ03` type-checks the file in ~0.3–2 s across runs with **no errors at the new lines** (236–256) and no `unsolved goals` / `type mismatch` / dependency-corruption in the log.
- The olean *write* crashes with SIGBUS (exit 135) on the shared docker cache — a known stochastic infrastructure failure at disk-write, not an elaboration error. Marking **elaboration-clean / UNVERIFIED-write**. Additions are purely additive.
- Research-layer file (no gallery `meta.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)