### PR TITLE
Enrich The Odd-Square Series ∑ 1/(2k+1)² = π²/8: refine sections

### DIFF
--- a/src/data/proofs/basel-problem-oq-09/meta.json
+++ b/src/data/proofs/basel-problem-oq-09/meta.json
@@ -123,17 +123,25 @@
       "id": "odd-part",
       "title": "hasSum_odd_squares — ∑ 1/(2k+1)² = π²/8",
       "startLine": 80,
-      "endLine": 121,
-      "summary": "Odd subseries summable via comp_injective; reassemble ζ(2) = even + odd with HasSum.even_add_odd and use HasSum.unique to pin the odd sum to π²/8, then bridge to the clean statement. Includes tsum and summability corollaries.",
+      "endLine": 124,
+      "summary": "Odd subseries summable via comp_injective; reassemble ζ(2) = even + odd with HasSum.even_add_odd and use HasSum.unique to pin the odd sum to π²/8, then bridge to the clean statement. Packages the reusable corollaries tsum_odd_squares, summable_odd_squares, and the positivity check odd_squares_value_pos.",
       "mathContext": "The odd-square Basel sum, recovered as ζ(2) minus its even part."
     },
     {
       "id": "decomposition",
-      "title": "The decomposition identity and sanity checks",
-      "startLine": 123,
+      "title": "The decomposition identity — π²/6 = π²/24 + π²/8",
+      "startLine": 126,
+      "endLine": 138,
+      "summary": "Records the value identity π²/6 = π²/24 + π²/8 (basel_even_odd_decomposition, closed by ring) and that the odd part exceeds the even part (odd_part_gt_even_part), so three quarters of the Basel mass lives on the odd indices.",
+      "mathContext": "$\\frac{\\pi^2}{6} = \\frac{\\pi^2}{24} + \\frac{\\pi^2}{8}$: the odd part (¾ζ(2)) exceeds the even part (¼ζ(2))."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Numerical sanity checks",
+      "startLine": 140,
       "endLine": 148,
-      "summary": "Records π²/6 = π²/24 + π²/8, that the odd part exceeds the even part, and numerical checks that the first two odd terms are 1 and 1/9.",
-      "mathContext": "Three quarters of the Basel mass lives on the odd indices."
+      "summary": "Two anonymous examples confirm the first two odd terms evaluate to 1/1² = 1 and 1/3² = 1/9, grounding the abstract HasSum statement in concrete arithmetic; being examples they contribute no axioms and no named theorems.",
+      "mathContext": "First odd terms: $\\frac{1}{1^2}=1$, $\\frac{1}{3^2}=\\frac19$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-09` (quality 95, passes 0).

This entry was already richly enriched (9 annotations all with mathContext/significance/relatedConcepts/prerequisites, 5 keyInsights, full conclusion, 5 cross-references, 3 references). Rather than inflate it, this pass closes the one genuine, measurable gap: the `sections` array had 4 entries where the Lean file has 5 natural `/-! ## -/` structural blocks.

## Changes
- Split the oversized `odd-part`/`decomposition` coverage into 5 sections matching the file's own markers: preamble (1–59), even part (61–78), odd part (80–124), decomposition identity (126–138), numerical sanity checks (140–148).
- Fixed `odd-part` endLine 121→124 so it includes `odd_squares_value_pos` (line 124), which sits before the next `/-! ## -/` marker.
- Separated the decomposition identity from the numerical sanity checks, which were previously merged into one section.

All section boundaries verified against the actual declarations in `Proofs/BaselProblemOQ09.lean`. meta.json remains well under size caps (~14 KB). Gallery data-build validation (enrichment, search-index, loading-facts) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)