### PR TITLE
Enrich Ultra-Log-Concavity of a Pascal Row (Liggett reference)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-04-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-01/meta.json
@@ -161,6 +161,15 @@
   "references": [
     {
       "authors": [
+        "Thomas M. Liggett"
+      ],
+      "title": "Ultra logconcave sequences and negative dependence",
+      "year": "1997",
+      "venue": "Journal of Combinatorial Theory, Series A 79(2), 315-325",
+      "note": "Origin of the term 'ultra-log-concave': a nonnegative sequence a_k is ultra-log-concave when a_k/C(n,k) is log-concave, which for the Pascal row itself is exactly the excess ratio C(n,k+1)²/(C(n,k)C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)) > 1 computed here; the sibling entry recovers Liggett's bound at the centered index."
+    },
+    {
+      "authors": [
         "Richard P. Stanley"
       ],
       "title": "Log-concave and unimodal sequences in algebra, combinatorics, and geometry",


### PR DESCRIPTION
Targeted enrichment for `combinations-formula-oq-04-oq-01`.

The entry was already rich (7 sections + 8 annotations all with mathContext, 4 substantive keyInsights, full conclusion). Per the diminishing-returns rule I did not deepen existing fields. The one genuine gap was the **references** list (only Stanley 1989 + Huh 2018), which omitted the paper that coined the entry's central term:

- **Added Liggett (1997), "Ultra logconcave sequences and negative dependence", JCTA 79(2)** — the origin of "ultra-log-concave" (a_k ultra-log-concave ⟺ a_k/C(n,k) log-concave). This is exactly the property the entry makes quantitative via the excess ratio C(n,k+1)²/(C(n,k)C(n,k+2)) = 1 + (n+1)/((k+1)(n−k−1)), and the sibling entry's cross-reference already alludes to "Liggett's ultra-log-concavity bound" — so the citation was conspicuously missing.

Verified the Lean file matches the meta exactly (7 theorems, 0 sorries, 0 axioms, 215 lines). meta.json 16.4 KB → 17.0 KB; references 2 → 3 (cap 25).