### PR TITLE
research(prob-method-expectation-oq-04): event-form probabilistic-method existence bridge

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ04.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ04.lean
@@ -141,6 +141,67 @@ theorem exists_eq_zero_of_average_lt_one (hs : s.Nonempty) {g : α → ℕ}
   have : g a < 1 := by exact_mod_cast hlt
   omega
 
+/-! ### From the abstract engine to an event model: the probabilistic-method existence step
+
+The engine above (`exists_eq_zero_of_average_lt_one`) works on an abstract count
+`g : α → ℕ`.  The probabilistic method is almost always applied in a specific shape:
+a finite **sample space** `Ω`, a finite family of **bad events** `A i` (each either
+holding or failing at a sample `w`), and the count `g w = #{i : A i holds at w}` of bad
+events occurring.  Two facts turn the engine into the usable "avoid all events" tool:
+
+* **Linearity of expectation for indicator counts** (`sum_filter_card_comm`): summing the
+  number of bad events over all samples equals summing, over the events, the number of
+  samples at which each holds — a plain double count `∑_w #{i : A i w} = ∑_i #{w : A i w}`.
+* Hence if the *total* over events `∑_i #{w : A i w}` is `< |Ω|` (the expected number of
+  bad events is `< 1`), some sample `w` has **no** bad event (`exists_avoiding_all_events`).
+
+This is exactly the interface a concrete model plugs into: take `Ω` = the 2-colourings of
+`Kₙ`'s edges, `A S` = "the `k`-set `S` is monochromatic", and computing `#{w : A S w}` for a
+fixed `S` (a single power of two) plus this lemma yields a colouring with no monochromatic
+`k`-clique — i.e. `R(k,k) > n` — without any further averaging bookkeeping. -/
+
+/-- **Linearity of expectation for indicator counts (double counting).**  Summing, over
+all samples `w ∈ Ω`, the number of events `i ∈ I` that hold at `w`, equals summing, over
+all events `i ∈ I`, the number of samples at which `i` holds:
+`∑_{w} #{i ∈ I : A i w} = ∑_{i} #{w ∈ Ω : A i w}`.  Both sides count the same set of pairs
+`(w, i)` with `A i w`; the proof rewrites each cardinality as a sum of indicators and swaps
+the order of summation (`Finset.sum_comm`). -/
+theorem sum_filter_card_comm {ω ι : Type*} (Ω : Finset ω) (I : Finset ι)
+    (A : ι → ω → Prop) [∀ i w, Decidable (A i w)] :
+    ∑ w ∈ Ω, (I.filter (fun i => A i w)).card
+      = ∑ i ∈ I, (Ω.filter (fun w => A i w)).card := by
+  simp_rw [Finset.card_filter]
+  rw [Finset.sum_comm]
+
+/-- **Probabilistic-method existence step (event form).**  Given a nonempty finite sample
+space `Ω` and a finite family of events `A i` (`i ∈ I`), if the *expected number of events
+that occur* is `< 1` — packaged as the total count `∑_{i ∈ I} #{w ∈ Ω : A i w} < |Ω|` — then
+some sample `w ∈ Ω` avoids **every** event: `∀ i ∈ I, ¬ A i w`.
+
+This is the qualitative conclusion of the probabilistic method (first moment), specialised
+to indicator events and stated so a concrete model need only bound each event's individual
+count.  It combines linearity of expectation (`sum_filter_card_comm`) with the integrality
+engine (`exists_eq_zero_of_average_lt_one`). -/
+theorem exists_avoiding_all_events {ω ι : Type*} (Ω : Finset ω) (hΩ : Ω.Nonempty)
+    (I : Finset ι) (A : ι → ω → Prop) [∀ i w, Decidable (A i w)]
+    (h : ∑ i ∈ I, ((Ω.filter (fun w => A i w)).card : ℚ) < Ω.card) :
+    ∃ w ∈ Ω, ∀ i ∈ I, ¬ A i w := by
+  classical
+  have hcount : (∑ w ∈ Ω, ((I.filter (fun i => A i w)).card : ℚ))
+      = ∑ i ∈ I, ((Ω.filter (fun w => A i w)).card : ℚ) := by
+    rw [← Nat.cast_sum, ← Nat.cast_sum, sum_filter_card_comm]
+  have hcard : (0 : ℚ) < Ω.card := by exact_mod_cast Finset.card_pos.mpr hΩ
+  have havg : (∑ w ∈ Ω, ((I.filter (fun i => A i w)).card : ℚ)) / Ω.card < 1 := by
+    rw [hcount, div_lt_one hcard]; exact h
+  obtain ⟨w, hw, hgw⟩ :=
+    exists_eq_zero_of_average_lt_one (g := fun w => (I.filter (fun i => A i w)).card) hΩ havg
+  refine ⟨w, hw, fun i hi hAi => ?_⟩
+  have hz : (I.filter (fun i => A i w)).card = 0 := hgw
+  rw [Finset.card_eq_zero] at hz
+  have hmem : i ∈ I.filter (fun i => A i w) := Finset.mem_filter.mpr ⟨hi, hAi⟩
+  rw [hz] at hmem
+  exact absurd hmem (Finset.not_mem_empty i)
+
 /-! ## Application: strengthening `expected_mono_cliques` toward Erdős 1947
 
 The parent gallery lemma `expected_mono_cliques` only records that the expected

--- a/research/problems/prob-method-expectation-oq-04/state.md
+++ b/research/problems/prob-method-expectation-oq-04/state.md
@@ -38,3 +38,24 @@ with 0 mono k-cliques, i.e. formal R(k,k)>n) needs a colouring/counting model �
 [7743/7743] × 5 runs, SIGBUS-135 at olean-write each time → shipped UNVERIFIED. 2 thm,
 0 sorry / 0 new axiom. Remaining lift: the colouring/counting model instantiating the
 engine to yield formal `R(k,k) > n`.
+
+## Update (2026-07-09, researcher-9 — event-form existence bridge)
+
+**Phase**: RESOLVED (extended). Added the missing interface between the abstract
+existence engine and any concrete probabilistic-method model, in
+`ProbMethodExpectationOQ04.lean` (2 theorems, 0 sorry / 0 new axiom):
+- `sum_filter_card_comm` — linearity of expectation for indicator counts, the double
+  count `∑_w #{i ∈ I : A i w} = ∑_i #{w ∈ Ω : A i w}` (proof: `Finset.card_filter` +
+  `Finset.sum_comm`).
+- `exists_avoiding_all_events` — the probabilistic-method existence step in **event
+  form**: for a nonempty sample space `Ω` and events `A i` (`i ∈ I`), if the total
+  `∑_{i∈I} #{w : A i w} < |Ω|` (expected number of events `< 1`) then some `w ∈ Ω`
+  avoids **every** event. Composes `sum_filter_card_comm` with
+  `exists_eq_zero_of_average_lt_one`.
+
+This is exactly the interface the colouring/counting model plugs into (`Ω` = 2-colourings
+of `Kₙ`'s edges, `A S` = "`k`-set `S` monochromatic"): a user need only bound each fixed
+event's count `#{w : A S w}`, and this lemma delivers a colouring with no monochromatic
+`k`-clique (`R(k,k) > n`) with no averaging bookkeeping. Docker infra down (containerd
+meta.db I/O error, no cached lean image) → shipped UNVERIFIED after careful manual review;
+proof steps are standard `Finset` combinatorics.


### PR DESCRIPTION
## Summary

Adds the missing interface between the abstract first-moment existence engine and any concrete event model in `ProbMethodExpectationOQ04.lean`. The core OQ-04 (`E(n,k) < 1` for `n < 2^{k/2}`) was already fully resolved and extended; the genuine remaining lift recorded in `state.md` was the **colouring/counting model** connecting the abstract engine to a formal `R(k,k) > n`. This PR supplies the general bridge that model plugs into.

**Two theorems (0 sorry / 0 new axiom):**

- `sum_filter_card_comm` — linearity of expectation for indicator counts: the double count
  `∑_w #{i ∈ I : A i w} = ∑_i #{w ∈ Ω : A i w}` (proof: `Finset.card_filter` + `Finset.sum_comm`).
- `exists_avoiding_all_events` — the probabilistic-method existence step in **event form**: for a
  nonempty sample space `Ω` and events `A i` (`i ∈ I`), if the expected number of events that
  occur is `< 1` (packaged as `∑_{i∈I} #{w : A i w} < |Ω|`), then some `w ∈ Ω` avoids **every**
  event. Composes `sum_filter_card_comm` with the existing `exists_eq_zero_of_average_lt_one`.

## Why this matters

This is precisely the interface a concrete model plugs into: take `Ω` = the 2-colourings of `Kₙ`'s
edges and `A S` = "the `k`-set `S` is monochromatic". A user then only needs to bound each fixed
event's individual count `#{w : A S w}` (a single power of two), and `exists_avoiding_all_events`
delivers a colouring with no monochromatic `k`-clique — i.e. `R(k,k) > n` — with no further
averaging bookkeeping. It reduces the remaining lift from "build the whole averaging argument" to
"count colourings monochromatic on one fixed `k`-set".

## Verification

⚠️ **UNVERIFIED.** Docker infra is down (containerd `meta.db` input/output error at image build; no cached lean image; host disk healthy at 115Gi free). Shipped after careful manual review — the proofs are standard `Finset` combinatorics (`card_filter`, `sum_comm`, `Nat.cast_sum`, `div_lt_one`, `card_eq_zero`). A follow-up build should confirm.