### PR TITLE
Enrich exact gcd(Fₙ,Lₙ) entry: add classical references

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -142,5 +142,34 @@
       "relationship": "sibling — completes the degree-2 Fibonacci–Lucas relations (sum-of-squares and cross identity); its second open question explicitly asks for the exact gcd value proved here"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Thomas Koshy"
+      ],
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience, New York",
+      "note": "Comprehensive reference for Fibonacci–Lucas identities; treats the same-index relationship of Fₙ and Lₙ, their near-coprimality (gcd ∈ {1,2}), and the divisibility 2 = F₃ ∣ Fₙ ⟺ 3 ∣ n underlying the parity criterion used here."
+    },
+    {
+      "authors": [
+        "Steven Vajda"
+      ],
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood, Chichester (Dover reprint 2008)",
+      "note": "Catalogue of Fibonacci–Lucas relations, including the quadratic identity Lₙ² − 5Fₙ² = 4(−1)ⁿ from which the parent's gcd(Fₙ, Lₙ) ∣ 2 bound is derived."
+    },
+    {
+      "authors": [
+        "Nikolai N. Vorobiev"
+      ],
+      "title": "Fibonacci Numbers",
+      "year": "2002",
+      "venue": "Birkhäuser, Basel (translation of the 1951 Russian original)",
+      "note": "Classic treatment of Fibonacci divisibility: gcd(Fₘ, Fₙ) = F_{gcd(m,n)}, which specializes to 2 = F₃ ∣ Fₙ ⟺ 3 ∣ n, the Fibonacci parity fact this entry formalizes (Mathlib lacks it)."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-02-oq-01-oq-01-oq-01` (The Exact gcd(Fₙ, Lₙ)).

This verified entry was otherwise fully enriched (quality 95, rich annotations/insights/sections) but had **no `references` array** — the productive REFS0 defect class in a saturated gallery. Added three accurate, well-known classical sources for the Fibonacci–Lucas gcd/parity results the entry formalizes:

- **Koshy**, *Fibonacci and Lucas Numbers with Applications* (Wiley, 2001) — standard reference; covers same-index near-coprimality and 2 = F₃ ∣ Fₙ ⟺ 3 ∣ n.
- **Vajda**, *Fibonacci and Lucas Numbers, and the Golden Section* (Ellis Horwood, 1989) — source of the identity Lₙ² − 5Fₙ² = 4(−1)ⁿ behind the parent's gcd ∣ 2 bound.
- **Vorobiev**, *Fibonacci Numbers* (Birkhäuser, 2002 / orig. 1951) — classic divisibility result gcd(Fₘ, Fₙ) = F_gcd(m,n), specializing to the parity fact this entry supplies.

meta.json is 13.8 KB (well under caps); no other fields changed. JSON validated; gallery data-build checks pass.