### PR TITLE
Enrich dissection-of-cubes OQ-01 subtree: reciprocal links into oq-01-oq-02

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -194,6 +194,11 @@
       "targetId": "dissection-of-cubes-oq-02",
       "relationship": "sibling",
       "description": "Sibling OQ exploring the Dehn invariant and algebraic obstructions to cube dissections"
+    },
+    {
+      "targetId": "dissection-of-cubes-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "Extends this entry: it reuses the achievability witness (exampleDissection) and cube constructions developed here, upgrading the 'tight' collision bound to the IsLeast statement that the minimum collision count is exactly 2."
     }
   ],
   "references": [

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-03/meta.json
@@ -185,6 +185,11 @@
       "targetId": "dissection-of-cubes-oq-02-oq-02",
       "relationship": "sibling-development",
       "description": "Sub-development of the Dehn-invariant track (oq-02 line) — provides further refinements of the scissor-congruence framework. The OQ-02 line and this entry's OQ-01-OQ-03 sub-tree pursue complementary refinements of the base CubeDissection structure: OQ-02 along the Dehn-invariant axis (relevant for *mixed-shape* dissections), OQ-01-OQ-03 along the volumetric axis (this entry, relevant for *cube-only* dissections). The eventual goal is a combined `MeasureDissection` enforcing $\\mu([0,1]^3 \\setminus \\bigcup C_i) = 0$ — strictly stronger than this entry's $\\sum s^3 = 1$ and strictly stronger than OQ-02's Dehn-invariant equality."
+    },
+    {
+      "targetId": "dissection-of-cubes-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling in the OQ-01 sub-tree (this entry already lists its companion OQ-01-OQ-01 as a sibling): where this entry formalizes the volume constraint ∑ c.side³ = 1, OQ-01-OQ-02 resolves the collision-count question, proving the minimum of collidingCubes.card is exactly 2 (IsLeast). Reciprocal to OQ-01-OQ-02's sibling link here."
     }
   ],
   "references": [

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -168,6 +168,11 @@
       "targetId": "hilbert-3",
       "relationship": "foundational",
       "description": "Hilbert's third problem (Dehn-Sydler theorem) provides the theoretical foundation: the Dehn invariant determines when polyhedra are scissors-congruent"
+    },
+    {
+      "targetId": "dissection-of-cubes-oq-01-oq-02",
+      "relationship": "answered-by",
+      "description": "Child answering this entry's second open question — 'what is the actual minimum of collidingCubes.card over all valid dissections?'. It proves the minimum is exactly 2: the collision spectrum has least element 2 (IsLeast), packaging OQ-01's lower bound together with an achievability witness."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass making the 'minimum collision number = 2' entry reachable from its own subtree.

## Gap
`dissection-of-cubes-oq-01-oq-02` (proves the minimum collision number is exactly 2) links **up** to its parent `oq-01`, to `oq-01-oq-01` (which it extends), and to `oq-01-oq-03` (sibling) — but **none of the three linked back**. The entry was navigable only outward. Notably `oq-01-oq-03` already lists `oq-01-oq-01` as a sibling while omitting `oq-01-oq-02` — an inconsistency.

## Change
Added three reciprocal cross-references:
- `oq-01` → `oq-01-oq-02` (`answered-by`) — the child answers its second open question.
- `oq-01-oq-01` → `oq-01-oq-02` (`extended-by`) — the child reuses its exampleDissection witness, upgrading 'tight' to IsLeast.
- `oq-01-oq-03` → `oq-01-oq-02` (`sibling`) — fixes the sibling-list omission.

## Notes
- Claimed target (`oq-01-oq-02`, quality 95) already at target and under caps; not deepened. The large curated root hub was left untouched (it links only direct children, not grandchildren).
- Sizes after: oq-01 12.6KB, oq-01-oq-01 12.2KB, oq-01-oq-03 30.2KB — all under the 60KB / 20-crossRef caps. JSON validates.