### PR TITLE
research(puiseux-theorem-wip-01): complete Puiseux closure family — subtraction + powers [UNVERIFIED — docker infra I/O failure]

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -710,6 +710,25 @@ theorem isPuiseux_mul {K : Type*} [NonUnitalNonAssocSemiring K] {f g : HahnSerie
   rw [div_add_div _ _ hn0 hm0, div_eq_div_iff (mul_ne_zero hn0 hm0) (mul_ne_zero hn0 hm0)]
   ring
 
+/-- **Closure under subtraction.** `f - g = f + (-g)`, so subtraction closure is
+immediate from `isPuiseux_add` and `isPuiseux_neg`; it completes the additive-group
+closure family (the missing companion to `isPuiseux_add` / `isPuiseux_neg`). -/
+theorem isPuiseux_sub {K : Type*} [AddCommGroup K] {f g : HahnSeries ℚ K}
+    (hf : IsPuiseuxSeries f) (hg : IsPuiseuxSeries g) :
+    IsPuiseuxSeries (f - g) := by
+  rw [sub_eq_add_neg]
+  exact isPuiseux_add hf (isPuiseux_neg hg)
+
+/-- **Closure under natural-number powers.** `f ^ k` is a Puiseux series, by induction
+from `isPuiseux_mul` and `isPuiseux_one` (`f ^ 0 = 1`). The multiplicative companion of
+`isPuiseux_add`'s iterated form; specializes the subring's `pow_mem` to a standalone,
+instance-light lemma. -/
+theorem isPuiseux_pow {K : Type*} [Semiring K] {f : HahnSeries ℚ K}
+    (hf : IsPuiseuxSeries f) (k : ℕ) : IsPuiseuxSeries (f ^ k) := by
+  induction k with
+  | zero => rw [pow_zero]; exact isPuiseux_one
+  | succ k ih => rw [pow_succ]; exact isPuiseux_mul ih hf
+
 /-- **The Puiseux series form a subring of `HahnSeries ℚ K`.**
 
 Bundling the five closure facts above, `{f : HahnSeries ℚ K | IsPuiseuxSeries f}`

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -173,9 +173,9 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 1068,
+    "lineCount": 1087,
     "axiomCount": 0,
-    "theoremCount": 34,
+    "theoremCount": 36,
     "definitionCount": 7,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`PuiseuxTheorem.lean` (Wiedijk #41) is verified and complete (0 sorries, 0 axioms). Its `isPuiseux_*` closure family — `zero`, `one`, `add`, `neg`, `mul`, `inv` — was missing the two natural companions. This adds them (both axiom-free; file stays 0-sorry/0-axiom):

- **`isPuiseux_sub`** — `f - g` is a Puiseux series. `f - g = f + (-g)`, so immediate from `isPuiseux_add` + `isPuiseux_neg`; completes the additive-group closure family.
- **`isPuiseux_pow`** — `f ^ k` is a Puiseux series, by induction from `isPuiseux_mul` and `isPuiseux_one` (`f^0 = 1`, `f^(k+1) = f^k · f`). A standalone, instance-light companion to the subring's `pow_mem`.

Synced gallery `meta.json` leanFile counts (lineCount 1068→1087, theoremCount 34→36). Still 0 sorries, 0 axioms.

## Verification

⚠️ **UNVERIFIED — docker infrastructure failure.** `./proofs/scripts/docker-build.sh Proofs.PuiseuxTheorem` fails at the image-build stage with a host-level containerd error (`write /var/lib/desktop-containerd/.../meta.db: input/output error`) — persistent across the session, no Lean elaboration reached. Disk had 27Gi free (not disk-full); containerd metadata corruption needing operator cleanup.

Manual confidence is high: `isPuiseux_sub` is `rw [sub_eq_add_neg]; exact isPuiseux_add hf (isPuiseux_neg hg)` (`AddCommGroup K` supplies the `AddCommMonoid`/`AddGroup` instances the two lemmas need). `isPuiseux_pow` is the standard `pow_zero`/`pow_succ` induction closing with `isPuiseux_one`/`isPuiseux_mul` (`Semiring K` supplies all instances). Please re-run the docker build once containerd is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)