### PR TITLE
research(erdos-18-oq-01): practical numbers closed under powers

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -441,4 +441,21 @@ theorem practical_mul {m n : ℕ} (hpm : IsPractical m) (hpn : IsPractical n) :
   rw [hAsum, hSrsum, hdecomp] at hunion
   exact hunion
 
+/-- **Practical numbers are closed under powers.**  If `m` is practical then so is
+    every power `m ^ k`.  This is the iterate of `practical_mul` starting from the
+    trivially practical `1 = m ^ 0` (`Erdos18.one_practical`): each factor of `m`
+    keeps the product practical.  In particular every practical base generates an
+    infinite family of practical numbers `m, m², m³, …`. -/
+theorem practical_pow {m : ℕ} (hp : IsPractical m) (k : ℕ) : IsPractical (m ^ k) := by
+  induction k with
+  | zero => simpa using one_practical
+  | succ k ih => rw [pow_succ]; exact practical_mul ih hp
+
+/-- **Powers of six are practical.**  Instantiating `practical_pow` at the verified
+    practical base `6` gives the infinite family `1, 6, 36, 216, …` of practical
+    numbers — a family with an odd prime factor, distinct from the powers of two
+    `two_pow_practical`. -/
+theorem six_pow_practical (k : ℕ) : IsPractical (6 ^ k) :=
+  practical_pow six_practical k
+
 end Erdos18OQ01

--- a/research/problems/erdos-18-oq-01/sessions/2026-07-09-r8-practical-pow.md
+++ b/research/problems/erdos-18-oq-01/sessions/2026-07-09-r8-practical-pow.md
@@ -1,0 +1,27 @@
+# Session 2026-07-09 (researcher-8) — practical numbers closed under powers
+
+**Mode**: REVISIT (MODERATE; fresh branch off origin/main) | **Outcome**: progress
+(UNVERIFIED — Docker infra fully down all session: containerd `meta.db` I/O error, image
+build fails; operator-level)
+
+## What I Did
+`Erdos18OQ01.lean` already had closure under multiplication (`practical_mul`) and the
+`2^k` family, but no closure under **powers**. Added:
+- `practical_pow` — `IsPractical m → IsPractical (m^k)`, the iterate of `practical_mul`
+  from `Erdos18.one_practical` (`m^0 = 1`).
+- `six_pow_practical` — `IsPractical (6^k)`: an infinite practical family with an odd
+  prime factor (distinct from the powers of two `two_pow_practical`).
+
+## Proof
+- `induction k`; `zero` = `simpa using one_practical` (`m^0` → `1` via `pow_zero`);
+  `succ` = `rw [pow_succ]; exact practical_mul ih hp` (`m^(k+1) = m^k * m`).
+- `six_pow_practical := practical_pow six_practical k` (one line).
+
+## Files Modified
+- `proofs/Proofs/Erdos18OQ01.lean` (+~20 lines, 2 theorems)
+
+## Next Steps
+- The elementary closure algebra is now fairly complete (even, odd⇒1, ×, powers,
+  2-power families). The open questions (h(m)/Mertens–Vose asymptotics) remain out of
+  elementary reach; the Stewart–Sierpiński characterization would be the next substantive
+  target but needs the σ-based inductive criterion.


### PR DESCRIPTION
## Summary

Adds **closure under powers** for practical numbers (Erdős #18, OEIS A005153) in `Erdos18OQ01.lean`.

The file already proves closure under multiplication (`practical_mul`) and that every power of two is practical (`two_pow_practical`), but never records the immediate consequence that *any* practical base generates an infinite family of practical powers.

## New declarations (all 0 sorry / 0 new axiom)

- **`practical_pow`** — `IsPractical m → IsPractical (m ^ k)`. Iterate of `practical_mul` from the trivially practical `1 = m^0` (`Erdos18.one_practical`).
- **`six_pow_practical`** — `IsPractical (6 ^ k)`: the infinite family `1, 6, 36, 216, …`, a practical family carrying an odd prime factor, distinct from the powers of two.

## Proof

`induction k`; base is `simpa using one_practical` (`m^0` reduces to `1`), successor is `rw [pow_succ]; exact practical_mul ih hp`. The concrete family is a one-line instantiation at the verified base `six_practical`.

## Verification status

⚠️ **UNVERIFIED** — Docker build infrastructure is down this session (containerd `meta.db` `input/output error`; image build fails — operator-level, not a code issue). The proof is a three-line induction over the file's already-verified `practical_mul` / `one_practical` / `six_practical`. Please re-run `./proofs/scripts/docker-build.sh Proofs.Erdos18OQ01` once infra recovers before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)