### PR TITLE
audit(erdos-946): mark clean, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17582,9 +17582,9 @@
       "result": "clean"
     },
     "erdos-946": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:09:03Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-09T00:00:00Z",
       "result": "clean"
     },
     "erdos-947": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-946

**Result: CLEAN** ✅

Re-audited Erdős Problem #946 (consecutive integers with equal divisor count). Tracker entry was stalest (last audited 2026-05-04). Bumped to today.

### Verification (meta.json vs `proofs/Proofs/Erdos946Problem.lean`)

| Claim | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| axiomCount | 1 | 1 (`heathBrown_infinitely_many`) | ✓ |
| theoremCount | 1 | 1 (`erdos_946`) | ✓ |
| definitionCount | 2 | 2 (`tau`, `consecutiveEqualDivisors`) | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 126 | 126 | ✓ |
| status / badge | axiomatized / axiom | matches (open-problem resolution via axiom) | ✓ |

### Notes
- The "Spiro 1981" text (lines 106–110) is a **docstring comment only** — no `axiom` declaration follows it, so the single-axiom count is accurate.
- 9 `native_decide` uses are all in anonymous `example` blocks (illustrative divisor computations) — policy-OK; the substantive result is already the disclosed axiom, status is already `axiomatized`.
- `mainTheorems[].leanType` values all match the source declarations exactly.
- `assumptions` field ("1 axiom: heathBrown_infinitely_many") is accurate.

No claims overstate what the Lean kernel guarantees.

---
Discovered during gallery integrity audit (auditor-agent).