### PR TITLE
Research: erdos-1008-oq-02-oq-02 — leading-order n^{3/2} KST asymptotic for K_{2,t}

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -378,6 +378,71 @@ theorem kst_edge_bound_of_free (G : SimpleGraph V) [DecidableRel G.Adj] [Nonempt
     rw [Nat.cast_sub ht, Nat.cast_one]
   rwa [hcast] at h
 
+/-- **Leading-order Kővári–Sós–Turán asymptotic for K_{2,t}.**
+
+The closed-form root bound `4m ≤ n·(1 + √(1 + 4(t-1)(n-1)))` still carries the
+exact quadratic-formula surd.  Its textbook leading-order consequence is the
+clean `n^{3/2}` estimate
+
+      ex(n ; K_{2,t}) ≤ ½·(√(t-1)·n^{3/2} + n),
+
+here written with `n^{3/2}` spelled out as `n·√n` to stay `Real.sqrt`-elementary
+(no `rpow`).  The only analytic input beyond `kst_edge_bound_of_free` is the
+surd relaxation
+
+      √(1 + 4(t-1)(n-1)) ≤ 2·√(t-1)·√n + 1,
+
+valid because squaring the right side gives `4(t-1)n + 4√(t-1)√n + 1`, which
+exceeds `1 + 4(t-1)(n-1) = 1 + 4(t-1)n - 4(t-1)` by `4√(t-1)√n + 4(t-1) ≥ 0`.
+Multiplying through by `n` and dividing by `4` yields the stated bound.  This is
+the explicit `ℝ`-valued form of the standard `ex(n ; K_{s,t}) = O(n^{2-1/s})`
+Kővári–Sós–Turán growth at `s = 2`. -/
+theorem kst_edge_bound_of_free_asymptotic (G : SimpleGraph V) [DecidableRel G.Adj]
+    [Nonempty V] (t : ℕ) (ht : 1 ≤ t) (hfree : ¬ HasK2t G t) :
+    (G.edgeFinset.card : ℝ) ≤
+      (1 / 2) * (Real.sqrt ((t : ℝ) - 1) * (Fintype.card V : ℝ)
+          * Real.sqrt (Fintype.card V : ℝ) + (Fintype.card V : ℝ)) := by
+  have h := kst_edge_bound_of_free G t ht hfree
+  set nR := (Fintype.card V : ℝ) with hnR
+  set κr := (t : ℝ) - 1 with hκr
+  -- Basic positivity: `n ≥ 1` and `κ = t-1 ≥ 0`.
+  have hn1 : (1 : ℝ) ≤ nR := by
+    have hpos : 1 ≤ Fintype.card V := Fintype.card_pos
+    rw [hnR]; exact_mod_cast hpos
+  have hn0 : (0 : ℝ) ≤ nR := by linarith
+  have hκr0 : (0 : ℝ) ≤ κr := by
+    have h1 : (1 : ℝ) ≤ (t : ℝ) := by exact_mod_cast ht
+    rw [hκr]; linarith
+  -- Square roots of `κr` and `nR`.
+  set sκ := Real.sqrt κr with hsκ
+  set sn := Real.sqrt nR with hsn
+  have hsκ0 : 0 ≤ sκ := Real.sqrt_nonneg _
+  have hsn0 : 0 ≤ sn := Real.sqrt_nonneg _
+  have hsκ2 : sκ ^ 2 = κr := by rw [hsκ]; exact Real.sq_sqrt hκr0
+  have hsn2 : sn ^ 2 = nR := by rw [hsn]; exact Real.sq_sqrt hn0
+  -- The surd relaxation `√(1 + 4κ(n-1)) ≤ 2·sκ·sn + 1`.
+  have hRHSnn : 0 ≤ 2 * sκ * sn + 1 := by positivity
+  -- Expand `(2·sκ·sn + 1)²` and substitute `sκ² = κ`, `sn² = n`.
+  have hexp : (2 * sκ * sn + 1) ^ 2 = 4 * κr * nR + 4 * (sκ * sn) + 1 := by
+    rw [show (2 * sκ * sn + 1) ^ 2 = 4 * sκ ^ 2 * sn ^ 2 + 4 * (sκ * sn) + 1 from by ring,
+      hsκ2, hsn2]
+  have hsqle : 1 + 4 * κr * (nR - 1) ≤ (2 * sκ * sn + 1) ^ 2 := by
+    rw [hexp]; nlinarith [mul_nonneg hsκ0 hsn0, hκr0]
+  have hsqrt_le : Real.sqrt (1 + 4 * κr * (nR - 1)) ≤ 2 * sκ * sn + 1 := by
+    rw [← Real.sqrt_sq hRHSnn]
+    exact Real.sqrt_le_sqrt hsqle
+  -- Feed the relaxation into the root bound and simplify.
+  have hstep : nR * (1 + Real.sqrt (1 + 4 * κr * (nR - 1)))
+      ≤ nR * (2 + 2 * sκ * sn) :=
+    mul_le_mul_of_nonneg_left (by linarith [hsqrt_le]) hn0
+  have hfin : 4 * (G.edgeFinset.card : ℝ)
+      ≤ 2 * nR + 2 * (sκ * nR * sn) := by
+    calc 4 * (G.edgeFinset.card : ℝ)
+        ≤ nR * (1 + Real.sqrt (1 + 4 * κr * (nR - 1))) := h
+      _ ≤ nR * (2 + 2 * sκ * sn) := hstep
+      _ = 2 * nR + 2 * (sκ * nR * sn) := by ring
+  linarith [hfin]
+
 end GraphLevel
 
 end Erdos1008

--- a/src/data/research/problems/erdos-1008-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-1008-oq-02-oq-02.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (UNVERIFIED, docker down): graph-level K_{2,t} KST bound COMPLETE — cherry count + quadratic assembly + closed-form edge bound + K_{2,t}-free bridge, feeding the merged algebraic core; closes the graph-level gap (parent had only t=2/C4)",
+    "progressSummary": "PROGRESS (researcher-6 2026-07-09): added kst_edge_bound_of_free_asymptotic, the explicit leading-order n^{3/2} KST bound ex(n;K_{2,t})<=1/2(sqrt(t-1)n^{3/2}+n), closing the second recorded next-step. UNVERIFIED (docker containerd blob I/O error, no elaboration). Graph-level core (cherry count + quadratic + root bound) complete for full K_{2,t} family; only remaining direction is s>=3 generalization (larger build) and docker verification. PR#37025.",
     "builtItems": [
       "kst_quadratic_solve (Erdos1008OQ02OQ02.lean): solves the general K_{2,t} KST quadratic 4m^2 <= (t-1)n^2(n-1)+2nm for the upper root 4m <= n(1+s), s=sqrt(1+4(t-1)(n-1))",
       "reiman_quadratic_solve_of_kst: t=2 specialisation recovering the sibling C4 lemma verbatim (1+4(t-1)(n-1)=4n-3)",
@@ -45,18 +45,20 @@
       "kst_cherry_count_nat (Erdos1008OQ02OQ02.lean): graph-level double count ∑_v d_v(d_v-1) ≤ κ·n(n-1) for graphs whose distinct vertex pairs share ≤ κ common neighbours (K_{2,κ+1}-free); cherry (a,b) fibre = |N(a)∩N(b)| via sum_comm double count",
       "kst_graph_quadratic (Erdos1008OQ02OQ02.lean): assembles cherry count + handshaking + CS (sq_sum_le_card) into 4m² ≤ κ·n²(n-1)+2nm — the graph-theoretic input kst_quadratic_solve needed",
       "kst_edge_bound (Erdos1008OQ02OQ02.lean): graph-level closed form 4m ≤ n(1+√(1+4κ(n-1))) via kst_quadratic_solve with t=κ+1",
-      "HasK2t + commonNbrs_card_lt_of_free + kst_edge_bound_of_free: connects the common-neighbour-bound hypothesis to the genuine forbidden-subgraph definition of K_{2,t}-freeness"
+      "HasK2t + commonNbrs_card_lt_of_free + kst_edge_bound_of_free: connects the common-neighbour-bound hypothesis to the genuine forbidden-subgraph definition of K_{2,t}-freeness",
+      "kst_edge_bound_of_free_asymptotic (Erdos1008OQ02OQ02.lean): explicit leading-order KST asymptotic ex(n;K_{2,t}) <= 1/2(sqrt(t-1)*n^{3/2}+n), n^{3/2}=n*sqrt(n), from the root bound via surd relaxation sqrt(1+4(t-1)(n-1))<=2sqrt(t-1)sqrt(n)+1 (PR#37025, UNVERIFIED docker-down)"
     ],
     "insights": [
       "The C4 algebraic core generalises to K_{2,t} with zero structural change: replace the single-common-neighbour bound by (t-1), so s^2=4n-3 becomes s^2=1+4(t-1)(n-1) and the KST quadratic gains a (t-1) factor on the n^2(n-1) term. Same nlinarith case-split proof works.",
-      "Leading-order closed form is ex(n;K_{2,t}) <= (1/2)(sqrt(t-1)*n^{3/2}+n), matching the classical Kovari-Sos-Turan asymptotic."
+      "Leading-order closed form is ex(n;K_{2,t}) <= (1/2)(sqrt(t-1)*n^{3/2}+n), matching the classical Kovari-Sos-Turan asymptotic.",
+      "The n^{3/2} leading term is extracted from the exact surd n(1+sqrt(1+4(t-1)(n-1))) by the elementary bound sqrt(1+4kn-4k)<=2sqrt(kn)+1 (RHS^2-LHS^2 = 4sqrt(kn)+4k >= 0); no rpow needed, n^{3/2} kept as n*sqrt(n)"
     ],
     "mathlibGaps": [
       "No graph-level general cherry-count sum_v C(d_v,2) <= (t-1)*C(n,2) for K_{2,t}-free graphs in the gallery; parent Erdos1008Problem only proves the t=2 (C4) case kovari_sos_turan."
     ],
     "nextSteps": [
-      "VERIFY the graph-level GraphLevel section of Erdos1008OQ02OQ02.lean once containerd/docker build backend is repaired (this session: meta.db + content-store blob I/O errors)",
-      "Optional: derive the leading-order asymptotic ex(n;K_{2,t}) ≤ ½(√(t-1)·n^{3/2}+n) as an explicit ℝ corollary of kst_edge_bound"
+      "VERIFY GraphLevel + new asymptotic corollary once docker/containerd build backend repaired (blob I/O error this session and prior)",
+      "Optional: generalize the cherry-count core to K_{s,t} (s>=3), giving ex(n;K_{s,t})=O(n^{2-1/s}) — needs s-fold common-neighbour counting + Holder/power-mean in place of Cauchy-Schwarz (larger build)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds `kst_edge_bound_of_free_asymptotic` to `Erdos1008OQ02OQ02.lean`, deriving the textbook leading-order Kővári–Sós–Turán estimate

```
ex(n ; K_{2,t}) ≤ ½·(√(t-1)·n^{3/2} + n)
```

as an explicit ℝ-valued corollary of the existing closed-form root bound `kst_edge_bound_of_free` (`4m ≤ n(1+√(1+4(t-1)(n-1)))`). This closes the second research next-step recorded for the problem.

## Math

The only analytic input beyond the root bound is the surd relaxation
```
√(1 + 4(t-1)(n-1)) ≤ 2·√(t-1)·√n + 1,
```
valid because squaring the RHS gives `4(t-1)n + 4√(t-1)√n + 1`, exceeding `1 + 4(t-1)(n-1) = 1 + 4(t-1)n − 4(t-1)` by `4√(t-1)√n + 4(t-1) ≥ 0`. Multiplying by `n` and dividing by `4` gives the stated bound. `n^{3/2}` is spelled out as `n·√n` to remain `Real.sqrt`-elementary (no `rpow`). This is the explicit form of the standard `ex(n;K_{s,t}) = O(n^{2-1/s})` growth at `s = 2`.

## Verification status

**UNVERIFIED** — the docker/containerd build backend is down (content-store blob I/O error), so elaboration could not be run this session. The added proof uses only stable Mathlib lemmas (`Real.sq_sqrt`, `Real.sqrt_sq`, `Real.sqrt_le_sqrt`, `mul_le_mul_of_nonneg_left`, `Fintype.card_pos`) and the algebra was checked by hand. Consistent with the file's existing UNVERIFIED status. Recommend a docker rebuild before merge.

0 new axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)