### PR TITLE
research(erdos-1059-oq-01-oq-01): formalize the bad-prime fraction bound (≤ 1/(l+1)) [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -262,6 +262,46 @@ theorem levelwise_strict_surplus (l k : ℕ) (hl : l ≥ 3) (hlk : l ≥ k + 2) 
   omega
 
 /-
+## Part IV.5: The Non-Qualifying (Bad) Prime Bound
+
+The strong Selberg density axiom `q(l)·(l+1) ≥ p(l)·l` is exactly the statement
+that at most a `1/(l+1)` fraction of the primes in `I(l)` are "bad"
+(non-qualifying).  The docstring of `strong_selberg_density` advertises this
+reading; the two lemmas below record it as formal consequences, using only the
+axiom and `q(l) ≤ p(l)`.
+-/
+
+/-- **The bad-prime fraction is at most `1/(l+1)`.**  The number of
+    non-qualifying primes `p(l) − q(l)` in the primorial interval `I(l)`
+    satisfies `(p(l) − q(l))·(l+1) ≤ p(l)`, i.e. at most a `1/(l+1)` fraction of
+    the primes fail the AFSC property.  This is the cross-multiplied form of the
+    sieve prediction stated informally in the `strong_selberg_density`
+    docstring. -/
+theorem nonqualifying_fraction_bound (l : ℕ) (hl : l ≥ 3) :
+    (primesInLevel l - qualifyingInLevel l) * (l + 1) ≤ primesInLevel l := by
+  have hs := strong_selberg_density l hl
+  have hqp := qualifyingInLevel_le_primesInLevel l
+  rw [Nat.sub_mul]
+  have h1 : primesInLevel l * (l + 1) = primesInLevel l * l + primesInLevel l := by ring
+  omega
+
+/-- **Qualifying primes outnumber the bad primes by a factor of at least `l`.**
+    From `q(l)·(l+1) ≥ p(l)·l` and `q(l) ≤ p(l)`: `(p(l) − q(l))·l ≤ q(l)`.  So
+    for every `l ≥ 3` the non-qualifying primes are at most a `1/l` fraction of
+    the qualifying ones — a form of the density bound that isolates the surplus
+    of good over bad primes. -/
+theorem nonqualifying_le_qualifying_div_level (l : ℕ) (hl : l ≥ 3) :
+    (primesInLevel l - qualifyingInLevel l) * l ≤ qualifyingInLevel l := by
+  have hs := strong_selberg_density l hl
+  have hqp := qualifyingInLevel_le_primesInLevel l
+  have hq1 : qualifyingInLevel l * (l + 1)
+      = qualifyingInLevel l * l + qualifyingInLevel l := by ring
+  have hp1 : primesInLevel l * l
+      = qualifyingInLevel l * l + (primesInLevel l - qualifyingInLevel l) * l := by
+    rw [← Nat.add_mul]; congr 1; omega
+  omega
+
+/-
 ## Part V: Gap Analysis — Why General x Fails
 
 At factorial evaluation points x = n!, the density bound follows from summing

--- a/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
@@ -69,7 +69,7 @@
       "Sieve theory: Selberg sieve, Brun-Titchmarsh inequality (motivational)",
       "Finset operations: filter, card, sum, sum splitting"
     ],
-    "lineCount": 552,
+    "lineCount": 682,
     "relatedProblems": [
       {
         "id": "erdos-1059-oq-01",


### PR DESCRIPTION
## Summary

The strong Selberg density axiom `q(l)·(l+1) ≥ p(l)·l` (`strong_selberg_density`)
is *exactly* the statement that at most a `1/(l+1)` fraction of the primes in the
primorial interval `I(l) = (l!, (l+1)!]` are **non-qualifying** ("bad"). The
axiom's own docstring advertises this reading in prose but the file never records
it as a lemma. This PR adds two direct consequences.

### New results (in `Erdos1059OQ01OQ01.lean`, Part IV.5)

- **`nonqualifying_fraction_bound`** — `(p(l) − q(l))·(l+1) ≤ p(l)`
  (the bad primes are at most a `1/(l+1)` fraction of all primes in `I(l)`).
- **`nonqualifying_le_qualifying_div_level`** — `(p(l) − q(l))·l ≤ q(l)`
  (the qualifying primes outnumber the bad ones by a factor of at least `l`).

Both follow from `strong_selberg_density` together with the already-proven
`qualifyingInLevel_le_primesInLevel` (`q(l) ≤ p(l)`), via ring-normalized
splittings and `omega` — the same style as the existing `levelwise_density_bound`
and `levelwise_strict_surplus`.

### Verification

- **Adds no axioms** (reuses the existing `strong_selberg_density`); no new
  `sorry`. The entry remains `axiomatized` on that one sieve axiom.
- Gallery meta `lineCount` synced 552 → 682 (folds in pre-existing drift from the
  merged #37126 plus this addition).
- **UNVERIFIED**: docker build blocked by the persistent containerd `meta.db`
  input/output error (infra #35184; host disk healthy). The proofs use only
  `omega`, `ring`, and `Nat.sub_mul`/`Nat.add_mul` (the former already used
  elsewhere in the repo), mirroring the file's own arithmetic idioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)