### PR TITLE
Enrich combinations-formula-oq-05: reciprocal sibling link to oq-04

### DIFF
--- a/src/data/proofs/combinations-formula-oq-05/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05/meta.json
@@ -115,6 +115,11 @@
       "targetId": "combinations-formula-oq-04-oq-01",
       "relationship": "related",
       "description": "A different structural property of the same Pascal row: where this entry splits the row into equal even/odd halves via the alternating sum, the log-concavity companion pins the exact ultra-log-concavity defect C(n,k+1)²/(C(n,k)·C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)). Together they characterize the additive (parity) and multiplicative (log-concave) structure of a binomial row."
+    },
+    {
+      "targetId": "combinations-formula-oq-04",
+      "relationship": "related",
+      "description": "Twin open-question entry under the same parent (combinations-formula), studying the complementary structural property of a Pascal row: oq-04 proves the row's basic multiplicative inequality (log-concavity C(n,k)·C(n,k+2) ≤ C(n,k+1)²), while this entry (oq-05) records the row's additive structure (the alternating sum vanishes, splitting the row into equal even/odd halves of 2^{n−1}). oq-04 already lists this entry as its sibling on the alternating row sum; this is the reciprocal link."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for the Pascal-row alternating-sum entry.

## Gap
The sibling `combinations-formula-oq-04` (Pascal-row log-concavity) lists this entry (`oq-05`, alternating row sum) as its sibling, but `oq-05` had **no reciprocal link back** to `oq-04`. The two are the complementary structural properties of a binomial row — additive (parity split into equal even/odd halves) vs multiplicative (log-concavity) — yet the navigation only went one way.

## Change
Added a single `related` crossReference (`oq-05` → `oq-04`) framing the two as twin open-question entries under the same parent studying the additive vs multiplicative structure of the row.

## Notes
- Claimed target (`oq-05`, quality 95) is already at all quality targets and under caps; per the diminishing-returns guardrail I did not deepen it — the value was the missing reciprocal link.
- `meta.json`: ~9.8KB → ~10.4KB, 3 → 4 crossReferences. Well under the 60KB / 20-item caps.
- JSON validates.