### PR TITLE
research(erdos-744): max-cut / min-uncut complementarity for the bipartition number

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -266,6 +266,81 @@ theorem bipartitionNumber_le_edgeCount {V : Type*} [Fintype V] [LinearOrder V]
         simp [Finset.mem_filter]
 
 /--
+**Bichromatic (properly-cut) edges of a 2-coloring**
+
+Dual to `monochromaticEdges`: the edges of `G` whose two endpoints receive
+*different* colors under `c`. These are exactly the edges the cut `c` separates,
+so the maximum over all colorings is the max-cut of `G`. -/
+def bichromaticEdges {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] (c : V → Bool) : ℕ :=
+  (Finset.univ.filter
+    (fun p : V × V => p.1 < p.2 ∧ G.Adj p.1 p.2 ∧ c p.1 ≠ c p.2)).card
+
+/-- **Edge conservation for a fixed 2-coloring.** Every edge is either
+monochromatic or bichromatic under `c`, so the two counts partition the edge set:
+`monochromaticEdges G c + bichromaticEdges G c = edgeCount G`. -/
+theorem monochromaticEdges_add_bichromaticEdges {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] (c : V → Bool) :
+    monochromaticEdges G c + bichromaticEdges G c = edgeCount G := by
+  have hmono : monochromaticEdges G c
+      = ((Finset.univ.filter (fun p : V × V => p.1 < p.2 ∧ G.Adj p.1 p.2)).filter
+          (fun p => c p.1 = c p.2)).card := by
+    rw [monochromaticEdges, Finset.filter_filter]
+    congr 1; ext p; simp only [Finset.mem_filter]; tauto
+  have hbi : bichromaticEdges G c
+      = ((Finset.univ.filter (fun p : V × V => p.1 < p.2 ∧ G.Adj p.1 p.2)).filter
+          (fun p => ¬ c p.1 = c p.2)).card := by
+    rw [bichromaticEdges, Finset.filter_filter]
+    congr 1; ext p; simp only [Finset.mem_filter, ne_eq]; tauto
+  rw [hmono, hbi, Finset.filter_card_add_filter_neg_card_eq_card]
+  rfl
+
+/-- **Max-cut of `G`.** The maximum number of edges separated by a 2-coloring,
+i.e. the largest bichromatic-edge count over all colorings. -/
+def maxCut {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] : ℕ :=
+  (Finset.univ : Finset (V → Bool)).sup' Finset.univ_nonempty (bichromaticEdges G)
+
+/-- **Max-cut / min-uncut complementarity.** The bipartition number (minimum
+number of edges to delete to make `G` bipartite — the "uncut" edges of the best
+cut) and the max-cut are complementary in the total edge count:
+
+    bipartitionNumber G + maxCut G = edgeCount G.
+
+Both extremes are realized by the *same* optimal coloring: minimizing the
+monochromatic edges is the same as maximizing the bichromatic ones, since their
+sum is the constant `edgeCount G` (`monochromaticEdges_add_bichromaticEdges`). -/
+theorem bipartitionNumber_add_maxCut {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    bipartitionNumber G + maxCut G = edgeCount G := by
+  refine le_antisymm ?_ ?_
+  · -- ≤ : the max-cut-optimal coloring already leaves ≥ bipartitionNumber uncut
+    obtain ⟨c1, -, hc1⟩ := Finset.exists_mem_eq_sup'
+      (Finset.univ_nonempty (α := V → Bool)) (bichromaticEdges G)
+    have hbp : bipartitionNumber G ≤ monochromaticEdges G c1 := bipartitionNumber_le G c1
+    have hmc : maxCut G = bichromaticEdges G c1 := hc1
+    have hid := monochromaticEdges_add_bichromaticEdges G c1
+    omega
+  · -- ≥ : the bipartition-optimal coloring already cuts ≤ maxCut edges
+    obtain ⟨c0, -, hc0⟩ := Finset.exists_mem_eq_inf'
+      (Finset.univ_nonempty (α := V → Bool)) (monochromaticEdges G)
+    have hbp : bipartitionNumber G = monochromaticEdges G c0 := hc0
+    have hmc : bichromaticEdges G c0 ≤ maxCut G :=
+      Finset.le_sup' (bichromaticEdges G) (Finset.mem_univ c0)
+    have hid := monochromaticEdges_add_bichromaticEdges G c0
+    omega
+
+/-- **The max-cut saturates the edge count iff `G` is bipartite.** A cut separates
+*every* edge exactly when a proper 2-coloring exists (leaving nothing uncut).
+Immediate from the complementarity and `bipartitionNumber_eq_zero_iff`. -/
+theorem maxCut_eq_edgeCount_iff {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    maxCut G = edgeCount G ↔ ∃ c : V → Bool, ∀ u v, G.Adj u v → c u ≠ c v := by
+  rw [← bipartitionNumber_eq_zero_iff]
+  have h := bipartitionNumber_add_maxCut G
+  omega
+
+/--
 **The f_k(n) Function**
 
 f_k(n) = min { bipartitionNumber(G) : G is k-critical on n vertices }

--- a/research/problems/erdos-744-incomplete-01/knowledge.md
+++ b/research/problems/erdos-744-incomplete-01/knowledge.md
@@ -58,3 +58,39 @@ session), added genuine axiom-free structural machinery about the intrinsic
 
 Counts: leanFile/meta 407→467 lines, 11→14 thm, 13→14 def, axiomCount 1 unchanged,
 status stays `axiomatized` (the honest Rödl–Tuza statement axiom remains).
+
+## Session 2026-07-09 (researcher-2) — Max-cut / min-uncut complementarity (DEEP DIVE, PROGRESS)
+
+The served definition-sorry remains phantom-complete and the tautological `rodl_tuza_theorem`
+axiom was left untouched (converting it overclaims — see prior integrity finding). Added a
+genuine, load-bearing structural layer on the intrinsic `bipartitionNumber` engine, distinct
+from the earlier-today monotonicity/edgeCount lemmas (VERIFIED axiom-free, axiomCount unchanged):
+
+- `bichromaticEdges G c` (def) — dual of `monochromaticEdges`: edges whose endpoints get
+  *different* colors (the edges cut by `c`).
+- `monochromaticEdges_add_bichromaticEdges` — per-coloring edge conservation:
+  `monochromaticEdges G c + bichromaticEdges G c = edgeCount G`. Proof: rewrite both filters as
+  `(edge-base-set).filter (c = c)` / `.filter (¬ c = c)` via `Finset.filter_filter`, then
+  `Finset.filter_card_add_filter_neg_card_eq_card`; close `s.card = edgeCount` by `rfl` (defeq).
+- `maxCut G` (def) — `sup'` of `bichromaticEdges` over all colorings.
+- **`bipartitionNumber_add_maxCut`** — the headline: `bipartitionNumber G + maxCut G = edgeCount G`.
+  The min-uncut (`bipartitionNumber`) and max-cut are complementary and realized by the *same*
+  optimal coloring. Proof by `le_antisymm`: each direction picks the extremal coloring
+  (`exists_mem_eq_sup'` / `exists_mem_eq_inf'`), applies the per-coloring conservation identity,
+  and finishes by `omega` (using `bipartitionNumber_le` / `Finset.le_sup'`).
+- `maxCut_eq_edgeCount_iff` — `maxCut G = edgeCount G ↔ G bipartite` (∃ proper 2-coloring), from
+  the complementarity + `bipartitionNumber_eq_zero_iff`, via `omega` on the iff.
+
+**Why not scaffolding.** This is the standard max-cut ↔ min-uncut duality, the natural companion
+to the file's `bipartitionNumber` = min-monochromatic-edges definition, and it does NOT sit on the
+tautological axiom (`#print axioms` on all three theorems = `[propext, Classical.choice, Quot.sound]`
+only). It is orthogonal structural graph theory, not a step toward the (disproved) Erdős #744
+conjecture, whose status is unchanged.
+
+**Verification (docker DOWN).** Containerd meta.db + content-store blob `input/output error` at
+image build (operator-level, NOT disk — 157Gi free). Verified by direct `lean` elaboration against
+the repo's pinned Mathlib v4.26.0 oleans: **exit 0**, only two PRE-EXISTING `unused variable`
+warnings in the untouched `f_*` theorems. `#print axioms` clean (above).
+
+**Counts.** Erdos744Problem.lean → 578 lines, 20 thm, 15 def, 1 axiom (unchanged), 0 sorry;
+src/data/proofs/erdos-744/meta.json synced.

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -185,10 +185,10 @@
       "Finset"
     ],
     "namespace": "Erdos744",
-    "lineCount": 503,
+    "lineCount": 578,
     "axiomCount": 1,
-    "theoremCount": 14,
-    "definitionCount": 14,
+    "theoremCount": 20,
+    "definitionCount": 15,
     "path": "Proofs/Erdos744Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

`erdos-744-incomplete-01` — the served definition-sorry is phantom-complete and the tautological `rodl_tuza_theorem` axiom is left untouched (converting it would overclaim `verified` on a definitional placeholder — see prior integrity finding in knowledge base). This PR adds a genuine, load-bearing structural layer on the intrinsic `bipartitionNumber` engine (min number of edges to delete to make `G` bipartite = min monochromatic edges over 2-colorings).

**New declarations (0 sorry, axiom-free — no dependence on `rodl_tuza_theorem`):**
- `bichromaticEdges G c` — dual of `monochromaticEdges`: edges whose endpoints get different colors (the cut edges).
- `monochromaticEdges_add_bichromaticEdges` — per-coloring edge conservation: `mono + bi = edgeCount`.
- `maxCut G` — the max bichromatic-edge count over all colorings.
- **`bipartitionNumber_add_maxCut`** — `bipartitionNumber G + maxCut G = edgeCount G`: the min-uncut and max-cut are complementary and realized by the *same* optimal coloring.
- `maxCut_eq_edgeCount_iff` — the cut saturates every edge iff `G` is bipartite.

This is the standard max-cut ↔ min-uncut duality, the natural companion to the file's `bipartitionNumber` definition. It is orthogonal structural graph theory, **not** a step toward the (disproved) Erdős #744 conjecture, whose status is unchanged.

## Verification

Docker infra down this session (containerd meta.db + content-store blob `input/output error` at image build — operator-level, not disk: 157Gi free). Verified by direct `lean` elaboration against the repo's pinned **Mathlib v4.26.0** oleans: **exit 0** (only two pre-existing `unused variable` warnings in the untouched `f_*` theorems). `#print axioms` on all three new theorems = `[propext, Classical.choice, Quot.sound]` only (no `rodl_tuza_theorem`, no `sorryAx`, no `Lean.ofReduceBool`).

Gallery meta `erdos-744` counts synced (578 lines, 20 thm, 15 def, 1 axiom unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)