### PR TITLE
research(erdos-703-incomplete-01): concrete r=1 lower bounds T(4,1)≥6, T(5,1)≥7

### DIFF
--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -555,6 +555,33 @@ theorem largeSetsFamily_subset_franklFurediOdd_one (n : ℕ) :
   rw [franklFurediOdd, Finset.mem_filter]
   exact ⟨hA.1, Or.inl hA.2⟩
 
+/-!
+### Concrete `r = 1` lower bounds from the Frankl–Füredi construction
+
+`T n r` is a supremum over exponentially many families, so it is not directly
+`decide`-able; but the explicit family `franklFurediOdd n 1 = {A ⊆ [n] : |A| > (n+1)/2
+or A = ∅}` is a *valid* `1`-avoiding family (`franklFurediOdd_avoids_r`), and its
+cardinality — a small, kernel-`decide`-able number — is a certified lower bound for
+`T n 1` (`franklFurediOdd_card_le_T`). For `n = 4` the family is
+`{∅} ∪ {|A| ∈ {3,4}}`, size `1 + C(4,3) + C(4,4) = 6`; for `n = 5` it is
+`{∅} ∪ {|A| ∈ {4,5}}`, size `1 + C(5,4) + C(5,5) = 7`. These give the first concrete
+numeric anchors for the (otherwise only-asymptotically-bounded) `r = 1` line, alongside
+the exact `T n 0 = 2^{n-1}` and `T n n = 2^n - 1`. -/
+
+/-- **`T(4,1) ≥ 6`**: the `n = 4` Frankl–Füredi family `{∅, and all 3- or 4-subsets of
+    [4]}` is `1`-avoiding with `6` members, so it is a concrete lower bound for `T 4 1`. -/
+theorem six_le_T_4_1 : 6 ≤ T 4 1 := by
+  have h : (franklFurediOdd 4 1).card = 6 := by decide
+  have hle := franklFurediOdd_card_le_T 4 1
+  omega
+
+/-- **`T(5,1) ≥ 7`**: the `n = 5` Frankl–Füredi family `{∅, and all 4- or 5-subsets of
+    [5]}` is `1`-avoiding with `7` members, so it is a concrete lower bound for `T 5 1`. -/
+theorem seven_le_T_5_1 : 7 ≤ T 5 1 := by
+  have h : (franklFurediOdd 5 1).card = 7 := by decide
+  have hle := franklFurediOdd_card_le_T 5 1
+  omega
+
 /-
 ## Part V: The Main Question - Exponential Bound
 

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -52,10 +52,10 @@
       "Structural lemmas on T: T_le_pow (T(n,r) ≤ 2^n), T_mono_ground (monotone in the ground-set size n), one_le_T (positivity), and full_powerset_avoids_r_of_lt / T_eq_pow_of_lt (T(n,r) = 2^n whenever n < r); plus largeSetsFamily_subset_franklFurediOdd_one linking Frankl's r=1 family into the general Frankl-Füredi construction."
     ],
     "axiomCount": 1,
-    "lineCount": 679,
+    "lineCount": 706,
     "assumptions": "1 axiom: frankl_rodl_1987 (the deep Frankl–Rödl 1987 exponential bound — the affirmative answer to the main question). 0 sorries: the trivial case T(n,0)=2^{n-1} is fully machine-checked (#print axioms T_n_0 = [propext, Classical.choice, Quot.sound]) via a complement-pairing upper bound and a star-family witness. The unused opaque chromaticNumber axiom was removed; the geometric chromatic-number consequence is recorded as prose only since infinite unit-distance chromatic numbers are not yet in Mathlib.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 27,
     "definitionCount": 8
   },
   "crossReferences": [
@@ -182,9 +182,9 @@
       "Finset"
     ],
     "namespace": "Erdos703",
-    "lineCount": 679,
+    "lineCount": 706,
     "axiomCount": 1,
-    "theoremCount": 25,
+    "theoremCount": 27,
     "definitionCount": 8,
     "path": "Proofs/Erdos703Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Fulfils the entry's documented next step — *"a concrete numeric lower bound for T(n,1)"*. `T n r` is a supremum over exponentially many families (not directly `decide`-able), but the explicit **`franklFurediOdd n 1 = {A ⊆ [n] : |A| > (n+1)/2 or A = ∅}`** is a valid 1-avoiding family (`franklFurediOdd_avoids_r`) whose small, kernel-`decide`-able cardinality bounds `T n 1` below (`franklFurediOdd_card_le_T`).

### New theorems
- **`six_le_T_4_1`** — `|franklFurediOdd 4 1| = 1 + C(4,3) + C(4,4) = 6` ⟹ `T(4,1) ≥ 6`.
- **`seven_le_T_5_1`** — `|franklFurediOdd 5 1| = 1 + C(5,4) + C(5,5) = 7` ⟹ `T(5,1) ≥ 7`.

These are the first concrete numeric anchors on the `r = 1` line, complementing the exact `T(n,0) = 2^{n-1}` and `T(n,n) = 2^n - 1` already in the file.

### Verification
- Kernel `decide` (axiom-free — no `native_decide`, no new axioms; the file's single axiom `frankl_rodl_1987` is untouched).
- Cardinalities verified by hand enumeration (family = `{∅}` ∪ upper-size subsets).
- Gallery meta resynced: `lineCount` 679→706, `theoremCount` 25→27.
- **UNVERIFIED**: docker build infra is down this session (containerd `meta.db` input/output error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)