### PR TITLE
research(law-of-cosines-oq-03-oq-03): strict Gram positivity + outer law-of-sines ratio

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -646,6 +646,15 @@ theorem sinh_c_num_sq (t : HyperbolicTriangle) :
 theorem gramNumerator_nonneg (t : HyperbolicTriangle) : 0 ≤ gramNumerator t := by
   rw [← sinh_a_num_sq t]; positivity
 
+/-- **The Gram numerator is strictly positive.** Strengthening `gramNumerator_nonneg`: it
+    equals `(sinh a · sin B · sin C)²`, whose base is a product of the strictly positive
+    quantities `sinh a`, `sin B`, `sin C`, so the square is `> 0`. Thus a genuine hyperbolic
+    triangle satisfies `cos²A + cos²B + cos²C + 2 cos A cos B cos C > 1` strictly — the
+    inequality is never tight (tightness would force a degenerate side or a straight angle). -/
+theorem gramNumerator_pos (t : HyperbolicTriangle) : 0 < gramNumerator t := by
+  rw [← sinh_a_num_sq t]
+  exact pow_pos (mul_pos (sinh_a_pos t) (mul_pos (sin_B_pos t) (sin_C_pos t))) 2
+
 /-- **Hyperbolic law of sines, pair `a,b` (cross form).**
     `sinh a · sin B = sinh b · sin A`. Both `(sinh a · sin B · sin C)²` and
     `(sinh b · sin A · sin C)²` equal the Gram numerator; cancelling the common
@@ -711,6 +720,16 @@ theorem hyperbolic_law_of_sines (t : HyperbolicTriangle) :
   refine ⟨?_, ?_⟩
   · rw [div_eq_div_iff hA hB]; linear_combination law_of_sines_ab t
   · rw [div_eq_div_iff hB hC]; linear_combination law_of_sines_bc t
+
+/-- **Hyperbolic law of sines, outer ratio `a,c`.** `sinh a / sin A = sinh c / sin C`, the
+    remaining pair of the three equal ratios (`hyperbolic_law_of_sines` records the two
+    adjacent equalities `a=b` and `b=c`; this is their transitive consequence, stated
+    directly from `law_of_sines_ac` for convenience). -/
+theorem hyperbolic_law_of_sines_ac (t : HyperbolicTriangle) :
+    Real.sinh t.a / Real.sin t.A = Real.sinh t.c / Real.sin t.C := by
+  have hA : Real.sin t.A ≠ 0 := (sin_A_pos t).ne'
+  have hC : Real.sin t.C ≠ 0 := (sin_C_pos t).ne'
+  rw [div_eq_div_iff hA hC]; linear_combination law_of_sines_ac t
 
 -- ============================================================
 -- PART 10: Realizability — the defect condition A+B+C<π is SUFFICIENT

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 810,
-    "theoremCount": 45,
+    "lineCount": 829,
+    "theoremCount": 47,
     "definitionCount": 2
   },
   "openQuestion": {


### PR DESCRIPTION
## Summary

Two small, correct-by-inspection completions to the hyperbolic-AAA-congruence file (`LawOfCosinesOQ03OQ03.lean`), each following in a couple of lines from lemmas already in the file and matching its established idioms.

- **`gramNumerator_pos`** — strengthens the existing (and used) `gramNumerator_nonneg` from `≥ 0` to `> 0`. The Gram numerator equals `(sinh a · sin B · sin C)²` (`sinh_a_num_sq`), whose base is a product of the strictly positive `sinh a`, `sin B`, `sin C`; hence the square is strictly positive. So a genuine hyperbolic triangle satisfies `cos²A + cos²B + cos²C + 2·cos A·cos B·cos C > 1` **strictly** — the Gram inequality is never tight.
- **`hyperbolic_law_of_sines_ac`** — the outer ratio `sinh a / sin A = sinh c / sin C`. `hyperbolic_law_of_sines` records only the two adjacent equalities (`a=b`, `b=c`); this states their transitive consequence directly from `law_of_sines_ac`, for convenience.

### Axioms / status
No new axioms or sorries. The entry remains `axiomatized` (its `badge: axiom` reflects the structure-encoded second-law-of-cosines assumptions `lawA/lawB/lawC`, unchanged by these additions). Syncs the gallery `leanFile` counts (810→829 lines, 45→47 theorems).

### ⚠️ Verification status: UNVERIFIED (environment blocker)
The Docker build could not run this session: the Lean image build fails with
`write /var/lib/desktop-containerd/daemon/io.containerd.metadata.v1.bolt/meta.db: input/output error`
— Docker Desktop containerd metadata-DB corruption (host disk healthy, ~150 Gi free), blocking all builds fleet-wide; an operator-level Docker reset is needed. Both additions use only `pow_pos`/`mul_pos` and the `div_eq_div_iff` + `linear_combination` pattern already used verbatim by the adjacent `hyperbolic_law_of_sines`. Please rebuild once Docker is healthy (`./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ03OQ03`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)