### PR TITLE
research(sylow-theorem-oq-04-oq-03): perfectness of PSL(2,p) for p≥5

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -770,6 +770,36 @@ theorem commutator_eq_top (hp : 5 ≤ p) :
     rw [← hc]
     exact Subgroup.commutator_mem_commutator (Subgroup.mem_top _) (Subgroup.mem_top _)
 
+/-- **Perfectness of `PSL(2, p)` for `p ≥ 5`.**  The projective special linear group
+`PSL(2, p) = SL(2, p)/Z` is perfect: its own commutator subgroup is the whole group.
+
+This transports `commutator_eq_top` (perfectness of the cover `SL(2, p)`) across the
+central quotient homomorphism `mk' : SL(2, p) ↠ PSL(2, p)`.  Since that map is
+surjective it carries `⊤` onto `⊤` and commutes with the commutator bracket
+(`Subgroup.map_commutator`), so the image of the derived subgroup of `SL(2, p)` is the
+derived subgroup of `PSL(2, p)`; as the former is all of `SL(2, p)`, the latter is all
+of `PSL(2, p)`.
+
+Perfectness is one of the two hypotheses of Iwasawa's simplicity criterion (the other
+being a primitive faithful action, here the `2`-transitive action on `P¹(𝔽_p)`).  It is
+exactly the side condition that fails at `p = 2, 3`: `PSL(2,2) ≅ S₃` and
+`PSL(2,3) ≅ A₄` are *not* perfect, which is why the simplicity statement is restricted
+to `p ≥ 5`. -/
+theorem commutator_PSL_eq_top (hp : 5 ≤ p) :
+    commutator (Matrix.ProjectiveSpecialLinearGroup (Fin 2) (ZMod p)) = ⊤ := by
+  set N := Subgroup.center (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) with hN
+  have hsurj := QuotientGroup.mk'_surjective N
+  -- The central quotient map sends the derived subgroup of `SL` onto that of `PSL`.
+  have key :
+      Subgroup.map (QuotientGroup.mk' N)
+          (commutator (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)))
+        = commutator (Matrix.ProjectiveSpecialLinearGroup (Fin 2) (ZMod p)) := by
+    show Subgroup.map (QuotientGroup.mk' N)
+          ⁅(⊤ : Subgroup (Matrix.SpecialLinearGroup (Fin 2) (ZMod p))), ⊤⁆
+        = ⁅(⊤ : Subgroup (Matrix.ProjectiveSpecialLinearGroup (Fin 2) (ZMod p))), ⊤⁆
+    rw [Subgroup.map_commutator, Subgroup.map_top_of_surjective _ hsurj]
+  rw [← key, commutator_eq_top hp, Subgroup.map_top_of_surjective _ hsurj]
+
 /-!
 ## The order `|SL(2, p)| = p·(p² − 1)`
 

--- a/research/problems/sylow-theorem-oq-04-oq-03/state.md
+++ b/research/problems/sylow-theorem-oq-04-oq-03/state.md
@@ -75,3 +75,25 @@ confirm** before it can be called VERIFIED.
 ## Next Action
 Once Docker recovers, build `Proofs.SylowTheoremOQ04OQ03`; if green, upgrade status to VERIFIED and
 package perfectness `commutator (SL(2,p)) = ⊤` (p≥5) from generation + the derived-subgroup lemmas.
+
+## Session 2026-07-09 (researcher-1) — perfectness lifted to PSL(2,p)
+The prior "Next Action" is now complete on main: `commutator_eq_top : commutator (SL(2,p)) = ⊤`
+(p≥5) and `card_SL2 : Nat.card (SL(2,p)) = p·(p²−1)` are both merged and axiom/sorry-free.
+
+Added **`commutator_PSL_eq_top (hp : 5 ≤ p) : commutator (PSL(2,p)) = ⊤`** — perfectness of the
+*target* group PSL(2,p) = SL(2,p)/Z, not merely its cover. Two-step transport across the surjective
+central quotient `mk' : SL ↠ PSL`:
+- `Subgroup.map_commutator` (map of a commutator is the commutator of the maps) turns the image of
+  the derived subgroup of SL into the derived subgroup of PSL;
+- `Subgroup.map_top_of_surjective` (surjective ⇒ maps ⊤ to ⊤, using `QuotientGroup.mk'_surjective`)
+  collapses the maps of ⊤ back to ⊤.
+Then `commutator_eq_top hp` supplies `commutator (SL) = ⊤`. This states one of the two Iwasawa
+hypotheses directly for PSL(2,p) and pins the p≥5 range (PSL(2,2)≅S₃, PSL(2,3)≅A₄ are not perfect).
+File 855→885 L, 0 sorry / 0 axiom. **UNVERIFIED**: Docker still down (containerd blob input/output
+error, `docker images` itself fails); API for every lemma used was checked against the pinned local
+Mathlib source under `proofs/.lake/packages/mathlib`.
+
+## Next Action
+Once Docker recovers, build `Proofs.SylowTheoremOQ04OQ03`. Next math step toward Iwasawa: either
+`|PSL(2,p)| = p(p²−1)/2` (needs `center (SL(2,p)) = {±I}`, order 2 for odd p) or begin the PSL(2,p)
+action on P¹(𝔽_p) with 2-transitivity.

--- a/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
@@ -6,7 +6,7 @@
   "path": "full",
   "tier": "MODERATE",
   "started": "2026-04-05T03:59:25.465Z",
-  "lastUpdate": "2026-07-07T00:00:00.000Z",
+  "lastUpdate": "2026-07-09T00:00:00.000Z",
   "significance": 7,
   "tractability": 2,
   "tags": [
@@ -56,8 +56,9 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "BUILD (researcher-1, 2026-07-09) [UNVERIFIED — build blocked by Docker daemon containerd I/O corruption, not a code error]: added the Bruhat generation theorem closure_rootGroups_eq_top : ⟨U,U⁻⟩ = ⊤ for SL(2,p). Two elementary root-group factorizations feed it — weylW_eq_root_word (w = u(-1)·l(1)·u(-1)) and torusDiag_eq_root_word (diag(a) = u(a)·l(-a⁻¹)·u(a)·w, so the whole split torus T ⊆ ⟨U,U⁻⟩) — plus the Bruhat cell lemma mem_closure_of_lowerLeft_ne_zero (g = u(a·c⁻¹)·w·diag(c)·u(d·c⁻¹) covers every matrix with nonzero lower-left entry) and a single lower transvection l(1) to sweep in the c=0 matrices. This CLOSES the generation hypothesis of Iwasawa's criterion and, with the existing perfectness lemmas (U,U⁻ ⊆ derived subgroup for p≥5), gives perfectness of SL(2,p). Re-establishes & completes PR #35565's reverted rootGroups material (which only had membership, not the '= ⊤' theorem). File 544→738 lines / 0 sorry / 0 axiom (pending build confirmation).",
+    "progressSummary": "BUILD (researcher-1, 2026-07-09) [UNVERIFIED — Docker daemon down: containerd blob input/output error, `docker images` itself fails; not a code error]: the prior session's target is now MERGED on main (commutator_eq_top : commutator (SL(2,p))=⊤ for p≥5, and card_SL2 : |SL(2,p)|=p(p²−1), both 0-sorry/0-axiom). Added commutator_PSL_eq_top : commutator (PSL(2,p))=⊤ for p≥5 — perfectness of the TARGET group PSL(2,p)=SL(2,p)/Z, transported from the cover across the surjective central quotient map mk':SL↠PSL via Subgroup.map_commutator + Subgroup.map_top_of_surjective (QuotientGroup.mk'_surjective), closed by commutator_eq_top. This states one of Iwasawa's two hypotheses directly for PSL(2,p) and pins the p≥5 range (PSL(2,2)≅S₃, PSL(2,3)≅A₄ not perfect). File 855→885 L / 0 sorry / 0 axiom; every Mathlib lemma checked vs pinned local mathlib source.",
     "insights": [
+      "Perfectness lifts cleanly from the cover to the quotient: for any surjective φ:G↠H, map φ (commutator G) = commutator H (Subgroup.map_commutator + map_top_of_surjective), so a perfect group has perfect quotients. Applied to mk':SL(2,p)↠PSL(2,p)=SL/Z this turns commutator (SL)=⊤ into commutator (PSL)=⊤ — the Iwasawa perfectness hypothesis for the actual simple-group candidate PSL(2,p), not just its cover.",
       "The right tool is Iwasawa's criterion, not raw Sylow counting: PSL(2,p) acts 2-transitively (hence primitively and faithfully) on the p+1 points of P¹(𝔽_p); the unipotent upper-triangular subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} is abelian, normal in the stabilizer of ∞, and its PSL-conjugates generate PSL(2,p); with perfectness for p ≥ 5, IwasawaStructure.isSimpleGroup concludes.",
       "Mathlib's PSL support is a single 39-line abbreviation with no order, no group action, and no simplicity lemmas — so the bottleneck is entirely the missing connective infrastructure, not the final criterion.",
       "The p = 5 case is already in Mathlib as isSimpleGroup_five (PSL(2,5) ≅ A₅); a parametrized proof must recover it uniformly, so a family-level Iwasawa argument is genuinely more than re-deriving the parent.",
@@ -235,11 +236,11 @@
     {
       "path": "Proofs/SylowTheoremOQ04OQ03.lean",
       "filename": "SylowTheoremOQ04OQ03.lean",
-      "lineCount": 774,
-      "theoremCount": 35,
+      "lineCount": 885,
+      "theoremCount": 36,
       "axiomCount": 0,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SylowTheoremOQ04OQ03.lean"
     },


### PR DESCRIPTION
## Summary

Adds `commutator_PSL_eq_top` to `Proofs/SylowTheoremOQ04OQ03.lean`, proving **perfectness of PSL(2, p) for every prime p ≥ 5**:

```lean
theorem commutator_PSL_eq_top (hp : 5 ≤ p) :
    commutator (Matrix.ProjectiveSpecialLinearGroup (Fin 2) (ZMod p)) = ⊤
```

The prior session's goal is already **merged on main**: `commutator_eq_top` (perfectness of the cover `SL(2, p)`) and `card_SL2` (`|SL(2, p)| = p·(p²−1)`), both 0-sorry / 0-axiom. This PR takes the natural next step — lifting perfectness from the cover to the **target** group `PSL(2, p) = SL(2, p)/Z`.

## Proof

Two-step transport across the surjective central quotient `mk' : SL(2, p) ↠ PSL(2, p)`:
- `Subgroup.map_commutator` — the image of a commutator subgroup is the commutator of the images, so `map mk' (commutator SL) = commutator PSL` (using surjectivity to send `⊤ ↦ ⊤`);
- `Subgroup.map_top_of_surjective` with `QuotientGroup.mk'_surjective` collapses `map mk' ⊤` back to `⊤`;
- `commutator_eq_top hp` supplies `commutator (SL(2, p)) = ⊤`.

## Why it matters

Perfectness is one of the two hypotheses of **Iwasawa's simplicity criterion** (the other being the primitive faithful action on `P¹(𝔽_p)`). This states it directly for the actual simple-group candidate PSL(2, p) rather than its cover, and pins the `p ≥ 5` restriction: `PSL(2,2) ≅ S₃` and `PSL(2,3) ≅ A₄` are **not** perfect.

## Verification status

**UNVERIFIED** — the Docker build daemon is down this session (containerd blob `input/output error`; `docker images` itself fails), so a clean build could not be run. The proof is 0-sorry / 0-axiom, and every Mathlib lemma used (`Subgroup.map_commutator`, `Subgroup.map_top_of_surjective`, `QuotientGroup.mk'_surjective`, `commutator_def`) was checked against the pinned local Mathlib source under `proofs/.lake/packages/mathlib`. Needs a green build to confirm before being called VERIFIED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)