### PR TITLE
Research: erdos-771 - maxAvoidingSize is monotone in n

### DIFF
--- a/proofs/Proofs/Erdos771Problem.lean
+++ b/proofs/Proofs/Erdos771Problem.lean
@@ -121,6 +121,36 @@ theorem maxAvoidingSize_le (n m : ℕ) : maxAvoidingSize n m ≤ n := by
   rw [Icc_n, Nat.card_Icc] at hcard
   omega
 
+/-- **Monotonicity in the range `n`.** For a fixed target `m`, enlarging the
+    ambient box `{1,…,n}` can only enlarge the family of `m`-avoiding subsets, so
+    the maximum avoiding size is non-decreasing in `n`: `maxAvoidingSize n m ≤
+    maxAvoidingSize (n+1) m`. Every `m`-avoiding `S ⊆ {1,…,n}` is still an
+    `m`-avoiding subset of `{1,…,n+1}` (the `AvoidSum S m` predicate depends only
+    on `S` and `m`, not on the box), so the filtered powerset for `n` embeds into
+    that for `n+1` and `Finset.sup_mono` transfers the bound. This is the analogue
+    for `maxAvoidingSize` of the counting-function monotonicity used elsewhere in
+    the gallery, and complements the lower bounds `interval_avoiding_lower` /
+    `primeMultiples_avoiding_lower` and the upper bound `maxAvoidingSize_le`. -/
+theorem maxAvoidingSize_le_succ (n m : ℕ) :
+    maxAvoidingSize n m ≤ maxAvoidingSize (n + 1) m := by
+  classical
+  unfold maxAvoidingSize
+  -- Reduce to nestedness of the two filtered avoiding families; working on the
+  -- unfolded goal directly keeps the `filter`'s decidability instances aligned
+  -- with the `open Classical`-based definition (a fresh `filter` term would not).
+  apply Finset.sup_mono
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS ⊢
+  -- `AvoidSum S m` is unchanged; only the box `{1,…,n} ⊆ {1,…,n+1}` grows.
+  refine ⟨hS.1.trans ?_, hS.2⟩
+  rw [Icc_n, Icc_n]
+  exact Finset.Icc_subset_Icc (le_refl 1) (Nat.le_succ n)
+
+/-- **`maxAvoidingSize` is monotone in `n`** (packaged form of
+    `maxAvoidingSize_le_succ`). -/
+theorem maxAvoidingSize_monotone (m : ℕ) : Monotone (fun n => maxAvoidingSize n m) :=
+  monotone_nat_of_le_succ (fun n => maxAvoidingSize_le_succ n m)
+
 /-- For `m > n²` the whole set `{1,…,n}` avoids `m`: every subset sum is at most
     `|A|·n ≤ n·n < m`, so `m` is never realised. -/
 theorem avoid_full (n m : ℕ) (h : n * n < m) : AvoidSum (Icc_n n) m := by

--- a/research/problems/erdos-771/knowledge.md
+++ b/research/problems/erdos-771/knowledge.md
@@ -115,3 +115,27 @@ rebuild impossible (cached-image builds also unavailable now). Proofs are verbat
 verified Construction.lean code → correctness inherited. Still open (unchanged): deep asymptotics
 f(n)=(1/2+o(1))n/log n, the 2 external axioms. Erdos771Aristotle.lean still has 4 sorries (separate
 companion; not addressed).
+
+## Session 2026-07-09 (researcher-2) — structural: maxAvoidingSize monotone in n (0-axiom)
+
+Added to `Erdos771Problem.lean` (does NOT touch the companion `Erdos771Aristotle.lean`
+under active PR #37121):
+- `maxAvoidingSize_le_succ (n m)`: `maxAvoidingSize n m ≤ maxAvoidingSize (n+1) m`.
+- `maxAvoidingSize_monotone (m) : Monotone (fun n => maxAvoidingSize n m)`.
+
+Enlarging the box `{1,…,n} ⊆ {1,…,n+1}` can only enlarge the family of `m`-avoiding
+subsets (the `AvoidSum S m` predicate depends only on `S,m`, not the box), so the
+`sup`-of-cardinality is non-decreasing. Proof: `apply Finset.sup_mono` on the unfolded
+goal (kept the `filter`'s classical decidability instances aligned with the `open
+Classical`-based def — a fresh `filter` term would have mismatched), then
+`mem_filter`/`mem_powerset` + `Finset.Icc_subset_Icc (le_refl 1) (Nat.le_succ n)`.
+This is the `maxAvoidingSize` analogue of the counting-function monotonicity used in
+erdos-748, complementing the existing lower bounds (`interval_avoiding_lower`,
+`primeMultiples_avoiding_lower`) and upper bound (`maxAvoidingSize_le`).
+
+**UNVERIFIED** — docker infra down, no local Mathlib oleans this session. All lemma
+names/signatures checked vs pinned `proofs/.lake/packages/mathlib`
+(`Finset.sup_mono`, `Finset.powerset_mono`, `Finset.filter_subset_filter`,
+`Finset.Icc_subset_Icc`, `monotone_nat_of_le_succ`); proof mirrors the verified
+`maxAvoidingSize_le` in the same file. Substantive status unchanged: 2 deep external
+axioms (Erdős–Graham / Alon–Freiman) remain BLOCKED.

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -79,9 +79,9 @@
       "erdos_771, erdos_771_main, erdos_771_solved: main theorem statements"
     ],
     "axiomCount": 2,
-    "lineCount": 490,
+    "lineCount": 520,
     "assumptions": "2 axioms: erdos_graham_lower_bound, alon_freiman_upper_bound. 0 sorries.",
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos771Aristotle.lean",
@@ -214,9 +214,9 @@
       "Nat"
     ],
     "namespace": "Erdos771",
-    "lineCount": 490,
+    "lineCount": 520,
     "axiomCount": 2,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 16,
     "sorries": 0,
     "path": "Proofs/Erdos771Problem.lean",

--- a/src/data/research/problems/erdos-771.json
+++ b/src/data/research/problems/erdos-771.json
@@ -9,7 +9,7 @@
   "knownResults": "SOLVED: f(n) = (1/2 + o(1))·n/log n (Erdős–Graham lower bound via prime multiples; Alon–Freiman upper bound via LCM).",
   "currentState": "Verified the elementary Erdős–Graham construction in a new self-contained file; the deep asymptotics remain axiomatized in the companion file.",
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdos771Problem.lean now compiles under Mathlib 4.26.0 (was broken) with sorries 7→3 and 2 honest external axioms. Discharged prime_multiples_size, prime_multiples_avoid (ported from verified construction), erdos_graham_conjecture_true (asymptotic from the two axiom bounds), and leading_constant (limit form). Remaining sorries: f_characterization, m_eq_one_case, m_eq_two_case (all reason about maxAvoidingSize as a sup over the powerset).",
+    "progressSummary": "Saturated: Erdos771Problem.lean 0-sorry/2-deep-axiom (Erdős–Graham/Alon–Freiman, BLOCKED). Session (researcher-2, 2026-07-09): added maxAvoidingSize monotonicity-in-n (le_succ + Monotone), 0 new axioms, in the Problem file (avoids companion PR #37121). UNVERIFIED docker-down; names checked vs pinned mathlib; mirrors verified maxAvoidingSize_le.",
     "builtItems": [
       "prime_multiples_size in Erdos771Construction.lean:64",
       "prime_multiples_avoid in Erdos771Construction.lean:78",
@@ -18,7 +18,8 @@
       "Repaired Erdos771Problem.lean to compile under Mathlib 4.26.0 (import Mathlib; classical DecidablePred for AvoidSum; dependent-if inf nonemptiness; removed dangling doc-comments)",
       "erdos_graham_conjecture_true in Erdos771Problem.lean: combined the two axiomatic bounds into |f n/(n/log n) - 1/2| < ε (squeeze on n≥2 where n/log n>0)",
       "leading_constant in Erdos771Problem.lean: Tendsto form via Metric.tendsto_atTop + Real.dist_eq, derived from the conjecture",
-      "Discharged prime_multiples_size and prime_multiples_avoid sorries in Erdos771Problem.lean (ported from verified Erdos771Construction.lean)"
+      "Discharged prime_multiples_size and prime_multiples_avoid sorries in Erdos771Problem.lean (ported from verified Erdos771Construction.lean)",
+      "maxAvoidingSize_le_succ + maxAvoidingSize_monotone (Erdos771Problem.lean): maxAvoidingSize is non-decreasing in the range n (0 axioms)."
     ],
     "insights": [
       "If every element of S is a multiple of p, so is every subset sum, so S avoids any m with p ∤ m — the engine of the Erdős–Graham lower bound. Primality is not even needed for avoidance.",


### PR DESCRIPTION
## Summary
Research session for `erdos-771` (Erdős–Graham `f(n) = (1/2+o(1))·n/log n`). `Erdos771Problem.lean` is saturated: **0 sorries, 2 deep external axioms** (Erdős–Graham lower bound + Alon–Freiman upper bound, genuinely irreducible / BLOCKED). This adds one correct, self-contained structural lemma.

## Progress
- Added `maxAvoidingSize_le_succ (n m) : maxAvoidingSize n m ≤ maxAvoidingSize (n+1) m` and the packaged `maxAvoidingSize_monotone (m) : Monotone (fun n => maxAvoidingSize n m)`.
- **0 new axioms.** Only `Erdos771Problem.lean` is touched — deliberately **not** the companion `Erdos771Aristotle.lean`, which is under active PR #37121.

## Findings
- Enlarging the ambient box `{1,…,n} ⊆ {1,…,n+1}` can only enlarge the family of `m`-avoiding subsets (the `AvoidSum S m` predicate depends only on `S` and `m`, not the box), so the `sup`-of-cardinality is non-decreasing. This is the `maxAvoidingSize` analogue of the counting-function monotonicity used in erdos-748, and complements the existing lower bounds (`interval_avoiding_lower`, `primeMultiples_avoiding_lower`) and upper bound (`maxAvoidingSize_le`).
- Proof works on the unfolded goal via `apply Finset.sup_mono` (keeping the `filter`'s classical decidability instances aligned with the `open Classical`-based definition — a fresh `filter` term would mismatch), then `mem_filter`/`mem_powerset` + `Finset.Icc_subset_Icc (le_refl 1) (Nat.le_succ n)`.

## Verification
**UNVERIFIED** — Docker infra is down this session and no local Mathlib oleans are present, so no build was possible. Mitigation: all lemma names/signatures checked against the pinned `proofs/.lake/packages/mathlib` (`Finset.sup_mono`, `Finset.powerset_mono`, `Finset.filter_subset_filter`, `Finset.Icc_subset_Icc`, `monotone_nat_of_le_succ`); the proof mirrors the already-verified `maxAvoidingSize_le` in the same file.

## Status
**Outcome**: progress (1 axiom-free structural lemma pair; substantive status unchanged — 2 deep external axioms remain BLOCKED)
**Next Steps**: the 2 axioms are deep literature results, not single-session work. The 4 companion sorries in `Erdos771Aristotle.lean` are owned by PR #37121.

🤖 Generated by researcher-2