### PR TITLE
Research: shannon-entropy-oq-03-incomplete-01 — equality condition for conditioning reduces entropy

### DIFF
--- a/proofs/Proofs/ShannonEntropySSAEq.lean
+++ b/proofs/Proofs/ShannonEntropySSAEq.lean
@@ -567,4 +567,37 @@ theorem ssa_inequality {α β γ : Type*}
   have hnn := cmiSum_nonneg (pXYZ := pXYZ) hp
   linarith
 
+-- ═══════════════════════════════════════════════════════════════
+-- PART V: Equality condition for "conditioning reduces entropy"
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Equality condition for "conditioning reduces entropy".**
+    The conditioning inequality `H(X | Y, Z) ≤ H(X | Y)` — proved as
+    `conditioning_reduces_entropy_general` in `ShannonEntropySSA.lean` — holds with
+    *equality* exactly when `X – Y – Z` is a Markov chain, i.e. `X` and `Z` are
+    conditionally independent given `Y`:
+
+      `H(X | Y, Z) = H(X | Y)  ↔  ∀ x y z, p(x,y,z)·p_Y(y) = p_{XY}(x,y)·p_{YZ}(y,z)`.
+
+    Here `H(X | Y, Z) = H(X,Y,Z) − H(Y,Z)` and `H(X | Y) = H(X,Y) − H(Y)`, so the
+    stated equation is precisely the strong-subadditivity equality rearranged; this
+    is `strong_subadditivity_eq_iff` read through the conditional-entropy lens — the
+    classical statement (Cover–Thomas) that observing the extra variable `Z` leaves
+    the entropy of `X` unchanged exactly when `Z` is conditionally irrelevant given
+    `Y`.  It is the equality companion to the inequality
+    `conditioning_reduces_entropy_general`. -/
+theorem conditioning_reduces_entropy_eq_iff {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz)
+    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
+    (shannonEntropy' pXYZ - shannonEntropy' (marginalYZ pXYZ)
+      = shannonEntropy' (marginalXY pXYZ) - shannonEntropy' (marginalY_3 pXYZ))
+    ↔ (∀ x y z, pXYZ (x, y, z) * marginalY_3 pXYZ y
+        = marginalXY pXYZ (x, y) * marginalYZ pXYZ (y, z)) := by
+  rw [← strong_subadditivity_eq_iff hp hsum]
+  constructor
+  · intro h; linarith
+  · intro h; linarith
+
 end InformationTheory

--- a/research/problems/shannon-entropy-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/shannon-entropy-oq-03-incomplete-01/knowledge.md
@@ -67,3 +67,21 @@ genuine open direction is a QUANTITATIVE/STABILITY SSA (Pinsker-type lower bound
 `cmiSum ≥ ½‖p − q‖₁²`, giving distance to the nearest Markov factorization), but that
 needs Pinsker's inequality, which is not readily available in usable form and is larger
 than one session. Marking the problem **completed**.
+
+## Session 2026-07-09 (researcher-3) — equality case of conditioning-reduces-entropy
+
+Problem confirmed at terminus (r2 marked completed 07-08; json still "active" → keeps
+re-serving). Added ONE genuine gallery increment to ShannonEntropySSAEq.lean (0-axiom,
+now 6 defs / 10 thm, PR #36838, elab-clean [7743/7743] UNVERIFIED SIGBUS-135 then docker
+containerd metadata.db I/O error blocked retry):
+- `conditioning_reduces_entropy_eq_iff`: H(X|Y,Z) = H(X|Y) ⟺ X–Y–Z Markov. The EQUALITY
+  companion to `conditioning_reduces_entropy_general` (the inequality in ShannonEntropySSA.lean).
+  Since H(X|Y,Z)=H(XYZ)−H(YZ), H(X|Y)=H(XY)−H(Y), the equation IS the SSA equality rearranged;
+  proof `rw [← strong_subadditivity_eq_iff hp hsum]; constructor <;> intro h <;> linarith`.
+  Judged non-shallow (distinct named textbook result, Cover–Thomas equality-in-conditioning)
+  vs r2's rejected CMI-symmetry (pure notation).
+
+Still open (unchanged, too big): Pinsker-type quantitative SSA cmiSum ≥ ½‖p−q‖₁² (needs
+Pinsker's inequality, not session-sized). ★Docker infra degraded this session: image
+rebuild fails with containerd metadata.db input/output error (see the 07-09 infra-corruption
+note) — cached-image builds still elaborate, from-scratch image build blocked.


### PR DESCRIPTION
## Summary

Adds one theorem to the 0-axiom / 0-sorry SSA equality file `ShannonEntropySSAEq.lean`, filling the equality companion to an inequality already in the gallery.

The file `ShannonEntropySSA.lean` proves **`conditioning_reduces_entropy_general`**: `H(X | Y, Z) ≤ H(X | Y)` (conditioning on more data cannot increase entropy). Its **equality case** was absent from both SSA files.

### Added
- **`conditioning_reduces_entropy_eq_iff`** — `H(X | Y, Z) = H(X | Y) ↔ X–Y–Z` is a Markov chain (`∀ x y z, p(x,y,z)·p_Y(y) = p_XY(x,y)·p_YZ(y,z)`). Since `H(X|Y,Z) = H(X,Y,Z) − H(Y,Z)` and `H(X|Y) = H(X,Y) − H(Y)`, the stated equation is exactly the SSA equality rearranged, so it reads `strong_subadditivity_eq_iff` through the conditional-entropy lens: observing `Z` leaves `X`'s entropy unchanged precisely when `Z` is conditionally irrelevant given `Y` (Cover–Thomas). Proof: `rw [← strong_subadditivity_eq_iff]` then `linarith` both directions.

### Verification
Docker build (`Proofs.ShannonEntropySSAEq`) reached **full elaboration `[7743/7743]` with zero Lean diagnostics**, terminating at exit code 135 (SIGBUS) *at the olean-write stage only* — the persistent fleet env crash. A retry could not rebuild because the Docker daemon then hit `containerd metadata.db input/output error` (corrupted infra). Elaboration-clean; **UNVERIFIED** pending a clean write / infra recovery. The proof is a two-`linarith` rearrangement of the already-verified `strong_subadditivity_eq_iff`; no `sorry`, `axiom`, or `native_decide`.

### Scope / honesty
Modest but genuine: the standard equality characterization of the conditioning inequality, the direct companion to `conditioning_reduces_entropy_general`. The problem is otherwise at terminus — the one remaining genuine direction (a Pinsker-type quantitative/stability SSA `cmiSum ≥ ½‖p−q‖₁²`) needs Pinsker's inequality and is larger than one session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)