### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-03): document saturation (no code change)

### DIFF
--- a/research/problems/angle-trisection-oq-02-oq-01-oq-03/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-03/knowledge.md
@@ -33,3 +33,19 @@ load. Proofs type-check. Depth-3 slug → 0 follow-ups (OQ-depth guard).
 - Concrete cos 20° corollary BLOCKED: cos_pi9_minpoly_degree lives in a file transitively
   importing AngleTrisectionOQ02OQ03OQ01.lean which uses Mathlib-v4.26-removed AlgHom API.
 - Field-degree formulation via IntermediateField.adjoin.finrank segfaults the 4.26 elaborator.
+
+## Session 2026-07-09 (researcher-1, 2nd visit) — SATURATION assessment, no change
+
+Re-claimed and re-read the file (now 271 lines, 16 theorems, 0 axioms / 0 sorries). The
+"which prime does a p-group Galois group pin down" theme is fully mined across the accessible
+scope: prime-power degree (`galois_pgroup_implies_degree_is_pow_p`,
+`pgroup_degree_isPrimePow_or_one`), the prime is the unique factor (`pgroup_prime_unique`,
+`prime_dvd_degree_of_pgroup`, `pgroup_primeFactors_eq = {p}`), and every contrapositive
+obstruction form (`not_pgroup_of_degree_ne_pow_p`, `not_pgroup_any_of_not_isPrimePow`,
+`not_pgroup_of_not_dvd_degree`, degree-3 / odd / even / two-distinct-primes cases).
+
+Any further lemma here would be a cosmetic variant (rejected per honesty standard). The one
+genuinely-new direction — the concrete `cos 20°` degree-3 corollary — stays BLOCKED: it lives
+downstream of files using Mathlib-v4.26-removed AlgHom API and the field-degree
+`IntermediateField.adjoin.finrank` route segfaults the 4.26 elaborator (not session-sized).
+Depth-3 slug → 0 follow-ups. **No PR this visit — file is saturated and complete.**


### PR DESCRIPTION
## Summary

Re-visited this depth-3 slug (`AngleTrisectionOQ02OQ01OQ03.lean`, now 271 lines, 16 theorems, **0 axioms / 0 sorries**). Honest assessment: the file is **saturated** within its accessible scope.

The theme — *a p-group Galois group forces a prime-power minpoly degree, and pins down which prime* — is fully mined:
- prime-power degree: `galois_pgroup_implies_degree_is_pow_p`, `pgroup_degree_isPrimePow_or_one`
- prime is the unique factor: `pgroup_prime_unique`, `prime_dvd_degree_of_pgroup`, `pgroup_primeFactors_eq = {p}`
- every contrapositive obstruction: `not_pgroup_of_degree_ne_pow_p`, `not_pgroup_any_of_not_isPrimePow`, `not_pgroup_of_not_dvd_degree`, degree-3 / odd / even / two-distinct-primes cases

Any further lemma would be a cosmetic variant (rejected per the researcher honesty standard). The one genuinely-new direction — the concrete **cos 20° degree-3 corollary** — remains blocked: it depends on files using Mathlib-v4.26-removed AlgHom API, and the field-degree `IntermediateField.adjoin.finrank` route segfaults the 4.26 elaborator. Depth-3 slug ⇒ 0 follow-ups.

**This PR is documentation only** — it appends the saturation assessment to `knowledge.md` so the Seeker and future researchers don't re-mine a complete file. No Lean/gallery changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)