### PR TITLE
Enrich Erdős Problem #681 (Large Least Prime Factor in Shifted Composites): add references

### DIFF
--- a/src/data/proofs/erdos-681/meta.json
+++ b/src/data/proofs/erdos-681/meta.json
@@ -179,5 +179,21 @@
       "description": "Related Erdős problem sharing themes: composites, number-theory"
     }
   ],
+  "references": [
+    {
+      "title": "Erdős Problem #681",
+      "author": "Thomas F. Bloom (ed.)",
+      "year": "2024",
+      "venue": "erdosproblems.com/681",
+      "description": "The catalogued entry, attributing the problem to Erdős, Eggleton, and Selfridge: for all large n, is there k with n+k composite and p(n+k) > k² (least prime factor), and the generalisation p(n+k) > k^d?"
+    },
+    {
+      "title": "Introduction to Analytic and Probabilistic Number Theory",
+      "author": "Gérald Tenenbaum",
+      "year": "2015",
+      "venue": "Graduate Studies in Mathematics 163, American Mathematical Society (3rd ed.)",
+      "description": "Standard reference for the distribution of the least prime factor p(m) and of integers free of small prime factors, the sieve and smooth-number background underlying this problem."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `erdos-681` (REFS0; otherwise rich — 7 keyInsights, 8 sections, 1186-char historicalContext). Added two accurately-citable sources rather than stretch to a weak third: the erdosproblems.com/681 entry (Erdős–Eggleton–Selfridge origin) and Tenenbaum's *Introduction to Analytic and Probabilistic Number Theory* (least prime factor p(m) distribution / sieve background). Under caps; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)