### PR TITLE
research(erdos-744): max-cut ≤ edgeCount and edgeless zero-case characterization

### DIFF
--- a/proofs/Proofs/Erdos744Problem.lean
+++ b/proofs/Proofs/Erdos744Problem.lean
@@ -340,6 +340,42 @@ theorem maxCut_eq_edgeCount_iff {V : Type*} [Fintype V] [LinearOrder V]
   have h := bipartitionNumber_add_maxCut G
   omega
 
+/-- **The max-cut never exceeds the total edge count.** A cut can separate at most
+every edge. Immediate dual of `bipartitionNumber_le_edgeCount` via the
+complementarity `bipartitionNumber G + maxCut G = edgeCount G`. -/
+theorem maxCut_le_edgeCount {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    maxCut G ≤ edgeCount G := by
+  have h := bipartitionNumber_add_maxCut G
+  omega
+
+/-- **The max-cut vanishes iff `G` is edgeless.** `maxCut G = 0 ↔ edgeCount G = 0`:
+the zero case of the max-cut, dual to `maxCut_eq_edgeCount_iff` (which characterizes
+the saturated case). If `G` has any edge `u < v`, the coloring `w ↦ (w = u)` separates
+it, so the cut is already positive; conversely with no edges there is nothing to cut. -/
+theorem maxCut_eq_zero_iff {V : Type*} [Fintype V] [LinearOrder V]
+    (G : SimpleGraph' V) [DecidableRel G.Adj] :
+    maxCut G = 0 ↔ edgeCount G = 0 := by
+  constructor
+  · intro h
+    by_contra hne
+    have hpos : 0 < edgeCount G := Nat.pos_of_ne_zero hne
+    unfold edgeCount at hpos
+    rw [Finset.card_pos] at hpos
+    obtain ⟨p, hp⟩ := hpos
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    obtain ⟨hlt, hadj⟩ := hp
+    -- The coloring that isolates `p.1` cuts the edge `p`.
+    set c : V → Bool := fun w => decide (w = p.1) with hc
+    have hne_uv : p.2 ≠ p.1 := ne_of_gt hlt
+    have hle : bichromaticEdges G c ≤ maxCut G := Finset.le_sup' _ (Finset.mem_univ c)
+    rw [h, Nat.le_zero, bichromaticEdges, Finset.card_eq_zero,
+      Finset.filter_eq_empty_iff] at hle
+    exact hle (Finset.mem_univ p) ⟨hlt, hadj, by simp only [hc]; simp [hne_uv]⟩
+  · intro h
+    have hle := maxCut_le_edgeCount G
+    omega
+
 /--
 **The f_k(n) Function**
 

--- a/research/problems/erdos-744-incomplete-01/knowledge.md
+++ b/research/problems/erdos-744-incomplete-01/knowledge.md
@@ -94,3 +94,27 @@ warnings in the untouched `f_*` theorems. `#print axioms` clean (above).
 
 **Counts.** Erdos744Problem.lean → 578 lines, 20 thm, 15 def, 1 axiom (unchanged), 0 sorry;
 src/data/proofs/erdos-744/meta.json synced.
+
+## Session 2026-07-09 (researcher-3) — max-cut ≤ edgeCount + edgeless zero-case (VERIFIED)
+
+The `bipartitionNumber`/`maxCut` engine already had complementarity
+(`bipartitionNumber_add_maxCut`), `bipartitionNumber_le_edgeCount`, and the saturated-case
+`maxCut_eq_edgeCount_iff`. Added the two missing companions (both axiom-free):
+
+- `maxCut_le_edgeCount`: the dual of `bipartitionNumber_le_edgeCount` — one-line `omega`
+  off the complementarity identity.
+- `maxCut_eq_zero_iff`: `maxCut G = 0 ↔ edgeCount G = 0` (max-cut vanishes iff `G` edgeless),
+  the zero-case dual of `maxCut_eq_edgeCount_iff`. Forward direction is a construction: if
+  `edgeCount > 0` pick an edge `p` (`Finset.card_pos`), the isolating coloring
+  `c = fun w => decide (w = p.1)` cuts it (`c p.1 = true ≠ false = c p.2` since `p.2 ≠ p.1`
+  from `p.1 < p.2`), so `bichromaticEdges G c ≥ 1 ≤ maxCut` contradicts `maxCut = 0`; reverse
+  is `omega` off `maxCut_le_edgeCount`. Membership discharge mirrors `monochromaticEdges_eq_zero_iff`
+  (`filter_eq_empty_iff` + `⟨hlt, hadj, by simp only [hc]; simp [hne_uv]⟩`).
+
+The tautological `rodl_tuza_theorem` axiom is untouched (converting it overclaims — prior
+integrity finding); axiomCount unchanged, status stays `axiomatized`.
+
+VERIFIED green via direct lean-elab vs pinned Mathlib v4.26.0 (docker containerd blob I/O down):
+exit 0, no errors; `#print axioms` on both = `[propext, Classical.choice, Quot.sound]`.
+Gallery meta erdos-744: lineCount 578→614, leanFile.theoremCount 20→22 (top-level curated
+theoremCount 14 left as-is — different convention).

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -59,7 +59,7 @@
       "erdos_744_statement theorem: combined main result"
     ],
     "axiomCount": 1,
-    "lineCount": 578,
+    "lineCount": 614,
     "assumptions": "1 axiom: rodl_tuza_theorem (the deep Rödl–Tuza 1985 result, stated as an assumption since a full formalization of the extremal argument is out of scope). The chromatic number is now defined intrinsically (least number of colors admitting a proper coloring) rather than axiomatized, and is proved well-defined by chromaticNumber_le_card. 0 sorries.",
     "theoremCount": 14,
     "definitionCount": 14
@@ -185,9 +185,9 @@
       "Finset"
     ],
     "namespace": "Erdos744",
-    "lineCount": 578,
+    "lineCount": 614,
     "axiomCount": 1,
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 15,
     "path": "Proofs/Erdos744Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Completes the `maxCut` companions on the intrinsic `bipartitionNumber` engine of `Erdos744Problem.lean`. The engine already had the complementarity identity `bipartitionNumber G + maxCut G = edgeCount G`, `bipartitionNumber_le_edgeCount`, and the saturated-case `maxCut_eq_edgeCount_iff`. This adds the two natural missing companions:

- **`maxCut_le_edgeCount`** — a cut separates at most every edge; the dual of `bipartitionNumber_le_edgeCount`, one line off the complementarity identity.
- **`maxCut_eq_zero_iff`** — `maxCut G = 0 ↔ edgeCount G = 0` (the max-cut vanishes iff `G` is edgeless), the **zero-case dual** of `maxCut_eq_edgeCount_iff`. The forward direction is a genuine construction: given any edge `p` (`u < v`), the isolating coloring `w ↦ (w = u)` separates it, so `bichromaticEdges ≥ 1 ≤ maxCut` contradicts `maxCut = 0`; the reverse is `omega` off `maxCut_le_edgeCount`.

Both are orthogonal, axiom-free structural graph theory; the tautological `rodl_tuza_theorem` axiom is untouched (converting it would overclaim — prior integrity finding), so `axiomCount` and `status: axiomatized` are unchanged.

## Verification

Docker containerd content-store blob I/O errors (new `docker run` blocked); verified via direct `lean` elaboration against pinned Mathlib v4.26.0:

- Exit 0, no errors.
- `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]`.

Gallery meta `erdos-744` synced: lineCount 578→614, `leanFile.theoremCount` 20→22 (the separate top-level curated `theoremCount` of 14 uses a different convention and is left unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)