### PR TITLE
Enrich combinations-formula-oq-01: reciprocal moment-sibling link to oq-09

### DIFF
--- a/src/data/proofs/combinations-formula-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01/meta.json
@@ -90,6 +90,11 @@
       "targetId": "inclusion-exclusion",
       "relationship": "related",
       "description": "The inclusion-exclusion principle and Vandermonde's identity are both fundamental counting tools in combinatorics. Vandermonde counts r-element subsets of a partitioned set by summing over sizes of the two parts; inclusion-exclusion counts elements in a union by alternating sums of intersection sizes. Both principles appear in the Fibonacci diagonal sum identity Sigma_j C(n-j,j) = F(n+1), where the tiling bijection uses complementary counting arguments similar to inclusion-exclusion"
+    },
+    {
+      "targetId": "combinations-formula-oq-09",
+      "relationship": "sibling",
+      "description": "Moment sibling: this entry supplies the zeroth-moment identities of a Pascal row (total sum ∑ C(n,k) = 2ⁿ and alternating sum ∑ (−1)ᵏ C(n,k) = 0), which oq-09 complements with the first and second moments ∑ k·C(n,k) = n·2^{n−1} and ∑ k²·C(n,k) = n(n+1)·2^{n−2}. Reciprocal to oq-09's link here."
     }
   ],
   "sections": [


### PR DESCRIPTION
Enrichment pass for the Pascal-row zeroth-moment entry.

## Gap
`combinations-formula-oq-09` (first and second moments ∑ k·C(n,k) = n·2^{n−1}, ∑ k²·C(n,k) = n(n+1)·2^{n−2}) links to `oq-01` as the source of the **zeroth-moment** identities (row sum ∑ C(n,k) = 2ⁿ, alternating sum ∑ (−1)ᵏ C(n,k) = 0). But `oq-01` had no reciprocal link back — the moment-hierarchy navigation only went one way.

## Change
Added a single `sibling` crossReference (`oq-01` → `oq-09`) framing them as complementary entries in the moment hierarchy of a Pascal row.

## Notes
- Claimed target (`oq-09`, quality 95) is already at all quality targets and under caps; per the diminishing-returns guardrail I did not deepen it.
- I deliberately did **not** add a reciprocal to `oq-02` (a Catalan-numbers entry): that link is tenuous, and manufacturing a weak back-reference would be accretion, not curation.
- `oq-01` meta.json: ~11.8KB → ~12.2KB, 4 → 5 crossReferences. Well under caps.
- JSON validates.