### PR TITLE
Enrich The Cardinality Gap (ℚ, ℝ, CH): add references (REFS0 fix)

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-01/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-01/meta.json
@@ -179,6 +179,43 @@
       "description": "Constructive denumerability of algebraic numbers — another cardinality result in the countable hierarchy."
     }
   ],
+  "references": [
+    {
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "author": "Georg Cantor",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik 77, 258–262",
+      "description": "Cantor's first proof that the algebraic (hence rational) reals are countable while ℝ is not, establishing the cardinality gap |ℚ| = ℵ₀ < 𝔠 = |ℝ| that this entry formalizes."
+    },
+    {
+      "title": "Über eine elementare Frage der Mannigfaltigkeitslehre",
+      "author": "Georg Cantor",
+      "year": "1891",
+      "venue": "Jahresbericht der Deutschen Mathematiker-Vereinigung 1, 75–78",
+      "description": "The diagonal argument giving |𝒫(X)| > |X| for every set, hence 𝔠 = |𝒫(ℚ)| = 2^ℵ₀ > ℵ₀ — the source of the Dedekind-cut cardinality |𝒫(ℚ)| = 𝔠 used here."
+    },
+    {
+      "title": "The Consistency of the Axiom of Choice and of the Generalized Continuum Hypothesis with the Axioms of Set Theory",
+      "author": "Kurt Gödel",
+      "year": "1940",
+      "venue": "Annals of Mathematics Studies 3, Princeton University Press",
+      "description": "Gödel's constructible universe L shows CH cannot be refuted from ZFC; half of the independence result axiomatized in this entry."
+    },
+    {
+      "title": "The Independence of the Continuum Hypothesis",
+      "author": "Paul J. Cohen",
+      "year": "1963",
+      "venue": "Proceedings of the National Academy of Sciences 50, 1143–1148",
+      "description": "Cohen's forcing method shows CH cannot be proved from ZFC; together with Gödel it establishes the full independence this entry states via axioms."
+    },
+    {
+      "title": "Set Theory",
+      "author": "Thomas Jech",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics (3rd Millennium ed.)",
+      "description": "Standard graduate reference for cardinal arithmetic, the continuum function, and the forcing proof of the independence of CH from ZFC."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.SetTheory.Cardinal.Basic",


### PR DESCRIPTION
Fills the empty `references` field on denumerability-rationals-oq-01 with 5 accurate sources:

- **Cantor (1874)** — countability of algebraic reals vs uncountable ℝ (the cardinality gap)
- **Cantor (1891)** — the diagonal argument, |𝒫(X)| > |X|, giving 𝔠 = 2^ℵ₀
- **Gödel (1940)** — consistency of CH with ZFC (constructible universe L)
- **Cohen (1963)** — independence of CH from ZFC (forcing)
- **Jech (2003)** — standard reference for cardinal arithmetic and forcing

Content-only enrichment (REFS0 defect class). Other fields (5 keyInsights, 8 sections, 5 crossReferences) were already complete. meta.json well under the 60 KB cap.