### PR TITLE
research(erdos-748): f injective, strictly increasing step-wise, and unbounded [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -244,6 +244,32 @@ theorem f_strictMono : StrictMono f := by
     rw [Finset.mem_Icc] at hmem
     omega
 
+/--
+**`f` is injective.**  Strict monotonicity (`f_strictMono`) makes the counting
+function injective: distinct ambient sizes give distinct sum-free subset counts.
+-/
+theorem f_injective : Function.Injective f := f_strictMono.injective
+
+/--
+**`f` grows by at least one at each step**, `f n < f (n+1)`.  The explicit
+successor form of `f_strictMono`, witnessing the strict inclusion of the
+sum-free families (`{n+1}` is the new member at step `n+1`).
+-/
+theorem f_lt_succ (n : ℕ) : f n < f (n + 1) := f_strictMono (Nat.lt_succ_self n)
+
+/--
+**`f` is unbounded**: for every target `M` there is an `n` with `f n ≥ M`, so
+there are arbitrarily many sum-free subsets.  Take `n = 2M`: the sharp lower
+bound gives `f (2M) ≥ 2^{⌈(2M+1)/2⌉} = 2^M ≥ M` (since `M < 2^M`).  This is the
+qualitative core of the Cameron–Erdős growth `f(n) = 2^{(1+o(1))n/2}` that the
+axiomatized asymptotics make precise. -/
+theorem f_unbounded (M : ℕ) : ∃ n, M ≤ f n := by
+  refine ⟨2 * M, ?_⟩
+  have h1 : (2 * M + 1) / 2 = M := by omega
+  calc M ≤ 2 ^ M := M.lt_two_pow_self.le
+    _ = 2 ^ ((2 * M + 1) / 2) := by rw [h1]
+    _ ≤ f (2 * M) := sharp_lower_bound (2 * M)
+
 /-
 ## Part IV: The Cameron-Erdős Conjecture
 -/

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -58,7 +58,7 @@
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 2,
-    "lineCount": 609,
+    "lineCount": 635,
     "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The lower bound is fully proved (no longer an axiom), and sharpened to f(n) ≥ 2^{⌈n/2⌉} (sharp_lower_bound) — the best the upper-half construction yields. See the Lean source for details.",
     "theoremCount": 21,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary

Three corollaries of the existing structural results on the sum-free subset
counting function `f(n) = |{sum-free A ⊆ {1,…,n}}|` (Cameron–Erdős, Erdős #748).

### New results (in `Erdos748Problem.lean`)

- **`f_injective`** — `Function.Injective f` (from `f_strictMono`): distinct
  ambient sizes give distinct sum-free counts.
- **`f_lt_succ`** — `f n < f (n + 1)`: the explicit successor form of strict
  monotonicity (`{n+1}` is the new member at step `n+1`).
- **`f_unbounded`** — `∀ M, ∃ n, M ≤ f n`: there are arbitrarily many sum-free
  subsets. At `n = 2M` the sharp lower bound gives
  `f(2M) ≥ 2^{(2M+1)/2} = 2^M ≥ M` (since `M < 2^M`, `Nat.lt_two_pow_self`).

`f_unbounded` is the qualitative core of the Cameron–Erdős growth
`f(n) = 2^{(1+o(1))n/2}` that the entry's axiomatized asymptotics make precise.

### Verification

- **Adds no axioms** (the entry keeps its 2 asymptotic axioms `green_upper_bound`
  / `precise_asymptotic`); no new `sorry`.
- Gallery meta `lineCount` synced 609 → 635.
- **UNVERIFIED**: docker build blocked by the persistent containerd `meta.db`
  input/output error (infra #35184; host disk healthy). The proofs are
  one-liners over `f_strictMono`/`sharp_lower_bound` plus a `calc` using
  `Nat.lt_two_pow_self` (already used elsewhere in the repo, e.g.
  `AbundantPrimitiveInfiniteOQ0104`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)