### PR TITLE
research(erdos-1110-oq-01): divisibility order on power forms — p^k q^l ∣ p^k' q^l' ↔ k≤k' ∧ l≤l' [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1110OQ01.lean
+++ b/proofs/Proofs/Erdos1110OQ01.lean
@@ -156,4 +156,79 @@ theorem powerFormSubmonoid_le_iff {p q : ℕ} {S : Submonoid ℕ} :
     · exact hp
     · exact hq
 
+/-! ### The divisibility order on power forms (distinct prime bases)
+
+For **distinct primes** `p ≠ q`, the exponent pair `(k, l)` of a power form
+`p^k q^l` is unique (unique factorization), and divisibility of power forms is
+exactly the product order on the exponents:
+
+  `p^k q^l ∣ p^{k'} q^{l'} ↔ k ≤ k' ∧ l ≤ l'`.
+
+Equivalently `(k, l) ↦ p^k q^l` is an order isomorphism from `(ℕ², ≤)` onto the
+power forms under divisibility. This is the structural fact behind #1110's
+central *antichain* hypothesis — "no summand divides another" — since it turns the
+divisibility test on power-form summands into a coordinatewise comparison of
+exponent vectors. The two prime-exponent readouts `factorization_powerForm_left`
+and `factorization_powerForm_right` extract `k` and `l` from `p^k q^l`. -/
+
+/-- **The `p`-adic exponent of a power form.** For distinct primes `p ≠ q`, the
+`p`-factorization of `p^k q^l` is exactly `k` (the `q^l` factor contributes nothing
+at `p`). -/
+theorem factorization_powerForm_left {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (k l : ℕ) : (p ^ k * q ^ l).factorization p = k := by
+  have hp0 : p ^ k ≠ 0 := pow_ne_zero k hp.pos.ne'
+  have hq0 : q ^ l ≠ 0 := pow_ne_zero l hq.pos.ne'
+  rw [Nat.factorization_mul hp0 hq0, Finsupp.add_apply, hp.factorization_pow,
+      hq.factorization_pow, Finsupp.single_eq_same,
+      Finsupp.single_eq_of_ne (Ne.symm hpq), add_zero]
+
+/-- **The `q`-adic exponent of a power form.** For distinct primes `p ≠ q`, the
+`q`-factorization of `p^k q^l` is exactly `l`. -/
+theorem factorization_powerForm_right {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (k l : ℕ) : (p ^ k * q ^ l).factorization q = l := by
+  have hp0 : p ^ k ≠ 0 := pow_ne_zero k hp.pos.ne'
+  have hq0 : q ^ l ≠ 0 := pow_ne_zero l hq.pos.ne'
+  rw [Nat.factorization_mul hp0 hq0, Finsupp.add_apply, hp.factorization_pow,
+      hq.factorization_pow, Finsupp.single_eq_of_ne hpq, Finsupp.single_eq_same,
+      zero_add]
+
+/-- **Divisibility of power forms is the product order on exponents.** For distinct
+primes `p ≠ q`,
+
+  `p^k q^l ∣ p^{k'} q^{l'} ↔ k ≤ k' ∧ l ≤ l'`.
+
+The `←` direction is `mul_dvd_mul` of `pow_dvd_pow`; the `→` direction reads the two
+prime exponents off both sides via `factorization_le_iff_dvd`. -/
+theorem powerForm_dvd_iff {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q)
+    (k l k' l' : ℕ) :
+    p ^ k * q ^ l ∣ p ^ k' * q ^ l' ↔ k ≤ k' ∧ l ≤ l' := by
+  constructor
+  · intro h
+    have hp0 : p ^ k * q ^ l ≠ 0 :=
+      mul_ne_zero (pow_ne_zero k hp.pos.ne') (pow_ne_zero l hq.pos.ne')
+    have hn0 : p ^ k' * q ^ l' ≠ 0 :=
+      mul_ne_zero (pow_ne_zero k' hp.pos.ne') (pow_ne_zero l' hq.pos.ne')
+    have hle := (Nat.factorization_le_iff_dvd hp0 hn0).mpr h
+    rw [Finsupp.le_def] at hle
+    refine ⟨?_, ?_⟩
+    · have hpk := hle p
+      simpa only [factorization_powerForm_left hp hq hpq] using hpk
+    · have hql := hle q
+      simpa only [factorization_powerForm_right hp hq hpq] using hql
+  · rintro ⟨hk, hl⟩
+    exact mul_dvd_mul (pow_dvd_pow p hk) (pow_dvd_pow q hl)
+
+/-- **Unique exponents.** For distinct primes `p ≠ q`, equal power forms have equal
+exponent pairs: `p^k q^l = p^{k'} q^{l'} → k = k' ∧ l = l'`. Hence `(k, l) ↦ p^k q^l`
+is injective, and the power-form submonoid is freely generated (as a commutative
+monoid) by the two bases. -/
+theorem powerForm_exponents_unique {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) {k l k' l' : ℕ} (h : p ^ k * q ^ l = p ^ k' * q ^ l') :
+    k = k' ∧ l = l' := by
+  refine ⟨?_, ?_⟩
+  · have := congrArg (fun n => n.factorization p) h
+    simpa only [factorization_powerForm_left hp hq hpq] using this
+  · have := congrArg (fun n => n.factorization q) h
+    simpa only [factorization_powerForm_right hp hq hpq] using this
+
 end Erdos1110

--- a/research/problems/erdos-1110-oq-01/knowledge.md
+++ b/research/problems/erdos-1110-oq-01/knowledge.md
@@ -89,3 +89,33 @@ counts in the research json (77/6/0 → 159/11/1; was never resynced after the s
 
 **Still open (parent, untouched)**: deep `erdos_lewin_infinite` axiom (coprime {p,q}≠{2,3}
 density / infinitely-many-coprime-non-representables). Not session-sized.
+
+## Session 2026-07-09 (researcher-1) — divisibility order + exponent uniqueness [UNVERIFIED]
+
+Built on the submonoid characterization. For **distinct prime bases** `p ≠ q`
+(the case #1110 cares about), added the divisibility partial order on power forms:
+- `factorization_powerForm_left/right`: `(p^k q^l).factorization p = k`, `… q = l`
+  (via `Nat.factorization_mul` + `Nat.Prime.factorization_pow` = `single p k`,
+  `Finsupp.add_apply`/`single_eq_same`/`single_eq_of_ne`).
+- `powerForm_dvd_iff`: `p^k q^l ∣ p^k' q^l' ↔ k ≤ k' ∧ l ≤ l'`. → via
+  `Nat.factorization_le_iff_dvd` + `Finsupp.le_def` then read exponents; ← via
+  `mul_dvd_mul (pow_dvd_pow p hk) (pow_dvd_pow q hl)`.
+- `powerForm_exponents_unique`: equal power forms ⇒ equal exponent pairs
+  (`congrArg (·.factorization p)` + the readouts).
+
+This is the coordinatewise-comparison backbone of #1110's "no summand divides
+another" antichain condition: `(k,l) ↦ p^k q^l` is an order embedding (ℕ²,≤) ↪ (ℕ,∣).
+
+NOTE: this file (Erdos1110OQ01.lean) picked up concurrent upstream additions
+(self_mem_powerFormSubmonoid_left/right, powerFormSubmonoid_le_iff) — merged
+cleanly. Its problem-json counts were stale (133/8 vs true 159/11 on origin/main);
+refreshed to 234/15 for the merged file.
+
+PARENT still open/untouched: Erdős–Lewin/Yu–Chen density of non-representables
+and infinitude of coprime non-representables for {p,q}≠{2,3}; parent carries
+`axiom erdos_lewin_infinite`. Not session-sized.
+Next OQ-01 self-contained increment: the antichain/incomparability corollary
+(distinct exponent pairs with neither ≤ the other give mutually non-dividing power
+forms) or the order-iso to ℕ² packaged as an `OrderEmbedding`.
+
+PR #37021 (UNVERIFIED — Docker containerd content-store I/O error all session).

--- a/src/data/research/problems/erdos-1110-oq-01.json
+++ b/src/data/research/problems/erdos-1110-oq-01.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/Erdos1110OQ01.lean",
       "filename": "Erdos1110OQ01.lean",
-      "lineCount": 133,
-      "theoremCount": 8,
+      "lineCount": 234,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Advances `erdos-1110-oq-01` (multiplicative structure of the *power forms* `{p^k q^l}` behind Erdős #1110). Prior sessions established that the power forms are exactly `Submonoid.closure {p, q}`. This PR supplies the **divisibility order** and **exponent uniqueness** for *distinct prime bases* `p ≠ q` — the structural fact underlying #1110's central "no summand divides another" (antichain) hypothesis.

| new theorem | statement |
|---|---|
| `factorization_powerForm_left` / `_right` | `(p^k q^l).factorization p = k`, `… q = l` (read exponents off via valuations) |
| `powerForm_dvd_iff` | `p^k q^l ∣ p^{k'} q^{l'} ↔ k ≤ k' ∧ l ≤ l'` |
| `powerForm_exponents_unique` | `p^k q^l = p^{k'} q^{l'} → k = k' ∧ l = l'` (so `(k,l) ↦ p^k q^l` is injective) |

This turns the divisibility test on power-form summands into a coordinatewise comparison of exponent vectors, i.e. `(k,l) ↦ p^k q^l` is an order embedding of `(ℕ², ≤)` into `(ℕ, ∣)`. **+4 theorems, 0 axioms, 0 sorries.**

## Notes for the reviewer

- **Clean merge with concurrent upstream work.** origin/main's copy of this file had picked up `self_mem_powerFormSubmonoid_left/right` and `powerFormSubmonoid_le_iff` from another session; this branch keeps those and adds the divisibility section after them.
- **JSON count refresh.** origin/main's `.lean` is 159 lines / 11 theorems but the problem JSON still read `133 / 8` (a prior PR added theorems without syncing counts). Updated to the true current file (234 / 15 theorems / 1 def / 0 sorries).

## Verification

⚠️ **UNVERIFIED** — Docker infrastructure is down this session: containerd content store returns `input/output error` at the image step (daemon metadata corruption, operator-level; disk healthy at 155 GiB free). No build or single-file elaboration path was available.

Mitigation: every lemma used was grepped and signature-checked against the pinned mathlib in `.lake` — `Nat.factorization_mul`, `Nat.Prime.factorization_pow` (= `single p k`), `Nat.factorization_le_iff_dvd`, `Finsupp.le_def` / `add_apply` / `single_eq_same` / `single_eq_of_ne`, `mul_dvd_mul`, `pow_dvd_pow`. Recommend a green rebuild once Docker is repaired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)