### PR TITLE
audit: erdos-952 clarify EisensteinMoatProblem placeholder

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17630,10 +17630,10 @@
       "result": "clean"
     },
     "erdos-952": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:06:51Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "erdos-953": {
       "auditCount": 5,

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -138,7 +138,7 @@
       "summary": "EisensteinMoatProblem, erdos_952_status, attribution_note",
       "startLine": 297,
       "endLine": 348,
-      "mathContext": "The analogous problem for Eisenstein primes. Status: OPEN. Attribution: Motzkin, Gordon et al. (1963)."
+      "mathContext": "EisensteinMoatProblem is a placeholder: its body reuses the Gaussian moat definition over ℤ[i] rather than formalizing Eisenstein primes in ℤ[ω] (a genuine ℤ[ω] version is future work). HigherDimensionalMoat is likewise a scaffold (n = n). Status: OPEN. Attribution: Motzkin, Gordon et al. (1963)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Auditor finding — erdos-952 (Gaussian Moat Problem)

**Issue (low severity, prose):** The `variants` section `mathContext` described `EisensteinMoatProblem` as *"The analogous problem for Eisenstein primes."* However, the Lean definition (`Erdos952Problem.lean:318`) has a body that is a **verbatim copy of the Gaussian moat problem** — it quantifies over `GaussianInt` via `IsInfiniteGaussianPrimeWalk`, with nothing about ℤ[ω]. So the meta overclaims a variant that isn't actually formalized.

**Fix:** Corrected the mathContext to state `EisensteinMoatProblem` is a placeholder reusing the Gaussian definition (a genuine ℤ[ω] version is future work), and noted `HigherDimensionalMoat` is likewise a scaffold (`n = n`).

### Rest of entry confirmed CLEAN
- Counts match source exactly: **18 defs / 18 theorems / 2 axioms / 359 lines**
- Both axioms (`gaussian_prime_classification`, `tsuchimura`) are real, meaningful, disclosed propositions — not `True`-stubs
- Examples use kernel `decide` (no `native_decide` → no undisclosed `Lean.ofReduceBool`); `axiomCount: 2` correct
- `status: axiomatized` + `badge: axiom` correct for an open problem
- Derived theorems (jordan_rabung, gethner_et_al, factorial construction) are genuine
- Aristotle companion stub: 5 routine sorries, standard pattern, disclosed in `additionalFiles`

Also bumps audit-tracker for erdos-952.

🤖 Generated with [Claude Code](https://claude.com/claude-code)