### PR TITLE
research(puiseux-theorem-wip-01): verify Part XI (ramification tower) + fix deprecation

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -1035,7 +1035,7 @@ theorem isPuiseuxOfRamification_mul {K : Type*} [NonUnitalNonAssocSemiring K] {n
   obtain ⟨k, hk⟩ := hf a ha
   obtain ⟨l, hl⟩ := hg b hb
   refine ⟨k + l, ?_⟩
-  rw [← hab, hk, hl, div_add_div_same]; push_cast; ring
+  rw [← hab, hk, hl, ← add_div]; push_cast; ring
 
 /-- **The level-`n` Puiseux series form a subring** — the ring of `(1/n)`-ramified
 "Laurent series in `x^{1/n}`". Its carrier is `{f | IsPuiseuxOfRamification n f}`. -/

--- a/research/problems/puiseux-theorem-wip-01/knowledge.md
+++ b/research/problems/puiseux-theorem-wip-01/knowledge.md
@@ -220,3 +220,24 @@ is repaired: `./proofs/scripts/docker-build.sh Proofs.PuiseuxTheorem`.
 
 **Files Modified:** proofs/Proofs/PuiseuxTheorem.lean (+Part XI: 2 defs + 10 theorems;
 933→1068 lines, 24→34 theorems, 5→7 defs), meta.json counts synced (both blocks).
+
+## Session 2026-07-10 (researcher-1) — VERIFY the standing-UNVERIFIED Part XI + deprecation fix
+
+Prior session shipped Part XI (ramification filtration tower: IsPuiseuxOfRamification,
+level closure lemmas, puiseuxRamificationSubring, _mono, iSup colimit = puiseuxSubring —
+12 decls) UNVERIFIED because docker was down, with "re-verify when docker is repaired".
+Docker is still down (containerd meta.db I/O), but the file is Mathlib-imports-only, so
+verified via [[reference-docker-down-lean-elab-verification-path]]:
+
+- Full `PuiseuxTheorem.lean` elaboration: **EXIT 0, ZERO errors**. Part XI confirmed correct.
+- `#print axioms iSup_puiseuxRamificationSubring` and `puiseuxRamificationSubring_mono`
+  = [propext, Classical.choice, Quot.sound] only — no sorryAx. Part XI is genuinely
+  0-axiom / 0-sorry as claimed.
+- Fixed the one deprecation warning INSIDE Part XI (line 1038, isPuiseuxOfRamification_mul):
+  `div_add_div_same` → `← add_div` (Mathlib v4.26 deprecation). Re-elaborated: warning gone,
+  still EXIT 0. (Two remaining warnings — line 353 unused `hq`, line 380 no-op push_cast —
+  are pre-existing in earlier Parts, not touched.)
+
+**Assessment: file SATURATED + now VERIFIED.** Structure complete through the ramification
+colimit capstone; the algebraic-closure frontier is >1000-line out of scope. No new lemma
+added (would be cosmetic); the value this session is turning UNVERIFIED→VERIFIED + cleanup.


### PR DESCRIPTION
## Summary

The prior session shipped **Part XI** of `PuiseuxTheorem.lean` — the ramification-filtration tower (`IsPuiseuxOfRamification`, per-level closure lemmas, `puiseuxRamificationSubring`, `_mono`, and the colimit capstone `iSup_puiseuxRamificationSubring = puiseuxSubring`, 12 declarations) — **UNVERIFIED**, because docker was down, with an explicit "re-verify when docker is repaired" note.

Docker is still down (containerd `meta.db` I/O error), but the file imports **only Mathlib**, so I verified it via direct `lean` elaboration against the pinned Mathlib v4.26.0 oleans:

- Full `PuiseuxTheorem.lean` elaboration: **EXIT 0, zero `error:` lines**. Part XI confirmed correct.
- `#print axioms iSup_puiseuxRamificationSubring` and `puiseuxRamificationSubring_mono` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`. Part XI is genuinely **0-axiom / 0-sorry** as claimed.

Additionally fixed the one deprecation warning **inside** Part XI (line 1038, `isPuiseuxOfRamification_mul`): `div_add_div_same` → `← add_div` (Mathlib v4.26 deprecation). Re-elaborated: warning gone, still EXIT 0.

**No new lemma is added** — the file is saturated (structure complete through the ramification colimit; the algebraic-closure frontier is >1000-line, out of scope). The value here is turning standing UNVERIFIED research into VERIFIED, plus the cleanup.

## Verification

Direct-`lean`-elaboration path (docker-down). EXIT 0, zero errors; the two remaining warnings (line 353 unused `hq`, line 380 no-op `push_cast`) are pre-existing in earlier Parts and untouched. Line count unchanged (1107); gallery meta unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)