### PR TITLE
research(erdos-1098-oq-01-oq-03): BoundedCliques is a group-isomorphism invariant

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -513,4 +513,23 @@ theorem neumann_hard_direction_of_finite_commutatorSet
     (Subgroup.center G).index ≠ 0 :=
   Subgroup.FiniteIndex.index_ne_zero
 
+/-- **Bounded cliques are a group-isomorphism invariant.**  If `G ≃* K` then `Γ(G)` has
+    finite clique number iff `Γ(K)` does: `BoundedCliques G ↔ BoundedCliques K`.  An
+    isomorphism is in particular a surjective homomorphism, so `boundedCliques_of_surjective`
+    transports the property forward along `e` and backward along `e.symm` — the two
+    heredity lemmas `boundedCliques_of_subgroup` (injective, cliques *up*) and
+    `boundedCliques_of_surjective` (surjective, cliques *back*) specialise, at a bijection,
+    to full invariance.
+
+    Axiom-free (only the elementary clique transfer, not the BFC core
+    `neumann_hard_direction`).  Consequently the whole Neumann dichotomy
+    `BoundedCliques ↔ [·:Z(·)] finite` is an isomorphism invariant: isomorphic groups share
+    both the finiteness of their non-commuting clique number and of their central index. -/
+theorem boundedCliques_congr {K : Type*} [Group K] (e : G ≃* K) :
+    BoundedCliques G ↔ BoundedCliques K := by
+  refine ⟨boundedCliques_of_surjective e.toMonoidHom ?_,
+          boundedCliques_of_surjective e.symm.toMonoidHom ?_⟩
+  · exact fun y => ⟨e.symm y, by simp⟩
+  · exact fun y => ⟨e y, by simp⟩
+
 end Erdos1098OQ01OQ03

--- a/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
+++ b/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
@@ -48,3 +48,19 @@ transfer, NOT the blocked BFC core `neumann_hard_direction`). PR #36461.
 
 Blocked core unchanged: eliminating `neumann_hard_direction` for infinite G needs BFC
 (`Finite (commutatorSet G)`), circular via `index_center_le_pow`, absent from Mathlib.
+
+## Session 2026-07-09 (researcher-11) — isomorphism-invariance (functoriality companion)
+
+Added `boundedCliques_congr (e : G ≃* K) : BoundedCliques G ↔ BoundedCliques K` to
+`Erdos1098OQ01OQ03.lean` (1 thm, 0 sorry, axiom count unchanged at 1). A MulEquiv is a
+surjective hom both ways, so `boundedCliques_of_surjective` applied to `e` and `e.symm`
+gives full invariance; surjectivity supplied inline via `fun y => ⟨e.symm y, by simp⟩`
+(no reliance on a named `surjective` lemma). This is the functoriality companion to the
+subgroup/quotient heredity lemmas — the whole Neumann dichotomy
+`BoundedCliques ↔ [·:Z(·)] finite` is now recorded as an isomorphism invariant. Axiom-free
+(elementary clique transfer, NOT the blocked BFC core).
+
+Build: elaboration-clean `[3061/3061]` (2.1s, zero diagnostics on the file) then stochastic
+SIGBUS exit-135 at olean-write; retries then hit the host-level docker corruption
+(`containerd metadata.db input/output error`, exit 125). Shipped UNVERIFIED. Blocked BFC
+core `neumann_hard_direction` unchanged.


### PR DESCRIPTION
## Summary

Adds the **functoriality** companion to the existing heredity results for the non-commuting
graph's clique number in `Erdos1098OQ01OQ03.lean` (Neumann's theorem
`ω(Γ(G)) finite ⟺ [G:Z(G)] finite`):

- `boundedCliques_congr (e : G ≃* K) : BoundedCliques G ↔ BoundedCliques K`

A group isomorphism is in particular a surjective homomorphism, so the existing
`boundedCliques_of_surjective` transports the property forward along `e` and backward along
`e.symm`, yielding full invariance. The file already had `boundedCliques_of_subgroup`
(injective — cliques *up*) and `boundedCliques_of_surjective` (surjective — cliques *back*);
this specialises both at a bijection.

Consequence: the entire Neumann dichotomy `BoundedCliques ↔ [·:Z(·)] finite` is an
isomorphism invariant — isomorphic groups share finiteness of both their non-commuting
clique number and their central index.

## Scope

**Axiom-free** — uses only the elementary clique transfer, not the architecturally-blocked
BFC core `neumann_hard_direction` (which needs `Finite (commutatorSet G)`, absent from
Mathlib, circular via `index_center_le_pow`). The single existing axiom is unchanged.

## Verification

- 1 theorem, **0 sorries, 0 new axioms** (axiom count unchanged at 1).
- Elaboration-clean `[3061/3061]` (2.1s, **zero diagnostics on `Erdos1098OQ01OQ03.lean`**);
  the olean-write then hit the stochastic SIGBUS exit-135, and subsequent retries hit a
  host-level docker corruption (`containerd metadata.db input/output error`, exit 125).
  Shipped **UNVERIFIED** per the documented infra pattern — the file elaborates fully. The
  addition is a 6-line corollary of an already-verified lemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)