### PR TITLE
research(brouwer-fixed-point-oq-02-oq-02-oq-01): convergence of the contraction iteration xₙ → x*

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
@@ -320,4 +320,44 @@ theorem aposteriori_estimate_unconditional (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 
   obtain ⟨xstar, hfp⟩ := exists_fixed_point f L hL0 hL1 hf
   exact ⟨xstar, hfp, fun n => aposteriori_estimate f L hL0 hL1 hf x hx xstar hfp n⟩
 
+/-! ### Convergence of the iteration (the qualitative limit behind the estimates)
+
+The a priori/a posteriori theorems above are *quantitative* error bounds; the
+underlying *qualitative* fact is that the iterates actually converge to the fixed
+point, `xₙ → x*`.  It is an immediate consequence of the geometric decay
+`iterate_dist` (`|xₙ − x*| ≤ Lⁿ·|x₀ − x*|`) together with `Lⁿ → 0` for `0 ≤ L < 1`,
+sandwiched to `0`.  This completes the Banach picture: existence + uniqueness of `x*`
+(`exists_unique_fixed_point`), the two computable error estimates, and now the
+convergence they estimate the *rate* of. -/
+
+/-- **Convergence of the iteration.**  For a contraction `f` on `ℝ` with fixed point
+    `x*` and iteration `xₙ₊₁ = f xₙ`, the iterates converge to `x*`:
+    `xₙ → x*` as `n → ∞`.  Proved by squeezing the error `|xₙ − x*|` between `0` and
+    the geometric bound `Lⁿ·|x₀ − x*| → 0` (`iterate_dist` +
+    `tendsto_pow_atTop_nhds_zero_of_lt_one`). -/
+theorem iterate_tendsto (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L) (hL1 : L < 1)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (x : ℕ → ℝ) (hx : ∀ n, x (n + 1) = f (x n))
+    (xstar : ℝ) (hfp : f xstar = xstar) :
+    Filter.Tendsto x Filter.atTop (nhds xstar) := by
+  rw [tendsto_iff_dist_tendsto_zero]
+  have hbound : ∀ n, dist (x n) xstar ≤ L ^ n * |x 0 - xstar| := by
+    intro n
+    rw [Real.dist_eq]
+    exact iterate_dist f L hL0 hf x hx xstar hfp n
+  have hg : Filter.Tendsto (fun n : ℕ => L ^ n * |x 0 - xstar|) Filter.atTop (nhds 0) := by
+    have h0 := tendsto_pow_atTop_nhds_zero_of_lt_one hL0 hL1
+    simpa using h0.mul_const |x 0 - xstar|
+  exact squeeze_zero (fun _ => dist_nonneg) hbound hg
+
+/-- **Unconditional convergence.**  A contraction on `ℝ` has a fixed point `x*` to which
+    every iteration sequence `xₙ₊₁ = f xₙ` converges — the hypothesis-free form of
+    `iterate_tendsto`, threading `exists_fixed_point` for the existence of `x*`. -/
+theorem exists_iterate_tendsto (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L) (hL1 : L < 1)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (x : ℕ → ℝ) (hx : ∀ n, x (n + 1) = f (x n)) :
+    ∃ xstar : ℝ, f xstar = xstar ∧ Filter.Tendsto x Filter.atTop (nhds xstar) := by
+  obtain ⟨xstar, hfp⟩ := exists_fixed_point f L hL0 hL1 hf
+  exact ⟨xstar, hfp, iterate_tendsto f L hL0 hL1 hf x hx xstar hfp⟩
+
 end BrouwerOQ02OQ02OQ01


### PR DESCRIPTION
## Summary

This entry (a priori / a posteriori error estimates for contraction iteration) already had the *quantitative* error bounds together with existence and uniqueness of the fixed point, but not the *qualitative* limit those estimates bound the **rate** of: that the iterates actually converge. This PR adds it.

## New theorems (2)

- `iterate_tendsto`: for an `L`-contraction `f` on `ℝ` (`0 ≤ L < 1`) with fixed point `x*` and iteration `xₙ₊₁ = f xₙ`, `Tendsto x atTop (nhds x*)` — the iterates converge to `x*`. Proved by squeezing the error `|xₙ − x*|` between `0` and the geometric bound `Lⁿ·|x₀ − x*| → 0` (the existing `iterate_dist` + `tendsto_pow_atTop_nhds_zero_of_lt_one`, via `squeeze_zero`).
- `exists_iterate_tendsto`: hypothesis-free form — a contraction on `ℝ` has a fixed point to which every iteration sequence converges (threads `exists_fixed_point`), matching the file's unconditional-estimate pattern.

Completes the Banach picture for this entry: existence + uniqueness (`exists_unique_fixed_point`), the two computable estimates, and now the convergence itself. 0 sorries, 0 axioms.

## Verification status

⚠️ **UNVERIFIED** — docker build infrastructure is down this session (containerd `meta.db` input/output error, operator-level; host disk healthy at 115Gi). To compensate, every Mathlib lemma name and signature used was checked against the local mathlib pin under `proofs/.lake/packages/mathlib`: `tendsto_pow_atTop_nhds_zero_of_lt_one` (`0 ≤ r → r < 1 → Tendsto (r^·) atTop (𝓝 0)`), `squeeze_zero`, `tendsto_iff_dist_tendsto_zero`, `Filter.Tendsto.mul_const`, `Real.dist_eq`. A green build should be confirmed once docker recovers.