### PR TITLE
research(feuerbachs-theorem-oq-04): spherical betweenness of the side-midpoint

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
@@ -42,6 +42,9 @@ file adds no axioms and no sorries.
 * `scos_sMidpoint_left` — the explicit vertex-to-midpoint spherical cosine `‖A+B‖⁻¹(1+⟪A,B⟫)`.
 * `sdist_sMidpoint_half` — **the midpoint bisects the arc**: `sdist A (sMidpoint A B) = ½·sdist A B`,
   the sharper fact (beyond equidistance) that justifies the name.
+* `sdist_sMidpoint_half_right` — the other half-arc `sdist (sMidpoint A B) B = ½·sdist A B`.
+* `sdist_sMidpoint_add` — **spherical betweenness**: `sdist A M + sdist M B = sdist A B`, the
+  equality case of the triangle inequality placing `M` on the geodesic segment `AB`.
 * `sphericalNinePointCircle_exists` — **existence of the spherical nine-point circle**: the
   three side-midpoints of a spherical triangle lie on a common spherical circle.
 -/
@@ -180,6 +183,30 @@ theorem sdist_sMidpoint_half (A B : E) (hA : OnSphere A) (hB : OnSphere B)
   have hcoseq : Real.cos (2 * sdist A M) = Real.cos (sdist A B) := by rw [hcos2, hcosAB]
   have hfin : 2 * sdist A M = sdist A B := Real.injOn_cos h2M_mem hAB_mem hcoseq
   linarith [hfin]
+
+/-- **The midpoint bisects the arc from the far endpoint too: `sdist (sMidpoint A B) B = ½ · sdist A B`.**
+The companion of `sdist_sMidpoint_half`, giving the *other* half of the arc.  Obtained from the
+`A`-side statement by symmetry (`sdist_comm`, `sMidpoint_comm`): swapping the roles of `A` and `B`
+turns `sdist A (sMidpoint A B)` into `sdist B (sMidpoint A B)`, and `sdist A B` is symmetric. -/
+theorem sdist_sMidpoint_half_right (A B : E) (hA : OnSphere A) (hB : OnSphere B)
+    (hAB : A + B ≠ 0) :
+    sdist (sMidpoint A B) B = sdist A B / 2 := by
+  rw [sdist_comm, sMidpoint_comm,
+      sdist_sMidpoint_half B A hB hA (by rwa [add_comm]), sdist_comm B A]
+
+/-- **Spherical betweenness of the midpoint: `sdist A M + sdist M B = sdist A B`.**
+For non-antipodal model points the spherical midpoint `M = sMidpoint A B` lies *on the minor
+arc between* `A` and `B`: the two half-arcs it cuts off add up to the whole side.  This is the
+*equality* case of the spherical triangle inequality (`sdist_triangle`), which in general only
+gives `≤`; equality pins `M` to the geodesic segment `AB` and, together with the equidistance
+`sdist_sMidpoint_eq`, uniquely characterises the midpoint (the equidistant antipode of `M`
+would instead give the complementary sum `2π − sdist A B`).  Immediate from the two half-arc
+computations `sdist_sMidpoint_half` and `sdist_sMidpoint_half_right`. -/
+theorem sdist_sMidpoint_add (A B : E) (hA : OnSphere A) (hB : OnSphere B)
+    (hAB : A + B ≠ 0) :
+    sdist A (sMidpoint A B) + sdist (sMidpoint A B) B = sdist A B := by
+  rw [sdist_sMidpoint_half A B hA hB hAB, sdist_sMidpoint_half_right A B hA hB hAB]
+  ring
 
 /-- **Existence of the spherical nine-point circle.**  Given a spherical triangle with
 vertices `A, B, C` whose sides are non-degenerate (no two endpoints antipodal), its three


### PR DESCRIPTION
## Summary

Two reusable lemmas added to the spherical-midpoint companion `FeuerbachsTheoremOQ04Midpoint.lean`, completing the arc-bisection picture of `sMidpoint A B = ‖A+B‖⁻¹•(A+B)`:

- **`sdist_sMidpoint_half_right`** — the *far* half-arc: `sdist (sMidpoint A B) B = ½·sdist A B`. The symmetric companion of the existing `sdist_sMidpoint_half` (which covers the near half `sdist A M`), obtained purely by `sdist_comm` + `sMidpoint_comm`.
- **`sdist_sMidpoint_add`** — **spherical betweenness**: `sdist A M + sdist M B = sdist A B`. This is the **equality case** of the spherical triangle inequality (`sdist_triangle` only gives `≤`). It places the midpoint on the geodesic *segment* `AB` and, together with the equidistance `sdist_sMidpoint_eq`, uniquely characterises the midpoint against the equidistant antipode (which instead yields the complementary sum `2π − sdist A B`).

## Why it matters

`sdist_sMidpoint_half` already showed the midpoint bisects the arc measured from `A`. Betweenness closes the gap between *equidistant* and *midpoint*: only the point ON the minor arc splits the side additively. This is the metric-side companion to `sphericalNinePointCircle_exists` (which uses these midpoints as the medial-triangle vertices) and a reusable equality-case triangle-inequality fact for the spherical model.

## Proof
Pure symmetry/algebra over the already-verified `sdist_sMidpoint_half`: `sdist_comm`, `sMidpoint_comm`, `add_comm`, `ring`. 0 axioms, 0 sorries. Companion 199→221 lines, 10→12 theorems.

## Verification status
⚠️ **UNVERIFIED** — the docker runner-image build is blocked fleet-wide by a corrupted containerd metadata store (`write /var/lib/desktop-containerd/.../meta.db: input/output error`), which aborts *before* any Lean elaboration. This is an infra fault requiring operator cleanup, not a proof error. The two proofs are short rewrite-chains over an already-`docker`-verified lemma (`sdist_sMidpoint_half`), so confidence is high; a re-build should be run once the containerd store is repaired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)