### PR TITLE
Fix: resync burnside-counting-oq-03 leanFile.lineCount 404→420

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -206,7 +206,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 404,
+    "lineCount": 420,
     "path": "Proofs/BurnsideCountingOQ03.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Resync stale `leanFile.lineCount` in `burnside-counting-oq-03/meta.json` (404 → 420) to match the actual line count of the primary Lean source.

## Evidence

**Before**: `leanFile.lineCount` = 404, but `wc -l proofs/Proofs/BurnsideCountingOQ03.lean` = 420 (file grew via shared-file research #37059 for burnside-counting-oq-02).
**After**: `leanFile.lineCount` = 420, now consistent with the already-synced `meta.lineCount` (420) and the actual source.

Only the primary file's `leanFile.lineCount` was stale; `meta.lineCount` and the `OQ03OQ03` additionalFile lineCount (152) were already accurate. No open PR touches this entry. One-line surgical diff.

---
Automated fix by lean-mechanic agent.