### PR TITLE
research(kepler-conjecture-oq-04): density functional attains a global maximum (IsGreatest) [UNVERIFIED — docker infra I/O failure]

### DIFF
--- a/proofs/Proofs/KeplerConjectureOQ04.lean
+++ b/proofs/Proofs/KeplerConjectureOQ04.lean
@@ -1068,5 +1068,41 @@ theorem packingDensity_le_rhombicDodecahedron (d : PackingDensity) :
   rw [rhombicDodecahedronPackingDensity_eq_one]
   exact d.le_one
 
+/-!
+## S21 — the density functional attains a genuine global maximum
+
+`packingDensity_le_rhombicDodecahedron` shows the space-filling density `δ = 1` is a
+universal ceiling, and `exists_packingDensity_eq_one` shows that ceiling is *attained*
+by `rhombicDodecahedronPacking`. The docstring of the former already calls the rhombic
+dodecahedron "a global maximum of the density functional" — but only in prose. This
+section turns that phrase into a single machine-checked statement in the two standard
+forms: the bare existential (a `PackingDensity` weakly dominating every other) and
+Mathlib's `IsGreatest` on the range of the density projection. Both are immediate
+combinations of the two facts above; no new axioms.
+-/
+
+/-- **The density functional attains a global maximum (existential form).**
+There is a `PackingDensity` weakly dominating every other, namely the space-filling
+rhombic dodecahedron: `∀ e, e.density ≤ rhombicDodecahedronPacking.density = 1`.
+Immediate from `packingDensity_le_rhombicDodecahedron` (the density-`1` ceiling is
+attained by `rhombicDodecahedronPacking`, so the universal bound is realized as a true
+maximum, not an unreached supremum). No axioms. -/
+theorem exists_greatest_packingDensity :
+    ∃ d : PackingDensity, ∀ e : PackingDensity, e.density ≤ d.density :=
+  ⟨rhombicDodecahedronPacking, packingDensity_le_rhombicDodecahedron⟩
+
+/-- **The density functional attains its supremum (`IsGreatest` form).**
+`1` is the greatest element of the range of `PackingDensity.density`: it lies in the
+range (witnessed by `rhombicDodecahedronPacking`) and it is an upper bound of the whole
+range (`packingDensity_le_rhombicDodecahedron`). This is the Mathlib-native packaging of
+the "space-filling body is universally optimal" statement — the density functional
+genuinely achieves its maximum value `δ = 1`, dual to the (conjecturally minimal, hence
+axiomatized via Ulam) sphere at the bottom of the hierarchy. No axioms. -/
+theorem isGreatest_packingDensity_range :
+    IsGreatest (Set.range (PackingDensity.density)) 1 := by
+  refine ⟨⟨rhombicDodecahedronPacking, rhombicDodecahedronPackingDensity_eq_one⟩, ?_⟩
+  rintro x ⟨d, rfl⟩
+  exact packingDensity_le_rhombicDodecahedron d
+
 
 end KeplerConjectureOQ04


### PR DESCRIPTION
## Summary

Kepler OQ-04 (`kepler-conjecture-oq-04`, non-spherical packing in ℝ³) is RESOLVED + machine-verified. This iteration (S21) fills one clean **prose→machine-checked gap**: the file already proves the universal density ceiling and that it is attained, but only *states in prose* that the space-filling body is a global maximum.

Added to `proofs/Proofs/KeplerConjectureOQ04.lean` (2 theorems, 0 new axioms):

- **`exists_greatest_packingDensity`** — `∃ d : PackingDensity, ∀ e, e.density ≤ d.density`. The density functional attains a global maximum, witnessed by `rhombicDodecahedronPacking` (δ = 1).
- **`isGreatest_packingDensity_range`** — `IsGreatest (Set.range PackingDensity.density) 1`. The Mathlib-native packaging: `1` is the greatest value in the range of the density projection.

Both are immediate combinations of the two facts already in the file:
- `packingDensity_le_rhombicDodecahedron` (universal ceiling, every density ≤ 1), and
- attainment via `rhombicDodecahedronPacking.density = 1`.

The `packingDensity_le_rhombicDodecahedron` docstring already calls the rhombic dodecahedron "a global maximum of the density functional" — this turns that phrase into machine-checked theorems. Dual to the (conjecturally minimal, hence Ulam-axiomatized) sphere at the bottom of the hierarchy.

## Axiom status

No new axioms. The file's 2 STATEMENT axioms (Bezdek–Kuperberg ellipsoid-lattice bound, Ulam's conjecture) are untouched. `status=axiomatized / badge=axiom / axiomCount=2` unchanged.

## Verification

⚠️ **UNVERIFIED — docker infrastructure failure.** `./proofs/scripts/docker-build.sh Proofs.KeplerConjectureOQ04` fails at the image-build stage with a host-level containerd error (`write /var/lib/desktop-containerd/.../meta.db: input/output error`) on two attempts — no Lean elaboration reached. Disk had 27Gi free (not disk-full); this is containerd metadata corruption needing operator cleanup. Same infra class as the prior kepler-oq-04 PRs.

Manual confidence is high: the range-membership proof is byte-identical to the existing green `exists_packingDensity_eq_one`, and `rhombicDodecahedronPackingDensity_eq_one` is proved by `rfl` (confirming the `= 1` defeq the two new proofs rely on). Please re-run the docker build once containerd is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)