### PR TITLE
research(erdos-1090): colored Ramsey number k-monotonicity

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -753,6 +753,56 @@ theorem ramseyNumber_le_ramseyNumberColored_fin {r : ℕ} (hr : 2 ≤ r) {k : �
   rw [h2]
   exact ramseyNumberColored_mono_fin hr hk
 
+/--
+**Colored Ramsey property is monotone under enlarging the set.**  If `A ⊆ B` and `A` has the
+`C`-colored Ramsey property for `k`, so does `B`: any `C`-coloring of the plane restricts to
+one on `A`, whose monochromatic `k`-collinear subset `S ⊆ A ⊆ B` also witnesses `B`.  The
+colored analogue of `hasRamseyProperty_mono`. -/
+theorem hasRamseyPropertyColored_mono {C : Type*} {A B : Finset Point} (hAB : A ⊆ B) {k : ℕ}
+    (hA : HasRamseyPropertyColored C A k) : HasRamseyPropertyColored C B k := by
+  intro c
+  obtain ⟨S, hSA, hScol, hSmono⟩ := hA c
+  exact ⟨S, hSA.trans hAB, hScol, hSmono⟩
+
+/--
+**Colored Ramsey property is antitone in `k`.**  Requiring fewer monochromatic collinear points
+is easier: if `A` has the `C`-colored Ramsey property for `k` and `k' ≤ k`, then it has it for
+`k'` — the same monochromatic `k`-collinear subset already has `≥ k ≥ k'` points on a common
+line.  The colored analogue of `hasRamseyProperty_antitone`. -/
+theorem hasRamseyPropertyColored_antitone {C : Type*} {A : Finset Point} {k k' : ℕ} (hk : k' ≤ k)
+    (hA : HasRamseyPropertyColored C A k) : HasRamseyPropertyColored C A k' := by
+  intro c
+  obtain ⟨S, hSA, ⟨hSk, hline⟩, hSmono⟩ := hA c
+  exact ⟨S, hSA, ⟨le_trans hk hSk, hline⟩, hSmono⟩
+
+/--
+**Colored upper bound from any witness: `R_C(k) ≤ |A|`.**  Any finite set `A` with the
+`C`-colored Ramsey property for `k` bounds the colored Ramsey number from above, since `|A|`
+lies in the set whose infimum defines `R_C(k)`.  The colored analogue of
+`ramseyNumber_le_of_hasRamseyProperty`. -/
+theorem ramseyNumberColored_le_of_hasRamseyProperty {C : Type*} {A : Finset Point} {k : ℕ}
+    (hA : HasRamseyPropertyColored C A k) : ramseyNumberColored C k ≤ A.card :=
+  Nat.sInf_le ⟨A, rfl, hA⟩
+
+/--
+**Monotonicity of the colored Ramsey number in `k`.**  For a finite palette `C` and
+`3 ≤ k' ≤ k`, `R_C(k') ≤ R_C(k)`: demanding *more* monochromatic collinear points cannot lower
+the threshold.  As in the uncolored `ramseyNumber_mono`, the set defining `R_C(k)` is contained
+in the one defining `R_C(k')` (`hasRamseyPropertyColored_antitone`), and
+`hasRamseyPropertyColored_construction` makes the `k`-set nonempty; its attained infimum is a set
+`A` that a fortiori witnesses `k'`, so `A.card = R_C(k) ∈` the `k'`-set and `Nat.sInf_le` applies.
+Completes the monotonicity picture for `ramseyNumberColored`: monotone both in the palette
+(`ramseyNumberColored_mono_colors`) and in `k`. -/
+theorem ramseyNumberColored_mono {C : Type*} [Finite C] {k k' : ℕ} (hk' : 3 ≤ k') (hkk : k' ≤ k) :
+    ramseyNumberColored C k' ≤ ramseyNumberColored C k := by
+  have hk : 3 ≤ k := le_trans hk' hkk
+  have hne : {n : ℕ | ∃ A : Finset Point, A.card = n ∧ HasRamseyPropertyColored C A k}.Nonempty := by
+    obtain ⟨A, hA⟩ := hasRamseyPropertyColored_construction C k hk
+    exact ⟨A.card, A, rfl, hA⟩
+  obtain ⟨A, hcard, hA⟩ := Nat.sInf_mem hne
+  refine Nat.sInf_le ⟨A, ?_, hasRamseyPropertyColored_antitone hkk hA⟩
+  simpa [ramseyNumberColored] using hcard
+
 /-
 **R(3) is Small:**
 The k = 3 case can be achieved with a small set of points.

--- a/research/problems/erdos-1090-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1090-incomplete-01/knowledge.md
@@ -220,3 +220,34 @@ UNVERIFIED: Docker infra down this session (containerd `meta.db input/output err
 build, before any Lean elaboration — operator-level outage, not a proof error). Remaining
 next-steps unchanged: NUMERIC upper bound on R(k)/R_C(k) (Hales–Jewett dimension non-explicit),
 SylvesterGallai placeholder def, projection-body dedup.
+
+## Session 2026-07-09 (researcher-9): colored Ramsey k-monotonicity (completes monotonicity)
+
+**Mode**: ACT (look-outward on SOLVED, 0-axiom). **Outcome**: progress, 0-axiom/0-sorry.
+The colored API had palette-monotonicity (`ramseyNumberColored_mono_colors`/`_mono_fin`/`_congr`)
+but NO monotonicity in `k` for the colored number — a genuine asymmetry vs the Bool API (which
+has `ramseyNumber_mono`). Filled it with 4 colored copies of already-VERIFIED uncolored siblings:
+- `hasRamseyPropertyColored_mono {A⊆B}` — colored copy of `hasRamseyProperty_mono`.
+- `hasRamseyPropertyColored_antitone {k'≤k}` — colored copy of `hasRamseyProperty_antitone`
+  (same `⟨hSk,hline⟩` IsKCollinear destructure, `le_trans hk hSk`).
+- `ramseyNumberColored_le_of_hasRamseyProperty` — colored copy of
+  `ramseyNumber_le_of_hasRamseyProperty` (`Nat.sInf_le ⟨A,rfl,hA⟩`).
+- `ramseyNumberColored_mono [Finite C] (3≤k') (k'≤k) : R_C(k')≤R_C(k)` — exact mirror of
+  `ramseyNumber_mono`: `hasRamseyPropertyColored_construction` makes the k-set nonempty
+  (`Nat.sInf_mem`), antitone transfers the witness to k', `Nat.sInf_le` + `simpa`. Completes the
+  monotonicity picture (R_C monotone in BOTH palette and k).
+
+File 1073→1123 lines, 33→37 theorems (defs 20 unchanged), 0 sorry / 0 axiom. Proofs are
+near-verbatim colored copies of VERIFIED uncolored siblings using colored infrastructure already
+exercised by verified colored theorems — high confidence.
+
+**BUILD UNVERIFIED**: Docker infra down (containerd `meta.db input/output error` at IMAGE build,
+before any Lean elaboration — operator-level outage #35184, disk healthy 153Gi avail, deterministic
+across 2 attempts, not self-fixable). Gallery `erdos-1090/meta.json` line/thm synced in BOTH .meta
+(was stale 1045/31) and .leanFile (1073/33) blocks → both now 1123/37.
+
+Remaining next-steps unchanged: `SylvesterGallai` still a placeholder DEF (full Sylvester-Gallai
+not in Mathlib); quantitative NUMERIC upper bound on R(k)/R_C(k) (HJ dimension non-explicit);
+projection-body dedup (3 copies). Possible clean follow-up: colored padding/realizable-card-iff
+(`exists_hasRamseyPropertyColored_card_eq` + `_realizable_card_iff`), mirroring the Bool chain
+via the same Infinite Point instance.

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -74,9 +74,9 @@
       "ramseyNumberColored_mono_colors (0-axiom): palette monotonicity — if C ↪ C' then R_C(k) ≤ R_{C'}(k); more colors cannot lower the threshold. Proved via hasRamseyPropertyColored_of_embedding (a C-coloring pushes forward along e, and injectivity of e pulls monochromaticity back). ramseyNumberColored_congr gives recoloring invariance (C ≃ C' ⟹ equal), ramseyNumberColored_mono_fin the monotone chain R_{Fin r} ≤ R_{Fin r'} for r ≤ r', and ramseyNumber_le_ramseyNumberColored_fin the bound R(k) ≤ R_{Fin r}(k) for r ≥ 2 (via finTwoEquiv)"
     ],
     "axiomCount": 0,
-    "lineCount": 1045,
+    "lineCount": 1123,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 31,
+    "theoremCount": 37,
     "definitionCount": 20
   },
   "overview": {
@@ -113,9 +113,9 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 1073,
+    "lineCount": 1123,
     "axiomCount": 0,
-    "theoremCount": 33,
+    "theoremCount": 37,
     "definitionCount": 20,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #1090 (monochromatic collinear points) is a **SOLVED, 0-axiom / 0-sorry** gallery entry. Its colored Ramsey API previously had **palette-monotonicity** (`ramseyNumberColored_mono_colors`/`_mono_fin`/`_congr`) but **no monotonicity in `k`** — an asymmetry versus the Bool API, which has `ramseyNumber_mono`. This PR closes that gap.

## New theorems (4, all 0-axiom / 0-sorry)

- `hasRamseyPropertyColored_mono` — enlarging the set (`A ⊆ B`) preserves the colored Ramsey property. Colored copy of `hasRamseyProperty_mono`.
- `hasRamseyPropertyColored_antitone` — antitone in `k` (`k' ≤ k`). Colored copy of `hasRamseyProperty_antitone`.
- `ramseyNumberColored_le_of_hasRamseyProperty` — upper bound from any witness (`R_C(k) ≤ |A|`). Colored copy of `ramseyNumber_le_of_hasRamseyProperty`.
- `ramseyNumberColored_mono` — **`3 ≤ k' ≤ k ⟹ R_C(k') ≤ R_C(k)`**. Exact mirror of `ramseyNumber_mono`: `hasRamseyPropertyColored_construction` makes the `k`-set nonempty, `hasRamseyPropertyColored_antitone` transfers the attained infimum witness to `k'`, `Nat.sInf_le` closes it.

With this, `ramseyNumberColored C k` is monotone in **both** the palette and `k`.

## Confidence

Each addition is a near-verbatim colored copy of an already-**verified** uncolored sibling, built on colored infrastructure already exercised by verified colored theorems (`hasRamseyPropertyColored_construction`, the `IsKCollinear` destructure). File 1073→1123 lines, 33→37 theorems, defs unchanged. Gallery meta synced in both `.meta` and `.leanFile` blocks.

## Verification

⚠️ **UNVERIFIED** — Docker infra down this session (containerd `meta.db input/output error` at image build, before any Lean elaboration; operator-level outage, disk healthy 153 GiB free, deterministic across attempts — not self-fixable). Please rebuild `Proofs.Erdos1090Problem` once infra is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)