### PR TITLE
research(erdos-18-oq-01): power-closure practical_pow + structural 36 practical

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -441,4 +441,23 @@ theorem practical_mul {m n : ℕ} (hpm : IsPractical m) (hpn : IsPractical n) :
   rw [hAsum, hSrsum, hdecomp] at hunion
   exact hunion
 
+/-- **Powers of a practical number are practical.** If `m` is practical then so is
+`m ^ k` for every `k`.  Induction on `k`: `m ^ 0 = 1` is practical (`one_practical`),
+and `m ^ (k+1) = m ^ k · m` is practical by `practical_mul` applied to the induction
+hypothesis and `hpm`.  This is the pure-power closure companion to the product law
+`practical_mul`; it subsumes `two_pow_practical` at `m = 2` and, more generally,
+turns any single verified practical number into an infinite family. -/
+theorem practical_pow {m : ℕ} (hpm : IsPractical m) (k : ℕ) : IsPractical (m ^ k) := by
+  induction k with
+  | zero => simpa using one_practical
+  | succ k ih => rw [pow_succ]; exact practical_mul ih hpm
+
+/-- **36 is practical**, obtained *structurally* as `6 ^ 2` via `practical_pow` from
+`six_practical` — no `decide`.  This extends the finite-check-verified `4, 6, 8`
+further along OEIS A005153 (`…, 30, 32, 36, …`) using the closure algebra rather
+than a per-number computation, illustrating `practical_pow`. -/
+theorem thirtysix_practical : IsPractical 36 := by
+  have h : (36 : ℕ) = 6 ^ 2 := by norm_num
+  rw [h]; exact practical_pow six_practical 2
+
 end Erdos18OQ01

--- a/src/data/research/problems/erdos-18-oq-01.json
+++ b/src/data/research/problems/erdos-18-oq-01.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (elementary groundwork). Child of erdos-18 (practical numbers, OPEN $250). The parent defines IsRepresentable/IsPractical/h and verifies 1, 2 practical; the open questions concern h(m) asymptotics (out of elementary reach). This entry adds the representability algebra (0, every divisor, 1, and m itself are representable) and a decidable bridge practical_of_check that turns IsPractical m into a finite check over (divisors m).powerset, yielding verified practical numbers 4, 6, 8 (extending 1, 2 along OEIS A005153). Erdos18OQ01.lean, 7 theorems, 0 axioms, 0 sorries, no native_decide (the `decide` for 4/6/8 is KERNEL-based, axioms = propext/Classical.choice/Quot.sound only, NO ofReduceBool).",
+    "progressSummary": "COMPLETE (elementary groundwork). Child of erdos-18 (practical numbers, OPEN $250). The parent defines IsRepresentable/IsPractical/h and verifies 1, 2 practical; the open questions concern h(m) asymptotics (out of elementary reach). This entry adds the representability algebra (0, every divisor, 1, and m itself are representable) and a decidable bridge practical_of_check that turns IsPractical m into a finite check over (divisors m).powerset, yielding verified practical numbers 4, 6, 8 (extending 1, 2 along OEIS A005153). Erdos18OQ01.lean, 7 theorems, 0 axioms, 0 sorries, no native_decide (the `decide` for 4/6/8 is KERNEL-based, axioms = propext/Classical.choice/Quot.sound only, NO ofReduceBool). UPDATE (researcher-9, 2026-07-09, UNVERIFIED — docker infra down, containerd meta.db I/O error): the file has since grown to 29 theorems incl. the full closure algebra (practical_mul product law, two_pow_practical, practical_two_mul, representable_scale). Added the pure-power closure companion practical_pow (IsPractical m → IsPractical (m^k), induction on k from one_practical + practical_mul) and, as a structural illustration, thirtysix_practical (IsPractical 36 = 6^2 via practical_pow six_practical 2, extending A005153 beyond the decide-verified 4/6/8 WITHOUT decide). Trivial high-confidence term/induction assembly; ships UNVERIFIED (build infra down this session).",
     "builtItems": [
       "Erdos18OQ01.lean: 7 theorems, 0 axioms, 0 sorries. Imports Proofs.Erdos18Problem for the definitions.",
       "zero_representable (∅), mem_divisors_representable (singleton {d}), one_representable (1∣m), self_representable ({m}).",
@@ -211,8 +211,8 @@
     {
       "path": "Proofs/Erdos18OQ01.lean",
       "filename": "Erdos18OQ01.lean",
-      "lineCount": 445,
-      "theoremCount": 27,
+      "lineCount": 463,
+      "theoremCount": 29,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends the elementary practical-numbers groundwork for Erdős #18 (OPEN, \$250). The file `Erdos18OQ01.lean` already proves the product-closure law `practical_mul` (`IsPractical m → IsPractical n → IsPractical (m·n)`) but lacked the pure-power closure. This PR adds it plus a structural application.

## New theorems (`namespace Erdos18OQ01`)

- **`practical_pow`** — `IsPractical m → IsPractical (m ^ k)` for every `k`. Induction on `k`: `m^0 = 1` is practical (`one_practical`), and `m^(k+1) = m^k · m` is practical by `practical_mul` from the induction hypothesis. Subsumes `two_pow_practical` at `m = 2`, and turns any single verified practical number into an infinite family.
- **`thirtysix_practical`** — `IsPractical 36`, obtained *structurally* as `6 ^ 2` via `practical_pow six_practical 2` (no `decide`). Extends the finite-check-verified `4, 6, 8` further along OEIS A005153 using the closure algebra rather than a per-number computation.

The parent's open questions (asymptotics of `h(m)`) are untouched — this is elementary closure algebra only.

## Verification status

**UNVERIFIED.** Docker build infra was down this entire session (containerd `meta.db` input/output error — operator-level, zero builds possible). Both additions are **0 axioms, 0 sorries, no `native_decide`**, and are trivial induction/term-mode assembly of already-present verified lemmas (`one_practical`, `practical_mul`, `six_practical`) — a clean build should confirm.

Also syncs stale research-JSON `leanFiles` for `Erdos18OQ01.lean` (27→29 theorems, 445→463 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)