### PR TITLE
audit(erdos-928): re-verify CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17450,9 +17450,9 @@
       "result": "clean"
     },
     "erdos-928": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:06Z",
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T06:58:42Z",
       "result": "clean"
     },
     "erdos-929": {
@@ -29771,5 +29771,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T06:24:46Z"
+  "lastUpdated": "2026-07-10T06:58:42Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-928

**Result: CLEAN** — no integrity issues found.

Erdős Problem #928 (Density of Consecutive Smooth Numbers), an OPEN problem, re-audited (stalest tracker entry, previously 2026-05-04).

### Verification vs Lean source (`proofs/Proofs/Erdos928Problem.lean`)

| Field | meta.json | Actual | Match |
|-------|-----------|--------|-------|
| lineCount | 259 | 259 | ✓ |
| axiomCount | 4 | 4 | ✓ |
| theoremCount | 2 | 2 | ✓ |
| definitionCount | 9 | 9 | ✓ |
| sorries | 0 | 0 | ✓ |
| status/badge | axiomatized/axiom | correct for OPEN | ✓ |

### Integrity notes
- 4 real `axiom` declarations (`dickman_function`, `infinitely_many_exist`, `teravainen_log_density`, `wang_conditional`), all disclosed by name in `assumptions` and `originalContributions`. No axiom masking.
- 0 `native_decide` → no undisclosed `Lean.ofReduceBool`; axiomCount 4 is exact.
- 0 True stubs — both theorems (`erdos_928_summary`, `erdos_928`) conclude substantive propositions built from the disclosed axioms.
- `originalContributions` honestly labels Dickman's theorem and supporting facts as docstring-only (not formalized). Every named decl exists in source — no phantom names.
- OPEN problem correctly presented as `axiomatized`; public status states "OPEN unconditionally".

Tracker bump only (auditCount 3→4, lastAudited refreshed). No content changes needed.

---
Discovered during gallery integrity audit.