### PR TITLE
Enrich FTA odd-degree root OQ-06: cross-link surjectivity child

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra-oq-06/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-06/meta.json
@@ -208,6 +208,11 @@
       "targetId": "fundamental-theorem-algebra-oq-04",
       "relationship": "complementary",
       "description": "That entry shows ℝ is not algebraically closed via X²+1 (even degree); this entry shows odd-degree polynomials always have roots, so the obstruction is exactly even degree."
+    },
+    {
+      "targetId": "fundamental-theorem-algebra-oq-06-oq-01",
+      "relationship": "extended-by",
+      "description": "Sharpens this entry's one-directional odd-degree root theorem into a two-sided characterisation: the polynomial function x ↦ P.eval x is surjective ℝ → ℝ iff P has odd degree. The forward direction reuses this entry's root existence applied to every shift P − C y; the converse pins even degree (including the constant case) as exactly the obstruction to surjectivity."
     }
   ],
   "sorries": []


### PR DESCRIPTION
Enrichment pass on `fundamental-theorem-algebra-oq-06`.

Already well-curated (refs 3, 5 keyInsights, 6 fully-populated annotations over 124 lines). Added the clearly-missing link:

- **`fundamental-theorem-algebra-oq-06-oq-01`** (`extended-by`) — the direct child sharpening this entry's one-directional odd-degree root theorem into the two-sided characterisation 'x ↦ P.eval x is surjective ℝ → ℝ iff deg P is odd', reusing this entry's root existence on every shift P − C y.

crossReferences 2 → 3. JSON validates; gallery data-validation passes; no annotation errors. Additive only.