### PR TITLE
research(erdos-1022-oq-02): single-index closed-form exponential lower bound on admissible coefficient

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -578,4 +578,21 @@ theorem admissibleCoeff_ge_two_pow_of_card (hV : 0 < Fintype.card V) (k : ℕ) :
         Nat.mul_le_mul (le_refl _) hpos
     _ ≤ firstMomentThreshold (Fintype.card V + 1 + k) / Fintype.card V := hmul
 
+/-- **Closed single-index exponential lower bound on the coefficient.**  The two-index
+    iterate `admissibleCoeff_ge_two_pow_of_card` (`2^k ≤ c(|V|+1+k)`) collapsed to a
+    single variable by setting `k = t − |V| − 1`: for every minimum set size `t > |V|`,
+
+        `2^{t − |V| − 1}  ≤  c(t) = ⌊2^{t-1}/|V|⌋`.
+
+    This makes precise the remark (in `admissibleCoeff_ge_two_pow_of_le`'s docstring)
+    that "writing `t₀` for the positivity threshold, `c(t) ≥ 2^{t−t₀}` for all `t ≥ t₀`":
+    here `t₀ = |V| + 1` is the concrete, unconditional threshold, so this is the explicit
+    exponential growth law of the admissible sparseness coefficient as a function of the
+    minimum set size `t` alone, with no auxiliary index. -/
+theorem admissibleCoeff_ge_two_pow_sub (hV : 0 < Fintype.card V) (t : ℕ)
+    (ht : Fintype.card V < t) :
+    2 ^ (t - Fintype.card V - 1) ≤ firstMomentThreshold t / Fintype.card V := by
+  have hk := admissibleCoeff_ge_two_pow_of_card hV (t - Fintype.card V - 1)
+  rwa [show Fintype.card V + 1 + (t - Fintype.card V - 1) = t from by omega] at hk
+
 end Erdos1022OQ02

--- a/research/problems/erdos-1022-oq-02/state.md
+++ b/research/problems/erdos-1022-oq-02/state.md
@@ -1,0 +1,43 @@
+# Research State: erdos-1022-oq-02
+
+## Current State
+**Phase**: ACT (saturated — verified 0-axiom/0-sorry file; adding closed-form corollaries)
+**Path**: full
+**Since**: 2026-07-09 (researcher-6)
+**Iteration**: 1
+
+## Problem
+Erdős #1022 OQ-02: growth rate of the Property-B sparseness threshold `c_t`.
+`Proofs/Erdos1022OQ02.lean` isolates the **first-moment** answer over bounded
+ground sets: the admissible coefficient `c(t) = ⌊2^{t-1}/|V|⌋` grows exponentially
+in the minimum set size `t`. File is `verified`, 0 axioms / 0 sorries, with a rich
+two-index (`t + k`) exponential API for `c`.
+
+## Iteration 1 (researcher-6, 2026-07-09) — single-index closed-form lower bound [UNVERIFIED — docker infra down]
+
+**Outcome**: one addition, `admissibleCoeff_ge_two_pow_sub` (0 new axioms, 0 new
+sorries). All the file's exponential lower bounds were in two-index `t + k` form
+(`admissibleCoeff_two_pow_mul_le`, `admissibleCoeff_ge_two_pow_of_card`
+`2^k ≤ c(|V|+1+k)`); none stated the growth in the single variable `t`. The new
+lemma collapses the unconditional iterate by `k = t − |V| − 1`:
+
+    for t > |V|:   2^{t − |V| − 1}  ≤  c(t) = ⌊2^{t-1}/|V|⌋.
+
+This turns the docstring remark in `admissibleCoeff_ge_two_pow_of_le`
+("`c(t) ≥ 2^{t−t₀}` for `t ≥ t₀`") into a checked theorem with the concrete,
+unconditional threshold `t₀ = |V| + 1`. One-line proof: specialise
+`admissibleCoeff_ge_two_pow_of_card` and rewrite the index via `omega`.
+
+Also synced the gallery `lineCount` (505 → 568; was already stale pre-edit).
+
+**Build note — UNVERIFIED (environmental)**: `docker-build.sh` died at Docker image
+build with `containerd .../meta.db: input/output error` (session-wide docker outage;
+host disk healthy). The proof is a one-line specialisation + `omega` index rewrite;
+hand-checked. CI in a clean environment is ground truth.
+
+## Next Action
+File is saturated. Future claimants: verify the added lemma builds once docker is
+restored; otherwise release without churning the complete verified core.
+
+## Blockers
+Docker infra down (containerd meta.db I/O error).


### PR DESCRIPTION
## Summary

Erdős #1022 OQ-02 — growth rate of the Property-B sparseness threshold. The first-moment file `Proofs/Erdos1022OQ02.lean` (verified, 0 axioms / 0 sorries) establishes that the admissible sparseness coefficient `c(t) = ⌊2^{t-1}/|V|⌋` grows exponentially in the minimum set size `t`, but its entire exponential API is stated in **two-index** `t + k` form (`admissibleCoeff_two_pow_mul_le`, `admissibleCoeff_ge_two_pow_of_card`: `2^k ≤ c(|V|+1+k)`).

This PR adds the missing **single-index closed form**:

**`admissibleCoeff_ge_two_pow_sub`** — for every `t > |V|`,
```
2^(t − |V| − 1) ≤ c(t) = ⌊2^{t-1}/|V|⌋.
```

It collapses the unconditional iterate `admissibleCoeff_ge_two_pow_of_card` by setting `k = t − |V| − 1`, turning the docstring remark in `admissibleCoeff_ge_two_pow_of_le` ("writing `t₀` for the positivity threshold, `c(t) ≥ 2^{t−t₀}`") into a checked theorem with the concrete, unconditional threshold `t₀ = |V| + 1`. One-line proof: specialise the iterate and rewrite the index via `omega`.

**0 new axioms, 0 new sorries.** Also synced the gallery `lineCount` (505 → 568; already stale before this edit) and added the previously-empty research `state.md`.

## Scope

A closed-form corollary of the existing verified API — it does not touch the OPEN conjecture (large ground sets / Lovász `c₂ = 1` regime remain untouched), which the file already scopes honestly as first-moment / bounded-ground-set only.

## Verification

⚠️ **UNVERIFIED** — `docker-build.sh Proofs.Erdos1022OQ02` failed at Docker image build with `containerd .../meta.db: input/output error` (session-wide docker-infra outage; host disk healthy), not a code fault. The proof is a one-line specialisation plus an `omega` index rewrite; hand-checked. CI in a clean environment is ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)