### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): unified Jacobi-RHS closed form

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Even.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Even.lean
@@ -96,4 +96,18 @@ theorem jacobiCount_four_dvd_add {n : ℕ} (hn : 4 ∣ n) :
 /-- Sanity check of the even closed form at `n = 4`: `jacobiCount 4 = 24`. -/
 example : jacobiCount 4 = 24 := by decide
 
+/-- **Unified closed form of the Jacobi right-hand side.**  Packaging
+`jacobiCount_of_not_four_dvd` and `jacobiCount_four_dvd_add` into a single
+determination valid for *every* `n`: off the `4 ∣ n` locus the Jacobi count is the
+plain scaled divisor sum `8·σ(n)`, and on it the same value is corrected by exactly
+`32·σ(n/4)` (equivalently `jacobiCount n = 8σ(n) − 32σ(n/4)`).  This is the entry
+point the docstring's "(1)+(3) determine `jacobiCount` on all `n`" claim refers to:
+the Jacobi RHS is pinned on every `n` purely from ordinary divisor sums, with no
+`native_decide` and no axioms (`propext`/`Classical.choice`/`Quot.sound` only). -/
+theorem jacobiCount_closed_form (n : ℕ) :
+    (¬ 4 ∣ n → jacobiCount n = 8 * ∑ d ∈ n.divisors, d) ∧
+    (4 ∣ n → jacobiCount n + 32 * ∑ e ∈ (n / 4).divisors, e
+        = 8 * ∑ d ∈ n.divisors, d) :=
+  ⟨jacobiCount_of_not_four_dvd, jacobiCount_four_dvd_add⟩
+
 end LagrangeFourSquaresOQ01OQ03Even


### PR DESCRIPTION
## Summary

`LagrangeFourSquaresOQ01OQ03Even.lean` proves the Jacobi four-square right-hand side (`jacobiCount n = 8·Σ_{d∣n, 4∤d} d`) in two separate cases — `jacobiCount_of_not_four_dvd` (the `8σ(n)` collapse when `4∤n`) and `jacobiCount_four_dvd_add` (the `+32σ(n/4)` correction when `4∣n`) — and the docstring notes these two "determine `jacobiCount` on all `n`", but no single theorem states that.

This PR adds that entry point, `jacobiCount_closed_form`.

## New declaration (1, 0 axiom)

```lean
theorem jacobiCount_closed_form (n : ℕ) :
    (¬ 4 ∣ n → jacobiCount n = 8 * ∑ d ∈ n.divisors, d) ∧
    (4 ∣ n → jacobiCount n + 32 * ∑ e ∈ (n / 4).divisors, e = 8 * ∑ d ∈ n.divisors, d)
```

Correct by construction — it is `⟨jacobiCount_of_not_four_dvd, jacobiCount_four_dvd_add⟩`, both already-verified theorems in this file. Keeps the file's deliberate 0-axiom status (no `native_decide`, hence no `Lean.ofReduceBool`).

## Verification status

**UNVERIFIED (infra)** — Docker build unavailable this session: `docker-build.sh` fails at image build with a containerd `meta.db` input/output error (known host infrastructure failure, not a proof error). The proof is a pair of already-verified theorems; confidence is essentially certain pending a green rebuild once Docker is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)