### PR TITLE
Research: erdos-659-incomplete-01 — representability = norm of ℤ[√-2] (+ stale-sorry finding)

### DIFF
--- a/proofs/Proofs/Erdos659OQ05.lean
+++ b/proofs/Proofs/Erdos659OQ05.lean
@@ -79,6 +79,23 @@ theorem isRepresented_mul {m n : ℤ} (hm : IsRepresented m) (hn : IsRepresented
   obtain ⟨c, d, rfl⟩ := hn
   exact ⟨a * c - 2 * b * d, a * d + b * c, Q_mul a b c d⟩
 
+/-- **Representability = being a norm of `ℤ[√-2]`.**
+
+An integer `n` is represented by `Q(x, y) = x² + 2y²` if and only if it is the
+`Zsqrtd` norm of some element of `ℤ√(-2)`.  This identifies the represented set
+with the *image of the norm map* `ℤ√(-2) → ℤ`, and is the conceptual reason for
+the multiplicative closure `isRepresented_mul`: `Zsqrtd.norm` is a monoid
+homomorphism, so its image is closed under multiplication.  Concretely it upgrades
+the coordinate-level composition law `Q_mul` to the statement that the represented
+integers are exactly `Set.range (Zsqrtd.norm : ℤ√(-2) → ℤ)`. -/
+theorem isRepresented_iff_isNorm {n : ℤ} :
+    IsRepresented n ↔ ∃ z : ℤ√(-2), Zsqrtd.norm z = n := by
+  constructor
+  · rintro ⟨x, y, rfl⟩
+    exact ⟨⟨x, y⟩, Q_eq_zsqrtd_norm x y⟩
+  · rintro ⟨z, rfl⟩
+    exact ⟨z.re, z.im, (Q_eq_zsqrtd_norm z.re z.im).symm⟩
+
 /-- The integers represented by `Q` form a submonoid of `(ℤ, ·)`. -/
 def representedSubmonoid : Submonoid ℤ where
   carrier := {n | IsRepresented n}

--- a/research/problems/erdos-659-incomplete-01/knowledge.md
+++ b/research/problems/erdos-659-incomplete-01/knowledge.md
@@ -1,5 +1,35 @@
 # Knowledge: erdos-659-incomplete-01
 
+## Session 2026-07-09 (researcher-3) — representability = norm of ℤ[√-2]; the "1 sorry" is a STALE FALSE POSITIVE
+
+**Finding (integrity):** the problem title "Point Configurations with Few Distances (1 sorry)"
+and the overview "Sorries: 1" are STALE/FALSE. All five Erdős-659 files are genuinely
+sorry-free: `grep -nE '\bsorry\b'` matches only docstring occurrences of "sorry-free"
+(Problem/OQ01/OQ01OQ02/OQ05) and "`sorry`-free" (OQ06). The real sorry was resolved on
+2026-06-25 (researcher-10, `fourPointProperty_from_avoiding_configs`). The problem sits at its
+axiomatized terminus: the only remaining assumptions are the deep Landau density axioms
+(`moreeOsburnWorks` in Problem.lean; `uniform_landau_lower_bound`, `moreeosburn_upper_bound`
+in OQ01.lean), genuinely out of reach in Mathlib 4.26 (no analytic density machinery).
+
+**Added (Erdos659OQ05.lean):** `isRepresented_iff_isNorm` —
+`IsRepresented n ↔ ∃ z : ℤ√(-2), Zsqrtd.norm z = n`. This identifies the integers represented
+by `Q(x,y) = x²+2y²` with the *image of the norm map* on `ℤ[√-2]`, i.e. the conceptual reason
+`isRepresented_mul` holds (`Zsqrtd.norm` is a monoid homomorphism → its image is
+multiplicatively closed). Upgrades the coordinate-level composition law `Q_mul` to the
+`Set.range Zsqrtd.norm` characterization. 1 theorem, 0 axioms, 0 sorries.
+
+Proof: forward `rintro ⟨x,y,rfl⟩ ⇒ ⟨⟨x,y⟩, Q_eq_zsqrtd_norm x y⟩`; reverse
+`rintro ⟨z,rfl⟩ ⇒ ⟨z.re, z.im, (Q_eq_zsqrtd_norm z.re z.im).symm⟩` (Zsqrtd structure eta:
+`z` defeq `⟨z.re, z.im⟩`).
+
+BUILD: UNVERIFIED. Docker fails fleet-wide at the image-build step (containerd meta.db I/O
+error, operator-level corruption). High elaboration confidence — uses only the verified
+`Q_eq_zsqrtd_norm` and structure eta. OQ05 counts: lineCount 125→142, theoremCount 9→10.
+
+---
+
+# Knowledge: erdos-659-incomplete-01
+
 ## Overview
 
 Initial knowledge for problem `erdos-659-incomplete-01`.

--- a/src/data/research/problems/erdos-659-incomplete-01.json
+++ b/src/data/research/problems/erdos-659-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-659-incomplete-01",
   "title": "Erdős #659: Point Configurations with Few Distances (1 sorry)",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -29,15 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "UPDATE (researcher-5, 2026-07-08): extended the multiplicative-structure section of the norm form x²+2y² with three verified closure lemmas: sq_representable (every perfect square n²=n²+2·0² is representable), representable_pow (powers mᵏ of a representable m stay representable — induction from representable_mul + one_representable), and two_pow_representable (every 2ᵏ is representable). The last makes precise the claim already asserted in the representable_mul docstring ('every power of 2 is representable') but not previously proved. All 0-axiom / 0-sorry, docker-build verified (3058 jobs, Mathlib v4.26.0). The Landau axiom moreeOsburnWorks and the isConfiguration True-placeholders are untouched (out of scope). COMPLETION: dangling sorry resolved (file now 0-sorry, 1-axiom, compiles clean after fixing 5 floating doc-comments). Added verified positive-definiteness lemmas for x²+2y². Main result erdos_659 remains axiomatized on moreeOsburnWorks (Landau theorem, not in Mathlib).",
+    "progressSummary": "AT AXIOMATIZED TERMINUS. All 5 Erdos659 files sorry-free (the 'incomplete-01/1 sorry' title is a stale false positive — grep matches only docstring 'sorry-free'; real sorry resolved 2026-06-25). Remaining assumptions = deep Landau density axioms, out of reach in Mathlib 4.26. researcher-3 (2026-07-09) added isRepresented_iff_isNorm to Erdos659OQ05.lean: represented integers = norm image of ℤ[√-2] (the conceptual source of multiplicative closure). 1 theorem, 0 axioms, 0 sorries. UNVERIFIED-by-build (docker containerd meta.db I/O corruption fleet-wide); high elaboration confidence (rintro + existing Q_eq_zsqrtd_norm, structure eta on Zsqrtd).",
     "builtItems": [
       "latticeDistSq_symm / latticeDistSq_nonneg / latticeDistSq_eq_zero_iff in Erdos659Problem.lean (positive-definiteness of x²+2y²)",
       "Verified fourPointProperty_from_avoiding_configs (0 sorries) with explicit lower-bound hypothesis",
-      "sq_representable / representable_pow / two_pow_representable: closure of the x²+2y² representable set under squares and powers; completes the 'every power of 2 is representable' claim from the representable_mul docstring."
+      "sq_representable / representable_pow / two_pow_representable: closure of the x²+2y² representable set under squares and powers; completes the 'every power of 2 is representable' claim from the representable_mul docstring.",
+      "isRepresented_iff_isNorm (researcher-3, 2026-07-09) in Erdos659OQ05.lean: IsRepresented n ↔ ∃ z:ℤ√(-2), Zsqrtd.norm z = n — identifies represented integers with the norm image of ℤ[√-2] (conceptual reason for isRepresented_mul: norm is a monoid hom)."
     ],
     "insights": [
       "The original fourPointProperty_from_avoiding_configs was false under the product/Chebyshev metric on ℝ×ℝ: unit-square corners (0,0),(1,0),(0,1),(1,1) are mutually equidistant (sup-distance 1), so distinctDistances=1 while avoiding every named 2-distance config. A geometric lower bound (2 ≤ distinctDistances on 4-subsets) is required and now explicit.",
-      "The defining form x²+2y² is positive-definite over ℤ (latticeDistSq_eq_zero_iff), so distinct lattice points have positive squared distance — verified independently of the deep axiom."
+      "The defining form x²+2y² is positive-definite over ℤ (latticeDistSq_eq_zero_iff), so distinct lattice points have positive squared distance — verified independently of the deep axiom.",
+      "The 'incomplete-01 (1 sorry)' label is STALE/FALSE: all 5 Erdos659 files (Problem/OQ01/OQ01OQ02/OQ05/OQ06) are genuinely sorry-free (grep 'sorry' matches only docstring 'sorry-free'). The real sorry was resolved 2026-06-25 (researcher-10). Remaining assumptions are deep Landau density axioms (moreeOsburnWorks, uniform_landau_lower_bound, moreeosburn_upper_bound) — out of reach in Mathlib."
     ],
     "mathlibGaps": [
       "Landau (1908) asymptotic count of integers representable as x²+2y² (~N/√log N) — not in Mathlib 4.26; blocks eliminating moreeOsburnWorks"


### PR DESCRIPTION
## Summary
Adds a norm-form characterization to the (axiom-free) OQ-05 file of Erdős #659, and documents that the problem's "1 sorry" label is a stale false positive.

## Progress
**`isRepresented_iff_isNorm`** (in `Erdos659OQ05.lean`):
```
IsRepresented n ↔ ∃ z : ℤ√(-2), Zsqrtd.norm z = n
```
This identifies the integers represented by `Q(x,y) = x² + 2y²` with the **image of the norm map** `ℤ√(-2) → ℤ`. It is the conceptual reason for the existing multiplicative closure `isRepresented_mul`: `Zsqrtd.norm` is a monoid homomorphism, so its image is closed under multiplication. It upgrades the coordinate-level composition law `Q_mul` to the `Set.range Zsqrtd.norm` characterization.

- 1 theorem, **0 axioms, 0 sorries**. Proof: `rintro` + the already-verified `Q_eq_zsqrtd_norm` + `Zsqrtd` structure eta.

## Findings
**The `incomplete-01` / "1 sorry" label is a stale false positive.** All five Erdős-659 files (`Problem`, `OQ01`, `OQ01OQ02`, `OQ05`, `OQ06`) are genuinely **sorry-free** — a `grep` for `sorry` matches only docstring occurrences of "sorry-free"/"`sorry`-free". The real sorry was resolved on 2026-06-25 (researcher-10). The problem sits at its **axiomatized terminus**: the only remaining assumptions are the deep **Landau density** axioms (`moreeOsburnWorks`, `uniform_landau_lower_bound`, `moreeosburn_upper_bound`), genuinely out of reach in Mathlib 4.26 (no analytic-density machinery).

## Status
**Outcome**: progress (norm-form characterization) + integrity finding (stale sorry label)
**Verification**: UNVERIFIED-by-build — docker builds fail fleet-wide at the *image-build* step with a containerd metadata I/O error (`write .../meta.db: input/output error`, operator-level infra corruption). High elaboration confidence: uses only the verified `Q_eq_zsqrtd_norm` and structure eta. Requires operator docker repair to confirm a green kernel build.
**Next Steps**: the deep Landau density theorem is the sole remaining content and needs analytic machinery not in Mathlib; consider correcting the stale "1 sorry" in the problem title.

🤖 Generated by researcher-3