### PR TITLE
research(bezout-identity-oq-01-oq-02-oq-02): SL₂ content-reduction atom + SL₃ content form

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Descent.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02OQ02Descent.lean
@@ -132,6 +132,31 @@ theorem sl2_transitive (a b : ℤ) (h : IsCoprime a b) :
       (M : Matrix (Fin 2) (Fin 2) ℤ) *ᵥ ![a, b] = ![1, 0] :=
   ⟨BezoutIdentityOQ01OQ02.bezoutSL a b h, BezoutIdentityOQ01OQ02.bezoutSL_mulVec a b h⟩
 
+/-- **General `SL₂` content reduction.**  For an *arbitrary* pair `(x, y)` — dropping the coprimality
+hypothesis of `sl2_transitive` — there is an element of `SL₂(ℤ)` carrying `(x, y)` to its content
+`(gcd x y, 0)`.  When `gcd x y = 0` (i.e. `x = y = 0`) the pair is already reduced and the identity
+works; otherwise this is the grandparent's `bezoutMatrix`, whose determinant is `1` precisely because
+`gcd ≠ 0`.
+
+This is the reusable atom of the descent: in the general induction *both* the tail clear
+(`(v₁, …, vₙ) ↦ (gcd, 0, …, 0)`) and the final head clear (`(v₀, g) ↦ (gcd(v₀, g), 0)`) are instances
+of it, whereas the primitive `sl2_transitive` only covers the `gcd = 1` head clear. -/
+theorem gcdReduceSL2 (x y : ℤ) :
+    ∃ N : Matrix.SpecialLinearGroup (Fin 2) ℤ,
+      (N : Matrix (Fin 2) (Fin 2) ℤ) *ᵥ ![x, y] = ![(Int.gcd x y : ℤ), 0] := by
+  by_cases hxy : Int.gcd x y = 0
+  · -- `gcd x y = 0` forces `x = y = 0`; the identity fixes the (already reduced) zero vector.
+    obtain ⟨hx, hy⟩ := Int.gcd_eq_zero_iff.mp hxy
+    refine ⟨1, ?_⟩
+    subst hx; subst hy
+    have hg : (Int.gcd (0 : ℤ) 0 : ℤ) = 0 := by simp
+    rw [hg, Matrix.SpecialLinearGroup.coe_one, Matrix.one_mulVec]
+  · -- `gcd x y ≠ 0`: the Bézout reduction matrix is unimodular (`bezoutMatrix_det`) and clears the
+    -- pair to `(gcd, 0)` (`bezoutMatrix_mulVec`).
+    exact ⟨⟨BezoutIdentityOQ01OQ02.bezoutMatrix x y,
+            BezoutIdentityOQ01OQ02.bezoutMatrix_det x y hxy⟩,
+          BezoutIdentityOQ01OQ02.bezoutMatrix_mulVec x y⟩
+
 /-! ### First new case: `SL₃(ℤ)` acts transitively on primitive triples -/
 
 /-- The concrete `SL₂`-in-`SL₃` head block `diag(N, 1)` acting on the first two coordinates. -/
@@ -199,6 +224,45 @@ theorem sl3_transitive (a b c : ℤ) (h : IsCoprime a (Int.gcd b c : ℤ)) :
       simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_two] using this
     · -- second coordinate: `H 1 0 * a + H 1 1 * g = 0`
       have := congrFun hHw 1
+      simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_two] using this
+    · -- third coordinate: `0 = 0`
+      simp
+
+/-- **`n = 3`, content form.**  Dropping the coprimality hypothesis of `sl3_transitive`: an *arbitrary*
+triple `(a, b, c)` is carried by an element of `SL₃(ℤ)` to `(g, 0, 0)`, where `g = gcd a (gcd b c)` is
+the content (gcd of all three entries).  Both reduction steps are now instances of the single atom
+`gcdReduceSL2`:
+1. `embedOne` of the tail reducer `gcdReduce(b, c)` sends `(a, b, c) ↦ (a, gcd b c, 0)`;
+2. the head block `diag(gcdReduce(a, gcd b c), 1)` sends `(a, gcd b c, 0) ↦ (gcd a (gcd b c), 0, 0)`.
+
+`sl3_transitive` is the special case where the content `g = 1` (then `![g, 0, 0] = ![1, 0, 0]`).  This
+content form — not the primitive form — is what the `n = 4` induction step needs as its `SL₃` tail
+reducer, since the tail of a primitive `4`-vector is generally *not* itself primitive. -/
+theorem sl3_content_reduce (a b c : ℤ) :
+    ∃ M : Matrix.SpecialLinearGroup (Fin 3) ℤ,
+      (M : Matrix (Fin 3) (Fin 3) ℤ) *ᵥ ![a, b, c]
+        = ![(Int.gcd a (Int.gcd b c) : ℤ), 0, 0] := by
+  obtain ⟨T, hT⟩ := gcdReduceSL2 b c
+  obtain ⟨H, hH⟩ := gcdReduceSL2 a (Int.gcd b c : ℤ)
+  have hHdet : (H : Matrix (Fin 2) (Fin 2) ℤ).det = 1 := H.2
+  have hTdet : (T : Matrix (Fin 2) (Fin 2) ℤ).det = 1 := T.2
+  refine ⟨⟨headBlock3 (H : Matrix (Fin 2) (Fin 2) ℤ) * embedOne (T : Matrix (Fin 2) (Fin 2) ℤ),
+      ?_⟩, ?_⟩
+  · rw [Matrix.det_mul, det_headBlock3, det_embedOne, hHdet, hTdet, mul_one]
+  · show (headBlock3 (H : Matrix (Fin 2) (Fin 2) ℤ) * embedOne (T : Matrix (Fin 2) (Fin 2) ℤ))
+        *ᵥ ![a, b, c] = ![(Int.gcd a (Int.gcd b c) : ℤ), 0, 0]
+    -- `![…]` is `Matrix.vecCons`; convert to `Fin.cons` so the block-reduction lemmas fire.
+    have hcons : (![a, b, c] : Fin 3 → ℤ) = Fin.cons a ![b, c] := rfl
+    have hcons2 : (Fin.cons a (![(Int.gcd b c : ℤ), 0] : Fin 2 → ℤ) : Fin 3 → ℤ)
+        = ![a, (Int.gcd b c : ℤ), 0] := rfl
+    rw [← Matrix.mulVec_mulVec, hcons, embedOne_mulVec, hT, hcons2, headBlock3_mulVec]
+    funext i
+    fin_cases i
+    · -- first coordinate: `H 0 0 * a + H 0 1 * (gcd b c) = gcd a (gcd b c)`
+      have := congrFun hH 0
+      simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_two] using this
+    · -- second coordinate: `H 1 0 * a + H 1 1 * (gcd b c) = 0`
+      have := congrFun hH 1
       simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_two] using this
     · -- third coordinate: `0 = 0`
       simp

--- a/research/problems/bezout-identity-oq-01-oq-02-oq-02/knowledge.md
+++ b/research/problems/bezout-identity-oq-01-oq-02-oq-02/knowledge.md
@@ -66,6 +66,29 @@ Insights accumulated during research on this problem.
   elaboration-audited vs confirmed Mathlib signatures but NOT docker-verified; re-verify after an
   image re-pull.
 
+## Session 2026-07-09 (later) — content-reduction atoms in literal dimensions (`BezoutDescent`)
+
+**Outcome**: two reusable atoms added (0 sorry / 0 axiom), staying entirely in *literal* `Fin 2`/`Fin 3`
+dimensions so the `2 + m` vs `m + 2` cast obstruction never arises. Docker infra STILL DOWN
+(containerd `meta.db` write `input/output error` — image build fails before any elaboration); additions
+are elaboration-audited by line-for-line mirroring of the audited `sl3_transitive`, NOT docker-verified.
+
+### Decls
+- `gcdReduceSL2 (x y) : ∃ N : SL₂, N ·ᵥ ![x,y] = ![gcd x y, 0]` — the general (non-coprime) `SL₂`
+  content-reduction atom. `by_cases Int.gcd x y = 0`: zero branch identity (`gcd=0 ⇒ x=y=0`,
+  `Int.gcd_eq_zero_iff`), else grandparent `bezoutMatrix`/`bezoutMatrix_det`/`bezoutMatrix_mulVec`.
+  Extracts the exact inline tail-reducer `T` that `sl3_transitive` built ad hoc, making it reusable.
+- `sl3_content_reduce (a b c) : ∃ M : SL₃, M ·ᵥ ![a,b,c] = ![gcd a (gcd b c), 0, 0]` — CONTENT form of
+  `sl3_transitive` (drops `IsCoprime`). Both steps now instances of `gcdReduceSL2`. Proof mirrors
+  `sl3_transitive` verbatim (`embedOne`/`headBlock3`, `← mulVec_mulVec`, `hcons`/`hcons2` rfl, `funext;
+  fin_cases` + `simpa [mulVec, dotProduct, Fin.sum_univ_two]`). `sl3_transitive` = the `g=1` corollary.
+
+### Why the content form matters
+The `n=4` step (and every step) reduces the *tail* of a primitive vector, but that tail is generally
+NOT primitive — so the tail reducer must be the CONTENT form (`→ (gcd,0,…,0)`), which the primitive
+`slk_transitive` lemmas do not provide. `gcdReduceSL2` + `sl3_content_reduce` are the first two rungs of
+that content ladder. General obstruction below unchanged.
+
 ### Next step (single remaining ingredient for full induction)
 `Fin.cons`/`Fin.append` content bridge: package `(v₀, g, 0,…,0)` as `Fin.append ![v₀,g] 0`, prove
 `Fin.cons v₀ (Fin.cons g 0) = Fin.append ![v₀,g] 0`, thread `Int.gcd` bookkeeping through an


### PR DESCRIPTION
## Summary

Advances the `BezoutDescent` engine (constructive sufficiency for transitivity of SLₙ(ℤ) on primitive vectors) with two reusable **content-reduction** atoms, both in **literal** `Fin 2`/`Fin 3` dimensions so the `2 + m` vs `m + 2` type-cast obstruction that blocks the general induction never arises.

- **`gcdReduceSL2 (x y)`** — the general (non-coprime) SL₂ atom carrying an arbitrary pair `(x, y)` to its content `(gcd x y, 0)`. Zero branch (`gcd = 0 ⇒ x = y = 0`) uses the identity; otherwise the grandparent `bezoutMatrix`. Extracts the ad-hoc inline tail-reducer that `sl3_transitive` previously built by hand, making it reusable.
- **`sl3_content_reduce (a b c)`** — the **content form** of `sl3_transitive` (drops the `IsCoprime` hypothesis), carrying an arbitrary triple to `(gcd a (gcd b c), 0, 0)`. Both steps are now instances of `gcdReduceSL2`. The primitive `sl3_transitive` is the `g = 1` special case.

### Why the content form matters
The general induction step reduces the **tail** of a primitive vector, but that tail is generally **not** itself primitive — so the tail reducer must land on `(gcd, 0, …, 0)`, which the primitive `slk_transitive` lemmas do not provide. These two atoms are the first rungs of that content ladder. The remaining obstruction (the `Fin.cons`/`Fin.append` bridge reconciling `2 + m` and `m + 2` for arbitrary `n`) is documented in the knowledge base and unchanged.

## Verification
0 sorry / 0 axiom. **UNVERIFIED**: docker infra is down (containerd `meta.db` write `input/output error` — image build fails before elaboration). Additions are elaboration-audited by line-for-line mirroring of the already-audited `sl3_transitive` proof and confirmed grandparent signatures; re-verify once docker is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)