### PR TITLE
research(e-transcendental-oq-02-oq-06): e is disjunctive in every base

### DIFF
--- a/proofs/Proofs/ETranscendentalOQ02.lean
+++ b/proofs/Proofs/ETranscendentalOQ02.lean
@@ -2013,4 +2013,17 @@ theorem absolutely_normal_imp_disjunctive (x : ℝ) (h : IsAbsolutelyNormal x)
     ∃ n : ℕ, ∀ i : Fin k, nthDigit b (n + i.val) x = (s i : ℤ) :=
   normal_imp_disjunctive b k hb x (h b hb) s
 
+/-- **e is disjunctive in every base** (consequence of the absolute-normality axiom
+    `e_absolutely_normal`).  For every base `b ≥ 2` and every finite digit string
+    `s : Fin k → Fin b`, the base-`b` expansion of `e` contains `s` as a contiguous block:
+    some window starting at position `n` matches `s` digit-for-digit.  This is the
+    qualitative "every finite pattern eventually occurs in `e`" richness that absolute
+    normality entails — the disjunctive companion of `e_normal_base_10` and
+    `e_irrational_necessary_for_normality`.  Like every `e_normal_*` statement in this
+    file it is conditional on the open axiom `e_absolutely_normal` (no base is proved
+    normal for `e` unconditionally). -/
+theorem e_disjunctive (b k : ℕ) (hb : 2 ≤ b) (s : Fin k → Fin b) :
+    ∃ n : ℕ, ∀ i : Fin k, nthDigit b (n + i.val) (Real.exp 1) = (s i : ℤ) :=
+  absolutely_normal_imp_disjunctive (Real.exp 1) e_absolutely_normal b k hb s
+
 end ETranscendentalOQ02

--- a/research/problems/e-transcendental-oq-02-oq-06/knowledge.md
+++ b/research/problems/e-transcendental-oq-02-oq-06/knowledge.md
@@ -115,3 +115,24 @@ base-2 non-normality theory from single-digit to full k-block distribution.
 - `proofs/Proofs/ETranscendentalOQ02.lean` (+4 decls, PART IX; 1608→1809 lines)
 - `src/data/proofs/e-transcendental-oq-02/meta.json` (lineCount 1608→1809,
   theoremCount 80→84)
+
+## Session 2026-07-09 (researcher-3) — `e_disjunctive` (VERIFIED, depends on open e_absolutely_normal)
+
+The oq-06 goal (`normal_imp_irrational`) is long-discharged; the sole axiom `e_absolutely_normal`
+is genuinely open (no base proved normal for e). Added one recognisable named e-consequence that
+the file's `absolutely_normal_imp_disjunctive` corollary made one line away but was missing:
+
+**`e_disjunctive`** (ETranscendentalOQ02.lean, end): for every base b ≥ 2 and every finite digit
+string `s : Fin k → Fin b`, e's base-b expansion contains s as a contiguous block
+(`∃ n, ∀ i, nthDigit b (n+i) e = s i`). The "every finite pattern occurs in e" richness property,
+the disjunctive companion of `e_normal_base_10` / `e_irrational_necessary_for_normality`. Proof =
+`absolutely_normal_imp_disjunctive (Real.exp 1) e_absolutely_normal b k hb s`.
+
+No new axiom: depends on exactly the SAME set as e_normal_base_10 —
+`[propext, Classical.choice, Quot.sound, ETranscendentalOQ02.e_absolutely_normal]`. File axiomCount
+stays 1, entry stays axiomatized (the open e-normality axiom).
+
+VERIFIED green via direct lean-elab vs pinned Mathlib v4.26.0 (docker containerd blob I/O down):
+built the dep chain deepest-first into /tmp — `Proofs.HermiteLindemann` (Mathlib-only, ~20s) then
+`Proofs.eTranscendental` (imports HermiteLindemann) — then elaborated target, exit 0. Gallery meta
+e-transcendental-oq-02: lineCount 2016→2029, theoremCount 89→90.

--- a/src/data/proofs/e-transcendental-oq-02/meta.json
+++ b/src/data/proofs/e-transcendental-oq-02/meta.json
@@ -22,7 +22,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "theoremCount": 89,
+    "theoremCount": 90,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_one_gt_d9",
@@ -82,7 +82,7 @@
     ],
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
-    "lineCount": 2016,
+    "lineCount": 2029,
     "assumptions": "1 axiom (the main open conjecture): e_absolutely_normal — e is absolutely normal (open as of 2026). Session 13 discharged the normal_imp_irrational axiom: composing rational_has_missing_ktuple_intCast (the ℤ-valued lift of S12's Layer 4a missing-tuple), rational_match_count_le (the matching-position count is bounded by N₀ via Finset.card_le_card), and tendsto_bounded_count_div_atTop_zero (squeeze: 0 ≤ count_N/N ≤ N₀/N → 0). For rational q, normality forces frequency → b^(-k) > 0, but the bound forces it → 0; tendsto_nhds_unique closes the contradiction. Earlier history: rational-digits-periodic was discharged in Session 11 via the 3-layer recipe (Layer 1 eventually_periodic_iterate S8, Layer 2 ratResidue_eventually_periodic S9, Layer 3 floor_pow_mul_div S10 + nthDigit_succ_via_residue S11), then Session 12 added Layer 4a (Fin b cast bridge) and rational_has_missing_ktuple. 33 public theorems including first 9 decimal digits of e proved from exp_one bounds and now normal_imp_irrational fully axiom-free.",
     "mathlib_version": "4.26.0",
     "definitionCount": 7
@@ -215,9 +215,9 @@
       "Filter"
     ],
     "namespace": "ETranscendentalOQ02",
-    "lineCount": 2016,
+    "lineCount": 2029,
     "axiomCount": 1,
-    "theoremCount": 89,
+    "theoremCount": 90,
     "definitionCount": 7,
     "path": "Proofs/ETranscendentalOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds **`e_disjunctive`** to `ETranscendentalOQ02.lean`: for every base `b ≥ 2` and every finite digit string `s : Fin k → Fin b`, the base-`b` expansion of `e` contains `s` as a contiguous block,

$$\exists n,\ \forall i,\ \mathrm{nthDigit}\ b\ (n+i)\ e = s_i.$$

This is the recognisable "every finite digit pattern eventually occurs in `e`" richness property that absolute normality entails — the **disjunctive companion** of the file's existing named `e`-consequences `e_normal_base_10`, `e_normal_binary`, and `e_irrational_necessary_for_normality`, which was one line away via the file's own `absolutely_normal_imp_disjunctive` corollary but not stated.

## Proof

`absolutely_normal_imp_disjunctive (Real.exp 1) e_absolutely_normal b k hb s`.

## Axioms

No new axiom. `e_disjunctive` depends on exactly the same axiom set as `e_normal_base_10` — `[propext, Classical.choice, Quot.sound, e_absolutely_normal]`. The `e_absolutely_normal` axiom is genuinely open (no base is proved normal for `e` unconditionally), so like every `e_normal_*` statement this theorem is appropriately conditional; the file's `axiomCount` (1) and `axiomatized` status are unchanged.

## Verification

Docker containerd blob I/O errors (new `docker run` blocked); verified via direct `lean` elaboration against pinned Mathlib v4.26.0, temp-building the dependency chain deepest-first (`Proofs.HermiteLindemann`, then `Proofs.eTranscendental`) into `LEAN_PATH`:

- Exit 0, no errors.
- `#print axioms e_disjunctive` matches `e_normal_base_10` (adds no axiom beyond `e_absolutely_normal`).

Gallery meta `e-transcendental-oq-02` synced: lineCount 2016→2029, theoremCount 89→90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)