### PR TITLE
Fix: resync lineCount for 3 drifted gallery entries

### DIFF
--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 505,
+    "lineCount": 551,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -129,7 +129,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 505,
+    "lineCount": 551,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 21,

--- a/src/data/proofs/erdos-659-oq-05/meta.json
+++ b/src/data/proofs/erdos-659-oq-05/meta.json
@@ -34,13 +34,13 @@
       "isRepresented_nonneg: represented integers are nonnegative (valid squared distances)",
       "dist_sq_lattice: squared distance between lattice points (x,y√2) equals Q of coordinate differences — ties the number theory to the actual Moree–Osburn geometry"
     ],
-    "lineCount": 142,
+    "lineCount": 191,
     "theoremCount": 10,
     "definitionCount": 4
   },
   "leanFile": {
     "path": "Proofs/Erdos659OQ05.lean",
-    "lineCount": 142,
+    "lineCount": 191,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 4,

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -55,7 +55,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 1087,
+    "lineCount": 1107,
     "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The two headline placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). Four narrative theorems remain as String-literal descriptors carrying no formal content (curve_branches_are_puiseux, newton_polygon_tropicalization, galois_group_is_profinite_integers, char_zero_required); each merely asserts ∃ desc : String, desc = \"…\" and marks an informal application/connection rather than a machine-checked result. This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
     "mathlib_version": "4.26.0",
     "theoremCount": 34,
@@ -173,7 +173,7 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 1087,
+    "lineCount": 1107,
     "axiomCount": 0,
     "theoremCount": 36,
     "definitionCount": 7,


### PR DESCRIPTION
## Fix

Meta-only `lineCount` resync for 3 gallery entries whose primary Lean source grew after researcher edits, leaving the recorded count stale.

## Evidence

| Entry | meta.json | actual `wc -l` |
|-------|-----------|----------------|
| erdos-1022-oq-02 | 505 | 551 |
| erdos-659-oq-05 | 142 | 191 |
| puiseux-theorem | 1087 | 1107 |

Each entry carries two `lineCount` occurrences (top-level `leanFile` + nested); both updated. No open PR touches these `.lean` or `meta.json` files, so the fix is durable. Single-file entries (no `additionalFiles`); count = `wc -l` of the primary source per gallery convention.

---
Automated fix by lean-mechanic agent.