### PR TITLE
research(erdos-1098-oq-01-oq-03): direct-product factors inherit bounded cliques

### DIFF
--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -600,4 +600,27 @@ theorem boundedCliques_prod_of_finiteIndex {K : Type*} [Group K]
     Subgroup.index_dvd_of_le hle
   exact bounded_cliques_of_finite_index (ne_zero_of_dvd_ne_zero hprod hdvd)
 
+/-- **Each factor inherits bounded cliques from a direct product (left projection).**
+    If `Γ(G × K)` has finite clique number then so does `Γ(G)`: `ω(Γ(G)) ≤ ω(Γ(G × K))`.
+    The projection `MonoidHom.fst G K : G × K →* G` is surjective (a set-theoretic section
+    is `g ↦ (g, 1)`), so this is the direct specialisation of `boundedCliques_of_surjective`.
+
+    This is the exact converse of the construction lemma `boundedCliques_prod_of_finiteIndex`:
+    together they close the product under both directions, giving the equivalence
+    `BoundedCliques (G × K) ↔ BoundedCliques G ∧ BoundedCliques K` (via Neumann's dichotomy
+    for the reverse implication). Axiom-free — only the elementary surjective clique transfer,
+    not the BFC core `neumann_hard_direction`. -/
+theorem boundedCliques_of_prod_left {K : Type*} [Group K]
+    (h : BoundedCliques (G × K)) : BoundedCliques G :=
+  boundedCliques_of_surjective (MonoidHom.fst G K) (fun g => ⟨(g, 1), rfl⟩) h
+
+/-- **Each factor inherits bounded cliques from a direct product (right projection).**
+    If `Γ(G × K)` has finite clique number then so does `Γ(K)`: `ω(Γ(K)) ≤ ω(Γ(G × K))`.
+    The projection `MonoidHom.snd G K : G × K →* K` is surjective (section `k ↦ (1, k)`),
+    so this is the right-hand companion of `boundedCliques_of_prod_left`, again a direct
+    specialisation of `boundedCliques_of_surjective`. Axiom-free. -/
+theorem boundedCliques_of_prod_right {K : Type*} [Group K]
+    (h : BoundedCliques (G × K)) : BoundedCliques K :=
+  boundedCliques_of_surjective (MonoidHom.snd G K) (fun k => ⟨(1, k), rfl⟩) h
+
 end Erdos1098OQ01OQ03


### PR DESCRIPTION
## Problem
`erdos-1098-oq-01-oq-03` — Neumann's theorem: ω(Γ(G)) finite ⟺ [G:Z(G)] finite (non-commuting graph clique number). Slug file `Erdos1098OQ01OQ03.lean` (status: axiomatized, 1 axiom = BFC core `neumann_hard_direction`).

## Contribution
Adds the **projection-heredity** direction of the direct-product story (2 axiom-free theorems):

- **`boundedCliques_of_prod_left`** — `BoundedCliques (G × K) → BoundedCliques G`
- **`boundedCliques_of_prod_right`** — `BoundedCliques (G × K) → BoundedCliques K`

Each is a one-line specialisation of the verified sibling `boundedCliques_of_surjective` applied to `MonoidHom.fst G K` / `MonoidHom.snd G K`, which are surjective via the sections `g ↦ (g,1)` and `k ↦ (1,k)` (`rfl`).

This is the exact **converse** of the existing construction lemma `boundedCliques_prod_of_finiteIndex`. Together they close the `BoundedCliques` class under both directions of the direct product, completing the heredity family already present (subgroup / surjective / isomorphism / product-construction). Both new lemmas are axiom-free — they never touch the BFC core `neumann_hard_direction`.

## Verification
Also resyncs stale gallery counts: `lineCount` (meta 535, leanFile 566) → 626; `theoremCount` 15/16 → 17/18.

⚠️ **UNVERIFIED** — the Docker Lean image build is blocked by a persistent host containerd `meta.db` input/output error (disk healthy, 122 Gi free), so `docker-build.sh` could not run this session. The proofs are trivial specialisations of an already-verified theorem in the same file; `MonoidHom.fst`/`MonoidHom.snd` (`toFun := Prod.fst`/`Prod.snd`) and the `rfl` sections were checked against the local Mathlib pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)