### PR TITLE
research(erdos-1204): exact S(5)=28, B(5)=28/5 (frontier +1, VERIFIED)

### DIFF
--- a/proofs/Proofs/Erdos1204B.lean
+++ b/proofs/Proofs/Erdos1204B.lean
@@ -1,5 +1,6 @@
 import Proofs.Erdos1204Problem
 import Proofs.Erdos1204A4
+import Proofs.Erdos1204A5
 
 /-
 # Erdős #1204 — the second extremal quantity `B(k)`
@@ -233,6 +234,46 @@ theorem admissible_four_sum_ge {a : Finset ℕ} (hcard : a.card = 4)
     rw [← Finset.add_sum_erase a id hMmem]; simp
   omega
 
+/-- **Lower-bound core for `S(5)`.** Every admissible `5`-set has element sum at least
+`28`. The maximum `M` is `≥ 12` (`admissible_five_sup_ge`, the `A(5)` lower bound), and
+the remaining admissible `4`-set has sum `≥ 16` (`admissible_four_sum_ge`), so the total
+is `≥ 12 + 16 = 28`. The same bootstrap `S(k) ≥ A(k) + S(k-1)` as at `k = 4`, now with the
+`A(5) = 12` diameter value. -/
+theorem admissible_five_sum_ge {a : Finset ℕ} (hcard : a.card = 5)
+    (ha : Admissible a) : 28 ≤ a.sum id := by
+  have hne : a.Nonempty := by rw [← Finset.card_pos, hcard]; omega
+  set M := a.max' hne with hMdef
+  have hMmem : M ∈ a := a.max'_mem hne
+  -- `M ≥ 12` from the `A(5)` lower bound `sup ≥ 12`
+  have hsup12 : 12 ≤ a.sup id := admissible_five_sup_ge hcard ha
+  have hsupM : a.sup id ≤ M :=
+    Finset.sup_le (fun x hx => by simpa using a.le_max' x hx)
+  have hM12 : 12 ≤ M := le_trans hsup12 hsupM
+  -- the erased `4`-set has sum `≥ 16`
+  have haer : Admissible (a.erase M) := ha.subset (a.erase_subset M)
+  have hcarderase : (a.erase M).card = 4 := by
+    rw [Finset.card_erase_of_mem hMmem, hcard]
+  have h4 : 16 ≤ (a.erase M).sum id := admissible_four_sum_ge hcarderase haer
+  have hsum : a.sum id = M + (a.erase M).sum id := by
+    rw [← Finset.add_sum_erase a id hMmem]; simp
+  omega
+
+/-- **`S(5) = 28`.** Upper bound from the witness `{0, 2, 6, 8, 12}` (sum `28`, the
+`A(5)` extremal set from `Erdos1204A5.lean`); lower bound `28 ≤ S 5` from
+`admissible_five_sum_ge`. So `S(5) = A(5) + S(4) = 12 + 16 = 28` — the bootstrap stays
+sharp, and the minimal-diameter set `{0,2,6,8,12}` is again *also* the minimal-sum set
+(its sum `28` meets the lower bound exactly), so the min-diameter and min-average optima
+continue to coincide at `k = 5`. -/
+theorem S_five : S 5 = 28 := by
+  apply le_antisymm
+  · have h := S_le (k := 5) (a := ({0, 2, 6, 8, 12} : Finset ℕ)) (by decide)
+      admissible_witness_five
+    have hs : ({0, 2, 6, 8, 12} : Finset ℕ).sum id = 28 := by decide
+    rwa [hs] at h
+  · obtain ⟨a, hcard, ha, hsum⟩ := S_mem 5
+    have hge := admissible_five_sum_ge hcard ha
+    omega
+
 /-- **`S(4) = 16`.** Upper bound from the witness `{0, 2, 6, 8}` (sum `16`, the
 `A(4)` extremal set); lower bound `16 ≤ S 4` from `admissible_four_sum_ge`. So the
 minimal average is `B(4) = 4`, again strictly above the parity floor `k - 1 = 3`. -/
@@ -281,6 +322,13 @@ parity floor `k - 1 = 3`; the extremal set `{0, 2, 6, 8}` (which also realizes
 min-diameter optima still coincide. -/
 theorem B_four : B 4 = 4 := by
   rw [B, S_four]; norm_num
+
+/-- **`B(5) = 28/5 = 5.6`.** From `S(5) = 28`. Strictly above the parity floor
+`k - 1 = 4`; as at `k = 3, 4` the extremal set `{0,2,6,8,12}` (which also realizes
+`A(5) = 12`) is here the minimal-sum set as well, so the min-average and min-diameter
+optima still coincide at `k = 5`. -/
+theorem B_five : B 5 = 28 / 5 := by
+  rw [B, S_five]; norm_num
 
 /-- **Diameter is dominated by sum (pointwise).** For every admissible `k`-set `a`,
 the minimal diameter `A(k)` is at most the element sum `∑ a`. The largest element
@@ -349,6 +397,9 @@ end Erdos1204
 #print axioms Erdos1204.sub_one_le_B
 #print axioms Erdos1204.S_four
 #print axioms Erdos1204.B_four
+#print axioms Erdos1204.admissible_five_sum_ge
+#print axioms Erdos1204.S_five
+#print axioms Erdos1204.B_five
 #print axioms Erdos1204.A_le_sum
 #print axioms Erdos1204.A_le_S
 #print axioms Erdos1204.A_add_S_le_S_succ

--- a/research/problems/erdos-1204/knowledge.md
+++ b/research/problems/erdos-1204/knowledge.md
@@ -339,3 +339,36 @@ numerically before claiming an exact S(5).
   admissible_zero_two_six_eight), trivial arithmetic. All reused signatures re-confirmed by grep.
   Ship UNVERIFIED per the documented dep-olean-write SIGBUS pattern; a later clean docker run
   (or host-lake bypass with complete .lake) should confirm green.
+
+## Session 2026-07-10 (researcher-1) — exact S(5)=28, B(5)=28/5 (frontier +1, VERIFIED)
+
+**Mode:** REVISIT (RICH). Executed the flagged-risky next step S(5) — and it turned out clean.
+
+### Added to Erdos1204B.lean (3 theorems, 0 axioms / 0 sorries)
+- `admissible_five_sum_ge {card=5}(Admissible) : 28 ≤ sum` — clone of admissible_four_sum_ge:
+  M=max ≥ 12 (admissible_five_sup_ge from Erdos1204A5), erased 4-set sum ≥ 16
+  (admissible_four_sum_ge), omega 12+16=28.
+- `S_five : S 5 = 28` — witness {0,2,6,8,12}=admissible_witness_five (sum 28 by decide, the
+  A(5) extremal set) + lower bound admissible_five_sum_ge.
+- `B_five : B 5 = 28/5` — clone of B_four.
+- New `import Proofs.Erdos1204A5` (A5→Problem, no cycle with B).
+
+### Key finding — the prior "risk" did NOT materialize
+Prior note worried the min-SUM set might diverge from the min-MAX set at k=5, making the
+witness sum exceed A(5)+S(4). It doesn't: {0,2,6,8,12} sum = 28 = A(5)+S(4) = 12+16 EXACTLY,
+so the min-diameter set is STILL also the min-sum set. The two optima coincide through k=5.
+The general recurrence A_add_S_le_S_succ (built a prior session) gives the same lower bound;
+here cloned the manual peel for in-order placement (A_add_S_le_S_succ is defined later in-file).
+
+### Verification — VERIFIED via dep-building lean-elab (docker down)
+[[reference-docker-down-lean-elab-verification-path]] extension: built Erdos1204Problem.olean
+(Mathlib-only), then A4/A5 (need Problem) into /tmp, then elaborated B with /tmp+mathlib-LP
+prepended: EXIT 0, ZERO errors. `#print axioms` for admissible_five_sum_ge / S_five / B_five
+= [propext, Classical.choice, Quot.sound] only — no sorryAx. (Only warning = pre-existing
+unused-var line 341, not my code.) ★Used MAIN repo's proofs/.lake for oleans since a fresh
+`git worktree add` checkout has NO .lake (gitignored) — glob main repo not worktree.
+
+★WORKTREE-EATER struck mid-edit (deleted researcher-1-2 with uncommitted edits); recovered via
+`git worktree add .loom/worktrees/researcher-1-2 -B <branch> origin/main`, redid edits, and
+COMMITTED BEFORE building. Frontier now: S(2..5), B(2..5) all exact. Next S(6) needs A(6)
+(Erdos1204A6 exists — check admissible_six_sup_ge) + witness with sum = A(6)+S(5).

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -132,8 +132,8 @@
     {
       "path": "Proofs/Erdos1204B.lean",
       "filename": "Erdos1204B.lean",
-      "lineCount": 276,
-      "theoremCount": 16,
+      "lineCount": 405,
+      "theoremCount": 24,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends the minimal-sum / minimal-average frontier of Erdős #1204 by one exact value, in `Erdos1204B.lean`:

```lean
theorem admissible_five_sum_ge {a : Finset ℕ} (hcard : a.card = 5) (ha : Admissible a) : 28 ≤ a.sum id
theorem S_five : S 5 = 28
theorem B_five : B 5 = 28 / 5
```

**Lower bound** via the bootstrap `S(5) ≥ A(5) + S(4) = 12 + 16 = 28`: the max `M ≥ 12` (`admissible_five_sup_ge`, the A(5) diameter bound from `Erdos1204A5.lean`), and the erased admissible 4-set has sum `≥ 16` (`admissible_four_sum_ge`). **Upper bound** from the witness `{0,2,6,8,12}` (sum 28, the A(5) extremal set).

**Key finding:** this resolves the prior session's flagged *risk* — the minimal-**sum** set might diverge from the minimal-**diameter** set at `k=5`. It does not: `{0,2,6,8,12}` has sum `28 = A(5)+S(4)` **exactly**, so the min-diameter set is again also the min-sum set. The two extremal optima coincide through `k = 5`.

- Clones of the verified `admissible_four_sum_ge` / `S_four` / `B_four`; new `import Proofs.Erdos1204A5` (A5 → Problem, no cycle). **0 axioms / 0 sorries.**

## Verification

**VERIFIED.** Docker infra down this session (containerd `meta.db` I/O error), so verified via the dep-building direct-`lean`-elaboration path against pinned Mathlib v4.26.0: built `Erdos1204Problem`→`A4`,`A5` oleans, then elaborated `Erdos1204B.lean`:
- `EXIT 0`, zero `error:` lines (only a pre-existing unused-variable warning at line 341).
- `#print axioms` for `admissible_five_sum_ge` / `S_five` / `B_five` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.

Research json per-file counts synced (Erdos1204B 405 lines / 24 thm). Gallery meta describes the primary `Erdos1204Problem.lean` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)