### PR TITLE
research(minpoly-charpoly-oq-02-incomplete-01): subtraction counterexample

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
@@ -426,4 +426,19 @@ theorem exists_diagonalizable_add_not_diagonalizable :
     rw [hD11] at hprod
     nlinarith [sq_nonneg (D 0 0), hprod]
 
+/-- **Subtraction does not preserve diagonalizability.**  Diagonalizable matrices
+    `M`, `N` can have a non-diagonalizable *difference* `M − N`, so the
+    common-diagonalizer hypothesis of `sub_of_commonDiagonalizer` is genuinely
+    necessary (not merely for products and sums).  Reduces to the additive
+    counterexample `exists_diagonalizable_add_not_diagonalizable`: negation
+    preserves diagonalizability (`IsDiagonalizable.neg`), so from diagonalizable
+    `M`, `N` with `M + N` non-diagonalizable we obtain diagonalizable `M`, `−N`
+    with `M − (−N) = M + N` non-diagonalizable.  Completes the trio of
+    binary-operation counterexamples (product, sum, difference). -/
+theorem exists_diagonalizable_sub_not_diagonalizable :
+    ∃ M N : Matrix (Fin 2) (Fin 2) ℚ,
+      M.IsDiagonalizable ∧ N.IsDiagonalizable ∧ ¬ (M - N).IsDiagonalizable := by
+  obtain ⟨M, N, hM, hN, hMN⟩ := exists_diagonalizable_add_not_diagonalizable
+  exact ⟨M, -N, hM, IsDiagonalizable.neg hN, by rwa [sub_neg_eq_add]⟩
+
 end MinpolyCharpolyOQ02Incomplete01


### PR DESCRIPTION
## Summary

`MinpolyCharpolyOQ02Incomplete01.lean` (closure properties of `Matrix.IsDiagonalizable`) already shows the common-diagonalizer hypothesis is necessary for **products** (`exists_diagonalizable_mul_not_diagonalizable`) and **sums** (`exists_diagonalizable_add_not_diagonalizable`), and it has `sub_of_commonDiagonalizer`. The **difference** counterexample was missing.

This PR adds `exists_diagonalizable_sub_not_diagonalizable`, completing the trio of binary-operation counterexamples (product, sum, difference).

## New declaration (1, 0 sorry / 0 axiom)

```lean
theorem exists_diagonalizable_sub_not_diagonalizable :
    ∃ M N : Matrix (Fin 2) (Fin 2) ℚ,
      M.IsDiagonalizable ∧ N.IsDiagonalizable ∧ ¬ (M - N).IsDiagonalizable
```

Three-line reduction to the additive counterexample: negation preserves diagonalizability (`IsDiagonalizable.neg`), so from diagonalizable `M, N` with `M + N` non-diagonalizable we get diagonalizable `M, -N` with `M - (-N) = M + N` non-diagonalizable (via `sub_neg_eq_add`).

## Verification status

**UNVERIFIED (infra)** — Docker build unavailable this session: `docker-build.sh` fails at image build with a containerd `meta.db` input/output error (known host infrastructure failure, not a proof error). The proof reuses only already-verified declarations in this file plus the Mathlib rewrite `sub_neg_eq_add`; confidence is high pending a green rebuild once Docker is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)