### PR TITLE
Enrich sharp k=3 birthday threshold: cross-ref exact-count sibling

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
@@ -128,6 +128,11 @@
       "description": "Sibling: the general-k threshold (k!·d^(k-1)·ln2)^(1/k) with loose ±(k-1) band; for k=3 it recovers the parent's ±2, which this entry sharpens using the k=3-specific centered cube"
     },
     {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01",
+      "relationship": "related",
+      "description": "Complementary exact-count view of the same k=3 problem: it proves the closed form for the number of no-triple seatings, birthdayCount3 n d = Σ_{p≤⌊n/2⌋} C(n,2p)·(2p−1)‼·(d)_{n−p}, for every finite n. Where this entry pins the asymptotic *threshold* (the n at which a triple becomes likely) via the expected-triple balance, that entry gives the exact finite-n count from which the balance heuristic is drawn — the finite-n and d→∞ ends of the k=3 analysis"
+    },
+    {
       "targetId": "birthday-problem",
       "relationship": "extends",
       "description": "The classic k=2 birthday problem (23 people, >50% coincidence) that this whole chain refines: where the classic asks for the first coincidence (two people, threshold ~√(2d·ln2)), this entry extends the question to the first triple coincidence (three people), pinning its sharp threshold at n = (6d²·ln2)^(1/3) + 1 + o(1). Both siblings in this cluster link to the root; this adds the parallel link so the k=3 refinement is reachable from and back to the flagship"


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01` (The Sharp k=3 Birthday Threshold).

**Verification:** Read the Lean source (`Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean`) and confirmed the existing meta.json and annotations are fully accurate — all section line ranges, theorem statements, tactic descriptions (centered cube `n(n-1)(n-2)=(n-1)³-(n-1)`, depressed cubic `m³-m=c³`, `(m-c)²≥0` collapse), and the 0-axiom claim (`#print axioms` reports only propext/Classical.choice/Quot.sound) match the source.

**Change:** Added one substantive crossReference to `birthday-problem-oq-03-oq-01-oq-01-oq-05-oq-01` (the exact closed-form no-triple count for every finite n). It is the complementary finite-n combinatorial view to this entry's d→∞ asymptotic threshold for the same k=3 problem — the exact count is where the expected-triple balance heuristic comes from.

The entry already meets all quality minimums (8 rich annotations, 5 keyInsights, full conclusion, sections covering the file) and stays well under the size caps (15.9 KB, 4/20 crossReferences), so this pass was kept deliberately targeted rather than inflating an already-complete page.