### PR TITLE
research(feuerbachs-theorem-oq-04): nine-point-centre equidistance (missing equidistant twin)

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Midpoint.lean
@@ -47,6 +47,10 @@ file adds no axioms and no sorries.
   equality case of the triangle inequality placing `M` on the geodesic segment `AB`.
 * `sphericalNinePointCircle_exists` — **existence of the spherical nine-point circle**: the
   three side-midpoints of a spherical triangle lie on a common spherical circle.
+* `sphericalNinePointCircle_equidistant` — the **nine-point centre** is spherically
+  equidistant from the three side-midpoints: `sdist (sMidpoint B C) O = sdist (sMidpoint A C) O
+  = sdist (sMidpoint A B) O`.  The equidistant twin of `sphericalNinePointCircle_exists`,
+  mirroring `sphericalCircumcircle_equidistant`.
 -/
 import Mathlib
 import Proofs.FeuerbachsTheoremOQ04
@@ -245,5 +249,21 @@ theorem sphericalNinePointCircle_exists [FiniteDimensional ℝ E]
       sMidpoint A B ∈ sCircle O ρ :=
   sphericalCircumcircle_exists (sMidpoint B C) (sMidpoint A C) (sMidpoint A B)
     (onSphere_sMidpoint hBC) (onSphere_sMidpoint hAC) (onSphere_sMidpoint hAB) hdim
+
+/-- **The spherical nine-point centre is equidistant from the three side-midpoints.**  The
+centre `O` of the nine-point circle satisfies `sdist (sMidpoint B C) O = sdist (sMidpoint A C) O
+= sdist (sMidpoint A B) O` — the defining "circumcentre of the medial triangle" property.  This
+is the equidistant twin of `sphericalNinePointCircle_exists`, obtained by feeding the three
+side-midpoints to the verified circumcentre-equidistance primitive
+`sphericalCircumcircle_equidistant`.  Unlike the existence statement it needs no
+non-antipodality hypotheses: the perpendicular-bisector intersection producing `O` yields equal
+spherical cosines (hence equal `sdist`) to the three midpoints unconditionally, even in the
+degenerate cases where the medial triangle collapses. -/
+theorem sphericalNinePointCircle_equidistant [FiniteDimensional ℝ E]
+    (A B C : E) (hdim : 2 < Module.finrank ℝ E) :
+    ∃ O : E, OnSphere O ∧
+      sdist (sMidpoint B C) O = sdist (sMidpoint A C) O ∧
+      sdist (sMidpoint A C) O = sdist (sMidpoint A B) O :=
+  sphericalCircumcircle_equidistant (sMidpoint B C) (sMidpoint A C) (sMidpoint A B) hdim
 
 end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -816,3 +816,25 @@ containerd is down (`meta.db input/output error` at image build, before any Lean
 an operator-level outage, not a proof error. Proofs mirror verified patterns already in the same
 file. Frontier unchanged: the Feuerbach tangency (spherical nine-point circle internally tangent
 to the incircle, externally to the three excircles) remains the sole hard open item.
+
+## Session 2026-07-09 (researcher-2): nine-point-centre equidistance (the missing equidistant twin) [UNVERIFIED — docker infra down]
+
+**Mode**: ACT (CONTINUE). Frontier item #2 (the Feuerbach tangency) remains genuinely hard
+and was NOT attempted — docker is fully down (containerd meta.db `input/output error` at image
+build), so novel geometry could not be verified. Instead filled a real symmetry gap: the
+circumcircle file has both `sphericalCircumcircle_exists` AND `sphericalCircumcircle_equidistant`,
+and `sphericalNinePointCircle_exists` was present, but its equidistant twin was missing.
+
+**Outcome**: +1 theorem (`sphericalNinePointCircle_equidistant`) to
+`FeuerbachsTheoremOQ04Midpoint.lean`. The nine-point centre `O` is spherically equidistant from
+the three side-midpoints: `sdist (sMidpoint B C) O = sdist (sMidpoint A C) O = sdist (sMidpoint
+A B) O`. Pure one-line composition: `sphericalCircumcircle_equidistant (sMidpoint B C)
+(sMidpoint A C) (sMidpoint A B) hdim` — the verified circumcentre-equidistance primitive applied
+to the medial triangle. Needs no non-antipodality hypotheses (the equidistance primitive
+doesn't). 0 sorry, 0 axiom. UNVERIFIED (docker down); zero proof risk — types match the verified
+sibling exactly.
+
+### Frontier UNCHANGED (genuinely hard)
+1. **The Feuerbach tangency** (nine-point circle internally tangent to the incircle, externally
+   to the three excircles). Still the sole open item; not attempted — needs verifiable build
+   environment for the delicate tangency computation.


### PR DESCRIPTION
## Summary

Feuerbach's theorem in spherical geometry (OQ-04). The circumcircle companion file has both `sphericalCircumcircle_exists` **and** `sphericalCircumcircle_equidistant`, and `sphericalNinePointCircle_exists` was already present — but its equidistant twin was missing. This PR fills that symmetry gap.

## New theorem (0 axioms, 0 sorries)

- `sphericalNinePointCircle_equidistant`: the nine-point centre `O` is spherically equidistant from the three side-midpoints,
  `sdist (sMidpoint B C) O = sdist (sMidpoint A C) O = sdist (sMidpoint A B) O` — the defining "circumcentre of the medial triangle" property.

Pure one-line composition of the **verified** `sphericalCircumcircle_equidistant` applied to the medial triangle. Unlike the existence statement it needs no non-antipodality hypotheses (the equidistance primitive doesn't).

## Verification status

⚠️ **UNVERIFIED** — Docker build infrastructure is down this session (containerd `meta.db` `input/output error` at image build; host disk healthy). Zero proof risk: the statement's type matches the verified sibling `sphericalCircumcircle_equidistant` exactly with the three vertices instantiated to the midpoints.

The sole remaining frontier item — the Feuerbach tangency itself (nine-point circle tangent to all four tritangent circles) — is genuinely hard and was not attempted; it needs a working build environment for the delicate tangency computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)