### PR TITLE
research(sperner-ndim-oq-02): general small-lex-minimum canonicality obstruction

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02Obstruction.lean
+++ b/proofs/Proofs/SpernerNDimOQ02Obstruction.lean
@@ -49,6 +49,32 @@ theorem canon_base_has_large_coord {d N : ℕ} (t : GridSimplex d N) :
     ∃ j : Fin (d + 1), d ≤ (t.verts 0).coords j :=
   ⟨t.miss, t.base_miss_ge_d⟩
 
+/-- **General small-lex-minimum obstruction.**  The formal content of the prose
+"cells whose lex-minimum is small in every coordinate are unreachable": if a grid
+simplex `t` has a vertex `v` that is the lex-minimum of its vertex set (`v` is
+`lexLE` every vertex and lies in the range) and *every* coordinate of `v` is
+`< d`, then `t` is not canonical.  Indeed `IsCanon t` would force the base
+`t.verts 0` to be `lexLE v`; with `v` `lexLE` the base, antisymmetry
+(`lexLE_antisymm`) pins `t.verts 0 = v`, so the base inherits `v`'s small
+coordinates — contradicting `base_miss_ge_d`, which forces the base's `miss`
+coordinate to be `≥ d`.  This is the single principle behind the concrete witness
+below (`sBad_no_canon_rep`): its lex-minimum `(0,1,1)` has all coordinates `≤ 1 < 2`. -/
+theorem not_canon_of_lexMin_small {d N : ℕ} (t : GridSimplex d N) (v : BaryPoint d N)
+    (hmem : v ∈ Set.range t.verts) (hmin : ∀ k, v.lexLE (t.verts k))
+    (hsmall : ∀ j, (v.coords j) < d) :
+    ¬ IsCanon t := by
+  intro hcanon
+  -- Canonicality against the vertex realising `v` gives `base ≤ v`.
+  have h1 : (t.verts 0).lexLE v := by
+    obtain ⟨k, hk⟩ := hmem; have := hcanon k; rwa [hk] at this
+  -- `v` is the lex-minimum, so `v ≤ base`.
+  have h2 : v.lexLE (t.verts 0) := hmin 0
+  -- Antisymmetry pins the base to `v`, which is small in every coordinate.
+  have hbase : t.verts 0 = v := BaryPoint.lexLE_antisymm h1 h2
+  have hge : d ≤ (t.verts 0).coords t.miss := t.base_miss_ge_d
+  rw [hbase] at hge
+  exact absurd hge (by have := hsmall t.miss; omega)
+
 /-- The three barycentric points of the witness cell. -/
 def p2 : BaryPoint 2 2 := ⟨![2, 0, 0], by decide⟩
 def p1 : BaryPoint 2 2 := ⟨![1, 1, 0], by decide⟩


### PR DESCRIPTION
## Summary

Adds `not_canon_of_lexMin_small` to `SpernerNDimOQ02Obstruction.lean` — the **general** obstruction principle the file states only in prose, of which the existing concrete witness `sBad_no_canon_rep` is a single instance.

The file shows the `IsCanon` carrier omits genuine Freudenthal cells, via a `d=2, N=2` witness whose lex-minimum `(0,1,1)` has all coordinates `≤ 1 < 2 = d`. The docstring of `canon_base_has_large_coord` states the general reason — *"Cells whose lex-minimum is small in every coordinate are unreachable"* — but only the witness case was formalized. The new theorem extracts the principle to arbitrary `d, N`:

> If a grid simplex `t` has a vertex `v` that is the lex-minimum of its vertex set (`v.lexLE (t.verts k)` for all `k`, and `v ∈ range t.verts`) and **every** coordinate of `v` is `< d`, then `t` is not `IsCanon`.

## Proof

`IsCanon t` forces the base `t.verts 0` to be `lexLE v`; since `v` is the lex-minimum, `v.lexLE (t.verts 0)`; `BaryPoint.lexLE_antisymm` pins `t.verts 0 = v`, so the base inherits `v`'s small coordinates — contradicting `base_miss_ge_d` (the base's `miss` coordinate is `≥ d`). This reuses the exact `lexLE_antisymm` + `base_miss_ge_d` pattern of the verified `sBad_no_canon_rep` in the same file. **0 sorries, 0 axioms.**

## Verification

⚠️ **UNVERIFIED** — docker build infra is down (containerd `meta.db` input/output error; `docker images` itself errors). Not disk-full (158Gi free). The proof is a direct generalization of an already-verified theorem in the same file, using identical API; high confidence. Flag for a clean-infra rebuild before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)