### PR TITLE
Enrich Abel-Ruffini Sylow-elimination: fix stale annotations + full structural coverage

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-03/annotations.json
@@ -2,20 +2,18 @@
   {
     "id": "ann-motivation-verbatim-lemmas",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
-    "range": {
-      "startLine": 1,
-      "endLine": 50
-    },
+    "range": { "startLine": 1, "endLine": 55 },
     "type": "context",
-    "title": "Motivation: Three Verbatim Sylow Lemmas, One Group-Order Fact",
-    "content": "The verified Abel–Ruffini proof that x⁵ − 4x + 2 is not solvable by radicals (parent AbelRuffiniOQ04OQ01) eliminates the intermediate Galois-group orders 10, 20, and 40 with three private lemmas gal_card_ne_10 / _20 / _40. Read side by side, the three proofs are byte-for-byte identical except for the order value (10/20/40) and the resulting Sylow index (2/4/8). Every structural step — that the Sylow 5-subgroup has order 5, that it is unique hence normal, that it equals ⟨c⟩ for a 5-cycle c, that every element therefore normalizes ⟨c⟩ — depends only on the group order, not on the ambient symmetric group. This entry isolates that shared skeleton into a single generic lemma quantified over the group order 5·m, discharging the open question oq-03. The whole file is fully abstract: no Polynomial.Gal, no permutations, and — unlike the private lemmas — no native_decide.",
-    "mathContext": "$\\text{gal\\_card\\_ne\\_}10/20/40$ share one core: order $5m \\Rightarrow$ normal Sylow 5-subgroup $= \\langle c\\rangle$.",
+    "title": "Motivation: Three Verbatim Sylow Lemmas, Lifted to an Arbitrary Prime",
+    "content": "The verified Abel–Ruffini proof that x⁵ − 4x + 2 is not solvable by radicals (parent AbelRuffiniOQ04OQ01) eliminates the intermediate Galois-group orders 10, 20, and 40 with three private lemmas gal_card_ne_10 / _20 / _40. Read side by side, the three proofs are byte-for-byte identical except for the order value (10/20/40) and the Sylow index (2/4/8). Every structural step — the Sylow 5-subgroup has order 5, it is unique hence normal, it equals ⟨c⟩ for a 5-cycle c, so every element normalizes ⟨c⟩ — depends only on the group order, not on S₅. Only the final 'a transposition cannot normalize a 5-cycle' is S₅-specific. This entry isolates that shared skeleton into one generic lemma and, as the oq-03·oq-01 follow-up, lifts it from the fixed prime 5 to an arbitrary prime p, then develops the full structural theory (N/C bound, centrality, solvability, nilpotency, direct-product decomposition) that the skeleton unlocks. The whole file is abstract (no Polynomial.Gal, no permutations) and avoids native_decide, so it is 0-sorry / 0-axiom verified.",
+    "mathContext": "$\\text{gal\\_card\\_ne\\_}10/20/40$ share one core: order $pm,\\ p\\nmid m \\Rightarrow$ normal Sylow $p$-subgroup $=\\langle c\\rangle$.",
     "significance": "supporting",
     "relatedConcepts": [
       "Abel–Ruffini theorem",
       "Sylow's theorems",
       "code refactoring / deduplication",
-      "normal subgroup"
+      "normal subgroup",
+      "generalization from a fixed prime"
     ],
     "prerequisites": [
       "Sylow theory",
@@ -26,19 +24,17 @@
   {
     "id": "ann-statement",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
-    "range": {
-      "startLine": 51,
-      "endLine": 62
-    },
+    "range": { "startLine": 61, "endLine": 77 },
     "type": "concept",
-    "title": "The Generic Statement, Parameterized by the Group Order",
-    "content": "zpowers_order5_normal takes an arbitrary finite group G together with three hypotheses that encode 'the order is 5·m with a well-behaved 5′-part': hcard : Nat.card G = 5 * m, hm5 : ¬ 5 ∣ m (so 5 divides |G| exactly once), and huniq : ∀ d, d ∣ m → d % 5 = 1 → d = 1 (the only divisor of the index congruent to 1 mod 5 is 1). Given any element c of order 5 it concludes (Subgroup.zpowers c).Normal. The hypotheses are precisely the data that varied between the three original lemmas: m is the Sylow index (2, 4, 8) and huniq is the arithmetic fact that pins the Sylow count to 1 for that specific m.",
-    "mathContext": "$G \\text{ finite},\\ |G| = 5m,\\ 5 \\nmid m,\\ (\\forall d \\mid m,\\ d \\equiv 1 \\Rightarrow d = 1),\\ \\mathrm{ord}(c) = 5 \\;\\Rightarrow\\; \\langle c\\rangle \\trianglelefteq G.$",
+    "title": "The Generic-Prime Statement zpowers_sylow_normal",
+    "content": "zpowers_sylow_normal takes an arbitrary finite group G with three hypotheses encoding 'the order is p·m with a well-behaved p′-part': hcard : Nat.card G = p * m, hpm : ¬ p ∣ m (so p divides |G| exactly once), and huniq : ∀ d, d ∣ m → d % p = 1 → d = 1 (the only divisor of the index congruent to 1 mod p is 1). Given any element c of order p it concludes (Subgroup.zpowers c).Normal. Lifting the fixed prime 5 to a variable p is not a cosmetic rename: with p a numeral the steps nₚ ≡ 1 (mod p) ⇒ nₚ = 1 and [G:P]·p = p·m ⇒ [G:P] = m are discharged by omega/interval_cases, but for variable p they need Nat.mod_eq_of_lt (to evaluate 1 % p) and Nat.eq_of_mul_eq_mul_right (a nonlinear cancellation omega cannot see). The p = 5 lemma is recovered as a one-line corollary further down.",
+    "mathContext": "$G \\text{ finite},\\ |G| = pm,\\ p \\nmid m,\\ (\\forall d \\mid m,\\ d \\equiv 1 \\Rightarrow d = 1),\\ \\mathrm{ord}(c) = p \\;\\Rightarrow\\; \\langle c\\rangle \\trianglelefteq G.$",
     "significance": "critical",
     "relatedConcepts": [
       "cyclic subgroup zpowers",
       "orderOf",
-      "parameterization by group order"
+      "parameterization by group order",
+      "arbitrary prime generalization"
     ],
     "prerequisites": [
       "Nat.card of a group",
@@ -48,14 +44,11 @@
   {
     "id": "ann-sylow-order-nonative",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
-    "range": {
-      "startLine": 63,
-      "endLine": 82
-    },
+    "range": { "startLine": 78, "endLine": 98 },
     "type": "technique",
     "title": "Sylow Order Without native_decide, and Uniqueness via Counting",
-    "content": "The private lemmas computed |P₅| = 5 with native_decide on a concrete order. Here the same fact is proved symbolically: Sylow.card_eq_multiplicity gives |P₅| = 5^(v₅(|G|)), and since |G| = 5·m with 5 ∤ m, Nat.factorization_mul together with Nat.Prime.factorization and Nat.factorization_eq_zero_of_not_dvd evaluate v₅(5·m) = 1 + 0 = 1, so |P₅| = 5. This avoids the Lean.ofReduceBool axiom that native_decide would introduce, keeping the result 0-axiom. Uniqueness then follows by counting: the index of P₅ is m, and Sylow's third theorem (card_sylow_modEq_one) with Sylow.card_dvd_index give the Sylow count n₅ ∣ m and n₅ ≡ 1 (mod 5); huniq collapses these to n₅ = 1.",
-    "mathContext": "$v_5(5m) = 1 \\Rightarrow |P_5| = 5; \\quad n_5 \\mid m \\wedge n_5 \\equiv 1 \\ (\\mathrm{mod}\\ 5) \\Rightarrow n_5 = 1.$",
+    "content": "The private lemmas computed |Pₚ| = 5 with native_decide on a concrete order. Here the same fact is proved symbolically: Sylow.card_eq_multiplicity gives |Pₚ| = p^(vₚ(|G|)), and since |G| = p·m with p ∤ m, Nat.factorization_mul together with Nat.Prime.factorization and Nat.factorization_eq_zero_of_not_dvd evaluate vₚ(p·m) = 1 + 0 = 1, so |Pₚ| = p. This avoids the Lean.ofReduceBool axiom that native_decide would introduce, keeping the result 0-axiom. Uniqueness then follows by counting: the index of Pₚ is m, and Sylow's third theorem (card_sylow_modEq_one) with Sylow.card_dvd_index give the Sylow count nₚ ∣ m and nₚ ≡ 1 (mod p); huniq collapses these to nₚ = 1.",
+    "mathContext": "$v_p(pm) = 1 \\Rightarrow |P_p| = p; \\quad n_p \\mid m \\wedge n_p \\equiv 1 \\ (\\mathrm{mod}\\ p) \\Rightarrow n_p = 1.$",
     "significance": "critical",
     "relatedConcepts": [
       "p-adic valuation Nat.factorization",
@@ -71,14 +64,11 @@
   {
     "id": "ann-normal-and-cyclic",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
-    "range": {
-      "startLine": 83,
-      "endLine": 110
-    },
+    "range": { "startLine": 99, "endLine": 132 },
     "type": "technique",
     "title": "Uniqueness ⇒ Normality ⇒ Identification with ⟨c⟩",
-    "content": "n₅ = 1 makes Sylow 5 G a subsingleton, and Sylow.smul_eq_iff_mem_normalizer turns 'g • P₅ = P₅ (automatic when there is only one Sylow subgroup)' into 'g normalizes P₅', giving (↑P₅).Normal. To identify P₅ with ⟨c⟩: the order-5 element c generates a 5-subgroup, which IsPGroup.exists_le_sylow places inside some Sylow subgroup Q; by uniqueness Q = P₅, so ⟨c⟩ ≤ P₅. Both have order 5, so the inclusion Subgroup.inclusion is a bijection (Fintype.bijective_iff_injective_and_card), giving P₅ = ⟨c⟩. Rewriting normality of P₅ along this equality (rwa [hP5_eq] at hNP) yields (Subgroup.zpowers c).Normal.",
-    "mathContext": "$\\mathrm{Subsingleton}(\\mathrm{Sylow}\\ 5\\ G) \\Rightarrow P_5 \\trianglelefteq G; \\quad \\langle c\\rangle \\le P_5 \\wedge |{\\langle c\\rangle}| = |P_5| \\Rightarrow P_5 = \\langle c\\rangle.$",
+    "content": "nₚ = 1 makes Sylow p G a subsingleton, and Sylow.smul_eq_iff_mem_normalizer turns 'g • Pₚ = Pₚ (automatic when there is only one Sylow subgroup)' into 'g normalizes Pₚ', giving (↑Pₚ).Normal. To identify Pₚ with ⟨c⟩: the order-p element c generates a p-subgroup, which IsPGroup.exists_le_sylow places inside some Sylow subgroup Q; by uniqueness Q = Pₚ, so ⟨c⟩ ≤ Pₚ. Both have order p, so the inclusion is a bijection (cardinality argument), giving Pₚ = ⟨c⟩. Rewriting normality of Pₚ along this equality yields (Subgroup.zpowers c).Normal.",
+    "mathContext": "$\\mathrm{Subsingleton}(\\mathrm{Sylow}\\ p\\ G) \\Rightarrow P_p \\trianglelefteq G; \\quad \\langle c\\rangle \\le P_p \\wedge |{\\langle c\\rangle}| = |P_p| \\Rightarrow P_p = \\langle c\\rangle.$",
     "significance": "critical",
     "relatedConcepts": [
       "normality of a unique Sylow subgroup",
@@ -91,25 +81,232 @@
     ]
   },
   {
-    "id": "ann-corollary-and-examples",
+    "id": "ann-conj-normalize-involution",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
-    "range": {
-      "startLine": 112,
-      "endLine": 142
-    },
+    "range": { "startLine": 132, "endLine": 201 },
     "type": "insight",
-    "title": "Corollary and Recovering the Orders 10, 20, 40",
-    "content": "conj_mem_zpowers_order5 packages the reusable consequence: under the same hypotheses, every g satisfies g·c·g⁻¹ ∈ ⟨c⟩ — this is exactly the 'hconj_zpow' line that appeared identically in all three private lemmas, now a one-line application of Normal.conj_mem. The three closing examples verify huniq for m = 2, 4, 8, which are precisely the 5′-parts of the original orders 10 = 5·2, 20 = 5·4, 40 = 5·8. The m = 8 example is the instructive one: 6 ≡ 1 (mod 5), so the congruence alone would admit n₅ = 6 — it is ruled out only because 6 ∤ 8, which is why huniq must require both d ∣ m and d % 5 = 1.",
-    "mathContext": "$g c g^{-1} \\in \\langle c\\rangle; \\quad m \\in \\{2,4,8\\} \\Leftrightarrow |G| \\in \\{10,20,40\\}; \\quad 6 \\equiv 1\\ (\\mathrm{mod}\\ 5)\\ \\text{but}\\ 6 \\nmid 8.$",
-    "significance": "supporting",
+    "title": "Every Element Normalizes ⟨c⟩; the Involution ±1 Step",
+    "content": "conj_mem_zpowers_sylow packages the reusable consequence of normality: under the same hypotheses every g satisfies g·c·g⁻¹ ∈ ⟨c⟩ — the 'hconj_zpow' line that appeared identically in all three private lemmas, now a one-line Normal.conj_mem. involution_conj_eq_self_or_inv is the abstract heart of the final S₅-specific bullet: for any involution g (g·g = 1, e.g. a transposition), conjugation sends c to c or c⁻¹. Proof: normality gives g·c·g⁻¹ = c^k for some k : ℤ; conjugating twice with g·g = 1 gives c^(k²) = c, so k² ≡ 1 (mod p); primality factors p ∣ (1−k)(1+k), forcing k ≡ ±1. The concrete proof then observes a genuine transposition moves a 5-cycle to a different 5-cycle, killing both alternatives — but that part needs the permutation structure and stays in the concrete file.",
+    "mathContext": "$g c g^{-1} \\in \\langle c\\rangle; \\quad g^2 = 1 \\Rightarrow k^2 \\equiv 1\\ (\\mathrm{mod}\\ p) \\Rightarrow k \\equiv \\pm 1 \\Rightarrow g c g^{-1} \\in \\{c, c^{-1}\\}.$",
+    "significance": "key",
     "relatedConcepts": [
       "Normal.conj_mem",
-      "specialization to concrete orders",
-      "necessity of the divisibility hypothesis"
+      "involution acting by inversion",
+      "quadratic congruence mod a prime",
+      "transposition vs 5-cycle"
     ],
     "prerequisites": [
       "conjugation in a group",
-      "interval_cases on bounded divisors"
+      "zpow_eq_zpow_iff_modEq",
+      "prime factorization of x²−1"
+    ]
+  },
+  {
+    "id": "ann-automorphism-order",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 203, "endLine": 260 },
+    "type": "insight",
+    "title": "From Involutions to Arbitrary Automorphism Order",
+    "content": "The involution ±1 step is the order-2 case of a general phenomenon: conjugation by g is an automorphism of the cyclic group ⟨c⟩, i.e. an element of Aut(⟨c⟩) ≅ (ℤ/p)ˣ, whose order divides orderOf g. conj_pow_eq_zpow_pow makes this precise as pure group theory (no finiteness): if g·c·g⁻¹ = c^k then g^j·c·(g^j)⁻¹ = c^(k^j), because conjugation commutes with ℤ-powers (map_zpow of MulAut.conj) and iterating multiplies the exponent. conj_exponent_pow_modEq_one then specializes: for any g with g^n = 1, the exponent obeys k^n ≡ 1 (mod p). The involution lemma is exactly n = 2, where primality upgrades k² ≡ 1 to k ≡ ±1.",
+    "mathContext": "$g^j c g^{-j} = c^{k^j}; \\qquad g^n = 1 \\Rightarrow k^n \\equiv 1 \\ (\\mathrm{mod}\\ p), \\text{ i.e. } \\mathrm{ord}(k \\bmod p) \\mid \\mathrm{ord}(g).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "automorphism group of a cyclic group",
+      "(ℤ/p)ˣ",
+      "MulAut.conj and map_zpow",
+      "order of an automorphism divides order of the element"
+    ],
+    "prerequisites": [
+      "conjugation as an automorphism",
+      "ZMOD congruence",
+      "induction on the exponent"
+    ]
+  },
+  {
+    "id": "ann-nc-bound",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 261, "endLine": 362 },
+    "type": "key-step",
+    "title": "The N/C Bound: [G : C_G(c)] Divides p − 1",
+    "content": "Packaging the per-element automorphism constraint over all of G is Mathlib's conjugation action on the normal subgroup, MulAut.conjNormal : G →* Aut(⟨c⟩). conjNormal_ker_eq_centralizer identifies its kernel with the centralizer C_G(c) (an element acts trivially on ⟨c⟩ iff it commutes with c). Its image lies in the cyclic Aut(⟨c⟩) ≅ (ℤ/p)ˣ of order φ(p) = p − 1, so Noether's first isomorphism theorem plus Lagrange give conjNormal_ker_index_dvd_sub_one, hence centralizer_index_dvd_sub_one: [G : C_G(c)] ∣ p − 1. This is the sharp normalizer/centralizer (N/C) refinement of the involution ±1 step — the full automorphism-group constraint, not just the order-2 slice. huniq_of_lt records a reusable sufficient condition for the divisor hypothesis: if m < p then the only divisor of m that is ≡ 1 (mod p) is 1 (covers m = 2, 4 < 5; only m = 8 > 5 genuinely needs the divisibility, since 6 ≡ 1 mod 5 but 6 ∤ 8).",
+    "mathContext": "$\\ker(\\mathrm{conjNormal}) = C_G(c),\\ \\mathrm{im} \\hookrightarrow \\mathrm{Aut}(\\langle c\\rangle)\\cong(\\mathbb Z/p)^\\times,\\ |{\\cdot}| = p-1 \\;\\Rightarrow\\; [G:C_G(c)] \\mid p-1.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "normalizer/centralizer (N/C) theorem",
+      "MulAut.conjNormal",
+      "first isomorphism theorem",
+      "Lagrange's theorem",
+      "(ℤ/p)ˣ has order p − 1"
+    ],
+    "prerequisites": [
+      "centralizer of an element",
+      "kernel and image of a homomorphism",
+      "quotientKerEquivRange"
+    ]
+  },
+  {
+    "id": "ann-not-simple",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 364, "endLine": 449 },
+    "type": "insight",
+    "title": "Non-Simplicity and the Conjugacy-Class-Size Form",
+    "content": "The point of a normal Sylow p-subgroup is structural: zpowers_index_eq shows [G : ⟨c⟩] = m by pure counting, and not_isSimpleGroup_of_sylow concludes that when 1 < m the group is not simple — ⟨c⟩ is a proper nontrivial normal subgroup (neither ⊥, since orderOf c = p > 1, nor ⊤, since its index is m > 1). This is exactly why the Galois groups of orders 10, 20, 40 cannot be the simple A₅. The conjugacy-class-size form (orbit_conjAct_card_eq_centralizer_index, conjClass_card_dvd_sub_one) restates the N/C bound via orbit–stabilizer: the conjugation action of ConjAct G has orbit = conjugacy class of c and stabilizer = C_G(c), so |conj class of c| = [G : C_G(c)] ∣ p − 1.",
+    "mathContext": "$1 < m \\Rightarrow \\langle c\\rangle \\text{ proper nontrivial normal} \\Rightarrow \\neg\\,\\mathrm{IsSimpleGroup}\\ G; \\quad |\\mathrm{Cl}(c)| = [G:C_G(c)] \\mid p-1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "simple group",
+      "composition series",
+      "orbit–stabilizer theorem",
+      "ConjAct conjugation action"
+    ],
+    "prerequisites": [
+      "normal subgroup lattice of a simple group",
+      "conjugacy class as an orbit"
+    ]
+  },
+  {
+    "id": "ann-centrality-criterion",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 451, "endLine": 530 },
+    "type": "key-step",
+    "title": "Class Equation: Coprime Index Forces Centrality",
+    "content": "A second, orthogonal constraint on [G : C_G(c)] comes from the subgroup lattice: since c commutes with its own powers, ⟨c⟩ ≤ C_G(c) (zpowers_le_centralizer), so [G : C_G(c)] ∣ [G : ⟨c⟩] = m (centralizer_index_dvd_index_zpowers). Combined with the N/C bound this gives the sharp class-equation reading conjClass_card_dvd_gcd: |conj class of c| = [G : C_G(c)] ∣ gcd(m, p − 1). Its striking consequence mem_center_of_coprime_index: when gcd(m, p − 1) = 1 the gcd is 1, the conjugacy class of c is a singleton, and c ∈ Z(G). This is the elementary transfer-theoretic phenomenon behind Burnside's normal p-complement theorem read for a single element — no automorphism of ⟨c⟩ of order dividing p − 1 can be realized by conjugation when the conjugating room m is coprime to p − 1.",
+    "mathContext": "$[G:C_G(c)] \\mid \\gcd(m, p-1); \\qquad \\gcd(m, p-1) = 1 \\Rightarrow |\\mathrm{Cl}(c)| = 1 \\Rightarrow c \\in Z(G).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "class equation",
+      "centre of a group Z(G)",
+      "gcd bound on a conjugacy class",
+      "Burnside normal p-complement theorem"
+    ],
+    "prerequisites": [
+      "centralizer contains the element's powers",
+      "index divisibility along a subgroup chain",
+      "coprimality forces gcd 1"
+    ]
+  },
+  {
+    "id": "ann-global-structure",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 532, "endLine": 625 },
+    "type": "insight",
+    "title": "Global Structure: Central Sylow, p ∣ |Z(G)|, Internal Direct Product",
+    "content": "The single-element criterion promotes to the whole Sylow p-subgroup. zpowers_le_center_of_coprime_index: when gcd(m, p − 1) = 1 every power of c is central, so ⟨c⟩ ≤ Z(G). prime_dvd_card_center_of_coprime_index: Lagrange on ⟨c⟩ ≤ Z(G) forces p ∣ |Z(G)| — the centre is large. Internal direct product: since p ∤ m, Schur–Zassenhaus (exists_pComplement) supplies a complement H of order m to the normal ⟨c⟩; when ⟨c⟩ is central this complement is itself normal, so exists_normal_pComplement_of_coprime_index exhibits G as the internal direct product ⟨c⟩ × H of its central Sylow p-subgroup and a normal p-complement. In the coprime-index regime the order-p part splits off as a central direct factor — the elementary content of Burnside's normal p-complement theorem.",
+    "mathContext": "$\\gcd(m,p-1)=1 \\Rightarrow \\langle c\\rangle \\le Z(G) \\Rightarrow p \\mid |Z(G)|; \\quad p \\nmid m \\Rightarrow G = \\langle c\\rangle \\times H,\\ |H| = m.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Schur–Zassenhaus theorem",
+      "normal p-complement",
+      "internal direct product",
+      "central subgroup"
+    ],
+    "prerequisites": [
+      "complement of a normal subgroup",
+      "centre and Lagrange's theorem",
+      "coprime orders split"
+    ]
+  },
+  {
+    "id": "ann-fixed-prime-five",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 627, "endLine": 722 },
+    "type": "insight",
+    "title": "The Fixed Prime p = 5 and Recovering the Orders 10, 20, 40",
+    "content": "The original Abel–Ruffini application only needs p = 5. With the general lemmas in hand the specializations become one-liners: zpowers_order5_normal, conj_mem_zpowers_order5, not_isSimpleGroup_order5, and mem_center_order5_of_coprime_index each instantiate [Fact (Nat.Prime 5)] and apply the generic result. The three closing examples verify huniq for m = 2, 4, 8 — precisely the 5′-parts of the original orders 10 = 5·2, 20 = 5·4, 40 = 5·8. The m = 8 example is the instructive one: 6 ≡ 1 (mod 5), so the congruence alone would admit n₅ = 6; it is ruled out only because 6 ∤ 8, which is why huniq must require both d ∣ m and d % 5 = 1 (m = 2, 4 fall to huniq_of_lt since they are < 5).",
+    "mathContext": "$m \\in \\{2,4,8\\} \\Leftrightarrow |G| \\in \\{10,20,40\\}; \\qquad 6 \\equiv 1\\ (\\mathrm{mod}\\ 5)\\ \\text{but}\\ 6 \\nmid 8.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialization to a concrete prime",
+      "necessity of the divisibility hypothesis",
+      "Abel–Ruffini orders 10, 20, 40"
+    ],
+    "prerequisites": [
+      "instantiating a Fact typeclass",
+      "verifying huniq for small m"
+    ]
+  },
+  {
+    "id": "ann-solvability",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 723, "endLine": 821 },
+    "type": "insight",
+    "title": "Structural Consequence: Solvability",
+    "content": "The stronger payoff of a normal Sylow p-subgroup — the one driving 'solvable by radicals' — is solvability. isSolvable_zpowers: ⟨c⟩ is cyclic hence abelian hence solvable. isSolvable_of_normal_solvable_quotient: an extension of a solvable group by a solvable one is solvable. isSolvable_of_sylow_primePow_index: so G is solvable as soon as the index m = q^k, since the quotient G ⧸ ⟨c⟩ is then a q-group (nilpotent, hence solvable). This is the Abel–Ruffini obstruction read the other way: the candidate orders 10, 20, 40 for x⁵−4x+2 all have solvable (2-group) ⟨c⟩-quotients, so any group of that order would be solvable — whereas the genuine Galois group A₅ is not solvable. That mismatch rules the orders out and forces S₅. isSolvable_order5_primePow_index is the p = 5 specialization.",
+    "mathContext": "$1 \\to \\langle c\\rangle \\to G \\to G/\\langle c\\rangle \\to 1 \\text{ with both ends solvable} \\Rightarrow G \\text{ solvable}; \\quad m = q^k \\Rightarrow G/\\langle c\\rangle \\text{ nilpotent}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "solvable group",
+      "solvable extension",
+      "p-group is nilpotent",
+      "Abel–Ruffini obstruction"
+    ],
+    "prerequisites": [
+      "cyclic ⇒ abelian ⇒ solvable",
+      "solvability of extensions",
+      "quotient by a normal subgroup"
+    ]
+  },
+  {
+    "id": "ann-nilpotency",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 822, "endLine": 892 },
+    "type": "insight",
+    "title": "Sharp Strengthening: Nilpotency in the Coprime Regime",
+    "content": "Solvability holds for every prime-power index. In the special coprime regime gcd(q^k, p − 1) = 1 the centrality criterion places ⟨c⟩ inside Z(G), so the extension 1 → ⟨c⟩ → G → G ⧸ ⟨c⟩ → 1 is central. A central extension of a nilpotent group is nilpotent (Mathlib's isNilpotent_of_ker_le_center), and the q-group quotient is nilpotent, so isNilpotent_of_sylow_central_primePow_index concludes G is nilpotent, not merely solvable. This is the sharp boundary: the Abel–Ruffini orders 20 = 5·4 and 40 = 5·8 live in the non-coprime regime (gcd(4,4) = gcd(8,4) = 4 ≠ 1), where nilpotency genuinely fails — the Frobenius group F₂₀ = C₅ ⋊ C₄ of order 20 is solvable but not nilpotent (its Sylow 2-subgroup is not normal). The coprime hypothesis is exactly what upgrades solvable to nilpotent. isNilpotent_order5_central_primePow_index is the p = 5 form.",
+    "mathContext": "$\\gcd(q^k, p-1) = 1 \\Rightarrow \\langle c\\rangle \\le Z(G) \\Rightarrow \\text{central extension of a nilpotent } q\\text{-group} \\Rightarrow G \\text{ nilpotent}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "nilpotent group",
+      "central extension",
+      "Frobenius group F₂₀",
+      "solvable but not nilpotent"
+    ],
+    "prerequisites": [
+      "isNilpotent_of_ker_le_center",
+      "central vs non-central extension",
+      "coprimality gcd = 1"
+    ]
+  },
+  {
+    "id": "ann-abelian-classification",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 893, "endLine": 1089 },
+    "type": "insight",
+    "title": "From Central Sylow to Abelian: the Order-pq Classification",
+    "content": "In the prime-index subcase (k = 1) one can say strictly more: G is abelian. Once mem_center_of_coprime_index puts c in Z(G), zpowers_normal_of_mem_center makes ⟨c⟩ normal (so G ⧸ ⟨c⟩ is a group), and when the index is a prime q the quotient has prime order hence is cyclic (isCyclic_quotient_zpowers_of_prime_index); the classical 'G ⧸ Z(G) cyclic ⇒ G abelian' (through the central ⟨c⟩) gives commutativity (mul_comm_of_prime_index_coprime). This is the mechanism behind 'every group of order 15 is cyclic': 15 = 5·3, gcd(3,4) = 1 centralises the order-5 element and the order-3 quotient is cyclic (mul_comm_of_card_fifteen, isCyclic_of_card_fifteen). The general order-pq classification (mul_comm_of_card_eq_prime_mul_prime_of_not_dvd, dvd_sub_one_of_not_isCyclic_card_eq_prime_mul_prime) gives the sharp converse: an order-pq group is cyclic unless q ∣ p − 1 — recovering isCyclic_of_card_thirtyfive (35 = 5·7) and isCyclic_of_card_thirtythree (33 = 3·11).",
+    "mathContext": "$c \\in Z(G),\\ [G:\\langle c\\rangle] = q \\text{ prime} \\Rightarrow G/\\langle c\\rangle \\text{ cyclic} \\Rightarrow G \\text{ abelian}; \\quad |G| = pq \\text{ cyclic} \\iff q \\nmid p-1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "G/Z(G) cyclic ⇒ G abelian",
+      "classification of groups of order pq",
+      "every group of order 15 is cyclic",
+      "cyclic iff q ∤ p − 1"
+    ],
+    "prerequisites": [
+      "central quotient theorem",
+      "prime-order quotient is cyclic",
+      "product of two distinct primes"
+    ]
+  },
+  {
+    "id": "ann-direct-product-endgame",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-03",
+    "range": { "startLine": 1090, "endLine": 1281 },
+    "type": "theorem",
+    "title": "Structural Endgame: the Internal Direct Product G ≃* ⟨c⟩ × H",
+    "content": "The final section upgrades the set-level splitting to a genuine group isomorphism. exists_mulEquiv_prod_zpowers_of_coprime_index produces, in the coprime-index regime, an explicit MulEquiv G ≃* ⟨c⟩ × H onto the direct product of the central Sylow p-subgroup and its normal p-complement — not merely |G| = |⟨c⟩|·|H| but the multiplicative structure itself. exists_mulEquiv_prod_of_card_fifteen instantiates it at order 15. The closing biconditionals exists_pComplement_isCyclic_iff and exists_pComplement_isNilpotent_iff characterize exactly when the complement can be taken cyclic / nilpotent, with their order-15 forms — the complete structural picture of the coprime-index regime that the humble Sylow-normality skeleton unlocks.",
+    "mathContext": "$G \\simeq^* \\langle c\\rangle \\times H \\text{ (internal direct product, central Sylow } \\times \\text{ normal complement)}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "MulEquiv group isomorphism",
+      "internal direct product decomposition",
+      "cyclic / nilpotent complement",
+      "structure theorem for the coprime regime"
+    ],
+    "prerequisites": [
+      "direct product of groups",
+      "normal complement and centrality",
+      "MulEquiv construction"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass on `abel-ruffini-oq-04-oq-01-oq-03` (Sylow-elimination lemmas, 1282-line Lean file).

**Defect found:** two annotations were **stale** after the file was generalized from the fixed prime 5 to an arbitrary prime `p`. `ann-statement` (lines 51–62) described `zpowers_order5_normal` with `Nat.card G = 5*m`, but that line range now holds the *generic* `zpowers_sylow_normal` (`p*m`); `ann-corollary-and-examples` described the p=5 corollary and the 10/20/40 examples, which have since moved to lines 639–722.

**Fix + enrichment:** corrected both stale annotations and added 10 annotations covering the previously-unannotated structural arc (lines 203–1281). Coverage **11% → 99%** (5 → 15 annotations):
- automorphism-order generalization (conjugation as an element of Aut(⟨c⟩) ≅ (ℤ/p)ˣ)
- the N/C bound [G:C_G(c)] ∣ p−1 (conjNormal kernel = centralizer, Noether + Lagrange)
- non-simplicity + the conjugacy-class-size form
- coprime-index centrality (class equation, gcd(m, p−1) = 1 ⇒ c ∈ Z(G))
- central Sylow, p ∣ |Z(G)|, Schur–Zassenhaus internal direct product
- the p = 5 specializations recovering orders 10/20/40
- solvability (the Abel–Ruffini engine)
- the sharp nilpotency upgrade in the coprime regime (F₂₀ boundary)
- the order-pq abelian classification (order 15/33/35)
- the internal direct-product isomorphism G ≃* ⟨c⟩ × H

Each carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, matching the existing style. Ranges verified within the 1282-line file; `pnpm build` passes.