### PR TITLE
research(erdos-1138-oq-03-oq-01): effective individual-gap bound

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -308,4 +308,21 @@ theorem consecutive_gap_div_le_rpow_neg {x p q : ℕ} (hx : 25 ≤ x)
       ≤ (maxPrimeGap x : ℝ) / x := by gcongr
     _ ≤ (x : ℝ) ^ (-(0.475 : ℝ)) := gap_div_le_rpow_neg x hx
 
+/-- **Effective individual-gap bound.** The gap-level counterpart of
+`bhp_gap_le_eps_effective`: for any `ε` and `x ≥ 25` at which the explicit threshold
+`1 ≤ ε · x^0.475` holds (equivalently `x^(-0.475) ≤ ε`, the point where the envelope has
+dropped below `ε`), *every* consecutive-prime gap `q - p` with `q ≤ x` already satisfies
+`q - p ≤ ε · x`.  Composes the bridge `consecutive_gap_le_maxPrimeGap` with the effective
+sup-level bound, completing the gap-level trilogy alongside `consecutive_gap_le_rpow`
+(`≤ x^0.525`) and `consecutive_gap_div_le_rpow_neg` (`/x ≤ x^(-0.475)`).  As with the
+sup-level version, positivity of `ε` is forced by the threshold, not assumed. -/
+theorem consecutive_gap_le_eps_effective {x p q : ℕ} (ε : ℝ)
+    (hx25 : 25 ≤ x) (hthr : 1 ≤ ε * (x : ℝ) ^ (0.475 : ℝ))
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p < q) (hqx : q ≤ x)
+    (hcons : ∀ r, Nat.Prime r → p < r → q ≤ r) :
+    ((q - p : ℕ) : ℝ) ≤ ε * x := by
+  have hbridge : ((q - p : ℕ) : ℝ) ≤ (maxPrimeGap x : ℝ) := by
+    exact_mod_cast consecutive_gap_le_maxPrimeGap hp hq hpq hqx hcons
+  exact le_trans hbridge (bhp_gap_le_eps_effective ε x hx25 hthr)
+
 end Erdos1138OQ03


### PR DESCRIPTION
## Summary

`Erdos1138OQ03OQ01.lean` (BHP ⟹ prime gaps are sublinear) already carries two gap-level bounds — `consecutive_gap_le_rpow` (`q-p ≤ x^0.525`) and `consecutive_gap_div_le_rpow_neg` (`(q-p)/x ≤ x^(-0.475)`) — but was missing the **effective-ε** version, the gap-level counterpart of the sup-level `bhp_gap_le_eps_effective`.

This PR adds `consecutive_gap_le_eps_effective`, completing the gap-level trilogy.

## New declaration (1, 0 sorry / 0 new axiom)

```lean
theorem consecutive_gap_le_eps_effective {x p q : ℕ} (ε : ℝ)
    (hx25 : 25 ≤ x) (hthr : 1 ≤ ε * (x : ℝ) ^ (0.475 : ℝ))
    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p < q) (hqx : q ≤ x)
    (hcons : ∀ r, Nat.Prime r → p < r → q ≤ r) :
    ((q - p : ℕ) : ℝ) ≤ ε * x
```

At any `x ≥ 25` where the explicit threshold `1 ≤ ε·x^0.475` holds (equivalently `x^(-0.475) ≤ ε`), every consecutive-prime gap `q-p` with `q ≤ x` satisfies `q-p ≤ ε·x`. Two-line composition of the bridge `consecutive_gap_le_maxPrimeGap` with the already-verified effective sup-level bound `bhp_gap_le_eps_effective`. (Depends on the file's existing `baker_harman_pintz` axiom — no new axioms.)

## Verification status

**UNVERIFIED (infra)** — Docker build unavailable this session: `docker-build.sh` fails at image build with a containerd `meta.db` input/output error (known host infrastructure failure, not a proof error). The proof composes only already-verified declarations in this file; confidence is high pending a green rebuild once Docker is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)