### PR TITLE
research(roth-theorem-k3-oq-03-oq-01): monotonicity of the k-AP count in the set

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -580,4 +580,38 @@ theorem kAPCount_nondeg_le {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k)
     _ = A.card * (N - 1) := by
           rw [Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, ZMod.card]
 
+/-- **Monotonicity of the `k`-AP count in the set.**  Enlarging `A` can only add
+    progressions: if `A ⊆ B` then every pair `(x, d)` whose length-`k` progression lies
+    in `A` also has it in `B`, so the counted set for `A` embeds in that for `B`.  This is
+    the basic structural fact behind density-increment arguments — the `k`-AP count is a
+    monotone functional of the underlying set. -/
+theorem kAPCount_count_mono {N : ℕ} [NeZero N] {k : ℕ} {A B : Finset (ZMod N)}
+    (hAB : A ⊆ B) :
+    (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        ∀ i : Fin k, p.1 + i.val • p.2 ∈ A)).card
+      ≤ (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+          ∀ i : Fin k, p.1 + i.val • p.2 ∈ B)).card := by
+  classical
+  apply Finset.card_le_card
+  intro p hp
+  rw [Finset.mem_filter] at hp ⊢
+  exact ⟨hp.1, fun i => hAB (hp.2 i)⟩
+
+/-- **Monotonicity of the nondegenerate `k`-AP count in the set.**  The `A ⊆ B` version of
+    `kAPCount_count_mono` restricted to nonzero common difference `d ≠ 0`: the genuine
+    (nondiagonal) `k`-AP count controlled by Roth's theorem is likewise monotone in the set,
+    since enlarging `A` preserves both the "all terms in the set" and the `d ≠ 0`
+    conditions. -/
+theorem kAPCount_nondeg_mono {N : ℕ} [NeZero N] {k : ℕ} {A B : Finset (ZMod N)}
+    (hAB : A ⊆ B) :
+    (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        (∀ i : Fin k, p.1 + i.val • p.2 ∈ A) ∧ p.2 ≠ 0)).card
+      ≤ (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+          (∀ i : Fin k, p.1 + i.val • p.2 ∈ B) ∧ p.2 ≠ 0)).card := by
+  classical
+  apply Finset.card_le_card
+  intro p hp
+  rw [Finset.mem_filter] at hp ⊢
+  exact ⟨hp.1, ⟨fun i => hAB (hp.2.1 i), hp.2.2⟩⟩
+
 end RothTheoremOQ03OQ01

--- a/research/problems/roth-theorem-k3-oq-03-oq-01/knowledge.md
+++ b/research/problems/roth-theorem-k3-oq-03-oq-01/knowledge.md
@@ -1,0 +1,26 @@
+# Knowledge: roth-theorem-k3-oq-03-oq-01
+
+File: `proofs/Proofs/RothTheoremOQ03OQ01.lean` (deep multilinear kAPCount/Gowers development;
+0 axioms / 0 sorries). Gowers norm, kAPCount, indicatorZMod, generalized von Neumann
+telescoping, diagonal/nondegenerate split, upper bounds #A·N and #A·(N−1).
+
+## Session 2026-07-09 (researcher-1) — monotonicity of the k-AP count in the set
+
+Executed the "monotonicity of nondeg count in A" open-next item.
+
+### Added (2 theorems, 0 axioms / 0 sorries)
+- `kAPCount_count_mono {A B} (hAB: A⊆B)`: card{(x,d):∀i,x+i•d∈A} ≤ card for B.
+- `kAPCount_nondeg_mono {A B} (hAB: A⊆B)`: same restricted to d≠0 (Roth-controlled count).
+Both: `Finset.card_le_card` + `intro p hp; rw[Finset.mem_filter]at hp⊢; exact ⟨hp.1,fun i=>hAB(hp.2 i)⟩`
+(nondeg: `⟨hp.1,⟨fun i=>hAB(hp.2.1 i),hp.2.2⟩⟩`). Faithful clone of the file's kAPCount_count_start_subset
+membership-unfold pattern. k-AP count is a monotone functional of the set (density-increment basic).
+
+### Verification — UNVERIFIED (docker INFRA down)
+Docker DAEMON failing: `failed to build: ... write .../io.containerd.metadata.v1.bolt/meta.db:
+input/output error` — containerd metadata.db I/O corruption, docker-build cannot build the image at
+all. Host .lake incomplete. Low-risk clones of an already-green same-file pattern; ship UNVERIFIED per
+docker-infra-down protocol. File →20 theorems,      617 lines.
+
+## Open next (unchanged)
+Real-analytic Λ_k(1_A) ≤ δ (re/nonneg of kAPCount:ℂ); k=3 reversal involution on nondeg pairs
+(not fixed-point-free in ZMod N → cannot conclude even).


### PR DESCRIPTION
## Summary

Adds the two monotonicity lemmas to `Proofs/RothTheoremOQ03OQ01.lean` (the deep multilinear `kAPCount`/Gowers development), executing the "monotonicity of nondeg count in `A`" item from the file's open-next list.

- `kAPCount_count_mono` — `A ⊆ B ⟹` `#{(x,d) : ∀ i, x + i·d ∈ A} ≤ #{(x,d) : ∀ i, x + i·d ∈ B}`.
- `kAPCount_nondeg_mono` — the same for the nondegenerate (`d ≠ 0`) count that Roth's theorem controls.

The `k`-AP count is a monotone functional of the underlying set — the basic structural fact behind density-increment arguments. Both proofs are `Finset.card_le_card` on filter subsets (a filtered-membership unfold, mirroring the existing `kAPCount_count_start_subset` pattern in the same file). File stays **0 axioms / 0 sorries**.

## Verification: UNVERIFIED (docker infrastructure down)

The docker daemon itself is failing this session: `failed to build: failed to solve: write /var/lib/desktop-containerd/.../io.containerd.metadata.v1.bolt/meta.db: input/output error` — a containerd `metadata.db` I/O corruption, so `docker-build.sh` cannot build the image at all, let alone run Lean. The host `.lake` is incomplete (would need a forbidden full `lake build`). The two lemmas are faithful low-risk clones of an already-verified membership-unfold pattern in the same file; a later clean docker run should confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)