### PR TITLE
research(erdos-1093-oq-02): Section XXV — location bound closes k=24, frontier k≥25

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -1876,3 +1876,96 @@ theorem maximalDeficiencyIs_nine_iff_kGe24 :
     by_cases hk : k ≤ 23
     · exact deficiency_le_nine_of_k_le_23 hv.1 hv.2 hk
     · exact h n k (by omega) hv
+
+/-
+## Section XXV: The location bound closes `k = 24` — frontier `k ≥ 24` → `k ≥ 25`
+
+Section XXIV cashed out the effective, ELS-free location bound at the open frontier
+`k = 23`.  The same mechanism advances one further step, to `k = 24`.  A deficiency
+`≥ 10` forces the window-floor power bound `(n - 23)^{10} ≤ 24!`, and `24! < 240^{10}`
+(`factorial_24_lt_240_pow_ten`), so `n - 23 < 240`, i.e. `n ≤ 262`.  With the admissibility
+floor `n ≥ 48` (`= 2·24`) this leaves the finite window `n ∈ {48, 49, …, 262}` (two hundred
+and fifteen values).
+
+As at `k = 18, …, 23`, `C(n,24)` is **not** uniformly even on this window: by
+Kummer/Lucas `C(n,24)` is odd exactly when the binary digits of `24 = 11000₂` sit inside
+those of `n`, which happens for fifty-six values of `n` in the window, so the single prime
+`2` no longer certifies inadmissibility.  It remains true — and this is what closes the
+slice — that *some* prime `≤ 24` divides `C(n,24)` for every one of the two hundred and
+fifteen values: `2` for the one hundred and fifty-nine even ones, `3` for all but two of
+the fifty-six odd ones, and `5` for the two remaining odd exceptions `n = 159, 186`.  So
+already the three-prime disjunction `2 ∣ C(n,24) ∨ 3 ∣ C(n,24) ∨ 5 ∣ C(n,24)` holds
+throughout the window — one prime richer than the two-prime economy of `k = 19, …, 23`,
+reflecting that no two primes `≤ 24` suffice here — so no pair is admissible and no
+admissible pair at `k = 24` has deficiency exceeding `9`.
+
+As before the `(k!)²` factorial method is powerless here
+(`sharp_bound_permits_deficiency_ten` permits deficiency `10` for every `k ≥ 16`); only
+the *location* bound closes the slice, through the uniform engine
+`deficiency_le_nine_of_location` (Section XVIIB).  The elementary resolution of OQ-02 now
+covers **all `k ≤ 24`**, moving the open frontier to `k ≥ 25`.  The structural results
+remain `ofReduceBool`-free; only the concrete divisibility facts use `native_decide`. -/
+
+/-- `24! < 240^10`, the numeric input that pins the `k = 24` window: `(n-23)^{10} ≤ 24!`
+forces `n - 23 < 240`.  `ofReduceBool`-free (`Nat.factorial` and `Nat.pow` on literals
+reduce under kernel `decide`; `24! = 620448401733239439360000 < 634033809653760000000000 = 240^{10}`). -/
+theorem factorial_24_lt_240_pow_ten : Nat.factorial 24 < 240 ^ 10 := by decide
+
+/-- For `48 ≤ n ≤ 262` some prime `≤ 24` divides `C(n,24)`: `2` for the even values, `3`
+for all but two of the odd binomials, and `5` for the two remaining odd exceptions
+`n ∈ {159, 186}`.  Stated as the disjunction `2 ∣ · ∨ 3 ∣ · ∨ 5 ∣ ·`, which holds across
+the whole window.  Uses `native_decide` (⇒ `Lean.ofReduceBool`) because the naive
+`Nat.choose` recursion is infeasible for kernel `decide`. -/
+theorem smallPrime_dvd_choose_24_of_range {n : ℕ} (hlo : 48 ≤ n) (hhi : n ≤ 262) :
+    2 ∣ Nat.choose n 24 ∨ 3 ∣ Nat.choose n 24 ∨ 5 ∣ Nat.choose n 24 := by
+  interval_cases n <;> native_decide
+
+/-- The two hundred and fifteen small pairs left by the `k = 24` location window are all
+inadmissible: some prime `p ∈ {2, 3, 5}` (each `≤ 24`) divides `C(n,24)`, contradicting
+`NoSmallPrimeFactors n 24` (which would force `24 < p`). -/
+theorem not_admissible_k24_of_range {n : ℕ} (hlo : 48 ≤ n) (hhi : n ≤ 262) :
+    ¬ NoSmallPrimeFactors n 24 := by
+  intro h
+  rcases smallPrime_dvd_choose_24_of_range hlo hhi with hd | hd | hd
+  · have := h 2 Nat.prime_two hd; omega
+  · have := h 3 Nat.prime_three hd; omega
+  · have := h 5 Nat.prime_five hd; omega
+
+/-- **The location bound closes `k = 24`.**  For an admissible pair with `k = 24` the
+deficiency never exceeds `9`.  A deficiency `≥ 10` would force, via the window-floor
+bound, `(n - 23)^{10} ≤ 24! < 240^{10}`, hence `n ≤ 262`; with the admissibility floor
+`n ≥ 48` this leaves only `n ∈ {48,…,262}`, none admissible (some prime `≤ 24` divides
+`C(n,24)`, even where `C(n,24)` is odd).  A one-line instantiation of the uniform engine
+`deficiency_le_nine_of_location` at `k = 24, M = 240`. -/
+theorem deficiency_le_nine_of_k_eq_24 {n : ℕ} (hn : 48 ≤ n)
+    (h : NoSmallPrimeFactors n 24) : deficiency n 24 ≤ 9 :=
+  deficiency_le_nine_of_location (k := 24) (M := 240) (by omega) h
+    factorial_24_lt_240_pow_ten
+    (fun m hlo hhi => not_admissible_k24_of_range (by omega) (by omega))
+
+/-- **Elementary resolution of OQ-02 for all `k ≤ 24`.**  Combines the location bound at
+`k ≤ 23` (`deficiency_le_nine_of_k_le_23`) with the location bound at `k = 24`
+(`deficiency_le_nine_of_k_eq_24`).  Strictly extends the `k ≤ 23` reach of Section XXIV. -/
+theorem deficiency_le_nine_of_k_le_24 {n k : ℕ} (hn : 2 * k ≤ n)
+    (h : NoSmallPrimeFactors n k) (hk : k ≤ 24) : deficiency n k ≤ 9 := by
+  by_cases hk23 : k ≤ 23
+  · exact deficiency_le_nine_of_k_le_23 hn h hk23
+  · have hk24 : k = 24 := by omega
+    subst hk24
+    exact deficiency_le_nine_of_k_eq_24 (by omega) h
+
+/-- **Sharpened reduction to `k ≥ 25`.**  `MaximalDeficiencyIs 9` is equivalent to the
+open universal bound restricted to `k ≥ 25`: the cases `k ≤ 23` are discharged by the
+sharp/location bounds and `k = 24` by the location bound (`deficiency_le_nine_of_k_le_24`).
+Strictly sharper than `maximalDeficiencyIs_nine_iff_kGe24`; the entire remaining open
+content of OQ-02 now lives at `k ≥ 25`. -/
+theorem maximalDeficiencyIs_nine_iff_kGe25 :
+    MaximalDeficiencyIs 9 ↔
+      ∀ n k, 25 ≤ k → ValidDeficiencyExample n k → deficiency n k ≤ 9 := by
+  rw [maximalDeficiencyIs_nine_iff_upperBound]
+  constructor
+  · intro h n k _ hv; exact h n k hv
+  · intro h n k hv
+    by_cases hk : k ≤ 24
+    · exact deficiency_le_nine_of_k_le_24 hv.1 hv.2 hk
+    · exact h n k (by omega) hv

--- a/research/problems/erdos-1093-oq-02/knowledge.md
+++ b/research/problems/erdos-1093-oq-02/knowledge.md
@@ -722,3 +722,37 @@ window floor `n ≥ 48`, window `{48..b+22}`, odd binomials of `24 = 11000₂` a
 prime dividing them; then clone this section with the new constants. The deep frontier
 (universal bound / `10≤d≤18` at k=28) remains BLOCKED on effective analytic NT (ELS) absent
 from Mathlib — the incremental k-by-k march is the only session-sized advance here.
+
+## Session 2026-07-09 (researcher-11) — Section XXV: location bound closes k=24, frontier k≥25
+
+**Mode:** ACT. Extended the elementary ELS-free location bound one step (k=23 → k=24),
+exactly following the "NEXT (k=24)" recipe left by researcher-3. Added 5 theorems (0 sorry,
+0 new axiom), instantiating the merged uniform engine `deficiency_le_nine_of_location`:
+- `factorial_24_lt_240_pow_ten` — `24! < 240^10` (kernel `decide`, ofReduceBool-free;
+  `24! = 620448401733239439360000 < 634033809653760000000000 = 240^10`). 240 is the LEAST
+  base with `24! < b^10` (Python-verified).
+- `smallPrime_dvd_choose_24_of_range` — `2 ∣ C(n,24) ∨ 3 ∣ C(n,24) ∨ 5 ∣ C(n,24)` for
+  `48 ≤ n ≤ 262` (`interval_cases n <;> native_decide`, 215 values).
+- `not_admissible_k24_of_range`, `deficiency_le_nine_of_k_eq_24` (one-line via the engine),
+  `deficiency_le_nine_of_k_le_24`, `maximalDeficiencyIs_nine_iff_kGe25`.
+
+**Numerics (Python-verified before Lean):** window-floor `(n-23)^10 ≤ 24! < 240^10` ⇒
+`n ≤ 262`; floor `n ≥ 48 (=2·24)`; window `{48..262}` = 215 values. `C(n,24)` odd (Kummer:
+`24 = 11000₂` submask of n) at 56 values in the window; the single prime 2 no longer covers.
+**Three primes are needed here** (Python: NO 2-prime subset of {2,…,23} covers the window;
+minimal covering `{2,3,5}`): `2` for the 159 even values, `3` for 54 of the 56 odd ones, and
+`5` for the two odd exceptions `n = 159, 186` (both lack a factor 3, both divisible by 5).
+This is one prime richer than the two-prime economy of k=19..23 — the first slice where two
+primes provably do not suffice.
+
+**Build:** UNVERIFIED. Docker infra still down — `docker ps` works but image build dies at
+`meta.db: input/output error` (containerd metadata store corrupt, known #35184, operator-
+level). No build signal obtainable. The section is a byte-exact structural mirror of the
+merged/verified k=18..23 sections (only constants + the extra disjunct differ), the two
+numeric facts are Python-verified, and the closing bound is a one-line instantiation of the
+already-merged engine `deficiency_le_nine_of_location` → high confidence.
+
+**Frontier:** now `k ≥ 25`. NEXT (k=25): least base `b` with `25! < b^10`; floor `n ≥ 50`;
+window `{50..b+23}`; `25 = 11001₂` odd binomials and their covering primes (may again need
+≥3 primes). Clone Section XXV with new constants. Deep frontier (universal bound / `10≤d≤18`
+at k=28) remains BLOCKED on effective analytic NT (ELS) absent from Mathlib.


### PR DESCRIPTION
## Summary

Extends the elementary, ELS-free **location bound** for Erdős #1093 OQ-02 one step further — from `k = 23` to `k = 24` — moving the open frontier from `k ≥ 24` to `k ≥ 25`. This continues the k-by-k march of Sections XVII–XXIV, now driven through the merged uniform engine `deficiency_le_nine_of_location` (Section XVIIB).

## Mathematical content

A deficiency `≥ 10` at `k = 24` forces the window-floor power bound `(n − 23)^10 ≤ 24!`. Since `24! < 240^10` (`240` is the least such base), `n − 23 < 240`, i.e. `n ≤ 262`; with the admissibility floor `n ≥ 48 (= 2·24)` this pins the finite window `n ∈ {48, …, 262}` (**215 values**). Every one is inadmissible because some prime `≤ 24` divides `C(n,24)`.

**First slice needing three covering primes.** Unlike `k = 19..23` (two primes sufficed), no two primes `≤ 24` cover this window (Python-verified). The minimal covering is `{2, 3, 5}`:
- `2` divides the 159 even `C(n,24)`;
- `3` divides 54 of the 56 odd ones (`C(n,24)` odd ⇔ `24 = 11000₂` is a binary submask of `n`);
- `5` divides the two odd exceptions `n = 159, 186` (both lack a factor 3).

## Theorems added (5; 0 sorry, 0 new axiom)

- `factorial_24_lt_240_pow_ten` — `24! < 240^10` (kernel `decide`, `ofReduceBool`-free)
- `smallPrime_dvd_choose_24_of_range` — `2 ∣ C(n,24) ∨ 3 ∣ C(n,24) ∨ 5 ∣ C(n,24)` on `{48..262}` (`interval_cases n <;> native_decide`)
- `not_admissible_k24_of_range`
- `deficiency_le_nine_of_k_eq_24` — one-line instantiation of `deficiency_le_nine_of_location` at `k = 24, M = 240`
- `deficiency_le_nine_of_k_le_24`, `maximalDeficiencyIs_nine_iff_kGe25`

The structural results remain `Lean.ofReduceBool`-free; only the concrete divisibility facts use `native_decide` (as in every earlier rung).

## Verification status

**UNVERIFIED.** Docker is up (`docker ps` works) but the image build fails at the containerd metadata store I/O error (`meta.db: input/output error`, known #35184, operator-level) — no build signal was obtainable this session. Confidence is high: the section is a byte-exact structural mirror of the merged/verified `k = 18..23` sections (only constants and one extra disjunct differ), both numeric facts (`24! < 240^10` least-base, and the `{2,3,5}` covering of all 215 window values) are Python-verified, and the closing bound is a one-line call to the already-merged engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)