### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-03): degree prime-factor set is {p}

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
@@ -253,4 +253,19 @@ theorem not_pgroup_of_not_dvd_degree (α : ℝ) (hα : IsIntegral ℚ α)
     ¬ IsPGroup p (minpoly ℚ α).Gal :=
   fun hP => hndvd (prime_dvd_degree_of_pgroup α hα hp hgt hP)
 
+/-- **The degree's prime-factor set is exactly `{p}`.**
+    The sharpest "which prime" statement for a nontrivial `p`-group Galois group.  The two
+    earlier facts say the degree is a prime power (`pgroup_degree_isPrimePow_or_one`) and
+    that `p` divides it (`prime_dvd_degree_of_pgroup`); this fuses and tightens them to the
+    exact identity `natDegree(minpoly ℚ α).primeFactors = {p}`.  So `p` is recovered as
+    literally the *unique* prime dividing the degree — the whole prime-factor set collapses
+    to the single target prime, the crispest form of `pgroup_prime_unique`'s content. -/
+theorem pgroup_primeFactors_eq (α : ℝ) (hα : IsIntegral ℚ α)
+    {p : ℕ} (hp : p.Prime) (hgt : 1 < (minpoly ℚ α).natDegree)
+    (hP : IsPGroup p (minpoly ℚ α).Gal) :
+    (minpoly ℚ α).natDegree.primeFactors = {p} := by
+  obtain ⟨k, hk⟩ := galois_pgroup_implies_degree_is_pow_p α hα hp hP
+  have hk0 : k ≠ 0 := by rintro rfl; rw [pow_zero] at hk; omega
+  rw [hk, Nat.primeFactors_prime_pow hk0 hp]
+
 end AngleTrisectionOQ02OQ01OQ03


### PR DESCRIPTION
## Summary

Adds one capstone theorem to `AngleTrisectionOQ02OQ01OQ03.lean`, the p-group Galois → prime-power-degree obstruction library behind the impossibility of angle trisection.

**`pgroup_primeFactors_eq`** — for an algebraic real `α` whose Galois group `Gal(minpoly ℚ α)` is a `p`-group and whose extension is nontrivial (`natDegree > 1`):
```
(minpoly ℚ α).natDegree.primeFactors = {p}
```

This is the sharpest "which prime" statement in the file. The two existing facts say the degree is a prime power (`pgroup_degree_isPrimePow_or_one`) and that `p` divides it (`prime_dvd_degree_of_pgroup`); this fuses and tightens them into the exact identity that the degree's *entire* prime-factor set collapses to the single target prime `{p}`. So `p` is recovered as literally the unique prime dividing the degree — the crispest form of `pgroup_prime_unique`'s content.

Proof: the degree is `p^k` (`galois_pgroup_implies_degree_is_pow_p`), `k ≠ 0` from `natDegree > 1`, then `Nat.primeFactors_prime_pow`.

## Verification

- **EXIT_CODE 0** on offline Lean elaboration against the cached Mathlib oleans plus the two parent proof oleans (`AngleTrisectionOQ01`, `AngleTrisectionOQ02OQ01`) compiled locally. Docker host was down this session (containerd `meta.db` I/O error, operator-level), so verification used `LAKE_UNSAFE=1 lake env lean` with the full dependency closure.
- `#print axioms pgroup_primeFactors_eq` reports only the standard foundational axioms `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`; the file remains 0-sorry, 0-axiom.

File 256 → 271 lines, 14 → 15 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)