### PR TITLE
Enrich Hall's marriage theorem OQ-01: cross-link defect-form and König children

### DIFF
--- a/src/data/proofs/hall-marriage-theorem-oq-01/meta.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01/meta.json
@@ -136,6 +136,16 @@
       "targetId": "halls-theorem-oq-01",
       "relationship": "related",
       "description": "The bipartite-graph matching formulation of Hall's theorem (SimpleGraph.IsBipartiteWith / IsMatching). This entry gives the dual set-system / transversal (SDR) formulation over a Finset family — the original 'marriage' statement — on a different Mathlib backbone."
+    },
+    {
+      "targetId": "hall-marriage-theorem-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Answers this entry's first open question — the quantitative defect (Ore) form: instead of the all-or-nothing biconditional, a maximum matching saturates all but the deficiency max_s (#s − #(s.biUnion t)), sharpening the failure obstruction proved here into an exact count."
+    },
+    {
+      "targetId": "hall-marriage-theorem-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "Answers this entry's second open question: derives the König–Egerváry min–max duality (maximum matching size = minimum vertex cover size in bipartite graphs) directly from the defect form of Hall's theorem — the optimisation face of the same combinatorial content."
     }
   ],
   "sections": [


### PR DESCRIPTION
Enrichment pass on `hall-marriage-theorem-oq-01`.

Well-curated already (refs 3, 4 keyInsights, 5 fully-populated annotations over 135 lines) but had only **1 crossReference**. Added the two direct children that resolve this entry's own two open questions verbatim:

- **`hall-marriage-theorem-oq-01-oq-01`** (`extended-by`) — the quantitative defect (Ore) form (open Q1).
- **`hall-marriage-theorem-oq-01-oq-02`** (`extended-by`) — the König–Egerváry min–max duality derived from defect Hall (open Q2).

crossReferences 1 → 3. JSON validates; gallery data-validation passes; no annotation errors. Additive only.