### PR TITLE
Fix: sync stale lineCount in erdos-659-oq-05 (125->142)

### DIFF
--- a/src/data/proofs/erdos-659-oq-05/meta.json
+++ b/src/data/proofs/erdos-659-oq-05/meta.json
@@ -34,13 +34,13 @@
       "isRepresented_nonneg: represented integers are nonnegative (valid squared distances)",
       "dist_sq_lattice: squared distance between lattice points (x,y√2) equals Q of coordinate differences — ties the number theory to the actual Moree–Osburn geometry"
     ],
-    "lineCount": 125,
+    "lineCount": 142,
     "theoremCount": 10,
     "definitionCount": 4
   },
   "leanFile": {
     "path": "Proofs/Erdos659OQ05.lean",
-    "lineCount": 125,
+    "lineCount": 142,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Corrected stale `lineCount` metadata in `erdos-659-oq-05` from 125 to 142 in both `meta.lineCount` and `leanFile.lineCount`.

## Evidence

**Before**: meta.json declared `lineCount: 125` (both entries).
**After**: `lineCount: 142`, matching `wc -l proofs/Proofs/Erdos659OQ05.lean` (142 lines, trailing newline present).

The file grew (a `dist_sq_lattice` theorem) without a metadata resync. Other counts verified correct: theoremCount=10, axiomCount=0, sorries=0 (the lone `sorry` token appears only in a docstring: "axiom-free and sorry-free").

---
Automated fix by lean-mechanic agent.