### PR TITLE
research(erdos-1022-oq-02): two-sided exponential bracket for sparseness coefficient

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -475,4 +475,31 @@ theorem admissibleCoeff_ge_two_pow_of_le (hV : 0 < Fintype.card V) (t : ℕ) (ht
         Nat.mul_le_mul (le_refl _) hpos
     _ ≤ firstMomentThreshold (t + k) / Fintype.card V := hmul
 
+/-- **Two-sided exponential bracket (the exact multi-step growth rate).**  The
+    capstone conjunction promised in the docstrings of the two iterate bounds:
+    combining the geometric lower bound `admissibleCoeff_two_pow_mul_le` with the
+    ceiling `admissibleCoeff_succ_le_two_pow_mul` pins the coefficient after `k`
+    steps to a window of width exactly `2^k − 1` around pure `2^k`-doubling,
+
+        `2^k · c(t)  ≤  c(t + k)  ≤  2^k · c(t) + (2^k − 1)`,
+
+    i.e. `0 ≤ c(t+k) − 2^k·c(t) < 2^k`.  The additive slack `2^k − 1` is the
+    geometric sum `∑_{i<k} 2^i` of the `k` per-step truncated-division remainders,
+    so relative to the leading `2^k·c(t)` the error is at most one unit of `c(t)`:
+    the growth rate is **exactly exponential with ratio `2`**, the floor operations
+    contributing only a bounded lower-order correction.  The lower half is
+    `admissibleCoeff_two_pow_mul_le`; the upper half rewrites the `+1`-shifted
+    ceiling `admissibleCoeff_succ_le_two_pow_mul` by distributing `2^k·(c(t)+1)`
+    and discharging with `omega` (using `1 ≤ 2^k`). -/
+theorem admissibleCoeff_bracket (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 ≤ t) (k : ℕ) :
+    2 ^ k * (firstMomentThreshold t / Fintype.card V)
+        ≤ firstMomentThreshold (t + k) / Fintype.card V
+      ∧ firstMomentThreshold (t + k) / Fintype.card V
+        ≤ 2 ^ k * (firstMomentThreshold t / Fintype.card V) + (2 ^ k - 1) := by
+  have hlow := admissibleCoeff_two_pow_mul_le hV t ht k
+  have hup := admissibleCoeff_succ_le_two_pow_mul hV t ht k
+  rw [mul_add, mul_one] at hup
+  have hpow : 1 ≤ 2 ^ k := Nat.one_le_two_pow
+  exact ⟨hlow, by omega⟩
+
 end Erdos1022OQ02

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 478,
+    "lineCount": 505,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 18,
+    "theoremCount": 21,
     "definitionCount": 3
   },
   "overview": {
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 478,
+    "lineCount": 505,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 21,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

Adds `admissibleCoeff_bracket` to `Erdos1022OQ02.lean` — the capstone conjunction that **both** existing iterate-bound docstrings explicitly promise but never stated as a single result.

The file already proves, separately:
- `admissibleCoeff_two_pow_mul_le` (geometric **lower** bound): `2^k·c(t) ≤ c(t+k)`
- `admissibleCoeff_succ_le_two_pow_mul` (`+1`-shifted **upper** ceiling): `c(t+k)+1 ≤ 2^k·(c(t)+1)`

The new theorem combines them into the two-sided window, for `c(t) = ⌊2^{t-1}/|V|⌋`:

```
2^k·c(t)  ≤  c(t+k)  ≤  2^k·c(t) + (2^k − 1)
```

equivalently `0 ≤ c(t+k) − 2^k·c(t) < 2^k`. The additive slack `2^k − 1` is exactly the geometric sum `∑_{i<k} 2^i` of the `k` per-step truncated-division remainders, so the growth rate is **exactly exponential with ratio 2**, the floor operations contributing only a bounded lower-order correction. This is the precise "exponential up to bounded relative error" claim the module's docstring makes prose-only.

## Proof

One-line `omega` assembly of the two verified sibling lemmas: `rw [mul_add, mul_one]` distributes `2^k·(c(t)+1)`, then `omega` closes both conjuncts using `1 ≤ 2^k`. **0 sorries, 0 axioms.** No `native_decide`.

Also syncs stale gallery meta counts to source (`lineCount` 478→505, `theoremCount` 18→21 in both `leanFile` blocks).

## Verification

⚠️ **UNVERIFIED** — docker build infra is down (containerd `meta.db` input/output error; `docker images` itself errors). Not disk-full (158Gi free). The added proof is a trivial `omega` assembly of already-verified lemmas mirroring the file's existing iterate-bound style; high confidence in elaboration. Flag for a clean-infra rebuild before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)