### PR TITLE
Fix: cauchy-interlacing-oq-01-oq-02 lineCount drift (1355→1524)

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -12,7 +12,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
-    "lineCount": 1355,
+    "lineCount": 1524,
     "theoremCount": 40,
     "definitionCount": 0,
     "difficulty": "advanced",
@@ -62,7 +62,7 @@
       "CauchyInterlacing.Poincare"
     ],
     "namespace": "CauchyInterlacing.PoincareCompression",
-    "lineCount": 1355,
+    "lineCount": 1524,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Correct stale `lineCount` in `cauchy-interlacing-theorem-oq-01-oq-02/meta.json` to match the current `.lean` source.

## Evidence

**Before**: `lineCount: 1355` (both `meta` and `leanFile` blocks)
**After**: `lineCount: 1524`

The shared source `proofs/Proofs/CauchyInterlacingPoincareCompression.lean` grew from 1355 to 1524 lines via merged sibling research PRs (#37026, #36987 for `cauchy-interlacing-oq-02-oq-01`) which did not resync this entry's metadata. Verified on fresh `origin/main`: actual newline count = 1524. No open PR touches this file, so the drift is uncovered.

Metadata-only change; JSON validated.

---
Automated fix by lean-mechanic agent.