### PR TITLE
research(erdos-659-oq-05): anisotropy and unit structure of the norm form x²+2y²

### DIFF
--- a/proofs/Proofs/Erdos659OQ05.lean
+++ b/proofs/Proofs/Erdos659OQ05.lean
@@ -19,6 +19,9 @@
 
     * `Q_mul`             : the Brahmagupta composition law for D = 2,
     * `Q_eq_zsqrtd_norm`  : Q is exactly the norm of `ℤ√(-2)`,
+    * `Q_eq_zero_iff`     : anisotropy — Q vanishes only at the origin (the norm
+                            has trivial kernel, so `ℤ[√-2]` is a domain),
+    * `Q_eq_one_iff`      : the units are `±1` — the only norm-1 vectors are `(±1,0)`,
     * `isRepresented_mul` : the integers represented by Q are closed under
                             multiplication (a submonoid of (ℤ, ·)),
     * `dist_sq_lattice`   : the squared Euclidean distance between two lattice
@@ -68,6 +71,52 @@ theorem isRepresented_two : IsRepresented 2 := ⟨0, 1, by decide⟩
 theorem isRepresented_nonneg {n : ℤ} (hn : IsRepresented n) : 0 ≤ n := by
   obtain ⟨x, y, rfl⟩ := hn
   unfold Q; positivity
+
+/-- **Anisotropy (positive-definiteness).**  The form `Q(x, y) = x² + 2y²` vanishes
+    *only* at the origin: `Q x y = 0 ↔ x = 0 ∧ y = 0`.  Equivalently the norm map
+    `ℤ√(-2) → ℤ` has trivial kernel, which is the algebraic reason `ℤ[√-2]` is an
+    integral domain — the multiplicative structure `Q_mul` never collapses a nonzero
+    lattice vector to a zero distance. -/
+theorem Q_eq_zero_iff (x y : ℤ) : Q x y = 0 ↔ x = 0 ∧ y = 0 := by
+  unfold Q
+  constructor
+  · intro h
+    have hx2 : (0 : ℤ) ≤ x ^ 2 := sq_nonneg x
+    have hy2 : (0 : ℤ) ≤ y ^ 2 := sq_nonneg y
+    have hxz : x ^ 2 = 0 := by omega
+    have hyz : y ^ 2 = 0 := by omega
+    exact ⟨pow_eq_zero_iff (by norm_num) |>.mp hxz,
+           pow_eq_zero_iff (by norm_num) |>.mp hyz⟩
+  · rintro ⟨rfl, rfl⟩; norm_num
+
+/-- **The value `1` is represented only trivially — the unit group is `{±1}`.**
+    `Q x y = 1 ↔ (x = 1 ∨ x = -1) ∧ y = 0`.  Since `2y² ≤ 1` forces `y = 0` and then
+    `x² = 1` forces `x = ±1`, the only lattice vectors at squared distance `1` from the
+    origin are `(±1, 0)`.  This is exactly the statement that the units of `ℤ[√-2]`
+    (norm-`1` elements) are just `±1`, complementing the anisotropy `Q_eq_zero_iff`. -/
+theorem Q_eq_one_iff (x y : ℤ) : Q x y = 1 ↔ (x = 1 ∨ x = -1) ∧ y = 0 := by
+  unfold Q
+  constructor
+  · intro h
+    have hx2 : (0 : ℤ) ≤ x ^ 2 := sq_nonneg x
+    have hy2 : (0 : ℤ) ≤ y ^ 2 := sq_nonneg y
+    have hyz : y ^ 2 = 0 := by omega
+    have hxone : x ^ 2 = 1 := by omega
+    have hy : y = 0 := pow_eq_zero_iff (by norm_num) |>.mp hyz
+    have hfac : (x - 1) * (x + 1) = 0 := by linear_combination hxone
+    rcases mul_eq_zero.mp hfac with hh | hh
+    · exact ⟨Or.inl (by linarith), hy⟩
+    · exact ⟨Or.inr (by linarith), hy⟩
+  · rintro ⟨hx | hx, rfl⟩ <;> subst hx <;> norm_num
+
+/-- **Strict positivity off the origin.**  Every nonzero lattice vector sits at a
+    strictly positive squared distance from the origin: `Q x y > 0` whenever
+    `(x, y) ≠ (0, 0)`.  A direct consequence of `isRepresented_nonneg` and the
+    anisotropy `Q_eq_zero_iff`. -/
+theorem Q_pos_of_ne (x y : ℤ) (h : ¬(x = 0 ∧ y = 0)) : 0 < Q x y := by
+  rcases lt_or_eq_of_le (isRepresented_nonneg ⟨x, y, rfl⟩) with hlt | heq
+  · exact hlt
+  · exact absurd ((Q_eq_zero_iff x y).mp heq.symm) h
 
 /-- **Multiplicative closure.**
 


### PR DESCRIPTION
## Summary

The OQ-05 file for Erdős #659 formalizes the norm form `Q(x,y)=x²+2y²` of `ℤ[√-2]` — the arithmetic behind the Moree–Osburn sparse-distance lattice. It already captures the **multiplicative** structure (Brahmagupta `Q_mul`, `representedSubmonoid`, `isRepresented_mul`, finite products). This PR adds the complementary **anisotropy / unit** structure, which the file previously lacked.

## New theorems (all 0-axiom, 0-sorry)

- **`Q_eq_zero_iff`** — `Q x y = 0 ↔ x = 0 ∧ y = 0`: positive-definiteness / anisotropy. Equivalently the norm map `ℤ√(-2) → ℤ` has trivial kernel, the algebraic reason `ℤ[√-2]` is an integral domain (no nonzero lattice vector has zero squared distance).
- **`Q_eq_one_iff`** — `Q x y = 1 ↔ (x = 1 ∨ x = -1) ∧ y = 0`: the unit group of `ℤ[√-2]` is exactly `{±1}` (the only norm-1 vectors are `(±1, 0)`), complementing the multiplicative closure with the multiplicative-identity/unit picture.
- **`Q_pos_of_ne`** — `0 < Q x y` for `(x,y) ≠ (0,0)`: strict positivity off the origin, a direct corollary of `isRepresented_nonneg` and the anisotropy.

## Verification status

⚠️ **UNVERIFIED** — Docker build infrastructure is down this session (containerd `meta.db` input/output error at the image-build step; no cached lean image). Proofs hand-verified: `Q_eq_zero_iff`/`Q_eq_one_iff` use `omega` over the integer atoms `x²,y²` (the key integrality step `2y² ≤ 1 ⟹ y = 0`), `pow_eq_zero_iff`, and `linear_combination` (`x²=1 ⟹ (x-1)(x+1)=0`); `Q_pos_of_ne` uses `lt_or_eq_of_le`. Recommend a clean build to confirm before/at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)