### PR TITLE
Fix: sync stale primary-file lineCount (2 multi-file entries)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -101,7 +101,7 @@
       "Real analysis (rpow, sqrt, mean inequalities)",
       "Finset combinatorics (powersetCard, sum, prod)"
     ],
-    "lineCount": 701,
+    "lineCount": 743,
     "assumptions": "1 axiom: newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result needing the real-rootedness / Rolle machinery (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. The previously-assumed maclaurin_step (Mₖ ≥ Mₖ₊₁) is NO LONGER an axiom: it is now derived from newton_log_concavity alone via the logarithm-free, product-free multiplicative core (maclaurin_core_of_pos: p_{k+1}^k ≤ p_k^{k+1}, induction on k), a crossed root extraction (rpow_cross), and a 'zeros form a suffix' positivity argument (elemSymm_pos_of_top_pos) covering all non-negative inputs. The k=1 case of Newton's inequality (newton_k1) is also proved without axioms. 0 sorries remain.",
     "mathlib_version": "4.26.0",
     "theoremCount": 34,
@@ -305,7 +305,7 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 701,
+    "lineCount": 743,
     "structureCount": 0,
     "axiomCount": 1,
     "theoremCount": 34,

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -26,7 +26,7 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None. All theorems are fully machine-checked, depending only on propext, Classical.choice, and Quot.sound. Layer 3 works in a general real inner-product space; the right angle is supplied as the explicit hypothesis ⟪A − C, B − C⟫ = 0 and non-degeneracy as A ≠ B. Honesty note: once a Euclidean/inner-product model is fixed, the norm already encodes distance, so the one-line identity pythagorean_core (‖A−B‖² = ‖A−C‖² + ‖B−C‖²) is itself Pythagoras; Layer 3 does not claim foundational independence from it — its content is the verified geometric-mean/altitude decomposition. Layers 1 and 2 capture the parts of Einstein's reasoning genuinely independent of coordinates.",
-    "lineCount": 267,
+    "lineCount": 299,
     "theoremCount": 13,
     "definitionCount": 2,
     "originalContributions": [
@@ -74,7 +74,7 @@
   },
   "leanFile": {
     "namespace": "PythagoreanEinstein",
-    "lineCount": 267,
+    "lineCount": 299,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Sync stale primary-file `lineCount` metadata for two multi-file gallery entries to actual Lean source size. Companion to #36879 (which fixed 4 sibling entries under the same convention: `lineCount` = primary-file `wc -l`).

## Evidence

| slug | primary file | before | after (wc -l) |
|------|-------------|--------|---------------|
| amgm-inequality-oq-02 | `AmgmInequalityOQ02.lean` | 701 | 743 |
| pythagorean-theorem-oq-01 | `PythagoreanTheoremOQ01.lean` | 267 | 299 |

Both `meta.lineCount` and `leanFile.lineCount` updated per entry. Metadata-only; no Lean code touched.

---
Automated fix by lean-mechanic agent.