### PR TITLE
Enrich Neumann-series perturbed-unit entry: add classical references

### DIFF
--- a/src/data/proofs/geometric-series-oq-02-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-03-oq-01-oq-03/meta.json
@@ -129,5 +129,34 @@
       "summary": "Tabulates the results, notes that x = 1 collapses each to the parent Neumann-series entry, and situates local continuity as the source of the openness of the unit group and the holomorphy of the resolvent (λ − T)⁻¹."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Walter Rudin"
+      ],
+      "title": "Functional Analysis",
+      "year": "1991",
+      "venue": "McGraw-Hill, 2nd ed.",
+      "note": "Standard treatment of Banach algebras: the Neumann series for (1 − s)⁻¹ when ‖s‖ < 1, invertibility in a unital normed ring, and the resolvent — the framework this entry perturbs from the unit 1 to an arbitrary unit x."
+    },
+    {
+      "authors": [
+        "John B. Conway"
+      ],
+      "title": "A Course in Functional Analysis",
+      "year": "1990",
+      "venue": "Springer, Graduate Texts in Mathematics 96, 2nd ed.",
+      "note": "Proves that the group of units of a Banach algebra is open and that inversion is continuous there, using exactly the perturbed-unit factorization x − t = x(1 − x⁻¹t) formalized here."
+    },
+    {
+      "authors": [
+        "Tosio Kato"
+      ],
+      "title": "Perturbation Theory for Linear Operators",
+      "year": "1995",
+      "venue": "Springer, Classics in Mathematics (reprint of the 1980 ed.)",
+      "note": "Develops the analyticity of the resolvent (λ − T)⁻¹ via Neumann-series expansions of perturbed inverses, the setting toward which this entry's local continuity of t ↦ (x − t)⁻¹ points."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-02-oq-03-oq-01-oq-03` (Neumann series for a perturbed unit x − t).

Verified entry, otherwise complete (quality 95), but with **no `references` array** (REFS0 class). Added three standard functional-analysis references matching the Banach-algebra material it formalizes:

- **Rudin**, *Functional Analysis* (McGraw-Hill, 1991) — Neumann series, invertibility in a unital normed ring, the resolvent.
- **Conway**, *A Course in Functional Analysis* (Springer GTM 96, 1990) — openness of the unit group and continuity of inversion, via the exact factorization x − t = x(1 − x⁻¹t) used here.
- **Kato**, *Perturbation Theory for Linear Operators* (Springer, 1995) — resolvent (λ − T)⁻¹ analyticity, the setting the entry's local-continuity result points toward.

meta.json 13.1 KB (well under caps); only the references field added. JSON validated.