### PR TITLE
Research: feuerbachs-theorem-oq-04 - side-midpoint geodesic membership + self-midpoint

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
@@ -67,6 +67,17 @@ noncomputable def sMidpoint (A B : E) : E := (‖A + B‖)⁻¹ • (A + B)
 theorem sMidpoint_comm (A B : E) : sMidpoint A B = sMidpoint B A := by
   unfold sMidpoint; rw [add_comm A B]
 
+/-- **The spherical midpoint of a model point with itself is that point.**  `sMidpoint A A = A`
+for `A` on the sphere: the degenerate side `AA` has the vertex as its own midpoint.  (Here
+`A + A ≠ 0` automatically, since `‖A‖ = 1`.) -/
+theorem sMidpoint_self {A : E} (hA : OnSphere A) : sMidpoint A A = A := by
+  have hnorm : ‖A‖ = 1 := hA
+  have h2 : ‖A + A‖ = 2 := by
+    rw [← two_smul ℝ A, norm_smul, hnorm, mul_one]; simp
+  unfold sMidpoint
+  rw [h2, ← two_smul ℝ A, smul_smul,
+      inv_mul_cancel₀ (by norm_num : (2:ℝ) ≠ 0), one_smul]
+
 /-- **The midpoint of a non-degenerate spherical side is a model point.**  For non-antipodal
 `A, B` (`A + B ≠ 0`) the normalised sum has unit norm.  The hypothesis is genuinely needed:
 antipodal points sum to `0` and have no well-defined midpoint. -/
@@ -85,6 +96,18 @@ theorem inner_sMidpoint_sub (A B : E) (hA : OnSphere A) (hB : OnSphere B) :
   rw [real_inner_smul_left, inner_sub_right, inner_add_left, inner_add_left,
       real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq, hA, hB, real_inner_comm B A]
   ring
+
+/-- **The spherical midpoint lies on the geodesic through `A` and `B`.**  Being the normalised
+sum `‖A + B‖⁻¹ • (A + B)`, the midpoint is a linear combination of `A` and `B`, hence lies in the
+plane they span — i.e. on the great circle through `A` and `B`.  Together with
+`inner_sMidpoint_sub` (the midpoint is on the perpendicular bisector of `AB`) this locates
+`sMidpoint A B` as the intersection of the side's geodesic with its perpendicular bisector. -/
+theorem sMidpoint_mem_span (A B : E) :
+    sMidpoint A B ∈ Submodule.span ℝ ({A, B} : Set E) := by
+  unfold sMidpoint
+  refine Submodule.smul_mem _ _ (Submodule.add_mem _ ?_ ?_)
+  · exact Submodule.subset_span (by simp)
+  · exact Submodule.subset_span (by simp)
 
 /-- **The spherical midpoint is equidistant (equal spherical cosine) from the two endpoints.**
 `scos A M = ‖A+B‖⁻¹ (1 + ⟪A,B⟫) = scos B M`, so `A` and `B` are on a common spherical circle

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -796,3 +796,23 @@ elaboration-clean when write-stage green is unobtainable).
 1. **The Feuerbach tangency** — nine-point circle internally tangent to the incircle, externally
    to the three excircles. Still the sole open item; needs an explicit spherical
    nine-point-centre / incentre distance identity (spherical Euler formula). Genuinely hard.
+
+## Session 2026-07-09 (researcher-1): side-midpoint geodesic membership + self-midpoint [UNVERIFIED — Docker infra down]
+
+**Mode**: ACT (CONTINUE). Rounded out the `sMidpoint` API in
+`FeuerbachsTheoremOQ04Midpoint.lean` with two clean gap-fills that the file's own docstring
+asserted but never proved:
+
+- **`sMidpoint_mem_span`** — `sMidpoint A B ∈ Submodule.span ℝ {A, B}`: the midpoint is a linear
+  combination of `A, B`, hence lies in their plane / on the great circle (geodesic) through them.
+  Combined with the pre-existing `inner_sMidpoint_sub` (midpoint ⟂ pole `A−B`, i.e. on the
+  perpendicular bisector) this finally *locates* `M` as geodesic∩perp-bisector — the on-geodesic
+  half of the characterisation was previously only stated in prose.
+- **`sMidpoint_self`** — `sMidpoint A A = A` for `A` on the sphere (degenerate side).
+
+Both 0-sorry/0-axiom, elementary (`Submodule.smul_mem`/`add_mem`/`subset_span`; `two_smul`,
+`norm_smul`, `inv_mul_cancel₀`). **Not machine-verified this session**: the build host's
+containerd is down (`meta.db input/output error` at image build, before any Lean elaboration) —
+an operator-level outage, not a proof error. Proofs mirror verified patterns already in the same
+file. Frontier unchanged: the Feuerbach tangency (spherical nine-point circle internally tangent
+to the incircle, externally to the three excircles) remains the sole hard open item.

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1 2026-07-08): the spherical midpoint sMidpoint was proven equidistant (sdist_sMidpoint_eq) but never proven to actually BISECT the arc. Added sdist_sMidpoint_half: sdist A (sMidpoint A B) = (1/2)*sdist A B — strictly stronger than equidistance (rules out the antipode of the true midpoint), justifying the name. Plus reusable helpers norm_add_sq_unit (‖A+B‖²=2+2⟪A,B⟫) and scos_sMidpoint_left (explicit vertex-to-midpoint spherical cosine ‖A+B‖⁻¹(1+⟪A,B⟫)). Companion FeuerbachsTheoremOQ04Midpoint.lean 119->199 lines, 6->9 theorems, VERIFIED 0 axioms / 0 sorries (docker Built, #print axioms = propext/Classical.choice/Quot.sound). Frontier unchanged: the Feuerbach tangency capstone (nine-point circle tangent to incircle) remains the sole hard open item.",
+    "progressSummary": "PROGRESS: side-midpoint API rounded out with geodesic-membership (span{A,B}) and self-midpoint lemmas; frontier remains the Feuerbach tangency (nine-point circle ↔ incircle/excircles).",
     "builtItems": [
       "FeuerbachsTheoremOQ04.chord_sq (Proofs/FeuerbachsTheoremOQ04.lean) — chord-cosine bridge: for unit vectors, ||P-Q||^2 = 2 - 2*scos P Q; turns spherical tangency into an inner-product equation. 0-axiom.",
       "FeuerbachsTheoremOQ04.abs_scos_le_one/scos_le_one/neg_one_le_scos — spherical cosine in [-1,1] (Cauchy-Schwarz on unit vectors)",
@@ -55,7 +55,8 @@
       "SphericalIncircle Na Nb Nc O ρ — circle tangent to all 3 side poles of a spherical triangle",
       "sphericalIncircle_contact_points — incircle meets each of the 3 sides in exactly one point (explicit feet)",
       "sphericalCircumcircle_exists in FeuerbachsTheoremOQ04Circumcircle.lean: any three model points lie on a common sCircle O rho (circumcircle), via greatCircles_inter on poles A-B, B-C. [VERIFIED, 0-axiom]",
-      "sphericalCircumcircle_equidistant + inner_sub_eq_zero_iff_scos_eq in FeuerbachsTheoremOQ04Circumcircle.lean: circumcentre is spherically equidistant sdist A O = sdist B O = sdist C O. [VERIFIED, 0-axiom]"
+      "sphericalCircumcircle_equidistant + inner_sub_eq_zero_iff_scos_eq in FeuerbachsTheoremOQ04Circumcircle.lean: circumcentre is spherically equidistant sdist A O = sdist B O = sdist C O. [VERIFIED, 0-axiom]",
+      "sMidpoint_self (degenerate midpoint sMidpoint A A = A) + sMidpoint_mem_span (midpoint lies in span{A,B}, i.e. on the geodesic through A,B) in FeuerbachsTheoremOQ04Midpoint.lean"
     ],
     "insights": [
       "Mathlib has clean spherical geometry for free (unit vectors of any InnerProductSpace R E; geodesic distance = arccos of inner product) but essentially no hyperbolic metric, so the spherical model is the tractable non-Euclidean route for Feuerbach.",
@@ -64,7 +65,8 @@
       "Spherical common tangent at a contact point is captured coordinate-free: since P ∈ span{O₁,O₂}, any T ⟂ {O₁,O₂} is simultaneously in the tangent space at P and tangent to both circles — no explicit geodesic parametrisation needed.",
       "Circle-to-great-circle tangency is the exact primitive a spherical INCIRCLE construction needs: the incircle is tangent to the three side-geodesics (great circles), not to other circles. Distance from a point to a great circle with unit pole N is arcsin|⟪O,N⟫|, so tangency criterion is |⟪O,N⟫| = sin ρ (spherical shadow of Euclidean distance-to-line = radius).",
       "The contact point of a tangent circle and a side is the FOOT OF THE PERPENDICULAR (O - ⟪O,N⟫•N)/cos ρ; it is pure inner-product algebra (no infimum/analysis): ⟪foot,N⟫=0, ⟪foot,O⟫=cos ρ, ‖foot‖=1 via ‖O⊥‖²=1-⟪O,N⟫²=cos²ρ under the criterion. Uniqueness via ⟪Q,foot⟫=1 ⟹ Q=foot (scos_eq_one_iff).",
-      "Spherical perpendicular bisector of a segment AB is the great circle with pole A-B: model points equidistant (equal scos) from A and B are exactly those orthogonal to A-B (inner_sub_eq_zero_iff_scos_eq). Dual to the side-pole bisector equidistant_two_sides_iff."
+      "Spherical perpendicular bisector of a segment AB is the great circle with pole A-B: model points equidistant (equal scos) from A and B are exactly those orthogonal to A-B (inner_sub_eq_zero_iff_scos_eq). Dual to the side-pole bisector equidistant_two_sides_iff.",
+      "The spherical midpoint is now located as the intersection of the side geodesic (sMidpoint_mem_span: M ∈ span{A,B}) with the perpendicular bisector (inner_sMidpoint_sub), completing the on-geodesic + equidistant characterisation the docstring asserted."
     ],
     "mathlibGaps": [
       "No developed hyperbolic-geometry metric (hyperboloid / Poincare disk distance) in Mathlib — blocks an axiom-free hyperbolic Feuerbach without building the model first.",


### PR DESCRIPTION
## Summary
Research session for `feuerbachs-theorem-oq-04` (spherical Feuerbach). Two clean gap-fill
lemmas in `FeuerbachsTheoremOQ04Midpoint.lean` that the file's docstring asserted but never
proved.

## Progress
- **`sMidpoint_mem_span`** — `sMidpoint A B ∈ Submodule.span ℝ {A, B}`: the spherical midpoint
  is a linear combination of `A` and `B`, so it lies in their plane / on the great circle
  (geodesic) through them. Combined with the existing `inner_sMidpoint_sub` (midpoint on the
  perpendicular bisector, ⟂ pole `A−B`), this locates `M` as the intersection of the side's
  geodesic with its perpendicular bisector — the on-geodesic half of the characterisation was
  previously only stated in prose.
- **`sMidpoint_self`** — `sMidpoint A A = A` for a model point (degenerate side).

Both 0-sorry / 0-axiom, elementary (`Submodule.smul_mem`/`add_mem`/`subset_span`; `two_smul`,
`norm_smul`, `inv_mul_cancel₀`), mirroring verified patterns already in the file.

## Findings
- The side-midpoint API is now rounded out; the sole remaining frontier is the Feuerbach
  tangency (spherical nine-point circle internally tangent to the incircle, externally to the
  three excircles) — genuinely hard, not attempted.

## Status
**Outcome**: progress (UNVERIFIED — Docker build host containerd down: `meta.db input/output
error` at image build, before any Lean elaboration; operator-level outage, not a proof error)
**Next Steps**: rebuild once Docker is healthy to confirm `=== Build succeeded ===`; then attack
the circle-circle tangency criterion needed for the Feuerbach tangency.

🤖 Generated by researcher-1