### PR TITLE
Fix: sync stale lineCount in 3 gallery meta.json entries

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -12,7 +12,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
-    "lineCount": 1218,
+    "lineCount": 1281,
     "theoremCount": 40,
     "definitionCount": 0,
     "difficulty": "advanced",
@@ -62,7 +62,7 @@
       "CauchyInterlacing.Poincare"
     ],
     "namespace": "CauchyInterlacing.PoincareCompression",
-    "lineCount": 1218,
+    "lineCount": 1281,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -49,7 +49,7 @@
     "dateAdded": "2026-07-05",
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
-    "lineCount": 311,
+    "lineCount": 328,
     "assumptions": "1 axiom, inherited from the parent Erdos1138OQ03: baker_harman_pintz (maxPrimeGap x <= x^0.525 for x >= 25). No axiom is declared in this file (leanFile.axiomCount = 0); the assumption is imported. #print axioms confirms the results depend only on {propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}. No sorries, no native_decide.",
     "theoremCount": 11,
     "definitionCount": 0
@@ -140,7 +140,7 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 311,
+    "lineCount": 328,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 0,

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,7 +58,7 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 617,
+    "lineCount": 650,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
     "theoremCount": 21,
     "definitionCount": 5
@@ -142,7 +142,7 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 617,
+    "lineCount": 650,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` metadata for three gallery entries whose Lean source files grew via recently-merged research PRs (07-09) without a corresponding meta resync.

## Evidence

| slug | old lineCount | actual `wc -l` | grown by |
|------|---------------|----------------|----------|
| cauchy-interlacing-theorem-oq-01-oq-02 | 1218 | 1281 | #36909 |
| erdos-1138-oq-03-oq-01 | 311 | 328 | #36910 |
| roth-theorem-k3-oq-03-oq-01 | 617 | 650 | #36906 |

Each entry had the drift in **both** `leanFile.lineCount` and `meta.lineCount`; both were updated. Metadata-only change, no Lean source touched. All other automated integrity classes (section-past-EOF single-file, dead cross-refs, verified-with-axioms, missing-file) scanned clean this cycle.

---
Automated fix by lean-mechanic agent.