### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-03): pin p-group prime as computable minFac of degree

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
@@ -268,4 +268,24 @@ theorem pgroup_primeFactors_eq (α : ℝ) (hα : IsIntegral ℚ α)
   have hk0 : k ≠ 0 := by rintro rfl; rw [pow_zero] at hk; omega
   rw [hk, Nat.primeFactors_prime_pow hk0 hp]
 
+/-- **The p-group prime is the computable minimal prime factor of the degree.**
+    The previous "which prime" results pin the prime `p` down as the unique element of
+    `natDegree.primeFactors` (`pgroup_primeFactors_eq`) or as *a* divisor of the degree
+    (`prime_dvd_degree_of_pgroup`).  This sharpens the identification to the concrete,
+    *computable* invariant `Nat.minFac`: for a nontrivial `p`-group Galois extension the
+    target prime `p` is forced to equal `natDegree(minpoly ℚ α).minFac`, the smallest
+    prime factor of the degree.  So the prime is not merely determined abstractly — it can
+    be read off by a decidable computation on the degree alone. -/
+theorem pgroup_prime_eq_minFac (α : ℝ) (hα : IsIntegral ℚ α)
+    {p : ℕ} (hp : p.Prime) (hgt : 1 < (minpoly ℚ α).natDegree)
+    (hP : IsPGroup p (minpoly ℚ α).Gal) :
+    p = (minpoly ℚ α).natDegree.minFac := by
+  have hne : (minpoly ℚ α).natDegree ≠ 1 := by omega
+  have hpf := pgroup_primeFactors_eq α hα hp hgt hP
+  have hmem : (minpoly ℚ α).natDegree.minFac ∈ (minpoly ℚ α).natDegree.primeFactors := by
+    rw [Nat.mem_primeFactors]
+    exact ⟨Nat.minFac_prime hne, Nat.minFac_dvd _, by omega⟩
+  rw [hpf, Finset.mem_singleton] at hmem
+  exact hmem.symm
+
 end AngleTrisectionOQ02OQ01OQ03


### PR DESCRIPTION
## Summary

Adds one theorem to `AngleTrisectionOQ02OQ01OQ03.lean` (p-group Galois → power-of-p degree criterion, general prime).

**`pgroup_prime_eq_minFac`** — For a nontrivial p-group Galois extension the target prime `p` is forced to equal `natDegree(minpoly ℚ α).minFac`, the smallest prime factor of the degree.

## Context

The file's "which prime" theme already establishes:
- `pgroup_primeFactors_eq`: the degree's prime-factor set is exactly `{p}` (abstract);
- `prime_dvd_degree_of_pgroup`: `p` divides the degree.

This new lemma sharpens the identification from the abstract `primeFactors = {p}` to the concrete, **decidably-computable** invariant `Nat.minFac`: the p-group prime can be read off by a computation on the degree alone, not merely determined abstractly. It is the crispest computational form of the prime-rigidity results.

## Proof

Straightforward assembly on top of the adjacent `pgroup_primeFactors_eq`: `minFac ∈ primeFactors` (via `Nat.mem_primeFactors`, `Nat.minFac_prime`, `Nat.minFac_dvd`) collapses to `minFac = p` through `Finset.mem_singleton`.

0 axioms, 0 sorries.

## Verification status

**UNVERIFIED** — the docker Lean image build fails with a `containerd meta.db input/output error` (build infrastructure down this session). The proof reuses only standard `Nat` API and mirrors the structure of the already-verified `pgroup_primeFactors_eq` in the same file, so confidence is high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)