### PR TITLE
research(erdos-1039-incomplete-01): ρ(f) is always strictly positive

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -639,6 +639,33 @@ theorem equalRoots_rho_eq_one (f : UnitDiscPolynomial) (hdeg : 0 < f.degree)
     exact hmem
   · exact le_csSup (bddAbove_inscribed_radii f hdeg) ⟨c, hins1⟩
 
+/-- **ρ is always strictly positive.**  For any polynomial of positive degree the
+    sublevel set `{z : |f(z)| < 1}` is open and contains every root `zᵢ` (where
+    `f(zᵢ) = 0`), so a whole open ball about `zᵢ` lies inside it; that ball is an
+    inscribed disc of positive radius, forcing `ρ(f) > 0`.  Together with
+    `equalRoots_rho_eq_one` (`ρ = 1` for repeated roots) this pins the qualitative
+    range of `ρ`: it is genuinely positive for every admissible polynomial and
+    maxes out at `1`, so the open question is only *how small* `ρ` can be (the
+    conjectured `≫ 1/n` floor), never whether it can collapse to `0`. -/
+theorem rho_pos (hf : 0 < f.degree) : 0 < rho f := by
+  -- a root lies in the open sublevel set
+  set z0 : ℂ := f.roots ⟨0, hf⟩ with hz0
+  have hmem : z0 ∈ sublevelSet f := root_in_sublevelSet f ⟨0, hf⟩
+  -- openness gives an ambient ball about `z0`
+  obtain ⟨δ, hδ, hball⟩ := Metric.isOpen_iff.mp (sublevelSet_isOpen f) z0 hmem
+  -- that ball is an inscribed disc of radius `δ`
+  have hins : isInscribedDisc (sublevelSet f) z0 δ := by
+    refine ⟨hδ, ?_⟩
+    intro z hz
+    apply hball
+    rw [Metric.mem_ball, dist_eq_norm]
+    exact hz
+  have hrho : rho f = sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} := rfl
+  rw [hrho]
+  calc (0 : ℝ) < δ := hδ
+    _ ≤ sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} :=
+        le_csSup (bddAbove_inscribed_radii f hf) ⟨z0, hins⟩
+
 /-
 ## Random Polynomials
 -/


### PR DESCRIPTION
## Summary

Erdős #1039 (polynomial lemniscate inscribed-disc radius). Adds one clean, axiom-free structural lemma to `proofs/Proofs/Erdos1039Problem.lean`:

- **`rho_pos (hf : 0 < f.degree) : 0 < rho f`** — ρ(f) is strictly positive for every admissible polynomial.

### Why it matters

The file already has:
- `equalRoots_rho_eq_one` — repeated roots give the maximal ρ = 1,
- the axiomatized published lower bounds (Pommerenke 1/(2en²), KLR 1/(n√log n)),
- `degree_one_optimal`, `clustered_implies_large_disc`.

`rho_pos` supplies the missing **qualitative** endpoint: ρ never collapses to 0. Combined with `equalRoots_rho_eq_one` it pins the range of ρ to `(0, 1]` for every degree-≥1 polynomial, so the entire open content of Erdős #1039 is *how small* ρ can be (the conjectured `≫ 1/n` floor) — never whether it can vanish.

### Proof

Each root `zᵢ` satisfies `f(zᵢ) = 0`, so `zᵢ ∈ sublevelSet f` (`root_in_sublevelSet`). The sublevel set is open (`sublevelSet_isOpen`), so `Metric.isOpen_iff` yields an ambient ball `B(zᵢ, δ) ⊆ sublevelSet f`. That ball is an inscribed disc of radius δ > 0, hence `δ ≤ sSup {…} = ρ(f)` via `le_csSup (bddAbove_inscribed_radii …)`. The argument reuses exactly the sSup infrastructure already used by `degree_one_optimal` and `equalRoots_rho_eq_one`.

- 0 new axioms, 0 new sorries. The 4 deep published axioms (benchmark/Pommerenke/KLR) are untouched.

### Verification status: UNVERIFIED (infra)

Docker build could not run this session: containerd `meta.db` input/output error (Docker infra down at operator level; host disk healthy, 154 GiB free). The proof is a direct reuse of the file's existing verified sSup/`le_csSup`/`bddAbove_inscribed_radii`/`isInscribedDisc` patterns; every lemma and Mathlib API it calls (`Metric.isOpen_iff`, `Metric.mem_ball`, `dist_eq_norm`, `le_csSup`) is standard and already exercised in this file. Recommend a green docker build once infra is restored.