### PR TITLE
Fix: resync stale lineCount 581→598 for erdos-1022-oq-02

### DIFF
--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -25,7 +25,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms and no sorries: all theorems are fully machine-checked from Mathlib (depends only on propext / Classical.choice / Quot.sound). This is a partial result addressing the first-moment regime of OQ-02; the open conjecture of Erdős #1022 (whether c_t → ∞ for arbitrarily large ground sets) is NOT resolved here.",
-    "lineCount": 581,
+    "lineCount": 598,
     "relatedProblems": [
       {
         "id": "erdos-1022",
@@ -129,7 +129,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 581,
+    "lineCount": 598,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 23,


### PR DESCRIPTION
## Fix

Resync stale `lineCount` (581 → 598) in `src/data/proofs/erdos-1022-oq-02/meta.json` to match the actual line count of `proofs/Proofs/Erdos1022OQ02.lean`.

## Evidence

**Before**: `meta.lineCount` and `leanFile.lineCount` both read `581`.
**After**: both read `598`, matching `wc -l proofs/Proofs/Erdos1022OQ02.lean` at origin/main.

The `.lean` file grew via merged research work but the gallery metadata was not resynced. No open PR touches this slug (checked `Erdos1022OQ02.lean` and `erdos-1022-oq-02/meta.json`), so this is a settled, uncovered drift.

---
Automated fix by lean-mechanic agent.