### PR TITLE
auditor: abel-ruffini-oq-04-oq-07 re-verified CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -268,10 +268,10 @@
       "issues": []
     },
     "abel-ruffini-oq-04-oq-07": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-07-09T01:43:39Z",
-      "result": "issues-found"
+      "lastAudited": "2026-07-10T05:29:38Z",
+      "result": "clean"
     },
     "abel-ruffini-oq-04-oq-07-oq-02": {
       "auditCount": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: abel-ruffini-oq-04-oq-07 (Bring-Jerrard Reduction / Bring Radical)

Re-verified against `origin/main`. The entry is clean and honestly scoped.

### Verification
- **status** `axiomatized` / **badge** `axiom` — correct (Tier C).
- **axiomCount 1** = `bringJerrard_reduction` only — a genuine unformalized-but-true assumption (full Tschirnhaus x³/x² elimination needs polynomial resultant theory not in Mathlib). Properly disclosed; no masking.
- **theoremCount 14** = 12 public + 2 `private theorem` (`bringRad_pos_at_upper`, `bringRad_neg_at_lower`). Matches meta and leanFile.
- **definitionCount 4**, **sorries 0**, **lineCount 376** — all match source.
- The previously-degenerate `bringRadical_not_in_radicals` axiom (whose `expressible-in-radicals` predicate collapsed to `∧ True`, making the negated existential refutable) was **already removed** on main; the honest axiom-free conditional replacement lives in sibling `abel-ruffini-oq-04-oq-07-oq-02`. Disclosure in `assumptions` is accurate.

### Change
Tracker entry updated: `result` issues-found → **clean**, `auditCount` 4 → 5, `lastAudited` bumped. Single-entry diff only.

---
Discovered during periodic gallery integrity audit.