### PR TITLE
audit(erdos-919): re-verified CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17390,9 +17390,9 @@
       "result": "clean"
     },
     "erdos-919": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:06Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T06:24:46Z",
       "result": "clean"
     },
     "erdos-92": {
@@ -29771,5 +29771,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T05:16:28Z"
+  "lastUpdated": "2026-07-10T06:24:46Z"
 }


### PR DESCRIPTION
## Integrity Audit: erdos-919 (Chromatic Numbers on Ordinal Products)

**Result**: clean (re-verified; was stalest at 2026-05-04)

### Verification (against `proofs/Proofs/Erdos919Problem.lean`)
- **Counts exact**: 0 axioms, 0 sorries, 0 `native_decide`; 40 theorems, 15 defs — all match meta.json.
- **No stubs**: every theorem is a genuine proof. Main results `erdosHajnal_chromatic` (χ(ω₁² E-H graph) = ℵ₁) and `erdosHajnalGraph2_chromatic` (χ(ω₂² E-H graph) = ℵ₂) are real double-pigeonhole arguments. `babai_fails_omega1`, `erdosHajnal_subgraph`, `partialConstruction`, `summary` all substantive.
- **Open questions honest**: `Question1`/`Question2` (the actual open #919 questions at ℵ₂) are stated as unproven `Prop` definitions — not axiomatized, not claimed proved.

### Status/badge assessment
`status: axiomatized` + `badge: wip` + `axiomCount: 0` for an open Erdős conjecture is the sanctioned conservative presentation (avoids implying the open problem is solved). The `assumptions` field accurately states "None. All results are fully machine-checked... The open questions (Questions 1 and 2) are stated but not assumed." `originalContributions` are modest and all present in source. No overclaiming.

Tracker bumped for erdos-919 (was stuck at 2026-05-04).

---
Discovered during gallery integrity audit.