### PR TITLE
Enrich Erdős #1015 OQ5→OQ1: annotate the §1 areDisjoint⟹Pairwise bridge

### DIFF
--- a/src/data/proofs/erdos-1015-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1015-oq-05-oq-01/annotations.json
@@ -46,6 +46,29 @@
     ]
   },
   {
+    "id": "ann-pairwise",
+    "proofId": "erdos-1015-oq-05-oq-01",
+    "range": {
+      "startLine": 100,
+      "endLine": 111
+    },
+    "type": "technique",
+    "title": "§1. Bridging Index-Disjointness to List.Pairwise",
+    "content": "areDisjoint_pairwise converts the CliquePartition's native disjointness predicate — areDisjoint, which asserts Disjoint (get i) (get j) for all index pairs i ≠ j — into List.Pairwise Disjoint, the form the fold induction of §2 consumes. The proof rewrites with List.pairwise_iff_get (Pairwise R ↔ R (get i) (get j) for i < j), then discharges the i < j case: strict inequality gives i.val ≠ j.val (Nat.ne_of_lt), and areDisjoint supplies disjointness for that pair. The step is small but load-bearing: Pairwise is the structure induction destructures via List.pairwise_cons (head-disjoint-from-tail + tail-Pairwise), which the accumulator-generalized fold in §2 relies on to maintain its disjointness invariant.",
+    "mathContext": "$\\mathrm{areDisjoint}\\,l \\iff \\forall i\\neq j,\\ \\mathrm{Disjoint}\\,(l_i)\\,(l_j);\\quad \\text{via } \\texttt{pairwise\\_iff\\_get} \\Rightarrow l.\\mathrm{Pairwise}\\ \\mathrm{Disjoint}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "List.pairwise_iff_get",
+      "List.pairwise_cons",
+      "index-based vs inductive disjointness",
+      "Nat.ne_of_lt"
+    ],
+    "prerequisites": [
+      "List.Pairwise",
+      "Finset.Disjoint"
+    ]
+  },
+  {
     "id": "ann-fold",
     "proofId": "erdos-1015-oq-05-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `erdos-1015-oq-05-oq-01` (quality 95, pass 0).

This entry was already comprehensive (6 annotations, 4 keyInsights, 6 sections covering the file, 3 crossReferences, 3 references, honest axiom accounting) and well under all size caps (12.4 KB meta). The one genuine gap was **annotation coverage**: §1's bridge lemma `areDisjoint_pairwise` (lines 100–111) — referenced as a prerequisite by the covered-count annotation and load-bearing for the §2 fold induction — had no dedicated annotation (coverage jumped from the definitions block at 58–99 to the fold lemma at 112–138).

This pass adds one annotation (`ann-pairwise`) explaining how the CliquePartition's index-based `areDisjoint` predicate is converted via `List.pairwise_iff_get` into `List.Pairwise Disjoint` — the inductive form `List.pairwise_cons` destructures, which the accumulator-generalized fold relies on to maintain its disjointness invariant. Full `mathContext`, `significance`, `relatedConcepts`, `prerequisites`; no existing content altered.

annotations: 6 → 7. meta unchanged, within caps.