### PR TITLE
Enrich Coprime Companion Blocks are Nonderogatory (Matrix CRT)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/meta.json
@@ -116,6 +116,16 @@
       "targetId": "cayley-hamilton-cyclic-vector-all-fields",
       "relationship": "related",
       "description": "Base of the chain — 'Nonderogatory → Cyclic Vector: All Fields (Primary Decomposition)': establishes the nonderogatory ⇒ cyclic-vector direction over an arbitrary field via primary decomposition. The CRT collapse proved here is the coprime instance of that primary-decomposition picture, where two coprime primary parts merge into one cyclic block."
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "The ring-level statement this entry realizes at the matrix level: the constructive Chinese Remainder Theorem gives K[X]/(p·q) ≅ K[X]/(p) × K[X]/(q) for coprime p, q. Here that isomorphism becomes a similarity of matrices C(p) ⊕ C(q) ~ C(p·q), with the single arithmetic input lcm p q = p·q playing the role of the coprimality/Bézout hypothesis that drives the constructive CRT splitting."
+    },
+    {
+      "targetId": "chinese-remainder-non-coprime",
+      "relationship": "related",
+      "description": "The complementary non-coprime regime — the exact obstruction flagged in this entry's third open question. When p, q share a factor, lcm p q ∣ p·q strictly, minpoly ≠ charpoly, and the block sum stays derogatory; the CRT isomorphism fails and overlapping blocks must be renormalized into the invariant-factor divisibility chain d₁ ∣ d₂ ∣ ⋯. This entry settles the coprime case; that one studies where coprimality breaks down."
     }
   ],
   "references": [


### PR DESCRIPTION
Targeted enrichment pass for `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05`.

This entry was already high quality (5 annotations with mathContext/significance/relatedConcepts, rich historicalContext, 6 keyInsights, full conclusion with 3 open questions). Per the diminishing-returns rule, no fields were deepened. Instead I added two **cross-gallery** links that were genuinely missing:

- **→ chinese-remainder-constructive**: the ring-level CRT $K[X]/(pq) \cong K[X]/(p) \times K[X]/(q)$ that this entry realizes as the matrix similarity $C(p)\oplus C(q) \sim C(pq)$, with `lcm p q = p·q` playing the role of the coprimality hypothesis.
- **→ chinese-remainder-non-coprime**: the complementary derogatory regime, which is exactly the obstruction described in this entry's third open question (shared factor ⟹ lcm ∣ product strictly ⟹ minpoly ≠ charpoly).

meta.json: 13.1 KB → 14.2 KB (well under the 60 KB cap; crossReferences 3 → 5, under the 20 cap). Gallery build validation (search index, enrichment summary, loading facts) passes; the only build error is an unrelated `tsc: command not found` from missing node_modules in the worktree.