### PR TITLE
research(erdos-1204): strict monotonicity of the minimal-diameter frontier A(k)

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -307,6 +307,49 @@ bound `A_le_A_succ`. -/
 theorem A_monotone : Monotone A :=
   monotone_nat_of_le_succ A_le_A_succ
 
+/-- **Strict one-step monotonicity.** For `k ≥ 1`, `A(k) < A(k+1)`. Deleting the
+*largest* element (rather than an arbitrary one) from an optimal admissible
+`(k+1)`-set leaves an admissible `k`-set whose maximum is *strictly* smaller: every
+surviving element lies below the deleted maximum. Since `A(k)` bounds that smaller
+maximum and the deleted maximum is `A(k+1)`, we get `A(k) < A(k+1)`.
+
+This sharpens `A_le_A_succ` from `≤` to `<`: no two distinct admissible-tuple sizes
+`k ≥ 1` share a minimal diameter — the exact-value frontier
+`A(2)=2, A(3)=6, A(4)=8, …` is genuinely strictly increasing. -/
+theorem A_lt_A_succ {k : ℕ} (hk : 1 ≤ k) : A k < A (k + 1) := by
+  obtain ⟨a, hcard, ha, hsup⟩ := A_mem (k + 1)
+  have hne : a.Nonempty := by rw [← Finset.card_pos, hcard]; omega
+  obtain ⟨x, hxa, hxsup⟩ := Finset.exists_mem_eq_sup a hne id
+  have hsub : a.erase x ⊆ a := fun y hy => Finset.mem_of_mem_erase hy
+  have hcard' : (a.erase x).card = k := by
+    rw [Finset.card_erase_of_mem hxa, hcard, Nat.add_sub_cancel]
+  have ha' : Admissible (a.erase x) := ha.subset hsub
+  -- The maximum `x` is positive: `a` has `k + 1 ≥ 2` distinct naturals, so `x ≥ k ≥ 1`.
+  have hxpos : 0 < x := by
+    have hcs := card_le_sup_succ a
+    rw [hcard, hxsup] at hcs
+    simp only [id_eq] at hcs
+    omega
+  -- Every surviving element is strictly below the deleted maximum `x`.
+  have hlt : (a.erase x).sup id < x := by
+    rw [Finset.sup_lt_iff (by simpa using hxpos)]
+    intro y hy
+    have hya : y ∈ a := Finset.mem_of_mem_erase hy
+    have hyne : y ≠ x := Finset.ne_of_mem_erase hy
+    have hle : id y ≤ a.sup id := Finset.le_sup hya
+    rw [hxsup] at hle
+    simp only [id_eq] at hle ⊢
+    omega
+  have hup : A k ≤ (a.erase x).sup id := A_le hcard' ha'
+  have hlt2 : (a.erase x).sup id < a.sup id := by rw [hxsup]; simpa using hlt
+  omega
+
+/-- **The frontier is strictly increasing.** Reindexing by `j ↦ A(j+1)` (so the
+domain starts at the first strictly-increasing index `k = 1`), `A` is strictly
+monotone. Packages `A_lt_A_succ`, which holds for every `k ≥ 1`. -/
+theorem A_succ_strictMono : StrictMono (fun j => A (j + 1)) :=
+  strictMono_nat_of_lt_succ (fun j => A_lt_A_succ (by omega))
+
 /-- **Trivial lower bound.** `A(k) ≥ k - 1`, since any `k` distinct naturals have maximum
 at least `k - 1`. -/
 theorem sub_one_le_A (k : ℕ) : k - 1 ≤ A k := by

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -70,9 +70,9 @@
       "S(2)=2 and S(3)=8 exact, giving the first exact averages B(2)=1 and B(3)=8/3. B(2)=1 attains the parity floor k-1=1 (the general bound is tight); B(3)=8/3 > 2 is the first place the mod-3 obstruction — the same one that makes A(3)=6 — forces the average strictly above the floor. The S(3) >= 8 lower bound combines the A(3) fact sup >= 6 (admissible_three_sup_ge) with admissible_sum_ge on the erased admissible 2-set: 6+2=8 (Proofs/Erdos1204B.lean)"
     ],
     "axiomCount": 0,
-    "lineCount": 561,
+    "lineCount": 604,
     "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved. Proofs use only kernel `decide` (no `native_decide`) and `Nat.sInf`; #print axioms (incl. admissible_same_parity, admissible_diam_ge, two_mul_sub_one_le_A) shows only propext/Classical.choice/Quot.sound — no Lean.ofReduceBool, no sorryAx. Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. Formalized here: the admissibility framework, the reduction to small primes, existence/well-definedness of A(k), the parity-sharpened two-sided bounds 2(k-1) ≤ A(k) ≤ (k-1)·primorial (doubling the trivial k-1 lower bound for all k), and the exact values A(0)=A(1)=0, A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, A(7)=20 (the last four in companion files Erdos1204A4.lean, Erdos1204A5.lean, Erdos1204A6.lean and Erdos1204A7.lean, each verified and axiom-free; A(6)=16 is the first exact value whose lower bound needs three primes 2,3,5, and A(7)=20 shows the prime 7 is not yet binding — two forced 7-sets per parity are all killed at p=5). The companion Erdos1204B.lean (B(k) theory: S/B definitions, the bound k(k-1) <= S(k), and exact S(2)=2/S(3)=8, B(2)=1/B(3)=8/3) is likewise 0 axioms / 0 sorries, kernel decide only (no native_decide), depending only on propext/Classical.choice/Quot.sound.",
-    "theoremCount": 30,
+    "theoremCount": 32,
     "definitionCount": 3,
     "summary": " A companion file (Erdos1204B.lean) now also introduces the SECOND extremal quantity B(k)=min(a1+...+ak)/k (the minimal average, carried by the minimal sum S(k)), previously untouched: it is defined as an attained infimum, satisfies the parity lower bound B(k) >= k-1 (average analogue of A(k) >= 2(k-1)), with first exact values B(2)=1 (tight) and B(3)=8/3 (mod-3 forces the average above the floor). The asymptotics of B(k) remain OPEN."
   },
@@ -223,9 +223,9 @@
       "Finset"
     ],
     "namespace": "Erdos1204",
-    "lineCount": 561,
+    "lineCount": 604,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 32,
     "definitionCount": 3,
     "path": "Proofs/Erdos1204Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Strengthens the existing monotonicity result for the minimal-diameter function `A(k)` (Erdős #1204, admissible tuples / Hardy–Littlewood `H(k)`) from `≤` to strict `<`.

The file already had `A_le_A_succ : A k ≤ A (k+1)` (delete an *arbitrary* element). Deleting the **largest** element instead yields the strict bound:

- **`A_lt_A_succ (hk : 1 ≤ k) : A k < A (k + 1)`** — for an optimal admissible `(k+1)`-set `a` (with `a.sup id = A(k+1)`), the max element `x` is positive (`|a| ≥ 2` distinct naturals ⇒ `x ≥ k ≥ 1`), and every surviving element of `a.erase x` is strictly below `x` (via `Finset.sup_lt_iff`). Since `A k ≤ (a.erase x).sup id < x = A(k+1)`.
- **`A_succ_strictMono : StrictMono (fun j => A (j + 1))`** — packages it (reindex so the domain starts at the first strictly-increasing index `k = 1`), via `strictMono_nat_of_lt_succ`.

**Consequence:** no two distinct tuple sizes `k ≥ 1` share a minimal diameter — the exact-value frontier `A(2)=2, A(3)=6, A(4)=8, A(5)=12, A(6)=16, A(7)=20, …` is genuinely strictly increasing, not merely non-decreasing.

## Axioms / sorries
Both theorems **axiom-free**: `#print axioms` reports `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`). 0 sorries.

## Meta sync
`lineCount` 561→604, `theoremCount` 30→32.

## Verification
✅ Verified via **direct `lean` single-file elaboration** against the pinned Mathlib v4.26.0 oleans (docker infra down this session — containerd `meta.db` I/O error; disk healthy). `Proofs/Erdos1204Problem.lean` elaborates **EXIT 0** with no error diagnostics (only a pre-existing `mul_le_mul_right'` deprecation warning at line 601, unrelated), and `#print axioms` confirms the axiom footprint above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)