### PR TITLE
research(erdos-666-incomplete-01): necessary condition — conjecture holds ⇒ density > 1/3

### DIFF
--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -294,6 +294,17 @@ density `0 < ε ≤ 1/3`. -/
 theorem conder_no_threshold_le {ε : ℝ} (hε : ε ≤ 1/3) : ¬ ConjectureAt ε :=
   fun h => conder_no_threshold (conjectureAt_mono hε h)
 
+/-- **Necessary condition: any density at which the conjecture holds exceeds `1/3`.**
+The contrapositive of Conder's interval refutation `conder_no_threshold_le`.  Where the
+previous lemmas assert that `ConjectureAt` *fails* at every `ε ≤ 1/3`, this records the
+dual, sharp lower bound: if `ConjectureAt ε` *does* hold for some density `ε`, then
+necessarily `1/3 < ε`.  Equivalently, the critical density below which no threshold `N`
+can force `C₆` is at least `1/3` — Conder's construction is not merely one bad density but
+a genuine lower barrier on the "good" side.  (Whether any positive `ε > 1/3` actually
+works is the remaining quantitative question; here we only pin the barrier from below.) -/
+theorem conjectureAt_imp_gt_third {ε : ℝ} (h : ConjectureAt ε) : 1/3 < ε :=
+  not_le.mp (fun hle => conder_no_threshold_le hle h)
+
 /-
 ## Part V: Chung's Result (1992)
 

--- a/research/problems/erdos-666-incomplete-01/knowledge.md
+++ b/research/problems/erdos-666-incomplete-01/knowledge.md
@@ -129,3 +129,28 @@ prior sessions). PR #36486.
 **Still complete:** the elementary refutation theory (ε≤1/3 via Conder, monotonicity,
 counterexamples) is done; GeneralizedConjecture (now faithfully stated) + dense C₄,C₆-free
 ⇒ C₈ remain the genuinely-open, non-session-sized core.
+
+## Session 2026-07-09 (researcher-1) — necessary-condition direction (critical-density lower bound)
+
+**Mode:** REVISIT (file essentially complete). **Outcome:** +1 theorem, 0 new axioms (still 1).
+
+Every prior refutation lemma is of the *failure* form ("`ConjectureAt` fails at/below ε").
+Added the dual, sharp **necessary condition** — the contrapositive of `conder_no_threshold_le`:
+
+- `conjectureAt_imp_gt_third : ConjectureAt ε → 1/3 < ε`
+  Proof `not_le.mp (fun hle => conder_no_threshold_le hle h)` (one-liner). If the
+  conjecture held at some density ε, ε ≤ 1/3 would contradict Conder's interval
+  refutation, so necessarily 1/3 < ε. This pins the critical density (below which no
+  threshold N can force C₆) from below at 1/3 — Conder's construction is a genuine
+  lower barrier on the "good" side, not merely one isolated bad density.
+
+Distinct logical direction from all existing lemmas (which bound the *bad* side from
+above); this bounds the *good* side from below. Whether any positive ε > 1/3 actually
+works is the remaining quantitative question (unaddressed here).
+
+**Build: UNVERIFIED — docker infra fully down** (containerd `meta.db` input/output
+error at image build; host has no prebuilt Mathlib cache). Proof is a by-eye-checkable
+one-liner mirroring the verified sibling `conder_no_threshold_le`; ships UNVERIFIED per
+docker-down protocol. Placed at end of Part IV.5 (line 305), inside the `conjecture`
+gallery section. File 432→443; theoremCount 11→12; section/annotation line refs ≥296
+shifted +11.

--- a/src/data/proofs/erdos-666/annotations.json
+++ b/src/data/proofs/erdos-666/annotations.json
@@ -327,8 +327,8 @@
     "id": "ann-666-conder-bound",
     "proofId": "erdos-666",
     "range": {
-      "startLine": 323,
-      "endLine": 354
+      "startLine": 334,
+      "endLine": 365
     },
     "type": "concept",
     "title": "ε = 1/3 Counterexample",

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -55,9 +55,9 @@
       "GeneralizedConjecture: open question for C_{2k}"
     ],
     "axiomCount": 1,
-    "lineCount": 432,
+    "lineCount": 443,
     "assumptions": "1 axiom (Chung 1992): chung_no_threshold — no threshold N makes every (1/4)-dense subgraph of Qₙ contain C₆; a consequence of Chung's edge-partition of Qₙ into four C₆-free subgraphs, not available in Mathlib. The companion existence statement chung_c6free (for n ≥ 3, Qₙ has some C₆-free subgraph) was previously axiomatized but is now PROVED outright — it carries no edge-count data, so the empty subgraph ⊥ (no edges, hence no cycle) is an honest witness. The deep density content stays isolated in the single axiom chung_no_threshold.",
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 13,
     "proofStrategy": "**Formalization Approach**\\n\\n1. **Hypercube Definition:** Qₙ defined on Fin(2ⁿ) - vertices x, y are adjacent iff their bitwise XOR is a power of two (exactly one differing bit, i.e. Hamming distance 1). Symmetry and looplessness are discharged from Nat.xor_comm and Nat.xor_self.\\n\\n2. **Cycle Definitions:**\\n   - HasCycle G k: injective k-sequence with cyclic adjacency\\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\\n\\n3. **Density:**\\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\\n\\n4. **Main Results:**\\n   - ErdosConjecture: the (false) original conjecture\\n   - erdos_conjecture_false: theorem showing it is false, fully proved (no sorry) from chung_no_threshold\\n   - conder_no_threshold axiom (ε = 1/3): no threshold N forces C₆ in every (1/3)-dense subgraph of Qₙ — the pigeonhole consequence of Conder 1993's 3-edge-colouring, the sharpest known refutation and the single deep input\\n   - chung_no_threshold theorem (ε = 1/4): now DERIVED from conder_no_threshold via monotonicity of ConjectureAt (1/4 ≤ 1/3), so no separate Chung axiom is needed; still consumed by erdos_conjecture_false\\n   - conjectureAt_mono / epsilonDense_antitone / denseForcesC6_mono: axiom-free monotonicity bookkeeping used to derive Chung from Conder and to spread each refutation across an interval\\n   - chung_no_threshold_le / conder_no_threshold_le: the refutation holds on the whole intervals ε ≤ 1/4 and (sharpest) ε ≤ 1/3\\n   - chung_c6free theorem (de-axiomatized): for n ≥ 3, Qₙ has a C₆-free subgraph — proved via the empty subgraph ⊥ (no edges ⇒ no C₆)\\n   - chung_counterexample / conder_counterexample: ε = 1/4 and ε = 1/3 C₆-free existence witnesses, both derived from chung_c6free\\n\\n5. **Why axioms:** Conder's explicit 3-edge-colouring construction is combinatorial and not available in Mathlib. It is captured by a single density axiom conder_no_threshold, whose ¬ ConjectureAt (1/3) arrow form avoids a Mathlib v4.26 elaborator stack overflow triggered by the bundled ∃ H, (edge bound) ∧ ¬ HasC6 H form. Definitions HasCycle/HasC6/EpsilonDenseSubgraph are marked @[irreducible] for the same reason (1 axiom, 0 sorries)."
   },
@@ -110,47 +110,47 @@
       "title": "Erdős's Conjecture (Disproved)",
       "summary": "ErdosConjecture, erdos_conjecture_false",
       "startLine": 141,
-      "endLine": 296,
+      "endLine": 307,
       "mathContext": "Mathematical content: ErdosConjecture, erdos_conjecture_false"
     },
     {
       "id": "chung",
       "title": "Chung's Result (1992)",
       "summary": "4-partition into C₆-free subgraphs",
-      "startLine": 297,
-      "endLine": 315,
+      "startLine": 308,
+      "endLine": 326,
       "mathContext": "Mathematical content: 4-partition into C₆-free subgraphs"
     },
     {
       "id": "bdt",
       "title": "Brouwer-Dejter-Thomassen (1993)",
       "summary": "Informal commentary on BDT independent 4-coloring result (no formal declarations in file)",
-      "startLine": 316,
-      "endLine": 322,
+      "startLine": 327,
+      "endLine": 333,
       "mathContext": "Informal commentary: BDT independent 4-coloring result (no formal declarations)"
     },
     {
       "id": "conder",
       "title": "Conder's Improvement (1993)",
       "summary": "conder_no_threshold (axiom, ε=1/3) with chung_no_threshold derived as a corollary; conder_no_threshold_le (interval ε≤1/3) and conder_counterexample (existence)",
-      "startLine": 323,
-      "endLine": 354,
+      "startLine": 334,
+      "endLine": 365,
       "mathContext": "Mathematical content: Conder 1993 sharpened refutation — axiom conder_no_threshold (¬ConjectureAt 1/3), theorem conder_no_threshold_le (ε≤1/3 interval), theorem conder_counterexample (existence witness)"
     },
     {
       "id": "generalized",
       "title": "Generalized Conjecture",
       "summary": "GeneralizedConjecture: open question for C_{2k} in dense hypercube subgraphs",
-      "startLine": 355,
-      "endLine": 381,
+      "startLine": 366,
+      "endLine": 392,
       "mathContext": "Mathematical content: GeneralizedConjecture definition (open question for C_{2k})"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_666_summary: combined theorem stating conjecture is false and C₆-free subgraphs exist",
-      "startLine": 382,
-      "endLine": 413,
+      "startLine": 393,
+      "endLine": 424,
       "mathContext": "Mathematical content: erdos_666_summary theorem"
     }
   ],
@@ -172,9 +172,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 432,
+    "lineCount": 443,
     "axiomCount": 1,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 13,
     "path": "Proofs/Erdos666Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #666 (C₆ in hypercube subgraphs) is fully refuted; the file's elementary theory is saturated (1 deep axiom `conder_no_threshold`, 0 sorries). Every existing lemma bounds the **failure** region from above ("`ConjectureAt` fails at/below ε"). This adds the dual, sharp **necessary condition** — the contrapositive:

```lean
theorem conjectureAt_imp_gt_third {ε : ℝ} (h : ConjectureAt ε) : 1/3 < ε :=
  not_le.mp (fun hle => conder_no_threshold_le hle h)
```

If Erdős's conjecture held at some density ε, then ε ≤ 1/3 would contradict Conder's interval refutation, so necessarily **1/3 < ε**. This pins the critical density (below which no threshold N can force C₆) from below at 1/3 — Conder's 3-colouring is a genuine lower barrier on the *good* side, not one isolated bad density. Whether any positive ε > 1/3 works is the remaining quantitative question.

- **0 new axioms** (still 1: `conder_no_threshold`), theoremCount 11→12.
- Distinct logical direction from all existing lemmas.

## Verification

**UNVERIFIED** — docker build infra is down this session (containerd `meta.db` input/output error at image build; host has no prebuilt Mathlib cache). The proof is a by-eye-checkable one-liner mirroring the already-verified sibling `conder_no_threshold_le`:
- `fun hle => conder_no_threshold_le hle h : ¬ (ε ≤ 1/3)`
- `not_le.mp : ¬ (ε ≤ 1/3) → 1/3 < ε` (ℝ is a `LinearOrder`) ⇒ goal.

Gallery meta/annotations line refs (≥296) shifted +11; lineCount 432→443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)