### PR TITLE
research(erdos-1012-oq-01-oq-02): global minimizer of the edge-threshold k-profile

### DIFF
--- a/proofs/Proofs/Erdos1012OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1012OQ01OQ02.lean
@@ -340,4 +340,63 @@ theorem edgeThreshold_second_diff_right (n k : ℕ) (h : k + 3 ≤ n) :
   rw [show k + 1 + 1 = k + 2 by omega] at h2
   omega
 
+/-! ## The `k`-profile has a global minimum (a well-defined `f(k)` minimizer)
+
+The single-step branch lemmas `edgeThreshold_succ_right_le` (decreasing while `n ≥ 2k+4`)
+and `edgeThreshold_le_succ_right` (increasing while `n ≤ 2k+4`) only compare *adjacent*
+clique sizes.  Iterating each along its branch gives genuine range-monotonicity — the
+threshold is antitone up to the turning point and monotone after it — and the two chains
+meet at the parity-uniform minimizer `k₀ = ⌊(n-3)/2⌋`, giving a *global* lower bound
+`edgeThreshold n k₀ ≤ edgeThreshold n k` for every clique size `k`.  This is precisely the
+"well-defined minimum" structure that makes the Woodall function `f(k)` meaningful: the
+edge threshold, viewed as a function of `k`, is minimized at one location. -/
+
+/-- **Antitone chain on the decreasing branch.**  Iterating `edgeThreshold_succ_right_le`:
+    whenever `k ≤ j` and the whole run stays in the decreasing region (`2j+2 ≤ n`, the
+    binding constraint at the top step `j-1 → j`), the threshold has fallen:
+    `edgeThreshold n j ≤ edgeThreshold n k`. -/
+theorem edgeThreshold_antitone_left (n : ℕ) {k j : ℕ} (hkj : k ≤ j)
+    (h : 2 * j + 2 ≤ n) : edgeThreshold n j ≤ edgeThreshold n k := by
+  revert h
+  induction j, hkj using Nat.le_induction with
+  | base => intro _; exact le_refl _
+  | succ j hkj ih =>
+    intro h
+    exact le_trans (edgeThreshold_succ_right_le n j (by omega)) (ih (by omega))
+
+/-- **Monotone chain on the increasing branch.**  Iterating `edgeThreshold_le_succ_right`:
+    whenever `k ≤ j`, the run starts in the increasing region (`n ≤ 2k+4`, binding at the
+    bottom step) and the top index stays meaningful (`j+1 ≤ n`, binding at `j-1 → j`), the
+    threshold has risen: `edgeThreshold n k ≤ edgeThreshold n j`. -/
+theorem edgeThreshold_monotone_right (n : ℕ) {k j : ℕ} (hkj : k ≤ j)
+    (h1 : n ≤ 2 * k + 4) (h2 : j + 1 ≤ n) :
+    edgeThreshold n k ≤ edgeThreshold n j := by
+  revert h2
+  induction j, hkj using Nat.le_induction with
+  | base => intro _; exact le_refl _
+  | succ j hkj ih =>
+    intro h2
+    have step : edgeThreshold n j ≤ edgeThreshold n (j + 1) :=
+      edgeThreshold_le_succ_right n j (by omega) (by omega)
+    exact le_trans (ih (by omega)) step
+
+/-- **Global minimum of the `k`-profile.**  For `n ≥ 5` the threshold, as a function of the
+    clique size `k`, attains its minimum at the parity-uniform location
+    `k₀ = ⌊(n-3)/2⌋`: for *every* clique size `k` with `k+2 ≤ n`,
+
+        edgeThreshold n k₀ ≤ edgeThreshold n k.
+
+    The choice `k₀ = ⌊(n-3)/2⌋` handles both parities at once — for even `n` it is the
+    turning point `(n-4)/2` (where `2k₀+4 = n`), and for odd `n` it is `(n-3)/2` (where
+    `2k₀+2 = n-1` and `2k₀+4 = n+1`), each side of it strictly monotone.  Seeds `k ≤ k₀`
+    are handled by the antitone chain (decreasing branch), seeds `k > k₀` by the monotone
+    chain (increasing branch); the branch constraints `2k₀+2 ≤ n` and `n ≤ 2k₀+4` both hold
+    for this `k₀`.  This upgrades the qualitative "U-shaped in `k`" observation to a proven
+    single global minimizer — the well-defined minimum underlying `f(k)`. -/
+theorem edgeThreshold_min_at (n : ℕ) (hn : 5 ≤ n) {k : ℕ} (hk : k + 2 ≤ n) :
+    edgeThreshold n ((n - 3) / 2) ≤ edgeThreshold n k := by
+  rcases le_or_lt k ((n - 3) / 2) with hle | hlt
+  · exact edgeThreshold_antitone_left n hle (by omega)
+  · exact edgeThreshold_monotone_right n (le_of_lt hlt) (by omega) (by omega)
+
 end Erdos1012OQ01OQ02

--- a/research/problems/erdos-1012-oq-01-oq-02/sessions/2026-07-09-r8-global-minimizer.md
+++ b/research/problems/erdos-1012-oq-01-oq-02/sessions/2026-07-09-r8-global-minimizer.md
@@ -1,0 +1,44 @@
+# Session 2026-07-09 (researcher-8) — global minimizer of the edge-threshold k-profile
+
+**Mode**: REVISIT (RICH; fresh branch off origin/main) | **Outcome**: progress
+(UNVERIFIED — Docker infra fully down all session: containerd `meta.db` + content-store
+blob `input/output error`, image build fails; operator-level, not a code issue)
+
+## What I Did
+`Erdos1012OQ01OQ02.lean` (the `edgeThreshold n k = C(n-k-1,2)+C(k+2,2)+1` arithmetic
+engine, already 0 sorry / 0 axiom) had single-step branch monotonicity in `k`
+(`edgeThreshold_succ_right_le` decreasing while `n≥2k+4`; `edgeThreshold_le_succ_right`
+increasing while `n≤2k+4`) and second-difference convexity, but **no multi-step chains and
+no proven global minimizer**. Added the "well-defined minimum" capstone:
+
+- `edgeThreshold_antitone_left` — decreasing-branch chain: `k ≤ j`, `2j+2 ≤ n` ⟹
+  `edgeThreshold n j ≤ edgeThreshold n k`.
+- `edgeThreshold_monotone_right` — increasing-branch chain: `k ≤ j`, `n ≤ 2k+4`,
+  `j+1 ≤ n` ⟹ `edgeThreshold n k ≤ edgeThreshold n j`.
+- `edgeThreshold_min_at` — **global minimizer** at parity-uniform `k₀ = ⌊(n-3)/2⌋`:
+  for `n ≥ 5` and every `k` with `k+2 ≤ n`, `edgeThreshold n k₀ ≤ edgeThreshold n k`.
+
+## Proof recipe
+- Both chains: `revert` the `j`-dependent bound hyp, then
+  `induction j, hkj using Nat.le_induction`; base = `le_refl`; succ = `le_trans` of the
+  single-step branch lemma at index `j` (precondition closed `by omega` from the reverted
+  bound) with `ih` (its bound closed `by omega`). Reverting the bound before induction
+  keeps the motive well-typed (bound mentions the induction variable).
+- `edgeThreshold_min_at`: `rcases le_or_lt k k₀`; `k ≤ k₀` → antitone chain (needs
+  `2k₀+2 ≤ n`), `k₀ < k` → monotone chain (needs `n ≤ 2k₀+4` and `k+1 ≤ n`). All three
+  `by omega` — omega natively handles `(n-3)/2` division; the k₀ choice makes both branch
+  constraints hold for either parity (`2⌊(n-3)/2⌋ ∈ {n-4, n-3}`).
+
+## Correctness note (parity)
+- n even: `k₀ = (n-4)/2`, `2k₀+4 = n` (turning point). n odd: `k₀ = (n-3)/2`,
+  `2k₀+2 = n-1`, `2k₀+4 = n+1` — strictly monotone each side. So `k₀` is the true argmin
+  for both parities; `edgeThreshold_min_at` verified against this by hand.
+
+## Files Modified
+- `proofs/Proofs/Erdos1012OQ01OQ02.lean` (+~60 lines, 3 theorems)
+
+## Next Steps
+- The `k`-profile minimum is now a theorem. A natural follow-up: the analogous
+  `n`-direction is strictly monotone (no interior min — `edgeThreshold_mono` already), so
+  the joint 2-D picture is complete. Remaining open work lives in siblings
+  `Erdos1012OQ02.lean` (3 sorries: Turán-threshold arithmetic + Walk-API connectivity).


### PR DESCRIPTION
## Summary

Adds the **proven global-minimum structure** for the Woodall edge threshold `edgeThreshold n k = C(n-k-1,2) + C(k+2,2) + 1` in `Erdos1012OQ01OQ02.lean` (Erdős #1012, vertex-pancyclicity thresholds).

The file already had the single-step branch monotonicity in `k` — decreasing while `n ≥ 2k+4`, increasing while `n ≤ 2k+4` (the qualitative "U-shape") — plus second-difference convexity, but it only compared *adjacent* clique sizes and never pinned down *where* the minimum is. This PR iterates those single steps into range-monotone chains and proves a single global minimizer.

## New declarations (all 0 sorry / 0 new axiom)

- **`edgeThreshold_antitone_left`** — decreasing-branch chain: `k ≤ j`, `2j+2 ≤ n` ⟹ `edgeThreshold n j ≤ edgeThreshold n k`.
- **`edgeThreshold_monotone_right`** — increasing-branch chain: `k ≤ j`, `n ≤ 2k+4`, `j+1 ≤ n` ⟹ `edgeThreshold n k ≤ edgeThreshold n j`.
- **`edgeThreshold_min_at`** — global minimizer at the parity-uniform location `k₀ = ⌊(n-3)/2⌋`: for `n ≥ 5` and every `k` with `k+2 ≤ n`, `edgeThreshold n k₀ ≤ edgeThreshold n k`.

This is the "well-defined minimum" underlying Woodall's `f(k)`.

## Proof approach

Both chains: `revert` the `j`-dependent bound, then `induction j, hkj using Nat.le_induction`; base is `le_refl`, succ is `le_trans` of the existing single-step branch lemma with the induction hypothesis (all preconditions closed by `omega`). The minimizer splits `rcases le_or_lt k k₀` and feeds each side to the matching chain; the choice `k₀ = ⌊(n-3)/2⌋` makes both branch constraints (`2k₀+2 ≤ n`, `n ≤ 2k₀+4`) hold for either parity, so `omega` (which handles the `/2` natively) discharges everything.

## Verification status

⚠️ **UNVERIFIED** — Docker build infrastructure is down this session (containerd `meta.db` + content-store blob `input/output error`; image build fails — operator-level, not a code issue). The proofs are standard `Nat.le_induction` chains over the file's existing verified branch lemmas plus `omega`. Please re-run `./proofs/scripts/docker-build.sh Proofs.Erdos1012OQ01OQ02` once infra recovers before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)