### PR TITLE
research(hilbert-17-oq-03-oq-05): sharp SOS threshold of the Motzkin family (SOS ⟺ c ≤ 0)

### DIFF
--- a/proofs/Proofs/Hilbert17OQ03OQ05.lean
+++ b/proofs/Proofs/Hilbert17OQ03OQ05.lean
@@ -339,6 +339,39 @@ theorem motzkinPoly_psd_not_sos {c : ℝ} (hc0 : 0 < c) (hc3 : c ≤ 3) :
     IsPSDMv (motzkinPoly c) ∧ ¬ Hilbert17MotzkinNotSOS.IsSOS (motzkinPoly c) :=
   ⟨(motzkinPoly_psd_iff c).2 hc3, motzkinPoly_not_sos hc0⟩
 
+/-- **SOS membership at `c ≤ 0`.** For a nonpositive coefficient the `−c·x²y²` term has a
+    nonnegative sign, so `motzkinPoly c` is a genuine sum of four squares,
+
+        Mₐ = (x²y)² + (xy²)² + 1² + (√(-c)·xy)²,
+
+    the last square carrying the coefficient `(√(-c))² = -c ≥ 0`.  This is the exact
+    complement of `motzkinPoly_not_sos` (which fails for `c > 0`). -/
+theorem motzkinPoly_sos_of_nonpos {c : ℝ} (hc : c ≤ 0) :
+    Hilbert17MotzkinNotSOS.IsSOS (motzkinPoly c) := by
+  refine ⟨4, ![X 0 ^ 2 * X 1, X 0 * X 1 ^ 2, 1, C (Real.sqrt (-c)) * (X 0 * X 1)], ?_⟩
+  have hsq : (C (Real.sqrt (-c)) : MvPolynomial (Fin 2) ℝ) ^ 2 = - C c := by
+    rw [← map_pow, Real.sq_sqrt (by linarith : (0 : ℝ) ≤ -c), map_neg]
+  rw [motzkinPoly, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons, Matrix.cons_val_three, mul_pow]
+  rw [hsq]
+  ring
+
+/-- **Sharp SOS threshold of the Motzkin family: `SOS ⟺ c ≤ 0`.** Combining
+    `motzkinPoly_sos_of_nonpos` (`c ≤ 0 ⟹ SOS`) with `motzkinPoly_not_sos`
+    (`c > 0 ⟹ not SOS`).  The SOS threshold `c ≤ 0` sits strictly below the PSD
+    threshold `c ≤ 3` (`motzkinPoly_psd_iff`): the entire segment `0 < c ≤ 3` is
+    PSD-but-not-SOS, a one-parameter family of witnesses to the Hilbert-17 gap with the
+    Motzkin polynomial (`c = 3`) at the far PSD-boundary end. -/
+theorem motzkinPoly_sos_iff (c : ℝ) :
+    Hilbert17MotzkinNotSOS.IsSOS (motzkinPoly c) ↔ c ≤ 0 := by
+  constructor
+  · intro hsos
+    by_contra hc
+    push_neg at hc
+    exact motzkinPoly_not_sos hc hsos
+  · exact motzkinPoly_sos_of_nonpos
+
 /-! ## Structure of the family: the diagonal value, the boundary zero, monotonicity
 
 Three elementary structural facts that expose *why* `c = 3` is the sharp threshold.

--- a/research/problems/hilbert-17-oq-03/knowledge.md
+++ b/research/problems/hilbert-17-oq-03/knowledge.md
@@ -527,3 +527,26 @@ undercount; 16 is the true comment-stripped count).
 QuadraticGram, MotzkinNotSOS, UnivariatePSDSOS), then my own file on the next two passes —
 pure fleet-memory volume corruption, elaboration was clean each time (no line numbers).
 Retry-loop-of-3 at LEAN_MEMORY_LIMIT=24576 went green.
+
+## Session 2026-07-09 (researcher-3) — sharp SOS threshold of the Motzkin family (VERIFIED)
+
+Worked in the oq-03 subtree file `Hilbert17OQ03OQ05.lean` (Motzkin family Mₐ = x⁴y²+x²y⁴+1−c·x²y²).
+It already proved PSD threshold `IsPSD ↔ c ≤ 3` and SOS FAILURE for all `c > 0`
+(`motzkinPoly_not_sos`), but never the complementary SOS-membership side. Added:
+
+- `motzkinPoly_sos_of_nonpos` (c ≤ 0 ⟹ IsSOS): explicit sum of four squares
+  `(x²y)² + (xy²)² + 1² + (√(-c)·xy)²` — the last carrying `(√(-c))² = -c ≥ 0`.
+- `motzkinPoly_sos_iff`: **IsSOS ↔ c ≤ 0**, the sharp SOS threshold, strictly below the PSD
+  threshold `c ≤ 3`, so the whole segment `0 < c ≤ 3` is PSD-but-not-SOS.
+
+Proof gotcha: `refine ⟨4, ![...], ?_⟩`; after `rw [motzkinPoly, Fin.sum_univ_four]` reduce the
+`![...] i` with `simp only [Matrix.cons_val_zero/one/two/three, head_cons, tail_cons, mul_pow]`
+— fold `mul_pow` INTO the simp (a bare `rw [mul_pow]` only rewrites the FIRST square, leaving the
+`C√(-c)` term unexpanded so `rw [hsq]` can't find its pattern). Then `rw [hsq]` (with
+`hsq : (C √(-c))^2 = -C c` via `← map_pow, Real.sq_sqrt, map_neg`) and `ring`.
+
+VERIFIED green via direct lean-elab vs pinned Mathlib v4.26.0 (docker containerd blob I/O down):
+built `Proofs.Hilbert17MotzkinNotSOS` dep olean into /tmp (Mathlib-only), elaborated target — exit 0,
+`#print axioms` on both = `[propext, Classical.choice, Quot.sound]`. Gallery meta hilbert-17-oq-03-oq-05:
+lineCount 386→419, theoremCount 25→27. Parent hilbert-17-oq-03 itself (complexity of DECIDING SOS)
+remains an open complexity question with no dedicated file — not a session-sized target.

--- a/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
@@ -48,7 +48,7 @@
       "The arithmetic–geometric mean (AM–GM) inequality and sum-of-squares certificates for non-negativity.",
       "Evaluation of multivariate polynomials and the PSD predicate ∀ v, 0 ≤ eval v p."
     ],
-    "lineCount": 386,
+    "lineCount": 419,
     "relatedProblems": [
       {
         "id": "hilbert-17-oq-03-oq-02",
@@ -68,19 +68,19 @@
       }
     ],
     "assumptions": "0 axioms. #print axioms reports only propext, Classical.choice, Quot.sound for motzkinFun_psd_iff, motzkinPoly_psd_iff, three_is_sharp, and motzkin_amgm. No sorryAx, no native_decide / Lean.ofReduceBool. The MvPolynomial PSD predicate IsPSDMv matches the parent entry's IsPositiveSemidefiniteMv definitionally.",
-    "theoremCount": 25,
+    "theoremCount": 27,
     "definitionCount": 3,
     "additionalFiles": []
   },
   "leanFile": {
-    "lineCount": 386,
+    "lineCount": 419,
     "namespace": "Hilbert17OQ03OQ05",
     "opens": [
       "MvPolynomial"
     ],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 27,
     "substantiveTheoremCount": 9,
     "computationalVerifications": 0,
     "lemmaCount": 0,


### PR DESCRIPTION
## Summary

The Motzkin-family file `Hilbert17OQ03OQ05.lean` (`Mₐ = x⁴y² + x²y⁴ + 1 − c·x²y²`) already establishes the **PSD threshold** `IsPSD ↔ c ≤ 3` (`motzkinPoly_psd_iff`) and **SOS failure** for every `c > 0` (`motzkinPoly_not_sos`), but never the complementary SOS-membership side. This PR closes that:

- **`motzkinPoly_sos_of_nonpos`** — for `c ≤ 0`, `motzkinPoly c` **is** a sum of squares, exhibited explicitly as the sum of four squares $(x^2y)^2 + (xy^2)^2 + 1^2 + (\sqrt{-c}\,xy)^2$, the last carrying the coefficient $(\sqrt{-c})^2 = -c \ge 0$.
- **`motzkinPoly_sos_iff`** — the sharp SOS threshold `IsSOS ↔ c ≤ 0`, obtained by combining the above with `motzkinPoly_not_sos`.

The SOS threshold `c ≤ 0` sits **strictly below** the PSD threshold `c ≤ 3`, so the entire segment `0 < c ≤ 3` is PSD-but-not-SOS — a crisp, quantitative separation of the two cones on this one-parameter family, with the Motzkin polynomial (`c = 3`) at the far PSD-boundary end.

## Verification

Docker containerd blob I/O errors (new `docker run` blocked); verified via direct `lean` elaboration against pinned Mathlib v4.26.0 (temp-built the Mathlib-only `Proofs.Hilbert17MotzkinNotSOS` dep olean, then elaborated the target with it on `LEAN_PATH`):

- Exit 0, no errors.
- `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]`.

Gallery meta `hilbert-17-oq-03-oq-05` synced: lineCount 386→419, theoremCount 25→27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)