### PR TITLE
research(erdos-1110-oq-01): universal property of the power-form submonoid

### DIFF
--- a/proofs/Proofs/Erdos1110OQ01.lean
+++ b/proofs/Proofs/Erdos1110OQ01.lean
@@ -129,4 +129,31 @@ theorem isPowerForm_iff_mem_closure (p q n : ℕ) :
   rw [← powerFormSubmonoid_eq_closure]
   exact mem_powerFormSubmonoid.symm
 
+/-- **The first base lies in the power-form submonoid.** `p = p^1 q^0`, one of the two
+generators identified by `powerFormSubmonoid_eq_closure`. -/
+theorem self_mem_powerFormSubmonoid_left (p q : ℕ) :
+    p ∈ powerFormSubmonoid p q := ⟨1, 0, by simp⟩
+
+/-- **The second base lies in the power-form submonoid.** `q = p^0 q^1`, the other
+generator. -/
+theorem self_mem_powerFormSubmonoid_right (p q : ℕ) :
+    q ∈ powerFormSubmonoid p q := ⟨0, 1, by simp⟩
+
+/-- **Universal property of the power-form submonoid.** `powerFormSubmonoid p q` is the
+*smallest* submonoid of `(ℕ, ×)` containing both bases: it is `≤ S` exactly when `S`
+already contains `p` and `q`. Mirrors `Submonoid.closure_le` through the identification
+`powerFormSubmonoid_eq_closure`, and reduces any "every power form lies in `S`" goal to the
+two base facts `p ∈ S`, `q ∈ S`. -/
+theorem powerFormSubmonoid_le_iff {p q : ℕ} {S : Submonoid ℕ} :
+    powerFormSubmonoid p q ≤ S ↔ p ∈ S ∧ q ∈ S := by
+  rw [powerFormSubmonoid_eq_closure, Submonoid.closure_le]
+  constructor
+  · intro h
+    exact ⟨h (by simp), h (by simp)⟩
+  · rintro ⟨hp, hq⟩ x hx
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+    rcases hx with rfl | rfl
+    · exact hp
+    · exact hq
+
 end Erdos1110

--- a/research/problems/erdos-1110-oq-01/knowledge.md
+++ b/research/problems/erdos-1110-oq-01/knowledge.md
@@ -65,3 +65,27 @@ with Mathlib's `Submonoid.closure`. Closed that gap (the natural capstone):
 
 ### Still open (parent, untouched)
 Deep `erdos_lewin_infinite` axiom for coprime `{p,q} ≠ {2,3}`. Not session-sized.
+
+## Session 2026-07-09 (researcher-3) — universal property of the power-form submonoid [UNVERIFIED, docker down]
+
+**Mode**: extend the submonoid identification (researcher-6 proved
+`powerFormSubmonoid = Submonoid.closure {p,q}`). Added the two named **generator
+memberships** and the **universal property**, 3 theorems (0 sorry / 0 axiom):
+- `self_mem_powerFormSubmonoid_left`  — `p ∈ powerFormSubmonoid p q` (`⟨1,0,by simp⟩`).
+- `self_mem_powerFormSubmonoid_right` — `q ∈ powerFormSubmonoid p q` (`⟨0,1,by simp⟩`).
+- `powerFormSubmonoid_le_iff` — `powerFormSubmonoid p q ≤ S ↔ p ∈ S ∧ q ∈ S` for any
+  `S : Submonoid ℕ`: the power forms are the *smallest* submonoid containing both bases.
+  Proof mirrors the file's own `powerFormSubmonoid_eq_closure` exactly (`rw
+  [powerFormSubmonoid_eq_closure, Submonoid.closure_le]` then `Set.mem_insert_iff` /
+  `Set.mem_singleton_iff` + `rcases hx with rfl | rfl`). Reduces any "every power form ∈ S"
+  goal to the two base facts.
+
+**Build**: UNVERIFIED — Docker infra down (containerd `meta.db input/output error`,
+`docker images` fails; known #35184, operator-level; disk healthy 155Gi). High confidence:
+the two membership terms are the exact `⟨_,_,by simp⟩` literals already used inside
+`powerFormSubmonoid_eq_closure` (lines 121-122), and `_le_iff` reuses that theorem's own
+`closure_le` + insert/singleton simp pattern verbatim. Also resynced the STALE OQ01 leanFile
+counts in the research json (77/6/0 → 159/11/1; was never resynced after the submonoid work).
+
+**Still open (parent, untouched)**: deep `erdos_lewin_infinite` axiom (coprime {p,q}≠{2,3}
+density / infinitely-many-coprime-non-representables). Not session-sized.


### PR DESCRIPTION
## Summary

Erdős #1110 OQ-01 studies the multiplicative structure of **power forms** `p^k q^l`. The companion `Erdos1110OQ01.lean` already identifies the power forms with `Submonoid.closure {p, q}` (`powerFormSubmonoid_eq_closure`). This PR adds the natural **universal property** and the two named generator memberships:

- `self_mem_powerFormSubmonoid_left` — `p ∈ powerFormSubmonoid p q` (`p = p^1 q^0`).
- `self_mem_powerFormSubmonoid_right` — `q ∈ powerFormSubmonoid p q` (`q = p^0 q^1`).
- `powerFormSubmonoid_le_iff` — `powerFormSubmonoid p q ≤ S ↔ p ∈ S ∧ q ∈ S` for any `S : Submonoid ℕ`: the power forms are the **smallest** submonoid of `(ℕ, ×)` containing both bases. Reduces any "every power form lies in `S`" goal to the two base facts.

3 theorems, 0 sorry / 0 axiom, no `native_decide`. Also resyncs the stale OQ01 `leanFile` counts in the research json (`77/6/0 → 159/11/1`; never resynced after the earlier submonoid additions).

## Verification

**UNVERIFIED by build — Docker infra down.** The containerd metadata store is corrupted (`docker images` errors with `meta.db: input/output error` at image build; known #35184, operator-level). Host disk healthy (155Gi free). No build signal obtainable this session.

Confidence is high: the two membership terms are the exact `⟨_, _, by simp⟩` literals already used inside the verified `powerFormSubmonoid_eq_closure` (lines 121-122), and `powerFormSubmonoid_le_iff` reuses that theorem's own `Submonoid.closure_le` + `Set.mem_insert_iff`/`Set.mem_singleton_iff` + `rcases … with rfl | rfl` pattern verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
