### PR TITLE
Fix: resync meta.lineCount for 3 gallery entries

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 332,
+    "lineCount": 359,
     "theoremCount": 16,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 141,
+    "lineCount": 151,
     "theoremCount": 11,
     "definitionCount": 0,
     "assumptions": "None.",

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -26,7 +26,7 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None. All theorems are fully machine-checked, depending only on propext, Classical.choice, and Quot.sound. Layer 3 works in a general real inner-product space; the right angle is supplied as the explicit hypothesis ⟪A − C, B − C⟫ = 0 and non-degeneracy as A ≠ B. Honesty note: once a Euclidean/inner-product model is fixed, the norm already encodes distance, so the one-line identity pythagorean_core (‖A−B‖² = ‖A−C‖² + ‖B−C‖²) is itself Pythagoras; Layer 3 does not claim foundational independence from it — its content is the verified geometric-mean/altitude decomposition. Layers 1 and 2 capture the parts of Einstein's reasoning genuinely independent of coordinates.",
-    "lineCount": 299,
+    "lineCount": 318,
     "theoremCount": 13,
     "definitionCount": 2,
     "originalContributions": [


### PR DESCRIPTION
## Fix

Resync stale `meta.lineCount` values that lagged behind the actual `.lean` source line count after merged research PRs grew each file.

## Evidence

For each entry, the top-level `leanFile.lineCount` (site-displayed field) and the actual `wc -l` of the source already agreed; only the internal `meta.lineCount` copy was stale:

| slug | before | after (actual wc / leanFile.lineCount) | grown by |
|------|--------|-------|----------|
| algebraic-numbers-countable-oq-07 | 332 | 359 | #37085 |
| pythagorean-theorem-oq-01 | 299 | 318 | #37101 |
| lagrange-theorem-oq-01 | 141 | 151 | #37099 |

All three growing PRs are merged and settled — no in-flight PR touches these files, so the counts will not re-drift.

Minimal diff: 3 single-line changes, one per file. No other drift classes found (section-past-EOF flags were multi-file/pre-split false positives; remaining lineCount drifts are covered by open research PRs).

---
Automated fix by lean-mechanic agent.