### PR TITLE
research(liouville-theorem-oq-03): measure side of Jarník–Besicovitch — Khintchine null sets

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ03.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ03.lean
@@ -307,4 +307,41 @@ theorem jarnik_besicovitch_summary :
    dimH_wellApprox_two,
    dimH_liouville_eq_zero⟩
 
+/-! ## Part VII: The measure side — Khintchine null sets
+
+The dimension law has an immediate **measure-theoretic** shadow. For `τ > 2` the
+well-approximable set has Hausdorff dimension `< 1` (`dimH_wellApprox_lt_one`), so
+its `1`-dimensional Hausdorff measure vanishes; and on `ℝ` that measure *is*
+Lebesgue measure (`hausdorffMeasure_real : μH[1] = volume`). Hence `W τ` is
+Lebesgue-null for every `τ > 2` — the "easy" (convergence) half of Khintchine's
+theorem: almost every real number is *not* `τ`-well-approximable once `τ > 2`. The
+classical corollary is that the **Liouville numbers form a null set** (they lie in
+`W 3`), a companion to `dimH_liouville_eq_zero` on the measure side. -/
+
+open MeasureTheory in
+/-- **`W τ` has Hausdorff `1`-measure zero for `τ > 2`.** From `dimH (W τ) < 1`
+(`dimH_wellApprox_lt_one`) via `hausdorffMeasure_of_dimH_lt`. -/
+theorem hausdorffMeasure_one_wellApprox_eq_zero {τ : ℝ} (hτ : 2 < τ) :
+    μH[(1 : ℝ)] (wellApprox τ) = 0 := by
+  simpa using
+    hausdorffMeasure_of_dimH_lt (X := ℝ) (s := wellApprox τ) (d := 1)
+      (by exact_mod_cast dimH_wellApprox_lt_one hτ)
+
+open MeasureTheory in
+/-- **`W τ` is Lebesgue-null for `τ > 2`** (Khintchine's convergence half): almost
+every real is not `τ`-well-approximable. Immediate from the Hausdorff-`1`-measure
+statement and `hausdorffMeasure_real : μH[1] = volume` on `ℝ`. -/
+theorem volume_wellApprox_eq_zero {τ : ℝ} (hτ : 2 < τ) :
+    volume (wellApprox τ) = 0 := by
+  rw [← hausdorffMeasure_real]
+  exact hausdorffMeasure_one_wellApprox_eq_zero hτ
+
+open MeasureTheory in
+/-- **The Liouville numbers form a Lebesgue-null set.** They are contained in the
+`τ = 3 > 2` well-approximable set, which is null. The measure-side companion to
+`dimH_liouville_eq_zero`. -/
+theorem volume_liouville_eq_zero :
+    volume {x : ℝ | Liouville x} = 0 :=
+  measure_mono_null (liouville_subset_wellApprox 3) (volume_wellApprox_eq_zero (by norm_num))
+
 end LiouvilleTheoremOQ03

--- a/research/problems/liouville-theorem-oq-03/knowledge.md
+++ b/research/problems/liouville-theorem-oq-03/knowledge.md
@@ -1,0 +1,33 @@
+# Knowledge Base: liouville-theorem-oq-03
+
+## Session 2026-07-09 (researcher-2) — Measure side of Jarník–Besicovitch (Khintchine null sets)
+
+The file `LiouvilleTheoremOQ03.lean` had the full DIMENSION theory of the τ-well-approximable
+sets `W τ` (dimension law `dimH (W τ) = min(1, 2/τ)`, antitone, strict, →0, `dimH{Liouville}=0`)
+over the single deep axiom `dimH_wellApprox` (Jarník–Besicovitch, τ≥2 — irreducible, not in Mathlib).
+Added the missing **measure-theoretic shadow** (VERIFIED, no new axiom):
+
+- `hausdorffMeasure_one_wellApprox_eq_zero {τ} (hτ : 2 < τ)`: `μH[1] (W τ) = 0` — from
+  `dimH_wellApprox_lt_one hτ` (`dimH < 1`) via `hausdorffMeasure_of_dimH_lt (d := 1)` (cast the
+  `< 1` ℝ≥0∞ bound to `< ↑(1:ℝ≥0)` with `exact_mod_cast`).
+- `volume_wellApprox_eq_zero {τ} (hτ : 2 < τ)`: `volume (W τ) = 0` — Khintchine's convergence half
+  (a.e. real is not τ-well-approximable for τ>2). `rw [← hausdorffMeasure_real]` (μH[1] = volume on ℝ,
+  EXACTLY) then the μH result.
+- `volume_liouville_eq_zero`: **Liouville numbers form a Lebesgue-null set** — classical corollary,
+  `measure_mono_null (liouville_subset_wellApprox 3) (volume_wellApprox_eq_zero (by norm_num))`.
+  The measure-side companion to `dimH_liouville_eq_zero`.
+
+Reusable Mathlib metric-measure API (v4.26, confirmed): `hausdorffMeasure_of_dimH_lt {d:ℝ≥0} :
+dimH s < ↑d → μH[d] s = 0`; `hausdorffMeasure_real : (μH[1] : Measure ℝ) = volume`;
+`measure_mono_null`. Use `open MeasureTheory in` per-theorem for the `μH[·]` scoped notation +
+`volume`/`measure_mono_null`. `#print axioms volume_liouville_eq_zero` = `[propext, Classical.choice,
+dimH_wellApprox, Quot.sound]` (correctly carries the JB axiom, no sorry).
+
+★META FIX: research json leanFiles had a STALE `axiomCount: 3` for this file — the real count is 1
+(only `dimH_wellApprox`); the "3" was a naive `^axiom ` grep catching two docstring lines that wrap
+onto "axiom of this entry…" / "axiom (stated for τ ≥ 2)…". Synced research json 3→1 (gallery meta was
+already correct at 1). File now 347 lines / 24 thm.
+
+**Verification (docker DOWN — containerd meta.db/blob I/O, NOT disk).** Direct `lean` elab vs pinned
+Mathlib v4.26.0 ([[reference-docker-down-lean-elab-verification-path]]): exit 0, only a pre-existing
+`le_or_lt` deprecation warning (line 200, not my code).

--- a/src/data/proofs/liouville-theorem-oq-03/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-03/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-06-24",
     "axiomCount": 1,
     "assumptions": "One axiom: `dimH_wellApprox` — the Jarník–Besicovitch dimension formula dimH(W τ) = ENNReal.ofReal(2/τ) for τ ≥ 2. This is the deep theorem of metric Diophantine approximation (Jarník 1931, Besicovitch 1934) and is not yet available in Mathlib (the upper bound requires a covering/Borel–Cantelli Hausdorff-measure estimate; the lower bound a mass-distribution principle / Frostman construction on a Cantor subset). `#print axioms` confirms: the structural lemmas (wellApprox_antitone, liouville_subset_wellApprox, dimH_liouville_le_wellApprox, and the jbDim exponent facts) depend on no axioms beyond the standard foundational trio; only the formula-dependent results (dimH_wellApprox_two, dimH_liouville_le, dimH_liouville_eq_zero, the summary) carry dimH_wellApprox.",
-    "lineCount": 310,
-    "theoremCount": 21,
+    "lineCount": 347,
+    "theoremCount": 24,
     "definitionCount": 2,
     "originalContributions": [
       "wellApprox τ := {x | LiouvilleWith τ x}: the τ-well-approximable sets, packaged on top of Mathlib's LiouvilleWith with the JB exponent in mind",
@@ -134,9 +134,9 @@
     "path": "Proofs/LiouvilleTheoremOQ03.lean",
     "sorries": 0,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 24,
     "definitionCount": 2,
-    "lineCount": 310
+    "lineCount": 347
   },
   "sorries": 0
 }

--- a/src/data/research/problems/liouville-theorem-oq-03.json
+++ b/src/data/research/problems/liouville-theorem-oq-03.json
@@ -86,9 +86,9 @@
     {
       "path": "Proofs/LiouvilleTheoremOQ03.lean",
       "filename": "LiouvilleTheoremOQ03.lean",
-      "lineCount": 311,
-      "theoremCount": 21,
-      "axiomCount": 3,
+      "lineCount": 347,
+      "theoremCount": 24,
+      "axiomCount": 1,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

`liouville-theorem-oq-03` — the file had the full **dimension** theory of the τ-well-approximable sets `W τ` (`dimH (W τ) = min(1, 2/τ)`, antitone/strict/→0, `dimH{Liouville} = 0`) over the single deep axiom `dimH_wellApprox` (Jarník–Besicovitch, τ≥2 — not in Mathlib). This PR adds the missing **measure-theoretic shadow** (no new axiom):

- `hausdorffMeasure_one_wellApprox_eq_zero` (`τ > 2`): `μH[1] (W τ) = 0` — from `dimH < 1` via `hausdorffMeasure_of_dimH_lt`.
- `volume_wellApprox_eq_zero` (`τ > 2`): `volume (W τ) = 0` — **Khintchine's convergence half** (almost every real is not τ-well-approximable for τ>2), using `hausdorffMeasure_real : μH[1] = volume` on ℝ.
- `volume_liouville_eq_zero`: **the Liouville numbers form a Lebesgue-null set** — the classical corollary (they lie in `W 3`), the measure-side companion to `dimH_liouville_eq_zero`.

0 sorry; still 1 axiom (`dimH_wellApprox`, unchanged). `#print axioms volume_liouville_eq_zero` = `[propext, Classical.choice, dimH_wellApprox, Quot.sound]` — correctly derived from the JB axiom, no `sorryAx`.

Also corrected a stale `axiomCount: 3` in the research json (the real count is 1; the "3" was a naive `^axiom ` grep catching two docstring lines wrapping onto "axiom …"). Gallery meta was already correct.

## Verification

Docker infra down this session (containerd meta.db + content-store blob `input/output error` at image build — operator-level, not disk: 157Gi free). Verified by direct `lean` elaboration against the repo's pinned **Mathlib v4.26.0** oleans: **exit 0** (only a pre-existing `le_or_lt` deprecation warning, not my code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)