### PR TITLE
research(descartes-rule-of-signs): eliminate 2 quadratic example axioms (base 7→5) [VERIFIED]

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSigns.lean
+++ b/proofs/Proofs/DescartesRuleOfSigns.lean
@@ -248,21 +248,103 @@ theorem descartes_negative_roots (p : ℝ[X]) (hp : p ≠ 0) :
 Concrete examples demonstrating sign change counting.
 -/
 
-/-- Example: The polynomial x² - 1 has coefficient sequence [1, 0, -1].
-    There is 1 sign change (from 1 to -1). -/
-axiom example_x2_minus_1_sign_changes :
-    signChangesInCoeffs (X^2 - 1 : ℝ[X]) = 1
+/-- **One sign change across a zero.**  If `f : Fin 3 → ℝ` has a zero middle entry
+(`f 1 = 0`) and outer entries of opposite sign (`f 0 · f 2 < 0`), then `f` has exactly
+one sign change — the pair `(0, 2)` jumping over the vanishing middle term.  Axiom-free.
+The `Fin 3` middle-zero engine behind the `X² − 1` example below; a self-contained copy of
+the downstream `DescartesRuleOfSignsOQ01OQ03` lemma, brought in-file so the base can prove
+its own quadratic examples without the (circular) downstream import. -/
+theorem countSignChanges_three_mid_zero_pos {f : Fin 3 → ℝ}
+    (hmid : f 1 = 0) (h : f 0 * f 2 < 0) :
+    countSignChanges f = 1 := by
+  have h0 : f 0 ≠ 0 := fun he => by rw [he, zero_mul] at h; exact lt_irrefl 0 h
+  have h2 : f 2 ≠ 0 := fun he => by rw [he, mul_zero] at h; exact lt_irrefl 0 h
+  unfold countSignChanges
+  rw [Finset.card_eq_one]
+  refine ⟨(0, 2), ?_⟩
+  ext ⟨i, j⟩
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_singleton,
+    decide_eq_true_eq, SignChangeBetween, oppositeSign, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hij, hi0, hj0, -, -⟩
+    have hi1 : i ≠ 1 := by rintro rfl; exact hi0 hmid
+    have hj1 : j ≠ 1 := by rintro rfl; exact hj0 hmid
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact ⟨rfl, rfl⟩
+        | (exfalso; revert hij hi1 hj1; decide)
+  · rintro ⟨rfl, rfl⟩
+    refine ⟨by decide, h0, h2, ?_, h⟩
+    intro k hk0 hk2
+    fin_cases k <;>
+      first
+        | exact hmid
+        | exact absurd hk0 (by decide)
+        | exact absurd hk2 (by decide)
 
-example : signChangesInCoeffs (X^2 - 1 : ℝ[X]) = 1 :=
-  example_x2_minus_1_sign_changes
+/-- **No sign change with a zero middle and non-opposite outer entries.**  If `f 1 = 0`
+and the outer entries do not have strictly opposite signs (`0 ≤ f 0 · f 2` — covering
+equal signs *and* a vanishing outer entry), then `f` has no sign change.  Axiom-free.
+Companion middle-zero engine behind the `X² + 1` example below. -/
+theorem countSignChanges_three_mid_zero_zero {f : Fin 3 → ℝ}
+    (hmid : f 1 = 0) (h : 0 ≤ f 0 * f 2) :
+    countSignChanges f = 0 := by
+  unfold countSignChanges
+  rw [Finset.card_eq_zero]
+  apply Finset.filter_eq_empty_iff.mpr
+  rintro ⟨i, j⟩ -
+  simp only [decide_eq_true_eq, SignChangeBetween, oppositeSign]
+  rintro ⟨hij, hi0, hj0, -, hopp⟩
+  have hi1 : i ≠ 1 := by rintro rfl; exact hi0 hmid
+  have hj1 : j ≠ 1 := by rintro rfl; exact hj0 hmid
+  have hij02 : i = 0 ∧ j = 2 := by
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact ⟨rfl, rfl⟩
+        | (exfalso; revert hij hi1 hj1; decide)
+  obtain ⟨rfl, rfl⟩ := hij02
+  exact absurd hopp (not_lt.mpr h)
 
-/-- Example: The polynomial x² + 1 has coefficient sequence [1, 0, 1].
-    There are 0 sign changes. -/
-axiom example_x2_plus_1_sign_changes :
-    signChangesInCoeffs (X^2 + 1 : ℝ[X]) = 0
+/-- **`X² − 1` has exactly one coefficient sign change, computed axiom-free.**  The
+coefficient sequence is `[1, 0, −1]`: a zero middle with opposite outer signs, hence one
+sign change.  Formerly an `axiom`; now discharged directly from the `Fin 3` middle-zero
+engine `countSignChanges_three_mid_zero_pos` (name kept for the downstream re-exports). -/
+theorem example_x2_minus_1_sign_changes :
+    signChangesInCoeffs (X ^ 2 - 1 : ℝ[X]) = 1 := by
+  have hne : (X ^ 2 - 1 : ℝ[X]) ≠ 0 := by
+    intro h
+    have : (X ^ 2 - 1 : ℝ[X]).coeff 2 = 0 := by rw [h]; simp
+    simp [coeff_sub, coeff_X_pow, coeff_one] at this
+  have hdeg : (X ^ 2 - 1 : ℝ[X]).natDegree = 2 := by compute_degree!
+  unfold signChangesInCoeffs
+  rw [dif_neg hne, hdeg]
+  apply countSignChanges_three_mid_zero_pos
+  · simp [coeffSequence, coeff_sub, coeff_X_pow, coeff_one]
+  · have e0 : coeffSequence (X ^ 2 - 1 : ℝ[X]) 2 0 = 1 := by
+      simp [coeffSequence, coeff_sub, coeff_X_pow, coeff_one]
+    have e2 : coeffSequence (X ^ 2 - 1 : ℝ[X]) 2 2 = -1 := by
+      simp [coeffSequence, coeff_sub, coeff_X_pow, coeff_one]
+    rw [e0, e2]; norm_num
 
-example : signChangesInCoeffs (X^2 + 1 : ℝ[X]) = 0 :=
-  example_x2_plus_1_sign_changes
+/-- **`X² + 1` has no coefficient sign change, computed axiom-free.**  The coefficient
+sequence is `[1, 0, 1]`: a zero middle with equal outer signs, hence no sign change.
+Formerly an `axiom`; now discharged from `countSignChanges_three_mid_zero_zero`. -/
+theorem example_x2_plus_1_sign_changes :
+    signChangesInCoeffs (X ^ 2 + 1 : ℝ[X]) = 0 := by
+  have hne : (X ^ 2 + 1 : ℝ[X]) ≠ 0 := by
+    intro h
+    have : (X ^ 2 + 1 : ℝ[X]).coeff 2 = 0 := by rw [h]; simp
+    simp [coeff_add, coeff_X_pow, coeff_one] at this
+  have hdeg : (X ^ 2 + 1 : ℝ[X]).natDegree = 2 := by compute_degree!
+  unfold signChangesInCoeffs
+  rw [dif_neg hne, hdeg]
+  apply countSignChanges_three_mid_zero_zero
+  · simp [coeffSequence, coeff_add, coeff_X_pow, coeff_one]
+  · have e0 : coeffSequence (X ^ 2 + 1 : ℝ[X]) 2 0 = 1 := by
+      simp [coeffSequence, coeff_add, coeff_X_pow, coeff_one]
+    have e2 : coeffSequence (X ^ 2 + 1 : ℝ[X]) 2 2 = 1 := by
+      simp [coeffSequence, coeff_add, coeff_X_pow, coeff_one]
+    rw [e0, e2]; norm_num
 
 /-- Example: `x³ - x = x(x-1)(x+1)` has real roots `{0, 1, -1}`, of which exactly one
     (`x = 1`) is positive, so `countPositiveRoots (X³ - X) = 1`.

--- a/src/data/proofs/descartes-rule-of-signs/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs/meta.json
@@ -50,11 +50,11 @@
     ],
     "dateAdded": "2024-12-27",
     "wiedijkNumber": 100,
-    "axiomCount": 7,
-    "lineCount": 594,
-    "assumptions": "7 axiom(s) encoding mathematical hypotheses. See the Lean source for details. (The former x_cubed_minus_x positive-roots example axiom is now a proved theorem.)",
+    "axiomCount": 5,
+    "lineCount": 676,
+    "assumptions": "5 axiom(s) encoding the deep Descartes-proof content (upper bound, parity, negative roots, alternating-signs maximum, derivative reduces sign changes). The former concrete example axioms (x_cubed_minus_x positive roots, and the X²−1 / X²+1 quadratic sign-change counts) are now proved theorems.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 36,
+    "theoremCount": 40,
     "definitionCount": 11
   },
   "overview": {
@@ -209,9 +209,9 @@
       "Polynomial"
     ],
     "namespace": "DescartesRuleOfSigns",
-    "lineCount": 594,
-    "axiomCount": 7,
-    "theoremCount": 36,
+    "lineCount": 676,
+    "axiomCount": 5,
+    "theoremCount": 40,
     "definitionCount": 11,
     "path": "Proofs/DescartesRuleOfSigns.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary — axiom elimination (base 7 → 5), VERIFIED

The base file `DescartesRuleOfSigns.lean` axiomatised two **concrete** degree-2 sign-change counts:

```
axiom example_x2_minus_1_sign_changes : signChangesInCoeffs (X² − 1) = 1
axiom example_x2_plus_1_sign_changes  : signChangesInCoeffs (X² + 1) = 0
```

These are not deep results — they persisted only because the classical `Fin n × Fin n` filter in `countSignChanges` does not reduce under `decide`. This PR proves both **axiom-free** by inlining the two `Fin 3` middle-zero engines (self-contained copies of the already-verified downstream `DescartesRuleOfSignsOQ01OQ03` lemmas; the base can't import downstream — circular):

- `countSignChanges_three_mid_zero_pos` — zero middle + opposite outer signs ⟹ exactly 1 sign change.
- `countSignChanges_three_mid_zero_zero` — zero middle + non-opposite outer signs ⟹ 0 sign changes.

Both `example_*` are now **theorems** (names preserved, so the downstream re-export docstrings still resolve). Base `axiomCount` 7 → 5. The 5 remaining axioms (`descartes_upper_bound`, `descartes_parity`, `descartes_negative_roots`, `alternating_signs_max_roots`, `derivative_reduces_sign_changes`) are the genuinely deep Descartes-proof content.

## Verification — VERIFIED (docker infra down this session)
Direct `lean` elaboration against the pinned Mathlib **v4.26.0** oleans (containerd `meta.db` I/O error blocks `docker-build.sh` at image build; disk healthy):

- **EXIT 0, 0 errors** — only 2 pre-existing `unused variable hp` warnings.
- `#print axioms` on both theorems ⇒ `[propext, Classical.choice, Quot.sound]` only (**no `sorryAx`, no `Lean.ofReduceBool`**).

## Meta sync
`leanFile.axiomCount` 7→5, `theoremCount` 36→40, `lineCount` 594→676, and the `assumptions` string updated to describe the 5 remaining deep axioms.

## Note
Comment prose in `DescartesRuleOfSignsOQ01OQ03.lean` (lines ~143/180) still calls these "axiom declarations" — now stale but harmless (comments only); left untouched to keep this PR atomic and avoid cross-file churn with concurrent agents.
