### PR TITLE
Enrich Erdős Problem #938 (APs in Consecutive Powerful Numbers): add references

### DIFF
--- a/src/data/proofs/erdos-938/meta.json
+++ b/src/data/proofs/erdos-938/meta.json
@@ -211,5 +211,28 @@
       "description": "Related Erdős problem sharing themes: number-theory, open, powerful-numbers"
     }
   ],
+  "references": [
+    {
+      "title": "Powerful numbers",
+      "author": "Solomon W. Golomb",
+      "year": "1970",
+      "venue": "American Mathematical Monthly 77, no. 8, pp. 848–852",
+      "description": "The classic reference introducing 'powerful numbers' (p | n ⟹ p² | n), their a²b³ parametrization, and the asymptotic count (ζ(3/2)/ζ(3))·√x that underlies this problem's density estimates."
+    },
+    {
+      "title": "Erdős Problem #938",
+      "author": "Thomas F. Bloom (ed.)",
+      "year": "2024",
+      "venue": "erdosproblems.com/938",
+      "description": "The catalogued entry recording the OPEN status and Erdős's original posing [Er76d]: are there only finitely many three-term APs among consecutive powerful numbers? Links to the related #364 (no three consecutive powerful integers)."
+    },
+    {
+      "title": "OEIS A001694: Powerful numbers",
+      "author": "N. J. A. Sloane (ed.), OEIS Foundation",
+      "year": "2024",
+      "venue": "The On-Line Encyclopedia of Integer Sequences, oeis.org/A001694",
+      "description": "The sequence 1, 4, 8, 9, 16, 25, 27, 32, 36, 49, … of powerful (squarefull) numbers whose consecutive triples this problem examines for arithmetic progressions."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `erdos-938` (REFS0; otherwise rich — 6 keyInsights, 10 sections, 1214-char historicalContext). Added three accurate sources: Golomb's classic 1970 *Powerful numbers* (Amer. Math. Monthly 77, 848–852; source of the a²b³ parametrization and (ζ(3/2)/ζ(3))·√x count), the erdosproblems.com/938 entry (Erdős [Er76d], links #364), and OEIS A001694. Under caps; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)