### PR TITLE
Auditor: label erdos-936 variants as theorems, not axioms

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17510,10 +17510,10 @@
       "result": "clean"
     },
     "erdos-936": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:13:05Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T06:07:54Z",
+      "result": "issues-fixed"
     },
     "erdos-937": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-936/meta.json
+++ b/src/data/proofs/erdos-936/meta.json
@@ -56,7 +56,7 @@
       "abc_conjecture_holds axiom: placeholder for ABC conjecture",
       "cushing_pascoe_theorem axiom: n! ± 1 result",
       "crowdmath_theorem axiom: 2^n ± 1 result",
-      "Four variant axioms for each sequence",
+      "Four variant theorems for each sequence (proved from the two conditional axioms)",
       "erdos_936_all_variants: combined conditional result",
       "Squarefree' definition and its relation to powerful numbers",
       "erdos_936_summary: complete status of the problem"


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-936 (Powerful Numbers Near 2^n and n!)

### Issue
The `originalContributions` bullet read **"Four variant axioms for each sequence"**, but these four declarations (`erdos_936_two_pow_add_one`, `erdos_936_two_pow_sub_one`, `erdos_936_factorial_add_one`, `erdos_936_factorial_sub_one`) are **proved theorems** derived from the two conditional axioms (`cushing_pascoe_theorem`, `crowdmath_theorem`).

This contradicted the entry's own `assumptions` field ("The four variant axioms have been PROVED from these two conditional theorems") and the `four-variants` section summary ("Four variant theorems proved from the two conditional axioms"). A reader of `originalContributions` would infer 7 axioms rather than the actual 3.

### Fix
Relabel the bullet to describe them as theorems proved from the two conditional axioms.

### Verification
- axiomCount 3 ✓ (`abc_conjecture_holds`, `cushing_pascoe_theorem`, `crowdmath_theorem`)
- sorries 0 ✓ · native_decide 0 ✓ · theoremCount 27 ✓ · definitionCount 3 ✓ · lineCount 327 ✓
- status `axiomatized` / badge `axiom` correct for an open problem gated on the ABC conjecture.

---
Discovered during gallery integrity audit.