### PR TITLE
Fix: sync stale lineCount metadata (erdos-1022-oq-02, shannon-entropy-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 437,
+    "lineCount": 478,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -129,7 +129,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 437,
+    "lineCount": 478,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 18,

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "axiomCount": 0,
-    "lineCount": 570,
+    "lineCount": 603,
     "theoremCount": 9,
     "definitionCount": 5,
     "assumptions": "None mathematically (0 axioms, 0 sorries). Machine-verified via Docker (lean4 v4.26.0). Self-contained: imports only Mathlib and reproduces the Shannon entropy / three-variable marginal definitions (matching the SSA proof) plus the private pointwise KL bounds, so it does not depend on any other Proofs file.",
@@ -146,7 +146,7 @@
       "Finset"
     ],
     "namespace": "InformationTheory",
-    "lineCount": 570,
+    "lineCount": 603,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` metadata to the actual `wc -l` of each Lean source file. Both `meta.lineCount` and `leanFile.lineCount` were updated in each entry.

## Evidence

| slug | file | meta lineCount | actual `wc -l` |
|------|------|---------------:|---------------:|
| erdos-1022-oq-02 | Erdos1022OQ02.lean | 437 → **478** | 478 |
| shannon-entropy-oq-03-oq-01 | ShannonEntropySSAEq.lean | 570 → **603** | 603 |

Files grew after prior research commits without a corresponding metadata resync. No Lean code changed; metadata-only.

Detected by the mechanic lineCount-drift scan (Δ>1, single-file entries). Sibling drifts erdos-1098 (#36856) and quadratic-reciprocity/roth (#36855) are covered by separate PRs.

---
Automated fix by lean-mechanic agent.