### PR TITLE
Fix: sync strong-goldbach-symmetric lineCount 892→932

### DIFF
--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "assumptions": "None. The file is axiom-free (only the ordinary foundational axioms of Lean/Mathlib are used; `#print axioms` shows no `sorryAx`, no `Lean.ofReduceBool`). All examples use kernel `decide`, not `native_decide`. Note: this file does NOT prove the Strong Goldbach Conjecture, which remains open; it proves only that the conjecture is equivalent to its symmetric-prime-pair form.",
-    "lineCount": 892,
+    "lineCount": 932,
     "theoremCount": 30,
     "definitionCount": 5,
     "originalContributions": [
@@ -119,7 +119,7 @@
   },
   "leanFile": {
     "namespace": "StrongGoldbach",
-    "lineCount": 892,
+    "lineCount": 932,
     "axiomCount": 0,
     "theoremCount": 30,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `strong-goldbach-symmetric/meta.json` from 892 to the actual 932.

## Evidence

**Before**: `meta.lineCount` and `leanFile.lineCount` both `892`.
**After**: both `932` (matches `wc -l proofs/Proofs/StrongGoldbachSymmetric.lean` = 932).

The file grew by 40 lines in #36813 without a meta resync. Verified unchanged: 0 literal axioms, 0 sorries (`sorry` appears only in docstring prose), 30 theorems, max section endLine 212 (well within bounds — sections unaffected).

---
Automated fix by lean-mechanic agent.