### PR TITLE
research(burnside-counting-oq-02): general cyclic-necklace count in divisor-sum form

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ03.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03.lean
@@ -397,6 +397,22 @@ theorem polya_necklace_formula_statement (n k : ℕ) [NeZero n]
   rw [h_burnside]
   exact Finset.sum_congr rfl (fun r _ => h_fixed r)
 
+/-- **Cyclic necklace count in divisor-sum form.** Combining Burnside's lemma and
+    Pólya's fixed-point formula (the two hypotheses of `polya_necklace_formula_statement`)
+    with the general reindexing identity `polya_sum_identity`, the number of `k`-colored
+    cyclic necklaces of length `n` satisfies the classical divisor-sum formula
+    `n · necklace_count = Σ_{d | n} φ(n/d) · k^d`. This generalizes the concrete
+    `polya_binary4_divisor_form` (n = 4, k = 2) to arbitrary `n, k`. -/
+theorem polya_necklace_divisor_formula (n k : ℕ) [NeZero n]
+    (necklace_count : ℕ)
+    (h_burnside : n * necklace_count =
+      ∑ r : Fin n, Fintype.card {c : Fin n → Fin k // IsFixed n k r c})
+    (h_fixed : ∀ r : Fin n,
+      Fintype.card {c : Fin n → Fin k // IsFixed n k r c} = k ^ Nat.gcd r.val n) :
+    n * necklace_count = ∑ d ∈ Nat.divisors n, Nat.totient (n / d) * k ^ d := by
+  rw [polya_necklace_formula_statement n k necklace_count h_burnside h_fixed]
+  exact polya_sum_identity n k (Nat.pos_of_ne_zero (NeZero.ne n))
+
 #check @MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group
 #check ZMod.addOrderOf_coe
 #check ZMod.natCast_zmod_val

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -25,8 +25,8 @@
     "axiomCount": 1,
     "assumptions": "0 sorries, 0 literal `axiom` declarations. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis. However, the concrete §4/§5 verification theorems (fp_count_rot0_4_2, fp_count_rot1_4_2, fp_count_rot2_4_2, fp_count_rot3_4_2, fp_sum_binary4, polya_sum_Z4_binary) discharge their finite Fintype.card computations using `native_decide`, which depends on the `Lean.ofReduceBool` axiom (Lean compiler kernel reduction); those named theorems are therefore not axiom-free. Hence axiomCount = 1; leanFile.axiomCount remains 0 since there are no literal `axiom` declarations.",
     "dateAdded": "2026-04-04",
-    "lineCount": 404,
-    "theoremCount": 18,
+    "lineCount": 420,
+    "theoremCount": 19,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/BurnsideCountingOQ03Aristotle.lean",


### PR DESCRIPTION
## Summary

Adds `polya_necklace_divisor_formula` to `Proofs/BurnsideCountingOQ03.lean` (the designated clean source for the `burnside-counting-oq-02` entry): given Burnside's lemma and Pólya's fixed-point formula `|Fix(r)| = k^gcd(r,n)`, the number of `k`-colored cyclic necklaces of length `n` satisfies the classical **divisor-sum formula**
```
n · necklace_count = Σ_{d | n} φ(n/d) · k^d
```

This generalizes the concrete `polya_binary4_divisor_form` (n=4, k=2, giving 6 binary 4-necklaces) to **arbitrary n, k**, by composing two already-merged theorems in the same file:
- `polya_necklace_formula_statement` — `n·count = Σ_r k^gcd(r,n)`
- `polya_sum_identity` — the general gcd-fiber reindexing `Σ_r k^gcd(r,n) = Σ_{d|n} φ(n/d)·k^d`

The proof is a two-line `rw` + `exact`. No new axioms or sorries. Gallery meta (`burnside-counting-oq-03`) counts synced (lineCount 404→420, theoremCount 18→19).

## Verification
⚠️ **UNVERIFIED** — Docker build infra is down this session (containerd `meta.db` input/output error at image build). The theorem is a pure composition of previously build-verified theorems (`polya_necklace_formula_statement`, `polya_sum_identity`); confidence high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)