### PR TITLE
Fix: sync stale meta.lineCount to actual Lean sources (6 entries)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "theoremCount": 56,
     "defCount": 4,
-    "lineCount": 845,
+    "lineCount": 879,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,7 +97,7 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 845,
+    "lineCount": 879,
     "axiomCount": 0,
     "theoremCount": 56,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 437,
+    "lineCount": 478,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -129,7 +129,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 437,
+    "lineCount": 478,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 18,

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -36,7 +36,7 @@
       "neumann_full_theorem: the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite",
       "center_finiteIndex_iff_relIndex_core: ω(Γ(G)) finite ⟹ [G:Z(G)] finite iff Z(G) has finite index within the explicit finite-index core H = ⋂ₐ C_G(a); localizes the residual axiom to (center G).relIndex H, whose Mathlib endgame is Subgroup.index_center_le_pow gated on Finite (commutatorSet G)"
     ],
-    "lineCount": 516,
+    "lineCount": 535,
     "theoremCount": 15,
     "defCount": 3,
     "definitionCount": 3
@@ -139,7 +139,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 516,
+    "lineCount": 535,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -49,7 +49,7 @@
       "Verified the necessity side (mod-8 obstruction) of the arithmetic characterization: not_representable_of_mod8 proves no integer ≡ 5 or 7 (mod 8) is a value of x²+2y² (finite decide over ZMod 8), with five_not_representable / seven_not_representable as the smallest concrete witnesses — the first non-representability results in the file, showing the form is not universal (5, 7 are inert in ℤ[√-2])"
     ],
     "axiomCount": 1,
-    "lineCount": 482,
+    "lineCount": 511,
     "assumptions": "1 axiom: moreeOsburnWorks (the two deep geometric facts about the box-truncated lattice — the 4-point property and the Landau/x²+2y² distinct-distance bound m/√(log m); not available in Mathlib 4.26). The cardinality (2k+1)² is now a verified theorem (moreeOsburnLattice_card), not an assumption. 0 sorries.",
     "theoremCount": 18,
     "definitionCount": 9

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,7 +58,7 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 583,
+    "lineCount": 617,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
     "theoremCount": 21,
     "definitionCount": 5
@@ -142,7 +142,7 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 583,
+    "lineCount": 617,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 5,

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "axiomCount": 0,
-    "lineCount": 570,
+    "lineCount": 603,
     "theoremCount": 9,
     "definitionCount": 5,
     "assumptions": "None mathematically (0 axioms, 0 sorries). Machine-verified via Docker (lean4 v4.26.0). Self-contained: imports only Mathlib and reproduces the Shannon entropy / three-variable marginal definitions (matching the SSA proof) plus the private pointwise KL bounds, so it does not depend on any other Proofs file.",
@@ -146,7 +146,7 @@
       "Finset"
     ],
     "namespace": "InformationTheory",
-    "lineCount": 570,
+    "lineCount": 603,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Six gallery entries had `meta.lineCount` / `leanFile.lineCount` values lagging the actual Lean source line counts after researcher file growth.

## Evidence

Values verified against `wc -l`:

| slug | old | new |
|------|-----|-----|
| erdos-1022-oq-02 | 437 | 478 |
| erdos-1098-oq-01-oq-03 | 516 | 535 |
| shannon-entropy-oq-03-oq-01 | 570 | 603 |
| elementary-quadratic-reciprocity-oq-03-oq-02 | 845 | 879 |
| roth-theorem-k3-oq-03-oq-01 | 583 | 617 |
| erdos-659 (`meta.lineCount` only; `leanFile.lineCount` was already 511) | 482 | 511 |

**Before**: meta counts disagreed with actual source line counts.
**After**: all six match `wc -l`; gallery-wide lineCount-drift scan now reports 0.

No other fields touched (theoremCount/definitionCount conventions left as-is).

---
Automated fix by lean-mechanic agent.