### PR TITLE
Enrich Erdős #428 (prime offsets with positive density): add references (REFS0 fix)

### DIFF
--- a/src/data/proofs/erdos-428/meta.json
+++ b/src/data/proofs/erdos-428/meta.json
@@ -232,5 +232,26 @@
       "description": "AllOffsetsPrime {2} n gives twin primes; the $k$-tuple conjecture generalizes the twin prime conjecture"
     }
   ],
+  "references": [
+    {
+      "authors": "Paul Erdős, Ronald L. Graham",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "Monographies de L'Enseignement Mathématique 28, Geneva",
+      "note": "Proves the limsup version of this problem — a set of prime-generating offsets with positive upper density relative to π(x) — assuming the prime k-tuple conjecture; the liminf version formalized here remains open."
+    },
+    {
+      "authors": "G. H. Hardy, J. E. Littlewood",
+      "title": "Some problems of 'Partitio Numerorum' III: On the expression of a number as a sum of primes",
+      "year": "1923",
+      "venue": "Acta Mathematica, 44, 1–70",
+      "note": "Source of the prime k-tuple (Hardy–Littlewood) conjecture on the asymptotic density of prime constellations, the hypothesis under which the limsup form of Erdős #428 is known."
+    },
+    {
+      "title": "Erdős Problem #428 (erdosproblems.com) — prime offsets with positive density",
+      "url": "https://www.erdosproblems.com/428",
+      "note": "Source problem (OPEN, liminf version): is there A ⊆ ℕ with liminf |A∩[1,x]|/π(x) > 0 such that infinitely often every offset a∈A gives n−a prime?"
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
## Enrichment pass — erdos-428

**Defect:** empty `references` (REFS0).

**Fix:** add 3 references from the docstring + the conjecture's source:
- **Erdős & Graham (1980)** — proved the limsup version assuming the prime k-tuple conjecture (the liminf version formalized here is open).
- **Hardy & Littlewood (1923)**, Acta Math. 44 — source of the prime k-tuple conjecture.
- **erdosproblems.com/428** — source problem (OPEN).

Gallery data-validation passes; under size cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)