### PR TITLE
research(de-moivre-oq-06-oq-02): Dirichlet kernel bounds |D_n(θ)| ≤ 1/(2|sin(θ/2)|)

### DIFF
--- a/proofs/Proofs/DeMoivreOQ06.lean
+++ b/proofs/Proofs/DeMoivreOQ06.lean
@@ -139,4 +139,43 @@ theorem lagrange_sin_sum (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (n : ℕ) :
   rw [eq_div_iff hden]
   linear_combination hk
 
+/-- **Dirichlet kernel bound (cosine form).**
+The classical Fourier-analysis estimate: the (one-sided, normalised) Dirichlet
+kernel `D_n(θ) = ∑_{k=0}^{n} cos(kθ) − 1/2 = sin((n+1/2)θ)/(2 sin(θ/2))` is
+bounded by `1/(2|sin(θ/2)|)` uniformly in `n`, since `|sin((n+1/2)θ)| ≤ 1`.
+This is the estimate underlying Dirichlet's test for the pointwise convergence
+of Fourier series. -/
+theorem dirichlet_kernel_bound (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (n : ℕ) :
+    |(∑ k ∈ Finset.range (n + 1), Real.cos ((k : ℝ) * θ)) - 1 / 2|
+      ≤ 1 / (2 * |Real.sin (θ / 2)|) := by
+  rw [lagrange_cos_sum θ hθ n]
+  have hrw : (1 / 2 + Real.sin (((n : ℝ) + 1 / 2) * θ) / (2 * Real.sin (θ / 2))) - 1 / 2
+      = Real.sin (((n : ℝ) + 1 / 2) * θ) / (2 * Real.sin (θ / 2)) := by ring
+  rw [hrw, abs_div, abs_mul, abs_two]
+  have hden : (0 : ℝ) < 2 * |Real.sin (θ / 2)| := mul_pos two_pos (abs_pos.mpr hθ)
+  rw [div_le_div_iff hden hden]
+  have hnum : |Real.sin (((n : ℝ) + 1 / 2) * θ)| ≤ 1 :=
+    abs_le.mpr ⟨Real.neg_one_le_sin _, Real.sin_le_one _⟩
+  nlinarith [mul_le_mul_of_nonneg_right hnum (le_of_lt hden)]
+
+/-- **Conjugate Dirichlet kernel bound (sine form).**
+The partial sums of `sin(kθ)` are bounded by `1/|sin(θ/2)|` uniformly in `n`:
+from the closed form `∑_{k=0}^{n} sin(kθ) = (cos(θ/2) − cos((n+1/2)θ))/(2 sin(θ/2))`
+the numerator is a difference of two cosines, hence at most `2` in absolute value. -/
+theorem dirichlet_conjugate_bound (θ : ℝ) (hθ : Real.sin (θ / 2) ≠ 0) (n : ℕ) :
+    |∑ k ∈ Finset.range (n + 1), Real.sin ((k : ℝ) * θ)|
+      ≤ 1 / |Real.sin (θ / 2)| := by
+  have hA : (0 : ℝ) < |Real.sin (θ / 2)| := abs_pos.mpr hθ
+  rw [lagrange_sin_sum θ hθ n, abs_div, abs_mul, abs_two]
+  rw [div_le_div_iff (mul_pos two_pos hA) hA]
+  have hnum : |Real.cos (θ / 2) - Real.cos (((n : ℝ) + 1 / 2) * θ)| ≤ 2 :=
+    abs_le.mpr ⟨by
+      have := Real.cos_le_one (θ / 2)
+      have := Real.neg_one_le_cos (((n : ℝ) + 1 / 2) * θ)
+      linarith, by
+      have := Real.neg_one_le_cos (θ / 2)
+      have := Real.cos_le_one (((n : ℝ) + 1 / 2) * θ)
+      linarith⟩
+  nlinarith [mul_le_mul_of_nonneg_right hnum (le_of_lt hA)]
+
 end DeMoivreOQ06

--- a/src/data/proofs/de-moivre-oq-06/meta.json
+++ b/src/data/proofs/de-moivre-oq-06/meta.json
@@ -54,9 +54,9 @@
     "dateAdded": "2026-07-01",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 142,
+    "lineCount": 181,
     "assumptions": "0 axioms, 0 sorries. Mathlib supplies the raw geometric series (geom_sum_eq), the exponential power law (Complex.exp_nat_mul), and the angle-addition formulas; the finite closed forms for ∑ e^{ikθ}, ∑ cos(kθ), ∑ sin(kθ) and the telescoping product-to-sum steps are supplied here. The real identities require sin(θ/2) ≠ 0 (θ not an integer multiple of 2π); the complex identity requires e^{iθ} ≠ 1.",
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "overview": {
@@ -154,9 +154,9 @@
       "Finset"
     ],
     "namespace": "DeMoivreOQ06",
-    "lineCount": 142,
+    "lineCount": 181,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/DeMoivreOQ06.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the classical **Dirichlet kernel bounds** to `DeMoivreOQ06.lean`, directly answering candidate `de-moivre-oq-06-oq-02` ("Bound the Dirichlet kernel $|D_n(θ)| ≤ 1/(2|\sin(θ/2)|)$").

The file already proves the Lagrange trigonometric identities (closed forms for the finite partial sums $∑\cos(kθ)$, $∑\sin(kθ)$) but stops short of the uniform kernel estimate. This PR supplies it as two short corollaries:

- **`dirichlet_kernel_bound`** — $\left|∑_{k=0}^{n}\cos(kθ) - \tfrac12\right| ≤ \dfrac{1}{2|\sin(θ/2)|}$. Since $∑_{k=0}^n\cos(kθ) - \tfrac12 = \dfrac{\sin((n+\tfrac12)θ)}{2\sin(θ/2)}$ (the normalised, one-sided Dirichlet kernel), the bound follows from $|\sin((n+\tfrac12)θ)| ≤ 1$.
- **`dirichlet_conjugate_bound`** — $\left|∑_{k=0}^{n}\sin(kθ)\right| ≤ \dfrac{1}{|\sin(θ/2)|}$, from the numerator being a difference of two cosines ($≤ 2$ in absolute value).

These are precisely the estimates underlying **Dirichlet's test** for the pointwise convergence of Fourier series. Both are 0-axiom / 0-sorry, built purely from the file's `lagrange_cos_sum` / `lagrange_sin_sum` via standard `abs`/`div` lemmas.

Also syncs `leanFile` counts (142→181 lines, 7→9 theorems).

## Verification status

⚠️ **UNVERIFIED** — the Docker build infrastructure was down this session (containerd content-store blob `input/output error` at the image-build stage, an operator-level fault). The proofs were reviewed by hand; every API name used (`div_le_div_iff`, `abs_two`, `Real.neg_one_le_sin`/`sin_le_one`/`neg_one_le_cos`/`cos_le_one`, `mul_le_mul_of_nonneg_right`) was confirmed present in the pinned Mathlib (`proofs/.lake/packages/mathlib`) and `div_le_div_iff (h₁) (h₂)` is used identically in already-compiled gallery files (e.g. `AmgmInequalityOQ03OQ02OQ02.lean`, `AreaOfCircleOQ01OQ02OQ01OQ03.lean`). Please re-run `./proofs/scripts/docker-build.sh Proofs.DeMoivreOQ06` once infra recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)