### PR TITLE
audit(erdos-931): disclose Lean.ofReduceBool from native_decide counterexamples

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17474,10 +17474,10 @@
       "result": "clean"
     },
     "erdos-931": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:12:01Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T06:01:20Z",
+      "result": "issues-fixed"
     },
     "erdos-932": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17504,9 +17504,9 @@
       "result": "clean"
     },
     "erdos-935": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:13:05Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T06:04:12Z",
       "result": "clean"
     },
     "erdos-936": {

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 931,
     "erdosUrl": "https://erdosproblems.com/931",
     "erdosProblemStatus": "open",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 540,
-    "assumptions": "2 sorry-stated assumptions (theorem-with-sorry, formerly axioms): stronger_implies_main (Størmer-type smooth number argument), exists_prime_between_blocks_hard (refined: only the hard case with k₁<n₁, tight gap, all factors ≤n₁ — general statement proved as theorem). Computational evidence: hard case hypotheses are vacuously inconsistent for n₁ ≤ 30 with k₁=k₂=3 (hard_case_vacuous_k3_n30). See Lean source. stronger_implies_main and exists_prime_between_blocks_hard converted from axiom to theorem-with-sorry (axiom integrity: do not assert unverified math).",
+    "assumptions": "2 sorry-stated assumptions (theorem-with-sorry, formerly axioms): stronger_implies_main (Størmer-type smooth number argument), exists_prime_between_blocks_hard (refined: only the hard case with k₁<n₁, tight gap, all factors ≤n₁ — general statement proved as theorem). Computational evidence: hard case hypotheses are vacuously inconsistent for n₁ ≤ 30 with k₁=k₂=3 (hard_case_vacuous_k3_n30). See Lean source. stronger_implies_main and exists_prime_between_blocks_hard converted from axiom to theorem-with-sorry (axiom integrity: do not assert unverified math). Additionally, native_decide is used to discharge the counterexample and computational-evidence theorems (alphaproof_same_factors, tijdeman_same_factors, the small_same_factors_* examples, the consecutiveProduct value lemmas, and hard_case_vacuous_k3_n30); native_decide trusts the compiler kernel reduction and depends on the Lean.ofReduceBool axiom rather than being purely kernel-checked, so meta.axiomCount counts it as 1 assumption (leanFile.axiomCount remains 0 — there are no literal axiom declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 46,
     "definitionCount": 5


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-931

**Proof**: erdos-931 (Erdős Problem #931: Same Prime Factors in Products of Consecutive Integers)
**Severity**: LOW (disclosure) — status/badge unchanged, entry remains honestly `formalized`/`wip`/OPEN with 2 sorries.

### Finding

The entry uses `native_decide` in **named theorems** (not just `example` blocks) that it explicitly presents as verified results:

- `alphaproof_same_factors` / `tijdeman_same_factors` — the counterexamples that disprove Erdős's stronger conjecture ("Two counterexamples … are fully verified by `native_decide`")
- `small_same_factors_*`, the `consecutiveProduct_*` value lemmas
- `hard_case_vacuous_k3_n30` — cited in `assumptions` as "computational evidence"

`native_decide` trusts the compiler's kernel reduction and depends on the `Lean.ofReduceBool` axiom (`#print axioms` would list it). This dependency was **undisclosed**: `meta.axiomCount` read 0 with no mention of `ofReduceBool` in `assumptions`.

This matches the project's `native_decide` rule (CLAUDE.md Axiom Integrity Policy) and prior fixes: legendre-partial (#36496), lagrange-theorem-oq-03 (#36527), partition-theorem-oq-01 (#36475).

### Fix

- `meta.axiomCount` 0 → 1 (accounts for `Lean.ofReduceBool`)
- `leanFile.axiomCount` stays 0 (counts only literal `axiom` declarations — there are none; detector-safe)
- `assumptions` expanded to disclose the `native_decide`/`ofReduceBool` dependency and name the affected theorems
- `status`/`badge`/`sorries` unchanged (2 sorries remain → `formalized`/`wip`)
- Bumps `audit-tracker.json` entry (result: issues-fixed)

### Verified consistent (no change needed)

- `sorries: 2` matches 2 real `sorry` statements (lines 217, 319; other "sorry" mentions are docstrings)
- `theoremCount: 46`, `definitionCount: 5`, `lineCount: 540` all match source
- No `axiom` declarations, no `True`-stub headline theorems
- OPEN problem correctly scoped; deep results honestly sorry-stated

---
Discovered during gallery integrity audit.