### PR TITLE
research(euler-polyhedral-formula-oq-02-oq-02): torus dim/chi structural companions

### DIFF
--- a/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
+++ b/proofs/Proofs/EulerPolyhedralOQ02OQ02.lean
@@ -306,6 +306,17 @@ def torusCGB (n : ℕ) : CGBManifold where
 /-- The flat torus has vanishing total Pfaffian. -/
 theorem torusCGB_totalPfaffian (n : ℕ) : (torusCGB n).totalPfaffian = 0 := rfl
 
+/-- The even-dimensional torus `T^{2n}` has dimension `2n`.  The `dim` companion of
+    `torusCGB_totalPfaffian`, matching `sphereCGB_dim` / `prodCGB_dim`. -/
+theorem torusCGB_dim (n : ℕ) : (torusCGB n).dim = 2 * n := rfl
+
+/-- The even-dimensional torus `T^{2n}` has vanishing Euler characteristic — the
+    defining feature that makes `torusCGB_totalPfaffian` an instance of
+    `totalPfaffian_eq_zero_of_chi_zero`.  The `chi` companion completing the torus's
+    invariant triple `(dim, chi, totalPfaffian) = (2n, 0, 0)`, matching the
+    `sphereCGB` / `prodCGB` / `genusSurfaceCGB` constructions. -/
+theorem torusCGB_chi (n : ℕ) : (torusCGB n).chi = 0 := rfl
+
 /-- A closed odd-dimensional manifold has vanishing Euler characteristic (Poincaré
     duality), which is *why* the Chern-Gauss-Bonnet integrand — built from the Pfaffian,
     an even-dimensional invariant — carries no information there. We record the

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-02/meta.json
@@ -154,9 +154,9 @@
       "Real"
     ],
     "namespace": "ChernGaussBonnet",
-    "lineCount": 545,
+    "lineCount": 556,
     "axiomCount": 0,
-    "theoremCount": 57,
+    "theoremCount": 59,
     "definitionCount": 12,
     "path": "Proofs/EulerPolyhedralOQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the two missing structural companions for the `torusCGB` construction in the Chern–Gauss–Bonnet file `EulerPolyhedralOQ02OQ02.lean`:

```lean
theorem torusCGB_dim (n : ℕ) : (torusCGB n).dim = 2 * n
theorem torusCGB_chi (n : ℕ) : (torusCGB n).chi = 0
```

Every other CGB construction (`sphereCGB`, `prodCGB`, `connectedSumCGB`, `genusSurfaceCGB`) carries its `_dim` / `_chi` companion theorems — but `torusCGB` had only `torusCGB_totalPfaffian`. These complete the torus invariant triple `(dim, chi, totalPfaffian) = (2n, 0, 0)`, and `χ = 0` is precisely what makes `torusCGB_totalPfaffian` an instance of `totalPfaffian_eq_zero_of_chi_zero`.

Both are `rfl`.

## Note on PR #36432

The open PR #36432 ("Part XI: genus-g surface") is **CONFLICTING and stale** — the genus-g surface development (`genusSurfaceCGB` and its chi/additivity theorems) is *already present* in this file, superseding it. This PR is deliberately orthogonal: it touches only the torus construction (Part VIII), nowhere near the genus/Part-XI material.

## Verification status

**UNVERIFIED.** The docker build wrapper is down this session (containerd `meta.db` input/output error; host disk healthy). Both theorems are `rfl` and by-eye trivial. `leanFile` block synced 545→556 lines, 57→59 theorems; the separate `meta` block counts (512/54) were already drifted before this edit and are left for a mechanic. 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)