### PR TITLE
research(puiseux-theorem-wip-01): ramification tower exhausts the Puiseux subring

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -1060,6 +1060,26 @@ theorem puiseuxRamificationSubring_mono {K : Type*} [Ring K] {n n' : ℕ+} (hdvd
     puiseuxRamificationSubring K n ≤ puiseuxRamificationSubring K n' :=
   fun _ hx => IsPuiseuxOfRamification.mono hdvd hx
 
+/-- **Every level sits inside the full Puiseux subring.** A `(1/n)`-ramified series is
+a fortiori a Puiseux series (take the ramification witness to be `n`), so each floor of
+the tower is bounded above by `puiseuxSubring K`. -/
+theorem puiseuxRamificationSubring_le_puiseuxSubring {K : Type*} [Ring K] (n : ℕ+) :
+    puiseuxRamificationSubring K n ≤ puiseuxSubring K :=
+  fun _ hx => ⟨n, hx⟩
+
+/-- **The ramification tower exhausts the Puiseux subring.** The directed union
+`⨆ n, puiseuxRamificationSubring K n` of the level-`n` Laurent subrings is exactly the
+full Puiseux subring: every level embeds (`puiseuxRamificationSubring_le_puiseuxSubring`)
+and every Puiseux series lands in *some* level (`isPuiseux_iff_exists_ramification`). This
+is the colimit description `K⦃⦃x⦄⦄ = colim_n K((x^{1/n}))` at the ring level. -/
+theorem iSup_puiseuxRamificationSubring {K : Type*} [Ring K] :
+    (⨆ n : ℕ+, puiseuxRamificationSubring K n) = puiseuxSubring K := by
+  refine le_antisymm (iSup_le puiseuxRamificationSubring_le_puiseuxSubring) ?_
+  intro x hx
+  rw [mem_puiseuxSubring] at hx
+  obtain ⟨n, hn⟩ := hx
+  exact (le_iSup (puiseuxRamificationSubring K) n) hn
+
 end Filtration
 
 /-! ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes a stated-but-unproved gap in **Part XI (the ramification filtration)** of `PuiseuxTheorem.lean` (Wiedijk #41). The section docstring advertises the colimit description "the directed union of the tower is the full Puiseux subring," but only the tower (`puiseuxRamificationSubring K n`) and its monotonicity (`puiseuxRamificationSubring_mono`) were formalized. This PR states and proves the union.

## New results

- **`puiseuxRamificationSubring_le_puiseuxSubring`** — each level `n` embeds in the full Puiseux subring: a `(1/n)`-ramified series is a fortiori a Puiseux series (ramification witness `n`).
- **`iSup_puiseuxRamificationSubring`** — `(⨆ n : ℕ+, puiseuxRamificationSubring K n) = puiseuxSubring K`. The ring-level colimit `K⦃⦃x⦄⦄ = colim_n K((x^{1/n}))`.
  - `≤`: `iSup_le` of the level embeddings.
  - `≥`: `le_iSup` applied to the ramification witness of each Puiseux series (`isPuiseux_iff_exists_ramification`).

Both are `[Ring K]`-level, consistent with the existing `puiseuxSubring`/`puiseuxRamificationSubring`. 0-sorry / 0 substantive axioms.

## Verification status

⚠️ **UNVERIFIED** — the docker build infrastructure is down at the daemon level (`containerd meta.db input/output error`; host disk healthy, 118Gi free). No `lake build` is possible in this environment, so the file was not machine-checked here.

Confidence is high, based on API cross-checked against the local Mathlib pin:
- `le_iSup (f : ι → α) (i : ι) : f i ≤ iSup f` — `Order/CompleteLattice/Basic.lean:317`
- `iSup_le (h : ∀ i, f i ≤ a) : iSup f ≤ a` — `Order/CompleteLattice/Basic.lean:358`
- `instance : CompleteLattice (Subring R)` — `Algebra/Ring/Subring/Basic.lean:337`
- The `≤`-as-membership application idiom is already used at `PuiseuxTheorem.lean:1060` (`puiseuxRamificationSubring_mono`).

A build should be run once docker infra recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)