### PR TITLE
research(szemeredi-regularity-oq-01): singleton partition has zero irregular pairs

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ01.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ01.lean
@@ -366,4 +366,21 @@ theorem card_irregularOrderedPairs_le (G : SimpleGraph V) [DecidableRel G.Adj]
         Finset.card_le_card (irregularOrderedPairs_subset_offDiag G eps parts)
     _ = parts.card * parts.card - parts.card := Finset.offDiag_card parts
 
+/-- **A partition with at most one part has no irregular pairs.**  The base case
+    of any regularity-partition induction: with `#parts ≤ 1` there are no two
+    *distinct* parts to be irregular, so the ordered irregular set is empty.
+    Reads off the trivial upper bound `card_irregularOrderedPairs_le` at
+    `parts.card ≤ 1`, where the off-diagonal ceiling `n·n − n` collapses to `0`.
+    Pairs with `card_irregularOrderedPairs_le` (the general ceiling) to pin the
+    count exactly at the degenerate end of the range. -/
+theorem card_irregularOrderedPairs_eq_zero_of_card_le_one
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (parts : Finset (Finset V)) (h : parts.card ≤ 1) :
+    (irregularOrderedPairs G eps parts).card = 0 := by
+  have hle := card_irregularOrderedPairs_le G eps parts
+  have hz : parts.card * parts.card - parts.card = 0 := by
+    interval_cases parts.card <;> decide
+  rw [hz] at hle
+  exact Nat.le_zero.mp hle
+
 end Szemeredi.Regularity.OQ01


### PR DESCRIPTION
## Summary

Adds `card_irregularOrderedPairs_eq_zero_of_card_le_one` to `SzemerediRegularityOQ01.lean` — the **base case** of any regularity-partition induction, which the file's chain of irregular-pair bounds was missing.

The file proves the general ceiling `card_irregularOrderedPairs_le`: `#irregular ≤ n·n − n` for `n = #parts` (via the off-diagonal embedding). The new lemma pins the degenerate end:

```
#parts ≤ 1  ⟹  (irregularOrderedPairs G eps parts).card = 0
```

Irregularity requires two **distinct** parts (`P ≠ Q` in the defining filter), so a partition with at most one part has none. The proof reads this off the existing verified bound: at `#parts ≤ 1` the off-diagonal ceiling `n·n − n` collapses to `0` (`interval_cases` + `decide`), then `Nat.le_zero.mp`. Together with `card_irregularOrderedPairs_le` this brackets the count exactly at the small-`n` end of the range.

## Proof

3-line assembly on top of the verified `card_irregularOrderedPairs_le`. **0 sorries, 0 axioms.**

## Verification

⚠️ **UNVERIFIED** — docker build infra is down (containerd `meta.db` input/output error; `docker images` itself errors). Not disk-full (158Gi free). The proof is a robust `interval_cases`/`decide` reduction of an already-verified lemma; high confidence. Flag for a clean-infra rebuild before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)