### PR TITLE
research(tetrahedral-number-formula-oq-01): strict monotonicity of simplex numbers

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -367,4 +367,37 @@ theorem simplexNumber_mono_dim {a b : ℕ} (n : ℕ) (h : a ≤ b) :
   rw [simplexNumber_symm a n, simplexNumber_symm b n]
   exact simplexNumber_mono_size n h
 
+/-- **Strict monotonicity in the size `n`** (positive dimension). For every dimension
+`d + 1 ≥ 1`, the simplex number `P_{d+1}(n) = C(n+d+1, d+1)` is *strictly* increasing
+in `n`: passing from `n` to `n+1` adds a full nonempty `d`-dimensional layer
+`P_d(n+1) > 0`. This sharpens the ≤-only `simplexNumber_mono_size`. Strictness genuinely
+needs `d ≥ 1`: at `d = 0`, `P_0 ≡ 1` is constant. Immediate from the figurate Pascal
+recurrence `simplexNumber_succ_succ` together with `simplexNumber_pos`. -/
+theorem simplexNumber_strictMono_size (d : ℕ) :
+    StrictMono (simplexNumber (d + 1)) := by
+  apply strictMono_nat_of_lt_succ
+  intro n
+  rw [simplexNumber_succ_succ]
+  have hpos : 0 < simplexNumber d (n + 1) := simplexNumber_pos d (n + 1)
+  omega
+
+/-- **Strict growth in size**, `<`-form: `m < n → P_{d+1}(m) < P_{d+1}(n)`. The
+convenient specialization of `simplexNumber_strictMono_size` to a strict-inequality
+hypothesis, mirroring `simplexNumber_mono_size` on the `≤` side. -/
+theorem simplexNumber_lt_of_lt {m n : ℕ} (d : ℕ) (h : m < n) :
+    simplexNumber (d + 1) m < simplexNumber (d + 1) n :=
+  simplexNumber_strictMono_size d h
+
+/-- **Strict monotonicity in the dimension `d`** (positive size). For every size
+`n + 1 ≥ 1`, `P_d(n+1)` is *strictly* increasing in the dimension `d`. By the
+reflection symmetry `P_d(n) = P_n(d)` this is `simplexNumber_strictMono_size` read
+along the other axis; it sharpens `simplexNumber_mono_dim`, and like it needs the size
+to be positive (`P_d(0) ≡ 1` is constant in `d`). -/
+theorem simplexNumber_strictMono_dim (n : ℕ) :
+    StrictMono (fun d => simplexNumber d (n + 1)) := by
+  intro a b hab
+  show simplexNumber a (n + 1) < simplexNumber b (n + 1)
+  rw [simplexNumber_symm a (n + 1), simplexNumber_symm b (n + 1)]
+  exact simplexNumber_strictMono_size n hab
+
 end TetrahedralNumberFormulaOQ01

--- a/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/knowledge.md
@@ -104,3 +104,32 @@ succeeded; the SIGBUS-135 tail on other runs is the fleet olean-write env issue,
 NEXT: entry is well saturated (Pascal-simplex identities, iterated-summation Cauchy/Vandermonde
 semigroup, Sym counting, ascFactorial closed form, and now the reflection symmetry). Remaining
 possible angles are finite-difference / generating-function forms — lower marginal value.
+
+## Session (researcher-1, 2026-07-09): strict monotonicity of simplex numbers
+
+**Mode**: REVISIT (RICH, depth-first) · **Outcome**: progress (3 theorems, UNVERIFIED —
+docker corrupted). Branch `research/tetrahedral-oq01-strict-mono`, PR pending.
+
+The merged #36700 gave only `≤` monotonicity (`simplexNumber_mono_size`/`_mono_dim`).
+Added the **strict** sharpening, both axes:
+- `simplexNumber_strictMono_size (d) : StrictMono (simplexNumber (d+1))` —
+  `strictMono_nat_of_lt_succ`, then the Pascal recurrence `simplexNumber_succ_succ`
+  turns the step goal into `a < a + P_d(n+1)` and `simplexNumber_pos` + `omega` close it.
+  Strictness genuinely needs `d ≥ 1` (index `d+1`); `P_0 ≡ 1` is constant.
+- `simplexNumber_lt_of_lt {m n} (d) (h : m < n)` — the `<`-hypothesis corollary
+  (`StrictMono` applied to `h`).
+- `simplexNumber_strictMono_dim (n) : StrictMono (fun d => simplexNumber d (n+1))` —
+  reflection symmetry `simplexNumber_symm` reduces to `_strictMono_size n`.
+
+**Context / de-duplication:** this problem is heavily in-flight — merged PRs #36386
+(hockey stick), #36499 (discrete Cauchy), #36589 (iterSum semigroup), #36599
+(simplexConv_comp), #36628 (reflection + dim-axis hockey stick), #36700 (positivity +
+`≤` monotonicity); OPEN PRs #36580 (Vandermonde convolution) and #36509 (dimension
+additivity). Chose the strict-monotonicity corollaries specifically because they are
+orthogonal to all of the above (no convolution/kernel machinery). `TetrahedralNumberFormulaOQ01.lean`
+is a **research-layer file with no gallery meta** (the `tetrahedral-number-formula`
+entry's `proofRepoPath` points only at `TetrahedralNumberFormula.lean`), so no meta
+count sync is required.
+
+**BLOCKER:** docker corrupted fleet-wide (containerd `meta.db` I/O error at image
+build). Shipped UNVERIFIED; proofs correct by inspection. Re-verify when repaired.

--- a/research/problems/tetrahedral-number-formula-oq-01/state.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/state.md
@@ -1,0 +1,35 @@
+# Research State: tetrahedral-number-formula-oq-01
+
+## Current State
+**Phase**: ACT
+**Path**: full
+**Since**: 2026-07-09T16:49:44-07:00
+**Iteration**: 2
+
+## Current Focus
+Sharpen the (merged, #36700) ≤-only monotonicity of simplex numbers to strict
+monotonicity, on both the size and dimension axes.
+
+## Active Approach
+Added to `TetrahedralNumberFormulaOQ01.lean`:
+- `simplexNumber_strictMono_size (d) : StrictMono (simplexNumber (d+1))`
+- `simplexNumber_lt_of_lt` (the `m<n ⟹ <` corollary)
+- `simplexNumber_strictMono_dim (n) : StrictMono (fun d => simplexNumber d (n+1))`
+Composes existing verified lemmas (simplexNumber_succ_succ, _pos, _symm) +
+`strictMono_nat_of_lt_succ`. Deliberately orthogonal to the in-flight convolution /
+Vandermonde (#36580) and dimension-additivity (#36509) PRs.
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Blockers
+Docker daemon corrupted this session (containerd `meta.db` I/O error at image build) —
+build could not run; shipped UNVERIFIED. Proofs verified correct by inspection against
+existing same-file lemmas.
+
+## Next Action
+Re-verify once docker repaired: `./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01`.
+The core hockey-stick family + convolution/Vandermonde/monotonicity layers are now
+well-covered (several merged + open PRs); further work is fine-grained corollaries.


### PR DESCRIPTION
## Summary

Sharpens the merged ≤-only monotonicity of simplex (hyper-tetrahedral) numbers `P_d(n) = C(n+d, d)` to **strict** monotonicity on both axes, in `TetrahedralNumberFormulaOQ01.lean`.

## What's new (3 theorems)

- `simplexNumber_strictMono_size (d) : StrictMono (simplexNumber (d + 1))` — for positive dimension, `P_{d+1}(n)` is strictly increasing in `n`. Proof: `strictMono_nat_of_lt_succ`, then the figurate Pascal recurrence `simplexNumber_succ_succ` turns the step into `a < a + P_d(n+1)`, closed by `simplexNumber_pos` + `omega`.
- `simplexNumber_lt_of_lt {m n} (d) (h : m < n)` — the strict-hypothesis corollary `P_{d+1}(m) < P_{d+1}(n)`.
- `simplexNumber_strictMono_dim (n) : StrictMono (fun d => simplexNumber d (n + 1))` — for positive size, strictly increasing in the dimension; reduced to the size version via the reflection symmetry `simplexNumber_symm`.

Strictness genuinely needs the extra `+1` (dimension/size ≥ 1): `P_0 ≡ 1` and `P_d(0) ≡ 1` are constant. These complement the merged `≤`-only `simplexNumber_mono_size` / `simplexNumber_mono_dim` (#36700).

**Orthogonal** to the in-flight convolution/Vandermonde (#36580) and dimension-additivity (#36509) PRs — no kernel/convolution machinery is touched.

## Verification status

⚠️ **UNVERIFIED.** The docker build daemon was corrupted this session (`write /var/lib/desktop-containerd/.../meta.db: input/output error` at image-build time) — elaboration never ran. This is an environment/operator issue, not a proof error; per protocol I did not self-prune shared docker caches.

All three proofs compose only already-verified lemmas from this same file (`simplexNumber_succ_succ`, `simplexNumber_pos`, `simplexNumber_symm`) plus standard `strictMono_nat_of_lt_succ` and `StrictMono` application. Re-verify when docker is repaired: `./proofs/scripts/docker-build.sh Proofs.TetrahedralNumberFormulaOQ01`.

0 sorries, 0 axioms. This is a research-layer file with no gallery meta, so no count sync is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)