### PR TITLE
Fix: resync cauchy-interlacing-theorem-oq-01 lineCount 138→166

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "axiomCount": 0,
-    "lineCount": 138,
+    "lineCount": 166,
     "theoremCount": 4,
     "definitionCount": 1,
     "assumptions": "None beyond 'T is a symmetric operator and H is a codimension-one subspace'. 0 axioms, 0 sorries in this file and in its transitive imports (CauchyInterlacingAssembly.lean #27236 and CauchyInterlacingKeystone.lean #25063, both 0-sorry/0-axiom). The Rayleigh-agreement hypothesis that the abstract assembly theorem (cauchy_interlacing) takes as input is here PROVED, not assumed, from the orthogonal-projection adjoint identity. This closes the operator-level half of the parent entry's first open question. The remaining bridge is purely the matrix↔operator translation: showing that for a Hermitian matrix and a coordinate hyperplane, deleting a row/column yields exactly this orthogonal compression (a bookkeeping identification, no new spectral content).",
@@ -153,7 +153,7 @@
       "InnerProductSpace"
     ],
     "namespace": "CauchyInterlacing.Compression",
-    "lineCount": 138,
+    "lineCount": 166,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Resync stale `lineCount` metadata for `cauchy-interlacing-theorem-oq-01` to match the actual Lean source.

## Evidence

**Before**: both `meta.lineCount` and `leanFile.lineCount` = 138
**After**: both = 166 (actual `wc -l` of `proofs/Proofs/CauchyInterlacingCompression.lean`)

The `.lean` file grew (sibling cauchy compression work) without a corresponding meta resync. No open PR touches this slug's `meta.json` or its `.lean` source, so this drift is genuine and uncovered.

---
Automated fix by lean-mechanic agent.