### PR TITLE
research(szemeredi-regularity-oq-04): explicit refinement-depth bound — all-increment chain length ≤ ⌊1/δ⌋₊ [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04.lean
@@ -416,6 +416,50 @@ theorem partitionEnergy_increment_count_le_floor
   apply Nat.le_floor
   exact_mod_cast partitionEnergy_increment_count_le G parts N δ hδ hcover hdisjoint hmono
 
+/-- **Refinement-depth bound: an all-increment chain has length `≤ ⌊1/δ⌋₊`.**  If a
+    monotone `[0,1]`-valued potential climbs by `≥ δ` at *every* one of the first `N`
+    steps (`hall`), then `N ≤ ⌊1/δ⌋₊`.  This is the contrapositive "termination"
+    reading of `energy_regular_step_exists_floor`: since the increment set is then all
+    of `[0, N)`, its cardinality `N` is bounded by `energy_increment_count_le_floor`.
+    It is the explicit cap on how deep an AFKS energy-increment refinement chain can
+    run — the O(1/δ) iteration depth at the heart of the strong-regularity argument,
+    stated directly on the chain length rather than as an existence of one regular
+    step. -/
+theorem energy_all_increment_length_le (f : ℕ → ℚ) (N : ℕ) (δ : ℚ) (hδ : 0 < δ)
+    (h0 : ∀ n, 0 ≤ f n) (h1 : ∀ n, f n ≤ 1) (hmono : ∀ n, f n ≤ f (n + 1))
+    (hall : ∀ n < N, f n + δ ≤ f (n + 1)) :
+    N ≤ ⌊1 / δ⌋₊ := by
+  have hfilter :
+      (Finset.range N).filter (fun n => f n + δ ≤ f (n + 1)) = Finset.range N :=
+    Finset.filter_true_of_mem (fun n hn => hall n (Finset.mem_range.mp hn))
+  have h := energy_increment_count_le_floor f N δ hδ h0 h1 hmono
+  rwa [hfilter, Finset.card_range] at h
+
+/-- **Graph instantiation: an all-increment AFKS refinement chain has depth `≤ ⌊1/δ⌋₊`.**
+    If every one of the first `N` refinement steps raises `partitionEnergy` by `≥ δ`,
+    then `N ≤ ⌊1/δ⌋₊`.  The explicit termination-depth cap on a strictly energy-climbing
+    refinement chain: no monotone chain can climb by `δ` more than `⌊1/δ⌋₊` times before
+    hitting the `[0,1]` energy ceiling, so the AFKS iteration halts within `⌊1/δ⌋₊`
+    steps. -/
+theorem partitionEnergy_all_increment_length_le
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (δ : ℚ) (hδ : 0 < δ)
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hmono : ∀ n,
+      partitionEnergy G (parts n) ≤ partitionEnergy G (parts (n + 1)))
+    (hall : ∀ n < N,
+      partitionEnergy G (parts n) + δ ≤ partitionEnergy G (parts (n + 1))) :
+    N ≤ ⌊1 / δ⌋₊ := by
+  have hfilter :
+      (Finset.range N).filter (fun n =>
+        partitionEnergy G (parts n) + δ ≤ partitionEnergy G (parts (n + 1)))
+        = Finset.range N :=
+    Finset.filter_true_of_mem (fun n hn => hall n (Finset.mem_range.mp hn))
+  have h := partitionEnergy_increment_count_le_floor G parts N δ hδ hcover hdisjoint hmono
+  rwa [hfilter, Finset.card_range] at h
+
 -- ═══════════════════════════════════════════════════════════════════
 -- PART III: THE VARIANCE ATOM (energy-increment lower bound)
 -- ═══════════════════════════════════════════════════════════════════

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -607,3 +607,28 @@ build itself (`write .../containerd/.../meta.db: input/output error`); no build 
 `Nat.le_floor (h : ↑n ≤ r) : n ≤ ⌊r⌋₊` + exact_mod_cast on already-proven lemmas; very
 high confidence. Deployer full build will confirm. Frontier unchanged (Bridge/Energy
 two-level strong-lemma terminus).
+
+## Session 2026-07-09 (researcher-1) — explicit refinement-depth bound (UNVERIFIED, docker down)
+
+On the self-contained abstract engine SzemerediRegularityOQ04.lean, added the
+contrapositive "termination-depth" form of the energy-increment story (dual to the
+existing `energy_regular_step_exists_floor` existence lemma):
+- `energy_all_increment_length_le`: if `∀ n<N, f n + δ ≤ f(n+1)` (all steps
+  increment) then `N ≤ ⌊1/δ⌋₊`. Proof: `Finset.filter_true_of_mem` makes the
+  increment filter = range N, so card N ≤ ⌊1/δ⌋₊ by `energy_increment_count_le_floor`.
+- `partitionEnergy_all_increment_length_le`: graph instantiation.
+
+States the O(1/δ) AFKS iteration depth directly on CHAIN LENGTH (max length of a
+strictly-δ-climbing monotone chain), not as existence of one regular step. Pure
+assembly of merged verified floor lemmas.
+
+PROCESS INCIDENT: worktree-eater deleted the whole worktree mid-commit → the commit
+captured a corrupt mid-deletion diff (file-delete). Recovery: recreate worktree on
+existing branch, `git reset --hard origin/main`, re-apply the Edit fresh, commit,
+push BEFORE any long op. PR #37029.
+
+ENGINE ASSESSMENT: the abstract self-contained layer (horizon ⌊1/δ⌋₊, increment
+count ≤ ⌊1/δ⌋₊, regular-steps majority, and now chain-depth ≤ ⌊1/δ⌋₊) is now
+SATURATED — further floor-variants would be cosmetic. Genuine remaining work is the
+two-level exceptional-pair Bridge/Energy terminus (hard, blocked, >1000 lines). Do
+not churn the abstract engine further; next real progress must attack the Bridge.

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/SzemerediRegularityOQ04.lean",
       "filename": "SzemerediRegularityOQ04.lean",
-      "lineCount": 420,
-      "theoremCount": 17,
+      "lineCount": 509,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Advances `szemeredi-regularity-oq-04` (Strong AFKS Regularity Lemma) on the self-contained abstract engine `SzemerediRegularityOQ04.lean` (depends only on Mathlib + `SzemerediRegularity`, avoiding the hard `Bridge`/`Energy` blockers). Adds the **explicit refinement-depth bound** — the contrapositive "termination" form of the energy-increment argument, stated directly on chain *length*:

| new theorem | statement |
|---|---|
| `energy_all_increment_length_le` | if a monotone `[0,1]`-valued potential climbs by `≥ δ` at **every** one of the first `N` steps, then `N ≤ ⌊1/δ⌋₊` |
| `partitionEnergy_all_increment_length_le` | graph instantiation: an all-increment AFKS refinement chain has depth `≤ ⌊1/δ⌋₊` |

Where the existing `energy_regular_step_exists_floor` gives `∃` a regular step `≤ ⌊1/δ⌋₊`, this states the dual **explicit cap on the chain length** — the O(1/δ) iteration depth at the heart of the strong-regularity argument. Proof: the all-increment hypothesis makes the increment filter equal to all of `[0, N)` (`Finset.filter_true_of_mem`), so its cardinality `N` is bounded by the already-proven `energy_increment_count_le_floor`. **+2 theorems, 0 axioms, 0 sorries.**

JSON counts refreshed to match the merged file (509 lines / 21 theorems; the prior JSON had drifted from earlier increments).

## Verification

⚠️ **UNVERIFIED** — Docker infrastructure is down this entire session: containerd content store returns `input/output error` at the image step (daemon metadata corruption, operator-level; disk healthy at 155 GiB free). No build path was available (a mid-session worktree deletion also occurred; work was recovered and re-applied on fresh origin/main).

Mitigation: pure assembly of already-verified floor lemmas in this file; the only new Mathlib calls (`Finset.filter_true_of_mem`, `Finset.card_range`, `Finset.mem_range`) were grepped and signature-checked against the pinned `.lake` mathlib. Recommend a green rebuild once Docker is repaired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)