### PR TITLE
Enrich Fibonacci Identities: cross-link Lucas-sum analogue

### DIFF
--- a/src/data/proofs/fibonacci-identities/meta.json
+++ b/src/data/proofs/fibonacci-identities/meta.json
@@ -172,6 +172,11 @@
       "proofId": "fibonacci-identities-oq-06",
       "relationship": "Linear-sum descendant",
       "description": "fibonacci-identities-oq-06 supplies the two un-filtered linear summation identities this entry left open: the full partial sum ∑Fᵢ = Fₙ₊₂ − 1 and the index-weighted first moment ∑ i·Fᵢ = n·Fₙ₊₂ − Fₙ₊₃ + 2 — directly answering the '∑ i·Fᵢ' weighted-sum open question posed below. Together they are the degree-zero and degree-one companions to this entry's degree-two sum of squares ∑Fᵢ² = Fₙ·Fₙ₊₁."
+    },
+    {
+      "proofId": "lucas-sum-oq-01",
+      "relationship": "Lucas analogue",
+      "description": "The Lucas counterpart of this entry's summation identities, realizing the open question below on whether 'the same template yields the Lucas-number summation identities': ∑_{k=1}^{n} L_k = L_{n+2} − 3 by the same telescoping induction from the Lucas recurrence (with the subtraction-free (∑L_k)+3 = L_{n+2} form to stay in ℕ), exactly mirroring this entry's even-indexed additive workaround (∑F₂ᵢ)+1 = F₂ₙ₊₁."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass on `fibonacci-identities`.

This entry is already well-curated (crossRefs 4, refs 5, 5 keyInsights, 6 fully-populated annotations covering the whole 70-line file). Rather than deepen saturated fields, I added the one genuinely-missing cross-reference:

- **`lucas-sum-oq-01`** (∑ L_k = L_{n+2} − 3) — the Lucas analogue that directly realizes this entry's own open question 'Does the same template yield the Lucas-number summation identities?' It mirrors this entry's subtraction-free additive workaround for ℕ.

crossReferences 4 → 5 (cap 20). meta.json 12.8KB → 13.4KB. JSON validates; gallery data-validation passes; entry has no annotation errors. Left the legacy `index.ts` untouched (obsolete per #20993, out of scope). Additive only.