### PR TITLE
research(erdos-1098-oq-01-oq-03): bounded cliques closed under direct products

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -563,4 +563,41 @@ theorem boundedCliques_congr {K : Type*} [Group K] (e : G ≃* K) :
   · exact fun y => ⟨e.symm y, by simp⟩
   · exact fun y => ⟨e y, by simp⟩
 
+/-- **Bounded cliques are closed under direct products (finite-central-index side).**
+    If both `[G : Z(G)]` and `[K : Z(K)]` are finite, then `Γ(G × K)` has bounded clique
+    number: `BoundedCliques (G × K)`.
+
+    *Proof.* The product of centres is central: `Z(G) × Z(K) ≤ Z(G × K)` (a pair is central
+    iff each coordinate is, and the easy inclusion suffices here).  By multiplicativity of
+    the index on products (`Subgroup.index_prod`) the subgroup `Z(G) × Z(K)` has finite index
+    `[G:Z(G)]·[K:Z(K)]`, and since it lies inside `Z(G × K)` the central index
+    `[G × K : Z(G × K)]` divides it (`Subgroup.index_dvd_of_le`), hence is also finite.  The
+    easy direction `bounded_cliques_of_finite_index` then bounds the cliques of `Γ(G × K)`.
+
+    This is the direct-product companion to the subgroup/quotient/isomorphism heredity lemmas
+    above: via Neumann's dichotomy the class of groups with `BoundedCliques` is closed under
+    finite products.  Axiom-free — it uses only the easy inclusion of centres and the easy
+    clique bound, never the BFC core `neumann_hard_direction`.  (Phrased on the finite-central-
+    index side so it stays axiom-free: turning a `BoundedCliques` hypothesis on the factors into
+    finite central index would route through the blocked hard direction.) -/
+theorem boundedCliques_prod_of_finiteIndex {K : Type*} [Group K]
+    (hG : (Subgroup.center G).index ≠ 0) (hK : (Subgroup.center K).index ≠ 0) :
+    BoundedCliques (G × K) := by
+  -- The product of the two centres is central in `G × K` (easy inclusion).
+  have hle : (Subgroup.center G).prod (Subgroup.center K) ≤ Subgroup.center (G × K) := by
+    intro x hx
+    rw [Subgroup.mem_prod] at hx
+    rw [Subgroup.mem_center_iff]
+    intro g
+    have h1 : g.1 * x.1 = x.1 * g.1 := Subgroup.mem_center_iff.mp hx.1 g.1
+    have h2 : g.2 * x.2 = x.2 * g.2 := Subgroup.mem_center_iff.mp hx.2 g.2
+    exact Prod.ext_iff.mpr ⟨h1, h2⟩
+  -- `[G:Z(G)]·[K:Z(K)]` is finite, and the central index of the product divides it.
+  have hprod : ((Subgroup.center G).prod (Subgroup.center K)).index ≠ 0 := by
+    rw [Subgroup.index_prod]; exact mul_ne_zero hG hK
+  have hdvd : (Subgroup.center (G × K)).index
+      ∣ ((Subgroup.center G).prod (Subgroup.center K)).index :=
+    Subgroup.index_dvd_of_le hle
+  exact bounded_cliques_of_finite_index (ne_zero_of_dvd_ne_zero hprod hdvd)
+
 end Erdos1098OQ01OQ03

--- a/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
+++ b/research/problems/erdos-1098-oq-01-oq-03/knowledge.md
@@ -81,3 +81,23 @@ confidence. Axiom-free (elementary clique transfer, NOT the blocked BFC core).
 UNVERIFIED: Docker infra down this session (containerd `meta.db input/output error` at image
 build, before any Lean elaboration — operator-level outage, not a proof error). Blocked BFC core
 `neumann_hard_direction` unchanged.
+
+## Session 2026-07-09 (researcher-9) — direct-product closure (finite-central-index side)
+
+Added `boundedCliques_prod_of_finiteIndex (hG : (center G).index ≠ 0) (hK : (center K).index ≠ 0)
+: BoundedCliques (G × K)` (1 thm, 0 sorry, axiom count unchanged at 1). The genuinely-new
+structural direction not previously covered: closure under **direct products**. Proof is
+axiom-free — uses only the easy inclusion `Z(G) × Z(K) ≤ Z(G × K)` (`Subgroup.mem_center_iff`
+coordinatewise), `Subgroup.index_prod` (index multiplicative on products) to get finite index
+`[G:Z(G)]·[K:Z(K)]`, `Subgroup.index_dvd_of_le` (the central index of the product divides it,
+hence finite), then the easy `bounded_cliques_of_finite_index`. Phrased on the finite-central-
+index side deliberately: taking `BoundedCliques` on the factors and deducing finite central
+index would route through the blocked BFC hard direction `neumann_hard_direction`. Companion to
+subgroup/quotient/injective/congr heredity — the `BoundedCliques` (≡ finite-central-index) class
+is now recorded closed under subgroups, quotients, isomorphism, and finite products.
+
+Build: docker infra fully DOWN (containerd meta.db input/output error at IMAGE build; `docker
+images` empty — whole daemon metadata corrupt; host disk healthy 115Gi). ZERO build possible →
+shipped UNVERIFIED. Every Mathlib API name (`center_prod`/`index_prod`/`index_dvd_of_le`/
+`mem_center_iff`/`mem_prod`/`ne_zero_of_dvd_ne_zero`) verified against the local mathlib pin;
+proof is standard. Blocked core (infinite-G hard direction) unchanged.


### PR DESCRIPTION
## Summary

Adds `boundedCliques_prod_of_finiteIndex` to `Erdos1098OQ01OQ03.lean` — the **direct-product** companion to the existing subgroup / quotient / injective / isomorphism heredity lemmas for Neumann's non-commuting-graph clique number:

```
(Subgroup.center G).index ≠ 0 → (Subgroup.center K).index ≠ 0 → BoundedCliques (G × K)
```

**1 theorem, 0 sorry, axiom count unchanged at 1** (the blocked BFC core `neumann_hard_direction` is untouched).

## Proof (axiom-free)

Uses only elementary facts, never the blocked hard direction:
- easy inclusion `Z(G) × Z(K) ≤ Z(G × K)` (`Subgroup.mem_center_iff` coordinatewise);
- multiplicativity of the index on products, `Subgroup.index_prod`, giving finite index `[G:Z(G)]·[K:Z(K)]`;
- `Subgroup.index_dvd_of_le`: the product's central index `[G×K : Z(G×K)]` divides that, hence is finite;
- the easy `bounded_cliques_of_finite_index` bounds the cliques of `Γ(G × K)`.

## Why this framing

Stated on the **finite-central-index side** deliberately. Deducing finite central index from a `BoundedCliques` hypothesis on the factors would route through the blocked BFC hard direction `neumann_hard_direction`; the finite-index form keeps the result axiom-free. Via Neumann's dichotomy `BoundedCliques ↔ [·:Z(·)] finite`, the class is now recorded closed under **subgroups, quotients, isomorphism, and finite products**.

## Verification

⚠️ **UNVERIFIED.** Docker infra is fully down (containerd `meta.db` input/output error at image build; `docker images` empty; host disk healthy at ~115Gi free). No build was possible. Every Mathlib API name used (`Subgroup.index_prod`, `Subgroup.index_dvd_of_le`, `Subgroup.mem_center_iff`, `Subgroup.mem_prod`, `ne_zero_of_dvd_ne_zero`) was verified against the local mathlib pin, and the `ne_zero_of_dvd_ne_zero ∘ index_dvd_of_le` pattern appears verbatim in Mathlib's own `Index.lean`. A follow-up build should confirm.