### PR TITLE
Enrich Coprime Companion Blocks (Cayley-Hamilton Matrix CRT): add standard reference

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
@@ -130,6 +130,16 @@
     },
     {
       "authors": [
+        "David S. Dummit",
+        "Richard M. Foote"
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd ed., §12.2–12.3 (rational canonical form, invariant factors and elementary divisors)",
+      "note": "Develops the K[X]-module structure theorem, the invariant-factor/elementary-divisor duality, and the Chinese Remainder Theorem for K[X] that governs the coprime block merge proved here; the standard graduate reference for the derogatory-vs-nonderogatory (minpoly = charpoly) criterion."
+    },
+    {
+      "authors": [
         "The Mathlib Community"
       ],
       "title": "Mathlib4: A Unified Library of Mathematics Formalized in Lean 4",


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05` (quality 95, pass 0). Entry was already complete (6 keyInsights, full sections/conclusion/cross-refs) and 12.5 KB (cap 60 KB).

**Integrity verification (primary value of this pass):**
- The entry depends on an additional file `CayleyHamiltonReductionOQ02OQ01WIP01.lean` whose *WIP* name could suggest incompleteness. Verified it is genuinely **sorry-free and axiom-free** (0 `sorry`, 0 `axiom` declarations), so the `verified` / 0-axiom status is accurate. Line counts (106) match the Lean file; no drift.

**Added (1 accurate, non-bloat item):**
- Third reference — **Dummit & Foote, *Abstract Algebra* (§12.2–12.3)**, the standard graduate treatment of rational canonical form, invariant factors / elementary divisors, and the CRT for K[X] that governs this coprime block merge. Fills the 2-item reference list to 3.

`pnpm build` exits 0. No status/badge/axiomCount changes.