### PR TITLE
research(cauchy-interlacing-oq-02-oq-01): sub-multiset refinement of compression spectrum inclusion

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
@@ -1098,6 +1098,38 @@ theorem card_roots_charpoly_eq_add_compress_of_reducing {T : V →ₗ[𝕜] V}
         + (LinearMap.charpoly (compress T Hᗮ)).roots.card := by
   rw [roots_charpoly_eq_add_compress_of_reducing H hH hHp, Multiset.card_add]
 
+/-- **The `H`-block eigenvalue multiset is a sub-multiset of the ambient one.**
+The with-multiplicity, root-level refinement of the set-level containment
+`spectrum_compress_subset_of_invariant`: over a reducing subspace the eigenvalues of the
+`H`-compression (roots of `charpoly (compress T H)`, counted with algebraic multiplicity)
+occur, *with at least the same multiplicity*, among the eigenvalues of the ambient `T`,
+
+  `(charpoly (compress T H)).roots ≤ (charpoly T).roots`.
+
+This is the multiset shadow of the divisibility `charpoly_compress_dvd_of_reducing`
+(`p ∣ q` forces `p.roots ≤ q.roots`) and sharpens the mere set inclusion of spectra to a
+counted containment.  Immediate from the additivity
+`roots_charpoly_eq_add_compress_of_reducing` via `Multiset.le_add_right`.  Symmetry-free. -/
+theorem roots_charpoly_compress_le_of_reducing {T : V →ₗ[𝕜] V}
+    (H : Submodule 𝕜 V) (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) :
+    (LinearMap.charpoly (compress T H)).roots ≤ (LinearMap.charpoly T).roots := by
+  rw [roots_charpoly_eq_add_compress_of_reducing H hH hHp]
+  exact Multiset.le_add_right _ _
+
+/-- The `Hᗮ`-block companion of `roots_charpoly_compress_le_of_reducing`: the orthogonal
+compression's eigenvalue multiset is likewise a sub-multiset of the ambient one,
+
+  `(charpoly (compress T Hᗮ)).roots ≤ (charpoly T).roots`.
+
+The two blocks' eigenvalue multisets partition the ambient one
+(`roots_charpoly_eq_add_compress_of_reducing`), so each is bounded above by the whole;
+here via `Multiset.le_add_left`. -/
+theorem roots_charpoly_orthogonal_compress_le_of_reducing {T : V →ₗ[𝕜] V}
+    (H : Submodule 𝕜 V) (hH : ∀ y ∈ H, T y ∈ H) (hHp : ∀ y ∈ Hᗮ, T y ∈ Hᗮ) :
+    (LinearMap.charpoly (compress T Hᗮ)).roots ≤ (LinearMap.charpoly T).roots := by
+  rw [roots_charpoly_eq_add_compress_of_reducing H hH hHp]
+  exact Multiset.le_add_left _ _
+
 /-! ### Upgrading eigenvalue-count additivity to a genuine `finrank` identity
 
 The multiset additivity `card_roots_charpoly_eq_add_compress_of_reducing` is

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -12,8 +12,8 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
-    "lineCount": 1186,
-    "theoremCount": 38,
+    "lineCount": 1218,
+    "theoremCount": 40,
     "definitionCount": 0,
     "difficulty": "advanced",
     "category": "linear-algebra",
@@ -62,9 +62,9 @@
       "CauchyInterlacing.Poincare"
     ],
     "namespace": "CauchyInterlacing.PoincareCompression",
-    "lineCount": 1186,
+    "lineCount": 1218,
     "axiomCount": 0,
-    "theoremCount": 38,
+    "theoremCount": 40,
     "definitionCount": 0,
     "path": "Proofs/CauchyInterlacingPoincareCompression.lean",
     "sorries": 0

--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-02-oq-01.json
@@ -64,7 +64,8 @@
       "charpoly_eq_mul_compress_of_reducing (CauchyInterlacingPoincareCompression.lean, PR #36265) — charpoly T = charpoly(compress T H)*charpoly(compress T Hᗮ) on a reducing subspace; polynomial master identity subsuming trace additivity + det factorization; symmetry-free",
       "roots_charpoly_eq_add_compress_of_reducing in CauchyInterlacingPoincareCompression.lean (eigenvalue-multiset additivity over reducing subspace, 0/0)",
       "card_roots_charpoly_eq_add_compress_of_reducing (eigenvalue-count additivity via Multiset.card_add, 0/0)",
-      "Repaired charpoly_eq_mul_compress_of_reducing hT rewrite (removed spurious leading ← comp_assoc after conj_apply)"
+      "Repaired charpoly_eq_mul_compress_of_reducing hT rewrite (removed spurious leading ← comp_assoc after conj_apply)",
+      "roots_charpoly_compress_le_of_reducing (+ orthogonal companion) in CauchyInterlacingPoincareCompression.lean (PR #36909) — with-multiplicity sub-multiset refinement of spectrum_compress_subset_of_invariant: over a reducing subspace (charpoly (compress T H)).roots ≤ (charpoly T).roots, the multiset shadow of charpoly_compress_dvd_of_reducing, via roots_charpoly_eq_add_compress_of_reducing + Multiset.le_add_{right,left}. 0 sorry/0 axiom. UNVERIFIED (docker infra down: containerd content-store I/O error)."
     ],
     "insights": [
       "This slug duplicates work already merged under sibling cauchy-interlacing-theorem-oq-01-oq-02 (#28084). The Rayleigh-agreement hypothesis of the abstract poincare_separation is discharged by rayleigh_compress_eq, which is stated for an ARBITRARY submodule H (nothing uses codim=1), so the abstract theorem and the explicit compression join for any codimension m with no new work.",
@@ -107,7 +108,7 @@
     "mathlib": []
   },
   "started": "2026-07-02T05:53:08.467Z",
-  "lastUpdate": "2026-07-08T00:00:00.000Z",
+  "lastUpdate": "2026-07-09T00:00:00.000Z",
   "completed": "2026-07-02T23:38:28.210Z",
   "significance": 3,
   "tractability": 7


### PR DESCRIPTION
## Summary

Adds two symmetry-free lemmas to `CauchyInterlacingPoincareCompression.lean` giving the **with-multiplicity, root-level** refinement of the compression's spectrum containment over a reducing subspace:

```
roots_charpoly_compress_le_of_reducing :
  (charpoly (compress T H)).roots ≤ (charpoly T).roots
roots_charpoly_orthogonal_compress_le_of_reducing :
  (charpoly (compress T Hᗮ)).roots ≤ (charpoly T).roots
```

Each compression block's eigenvalue multiset (roots of its charpoly, counted with algebraic multiplicity) is a **sub-multiset** of the ambient eigenvalue multiset. This sharpens the set-level `spectrum_compress_subset_of_invariant` to a counted containment, and is the multiset shadow of the divisibility lemma `charpoly_compress_dvd_of_reducing` (`p ∣ q ⟹ p.roots ≤ q.roots`).

Both follow in two lines from the existing eigenvalue-multiset additivity `roots_charpoly_eq_add_compress_of_reducing` via `Multiset.le_add_right` / `Multiset.le_add_left`. **0 sorry / 0 axiom.**

## Verification status: UNVERIFIED (infra-blocked)

Docker build infrastructure is down fleet-wide this session — the containerd content-store returns I/O errors (`.../io.containerd.content.v1.content/blobs/...: input/output error`) before image build, so `docker-build.sh` cannot run. This is an operator-level blocker, not a proof defect.

Confidence is high regardless:
- The two Mathlib lemmas `Multiset.le_add_right (s t) : s ≤ s + t` and `Multiset.le_add_left (s t) : s ≤ t + s` were verified against `Mathlib/Data/Multiset/AddSub.lean`.
- The proofs consume the same `roots_charpoly_eq_add_compress_of_reducing` equation that the already-verified sibling `charpoly_compress_dvd_of_reducing` uses.

Also syncs the sibling gallery meta (`cauchy-interlacing-theorem-oq-01-oq-02`) lineCount 1186→1218, theoremCount 38→40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)