### PR TITLE
research(szemeredi-regularity-oq-01): irregular-pair monotonicity in the partition

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ01.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ01.lean
@@ -298,6 +298,30 @@ theorem card_irregularOrderedPairs_antitone (G : SimpleGraph V) [DecidableRel G.
     (irregularOrderedPairs G eps₂ parts).card ≤ (irregularOrderedPairs G eps₁ parts).card :=
   Finset.card_le_card (irregularOrderedPairs_antitone G h parts)
 
+/-- **The irregular-pair set is monotone in the vertex partition.**  Enlarging the pool of
+    parts can only add ordered irregular pairs: if `parts₁ ⊆ parts₂` then every irregular
+    ordered pair over `parts₁` is also one over `parts₂`.  The `eps`-parameter monotonicity
+    (`irregularOrderedPairs_antitone`) and this partition monotonicity are the two ways the
+    irregular set can grow — coarser `eps` (smaller parameter) or a larger set of parts.
+    The filter predicate `p.1 ≠ p.2 ∧ ¬IsEpsilonRegular …` is independent of the partition,
+    so the containment is inherited directly from `parts₁ ×ˢ parts₁ ⊆ parts₂ ×ˢ parts₂`. -/
+theorem irregularOrderedPairs_mono_parts (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) {parts₁ parts₂ : Finset (Finset V)} (h : parts₁ ⊆ parts₂) :
+    irregularOrderedPairs G eps parts₁ ⊆ irregularOrderedPairs G eps parts₂ := by
+  intro x hx
+  simp only [irregularOrderedPairs, Finset.mem_filter, Finset.mem_product] at hx ⊢
+  obtain ⟨⟨h1, h2⟩, hne, hreg⟩ := hx
+  exact ⟨⟨h h1, h h2⟩, hne, hreg⟩
+
+/-- **The irregular-pair count is monotone (non-decreasing) in the partition.**  Cardinality
+    form of `irregularOrderedPairs_mono_parts`: refining a partition — passing to any
+    superset of parts — can only increase the number of ordered irregular pairs.  The
+    partition-side counterpart of `card_irregularOrderedPairs_antitone`. -/
+theorem card_irregularOrderedPairs_mono_parts (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) {parts₁ parts₂ : Finset (Finset V)} (h : parts₁ ⊆ parts₂) :
+    (irregularOrderedPairs G eps parts₁).card ≤ (irregularOrderedPairs G eps parts₂).card :=
+  Finset.card_le_card (irregularOrderedPairs_mono_parts G eps h)
+
 /-- **A partition is exactly as irregular for `Gᶜ` as for `G`.**  Lifting the per-pair
     `isEpsilonRegular_compl` to the whole partition: for a positive parameter `eps` and a
     family of *pairwise-disjoint, nonempty* parts (the standing hypotheses of a genuine


### PR DESCRIPTION
## Summary
Adds the **partition-side monotonicity** of the ordered irregular-pair set to the saturated (0-axiom/0-sorry, graduated) `SzemerediRegularityOQ01.lean`, completing the top open item in the problem's `knowledge.md`.

- `irregularOrderedPairs_mono_parts`: `parts₁ ⊆ parts₂ ⟹ irregularOrderedPairs G eps parts₁ ⊆ irregularOrderedPairs G eps parts₂`.
- `card_irregularOrderedPairs_mono_parts`: the cardinality corollary (`Finset.card_le_card`).

Partition-side counterparts of the existing `eps`-parameter lemmas `irregularOrderedPairs_antitone` / `card_irregularOrderedPairs_antitone`.

## Proof
Line-for-line mirror of the verified `irregularOrderedPairs_antitone`: the filter predicate is partition-independent, so containment is inherited from `parts₁ ×ˢ parts₁ ⊆ parts₂ ×ˢ parts₂`. 0 axioms, 0 sorries.

## Verification status
**UNVERIFIED** — docker build infra down (containerd meta.db I/O error at image build; disk healthy). High confidence: direct structural mirror of an already-verified sibling in the same file.