### PR TITLE
Enrich Chebyshev's Second Function ψ(n) Bounds: add references

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-04/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04/meta.json
@@ -65,6 +65,36 @@
       "Formalize the explicit formula ψ(x) = x − Σ_ρ x^ρ/ρ − log(2π) connecting ψ to nontrivial zeros of ζ(s)"
     ]
   },
+  "references": [
+    {
+      "authors": [
+        "Pafnuty L. Chebyshev"
+      ],
+      "title": "Mémoire sur les nombres premiers",
+      "year": "1852",
+      "venue": "Journal de mathématiques pures et appliquées, 1re série, 17, 366–390",
+      "note": "Introduces the functions θ and ψ and proves the first effective bounds A·x < ψ(x) < B·x (the Chebyshev bounds), the elementary precursor to the Prime Number Theorem whose ψ(n) ≤ 2n·log 2 upper bound and Bertrand-type increment lower bound are formalized here."
+    },
+    {
+      "authors": [
+        "Tom M. Apostol"
+      ],
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Undergraduate Texts in Mathematics, Springer, Ch. 4 (Some Elementary Theorems on the Distribution of Prime Numbers)",
+      "note": "Standard development of the Chebyshev functions ψ(x) = Σ_{p^k ≤ x} log p and θ(x), the identity ψ(x) = Σ_{n ≤ x} Λ(n), the central-binomial upper bound, and the equivalence of ψ(x) ~ x with the Prime Number Theorem — the results this entry proves or axiomatizes."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "6th ed. (revised by D. R. Heath-Brown and J. H. Silverman), Oxford University Press, §22 (The Series of Primes)",
+      "note": "Classical treatment of Chebyshev's θ and ψ, Bertrand's postulate, and the central-binomial estimates underlying the ψ increment bounds formalized here."
+    }
+  ],
   "sections": [
     {
       "id": "sec-header-imports",


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-04`.

**Defect fixed:** the entry had no `references` field (REFS0). All other fields already rich (5 keyInsights, full conclusion, sections covering the file, 3 valid crossReferences).

**Added 3 accurate analytic-number-theory references** — no fabrication:
- Chebyshev (1852, J. math. pures appl. 17) — the original memoir introducing θ and ψ and the Chebyshev bounds
- Apostol, *Introduction to Analytic Number Theory* (1976), Ch. 4
- Hardy & Wright, *An Introduction to the Theory of Numbers* (2008, 6th ed.), §22

meta.json 13.2 KB → 14.8 KB (well under caps). JSON validated. Status/badge (axiomatized, 2 assumptions) unchanged and accurate.