### PR TITLE
research(erdos-101-oq-04): four-point-line quadruple condition is a fixed ternary conic Q=5

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03.lean
+++ b/proofs/Proofs/Erdos1014OQ03.lean
@@ -92,6 +92,57 @@ theorem increment_div_tendsto_zero_of_ratio_tendsto_one (R : ℕ → ℝ)
     Tendsto (fun l => (R (l + 1) - R l) / R l) atTop (𝓝 0) :=
   (increment_div_tendsto_zero_iff_ratio_tendsto_one R hpos).mpr hratio
 
+/-- **General-limit increment–ratio bridge.** For an eventually-nonzero sequence
+`R` and any real `c`, the normalized increment `(R(l+1) − R(l))/R(l)` tends to `c`
+**iff** the consecutive ratio `R(l+1)/R(l)` tends to `c + 1`.
+
+The special case `c = 0` is `increment_div_tendsto_zero_iff_ratio_tendsto_one`. For
+a geometrically-growing sequence whose ratio tends to a limit `L` (e.g. the
+*diagonal* Ramsey number `R(k,k)`, whose growth ratio `R(k+1,k+1)/R(k,k)` tends to
+`4`), this reads off the normalized-increment limit `L − 1` directly, exhibiting the
+`o(R)` conclusion for #1014's off-diagonal `R(k,l)` (where `L = 1`) as the borderline
+case of a general statement. -/
+theorem increment_div_tendsto_iff_ratio_tendsto (R : ℕ → ℝ) (c : ℝ)
+    (hpos : ∀ᶠ l in atTop, R l ≠ 0) :
+    Tendsto (fun l => (R (l + 1) - R l) / R l) atTop (𝓝 c) ↔
+      Tendsto (fun l => R (l + 1) / R l) atTop (𝓝 (c + 1)) := by
+  have heq : (fun l => (R (l + 1) - R l) / R l)
+      =ᶠ[atTop] (fun l => R (l + 1) / R l - 1) := by
+    filter_upwards [hpos] with l hl using increment_div_eq_ratio_sub_one R l hl
+  rw [tendsto_congr' heq]
+  constructor
+  · intro h
+    have h1 := h.add_const 1
+    simpa using h1
+  · intro h
+    have h1 := h.sub_const 1
+    simpa using h1
+
+/-- **Increment-asymptotic reformulation.** Fix a comparison sequence `g`, with both
+`R` and `g` eventually nonzero. Then the increment `R(l+1) − R(l)` is asymptotically
+equivalent to `g` (normalized quotient `→ 1`) **iff** the *ratio-minus-one*
+`R(l+1)/R(l) − 1` is asymptotically equivalent to `g/R`:
+
+`(R(l+1) − R(l)) / g(l) → 1  ↔  (R(l+1)/R(l) − 1) / (g(l)/R(l)) → 1`.
+
+This is the rigorous, hypothesis-honest form of the naive power-law expansion warned
+against in the module docstring: an increment asymptotic `Δ_l(k) ~ g_k(l)` is
+*exactly* a statement about the consecutive ratio, namely
+`R(k,l+1)/R(k,l) − 1 ~ g_k(l)/R(k,l)`. The two normalized quantities are in fact
+eventually equal, so neither direction of the equivalence adds a hypothesis beyond
+eventual nonvanishing — a faithful reformulation, not a derivation that smuggles in
+regularity. -/
+theorem increment_asymptotic_iff_ratioSubOne_asymptotic (R g : ℕ → ℝ)
+    (hR : ∀ᶠ l in atTop, R l ≠ 0) (hg : ∀ᶠ l in atTop, g l ≠ 0) :
+    Tendsto (fun l => (R (l + 1) - R l) / g l) atTop (𝓝 1) ↔
+      Tendsto (fun l => (R (l + 1) / R l - 1) / (g l / R l)) atTop (𝓝 1) := by
+  have heq : (fun l => (R (l + 1) / R l - 1) / (g l / R l))
+      =ᶠ[atTop] (fun l => (R (l + 1) - R l) / g l) := by
+    filter_upwards [hR, hg] with l hR' hg'
+    field_simp
+    ring
+  rw [tendsto_congr' heq]
+
 /-- **Logarithmic increment–ratio bridge.** For an eventually-positive sequence
 `R`, the *additive* increment of `log R` tends to `0` **iff** the consecutive ratio
 tends to `1`:

--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -2920,6 +2920,29 @@ theorem four_onQuartic_collinear_iff_sq {a b c d : ℝ × ℝ}
     exact ⟨h1, by
       linear_combination (1 / 2 : ℝ) * (a.1 + b.1 + c.1 + d.1) * h1 - (1 / 2 : ℝ) * h2⟩
 
+/-- **The four-point-line quadruple condition is a fixed ternary conic.**
+Eliminating the fourth abscissa via `Σx = 0` (so `x₃ = −(x₀+x₁+x₂)`), the engine's
+sum-of-squares condition `Σx² = 10` is *equivalent* to the ternary quadratic relation
+`x₀² + x₁² + x₂² + x₀x₁ + x₁x₂ + x₂x₀ = 5` in the three free abscissae — because
+`Σx² = 2·(x₀²+x₁²+x₂²+x₀x₁+x₁x₂+x₂x₀)` once `x₃` is substituted.
+
+This is the *same* quadratic form (and the same constant `5`) that governs the
+three-point collinearity criterion `collinear_onQuartic_iff`.  Its consequence is
+structural: a four-point line on `y = x⁴ − 5x²` is exactly a point
+`(x₀, x₁, x₂)` on the fixed ellipsoid `Q = 5` with `x₃` determined by `Σx = 0`, so the
+open super-linear-growth question (`quartic_fourPointLineCount_from_quadruples`)
+becomes the purely arithmetic problem of exhibiting super-linearly many *distinct*
+solution-sets on a single fixed ternary conic `Q = 5` — no `x⁴` term survives. -/
+theorem quartic_quadruple_sum_zero_sq_iff_ternary (x₀ x₁ x₂ x₃ : ℝ)
+    (hsum : x₀ + x₁ + x₂ + x₃ = 0) :
+    x₀ ^ 2 + x₁ ^ 2 + x₂ ^ 2 + x₃ ^ 2 = 10 ↔
+      x₀ ^ 2 + x₁ ^ 2 + x₂ ^ 2 + x₀ * x₁ + x₁ * x₂ + x₂ * x₀ = 5 := by
+  have hx3 : x₃ = -(x₀ + x₁ + x₂) := by linarith
+  subst hx3
+  constructor
+  · intro h; linear_combination (1 / 2 : ℝ) * h
+  · intro h; linear_combination 2 * h
+
 /-- **General four-point-line count from arithmetic quadruples.**
 Let `x : Fin k → Fin 4 → ℝ` list `k` quadruples of abscissae with
 * four distinct entries per quadruple (`hx_inj`),

--- a/proofs/Proofs/Erdos3LogHarmonic.lean
+++ b/proofs/Proofs/Erdos3LogHarmonic.lean
@@ -332,6 +332,64 @@ theorem summable_one_div_nat_mul_log_mul_const {c δ : ℝ} (hc : 0 < c) (hδ : 
           mul_le_mul_of_nonneg_left hPQ hm_pos.le
       _ = (2 : ℝ) ^ (1 + δ) * (m * (Real.log (m * c)) ^ (1 + δ)) := by ring
 
+/-- **Divergent Bertrand series with a multiplicative constant inside the log.**
+    For every `c > 0`, `∑ 1/(n·log (n·c))` diverges.  This is the exact `p = 1`
+    divergence twin of the convergent `summable_one_div_nat_mul_log_mul_const`
+    (`p = 1+δ`): together they pin the constant-in-log Bertrand boundary at the
+    exponent `p = 1`, exactly as `not_summable_one_div_nat_mul_log` and
+    `summable_one_div_nat_mul_log_rpow` do for the constant-free series (`c = 1`).
+    The multiplicative constant inside the log does not move the threshold.
+    Proof: a tail comparison the mirror of the convergent lemma's.  On the tail
+    `n ≥ max (c) (2/c)` one has `c ≤ n` (so `log c ≤ log n`, giving `log (n·c) ≤ 2·log n`)
+    and `n·c ≥ 2` (so `log (n·c) > 0`); hence each term dominates `½·1/(n·log n)`,
+    and `∑ 1/(n·log n)` already diverges (`not_summable_one_div_nat_mul_log`). -/
+theorem not_summable_one_div_nat_mul_log_mul_const {c : ℝ} (hc : 0 < c) :
+    ¬ Summable (fun n : ℕ => 1 / ((n : ℝ) * Real.log ((n : ℝ) * c))) := by
+  intro hsum
+  -- threshold `N₀ ≥ 2`, `≥ c`, `≥ 2/c` (so `m ≥ 2`, `c ≤ m`, `m·c ≥ 2` on the tail)
+  set N₀ : ℕ := max 2 (⌈c⌉₊ + ⌈2 / c⌉₊) with hN₀def
+  have hN₀2 : (2 : ℝ) ≤ (N₀ : ℝ) := by exact_mod_cast le_max_left 2 (⌈c⌉₊ + ⌈2 / c⌉₊)
+  have hN₀c : c ≤ (N₀ : ℝ) :=
+    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_right _ _)
+      (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
+  have hN₀2c : 2 / c ≤ (N₀ : ℝ) :=
+    le_trans (Nat.le_ceil _) (by exact_mod_cast le_trans (Nat.le_add_left _ _)
+      (le_max_right 2 (⌈c⌉₊ + ⌈2 / c⌉₊)))
+  -- the given series, shifted past the threshold and scaled by `2`, dominates `1/(n·log n)`
+  have hdom : Summable (fun n : ℕ => (2 : ℝ) *
+      (1 / (((n + N₀ : ℕ) : ℝ) * Real.log (((n + N₀ : ℕ) : ℝ) * c)))) :=
+    ((summable_nat_add_iff N₀).mpr hsum).mul_left _
+  -- derive `Summable (1/(n·log n))`, contradicting its divergence
+  apply not_summable_one_div_nat_mul_log
+  apply (summable_nat_add_iff N₀).mp
+  refine Summable.of_nonneg_of_le (fun n => ?_) (fun n => ?_) hdom
+  · -- nonnegativity of the shifted `1/(m·log m)`
+    set m : ℝ := ((n + N₀ : ℕ) : ℝ) with hm
+    have hmN : (N₀ : ℝ) ≤ m := by rw [hm]; exact_mod_cast Nat.le_add_left N₀ n
+    have hm2 : (2 : ℝ) ≤ m := le_trans hN₀2 hmN
+    have hm_pos : 0 < m := by linarith
+    have hlogm : 0 ≤ Real.log m := Real.log_nonneg (by linarith)
+    positivity
+  · -- termwise domination `1/(m·log m) ≤ 2·(1/(m·log (m·c)))`
+    set m : ℝ := ((n + N₀ : ℕ) : ℝ) with hm
+    have hmN : (N₀ : ℝ) ≤ m := by rw [hm]; exact_mod_cast Nat.le_add_left N₀ n
+    have hm2 : (2 : ℝ) ≤ m := le_trans hN₀2 hmN
+    have hm_pos : 0 < m := by linarith
+    have hmc_ge : c ≤ m := le_trans hN₀c hmN
+    have hmc2 : (2 : ℝ) ≤ m * c := (div_le_iff₀ hc).mp (le_trans hN₀2c hmN)
+    have hlogm_pos : 0 < Real.log m := Real.log_pos (by linarith)
+    have hlogmc_pos : 0 < Real.log (m * c) := Real.log_pos (by linarith)
+    have hlogc_le : Real.log c ≤ Real.log m := Real.log_le_log hc hmc_ge
+    have hmc_eq : Real.log (m * c) = Real.log m + Real.log c :=
+      Real.log_mul (ne_of_gt hm_pos) (ne_of_gt hc)
+    -- key comparison `log (m·c) ≤ 2·log m` (`log c ≤ log m` since `c ≤ m`)
+    have hcrux : Real.log (m * c) ≤ 2 * Real.log m := by rw [hmc_eq]; linarith
+    rw [mul_one_div, div_le_div_iff₀ (mul_pos hm_pos hlogm_pos) (mul_pos hm_pos hlogmc_pos),
+      one_mul]
+    calc m * Real.log (m * c)
+        ≤ m * (2 * Real.log m) := mul_le_mul_of_nonneg_left hcrux hm_pos.le
+      _ = 2 * (m * Real.log m) := by ring
+
 /-!
 ### Second-tier (iterated-log) Bertrand divergence: `∑ 1/(n · log n · log log n)`
 

--- a/research/problems/erdos-101-oq-04/state.md
+++ b/research/problems/erdos-101-oq-04/state.md
@@ -2,7 +2,24 @@
 
 **Phase**: ACT
 **Since**: 2026-07-08T00:00:00Z
-**Iteration**: 2
+**Iteration**: 3
+
+## Progress This Iteration (iter 3, 2026-07-09) — UNVERIFIED (docker infra down)
+
+Added `quartic_quadruple_sum_zero_sq_iff_ternary` to `Proofs/Erdos101OQ04.lean`:
+eliminating `x₃ = −(x₀+x₁+x₂)` via `Σx = 0`, the engine's sum-of-squares condition
+`Σx² = 10` is *equivalent* to the fixed **ternary conic**
+`x₀²+x₁²+x₂²+x₀x₁+x₁x₂+x₂x₀ = 5` — the same quadratic form and constant `5` that
+governs the three-point criterion `collinear_onQuartic_iff`. This recasts the OPEN
+super-linear-growth question (`quartic_fourPointLineCount_from_quadruples`) as the
+purely arithmetic problem of finding super-linearly many distinct solution-sets on
+one fixed ternary conic — no `x⁴` term survives. Pure algebra (`linarith`/`subst`/
+`linear_combination`), 0-sorry, 0-axiom, no new API. Docker build infra down all
+session (containerd meta.db I/O error), so shipped UNVERIFIED with hand-audit; the
+`(1/2)·h` and `2·h` linear_combination coefficients are the exact factor of 2
+between `Σx²` and the ternary form. The two OPEN construction sorries
+(`grunbaum_lower_bound_three_halves`, `solymosi_stojakovic_lower_bound`) are the
+genuine hard frontier and remain untouched.
 
 ## Current Focus
 

--- a/research/problems/erdos-1014-oq-03/state.md
+++ b/research/problems/erdos-1014-oq-03/state.md
@@ -3,22 +3,23 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T15:40:17-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Delivered the increment-ratio bridge (VERIFIED). Found Approach A invalid from ~ alone.
+Extended the increment-ratio bridge with two honest additions (PR #36922, UNVERIFIED docker-down):
+- increment_div_tendsto_iff_ratio_tendsto: general-limit c version (c=0 subsumes the o(R) bridge).
+- increment_asymptotic_iff_ratioSubOne_asymptotic: Delta_l ~ g  iff  (ratio-1) ~ g/R
+  (the rigorous ratio-form of the invalid-from-~-alone power-law expansion).
 
 ## Active Approach
-Increment-ratio bridge (DONE). Full asymptotic needs a ratio/regular-variation hypothesis.
-
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+Elementary bridge family is complete. The full asymptotic Delta_l(k) ~ g_k(l) needs a
+regular-variation / ratio-asymptotic hypothesis + the R(3,l) constant matching (both OPEN).
 
 ## Blockers
-None.
+Docker build infra down all session (containerd meta.db I/O error; docker images fails).
+Contributions shipped UNVERIFIED with hand-audit.
 
 ## Next Action
-The elementary bridge is complete and verified. The remaining open asymptotic Delta_l(k) ~ g_k(l) is not session-sized (needs a regular-variation hypothesis + the R(3,l) constant matching, both open).
+Not session-sized: remaining open asymptotic needs a regular-variation hypothesis, not
+another elementary bridge lemma. Future work could formalize a Karamata/regular-variation
+sufficient condition (ratio -> ((l+1)/l)^{k-1}) that forces the increment asymptotic.

--- a/research/problems/erdos-3-incomplete-01/state.md
+++ b/research/problems/erdos-3-incomplete-01/state.md
@@ -2,10 +2,29 @@
 
 **Phase**: COMPLETE-EXCEPT-OPEN-CRUX (mature)
 **Since**: 2026-07-04
-**Attempts**: 5
-**Status**: mature — no incremental work remains that is not the open crux
+**Attempts**: 6
+**Status**: mature — the sole remaining sorry is the open crux; the analytic
+Bertrand-boundary toolkit around it is now complete on both threshold axes.
 
-## Current Focus
+## Result this iteration (attempt 6, 2026-07-09) — UNVERIFIED (docker infra down)
+
+Added `not_summable_one_div_nat_mul_log_mul_const` to `Erdos3LogHarmonic.lean`:
+for every `c > 0`, `∑ 1/(n·log(n·c))` **diverges**. This is the exact `p = 1`
+divergence twin of the already-verified convergent
+`summable_one_div_nat_mul_log_mul_const` (`p = 1+δ`) — together they pin the
+constant-in-log Bertrand boundary at the exponent `p = 1`, exactly as
+`not_summable_one_div_nat_mul_log` / `summable_one_div_nat_mul_log_rpow` do for
+the constant-free (`c = 1`) series. Proof is a tail comparison (mirror of the
+convergent lemma's): on `n ≥ max c (2/c)` one has `c ≤ n` ⟹ `log(n·c) ≤ 2·log n`
+and `n·c ≥ 2` ⟹ `log(n·c) > 0`, so each term dominates `½·1/(n·log n)`, whose
+divergence is the verified `not_summable_one_div_nat_mul_log`. 0-sorry, 0-axiom,
+no new API — mirrors two verified siblings in the same file. Docker build infra
+down all session (containerd meta.db I/O error; `docker images` fails), so
+shipped UNVERIFIED with full hand-audit of every tactic step against the sibling
+proofs it mirrors. The main-file open crux `required_bound_implies_conjecture`
+is untouched.
+
+## Current Focus (prior attempts)
 
 None. Attempt 5 (2026-07-07) was a notes-only reconciliation: a full re-read
 confirmed `Proofs/Erdos3Problem.lean` (773 lines) is **0-axiom, 1-sorry** and


### PR DESCRIPTION
## Summary

Adds `quartic_quadruple_sum_zero_sq_iff_ternary` to `Proofs/Erdos101OQ04.lean`.

The capstone engine `quartic_fourPointLineCount_from_quadruples` reduces the OPEN growth
question to exhibiting many injective *arithmetic quadruples* `(Σx = 0, Σx² = 10)`. This
lemma pins down exactly what that condition **is**: eliminating the fourth abscissa via
`x₃ = −(x₀+x₁+x₂)`, the sum-of-squares condition `Σx² = 10` is equivalent to the fixed
**ternary quadratic form**

```
x₀² + x₁² + x₂² + x₀x₁ + x₁x₂ + x₂x₀ = 5
```

because `Σx² = 2·(x₀²+x₁²+x₂²+x₀x₁+x₁x₂+x₂x₀)` once `x₃` is substituted. This is the *same*
quadratic form and constant `5` that governs the three-point criterion
`collinear_onQuartic_iff`.

## Why it matters

A four-point line on `y = x⁴ − 5x²` is exactly a point `(x₀,x₁,x₂)` on the single fixed
ellipsoid `Q = 5` with `x₃` determined by `Σx = 0` — **no `x⁴` term survives**. So the open
`Ω(n^{3/2})` / `n^{2−o(1)}` growth question becomes the purely arithmetic problem of finding
super-linearly many distinct solution-sets on one fixed ternary conic. This is a clean
reduction that future construction work can target directly.

- Pure algebra (`linarith` / `subst` / `linear_combination`); **0 sorries, 0 axioms, no new API**.
- The two OPEN construction sorries (`grunbaum_lower_bound_three_halves`,
  `solymosi_stojakovic_lower_bound`) are the genuine hard frontier and are untouched.

## Verification

⚠️ **UNVERIFIED** — docker build infrastructure down all session (containerd meta.db I/O
error; `docker images` fails). Hand-audited: the `(1/2)·h` and `2·h` `linear_combination`
coefficients are the exact factor of `2` between `Σx²` and the ternary form. Needs a clean
`docker-build.sh Proofs.Erdos101OQ04` once infra recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)