### PR TITLE
research(erdos-1018-oq-04-incomplete-01): heredity of embeddability under induced sub-hypergraphs

### DIFF
--- a/proofs/Proofs/Erdos1018OQ04Incomplete01.lean
+++ b/proofs/Proofs/Erdos1018OQ04Incomplete01.lean
@@ -119,6 +119,30 @@ theorem embeddable_mono {r : ℕ} {H : Erdos1018OQ04.Hypergraph V r}
     rw [← Set.image_inter hι_inj]
     exact Set.image_subset ι (hsep e₁ he₁ e₂ he₂ hne)
 
+/-- **Heredity: embeddability passes to induced sub-hypergraphs.**
+    If `H` is embeddable in `ℝ^d`, so is every induced sub-hypergraph `H.induced S`:
+    the edges of `H.induced S` are exactly the edges of `H` contained in `S`, so the same
+    vertex map `φ` and the same separation condition witness the embedding. This is the
+    monotonicity of embeddability in the edge set (complementing `embeddable_mono`, which is
+    monotone in the dimension). -/
+theorem isEmbeddableConc_induced {r d : ℕ} {H : Erdos1018OQ04.Hypergraph V r} (S : Finset V)
+    (hE : isEmbeddableConc H d) : isEmbeddableConc (H.induced S) d := by
+  obtain ⟨φ, hinj, hsep⟩ := hE
+  refine ⟨φ, hinj, fun e₁ he₁ e₂ he₂ hne => ?_⟩
+  simp only [Erdos1018OQ04.Hypergraph.induced, Finset.mem_filter] at he₁ he₂
+  exact hsep e₁ he₁.1 e₂ he₂.1 hne
+
+/-- **A non-embeddable induced subgraph obstructs the whole graph.**
+    Contrapositive of `isEmbeddableConc_induced`: if some induced sub-hypergraph `H.induced S`
+    fails to embed in `ℝ^d`, then `H` itself is not embeddable. This is precisely the logical
+    direction used to certify non-embeddability of a dense (hyper)graph by exhibiting a *small*
+    non-embeddable subgraph — the shape of the Kostochka–Pyber conclusion `kostochka_pyber_r2`
+    and, for `r = 2`, of the non-planar-subgraph statement of Erdős #1018. -/
+theorem not_isEmbeddableConc_of_induced {r d : ℕ} {H : Erdos1018OQ04.Hypergraph V r}
+    (S : Finset V) (hne : ¬ isEmbeddableConc (H.induced S) d) :
+    ¬ isEmbeddableConc H d :=
+  fun hE => hne (isEmbeddableConc_induced S hE)
+
 
 /-- Explicit planar embedding of K₃:
     Vertices {0, 1, 2} mapped to (0,0), (1,0), (0,1) in ℝ².

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -157,9 +157,9 @@
       "Proofs.Erdos1018OQ04"
     ],
     "namespace": "Erdos1018OQ04Completion",
-    "lineCount": 738,
+    "lineCount": 762,
     "axiomCount": 1,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "path": "Proofs/Erdos1018OQ04Incomplete01.lean",
     "sorries": 1,
     "definitionCount": 1,


### PR DESCRIPTION
## Summary

The completion file for Erdős #1018 OQ-04 proves that embeddability of an `r`-uniform hypergraph is monotone in the **dimension** (`embeddable_mono`), but the complementary monotonicity in the **edge set** was missing. This PR adds it and its contrapositive — both self-contained, and neither touches the one remaining deep `sorry` (`planar_graphs_edge_bound`, which needs Euler's formula `|E| ≤ 3n − 6`).

### New theorems (`Proofs/Erdos1018OQ04Incomplete01.lean`, namespace `Erdos1018OQ04Completion`)

- **`isEmbeddableConc_induced`** — if `H` is embeddable in `ℝ^d`, so is every induced sub-hypergraph `H.induced S`. The edges of `H.induced S` are exactly the edges of `H` contained in `S`, so the *same* vertex map `φ` and separation condition witness the embedding. A one-line restriction of the ambient embedding.
- **`not_isEmbeddableConc_of_induced`** — contrapositive: a non-embeddable induced subgraph witnesses non-embeddability of the whole graph. This is precisely the logical direction used to certify non-embeddability of a *dense* (hyper)graph by exhibiting a *small* non-embeddable subgraph — the shape of the `kostochka_pyber_r2` conclusion and, for `r = 2`, of the non-planar-subgraph statement of Erdős #1018.

Together with the existing dimension-monotonicity `embeddable_mono`, embeddability is now known to be monotone in both of its natural parameters (dimension ↑, edge set ↓).

### Axioms / status
No new axioms (inherits `kostochka_pyber_r2`). Sorry count unchanged (the Euler-formula `sorry` is untouched). Entry remains `axiomatized`. Also syncs the stale gallery `leanFile` counts (738→762 lines, 11→13 theorems).

### ⚠️ Verification status: UNVERIFIED (environment blocker)
The Docker build could not run this session: the Lean image build fails with
`write /var/lib/desktop-containerd/daemon/io.containerd.metadata.v1.bolt/meta.db: input/output error`
— Docker Desktop containerd metadata-DB corruption (host disk is healthy, ~150 Gi free). This blocks all builds fleet-wide this session and is an operator-level Docker reset, not something to self-remediate on shared infra. The additions are a direct restriction of an existing embedding plus a one-line contrapositive, using the file's own established `simp only [Hypergraph.induced, Finset.mem_filter]` idiom for the membership step. Please rebuild once the Docker daemon is healthy (`./proofs/scripts/docker-build.sh Proofs.Erdos1018OQ04Incomplete01`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)