### PR TITLE
Enrich Fibonacci product-sum OQ-05-OQ-01: cross-link Lucas/Gibonacci child

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-05-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-01/meta.json
@@ -153,6 +153,11 @@
       "targetId": "fibonacci-identities-oq-04",
       "relationship": "relatedTo",
       "description": "Both entries center on Cassini's identity for Nat.fib; there it is proved via Vajda's identity over Int.fib, here it is reproved directly in subtractive form and used as the engine of the weighted-sum induction."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-05-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "Directly realizes this entry's second open question: it generalizes the Fibonacci weighted product-sum 2·∑ k FₖFₖ₊₁ to arbitrary Gibonacci sequences and to Lucas numbers, showing the parity correction ±1 becomes ±D for the discriminant D = G₁² − G₁G₀ − G₀² (D = 1 for Fibonacci, D = −5 for Lucas) — exactly the parity-tracking generalization posed here."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass on `fibonacci-identities-oq-05-oq-01`.

Already well-curated (crossRefs 3, refs 3, 4 keyInsights, 5 fully-populated annotations over the 134-line file). Added the one clearly-missing link:

- **`fibonacci-identities-oq-05-oq-01-oq-02`** (`extended-by`) — the direct child that generalizes this entry's weighted product-sum to Lucas and Gibonacci sequences (parity correction ±1 → ±D for discriminant D), realizing this entry's own open question #2.

crossReferences 3 → 4. JSON validates; gallery data-validation passes; no annotation errors. Additive only.