### PR TITLE
Enrich Fibonacci prime-index: divisibility-law xref + annotation anchor fix

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02-prime-index/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02-prime-index/annotations.json
@@ -110,7 +110,7 @@
     "id": "ann-fiboq0202-5",
     "proofId": "fibonacci-identities-oq-02-oq-02-prime-index",
     "range": {
-      "startLine": 96,
+      "startLine": 100,
       "endLine": 119
     },
     "type": "concept",

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02-prime-index/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02-prime-index/meta.json
@@ -127,6 +127,11 @@
       "targetId": "fibonacci-identities-oq-02-oq-01",
       "relationship": "related",
       "description": "Sibling entry on the Lucas companion sequence's divisibility law. Both explore the divisibility structure exposed by the parent's index-divisibility characterization; this entry applies it to primality of the values."
+    },
+    {
+      "targetId": "fibonacci-divisibility-oq-07",
+      "relationship": "foundational",
+      "description": "The precise index-divisibility characterization this proof rests on: Fₘ ∣ Fₙ ⟺ m ∣ n, sharp at m = 2 (where F₂ = 1 is a unit and divides every Fₙ). It is exactly this sharpness at 2 that produces the unique exceptional index n = 4 here — 4's only proper divisor above 1 is 2, whose Fibonacci value is a unit — so the m = 2 boundary of that entry and the n = 4 escape of this one are the same phenomenon."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass on `fibonacci-identities-oq-02-oq-02-prime-index`.

**Gaps addressed:**
- **crossReferences (2 → 3):** added a `foundational` link to `fibonacci-divisibility-oq-07` (Fₘ ∣ Fₙ ⟺ m ∣ n, sharp at m = 2) — the exact index-divisibility characterization this proof rests on. The description draws out that the entry's sharpness at m = 2 and this proof's unique exceptional index n = 4 are the same phenomenon.
- **Annotation anchor fix:** `ann-fiboq0202-5` had `startLine: 96` (a comment separator), triggering a 'No Lean construct found' validator warning. Moved it to line 100 (the theorem docstring); warning cleared.

meta.json 14.0KB → 14.6KB. JSON validates; gallery data-validation passes; entry now has zero annotation warnings. Additive + one anchor correction.