### PR TITLE
research(shannon-awgn-oq-03-oq-01): parallel Gaussian channel sum-capacity object

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03.lean
@@ -217,4 +217,68 @@ theorem shannonHartley_le_snr_linear {B P N : ℝ} (hB : 0 ≤ B) (hP : 0 ≤ P)
       ≤ B * ((P / N) / Real.log 2) := mul_le_mul_of_nonneg_left hlogb_le hB
     _ = B * (P / N) / Real.log 2 := by ring
 
+/-! ## Toward the vector channel: the parallel (multi-band) capacity
+
+    The bandlimited scalar formula above extends to a *bank* of `n` independent
+    Gaussian sub-channels — the discrete model of a frequency-selective (or
+    parallel-band) channel.  Splitting the spectrum into `n` narrowband slots
+    with signal powers `P i` and noise powers `N i`, the total capacity is the
+    *sum* of the per-band per-use capacities
+
+          Cᵥ(P, N) = Σᵢ awgnCapacity (Pᵢ, Nᵢ) = Σᵢ ½ log(1 + Pᵢ/Nᵢ)   [nats/use].
+
+    The water-filling *optimisation* — maximising this sum over the allocation
+    `P` subject to a total power budget `Σᵢ Pᵢ ≤ P` — is the genuinely separate
+    problem left open by this entry.  What follows is the additive capacity
+    object that water-filling optimises, together with its structural
+    (non-negativity / monotonicity) properties, each inherited term-by-term
+    from the scalar `awgnCapacity`. -/
+
+/-- The **sum capacity of a parallel (vector) AWGN channel**: `n` independent
+    Gaussian sub-channels with signal powers `P i` and noise powers `N i` have
+    total per-use capacity `Σᵢ awgnCapacity (P i) (N i) = Σᵢ ½ log(1 + Pᵢ/Nᵢ)`
+    nats. -/
+noncomputable def parallelAwgnCapacity {n : ℕ} (P N : Fin n → ℝ) : ℝ :=
+  ∑ i, awgnCapacity (P i) (N i)
+
+/-- The vector capacity written out explicitly as the sum of Shannon terms. -/
+theorem parallelAwgnCapacity_eq_sum {n : ℕ} (P N : Fin n → ℝ) :
+    parallelAwgnCapacity P N = ∑ i, (1 / 2) * Real.log (1 + P i / N i) :=
+  rfl
+
+/-- For a single sub-channel (`n = 1`) the vector capacity reduces to the
+    scalar per-use AWGN capacity. -/
+theorem parallelAwgnCapacity_one (P N : Fin 1 → ℝ) :
+    parallelAwgnCapacity P N = awgnCapacity (P 0) (N 0) := by
+  unfold parallelAwgnCapacity
+  rw [Fin.sum_univ_one]
+
+/-- The vector capacity is non-negative when every sub-channel has
+    non-negative signal power and positive noise power. -/
+theorem parallelAwgnCapacity_nonneg {n : ℕ} {P N : Fin n → ℝ}
+    (hP : ∀ i, 0 ≤ P i) (hN : ∀ i, 0 < N i) :
+    0 ≤ parallelAwgnCapacity P N := by
+  unfold parallelAwgnCapacity
+  exact Finset.sum_nonneg (fun i _ => awgn_capacity_nonneg (hP i) (hN i))
+
+/-- The vector capacity is monotone increasing in the signal-power allocation:
+    raising every sub-channel's power (weakly) cannot decrease total capacity.
+    This is the monotonicity against which a water-filling power budget is
+    spent. -/
+theorem parallelAwgnCapacity_mono_power {n : ℕ} {P₁ P₂ N : Fin n → ℝ}
+    (hN : ∀ i, 0 < N i) (hP₁ : ∀ i, 0 ≤ P₁ i) (h : ∀ i, P₁ i ≤ P₂ i) :
+    parallelAwgnCapacity P₁ N ≤ parallelAwgnCapacity P₂ N := by
+  unfold parallelAwgnCapacity
+  exact Finset.sum_le_sum
+    (fun i _ => awgn_capacity_mono_power (hN i) (hP₁ i) (h i))
+
+/-- The vector capacity is decreasing in the noise allocation: more noise in
+    any sub-channel (weakly) lowers the total capacity. -/
+theorem parallelAwgnCapacity_antitone_noise {n : ℕ} {P N₁ N₂ : Fin n → ℝ}
+    (hP : ∀ i, 0 ≤ P i) (hN₁ : ∀ i, 0 < N₁ i) (h : ∀ i, N₁ i ≤ N₂ i) :
+    parallelAwgnCapacity P N₂ ≤ parallelAwgnCapacity P N₁ := by
+  unfold parallelAwgnCapacity
+  exact Finset.sum_le_sum
+    (fun i _ => awgn_capacity_antitone_noise (hP i) (hN₁ i) (h i))
+
 end ShannonHartley

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-03/meta.json
@@ -13,10 +13,10 @@
       "ShannonAWGN"
     ],
     "namespace": "ShannonHartley",
-    "lineCount": 220,
+    "lineCount": 284,
     "axiomCount": 0,
-    "theoremCount": 11,
-    "definitionCount": 1,
+    "theoremCount": 17,
+    "definitionCount": 2,
     "path": "Proofs/ShannonChannelCodingAWGNOQ03.lean",
     "sorries": 0
   },
@@ -38,9 +38,9 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 220,
-    "theoremCount": 11,
-    "definitionCount": 1,
+    "lineCount": 284,
+    "theoremCount": 17,
+    "definitionCount": 2,
     "badge": "verified",
     "originalContributions": [
       "shannonHartley_eq_awgn: the bridge identity C(B, P, N) = (2B / log 2)·awgnCapacity P N. This is the precise formal content of 'Nyquist sampling + change of logarithm base': the per-use AWGN capacity awgnCapacity P N = ½ log(1 + P/N) (nats per channel use, from the parent file) is multiplied by the Nyquist factor 2B (independent dimensions per second) and divided by log 2 (the nats→bits change of base), yielding the bits-per-second Shannon–Hartley value. It ties the bandlimited formula directly to the parent's verified per-use quantity rather than re-deriving it.",


### PR DESCRIPTION
## Summary

Advances the still-open half of `shannon-channel-coding-awgn-oq-03`. The entry's scope note formalises the *scalar* bandlimited Shannon–Hartley capacity $C = B\log_2(1+P/N)$ exactly, and explicitly leaves open the **vector / parallel Gaussian channel** (water-filling) extension. This PR builds the additive capacity object that water-filling optimises and proves its structural properties.

### New declarations (in `ShannonHartley`, on `ShannonChannelCodingAWGNOQ03.lean`)

- `parallelAwgnCapacity {n} (P N : Fin n → ℝ) := ∑ i, awgnCapacity (P i) (N i)` — the per-use sum capacity of a bank of `n` independent AWGN sub-channels, i.e. $\sum_i \tfrac12\log(1+P_i/N_i)$ nats.
- `parallelAwgnCapacity_eq_sum` — explicit Shannon-term form.
- `parallelAwgnCapacity_one` — for `n = 1` reduces to the scalar `awgnCapacity`.
- `parallelAwgnCapacity_nonneg` — non-negative when every $P_i \ge 0$, $N_i > 0$.
- `parallelAwgnCapacity_mono_power` — monotone in the power allocation (the monotonicity a water-filling budget is spent against).
- `parallelAwgnCapacity_antitone_noise` — antitone in the noise allocation.

Each structural fact is inherited term-by-term from the verified scalar siblings (`awgn_capacity_nonneg`, `awgn_capacity_mono_power`, `awgn_capacity_antitone_noise`) via standard `Finset.sum_nonneg` / `Finset.sum_le_sum`. The **water-filling optimisation** (maximising the sum under $\sum_i P_i \le P$) remains genuinely open.

### Axioms / status
0 new `sorry`, 0 new `axiom`. No new assumptions. Additions are 0-sorry structural corollaries of the existing verified base.

### ⚠️ Verification status: UNVERIFIED (build blocked)
Docker build infrastructure is down this session (containerd `meta.db` input/output error at image build; host disk healthy, 112 GiB free), so `docker-build.sh Proofs.ShannonChannelCodingAWGNOQ03` could not run. The additions are pure assembly over standard `Finset` API mirroring the file's already-verified scalar monotonicity lemmas line-for-line; elaboration confidence is high but a green build should be confirmed once infra recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)