### PR TITLE
research(szemeredi-regularity-oq-04): integer ⌊1/δ⌋₊ bound on energy-increment step count

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -380,4 +380,40 @@ theorem partitionEnergy_regular_steps_card_ge
   · intro n; exact partitionEnergy_nonneg G (parts n)
   · intro n; exact partitionEnergy_le_one G (parts n) (hcover n) (hdisjoint n)
 
+/-! ## Part VI: the increment count as an explicit natural number `⌊1/δ⌋₊`
+
+`energy_increment_count_le` bounds the increment-step count by the *rational* `1/δ`.
+Since the count is a natural number, it is in fact bounded by the integer `⌊1/δ⌋₊`.
+This is the increment-count analogue of the Part IV horizon sharpening
+`energy_regular_step_exists_floor`, pinning the exceptional-set size to a concrete
+natural number. -/
+
+/-- **At most `⌊1/δ⌋₊` increment steps (integer bound).**  Sharpens
+    `energy_increment_count_le` from the rational bound `1/δ` to the natural number
+    `⌊1/δ⌋₊`: a monotone `[0,1]`-valued potential has at most `⌊1/δ⌋₊` steps at which
+    it climbs by `≥ δ`, in *any* window `[0, N)`. -/
+theorem energy_increment_count_le_floor (f : ℕ → ℚ) (N : ℕ) (δ : ℚ) (hδ : 0 < δ)
+    (h0 : ∀ n, 0 ≤ f n) (h1 : ∀ n, f n ≤ 1) (hmono : ∀ n, f n ≤ f (n + 1)) :
+    ((Finset.range N).filter (fun n => f n + δ ≤ f (n + 1))).card ≤ ⌊1 / δ⌋₊ := by
+  apply Nat.le_floor
+  exact_mod_cast energy_increment_count_le f N δ hδ h0 h1 hmono
+
+/-- **Graph instantiation: at most `⌊1/δ⌋₊` energy-increment refinements (integer
+    bound).**  Along a monotone AFKS refinement chain, the number of window-`[0,N)`
+    steps at which `partitionEnergy` climbs by `≥ δ` is at most the explicit natural
+    number `⌊1/δ⌋₊`, independent of `N`. -/
+theorem partitionEnergy_increment_count_le_floor
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (δ : ℚ) (hδ : 0 < δ)
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hmono : ∀ n,
+      partitionEnergy G (parts n) ≤ partitionEnergy G (parts (n + 1))) :
+    ((Finset.range N).filter (fun n =>
+        partitionEnergy G (parts n) + δ ≤ partitionEnergy G (parts (n + 1)))).card
+      ≤ ⌊1 / δ⌋₊ := by
+  apply Nat.le_floor
+  exact_mod_cast partitionEnergy_increment_count_le G parts N δ hδ hcover hdisjoint hmono
+
 end Szemeredi.RegularityOQ04

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -585,3 +585,25 @@ capstone of the Part III existence result.
   energy monotonicity, then feed this ⌊1/δ⌋₊ horizon to bound the refinement depth.
 - Full two-level strong-lemma statement (exceptional-pair accounting) remains the open
   research terminus.
+
+## Session 2026-07-09 (researcher-2) — Part VI: integer ⌊1/δ⌋₊ increment-count bound (UNVERIFIED, docker infra down)
+
+On the self-contained abstract engine `SzemerediRegularityOQ04.lean`, sharpened the
+increment-step count from the rational bound to an explicit natural number (the
+increment-count analogue of Part IV's `energy_regular_step_exists_floor` horizon):
+- `energy_increment_count_le_floor`: `card{n<N : f n + δ ≤ f(n+1)} ≤ ⌊1/δ⌋₊` for any
+  monotone [0,1]-valued ℚ potential — `Nat.le_floor` + `exact_mod_cast` on the existing
+  `energy_increment_count_le` (which gives the ℚ bound `≤ 1/δ`).
+- `partitionEnergy_increment_count_le_floor`: graph instantiation (same cover/disjoint/
+  monotone hypotheses, via `partitionEnergy_increment_count_le`).
+
+Pins the AFKS exceptional-set size (energy-increment refinement steps) to the concrete
+natural number ⌊1/δ⌋₊. Pure low-risk assembly of merged lemmas (no new arithmetic).
+Research json leanFile synced: lineCount 352→419, theoremCount 14→17 (was stale; now
+matches wc-l / grep).
+
+**Verification: UNVERIFIED — docker infra down.** `docker-build.sh` fails at the image
+build itself (`write .../containerd/.../meta.db: input/output error`); no build ran.
+`Nat.le_floor (h : ↑n ≤ r) : n ≤ ⌊r⌋₊` + exact_mod_cast on already-proven lemmas; very
+high confidence. Deployer full build will confirm. Frontier unchanged (Bridge/Energy
+two-level strong-lemma terminus).

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -183,8 +183,8 @@
     {
       "path": "Proofs/SzemerediRegularityOQ04.lean",
       "filename": "SzemerediRegularityOQ04.lean",
-      "lineCount": 352,
-      "theoremCount": 14,
+      "lineCount": 419,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds **Part VI** to the self-contained abstract engine
`proofs/Proofs/SzemerediRegularityOQ04.lean`: the integer sharpening of the
energy-increment step count.

- **`energy_increment_count_le_floor`** — for a monotone `[0,1]`-valued potential `f`,
  `card{n < N : f n + δ ≤ f(n+1)} ≤ ⌊1/δ⌋₊`. Sharpens `energy_increment_count_le`
  (which gives the rational bound `≤ 1/δ`) to an explicit natural number.
- **`partitionEnergy_increment_count_le_floor`** — the graph instantiation along a
  monotone AFKS refinement chain.

This is the increment-count analogue of the Part IV horizon sharpening
`energy_regular_step_exists_floor`, pinning the AFKS exceptional-set size (the number
of energy-increment refinement steps) to the concrete natural number `⌊1/δ⌋₊`,
independent of the window `N`.

2 new theorems, 0 axioms/sorries. Pure assembly: `Nat.le_floor` + `exact_mod_cast` on
the already-proven `energy_increment_count_le` / `partitionEnergy_increment_count_le`.
Research json leanFile counts synced (was stale: 352→419 lines, 14→17 theorems).

## Verification status: UNVERIFIED (docker infra down)

`docker-build.sh` fails at the image build itself this session
(`write .../containerd/.../meta.db: input/output error`), so no build could run. Both
proofs are one-liners (`apply Nat.le_floor; exact_mod_cast <existing lemma>`); very high
confidence. The deployer's full build will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)