### PR TITLE
research(erdos-1093-oq-02): well-definedness of the maximal deficiency

### DIFF
--- a/proofs/Proofs/Erdos1093ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1093ProblemOQ02.lean
@@ -168,6 +168,23 @@ theorem exists_deficiency_nine :
     ∃ n k, ValidDeficiencyExample n k ∧ deficiency n k = 9 :=
   ⟨284, 28, record_valid, deficiency_284_28⟩
 
+/-- **Well-definedness of the maximal deficiency.**  The value `D` in
+`MaximalDeficiencyIs D` is unique: if two constants `D₁, D₂` are both maximal
+deficiencies, then `D₁ = D₂`.  Each maximal value is *attained* by some admissible
+pair and *dominates* every admissible pair, so `D₁`'s attaining example is bounded by
+`D₂` (giving `D₁ ≤ D₂`) and symmetrically `D₂ ≤ D₁`.  In particular the target value
+`9` of OQ-02 is the *only* possible answer — `MaximalDeficiencyIs` picks out a single
+number — so no rival constant can also satisfy the conjecture's shape.  Pure
+consequence of the definition (no Ramsey/prime input), the exact analogue of the
+"unique extremal constant" packaging. -/
+theorem maximalDeficiencyIs_unique {D₁ D₂ : ℕ}
+    (h₁ : MaximalDeficiencyIs D₁) (h₂ : MaximalDeficiencyIs D₂) : D₁ = D₂ := by
+  obtain ⟨⟨n₁, k₁, hv₁, he₁⟩, hub₁⟩ := h₁
+  obtain ⟨⟨n₂, k₂, hv₂, he₂⟩, hub₂⟩ := h₂
+  have hb1 := hub₂ n₁ k₁ hv₁
+  have hb2 := hub₁ n₂ k₂ hv₂
+  omega
+
 /-- **Reduction of OQ-02 to its open core.**  Because the existence half is
 established (`exists_deficiency_nine`), the conjecture `MaximalDeficiencyIs 9`
 is *equivalent* to the single open statement: no admissible pair has deficiency


### PR DESCRIPTION
## Summary

Adds `maximalDeficiencyIs_unique` to `Erdos1093ProblemOQ02.lean`:

> `MaximalDeficiencyIs D₁ → MaximalDeficiencyIs D₂ → D₁ = D₂`.

The value `D` in `MaximalDeficiencyIs D` is **unique** — so OQ-02's target value `9` is the *only* possible answer, and the conjecture's shape picks out a single number. Each maximal value is simultaneously *attained* by an admissible pair and *dominates* every admissible pair, so `D₁`'s witness is `≤ D₂` and symmetrically `D₂ ≤ D₁`.

## Why this (and not another k-ladder rung)

This file is a large, actively-extended k-ladder (Sections XV–XXV, per-`k` reductions with rungs up to `k = 24`, current frontier `k ≥ 25`, plus a stale open PR #36644 at k=17). Adding another rung risks colliding with the next agent's frontier extension. Instead this lemma is **deliberately orthogonal**: placed immediately after the `MaximalDeficiencyIs` definition / `exists_deficiency_nine`, it uses only the definition + `obtain` + `omega`, nowhere near the frontier.

## Proof

Destructure both hypotheses; apply each upper-bound half to the other's attaining example; `omega`.

## Verification status

**UNVERIFIED.** The docker build wrapper is down this session (containerd `meta.db` input/output error; host disk healthy). Proof is pure destructuring + `omega`, by-eye trivial. No meta sync needed — the OQ02 file has no gallery entry (the `erdos-1093` meta tracks only the parent `Erdos1093Problem.lean`). 0 new axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)