### PR TITLE
research(erdos-117-oq-01-incomplete-01): limsup of the growth rate is positive

### DIFF
--- a/proofs/Proofs/Erdos117OQ01.lean
+++ b/proofs/Proofs/Erdos117OQ01.lean
@@ -462,6 +462,15 @@ theorem growthRateLimInf_pos : 0 < growthRateLimInf := by
   obtain ⟨c₁, hc1, hge⟩ := limInf_ge_log_c1
   exact lt_of_lt_of_le (Real.log_pos hc1) hge
 
+/-- **The limsup is strictly positive.** The highest cluster value of the growth-rate
+sequence is likewise bounded away from `0`: since `growthRateLimInf ≤ growthRateLimSup`
+(`limInf_le_limSup`) and the liminf is already `> 0` (`growthRateLimInf_pos`), the
+limsup is `> 0` a fortiori. The upper companion of `growthRateLimInf_pos`: whether or
+not the exponential base exists, both cluster extremes sit strictly inside the positive
+Pyber window, so `h(n)` grows at least exponentially in every asymptotic sense. -/
+theorem growthRateLimSup_pos : 0 < growthRateLimSup :=
+  lt_of_lt_of_le growthRateLimInf_pos limInf_le_limSup
+
 /-- **Uniform two-sided Pyber window.** A single pair of constants `1 < c₁ < c₂`
 traps every `growthRate n` (`n ≥ 1`) in the fixed band `[log c₁, log c₂]`. This
 consolidates `growthRate_lower_bound` and `growthRate_upper_bound` — which produce


### PR DESCRIPTION
## Summary

The completion target `erdos-117-oq-01-incomplete-01` was already resolved (its lone `sorry` in `Erdos117OQ01.base_implies_behavior` was discharged back in April; the file is at 0 sorries, phase `COMPLETED`). Rather than fabricate, this adds the missing upper companion of the existing `growthRateLimInf_pos`:

```lean
theorem growthRateLimSup_pos : 0 < growthRateLimSup
```

Since `growthRateLimInf ≤ growthRateLimSup` (`limInf_le_limSup`) and the liminf is already `> 0` (`growthRateLimInf_pos`), the limsup is `> 0` a fortiori. Both cluster extremes of `log h(n)/n` sit strictly inside the positive Pyber window, so the abelian covering number `h(n)` grows at least exponentially in every asymptotic sense — whether or not the exponential base (Erdős #117 OQ-01's open question) exists.

## Proof

One line: `lt_of_lt_of_le growthRateLimInf_pos limInf_le_limSup`.

## Verification status

**UNVERIFIED.** The docker build wrapper is down this session (containerd `meta.db` input/output error; host disk healthy). The proof is a one-line composition of two existing lemmas. Meta counts synced: lineCount 472→481, theoremCount 12→13. 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)