### PR TITLE
research(erdos101-problem-oq-04): concrete oblique quadruple witness for four-point-line engine

### DIFF
--- a/proofs/Proofs/Erdos101OQ04.lean
+++ b/proofs/Proofs/Erdos101OQ04.lean
@@ -3088,4 +3088,57 @@ theorem symmetric_quadruple_onQuartic_collinear (a b : ℝ) (hab : a ^ 2 + b ^ 2
   rw [four_onQuartic_collinear_iff_sq rfl rfl rfl rfl h1 h4 (Ne.symm h2) h5 (Ne.symm h3) h6]
   exact symmetric_quadruple_criterion a b hab
 
+/-! ### An oblique (non-symmetric) quadruple realizes the engine
+
+`quartic_fourPointLineCount_from_quadruples` and its docstring assert that the engine
+accepts *oblique* abscissa-quadruples — solutions of `Σx = 0 ∧ Σx² = 10` that are **not**
+of the symmetric shape `(a, −a, b, −b)`.  Every concrete witness realized so far
+(`quartic_linear_lower_bound`, `symmetric_quadruple_onQuartic_collinear`) is symmetric, so
+the "additionally accepts oblique quadruples" claim was, until now, unsubstantiated by an
+actual checked example.  The three lemmas below fix that with the concrete rational witness
+`(−8/3, 1/3, 1, 4/3)`: it meets the arithmetic criterion, is genuinely oblique (its abscissa
+set is not closed under negation), and forms a bona-fide four-point line on the quartic.
+
+Note this is a *single* oblique quadruple, not a family — it does not touch the OPEN
+super-linear growth (`solymosi_stojakovic_lower_bound`), which needs *super-linearly many*
+distinct oblique solution-sets on the fixed ternary conic `Q = 5`.  It closes the smaller
+gap between the engine's stated generality and the witnesses actually exhibited. -/
+
+/-- **An oblique quadruple solves the arithmetic four-point-line criterion.**
+The rational abscissae `(−8/3, 1/3, 1, 4/3)` satisfy `Σx = 0` and `Σx² = 10`
+(`(−8/3)² + (1/3)² + 1² + (4/3)² = (64 + 1 + 9 + 16)/9 = 90/9 = 10`), exactly the two
+relations `four_onQuartic_collinear_iff_sq` and `quartic_fourPointLineCount_from_quadruples`
+require. -/
+theorem oblique_quadruple_criterion :
+    (-8 / 3 : ℝ) + 1 / 3 + 1 + 4 / 3 = 0 ∧
+      (-8 / 3 : ℝ) ^ 2 + (1 / 3 : ℝ) ^ 2 + (1 : ℝ) ^ 2 + (4 / 3 : ℝ) ^ 2 = 10 := by
+  refine ⟨by norm_num, by norm_num⟩
+
+/-- **The oblique quadruple is genuinely non-symmetric.**
+A symmetric family `(a, −a, b, −b)` has an abscissa set closed under negation.  Here the
+abscissa `1` is present but its negation `−1` equals none of the four abscissae, so no
+symmetric `(a, −a, b, −b)` relabeling of `(−8/3, 1/3, 1, 4/3)` exists — the quadruple is
+strictly oblique. -/
+theorem oblique_quadruple_not_symmetric :
+    (-(1 : ℝ) ≠ -8 / 3) ∧ (-(1 : ℝ) ≠ 1 / 3) ∧ (-(1 : ℝ) ≠ 1) ∧ (-(1 : ℝ) ≠ 4 / 3) := by
+  refine ⟨by norm_num, by norm_num, by norm_num, by norm_num⟩
+
+/-- **The oblique quadruple forms a four-point line on the quartic.**
+For the four distinct abscissae `−8/3, 1/3, 1, 4/3`, the four points above them on
+`y = x⁴ − 5x²` are collinear — a genuine four-point line anchored through the `(−8/3, ·)`
+and `(1/3, ·)` points.  Derived directly from the sum-of-squares criterion
+`four_onQuartic_collinear_iff_sq` via `oblique_quadruple_criterion`, this is the *oblique*
+analogue of `symmetric_quadruple_onQuartic_collinear`, witnessing that the engine
+`quartic_fourPointLineCount_from_quadruples` accepts inputs outside the symmetric family. -/
+theorem oblique_quadruple_onQuartic_collinear :
+    collinear (-8 / 3, (-8 / 3 : ℝ) ^ 4 - 5 * (-8 / 3) ^ 2)
+        (1 / 3, (1 / 3 : ℝ) ^ 4 - 5 * (1 / 3) ^ 2)
+        (1, (1 : ℝ) ^ 4 - 5 * 1 ^ 2) ∧
+      collinear (-8 / 3, (-8 / 3 : ℝ) ^ 4 - 5 * (-8 / 3) ^ 2)
+        (1 / 3, (1 / 3 : ℝ) ^ 4 - 5 * (1 / 3) ^ 2)
+        (4 / 3, (4 / 3 : ℝ) ^ 4 - 5 * (4 / 3) ^ 2) := by
+  rw [four_onQuartic_collinear_iff_sq rfl rfl rfl rfl (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num) (by norm_num)]
+  exact oblique_quadruple_criterion
+
 end Erdos101OQ04

--- a/research/problems/erdos101-problem-oq-04/state.md
+++ b/research/problems/erdos101-problem-oq-04/state.md
@@ -2,8 +2,41 @@
 
 **Phase**: ACT (arithmetization complete: four-point-line counting on the quartic is now the additive problem "count 4-subsets with Σx=0 ∧ Σx²=10")
 **Since**: 2026-07-01
-**Last Updated**: 2026-07-09 (Iteration 11, researcher-4)
-**Iteration**: 11
+**Last Updated**: 2026-07-09 (Iteration 12, researcher-6)
+**Iteration**: 12
+
+## Iteration 12 (researcher-6, 2026-07-09) — concrete OBLIQUE quadruple witness [UNVERIFIED — docker infra down]
+
+**Outcome**: three additions to `Proofs/Erdos101OQ04.lean` (0 new axioms, 0 new
+sorries) substantiating the engine's repeated "additionally accepts *oblique*
+quadruples" claim with an actual checked example. Every prior realized witness
+(`quartic_linear_lower_bound`, `symmetric_quadruple_onQuartic_collinear`) is
+symmetric `(a,−a,b,−b)`; the engine's generality over *oblique* inputs was asserted
+but never exhibited.
+
+1. **`oblique_quadruple_criterion`** — the rational abscissae `(−8/3, 1/3, 1, 4/3)`
+   satisfy `Σx = 0` and `Σx² = (64+1+9+16)/9 = 90/9 = 10`, the two relations the
+   engine requires (`norm_num`).
+2. **`oblique_quadruple_not_symmetric`** — checked non-symmetry: the abscissa `1` is
+   present but its negation `−1` equals none of the four abscissae, so the abscissa
+   set is not closed under negation and no `(a,−a,b,−b)` relabeling exists (`norm_num`).
+3. **`oblique_quadruple_onQuartic_collinear`** — the four points above these abscissae
+   on `y = x⁴ − 5x²` are genuinely collinear (a four-point line), via
+   `four_onQuartic_collinear_iff_sq` + `oblique_quadruple_criterion`. The oblique
+   analogue of `symmetric_quadruple_onQuartic_collinear`.
+
+**Honest scope**: a *single* oblique quadruple, not a family — it does NOT touch the
+OPEN super-linear growth (`solymosi_stojakovic_lower_bound`), which needs
+super-linearly many distinct oblique solution-sets on the fixed conic `Q = 5`. It
+closes the smaller gap between the engine's stated generality and the concrete
+witnesses actually exhibited.
+
+**Build note — UNVERIFIED (environmental)**: `docker-build.sh Proofs.Erdos101OQ04`
+died at Docker image build with `containerd .../meta.db: input/output error` — the
+known session-wide docker-infra outage (disk healthy, 115Gi free), not a code fault.
+Each proof step is elementary (`norm_num` + one `rw` mirroring the already-present
+`symmetric_quadruple_onQuartic_collinear`); hand-checked. CI in a clean environment
+is ground truth.
 
 ## Iteration 11 (researcher-4, 2026-07-09) — sum-of-squares criterion + general arithmetic counting engine [UNVERIFIED — env SIGBUS]
 


### PR DESCRIPTION
## Summary

Erdős #101 OQ-04 (Solymosi–Stojaković lower bound on four-point lines). The arithmetization engine `quartic_fourPointLineCount_from_quadruples` reduces the lower bound to counting abscissa-quadruples solving `Σx = 0 ∧ Σx² = 10`, and its docstring repeatedly claims the engine "additionally accepts *oblique* quadruples" beyond the symmetric `(a,−a,b,−b)` family. Until now **every** realized witness (`quartic_linear_lower_bound`, `symmetric_quadruple_onQuartic_collinear`) was symmetric — the oblique claim was unsubstantiated by a checked example.

This PR exhibits a concrete oblique witness `(−8/3, 1/3, 1, 4/3)`:

- **`oblique_quadruple_criterion`** — solves `Σx = 0` and `Σx² = (64+1+9+16)/9 = 90/9 = 10`.
- **`oblique_quadruple_not_symmetric`** — checked non-symmetry: the abscissa `1` is present but its negation `−1` equals none of the four, so the abscissa set is not closed under negation ⇒ no `(a,−a,b,−b)` relabeling exists.
- **`oblique_quadruple_onQuartic_collinear`** — the four points above these abscissae on `y = x⁴ − 5x²` are a genuine four-point line, via `four_onQuartic_collinear_iff_sq`; the oblique analogue of the existing `symmetric_quadruple_onQuartic_collinear`.

**0 new axioms, 0 new sorries.**

## Honest scope

A *single* oblique quadruple, not a family. It does **not** touch the OPEN super-linear growth (`solymosi_stojakovic_lower_bound`, the file's one remaining `sorry`), which requires super-linearly many distinct oblique solution-sets on the fixed ternary conic `Q = 5`. It closes the smaller gap between the engine's stated generality and the witnesses actually exhibited.

## Verification

⚠️ **UNVERIFIED** — `docker-build.sh Proofs.Erdos101OQ04` failed at Docker image build with `containerd .../meta.db: input/output error` (session-wide docker-infra outage; host disk healthy, 115 GiB free), not a code fault. Proofs are elementary `norm_num` + one `rw` mirroring the already-present `symmetric_quadruple_onQuartic_collinear`; each step hand-checked. CI in a clean environment is ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)