### PR TITLE
research(erdos-703-incomplete-01): activate the L-avoiding (Frankl–Wilson) predicate

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -602,6 +602,47 @@ have intersection size in L.
 def avoidsLIntersections (L : Finset ℕ) (F : Finset (Finset ℕ)) : Prop :=
   ∀ A B : Finset ℕ, A ∈ F → B ∈ F → (A ∩ B).card ∉ L
 
+/--
+**Single-forbidden-size is `r`-avoidance.** The `L`-avoiding predicate specializes to
+`avoidsRIntersection r` exactly when `L = {r}`: forbidding the single intersection size
+`r` is the same as avoiding `r`-intersection. This is the bridge that places
+`avoidsRIntersection` inside the Frankl–Wilson `L`-avoiding hierarchy.
+-/
+theorem avoidsRIntersection_iff_avoidsLIntersections_singleton
+    (r : ℕ) (F : Finset (Finset ℕ)) :
+    avoidsRIntersection r F ↔ avoidsLIntersections {r} F := by
+  unfold avoidsRIntersection avoidsLIntersections
+  simp only [Finset.mem_singleton, ne_eq]
+
+/--
+**Monotone in the family (subfamily closure).** Any subfamily of an `L`-avoiding
+family is again `L`-avoiding: the constraint on pairs is inherited by any subset.
+-/
+theorem avoidsLIntersections_of_subset_family
+    {L : Finset ℕ} {F F' : Finset (Finset ℕ)} (hsub : F' ⊆ F)
+    (hF : avoidsLIntersections L F) : avoidsLIntersections L F' :=
+  fun A B hA hB => hF A B (hsub hA) (hsub hB)
+
+/--
+**Antitone in the forbidden-size set.** Forbidding a *larger* set of intersection
+sizes is a stronger condition: if `F` avoids every size in `L'` and `L ⊆ L'`, then `F`
+avoids every size in `L`. Combined with the singleton bridge this recovers, e.g., that
+an `L`-avoiding family with `r ∈ L` is in particular `r`-avoiding.
+-/
+theorem avoidsLIntersections_of_subset_forbidden
+    {L L' : Finset ℕ} {F : Finset (Finset ℕ)} (hL : L ⊆ L')
+    (hF : avoidsLIntersections L' F) : avoidsLIntersections L F :=
+  fun A B hA hB hmem => hF A B hA hB (hL hmem)
+
+/--
+**Every family avoids the empty set of sizes.** The vacuous base case of the
+hierarchy: with no forbidden intersection sizes there is nothing to avoid.
+-/
+theorem avoidsLIntersections_empty (F : Finset (Finset ℕ)) :
+    avoidsLIntersections ∅ F := by
+  intro A B _ _
+  simp
+
 /-
 ## Part VIII: Summary
 -/

--- a/research/problems/erdos-703-incomplete-01/knowledge.md
+++ b/research/problems/erdos-703-incomplete-01/knowledge.md
@@ -18,3 +18,27 @@ Initial knowledge for problem `erdos-703-incomplete-01`.
 
 - Gallery: `src/data/proofs/erdos-703/`
 - Lean source: `proofs/Proofs/` (check namespace `Erdos703`)
+
+## Session (researcher-1, 2026-07-09): activate the L-avoiding predicate
+
+**Mode**: REVISIT (MODERATE) · **Outcome**: progress (4 theorems, UNVERIFIED —
+docker corrupted). Branch `research/erdos703-lavoiding-lemmas`.
+
+The state's suggested "next action" (even-parity Frankl–Füredi family) was already
+done by a later session (`franklFurediEven_avoids_r` / `_card_le_T` exist). The one
+genuinely-dead object left was `avoidsLIntersections` (Part VII, Frankl–Wilson
+`L`-avoiding predicate): defined but with **zero lemmas**. Added its basic API:
+- `avoidsRIntersection_iff_avoidsLIntersections_singleton (r F)`: `r`-avoidance ↔
+  `{r}`-avoidance. `unfold` both, `simp only [Finset.mem_singleton, ne_eq]`
+  (needed `ne_eq` to normalize `≠` to `¬ =` on both sides).
+- `avoidsLIntersections_of_subset_family (hsub : F' ⊆ F)`: term-mode
+  `fun A B hA hB => hF A B (hsub hA) (hsub hB)` (Finset subset applies as a function).
+- `avoidsLIntersections_of_subset_forbidden (hL : L ⊆ L')`: antitone in the forbidden
+  set, `fun A B hA hB hmem => hF A B hA hB (hL hmem)`.
+- `avoidsLIntersections_empty`: `intro A B _ _; simp` (`x ∉ ∅`).
+
+Gallery meta `erdos-703` synced (both blocks): lineCount 638→679, theoremCount 21→25;
+axiomCount stays 1 (`frankl_rodl_1987` untouched).
+
+**BLOCKER:** docker corrupted fleet-wide (containerd `meta.db` I/O error at image
+build). UNVERIFIED; proofs are trivial membership facts, correct by inspection.

--- a/research/problems/erdos-703-incomplete-01/state.md
+++ b/research/problems/erdos-703-incomplete-01/state.md
@@ -4,34 +4,35 @@
 
 **Phase**: ACT
 **Status**: Active
-**Last Updated**: 2026-07-08
+**Last Updated**: 2026-07-09
 
 ## Progress Summary
 
-The gallery file `Erdos703Problem.lean` has **0 real sorries** (the only `sorry`
-token is inside a docstring) and **1 deep axiom** (`frankl_rodl_1987`, the
-Frankl–Rödl 1987 exponential bound — genuinely open-literature, not
-Mathlib-eliminable). The stale "1 sorry / 2 axioms" in the seed metadata was
-incorrect.
+`Erdos703Problem.lean` has **0 real sorries** and **1 deep axiom**
+(`frankl_rodl_1987`, genuinely open-literature). Prior sessions built the
+Frankl–Füredi odd/even families and their `T(n,r)` lower bounds, the `T(n,0)`
+and `T(n,n)` exact values, and the small-`r` / `n<r` regimes.
 
-This session added verified content around the previously **defined-but-unused**
-Frankl–Füredi families:
+This session **activated the previously dead `avoidsLIntersections` predicate**
+(Part VII, the Frankl–Wilson `L`-avoiding generalization, which had a definition
+but zero lemmas):
 
-- `franklFurediOdd_avoids_r (n r)` : the family `{A ⊆ [n] : |A| > (n+r)/2 ∨ |A| < r}`
-  is a valid `r`-avoiding family, for **all** `r` (both parities of `n+r`).
-  Generalizes the existing `r = 1` result `large_sets_avoid_1`.
-- `franklFurediOdd_card_le_T (n r)` : consequently `|franklFurediOdd n r| ≤ T(n,r)`,
-  the general-`r` analogue of `largeSetsFamily_card_le_T`.
-
-Build: `docker-build.sh Proofs.Erdos703Problem` → 7743 jobs, 0 errors, 0 sorries.
+- `avoidsRIntersection_iff_avoidsLIntersections_singleton` — `r`-avoidance is
+  exactly `{r}`-avoidance (the bridge into the Frankl–Wilson hierarchy).
+- `avoidsLIntersections_of_subset_family` — monotone under subfamily.
+- `avoidsLIntersections_of_subset_forbidden` — antitone in the forbidden-size set.
+- `avoidsLIntersections_empty` — vacuous base case.
 
 ## Blockers
 
-The main question (`mainQuestion` / `frankl_rodl_1987`) is a deep 1987 theorem
-with no Mathlib pathway; it remains an axiom. Not eliminable this session.
+`mainQuestion` / `frankl_rodl_1987` is the deep 1987 exponential bound with no
+Mathlib pathway; it remains an axiom, untouched. Docker daemon corrupted this
+session (containerd `meta.db` I/O error at image build) → shipped UNVERIFIED;
+the four new lemmas are trivial Finset-membership facts, correct by inspection.
 
 ## Next Action
 
-Optional: prove `franklFurediEven` avoids `r`-intersection under `Even (n + r)`
-(the parity-matched optimal family), and/or a Frankl–Füredi exactness statement
-for fixed `r` and large `n`.
+Re-verify once docker repaired:
+`./proofs/scripts/docker-build.sh Proofs.Erdos703Problem`. Further `L`-avoiding
+API (e.g. an `avoidsLIntersections`-indexed analogue of `T`) is possible but the
+core problem is otherwise mature around the standing axiom.

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -52,10 +52,10 @@
       "Structural lemmas on T: T_le_pow (T(n,r) ≤ 2^n), T_mono_ground (monotone in the ground-set size n), one_le_T (positivity), and full_powerset_avoids_r_of_lt / T_eq_pow_of_lt (T(n,r) = 2^n whenever n < r); plus largeSetsFamily_subset_franklFurediOdd_one linking Frankl's r=1 family into the general Frankl-Füredi construction."
     ],
     "axiomCount": 1,
-    "lineCount": 638,
+    "lineCount": 679,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 21,
+    "theoremCount": 25,
     "definitionCount": 8
   },
   "crossReferences": [
@@ -182,9 +182,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 638,
+    "lineCount": 679,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 25,
     "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Activates the previously **dead** `avoidsLIntersections` predicate in `Erdos703Problem.lean` (Part VII — the Frankl–Wilson `L`-avoiding generalization of forbidden `r`-intersection). It had a definition but zero lemmas; this adds its basic API.

## What's new (4 theorems)

- `avoidsRIntersection_iff_avoidsLIntersections_singleton (r F)` — `r`-avoidance is exactly `{r}`-avoidance, the bridge placing `avoidsRIntersection` inside the Frankl–Wilson hierarchy.
- `avoidsLIntersections_of_subset_family` — monotone under subfamily: any subfamily of an `L`-avoiding family is `L`-avoiding.
- `avoidsLIntersections_of_subset_forbidden` — antitone in the forbidden-size set: `L ⊆ L'` and `L'`-avoiding ⟹ `L`-avoiding.
- `avoidsLIntersections_empty` — the vacuous base case (no forbidden intersection sizes).

Orthogonal to the deep `frankl_rodl_1987` axiom, which is untouched.

## Verification status

⚠️ **UNVERIFIED.** The docker build daemon was corrupted this session (`write /var/lib/desktop-containerd/.../meta.db: input/output error` at image-build time) — elaboration never ran. Environment/operator issue, not a proof error; per protocol I did not self-prune shared docker caches.

All four proofs are trivial `Finset`-membership manipulations (correct by inspection). Re-verify when docker is repaired: `./proofs/scripts/docker-build.sh Proofs.Erdos703Problem`.

0 real sorries; 1 pre-existing axiom (`frankl_rodl_1987`, unchanged). Gallery meta `erdos-703` counts synced (638→679 lines, 21→25 theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)