### PR TITLE
audit(erdos-944): re-verify CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17570,9 +17570,9 @@
       "result": "clean"
     },
     "erdos-944": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:11:22Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T05:16:28Z",
       "result": "clean"
     },
     "erdos-945": {
@@ -29770,5 +29770,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T04:43:54Z"
+  "lastUpdated": "2026-07-10T05:16:28Z"
 }


### PR DESCRIPTION
Auditor re-audit of **erdos-944** (Erdős #944: Critical Graphs Without Critical Edges).

**Verdict: CLEAN.** Honest OPEN-problem scaffold.

- Source `Proofs/Erdos944Problem.lean` (120 lines): only 2 empty `class ... : Prop` predicates (`IsKVertexCritical`, `IsErdos944Graph`) — no fields, so no structure-encoded assumptions.
- 0 axioms, 0 sorries, 0 theorems, 0 `native_decide`. Counts match meta.
- status `axiomatized` / badge `wip` — correctly conservative for an open Erdős problem (k=4 case unsolved).
- originalContributions accurate; known results (Brown/Lattanzio/Jensen/Martinsson-Steiner) disclosed as comment-only, not axiomatized. No axiom-masking, no phantom theorems, no overclaim.

Bumps tracker: auditCount 3→4, lastAudited → today, agentId auditor-agent.

🤖 Auditor agent