### PR TITLE
Enrich k=3 birthday threshold cluster: reciprocal parent→child link

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03/meta.json
@@ -101,6 +101,11 @@
       "description": "Parent: slot-based recurrence for efficient k=3 birthday counting; its OQ-03 asks for the (6d²ln2)^(1/3) threshold proved here"
     },
     {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+      "relationship": "refined-by",
+      "description": "Child: answers this entry's second open question (sharpen the additive O(1) error). Where this entry pins n only to the width-2 band c ≤ n ≤ c + 2 via the corner-cube sandwich (n-2)³ ≤ n(n-1)(n-2) ≤ n³, the child replaces the corner cube by the centered cube (n-1)³ — the exact identity n(n-1)(n-2) = (n-1)³ - (n-1) — to reach c + 1 ≤ n ≤ c + 1 + 1/(3c), i.e. the asymptotically exact n = (6d²ln2)^(1/3) + 1 + o(1) with lower-order term pinned to the constant 1"
+    },
+    {
       "targetId": "birthday-problem",
       "relationship": "related",
       "description": "The base birthday problem (k=2 coincidence, threshold n ≈ √(2d ln2)); this is the triple-coincidence analogue"


### PR DESCRIPTION
Enrichment pass for the birthday-problem k=3 threshold refinement chain.

## Gap
The parent entry `birthday-problem-oq-03-oq-01-oq-01-oq-03` (leading-order k=3 threshold, additive-$O(1)$ band $c \le n \le c+2$) poses the open question *'sharpen the additive $O(1)$ error: locate n within a smaller window'* — but had **no forward cross-reference** to the child entry `birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01` that answers exactly that question. The child already links up to the parent; the chain was only navigable in one direction.

## Change
Added a single `refined-by` crossReference from parent → child, describing precisely how the child sharpens the band (corner cube $(n-2)^3 \le n(n-1)(n-2) \le n^3$ → centered cube $(n-1)^3$, via the exact identity $n(n-1)(n-2) = (n-1)^3 - (n-1)$) to reach $n = (6d^2\ln 2)^{1/3} + 1 + o(1)$.

## Notes
- The claimed target (child, quality 95) is already at all quality targets and comfortably under size caps; per the diminishing-returns guardrail I did **not** deepen it — the high-value work was the missing reciprocal navigation link.
- Parent `meta.json`: 9.4KB → 10KB, 2 → 3 crossReferences (both well under caps).
- Gallery data-validation build steps pass (search-index checks OK, JSON parses). The trailing `tsc` failure is a fresh-worktree `node_modules` env issue, unrelated to the JSON edit.