### PR TITLE
research(erdos-1138-oq-03-oq-01): complete the abstract sublinearity-engine family (=O and =o id)

### DIFF
--- a/proofs/Proofs/Erdos1138OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1138OQ03OQ01.lean
@@ -260,6 +260,36 @@ theorem gap_isLittleO_rpow_of_rpow_bound {θ a : ℝ} (hθa : θ < a)
   rw [h0] at hrp
   exact absurd hrp (lt_irrefl 0)
 
+/-- **Master engine, big-O idiom.** Any eventual power envelope `maxPrimeGap x ≤ x^θ`
+already gives `maxPrimeGap =O[atTop] (x ↦ x^θ)` — the envelope *is* the big-O witness (constant
+`1`), no sublinearity of `θ` required. This is the abstract counterpart of `gap_isBigO_rpow`
+(which fixes `θ = 0.525` and uses `baker_harman_pintz`); together with the little-o and `Tendsto`
+engines above it completes the abstract family, matching the concrete BHP family term for term. -/
+theorem gap_isBigO_rpow_of_rpow_bound {θ : ℝ}
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
+    (fun x : ℕ => (maxPrimeGap x : ℝ)) =O[atTop] (fun x : ℕ => (x : ℝ) ^ θ) := by
+  rw [isBigO_iff]
+  refine ⟨1, ?_⟩
+  filter_upwards [H, eventually_ge_atTop 1] with x hx hx1
+  have hnn : (0 : ℝ) ≤ (x : ℝ) ^ θ := Real.rpow_nonneg (Nat.cast_nonneg x) _
+  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs,
+    abs_of_nonneg (Nat.cast_nonneg (maxPrimeGap x)), abs_of_nonneg hnn]
+  exact hx
+
+/-- **Master engine, little-o against `id`.** From *any* eventual power envelope
+`maxPrimeGap x ≤ x^θ` with sub-linear exponent `θ < 1`, `maxPrimeGap =o[atTop] id`. This is the
+abstract counterpart of `bhp_gap_isLittleO_id` (the BHP instance `θ = 0.525`), and the `=o id`
+twin of the `Tendsto (·/x)` engine `gap_littleo_of_rpow_bound`. It is *not* subsumed by
+`gap_isLittleO_rpow_of_rpow_bound` at `a = 1`, whose target `x^1` differs from `id`. -/
+theorem gap_isLittleO_id_of_rpow_bound {θ : ℝ} (hθ : θ < 1)
+    (H : ∀ᶠ x : ℕ in atTop, (maxPrimeGap x : ℝ) ≤ (x : ℝ) ^ θ) :
+    (fun x : ℕ => (maxPrimeGap x : ℝ)) =o[atTop] (fun x : ℕ => (x : ℝ)) := by
+  refine (isLittleO_iff_tendsto' ?_).mpr (gap_littleo_of_rpow_bound hθ H)
+  filter_upwards [eventually_ge_atTop 1] with x hx h0
+  have hxpos : (0 : ℝ) < (x : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one hx
+  rw [h0] at hxpos
+  exact absurd hxpos (lt_irrefl 0)
+
 -- ============================================================================
 -- Individual-gap bridge: from the maximal gap `sSup` back to actual gaps
 -- ============================================================================

--- a/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03-oq-01/meta.json
@@ -49,9 +49,9 @@
     "dateAdded": "2026-07-05",
     "mathlib_version": "4.26.0",
     "axiomCount": 1,
-    "lineCount": 328,
+    "lineCount": 358,
     "assumptions": "1 axiom, inherited from the parent Erdos1138OQ03: baker_harman_pintz (maxPrimeGap x <= x^0.525 for x >= 25). No axiom is declared in this file (leanFile.axiomCount = 0); the assumption is imported. #print axioms confirms the results depend only on {propext, Classical.choice, Quot.sound, Erdos1138OQ03.baker_harman_pintz}. No sorries, no native_decide.",
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 0
   },
   "overview": {
@@ -140,9 +140,9 @@
       "Topology"
     ],
     "namespace": "Erdos1138OQ03",
-    "lineCount": 328,
+    "lineCount": 358,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 0,
     "path": "Proofs/Erdos1138OQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The entry `Erdos1138OQ03OQ01` derives unconditional sublinearity of prime gaps from the Baker–Harman–Pintz bound, and abstracts the argument into *engines* that take an arbitrary eventual envelope `maxPrimeGap x ≤ x^θ`. The abstract family already had the `Tendsto` and little-o (`x^a`) forms, but was **missing the `=O` and `=o id` idioms** that the concrete BHP family (`gap_isBigO_rpow`, `bhp_gap_isLittleO_id`) provides. This PR fills that gap, making the abstract family a term-for-term mirror of the concrete one.

## What's added

- **`gap_isBigO_rpow_of_rpow_bound`** — any eventual envelope `maxPrimeGap x ≤ x^θ` gives `maxPrimeGap =O[atTop] (x ↦ x^θ)` (the envelope *is* the big-O witness, constant `1`; no sublinearity of `θ` needed). Abstract twin of `gap_isBigO_rpow`.
- **`gap_isLittleO_id_of_rpow_bound`** — a sub-linear envelope (`θ < 1`) gives `maxPrimeGap =o[atTop] id`. Abstract twin of `bhp_gap_isLittleO_id`, and the `=o id` form of the `Tendsto (·/x)` engine `gap_littleo_of_rpow_bound`. It is genuinely distinct from `gap_isLittleO_rpow_of_rpow_bound` at `a = 1`, whose target `x^1` differs from `id`.

The abstract engine family now covers every idiom of the concrete BHP family: `=O`, `=o id`, `=o x^a`, `Tendsto (·/x)`, `Tendsto (·/x^a)`.

## Verification status

**UNVERIFIED** — Docker build infrastructure is down this session (containerd `meta.db` input/output error; host disk healthy at 112 GiB). Both proofs are line-for-line copies of the verified siblings `gap_isBigO_rpow` and `bhp_gap_isLittleO_id`, substituting the abstract hypothesis `H`/`hθ` for the concrete `baker_harman_pintz` input; purely additive (30 insertions, 0 deletions). No new axioms. Meta counts synced (lineCount 328→358, theoremCount +2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)