### PR TITLE
research(weak-goldbach-oq-01): diagonal/off-diagonal decomposition of the Goldbach comet height

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -235,6 +235,71 @@ theorem symmetricPairCount_pos_of_prime {m : ℕ} (hm : Nat.Prime m) :
 -- `m = 7` is prime, so `14 = 7 + 7` is the diagonal Goldbach partition.
 example : HasSymmetricPrimePair 7 := hasSymmetricPrimePair_of_prime (by decide)
 
+/-! ## Diagonal / Off-Diagonal Decomposition of the Comet Height
+
+The offset `k = 0` is special: the symmetric pair it produces is the **diagonal**
+partition `2 * m = m + m`, present exactly when `m` itself is prime. Every other
+contributing offset `k ≥ 1` gives a partition `2 * m = (m - k) + (m + k)` into two
+**distinct** primes. Splitting the comet count at `k = 0` therefore separates the
+single possible "square" representation from the genuinely distinct-prime ones:
+
+    symmetricPairCount m  =  [m prime]  +  #{ 1 ≤ k < m : m - k, m + k both prime }.
+
+This makes precise the `+ 1` that recurs in the totient ceilings
+(`symmetricPairCount_le_totient_succ`, `symmetricPairCount_le_half_totient_succ_of_odd`):
+that unit is exactly the diagonal term, contributed by `k = 0` only at a prime midpoint,
+so on composite `m` it drops and the comet height counts *only* distinct-prime pairs. -/
+
+/-- **Diagonal / off-diagonal decomposition of the comet height.** The Goldbach
+partitions of `2 * m` split into the single diagonal `2 * m = m + m` (present iff `m`
+is prime, the `k = 0` offset) and the distinct-prime pairs (offsets `1 ≤ k < m`):
+
+    symmetricPairCount m = (if m prime then 1 else 0)
+        + #{ k ∈ [1, m) : Prime (m - k) ∧ Prime (m + k) }.
+
+Isolating the `k = 0` term via `Finset.filter_insert` and simplifying `m ± 0 = m`
+(so the diagonal condition `Prime m ∧ Prime m` collapses to `Prime m`). -/
+theorem symmetricPairCount_eq_diagonal_add_offDiagonal (m : ℕ) :
+    symmetricPairCount m
+      = (if Nat.Prime m then 1 else 0)
+        + ((Finset.Ico 1 m).filter
+            (fun k => Nat.Prime (m - k) ∧ Nat.Prime (m + k))).card := by
+  rcases Nat.eq_zero_or_pos m with rfl | hm
+  · simp [symmetricPairCount, Nat.not_prime_zero]
+  · have hrange : Finset.range m = insert 0 (Finset.Ico 1 m) := by
+      ext k
+      simp only [Finset.mem_range, Finset.mem_insert, Finset.mem_Ico]
+      omega
+    rw [symmetricPairCount, hrange, Finset.filter_insert]
+    simp only [Nat.sub_zero, Nat.add_zero, and_self]
+    by_cases hp : Nat.Prime m
+    · rw [if_pos hp, if_pos hp, Finset.card_insert_of_notMem (by simp)]
+      omega
+    · rw [if_neg hp, if_neg hp, Nat.zero_add]
+
+/-- **On a composite midpoint the comet height counts only distinct-prime pairs.**
+When `m` is not prime the diagonal `2 * m = m + m` is unavailable, so the comet
+height equals exactly the number of Goldbach partitions of `2 * m` into two
+*distinct* primes (offsets `1 ≤ k < m`). Corollary of the diagonal decomposition. -/
+theorem symmetricPairCount_eq_offDiagonal_of_not_prime {m : ℕ} (hm : ¬ Nat.Prime m) :
+    symmetricPairCount m
+      = ((Finset.Ico 1 m).filter
+          (fun k => Nat.Prime (m - k) ∧ Nat.Prime (m + k))).card := by
+  rw [symmetricPairCount_eq_diagonal_add_offDiagonal, if_neg hm, Nat.zero_add]
+
+-- `m = 5` is prime: the diagonal `10 = 5 + 5` plus one distinct-prime pair
+-- (`k = 2`, `10 = 3 + 7`) gives comet height `2`.
+example :
+    ((Finset.Ico 1 5).filter (fun k => Nat.Prime (5 - k) ∧ Nat.Prime (5 + k))).card = 1 := by
+  decide
+
+-- `m = 6` is composite: no diagonal, and the lone distinct-prime pair is
+-- `k = 1` (`12 = 5 + 7`), so the comet height `1` is purely off-diagonal.
+example :
+    symmetricPairCount 6
+      = ((Finset.Ico 1 6).filter (fun k => Nat.Prime (6 - k) ∧ Nat.Prime (6 + k))).card :=
+  symmetricPairCount_eq_offDiagonal_of_not_prime (by decide)
+
 /-! ## Upper Bound: Comet Height ≤ Primes in the Upper Arm
 
 Each symmetric pair `(m - k, m + k)` with `k < m` contributes a *distinct* prime

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -589,3 +589,41 @@ in the SHARED main-repo checkout (branch `main`), NOT the worktree; a concurrent
 wiped it before `cp` propagated. Re-applied directly to the worktree file, committed+pushed
 BEFORE building. LESSON: always Edit the `.loom/worktrees/researcher-3/...` path and
 `grep -c <newdecl>` the worktree file before trusting.
+
+## Session 2026-07-09 (researcher-2) — Diagonal / off-diagonal decomposition of the comet height (DEEP DIVE, PROGRESS)
+
+**Mode**: REVISIT (RICH, saturated 0-axiom file `StrongGoldbachSymmetric.lean`) · **Outcome**:
+2 new verified theorems (0-axiom / 0-sorry), file elaborates clean.
+
+The file's entire ceiling apparatus repeatedly carries a `+ 1` (`symmetricPairCount_le_totient_succ`
+`≤ φ(m)+1`, `symmetricPairCount_le_half_totient_succ_of_odd` `≤ φ(m)/2+1`) whose meaning was only
+ever explained in prose — the `k = 0` diagonal `2m = m + m`, available iff `m` is prime. Made that
+exact:
+
+1. **`symmetricPairCount_eq_diagonal_add_offDiagonal`** — for every `m`,
+   `symmetricPairCount m = (if Prime m then 1 else 0) + #{k ∈ Ico 1 m : Prime(m−k) ∧ Prime(m+k)}`.
+   The diagonal term is the `k = 0` offset (condition `Prime(m−0) ∧ Prime(m+0)` collapses to
+   `Prime m` via `and_self`); the off-diagonal term counts Goldbach partitions of `2m` into two
+   **distinct** primes.
+2. **`symmetricPairCount_eq_offDiagonal_of_not_prime`** — corollary: on composite `m` the diagonal
+   vanishes, so the comet height counts *only* distinct-prime pairs.
+
+**Proof mechanics (reusable).** Peel `k = 0` from `range m`: `have hrange : range m = insert 0
+(Ico 1 m)` by `ext; simp[mem_range,mem_insert,mem_Ico]; omega` (needs `0 < m` in context — split
+`Nat.eq_zero_or_pos` first, `m = 0` closes by `simp[symmetricPairCount, Nat.not_prime_zero]`), then
+`rw[symmetricPairCount, hrange, Finset.filter_insert]`, `simp only[Nat.sub_zero,Nat.add_zero,
+and_self]`, `by_cases Nat.Prime m`, in the prime branch `Finset.card_insert_of_notMem (by simp)`
+(0 ∉ Ico 1 m) + `omega`. NOTE: `Finset.card_insert_of_not_mem` is **deprecated → `_of_notMem`**.
+
+**Honest status.** Structural decomposition, not a step toward the open conjecture; still on the
+counting/upper-bound side (a nontrivial LOWER bound remains the real advance and is essentially
+Goldbach). But it is the natural home for the recurring `+1` and cleanly names the distinct-prime
+sub-count. `WeakGoldbach.lean`'s 4 axioms (Helfgott / circle method / Chen / binary-verified) remain
+irreducible; the Schnirelmann axiom was already discharged (Part V).
+
+**Verification (docker DOWN).** Docker infra fully down all session (containerd meta.db +
+content-store blob `input/output error` at image build — operator-level, NOT disk: `df` shows 157Gi
+free). Verified instead by direct `lean` elaboration against the main repo's pinned Mathlib v4.26.0
+oleans (`~/.elan/toolchains/leanprover--lean4---v4.26.0/bin/lean` with `LEAN_PATH` = every
+`.lake/packages/*/.lake/build/lib/lean`): **exit 0, zero diagnostics**. `#print axioms` on both new
+theorems = `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).

--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -119,9 +119,9 @@
   },
   "leanFile": {
     "namespace": "StrongGoldbach",
-    "lineCount": 932,
+    "lineCount": 997,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 34,
     "definitionCount": 5,
     "path": "Proofs/StrongGoldbachSymmetric.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`weak-goldbach-oq-01` — REVISIT of the saturated 0-axiom file `StrongGoldbachSymmetric.lean` (the "Goldbach comet" reformulation). The file's ceiling apparatus repeatedly carries a `+ 1` (`symmetricPairCount_le_totient_succ` ≤ φ(m)+1, `symmetricPairCount_le_half_totient_succ_of_odd` ≤ φ(m)/2+1) whose meaning was only ever explained in prose — the `k = 0` diagonal `2m = m + m`, present iff `m` is prime. This PR makes it exact.

**New theorems (0 sorry / 0 axiom):**
- `symmetricPairCount_eq_diagonal_add_offDiagonal` — for every `m`,
  `symmetricPairCount m = (if m prime then 1 else 0) + #{k ∈ [1,m) : Prime(m−k) ∧ Prime(m+k)}`. Separates the single diagonal (square) partition from the distinct-prime pairs.
- `symmetricPairCount_eq_offDiagonal_of_not_prime` — on composite `m` the diagonal vanishes, so the comet height counts *only* distinct-prime Goldbach partitions of `2m`.

Plus two `decide`-checked example sanity cases (m = 5 prime, m = 6 composite).

## Honesty

Structural decomposition, **not** a step toward the open conjecture — still on the counting/upper-bound side (a nontrivial lower bound is essentially Goldbach itself). It is the natural home for the recurring `+1` and cleanly names the distinct-prime sub-count. `WeakGoldbach.lean`'s 4 axioms (Helfgott / circle method / Chen / binary-verified) remain irreducible; the Schnirelmann axiom was already discharged in a prior session.

## Verification

Docker infra was down this session (containerd meta.db + content-store blob `input/output error` at image build — operator-level, not disk: 157Gi free). Verified instead by direct `lean` elaboration against the repo's pinned **Mathlib v4.26.0** oleans: **exit 0, zero diagnostics**. `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).

Gallery meta `strong-goldbach-symmetric` counts synced (lineCount 932→997, theoremCount 30→34; the 30 was already stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)