### PR TITLE
research(erdos-748-incomplete-01): prove table values f(4)=9, f(5)=16

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -526,6 +526,17 @@ theorem f_1 : f 1 = 2 := by decide
 theorem f_2 : f 2 = 3 := by decide
 theorem f_3 : f 3 = 6 := by decide
 
+/-- `f 4 = 9`: the nine sum-free subsets of `{1,2,3,4}` are `∅`, `{1}`, `{2}`, `{3}`,
+    `{4}`, `{1,3}`, `{2,3}`, `{3,4}`, `{1,4}` (every subset containing `{1,2}`, `{2,4}`,
+    or `{1,3,4}` is excluded, since `2 = 1+1`, `4 = 2+2`, `4 = 1+3`). This upgrades the
+    table value `f(4) = 9` above from prose to a machine-checked (kernel `decide`) fact. -/
+theorem f_4 : f 4 = 9 := by decide
+
+/-- `f 5 = 16`: upgrades the table value `f(5) = 16` above from prose to a kernel-`decide`
+    fact. Beyond the `n = 4` exclusions this adds `5 = 1+4` and `5 = 2+3`, forbidding the
+    subsets containing `{1,4,5}` or `{2,3,5}`. -/
+theorem f_5 : f 5 = 16 := by decide
+
 /-
 ## Part IX: Summary
 -/

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -58,9 +58,9 @@
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 2,
-    "lineCount": 564,
+    "lineCount": 575,
     "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The lower bound is fully proved (no longer an axiom), and sharpened to f(n) ≥ 2^{⌈n/2⌉} (sharp_lower_bound) — the best the upper-half construction yields. See the Lean source for details.",
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 5,
     "additionalFiles": [
       "Proofs/Erdos748Aristotle.lean"
@@ -180,9 +180,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 564,
+    "lineCount": 575,
     "axiomCount": 2,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

The Cameron–Erdős sum-free-set counting file states a small-value table (`f(1)=2, f(2)=3, f(3)=6, f(4)=9, f(5)=16`) in prose but only proves the first three as theorems. This adds **`f_4 : f 4 = 9`** and **`f_5 : f 5 = 16`**, upgrading the two prose values to machine-checked facts.

- Uses the file's established **kernel `decide`** pattern (axiom-free — no `native_decide`, so no `Lean.ofReduceBool`; no new axioms).
- Both values independently verified by full enumeration of the sum-free subsets (`a ≠ b+c` over `{1,…,n}`, `b,c` may coincide):
  - `f(4)=9`: subsets containing `{1,2}` (`2=1+1`), `{2,4}` (`4=2+2`), or `{1,3,4}` (`4=1+3`) are excluded → 9 of 16 survive.
  - `f(5)=16`: additionally exclude `{1,4,5}` (`5=1+4`) and `{2,3,5}` (`5=2+3`) → 16 of 32 survive.

### Verification
- Gallery meta resynced: `lineCount` 564→575, `theoremCount` +2.
- **UNVERIFIED**: docker build infra is down this session (containerd `meta.db` input/output error). The `decide` values are confirmed by the hand enumeration above; the two theorems match the file's own prose table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)