### PR TITLE
research(szemeredi-regularity-oq-01): eps≥1 trivial-regularity threshold

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ01.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ01.lean
@@ -383,4 +383,41 @@ theorem card_irregularOrderedPairs_eq_zero_of_card_le_one
   rw [hz] at hle
   exact Nat.le_zero.mp hle
 
+/-- **Every pair is ε-regular once `eps ≥ 1`.**  The density gap between any two
+    sub-densities is at most `1` (both edge densities lie in `[0, 1]`, so their
+    difference is in `[-1, 1]`), which is `≤ eps` as soon as `1 ≤ eps`.  Thus `eps = 1`
+    is the trivial-regularity threshold: at or above it the ε-regularity condition
+    imposes no constraint at all.  This is the large-parameter extreme complementing
+    `isEpsilonRegular_mono` (regularity only weakens as `eps` grows). -/
+theorem isEpsilonRegular_of_one_le (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 1 ≤ eps) (A B : Finset V) :
+    IsEpsilonRegular G eps A B := by
+  intro A' B' _ _ _ _
+  have h1 := edgeDensity_mem_Icc G A' B'
+  have h2 := edgeDensity_mem_Icc G A B
+  rw [Set.mem_Icc] at h1 h2
+  rw [abs_le]
+  exact ⟨by linarith [h1.1, h2.2], by linarith [h1.2, h2.1]⟩
+
+/-- **No irregular pairs once `eps ≥ 1`.**  Since every pair is ε-regular at `eps ≥ 1`
+    (`isEpsilonRegular_of_one_le`), the ordered irregular set is empty for any partition.
+    The high-`eps` counterpart of `card_irregularOrderedPairs_eq_zero_of_card_le_one`
+    (which is the few-parts extreme): the irregular count vanishes at *both* ends of the
+    regularity regime. -/
+theorem irregularOrderedPairs_eq_empty_of_one_le (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 1 ≤ eps) (parts : Finset (Finset V)) :
+    irregularOrderedPairs G eps parts = ∅ := by
+  rw [Finset.eq_empty_iff_forall_not_mem]
+  rintro x hx
+  simp only [irregularOrderedPairs, Finset.mem_filter, Finset.mem_product] at hx
+  exact hx.2.2 (isEpsilonRegular_of_one_le G heps x.1 x.2)
+
+/-- **The irregular-pair count vanishes for `eps ≥ 1`.**  Cardinality form of
+    `irregularOrderedPairs_eq_empty_of_one_le`: at or above the trivial threshold the
+    `IsRegularPartition` irregular-count bound is satisfied vacuously by every partition. -/
+theorem card_irregularOrderedPairs_eq_zero_of_one_le (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 1 ≤ eps) (parts : Finset (Finset V)) :
+    (irregularOrderedPairs G eps parts).card = 0 := by
+  rw [irregularOrderedPairs_eq_empty_of_one_le G heps parts, Finset.card_empty]
+
 end Szemeredi.Regularity.OQ01

--- a/research/problems/szemeredi-regularity-oq-01/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-01/knowledge.md
@@ -1,0 +1,32 @@
+# szemeredi-regularity-oq-01 — knowledge
+
+## Problem
+Szemerédi Regularity OQ-01: symmetry/complement/monotonicity structure of the gallery's
+`edgeDensity` and `IsEpsilonRegular` (file `Proofs/SzemerediRegularityOQ01.lean`, imports
+`Proofs.SzemerediRegularity` → `Szemeredi.Core`). Graduated/COMPLETED entry, 0-axiom/0-sorry.
+No dedicated gallery `src/data/proofs/` dir (research-layer; base slug = `szemeredi-regularity`).
+
+Key defs (in `SzemerediCore.lean`): `edgeDensity G A B : ℚ` (= |E(A,B)|/(|A||B|), 0 if degenerate);
+`IsEpsilonRegular G eps A B := ∀ A'⊆A B'⊆B, |A'|≥eps|A| → |B'|≥eps|B| → |d(A',B')−d(A,B)| ≤ eps`.
+Useful in-file lemmas: `edgeDensity_comm`, `edgeDensity_mem_Icc` (∈ Set.Icc 0 1),
+`edgeDensity_compl` (disjoint nonempty: d_Gᶜ = 1−d_G), `isEpsilonRegular_mono` (eps grows ⟹ weaker),
+`irregularOrderedPairs` (filter of parts×parts), `even_card_irregularOrderedPairs` (Prod.swap FPF
+involution), `card_irregularOrderedPairs_eq_zero_of_card_le_one` (few-parts extreme).
+
+## Session 2026-07-09 (researcher-9): eps≥1 trivial-regularity threshold
+**Mode**: ACT (look-outward, saturated 0-axiom file). **Outcome**: progress, 0-axiom/0-sorry.
+Added the LARGE-eps extreme (complement of the existing few-parts extreme):
+- `isEpsilonRegular_of_one_le (1≤eps) : IsEpsilonRegular G eps A B` for ALL A,B — density gap of
+  two values in [0,1] is ≤1≤eps. Proof: `intro A' B' _ _ _ _; edgeDensity_mem_Icc ×2; Set.mem_Icc;
+  rw[abs_le]; ⟨linarith[h1.1,h2.2], linarith[h1.2,h2.1]⟩`.
+- `irregularOrderedPairs_eq_empty_of_one_le` (Finset.eq_empty_iff_forall_not_mem + simp-destructure
+  copied from irregularOrderedPairs_subset_offDiag).
+- `card_irregularOrderedPairs_eq_zero_of_one_le`.
+So irregular count provably vanishes at BOTH ends (few-parts AND eps≥1). File 386→426 L, +3 thm.
+PR #36999. UNVERIFIED (docker containerd meta.db I/O error at image build, operator outage, disk
+healthy, deterministic — not self-fixable). No gallery meta to sync (research-layer file).
+
+## Next / open
+- Monotonicity of `irregularOrderedPairs` in `parts` under ⊆ (clean: filter+product subset).
+- Unordered irregular-pair count = card/2 (needs a Sym2/quotient def; refines evenness).
+- Lift `card_irregularOrderedPairs_compl`/threshold-invariance to the `IsRegularPartition` Prop.


### PR DESCRIPTION
## Summary

The OQ-01 regularity file (`SzemerediRegularityOQ01.lean`) develops edge-density symmetry, complement transfer, and monotonicity in the parameter `eps`, and pins the irregular-pair count at the **few-parts** extreme (`card_irregularOrderedPairs_eq_zero_of_card_le_one`). It was missing the **large-`eps`** extreme. This PR supplies it.

## New theorems (3, 0-axiom / 0-sorry)

- `isEpsilonRegular_of_one_le` — **`1 ≤ eps ⟹ IsEpsilonRegular G eps A B`** for *every* pair. The density gap between any two sub-densities is at most `1` (both edge densities lie in `[0,1]`, so their difference is in `[-1,1]`), which is `≤ eps` once `1 ≤ eps`. Thus `eps = 1` is the trivial-regularity threshold — at or above it the ε-regularity condition imposes no constraint.
- `irregularOrderedPairs_eq_empty_of_one_le` — the ordered irregular set is empty for `eps ≥ 1`.
- `card_irregularOrderedPairs_eq_zero_of_one_le` — its count is `0`, so the `IsRegularPartition` irregular-count bound holds vacuously.

Together with the existing few-parts result, the irregular count now provably vanishes at **both** ends of the regularity regime, complementing `isEpsilonRegular_mono` (regularity only weakens as `eps` grows).

## Confidence

The main lemma is a standard `abs_le` + `linarith` on the already-in-file `edgeDensity_mem_Icc` (density ∈ [0,1]); the membership destructure is copied verbatim from the sibling `irregularOrderedPairs_subset_offDiag`. 0 axioms, 0 sorries.

## Verification

⚠️ **UNVERIFIED** — Docker infra down this session (containerd `meta.db input/output error` at image build, before any Lean elaboration; operator-level outage, disk healthy, deterministic across attempts). Please rebuild `Proofs.SzemerediRegularityOQ01` once infra is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)