### PR TITLE
research(pythagorean-theorem-oq-01): altitude-on-hypotenuse length |CH| = |CA|·|CB|/|AB|

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ01.lean
@@ -277,6 +277,25 @@ theorem altitude_geometric_mean (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
       = ‖A - B‖ - ‖A - altitudeFoot A B C‖ := by linarith
   rw [hCH, hgA, hBsub]; ring
 
+include hAB in
+/-- **Altitude-on-hypotenuse length.** The altitude from the right-angle vertex has length
+`|CH| = |CA|·|CB| / |AB|` — the product of the legs divided by the hypotenuse. Equivalently,
+`|AB|·|CH| = |CA|·|CB|`, the statement that the triangle's area computed on the hypotenuse
+(`½|AB|·|CH|`) equals its area computed on the legs (`½|CA|·|CB|`). It is the positive square
+root of the altitude geometric-mean relation `|CH|² = |AH|·|HB|` after substituting the two
+segment lengths `|AH| = |CA|²/|AB|` and `|HB| = |CB|²/|AB|`. -/
+theorem altitude_length (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    ‖C - altitudeFoot A B C‖ = ‖A - C‖ * ‖B - C‖ / ‖A - B‖ := by
+  have hne := hnorm_ne A B hAB
+  have hgm := altitude_geometric_mean A B C hAB hperp
+  have hAH := dist_A_foot A B C hAB
+  have hHB := dist_foot_B A B C hAB hperp
+  have hlhs : 0 ≤ ‖C - altitudeFoot A B C‖ := norm_nonneg _
+  have hrhs : 0 ≤ ‖A - C‖ * ‖B - C‖ / ‖A - B‖ := by positivity
+  have hsq : ‖C - altitudeFoot A B C‖ ^ 2 = (‖A - C‖ * ‖B - C‖ / ‖A - B‖) ^ 2 := by
+    rw [hgm, hAH, hHB]; field_simp; ring
+  rw [← Real.sqrt_sq hlhs, hsq, Real.sqrt_sq hrhs]
+
 end Geometric
 
 -- ============================================================

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -74,9 +74,9 @@
   },
   "leanFile": {
     "namespace": "PythagoreanEinstein",
-    "lineCount": 299,
+    "lineCount": 318,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 2,
     "path": "Proofs/PythagoreanTheoremOQ01.lean",
     "imports": [


### PR DESCRIPTION
## Summary

Adds `altitude_length` to the Einstein similar-triangles Pythagorean file — the classical **fourth** member of the altitude family, alongside the two leg geometric-mean relations and `altitude_geometric_mean`:

$$|CH| = \frac{|CA|\cdot|CB|}{|AB|}$$

The altitude from the right-angle vertex has length equal to the product of the legs over the hypotenuse. Equivalently `|AB|·|CH| = |CA|·|CB|` — the statement that the triangle's area computed on the hypotenuse (`½|AB|·|CH|`) equals its area computed on the legs (`½|CA|·|CB|`).

## Proof

It is the positive square root of the existing `altitude_geometric_mean` (`|CH|² = |AH|·|HB|`) after substituting the segment lengths from `dist_A_foot`/`dist_foot_B`:

`|CH|² = (|CA|²/|AB|)·(|CB|²/|AB|) = (|CA|·|CB|/|AB|)²`

Both sides nonneg ⇒ `Real.sqrt_sq` closes it. Axiom-free; a mechanical assembly of already-verified in-file lemmas.

## Verification status

⚠️ **UNVERIFIED** — docker build infra is down this session (containerd content-store + `meta.db` `input/output error`, operator-level; host disk healthy at 114Gi free). Shipped per the established pattern for env-blocked increments; the proof is a straightforward square-root of relations already machine-checked in this file. Gallery `leanFile` counts synced (lineCount 299→318, theoremCount 13→14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)