### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): closed form jacobiCount p = 8(p+1) for odd primes

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ01OQ03.lean
@@ -90,6 +90,15 @@ theorem jacobiCount_odd {n : ℕ} (hn : Odd n) :
   have : (2 : ℕ) ∣ n := dvd_trans hd4 hd.1
   exact (Nat.not_even_iff_odd.mpr hn) (even_iff_two_dvd.mpr this)
 
+/-- **Prime specialization (0-axiom, general).** For an odd prime `p` the only
+divisors are `1` and `p`, both coprime to `4`, so Jacobi's count is the closed form
+`jacobiCount p = 8·(p+1)`. Combined with `jacobi_oracle` this pins `r₄(p) = 8(p+1)`
+for the small odd primes in range (`r₄(3)=32=8·4`, `r₄(5)=48=8·6`, `r₄(7)=64=8·8`). -/
+theorem jacobiCount_prime {p : ℕ} (hp : p.Prime) (hodd : Odd p) :
+    jacobiCount p = 8 * (p + 1) := by
+  rw [jacobiCount_odd hodd, hp.divisors, Finset.sum_pair hp.one_lt.ne]
+  ring
+
 /-- **Convention guard (0-axiom).** The naive formula `8·σ(n)` is WRONG for `n = 4`:
 `8·σ(4) = 8·(1+2+4) = 56`, whereas the true count is `r4 4 = 24`. Equivalently the
 `4 ∤ d` exclusion drops the divisor `d = 4`. This is exactly why the general formula

--- a/src/data/proofs/lagrange-four-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-01-oq-03/meta.json
@@ -35,8 +35,8 @@
       }
     ],
     "assumptions": "The general Jacobi four-square theorem is NOT proved — it is a genuine Mathlib gap requiring either Hurwitz-quaternion order arithmetic or weight-2 modular forms (θ⁴∈M₂(Γ₀(4))), each ≫1000 LOC of absent number theory. This entry proves (a) a 0-axiom general lemma jacobiCount_odd (for odd n the 4∤d filter is vacuous, so jacobiCount n = 8·σ(n)), and (b) a machine-checked oracle jacobi_oracle : ∀ n∈[1,24], r₄ n = jacobiCount n, discharged by native_decide. native_decide trusts the Lean compiler and depends on the Lean.ofReduceBool axiom (#print axioms lists it, together with Lean.trustCompiler); naive_sigma_fails and r4_anchor_values also use native_decide. The entry is therefore axiomatized, not axiom-free. The literal `axiom` declaration count in the Lean file is 0; the single counted assumption is Lean.ofReduceBool introduced via native_decide.",
-    "lineCount": 117,
-    "theoremCount": 4,
+    "lineCount": 126,
+    "theoremCount": 5,
     "definitionCount": 3,
     "originalContributions": [
       "r4: the ordered, signed four-square representation count r₄(n), defined as a computable Finset.card over the integer box [-√n,√n]⁴ — an object Mathlib lacks entirely",
@@ -123,12 +123,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 117,
+    "lineCount": 126,
     "path": "Proofs/LagrangeFourSquaresOQ01OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 4
+    "theoremCount": 5
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Adds one clean, **0-axiom, general** gap-fill lemma to the saturated Jacobi four-square oracle entry.

```lean
theorem jacobiCount_prime {p : ℕ} (hp : p.Prime) (hodd : Odd p) :
    jacobiCount p = 8 * (p + 1) := by
  rw [jacobiCount_odd hodd, hp.divisors, Finset.sum_pair hp.one_lt.ne]
  ring
```

For an odd prime `p`, the only divisors are `1` and `p`, both coprime to `4`, so Jacobi's divisor-sum `jacobiCount p = 8·Σ_{d|p, 4∤d} d` collapses to the closed form `8·(p+1)`. It builds directly on the file's existing general lemma `jacobiCount_odd` (odd n ⟹ 4∤d filter vacuous ⟹ `8·σ(n)`), then specializes σ(p)=1+p via `Nat.Prime.divisors` (`p.divisors = {1,p}`) and `Finset.sum_pair`.

Combined with the existing `jacobi_oracle` (`r₄ n = jacobiCount n` for 1≤n≤24), this pins the ordered-signed representation count `r₄(p) = 8(p+1)` for the small odd primes in range: `r₄(3)=32=8·4`, `r₄(5)=48=8·6`, `r₄(7)=64=8·8`.

No new axioms; the lemma is `decide`/kernel-level (no `native_decide`). Meta resynced: lineCount 117→126, theoremCount 4→5.

## Verification status

**UNVERIFIED** — the docker build wrapper is down this session (containerd `meta.db` input/output error at image build, an operator-level infra fault). The proof is a short, by-eye-checkable `rw … ; ring` over rock-solid, long-stable Mathlib API (`Nat.Prime.divisors`, `Finset.sum_pair`, `Nat.Prime.one_lt`). Requesting a clean docker rebuild to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)