### PR TITLE
research(erdos-18-oq-01): full-range representation when abundancy ≤ 2

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -303,6 +303,22 @@ theorem practical_top_segment {m : ℕ} (hp : IsPractical m) {k : ℕ}
   have hcancel : (divisors m).sum id - ((divisors m).sum id - k) = k := by omega
   rwa [hcancel] at hrep
 
+/-- **Full-range representation when the abundancy is at most `2`.**  The two known
+    segments — the bottom `[0, m]` (`practical_represents_le`) and the top
+    `[σ(m) - m, σ(m)]` (`practical_top_segment`) — together tile the whole range
+    `[0, σ(m)]` exactly when they meet, i.e. when `σ(m) - m ≤ m`, that is
+    `σ(m) ≤ 2m` (abundancy `σ(m)/m ≤ 2`).  Under that hypothesis a practical `m`
+    represents *every* `k ≤ σ(m)` — a partial form of the classical fact that a
+    practical number represents all of `[1, σ(m)]`.  The hypothesis holds for e.g.
+    `2, 4, 8` and every `2^k` (and, with equality, for `6`), though it can fail for
+    more abundant practicals such as `12` (`σ(12) = 28 > 24`). -/
+theorem practical_represents_all_of_sigma_le_two_mul {m : ℕ} (hp : IsPractical m)
+    (hσ : (divisors m).sum id ≤ 2 * m) {k : ℕ} (hk : k ≤ (divisors m).sum id) :
+    IsRepresentable k m := by
+  rcases le_or_lt k m with hle | hgt
+  · exact practical_represents_le hp hle
+  · exact practical_top_segment hp (by omega) hk
+
 /-! ## Multiplicative closure under doubling
 
 If `m` is practical, so is `2m`.  This is the smallest case of the


### PR DESCRIPTION
## Summary

Adds one structural theorem to the practical-numbers file `Erdos18OQ01.lean` (Erdős #18):

**`practical_represents_all_of_sigma_le_two_mul`** — a practical number `m` with `σ(m) ≤ 2m` represents **every** `k ≤ σ(m)`.

The file already proves the two boundary segments of the representable range:
- bottom `[0, m]` — `practical_represents_le`;
- top `[σ(m) − m, σ(m)]` — `practical_top_segment`.

These tile the whole interval `[0, σ(m)]` exactly when they meet, i.e. `σ(m) − m ≤ m` ⟺ `σ(m) ≤ 2m` (abundancy `σ(m)/m ≤ 2`). Under that hypothesis every target `k ≤ σ(m)` lands in one segment or the other. This is a partial, conditional form of the classical theorem that a practical number represents all of `[1, σ(m)]`; the hypothesis holds for `2, 4, 8` and every `2^k` (equality at `6`) and can fail for more abundant practicals such as `12` (`σ(12) = 28 > 24`).

Proof is a two-case split (`rcases le_or_lt k m`) dispatching to the two named lemmas plus `omega` glue. **0 sorries, 0 axioms.**

## Verification status
⚠️ **UNVERIFIED this session** — Docker build infrastructure is down (containerd `meta.db` input/output error), so elaboration could not be run. The proof is a short two-case composition of two already-verified lemmas in the same file; by-eye checkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)