### PR TITLE
research(erdos-729-oq-02): sharp n/(p-1) upper bound on v_p(n!)

### DIFF
--- a/proofs/Proofs/Erdos729LegendreGeneral.lean
+++ b/proofs/Proofs/Erdos729LegendreGeneral.lean
@@ -93,6 +93,25 @@ theorem sub_one_dvd_sub_digitSum (p n : ℕ) (hp : p.Prime) :
     (p - 1) ∣ (n - digitSum p n) :=
   ⟨padicValNat p n.factorial, (sub_one_mul_padicValNat_factorial_digitSum p n hp).symm⟩
 
+/-- **The sharp `n/(p-1)` upper bound, multiplied form.**  For every prime `p`,
+`(p - 1)·v_p(n!) ≤ n`.  Immediate from Legendre's identity
+`(p-1)·v_p(n!) = n - s_p(n)` and `n - s_p(n) ≤ n`; this is the exact integer form
+of the classical estimate `v_p(n!) ≤ n/(p-1)` (and its heuristic `v_p(n!) ≈ n/(p-1)`),
+with the digit-sum defect `s_p(n)` measuring the shortfall. -/
+theorem sub_one_mul_padicValNat_factorial_le (p n : ℕ) (hp : p.Prime) :
+    (p - 1) * padicValNat p n.factorial ≤ n := by
+  rw [sub_one_mul_padicValNat_factorial_digitSum p n hp]
+  exact Nat.sub_le n (digitSum p n)
+
+/-- **The sharp `n/(p-1)` upper bound, division form.**  For every prime `p`,
+`v_p(n!) ≤ n / (p - 1)` (truncated natural division).  The classical bound on the
+`p`-adic valuation of a factorial, obtained from the division identity
+`v_p(n!) = (n - s_p(n))/(p-1)` by monotonicity of division in the numerator. -/
+theorem padicValNat_factorial_le_div (p n : ℕ) (hp : p.Prime) :
+    padicValNat p n.factorial ≤ n / (p - 1) := by
+  rw [padicValNat_factorial_eq_div p n hp]
+  exact Nat.div_le_div_right (Nat.sub_le n ((p.digits n).sum))
+
 -- The numerical content (v_p(n!) = (n - s_p(n))/(p-1) for many p, n) is certified
 -- independently in `research/problems/erdos-729-oq-02/verify_legendre_general.py`
 -- (no Lean `decide` on `Nat.digits`, which is well-founded and does not reduce
@@ -102,5 +121,7 @@ theorem sub_one_dvd_sub_digitSum (p n : ℕ) (hp : p.Prime) :
 #check @legendre_digit_sum_identity
 #check @sub_one_mul_padicValNat_factorial_digitSum
 #check @sub_one_dvd_sub_digitSum
+#check @sub_one_mul_padicValNat_factorial_le
+#check @padicValNat_factorial_le_div
 
 end Erdos729Legendre


### PR DESCRIPTION
## Summary

Adds the classical valuation upper bound to `Erdos729LegendreGeneral.lean`, a direct corollary of the file's proven general-$p$ Legendre identity $(p-1)\cdot v_p(n!) = n - s_p(n)$:

- **`sub_one_mul_padicValNat_factorial_le`** — $(p-1)\cdot v_p(n!) \le n$
- **`padicValNat_factorial_le_div`** — $v_p(n!) \le n/(p-1)$ (truncated natural division)

## Motivation

The file already proves Legendre's identity in both multiplied and division form. Its immediate and most-cited consequence — the sharp bound $v_p(n!) \le n/(p-1)$, the integer form of the standard heuristic $v_p(n!) \approx n/(p-1)$ — was not stated. The base-$p$ digit-sum defect $s_p(n)$ is exactly the shortfall $n - (p-1)v_p(n!)$.

## Proof

Both are one-liners over the existing identity: rewrite by `sub_one_mul_padicValNat_factorial_digitSum` then `Nat.sub_le` for the multiplied form; rewrite by `padicValNat_factorial_eq_div` then `Nat.div_le_div_right (Nat.sub_le ..)` for the division form.

0 axioms, 0 sorries.

## Verification

⚠️ **UNVERIFIED**: docker build infrastructure is down this session (containerd `meta.db` input/output error; host disk healthy, 114Gi free). Each proof is a rewrite by an already-verified lemma in the same file followed by `Nat.sub_le` / `Nat.div_le_div_right` — no fragile API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)