### PR TITLE
research(pythagorean-theorem-oq-01): altitude geometric-mean theorem |CH|²=|AH|·|HB|

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ01.lean
@@ -41,12 +41,14 @@ The file isolates Einstein's argument into three fully verified layers.
   `cA² + cB² = h²`. This is the "cancel `k`" step, verified without any geometry.
 
 - **Layer 3 — the altitude decomposition realised** (`altitudeFoot`, `foot_perp`,
-  `geometric_mean_A`, `geometric_mean_B`, `segments_sum`, `pythagorean_via_altitude`):
+  `geometric_mean_A`, `geometric_mean_B`, `segments_sum`, `altitude_geometric_mean`,
+  `pythagorean_via_altitude`):
   we build the altitude foot `H` explicitly in a real inner-product space, prove it is
-  perpendicular to the hypotenuse, and verify the two **geometric-mean relations**
-  `cA² = h·|AH|` and `cB² = h·|HB|` together with the betweenness identity
-  `|AH| + |HB| = h`. These are exactly the numerical shadows of "`T₁`, `T₂` are similar
-  to `T`", and summing them reconstructs `h² = cA² + cB²`.
+  perpendicular to the hypotenuse, and verify the two **leg geometric-mean relations**
+  `cA² = h·|AH|` and `cB² = h·|HB|`, the **altitude geometric-mean relation**
+  `|CH|² = |AH|·|HB|`, and the betweenness identity `|AH| + |HB| = h`. These are exactly
+  the numerical shadows of "`T₁`, `T₂` are similar to `T`" (and to each other), and
+  summing the leg relations reconstructs `h² = cA² + cB²`.
 
 ## Honesty note
 
@@ -244,6 +246,36 @@ theorem pythagorean_via_altitude (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
       = ‖A - B‖ * (‖A - altitudeFoot A B C‖ + ‖altitudeFoot A B C - B‖) := by
     rw [hsum]; ring
   rw [key, mul_add, ← hgA, ← hgB]
+
+include hAB in
+/-- **Geometric-mean (altitude) theorem.** The altitude from the right-angle vertex is the
+geometric mean of the two hypotenuse segments it cuts: `|CH|² = |AH| · |HB|`.  This is the
+third classical member of the altitude family (alongside the two leg relations
+`geometric_mean_A`, `geometric_mean_B`) and the numerical form of "the two sub-triangles
+`T₁`, `T₂` are similar to each other".  Proof: the altitude splits `T` into the right
+sub-triangle `A H C` (right angle at the foot `H`, by `foot_perp`), so `pythagorean_core`
+gives `|AC|² = |AH|² + |CH|²`; substituting `|AC|² = |AB|·|AH|` (`geometric_mean_A`) and
+`|HB| = |AB| − |AH|` (`segments_sum`) collapses the difference to `|AH|·|HB|`. -/
+theorem altitude_geometric_mean (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    ‖C - altitudeFoot A B C‖ ^ 2
+      = ‖A - altitudeFoot A B C‖ * ‖altitudeFoot A B C - B‖ := by
+  -- The altitude segment `A - H` is parallel to the hypotenuse `A - B`.
+  have hAHpar : A - altitudeFoot A B C = (‖A - C‖ ^ 2 / ‖A - B‖ ^ 2) • (A - B) := by
+    unfold altitudeFoot; rw [smul_sub, smul_sub]; abel
+  -- so the altitude `C - H` meets it at a right angle at the foot `H`.
+  have hCHperp : ⟪C - altitudeFoot A B C, A - B⟫ = (0 : ℝ) := foot_perp A B C hAB hperp
+  have hperp2 : ⟪A - altitudeFoot A B C, C - altitudeFoot A B C⟫ = (0 : ℝ) := by
+    rw [hAHpar, real_inner_smul_left,
+        real_inner_comm (A - B) (C - altitudeFoot A B C), hCHperp, mul_zero]
+  -- Pythagoras on the right sub-triangle `A H C`: `|AC|² = |AH|² + |CH|²`.
+  have hsub := pythagorean_core A C (altitudeFoot A B C) hperp2
+  have hgA := geometric_mean_A A B C hAB          -- `|AC|² = |AB|·|AH|`
+  have hsum := segments_sum A B C hAB hperp        -- `|AH| + |HB| = |AB|`
+  have hCH : ‖C - altitudeFoot A B C‖ ^ 2
+      = ‖A - C‖ ^ 2 - ‖A - altitudeFoot A B C‖ ^ 2 := by linarith
+  have hBsub : ‖altitudeFoot A B C - B‖
+      = ‖A - B‖ - ‖A - altitudeFoot A B C‖ := by linarith
+  rw [hCH, hgA, hBsub]; ring
 
 end Geometric
 


### PR DESCRIPTION
## Summary

Completes the **altitude family** in `PythagoreanTheoremOQ01.lean` with its third classical member, the **geometric-mean (altitude) theorem**:

- **`altitude_geometric_mean`** — the altitude dropped from the right-angle vertex `C` onto the hypotenuse is the *geometric mean* of the two segments it cuts:
  `‖C − altitudeFoot A B C‖² = ‖A − H‖ · ‖H − B‖`, i.e. `h² = |AH|·|HB|`.

The file already had the two **leg** geometric-mean relations (`geometric_mean_A`: `|CA|²=|AB|·|AH|`, `geometric_mean_B`: `|CB|²=|AB|·|HB|`) and the betweenness identity `segments_sum` (`|AH|+|HB|=|AB|`), but not the altitude relation — the numerical form of "the two sub-triangles `T₁`, `T₂` are similar to *each other*". This closes the `nextSteps` item "altitude geometric-mean `h²=|AH|·|HB|`".

## Proof

Routes entirely through already-verified lemmas — no new inner-product computation, no division:
1. The altitude segment `A−H` is parallel to the hypotenuse `A−B`, so `foot_perp` (`⟪C−H, A−B⟫=0`) gives a right angle at the foot: `⟪A−H, C−H⟫=0`.
2. `pythagorean_core` on the right sub-triangle `A H C` gives `|AC|² = |AH|² + |CH|²`.
3. Substituting `|AC|² = |AB|·|AH|` (`geometric_mean_A`) and `|HB| = |AB| − |AH|` (`segments_sum`) collapses `|CH|² = |AC|² − |AH|²` to `|AH|·|HB|`; closed by `linarith` + `ring`.

0 axioms, 0 sorries. This file 267→303 lines, 8→9 theorems.

## Verification status
⚠️ **UNVERIFIED** — the docker runner-image build is blocked fleet-wide by a corrupted containerd metadata store (`write /var/lib/desktop-containerd/.../meta.db: input/output error`), which aborts *before* any Lean elaboration; this is an infra fault needing operator cleanup, not a proof error. The proof is a short reduction over four already-`docker`-verified lemmas (`foot_perp`, `pythagorean_core`, `geometric_mean_A`, `segments_sum`), so confidence is high; a re-build should be run once containerd is repaired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)