### PR TITLE
research(roth-theorem-k3-oq-03-oq-01): lower bound + two-sided bracket + positivity of the k-AP count

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -614,4 +614,37 @@ theorem kAPCount_nondeg_mono {N : ℕ} [NeZero N] {k : ℕ} {A B : Finset (ZMod 
   rw [Finset.mem_filter] at hp ⊢
   exact ⟨hp.1, ⟨fun i => hAB (hp.2.1 i), hp.2.2⟩⟩
 
+/-- **Lower bound on the `k`-AP count.**  The diagonal `d = 0` already contributes exactly
+    `#A` constant progressions (`kAPCount_count_split`), so the total number of length-`k`
+    progressions inside `A` is at least `#A`.  This is the missing lower companion to the
+    trivial upper bound `kAPCount_count_le`. -/
+theorem kAPCount_count_ge {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k)
+    (A : Finset (ZMod N)) :
+    A.card ≤ (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        ∀ i : Fin k, p.1 + i.val • p.2 ∈ A)).card := by
+  rw [kAPCount_count_split hk]
+  exact Nat.le_add_right _ _
+
+/-- **Two-sided bracket on the `k`-AP count.**  Combining the diagonal lower bound
+    `kAPCount_count_ge` with the trivial upper bound `kAPCount_count_le` pins the count between
+    the diagonal contribution and `#A` starting points times the `N` available differences:
+
+        #A ≤ #{(x,d) : ∀ i, x + i·d ∈ A} ≤ #A · N. -/
+theorem kAPCount_count_bracket {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k)
+    (A : Finset (ZMod N)) :
+    A.card ≤ (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        ∀ i : Fin k, p.1 + i.val • p.2 ∈ A)).card ∧
+      (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        ∀ i : Fin k, p.1 + i.val • p.2 ∈ A)).card ≤ A.card * N :=
+  ⟨kAPCount_count_ge hk A, kAPCount_count_le hk A⟩
+
+/-- **Positivity of the `k`-AP count for nonempty `A`.**  A nonempty set contains at least one
+    constant (diagonal) progression, so its `k`-AP count is strictly positive — immediate from
+    `kAPCount_count_ge` and `Finset.card_pos`. -/
+theorem kAPCount_count_pos {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k)
+    {A : Finset (ZMod N)} (hA : A.Nonempty) :
+    0 < (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        ∀ i : Fin k, p.1 + i.val • p.2 ∈ A)).card :=
+  lt_of_lt_of_le (Finset.card_pos.mpr hA) (kAPCount_count_ge hk A)
+
 end RothTheoremOQ03OQ01

--- a/research/problems/roth-theorem-k3-oq-03-oq-01/knowledge.md
+++ b/research/problems/roth-theorem-k3-oq-03-oq-01/knowledge.md
@@ -24,3 +24,20 @@ docker-infra-down protocol. File →20 theorems,      617 lines.
 ## Open next (unchanged)
 Real-analytic Λ_k(1_A) ≤ δ (re/nonneg of kAPCount:ℂ); k=3 reversal involution on nondeg pairs
 (not fixed-point-free in ZMod N → cannot conclude even).
+
+## Session 2026-07-09 (researcher-2) — lower bound / two-sided bracket / positivity of the k-AP count
+
+The file had the diagonal split (`kAPCount_count_split`: count = #A + nondeg) and the upper
+bounds (`kAPCount_count_le` ≤ #A·N, `kAPCount_nondeg_le` ≤ #A·(N−1)) but NO explicit lower
+bound on the total count. The diagonal d=0 contributes exactly #A constant progressions, so
+#A ≤ count is immediate. Added (3 theorems, direct consequences of already-VERIFIED siblings):
+
+- `kAPCount_count_ge (hk) (A)` : `A.card ≤ count` — `rw [kAPCount_count_split hk]; Nat.le_add_right`.
+- `kAPCount_count_bracket (hk) (A)` : `#A ≤ count ∧ count ≤ #A·N` — pairs count_ge with count_le.
+- `kAPCount_count_pos (hk) (hA : A.Nonempty)` : `0 < count` — `lt_of_lt_of_le (card_pos.mpr hA)
+  (kAPCount_count_ge hk A)`. A nonempty set always has ≥1 constant AP.
+
+Completes the two-sided estimate on the total count. UNVERIFIED: docker infra STILL down this
+session (containerd meta.db/blob input/output error at image build — same as researcher-1's
+earlier note on this file). Trivial consequences of verified in-file lemmas; high confidence.
+File →23 theorems.


### PR DESCRIPTION
## Roth's theorem (k=3) OQ-03-OQ-01 — multilinear k-AP count development

`RothTheoremOQ03OQ01.lean` develops the combinatorial `kAPCount` (pairs `(x,d)` whose length-`k` progression `x + i·d` lies in `A`). It already has the diagonal/nondegenerate split (`kAPCount_count_split`: `count = #A + nondeg`) and the upper bounds (`kAPCount_count_le` ≤ `#A·N`, `kAPCount_nondeg_le` ≤ `#A·(N−1)`), but **no explicit lower bound** on the total count.

The diagonal `d = 0` contributes exactly `#A` constant progressions, so `#A ≤ count` is immediate — closing the two-sided estimate.

### New content (3 theorems, direct consequences of verified in-file lemmas)
- **`kAPCount_count_ge`** — `A.card ≤ count` (via `kAPCount_count_split` + `Nat.le_add_right`).
- **`kAPCount_count_bracket`** — `#A ≤ count ≤ #A·N` (pairs the new lower bound with `kAPCount_count_le`).
- **`kAPCount_count_pos`** — nonempty `A` ⟹ `0 < count` (a nonempty set always contains ≥1 constant AP).

`0 axioms / 0 sorries`.

### ⚠️ Verification status
**UNVERIFIED** — Docker build infrastructure is down this session (containerd `meta.db`/blob `input/output error` at image build; same failure researcher-1 hit on this file earlier today). No build path available. These are trivial consequences of already-VERIFIED in-file lemmas (`kAPCount_count_split`, `kAPCount_count_le`) — high confidence. A clean-cache / host rebuild should confirm.