### PR TITLE
Audit erdos-928: correct phantom dickman_theorem overclaim

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17450,10 +17450,10 @@
       "result": "clean"
     },
     "erdos-928": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:06Z",
-      "result": "clean"
+      "agentId": "auditor-manual",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T06:36:59Z",
+      "result": "issues-fixed"
     },
     "erdos-929": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-928/meta.json
+++ b/src/data/proofs/erdos-928/meta.json
@@ -115,7 +115,7 @@
     {
       "id": "dickman-theorem",
       "title": "Dickman's Theorem (1930)",
-      "summary": "psi counting function, dickman_theorem (proved as theorem — not a Lean axiom)",
+      "summary": "psi counting function; Dickman's theorem stated informally (docstring only, not a Lean declaration)",
       "startLine": 114,
       "endLine": 134,
       "mathContext": "$\\Psi(x, x^\\alpha) / x \\to \\rho(1/\\alpha)$ as $x \\to \\infty$ (Dickman, 1930). The density of $\\alpha$-smooth numbers is $\\rho(1/\\alpha)$."

--- a/src/data/proofs/erdos-928/meta.json
+++ b/src/data/proofs/erdos-928/meta.json
@@ -53,7 +53,7 @@
       "isFriable predicate: P(n) ≤ y condition",
       "dickman_function axiom: the Dickman-de Bruijn function ρ",
       "psi counting function: Ψ(x, y) = #{n ≤ x : P(n) ≤ y}",
-      "dickman_theorem: Ψ(x, x^α)/x → ρ(1/α) (proved as theorem, not a Lean axiom)",
+      "Dickman's theorem Ψ(x, x^α)/x → ρ(1/α) stated informally (docstring only; not formalized as a Lean declaration)",
       "consecutiveSmooth definition: both n and n+1 smooth",
       "densityExists predicate: natural density existence",
       "erdos928Question: formal problem statement",
@@ -63,7 +63,7 @@
       "wang_conditional axiom: conditional on Elliott-Halberstam"
     ],
     "axiomCount": 4,
-    "assumptions": "4 axiom declarations: dickman_function (Dickman rho function definition), infinitely_many_exist (Schinzel/Meza: infinitely many consecutive smooth pairs exist), teravainen_log_density (Teravaeinen 2018: logarithmic density equals rho(1/alpha)*rho(1/beta)), wang_conditional (Wang 2021: natural density under Elliott-Halberstam conjecture). Former axioms lpf_divides, lpf_prime, lpf_of_prime, dickman_at_one, dickman_at_two, dickman_positive, dickman_decreasing, dickman_theorem, elliott_halberstam_conjecture, schinzel_product now proved as theorems or definitions.",
+    "assumptions": "4 axiom declarations: dickman_function (Dickman rho function definition), infinitely_many_exist (Schinzel/Meza: infinitely many consecutive smooth pairs exist), teravainen_log_density (Teravaeinen 2018: logarithmic density equals rho(1/alpha)*rho(1/beta)), wang_conditional (Wang 2021: natural density under Elliott-Halberstam conjecture). Earlier scaffolding declarations (lpf_divides, lpf_prime, lpf_of_prime, dickman_at_one, dickman_at_two, dickman_positive, dickman_decreasing, dickman_theorem, elliott_halberstam_conjecture, schinzel_product) were removed; they now survive only as descriptive docstrings and are not present as axioms, theorems, or definitions.",
     "lineCount": 259,
     "theoremCount": 2,
     "definitionCount": 9


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-928

**Proof**: erdos-928 (Density of Consecutive Smooth Numbers, OPEN Erdős problem)
**Result**: issues-fixed (prose-only; counts already correct)

## Problem

Two narrative overclaims in `meta.json` naming declarations that do not exist:

1. **originalContributions** listed:
   > "dickman_theorem: Ψ(x, x^α)/x → ρ(1/α) (proved as theorem, not a Lean axiom)"

   `dickman_theorem` does **not** exist as any declaration in `Erdos928Problem.lean`. Dickman's theorem — a deep analytic number-theory result — is only *stated in a docstring* (lines 112–119). Claiming it is "proved as theorem" is a phantom-theorem overclaim on a famous named result.

2. **assumptions** claimed:
   > "Former axioms lpf_divides, lpf_prime, lpf_of_prime, dickman_at_one, dickman_at_two, dickman_positive, dickman_decreasing, dickman_theorem, elliott_halberstam_conjecture, schinzel_product now proved as theorems or definitions."

   None of these 10 names exist as theorems or definitions (grep: 0 hits each). They were simply removed; only descriptive docstrings remain.

## Evidence

```
$ grep -c "<name>" proofs/Proofs/Erdos928Problem.lean
dickman_theorem: 0   lpf_divides: 0   lpf_prime: 0   lpf_of_prime: 0
dickman_at_one: 0    dickman_at_two: 0   dickman_positive: 0
dickman_decreasing: 0   elliott_halberstam_conjecture: 0   schinzel_product: 0
```

**Counts verified correct** (no change needed): 4 axioms (dickman_function, infinitely_many_exist, teravainen_log_density, wang_conditional), 0 sorries, 2 theorems (erdos_928_summary, erdos_928), 9 defs, 259 lines. Automated detector passes; this was caught by manual prose review.

## Fix

- Reword the `dickman_theorem` bullet to state it is only informally stated (docstring), not formalized.
- Reword `assumptions` to say the earlier scaffolding declarations were removed and survive only as docstrings — not proved as theorems/definitions.
- Status/badge (`axiomatized`/`axiom`) unchanged — correct for an open problem.
- Tracker bumped.

---
Discovered during gallery integrity audit.