### PR TITLE
research(descartes-rule-of-signs): discharge x_cubed_minus_x positive-roots axiom (8→7)

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSigns.lean
+++ b/proofs/Proofs/DescartesRuleOfSigns.lean
@@ -264,10 +264,28 @@ axiom example_x2_plus_1_sign_changes :
 example : signChangesInCoeffs (X^2 + 1 : ℝ[X]) = 0 :=
   example_x2_plus_1_sign_changes
 
-/-- Example: x³ - x has coefficients [1, 0, -1, 0], giving 1 sign change.
-    It has exactly 1 positive root (x = 1). -/
-axiom x_cubed_minus_x_positive_roots_axiom :
-    countPositiveRoots (X^3 - X : ℝ[X]) = 1
+/-- Example: `x³ - x = x(x-1)(x+1)` has real roots `{0, 1, -1}`, of which exactly one
+    (`x = 1`) is positive, so `countPositiveRoots (X³ - X) = 1`.
+
+    Formerly an `axiom`; the count is now computed directly from Mathlib's polynomial
+    root API (`roots_mul`, `roots_X`, `roots_X_sub_C`) — a concrete arithmetic fact
+    that needs no assumption. -/
+theorem x_cubed_minus_x_positive_roots_axiom :
+    countPositiveRoots (X^3 - X : ℝ[X]) = 1 := by
+  have hfac : (X ^ 3 - X : ℝ[X]) = X * (X - C 1) * (X + C 1) := by
+    simp only [map_one]; ring
+  have hX : (X : ℝ[X]) ≠ 0 := X_ne_zero
+  have hXm : (X - C 1 : ℝ[X]) ≠ 0 := X_sub_C_ne_zero 1
+  have hpe : (X + C 1 : ℝ[X]) = X - C (-1) := by rw [map_neg, sub_neg_eq_add]
+  have hXp : (X + C 1 : ℝ[X]) ≠ 0 := by rw [hpe]; exact X_sub_C_ne_zero (-1)
+  have hne : (X ^ 3 - X : ℝ[X]) ≠ 0 := by
+    rw [hfac]; exact mul_ne_zero (mul_ne_zero hX hXm) hXp
+  unfold countPositiveRoots
+  rw [if_neg hne, hfac,
+    roots_mul (by rw [← hfac]; exact hne),
+    roots_mul (mul_ne_zero hX hXm), roots_X, roots_X_sub_C, hpe, roots_X_sub_C]
+  simp only [Multiset.filter_add, Multiset.filter_singleton]
+  norm_num
 
 theorem x_cubed_minus_x_positive_roots :
     countPositiveRoots (X^3 - X : ℝ[X]) = 1 :=

--- a/research/problems/descartes-rule-of-signs-oq-01-oq-03/knowledge.md
+++ b/research/problems/descartes-rule-of-signs-oq-01-oq-03/knowledge.md
@@ -1,0 +1,36 @@
+# Knowledge Base: descartes-rule-of-signs-oq-01-oq-03
+
+## Session 2026-07-09 (researcher-2) — AXIOM ELIMINATION on base file (8→7)
+
+**Mode**: AXIOM HUNT (RICH family, score 20). My slug's on-target file
+`DescartesRuleOfSignsOQ01OQ03.lean` (871 lines, 30 thm) is saturated (r6 §7 invariances).
+Pivoted to the family's base `DescartesRuleOfSigns.lean`, which carried 8 axioms including
+three CONCRETE `example_*` "axioms" that are not deep results at all.
+
+**Discharged `x_cubed_minus_x_positive_roots_axiom` → theorem** (`countPositiveRoots (X³-X)=1`):
+factor `X³−X = X(X−1)(X+1)`, compute `.roots` via Mathlib `roots_mul`/`roots_X`/`roots_X_sub_C`
+= `{0,1,−1}`, filter `(· > 0)` leaves `{1}`, card 1. **Self-contained (pure Mathlib root API, no
+downstream helper) so it discharges IN the base file** — base axiomCount 8 → 7. `#print axioms`
+= `[propext, Classical.choice, Quot.sound]` only. Kept the `_axiom` name (now a theorem) so the
+wrapper `x_cubed_minus_x_positive_roots` still resolves.
+
+Recipe: `hpe : X + C 1 = X - C (-1) := by rw [map_neg, sub_neg_eq_add]` to reuse `roots_X_sub_C`
+for the `(X+1)` factor; nonzero side-conditions via `X_ne_zero` / `X_sub_C_ne_zero` /
+`mul_ne_zero`; finish `simp only [Multiset.filter_add, Multiset.filter_singleton]; norm_num`.
+
+**The other two concrete axioms** `example_x2_minus_1_sign_changes` (=1) and
+`example_x2_plus_1_sign_changes` (=0) are ALSO not deep — they are already PROVED axiom-free
+downstream in `DescartesRuleOfSignsOQ01OQ03.lean` (~lines 481/502) using its
+`countSignChanges_three_mid_zero_pos/zero` helpers. They persist in the base ONLY because
+`signChangesInCoeffs` is noncomputable (classical `Fin n × Fin n` filter) and the base file
+cannot import the downstream helpers (circular). Eliminating them at the base needs the Fin-3
+enumeration helpers copied in, or the base `axiom`+local `example` simply deleted (nothing outside
+depends on them). ACTIONABLE next: either inline the two helpers to prove them in the base, or
+delete the redundant base axioms — base would then reach 5 axioms (the remaining 5 —
+`descartes_upper_bound`, `descartes_parity`, `descartes_negative_roots`,
+`alternating_signs_max_roots`, `derivative_reduces_sign_changes` — are the genuinely deep
+Descartes-proof content).
+
+**Verification (docker DOWN — containerd meta.db/blob I/O, NOT disk).** Direct `lean` elab vs
+pinned Mathlib v4.26.0 (see [[reference-docker-down-lean-elab-verification-path]]): exit 0, only
+2 pre-existing `unused variable hp` warnings. Meta `descartes-rule-of-signs` synced 8→7 axioms.

--- a/src/data/proofs/descartes-rule-of-signs/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs/meta.json
@@ -50,11 +50,11 @@
     ],
     "dateAdded": "2024-12-27",
     "wiedijkNumber": 100,
-    "axiomCount": 8,
-    "lineCount": 576,
-    "assumptions": "8 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
+    "axiomCount": 7,
+    "lineCount": 594,
+    "assumptions": "7 axiom(s) encoding mathematical hypotheses. See the Lean source for details. (The former x_cubed_minus_x positive-roots example axiom is now a proved theorem.)",
     "mathlib_version": "4.26.0",
-    "theoremCount": 35,
+    "theoremCount": 36,
     "definitionCount": 11
   },
   "overview": {
@@ -209,9 +209,9 @@
       "Polynomial"
     ],
     "namespace": "DescartesRuleOfSigns",
-    "lineCount": 576,
-    "axiomCount": 8,
-    "theoremCount": 35,
+    "lineCount": 594,
+    "axiomCount": 7,
+    "theoremCount": 36,
     "definitionCount": 11,
     "path": "Proofs/DescartesRuleOfSigns.lean",
     "sorries": 0

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
@@ -111,7 +111,7 @@
       "filename": "DescartesRuleOfSigns.lean",
       "lineCount": 577,
       "theoremCount": 35,
-      "axiomCount": 8,
+      "axiomCount": 7,
       "defCount": 11,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

`descartes-rule-of-signs-oq-01-oq-03` — **axiom elimination** on the family's base file `DescartesRuleOfSigns.lean`, whose 8 axioms include three concrete `example_*` "axioms" that are not deep results.

Discharged **`x_cubed_minus_x_positive_roots_axiom`** (`countPositiveRoots (X³ − X) = 1`) → theorem: factor `X³ − X = X(X−1)(X+1)`, compute `.roots` via Mathlib `roots_mul` / `roots_X` / `roots_X_sub_C` = `{0, 1, −1}`, filter `(· > 0)` leaves `{1}`. Self-contained (pure Mathlib root API), so it discharges **in the base file** — axiom count **8 → 7**. `#print axioms` = `[propext, Classical.choice, Quot.sound]` only.

## Context on the other two concrete axioms

`example_x2_minus_1_sign_changes` (= 1) and `example_x2_plus_1_sign_changes` (= 0) are likewise not deep — they are **already proved axiom-free downstream** in `DescartesRuleOfSignsOQ01OQ03.lean` (via its `countSignChanges_three_mid_zero_*` helpers). They persist in the base only because `signChangesInCoeffs` is noncomputable (classical `Fin n × Fin n` filter) and the base cannot import the downstream helpers (circular). A follow-up can inline those helpers or delete the redundant base axioms; the remaining 5 axioms (`descartes_upper_bound`, `descartes_parity`, `descartes_negative_roots`, `alternating_signs_max_roots`, `derivative_reduces_sign_changes`) are the genuinely deep Descartes-proof content. The entry stays `axiomatized`.

## Verification

Docker infra down this session (containerd meta.db + content-store blob `input/output error` at image build — operator-level, not disk: 157Gi free). Verified by direct `lean` elaboration against the repo's pinned **Mathlib v4.26.0** oleans: **exit 0** (only two pre-existing `unused variable hp` warnings), `#print axioms` clean.

Gallery meta `descartes-rule-of-signs` synced (axiomCount 8→7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)