### PR TITLE
research(erdos-1064-oq-03): prime-landing .eq/.gt family packaging

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ03.lean
@@ -2548,6 +2548,34 @@ theorem classifySeed_gt_iff_of_seedS_one_seedE_prime {a : ℕ} (ha3 : 3 ≤ a)
       2 * (a - Nat.totient a) < Nat.totient (seedB a) + 2 ^ seedT a := by
   rw [classifySeed_eq_compare_of_seedS_one_seedE_prime ha3 hs1 hep, compare_gt_iff_gt]
 
+/-- **Prime-landing equality family.**  The `.eq` analogue of
+    `prime_landing_family_reversal`: under the hypotheses of
+    `classifySeed_eq_iff_of_seedS_one_seedE_prime` together with the balance
+    equality, the *entire* family `n = a·2^(k+1)` lies in `EqualitySet`
+    (`φ(n) = φ(D(n))` for every `k`).  This packages the equality criterion into an
+    infinitely-often statement for each qualifying seed (e.g. every Sophie–Germain
+    seed `a = 3q`, cf. `mem_EqualitySet_sophieGermain`). -/
+theorem prime_landing_family_equality {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a)
+    (hs1 : seedS a = 1) (hep : (seedE a).Prime)
+    (hcrit : Nat.totient (seedB a) + 2 ^ seedT a = 2 * (a - Nat.totient a))
+    (k : ℕ) : a * 2 ^ (k + 1) ∈ EqualitySet := by
+  rw [classifySeed_eq_iff ha ha3 k]
+  exact (classifySeed_eq_iff_of_seedS_one_seedE_prime ha3 hs1 hep).2 hcrit
+
+/-- **Prime-landing forward family.**  The `.gt` analogue of
+    `prime_landing_family_reversal`: under the hypotheses of
+    `classifySeed_gt_iff_of_seedS_one_seedE_prime` together with the strict forward
+    inequality, the *entire* family `n = a·2^(k+1)` lies in `ForwardSet`
+    (`φ(D(n)) < φ(n)` for every `k`).  With the reversal and equality families this
+    completes the packaging of the prime-landing trichotomy into infinitely-often
+    membership for all three regimes. -/
+theorem prime_landing_family_forward {a : ℕ} (ha : Odd a) (ha3 : 3 ≤ a)
+    (hs1 : seedS a = 1) (hep : (seedE a).Prime)
+    (hcrit : 2 * (a - Nat.totient a) < Nat.totient (seedB a) + 2 ^ seedT a)
+    (k : ℕ) : a * 2 ^ (k + 1) ∈ ForwardSet := by
+  rw [classifySeed_gt_iff ha ha3 k]
+  exact (classifySeed_gt_iff_of_seedS_one_seedE_prime ha3 hs1 hep).2 hcrit
+
 -- ----------------------------------------------------------------------------
 -- A Sophie–Germain–indexed EQUALITY family: `n = 3q·2^(k+1)` with `2q+1` prime
 -- ----------------------------------------------------------------------------

--- a/research/problems/erdos-1064-oq-03/sessions/2026-07-10-r6-prime-landing-families.md
+++ b/research/problems/erdos-1064-oq-03/sessions/2026-07-10-r6-prime-landing-families.md
@@ -1,0 +1,43 @@
+# Session 2026-07-10 (researcher-6) — prime-landing .eq/.gt family packaging
+
+**Mode**: REVISIT (RICH tier; fresh branch off origin/main) | **Outcome**: progress
+(UNVERIFIED — Docker infra down all session: containerd content-store blob
+`input/output error`, `docker images` errors; operator-level, disk healthy ~115 GiB)
+
+## What I Did
+Completed the r8 "Next Steps" item: package the prime-landing trichotomy criteria
+into infinitely-often family membership, the `.eq`/`.gt` analogues of the VERIFIED
+`prime_landing_family_reversal`.
+
+- `prime_landing_family_equality` — for `Odd a`, `a ≥ 3`, `seedS a = 1`,
+  `seedE a` prime, and the balance equality
+  `φ(seedB a) + 2^{seedT a} = 2·(a − φ a)`, the *entire* family `a·2^(k+1)` lies in
+  `EqualitySet` (`φ(n) = φ(D(n))` for every `k`).
+- `prime_landing_family_forward` — same hypotheses with the strict forward inequality
+  `2·(a − φ a) < φ(seedB a) + 2^{seedT a}` place the whole family in `ForwardSet`
+  (`φ(D(n)) < φ(n)` for every `k`).
+
+Together with `prime_landing_family_reversal` this packages all three regimes of the
+prime-landing trichotomy into infinitely-often membership. The abstract packagings
+subsume the previously isolated concrete families (`mem_EqualitySet_sophieGermain`,
+`mem_EqualitySet_five`, `mem_ForwardSet_thirteen`).
+
+## Proof recipe
+Line-for-line mirror of `prime_landing_family_reversal` (2-liner each), swapping
+`lt → eq/gt`:
+`rw [classifySeed_eq_iff ha ha3 k]` (VERIFIED general bridge, membership ⇔ classifier
+value) then `exact (classifySeed_eq_iff_of_seedS_one_seedE_prime ha3 hs1 hep).2 hcrit`
+(the r8 criterion, classifier value ⇔ linear inequality). Same for `.gt`.
+
+## New declarations (0 sorry / 0 new axiom; UNVERIFIED, infra down)
+- `prime_landing_family_equality`
+- `prime_landing_family_forward`
+
+## Files Modified
+- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (+~30 lines, 2 theorems)
+
+## Next Steps
+- Elementary/structural side is now fully packaged (all three regimes as
+  infinitely-often families + trichotomy criteria). The only remaining open direction
+  is the density-1 analytic forward statement (smooth-number density / Luca–Pomerance)
+  — a genuine Mathlib gap, not session-sized.


### PR DESCRIPTION
## Summary

Completes the standing "next step" for **erdos-1064-oq-03** (φ(n) vs φ(n−φ(n))): package the prime-landing trichotomy criteria into infinitely-often family membership — the `.eq` / `.gt` analogues of the already-VERIFIED `prime_landing_family_reversal`.

| Theorem | For `Odd a`, `a≥3`, `seedS a=1`, `seedE a` prime, and… | …the family `a·2^(k+1)` lands in |
|---------|--------------------------------------------------------|----------------------------------|
| `prime_landing_family_equality` | `φ(seedB a)+2^{seedT a} = 2·(a−φ a)` | `EqualitySet` (`φ(n)=φ(D(n))`) |
| `prime_landing_family_forward`  | `2·(a−φ a) < φ(seedB a)+2^{seedT a}` | `ForwardSet` (`φ(D(n))<φ(n)`) |

With `prime_landing_family_reversal` this packages **all three regimes** of the prime-landing trichotomy into infinitely-often membership. The abstract statements subsume the previously isolated concrete families `mem_EqualitySet_sophieGermain`, `mem_EqualitySet_five`, `mem_ForwardSet_thirteen`.

## Details
- `proofs/Proofs/EulerTotientOQ04OQ03.lean` (+2 theorems, **0 axiom / 0 sorry**).
- Each proof is a 2-line mirror of the verified `prime_landing_family_reversal`: `rw` the VERIFIED general bridge `classifySeed_eq_iff` / `classifySeed_gt_iff` (membership ⇔ classifier value), then apply the criterion `classifySeed_eq_iff_of_seedS_one_seedE_prime` / `_gt_` (from the prior session's trichotomy work).
- No gallery meta change: the `erdos-1064` meta tracks only `Erdos1064Problem.lean` (no `additionalFiles`); no meta references this companion file.

## Verification
⚠️ **UNVERIFIED** — docker build infrastructure is down this session (containerd content-store blob `input/output error`; host disk healthy ~115 GiB). The proofs are pure composition of already-elaborated sibling lemmas and are structurally identical to the verified reversal family. Recommend a clean-cache docker rebuild to confirm before/at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)