### PR TITLE
Enrich Cyclic Specialization (Burnside necklace count): add classical references

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01/meta.json
@@ -158,5 +158,42 @@
     "definitionCount": 2,
     "theoremCount": 5
   },
+  "references": [
+    {
+      "authors": "Augustin-Louis Cauchy",
+      "title": "Mémoire sur diverses propriétés remarquables des substitutions régulières ou irrégulières, et des systèmes de substitutions conjuguées",
+      "year": "1845",
+      "venue": "Comptes Rendus de l'Académie des Sciences, Paris, 21, 835–843",
+      "note": "Establishes the transitive case of the orbit-counting lemma (average number of fixed points equals the number of orbits) — the earliest source for what is now called the Cauchy–Frobenius–Burnside lemma underlying this necklace count."
+    },
+    {
+      "authors": "Ferdinand Georg Frobenius",
+      "title": "Über die Congruenz nach einem aus zwei endlichen Gruppen gebildeten Doppelmodul",
+      "year": "1887",
+      "venue": "Journal für die reine und angewandte Mathematik (Crelle) 101, 273–299",
+      "note": "General form of the orbit-counting lemma for an arbitrary finite group action; the averaging identity Σ_g |Fix(g)| = (#orbits)·|G| specialized here to the cyclic rotation action (result (C))."
+    },
+    {
+      "authors": "William Burnside",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "venue": "Cambridge University Press (2nd ed. 1911, §145)",
+      "note": "Popularized the orbit-counting lemma — hence the common name 'Burnside's lemma' — though Burnside himself attributed it to Frobenius; the k-colored necklace count is its textbook first application."
+    },
+    {
+      "authors": "George Pólya",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "venue": "Acta Mathematica 68, 145–254",
+      "note": "The Pólya enumeration theorem, a cycle-index refinement of Burnside's lemma that generalizes the k^{gcd(n,r)} per-rotation count to the full generating-function necklace enumeration (1/n)·Σ_{d|n} φ(n/d) k^d (see openQuestions)."
+    },
+    {
+      "authors": "J. Howard Redfield",
+      "title": "The Theory of Group-Reduced Distributions",
+      "year": "1927",
+      "venue": "American Journal of Mathematics 49 (3), 433–455",
+      "note": "Independent earlier discovery of the enumeration theory later rediscovered by Pólya; the foundational combinatorial source for counting colorings up to a group action such as necklace rotations."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-03-oq-02-oq-01`.

**Defect addressed:** REFS0 — the entry had `references: null` (empty) despite being an otherwise fully-enriched, verified entry on the classical topic of counting k-colored necklaces via Burnside's lemma.

**Change:** Added 5 accurate classical references, grounded in the entry's own content and Lean docstring (Cauchy–Frobenius–Burnside orbit counting + Pólya/Redfield enumeration):
- **Cauchy (1845)** — transitive case of the orbit-counting lemma
- **Frobenius (1887)** — general finite-group form (the averaging identity behind result (C))
- **Burnside (1897)** — popularization / the 'Burnside's lemma' name (with the standard historical caveat that he attributed it to Frobenius)
- **Pólya (1937)** — cycle-index generalization matching openQuestions[1]'s divisor form (1/n)·Σ φ(n/d) k^d
- **Redfield (1927)** — earlier independent discovery

No other fields were modified. Size check passes (18 KB, well under the 60 KB cap).