### PR TITLE
Research: algebraic-numbers-countable-oq-07 - complex Hausdorff-measure-zero corollary

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -246,6 +246,16 @@ theorem algebraic_complex_dimH_zero :
     dimH {z : ℂ | IsAlgebraic ℚ z} = 0 :=
   (AlgebraicNumbersCountable.algebraic_complex_countable).dimH_zero
 
+/-- **Every positive-order Hausdorff measure of the complex algebraic numbers vanishes.**
+The complex analogue of `algebraic_reals_hausdorffMeasure_zero`: for each `d > 0`,
+`μH[d] {z | IsAlgebraic ℚ z} = 0`.  Hausdorff dimension zero (`algebraic_complex_dimH_zero`)
+kills the entire positive-order gauge scale on `ℂ` at once, sharpening the plane-Lebesgue-null
+fact `algebraic_complex_null` (the order-`d = 2` slice). -/
+theorem algebraic_complex_hausdorffMeasure_zero {d : NNReal} (hd : 0 < d) :
+    μH[(d : ℝ)] {z : ℂ | IsAlgebraic ℚ z} = 0 :=
+  hausdorffMeasure_of_dimH_lt (by
+    rw [algebraic_complex_dimH_zero]; exact_mod_cast hd)
+
 /-- **The transcendental reals are dense**, obtained from the dimensional bound:
 `dimH {algebraic} = 0 < 1 = finrank ℝ ℝ`, so the complement of the algebraic reals
 is dense (`dense_compl_of_dimH_lt_finrank`).  A dimension-theoretic route to the

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -177,8 +177,8 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicRealsNull.lean",
-    "lineCount": 322,
-    "theoremCount": 16,
+    "lineCount": 332,
+    "theoremCount": 17,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0

--- a/src/data/research/problems/algebraic-numbers-countable-oq-07.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-07.json
@@ -37,14 +37,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED + SHARPENED: the algebraic reals are Lebesgue-null (existing) and now shown to have Hausdorff DIMENSION zero — strictly stronger, killing every positive-order Hausdorff gauge μH[d] (Lebesgue-null = d=1 slice). Dimensional corollary yields density of the transcendentals in ℝ and ℂ (dimH 0 < finrank), a route independent of Baire category. 16 theorems, 0 axioms, 0 sorries (elaboration-clean; olean-write blocked by fleet SIGBUS-135).",
+    "progressSummary": "COMPLETED + SHARPENED: the algebraic reals are Lebesgue-null (existing) and now shown to have Hausdorff DIMENSION zero — strictly stronger, killing every positive-order Hausdorff gauge μH[d] (Lebesgue-null = d=1 slice). Dimensional corollary yields density of the transcendentals in ℝ and ℂ (dimH 0 < finrank), a route independent of Baire category. 16 theorems, 0 axioms, 0 sorries (elaboration-clean; olean-write blocked by fleet SIGBUS-135). | Session (researcher-1): added algebraic_complex_hausdorffMeasure_zero — the complex Hausdorff-measure-zero corollary the ℝ branch already had (algebraic_reals_hausdorffMeasure_zero) but ℂ lacked despite having algebraic_complex_dimH_zero. 1 thm, 0 axiom, 0 sorry. UNVERIFIED (Docker infra down).",
     "builtItems": [
       "algebraic_reals_null: volume {x : ℝ | IsAlgebraic ℚ x} = 0 in Proofs/AlgebraicRealsNull.lean",
       "ae_transcendental: almost every real is transcendental (∀ᵐ x ∂volume, Transcendental ℚ x)",
       "transcendental_full_on_interval: transcendentals carry the full measure ofReal (b − a) of any interval",
       "exists_transcendental_of_pos_measure: any positive-measure set contains a transcendental",
       "NoAtoms (volume : Measure ℂ) + algebraic_complex_null: complex algebraic numbers are null",
-      "AlgebraicRealsNull.lean §6 (researcher-2): algebraic_reals_dimH_zero (dimH{alg reals}=0 via Set.Countable.dimH_zero), algebraic_reals_hausdorffMeasure_zero (μH[d]{alg}=0 for d>0 via hausdorffMeasure_of_dimH_lt), algebraic_complex_dimH_zero, transcendental_reals_dense + transcendental_complex_dense (dense_compl_of_dimH_lt_finrank + Module.finrank_pos). File now 16 theorems, 0 axioms, 0 sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135."
+      "AlgebraicRealsNull.lean §6 (researcher-2): algebraic_reals_dimH_zero (dimH{alg reals}=0 via Set.Countable.dimH_zero), algebraic_reals_hausdorffMeasure_zero (μH[d]{alg}=0 for d>0 via hausdorffMeasure_of_dimH_lt), algebraic_complex_dimH_zero, transcendental_reals_dense + transcendental_complex_dense (dense_compl_of_dimH_lt_finrank + Module.finrank_pos). File now 16 theorems, 0 axioms, 0 sorries. Elaboration-clean; olean-write blocked by fleet SIGBUS-135.",
+      "algebraic_complex_hausdorffMeasure_zero {d>0}: μH[d]{z|IsAlgebraic ℚ z}=0 — the complex analogue of algebraic_reals_hausdorffMeasure_zero, completing the dimH-zero corollary parity between the ℝ and ℂ branches. AlgebraicRealsNull.lean."
     ],
     "insights": [
       "Countable ⟹ null requires the measure to be atomless; Lebesgue measure qualifies via Real.noAtoms_volume, so Set.Countable.measure_zero applies to the parent's countability theorem in one line.",


### PR DESCRIPTION
## Summary
Research session for `algebraic-numbers-countable-oq-07`. Restores ℝ/ℂ parity in the
Hausdorff-dimension corollaries of `AlgebraicRealsNull.lean`.

## Progress
- **`algebraic_complex_hausdorffMeasure_zero`** (`{d : NNReal} (hd : 0 < d)`):
  `μH[(d:ℝ)] {z : ℂ | IsAlgebraic ℚ z} = 0`. The ℝ branch already had
  `algebraic_reals_hausdorffMeasure_zero`, and the ℂ branch had `algebraic_complex_dimH_zero`,
  but the complex Hausdorff-measure-zero corollary was missing. Added as a verbatim ℝ→ℂ copy of
  the real version (`hausdorffMeasure_of_dimH_lt` + `rw algebraic_complex_dimH_zero` +
  `exact_mod_cast hd`). Dimension zero kills the whole positive-order gauge scale on ℂ,
  sharpening plane-Lebesgue-null (`algebraic_complex_null`, the `d = 2` slice).

1 theorem, 0 sorries, 0 axioms. Synced gallery `meta.json` leanFile counts (322→332 L, 16→17 thm).

## Status
**Outcome**: progress (UNVERIFIED — Docker build host containerd down: `meta.db input/output
error` at image build, before any Lean elaboration; operator-level outage, not a proof error)
**Next Steps**: rebuild once Docker is healthy to confirm `=== Build succeeded ===`.

🤖 Generated by researcher-1