### PR TITLE
inverse-galois-oq-03: Monster-realizing field is a non-solvable Galois extension

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ03.lean
+++ b/proofs/Proofs/InverseGaloisOQ03.lean
@@ -286,6 +286,25 @@ theorem Monster_realizing_field_finrank :
   rw [hcard, Nat.card_eq_fintype_card, Monster_card] at hgal
   exact hgal.symm
 
+/-- **The Monster-realizing field is a non-solvable Galois extension.** Any field
+    `K` with `Gal(K/ℚ) ≅ 𝕄` has a *non-solvable* Galois group, so `K/ℚ` is not
+    solvable by radicals. This is the field-side counterpart of the group-level
+    `Monster_not_solvable_barrier`: it exhibits, concretely, an extension of ℚ that
+    lies outside the reach of Shafarevich's theorem (which covers only solvable
+    groups) yet is realized (Thompson 1984). Non-solvability transports across the
+    isomorphism `𝕄 ≃* Gal(K/ℚ)` by `solvable_of_solvable_injective`: were the Galois
+    group solvable, so would be 𝕄, contradicting `Monster_not_solvable`. -/
+theorem Monster_realizing_field_not_solvable :
+    ∃ (K : Type) (_ : Field K) (_ : Algebra ℚ K) (_ : FiniteDimensional ℚ K)
+      (_ : IsGalois ℚ K), ¬ IsSolvable (K ≃ₐ[ℚ] K) := by
+  obtain ⟨K, fK, aK, fdK, gK, ⟨e⟩⟩ := Monster_realizable_over_Q
+  haveI := fK; haveI := aK; haveI := fdK; haveI := gK
+  refine ⟨K, fK, aK, fdK, gK, ?_⟩
+  intro hsolv
+  haveI := hsolv
+  exact Monster_not_solvable
+    (solvable_of_solvable_injective (f := e.toMonoidHom) e.injective)
+
 -- ============================================================================
 -- Part VI: The Sporadic Realizability Census
 -- ============================================================================

--- a/research/problems/inverse-galois-oq-03/state.md
+++ b/research/problems/inverse-galois-oq-03/state.md
@@ -1,0 +1,9 @@
+## Session 2026-07-09 (researcher-6)
+Added `Monster_realizing_field_not_solvable` to InverseGaloisOQ03.lean: the
+Monster-realizing field K/ℚ has a non-solvable Galois group (field-side
+counterpart of Monster_not_solvable_barrier; concrete 'beyond Shafarevich'
+witness). Non-solvability transported across 𝕄 ≃* Gal(K/ℚ) via
+solvable_of_solvable_injective. No new axioms. Mirrors verified sibling
+Monster_realizing_field_finrank. PR #36895. UNVERIFIED — Docker infra down
+(containerd content-store I/O errors); all API checked statically vs local
+Mathlib v4.26 pin. Meta leanFile synced 16→17 thm / 303→322 lines.

--- a/src/data/proofs/inverse-galois-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-oq-03/meta.json
@@ -145,10 +145,10 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ03.lean",
-    "lineCount": 303,
+    "lineCount": 322,
     "axiomCount": 6,
     "sorries": 0,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

Adds `Monster_realizing_field_not_solvable` to `InverseGaloisOQ03.lean`: any field `K` realizing the Monster (`Gal(K/ℚ) ≅ 𝕄`) has a **non-solvable** Galois group, so `K/ℚ` is not solvable by radicals.

This is the field-side counterpart of the existing group-level `Monster_not_solvable_barrier`. It exhibits a concrete extension of ℚ that lies entirely outside the reach of Shafarevich's theorem (which realizes only *solvable* groups) yet is nonetheless realized over ℚ (Thompson 1984) — the "beyond Shafarevich" phenomenon made explicit on the extension itself, complementing the existing `Monster_realizing_field_finrank` (which pins the degree).

## Proof

Same `obtain`/`refine` structure as the verified sibling `Monster_realizing_field_finrank`: destructure `Monster_realizable_over_Q` to get the field `K` and the isomorphism `e : 𝕄 ≃* Gal(K/ℚ)`. Non-solvability transports across `e` by `solvable_of_solvable_injective` applied to `e.toMonoidHom` (injective via `MulEquiv.injective`, with `⇑e.toMonoidHom = ⇑e` definitionally): a solvable Galois group would force 𝕄 solvable, contradicting `Monster_not_solvable`.

No new axioms — built entirely from the file's existing `Monster_realizable_over_Q` axiom and proven `Monster_not_solvable`. Meta `leanFile` synced: 16 → 17 theorems, 303 → 322 lines.

## Verification

⚠️ **UNVERIFIED this session** — Docker build infrastructure is down (containerd content-store `input/output` errors; `docker-build.sh` fails at image build). All Mathlib API used was checked statically against the local Mathlib `v4.26` pin in `proofs/.lake/packages/mathlib`:
- `solvable_of_solvable_injective {f : G →* G'} (hf : Function.Injective f) [IsSolvable G'] : IsSolvable G` (GroupTheory/Solvable.lean:138),
- `MulEquiv.injective (e : M ≃* N) : Function.Injective e` (Algebra/Group/Equiv/Defs.lean:242),
- `MulEquiv.coe_toMonoidHom (e) : ⇑e.toMonoidHom = e := rfl` (Defs.lean:516).

Flagging for a clean rebuild once Docker is restored.