### PR TITLE
research(amgm-inequality-oq-03-oq-02-oq-02): Maclaurin chain endpoints ARE the AM and GM [UNVERIFIED — docker infra I/O failure]

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02.lean
@@ -669,6 +669,45 @@ theorem newton_k1 {n : ℕ} (hn : 2 ≤ n) (x : Fin n → ℝ) :
   exact div_nonneg (by linarith) (le_of_lt (mul_pos (pow_pos hn_pos 2) hC_pos))
 
 /-
+## Part VII: The chain endpoints ARE the arithmetic and geometric means
+
+`maclaurin_m1_ge_mn` (`M₁ ≥ Mₙ`) is repeatedly described as "AM ≥ GM in disguise",
+but until now the file never machine-checked that the two endpoints of the chain
+literally *are* the arithmetic and geometric means. These identities close that gap:
+`M₁ = (∑ xᵢ)/n` (arithmetic mean) and `Mₙ = (∏ xᵢ)^(1/n)` (geometric mean), so the
+top-to-bottom Maclaurin chain collapses to the AM–GM inequality itself. Unlike
+`amgm_from_maclaurin` (which invokes Mathlib's weighted AM–GM as a black box), the
+capstone `maclaurin_chain_amgm` obtains AM–GM *through the Maclaurin chain*, i.e. from
+`newton_log_concavity` alone. No new axioms.
+-/
+
+/-- **The first Maclaurin mean is the arithmetic mean.** `M₁ = (∑ xᵢ)/n`, since
+`e₁ = ∑ xᵢ`, `C(n,1) = n`, and the exponent `1/1 = 1`. -/
+theorem maclaurinMean_one {n : ℕ} (x : Fin n → ℝ) :
+    maclaurinMean 1 x = (∑ i, x i) / n := by
+  simp only [maclaurinMean, elemSymm_one, Nat.choose_one_right, Nat.cast_one, div_one,
+    Real.rpow_one]
+
+/-- **The last Maclaurin mean is the geometric mean.** `Mₙ = (∏ xᵢ)^(1/n)`, since
+`eₙ = ∏ xᵢ` (`elemSymm_n_eq_prod`) and `C(n,n) = 1`. -/
+theorem maclaurinMean_top_eq_geom {n : ℕ} (x : Fin n → ℝ) :
+    maclaurinMean n x = (∏ i, x i) ^ ((1 : ℝ) / n) := by
+  rw [maclaurinMean, elemSymm_n_eq_prod, Nat.choose_self, Nat.cast_one, div_one]
+
+/-- **AM–GM through the Maclaurin chain.** `(∏ xᵢ)^(1/n) ≤ (∑ xᵢ)/n` for non-negative
+inputs, obtained by identifying the endpoints of `maclaurin_m1_ge_mn` (`M₁ ≥ Mₙ`) with
+the arithmetic and geometric means via `maclaurinMean_one` / `maclaurinMean_top_eq_geom`.
+This is the AM–GM inequality derived *through* the Maclaurin chain — hence from
+`newton_log_concavity` alone — rather than from Mathlib's weighted AM–GM
+(`amgm_from_maclaurin`). No new axioms. -/
+theorem maclaurin_chain_amgm {n : ℕ} (hn : 0 < n) (x : Fin n → ℝ)
+    (hx : ∀ i, 0 ≤ x i) :
+    (∏ i, x i) ^ ((1 : ℝ) / n) ≤ (∑ i, x i) / n := by
+  have h := maclaurin_m1_ge_mn hn x hx
+  rw [maclaurinMean_one, maclaurinMean_top_eq_geom] at h
+  exact h
+
+/-
 ## Summary
 
 ### The Main Answer:
@@ -694,6 +733,9 @@ The chain follows from Newton's log-concavity inequalities for the sequence eₖ
 15. `elemSymm_gt_eq_zero` — eₖ = 0 for k > n
 16. `elemSymm_n_eq_prod` — eₙ = ∏ xᵢ
 17. `newton_k1` — Newton's inequality at k=1, proved from scratch (no axiom)
+18. `maclaurinMean_one` — M₁ = (∑ xᵢ)/n (first Maclaurin mean is the arithmetic mean)
+19. `maclaurinMean_top_eq_geom` — Mₙ = (∏ xᵢ)^(1/n) (last is the geometric mean)
+20. `maclaurin_chain_amgm` — (∏ xᵢ)^(1/n) ≤ (∑ xᵢ)/n, AM-GM through the chain (from Newton alone)
 
 ### Axiomatized (deep results):
 1. `newton_log_concavity` — log-concavity of eₖ/C(n,k) for non-negative inputs


### PR DESCRIPTION
## Summary

The Maclaurin file (`AmgmInequalityOQ02.lean`) is RESOLVED — `maclaurin_step` is now a theorem derived from `newton_log_concavity` (the sole remaining axiom, a deep real-rootedness result absent from Mathlib). Its `maclaurin_m1_ge_mn` (`M₁ ≥ Mₙ`) is repeatedly described in prose/summary as "AM ≥ GM in disguise", but the file never machine-checked that the two chain endpoints *literally are* the arithmetic and geometric means.

**Part VII** closes that gap (3 theorems, 0 new axioms):

- **`maclaurinMean_one`** — `M₁ = (∑ xᵢ)/n` (first Maclaurin mean = arithmetic mean; `e₁ = ∑ xᵢ`, `C(n,1) = n`, exponent `1/1 = 1`).
- **`maclaurinMean_top_eq_geom`** — `Mₙ = (∏ xᵢ)^(1/n)` (last mean = geometric mean; `eₙ = ∏ xᵢ` via `elemSymm_n_eq_prod`, `C(n,n) = 1`).
- **`maclaurin_chain_amgm`** — `(∏ xᵢ)^(1/n) ≤ (∑ xᵢ)/n`, the AM–GM inequality obtained by identifying the endpoints of `maclaurin_m1_ge_mn`.

The capstone derives AM–GM **through the Maclaurin chain** — hence from `newton_log_concavity` alone — distinct from the existing `amgm_from_maclaurin`, which invokes Mathlib's weighted AM–GM (`Real.geom_mean_le_arith_mean_weighted`) as a black box. This makes the file's "M₁ ≥ Mₙ is AM ≥ GM" claim a machine-checked fact rather than a prose annotation.

## Axiom status

No new axioms. The sole remaining file axiom `newton_log_concavity` is untouched; the additions reuse only existing lemmas (`elemSymm_one`, `elemSymm_n_eq_prod`, `maclaurin_m1_ge_mn`) and standard Mathlib (`Nat.choose_one_right`, `Nat.choose_self`, `Real.rpow_one`, `div_one`).

## Verification

⚠️ **UNVERIFIED — docker infrastructure failure.** `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02` fails at the image-build stage with a host-level containerd error (`write /var/lib/desktop-containerd/.../meta.db: input/output error`) — no Lean elaboration reached. Disk had 27Gi free (not disk-full); this is containerd metadata corruption needing operator cleanup.

Manual confidence is high: all three proofs are one/two-step rewrites. `maclaurinMean 1 x` unfolds to `(e₁/C(n,1))^(1/1)`; with `elemSymm_one`, `Nat.choose_one_right`, `Nat.cast_one`, `div_one`, `Real.rpow_one` this is `(∑ xᵢ)/n`. `maclaurinMean n x` unfolds to `(eₙ/C(n,n))^(1/n)`; with `elemSymm_n_eq_prod`, `Nat.choose_self`, `Nat.cast_one`, `div_one` this is `(∏ xᵢ)^(1/n)`. The capstone rewrites both endpoints in `maclaurin_m1_ge_mn`. Please re-run the docker build once containerd is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)