### PR TITLE
Enrich Sharp k=3 Birthday Threshold: sub-unit localization insight

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
@@ -70,7 +70,8 @@
       "Substituting m = n - 1 turns the balance into the depressed cubic m³ - m = c³, where c = (6d²ln2)^(1/3); the depressed (no quadratic term) form is exactly what makes the centered analysis clean.",
       "The upper bound is not an analytic estimate but an algebraic identity: 3c(m-c) ≤ 1 is equivalent, after clearing the positive factor m² + mc + c², to (m-c)² ≥ 0. The remainder 1/(3c) is therefore sharp for this argument.",
       "The remainder 1/(3c) = O(d^(-2/3)) vanishes as d → ∞, so the constant term is genuinely exactly 1 in the limit — a strict refinement, not merely a smaller constant in an O(1) bound.",
-      "The sharpening is special to k = 3: for general k the centered monomial (n - (k-1)/2)^k does not divide the falling factorial exactly, which is why the sibling general-k entry retains the loose ±(k-1) band."
+      "The sharpening is special to k = 3: for general k the centered monomial (n - (k-1)/2)^k does not divide the falling factorial exactly, which is why the sibling general-k entry retains the loose ±(k-1) band.",
+      "The sharp window has sub-unit width, so it pins the integer threshold. Because c = (6d²ln2)^(1/3) ≥ (6ln2)^(1/3) ≈ 1.61 for every d ≥ 1, the remainder satisfies 1/(3c) ≤ 0.21 < 1: the balance solution n is located to better than a fifth of an integer. This is the practical payoff over the parent's width-2 band c ≤ n ≤ c + 2, which could straddle three consecutive integers — the sharp bound instead predicts a single rounded threshold value."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01` (quality 95, pass 0). The entry was already exceptionally complete (5 keyInsights, mainTheorems, full sections/conclusion/refs) and well under the 60 KB cap, so this is one targeted, accurate addition rather than deepening the shallowest field. Verified there is no line-count drift or axiom-claim defect (Lean file is 162 lines = meta; 0 axioms/sorries; 3 theorems).

**Added (1 genuinely new insight, numerically verified):**
- **6th keyInsight** — the sharp remainder 1/(3c) is below 1 for *every* d ≥ 1: since c = (6d²ln2)^(1/3) ≥ (6ln2)^(1/3) ≈ 1.61, we get 1/(3c) ≤ 0.21. So the balance solution n is localized to better than a fifth of an integer — the concrete practical payoff over the parent's width-2 band c ≤ n ≤ c+2, which could straddle three consecutive integers. The sharp bound instead predicts a single rounded threshold value.

`meta.json` is 15.8 KB (cap 60 KB); keyInsights now 6 (within 4–12). `pnpm build` exits 0. No status/badge/axiomCount changes (remains `verified`, 0 axioms, 0 sorries).