### PR TITLE
audit(erdos-91): disclose AreSimilar True-stub / vacuous similarity scaffold

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17330,10 +17330,10 @@
       "result": "clean"
     },
     "erdos-91": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:53Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T06:32:33Z",
+      "result": "issues-fixed"
     },
     "erdos-910": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-91/meta.json
+++ b/src/data/proofs/erdos-91/meta.json
@@ -29,7 +29,7 @@
     ],
     "axiomCount": 5,
     "lineCount": 276,
-    "assumptions": "5 axioms: n3_unique, n4_two_optima, kovacs_2024_n5_unique, and 2 more. See Lean source for complete statements.",
+    "assumptions": "5 axioms: n3_unique, n4_two_optima, kovacs_2024_n5_unique, n6_to_9_nonunique, guth_katz_bound. 0 sorries. Scaffolding note: the similarity relation AreSimilar stubs its geometric transform with a True placeholder ('Simplified; actual transform is complex'), so AreSimilar holds for any two equal-cardinality nonempty sets and AreNonSimilar is correspondingly vacuous. The small-case axioms (n4_two_optima, n6_to_9_nonunique) are therefore stated over these simplified predicates rather than a faithful encoding of Euclidean similarity; minDistinctDistances is likewise a simplified placeholder definition. This entry is an axiomatized scaffold for an OPEN problem, not a verified formalization of the geometry.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
     "definitionCount": 10
@@ -79,7 +79,7 @@
       "title": "Part III: Similarity of Point Sets",
       "startLine": 88,
       "endLine": 110,
-      "summary": "AreSimilar and AreNonSimilar definitions"
+      "summary": "AreSimilar and AreNonSimilar definitions. Note: AreSimilar stubs the geometric transform with a True placeholder ('Simplified; actual transform is complex'), so these predicates do not faithfully capture Euclidean similarity — the downstream small-case axioms are scaffolding stated over these simplified relations."
     },
     {
       "id": "small-cases",


### PR DESCRIPTION
## Integrity Audit: erdos-91 (Non-Uniqueness of Minimal Distance Sets)

**Result**: issues-fixed (prose disclosure only; counts already exact, badge/status correct)

### Problem
The similarity relation is stubbed, but the gap was not disclosed in `meta.json`:

```lean
def AreSimilar (A B : Finset Point) : Prop :=
  A.card = B.card ∧
  ∃ (c θ tx ty : ℝ) (refl : Bool), c > 0 ∧
    ∀ p ∈ A, ∃ q ∈ B,
      True  -- Simplified; actual transform is complex   (line 103)
```

Because the inner predicate is `True`, `AreSimilar A B` holds for **any** two equal-cardinality nonempty sets, and `AreNonSimilar := card= ∧ ¬AreSimilar` is correspondingly **vacuous (always false)**. The small-case axioms `n4_two_optima` and `n6_to_9_nonunique` assert `∃ A B, … ∧ AreNonSimilar A B`, so they are inconsistent scaffolding over the simplified predicate rather than faithful encodings of the Euclidean-similarity results they are labelled with. (`minDistinctDistances` is likewise a simplified placeholder def.)

This is the same class of issue as hilbert-3 / hilbert-4: an axiomatized scaffold that is *correctly badged* but *under-discloses* the vacuity of its supporting definitions.

### Reality (verified against `proofs/Proofs/Erdos91Problem.lean`)
- Counts all exact: **5 axioms** (`n3_unique`, `n4_two_optima`, `kovacs_2024_n5_unique`, `n6_to_9_nonunique`, `guth_katz_bound`), **2 theorems** (`known_cases`, `erdos_91_summary` — both just combine disclosed axioms), **10 defs**, **0 sorries**, **0 native_decide**.
- `status: axiomatized` / `badge: axiom` are correct for this OPEN problem — **unchanged**.

### Fix
- `meta.assumptions`: named all 5 axioms (was "and 2 more") and added a scaffolding note disclosing the `AreSimilar` `True` placeholder, the resulting vacuity of `AreNonSimilar`, and that the small-case axioms are stated over simplified predicates.
- `sections[similarity].summary`: added the same placeholder disclosure.

No count, badge, or status changes. Tracker bumped for erdos-91 (was stalest at 2026-05-04).

---
Discovered during gallery integrity audit.