### PR TITLE
research(cayley-hamilton-...-oq-02-oq-02): dim C(M)=n from C(M)=K[M]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean
@@ -132,6 +132,23 @@ theorem finrank_centralizer_eq_natDegree_charpoly
   rw [finrank_centralizer_eq_of_nonderogatory M hM, M.charpoly_natDegree_eq_dim,
     Fintype.card_fin]
 
+/-- **Commutant dimension from `C(M) = K[M]`.**  If the centralizer of `M` already
+    coincides with the polynomial algebra `K[M]`, then it has `K`-dimension exactly
+    `n`.  This is the `(iii) ⟹ dim = n` edge: together with `(ii) ⟹ (iii)`
+    (`centralizer_eq_adjoin_of_nonderogatory`) and `(ii) ⟹ dim = n`
+    (`finrank_centralizer_eq_of_nonderogatory`) it names all three forward
+    implications among {nonderogatory, `C(M) = K[M]`, `dim = n`} that are available
+    without the Frobenius invariant-factor formula.  Obtained by feeding the
+    characterization `centralizer_eq_adjoin_iff_nonderogatory` into the headline. -/
+theorem finrank_centralizer_eq_of_centralizer_eq_adjoin
+    (M : Matrix (Fin n) (Fin n) K)
+    (h : Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))
+        = Algebra.adjoin K ({M} : Set (Matrix (Fin n) (Fin n) K))) :
+    Module.finrank K
+        ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))) = n :=
+  finrank_centralizer_eq_of_nonderogatory M
+    ((centralizer_eq_adjoin_iff_nonderogatory M).mp h)
+
 /-! ### Summary -/
 
 /-- **De Moivre / Cayley–Hamilton OQ-02-OQ-02 summary.**  For an `n × n` matrix


### PR DESCRIPTION
## Summary

Adds `finrank_centralizer_eq_of_centralizer_eq_adjoin` to `Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02.lean`: if the centralizer of `M` already coincides with the polynomial algebra `K[M]`, then `dim_K C(M) = n`.

This names the **(iii) ⟹ dim = n** edge, completing the triangle of forward implications among the three equivalent conditions that are available *without* the deep Frobenius invariant-factor dimension formula:
- `(ii) ⟹ (iii)`: `centralizer_eq_adjoin_of_nonderogatory` (nonderogatory ⟹ C(M)=K[M])
- `(ii) ⟹ dim=n`: `finrank_centralizer_eq_of_nonderogatory`
- `(iii) ⟹ dim=n`: **new**

The proof is a one-line composition of `centralizer_eq_adjoin_iff_nonderogatory` and `finrank_centralizer_eq_of_nonderogatory`. No new axioms or sorries. (The remaining converse `dim=n ⟹ nonderogatory` genuinely requires the Frobenius formula and is left as the standing next-step.)

## Verification
⚠️ **UNVERIFIED** — Docker build infra is down this session (containerd `meta.db` input/output error); this chain additionally has a known isModule-poisoned shared cache on dependency OQ02OQ01. The added theorem is a pure composition of two theorems already present in the same file; confidence high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)