### PR TITLE
research(law-of-cosines-oq-03-oq-03): non-strict side–angle order-equivalence a ≤ b ↔ A ≤ B

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -419,6 +419,12 @@ theorem side_lt_iff_angle_lt (t : HyperbolicTriangle) : t.a < t.b ↔ t.A < t.B 
 theorem side_eq_iff_angle_eq (t : HyperbolicTriangle) : t.a = t.b ↔ t.A = t.B :=
   ⟨angle_eq_of_side_eq t, isosceles_of_angle_eq t⟩
 
+/-- **Hyperbolic side–angle order-equivalence (non-strict).** `a ≤ b ↔ A ≤ B`, the `≤`
+    companion completing the order trio with `side_lt_iff_angle_lt` (`<`) and
+    `side_eq_iff_angle_eq` (`=`). Immediate by splitting each `≤` into `<` or `=`. -/
+theorem side_le_iff_angle_le (t : HyperbolicTriangle) : t.a ≤ t.b ↔ t.A ≤ t.B := by
+  rw [le_iff_lt_or_eq, side_lt_iff_angle_lt, side_eq_iff_angle_eq, ← le_iff_lt_or_eq]
+
 -- ============================================================
 -- PART 4b: Angle–side monotonicity — a larger opposite angle forces a shorter side
 -- ============================================================

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -17,8 +17,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 881,
-    "theoremCount": 52,
+    "lineCount": 887,
+    "theoremCount": 53,
     "definitionCount": 3
   },
   "openQuestion": {
@@ -384,8 +384,8 @@
     ],
     "sorries": 0,
     "axiomCount": 6,
-    "lineCount": 881,
-    "theoremCount": 45,
+    "lineCount": 887,
+    "theoremCount": 46,
     "definitionCount": 2,
     "originalContributions": [
       "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",


### PR DESCRIPTION
## Summary

Adds `side_le_iff_angle_le` to `Proofs/LawOfCosinesOQ03OQ03.lean` (Hyperbolic AAA Congruence): for a `HyperbolicTriangle`,
```
a ≤ b  ↔  A ≤ B
```
the opposite side of the larger-or-equal angle is longer-or-equal, and conversely.

This is the `≤` companion **completing the side–angle order trio** with the already-merged `side_lt_iff_angle_lt` (`<`) and `side_eq_iff_angle_eq` (`=`). The proof splits each `≤` into `<` or `=` (`le_iff_lt_or_eq`) and rewrites through the two existing equivalences — a pure one-line `rw` composition.

**No new axioms** (the structure-encoded second-law-of-cosines assumptions are unchanged). Gallery `meta.json` counts synced (lineCount 881→887, theoremCount 52→53 / 45→46).

## Verification
⚠️ **UNVERIFIED** — Docker build infra is down this session (containerd `meta.db` input/output error at image build). The theorem is a single `rw` chain over previously build-verified lemmas (`side_lt_iff_angle_lt`, `side_eq_iff_angle_eq`, `le_iff_lt_or_eq`); confidence high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)