### PR TITLE
Enrich combinations-formula log-concavity cluster: reciprocal cross-references

### DIFF
--- a/src/data/proofs/combinations-formula-oq-04-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-03/meta.json
@@ -121,6 +121,11 @@
       "targetId": "combinations-formula",
       "relationship": "related",
       "description": "Root of the combinations-formula family: the basic count C(n,k) = n!/(k!(n−k)!). This entry supplies the row's sharp structural equality."
+    },
+    {
+      "targetId": "combinations-formula-oq-04-oq-01",
+      "relationship": "sibling",
+      "description": "Twin entry answering the same parent open question (ultra-log-concavity of a Pascal row) from the same core adjacent-triple identity. Its choose_adjacent_ratio_prod is this entry's identity in n,k form (n = k+2+t, so n−k = t+2, n−k−1 = t+1); it then extracts the exact defect/gap and the rational excess 1 + (n+1)/((k+1)(n−k−1)), complementary to this entry's middle-index centering that recovers Liggett's ultra-log-concavity bound."
     }
   ],
   "references": [

--- a/src/data/proofs/combinations-formula-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-04/meta.json
@@ -156,6 +156,16 @@
       "targetId": "combinations-formula-oq-05",
       "relationship": "related",
       "description": "Sibling on the alternating row sum and the even/odd split of a Pascal row — another structural property of the row, complementary to log-concavity."
+    },
+    {
+      "targetId": "combinations-formula-oq-04-oq-01",
+      "relationship": "answered-by",
+      "description": "Child answering this entry's ultra-log-concavity open question: sharpens the bare inequality C(n,k)·C(n,k+2) ≤ C(n,k+1)² to the exact defect identity (C(n,k+1)² − C(n,k)·C(n,k+2))·(k+1)(n−k−1) = (n+1)·C(n,k)·C(n,k+2), equivalently the ratio C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)) > 1. Both this entry's ≤ and its strict interior < are recovered as corollaries."
+    },
+    {
+      "targetId": "combinations-formula-oq-04-oq-03",
+      "relationship": "answered-by",
+      "description": "Twin child answering the same ultra-log-concavity open question via the same core adjacent-triple identity, centered at the middle index to recover Liggett's ultra-log-concavity bound."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for the Pascal-row log-concavity / ultra-log-concavity family.

## Gaps
- The parent `combinations-formula-oq-04` (bare log-concavity inequality $C(n,k)C(n,k+2) \le C(n,k+1)^2$) lists **ultra-log-concavity as its open question** but had no forward link to either twin child that answers it (`oq-04-oq-01`, `oq-04-oq-03`).
- The two twins already cross-reference each other one-way: `oq-04-oq-01` names `oq-04-oq-03` as a sibling, but `oq-04-oq-03` did **not** link back.

## Changes
- `oq-04`: added `answered-by` links to **both** children that resolve its open question, completing the parent's downward navigation.
- `oq-04-oq-03`: added the reciprocal `sibling` link to `oq-04-oq-01`, explaining that its identity is the same adjacent-triple relation in $n,k$ form vs the $n=k+2+t$ form.

## Notes
- Claimed target (`oq-04-oq-01`, quality 95) is already at all quality targets and under caps; per the diminishing-returns guardrail I did not deepen it — the value was the missing reciprocal navigation.
- `oq-04`: 13.7KB → 14.5KB; `oq-04-oq-03`: 13.6KB → 14.1KB. Both well under the 60KB / 20-crossRef caps.
- JSON validates.