### PR TITLE
research(shannon-awgn-oq-03-oq-01): parallel Gaussian channel capacity capstone

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03OQ01.lean
@@ -318,4 +318,53 @@ theorem waterLevel_unique (N : ι → ℝ) {P : ℝ} (hP : 0 < P)
     rw [h1, h2] at hlt
     exact absurd hlt (lt_irrefl P)
 
+/-- **A positive budget forces a positive water level.**  If the water level `μ`
+    realises a strictly positive budget `P > 0`, then `μ > 0`.  Otherwise
+    (`μ ≤ 0`) monotonicity would push the budget below its value `0` at level `0`
+    (all channels off, since every noise power is positive), contradicting
+    `g(μ) = P > 0`.  This is the bridge that upgrades the *existence* level
+    `0 ≤ μ` to the *strictly positive* level required by optimality. -/
+theorem waterLevel_pos (N : ι → ℝ) (hN : ∀ i, 0 < N i) {P : ℝ} (hP : 0 < P)
+    {μ : ℝ} (hμ : waterBudget N μ = P) : 0 < μ := by
+  by_contra hcon
+  push_neg at hcon
+  have hmono := monotone_waterBudget N hcon
+  rw [waterBudget_zero N hN, hμ] at hmono
+  linarith
+
+/-! ## Capacity of the parallel Gaussian channel (capstone) -/
+
+/-- **Capacity of the parallel Gaussian channel via water-filling.**  This is the
+    full statement of the open question.  For any strictly positive power budget
+    `P > 0` there is a water level `μ > 0` whose water-filling allocation
+    `Pᵢ⋆ = (μ − Nᵢ)₊`
+
+      * **is feasible** — every `Pᵢ⋆ ≥ 0` and it uses exactly the budget,
+        `∑ᵢ Pᵢ⋆ = P`;
+      * **is optimal** — it maximises the total rate `∑ᵢ ½ log(1 + Pᵢ/Nᵢ)` over
+        every feasible allocation `x` (`xᵢ ≥ 0`, `∑ xᵢ ≤ P`);
+      * **attains the closed-form capacity** `∑ᵢ ½ log(max μ Nᵢ / Nᵢ)`.
+
+    It assembles the file's separate results — `exists_waterLevel`,
+    `waterLevel_pos`, `waterfilling_optimal`, `waterAlloc_rate_closedForm` — into
+    the single "the constrained capacity of a bank of parallel AWGN sub-channels
+    is achieved by water-filling" statement.  The *value* of the water level `μ`
+    is the only remaining implicit datum; by `waterLevel_unique` it is uniquely
+    determined by `P`. -/
+theorem parallel_gaussian_capacity [Nonempty ι]
+    (N : ι → ℝ) (hN : ∀ i, 0 < N i) {P : ℝ} (hP : 0 < P) :
+    ∃ μ : ℝ, 0 < μ ∧
+      (∀ i, 0 ≤ waterAlloc μ N i) ∧
+      (∑ i, waterAlloc μ N i = P) ∧
+      (∀ x : ι → ℝ, (∀ i, 0 ≤ x i) → (∑ i, x i ≤ P) →
+        parallelRate N x ≤ parallelRate N (waterAlloc μ N)) ∧
+      parallelRate N (waterAlloc μ N)
+        = ∑ i, (1 / 2) * Real.log (max μ (N i) / N i) := by
+  obtain ⟨μ, hμ0, hbudget⟩ := exists_waterLevel N hN hP.le
+  have hμpos : 0 < μ := waterLevel_pos N hN hP hbudget
+  refine ⟨μ, hμpos, fun i => waterAlloc_nonneg μ N i, hbudget, ?_,
+          waterAlloc_rate_closedForm N hN μ⟩
+  intro x hx hxsum
+  exact waterfilling_optimal N hN hμpos hbudget x hx hxsum
+
 end ShannonWaterFilling

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-03-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-03-oq-01.json
@@ -62,7 +62,8 @@
       "Water-filling KKT optimality has a fully ELEMENTARY proof: the first-order condition is replaced by the per-channel tangent bound log u <= u-1 (Real.log_le_sub_one_of_pos), summed across channels. No differentiability/Lagrange/KKT machinery needed.",
       "Key identity N_i + (mu-N_i)_+ = max mu N_i turns the derivative coefficient 1/(2(N_i+P_i*)) into 1/(2 max(mu,N_i)), which is constant 1/(2mu) on ACTIVE channels (N_i<mu) and <= 1/(2mu) on inactive ones (P_i*=0, x_i>=0). This case split is exactly what makes the aggregated linear term collapse to (sum x_i - P)/(2mu) <= 0.",
       "Water level existence = IVT on the continuous monotone budget g(mu)=sum (mu-N_i)_+ between g(0)=0 and g(N_{i0}+P)>=P; uniqueness (for P>0) = strict monotonicity of g wherever g>0 (some channel active).",
-      "VERIFIED (researcher-2, 2026-07-09, GREEN build attempt 1): capacity properties of the equal-noise closed form C(P)=(n/2)log(1+P/(nc)) in ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean. rate_equalNoise_nonneg (C(P)≥0 for P≥0, via Real.log_nonneg on 1≤1+P/(nc) + mul_nonneg) and rate_equalNoise_mono_power (P₁≤P₂⟹C(P₁)≤C(P₂), via Real.log_le_log + gcongr for the argument monotonicity). Standard 'capacity is a nonneg increasing function of the power budget' facts, absent from the file. The three parent open items (optimality, water-level existence/uniqueness, closed form) + equal-noise specialization are all complete; remaining nextSteps (operational random-coding theorem, infinite-band integral limit) are substantial."
+      "VERIFIED (researcher-2, 2026-07-09, GREEN build attempt 1): capacity properties of the equal-noise closed form C(P)=(n/2)log(1+P/(nc)) in ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean. rate_equalNoise_nonneg (C(P)≥0 for P≥0, via Real.log_nonneg on 1≤1+P/(nc) + mul_nonneg) and rate_equalNoise_mono_power (P₁≤P₂⟹C(P₁)≤C(P₂), via Real.log_le_log + gcongr for the argument monotonicity). Standard 'capacity is a nonneg increasing function of the power budget' facts, absent from the file. The three parent open items (optimality, water-level existence/uniqueness, closed form) + equal-noise specialization are all complete; remaining nextSteps (operational random-coding theorem, infinite-band integral limit) are substantial.",
+      "The four separately-proved water-filling facts (existence, positivity, optimality, closed form) compose directly into the single \"parallel Gaussian channel capacity is achieved by water-filling\" statement — no new analysis needed, only the μ>0 bridge lemma."
     ],
     "builtItems": [
       "waterfilling_optimal (KKT optimality of P_i*=(mu-N_i)_+) in ShannonChannelCodingAWGNOQ03OQ01.lean",
@@ -70,7 +71,9 @@
       "add_waterAlloc (N_i + (mu-N_i)_+ = max mu N_i)",
       "waterAlloc_rate_closedForm (R(P*) = sum 1/2 log(max mu N_i / N_i))",
       "exists_waterLevel (IVT existence) + waterLevel_unique (strict-monotone uniqueness) + continuous/monotone_waterBudget",
-      "ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean: rate_equalNoise_nonneg + rate_equalNoise_mono_power. VERIFIED green, 0 axioms/sorries. File now 7 theorems."
+      "ShannonChannelCodingAWGNOQ03OQ01EqualNoise.lean: rate_equalNoise_nonneg + rate_equalNoise_mono_power. VERIFIED green, 0 axioms/sorries. File now 7 theorems.",
+      "waterLevel_pos (ShannonChannelCodingAWGNOQ03OQ01.lean): P>0 ⟹ water level μ>0 — bridges exists_waterLevel (0≤μ) to waterfilling_optimal (0<μ), via monotone_waterBudget + waterBudget_zero",
+      "parallel_gaussian_capacity (ShannonChannelCodingAWGNOQ03OQ01.lean): capstone — for P>0 there is μ>0 whose water-filling allocation is feasible (∑Pᵢ⋆=P), optimal over all feasible x, and attains closed form ∑½log(max μ Nᵢ/Nᵢ); assembles exists_waterLevel+waterLevel_pos+waterfilling_optimal+waterAlloc_rate_closedForm into the single capacity statement"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -78,6 +81,6 @@
       "Extend the finite water-filling optimum to the continuous infinite-band (integral) limit.",
       "Prove the explicit water level for the equal-noise case mu = (P + sum N_i)/n and derive C = (n/2) log(1 + P/(sum N_i)) style corollaries."
     ],
-    "progressSummary": "PROGRESS: All three open items formalized (optimality, existence+uniqueness of water level, closed form) via an elementary tangent-bound proof; pending Docker build verification."
+    "progressSummary": "PROGRESS: capstone parallel_gaussian_capacity assembles the full capacity theorem (feasible+optimal+closed-form) for P>0; water level uniqueness already established. UNVERIFIED (docker infra down)."
   }
 }


### PR DESCRIPTION
## Summary

Assembles the four separately-proved water-filling facts already in
`ShannonChannelCodingAWGNOQ03OQ01.lean` (existence of the water level, optimality
of the water-filling allocation, its closed form) into the **single statement the
open question asks for**: the constrained capacity of a bank of `n` parallel AWGN
sub-channels is achieved by water-filling.

Two additions:

- **`waterLevel_pos`** — a positive budget `P > 0` forces a positive water level
  `μ > 0`. If `μ ≤ 0`, monotonicity of the budget function `g(μ)=∑ᵢ(μ−Nᵢ)₊` would
  push it below its value `0` at `μ=0` (all channels off, since every `Nᵢ>0`),
  contradicting `g(μ)=P>0`. This is the missing bridge from `exists_waterLevel`
  (which yields only `0 ≤ μ`) to `waterfilling_optimal` (which requires `0 < μ`).

- **`parallel_gaussian_capacity`** (capstone) — for any `P > 0` there is a water
  level `μ > 0` whose water-filling allocation `Pᵢ⋆ = (μ − Nᵢ)₊`:
  - **is feasible** — `Pᵢ⋆ ≥ 0` and `∑ᵢ Pᵢ⋆ = P`;
  - **is optimal** — maximises `∑ᵢ ½ log(1 + Pᵢ/Nᵢ)` over every feasible allocation;
  - **attains the closed-form capacity** `∑ᵢ ½ log(max μ Nᵢ / Nᵢ)`.

  Pure composition of `exists_waterLevel`, `waterLevel_pos`, `waterfilling_optimal`,
  and `waterAlloc_rate_closedForm`; the water level's value is uniquely determined
  by the file's `waterLevel_unique`.

## Verification status

⚠️ **UNVERIFIED** — Docker build infrastructure is down this session (containerd
`meta.db` input/output error; image build fails before elaboration). Both proofs
are elementary compositions of existing in-file lemmas plus idioms already used in
the file (`monotone_waterBudget`, `waterBudget_zero`, `rw`, `linarith`), so they
are readily checkable by eye. Please build with
`./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingAWGNOQ03OQ01` once
infrastructure recovers.

No new axioms, no sorries. Additions only (no existing declarations changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)