### PR TITLE
research(erdos-634): link KnownNonDissectable set to Beeson's axioms

### DIFF
--- a/proofs/Proofs/Erdos634Problem.lean
+++ b/proofs/Proofs/Erdos634Problem.lean
@@ -230,6 +230,19 @@ theorem non_dissectable_form :
   | inl h => exact ⟨1, h⟩
   | inr h => exact ⟨2, h⟩
 
+/-- **Every element of `KnownNonDissectable` is genuinely non-dissectable.**
+This ties the `KnownNonDissectable = {7, 11}` set back to Beeson's two theorems
+(`seven_not_dissectable`, `eleven_not_dissectable`): the set is not merely a label,
+its members really fail to admit a congruent tiling.  Provides a single
+`n ∈ KnownNonDissectable → ¬ IsDissectable n` entry point for downstream use. -/
+theorem knownNonDissectable_not_dissectable :
+    ∀ n ∈ KnownNonDissectable, ¬ IsDissectable n := by
+  intro n hn
+  simp [KnownNonDissectable] at hn
+  cases hn with
+  | inl h => subst h; exact seven_not_dissectable
+  | inr h => subst h; exact eleven_not_dissectable
+
 /-
 ## Part VI: The Conjecture
 

--- a/research/problems/erdos-634/knowledge.md
+++ b/research/problems/erdos-634/knowledge.md
@@ -77,3 +77,25 @@ with the covering statements.
   meet in a shared *edge*, a `triHull` of two midpoints — a segment, not a point).
 - The measure/area accounting to upgrade covering + interior-disjointness to a
   fully quantitative tiling (needs a Mathlib area/measure-of-triangle input).
+
+## Session 2026-07-09 (researcher-1) — link KnownNonDissectable set to Beeson's axioms
+
+**Mode:** REVISIT (base file). **Outcome:** +1 theorem, 0 new axioms (still 4), 0 new sorries.
+
+The set `KnownNonDissectable = {7, 11}` (line 222) was defined and used only by
+`non_dissectable_form` (its 4k+3 shape), but was never tied back to the two Beeson
+axioms — the name asserted non-dissectability that the file never actually derived.
+Added:
+
+- `knownNonDissectable_not_dissectable : ∀ n ∈ KnownNonDissectable, ¬ IsDissectable n`
+  Proof mirrors the verified `non_dissectable_form` exactly: `simp [KnownNonDissectable]`
+  turns membership into `n = 7 ∨ n = 11`, then `cases`/`subst` discharges each with
+  `seven_not_dissectable` / `eleven_not_dissectable`. A single membership→¬dissectable
+  entry point; validates the set's naming.
+
+The 5 remaining sorries (squares/two/three/six/sum reptiling constructions) stay blocked
+on a Mathlib polygonal-tiling API — not touched (unsafe without a build, not session-sized).
+
+**Build: UNVERIFIED — docker infra down** (containerd meta.db I/O error; host has no
+Mathlib cache). By-eye-checkable, mirrors the adjacent verified `non_dissectable_form`.
+File 373→386; theoremCount 16→17; section/annotation line refs ≥231 shifted +13.

--- a/src/data/proofs/erdos-634/annotations.json
+++ b/src/data/proofs/erdos-634/annotations.json
@@ -494,8 +494,8 @@
     "id": "ann-634-similar-dissection",
     "proofId": "erdos-634",
     "range": {
-      "startLine": 237,
-      "endLine": 243
+      "startLine": 250,
+      "endLine": 256
     },
     "type": "definition",
     "title": "Similar Dissection Definitions",
@@ -516,8 +516,8 @@
     "id": "ann-634-soifer",
     "proofId": "erdos-634",
     "range": {
-      "startLine": 245,
-      "endLine": 247
+      "startLine": 258,
+      "endLine": 260
     },
     "type": "concept",
     "title": "Soifer's Theorem (Complete Solution for Similar Case)",
@@ -537,8 +537,8 @@
     "id": "ann-634-similar-fails",
     "proofId": "erdos-634",
     "range": {
-      "startLine": 249,
-      "endLine": 251
+      "startLine": 262,
+      "endLine": 264
     },
     "type": "concept",
     "title": "Similar Dissection Failures: 2, 3, 5",
@@ -559,8 +559,8 @@
     "id": "ann-634-self-similar-def",
     "proofId": "erdos-634",
     "range": {
-      "startLine": 259,
-      "endLine": 264
+      "startLine": 272,
+      "endLine": 277
     },
     "type": "definition",
     "title": "Self-Similar Dissection",
@@ -582,8 +582,8 @@
     "id": "ann-634-sww",
     "proofId": "erdos-634",
     "range": {
-      "startLine": 266,
-      "endLine": 267
+      "startLine": 279,
+      "endLine": 280
     },
     "type": "concept",
     "title": "Snover–Waiveris–Williams Theorem",
@@ -605,8 +605,8 @@
     "id": "ann-634-zhang",
     "proofId": "erdos-634",
     "range": {
-      "startLine": 274,
-      "endLine": 274
+      "startLine": 287,
+      "endLine": 287
     },
     "type": "concept",
     "title": "Zhang's 2025 Sufficient Condition",
@@ -627,8 +627,8 @@
     "id": "ann-634-known-set",
     "proofId": "erdos-634",
     "range": {
-      "startLine": 276,
-      "endLine": 281
+      "startLine": 289,
+      "endLine": 294
     },
     "type": "definition",
     "title": "Known Dissectable Set",
@@ -649,8 +649,8 @@
     "id": "ann-634-partial",
     "proofId": "erdos-634",
     "range": {
-      "startLine": 289,
-      "endLine": 317
+      "startLine": 302,
+      "endLine": 330
     },
     "type": "concept",
     "title": "Erdős Problem #634 — Partial Answer",

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -57,8 +57,8 @@
     ],
     "axiomCount": 4,
     "assumptions": "4 axioms in Erdos634Problem.lean: Tiles (abstract tiling predicate), seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 5 sorries: the five positive-result stubs (squares/two/three/six/sum), each a genuine reptiling construction blocked only on Mathlib's missing polygonal-tiling API. SOUNDNESS (resolved): a prior version was internally inconsistent — the area-only IsDissectable is provable for every n >= 1 (constant equilateral witnesses of side 1/sqrt(n), proven in Erdos634AreaCollapse.lean), which contradicted the Beeson non-dissectability axioms; and congruent_implies_similar was a sorry on a false statement (unordered-multiset Congruent vs order-pinned Similar). Both are now fixed: IsDissectable additionally requires an abstract Tiles (covering + interior-disjointness) witness, blocking the trivial equal-area construction so Beeson's negatives are consistent; and Similar is restated on the unordered side multiset, making congruent_implies_similar a real 1-line proof. A faithful non-abstract Tiles still awaits a Mathlib tiling API (the oq-02 covering line).",
-    "lineCount": 373,
-    "theoremCount": 16,
+    "lineCount": 386,
+    "theoremCount": 17,
     "definitionCount": 20,
     "additionalFiles": [
       "Proofs/Erdos634Aristotle.lean",
@@ -145,39 +145,39 @@
       "title": "Open Cases",
       "summary": "Analyzes $n = 19$: proves it is prime (`by decide`), of form $4 \\cdot 4 + 3$, and that the refined $4k+3$ conjecture would imply $\\neg\\text{IsDissectable}\\, 19$.",
       "startLine": 212,
-      "endLine": 231,
+      "endLine": 244,
       "mathContext": "Verified: Analyzes $n = 19$: proves it is prime (`by decide`), of form $4 \\cdot 4 + 3$, and that the refined $4k+3$ conjecture would imply $\\neg\\text{IsDissectable}\\, 19$."
     },
     {
       "id": "soifer",
       "title": "Similar Triangles (Soifer's Result)",
       "summary": "Defines `IsSimilarDissection` and `IsSimilarDissectable`, then axiomatizes Soifer's complete theorem: all $n \\geq 1$ except $2, 3, 5$ admit similar dissections, with the three exceptions also axiomatized.",
-      "startLine": 232,
-      "endLine": 252,
+      "startLine": 245,
+      "endLine": 265,
       "mathContext": "Defines `IsSimilarDissection` and `IsSimilarDissectable`, then axiomatizes Soifer's complete theorem: all $n \\geq 1$ except $2, 3, 5$ admit similar dissections, with the three exceptions also axiomatized."
     },
     {
       "id": "self-similar",
       "title": "Self-Similar Dissections (Snover–Waiveris–Williams)",
       "summary": "Defines `IsSelfSimilarDissection` (pieces similar to the original) and axiomatizes the SWW characterization: $n$ is self-similar-dissectable iff $n \\in \\{k^2\\} \\cup \\{k^2 + m^2\\} \\cup \\{3k^2\\}$.",
-      "startLine": 253,
-      "endLine": 268,
+      "startLine": 266,
+      "endLine": 281,
       "mathContext": "Defines `IsSelfSimilarDissection` (pieces similar to the original) and axiomatizes the SWW characterization: $n$ is self-similar-dissectable iff $n \\in \\{$k^{2}$\\} \\cup \\{$k^{2}$ + m^2\\} \\cup \\{3k^2\\}$."
     },
     {
       "id": "recent",
       "title": "Recent Progress (Zhang 2025)",
       "summary": "Axiomatizes Zhang's 2025 result on sufficient conditions: for fixed $a \\geq b \\geq 1$, all sufficiently large $n^2 a b$ are dissectable. Also defines `KnownDissectable` as the union of all known parametric families.",
-      "startLine": 269,
-      "endLine": 283,
+      "startLine": 282,
+      "endLine": 296,
       "mathContext": "Axiomatizes Zhang's 2025 result on sufficient conditions: for fixed $a \\geq b \\geq 1$, all sufficiently large $n^2 a b$ are dissectable. Also defines `KnownDissectable` as the union of all known parametric families."
     },
     {
       "id": "main-result",
       "title": "Main Results — Erdős Problem #634",
       "summary": "The partial answer theorem `erdos_634_partial`: $\\forall k \\geq 1, \\text{IsDissectable}(k^2) \\wedge \\neg\\text{IsDissectable}\\, 7 \\wedge \\neg\\text{IsDissectable}\\, 11$, combining the grid subdivision theorem with Beeson's axioms.",
-      "startLine": 284,
-      "endLine": 331,
+      "startLine": 297,
+      "endLine": 344,
       "mathContext": "The partial answer theorem `erdos_634_partial`: $\\forall k \\geq 1, \\text{IsDissectable}(k^2) \\wedge \\neg\\text{IsDissectable}\\, 7 \\wedge \\neg\\text{IsDissectable}\\, 11$, combining the grid subdivision theorem with Beeson's axioms."
     }
   ],
@@ -201,9 +201,9 @@
       "Function"
     ],
     "namespace": "Erdos634",
-    "lineCount": 373,
+    "lineCount": 386,
     "axiomCount": 4,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 20,
     "sorries": 5,
     "path": "Proofs/Erdos634Problem.lean",


### PR DESCRIPTION
## Summary

The base file for Erdős #634 defines `KnownNonDissectable = {7, 11}` (line 222) but only ever used it for its arithmetic shape (`non_dissectable_form`, the 4k+3 form). The set's *name* asserts non-dissectability that the file never actually derived from Beeson's two axioms. This adds the missing bridge:

```lean
theorem knownNonDissectable_not_dissectable :
    ∀ n ∈ KnownNonDissectable, ¬ IsDissectable n := by
  intro n hn
  simp [KnownNonDissectable] at hn
  cases hn with
  | inl h => subst h; exact seven_not_dissectable
  | inr h => subst h; exact eleven_not_dissectable
```

Validates the set's naming and provides a single `n ∈ KnownNonDissectable → ¬ IsDissectable n` entry point.

- **0 new axioms** (still 4), **0 new sorries**. theoremCount 16→17.
- Proof mirrors the already-present, verified `non_dissectable_form` (same `simp [KnownNonDissectable]` → `n = 7 ∨ n = 11` → `cases`).
- The 5 remaining sorries (reptiling constructions) are untouched — they are blocked on a Mathlib polygonal-tiling API, not session-sized.

## Verification

**UNVERIFIED** — docker build infra is down this session (containerd `meta.db` input/output error; host has no prebuilt Mathlib cache). The proof is a by-eye-checkable copy of the adjacent verified sibling `non_dissectable_form`, using the in-scope axioms `seven_not_dissectable`/`eleven_not_dissectable` (declared above at lines 216/219).

Gallery meta/annotation line refs (≥231) shifted +13; lineCount 373→386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)