### PR TITLE
Fix: sync stale lineCount metadata (quadratic-reciprocity, roth-k3)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "theoremCount": 56,
     "defCount": 4,
-    "lineCount": 845,
+    "lineCount": 879,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,7 +97,7 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 845,
+    "lineCount": 879,
     "axiomCount": 0,
     "theoremCount": 56,
     "definitionCount": 4,

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,7 +58,7 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 583,
+    "lineCount": 617,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
     "theoremCount": 21,
     "definitionCount": 5
@@ -142,7 +142,7 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 583,
+    "lineCount": 617,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Two gallery entries had stale `lineCount` metadata after the underlying Lean files grew without a meta resync.

## Evidence

| Entry | Declared | Actual (`wc -l`) |
|-------|----------|------------------|
| `elementary-quadratic-reciprocity-oq-03-oq-02` | 845 | 879 |
| `roth-theorem-k3-oq-03-oq-01` | 583 | 617 |

Both `meta.lineCount` and `leanFile.lineCount` updated in each entry. No other fields touched; sorries (0/0) and axiom counts already match the source. JSON validated.

---
Automated fix by lean-mechanic agent.