### PR TITLE
audit(erdos-907): remove phantom mathlib deps + overstated regularity claims

### DIFF
--- a/src/data/proofs/erdos-907/meta.json
+++ b/src/data/proofs/erdos-907/meta.json
@@ -25,30 +25,15 @@
     "mathlibDependencies": [
       {
         "theorem": "Continuous",
-        "description": "Continuity predicate for real-valued functions",
+        "description": "Continuity predicate for real-valued functions (the only Mathlib predicate used in the proofs; via .sub/.comp)",
         "module": "Mathlib.Topology.ContinuousFunction.Basic"
-      },
-      {
-        "theorem": "Measurable",
-        "description": "Measurability predicate for the regularity theory extension",
-        "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"
-      },
-      {
-        "theorem": "Monotone",
-        "description": "Monotonicity as a regularity condition for additive functions",
-        "module": "Mathlib.Order.Monotone.Basic"
-      },
-      {
-        "theorem": "Real.log",
-        "description": "Real analysis foundations (imported via SpecialFunctions.Pow.Real)",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       }
     ],
     "originalContributions": [
       "Custom `IsAdditive` definition for Cauchy's equation with proved properties: additive_zero, additive_neg, additive_nat_mul (all fully proved by induction/linarith/ring)",
       "Full proof that linear_is_additive, continuous_has_continuous_differences, additive_difference_const, continuous_decomposition, sq_has_continuous_differences (all 0-sorry)",
       "Axiomatization of exactly 2 deep results: continuous_additive_is_linear (Cauchy regularity), de_bruijn_theorem (main decomposition theorem)",
-      "Extension to regularity theory: bounded differences → linear growth and measurable differences → measurable+additive decomposition (discussed in docstring comments; not axiomatized)",
+      "Regularity remark: a docstring notes that continuous, measurable, or monotone additive functions are all linear (mathematical context only; only the continuous case is stated, as the axiom continuous_additive_is_linear)",
       "Connection to erdos-908 via decomposition_continuous_additive characterization",
       "Summary theorem packaging de Bruijn + continuous direction + additive constancy as conjunction"
     ],
@@ -62,7 +47,7 @@
     "historicalContext": "Erdős Problem #907 belongs to the rich tradition of studying Cauchy's functional equation φ(x+y) = φ(x) + φ(y) and its interplay with regularity conditions.\n\nCauchy (1821) showed that continuous additive functions must be linear: φ(x) = cx. The quest to weaken this regularity hypothesis became a central theme in 19th-20th century analysis. Lebesgue measurability, local boundedness, and monotonicity all suffice; but Hamel (1905) used the Axiom of Choice to construct discontinuous additive functions whose graphs are dense in ℝ², showing that *some* regularity condition is necessary.\n\nDe Bruijn's 1951 paper 'Functions whose differences belong to a given class' addressed the natural question: if f is not itself continuous but all its differences Δ_h f(x) = f(x+h) - f(x) are continuous, what can we say about f? His answer is a clean decomposition: f = g + φ with g continuous and φ additive. The 'irregular' part is exactly additive—and additive functions are invisible to the difference operator (since Δ_h φ = φ(h) is constant).\n\nThis result is a prototype for regularity theory: local or incremental smoothness (continuous differences) forces global structure (continuous + additive decomposition). The uniqueness theorem shows the decomposition is canonical modulo linear functions (which are both continuous and additive). The formalization in Lean 4 achieves 0 sorries by axiomatizing de Bruijn's theorem and the Cauchy-regularity results, while fully proving all structural consequences including the additive function properties, the difference operator algebra, and the x² example.",
     "problemStatement": "Let f : ℝ → ℝ be such that f(x+h) - f(x) is continuous for every h > 0. Is it true that f = g + φ for some continuous g and additive φ (i.e., φ(x+y) = φ(x) + φ(y))? Answer: YES.",
     "text": "If f(x+h) - f(x) is continuous for every h > 0, can f be decomposed as g + φ for continuous g and additive φ? Answer: YES, proved by de Bruijn (1951).",
-    "proofStrategy": "The formalization is organized into ten parts:\n\n1. **Additive Functions**: `IsAdditive` definition with proved properties: `additive_zero` (φ(0) = 0, via linarith), `additive_neg` (φ(-x) = -φ(x), via linarith), `additive_nat_mul` (φ(nx) = nφ(x), via induction+ring)\n2. **Continuous Additive = Linear**: `IsLinear` definition, `linear_is_additive` (proved via ring), `continuous_additive_is_linear` (axiom)\n3. **Discontinuous Additive**: Hamel basis + AC construction and dense graph property (mathematical context in docstrings; not axiomatized)\n4. **Difference Operator**: `difference f h x = f(x+h) - f(x)` with `Δ[h]` notation, `hasContinuousDifferences` as ∀ h > 0, Continuous (Δ[h] f)\n5. **De Bruijn's Theorem**: `hasDeBruijnDecomposition` as ∃ (g φ), Continuous g ∧ IsAdditive φ ∧ f = g + φ; `de_bruijn_theorem` (axiom); `erdos_907` := de_bruijn_theorem\n6. **Decomposition Properties**: decomposition uniqueness modulo linear functions (mathematical context; not axiomatized), `continuous_decomposition` (proved: f + 0), `additive_continuous_decomposition` (proved via continuous_additive_is_linear)\n7. **Examples**: `sq_has_continuous_differences` (proved: Δ_h(x²) = 2hx+h² via ring+continuity)\n8. **Regularity Theory**: bounded Δ_h → linear growth and measurable Δ_h → measurable+additive decomposition (docstring comments; not axiomatized)\n9. **Related Problem**: Brief comment pointing to Erdős Problem #908 for related questions; no formal declarations in this section. (`decomposition_continuous_additive` does not exist as an axiom in this file.)\n10. **Summary**: `erdos_907_summary` (proved conjunction of 3 results)",
+    "proofStrategy": "The formalization is organized into ten parts:\n\n1. **Additive Functions**: `IsAdditive` definition with proved properties: `additive_zero` (φ(0) = 0, via linarith), `additive_neg` (φ(-x) = -φ(x), via linarith), `additive_nat_mul` (φ(nx) = nφ(x), via induction+ring)\n2. **Continuous Additive = Linear**: `IsLinear` definition, `linear_is_additive` (proved via ring), `continuous_additive_is_linear` (axiom)\n3. **Discontinuous Additive**: Hamel basis + AC construction and dense graph property (mathematical context in docstrings; not axiomatized)\n4. **Difference Operator**: `difference f h x = f(x+h) - f(x)` with `Δ[h]` notation, `hasContinuousDifferences` as ∀ h > 0, Continuous (Δ[h] f)\n5. **De Bruijn's Theorem**: `hasDeBruijnDecomposition` as ∃ (g φ), Continuous g ∧ IsAdditive φ ∧ f = g + φ; `de_bruijn_theorem` (axiom); `erdos_907` := de_bruijn_theorem\n6. **Decomposition Properties**: decomposition uniqueness modulo linear functions (mathematical context; not axiomatized), `continuous_decomposition` (proved: f + 0), `additive_continuous_decomposition` (proved via continuous_additive_is_linear)\n7. **Examples**: `sq_has_continuous_differences` (proved: Δ_h(x²) = 2hx+h² via ring+continuity)\n8. **Regularity Theory**: a section header noting only that regularity on differences implies global structure; no bounded/measurable variants are stated or axiomatized here\n9. **Related Problem**: Brief comment pointing to Erdős Problem #908 for related questions; no formal declarations in this section. (`decomposition_continuous_additive` does not exist as an axiom in this file.)\n10. **Summary**: `erdos_907_summary` (proved conjunction of 3 results)",
     "keyInsights": [
       "**Additive functions are 'invisible' to the difference operator**: Since Δ_h φ(x) = φ(h) is constant (and thus continuous), additive functions always satisfy the continuous differences condition regardless of their own regularity. This makes them the exact obstruction to concluding continuity from continuous differences.",
       "**The decomposition f = g + φ is a quotient by the kernel**: The space of functions with continuous differences modulo C(ℝ) is exactly the space of additive functions. De Bruijn's theorem says this quotient map splits: every f with continuous differences has a section g ∈ C(ℝ) such that f - g is additive.",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-907

**Result: ISSUES-FIXED** (was stalest uncovered entry, last audited 2026-05-04)

Erdős #907 (de Bruijn 1951: continuous differences → g + φ decomposition). Axiomatized formalization.

### Verified correct (unchanged)
- **Axioms: 2** — `continuous_additive_is_linear`, `de_bruijn_theorem` — both disclosed by name.
- Counts exact: 12 thm / 5 def / 0 sorry / 232 lines. No True stubs, no native_decide.
- status `axiomatized` + badge `axiom` honest; proofStrategy is otherwise accurate and even self-corrects a phantom axiom name.

### Fixed
1. **Phantom mathlibDependencies** — `Measurable`, `Monotone`, `Real.log` were listed but have **0 usages** in the source (`Real.log` never appears; `Measurable`/`Monotone` appear only in one prose docstring line). Trimmed to `Continuous`, the only Mathlib predicate actually used.
2. **Overstated contribution** — a bullet and proofStrategy Part 8 claimed docstring discussion of "bounded differences → linear growth" and "measurable+additive decomposition." No such discussion exists (Part 8 is a bare header; line 78 only notes continuous/measurable/monotone additive ⟹ linear). Reworded to match the file.

Tracker bumped.

---
Discovered during gallery integrity audit.