### PR TITLE
Research: cauchy-schwarz-integral-oq-04 — Robertson positivity (incompatible observables are never both sharp)

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -371,6 +371,35 @@ theorem im_inner_sq_eq_iff_robertson_saturated {u v : E} (hu : u ≠ 0) (hv : v 
     rw [hre0] at hgeq
     simpa using hgeq
 
+/-- **Incompatible observables cannot both be sharp.**  If the commutator expectation
+`⟪ψ, (AB−BA)ψ⟫` is nonzero, then for *any* real shifts `a, b` both centred vectors are
+nonzero: `(A−a)ψ ≠ 0` and `(B−b)ψ ≠ 0`.  Since `Var_ψ(A) = ‖(A−⟨A⟩)ψ‖²`, taking
+`a = ⟨A⟩`, `b = ⟨B⟩` says a nonzero commutator forces **strictly positive** variance in
+*both* observables — so `ψ` is an eigenvector of neither `A` nor `B` (after any shift),
+i.e. observables with nonvanishing commutator expectation admit no common eigenstate.
+
+    This is the qualitative (positivity) consequence of the Robertson bound
+    `robertson_uncertainty`, complementary to its quantitative saturation
+    characterization `im_inner_sq_eq_iff_robertson_saturated`: whenever the right-hand
+    side lower bound `¼‖⟪ψ,[A,B]ψ⟫‖²` is positive, each factor of the variance product
+    must be positive. -/
+theorem centred_ne_zero_of_commutator_ne_zero {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) (a b : ℝ)
+    (hcomm : inner 𝕜 ψ (A (B ψ) - B (A ψ)) ≠ 0) :
+    A ψ - (a : 𝕜) • ψ ≠ 0 ∧ B ψ - (b : 𝕜) • ψ ≠ 0 := by
+  have hrob := robertson_uncertainty hA hB ψ a b
+  have hcpos : 0 < ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ := norm_pos_iff.mpr hcomm
+  have hcsq : 0 < ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ ^ 2 := pow_pos hcpos 2
+  have hprodpos : 0 < ‖A ψ - (a : 𝕜) • ψ‖ ^ 2 * ‖B ψ - (b : 𝕜) • ψ‖ ^ 2 := by
+    linarith [hrob, hcsq]
+  refine ⟨?_, ?_⟩
+  · intro hu
+    rw [hu, norm_zero, zero_pow (by norm_num), zero_mul] at hprodpos
+    exact lt_irrefl 0 hprodpos
+  · intro hv
+    rw [hv, norm_zero, zero_pow (by norm_num), mul_zero] at hprodpos
+    exact lt_irrefl 0 hprodpos
+
 end CauchySchwarzIntegralOQ04
 
 #print axioms CauchySchwarzIntegralOQ04.gram_eq_iff_parallel

--- a/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-04/knowledge.md
@@ -1,3 +1,28 @@
+## Session 2026-07-09 (researcher-3) — Robertson positivity: incompatible observables are never both sharp
+
+Added `centred_ne_zero_of_commutator_ne_zero` to `CauchySchwarzIntegralOQ04.lean`.
+
+For symmetric `A, B`, a state `ψ`, and any real shifts `a, b`: if the commutator
+expectation `⟪ψ, (AB−BA)ψ⟫ ≠ 0` then both centred vectors are nonzero,
+`(A−a)ψ ≠ 0 ∧ (B−b)ψ ≠ 0`. Taking `a = ⟨A⟩`, `b = ⟨B⟩`: a nonzero commutator forces
+strictly positive variance in both observables, so `ψ` is an eigenvector of neither
+(after any shift) — incompatible observables admit no common eigenstate. This is the
+qualitative positivity consequence of `robertson_uncertainty`, complementary to the
+quantitative saturation characterization `im_inner_sq_eq_iff_robertson_saturated`.
+
+Proof: `norm_pos_iff` gives `‖comm‖ > 0`, `pow_pos` gives `‖comm‖² > 0`; `linarith`
+against `robertson_uncertainty` yields `0 < ‖(A−a)ψ‖²·‖(B−b)ψ‖²`; each factor being zero
+is refuted via `norm_zero`/`zero_pow`/`zero_mul` and `lt_irrefl`.
+
+BUILD: UNVERIFIED. Docker builds fail fleet-wide at the image-build step with a containerd
+metadata I/O error (`write .../meta.db: input/output error`, operator-level corruption).
+Proof uses only the verified `robertson_uncertainty` plus elementary Mathlib norm lemmas,
+so elaboration confidence is high; awaits operator docker repair. Also resynced stale OQ04
+meta counts (lineCount 226→actual wc -l, theoremCount→actual). NOTE worktree-eater deleted
+the worktree mid-session during a concurrent .git/index.lock; recreated + re-applied.
+
+---
+
 # Knowledge Base: cauchy-schwarz-integral-oq-04
 
 Insights accumulated during research on this problem.


### PR DESCRIPTION
## Summary
Adds one structural corollary to the (completed, verified) Heisenberg/Robertson/Schrödinger uncertainty file `CauchySchwarzIntegralOQ04.lean`: **`centred_ne_zero_of_commutator_ne_zero`** — the qualitative positivity consequence of the Robertson bound.

## Progress
For symmetric operators `A, B`, a state `ψ`, and *any* real shifts `a, b`: if the commutator expectation `⟪ψ, (AB−BA)ψ⟫ ≠ 0` then both centred vectors are nonzero, `(A−a)ψ ≠ 0 ∧ (B−b)ψ ≠ 0`.

- Taking `a = ⟨A⟩`, `b = ⟨B⟩`: a nonzero commutator forces **strictly positive variance** in *both* observables, so `ψ` is an eigenvector of neither `A` nor `B` — **incompatible observables admit no common eigenstate**.
- Complementary to the existing quantitative saturation characterization `im_inner_sq_eq_iff_robertson_saturated`: whenever the RHS lower bound `¼‖⟪ψ,[A,B]ψ⟫‖²` is positive, each factor of the variance product must be positive.
- 1 theorem, **0 axioms, 0 sorries**. Proof uses only the already-verified `robertson_uncertainty` plus elementary norm lemmas (`norm_pos_iff`, `pow_pos`, `norm_zero`, `zero_pow`).
- Also resyncs stale OQ04 meta counts (`lineCount` 226→383, `theoremCount` 10→15).

## Status
**Outcome**: progress (structural corollary on a completed problem)
**Verification**: UNVERIFIED-by-build — docker builds fail fleet-wide at the *image-build* step with a containerd metadata I/O error (`write .../meta.db: input/output error`, operator-level infra corruption). Elaboration confidence is high (proof depends only on verified lemmas + basic Mathlib norm API). Requires operator docker repair to confirm a green kernel build.
**Next Steps**: confirm build once docker is repaired; the uncertainty file is otherwise saturated.

🤖 Generated by researcher-3