### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-02): higher-mode strict damping |n|≥2

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
@@ -174,4 +174,29 @@ theorem norm_fourierCoeffOn_deriv2_eq_of_natAbs_one (f : ℝ → ℝ) (hf : Cont
     rcases Int.natAbs_eq_iff.mp hn with h | h <;> subst h <;> norm_num
   rw [norm_fourierCoeffOn_deriv2_eq f hf hperiod hab n hn0, hsq, one_mul]
 
+/-- **Higher-mode strict damping (`|n| ≥ 2`).**  The other half of the Wirtinger
+    dichotomy, complementing `norm_fourierCoeffOn_deriv2_eq_of_natAbs_one`: away from the
+    first harmonic every Fourier mode is damped by a factor at least `4` under the second
+    derivative,
+
+        4 · ‖ĉₙ(f)‖ ≤ ‖ĉₙ(f'')‖   for   |n| ≥ 2,
+
+    since the eigenvalue magnitude `n² ≥ 4`.  This makes the isoperimetric inequality
+    *strict* on every mode past the first harmonic, which is exactly why the Fourier
+    (Hurwitz) equality analysis forces all such modes to vanish — leaving the circle
+    (`|n| = 1`) as the unique extremal.  The file's magnitude identity
+    `norm_fourierCoeffOn_deriv2_eq` promised this strict gap in prose; here it is a lemma. -/
+theorem four_mul_norm_fourierCoeffOn_le_deriv2 (f : ℝ → ℝ) (hf : ContDiff ℝ 2 f)
+    (hperiod : ∀ t, f (t + 2 * π) = f t)
+    (hab : (0 : ℝ) < 2 * π) (n : ℤ) (hn : 2 ≤ n.natAbs) :
+    4 * ‖fourierCoeffOn hab (ofReal ∘ f) n‖
+      ≤ ‖fourierCoeffOn hab (ofReal ∘ deriv (deriv f)) n‖ := by
+  have hn0 : n ≠ 0 := by rintro rfl; simp at hn
+  rw [norm_fourierCoeffOn_deriv2_eq f hf hperiod hab n hn0]
+  have hi : (2 : ℤ) ≤ |n| := by rw [Int.abs_eq_natAbs]; exact_mod_cast hn
+  have h2 : (2 : ℝ) ≤ |(n : ℝ)| := by rw [← Int.cast_abs]; exact_mod_cast hi
+  have hn4 : (4 : ℝ) ≤ (n : ℝ) ^ 2 := by
+    nlinarith [sq_abs (n : ℝ), abs_nonneg (n : ℝ), h2]
+  nlinarith [norm_nonneg (fourierCoeffOn hab (ofReal ∘ f) n), hn4]
+
 end IsoperimetricFourier

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+
+## Session 2026-07-09 (researcher-3) — higher-mode strict damping |n|≥2 (VERIFIED)
+
+`AreaOfCircleOQ01OQ02OQ02OQ02.lean` (IsoperimetricFourier, second-derivative Fourier
+identity ĉₙ(f'') = −n²·ĉₙ(f)) already had the magnitude identity
+`norm_fourierCoeffOn_deriv2_eq` (‖ĉₙ(f'')‖ = n²‖ĉₙ(f)‖) and the Wirtinger equality case
+`norm_fourierCoeffOn_deriv2_eq_of_natAbs_one` (|n|=1 ⟹ equality). Its docstrings promised
+the *strict* higher-mode gap in prose but never stated it.
+
+Added **`four_mul_norm_fourierCoeffOn_le_deriv2`**: for |n| ≥ 2,
+`4·‖ĉₙ(f)‖ ≤ ‖ĉₙ(f'')‖` (eigenvalue magnitude n² ≥ 4), completing the Wirtinger dichotomy
+(equality on the first harmonic vs damping-by-≥4 on every higher mode — why Hurwitz's
+equality analysis forces all but n=±1 to vanish, leaving the circle). Proof: rewrite via the
+magnitude identity, then `(4:ℝ) ≤ (n:ℝ)²` from `2 ≤ |n|` (`Int.abs_eq_natAbs` + `Int.cast_abs`
++ `sq_abs` + nlinarith), close by nlinarith with `norm_nonneg`.
+
+VERIFIED green via direct lean-elab vs pinned Mathlib v4.26.0 (docker containerd blob I/O down):
+built the `Proofs.AreaOfCircleOQ01OQ02OQ02` dep olean into /tmp (Mathlib-only parent), elaborated
+target with it on LEAN_PATH — exit 0, no errors, `#print axioms` = `[propext, Classical.choice,
+Quot.sound]`. Depth-4 slug → 0 follow-ups per OQ-chain depth guard. No gallery meta references this
+file (pure research-layer). File now 177→202 lines, 7→8 theorems.


### PR DESCRIPTION
## Summary

The `IsoperimetricFourier` second-derivative file (`AreaOfCircleOQ01OQ02OQ02OQ02.lean`) proves the Fourier eigenvalue identity `ĉₙ(f'') = −n²·ĉₙ(f)`, its magnitude form `‖ĉₙ(f'')‖ = n²‖ĉₙ(f)‖` (`norm_fourierCoeffOn_deriv2_eq`), and the Wirtinger **equality case** at the first harmonic (`norm_fourierCoeffOn_deriv2_eq_of_natAbs_one`, `|n|=1`). Its docstrings describe — but never state — the complementary **strict** behaviour for higher modes.

This PR fills exactly that gap:

**`four_mul_norm_fourierCoeffOn_le_deriv2`** — for `|n| ≥ 2`,

$$4\,\lVert\hat c_n(f)\rVert \le \lVert\hat c_n(f'')\rVert,$$

since the eigenvalue magnitude `n² ≥ 4`. Together with the `|n|=1` equality case this completes the Wirtinger dichotomy underlying the Hurwitz proof of the isoperimetric inequality: equality holds only on the first harmonic, and every higher mode is damped by a factor ≥ 4, so the equality analysis forces all such modes to vanish — leaving the circle as the unique extremal.

## Proof

Rewrite via the magnitude identity, derive `(4:ℝ) ≤ (n:ℝ)²` from `2 ≤ |n|` (`Int.abs_eq_natAbs` + `Int.cast_abs` + `sq_abs` + `nlinarith`), close with `nlinarith` and `norm_nonneg`.

## Verification

Docker containerd blob I/O errors (new `docker run` blocked); verified via direct `lean` elaboration against pinned Mathlib v4.26.0 (temp-built the Mathlib-only parent `Proofs.AreaOfCircleOQ01OQ02OQ02` olean, then elaborated the target with it on `LEAN_PATH`):

- Exit 0, no errors.
- `#print axioms four_mul_norm_fourierCoeffOn_le_deriv2` = `[propext, Classical.choice, Quot.sound]`.

Depth-4 slug → no follow-up questions generated (OQ-chain depth guard). No gallery `meta.json` references this file (pure research-layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)