### PR TITLE
audit: erdos-940 fix stale sorry prose + drifted section line numbers

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17546,10 +17546,10 @@
       "agentId": "auditor-2026-05-13-batch"
     },
     "erdos-940": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:09:29Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T05:00:00Z",
+      "result": "issues-fixed"
     },
     "erdos-941": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-940/meta.json
+++ b/src/data/proofs/erdos-940/meta.json
@@ -112,70 +112,70 @@
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture (OPEN)",
-      "summary": "States `erdos_940_conjecture`: $\\forall r \\ge 3$, $\\text{DiagonalSums}(r)$ has density 0. Also `erdos_940_infinitely_many` (complement is infinite) and `conjecture_implies_infinite` (1 sorry).",
+      "summary": "States `erdos_940_conjecture`: $\\forall r \\ge 3$, $\\text{DiagonalSums}(r)$ has density 0. Also `erdos_940_infinitely_many` (complement is infinite) and `conjecture_implies_infinite` (proved: density 0 $\\Rightarrow$ complement infinite).",
       "startLine": 119,
-      "endLine": 143,
-      "mathContext": "Mathematical content: States `erdos_940_conjecture`: $\\forall r \\ge 3$, $\\text{DiagonalSums}(r)$ has density 0. Also `erdos_940_infinitely_many` (complement is infinite) and `conjecture_implies_infinite` (1 sorry)."
+      "endLine": 187,
+      "mathContext": "Mathematical content: States `erdos_940_conjecture`: $\\forall r \\ge 3$, $\\text{DiagonalSums}(r)$ has density 0. Also `erdos_940_infinitely_many` (complement is infinite) and `conjecture_implies_infinite` (proved: density 0 $\\Rightarrow$ complement infinite)."
     },
     {
       "id": "squarefull",
       "title": "The Squarefull Case (r = 2)",
       "summary": "Axiomatizes `baker_brudern_theorem`: $\\text{SumsOfPowerful}(2, 2)$ has density 0. Baker-Brüdern (1994) proved this 18 years after Erdős called it 'easy'.",
-      "startLine": 144,
-      "endLine": 160,
+      "startLine": 188,
+      "endLine": 204,
       "mathContext": "Verified: Axiomatizes `baker_brudern_theorem`: $\\text{SumsOfPowerful}(2, 2)$ has density 0. Baker-Brüdern (1994) proved this 18 years after Erdős called it 'easy'."
     },
     {
       "id": "heath-brown",
       "title": "Heath-Brown's Representation Theorem",
       "summary": "Axiomatizes `heath_brown_theorem`: $\\forall^\\infty n$, $n \\in \\text{SumsOfPowerful}(2, 3)$. All large integers are sums of $\\le 3$ squarefull numbers (1988, ternary quadratic forms).",
-      "startLine": 161,
-      "endLine": 181,
+      "startLine": 205,
+      "endLine": 234,
       "mathContext": "Verified: Axiomatizes `heath_brown_theorem`: $\\forall^\\infty n$, $n \\in \\text{SumsOfPowerful}(2, 3)$. All large integers are sums of $\\le 3$ squarefull numbers (1988, ternary quadratic forms)."
     },
     {
       "id": "cubefull",
       "title": "The Cubefull Case and Three Cubes",
       "summary": "States `three_cubes_conjecture` (OPEN). Proves `cubes_subset_cubefull` ($n^3$ is 3-powerful). Defines `cubefull_conjecture` ($r = 3$ case).",
-      "startLine": 182,
-      "endLine": 204,
+      "startLine": 235,
+      "endLine": 257,
       "mathContext": "States `three_cubes_conjecture` (OPEN). Proves `cubes_subset_cubefull` ($$n^{3}$$ is 3-powerful). Defines `cubefull_conjecture` ($r = 3$ case)."
     },
     {
       "id": "universal",
       "title": "The Large Integer Representation Question",
       "summary": "States `universal_representation_conjecture`: $\\forall r \\ge 2$, $\\forall^\\infty n$, $n \\in \\text{DiagonalSums}(r)$. OPEN even for $r = 2$ (diagonal case).",
-      "startLine": 205,
-      "endLine": 224,
+      "startLine": 258,
+      "endLine": 277,
       "mathContext": "Mathematical content: States `universal_representation_conjecture`: $\\forall r \\ge 2$, $\\forall^\\infty n$, $n \\in \\text{DiagonalSums}(r)$. OPEN even for $r = 2$ (diagonal case)."
     },
     {
       "id": "relationship",
       "title": "Relationship Between the Questions",
       "summary": "Proves `status_summary`: Baker-Brüdern $\\wedge$ Heath-Brown in one line. Summarizes known vs open cases.",
-      "startLine": 225,
-      "endLine": 248,
+      "startLine": 278,
+      "endLine": 301,
       "mathContext": "Verified: Proves `status_summary`: Baker-Brüdern $\\wedge$ Heath-Brown in one line. Summarizes known vs open cases."
     },
     {
       "id": "examples",
       "title": "Examples and Computations",
       "summary": "Concrete proofs: $4 = 2^2$ is squarefull, $8 = 2^3$ is cubefull, $72 = 2^3 \\cdot 3^2$ is squarefull. All use `interval_cases` and `simp_all`.",
-      "startLine": 249,
-      "endLine": 281,
+      "startLine": 302,
+      "endLine": 334,
       "mathContext": "Concrete proofs: $4 = $2^{2}$$ is squarefull, $8 = $2^{3}$$ is cubefull, $72 = $2^{3}$ \\cdot $3^{2}$$ is squarefull. All use `interval_cases` and `simp_all`."
     },
     {
       "id": "related",
       "title": "Related Problems",
       "summary": "Defines connections to Erdős #941 (Heath-Brown's theorem), #1081 (refined $r=2$), and #1107 ($r+1$ summands, off-diagonal).",
-      "startLine": 282,
-      "endLine": 339,
+      "startLine": 335,
+      "endLine": 349,
       "mathContext": "Formal definition: Defines connections to Erdős #941 (Heath-Brown's theorem), #1081 (refined $r=2$), and #1107 ($r+1$ summands, off-diagonal)."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem #940 on density of sums of r-powerful numbers. The main conjecture (density 0 for r ≥ 3) remains OPEN. We formalize isPowerful, SumsOfPowerful, DiagonalSums, and the natural density framework. Known results are axiomatized: Baker-Brüdern (squarefull pairs, density 0) and Heath-Brown (squarefull triples, eventual coverage). Structural theorems (1 is powerful, n^r is powerful, cubes ⊆ cubefull) are proved. 2 sorries.",
+    "summary": "The formalization captures Erdős Problem #940 on density of sums of r-powerful numbers. The main conjecture (density 0 for r ≥ 3) remains OPEN. We formalize isPowerful, SumsOfPowerful, DiagonalSums, and the natural density framework. Known results are axiomatized: Baker-Brüdern (squarefull pairs, density 0) and Heath-Brown (squarefull triples, eventual coverage). Structural theorems (1 is powerful, n^r is powerful, cubes ⊆ cubefull) are proved, along with `conjecture_implies_infinite` (density 0 ⟹ complement infinite) and `heath_brown_complement_finite`. 0 sorries.",
     "implications": "**Theoretical Significance**: **Connections to Number Theory**\n\n1. **Phase Transitions**: The 2-to-3 summand transition for squarefull numbers (density 0 vs density 1) is a prototype for threshold phenomena in additive number theory\n2. **Waring's Problem**: Since perfect powers are powerful, Waring-type results are special cases of powerful number sum problems\n**3. Counting Function Asymptotics**: The $c_r N^{1/r}$ growth of $r$-powerful numbers places sum problems at the critical density boundary\n4. **Analytic Methods**: Baker-Brüdern used exponential sums; Heath-Brown used quadratic forms — different tools for density vs representation\n5. **ABC Conjecture**: Powerful numbers connect to ABC through the radical; bounds on powerful number sums would follow from strong ABC-type results.",
     "openQuestions": [
       "Does the set of sums of ≤ 3 cubes have density 0 (the r = 3 special case)?",


### PR DESCRIPTION
## Auditor finding — erdos-940 (Sums of r-Powerful Numbers)

Audited the next-stalest uncovered gallery entry (last audited 2026-05-04). The Lean source is **substantively honest**: 2 disclosed axioms (`baker_brudern_theorem`, `heath_brown_theorem`), 0 sorries, 0 native_decide, accurate counts (10 theorems / 15 defs verified against source). Status `axiomatized`/badge `axiom` is correct for this OPEN Erdős problem.

### Issues fixed (prose/metadata only — no source or count changes)

1. **Stale sorry claims.** The `main-conjecture` section summary + mathContext both claimed `conjecture_implies_infinite (1 sorry)`, and the conclusion summary claimed "2 sorries". The file is sorry-free — `conjecture_implies_infinite` (density 0 ⟹ complement infinite) is fully proved (source lines 141–186), as is `heath_brown_complement_finite`. Updated all three to reflect the completed proofs.

2. **Drifted section line numbers.** When the sorry was replaced by the ~45-line proof, the file shifted but section `startLine`/`endLine` values were not resynced. Corrected `main-conjecture` (119–143 → 119–187) and `squarefull`/`heath-brown`/`cubefull`/`universal`/`relationship`/`examples`/`related` to match actual `Part` boundaries.

Top-level `sorries: 0` / `axiomCount: 2` / `assumptions` were already correct. Tracker bumped (erdos-940 → issues-fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)