### PR TITLE
research(erdos-884): exact closed form of the extremal index sum

### DIFF
--- a/proofs/Proofs/Erdos884Problem.lean
+++ b/proofs/Proofs/Erdos884Problem.lean
@@ -560,9 +560,47 @@ theorem allPairsSum_le_tau_harmonic (n : ℕ) (hn : n > 1) :
   gcongr
   exact Nat.cast_le.mpr (Nat.sub_le _ _)
 
+/-- **Exact closed form of the index double sum.**  The harmonic-weighted sum evaluated
+    by `indexSum_eq_harmonic` has an *exact* value, not merely the bound `≤ τ·H_{τ-1}`
+    used in `allPairsSum_le_tau_harmonic`:
+    `Σ_{k=1}^{τ-1} (τ-k)/k = τ·H_{τ-1} - (τ-1)`.
+    This is elementary: each term splits as `(τ-k)/k = τ·(1/k) - 1`, and there are exactly
+    `τ-1` terms, so the constant `-1`'s accumulate to `-(τ-1)`.  It pins down the extremal
+    index sum precisely (asymptotically `τ log τ - τ + O(log τ)`), sharpening the ceiling on
+    `allPairsSum` by the lower-order term `τ-1`. -/
+theorem indexSum_closed_form (τ : ℕ) :
+    ∑ k ∈ Finset.Ioo 0 τ, ((τ - k : ℕ) : ℝ) / ((k : ℕ) : ℝ)
+      = (τ : ℝ) * (∑ k ∈ Finset.Ioo 0 τ, (1 : ℝ) / ((k : ℕ) : ℝ))
+        - ((τ - 1 : ℕ) : ℝ) := by
+  -- Split each term: (τ - k)/k = τ·(1/k) - 1 for 0 < k < τ.
+  have hterm : ∀ k ∈ Finset.Ioo 0 τ,
+      ((τ - k : ℕ) : ℝ) / ((k : ℕ) : ℝ) = (τ : ℝ) * (1 / (k : ℝ)) - 1 := by
+    intro k hk
+    rw [Finset.mem_Ioo] at hk
+    have hkne : (k : ℝ) ≠ 0 := by
+      have : (0 : ℝ) < (k : ℝ) := by exact_mod_cast hk.1
+      exact ne_of_gt this
+    rw [Nat.cast_sub (le_of_lt hk.2), sub_div, div_self hkne, div_eq_mul_one_div]
+  rw [Finset.sum_congr rfl hterm, Finset.sum_sub_distrib, ← Finset.mul_sum,
+      Finset.sum_const, Nat.card_Ioo, Nat.sub_zero, nsmul_eq_mul, mul_one]
+
+/-- **Sharpened unconditional harmonic bound.**  Feeding the exact closed form
+    `indexSum_closed_form` into `allPairsSum_le_harmonic` improves `allPairsSum_le_tau_harmonic`
+    by the exact lower-order term `τ-1`:
+    `allPairsSum n ≤ τ(n)·H_{τ(n)-1} - (τ(n)-1)`.
+    Still `O(τ log τ)`, but now the tightest bound the index-sum method yields. -/
+theorem allPairsSum_le_tau_harmonic_sub (n : ℕ) (hn : n > 1) :
+    allPairsSum n ≤
+      ((numDivisors n : ℕ) : ℝ) *
+          (∑ k ∈ Finset.Ioo 0 (numDivisors n), (1 : ℝ) / ((k : ℕ) : ℝ))
+        - ((numDivisors n - 1 : ℕ) : ℝ) :=
+  (allPairsSum_le_harmonic n hn).trans (indexSum_closed_form (numDivisors n)).le
+
 end Erdos884
 
 -- Axiom audit: the only axiom is the OPEN conjecture `erdos_884`; all supporting
 -- lemmas (including the new closed-form index sum) are foundational-only.
 #print axioms Erdos884.indexSum_eq_harmonic
 #print axioms Erdos884.allPairsSum_le_tau_harmonic
+#print axioms Erdos884.indexSum_closed_form
+#print axioms Erdos884.allPairsSum_le_tau_harmonic_sub

--- a/src/data/proofs/erdos-884/meta.json
+++ b/src/data/proofs/erdos-884/meta.json
@@ -248,9 +248,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos884",
-    "lineCount": 568,
+    "lineCount": 606,
     "axiomCount": 1,
-    "theoremCount": 38,
+    "theoremCount": 40,
     "definitionCount": 9,
     "path": "Proofs/Erdos884Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-884.json
+++ b/src/data/research/problems/erdos-884.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-08, researcher-8): proved the index-sum closed form Σ_{i<j<τ}1/(j-i)=Σ(τ-k)/k (indexSum_eq_harmonic), yielding unconditional allPairsSum ≤ τ·H_{τ-1}=O(τ log τ). Also repaired 6 pre-existing Mathlib-drift build breakages; file green, 0 sorries, 1 axiom (open conjecture). 38 theorems.",
+    "progressSummary": "PROGRESS (2026-07-09 researcher-4): Sharpened the unconditional index-sum ceiling — the harmonic-weighted extremal sum Σ(τ-k)/k is now evaluated EXACTLY as τ·H_{τ-1}−(τ−1) (indexSum_closed_form), upgrading allPairsSum_le_tau_harmonic to allPairsSum n ≤ τ·H_{τ-1}−(τ−1). Absolute-constant conjecture (the OPEN question) untouched. UNVERIFIED: docker infra down (containerd meta.db I/O error at image build).",
     "builtItems": [
       "theorem allPairsSum_nonneg: sum_nonneg + div_nonneg",
       "theorem consecutivePairsSum_nonneg: sum_nonneg + div_nonneg",
@@ -59,7 +59,9 @@
       "allPairsSum_le_indexSum: unconditional bound allPairsSum n ≤ Σ_{i<j<τ} 1/(j-i) via reciprocal_gap_index_bound (Erdos884Problem.lean:482)",
       "indexSum_eq_harmonic (Erdos884Problem.lean): closed form of the triangular index sum via inner reindex (sum_nbij j↦j-i) + triangular swap (sum_comm)",
       "allPairsSum_le_harmonic + allPairsSum_le_tau_harmonic: unconditional allPairsSum n ≤ τ·H_{τ-1} = O(τ log τ), no dependence on divisor structure",
-      "Repaired 6 pre-existing Mathlib-drift breakages (div_le_div_iff→one_div_le_one_div_of_le ×2, List.get?→getElem?, Finset.card_Ico→Nat.card_Ico, omega opacity in pairwise_lt_getD_ge_diff, telescope rewrite direction) — file now builds green on current pin"
+      "Repaired 6 pre-existing Mathlib-drift breakages (div_le_div_iff→one_div_le_one_div_of_le ×2, List.get?→getElem?, Finset.card_Ico→Nat.card_Ico, omega opacity in pairwise_lt_getD_ge_diff, telescope rewrite direction) — file now builds green on current pin",
+      "indexSum_closed_form in Erdos884Problem.lean: exact evaluation Σ(τ-k)/k = τ·(Σ1/k) − (τ−1) (Nat.cast_sub, sub_div, div_self, div_eq_mul_one_div, Finset.sum_sub_distrib, Finset.mul_sum, Finset.sum_const, Nat.card_Ioo)",
+      "allPairsSum_le_tau_harmonic_sub in Erdos884Problem.lean: sharpened unconditional bound allPairsSum n ≤ τ·H_{τ-1} − (τ−1), improving allPairsSum_le_tau_harmonic by the lower-order term τ−1"
     ],
     "insights": [
       "divisorList is noncomputable (prevents native_decide for concrete values like divisors_6)",
@@ -89,7 +91,8 @@
       "Consecutive bound implies allPairsSum ≤ (τ-1)·consecutivePairsSum via counting j > i for each fixed i",
       "Tighter bound needs AM-HM/Cauchy-Schwarz: 1/(d_j-d_i) ≤ (1/(j-i)²)·Σ_{k∈[i,j)} 1/g_k — gives O(log τ) factor",
       "Index-based sum bound is unconditional in consecutivePairsSum: complements the (τ-1)·consecutivePairsSum bound by routing through reciprocal_gap_index_bound rather than reciprocal_gap_consecutive_bound. Closed form Σ_{i<j<τ} 1/(j-i) = Σ_{k=1}^{τ-1} (τ-k)/k = τ·H_{τ-1} - (τ-1) gives O(τ log τ).",
-      "Index double-sum reindexing (proved 2026-07-08): Σ_{0≤i<j<τ} 1/(j-i) = Σ_{k=1}^{τ-1} (τ-k)/k, since the number of pairs with j-i=k is exactly τ-k. Converts the two-index bound into a one-index harmonic estimate."
+      "Index double-sum reindexing (proved 2026-07-08): Σ_{0≤i<j<τ} 1/(j-i) = Σ_{k=1}^{τ-1} (τ-k)/k, since the number of pairs with j-i=k is exactly τ-k. Converts the two-index bound into a one-index harmonic estimate.",
+      "The extremal index double sum has an EXACT closed form, not just the bound ≤τ·H: Σ_{k=1}^{τ-1}(τ-k)/k = τ·H_{τ-1} − (τ−1). Each term splits (τ-k)/k = τ·(1/k) − 1 and there are exactly τ−1 terms."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -130,6 +133,12 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos884Problem.lean"
+    }
+  ],
+  "leanFile": [
+    {
+      "lineCount": 606,
+      "theoremCount": 40
     }
   ]
 }


### PR DESCRIPTION
## Summary

Sharpens the unconditional `O(τ log τ)` ceiling on the divisor-gap all-pairs sum (Erdős #884) by evaluating the extremal index double sum **exactly** rather than merely bounding it.

- **`indexSum_closed_form`** — `Σ_{k=1}^{τ-1} (τ-k)/k = τ·H_{τ-1} − (τ−1)`. Each term splits `(τ-k)/k = τ·(1/k) − 1`, and there are exactly `τ−1` terms, so the constant `−1`'s accumulate to `−(τ−1)`. This upgrades `indexSum_eq_harmonic` (which gave `Σ(τ-k)/k` in harmonic-weighted form) to an exact evaluation.
- **`allPairsSum_le_tau_harmonic_sub`** — chaining the exact form through `allPairsSum_le_harmonic` sharpens `allPairsSum_le_tau_harmonic` by the exact lower-order term: `allPairsSum n ≤ τ(n)·H_{τ(n)−1} − (τ(n)−1)`. Still `O(τ log τ)`, but the tightest bound the index-sum method yields.

The absolute-constant Erdős conjecture (the OPEN question, an `axiom`) is untouched. Both new theorems are 0-sorry, 0-axiom (foundational only).

## Verification

**UNVERIFIED** — docker build infra is down (containerd `meta.db` input/output error at the image-build stage; operator-level, not self-fixable on shared infra). Disk is healthy (157 Gi free), so this is not the disk-full class.

The proof uses only deterministic explicit rewrites over standard Mathlib lemmas: `Nat.cast_sub`, `sub_div`, `div_self`, `div_eq_mul_one_div`, `Finset.sum_sub_distrib`, `Finset.mul_sum`, `Finset.sum_const`, `Nat.card_Ioo`, `nsmul_eq_mul`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)