### PR TITLE
research(tetrahedral-number-formula-oq-01): central simplex-number doubling recurrence

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean
@@ -64,4 +64,22 @@ theorem simplexNumber_diag (d : ℕ) : simplexNumber d d = (2 * d).choose d := b
   unfold simplexNumber
   rw [two_mul]
 
+/-- **Central simplex-number doubling recurrence.**  Along the diagonal `d = n` the
+figurate number is the central binomial coefficient `P_d(d) = C(2d, d)`
+(`simplexNumber_diag`), and successive diagonal entries obey the central binomial
+recurrence
+
+`(d+1) · P_{d+1}(d+1) = 2·(2d+1) · P_d(d)`.
+
+Equivalently `P_{d+1}(d+1)/P_d(d) = 2(2d+1)/(d+1)`, the exact growth ratio of the
+central binomials `C(2d,d)` (which underlies their `4^d/√(πd)` asymptotics and the
+Catalan numbers `C(2d,d)/(d+1)`). Immediate from Mathlib's
+`Nat.succ_mul_centralBinom_succ` once `simplexNumber_diag` identifies the diagonal with
+`Nat.centralBinom`. This is the diagonal companion of the off-diagonal absorption
+recurrences `simplexNumber_absorption` / `simplexNumber_size_absorption`. -/
+theorem simplexNumber_diag_succ (d : ℕ) :
+    (d + 1) * simplexNumber (d + 1) (d + 1) = 2 * (2 * d + 1) * simplexNumber d d := by
+  rw [simplexNumber_diag (d + 1), simplexNumber_diag d]
+  exact Nat.succ_mul_centralBinom_succ d
+
 end TetrahedralNumberFormulaOQ01


### PR DESCRIPTION
## Summary

Adds `simplexNumber_diag_succ` to `proofs/Proofs/TetrahedralNumberFormulaOQ01Absorption.lean`:

**`(d+1)·P_{d+1}(d+1) = 2·(2d+1)·P_d(d)`** — the central-binomial doubling recurrence along the diagonal `d = n` of Pascal's simplex.

### Why it matters

The companion already has `simplexNumber_diag` (`P_d(d) = C(2d,d)`, the central binomial coefficient) but no *recurrence* relating successive diagonal entries. This supplies it: the diagonal grows by the exact ratio `P_{d+1}(d+1)/P_d(d) = 2(2d+1)/(d+1)` — the growth law of the central binomials `C(2d,d)` that underlies their `4^d/√(πd)` asymptotics and the Catalan numbers `C(2d,d)/(d+1)`. It is the **diagonal companion** of the off-diagonal absorption recurrences `simplexNumber_absorption` / `simplexNumber_size_absorption` already in the file.

### Proof

Immediate from Mathlib's `Nat.succ_mul_centralBinom_succ` once `simplexNumber_diag` identifies the diagonal entry with `Nat.centralBinom` (`centralBinom n := (2*n).choose n`, definitionally equal). 0 axioms / 0 sorries.

### Verification status: UNVERIFIED (infra)

Docker build could not run: containerd `meta.db` input/output error (Docker infra down at operator level this session; host disk healthy). Static check: `simplexNumber_diag (d+1)` / `simplexNumber_diag d` rewrite both sides to `(2·_).choose _`, which are defeq to `Nat.centralBinom`, so `exact Nat.succ_mul_centralBinom_succ d` closes the goal. Recommend a green docker build once infra recovers.

Note: distinct from open PR #36580 (Vandermonde convolution of simplex kernels) — that adds `simplex_vandermonde`; this adds the diagonal central-binomial recurrence.