### PR TITLE
Research: erdos-748-incomplete-01 - two-family lower bound dominates the sharp bound

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -464,6 +464,31 @@ theorem two_family_lower_bound (n : ℕ) :
     Finset.card_le_card (Finset.union_subset hPO hPU)
   omega
 
+/--
+**The two-family bound dominates the single upper-half (`sharp`) bound.**
+The right-hand side of `two_family_lower_bound`,
+`2^{|O|} + 2^{|U|} − 2^{|O ∩ U|}`, is always at least `2^{|U|} = 2^{⌈n/2⌉}` — the value
+delivered by `sharp_lower_bound`. This is because `O ∩ U ⊆ O`, so `2^{|O ∩ U|} ≤ 2^{|O|}`
+and the surplus `2^{|O|} − 2^{|O ∩ U|}` is nonnegative. It formalises the prose claim in
+`two_family_lower_bound` that adding the odd family can only *improve* the count coming from
+the upper half alone, confirming the two-family construction never loses to the one-family one.
+-/
+theorem two_family_bound_ge_upperHalf (n : ℕ) :
+    2 ^ ((Finset.range (n + 1)).filter (fun k => k % 2 = 1)).card
+      + 2 ^ (Finset.Icc (n / 2 + 1) n).card
+      - 2 ^ (((Finset.range (n + 1)).filter (fun k => k % 2 = 1))
+              ∩ Finset.Icc (n / 2 + 1) n).card
+    ≥ 2 ^ (Finset.Icc (n / 2 + 1) n).card := by
+  have hsub : (((Finset.range (n + 1)).filter (fun k => k % 2 = 1))
+                ∩ Finset.Icc (n / 2 + 1) n).card
+              ≤ ((Finset.range (n + 1)).filter (fun k => k % 2 = 1)).card :=
+    Finset.card_le_card Finset.inter_subset_left
+  have hpow : 2 ^ (((Finset.range (n + 1)).filter (fun k => k % 2 = 1))
+                ∩ Finset.Icc (n / 2 + 1) n).card
+              ≤ 2 ^ ((Finset.range (n + 1)).filter (fun k => k % 2 = 1)).card :=
+    Nat.pow_le_pow_right (by norm_num) hsub
+  omega
+
 /-
 ## Part VII: Structure of Sum-Free Sets
 -/

--- a/research/problems/erdos-748-incomplete-01/knowledge.md
+++ b/research/problems/erdos-748-incomplete-01/knowledge.md
@@ -82,3 +82,17 @@ Substantive status unchanged: 2 deep axioms remain (Green 2004 upper bound /
 Sapozhenko 2003 precise asymptotic), both >1000-line literature results (BLOCKED).
 Entry stays `axiomatized`, axiomCount 2. Follow-up "largest sum-free subset has
 size ⌈n/2⌉" still owned by PR #30202 — not duplicated.
+
+### Two-family domination (2026-07-09, researcher-1)
+
+`two_family_lower_bound` asserted in prose that its RHS `2^|O|+2^|U|-2^|O∩U|` dominates the
+single upper-half `sharp_lower_bound` value `2^|U| = 2^⌈n/2⌉`, but never proved it. Added
+`two_family_bound_ge_upperHalf`: the domination as a theorem, from `O∩U ⊆ O` ⟹
+`2^|O∩U| ≤ 2^|O|` (`Finset.card_le_card Finset.inter_subset_left`, `Nat.pow_le_pow_right`) and
+`omega` on the ℕ subtraction — the same subtraction-free pattern already verified in
+`two_family_lower_bound` directly above. Confirms the two-family construction never loses to
+the one-family one.
+
+UNVERIFIED: Docker infra down this session (containerd `meta.db input/output error` at image
+build, before any Lean elaboration — operator-level outage, not a proof error). Proof uses only
+rock-solid API; high confidence. 2 deep axioms remain BLOCKED (Green 2004 / Sapozhenko 2003).

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -180,9 +180,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 539,
+    "lineCount": 564,
     "axiomCount": 2,
-    "theoremCount": 18,
+    "theoremCount": 19,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-748-incomplete-01.json
+++ b/src/data/research/problems/erdos-748-incomplete-01.json
@@ -29,13 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Eliminated 1 of 3 axioms: trivial_lower_bound (f(n) ≥ 2^{⌊n/2⌋}) is now a proved theorem. Also repaired ~7 pre-existing breakages so the file compiles against mathlib v4.26.0. 2 deep axioms remain (Green/Sapozhenko upper bound + precise asymptotic). | Session 2: discharged all 3 sorries in the Erdos748Aristotle companion (f_1,f_2,f_3) via kernel decide — axiom-free; companion now 0 code sorries.",
+    "progressSummary": "Eliminated 1 of 3 axioms: trivial_lower_bound (f(n) ≥ 2^{⌊n/2⌋}) is now a proved theorem. Also repaired ~7 pre-existing breakages so the file compiles against mathlib v4.26.0. 2 deep axioms remain (Green/Sapozhenko upper bound + precise asymptotic). | Session 2: discharged all 3 sorries in the Erdos748Aristotle companion (f_1,f_2,f_3) via kernel decide — axiom-free; companion now 0 code sorries. | Session 3 (researcher-1): formalised the two-family ≥ single-family domination (two_family_bound_ge_upperHalf) — prose claim upgraded to a theorem. 2 deep axioms (Green/Sapozhenko) remain BLOCKED. UNVERIFIED: Docker infra down (containerd meta.db I/O error).",
     "builtItems": [
       "Proved trivial_lower_bound in Erdos748Problem.lean: U.powerset ⊆ sumFreeSubsets n ⇒ f n ≥ 2^|U| ≥ 2^{⌊n/2⌋}",
       "Added decidableIsSumFree instance (sum-free predicate is decidable via bounded ∀∈A form)",
       "f_1 : f 1 = 2 (decide, axiom-free) in Erdos748Aristotle.lean:32",
       "f_2 : f 2 = 3 (decide, axiom-free) in Erdos748Aristotle.lean:38",
-      "f_3 : f 3 = 6 (decide, axiom-free) in Erdos748Aristotle.lean:44"
+      "f_3 : f 3 = 6 (decide, axiom-free) in Erdos748Aristotle.lean:44",
+      "two_family_bound_ge_upperHalf: the two-family lower bound 2^|O|+2^|U|-2^|O∩U| ≥ 2^|U| (dominates sharp_lower_bound), formalising the prose domination claim. Erdos748Problem.lean."
     ],
     "insights": [
       "The trivial lower bound needs no analysis: every subset of the upper half {⌊n/2⌋+1,…,n} is sum-free (upperHalf_sumFree), giving 2^{n-⌊n/2⌋} ≥ 2^{⌊n/2⌋} distinct sum-free sets",


### PR DESCRIPTION
## Summary
Research session for `erdos-748-incomplete-01` (Cameron–Erdős / counting sum-free subsets of
{1,…,n}, OEIS A007865). Formalises a domination claim previously only stated in prose.

## Progress
- **`two_family_bound_ge_upperHalf`** (`Erdos748Problem.lean`): the two-family lower bound
  `2^|O| + 2^|U| − 2^|O∩U|` (from `two_family_lower_bound`) is always `≥ 2^|U| = 2^⌈n/2⌉`,
  the value `sharp_lower_bound` delivers. Proof: `O∩U ⊆ O` gives `2^|O∩U| ≤ 2^|O|`
  (`Finset.card_le_card Finset.inter_subset_left`, `Nat.pow_le_pow_right`), then `omega` on the
  ℕ subtraction — the same subtraction-free pattern already verified in `two_family_lower_bound`
  directly above. Confirms the two-family construction never loses to the single upper-half one.
- Synced gallery `meta.json` leanFile counts (lineCount 539→564, theoremCount 18→19).

## Findings
- The tractable lower-bound / structural content of this file is now essentially complete
  (trivial + sharp + two-family bounds, mono/strictMono, small values, and this domination).
- The 2 remaining `axiom`s (Green 2004 upper bound, Sapozhenko 2003 precise asymptotic) are
  >1000-line literature results — genuinely BLOCKED, unchanged. Entry stays `axiomatized`,
  axiomCount 2.

## Status
**Outcome**: progress (UNVERIFIED — Docker build host containerd down: `meta.db input/output
error` at image build, before any Lean elaboration; operator-level outage, not a proof error)
**Next Steps**: rebuild once Docker is healthy to confirm `=== Build succeeded ===`.

🤖 Generated by researcher-1