### PR TITLE
research(cauchy-schwarz-integral-oq-04): Schrödinger uncertainty in variance form

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ04.lean
@@ -261,6 +261,28 @@ theorem heisenberg_variance_form {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
   robertson_uncertainty hA hB ψ (RCLike.re (inner 𝕜 ψ (A ψ)))
     (RCLike.re (inner 𝕜 ψ (B ψ)))
 
+/-- **Schrödinger uncertainty principle (variance form).**  The Schrödinger analogue
+of `heisenberg_variance_form`: instantiating `schrodinger_uncertainty` at the
+expectation values `⟨A⟩ = Re⟪ψ,Aψ⟫`, `⟨B⟩ = Re⟪ψ,Bψ⟫` turns each right-hand factor
+into a variance `Var_ψ(A) = ‖(A−⟨A⟩)ψ‖²`, `Var_ψ(B) = ‖(B−⟨B⟩)ψ‖²`, giving the
+physically standard Schrödinger relation
+
+  `Var_ψ(A)·Var_ψ(B) ≥ ¼·‖⟪ψ, (AB−BA)ψ⟫‖² + (Re⟪(A−⟨A⟩)ψ,(B−⟨B⟩)ψ⟫)²`,
+
+whose covariance term reads in anticommutator form via
+`re_inner_centred_eq_anticommutator` (at `a = ⟨A⟩`, `b = ⟨B⟩`, unit `ψ`) as the
+symmetrized covariance `½⟪ψ,{A,B}ψ⟫ − ⟨A⟩⟨B⟩`.  Dropping that nonnegative term
+recovers `heisenberg_variance_form`. -/
+theorem schrodinger_variance_form {A B : E →ₗ[𝕜] E} (hA : A.IsSymmetric)
+    (hB : B.IsSymmetric) (ψ : E) :
+    (1 / 4 : ℝ) * ‖inner 𝕜 ψ (A (B ψ) - B (A ψ))‖ ^ 2
+        + RCLike.re (inner 𝕜 (A ψ - ((RCLike.re (inner 𝕜 ψ (A ψ)) : ℝ) : 𝕜) • ψ)
+            (B ψ - ((RCLike.re (inner 𝕜 ψ (B ψ)) : ℝ) : 𝕜) • ψ)) ^ 2
+      ≤ ‖A ψ - ((RCLike.re (inner 𝕜 ψ (A ψ)) : ℝ) : 𝕜) • ψ‖ ^ 2
+        * ‖B ψ - ((RCLike.re (inner 𝕜 ψ (B ψ)) : ℝ) : 𝕜) • ψ‖ ^ 2 :=
+  schrodinger_uncertainty hA hB ψ (RCLike.re (inner 𝕜 ψ (A ψ)))
+    (RCLike.re (inner 𝕜 ψ (B ψ)))
+
 /-- **Anticommutator = symmetric part of the centred inner product.**  Dual to
 `inner_commutator_eq_sub`.  For symmetric `A, B` and real shifts `a, b`, with
 `u = (A−a)ψ`, `v = (B−b)ψ`,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -43,7 +43,8 @@
       "inner_sq_le_gram build-break FIX (researcher-1): main's proof used RCLike.norm_sq_eq_def' (nonexistent); replaced with `rw [RCLike.norm_sq_eq_def]; ring`. The (Re⟪u,v⟫)²+(Im⟪u,v⟫)² ≤ ‖u‖²·‖v‖² Gram split itself was added by a concurrent PR.",
       "schrodinger_uncertainty in CauchySchwarzIntegralOQ04.lean (researcher-1): ¼‖⟪ψ,[A,B]ψ⟫‖² + (Re⟪(A−a)ψ,(B−b)ψ⟫)² ≤ ‖(A−a)ψ‖²·‖(B−b)ψ‖² — Schrödinger's 1930 strengthening of Robertson including the covariance term, built on inner_sq_le_gram. Verified 0 axioms, 0 sorries.",
       "robertson_of_schrodinger in CauchySchwarzIntegralOQ04.lean (researcher-1): Robertson follows from Schrödinger by dropping the nonnegative (Re…)² covariance term (sq_nonneg + nlinarith).",
-      "CauchySchwarzIntegralOQ04.lean (researcher-3, 2026-07-08, VERIFIED 0-axiom): the anticommutator/covariance identities dual to inner_commutator_eq_sub. inner_anticommutator_eq_add {A B}(hA hB : IsSymmetric)(ψ)(a b:ℝ): ⟪u,v⟫+⟪v,u⟫ = ⟪ψ,(AB+BA)ψ⟫ − 2b⟪ψ,Aψ⟫ − 2a⟪ψ,Bψ⟫ + 2ab⟪ψ,ψ⟫ (u=(A−a)ψ, v=(B−b)ψ) — the shifts do NOT cancel (unlike the commutator); same e1..e4 symmetry rewrites + push_cast + ring. re_inner_centred_eq_anticommutator: Re⟪u,v⟫ = ½Re⟪ψ,(AB+BA)ψ⟫ − b·Re⟪ψ,Aψ⟫ − a·Re⟪ψ,Bψ⟫ + ab·Re⟪ψ,ψ⟫ — take Re of the identity (map_add/map_sub + RCLike.re_ofReal_mul) and collapse Re⟪v,u⟫=Re⟪u,v⟫ via inner_re_symm, then linarith. At a=⟨A⟩,b=⟨B⟩,‖ψ‖=1 this is the symmetrized covariance ½⟪ψ,{A,B}ψ⟫−⟨A⟩⟨B⟩ that schrodinger_uncertainty keeps over Robertson. #print axioms → [propext, Classical.choice, Quot.sound]. File now 12 theorems."
+      "CauchySchwarzIntegralOQ04.lean (researcher-3, 2026-07-08, VERIFIED 0-axiom): the anticommutator/covariance identities dual to inner_commutator_eq_sub. inner_anticommutator_eq_add {A B}(hA hB : IsSymmetric)(ψ)(a b:ℝ): ⟪u,v⟫+⟪v,u⟫ = ⟪ψ,(AB+BA)ψ⟫ − 2b⟪ψ,Aψ⟫ − 2a⟪ψ,Bψ⟫ + 2ab⟪ψ,ψ⟫ (u=(A−a)ψ, v=(B−b)ψ) — the shifts do NOT cancel (unlike the commutator); same e1..e4 symmetry rewrites + push_cast + ring. re_inner_centred_eq_anticommutator: Re⟪u,v⟫ = ½Re⟪ψ,(AB+BA)ψ⟫ − b·Re⟪ψ,Aψ⟫ − a·Re⟪ψ,Bψ⟫ + ab·Re⟪ψ,ψ⟫ — take Re of the identity (map_add/map_sub + RCLike.re_ofReal_mul) and collapse Re⟪v,u⟫=Re⟪u,v⟫ via inner_re_symm, then linarith. At a=⟨A⟩,b=⟨B⟩,‖ψ‖=1 this is the symmetrized covariance ½⟪ψ,{A,B}ψ⟫−⟨A⟩⟨B⟩ that schrodinger_uncertainty keeps over Robertson. #print axioms → [propext, Classical.choice, Quot.sound]. File now 12 theorems.",
+      "schrodinger_variance_form in CauchySchwarzIntegralOQ04.lean (researcher-5, PR #36924) — Schrödinger analogue of heisenberg_variance_form: instantiate schrodinger_uncertainty at a=⟨A⟩=Re⟪ψ,Aψ⟫, b=⟨B⟩=Re⟪ψ,Bψ⟫ → Var(A)Var(B) ≥ ¼‖⟪ψ,[A,B]ψ⟫‖²+(Re⟪(A−⟨A⟩)ψ,(B−⟨B⟩)ψ⟫)². Term-mode. 0/0. UNVERIFIED (docker infra down: containerd content-store I/O error)."
     ],
     "insights": [
       "The Heisenberg/Robertson uncertainty inequality's analytic core is Cauchy-Schwarz on the imaginary part: |Im⟪u,v⟫| ≤ |⟪u,v⟫| ≤ ‖u‖‖v‖. For real fields Im = 0 (trivial); the content is the ℂ case.",
@@ -104,7 +105,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T15:38:25.652Z",
-  "lastUpdate": "2026-07-08T21:00:00.000Z",
+  "lastUpdate": "2026-07-09T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",


### PR DESCRIPTION
## Summary

Adds `schrodinger_variance_form`, the Schrödinger analogue of the existing `heisenberg_variance_form`. Instantiating `schrodinger_uncertainty` at the expectation values `⟨A⟩ = Re⟪ψ,Aψ⟫`, `⟨B⟩ = Re⟪ψ,Bψ⟫` makes each right-hand factor a variance, giving the physically standard Schrödinger relation:

```
Var_ψ(A)·Var_ψ(B) ≥ ¼‖⟪ψ,[A,B]ψ⟫‖² + (Re⟪(A−⟨A⟩)ψ,(B−⟨B⟩)ψ⟫)²
```

The covariance term reads in anticommutator form via the already-verified `re_inner_centred_eq_anticommutator` (at `a=⟨A⟩`, `b=⟨B⟩`, unit `ψ`) as `½⟪ψ,{A,B}ψ⟫ − ⟨A⟩⟨B⟩`; dropping the nonnegative covariance term recovers `heisenberg_variance_form`. This is the physical Schrödinger companion to the physical Heisenberg form already in the file. **0 sorry / 0 axiom.**

## Verification status: UNVERIFIED (infra-blocked)

Docker build infrastructure is down fleet-wide this session — the containerd store returns I/O errors (`.../meta.db: input/output error`) before image build, so `docker-build.sh` cannot run. Operator-level blocker, not a proof defect.

Confidence is high: the proof is a one-line term-mode instantiation `schrodinger_uncertainty hA hB ψ (RCLike.re ⟪ψ,Aψ⟫) (RCLike.re ⟪ψ,Bψ⟫)`, and the theorem statement is exactly that lemma's conclusion with `a,b` substituted — structurally identical to the verified `heisenberg_variance_form` (which instantiates `robertson_uncertainty` the same way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)