### PR TITLE
Enrich Erdős #1026 OQ-02: sibling xref + tolerance-monotonicity annotation

### DIFF
--- a/src/data/proofs/erdos-1026-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1026-oq-02/annotations.json
@@ -54,6 +54,28 @@
     ]
   },
   {
+    "id": "tolerance-mono",
+    "proofId": "erdos-1026-oq-02",
+    "range": {
+      "startLine": 100,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "A Larger Tolerance Is a Weaker Constraint",
+    "content": "isApproxIncreasing_mono (and its dual isApproxDecreasing_mono) prove monotonicity of the predicate in the tolerance parameter: if ε₁ ≤ ε₂ then IsApproxIncreasing ε₁ implies IsApproxIncreasing ε₂. The proof is one line — the ε₁-approximate inequality seq(idxᵢ) − ε₁ < seq(idxⱼ) already implies the slacker seq(idxᵢ) − ε₂ < seq(idxⱼ) because subtracting a larger number lowers the threshold (linarith with hε). Together with the ε = 0 coincidence this makes the approximate notions a nested one-parameter family: the sets of ε-approximately monotonic subsequences grow monotonically from the classical set at ε = 0.",
+    "mathContext": "$\\varepsilon_1 \\le \\varepsilon_2 \\Rightarrow \\mathrm{ApproxInc}_{\\varepsilon_1} \\subseteq \\mathrm{ApproxInc}_{\\varepsilon_2}$; the threshold $\\mathrm{seq}(\\iota_i) - \\varepsilon$ only decreases as $\\varepsilon$ grows.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotone parameter family",
+      "nested predicate sets",
+      "linarith"
+    ],
+    "prerequisites": [
+      "IsApproxIncreasing definition",
+      "order on ℝ"
+    ]
+  },
+  {
     "id": "containment",
     "proofId": "erdos-1026-oq-02",
     "range": {

--- a/src/data/proofs/erdos-1026-oq-02/meta.json
+++ b/src/data/proofs/erdos-1026-oq-02/meta.json
@@ -108,6 +108,11 @@
       "targetId": "erdos-1026",
       "relationship": "extends",
       "description": "Parent gallery proof: Erdős Problem #1026 (monotonic subsequence sum optimization), whose Erdős–Szekeres length guarantee is the bound this entry relaxes."
+    },
+    {
+      "targetId": "erdos-1026-oq-05",
+      "relationship": "sibling",
+      "description": "Companion open question of #1026 that pushes in the orthogonal direction: instead of relaxing single-subsequence monotonicity by a tolerance ε, OQ-05 studies decompositions of the whole sequence into monotonic pieces (Hanani's 1957 theorem, MonotonicDecomposition) and bounds the number of parts. Both isolate and settle the axiom-free easy half of their respective questions on the same Subsequence interface, leaving the quantitative optimum open."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass on `erdos-1026-oq-02`.

**Gaps addressed:**
- **crossReferences (1 → 2):** the entry linked only its parent `erdos-1026`. Added a `sibling` link to `erdos-1026-oq-05` (the orthogonal open question: monotonic *decompositions* / Hanani 1957 vs. this entry's ε-tolerance relaxation), both settling the axiom-free easy half on the same Subsequence interface.
- **Annotation coverage:** lines 100–113 (`isApproxIncreasing_mono` / `isApproxDecreasing_mono`, the 'larger ε is a weaker constraint' direction) were uncovered. Added `tolerance-mono` annotation explaining the nested one-parameter family framing.

meta.json 13.6KB → 14.1KB (well under cap). JSON validates; gallery data-validation stages pass; annotations land on constructs. Content preserved; only additive.