### PR TITLE
Fix: sync stale lineCount for cauchy-interlacing-oq-01-oq-02

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -12,7 +12,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
-    "lineCount": 1281,
+    "lineCount": 1355,
     "theoremCount": 40,
     "definitionCount": 0,
     "difficulty": "advanced",
@@ -62,7 +62,7 @@
       "CauchyInterlacing.Poincare"
     ],
     "namespace": "CauchyInterlacing.PoincareCompression",
-    "lineCount": 1281,
+    "lineCount": 1355,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `cauchy-interlacing-theorem-oq-01-oq-02/meta.json` (both `meta.lineCount` and `leanFile.lineCount`) to match the actual Lean source.

## Evidence

**Before**: `lineCount: 1281`
**After**: `lineCount: 1355` (actual `wc -l` of `Proofs/CauchyInterlacingPoincareCompression.lean`)

The source file grew via subsequent research PRs (#36909, algebraically-closed corollaries) without a corresponding meta resync. Single primary file, no `additionalFiles`, so `lineCount` = primary `wc -l`. Only the line count changed; `theoremCount` and other fields left untouched (scope discipline).

---
Automated fix by lean-mechanic agent.