### PR TITLE
abel-ruffini galois-direction: explicit order upper bound |H| ≤ p(p-1)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -729,4 +729,21 @@ theorem primitive_solvable_subgroup_card_eq_prime_mul
   rw [hm] at hdvd
   exact (Nat.mul_dvd_mul_iff_left hp.pos).mp hdvd
 
+/-- **Corollary (Galois order upper bound).** A primitive solvable subgroup
+    `H ≤ S_p = Equiv.Perm (ZMod p)` has order **at most** `p * (p - 1)`.
+
+    This is the explicit numeric ceiling — the form in which Galois's 1832 theorem
+    is most often quoted ("a solvable transitive group of prime degree `p` has order
+    `≤ p(p-1)`"). It is immediate from `primitive_solvable_subgroup_card_dvd`
+    (`|H| ∣ p(p-1)`) together with `Nat.le_of_dvd`, since `p(p-1) > 0` for a prime
+    `p ≥ 2`. No new `sorry`, no axiom. -/
+theorem primitive_solvable_subgroup_card_le
+    (H : Subgroup (Equiv.Perm (ZMod p)))
+    (hPrim : MulAction.IsPreprimitive H (ZMod p))
+    (hSolv : IsSolvable H) :
+    Nat.card H ≤ p * (p - 1) := by
+  have hp : p.Prime := Fact.out
+  have hpos : 0 < p * (p - 1) := Nat.mul_pos hp.pos (by have := hp.two_le; omega)
+  exact Nat.le_of_dvd hpos (primitive_solvable_subgroup_card_dvd H hPrim hSolv)
+
 end AbelRuffiniGaloisExtensionsOQ06GaloisDirection

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
@@ -1,5 +1,17 @@
 # Current State
 
+> **S27 — order UPPER BOUND corollary added (researcher-6, 2026-07-09).**
+> Slug remains COMPLETE/build-verified on main; nothing was broken. Added one
+> safe capstone corollary `primitive_solvable_subgroup_card_le`: |H| ≤ p(p-1)
+> (numeric-ceiling form of Galois 1832), a two-line `Nat.le_of_dvd` composition
+> of the existing `primitive_solvable_subgroup_card_dvd`. Completes the corollary
+> trio (dvd / =p·m / ≤). No new sorry/axiom. PR #36901. UNVERIFIED — Docker infra
+> down (containerd content-store I/O errors); pattern is verbatim-identical to
+> verified uses elsewhere in repo. Released claim.
+>
+> ---
+>
+
 > **S26 — FULL-CHAIN DOCKER BUILD-VERIFIED + redundant Aristotle companion removed (researcher-3, 2026-07-08) — READ FIRST.**
 > The problem was re-served as `available` (phantom re-serve of an already-complete
 > slug). Confirmed the 5 registered GaloisDirection files match `origin/main`


### PR DESCRIPTION
## Summary

Adds `primitive_solvable_subgroup_card_le` to `AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean`: a primitive solvable subgroup `H ≤ S_p = Equiv.Perm (ZMod p)` has order **at most** `p * (p - 1)`.

This is the explicit numeric ceiling — the form in which Galois's 1832 theorem is most often quoted ("a solvable transitive group of prime degree `p` has order `≤ p(p-1)`"). It completes the corollary trio in this file:

- `primitive_solvable_subgroup_card_dvd`: `|H| ∣ p(p-1)`,
- `primitive_solvable_subgroup_card_eq_prime_mul`: `|H| = p·m`, `m ∣ p-1` (Rotman 9.11),
- **`primitive_solvable_subgroup_card_le`: `|H| ≤ p(p-1)` (this PR).**

## Proof

Immediate from `primitive_solvable_subgroup_card_dvd` via `Nat.le_of_dvd`, since `p(p-1) > 0` for a prime `p ≥ 2`. This exact `Nat.le_of_dvd hpos hdvd` pattern already appears verbatim elsewhere in the codebase (e.g. `AbelRuffiniOQ04OQ01.lean`). No new `sorry`, no axiom.

## Verification

⚠️ **UNVERIFIED this session** — Docker build infrastructure is down (containerd content-store `input/output` errors; `docker-build.sh` fails at image build). The addition is a two-line composition of an already-build-verified lemma in the same file with the standard `Nat.le_of_dvd`; very high confidence. The underlying `primitive_solvable_subgroup_embeds_AGL1Z` chain is build-verified on `main` (per S26 state note). Flagging for a clean rebuild once Docker is restored.