### PR TITLE
Enrich derangement-error cluster: reciprocal links into oq-03-oq-03

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-03-oq-02/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-02/meta.json
@@ -122,6 +122,11 @@
       "targetId": "derangements-convergence",
       "relationship": "related",
       "description": "Establishes the convergence rate |D(n)/n! - e⁻¹| ≤ 1/(n+1)!; this entry works with the integer recurrence directly rather than the analytic limit."
+    },
+    {
+      "targetId": "derangements-convergence-oq-03-oq-03",
+      "relationship": "sibling",
+      "description": "Companion sharpening of the same rounding recurrence in the analytic direction: it tightens the parent's error bound to the two-sided sandwich 1/(n+1) − 1/((n+1)(n+2)) ≤ |D(n) − n!/e| ≤ 1/(n+1), whereas this entry gives the exact ±1 one-term remainder in the discrete/modular direction. Reciprocal to that entry's sibling link here."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/derangements-convergence-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03/meta.json
@@ -145,6 +145,11 @@
       "targetId": "inclusion-exclusion",
       "relationship": "foundational",
       "description": "The derangement formula D(n) = n! · Σ_{k=0}^n (−1)^k/k! is derived via inclusion-exclusion: subtract from n! all permutations fixing at least one point. This is the foundational formula from which the convergence to e⁻¹ and the rounding characterization both flow."
+    },
+    {
+      "targetId": "derangements-convergence-oq-03-oq-03",
+      "relationship": "refined-by",
+      "description": "Child sharpening this entry's one-sided rounding bound |D(n) − n!/e| ≤ 1/(n+1) to a two-sided sandwich 1/(n+1) − 1/((n+1)(n+2)) ≤ |D(n) − n!/e| ≤ 1/(n+1), pinning the error to an interval of width 1/((n+1)(n+2)) via a refined alternating-series lower bound."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass making the derangement rounding-error sub-cluster navigable.

## Gap
`derangements-convergence-oq-03-oq-03` (two-sided sandwich for the derangement error |D(n) − n!/e|) links **up** to its parent `oq-03` and **across** to its sibling `oq-03-oq-02`, but neither linked back — the sub-cluster was only navigable in one direction.

## Change
- `oq-03` → `oq-03-oq-03` (`refined-by`): the child sharpens this entry's one-sided rounding bound |D(n) − n!/e| ≤ 1/(n+1) to the two-sided sandwich 1/(n+1) − 1/((n+1)(n+2)) ≤ |D(n) − n!/e| ≤ 1/(n+1).
- `oq-03-oq-02` → `oq-03-oq-03` (`sibling`): reciprocal link between the analytic (this child) and discrete/modular (oq-03-oq-02) sharpenings of the same rounding recurrence.

## Notes
- Claimed target (`oq-03-oq-03`, quality 95) already at target and under caps; not deepened — value is the reciprocal navigation.
- Sizes: oq-03 17.9→18.4KB (6→7 crossRefs); oq-03-oq-02 12.5→13.0KB (3→4 crossRefs). Under caps. JSON validates.