### PR TITLE
research(sylow-theorem-oq-04-oq-03): SL(2,p) not solvable for p≥5

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -852,4 +852,36 @@ theorem card_SL2 :
   rw [hfact] at key
   exact Nat.eq_of_mul_eq_mul_right hpos key
 
+/-!
+## `SL(2, p)` is not solvable for `p ≥ 5`
+
+Perfectness (`commutator_eq_top`) rules out solvability outright: a *nontrivial
+solvable* group has a **proper** commutator subgroup
+(`IsSolvable.commutator_lt_top_of_nontrivial`), whereas `SL(2, p)` equals its own
+commutator subgroup for `p ≥ 5`.  Non-solvability is the group-theoretic heart of
+the simplicity of `PSL(2, p)`: `SL(2, p)` (and hence its central quotient
+`PSL(2, p)`) escapes the entire solvable hierarchy exactly when `p ≥ 5`, the same
+threshold at which the simplicity theorem turns on.
+-/
+
+/-- **`SL(2, p)` is not solvable for `p ≥ 5`.**  It is perfect
+(`commutator_eq_top`) and nontrivial (the unipotent `[[1, 1], [0, 1]] ≠ 1`), and a
+nontrivial solvable group would have a proper commutator subgroup
+(`IsSolvable.commutator_lt_top_of_nontrivial`), contradicting
+`commutator (SL(2, p)) = ⊤`.  This is the non-solvability obstruction underlying the
+simplicity of `PSL(2, p)`. -/
+theorem not_isSolvable (hp : 5 ≤ p) :
+    ¬ IsSolvable (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) := by
+  intro hsolv
+  haveI := hsolv
+  haveI : Nontrivial (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) := by
+    refine ⟨unipotentUpper 1, 1, ?_⟩
+    rw [← unipotentUpper_zero (p := p)]
+    intro h
+    exact one_ne_zero (unipotentUpper_injective h)
+  have hlt : commutator (Matrix.SpecialLinearGroup (Fin 2) (ZMod p)) < ⊤ :=
+    IsSolvable.commutator_lt_top_of_nontrivial _
+  rw [commutator_eq_top hp] at hlt
+  exact lt_irrefl _ hlt
+
 end SylowOQ04OQ03

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -254,12 +254,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 773,
+    "lineCount": 887,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 8,
-    "theoremCount": 44
+    "theoremCount": 45
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Adds `not_isSolvable` to `SylowTheoremOQ04OQ03.lean`: **`SL(2, ZMod p)` is not solvable for `p ≥ 5`.**

This is a clean corollary of infrastructure already verified in the file:
- **perfectness** `commutator_eq_top (hp : 5 ≤ p) : commutator (SL(2,p)) = ⊤`, and
- **nontriviality** (`unipotentUpper 1 ≠ 1`, from the existing `unipotentUpper_injective`/`unipotentUpper_zero`).

A nontrivial solvable group has a *proper* commutator subgroup (Mathlib's `IsSolvable.commutator_lt_top_of_nontrivial : commutator G < ⊤`), which contradicts `commutator (SL(2,p)) = ⊤`. Hence `SL(2,p)` is not solvable.

## Why it matters

Non-solvability is the group-theoretic heart of the simplicity of `PSL(2, p)` (the parent open question). `SL(2,p)` — and hence its central quotient `PSL(2,p)` — escapes the entire solvable hierarchy exactly at the `p ≥ 5` threshold where the simplicity theorem turns on. This slots directly next to the existing perfectness, root-group generation, and `card_SL2 = p(p²−1)` results as another Iwasawa-route ingredient.

## Proof

Short assembly: `intro hsolv`, supply the `Nontrivial` instance from `unipotentUpper`, apply `IsSolvable.commutator_lt_top_of_nontrivial`, rewrite with `commutator_eq_top hp`, close with `lt_irrefl`.

No new `axiom`s, no `sorry`s; status remains `verified`. `leanFile` counts synced (lineCount 773→887, theoremCount 44→45).

## Verification status

⚠️ **UNVERIFIED** — the Docker build wrapper is down this session (containerd `meta.db` input/output error, an operator-level infra failure documented in prior sessions; `docker images` also errors). The added theorem is a short assembly of already-verified in-file lemmas plus one Mathlib lemma (`IsSolvable.commutator_lt_top_of_nontrivial`) whose exact signature and explicit-`G` binding were confirmed against the pinned Mathlib source in `.lake`. Please re-run `./proofs/scripts/docker-build.sh Proofs.SylowTheoremOQ04OQ03` once Docker is restored.