### PR TITLE
research(algebraic-numbers-countable-oq-07): complex ae-transcendental + positive-measure witness for every atomless measure [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -329,4 +329,31 @@ theorem exists_transcendental_of_pos_measure_noAtoms {μ : Measure ℝ} [NoAtoms
   rw [hz] at hs
   exact lt_irrefl 0 hs
 
+/-- **Almost every complex number is transcendental, for any atomless measure `μ` on `ℂ`.**
+The complex analogue of `ae_transcendental_of_noAtoms`, and the atomless-measure
+generalization of `ae_transcendental_complex`: countability of the algebraic complex
+numbers forces them to be `μ`-null whenever `μ` has no atoms. -/
+theorem ae_transcendental_complex_of_noAtoms (μ : Measure ℂ) [NoAtoms μ] :
+    ∀ᵐ z : ℂ ∂μ, Transcendental ℚ z := by
+  have hset : {z : ℂ | Transcendental ℚ z} = {z : ℂ | IsAlgebraic ℚ z}ᶜ := by
+    ext z; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  rw [Filter.eventually_iff, hset]
+  exact compl_mem_ae_iff.mpr (algebraic_complex_null_of_noAtoms μ)
+
+/-- **Positive-measure sets in `ℂ` contain transcendentals, for any atomless `μ`.** If `μ`
+has no atoms and `μ s > 0`, then `s` contains a transcendental complex number — otherwise
+`s ⊆ {algebraic}` would be `μ`-null. The complex analogue of
+`exists_transcendental_of_pos_measure_noAtoms`. -/
+theorem exists_transcendental_of_pos_measure_noAtoms_complex {μ : Measure ℂ} [NoAtoms μ]
+    {s : Set ℂ} (hs : 0 < μ s) : ∃ z ∈ s, Transcendental ℚ z := by
+  by_contra h
+  push_neg at h
+  have hsub : s ⊆ {z : ℂ | IsAlgebraic ℚ z} := by
+    intro z hz
+    have := h z hz
+    simpa only [mem_setOf_eq, Transcendental, not_not] using this
+  have hz : μ s = 0 := measure_mono_null hsub (algebraic_complex_null_of_noAtoms μ)
+  rw [hz] at hs
+  exact lt_irrefl 0 hs
+
 end AlgebraicRealsNull

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -177,8 +177,8 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicRealsNull.lean",
-    "lineCount": 332,
-    "theoremCount": 17,
+    "lineCount": 359,
+    "theoremCount": 19,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Summary

Completes §5 ("Generalization to arbitrary atomless measures") of `AlgebraicRealsNull.lean`, which generalized the Lebesgue-null / conull-transcendental results to every `[NoAtoms μ]` measure but only supplied the **ℝ** analogues (`ae_transcendental_of_noAtoms`, `exists_transcendental_of_pos_measure_noAtoms`). This fills the two missing **ℂ** analogues:

- **`ae_transcendental_complex_of_noAtoms`** — for any atomless `μ` on `ℂ`, almost every complex number is transcendental. (Complex analogue of `ae_transcendental_of_noAtoms`; atomless-measure generalization of `ae_transcendental_complex`.)
- **`exists_transcendental_of_pos_measure_noAtoms_complex`** — any `μ`-positive-measure set in `ℂ` contains a transcendental, for any atomless `μ`.

Both are line-for-line mirrors of the already-verified real siblings, routed through the existing lemma `algebraic_complex_null_of_noAtoms` (countability of the algebraic complex numbers forces `μ`-measure zero for atomless `μ`). No new axioms, no new definitions; the entry stays fully `verified` (0 sorries / 0 axioms).

## Verification status

**UNVERIFIED** — Docker build infra is down this session (containerd `meta.db` input/output error at image-build stage, operator-level, fleet-wide). The two additions are exact structural copies of verified ℝ theorems in the same file (only `ℝ→ℂ` and `algebraic_reals_null_of_noAtoms → algebraic_complex_null_of_noAtoms`), so confidence is high, but they have not been machine-checked this session.

Gallery meta synced: `lineCount` 332→359, `theoremCount` 17→19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)