### PR TITLE
research(erdos-1059-oq-01-oq-01): level-wise non-qualifying deficit bound

### DIFF
--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -261,6 +261,25 @@ theorem levelwise_strict_surplus (l k : ℕ) (hl : l ≥ 3) (hlk : l ≥ k + 2) 
   have hexp : primesInLevel l * (k + 1) = primesInLevel l * k + primesInLevel l := by ring
   omega
 
+/-- **Level-wise non-qualifying deficit bound.**  For `l ≥ 3` and `l ≥ k`, the *non*-qualifying
+    primes in the primorial interval `I(l)` occupy at most a `1/(k+1)` fraction of all primes in
+    `I(l)`:
+
+      `(p(l) − q(l)) · (k+1) ≤ p(l)`.
+
+    This is the per-interval dual of the cumulative pointwise equivalence `deficit_le_iff_density`,
+    obtained from the level-wise density bound `levelwise_density_bound` (`q(l)·(k+1) ≥ p(l)·k`) by
+    the same truncated-subtraction identity `(p−q)·(k+1) = p·(k+1) − q·(k+1)` and
+    `p·(k+1) = p·k + p`. Letting `k → l` (its largest admissible value) it says the deficit fraction
+    in `I(l)` is at most `1/(l+1)` — the sharp per-level reading of the Selberg density prediction. -/
+theorem levelwise_deficit_le (l k : ℕ) (hl : l ≥ 3) (hlk : l ≥ k) :
+    (primesInLevel l - qualifyingInLevel l) * (k + 1) ≤ primesInLevel l := by
+  have hb := levelwise_density_bound l k hl hlk
+  have e1 : (primesInLevel l - qualifyingInLevel l) * (k + 1)
+      = primesInLevel l * (k + 1) - qualifyingInLevel l * (k + 1) := Nat.sub_mul _ _ _
+  have e2 : primesInLevel l * (k + 1) = primesInLevel l * k + primesInLevel l := by ring
+  omega
+
 /-
 ## Part IV.5: The Non-Qualifying (Bad) Prime Bound
 


### PR DESCRIPTION
## Summary

Adds `levelwise_deficit_le` to the Selberg-density file for Erdős #1059 OQ-01-OQ-01: for `l ≥ 3` and `l ≥ k`,

    (primesInLevel l − qualifyingInLevel l) · (k+1) ≤ primesInLevel l.

This is the **per-interval dual** of the cumulative pointwise equivalence `deficit_le_iff_density`. It says that within each primorial interval `I(l) = (l!, (l+1)!]`, the *non*-qualifying primes occupy at most a `1/(k+1)` fraction of all primes; at the largest admissible threshold `k = l` this is the sharp `1/(l+1)` per-level reading of the Selberg sieve's density prediction, complementing the existing level-wise density bound `levelwise_density_bound` and level-sum deficit `nonqualifying_deficit_at_factorials`.

## Proof

Reuses the already-proved `levelwise_density_bound` (`q(l)·(k+1) ≥ p(l)·k`) and the verified truncated-subtraction identity of `deficit_le_iff_density` (`Nat.sub_mul` + `p·(k+1) = p·k + p` + `omega`). No new axioms — the file retains the single disclosed sieve axiom `strong_selberg_density` and remains sorry-free.

## Verification

The Docker build wrapper is down at the infrastructure level this session (containerd `meta.db` input/output error), so a containerized rebuild was not possible. The lemma is a direct reuse of proof patterns already machine-checked in the same file, so confidence is high; it awaits CI rebuild.

Meta synced: `lineCount 552→571`, `theoremCount 14→15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)