### PR TITLE
research(minpoly-charpoly-oq-02): isDiag_of_commute_diag_distinct — crux of the hard converse

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
@@ -329,6 +329,47 @@ theorem commute_of_commonDiagonalizer {M N P : Matrix n n K}
     _ = P * (P⁻¹ * (N * M) * P) * P⁻¹ := by rw [hconj]
     _ = N * M := hcancel _
 
+/-- **A matrix commuting with a diagonal matrix of *distinct* entries is itself diagonal.**
+
+    This is the combinatorial heart of the hard (still-open) converse
+    "commuting diagonalizable ⟹ common diagonalizer": if `D` is diagonal with pairwise
+    distinct diagonal entries and `A` commutes with `D`, then `A` must be diagonal.
+    Entrywise, `(A*D)_{ij} = A_{ij}·D_{jj}` and `(D*A)_{ij} = D_{ii}·A_{ij}`, so
+    `A_{ij}·(D_{jj} − D_{ii}) = 0`; for `i ≠ j` the distinctness `D_{jj} ≠ D_{ii}` forces
+    `A_{ij} = 0`.
+
+    Consequence (the reusable step a build-capable session can assemble into the converse):
+    if `P` diagonalizes `M` (so `D = P⁻¹MP` is diagonal) with distinct eigenvalues and `N`
+    commutes with `M`, then `P⁻¹NP` commutes with `D`, hence is diagonal — i.e. the *same*
+    `P` diagonalizes `N`, giving a common diagonalizer. This settles the generic
+    (distinct-eigenvalue) case of the classical theorem. -/
+theorem isDiag_of_commute_diag_distinct {D A : Matrix n n K} (hD : D.IsDiag)
+    (hdist : ∀ i j, i ≠ j → D i i ≠ D j j) (hcomm : A * D = D * A) :
+    A.IsDiag := by
+  intro i j hij
+  -- `(A * D) i j = A i j * D j j` — only the `k = j` term of the row·column sum survives.
+  have hAD : (A * D) i j = A i j * D j j := by
+    rw [Matrix.mul_apply]
+    refine Finset.sum_eq_single j ?_ ?_
+    · intro k _ hkj; rw [hD hkj, mul_zero]
+    · intro hj; exact absurd (Finset.mem_univ j) hj
+  -- `(D * A) i j = D i i * A i j` — only the `k = i` term survives.
+  have hDA : (D * A) i j = D i i * A i j := by
+    rw [Matrix.mul_apply]
+    refine Finset.sum_eq_single i ?_ ?_
+    · intro k _ hki; rw [hD (Ne.symm hki), zero_mul]
+    · intro hi; exact absurd (Finset.mem_univ i) hi
+  -- commutativity equates the two entries
+  have hkey : A i j * D j j = D i i * A i j := by rw [← hAD, ← hDA, hcomm]
+  -- `A i j * (D j j - D i i) = 0`
+  have hz : A i j * (D j j - D i i) = 0 := by
+    rw [mul_sub, hkey, mul_comm (D i i) (A i j), sub_self]
+  -- the second factor is nonzero, so `A i j = 0`
+  have hne : D j j - D i i ≠ 0 := sub_ne_zero.mpr (hdist j i (Ne.symm hij))
+  rcases mul_eq_zero.mp hz with h | h
+  · exact h
+  · exact absurd h hne
+
 /-- **The (ordered) product of a list of diagonal matrices is diagonal.**  The
     multiplicative companion of `isDiag_sum`.  Because matrix multiplication is
     *not* commutative, the product must be taken over an ordered `List` rather than

--- a/research/problems/minpoly-charpoly-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/minpoly-charpoly-oq-02-incomplete-01/knowledge.md
@@ -78,3 +78,38 @@ siblings. Re-verify once infra repaired. File 429→481 lines.
 
 REMAINING (unchanged): the HARD half — commuting diagonalizable ⟹ common diagonalizer
 (eigenspace decomposition, genuinely not session-sized).
+
+## Session 2026-07-09 (researcher-3) — crux stepping stone toward the hard converse (UNVERIFIED, docker down)
+
+**Mode**: ACT (SOLVED-side, toward the standing HARD half). **Outcome**: added one
+0-new-axiom theorem that is the genuine combinatorial crux of the still-open converse
+"commuting diagonalizable ⟹ common diagonalizer" — not another counterexample, but real
+forward progress on the hard direction's generic case.
+
+### What I added (`isDiag_of_commute_diag_distinct`)
+`{D A} (hD : D.IsDiag) (hdist : ∀ i j, i≠j → D i i ≠ D j j) (hcomm : A*D = D*A) : A.IsDiag`.
+A matrix commuting with a diagonal matrix of **pairwise-distinct** diagonal entries is
+itself diagonal. This is exactly the step that upgrades `commute_of_commonDiagonalizer`
+(the easy converse: common diagonalizer ⟹ commute) toward the hard direction: if `P`
+diagonalizes `M` (D=P⁻¹MP diagonal, distinct eigenvalues) and `N` commutes with `M`, then
+P⁻¹NP commutes with D ⟹ is diagonal ⟹ P is a common diagonalizer. Settles the generic
+(distinct-eigenvalue) case; only the repeated-eigenvalue case (eigenspace decomposition)
+of the full converse remains.
+
+### Proof (elementary, entrywise)
+`(A*D)_{ij} = A_{ij}·D_{jj}` and `(D*A)_{ij} = D_{ii}·A_{ij}` via `Matrix.mul_apply` +
+`Finset.sum_eq_single` (only the k=j resp. k=i term survives, since IsDiag kills the rest —
+note the surviving factor is on the RIGHT for A*D → `mul_zero`, on the LEFT for D*A →
+`zero_mul`). Commutativity ⟹ `A_{ij}·(D_{jj}−D_{ii}) = 0`; `mul_sub`+`hkey`+`mul_comm`+
+`sub_self`; distinctness `D_{jj}≠D_{ii}` (`sub_ne_zero.mpr`) + `mul_eq_zero` ⟹ A_{ij}=0.
+
+### Verification: UNVERIFIED — docker infra STILL down (#35184)
+`docker-build.sh` fails at IMAGE-build stage with the containerd `meta.db: input/output
+error` on every attempt (whole session, same as the erdos-3 PR#37013 this session). No
+elaboration signal. Proof is elementary with only standard Mathlib lemmas
+(`Matrix.mul_apply`, `Finset.sum_eq_single`, `mul_zero`/`zero_mul`, `mul_sub`, `sub_self`,
+`sub_ne_zero`, `mul_eq_zero`); manual review fixed one `mul_zero`→`zero_mul` (D*A left
+factor). A build-capable session should confirm green. No gallery meta on this research file.
+
+REMAINING (unchanged): repeated-eigenvalue case of the converse (eigenspace decomposition)
+— genuinely hard, not session-sized.


### PR DESCRIPTION
## Summary

Adds `isDiag_of_commute_diag_distinct` to `Proofs/MinpolyCharpolyOQ02Incomplete01.lean`:

> A matrix commuting with a diagonal matrix of **pairwise-distinct** diagonal entries is itself diagonal.

`{D A} (hD : D.IsDiag) (hdist : ∀ i j, i≠j → D i i ≠ D j j) (hcomm : A*D = D*A) : A.IsDiag`.

This is not another counterexample — it is genuine forward progress on the file's standing **hard** open half, the converse "commuting diagonalizable ⟹ common diagonalizer." It is the combinatorial heart of that theorem: if `P` diagonalizes `M` (so `D = P⁻¹MP` is diagonal with distinct eigenvalues) and `N` commutes with `M`, then `P⁻¹NP` commutes with `D`, hence is diagonal — i.e. the *same* `P` diagonalizes `N`, giving a common diagonalizer. So this settles the **generic (distinct-eigenvalue) case**; only the repeated-eigenvalue case (eigenspace decomposition) of the full converse remains. It is the exact complement of the file's existing easy direction `commute_of_commonDiagonalizer`.

## Proof

Elementary and entrywise: `(A·D)_{ij} = A_{ij}·D_{jj}` and `(D·A)_{ij} = D_{ii}·A_{ij}` (via `Matrix.mul_apply` + `Finset.sum_eq_single` — only one term of each row·column sum survives because `D.IsDiag` kills the off-diagonal factors). Commutativity gives `A_{ij}·(D_{jj} − D_{ii}) = 0`; for `i ≠ j` the distinctness `D_{jj} ≠ D_{ii}` forces `A_{ij} = 0`. **0 new axioms.**

## ⚠️ Verification status: UNVERIFIED — build infra down

`docker-build.sh` fails at the image-build stage on every attempt this session with `write .../io.containerd.metadata.v1.bolt/meta.db: input/output error` (containerd metadata-store corruption, known #35184 — operator-level; disk healthy, daemon responsive). No elaboration signal was obtainable.

**Confidence: high.** The proof uses only standard Mathlib lemmas (`Matrix.mul_apply`, `Finset.sum_eq_single`, `mul_zero`/`zero_mul`, `mul_sub`, `mul_comm`, `sub_self`, `sub_ne_zero`, `mul_eq_zero`) in an elementary entrywise argument; manual review before commit fixed one `mul_zero`→`zero_mul` (the zeroed factor is on the left for `D·A`). **Please confirm the green docker build before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)