### PR TITLE
research(erdos-659-incomplete-01): conjugate norm-form identity + finite-product closure [UNVERIFIED — docker infra I/O failure]

### DIFF
--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -297,6 +297,17 @@ theorem repr_mul_identity (a b c d : ℤ) :
       = (a * c + 2 * b * d) ^ 2 + 2 * (a * d - b * c) ^ 2 := by
   ring
 
+/-- **Conjugate composition identity for `x² + 2y²`.** The same product also factors
+    as `(ac − 2bd)² + 2(ad + bc)²` — the "conjugate" of `repr_mul_identity`, obtained by
+    replacing `d ↦ -d` (conjugating the second factor in `ℤ[√-2]`). The two identities
+    generically yield *distinct* representations of the same product, the arithmetic
+    source of the non-uniqueness in the representation count that Landau's theorem
+    (`moreeOsburnWorks`) ultimately measures. A pure `ring` fact. -/
+theorem repr_mul_identity' (a b c d : ℤ) :
+    (a ^ 2 + 2 * b ^ 2) * (c ^ 2 + 2 * d ^ 2)
+      = (a * c - 2 * b * d) ^ 2 + 2 * (a * d + b * c) ^ 2 := by
+  ring
+
 /-- The set of integers representable as `x² + 2y²` is **closed under multiplication**.
     Combined with `one_representable`/`two_representable` this shows, e.g., every power
     of `2` is representable. This is the norm-multiplicativity of `ℤ[√-2]`. -/
@@ -338,6 +349,19 @@ theorem representable_pow {m : ℕ} (hm : m ∈ representable_x2_2y2) (k : ℕ) 
     of `representable_pow` promised by the `representable_mul` docstring. -/
 theorem two_pow_representable (k : ℕ) : 2 ^ k ∈ representable_x2_2y2 :=
   representable_pow two_representable k
+
+/-- **Closure under finite products.** A product `∏ i ∈ s, f i` of representable
+    integers is representable. Generalises `representable_pow` (the constant-`f` case)
+    from a single repeated factor to an arbitrary finite family, via
+    `Finset.prod_induction` over the multiplicative monoid `(ℕ, ·, 1)` with
+    `representable_mul` as the step and `one_representable` as the base. No axioms. -/
+theorem representable_prod {ι : Type*} (s : Finset ι) (f : ι → ℕ)
+    (hf : ∀ i ∈ s, f i ∈ representable_x2_2y2) :
+    (∏ i ∈ s, f i) ∈ representable_x2_2y2 := by
+  refine Finset.prod_induction f (· ∈ representable_x2_2y2) ?_ ?_ hf
+  · intro a b ha hb
+    exact representable_mul ha hb
+  · exact one_representable
 
 /-! ### Basic behaviour of the counting function `B₂`
 

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -140,9 +140,9 @@
       "Real"
     ],
     "namespace": "Erdos659",
-    "lineCount": 511,
+    "lineCount": 535,
     "axiomCount": 1,
-    "theoremCount": 23,
+    "theoremCount": 25,
     "definitionCount": 9,
     "path": "Proofs/Erdos659Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #659's gallery file (`Erdos659Problem.lean`) is resolved to 0 sorries / 1 axiom (`moreeOsburnWorks`, packaging Landau's 1908 theorem on the count of `x²+2y²`-representable integers — irreducible, absent from Mathlib). This iteration extends the surrounding **ℤ[√-2] norm-form arithmetic** with two axiom-free lemmas, without touching that deep axiom:

- **`repr_mul_identity'`** — the *conjugate* composition identity
  `(a²+2b²)(c²+2d²) = (ac−2bd)² + 2(ad+bc)²`, the mirror of the existing
  `repr_mul_identity` (`… = (ac+2bd)² + 2(ad−bc)²`), obtained by conjugating the second
  factor (`d ↦ −d`). The two identities generically give **distinct** representations of
  the same product — the arithmetic source of the representation-count non-uniqueness
  that Landau's theorem ultimately measures. Pure `ring`.
- **`representable_prod`** — the representable set is closed under **arbitrary finite
  products** `∏ i ∈ s, f i`, generalizing the existing `representable_pow` (the
  constant-`f` case) via `Finset.prod_induction` with `representable_mul` (step) and
  `one_representable` (base).

Synced gallery `meta.json` leanFile counts: `lineCount` 511→535, `theoremCount` 23→25 (convention: `grep -c "^theorem "`); `axiomCount` unchanged at 1. Still 0 sorries, 1 axiom.

## Verification

⚠️ **UNVERIFIED — docker infrastructure failure.** `./proofs/scripts/docker-build.sh Proofs.Erdos659Problem` fails at the image-build stage with a host-level containerd error (`write /var/lib/desktop-containerd/.../meta.db: input/output error`) across the session — no Lean elaboration reached. Disk had 27Gi free (not disk-full); containerd metadata corruption needing operator cleanup.

Manual confidence is high: `repr_mul_identity'` is a pure `ring` identity (expand: RHS `= a²c² + 4b²d² + 2a²d² + 2b²c² =` LHS). `representable_prod` is `Finset.prod_induction f (· ∈ representable_x2_2y2) ?hom ?unit hf`, closing `?hom` with `representable_mul` and `?unit` with `one_representable` — all pre-existing, ℕ is the multiplicative `CommMonoid`. Please re-run the docker build once containerd is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)