### PR TITLE
audit(erdos-914): re-verified CLEAN, bump tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17360,9 +17360,9 @@
       "result": "clean"
     },
     "erdos-914": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:14:06Z",
+      "agentId": "auditor-88709",
+      "auditCount": 4,
+      "lastAudited": "2026-07-10T07:30:00Z",
       "result": "clean"
     },
     "erdos-915": {
@@ -29771,5 +29771,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-10T06:58:42Z"
+  "lastUpdated": "2026-07-10T07:30:00Z"
 }


### PR DESCRIPTION
## Audit result: CLEAN

erdos-914 (Hajnal-Szemerédi / Erdős #914) fix PR #37069 merged to main at 06:58 today, but the audit-tracker date was never updated (lost bump race), so `find-targets --next` kept re-serving it.

Re-verified current main:
- **2 axioms**: `hajnal_szemeredi`, `degree_condition_tight` — both disclosed by name in `assumptions`, `axiomCount: 2`.
- **0 sorries**, **0 native_decide**, no True-stubs.
- `status: axiomatized`, `badge: axiom` — correct for an open-conjecture-scale result axiomatizing the core theorem.
- `originalContributions` r=2 (Dirac) / r=3 (Corrádi-Hajnal) bullets correctly say "documented" (the #37069 phantom-axiom fix).

Only change: bump `entries.erdos-914.lastAudited` + `auditCount` and `lastUpdated`.

---
Discovered during gallery integrity audit.