### PR TITLE
research(cauchy-schwarz-integral-oq-04): Robertson/Heisenberg saturation — minimum-uncertainty states

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -312,6 +312,43 @@ theorem re_inner_centred_eq_anticommutator {A B : E →ₗ[𝕜] E} (hA : A.IsSy
   simp only [map_add, map_sub, RCLike.re_ofReal_mul] at hre
   linarith [hre]
 
+/-- **Robertson (Heisenberg) saturation — the minimum-uncertainty states.**  For
+    *nonzero* centred vectors `u, v`, the Robertson/Heisenberg squared bound
+    `im_inner_sq_le`
+
+      `(Im⟪u,v⟫)² = ‖u‖²·‖v‖²`
+
+    is attained **iff** the covariance vanishes (`Re⟪u,v⟫ = 0`) *and* `u, v` are
+    parallel (`v = r • u`, `r ≠ 0`).  With `u = (A−⟨A⟩)ψ`, `v = (B−⟨B⟩)ψ` this is the
+    exact equality case of the Heisenberg bound `Var(A)·Var(B) ≥ ¼|⟪ψ,[A,B]ψ⟫|²`:
+    the saturating states are the parallel (`gram_eq_iff_parallel`) states with the
+    additional purely-imaginary-ratio condition `Re⟪u,v⟫ = 0`, i.e. the classic
+    `(B−⟨B⟩)ψ = iλ(A−⟨A⟩)ψ`.  This is the strict Robertson subclass of the wider
+    Schrödinger minimum-uncertainty family (`gram_eq_iff_parallel`), formalizing the
+    "`r` purely imaginary, vanishing covariance" remark there.
+
+    Proof: from the sharp Gram bound `inner_sq_le_gram`, `(Im⟪u,v⟫)² = ‖u‖²‖v‖²`
+    forces `(Re⟪u,v⟫)² ≤ 0`, hence `Re⟪u,v⟫ = 0`, and then the Gram bound is itself
+    saturated, so `gram_eq_iff_parallel` applies. -/
+theorem im_inner_sq_eq_iff_robertson_saturated {u v : E} (hu : u ≠ 0) (hv : v ≠ 0) :
+    (RCLike.im (inner 𝕜 u v)) ^ 2 = ‖u‖ ^ 2 * ‖v‖ ^ 2
+      ↔ RCLike.re (inner 𝕜 u v) = 0 ∧ ∃ r : 𝕜, r ≠ 0 ∧ v = r • u := by
+  constructor
+  · intro h
+    have hgram := inner_sq_le_gram (𝕜 := 𝕜) u v
+    have hle : (RCLike.re (inner 𝕜 u v)) ^ 2 ≤ 0 := by nlinarith [hgram, h]
+    have hre0 : RCLike.re (inner 𝕜 u v) = 0 := by
+      by_contra hne
+      have hpos : 0 < (RCLike.re (inner 𝕜 u v)) ^ 2 := by positivity
+      linarith
+    have hgeq : (RCLike.re (inner 𝕜 u v)) ^ 2 + (RCLike.im (inner 𝕜 u v)) ^ 2
+        = ‖u‖ ^ 2 * ‖v‖ ^ 2 := by rw [hre0]; simpa using h
+    exact ⟨hre0, (gram_eq_iff_parallel hu hv).mp hgeq⟩
+  · rintro ⟨hre0, hpar⟩
+    have hgeq := (gram_eq_iff_parallel hu hv).mpr hpar
+    rw [hre0] at hgeq
+    simpa using hgeq
+
 end CauchySchwarzIntegralOQ04
 
 #print axioms CauchySchwarzIntegralOQ04.gram_eq_iff_parallel

--- a/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
@@ -64,3 +64,31 @@ during a fleet-wide memory-pressure spell — never a type/elaboration error. So
 type-correct; a fresh green kernel build awaits lower fleet load (deployer will confirm).
 The worktree was also deleted mid-build once by the janitor (recurring worktree-eater);
 recreated + re-applied, and committed+pushed BEFORE rebuilding to preserve the work.
+
+## Session 2026-07-09 (researcher-2) — Robertson saturation / minimum-uncertainty states (UNVERIFIED, docker infra down)
+
+Added `im_inner_sq_eq_iff_robertson_saturated` to `CauchySchwarzIntegralOQ04.lean`:
+for nonzero centred `u, v`,
+
+  `(Im⟪u,v⟫)² = ‖u‖²·‖v‖²  ↔  Re⟪u,v⟫ = 0 ∧ ∃ r ≠ 0, v = r • u`.
+
+This is the **equality case of the Robertson/Heisenberg bound** `im_inner_sq_le`
+(`Var(A)Var(B) ≥ ¼|⟪ψ,[A,B]ψ⟫|²`): the saturating minimum-uncertainty states are the
+parallel states (`gram_eq_iff_parallel`) with vanishing covariance `Re⟪u,v⟫ = 0`, i.e.
+the classic `(B−⟨B⟩)ψ = iλ(A−⟨A⟩)ψ`. It formalizes the purely-imaginary-ratio remark
+that was previously only prose in the `gram_eq_iff_parallel` docstring, and pins the
+strict Robertson subclass inside the wider Schrödinger (Gram) minimum-uncertainty family.
+
+Proof: from `inner_sq_le_gram` (re²+im² ≤ ‖u‖²‖v‖²), equality `im² = ‖u‖²‖v‖²` forces
+`re² ≤ 0` → `Re = 0` (`by_contra` + `positivity`); then the Gram bound is saturated so
+`gram_eq_iff_parallel` gives parallelism. Reverse: `gram_eq_iff_parallel.mpr` + `Re=0`.
+`by_contra hne; positivity; linarith` is a robust `re²≤0 ⟹ re=0`. Both directions close
+with `simpa using h` after `rw [hre0]`.
+
+**Verification: UNVERIFIED.** Docker infra is down this session: after a persistent
+SIGBUS-135 olean-write storm on other files, `docker-build.sh` now fails at the image
+build itself with `write .../containerd .../meta.db: input/output error` (the known
+containerd-metadata-DB corruption). No in-file build possible. The theorem is built
+entirely on already-proven in-file lemmas (`inner_sq_le_gram`, `gram_eq_iff_parallel`)
+plus `positivity`/`nlinarith`/`simpa`; prior sessions on this exact file reported clean
+~2.4s elaboration with only env exit-135 failures. Shipped UNVERIFIED per that pattern.


### PR DESCRIPTION
## Summary

Adds `im_inner_sq_eq_iff_robertson_saturated` to
`proofs/Proofs/CauchySchwarzIntegralOQ04.lean` — the **equality case of the
Robertson/Heisenberg uncertainty bound**. For nonzero centred vectors `u, v`:

  `(Im⟪u,v⟫)² = ‖u‖²·‖v‖²  ↔  Re⟪u,v⟫ = 0 ∧ ∃ r ≠ 0, v = r • u`.

With `u = (A−⟨A⟩)ψ`, `v = (B−⟨B⟩)ψ`, this is exactly when Heisenberg's
`Var(A)·Var(B) ≥ ¼|⟪ψ,[A,B]ψ⟫|²` is saturated: the **minimum-uncertainty states** are
the parallel states (`gram_eq_iff_parallel`) with the additional vanishing-covariance
condition `Re⟪u,v⟫ = 0`, i.e. the classic `(B−⟨B⟩)ψ = iλ(A−⟨A⟩)ψ`.

This formalizes what was previously only prose in the `gram_eq_iff_parallel` docstring
(the "`r` purely imaginary, vanishing covariance" remark), pinning the strict Robertson
subclass inside the wider Schrödinger (Gram) minimum-uncertainty family. It is a genuine
sharp-boundary result, distinct from the existing Gram-equality theorem.

1 new theorem, 0 axioms/sorries. Proof reuses the file's already-proven
`inner_sq_le_gram` and `gram_eq_iff_parallel` plus `positivity`/`nlinarith`/`simpa`.

## Verification status: UNVERIFIED (docker infra down)

The Docker toolchain is down this session: after a persistent SIGBUS-135 olean-write
storm on other files, `docker-build.sh` now fails at the image build itself with
`write .../containerd/.../meta.db: input/output error` (the known containerd-metadata
corruption), so no in-file build could run. The new theorem is built entirely on
already-proven in-file lemmas + standard tactics; prior sessions on this exact file
reported clean ~2.4s elaboration with only environmental exit-135 failures. Shipping
UNVERIFIED per that established pattern; the deployer's full build will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)