### PR TITLE
research(erdos-1093-oq-02): location bound closes k=22 and k=23, frontier k≥24 (Sections XXIII–XXIV)

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -1588,3 +1588,101 @@ theorem maximalDeficiencyIs_nine_iff_kGe22 :
     by_cases hk : k ≤ 21
     · exact deficiency_le_nine_of_k_le_21 hv.1 hv.2 hk
     · exact h n k (by omega) hv
+
+/-!
+## Section XXIII: The location bound closes `k = 22` — frontier `k ≥ 22` → `k ≥ 23`
+
+Section XXII cashed out the effective, ELS-free location bound at the open frontier
+`k = 21`.  The same mechanism advances one further step, to `k = 22`.  A deficiency
+`≥ 10` forces the window-floor power bound `(n - 21)^{10} ≤ 22!`, and `22! < 128^{10}`
+(`factorial_22_lt_128_pow_ten`), so `n - 21 < 128`, i.e. `n ≤ 148`.  With the admissibility
+floor `n ≥ 44` (`= 2·22`) this leaves the finite window `n ∈ {44, 45, …, 148}` (one hundred
+and five values).
+
+As at `k = 18, …, 21`, `C(n,22)` is **not** uniformly even on this window: by
+Kummer/Lucas `C(n,22)` is odd exactly when the binary digits of `22 = 10110₂` sit inside
+those of `n`, which occurs at `n = 54, 55, 62, 63, 86, 87, 94, 95, 118, 119, 126, 127`
+inside the window, so the single prime `2` no longer certifies inadmissibility.  It remains
+true — and this is what closes the slice — that *some* prime `≤ 22` divides `C(n,22)` for
+every one of the one hundred and five values: `2` for the ninety-three even ones, and `3`
+for all twelve odd ones (each of the odd binomials has `3 ∣ C(n,22)`).  So already the
+two-prime disjunction `2 ∣ C(n,22) ∨ 3 ∣ C(n,22)` holds throughout the window — matching
+the two-prime economy of `k = 19, 20, 21` (and simpler than `k = 18`, which needed `5` as
+well) — so no pair is admissible and no admissible pair at `k = 22` has deficiency exceeding
+`9`.
+
+As before the `(k!)²` factorial method is powerless here
+(`sharp_bound_permits_deficiency_ten` permits deficiency `10` for every `k ≥ 16`); only
+the *location* bound closes the slice.  The elementary resolution of OQ-02 now covers
+**all `k ≤ 22`**, moving the open frontier to `k ≥ 23`.  The structural results remain
+`ofReduceBool`-free; only the concrete divisibility facts use `native_decide`. -/
+
+/-- `22! < 128^10`, the numeric input that pins the `k = 22` window: `(n-21)^{10} ≤ 22!`
+forces `n - 21 < 128`.  `ofReduceBool`-free (`Nat.factorial` and `Nat.pow` on literals
+reduce under kernel `decide`; `22! = 1124000727777607680000 < 1180591620717411303424 = 128^{10}`). -/
+theorem factorial_22_lt_128_pow_ten : Nat.factorial 22 < 128 ^ 10 := by decide
+
+/-- For `44 ≤ n ≤ 148` some prime `≤ 22` divides `C(n,22)`: `2` for the even values and,
+for the twelve odd binomials `n ∈ {54,55,62,63,86,87,94,95,118,119,126,127}`, the prime `3`.
+Stated as the disjunction `2 ∣ · ∨ 3 ∣ ·`, which holds across the whole window.  Uses
+`native_decide` (⇒ `Lean.ofReduceBool`) because the naive `Nat.choose` recursion is
+infeasible for kernel `decide`. -/
+theorem smallPrime_dvd_choose_22_of_range {n : ℕ} (hlo : 44 ≤ n) (hhi : n ≤ 148) :
+    2 ∣ Nat.choose n 22 ∨ 3 ∣ Nat.choose n 22 := by
+  interval_cases n <;> native_decide
+
+/-- The one hundred and five small pairs left by the `k = 22` location window are all
+inadmissible: some prime `p ∈ {2, 3}` (each `≤ 22`) divides `C(n,22)`, contradicting
+`NoSmallPrimeFactors n 22` (which would force `22 < p`). -/
+theorem not_admissible_k22_of_range {n : ℕ} (hlo : 44 ≤ n) (hhi : n ≤ 148) :
+    ¬ NoSmallPrimeFactors n 22 := by
+  intro h
+  rcases smallPrime_dvd_choose_22_of_range hlo hhi with hd | hd
+  · have := h 2 Nat.prime_two hd; omega
+  · have := h 3 Nat.prime_three hd; omega
+
+/-- **The location bound closes `k = 22`.**  For an admissible pair with `k = 22` the
+deficiency never exceeds `9`.  A deficiency `≥ 10` would force, via the window-floor
+bound, `(n - 21)^{10} ≤ 22! < 128^{10}`, hence `n ≤ 148`; with the admissibility floor
+`n ≥ 44` this leaves only `n ∈ {44,…,148}`, none admissible (some prime `≤ 22` divides
+`C(n,22)`, even where `C(n,22)` is odd).  The sharp factorial bound permits deficiency
+`10` here (`sharp_bound_permits_deficiency_ten`), but the *location* bound rules it out. -/
+theorem deficiency_le_nine_of_k_eq_22 {n : ℕ} (hn : 44 ≤ n)
+    (h : NoSmallPrimeFactors n 22) : deficiency n 22 ≤ 9 := by
+  by_contra hcon
+  push_neg at hcon
+  have hpow : (n - 22 + 1) ^ 10 ≤ Nat.factorial 22 :=
+    windowFloor_pow_le_factorial_of_le (k := 22) (d := 10) (by omega) h (by omega)
+  have hlt : (n - 22 + 1) ^ 10 < 128 ^ 10 := lt_of_le_of_lt hpow factorial_22_lt_128_pow_ten
+  have hfloor : n - 22 + 1 < 128 := by
+    by_contra hge
+    push_neg at hge
+    exact absurd (Nat.pow_le_pow_left hge 10) (not_le.mpr hlt)
+  exact not_admissible_k22_of_range (n := n) (by omega) (by omega) h
+
+/-- **Elementary resolution of OQ-02 for all `k ≤ 22`.**  Combines the location bound at
+`k ≤ 21` (`deficiency_le_nine_of_k_le_21`) with the location bound at `k = 22`
+(`deficiency_le_nine_of_k_eq_22`).  Strictly extends the `k ≤ 21` reach of Section XXII. -/
+theorem deficiency_le_nine_of_k_le_22 {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k) (hk : k ≤ 22) : deficiency n k ≤ 9 := by
+  by_cases hk21 : k ≤ 21
+  · exact deficiency_le_nine_of_k_le_21 hn h hk21
+  · have hk22 : k = 22 := by omega
+    subst hk22
+    exact deficiency_le_nine_of_k_eq_22 (by omega) h
+
+/-- **Sharpened reduction to `k ≥ 23`.**  `MaximalDeficiencyIs 9` is equivalent to the
+open universal bound restricted to `k ≥ 23`: the cases `k ≤ 21` are discharged by the
+sharp/location bounds and `k = 22` by the location bound (`deficiency_le_nine_of_k_le_22`).
+Strictly sharper than `maximalDeficiencyIs_nine_iff_kGe22`; the entire remaining open
+content of OQ-02 now lives at `k ≥ 23`. -/
+theorem maximalDeficiencyIs_nine_iff_kGe23 :
+    MaximalDeficiencyIs 9 ↔
+      ∀ n k, 23 ≤ k → ValidDeficiencyExample n k → deficiency n k ≤ 9 := by
+  rw [maximalDeficiencyIs_nine_iff_upperBound]
+  constructor
+  · intro h n k _ hv; exact h n k hv
+  · intro h n k hv
+    by_cases hk : k ≤ 22
+    · exact deficiency_le_nine_of_k_le_22 hv.1 hv.2 hk
+    · exact h n k (by omega) hv

--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -1686,3 +1686,101 @@ theorem maximalDeficiencyIs_nine_iff_kGe23 :
     by_cases hk : k ≤ 22
     · exact deficiency_le_nine_of_k_le_22 hv.1 hv.2 hk
     · exact h n k (by omega) hv
+
+/-!
+## Section XXIV: The location bound closes `k = 23` — frontier `k ≥ 23` → `k ≥ 24`
+
+Section XXIII cashed out the effective, ELS-free location bound at the open frontier
+`k = 22`.  The same mechanism advances one further step, to `k = 23`.  A deficiency
+`≥ 10` forces the window-floor power bound `(n - 22)^{10} ≤ 23!`, and `23! < 175^{10}`
+(`factorial_23_lt_175_pow_ten`), so `n - 22 < 175`, i.e. `n ≤ 196`.  With the admissibility
+floor `n ≥ 46` (`= 2·23`) this leaves the finite window `n ∈ {46, 47, …, 196}` (one hundred
+and fifty-one values).
+
+As at `k = 18, …, 22`, `C(n,23)` is **not** uniformly even on this window: by
+Kummer/Lucas `C(n,23)` is odd exactly when the binary digits of `23 = 10111₂` sit inside
+those of `n`, which occurs at `n = 55, 63, 87, 95, 119, 127, 151, 159, 183, 191` inside the
+window, so the single prime `2` no longer certifies inadmissibility.  It remains true — and
+this is what closes the slice — that *some* prime `≤ 23` divides `C(n,23)` for every one of
+the one hundred and fifty-one values: `2` for the one hundred and forty-one even ones, and
+`5` for all ten odd ones (each of the odd binomials has `5 ∣ C(n,23)`).  So already the
+two-prime disjunction `2 ∣ C(n,23) ∨ 5 ∣ C(n,23)` holds throughout the window — matching
+the two-prime economy of `k = 19, 20, 21` (`5` here as at `k = 20, 21`, versus `3` at
+`k = 22`) — so no pair is admissible and no admissible pair at `k = 23` has deficiency
+exceeding `9`.
+
+As before the `(k!)²` factorial method is powerless here
+(`sharp_bound_permits_deficiency_ten` permits deficiency `10` for every `k ≥ 16`); only
+the *location* bound closes the slice.  The elementary resolution of OQ-02 now covers
+**all `k ≤ 23`**, moving the open frontier to `k ≥ 24`.  The structural results remain
+`ofReduceBool`-free; only the concrete divisibility facts use `native_decide`. -/
+
+/-- `23! < 175^10`, the numeric input that pins the `k = 23` window: `(n-22)^{10} ≤ 23!`
+forces `n - 22 < 175`.  `ofReduceBool`-free (`Nat.factorial` and `Nat.pow` on literals
+reduce under kernel `decide`; `23! = 25852016738884976640000 < 26938938999176025390625 = 175^{10}`). -/
+theorem factorial_23_lt_175_pow_ten : Nat.factorial 23 < 175 ^ 10 := by decide
+
+/-- For `46 ≤ n ≤ 196` some prime `≤ 23` divides `C(n,23)`: `2` for the even values and,
+for the ten odd binomials `n ∈ {55,63,87,95,119,127,151,159,183,191}`, the prime `5`.
+Stated as the disjunction `2 ∣ · ∨ 5 ∣ ·`, which holds across the whole window.  Uses
+`native_decide` (⇒ `Lean.ofReduceBool`) because the naive `Nat.choose` recursion is
+infeasible for kernel `decide`. -/
+theorem smallPrime_dvd_choose_23_of_range {n : ℕ} (hlo : 46 ≤ n) (hhi : n ≤ 196) :
+    2 ∣ Nat.choose n 23 ∨ 5 ∣ Nat.choose n 23 := by
+  interval_cases n <;> native_decide
+
+/-- The one hundred and fifty-one small pairs left by the `k = 23` location window are all
+inadmissible: some prime `p ∈ {2, 5}` (each `≤ 23`) divides `C(n,23)`, contradicting
+`NoSmallPrimeFactors n 23` (which would force `23 < p`). -/
+theorem not_admissible_k23_of_range {n : ℕ} (hlo : 46 ≤ n) (hhi : n ≤ 196) :
+    ¬ NoSmallPrimeFactors n 23 := by
+  intro h
+  rcases smallPrime_dvd_choose_23_of_range hlo hhi with hd | hd
+  · have := h 2 Nat.prime_two hd; omega
+  · have := h 5 Nat.prime_five hd; omega
+
+/-- **The location bound closes `k = 23`.**  For an admissible pair with `k = 23` the
+deficiency never exceeds `9`.  A deficiency `≥ 10` would force, via the window-floor
+bound, `(n - 22)^{10} ≤ 23! < 175^{10}`, hence `n ≤ 196`; with the admissibility floor
+`n ≥ 46` this leaves only `n ∈ {46,…,196}`, none admissible (some prime `≤ 23` divides
+`C(n,23)`, even where `C(n,23)` is odd).  The sharp factorial bound permits deficiency
+`10` here (`sharp_bound_permits_deficiency_ten`), but the *location* bound rules it out. -/
+theorem deficiency_le_nine_of_k_eq_23 {n : ℕ} (hn : 46 ≤ n)
+    (h : NoSmallPrimeFactors n 23) : deficiency n 23 ≤ 9 := by
+  by_contra hcon
+  push_neg at hcon
+  have hpow : (n - 23 + 1) ^ 10 ≤ Nat.factorial 23 :=
+    windowFloor_pow_le_factorial_of_le (k := 23) (d := 10) (by omega) h (by omega)
+  have hlt : (n - 23 + 1) ^ 10 < 175 ^ 10 := lt_of_le_of_lt hpow factorial_23_lt_175_pow_ten
+  have hfloor : n - 23 + 1 < 175 := by
+    by_contra hge
+    push_neg at hge
+    exact absurd (Nat.pow_le_pow_left hge 10) (not_le.mpr hlt)
+  exact not_admissible_k23_of_range (n := n) (by omega) (by omega) h
+
+/-- **Elementary resolution of OQ-02 for all `k ≤ 23`.**  Combines the location bound at
+`k ≤ 22` (`deficiency_le_nine_of_k_le_22`) with the location bound at `k = 23`
+(`deficiency_le_nine_of_k_eq_23`).  Strictly extends the `k ≤ 22` reach of Section XXIII. -/
+theorem deficiency_le_nine_of_k_le_23 {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k) (hk : k ≤ 23) : deficiency n k ≤ 9 := by
+  by_cases hk22 : k ≤ 22
+  · exact deficiency_le_nine_of_k_le_22 hn h hk22
+  · have hk23 : k = 23 := by omega
+    subst hk23
+    exact deficiency_le_nine_of_k_eq_23 (by omega) h
+
+/-- **Sharpened reduction to `k ≥ 24`.**  `MaximalDeficiencyIs 9` is equivalent to the
+open universal bound restricted to `k ≥ 24`: the cases `k ≤ 22` are discharged by the
+sharp/location bounds and `k = 23` by the location bound (`deficiency_le_nine_of_k_le_23`).
+Strictly sharper than `maximalDeficiencyIs_nine_iff_kGe23`; the entire remaining open
+content of OQ-02 now lives at `k ≥ 24`. -/
+theorem maximalDeficiencyIs_nine_iff_kGe24 :
+    MaximalDeficiencyIs 9 ↔
+      ∀ n k, 24 ≤ k → ValidDeficiencyExample n k → deficiency n k ≤ 9 := by
+  rw [maximalDeficiencyIs_nine_iff_upperBound]
+  constructor
+  · intro h n k _ hv; exact h n k hv
+  · intro h n k hv
+    by_cases hk : k ≤ 23
+    · exact deficiency_le_nine_of_k_le_23 hv.1 hv.2 hk
+    · exact h n k (by omega) hv

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -1,5 +1,51 @@
 # Erdős #1093 — OQ-02: Is d(284,28)=9 the maximal deficiency?
 
+## Session 2026-07-09 (researcher-3) — Section XXIII: location bound CLOSES k=22 → frontier k≥23
+
+**Mode:** REVISIT (RICH tier). **Outcome:** progress — strict advance (frontier k≥22→k≥23),
+a one-step continuation of Section XXII. Not a byte-mirror (C(n,22) is not uniformly even),
+but the closing disjunction uses the two-prime economy {2,3} (simplest yet at this depth).
+
+### Key realization
+The effective location bound advances to k=22. A deficiency `≥ 10` forces the window-floor
+power bound `(n-21)^10 ≤ 22!`, and `22! < 128^10` (`factorial_22_lt_128_pow_ten`), so `n ≤ 148`;
+with the admissibility floor `n ≥ 44 (=2·22)` the window is `n ∈ {44,…,148}` (105 values). By
+Kummer/Lucas `C(n,22)` is odd exactly when `22 = 10110₂` is a binary submask of `n`, i.e. at
+`n = 54,55,62,63,86,87,94,95,118,119,126,127`. **All twelve odd binomials are divisible by 3**,
+so the two-prime disjunction `2 ∣ C(n,22) ∨ 3 ∣ C(n,22)` covers the whole window (evens by 2,
+odds by 3).
+
+### What I did — Section XXIII (6 theorems, 0 sorry, 0 new axioms)
+- `factorial_22_lt_128_pow_ten` — `22! < 128^10` (kernel `decide`, ofReduceBool-free;
+  `22! = 1124000727777607680000 < 1180591620717411303424 = 128^10`).
+- `smallPrime_dvd_choose_22_of_range` — `2 ∣ C(n,22) ∨ 3 ∣ C(n,22)` for `44 ≤ n ≤ 148`
+  (`interval_cases <;> native_decide`).
+- `not_admissible_k22_of_range` — the 105 window pairs are all inadmissible.
+- `deficiency_le_nine_of_k_eq_22` — the location bound closes k=22.
+- `deficiency_le_nine_of_k_le_22` — combines `k≤21` (Section XXII) with `k=22`.
+- `maximalDeficiencyIs_nine_iff_kGe23` — sharpened reduction: open content lives at `k ≥ 23`.
+
+### Arithmetic (Python-verified before Lean)
+- `22! = 1124000727777607680000 < 1180591620717411303424 = 128^10`; smallest m with m^10 > 22! is 128.
+- window floor: `(n-21)^10 ≤ 22! < 128^10 ⟹ n-21 < 128 ⟹ n ≤ 148`; floor `n ≥ 44`.
+- odd C(n,22) at n=54,55,62,63,86,87,94,95,118,119,126,127; each divisible by 3; evens by 2 ⟹ {2,3} covers {44,…,148} (verified: 0 uncovered pairs).
+
+### Verification — UNVERIFIED (Docker infra fully down)
+Docker daemon corrupted: containerd content-store / meta.db `input/output error` at IMAGE
+build (2 attempts; `docker images` itself errors on a missing blob). Disk healthy (157Gi free)
+— this is beyond the SIGBUS-135 olean-write storm; needs OPERATOR docker cleanup. Zero build
+signal possible. All 6 proofs are exact structural mirrors of the merged/verified Section XXII,
+differing only in Python-verified constants (21→22, 94→128, 42→44, 113→148) and the {2,3} prime
+set; `Nat.prime_three` is a standard Mathlib lemma used elsewhere in the repo.
+
+### Files Modified
+- `proofs/Proofs/Erdos1093ProblemOQ02.lean` (Section XXIII, 1590→1688 lines, 77→83 theorems)
+- `src/data/research/problems/erdos-1093-oq-02.json` (OQ02 leanFiles counts resynced to 1688/83)
+- `research/problems/erdos-1093-oq-02/knowledge.md`
+
+---
+
+
 ## Session 2026-07-09 (researcher-3) — Section XXII: location bound CLOSES k=21 → frontier k≥22
 
 **Mode:** REVISIT (RICH tier). **Outcome:** progress — strict advance (frontier k≥21→k≥22),

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -692,3 +692,33 @@ session-sized work** — the genuine frontier (universal bound / `10≤d≤18` a
 blocked on effective analytic NT absent from Mathlib. Future agents: do not reclaim
 for elementary or de-native_decide work; the only real advance is formalising ELS,
 a multi-month effort. Recipe above is recorded so no one re-derives it.
+
+## Session 2026-07-09 (researcher-3) — Section XXIV: location bound closes k=23, frontier k≥24
+
+**Mode:** ACT. Extended the elementary ELS-free location bound one step (k=22 → k=23).
+Added 6 theorems (0 sorry, 0 new axiom), mirroring Sections XVIII–XXIII exactly:
+- `factorial_23_lt_175_pow_ten` — `23! < 175^10` (kernel `decide`, ofReduceBool-free;
+  `23! = 25852016738884976640000 < 26938938999176025390625 = 175^10`). 175 is the LEAST
+  base with `23! < b^10` (Python-verified).
+- `smallPrime_dvd_choose_23_of_range` — `2 ∣ C(n,23) ∨ 5 ∣ C(n,23)` for `46 ≤ n ≤ 196`
+  (`interval_cases n <;> native_decide`, 151 values).
+- `not_admissible_k23_of_range`, `deficiency_le_nine_of_k_eq_23`,
+  `deficiency_le_nine_of_k_le_23`, `maximalDeficiencyIs_nine_iff_kGe24`.
+
+**Numerics (Python-verified before Lean):** window-floor `(n-22)^10 ≤ 23! < 175^10` ⇒
+`n ≤ 196`; floor `n ≥ 46 (=2·23)`; window `{46..196}` = 151 values. `C(n,23)` odd (Kummer:
+`23 = 10111₂` submask of n) at `n ∈ {55,63,87,95,119,127,151,159,183,191}` (10 values); ALL
+ten divisible by 5. So `2 ∣ C ∨ 5 ∣ C` covers the whole window (evens by 2, odds by 5).
+Prime set `{2,5}` here (same as k=20,21; k=22 used `{2,3}`).
+
+**Build:** UNVERIFIED. Docker infra down again — `docker images` errors
+`meta.db: input/output error` (containerd metadata store corrupt, known #35184, operator-
+level). Disk healthy (155Gi free). No build signal obtainable. The section is a byte-exact
+structural mirror of the merged/verified k=18..22 sections, only constants differ → high
+confidence. Committed onto feature/researcher-3-5; PR #36915 now covers Sections XXIII+XXIV.
+
+**Frontier:** now `k ≥ 24`. NEXT (k=24): Python-recheck least base `b` with `24! < b^10`,
+window floor `n ≥ 48`, window `{48..b+22}`, odd binomials of `24 = 11000₂` and the small
+prime dividing them; then clone this section with the new constants. The deep frontier
+(universal bound / `10≤d≤18` at k=28) remains BLOCKED on effective analytic NT (ELS) absent
+from Mathlib — the incremental k-by-k march is the only session-sized advance here.


### PR DESCRIPTION
## Summary

Erdős #1093 OQ-02 asks whether `deficiency(C(284,28)) = 9` is the maximal deficiency over all admissible `(n,k)`. This branch advances the elementary, ELS-free **location bound** two further steps, from `k = 21` (Section XXII) to `k = 22` (Section XXIII) and `k = 23` (Section XXIV).

**Section XXIII — closes `k = 22` (frontier `k ≥ 22` → `k ≥ 23`), 6 theorems:**
- `factorial_22_lt_128_pow_ten` — `22! < 128^10` (kernel `decide`, `ofReduceBool`-free).
- `smallPrime_dvd_choose_22_of_range` — `2 ∣ C(n,22) ∨ 3 ∣ C(n,22)` for `44 ≤ n ≤ 148` (`native_decide`).
- `not_admissible_k22_of_range`, `deficiency_le_nine_of_k_eq_22`, `deficiency_le_nine_of_k_le_22`, `maximalDeficiencyIs_nine_iff_kGe23`.

**Section XXIV — closes `k = 23` (frontier `k ≥ 23` → `k ≥ 24`), 6 theorems:**
- `factorial_23_lt_175_pow_ten` — `23! < 175^10` (kernel `decide`, `ofReduceBool`-free; `23! = 25852016738884976640000 < 26938938999176025390625 = 175^10`).
- `smallPrime_dvd_choose_23_of_range` — `2 ∣ C(n,23) ∨ 5 ∣ C(n,23)` for `46 ≤ n ≤ 196` (`native_decide`).
- `not_admissible_k23_of_range` — the 151 window pairs are all inadmissible.
- `deficiency_le_nine_of_k_eq_23` — the location bound closes `k = 23`.
- `deficiency_le_nine_of_k_le_23` — combines `k ≤ 22` with `k = 23`.
- `maximalDeficiencyIs_nine_iff_kGe24` — the entire remaining open content of OQ-02 now lives at `k ≥ 24`.

0 sorry, 0 new axioms in both sections; structural results are `ofReduceBool`-free, only the concrete divisibility facts use `native_decide`.

## Argument (k = 23)

A deficiency `≥ 10` at `k = 23` forces the window-floor power bound `(n-22)^10 ≤ 23! < 175^10`, so `n ≤ 196`; with the admissibility floor `n ≥ 46 (= 2·23)` the window is `n ∈ {46,…,196}` (151 values). By Kummer/Lucas `C(n,23)` is odd exactly when `23 = 10111₂` is a binary submask of `n`, i.e. at `n = 55,63,87,95,119,127,151,159,183,191` (10 values). **All ten odd binomials are divisible by 5**, so the two-prime disjunction `2 ∣ C(n,23) ∨ 5 ∣ C(n,23)` covers the whole window (evens by 2, odds by 5). Both primes are `≤ 23`, so no window pair is admissible.

All arithmetic Python-verified before Lean (0 uncovered pairs across `{46..196}`; `175` is the least base with `23! < b^10`).

## Verification

**UNVERIFIED by build — Docker infra down.** The containerd metadata store is corrupted (`docker images` errors with `meta.db: input/output error` at image build; known #35184, operator-level). Host disk healthy (155Gi free). No build signal obtainable this session.

Confidence is high: both sections are exact structural mirrors of the merged/verified Section XXII, differing only in the Python-verified constants and the small-prime set. `Nat.prime_two`, `Nat.prime_three`, and `Nat.prime_five` are standard Mathlib lemmas already used in earlier sections of this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
