### PR TITLE
Audit: erdos-93 — remove phantom regular_polygon_exact from meta prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17462,10 +17462,10 @@
       "result": "clean"
     },
     "erdos-93": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:13:05Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T05:49:47Z",
+      "result": "issues-fixed"
     },
     "erdos-930": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-93/meta.json
+++ b/src/data/proofs/erdos-93/meta.json
@@ -39,7 +39,6 @@
       "Point, dist, distinctDistances, numDistinctDistances definitions",
       "InConvexPosition axiomatized predicate",
       "altman_theorem: convex n-gon ≥ ⌊n/2⌋ distances",
-      "regular_polygon_exact: tightness of bound",
       "StrongerVariant definition (Problem #982, OPEN)",
       "FishburnConjecture definition and implication",
       "erdos_93_summary proved from axioms"
@@ -68,7 +67,7 @@
     "historicalContext": "Erdős Problem #93 concerns the minimum number of distinct pairwise distances among n points in convex position in the plane. This is one of Erdős's classic problems in discrete geometry, part of a broader program studying how geometric constraints force distance diversity.\n\nAltman proved in 1963 that the vertices of a convex n-gon determine at least ⌊n/2⌋ distinct distances. The bound is tight: the regular n-gon achieves exactly ⌊n/2⌋ distinct distances, since the distance from any vertex to the k-th vertex is 2R sin(kπ/n), giving ⌊n/2⌋ distinct values.\n\nThe result spawned several open variants. Problem #982 asks whether some single vertex must see ⌊n/2⌋ distinct distances (strictly stronger). Fishburn conjectured that Σ R(x) ≥ C(n,2), which would imply the stronger variant by averaging. Szemerédi's Problem #1082 asks whether the same bound holds under the weaker condition of no three collinear points.",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nIf n distinct points in ℝ² form a convex polygon, then they determine at least ⌊n/2⌋ distinct distances.\n\n**Answer**: TRUE — proved by Altman (1963)\n\n**Tightness**: Regular n-gon achieves exactly ⌊n/2⌋:\n- Triangle: 1 distance; Square: 2; Pentagon: 2; Hexagon: 3",
     "text": "The vertices of a convex n-gon determine at least ⌊n/2⌋ distinct distances. Proved by Altman (1963), this is a foundational result in discrete geometry, though stronger variants remain open.",
-    "proofStrategy": "We formalize this by:\n\n1. **Definitions**: Point (ℝ²), dist, distinctDistances, numDistinctDistances\n2. **Convex position**: Axiomatized InConvexPosition predicate\n3. **Main theorem**: altman_theorem axiomatized\n4. **Tightness**: regular_polygon_exact shows bound is best possible\n5. **Open variants**: StrongerVariant (Problem #982) and FishburnConjecture\n6. **Implication**: fishburn_implies_stronger connecting the open conjectures",
+    "proofStrategy": "We formalize this by:\n\n1. **Definitions**: Point (ℝ²), dist, distinctDistances, numDistinctDistances\n2. **Convex position**: Axiomatized InConvexPosition predicate\n3. **Main theorem**: altman_theorem axiomatized\n4. **Tightness (documented)**: the regular n-gon achieves exactly ⌊n/2⌋ distinct distances — a known mathematical fact recorded in the documentation, not separately formalized in Lean\n5. **Open variants**: StrongerVariant (Problem #982) and FishburnConjecture\n6. **Implication**: fishburn_implies_stronger connecting the open conjectures",
     "keyInsights": [
       "Convexity forces angular spread, creating distance diversity among vertices",
       "The regular n-gon is the extremal configuration achieving exactly ⌊n/2⌋ distances",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-93 (issues-fixed)

Re-audited Erdős Problem #93 (Distinct Distances in Convex Polygons), stalest tracker entry from 2026-05-04.

### Issue found: phantom Lean declaration (MEDIUM)
The meta.json referenced a declaration **`regular_polygon_exact`** that does not exist anywhere in `Proofs/Erdos93Problem.lean`. The file's complete declaration list is 1 `abbrev` + 7 `def`s + 3 `axiom`s + 1 `theorem` — no tightness declaration is formalized. The tightness fact (a regular n-gon achieves exactly ⌊n/2⌋ distinct distances) is a true mathematical statement but appears only in prose, not in Lean.

Two phantom references removed/corrected:
- `originalContributions`: dropped the bullet `"regular_polygon_exact: tightness of bound"`.
- `overview.proofStrategy` step 4: reworded from `"regular_polygon_exact shows bound is best possible"` to note tightness is **documented, not separately formalized**.

### Everything else verified CLEAN
| Field | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| lineCount | 146 | 146 | ✓ |
| axiomCount | 3 | 3 (`InConvexPosition`, `altman_theorem`, `fishburn_implies_stronger`) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 1 | 1 (`erdos_93_summary`) | ✓ |
| definitionCount | 8 | 8 | ✓ |

- **status=axiomatized / badge=axiom** correct (Tier C): the main result `altman_theorem` and the `InConvexPosition` predicate are honestly axiomatized and disclosed; `erdos_93_summary` is transparently the conjunction of the two axioms.
- All other named decls in the meta cross-check against the source. No True stubs, no `native_decide`.

*Note (not fixed, source-internal):* the `erdos_93_summary` docstring lists "Regular polygon tightness" as one of three combined items, but the theorem has only two conjuncts (Altman + Fishburn). Cosmetic docstring inaccuracy; left for a source-editing pass.

Only meta.json prose and the audit tracker date are changed.

---
Discovered during periodic gallery integrity audit.