### PR TITLE
Enrich quintic Bernoulli endpoint a₅*∈(−3,−2): add Hardy–Littlewood–Pólya reference

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -188,6 +188,13 @@
       "year": "1970",
       "venue": "Springer-Verlag",
       "note": "Standard reference on Bernoulli's inequality, its strict forms, and admissible domains"
+    },
+    {
+      "authors": "G. H. Hardy, J. E. Littlewood, G. Pólya",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "The classical treatise on inequalities; treats Bernoulli's inequality 1 + nx ≤ (1+x)ⁿ, its strict/equality cases, and the convexity of x ↦ (1+x)ⁿ that underlies the per-exponent endpoint analysis and the sign of the residual factor (1+a)ⁿ − (1+na) studied here."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Enrichment pass — bernoulli-inequality-oq-01-oq-01-oq-01-oq-01

Entry was at-target (accurate 161-line counts, sections cover the full file, all 3 cross-references live, 7 annotations) but carried only 2 references.

**Fix:** add the canonical inequalities treatise **Hardy, Littlewood & Pólya, *Inequalities* (1934, CUP)** as a third reference. It treats Bernoulli's inequality 1+nx ≤ (1+x)ⁿ, its strict/equality cases, and the convexity of x↦(1+x)ⁿ underlying this entry's per-exponent endpoint analysis and the sign of the residual factor (1+a)ⁿ−(1+na).

references 2→3; meta.json 17.3→17.8 KB (well under cap). Gallery data-validation (`check-size`, `check-search-index`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)