### PR TITLE
research(lagrange-theorem-oq-01): n_p divides |G| (Sylow III headline form)

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01.lean
@@ -95,6 +95,16 @@ theorem sylow_count_dvd_index (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
     card (Sylow p G) ∣ P.toSubgroup.index :=
   Sylow.card_sylow_dvd_index P
 
+/-- The number of Sylow p-subgroups divides `|G|`.
+    Since `n_p` divides the index `[G : P] = |G| / p^k` (`sylow_count_dvd_index`)
+    and that index divides `|G|` (`Subgroup.index_dvd_card`), transitivity gives the
+    headline Third-Sylow divisibility `n_p | |G|` — the coarser but self-contained
+    form of `n_p | |G|/p^k` that needs no reference to the Sylow order. -/
+theorem sylow_count_dvd_card (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
+    card (Sylow p G) ∣ card G := by
+  have h := (Sylow.card_sylow_dvd_index P).trans P.toSubgroup.index_dvd_card
+  rwa [Nat.card_eq_fintype_card] at h
+
 /-- The number of Sylow p-subgroups is congruent to 1 mod p. -/
 theorem sylow_count_mod_p (p : ℕ) [hp : Fact p.Prime] :
     card (Sylow p G) % p = 1 := by

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -151,9 +151,9 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01",
-    "lineCount": 141,
+    "lineCount": 151,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 0,
     "path": "Proofs/LagrangeTheoremOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds `sylow_count_dvd_card` to `LagrangeTheoremOQ01.lean`: **the number `n_p` of Sylow `p`-subgroups divides `|G|`.**

Part IV of the file states the Third Sylow Theorem as `n_p ≡ 1 (mod p)` and `n_p | |G|/p^k`, but the only divisibility it actually formalizes is `n_p | [G : P]` (`sylow_count_dvd_index`). This PR closes that stated-but-unformalized gap with the coarser, self-contained form `n_p | |G|`.

## Proof

Transitivity of two facts already available:
- `Sylow.card_sylow_dvd_index P : n_p ∣ [G : P]` (already used in-file at `sylow_count_dvd_index`), and
- `Subgroup.index_dvd_card : [G : P] ∣ Nat.card G`,

bridged `Nat.card → Fintype.card` via the standard `Nat.card_eq_fintype_card` (the file uses `Fintype.card` throughout).

No new `axiom`s, no `sorry`s; status stays `verified`. `leanFile` counts synced (lineCount 141→151, theoremCount 11→12).

## Verification status

⚠️ **UNVERIFIED** — the Docker build wrapper is down this session (containerd `meta.db` input/output error, operator-level infra failure). The addition is a two-line transitivity assembly over lemmas whose names/signatures were confirmed against the pinned Mathlib source in `.lake`. Please re-run `./proofs/scripts/docker-build.sh Proofs.LagrangeTheoremOQ01` once Docker is restored.