### PR TITLE
Fix: sync stale lineCount in erdos-659-oq-05 (125->142)

### DIFF
--- a/src/data/proofs/erdos-659-oq-05/meta.json
+++ b/src/data/proofs/erdos-659-oq-05/meta.json
@@ -34,13 +34,13 @@
       "isRepresented_nonneg: represented integers are nonnegative (valid squared distances)",
       "dist_sq_lattice: squared distance between lattice points (x,y√2) equals Q of coordinate differences — ties the number theory to the actual Moree–Osburn geometry"
     ],
-    "lineCount": 125,
+    "lineCount": 142,
     "theoremCount": 10,
     "definitionCount": 4
   },
   "leanFile": {
     "path": "Proofs/Erdos659OQ05.lean",
-    "lineCount": 125,
+    "lineCount": 142,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` metadata in `erdos-659-oq-05` to match the actual Lean source file.

## Evidence

**Before**: `meta.lineCount` and `leanFile.lineCount` = 125
**After**: both = 142 (matches `wc -l proofs/Proofs/Erdos659OQ05.lean` = 142, file ends with trailing newline so content-line and newline conventions agree)

The Lean file grew via research commits without a corresponding metadata resync. No code changes; metadata-only.

---
Automated fix by lean-mechanic agent.