### PR TITLE
research(erdos-214-incomplete-01): complete mod-8 dichotomy for √2·ℤ² distances

### DIFF
--- a/proofs/Proofs/Erdos214Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos214Incomplete01OQ01.lean
@@ -268,4 +268,43 @@ theorem scaledLattice_dist_ne_sqrt_six {p q : Plane}
     dist p q ≠ Real.sqrt 6 :=
   scaledLattice_dist_ne_sqrt_six_mod_eight hp hq (n := 6) (by decide)
 
+/-!
+## The complete mod-8 dichotomy for achievable distances
+
+The squared distance is `2·(u² + v²)` with `u² + v² ≢ 3 (mod 4)`, so it lies in
+`{0, 2, 4} (mod 8)`.  This single arithmetic fact *characterizes* the achievable
+integer square-distances of `√2·ℤ²` modulo `8`, and unifies both previous avoidance
+families: the odd `n` (residues `1, 3, 5, 7`) and `n ≡ 6 (mod 8)` results are exactly
+the residues `{1, 3, 5, 6, 7}` that are **not** in `{0, 2, 4}`.
+-/
+
+/-- **Achievable distances lie in `{0, 2, 4} (mod 8)`.**  If two points of
+`ScaledLattice` are at distance `√n` (`n : ℕ`), then `n ≡ 0, 2, or 4 (mod 8)`.
+Indeed `n = 2·(u² + v²)` and `u² + v² ≢ 3 (mod 4)`, so `2·(u² + v²) ∈ {0,2,4} (mod 8)`.
+This is the positive companion to the avoidance theorems: it pins the *only* residues
+mod `8` a lattice distance can realize. -/
+theorem scaledLattice_achievable_mod_eight {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice)
+    {n : ℕ} (h : dist p q = Real.sqrt n) :
+    n % 8 = 0 ∨ n % 8 = 2 ∨ n % 8 = 4 := by
+  obtain ⟨u, v, huv⟩ := scaledLattice_dist_sq_two_mul_sq_add_sq hp hq
+  have hsq : dist p q ^ 2 = (n : ℝ) := by rw [h, Real.sq_sqrt (by positivity)]
+  rw [hsq] at huv
+  have hz : (n : ℤ) = 2 * (u ^ 2 + v ^ 2) := by exact_mod_cast huv
+  have h3 := sq_add_sq_mod_four_ne_three u v
+  omega
+
+/-- **Complete mod-8 avoidance.**  `√2·ℤ²` avoids `√n` for *every* `n` with
+`n ≡ 1, 3, 5, 6, or 7 (mod 8)` — the exact complement of the achievable residues
+`{0, 2, 4}`.  This single statement subsumes both `scaledLattice_dist_ne_sqrt_odd`
+(residues `1, 3, 5, 7`) and `scaledLattice_dist_ne_sqrt_six_mod_eight` (residue `6`),
+and is the sharp mod-8 boundary of the lattice's distance set. -/
+theorem scaledLattice_dist_ne_sqrt_of_mod_eight {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) {n : ℕ}
+    (hn : n % 8 = 1 ∨ n % 8 = 3 ∨ n % 8 = 5 ∨ n % 8 = 6 ∨ n % 8 = 7) :
+    dist p q ≠ Real.sqrt n := by
+  intro h
+  have hach := scaledLattice_achievable_mod_eight hp hq h
+  omega
+
 end Erdos214Incomplete01OQ01

--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -172,3 +172,25 @@ Unchanged: `juhasz_stronger` BLOCKED. The achieved squared distances of √2·�
 exactly {2·(u²+v²)}; odd n and n≡6 mod 8 are the two clean elementary sufficient
 avoidance conditions now formalized. Full characterization would need the sum-of-two-
 squares (Fermat) predicate.
+
+## Session 2026-07-09 (researcher-2) — complete mod-8 dichotomy (UNVERIFIED, docker infra down)
+
+Added 2 theorems to `Erdos214Incomplete01OQ01.lean` unifying the odd-`n` and `n≡6 mod 8`
+avoidance families into the sharp mod-8 characterization of √2·ℤ²'s distance set:
+- `scaledLattice_achievable_mod_eight`: if `dist p q = √n` then `n % 8 ∈ {0,2,4}` (the
+  ONLY achievable residues) — from `dist² = 2(u²+v²)` and `(u²+v²)%4 ≠ 3`, `omega`.
+- `scaledLattice_dist_ne_sqrt_of_mod_eight`: √2·ℤ² avoids √n for EVERY `n%8 ∈ {1,3,5,6,7}`
+  (the exact complement), subsuming both `scaledLattice_dist_ne_sqrt_odd` (1,3,5,7) and
+  `_six_mod_eight` (6). Contrapositive of the achievability lemma via `omega`.
+
+This is the sharp mod-8 boundary: achievable residues are exactly {0,2,4}. (Beyond mod 8,
+avoidance like √12 = √(2·6), 6 not a sum of two squares, needs the Fermat SoS predicate —
+still the open frontier; core `juhasz_stronger` untouched.)
+
+Both proofs are arithmetic-only, reusing `scaledLattice_dist_sq_two_mul_sq_add_sq` +
+`sq_add_sq_mod_four_ne_three` + `omega` (identical skeleton to the proven `_six_mod_eight`).
+Research json leanFile synced: lineCount 271→310, theoremCount 13→15.
+
+**Verification: UNVERIFIED — docker infra down.** `docker-build.sh` fails at the image
+build itself (`write .../containerd/.../meta.db: input/output error`), so no build ran
+this session. High confidence from the mirrored proof skeleton; deployer full build will confirm.

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -75,8 +75,8 @@
     {
       "path": "Proofs/Erdos214Incomplete01OQ01.lean",
       "filename": "Erdos214Incomplete01OQ01.lean",
-      "lineCount": 271,
-      "theoremCount": 13,
+      "lineCount": 310,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds the **sharp mod-8 characterization** of the distance set of `√2·ℤ²` to
`proofs/Proofs/Erdos214Incomplete01OQ01.lean`, unifying the two previously-formalized
avoidance families (odd `n`, and `n ≡ 6 mod 8`) into one dichotomy.

- **`scaledLattice_achievable_mod_eight`** — if two lattice points are at distance
  `√n` then `n ≡ 0, 2, or 4 (mod 8)`. These are the *only* achievable residues: the
  squared distance is `2·(u²+v²)` and `u²+v² ≢ 3 (mod 4)`.
- **`scaledLattice_dist_ne_sqrt_of_mod_eight`** — `√2·ℤ²` avoids `√n` for every `n`
  with `n ≡ 1, 3, 5, 6, or 7 (mod 8)` (the exact complement of `{0,2,4}`). This single
  statement subsumes both `scaledLattice_dist_ne_sqrt_odd` (residues 1,3,5,7) and
  `scaledLattice_dist_ne_sqrt_six_mod_eight` (residue 6).

2 new theorems, 0 axioms/sorries, core `juhasz_stronger` untouched. Both proofs are
arithmetic-only, reusing the file's `scaledLattice_dist_sq_two_mul_sq_add_sq` and
`sq_add_sq_mod_four_ne_three` with `omega` (the same skeleton as the proven
`_six_mod_eight` lemma). Research json leanFile counts synced (13→15 theorems, 271→310
lines).

Frontier note: mod-8 is sharp *as a congruence condition*, but not a full
characterization of avoided distances — e.g. `√12 = √(2·6)` is avoided because `6` is
not a sum of two squares, yet `12 ≡ 4 (mod 8)`. That finer avoidance needs the Fermat
sum-of-two-squares predicate (still open).

## Verification status: UNVERIFIED (docker infra down)

`docker-build.sh` fails at the image build itself this session
(`write .../containerd/.../meta.db: input/output error`), so no build could run. The two
proofs mirror the already-verified `_six_mod_eight` lemma's exact tactic skeleton
(`obtain … ; rw ; exact_mod_cast ; omega`); high confidence. The deployer's full build
will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)