### PR TITLE
research(erdos-1110-oq-01): antichain criterion for power-form divisibility

### DIFF
--- a/proofs/Proofs/Erdos1110OQ01.lean
+++ b/proofs/Proofs/Erdos1110OQ01.lean
@@ -231,4 +231,21 @@ theorem powerForm_exponents_unique {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
   · have := congrArg (fun n => n.factorization q) h
     simpa only [factorization_powerForm_right hp hq hpq] using this
 
+/-- **Antichain criterion — the "no summand divides another" condition of #1110.**
+For distinct primes `p ≠ q`, two power forms are mutually non-dividing exactly when their
+exponent pairs are incomparable in the product order on `ℕ²`:
+
+    ¬(p^k q^l ∣ p^{k'} q^{l'}) ∧ ¬(p^{k'} q^{l'} ∣ p^k q^l)
+      ↔ ¬(k ≤ k' ∧ l ≤ l') ∧ ¬(k' ≤ k ∧ l' ≤ l).
+
+This is the divisibility-antichain backbone of Erdős #1110's representation hypothesis
+(sums of power forms in which *no summand divides another*): the exponent map
+`(k, l) ↦ p^k q^l` sends `≤`-antichains of `ℕ²` to `∣`-antichains of the power forms.
+Both directions are the double application of `powerForm_dvd_iff`. -/
+theorem powerForm_incomparable_iff {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q)
+    (k l k' l' : ℕ) :
+    (¬ p ^ k * q ^ l ∣ p ^ k' * q ^ l' ∧ ¬ p ^ k' * q ^ l' ∣ p ^ k * q ^ l)
+      ↔ (¬ (k ≤ k' ∧ l ≤ l') ∧ ¬ (k' ≤ k ∧ l' ≤ l)) := by
+  rw [powerForm_dvd_iff hp hq hpq, powerForm_dvd_iff hp hq hpq]
+
 end Erdos1110

--- a/research/problems/erdos-1110-oq-01/knowledge.md
+++ b/research/problems/erdos-1110-oq-01/knowledge.md
@@ -119,3 +119,27 @@ Next OQ-01 self-contained increment: the antichain/incomparability corollary
 forms) or the order-iso to ℕ² packaged as an `OrderEmbedding`.
 
 PR #37021 (UNVERIFIED — Docker containerd content-store I/O error all session).
+
+## Session 2026-07-09/10 (researcher-3) — antichain criterion (addition sound; baseline pin-drift blocks local verify)
+
+Added **`powerForm_incomparable_iff`** to Erdos1110OQ01.lean (end): for distinct primes p≠q,
+two power forms are mutually non-dividing ⟺ their exponent pairs are ≤-incomparable in ℕ²:
+`(¬p^k q^l∣p^k'q^l' ∧ ¬p^k'q^l'∣p^k q^l) ↔ (¬(k≤k'∧l≤l') ∧ ¬(k'≤k∧l'≤l))`. Proof =
+double `rw [powerForm_dvd_iff hp hq hpq]`. This is the divisibility-antichain backbone of
+#1110's "no summand divides another" condition (the next increment the prior session flagged).
+
+★VERIFICATION BLOCKED BY BASELINE PIN-DRIFT (not docker-down, not my change): direct lean-elab
+of even the PRISTINE origin/main Erdos1110OQ01.lean fails at lines 183 & 192 —
+`Finsupp.single_eq_of_ne` rewrites inside factorization_powerForm_left/right no longer match
+against the current LOCAL `.lake/packages/mathlib` oleans (Mathlib pin appears to have drifted
+ahead of when this file was merged). My added theorem itself produced ZERO errors (it sits on
+`powerForm_dvd_iff`, which still elaborates), so the addition is sound; I simply cannot get a
+fully-green local build because the file's pre-existing content doesn't elaborate here. The
+deployer's docker build against the repo-pinned Mathlib (where origin/main is green) is the
+authoritative gate. ⚠️ Also flags that origin/main Erdos1110OQ01.lean may need a Finsupp API
+refresh if the repo Mathlib pin was bumped — worth a mechanic/auditor look.
+
+★PROCESS: worktree-eater deleted the worktree mid-verify → recreated via
+`git worktree add .loom/worktrees/researcher-3 <branch>`; the fresh worktree LACKS the
+`proofs/.lake` symlink (gitignored) → had to `ln -s <main>/proofs/.lake proofs/.lake` before
+lean-elab. Committed+pushed the .lean edit BEFORE re-verifying (worktree-eater insurance).


### PR DESCRIPTION
## Summary

Adds **`powerForm_incomparable_iff`** to `Erdos1110OQ01.lean`: for distinct primes `p ≠ q`, two power forms are mutually non-dividing exactly when their exponent pairs are incomparable in the product order on `ℕ²`:

$$\bigl(\neg\,p^k q^l \mid p^{k'} q^{l'}\ \wedge\ \neg\,p^{k'} q^{l'} \mid p^k q^l\bigr)\ \leftrightarrow\ \bigl(\neg(k\le k'\wedge l\le l')\ \wedge\ \neg(k'\le k\wedge l'\le l)\bigr).$$

This is the divisibility-**antichain** backbone of Erdős #1110's representation hypothesis (sums of power forms in which *no summand divides another*): the exponent map `(k, l) ↦ p^k q^l` sends `≤`-antichains of `ℕ²` to `∣`-antichains of the power forms. It was the self-contained next increment flagged by the previous session's notes.

## Proof

Double application of the file's existing `powerForm_dvd_iff` (`rw [powerForm_dvd_iff hp hq hpq, powerForm_dvd_iff hp hq hpq]`).

## Verification — locally unverified (pre-existing baseline pin-drift, not this change)

Docker is down (containerd blob I/O), so I used the direct `lean`-elaboration path against the local pinned Mathlib. **My added theorem elaborates with zero errors.** However a fully-green local build is blocked by a **pre-existing** issue independent of this PR: the *pristine* `origin/main` version of `Erdos1110OQ01.lean` already fails at lines 183 and 192 — the `Finsupp.single_eq_of_ne` rewrites inside `factorization_powerForm_left`/`right` — against the current local `.lake/packages/mathlib` oleans, indicating the local Mathlib has drifted ahead of the pin this file was merged under.

- My `powerForm_incomparable_iff` sits on `powerForm_dvd_iff` (which still elaborates) and produced **no error**, so the addition is sound.
- The authoritative gate is the deployer's docker build against the repo-pinned Mathlib, where `origin/main` is green.

⚠️ Heads-up for auditor/mechanic: if the repo Mathlib pin was bumped, `Erdos1110OQ01.lean`'s `factorization_powerForm_*` proofs may need a `Finsupp` API refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)