### PR TITLE
research(erdos-1014-oq-03): increment undetermined even under normalized-increment regularity [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1014OQ03Obstruction.lean
+++ b/proofs/Proofs/Erdos1014OQ03Obstruction.lean
@@ -156,4 +156,25 @@ theorem increment_asymptotic_not_determined_by_asymptotic_class :
       ¬ Tendsto (fun l => (v (l + 1) - v l) / (u (l + 1) - u l)) atTop (𝓝 1) :=
   ⟨u, v, u_pos, v_pos, asymptotic_equiv, increment_ratio_not_tendsto_one⟩
 
+/-- **Increment undetermined even under normalized-increment regularity (sharpened
+existential).**
+
+A strengthening of `increment_asymptotic_not_determined_by_asymptotic_class`: the two
+witnesses can additionally be required to have `u` *normalized-increment regular*, i.e.
+`(u(l+1) − u(l))/u(l) → 0`.  So even when the sequences are asymptotically equivalent
+**and** the base sequence's own jumps are `o(u)` — the natural first-order smoothness
+hypothesis one might hope to leverage — the consecutive-increment ratio still fails to
+tend to `1`.  Hence a normalized-increment (`o(R)`-scale) regularity assumption on the
+sequence does **not** substitute for the honest increment–ratio bridge, which
+hypothesizes the consecutive ratio directly. -/
+theorem increment_asymptotic_not_determined_under_normalized_regularity :
+    ∃ u v : ℕ → ℝ,
+      (∀ᶠ l in atTop, 0 < u l) ∧
+      (∀ᶠ l in atTop, 0 < v l) ∧
+      Tendsto (fun l => v l / u l) atTop (𝓝 1) ∧
+      Tendsto (fun l => (u (l + 1) - u l) / u l) atTop (𝓝 0) ∧
+      ¬ Tendsto (fun l => (v (l + 1) - v l) / (u (l + 1) - u l)) atTop (𝓝 1) :=
+  ⟨u, v, u_pos, v_pos, asymptotic_equiv, u_normalizedIncrement_tendsto_zero,
+    increment_ratio_not_tendsto_one⟩
+
 end Erdos1014OQ03Obstruction

--- a/src/data/research/problems/erdos-1014-oq-03.json
+++ b/src/data/research/problems/erdos-1014-oq-03.json
@@ -47,10 +47,12 @@
       "increment_div_eq_ratio_sub_one — (R(l+1)-R(l))/R(l) = R(l+1)/R(l)-1 (algebraic engine).",
       "increment_div_tendsto_zero_iff_ratio_tendsto_one — normalized increment ->0 IFF consecutive ratio ->1; converts #1014's ratio convergence into Delta_l(k)=o(R(k,l)).",
       "increment_div_tendsto_zero_of_ratio_tendsto_one — forward corollary packaged for direct use.",
-      "Erdos1014OQ03Obstruction.lean: increment_asymptotic_not_determined_by_asymptotic_class (packaged existential) + increment_ratio_not_tendsto_one (crux, even-subsequence limit-uniqueness argument) + asymptotic_equiv (u~v via squeeze (-1)^l/l -> 0) + u_increment/v_increment closed forms. 0 axiom/0 sorry, UNVERIFIED (docker image-build down: containerd meta.db I/O error)."
+      "Erdos1014OQ03Obstruction.lean: increment_asymptotic_not_determined_by_asymptotic_class (packaged existential) + increment_ratio_not_tendsto_one (crux, even-subsequence limit-uniqueness argument) + asymptotic_equiv (u~v via squeeze (-1)^l/l -> 0) + u_increment/v_increment closed forms. 0 axiom/0 sorry, UNVERIFIED (docker image-build down: containerd meta.db I/O error).",
+      "increment_asymptotic_not_determined_under_normalized_regularity in Erdos1014OQ03Obstruction.lean — sharpened capstone existential: witnesses u,v can additionally be required normalized-increment-regular ((u(l+1)-u l)/u l → 0) while the increment ratio still fails to tend to 1"
     ],
     "insights": [
-      "The consecutive increment of a sequence is provably NOT a function of its asymptotic (~) equivalence class: witness u l = l, v l = l + (-1)^l have v/u -> 1 (u ~ v) yet increment ratio (v(l+1)-v l)/(u(l+1)-u l) = 1 - 2(-1)^l does not converge (=-1 on evens, =3 on odds). This is the rigorous form of the prose sin-based caution and formally justifies why the naive power-law Approach A is invalid."
+      "The consecutive increment of a sequence is provably NOT a function of its asymptotic (~) equivalence class: witness u l = l, v l = l + (-1)^l have v/u -> 1 (u ~ v) yet increment ratio (v(l+1)-v l)/(u(l+1)-u l) = 1 - 2(-1)^l does not converge (=-1 on evens, =3 on odds). This is the rigorous form of the prose sin-based caution and formally justifies why the naive power-law Approach A is invalid.",
+      "Adding the base sequence u its own o(u)-scale (normalized-increment) regularity does NOT rescue increment-ratio convergence; asymptotic equivalence + first-order smoothness of u together are still insufficient, so the honest increment-ratio bridge is unavoidable"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Sharpens the capstone obstruction of the Erdős #1014 OQ-03 increment theory. The existing headline `increment_asymptotic_not_determined_by_asymptotic_class` shows asymptotic equivalence (`v/u → 1`) alone does not force the consecutive-increment ratio `(v(l+1)−v l)/(u(l+1)−u l)` to tend to 1.

This adds `increment_asymptotic_not_determined_under_normalized_regularity`, which additionally requires the base sequence `u` to be **normalized-increment regular** — `(u(l+1)−u l)/u l = 1/l → 0` — while the increment ratio *still* fails to converge. So even asymptotic equivalence **plus** first-order (o(R)-scale) smoothness of the base sequence is insufficient to determine the increment asymptotic; the honest increment–ratio bridge (which hypothesizes the consecutive ratio directly) is unavoidable.

Witnesses: `u l = l`, `v l = l + (−1)^l`.

## Nature of the change

Pure anonymous-constructor assembly of already-established lemmas in the same file: `u_pos`, `v_pos`, `asymptotic_equiv`, `u_normalizedIncrement_tendsto_zero`, `increment_ratio_not_tendsto_one`. Self-contained on `origin/main` — no dependency on the in-flight v-companion PR (#37124).

## Verification

⚠️ **UNVERIFIED** — docker build infrastructure is down this session (containerd `meta.db` input/output error at image-build; host disk healthy, 112 GiB free). The added theorem is a direct assembly of existing verified lemmas whose types match the stated conjuncts by inspection. Should be re-verified once docker recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)