### PR TITLE
Enrich Sharp k=3 Birthday Threshold — add sourceUrl

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
@@ -5,6 +5,7 @@
   "description": "Sharpens the parent's k=3 birthday threshold from an O(1) error band to an asymptotically exact constant. Writing c = (6d²ln2)^(1/3), the n ≥ 2 solving the expected-triple balance n(n-1)(n-2) = 6d²ln2 satisfies c + 1 ≤ n ≤ c + 1 + 1/(3c), i.e. n = (6d²ln2)^(1/3) + 1 + o(1): the lower-order term is the explicit constant 1, with a remainder bounded by 1/(3c) = O(d^(-2/3)) that vanishes as d → ∞. Improves the parent's c ≤ n ≤ c + 2 (additive error 2). Verified, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Birthday_problem",
     "date": "2026",
     "status": "verified",
     "proofRepoPath": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean",


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01`.

The entry was already fully enriched (3 topic-specific references — McKinney, DasGupta, Diaconis–Mosteller — 8 annotations with full mathContext coverage, 6 keyInsights, complete conclusion) but had **no `sourceUrl`** metadata link, so the gallery page offered no external source pointer.

**Change:** set `sourceUrl` to the Birthday problem reference article (which covers the k-collision / generalized birthday generalization this entry sharpens). Single-field metadata completion; no content fields modified.