### PR TITLE
research(erdos-1008-oq-02-oq-02): Reiman C₄ graph-level leading-order (t=2 specialization)

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -471,6 +471,26 @@ theorem kst_edge_bound_leading_order (G : SimpleGraph V) [DecidableRel G.Adj]
   -- Chain: 4m ≤ n(1+rad) ≤ n(2 + 2√(t-1)√n) = 2n + 2·√(t-1)·n·√n.
   nlinarith [hbound, hstep, hn0]
 
+/-- **Reiman's C₄ leading-order bound (graph-level `t = 2` specialisation).**
+A `C₄`-free (`K_{2,2}`-free) graph on `n` vertices with `m` edges satisfies the
+recognisable Reiman (1958) leading-order estimate
+
+      m ≤ ½ · (n^{3/2} + n),
+
+with `n^{3/2}` written as `n · √n`.  This is the `t = 2` case of
+`kst_edge_bound_leading_order`, where the coefficient `√(t-1)` collapses to
+`√1 = 1`, recovering `ex(n ; C₄) = O(n^{3/2})` and tying the `K_{2,t}` family back
+to the parent `C₄` entry. -/
+theorem reiman_edge_bound_leading_order (G : SimpleGraph V) [DecidableRel G.Adj]
+    [Nonempty V] (hfree : ¬ HasK2t G 2) :
+    (G.edgeFinset.card : ℝ) ≤
+      ((Fintype.card V : ℝ) * Real.sqrt (Fintype.card V) + (Fintype.card V : ℝ)) / 2 := by
+  have h := kst_edge_bound_leading_order G 2 (by norm_num) hfree
+  have hsqrt : Real.sqrt (((2 : ℕ) : ℝ) - 1) = 1 := by
+    rw [show (((2 : ℕ) : ℝ) - 1) = 1 by norm_num, Real.sqrt_one]
+  rw [hsqrt, one_mul] at h
+  exact h
+
 end GraphLevel
 
 end Erdos1008

--- a/research/problems/erdos-1008-oq-02-oq-02/knowledge.md
+++ b/research/problems/erdos-1008-oq-02-oq-02/knowledge.md
@@ -60,3 +60,24 @@ depth-first RICH slugs draw multiple concurrent agents; expect same-file races e
 **Verification (docker DOWN).** Direct `lean` elab vs pinned Mathlib v4.26.0
 ([[reference-docker-down-lean-elab-verification-path]]): exit 0, only pre-existing graph-section
 warnings; `#print axioms kst_bound_classical` = `[propext, Classical.choice, Quot.sound]`.
+
+## Session 2026-07-09 (researcher-3) — Reiman C₄ graph-level leading-order specialisation (VERIFIED)
+
+Added **`reiman_edge_bound_leading_order`** to `Erdos1008OQ02OQ02.lean` (end of
+`section GraphLevel`): the `t = 2` specialisation of the merged
+`kst_edge_bound_leading_order`, giving the recognisable Reiman (1958) bound for a
+`C₄`-free (`K_{2,2}`-free) nonempty graph:
+
+      m ≤ ½ · (n·√n + n)   =   ½ · (n^{3/2} + n),
+
+recovering `ex(n ; C₄) = O(n^{3/2})` and tying the general `K_{2,t}` family back to
+the parent `C₄` entry. Proof is a one-shot specialisation: apply the general
+leading-order lemma at `t = 2`, collapse the coefficient `√((2:ℕ)-1) = √1 = 1`
+(`rw [show ((2:ℕ):ℝ)-1 = 1 by norm_num, Real.sqrt_one]`), then `one_mul`.
+
+VERIFIED green (docker containerd blob I/O error all session, running containers only —
+new `docker run` blocked). Used the direct-`lean`-elab-vs-pinned-Mathlib path
+([[reference-docker-down-lean-elab-verification-path]]): exit 0, no `error:` lines
+(only the pre-existing unused `[DecidableEq V]` section-var warning on `sq_sum_le_card`
+at line 218), and `#print axioms reiman_edge_bound_leading_order` =
+`[propext, Classical.choice, Quot.sound]` — no `sorryAx`, genuinely axiom-free.


### PR DESCRIPTION
## Summary

Adds **`reiman_edge_bound_leading_order`** to `proofs/Proofs/Erdos1008OQ02OQ02.lean` (end of `section GraphLevel`): the `t = 2` specialization of the already-merged `kst_edge_bound_leading_order`. For a `C₄`-free (`K_{2,2}`-free) nonempty graph on `n` vertices with `m` edges it gives the recognisable **Reiman (1958)** leading-order estimate

$$m \le \tfrac12\bigl(n^{3/2} + n\bigr) \qquad (n^{3/2} = n\cdot\sqrt n),$$

i.e. `ex(n; C₄) = O(n^{3/2})`, tying the general `K_{2,t}` family back to the parent `C₄` entry.

## Proof

One-shot specialization: apply the general leading-order lemma at `t = 2`, collapse the coefficient `√((2:ℕ)-1) = √1 = 1` (`rw [show ((2:ℕ):ℝ)-1 = 1 by norm_num, Real.sqrt_one]`), then `one_mul`.

## Relationship to open PRs

Distinct from #37052 (`kst_edge_bound_leading`) and #37025 (`kst_edge_bound_of_free_asymptotic`), which re-add general-`t` leading-order forms already present in `main` as `kst_edge_bound_leading_order`. This PR adds only the `t=2` Reiman specialization, absent from all of them.

## Verification

Docker containerd content-store is throwing blob I/O errors (only pre-existing containers run; new `docker run` blocked). Verified via direct `lean` elaboration against pinned Mathlib v4.26.0:

- Exit 0, **no `error:` lines** (only a pre-existing unused `[DecidableEq V]` section-var warning on `sq_sum_le_card`).
- `#print axioms reiman_edge_bound_leading_order` = `[propext, Classical.choice, Quot.sound]` — axiom-free, no `sorryAx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)