### PR TITLE
research(liouville-theorem-oq-03): very-well-approximable reals form a Lebesgue-null set

### DIFF
--- a/proofs/Proofs/LiouvilleTheoremOQ03.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ03.lean
@@ -344,4 +344,31 @@ theorem volume_liouville_eq_zero :
     volume {x : ℝ | Liouville x} = 0 :=
   measure_mono_null (liouville_subset_wellApprox 3) (volume_wellApprox_eq_zero (by norm_num))
 
+open MeasureTheory in
+/-- **The very-well-approximable reals form a Lebesgue-null set.** The set of `x`
+that are `τ`-well-approximable for *some* exponent `τ > 2` — the union
+`⋃_{τ > 2} W τ` — is Lebesgue-null, strengthening the fixed-exponent statement
+`volume_wellApprox_eq_zero` from each individual `W τ` to their whole union.
+
+This is the sharp measure-theoretic form of Khintchine's convergence theorem: for
+almost every real number the irrationality measure is *exactly* `2`. The proof
+covers the union by the countable subfamily `W(2 + 1/(n+1))` (any `τ > 2` exceeds
+`2 + 1/(n+1)` for some `n`, and `W τ ⊆ W(2 + 1/(n+1))` by antitonicity), each of
+which is null by `volume_wellApprox_eq_zero`, then applies countable subadditivity.
+Since the Liouville numbers are `τ`-well-approximable for every `τ` (in particular
+some `τ > 2`), this re-proves and generalises `volume_liouville_eq_zero`. -/
+theorem volume_setOf_exists_liouvilleWith_gt_two_eq_zero :
+    volume {x : ℝ | ∃ τ : ℝ, 2 < τ ∧ LiouvilleWith τ x} = 0 := by
+  have hsub : {x : ℝ | ∃ τ : ℝ, 2 < τ ∧ LiouvilleWith τ x}
+      ⊆ ⋃ n : ℕ, wellApprox (2 + 1 / ((n : ℝ) + 1)) := by
+    rintro x ⟨τ, hτ, hx⟩
+    obtain ⟨n, hn⟩ := exists_nat_one_div_lt (sub_pos.mpr hτ)
+    refine Set.mem_iUnion.2 ⟨n, ?_⟩
+    have hle : 2 + 1 / ((n : ℝ) + 1) ≤ τ := by linarith
+    exact hx.mono hle
+  refine measure_mono_null hsub (measure_iUnion_null (fun n => ?_))
+  refine volume_wellApprox_eq_zero ?_
+  have hpos : (0 : ℝ) < 1 / ((n : ℝ) + 1) := by positivity
+  linarith
+
 end LiouvilleTheoremOQ03

--- a/src/data/proofs/liouville-theorem-oq-03/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-03/meta.json
@@ -23,8 +23,8 @@
     "dateAdded": "2026-06-24",
     "axiomCount": 1,
     "assumptions": "One axiom: `dimH_wellApprox` — the Jarník–Besicovitch dimension formula dimH(W τ) = ENNReal.ofReal(2/τ) for τ ≥ 2. This is the deep theorem of metric Diophantine approximation (Jarník 1931, Besicovitch 1934) and is not yet available in Mathlib (the upper bound requires a covering/Borel–Cantelli Hausdorff-measure estimate; the lower bound a mass-distribution principle / Frostman construction on a Cantor subset). `#print axioms` confirms: the structural lemmas (wellApprox_antitone, liouville_subset_wellApprox, dimH_liouville_le_wellApprox, and the jbDim exponent facts) depend on no axioms beyond the standard foundational trio; only the formula-dependent results (dimH_wellApprox_two, dimH_liouville_le, dimH_liouville_eq_zero, the summary) carry dimH_wellApprox.",
-    "lineCount": 347,
-    "theoremCount": 24,
+    "lineCount": 374,
+    "theoremCount": 25,
     "definitionCount": 2,
     "originalContributions": [
       "wellApprox τ := {x | LiouvilleWith τ x}: the τ-well-approximable sets, packaged on top of Mathlib's LiouvilleWith with the JB exponent in mind",
@@ -134,9 +134,9 @@
     "path": "Proofs/LiouvilleTheoremOQ03.lean",
     "sorries": 0,
     "axiomCount": 1,
-    "theoremCount": 24,
+    "theoremCount": 25,
     "definitionCount": 2,
-    "lineCount": 347
+    "lineCount": 374
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Adds `volume_setOf_exists_liouvilleWith_gt_two_eq_zero` to Part VII (the measure side) of `LiouvilleTheoremOQ03.lean`: the set of reals that are `τ`-well-approximable for **some** exponent `τ > 2`,
`{x | ∃ τ, 2 < τ ∧ LiouvilleWith τ x} = ⋃_{τ>2} W τ`,
is Lebesgue-null.

This is the sharp measure-theoretic form of **Khintchine's convergence theorem**: for almost every real number the irrationality measure is *exactly* 2. It strengthens the existing fixed-exponent result `volume_wellApprox_eq_zero` (null for each individual `W τ`, `τ > 2`) to the whole union over all `τ > 2`, and re-derives/generalises `volume_liouville_eq_zero` (the Liouville numbers are `τ`-well-approximable for every `τ`, in particular some `τ > 2`).

## Proof

Cover the union by the countable subfamily `W(2 + 1/(n+1))`: any `τ > 2` exceeds `2 + 1/(n+1)` for some `n` (`exists_nat_one_div_lt`), and `W τ ⊆ W(2 + 1/(n+1))` by antitonicity (`LiouvilleWith.mono`). Each `W(2 + 1/(n+1))` is null by `volume_wellApprox_eq_zero`, so countable subadditivity (`measure_iUnion_null` + `measure_mono_null`) finishes.

Reuses only this file's own antitonicity and measure-null lemmas plus standard Mathlib measure API.

## Scope

- 0 new axioms (the entry still carries only the single Jarník–Besicovitch axiom `dimH_wellApprox`), 0 sorries.
- Gallery meta synced: `lineCount` 347→374, `theoremCount` 24→25.

## Verification status

⚠️ **UNVERIFIED** — the Docker Lean image build was down for the entire session (containerd `meta.db` input/output error at the image-build stage; operator-level, not self-fixable). The proof follows the file's existing `wellApprox_antitone` / `volume_wellApprox_eq_zero` patterns; every API step (`LiouvilleWith.mono`, `exists_nat_one_div_lt`, `measure_iUnion_null`, `measure_mono_null`, `sub_pos.mpr`) was checked by hand against existing in-file usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)