### PR TITLE
research(erdos-1215-oq-02): cyclotomic polynomials as axiom-free unit-circle witnesses

### DIFF
--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ05.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ05.lean
@@ -1,0 +1,99 @@
+/-
+Erdős Problem #1215 — cyclotomic restriction (OQ-02): cyclotomic polynomials are
+explicit unit-circle witnesses to the negative answer.
+
+Parent: `Proofs.Erdos1215Problem` asks whether, for every polynomial `P` with
+`P(0) = 1` and all roots on the unit circle (`IsUnitCirclePolynomial P`), there is a
+bounded-level path from `0` to `∞` inside `{z : |P(z)| < C}`
+(`HasBoundedLevelPath P C`).  The parent file records the negative answer as the
+black-box axiom `Erdos1215.maclane_1953`.
+
+The companion `CyclotomicPolynomialsOQ02OQ01` proved that for the cyclotomic
+polynomials `Φ_n` the level set `{z : |Φ_n(z)| < C}` is **bounded** for *every*
+threshold `C`, so `Φ_n` admits no escape-to-`∞` path
+(`not_hasBoundedLevelPath_cyclotomic`).  What was missing is the observation that
+these `Φ_n` are themselves members of the parent hypothesis class: for `n ≥ 2` the
+constant term of `Φ_n` is `1` (so `Φ_n(0) = 1`) and every root is a primitive
+`n`-th root of unity, hence lies on the unit circle.
+
+Combining the two facts, each `Φ_n` (`n ≥ 2`) is a *concrete arithmetic witness* to
+the negative answer of Erdős #1215: a genuine unit-circle polynomial with no
+bounded-level path, for every `C`.  In particular this lets us **re-derive the parent
+conclusion `¬∃ C > 1, ∀ unit-circle P, HasBoundedLevelPath P C` without invoking the
+`maclane_1953` axiom** — the single witness `Φ₂ = X + 1` already suffices, since its
+level sets are compact for all `C`.
+
+(This does not reproduce Mac Lane's deep labyrinth phenomenon, which lives in the
+`C > 1` regime and forces paths near `0`; it only shows the literal
+escape-to-`∞` formulation is already refuted by the compactness of cyclotomic
+lemniscates, and identifies `Φ_n` as explicit members of the hypothesis class.)
+
+Main results:
+* `cyclotomic_eval_zero_eq_one`       : `Φ_n(0) = 1` for `n ≥ 2`.
+* `norm_eq_one_of_isRoot_cyclotomic`  : every root of `Φ_n` has modulus `1`.
+* `cyclotomic_isUnitCirclePolynomial` : `Φ_n` is an `IsUnitCirclePolynomial` (`n ≥ 2`).
+* `cyclotomic_witness_no_path`        : explicit unit-circle witness with no path.
+* `erdos_1215_via_cyclotomic`         : axiom-free re-derivation of the parent
+                                        negative answer via the cyclotomic family.
+
+All results are `0`-axiom / `0`-sorry (they do not depend on `maclane_1953`).
+-/
+
+import Mathlib
+import Proofs.Erdos1215Problem
+import Proofs.CyclotomicPolynomialsOQ02OQ01
+
+open Complex Polynomial
+
+namespace CyclotomicPolynomialsOQ02OQ05
+
+/-- **`Φ_n(0) = 1` for `n ≥ 2`.**
+The value of a cyclotomic polynomial at the origin is its constant term, which equals
+`1` whenever `2 ≤ n` (`Polynomial.cyclotomic_coeff_zero`). -/
+theorem cyclotomic_eval_zero_eq_one (n : ℕ) (hn : 2 ≤ n) :
+    (cyclotomic n ℂ).eval 0 = 1 := by
+  rw [← coeff_zero_eq_eval_zero]
+  exact cyclotomic_coeff_zero ℂ (by omega)
+
+/-- **Every root of `Φ_n` lies on the unit circle.**
+For `n ≥ 2`, if `z` is a root of `cyclotomic n ℂ` then `z` is a primitive `n`-th root
+of unity (`isRoot_cyclotomic_iff`), hence `‖z‖ = 1`. -/
+theorem norm_eq_one_of_isRoot_cyclotomic (n : ℕ) (hn : 2 ≤ n) (z : ℂ)
+    (hz : (cyclotomic n ℂ).IsRoot z) : ‖z‖ = 1 := by
+  have hn0 : n ≠ 0 := by omega
+  haveI : NeZero (n : ℂ) := ⟨by exact_mod_cast hn0⟩
+  have hprim : IsPrimitiveRoot z n := (isRoot_cyclotomic_iff).1 hz
+  exact hprim.norm'_eq_one hn0
+
+/-- **Cyclotomic polynomials are unit-circle polynomials.**
+For `n ≥ 2`, `Φ_n` satisfies `Φ_n(0) = 1` and has all roots on the unit circle, so it
+belongs to the parent hypothesis class `Erdos1215.IsUnitCirclePolynomial`. -/
+theorem cyclotomic_isUnitCirclePolynomial (n : ℕ) (hn : 2 ≤ n) :
+    Erdos1215.IsUnitCirclePolynomial (cyclotomic n ℂ) :=
+  ⟨cyclotomic_eval_zero_eq_one n hn, norm_eq_one_of_isRoot_cyclotomic n hn⟩
+
+/-- **Explicit cyclotomic witness to the negative answer.**
+For `n ≥ 2` and *any* threshold `C`, the cyclotomic polynomial `Φ_n` is a genuine
+unit-circle polynomial that nonetheless admits no bounded-level path from `0` to `∞`
+inside `{z : |Φ_n(z)| < C}`.  This packages the parent hypothesis membership with the
+OQ-01 compactness obstruction into one concrete witness. -/
+theorem cyclotomic_witness_no_path (n : ℕ) (hn : 2 ≤ n) (C : ℝ) :
+    Erdos1215.IsUnitCirclePolynomial (cyclotomic n ℂ) ∧
+      ¬ Erdos1215.HasBoundedLevelPath (cyclotomic n ℂ) C :=
+  ⟨cyclotomic_isUnitCirclePolynomial n hn,
+    CyclotomicPolynomialsOQ02OQ01.not_hasBoundedLevelPath_cyclotomic n (by omega) C⟩
+
+/-- **Axiom-free re-derivation of the Erdős #1215 negative answer via cyclotomics.**
+The parent theorem `Erdos1215.erdos_1215` obtains its witnesses from the black-box
+axiom `maclane_1953`.  Here we reprove the same statement using only the concrete
+cyclotomic family: the single polynomial `Φ₂ = X + 1` is a unit-circle polynomial
+whose level sets are compact for *every* `C`, so it defeats any candidate constant.
+This derivation does not depend on `maclane_1953`. -/
+theorem erdos_1215_via_cyclotomic :
+    ¬∃ C : ℝ, C > 1 ∧ ∀ P : ℂ[X], Erdos1215.IsUnitCirclePolynomial P →
+      Erdos1215.HasBoundedLevelPath P C := by
+  rintro ⟨C, _hC, hall⟩
+  obtain ⟨hunit, hnopath⟩ := cyclotomic_witness_no_path 2 le_rfl C
+  exact hnopath (hall _ hunit)
+
+end CyclotomicPolynomialsOQ02OQ05


### PR DESCRIPTION
## Summary

Erdős #1215 (cyclotomic restriction, OQ-02). New file `Proofs/CyclotomicPolynomialsOQ02OQ05.lean` closes a natural gap in the OQ-02 development: it shows the cyclotomic polynomials `Φ_n` are themselves members of the **parent hypothesis class** `Erdos1215.IsUnitCirclePolynomial`, turning the earlier OQ-01 compactness result into an *explicit, axiom-free* witness to the negative answer of Erdős #1215.

## What was missing

- OQ-01 proved `{z : |Φ_n(z)| < C}` is bounded for every `C`, hence `Φ_n` admits no escape-to-∞ path (`not_hasBoundedLevelPath_cyclotomic`).
- But it was never recorded that `Φ_n` *satisfies the parent's hypotheses*: `Φ_n(0) = 1` and all roots on the unit circle. Without that, `Φ_n` is not obviously a legitimate instance of the problem.

## New results (all 0-sorry, and independent of the `maclane_1953` axiom)

- `cyclotomic_eval_zero_eq_one` — `Φ_n(0) = 1` for `n ≥ 2` (via `cyclotomic_coeff_zero` + `coeff_zero_eq_eval_zero`).
- `norm_eq_one_of_isRoot_cyclotomic` — every root of `Φ_n` has modulus `1` (via `isRoot_cyclotomic_iff` + `IsPrimitiveRoot.norm'_eq_one`).
- `cyclotomic_isUnitCirclePolynomial` — `Φ_n` is an `IsUnitCirclePolynomial` for `n ≥ 2`.
- `cyclotomic_witness_no_path` — for any `C`, `Φ_n` is a unit-circle polynomial with no bounded-level path.
- `erdos_1215_via_cyclotomic` — **re-derives the parent negative answer** `¬∃ C > 1, ∀ unit-circle P, HasBoundedLevelPath P C` **without the `maclane_1953` axiom**: the single witness `Φ₂ = X + 1` already defeats every candidate constant, since its lemniscates are compact for all `C`.

## Scope / honesty

This does **not** reproduce Mac Lane's deep labyrinth phenomenon (the `C > 1` regime forcing paths near `0`). It shows the *literal* escape-to-∞ formulation used in `Erdos1215Problem.lean` is already refuted by cyclotomic compactness, and identifies `Φ_n` as concrete arithmetic members of the hypothesis class. The docstring states this limitation explicitly.

## Verification status

**UNVERIFIED (environment-blocked).** The Docker Lean build is currently down with a host-level containerd I/O error (`write .../io.containerd.metadata.v1.bolt/meta.db: input/output error`) affecting the whole fleet, so I could not obtain a green build signal. The proof was hand-checked against the exact Mathlib signatures (`cyclotomic_coeff_zero`, `coeff_zero_eq_eval_zero`, `isRoot_cyclotomic_iff`, `IsPrimitiveRoot.norm'_eq_one`) and the parent/OQ-01 definitions. Recommend a green rebuild once Docker is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)