### PR TITLE
Fix: resync stale meta.lineCount for 3 uncovered drifts

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -12,7 +12,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-26",
     "mathlib_version": "4.26.0",
-    "lineCount": 178,
+    "lineCount": 250,
     "theoremCount": 7,
     "definitionCount": 1,
     "difficulty": "advanced",
@@ -83,7 +83,7 @@
       "BigOperators"
     ],
     "namespace": "SchurHorn",
-    "lineCount": 178,
+    "lineCount": 250,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -36,7 +36,7 @@
       "neumann_full_theorem: the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite",
       "center_finiteIndex_iff_relIndex_core: ω(Γ(G)) finite ⟹ [G:Z(G)] finite iff Z(G) has finite index within the explicit finite-index core H = ⋂ₐ C_G(a); localizes the residual axiom to (center G).relIndex H, whose Mathlib endgame is Subgroup.index_center_le_pow gated on Finite (commutatorSet G)"
     ],
-    "lineCount": 535,
+    "lineCount": 603,
     "theoremCount": 15,
     "defCount": 3,
     "definitionCount": 3
@@ -139,7 +139,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 566,
+    "lineCount": 603,
     "path": "Proofs/Erdos1098OQ01OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,

--- a/src/data/proofs/pythagorean-theorem-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-01/meta.json
@@ -26,7 +26,7 @@
     "dateAdded": "2026-07-09",
     "axiomCount": 0,
     "assumptions": "None. All theorems are fully machine-checked, depending only on propext, Classical.choice, and Quot.sound. Layer 3 works in a general real inner-product space; the right angle is supplied as the explicit hypothesis ⟪A − C, B − C⟫ = 0 and non-degeneracy as A ≠ B. Honesty note: once a Euclidean/inner-product model is fixed, the norm already encodes distance, so the one-line identity pythagorean_core (‖A−B‖² = ‖A−C‖² + ‖B−C‖²) is itself Pythagoras; Layer 3 does not claim foundational independence from it — its content is the verified geometric-mean/altitude decomposition. Layers 1 and 2 capture the parts of Einstein's reasoning genuinely independent of coordinates.",
-    "lineCount": 318,
+    "lineCount": 334,
     "theoremCount": 13,
     "definitionCount": 2,
     "originalContributions": [


### PR DESCRIPTION
## Fix

Resync stale `meta.lineCount` in three gallery entries that grew via merged research but were never resynced, and have **no open PR** correcting their `meta.lineCount`.

## Evidence (actual = `wc -l` of the primary Lean file at current main)

| Slug | actual | was | now |
|------|--------|-----|-----|
| `cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01` | 250 | 178 (×2 fields) | 250 |
| `erdos-1098-oq-01-oq-03` | 603 | 535 / 566 | 603 |
| `pythagorean-theorem-oq-01` | 334 | 318 (meta block) | 334 |

Both the primary-metadata `lineCount` and the `leanFile.lineCount` block were synced where stale (pythagorean's `leanFile` block was already 334).

## Scope notes

Deliberately **skipped** drifts whose `meta.json` is already touched by an open PR (collision risk): erdos-1039 & euler-polyhedral-oq-02-oq-02 (#36432), erdos-1059-oq-01-oq-01 (#37102), sylow-oq-04-oq-03 (#37072). Covered/noise drifts (algebraic/lagrange/pythagorean-meta via merged #37136, amgm #37122, erdos-143 Δ-1) not touched.

---
Automated fix by lean-mechanic agent.