### PR TITLE
research(erdos-1038-wip-01): non-degeneracy sublevelInf' < sublevelSup'

### DIFF
--- a/proofs/Proofs/Erdos1038WIP01.lean
+++ b/proofs/Proofs/Erdos1038WIP01.lean
@@ -531,4 +531,39 @@ theorem sublevelSup'_le_sublevelSup : sublevelSup' ≤ sublevelSup :=
 theorem sublevelInf_le_sublevelInf' : sublevelInf ≤ sublevelInf' :=
   le_iInf fun f => le_iInf fun hf => iInf_le_of_le f (iInf_le_of_le hf.1 le_rfl)
 
+/-! ### The faithful extremal problem is non-degenerate: `sublevelInf' < sublevelSup'`
+
+The two elementary witnesses bound the faithful extremal object from *both* sides:
+the linear `X` gives `sublevelInf' ≤ 2` and the quadratic `X² − 1` gives
+`2√2 ≤ sublevelSup'`.  Since `2 < 2√2` (as `1 < √2`), these two bounds do not overlap,
+so the faithful supremum is *strictly* greater than the faithful infimum.  This records
+— with no potential theory — that the Erdős #1038 sublevel problem is genuinely
+non-degenerate: the sup and inf are separated, independently of their exact endpoints
+`2^(4/3) − 1` and `2√2`. -/
+
+/-- **The faithful infimum is strictly below the faithful supremum.**  Chaining
+    `sublevelInf' ≤ ofReal 2` (`sublevelInf'_le_two`) through the strict numeric gap
+    `2 < 2√2` (from `1 < √2`) into `ofReal (2√2) ≤ sublevelSup'` (`le_sublevelSup'`) shows
+    the faithful extremal spread is nonzero. -/
+theorem sublevelInf'_lt_sublevelSup' : sublevelInf' < sublevelSup' := by
+  have hgap : ENNReal.ofReal 2 < ENNReal.ofReal (2 * Real.sqrt 2) := by
+    rw [ENNReal.ofReal_lt_ofReal_iff (by positivity)]
+    have h1 : (1 : ℝ) < Real.sqrt 2 := by
+      rw [show (1 : ℝ) = Real.sqrt 1 from Real.sqrt_one.symm]
+      exact Real.sqrt_lt_sqrt (by norm_num) (by norm_num)
+    nlinarith [h1]
+  calc sublevelInf' ≤ ENNReal.ofReal 2 := sublevelInf'_le_two
+    _ < ENNReal.ofReal (2 * Real.sqrt 2) := hgap
+    _ ≤ sublevelSup' := le_sublevelSup'
+
+/-- **The literal supremum is strictly positive**, hence `sublevelInf < sublevelSup`.
+    The literal infimum collapses to `0` (`sublevelInf_eq_zero`) via the rootless
+    `X² + 1`, while `2√2 ≤ sublevelSup` keeps the supremum positive; the strict ordering
+    survives the collapse. -/
+theorem sublevelInf_lt_sublevelSup : sublevelInf < sublevelSup := by
+  rw [sublevelInf_eq_zero]
+  have hpos : (0 : ℝ≥0∞) < ENNReal.ofReal (2 * Real.sqrt 2) := by
+    rw [ENNReal.ofReal_pos]; positivity
+  exact lt_of_lt_of_le hpos le_sublevelSup
+
 end Erdos1038WIP01


### PR DESCRIPTION
## Summary

Adds the missing **non-degeneracy** fact for the faithful Erdős #1038 sublevel-set extremal problem: the faithful supremum is **strictly** greater than the faithful infimum.

Both sides are already bounded by elementary witnesses in the file:
- linear `X` → `sublevelInf' ≤ 2` (`sublevelInf'_le_two`)
- quadratic `X² − 1` → `2√2 ≤ sublevelSup'` (`le_sublevelSup'`)

Since `2 < 2√2` (as `1 < √2`), these bounds do not overlap, giving `sublevelInf' < sublevelSup'` — a machine-checkable statement that the extremal spread is nonzero, **independent** of the potential-theoretic exact endpoints `2^(4/3)−1` and `2√2`.

### New theorems
- `sublevelInf'_lt_sublevelSup'` — the faithful infimum is strictly below the faithful supremum (headline non-degeneracy).
- `sublevelInf_lt_sublevelSup` — literal-object companion: `sublevelInf = 0 < sublevelSup` (survives the rootless `X²+1` collapse).

### Verification
- 0 new axioms, 0 sorries. Pure assembly of existing bounds + `2 < 2√2`.
- API verified against the pinned Mathlib source: `ENNReal.ofReal_lt_ofReal_iff` (Data/ENNReal/Real.lean:167), `ENNReal.ofReal_pos` (176), `Real.sqrt_lt_sqrt` (Data/Real/Sqrt.lean:203), `Real.sqrt_one` (180).
- **UNVERIFIED**: docker build infra is down this session (containerd `meta.db` input/output error at image build) — no Lean build was possible. Proof is a short, high-confidence assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)