### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-02): strict Frobenius bound at the scalar extreme

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Scalar.lean
@@ -24,6 +24,9 @@
       commutant has dimension `n² > n`.  (Obtained purely from the sibling headline:
       were `c • I` nonderogatory its commutant would have dimension `n`, but it has
       dimension `n²`.)
+    * `finrank_centralizer_scalar_gt` — the quantitative form: for `n ≥ 2`,
+      `n < dim_K C(c • I)`, i.e. the Frobenius lower bound is *strictly* exceeded at
+      the derogatory extreme.
 
   Together with `...OQ02OQ02` (dimension `n`, nonderogatory) and its `...Masa`
   refinement, this pins both ends of the interval `n ≤ dim_K C(M) ≤ n²`:
@@ -95,6 +98,23 @@ theorem scalar_derogatory (c : K) (hn : 2 ≤ n) :
       (c • (1 : Matrix (Fin n) (Fin n) K)) hM
   rw [finrank_centralizer_scalar] at h1
   -- `h1 : n * n = n`, impossible for `n ≥ 2` since `2 * n ≤ n * n`.
+  have h2 : 2 * n ≤ n * n := Nat.mul_le_mul hn (le_refl n)
+  omega
+
+/-- **The Frobenius lower bound is strict at the derogatory extreme.**  For `n ≥ 2`
+    the commutant of a scalar matrix `c • I` has dimension `n² > n`, so the bound
+    `dim_K C(M) ≥ n` (equality iff `M` nonderogatory) is *strictly* exceeded here:
+
+      `n < dim_K C(c • I)`.
+
+    This is the quantitative companion of `scalar_derogatory` (which records only
+    the qualitative failure `minpoly ≠ charpoly`): a scalar matrix is not merely
+    derogatory, its commutant is maximally large. -/
+theorem finrank_centralizer_scalar_gt (c : K) (hn : 2 ≤ n) :
+    n < Module.finrank K
+        ↥(Subalgebra.centralizer K
+            ({c • (1 : Matrix (Fin n) (Fin n) K)} : Set (Matrix (Fin n) (Fin n) K))) := by
+  rw [finrank_centralizer_scalar]
   have h2 : 2 * n ≤ n * n := Nat.mul_le_mul hn (le_refl n)
   omega
 


### PR DESCRIPTION
## Summary

Adds one honest, by-eye-clean corollary to the mature `...OQ02OQ02Scalar.lean` companion (commutant dimension, scalar/derogatory extreme):

**`finrank_centralizer_scalar_gt`** — for `n ≥ 2`, `n < dim_K C(c • I)`.

The file already proves `finrank_centralizer_scalar` (`dim_K C(c•I) = n²`) and the qualitative `scalar_derogatory` (`minpoly ≠ charpoly`). This adds the **quantitative strict form**: the Frobenius lower bound `dim_K C(M) ≥ n` — an equality exactly for nonderogatory `M` — is *strictly* exceeded at the maximally-derogatory extreme, since `n² > n` for `n ≥ 2`. It makes precise that a scalar matrix is not merely derogatory but has a commutant of maximal size `n²`, pinning the strict gap at the top of the range `n ≤ dim_K C(M) ≤ n²`.

### Proof

Reuses the verified idiom of the sibling `scalar_derogatory` two lines above: rewrite with `finrank_centralizer_scalar` to reduce the goal to `n < n * n`, then `Nat.mul_le_mul hn (le_refl n)` (giving `2*n ≤ n*n`) + `omega`.

## Verification status

**UNVERIFIED (build infra down).** The local Docker build fails this session at image-build time with a containerd `meta.db` input/output error (environment/IO fault; disk healthy at 121Gi free), so `docker-build.sh` cannot run. The lemma is by-eye trivial and reuses only lemmas already in the same file plus the identical `Nat.mul_le_mul + omega` pattern the adjacent verified `scalar_derogatory` uses. No new axioms, no `sorry`. This slug has no gallery meta yet, so no meta sync is needed. CI produces the build artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)