### PR TITLE
Enrich p-group-center ↔ p²-abelian: cross-cluster application link

### DIFF
--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
@@ -136,6 +136,11 @@
       "targetId": "conjugacy-class-equation-oq-01-oq-01",
       "relationship": "uses",
       "description": "Sibling entry proving the class equation in index form |G| = |Z(G)| + Σ [G : C_G(gᵢ)]. That is precisely the identity this entry applies: for a p-group each nontrivial-class index [G : C_G(gᵢ)] is divisible by p, so p divides |Z(G)|, forcing the center to be nontrivial."
+    },
+    {
+      "targetId": "sylow-theorem-oq-05",
+      "relationship": "applied-in",
+      "description": "Flagship application in the Sylow chain: 'Groups of Order p² are Abelian'. Its abelianness step is Mathlib's IsPGroup.commutative_of_card_eq_prime_sq, whose proof is exactly the chain formalized here — class equation ⇒ nontrivial centre ⇒ |Z(G)| ∈ {p, p²} ⇒ G/Z(G) cyclic ⇒ G abelian. This entry supplies the first, foundational link (nontrivial centre) of that classification; oq-05 then refines the p²-order case into its cyclic vs elementary-abelian dichotomy."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/sylow-theorem-oq-05/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-05/meta.json
@@ -147,6 +147,11 @@
       "targetId": "lagrange-theorem",
       "relationship": "foundational",
       "description": "Lagrange's Theorem (the order of an element divides the order of the group) is the sole tool separating the two isomorphism types: it forces orderOf g ∈ {1, p, p²}, so a maximal-order element gives the cyclic ℤ/p² case and its absence forces g^p = 1 for all g, the elementary-abelian (ℤ/p)² case."
+    },
+    {
+      "targetId": "conjugacy-class-equation-oq-01-oq-02",
+      "relationship": "foundational",
+      "description": "Supplies the class-equation proof of the step this entry imports: a nontrivial finite p-group has nontrivial centre. That is the first link of the chain inside Mathlib's IsPGroup.commutative_of_card_eq_prime_sq (nontrivial centre ⇒ |Z(G)| ∈ {p, p²} ⇒ G/Z(G) cyclic ⇒ G abelian) which this entry takes as its abelian base before adding the ℤ/p² vs (ℤ/p)² dichotomy."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass connecting a foundational group-theory lemma to its flagship application.

## Gap
`conjugacy-class-equation-oq-01-oq-02` gives the class-equation proof that a nontrivial finite p-group has nontrivial centre. `sylow-theorem-oq-05` (Groups of Order p² Are Abelian) imports its abelianness from Mathlib's `IsPGroup.commutative_of_card_eq_prime_sq`, whose internal proof is exactly *class equation ⇒ nontrivial centre ⇒ |Z(G)| ∈ {p,p²} ⇒ G/Z(G) cyclic ⇒ abelian*. The p-group-centre lemma is the foundational first step of the p²-abelian classification, yet the two entries were **not linked in either direction**.

(The claimed target's own cluster — parent `oq-01`, sibling `oq-01-oq-01` — is already fully reciprocal, so there was no within-cluster gap.)

## Change
Bidirectional cross-reference: `conjugacy-class-equation-oq-01-oq-02` → `sylow-theorem-oq-05` (applied-in), and `sylow-theorem-oq-05` → back (foundational).

## Notes
- Neither entry deepened (both ~quality 95, at target); the value is the missing cross-cluster navigation between a foundational lemma and its flagship application.
- Sizes: conjugacy 14.8→15.4KB (2→3 crossRefs); sylow-oq-05 11.4→11.9KB (3→4 crossRefs). Well under caps. JSON validates.