### PR TITLE
research(erdos-1014-oq-03): general-limit increment bridge + increment-asymptotic reformulation

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03.lean
+++ b/proofs/Proofs/Erdos1014OQ03.lean
@@ -92,6 +92,57 @@ theorem increment_div_tendsto_zero_of_ratio_tendsto_one (R : ℕ → ℝ)
     Tendsto (fun l => (R (l + 1) - R l) / R l) atTop (𝓝 0) :=
   (increment_div_tendsto_zero_iff_ratio_tendsto_one R hpos).mpr hratio
 
+/-- **General-limit increment–ratio bridge.** For an eventually-nonzero sequence
+`R` and any real `c`, the normalized increment `(R(l+1) − R(l))/R(l)` tends to `c`
+**iff** the consecutive ratio `R(l+1)/R(l)` tends to `c + 1`.
+
+The special case `c = 0` is `increment_div_tendsto_zero_iff_ratio_tendsto_one`. For
+a geometrically-growing sequence whose ratio tends to a limit `L` (e.g. the
+*diagonal* Ramsey number `R(k,k)`, whose growth ratio `R(k+1,k+1)/R(k,k)` tends to
+`4`), this reads off the normalized-increment limit `L − 1` directly, exhibiting the
+`o(R)` conclusion for #1014's off-diagonal `R(k,l)` (where `L = 1`) as the borderline
+case of a general statement. -/
+theorem increment_div_tendsto_iff_ratio_tendsto (R : ℕ → ℝ) (c : ℝ)
+    (hpos : ∀ᶠ l in atTop, R l ≠ 0) :
+    Tendsto (fun l => (R (l + 1) - R l) / R l) atTop (𝓝 c) ↔
+      Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 (c + 1)) := by
+  have heq : (fun l => (R (l + 1) - R l) / R l)
+      =ᶠ[atTop] (fun l => R (l + 1) / R l - 1) := by
+    filter_upwards [hpos] with l hl using increment_div_eq_ratio_sub_one R l hl
+  rw [tendsto_congr' heq]
+  constructor
+  · intro h
+    have h1 := h.add_const 1
+    simpa using h1
+  · intro h
+    have h1 := h.sub_const 1
+    simpa using h1
+
+/-- **Increment-asymptotic reformulation.** Fix a comparison sequence `g`, with both
+`R` and `g` eventually nonzero. Then the increment `R(l+1) − R(l)` is asymptotically
+equivalent to `g` (normalized quotient `→ 1`) **iff** the *ratio-minus-one*
+`R(l+1)/R(l) − 1` is asymptotically equivalent to `g/R`:
+
+`(R(l+1) − R(l)) / g(l) → 1  ↔  (R(l+1)/R(l) − 1) / (g(l)/R(l)) → 1`.
+
+This is the rigorous, hypothesis-honest form of the naive power-law expansion warned
+against in the module docstring: an increment asymptotic `Δ_l(k) ~ g_k(l)` is
+*exactly* a statement about the consecutive ratio, namely
+`R(k,l+1)/R(k,l) − 1 ~ g_k(l)/R(k,l)`. The two normalized quantities are in fact
+eventually equal, so neither direction of the equivalence adds a hypothesis beyond
+eventual nonvanishing — a faithful reformulation, not a derivation that smuggles in
+regularity. -/
+theorem increment_asymptotic_iff_ratioSubOne_asymptotic (R g : ℕ → ℝ)
+    (hR : ∀ᶠ l in atTop, R l ≠ 0) (hg : ∀ᶠ l in atTop, g l ≠ 0) :
+    Tendsto (fun l => (R (l + 1) - R l) / g l) atTop (𝓝 1) ↔
+      Tendsto (fun l => (R (l + 1) / R l - 1) / (g l / R l)) atTop (𝓝 1) := by
+  have heq : (fun l => (R (l + 1) / R l - 1) / (g l / R l))
+      =ᶠ[atTop] (fun l => (R (l + 1) - R l) / g l) := by
+    filter_upwards [hR, hg] with l hR' hg'
+    field_simp
+    ring
+  rw [tendsto_congr' heq]
+
 /-- **Logarithmic increment–ratio bridge.** For an eventually-positive sequence
 `R`, the *additive* increment of `log R` tends to `0` **iff** the consecutive ratio
 tends to `1`:

--- a/research/problems/erdos-1014-oq-03/state.md
+++ b/research/problems/erdos-1014-oq-03/state.md
@@ -3,22 +3,23 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T15:40:17-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Delivered the increment-ratio bridge (VERIFIED). Found Approach A invalid from ~ alone.
+Extended the increment-ratio bridge with two honest additions (PR #36922, UNVERIFIED docker-down):
+- increment_div_tendsto_iff_ratio_tendsto: general-limit c version (c=0 subsumes the o(R) bridge).
+- increment_asymptotic_iff_ratioSubOne_asymptotic: Delta_l ~ g  iff  (ratio-1) ~ g/R
+  (the rigorous ratio-form of the invalid-from-~-alone power-law expansion).
 
 ## Active Approach
-Increment-ratio bridge (DONE). Full asymptotic needs a ratio/regular-variation hypothesis.
-
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+Elementary bridge family is complete. The full asymptotic Delta_l(k) ~ g_k(l) needs a
+regular-variation / ratio-asymptotic hypothesis + the R(3,l) constant matching (both OPEN).
 
 ## Blockers
-None.
+Docker build infra down all session (containerd meta.db I/O error; docker images fails).
+Contributions shipped UNVERIFIED with hand-audit.
 
 ## Next Action
-The elementary bridge is complete and verified. The remaining open asymptotic Delta_l(k) ~ g_k(l) is not session-sized (needs a regular-variation hypothesis + the R(3,l) constant matching, both open).
+Not session-sized: remaining open asymptotic needs a regular-variation hypothesis, not
+another elementary bridge lemma. Future work could formalize a Karamata/regular-variation
+sufficient condition (ratio -> ((l+1)/l)^{k-1}) that forces the increment asymptotic.


### PR DESCRIPTION
## Summary

Two honest, self-contained additions to `Erdos1014OQ03.lean` for the off-diagonal Ramsey increment $\Delta_l(k) = R(k,l+1) - R(k,l)$ (Erdős #1014 OQ-03).

### `increment_div_tendsto_iff_ratio_tendsto`
Generalizes the existing `c = 0` bridge to **any** limit `c`:
$$(R(l+1)-R(l))/R(l) \to c \iff R(l+1)/R(l) \to c+1.$$
The $o(R)$ conclusion for #1014 (ratio $\to 1$) is exhibited as the `c = 0` borderline of a general statement; a geometrically-growing sequence with ratio limit $L$ (e.g. diagonal $R(k,k)$, ratio $\to 4$) gets normalized increment $\to L-1$. Proof mirrors the already-verified zero-limit sibling exactly.

### `increment_asymptotic_iff_ratioSubOne_asymptotic`
The rigorous, hypothesis-honest form of the naive power-law expansion warned against in the module docstring. An increment asymptotic $\Delta_l(k) \sim g_k(l)$ is **exactly** a statement about the consecutive ratio:
$$R(k,l+1)/R(k,l) - 1 \sim g_k(l)/R(k,l).$$
The two normalized quantities are eventually equal, so neither direction adds a regularity hypothesis beyond eventual nonvanishing — a faithful reformulation, directly serving the problem's stated goal of relating the increment asymptotic to the ratio/difference reformulations of #1014.

## Verification
**UNVERIFIED (docker build infrastructure down)**: `docker-build.sh` fails at image build with `containerd meta.db input/output error`; `docker images` also fails — operator-level infra issue, not a proof issue. Both proofs audited by hand: the general-limit lemma is a line-for-line generalization of the verified `increment_div_tendsto_zero_iff_ratio_tendsto_one`; the reformulation reduces to an eventual algebraic identity (`field_simp; ring`) followed by `tendsto_congr'`.

0 new axioms, 0 sorries, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)