### PR TITLE
research(tetrahedral-number-formula-oq-01): explicit 4-dim (pentatope) figurate formula

### DIFF
--- a/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
+++ b/proofs/Proofs/TetrahedralNumberFormulaOQ01.lean
@@ -363,6 +363,22 @@ theorem simplexNumber_three_dim (n : ℕ) :
       Finset.prod_range_zero]
   ring
 
+/-- **Pentatope numbers (`d = 4`, division-free).**  The four-dimensional simplex
+number is the pentatope (4-simplex) number, the next figurate after the tetrahedral:
+
+`24 · P_4(n) = (n+1)(n+2)(n+3)(n+4)`,  i.e.  `C(n+4, 4) = (n+1)(n+2)(n+3)(n+4)/24`.
+
+The `d = 4` specialisation of `factorial_mul_simplexNumber_prod`, extending the explicit
+figurate-formula family `simplexNumber_one_dim` / `_two_dim` / `_three_dim` one dimension
+further with the denominator cleared. -/
+theorem simplexNumber_four_dim (n : ℕ) :
+    24 * simplexNumber 4 n = (n + 1) * (n + 2) * (n + 3) * (n + 4) := by
+  have h := factorial_mul_simplexNumber_prod 4 n
+  rw [show (4 : ℕ)! = 24 from rfl] at h
+  rw [h, Finset.prod_range_succ, Finset.prod_range_succ, Finset.prod_range_succ,
+      Finset.prod_range_succ, Finset.prod_range_zero]
+  ring
+
 /-- Bridge to the parent `TetrahedralNumberFormula`. The `d = 2` instance of the
 general hockey stick sums the triangular numbers `C(k+2, 2)` to the tetrahedral
 number `C(n+3, 3)`, matching the parent's `∑ T_k = C(n+2, 3)` up to the standard

--- a/research/problems/tetrahedral-number-formula-oq-01/state.md
+++ b/research/problems/tetrahedral-number-formula-oq-01/state.md
@@ -4,7 +4,17 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T16:49:44-07:00
-**Iteration**: 2
+**Iteration**: 3
+
+## Iteration 3 (researcher-6, 2026-07-09) — explicit 4-dim (pentatope) formula [UNVERIFIED — docker down]
+Added `simplexNumber_four_dim`: `24 · P_4(n) = (n+1)(n+2)(n+3)(n+4)` (pentatope /
+4-simplex number), extending the explicit division-free figurate family
+`simplexNumber_one_dim` / `_two_dim` / `_three_dim` one dimension further. Proof is
+the `d = 4` specialisation of `factorial_mul_simplexNumber_prod` (4 `prod_range_succ`
+peels + `ring`), a line-for-line mirror of `simplexNumber_three_dim`. 0 axioms / 0
+sorries. Deliberately orthogonal to the in-flight convolution/Vandermonde (#36580)
+and dimension-additivity (#36509) PRs (explicit-formula family, disjoint region).
+UNVERIFIED: docker infra down (containerd meta.db I/O error); hand-checked vs sibling.
 
 ## Current Focus
 Sharpen the (merged, #36700) ≤-only monotonicity of simplex numbers to strict


### PR DESCRIPTION
## Summary

Extends the division-free explicit figurate-formula family in `Proofs/TetrahedralNumberFormulaOQ01.lean` (`simplexNumber_one_dim`, `_two_dim` = triangular, `_three_dim` = tetrahedral) one dimension further:

**`simplexNumber_four_dim`** — the pentatope (4-simplex) number,
```
24 · P_4(n) = (n+1)(n+2)(n+3)(n+4),   i.e.  C(n+4,4) = (n+1)(n+2)(n+3)(n+4)/24.
```

Proof is the `d = 4` specialisation of `factorial_mul_simplexNumber_prod` (four `Finset.prod_range_succ` peels + `ring`) — a line-for-line mirror of the existing `simplexNumber_three_dim`.

**0 new axioms, 0 new sorries.**

## Coordination

Deliberately orthogonal to the two in-flight PRs on this file — #36580 (Vandermonde convolution) and #36509 (dimension-additivity) — living in the disjoint explicit-formula region alongside the `_two_dim`/`_three_dim` siblings.

## Verification

⚠️ **UNVERIFIED** — `docker-build.sh` failed at Docker image build with `containerd .../meta.db: input/output error` (session-wide docker-infra outage; host disk healthy), not a code fault. The proof is a mechanical mirror of the adjacent `simplexNumber_three_dim`; hand-checked. CI in a clean environment is ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)