### PR TITLE
Research: erdos-1098-oq-01-oq-03 - general injective-hom pullback of BoundedCliques

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -470,6 +470,37 @@ theorem boundedCliques_of_surjective {K : Type*} [Group K] (f : G →* K)
   rw [← Finset.card_image_of_injective S hginj]
   exact hB _ hclique
 
+/-- **Bounded cliques pull back along any injective homomorphism (heredity of ω(Γ)).**
+    If `f : G →* K` is an *injective* homomorphism and `Γ(K)` has finite clique number,
+    then so does `Γ(G)`: `ω(Γ(G)) ≤ ω(Γ(K))`.  The embedding `f` carries each clique
+    `S ⊆ G` of `Γ(G)` to a clique `f '' S ⊆ K` of the *same* size — non-commuting
+    elements have non-commuting images under a hom (`f a · f b = f (a·b)`), and injectivity
+    keeps the images distinct — so any uniform clique bound for `K` bounds `G`.
+
+    This is the general form of `boundedCliques_of_subgroup`, which is exactly the case
+    `f = H.subtype : H →* G`; it is also the injective dual of `boundedCliques_of_surjective`
+    (surjections push cliques *back*, injections push them *up*).  Axiom-free — only the
+    elementary clique transfer, not the BFC core `neumann_hard_direction`. -/
+theorem boundedCliques_of_injective {K : Type*} [Group K] (f : G →* K)
+    (hf : Function.Injective f) (h : BoundedCliques K) : BoundedCliques G := by
+  obtain ⟨B, hB⟩ := h
+  refine ⟨B, fun S hS => ?_⟩
+  let e : G ↪ K := ⟨f, hf⟩
+  have hclique : IsClique (S.map e) := by
+    intro a ha b hb hab
+    rw [Finset.mem_map] at ha hb
+    obtain ⟨a', ha', rfl⟩ := ha
+    obtain ⟨b', hb', rfl⟩ := hb
+    have hne : a' ≠ b' := fun heq => hab (by rw [heq])
+    have key := hS a' ha' b' hb' hne
+    intro hEq
+    apply key
+    apply hf
+    rw [map_mul, map_mul]
+    exact hEq
+  rw [← Finset.card_map e]
+  exact hB _ hclique
+
 /-- **The hard direction holds unconditionally — and axiom-free — for finite groups.**
     When `G` is finite the centre automatically has finite index (`[G:Z(G)] ≤ |G| < ∞`,
     here via `Subgroup.index_ne_zero_of_finite`), so the forward implication of

--- a/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
+++ b/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
@@ -64,3 +64,20 @@ Build: elaboration-clean `[3061/3061]` (2.1s, zero diagnostics on the file) then
 SIGBUS exit-135 at olean-write; retries then hit the host-level docker corruption
 (`containerd metadata.db input/output error`, exit 125). Shipped UNVERIFIED. Blocked BFC
 core `neumann_hard_direction` unchanged.
+
+## Session 2026-07-09 (researcher-1) — general injective-hom pullback (functorial completion)
+
+Added `boundedCliques_of_injective (f : G →* K) (hf : Injective f) : BoundedCliques K →
+BoundedCliques G` to `Erdos1098OQ01OQ03.lean` (1 thm, axiom count unchanged at 1). The
+embedding `f` carries each clique `S ⊆ G` to a clique `f '' S ⊆ K` of the same size
+(non-commuting elements have non-commuting images under a hom; injectivity keeps images
+distinct), so any uniform clique bound for `K` bounds `G`. This is the **general form** of
+`boundedCliques_of_subgroup` (exactly the case `f = H.subtype`) and the injective **dual** of
+`boundedCliques_of_surjective` — completing the injective/surjective functorial pair for the
+`BoundedCliques` predicate. Proof is a near-verbatim copy of the already-VERIFIED
+`boundedCliques_of_subgroup` (same `Finset.map`/`map_mul`/`card_map` transfer), so high
+confidence. Axiom-free (elementary clique transfer, NOT the blocked BFC core).
+
+UNVERIFIED: Docker infra down this session (containerd `meta.db input/output error` at image
+build, before any Lean elaboration — operator-level outage, not a proof error). Blocked BFC core
+`neumann_hard_direction` unchanged.

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -139,12 +139,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 535,
+    "lineCount": 566,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 15
+    "theoremCount": 16
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary
Research session for `erdos-1098-oq-01-oq-03` (Neumann's theorem: ω(Γ(G)) finite ⟺ [G:Z(G)]
finite). Adds the general injective-homomorphism heredity lemma, completing the functorial pair.

## Progress
- **`boundedCliques_of_injective`** (`Erdos1098OQ01OQ03.lean`): for an injective hom
  `f : G →* K`, `BoundedCliques K → BoundedCliques G`. The embedding carries each clique of
  Γ(G) to a clique of Γ(K) of the same size (`Finset.map`, `map_mul`, `Finset.card_map`), so a
  uniform bound for K bounds G.
  - This is the **general form** of the existing `boundedCliques_of_subgroup` (exactly the case
    `f = H.subtype`), and the injective **dual** of `boundedCliques_of_surjective`. The
    injective/surjective heredity pair for `BoundedCliques` is now complete.
  - Proof is a near-verbatim copy of the already-VERIFIED `boundedCliques_of_subgroup` transfer.
- Synced gallery `meta.json` leanFile counts (lineCount 535→566, theoremCount 15→16).

## Findings
- Axiom-free (elementary clique transfer); the single remaining `axiom`
  `neumann_hard_direction` (BFC core, Neumann 1976) is unchanged and still BLOCKED — its residual
  content is pinned to `BoundedCliques G → Finite (commutatorSet G)`.

## Status
**Outcome**: progress (UNVERIFIED — Docker build host containerd down: `meta.db input/output
error` at image build, before any Lean elaboration; operator-level outage, not a proof error)
**Next Steps**: rebuild once Docker is healthy to confirm `=== Build succeeded ===`.

🤖 Generated by researcher-1