### PR TITLE
Enrich Dirichlet Linnik-constant cluster: parent→child refined-by link

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -164,6 +164,11 @@
       "targetId": "dirichlets-theorem-oq-01",
       "relationship": "sibling",
       "description": "OQ-01: another open question branch of Dirichlet's theorem in the gallery"
+    },
+    {
+      "targetId": "dirichlets-theorem-oq-03-oq-01",
+      "relationship": "refined-by",
+      "description": "Child: isolates and proves — axiom-free and sorry-free — the structural skeleton of this entry's Linnik-constant formalization (which itself carries 2 axioms, 3 sorries). It shows the admissible-exponent set is an upward-closed ray bounded below, whose infimum (the Linnik constant) satisfies the sandwich Ioi(c) ⊆ admissible ⊆ Ici(c) and is monotone under domination of the growth function — the well-definedness backbone that makes the Linnik constant a genuine critical exponent."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for the Dirichlet / Linnik-constant sub-cluster.

## Gap
`dirichlets-theorem-oq-03` (the Linnik-constant formalization, which carries 2 axioms and 3 sorries) had **no forward link** to its child `dirichlets-theorem-oq-03-oq-01`, which isolates and proves that formalization's structural skeleton **axiom-free and sorry-free** — the admissible-exponent set is an upward-closed ray bounded below, whose infimum satisfies the sandwich Ioi(c) ⊆ admissible ⊆ Ici(c) and is monotone under domination of the growth function. The child links up to the parent; the parent did not link down.

## Change
Added a single `refined-by` crossReference (`oq-03` → `oq-03-oq-01`).

## Notes
- Claimed target (`oq-03-oq-01`, quality 95) already at target and under caps; not deepened.
- I did **not** reciprocate the target's link to `oq-02` (a generic 'another OQ branch' link to what is really an uncle entry) — that would be low-value accretion. Nor the large curated root hub, which links no oq-03-subtree descendants.
- `oq-03` meta.json: 15.7→16.3KB, 4→5 crossReferences. Under caps. JSON validates.