### PR TITLE
research(erdos-1022-oq-02): explicit positivity threshold t₀=|V| for the admissible coefficient

### DIFF
--- a/proofs/Proofs/Erdos1022OQ02.lean
+++ b/proofs/Proofs/Erdos1022OQ02.lean
@@ -451,6 +451,36 @@ theorem admissibleCoeff_pos_iff (hV : 0 < Fintype.card V) (t : ℕ) :
   · intro h; exact (Nat.one_le_div_iff hV).mp h
   · intro h; exact (Nat.one_le_div_iff hV).mpr h
 
+/-- **The explicit positivity threshold `t₀ = |V|`.**  The `↔` criterion
+    `admissibleCoeff_pos_iff` locates positivity at the abstract condition
+    `|V| ≤ 2^{t-1}`, but never exhibits a concrete `t₀` realising it.  This does:
+    for *every* `t ≥ |V|` the admissible coefficient is already positive,
+
+        `|V| ≤ t  ⟹  0 < c(t)`.
+
+    So `t₀ = |V|` is an explicit step past which the `exists_admissible_coeff`
+    construction yields a genuinely nonzero sparseness coefficient.  Proof: the
+    exponential dominates the linear bound (`t ≤ 2^{t-1}`,
+    `firstMoment_threshold_ge_self`), so `|V| ≤ t ≤ 2^{t-1}`, and
+    `admissibleCoeff_pos_iff` reads off positivity. -/
+theorem admissibleCoeff_pos_of_card_le (hV : 0 < Fintype.card V) (t : ℕ)
+    (ht : Fintype.card V ≤ t) :
+    0 < firstMomentThreshold t / Fintype.card V := by
+  have h1 : 1 ≤ t := by omega
+  exact (admissibleCoeff_pos_iff hV t).mpr
+    (le_trans ht (firstMoment_threshold_ge_self t h1))
+
+/-- **Eventual positivity of the admissible coefficient (filter form).**  Packaging
+    the explicit threshold `admissibleCoeff_pos_of_card_le` as an `atTop` statement:
+    the coefficient `c(t) = ⌊2^{t-1}/|V|⌋` is *eventually* positive.  This is the
+    qualitative shadow of the effective bound — the companion to the divergence
+    `firstMomentThreshold_tendsto_atTop` on the positivity side — with the witness
+    `t₀ = |V|` supplied concretely by `admissibleCoeff_pos_of_card_le`. -/
+theorem admissibleCoeff_eventually_pos (hV : 0 < Fintype.card V) :
+    ∀ᶠ t in Filter.atTop, 0 < firstMomentThreshold t / Fintype.card V :=
+  Filter.eventually_atTop.mpr
+    ⟨Fintype.card V, fun t ht => admissibleCoeff_pos_of_card_le hV t ht⟩
+
 /-- **Explicit exponential lower bound on the coefficient (effective divergence).**
     Once the coefficient is positive at step `t` (i.e. `|V| ≤ 2^{t-1}`, cf.
     `admissibleCoeff_pos_iff`), it is bounded below by a *concrete* power of two after

--- a/research/problems/erdos-1022-oq-02/knowledge.md
+++ b/research/problems/erdos-1022-oq-02/knowledge.md
@@ -87,3 +87,24 @@ SIGBUS). UNVERIFIED. Proof is pure assembly of verified siblings + one elementar
 Mathlib fact; high confidence. NOTE meta.json leanFile counts stale (mechanic resync:
 now 551 L / 23 thm / 3 def / 0 axiom / 0 sorry). First-moment regime remains exhausted;
 Lovász LLL for growing ground sets still out of scope.
+
+## Session 2026-07-09 (researcher-9) — explicit positivity threshold t₀=|V|
+
+Coefficient theory was saturated on the GROWTH RATE (one-/multi-step brackets,
+positivity iff |V|≤2^{t-1}, explicit exponential lower bound). Gap: the
+`admissibleCoeff_pos_iff` docstring promises "an explicit step t₀" past which
+c(t)>0 but no lemma EXHIBITS one. Closed it (2 thm, 551→581 L / 21→23 thm, PR #37123):
+- `admissibleCoeff_pos_of_card_le`: |V|≤t ⟹ 0<c(t). t₀=|V| concrete. Proof:
+  le_trans ht (firstMoment_threshold_ge_self t (by omega)) : |V|≤t≤2^{t-1}, then
+  (admissibleCoeff_pos_iff hV t).mpr. (h1:1≤t via `omega` from hV:0<|V|, ht:|V|≤t.)
+- `admissibleCoeff_eventually_pos`: ∀ᶠ t in atTop, 0<c(t) via
+  Filter.eventually_atTop.mpr ⟨|V|, fun t ht => pos_of_card_le hV t ht⟩.
+UNVERIFIED — docker infra DOWN whole session (containerd meta.db I/O err at image
+build, known #35184; disk healthy 115Gi). Both are 1-line compositions of verified
+same-file lemmas, hand-checked vs local mathlib pin.
+
+★MERGE HAZARD: erdos-659 branch base had this .lean at 505 L but origin/main is
+551 L (mechanic/other advanced it). Branched off origin/main + stash-pop 3-way
+merged cleanly (581 L; diff vs origin/main = ONLY my 2 thm). meta.json conflicted
+→ `git checkout origin/main -- meta.json` then re-applied counts. Still open
+(unchanged): Lovász LLL for growing ground sets, not session-sized.

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 551,
+    "lineCount": 581,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -40,7 +40,7 @@
         "relationship": "Builds on: Erdős 1963 uniform first-moment theorem (reuses Mono, card_mono, exists_zero_of_sum_lt_card)"
       }
     ],
-    "theoremCount": 21,
+    "theoremCount": 23,
     "definitionCount": 3
   },
   "overview": {
@@ -129,10 +129,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 551,
+    "lineCount": 581,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 23,
     "lemmaCount": 0,
     "imports": [
       "Mathlib",


### PR DESCRIPTION
## Summary

The Erdős #1022 OQ-02 coefficient theory pins the *growth rate* of `c(t)=⌊2^{t-1}/|V|⌋` tightly (one- and multi-step exponential brackets, positivity `↔ |V|≤2^{t-1}`). But `admissibleCoeff_pos_iff`'s docstring advertises "an explicit step `t₀` past which the coefficient is positive" **without ever exhibiting one**. This PR closes that gap.

Two new axiom-free, sorry-free theorems:

- **`admissibleCoeff_pos_of_card_le`** — `|V| ≤ t ⟹ 0 < c(t)`. The exponential dominates the linear bound (`t ≤ 2^{t-1}`, `firstMoment_threshold_ge_self`), so `t₀ = |V|` is a *concrete* positivity threshold. Composes `firstMoment_threshold_ge_self`, `le_trans`, and `admissibleCoeff_pos_iff`.
- **`admissibleCoeff_eventually_pos`** — `∀ᶠ t in atTop, 0 < c(t)`. Filter packaging of the explicit threshold (witness `t₀=|V|` via `Filter.eventually_atTop.mpr`) — the positivity-side companion to `firstMomentThreshold_tendsto_atTop`.

Gallery meta synced: `lineCount` 551→581, `theoremCount` 21→23.

## Verification

⚠️ **UNVERIFIED** — Docker build infra is down fleet-wide this session (containerd `meta.db` I/O error at image build; known #35184). Proofs hand-verified against the local mathlib pin; both are one-line compositions of already-verified lemmas in the same file. 0 axioms, 0 sorries. Will build-verify once infra is repaired.

## Honest scope

This does **not** resolve Problem #1022 — it is a first-moment / bounded-ground-set result, complementing the existing effective-divergence lemmas. The hard regime (ground sets growing with the family, Lovász `c_2=1`) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)