### PR TITLE
research(erdos-1022-oq-02): unconditional effective divergence of the admissible coefficient

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -502,4 +502,50 @@ theorem admissibleCoeff_bracket (hV : 0 < Fintype.card V) (t : ℕ) (ht : 1 ≤ 
   have hpow : 1 ≤ 2 ^ k := Nat.one_le_two_pow
   exact ⟨hlow, by omega⟩
 
+/-- **Unconditional positivity step (explicit `t₀` for every ground set).**  The
+    positivity criterion `admissibleCoeff_pos_iff` requires the side condition
+    `|V| ≤ 2^{t-1}`; here we discharge it with a *concrete, computable* step valid
+    for arbitrary ground sets.  As soon as `t` exceeds `|V|`, the elementary bound
+    `|V| < 2^{|V|} ≤ 2^{t-1}` supplies the hypothesis, so
+
+        `|V| < t  ⟹  0 < c(t)`.
+
+    Thus `t₀ = |V| + 1` is an explicit positivity threshold that does not require
+    knowing where `2^{t-1}` overtakes `|V|` — the crude gap `2^{|V|} > |V|` already
+    forces it.  (This `t₀` is far from the sharp `⌈log₂|V|⌉ + 1`, but it is
+    unconditional and computable directly from `|V|`.) -/
+theorem admissibleCoeff_pos_of_card_lt (hV : 0 < Fintype.card V) (t : ℕ)
+    (ht : Fintype.card V < t) :
+    0 < firstMomentThreshold t / Fintype.card V := by
+  refine (admissibleCoeff_pos_iff hV t).mpr ?_
+  have h1 : Fintype.card V < 2 ^ (Fintype.card V) := Nat.lt_two_pow_self
+  have h2 : 2 ^ (Fintype.card V) ≤ 2 ^ (t - 1) :=
+    Nat.pow_le_pow_right (by norm_num) (by omega)
+  calc Fintype.card V ≤ 2 ^ (Fintype.card V) := le_of_lt h1
+    _ ≤ 2 ^ (t - 1) := h2
+    _ = firstMomentThreshold t := rfl
+
+/-- **Unconditional effective exponential divergence.**  Feeding the explicit
+    positivity step `admissibleCoeff_pos_of_card_lt` into the iterated lower bound
+    `admissibleCoeff_two_pow_mul_le` removes *all* side conditions relating `|V|` to
+    the threshold: for every nonempty ground set and every target exponent `k`,
+
+        `2^k ≤ c(|V| + 1 + k)`.
+
+    This is the fully explicit, hypothesis-free form of the divergence
+    `firstMomentThreshold_tendsto_atTop` / `exists_admissible_coeff`: it names, for
+    each `k`, the concrete step `|V| + 1 + k` at which the admissible sparseness
+    coefficient of a bounded ground set already exceeds `2^k`.  Proof: `1 ≤ c(|V|+1)`
+    from the positivity step, then scale the iterated bound `2^k·c(|V|+1) ≤ c(|V|+1+k)`. -/
+theorem admissibleCoeff_ge_two_pow_of_card (hV : 0 < Fintype.card V) (k : ℕ) :
+    2 ^ k ≤ firstMomentThreshold (Fintype.card V + 1 + k) / Fintype.card V := by
+  have ht : (1 : ℕ) ≤ Fintype.card V + 1 := by omega
+  have hpos : 0 < firstMomentThreshold (Fintype.card V + 1) / Fintype.card V :=
+    admissibleCoeff_pos_of_card_lt hV (Fintype.card V + 1) (by omega)
+  have hmul := admissibleCoeff_two_pow_mul_le hV (Fintype.card V + 1) ht k
+  calc 2 ^ k = 2 ^ k * 1 := (mul_one _).symm
+    _ ≤ 2 ^ k * (firstMomentThreshold (Fintype.card V + 1) / Fintype.card V) :=
+        Nat.mul_le_mul (le_refl _) hpos
+    _ ≤ firstMomentThreshold (Fintype.card V + 1 + k) / Fintype.card V := hmul
+
 end Erdos1022OQ02

--- a/research/problems/erdos-1022-oq-02/knowledge.md
+++ b/research/problems/erdos-1022-oq-02/knowledge.md
@@ -58,3 +58,32 @@ Coefficient theory now: one-step bracket + multi-step bracket + explicit positiv
 + explicit exponential lower bound. Still open (unchanged): Lovász LLL for growing ground sets,
 not session-sized. NOTE json meta.leanFile is STALE (391L/16thm; actual 437→482L, now 20 thm) —
 mechanic should resync lineCount/theoremCount.
+
+## Session 2026-07-09 (researcher-2) — unconditional (hypothesis-free) effective divergence
+
+Prior sessions made the coefficient c(t)=⌊2^{t-1}/|V|⌋ divergence *effective* but
+**conditional**: `admissibleCoeff_pos_iff` (0<c(t) ↔ |V|≤2^{t-1}) and
+`admissibleCoeff_ge_two_pow_of_le` (|V|≤2^{t-1} ⟹ 2^k ≤ c(t+k)) both carry the side
+hypothesis `|V| ≤ 2^{t-1}`. This session discharges that hypothesis with an explicit
+computable step, making the divergence unconditional (2 thm, 505→551 L / 21→23 thm):
+- `admissibleCoeff_pos_of_card_lt`: |V| < t ⟹ 0 < c(t). Proof: `(pos_iff).mpr` needs
+  |V| ≤ 2^{t-1}; supplied by `Nat.lt_two_pow_self` (|V| < 2^{|V|}) chained with
+  `Nat.pow_le_pow_right (norm_num) (omega: |V| ≤ t-1)` (2^{|V|} ≤ 2^{t-1}), then `rfl`
+  for firstMomentThreshold t = 2^{t-1}. So t₀ = |V|+1 is an explicit (non-sharp,
+  vs ⌈log₂|V|⌉+1) positivity threshold computable directly from |V|.
+- `admissibleCoeff_ge_two_pow_of_card`: for EVERY ground set & every k, 2^k ≤ c(|V|+1+k)
+  — no hypothesis relating |V| to the threshold. Near-exact structural copy of the
+  verified `admissibleCoeff_ge_two_pow_of_le` with the pos hypothesis discharged by
+  `admissibleCoeff_pos_of_card_lt`. Fully explicit hypothesis-free form of
+  `firstMomentThreshold_tendsto_atTop`.
+
+**Recipe** (turn conditional effective bound → unconditional): `Nat.lt_two_pow_self`
+(implicit n, protected) gives n<2^n; `Nat.pow_le_pow_right (hx:2>0) (i≤j)` for base
+monotonicity; feed into the existing pos_iff + iterated-lower-bound assembly.
+
+DOCKER FULLY DOWN this session (containerd meta.db `input/output error` at IMAGE build,
+`docker images` errors on blob, disk healthy 116Gi — known infra corruption, not
+SIGBUS). UNVERIFIED. Proof is pure assembly of verified siblings + one elementary
+Mathlib fact; high confidence. NOTE meta.json leanFile counts stale (mechanic resync:
+now 551 L / 23 thm / 3 def / 0 axiom / 0 sorry). First-moment regime remains exhausted;
+Lovász LLL for growing ground sets still out of scope.


### PR DESCRIPTION
## Summary

Erdős #1022 OQ-02 (growth rate of the Property-B sparseness threshold). Prior sessions made the divergence of the admissible coefficient `c(t)=⌊2^{t-1}/|V|⌋` **effective but conditional** — both `admissibleCoeff_pos_iff` and `admissibleCoeff_ge_two_pow_of_le` carry the side hypothesis `|V| ≤ 2^{t-1}`. This PR discharges that hypothesis with an explicit computable step, yielding **unconditional, hypothesis-free** statements valid for every bounded ground set.

## New theorems (2, 0 axioms, 0 sorries)

- `admissibleCoeff_pos_of_card_lt`: `|V| < t ⟹ 0 < c(t)`. Proof chains `|V| < 2^{|V|}` (`Nat.lt_two_pow_self`) with `2^{|V|} ≤ 2^{t-1}` (`Nat.pow_le_pow_right`) to supply the `pos_iff` hypothesis. Gives an explicit (non-sharp) positivity threshold `t₀ = |V|+1` computable directly from `|V|`.
- `admissibleCoeff_ge_two_pow_of_card`: `2^k ≤ c(|V|+1+k)` for **every** ground set and every `k` — the fully explicit, hypothesis-free form of `firstMomentThreshold_tendsto_atTop`. Near-exact structural copy of the verified `admissibleCoeff_ge_two_pow_of_le` with the positivity hypothesis discharged.

Both are pure assembly of already-verified sibling lemmas (`admissibleCoeff_pos_iff`, `admissibleCoeff_two_pow_mul_le`) plus one elementary Mathlib fact.

## Verification status

⚠️ **UNVERIFIED** — Docker build infrastructure is down this session (containerd `meta.db` `input/output error` at image build; `docker images` errors on a corrupt blob; host disk healthy at 116Gi). Could not run `docker-build.sh`. Signatures (`Nat.lt_two_pow_self`, `Nat.pow_le_pow_right {n}(hx:n>0){i}: i≤j → n^i≤n^j`) checked against the pinned toolchain source; `firstMomentThreshold t = 2^{t-1}` closes by `rfl`. High confidence pending a clean rebuild.

First-moment regime remains exhausted; Lovász-LLL for growing ground sets is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)