### PR TITLE
Research: erdos-771 — discharge both sorries in Erdos771ProblemAristotle companion (0/0)

### DIFF
--- a/proofs/Proofs/Erdos771ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos771ProblemAristotle.lean
@@ -28,7 +28,11 @@ def primeMutliples (p n : ℕ) : Finset ℕ :=
 -- Uses Finset.Nat.card_multiples or Icc filter card formula.
 theorem prime_multiples_size (p n : ℕ) (hp : p > 0) :
     (primeMutliples p n).card = n / p := by
-  sorry
+  have hIcc : Icc_n n = Finset.Ioc 0 n := by
+    unfold Icc_n; ext k; simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+  unfold primeMutliples
+  rw [hIcc]
+  exact Nat.Ioc_filter_dvd_card_eq_div n p
 
 -- Routine: The set of all subset sums of S.
 noncomputable def subsetSums (S : Finset ℕ) : Finset ℕ :=
@@ -44,6 +48,16 @@ def AvoidSum (S : Finset ℕ) (m : ℕ) : Prop :=
 -- be achieved as a subset sum.
 theorem prime_multiples_avoid (p m n : ℕ) (hp : Nat.Prime p) (hpm : ¬p ∣ m) :
     AvoidSum (primeMutliples p n) m := by
-  sorry
+  intro hmem
+  rw [subsetSums, Finset.mem_filter, Finset.mem_image] at hmem
+  obtain ⟨⟨A, hA, hAsum⟩, _⟩ := hmem
+  rw [Finset.mem_powerset] at hA
+  have hdvd : p ∣ ∑ a ∈ A, a := by
+    refine Finset.dvd_sum (fun a ha => ?_)
+    have ha' : a ∈ primeMutliples p n := hA ha
+    rw [primeMutliples, Finset.mem_filter] at ha'
+    exact ha'.2
+  rw [hAsum] at hdvd
+  exact hpm hdvd
 
 end Erdos771ProblemAristotle

--- a/research/problems/erdos-771/knowledge.md
+++ b/research/problems/erdos-771/knowledge.md
@@ -98,3 +98,20 @@ bounds. Genuinely external; status stays `axiomatized`.
 Codegen crash (exit 135/139) in this Docker env is **nondeterministic and masks real errors** —
 tail of the log showed only the crash; a full `> log 2>&1` capture revealed the actual parse
 error. Always capture full output when a build "crashes" with no diagnostic.
+
+## Session 2026-07-09 (researcher-3) — companion sorry-elimination (Erdos771ProblemAristotle)
+
+Erdos771Problem.lean is 0-sorry/2-axiom (deep erdos_graham_lower_bound + alon_freiman_upper_bound,
+external/irreducible). Erdos771Construction.lean verified 0/0. The Aristotle companion
+`Erdos771ProblemAristotle.lean` still carried 2 sorries (prime_multiples_size, prime_multiples_avoid)
+— both ALREADY verified in Construction.lean. Ported verbatim (identical defs modulo `primeMutliples`
+typo), companion now 0-sorry/0-axiom. PR #36849.
+- prime_multiples_size: rw Icc_n=Ioc 0 n (omega) + `Nat.Ioc_filter_dvd_card_eq_div n p`.
+- prime_multiples_avoid: intro hmem; mem_filter/mem_image/mem_powerset; `Finset.dvd_sum` (each elt
+  p∣·) then hpm.
+
+★UNVERIFIED — docker infra DOWN this session: `containerd metadata.db input/output error`, image
+rebuild impossible (cached-image builds also unavailable now). Proofs are verbatim ports of
+verified Construction.lean code → correctness inherited. Still open (unchanged): deep asymptotics
+f(n)=(1/2+o(1))n/log n, the 2 external axioms. Erdos771Aristotle.lean still has 4 sorries (separate
+companion; not addressed).


### PR DESCRIPTION
## Summary

Eliminates both `sorry`s in the Aristotle companion `Erdos771ProblemAristotle.lean` by **porting the two proofs already verified** (0-axiom / 0-sorry) in `Erdos771Construction.lean`. The companion's definitions (`Icc_n`, `primeMutliples`, `subsetSums`, `AvoidSum`) are structurally identical to the Construction file's, so the proofs transfer verbatim.

### Discharged
- **`prime_multiples_size`** — `|{multiples of p in {1,…,n}}| = ⌊n/p⌋`. Rewrite `Icc 1 n = Ioc 0 n` (`omega` on membership), then `Nat.Ioc_filter_dvd_card_eq_div`.
- **`prime_multiples_avoid`** — if `p` prime and `p ∤ m`, the multiples of `p` avoid `m`: every subset sum is `p`-divisible (`Finset.dvd_sum`), but `p ∤ m`.

Companion file is now **0 sorry / 0 axiom**. The deep Erdős–Graham / Alon–Freiman asymptotic bounds remain the two external axioms in `Erdos771Problem.lean` (unchanged, genuinely external).

### Verification
**UNVERIFIED — infra-blocked.** The Docker build could not run: the daemon fails at `containerd metadata.db input/output error` (corrupted infra this session; image rebuild impossible). However, both proofs are **verbatim copies of proofs verified** in `Erdos771Construction.lean` (`prime_multiples_size` line 57, `prime_multiples_avoid` line 69) under the same Mathlib 4.26 toolchain — the definitions match, so correctness is effectively inherited. No `sorry`, `axiom`, or `native_decide` added.

### Scope
Sorry-elimination on a companion file; does not touch the mathematics or the two deep axioms. Modest but a clean reduction of the codebase's sorry count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)