### PR TITLE
Enrich Abel–Ruffini S₄ threshold: add foundational Ruffini/Abel/Galois references

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-06-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01/meta.json
@@ -138,6 +138,33 @@
       "year": "2015",
       "venue": "4th ed., Chapman & Hall/CRC",
       "note": "Insolvability of the quintic, transitive Galois groups, and radical solvability."
+    },
+    {
+      "authors": [
+        "Ruffini, P."
+      ],
+      "title": "Teoria generale delle equazioni, in cui si dimostra impossibile la soluzione algebraica delle equazioni generali di grado superiore al quarto",
+      "year": "1799",
+      "venue": "Bologna",
+      "note": "The first (incomplete) argument that the general equation of degree > 4 is not solvable by radicals — the historical origin of the solvable/unsolvable threshold this entry pins at n = 4."
+    },
+    {
+      "authors": [
+        "Abel, N.H."
+      ],
+      "title": "Mémoire sur les équations algébriques, où l'on démontre l'impossibilité de la résolution de l'équation générale du cinquième degré",
+      "year": "1824",
+      "venue": "Christiania (Oslo)",
+      "note": "Abel's complete proof of the insolvability of the general quintic — the 'n ≥ 5' side complementary to the solvable cases n ≤ 4 this entry closes with S₄."
+    },
+    {
+      "authors": [
+        "Galois, É."
+      ],
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
+      "year": "1846",
+      "venue": "Journal de Mathématiques Pures et Appliquées 11, 417–433 (posthumous, ed. Liouville)",
+      "note": "The group-theoretic criterion: an equation is solvable by radicals iff its Galois group is solvable. The Sₙ-solvability threshold formalized here is exactly this criterion for the general degree-n equation."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-06-oq-01` (quality 95, pass 0).

Annotations (all theorems covered), keyInsights (4), historicalContext, sections, conclusion (3 open questions), and crossReferences (2, both verified) were all at target. The one thin field was **references** — only two modern textbooks (Dummit–Foote, Stewart) for a landmark theorem whose whole point is historical.

Added the three foundational primary sources (2 → 5, well under cap 25):
- **Ruffini (1799)** — the first (incomplete) argument for insolvability of degree > 4, the historical origin of the threshold this entry pins at n = 4;
- **Abel (1824)** — the complete proof of quintic insolvability, the n ≥ 5 side complementary to the solvable cases n ≤ 4 closed here with S₄;
- **Galois (1846, posthumous)** — the criterion *solvable by radicals ⟺ solvable Galois group*, which the formalized Sₙ-solvability threshold instantiates.

No existing content altered; within all size caps.