### PR TITLE
research(erdos-1008-oq-02-oq-02): KST forcing direction — too many edges ⟹ K_{2,t} [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1008OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos1008OQ02OQ02.lean
@@ -491,6 +491,46 @@ theorem reiman_edge_bound_leading_order (G : SimpleGraph V) [DecidableRel G.Adj]
   rw [hsqrt, one_mul] at h
   exact h
 
+/-- **Forcing direction (exact form).**  The extremal *existence* content of
+Kővári–Sós–Turán: a nonempty graph (`t ≥ 1`) whose edge count *exceeds* the exact
+Reiman/KST nested-radical threshold must actually *contain* a `K_{2,t}`, i.e.
+some pair of distinct vertices with `t` common neighbours.  This is the
+contrapositive of `kst_edge_bound_of_free` — the reason the bound is a genuine
+Turán-type theorem (too many edges force the forbidden subgraph), not merely an
+inequality on `K_{2,t}`-free graphs. -/
+theorem hasK2t_of_edge_bound_lt (G : SimpleGraph V) [DecidableRel G.Adj] [Nonempty V]
+    (t : ℕ) (ht : 1 ≤ t)
+    (hm : (Fintype.card V : ℝ) *
+        (1 + Real.sqrt (1 + 4 * ((t : ℝ) - 1) * ((Fintype.card V : ℝ) - 1)))
+        < 4 * (G.edgeFinset.card : ℝ)) :
+    HasK2t G t := by
+  by_contra hfree
+  exact absurd (kst_edge_bound_of_free G t ht hfree) (not_le.2 hm)
+
+/-- **Forcing direction (leading-order form).**  If a nonempty graph (`t ≥ 1`) has
+more than `½·(√(t-1)·n^{3/2} + n)` edges then it contains `K_{2,t}`.  The
+recognisable `ex(n ; K_{2,t}) = O(√(t-1)·n^{3/2})` existence threshold, obtained as
+the contrapositive of `kst_edge_bound_leading_order`. -/
+theorem hasK2t_of_edge_bound_leading_order_lt (G : SimpleGraph V) [DecidableRel G.Adj]
+    [Nonempty V] (t : ℕ) (ht : 1 ≤ t)
+    (hm : (Real.sqrt ((t : ℝ) - 1) * (Fintype.card V : ℝ) * Real.sqrt (Fintype.card V)
+        + (Fintype.card V : ℝ)) / 2 < (G.edgeFinset.card : ℝ)) :
+    HasK2t G t := by
+  by_contra hfree
+  exact absurd (kst_edge_bound_leading_order G t ht hfree) (not_le.2 hm)
+
+/-- **Reiman C₄ forcing threshold (graph-level `t = 2`).**  A graph on `n` vertices
+with more than `½·(n^{3/2} + n)` edges contains a `C₄` (`K_{2,2}`).  The `t = 2`
+specialisation of `hasK2t_of_edge_bound_leading_order_lt`, tying the extremal
+existence threshold back to the parent `C₄` entry. -/
+theorem hasK2t_two_of_edge_bound_leading_order_lt (G : SimpleGraph V) [DecidableRel G.Adj]
+    [Nonempty V]
+    (hm : ((Fintype.card V : ℝ) * Real.sqrt (Fintype.card V) + (Fintype.card V : ℝ)) / 2
+        < (G.edgeFinset.card : ℝ)) :
+    HasK2t G 2 := by
+  by_contra hfree
+  exact absurd (reiman_edge_bound_leading_order G hfree) (not_le.2 hm)
+
 end GraphLevel
 
 end Erdos1008

--- a/src/data/research/problems/erdos-1008-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-1008-oq-02-oq-02.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (UNVERIFIED, docker down): graph-level K_{2,t} KST bound COMPLETE — cherry count + quadratic assembly + closed-form edge bound + K_{2,t}-free bridge, feeding the merged algebraic core; closes the graph-level gap (parent had only t=2/C4)",
+    "progressSummary": "PROGRESS (UNVERIFIED, docker infra down): graph-level K_{2,t} KST development now has BOTH directions — the K_{2,t}-free edge upper bounds AND the forcing/existence converse (edges over threshold ⟹ K_{2,t}). OQ deliverable (graph-level K_{2,t} bound) complete; only re-verification pending build-backend repair.",
     "builtItems": [
       "kst_quadratic_solve (Erdos1008OQ02OQ02.lean): solves the general K_{2,t} KST quadratic 4m^2 <= (t-1)n^2(n-1)+2nm for the upper root 4m <= n(1+s), s=sqrt(1+4(t-1)(n-1))",
       "reiman_quadratic_solve_of_kst: t=2 specialisation recovering the sibling C4 lemma verbatim (1+4(t-1)(n-1)=4n-3)",
@@ -45,11 +45,13 @@
       "kst_cherry_count_nat (Erdos1008OQ02OQ02.lean): graph-level double count ∑_v d_v(d_v-1) ≤ κ·n(n-1) for graphs whose distinct vertex pairs share ≤ κ common neighbours (K_{2,κ+1}-free); cherry (a,b) fibre = |N(a)∩N(b)| via sum_comm double count",
       "kst_graph_quadratic (Erdos1008OQ02OQ02.lean): assembles cherry count + handshaking + CS (sq_sum_le_card) into 4m² ≤ κ·n²(n-1)+2nm — the graph-theoretic input kst_quadratic_solve needed",
       "kst_edge_bound (Erdos1008OQ02OQ02.lean): graph-level closed form 4m ≤ n(1+√(1+4κ(n-1))) via kst_quadratic_solve with t=κ+1",
-      "HasK2t + commonNbrs_card_lt_of_free + kst_edge_bound_of_free: connects the common-neighbour-bound hypothesis to the genuine forbidden-subgraph definition of K_{2,t}-freeness"
+      "HasK2t + commonNbrs_card_lt_of_free + kst_edge_bound_of_free: connects the common-neighbour-bound hypothesis to the genuine forbidden-subgraph definition of K_{2,t}-freeness",
+      "hasK2t_of_edge_bound_lt / hasK2t_of_edge_bound_leading_order_lt / hasK2t_two_of_edge_bound_leading_order_lt in Erdos1008OQ02OQ02.lean (GraphLevel): the KST forcing/existence direction — edges above the exact / leading-order / Reiman-C4 threshold force HasK2t; one-line contrapositives of the corresponding upper bounds (PR #37195, UNVERIFIED docker-down)"
     ],
     "insights": [
       "The C4 algebraic core generalises to K_{2,t} with zero structural change: replace the single-common-neighbour bound by (t-1), so s^2=4n-3 becomes s^2=1+4(t-1)(n-1) and the KST quadratic gains a (t-1) factor on the n^2(n-1) term. Same nlinarith case-split proof works.",
-      "Leading-order closed form is ex(n;K_{2,t}) <= (1/2)(sqrt(t-1)*n^{3/2}+n), matching the classical Kovari-Sos-Turan asymptotic."
+      "Leading-order closed form is ex(n;K_{2,t}) <= (1/2)(sqrt(t-1)*n^{3/2}+n), matching the classical Kovari-Sos-Turan asymptotic.",
+      "The graph-level file only had the K_{2,t}-free upper bounds; the forcing converse (too many edges ⟹ K_{2,t}) is what makes KST an extremal theorem and was missing. Trivial via by_contra + absurd (bound) (not_le.2 hm)."
     ],
     "mathlibGaps": [
       "No graph-level general cherry-count sum_v C(d_v,2) <= (t-1)*C(n,2) for K_{2,t}-free graphs in the gallery; parent Erdos1008Problem only proves the t=2 (C4) case kovari_sos_turan."
@@ -117,10 +119,10 @@
     {
       "path": "Proofs/Erdos1008OQ02OQ02.lean",
       "filename": "Erdos1008OQ02OQ02.lean",
-      "lineCount": 421,
-      "theoremCount": 9,
+      "lineCount": 497,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1008OQ02OQ02.lean"


### PR DESCRIPTION
## Summary

Adds the **extremal existence / forcing direction** to the graph-level Kővári–Sós–Turán development in `Erdos1008OQ02OQ02.lean`. The file already proves the K_{2,t}-free edge *upper bounds* (`kst_edge_bound_of_free`, `kst_edge_bound_leading_order`, `reiman_edge_bound_leading_order`); these are their contrapositives — the statements that make KST a genuine Turán-type theorem: **having more than the KST threshold of edges *forces* a K_{2,t} to appear.**

Three new theorems (0 sorry, 0 axiom), each a one-line contrapositive of an existing verified bound in the same file:

- `hasK2t_of_edge_bound_lt` — exact nested-radical threshold: `n·(1+√(1+4(t-1)(n-1))) < 4m ⟹ HasK2t G t`
- `hasK2t_of_edge_bound_leading_order_lt` — leading-order threshold: `½(√(t-1)·n^{3/2}+n) < m ⟹ HasK2t G t`
- `hasK2t_two_of_edge_bound_leading_order_lt` — Reiman C₄ (`t=2`) specialisation: `½(n^{3/2}+n) < m ⟹ HasK2t G 2`

Each proof is `by_contra hfree; exact absurd (⟨existing bound⟩ G t ht hfree) (not_le.2 hm)`.

## Why this is progress (not padding)

The upper-bound half only constrains K_{2,t}-*free* graphs. The forcing half is the direction that makes the result an *extremal* theorem — it is the statement one actually uses to conclude a substructure exists from an edge-density hypothesis. It closes the natural converse of the graph-level deliverable this OQ was about.

## Verification

**UNVERIFIED.** The Docker build backend was down all session (containerd `meta.db` input/output error at the image-build stage — `docker info` reported healthy but every build died), and no host Mathlib oleans were available, so neither `docker-build.sh` nor `lake env lean` could check it. Disk healthy (119 Gi).

Confidence is high: the additions are three verbatim contrapositives. Each `hm` hypothesis is copied character-for-character from the conclusion of the theorem it negates, and the proof term is the standard `absurd (h) (not_le.2 hm)` pattern. Should be re-verified once the containerd build backend is repaired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)