### PR TITLE
research(shannon-channel-coding-awgn-oq-03-oq-01): water-filling capacity monotonicity

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean
@@ -1,0 +1,179 @@
+/-
+# Shannon AWGN water-filling, oq-03-oq-01 — capacity monotonicity
+
+Source: parallel-Gaussian-channel water-filling (see
+`ShannonChannelCodingAWGNOQ03OQ01.lean`, namespace `ShannonWaterFilling`, which
+proves optimality of `Pᵢ⋆ = (μ − Nᵢ)₊`, the closed-form optimum
+`∑ᵢ ½ log(max μ Nᵢ / Nᵢ)`, and existence/uniqueness of the water level `μ`).
+
+The companion `…EqualNoise.lean` records the equal-noise closed form and its
+monotonicities.  This file supplies the *general* (arbitrary noise profile)
+structural monotonicities of the water-filling capacity, all axiom-free /
+sorry-free:
+
+* `perUseCapacity_nonneg`   — a single AWGN sub-channel with `P ≥ 0`, `N > 0` has
+  nonnegative rate `½ log(1 + P/N) ≥ 0`.
+* `perUseCapacity_mono`     — the per-channel rate is monotone in the allotted
+  power `P`.
+* `waterAlloc_mono_level`   — the water-filling depth `(μ − Nᵢ)₊` is monotone in
+  the water level `μ`.
+* `rate_waterAlloc_nonneg`  — the water-filling rate is nonnegative.
+* `rate_waterAlloc_mono_level` — the water-filling rate is monotone in the water
+  level `μ` (raising the surface never lowers the achievable rate).
+* `waterBudget_nonneg`      — the poured-in power is nonnegative.
+* `waterLevel_pos`          — a positive budget forces a positive water level.
+* `rate_waterAlloc_eq_zero_of_budget_zero` — a zero budget yields zero rate.
+* `capacity_mono_budget`    — **the headline**: the constrained capacity
+  `C(P) = R(waterAlloc μ N)` is monotone in the total power budget `P`; more
+  power never decreases the optimal achievable rate.  Proved directly from
+  optimality (`waterfilling_optimal`): the water-filling allocation for a smaller
+  budget is a *feasible* allocation for the larger budget, so the larger budget's
+  optimum dominates it.
+
+Tags: information-theory, shannon, awgn, water-filling, capacity, monotonicity
+-/
+
+import Mathlib
+import Proofs.ShannonChannelCodingAWGNOQ03OQ01
+
+set_option linter.unusedSectionVars false
+
+namespace ShannonWaterFilling
+
+open scoped BigOperators
+
+variable {ι : Type*} [Fintype ι]
+
+/-! ## Per-channel rate: nonnegativity and power-monotonicity -/
+
+/-- **A single sub-channel has nonnegative rate.**  With nonnegative allotted
+power `P` and positive noise `N`, the per-use AWGN capacity `½ log(1 + P/N)` is
+nonnegative, since `1 + P/N ≥ 1`. -/
+theorem perUseCapacity_nonneg {P N : ℝ} (hP : 0 ≤ P) (hN : 0 < N) :
+    0 ≤ perUseCapacity P N := by
+  unfold perUseCapacity
+  apply mul_nonneg (by norm_num)
+  apply Real.log_nonneg
+  have : 0 ≤ P / N := div_nonneg hP hN.le
+  linarith
+
+/-- **Per-channel rate is monotone in power.**  For fixed positive noise `N`,
+allocating more (nonnegative) power to a sub-channel never decreases its rate:
+`P₁ ≤ P₂ ⟹ ½ log(1 + P₁/N) ≤ ½ log(1 + P₂/N)`. -/
+theorem perUseCapacity_mono {N : ℝ} (hN : 0 < N) {P₁ P₂ : ℝ}
+    (hP1 : 0 ≤ P₁) (hP : P₁ ≤ P₂) :
+    perUseCapacity P₁ N ≤ perUseCapacity P₂ N := by
+  unfold perUseCapacity
+  apply mul_le_mul_of_nonneg_left _ (by norm_num)
+  apply Real.log_le_log
+  · have : 0 ≤ P₁ / N := div_nonneg hP1 hN.le
+    linarith
+  · have hdiv : P₁ / N ≤ P₂ / N := by gcongr
+    linarith
+
+/-! ## Water-filling depth: monotonicity in the water level -/
+
+/-- **The water-filling depth is monotone in the water level.**  Raising the
+surface `μ₁ ≤ μ₂` never decreases any channel's depth `(μ − Nᵢ)₊`. -/
+theorem waterAlloc_mono_level {μ₁ μ₂ : ℝ} (h : μ₁ ≤ μ₂) (N : ι → ℝ) (i : ι) :
+    waterAlloc μ₁ N i ≤ waterAlloc μ₂ N i := by
+  unfold waterAlloc
+  exact max_le_max (by linarith) le_rfl
+
+/-! ## Water-filling rate: nonnegativity and monotonicity in the water level -/
+
+/-- **The water-filling rate is nonnegative.**  Summing nonnegative per-channel
+rates, the total rate `R(waterAlloc μ N)` is `≥ 0`. -/
+theorem rate_waterAlloc_nonneg (N : ι → ℝ) (hN : ∀ i, 0 < N i) (μ : ℝ) :
+    0 ≤ parallelRate N (waterAlloc μ N) := by
+  unfold parallelRate
+  apply Finset.sum_nonneg
+  intro i _
+  exact perUseCapacity_nonneg (waterAlloc_nonneg μ N i) (hN i)
+
+/-- **The water-filling rate is monotone in the water level.**  Raising the water
+surface `μ₁ ≤ μ₂` never decreases the total achievable rate; each per-channel term
+grows with its (monotone) depth. -/
+theorem rate_waterAlloc_mono_level (N : ι → ℝ) (hN : ∀ i, 0 < N i)
+    {μ₁ μ₂ : ℝ} (h : μ₁ ≤ μ₂) :
+    parallelRate N (waterAlloc μ₁ N) ≤ parallelRate N (waterAlloc μ₂ N) := by
+  unfold parallelRate
+  apply Finset.sum_le_sum
+  intro i _
+  exact perUseCapacity_mono (hN i) (waterAlloc_nonneg μ₁ N i)
+    (waterAlloc_mono_level h N i)
+
+/-! ## Budget positivity ⇒ water-level positivity, and the zero-budget degeneracy -/
+
+/-- The poured-in power `g(μ) = ∑ᵢ (μ − Nᵢ)₊` is nonnegative. -/
+theorem waterBudget_nonneg (N : ι → ℝ) (μ : ℝ) : 0 ≤ waterBudget N μ := by
+  unfold waterBudget
+  exact Finset.sum_nonneg fun i _ => waterAlloc_nonneg μ N i
+
+/-- **A positive budget forces a positive water level.**  If the water level `μ`
+realises a strictly positive budget `P > 0` (with positive noise floors) then
+`μ > 0`: at `μ ≤ 0` every channel is dry (`μ − Nᵢ < 0`) and the budget vanishes. -/
+theorem waterLevel_pos (N : ι → ℝ) (hN : ∀ i, 0 < N i) {μ P : ℝ}
+    (hbudget : waterBudget N μ = P) (hP : 0 < P) : 0 < μ := by
+  by_contra hcon
+  push_neg at hcon
+  have hzero : waterBudget N μ = 0 := by
+    unfold waterBudget waterAlloc
+    apply Finset.sum_eq_zero
+    intro i _
+    exact max_eq_right (by linarith [hN i])
+  rw [hbudget] at hzero
+  linarith
+
+/-- **A zero budget yields zero rate.**  When no power is poured in
+(`g(μ) = 0`) every channel is switched off and the water-filling rate is `0`. -/
+theorem rate_waterAlloc_eq_zero_of_budget_zero (N : ι → ℝ)
+    {μ : ℝ} (h : waterBudget N μ = 0) :
+    parallelRate N (waterAlloc μ N) = 0 := by
+  have hsum : ∑ i, waterAlloc μ N i = 0 := h
+  have hzero : ∀ i, waterAlloc μ N i = 0 := by
+    have := (Finset.sum_eq_zero_iff_of_nonneg
+      (fun i _ => waterAlloc_nonneg μ N i)).1 hsum
+    intro i; exact this i (Finset.mem_univ i)
+  unfold parallelRate
+  apply Finset.sum_eq_zero
+  intro i _
+  rw [hzero i]
+  simp [perUseCapacity]
+
+/-! ## The headline: capacity is monotone in the power budget -/
+
+/-- **Capacity is monotone in the total power budget.**  Let `μ₁` and `μ₂` be the
+water levels realising budgets `P₁` and `P₂` respectively (`g(μⱼ) = Pⱼ`), with
+positive noise floors and `P₁ ≤ P₂`.  Then the constrained parallel-channel
+capacities satisfy
+
+    R(waterAlloc μ₁ N) ≤ R(waterAlloc μ₂ N).
+
+More total power never decreases the optimal achievable rate.  The proof is a
+direct consequence of optimality: the water-filling allocation for the smaller
+budget `P₁` is a *feasible* allocation for the larger budget `P₂` (its total power
+is `P₁ ≤ P₂`), so the optimum at `P₂` dominates it (`waterfilling_optimal`). -/
+theorem capacity_mono_budget (N : ι → ℝ) (hN : ∀ i, 0 < N i)
+    {μ₁ μ₂ P₁ P₂ : ℝ}
+    (h1 : waterBudget N μ₁ = P₁) (h2 : waterBudget N μ₂ = P₂) (hP : P₁ ≤ P₂) :
+    parallelRate N (waterAlloc μ₁ N) ≤ parallelRate N (waterAlloc μ₂ N) := by
+  have hP2nonneg : 0 ≤ P₂ := by rw [← h2]; exact waterBudget_nonneg N μ₂
+  rcases eq_or_lt_of_le hP2nonneg with hP2z | hP2pos
+  · -- degenerate: P₂ = 0 forces P₁ = 0, so both capacities are 0
+    have hP2 : P₂ = 0 := hP2z.symm
+    have hP1nonneg : 0 ≤ P₁ := by rw [← h1]; exact waterBudget_nonneg N μ₁
+    have hP1 : P₁ = 0 := le_antisymm (hP2 ▸ hP) hP1nonneg
+    rw [rate_waterAlloc_eq_zero_of_budget_zero N (h1.trans hP1),
+        rate_waterAlloc_eq_zero_of_budget_zero N (h2.trans hP2)]
+    -- both capacities are 0
+    exact le_refl 0
+  · -- generic: P₂ > 0, so μ₂ > 0 and optimality at P₂ dominates the P₁ allocation
+    have hμ₂ : 0 < μ₂ := waterLevel_pos N hN h2 hP2pos
+    have hxsum : ∑ i, waterAlloc μ₁ N i ≤ P₂ := by
+      have hb : (∑ i, waterAlloc μ₁ N i) = P₁ := h1
+      rw [hb]; exact hP
+    exact waterfilling_optimal N hN hμ₂ h2 (waterAlloc μ₁ N)
+      (fun i => waterAlloc_nonneg μ₁ N i) hxsum
+
+end ShannonWaterFilling

--- a/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-03-oq-01/knowledge.md
@@ -116,3 +116,45 @@ Delivered:
 - The wideband limit as a genuine `Tendsto`: `C(n) → P/(2c)` as `n → ∞` (needs
   `n·log(1 + a/n) → a`), upgrading the `≤ P/(2c)` bound to an attained supremum.
 - Concavity of `C(P)` in the power budget (diminishing returns / `ConcaveOn`).
+
+---
+
+## Session 2026-07-09 (Session 2) — Capacity monotonicity layer (researcher-4)
+
+**Mode**: SATURATED (problem COMPLETED) · **Outcome**: progress (new general structural layer)
+
+### What I did
+- Created `proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean` (namespace
+  `ShannonWaterFilling`, imports the main OQ0301 file). Nine axiom-free / sorry-free
+  lemmas giving the **general** (arbitrary noise profile) monotonicities of the
+  water-filling capacity, complementing the equal-noise companion:
+  1. `perUseCapacity_nonneg` / `perUseCapacity_mono` — a single AWGN sub-channel's
+     rate is `≥ 0` and monotone in allotted power.
+  2. `waterAlloc_mono_level` — the depth `(μ − Nᵢ)₊` is monotone in the water level.
+  3. `rate_waterAlloc_nonneg` / `rate_waterAlloc_mono_level` — the water-filling
+     rate is `≥ 0` and monotone in the water level `μ`.
+  4. `waterBudget_nonneg`, `waterLevel_pos` (0 < P ⟹ 0 < μ),
+     `rate_waterAlloc_eq_zero_of_budget_zero` (support lemmas).
+  5. **`capacity_mono_budget`** (headline) — the constrained capacity `C(P)` is
+     monotone in the total power budget `P`: more power never decreases the optimal
+     achievable rate.
+
+### Key finding
+- `capacity_mono_budget` needs *no* new analysis: the water-filling allocation for a
+  smaller budget `P₁` is a **feasible** allocation for a larger budget `P₂` (its total
+  power is `P₁ ≤ P₂`), so `waterfilling_optimal` at `μ₂` immediately dominates it.
+  The only wrinkle is the degenerate `P₂ = 0` case (forces `P₁ = 0`, both capacities
+  `= 0`), dispatched via `rate_waterAlloc_eq_zero_of_budget_zero`. Positivity of the
+  water level for a positive budget (`waterLevel_pos`) supplies the `0 < μ₂` premise.
+
+### Infrastructure / environment
+- **DOCKER INFRA DOWN**: `docker-build.sh` dies at image build with
+  `containerd .../meta.db: input/output error` and `docker images` reports
+  content-store blob I/O errors. Host disk fine (156Gi free). Operator-level
+  containerd corruption; not self-fixable (won't prune shared caches). Shipped
+  **UNVERIFIED** with careful manual review — every API call mirrors the already
+  VERIFIED main + EqualNoise sibling files (`Real.log_le_log`,
+  `mul_le_mul_of_nonneg_left`, `Finset.sum_nonneg`, `gcongr`, `waterfilling_optimal`).
+
+### Files modified
+- `proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01Monotone.lean` (new)


### PR DESCRIPTION
## Summary

Adds a new companion `ShannonChannelCodingAWGNOQ03OQ01Monotone.lean` (namespace `ShannonWaterFilling`) to the parallel-Gaussian-channel water-filling entry. Nine axiom-free / sorry-free lemmas establishing the **general** (arbitrary noise profile) structural monotonicities of the water-filling capacity — the general counterpart to the existing equal-noise companion's monotonicities.

## What's proved

- `perUseCapacity_nonneg` / `perUseCapacity_mono` — a single AWGN sub-channel's rate ½·log(1 + P/N) is nonnegative and monotone in allotted power P.
- `waterAlloc_mono_level` — the water-filling depth (μ − Nᵢ)₊ is monotone in the water level μ.
- `rate_waterAlloc_nonneg` / `rate_waterAlloc_mono_level` — the water-filling rate is nonnegative and monotone in the water level.
- `waterBudget_nonneg`, `waterLevel_pos` (0 < P ⟹ 0 < μ), `rate_waterAlloc_eq_zero_of_budget_zero` — support lemmas.
- **`capacity_mono_budget`** (headline) — the constrained capacity C(P) is monotone in the total power budget P: more total power never decreases the optimal achievable rate.

## Key idea

`capacity_mono_budget` needs no new analysis. The water-filling allocation for a smaller budget P₁ is a *feasible* allocation for a larger budget P₂ (its total power is P₁ ≤ P₂), so the existing optimality theorem `waterfilling_optimal` at the water level μ₂ immediately dominates it. The only wrinkle is the degenerate P₂ = 0 case (forces P₁ = 0, both capacities 0), dispatched via `rate_waterAlloc_eq_zero_of_budget_zero`; `waterLevel_pos` supplies the 0 < μ₂ premise for the generic case.

## Verification status

⚠️ **UNVERIFIED** — Docker build infra was down for the entire session: `docker-build.sh` fails at image build with `containerd .../meta.db: input/output error` and the content store reports blob I/O errors (host disk has 156Gi free — this is operator-level containerd corruption, not disk pressure). Reviewed manually: every API call mirrors the already-VERIFIED main OQ0301 file and its EqualNoise companion (`Real.log_le_log`, `mul_le_mul_of_nonneg_left`, `Finset.sum_nonneg`, `gcongr`, `waterfilling_optimal`). A green rebuild once infra recovers is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)