### PR TITLE
research(elementary-quadratic-reciprocity-oq-03-oq-02): Kronecker symbol at square numerators

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -847,6 +847,39 @@ theorem kronecker_two_ne_kronecker2 :
   rw [kronecker_at_two 3, kronecker2_three]
   norm_num
 
+-- ============================================================
+-- Section 13: Square numerators — the character on quadratic residues
+-- ============================================================
+
+/-! First-argument multiplicativity (`kronecker_mul_left`) applied to a repeated
+factor `a·a` shows the symbol at a *square* numerator is a perfect square, hence
+`≥ 0` and equal to `1` on units.  This is the concrete statement that squares are
+"quadratic residues" for the character `(·/n)` — the numerator-side companion of
+`kronecker_sq_eq_one_of_coprime` (which squares the *value*). -/
+
+/-- **The symbol at a square numerator is the square of the symbol.**  For nonzero
+`a`, `(a²/n) = (a/n)²` — a direct instance of first-argument multiplicativity
+`kronecker_mul_left` on `a² = a·a` (nonzero product). -/
+theorem kronecker_sq_left (a n : ℤ) (ha : a ≠ 0) :
+    kronecker (a ^ 2) n = kronecker a n ^ 2 := by
+  rw [pow_two, kronecker_mul_left a a n (mul_ne_zero ha ha), pow_two]
+
+/-- **The symbol is non-negative at square numerators.**  `0 ≤ (a²/n)` for nonzero
+`a`: by `kronecker_sq_left` the value is a perfect square.  So a square numerator
+is never a quadratic *non*-residue — it is `0` (non-coprime) or `1`. -/
+theorem kronecker_sq_left_nonneg (a n : ℤ) (ha : a ≠ 0) :
+    0 ≤ kronecker (a ^ 2) n := by
+  rw [kronecker_sq_left a n ha]; exact sq_nonneg _
+
+/-- **Square numerators coprime to the modulus are residues.**  For odd positive `n`
+and nonzero `a` coprime to `n`, `(a²/n) = 1`: squares are quadratic residues.
+Combines `kronecker_sq_left` with `kronecker_sq_eq_one_of_coprime`. -/
+theorem kronecker_sq_left_eq_one_of_coprime (a : ℤ) (n : ℕ) (hn : 0 < n) (hno : n % 2 = 1)
+    (h : Int.gcd a n = 1) (ha : a ≠ 0) :
+    kronecker (a ^ 2) (n : ℤ) = 1 := by
+  rw [kronecker_sq_left a (n : ℤ) ha]
+  exact kronecker_sq_eq_one_of_coprime a n hn hno h
+
 /-!
 ## Module note: what remains open
 

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "theoremCount": 56,
     "defCount": 4,
-    "lineCount": 897,
+    "lineCount": 930,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries — the file is fully machine-verified (no axiom or sorry is used). Complete multiplicativity is now proven in BOTH arguments over all nonzero moduli: kronecker_mul_left and kronecker_mul_right, alongside agreement with the Jacobi symbol and odd-modulus quadratic reciprocity. Status is kept 'wip' because the FORMALIZATION of the classical symbol is still partial, not because anything is assumed: (1) the definition routes even moduli through jacobiSym |n| rather than the classical mod-8 character kronecker2, so kronecker_mul_right is multiplicativity of the symbol as defined (which matches the classical Kronecker symbol at all odd moduli and at n = plus/minus 1); and (2) generalized quadratic reciprocity for arbitrary fundamental discriminants remains open. Both are documented as open work in the source module note; neither is axiomatized. Toward (2), the denominator-side supplementary characters are now shown periodic: kronecker_neg_one_periodic ((-1/.) is periodic mod 4) and kronecker_two_periodic ((2/.) is periodic mod 8), the structural complement of kronecker2_periodic (the numerator character (./2) is a Dirichlet character mod 8) and a Gauss-sum-route input.",
     "mathlib_version": "4.26.0",
@@ -97,7 +97,7 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 897,
+    "lineCount": 930,
     "axiomCount": 0,
     "theoremCount": 56,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary

Adds Section 13 to the (saturated) Kronecker-symbol file — the value of the symbol on **square numerators** (quadratic residues), a coherent trio of one-liners over the file's existing multiplicativity:

1. **`kronecker_sq_left`**: `(a²/n) = (a/n)²` for `a ≠ 0` — a direct instance of first-argument multiplicativity `kronecker_mul_left` on `a² = a·a`.
2. **`kronecker_sq_left_nonneg`**: `0 ≤ (a²/n)` — a square numerator is never a quadratic *non*-residue (the value is a perfect square).
3. **`kronecker_sq_left_eq_one_of_coprime`**: `(a²/n) = 1` for `a` coprime to odd `n` — squares are quadratic residues (composes 1 with `kronecker_sq_eq_one_of_coprime`).

This is the numerator-side companion to the existing `kronecker_sq_eq_one_of_coprime` (which squares the *value*). **0 sorries, 0 axioms**; synced meta `lineCount` 897→930.

## Verification status
⚠️ **UNVERIFIED this session** — Docker build infrastructure is down (containerd `meta.db` input/output error), so elaboration could not be run. Each proof is a one/two-line rewrite over lemmas already verified in the same file (`kronecker_mul_left`, `kronecker_sq_eq_one_of_coprime`, `sq_nonneg`); by-eye checkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)