### PR TITLE
research(erdos-1138-oq-03-oq-01): bridge maximal-gap sup to individual consecutive-prime gaps

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -260,4 +260,52 @@ theorem gap_isLittleO_rpow_of_rpow_bound {θ a : ℝ} (hθa : θ < a)
   rw [h0] at hrp
   exact absurd hrp (lt_irrefl 0)
 
+-- ============================================================================
+-- Individual-gap bridge: from the maximal gap `sSup` back to actual gaps
+-- ============================================================================
+
+/-- **Bridge: an individual consecutive-prime gap is at most the maximal gap.**
+
+Every result above bounds the *maximal* gap `maxPrimeGap x = sSup (primeGapSet x)`. But the
+object of Erdős #1138 is an *individual* gap `q - p` between consecutive primes `p < q ≤ x`.
+This lemma connects the two: any such gap lies in `primeGapSet x`, hence is `≤` its supremum.
+It is the `le_csSup` half complementing the parent's `csSup_le`-based upper bounds, and is what
+lets the sup-level asymptotics below be read as statements about genuine prime gaps. -/
+theorem consecutive_gap_le_maxPrimeGap {x p q : ℕ}
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p < q) (hqx : q ≤ x)
+    (hcons : ∀ r, Nat.Prime r → p < r → q ≤ r) :
+    q - p ≤ maxPrimeGap x := by
+  unfold maxPrimeGap
+  exact le_csSup (primeGapSet_bddAbove x) ⟨p, q, hp, hq, hpq, hqx, hcons, rfl⟩
+
+/-- **Individual consecutive-prime gaps obey the Baker–Harman–Pintz bound.**
+
+Composing the bridge `consecutive_gap_le_maxPrimeGap` with `baker_harman_pintz`: for `x ≥ 25`,
+*every* gap `q - p` between consecutive primes with `q ≤ x` satisfies `q - p ≤ x^0.525`.
+This is the concrete, gap-level statement of the BHP bound (the parent axiom is phrased for the
+supremum only). -/
+theorem consecutive_gap_le_rpow {x p q : ℕ} (hx : 25 ≤ x)
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p < q) (hqx : q ≤ x)
+    (hcons : ∀ r, Nat.Prime r → p < r → q ≤ r) :
+    ((q - p : ℕ) : ℝ) ≤ (x : ℝ) ^ (0.525 : ℝ) := by
+  calc ((q - p : ℕ) : ℝ)
+      ≤ (maxPrimeGap x : ℝ) := by
+        exact_mod_cast consecutive_gap_le_maxPrimeGap hp hq hpq hqx hcons
+    _ ≤ (x : ℝ) ^ (0.525 : ℝ) := baker_harman_pintz x hx
+
+/-- **Normalised individual gap bound.** The gap-level counterpart of `gap_div_le_rpow_neg`:
+for `x ≥ 25` and any consecutive primes `p < q ≤ x`, the normalised gap `(q - p) / x` is at most
+`x^(-0.475)`. As `x → ∞` this envelope vanishes, so every consecutive-prime gap below `x` is
+eventually negligible compared with `x` — the sublinearity of `bhp_implies_gap_littleo` made
+pointwise and gap-explicit. -/
+theorem consecutive_gap_div_le_rpow_neg {x p q : ℕ} (hx : 25 ≤ x)
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p < q) (hqx : q ≤ x)
+    (hcons : ∀ r, Nat.Prime r → p < r → q ≤ r) :
+    ((q - p : ℕ) : ℝ) / x ≤ (x : ℝ) ^ (-(0.475 : ℝ)) := by
+  have hbridge : ((q - p : ℕ) : ℝ) ≤ (maxPrimeGap x : ℝ) := by
+    exact_mod_cast consecutive_gap_le_maxPrimeGap hp hq hpq hqx hcons
+  calc ((q - p : ℕ) : ℝ) / x
+      ≤ (maxPrimeGap x : ℝ) / x := by gcongr
+    _ ≤ (x : ℝ) ^ (-(0.475 : ℝ)) := gap_div_le_rpow_neg x hx
+
 end Erdos1138OQ03

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -140,9 +140,9 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 263,
+    "lineCount": 311,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 0,
     "path": "Proofs/Erdos1138OQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #1138 concerns **individual** gaps between consecutive primes. Yet every result in the `erdos-1138-oq-03-oq-01` entry so far bounds only the *maximal* gap `maxPrimeGap x = sSup (primeGapSet x)` (envelopes, sublinearity engines, little-o repackagings). The bridge from an actual consecutive-prime gap `q - p` back to that supremum was missing. This PR adds it and its two BHP corollaries.

### New theorems (`Proofs/Erdos1138OQ03OQ01.lean`, namespace `Erdos1138OQ03`)

- **`consecutive_gap_le_maxPrimeGap`** — for consecutive primes `p < q ≤ x`, `q - p ≤ maxPrimeGap x`. The `le_csSup` half (membership → supremum), complementing the parent's `csSup_le`-based upper bounds.
- **`consecutive_gap_le_rpow`** — composing the bridge with `baker_harman_pintz`: for `x ≥ 25`, *every* consecutive-prime gap satisfies `q - p ≤ x^0.525`. The gap-level form of the BHP axiom, which is stated for the supremum only.
- **`consecutive_gap_div_le_rpow_neg`** — normalised: `(q - p)/x ≤ x^(-0.475)`, the gap-explicit pointwise counterpart of `gap_div_le_rpow_neg` / `bhp_implies_gap_littleo`.

Each new lemma is a short composition of already-present verified lemmas plus one `le_csSup` step.

### Axioms / status
No new axioms — inherits the parent's `baker_harman_pintz` (BHP 2001, deep unconditional result). 0 sorries. Entry remains `axiomatized`.

Also syncs the stale gallery `leanFile` counts (263→311 lines, 11→14 theorems; prior engine additions were never resynced).

### ⚠️ Verification status: UNVERIFIED (environment blocker)
The Docker build could not run this session: `docker-build.sh` fails while building the Lean image with
`write /var/lib/desktop-containerd/daemon/io.containerd.metadata.v1.bolt/meta.db: input/output error`
— Docker Desktop containerd metadata-DB corruption (host disk is healthy, 154 Gi free; no pre-built lean image on disk). This is an operator-level Docker reset, not something to self-remediate on shared infra. The additions are a direct composition of existing verified lemmas and one `le_csSup` bridge; please rebuild once the Docker daemon is healthy (`./proofs/scripts/docker-build.sh Proofs.Erdos1138OQ03OQ01`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)