### PR TITLE
research(roth-theorem-k3-oq-03-oq-01): empty-set base case for the k-AP count

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -675,4 +675,45 @@ theorem kAPCount_count_univ {N : ℕ} [NeZero N] (k : ℕ) :
       Finset.card_univ, Fintype.card_prod, ZMod.card]
   ring
 
+-- ============================================================
+-- Empty-set base case
+--
+-- The degenerate companion of the `A = univ` saturation block: the empty
+-- set carries no `k`-AP mass at all.  Its indicator is the zero function
+-- (`indicatorZMod_empty`), so — for `k ≥ 1`, where the `i = 0` term forces
+-- the starting point into `A` — both the combinatorial count and the
+-- analytic operator `Λ_k` vanish.  This is the `δ = 0` end of the density
+-- scale, opposite the `Λ_k(1_univ) = 1` normalization.
+-- ============================================================
+
+/-- The indicator of the empty set is the zero function: `1_∅ = 0`.  The
+    degenerate companion of `indicatorZMod_univ` (`1_univ = 1`), feeding the
+    additive/multiplicative base points of the `1_A = δ·1 + (1_A − δ)`
+    decomposition. -/
+@[simp] theorem indicatorZMod_empty {N : ℕ} :
+    indicatorZMod (∅ : Finset (ZMod N)) = fun _ => (0 : ℂ) := by
+  funext x
+  simp [indicatorZMod]
+
+/-- **The empty set carries no `k`-AP mass.**  For `k ≥ 1`, no pair `(x, d)` has its
+    length-`k` progression inside `∅` — the `i = 0` term `x` would have to lie in `∅` —
+    so the count is `0`.  Immediate from the trivial upper bound `kAPCount_count_le`
+    (`≤ #∅ · N = 0`), and the `A = ∅` degenerate case of the exact univ count
+    `kAPCount_count_univ`. -/
+theorem kAPCount_count_empty {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k) :
+    (Finset.univ.filter (fun p : ZMod N × ZMod N =>
+        ∀ i : Fin k, p.1 + i.val • p.2 ∈ (∅ : Finset (ZMod N)))).card = 0 := by
+  simpa using kAPCount_count_le hk (∅ : Finset (ZMod N))
+
+/-- **`Λ_k(1_∅) = 0`.**  For `k ≥ 1`, the analytic `k`-AP operator on the empty
+    indicator vanishes: `1_∅ = 0` (`indicatorZMod_empty`) is the zero function, and a
+    single zero slot annihilates the count (`kAPCount_eq_zero_of_zero`).  The degenerate
+    companion of `kAPCount_indicator_univ` (`Λ_k(1_univ) = 1`), and the analytic shadow of
+    the combinatorial `kAPCount_count_empty`. -/
+theorem kAPCount_indicator_empty {N : ℕ} [NeZero N] {k : ℕ} (hk : 0 < k) :
+    kAPCount k (fun _ : Fin k => indicatorZMod (∅ : Finset (ZMod N))) = 0 := by
+  refine kAPCount_eq_zero_of_zero k _ ⟨0, hk⟩ ?_
+  funext x
+  simp [indicatorZMod]
+
 end RothTheoremOQ03OQ01

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -58,9 +58,9 @@
       "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
     ],
     "axiomCount": 0,
-    "lineCount": 678,
+    "lineCount": 719,
     "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
-    "theoremCount": 23,
+    "theoremCount": 26,
     "definitionCount": 5
   },
   "overview": {
@@ -142,9 +142,9 @@
       "BigOperators"
     ],
     "namespace": "RothTheoremOQ03OQ01",
-    "lineCount": 678,
+    "lineCount": 719,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 26,
     "definitionCount": 5,
     "path": "Proofs/RothTheoremOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Fills the empty-set (`A = ∅`) base case in `RothTheoremOQ03OQ01.lean` — the degenerate companion of the file's existing `A = univ` saturation block (`indicatorZMod_univ` / `kAPCount_indicator_univ` / `kAPCount_count_univ = N²`). The file already treats `univ`, nonemptiness, and positivity extensively, but had no `∅` base case. Three new axiom-free lemmas:

| lemma | statement |
|-------|-----------|
| `indicatorZMod_empty` | `1_∅ = 0` (the zero function; `@[simp]`), mirror of `indicatorZMod_univ` |
| `kAPCount_count_empty` | for `k ≥ 1`, `#{(x,d) : ∀ i, x+i·d ∈ ∅} = 0` (the `i=0` term forces `x ∈ ∅`) |
| `kAPCount_indicator_empty` | for `k ≥ 1`, `Λ_k(1_∅) = 0` (a single zero slot annihilates the count) |

Together these pin the `δ = 0` end of the density scale, opposite the `Λ_k(1_univ) = 1` normalization.

## Proof approach

Each is a line-for-line reuse of merged sibling idioms already in the file:
- `indicatorZMod_empty`: `funext x; simp [indicatorZMod]` (identical to `indicatorZMod_univ`).
- `kAPCount_count_empty`: `simpa using kAPCount_count_le hk ∅` (trivial upper bound `≤ #∅·N = 0`).
- `kAPCount_indicator_empty`: `kAPCount_eq_zero_of_zero` at slot `⟨0, hk⟩`, discharged by `funext + simp`.

## Verification status

**UNVERIFIED.** The docker build wrapper is down this session (containerd `meta.db` input/output error at image-build; host disk healthy, 113Gi free). Elaboration checked by eye against the file's merged `univ`/count idioms. Meta counts synced: lineCount 678→719, theoremCount 23→26. 0 new axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)