### PR TITLE
research(erdos-165-oq-05): uniqueness of the exact asymptotic constant for R(3,k)

### DIFF
--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -376,6 +376,28 @@ theorem constantConjecture_forces_bracket (c : ℝ) (h : constantConjecture c) :
     push_neg at hgt
     exact constantConjecture_refuted_of_one_lt c hgt h
 
+/-- **Uniqueness of the exact asymptotic constant.**  At most one constant can be the
+    first-order asymptotic constant of `R(3,k)`: if both `constantConjecture c₁` and
+    `constantConjecture c₂` hold, then `c₁ = c₂`.  A two-sided application of the axiom-free
+    `asymptotic_constant_le` — pairing `c₁`'s lower bound with `c₂`'s upper bound gives
+    `c₁ ≤ c₂`, and the symmetric pairing gives `c₂ ≤ c₁`.  So the family `constantConjecture c`
+    is a genuine *singleton predicate*: at most one member can hold, and (with
+    `constantConjecture_forces_bracket`) that member's constant lies in `[1/2, 1]`.  In
+    particular `mainConjecture` (`c = 1/2`) and `pgmConjecture` (`c = 1/4`) are mutually
+    exclusive.  No Ramsey axioms are used. -/
+theorem constantConjecture_unique (c₁ c₂ : ℝ)
+    (h₁ : constantConjecture c₁) (h₂ : constantConjecture c₂) :
+    c₁ = c₂ := by
+  have h12 : c₁ ≤ c₂ :=
+    asymptotic_constant_le (fun k => (R3 k : ℝ)) c₁ c₂
+      (fun ε hε => by obtain ⟨k₀, hk₀⟩ := h₁ ε hε; exact ⟨k₀, fun k hk => (hk₀ k hk).1⟩)
+      (fun ε hε => by obtain ⟨k₀, hk₀⟩ := h₂ ε hε; exact ⟨k₀, fun k hk => (hk₀ k hk).2⟩)
+  have h21 : c₂ ≤ c₁ :=
+    asymptotic_constant_le (fun k => (R3 k : ℝ)) c₂ c₁
+      (fun ε hε => by obtain ⟨k₀, hk₀⟩ := h₂ ε hε; exact ⟨k₀, fun k hk => (hk₀ k hk).1⟩)
+      (fun ε hε => by obtain ⟨k₀, hk₀⟩ := h₁ ε hε; exact ⟨k₀, fun k hk => (hk₀ k hk).2⟩)
+  linarith
+
 /- ## Part VII: Related Problems -/
 
 /-

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -56,10 +56,10 @@
       "Repaired latent Mathlib-drift breakage in erdos_165 (linarith could not widen 5/4 to 2 without k²/log k ≥ 0)"
     ],
     "axiomCount": 10,
-    "lineCount": 396,
+    "lineCount": 418,
     "assumptions": "10 axioms (unchanged): ramseyNumber, ramseyNumber_symm, ramseyNumber_recurrence, R3_small_values, aks_upper_bound, shearer_upper_bound, kim_lower_bound, bk_pgm_bound, cjms_bound, hhkp_bound. 0 sorries. New theorems add no axioms; asymptotic_constant_le is fully axiom-free; pgm_conjecture_refuted depends only on the existing hhkp_bound.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 4,
     "additionalFiles": [
       "Proofs/Stubs/Erdos165Aristotle.lean"
@@ -166,9 +166,9 @@
       "Real"
     ],
     "namespace": "Erdos165",
-    "lineCount": 396,
+    "lineCount": 418,
     "axiomCount": 10,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 4,
     "path": "Proofs/Erdos165Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds `constantConjecture_unique` to `Erdos165Problem.lean` (Erdős #165, asymptotics of R(3,k)):

> If both `constantConjecture c₁` and `constantConjecture c₂` hold, then `c₁ = c₂`.

The predicate family `constantConjecture c` (`R(3,k) ~ c·k²/log k`) is therefore a genuine **singleton** — at most one exact asymptotic constant can exist. In particular `mainConjecture` (c = 1/2) and `pgmConjecture` (c = 1/4) are mutually exclusive, and (with the existing `constantConjecture_forces_bracket`) the unique surviving value lies in `[1/2, 1]`.

## Proof

A two-sided application of the file's own **axiom-free** `asymptotic_constant_le`:
- pair `c₁`'s lower bound with `c₂`'s upper bound → `c₁ ≤ c₂`;
- the symmetric pairing → `c₂ ≤ c₁`;
- `linarith`.

It reuses the exact `.1`/`.2` conjunction-extraction idiom already used by `R3_upper_constant_ge_half` and `R3_lower_constant_le_one`. No new axioms.

## Verification status

**UNVERIFIED.** The docker build wrapper is down this session (containerd `meta.db` input/output error at image-build; host disk healthy). Elaboration checked by eye against the file's sibling obstruction lemmas. Meta counts synced: lineCount 396→418, theoremCount 10→11. 0 new axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)