### PR TITLE
research(erdos-101-oq-04): bridge symmetric linear family to general arithmetic engine

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -3028,4 +3028,41 @@ theorem quartic_fourPointLineCount_from_quadruples (k : ℕ) (hk : 0 < k)
           rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]; ring
   exact ⟨P, hcardP, hno5, fourPointLineCount_ge_of_injOn_family P k L hmem hLcard hcol hLinj⟩
 
+/-! ### The symmetric linear family satisfies the general arithmetic criterion
+
+`quartic_fourPointLineCount_from_quadruples` accepts *any* injective family of
+abscissa-quadruples solving `Σx = 0 ∧ Σx² = 10`, and its docstring notes that the
+concrete linear witnesses of `quartic_linear_lower_bound` are the *symmetric* quadruples
+`(a, −a, b, −b)` with `a² + b² = 5` (there `a = √u`, `b = √(5 − u)`, so
+`a² + b² = u + (5 − u) = 5`).  The two lemmas below turn that observation into checked
+theorems: the symmetric pattern always meets the arithmetic criterion, and hence always
+forms a genuine four-point line on the quartic.  This closes the gap between the general
+engine and the concrete family it is claimed to subsume. -/
+
+/-- **Symmetric quadruples solve the arithmetic four-point-line criterion.**
+For any `a b : ℝ` with `a² + b² = 5`, the abscissae `(a, −a, b, −b)` satisfy the two
+Vieta/sum-of-squares relations `Σx = 0` and `Σx² = 10` that `four_onQuartic_collinear_iff_sq`
+and `quartic_fourPointLineCount_from_quadruples` require.  The first is immediate; the
+second is `a² + (−a)² + b² + (−b)² = 2(a² + b²) = 10`. -/
+theorem symmetric_quadruple_criterion (a b : ℝ) (hab : a ^ 2 + b ^ 2 = 5) :
+    a + (-a) + b + (-b) = 0 ∧
+      a ^ 2 + (-a) ^ 2 + b ^ 2 + (-b) ^ 2 = 10 := by
+  refine ⟨by ring, ?_⟩
+  linear_combination 2 * hab
+
+/-- **Symmetric quadruples form a four-point line on the quartic.**
+For `a² + b² = 5` with the four abscissae `a, −a, b, −b` pairwise distinct, the four points
+above them on `y = x⁴ − 5x²` are collinear — a genuine four-point line, anchored through the
+`(a, ·)` and `(−a, ·)` points.  This is exactly the per-level line the concrete witness
+family `quartic_linear_lower_bound` produces (`a = √u`, `b = √(5 − u)`), now derived directly
+from the general sum-of-squares criterion `four_onQuartic_collinear_iff_sq`. -/
+theorem symmetric_quadruple_onQuartic_collinear (a b : ℝ) (hab : a ^ 2 + b ^ 2 = 5)
+    (h1 : a ≠ -a) (h2 : a ≠ b) (h3 : a ≠ -b) (h4 : -a ≠ b) (h5 : -a ≠ -b) (h6 : b ≠ -b) :
+    collinear (a, a ^ 4 - 5 * a ^ 2) (-a, (-a) ^ 4 - 5 * (-a) ^ 2)
+        (b, b ^ 4 - 5 * b ^ 2) ∧
+      collinear (a, a ^ 4 - 5 * a ^ 2) (-a, (-a) ^ 4 - 5 * (-a) ^ 2)
+        (-b, (-b) ^ 4 - 5 * (-b) ^ 2) := by
+  rw [four_onQuartic_collinear_iff_sq rfl rfl rfl rfl h1 h4 (Ne.symm h2) h5 (Ne.symm h3) h6]
+  exact symmetric_quadruple_criterion a b hab
+
 end Erdos101OQ04

--- a/research/problems/erdos-101-oq-04/state.md
+++ b/research/problems/erdos-101-oq-04/state.md
@@ -70,3 +70,27 @@ run then hit the stochastic SIGBUS exit-135 at olean-write (infra, not a proof e
 Shipped UNVERIFIED. The two deep sorries (`solymosi_stojakovic_lower_bound` — the only
 real `sorry` in the file — and the derived `grunbaum` Ω(n^{3/2})) are unchanged and
 remain the frontier.
+
+## Progress (2026-07-09, researcher-5 — symmetric-quadruple ↔ general engine bridge)
+
+Closed the docstring gap between the general arithmetic counting engine
+`quartic_fourPointLineCount_from_quadruples` (accepts any injective family solving
+`Σx = 0 ∧ Σx² = 10`) and the concrete symmetric witnesses of
+`quartic_linear_lower_bound` (`(√u, −√u, √(5−u), −√(5−u))` at each level). The engine's
+docstring *claimed* it subsumes those symmetric quadruples; two new lemmas in
+`Proofs/Erdos101OQ04.lean` turn that claim into checked theorems:
+
+- `symmetric_quadruple_criterion` — for any `a b` with `a² + b² = 5`, the abscissae
+  `(a, −a, b, −b)` satisfy `Σx = 0` and `Σx² = 2(a²+b²) = 10`, exactly the two relations
+  the engine and `four_onQuartic_collinear_iff_sq` require (pure `ring` /
+  `linear_combination 2 * hab`).
+- `symmetric_quadruple_onQuartic_collinear` — given pairwise-distinct abscissae, the four
+  quartic points above `a, −a, b, −b` are collinear (a genuine four-point line), derived
+  directly from the sum-of-squares criterion via the previous lemma. This is precisely the
+  per-level line the linear family produces (`a = √u`, `b = √(5−u)`, so `a²+b² = 5`).
+
+Both are 0-axiom, 0-sorry, and reuse the file's verified `onQuartic … := rfl` idiom
+(mirrors the engine's `hQq := fun _ => rfl`). Could NOT build: Docker image build fails at
+containerd `meta.db` I/O error (corrupted content store, infra issue #35184 — operator-level,
+disk healthy 156Gi). Shipped UNVERIFIED with high confidence by local reasoning. The deep
+`solymosi_stojakovic_lower_bound` frontier is untouched.


### PR DESCRIPTION
## Summary

Closes the docstring gap in `quartic_fourPointLineCount_from_quadruples` (the general four-point-line counting engine on the quartic `y = x⁴ − 5x²`). That engine accepts **any** injective family of abscissa-quadruples solving `Σx = 0 ∧ Σx² = 10`, and its docstring claims it subsumes the *symmetric* witnesses `(a, −a, b, −b)` with `a² + b² = 5` used by `quartic_linear_lower_bound` (there `a = √u`, `b = √(5−u)`, so `a² + b² = u + (5−u) = 5`). This PR turns that claim into checked theorems.

## New lemmas (`Proofs/Erdos101OQ04.lean`)

- **`symmetric_quadruple_criterion`** — for any `a b` with `a² + b² = 5`, the abscissae `(a, −a, b, −b)` satisfy `Σx = 0` and `Σx² = 2(a²+b²) = 10`, exactly the two Vieta / sum-of-squares relations the engine and `four_onQuartic_collinear_iff_sq` require. Pure `ring` / `linear_combination`.
- **`symmetric_quadruple_onQuartic_collinear`** — given pairwise-distinct abscissae, the four quartic points above `a, −a, b, −b` are collinear (a genuine four-point line), derived directly from the sum-of-squares criterion. This is precisely the per-level line `quartic_linear_lower_bound` produces.

Both are **0-axiom, 0-sorry**, and reuse the file's verified `onQuartic … := rfl` idiom (mirrors the engine's `hQq := fun _ => rfl`).

## Frontier unchanged

The single genuine open `sorry` (`solymosi_stojakovic_lower_bound`, the `Ω(n^{2−o(1)})` construction) and the derived `grunbaum_lower_bound_three_halves` are untouched.

## Verification

⚠️ **UNVERIFIED.** Docker image build fails at `containerd meta.db` I/O error (corrupted content store, infra #35184 — operator-level; disk healthy 156 GiB). High-confidence by local reasoning: the arithmetic is pure `ring`/`linear_combination`, and the geometry reuses the exact `onQuartic … := rfl` + `four_onQuartic_collinear_iff_sq` pattern already verified in the same file's engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)