### PR TITLE
research(algebraic-numbers-countable-oq-07): transcendentals have full Hausdorff dimension (dimH=1 on ℝ, =2 on ℂ) [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -280,6 +280,40 @@ theorem transcendental_complex_dense :
   rw [algebraic_complex_dimH_zero]
   exact_mod_cast Module.finrank_pos
 
+/-- **The transcendental reals have full Hausdorff dimension**, `dimH = 1`.
+
+This is the co-small dual of `algebraic_reals_dimH_zero`, completing the
+Hausdorff-dimension pillar: whereas the algebraic reals are dimension `0`, the
+transcendentals fill the whole line dimensionally.  Since `ℝ = {algebraic} ∪
+{transcendental}` and `dimH` of a union is the max of the parts
+(`dimH_union`), the transcendentals must carry the full dimension of `ℝ`:
+`1 = dimH ℝ = max (dimH {algebraic}) (dimH {transcendental}) = max 0 (dimH
+{transcendental})`. -/
+theorem transcendental_reals_dimH_one :
+    dimH {x : ℝ | Transcendental ℚ x} = 1 := by
+  have hcompl : {x : ℝ | Transcendental ℚ x} = {x : ℝ | IsAlgebraic ℚ x}ᶜ := by
+    ext x; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  have huniv : {x : ℝ | IsAlgebraic ℚ x} ∪ {x : ℝ | Transcendental ℚ x} = univ := by
+    rw [hcompl, union_compl_self]
+  have hun := dimH_union {x : ℝ | IsAlgebraic ℚ x} {x : ℝ | Transcendental ℚ x}
+  rw [huniv, Real.dimH_univ, algebraic_reals_dimH_zero, max_eq_right (zero_le _)] at hun
+  exact hun.symm
+
+/-- **The transcendental complex numbers have full Hausdorff dimension**, `dimH = 2`.
+
+The complex analogue of `transcendental_reals_dimH_one`, with `dimH (univ : Set ℂ)
+= finrank ℝ ℂ = 2`.  Co-small dual of `algebraic_complex_dimH_zero`. -/
+theorem transcendental_complex_dimH_two :
+    dimH {z : ℂ | Transcendental ℚ z} = 2 := by
+  have hcompl : {z : ℂ | Transcendental ℚ z} = {z : ℂ | IsAlgebraic ℚ z}ᶜ := by
+    ext z; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  have huniv : {z : ℂ | IsAlgebraic ℚ z} ∪ {z : ℂ | Transcendental ℚ z} = univ := by
+    rw [hcompl, union_compl_self]
+  have hun := dimH_union {z : ℂ | IsAlgebraic ℚ z} {z : ℂ | Transcendental ℚ z}
+  rw [huniv, Real.dimH_univ_eq_finrank ℂ, Complex.finrank_real_complex,
+    algebraic_complex_dimH_zero, max_eq_right (zero_le _)] at hun
+  rw [← hun]; norm_num
+
 -- ============================================================================
 -- § 5. Generalization to arbitrary atomless measures
 -- ============================================================================

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 359,
+    "lineCount": 393,
     "theoremCount": 16,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",


### PR DESCRIPTION
## Summary

`AlgebraicRealsNull` (the measure/dimension pillar of the algebraic-numbers
trichotomy) proves the **algebraic** reals/complexes have Hausdorff dimension
`0` — sharper than Lebesgue-null. It supplies the co-small duals for *measure*
(transcendentals conull) and *category* (transcendentals dense), but the
co-small **Hausdorff-dimension** statement was missing. This PR adds it.

### New results

- **`transcendental_reals_dimH_one`** — `dimH {x : ℝ | Transcendental ℚ x} = 1`
- **`transcendental_complex_dimH_two`** — `dimH {z : ℂ | Transcendental ℚ z} = 2`

### Proof

`ℝ = {algebraic} ∪ {transcendental}` and `dimH` of a union is the max of the
parts (`dimH_union`). Since `dimH {algebraic} = 0` (`algebraic_reals_dimH_zero`)
and `dimH (univ : Set ℝ) = 1` (`Real.dimH_univ`; `= finrank ℝ ℂ = 2` for ℂ via
`Real.dimH_univ_eq_finrank` + `Complex.finrank_real_complex`), the
transcendentals must carry the full ambient dimension. This mirrors the existing
`transcendental_reals_dense` / `transcendental_reals_conull` co-small statements,
now giving the metric-dimension pillar both directions.

### Verification

- **0 sorry / 0 axiom** on top of Mathlib + the parent countability entry.
- Gallery meta `lineCount` synced 359 → 393.
- **UNVERIFIED**: docker build blocked by the persistent containerd `meta.db`
  input/output error (infra #35184; host disk healthy). The proof reuses the
  exact `hcompl`/`huniv` set-manipulation idioms already verified in this file
  and was checked against confirmed Mathlib API (`dimH_union`, `Real.dimH_univ`,
  `Real.dimH_univ_eq_finrank` with explicit `E`, `Complex.finrank_real_complex`,
  `union_compl_self` (`@[simp]`), `max_eq_right`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)