### PR TITLE
research(pascals-hexagon-oq-03-incomplete-01): census exactness at proven-cardinality level

### DIFF
--- a/proofs/Proofs/PascalsHexagonOQ03Incomplete01.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03Incomplete01.lean
@@ -210,4 +210,40 @@ theorem hexagrammum_points_eq_95 : 60 + 20 + 15 = 95 := by norm_num
 
 theorem hexagrammum_lines_eq_95 : 60 + 20 + 15 = 95 := by norm_num
 
+/-! ### Census exactness at the level of the proven cardinalities
+
+`fixedPointFree_census_sum` records the bare numeral identity `120 + 90 + 40 + 15 = 265`.
+The following capstone upgrades it to reference the *proven* filter cardinalities: the four
+class sizes, as machine-checked `Finset.card`s, sum to exactly the derangement count
+`card_fixedPointFree`. Together with `fixedPointFree_iff_census` (the four classes cover
+every derangement), this exact equality forces the classes to be pairwise disjoint — no
+derangement is double-counted — closing the census both ways (cover *and* exactness). -/
+
+/-- **Census exactness.** The four fixed-point-free class sizes, taken as the *proven*
+    filter cardinalities (`card_sixCycles`, `card_fourTwoCycles`, `card_doubleThreeCycles`,
+    `card_tripleTranspositions`), sum to exactly `card_fixedPointFree = 265`. With the
+    exhaustive cover `fixedPointFree_iff_census`, the exact count forces pairwise
+    disjointness of the four classes. -/
+theorem census_cards_sum_eq_fixedPointFree :
+    (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsSixCycle σ)).card
+      + (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsFourTwoCycle σ)).card
+      + (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsDoubleThreeCycle σ)).card
+      + (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsTripleTransposition σ)).card
+      = (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => FixedPointFree σ)).card := by
+  simp only [card_sixCycles, card_fourTwoCycles, card_doubleThreeCycles,
+    card_tripleTranspositions, card_fixedPointFree]
+
+/-- **Hexagrammum totals from the census.** The `95` points (and `95` lines) of the
+    `(95₃, 95₃)` configuration derived directly from the proven class cardinalities via the
+    2:1 outer-automorphism pairing (self-paired at the triple-transposition class): the
+    `120` six-cycles give `60` Pascal lines, the `40` double-3-cycles give `20` Steiner
+    points, and the `15` triple transpositions are self-paired — `60 + 20 + 15 = 95`. This
+    sources the totals from the machine-checked census rather than as bare numerals. -/
+theorem hexagrammum_total_from_census :
+    (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsSixCycle σ)).card / 2
+      + (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsDoubleThreeCycle σ)).card / 2
+      + (Finset.univ.filter (fun σ : Equiv.Perm (Fin 6) => IsTripleTransposition σ)).card
+      = 95 := by
+  simp only [card_sixCycles, card_doubleThreeCycles, card_tripleTranspositions]
+
 end PascalsHexagonOQ03Incomplete01

--- a/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
@@ -24,11 +24,11 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 213,
+    "lineCount": 249,
     "assumptions": "0 sorries; 0 literal `axiom` declarations. The three census theorems (card_sixCycles = 120, card_doubleThreeCycles = 40, card_tripleTranspositions = 15) and the anchor card_sym6 = 720 are discharged by `native_decide`, which trusts the Lean compiler and so depends on the `Lean.ofReduceBool` axiom (axiomCount = 1). Under the project axiom-integrity policy this makes the entry `axiomatized`. The geometric bijection from these conjugacy classes to the actual Steiner/Kirkman/Plücker/Salmon points and lines is NOT formalized here — only the combinatorial class sizes are certified; the projective concurrence (the open steiner_count_eq_20 / kirkman_count_eq_60 targets in oq-03) remains future work.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-07-04",
-    "theoremCount": 15,
+    "theoremCount": 17,
     "definitionCount": 5,
     "originalContributions": [
       "Identifies the Conway–Ryba (Math. Intelligencer 34 (2012) 4–8) conjugacy-class indexing of the Hexagrammum Mysticum and certifies its three governing class sizes in Lean over the concrete group Equiv.Perm (Fin 6).",
@@ -144,9 +144,9 @@
       "Equiv"
     ],
     "namespace": "PascalsHexagonOQ03Incomplete01",
-    "lineCount": 213,
+    "lineCount": 249,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 17,
     "definitionCount": 5,
     "path": "Proofs/PascalsHexagonOQ03Incomplete01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds two `native_decide`-free capstones to the Hexagrammum Mysticum fixed-point-free permutation census. The file already proves the individual class cardinalities and the total `card_fixedPointFree = 265`, but only asserts the closure as the bare numeral identity `120+90+40+15=265`. These theorems lift that to the level of the *proven* cardinalities.

### New theorems
- **`census_cards_sum_eq_fixedPointFree`** — the four class filter cardinalities sum to exactly `card_fixedPointFree`. With the exhaustive cover `fixedPointFree_iff_census`, exact count forces pairwise disjointness — closing the census both ways (cover *and* exactness).
- **`hexagrammum_total_from_census`** — derives the `(95₃,95₃)` configuration total `60+20+15=95` from the proven class cards via the 2:1 outer-automorphism pairing, sourcing the totals from the machine-checked census rather than as bare numerals.

### Verification
- Both proofs are `simp only` reductions of existing card lemmas to numerals (`Nat.reduceAdd`/`Nat.reduceDiv`). They introduce **no new axioms** — no new `native_decide`; the entry's existing `Lean.ofReduceBool` dependency (from the census cards) is unchanged.
- Gallery meta resynced: `lineCount` 213→249, `theoremCount` 15→17.
- **UNVERIFIED**: docker build infra is down this session (containerd `meta.db` input/output error) — no Lean build possible. Proofs are short simp-only assemblies of already-proven lemmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)