### PR TITLE
research(erdos-659-incomplete-01): first lemmas for the counting function B₂ [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -339,6 +339,35 @@ theorem representable_pow {m : ℕ} (hm : m ∈ representable_x2_2y2) (k : ℕ) 
 theorem two_pow_representable (k : ℕ) : 2 ^ k ∈ representable_x2_2y2 :=
   representable_pow two_representable k
 
+/-! ### Basic behaviour of the counting function `B₂`
+
+The counting function `B₂(N) = |{d ≤ N : d = x² + 2y²}|` (whose growth `∼ c·N/√(log N)`
+is Landau's deep theorem) satisfies two elementary structural facts unconditionally: it
+is monotone in `N`, and it is positive once `N ≥ 1` (since `1 = 1² + 2·0²` is always
+counted). Both are finiteness bookkeeping on the underlying set, independent of the deep
+analytic input `moreeOsburnWorks`. -/
+
+/-- **`B₂` is monotone.** Enlarging the cutoff can only add representable integers:
+    `N ≤ M ⟹ B₂(N) ≤ B₂(M)`. The counted set `representable ∩ Icc 1 N` grows with `N`
+    and stays finite (bounded by `Icc 1 M`). -/
+theorem B2_mono {N M : ℕ} (h : N ≤ M) : B2 N ≤ B2 M := by
+  unfold B2
+  exact Set.ncard_le_ncard
+    (Set.inter_subset_inter subset_rfl (Set.Icc_subset_Icc_right h))
+    ((Set.finite_Icc 1 M).inter_of_right _)
+
+/-- **`B₂(N) ≥ 1` for `N ≥ 1`.** The integer `1 = 1² + 2·0²` is representable and lies
+    in every window `Icc 1 N` with `N ≥ 1`, so the counted set is nonempty. -/
+theorem one_le_B2 {N : ℕ} (hN : 1 ≤ N) : 1 ≤ B2 N := by
+  unfold B2
+  have hfin : (representable_x2_2y2 ∩ Set.Icc 1 N).Finite :=
+    (Set.finite_Icc 1 N).inter_of_right _
+  have hmem : (1 : ℕ) ∈ representable_x2_2y2 ∩ Set.Icc 1 N :=
+    ⟨one_representable, Set.mem_Icc.mpr ⟨le_refl 1, hN⟩⟩
+  have hpos : 0 < (representable_x2_2y2 ∩ Set.Icc 1 N).ncard :=
+    (Set.ncard_pos hfin).mpr ⟨1, hmem⟩
+  omega
+
 /-! ### The mod-8 obstruction (necessity side of the characterization)
 
 The lemmas above are all *positivity* results — they exhibit integers that **are**

--- a/research/problems/erdos-659-incomplete-01/knowledge.md
+++ b/research/problems/erdos-659-incomplete-01/knowledge.md
@@ -132,3 +132,22 @@ genuinely-deep Landau bounds — out of session scope.
 **Gotchas:** persistent SIGBUS-135 flakes + one corrupt dep `Data/List/Pairwise.ir` invalid-header
 → `docker-repair-cache.sh` (force cache get) then default-32GB build went green (reduced 24576 kept
 135-flaking). Default memory beat reduced here.
+
+## Session 2026-07-09 (researcher-1) — first lemmas for the counting function B₂ (VERIFIED green)
+
+The counting function `B2(N) = (representable_x2_2y2 ∩ Set.Icc 1 N).ncard` (Landau's
+∼c·N/√log N) was DEFINED but had NO lemmas. Added the two elementary unconditional facts:
+- `B2_mono {N M} (h: N≤M) : B2 N ≤ B2 M` — `Set.ncard_le_ncard (Set.inter_subset_inter
+  subset_rfl (Set.Icc_subset_Icc_right h)) ((Set.finite_Icc 1 M).inter_of_right _)`.
+- `one_le_B2 {N} (hN: 1≤N) : 1 ≤ B2 N` — 1=1²+2·0² ∈ rep ∩ Icc 1 N ⟹ ncard>0 via
+  `(Set.ncard_pos hfin).mpr ⟨1,hmem⟩` + omega.
+
+Pure finiteness bookkeeping, 0 new axioms (independent of moreeOsburnWorks). Docker
+**VERIFIED green** `✔ Built Proofs.Erdos659Problem (4.3s)` (3058 jobs, confirmed twice).
+File 21→23 theorems, 482→511 lines (gallery meta leanFile synced). Reusable ncard API:
+Set.ncard_le_ncard, Set.finite_Icc, Set.Finite.inter_of_right, Set.ncard_pos, Set.mem_Icc,
+Set.Icc_subset_Icc_right, Set.inter_subset_inter subset_rfl.
+
+Terminus unchanged: deep arithmetic characterization (primes ≡5,7 mod8 to even powers) =
+axiom moreeOsburnWorks (Landau disc −8); representability elementary theory now essentially
+complete (closure mul/pow/sq/2^k, mod-8 necessity, 35-counterexample, B₂ basics).

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -140,9 +140,9 @@
       "Real"
     ],
     "namespace": "Erdos659",
-    "lineCount": 482,
+    "lineCount": 511,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 23,
     "definitionCount": 9,
     "path": "Proofs/Erdos659Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The counting function `B₂(N) = |{d ≤ N : d = x² + 2y²}|` (`(representable_x2_2y2 ∩ Set.Icc 1 N).ncard`) — whose asymptotic growth `∼ c·N/√(log N)` is Landau's deep theorem — was **defined but had no lemmas**. This adds its two elementary, unconditional structural facts:

- `B2_mono : N ≤ M → B2 N ≤ B2 M` — monotonicity (the counted set grows with the cutoff and stays finite).
- `one_le_B2 : 1 ≤ N → 1 ≤ B2 N` — positivity (`1 = 1² + 2·0²` is representable and lies in every window `Icc 1 N`).

Both are pure finiteness bookkeeping on the underlying set, independent of the deep analytic axiom `moreeOsburnWorks`. The file stays at 1 axiom / 0 sorries.

## Verification: VERIFIED (green)

Docker build: `✔ [3058/3058] Built Proofs.Erdos659Problem (4.3s)`, `Build completed successfully (3058 jobs)` — confirmed on two consecutive runs. File: 21 → 23 theorems (gallery `meta.json` `leanFile` counts synced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)