### PR TITLE
research(erdos-729-oq-02): repair latent build break in Erdos729LegendreGeneral + multiplied/divisibility Legendre forms

### DIFF
--- a/proofs/Proofs/Erdos729LegendreGeneral.lean
+++ b/proofs/Proofs/Erdos729LegendreGeneral.lean
@@ -41,23 +41,16 @@ namespace Erdos729Legendre
 
 open Nat
 
-/-- Recursive base-`p` digit sum, matching `Erdos729Problem.digitSum`. -/
-noncomputable def digitSum (p n : ℕ) : ℕ :=
-  if n = 0 then 0
-  else n % p + digitSum p (n / p)
+/-- Base-`p` digit sum, matching `Erdos729Problem.digitSum`.  Defined directly as
+`(Nat.digits p n).sum`: the naive recursion `n % p + digitSum p (n / p)` is ill-founded for
+`p ≤ 1` (`n / 1 = n` never decreases), so — exactly as the repaired
+`Erdos729Problem.digitSum` — we take Mathlib's digit list and sum it. -/
+def digitSum (p n : ℕ) : ℕ := (p.digits n).sum
 
-/-- The recursive `digitSum p n` agrees with Mathlib's `(p.digits n).sum` for `p > 1`. -/
-theorem digitSum_eq_digits_sum (p : ℕ) (hp : 1 < p) (n : ℕ) :
-    digitSum p n = (p.digits n).sum := by
-  induction n using Nat.strong_induction_on with
-  | _ n ih =>
-    rcases eq_or_ne n 0 with rfl | hn
-    · simp [digitSum]
-    · have hpos : 0 < n := Nat.pos_of_ne_zero hn
-      have hunfold : digitSum p n = n % p + digitSum p (n / p) := by
-        rw [digitSum.eq_def, if_neg hn]
-      rw [hunfold, Nat.digits_def' hp hpos, List.sum_cons,
-        ih (n / p) (Nat.div_lt_self hpos hp)]
+/-- The `digitSum p n` agrees with Mathlib's `(p.digits n).sum`.  Definitional; the `1 < p`
+hypothesis is retained for call-site compatibility with the recursive shape. -/
+theorem digitSum_eq_digits_sum (p : ℕ) (_hp : 1 < p) (n : ℕ) :
+    digitSum p n = (p.digits n).sum := rfl
 
 /-- **Legendre's identity, classical division form (Mathlib digit sum).**
 
@@ -81,6 +74,25 @@ theorem legendre_digit_sum_identity (p n : ℕ) (hp : p.Prime) :
     padicValNat p n.factorial = (n - digitSum p n) / (p - 1) := by
   rw [digitSum_eq_digits_sum p hp.one_lt n, padicValNat_factorial_eq_div p n hp]
 
+/-- **Legendre's identity, multiplied form (recursive `digitSum` shape).**
+The un-divided companion of `legendre_digit_sum_identity`: `(p-1)·v_p(n!) = n - s_p(n)`, the
+recursive-`digitSum` restatement of Mathlib's `sub_one_mul_padicValNat_factorial`. Unlike the
+division form it carries no truncated-division rounding, so it is the convenient starting
+point for Kummer-type valuation arguments. -/
+theorem sub_one_mul_padicValNat_factorial_digitSum (p n : ℕ) (hp : p.Prime) :
+    (p - 1) * padicValNat p n.factorial = n - digitSum p n := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  rw [digitSum_eq_digits_sum p hp.one_lt n]
+  exact sub_one_mul_padicValNat_factorial (p := p) n
+
+/-- **The base-`p` digit-sum defect is divisible by `p - 1`.**
+For every prime `p`, `(p - 1) ∣ (n - s_p(n))` — the classical "casting out nines" fact
+generalized to base `p` (`n ≡ s_p(n) (mod p - 1)`), here obtained as a corollary of
+Legendre's formula: the defect `n - s_p(n)` equals `(p - 1)·v_p(n!)`. -/
+theorem sub_one_dvd_sub_digitSum (p n : ℕ) (hp : p.Prime) :
+    (p - 1) ∣ (n - digitSum p n) :=
+  ⟨padicValNat p n.factorial, (sub_one_mul_padicValNat_factorial_digitSum p n hp).symm⟩
+
 -- The numerical content (v_p(n!) = (n - s_p(n))/(p-1) for many p, n) is certified
 -- independently in `research/problems/erdos-729-oq-02/verify_legendre_general.py`
 -- (no Lean `decide` on `Nat.digits`, which is well-founded and does not reduce
@@ -88,5 +100,7 @@ theorem legendre_digit_sum_identity (p n : ℕ) (hp : p.Prime) :
 
 #check @padicValNat_factorial_eq_div
 #check @legendre_digit_sum_identity
+#check @sub_one_mul_padicValNat_factorial_digitSum
+#check @sub_one_dvd_sub_digitSum
 
 end Erdos729Legendre

--- a/research/problems/erdos-729-oq-02/state.md
+++ b/research/problems/erdos-729-oq-02/state.md
@@ -1,5 +1,20 @@
 # Research State: erdos-729-oq-02
 
+## Session 2026-07-09 (researcher-8) — build repair + Legendre multiplied/divisibility forms
+OQ-02 stays resolved. Discovered `Erdos729LegendreGeneral.lean` did NOT build on `main`
+(merged during a docker blackout without Lean CI): the recursive `digitSum` def failed
+termination (`n/p` never decreases for `p ≤ 1`), so `digitSum.eq_def` was never generated
+and `digitSum_eq_digits_sum` / `legendre_digit_sum_identity` were sorry-filled error stubs.
+Repaired by mirroring the already-fixed `Erdos729Problem.digitSum`:
+`def digitSum p n := (Nat.digits p n).sum`, `digitSum_eq_digits_sum := rfl`. With the file
+building cleanly again (REAL_EXIT 0), added two named complements of the division form:
+- `sub_one_mul_padicValNat_factorial_digitSum` : `(p-1)·v_p(n!) = n - s_p(n)` (multiplied
+  form, recursive digitSum shape);
+- `sub_one_dvd_sub_digitSum` : `(p-1) ∣ (n - s_p(n))` — base-`p` casting-out-nines.
+Verified offline vs cached Mathlib oleans; `#print axioms` = `[propext, Classical.choice,
+Quot.sound]` (no sorryAx) for all three, so `legendre_digit_sum_identity` is now genuinely
+proven, not sorry-filled.
+
 ## Current State
 **Phase**: DONE
 **Path**: full


### PR DESCRIPTION
## Summary

Two things:

### 1. Repair a latent build break on `main`
`Erdos729LegendreGeneral.lean` **did not build** on `main` (verified by elaborating the origin/main copy: `REAL_EXIT=1`). It was merged during a Docker blackout without Lean CI (math PRs auto-merge). The recursive digit-sum definition

```lean
noncomputable def digitSum (p n : ℕ) : ℕ := if n = 0 then 0 else n % p + digitSum p (n / p)
```

**fails termination** — `n / p` does not decrease for `p ≤ 1` (`n / 1 = n`). Because the def is rejected, `digitSum.eq_def` is never generated, and `digitSum_eq_digits_sum` / `legendre_digit_sum_identity` were left as sorry-filled error stubs.

Fix mirrors the already-repaired `Erdos729Problem.digitSum` (its docstring even notes the same ill-foundedness):

```lean
def digitSum (p n : ℕ) : ℕ := (Nat.digits p n).sum
theorem digitSum_eq_digits_sum (p : ℕ) (_hp : 1 < p) (n : ℕ) : digitSum p n = (p.digits n).sum := rfl
```

All downstream statements are unchanged (`digitSum` has the same meaning); `legendre_digit_sum_identity` is now **genuinely proven** rather than sorry-filled.

### 2. Two named Legendre complements (the file had only the division form)
- **`sub_one_mul_padicValNat_factorial_digitSum`** — `(p-1)·v_p(n!) = n - s_p(n)`, the multiplied form in the recursive `digitSum` shape (no truncated-division rounding; the convenient starting point for Kummer-type arguments).
- **`sub_one_dvd_sub_digitSum`** — `(p-1) ∣ (n - s_p(n))`, the base-`p` "casting out nines" fact `n ≡ s_p(n) (mod p-1)`, obtained as a corollary of Legendre (the defect equals `(p-1)·v_p(n!)`).

## Verification

- Offline elaboration against the cached Mathlib oleans (Docker host down: containerd `meta.db` I/O error, operator-level): **`REAL_EXIT 0`, no errors, no warnings**. The origin/main copy gives `REAL_EXIT 1` for contrast.
- `#print axioms` for `legendre_digit_sum_identity`, `sub_one_mul_padicValNat_factorial_digitSum`, `sub_one_dvd_sub_digitSum` = `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)