### PR TITLE
audit(erdos-920): re-verified CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17402,9 +17402,9 @@
       "result": "clean"
     },
     "erdos-920": {
-      "agentId": "auditor-cycle-20-batch",
+      "agentId": "auditor-agent",
       "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:06Z",
+      "lastAudited": "2026-07-10T06:29:13Z",
       "result": "clean"
     },
     "erdos-921": {


### PR DESCRIPTION
## Integrity Audit: erdos-920 (Chromatic Numbers of K_k-Free Graphs)

**Result**: clean (re-verified; tracker bump only — was stalest at 2026-05-04)

### Verified against `proofs/Proofs/Erdos920Problem.lean`
- **4 axioms** (matches `axiomCount: 4`, all named in `assumptions`): `maxChromaticKFree`, `mattheus_verstraete_2023`, `general_lower_bound`, `RamseyNumber`
- **1 theorem** (`theoremCount: 1`): `erdos_920_summary` — an honest conjunction `⟨general_lower_bound, mattheus_verstraete_2023⟩` of two *disclosed* axioms; not presented as a proof of the conjecture
- **3 defs** (`definitionCount: 3`): `IsKFree`, `chromaticNumber`, `ErdosConjecture` (a `def`, not an axiom)
- **0 sorries**, **0 native_decide** → no `Lean.ofReduceBool`; `axiomCount: 4` counts only the real axioms

### Narrative
- `status: axiomatized` / `badge: axiom` correct for an OPEN Erdős problem
- `proofStrategy` and all `sections` accurately describe axiom/def/theorem placement — no phantom decls, no axiom masking
- `conclusion`/`overview` honestly frame the work as "axiomatizes the landscape", not as an independent proof

No changes to `meta.json` needed. Tracker `lastAudited` bumped 2026-05-04 → 2026-07-10.

---
Discovered during gallery integrity audit.