### PR TITLE
research(erdos-1012-oq-01-oq-02): discrete convexity — constant second differences of the edge threshold

### DIFF
--- a/proofs/Proofs/Erdos1012OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1012OQ01OQ02.lean
@@ -304,4 +304,40 @@ theorem edgeThreshold_quadratic_sandwich (n k : ℕ) (h : 2 * k + 3 ≤ n) :
   have hd : 2 * n.choose 2 = n * (n - 1) := two_mul_choose_two n
   omega
 
+/-! ## Discrete convexity: the second differences are constant
+
+The first-difference results (`edgeThreshold_succ_left`, `edgeThreshold_succ_right`) have
+discrete derivatives `n − k − 1` (in `n`) and `2k + 4 − n` (in `k`) that are themselves
+*linear*, so the threshold is discretely **convex** in each variable: the second difference
+is a strictly positive constant — `+1` in `n` and `+2` in `k`.  These identities upgrade the
+monotone `n`-growth and the two U-shaped `k`-branches to a quantitative convexity statement:
+a positive second difference forces the `k`-profile to be strictly convex (hence a unique
+minimizing band, sharpening `edgeThreshold_succ_right_le` / `edgeThreshold_le_succ_right`)
+and shows the `n`-growth is genuinely accelerating (consistent with the `Θ(n²)` sandwich). -/
+
+/-- **Discrete convexity in `n`: the second difference is the constant `+1`.**  For
+    `n ≥ k+1`,
+    `edgeThreshold (n+2) k + edgeThreshold n k = 2·edgeThreshold (n+1) k + 1`.
+    The `n`-derivative `n − k − 1` (`edgeThreshold_succ_left`) increases by exactly `1`
+    with each added vertex, so the threshold is strictly convex in `n`. -/
+theorem edgeThreshold_second_diff_left (n k : ℕ) (h : k + 1 ≤ n) :
+    edgeThreshold (n + 2) k + edgeThreshold n k = 2 * edgeThreshold (n + 1) k + 1 := by
+  have h1 := edgeThreshold_succ_left n k h
+  have h2 := edgeThreshold_succ_left (n + 1) k (by omega)
+  rw [show n + 1 + 1 = n + 2 by omega, show n + 1 - k - 1 = n - k by omega] at h2
+  omega
+
+/-- **Discrete convexity in `k`: the second difference is the constant `+2`.**  For
+    `n ≥ k+3`,
+    `edgeThreshold n (k+2) + edgeThreshold n k = 2·edgeThreshold n (k+1) + 2`.
+    The signed `k`-derivative `2k + 4 − n` (`edgeThreshold_succ_right`) increases by exactly
+    `2` per unit of `k`, so the threshold is strictly convex in `k` — pinning the U-shape to
+    a unique minimizing band near `k = (n-4)/2`. -/
+theorem edgeThreshold_second_diff_right (n k : ℕ) (h : k + 3 ≤ n) :
+    edgeThreshold n (k + 2) + edgeThreshold n k = 2 * edgeThreshold n (k + 1) + 2 := by
+  have h1 := edgeThreshold_succ_right n k (by omega)
+  have h2 := edgeThreshold_succ_right n (k + 1) (by omega)
+  rw [show k + 1 + 1 = k + 2 by omega] at h2
+  omega
+
 end Erdos1012OQ01OQ02

--- a/research/problems/erdos-1012-oq-01-oq-02/knowledge.md
+++ b/research/problems/erdos-1012-oq-01-oq-02/knowledge.md
@@ -53,3 +53,26 @@ Boundary-difference bridge (parent `threshold_diff` = `C(k+2,2)-C(k+1,2)`, evalu
 The next step is now COMPLETE; no obvious further elementary arithmetic remains for this
 child (the n- and k-recurrences, non-degeneracy, boundary connection, and growth rate are
 all recorded). Deeper work belongs to the parent (Woodall's f(k) axioms).
+
+## Discrete convexity — constant second differences (researcher-2, 2026-07-09)
+
+The file had first differences (`edgeThreshold_succ_left/_succ_right`) and the monotone
+`n`-growth + U-shaped `k`-branches, but never the SECOND difference. Both derivatives are
+linear (`n-k-1` in n, `2k+4-n` in k), so the threshold is discretely CONVEX in each variable
+with a strictly positive constant second difference. Added:
+
+- `edgeThreshold_second_diff_left (h : k+1 ≤ n)` :
+  `edgeThreshold (n+2) k + edgeThreshold n k = 2·edgeThreshold (n+1) k + 1` (convex in n, +1).
+- `edgeThreshold_second_diff_right (h : k+3 ≤ n)` :
+  `edgeThreshold n (k+2) + edgeThreshold n k = 2·edgeThreshold n (k+1) + 2` (convex in k, +2).
+
+Both are subtraction-free ℕ identities proved by `omega` from two instances of the
+corresponding first-difference recurrence (gotcha: `edgeThreshold_succ_left (n+1)` yields
+`edgeThreshold (n+1+1) k` — omega treats it as an atom distinct from `edgeThreshold (n+2) k`,
+so `rw [show n+1+1 = n+2 by omega]` first; likewise `k+1+1 = k+2` for the k-direction, and
+`rw [show n+1-k-1 = n-k]`). This upgrades the qualitative U-shape to quantitative strict
+convexity: the +2 second difference pins a unique minimizing k-band near `(n-4)/2`.
+
+UNVERIFIED: Docker infra down this session (containerd meta.db/blob input/output error at
+image build; docker images errors). No build path. Proofs are pure omega from already-VERIFIED
+in-file recurrences — high confidence; flag clean-cache/host rebuild to confirm.


### PR DESCRIPTION
## Erdős #1012 (OQ-01-OQ-02) — structural arithmetic of the Woodall edge threshold

`edgeThreshold n k = C(n−k−1,2) + C(k+2,2) + 1`. The file already records the first differences (recurrences `edgeThreshold_succ_left` in `n`, `edgeThreshold_succ_right` in `k`), the monotone `n`-growth, the two U-shaped `k`-branches, non-degeneracy vs `C(n,2)`, the boundary connection, and the Θ(n²) growth sandwich. What was missing: the **second** differences.

Both discrete derivatives are *linear* (`n−k−1` in `n`, `2k+4−n` in `k`), so the threshold is discretely **convex** in each variable, with a strictly positive constant second difference.

### New content
- **`edgeThreshold_second_diff_left`** (`k+1 ≤ n`): `edgeThreshold (n+2) k + edgeThreshold n k = 2·edgeThreshold (n+1) k + 1` — second difference `+1` in `n` (strict convexity; the `n`-growth accelerates, consistent with the Θ(n²) sandwich).
- **`edgeThreshold_second_diff_right`** (`k+3 ≤ n`): `edgeThreshold n (k+2) + edgeThreshold n k = 2·edgeThreshold n (k+1) + 2` — second difference `+2` in `k` (strict convexity; pins the U-shape to a unique minimizing band near `k = (n−4)/2`, sharpening the two existing monotone branches).

Both are subtraction-free ℕ identities proved by `omega` from two instances of the corresponding existing first-difference recurrence.

`0 axioms / 0 sorries`. File 307→343 lines.

### ⚠️ Verification status
**UNVERIFIED** — Docker build infrastructure is down this session (containerd `meta.db`/blob `input/output error` at image build; `docker images` also errors), so no build path was available. The proofs are pure `omega` from already-VERIFIED in-file recurrences (`edgeThreshold_succ_left`, `edgeThreshold_succ_right`) — high confidence. A clean-cache / host rebuild should confirm before treating as machine-checked.