### PR TITLE
research(algebraic-numbers-countable-oq-07): the transcendental reals are uncountable

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -3,6 +3,7 @@ import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
 import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 import Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms
 import Mathlib.Topology.MetricSpace.HausdorffDimension
+import Mathlib.Analysis.Real.Cardinality
 import Mathlib.Tactic
 import Proofs.AlgebraicNumbersCountable
 
@@ -111,6 +112,27 @@ theorem ae_transcendental :
     ext x; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
   rw [Filter.eventually_iff, hset]
   exact compl_mem_ae_iff.mpr algebraic_reals_null
+
+/-- **The transcendental reals are uncountable.**  Completing the "smallness trichotomy"
+dual: the algebraic reals are countable, meagre, and null, so — dually — the transcendentals
+are uncountable, comeagre, and conull.  Here is the cardinality half: `{x | Transcendental ℚ x}`
+is not countable.
+
+Proof by contradiction: if the transcendentals were countable then, together with the
+countable algebraic reals (`AlgebraicNumbersCountable.algebraic_reals_countable`), their union
+`{Transcendental} ∪ {Transcendental}ᶜ = ℝ` would be countable, contradicting the
+uncountability of the reals (`Cardinal.not_countable_real`).  A purely cardinal argument,
+independent of the measure- and category-theoretic routes above. -/
+theorem transcendental_reals_uncountable :
+    ¬ {x : ℝ | Transcendental ℚ x}.Countable := by
+  intro hcount
+  have hcompl : {x : ℝ | Transcendental ℚ x}ᶜ.Countable := by
+    rw [compl_transcendental_eq_algebraic]
+    exact AlgebraicNumbersCountable.algebraic_reals_countable
+  have huniv : (Set.univ : Set ℝ).Countable := by
+    have hu := hcount.union hcompl
+    rwa [Set.union_compl_self] at hu
+  exact Cardinal.not_countable_real huniv
 
 -- ============================================================================
 -- § 3. Transcendentals fill almost all of every interval

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -177,8 +177,8 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicRealsNull.lean",
-    "lineCount": 359,
-    "theoremCount": 19,
+    "lineCount": 381,
+    "theoremCount": 20,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Summary

`AlgebraicRealsNull.lean` proves the algebraic reals are **null** and **Hausdorff-dimension zero**, and the transcendentals **conull**, **dense**, and **full-measure on every interval** — the measure- and category-theoretic halves of the "smallness trichotomy". This PR adds the missing **cardinality** half.

## New theorem

- `transcendental_reals_uncountable`: `¬ {x : ℝ | Transcendental ℚ x}.Countable`. Proof by contradiction — if the transcendentals were countable, their union with the countable algebraic reals (`AlgebraicNumbersCountable.algebraic_reals_countable`, already used in the file) is all of `ℝ` and hence countable, contradicting `Cardinal.not_countable_real`. A purely cardinal argument, independent of the measure- and category-theoretic routes already present.

This completes the dual trichotomy: **algebraic reals countable + meagre + null ⟺ transcendentals uncountable + comeagre + conull.**

0 new axioms, 0 sorries. Adds `import Mathlib.Analysis.Real.Cardinality`; syncs `leanFile.lineCount` 359→381 and `theoremCount` 19→20.

## Verification status

⚠️ **UNVERIFIED** — docker build infrastructure is down this session (containerd `meta.db` input/output error, operator-level; host disk healthy at 115Gi). All lemma names were verified against the local mathlib pin: `Cardinal.not_countable_real` (`Analysis/Real/Cardinality.lean:205`), `Set.Countable.union` (`Data/Set/Countable.lean:232`), `Set.union_compl_self`, plus the in-file `compl_transcendental_eq_algebraic` and `algebraic_reals_countable`. A green build should be confirmed once docker recovers.