### PR TITLE
Fix: resync stale lineCount in 13 gallery meta.json entries

### DIFF
--- a/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
@@ -20,7 +20,7 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 2516,
+    "lineCount": 127,
     "theoremCount": 97,
     "definitionCount": 8,
     "dateAdded": "2026-07-02",

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 322,
+    "lineCount": 332,
     "theoremCount": 16,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",

--- a/src/data/proofs/erdos-10-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-oq-02/meta.json
@@ -25,7 +25,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 542,
+    "lineCount": 188,
     "assumptions": "0 axioms, 0 sorries. The Granville–Soundararajan k=3 (odd) conjecture itself is OPEN and is formalized only as a Prop definition (GranvilleSoundararajanOdd), not assumed. The stack proves the supporting infrastructure (reduction lemma, exponent/prime bounds, popcount characterization, decision procedure). Docker-verified green (2026-06-15, 3066 jobs): all three files — Erdos10OQ02, Erdos10OQ02Decidable, Erdos10OQ02Popcount — kernel-check at the v4.26.0 pin, including the native_decide witnesses (e.g. 906 ∉ S_3). Two Mathlib-drift fixes were needed: a stray omega after a now-self-closing simp (Erdos10OQ02:133) and a rw chain that no longer auto-closes a defeq powSum goal (Erdos10OQ02Popcount:83, closed with rfl).",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 1,
     "axiomCount": 1,
     "theoremCount": 11,
-    "lineCount": 738,
+    "lineCount": 762,
     "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 1 sorry in this file: planar_graphs_edge_bound (Euler's formula |E| ≤ 3|V| - 6, not yet in Lean Mathlib). K₃ and K₄ planarity proved with explicit coordinates and linear-functional convex hull arguments.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -62,7 +62,7 @@
       "Repaired the faithful ∀ c > 0 statement of grunskyConjecture (the earlier small-c form was vacuously true, making its negation a false axiom)"
     ],
     "axiomCount": 0,
-    "lineCount": 842,
+    "lineCount": 70,
     "assumptions": "None — fully machine-checked. The former lone axiom goodman_counterexample (Goodman's polynomial f = (z²+1)(z−2)² has a non-convex lemniscate component at c = 5^(3/2)/4) is now the sorry-free, axiom-free theorem Erdos1047OQ02Cert.goodman_counterexample_proof in Proofs/Erdos1047OQ02Certificate.lean. It is established by a constructive geometric certificate: an explicit preconnected 4-segment polyline arc −i → (1−i)/2 → 2 → (1+i)/2 → +i lying inside the lemniscate (each segment verified by a Bernstein/SOS rational inequality discharged by nlinarith) whose chord midpoint 0 escapes the sublevel set (‖f(0)‖ = 4 > c ≈ 2.795), fed through the topological reduction bridge componentContaining_lemniscate_not_convex_of_chord_exits (built only on Mathlib's IsPreconnected.subset_connectedComponentIn and connectedComponentIn_subset). Docker-verified (3061 jobs): #print axioms for erdos_1047, grunskyConjecture_false, and erdos_1047_answer reports exactly [propext, Classical.choice, Quot.sound] — Mathlib's standard foundational axioms, with no problem-specific axiom, no sorry, and no native_decide. The earlier spurious ∃ c₀, ∀ c < c₀ small-c form of grunskyConjecture (which was actually TRUE, making its negation a false axiom) was repaired to the faithful ∀ c > 0 form.",
     "mathlib_version": "4.26.0",
     "theoremCount": 37,

--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -95,7 +95,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 2355,
+    "lineCount": 293,
     "prerequisites": [
       "Divisibility and the divisor lattice",
       "Extremal set theory",

--- a/src/data/proofs/erdos-26/meta.json
+++ b/src/data/proofs/erdos-26/meta.json
@@ -49,7 +49,7 @@
       "Educational documentation of thick/Behrend sequence concepts"
     ],
     "axiomCount": 2,
-    "lineCount": 1328,
+    "lineCount": 202,
     "prerequisites": [
       "Arithmetic progressions and AP-free sets",
       "Behrend's construction (sphere method)",

--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -74,7 +74,7 @@
       "Erdos741APN_II.cassels_set + 25 supporting lemmas: Cassels-style basis with not_syndetic_of_large_gaps obstruction (657-line port)"
     ],
     "axiomCount": 0,
-    "lineCount": 2690,
+    "lineCount": 351,
     "assumptions": "0 axioms, 0 sorries (combined across the three files: Erdos741Problem.lean, Erdos741ProblemAPNPartI.lean, Erdos741ProblemAPNPartII.lean). cofinite_density_one proved as a theorem in PR #16461. AlphaProof Nexus companion files (parts i and ii, 2026-05-21) port Apache-2.0 DeepMind Lean output verbatim against Mathlib. Both parts were confirmed to elaborate against Mathlib v4.26.0 via `./proofs/scripts/docker-build.sh Proofs.Erdos741ProblemAPNPartI` and `... Erdos741ProblemAPNPartII` (both exit 0, warnings only) on 2026-07-07 (issue #20841); status is now 'verified'. Badge stays 'wip' pending peer review.",
     "theoremCount": 160,
     "definitionCount": 35,

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -59,7 +59,7 @@
       "erdos_744_statement theorem: combined main result"
     ],
     "axiomCount": 1,
-    "lineCount": 503,
+    "lineCount": 578,
     "assumptions": "1 axiom: rodl_tuza_theorem (the deep Rödl–Tuza 1985 result, stated as an assumption since a full formalization of the extremal argument is out of scope). The chromatic number is now defined intrinsically (least number of colors admitting a proper coloring) rather than axiomatized, and is proved well-defined by chromaticNumber_le_card. 0 sorries.",
     "theoremCount": 14,
     "definitionCount": 14

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -58,7 +58,7 @@
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 2,
-    "lineCount": 539,
+    "lineCount": 564,
     "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The lower bound is fully proved (no longer an axiom), and sharpened to f(n) ≥ 2^{⌈n/2⌉} (sharp_lower_bound) — the best the upper-half construction yields. See the Lean source for details.",
     "theoremCount": 18,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-884/meta.json
+++ b/src/data/proofs/erdos-884/meta.json
@@ -68,7 +68,7 @@
     ],
     "axiomCount": 1,
     "assumptions": "1 axiom: erdos_884 (the OPEN main conjecture). All 8 supporting axioms eliminated: divisorList_pairwise_lt, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, divisors_6, divisors_prime, prime_case_equality, gap_lower_bound — all proved. numDivisors_mul_coprime sorry also proved via σ��� multiplicativity.",
-    "lineCount": 568,
+    "lineCount": 606,
     "theoremCount": 38,
     "definitionCount": 9
   },

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -384,7 +384,7 @@
     ],
     "sorries": 0,
     "axiomCount": 6,
-    "lineCount": 829,
+    "lineCount": 881,
     "theoremCount": 45,
     "definitionCount": 2,
     "originalContributions": [

--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "assumptions": "None. The file is axiom-free (only the ordinary foundational axioms of Lean/Mathlib are used; `#print axioms` shows no `sorryAx`, no `Lean.ofReduceBool`). All examples use kernel `decide`, not `native_decide`. Note: this file does NOT prove the Strong Goldbach Conjecture, which remains open; it proves only that the conjecture is equivalent to its symmetric-prime-pair form.",
-    "lineCount": 932,
+    "lineCount": 997,
     "theoremCount": 30,
     "definitionCount": 5,
     "originalContributions": [


### PR DESCRIPTION
## Fix

Resync `meta.lineCount` to the actual `wc -l` of the referenced Lean source for 13 gallery entries whose recorded line counts had drifted.

## Evidence

Gallery convention is `lineCount == wc -l` (newline count). These entries drifted because their Lean files were rewritten (large shrinks) or grew (enrichment) after the meta was last written. In every case the `sections[].endLine` values already fit within the *current* file size — confirming the sections were updated but the `lineCount` field lagged, so this is a safe meta-only resync (not a stale-file mispointer).

| slug | stored | actual (`wc -l`) |
|------|-------:|-----------------:|
| abundant-number-oq-02-oq-01 | 2516 | 127 |
| erdos-741 | 2690 | 351 |
| erdos-12 | 2355 | 293 |
| erdos-26 | 1328 | 202 |
| erdos-1047 | 842 | 70 |
| erdos-10-oq-02 | 542 | 188 |
| erdos-744 | 503 | 578 |
| strong-goldbach-symmetric | 932 | 997 |
| law-of-cosines-oq-03-oq-03 | 829 | 881 |
| erdos-884 | 568 | 606 |
| erdos-748 | 539 | 564 |
| erdos-1018-oq-04-incomplete-01 | 738 | 762 |
| algebraic-numbers-countable-oq-07 | 322 | 332 |

Each change is a single-field, 1-line surgical edit; all JSON revalidated. Entries with in-flight PRs touching their `.lean` (which would re-drift) or already-open mechanic meta PRs were deliberately excluded.

---
Automated fix by lean-mechanic agent.