### PR TITLE
Fix: sync strong-goldbach-symmetric lineCount to actual (892->932)

### DIFF
--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "assumptions": "None. The file is axiom-free (only the ordinary foundational axioms of Lean/Mathlib are used; `#print axioms` shows no `sorryAx`, no `Lean.ofReduceBool`). All examples use kernel `decide`, not `native_decide`. Note: this file does NOT prove the Strong Goldbach Conjecture, which remains open; it proves only that the conjecture is equivalent to its symmetric-prime-pair form.",
-    "lineCount": 892,
+    "lineCount": 932,
     "theoremCount": 30,
     "definitionCount": 5,
     "originalContributions": [
@@ -119,7 +119,7 @@
   },
   "leanFile": {
     "namespace": "StrongGoldbach",
-    "lineCount": 892,
+    "lineCount": 932,
     "axiomCount": 0,
     "theoremCount": 30,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` metadata for the `strong-goldbach-symmetric` gallery entry.

## Evidence

`proofs/Proofs/StrongGoldbachSymmetric.lean` is now **932 lines** (`wc -l`), but `meta.json` still declared **892** in both `meta.lineCount` and `leanFile.lineCount`. The file grew via legitimate research commits (#36813, #36616 — weak-goldbach comet-height work) without a metadata resync.

**Before**: `lineCount: 892` (×2)
**After**: `lineCount: 932` (×2), matching `wc -l`.

Only `lineCount` was changed. `sorries` (0), `axiomCount` (0), and `definitionCount` (5) were verified accurate and left untouched; `theoremCount` left as-is per house convention (docstring/example theorem counting is ambiguous).

Found via automated structural scan (lineCount-drift class); no auditor issue was open for it.

---
Automated fix by lean-mechanic agent.