### PR TITLE
erdos-729-oq-04: no-carry equality criteria for multinomial/binomial coefficients

### DIFF
--- a/proofs/Proofs/Erdos729LegendreMultinomial.lean
+++ b/proofs/Proofs/Erdos729LegendreMultinomial.lean
@@ -205,4 +205,32 @@ theorem prime_dvd_choose_iff (p : ℕ) [Fact p.Prime] (m n : ℕ) :
     ← mul_pos_iff_of_pos_left hq]
   omega
 
+/-- **Multinomial no-carry criterion (equality form).** A prime `p` does *not*
+divide `multinomial s f` iff the base-`p` digit sum of the total *equals* the sum
+of the digit sums of the parts — i.e. adding the parts in base `p` produces *no*
+carry at all.  This is the exact complement of `prime_dvd_multinomial_iff`: the
+Kummer identity forces the digit sum of a sum to never exceed the sum of the digit
+sums, so non-divisibility (`¬ p ∣ ·`) coincides with equality rather than merely
+`≤`. -/
+theorem not_prime_dvd_multinomial_iff {α : Type*} (p : ℕ) [Fact p.Prime]
+    (s : Finset α) (f : α → ℕ) :
+    ¬ p ∣ Nat.multinomial s f
+      ↔ (p.digits (∑ i ∈ s, f i)).sum = ∑ i ∈ s, (p.digits (f i)).sum := by
+  rw [prime_dvd_multinomial_iff]
+  have hmain := sub_one_mul_padicValNat_multinomial p s f
+  omega
+
+/-- **Kummer's no-carry criterion for binomials (equality form).** A prime `p`
+does *not* divide `C(m+n, n)` iff the base-`p` digit sum of `m + n` *equals* the
+sum of the digit sums of `m` and `n` — i.e. adding `m` and `n` in base `p`
+produces no carry.  The exact complement of `prime_dvd_choose_iff`.  At `p = 2`
+this is the classical criterion that `C(m+n, n)` is odd iff the binary
+representations of `m` and `n` have disjoint support (Lucas' theorem, carry form). -/
+theorem not_prime_dvd_choose_iff (p : ℕ) [Fact p.Prime] (m n : ℕ) :
+    ¬ p ∣ (m + n).choose n
+      ↔ (p.digits (m + n)).sum = (p.digits m).sum + (p.digits n).sum := by
+  rw [prime_dvd_choose_iff]
+  have hmain := sub_one_mul_padicValNat_choose p m n
+  omega
+
 end Erdos729Multinomial

--- a/research/problems/erdos-729-oq-02/state.md
+++ b/research/problems/erdos-729-oq-02/state.md
@@ -50,3 +50,17 @@ exposed four latent errors, all now fixed:
 
 Remaining axioms (Erdős 1968, Barreto–Leeham) are the genuinely deep open math,
 out of scope for OQ-02.
+
+## Session 2026-07-09 (researcher-6) — no-carry equality companions
+OQ-02 remains fully resolved. Added two clean companion lemmas to the shared
+`Erdos729LegendreMultinomial.lean` (gallery entry erdos-729-oq-04), the
+equality-form complements of the existing Kummer divisibility criteria:
+- `not_prime_dvd_multinomial_iff`: ¬p∣multinomial ↔ s_p(Σf) = Σ s_p(f i);
+- `not_prime_dvd_choose_iff`: ¬p∣C(m+n,n) ↔ s_p(m+n) = s_p(m)+s_p(n)
+  (at p=2: C(m+n,n) odd iff binary supports of m,n are disjoint).
+Both derived from the file's own additive Kummer identities + omega
+(nonneg-atom). Axiom-free. UNVERIFIED — Docker infra down this session
+(containerd content-store I/O errors, `docker-build.sh` dies at image build,
+`docker images` errors; operator-level, not self-fixable). Clean assembly
+mirroring the verified siblings `prime_dvd_{choose,multinomial}_iff`.
+Gallery meta erdos-729-oq-04 leanFile synced 8→10 theorems / 208→236 lines.

--- a/src/data/proofs/erdos-729-oq-04/meta.json
+++ b/src/data/proofs/erdos-729-oq-04/meta.json
@@ -159,9 +159,9 @@
       "Finset"
     ],
     "namespace": "Erdos729Multinomial",
-    "lineCount": 208,
+    "lineCount": 236,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/Erdos729LegendreMultinomial.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the two **equality-form (no-carry) companions** to the existing Kummer divisibility criteria in `Erdos729LegendreMultinomial.lean` (gallery entry `erdos-729-oq-04`). The file already proves the general-`p` additive Kummer identities and the strict "`p ∣ coeff ↔ carries occur`" criteria; these two lemmas capture the exact complement — when the coefficient is **coprime** to `p`.

- `not_prime_dvd_multinomial_iff`: `¬ p ∣ multinomial s f ↔ s_p(∑ f i) = ∑ s_p(f i)` — adding the parts in base `p` produces **no** carry.
- `not_prime_dvd_choose_iff`: `¬ p ∣ C(m+n, n) ↔ s_p(m+n) = s_p(m) + s_p(n)`. At `p = 2` this is the classical result that `C(m+n, n)` is **odd** iff the binary representations of `m` and `n` have disjoint support (carry form of Lucas' theorem).

## Proof

Each is a two-line derivation from the file's own additive Kummer identity (`sub_one_mul_padicValNat_{multinomial,choose}`): rewriting through the strict `prime_dvd_*_iff` criterion, the identity `(p-1)·v_p(coeff) + s_p(total) = ∑ s_p(parts)` forces `s_p(total) ≤ ∑ s_p(parts)` (the `(p-1)·v_p` term is a nonnegative atom), so non-divisibility (`v_p = 0`) coincides with **equality**, not merely `≤`. `omega` closes it.

Axiom-free, 2 theorems. Complements `prime_dvd_choose_iff` / `prime_dvd_multinomial_iff` exactly.

## Verification

⚠️ **UNVERIFIED this session** — Docker build infrastructure is down (containerd content-store `input/output` errors; `docker-build.sh` fails at image build and `docker images` itself errors — operator-level, not self-fixable). The two lemmas are trivial `rw [existing_iff]; have := existing_identity; omega` assemblies that mirror the already-verified sibling criteria in the same file, using the identical nonneg-atom `omega` pattern. High confidence in elaboration; flagging for a clean rebuild once Docker is restored.

Gallery meta `erdos-729-oq-04` `leanFile` synced: 8 → 10 theorems, 208 → 236 lines.