### PR TITLE
research(erdos-1014-oq-03): base-sequence normalized increment vanishes

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03Obstruction.lean
+++ b/proofs/Proofs/Erdos1014OQ03Obstruction.lean
@@ -122,6 +122,24 @@ theorem increment_ratio_not_tendsto_one :
   have : (-1 : ℝ) = 1 := tendsto_nhds_unique tendsto_const_nhds heven
   norm_num at this
 
+/-- **The base sequence's normalized increment vanishes.**  For the witness `u l = l`
+the normalized consecutive increment is `(u(l+1) − u(l))/u(l) = 1/l`, which tends to
+`0`.  Read alongside `increment_ratio_not_tendsto_one`, this sharpens the obstruction:
+`u` individually has a vanishing *normalized* increment (its jumps are `o(u)`), yet the
+increment *ratio* against the `~`-equivalent `v` still fails to converge.  So even
+`o(R)`-scale agreement of the sequences does not pin down the increment asymptotic —
+the honest increment–ratio bridge, which hypothesizes the consecutive ratio directly,
+is unavoidable.  (The companion statement for `v`, whose oscillating increment is
+`1 − 2(−1)^l` over the diverging `v l = l + (−1)^l`, likewise tends to `0` but requires
+a bounded-numerator-over-divergent-denominator estimate; recorded here as the base
+case.) -/
+theorem u_normalizedIncrement_tendsto_zero :
+    Tendsto (fun l => (u (l + 1) - u l) / u l) atTop (𝓝 0) := by
+  have hEq : (fun l => (u (l + 1) - u l) / u l) = (fun l : ℕ => 1 / (l : ℝ)) := by
+    funext l; rw [u_increment]; simp [u]
+  rw [hEq]
+  exact tendsto_one_div_atTop_nhds_zero_nat
+
 /-- **Increment not determined by the asymptotic class (packaged existential).**
 
 There exist eventually-positive sequences `u, v` that are asymptotically equivalent


### PR DESCRIPTION
## Summary

Adds `u_normalizedIncrement_tendsto_zero` to `Proofs/Erdos1014OQ03Obstruction.lean`: for the obstruction witness `u l = l`, the normalized consecutive increment
```
(u(l+1) − u(l)) / u(l) = 1/l → 0.
```

Read alongside the existing `increment_ratio_not_tendsto_one`, this **sharpens the obstruction**: the sequence `u` individually has a vanishing *normalized* increment (its jumps are `o(u)`), yet the increment *ratio* against the `~`-equivalent `v = l + (−1)^l` still fails to converge. So even `o(R)`-scale agreement of the sequences does not pin down the increment asymptotic — reinforcing why the honest increment–ratio bridge (which hypothesizes the consecutive ratio directly) is unavoidable.

This realizes the **base half** of the documented optional next-step ("both normalized increments → 0"). The `v` half tends to `0` too but needs a bounded-numerator-over-divergent-denominator estimate on the oscillating `(1 − 2(−1)^l)/(l + (−1)^l)`; it is documented and left for a build-capable session rather than shipped as an unverifiable fragile estimate.

Proof: `(u(l+1)−u l)/u l = 1/l` (via `u_increment`), then `tendsto_one_div_atTop_nhds_zero_nat` — the same lemma already used by `asymptotic_equiv` in this file. No new axioms or sorries.

## Verification
⚠️ **UNVERIFIED** — Docker build infra is down this session (containerd `meta.db` input/output error). The proof reuses only `u_increment` and a Mathlib lemma already invoked elsewhere in the same file; confidence high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)