### PR TITLE
Fix: resync lineCount for erdos-378 and elementary-quadratic-reciprocity-oq-03-oq-02

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "theoremCount": 56,
     "defCount": 4,
-    "lineCount": 879,
+    "lineCount": 897,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,7 +97,7 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 879,
+    "lineCount": 897,
     "axiomCount": 0,
     "theoremCount": 56,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -64,7 +64,7 @@
       "erdos_378, erdos_378_answer (no sorries): combined resolution of both questions"
     ],
     "axiomCount": 2,
-    "lineCount": 403,
+    "lineCount": 432,
     "assumptions": "2 axioms, both isolating the deep analytic content of Granville-Ramaré (1996): granville_ramare_density_exists (the density η_m of n with exactly 2m+2 squarefree binomials exists) and complement_density (the set of n with fewer than r squarefree binomials has density Σ_{0≤m≤(r-1)/2} η_m, which is < 1). 0 sorries. All other results, including the resolution of both questions and the parity theorems squarefreeCount_even_of_odd (odd rows have an even count) and squarefreeCount_odd_iff_central_squarefree (an even row has an odd count iff its central binomial C(n,n/2) is squarefree), are fully machine-checked (depend only on propext/Classical.choice/Quot.sound).",
     "theoremCount": 12,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Resync stale `lineCount` metadata for two gallery entries whose Lean source grew via merged research PRs without a corresponding meta update. Neither is covered by any open PR.

## Evidence

**erdos-378** (`Proofs/Erdos378Problem.lean`, 432 lines actual):
- `meta.lineCount`: 403 → 432 (`leanFile.lineCount` was already correct at 432)

**elementary-quadratic-reciprocity-oq-03-oq-02** (`Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean`, 897 lines actual):
- `meta.lineCount`: 879 → 897
- `leanFile.lineCount`: 879 → 897

Metadata-only change (3 lines). No Lean source touched.

---
Automated fix by lean-mechanic agent.