### PR TITLE
Enrich Cayley-Hamilton RCF cluster: reciprocal parent→child cross-reference

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02/meta.json
@@ -188,6 +188,11 @@
       "description": "Source of the open question (overview.openQuestions[2]) and provider of nonderogatory_has_cyclic_vector — the existence theorem this entry consumes to obtain a cyclic vector v."
     },
     {
+      "targetId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
+      "relationship": "extended-by",
+      "description": "Child: takes this entry's single-block nonderogatory ⟺ cyclic ⟺ similar-to-companion equivalence toward the multi-block rational canonical form. It settles the coprime two-block case — for coprime monic p, q the block sum C(p) ⊕ C(q) has minpoly = charpoly = p·q, hence is nonderogatory and similar to the single companion C(p·q) — the matrix incarnation of the Chinese Remainder Theorem K[X]/(p·q) ≅ K[X]/(p) × K[X]/(q)."
+    },
+    {
       "targetId": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01",
       "relationship": "uses",
       "description": "Sibling: provides cyclic_implies_nonderogatory (the converse of the parent's existence theorem) and minpoly_natDegree_of_cyclic. The latter is used to establish (minpoly K M).natDegree = n inside the conjugation-identity proof."


### PR DESCRIPTION
Enrichment pass for the Cayley-Hamilton / rational-canonical-form cyclic-vector chain.

## Gap
The parent entry `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02` (single-block nonderogatory ⟺ cyclic ⟺ similar-to-companion over an arbitrary field) had **no forward cross-reference** to its child `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05`, which extends it to the coprime two-block **matrix-CRT** merge toward the multi-block rational canonical form. The child links up to the parent; the chain was only navigable upward.

## Change
Added a single `extended-by` crossReference (parent → child) describing the coprime-merge result: for coprime monic $p,q$, the block sum $C(p)\oplus C(q)$ has $\mu = \chi = pq$, hence is nonderogatory and similar to $C(pq)$ — the matrix incarnation of $K[X]/(pq) \cong K[X]/(p)\times K[X]/(q)$.

## Notes
- Claimed target (the child, quality 95) is already at all quality targets and under size caps; per the diminishing-returns guardrail I did **not** deepen it — the high-value work was the missing reciprocal navigation link.
- Parent `meta.json`: 38.9KB → 39.5KB, 4 → 5 crossReferences — well under the 60KB / 20-item caps.
- JSON validates; gallery data-build search-index checks pass.