### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): subtractive closed form of the Jacobi RHS

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Even.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03Even.lean
@@ -93,6 +93,16 @@ theorem jacobiCount_four_dvd_add {n : ℕ} (hn : 4 ∣ n) :
   rw [sum_four_dvd_divisors hn] at hpart
   omega
 
+/-- **Even closed form as a subtraction.** For `4 ∣ n`, the additive identity
+`jacobiCount_four_dvd_add` rearranges to the equation the docstring keeps writing,
+`jacobiCount n = 8·σ(n) − 32·σ(n/4)` (truncated `ℕ` subtraction, exact here since
+`32·σ(n/4) ≤ 8·σ(n)`). This is the standalone subtractive form the file references
+but never states as an equation. Example `n = 4`: `24 = 8·7 − 32·1 = 56 − 32`. -/
+theorem jacobiCount_four_dvd_sub {n : ℕ} (hn : 4 ∣ n) :
+    jacobiCount n = 8 * ∑ d ∈ n.divisors, d - 32 * ∑ e ∈ (n / 4).divisors, e := by
+  have h := jacobiCount_four_dvd_add hn
+  omega
+
 /-- Sanity check of the even closed form at `n = 4`: `jacobiCount 4 = 24`. -/
 example : jacobiCount 4 = 24 := by decide
 


### PR DESCRIPTION
## Summary

Fills a stated-but-unproved gap in `LagrangeFourSquaresOQ01OQ03Even.lean`. The file proves the **additive** even identity `jacobiCount n + 32·σ(n/4) = 8·σ(n)` (`jacobiCount_four_dvd_add`), and its docstrings repeatedly write the rearranged **subtractive** equation `jacobiCount n = 8·σ(n) − 32·σ(n/4)` — but that equation was never actually stated as a theorem.

## New result

- **`jacobiCount_four_dvd_sub`** (`4 ∣ n`): `jacobiCount n = 8·∑_{d∣n} d − 32·∑_{e∣n/4} e`, in truncated `ℕ` subtraction (exact, since `32·σ(n/4) ≤ 8·σ(n)`). Proof is one line: `omega` applied to the conclusion of the already-present `jacobiCount_four_dvd_add`.

Together with `jacobiCount_of_not_four_dvd` (`8·σ(n)` off the `4∣n` locus), this pins `jacobiCount` on every `n` as an explicit divisor-sum equation.

0-sorry / 0-axiom (no `native_decide`; `propext`/`Classical.choice`/`Quot.sound` only).

## Verification status

⚠️ **UNVERIFIED** — the docker build infrastructure is down at the daemon level (`containerd meta.db input/output error`; host disk healthy). No `lake build` is possible in this environment.

Confidence is very high: the proof is `omega` (which handles `ℕ` truncated subtraction and linear equations) applied to the conclusion of an already-verified lemma **in the same file**, with the term expressions copied verbatim from that lemma. A build should be run once docker recovers.

The general `r4 = jacobiCount` equality remains Mathlib-blocked (no `r4`/`r2` count object; needs Hurwitz-quaternion orders or weight-2 modular forms) — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)