### PR TITLE
research(erdos-101-oq-04): universal counting bounds for kPointLineCount

### DIFF
--- a/proofs/Proofs/Erdos101OQ04OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ04OQ01.lean
@@ -109,4 +109,32 @@ theorem realParabolaSet_threePointLineCount_zero (p : ℕ) [NeZero p]
     kPointLineCount (realParabolaSet p hp) 3 = 0 :=
   realParabolaSet_kPointLineCount_zero p hp (le_refl 3)
 
+/-- **Universal counting upper bound.** A `k`-point line is in particular a
+`k`-element subset of the `n = |P|` points, so there are at most `C(n, k)` of them:
+`kPointLineCount P k ≤ (|P|).choose k`. This is the general-position-free companion of
+the `= 0` lower results above — the collinearity constraint can only *cut down* the
+raw subset count `C(n, k)`, never exceed it. -/
+theorem kPointLineCount_le_choose (P : PlanarPointSet) (k : ℕ) :
+    kPointLineCount P k ≤ P.points.card.choose k := by
+  rw [kPointLineCount, ← Finset.card_powersetCard k P.points]
+  apply Finset.card_le_card
+  intro S hS
+  simp only [Finset.mem_filter, Finset.mem_powerset] at hS
+  rw [Finset.mem_powersetCard]
+  exact ⟨hS.1, hS.2.1⟩
+
+/-- **Vacuity below the point count.** A set with fewer than `k` points cannot carry
+any `k`-point line: `|P| < k ⟹ kPointLineCount P k = 0`. Any witnessing subset `S`
+satisfies `k = |S| ≤ |P| < k`, a contradiction. Together with
+`kPointLineCount_le_choose` this bookends the count: it vanishes past `|P|` and never
+exceeds `C(|P|, k)`. -/
+theorem kPointLineCount_eq_zero_of_card_lt (P : PlanarPointSet) {k : ℕ}
+    (hk : P.points.card < k) : kPointLineCount P k = 0 := by
+  rw [kPointLineCount, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  intro S hS
+  simp only [Finset.mem_powerset] at hS
+  rintro ⟨hScard, -⟩
+  have hle := Finset.card_le_card hS
+  omega
+
 end Erdos101OQ04OQ01


### PR DESCRIPTION
## Summary

Adds two general-position-free structural bounds to `proofs/Proofs/Erdos101OQ04OQ01.lean` (the clean OQ-01 companion), bookending the count `kPointLineCount P k` = number of `k`-point lines of a planar point set:

- **`kPointLineCount_le_choose`** — `kPointLineCount P k ≤ (|P|).choose k`. Each `k`-point line is in particular a `k`-element subset of the `n = |P|` points, so their number is bounded by the raw subset count `C(n, k)`; collinearity can only cut this down.
- **`kPointLineCount_eq_zero_of_card_lt`** — `|P| < k ⟹ kPointLineCount P k = 0`. A witnessing subset would satisfy `k = |S| ≤ |P| < k`, contradiction.

### Why it matters

The companion already has the general-position *lower* engine (`kPointLineCount_eq_zero_of_no_three_collinear`) and its arc instances. These add the **universal** bounds that hold for *every* point set with no hypothesis: an upper ceiling `C(n,k)` and a vacuity floor past `n`. Together they bracket the count and are the natural reusable ingredients for any counting argument over `kPointLineCount` (the `k`-parameterised generalization of Erdős #101's `fourPointLineCount`).

### Proof

`kPointLineCount_le_choose`: the filtered set is a subset of `Finset.powersetCard k P.points`, whose card is `Finset.card_powersetCard = P.points.card.choose k`; conclude by `Finset.card_le_card`. `kPointLineCount_eq_zero_of_card_lt`: mirror the existing `filter_eq_empty_iff` proof and close with `Finset.card_le_card` + `omega`. Uses only standard Finset API; 0 axioms / 0 sorries. Hard open sorries (Grünbaum Ω(n^{3/2}), Solymosi–Stojaković) untouched.

### Verification status: UNVERIFIED (infra)

Docker build could not run: containerd `meta.db` input/output error (Docker infra down at operator level this session; host disk healthy). Static check: both proofs mirror the file's existing verified `kPointLineCount_eq_zero_of_no_three_collinear` rewrite chain (`rw [kPointLineCount, Finset.card_eq_zero, Finset.filter_eq_empty_iff]`) and use only confirmed APIs (`Finset.card_powersetCard (n) (s) : card (powersetCard n s) = (card s).choose n`, `Finset.mem_powersetCard`, `Finset.card_le_card`). Recommend a green docker build once infra recovers.