### PR TITLE
Enrich The Minimum Collision Number is Exactly 2: structural keyInsight

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-02/meta.json
@@ -79,6 +79,7 @@
    "The 'actual minimum' question is exactly an IsLeast statement: attainability + lower bound",
    "IsLeast.csInf_eq converts the least element into the infimum sInf collisionSpectrum = 2",
    "0 and 1 are excluded as direct omega consequences of the ≥ 2 lower bound",
+   "A cube collides precisely when the dissection holds a distinct cube of the same size (collidingCubes filters for ∃ c' ≠ c, c.size = c'.size), so colliding cubes partition into equal-size classes each of cardinality ≥ 2 — this equivalence-class structure is the mechanism forcing the minimum to be 2 and making a lone colliding cube impossible",
    "Three equal-size cubes side-by-side give collision count 3, so the spectrum is not the singleton {2}",
    "Achievability is axiom-free; only the inherited lower bound carries the base geometric axiom"
   ],


### PR DESCRIPTION
Enrichment pass for `dissection-of-cubes-oq-01-oq-02` (quality 95, pass 0).

This entry was already comprehensive (7 rich annotations, full historical context, conclusion with implications + 3 open questions, sections covering the whole file, 3 references) and comfortably under all size caps (14.7 KB). Rather than inflate it, this pass adds a single sharp keyInsight capturing the **structural mechanism** behind the ≥2 collision lower bound:

> A cube collides precisely when the dissection holds a distinct cube of the same size (`collidingCubes` filters for `∃ c' ≠ c, c.size = c'.size`), so colliding cubes partition into equal-size classes each of cardinality ≥ 2 — this equivalence-class structure is the mechanism forcing the minimum to be 2 and making a lone colliding cube impossible.

The metadata previously stated only the surface fact ("collisions come in pairs"); this makes the underlying equivalence-class reason explicit, grounded directly in the Lean's `mem_collidingCubes_tri_iff`. No claims altered; axiom accounting untouched.

keyInsights: 5 → 6 (cap 12). meta.json: 14.3 → 14.7 KB (cap 60).