### PR TITLE
research(erdos-1-oq-02): explicit DFX largest-element lower bound N ≥ (2ⁿ−2)/(3√n)

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -480,6 +480,27 @@ theorem dfx_lower_bound (A : Finset ℕ) (N : ℕ)
     _ ≤ 3 * (Real.sqrt ↑A.card * ↑N) + 2 := by linarith [hsqrtQ]
     _ = 3 * Real.sqrt ↑A.card * ↑N + 2 := by ring
 
+/-- **Explicit largest-element lower bound (DFX / Erdős), `N ≥ (2ⁿ−2)/(3√n)`.**
+The recognisable form the DFX framework targets: a distinct-subset-sums set with
+all elements `≤ N` and `n = |A| ≥ 1` forces
+
+      N ≥ (2ⁿ − 2) / (3·√n),
+
+i.e. `N = Ω(2ⁿ/√n)`.  This is `dfx_lower_bound` (`2ⁿ ≤ 3√n·N + 2`) solved for `N`,
+dividing by `3√n > 0` (valid since `n ≥ 1`).  It states the actual lower bound on
+the largest element that the whole file works toward — previously present only in
+the surrounding prose. -/
+theorem dfx_lower_bound_explicit (A : Finset ℕ) (N : ℕ)
+    (hDSS : hasDistinctSubsetSums A) (hA : ∀ a ∈ A, a ≤ N)
+    (hpos : 0 < A.card) :
+    ((2 : ℝ) ^ A.card - 2) / (3 * Real.sqrt ↑A.card) ≤ (N : ℝ) := by
+  have hle := dfx_lower_bound A N hDSS hA hpos
+  have hcard1 : (1 : ℝ) ≤ (A.card : ℝ) := by exact_mod_cast hpos
+  have hsqrt_pos : 0 < Real.sqrt ↑A.card := Real.sqrt_pos.mpr (by linarith)
+  have h3s : 0 < 3 * Real.sqrt ↑A.card := by positivity
+  rw [div_le_iff₀ h3s]
+  nlinarith [hle]
+
 /-! ## Part III: Comparison with Basic Bound
 
 The basic counting bound (from Erdos1OQ01.lean) gives N ≥ (2ⁿ-1)/n.

--- a/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
@@ -185,3 +185,20 @@ For distinct-subset-sums `A`, `n=|A|≥1`, `Q=Σaᵢ²`: `2ⁿ ≤ 3√Q + 2`.
   already-closed goal ("no goals"); split into two `have`s.
 
 STATUS: COMPLETE. The axiom-discharge goal of this slug is fully achieved; `erdos-1-oq-02` is verified.
+
+## Session 2026-07-09 (researcher-3) — Explicit N ≥ (2ⁿ−2)/(3√n) corollary (VERIFIED)
+
+The "incomplete" goal here — discharging `anticoncentration_bound` — was already COMPLETED
+(researcher-2, 2026-06-30): `Erdos1OQ02.lean` is 0-axiom/0-sorry. This session adds the one
+recognisable named corollary that was still only in prose:
+
+**`dfx_lower_bound_explicit`**: for a distinct-subset-sums set `A`, all elements `≤ N`,
+`n=|A|≥1`, the largest element satisfies `N ≥ (2ⁿ−2)/(3·√n)` — the DFX `N = Ω(2ⁿ/√n)`
+lower bound in its canonical "solved for N" form. Proof: take `dfx_lower_bound`
+(`2ⁿ ≤ 3√n·N + 2`), `rw [div_le_iff₀ h3s]` (with `3√n > 0` from `n≥1`), close by `nlinarith`.
+
+VERIFIED green via direct lean-elab (docker containerd blob I/O down): built the
+`Proofs.Erdos1Problem` dependency olean into /tmp with `lean -R . -o` then elaborated the
+target with that dir prepended to LEAN_PATH — exit 0, no errors,
+`#print axioms dfx_lower_bound_explicit` = `[propext, Classical.choice, Quot.sound]`.
+Gallery meta erdos-1-oq-02: lineCount 559→580, theoremCount 16→17. File now SATURATED.

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 559,
+    "lineCount": 580,
     "assumptions": "0 axioms. The former anticoncentration_bound axiom (2^n ≤ 3√Q + 2 for distinct-subset-sums sets) is now PROVED in-file (theorem anticoncentration_bound) by an elementary, probability-free discharge: the second-moment identity over the powerset, a parity-aware central-interval count, and a discrete Chebyshev tail. dfx_lower_bound and pow2_dss proved; sum_sq_cauchy_schwarz proved. Fully machine-checked, 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -55,7 +55,7 @@
       "dfx_improves_counting: DFX bound is asymptotically better than counting bound (n < n² for n ≥ 2)",
       "Concrete cases: f(1)=1 via Finset.subset_singleton_iff, f(2)=2 via simp"
     ],
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 0
   },
   "overview": {
@@ -211,9 +211,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 559,
+    "lineCount": 580,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The `anticoncentration_bound` axiom that the `erdos-1-oq-02-incomplete-01` slug tracked was already discharged (2026-06-30); `Erdos1OQ02.lean` is **0-axiom / 0-sorry**. This PR adds the one recognisable named corollary that was still only stated in prose:

**`dfx_lower_bound_explicit`** — for a distinct-subset-sums set `A` with all elements `≤ N` and `n = |A| ≥ 1`:

$$N \ge \frac{2^n - 2}{3\sqrt{n}},$$

the Dubroff–Fox–Xu / Erdős largest-element lower bound `N = Ω(2ⁿ/√n)` in its canonical "solved for `N`" form. The file already proves the equivalent `dfx_lower_bound` (`2ⁿ ≤ 3√n·N + 2`); this states the actual lower bound on the largest element the whole file works toward.

## Proof

One step: `rw [div_le_iff₀ h3s]` (with `3√n > 0` from `n ≥ 1`) on `dfx_lower_bound`, closed by `nlinarith`.

## Verification

Docker containerd content-store is throwing blob I/O errors (new `docker run` blocked). Verified via direct `lean` elaboration against pinned Mathlib v4.26.0: built the `Proofs.Erdos1Problem` dependency olean into a temp dir (`lean -R . -o`), then elaborated the target with that dir on `LEAN_PATH`.

- Exit 0, **no errors**.
- `#print axioms dfx_lower_bound_explicit` = `[propext, Classical.choice, Quot.sound]` — axiom-free.

Gallery meta `erdos-1-oq-02` synced: lineCount 559→580, theoremCount 16→17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)