### PR TITLE
Enrich Erdős Problem #372 (Descending Largest Prime Factors): add references

### DIFF
--- a/src/data/proofs/erdos-372/meta.json
+++ b/src/data/proofs/erdos-372/meta.json
@@ -199,5 +199,28 @@
       "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, prime-factors"
     }
   ],
+  "references": [
+    {
+      "title": "On the largest prime factors of n and n + 1",
+      "author": "Paul Erdős and Carl Pomerance",
+      "year": "1978",
+      "venue": "Aequationes Mathematicae 17, no. 2–3, pp. 311–321",
+      "description": "Introduces the study of consecutive largest prime factors P(n), P(n+1) and proves the ascending case P(n) < P(n+1) < P(n+2) holds infinitely often, posing the descending analogue resolved here."
+    },
+    {
+      "title": "On triplets with descending largest prime factors",
+      "author": "Antal Balog",
+      "year": "2001",
+      "venue": "Studia Scientiarum Mathematicarum Hungarica 38, pp. 45–50",
+      "description": "Proves the descending case: #{n ≤ x : P(n) > P(n+1) > P(n+2)} ≫ √x, giving infinitely many n and thereby answering Erdős Problem #372 in the affirmative."
+    },
+    {
+      "title": "Erdős Problem #372",
+      "author": "Thomas F. Bloom (ed.)",
+      "year": "2024",
+      "venue": "erdosproblems.com/372",
+      "description": "The catalogued entry, recording the SOLVED status (Balog, 2001) and the De Koninck–Doyon (2011) conjecture that the descending triplets have natural density 1/6."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `erdos-372`. REFS0 (empty `references`) but otherwise rich (5 keyInsights, 9 sections, 985-char historicalContext, 3 cross-references).

Transcribed the three sources already named in the Lean docstring's history:
- **Erdős & Pomerance (1978)** — *On the largest prime factors of n and n+1*, Aequationes Math. 17, 311–321. Posed the problem; proved the ascending case.
- **Balog (2001)** — *On triplets with descending largest prime factors*, Studia Sci. Math. Hungar. 38, 45–50. Proved the descending case ≫ √x, solving #372.
- **erdosproblems.com/372** — catalogued entry (solved status + De Koninck–Doyon density-1/6 conjecture).

meta.json ~11.3 KB, well under caps. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)