### PR TITLE
Research: law-of-cosines-oq-03-oq-03 - side-angle order-equivalence (converse)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -367,6 +367,58 @@ theorem side_lt_of_angle_lt (t : HyperbolicTriangle) (hAB : t.A < t.B) : t.a < t
     linarith
   exact (Real.cosh_strictMonoOn.lt_iff_lt (mem_Ici.mpr t.ha.le) (mem_Ici.mpr t.hb.le)).mp hcosh
 
+/-- **Relabeling a hyperbolic triangle by swapping vertices `A` and `B`** (fixing `C`).
+    The three second-law-of-cosines fields are symmetric under `(A,a) ↔ (B,b)`
+    (`lawA ↔ lawB`, `lawC` invariant up to commutativity), so the swap is again a valid
+    `HyperbolicTriangle`.  It lets the `A`-vs-`B` ordering lemmas be applied with the two
+    roles exchanged, without re-deriving the `cosh` comparison. -/
+def HyperbolicTriangle.swapAB (t : HyperbolicTriangle) : HyperbolicTriangle where
+  a := t.b; b := t.a; c := t.c
+  A := t.B; B := t.A; C := t.C
+  ha := t.hb; hb := t.ha; hc := t.hc
+  hA := t.hB; hB := t.hA; hC := t.hC
+  hA_lt := t.hB_lt; hB_lt := t.hA_lt; hC_lt := t.hC_lt
+  lawA := t.lawB
+  lawB := t.lawA
+  lawC := by rw [t.lawC]; ring
+
+/-- **Smaller angle, shorter side (the `B`-side companion).** `B < A` forces `b < a`,
+    obtained from `side_lt_of_angle_lt` applied to the `A ↔ B` relabeling `swapAB`. -/
+theorem side_gt_of_angle_gt (t : HyperbolicTriangle) (hBA : t.B < t.A) : t.b < t.a :=
+  side_lt_of_angle_lt t.swapAB hBA
+
+/-- **Converse side–angle inequality: shorter side ⟹ smaller opposite angle.** Within one
+    hyperbolic triangle, `a < b` forces `A < B`. Together with `side_lt_of_angle_lt` this is
+    the full order-equivalence `a < b ↔ A < B` (`side_lt_iff_angle_lt`). Proof by trichotomy on
+    `A` vs `B`: equality would give `a = b` (`isosceles_of_angle_eq`) and `B < A` would give
+    `b < a` (`side_gt_of_angle_gt`), both contradicting `a < b`. -/
+theorem angle_lt_of_side_lt (t : HyperbolicTriangle) (hab : t.a < t.b) : t.A < t.B := by
+  rcases lt_trichotomy t.A t.B with h | h | h
+  · exact h
+  · exact absurd (isosceles_of_angle_eq t h) (ne_of_lt hab)
+  · exact absurd (side_gt_of_angle_gt t h) (not_lt.mpr hab.le)
+
+/-- **Converse of the isosceles criterion: equal sides ⟹ equal opposite angles.**
+    `a = b → A = B`, completing `isosceles_of_angle_eq` to the equivalence
+    `a = b ↔ A = B` (`side_eq_iff_angle_eq`). Trichotomy on `A` vs `B`: either strict order
+    would force the corresponding strict side inequality, contradicting `a = b`. -/
+theorem angle_eq_of_side_eq (t : HyperbolicTriangle) (h : t.a = t.b) : t.A = t.B := by
+  rcases lt_trichotomy t.A t.B with hlt | heq | hgt
+  · exact absurd (side_lt_of_angle_lt t hlt) (by rw [h]; exact lt_irrefl _)
+  · exact heq
+  · exact absurd (side_gt_of_angle_gt t hgt) (by rw [h]; exact lt_irrefl _)
+
+/-- **Hyperbolic side–angle order-equivalence (strict).** `a < b ↔ A < B`: the opposite side
+    of the larger angle is strictly longer, and conversely. Packages `angle_lt_of_side_lt`
+    with `side_lt_of_angle_lt`. -/
+theorem side_lt_iff_angle_lt (t : HyperbolicTriangle) : t.a < t.b ↔ t.A < t.B :=
+  ⟨angle_lt_of_side_lt t, side_lt_of_angle_lt t⟩
+
+/-- **Hyperbolic side–angle equality-equivalence.** `a = b ↔ A = B`: a hyperbolic triangle is
+    isosceles in two sides iff it is isosceles in the two opposite angles. -/
+theorem side_eq_iff_angle_eq (t : HyperbolicTriangle) : t.a = t.b ↔ t.A = t.B :=
+  ⟨angle_eq_of_side_eq t, isosceles_of_angle_eq t⟩
+
 -- ============================================================
 -- PART 4b: Angle–side monotonicity — a larger opposite angle forces a shorter side
 -- ============================================================

--- a/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
+++ b/research/problems/law-of-cosines-oq-03-oq-03/knowledge.md
@@ -152,3 +152,28 @@ Docker `Built Proofs.LawOfCosinesOQ03OQ03 (2.4s)` — 0 sorries, 0 new axioms
 - Derive the FIRST law of cosines `cosh c = cosh a cosh b − sinh a sinh b cos C`
   from the second-law structure + this law of sines (closes the trig system).
 - SAS / ASA congruence by inverting the angle–side system.
+
+## Session 2026-07-09 (researcher-1) — side–angle order-equivalence (converse direction)
+
+The file had the FORWARD side–angle ordering (`side_lt_of_angle_lt`: A<B ⟹ a<b;
+`isosceles_of_angle_eq`: A=B ⟹ a=b) but not the converses. Added them, completing the strict
+order-equivalence:
+
+- `HyperbolicTriangle.swapAB` — the (A,a)↔(B,b) relabeling (fixing C,c). Valid because the
+  three second-law fields are symmetric: `lawA := t.lawB`, `lawB := t.lawA` (definitional),
+  `lawC := by rw [t.lawC]; ring` (invariant up to commutativity). Lets the A-vs-B lemmas be
+  reused with roles exchanged without re-deriving the cosh comparison.
+- `side_gt_of_angle_gt` (B<A ⟹ b<a) = `side_lt_of_angle_lt` on `swapAB`.
+- `angle_lt_of_side_lt` (a<b ⟹ A<B) and `angle_eq_of_side_eq` (a=b ⟹ A=B): trichotomy on A vs B,
+  excluding the two contradictory branches via the forward lemmas + `side_gt_of_angle_gt`.
+- `side_lt_iff_angle_lt` (a<b ↔ A<B) and `side_eq_iff_angle_eq` (a=b ↔ A=B): the packaged
+  equivalences.
+
+1 def + 5 theorems, 0 sorry, 0 new axioms (7 structure-encoded second-law assumptions unchanged).
+Proofs use only already-VERIFIED in-file lemmas + `lt_trichotomy` + the symmetric relabeling —
+high confidence.
+
+UNVERIFIED: Docker infra down this session (containerd `meta.db input/output error` at image
+build, before any Lean elaboration — operator-level outage, not a proof error). The genuine
+remaining frontier is the FIRST law of cosines (`cosh c = cosh a cosh b − sinh a sinh b cos C`)
+from the second-law structure + law of sines, and SAS/ASA — both heavier algebra.

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,9 +17,9 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 829,
-    "theoremCount": 47,
-    "definitionCount": 2
+    "lineCount": 881,
+    "theoremCount": 52,
+    "definitionCount": 3
   },
   "openQuestion": {
     "id": "law-of-cosines-oq-03-oq-03",

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -13,7 +13,7 @@
   "significance": "AAA congruence is one of the sharpest qualitative differences between hyperbolic and Euclidean geometry, and underlies the rigidity of hyperbolic structures (Thurston). Completes the basic congruence theory alongside the parent law of cosines and sibling law of sines.",
   "currentState": "COMPLETED. Proved AAA congruence: the second law of cosines inverts to cosh c = (cos C + cos A cos B)/(sin A sin B), a function of the angles alone; injectivity of cosh on [0,∞) turns equal angles into equal sides. Also proved internal consistency (the defect A+B+C<π is exactly what makes the formula exceed 1) and the equilateral closed form cosh(side)=cos θ/(1-cos θ).",
   "knowledge": {
-    "progressSummary": "COMPLETE: AAA congruence + hyperbolic law of sines + realizability (defect condition is necessary AND sufficient; angles↦triangle is a bijection). 0 sorries, structure-encoded second-law assumptions only.",
+    "progressSummary": "COMPLETE: AAA congruence + hyperbolic law of sines + realizability (defect condition is necessary AND sufficient; angles↦triangle is a bijection). 0 sorries, structure-encoded second-law assumptions only. | Session (researcher-1): completed the side-angle ORDER-EQUIVALENCE — added the converse direction (a<b ⟹ A<B, a=b ⟹ A=B) via a HyperbolicTriangle.swapAB relabeling (valid since the 3 second-law fields are A↔B symmetric), giving side_lt_iff_angle_lt / side_eq_iff_angle_eq. 0 sorry, 0 new axioms. UNVERIFIED (Docker infra down).",
     "builtItems": [
       "LawOfCosinesOQ03OQ03.lean: hyperbolic AAA congruence (0 sorries, 7 structure-encoded axioms)",
       "HyperbolicTriangle: structure with sides a,b,c, angles A,B,C, side positivity, angle bounds, defect, and three second laws of cosines lawA/lawB/lawC",
@@ -27,7 +27,8 @@
       "LawOfCosinesOQ03OQ03.lean PART 9: hyperbolic law of sines derived from the second law of cosines. gramNumerator (symmetric Gram numerator of the three angles); sinh_a/b/c_num_sq: (sinh side · product of the two adjacent sines)^2 = gramNumerator; law_of_sines_ab/bc/ac (cross form sinh a sin B = sinh b sin A); hyperbolic_law_of_sines (ratio form sinh a/sin A = sinh b/sin B = sinh c/sin C); gramNumerator_nonneg.",
       "angle_ineq (LawOfCosinesOQ03OQ03.lean Part 10): raw-real form sin A sin B < cos C + cos A cos B from 0<A,B,C and A+B+C<π; applied under cyclic permutations to bound all three inverted-side quotients above 1",
       "exists_triangle_of_defect (Part 10): constructs a HyperbolicTriangle from any A,B,C∈(0,π) with A+B+C<π, sides = arcosh of inverted second-law quotients (Real.cosh_arcosh, Real.arcosh_pos); laws proved by field_simp;ring",
-      "exists_iff_defect + exists_equilateral (Part 10): full bijection characterization (realized ⟺ defect>0) and equilateral existence for every θ∈(0,π/3)"
+      "exists_iff_defect + exists_equilateral (Part 10): full bijection characterization (realized ⟺ defect>0) and equilateral existence for every θ∈(0,π/3)",
+      "swapAB relabeling (A↔B, fixing C) + side_gt_of_angle_gt + angle_lt_of_side_lt + angle_eq_of_side_eq + side_lt_iff_angle_lt + side_eq_iff_angle_eq: the CONVERSE side↔angle ordering, completing the strict order-equivalence a<b ↔ A<B and a=b ↔ A=B. LawOfCosinesOQ03OQ03.lean."
     ],
     "insights": [
       "The second law of cosines is linear in cosh of the opposite side, so it inverts algebraically — no Euclidean analogue, since the Euclidean law relates a side to the other two sides, not purely to angles.",


### PR DESCRIPTION
## Summary
Research session for `law-of-cosines-oq-03-oq-03` (hyperbolic law of cosines). Completes the
**side–angle order-equivalence** by adding the converse of the existing forward ordering lemmas.

## Progress
The file had the forward direction (`side_lt_of_angle_lt`: `A<B ⟹ a<b`;
`isosceles_of_angle_eq`: `A=B ⟹ a=b`) but not the converses. Added:
- **`HyperbolicTriangle.swapAB`** — the `(A,a) ↔ (B,b)` relabeling (fixing `C,c`), valid because
  the three second-law-of-cosines fields are symmetric (`lawA := t.lawB`, `lawB := t.lawA`
  definitionally, `lawC := by rw [t.lawC]; ring`). Lets the A-vs-B lemmas be reused with roles
  exchanged without re-deriving the `cosh` comparison.
- **`side_gt_of_angle_gt`** (`B<A ⟹ b<a`) via `swapAB`.
- **`angle_lt_of_side_lt`** (`a<b ⟹ A<B`) and **`angle_eq_of_side_eq`** (`a=b ⟹ A=B`) by
  trichotomy, excluding the two contradictory branches with the forward lemmas.
- **`side_lt_iff_angle_lt`** (`a<b ↔ A<B`) and **`side_eq_iff_angle_eq`** (`a=b ↔ A=B`) — the
  packaged equivalences.

1 def + 5 theorems, 0 sorries, 0 new axioms (7 structure-encoded second-law assumptions
unchanged). Synced gallery `meta.json` leanFile counts (829→881 L, 47→52 thm, 2→3 def).

## Findings
- Proofs use only already-VERIFIED in-file lemmas + `lt_trichotomy` + the symmetric relabeling.
- Genuine remaining frontier (heavier): the first law of cosines from the second-law structure +
  law of sines, and SAS/ASA congruence.

## Status
**Outcome**: progress (UNVERIFIED — Docker build host containerd down: `meta.db input/output
error` at image build, before any Lean elaboration; operator-level outage, not a proof error)
**Next Steps**: rebuild once Docker is healthy to confirm `=== Build succeeded ===`.

🤖 Generated by researcher-1