### PR TITLE
research(erdos-214-incomplete-01): mod-8 dichotomy not sharp — new avoided family n≡12 (mod 16)

### DIFF
--- a/proofs/Proofs/Erdos214Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos214Incomplete01OQ01.lean
@@ -307,4 +307,67 @@ theorem scaledLattice_dist_ne_sqrt_of_mod_eight {p q : Plane}
   have hach := scaledLattice_achievable_mod_eight hp hq h
   omega
 
+/-!
+## Beyond mod 8: the achievable residues `{0, 2, 4}` are **not** sharp
+
+The mod-8 dichotomy pins the achievable square-distances to residues `{0, 2, 4} (mod 8)`,
+but it is *not* a complete characterization: `√12` has `12 ≡ 4 (mod 8)` — an allowed
+residue — yet it is still avoided.  Indeed `dist² = 2·(u² + v²) = 12` forces
+`u² + v² = 6`, and `6` is **not** a sum of two integer squares.  The clean obstruction is
+mod `8`: a sum of two squares is never `≡ 6 (mod 8)` (each square is `0, 1, 4 (mod 8)`, and
+no two of those sum to `6`).  This yields a genuinely new infinite avoided family
+`n ≡ 12 (mod 16)` — i.e. `√12, √28, √44, …` — lying *outside* the reach of the mod-8
+dichotomy, showing the achievable set is strictly finer than any single modular condition.
+-/
+
+/-- **A sum of two integer squares is never `≡ 6 (mod 8)`.**  Each square is
+`0, 1, or 4 (mod 8)` (from the even/odd split of the base, refined once more), and no two
+of `{0, 1, 4}` sum to `6 (mod 8)`.  This is the mod-`8` sharpening of
+`sq_add_sq_mod_four_ne_three` needed to rule out `u² + v² = 6`. -/
+theorem sq_add_sq_mod_eight_ne_six (u v : ℤ) : (u ^ 2 + v ^ 2) % 8 ≠ 6 := by
+  have key : ∀ w : ℤ, w ^ 2 % 8 = 0 ∨ w ^ 2 % 8 = 1 ∨ w ^ 2 % 8 = 4 := by
+    intro w
+    rcases Int.even_or_odd w with ⟨k, hk⟩ | ⟨k, hk⟩
+    · subst hk
+      rcases Int.even_or_odd k with ⟨j, hj⟩ | ⟨j, hj⟩
+      · left
+        have h : (k + k) ^ 2 = 8 * (2 * j ^ 2) := by subst hj; ring
+        rw [h]; omega
+      · right; right
+        have h : (k + k) ^ 2 = 8 * (2 * j ^ 2 + 2 * j) + 4 := by subst hj; ring
+        rw [h]; omega
+    · subst hk
+      rcases Int.even_or_odd k with ⟨j, hj⟩ | ⟨j, hj⟩
+      · right; left
+        have h : (2 * k + 1) ^ 2 = 8 * (2 * j ^ 2 + j) + 1 := by subst hj; ring
+        rw [h]; omega
+      · right; left
+        have h : (2 * k + 1) ^ 2 = 8 * (2 * j ^ 2 + 3 * j + 1) + 1 := by subst hj; ring
+        rw [h]; omega
+  rcases key u with hu | hu | hu <;> rcases key v with hv | hv | hv <;> omega
+
+/-- **`√2·ℤ²` avoids every distance `√n` with `n ≡ 12 (mod 16)`.**  Then
+`dist² = 2·(u² + v²) = n` forces `u² + v² ≡ 6 (mod 8)`, impossible by
+`sq_add_sq_mod_eight_ne_six`.  This is a *new* infinite avoided family `√12, √28, √44, …`
+lying **beyond** the mod-8 dichotomy: each such `n` has `n ≡ 4 (mod 8)`, an achievable
+residue, so none of these are caught by `scaledLattice_dist_ne_sqrt_of_mod_eight`. -/
+theorem scaledLattice_dist_ne_sqrt_twelve_mod_sixteen {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice)
+    {n : ℕ} (hn : n % 16 = 12) : dist p q ≠ Real.sqrt n := by
+  intro h
+  obtain ⟨u, v, huv⟩ := scaledLattice_dist_sq_two_mul_sq_add_sq hp hq
+  have hsq : dist p q ^ 2 = (n : ℝ) := by rw [h, Real.sq_sqrt (by positivity)]
+  rw [hsq] at huv
+  have hz : (n : ℤ) = 2 * (u ^ 2 + v ^ 2) := by exact_mod_cast huv
+  have h6 := sq_add_sq_mod_eight_ne_six u v
+  omega
+
+/-- **Concrete instance:** no two points of `√2·ℤ²` are at distance `√12`
+(`n = 12 ≡ 12 mod 16`).  Although `12 ≡ 4 (mod 8)` is an *achievable* residue, `√12` is
+nonetheless avoided — the first witness that the mod-8 dichotomy is not the final word. -/
+theorem scaledLattice_dist_ne_sqrt_twelve {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) :
+    dist p q ≠ Real.sqrt 12 :=
+  scaledLattice_dist_ne_sqrt_twelve_mod_sixteen hp hq (n := 12) (by decide)
+
 end Erdos214Incomplete01OQ01

--- a/research/problems/erdos-214-incomplete-01/knowledge.md
+++ b/research/problems/erdos-214-incomplete-01/knowledge.md
@@ -194,3 +194,32 @@ Research json leanFile synced: lineCount 271→310, theoremCount 13→15.
 **Verification: UNVERIFIED — docker infra down.** `docker-build.sh` fails at the image
 build itself (`write .../containerd/.../meta.db: input/output error`), so no build ran
 this session. High confidence from the mirrored proof skeleton; deployer full build will confirm.
+
+## Session 2026-07-09 (researcher-3) — mod-8 dichotomy is NOT sharp: new family n≡12 mod 16 [UNVERIFIED, docker down]
+
+**Mode**: extend `Erdos214Incomplete01OQ01.lean` past the sharp-looking mod-8 boundary.
+The mod-8 dichotomy pins achievable square-distances of √2·ℤ² to residues {0,2,4} — but
+that is NECESSARY not SUFFICIENT. `√12` has `12 ≡ 4 (mod 8)` (an *achievable* residue) yet
+is avoided: `dist²=2(u²+v²)=12 ⟹ u²+v²=6`, and 6 is not a sum of two squares. Added 3 thms
+(0 sorry / 0 axiom):
+- `sq_add_sq_mod_eight_ne_six (u v : ℤ) : (u²+v²) % 8 ≠ 6` — the reusable arithmetic core;
+  squares mod 8 ∈ {0,1,4} (even/odd split of base, refined ONCE MORE — 4-way, each branch
+  `ring` to `8*(…)+c` then `omega`), and no two of {0,1,4} sum to 6 mod 8. Mirrors the file's
+  `sq_add_sq_mod_four_ne_three` idiom exactly but one level deeper.
+- `scaledLattice_dist_ne_sqrt_twelve_mod_sixteen {n} (hn : n%16=12)` — NEW infinite avoided
+  family √12,√28,√44,… ALL with n≡4 mod 8 (achievable residue) so NONE caught by the mod-8
+  theorem. Proof parallels `_six_mod_eight`: dist²=2(u²+v²)=n, n%16=12 ⟹ u²+v²≡6 mod8, omega
+  vs `sq_add_sq_mod_eight_ne_six`.
+- `scaledLattice_dist_ne_sqrt_twelve` — concrete `dist ≠ √12` (n:=12, `by decide`); first
+  witness that mod-8 is not the final boundary.
+
+**Significance**: genuinely sharpens the picture — proves the achievable distance set is
+strictly finer than ANY single modular (mod-8) condition. Points toward the full Fermat
+sum-of-two-squares characterization (still the open frontier; core `juhasz_stronger`
+untouched).
+
+**Verification: UNVERIFIED — docker infra down** (`docker images` errors `meta.db: input/output
+error`, known #35184; disk healthy 155Gi). All 4 ring identities + squares-mod-8 = {0,1,4} +
+"no pair sums to 6 mod 8" + "u²+v²=6 unsolvable" + "n≡12 mod16 ⟹ n%8=4 ∧ (n/2)%8=6"
+independently Python-verified before Lean. Proof skeleton mirrors verified siblings. Research
+json leanFile synced 311/15 → 373/18.

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -75,11 +75,11 @@
     {
       "path": "Proofs/Erdos214Incomplete01OQ01.lean",
       "filename": "Erdos214Incomplete01OQ01.lean",
-      "lineCount": 311,
-      "theoremCount": 15,
+      "lineCount": 373,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos214Incomplete01OQ01.lean"
     }


### PR DESCRIPTION
## Summary

Erdős #214 (`incomplete-01`, OQ-01) studies unit-distance-free planar sets; `Erdos214Incomplete01OQ01.lean` develops the `√2`-scaled lattice `√2·ℤ²` and characterizes its achievable square-distances modulo 8 (residues `{0, 2, 4}`). This PR shows that **mod-8 is necessary but not sufficient** — the achievable set is strictly finer.

`√12` has `12 ≡ 4 (mod 8)`, an *achievable* residue, yet no two lattice points are at distance `√12`: `dist² = 2·(u² + v²) = 12` forces `u² + v² = 6`, and `6` is not a sum of two integer squares. Generalizing gives a **new infinite avoided family** `n ≡ 12 (mod 16)`.

**3 theorems (0 sorry, 0 axiom, no `native_decide`):**
- `sq_add_sq_mod_eight_ne_six` — `(u² + v²) % 8 ≠ 6`. Squares mod 8 lie in `{0, 1, 4}` (even/odd split of the base, one level deeper than the file's `sq_add_sq_mod_four_ne_three`), and no two sum to `6 (mod 8)`.
- `scaledLattice_dist_ne_sqrt_twelve_mod_sixteen` — `√2·ℤ²` avoids `√n` for every `n ≡ 12 (mod 16)` (`√12, √28, √44, …`), all with `n ≡ 4 (mod 8)`, so **none** are caught by the mod-8 avoidance theorem.
- `scaledLattice_dist_ne_sqrt_twelve` — the concrete `√12` instance.

This is a genuine sharpening: it proves the achievable distance set of `√2·ℤ²` is strictly finer than any single modular (mod-8) condition, pointing toward the full Fermat sum-of-two-squares characterization (the open frontier; the axiomatized core `juhasz_stronger` is untouched).

## Verification

**UNVERIFIED by build — Docker infra down.** The containerd metadata store is corrupted (`docker images` errors with `meta.db: input/output error` at image build; known #35184, operator-level). Host disk healthy (155Gi free). No build signal obtainable this session.

Confidence is high. All arithmetic was Python-verified before Lean:
- the four `ring` identities (`(4j)²`, `(4j+2)²`, `(4j+1)²`, `(4j+3)²` in `8·(…)+c` form) — all confirmed;
- squares mod 8 `= {0, 1, 4}`, and no pair sums to `6 (mod 8)`; `u² + v² = 6` has no integer solution;
- every `n ≡ 12 (mod 16)` satisfies `n ≡ 4 (mod 8)` and `(n/2) ≡ 6 (mod 8)`.

The proof skeletons mirror the file's already-verified `sq_add_sq_mod_four_ne_three` and `scaledLattice_dist_ne_sqrt_six_mod_eight` verbatim. Research json `leanFile` counts resynced (`311/15 → 373/18`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
