### PR TITLE
research(cauchy-interlacing-theorem-oq-02-oq-01): expose unconditional compression adjoint identity

### DIFF
--- a/proofs/Proofs/CauchyInterlacingCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingCompression.lean
@@ -69,6 +69,34 @@ noncomputable def compress (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) : H →
 @[simp] theorem compress_apply (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) (y : H) :
     compress T H y = H.orthogonalProjection (T (y : V)) := rfl
 
+/-- **Projection-adjoint identity for the compression (unconditional, left slot).**
+For *any* operator `T`, *any* subspace `H`, and *any* `y z : H`, the compression's inner
+product agrees with the ambient one in the left slot:
+
+  `⟪compress T H y, z⟫_H = ⟪T ↑y, ↑z⟫_V`.
+
+No symmetry of `T` and no invariance / special-position hypothesis on `H` is required: the
+orthogonal projection in `compress` is adjoint to the inclusion
+(`Submodule.inner_orthogonalProjection_eq_of_mem_right`), so it is inert against the in-`H`
+test vector `z`.  This is the single unconditional primitive behind both
+`isSymmetric_compress` and `rayleigh_compress_eq`, and the bilinear generalisation of the
+latter (the Rayleigh quotient is its diagonal `z = y` real part). -/
+theorem inner_compress_eq (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) (y z : H) :
+    @inner 𝕜 H _ (compress T H y) z = @inner 𝕜 V _ (T (y : V)) (z : V) := by
+  rw [compress_apply, Submodule.inner_orthogonalProjection_eq_of_mem_right]
+
+/-- **Projection-adjoint identity for the compression (unconditional, right slot).**
+The right-slot companion of `inner_compress_eq`:
+
+  `⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫_V`  for any `T`, any subspace `H`, any `y z : H`.
+
+Same reasoning via `Submodule.inner_orthogonalProjection_eq_of_mem_left`.  Together with
+`inner_compress_eq` this is the full unconditional two-sided adjoint identity for the
+orthogonal compression; `isSymmetric_compress` is their combination when `T` is symmetric. -/
+theorem inner_compress_eq' (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) (y z : H) :
+    @inner 𝕜 H _ y (compress T H z) = @inner 𝕜 V _ (y : V) (T (z : V)) := by
+  rw [compress_apply, Submodule.inner_orthogonalProjection_eq_of_mem_left]
+
 /-- The compression of a symmetric operator is symmetric.  Both inner products
 collapse to `⟪T ↑y, ↑z⟫_V` via the projection adjoint identity, and that is
 symmetric because `T` is. -/


### PR DESCRIPTION
## Context — the OQ is already discharged
This seeker-selected OQ asks to *discharge the Rayleigh-agreement hypothesis for the codimension-m orthogonal compression, yielding an unconditional codimension-m interlacing corollary.* **That deliverable already exists and is verified in the gallery:**

- `poincare_separation_compression` (`CauchyInterlacingPoincareCompression.lean`): the unconditional `λ_{k+m} ≤ μ_k ≤ λ_k` for **any** codimension-m subspace, **no Rayleigh side condition**.
- `rayleigh_compress_eq` (`CauchyInterlacingCompression.lean`): the Rayleigh-agreement identity, proved for **any** `T` and **any** subspace `H` — exactly the unconditional discharge the OQ describes.

So the mathematical content of this OQ is complete. I am **not** claiming new interlacing results.

## What this PR adds
The OQ's prose singles out *the projection–adjoint identity holds for every subspace* as "the point." That primitive currently exists only as duplicated local `have`s inside three proofs. This PR lifts it to two reusable, fully unconditional top-level lemmas in `CauchyInterlacingCompression.lean`:

- `inner_compress_eq`  : `⟪compress T H y, z⟫_H = ⟪T ↑y, ↑z⟫_V`
- `inner_compress_eq'` : `⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫_V`

for **any** operator `T`, **any** subspace `H`, **any** `y z : H` (no symmetry, no invariance). These are the bilinear generalisation of `rayleigh_compress_eq` (its diagonal `z = y` real part) and the two halves of `isSymmetric_compress`.

## Proof
Verbatim the already-verified inline `have hl`/`have hr` of `isSymmetric_compress`, each a two-`rw` one-liner (`compress_apply` + `Submodule.inner_orthogonalProjection_eq_of_mem_{right,left}`). 0 axioms, 0 sorries.

## Verification status
**UNVERIFIED** — docker build infra down this session (containerd `meta.db` input/output error at image build). Confidence is very high: both proofs are copies of already-verified inline proofs in the same file, only generalised by dropping the unused symmetry hypothesis.