### PR TITLE
audit(erdos-949): correct sidon-solved/general section line ranges

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17600,10 +17600,10 @@
       "result": "clean"
     },
     "erdos-949": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:08:53Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
+      "result": "issues-fixed"
     },
     "erdos-95": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-949/meta.json
+++ b/src/data/proofs/erdos-949/meta.json
@@ -86,15 +86,15 @@
     {
       "id": "sec-949-sidon-solved",
       "title": "Sidon Variant (Solved)",
-      "startLine": 102,
-      "endLine": 112,
+      "startLine": 175,
+      "endLine": 184,
       "summary": "Axiom recording Dillies-AlphaProof solution: for Sidon S, the continuum-sized sumset-avoiding subset exists in S^c. Does NOT require S to be sum-free."
     },
     {
       "id": "sec-949-general",
       "title": "General Sum-Free Case (Open)",
-      "startLine": 155,
-      "endLine": 158,
+      "startLine": 186,
+      "endLine": 189,
       "summary": "Documents that the general sum-free case remains open. The Sidon technique (injectivity of the sum map) does not generalize to the denser sum-free setting."
     }
   ],


### PR DESCRIPTION
## Auditor findings — erdos-949 (Sum-Free Sets and Continuum-Sized Sumset Avoidance)

Re-audit of the stalest tracker entry (last audited 2026-05-04).

### Core integrity: CLEAN ✓
Static audit of `proofs/Proofs/Erdos949Problem.lean` — all counts match meta.json exactly:
- **lineCount** 189 ✓, **sorries** 0 ✓, **native_decide** 0 (no `Lean.ofReduceBool` concern) ✓
- **axiomCount** 1 (`sidon_variant_solved`) ✓, **theoremCount** 16 ✓, **definitionCount** 4 ✓
- Status `axiomatized` / badge `axiom` correct for an OPEN problem with one genuine, non-vacuous axiom (the Dillies–AlphaProof Sidon variant).
- Main conjecture `ErdosProblem949` is a `def`, **not** falsely asserted as a theorem/axiom. No `True`-stubs, no masking. Mathematical narrative accurate.

### Fixed: section line-number drift
The file grew after the `sections` metadata was written (16-case `sidon_two_element` proof + structural-property theorems added), leaving two section ranges pointing at unrelated code:
- `sec-949-sidon-solved` ("Sidon Variant (Solved)"): claimed lines **102–112** (actually `sidon_subset`/`sidon_two_element`); the `axiom sidon_variant_solved` is at line **180**. → corrected to **175–184**.
- `sec-949-general` ("General Sum-Free Case (Open)"): claimed lines **155–158** (actually `realSumset_empty`); the open-case comment is at line **186**. → corrected to **186–189**.

Tracker bumped (auditCount 3→4, result `issues-fixed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)