### PR TITLE
research(pythagorean-oq-01): area-two-ways identity triArea_hypotenuse_eq_legs

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ01.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ01.lean
@@ -296,6 +296,22 @@ theorem altitude_length (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
     rw [hgm, hAH, hHB]; field_simp; ring
   rw [← Real.sqrt_sq hlhs, hsq, Real.sqrt_sq hrhs]
 
+include hAB in
+/-- **Area computed two ways agree** — the hypotenuse–leg area identity underpinning
+Einstein's dissection. Computing the triangle's area with the hypotenuse as base and the
+altitude `|CH|` as height, `½·|AB|·|CH|`, yields the same value as computing it from the two
+perpendicular legs, `½·|CA|·|CB|`. This is exactly `altitude_length`
+(`|CH| = |CA|·|CB|/|AB|`) cleared of its denominator, and it ties Layer 1's area functional
+`triArea` back to the Layer 3 altitude decomposition — the "same area, two bases" fact that
+makes the area–square law (`triArea_scale`) applicable to Einstein's three similar pieces. -/
+theorem triArea_hypotenuse_eq_legs (hperp : ⟪A - C, B - C⟫ = (0 : ℝ)) :
+    triArea ‖A - B‖ ‖C - altitudeFoot A B C‖ = triArea ‖A - C‖ ‖B - C‖ := by
+  have hne := hnorm_ne A B hAB
+  unfold triArea
+  rw [altitude_length A B C hAB hperp]
+  field_simp
+  ring
+
 end Geometric
 
 -- ============================================================

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -74,9 +74,9 @@
   },
   "leanFile": {
     "namespace": "PythagoreanEinstein",
-    "lineCount": 318,
+    "lineCount": 334,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 2,
     "path": "Proofs/PythagoreanTheoremOQ01.lean",
     "imports": [


### PR DESCRIPTION
## Summary

Adds one clean, well-motivated corollary to the verified Einstein similar-triangles proof of Pythagoras (`PythagoreanTheoremOQ01.lean`): **`triArea_hypotenuse_eq_legs`**, the hypotenuse–leg area identity

```
triArea ‖A - B‖ ‖C - altitudeFoot A B C‖ = triArea ‖A - C‖ ‖B - C‖
```

i.e. computing the triangle's area on the hypotenuse with the altitude `|CH|` as height (`½·|AB|·|CH|`) gives the same value as computing it from the two perpendicular legs (`½·|CA|·|CB|`).

## Why this fills a real gap

This identity is stated **in prose** in the existing `altitude_length` docstring —

> *Equivalently, `|AB|·|CH| = |CA|·|CB|`, the statement that the triangle's area computed on the hypotenuse (`½|AB|·|CH|`) equals its area computed on the legs (`½|CA|·|CB|`).*

— but was never formalized. It is the missing bridge between **Layer 1** (the area functional `triArea` / area–square law `triArea_scale`) and **Layer 3** (the altitude decomposition), i.e. the *same-area, two-bases* fact that lets Einstein apply the area–square law to his three similar pieces.

## Proof

Direct: `unfold triArea; rw [altitude_length …]; field_simp; ring` — the same verified idiom already used by `altitude_length` and `geometric_mean_A` in this file. No new axioms, 0 sorries.

## Verification status

⚠️ **UNVERIFIED** — the Docker build infrastructure is currently down (containerd `meta.db` input/output error, operator-level; host disk healthy at 115Gi). The proof is a one-line algebraic consequence of the already-verified `altitude_length`, mirroring existing verified proofs in the same file, so confidence is high. Should be re-run through `docker-build.sh Proofs.PythagoreanTheoremOQ01` once infra recovers.

- leanFile counts synced: lineCount 318→334, theoremCount 14→15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)