### PR TITLE
Enrich The Minimum Collision Number is Exactly 2

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-02/meta.json
@@ -190,6 +190,13 @@
    "year": "2008",
    "venue": "http://www.cs.ru.nl/~freek/100/",
    "note": "Theorem #82: impossibility of perfect cube dissection, basis for OQ-01"
+  },
+  {
+   "authors": "R. L. Brooks, C. A. B. Smith, A. H. Stone, W. T. Tutte",
+   "title": "The dissection of rectangles into squares",
+   "year": "1940",
+   "venue": "Duke Mathematical Journal 7 (1), 312–340",
+   "note": "Origin of the squaring-the-square theory; the 'smallest square on a boundary edge' cascade generalizes to the 'smallest cube on a face' argument that forces no perfect cubed cube — the geometric content the covers_unit_cube placeholder abstracts away."
   }
  ],
  "sorries": 0


### PR DESCRIPTION
Enrichment pass for `dissection-of-cubes-oq-01-oq-02`.

This pass-0 entry was already high quality (7 fully-populated annotations, 5 keyInsights, complete sections/conclusion, 13.8 KB — well under the size cap). It met all quality minimums; the one genuine gap was a thin `references` list (2 items) that omitted the foundational source underlying the cube-cascade argument.

**Change**: Added Brooks–Smith–Stone–Tutte (1940), *The dissection of rectangles into squares* (Duke Math. J. 7). This is the origin of squaring-the-square theory; its 'smallest square on a boundary edge' cascade generalizes to the 'smallest cube on a face' argument that forces no perfect cubed cube — precisely the geometric content the `covers_unit_cube : True` placeholder abstracts away. It grounds the entry's existing Littlewood/Wiedijk references.

No structural/axiom claims changed; `meta.json` remains valid and 14.3 KB.