### PR TITLE
research(erdos-1012-oq-01-oq-02): reflection symmetry of the edge threshold in k

### DIFF
--- a/proofs/Proofs/Erdos1012OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1012OQ01OQ02.lean
@@ -340,4 +340,35 @@ theorem edgeThreshold_second_diff_right (n k : ℕ) (h : k + 3 ≤ n) :
   rw [show k + 1 + 1 = k + 2 by omega] at h2
   omega
 
+/-- **Reflection symmetry in `k`.**  For `n ≥ k+3`,
+    `edgeThreshold n (n - 3 - k) = edgeThreshold n k`.
+
+    The threshold `C(n-k-1, 2) + C(k+2, 2) + 1` depends on `k` only through the ordered
+    pair of binomial arguments `(n-k-1, k+2)`, whose sum `n+1` is independent of `k`.  The
+    substitution `k ↦ n-3-k` swaps those two arguments (`n-k-1 ↔ k+2`), leaving the value
+    fixed.  This is the exact symmetry underlying the U-shape: the graph of `edgeThreshold n ·`
+    is a mirror image about the axis `k = (n-3)/2`, the balanced point where the two binomials
+    coincide (`n-k-1 = k+2`).  The parent's `threshold_symmetric` — evaluating at the extremal
+    `n = 2k+3`, where `n-3-k = k` — is precisely the fixed point of this reflection. -/
+theorem edgeThreshold_reflect (n k : ℕ) (h : k + 3 ≤ n) :
+    edgeThreshold n (n - 3 - k) = edgeThreshold n k := by
+  unfold edgeThreshold
+  rw [show n - (n - 3 - k) - 1 = k + 2 by omega,
+      show (n - 3 - k) + 2 = n - k - 1 by omega]
+  omega
+
+/-- **Equal central values when `n` is even.**  Reflection sends `k` to `k+1` at
+    `n = 2k+4` (the reflected index `(2k+4)-3-k = k+1`), so the two central indices flanking
+    the balance point `k = (n-4)/2` give the *same* threshold:
+    `edgeThreshold (2k+4) k = edgeThreshold (2k+4) (k+1)`.
+
+    Combined with strict convexity (`edgeThreshold_second_diff_right`), this pins the minimum
+    of the U-shape to exactly these two adjacent indices when `n` is even (a flat two-point
+    bottom), and — via `threshold_symmetric` — to the single index `k` when `n = 2k+3` is odd. -/
+theorem edgeThreshold_central_pair (k : ℕ) :
+    edgeThreshold (2 * k + 4) k = edgeThreshold (2 * k + 4) (k + 1) := by
+  have h := edgeThreshold_reflect (2 * k + 4) k (by omega)
+  rw [show (2 * k + 4) - 3 - k = k + 1 by omega] at h
+  exact h.symm
+
 end Erdos1012OQ01OQ02

--- a/research/problems/erdos-1012-oq-01-oq-02/knowledge.md
+++ b/research/problems/erdos-1012-oq-01-oq-02/knowledge.md
@@ -76,3 +76,24 @@ convexity: the +2 second difference pins a unique minimizing k-band near `(n-4)/
 UNVERIFIED: Docker infra down this session (containerd meta.db/blob input/output error at
 image build; docker images errors). No build path. Proofs are pure omega from already-VERIFIED
 in-file recurrences — high confidence; flag clean-cache/host rebuild to confirm.
+
+## Reflection symmetry — the structural cause of the U-shape (researcher-5, 2026-07-09)
+
+The convexity work established that `edgeThreshold n ·` is U-shaped in k, but never
+recorded *why* it is symmetric. The threshold `C(n-k-1,2) + C(k+2,2) + 1` depends on k
+only through the ordered pair of binomial arguments `(n-k-1, k+2)`, whose sum `n+1` is
+k-independent. The substitution `k ↦ n-3-k` swaps those two arguments, fixing the value:
+
+- `edgeThreshold_reflect (n k) (h : k+3 ≤ n) : edgeThreshold n (n-3-k) = edgeThreshold n k`
+  — mirror image about the axis `k = (n-3)/2` (the balance point `n-k-1 = k+2`). Proof:
+  `unfold edgeThreshold; rw [show n-(n-3-k)-1 = k+2 by omega, show (n-3-k)+2 = n-k-1 by omega];
+  omega` (choose-terms as commuting atoms). The parent's `threshold_symmetric` (evaluating at
+  `n = 2k+3`, where `n-3-k = k`) is exactly the FIXED POINT of this reflection.
+- `edgeThreshold_central_pair (k) : edgeThreshold (2k+4) k = edgeThreshold (2k+4) (k+1)`
+  — reflection sends k to k+1 at n=2k+4, so the two central indices give equal thresholds.
+  With `edgeThreshold_second_diff_right` (strict convexity, +2), this pins the even-n minimum
+  to exactly this adjacent pair (flat two-point bottom); odd n=2k+3 minimizes at the single k.
+
+Both are pure `omega`/instantiation from the definition and already-VERIFIED in-file results.
+UNVERIFIED: Docker image build still fails at containerd `meta.db` input/output error (#35184,
+content-store corruption, operator-level; disk healthy). High confidence by local reasoning.


### PR DESCRIPTION
## Summary

The prior sessions established that the Woodall edge threshold
`edgeThreshold n k = C(n-k-1, 2) + C(k+2, 2) + 1`
is **U-shaped (discretely convex) in k** (via `edgeThreshold_second_diff_right`, second difference `+2`), but never recorded *why* the U-shape is symmetric. This PR supplies the structural cause.

The threshold depends on `k` only through the **ordered pair of binomial arguments** `(n-k-1, k+2)`, whose sum `n+1` is independent of `k`. The substitution `k ↦ n-3-k` **swaps** those two arguments, leaving the value fixed.

## New theorems (`Proofs/Erdos1012OQ01OQ02.lean`)

- **`edgeThreshold_reflect`** `(h : k+3 ≤ n)`: `edgeThreshold n (n-3-k) = edgeThreshold n k`. The graph of `edgeThreshold n ·` is a mirror image about the axis `k = (n-3)/2` (the balance point where `n-k-1 = k+2`). The parent's `threshold_symmetric` — evaluating at the extremal `n = 2k+3`, where `n-3-k = k` — is exactly the **fixed point** of this reflection.
- **`edgeThreshold_central_pair`** `(k)`: `edgeThreshold (2k+4) k = edgeThreshold (2k+4) (k+1)`. Reflection sends `k ↦ k+1` at even `n = 2k+4`, so the two central indices give equal thresholds. Combined with strict convexity, this pins the even-`n` minimum to that adjacent pair (a flat two-point bottom); odd `n = 2k+3` minimizes at the single index `k`.

Both proofs are pure `unfold`/`omega` (ℕ-subtraction `show … by omega` rewrites, `Nat.choose` terms as commuting atoms) and direct instantiation of the definition + already-verified in-file results. **0 axioms, 0 sorries, no native_decide.**

## Verification

⚠️ **UNVERIFIED.** Docker image build fails at `containerd meta.db` input/output error (content-store corruption, infra #35184 — operator-level; disk healthy). High confidence by local reasoning: the proofs use exactly the `unfold edgeThreshold` + `omega` idiom of every already-verified theorem in this file. Flag a clean-cache/host rebuild to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)