### PR TITLE
audit(erdos-944): definitionCount 0→2 (typeclass definitions)

### DIFF
--- a/src/data/proofs/erdos-944/meta.json
+++ b/src/data/proofs/erdos-944/meta.json
@@ -38,7 +38,7 @@
     "axiomCount": 0,
     "lineCount": 120,
     "theoremCount": 0,
-    "definitionCount": 0,
+    "definitionCount": 2,
     "assumptions": "0 axioms. Lean source contains only typeclass definitions (IsKVertexCritical, IsErdos944Graph) used as abstract predicates with no declared instances; the known results of Brown, Lattanzio, Jensen, and Martinsson-Steiner are described in comments only, not formally axiomatized. Open conjecture (k = 4 case unsolved)."
   },
   "overview": {
@@ -123,7 +123,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 2
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-944

**Proof**: erdos-944 (Erdős Problem #944: Critical Graphs Without Critical Edges)
**Result**: issues-fixed (1 minor count drift) — otherwise CLEAN

## Finding

`meta.json` reported `definitionCount: 0` (in both the `meta` and `leanFile` blocks), but the Lean source `proofs/Proofs/Erdos944Problem.lean` declares **2 typeclasses**:

- `class IsKVertexCritical (G : Type*) (k : ℕ) : Prop`
- `class IsErdos944Graph (G : Type*) (k r : ℕ) extends IsKVertexCritical G k : Prop`

The entry's own `originalContributions` advertises the "Typeclass definition of k-vertex-critical graphs (IsKVertexCritical) and the Erdős944 property (IsErdos944Graph)", so `definitionCount: 0` was internally inconsistent with the entry's own prose. Per repo convention (`class`/`structure` count toward `definitionCount`), corrected to `2`.

This is an **undercount** (understated content, not an overclaim), hence low severity.

## Verified CLEAN otherwise

- **sorries**: 0 claimed, 0 actual ✓
- **axiomCount**: 0 claimed, 0 actual — the two classes are empty `Prop` classes (no fields, no declared instances), carrying no assumptions ✓
- **theoremCount**: 0 claimed, 0 actual ✓
- **status/badge**: `axiomatized`/`wip` — correct for an OPEN Erdős problem formalized only as abstract typeclass scaffolding
- **assumptions** prose honestly discloses that known results (Brown/Lattanzio/Jensen/Martinsson-Steiner) are described in comments only, not axiomatized ✓
- No True-stubs, no Mathlib-wrapper masking, no overclaim

## Changes

- `meta.json`: `definitionCount` 0 → 2 (both blocks)
- `audit-tracker.json`: bump erdos-944 audit record (issues-fixed)

---
Discovered during gallery integrity audit.